### PR TITLE
Fix build of `./mach test-unit -p base`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8307,6 +8307,7 @@ dependencies = [
  "stylo_dom",
  "stylo_malloc_size_of",
  "taffy",
+ "tendril",
  "tokio",
  "unicode-bidi",
  "unicode-script",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -176,6 +176,7 @@ surfman = { version = "0.11.0", features = ["chains"] }
 syn = { version = "2", default-features = false, features = ["clone-impls", "derive", "parsing"] }
 synstructure = "0.13"
 taffy = { version = "0.9.2", default-features = false, features = ["calc", "detailed_layout_info", "grid", "std"] }
+tendril = { version = "0.4.1", features = ["encoding_rs"] }
 tikv-jemalloc-sys = "0.6.1"
 tikv-jemallocator = "0.6.1"
 time = { package = "time", version = "0.3", features = ["large-dates", "local-offset", "serde"] }

--- a/components/malloc_size_of/Cargo.toml
+++ b/components/malloc_size_of/Cargo.toml
@@ -33,6 +33,7 @@ stylo = { workspace = true }
 stylo_dom = { workspace = true }
 stylo_malloc_size_of = { workspace = true }
 taffy = { workspace = true }
+tendril = { workspace = true }
 tokio = { workspace = true, features = ["sync"] }
 unicode-bidi = { workspace = true }
 unicode-script = { workspace = true }

--- a/components/malloc_size_of/lib.rs
+++ b/components/malloc_size_of/lib.rs
@@ -894,10 +894,8 @@ malloc_size_of_is_0!(unicode_script::Script);
 malloc_size_of_is_0!(urlpattern::UrlPattern);
 malloc_size_of_is_0!(utf8::Incomplete);
 
-impl<
-    S: markup5ever::tendril::TendrilSink<markup5ever::tendril::fmt::UTF8, A>,
-    A: markup5ever::tendril::Atomicity,
-> MallocSizeOf for markup5ever::tendril::stream::LossyDecoder<S, A>
+impl<S: tendril::TendrilSink<tendril::fmt::UTF8, A>, A: tendril::Atomicity> MallocSizeOf
+    for tendril::stream::LossyDecoder<S, A>
 {
     fn size_of(&self, _: &mut MallocSizeOfOps) -> usize {
         0

--- a/components/script/Cargo.toml
+++ b/components/script/Cargo.toml
@@ -143,7 +143,7 @@ stylo_malloc_size_of = { workspace = true }
 stylo_traits = { workspace = true }
 swapper = "0.1"
 tempfile = "3"
-tendril = { version = "0.4.1", features = ["encoding_rs"] }
+tendril = { workspace = true }
 time = { workspace = true }
 timers = { path = "../timers" }
 tracing = { workspace = true, optional = true }

--- a/components/script_bindings/Cargo.toml
+++ b/components/script_bindings/Cargo.toml
@@ -41,7 +41,7 @@ servo_url = { path = "../url" }
 smallvec = { workspace = true }
 stylo = { workspace = true }
 stylo_atoms = { workspace = true }
-tendril = { version = "0.4.1", features = ["encoding_rs"] }
+tendril = { workspace = true }
 tracing = { workspace = true, optional = true }
 webxr-api = { workspace = true, optional = true }
 xml5ever = { workspace = true }


### PR DESCRIPTION
`malloc_size_of` depends on `tendril` having the `encoding_rs` feature
turned on, but this was only turned on transitively via `html5ever` and
`script`/ `script_bindings` `tendril` dependencies. This change makes it
so that `malloc_size_of` depends directly on `tendril` and moves this
dependency to the root `Cargo.toml`.

Testing: This just fixes a particular build configuration.
