### PR TITLE
Use `webrender_api` to get current epoch.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6062,8 +6062,6 @@ checksum = "b867cad97c0791bbd3aaa6472142568c6c9e8f71937e98379f584cfb0cf35bec"
 [[package]]
 name = "peek-poke"
 version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef60922033e31835f6cf98b9b81b58368037b71d2a81928985cd9d0b3b3171fb"
 dependencies = [
  "euclid",
  "peek-poke-derive",
@@ -6072,8 +6070,6 @@ dependencies = [
 [[package]]
 name = "peek-poke-derive"
 version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "271f78bae1e699b58c180a384a2e8d78ccbb60b853e15db92339725f3a2764d5"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -10759,8 +10755,6 @@ dependencies = [
 [[package]]
 name = "webrender"
 version = "0.68.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a591c25221a9f8ac2ad7754659b283d912cee6c8424f0fa3777aabed3be91c16"
 dependencies = [
  "allocator-api2",
  "bincode",
@@ -10796,8 +10790,6 @@ dependencies = [
 [[package]]
 name = "webrender_api"
 version = "0.68.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb206f613b4635881065a2ff4670e656edc904af0b8729c51ce1196679fd1b6d"
 dependencies = [
  "app_units",
  "bitflags 2.11.0",
@@ -10816,8 +10808,6 @@ dependencies = [
 [[package]]
 name = "webrender_build"
 version = "0.68.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e6165a81201892371061250bd6f08ede9ed7279842fedc4033f48582a789068"
 dependencies = [
  "bitflags 2.11.0",
  "lazy_static",
@@ -11667,8 +11657,6 @@ dependencies = [
 [[package]]
 name = "wr_glyph_rasterizer"
 version = "0.68.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef4fcffa889d25131fc7c6ec8a558aa7c78d6030eaa17e31695c172adcc4eb0b"
 dependencies = [
  "core-foundation 0.9.4",
  "core-graphics",
@@ -11693,8 +11681,6 @@ dependencies = [
 [[package]]
 name = "wr_malloc_size_of"
 version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "482308b684f11723b200a32808094bb460b5ac4840903ccbcb78ad92a6354a1f"
 dependencies = [
  "app_units",
  "euclid",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -333,9 +333,9 @@ egui-winit = { git = "https://github.com/emilk/egui.git", rev = "5d8f393335e0517
 # Or for WebRender:
 #
 # [patch."https://github.com/servo/webrender"]
-# webrender = { path = "../webrender/webrender" }
-# webrender_api = { path = "../webrender/webrender_api" }
-# wr_malloc_size_of = { path = "../webrender/wr_malloc_size_of" }
+webrender = { path = "../webrender/webrender" }
+webrender_api = { path = "../webrender/webrender_api" }
+wr_malloc_size_of = { path = "../webrender/wr_malloc_size_of" }
 #
 # Or for another Git dependency:
 #

--- a/components/paint/painter.rs
+++ b/components/paint/painter.rs
@@ -442,9 +442,8 @@ impl Painter {
         for webview_renderer in self.webview_renderers.values() {
             for (pipeline_id, pipeline) in webview_renderer.pipelines.iter() {
                 let Some(current_epoch) = self
-                    .webrender_renderer
-                    .as_ref()
-                    .and_then(|wr| wr.current_epoch(self.webrender_document, pipeline_id.into()))
+                    .webrender_api
+                    .current_epoch(self.webrender_document, pipeline_id.into())
                 else {
                     continue;
                 };


### PR DESCRIPTION
Use `webrender_api` to get current epoch using https://github.com/servo/webrender/pull/4877.

As of now `render_api` is already being used for most of communication to `webrender` except this one.

Testing: No tests yet. Behavior should be same.
Fixes: None, no change in behavior expected.