### PR TITLE
net: Keep track of size of keep-alive records

### DIFF
--- a/components/net/tests/fetch.rs
+++ b/components/net/tests/fetch.rs
@@ -768,6 +768,7 @@ fn test_fetch_with_hsts() {
         ca_certificates: CACertificates::Default,
         ignore_certificate_errors: false,
         preloaded_resources: Default::default(),
+        in_flight_keep_alive_records: Default::default(),
     };
 
     // The server certificate is self-signed, so we need to add an override
@@ -833,6 +834,7 @@ fn test_load_adds_host_to_hsts_list_when_url_is_https() {
         ca_certificates: CACertificates::Default,
         ignore_certificate_errors: false,
         preloaded_resources: Default::default(),
+        in_flight_keep_alive_records: Default::default(),
     };
 
     // The server certificate is self-signed, so we need to add an override
@@ -903,6 +905,7 @@ fn test_fetch_self_signed() {
         ca_certificates: CACertificates::Default,
         ignore_certificate_errors: false,
         preloaded_resources: Default::default(),
+        in_flight_keep_alive_records: Default::default(),
     };
 
     let request = RequestBuilder::new(Some(TEST_WEBVIEW_ID), url.clone(), Referrer::NoReferrer)
@@ -1555,6 +1558,7 @@ fn test_fetch_request_intercepted() {
         ca_certificates: CACertificates::Default,
         ignore_certificate_errors: false,
         preloaded_resources: Default::default(),
+        in_flight_keep_alive_records: Default::default(),
     };
 
     let url = ServoUrl::parse("http://www.example.org").unwrap();

