### PR TITLE
script: Add helper functions to JsonWebKey to handle common tasks

### DIFF
--- a/components/script/dom/subtlecrypto/ecdh_operation.rs
+++ b/components/script/dom/subtlecrypto/ecdh_operation.rs
@@ -2,7 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-use base64ct::{Base64UrlUnpadded, Encoding};
 use elliptic_curve::SecretKey;
 use elliptic_curve::rand_core::OsRng;
 use elliptic_curve::sec1::{FromEncodedPoint, ToEncodedPoint, ValidatePublicKey};
@@ -25,8 +24,8 @@ use crate::dom::bindings::str::DOMString;
 use crate::dom::cryptokey::{CryptoKey, Handle};
 use crate::dom::globalscope::GlobalScope;
 use crate::dom::subtlecrypto::{
-    ALG_ECDH, ExportedKey, JsonWebKeyExt, KeyAlgorithmAndDerivatives, NAMED_CURVE_P256,
-    NAMED_CURVE_P384, NAMED_CURVE_P521, SUPPORTED_CURVES, SubtleEcKeyAlgorithm,
+    ALG_ECDH, ExportedKey, JsonWebKeyExt, JwkStringField, KeyAlgorithmAndDerivatives,
+    NAMED_CURVE_P256, NAMED_CURVE_P384, NAMED_CURVE_P521, SUPPORTED_CURVES, SubtleEcKeyAlgorithm,
     SubtleEcKeyGenParams, SubtleEcKeyImportParams, SubtleEcdhKeyDeriveParams,
 };
 use crate::script_runtime::CanGc;
@@ -599,7 +598,8 @@ pub(crate) fn import_key(
             // normalizedAlgorithm, throw a DataError.
             let named_curve = jwk
                 .crv
-                .filter(|crv| *crv == normalized_algorithm.named_curve)
+                .as_ref()
+                .filter(|crv| **crv == normalized_algorithm.named_curve)
                 .map(|crv| crv.to_string())
                 .ok_or(Error::Data(None))?;
 
@@ -609,137 +609,115 @@ pub(crate) fn import_key(
                 named_curve.as_str(),
                 NAMED_CURVE_P256 | NAMED_CURVE_P384 | NAMED_CURVE_P521
             ) {
-                match jwk.d {
-                    // If the d field is present:
-                    Some(d) => {
-                        // Step 2.10.1. If jwk does not meet the requirements of Section 6.2.2 of
-                        // JSON Web Algorithms [JWA], then throw a DataError.
-                        let x = match jwk.x {
-                            Some(x) => Base64UrlUnpadded::decode_vec(&x.str())
-                                .map_err(|_| Error::Data(None))?,
-                            None => return Err(Error::Data(None)),
-                        };
-                        let y = match jwk.y {
-                            Some(y) => Base64UrlUnpadded::decode_vec(&y.str())
-                                .map_err(|_| Error::Data(None))?,
-                            None => return Err(Error::Data(None)),
-                        };
-                        let d = Base64UrlUnpadded::decode_vec(&d.str())
-                            .map_err(|_| Error::Data(None))?;
+                // If the d field is present:
+                if jwk.d.is_some() {
+                    // Step 2.10.1. If jwk does not meet the requirements of Section 6.2.2 of
+                    // JSON Web Algorithms [JWA], then throw a DataError.
+                    let x = jwk.decode_required_string_field(JwkStringField::X)?;
+                    let y = jwk.decode_required_string_field(JwkStringField::Y)?;
+                    let d = jwk.decode_required_string_field(JwkStringField::D)?;
 
-                        // Step 2.10.2. Let key be a new CryptoKey object that represents the
-                        // Elliptic Curve private key identified by interpreting jwk according to
-                        // Section 6.2.2 of JSON Web Algorithms [JWA].
-                        // NOTE: CryptoKey is created in Step 2.12 - 2.15.
-                        let handle = match named_curve.as_str() {
-                            NAMED_CURVE_P256 => {
-                                let private_key = p256::SecretKey::from_slice(&d)
-                                    .map_err(|_| Error::Data(None))?;
-                                let mut sec1_bytes = vec![4u8];
-                                sec1_bytes.extend_from_slice(&x);
-                                sec1_bytes.extend_from_slice(&y);
-                                let encoded_point = EncodedPoint::from_bytes(&sec1_bytes)
-                                    .map_err(|_| Error::Data(None))?;
-                                NistP256::validate_public_key(&private_key, &encoded_point)
-                                    .map_err(|_| Error::Data(None))?;
-                                Handle::P256PrivateKey(private_key)
-                            },
-                            NAMED_CURVE_P384 => {
-                                let private_key = p384::SecretKey::from_slice(&d)
-                                    .map_err(|_| Error::Data(None))?;
-                                let mut sec1_bytes = vec![4u8];
-                                sec1_bytes.extend_from_slice(&x);
-                                sec1_bytes.extend_from_slice(&y);
-                                let encoded_point = EncodedPoint::from_bytes(&sec1_bytes)
-                                    .map_err(|_| Error::Data(None))?;
-                                NistP384::validate_public_key(&private_key, &encoded_point)
-                                    .map_err(|_| Error::Data(None))?;
-                                Handle::P384PrivateKey(private_key)
-                            },
-                            NAMED_CURVE_P521 => {
-                                let private_key = p521::SecretKey::from_slice(&d)
-                                    .map_err(|_| Error::Data(None))?;
-                                let mut sec1_bytes = vec![4u8];
-                                sec1_bytes.extend_from_slice(&x);
-                                sec1_bytes.extend_from_slice(&y);
-                                let encoded_point = EncodedPoint::from_bytes(&sec1_bytes)
-                                    .map_err(|_| Error::Data(None))?;
-                                NistP521::validate_public_key(&private_key, &encoded_point)
-                                    .map_err(|_| Error::Data(None))?;
-                                Handle::P521PrivateKey(private_key)
-                            },
-                            _ => unreachable!(),
-                        };
+                    // Step 2.10.2. Let key be a new CryptoKey object that represents the
+                    // Elliptic Curve private key identified by interpreting jwk according to
+                    // Section 6.2.2 of JSON Web Algorithms [JWA].
+                    // NOTE: CryptoKey is created in Step 2.12 - 2.15.
+                    let handle = match named_curve.as_str() {
+                        NAMED_CURVE_P256 => {
+                            let private_key =
+                                p256::SecretKey::from_slice(&d).map_err(|_| Error::Data(None))?;
+                            let mut sec1_bytes = vec![4u8];
+                            sec1_bytes.extend_from_slice(&x);
+                            sec1_bytes.extend_from_slice(&y);
+                            let encoded_point = EncodedPoint::from_bytes(&sec1_bytes)
+                                .map_err(|_| Error::Data(None))?;
+                            NistP256::validate_public_key(&private_key, &encoded_point)
+                                .map_err(|_| Error::Data(None))?;
+                            Handle::P256PrivateKey(private_key)
+                        },
+                        NAMED_CURVE_P384 => {
+                            let private_key =
+                                p384::SecretKey::from_slice(&d).map_err(|_| Error::Data(None))?;
+                            let mut sec1_bytes = vec![4u8];
+                            sec1_bytes.extend_from_slice(&x);
+                            sec1_bytes.extend_from_slice(&y);
+                            let encoded_point = EncodedPoint::from_bytes(&sec1_bytes)
+                                .map_err(|_| Error::Data(None))?;
+                            NistP384::validate_public_key(&private_key, &encoded_point)
+                                .map_err(|_| Error::Data(None))?;
+                            Handle::P384PrivateKey(private_key)
+                        },
+                        NAMED_CURVE_P521 => {
+                            let private_key =
+                                p521::SecretKey::from_slice(&d).map_err(|_| Error::Data(None))?;
+                            let mut sec1_bytes = vec![4u8];
+                            sec1_bytes.extend_from_slice(&x);
+                            sec1_bytes.extend_from_slice(&y);
+                            let encoded_point = EncodedPoint::from_bytes(&sec1_bytes)
+                                .map_err(|_| Error::Data(None))?;
+                            NistP521::validate_public_key(&private_key, &encoded_point)
+                                .map_err(|_| Error::Data(None))?;
+                            Handle::P521PrivateKey(private_key)
+                        },
+                        _ => unreachable!(),
+                    };
 
-                        // Step 2.10.3. Set the [[type]] internal slot of Key to "private".
-                        let key_type = KeyType::Private;
+                    // Step 2.10.3. Set the [[type]] internal slot of Key to "private".
+                    let key_type = KeyType::Private;
 
-                        (handle, key_type)
-                    },
-                    // Otherwise:
-                    None => {
-                        // Step 2.10.1. If jwk does not meet the requirements of Section 6.2.1 of
-                        // JSON Web Algorithms [JWA], then throw a DataError.
-                        let x = match jwk.x {
-                            Some(x) => Base64UrlUnpadded::decode_vec(&x.str())
-                                .map_err(|_| Error::Data(None))?,
-                            None => return Err(Error::Data(None)),
-                        };
-                        let y = match jwk.y {
-                            Some(y) => Base64UrlUnpadded::decode_vec(&y.str())
-                                .map_err(|_| Error::Data(None))?,
-                            None => return Err(Error::Data(None)),
-                        };
+                    (handle, key_type)
+                }
+                // Otherwise:
+                else {
+                    // Step 2.10.1. If jwk does not meet the requirements of Section 6.2.1 of
+                    // JSON Web Algorithms [JWA], then throw a DataError.
+                    let x = jwk.decode_required_string_field(JwkStringField::X)?;
+                    let y = jwk.decode_required_string_field(JwkStringField::Y)?;
 
-                        // Step 2.10.2. Let key be a new CryptoKey object that represents the
-                        // Elliptic Curve public key identified by interpreting jwk according to
-                        // Section 6.2.1 of JSON Web Algorithms [JWA].
-                        // NOTE: CryptoKey is created in Step 2.12 - 2.15.
-                        let handle = match named_curve.as_str() {
-                            NAMED_CURVE_P256 => {
-                                let mut sec1_bytes = vec![4u8];
-                                sec1_bytes.extend_from_slice(&x);
-                                sec1_bytes.extend_from_slice(&y);
-                                let encoded_point = EncodedPoint::from_bytes(&sec1_bytes)
-                                    .map_err(|_| Error::Data(None))?;
-                                let public_key =
-                                    p256::PublicKey::from_encoded_point(&encoded_point)
-                                        .into_option()
-                                        .ok_or(Error::Data(None))?;
-                                Handle::P256PublicKey(public_key)
-                            },
-                            NAMED_CURVE_P384 => {
-                                let mut sec1_bytes = vec![4u8];
-                                sec1_bytes.extend_from_slice(&x);
-                                sec1_bytes.extend_from_slice(&y);
-                                let encoded_point = EncodedPoint::from_bytes(&sec1_bytes)
-                                    .map_err(|_| Error::Data(None))?;
-                                let public_key =
-                                    p384::PublicKey::from_encoded_point(&encoded_point)
-                                        .into_option()
-                                        .ok_or(Error::Data(None))?;
-                                Handle::P384PublicKey(public_key)
-                            },
-                            NAMED_CURVE_P521 => {
-                                let mut sec1_bytes = vec![4u8];
-                                sec1_bytes.extend_from_slice(&x);
-                                sec1_bytes.extend_from_slice(&y);
-                                let encoded_point = EncodedPoint::from_bytes(&sec1_bytes)
-                                    .map_err(|_| Error::Data(None))?;
-                                let public_key =
-                                    p521::PublicKey::from_encoded_point(&encoded_point)
-                                        .into_option()
-                                        .ok_or(Error::Data(None))?;
-                                Handle::P521PublicKey(public_key)
-                            },
-                            _ => unreachable!(),
-                        };
+                    // Step 2.10.2. Let key be a new CryptoKey object that represents the
+                    // Elliptic Curve public key identified by interpreting jwk according to
+                    // Section 6.2.1 of JSON Web Algorithms [JWA].
+                    // NOTE: CryptoKey is created in Step 2.12 - 2.15.
+                    let handle = match named_curve.as_str() {
+                        NAMED_CURVE_P256 => {
+                            let mut sec1_bytes = vec![4u8];
+                            sec1_bytes.extend_from_slice(&x);
+                            sec1_bytes.extend_from_slice(&y);
+                            let encoded_point = EncodedPoint::from_bytes(&sec1_bytes)
+                                .map_err(|_| Error::Data(None))?;
+                            let public_key = p256::PublicKey::from_encoded_point(&encoded_point)
+                                .into_option()
+                                .ok_or(Error::Data(None))?;
+                            Handle::P256PublicKey(public_key)
+                        },
+                        NAMED_CURVE_P384 => {
+                            let mut sec1_bytes = vec![4u8];
+                            sec1_bytes.extend_from_slice(&x);
+                            sec1_bytes.extend_from_slice(&y);
+                            let encoded_point = EncodedPoint::from_bytes(&sec1_bytes)
+                                .map_err(|_| Error::Data(None))?;
+                            let public_key = p384::PublicKey::from_encoded_point(&encoded_point)
+                                .into_option()
+                                .ok_or(Error::Data(None))?;
+                            Handle::P384PublicKey(public_key)
+                        },
+                        NAMED_CURVE_P521 => {
+                            let mut sec1_bytes = vec![4u8];
+                            sec1_bytes.extend_from_slice(&x);
+                            sec1_bytes.extend_from_slice(&y);
+                            let encoded_point = EncodedPoint::from_bytes(&sec1_bytes)
+                                .map_err(|_| Error::Data(None))?;
+                            let public_key = p521::PublicKey::from_encoded_point(&encoded_point)
+                                .into_option()
+                                .ok_or(Error::Data(None))?;
+                            Handle::P521PublicKey(public_key)
+                        },
+                        _ => unreachable!(),
+                    };
 
-                        // Step 2.10.3. Set the [[type]] internal slot of Key to "public".
-                        let key_type = KeyType::Public;
+                    // Step 2.10.3. Set the [[type]] internal slot of Key to "public".
+                    let key_type = KeyType::Public;
 
-                        (handle, key_type)
-                    },
+                    (handle, key_type)
                 }
             }
             // Otherwise
@@ -1071,8 +1049,8 @@ pub(crate) fn export_key(format: KeyFormat, key: &CryptoKey) -> Result<ExportedK
                     },
                     _ => return Err(Error::Operation(None)),
                 };
