### PR TITLE
script: Add helper function to handle JsonWebKey common encoding tasks

### DIFF
--- a/components/script/dom/subtlecrypto/aes_operation.rs
+++ b/components/script/dom/subtlecrypto/aes_operation.rs
@@ -8,7 +8,6 @@ use aes::cipher::{BlockDecryptMut, BlockEncryptMut, KeyIvInit, StreamCipher};
 use aes::{Aes128, Aes192, Aes256};
 use aes_gcm::{AeadInPlace, AesGcm, KeyInit};
 use aes_kw::{KekAes128, KekAes192, KekAes256};
-use base64ct::{Base64UrlUnpadded, Encoding};
 use cipher::consts::{U12, U16, U32};
 use rand::TryRngCore;
 use rand::rngs::OsRng;
@@ -1072,13 +1071,20 @@ fn export_key_aes(format: KeyFormat, key: &CryptoKey) -> Result<ExportedKey, Err
         },
         // If format is "jwk":
         KeyFormat::Jwk => {
+            // Step 2.1. Let jwk be a new JsonWebKey dictionary.
+            // Step 2.2. Set the kty attribute of jwk to the string "oct".
+            let mut jwk = JsonWebKey {
+                kty: Some(DOMString::from("oct")),
+                ..Default::default()
+            };
+
             // Step 2.3. Set the k attribute of jwk to be a string containing the raw octets of
             // the key represented by the [[handle]] internal slot of key, encoded according to
             // Section 6.4 of JSON Web Algorithms [JWA].
-            let k = match key.handle() {
-                Handle::Aes128(key) => Base64UrlUnpadded::encode_string(key),
-                Handle::Aes192(key) => Base64UrlUnpadded::encode_string(key),
-                Handle::Aes256(key) => Base64UrlUnpadded::encode_string(key),
+            match key.handle() {
+                Handle::Aes128(key) => jwk.encode_string_field(JwkStringField::K, key),
+                Handle::Aes192(key) => jwk.encode_string_field(JwkStringField::K, key),
+                Handle::Aes256(key) => jwk.encode_string_field(JwkStringField::K, key),
                 _ => unreachable!(),
             };
 
@@ -1100,40 +1106,35 @@ fn export_key_aes(format: KeyFormat, key: &CryptoKey) -> Result<ExportedKey, Err
             // If the length attribute of key is 256: Set the alg attribute of jwk to the string "A256CTR".
             //
             // NOTE: Check key length via key.handle()
-            let alg = match (key.handle(), key.algorithm().name()) {
-                (Handle::Aes128(_), ALG_AES_CTR) => "A128CTR",
-                (Handle::Aes192(_), ALG_AES_CTR) => "A192CTR",
-                (Handle::Aes256(_), ALG_AES_CTR) => "A256CTR",
-                (Handle::Aes128(_), ALG_AES_CBC) => "A128CBC",
-                (Handle::Aes192(_), ALG_AES_CBC) => "A192CBC",
-                (Handle::Aes256(_), ALG_AES_CBC) => "A256CBC",
-                (Handle::Aes128(_), ALG_AES_GCM) => "A128GCM",
-                (Handle::Aes192(_), ALG_AES_GCM) => "A192GCM",
-                (Handle::Aes256(_), ALG_AES_GCM) => "A256GCM",
-                (Handle::Aes128(_), ALG_AES_KW) => "A128KW",
-                (Handle::Aes192(_), ALG_AES_KW) => "A192KW",
-                (Handle::Aes256(_), ALG_AES_KW) => "A256KW",
-                _ => unreachable!(),
-            };
+            jwk.alg = Some(
+                match (key.handle(), key.algorithm().name()) {
+                    (Handle::Aes128(_), ALG_AES_CTR) => "A128CTR",
+                    (Handle::Aes192(_), ALG_AES_CTR) => "A192CTR",
+                    (Handle::Aes256(_), ALG_AES_CTR) => "A256CTR",
+                    (Handle::Aes128(_), ALG_AES_CBC) => "A128CBC",
+                    (Handle::Aes192(_), ALG_AES_CBC) => "A192CBC",
+                    (Handle::Aes256(_), ALG_AES_CBC) => "A256CBC",
+                    (Handle::Aes128(_), ALG_AES_GCM) => "A128GCM",
+                    (Handle::Aes192(_), ALG_AES_GCM) => "A192GCM",
+                    (Handle::Aes256(_), ALG_AES_GCM) => "A256GCM",
+                    (Handle::Aes128(_), ALG_AES_KW) => "A128KW",
+                    (Handle::Aes192(_), ALG_AES_KW) => "A192KW",
+                    (Handle::Aes256(_), ALG_AES_KW) => "A256KW",
+                    _ => unreachable!(),
+                }
+                .into(),
+            );
 
             // Step 2.5. Set the key_ops attribute of jwk to equal the [[usages]] internal slot of key.
-            let key_ops = key
-                .usages()
-                .iter()
-                .map(|usage| DOMString::from(usage.as_str()))
-                .collect::<Vec<DOMString>>();
+            jwk.key_ops = Some(
+                key.usages()
+                    .iter()
+                    .map(|usage| DOMString::from(usage.as_str()))
+                    .collect::<Vec<DOMString>>(),
+            );
 
-            // Step 2.1. Let jwk be a new JsonWebKey dictionary.
-            // Step 2.2. Set the kty attribute of jwk to the string "oct".
             // Step 2.6. Set the ext attribute of jwk to equal the [[extractable]] internal slot of key.
-            let jwk = JsonWebKey {
-                kty: Some(DOMString::from("oct")),
-                k: Some(DOMString::from(k)),
-                alg: Some(DOMString::from(alg)),
-                key_ops: Some(key_ops),
-                ext: Some(key.Extractable()),
-                ..Default::default()
-            };
+            jwk.ext = Some(key.Extractable());
 
             // Step 2.7. Let result be jwk.
             result = ExportedKey::Jwk(Box::new(jwk));

--- a/components/script/dom/subtlecrypto/ecdh_operation.rs
+++ b/components/script/dom/subtlecrypto/ecdh_operation.rs
@@ -2,7 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-use base64ct::{Base64UrlUnpadded, Encoding};
 use elliptic_curve::SecretKey;
 use elliptic_curve::rand_core::OsRng;
 use elliptic_curve::sec1::{FromEncodedPoint, ToEncodedPoint, ValidatePublicKey};
@@ -1052,8 +1051,8 @@ pub(crate) fn export_key(format: KeyFormat, key: &CryptoKey) -> Result<ExportedK
                     },
                     _ => return Err(Error::Operation(None)),
                 };
