### PR TITLE
OHOS CI: Use the list as retrieval target

### DIFF
--- a/etc/ci/scenario/common_function_for_mossel.py
+++ b/etc/ci/scenario/common_function_for_mossel.py
@@ -67,12 +67,8 @@ def click_category(driver: webdriver.Remote):
 
 
 def identify_element_in_category(driver: webdriver.Remote):
-    driver.implicitly_wait(40)
-    target_css_selector = (
-        "#app > uni-app > uni-page > uni-page-wrapper > uni-page-body > uni-view "
-        "> uni-view.sort-main.m-flex.m-bgWhite > uni-scroll-view > div > div > div "
-        "> uni-view.item.active"
-    )
+    driver.implicitly_wait(30)
+    target_css_selector = "#goodsGroup"
     while True:
         try:
             print("Finding components ...")


### PR DESCRIPTION
There is a corner case failure that happens for the first time: 
https://github.com/servo/servo/actions/runs/20458237142/job/58786068437
The swipe failed because the "list" has not loaded yet, as we started swiping as long as another irrelevant element is loaded.

This PR use the "list" as element retrieval target.

Testing: Tested with simulated congested network.