### PR TITLE
compositor: Remove unwrap if surface unbound

### DIFF
--- a/components/shared/compositing/rendering_context.rs
+++ b/components/shared/compositing/rendering_context.rs
@@ -201,7 +201,11 @@ impl SurfmanRenderingContext {
         let device = &self.device.borrow();
         let context = &mut self.context.borrow_mut();
 
-        let mut surface = device.unbind_surface_from_context(context)?.unwrap();
+        let mut surface = device
+            .unbind_surface_from_context(context)?
+            // todo: proper error type. This probably should be done in surfman.
+            .ok_or(Error::Failed)
+            .inspect_err(|_| log::error!("Unable to present bound surface: no surface bound"))?;
         device.present_surface(context, &mut surface)?;
         device
             .bind_surface_to_context(context, surface)


### PR DESCRIPTION
If present_bound_surface fails for other reasons, we already handle this by simply printing the error.
If there is no surface attached to the context, we also simply log the error and otherwise ignore it,
instead of crashing servo.
Prevents a spurious crash when switching windows in #41532 (which is probably also something that should be fixed, but the error should not cause a crash in the first place). 

Testing: Trivial, doesn't require extra testing.

