### PR TITLE
layout: Stop clearing floats on anonymous blocks for intrinsic sizes

### DIFF
--- a/components/layout/flow/mod.rs
+++ b/components/layout/flow/mod.rs
@@ -501,14 +501,16 @@ fn compute_inline_content_sizes_for_block_level_boxes(
                 ))
             },
             BlockLevelBox::SameFormattingContextBlock { base, contents, .. } => {
+                let is_anonymous_block =
+                    matches!(base.style.pseudo(), Some(PseudoElement::ServoAnonymousBox));
                 let inline_content_sizes_result = sizing::outer_inline(
                     base,
                     &contents.layout_style(base),
                     containing_block,
                     &LogicalVec2::zero(),
-                    false, /* auto_block_size_stretches_to_containing_block */
-                    false, /* is_replaced */
-                    !matches!(base.style.pseudo(), Some(PseudoElement::ServoAnonymousBox)),
+                    false,               /* auto_block_size_stretches_to_containing_block */
+                    false,               /* is_replaced */
+                    !is_anonymous_block, /* establishes_containing_block */
                     |_| None, /* TODO: support preferred aspect ratios on non-replaced boxes */
                     |constraint_space| {
                         base.inline_content_sizes(layout_context, constraint_space, contents)
@@ -517,8 +519,18 @@ fn compute_inline_content_sizes_for_block_level_boxes(
                 );
                 // A block in the same BFC can overlap floats, it's not moved next to them,
                 // so we shouldn't add its size to the size of the floats.
-                // Instead, we treat it like an independent block with 'clear: both'.
-                Some((inline_content_sizes_result, None, Clear::Both))
+                // Instead, we treat it like an independent block with 'clear: both',
+                // except if it's an anonymous block.
+                // Presumably, the exception is because an anonymous block will always have
+                // inline-level contents, which don't overlap floats. However, the same might
+                // also happen with a non-anonymous block, so the logic is a bit arbitrary,
+                // but matches other browsers (see #41280).
+                let clear = if is_anonymous_block {
+                    Clear::None
+                } else {
+                    Clear::Both
+                };
+                Some((inline_content_sizes_result, None, clear))
             },
             BlockLevelBox::Independent(independent) => {
                 let inline_content_sizes_result = independent.outer_inline_content_sizes(

--- a/tests/wpt/meta/css/CSS2/floats/intrinsic-size-float-and-line.html.ini
+++ b/tests/wpt/meta/css/CSS2/floats/intrinsic-size-float-and-line.html.ini
@@ -1,2 +1,0 @@
-[intrinsic-size-float-and-line.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/text/text-indent-012.xht.ini
+++ b/tests/wpt/meta/css/CSS2/text/text-indent-012.xht.ini
@@ -1,2 +1,0 @@
-[text-indent-012.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-transforms/transform-generated-001.html.ini
+++ b/tests/wpt/meta/css/css-transforms/transform-generated-001.html.ini
@@ -1,2 +1,0 @@
-[transform-generated-001.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-ui/outline-028.html.ini
+++ b/tests/wpt/meta/css/css-ui/outline-028.html.ini
@@ -1,2 +1,0 @@
-[outline-028.html]
-  expected: FAIL


### PR DESCRIPTION
When computing the intrinsic sizes of a block container which doesn't establish an inline formatting context, block-level children which don't establish an independent formatting context clear floats. That's because these blocks overlap the floats instead of being placed next to them.

However, we shouldn't do that if the block-level child is an anonymous box that establishes an inline formatting context. This matches what other browsers do.

Testing: 4 tests are now passing
Fixes: #41280