-                jwk.x = Some(Base64UrlUnpadded::encode_string(&x).into());
-                jwk.y = Some(Base64UrlUnpadded::encode_string(&y).into());
+                jwk.encode_string_field(JwkStringField::X, &x);
+                jwk.encode_string_field(JwkStringField::Y, &y);
 
                 // Step 3.3.4.
                 // If the [[type]] internal slot of key is "private"
@@ -1066,7 +1065,7 @@ pub(crate) fn export_key(format: KeyFormat, key: &CryptoKey) -> Result<ExportedK
                         Handle::P521PrivateKey(private_key) => private_key.to_bytes().to_vec(),
                         _ => return Err(Error::NotSupported(None)),
                     };
-                    jwk.d = Some(Base64UrlUnpadded::encode_string(&d).into());
+                    jwk.encode_string_field(JwkStringField::D, &d);
                 }
             }
             // Otherwise:

--- a/components/script/dom/subtlecrypto/ecdsa_operation.rs
+++ b/components/script/dom/subtlecrypto/ecdsa_operation.rs
@@ -2,7 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-use base64ct::{Base64UrlUnpadded, Encoding};
 use digest::Digest;
 use ecdsa::signature::hazmat::{PrehashVerifier, RandomizedPrehashSigner};
 use ecdsa::{Signature, SigningKey, VerifyingKey};
@@ -1179,8 +1178,8 @@ pub(crate) fn export_key(format: KeyFormat, key: &CryptoKey) -> Result<ExportedK
                     },
                     _ => return Err(Error::Operation(None)),
                 };
-                jwk.x = Some(Base64UrlUnpadded::encode_string(&x).into());
-                jwk.y = Some(Base64UrlUnpadded::encode_string(&y).into());
+                jwk.encode_string_field(JwkStringField::X, &x);
+                jwk.encode_string_field(JwkStringField::Y, &y);
 
                 // Step 3.3.4.
                 // If the [[type]] internal slot of key is "private"
@@ -1193,7 +1192,7 @@ pub(crate) fn export_key(format: KeyFormat, key: &CryptoKey) -> Result<ExportedK
                         Handle::P521PrivateKey(private_key) => private_key.to_bytes().to_vec(),
                         _ => return Err(Error::NotSupported(None)),
                     };
