### PR TITLE
net: Expose `replace_host_table` via test_util

### DIFF
--- a/components/net/hosts.rs
+++ b/components/net/hosts.rs
@@ -27,6 +27,7 @@ fn create_host_table() -> Option<HashMap<String, IpAddr>> {
     Some(parse_hostsfile(&lines))
 }
 
+#[cfg_attr(not(feature = "test-util"), expect(dead_code))]
 pub fn replace_host_table(table: HashMap<String, IpAddr>) {
     *HOST_TABLE.lock() = Some(table);
 }

--- a/components/net/lib.rs
+++ b/components/net/lib.rs
@@ -35,6 +35,6 @@ pub mod fetch {
 /// A module for re-exports of items used in unit tests.
 pub mod test {
     pub use crate::decoder::DECODER_BUFFER_SIZE;
-    pub use crate::hosts::{parse_hostsfile, replace_host_table};
+    pub use crate::hosts::parse_hostsfile;
     pub use crate::http_loader::HttpState;
 }

--- a/components/net/test_util.rs
+++ b/components/net/test_util.rs
@@ -29,6 +29,7 @@ use tokio_rustls::{self, TlsAcceptor};
 use crate::async_runtime::{
     async_runtime_initialized, init_async_runtime, spawn_blocking_task, spawn_task,
 };
+pub use crate::hosts::replace_host_table;
 
 static ASYNC_RUNTIME: LazyLock<Arc<Mutex<Box<dyn AsyncRuntime>>>> =
     LazyLock::new(|| Arc::new(Mutex::new(init_async_runtime())));

--- a/components/net/tests/http_loader.rs
+++ b/components/net/tests/http_loader.rs
@@ -36,7 +36,7 @@ use net::cookie_storage::CookieStorage;
 use net::fetch::methods::{self};
 use net::http_loader::{determine_requests_referrer, serialize_origin};
 use net::resource_thread::AuthCacheEntry;
-use net::test::{DECODER_BUFFER_SIZE, replace_host_table};
+use net::test::DECODER_BUFFER_SIZE;
 use net_traits::http_status::HttpStatus;
 use net_traits::request::{
     CredentialsMode, Destination, Referrer, Request, RequestBuilder, RequestMode,
@@ -51,7 +51,7 @@ use url::Url;
 use crate::{
     create_embedder_proxy_and_receiver, fetch, fetch_with_context, make_body, make_server,
     make_ssl_server, mock_origin, new_fetch_context, receive_credential_prompt_msgs,
-    spawn_blocking_task,
+    replace_host_table, spawn_blocking_task,
 };
 
 fn assert_cookie_for_domain(

--- a/components/net/tests/main.rs
+++ b/components/net/tests/main.rs
@@ -36,7 +36,9 @@ use net::filemanager_thread::FileManager;
 use net::protocols::ProtocolRegistry;
 use net::request_interceptor::RequestInterceptor;
 use net::test::HttpState;
-use net::test_util::{create_embedder_proxy, make_body, make_server, make_ssl_server};
+use net::test_util::{
+    create_embedder_proxy, make_body, make_server, make_ssl_server, replace_host_table,
+};
 use net_traits::filemanager_thread::FileTokenCheck;
 use net_traits::request::Request;
 use net_traits::response::Response;


### PR DESCRIPTION
Expose `replace_host_table` via test_util so it can be reused by other
crates, notably libservo tests.
    
This allows tests to map arbitrary host names to localhost, so loading of
arbitrary sites can be done via the lightweight http server (without reaching
the external network).
    
Arbitrary sites are needed for upcoming `SiteDataManager` site grouping by
domain.

Testing: A new integration test has been added