--- a/components/net/tests/main.rs
+++ b/components/net/tests/main.rs
@@ -146,6 +146,7 @@ fn new_fetch_context(
         ca_certificates: CACertificates::Default,
         ignore_certificate_errors: false,
         preloaded_resources: Default::default(),
+        in_flight_keep_alive_records: Default::default(),
     }
 }
 impl FetchTaskTarget for FetchResponseCollector {

--- a/components/script/dom/eventsource.rs
+++ b/components/script/dom/eventsource.rs
@@ -600,7 +600,7 @@ impl EventSourceMethods<crate::DomTypeHolder> for EventSource {
 
         event_source.droppable.set_canceller(FetchCanceller::new(
             request.id,
-            request.keep_alive,
+            false,
             global.core_resource_thread(),
         ));
 

--- a/components/script/dom/html/htmlmediaelement.rs
+++ b/components/script/dom/html/htmlmediaelement.rs
@@ -1450,7 +1450,6 @@ impl HTMLMediaElement {
 
         *current_fetch_context = Some(HTMLMediaElementFetchContext::new(
             request.id,
-            request.keep_alive,
             global.core_resource_thread(),
         ));
         let listener =
@@ -3623,7 +3622,6 @@ pub(crate) struct HTMLMediaElementFetchContext {
 impl HTMLMediaElementFetchContext {
     fn new(
         request_id: RequestId,
-        keep_alive: bool,
         core_resource_thread: CoreResourceThread,
     ) -> HTMLMediaElementFetchContext {
         HTMLMediaElementFetchContext {
@@ -3632,11 +3630,7 @@ impl HTMLMediaElementFetchContext {
             is_seekable: false,
             origin_clean: true,
             data_source: RefCell::new(BufferedDataSource::new()),
-            fetch_canceller: FetchCanceller::new(
-                request_id,
-                keep_alive,
-                core_resource_thread.clone(),
-            ),
+            fetch_canceller: FetchCanceller::new(request_id, false, core_resource_thread.clone()),
         }
     }
 

--- a/components/script/dom/html/htmlvideoelement.rs
+++ b/components/script/dom/html/htmlvideoelement.rs
@@ -260,7 +260,6 @@ impl HTMLVideoElement {
             poster_url,
             id,
             request.id,
-            request.keep_alive,
             self.global().core_resource_thread(),
         );
         self.owner_document().fetch_background(request, context);
@@ -494,7 +493,6 @@ impl PosterFrameFetchContext {
         url: ServoUrl,
         id: PendingImageId,
         request_id: RequestId,
-        keep_alive: bool,
         core_resource_thread: CoreResourceThread,
     ) -> PosterFrameFetchContext {
         let window = elem.owner_window();
@@ -504,7 +502,7 @@ impl PosterFrameFetchContext {
             id,
             cancelled: false,
             url,
-            fetch_canceller: FetchCanceller::new(request_id, keep_alive, core_resource_thread),
+            fetch_canceller: FetchCanceller::new(request_id, false, core_resource_thread),
         }
     }
 }

--- a/components/script/dom/navigator.rs
+++ b/components/script/dom/navigator.rs
@@ -492,7 +492,9 @@ impl NavigatorMethods<crate::DomTypeHolder> for Navigator {
             // is exceeded by the size of transmittedData (as defined in HTTP-network-or-cache fetch),
             // set the return value to false and terminate these steps.
             if let Some(total_bytes) = extracted_body.total_bytes {
-                if total_bytes > 64 * 1024 {
+                let in_flight_keep_alive_bytes =
+                    global.total_size_of_in_flight_keep_alive_records();
+                if total_bytes as u64 + in_flight_keep_alive_bytes > 64 * 1024 {
                     return Ok(false);
                 }
             }
@@ -526,6 +528,8 @@ impl NavigatorMethods<crate::DomTypeHolder> for Navigator {
             .method(http::Method::POST)
             .body(request_body)
             .origin(origin)
+            .pipeline_id(Some(global.pipeline_id()))
+            .client(global.request_client())
             .keep_alive(true)
             .credentials_mode(CredentialsMode::Include)
             .headers(headers);

--- a/components/script/dom/servoparser/mod.rs
+++ b/components/script/dom/servoparser/mod.rs
@@ -1332,6 +1332,7 @@ impl FetchResponseListener for ParserContext {
                 NetworkError::ConnectionFailure |
                 NetworkError::RedirectError |
                 NetworkError::TooManyRedirects |
+                NetworkError::TooManyInFlightKeepAliveRequests |
                 NetworkError::InvalidMethod |
                 NetworkError::ContentSecurityPolicy |
                 NetworkError::Nosniff |

--- a/components/script/dom/xmlhttprequest.rs
+++ b/components/script/dom/xmlhttprequest.rs
@@ -529,7 +529,7 @@ impl XMLHttpRequestMethods<crate::DomTypeHolder> for XMLHttpRequest {
         DomRoot::from_ref(&*self.upload)
     }
 
-    /// <https://xhr.spec.whatwg.org/#the-send()-method>
+    /// <https://xhr.spec.whatwg.org/#dom-xmlhttprequest-send>
     fn Send(
         &self,
         cx: &mut js::context::JSContext,
@@ -1603,11 +1603,8 @@ impl XMLHttpRequest {
             )
         };
 
-        *self.canceller.borrow_mut() = FetchCanceller::new(
-            request_builder.id,
-            request_builder.keep_alive,
-            global.core_resource_thread(),
-        );
+        *self.canceller.borrow_mut() =
+            FetchCanceller::new(request_builder.id, false, global.core_resource_thread());
 
         global.fetch(request_builder, context, task_source);
 

--- a/components/script/script_thread.rs
+++ b/components/script/script_thread.rs
@@ -3621,7 +3621,7 @@ impl ScriptThread {
         let request_builder = incomplete.request_builder();
         incomplete.canceller = FetchCanceller::new(
             request_builder.id,
-            request_builder.keep_alive,
+            false,
             self.resource_threads.core_thread.clone(),
         );
         NavigationListener::new(request_builder, self.senders.self_sender.clone())
@@ -3758,7 +3758,7 @@ impl ScriptThread {
 
         incomplete_load.canceller = FetchCanceller::new(
             request_builder.id,
-            request_builder.keep_alive,
+            false,
             self.resource_threads.core_thread.clone(),
         );
         NavigationListener::new(request_builder, self.senders.self_sender.clone())

--- a/components/shared/net/lib.rs
+++ b/components/shared/net/lib.rs
@@ -10,7 +10,7 @@ use std::thread::{self, JoinHandle};
 
 use base::cross_process_instant::CrossProcessInstant;
 use base::generic_channel::{self, GenericSender};
-use base::id::{CookieStoreId, HistoryStateId};
+use base::id::{CookieStoreId, HistoryStateId, PipelineId};
 use base::{IpcSend, IpcSendResult};
 use content_security_policy::{self as csp};
 use cookie::Cookie;
@@ -651,6 +651,7 @@ pub enum CoreResourceMsg {
     /// Message forwarded to file manager's handler
     ToFileManager(FileManagerThreadMsg),
     StorePreloadedResponse(PreloadId, Response),
+    TotalSizeOfInFlightKeepAliveRecords(PipelineId, GenericSender<u64>),
     /// Break the load handler loop, send a reply when done cleaning up local resources
     /// and exit
     Exit(IpcSender<()>),
@@ -1152,6 +1153,7 @@ pub enum NetworkError {
     ConnectionFailure,
     RedirectError,
     TooManyRedirects,
+    TooManyInFlightKeepAliveRequests,
     InvalidMethod,
     ResourceLoadError(String),
     ContentSecurityPolicy,
@@ -1180,6 +1182,9 @@ impl fmt::Debug for NetworkError {
             NetworkError::ConnectionFailure => write!(f, "Request failed"),
             NetworkError::RedirectError => write!(f, "Redirect failed"),
             NetworkError::TooManyRedirects => write!(f, "Too many redirects"),
+            NetworkError::TooManyInFlightKeepAliveRequests => {
+                write!(f, "Too many in flight keep-alive requests")
+            },
             NetworkError::InvalidMethod => write!(f, "Unexpected method"),
             NetworkError::ResourceLoadError(s) => write!(f, "{}", s),
             NetworkError::ContentSecurityPolicy => write!(f, "Blocked by Content-Security-Policy"),

--- a/tests/wpt/meta/beacon/beacon-basic.https.window.js.ini
+++ b/tests/wpt/meta/beacon/beacon-basic.https.window.js.ini
@@ -1,9 +1,0 @@
-[beacon-basic.https.window.html]
-  [Payload size restriction should be accumulated: type = string]
-    expected: FAIL
-
-  [Payload size restriction should be accumulated: type = arraybuffer]
-    expected: FAIL
-
-  [Payload size restriction should be accumulated: type = blob]
-    expected: FAIL

--- a/tests/wpt/tests/beacon/resources/beacon.py
+++ b/tests/wpt/tests/beacon/resources/beacon.py
@@ -72,7 +72,7 @@ def main(request, response):
                 payload = request.body
 
             payload_parts = list(filter(None, payload.split(b":")))
-            if len(payload_parts) > 0:
+            if len(payload_parts) > 1:
                 payload_size = int(payload_parts[0])
 
                 # Confirm the payload size sent matches with the number of


### PR DESCRIPTION
These keep-alive records live on the `CoreResourceManager` since the vec
of records must be modified by the fetch thread. The script thread sometimes
requires this information as well, which is why it can send a message to
obtain the total size.

The keep-alive records must be tracked per global. That's why all code needs
to specify the `pipeline_id`. Requests optionally have this field, which is why
the code expects it to be present. The relevant information is added to the
navigator request to ensure it can compute it.

Fixes #41230 