### PR TITLE
layout: Stop splitting inline boxes when they contain block-levels

### DIFF
--- a/components/layout/flow/inline/inline_box.rs
+++ b/components/layout/flow/inline/inline_box.rs
@@ -31,12 +31,6 @@ pub(crate) struct InlineBox {
     pub(super) shared_inline_styles: SharedInlineStyles,
     /// The identifier of this inline box in the containing [`super::InlineFormattingContext`].
     pub(super) identifier: InlineBoxIdentifier,
-    /// Whether or not this is the first instance of an [`InlineBox`] before a possible
-    /// block-in-inline split. When no split occurs, this is always true.
-    pub is_first_split: bool,
-    /// Whether or not this is the last instance of an [`InlineBox`] before a possible
-    /// block-in-inline split. When no split occurs, this is always true.
-    pub is_last_split: bool,
     /// The index of the default font in the [`super::InlineFormattingContext`]'s font metrics store.
     /// This is initialized during IFC shaping.
     pub default_font: Option<FontRef>,
@@ -49,20 +43,7 @@ impl InlineBox {
             shared_inline_styles: info.into(),
             // This will be assigned later, when the box is actually added to the IFC.
             identifier: InlineBoxIdentifier::default(),
-            is_first_split: true,
-            is_last_split: false,
             default_font: None,
-        }
-    }
-
-    pub(crate) fn split_around_block(&self) -> Self {
-        Self {
-            base: LayoutBoxBase::new(self.base.base_fragment_info, self.base.style.clone()),
-            shared_inline_styles: self.shared_inline_styles.clone(),
-            is_first_split: false,
-            is_last_split: false,
-            default_font: self.default_font.clone(),
-            ..*self
         }
     }
 
@@ -228,11 +209,6 @@ pub(super) struct InlineBoxContainerState {
 
     /// The [`PaddingBorderMargin`] of the [`InlineBox`] that this state tracks.
     pub pbm: PaddingBorderMargin,
-
-    /// Whether this is the last fragment of this InlineBox. This may not be the case if
-    /// the InlineBox is split due to an block-in-inline-split and this is not the last of
-    /// that split.
-    pub is_last_fragment: bool,
 }
 
 impl InlineBoxContainerState {
@@ -241,7 +217,6 @@ impl InlineBoxContainerState {
         containing_block: &ContainingBlock,
         layout_context: &LayoutContext,
         parent_container: &InlineContainerState,
-        is_last_fragment: bool,
         font_metrics: Option<&FontMetrics>,
     ) -> Self {
         let style = inline_box.base.style.clone();
@@ -259,7 +234,6 @@ impl InlineBoxContainerState {
             identifier: inline_box.identifier,
             base_fragment_info: inline_box.base.base_fragment_info,
             pbm,
-            is_last_fragment,
         }
     }
 

--- a/components/layout/flow/inline/mod.rs
+++ b/components/layout/flow/inline/mod.rs
@@ -117,16 +117,20 @@ use crate::cell::ArcRefCell;
 use crate::context::LayoutContext;
 use crate::dom_traversal::NodeAndStyleInfo;
 use crate::flow::float::{FloatBox, SequentialLayoutState};
-use crate::flow::{CollapsibleWithParentStartMargin, FloatSide};
+use crate::flow::{
+    BlockContainer, CollapsibleWithParentStartMargin, FloatSide, PlacementState,
+    layout_in_flow_non_replaced_block_level_same_formatting_context,
+};
 use crate::formatting_contexts::{Baselines, IndependentFormattingContext};
 use crate::fragment_tree::{
-    BoxFragment, CollapsedBlockMargins, CollapsedMargin, Fragment, FragmentFlags,
-    PositioningFragment,
+    BoxFragment, CollapsedMargin, Fragment, FragmentFlags, PositioningFragment,
 };
 use crate::geom::{LogicalRect, LogicalSides1D, LogicalVec2, ToLogical};
 use crate::layout_box_base::LayoutBoxBase;
 use crate::positioned::{AbsolutelyPositionedBox, PositioningContext};
-use crate::sizing::{ComputeInlineContentSizes, ContentSizes, InlineContentSizesResult};
+use crate::sizing::{
+    ComputeInlineContentSizes, ContentSizes, InlineContentSizesResult, outer_inline,
+};
 use crate::style_ext::{ComputedValuesExt, PaddingBorderMargin};
 use crate::{ConstraintSpace, ContainingBlock, IndefiniteContainingBlock, SharedStyle};
 
@@ -188,6 +192,69 @@ impl From<&NodeAndStyleInfo<'_>> for SharedInlineStyles {
     }
 }
 
