### PR TITLE
script: Make link elements set `ElementState::UNVISITED`

### DIFF
--- a/components/script/dom/html/htmlanchorelement.rs
+++ b/components/script/dom/html/htmlanchorelement.rs
@@ -12,6 +12,7 @@ use num_traits::ToPrimitive;
 use servo_url::ServoUrl;
 use style::attr::AttrValue;
 use stylo_atoms::Atom;
+use stylo_dom::ElementState;
 use xml5ever::ns;
 
 use crate::dom::activation::Activatable;
@@ -115,6 +116,9 @@ impl VirtualMethods for HTMLAnchorElement {
             .attribute_mutated(attr, mutation, can_gc);
 
         match *attr.local_name() {
+            local_name!("href") => self
+                .upcast::<Element>()
+                .set_state(ElementState::UNVISITED, !mutation.is_removal()),
             local_name!("rel") | local_name!("rev") => {
                 self.relations
                     .set(LinkRelations::for_element(self.upcast()));

--- a/components/script/dom/html/htmlareaelement.rs
+++ b/components/script/dom/html/htmlareaelement.rs
@@ -14,6 +14,7 @@ use js::rust::HandleObject;
 use servo_url::ServoUrl;
 use style::attr::AttrValue;
 use stylo_atoms::Atom;
+use stylo_dom::ElementState;
 
 use crate::dom::activation::Activatable;
 use crate::dom::attr::Attr;
@@ -349,6 +350,9 @@ impl VirtualMethods for HTMLAreaElement {
             .attribute_mutated(attr, mutation, can_gc);
 
         match *attr.local_name() {
+            local_name!("href") => self
+                .upcast::<Element>()
+                .set_state(ElementState::UNVISITED, !mutation.is_removal()),
             local_name!("rel") | local_name!("rev") => {
                 self.relations
                     .set(LinkRelations::for_element(self.upcast()));

--- a/tests/wpt/meta/css/css-cascade/scope-visited-cssom.html.ini
+++ b/tests/wpt/meta/css/css-cascade/scope-visited-cssom.html.ini
@@ -2,12 +2,6 @@
   [:link as scoped selector]
     expected: FAIL
 
-  [:visited as scoped selector]
-    expected: FAIL
-
-  [:not(:link) as scoped selector]
-    expected: FAIL
-
   [:not(:visited) as scoped selector]
     expected: FAIL
 
@@ -20,23 +14,11 @@
   [:link as scoping root, :scope]
     expected: FAIL
 
-  [:visited as scoping root, :scope]
-    expected: FAIL
-
   [:not(:visited) as scoping root, :scope]
-    expected: FAIL
-
-  [:not(:link) as scoping root, :scope]
-    expected: FAIL
-
-  [:link as scoping limit]
     expected: FAIL
 
   [:visited as scoping limit]
     expected: FAIL
 
   [:not(:link) as scoping limit]
-    expected: FAIL
-
-  [:not(:visited) as scoping limit]
     expected: FAIL

--- a/tests/wpt/meta/css/selectors/invalidation/any-link-attribute-removal.html.ini
+++ b/tests/wpt/meta/css/selectors/invalidation/any-link-attribute-removal.html.ini
@@ -1,2 +1,0 @@
-[any-link-attribute-removal.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/selectors/invalidation/any-link-pseudo.html.ini
+++ b/tests/wpt/meta/css/selectors/invalidation/any-link-pseudo.html.ini
@@ -1,3 +1,0 @@
-[any-link-pseudo.html]
-  [Style was recalculated for the :any-link pseudo class.]
-    expected: FAIL


### PR DESCRIPTION
In Servo, the `:link` and `:any-link` pseudo-classes correctly match link elements when they are part of a compound selector whose last simple selector does not start with them (e.g. `a:link` or `:link b`), but they do not match when the last simple selector starts with `:link`.

The reason for this seems to be that Stylo uses two methods to determine whether an element is an (unvisited) link: to call the `is_link()` method on the `selectors::Element` trait, and to check if the element's state has `ElementState::UNVISITED` set.

In a browser like Servo which does not support visited styles, these two checks should be equivalent. However, they turn out not to be, because Servo never actually sets `ElementState::UNVISITED`.

Since per the HTML spec the `:link` selector applies to all `<a>` and `<area>` elements that have an `href` attribute, this patch fixes this by setting `ElementState::UNVISITED` on such elements when the `href` attribute is set, and by unsetting it when it is removed.

Testing: There are two invalidation-related WPT tests about the `:any-link` selector that now pass with this patch.

Fixes: servo/stylo#282