-                    jwk.d = Some(Base64UrlUnpadded::encode_string(&d).into());
+                    jwk.encode_string_field(JwkStringField::D, &d);
                 }
             }
             // Otherwise:

--- a/components/script/dom/subtlecrypto/ed25519_operation.rs
+++ b/components/script/dom/subtlecrypto/ed25519_operation.rs
@@ -4,7 +4,6 @@
 
 use aws_lc_rs::encoding::{AsBigEndian, AsDer};
 use aws_lc_rs::signature::{ED25519, Ed25519KeyPair, KeyPair, ParsedPublicKey, UnparsedPublicKey};
-use base64ct::{Base64UrlUnpadded, Encoding};
 use rand::TryRngCore;
 use rand::rngs::OsRng;
 
@@ -477,56 +476,48 @@ pub(crate) fn export_key(format: KeyFormat, key: &CryptoKey) -> Result<ExportedK
         },
         // If format is "jwk":
         KeyFormat::Jwk => {
+            // Step 3.1. Let jwk be a new JsonWebKey dictionary.
+            // Step 3.2. Set the kty attribute of jwk to "OKP".
+            // Step 3.3. Set the alg attribute of jwk to "Ed25519".
+            // Step 3.4. Set the crv attribute of jwk to "Ed25519".
+            let mut jwk = JsonWebKey {
+                kty: Some(DOMString::from("OKP")),
+                alg: Some(DOMString::from(ALG_ED25519)),
+                crv: Some(DOMString::from(ALG_ED25519)),
+                ..Default::default()
+            };
+
             // Step 3.5. Set the x attribute of jwk according to the definition in Section 2 of [RFC8037].
             // Step 3.6.
             // If the [[type]] internal slot of key is "private"
             //     Set the d attribute of jwk according to the definition in Section 2 of [RFC8037].
-            let (x, d) = match key.Type() {
+            match key.Type() {
                 KeyType::Public => {
-                    let public_key = Base64UrlUnpadded::encode_string(key_data);
-                    (Some(DOMString::from(public_key)), None)
+                    jwk.encode_string_field(JwkStringField::X, key_data);
                 },
                 KeyType::Private => {
                     let key_pair = Ed25519KeyPair::from_seed_unchecked(key_data)
                         .map_err(|_| Error::Data(None))?;
-                    let public_key =
-                        Base64UrlUnpadded::encode_string(key_pair.public_key().as_ref());
-                    let private_key = Base64UrlUnpadded::encode_string(key_data);
-                    (
-                        Some(DOMString::from(public_key)),
-                        Some(DOMString::from(private_key)),
-                    )
+                    jwk.encode_string_field(JwkStringField::X, key_pair.public_key().as_ref());
+                    jwk.encode_string_field(JwkStringField::D, key_data);
                 },
                 KeyType::Secret => {
                     return Err(Error::Data(None));
                 },
-            };
+            }
 
             // Step 3.7. Set the key_ops attribute of jwk to the usages attribute of key.
-            let key_ops = Some(
+            jwk.key_ops = Some(
                 key.usages()
                     .iter()
                     .map(|usage| DOMString::from(usage.as_str()))
                     .collect::<Vec<DOMString>>(),
             );
 
-            // Step 3.1. Let jwk be a new JsonWebKey dictionary.
-            // Step 3.2. Set the kty attribute of jwk to "OKP".
-            // Step 3.3. Set the alg attribute of jwk to "Ed25519".
-            // Step 3.4. Set the crv attribute of jwk to "Ed25519".
             // Step 3.8. Set the ext attribute of jwk to the [[extractable]] internal slot of key.
-            let jwk = JsonWebKey {
-                kty: Some(DOMString::from("OKP")),
-                alg: Some(DOMString::from(ALG_ED25519)),
-                crv: Some(DOMString::from(ALG_ED25519)),
-                x,
-                d,
-                key_ops,
-                ext: Some(key.Extractable()),
-                ..Default::default()
-            };
+            jwk.ext = Some(key.Extractable());
 
-            // Step 9. Let result be jwk.
+            // Step 3.9. Let result be jwk.
             ExportedKey::Jwk(Box::new(jwk))
         },
         // If format is "raw":

--- a/components/script/dom/subtlecrypto/rsa_common.rs
+++ b/components/script/dom/subtlecrypto/rsa_common.rs
@@ -26,8 +26,8 @@ use crate::dom::cryptokey::{CryptoKey, Handle};
 use crate::dom::globalscope::GlobalScope;
 use crate::dom::subtlecrypto::{
     ALG_RSA_OAEP, ALG_RSA_PSS, ALG_RSASSA_PKCS1_V1_5, ALG_SHA1, ALG_SHA256, ALG_SHA384, ALG_SHA512,
-    ExportedKey, KeyAlgorithmAndDerivatives, SubtleRsaHashedKeyAlgorithm,
-    SubtleRsaHashedKeyGenParams,
+    ExportedKey, JsonWebKeyExt, JwkStringField, KeyAlgorithmAndDerivatives,
+    SubtleRsaHashedKeyAlgorithm, SubtleRsaHashedKeyGenParams,
 };
 use crate::script_runtime::CanGc;
 
@@ -469,12 +469,12 @@ pub(crate) fn export_key(
                     .ok_or(Error::Operation(Some(
                         "Failed to convert first CRT coefficient qi to BigUint".to_string(),
                     )))?;
-                jwk.d = Some(Base64UrlUnpadded::encode_string(&d.to_bytes_be()).into());
-                jwk.p = Some(Base64UrlUnpadded::encode_string(&p.to_bytes_be()).into());
-                jwk.q = Some(Base64UrlUnpadded::encode_string(&q.to_bytes_be()).into());
-                jwk.dp = Some(Base64UrlUnpadded::encode_string(&dp.to_bytes_be()).into());
-                jwk.dq = Some(Base64UrlUnpadded::encode_string(&dq.to_bytes_be()).into());
-                jwk.qi = Some(Base64UrlUnpadded::encode_string(&qi.to_bytes_be()).into());
+                jwk.encode_string_field(JwkStringField::D, &d.to_bytes_be());
+                jwk.encode_string_field(JwkStringField::P, &p.to_bytes_be());
+                jwk.encode_string_field(JwkStringField::Q, &q.to_bytes_be());
+                jwk.encode_string_field(JwkStringField::DP, &dp.to_bytes_be());
+                jwk.encode_string_field(JwkStringField::DQ, &dq.to_bytes_be());
+                jwk.encode_string_field(JwkStringField::QI, &qi.to_bytes_be());
 
                 // Step 3.6.2. If the underlying RSA private key represented by the [[handle]]
                 // internal slot of key is represented by more than two primes, set the attribute

--- a/components/script/dom/subtlecrypto/x25519_operation.rs
+++ b/components/script/dom/subtlecrypto/x25519_operation.rs
@@ -2,7 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-use base64ct::{Base64UrlUnpadded, Encoding};
 use pkcs8::PrivateKeyInfo;
 use pkcs8::der::asn1::{BitStringRef, OctetString, OctetStringRef};
 use pkcs8::der::{AnyRef, Decode, Encode};
@@ -562,16 +561,16 @@ pub(crate) fn export_key(format: KeyFormat, key: &CryptoKey) -> Result<ExportedK
 
             // Step 3.4. Set the x attribute of jwk according to the definition in Section 2 of
             // [RFC8037].
-            jwk.x = match key.handle() {
+            match key.handle() {
                 Handle::X25519PrivateKey(private_key) => {
                     let public_key = PublicKey::from(private_key);
-                    Some(Base64UrlUnpadded::encode_string(public_key.as_bytes()).into())
+                    jwk.encode_string_field(JwkStringField::X, public_key.as_bytes());
                 },
                 Handle::X25519PublicKey(public_key) => {
-                    Some(Base64UrlUnpadded::encode_string(public_key.as_bytes()).into())
+                    jwk.encode_string_field(JwkStringField::X, public_key.as_bytes());
                 },
                 _ => return Err(Error::Operation(None)),
-            };
+            }
 
             // Step 3.5.
             // If the [[type]] internal slot of key is "private"
@@ -579,7 +578,7 @@ pub(crate) fn export_key(format: KeyFormat, key: &CryptoKey) -> Result<ExportedK
             //     [RFC8037].
             if key.Type() == KeyType::Private {
                 if let Handle::X25519PrivateKey(private_key) = key.handle() {
-                    jwk.d = Some(Base64UrlUnpadded::encode_string(private_key.as_bytes()).into());
+                    jwk.encode_string_field(JwkStringField::D, private_key.as_bytes());
                 } else {
                     return Err(Error::Operation(None));
                 }


### PR DESCRIPTION
Companion of #41428, which added helper functions to handle JsonWebKey common decoding tasks.

This patch adds a helper function `JsonWebKey::encode_string_field` to handle common base64url encoding tasks across multiple algorithms.

Testing: Refactoring. Existing tests suffice.