### PR TITLE
servoshell: ohos: Move main thread code into function

### DIFF
--- a/ports/servoshell/egl/ohos/mod.rs
+++ b/ports/servoshell/egl/ohos/mod.rs
@@ -465,6 +465,56 @@ unsafe extern "C" fn on_vsync_cb(
     }
 }
 
+fn main_thread(xc: XComponentWrapper, window: WindowWrapper) {
+    let (tx, rx): (Sender<ServoAction>, Receiver<ServoAction>) = mpsc::channel();
+
+    SERVO_CHANNEL
+        .set(tx.clone())
+        .expect("Servo channel already initialized");
+
+    let wakeup = Box::new(WakeupCallback::new(tx));
+    let callbacks = Box::new(HostCallbacks::new());
+
+    let init_opts = if let Ok(ServoAction::Initialize(init_opts)) = rx.recv() {
+        init_opts
+    } else {
+        panic!("Servos GL thread received another event before it was initialized")
+    };
+    let servo = init_app(*init_opts, window.0, xc.0, wakeup, callbacks)
+        .expect("Servo initialization failed");
+    let id = servo
+        .active_or_newest_webview()
+        .expect("Should always start with at least one WebView")
+        .id();
+    NATIVE_WEBVIEWS
+        .lock()
+        .unwrap()
+        .push(NativeWebViewComponents {
+            id,
+            xcomponent: xc,
+            window,
+        });
+
+    info!("Surface created!");
+    let native_vsync =
+        ohos_vsync::NativeVsync::new("ServoVsync").expect("Failed to create NativeVsync");
+    // get_period() returns an error - perhaps we need to wait until the first callback?
+    // info!("Native vsync period is {} nanoseconds", native_vsync.get_period().unwrap());
+    unsafe {
+        native_vsync
+            .request_raw_callback_with_self(Some(on_vsync_cb))
+            .expect("Failed to request vsync callback")
+    }
+    info!("Enabled Vsync!");
+
+    while let Ok(action) = rx.recv() {
+        trace!("Wakeup message received!");
+        action.do_action(&servo);
+    }
+
+    info!("Sender disconnected - Terminating main surface thread");
+}
+
 #[unsafe(no_mangle)]
 extern "C" fn on_surface_created_cb(xcomponent: *mut OH_NativeXComponent, window: *mut c_void) {
     info!("on_surface_created_cb");
@@ -480,56 +530,7 @@ extern "C" fn on_surface_created_cb(xcomponent: *mut OH_NativeXComponent, window
         //
         // Each thread will send its id via the channel
         let _main_surface_thread = thread::spawn(move || {
-            let (tx, rx): (Sender<ServoAction>, Receiver<ServoAction>) = mpsc::channel();
-
-            SERVO_CHANNEL
-                .set(tx.clone())
-                .expect("Servo channel already initialized");
-
-            let wakeup = Box::new(WakeupCallback::new(tx));
-            let callbacks = Box::new(HostCallbacks::new());
-
-            let xc = xc_wrapper;
-            let window = window_wrapper;
-
-            let init_opts = if let Ok(ServoAction::Initialize(init_opts)) = rx.recv() {
-                init_opts
-            } else {
-                panic!("Servos GL thread received another event before it was initialized")
-            };
-            let servo = init_app(*init_opts, window.0, xc.0, wakeup, callbacks)
-                .expect("Servo initialization failed");
-            let id = servo
-                .active_or_newest_webview()
-                .expect("Should always start with at least one WebView")
-                .id();
-            NATIVE_WEBVIEWS
-                .lock()
-                .unwrap()
-                .push(NativeWebViewComponents {
-                    id,
-                    xcomponent: xc,
-                    window,
-                });
-
-            info!("Surface created!");
-            let native_vsync =
-                ohos_vsync::NativeVsync::new("ServoVsync").expect("Failed to create NativeVsync");
-            // get_period() returns an error - perhaps we need to wait until the first callback?
-            // info!("Native vsync period is {} nanoseconds", native_vsync.get_period().unwrap());
-            unsafe {
-                native_vsync
-                    .request_raw_callback_with_self(Some(on_vsync_cb))
-                    .expect("Failed to request vsync callback")
-            }
-            info!("Enabled Vsync!");
-
-            while let Ok(action) = rx.recv() {
-                trace!("Wakeup message received!");
-                action.do_action(&servo);
-            }
-
-            info!("Sender disconnected - Terminating main surface thread");
+            main_thread(xc_wrapper, window_wrapper);
         });
     } else {
         call(ServoAction::NewWebview(xc_wrapper, window_wrapper))


### PR DESCRIPTION
Refactor the code out of the lambda and move it into a dedicated function. This is a first step towards untangling initialization and window creation (see #41532 )

Testing: No functionality change, covered by existing tests

