### PR TITLE
malloc_size_of: Track allocations from parsed SVG trees.

### DIFF
--- a/components/malloc_size_of/lib.rs
+++ b/components/malloc_size_of/lib.rs
@@ -54,6 +54,7 @@ use std::rc::Rc;
 use std::sync::{Arc, OnceLock};
 
 use resvg::usvg::fontdb::Source;
+use resvg::usvg::{self, tiny_skia_path};
 use style::properties::ComputedValues;
 use style::values::generics::length::GenericLengthPercentageOrAuto;
 pub use stylo_malloc_size_of::MallocSizeOfOps;
@@ -825,6 +826,183 @@ impl<Static: string_cache::StaticAtomSet> MallocSizeOf for string_cache::Atom<St
     }
 }
 
+impl MallocSizeOf for usvg::Tree {
+    fn size_of(&self, ops: &mut MallocSizeOfOps) -> usize {
+        let root = self.root();
+        let linear_gradients = self.linear_gradients();
+        let radial_gradients = self.radial_gradients();
+        let patterns = self.patterns();
+        let clip_paths = self.clip_paths();
+        let masks = self.masks();
+        let filters = self.filters();
+        let fontdb = self.fontdb();
+
+        let mut sum = 0;
+        sum += root.size_of(ops);
+        sum += linear_gradients
+            .iter()
+            .map(|x| x.size_of(ops))
+            .sum::<usize>();
+        sum += radial_gradients
+            .iter()
+            .map(|x| x.size_of(ops))
+            .sum::<usize>();
+        sum += patterns.iter().map(|x| x.size_of(ops)).sum::<usize>();
+        sum += clip_paths.iter().map(|x| x.size_of(ops)).sum::<usize>();
+        sum += masks.iter().map(|x| x.size_of(ops)).sum::<usize>();
+        sum += filters.iter().map(|x| x.size_of(ops)).sum::<usize>();
+        sum += fontdb.size_of(ops);
+
+        if ops.has_malloc_enclosing_size_of() {
+            unsafe {
+                sum += ops.malloc_enclosing_size_of(root);
+                if !linear_gradients.is_empty() {
+                    sum += ops.malloc_enclosing_size_of(linear_gradients.as_ptr());
+                }
+                if !radial_gradients.is_empty() {
+                    sum += ops.malloc_enclosing_size_of(radial_gradients.as_ptr());
+                }
+                if !patterns.is_empty() {
+                    sum += ops.malloc_enclosing_size_of(patterns.as_ptr());
+                }
+                if !clip_paths.is_empty() {
+                    sum += ops.malloc_enclosing_size_of(clip_paths.as_ptr());
+                }
+                if !masks.is_empty() {
+                    sum += ops.malloc_enclosing_size_of(masks.as_ptr());
+                }
+                if !filters.is_empty() {
+                    sum += ops.malloc_enclosing_size_of(filters.as_ptr());
+                }
+                sum += ops.malloc_enclosing_size_of(fontdb);
+            }
+        }
+        sum
+    }
+}
+
+impl MallocSizeOf for usvg::Group {
+    fn size_of(&self, ops: &mut MallocSizeOfOps) -> usize {
+        let id = self.id();
+        let children = self.children();
+        let filters = self.filters();
+        let clip_path = self.clip_path();
+
+        let mut sum = 0;
+        sum += id.size_of(ops);
+        sum += children.iter().map(|x| x.size_of(ops)).sum::<usize>();
+        sum += filters.iter().map(|x| x.size_of(ops)).sum::<usize>();
+        sum += clip_path.size_of(ops);
+
+        if ops.has_malloc_enclosing_size_of() {
+            unsafe {
+                if !id.is_empty() {
+                    sum += ops.malloc_enclosing_size_of(id.as_ptr());
+                }
+                if let Some(c) = clip_path {
+                    sum += ops.malloc_enclosing_size_of(c)
+                }
+                if !children.is_empty() {
+                    sum += ops.malloc_enclosing_size_of(children.as_ptr());
+                }
+                if !filters.is_empty() {
+                    sum += ops.malloc_enclosing_size_of(filters.as_ptr());
+                }
+            }
+        }
+        sum
+    }
+}
+
+impl MallocSizeOf for usvg::Node {
+    fn size_of(&self, ops: &mut MallocSizeOfOps) -> usize {
+        let id = self.id();
+
+        let mut sum = 0;
+        sum += id.size_of(ops);
+        if ops.has_malloc_enclosing_size_of() {
+            unsafe {
+                if !id.is_empty() {
+                    sum += ops.malloc_enclosing_size_of(id.as_ptr())
+                }
+            }
+        }
+        match self {
+            usvg::Node::Group(group) => {
+                sum += group.size_of(ops);
+                if ops.has_malloc_enclosing_size_of() {
+                    unsafe { sum += ops.malloc_enclosing_size_of(group) }
+                }
+            },
+            usvg::Node::Path(path) => {
+                sum += path.size_of(ops);
+                if ops.has_malloc_enclosing_size_of() {
+                    unsafe { sum += ops.malloc_enclosing_size_of(path) }
+                }
+            },
+            usvg::Node::Image(image) => {
+                sum += image.size_of(ops);
+            },
+            usvg::Node::Text(text) => {
+                sum += text.size_of(ops);
+            },
+        };
+        sum
+    }
+}
+
+impl MallocSizeOf for usvg::Path {
+    fn size_of(&self, ops: &mut MallocSizeOfOps) -> usize {
+        let id = self.id();
+        let data = self.data();
+        let fill = self.fill();
+        let stroke = self.stroke();
+
+        let mut sum = 0;
+        sum += id.size_of(ops);
+        sum += data.size_of(ops);
+        sum += fill.size_of(ops);
+        sum += stroke.size_of(ops);
+        if ops.has_malloc_enclosing_size_of() {
+            unsafe {
+                if !id.is_empty() {
+                    sum += ops.malloc_enclosing_size_of(id.as_ptr());
+                }
+                sum += ops.malloc_enclosing_size_of(data);
+                if let Some(f) = fill {
+                    sum += ops.malloc_enclosing_size_of(f)
+                }
+                if let Some(s) = stroke {
+                    sum += ops.malloc_enclosing_size_of(s)
+                }
+            }
+        }
+        sum
+    }
+}
+impl MallocSizeOf for tiny_skia_path::Path {
+    fn size_of(&self, ops: &mut MallocSizeOfOps) -> usize {
+        let verbs = self.verbs();
+        let points = self.points();
+
+        let mut sum = 0;
+        sum += verbs.iter().map(|x| x.size_of(ops)).sum::<usize>();
+        sum += points.iter().map(|x| x.size_of(ops)).sum::<usize>();
+        if ops.has_malloc_enclosing_size_of() {
+            unsafe {
+                if !points.is_empty() {
+                    sum += ops.malloc_enclosing_size_of(points.as_ptr());
+                }
+                if !verbs.is_empty() {
+                    sum += ops.malloc_enclosing_size_of(verbs.as_ptr());
+                }
+            }
+        }
+
+        sum
+    }
+}
+
 // Placeholder for unique case where internals of Sender cannot be measured.
 // malloc size of is 0 macro complains about type supplied!
 impl<T> MallocSizeOf for crossbeam_channel::Sender<T> {
@@ -887,7 +1065,6 @@ malloc_size_of_is_0!(content_security_policy::sandboxing_directive::SandboxingFl
 malloc_size_of_is_0!(http::StatusCode);
 malloc_size_of_is_0!(keyboard_types::Modifiers);
 malloc_size_of_is_0!(mime::Mime);
-malloc_size_of_is_0!(resvg::usvg::Tree);
 malloc_size_of_is_0!(resvg::usvg::fontdb::ID);
 malloc_size_of_is_0!(resvg::usvg::fontdb::Style);
 malloc_size_of_is_0!(resvg::usvg::fontdb::Weight);

--- a/components/malloc_size_of/lib.rs
+++ b/components/malloc_size_of/lib.rs
@@ -843,8 +843,9 @@ impl MallocSizeOf for usvg::Tree {
             patterns.size_of(ops) +
             clip_paths.size_of(ops) +
             masks.size_of(ops) +
-            filters.size_of(ops) +
-            fontdb.size_of(ops);
+            filters.size_of(ops);
+
+        sum += fontdb.conditional_size_of(ops);
 
         if ops.has_malloc_enclosing_size_of() {
             unsafe {
@@ -867,7 +868,6 @@ impl MallocSizeOf for usvg::Tree {
                 if !filters.is_empty() {
                     sum += ops.malloc_enclosing_size_of(filters.as_ptr());
                 }
-                sum += ops.malloc_enclosing_size_of(fontdb);
             }
         }
         sum

--- a/components/malloc_size_of/lib.rs
+++ b/components/malloc_size_of/lib.rs
@@ -837,21 +837,14 @@ impl MallocSizeOf for usvg::Tree {
         let filters = self.filters();
         let fontdb = self.fontdb();
 
-        let mut sum = 0;
-        sum += root.size_of(ops);
-        sum += linear_gradients
-            .iter()
-            .map(|x| x.size_of(ops))
-            .sum::<usize>();
-        sum += radial_gradients
-            .iter()
-            .map(|x| x.size_of(ops))
-            .sum::<usize>();
-        sum += patterns.iter().map(|x| x.size_of(ops)).sum::<usize>();
-        sum += clip_paths.iter().map(|x| x.size_of(ops)).sum::<usize>();
-        sum += masks.iter().map(|x| x.size_of(ops)).sum::<usize>();
-        sum += filters.iter().map(|x| x.size_of(ops)).sum::<usize>();
-        sum += fontdb.size_of(ops);
+        let mut sum = root.size_of(ops) +
+            linear_gradients.size_of(ops) +
+            radial_gradients.size_of(ops) +
+            patterns.size_of(ops) +
+            clip_paths.size_of(ops) +
+            masks.size_of(ops) +
+            filters.size_of(ops) +
+            fontdb.size_of(ops);
 
         if ops.has_malloc_enclosing_size_of() {
             unsafe {
@@ -888,11 +881,8 @@ impl MallocSizeOf for usvg::Group {
         let filters = self.filters();
         let clip_path = self.clip_path();
 
-        let mut sum = 0;
-        sum += id.size_of(ops);
-        sum += children.iter().map(|x| x.size_of(ops)).sum::<usize>();
-        sum += filters.iter().map(|x| x.size_of(ops)).sum::<usize>();
-        sum += clip_path.size_of(ops);
+        let mut sum =
+            id.size_of(ops) + children.size_of(ops) + filters.size_of(ops) + clip_path.size_of(ops);
 
         if ops.has_malloc_enclosing_size_of() {
             unsafe {
@@ -918,8 +908,7 @@ impl MallocSizeOf for usvg::Node {
     fn size_of(&self, ops: &mut MallocSizeOfOps) -> usize {
         let id = self.id();
 
-        let mut sum = 0;
-        sum += id.size_of(ops);
+        let mut sum = id.size_of(ops);
         if ops.has_malloc_enclosing_size_of() {
             unsafe {
                 if !id.is_empty() {
@@ -958,11 +947,7 @@ impl MallocSizeOf for usvg::Path {
         let fill = self.fill();
         let stroke = self.stroke();
 
-        let mut sum = 0;
-        sum += id.size_of(ops);
-        sum += data.size_of(ops);
-        sum += fill.size_of(ops);
-        sum += stroke.size_of(ops);
+        let mut sum = id.size_of(ops) + data.size_of(ops) + fill.size_of(ops) + stroke.size_of(ops);
         if ops.has_malloc_enclosing_size_of() {
             unsafe {
                 if !id.is_empty() {
@@ -985,9 +970,7 @@ impl MallocSizeOf for tiny_skia_path::Path {
         let verbs = self.verbs();
         let points = self.points();
 
-        let mut sum = 0;
-        sum += verbs.iter().map(|x| x.size_of(ops)).sum::<usize>();
-        sum += points.iter().map(|x| x.size_of(ops)).sum::<usize>();
+        let mut sum = verbs.size_of(ops) + points.size_of(ops);
         if ops.has_malloc_enclosing_size_of() {
             unsafe {
                 if !points.is_empty() {

--- a/components/malloc_size_of/lib.rs
+++ b/components/malloc_size_of/lib.rs
@@ -986,6 +986,28 @@ impl MallocSizeOf for tiny_skia_path::Path {
     }
 }
 
+impl MallocSizeOf for usvg::ClipPath {
+    fn size_of(&self, ops: &mut MallocSizeOfOps) -> usize {
+        let id = self.id();
+        let clip_path = self.clip_path();
+        let root = self.root();
+
+        let mut sum = id.size_of(ops) + clip_path.size_of(ops) + root.size_of(ops);
+        if ops.has_malloc_enclosing_size_of() {
+            unsafe {
+                sum += ops.malloc_enclosing_size_of(root);
+                if !id.is_empty() {
+                    sum += ops.malloc_enclosing_size_of(id.as_ptr());
+                }
+                if let Some(c) = clip_path {
+                    sum += c.size_of(ops)
+                }
+            }
+        }
+        sum
+    }
+}
+
 // Placeholder for unique case where internals of Sender cannot be measured.
 // malloc size of is 0 macro complains about type supplied!
 impl<T> MallocSizeOf for crossbeam_channel::Sender<T> {


### PR DESCRIPTION
Implemented `MallocSizeOf` trait for `usvg::Tree`, `usvg::Node`, `usvg::Group`, `usvg::Path`, `usvg::ClipPath` and  `tiny_skia_path::Path`. 

Testing:
- build servo with `./mach build --features servo_allocator/allocation-tracking`
- run servo with `UNTRACKED_LOG_FILE=untracked ./mach run`
- after the homepage loads, open a tab to about:memory
- press the Measure button
- when the browser is responsive again, close the browser
- run `grep "usvg::parser::<impl usvg::tree::Tree>::from_data" untracked  | wc -l`


```
Before:
grep "usvg::parser::<impl usvg::tree::Tree>::from_data" untracked | wc -l
130

After:
> grep "usvg::parser::<impl usvg::tree::Tree>::from_data" untracked | wc -l
0
``` 

Fixes: https://github.com/servo/servo/issues/41069
