### PR TITLE
script: Add helper functions to handle JsonWebKey common decoding tasks

### DIFF
--- a/components/script/dom/subtlecrypto.rs
+++ b/components/script/dom/subtlecrypto.rs
@@ -20,10 +20,12 @@ mod sha3_operation;
 mod sha_operation;
 mod x25519_operation;
 
+use std::fmt::Display;
 use std::ptr;
 use std::rc::Rc;
 use std::str::FromStr;
 
+use base64ct::{Base64UrlUnpadded, Encoding};
 use dom_struct::dom_struct;
 use js::conversions::ConversionResult;
 use js::jsapi::{Heap, JSObject};
@@ -2426,11 +2428,49 @@ impl SafeToJSValConvertible for KeyAlgorithmAndDerivatives {
     }
 }
 
+#[derive(Clone, Copy)]
+enum JwkStringField {
+    X,
+    Y,
+    D,
+    N,
+    E,
+    P,
+    Q,
+    DP,
+    DQ,
+    QI,
+    K,
+}
+
+impl Display for JwkStringField {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let field_name = match self {
+            JwkStringField::X => "x",
+            JwkStringField::Y => "y",
+            JwkStringField::D => "d",
+            JwkStringField::N => "n",
+            JwkStringField::E => "e",
+            JwkStringField::P => "q",
+            JwkStringField::Q => "q",
+            JwkStringField::DP => "dp",
+            JwkStringField::DQ => "dq",
+            JwkStringField::QI => "qi",
+            JwkStringField::K => "k",
+        };
+        write!(f, "{}", field_name)
+    }
+}
+
 trait JsonWebKeyExt {
     fn parse(cx: JSContext, data: &[u8]) -> Result<JsonWebKey, Error>;
     fn stringify(&self, cx: JSContext) -> Result<DOMString, Error>;
     fn get_usages_from_key_ops(&self) -> Result<Vec<KeyUsage>, Error>;
     fn check_key_ops(&self, specified_usages: &[KeyUsage]) -> Result<(), Error>;
+    fn decode_optional_string_field(&self, field: JwkStringField)
+    -> Result<Option<Vec<u8>>, Error>;
+    fn decode_required_string_field(&self, field: JwkStringField) -> Result<Vec<u8>, Error>;
+    fn decode_primes_from_oth_field(&self, primes: &mut Vec<Vec<u8>>) -> Result<(), Error>;
 }
 
 impl JsonWebKeyExt for JsonWebKey {
@@ -2527,6 +2567,116 @@ impl JsonWebKeyExt for JsonWebKey {
             {
                 return Err(Error::Data(None));
             }
+        }
+
+        Ok(())
+    }
+
+    // Decode a field from a base64url-encoded string to a byte sequence. If the field is not a
+    // valid base64url-encoded string, then throw a DataError.
+    fn decode_optional_string_field(
+        &self,
+        field: JwkStringField,
+    ) -> Result<Option<Vec<u8>>, Error> {
+        let field_string = match field {
+            JwkStringField::X => &self.x,
+            JwkStringField::Y => &self.y,
+            JwkStringField::D => &self.d,
+            JwkStringField::N => &self.n,
+            JwkStringField::E => &self.e,
+            JwkStringField::P => &self.p,
+            JwkStringField::Q => &self.q,
+            JwkStringField::DP => &self.dp,
+            JwkStringField::DQ => &self.dq,
+            JwkStringField::QI => &self.qi,
+            JwkStringField::K => &self.k,
+        };
+
+        field_string
+            .as_ref()
+            .map(|field_string| Base64UrlUnpadded::decode_vec(&field_string.str()))
+            .transpose()
+            .map_err(|_| Error::Data(Some(format!("Failed to decode {} field in jwk", field))))
+    }
+
+    // Decode a field from a base64url-encoded string to a byte sequence. If the field is not
+    // present or it is not a valid base64url-encoded string, then throw a DataError.
+    fn decode_required_string_field(&self, field: JwkStringField) -> Result<Vec<u8>, Error> {
+        self.decode_optional_string_field(field)?
+            .ok_or(Error::Data(Some(format!(
+                "The {} field is not present in jwk",
+                field
+            ))))
+    }
+
+    // Decode the "r", "d" and "t" field of each entry in the "oth" array, from a base64url-encoded
+    // string to a byte sequence, and append the decoded "r" field to the `primes` list, in the
+    // order of presence in the "oth" array.
+    //
+    // For each entry in the "oth" array, if any of the "r", "d" and "t" field is not present or it
+    // is not a valid base64url-encoded string, then throw a DataError.
+    fn decode_primes_from_oth_field(&self, primes: &mut Vec<Vec<u8>>) -> Result<(), Error> {
+        if self.oth.is_some() &&
+            (self.p.is_none() ||
+                self.q.is_none() ||
+                self.dp.is_none() ||
+                self.dq.is_none() ||
+                self.qi.is_none())
+        {
+            return Err(Error::Data(Some(
+                "The oth field is present while at least one of p, q, dp, dq, qi is missing, in jwk".to_string()
+            )));
+        }
+
+        for rsa_other_prime_info in self.oth.as_ref().unwrap_or(&Vec::new()) {
+            let r = Base64UrlUnpadded::decode_vec(
+                &rsa_other_prime_info
+                    .r
+                    .as_ref()
+                    .ok_or(Error::Data(Some(
+                        "The r field is not present in one of the entry of oth field in jwk"
+                            .to_string(),
+                    )))?
+                    .str(),
+            )
+            .map_err(|_| {
+                Error::Data(Some(
+                    "Fail to decode r field in one of the entry of oth field in jwk".to_string(),
+                ))
+            })?;
+            primes.push(r);
+
+            let _d = Base64UrlUnpadded::decode_vec(
+                &rsa_other_prime_info
+                    .d
+                    .as_ref()
+                    .ok_or(Error::Data(Some(
+                        "The d field is not present in one of the entry of oth field in jwk"
+                            .to_string(),
+                    )))?
+                    .str(),
+            )
+            .map_err(|_| {
+                Error::Data(Some(
+                    "Fail to decode d field in one of the entry of oth field in jwk".to_string(),
+                ))
+            })?;
+
+            let _t = Base64UrlUnpadded::decode_vec(
+                &rsa_other_prime_info
+                    .t
+                    .as_ref()
+                    .ok_or(Error::Data(Some(
+                        "The t field is not present in one of the entry of oth field in jwk"
+                            .to_string(),
+                    )))?
+                    .str(),
+            )
+            .map_err(|_| {
+                Error::Data(Some(
+                    "Fail to decode t field in one of the entry of oth field in jwk".to_string(),
+                ))
+            })?;
         }
 
         Ok(())

--- a/components/script/dom/subtlecrypto/aes_operation.rs
+++ b/components/script/dom/subtlecrypto/aes_operation.rs
@@ -23,7 +23,7 @@ use crate::dom::bindings::str::DOMString;
 use crate::dom::cryptokey::{CryptoKey, Handle};
 use crate::dom::globalscope::GlobalScope;
 use crate::dom::subtlecrypto::{
-    ALG_AES_CBC, ALG_AES_CTR, ALG_AES_GCM, ALG_AES_KW, ExportedKey, JsonWebKeyExt,
+    ALG_AES_CBC, ALG_AES_CTR, ALG_AES_GCM, ALG_AES_KW, ExportedKey, JsonWebKeyExt, JwkStringField,
     KeyAlgorithmAndDerivatives, SubtleAesCbcParams, SubtleAesCtrParams, SubtleAesDerivedKeyParams,
     SubtleAesGcmParams, SubtleAesKeyAlgorithm, SubtleAesKeyGenParams,
 };
@@ -918,13 +918,7 @@ fn import_key_aes(
             // NOTE: Done by Step 2.4 and 2.5.
 
             // Step 2.4. Let data be the byte sequence obtained by decoding the k field of jwk.
-            data = Base64UrlUnpadded::decode_vec(
-                &jwk.k
-                    .as_ref()
-                    .ok_or(Error::Data(Some("JWK `k` field is missing".into())))?
-                    .str(),
-            )
-            .map_err(|_| Error::Data(Some("JWK key could not be decoded from base64".into())))?;
+            data = jwk.decode_required_string_field(JwkStringField::K)?;
 
             // NOTE: This function is shared by AES-CBC, AES-CTR, AES-GCM and AES-KW.
             // Different static texts are used in different AES types, in the following step.

--- a/components/script/dom/subtlecrypto/chacha20_poly1305_operation.rs
+++ b/components/script/dom/subtlecrypto/chacha20_poly1305_operation.rs
@@ -16,7 +16,7 @@ use crate::dom::bindings::str::DOMString;
 use crate::dom::cryptokey::{CryptoKey, Handle};
 use crate::dom::globalscope::GlobalScope;
 use crate::dom::subtlecrypto::{
-    ALG_CHACHA20_POLY1305, ExportedKey, JsonWebKeyExt, KeyAlgorithmAndDerivatives,
+    ALG_CHACHA20_POLY1305, ExportedKey, JsonWebKeyExt, JwkStringField, KeyAlgorithmAndDerivatives,
     SubtleAeadParams, SubtleKeyAlgorithm,
 };
 use crate::script_runtime::CanGc;
@@ -256,18 +256,8 @@ pub(crate) fn import_key(
 
             // Step 3.3. If jwk does not meet the requirements of Section 6.4 of JSON Web
             // Algorithms [JWA], then throw a DataError.
-            let Some(k) = jwk.k.as_ref() else {
-                return Err(Error::Data(Some(
-                    "jwk does not meet the requirements of JWA".to_string(),
-                )));
-            };
-
             // Step 3.4. Let data be the byte sequence obtained by decoding the k field of jwk.
-            data = Base64UrlUnpadded::decode_vec(&k.str()).map_err(|_| {
-                Error::Data(Some(
-                    "Fail to obtain byte sequence by decoding the k field of jwk".to_string(),
-                ))
-            })?;
+            data = jwk.decode_required_string_field(JwkStringField::K)?;
 
             // Step 3.5. If the alg field of jwk is present, and is not "C20P", then throw a
             // DataError.

--- a/components/script/dom/subtlecrypto/ecdsa_operation.rs
+++ b/components/script/dom/subtlecrypto/ecdsa_operation.rs
@@ -31,9 +31,9 @@ use crate::dom::cryptokey::{CryptoKey, Handle};
 use crate::dom::globalscope::GlobalScope;
 use crate::dom::subtlecrypto::{
     ALG_ECDSA, ALG_SHA1, ALG_SHA256, ALG_SHA384, ALG_SHA512, ExportedKey, JsonWebKeyExt,
-    KeyAlgorithmAndDerivatives, NAMED_CURVE_P256, NAMED_CURVE_P384, NAMED_CURVE_P521,
-    SUPPORTED_CURVES, SubtleEcKeyAlgorithm, SubtleEcKeyGenParams, SubtleEcKeyImportParams,
-    SubtleEcdsaParams,
+    JwkStringField, KeyAlgorithmAndDerivatives, NAMED_CURVE_P256, NAMED_CURVE_P384,
+    NAMED_CURVE_P521, SUPPORTED_CURVES, SubtleEcKeyAlgorithm, SubtleEcKeyGenParams,
+    SubtleEcKeyImportParams, SubtleEcdsaParams,
 };
 use crate::script_runtime::CanGc;
 
@@ -689,7 +689,8 @@ pub(crate) fn import_key(
             // normalizedAlgorithm, throw a DataError.
             let named_curve = jwk
                 .crv
-                .filter(|crv| *crv == normalized_algorithm.named_curve)
+                .as_ref()
+                .filter(|crv| **crv == normalized_algorithm.named_curve)
                 .map(|crv| crv.to_string())
                 .ok_or(Error::Data(None))?;
 
@@ -700,8 +701,8 @@ pub(crate) fn import_key(
                     named_curve.as_str(),
                     NAMED_CURVE_P256 | NAMED_CURVE_P384 | NAMED_CURVE_P521
                 ) {
-                    // Step 9.1. Let algNamedCurve be a string whose initial value is undefined.
-                    // Step 9.2.
+                    // Step 2.9.1. Let algNamedCurve be a string whose initial value is undefined.
+                    // Step 2.9.2.
                     // If the alg field is not present:
                     //     Let algNamedCurve be undefined.
                     // If the alg field is equal to the string "ES256":
@@ -712,7 +713,7 @@ pub(crate) fn import_key(
                     //     Let algNamedCurve be the string "P-521".
                     // otherwise:
                     //     throw a DataError.
-                    let alg = jwk.alg.map(|alg| alg.to_string());
+                    let alg = jwk.alg.as_ref().map(|alg| alg.to_string());
                     let alg_named_curve = match alg.as_deref() {
                         None => None,
                         Some("ES256") => Some(NAMED_CURVE_P256),
@@ -721,143 +722,127 @@ pub(crate) fn import_key(
                         _ => return Err(Error::Data(None)),
                     };
 
-                    // Step 9.3. If algNamedCurve is defined, and is not equal to namedCurve, throw
-                    // a DataError.
+                    // Step 2.9.3. If algNamedCurve is defined, and is not equal to namedCurve,
+                    // throw a DataError.
                     if alg_named_curve.is_some_and(|alg_named_curve| alg_named_curve != named_curve) {
                         return Err(Error::Data(None));
                     }
 
-                    match jwk.d {
-                        // If the d field is present:
-                        Some(d) => {
-                            // Step 2.9.1. If jwk does not meet the requirements of Section 6.2.2 of
-                            // JSON Web Algorithms [JWA], then throw a DataError.
-                            let x = match jwk.x {
-                                Some(x) => Base64UrlUnpadded::decode_vec(&x.str())
-                                    .map_err(|_| Error::Data(None))?,
-                                None => return Err(Error::Data(None)),
-                            };
-                            let y = match jwk.y {
-                                Some(y) => Base64UrlUnpadded::decode_vec(&y.str())
-                                    .map_err(|_| Error::Data(None))?,
-                                None => return Err(Error::Data(None)),
-                            };
-                            let d =
-                                Base64UrlUnpadded::decode_vec(&d.str()).map_err(|_| Error::Data(None))?;
+                    // Step 2.9.4.
+                    // If the d field is present:
+                    if jwk.d.is_some() {
+                        // Step 2.9.4.1. If jwk does not meet the requirements of Section 6.2.2 of
+                        // JSON Web Algorithms [JWA], then throw a DataError.
+                        let x = jwk.decode_required_string_field(JwkStringField::X)?;
+                        let y = jwk.decode_required_string_field(JwkStringField::Y)?;
+                        let d = jwk.decode_required_string_field(JwkStringField::D)?;
 
-                            // Step 2.9.2. Let key be a new CryptoKey object that represents the
-                            // Elliptic Curve private key identified by interpreting jwk according to
-                            // Section 6.2.2 of JSON Web Algorithms [JWA].
-                            // NOTE: CryptoKey is created in Step 2.12 - 2.15.
-                            let handle = match named_curve.as_str() {
-                                NAMED_CURVE_P256 => {
-                                    let private_key =
-                                        p256::SecretKey::from_slice(&d).map_err(|_| Error::Data(None))?;
-                                    let mut sec1_bytes = vec![4u8];
-                                    sec1_bytes.extend_from_slice(&x);
-                                    sec1_bytes.extend_from_slice(&y);
-                                    let encoded_point = EncodedPoint::from_bytes(&sec1_bytes)
-                                        .map_err(|_| Error::Data(None))?;
-                                    NistP256::validate_public_key(&private_key, &encoded_point)
-                                        .map_err(|_| Error::Data(None))?;
-                                    Handle::P256PrivateKey(private_key)
-                                },
-                                NAMED_CURVE_P384 => {
-                                    let private_key =
-                                        p384::SecretKey::from_slice(&d).map_err(|_| Error::Data(None))?;
-                                    let mut sec1_bytes = vec![4u8];
-                                    sec1_bytes.extend_from_slice(&x);
-                                    sec1_bytes.extend_from_slice(&y);
-                                    let encoded_point = EncodedPoint::from_bytes(&sec1_bytes)
-                                        .map_err(|_| Error::Data(None))?;
-                                    NistP384::validate_public_key(&private_key, &encoded_point)
-                                        .map_err(|_| Error::Data(None))?;
-                                    Handle::P384PrivateKey(private_key)
-                                },
-                                NAMED_CURVE_P521 => {
-                                    let private_key =
-                                        p521::SecretKey::from_slice(&d).map_err(|_| Error::Data(None))?;
-                                    let mut sec1_bytes = vec![4u8];
-                                    sec1_bytes.extend_from_slice(&x);
-                                    sec1_bytes.extend_from_slice(&y);
-                                    let encoded_point = EncodedPoint::from_bytes(&sec1_bytes)
-                                        .map_err(|_| Error::Data(None))?;
-                                    NistP521::validate_public_key(&private_key, &encoded_point)
-                                        .map_err(|_| Error::Data(None))?;
-                                    Handle::P521PrivateKey(private_key)
-                                },
-                                _ => unreachable!(),
-                            };
+                        // Step 2.9.4.2. Let key be a new CryptoKey object that represents the
+                        // Elliptic Curve private key identified by interpreting jwk according to
+                        // Section 6.2.2 of JSON Web Algorithms [JWA].
+                        // NOTE: CryptoKey is created in Step 2.11 - 2.14.
+                        let handle = match named_curve.as_str() {
+                            NAMED_CURVE_P256 => {
+                                let private_key =
+                                    p256::SecretKey::from_slice(&d).map_err(|_| Error::Data(None))?;
+                                let mut sec1_bytes = vec![4u8];
+                                sec1_bytes.extend_from_slice(&x);
+                                sec1_bytes.extend_from_slice(&y);
+                                let encoded_point = EncodedPoint::from_bytes(&sec1_bytes)
+                                    .map_err(|_| Error::Data(None))?;
+                                NistP256::validate_public_key(&private_key, &encoded_point)
+                                    .map_err(|_| Error::Data(None))?;
+                                Handle::P256PrivateKey(private_key)
+                            },
+                            NAMED_CURVE_P384 => {
+                                let private_key =
+                                    p384::SecretKey::from_slice(&d).map_err(|_| Error::Data(None))?;
+                                let mut sec1_bytes = vec![4u8];
+                                sec1_bytes.extend_from_slice(&x);
+                                sec1_bytes.extend_from_slice(&y);
+                                let encoded_point = EncodedPoint::from_bytes(&sec1_bytes)
+                                    .map_err(|_| Error::Data(None))?;
+                                NistP384::validate_public_key(&private_key, &encoded_point)
+                                    .map_err(|_| Error::Data(None))?;
+                                Handle::P384PrivateKey(private_key)
+                            },
+                            NAMED_CURVE_P521 => {
+                                let private_key =
+                                    p521::SecretKey::from_slice(&d).map_err(|_| Error::Data(None))?;
+                                let mut sec1_bytes = vec![4u8];
+                                sec1_bytes.extend_from_slice(&x);
+                                sec1_bytes.extend_from_slice(&y);
+                                let encoded_point = EncodedPoint::from_bytes(&sec1_bytes)
+                                    .map_err(|_| Error::Data(None))?;
+                                NistP521::validate_public_key(&private_key, &encoded_point)
+                                    .map_err(|_| Error::Data(None))?;
+                                Handle::P521PrivateKey(private_key)
+                            },
+                            _ => unreachable!(),
+                        };
 
-                            // Step 2.9.3. Set the [[type]] internal slot of Key to "private".
-                            let key_type = KeyType::Private;
+                        // Step 2.9.4.3. Set the [[type]] internal slot of Key to "private".
+                        // NOTE: CryptoKey is created in Step 2.11 - 2.14.
+                        let key_type = KeyType::Private;
 
-                            (handle, key_type)
-                        },
-                        // Otherwise:
-                        None => {
-                            // Step 2.9.1. If jwk does not meet the requirements of Section 6.2.1 of
-                            // JSON Web Algorithms [JWA], then throw a DataError.
-                            let x = match jwk.x {
-                                Some(x) => Base64UrlUnpadded::decode_vec(&x.str())
-                                    .map_err(|_| Error::Data(None))?,
-                                None => return Err(Error::Data(None)),
-                            };
-                            let y = match jwk.y {
-                                Some(y) => Base64UrlUnpadded::decode_vec(&y.str())
-                                    .map_err(|_| Error::Data(None))?,
-                                None => return Err(Error::Data(None)),
-                            };
+                        (handle, key_type)
+                    }
+                    // Otherwise:
+                    else {
+                        // Step 2.9.4.1. If jwk does not meet the requirements of Section 6.2.1 of
+                        // JSON Web Algorithms [JWA], then throw a DataError.
+                        let x = jwk.decode_required_string_field(JwkStringField::X)?;
+                        let y = jwk.decode_required_string_field(JwkStringField::Y)?;
 
-                            // Step 2.9.2. Let key be a new CryptoKey object that represents the
-                            // Elliptic Curve public key identified by interpreting jwk according to
-                            // Section 6.2.1 of JSON Web Algorithms [JWA].
-                            // NOTE: CryptoKey is created in Step 2.12 - 2.15.
-                            let handle = match named_curve.as_str() {
-                                NAMED_CURVE_P256 => {
-                                    let mut sec1_bytes = vec![4u8];
-                                    sec1_bytes.extend_from_slice(&x);
-                                    sec1_bytes.extend_from_slice(&y);
-                                    let encoded_point = EncodedPoint::from_bytes(&sec1_bytes)
-                                        .map_err(|_| Error::Data(None))?;
-                                    let public_key =
-                                        p256::PublicKey::from_encoded_point(&encoded_point)
-                                            .into_option()
-                                            .ok_or(Error::Data(None))?;
-                                    Handle::P256PublicKey(public_key)
-                                },
-                                NAMED_CURVE_P384 => {
-                                    let mut sec1_bytes = vec![4u8];
-                                    sec1_bytes.extend_from_slice(&x);
-                                    sec1_bytes.extend_from_slice(&y);
-                                    let encoded_point = EncodedPoint::from_bytes(&sec1_bytes)
-                                        .map_err(|_| Error::Data(None))?;
-                                    let public_key =
-                                        p384::PublicKey::from_encoded_point(&encoded_point)
-                                            .into_option()
-                                            .ok_or(Error::Data(None))?;
-                                    Handle::P384PublicKey(public_key)
-                                },
-                                NAMED_CURVE_P521 => {
-                                    let mut sec1_bytes = vec![4u8];
-                                    sec1_bytes.extend_from_slice(&x);
-                                    sec1_bytes.extend_from_slice(&y);
-                                    let encoded_point = EncodedPoint::from_bytes(&sec1_bytes)
-                                        .map_err(|_| Error::Data(None))?;
-                                    let public_key =
-                                        p521::PublicKey::from_encoded_point(&encoded_point)
-                                            .into_option()
-                                            .ok_or(Error::Data(None))?;
-                                    Handle::P521PublicKey(public_key)
-                                },
-                                _ => unreachable!(),
-                            };
+                        // Step 2.9.4.2. Let key be a new CryptoKey object that represents the
+                        // Elliptic Curve public key identified by interpreting jwk according to
+                        // Section 6.2.1 of JSON Web Algorithms [JWA].
+                        // NOTE: CryptoKey is created in Step 2.11 - 2.14.
+                        let handle = match named_curve.as_str() {
+                            NAMED_CURVE_P256 => {
+                                let mut sec1_bytes = vec![4u8];
+                                sec1_bytes.extend_from_slice(&x);
+                                sec1_bytes.extend_from_slice(&y);
+                                let encoded_point = EncodedPoint::from_bytes(&sec1_bytes)
+                                    .map_err(|_| Error::Data(None))?;
+                                let public_key =
+                                    p256::PublicKey::from_encoded_point(&encoded_point)
+                                        .into_option()
+                                        .ok_or(Error::Data(None))?;
+                                Handle::P256PublicKey(public_key)
+                            },
+                            NAMED_CURVE_P384 => {
+                                let mut sec1_bytes = vec![4u8];
+                                sec1_bytes.extend_from_slice(&x);
+                                sec1_bytes.extend_from_slice(&y);
+                                let encoded_point = EncodedPoint::from_bytes(&sec1_bytes)
+                                    .map_err(|_| Error::Data(None))?;
+                                let public_key =
+                                    p384::PublicKey::from_encoded_point(&encoded_point)
+                                        .into_option()
+                                        .ok_or(Error::Data(None))?;
+                                Handle::P384PublicKey(public_key)
+                            },
+                            NAMED_CURVE_P521 => {
+                                let mut sec1_bytes = vec![4u8];
+                                sec1_bytes.extend_from_slice(&x);
+                                sec1_bytes.extend_from_slice(&y);
+                                let encoded_point = EncodedPoint::from_bytes(&sec1_bytes)
+                                    .map_err(|_| Error::Data(None))?;
+                                let public_key =
+                                    p521::PublicKey::from_encoded_point(&encoded_point)
+                                        .into_option()
+                                        .ok_or(Error::Data(None))?;
+                                Handle::P521PublicKey(public_key)
+                            },
+                            _ => unreachable!(),
+                        };
 
-                            // Step 2.9.3. Set the [[type]] internal slot of Key to "public".
-                            let key_type = KeyType::Public;
+                        // Step 2.9.4.3. Set the [[type]] internal slot of Key to "public".
+                        // NOTE: CryptoKey is created in Step 2.11 - 2.14.
+                        let key_type = KeyType::Public;
 
-                            (handle, key_type)
-                        },
+                        (handle, key_type)
                     }
                 }
                 // Otherwise

--- a/components/script/dom/subtlecrypto/hmac_operation.rs
+++ b/components/script/dom/subtlecrypto/hmac_operation.rs
@@ -17,7 +17,7 @@ use crate::dom::cryptokey::{CryptoKey, Handle};
 use crate::dom::globalscope::GlobalScope;
 use crate::dom::subtlecrypto::{
     ALG_HMAC, ALG_SHA1, ALG_SHA256, ALG_SHA384, ALG_SHA512, ExportedKey, JsonWebKeyExt,
-    KeyAlgorithmAndDerivatives, SubtleHmacImportParams, SubtleHmacKeyAlgorithm,
+    JwkStringField, KeyAlgorithmAndDerivatives, SubtleHmacImportParams, SubtleHmacKeyAlgorithm,
     SubtleHmacKeyGenParams, SubtleKeyAlgorithm,
 };
 use crate::script_runtime::CanGc;
@@ -199,8 +199,7 @@ pub(crate) fn import_key(
             // NOTE: Done by Step 2.4 and 2.6.
 
             // Step 2.4. Let data be the byte sequence obtained by decoding the k field of jwk.
-            data = Base64UrlUnpadded::decode_vec(&jwk.k.as_ref().ok_or(Error::Data(None))?.str())
-                .map_err(|_| Error::Data(None))?;
+            data = jwk.decode_required_string_field(JwkStringField::K)?;
 
             // Step 2.5. Set the hash to equal the hash member of normalizedAlgorithm.
             hash = normalized_algorithm.hash.as_ref();

--- a/components/script/dom/subtlecrypto/rsa_oaep_operation.rs
+++ b/components/script/dom/subtlecrypto/rsa_oaep_operation.rs
@@ -2,7 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-use base64ct::{Base64UrlUnpadded, Encoding};
 use pkcs8::der::asn1::BitString;
 use pkcs8::der::{AnyRef, Decode};
 use pkcs8::rand_core::OsRng;
@@ -27,7 +26,7 @@ use crate::dom::globalscope::GlobalScope;
 use crate::dom::subtlecrypto::rsa_common::{self, RsaAlgorithm};
 use crate::dom::subtlecrypto::{
     ALG_RSA_OAEP, ALG_SHA1, ALG_SHA256, ALG_SHA384, ALG_SHA512, ExportedKey, JsonWebKeyExt,
-    KeyAlgorithmAndDerivatives, Operation, SubtleRsaHashedImportParams,
+    JwkStringField, KeyAlgorithmAndDerivatives, Operation, SubtleRsaHashedImportParams,
     SubtleRsaHashedKeyAlgorithm, SubtleRsaHashedKeyGenParams, SubtleRsaOaepParams,
     normalize_algorithm,
 };
@@ -389,7 +388,7 @@ pub(crate) fn import_key(
             //     Perform any key import steps defined by other applicable specifications, passing
             //     format, jwk and obtaining hash.
             //     If an error occurred or there are no applicable specifications, throw a DataError.
-            let hash = match jwk.alg {
+            let hash = match &jwk.alg {
                 None => None,
                 Some(alg) => match &*alg.str() {
                     "RSA-OAEP" => Some(ALG_SHA1),
@@ -402,7 +401,7 @@ pub(crate) fn import_key(
 
             // Step 2.9. If hash is not undefined:
             if let Some(hash) = hash {
-                // Step 2.8.1. Let normalizedHash be the result of normalize an algorithm with alg
+                // Step 2.9.1. Let normalizedHash be the result of normalize an algorithm with alg
                 // set to hash and op set to digest.
                 let normalized_hash = normalize_algorithm(
                     cx,
@@ -411,7 +410,7 @@ pub(crate) fn import_key(
                     can_gc,
                 )?;
 
-                // Step 2.8.2. If normalizedHash is not equal to the hash member of
+                // Step 2.9.2. If normalizedHash is not equal to the hash member of
                 // normalizedAlgorithm, throw a DataError.
                 if normalized_hash.name() != normalized_algorithm.hash.name() {
                     return Err(Error::Data(Some(
@@ -422,164 +421,79 @@ pub(crate) fn import_key(
             }
 
             // Step 2.10.
-            match jwk.d {
-                // If the d field of jwk is present:
-                Some(d) => {
-                    // Step 2.10.1. If jwk does not meet the requirements of Section 6.3.2 of JSON
-                    // Web Algorithms [JWA], then throw a DataError.
-                    let n = Base64UrlUnpadded::decode_vec(
-                        &jwk.n
-                            .ok_or(Error::Data(Some(
-                                "The n field does not exist in jwk".to_string(),
-                            )))?
-                            .str(),
-                    )
-                    .map_err(|_| Error::Data(Some("Fail to decode n field of jwk".to_string())))?;
-                    let e = Base64UrlUnpadded::decode_vec(
-                        &jwk.e
-                            .ok_or(Error::Data(Some(
-                                "The e field does not exist in jwk".to_string(),
-                            )))?
-                            .str(),
-                    )
-                    .map_err(|_| Error::Data(Some("Fail to decode e field of jwk".to_string())))?;
-                    let d = Base64UrlUnpadded::decode_vec(&d.str()).map_err(|_| {
-                        Error::Data(Some("Fail to decode d field of jwk".to_string()))
-                    })?;
-                    let p = jwk
-                        .p
-                        .map(|p| Base64UrlUnpadded::decode_vec(&p.str()))
-                        .transpose()
-                        .map_err(|_| {
-                            Error::Data(Some("Fail to decode p field of jwk".to_string()))
-                        })?;
-                    let q = jwk
-                        .q
-                        .map(|q| Base64UrlUnpadded::decode_vec(&q.str()))
-                        .transpose()
-                        .map_err(|_| {
-                            Error::Data(Some("Fail to decode q field of jwk".to_string()))
-                        })?;
-                    let dp = jwk
-                        .dp
-                        .map(|dp| Base64UrlUnpadded::decode_vec(&dp.str()))
-                        .transpose()
-                        .map_err(|_| {
-                            Error::Data(Some("Fail to decode dp field of jwk".to_string()))
-                        })?;
-                    let dq = jwk
-                        .dq
-                        .map(|dq| Base64UrlUnpadded::decode_vec(&dq.str()))
-                        .transpose()
-                        .map_err(|_| {
-                            Error::Data(Some("Fail to decode dq field of jwk".to_string()))
-                        })?;
-                    let qi = jwk
-                        .qi
-                        .map(|qi| Base64UrlUnpadded::decode_vec(&qi.str()))
-                        .transpose()
-                        .map_err(|_| {
-                            Error::Data(Some("Fail to decode qi field of jwk".to_string()))
-                        })?;
-                    let mut primes = match (p, q, dp, dq, qi) {
-                        (Some(p), Some(q), Some(_dp), Some(_dq), Some(_qi)) => vec![p, q],
-                        (None, None, None, None, None) => Vec::new(),
-                        _ => return Err(Error::Data(Some(
-                            "The p, q, dp, dq, qi fields of jwk must be either all-present or all-absent"
-                                .to_string()
-                        ))),
-                    };
-                    if let Some(oth) = jwk.oth {
-                        if primes.is_empty() {
-                            return Err(Error::Data(Some(
-                                "The oth field exists in jwk but one of p, q, dp, dq, qi is missing".to_string()
-                            )));
-                        }
-                        for other_prime in oth {
-                            let r = Base64UrlUnpadded::decode_vec(
-                                &other_prime
-                                    .r
-                                    .ok_or(Error::Data(Some(
-                                        "The e field does not exist in oth field of jwk"
-                                            .to_string(),
-                                    )))?
-                                    .str(),
-                            )
-                            .map_err(|_| {
-                                Error::Data(Some(
-                                    "Fail to decode r field of oth field of jwk".to_string(),
-                                ))
-                            })?;
-                            primes.push(r);
-                        }
-                    }
+            // If the d field of jwk is present:
+            if jwk.d.is_some() {
+                // Step 2.10.1. If jwk does not meet the requirements of Section 6.3.2 of JSON Web
+                // Algorithms [JWA], then throw a DataError.
+                let n = jwk.decode_required_string_field(JwkStringField::N)?;
+                let e = jwk.decode_required_string_field(JwkStringField::E)?;
+                let d = jwk.decode_required_string_field(JwkStringField::D)?;
+                let p = jwk.decode_optional_string_field(JwkStringField::P)?;
+                let q = jwk.decode_optional_string_field(JwkStringField::Q)?;
+                let dp = jwk.decode_optional_string_field(JwkStringField::DP)?;
+                let dq = jwk.decode_optional_string_field(JwkStringField::DQ)?;
+                let qi = jwk.decode_optional_string_field(JwkStringField::QI)?;
+                let mut primes = match (p, q, dp, dq, qi) {
+                    (Some(p), Some(q), Some(_dp), Some(_dq), Some(_qi)) => vec![p, q],
+                    (None, None, None, None, None) => Vec::new(),
+                    _ => return Err(Error::Data(Some(
+                        "The p, q, dp, dq, qi fields of jwk must be either all-present or all-absent"
+                            .to_string()
+                    ))),
+                };
+                jwk.decode_primes_from_oth_field(&mut primes)?;
 
-                    // Step 2.10.2. Let privateKey represents the RSA private key identified by
-                    // interpreting jwk according to Section 6.3.2 of JSON Web Algorithms [JWA].
-                    // Step 2.10.3. If privateKey is not a valid RSA private key according to
-                    // [RFC3447], then throw a DataError.
-                    let private_key = RsaPrivateKey::from_components(
-                        BigUint::from_bytes_be(&n),
-                        BigUint::from_bytes_be(&e),
-                        BigUint::from_bytes_be(&d),
-                        primes
-                            .into_iter()
-                            .map(|prime| BigUint::from_bytes_be(&prime))
-                            .collect(),
-                    )
-                    .map_err(|_| {
-                        Error::Data(Some(
-                            "Fail to construct RSA private key from values in jwk".to_string(),
-                        ))
-                    })?;
+                // Step 2.10.2. Let privateKey represents the RSA private key identified by
+                // interpreting jwk according to Section 6.3.2 of JSON Web Algorithms [JWA].
+                // Step 2.10.3. If privateKey is not a valid RSA private key according to
+                // [RFC3447], then throw a DataError.
+                let private_key = RsaPrivateKey::from_components(
+                    BigUint::from_bytes_be(&n),
+                    BigUint::from_bytes_be(&e),
+                    BigUint::from_bytes_be(&d),
+                    primes
+                        .into_iter()
+                        .map(|prime| BigUint::from_bytes_be(&prime))
+                        .collect(),
+                )
+                .map_err(|_| {
+                    Error::Data(Some(
+                        "Failed to construct RSA private key from values in jwk".to_string(),
+                    ))
+                })?;
 
-                    // Step 2.10.4. Let key be a new CryptoKey object that represents privateKey.
-                    // Step 2.10.5. Set the [[type]] internal slot of key to "private"
-                    // NOTE: Done in Step 3-8.
-                    let key_handle = Handle::RsaPrivateKey(private_key);
-                    let key_type = KeyType::Private;
-                    (key_handle, key_type)
-                },
-                // Otherwise:
-                None => {
-                    // Step 2.10.1. If jwk does not meet the requirements of Section 6.3.1 of JSON
-                    // Web Algorithms [JWA], then throw a DataError.
-                    let n = Base64UrlUnpadded::decode_vec(
-                        &jwk.n
-                            .ok_or(Error::Data(Some(
-                                "The n field does not exist in jwk".to_string(),
-                            )))?
-                            .str(),
-                    )
-                    .map_err(|_| Error::Data(Some("Fail to decode n field of jwk".to_string())))?;
-                    let e = Base64UrlUnpadded::decode_vec(
-                        &jwk.e
-                            .ok_or(Error::Data(Some(
-                                "The e field does not exist in jwk".to_string(),
-                            )))?
-                            .str(),
-                    )
-                    .map_err(|_| Error::Data(Some("Fail to decode e field of jwk".to_string())))?;
+                // Step 2.10.4. Let key be a new CryptoKey object that represents privateKey.
+                // Step 2.10.5. Set the [[type]] internal slot of key to "private"
+                // NOTE: Done in Step 3-8.
+                let key_handle = Handle::RsaPrivateKey(private_key);
+                let key_type = KeyType::Private;
+                (key_handle, key_type)
+            }
+            // Otherwise:
+            else {
+                // Step 2.10.1. If jwk does not meet the requirements of Section 6.3.1 of JSON Web
+                // Algorithms [JWA], then throw a DataError.
+                let n = jwk.decode_required_string_field(JwkStringField::N)?;
+                let e = jwk.decode_required_string_field(JwkStringField::E)?;
 
-                    // Step 2.10.2. Let publicKey represent the RSA public key identified by
-                    // interpreting jwk according to Section 6.3.1 of JSON Web Algorithms [JWA].
-                    // Step 2.10.3. If publicKey can be determined to not be a valid RSA public key
-                    // according to [RFC3447], then throw a DataError.
-                    let public_key =
-                        RsaPublicKey::new(BigUint::from_bytes_be(&n), BigUint::from_bytes_be(&e))
-                            .map_err(|_| {
+                // Step 2.10.2. Let publicKey represent the RSA public key identified by
+                // interpreting jwk according to Section 6.3.1 of JSON Web Algorithms [JWA].
+                // Step 2.10.3. If publicKey can be determined to not be a valid RSA public key
+                // according to [RFC3447], then throw a DataError.
+                let public_key =
+                    RsaPublicKey::new(BigUint::from_bytes_be(&n), BigUint::from_bytes_be(&e))
+                        .map_err(|_| {
                             Error::Data(Some(
-                                "Fail to construct RSA public key from values in jwk".to_string(),
+                                "Failed to construct RSA public key from values in jwk".to_string(),
                             ))
                         })?;
 
-                    // Step 2.10.4. Let key be a new CryptoKey representing publicKey.
-                    // Step 2.10.5. Set the [[type]] internal slot of key to "public"
-                    // NOTE: Done in Step 3-8.
-                    let key_handle = Handle::RsaPublicKey(public_key);
-                    let key_type = KeyType::Public;
-                    (key_handle, key_type)
-                },
+                // Step 2.10.4. Let key be a new CryptoKey representing publicKey.
+                // Step 2.10.5. Set the [[type]] internal slot of key to "public"
+                // NOTE: Done in Step 3-8.
+                let key_handle = Handle::RsaPublicKey(public_key);
+                let key_type = KeyType::Public;
+                (key_handle, key_type)
             }
         },
         // Otherwise:

--- a/components/script/dom/subtlecrypto/rsa_pss_operation.rs
+++ b/components/script/dom/subtlecrypto/rsa_pss_operation.rs
@@ -2,7 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-use base64ct::{Base64UrlUnpadded, Encoding};
 use pkcs8::der::asn1::BitString;
 use pkcs8::der::{AnyRef, Decode};
 use pkcs8::rand_core::OsRng;
@@ -29,7 +28,7 @@ use crate::dom::globalscope::GlobalScope;
 use crate::dom::subtlecrypto::rsa_common::{self, RsaAlgorithm};
 use crate::dom::subtlecrypto::{
     ALG_RSA_PSS, ALG_SHA1, ALG_SHA256, ALG_SHA384, ALG_SHA512, ExportedKey, JsonWebKeyExt,
-    KeyAlgorithmAndDerivatives, Operation, SubtleRsaHashedImportParams,
+    JwkStringField, KeyAlgorithmAndDerivatives, Operation, SubtleRsaHashedImportParams,
     SubtleRsaHashedKeyAlgorithm, SubtleRsaHashedKeyGenParams, SubtleRsaPssParams,
     normalize_algorithm,
 };
@@ -405,7 +404,7 @@ pub(crate) fn import_key(
             //     Perform any key import steps defined by other applicable specifications, passing
             //     format, jwk and obtaining hash.
             //     If an error occurred or there are no applicable specifications, throw a DataError.
-            let hash = match jwk.alg {
+            let hash = match &jwk.alg {
                 None => None,
                 Some(alg) => match &*alg.str() {
                     "PS1" => Some(ALG_SHA1),
@@ -438,164 +437,79 @@ pub(crate) fn import_key(
             }
 
             // Step 2.9.
-            match jwk.d {
-                // If the d field of jwk is present:
-                Some(d) => {
-                    // Step 2.9.1. If jwk does not meet the requirements of Section 6.3.2 of JSON
-                    // Web Algorithms [JWA], then throw a DataError.
-                    let n = Base64UrlUnpadded::decode_vec(
-                        &jwk.n
-                            .ok_or(Error::Data(Some(
-                                "The n field does not exist in jwk".to_string(),
-                            )))?
-                            .str(),
-                    )
-                    .map_err(|_| Error::Data(Some("Fail to decode n field of jwk".to_string())))?;
-                    let e = Base64UrlUnpadded::decode_vec(
-                        &jwk.e
-                            .ok_or(Error::Data(Some(
-                                "The e field does not exist in jwk".to_string(),
-                            )))?
-                            .str(),
-                    )
-                    .map_err(|_| Error::Data(Some("Fail to decode e field of jwk".to_string())))?;
-                    let d = Base64UrlUnpadded::decode_vec(&d.str()).map_err(|_| {
-                        Error::Data(Some("Fail to decode d field of jwk".to_string()))
-                    })?;
-                    let p = jwk
-                        .p
-                        .map(|p| Base64UrlUnpadded::decode_vec(&p.str()))
-                        .transpose()
-                        .map_err(|_| {
-                            Error::Data(Some("Fail to decode p field of jwk".to_string()))
-                        })?;
-                    let q = jwk
-                        .q
-                        .map(|q| Base64UrlUnpadded::decode_vec(&q.str()))
-                        .transpose()
-                        .map_err(|_| {
-                            Error::Data(Some("Fail to decode q field of jwk".to_string()))
-                        })?;
-                    let dp = jwk
-                        .dp
-                        .map(|dp| Base64UrlUnpadded::decode_vec(&dp.str()))
-                        .transpose()
-                        .map_err(|_| {
-                            Error::Data(Some("Fail to decode dp field of jwk".to_string()))
-                        })?;
-                    let dq = jwk
-                        .dq
-                        .map(|dq| Base64UrlUnpadded::decode_vec(&dq.str()))
-                        .transpose()
-                        .map_err(|_| {
-                            Error::Data(Some("Fail to decode dq field of jwk".to_string()))
-                        })?;
-                    let qi = jwk
-                        .qi
-                        .map(|qi| Base64UrlUnpadded::decode_vec(&qi.str()))
-                        .transpose()
-                        .map_err(|_| {
-                            Error::Data(Some("Fail to decode qi field of jwk".to_string()))
-                        })?;
-                    let mut primes = match (p, q, dp, dq, qi) {
-                        (Some(p), Some(q), Some(_dp), Some(_dq), Some(_qi)) => vec![p, q],
-                        (None, None, None, None, None) => Vec::new(),
-                        _ => return Err(Error::Data(Some(
-                            "The p, q, dp, dq, qi fields of jwk must be either all-present or all-absent"
-                                .to_string()
-                        ))),
-                    };
-                    if let Some(oth) = jwk.oth {
-                        if primes.is_empty() {
-                            return Err(Error::Data(Some(
-                                "The oth field exists in jwk but one of p, q, dp, dq, qi is missing".to_string()
-                            )));
-                        }
-                        for other_prime in oth {
-                            let r = Base64UrlUnpadded::decode_vec(
-                                &other_prime
-                                    .r
-                                    .ok_or(Error::Data(Some(
-                                        "The e field does not exist in oth field of jwk"
-                                            .to_string(),
-                                    )))?
-                                    .str(),
-                            )
-                            .map_err(|_| {
-                                Error::Data(Some(
-                                    "Fail to decode r field of oth field of jwk".to_string(),
-                                ))
-                            })?;
-                            primes.push(r);
-                        }
-                    }
+            // If the d field of jwk is present:
+            if jwk.d.is_some() {
+                // Step 2.9.1. If jwk does not meet the requirements of Section 6.3.2 of JSON Web
+                // Algorithms [JWA], then throw a DataError.
+                let n = jwk.decode_required_string_field(JwkStringField::N)?;
+                let e = jwk.decode_required_string_field(JwkStringField::E)?;
+                let d = jwk.decode_required_string_field(JwkStringField::D)?;
+                let p = jwk.decode_optional_string_field(JwkStringField::P)?;
+                let q = jwk.decode_optional_string_field(JwkStringField::Q)?;
+                let dp = jwk.decode_optional_string_field(JwkStringField::DP)?;
+                let dq = jwk.decode_optional_string_field(JwkStringField::DQ)?;
+                let qi = jwk.decode_optional_string_field(JwkStringField::QI)?;
+                let mut primes = match (p, q, dp, dq, qi) {
+                    (Some(p), Some(q), Some(_dp), Some(_dq), Some(_qi)) => vec![p, q],
+                    (None, None, None, None, None) => Vec::new(),
+                    _ => return Err(Error::Data(Some(
+                        "The p, q, dp, dq, qi fields of jwk must be either all-present or all-absent"
+                            .to_string()
+                    ))),
+                };
+                jwk.decode_primes_from_oth_field(&mut primes)?;
 
-                    // Step 2.9.2. Let privateKey represents the RSA private key identified by
-                    // interpreting jwk according to Section 6.3.2 of JSON Web Algorithms [JWA].
-                    // Step 2.9.3. If privateKey is not a valid RSA private key according to
-                    // [RFC3447], then throw a DataError.
-                    let private_key = RsaPrivateKey::from_components(
-                        BigUint::from_bytes_be(&n),
-                        BigUint::from_bytes_be(&e),
-                        BigUint::from_bytes_be(&d),
-                        primes
-                            .into_iter()
-                            .map(|prime| BigUint::from_bytes_be(&prime))
-                            .collect(),
-                    )
-                    .map_err(|_| {
-                        Error::Data(Some(
-                            "Fail to construct RSA private key from values in jwk".to_string(),
-                        ))
-                    })?;
+                // Step 2.9.2. Let privateKey represents the RSA private key identified by
+                // interpreting jwk according to Section 6.3.2 of JSON Web Algorithms [JWA].
+                // Step 2.9.3. If privateKey is not a valid RSA private key according to [RFC3447],
+                // then throw a DataError.
+                let private_key = RsaPrivateKey::from_components(
+                    BigUint::from_bytes_be(&n),
+                    BigUint::from_bytes_be(&e),
+                    BigUint::from_bytes_be(&d),
+                    primes
+                        .into_iter()
+                        .map(|prime| BigUint::from_bytes_be(&prime))
+                        .collect(),
+                )
+                .map_err(|_| {
+                    Error::Data(Some(
+                        "Failed to construct RSA private key from values in jwk".to_string(),
+                    ))
+                })?;
 
-                    // Step 2.9.4. Let key be a new CryptoKey object that represents privateKey.
-                    // Step 2.9.5. Set the [[type]] internal slot of key to "private"
-                    // NOTE: Done in Step 3-8.
-                    let key_handle = Handle::RsaPrivateKey(private_key);
-                    let key_type = KeyType::Private;
-                    (key_handle, key_type)
-                },
-                // Otherwise:
-                None => {
-                    // Step 2.9.1. If jwk does not meet the requirements of Section 6.3.1 of JSON
-                    // Web Algorithms [JWA], then throw a DataError.
-                    let n = Base64UrlUnpadded::decode_vec(
-                        &jwk.n
-                            .ok_or(Error::Data(Some(
-                                "The n field does not exist in jwk".to_string(),
-                            )))?
-                            .str(),
-                    )
-                    .map_err(|_| Error::Data(Some("Fail to decode n field of jwk".to_string())))?;
-                    let e = Base64UrlUnpadded::decode_vec(
-                        &jwk.e
-                            .ok_or(Error::Data(Some(
-                                "The e field does not exist in jwk".to_string(),
-                            )))?
-                            .str(),
-                    )
-                    .map_err(|_| Error::Data(Some("Fail to decode e field of jwk".to_string())))?;
+                // Step 2.9.4. Let key be a new CryptoKey object that represents privateKey.
+                // Step 2.9.5. Set the [[type]] internal slot of key to "private"
+                // NOTE: Done in Step 3-8.
+                let key_handle = Handle::RsaPrivateKey(private_key);
+                let key_type = KeyType::Private;
+                (key_handle, key_type)
+            }
+            // Otherwise:
+            else {
+                // Step 2.9.1. If jwk does not meet the requirements of Section 6.3.1 of JSON Web
+                // Algorithms [JWA], then throw a DataError.
+                let n = jwk.decode_required_string_field(JwkStringField::N)?;
+                let e = jwk.decode_required_string_field(JwkStringField::E)?;
 
-                    // Step 2.9.2. Let publicKey represent the RSA public key identified by
-                    // interpreting jwk according to Section 6.3.1 of JSON Web Algorithms [JWA].
-                    // Step 2.9.3. If publicKey can be determined to not be a valid RSA public key
-                    // according to [RFC3447], then throw a DataError.
-                    let public_key =
-                        RsaPublicKey::new(BigUint::from_bytes_be(&n), BigUint::from_bytes_be(&e))
-                            .map_err(|_| {
+                // Step 2.9.2. Let publicKey represent the RSA public key identified by
+                // interpreting jwk according to Section 6.3.1 of JSON Web Algorithms [JWA].
+                // Step 2.9.3. If publicKey can be determined to not be a valid RSA public key
+                // according to [RFC3447], then throw a DataError.
+                let public_key =
+                    RsaPublicKey::new(BigUint::from_bytes_be(&n), BigUint::from_bytes_be(&e))
+                        .map_err(|_| {
                             Error::Data(Some(
-                                "Fail to construct RSA public key from values in jwk".to_string(),
+                                "Failed to construct RSA public key from values in jwk".to_string(),
                             ))
                         })?;
 
-                    // Step 2.9.4. Let key be a new CryptoKey representing publicKey.
-                    // Step 2.9.5. Set the [[type]] internal slot of key to "public"
-                    // NOTE: Done in Step 3-8.
-                    let key_handle = Handle::RsaPublicKey(public_key);
-                    let key_type = KeyType::Public;
-                    (key_handle, key_type)
-                },
+                // Step 2.9.4. Let key be a new CryptoKey representing publicKey.
+                // Step 2.9.5. Set the [[type]] internal slot of key to "public"
+                // NOTE: Done in Step 3-8.
+                let key_handle = Handle::RsaPublicKey(public_key);
+                let key_type = KeyType::Public;
+                (key_handle, key_type)
             }
         },
         // Otherwise:

--- a/components/script/dom/subtlecrypto/rsassa_pkcs1_v1_5_operation.rs
+++ b/components/script/dom/subtlecrypto/rsassa_pkcs1_v1_5_operation.rs
@@ -2,7 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-use base64ct::{Base64UrlUnpadded, Encoding};
 use pkcs8::der::asn1::BitString;
 use pkcs8::der::{AnyRef, Decode};
 use pkcs8::{PrivateKeyInfo, SubjectPublicKeyInfo};
@@ -28,8 +27,9 @@ use crate::dom::globalscope::GlobalScope;
 use crate::dom::subtlecrypto::rsa_common::{self, RsaAlgorithm};
 use crate::dom::subtlecrypto::{
     ALG_RSASSA_PKCS1_V1_5, ALG_SHA1, ALG_SHA256, ALG_SHA384, ALG_SHA512, ExportedKey,
-    JsonWebKeyExt, KeyAlgorithmAndDerivatives, Operation, SubtleRsaHashedImportParams,
-    SubtleRsaHashedKeyAlgorithm, SubtleRsaHashedKeyGenParams, normalize_algorithm,
+    JsonWebKeyExt, JwkStringField, KeyAlgorithmAndDerivatives, Operation,
+    SubtleRsaHashedImportParams, SubtleRsaHashedKeyAlgorithm, SubtleRsaHashedKeyGenParams,
+    normalize_algorithm,
 };
 use crate::script_runtime::CanGc;
 
@@ -368,7 +368,7 @@ pub(crate) fn import_key(
             //     Perform any key import steps defined by other applicable specifications, passing
             //     format, jwk and obtaining hash.
             //     If an error occurred or there are no applicable specifications, throw a DataError.
-            let hash = match jwk.alg {
+            let hash = match &jwk.alg {
                 None => None,
                 Some(alg) => match &*alg.str() {
                     "RS1" => Some(ALG_SHA1),
@@ -401,164 +401,79 @@ pub(crate) fn import_key(
             }
 
             // Step 2.10.
-            match jwk.d {
-                // If the d field of jwk is present:
-                Some(d) => {
-                    // Step 2.10.1. If jwk does not meet the requirements of Section 6.3.2 of JSON
-                    // Web Algorithms [JWA], then throw a DataError.
-                    let n = Base64UrlUnpadded::decode_vec(
-                        &jwk.n
-                            .ok_or(Error::Data(Some(
-                                "The n field does not exist in jwk".to_string(),
-                            )))?
-                            .str(),
-                    )
-                    .map_err(|_| Error::Data(Some("Fail to decode n field of jwk".to_string())))?;
-                    let e = Base64UrlUnpadded::decode_vec(
-                        &jwk.e
-                            .ok_or(Error::Data(Some(
-                                "The e field does not exist in jwk".to_string(),
-                            )))?
-                            .str(),
-                    )
-                    .map_err(|_| Error::Data(Some("Fail to decode e field of jwk".to_string())))?;
-                    let d = Base64UrlUnpadded::decode_vec(&d.str()).map_err(|_| {
-                        Error::Data(Some("Fail to decode d field of jwk".to_string()))
-                    })?;
-                    let p = jwk
-                        .p
-                        .map(|p| Base64UrlUnpadded::decode_vec(&p.str()))
-                        .transpose()
-                        .map_err(|_| {
-                            Error::Data(Some("Fail to decode p field of jwk".to_string()))
-                        })?;
-                    let q = jwk
-                        .q
-                        .map(|q| Base64UrlUnpadded::decode_vec(&q.str()))
-                        .transpose()
-                        .map_err(|_| {
-                            Error::Data(Some("Fail to decode q field of jwk".to_string()))
-                        })?;
-                    let dp = jwk
-                        .dp
-                        .map(|dp| Base64UrlUnpadded::decode_vec(&dp.str()))
-                        .transpose()
-                        .map_err(|_| {
-                            Error::Data(Some("Fail to decode dp field of jwk".to_string()))
-                        })?;
-                    let dq = jwk
-                        .dq
-                        .map(|dq| Base64UrlUnpadded::decode_vec(&dq.str()))
-                        .transpose()
-                        .map_err(|_| {
-                            Error::Data(Some("Fail to decode dq field of jwk".to_string()))
-                        })?;
-                    let qi = jwk
-                        .qi
-                        .map(|qi| Base64UrlUnpadded::decode_vec(&qi.str()))
-                        .transpose()
-                        .map_err(|_| {
-                            Error::Data(Some("Fail to decode qi field of jwk".to_string()))
-                        })?;
-                    let mut primes = match (p, q, dp, dq, qi) {
-                        (Some(p), Some(q), Some(_dp), Some(_dq), Some(_qi)) => vec![p, q],
-                        (None, None, None, None, None) => Vec::new(),
-                        _ => return Err(Error::Data(Some(
-                            "The p, q, dp, dq, qi fields of jwk must be either all-present or all-absent"
-                                .to_string()
-                        ))),
-                    };
-                    if let Some(oth) = jwk.oth {
-                        if primes.is_empty() {
-                            return Err(Error::Data(Some(
-                                "The oth field exists in jwk but one of p, q, dp, dq, qi is missing".to_string()
-                            )));
-                        }
-                        for other_prime in oth {
-                            let r = Base64UrlUnpadded::decode_vec(
-                                &other_prime
-                                    .r
-                                    .ok_or(Error::Data(Some(
-                                        "The e field does not exist in oth field of jwk"
-                                            .to_string(),
-                                    )))?
-                                    .str(),
-                            )
-                            .map_err(|_| {
-                                Error::Data(Some(
-                                    "Fail to decode r field of oth field of jwk".to_string(),
-                                ))
-                            })?;
-                            primes.push(r);
-                        }
-                    }
+            // If the d field of jwk is present:
+            if jwk.d.is_some() {
+                // Step 2.10.1. If jwk does not meet the requirements of Section 6.3.2 of JSON Web
+                // Algorithms [JWA], then throw a DataError.
+                let n = jwk.decode_required_string_field(JwkStringField::N)?;
+                let e = jwk.decode_required_string_field(JwkStringField::E)?;
+                let d = jwk.decode_required_string_field(JwkStringField::D)?;
+                let p = jwk.decode_optional_string_field(JwkStringField::P)?;
+                let q = jwk.decode_optional_string_field(JwkStringField::Q)?;
+                let dp = jwk.decode_optional_string_field(JwkStringField::DP)?;
+                let dq = jwk.decode_optional_string_field(JwkStringField::DQ)?;
+                let qi = jwk.decode_optional_string_field(JwkStringField::QI)?;
+                let mut primes = match (p, q, dp, dq, qi) {
+                    (Some(p), Some(q), Some(_dp), Some(_dq), Some(_qi)) => vec![p, q],
+                    (None, None, None, None, None) => Vec::new(),
+                    _ => return Err(Error::Data(Some(
+                        "The p, q, dp, dq, qi fields of jwk must be either all-present or all-absent"
+                            .to_string()
+                    ))),
+                };
+                jwk.decode_primes_from_oth_field(&mut primes)?;
 
-                    // Step 2.10.2. Let privateKey represents the RSA private key identified by
-                    // interpreting jwk according to Section 6.3.2 of JSON Web Algorithms [JWA].
-                    // Step 2.10.3. If privateKey is not a valid RSA private key according to
-                    // [RFC3447], then throw a DataError.
-                    let private_key = RsaPrivateKey::from_components(
-                        BigUint::from_bytes_be(&n),
-                        BigUint::from_bytes_be(&e),
-                        BigUint::from_bytes_be(&d),
-                        primes
-                            .into_iter()
-                            .map(|prime| BigUint::from_bytes_be(&prime))
-                            .collect(),
-                    )
-                    .map_err(|_| {
-                        Error::Data(Some(
-                            "Fail to construct RSA private key from values in jwk".to_string(),
-                        ))
-                    })?;
+                // Step 2.10.2. Let privateKey represents the RSA private key identified by
+                // interpreting jwk according to Section 6.3.2 of JSON Web Algorithms [JWA].
+                // Step 2.10.3. If privateKey is not a valid RSA private key according to
+                // [RFC3447], then throw a DataError.
+                let private_key = RsaPrivateKey::from_components(
+                    BigUint::from_bytes_be(&n),
+                    BigUint::from_bytes_be(&e),
+                    BigUint::from_bytes_be(&d),
+                    primes
+                        .into_iter()
+                        .map(|prime| BigUint::from_bytes_be(&prime))
+                        .collect(),
+                )
+                .map_err(|_| {
+                    Error::Data(Some(
+                        "Failed to construct RSA private key from values in jwk".to_string(),
+                    ))
+                })?;
 
-                    // Step 2.10.4. Let key be a new CryptoKey object that represents privateKey.
-                    // Step 2.10.5. Set the [[type]] internal slot of key to "private"
-                    // NOTE: Done in Step 3-8.
-                    let key_handle = Handle::RsaPrivateKey(private_key);
-                    let key_type = KeyType::Private;
-                    (key_handle, key_type)
-                },
-                // Otherwise:
-                None => {
-                    // Step 2.10.1. If jwk does not meet the requirements of Section 6.3.1 of JSON
-                    // Web Algorithms [JWA], then throw a DataError.
-                    let n = Base64UrlUnpadded::decode_vec(
-                        &jwk.n
-                            .ok_or(Error::Data(Some(
-                                "The n field does not exist in jwk".to_string(),
-                            )))?
-                            .str(),
-                    )
-                    .map_err(|_| Error::Data(Some("Fail to decode n field of jwk".to_string())))?;
-                    let e = Base64UrlUnpadded::decode_vec(
-                        &jwk.e
-                            .ok_or(Error::Data(Some(
-                                "The e field does not exist in jwk".to_string(),
-                            )))?
-                            .str(),
-                    )
-                    .map_err(|_| Error::Data(Some("Fail to decode e field of jwk".to_string())))?;
+                // Step 2.10.4. Let key be a new CryptoKey object that represents privateKey.
+                // Step 2.10.5. Set the [[type]] internal slot of key to "private"
+                // NOTE: Done in Step 3-8.
+                let key_handle = Handle::RsaPrivateKey(private_key);
+                let key_type = KeyType::Private;
+                (key_handle, key_type)
+            }
+            // Otherwise:
+            else {
+                // Step 2.10.1. If jwk does not meet the requirements of Section 6.3.1 of JSON Web
+                // Algorithms [JWA], then throw a DataError.
+                let n = jwk.decode_required_string_field(JwkStringField::N)?;
+                let e = jwk.decode_required_string_field(JwkStringField::E)?;
 
-                    // Step 2.10.2. Let publicKey represent the RSA public key identified by
-                    // interpreting jwk according to Section 6.3.1 of JSON Web Algorithms [JWA].
-                    // Step 2.10.3. If publicKey can be determined to not be a valid RSA public key
-                    // according to [RFC3447], then throw a DataError.
-                    let public_key =
-                        RsaPublicKey::new(BigUint::from_bytes_be(&n), BigUint::from_bytes_be(&e))
-                            .map_err(|_| {
+                // Step 2.10.2. Let publicKey represent the RSA public key identified by
+                // interpreting jwk according to Section 6.3.1 of JSON Web Algorithms [JWA].
+                // Step 2.10.3. If publicKey can be determined to not be a valid RSA public key
+                // according to [RFC3447], then throw a DataError.
+                let public_key =
+                    RsaPublicKey::new(BigUint::from_bytes_be(&n), BigUint::from_bytes_be(&e))
+                        .map_err(|_| {
                             Error::Data(Some(
-                                "Fail to construct RSA public key from values in jwk".to_string(),
+                                "Failed to construct RSA public key from values in jwk".to_string(),
                             ))
                         })?;
 
-                    // Step 2.10.4. Let key be a new CryptoKey representing publicKey.
-                    // Step 2.10.5. Set the [[type]] internal slot of key to "public"
-                    // NOTE: Done in Step 3-8.
-                    let key_handle = Handle::RsaPublicKey(public_key);
-                    let key_type = KeyType::Public;
-                    (key_handle, key_type)
-                },
+                // Step 2.10.4. Let key be a new CryptoKey representing publicKey.
+                // Step 2.10.5. Set the [[type]] internal slot of key to "public"
+                // NOTE: Done in Step 3-8.
+                let key_handle = Handle::RsaPublicKey(public_key);
+                let key_type = KeyType::Public;
+                (key_handle, key_type)
             }
         },
         // Otherwise:


### PR DESCRIPTION
Add several helper functions to JsonWebKey to handle common base64url decoding tasks across multiple algorithms. Those helper functions include:

- `JsonWebKey::decode_optional_string_field`: decode optional field
- `JsonWebKey::decode_required_string_field`: decode required field
- `JsonWebKey::decode_primes_from_oth_field`: decode oth field to primes

These help simplify our code for importing keys in JsonWebKey format.

Testing: Refactoring. Existing tests suffice.