### PR TITLE
script: Introduce concept of a fetch group

### DIFF
--- a/components/shared/net/request.rs
+++ b/components/shared/net/request.rs
@@ -24,7 +24,7 @@ use crate::response::{HttpsState, Response};
 use crate::{ReferrerPolicy, ResourceTimingType};
 
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, MallocSizeOf, PartialEq, Serialize)]
-/// An id to differeniate one network request from another.
+/// An id to differentiate one network request from another.
 pub struct RequestId(pub Uuid);
 
 impl Default for RequestId {


### PR DESCRIPTION
We now keep track of deferred fetches in globalscope
rather than in document loader. This matches what
the spec expects with its concept of a fetchgroup.

Cancellations are still present in a document loader
and don't match yet all places where we perform fetches.
Therefore, these will leave in document loader for now
until we rearranged the fetch record tracking in the
fetch group (which is a separate field from deferred
fetches).

Fixes #41286