### PR TITLE
layout: Support `content: <image>` on non-pseudo-elements

### DIFF
--- a/tests/wpt/meta/css/css-content/element-replacement-alt.html.ini
+++ b/tests/wpt/meta/css/css-content/element-replacement-alt.html.ini
@@ -1,2 +1,0 @@
-[element-replacement-alt.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-content/element-replacement-dynamic.html.ini
+++ b/tests/wpt/meta/css/css-content/element-replacement-dynamic.html.ini
@@ -1,2 +1,0 @@
-[element-replacement-dynamic.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-content/element-replacement-image-alt.html.ini
+++ b/tests/wpt/meta/css/css-content/element-replacement-image-alt.html.ini
@@ -1,2 +1,0 @@
-[element-replacement-image-alt.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-content/element-replacement-image-no-src.tentative.html.ini
+++ b/tests/wpt/meta/css/css-content/element-replacement-image-no-src.tentative.html.ini
@@ -1,2 +1,0 @@
-[element-replacement-image-no-src.tentative.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-content/element-replacement-image-src.tentative.html.ini
+++ b/tests/wpt/meta/css/css-content/element-replacement-image-src.tentative.html.ini
@@ -1,2 +1,0 @@
-[element-replacement-image-src.tentative.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-content/element-replacement-on-replaced-element.tentative.html.ini
+++ b/tests/wpt/meta/css/css-content/element-replacement-on-replaced-element.tentative.html.ini
@@ -1,0 +1,2 @@
+[element-replacement-on-replaced-element.tentative.html]
+  expected: FAIL

--- a/tests/wpt/meta/css/css-content/element-replacement.html.ini
+++ b/tests/wpt/meta/css/css-content/element-replacement.html.ini
@@ -1,2 +1,0 @@
-[element-replacement.html]
-  expected: FAIL

--- a/tests/wpt/meta/fetch/metadata/generated/css-images.https.sub.tentative.html.ini
+++ b/tests/wpt/meta/fetch/metadata/generated/css-images.https.sub.tentative.html.ini
@@ -6,9 +6,6 @@
   [border-image sec-fetch-site - Same origin]
     expected: FAIL
 
-  [content sec-fetch-site - Same origin]
-    expected: FAIL
-
   [cursor sec-fetch-site - Same origin]
     expected: FAIL
 
@@ -19,9 +16,6 @@
     expected: TIMEOUT
 
   [border-image sec-fetch-site - Cross-site]
-    expected: FAIL
-
-  [content sec-fetch-site - Cross-site]
     expected: FAIL
 
   [cursor sec-fetch-site - Cross-site]
@@ -36,9 +30,6 @@
   [border-image sec-fetch-site - Same site]
     expected: FAIL
 
-  [content sec-fetch-site - Same site]
-    expected: FAIL
-
   [cursor sec-fetch-site - Same site]
     expected: FAIL
 
@@ -49,9 +40,6 @@
     expected: TIMEOUT
 
   [border-image sec-fetch-site - Same-Origin -> Cross-Site -> Same-Origin redirect]
-    expected: FAIL
-
-  [content sec-fetch-site - Same-Origin -> Cross-Site -> Same-Origin redirect]
     expected: FAIL
 
   [cursor sec-fetch-site - Same-Origin -> Cross-Site -> Same-Origin redirect]
@@ -96,9 +84,6 @@
   [border-image sec-fetch-site - Cross-Site -> Same-Site]
     expected: FAIL
 
-  [content sec-fetch-site - Cross-Site -> Same-Site]
-    expected: FAIL
-
   [cursor sec-fetch-site - Cross-Site -> Same-Site]
     expected: FAIL
 
@@ -109,9 +94,6 @@
     expected: TIMEOUT
 
   [border-image sec-fetch-site - Cross-Site -> Cross-Site]
-    expected: FAIL
-
-  [content sec-fetch-site - Cross-Site -> Cross-Site]
     expected: FAIL
 
   [cursor sec-fetch-site - Cross-Site -> Cross-Site]
@@ -126,9 +108,6 @@
   [border-image sec-fetch-site - Same-Origin -> Same Origin]
     expected: FAIL
 
-  [content sec-fetch-site - Same-Origin -> Same Origin]
-    expected: FAIL
-
   [cursor sec-fetch-site - Same-Origin -> Same Origin]
     expected: FAIL
 
@@ -141,9 +120,6 @@
   [border-image sec-fetch-site - Same-Origin -> Same-Site]
     expected: FAIL
 
-  [content sec-fetch-site - Same-Origin -> Same-Site]
-    expected: FAIL
-
   [cursor sec-fetch-site - Same-Origin -> Same-Site]
     expected: FAIL
 
@@ -154,9 +130,6 @@
     expected: TIMEOUT
 
   [border-image sec-fetch-site - Same-Origin -> Cross-Site]
-    expected: FAIL
-
-  [content sec-fetch-site - Same-Origin -> Cross-Site]
     expected: FAIL
 
   [cursor sec-fetch-site - Same-Origin -> Cross-Site]
@@ -186,9 +159,6 @@
   [border-image sec-fetch-site - Same-Site -> Same-Site]
     expected: FAIL
 
-  [content sec-fetch-site - Same-Site -> Same-Site]
-    expected: FAIL
-
   [cursor sec-fetch-site - Same-Site -> Same-Site]
     expected: FAIL
 
@@ -199,9 +169,6 @@
     expected: TIMEOUT
 
   [border-image sec-fetch-site - Same-Site -> Cross-Site]
-    expected: FAIL
-
-  [content sec-fetch-site - Same-Site -> Cross-Site]
     expected: FAIL
 
   [cursor sec-fetch-site - Same-Site -> Cross-Site]
@@ -231,9 +198,6 @@
   [border-image sec-fetch-mode]
     expected: FAIL
 
-  [content sec-fetch-mode]
-    expected: FAIL
-
   [cursor sec-fetch-mode]
     expected: FAIL
 
@@ -246,16 +210,10 @@
   [border-image sec-fetch-dest]
     expected: FAIL
 
-  [content sec-fetch-dest]
-    expected: FAIL
-
   [cursor sec-fetch-dest]
     expected: FAIL
 
   [list-style-image sec-fetch-dest]
-    expected: FAIL
-
-  [content sec-fetch-user]
     expected: FAIL
 
   [cursor sec-fetch-user]
@@ -285,11 +243,11 @@
   [border-image sec-fetch-storage-access - Same site]
     expected: FAIL
 
-  [content sec-fetch-storage-access - Same site]
-    expected: FAIL
-
   [cursor sec-fetch-storage-access - Same site]
     expected: FAIL
 
   [list-style-image sec-fetch-storage-access - Same site]
+    expected: FAIL
+
+  [content sec-fetch-site - Same-Origin -> Cross-Site -> Same-Origin redirect]
     expected: FAIL

--- a/tests/wpt/meta/fetch/metadata/generated/css-images.sub.tentative.html.ini
+++ b/tests/wpt/meta/fetch/metadata/generated/css-images.sub.tentative.html.ini
@@ -1,15 +1,9 @@
 [css-images.sub.tentative.html]
   expected: TIMEOUT
-  [content sec-fetch-site - Not sent to non-trustworthy same-origin destination]
-    expected: FAIL
-
   [cursor sec-fetch-site - Not sent to non-trustworthy same-origin destination]
     expected: FAIL
 
   [list-style-image sec-fetch-site - Not sent to non-trustworthy same-origin destination]
-    expected: FAIL
-
-  [content sec-fetch-site - Not sent to non-trustworthy same-site destination]
     expected: FAIL
 
   [cursor sec-fetch-site - Not sent to non-trustworthy same-site destination]
@@ -18,16 +12,10 @@
   [list-style-image sec-fetch-site - Not sent to non-trustworthy same-site destination]
     expected: FAIL
 
-  [content sec-fetch-site - Not sent to non-trustworthy cross-site destination]
-    expected: FAIL
-
   [cursor sec-fetch-site - Not sent to non-trustworthy cross-site destination]
     expected: FAIL
 
   [list-style-image sec-fetch-site - Not sent to non-trustworthy cross-site destination]
-    expected: FAIL
-
-  [content sec-fetch-mode - Not sent to non-trustworthy same-origin destination]
     expected: FAIL
 
   [cursor sec-fetch-mode - Not sent to non-trustworthy same-origin destination]
@@ -36,16 +24,10 @@
   [list-style-image sec-fetch-mode - Not sent to non-trustworthy same-origin destination]
     expected: FAIL
 
-  [content sec-fetch-mode - Not sent to non-trustworthy same-site destination]
-    expected: FAIL
-
   [cursor sec-fetch-mode - Not sent to non-trustworthy same-site destination]
     expected: FAIL
 
   [list-style-image sec-fetch-mode - Not sent to non-trustworthy same-site destination]
-    expected: FAIL
-
-  [content sec-fetch-mode - Not sent to non-trustworthy cross-site destination]
     expected: FAIL
 
   [cursor sec-fetch-mode - Not sent to non-trustworthy cross-site destination]
@@ -54,16 +36,10 @@
   [list-style-image sec-fetch-mode - Not sent to non-trustworthy cross-site destination]
     expected: FAIL
 
-  [content sec-fetch-dest - Not sent to non-trustworthy same-origin destination]
-    expected: FAIL
-
   [cursor sec-fetch-dest - Not sent to non-trustworthy same-origin destination]
     expected: FAIL
 
   [list-style-image sec-fetch-dest - Not sent to non-trustworthy same-origin destination]
-    expected: FAIL
-
-  [content sec-fetch-dest - Not sent to non-trustworthy same-site destination]
     expected: FAIL
 
   [cursor sec-fetch-dest - Not sent to non-trustworthy same-site destination]
@@ -72,16 +48,10 @@
   [list-style-image sec-fetch-dest - Not sent to non-trustworthy same-site destination]
     expected: FAIL
 
-  [content sec-fetch-dest - Not sent to non-trustworthy cross-site destination]
-    expected: FAIL
-
   [cursor sec-fetch-dest - Not sent to non-trustworthy cross-site destination]
     expected: FAIL
 
   [list-style-image sec-fetch-dest - Not sent to non-trustworthy cross-site destination]
-    expected: FAIL
-
-  [content sec-fetch-user - Not sent to non-trustworthy same-origin destination]
     expected: FAIL
 
   [cursor sec-fetch-user - Not sent to non-trustworthy same-origin destination]
@@ -90,16 +60,10 @@
   [list-style-image sec-fetch-user - Not sent to non-trustworthy same-origin destination]
     expected: FAIL
 
-  [content sec-fetch-user - Not sent to non-trustworthy same-site destination]
-    expected: FAIL
-
   [cursor sec-fetch-user - Not sent to non-trustworthy same-site destination]
     expected: FAIL
 
   [list-style-image sec-fetch-user - Not sent to non-trustworthy same-site destination]
-    expected: FAIL
-
-  [content sec-fetch-user - Not sent to non-trustworthy cross-site destination]
     expected: FAIL
 
   [cursor sec-fetch-user - Not sent to non-trustworthy cross-site destination]
@@ -192,9 +156,6 @@
   [border-image sec-fetch-storage-access - Not sent to non-trustworthy same-origin destination]
     expected: FAIL
 
-  [content sec-fetch-storage-access - Not sent to non-trustworthy same-origin destination]
-    expected: FAIL
-
   [cursor sec-fetch-storage-access - Not sent to non-trustworthy same-origin destination]
     expected: FAIL
 
@@ -204,9 +165,6 @@
   [border-image sec-fetch-storage-access - Not sent to non-trustworthy same-site destination]
     expected: FAIL
 
-  [content sec-fetch-storage-access - Not sent to non-trustworthy same-site destination]
-    expected: FAIL
-
   [cursor sec-fetch-storage-access - Not sent to non-trustworthy same-site destination]
     expected: FAIL
 
@@ -214,9 +172,6 @@
     expected: FAIL
 
   [border-image sec-fetch-storage-access - Not sent to non-trustworthy cross-site destination]
-    expected: FAIL
-
-  [content sec-fetch-storage-access - Not sent to non-trustworthy cross-site destination]
     expected: FAIL
 
   [cursor sec-fetch-storage-access - Not sent to non-trustworthy cross-site destination]

--- a/tests/wpt/meta/html/rendering/replaced-elements/images/input-image-content.html.ini
+++ b/tests/wpt/meta/html/rendering/replaced-elements/images/input-image-content.html.ini
@@ -1,0 +1,2 @@
+[input-image-content.html]
+  expected: FAIL

--- a/tests/wpt/meta/html/semantics/interactive-elements/the-dialog-element/modal-dialog-in-replaced-renderer.html.ini
+++ b/tests/wpt/meta/html/semantics/interactive-elements/the-dialog-element/modal-dialog-in-replaced-renderer.html.ini
@@ -1,2 +1,0 @@
-[modal-dialog-in-replaced-renderer.html]
-  expected: FAIL

--- a/tests/wpt/meta/referrer-policy/css-integration/image/inline-style-with-differentorigin-base-tag.tentative.html.ini
+++ b/tests/wpt/meta/referrer-policy/css-integration/image/inline-style-with-differentorigin-base-tag.tentative.html.ini
@@ -1,4 +1,0 @@
-[inline-style-with-differentorigin-base-tag.tentative.html]
-  [Image from inline styles.]
-    expected: FAIL
-

--- a/tests/wpt/meta/referrer-policy/css-integration/image/inline-style.html.ini
+++ b/tests/wpt/meta/referrer-policy/css-integration/image/inline-style.html.ini
@@ -1,3 +1,0 @@
-[inline-style.html]
-  [Image from inline styles.]
-    expected: FAIL

--- a/tests/wpt/tests/css/css-content/element-replacement-dynamic.html
+++ b/tests/wpt/tests/css/css-content/element-replacement-dynamic.html
@@ -1,10 +1,14 @@
 <!DOCTYPE html>
+<html class="reftest-wait">
 <meta charset="utf-8">
 <title>The content CSS attribute can replace an element's contents dynamically</title>
 <link rel="author" title="Oriol Brufau" href="mailto:obrufau@igalia.com" />
 <link rel="match" href="element-replacement-ref.html" />
 <link rel="help" href="https://drafts.csswg.org/css-content-3/#content-property" />
-<meta name="assert" content"This test checks that the CSS content propertly can replace a normal element's contents when changed dynamically" />
+<meta name="assert" content="This test checks that the CSS content propertly can replace a normal element's contents when changed dynamically" />
+
+<script src="/common/reftest-wait.js"></script>
+<script src="/common/rendering-utils.js"></script>
 
 <style>
 #target {
@@ -18,7 +22,8 @@
 <div id="target">This text should not be visible</div>
 
 <script>
-const target = document.getElementById("target");
-getComputedStyle(target).width;
-target.className = "replaced";
+waitForAtLeastOneFrame().then(() => {
+  document.getElementById("target").className = "replaced";
+  takeScreenshot();
+});
 </script>

--- a/tests/wpt/tests/css/css-content/element-replacement-root-canvas-bg-from-body.html
+++ b/tests/wpt/tests/css/css-content/element-replacement-root-canvas-bg-from-body.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<title>When content CSS attribute can replace a document's root, the HTML body element's background does not become the canvas background</title>
+<link rel="match" href="element-replacement-root-ref.html" />
+<link rel="help" href="https://drafts.csswg.org/css-content-3/#content-property" />
+<link rel="help" href="https://drafts.csswg.org/css-backgrounds-3/#body-background" />
+<meta name="assert" content="When the content CSS attribute replaces a document's root, its contents do not create boxes, so the HTML body element's background can't affect the canvas background." />
+
+<style>
+:root {
+  content: url('resources/rect.svg');
+}
+body {
+  background-color: aquamarine;
+}
+</style>
+
+<p>This text should not be visible</p>

--- a/tests/wpt/tests/css/css-content/element-replacement-root-canvas-bg-ref.html
+++ b/tests/wpt/tests/css/css-content/element-replacement-root-canvas-bg-ref.html
@@ -1,0 +1,13 @@
+<!doctype html>
+<title>Reference for the content CSS attribute can replace a document's root</title>
+
+<style>
+:root {
+    background-color: aquamarine;
+}
+body {
+  margin: 0;
+}
+</style>
+
+<img src="resources/rect.svg" />

--- a/tests/wpt/tests/css/css-content/element-replacement-root-canvas-bg.html
+++ b/tests/wpt/tests/css/css-content/element-replacement-root-canvas-bg.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<title>When content CSS attribute can replace a document's root, its canvas still becomes the canvas background</title>
+<link rel="match" href="element-replacement-root-canvas-bg-ref.html" />
+<link rel="help" href="https://drafts.csswg.org/css-content-3/#content-property" />
+<link rel="help" href="https://drafts.csswg.org/css-backgrounds-3/#root-background" />
+<meta name="assert" content="When the content CSS attribute replaces a document's root, it does not affect the fact that the root's background becomes the canvas background" />
+
+<style>
+:root {
+  content: url('resources/rect.svg');
+  background-color: aquamarine;
+}
+</style>
+
+<p>This text should not be visible</p>

--- a/tests/wpt/tests/css/css-content/element-replacement-root-ref.html
+++ b/tests/wpt/tests/css/css-content/element-replacement-root-ref.html
@@ -1,0 +1,10 @@
+<!doctype html>
+<title>Reference for the content CSS attribute can replace a document's root</title>
+
+<style>
+body {
+  margin: 0;
+}
+</style>
+
+<img src="resources/rect.svg" />

--- a/tests/wpt/tests/css/css-content/element-replacement-root.html
+++ b/tests/wpt/tests/css/css-content/element-replacement-root.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<title>The content CSS attribute can replace a document's root</title>
+<link rel="match" href="element-replacement-root-ref.html" />
+<link rel="help" href="https://drafts.csswg.org/css-content-3/#content-property" />
+<meta name="assert" content="This test checks that the CSS content propertly can replace the contents of a document's root" />
+
+<style>
+:root {
+  content: url('resources/rect.svg');
+}
+</style>
+
+<p>This text should not be visible</p>


### PR DESCRIPTION
Per CSS-CONTENT-3, one of the possible values of the `content` CSS property is `<content-replacement>`, which evaluates to a single `<image>`. This value is also allowed on regular elements, not just on pseudo-elements, and it will make the element into a replaced element representing the given image, discarding its contents.

This patch implements this in `traverse_element`: if the `display` value is not `none` or `contents`, we first check whether the `contents` property should make the element replaced, and if it shouldn't, then we check whether the element itself is replaced or a widget.

Per the spec, an invalid image must be treated as representing a transparent black image with zero natural width and height – in particular, it must not show a broken image icon. We added the method `ReplacedContents::zero_sized_invalid_image` to implement this.

This patch adds support for image URL references, but not for color gradients, which are treated as invalid images. The reason for this is that currently Servo does not support gradients in `ReplacedContentKind`. This is left as a follow-up change.

Testing: Some of the existing `css/css-content/element-replacement*` WPT tests now pass with this patch. We also added some new ones dealing with replacing the document root.

Fixes: #41479