-                jwk.x = Some(Base64UrlUnpadded::encode_string(&x).into());
-                jwk.y = Some(Base64UrlUnpadded::encode_string(&y).into());
+                jwk.encode_string_field(JwkStringField::X, &x);
+                jwk.encode_string_field(JwkStringField::Y, &y);
 
                 // Step 3.3.4.
                 // If the [[type]] internal slot of key is "private"
@@ -1085,7 +1063,7 @@ pub(crate) fn export_key(format: KeyFormat, key: &CryptoKey) -> Result<ExportedK
                         Handle::P521PrivateKey(private_key) => private_key.to_bytes().to_vec(),
                         _ => return Err(Error::NotSupported(None)),
                     };
-                    jwk.d = Some(Base64UrlUnpadded::encode_string(&d).into());
+                    jwk.encode_string_field(JwkStringField::D, &d);
                 }
             }
             // Otherwise:
@@ -1098,12 +1076,7 @@ pub(crate) fn export_key(format: KeyFormat, key: &CryptoKey) -> Result<ExportedK
             }
 
             // Step 3.4. Set the key_ops attribute of jwk to the usages attribute of key.
-            jwk.key_ops = Some(
-                key.usages()
-                    .iter()
-                    .map(|usage| DOMString::from(usage.as_str()))
-                    .collect::<Vec<DOMString>>(),
-            );
+            jwk.set_key_ops(key.usages());
 
             // Step 3.4. Set the ext attribute of jwk to the [[extractable]] internal slot of key.
             jwk.ext = Some(key.Extractable());

--- a/components/script/dom/subtlecrypto/ecdsa_operation.rs
+++ b/components/script/dom/subtlecrypto/ecdsa_operation.rs
@@ -2,7 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-use base64ct::{Base64UrlUnpadded, Encoding};
 use digest::Digest;
 use ecdsa::signature::hazmat::{PrehashVerifier, RandomizedPrehashSigner};
 use ecdsa::{Signature, SigningKey, VerifyingKey};
@@ -31,9 +30,9 @@ use crate::dom::cryptokey::{CryptoKey, Handle};
 use crate::dom::globalscope::GlobalScope;
 use crate::dom::subtlecrypto::{
     ALG_ECDSA, ALG_SHA1, ALG_SHA256, ALG_SHA384, ALG_SHA512, ExportedKey, JsonWebKeyExt,
-    KeyAlgorithmAndDerivatives, NAMED_CURVE_P256, NAMED_CURVE_P384, NAMED_CURVE_P521,
-    SUPPORTED_CURVES, SubtleEcKeyAlgorithm, SubtleEcKeyGenParams, SubtleEcKeyImportParams,
-    SubtleEcdsaParams,
+    JwkStringField, KeyAlgorithmAndDerivatives, NAMED_CURVE_P256, NAMED_CURVE_P384,
+    NAMED_CURVE_P521, SUPPORTED_CURVES, SubtleEcKeyAlgorithm, SubtleEcKeyGenParams,
+    SubtleEcKeyImportParams, SubtleEcdsaParams,
 };
 use crate::script_runtime::CanGc;
 
