### PR TITLE
script: Reload the page when an incompatible encoding is detected during parsing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7853,6 +7853,7 @@ dependencies = [
  "deny_public_fields",
  "dom_struct",
  "domobject_derive",
+ "encoding_rs",
  "html5ever",
  "indexmap",
  "jstraceable_derive",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3019,16 +3019,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ab85b9b05e3978cc9a9cf8fea7f01b494e1a09ed3037e16ba39edc7a29eb61a"
 
 [[package]]
-name = "futf"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df420e2e84819663797d1ec6544b13c5be84629e7bb00dc960d6917db2987843"
-dependencies = [
- "mac",
- "new_debug_unreachable",
-]
-
-[[package]]
 name = "futures"
 version = "0.1.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3979,8 +3969,6 @@ dependencies = [
 [[package]]
 name = "html5ever"
 version = "0.36.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6452c4751a24e1b99c3260d505eaeee76a050573e61f30ac2c924ddc7236f01e"
 dependencies = [
  "log",
  "markup5ever",
@@ -5319,12 +5307,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "mac"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c41e0c4fef86961ac6d6f8a82609f55f31b05e4fce149ac5710e439df7619ba4"
-
-[[package]]
 name = "mach2"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5370,8 +5352,6 @@ dependencies = [
 [[package]]
 name = "markup5ever"
 version = "0.36.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c3294c4d74d0742910f8c7b466f44dda9eb2d5742c1e430138df290a1e8451c"
 dependencies = [
  "log",
  "tendril",
@@ -9196,12 +9176,9 @@ dependencies = [
 [[package]]
 name = "tendril"
 version = "0.4.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d24a120c5fc464a3458240ee02c299ebcb9d67b5249c8848b09d639dca8d7bb0"
 dependencies = [
  "encoding_rs",
- "futf",
- "mac",
+ "new_debug_unreachable",
  "utf-8",
 ]
 
@@ -10319,8 +10296,6 @@ dependencies = [
 [[package]]
 name = "web_atoms"
 version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "acd0c322f146d0f8aad130ce6c187953889359584497dac6561204c8e17bb43d"
 dependencies = [
  "phf",
  "phf_codegen",
@@ -11386,8 +11361,6 @@ checksum = "3ae8337f8a065cfc972643663ea4279e04e7256de865aa66fe25cec5fb912d3f"
 [[package]]
 name = "xml5ever"
 version = "0.36.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f57dd51b88a4b9f99f9b55b136abb86210629d61c48117ddb87f567e51e66be7"
 dependencies = [
  "log",
  "markup5ever",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3969,6 +3969,7 @@ dependencies = [
 [[package]]
 name = "html5ever"
 version = "0.36.1"
+source = "git+https://github.com/simonwuelker/html5ever?branch=encoding-hints#e6f2cf2b381577e69d89f88fd00e4fc7d44efe21"
 dependencies = [
  "log",
  "markup5ever",
@@ -5352,6 +5353,7 @@ dependencies = [
 [[package]]
 name = "markup5ever"
 version = "0.36.1"
+source = "git+https://github.com/simonwuelker/html5ever?branch=encoding-hints#e6f2cf2b381577e69d89f88fd00e4fc7d44efe21"
 dependencies = [
  "log",
  "tendril",
@@ -9176,6 +9178,7 @@ dependencies = [
 [[package]]
 name = "tendril"
 version = "0.4.3"
+source = "git+https://github.com/simonwuelker/html5ever?branch=encoding-hints#e6f2cf2b381577e69d89f88fd00e4fc7d44efe21"
 dependencies = [
  "encoding_rs",
  "new_debug_unreachable",
@@ -10296,6 +10299,7 @@ dependencies = [
 [[package]]
 name = "web_atoms"
 version = "0.2.0"
+source = "git+https://github.com/simonwuelker/html5ever?branch=encoding-hints#e6f2cf2b381577e69d89f88fd00e4fc7d44efe21"
 dependencies = [
  "phf",
  "phf_codegen",
@@ -11361,6 +11365,7 @@ checksum = "3ae8337f8a065cfc972643663ea4279e04e7256de865aa66fe25cec5fb912d3f"
 [[package]]
 name = "xml5ever"
 version = "0.36.1"
+source = "git+https://github.com/simonwuelker/html5ever?branch=encoding-hints#e6f2cf2b381577e69d89f88fd00e4fc7d44efe21"
 dependencies = [
  "log",
  "markup5ever",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -281,11 +281,16 @@ codegen-units = 1
 #
 # For html5ever:
 #
-html5ever = { path = "../html5ever/html5ever" }
-markup5ever = { path = "../html5ever/markup5ever" }
-web_atoms = { path = "../html5ever/web_atoms" }
-xml5ever = { path = "../html5ever/xml5ever" }
-tendril = { path = "../html5ever/tendril" }
+# html5ever = { path = "../html5ever/html5ever" }
+# markup5ever = { path = "../html5ever/markup5ever" }
+# web_atoms = { path = "../html5ever/web_atoms" }
+# xml5ever = { path = "../html5ever/xml5ever" }
+# tendril = { path = "../html5ever/tendril" }
+html5ever = { git = "https://github.com/simonwuelker/html5ever", branch="encoding-hints" }
+markup5ever = { git = "https://github.com/simonwuelker/html5ever", branch="encoding-hints" }
+web_atoms = { git = "https://github.com/simonwuelker/html5ever", branch="encoding-hints" }
+xml5ever = { git = "https://github.com/simonwuelker/html5ever", branch="encoding-hints" }
+tendril = { git = "https://github.com/simonwuelker/html5ever", branch="encoding-hints" }
 #
 # Or for Stylo:
 #

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -281,11 +281,11 @@ codegen-units = 1
 #
 # For html5ever:
 #
-# html5ever = { path = "../html5ever/html5ever" }
-# markup5ever = { path = "../html5ever/markup5ever" }
-# web_atoms = { path = "../html5ever/web_atoms" }
-# xml5ever = { path = "../html5ever/xml5ever" }
-# tendril = { path = "../html5ever/tendril" }
+html5ever = { path = "../html5ever/html5ever" }
+markup5ever = { path = "../html5ever/markup5ever" }
+web_atoms = { path = "../html5ever/web_atoms" }
+xml5ever = { path = "../html5ever/xml5ever" }
+tendril = { path = "../html5ever/tendril" }
 #
 # Or for Stylo:
 #

--- a/components/malloc_size_of/lib.rs
+++ b/components/malloc_size_of/lib.rs
@@ -1106,6 +1106,12 @@ impl<S: tendril::TendrilSink<tendril::fmt::UTF8, A>, A: tendril::Atomicity> Mall
     }
 }
 
+impl<F: tendril::Format> MallocSizeOf for tendril::SendTendril<F> {
+    fn size_of(&self, _: &mut MallocSizeOfOps) -> usize {
+        0
+    }
+}
+
 macro_rules! malloc_size_of_is_webrender_malloc_size_of(
     ($($ty:ty),+) => (
         $(

--- a/components/script/dom/domimplementation.rs
+++ b/components/script/dom/domimplementation.rs
@@ -184,6 +184,7 @@ impl DOMImplementationMethods<crate::DomTypeHolder> for DOMImplementation {
             self.document.has_trustworthy_ancestor_or_current_origin(),
             self.document.custom_element_reaction_stack(),
             self.document.creation_sandboxing_flag_set(),
+            None,
             can_gc,
         );
 

--- a/components/script/dom/domparser.rs
+++ b/components/script/dom/domparser.rs
@@ -19,7 +19,7 @@ use crate::dom::bindings::error::Fallible;
 use crate::dom::bindings::reflector::{Reflector, reflect_dom_object_with_proto};
 use crate::dom::bindings::root::{Dom, DomRoot};
 use crate::dom::document::{Document, DocumentSource, HasBrowsingContext, IsHTMLDocument};
-use crate::dom::servoparser::ServoParser;
+use crate::dom::servoparser::{EncodingInformation, ServoParser};
 use crate::dom::trustedhtml::TrustedHTML;
 use crate::dom::window::Window;
 use crate::script_runtime::CanGc;
@@ -106,6 +106,7 @@ impl DOMParserMethods<crate::DomTypeHolder> for DOMParser {
                     doc.has_trustworthy_ancestor_or_current_origin(),
                     doc.custom_element_reaction_stack(),
                     doc.creation_sandboxing_flag_set(),
+                    None,
                     can_gc,
                 );
                 // Step switch-1. Parse HTML from a string given document and compliantString.
@@ -113,8 +114,7 @@ impl DOMParserMethods<crate::DomTypeHolder> for DOMParser {
                     &document,
                     Some(compliant_string),
                     url,
-                    None,
-                    None,
+                    EncodingInformation::Irrelevant,
                     can_gc,
                 );
                 document
@@ -142,6 +142,7 @@ impl DOMParserMethods<crate::DomTypeHolder> for DOMParser {
                     doc.has_trustworthy_ancestor_or_current_origin(),
                     doc.custom_element_reaction_stack(),
                     doc.creation_sandboxing_flag_set(),
+                    None,
                     can_gc,
                 );
                 // Step switch-1. Create an XML parser parser, associated with document,
@@ -150,7 +151,7 @@ impl DOMParserMethods<crate::DomTypeHolder> for DOMParser {
                     &document,
                     Some(compliant_string),
                     url,
-                    None,
+                    EncodingInformation::Irrelevant,
                     can_gc,
                 );
                 document

--- a/components/script/dom/location.rs
+++ b/components/script/dom/location.rs
@@ -4,6 +4,7 @@
 
 use constellation_traits::{LoadData, LoadOrigin, NavigationHistoryBehavior};
 use dom_struct::dom_struct;
+use encoding_rs::Encoding;
 use net_traits::request::Referrer;
 use servo_url::{MutableOrigin, ServoUrl};
 
@@ -71,6 +72,7 @@ impl Location {
         url: ServoUrl,
         history_handling: NavigationHistoryBehavior,
         navigation_type: NavigationType,
+        encoding_override: Option<&'static Encoding>,
         can_gc: CanGc,
     ) {
         fn incumbent_window() -> DomRoot<Window> {
@@ -122,7 +124,7 @@ impl Location {
 
         // Initiate navigation
         // TODO: rethrow exceptions, set exceptions enabled flag.
-        let load_data = LoadData::new(
+        let mut load_data = LoadData::new(
             LoadOrigin::Script(load_origin),
             url,
             creator_pipeline_id,
@@ -133,6 +135,7 @@ impl Location {
             source_document.has_trustworthy_ancestor_origin(),
             source_document.creation_sandboxing_flag_set_considering_parent_iframe(),
         );
+        load_data.encoding_override = encoding_override;
         self.window
             .load_url(history_handling, reload_triggered, load_data, can_gc);
     }
@@ -238,6 +241,7 @@ impl Location {
                     copy_url,
                     NavigationHistoryBehavior::Push,
                     NavigationType::Normal,
+                    None,
                     can_gc,
                 );
             }
@@ -259,6 +263,7 @@ impl Location {
             url,
             NavigationHistoryBehavior::Replace,
             NavigationType::ReloadByConstellation,
+            None,
             can_gc,
         );
     }
@@ -295,6 +300,7 @@ impl LocationMethods<crate::DomTypeHolder> for Location {
             url,
             NavigationHistoryBehavior::Replace,
             NavigationType::ReloadByScript,
+            None,
             can_gc,
         );
         Ok(())
@@ -317,6 +323,7 @@ impl LocationMethods<crate::DomTypeHolder> for Location {
                 url,
                 NavigationHistoryBehavior::Replace,
                 NavigationType::Normal,
+                None,
                 can_gc,
             );
         }
@@ -429,6 +436,7 @@ impl LocationMethods<crate::DomTypeHolder> for Location {
                 url,
                 NavigationHistoryBehavior::Push,
                 NavigationType::Normal,
+                None,
                 can_gc,
             );
         }

--- a/components/script/dom/node.rs
+++ b/components/script/dom/node.rs
@@ -3017,6 +3017,7 @@ impl Node {
                     document.has_trustworthy_ancestor_or_current_origin(),
                     document.custom_element_reaction_stack(),
                     document.creation_sandboxing_flag_set(),
+                    None,
                     can_gc,
                 );
                 DomRoot::upcast::<Node>(document)

--- a/components/script/dom/servoparser/async_html.rs
+++ b/components/script/dom/servoparser/async_html.rs
@@ -158,15 +158,13 @@ enum ParseOperation {
 enum ToTokenizerMsg {
     // From HtmlTokenizer
     TokenizerResultDone {
-        #[ignore_malloc_size_of = "Defined in html5ever"]
         updated_input: VecDeque<SendTendril<UTF8>>,
     },
     TokenizerResultScript {
         script: ParseNode,
-        #[ignore_malloc_size_of = "Defined in html5ever"]
         updated_input: VecDeque<SendTendril<UTF8>>,
     },
-    EncodingIndicator(#[ignore_malloc_size_of = "Defined in html5ever"] SendTendril<UTF8>),
+    EncodingIndicator(SendTendril<UTF8>),
     End, // Sent to Tokenizer to signify HtmlTokenizer's end method has returned
 
     // From Sink
@@ -175,10 +173,7 @@ enum ToTokenizerMsg {
 
 #[derive(MallocSizeOf)]
 enum ToHtmlTokenizerMsg {
-    Feed {
-        #[ignore_malloc_size_of = "Defined in html5ever"]
-        input: VecDeque<SendTendril<UTF8>>,
-    },
+    Feed { input: VecDeque<SendTendril<UTF8>> },
     End,
     SetPlainTextState,
 }

--- a/components/script/dom/servoparser/html.rs
+++ b/components/script/dom/servoparser/html.rs
@@ -104,6 +104,9 @@ impl Tokenizer {
             TokenizerResult::Script(script) => {
                 TokenizerResult::Script(DomRoot::from_ref(script.downcast().unwrap()))
             },
+            TokenizerResult::EncodingIndicator(encoding) => {
+                TokenizerResult::EncodingIndicator(encoding)
+            },
         }
     }
 

--- a/components/script/dom/servoparser/xml.rs
+++ b/components/script/dom/servoparser/xml.rs
@@ -55,6 +55,9 @@ impl Tokenizer {
                         return TokenizerResult::Script(DomRoot::from_ref(script));
                     }
                 },
+                TokenizerResult::EncodingIndicator(encoding) => {
+                    return TokenizerResult::EncodingIndicator(encoding);
+                },
             }
         }
     }

--- a/components/script/dom/xmldocument.rs
+++ b/components/script/dom/xmldocument.rs
@@ -71,6 +71,7 @@ impl XMLDocument {
                 has_trustworthy_ancestor_origin,
                 custom_element_reaction_stack,
                 window.Document().creation_sandboxing_flag_set(),
+                None,
             ),
         }
     }

--- a/components/script/dom/xmlhttprequest.rs
+++ b/components/script/dom/xmlhttprequest.rs
@@ -67,8 +67,8 @@ use crate::dom::node::Node;
 use crate::dom::performance::performanceresourcetiming::InitiatorType;
 use crate::dom::progressevent::ProgressEvent;
 use crate::dom::readablestream::ReadableStream;
-use crate::dom::servoparser::ServoParser;
 use crate::dom::servoparser::html::HtmlSerialize;
+use crate::dom::servoparser::{EncodingInformation, ServoParser};
 use crate::dom::window::Window;
 use crate::dom::workerglobalscope::WorkerGlobalScope;
 use crate::dom::xmlhttprequesteventtarget::XMLHttpRequestEventTarget;
@@ -1500,8 +1500,7 @@ impl XMLHttpRequest {
             &document,
             Some(DOMString::from(decoded)),
             wr.get_url(),
-            None,
-            None,
+            EncodingInformation::Irrelevant,
             can_gc,
         );
         document
@@ -1518,7 +1517,7 @@ impl XMLHttpRequest {
             &document,
             Some(DOMString::from(decoded)),
             wr.get_url(),
-            None,
+            EncodingInformation::Irrelevant,
             can_gc,
         );
         document
@@ -1552,6 +1551,7 @@ impl XMLHttpRequest {
             doc.has_trustworthy_ancestor_origin(),
             doc.custom_element_reaction_stack(),
             doc.creation_sandboxing_flag_set(),
+            None,
             can_gc,
         )
     }

--- a/components/script_bindings/Cargo.toml
+++ b/components/script_bindings/Cargo.toml
@@ -23,6 +23,7 @@ cssparser = { workspace = true }
 deny_public_fields = { path = "../deny_public_fields" }
 dom_struct = { path = "../dom_struct" }
 domobject_derive = { path = "../domobject_derive" }
+encoding_rs = { workspace = true }
 html5ever = { workspace = true }
 indexmap = { workspace = true }
 js = { workspace = true }

--- a/components/script_bindings/domstring.rs
+++ b/components/script_bindings/domstring.rs
@@ -362,7 +362,7 @@ impl DOMString {
                 #[cfg(test)]
                 DOMStringType::Latin1Vec(ref items) => {
                     let mut v = vec![0; items.len() * 2];
-                    let real_size = tendril::encoding_rs::mem::convert_latin1_to_utf8(
+                    let real_size = encoding_rs::mem::convert_latin1_to_utf8(
                         items.as_slice(),
                         v.as_mut_slice(),
                     );
@@ -739,10 +739,8 @@ impl ToJSValConvertible for DOMString {
             #[cfg(test)]
             DOMStringType::Latin1Vec(ref items) => {
                 let mut v = vec![0; items.len() * 2];
-                let real_size = tendril::encoding_rs::mem::convert_latin1_to_utf8(
-                    items.as_slice(),
-                    v.as_mut_slice(),
-                );
+                let real_size =
+                    encoding_rs::mem::convert_latin1_to_utf8(items.as_slice(), v.as_mut_slice());
                 v.truncate(real_size);
 
                 String::from_utf8(v)

--- a/components/shared/constellation/from_script_message.rs
+++ b/components/shared/constellation/from_script_message.rs
@@ -131,6 +131,9 @@ pub struct LoadData {
     /// If this is a load operation for an `<iframe>` whose origin is same-origin with its
     /// container documents origin then this is the encoding of the container document.
     pub container_document_encoding: Option<&'static Encoding>,
+    /// Indicates that servo has previously attempted to load this document with an incompatible
+    /// encoding and detected that this one should be used instead.
+    pub encoding_override: Option<&'static Encoding>,
 }
 
 /// The result of evaluating a javascript scheme url.
@@ -176,6 +179,7 @@ impl LoadData {
             destination: Destination::Document,
             creation_sandboxing_flag_set,
             container_document_encoding: None,
+            encoding_override: None,
         }
     }
 

--- a/tests/wpt/tests/domparsing/DOMParser-parseFromString-encoding.html
+++ b/tests/wpt/tests/domparsing/DOMParser-parseFromString-encoding.html
@@ -10,7 +10,7 @@
 function assertEncoding(doc) {
   assert_equals(doc.charset, "UTF-8", "document.charset");
   assert_equals(doc.characterSet, "UTF-8", "document.characterSet");
-  assert_equals(doc.inputEncoding, "UTF-8", "document.characterSet");
+  assert_equals(doc.inputEncoding, "UTF-8", "document.inputEncoding");
 }
 
 setup(() => {

--- a/tests/wpt/tests/html/webappapis/dynamic-markup-insertion/html-unsafe-methods/Document-parseHTMLUnsafe-encoding.html
+++ b/tests/wpt/tests/html/webappapis/dynamic-markup-insertion/html-unsafe-methods/Document-parseHTMLUnsafe-encoding.html
@@ -11,7 +11,7 @@
 function assertEncoding(doc) {
   assert_equals(doc.charset, "UTF-8", "document.charset");
   assert_equals(doc.characterSet, "UTF-8", "document.characterSet");
-  assert_equals(doc.inputEncoding, "UTF-8", "document.characterSet");
+  assert_equals(doc.inputEncoding, "UTF-8", "document.inputEncoding");
 }
 
 setup(() => {


### PR DESCRIPTION
This continues https://github.com/servo/servo/pull/41376. With this change servo will properly parse `<meta charset`> and `<meta http-equiv="content-type">` tags and reload the page when appropriate.

Encoding hints encountered during dynamic markup insertion (such as `document.write`) or when the encoding does not matter (such as during `DOMParser.parseFromString`) are ignored.

@jdm I've added you as a co-author on the commit, since I used https://gist.github.com/jdm/1f08c1b8b3c33d3f5c44882a1b5eb822 which you posted earlier this year on zulip.

Companion PR for https://github.com/servo/html5ever/pull/702
Fixes https://github.com/servo/servo/issues/24898
Closes https://github.com/servo/servo/issues/6414