### PR TITLE
script: Add helper function for setting JsonWebKey key_ops attribute

### DIFF
--- a/components/script/dom/subtlecrypto.rs
+++ b/components/script/dom/subtlecrypto.rs
@@ -2467,6 +2467,7 @@ trait JsonWebKeyExt {
     fn stringify(&self, cx: JSContext) -> Result<DOMString, Error>;
     fn get_usages_from_key_ops(&self) -> Result<Vec<KeyUsage>, Error>;
     fn check_key_ops(&self, specified_usages: &[KeyUsage]) -> Result<(), Error>;
+    fn set_key_ops(&mut self, usages: Vec<KeyUsage>);
     fn encode_string_field(&mut self, field: JwkStringField, data: &[u8]);
     fn decode_optional_string_field(&self, field: JwkStringField)
     -> Result<Option<Vec<u8>>, Error>;
@@ -2571,6 +2572,16 @@ impl JsonWebKeyExt for JsonWebKey {
         }
 
         Ok(())
+    }
+
+    // Set the key_ops attribute of jwk to equal the given usages.
+    fn set_key_ops(&mut self, usages: Vec<KeyUsage>) {
+        self.key_ops = Some(
+            usages
+                .into_iter()
+                .map(|usage| DOMString::from(usage.as_str()))
+                .collect(),
+        );
     }
 
     // Encode a byte sequence to a base64url-encoded string, and set the field to the encoded

--- a/components/script/dom/subtlecrypto/aes_operation.rs
+++ b/components/script/dom/subtlecrypto/aes_operation.rs
@@ -1126,12 +1126,7 @@ fn export_key_aes(format: KeyFormat, key: &CryptoKey) -> Result<ExportedKey, Err
             );
 
             // Step 2.5. Set the key_ops attribute of jwk to equal the [[usages]] internal slot of key.
-            jwk.key_ops = Some(
-                key.usages()
-                    .iter()
-                    .map(|usage| DOMString::from(usage.as_str()))
-                    .collect::<Vec<DOMString>>(),
-            );
+            jwk.set_key_ops(key.usages());
 
             // Step 2.6. Set the ext attribute of jwk to equal the [[extractable]] internal slot of key.
             jwk.ext = Some(key.Extractable());

--- a/components/script/dom/subtlecrypto/chacha20_poly1305_operation.rs
+++ b/components/script/dom/subtlecrypto/chacha20_poly1305_operation.rs
@@ -365,12 +365,7 @@ pub(crate) fn export_key(format: KeyFormat, key: &CryptoKey) -> Result<ExportedK
             jwk.alg = Some(DOMString::from("C20P"));
 
             // Step 2.5. Set the key_ops attribute of jwk to equal the usages attribute of key.
-            jwk.key_ops = Some(
-                key.usages()
-                    .iter()
-                    .map(|usage| DOMString::from(usage.as_str()))
-                    .collect::<Vec<DOMString>>(),
-            );
+            jwk.set_key_ops(key.usages());
 
             // Step 2.6. Set the ext attribute of jwk to equal the [[extractable]] internal slot of
             // key.

--- a/components/script/dom/subtlecrypto/ecdh_operation.rs
+++ b/components/script/dom/subtlecrypto/ecdh_operation.rs
@@ -1078,12 +1078,7 @@ pub(crate) fn export_key(format: KeyFormat, key: &CryptoKey) -> Result<ExportedK
             }
 
             // Step 3.4. Set the key_ops attribute of jwk to the usages attribute of key.
-            jwk.key_ops = Some(
-                key.usages()
-                    .iter()
-                    .map(|usage| DOMString::from(usage.as_str()))
-                    .collect::<Vec<DOMString>>(),
-            );
+            jwk.set_key_ops(key.usages());
 
             // Step 3.4. Set the ext attribute of jwk to the [[extractable]] internal slot of key.
             jwk.ext = Some(key.Extractable());