@@ -689,7 +688,8 @@ pub(crate) fn import_key(
             // normalizedAlgorithm, throw a DataError.
             let named_curve = jwk
                 .crv
-                .filter(|crv| *crv == normalized_algorithm.named_curve)
+                .as_ref()
+                .filter(|crv| **crv == normalized_algorithm.named_curve)
                 .map(|crv| crv.to_string())
                 .ok_or(Error::Data(None))?;
 
@@ -712,7 +712,7 @@ pub(crate) fn import_key(
                     //     Let algNamedCurve be the string "P-521".
                     // otherwise:
                     //     throw a DataError.
-                    let alg = jwk.alg.map(|alg| alg.to_string());
+                    let alg = jwk.alg.as_ref().map(|alg| alg.to_string());
                     let alg_named_curve = match alg.as_deref() {
                         None => None,
                         Some("ES256") => Some(NAMED_CURVE_P256),
@@ -727,137 +727,120 @@ pub(crate) fn import_key(
                         return Err(Error::Data(None));
                     }
 
-                    match jwk.d {
-                        // If the d field is present:
-                        Some(d) => {
-                            // Step 2.9.1. If jwk does not meet the requirements of Section 6.2.2 of
-                            // JSON Web Algorithms [JWA], then throw a DataError.
-                            let x = match jwk.x {
-                                Some(x) => Base64UrlUnpadded::decode_vec(&x.str())
-                                    .map_err(|_| Error::Data(None))?,
-                                None => return Err(Error::Data(None)),
-                            };
-                            let y = match jwk.y {
-                                Some(y) => Base64UrlUnpadded::decode_vec(&y.str())
-                                    .map_err(|_| Error::Data(None))?,
-                                None => return Err(Error::Data(None)),
-                            };
-                            let d =
-                                Base64UrlUnpadded::decode_vec(&d.str()).map_err(|_| Error::Data(None))?;
+                    // Step 9.4
+                    // If the d field is present:
+                    if jwk.d.is_some() {
+                        // Step 2.9.1. If jwk does not meet the requirements of Section 6.2.2 of
+                        // JSON Web Algorithms [JWA], then throw a DataError.
+                        let x = jwk.decode_required_string_field(JwkStringField::X)?;
+                        let y = jwk.decode_required_string_field(JwkStringField::Y)?;
+                        let d = jwk.decode_required_string_field(JwkStringField::D)?;
 
-                            // Step 2.9.2. Let key be a new CryptoKey object that represents the
-                            // Elliptic Curve private key identified by interpreting jwk according to
-                            // Section 6.2.2 of JSON Web Algorithms [JWA].
-                            // NOTE: CryptoKey is created in Step 2.12 - 2.15.
-                            let handle = match named_curve.as_str() {
-                                NAMED_CURVE_P256 => {
-                                    let private_key =
-                                        p256::SecretKey::from_slice(&d).map_err(|_| Error::Data(None))?;
-                                    let mut sec1_bytes = vec![4u8];
-                                    sec1_bytes.extend_from_slice(&x);
-                                    sec1_bytes.extend_from_slice(&y);
-                                    let encoded_point = EncodedPoint::from_bytes(&sec1_bytes)
-                                        .map_err(|_| Error::Data(None))?;
-                                    NistP256::validate_public_key(&private_key, &encoded_point)
-                                        .map_err(|_| Error::Data(None))?;
-                                    Handle::P256PrivateKey(private_key)
-                                },
-                                NAMED_CURVE_P384 => {
-                                    let private_key =
-                                        p384::SecretKey::from_slice(&d).map_err(|_| Error::Data(None))?;
-                                    let mut sec1_bytes = vec![4u8];
-                                    sec1_bytes.extend_from_slice(&x);
-                                    sec1_bytes.extend_from_slice(&y);
-                                    let encoded_point = EncodedPoint::from_bytes(&sec1_bytes)
-                                        .map_err(|_| Error::Data(None))?;
-                                    NistP384::validate_public_key(&private_key, &encoded_point)
-                                        .map_err(|_| Error::Data(None))?;
-                                    Handle::P384PrivateKey(private_key)
-                                },
-                                NAMED_CURVE_P521 => {
-                                    let private_key =
-                                        p521::SecretKey::from_slice(&d).map_err(|_| Error::Data(None))?;
-                                    let mut sec1_bytes = vec![4u8];
-                                    sec1_bytes.extend_from_slice(&x);
-                                    sec1_bytes.extend_from_slice(&y);
-                                    let encoded_point = EncodedPoint::from_bytes(&sec1_bytes)
-                                        .map_err(|_| Error::Data(None))?;
-                                    NistP521::validate_public_key(&private_key, &encoded_point)
-                                        .map_err(|_| Error::Data(None))?;
-                                    Handle::P521PrivateKey(private_key)
-                                },
-                                _ => unreachable!(),
-                            };
+                        // Step 2.9.2. Let key be a new CryptoKey object that represents the
+                        // Elliptic Curve private key identified by interpreting jwk according to
+                        // Section 6.2.2 of JSON Web Algorithms [JWA].
+                        // NOTE: CryptoKey is created in Step 2.12 - 2.15.
+                        let handle = match named_curve.as_str() {
+                            NAMED_CURVE_P256 => {
+                                let private_key =
+                                    p256::SecretKey::from_slice(&d).map_err(|_| Error::Data(None))?;
+                                let mut sec1_bytes = vec![4u8];
+                                sec1_bytes.extend_from_slice(&x);
+                                sec1_bytes.extend_from_slice(&y);
+                                let encoded_point = EncodedPoint::from_bytes(&sec1_bytes)
+                                    .map_err(|_| Error::Data(None))?;
+                                NistP256::validate_public_key(&private_key, &encoded_point)
+                                    .map_err(|_| Error::Data(None))?;
+                                Handle::P256PrivateKey(private_key)
+                            },
+                            NAMED_CURVE_P384 => {
+                                let private_key =
+                                    p384::SecretKey::from_slice(&d).map_err(|_| Error::Data(None))?;
+                                let mut sec1_bytes = vec![4u8];
+                                sec1_bytes.extend_from_slice(&x);
+                                sec1_bytes.extend_from_slice(&y);
+                                let encoded_point = EncodedPoint::from_bytes(&sec1_bytes)
+                                    .map_err(|_| Error::Data(None))?;
+                                NistP384::validate_public_key(&private_key, &encoded_point)
+                                    .map_err(|_| Error::Data(None))?;
+                                Handle::P384PrivateKey(private_key)
+                            },
+                            NAMED_CURVE_P521 => {
+                                let private_key =
+                                    p521::SecretKey::from_slice(&d).map_err(|_| Error::Data(None))?;
+                                let mut sec1_bytes = vec![4u8];
+                                sec1_bytes.extend_from_slice(&x);
+                                sec1_bytes.extend_from_slice(&y);
+                                let encoded_point = EncodedPoint::from_bytes(&sec1_bytes)
+                                    .map_err(|_| Error::Data(None))?;
+                                NistP521::validate_public_key(&private_key, &encoded_point)
+                                    .map_err(|_| Error::Data(None))?;
+                                Handle::P521PrivateKey(private_key)
+                            },
+                            _ => unreachable!(),
+                        };
 
-                            // Step 2.9.3. Set the [[type]] internal slot of Key to "private".
-                            let key_type = KeyType::Private;
+                        // Step 2.9.3. Set the [[type]] internal slot of Key to "private".
+                        let key_type = KeyType::Private;
 
-                            (handle, key_type)
-                        },
-                        // Otherwise:
-                        None => {
-                            // Step 2.9.1. If jwk does not meet the requirements of Section 6.2.1 of
-                            // JSON Web Algorithms [JWA], then throw a DataError.
-                            let x = match jwk.x {
-                                Some(x) => Base64UrlUnpadded::decode_vec(&x.str())
-                                    .map_err(|_| Error::Data(None))?,
-                                None => return Err(Error::Data(None)),
-                            };
-                            let y = match jwk.y {
-                                Some(y) => Base64UrlUnpadded::decode_vec(&y.str())
-                                    .map_err(|_| Error::Data(None))?,
-                                None => return Err(Error::Data(None)),
-                            };
+                        (handle, key_type)
+                    }
+                    // Otherwise:
+                    else {
 
-                            // Step 2.9.2. Let key be a new CryptoKey object that represents the
-                            // Elliptic Curve public key identified by interpreting jwk according to
-                            // Section 6.2.1 of JSON Web Algorithms [JWA].
-                            // NOTE: CryptoKey is created in Step 2.12 - 2.15.
-                            let handle = match named_curve.as_str() {
-                                NAMED_CURVE_P256 => {
-                                    let mut sec1_bytes = vec![4u8];
-                                    sec1_bytes.extend_from_slice(&x);
-                                    sec1_bytes.extend_from_slice(&y);
-                                    let encoded_point = EncodedPoint::from_bytes(&sec1_bytes)
-                                        .map_err(|_| Error::Data(None))?;
-                                    let public_key =
-                                        p256::PublicKey::from_encoded_point(&encoded_point)
-                                            .into_option()
-                                            .ok_or(Error::Data(None))?;
-                                    Handle::P256PublicKey(public_key)
-                                },
-                                NAMED_CURVE_P384 => {
-                                    let mut sec1_bytes = vec![4u8];
-                                    sec1_bytes.extend_from_slice(&x);
-                                    sec1_bytes.extend_from_slice(&y);
-                                    let encoded_point = EncodedPoint::from_bytes(&sec1_bytes)
-                                        .map_err(|_| Error::Data(None))?;
-                                    let public_key =
-                                        p384::PublicKey::from_encoded_point(&encoded_point)
-                                            .into_option()
-                                            .ok_or(Error::Data(None))?;
-                                    Handle::P384PublicKey(public_key)
-                                },
-                                NAMED_CURVE_P521 => {
-                                    let mut sec1_bytes = vec![4u8];
-                                    sec1_bytes.extend_from_slice(&x);
-                                    sec1_bytes.extend_from_slice(&y);
-                                    let encoded_point = EncodedPoint::from_bytes(&sec1_bytes)
-                                        .map_err(|_| Error::Data(None))?;
-                                    let public_key =
-                                        p521::PublicKey::from_encoded_point(&encoded_point)
-                                            .into_option()
-                                            .ok_or(Error::Data(None))?;
-                                    Handle::P521PublicKey(public_key)
-                                },
-                                _ => unreachable!(),
-                            };
+                        // Step 2.9.1. If jwk does not meet the requirements of Section 6.2.1 of
+                        // JSON Web Algorithms [JWA], then throw a DataError.
+                        let x = jwk.decode_required_string_field(JwkStringField::X)?;
+                        let y = jwk.decode_required_string_field(JwkStringField::Y)?;
 
-                            // Step 2.9.3. Set the [[type]] internal slot of Key to "public".
-                            let key_type = KeyType::Public;
+                        // Step 2.9.2. Let key be a new CryptoKey object that represents the
+                        // Elliptic Curve public key identified by interpreting jwk according to
+                        // Section 6.2.1 of JSON Web Algorithms [JWA].
+                        // NOTE: CryptoKey is created in Step 2.12 - 2.15.
+                        let handle = match named_curve.as_str() {
+                            NAMED_CURVE_P256 => {
+                                let mut sec1_bytes = vec![4u8];
+                                sec1_bytes.extend_from_slice(&x);
+                                sec1_bytes.extend_from_slice(&y);
+                                let encoded_point = EncodedPoint::from_bytes(&sec1_bytes)
+                                    .map_err(|_| Error::Data(None))?;
+                                let public_key =
+                                    p256::PublicKey::from_encoded_point(&encoded_point)
+                                        .into_option()
+                                        .ok_or(Error::Data(None))?;
+                                Handle::P256PublicKey(public_key)
+                            },
+                            NAMED_CURVE_P384 => {
+                                let mut sec1_bytes = vec![4u8];
+                                sec1_bytes.extend_from_slice(&x);
+                                sec1_bytes.extend_from_slice(&y);
+                                let encoded_point = EncodedPoint::from_bytes(&sec1_bytes)
+                                    .map_err(|_| Error::Data(None))?;
+                                let public_key =
+                                    p384::PublicKey::from_encoded_point(&encoded_point)
+                                        .into_option()
+                                        .ok_or(Error::Data(None))?;
+                                Handle::P384PublicKey(public_key)
+                            },
+                            NAMED_CURVE_P521 => {
+                                let mut sec1_bytes = vec![4u8];
+                                sec1_bytes.extend_from_slice(&x);
+                                sec1_bytes.extend_from_slice(&y);
+                                let encoded_point = EncodedPoint::from_bytes(&sec1_bytes)
+                                    .map_err(|_| Error::Data(None))?;
+                                let public_key =
+                                    p521::PublicKey::from_encoded_point(&encoded_point)
+                                        .into_option()
+                                        .ok_or(Error::Data(None))?;
+                                Handle::P521PublicKey(public_key)
+                            },
+                            _ => unreachable!(),
+                        };
 
-                            (handle, key_type)
-                        },
+                        // Step 2.9.3. Set the [[type]] internal slot of Key to "public".
+                        let key_type = KeyType::Public;
+
+                        (handle, key_type)
                     }
                 }
                 // Otherwise
@@ -1194,8 +1177,8 @@ pub(crate) fn export_key(format: KeyFormat, key: &CryptoKey) -> Result<ExportedK
                     },
                     _ => return Err(Error::Operation(None)),
                 };
-                jwk.x = Some(Base64UrlUnpadded::encode_string(&x).into());
-                jwk.y = Some(Base64UrlUnpadded::encode_string(&y).into());
+                jwk.encode_string_field(JwkStringField::X, &x);
+                jwk.encode_string_field(JwkStringField::Y, &y);
 
                 // Step 3.3.4.
                 // If the [[type]] internal slot of key is "private"
@@ -1208,7 +1191,7 @@ pub(crate) fn export_key(format: KeyFormat, key: &CryptoKey) -> Result<ExportedK
                         Handle::P521PrivateKey(private_key) => private_key.to_bytes().to_vec(),
                         _ => return Err(Error::NotSupported(None)),
                     };
-                    jwk.d = Some(Base64UrlUnpadded::encode_string(&d).into());
+                    jwk.encode_string_field(JwkStringField::D, &d);
                 }
             }
             // Otherwise:
@@ -1222,12 +1205,7 @@ pub(crate) fn export_key(format: KeyFormat, key: &CryptoKey) -> Result<ExportedK
             }
 
             // Step 3.4. Set the key_ops attribute of jwk to the usages attribute of key.
-            jwk.key_ops = Some(
-                key.usages()
-                    .iter()
-                    .map(|usage| DOMString::from(usage.as_str()))
-                    .collect::<Vec<DOMString>>(),
-            );
+            jwk.set_key_ops(key.usages());
 
             // Step 3.4. Set the ext attribute of jwk to the [[extractable]] internal slot of key.
             jwk.ext = Some(key.Extractable());

--- a/components/script/dom/subtlecrypto/ed25519_operation.rs
+++ b/components/script/dom/subtlecrypto/ed25519_operation.rs
@@ -4,7 +4,6 @@
 
 use aws_lc_rs::encoding::{AsBigEndian, AsDer};
 use aws_lc_rs::signature::{ED25519, Ed25519KeyPair, KeyPair, ParsedPublicKey, UnparsedPublicKey};
-use base64ct::{Base64UrlUnpadded, Encoding};
 use rand::TryRngCore;
 use rand::rngs::OsRng;
 
@@ -18,7 +17,8 @@ use crate::dom::bindings::str::DOMString;
 use crate::dom::cryptokey::{CryptoKey, Handle};
 use crate::dom::globalscope::GlobalScope;
 use crate::dom::subtlecrypto::{
-    ALG_ED25519, ExportedKey, JsonWebKeyExt, KeyAlgorithmAndDerivatives, SubtleKeyAlgorithm,
+    ALG_ED25519, ExportedKey, JsonWebKeyExt, JwkStringField, KeyAlgorithmAndDerivatives,
+    SubtleKeyAlgorithm,
 };
 use crate::script_runtime::CanGc;
 
@@ -322,58 +322,47 @@ pub(crate) fn import_key(
             };
 
             // Step 2.9
