### PR TITLE
libservo: Group site data entries by eTLD+1 and simplify related tests

### DIFF
--- a/components/net/test_util.rs
+++ b/components/net/test_util.rs
@@ -62,6 +62,7 @@ pub fn create_embedder_proxy() -> EmbedderProxy {
     }
 }
 
+#[derive(Debug)]
 pub struct Server {
     pub close_channel: tokio::sync::oneshot::Sender<()>,
     pub certificates: Option<Vec<CertificateDer<'static>>>,

--- a/components/servo/site_data_manager.rs
+++ b/components/servo/site_data_manager.rs
@@ -95,6 +95,8 @@ impl SiteDataManager {
     /// origin) and indicates which kinds of storage data are present for it
     /// (e.g. localStorage, sessionStorage).
     ///
+    /// The returned list is sorted by site name.
+    ///
     /// Both public and private storage are included in the result.
     ///
     /// Note: At this stage, sites correspond directly to origins. Future work
@@ -135,10 +137,14 @@ impl SiteDataManager {
             add_origins(private_origins, StorageType::Session);
         }
 
-        sites
+        let mut result: Vec<SiteData> = sites
             .into_iter()
             .map(|(name, storage_types)| SiteData::new(name, storage_types))
-            .collect()
+            .collect();
+
+        result.sort_by_key(|a| a.name());
+
+        result
     }
 
     pub fn clear_cookies(&self) {

--- a/components/servo/site_data_manager.rs
+++ b/components/servo/site_data_manager.rs
@@ -28,21 +28,6 @@ bitflags! {
     }
 }
 
-/// Provides APIs for inspecting and managing site data.
-///
-/// `SiteDataManager` exposes information about data that is conceptually
-/// associated with a site (currently equivalent to an origin), such as
-/// web exposed storage mechanisms like `localStorage` and `sessionStorage`.
-///
-/// The manager can be used by embedders to list sites with stored data.
-/// Support for site scoped management operations (e.g. clearing data for a
-/// specific site) will be added in the future.
-///
-/// At this stage, sites correspond directly to origins. Future work may group
-/// data at a higher level (e.g. by eTLD+1).
-///
-/// Note: Network layer state (such as the HTTP cache) is intentionally not
-/// handled by `SiteDataManager`. That functionality lives in `NetworkManager`.
 #[derive(Clone, Debug, PartialEq)]
 pub struct SiteData {
     name: String,
@@ -66,6 +51,21 @@ impl SiteData {
     }
 }
 
+/// Provides APIs for inspecting and managing site data.
+///
+/// `SiteDataManager` exposes information about data that is conceptually
+/// associated with a site (currently equivalent to an origin), such as
+/// web exposed storage mechanisms like `localStorage` and `sessionStorage`.
+///
+/// The manager can be used by embedders to list sites with stored data.
+/// Support for site scoped management operations (e.g. clearing data for a
+/// specific site) will be added in the future.
+///
+/// At this stage, sites correspond directly to origins. Future work may group
+/// data at a higher level (e.g. by eTLD+1).
+///
+/// Note: Network layer state (such as the HTTP cache) is intentionally not
+/// handled by `SiteDataManager`. That functionality lives in `NetworkManager`.
 pub struct SiteDataManager {
     public_resource_threads: ResourceThreads,
     private_resource_threads: ResourceThreads,

--- a/components/servo/tests/site_data_manager.rs
+++ b/components/servo/tests/site_data_manager.rs
@@ -14,15 +14,6 @@ use servo::{JSValue, SiteData, StorageType, WebViewBuilder};
 
 use crate::common::{ServoTest, WebViewDelegateImpl, evaluate_javascript};
 
-fn sites_equal_unordered(actual: &[SiteData], expected: &[SiteData]) -> bool {
-    let mut actual = actual.to_vec();
-    let expected = expected.to_vec();
-
-    actual.sort_by(|a, b| a.name().cmp(&b.name()));
-
-    actual == expected
-}
-
 #[test]
 fn test_site_data() {
     let servo_test = ServoTest::new();
@@ -76,23 +67,23 @@ fn test_site_data() {
     );
 
     let sites = site_data_manager.site_data(StorageType::Local);
-    assert!(sites_equal_unordered(
+    assert_eq!(
         &sites,
         &[SiteData::new(
             format!("http://localhost:{}", port1),
             StorageType::Local
         ),]
-    ));
+    );
     let sites = site_data_manager.site_data(StorageType::Session);
     assert_eq!(sites.len(), 0);
     let sites = site_data_manager.site_data(StorageType::all());
-    assert!(sites_equal_unordered(
+    assert_eq!(
         &sites,
         &[SiteData::new(
             format!("http://localhost:{}", port1),
             StorageType::Local
         ),]
-    ));
+    );
 
     delegate.reset();
     webview.load(url2.clone().into_url());
@@ -109,23 +100,23 @@ fn test_site_data() {
     let sites = site_data_manager.site_data(StorageType::Local);
     // TODO: File an issue for this, there should be only one site with
     // localStorage origin.
-    assert!(sites_equal_unordered(
+    assert_eq!(
         &sites,
         &[
             SiteData::new(format!("http://localhost:{}", port1), StorageType::Local),
             SiteData::new(format!("http://localhost:{}", port2), StorageType::Local),
         ]
-    ));
+    );
     let sites = site_data_manager.site_data(StorageType::Session);
-    assert!(sites_equal_unordered(
+    assert_eq!(
         &sites,
         &[SiteData::new(
             format!("http://localhost:{}", port2),
             StorageType::Session
         ),]
-    ));
+    );
     let sites = site_data_manager.site_data(StorageType::all());
-    assert!(sites_equal_unordered(
+    assert_eq!(
         &sites,
         &[
             SiteData::new(format!("http://localhost:{}", port1), StorageType::Local),
@@ -134,7 +125,7 @@ fn test_site_data() {
                 StorageType::Local | StorageType::Session
             ),
         ]
-    ));
+    );
 }
 
 #[test]

--- a/components/servo/tests/site_data_manager.rs
+++ b/components/servo/tests/site_data_manager.rs
@@ -14,13 +14,9 @@ use servo::{JSValue, SiteData, StorageType, WebViewBuilder};
 
 use crate::common::{ServoTest, WebViewDelegateImpl, evaluate_javascript};
 
-fn sites_equal_unordered(actual: &[SiteData], expected: &[(&str, StorageType)]) -> bool {
+fn sites_equal_unordered(actual: &[SiteData], expected: &[SiteData]) -> bool {
     let mut actual = actual.to_vec();
-
-    let expected: Vec<SiteData> = expected
-        .iter()
-        .map(|(name, storage_types)| SiteData::new((*name).to_string(), *storage_types))
-        .collect();
+    let expected = expected.to_vec();
 
     actual.sort_by(|a, b| a.name().cmp(&b.name()));
 
@@ -82,14 +78,20 @@ fn test_site_data() {
     let sites = site_data_manager.site_data(StorageType::Local);
     assert!(sites_equal_unordered(
         &sites,
-        &[(&format!("http://localhost:{}", port1), StorageType::Local),]
+        &[SiteData::new(
+            format!("http://localhost:{}", port1),
+            StorageType::Local
+        ),]
     ));
     let sites = site_data_manager.site_data(StorageType::Session);
     assert_eq!(sites.len(), 0);
     let sites = site_data_manager.site_data(StorageType::all());
     assert!(sites_equal_unordered(
         &sites,
-        &[(&format!("http://localhost:{}", port1), StorageType::Local),]
+        &[SiteData::new(
+            format!("http://localhost:{}", port1),
+            StorageType::Local
+        ),]
     ));
 
     delegate.reset();
@@ -110,22 +112,25 @@ fn test_site_data() {
     assert!(sites_equal_unordered(
         &sites,
         &[
-            (&format!("http://localhost:{}", port1), StorageType::Local),
-            (&format!("http://localhost:{}", port2), StorageType::Local),
+            SiteData::new(format!("http://localhost:{}", port1), StorageType::Local),
+            SiteData::new(format!("http://localhost:{}", port2), StorageType::Local),
         ]
     ));
     let sites = site_data_manager.site_data(StorageType::Session);
     assert!(sites_equal_unordered(
         &sites,
-        &[(&format!("http://localhost:{}", port2), StorageType::Session),]
+        &[SiteData::new(
+            format!("http://localhost:{}", port2),
+            StorageType::Session
+        ),]
     ));
     let sites = site_data_manager.site_data(StorageType::all());
     assert!(sites_equal_unordered(
         &sites,
         &[
-            (&format!("http://localhost:{}", port1), StorageType::Local),
-            (
-                &format!("http://localhost:{}", port2),
+            SiteData::new(format!("http://localhost:{}", port1), StorageType::Local),
+            SiteData::new(
+                format!("http://localhost:{}", port2),
                 StorageType::Local | StorageType::Session
             ),
         ]

--- a/components/servo/tests/site_data_manager.rs
+++ b/components/servo/tests/site_data_manager.rs
@@ -80,20 +80,14 @@ fn test_site_data() {
     let sites = site_data_manager.site_data(StorageType::Local);
     assert_eq!(
         &sites,
-        &[SiteData::new(
-            format!("http://www.site-data-1.test:{}", port1),
-            StorageType::Local
-        ),]
+        &[SiteData::new("site-data-1.test", StorageType::Local),]
     );
     let sites = site_data_manager.site_data(StorageType::Session);
     assert_eq!(sites.len(), 0);
     let sites = site_data_manager.site_data(StorageType::all());
     assert_eq!(
         &sites,
-        &[SiteData::new(
-            format!("http://www.site-data-1.test:{}", port1),
-            StorageType::Local
-        ),]
+        &[SiteData::new("site-data-1.test", StorageType::Local),]
     );
 
     delegate.reset();
@@ -114,34 +108,22 @@ fn test_site_data() {
     assert_eq!(
         &sites,
         &[
-            SiteData::new(
-                format!("http://www.site-data-1.test:{}", port1),
-                StorageType::Local
-            ),
-            SiteData::new(
-                format!("http://www.site-data-2.test:{}", port2),
-                StorageType::Local
-            ),
+            SiteData::new("site-data-1.test", StorageType::Local),
+            SiteData::new("site-data-2.test", StorageType::Local),
         ]
     );
     let sites = site_data_manager.site_data(StorageType::Session);
     assert_eq!(
         &sites,
-        &[SiteData::new(
-            format!("http://www.site-data-2.test:{}", port2),
-            StorageType::Session
-        ),]
+        &[SiteData::new("site-data-2.test", StorageType::Session),]
     );
     let sites = site_data_manager.site_data(StorageType::all());
     assert_eq!(
         &sites,
         &[
+            SiteData::new("site-data-1.test", StorageType::Local),
             SiteData::new(
-                format!("http://www.site-data-1.test:{}", port1),
-                StorageType::Local
-            ),
-            SiteData::new(
-                format!("http://www.site-data-2.test:{}", port2),
+                "site-data-2.test",
                 StorageType::Local | StorageType::Session
             ),
         ]


### PR DESCRIPTION
This PR updates `SiteDataManager::site_data` to group entries by eTLD+1
instead of origin, matching how site data is typically presented in browser
UI and aligning the API with user expectations.

The earlier patches in the series clean up the related tests (deterministic
server ordering, clearer expectations, sorted output) to make the change straightforward.

This also lays groundwork for future extensions such as cookie related site
data reporting.

Testing: The integration test was updated to reflect the new eTLD+1 grouping.