+/// Each sequence of block-level boxes that participate in an inline formatting context
+/// (because their parent is an inline box) gets wrapped inside an [`AnonymousBlockBox`].
+/// This way we don't have to deal with the block-levels directly.
+#[derive(Debug, MallocSizeOf)]
+pub(crate) struct AnonymousBlockBox {
+    base: LayoutBoxBase,
+    contents: BlockContainer,
+}
+
+impl AnonymousBlockBox {
+    fn layout_into_line_items(&self, layout: &mut InlineFormattingContextLayout) {
+        layout.process_soft_wrap_opportunity();
+        layout.commit_current_segment_to_line();
+        layout.process_line_break(true);
+        layout.current_line.for_block_level = true;
+
+        let fragment = layout
+            .positioning_context
+            .layout_maybe_position_relative_fragment(
+                layout.layout_context,
+                layout.placement_state.containing_block,
+                &self.base,
+                |positioning_context| {
+                    layout_in_flow_non_replaced_block_level_same_formatting_context(
+                        layout.layout_context,
+                        positioning_context,
+                        layout.placement_state.containing_block,
+                        &self.base,
+                        &self.contents,
+                        layout.sequential_layout_state.as_deref_mut(),
+                        Some(CollapsibleWithParentStartMargin(
+                            layout
+                                .placement_state
+                                .next_in_flow_margin_collapses_with_parent_start_margin,
+                        )),
+                        // This doesn't matter, because the anonymous block doesn't stretch in the
+                        // block axis. However, it's not clear what to do for the block-levels inside,
+                        // see <https://github.com/w3c/csswg-drafts/issues/13260>
+                        LogicalSides1D::new(false, false),
+                    )
+                },
+            );
+
+        let mut fragment = Fragment::Box(ArcRefCell::new(fragment));
+        layout.placement_state.place_fragment_and_update_baseline(
+            &mut fragment,
+            layout.sequential_layout_state.as_deref_mut(),
+        );
+
+        let Fragment::Box(fragment) = fragment else {
+            unreachable!("The fragment should still be a Fragment::Box()");
+        };
+        layout.push_line_item_to_unbreakable_segment(LineItem::AnonymousBlockBox(
+            layout.current_inline_box_identifier(),
+            fragment,
+        ));
+
+        layout.commit_current_segment_to_line();
+        layout.process_line_break(true);
+        layout.current_line.for_block_level = false;
+    }
+}
+
 #[derive(Debug, MallocSizeOf)]
 pub(crate) enum InlineItem {
     StartInlineBox(ArcRefCell<InlineBox>),
@@ -203,6 +270,7 @@ pub(crate) enum InlineItem {
         usize, /* offset_in_text */
         Level, /* bidi_level */
     ),
+    AnonymousBlock(ArcRefCell<AnonymousBlockBox>),
 }
 
 impl InlineItem {
@@ -231,6 +299,11 @@ impl InlineItem {
             InlineItem::Atomic(atomic, ..) => {
                 atomic.borrow_mut().repair_style(context, node, new_style)
             },
+            InlineItem::AnonymousBlock(block_box) => {
+                let mut block_box = block_box.borrow_mut();
+                block_box.base.repair_style(new_style);
+                block_box.contents.repair_style(node, new_style);
+            },
         }
     }
 
@@ -247,6 +320,7 @@ impl InlineItem {
             InlineItem::Atomic(independent_formatting_context, ..) => {
                 callback(&independent_formatting_context.borrow().base)
             },
+            InlineItem::AnonymousBlock(block_box) => callback(&block_box.borrow().base),
         }
     }
 
@@ -265,6 +339,7 @@ impl InlineItem {
             InlineItem::Atomic(independent_formatting_context, ..) => {
                 callback(&mut independent_formatting_context.borrow_mut().base)
             },
+            InlineItem::AnonymousBlock(block_box) => callback(&mut block_box.borrow_mut().base),
         }
     }
 }
@@ -311,6 +386,9 @@ struct LineUnderConstruction {
     /// The LineItems for the current line under construction that have already
     /// been committed to this line.
     line_items: Vec<LineItem>,
+
+    /// Whether the current line is for a block-level box.
+    for_block_level: bool,
 }
 
 impl LineUnderConstruction {
@@ -324,13 +402,7 @@ impl LineUnderConstruction {
             has_floats_waiting_to_be_placed: false,
             placement_among_floats: OnceCell::new(),
             line_items: Vec::new(),
-        }
-    }
-
-    fn line_block_start_considering_placement_among_floats(&self) -> Au {
-        match self.placement_among_floats.get() {
-            Some(placement_among_floats) => placement_among_floats.start_corner.block,
-            None => self.start_position.block,
+            for_block_level: false,
         }
     }
 
@@ -633,7 +705,7 @@ pub(super) struct InlineContainerState {
 
 pub(super) struct InlineFormattingContextLayout<'layout_data> {
     positioning_context: &'layout_data mut PositioningContext,
-    containing_block: &'layout_data ContainingBlock<'layout_data>,
+    placement_state: PlacementState<'layout_data>,
     sequential_layout_state: Option<&'layout_data mut SequentialLayoutState>,
     layout_context: &'layout_data LayoutContext<'layout_data>,
 
@@ -703,10 +775,6 @@ pub(super) struct InlineFormattingContextLayout<'layout_data> {
     /// is encountered.
     pub have_deferred_soft_wrap_opportunity: bool,
 
-    /// Whether or not this InlineFormattingContext contains line boxes, excluding
-    /// [phantom line boxes](https://drafts.csswg.org/css-inline-3/#phantom-line-box).
-    has_line_boxes: bool,
-
     /// Whether or not the layout of this InlineFormattingContext depends on the block size
     /// of its container for the purposes of flexbox layout.
     depends_on_block_constraints: bool,
@@ -722,11 +790,6 @@ pub(super) struct InlineFormattingContextLayout<'layout_data> {
     /// by the boundary between two characters, the text-wrap-mode property of their nearest
     /// common ancestor is used.
     text_wrap_mode: TextWrapMode,
-
-    /// The offset of the first and last baselines in the inline formatting context that we
-    /// are laying out. This is used to propagate baselines to the ancestors of
-    /// `display: inline-block` elements and table content.
-    baselines: Baselines,
 }
 
 impl InlineFormattingContextLayout<'_> {
