### PR TITLE
feature: Add fling support for mouse wheel events

### DIFF
--- a/components/compositing/Cargo.toml
+++ b/components/compositing/Cargo.toml
@@ -16,6 +16,10 @@ default = []
 tracing = ["dep:tracing"]
 webgpu = ["dep:webgpu"]
 webxr = ["dep:webxr", "dep:webxr-api"]
+# Enable software-based wheel fling/momentum scrolling.
+# This should be enabled on platforms that don't provide native
+# momentum scroll events.
+wheel_fling = []
 
 [lints.clippy]
 unwrap_used = "deny"

--- a/components/compositing/lib.rs
+++ b/components/compositing/lib.rs
@@ -32,6 +32,8 @@ mod screenshot;
 mod touch;
 mod webrender_external_images;
 mod webview_renderer;
+#[cfg(feature = "wheel_fling")]
+mod wheel_fling;
 
 /// Data used to initialize the `Paint` subsystem.
 pub struct InitialPaintState {

--- a/components/compositing/wheel_fling.rs
+++ b/components/compositing/wheel_fling.rs
@@ -1,0 +1,228 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+//! Wheel fling support for platforms that don't provide native fling events (e.g., Linux).
+
+use std::cell::Cell;
+use std::rc::Rc;
+use std::time::Instant;
+
+use base::id::WebViewId;
+use embedder_traits::WheelPhase;
+use euclid::Vector2D;
+use webrender_api::units::{DevicePixel, DevicePoint, DeviceVector2D};
+
+use crate::paint::RepaintReason;
+use crate::painter::Painter;
+use crate::refresh_driver::{BaseRefreshDriver, RefreshDriverObserver};
+use crate::webview_renderer::WebViewRenderer;
+
+/// Factor by which the flinging velocity changes on each tick.
+const FLING_SCALING_FACTOR: f32 = 0.98;
+/// Minimum velocity required to continue flinging (in device pixels per frame).
+const FLING_MIN_VELOCITY: f32 = 1.0;
+/// Maximum velocity when flinging (in device pixels per frame).
+const FLING_MAX_VELOCITY: f32 = 4000.0;
+/// Maximum time (in ms) between the last scroll movement and lifting fingers
+/// for a fling to be triggered.
+const FLING_START_TIMEOUT_MS: u128 = 100;
+
+/// State of the wheel fling handler.
+#[derive(Clone, Copy, Debug, PartialEq)]
+enum WheelFlingState {
+    /// Not currently tracking wheel events or flinging.
+    Idle,
+    /// Accumulating velocity from wheel scroll events.
+    Scrolling {
+        velocity: Vector2D<f32, DevicePixel>,
+        last_point: DevicePoint,
+    },
+    /// Actively flinging with momentum.
+    Flinging {
+        velocity: Vector2D<f32, DevicePixel>,
+        point: DevicePoint,
+    },
+}
+
+/// An action that can be performed during wheel fling animation.
+pub(crate) struct WheelFlingAction {
+    pub delta: DeviceVector2D,
+    pub cursor: DevicePoint,
+}
+
+/// Handler for wheel-based fling/momentum scrolling state.
+pub(crate) struct WheelFlingHandler {
+    webview_id: WebViewId,
+    state: WheelFlingState,
+    observing_frames_for_fling: bool,
+    last_scroll_time: Option<Instant>,
+}
+
+impl WheelFlingHandler {
+    pub(crate) fn new(webview_id: WebViewId) -> Self {
+        Self {
+            webview_id,
+            state: WheelFlingState::Idle,
+            observing_frames_for_fling: false,
+            last_scroll_time: None,
+        }
+    }
+
+    /// Called when a wheel event is received. Returns true if a fling should be started.
+    pub(crate) fn on_wheel_event(
+        &mut self,
+        delta: DeviceVector2D,
+        point: DevicePoint,
+        phase: WheelPhase,
+    ) -> bool {
+        // If we're currently flinging and receive any wheel event, stop the fling first.
+        // This stops the fling when the user starts a new scroll gesture. Note that on most
+        // platforms, simply touching the trackpad without moving doesn't generate a wheel event,
+        // so the fling will only stop once the user starts scrolling (receives Started/Moved).
+        if self.is_flinging() {
+            self.stop_fling();
+        }
+
+        match phase {
+            WheelPhase::Started => {
+                self.state = WheelFlingState::Scrolling {
+                    velocity: Vector2D::new(delta.x, delta.y),
+                    last_point: point,
+                };
+                self.last_scroll_time = Some(Instant::now());
+            },
+            WheelPhase::Moved => {
+                self.last_scroll_time = Some(Instant::now());
+                match self.state {
+                    WheelFlingState::Idle => {
+                        // Started event might have been missed, start tracking now.
+                        self.state = WheelFlingState::Scrolling {
+                            velocity: Vector2D::new(delta.x, delta.y),
+                            last_point: point,
+                        };
+                    },
+                    WheelFlingState::Scrolling {
+                        ref mut velocity,
+                        ref mut last_point,
+                    } => {
+                        // Accumulate velocity with light smoothing
+                        // Use weighted average favoring the new delta for responsiveness.
+                        *velocity = *velocity * 0.3 + Vector2D::new(delta.x, delta.y) * 0.7;
+                        *last_point = point;
+                    },
+                    WheelFlingState::Flinging { .. } => {
+                        // User started scrolling again without a Started event.
+                        // Stop fling and start new scroll tracking
+                        self.observing_frames_for_fling = false;
+                        self.state = WheelFlingState::Scrolling {
+                            velocity: Vector2D::new(delta.x, delta.y),
+                            last_point: point,
+                        };
+                    },
+                }
+            },
+            WheelPhase::Ended => {
+                if let WheelFlingState::Scrolling {
+                    velocity,
+                    last_point,
+                } = self.state
+                {
+                    let elapsed_since_last_scroll = self
+                        .last_scroll_time
+                        .map(|t| t.elapsed().as_millis())
+                        .unwrap_or(u128::MAX);
+
+                    // Don't start a fling if idle for too long before lifting fingers.
+                    if elapsed_since_last_scroll > FLING_START_TIMEOUT_MS {
+                        self.stop_fling();
+                        return false;
+                    }
+
+                    if velocity.length().abs() >= FLING_MIN_VELOCITY {
+                        let velocity = velocity.with_max_length(FLING_MAX_VELOCITY);
+                        self.state = WheelFlingState::Flinging {
+                            velocity,
+                            point: last_point,
+                        };
+                        self.last_scroll_time = None;
+                        return true;
+                    }
+                }
+                // Velocity too low or not scrolling, just stop
+                self.stop_fling();
+            },
+            WheelPhase::Cancelled => {
+                self.stop_fling();
+            },
+        }
+        false
+    }
+
+    /// Called at the start of each frame during fling animation.
+    /// Returns the fling action to apply, or None if not currently flinging.
+    pub(crate) fn notify_new_frame_start(&mut self) -> Option<WheelFlingAction> {
+        let WheelFlingState::Flinging {
+            ref mut velocity,
+            point,
+        } = self.state
+        else {
+            return None;
+        };
+
+        if velocity.length().abs() < FLING_MIN_VELOCITY {
+            self.stop_fling();
+            return None;
+        }
+
+        // Apply decay
+        *velocity *= FLING_SCALING_FACTOR;
+
+        Some(WheelFlingAction {
+            delta: DeviceVector2D::new(velocity.x, velocity.y),
+            cursor: point,
+        })
+    }
+
+    /// Stop any ongoing fling.
+    fn stop_fling(&mut self) {
+        self.state = WheelFlingState::Idle;
+        self.last_scroll_time = None;
+        self.observing_frames_for_fling = false;
+    }
+
+    /// Returns true if currently in fling state.
+    fn is_flinging(&self) -> bool {
+        matches!(self.state, WheelFlingState::Flinging { .. })
+    }
+
+    /// Add a refresh driver observer to continue the fling animation if necessary.
+    pub(crate) fn add_fling_refresh_observer_if_necessary(
+        &mut self,
+        refresh_driver: Rc<BaseRefreshDriver>,
+        repaint_reason: &Cell<RepaintReason>,
+    ) {
+        if self.observing_frames_for_fling || !self.is_flinging() {
+            return;
+        }
+
+        refresh_driver.add_observer(Rc::new(WheelFlingRefreshDriverObserver {
+            webview_id: self.webview_id,
+        }));
+        self.observing_frames_for_fling = true;
+        repaint_reason.set(repaint_reason.get().union(RepaintReason::StartedFlinging));
+    }
+}
+
+/// Observer that drives the wheel fling animation on each frame.
+pub(crate) struct WheelFlingRefreshDriverObserver {
+    pub webview_id: WebViewId,
+}
+
+impl RefreshDriverObserver for WheelFlingRefreshDriverObserver {
+    fn frame_started(&self, painter: &mut Painter) -> bool {
+        painter
+            .webview_renderer_mut(self.webview_id)
+            .is_some_and(WebViewRenderer::update_wheel_fling_at_new_frame_start)
+    }
+}

--- a/components/servo/Cargo.toml
+++ b/components/servo/Cargo.toml
@@ -71,6 +71,10 @@ webxr = [
     "webgl/webxr",
     "script/webxr",
 ]
+# Enable software-based wheel fling/momentum scrolling.
+# This should be enabled on platforms that don't provide native momentum scroll
+# events (e.g., Linux). macOS provides native momentum events, so this is not needed there.
+wheel_fling = ["compositing/wheel_fling"]
 
 [dependencies]
 accesskit = { workspace = true }

--- a/components/shared/embedder/input_events.rs
+++ b/components/shared/embedder/input_events.rs
@@ -285,6 +285,23 @@ pub enum WheelMode {
     DeltaPage = 0x02,
 }
 
+/// Phase of a wheel/trackpad scroll gesture.
+///
+/// This is used to determine the beginning and end of a scroll gesture,
+/// which is useful for implementing momentum scrolling (fling) on platforms
+/// that don't provide native momentum events.
+#[derive(Clone, Copy, Debug, Deserialize, PartialEq, Serialize)]
+pub enum WheelPhase {
+    /// The scroll gesture has started.
+    Started,
+    /// The scroll gesture is in progress.
+    Moved,
+    /// The scroll gesture has ended.
+    Ended,
+    /// The scroll gesture was cancelled.
+    Cancelled,
+}
+
 /// The Wheel event deltas in every direction
 #[derive(Clone, Copy, Debug, Deserialize, PartialEq, Serialize)]
 pub struct WheelDelta {
@@ -302,11 +319,16 @@ pub struct WheelDelta {
 pub struct WheelEvent {
     pub delta: WheelDelta,
     pub point: WebViewPoint,
+    pub phase: WheelPhase,
 }
 
 impl WheelEvent {
-    pub fn new(delta: WheelDelta, point: WebViewPoint) -> Self {
-        WheelEvent { delta, point }
+    pub fn new(delta: WheelDelta, point: WebViewPoint, phase: WheelPhase) -> Self {
+        WheelEvent {
+            delta,
+            point,
+            phase,
+        }
     }
 }
 

--- a/components/webdriver_server/actions.rs
+++ b/components/webdriver_server/actions.rs
@@ -12,7 +12,7 @@ use crossbeam_channel::Select;
 use embedder_traits::{
     InputEvent, KeyboardEvent, MouseButtonAction, MouseButtonEvent, MouseMoveEvent, TouchEvent,
     TouchEventType, TouchId, WebDriverCommandMsg, WebDriverScriptCommand, WebViewPoint, WheelDelta,
-    WheelEvent, WheelMode,
+    WheelEvent, WheelMode, WheelPhase,
 };
 use euclid::Point2D;
 use keyboard_types::webdriver::KeyInputState;
@@ -734,7 +734,8 @@ impl Handler {
                     mode: WheelMode::DeltaPixel,
                 };
                 let point = WebViewPoint::Page(Point2D::new(x as f32, y as f32));
-                let input_event = InputEvent::Wheel(WheelEvent::new(delta, point));
+                let input_event =
+                    InputEvent::Wheel(WheelEvent::new(delta, point, WheelPhase::Moved));
                 if last {
                     self.send_blocking_input_event_to_embedder(input_event);
                 } else {

--- a/ports/servoshell/Cargo.toml
+++ b/ports/servoshell/Cargo.toml
@@ -54,6 +54,7 @@ vello = ["libservo/vello"]
 webgl_backtrace = ["libservo/webgl_backtrace"]
 webgpu = ["libservo/webgpu"]
 webxr = ["libservo/webxr"]
+wheel_fling = ["libservo/wheel_fling"]
 
 [dependencies]
 accesskit = { workspace = true }
@@ -124,6 +125,10 @@ winit = { workspace = true }
 
 [target.'cfg(any(all(target_os = "linux", not(target_env = "ohos")), target_os = "macos"))'.dependencies]
 sig = "1.0"
+
+# Enable wheel_fling on Linux since the OS doesn't provide native momentum scroll events
+[target.'cfg(all(target_os = "linux", not(target_env = "ohos")))'.dependencies]
+libservo = { path = "../../components/servo", features = ["wheel_fling"] }
 
 [target.'cfg(target_os = "windows")'.dependencies]
 libservo = { path = "../../components/servo", features = ["no-wgl"] }

--- a/ports/servoshell/desktop/headed_window.rs
+++ b/ports/servoshell/desktop/headed_window.rs
@@ -25,7 +25,7 @@ use servo::{
     MouseButtonAction, MouseButtonEvent, MouseLeftViewportEvent, MouseMoveEvent, NamedKey,
     OffscreenRenderingContext, PermissionRequest, RenderingContext, ScreenGeometry, Theme,
     TouchEvent, TouchEventType, TouchId, WebRenderDebugOption, WebView, WebViewId, WheelDelta,
-    WheelEvent, WheelMode, WindowRenderingContext, convert_rect_to_css_pixel,
+    WheelEvent, WheelMode, WheelPhase, WindowRenderingContext, convert_rect_to_css_pixel,
 };
 use url::Url;
 use winit::dpi::{LogicalPosition, LogicalSize, PhysicalPosition, PhysicalSize};
@@ -53,6 +53,8 @@ use crate::desktop::gui::Gui;
 use crate::desktop::keyutils::CMD_OR_CONTROL;
 use crate::prefs::ServoShellPreferences;
 use crate::running_app_state::{RunningAppState, UserInterfaceCommand};
+#[cfg(feature = "wheel_fling")]
+use crate::window::SCROLL_FACTOR;
 use crate::window::{
     LINE_HEIGHT, LINE_WIDTH, MIN_WINDOW_INNER_SIZE, PlatformWindow, ServoShellWindow,
     ServoShellWindowId,
@@ -673,7 +675,7 @@ impl HeadedWindow {
                             ));
                         }
                     },
-                    WindowEvent::MouseWheel { delta, .. } => {
+                    WindowEvent::MouseWheel { delta, phase, .. } => {
                         let (delta_x, delta_y, mode) = match delta {
                             MouseScrollDelta::LineDelta(delta_x, delta_y) => (
                                 (delta_x * LINE_WIDTH) as f64,
@@ -681,7 +683,16 @@ impl HeadedWindow {
                                 WheelMode::DeltaPixel,
                             ),
                             MouseScrollDelta::PixelDelta(delta) => {
-                                (delta.x, delta.y, WheelMode::DeltaPixel)
+                                #[cfg(not(feature = "wheel_fling"))]
+                                let scroll_factor = 1.0;
+                                #[cfg(feature = "wheel_fling")]
+                                let scroll_factor = SCROLL_FACTOR;
+
+                                (
+                                    delta.x * scroll_factor,
+                                    delta.y * scroll_factor,
+                                    WheelMode::DeltaPixel,
+                                )
                             },
                         };
 
@@ -693,9 +704,11 @@ impl HeadedWindow {
                             mode,
                         };
                         let point = self.webview_relative_mouse_point.get();
+                        let wheel_phase = winit_phase_to_wheel_phase(phase);
                         webview.notify_input_event(InputEvent::Wheel(WheelEvent::new(
                             delta,
                             point.into(),
+                            wheel_phase,
                         )));
                     },
                     WindowEvent::Touch(touch) => {
@@ -1151,6 +1164,15 @@ fn winit_phase_to_touch_event_type(phase: TouchPhase) -> TouchEventType {
         TouchPhase::Moved => TouchEventType::Move,
         TouchPhase::Ended => TouchEventType::Up,
         TouchPhase::Cancelled => TouchEventType::Cancel,
+    }
+}
+
+fn winit_phase_to_wheel_phase(phase: TouchPhase) -> WheelPhase {
+    match phase {
+        TouchPhase::Started => WheelPhase::Started,
+        TouchPhase::Moved => WheelPhase::Moved,
+        TouchPhase::Ended => WheelPhase::Ended,
+        TouchPhase::Cancelled => WheelPhase::Cancelled,
     }
 }
 

--- a/ports/servoshell/window.rs
+++ b/ports/servoshell/window.rs
@@ -23,6 +23,8 @@ use crate::running_app_state::{RunningAppState, UserInterfaceCommand, WebViewCol
 pub(crate) const LINE_HEIGHT: f32 = 76.0;
 #[cfg_attr(any(target_os = "android", target_env = "ohos"), expect(dead_code))]
 pub(crate) const LINE_WIDTH: f32 = 76.0;
+#[cfg(feature = "wheel_fling")]
+pub(crate) const SCROLL_FACTOR: f64 = 6.0;
 
 /// <https://github.com/web-platform-tests/wpt/blob/9320b1f724632c52929a3fdb11bdaf65eafc7611/webdriver/tests/classic/set_window_rect/set.py#L287-L290>
 /// "A window size of 10x10px shouldn't be supported by any browser."


### PR DESCRIPTION
This add a WheelFlingHandler that manages fling state tied to mouse wheel events. This is gated by the wheel_fling feature that is not part of the default features: some platforms such as MacOS manage their own fling when sending the MouseWheel events.

Tested on Linux, this brings scrolling behavior on par with Firefox and Chromium.

Testing: manual testing
Fixes: https://github.com/servo/servo/issues/41469
