### PR TITLE
script: Use more wrappers2 in maybe_cross_origin_set_rawcx

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -104,7 +104,7 @@ imsz = "0.4"
 indexmap = { version = "2.11.4", features = ["std"] }
 ipc-channel = "0.20.2"
 itertools = "0.14"
-js = { package = "mozjs", version = "0.14.2", default-features = false, features = ["libz-sys", "intl"] }
+js = { package = "mozjs", version = "0.14.3", default-features = false, features = ["libz-sys", "intl"] }
 keyboard-types = { version = "0.8.3", features = ["serde", "webdriver"] }
 kurbo = { version = "0.12", features = ["euclid"] }
 layout_api = { path = "components/shared/layout" }


### PR DESCRIPTION
This is companion PR to https://github.com/servo/mozjs/pull/680 but it was originally written as part of #40716.

Testing: Covered by `/webidl/ecmascript-binding/global-object-implicit-this-value-cross-realm.html`
