### PR TITLE
storage: Scope `WebStorage` quota per storage type instead of per origin total

### DIFF
--- a/components/servo/tests/site_data_manager.rs
+++ b/components/servo/tests/site_data_manager.rs
@@ -154,14 +154,9 @@ fn test_site_data() {
         &[SiteData::new("site-data-0.test", StorageType::Cookies),]
     );
     let sites = site_data_manager.site_data(StorageType::Local);
-    // TODO: File an issue for this, there should be only one site with
-    // localStorage origin.
     assert_eq!(
         &sites,
-        &[
-            SiteData::new("site-data-1.test", StorageType::Local),
-            SiteData::new("site-data-2.test", StorageType::Local),
-        ]
+        &[SiteData::new("site-data-1.test", StorageType::Local),]
     );
     let sites = site_data_manager.site_data(StorageType::Session);
     assert_eq!(
@@ -174,10 +169,7 @@ fn test_site_data() {
         &[
             SiteData::new("site-data-0.test", StorageType::Cookies),
             SiteData::new("site-data-1.test", StorageType::Local),
-            SiteData::new(
-                "site-data-2.test",
-                StorageType::Local | StorageType::Session
-            ),
+            SiteData::new("site-data-2.test", StorageType::Session),
         ]
     );
 
@@ -204,13 +196,10 @@ fn test_site_data() {
         ]
     );
     let sites = site_data_manager.site_data(StorageType::Local);
-    // TODO: File an issue for this, there should be only two sites with
-    // localStorage origin.
     assert_eq!(
         &sites,
         &[
             SiteData::new("site-data-1.test", StorageType::Local),
-            SiteData::new("site-data-2.test", StorageType::Local),
             SiteData::new("site-data-3.test", StorageType::Local),
         ]
     );
@@ -228,10 +217,7 @@ fn test_site_data() {
         &[
             SiteData::new("site-data-0.test", StorageType::Cookies),
             SiteData::new("site-data-1.test", StorageType::Local),
-            SiteData::new(
-                "site-data-2.test",
-                StorageType::Local | StorageType::Session
-            ),
+            SiteData::new("site-data-2.test", StorageType::Session),
             SiteData::new(
                 "site-data-3.test",
                 StorageType::Cookies | StorageType::Local | StorageType::Session

--- a/tests/wpt/meta/webstorage/storage_local_quota_independent_from_session.window.js.ini
+++ b/tests/wpt/meta/webstorage/storage_local_quota_independent_from_session.window.js.ini
@@ -1,3 +1,0 @@
-[storage_local_quota_independent_from_session.window.html]
-  [localStorage retains comparable quota after sessionStorage exhaustion]
-    expected: FAIL

--- a/tests/wpt/meta/webstorage/storage_local_quota_independent_from_session.window.js.ini
+++ b/tests/wpt/meta/webstorage/storage_local_quota_independent_from_session.window.js.ini
@@ -1,0 +1,3 @@
+[storage_local_quota_independent_from_session.window.html]
+  [localStorage retains comparable quota after sessionStorage exhaustion]
+    expected: FAIL

--- a/tests/wpt/meta/webstorage/storage_session_quota_independent_from_local.window.js.ini
+++ b/tests/wpt/meta/webstorage/storage_session_quota_independent_from_local.window.js.ini
@@ -1,0 +1,3 @@
+[storage_session_quota_independent_from_local.window.html]
+  [sessionStorage retains comparable quota after localStorage exhaustion]
+    expected: FAIL

--- a/tests/wpt/meta/webstorage/storage_session_quota_independent_from_local.window.js.ini
+++ b/tests/wpt/meta/webstorage/storage_session_quota_independent_from_local.window.js.ini
@@ -1,3 +1,0 @@
-[storage_session_quota_independent_from_local.window.html]
-  [sessionStorage retains comparable quota after localStorage exhaustion]
-    expected: FAIL

--- a/tests/wpt/tests/webstorage/storage_local_quota_independent_from_session.window.js
+++ b/tests/wpt/tests/webstorage/storage_local_quota_independent_from_session.window.js
@@ -1,0 +1,43 @@
+test(t => {
+    localStorage.clear();
+    sessionStorage.clear();
+
+    var key = "name";
+    var val = "x".repeat(4 * 1024);
+
+    t.add_cleanup(() => {
+        localStorage.clear();
+        sessionStorage.clear();
+    });
+
+    let indexBefore = 0;
+    assert_throws_quotaexceedederror(() => {
+        while (true) {
+            localStorage.setItem("" + key + indexBefore, "" + val + indexBefore);
+            indexBefore++;
+        }
+    }, null, null);
+
+    localStorage.clear();
+
+    let indexLocal = 0;
+    assert_throws_quotaexceedederror(() => {
+        while (true) {
+            sessionStorage.setItem("" + key + indexLocal, "" + val + indexLocal);
+            indexLocal++;
+        }
+    }, null, null);
+
+    let indexAfter = 0;
+    assert_throws_quotaexceedederror(() => {
+        while (true) {
+            localStorage.setItem("" + key + indexAfter, "" + val + indexAfter);
+            indexAfter++;
+        }
+    }, null, null);
+
+    assert_greater_than_equal(
+        indexAfter,
+        Math.floor(indexBefore / 2)
+    );
+}, "localStorage retains comparable quota after sessionStorage exhaustion");

--- a/tests/wpt/tests/webstorage/storage_session_quota_independent_from_local.window.js
+++ b/tests/wpt/tests/webstorage/storage_session_quota_independent_from_local.window.js
@@ -1,0 +1,43 @@
+test(t => {
+    sessionStorage.clear();
+    localStorage.clear();
+
+    var key = "name";
+    var val = "x".repeat(4 * 1024);
+
+    t.add_cleanup(() => {
+        sessionStorage.clear();
+        localStorage.clear();
+    });
+
+    let indexBefore = 0;
+    assert_throws_quotaexceedederror(() => {
+        while (true) {
+            sessionStorage.setItem("" + key + indexBefore, "" + val + indexBefore);
+            indexBefore++;
+        }
+    }, null, null);
+
+    sessionStorage.clear();
+
+    let indexLocal = 0;
+    assert_throws_quotaexceedederror(() => {
+        while (true) {
+            localStorage.setItem("" + key + indexLocal, "" + val + indexLocal);
+            indexLocal++;
+        }
+    }, null, null);
+
+    let indexAfter = 0;
+    assert_throws_quotaexceedederror(() => {
+        while (true) {
+            sessionStorage.setItem("" + key + indexAfter, "" + val + indexAfter);
+            indexAfter++;
+        }
+    }, null, null);
+
+    assert_greater_than_equal(
+        indexAfter,
+        Math.floor(indexBefore / 2)
+    );
+}, "sessionStorage retains comparable quota after localStorage exhaustion");


### PR DESCRIPTION
Change quota accounting for `WebStorage` so that usage is tracked per storage
type instead of combining `localStorage` and `sessionStorage` into a single per
origin total.

The previous implementation summed the sizes of both storage types and applied
a shared quota limit. This could cause a write to `sessionStorage` to fail due
to data stored in `localStorage` (and vice-versa), and also resulted in origin
descriptors being created even when only one storage type was in use.

This behavior is not consistent with other browsers, where quota is enforced
independently for each storage mechanism.

Testing: Existing unit and WPT tests continue to pass, a new WPT test has been
added
