### PR TITLE
Fix warnings in unit tests (#41524)

### DIFF
--- a/components/servo/tests/common/mod.rs
+++ b/components/servo/tests/common/mod.rs
@@ -88,6 +88,7 @@ pub(crate) struct WebViewDelegateImpl {
     pub(crate) number_of_controls_hidden: Cell<usize>,
 }
 
+#[allow(dead_code)]
 impl WebViewDelegateImpl {
     pub(crate) fn reset(&self) {
         self.url_changed.set(false);
@@ -139,6 +140,7 @@ impl WebViewDelegate for WebViewDelegateImpl {
     }
 }
 
+#[allow(dead_code)]
 pub(crate) fn evaluate_javascript(
     servo_test: &ServoTest,
     webview: WebView,

--- a/components/servo/tests/webview.rs
+++ b/components/servo/tests/webview.rs
@@ -1008,7 +1008,7 @@ fn test_user_content_manager_for_auxiliary_webviews() {
         servo: Servo,
         rendering_context: Rc<dyn RenderingContext>,
         auxiliary_webview: RefCell<Option<WebView>>,
-    };
+    }
 
     impl WebViewDelegate for WebViewAuxiliaryTestDelegate {
         fn request_create_new(&self, _parent_webview: WebView, request: CreateNewWebViewRequest) {


### PR DESCRIPTION
Fix warnings when building unit tests by adding #[allow(dead_code)] attributes to evaluate_javascript function and WebViewDelegateImpl::reset method in common/mod.rs (which are used in some test binaries but not others), and removing the unnecessary trailing semicolon after the struct definition in webview.rs test_user_content_manager_for_auxiliary_webviews test. Fixes #41524