@@ -749,10 +812,17 @@ impl InlineFormattingContextLayout<'_> {
             .max(&self.current_line.max_block_size)
     }
 
+    fn current_line_block_start_considering_placement_among_floats(&self) -> Au {
+        self.current_line.placement_among_floats.get().map_or(
+            self.current_line.start_position.block,
+            |placement_among_floats| placement_among_floats.start_corner.block,
+        )
+    }
+
     fn propagate_current_nesting_level_white_space_style(&mut self) {
         let style = match self.inline_box_state_stack.last() {
             Some(inline_box_state) => &inline_box_state.base.style,
-            None => self.containing_block.style,
+            None => self.placement_state.containing_block.style,
         };
         let style_text = style.get_inherited_text();
         self.white_space_collapse = style_text.white_space_collapse;
@@ -771,12 +841,12 @@ impl InlineFormattingContextLayout<'_> {
     /// Start laying out a particular [`InlineBox`] into line items. This will push
     /// a new [`InlineBoxContainerState`] onto [`Self::inline_box_state_stack`].
     fn start_inline_box(&mut self, inline_box: &InlineBox) {
+        let containing_block = self.containing_block();
         let inline_box_state = InlineBoxContainerState::new(
             inline_box,
-            self.containing_block,
+            containing_block,
             self.layout_context,
             self.current_inline_container_state(),
-            inline_box.is_last_split,
             inline_box.default_font.as_ref().map(|font| &font.metrics),
         );
 
@@ -784,7 +854,7 @@ impl InlineFormattingContextLayout<'_> {
             .base
             .style
             .depends_on_block_constraints_due_to_relative_positioning(
-                self.containing_block.style.writing_mode,
+                containing_block.style.writing_mode,
             );
 
         // If we are starting a `<br>` element prepare to clear after its deferred linebreak has been
@@ -799,26 +869,24 @@ impl InlineFormattingContextLayout<'_> {
         {
             self.deferred_br_clear = Clear::from_style_and_container_writing_mode(
                 &inline_box_state.base.style,
-                self.containing_block.style.writing_mode,
+                self.containing_block().style.writing_mode,
             );
         }
 
-        if inline_box.is_first_split {
-            let padding = inline_box_state.pbm.padding.inline_start;
-            let border = inline_box_state.pbm.border.inline_start;
-            let margin = inline_box_state.pbm.margin.inline_start.auto_is(Au::zero);
-            // We can't just check if the sum is zero because the margin can be negative,
-            // we need to check the values separately.
-            if !padding.is_zero() || !border.is_zero() || !margin.is_zero() {
-                self.current_line_segment.has_inline_pbm = true;
-            }
-            self.current_line_segment.inline_size += padding + border + margin;
-            self.current_line_segment
-                .line_items
-                .push(LineItem::InlineStartBoxPaddingBorderMargin(
-                    inline_box.identifier,
-                ));
+        let padding = inline_box_state.pbm.padding.inline_start;
+        let border = inline_box_state.pbm.border.inline_start;
+        let margin = inline_box_state.pbm.margin.inline_start.auto_is(Au::zero);
+        // We can't just check if the sum is zero because the margin can be negative,
+        // we need to check the values separately.
+        if !padding.is_zero() || !border.is_zero() || !margin.is_zero() {
+            self.current_line_segment.has_inline_pbm = true;
         }
+        self.current_line_segment.inline_size += padding + border + margin;
+        self.current_line_segment
+            .line_items
+            .push(LineItem::InlineStartBoxPaddingBorderMargin(
+                inline_box.identifier,
+            ));
 
         let inline_box_state = Rc::new(inline_box_state);
 
@@ -853,22 +921,20 @@ impl InlineFormattingContextLayout<'_> {
             self.propagate_current_nesting_level_white_space_style();
         }
 
-        if inline_box_state.is_last_fragment {
-            let padding = inline_box_state.pbm.padding.inline_end;
-            let border = inline_box_state.pbm.border.inline_end;
-            let margin = inline_box_state.pbm.margin.inline_end.auto_is(Au::zero);
-            // We can't just check if the sum is zero because the margin can be negative,
-            // we need to check the values separately.
-            if !padding.is_zero() || !border.is_zero() || !margin.is_zero() {
-                self.current_line_segment.has_inline_pbm = true;
-            }
-            self.current_line_segment.inline_size += padding + border + margin;
-            self.current_line_segment
-                .line_items
-                .push(LineItem::InlineEndBoxPaddingBorderMargin(
-                    inline_box_state.identifier,
-                ))
+        let padding = inline_box_state.pbm.padding.inline_end;
+        let border = inline_box_state.pbm.border.inline_end;
+        let margin = inline_box_state.pbm.margin.inline_end.auto_is(Au::zero);
+        // We can't just check if the sum is zero because the margin can be negative,
+        // we need to check the values separately.
+        if !padding.is_zero() || !border.is_zero() || !margin.is_zero() {
+            self.current_line_segment.has_inline_pbm = true;
         }
+        self.current_line_segment.inline_size += padding + border + margin;
+        self.current_line_segment
+            .line_items
+            .push(LineItem::InlineEndBoxPaddingBorderMargin(
+                inline_box_state.identifier,
+            ))
     }
 
     fn finish_last_line(&mut self) {
@@ -899,10 +965,6 @@ impl InlineFormattingContextLayout<'_> {
                 last_line_or_forced_line_break,
             );
 
-        let block_start_position = self
-            .current_line
-            .line_block_start_considering_placement_among_floats();
-
         // https://drafts.csswg.org/css-inline-3/#invisible-line-boxes
         // > Line boxes that contain no text, no preserved white space, no inline boxes with non-zero
         // > inline-axis margins, padding, or borders, and no other in-flow content (such as atomic
@@ -912,6 +974,13 @@ impl InlineFormattingContextLayout<'_> {
         // > line box and its in-flow content must be treated as not existing for any other layout or
         // > rendering purpose.
         let is_phantom_line = !self.current_line.has_content && !self.current_line.has_inline_pbm;
+        if !is_phantom_line {
+            self.current_line.start_position.block += self.placement_state.current_margin.solve();
+            self.placement_state.current_margin = CollapsedMargin::zero();
+        }
+        let block_start_position =
+            self.current_line_block_start_considering_placement_among_floats();
+
         let effective_block_advance = if is_phantom_line {
             LineBlockSizes::zero()
         } else {
@@ -919,24 +988,29 @@ impl InlineFormattingContextLayout<'_> {
         };
 
         let resolved_block_advance = effective_block_advance.resolve();
-        let mut block_end_position = block_start_position + resolved_block_advance;
-        if let Some(sequential_layout_state) = self.sequential_layout_state.as_mut() {
-            // This amount includes both the block size of the line and any extra space
-            // added to move the line down in order to avoid overlapping floats.
-            let increment = block_end_position - self.current_line.start_position.block;
-            sequential_layout_state.advance_block_position(increment);
+        let block_end_position = if self.current_line.for_block_level {
+            self.placement_state.current_block_direction_position
+        } else {
+            let mut block_end_position = block_start_position + resolved_block_advance;
+            if let Some(sequential_layout_state) = self.sequential_layout_state.as_mut() {
+                // This amount includes both the block size of the line and any extra space
+                // added to move the line down in order to avoid overlapping floats.
+                let increment = block_end_position - self.current_line.start_position.block;
+                sequential_layout_state.advance_block_position(increment);
 
-            // This newline may have been triggered by a `<br>` with clearance, in which case we
-            // want to make sure that we make space not only for the current line, but any clearance
-            // from floats.
-            if let Some(clearance) = sequential_layout_state
-                .calculate_clearance(self.deferred_br_clear, &CollapsedMargin::zero())
-            {
-                sequential_layout_state.advance_block_position(clearance);
-                block_end_position += clearance;
-            };
-            self.deferred_br_clear = Clear::None;
-        }
+                // This newline may have been triggered by a `<br>` with clearance, in which case we
+                // want to make sure that we make space not only for the current line, but any clearance
+                // from floats.
+                if let Some(clearance) = sequential_layout_state
+                    .calculate_clearance(self.deferred_br_clear, &CollapsedMargin::zero())
+                {
+                    sequential_layout_state.advance_block_position(clearance);
+                    block_end_position += clearance;
+                };
+                self.deferred_br_clear = Clear::None;
+            }
+            block_end_position
+        };
 
         // Set up the new line now that we no longer need the old one.
         let mut line_to_layout = std::mem::replace(
@@ -946,6 +1020,9 @@ impl InlineFormattingContextLayout<'_> {
                 block: block_end_position,
             }),
         );
