### PR TITLE
fonts: Clean up a little bit of code in h advance determination

### DIFF
--- a/components/fonts/font.rs
+++ b/components/fonts/font.rs
@@ -558,12 +558,10 @@ impl Font {
             }
         }
 
-        // TODO: Need a fallback strategy.
-        let new_width = match self.handle.glyph_h_advance(glyph_id) {
-            Some(adv) => adv,
-            None => LAST_RESORT_GLYPH_ADVANCE as FractionalPixel,
-        };
-
+        let new_width = self
+            .handle
+            .glyph_h_advance(glyph_id)
+            .unwrap_or(LAST_RESORT_GLYPH_ADVANCE as FractionalPixel);
         let mut cache = self.cached_shape_data.write();
         cache.glyph_advances.insert(glyph_id, new_width);
         new_width


### PR DESCRIPTION
The comment here is out of date and also using `unwrap_or` is a bit more
idiomatic.

Testing: This doesn't change behavior so is covered by existing tests.
