### PR TITLE
base: Move Unicode offset types to `base`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7783,6 +7783,7 @@ dependencies = [
 name = "script_bindings"
 version = "0.0.1"
 dependencies = [
+ "base",
  "bitflags 2.10.0",
  "crossbeam-channel",
  "cssparser",
@@ -7821,6 +7822,7 @@ dependencies = [
 name = "script_tests"
 version = "0.0.1"
 dependencies = [
+ "base",
  "encoding_rs",
  "euclid",
  "keyboard-types",

--- a/components/script/dom/html/htmltextareaelement.rs
+++ b/components/script/dom/html/htmltextareaelement.rs
@@ -6,6 +6,7 @@ use std::cell::Cell;
 use std::default::Default;
 use std::ops::Range;
 
+use base::text::{Utf8CodeUnitLength, Utf16CodeUnitLength};
 use dom_struct::dom_struct;
 use embedder_traits::{EmbedderControlRequest, InputMethodRequest, InputMethodType};
 use html5ever::{LocalName, Prefix, local_name, ns};
@@ -47,7 +48,6 @@ use crate::dom::virtualmethods::VirtualMethods;
 use crate::script_runtime::CanGc;
 use crate::textinput::{
     ClipboardEventFlags, Direction, IsComposing, KeyReaction, Lines, SelectionDirection, TextInput,
-    UTF8Bytes, UTF16CodeUnits,
 };
 
 #[dom_struct]
@@ -81,7 +81,7 @@ impl<'dom> LayoutDom<'dom, HTMLTextAreaElement> {
         }
     }
 
-    fn textinput_sorted_selection_offsets_range(self) -> Range<UTF8Bytes> {
+    fn textinput_sorted_selection_offsets_range(self) -> Range<Utf8CodeUnitLength> {
         unsafe {
             self.unsafe_get()
                 .textinput
@@ -111,7 +111,7 @@ impl LayoutHTMLTextAreaElementHelpers for LayoutDom<'_, HTMLTextAreaElement> {
         if !self.upcast::<Element>().focus_state() {
             return None;
         }
-        Some(UTF8Bytes::unwrap_range(
+        Some(Utf8CodeUnitLength::unwrap_range(
             self.textinput_sorted_selection_offsets_range(),
         ))
     }
@@ -394,7 +394,7 @@ impl HTMLTextAreaElementMethods<crate::DomTypeHolder> for HTMLTextAreaElement {
 
     /// <https://html.spec.whatwg.org/multipage/#dom-textarea-textlength>
     fn TextLength(&self) -> u32 {
-        let UTF16CodeUnits(num_units) = self.textinput.borrow().utf16_len();
+        let Utf16CodeUnitLength(num_units) = self.textinput.borrow().utf16_len();
         num_units as u32
     }
 
@@ -574,7 +574,7 @@ impl VirtualMethods for HTMLTextAreaElement {
                     if value < 0 {
                         textinput.set_max_length(None);
                     } else {
-                        textinput.set_max_length(Some(UTF16CodeUnits(value as usize)))
+                        textinput.set_max_length(Some(Utf16CodeUnitLength(value as usize)))
                     }
                 },
                 _ => panic!("Expected an AttrValue::Int"),
@@ -586,7 +586,7 @@ impl VirtualMethods for HTMLTextAreaElement {
                     if value < 0 {
                         textinput.set_min_length(None);
                     } else {
-                        textinput.set_min_length(Some(UTF16CodeUnits(value as usize)))
+                        textinput.set_min_length(Some(Utf16CodeUnitLength(value as usize)))
                     }
                 },
                 _ => panic!("Expected an AttrValue::Int"),
@@ -823,7 +823,7 @@ impl Validatable for HTMLTextAreaElement {
         let mut failed_flags = ValidationFlags::empty();
 
         let textinput = self.textinput.borrow();
-        let UTF16CodeUnits(value_len) = textinput.utf16_len();
+        let Utf16CodeUnitLength(value_len) = textinput.utf16_len();
         let last_edit_by_user = !textinput.was_last_change_by_set_content();
         let value_dirty = self.value_dirty.get();
 

--- a/components/script/dom/textcontrol.rs
+++ b/components/script/dom/textcontrol.rs
@@ -7,6 +7,8 @@
 //!
 //! <https://html.spec.whatwg.org/multipage/#textFieldSelection>
 
+use base::text::Utf8CodeUnitLength;
+
 use crate::clipboard_provider::EmbedderClipboardProvider;
 use crate::dom::bindings::cell::DomRefCell;
 use crate::dom::bindings::codegen::Bindings::HTMLFormElementBinding::SelectionMode;
@@ -16,7 +18,7 @@ use crate::dom::bindings::str::DOMString;
 use crate::dom::event::{EventBubbles, EventCancelable};
 use crate::dom::eventtarget::EventTarget;
 use crate::dom::node::{Node, NodeDamage, NodeTraits};
-use crate::textinput::{SelectionDirection, SelectionState, TextInput, UTF8Bytes};
+use crate::textinput::{SelectionDirection, SelectionState, TextInput};
 
 pub(crate) trait TextControlElement: DerivedFrom<EventTarget> + DerivedFrom<Node> {
     fn selection_api_applies(&self) -> bool;
@@ -185,7 +187,7 @@ impl<'a, E: TextControlElement> TextControlSelection<'a, E> {
         // change the selection state in order to replace the text in the range.
         let original_selection_state = self.textinput.borrow().selection_state();
 
-        let UTF8Bytes(content_length) = self.textinput.borrow().len_utf8();
+        let Utf8CodeUnitLength(content_length) = self.textinput.borrow().len_utf8();
         let content_length = content_length as u32;
 
         // Step 5
@@ -271,12 +273,12 @@ impl<'a, E: TextControlElement> TextControlSelection<'a, E> {
     }
 
     fn start(&self) -> u32 {
-        let UTF8Bytes(offset) = self.textinput.borrow().selection_start_offset();
+        let Utf8CodeUnitLength(offset) = self.textinput.borrow().selection_start_offset();
         offset as u32
     }
 
     fn end(&self) -> u32 {
-        let UTF8Bytes(offset) = self.textinput.borrow().selection_end_offset();
+        let Utf8CodeUnitLength(offset) = self.textinput.borrow().selection_end_offset();
         offset as u32
     }
 

--- a/components/script/test.rs
+++ b/components/script/test.rs
@@ -72,8 +72,7 @@ pub mod timeranges {
 pub mod textinput {
     pub use crate::clipboard_provider::ClipboardProvider;
     pub use crate::textinput::{
-        Direction, Lines, Selection, SelectionDirection, TextInput, TextPoint, UTF8Bytes,
-        UTF16CodeUnits,
+        Direction, Lines, Selection, SelectionDirection, TextInput, TextPoint,
     };
 }
 

--- a/components/script_bindings/Cargo.toml
+++ b/components/script_bindings/Cargo.toml
@@ -16,6 +16,7 @@ name = "script_bindings"
 path = "lib.rs"
 
 [dependencies]
+base = { workspace = true }
 bitflags = { workspace = true }
 crossbeam-channel = { workspace = true }
 cssparser = { workspace = true }

--- a/components/script_bindings/domstring.rs
+++ b/components/script_bindings/domstring.rs
@@ -12,6 +12,7 @@ use std::str::{Chars, FromStr};
 use std::sync::LazyLock;
 use std::{fmt, slice, str};
 
+use base::text::{Utf8CodeUnitLength, Utf16CodeUnitLength};
 use html5ever::{LocalName, Namespace};
 use js::conversions::{ToJSValConvertible, jsstr_to_string};
 use js::gc::MutableHandleValue;
@@ -415,9 +416,30 @@ impl DOMString {
         self.view().is_empty()
     }
 
-    /// This length (as rust spec) is in bytes if the string would be utf8 not chars.
+    /// The length of this string in UTF-8 code units, each one being one byte in size.
+    ///
+    /// Note: This is different than the number of Unicode characters (or code points). A
+    /// character may require multiple UTF-8 code units.
     pub fn len(&self) -> usize {
         self.view().len()
+    }
+
+    /// The length of this string in UTF-8 code units, each one being one byte in size.
+    /// This method is the same as [`DOMString::len`], but the result is wrapped in a
+    /// `Utf8CodeUnitLength` to be used in code that mixes different kinds of offsets.
+    ///
+    /// Note: This is different than the number of Unicode characters (or code points). A
+    /// character may require multiple UTF-8 code units.
+    pub fn len_utf8(&self) -> Utf8CodeUnitLength {
+        Utf8CodeUnitLength(self.len())
+    }
+
+    /// The length of this string in UTF-16 code units, each one being one two bytes in size.
+    ///
+    /// Note: This is different than the number of Unicode characters (or code points). A
+    /// character may require multiple UTF-16 code units.
+    pub fn len_utf16(&self) -> Utf16CodeUnitLength {
+        Utf16CodeUnitLength(self.str().chars().map(char::len_utf16).sum())
     }
 
     pub fn make_ascii_lowercase(&mut self) {

--- a/components/shared/base/text.rs
+++ b/components/shared/base/text.rs
@@ -2,6 +2,11 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
+use std::iter::Sum;
+use std::ops::{Add, AddAssign, Range, Sub, SubAssign};
+
+use malloc_size_of_derive::MallocSizeOf;
+
 pub use crate::unicode_block::{UnicodeBlock, UnicodeBlockMethod};
 
 pub fn is_bidi_control(c: char) -> bool {
@@ -43,6 +48,70 @@ pub fn is_cjk(codepoint: char) -> bool {
     // https://en.wikipedia.org/wiki/Plane_(Unicode)#Tertiary_Ideographic_Plane
     unicode_plane(codepoint) == 2 || unicode_plane(codepoint) == 3
 }
+
+macro_rules! unicode_length_type {
+    ($type_name:ident) => {
+        /// A length in code units of the given text encoding. For instance, `Utf8CodeUnitLength`
+        /// is a length in UTF-8 code units (one byte each). `Utf16CodeUnitLength` is a length in
+        /// UTF-16 code units (two bytes each). This type is used to more reliable work with
+        /// lengths in different encodings.
+        #[derive(Clone, Copy, Debug, Eq, MallocSizeOf, Ord, PartialEq, PartialOrd)]
+        pub struct $type_name(pub usize);
+
+        impl $type_name {
+            pub fn zero() -> Self {
+                Self(0)
+            }
+
+            pub fn one() -> Self {
+                Self(1)
+            }
+
+            pub fn unwrap_range(byte_range: Range<Self>) -> Range<usize> {
+                byte_range.start.0..byte_range.end.0
+            }
+
+            pub fn saturating_sub(self, value: Self) -> Self {
+                Self(self.0.saturating_sub(value.0))
+            }
+        }
+
+        impl Add for $type_name {
+            type Output = Self;
+            fn add(self, other: Self) -> Self {
+                Self(self.0 + other.0)
+            }
+        }
+
+        impl AddAssign for $type_name {
+            fn add_assign(&mut self, other: Self) {
+                *self = Self(self.0 + other.0)
+            }
+        }
+
+        impl Sub for $type_name {
+            type Output = Self;
+            fn sub(self, value: Self) -> Self {
+                Self(self.0 - value.0)
+            }
+        }
+
+        impl SubAssign for $type_name {
+            fn sub_assign(&mut self, other: Self) {
+                *self = Self(self.0 - other.0)
+            }
+        }
+
+        impl Sum for $type_name {
+            fn sum<I: Iterator<Item = Self>>(iter: I) -> Self {
+                iter.fold(Self::zero(), |a, b| Self(a.0 + b.0))
+            }
+        }
+    };
+}
+
+unicode_length_type!(Utf8CodeUnitLength);
+unicode_length_type!(Utf16CodeUnitLength);
 
 #[cfg(test)]
 mod test {

--- a/tests/unit/script/Cargo.toml
+++ b/tests/unit/script/Cargo.toml
@@ -12,6 +12,7 @@ name = "script_tests"
 path = "lib.rs"
 
 [dependencies]
+base = { workspace = true }
 encoding_rs = { workspace = true }
 euclid = { workspace = true }
 keyboard-types = { workspace = true }

--- a/tests/unit/script/textinput.rs
+++ b/tests/unit/script/textinput.rs
@@ -7,11 +7,11 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+use base::text::{Utf8CodeUnitLength, Utf16CodeUnitLength};
 use keyboard_types::{Key, Modifiers, NamedKey};
 use script::test::DOMString;
 use script::test::textinput::{
     ClipboardProvider, Direction, Lines, Selection, SelectionDirection, TextInput, TextPoint,
-    UTF8Bytes, UTF16CodeUnits,
 };
 
 pub struct DummyClipboardContext {
@@ -52,7 +52,7 @@ fn test_set_content_ignores_max_length() {
         Lines::Single,
         DOMString::from(""),
         DummyClipboardContext::new(""),
-        Some(UTF16CodeUnits::one()),
+        Some(Utf16CodeUnitLength::one()),
         None,
         SelectionDirection::None,
     );
@@ -67,13 +67,21 @@ fn test_textinput_when_inserting_multiple_lines_over_a_selection_respects_max_le
         Lines::Multiple,
         DOMString::from("hello\nworld"),
         DummyClipboardContext::new(""),
-        Some(UTF16CodeUnits(17)),
+        Some(Utf16CodeUnitLength(17)),
         None,
         SelectionDirection::None,
     );
 
-    textinput.adjust_horizontal(UTF8Bytes::one(), Direction::Forward, Selection::NotSelected);
-    textinput.adjust_horizontal(UTF8Bytes(3), Direction::Forward, Selection::Selected);
+    textinput.adjust_horizontal(
+        Utf8CodeUnitLength::one(),
+        Direction::Forward,
+        Selection::NotSelected,
+    );
+    textinput.adjust_horizontal(
+        Utf8CodeUnitLength(3),
+        Direction::Forward,
+        Selection::Selected,
+    );
     textinput.adjust_vertical(1, Selection::Selected);
 
     // Selection is now "hello\n
@@ -92,7 +100,7 @@ fn test_textinput_when_inserting_multiple_lines_still_respects_max_length() {
         Lines::Multiple,
         DOMString::from("hello\nworld"),
         DummyClipboardContext::new(""),
-        Some(UTF16CodeUnits(17)),
+        Some(Utf16CodeUnitLength(17)),
         None,
         SelectionDirection::None,
     );
@@ -110,7 +118,7 @@ fn test_textinput_when_content_is_already_longer_than_max_length_and_theres_no_s
         Lines::Single,
         DOMString::from("abc"),
         DummyClipboardContext::new(""),
-        Some(UTF16CodeUnits::one()),
+        Some(Utf16CodeUnitLength::one()),
         None,
         SelectionDirection::None,
     );
@@ -127,7 +135,7 @@ fn test_multi_line_textinput_with_maxlength_doesnt_allow_appending_characters_wh
         Lines::Multiple,
         DOMString::from("abc\nd"),
         DummyClipboardContext::new(""),
-        Some(UTF16CodeUnits(5)),
+        Some(Utf16CodeUnitLength(5)),
         None,
         SelectionDirection::None,
     );
@@ -144,13 +152,21 @@ fn test_single_line_textinput_with_max_length_doesnt_allow_appending_characters_
         Lines::Single,
         DOMString::from("abcde"),
         DummyClipboardContext::new(""),
-        Some(UTF16CodeUnits(5)),
+        Some(Utf16CodeUnitLength(5)),
         None,
         SelectionDirection::None,
     );
 
-    textinput.adjust_horizontal(UTF8Bytes::one(), Direction::Forward, Selection::NotSelected);
-    textinput.adjust_horizontal(UTF8Bytes(3), Direction::Forward, Selection::Selected);
+    textinput.adjust_horizontal(
+        Utf8CodeUnitLength::one(),
+        Direction::Forward,
+        Selection::NotSelected,
+    );
+    textinput.adjust_horizontal(
+        Utf8CodeUnitLength(3),
+        Direction::Forward,
+        Selection::Selected,
+    );
 
     // Selection is now "abcde"
     //                    ---
@@ -166,13 +182,21 @@ fn test_single_line_textinput_with_max_length_allows_deletion_when_replacing_a_s
         Lines::Single,
         DOMString::from("abcde"),
         DummyClipboardContext::new(""),
-        Some(UTF16CodeUnits(1)),
+        Some(Utf16CodeUnitLength(1)),
         None,
         SelectionDirection::None,
     );
 
-    textinput.adjust_horizontal(UTF8Bytes::one(), Direction::Forward, Selection::NotSelected);
-    textinput.adjust_horizontal(UTF8Bytes(2), Direction::Forward, Selection::Selected);
+    textinput.adjust_horizontal(
+        Utf8CodeUnitLength::one(),
+        Direction::Forward,
+        Selection::NotSelected,
+    );
+    textinput.adjust_horizontal(
+        Utf8CodeUnitLength(2),
+        Direction::Forward,
+        Selection::Selected,
+    );
 
     // Selection is now "abcde"
     //                    --
@@ -188,7 +212,7 @@ fn test_single_line_textinput_with_max_length_multibyte() {
         Lines::Single,
         DOMString::from(""),
         DummyClipboardContext::new(""),
-        Some(UTF16CodeUnits(2)),
+        Some(Utf16CodeUnitLength(2)),
         None,
         SelectionDirection::None,
     );
@@ -207,7 +231,7 @@ fn test_single_line_textinput_with_max_length_multi_code_unit() {
         Lines::Single,
         DOMString::from(""),
         DummyClipboardContext::new(""),
-        Some(UTF16CodeUnits(3)),
+        Some(Utf16CodeUnitLength(3)),
         None,
         SelectionDirection::None,
     );
@@ -228,7 +252,7 @@ fn test_single_line_textinput_with_max_length_inside_char() {
         Lines::Single,
         DOMString::from("\u{10437}"),
         DummyClipboardContext::new(""),
-        Some(UTF16CodeUnits::one()),
+        Some(Utf16CodeUnitLength::one()),
         None,
         SelectionDirection::None,
     );
@@ -244,7 +268,7 @@ fn test_single_line_textinput_with_max_length_doesnt_allow_appending_characters_
         Lines::Single,
         DOMString::from("a"),
         DummyClipboardContext::new(""),
-        Some(UTF16CodeUnits::one()),
+        Some(Utf16CodeUnitLength::one()),
         None,
         SelectionDirection::None,
     );
@@ -256,14 +280,22 @@ fn test_single_line_textinput_with_max_length_doesnt_allow_appending_characters_
 #[test]
 fn test_textinput_delete_char() {
     let mut textinput = text_input(Lines::Single, "abcdefg");
-    textinput.adjust_horizontal(UTF8Bytes(2), Direction::Forward, Selection::NotSelected);
+    textinput.adjust_horizontal(
+        Utf8CodeUnitLength(2),
+        Direction::Forward,
+        Selection::NotSelected,
+    );
     textinput.delete_char(Direction::Backward);
     assert_eq!(textinput.get_content(), "acdefg");
 
     textinput.delete_char(Direction::Forward);
     assert_eq!(textinput.get_content(), "adefg");
 
-    textinput.adjust_horizontal(UTF8Bytes(2), Direction::Forward, Selection::Selected);
+    textinput.adjust_horizontal(
+        Utf8CodeUnitLength(2),
+        Direction::Forward,
+        Selection::Selected,
+    );
     textinput.delete_char(Direction::Forward);
     assert_eq!(textinput.get_content(), "afg");
 
@@ -283,11 +315,19 @@ fn test_textinput_delete_char() {
 #[test]
 fn test_textinput_insert_char() {
     let mut textinput = text_input(Lines::Single, "abcdefg");
-    textinput.adjust_horizontal(UTF8Bytes(2), Direction::Forward, Selection::NotSelected);
+    textinput.adjust_horizontal(
+        Utf8CodeUnitLength(2),
+        Direction::Forward,
+        Selection::NotSelected,
+    );
     textinput.insert_char('a');
     assert_eq!(textinput.get_content(), "abacdefg");
 
-    textinput.adjust_horizontal(UTF8Bytes(2), Direction::Forward, Selection::Selected);
+    textinput.adjust_horizontal(
+        Utf8CodeUnitLength(2),
+        Direction::Forward,
+        Selection::Selected,
+    );
     textinput.insert_char('b');
     assert_eq!(textinput.get_content(), "ababefg");
 
@@ -303,25 +343,45 @@ fn test_textinput_insert_char() {
 #[test]
 fn test_textinput_get_sorted_selection() {
     let mut textinput = text_input(Lines::Single, "abcdefg");
-    textinput.adjust_horizontal(UTF8Bytes(2), Direction::Forward, Selection::NotSelected);
-    textinput.adjust_horizontal(UTF8Bytes(2), Direction::Forward, Selection::Selected);
+    textinput.adjust_horizontal(
+        Utf8CodeUnitLength(2),
+        Direction::Forward,
+        Selection::NotSelected,
+    );
+    textinput.adjust_horizontal(
+        Utf8CodeUnitLength(2),
+        Direction::Forward,
+        Selection::Selected,
+    );
     let (start, end) = textinput.sorted_selection_bounds();
-    assert_eq!(start.index, UTF8Bytes(2));
-    assert_eq!(end.index, UTF8Bytes(4));
+    assert_eq!(start.index, Utf8CodeUnitLength(2));
+    assert_eq!(end.index, Utf8CodeUnitLength(4));
 
     textinput.clear_selection();
 
-    textinput.adjust_horizontal(UTF8Bytes(2), Direction::Backward, Selection::Selected);
+    textinput.adjust_horizontal(
+        Utf8CodeUnitLength(2),
+        Direction::Backward,
+        Selection::Selected,
+    );
     let (start, end) = textinput.sorted_selection_bounds();
-    assert_eq!(start.index, UTF8Bytes(2));
-    assert_eq!(end.index, UTF8Bytes(4));
+    assert_eq!(start.index, Utf8CodeUnitLength(2));
+    assert_eq!(end.index, Utf8CodeUnitLength(4));
 }
 
 #[test]
 fn test_textinput_replace_selection() {
     let mut textinput = text_input(Lines::Single, "abcdefg");
-    textinput.adjust_horizontal(UTF8Bytes(2), Direction::Forward, Selection::NotSelected);
-    textinput.adjust_horizontal(UTF8Bytes(2), Direction::Forward, Selection::Selected);
+    textinput.adjust_horizontal(
+        Utf8CodeUnitLength(2),
+        Direction::Forward,
+        Selection::NotSelected,
+    );
+    textinput.adjust_horizontal(
+        Utf8CodeUnitLength(2),
+        Direction::Forward,
+        Selection::Selected,
+    );
 
     textinput.replace_selection(DOMString::from("xyz"));
     assert_eq!(textinput.get_content(), "abxyzefg");
@@ -339,34 +399,38 @@ fn test_textinput_replace_selection_multibyte_char() {
 #[test]
 fn test_textinput_current_line_length() {
     let mut textinput = text_input(Lines::Multiple, "abc\nde\nf");
-    assert_eq!(textinput.current_line_length(), UTF8Bytes(3));
+    assert_eq!(textinput.current_line_length(), Utf8CodeUnitLength(3));
 
     textinput.adjust_vertical(1, Selection::NotSelected);
-    assert_eq!(textinput.current_line_length(), UTF8Bytes(2));
+    assert_eq!(textinput.current_line_length(), Utf8CodeUnitLength(2));
 
     textinput.adjust_vertical(1, Selection::NotSelected);
-    assert_eq!(textinput.current_line_length(), UTF8Bytes::one());
+    assert_eq!(textinput.current_line_length(), Utf8CodeUnitLength::one());
 }
 
 #[test]
 fn test_textinput_adjust_vertical() {
     let mut textinput = text_input(Lines::Multiple, "abc\nde\nf");
-    textinput.adjust_horizontal(UTF8Bytes(3), Direction::Forward, Selection::NotSelected);
+    textinput.adjust_horizontal(
+        Utf8CodeUnitLength(3),
+        Direction::Forward,
+        Selection::NotSelected,
+    );
     textinput.adjust_vertical(1, Selection::NotSelected);
     assert_eq!(textinput.edit_point().line, 1);
-    assert_eq!(textinput.edit_point().index, UTF8Bytes(2));
+    assert_eq!(textinput.edit_point().index, Utf8CodeUnitLength(2));
 
     textinput.adjust_vertical(-1, Selection::NotSelected);
     assert_eq!(textinput.edit_point().line, 0);
-    assert_eq!(textinput.edit_point().index, UTF8Bytes(2));
+    assert_eq!(textinput.edit_point().index, Utf8CodeUnitLength(2));
 
     textinput.adjust_vertical(2, Selection::NotSelected);
     assert_eq!(textinput.edit_point().line, 2);
-    assert_eq!(textinput.edit_point().index, UTF8Bytes(1));
+    assert_eq!(textinput.edit_point().index, Utf8CodeUnitLength(1));
 
     textinput.adjust_vertical(-1, Selection::Selected);
     assert_eq!(textinput.edit_point().line, 1);
-    assert_eq!(textinput.edit_point().index, UTF8Bytes(1));
+    assert_eq!(textinput.edit_point().index, Utf8CodeUnitLength(1));
 }
 
 #[test]
@@ -375,35 +439,47 @@ fn test_textinput_adjust_vertical_multibyte() {
 
     textinput.adjust_horizontal_by_one(Direction::Forward, Selection::NotSelected);
     assert_eq!(textinput.edit_point().line, 0);
-    assert_eq!(textinput.edit_point().index, UTF8Bytes(2));
+    assert_eq!(textinput.edit_point().index, Utf8CodeUnitLength(2));
 
     textinput.adjust_vertical(1, Selection::NotSelected);
     assert_eq!(textinput.edit_point().line, 1);
-    assert_eq!(textinput.edit_point().index, UTF8Bytes(1));
+    assert_eq!(textinput.edit_point().index, Utf8CodeUnitLength(1));
 }
 
 #[test]
 fn test_textinput_adjust_horizontal() {
     let mut textinput = text_input(Lines::Multiple, "abc\nde\nf");
-    textinput.adjust_horizontal(UTF8Bytes(4), Direction::Forward, Selection::NotSelected);
+    textinput.adjust_horizontal(
+        Utf8CodeUnitLength(4),
+        Direction::Forward,
+        Selection::NotSelected,
+    );
     assert_eq!(textinput.edit_point().line, 1);
-    assert_eq!(textinput.edit_point().index, UTF8Bytes::zero());
-
-    textinput.adjust_horizontal(UTF8Bytes::one(), Direction::Forward, Selection::NotSelected);
-    assert_eq!(textinput.edit_point().line, 1);
-    assert_eq!(textinput.edit_point().index, UTF8Bytes(1));
-
-    textinput.adjust_horizontal(UTF8Bytes(2), Direction::Forward, Selection::NotSelected);
-    assert_eq!(textinput.edit_point().line, 2);
-    assert_eq!(textinput.edit_point().index, UTF8Bytes::zero());
+    assert_eq!(textinput.edit_point().index, Utf8CodeUnitLength::zero());
 
     textinput.adjust_horizontal(
-        UTF8Bytes::one(),
+        Utf8CodeUnitLength::one(),
+        Direction::Forward,
+        Selection::NotSelected,
+    );
+    assert_eq!(textinput.edit_point().line, 1);
+    assert_eq!(textinput.edit_point().index, Utf8CodeUnitLength(1));
+
+    textinput.adjust_horizontal(
+        Utf8CodeUnitLength(2),
+        Direction::Forward,
+        Selection::NotSelected,
+    );
+    assert_eq!(textinput.edit_point().line, 2);
+    assert_eq!(textinput.edit_point().index, Utf8CodeUnitLength::zero());
+
+    textinput.adjust_horizontal(
+        Utf8CodeUnitLength::one(),
         Direction::Backward,
         Selection::NotSelected,
     );
     assert_eq!(textinput.edit_point().line, 1);
-    assert_eq!(textinput.edit_point().index, UTF8Bytes(2));
+    assert_eq!(textinput.edit_point().index, Utf8CodeUnitLength(2));
 }
 
 #[test]
@@ -413,44 +489,44 @@ fn test_textinput_adjust_horizontal_by_word() {
     textinput.adjust_horizontal_by_word(Direction::Forward, Selection::NotSelected);
     textinput.adjust_horizontal_by_word(Direction::Forward, Selection::NotSelected);
     assert_eq!(textinput.edit_point().line, 0);
-    assert_eq!(textinput.edit_point().index, UTF8Bytes(7));
+    assert_eq!(textinput.edit_point().index, Utf8CodeUnitLength(7));
     textinput.adjust_horizontal_by_word(Direction::Backward, Selection::NotSelected);
     assert_eq!(textinput.edit_point().line, 0);
-    assert_eq!(textinput.edit_point().index, UTF8Bytes(4));
+    assert_eq!(textinput.edit_point().index, Utf8CodeUnitLength(4));
     textinput.adjust_horizontal_by_word(Direction::Backward, Selection::NotSelected);
     assert_eq!(textinput.edit_point().line, 0);
-    assert_eq!(textinput.edit_point().index, UTF8Bytes::zero());
+    assert_eq!(textinput.edit_point().index, Utf8CodeUnitLength::zero());
 
     // Test new line case of movement word by word based on UAX#29 rules
     let mut textinput_2 = text_input(Lines::Multiple, "abc\ndef");
     textinput_2.adjust_horizontal_by_word(Direction::Forward, Selection::NotSelected);
     textinput_2.adjust_horizontal_by_word(Direction::Forward, Selection::NotSelected);
     assert_eq!(textinput_2.edit_point().line, 1);
-    assert_eq!(textinput_2.edit_point().index, UTF8Bytes(3));
+    assert_eq!(textinput_2.edit_point().index, Utf8CodeUnitLength(3));
     textinput_2.adjust_horizontal_by_word(Direction::Backward, Selection::NotSelected);
     assert_eq!(textinput_2.edit_point().line, 1);
-    assert_eq!(textinput_2.edit_point().index, UTF8Bytes::zero());
+    assert_eq!(textinput_2.edit_point().index, Utf8CodeUnitLength::zero());
     textinput_2.adjust_horizontal_by_word(Direction::Backward, Selection::NotSelected);
     assert_eq!(textinput_2.edit_point().line, 0);
-    assert_eq!(textinput_2.edit_point().index, UTF8Bytes::zero());
+    assert_eq!(textinput_2.edit_point().index, Utf8CodeUnitLength::zero());
 
     // Test non-standard sized characters case of movement word by word based on UAX#29 rules
     let mut textinput_3 = text_input(Lines::Single, "áéc d🌠bc");
     textinput_3.adjust_horizontal_by_word(Direction::Forward, Selection::NotSelected);
     assert_eq!(textinput_3.edit_point().line, 0);
-    assert_eq!(textinput_3.edit_point().index, UTF8Bytes(5));
+    assert_eq!(textinput_3.edit_point().index, Utf8CodeUnitLength(5));
     textinput_3.adjust_horizontal_by_word(Direction::Forward, Selection::NotSelected);
     assert_eq!(textinput_3.edit_point().line, 0);
-    assert_eq!(textinput_3.edit_point().index, UTF8Bytes(7));
+    assert_eq!(textinput_3.edit_point().index, Utf8CodeUnitLength(7));
     textinput_3.adjust_horizontal_by_word(Direction::Forward, Selection::NotSelected);
     assert_eq!(textinput_3.edit_point().line, 0);
-    assert_eq!(textinput_3.edit_point().index, UTF8Bytes(13));
+    assert_eq!(textinput_3.edit_point().index, Utf8CodeUnitLength(13));
     textinput_3.adjust_horizontal_by_word(Direction::Backward, Selection::NotSelected);
     assert_eq!(textinput_3.edit_point().line, 0);
-    assert_eq!(textinput_3.edit_point().index, UTF8Bytes(11));
+    assert_eq!(textinput_3.edit_point().index, Utf8CodeUnitLength(11));
     textinput_3.adjust_horizontal_by_word(Direction::Backward, Selection::NotSelected);
     assert_eq!(textinput_3.edit_point().line, 0);
-    assert_eq!(textinput_3.edit_point().index, UTF8Bytes(6));
+    assert_eq!(textinput_3.edit_point().index, Utf8CodeUnitLength(6));
 }
 
 #[test]
@@ -459,28 +535,28 @@ fn test_textinput_adjust_horizontal_to_line_end() {
     let mut textinput = text_input(Lines::Single, "abc def");
     textinput.adjust_horizontal_to_line_end(Direction::Forward, Selection::NotSelected);
     assert_eq!(textinput.edit_point().line, 0);
-    assert_eq!(textinput.edit_point().index, UTF8Bytes(7));
+    assert_eq!(textinput.edit_point().index, Utf8CodeUnitLength(7));
 
     // Test new line case of movement to end based on UAX#29 rules
     let mut textinput_2 = text_input(Lines::Multiple, "abc\ndef");
     textinput_2.adjust_horizontal_to_line_end(Direction::Forward, Selection::NotSelected);
     assert_eq!(textinput_2.edit_point().line, 0);
-    assert_eq!(textinput_2.edit_point().index, UTF8Bytes(3));
+    assert_eq!(textinput_2.edit_point().index, Utf8CodeUnitLength(3));
     textinput_2.adjust_horizontal_to_line_end(Direction::Forward, Selection::NotSelected);
     assert_eq!(textinput_2.edit_point().line, 0);
-    assert_eq!(textinput_2.edit_point().index, UTF8Bytes(3));
+    assert_eq!(textinput_2.edit_point().index, Utf8CodeUnitLength(3));
     textinput_2.adjust_horizontal_to_line_end(Direction::Backward, Selection::NotSelected);
     assert_eq!(textinput_2.edit_point().line, 0);
-    assert_eq!(textinput_2.edit_point().index, UTF8Bytes::zero());
+    assert_eq!(textinput_2.edit_point().index, Utf8CodeUnitLength::zero());
 
     // Test non-standard sized characters case of movement to end based on UAX#29 rules
     let mut textinput_3 = text_input(Lines::Single, "áéc d🌠bc");
     textinput_3.adjust_horizontal_to_line_end(Direction::Forward, Selection::NotSelected);
     assert_eq!(textinput_3.edit_point().line, 0);
-    assert_eq!(textinput_3.edit_point().index, UTF8Bytes(13));
+    assert_eq!(textinput_3.edit_point().index, Utf8CodeUnitLength(13));
     textinput_3.adjust_horizontal_to_line_end(Direction::Backward, Selection::NotSelected);
     assert_eq!(textinput_3.edit_point().line, 0);
-    assert_eq!(textinput_3.edit_point().index, UTF8Bytes::zero());
+    assert_eq!(textinput_3.edit_point().index, Utf8CodeUnitLength::zero());
 }
 
 #[test]
@@ -489,52 +565,52 @@ fn test_navigation_keyboard_shortcuts() {
 
     // Test that CMD + Right moves to the end of the current line.
     textinput.handle_keydown_aux(Key::Named(NamedKey::ArrowRight), Modifiers::META, true);
-    assert_eq!(textinput.edit_point().index, UTF8Bytes(11));
+    assert_eq!(textinput.edit_point().index, Utf8CodeUnitLength(11));
     // Test that CMD + Right moves to the beginning of the current line.
     textinput.handle_keydown_aux(Key::Named(NamedKey::ArrowLeft), Modifiers::META, true);
-    assert_eq!(textinput.edit_point().index, UTF8Bytes::zero());
+    assert_eq!(textinput.edit_point().index, Utf8CodeUnitLength::zero());
     // Test that CTRL + ALT + E moves to the end of the current line also.
     textinput.handle_keydown_aux(
         Key::Character("e".to_owned()),
         Modifiers::CONTROL | Modifiers::ALT,
         true,
     );
-    assert_eq!(textinput.edit_point().index, UTF8Bytes(11));
+    assert_eq!(textinput.edit_point().index, Utf8CodeUnitLength(11));
     // Test that CTRL + ALT + A moves to the beginning of the current line also.
     textinput.handle_keydown_aux(
         Key::Character("a".to_owned()),
         Modifiers::CONTROL | Modifiers::ALT,
         true,
     );
-    assert_eq!(textinput.edit_point().index, UTF8Bytes::zero());
+    assert_eq!(textinput.edit_point().index, Utf8CodeUnitLength::zero());
 
     // Test that ALT + Right moves to the end of the word.
     textinput.handle_keydown_aux(Key::Named(NamedKey::ArrowRight), Modifiers::ALT, true);
-    assert_eq!(textinput.edit_point().index, UTF8Bytes(5));
+    assert_eq!(textinput.edit_point().index, Utf8CodeUnitLength(5));
     // Test that CTRL + ALT + F moves to the end of the word also.
     textinput.handle_keydown_aux(
         Key::Character("f".to_owned()),
         Modifiers::CONTROL | Modifiers::ALT,
         true,
     );
-    assert_eq!(textinput.edit_point().index, UTF8Bytes(11));
+    assert_eq!(textinput.edit_point().index, Utf8CodeUnitLength(11));
     // Test that ALT + Left moves to the end of the word.
     textinput.handle_keydown_aux(Key::Named(NamedKey::ArrowLeft), Modifiers::ALT, true);
-    assert_eq!(textinput.edit_point().index, UTF8Bytes(6));
+    assert_eq!(textinput.edit_point().index, Utf8CodeUnitLength(6));
     // Test that CTRL + ALT + B moves to the end of the word also.
     textinput.handle_keydown_aux(
         Key::Character("b".to_owned()),
         Modifiers::CONTROL | Modifiers::ALT,
         true,
     );
-    assert_eq!(textinput.edit_point().index, UTF8Bytes::zero());
+    assert_eq!(textinput.edit_point().index, Utf8CodeUnitLength::zero());
 }
 
 #[test]
 fn test_textinput_handle_return() {
     let mut single_line_textinput = text_input(Lines::Single, "abcdef");
     single_line_textinput.adjust_horizontal(
-        UTF8Bytes(3),
+        Utf8CodeUnitLength(3),
         Direction::Forward,
         Selection::NotSelected,
     );
@@ -543,7 +619,7 @@ fn test_textinput_handle_return() {
 
     let mut multi_line_textinput = text_input(Lines::Multiple, "abcdef");
     multi_line_textinput.adjust_horizontal(
-        UTF8Bytes(3),
+        Utf8CodeUnitLength(3),
         Direction::Forward,
         Selection::NotSelected,
     );
@@ -555,11 +631,11 @@ fn test_textinput_handle_return() {
 fn test_textinput_select_all() {
     let mut textinput = text_input(Lines::Multiple, "abc\nde\nf");
     assert_eq!(textinput.edit_point().line, 0);
-    assert_eq!(textinput.edit_point().index, UTF8Bytes::zero());
+    assert_eq!(textinput.edit_point().index, Utf8CodeUnitLength::zero());
 
     textinput.select_all();
     assert_eq!(textinput.edit_point().line, 2);
-    assert_eq!(textinput.edit_point().index, UTF8Bytes(1));
+    assert_eq!(textinput.edit_point().index, Utf8CodeUnitLength(1));
 }
 
 #[test]
@@ -580,15 +656,19 @@ fn test_textinput_set_content() {
     assert_eq!(textinput.get_content(), "abc\nf");
 
     assert_eq!(textinput.edit_point().line, 0);
-    assert_eq!(textinput.edit_point().index, UTF8Bytes::zero());
+    assert_eq!(textinput.edit_point().index, Utf8CodeUnitLength::zero());
 
-    textinput.adjust_horizontal(UTF8Bytes(3), Direction::Forward, Selection::Selected);
+    textinput.adjust_horizontal(
+        Utf8CodeUnitLength(3),
+        Direction::Forward,
+        Selection::Selected,
+    );
     assert_eq!(textinput.edit_point().line, 0);
-    assert_eq!(textinput.edit_point().index, UTF8Bytes(3));
+    assert_eq!(textinput.edit_point().index, Utf8CodeUnitLength(3));
     textinput.set_content(DOMString::from("de"));
     assert_eq!(textinput.get_content(), "de");
     assert_eq!(textinput.edit_point().line, 0);
-    assert_eq!(textinput.edit_point().index, UTF8Bytes(2));
+    assert_eq!(textinput.edit_point().index, Utf8CodeUnitLength(2));
 }
 
 #[test]
@@ -607,7 +687,7 @@ fn test_clipboard_paste() {
         SelectionDirection::None,
     );
     assert_eq!(textinput.get_content(), "defg");
-    assert_eq!(textinput.edit_point().index, UTF8Bytes::zero());
+    assert_eq!(textinput.edit_point().index, Utf8CodeUnitLength::zero());
     textinput.handle_keydown_aux(Key::Character("v".to_owned()), MODIFIERS, false);
     assert_eq!(textinput.get_content(), "abcdefg");
 }
@@ -617,59 +697,123 @@ fn test_textinput_cursor_position_correct_after_clearing_selection() {
     let mut textinput = text_input(Lines::Single, "abcdef");
 
     // Single line - Forward
-    textinput.adjust_horizontal(UTF8Bytes(3), Direction::Forward, Selection::Selected);
-    textinput.adjust_horizontal(UTF8Bytes::one(), Direction::Forward, Selection::NotSelected);
-    assert_eq!(textinput.edit_point().index, UTF8Bytes(3));
-
-    textinput.adjust_horizontal(UTF8Bytes(3), Direction::Backward, Selection::NotSelected);
-    textinput.adjust_horizontal(UTF8Bytes(3), Direction::Forward, Selection::Selected);
-    textinput.adjust_horizontal_by_one(Direction::Forward, Selection::NotSelected);
-    assert_eq!(textinput.edit_point().index, UTF8Bytes(3));
-
-    // Single line - Backward
-    textinput.adjust_horizontal(UTF8Bytes(3), Direction::Backward, Selection::NotSelected);
-    textinput.adjust_horizontal(UTF8Bytes(3), Direction::Forward, Selection::Selected);
     textinput.adjust_horizontal(
-        UTF8Bytes::one(),
+        Utf8CodeUnitLength(3),
+        Direction::Forward,
+        Selection::Selected,
+    );
+    textinput.adjust_horizontal(
+        Utf8CodeUnitLength::one(),
+        Direction::Forward,
+        Selection::NotSelected,
+    );
+    assert_eq!(textinput.edit_point().index, Utf8CodeUnitLength(3));
+
+    textinput.adjust_horizontal(
+        Utf8CodeUnitLength(3),
         Direction::Backward,
         Selection::NotSelected,
     );
-    assert_eq!(textinput.edit_point().index, UTF8Bytes::zero());
+    textinput.adjust_horizontal(
+        Utf8CodeUnitLength(3),
+        Direction::Forward,
+        Selection::Selected,
+    );
+    textinput.adjust_horizontal_by_one(Direction::Forward, Selection::NotSelected);
+    assert_eq!(textinput.edit_point().index, Utf8CodeUnitLength(3));
 
-    textinput.adjust_horizontal(UTF8Bytes(3), Direction::Backward, Selection::NotSelected);
-    textinput.adjust_horizontal(UTF8Bytes(3), Direction::Forward, Selection::Selected);
+    // Single line - Backward
+    textinput.adjust_horizontal(
+        Utf8CodeUnitLength(3),
+        Direction::Backward,
+        Selection::NotSelected,
+    );
+    textinput.adjust_horizontal(
+        Utf8CodeUnitLength(3),
+        Direction::Forward,
+        Selection::Selected,
+    );
+    textinput.adjust_horizontal(
+        Utf8CodeUnitLength::one(),
+        Direction::Backward,
+        Selection::NotSelected,
+    );
+    assert_eq!(textinput.edit_point().index, Utf8CodeUnitLength::zero());
+
+    textinput.adjust_horizontal(
+        Utf8CodeUnitLength(3),
+        Direction::Backward,
+        Selection::NotSelected,
+    );
+    textinput.adjust_horizontal(
+        Utf8CodeUnitLength(3),
+        Direction::Forward,
+        Selection::Selected,
+    );
     textinput.adjust_horizontal_by_one(Direction::Backward, Selection::NotSelected);
-    assert_eq!(textinput.edit_point().index, UTF8Bytes::zero());
+    assert_eq!(textinput.edit_point().index, Utf8CodeUnitLength::zero());
 
     let mut textinput = text_input(Lines::Multiple, "abc\nde\nf");
 
     // Multiline - Forward
-    textinput.adjust_horizontal(UTF8Bytes(4), Direction::Forward, Selection::Selected);
-    textinput.adjust_horizontal(UTF8Bytes::one(), Direction::Forward, Selection::NotSelected);
-    assert_eq!(textinput.edit_point().index, UTF8Bytes::zero());
-    assert_eq!(textinput.edit_point().line, 1);
-
-    textinput.adjust_horizontal(UTF8Bytes(4), Direction::Backward, Selection::NotSelected);
-    textinput.adjust_horizontal(UTF8Bytes(4), Direction::Forward, Selection::Selected);
-    textinput.adjust_horizontal_by_one(Direction::Forward, Selection::NotSelected);
-    assert_eq!(textinput.edit_point().index, UTF8Bytes::zero());
-    assert_eq!(textinput.edit_point().line, 1);
-
-    // Multiline - Backward
-    textinput.adjust_horizontal(UTF8Bytes(4), Direction::Backward, Selection::NotSelected);
-    textinput.adjust_horizontal(UTF8Bytes(4), Direction::Forward, Selection::Selected);
     textinput.adjust_horizontal(
-        UTF8Bytes::one(),
+        Utf8CodeUnitLength(4),
+        Direction::Forward,
+        Selection::Selected,
+    );
+    textinput.adjust_horizontal(
+        Utf8CodeUnitLength::one(),
+        Direction::Forward,
+        Selection::NotSelected,
+    );
+    assert_eq!(textinput.edit_point().index, Utf8CodeUnitLength::zero());
+    assert_eq!(textinput.edit_point().line, 1);
+
+    textinput.adjust_horizontal(
+        Utf8CodeUnitLength(4),
         Direction::Backward,
         Selection::NotSelected,
     );
-    assert_eq!(textinput.edit_point().index, UTF8Bytes::zero());
+    textinput.adjust_horizontal(
+        Utf8CodeUnitLength(4),
+        Direction::Forward,
+        Selection::Selected,
+    );
+    textinput.adjust_horizontal_by_one(Direction::Forward, Selection::NotSelected);
+    assert_eq!(textinput.edit_point().index, Utf8CodeUnitLength::zero());
+    assert_eq!(textinput.edit_point().line, 1);
+
+    // Multiline - Backward
+    textinput.adjust_horizontal(
+        Utf8CodeUnitLength(4),
+        Direction::Backward,
+        Selection::NotSelected,
+    );
+    textinput.adjust_horizontal(
+        Utf8CodeUnitLength(4),
+        Direction::Forward,
+        Selection::Selected,
+    );
+    textinput.adjust_horizontal(
+        Utf8CodeUnitLength::one(),
+        Direction::Backward,
+        Selection::NotSelected,
+    );
+    assert_eq!(textinput.edit_point().index, Utf8CodeUnitLength::zero());
     assert_eq!(textinput.edit_point().line, 0);
 
-    textinput.adjust_horizontal(UTF8Bytes(4), Direction::Backward, Selection::NotSelected);
-    textinput.adjust_horizontal(UTF8Bytes(4), Direction::Forward, Selection::Selected);
+    textinput.adjust_horizontal(
+        Utf8CodeUnitLength(4),
+        Direction::Backward,
+        Selection::NotSelected,
+    );
+    textinput.adjust_horizontal(
+        Utf8CodeUnitLength(4),
+        Direction::Forward,
+        Selection::Selected,
+    );
     textinput.adjust_horizontal_by_one(Direction::Backward, Selection::NotSelected);
-    assert_eq!(textinput.edit_point().index, UTF8Bytes::zero());
+    assert_eq!(textinput.edit_point().index, Utf8CodeUnitLength::zero());
     assert_eq!(textinput.edit_point().line, 0);
 }
 
@@ -678,16 +822,19 @@ fn test_textinput_set_selection_with_direction() {
     let mut textinput = text_input(Lines::Single, "abcdef");
     textinput.set_selection_range(2, 6, SelectionDirection::Forward);
     assert_eq!(textinput.edit_point().line, 0);
-    assert_eq!(textinput.edit_point().index, UTF8Bytes(6));
+    assert_eq!(textinput.edit_point().index, Utf8CodeUnitLength(6));
     assert_eq!(textinput.selection_direction(), SelectionDirection::Forward);
 
     assert!(textinput.selection_origin().is_some());
     assert_eq!(textinput.selection_origin().unwrap().line, 0);
-    assert_eq!(textinput.selection_origin().unwrap().index, UTF8Bytes(2));
+    assert_eq!(
+        textinput.selection_origin().unwrap().index,
+        Utf8CodeUnitLength(2)
+    );
 
     textinput.set_selection_range(2, 6, SelectionDirection::Backward);
     assert_eq!(textinput.edit_point().line, 0);
-    assert_eq!(textinput.edit_point().index, UTF8Bytes(2));
+    assert_eq!(textinput.edit_point().index, Utf8CodeUnitLength(2));
     assert_eq!(
         textinput.selection_direction(),
         SelectionDirection::Backward
@@ -695,43 +842,46 @@ fn test_textinput_set_selection_with_direction() {
 
     assert!(textinput.selection_origin().is_some());
     assert_eq!(textinput.selection_origin().unwrap().line, 0);
-    assert_eq!(textinput.selection_origin().unwrap().index, UTF8Bytes(6));
+    assert_eq!(
+        textinput.selection_origin().unwrap().index,
+        Utf8CodeUnitLength(6)
+    );
 
     textinput = text_input(Lines::Multiple, "\n\n");
     textinput.set_selection_range(0, 1, SelectionDirection::Forward);
     assert_eq!(textinput.edit_point().line, 1);
-    assert_eq!(textinput.edit_point().index, UTF8Bytes::zero());
+    assert_eq!(textinput.edit_point().index, Utf8CodeUnitLength::zero());
     assert_eq!(textinput.selection_direction(), SelectionDirection::Forward);
 
     assert!(textinput.selection_origin().is_some());
     assert_eq!(textinput.selection_origin().unwrap().line, 0);
     assert_eq!(
         textinput.selection_origin().unwrap().index,
-        UTF8Bytes::zero()
+        Utf8CodeUnitLength::zero()
     );
 
     textinput = text_input(Lines::Multiple, "\n");
     textinput.set_selection_range(0, 1, SelectionDirection::Forward);
     assert_eq!(textinput.edit_point().line, 1);
-    assert_eq!(textinput.edit_point().index, UTF8Bytes::zero());
+    assert_eq!(textinput.edit_point().index, Utf8CodeUnitLength::zero());
     assert_eq!(textinput.selection_direction(), SelectionDirection::Forward);
 
     assert!(textinput.selection_origin().is_some());
     assert_eq!(textinput.selection_origin().unwrap().line, 0);
     assert_eq!(
         textinput.selection_origin().unwrap().index,
-        UTF8Bytes::zero()
+        Utf8CodeUnitLength::zero()
     );
 }
 
 #[test]
 fn test_textinput_unicode_handling() {
     let mut textinput = text_input(Lines::Single, "éèùµ$£");
-    assert_eq!(textinput.edit_point().index, UTF8Bytes::zero());
+    assert_eq!(textinput.edit_point().index, Utf8CodeUnitLength::zero());
     textinput.set_edit_point_index(1);
-    assert_eq!(textinput.edit_point().index, UTF8Bytes(2));
+    assert_eq!(textinput.edit_point().index, Utf8CodeUnitLength(2));
     textinput.set_edit_point_index(4);
-    assert_eq!(textinput.edit_point().index, UTF8Bytes(8));
+    assert_eq!(textinput.edit_point().index, Utf8CodeUnitLength(8));
 }
 
 #[test]
@@ -741,21 +891,21 @@ fn test_selection_bounds() {
     assert_eq!(
         TextPoint {
             line: 0,
-            index: UTF8Bytes::zero()
+            index: Utf8CodeUnitLength::zero()
         },
         textinput.selection_origin_or_edit_point()
     );
     assert_eq!(
         TextPoint {
             line: 0,
-            index: UTF8Bytes::zero()
+            index: Utf8CodeUnitLength::zero()
         },
         textinput.selection_start()
     );
     assert_eq!(
         TextPoint {
             line: 0,
-            index: UTF8Bytes::zero()
+            index: Utf8CodeUnitLength::zero()
         },
         textinput.selection_end()
     );
@@ -764,72 +914,72 @@ fn test_selection_bounds() {
     assert_eq!(
         TextPoint {
             line: 0,
-            index: UTF8Bytes(2)
+            index: Utf8CodeUnitLength(2)
         },
         textinput.selection_origin_or_edit_point()
     );
     assert_eq!(
         TextPoint {
             line: 0,
-            index: UTF8Bytes(2)
+            index: Utf8CodeUnitLength(2)
         },
         textinput.selection_start()
     );
     assert_eq!(
         TextPoint {
             line: 0,
-            index: UTF8Bytes(5)
+            index: Utf8CodeUnitLength(5)
         },
         textinput.selection_end()
     );
-    assert_eq!(UTF8Bytes(2), textinput.selection_start_offset());
-    assert_eq!(UTF8Bytes(5), textinput.selection_end_offset());
+    assert_eq!(Utf8CodeUnitLength(2), textinput.selection_start_offset());
+    assert_eq!(Utf8CodeUnitLength(5), textinput.selection_end_offset());
 
     textinput.set_selection_range(3, 6, SelectionDirection::Backward);
     assert_eq!(
         TextPoint {
             line: 0,
-            index: UTF8Bytes(6)
+            index: Utf8CodeUnitLength(6)
         },
         textinput.selection_origin_or_edit_point()
     );
     assert_eq!(
         TextPoint {
             line: 0,
-            index: UTF8Bytes(3)
+            index: Utf8CodeUnitLength(3)
         },
         textinput.selection_start()
     );
     assert_eq!(
         TextPoint {
             line: 0,
-            index: UTF8Bytes(6)
+            index: Utf8CodeUnitLength(6)
         },
         textinput.selection_end()
     );
-    assert_eq!(UTF8Bytes(3), textinput.selection_start_offset());
-    assert_eq!(UTF8Bytes(6), textinput.selection_end_offset());
+    assert_eq!(Utf8CodeUnitLength(3), textinput.selection_start_offset());
+    assert_eq!(Utf8CodeUnitLength(6), textinput.selection_end_offset());
 
     textinput = text_input(Lines::Multiple, "\n\n");
     textinput.set_selection_range(0, 1, SelectionDirection::Forward);
     assert_eq!(
         TextPoint {
             line: 0,
-            index: UTF8Bytes::zero()
+            index: Utf8CodeUnitLength::zero()
         },
         textinput.selection_origin_or_edit_point()
     );
     assert_eq!(
         TextPoint {
             line: 0,
-            index: UTF8Bytes::zero()
+            index: Utf8CodeUnitLength::zero()
         },
         textinput.selection_start()
     );
     assert_eq!(
         TextPoint {
             line: 1,
-            index: UTF8Bytes::zero()
+            index: Utf8CodeUnitLength::zero()
         },
         textinput.selection_end()
     );
@@ -844,14 +994,14 @@ fn test_select_all() {
     assert_eq!(
         TextPoint {
             line: 0,
-            index: UTF8Bytes::zero()
+            index: Utf8CodeUnitLength::zero()
         },
         textinput.selection_start()
     );
     assert_eq!(
         TextPoint {
             line: 0,
-            index: UTF8Bytes(3)
+            index: Utf8CodeUnitLength(3)
         },
         textinput.selection_end()
     );


### PR DESCRIPTION
This moves the Unicode offset types to the `base` crate and makes them
generally more usable throughout the Servo codebase. In addition, they
are renamed to use Rust naming and to be a bit more consistent:

 - `UTF8Bytes` -> `Utf8CodeUnitLength`
 - `UTF16CodeUnits` -> `Utf16CodeUnitLength`

There is also a bit more documentation explaining their use.

This is preparation for fixing issues with UTF-16 offsets in editable
text fields.

Testing: This does not change behavior so existing WPT tests should suffice.
