### PR TITLE
script: Support new context for promise and add some more helpers to ease migration

### DIFF
--- a/components/script/dom/canvas/imagebitmap.rs
+++ b/components/script/dom/canvas/imagebitmap.rs
@@ -9,10 +9,10 @@ use base::id::{ImageBitmapId, ImageBitmapIndex};
 use constellation_traits::SerializableImageBitmap;
 use dom_struct::dom_struct;
 use euclid::default::{Point2D, Rect, Size2D};
+use js::realm::CurrentRealm;
 use pixels::{CorsStatus, Snapshot, SnapshotAlphaMode, SnapshotPixelFormat};
 use rustc_hash::FxHashMap;
 use script_bindings::error::{Error, Fallible};
-use script_bindings::realms::{AlreadyInRealm, InRealm};
 
 use crate::dom::bindings::cell::DomRefCell;
 use crate::dom::bindings::codegen::Bindings::ImageBitmapBinding::{
@@ -284,10 +284,10 @@ impl ImageBitmap {
         sw: Option<i32>,
         sh: Option<i32>,
         options: &ImageBitmapOptions,
-        can_gc: CanGc,
+        realm: &mut CurrentRealm,
     ) -> Rc<Promise> {
-        let in_realm_proof = AlreadyInRealm::assert::<crate::DomTypeHolder>();
-        let p = Promise::new_in_current_realm(InRealm::Already(&in_realm_proof), can_gc);
+        let can_gc = CanGc::from_cx(realm);
+        let p = Promise::new_in_realm(realm);
 
         // Step 1. If either sw or sh is given and is 0, then return a promise rejected with a RangeError.
         if sw.is_some_and(|w| w == 0) {

--- a/components/script/dom/window.rs
+++ b/components/script/dom/window.rs
@@ -49,6 +49,7 @@ use js::jsapi::{
     GCReason, Heap, JS_GC, JSAutoRealm, JSContext as RawJSContext, JSObject, JSPROP_ENUMERATE,
 };
 use js::jsval::{NullValue, UndefinedValue};
+use js::realm::CurrentRealm;
 use js::rust::wrappers::JS_DefineProperty;
 use js::rust::{
     CustomAutoRooter, CustomAutoRooterGuard, HandleObject, HandleValue, MutableHandleObject,
@@ -1489,9 +1490,9 @@ impl WindowMethods<crate::DomTypeHolder> for Window {
     /// <https://html.spec.whatwg.org/multipage/#dom-createimagebitmap>
     fn CreateImageBitmap(
         &self,
+        realm: &mut CurrentRealm,
         image: ImageBitmapSource,
         options: &ImageBitmapOptions,
-        can_gc: CanGc,
     ) -> Rc<Promise> {
         ImageBitmap::create_image_bitmap(
             self.as_global_scope(),
@@ -1501,20 +1502,20 @@ impl WindowMethods<crate::DomTypeHolder> for Window {
             None,
             None,
             options,
-            can_gc,
+            realm,
         )
     }
 
     /// <https://html.spec.whatwg.org/multipage/#dom-createimagebitmap>
     fn CreateImageBitmap_(
         &self,
+        realm: &mut CurrentRealm,
         image: ImageBitmapSource,
         sx: i32,
         sy: i32,
         sw: i32,
         sh: i32,
         options: &ImageBitmapOptions,
-        can_gc: CanGc,
     ) -> Rc<Promise> {
         ImageBitmap::create_image_bitmap(
             self.as_global_scope(),
@@ -1524,7 +1525,7 @@ impl WindowMethods<crate::DomTypeHolder> for Window {
             Some(sw),
             Some(sh),
             options,
-            can_gc,
+            realm,
         )
     }
 

--- a/components/script/dom/workers/workerglobalscope.rs
+++ b/components/script/dom/workers/workerglobalscope.rs
@@ -21,6 +21,7 @@ use encoding_rs::UTF_8;
 use fonts::FontContext;
 use headers::{HeaderMapExt, ReferrerPolicy as ReferrerPolicyHeader};
 use js::jsapi::JS_AddInterruptCallback;
+use js::realm::CurrentRealm;
 use js::rust::{HandleValue, MutableHandleValue, ParentRuntime};
 use mime::Mime;
 use net_traits::policy_container::PolicyContainer;
@@ -903,23 +904,23 @@ impl WorkerGlobalScopeMethods<crate::DomTypeHolder> for WorkerGlobalScope {
     /// <https://html.spec.whatwg.org/multipage/#dom-createimagebitmap>
     fn CreateImageBitmap(
         &self,
+        realm: &mut CurrentRealm,
         image: ImageBitmapSource,
         options: &ImageBitmapOptions,
-        can_gc: CanGc,
     ) -> Rc<Promise> {
-        ImageBitmap::create_image_bitmap(self.upcast(), image, 0, 0, None, None, options, can_gc)
+        ImageBitmap::create_image_bitmap(self.upcast(), image, 0, 0, None, None, options, realm)
     }
 
     /// <https://html.spec.whatwg.org/multipage/#dom-createimagebitmap>
     fn CreateImageBitmap_(
         &self,
+        realm: &mut CurrentRealm,
         image: ImageBitmapSource,
         sx: i32,
         sy: i32,
         sw: i32,
         sh: i32,
         options: &ImageBitmapOptions,
-        can_gc: CanGc,
     ) -> Rc<Promise> {
         ImageBitmap::create_image_bitmap(
             self.upcast(),
@@ -929,7 +930,7 @@ impl WorkerGlobalScopeMethods<crate::DomTypeHolder> for WorkerGlobalScope {
             Some(sw),
             Some(sh),
             options,
-            can_gc,
+            realm,
         )
     }
 

--- a/components/script_bindings/codegen/Bindings.conf
+++ b/components/script_bindings/codegen/Bindings.conf
@@ -781,9 +781,10 @@ DOMInterfaces = {
 },
 
 'Window': {
-    'canGc': ['CreateImageBitmap', 'CreateImageBitmap_', 'CookieStore', 'Fetch', 'FetchLater', 'Open', 'ReportError', 'Screen', 'SetInterval', 'SetTimeout', 'Stop', 'StructuredClone', 'TrustedTypes', 'WebdriverCallback', 'WebdriverException', 'GetVisualViewport'],
+    'canGc': ['CookieStore', 'Fetch', 'FetchLater', 'Open', 'ReportError', 'Screen', 'SetInterval', 'SetTimeout', 'Stop', 'StructuredClone', 'TrustedTypes', 'WebdriverCallback', 'WebdriverException', 'GetVisualViewport'],
     'inRealms': ['Fetch', 'GetOpener', 'WebdriverCallback'],
     'additionalTraits': ['crate::interfaces::WindowHelpers'],
+    'realm': ['CreateImageBitmap', 'CreateImageBitmap_'],
 },
 
 'WindowProxy' : {
@@ -793,7 +794,8 @@ DOMInterfaces = {
 
 'WorkerGlobalScope': {
     'inRealms': ['Fetch'],
-    'canGc': ['Fetch', 'CreateImageBitmap', 'CreateImageBitmap_', 'ImportScripts', 'ReportError', 'SetInterval', 'SetTimeout', 'StructuredClone', 'TrustedTypes'],
+    'canGc': ['Fetch', 'ImportScripts', 'ReportError', 'SetInterval', 'SetTimeout', 'StructuredClone', 'TrustedTypes'],
+    'realm': ['CreateImageBitmap', 'CreateImageBitmap_'],
 },
 
 'Worklet': {

--- a/components/script_bindings/script_runtime.rs
+++ b/components/script_bindings/script_runtime.rs
@@ -8,6 +8,7 @@ use std::ops::Deref;
 
 use js::context::JSContext as SafeJSContext;
 use js::jsapi::JSContext as RawJSContext;
+use js::realm::CurrentRealm;
 
 #[derive(Clone, Copy)]
 #[repr(transparent)]
@@ -15,6 +16,12 @@ pub struct JSContext(*mut RawJSContext);
 
 impl From<&mut SafeJSContext> for JSContext {
     fn from(safe_cx: &mut SafeJSContext) -> Self {
+        unsafe { JSContext(safe_cx.raw_cx()) }
+    }
+}
+
+impl<'a> From<&mut CurrentRealm<'a>> for JSContext {
+    fn from(safe_cx: &mut CurrentRealm<'a>) -> Self {
         unsafe { JSContext(safe_cx.raw_cx()) }
     }
 }

--- a/components/script_bindings/script_runtime.rs
+++ b/components/script_bindings/script_runtime.rs
@@ -6,11 +6,18 @@ use std::cell::Cell;
 use std::marker::PhantomData;
 use std::ops::Deref;
 
+use js::context::JSContext as SafeJSContext;
 use js::jsapi::JSContext as RawJSContext;
 
 #[derive(Clone, Copy)]
 #[repr(transparent)]
 pub struct JSContext(*mut RawJSContext);
+
+impl From<&mut SafeJSContext> for JSContext {
+    fn from(safe_cx: &mut SafeJSContext) -> Self {
+        unsafe { JSContext(safe_cx.raw_cx()) }
+    }
+}
 
 #[expect(unsafe_code)]
 impl JSContext {
@@ -67,5 +74,10 @@ impl CanGc {
     /// current stack frame.
     pub fn note() -> CanGc {
         CanGc(PhantomData)
+    }
+
+    /// &mut SafeJSContext is always an indication that GC is possible.
+    pub fn from_cx(_cx: &mut SafeJSContext) -> CanGc {
+        CanGc::note()
     }
 }


### PR DESCRIPTION
This PR adds support for using new JSContext/CurrentRealm to promise and adds some more helpers that will ease migration to new context model. Second commit has another demo.

Testing: Covered by WPT
Part of #40600