### PR TITLE
OHOS CI: Resolve TIMEOUT notified by scenario test server

### DIFF
--- a/etc/ci/scenario/common_function_for_mossel.py
+++ b/etc/ci/scenario/common_function_for_mossel.py
@@ -12,6 +12,7 @@
 from selenium.common import NoSuchElementException
 from selenium.webdriver.common.by import By
 from selenium import webdriver
+from time import sleep
 
 
 def load_mossel(driver: webdriver.Remote):
@@ -42,6 +43,7 @@ def close_popup(driver: webdriver.Remote):
         birthday_element = driver.find_element(By.CSS_SELECTOR, popup_css_selector)
         birthday_element.click()
         print("Closed the popup")
+        sleep(1)
     except NoSuchElementException:
         print(f"Failed to find pop_up element with selector `{popup_css_selector}`. Skip it.")
 
@@ -55,3 +57,14 @@ def click_category(driver: webdriver.Remote):
         raise NoSuchElementException("Category element not found. Test failed.")
 
     category_element.click()
+    post_click_category(driver)
+
+
+def post_click_category(driver: webdriver.Remote):
+    try:
+        driver.find_element(By.CSS_SELECTOR, ".uni-async-error")
+        print("\033[31mMossel timeout JS triggered for category page, reloading...\033[0m")
+        driver.refresh()
+        post_click_category(driver)
+    except NoSuchElementException:
+        print("\033[32mCategory page loaded.\033[0m")

--- a/etc/ci/scenario/common_function_for_mossel.py
+++ b/etc/ci/scenario/common_function_for_mossel.py
@@ -14,6 +14,18 @@ from selenium.webdriver.common.by import By
 from selenium import webdriver
 
 
+def load_mossel(driver: webdriver.Remote):
+    PAGE_URL = "https://m.huaweimossel.com"
+    while True:
+        driver.get(PAGE_URL)
+        try:
+            driver.find_elements(By.CSS_SELECTOR, ".uni-async-error")
+            print("\033[31mMossel timeout JS triggered, reloading...\033[0m")
+        except NoSuchElementException:
+            break
+    print("\033[32mPage loaded.\033[0m")
+
+
 # Click to close the pop-up
 # Note that the pop-up may not exist, either because we did this in the past
 # which sets localstorage, or the website does not have seasonal promotions/recommendations.

--- a/etc/ci/scenario/common_function_for_mossel.py
+++ b/etc/ci/scenario/common_function_for_mossel.py
@@ -26,8 +26,8 @@ def load_mossel(driver: webdriver.Remote):
                 print("\033[31mMossel timeout JS triggered, reloading...\033[0m")
             except NoSuchElementException:
                 break
-        except Exception:
-            print("\033[31mPage load failed, retrying...\033[0m")
+        except Exception as e:
+            print(f"\033[31mPage load failed: {e}, retrying...\033[0m")
             continue
 
     print("\033[32mPage loaded.\033[0m")
@@ -82,7 +82,7 @@ def identify_element_in_category(driver: webdriver.Remote):
             print("\033[31mMossel timeout JS triggered, reloading...\033[0m")
             try:
                 driver.refresh()
-            except Exception:
-                print("\033[31mPage refresh failed, retrying...\033[0m")
+            except Exception as e:
+                print(f"\033[31mPage refresh failed: {e}, retrying...\033[0m")
                 continue
     print("\033[32mComponents found!\033[0m")

--- a/etc/ci/scenario/common_function_for_mossel.py
+++ b/etc/ci/scenario/common_function_for_mossel.py
@@ -27,7 +27,8 @@ def load_mossel(driver: webdriver.Remote):
             except NoSuchElementException:
                 break
         except Exception as e:
-            print(f"\033[31mPage load failed: {e}, retrying...\033[0m")
+            print(f"\033[31mPage load failed: {e}\033[0m")
+            print("Retrying...")
             continue
 
     print("\033[32mPage loaded.\033[0m")
@@ -83,6 +84,7 @@ def identify_element_in_category(driver: webdriver.Remote):
             try:
                 driver.refresh()
             except Exception as e:
