### PR TITLE
script: Use chardetng to guess encoding when all else fails

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1303,6 +1303,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "chardetng"
+version = "0.1.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "14b8f0b65b7b08ae3c8187e8d77174de20cb6777864c6b832d8ad365999cf1ea"
+dependencies = [
+ "cfg-if",
+ "encoding_rs",
+ "memchr",
+]
+
+[[package]]
 name = "chrono"
 version = "0.4.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7647,6 +7658,7 @@ dependencies = [
  "canvas_traits",
  "cbc",
  "chacha20poly1305",
+ "chardetng",
  "chrono",
  "cipher",
  "compositing_traits",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,6 +54,7 @@ canvas_traits = { path = "components/shared/canvas" }
 cbc = "0.1.2"
 cfg-if = "1.0.4"
 chacha20poly1305 = "0.10"
+chardetng = "0.1"
 chrono = { version = "0.4", features = ["serde"] }
 cipher = { version = "0.4.4", features = ["alloc"] }
 compositing_traits = { path = "components/shared/compositing" }

--- a/components/script/Cargo.toml
+++ b/components/script/Cargo.toml
@@ -52,6 +52,7 @@ brotli = { workspace = true }
 canvas_traits = { workspace = true }
 cbc = { workspace = true }
 chacha20poly1305 = { workspace = true }
+chardetng = { workspace = true }
 chrono = { workspace = true }
 cipher = { workspace = true }
 compositing_traits = { workspace = true }

--- a/tests/wpt/include.ini
+++ b/tests/wpt/include.ini
@@ -142,6 +142,8 @@ skip: true
   skip: false
 [encoding]
   skip: false
+[encoding-detection]
+  skip: false
 [eventsource]
   skip: false
 [fetch]

--- a/tests/wpt/meta/encoding-detection/utf-8.html.ini
+++ b/tests/wpt/meta/encoding-detection/utf-8.html.ini
@@ -1,0 +1,3 @@
+[utf-8.html]
+  [Check detection result]
+    expected: FAIL

--- a/tests/wpt/meta/encoding/utf-32-from-win1252.html.ini
+++ b/tests/wpt/meta/encoding/utf-32-from-win1252.html.ini
@@ -1,9 +1,9 @@
 [utf-32-from-win1252.html]
-  [Expect resources/utf-32-big-endian-bom.html to parse as windows-1252]
-    expected: FAIL
-
   [Expect resources/utf-32-big-endian-nobom.html to parse as windows-1252]
     expected: FAIL
 
   [Expect resources/utf-32-little-endian-nobom.html to parse as windows-1252]
+    expected: FAIL
+
+  [Expect resources/utf-32-big-endian-bom.xml to parse as UTF-8]
     expected: FAIL

--- a/tests/wpt/meta/encoding/utf-32.html.ini
+++ b/tests/wpt/meta/encoding/utf-32.html.ini
@@ -1,0 +1,6 @@
+[utf-32.html]
+  [Expect resources/utf-32-big-endian-bom.html to parse as UTF-8]
+    expected: FAIL
+
+  [Expect resources/utf-32-big-endian-bom.xml to parse as UTF-8]
+    expected: FAIL

--- a/tests/wpt/meta/html/syntax/charset/inheritance-bogus-meta-utf-8.html.ini
+++ b/tests/wpt/meta/html/syntax/charset/inheritance-bogus-meta-utf-8.html.ini
@@ -1,4 +1,4 @@
-[inheritance-bogus-meta.html]
+[inheritance-bogus-meta-utf-8.html]
   [Child with bogus <meta charset>]
     expected: FAIL
 


### PR DESCRIPTION
[`chardetng`](https://github.com/hsivonen/chardetng) is the library used by gecko to guess encodings.

This makes https://intsys.co.jp/game/panepon/p01/index.html load with the correct encoding. Notably, that site uses shift-jis but has no encoding declaration of any kind.

Part of https://github.com/servo/servo/issues/6414
