### PR TITLE
libservo: Extend `SiteDataManager::site_data` to include cookie sites

### DIFF
--- a/components/net/resource_thread.rs
+++ b/components/net/resource_thread.rs
@@ -505,6 +505,11 @@ impl ResourceChannelManager {
                     .collect();
                 consumer.send(cookies).unwrap();
             },
+            CoreResourceMsg::ListCookies(sender) => {
+                let mut cookie_jar = http_state.cookie_jar.write();
+                cookie_jar.remove_all_expired_cookies();
+                let _ = sender.send(cookie_jar.cookie_site_descriptors());
+            },
             CoreResourceMsg::GetHistoryState(history_state_id, consumer) => {
                 let history_states = http_state.history_states.read();
                 consumer


### PR DESCRIPTION
Extend `SiteDataManager::site_data` to include sites that have cookies
stored by the networking layer.

This aligns cookie handling with the grouping model already used for
localStorage and sessionStorage, allowing embedders to obtain a more complete
view of site data.

Both public and private browsing contexts are included in the result.

The necessary support has been added to the net crate to expose cookie site
information.

Testing: The existing integration test has been extended to cover cookies.