+        if !line_to_layout.for_block_level {
+            self.placement_state.current_block_direction_position = block_end_position;
+        }
 
         if line_to_layout.has_floats_waiting_to_be_placed {
             place_pending_floats(self, &mut line_to_layout.line_items);
@@ -969,9 +1046,13 @@ impl InlineFormattingContextLayout<'_> {
 
         if !is_phantom_line {
             let baseline = baseline_offset + block_start_position;
-            self.baselines.first.get_or_insert(baseline);
-            self.baselines.last = Some(baseline);
-            self.has_line_boxes = true;
+            self.placement_state
+                .inflow_baselines
+                .first
+                .get_or_insert(baseline);
+            self.placement_state.inflow_baselines.last = Some(baseline);
+            self.placement_state
+                .next_in_flow_margin_collapses_with_parent_start_margin = false;
         }
 
         // If the line doesn't have any fragments, we don't need to add a containing fragment for it.
@@ -990,21 +1071,22 @@ impl InlineFormattingContextLayout<'_> {
         };
 
         let logical_origin_in_physical_coordinates =
-            start_corner.to_physical_vector(self.containing_block.style.writing_mode);
+            start_corner.to_physical_vector(self.containing_block().style.writing_mode);
         self.positioning_context
             .adjust_static_position_of_hoisted_fragments_with_offset(
                 &logical_origin_in_physical_coordinates,
                 start_positioning_context_length,
             );
 