-                print(f"\033[31mPage refresh failed: {e}, retrying...\033[0m")
+                print(f"\033[31mPage refresh failed: {e}\033[0m")
+                print("Retrying...")
                 continue
     print("\033[32mComponents found!\033[0m")

--- a/etc/ci/scenario/common_function_for_mossel.py
+++ b/etc/ci/scenario/common_function_for_mossel.py
@@ -19,7 +19,7 @@ def load_mossel(driver: webdriver.Remote):
     while True:
         driver.get(PAGE_URL)
         try:
-            driver.find_elements(By.CSS_SELECTOR, ".uni-async-error")
+            driver.find_element(By.CSS_SELECTOR, ".uni-async-error")
             print("\033[31mMossel timeout JS triggered, reloading...\033[0m")
         except NoSuchElementException:
             break

--- a/etc/ci/scenario/common_function_for_mossel.py
+++ b/etc/ci/scenario/common_function_for_mossel.py
@@ -17,13 +17,19 @@ from time import sleep
 
 def load_mossel(driver: webdriver.Remote):
     PAGE_URL = "https://m.huaweimossel.com"
+    driver.set_page_load_timeout(30)
     while True:
-        driver.get(PAGE_URL)
         try:
-            driver.find_element(By.CSS_SELECTOR, ".uni-async-error")
-            print("\033[31mMossel timeout JS triggered, reloading...\033[0m")
-        except NoSuchElementException:
-            break
+            driver.get(PAGE_URL)
+            try:
+                driver.find_element(By.CSS_SELECTOR, ".uni-async-error")
+                print("\033[31mMossel timeout JS triggered, reloading...\033[0m")
+            except NoSuchElementException:
+                break
+        except Exception:
+            print("\033[31mPage load failed, retrying...\033[0m")
+            continue
+
     print("\033[32mPage loaded.\033[0m")
 
 
@@ -73,5 +79,10 @@ def identify_element_in_category(driver: webdriver.Remote):
             break
         except NoSuchElementException:
             # We hit the timeout JS, reload and try again.
-            driver.refresh()
-    print("\033[31mComponents found!\033[0m")
+            print("\033[31mMossel timeout JS triggered, reloading...\033[0m")
+            try:
+                driver.refresh()
+            except Exception:
+                print("\033[31mPage refresh failed, retrying...\033[0m")
+                continue
+    print("\033[32mComponents found!\033[0m")

--- a/etc/ci/scenario/common_function_for_mossel.py
+++ b/etc/ci/scenario/common_function_for_mossel.py
@@ -57,6 +57,7 @@ def click_category(driver: webdriver.Remote):
         raise NoSuchElementException("Category element not found. Test failed.")
 
     category_element.click()
+    driver.implicitly_wait(40)
     post_click_category(driver)
 
 

--- a/etc/ci/scenario/common_function_for_mossel.py
+++ b/etc/ci/scenario/common_function_for_mossel.py
@@ -57,15 +57,21 @@ def click_category(driver: webdriver.Remote):
         raise NoSuchElementException("Category element not found. Test failed.")
 
     category_element.click()
+
+
+def identify_element_in_category(driver: webdriver.Remote):
     driver.implicitly_wait(40)
-    post_click_category(driver)
-
-
-def post_click_category(driver: webdriver.Remote):
-    try:
-        driver.find_element(By.CSS_SELECTOR, ".uni-async-error")
-        print("\033[31mMossel timeout JS triggered for category page, reloading...\033[0m")
-        driver.refresh()
-        post_click_category(driver)
-    except NoSuchElementException:
-        print("\033[32mCategory page loaded.\033[0m")
+    target_css_selector = (
+        "#app > uni-app > uni-page > uni-page-wrapper > uni-page-body > uni-view "
+        "> uni-view.sort-main.m-flex.m-bgWhite > uni-scroll-view > div > div > div "
+        "> uni-view.item.active"
+    )
+    while True:
+        try:
+            print("Finding components ...")
+            driver.find_element(By.CSS_SELECTOR, target_css_selector)
+            break
+        except NoSuchElementException:
+            # We hit the timeout JS, reload and try again.
+            driver.refresh()
+    print("\033[31mComponents found!\033[0m")

