### PR TITLE
servoshell: Reduce allocations during cmdline parsing

### DIFF
--- a/ports/servoshell/desktop/cli.rs
+++ b/ports/servoshell/desktop/cli.rs
@@ -18,8 +18,9 @@ pub fn main() {
     // log_panics::init()?
     panic::set_hook(Box::new(panic_hook::panic_hook));
 
-    let args = env::args().collect();
-    let (opts, preferences, servoshell_preferences) = match parse_command_line_arguments(args) {
+    // Skip the first argument, which is the binary name.
+    let args: Vec<String> = env::args().skip(1).collect();
+    let (opts, preferences, servoshell_preferences) = match parse_command_line_arguments(&*args) {
         ArgumentParsingResult::ContentProcess(token) => return servo::run_content_process(token),
         ArgumentParsingResult::ChromeProcess(opts, preferences, servoshell_preferences) => {
             (opts, preferences, servoshell_preferences)

--- a/ports/servoshell/egl/android/mod.rs
+++ b/ports/servoshell/egl/android/mod.rs
@@ -170,22 +170,19 @@ pub extern "C" fn Java_org_servo_servoview_JNIServo_init<'local>(
     crate::init_crypto();
     servo::resources::set(Box::new(ResourceReaderInstance::new()));
 
-    // `parse_command_line_arguments` expects the first argument to be the binary name.
-    let mut args = mem::take(&mut init_opts.args);
-    args.insert(0, "servo".to_string());
-
-    let (opts, mut preferences, servoshell_preferences) = match parse_command_line_arguments(args) {
-        ArgumentParsingResult::ContentProcess(..) => {
-            unreachable!("Android does not have support for multiprocess yet.")
-        },
-        ArgumentParsingResult::ChromeProcess(opts, preferences, servoshell_preferences) => {
-            (opts, preferences, servoshell_preferences)
-        },
-        ArgumentParsingResult::Exit => {
-            std::process::exit(0);
-        },
-        ArgumentParsingResult::ErrorParsing => std::process::exit(1),
-    };
+    let (opts, mut preferences, servoshell_preferences) =
+        match parse_command_line_arguments(init_opts.args.as_slice()) {
+            ArgumentParsingResult::ContentProcess(..) => {
+                unreachable!("Android does not have support for multiprocess yet.")
+            },
+            ArgumentParsingResult::ChromeProcess(opts, preferences, servoshell_preferences) => {
+                (opts, preferences, servoshell_preferences)
+            },
+            ArgumentParsingResult::Exit => {
+                std::process::exit(0);
+            },
+            ArgumentParsingResult::ErrorParsing => std::process::exit(1),
+        };
 
     preferences.set_value("viewport_meta_enabled", servo::PrefValue::Bool(true));
 


### PR DESCRIPTION
- The helper method now accepts args without the binary name. This allows us to remove the injection of servo / servoshell in the tests and on android / ohos.
- Allow parsing str slices, instead of requiring Vec<String>. This allows removing unnecessary conversions / allocations.

Testing: Covered by existing unit, integration and wpt tests, which pass commandline arguments.