+        let containing_block = self.containing_block();
         let physical_line_rect = LogicalRect {
             start_corner,
             size: LogicalVec2 {
-                inline: self.containing_block.size.inline,
+                inline: containing_block.size.inline,
                 block: effective_block_advance.resolve(),
             },
         }
-        .as_physical(Some(self.containing_block));
+        .as_physical(Some(containing_block));
         self.fragments
             .push(Fragment::Positioning(PositioningFragment::new_anonymous(
                 self.root_nesting_level.style.clone(),
@@ -1027,7 +1109,8 @@ impl InlineFormattingContextLayout<'_> {
             Center,
             End,
         }
-        let style = self.containing_block.style;
+        let containing_block = self.containing_block();
+        let style = containing_block.style;
         let mut text_align_keyword = style.clone_text_align();
 
         if last_line_or_forced_line_break {
@@ -1071,7 +1154,7 @@ impl InlineFormattingContextLayout<'_> {
                 placement_among_floats.start_corner.inline,
                 placement_among_floats.size.inline,
             ),
-            None => (Au::zero(), self.containing_block.size.inline),
+            None => (Au::zero(), containing_block.size.inline),
         };
 
         // Properly handling text-indent requires that we do not align the text
@@ -1094,7 +1177,7 @@ impl InlineFormattingContextLayout<'_> {
         // Calculate the justification adjustment. This is simply the remaining space on the line,
         // dividided by the number of justficiation opportunities that we recorded when building
         // the line.
-        let text_justify = self.containing_block.style.clone_text_justify();
+        let text_justify = containing_block.style.clone_text_justify();
         let justification_adjustment = match (text_align_keyword, text_justify) {
             // `text-justify: none` should disable text justification.
             // TODO: Handle more `text-justify` values.
@@ -1129,7 +1212,7 @@ impl InlineFormattingContextLayout<'_> {
             state.current_containing_block_offset();
         state.place_float_fragment(
             fragment,
-            self.containing_block,
+            self.placement_state.containing_block,
             CollapsedMargin::zero(),
             block_offset_from_containining_block_top,
         );
@@ -1148,16 +1231,17 @@ impl InlineFormattingContextLayout<'_> {
         float_item: &mut FloatLineItem,
         line_inline_size_without_trailing_whitespace: Au,
     ) {
+        let containing_block = self.containing_block();
         let mut float_fragment = float_item.fragment.borrow_mut();
         let logical_margin_rect_size = float_fragment
             .margin_rect()
             .size
-            .to_logical(self.containing_block.style.writing_mode);
+            .to_logical(containing_block.style.writing_mode);
         let inline_size = logical_margin_rect_size.inline.max(Au::zero());
 
         let available_inline_size = match self.current_line.placement_among_floats.get() {
             Some(placement_among_floats) => placement_among_floats.size.inline,
-            None => self.containing_block.size.inline,
+            None => containing_block.size.inline,
         } - line_inline_size_without_trailing_whitespace;
 
         // If this float doesn't fit on the current line or a previous float didn't fit on
@@ -1207,9 +1291,7 @@ impl InlineFormattingContextLayout<'_> {
             block: sequential_layout_state.current_containing_block_offset(),
         };
 
-        let ceiling = self
-            .current_line
-            .line_block_start_considering_placement_among_floats();
+        let ceiling = self.current_line_block_start_considering_placement_among_floats();
         let mut placement = PlacementAmongFloats::new(
             &sequential_layout_state.floats,
             ceiling + ifc_offset_in_float_container.block,
@@ -1235,6 +1317,7 @@ impl InlineFormattingContextLayout<'_> {
         &mut self,
         potential_line_size: &LogicalVec2<Au>,
     ) -> bool {
+        let containing_block = self.containing_block();
         let available_line_space = if self.sequential_layout_state.is_some() {
             self.current_line
                 .placement_among_floats
@@ -1242,7 +1325,7 @@ impl InlineFormattingContextLayout<'_> {
                 .size
         } else {
             LogicalVec2 {
-                inline: self.containing_block.size.inline,
+                inline: containing_block.size.inline,
                 block: MAX_AU,
             }
         };
@@ -1275,7 +1358,7 @@ impl InlineFormattingContextLayout<'_> {
 
         // If the potential line is larger than the containing block we do not even need to consider
         // floats. We definitely have to do a linebreak.
-        if potential_line_size.inline > self.containing_block.size.inline {
+        if potential_line_size.inline > containing_block.size.inline {
             return true;
         }
 
@@ -1287,8 +1370,7 @@ impl InlineFormattingContextLayout<'_> {
             assert!(self.sequential_layout_state.is_some());
             let new_placement = self.place_line_among_floats(potential_line_size);
             if new_placement.start_corner.block !=
-                self.current_line
-                    .line_block_start_considering_placement_among_floats()
+                self.current_line_block_start_considering_placement_among_floats()
             {
                 return true;
             } else {
@@ -1584,6 +1666,11 @@ impl InlineFormattingContextLayout<'_> {
 
         self.current_line_segment.reset();
     }
+
+    #[inline]
+    fn containing_block(&self) -> &ContainingBlock<'_> {
+        self.placement_state.containing_block
+    }
 }
 
 bitflags! {
@@ -1667,7 +1754,8 @@ impl InlineFormattingContext {
                 },
                 InlineItem::OutOfFlowAbsolutelyPositionedBox(..) |
                 InlineItem::OutOfFlowFloatBox(_) |
-                InlineItem::EndInlineBox => {},
+                InlineItem::EndInlineBox |
+                InlineItem::AnonymousBlock { .. } => {},
             }
         }
 