--- a/etc/ci/scenario/servo_test_open_page_base.py
+++ b/etc/ci/scenario/servo_test_open_page_base.py
@@ -23,6 +23,7 @@ def operator():
     # This is used to wait for element retrieval if not found
     # and certain element click, element send key exceptions.
     driver.implicitly_wait(IMPLICIT_WAIT_TIME_FOR_POPUP)
+    driver.set_page_load_timeout(30)
     common_function_for_mossel.load_mossel(driver)
 
     # Step 2. Click to close the pop-up

--- a/etc/ci/scenario/servo_test_open_page_base.py
+++ b/etc/ci/scenario/servo_test_open_page_base.py
@@ -18,15 +18,12 @@ from selenium.webdriver.common.by import By
 
 
 def operator():
-    IMPLICIT_WAIT_TIME = 10
-    PAGE_URL = "https://m.huaweimossel.com"
+    IMPLICIT_WAIT_TIME_FOR_POPUP = 10
     driver = common_function_for_servo_test.create_driver()
-    driver.get(PAGE_URL)
-
-    print("Page loaded.")
     # This is used to wait for element retrieval if not found
     # and certain element click, element send key exceptions.
-    driver.implicitly_wait(IMPLICIT_WAIT_TIME)
+    driver.implicitly_wait(IMPLICIT_WAIT_TIME_FOR_POPUP)
+    common_function_for_mossel.load_mossel(driver)
 
     # Step 2. Click to close the pop-up
     common_function_for_mossel.close_popup(driver)

--- a/etc/ci/scenario/servo_test_open_page_base.py
+++ b/etc/ci/scenario/servo_test_open_page_base.py
@@ -23,7 +23,6 @@ def operator():
     # This is used to wait for element retrieval if not found
     # and certain element click, element send key exceptions.
     driver.implicitly_wait(IMPLICIT_WAIT_TIME_FOR_POPUP)
-    driver.set_page_load_timeout(30)
     common_function_for_mossel.load_mossel(driver)
 
     # Step 2. Click to close the pop-up

--- a/etc/ci/scenario/servo_test_open_page_base.py
+++ b/etc/ci/scenario/servo_test_open_page_base.py
@@ -18,7 +18,7 @@ from selenium.webdriver.common.by import By
 
 
 def operator():
-    IMPLICIT_WAIT_TIME_FOR_POPUP = 10
+    IMPLICIT_WAIT_TIME_FOR_POPUP = 6
     driver = common_function_for_servo_test.create_driver()
     # This is used to wait for element retrieval if not found
     # and certain element click, element send key exceptions.

--- a/etc/ci/scenario/servo_test_open_page_servo.py
+++ b/etc/ci/scenario/servo_test_open_page_servo.py
@@ -16,7 +16,7 @@ from selenium.webdriver.common.by import By
 
 
 def operator():
-    IMPLICIT_WAIT_TIME = 10
+    IMPLICIT_WAIT_TIME = 6
     PAGE_URL = "https://servo.org"
     driver = common_function_for_servo_test.create_driver()
     driver.get(PAGE_URL)

--- a/etc/ci/scenario/servo_test_redirection.py
+++ b/etc/ci/scenario/servo_test_redirection.py
@@ -19,17 +19,13 @@ from selenium.webdriver.common.by import By
 
 
 def operator():
-    IMPLICIT_WAIT_TIME_FOR_POPUP = 15
-    PAGE_URL = "https://m.huaweimossel.com"
-    # Based on experience, it could take up to 40 seconds to load the page after click.
-    IMPLICIT_WAIT_TIME_AFTER_REDIRECTION = 60
+    IMPLICIT_WAIT_TIME_FOR_POPUP = 10
+    IMPLICIT_WAIT_TIME_AFTER_REDIRECTION = 40
     driver = common_function_for_servo_test.create_driver()
-    driver.get(PAGE_URL)
-
-    print("Page loaded.")
     # This is used to wait for element retrieval if not found
     # and certain element click, element send key exceptions.
     driver.implicitly_wait(IMPLICIT_WAIT_TIME_FOR_POPUP)
