### PR TITLE
ci: Skip tests if ohos build failed

### DIFF
--- a/.github/workflows/ohos.yml
+++ b/.github/workflows/ohos.yml
@@ -159,6 +159,8 @@ jobs:
     runs-on: hos-builder
     if: github.repository == 'servo/servo'
     outputs:
+      # We need to save the job status as an output, since our usage of `continue-on-error`
+      # will make `needs.build-harmonyos-aarch64.result` evaluate to `success` even if the job failed.
       job_status: ${{ steps.result.outputs.JOB_STATUS }}
     steps:
       - if: ${{ github.event_name != 'pull_request_target' }}

--- a/.github/workflows/ohos.yml
+++ b/.github/workflows/ohos.yml
@@ -158,6 +158,8 @@ jobs:
     continue-on-error: true
     runs-on: hos-builder
     if: github.repository == 'servo/servo'
+    outputs:
+      job_status: ${{ steps.result.outputs.JOB_STATUS }}
     steps:
       - if: ${{ github.event_name != 'pull_request_target' }}
         run: git fetch --depth=1 origin $GITHUB_SHA
@@ -176,6 +178,10 @@ jobs:
           # Upload the **unsigned** artifact - We don't have the signing materials in pull request workflows
           name: servoshell-hos-${{ inputs.profile }}.hap
           path: target/openharmony/aarch64-unknown-linux-ohos/${{ inputs.profile }}/entry/build/harmonyos/outputs/default/servoshell-default-unsigned.hap
+      - name: Save result as job output
+        id: result
+        if: always()
+        run: echo "JOB_STATUS=${{ job.status }}" | tee $GITHUB_OUTPUT
 
   test-harmonyos-aarch64:
     name: Test HarmonyOS aarch64
@@ -184,7 +190,7 @@ jobs:
     # so in the beginning we will just do a best effort approach but ignore errors.
     continue-on-error: true
     runs-on: hos-runner
-    if: github.repository == 'servo/servo' && needs.build-harmonyos-aarch64.result == 'success'
+    if: github.repository == 'servo/servo' && needs.build-harmonyos-aarch64.outputs.job_status == 'success'
     needs: build-harmonyos-aarch64
     steps:
       - uses: actions/download-artifact@v4
@@ -249,7 +255,7 @@ jobs:
     continue-on-error: true
     runs-on: hos-runner
     needs: test-harmonyos-aarch64
-    if: github.repository == 'servo/servo' && needs.build-harmonyos-aarch64.result == 'success'
+    if: github.repository == 'servo/servo' && needs.build-harmonyos-aarch64.outputs.job_status == 'success'
     steps:
       - uses: actions/download-artifact@v4
         with:
@@ -362,7 +368,7 @@ jobs:
     name: Mossel Scenario test
     continue-on-error: true
     runs-on: hos-runner
-    if: github.repository == 'servo/servo' && needs.build-harmonyos-aarch64.result == 'success'
+    if: github.repository == 'servo/servo' && needs.build-harmonyos-aarch64.outputs.job_status == 'success'
     needs: build-harmonyos-aarch64
     env:
       # This will ensure the scenario pyproject.toml is picked up and the correct venv used.

--- a/.github/workflows/ohos.yml
+++ b/.github/workflows/ohos.yml
@@ -184,7 +184,7 @@ jobs:
     # so in the beginning we will just do a best effort approach but ignore errors.
     continue-on-error: true
     runs-on: hos-runner
-    if: github.repository == 'servo/servo'
+    if: github.repository == 'servo/servo' && needs.build-harmonyos-aarch64.result == 'success'
     needs: build-harmonyos-aarch64
     steps:
       - uses: actions/download-artifact@v4
@@ -249,7 +249,7 @@ jobs:
     continue-on-error: true
     runs-on: hos-runner
     needs: test-harmonyos-aarch64
-    if: github.repository == 'servo/servo'
+    if: github.repository == 'servo/servo' && needs.build-harmonyos-aarch64.result == 'success'
     steps:
       - uses: actions/download-artifact@v4
         with:
@@ -362,7 +362,7 @@ jobs:
     name: Mossel Scenario test
     continue-on-error: true
     runs-on: hos-runner
-    if: github.repository == 'servo/servo'
+    if: github.repository == 'servo/servo' && needs.build-harmonyos-aarch64.result == 'success'
     needs: build-harmonyos-aarch64
     env:
       # This will ensure the scenario pyproject.toml is picked up and the correct venv used.


### PR DESCRIPTION
Since the build job has `continue-on-error: true` to avoid failing the workflow, we need to check the success of the build step in the test jobs to skip the jobs, if the build fail. Currently those jobs run, but fail when trying to download the build artifact.

Testing:
- [mach try ohos](https://github.com/servo/servo/actions/runs/20556636022) (with the build succeeding)
- [mach try ohos](https://github.com/servo/servo/actions/runs/20557565744/job/59043826203) with the build force-failing, showing that the dependant jobs are properly skipped now

Notes:
- `if: github.repository == 'servo/servo' && needs.build-harmonyos-aarch64.result == 'success'` does not work, jobs are still spawned, see [mach try ohos, with failing build step](https://github.com/servo/servo/actions/runs/20556664058) and [upstream issue](https://github.com/actions/toolkit/issues/581)