@@ -1741,10 +1829,12 @@ impl InlineFormattingContext {
             inline_container_state_flags
                 .insert(InlineContainerStateFlags::IS_SINGLE_LINE_TEXT_INPUT);
         }
+        let placement_state =
+            PlacementState::new(collapsible_with_parent_start_margin, containing_block);
 
         let mut layout = InlineFormattingContextLayout {
             positioning_context,
-            containing_block,
+            placement_state,
             sequential_layout_state,
             layout_context,
             ifc: self,
@@ -1765,11 +1855,9 @@ impl InlineFormattingContext {
             linebreak_before_new_content: false,
             deferred_br_clear: Clear::None,
             have_deferred_soft_wrap_opportunity: false,
-            has_line_boxes: false,
             depends_on_block_constraints: false,
             white_space_collapse: style_text.white_space_collapse,
             text_wrap_mode: style_text.text_wrap_mode,
-            baselines: Baselines::default(),
         };
 
         // FIXME(pcwalton): This assumes that margins never collapse through inline formatting
@@ -1812,22 +1900,21 @@ impl InlineFormattingContext {
                 InlineItem::OutOfFlowFloatBox(float_box) => {
                     float_box.borrow().layout_into_line_items(&mut layout);
                 },
+                InlineItem::AnonymousBlock(block_box) => {
+                    block_box.borrow().layout_into_line_items(&mut layout);
+                },
             }
         }
 
         layout.finish_last_line();
-
-        let mut collapsible_margins_in_children = CollapsedBlockMargins::zero();
-        let content_block_size = layout.current_line.start_position.block;
-        collapsible_margins_in_children.collapsed_through = !layout.has_line_boxes &&
-            content_block_size.is_zero() &&
-            collapsible_with_parent_start_margin.0;
+        let (content_block_size, collapsible_margins_in_children, baselines) =
+            layout.placement_state.finish();
 
         CacheableLayoutResult {
             fragments: layout.fragments,
             content_block_size,
             collapsible_margins_in_children,
-            baselines: layout.baselines,
+            baselines,
             depends_on_block_constraints: layout.depends_on_block_constraints,
             content_inline_size_for_table: None,
             specific_layout_info: None,
@@ -2044,7 +2131,7 @@ impl IndependentFormattingContext {
         } = self.layout_float_or_atomic_inline(
             layout.layout_context,
             &mut child_positioning_context,
-            layout.containing_block,
+            layout.containing_block(),
         );
 
         // If this Fragment's layout depends on the block size of the containing block,
@@ -2054,7 +2141,7 @@ impl IndependentFormattingContext {
         );
 
         // Offset the content rectangle by the physical offset of the padding, border, and margin.
-        let container_writing_mode = layout.containing_block.style.writing_mode;
+        let container_writing_mode = layout.containing_block().style.writing_mode;
         let pbm_physical_offset = pbm_sums
             .start_offset()
             .to_physical_size(container_writing_mode);
@@ -2178,7 +2265,7 @@ impl FloatBox {
         let fragment = ArcRefCell::new(self.layout(
             layout.layout_context,
             layout.positioning_context,
-            layout.containing_block,
+            layout.placement_state.containing_block,
         ));
 
         self.contents
@@ -2341,12 +2428,10 @@ impl<'layout_data> ContentSizesComputation<'layout_data> {
             self.process_item(&inline_item.borrow(), inline_formatting_context);
         }
         self.forced_line_break();
-        self.clear_floats(Clear::Both);
+        self.flush_floats();
 
         InlineContentSizesResult {
-            sizes: self
-                .paragraph
-                .union(&self.cleared_floats.start.union(&self.cleared_floats.end)),
+            sizes: self.paragraph,
             depends_on_block_constraints: self.depends_on_block_constraints,
         }
     }
@@ -2377,14 +2462,8 @@ impl<'layout_data> ContentSizesComputation<'layout_data> {
                     .auto_is(Au::zero);
 
                 let pbm = margin + padding + border;
-                if inline_box.is_first_split {
-                    self.add_inline_size(pbm.inline_start);
-                }
-                if inline_box.is_last_split {
-                    self.ending_inline_pbm_stack.push(pbm.inline_end);
-                } else {
-                    self.ending_inline_pbm_stack.push(Au::zero());
-                }
+                self.add_inline_size(pbm.inline_start);
+                self.ending_inline_pbm_stack.push(pbm.inline_end);
             },
             InlineItem::EndInlineBox => {
                 let length = self.ending_inline_pbm_stack.pop().unwrap_or_else(Au::zero);
@@ -2489,6 +2568,32 @@ impl<'layout_data> ContentSizesComputation<'layout_data> {
                     FloatSide::InlineEnd => self.uncleared_floats.end.union_assign(&sizes),
                 }
             },
+            InlineItem::AnonymousBlock(block) => {
+                self.forced_line_break();
+                self.flush_floats();
+                let borrowed_block = block.borrow();
+                let AnonymousBlockBox {
+                    ref base,
+                    ref contents,
+                    ..
+                } = *borrowed_block;
+                let inline_content_sizes_result = outer_inline(
+                    base,
+                    &contents.layout_style(base),
+                    &self.constraint_space.into(),
+                    &LogicalVec2::zero(),
+                    false,    /* auto_block_size_stretches_to_containing_block */
+                    false,    /* is_replaced */
+                    false,    /* establishes_containing_block */
+                    |_| None, /* get_preferred_aspect_ratio */
+                    |constraint_space| {
+                        base.inline_content_sizes(self.layout_context, constraint_space, contents)
+                    },
+                    |_aspect_ratio| None,
+                );
+                self.current_line = inline_content_sizes_result.sizes;
+                self.forced_line_break();
+            },
             InlineItem::OutOfFlowAbsolutelyPositionedBox(..) => {},
         }
     }
