### PR TITLE
layout: Take floats into account for the intrinsic sizes of an inline FC

### DIFF
--- a/components/layout/flow/mod.rs
+++ b/components/layout/flow/mod.rs
@@ -588,12 +588,11 @@ fn compute_inline_content_sizes_for_block_level_boxes(
             data.depends_on_block_constraints |= depends_on_block_constraints;
             data.clear_floats(clear);
             match float {
-                Some(FloatSide::InlineStart) => data.start_floats = data.start_floats.union(&size),
-                Some(FloatSide::InlineEnd) => data.end_floats = data.end_floats.union(&size),
+                Some(FloatSide::InlineStart) => data.start_floats.union_assign(&size),
+                Some(FloatSide::InlineEnd) => data.end_floats.union_assign(&size),
                 None => {
-                    data.max_size = data
-                        .max_size
-                        .max(data.start_floats.union(&data.end_floats).union(&size));
+                    data.max_size
+                        .max_assign(data.start_floats.union(&data.end_floats).union(&size));
                     data.start_floats = ContentSizes::zero();
                     data.end_floats = ContentSizes::zero();
                 },

--- a/components/layout/geom.rs
+++ b/components/layout/geom.rs
@@ -45,7 +45,7 @@ pub struct LogicalSides<T> {
     pub block_end: T,
 }
 
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone, Copy, Debug, Default)]
 pub(crate) struct LogicalSides1D<T> {
     pub start: T,
     pub end: T,

--- a/components/layout/sizing.rs
+++ b/components/layout/sizing.rs
@@ -63,6 +63,11 @@ impl ContentSizes {
         }
     }
 
+    pub fn union_assign(&mut self, other: &Self) {
+        self.min_content.max_assign(other.min_content);
+        self.max_content += other.max_content;
+    }
+
     pub fn map(&self, f: impl Fn(Au) -> Au) -> Self {
         Self {
             min_content: f(self.min_content),

--- a/tests/wpt/meta/css/css-sizing/intrinsic-percent-replaced-dynamic-010.html.ini
+++ b/tests/wpt/meta/css/css-sizing/intrinsic-percent-replaced-dynamic-010.html.ini
@@ -1,2 +1,0 @@
-[intrinsic-percent-replaced-dynamic-010.html]
-  expected: FAIL


### PR DESCRIPTION
The computation of the min-content and max-content sizes of an inline formatting context was ignoring floated contents.

Now we will take them into account.

Testing: One test is now passing. Note there isn't much test coverage because there is no spec, and browsers aren't fully interoperable. More tests should be added as part of https://github.com/w3c/csswg-drafts/issues/9120
Fixes: #3923