+    common_function_for_mossel.load_mossel(driver)
 
     # Step 2. Click to close the pop-up
     common_function_for_mossel.close_popup(driver)

--- a/etc/ci/scenario/servo_test_redirection.py
+++ b/etc/ci/scenario/servo_test_redirection.py
@@ -19,12 +19,11 @@ from selenium.webdriver.common.by import By
 
 
 def operator():
-    IMPLICIT_WAIT_TIME_FOR_POPUP = 6
-    IMPLICIT_WAIT_TIME_AFTER_REDIRECTION = 40
+    IMPLICIT_WAIT_TIME = 6
     driver = common_function_for_servo_test.create_driver()
     # This is used to wait for element retrieval if not found
     # and certain element click, element send key exceptions.
-    driver.implicitly_wait(IMPLICIT_WAIT_TIME_FOR_POPUP)
+    driver.implicitly_wait(IMPLICIT_WAIT_TIME)
     common_function_for_mossel.load_mossel(driver)
 
     # Step 2. Click to close the pop-up
@@ -44,7 +43,6 @@ def operator():
 
     try:
         print("Finding components ...")
-        driver.implicitly_wait(IMPLICIT_WAIT_TIME_AFTER_REDIRECTION)
         driver.find_element(By.CSS_SELECTOR, target_css_selector)
     except NoSuchElementException:
         raise NoSuchElementException("Components not found. Test failed.")

--- a/etc/ci/scenario/servo_test_redirection.py
+++ b/etc/ci/scenario/servo_test_redirection.py
@@ -19,7 +19,7 @@ from selenium.webdriver.common.by import By
 
 
 def operator():
-    IMPLICIT_WAIT_TIME_FOR_POPUP = 10
+    IMPLICIT_WAIT_TIME_FOR_POPUP = 6
     IMPLICIT_WAIT_TIME_AFTER_REDIRECTION = 40
     driver = common_function_for_servo_test.create_driver()
     # This is used to wait for element retrieval if not found

--- a/etc/ci/scenario/servo_test_redirection.py
+++ b/etc/ci/scenario/servo_test_redirection.py
@@ -11,11 +11,9 @@
 
 import time
 
-from selenium.common import NoSuchElementException
 
 import common_function_for_servo_test
 import common_function_for_mossel
-from selenium.webdriver.common.by import By
 
 
 def operator():
@@ -35,19 +33,7 @@ def operator():
     common_function_for_mossel.click_category(driver)
 
     # Step 4. Find components
-    target_css_selector = (
-        "#app > uni-app > uni-page > uni-page-wrapper > uni-page-body > uni-view "
-        "> uni-view.sort-main.m-flex.m-bgWhite > uni-scroll-view > div > div > div "
-        "> uni-view.item.active"
-    )
-
-    try:
-        print("Finding components ...")
-        driver.find_element(By.CSS_SELECTOR, target_css_selector)
-    except NoSuchElementException:
-        raise NoSuchElementException("Components not found. Test failed.")
-
-    print("Find components successful!")
+    common_function_for_mossel.identify_element_in_category(driver)
 
 
 if __name__ == "__main__":

--- a/etc/ci/scenario/servo_test_slide.py
+++ b/etc/ci/scenario/servo_test_slide.py
@@ -21,12 +21,11 @@ from selenium.webdriver.common.by import By
 
 
 def operator():
-    IMPLICIT_WAIT_TIME_FOR_POPUP = 6
-    IMPLICIT_WAIT_TIME_AFTER_REDIRECTION = 40
+    IMPLICIT_WAIT_TIME = 6
     driver = common_function_for_servo_test.create_driver()
     # This is used to wait for element retrieval if not found
     # and certain element click, element send key exceptions.
-    driver.implicitly_wait(IMPLICIT_WAIT_TIME_FOR_POPUP)
+    driver.implicitly_wait(IMPLICIT_WAIT_TIME)
     common_function_for_mossel.load_mossel(driver)
 
     # Step 2. Click to close the pop-up
@@ -44,7 +43,6 @@ def operator():
 
     try:
         print("Finding components ...")
