### PR TITLE
Separate `console.clear()` from `ConsoleLogLevel`

### DIFF
--- a/components/devtools/actors/console.rs
+++ b/components/devtools/actors/console.rs
@@ -17,8 +17,8 @@ use devtools_traits::EvaluateJSReply::{
     ActorValue, BooleanValue, NullValue, NumberValue, StringValue, VoidValue,
 };
 use devtools_traits::{
-    CachedConsoleMessage, CachedConsoleMessageTypes, ConsoleLog, ConsoleMessage,
-    DevtoolScriptControlMsg, PageError,
+    CachedConsoleMessage, CachedConsoleMessageTypes, ConsoleClearMessage, ConsoleLog,
+    ConsoleMessage, DevtoolScriptControlMsg, PageError,
 };
 use log::debug;
 use serde::Serialize;
@@ -288,6 +288,26 @@ impl ConsoleActor {
             if let Root::BrowsingContext(bc) = &self.root {
                 registry.find::<BrowsingContextActor>(bc).resource_array(
                     log_message,
+                    "console-message".into(),
+                    ResourceArrayType::Available,
+                    stream,
+                )
+            };
+        }
+    }
+
+    pub(crate) fn send_clear_message(
+        &self,
+        id: UniqueId,
+        registry: &ActorRegistry,
+        stream: &mut TcpStream,
+    ) {
+        if id == self.current_unique_id(registry) {
+            if let Root::BrowsingContext(bc) = &self.root {
+                registry.find::<BrowsingContextActor>(bc).resource_array(
+                    ConsoleClearMessage {
+                        level: "clear".to_owned(),
+                    },
                     "console-message".into(),
                     ResourceArrayType::Available,
                     stream,

--- a/components/shared/devtools/lib.rs
+++ b/components/shared/devtools/lib.rs
@@ -96,6 +96,8 @@ pub enum ScriptToDevtoolsControlMsg {
     Navigate(BrowsingContextId, NavigationState),
     /// A particular page has invoked the console API.
     ConsoleAPI(PipelineId, ConsoleMessage, Option<WorkerId>),
+    /// Request to clear the console for a given pipeline.
+    ClearConsole(PipelineId, Option<WorkerId>),
     /// An animation frame with the given timestamp was processed in a script thread.
     /// The actor with the provided name should be notified.
     FramerateTick(String, f64),
@@ -402,7 +404,6 @@ impl From<ConsoleMessage> for ConsoleLog {
             ConsoleLogLevel::Info => "info",
             ConsoleLogLevel::Warn => "warn",
             ConsoleLogLevel::Error => "error",
-            ConsoleLogLevel::Clear => "clear",
             ConsoleLogLevel::Trace => "trace",
             ConsoleLogLevel::Log => "log",
         }
@@ -423,6 +424,11 @@ impl From<ConsoleMessage> for ConsoleLog {
             stacktrace: value.stacktrace,
         }
     }
+}
+
+#[derive(Serialize)]
+pub struct ConsoleClearMessage {
+    pub level: String,
 }
 
 #[derive(Debug, Deserialize, Serialize)]

--- a/components/shared/embedder/lib.rs
+++ b/components/shared/embedder/lib.rs
@@ -392,7 +392,6 @@ pub enum ConsoleLogLevel {
     Info,
     Warn,
     Error,
-    Clear,
     Trace,
 }
 
@@ -400,7 +399,6 @@ impl From<ConsoleLogLevel> for log::Level {
     fn from(value: ConsoleLogLevel) -> Self {
         match value {
             ConsoleLogLevel::Log => log::Level::Info,
-            ConsoleLogLevel::Clear => log::Level::Info,
             ConsoleLogLevel::Debug => log::Level::Debug,
             ConsoleLogLevel::Info => log::Level::Info,
             ConsoleLogLevel::Warn => log::Level::Warn,


### PR DESCRIPTION
Separate `console.clear()` from `ConsoleLogLevel`. See https://github.com/servo/servo/pull/41311#discussion_r2622642820

Testing: Tested locally. Unfortunately in DevTools tests we do not cover console tab
