### PR TITLE
libservo: Move network cache management to `NetworkManager`

### DIFF
--- a/components/servo/Cargo.toml
+++ b/components/servo/Cargo.toml
@@ -158,6 +158,9 @@ tracing = { workspace = true }
 winit = { workspace = true }
 
 [[test]]
+name = "network_manager"
+
+[[test]]
 name = "webview"
 
 [[test]]

--- a/components/servo/network_manager.rs
+++ b/components/servo/network_manager.rs
@@ -4,20 +4,36 @@
 
 use net_traits::ResourceThreads;
 
+/// Provides APIs for managing network-related state.
+///
+/// `NetworkManager` is responsible for data owned by the networking layer,
+/// such as the HTTP cache. This data is not considered site data and is
+/// therefore intentionally separate from `SiteDataManager`.
 pub struct NetworkManager {
-    _public_resource_threads: ResourceThreads,
-    _private_resource_threads: ResourceThreads,
+    public_resource_threads: ResourceThreads,
+    private_resource_threads: ResourceThreads,
 }
 
-// Placeholder for protocol handlers and related networking functionality.
 impl NetworkManager {
     pub(crate) fn new(
         public_resource_threads: ResourceThreads,
         private_resource_threads: ResourceThreads,
     ) -> Self {
         Self {
-            _public_resource_threads: public_resource_threads,
-            _private_resource_threads: private_resource_threads,
+            public_resource_threads,
+            private_resource_threads,
         }
+    }
+
+    /// Clears the network (HTTP) cache.
+    ///
+    /// This removes all cached network responses maintained by the networking
+    /// layer for both public and private browsing contexts.
+    ///
+    /// Note: The networking layer currently only implements an in-memory HTTP
+    /// cache. Support for an on-disk cache is under development.
+    pub fn clear_cache(&self) {
+        self.public_resource_threads.clear_cache();
+        self.private_resource_threads.clear_cache();
     }
 }

--- a/components/servo/site_data_manager.rs
+++ b/components/servo/site_data_manager.rs
@@ -14,8 +14,8 @@ bitflags! {
     /// This type is used by `SiteDataManager` to query, describe, and manage
     /// different kinds of data stored by the user agent for a given site.
     ///
-    /// Additional storage categories (e.g. network cache, cookies, IndexedDB)
-    /// may be added in the future.
+    /// Additional storage categories (e.g. cookies, IndexedDB) may be added in
+    /// the future.
     #[derive(Clone, Copy, Debug, PartialEq)]
     pub struct StorageType: u8 {
         /// Corresponds to the `localStorage` Web API:
@@ -28,6 +28,21 @@ bitflags! {
     }
 }
 
+/// Provides APIs for inspecting and managing site data.
+///
+/// `SiteDataManager` exposes information about data that is conceptually
+/// associated with a site (currently equivalent to an origin), such as
+/// web exposed storage mechanisms like `localStorage` and `sessionStorage`.
+///
+/// The manager can be used by embedders to list sites with stored data.
+/// Support for site scoped management operations (e.g. clearing data for a
+/// specific site) will be added in the future.
+///
+/// At this stage, sites correspond directly to origins. Future work may group
+/// data at a higher level (e.g. by eTLD+1).
+///
+/// Note: Network layer state (such as the HTTP cache) is intentionally not
+/// handled by `SiteDataManager`. That functionality lives in `NetworkManager`.
 #[derive(Clone, Debug, PartialEq)]
 pub struct SiteData {
     name: String,
@@ -129,10 +144,5 @@ impl SiteDataManager {
     pub fn clear_cookies(&self) {
         self.public_resource_threads.clear_cookies();
         self.private_resource_threads.clear_cookies();
-    }
-
-    pub fn clear_cache(&self) {
-        self.public_resource_threads.clear_cache();
-        self.private_resource_threads.clear_cache();
     }
 }

--- a/components/servo/tests/network_manager.rs
+++ b/components/servo/tests/network_manager.rs
@@ -1,0 +1,45 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+mod common;
+
+use std::rc::Rc;
+
+use http_body_util::combinators::BoxBody;
+use hyper::body::{Bytes, Incoming};
+use hyper::{Request as HyperRequest, Response as HyperResponse};
+use net::test_util::{make_body, make_server};
+use servo::WebViewBuilder;
+
+use crate::common::{ServoTest, WebViewDelegateImpl};
+
+#[test]
+fn test_clear_cache() {
+    let servo_test = ServoTest::new();
+
+    static MESSAGE: &'static [u8] = b"<!DOCTYPE html>\nHello";
+
+    let handler =
+        move |_: HyperRequest<Incoming>,
+              response: &mut HyperResponse<BoxBody<Bytes, hyper::Error>>| {
+            *response.body_mut() = make_body(MESSAGE.to_vec());
+        };
+    let (server, url) = make_server(handler);
+
+    let delegate = Rc::new(WebViewDelegateImpl::default());
+
+    let _webview = WebViewBuilder::new(servo_test.servo(), servo_test.rendering_context.clone())
+        .delegate(delegate.clone())
+        .url(url.into_url())
+        .build();
+
+    servo_test.spin(move || !delegate.url_changed.get());
+
+    let _ = server.close();
+
+    servo_test.servo().network_manager().clear_cache();
+
+    // TODO: Check that the cache was actually cleared once there's a way to
+    //       check it.
+}

--- a/components/servo/tests/site_data_manager.rs
+++ b/components/servo/tests/site_data_manager.rs
@@ -162,33 +162,3 @@ fn test_clear_cookies() {
     let result = evaluate_javascript(&servo_test, webview.clone(), "document.cookie");
     assert_eq!(result, Ok(JSValue::String("".into())));
 }
-
-#[test]
-fn test_clear_cache() {
-    let servo_test = ServoTest::new();
-
-    static MESSAGE: &'static [u8] = b"<!DOCTYPE html>\nHello";
-
-    let handler =
-        move |_: HyperRequest<Incoming>,
-              response: &mut HyperResponse<BoxBody<Bytes, hyper::Error>>| {
-            *response.body_mut() = make_body(MESSAGE.to_vec());
-        };
-    let (server, url) = make_server(handler);
-
-    let delegate = Rc::new(WebViewDelegateImpl::default());
-
-    let _webview = WebViewBuilder::new(servo_test.servo(), servo_test.rendering_context.clone())
-        .delegate(delegate.clone())
-        .url(url.into_url())
-        .build();
-
-    servo_test.spin(move || !delegate.url_changed.get());
-
-    let _ = server.close();
-
-    servo_test.servo().site_data_manager().clear_cache();
-
-    // TODO: Check that the cache was actually cleared once there's a way to
-    //       check it.
-}


### PR DESCRIPTION
This PR moves network cache management out of `SiteDataManager` and into
`NetworkManager`, aligning the API with how browser engines conceptually
separate network layer state from site scoped data.

`clear_cache` is now exposed on `NetworkManager`, and documentation has been
added to clarify the responsibility boundaries between site data and network
state.

Testing: No functional changes, just a moved test, verified by running unit tests