-        driver.implicitly_wait(IMPLICIT_WAIT_TIME_AFTER_REDIRECTION)
         driver.find_element(By.CSS_SELECTOR, target_css_selector)
     except NoSuchElementException:
         raise NoSuchElementException("Components not found. Test failed.")

--- a/etc/ci/scenario/servo_test_slide.py
+++ b/etc/ci/scenario/servo_test_slide.py
@@ -21,17 +21,13 @@ from selenium.webdriver.common.by import By
 
 
 def operator():
-    IMPLICIT_WAIT_TIME_FOR_POPUP = 15
-    PAGE_URL = "https://m.huaweimossel.com"
-    # Based on experience, it could take up to seconds to load the page after click.
-    IMPLICIT_WAIT_TIME_AFTER_REDIRECTION = 60
+    IMPLICIT_WAIT_TIME_FOR_POPUP = 10
+    IMPLICIT_WAIT_TIME_AFTER_REDIRECTION = 40
     driver = common_function_for_servo_test.create_driver()
-    driver.get(PAGE_URL)
-
-    print("Page loaded.")
     # This is used to wait for element retrieval if not found
     # and certain element click, element send key exceptions.
     driver.implicitly_wait(IMPLICIT_WAIT_TIME_FOR_POPUP)
+    common_function_for_mossel.load_mossel(driver)
 
     # Step 2. Click to close the pop-up
     common_function_for_mossel.close_popup(driver)

--- a/etc/ci/scenario/servo_test_slide.py
+++ b/etc/ci/scenario/servo_test_slide.py
@@ -21,7 +21,7 @@ from selenium.webdriver.common.by import By
 
 
 def operator():
-    IMPLICIT_WAIT_TIME_FOR_POPUP = 10
+    IMPLICIT_WAIT_TIME_FOR_POPUP = 6
     IMPLICIT_WAIT_TIME_AFTER_REDIRECTION = 40
     driver = common_function_for_servo_test.create_driver()
     # This is used to wait for element retrieval if not found

--- a/etc/ci/scenario/servo_test_slide.py
+++ b/etc/ci/scenario/servo_test_slide.py
@@ -16,9 +16,6 @@ import subprocess
 import common_function_for_servo_test
 import common_function_for_mossel
 
-from selenium.common import NoSuchElementException
-from selenium.webdriver.common.by import By
-
 
 def operator():
     IMPLICIT_WAIT_TIME = 6
@@ -35,19 +32,9 @@ def operator():
     common_function_for_mossel.click_category(driver)
 
     # Step 4. Find components which indicates the page has loaded, before sliding.
-    target_css_selector = (
-        "#app > uni-app > uni-page > uni-page-wrapper > uni-page-body > uni-view "
-        "> uni-view.sort-main.m-flex.m-bgWhite > uni-scroll-view > div > div > div "
-        "> uni-view.item.active"
-    )
+    common_function_for_mossel.identify_element_in_category(driver)
 
-    try:
-        print("Finding components ...")
-        driver.find_element(By.CSS_SELECTOR, target_css_selector)
-    except NoSuchElementException:
-        raise NoSuchElementException("Components not found. Test failed.")
-
-    print("Find components successful! Ready to swipe.")
+    print("Ready to swipe.")
     # Step 4. Slide and check if it actually happened.
     print("Screenshot before swiping.")
     before = driver.get_screenshot_as_base64()


### PR DESCRIPTION
Fixes the corner case where server notifies TIMEOUT through JS.
We now enforces WebDriver page load timeout.
Also reduces runtime by eliminating unnecessary wait.

Testing: 15 consecutive successes.
https://github.com/servo/servo/actions/runs/20424254640
https://github.com/servo/servo/actions/runs/20424278175
https://github.com/servo/servo/actions/runs/20424275366
https://github.com/servo/servo/actions/runs/20424009716
https://github.com/servo/servo/actions/runs/20424461693
https://github.com/servo/servo/actions/runs/20424475579
https://github.com/servo/servo/actions/runs/20424957847
https://github.com/servo/servo/actions/runs/20424955422
https://github.com/servo/servo/actions/runs/20424953070
...

How network issue/failure is addressed:
https://github.com/servo/servo/actions/runs/20430835294/job/58701225338

Fixes: #41467