-            match jwk.d {
-                // If the d field is present:
-                Some(d) => {
-                    // Step 2.9.1. If jwk does not meet the requirements of the JWK private key
-                    // format described in Section 2 of [RFC8037], then throw a DataError.
-                    let x = jwk.x.ok_or(Error::Data(None))?;
-
-                    // Step 2.9.2. Let key be a new CryptoKey object that represents the Ed25519
-                    // private key identified by interpreting jwk according to Section
-                    // 2 of [RFC8037]
-                    // Step 2.9.3. Set the [[type]] internal slot of Key to "private".
-                    let public_key_bytes =
-                        Base64UrlUnpadded::decode_vec(&x.str()).map_err(|_| Error::Data(None))?;
-                    let private_key_bytes =
-                        Base64UrlUnpadded::decode_vec(&d.str()).map_err(|_| Error::Data(None))?;
-                    let _ = Ed25519KeyPair::from_seed_and_public_key(
-                        &private_key_bytes,
-                        &public_key_bytes,
-                    )
+            // If the d field is present:
+            if jwk.d.is_some() {
+                // Step 2.9.1. If jwk does not meet the requirements of the JWK private key format
+                // described in Section 2 of [RFC8037], then throw a DataError.
+                let d = jwk.decode_required_string_field(JwkStringField::D)?;
+                let x = jwk.decode_required_string_field(JwkStringField::X)?;
+                let _ = Ed25519KeyPair::from_seed_and_public_key(&d, &x)
                     .map_err(|_| Error::Data(None))?;
-                    CryptoKey::new(
-                        global,
-                        KeyType::Private,
-                        extractable,
-                        KeyAlgorithmAndDerivatives::KeyAlgorithm(algorithm),
-                        usages,
-                        Handle::Ed25519(private_key_bytes),
-                        can_gc,
-                    )
-                },
-                // Otherwise:
-                None => {
-                    // Step 2.9.1. If jwk does not meet the requirements of the JWK public key
-                    // format described in Section 2 of [RFC8037], then throw a DataError.
-                    let x = jwk.x.ok_or(Error::Data(None))?;
 
-                    // Step 2.9.2. Let key be a new CryptoKey object that represents the Ed25519
-                    // public key identified by interpreting jwk according to Section 2 of
-                    // [RFC8037].
-                    // Step 2.9.3. Set the [[type]] internal slot of Key to "public".
-                    let public_key_bytes =
-                        Base64UrlUnpadded::decode_vec(&x.str()).map_err(|_| Error::Data(None))?;
-                    CryptoKey::new(
-                        global,
-                        KeyType::Public,
-                        extractable,
-                        KeyAlgorithmAndDerivatives::KeyAlgorithm(algorithm),
-                        usages,
-                        Handle::Ed25519(public_key_bytes),
-                        can_gc,
-                    )
-                },
+                // Step 2.9.2. Let key be a new CryptoKey object that represents the Ed25519
+                // private key identified by interpreting jwk according to Section
+                // 2 of [RFC8037]
+                // Step 2.9.3. Set the [[type]] internal slot of Key to "private".
+                CryptoKey::new(
+                    global,
+                    KeyType::Private,
+                    extractable,
+                    KeyAlgorithmAndDerivatives::KeyAlgorithm(algorithm),
+                    usages,
+                    Handle::Ed25519(d),
+                    can_gc,
+                )
+            }
+            // Otherwise:
+            else {
+                // Step 2.9.1. If jwk does not meet the requirements of the JWK public key format
+                // described in Section 2 of [RFC8037], then throw a DataError.
+                let x = jwk.decode_required_string_field(JwkStringField::X)?;
+
+                // Step 2.9.2. Let key be a new CryptoKey object that represents the Ed25519 public
+                // key identified by interpreting jwk according to Section 2 of [RFC8037].
+                // Step 2.9.3. Set the [[type]] internal slot of Key to "public".
+                CryptoKey::new(
+                    global,
+                    KeyType::Public,
+                    extractable,
+                    KeyAlgorithmAndDerivatives::KeyAlgorithm(algorithm),
+                    usages,
+                    Handle::Ed25519(x),
+                    can_gc,
+                )
             }
 
             // Step 2.12. Set the [[algorithm]] internal slot of key to algorithm.
@@ -487,25 +476,30 @@ pub(crate) fn export_key(format: KeyFormat, key: &CryptoKey) -> Result<ExportedK
         },
         // If format is "jwk":
         KeyFormat::Jwk => {
+            // Step 3.1. Let jwk be a new JsonWebKey dictionary.
+            // Step 3.2. Set the kty attribute of jwk to "OKP".
+            // Step 3.3. Set the alg attribute of jwk to "Ed25519".
+            // Step 3.4. Set the crv attribute of jwk to "Ed25519".
+            let mut jwk = JsonWebKey {
+                kty: Some(DOMString::from("OKP")),
+                alg: Some(DOMString::from(ALG_ED25519)),
+                crv: Some(DOMString::from(ALG_ED25519)),
+                ..Default::default()
+            };
+
             // Step 3.5. Set the x attribute of jwk according to the definition in Section 2 of [RFC8037].
             // Step 3.6.
             // If the [[type]] internal slot of key is "private"
             //     Set the d attribute of jwk according to the definition in Section 2 of [RFC8037].
-            let (x, d) = match key.Type() {
+            match key.Type() {
                 KeyType::Public => {
-                    let public_key = Base64UrlUnpadded::encode_string(key_data);
-                    (Some(DOMString::from(public_key)), None)
+                    jwk.encode_string_field(JwkStringField::X, key_data);
                 },
                 KeyType::Private => {
                     let key_pair = Ed25519KeyPair::from_seed_unchecked(key_data)
                         .map_err(|_| Error::Data(None))?;
-                    let public_key =
-                        Base64UrlUnpadded::encode_string(key_pair.public_key().as_ref());
-                    let private_key = Base64UrlUnpadded::encode_string(key_data);
-                    (
-                        Some(DOMString::from(public_key)),
-                        Some(DOMString::from(private_key)),
-                    )
+                    jwk.encode_string_field(JwkStringField::X, key_pair.public_key().as_ref());
+                    jwk.encode_string_field(JwkStringField::D, key_data);
                 },
                 KeyType::Secret => {
                     return Err(Error::Data(None));
@@ -513,30 +507,12 @@ pub(crate) fn export_key(format: KeyFormat, key: &CryptoKey) -> Result<ExportedK
             };
 
             // Step 3.7. Set the key_ops attribute of jwk to the usages attribute of key.
-            let key_ops = Some(
-                key.usages()
-                    .iter()
-                    .map(|usage| DOMString::from(usage.as_str()))
-                    .collect::<Vec<DOMString>>(),
-            );
+            jwk.set_key_ops(key.usages());
 
-            // Step 3.1. Let jwk be a new JsonWebKey dictionary.
-            // Step 3.2. Set the kty attribute of jwk to "OKP".
-            // Step 3.3. Set the alg attribute of jwk to "Ed25519".
-            // Step 3.4. Set the crv attribute of jwk to "Ed25519".
             // Step 3.8. Set the ext attribute of jwk to the [[extractable]] internal slot of key.
-            let jwk = JsonWebKey {
-                kty: Some(DOMString::from("OKP")),
-                alg: Some(DOMString::from(ALG_ED25519)),
-                crv: Some(DOMString::from(ALG_ED25519)),
-                x,
-                d,
-                key_ops,
-                ext: Some(key.Extractable()),
-                ..Default::default()
-            };
+            jwk.ext = Some(key.Extractable());
 
-            // Step 9. Let result be jwk.
+            // Step 3.9. Let result be jwk.
             ExportedKey::Jwk(Box::new(jwk))
         },
         // If format is "raw":

--- a/components/script/dom/subtlecrypto/hmac_operation.rs
+++ b/components/script/dom/subtlecrypto/hmac_operation.rs
@@ -3,7 +3,6 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 use aws_lc_rs::hmac;
-use base64ct::{Base64UrlUnpadded, Encoding};
 use rand::TryRngCore;
 use rand::rngs::OsRng;
 use script_bindings::codegen::GenericBindings::CryptoKeyBinding::CryptoKeyMethods;
@@ -17,7 +16,7 @@ use crate::dom::cryptokey::{CryptoKey, Handle};
 use crate::dom::globalscope::GlobalScope;
 use crate::dom::subtlecrypto::{
     ALG_HMAC, ALG_SHA1, ALG_SHA256, ALG_SHA384, ALG_SHA512, ExportedKey, JsonWebKeyExt,
-    KeyAlgorithmAndDerivatives, SubtleHmacImportParams, SubtleHmacKeyAlgorithm,
+    JwkStringField, KeyAlgorithmAndDerivatives, SubtleHmacImportParams, SubtleHmacKeyAlgorithm,
     SubtleHmacKeyGenParams, SubtleKeyAlgorithm,
 };
 use crate::script_runtime::CanGc;
@@ -199,8 +198,7 @@ pub(crate) fn import_key(
             // NOTE: Done by Step 2.4 and 2.6.
 
             // Step 2.4. Let data be the byte sequence obtained by decoding the k field of jwk.
-            data = Base64UrlUnpadded::decode_vec(&jwk.k.as_ref().ok_or(Error::Data(None))?.str())
-                .map_err(|_| Error::Data(None))?;
+            data = jwk.decode_required_string_field(JwkStringField::K)?;
 
             // Step 2.5. Set the hash to equal the hash member of normalizedAlgorithm.
             hash = normalized_algorithm.hash.as_ref();
@@ -330,10 +328,33 @@ pub(crate) fn export_key(format: KeyFormat, key: &CryptoKey) -> Result<ExportedK
             _ => Err(Error::Operation(None)),
         },
         KeyFormat::Jwk => {
+            // Step 1. Let jwk be a new JsonWebKey dictionary.
+            // Step 2. Set the kty attribute of jwk to the string "oct".
+            let mut jwk = JsonWebKey {
+                kty: Some(DOMString::from("oct")),
+                ..Default::default()
+            };
+
+            // Step 3. Set the k attribute of jwk to be a string containing data, encoded according
+            // to Section 6.4 of JSON Web Algorithms [JWA].
             let key_data = key.handle().as_bytes();
-            // Step 3. Set the k attribute of jwk to be a string containing data
-            let k = Base64UrlUnpadded::encode_string(key_data);
+            jwk.encode_string_field(JwkStringField::K, key_data);
+
+            // Step 4. Let algorithm be the [[algorithm]] internal slot of key.
+            // Step 5. Let hash be the hash attribute of algorithm.
             // Step 6.
+            // If the name attribute of hash is "SHA-1":
+            //     Set the alg attribute of jwk to the string "HS1".
+            // If the name attribute of hash is "SHA-256":
+            //     Set the alg attribute of jwk to the string "HS256".
+            // If the name attribute of hash is "SHA-384":
+            //     Set the alg attribute of jwk to the string "HS384".
+            // If the name attribute of hash is "SHA-512":
+            //     Set the alg attribute of jwk to the string "HS512".
+            // Otherwise, the name attribute of hash is defined in another applicable specification:
+            //     Perform any key export steps defined by other applicable specifications, passing
+            //     format and key and obtaining alg.
+            //     Set the alg attribute of jwk to alg.
             let hash_algorithm = match key.algorithm() {
                 KeyAlgorithmAndDerivatives::HmacKeyAlgorithm(alg) => match &*alg.hash.name {
                     ALG_SHA1 => "HS1",
@@ -344,27 +365,15 @@ pub(crate) fn export_key(format: KeyFormat, key: &CryptoKey) -> Result<ExportedK
                 },
                 _ => return Err(Error::NotSupported(None)),
             };
+            jwk.alg = Some(DOMString::from(hash_algorithm));
 
             // Step 7. Set the key_ops attribute of jwk to the usages attribute of key.
-            let key_ops = key
-                .usages()
-                .iter()
-                .map(|usage| DOMString::from(usage.as_str()))
-                .collect::<Vec<DOMString>>();
+            jwk.set_key_ops(key.usages());
 
-            // Step 1. Let jwk be a new JsonWebKey dictionary.
-            let jwk = JsonWebKey {
-                // Step 2. Set the kty attribute of jwk to the string "oct".
-                kty: Some(DOMString::from("oct")),
-                k: Some(DOMString::from(k)),
-                alg: Some(DOMString::from(hash_algorithm.to_string())),
-                // Step 7. Set the key_ops attribute of jwk to equal the usages attribute of key.
-                key_ops: Some(key_ops),
-                // Step 8. Set the ext attribute of jwk to the [[extractable]] internal slot of key.
-                ext: Some(key.Extractable()),
-                ..Default::default()
-            };
+            // Step 8. Set the ext attribute of jwk to the [[extractable]] internal slot of key.
+            jwk.ext = Some(key.Extractable());
 
+            // Step 9. Let result be jwk.
             Ok(ExportedKey::Jwk(Box::new(jwk)))
         },
         // Otherwise:

--- a/components/script/dom/subtlecrypto/rsa_common.rs
+++ b/components/script/dom/subtlecrypto/rsa_common.rs
@@ -26,8 +26,8 @@ use crate::dom::cryptokey::{CryptoKey, Handle};
 use crate::dom::globalscope::GlobalScope;
 use crate::dom::subtlecrypto::{
     ALG_RSA_OAEP, ALG_RSA_PSS, ALG_RSASSA_PKCS1_V1_5, ALG_SHA1, ALG_SHA256, ALG_SHA384, ALG_SHA512,
-    ExportedKey, KeyAlgorithmAndDerivatives, SubtleRsaHashedKeyAlgorithm,
-    SubtleRsaHashedKeyGenParams,
+    ExportedKey, JsonWebKeyExt, JwkStringField, KeyAlgorithmAndDerivatives,
+    SubtleRsaHashedKeyAlgorithm, SubtleRsaHashedKeyGenParams,
 };
 use crate::script_runtime::CanGc;
 
@@ -469,12 +469,12 @@ pub(crate) fn export_key(
                     .ok_or(Error::Operation(Some(
                         "Failed to convert first CRT coefficient qi to BigUint".to_string(),
                     )))?;
-                jwk.d = Some(Base64UrlUnpadded::encode_string(&d.to_bytes_be()).into());
-                jwk.p = Some(Base64UrlUnpadded::encode_string(&p.to_bytes_be()).into());
-                jwk.q = Some(Base64UrlUnpadded::encode_string(&q.to_bytes_be()).into());
-                jwk.dp = Some(Base64UrlUnpadded::encode_string(&dp.to_bytes_be()).into());
-                jwk.dq = Some(Base64UrlUnpadded::encode_string(&dq.to_bytes_be()).into());
-                jwk.qi = Some(Base64UrlUnpadded::encode_string(&qi.to_bytes_be()).into());
+                jwk.encode_string_field(JwkStringField::D, &d.to_bytes_be());
+                jwk.encode_string_field(JwkStringField::P, &p.to_bytes_be());
+                jwk.encode_string_field(JwkStringField::Q, &q.to_bytes_be());
+                jwk.encode_string_field(JwkStringField::DP, &dp.to_bytes_be());
+                jwk.encode_string_field(JwkStringField::DQ, &dq.to_bytes_be());
+                jwk.encode_string_field(JwkStringField::QI, &qi.to_bytes_be());
 
                 // Step 3.6.2. If the underlying RSA private key represented by the [[handle]]
                 // internal slot of key is represented by more than two primes, set the attribute
@@ -517,12 +517,7 @@ pub(crate) fn export_key(
             }
 
             // Step 3.7. Set the key_ops attribute of jwk to the usages attribute of key.
-            jwk.key_ops = Some(
-                key.usages()
-                    .iter()
-                    .map(|usage| DOMString::from(usage.as_str()))
-                    .collect::<Vec<DOMString>>(),
-            );
+            jwk.set_key_ops(key.usages());
 
             // Step 3.8. Set the ext attribute of jwk to the [[extractable]] internal slot of key.
             jwk.ext = Some(key.Extractable());

--- a/components/script/dom/subtlecrypto/rsa_oaep_operation.rs
+++ b/components/script/dom/subtlecrypto/rsa_oaep_operation.rs
@@ -2,7 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-use base64ct::{Base64UrlUnpadded, Encoding};
 use pkcs8::der::asn1::BitString;
 use pkcs8::der::{AnyRef, Decode};
 use pkcs8::rand_core::OsRng;
@@ -27,7 +26,7 @@ use crate::dom::globalscope::GlobalScope;
 use crate::dom::subtlecrypto::rsa_common::{self, RsaAlgorithm};
 use crate::dom::subtlecrypto::{
     ALG_RSA_OAEP, ALG_SHA1, ALG_SHA256, ALG_SHA384, ALG_SHA512, ExportedKey, JsonWebKeyExt,
-    KeyAlgorithmAndDerivatives, Operation, SubtleRsaHashedImportParams,
+    JwkStringField, KeyAlgorithmAndDerivatives, Operation, SubtleRsaHashedImportParams,
     SubtleRsaHashedKeyAlgorithm, SubtleRsaHashedKeyGenParams, SubtleRsaOaepParams,
     normalize_algorithm,
 };
@@ -389,7 +388,7 @@ pub(crate) fn import_key(
             //     Perform any key import steps defined by other applicable specifications, passing
             //     format, jwk and obtaining hash.
             //     If an error occurred or there are no applicable specifications, throw a DataError.
-            let hash = match jwk.alg {
+            let hash = match &jwk.alg {
                 None => None,
                 Some(alg) => match &*alg.str() {
                     "RSA-OAEP" => Some(ALG_SHA1),
@@ -402,7 +401,7 @@ pub(crate) fn import_key(
 
             // Step 2.9. If hash is not undefined:
             if let Some(hash) = hash {
-                // Step 2.8.1. Let normalizedHash be the result of normalize an algorithm with alg
+                // Step 2.9.1. Let normalizedHash be the result of normalize an algorithm with alg
                 // set to hash and op set to digest.
                 let normalized_hash = normalize_algorithm(
                     cx,
@@ -411,7 +410,7 @@ pub(crate) fn import_key(
                     can_gc,
                 )?;
 
-                // Step 2.8.2. If normalizedHash is not equal to the hash member of
+                // Step 2.9.2. If normalizedHash is not equal to the hash member of
                 // normalizedAlgorithm, throw a DataError.
                 if normalized_hash.name() != normalized_algorithm.hash.name() {
                     return Err(Error::Data(Some(
@@ -422,164 +421,79 @@ pub(crate) fn import_key(
             }
 
             // Step 2.10.
-            match jwk.d {
-                // If the d field of jwk is present:
-                Some(d) => {
-                    // Step 2.10.1. If jwk does not meet the requirements of Section 6.3.2 of JSON
-                    // Web Algorithms [JWA], then throw a DataError.
-                    let n = Base64UrlUnpadded::decode_vec(
-                        &jwk.n
-                            .ok_or(Error::Data(Some(
-                                "The n field does not exist in jwk".to_string(),
-                            )))?
-                            .str(),
-                    )
-                    .map_err(|_| Error::Data(Some("Fail to decode n field of jwk".to_string())))?;
-                    let e = Base64UrlUnpadded::decode_vec(
-                        &jwk.e
-                            .ok_or(Error::Data(Some(
-                                "The e field does not exist in jwk".to_string(),
-                            )))?
-                            .str(),
-                    )
-                    .map_err(|_| Error::Data(Some("Fail to decode e field of jwk".to_string())))?;
-                    let d = Base64UrlUnpadded::decode_vec(&d.str()).map_err(|_| {
-                        Error::Data(Some("Fail to decode d field of jwk".to_string()))
-                    })?;
-                    let p = jwk
-                        .p
-                        .map(|p| Base64UrlUnpadded::decode_vec(&p.str()))
-                        .transpose()
-                        .map_err(|_| {
-                            Error::Data(Some("Fail to decode p field of jwk".to_string()))
-                        })?;
-                    let q = jwk
-                        .q
-                        .map(|q| Base64UrlUnpadded::decode_vec(&q.str()))
-                        .transpose()
-                        .map_err(|_| {
-                            Error::Data(Some("Fail to decode q field of jwk".to_string()))
-                        })?;
-                    let dp = jwk
-                        .dp
-                        .map(|dp| Base64UrlUnpadded::decode_vec(&dp.str()))
-                        .transpose()
-                        .map_err(|_| {
-                            Error::Data(Some("Fail to decode dp field of jwk".to_string()))
-                        })?;
-                    let dq = jwk
-                        .dq
-                        .map(|dq| Base64UrlUnpadded::decode_vec(&dq.str()))
-                        .transpose()
-                        .map_err(|_| {
-                            Error::Data(Some("Fail to decode dq field of jwk".to_string()))
-                        })?;
-                    let qi = jwk
-                        .qi
-                        .map(|qi| Base64UrlUnpadded::decode_vec(&qi.str()))
-                        .transpose()
-                        .map_err(|_| {
-                            Error::Data(Some("Fail to decode qi field of jwk".to_string()))
-                        })?;
-                    let mut primes = match (p, q, dp, dq, qi) {
-                        (Some(p), Some(q), Some(_dp), Some(_dq), Some(_qi)) => vec![p, q],
-                        (None, None, None, None, None) => Vec::new(),
-                        _ => return Err(Error::Data(Some(
-                            "The p, q, dp, dq, qi fields of jwk must be either all-present or all-absent"
-                                .to_string()
-                        ))),
-                    };
-                    if let Some(oth) = jwk.oth {
-                        if primes.is_empty() {
-                            return Err(Error::Data(Some(
-                                "The oth field exists in jwk but one of p, q, dp, dq, qi is missing".to_string()
-                            )));
-                        }
-                        for other_prime in oth {
-                            let r = Base64UrlUnpadded::decode_vec(
-                                &other_prime
-                                    .r
-                                    .ok_or(Error::Data(Some(
-                                        "The e field does not exist in oth field of jwk"
-                                            .to_string(),
-                                    )))?
-                                    .str(),
-                            )
-                            .map_err(|_| {
-                                Error::Data(Some(
-                                    "Fail to decode r field of oth field of jwk".to_string(),
-                                ))
-                            })?;
-                            primes.push(r);
-                        }
-                    }
+            // If the d field of jwk is present:
+            if jwk.d.is_some() {
+                // Step 2.10.1. If jwk does not meet the requirements of Section 6.3.2 of JSON Web
+                // Algorithms [JWA], then throw a DataError.
+                let n = jwk.decode_required_string_field(JwkStringField::N)?;
+                let e = jwk.decode_required_string_field(JwkStringField::E)?;
+                let d = jwk.decode_required_string_field(JwkStringField::D)?;
+                let p = jwk.decode_optional_string_field(JwkStringField::P)?;
+                let q = jwk.decode_optional_string_field(JwkStringField::Q)?;
+                let dp = jwk.decode_optional_string_field(JwkStringField::DP)?;
+                let dq = jwk.decode_optional_string_field(JwkStringField::DQ)?;
+                let qi = jwk.decode_optional_string_field(JwkStringField::QI)?;
+                let mut primes = match (p, q, dp, dq, qi) {
+                    (Some(p), Some(q), Some(_dp), Some(_dq), Some(_qi)) => vec![p, q],
+                    (None, None, None, None, None) => Vec::new(),
+                    _ => return Err(Error::Data(Some(
+                        "The p, q, dp, dq, qi fields of jwk must be either all-present or all-absent"
+                            .to_string()
+                    ))),
+                };
+                jwk.decode_primes_from_oth_field(&mut primes)?;
 
-                    // Step 2.10.2. Let privateKey represents the RSA private key identified by
-                    // interpreting jwk according to Section 6.3.2 of JSON Web Algorithms [JWA].
-                    // Step 2.10.3. If privateKey is not a valid RSA private key according to
-                    // [RFC3447], then throw a DataError.
-                    let private_key = RsaPrivateKey::from_components(
-                        BigUint::from_bytes_be(&n),
-                        BigUint::from_bytes_be(&e),
-                        BigUint::from_bytes_be(&d),
-                        primes
-                            .into_iter()
-                            .map(|prime| BigUint::from_bytes_be(&prime))
-                            .collect(),
-                    )
-                    .map_err(|_| {
-                        Error::Data(Some(
-                            "Fail to construct RSA private key from values in jwk".to_string(),
-                        ))
-                    })?;
+                // Step 2.10.2. Let privateKey represents the RSA private key identified by
+                // interpreting jwk according to Section 6.3.2 of JSON Web Algorithms [JWA].
+                // Step 2.10.3. If privateKey is not a valid RSA private key according to
+                // [RFC3447], then throw a DataError.
+                let private_key = RsaPrivateKey::from_components(
+                    BigUint::from_bytes_be(&n),
+                    BigUint::from_bytes_be(&e),
+                    BigUint::from_bytes_be(&d),
+                    primes
+                        .into_iter()
+                        .map(|prime| BigUint::from_bytes_be(&prime))
+                        .collect(),
+                )
+                .map_err(|_| {
+                    Error::Data(Some(
+                        "Failed to construct RSA private key from values in jwk".to_string(),
+                    ))
+                })?;
 
-                    // Step 2.10.4. Let key be a new CryptoKey object that represents privateKey.
-                    // Step 2.10.5. Set the [[type]] internal slot of key to "private"
-                    // NOTE: Done in Step 3-8.
-                    let key_handle = Handle::RsaPrivateKey(private_key);
-                    let key_type = KeyType::Private;
-                    (key_handle, key_type)
-                },
-                // Otherwise:
-                None => {
-                    // Step 2.10.1. If jwk does not meet the requirements of Section 6.3.1 of JSON
-                    // Web Algorithms [JWA], then throw a DataError.
-                    let n = Base64UrlUnpadded::decode_vec(
-                        &jwk.n
-                            .ok_or(Error::Data(Some(
-                                "The n field does not exist in jwk".to_string(),
-                            )))?
-                            .str(),
-                    )
-                    .map_err(|_| Error::Data(Some("Fail to decode n field of jwk".to_string())))?;
-                    let e = Base64UrlUnpadded::decode_vec(
-                        &jwk.e
-                            .ok_or(Error::Data(Some(
-                                "The e field does not exist in jwk".to_string(),
-                            )))?
-                            .str(),
-                    )
-                    .map_err(|_| Error::Data(Some("Fail to decode e field of jwk".to_string())))?;
+                // Step 2.10.4. Let key be a new CryptoKey object that represents privateKey.
+                // Step 2.10.5. Set the [[type]] internal slot of key to "private"
+                // NOTE: Done in Step 3-8.
+                let key_handle = Handle::RsaPrivateKey(private_key);
+                let key_type = KeyType::Private;
+                (key_handle, key_type)
+            }
+            // Otherwise:
+            else {
+                // Step 2.10.1. If jwk does not meet the requirements of Section 6.3.1 of JSON Web
+                // Algorithms [JWA], then throw a DataError.
+                let n = jwk.decode_required_string_field(JwkStringField::N)?;
+                let e = jwk.decode_required_string_field(JwkStringField::E)?;
 
-                    // Step 2.10.2. Let publicKey represent the RSA public key identified by
-                    // interpreting jwk according to Section 6.3.1 of JSON Web Algorithms [JWA].
-                    // Step 2.10.3. If publicKey can be determined to not be a valid RSA public key
-                    // according to [RFC3447], then throw a DataError.
-                    let public_key =
-                        RsaPublicKey::new(BigUint::from_bytes_be(&n), BigUint::from_bytes_be(&e))
-                            .map_err(|_| {
+                // Step 2.10.2. Let publicKey represent the RSA public key identified by
+                // interpreting jwk according to Section 6.3.1 of JSON Web Algorithms [JWA].
+                // Step 2.10.3. If publicKey can be determined to not be a valid RSA public key
+                // according to [RFC3447], then throw a DataError.
+                let public_key =
+                    RsaPublicKey::new(BigUint::from_bytes_be(&n), BigUint::from_bytes_be(&e))
+                        .map_err(|_| {
                             Error::Data(Some(
-                                "Fail to construct RSA public key from values in jwk".to_string(),
+                                "Failed to construct RSA public key from values in jwk".to_string(),
                             ))
                         })?;
 
-                    // Step 2.10.4. Let key be a new CryptoKey representing publicKey.
-                    // Step 2.10.5. Set the [[type]] internal slot of key to "public"
-                    // NOTE: Done in Step 3-8.
-                    let key_handle = Handle::RsaPublicKey(public_key);
-                    let key_type = KeyType::Public;
-                    (key_handle, key_type)
-                },
+                // Step 2.10.4. Let key be a new CryptoKey representing publicKey.
+                // Step 2.10.5. Set the [[type]] internal slot of key to "public"
+                // NOTE: Done in Step 3-8.
+                let key_handle = Handle::RsaPublicKey(public_key);
+                let key_type = KeyType::Public;
+                (key_handle, key_type)
             }
         },
         // Otherwise:

--- a/components/script/dom/subtlecrypto/rsa_pss_operation.rs
+++ b/components/script/dom/subtlecrypto/rsa_pss_operation.rs
@@ -2,7 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-use base64ct::{Base64UrlUnpadded, Encoding};
 use pkcs8::der::asn1::BitString;
 use pkcs8::der::{AnyRef, Decode};
 use pkcs8::rand_core::OsRng;
@@ -29,7 +28,7 @@ use crate::dom::globalscope::GlobalScope;
 use crate::dom::subtlecrypto::rsa_common::{self, RsaAlgorithm};
 use crate::dom::subtlecrypto::{
     ALG_RSA_PSS, ALG_SHA1, ALG_SHA256, ALG_SHA384, ALG_SHA512, ExportedKey, JsonWebKeyExt,
-    KeyAlgorithmAndDerivatives, Operation, SubtleRsaHashedImportParams,
+    JwkStringField, KeyAlgorithmAndDerivatives, Operation, SubtleRsaHashedImportParams,
     SubtleRsaHashedKeyAlgorithm, SubtleRsaHashedKeyGenParams, SubtleRsaPssParams,
     normalize_algorithm,
 };
@@ -405,7 +404,7 @@ pub(crate) fn import_key(
             //     Perform any key import steps defined by other applicable specifications, passing
             //     format, jwk and obtaining hash.
             //     If an error occurred or there are no applicable specifications, throw a DataError.
-            let hash = match jwk.alg {
+            let hash = match &jwk.alg {
                 None => None,
                 Some(alg) => match &*alg.str() {
                     "PS1" => Some(ALG_SHA1),
@@ -438,164 +437,79 @@ pub(crate) fn import_key(
             }
 
             // Step 2.9.
-            match jwk.d {
-                // If the d field of jwk is present:
-                Some(d) => {
-                    // Step 2.9.1. If jwk does not meet the requirements of Section 6.3.2 of JSON
-                    // Web Algorithms [JWA], then throw a DataError.
-                    let n = Base64UrlUnpadded::decode_vec(
-                        &jwk.n
-                            .ok_or(Error::Data(Some(
-                                "The n field does not exist in jwk".to_string(),
-                            )))?
-                            .str(),
-                    )
-                    .map_err(|_| Error::Data(Some("Fail to decode n field of jwk".to_string())))?;
-                    let e = Base64UrlUnpadded::decode_vec(
-                        &jwk.e
-                            .ok_or(Error::Data(Some(
-                                "The e field does not exist in jwk".to_string(),
-                            )))?
-                            .str(),
-                    )
-                    .map_err(|_| Error::Data(Some("Fail to decode e field of jwk".to_string())))?;
-                    let d = Base64UrlUnpadded::decode_vec(&d.str()).map_err(|_| {
-                        Error::Data(Some("Fail to decode d field of jwk".to_string()))
-                    })?;
-                    let p = jwk
-                        .p
-                        .map(|p| Base64UrlUnpadded::decode_vec(&p.str()))
-                        .transpose()
-                        .map_err(|_| {
-                            Error::Data(Some("Fail to decode p field of jwk".to_string()))
-                        })?;
-                    let q = jwk
-                        .q
-                        .map(|q| Base64UrlUnpadded::decode_vec(&q.str()))
-                        .transpose()
-                        .map_err(|_| {
-                            Error::Data(Some("Fail to decode q field of jwk".to_string()))
-                        })?;
-                    let dp = jwk
-                        .dp
-                        .map(|dp| Base64UrlUnpadded::decode_vec(&dp.str()))
-                        .transpose()
-                        .map_err(|_| {
-                            Error::Data(Some("Fail to decode dp field of jwk".to_string()))
-                        })?;
-                    let dq = jwk
-                        .dq
-                        .map(|dq| Base64UrlUnpadded::decode_vec(&dq.str()))
-                        .transpose()
-                        .map_err(|_| {
-                            Error::Data(Some("Fail to decode dq field of jwk".to_string()))
-                        })?;
-                    let qi = jwk
-                        .qi
-                        .map(|qi| Base64UrlUnpadded::decode_vec(&qi.str()))
-                        .transpose()
-                        .map_err(|_| {
-                            Error::Data(Some("Fail to decode qi field of jwk".to_string()))
-                        })?;
-                    let mut primes = match (p, q, dp, dq, qi) {
-                        (Some(p), Some(q), Some(_dp), Some(_dq), Some(_qi)) => vec![p, q],
-                        (None, None, None, None, None) => Vec::new(),
-                        _ => return Err(Error::Data(Some(
-                            "The p, q, dp, dq, qi fields of jwk must be either all-present or all-absent"
-                                .to_string()
-                        ))),
-                    };
-                    if let Some(oth) = jwk.oth {
-                        if primes.is_empty() {
-                            return Err(Error::Data(Some(
-                                "The oth field exists in jwk but one of p, q, dp, dq, qi is missing".to_string()
-                            )));
-                        }
-                        for other_prime in oth {
-                            let r = Base64UrlUnpadded::decode_vec(
-                                &other_prime
-                                    .r
-                                    .ok_or(Error::Data(Some(
-                                        "The e field does not exist in oth field of jwk"
-                                            .to_string(),
-                                    )))?
-                                    .str(),
-                            )
-                            .map_err(|_| {
-                                Error::Data(Some(
-                                    "Fail to decode r field of oth field of jwk".to_string(),
-                                ))
-                            })?;
-                            primes.push(r);
-                        }
-                    }
+            // If the d field of jwk is present:
+            if jwk.d.is_some() {
+                // Step 2.9.1. If jwk does not meet the requirements of Section 6.3.2 of JSON Web
+                // Algorithms [JWA], then throw a DataError.
+                let n = jwk.decode_required_string_field(JwkStringField::N)?;
+                let e = jwk.decode_required_string_field(JwkStringField::E)?;
+                let d = jwk.decode_required_string_field(JwkStringField::D)?;
+                let p = jwk.decode_optional_string_field(JwkStringField::P)?;
+                let q = jwk.decode_optional_string_field(JwkStringField::Q)?;
+                let dp = jwk.decode_optional_string_field(JwkStringField::DP)?;
+                let dq = jwk.decode_optional_string_field(JwkStringField::DQ)?;
+                let qi = jwk.decode_optional_string_field(JwkStringField::QI)?;
+                let mut primes = match (p, q, dp, dq, qi) {
+                    (Some(p), Some(q), Some(_dp), Some(_dq), Some(_qi)) => vec![p, q],
+                    (None, None, None, None, None) => Vec::new(),
+                    _ => return Err(Error::Data(Some(
+                        "The p, q, dp, dq, qi fields of jwk must be either all-present or all-absent"
+                            .to_string()
+                    ))),
+                };
+                jwk.decode_primes_from_oth_field(&mut primes)?;
 
-                    // Step 2.9.2. Let privateKey represents the RSA private key identified by
-                    // interpreting jwk according to Section 6.3.2 of JSON Web Algorithms [JWA].
-                    // Step 2.9.3. If privateKey is not a valid RSA private key according to
-                    // [RFC3447], then throw a DataError.
-                    let private_key = RsaPrivateKey::from_components(
-                        BigUint::from_bytes_be(&n),
-                        BigUint::from_bytes_be(&e),
-                        BigUint::from_bytes_be(&d),
-                        primes
-                            .into_iter()
-                            .map(|prime| BigUint::from_bytes_be(&prime))
-                            .collect(),
-                    )
-                    .map_err(|_| {
-                        Error::Data(Some(
-                            "Fail to construct RSA private key from values in jwk".to_string(),
-                        ))
-                    })?;
+                // Step 2.9.2. Let privateKey represents the RSA private key identified by
+                // interpreting jwk according to Section 6.3.2 of JSON Web Algorithms [JWA].
+                // Step 2.9.3. If privateKey is not a valid RSA private key according to [RFC3447],
+                // then throw a DataError.
+                let private_key = RsaPrivateKey::from_components(
+                    BigUint::from_bytes_be(&n),
+                    BigUint::from_bytes_be(&e),
+                    BigUint::from_bytes_be(&d),
+                    primes
+                        .into_iter()
+                        .map(|prime| BigUint::from_bytes_be(&prime))
+                        .collect(),
+                )
+                .map_err(|_| {
+                    Error::Data(Some(
+                        "Failed to construct RSA private key from values in jwk".to_string(),
+                    ))
+                })?;
 
-                    // Step 2.9.4. Let key be a new CryptoKey object that represents privateKey.
-                    // Step 2.9.5. Set the [[type]] internal slot of key to "private"
-                    // NOTE: Done in Step 3-8.
-                    let key_handle = Handle::RsaPrivateKey(private_key);
-                    let key_type = KeyType::Private;
-                    (key_handle, key_type)
-                },
-                // Otherwise:
-                None => {
-                    // Step 2.9.1. If jwk does not meet the requirements of Section 6.3.1 of JSON
-                    // Web Algorithms [JWA], then throw a DataError.
-                    let n = Base64UrlUnpadded::decode_vec(
-                        &jwk.n
-                            .ok_or(Error::Data(Some(
-                                "The n field does not exist in jwk".to_string(),
-                            )))?
-                            .str(),
-                    )
-                    .map_err(|_| Error::Data(Some("Fail to decode n field of jwk".to_string())))?;
-                    let e = Base64UrlUnpadded::decode_vec(
-                        &jwk.e
-                            .ok_or(Error::Data(Some(
-                                "The e field does not exist in jwk".to_string(),
-                            )))?
-                            .str(),
-                    )
-                    .map_err(|_| Error::Data(Some("Fail to decode e field of jwk".to_string())))?;
+                // Step 2.9.4. Let key be a new CryptoKey object that represents privateKey.
+                // Step 2.9.5. Set the [[type]] internal slot of key to "private"
+                // NOTE: Done in Step 3-8.
+                let key_handle = Handle::RsaPrivateKey(private_key);
+                let key_type = KeyType::Private;
+                (key_handle, key_type)
+            }
+            // Otherwise:
+            else {
+                // Step 2.9.1. If jwk does not meet the requirements of Section 6.3.1 of JSON Web
+                // Algorithms [JWA], then throw a DataError.
+                let n = jwk.decode_required_string_field(JwkStringField::N)?;
+                let e = jwk.decode_required_string_field(JwkStringField::E)?;
 
-                    // Step 2.9.2. Let publicKey represent the RSA public key identified by
-                    // interpreting jwk according to Section 6.3.1 of JSON Web Algorithms [JWA].
-                    // Step 2.9.3. If publicKey can be determined to not be a valid RSA public key
-                    // according to [RFC3447], then throw a DataError.
-                    let public_key =
-                        RsaPublicKey::new(BigUint::from_bytes_be(&n), BigUint::from_bytes_be(&e))
-                            .map_err(|_| {
+                // Step 2.9.2. Let publicKey represent the RSA public key identified by
+                // interpreting jwk according to Section 6.3.1 of JSON Web Algorithms [JWA].
+                // Step 2.9.3. If publicKey can be determined to not be a valid RSA public key
+                // according to [RFC3447], then throw a DataError.
+                let public_key =
+                    RsaPublicKey::new(BigUint::from_bytes_be(&n), BigUint::from_bytes_be(&e))
+                        .map_err(|_| {
                             Error::Data(Some(
-                                "Fail to construct RSA public key from values in jwk".to_string(),
+                                "Failed to construct RSA public key from values in jwk".to_string(),
                             ))
                         })?;
 
-                    // Step 2.9.4. Let key be a new CryptoKey representing publicKey.
-                    // Step 2.9.5. Set the [[type]] internal slot of key to "public"
-                    // NOTE: Done in Step 3-8.
-                    let key_handle = Handle::RsaPublicKey(public_key);
-                    let key_type = KeyType::Public;
-                    (key_handle, key_type)
-                },
+                // Step 2.9.4. Let key be a new CryptoKey representing publicKey.
+                // Step 2.9.5. Set the [[type]] internal slot of key to "public"
+                // NOTE: Done in Step 3-8.
+                let key_handle = Handle::RsaPublicKey(public_key);
+                let key_type = KeyType::Public;
+                (key_handle, key_type)
             }
         },
         // Otherwise:

--- a/components/script/dom/subtlecrypto/rsassa_pkcs1_v1_5_operation.rs
+++ b/components/script/dom/subtlecrypto/rsassa_pkcs1_v1_5_operation.rs
@@ -2,7 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-use base64ct::{Base64UrlUnpadded, Encoding};
 use pkcs8::der::asn1::BitString;
 use pkcs8::der::{AnyRef, Decode};
 use pkcs8::{PrivateKeyInfo, SubjectPublicKeyInfo};
@@ -28,8 +27,9 @@ use crate::dom::globalscope::GlobalScope;
 use crate::dom::subtlecrypto::rsa_common::{self, RsaAlgorithm};
 use crate::dom::subtlecrypto::{
     ALG_RSASSA_PKCS1_V1_5, ALG_SHA1, ALG_SHA256, ALG_SHA384, ALG_SHA512, ExportedKey,
-    JsonWebKeyExt, KeyAlgorithmAndDerivatives, Operation, SubtleRsaHashedImportParams,
-    SubtleRsaHashedKeyAlgorithm, SubtleRsaHashedKeyGenParams, normalize_algorithm,
+    JsonWebKeyExt, JwkStringField, KeyAlgorithmAndDerivatives, Operation,
+    SubtleRsaHashedImportParams, SubtleRsaHashedKeyAlgorithm, SubtleRsaHashedKeyGenParams,
+    normalize_algorithm,
 };
 use crate::script_runtime::CanGc;
 
@@ -368,7 +368,7 @@ pub(crate) fn import_key(
             //     Perform any key import steps defined by other applicable specifications, passing
             //     format, jwk and obtaining hash.
             //     If an error occurred or there are no applicable specifications, throw a DataError.
-            let hash = match jwk.alg {
+            let hash = match &jwk.alg {
                 None => None,
                 Some(alg) => match &*alg.str() {
                     "RS1" => Some(ALG_SHA1),
@@ -401,164 +401,79 @@ pub(crate) fn import_key(
             }
 
             // Step 2.10.
-            match jwk.d {
-                // If the d field of jwk is present:
-                Some(d) => {
-                    // Step 2.10.1. If jwk does not meet the requirements of Section 6.3.2 of JSON
-                    // Web Algorithms [JWA], then throw a DataError.
-                    let n = Base64UrlUnpadded::decode_vec(
-                        &jwk.n
-                            .ok_or(Error::Data(Some(
-                                "The n field does not exist in jwk".to_string(),
-                            )))?
-                            .str(),
-                    )
-                    .map_err(|_| Error::Data(Some("Fail to decode n field of jwk".to_string())))?;
-                    let e = Base64UrlUnpadded::decode_vec(
-                        &jwk.e
-                            .ok_or(Error::Data(Some(
-                                "The e field does not exist in jwk".to_string(),
-                            )))?
-                            .str(),
-                    )
-                    .map_err(|_| Error::Data(Some("Fail to decode e field of jwk".to_string())))?;
-                    let d = Base64UrlUnpadded::decode_vec(&d.str()).map_err(|_| {
-                        Error::Data(Some("Fail to decode d field of jwk".to_string()))
-                    })?;
-                    let p = jwk
-                        .p
-                        .map(|p| Base64UrlUnpadded::decode_vec(&p.str()))
-                        .transpose()
-                        .map_err(|_| {
-                            Error::Data(Some("Fail to decode p field of jwk".to_string()))
-                        })?;
-                    let q = jwk
-                        .q
-                        .map(|q| Base64UrlUnpadded::decode_vec(&q.str()))
-                        .transpose()
-                        .map_err(|_| {
-                            Error::Data(Some("Fail to decode q field of jwk".to_string()))
-                        })?;
-                    let dp = jwk
-                        .dp
-                        .map(|dp| Base64UrlUnpadded::decode_vec(&dp.str()))
-                        .transpose()
-                        .map_err(|_| {
-                            Error::Data(Some("Fail to decode dp field of jwk".to_string()))
-                        })?;
-                    let dq = jwk
-                        .dq
-                        .map(|dq| Base64UrlUnpadded::decode_vec(&dq.str()))
-                        .transpose()
-                        .map_err(|_| {
-                            Error::Data(Some("Fail to decode dq field of jwk".to_string()))
-                        })?;
-                    let qi = jwk
-                        .qi
-                        .map(|qi| Base64UrlUnpadded::decode_vec(&qi.str()))
-                        .transpose()
-                        .map_err(|_| {
-                            Error::Data(Some("Fail to decode qi field of jwk".to_string()))
-                        })?;
-                    let mut primes = match (p, q, dp, dq, qi) {
-                        (Some(p), Some(q), Some(_dp), Some(_dq), Some(_qi)) => vec![p, q],
-                        (None, None, None, None, None) => Vec::new(),
-                        _ => return Err(Error::Data(Some(
-                            "The p, q, dp, dq, qi fields of jwk must be either all-present or all-absent"
-                                .to_string()
-                        ))),
-                    };
-                    if let Some(oth) = jwk.oth {
-                        if primes.is_empty() {
-                            return Err(Error::Data(Some(
-                                "The oth field exists in jwk but one of p, q, dp, dq, qi is missing".to_string()
-                            )));
-                        }
-                        for other_prime in oth {
-                            let r = Base64UrlUnpadded::decode_vec(
-                                &other_prime
-                                    .r
-                                    .ok_or(Error::Data(Some(
-                                        "The e field does not exist in oth field of jwk"
-                                            .to_string(),
-                                    )))?
-                                    .str(),
-                            )
-                            .map_err(|_| {
-                                Error::Data(Some(
-                                    "Fail to decode r field of oth field of jwk".to_string(),
-                                ))
-                            })?;
-                            primes.push(r);
-                        }
-                    }
+            // If the d field of jwk is present:
+            if jwk.d.is_some() {
+                // Step 2.10.1. If jwk does not meet the requirements of Section 6.3.2 of JSON Web
+                // Algorithms [JWA], then throw a DataError.
+                let n = jwk.decode_required_string_field(JwkStringField::N)?;
+                let e = jwk.decode_required_string_field(JwkStringField::E)?;
+                let d = jwk.decode_required_string_field(JwkStringField::D)?;
+                let p = jwk.decode_optional_string_field(JwkStringField::P)?;
+                let q = jwk.decode_optional_string_field(JwkStringField::Q)?;
+                let dp = jwk.decode_optional_string_field(JwkStringField::DP)?;
+                let dq = jwk.decode_optional_string_field(JwkStringField::DQ)?;
+                let qi = jwk.decode_optional_string_field(JwkStringField::QI)?;
+                let mut primes = match (p, q, dp, dq, qi) {
+                    (Some(p), Some(q), Some(_dp), Some(_dq), Some(_qi)) => vec![p, q],
+                    (None, None, None, None, None) => Vec::new(),
+                    _ => return Err(Error::Data(Some(
+                        "The p, q, dp, dq, qi fields of jwk must be either all-present or all-absent"
+                            .to_string()
+                    ))),
+                };
+                jwk.decode_primes_from_oth_field(&mut primes)?;
 
-                    // Step 2.10.2. Let privateKey represents the RSA private key identified by
-                    // interpreting jwk according to Section 6.3.2 of JSON Web Algorithms [JWA].
-                    // Step 2.10.3. If privateKey is not a valid RSA private key according to
-                    // [RFC3447], then throw a DataError.
-                    let private_key = RsaPrivateKey::from_components(
-                        BigUint::from_bytes_be(&n),
-                        BigUint::from_bytes_be(&e),
-                        BigUint::from_bytes_be(&d),
-                        primes
-                            .into_iter()
-                            .map(|prime| BigUint::from_bytes_be(&prime))
-                            .collect(),
-                    )
-                    .map_err(|_| {
-                        Error::Data(Some(
-                            "Fail to construct RSA private key from values in jwk".to_string(),
-                        ))
-                    })?;
+                // Step 2.10.2. Let privateKey represents the RSA private key identified by
+                // interpreting jwk according to Section 6.3.2 of JSON Web Algorithms [JWA].
+                // Step 2.10.3. If privateKey is not a valid RSA private key according to
+                // [RFC3447], then throw a DataError.
+                let private_key = RsaPrivateKey::from_components(
+                    BigUint::from_bytes_be(&n),
+                    BigUint::from_bytes_be(&e),
+                    BigUint::from_bytes_be(&d),
+                    primes
+                        .into_iter()
+                        .map(|prime| BigUint::from_bytes_be(&prime))
+                        .collect(),
+                )
+                .map_err(|_| {
+                    Error::Data(Some(
+                        "Failed to construct RSA private key from values in jwk".to_string(),
+                    ))
+                })?;
 
-                    // Step 2.10.4. Let key be a new CryptoKey object that represents privateKey.
-                    // Step 2.10.5. Set the [[type]] internal slot of key to "private"
-                    // NOTE: Done in Step 3-8.
-                    let key_handle = Handle::RsaPrivateKey(private_key);
-                    let key_type = KeyType::Private;
-                    (key_handle, key_type)
-                },
-                // Otherwise:
-                None => {
-                    // Step 2.10.1. If jwk does not meet the requirements of Section 6.3.1 of JSON
-                    // Web Algorithms [JWA], then throw a DataError.
-                    let n = Base64UrlUnpadded::decode_vec(
-                        &jwk.n
-                            .ok_or(Error::Data(Some(
-                                "The n field does not exist in jwk".to_string(),
-                            )))?
-                            .str(),
-                    )
-                    .map_err(|_| Error::Data(Some("Fail to decode n field of jwk".to_string())))?;
-                    let e = Base64UrlUnpadded::decode_vec(
-                        &jwk.e
-                            .ok_or(Error::Data(Some(
-                                "The e field does not exist in jwk".to_string(),
-                            )))?
-                            .str(),
-                    )
-                    .map_err(|_| Error::Data(Some("Fail to decode e field of jwk".to_string())))?;
+                // Step 2.10.4. Let key be a new CryptoKey object that represents privateKey.
+                // Step 2.10.5. Set the [[type]] internal slot of key to "private"
+                // NOTE: Done in Step 3-8.
+                let key_handle = Handle::RsaPrivateKey(private_key);
+                let key_type = KeyType::Private;
+                (key_handle, key_type)
+            }
+            // Otherwise:
+            else {
+                // Step 2.10.1. If jwk does not meet the requirements of Section 6.3.1 of JSON Web
+                // Algorithms [JWA], then throw a DataError.
+                let n = jwk.decode_required_string_field(JwkStringField::N)?;
+                let e = jwk.decode_required_string_field(JwkStringField::E)?;
 
-                    // Step 2.10.2. Let publicKey represent the RSA public key identified by
-                    // interpreting jwk according to Section 6.3.1 of JSON Web Algorithms [JWA].
-                    // Step 2.10.3. If publicKey can be determined to not be a valid RSA public key
-                    // according to [RFC3447], then throw a DataError.
-                    let public_key =
-                        RsaPublicKey::new(BigUint::from_bytes_be(&n), BigUint::from_bytes_be(&e))
-                            .map_err(|_| {
+                // Step 2.10.2. Let publicKey represent the RSA public key identified by
+                // interpreting jwk according to Section 6.3.1 of JSON Web Algorithms [JWA].
+                // Step 2.10.3. If publicKey can be determined to not be a valid RSA public key
+                // according to [RFC3447], then throw a DataError.
+                let public_key =
+                    RsaPublicKey::new(BigUint::from_bytes_be(&n), BigUint::from_bytes_be(&e))
+                        .map_err(|_| {
                             Error::Data(Some(
-                                "Fail to construct RSA public key from values in jwk".to_string(),
+                                "Failed to construct RSA public key from values in jwk".to_string(),
                             ))
                         })?;
 
-                    // Step 2.10.4. Let key be a new CryptoKey representing publicKey.
-                    // Step 2.10.5. Set the [[type]] internal slot of key to "public"
-                    // NOTE: Done in Step 3-8.
-                    let key_handle = Handle::RsaPublicKey(public_key);
-                    let key_type = KeyType::Public;
-                    (key_handle, key_type)
-                },
+                // Step 2.10.4. Let key be a new CryptoKey representing publicKey.
+                // Step 2.10.5. Set the [[type]] internal slot of key to "public"
+                // NOTE: Done in Step 3-8.
+                let key_handle = Handle::RsaPublicKey(public_key);
+                let key_type = KeyType::Public;
+                (key_handle, key_type)
             }
         },
         // Otherwise:

--- a/components/script/dom/subtlecrypto/x25519_operation.rs
+++ b/components/script/dom/subtlecrypto/x25519_operation.rs
@@ -2,7 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-use base64ct::{Base64UrlUnpadded, Encoding};
 use pkcs8::PrivateKeyInfo;
 use pkcs8::der::asn1::{BitStringRef, OctetString, OctetStringRef};
 use pkcs8::der::{AnyRef, Decode, Encode};
@@ -20,8 +19,8 @@ use crate::dom::bindings::str::DOMString;
 use crate::dom::cryptokey::{CryptoKey, Handle};
 use crate::dom::globalscope::GlobalScope;
 use crate::dom::subtlecrypto::{
-    ALG_X25519, ExportedKey, JsonWebKeyExt, KeyAlgorithmAndDerivatives, SubtleEcdhKeyDeriveParams,
-    SubtleKeyAlgorithm,
+    ALG_X25519, ExportedKey, JsonWebKeyExt, JwkStringField, KeyAlgorithmAndDerivatives,
+    SubtleEcdhKeyDeriveParams, SubtleKeyAlgorithm,
 };
 use crate::script_runtime::CanGc;
 
@@ -366,62 +365,50 @@ pub(crate) fn import_key(
             }
 
             // Step 2.9.
-            let (handle, key_type) = match jwk.d {
-                Some(d) => {
-                    // Step 2.9.1. If jwk does not meet the requirements of the JWK private key
-                    // format described in Section 2 of [RFC8037], then throw a DataError.
-                    let x = match jwk.x {
-                        Some(x) => Base64UrlUnpadded::decode_vec(&x.str())
-                            .map_err(|_| Error::Data(None))?,
-                        None => return Err(Error::Data(None)),
-                    };
-                    let d =
-                        Base64UrlUnpadded::decode_vec(&d.str()).map_err(|_| Error::Data(None))?;
-                    let public_key_bytes: [u8; PUBLIC_KEY_LENGTH] =
-                        x.try_into().map_err(|_| Error::Data(None))?;
-                    let private_key_bytes: [u8; PRIVATE_KEY_LENGTH] =
-                        d.try_into().map_err(|_| Error::Data(None))?;
-                    let public_key = PublicKey::from(public_key_bytes);
-                    let private_key = StaticSecret::from(private_key_bytes);
-                    if PublicKey::from(&private_key) != public_key {
-                        return Err(Error::Data(None));
-                    }
+            // If the d field is present:
+            let (handle, key_type) = if jwk.d.is_some() {
+                // Step 2.9.1. If jwk does not meet the requirements of the JWK private key format
+                // described in Section 2 of [RFC8037], then throw a DataError.
+                let x = jwk.decode_required_string_field(JwkStringField::X)?;
+                let d = jwk.decode_required_string_field(JwkStringField::D)?;
+                let public_key_bytes: [u8; PUBLIC_KEY_LENGTH] =
+                    x.try_into().map_err(|_| Error::Data(None))?;
+                let private_key_bytes: [u8; PRIVATE_KEY_LENGTH] =
+                    d.try_into().map_err(|_| Error::Data(None))?;
+                let public_key = PublicKey::from(public_key_bytes);
+                let private_key = StaticSecret::from(private_key_bytes);
+                if PublicKey::from(&private_key) != public_key {
+                    return Err(Error::Data(None));
+                }
 
-                    // Step 2.9.1. Let key be a new CryptoKey object that represents the X25519
-                    // private key identified by interpreting jwk according to Section 2 of
-                    // [RFC8037].
-                    // NOTE: CryptoKey is created in Step 2.10 - 2.12.
-                    let handle = Handle::X25519PrivateKey(private_key);
+                // Step 2.9.1. Let key be a new CryptoKey object that represents the X25519 private
+                // key identified by interpreting jwk according to Section 2 of [RFC8037].
+                // NOTE: CryptoKey is created in Step 2.10 - 2.12.
+                let handle = Handle::X25519PrivateKey(private_key);
 
-                    // Step 2.9.1. Set the [[type]] internal slot of Key to "private".
-                    let key_type = KeyType::Private;
+                // Step 2.9.1. Set the [[type]] internal slot of Key to "private".
+                let key_type = KeyType::Private;
 
-                    (handle, key_type)
-                },
-                // Otherwise:
-                None => {
-                    // Step 2.9.1. If jwk does not meet the requirements of the JWK public key
-                    // format described in Section 2 of [RFC8037], then throw a DataError.
-                    let x = match jwk.x {
-                        Some(x) => Base64UrlUnpadded::decode_vec(&x.str())
-                            .map_err(|_| Error::Data(None))?,
-                        None => return Err(Error::Data(None)),
-                    };
-                    let public_key_bytes: [u8; PUBLIC_KEY_LENGTH] =
-                        x.try_into().map_err(|_| Error::Data(None))?;
-                    let public_key = PublicKey::from(public_key_bytes);
+                (handle, key_type)
+            }
+            // Otherwise:
+            else {
+                // Step 2.9.1. If jwk does not meet the requirements of the JWK public key format
+                // described in Section 2 of [RFC8037], then throw a DataError.
+                let x = jwk.decode_required_string_field(JwkStringField::X)?;
+                let public_key_bytes: [u8; PUBLIC_KEY_LENGTH] =
+                    x.try_into().map_err(|_| Error::Data(None))?;
+                let public_key = PublicKey::from(public_key_bytes);
 
-                    // Step 2.9.1. Let key be a new CryptoKey object that represents the X25519
-                    // public key identified by interpreting jwk according to Section 2 of
-                    // [RFC8037].
-                    // NOTE: CryptoKey is created in Step 2.10 - 2.12.
-                    let handle = Handle::X25519PublicKey(public_key);
+                // Step 2.9.1. Let key be a new CryptoKey object that represents the X25519 public
+                // key identified by interpreting jwk according to Section 2 of [RFC8037].
+                // NOTE: CryptoKey is created in Step 2.10 - 2.12.
+                let handle = Handle::X25519PublicKey(public_key);
 
-                    // Step 2.9.1. Set the [[type]] internal slot of Key to "public".
-                    let key_type = KeyType::Public;
+                // Step 2.9.1. Set the [[type]] internal slot of Key to "public".
+                let key_type = KeyType::Public;
 
-                    (handle, key_type)
-                },
+                (handle, key_type)
             };
 
             // Step 2.10. Let algorithm be a new instance of a KeyAlgorithm object.
@@ -574,13 +561,13 @@ pub(crate) fn export_key(format: KeyFormat, key: &CryptoKey) -> Result<ExportedK
 
             // Step 3.4. Set the x attribute of jwk according to the definition in Section 2 of
             // [RFC8037].
-            jwk.x = match key.handle() {
+            match key.handle() {
                 Handle::X25519PrivateKey(private_key) => {
                     let public_key = PublicKey::from(private_key);
-                    Some(Base64UrlUnpadded::encode_string(public_key.as_bytes()).into())
+                    jwk.encode_string_field(JwkStringField::X, public_key.as_bytes());
                 },
                 Handle::X25519PublicKey(public_key) => {
-                    Some(Base64UrlUnpadded::encode_string(public_key.as_bytes()).into())
+                    jwk.encode_string_field(JwkStringField::X, public_key.as_bytes());
                 },
                 _ => return Err(Error::Operation(None)),
             };
@@ -591,19 +578,14 @@ pub(crate) fn export_key(format: KeyFormat, key: &CryptoKey) -> Result<ExportedK
             //     [RFC8037].
             if key.Type() == KeyType::Private {
                 if let Handle::X25519PrivateKey(private_key) = key.handle() {
-                    jwk.d = Some(Base64UrlUnpadded::encode_string(private_key.as_bytes()).into());
+                    jwk.encode_string_field(JwkStringField::D, private_key.as_bytes());
                 } else {
                     return Err(Error::Operation(None));
                 }
             }
 
             // Step 3.6. Set the key_ops attribute of jwk to the usages attribute of key.
-            jwk.key_ops = Some(
-                key.usages()
-                    .iter()
-                    .map(|usage| DOMString::from(usage.as_str()))
-                    .collect::<Vec<DOMString>>(),
-            );
+            jwk.set_key_ops(key.usages());
 
             // Step 3.7. Set the ext attribute of jwk to the [[extractable]] internal slot of key.
             jwk.ext = Some(key.Extractable());


### PR DESCRIPTION
Add several helper functions to JsonWebKey to handle common tasks across multiple algorithms, including:

- Set "key_ops" field to a given list of usages: `JsonWebKey::set_key_ops`.
- Encode a byte sequence to a base64encoded string in field: `JsonWebKey::encode_string_field`.
- Decode a base64encoded string in field to a byte sequence: `JsonWebKey::decode_optional_string_field` and `JsonWebKey::decode_required_string_field`.
- Decode "oth" field to primes: `JsonWebKey::decode_primes_from_oth_field`.

These help simplify our code for importing and exporting keys in JsonWebKey format.

Testing: Refactoring. Existing tests suffice.