@@ -2557,6 +2662,14 @@ impl<'layout_data> ContentSizesComputation<'layout_data> {
             },
             Clear::None => {},
         }
+    }
+
+    fn flush_floats(&mut self) {
+        self.clear_floats(Clear::Both);
+        let start_floats = mem::take(&mut self.cleared_floats.start);
+        let end_floats = mem::take(&mut self.cleared_floats.end);
+        self.paragraph.union_assign(&start_floats);
+        self.paragraph.union_assign(&end_floats);
     }
 
     /// Compute the [`ContentSizes`] of the given [`InlineFormattingContext`].

--- a/components/layout/flow/mod.rs
+++ b/components/layout/flow/mod.rs
@@ -916,7 +916,7 @@ impl BlockLevelBox {
 /// - <https://drafts.csswg.org/css2/visudet.html#blockwidth>
 /// - <https://drafts.csswg.org/css2/visudet.html#normal-block>
 #[allow(clippy::too_many_arguments)]
-fn layout_in_flow_non_replaced_block_level_same_formatting_context(
+pub(crate) fn layout_in_flow_non_replaced_block_level_same_formatting_context(
     layout_context: &LayoutContext,
     positioning_context: &mut PositioningContext,
     containing_block: &ContainingBlock,

--- a/components/layout/flow/root.rs
+++ b/components/layout/flow/root.rs
@@ -103,11 +103,11 @@ impl BoxTree {
             // See https://github.com/w3c/csswg-drafts/issues/12643
             let body_layout_data = body.inner_layout_data()?;
             let mut body_box = body_layout_data.self_box.borrow_mut();
-            body_box.as_mut()?.with_base_mut_fold(None, |accum, base| {
+            body_box.as_mut()?.with_base_mut(|base| {
                 base.base_fragment_info
                     .flags
                     .insert(FragmentFlags::PROPAGATED_OVERFLOW_TO_VIEWPORT);
-                accum.or_else(|| Some(AxesOverflow::from(&*base.style)))
+                AxesOverflow::from(&*base.style)
             })
         };
 
@@ -362,8 +362,7 @@ impl<'dom> IncrementalBoxTreeUpdate<'dom> {
                     },
                     _ => return None,
                 },
-                LayoutBox::InlineLevel(inline_level_items) => {
-                    let inline_level_box = inline_level_items.first()?;
+                LayoutBox::InlineLevel(inline_level_box) => {
                     let InlineItem::OutOfFlowAbsolutelyPositionedBox(_, text_offset_index) =
                         &*inline_level_box.borrow()
                     else {

--- a/components/layout/query.rs
+++ b/components/layout/query.rs
@@ -171,7 +171,7 @@ pub fn process_current_css_zoom_query(node: ServoLayoutNode<'_>) -> f32 {
         return 1.0;
     };
     layout_box
-        .with_first_base(|base| base.style.effective_zoom.value())
+        .with_base(|base| base.style.effective_zoom.value())
         .unwrap_or(1.0)
 }
 
@@ -781,7 +781,7 @@ pub(crate) fn process_scroll_container_query(
     let layout_box = layout_box.as_ref()?;
 
     let (style, flags) =
-        layout_box.with_first_base(|base| (base.style.clone(), base.base_fragment_info.flags))?;
+        layout_box.with_base(|base| (base.style.clone(), base.base_fragment_info.flags))?;
 
     // - The element is the root element.
     // - The element is the body element.
@@ -838,7 +838,7 @@ pub(crate) fn process_scroll_container_query(
         };
 
         let Some((ancestor_style, ancestor_flags)) = ancestor_layout_box
-            .with_first_base(|base| (base.style.clone(), base.base_fragment_info.flags))
+            .with_base(|base| (base.style.clone(), base.base_fragment_info.flags))
         else {
             continue;
         };

--- a/components/layout/traversal.rs
+++ b/components/layout/traversal.rs
@@ -170,7 +170,7 @@ pub(crate) fn compute_damage_and_repair_style_inner(
         damage_for_parent.contains(RestyleDamage::RELAYOUT)
     {
         let outer_inline_content_sizes_depend_on_content = Cell::new(false);
-        node.with_each_layout_box_base_including_pseudos(|base| {
+        node.with_layout_box_base_including_pseudos(|base| {
             base.clear_fragments();
             if original_element_damage.contains(RestyleDamage::RELAYOUT) {
                 // If the node itself has damage, we must clear both the cached layout results

--- a/tests/wpt/meta/css/CSS2/box-display/block-in-inline-relpos-001.xht.ini
+++ b/tests/wpt/meta/css/CSS2/box-display/block-in-inline-relpos-001.xht.ini
@@ -1,2 +1,0 @@
-[block-in-inline-relpos-001.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/box-display/block-in-inline-relpos-002.xht.ini
+++ b/tests/wpt/meta/css/CSS2/box-display/block-in-inline-relpos-002.xht.ini
@@ -1,2 +1,0 @@
-[block-in-inline-relpos-002.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/generated-content/content-082.xht.ini
+++ b/tests/wpt/meta/css/CSS2/generated-content/content-082.xht.ini
@@ -1,2 +1,0 @@
-[content-082.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/linebox/inline-box-002.xht.ini
+++ b/tests/wpt/meta/css/CSS2/linebox/inline-box-002.xht.ini
@@ -1,2 +1,0 @@
-[inline-box-002.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/normal-flow/block-in-inline-float-between-001.xht.ini
+++ b/tests/wpt/meta/css/CSS2/normal-flow/block-in-inline-float-between-001.xht.ini
@@ -1,2 +1,0 @@
-[block-in-inline-float-between-001.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/normal-flow/block-in-inline-float-in-layer-001.html.ini
+++ b/tests/wpt/meta/css/CSS2/normal-flow/block-in-inline-float-in-layer-001.html.ini
@@ -1,2 +1,0 @@
-[block-in-inline-float-in-layer-001.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/stacking-context/opacity-affects-block-in-inline.html.ini
+++ b/tests/wpt/meta/css/CSS2/stacking-context/opacity-affects-block-in-inline.html.ini
@@ -1,2 +1,0 @@
-[opacity-affects-block-in-inline.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/stacking-context/zindex-affects-block-in-inline.html.ini
+++ b/tests/wpt/meta/css/CSS2/stacking-context/zindex-affects-block-in-inline.html.ini
@@ -1,2 +1,0 @@
-[zindex-affects-block-in-inline.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/visuren/float-inside-inline-between-blocks-1.html.ini
+++ b/tests/wpt/meta/css/CSS2/visuren/float-inside-inline-between-blocks-1.html.ini
@@ -1,2 +1,0 @@
-[float-inside-inline-between-blocks-1.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-position/position-relative-001.html.ini
+++ b/tests/wpt/meta/css/css-position/position-relative-001.html.ini
@@ -1,2 +1,0 @@
-[position-relative-001.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-position/position-relative-002.html.ini
+++ b/tests/wpt/meta/css/css-position/position-relative-002.html.ini
@@ -1,2 +1,0 @@
-[position-relative-002.html]
-  expected: FAIL

--- a/tests/wpt/meta/html/rendering/non-replaced-elements/phrasing-content-0/font-element-text-decoration-color/001-a.html.ini
+++ b/tests/wpt/meta/html/rendering/non-replaced-elements/phrasing-content-0/font-element-text-decoration-color/001-a.html.ini
@@ -1,2 +1,0 @@
-[001-a.html]
-  expected: FAIL

--- a/tests/wpt/meta/html/rendering/non-replaced-elements/phrasing-content-0/font-element-text-decoration-color/001-q.html.ini
+++ b/tests/wpt/meta/html/rendering/non-replaced-elements/phrasing-content-0/font-element-text-decoration-color/001-q.html.ini
@@ -1,2 +1,0 @@
-[001-q.html]
-  expected: FAIL

--- a/tests/wpt/meta/html/rendering/non-replaced-elements/phrasing-content-0/font-element-text-decoration-color/001-s.html.ini
+++ b/tests/wpt/meta/html/rendering/non-replaced-elements/phrasing-content-0/font-element-text-decoration-color/001-s.html.ini
@@ -1,2 +1,0 @@
-[001-s.html]
-  expected: FAIL

--- a/tests/wpt/meta/html/rendering/non-replaced-elements/phrasing-content-0/font-element-text-decoration-color/001-x.xhtml.ini
+++ b/tests/wpt/meta/html/rendering/non-replaced-elements/phrasing-content-0/font-element-text-decoration-color/001-x.xhtml.ini
@@ -1,2 +1,0 @@
-[001-x.xhtml]
-  expected: FAIL

--- a/tests/wpt/meta/quirks/text-decoration-doesnt-propagate-into-tables/standards.html.ini
+++ b/tests/wpt/meta/quirks/text-decoration-doesnt-propagate-into-tables/standards.html.ini
@@ -1,2 +1,0 @@
-[standards.html]
-  expected: FAIL


### PR DESCRIPTION
We now follow the same approach as Blink: sequences of block-levels in an inline formatting context get wrapped in an anonymous block, which is treated as a line item. Inline ancestors are no longer split.

This means that inline elements will now generate a single inline box, and the box tree makes more sense in general. This will help for incremental layout.

This also means that block-level elements will now be properly affected by effects like opacity or filters set on inline ancestors.

Recently, WebKit has done some similar work, but without the anonymous blocks. We might also consider removing them in the future.

Google's explainer: https://docs.google.com/document/d/15kgdIHhb9EVNup6Ir5NWwJxpzY5GH0ED7Ld3iMW3HlA/

Testing: Several tests are now passing
Fixes: #39813