--- a/components/script/dom/subtlecrypto/ecdsa_operation.rs
+++ b/components/script/dom/subtlecrypto/ecdsa_operation.rs
@@ -1206,12 +1206,7 @@ pub(crate) fn export_key(format: KeyFormat, key: &CryptoKey) -> Result<ExportedK
             }
 
             // Step 3.4. Set the key_ops attribute of jwk to the usages attribute of key.
-            jwk.key_ops = Some(
-                key.usages()
-                    .iter()
-                    .map(|usage| DOMString::from(usage.as_str()))
-                    .collect::<Vec<DOMString>>(),
-            );
+            jwk.set_key_ops(key.usages());
 
             // Step 3.4. Set the ext attribute of jwk to the [[extractable]] internal slot of key.
             jwk.ext = Some(key.Extractable());

--- a/components/script/dom/subtlecrypto/ed25519_operation.rs
+++ b/components/script/dom/subtlecrypto/ed25519_operation.rs
@@ -507,12 +507,7 @@ pub(crate) fn export_key(format: KeyFormat, key: &CryptoKey) -> Result<ExportedK
             }
 
             // Step 3.7. Set the key_ops attribute of jwk to the usages attribute of key.
-            jwk.key_ops = Some(
-                key.usages()
-                    .iter()
-                    .map(|usage| DOMString::from(usage.as_str()))
-                    .collect::<Vec<DOMString>>(),
-            );
+            jwk.set_key_ops(key.usages());
 
             // Step 3.8. Set the ext attribute of jwk to the [[extractable]] internal slot of key.
             jwk.ext = Some(key.Extractable());

--- a/components/script/dom/subtlecrypto/hmac_operation.rs
+++ b/components/script/dom/subtlecrypto/hmac_operation.rs
@@ -369,12 +369,7 @@ pub(crate) fn export_key(format: KeyFormat, key: &CryptoKey) -> Result<ExportedK
             jwk.alg = Some(DOMString::from(hash_algorithm));
 
             // Step 4.7. Set the key_ops attribute of jwk to the usages attribute of key.
-            jwk.key_ops = Some(
-                key.usages()
-                    .iter()
-                    .map(|usage| DOMString::from(usage.as_str()))
-                    .collect::<Vec<DOMString>>(),
-            );
+            jwk.set_key_ops(key.usages());
 
             // Step 4.8. Set the ext attribute of jwk to the [[extractable]] internal slot of key.
             jwk.ext = Some(key.Extractable());

--- a/components/script/dom/subtlecrypto/rsa_common.rs
+++ b/components/script/dom/subtlecrypto/rsa_common.rs
@@ -517,12 +517,7 @@ pub(crate) fn export_key(
             }
 
             // Step 3.7. Set the key_ops attribute of jwk to the usages attribute of key.
-            jwk.key_ops = Some(
-                key.usages()
-                    .iter()
-                    .map(|usage| DOMString::from(usage.as_str()))
-                    .collect::<Vec<DOMString>>(),
-            );
+            jwk.set_key_ops(key.usages());
 
             // Step 3.8. Set the ext attribute of jwk to the [[extractable]] internal slot of key.
             jwk.ext = Some(key.Extractable());

--- a/components/script/dom/subtlecrypto/x25519_operation.rs
+++ b/components/script/dom/subtlecrypto/x25519_operation.rs
@@ -585,12 +585,7 @@ pub(crate) fn export_key(format: KeyFormat, key: &CryptoKey) -> Result<ExportedK
             }
 
             // Step 3.6. Set the key_ops attribute of jwk to the usages attribute of key.
-            jwk.key_ops = Some(
-                key.usages()
-                    .iter()
-                    .map(|usage| DOMString::from(usage.as_str()))
-                    .collect::<Vec<DOMString>>(),
-            );
+            jwk.set_key_ops(key.usages());
 
             // Step 3.7. Set the ext attribute of jwk to the [[extractable]] internal slot of key.
             jwk.ext = Some(key.Extractable());


### PR DESCRIPTION
Add a helper function `JsonWebKey::set_key_ops` for setting JsonWebKey key_ops attribute to a given list of key usages. This task is very common in export key operation of different cryptographic algorithms. Adding this helper function helps simplify our code.

Testing: Refactoring. Existing tests suffice.
