### PR TITLE
script: Obtain `&mut JSContext` at the start of the script and pass it down to msg handlers

### DIFF
--- a/components/script/dom/globalscope.rs
+++ b/components/script/dom/globalscope.rs
@@ -3048,9 +3048,13 @@ impl GlobalScope {
     /// Process a single event as if it were the next event
     /// in the queue for the event-loop where this global scope is running on.
     /// Returns a boolean indicating whether further events should be processed.
-    pub(crate) fn process_event(&self, msg: CommonScriptMsg, can_gc: CanGc) -> bool {
+    pub(crate) fn process_event(
+        &self,
+        msg: CommonScriptMsg,
+        cx: &mut js::context::JSContext,
+    ) -> bool {
         if self.is::<Window>() {
-            return ScriptThread::process_event(msg, can_gc);
+            return ScriptThread::process_event(msg, cx);
         }
         if let Some(worker) = self.downcast::<WorkerGlobalScope>() {
             return worker.process_event(msg);

--- a/components/script/dom/xmlhttprequest.rs
+++ b/components/script/dom/xmlhttprequest.rs
@@ -530,7 +530,12 @@ impl XMLHttpRequestMethods<crate::DomTypeHolder> for XMLHttpRequest {
     }
 
     /// <https://xhr.spec.whatwg.org/#the-send()-method>
-    fn Send(&self, data: Option<DocumentOrXMLHttpRequestBodyInit>, can_gc: CanGc) -> ErrorResult {
+    fn Send(
+        &self,
+        cx: &mut js::context::JSContext,
+        data: Option<DocumentOrXMLHttpRequestBodyInit>,
+    ) -> ErrorResult {
+        let can_gc = CanGc::from_cx(cx);
         // Step 1, 2
         if self.ready_state.get() != XMLHttpRequestState::Opened || self.send_flag.get() {
             return Err(Error::InvalidState(None));
@@ -756,7 +761,7 @@ impl XMLHttpRequestMethods<crate::DomTypeHolder> for XMLHttpRequest {
 
         self.fetch_time.set(Instant::now());
 
-        let rv = self.fetch(request, &self.global(), can_gc);
+        let rv = self.fetch(cx, request, &self.global());
         // Step 10
         if self.sync.get() {
             return rv;
@@ -1565,9 +1570,9 @@ impl XMLHttpRequest {
 
     fn fetch(
         &self,
+        cx: &mut js::context::JSContext,
         request_builder: RequestBuilder,
         global: &GlobalScope,
-        can_gc: CanGc,
     ) -> ErrorResult {
         let xhr = Trusted::new(self);
 
@@ -1607,7 +1612,7 @@ impl XMLHttpRequest {
 
         if let Some(script_port) = script_port {
             loop {
-                if !global.process_event(script_port.recv().unwrap(), can_gc) {
+                if !global.process_event(script_port.recv().unwrap(), cx) {
                     // We're exiting.
                     return Err(Error::Abort(None));
                 }

--- a/components/script/realms.rs
+++ b/components/script/realms.rs
@@ -2,10 +2,19 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
+use js::context::JSContext;
 use js::jsapi::JSAutoRealm;
+use js::realm::AutoRealm;
 pub(crate) use script_bindings::realms::{AlreadyInRealm, InRealm};
 use script_bindings::reflector::DomObject;
 
 pub(crate) fn enter_realm(object: &impl DomObject) -> JSAutoRealm {
     script_bindings::realms::enter_realm::<crate::DomTypeHolder>(object)
+}
+
+pub(crate) fn enter_auto_realm<'cx>(
+    cx: &'cx mut JSContext,
+    object: &impl DomObject,
+) -> AutoRealm<'cx> {
+    script_bindings::realms::enter_auto_realm::<crate::DomTypeHolder>(cx, object)
 }

--- a/components/script/script_thread.rs
+++ b/components/script/script_thread.rs
@@ -150,7 +150,7 @@ use crate::microtask::{Microtask, MicrotaskQueue};
 use crate::mime::{APPLICATION, CHARSET, MimeExt, TEXT, XML};
 use crate::navigation::{InProgressLoad, NavigationListener};
 use crate::network_listener::FetchResponseListener;
-use crate::realms::enter_realm;
+use crate::realms::{enter_auto_realm, enter_realm};
 use crate::script_mutation_observers::ScriptMutationObservers;
 use crate::script_runtime::{
     CanGc, IntroductionType, JSContext, JSContextHelper, Runtime, ScriptThreadEventCategory,
@@ -456,8 +456,14 @@ impl ScriptThreadFactory for ScriptThread {
 
                 let mut failsafe = ScriptMemoryFailsafe::new(&script_thread);
 
+                // Safety: We ensure that only one JSContext exists in this thread.
+                // This is the first one and the only one
+                // (minus the ones created when reentering rust code through hooks,
+                // but such code was derived from this JSContext so it is okay).
+                let mut cx = unsafe { script_thread.get_safe_cx() };
+
                 memory_profiler_sender.run_with_memory_reporting(
-                    || script_thread.start(CanGc::note()),
+                    || script_thread.start(&mut cx),
                     reporter_name,
                     ScriptEventLoopSender::MainThread(script_thread.senders.self_sender.clone()),
                     CommonScriptMsg::CollectReports,
@@ -518,12 +524,12 @@ impl ScriptThread {
     /// Process a single event as if it were the next event
     /// in the queue for this window event-loop.
     /// Returns a boolean indicating whether further events should be processed.
-    pub(crate) fn process_event(msg: CommonScriptMsg, can_gc: CanGc) -> bool {
+    pub(crate) fn process_event(msg: CommonScriptMsg, cx: &mut js::context::JSContext) -> bool {
         with_script_thread(|script_thread| {
             if !script_thread.can_continue_running_inner() {
                 return false;
             }
-            script_thread.handle_msg_from_script(MainThreadScriptMsg::Common(msg), can_gc);
+            script_thread.handle_msg_from_script(MainThreadScriptMsg::Common(msg), cx);
             true
         })
     }
@@ -999,6 +1005,12 @@ impl ScriptThread {
         unsafe { JSContext::from_ptr(js::rust::Runtime::get().unwrap().as_ptr()) }
     }
 
+    #[expect(unsafe_code)]
+    /// Users must ensure only one such JSContext exists in the current thread.
+    pub(crate) unsafe fn get_safe_cx(&self) -> js::context::JSContext {
+        unsafe { js::context::JSContext::from_ptr(js::rust::Runtime::get().unwrap()) }
+    }
+
     /// Check if we are closing.
     fn can_continue_running_inner(&self) -> bool {
         if self.closing.load(Ordering::SeqCst) {
@@ -1020,9 +1032,9 @@ impl ScriptThread {
 
     /// Starts the script thread. After calling this method, the script thread will loop receiving
     /// messages on its port.
-    pub(crate) fn start(&self, can_gc: CanGc) {
+    pub(crate) fn start(&self, cx: &mut js::context::JSContext) {
         debug!("Starting script thread.");
-        while self.handle_msgs(can_gc) {
+        while self.handle_msgs(cx) {
             // Go on...
             debug!("Running script thread.");
         }
@@ -1316,7 +1328,7 @@ impl ScriptThread {
     }
 
     /// Handle incoming messages from other tasks and the task queue.
-    fn handle_msgs(&self, can_gc: CanGc) -> bool {
+    fn handle_msgs(&self, cx: &mut js::context::JSContext) -> bool {
         // Proritize rendering tasks and others, and gather all other events as `sequential`.
         let mut sequential = vec![];
 
@@ -1361,7 +1373,7 @@ impl ScriptThread {
                 },
                 MixedMessage::FromConstellation(ScriptThreadMessage::ExitFullScreen(id)) => self
                     .profile_event(ScriptThreadEventCategory::ExitFullscreen, Some(id), || {
-                        self.handle_exit_fullscreen(id, can_gc);
+                        self.handle_exit_fullscreen(id, cx);
                     }),
                 _ => {
                     sequential.push(event);
@@ -1392,7 +1404,7 @@ impl ScriptThread {
                 // If we've received the closed signal from the BHM, only handle exit messages.
                 match msg {
                     MixedMessage::FromConstellation(ScriptThreadMessage::ExitScriptThread) => {
-                        self.handle_exit_script_thread_msg(can_gc);
+                        self.handle_exit_script_thread_msg(CanGc::from_cx(cx));
                         return false;
                     },
                     MixedMessage::FromConstellation(ScriptThreadMessage::ExitPipeline(
@@ -1404,7 +1416,7 @@ impl ScriptThread {
                             webview_id,
                             pipeline_id,
                             discard_browsing_context,
-                            can_gc,
+                            CanGc::from_cx(cx),
                         );
                     },
                     _ => {},
@@ -1412,27 +1424,27 @@ impl ScriptThread {
                 continue;
             }
 
-            let exiting = self.profile_event(category, pipeline_id, move || {
+            let exiting = self.profile_event(category, pipeline_id, || {
                 match msg {
                     MixedMessage::FromConstellation(ScriptThreadMessage::ExitScriptThread) => {
-                        self.handle_exit_script_thread_msg(can_gc);
+                        self.handle_exit_script_thread_msg(CanGc::from_cx(cx));
                         return true;
                     },
                     MixedMessage::FromConstellation(inner_msg) => {
-                        self.handle_msg_from_constellation(inner_msg, can_gc)
+                        self.handle_msg_from_constellation(inner_msg, cx)
                     },
                     MixedMessage::FromScript(inner_msg) => {
-                        self.handle_msg_from_script(inner_msg, can_gc)
+                        self.handle_msg_from_script(inner_msg, cx)
                     },
                     MixedMessage::FromDevtools(inner_msg) => {
-                        self.handle_msg_from_devtools(inner_msg, can_gc)
+                        self.handle_msg_from_devtools(inner_msg, cx)
                     },
                     MixedMessage::FromImageCache(inner_msg) => {
                         self.handle_msg_from_image_cache(inner_msg)
                     },
                     #[cfg(feature = "webgpu")]
                     MixedMessage::FromWebGPUServer(inner_msg) => {
-                        self.handle_msg_from_webgpu_server(inner_msg)
+                        self.handle_msg_from_webgpu_server(inner_msg, cx)
                     },
                     MixedMessage::TimerFired => {},
                 }
@@ -1447,7 +1459,7 @@ impl ScriptThread {
 
             // https://html.spec.whatwg.org/multipage/#event-loop-processing-model step 6
             // TODO(#32003): A microtask checkpoint is only supposed to be performed after running a task.
-            self.perform_a_microtask_checkpoint(can_gc);
+            self.perform_a_microtask_checkpoint(CanGc::from_cx(cx));
         }
 
         for (_, doc) in self.documents.borrow().iter() {
@@ -1461,17 +1473,17 @@ impl ScriptThread {
             // https://html.spec.whatwg.org/multipage/#the-end step 6
             let mut docs = self.docs_with_no_blocking_loads.borrow_mut();
             for document in docs.iter() {
-                let _realm = enter_realm(&**document);
+                let _realm = enter_auto_realm(cx, &**document);
                 document.maybe_queue_document_completion();
             }
             docs.clear();
         }
 
         let built_any_display_lists = self.needs_rendering_update.load(Ordering::Relaxed) &&
-            self.update_the_rendering(can_gc);
+            self.update_the_rendering(CanGc::from_cx(cx));
 
-        self.maybe_fulfill_font_ready_promises(can_gc);
-        self.maybe_resolve_pending_screenshot_readiness_requests(can_gc);
+        self.maybe_fulfill_font_ready_promises(CanGc::from_cx(cx));
+        self.maybe_resolve_pending_screenshot_readiness_requests(CanGc::from_cx(cx));
 
         // This must happen last to detect if any change above makes a rendering update necessary.
         self.maybe_schedule_rendering_opportunity_after_ipc_message(built_any_display_lists);
@@ -1678,7 +1690,11 @@ impl ScriptThread {
         value
     }
 
-    fn handle_msg_from_constellation(&self, msg: ScriptThreadMessage, can_gc: CanGc) {
+    fn handle_msg_from_constellation(
+        &self,
+        msg: ScriptThreadMessage,
+        cx: &mut js::context::JSContext,
+    ) {
         match msg {
             ScriptThreadMessage::StopDelayingLoadEventsMode(pipeline_id) => {
                 self.handle_stop_delaying_load_events_mode(pipeline_id)
@@ -1693,10 +1709,10 @@ impl ScriptThread {
                 browsing_context_id,
                 load_data,
                 history_handling,
-                can_gc,
+                CanGc::from_cx(cx),
             ),
             ScriptThreadMessage::UnloadDocument(pipeline_id) => {
-                self.handle_unload_document(pipeline_id, can_gc)
+                self.handle_unload_document(pipeline_id, CanGc::from_cx(cx))
             },
             ScriptThreadMessage::ResizeInactive(id, new_size) => {
                 self.handle_resize_inactive_msg(id, new_size)
@@ -1706,7 +1722,7 @@ impl ScriptThread {
             },
             ScriptThreadMessage::GetTitle(pipeline_id) => self.handle_get_title_msg(pipeline_id),
             ScriptThreadMessage::SetDocumentActivity(pipeline_id, activity) => {
-                self.handle_set_document_activity_msg(pipeline_id, activity, can_gc)
+                self.handle_set_document_activity_msg(pipeline_id, activity, CanGc::from_cx(cx))
             },
             ScriptThreadMessage::SetThrottled(webview_id, pipeline_id, throttled) => {
                 self.handle_set_throttled_msg(webview_id, pipeline_id, throttled)
@@ -1748,25 +1764,33 @@ impl ScriptThread {
                 webview_id,
                 new_pipeline_id,
                 reason,
-                can_gc,
+                CanGc::from_cx(cx),
             ),
-            ScriptThreadMessage::UpdateHistoryState(pipeline_id, history_state_id, url) => {
-                self.handle_update_history_state_msg(pipeline_id, history_state_id, url, can_gc)
-            },
+            ScriptThreadMessage::UpdateHistoryState(pipeline_id, history_state_id, url) => self
+                .handle_update_history_state_msg(
+                    pipeline_id,
+                    history_state_id,
+                    url,
+                    CanGc::from_cx(cx),
+                ),
             ScriptThreadMessage::RemoveHistoryStates(pipeline_id, history_states) => {
                 self.handle_remove_history_states(pipeline_id, history_states)
             },
-            ScriptThreadMessage::FocusIFrame(parent_pipeline_id, frame_id, sequence) => {
-                self.handle_focus_iframe_msg(parent_pipeline_id, frame_id, sequence, can_gc)
-            },
+            ScriptThreadMessage::FocusIFrame(parent_pipeline_id, frame_id, sequence) => self
+                .handle_focus_iframe_msg(
+                    parent_pipeline_id,
+                    frame_id,
+                    sequence,
+                    CanGc::from_cx(cx),
+                ),
             ScriptThreadMessage::FocusDocument(pipeline_id, sequence) => {
-                self.handle_focus_document_msg(pipeline_id, sequence, can_gc)
+                self.handle_focus_document_msg(pipeline_id, sequence, CanGc::from_cx(cx))
             },
             ScriptThreadMessage::Unfocus(pipeline_id, sequence) => {
-                self.handle_unfocus_msg(pipeline_id, sequence, can_gc)
+                self.handle_unfocus_msg(pipeline_id, sequence, CanGc::from_cx(cx))
             },
             ScriptThreadMessage::WebDriverScriptCommand(pipeline_id, msg) => {
-                self.handle_webdriver_msg(pipeline_id, msg, can_gc)
+                self.handle_webdriver_msg(pipeline_id, msg, CanGc::from_cx(cx))
             },
             ScriptThreadMessage::WebFontLoaded(pipeline_id, success) => {
                 self.handle_web_font_loaded(pipeline_id, success)
@@ -1775,7 +1799,12 @@ impl ScriptThread {
                 target: browsing_context_id,
                 parent: parent_id,
                 child: child_id,
-            } => self.handle_iframe_load_event(parent_id, browsing_context_id, child_id, can_gc),
+            } => self.handle_iframe_load_event(
+                parent_id,
+                browsing_context_id,
+                child_id,
+                CanGc::from_cx(cx),
+            ),
             ScriptThreadMessage::DispatchStorageEvent(
                 pipeline_id,
                 storage,
@@ -1787,7 +1816,9 @@ impl ScriptThread {
             ScriptThreadMessage::ReportCSSError(pipeline_id, filename, line, column, msg) => {
                 self.handle_css_error_reporting(pipeline_id, filename, line, column, msg)
             },
-            ScriptThreadMessage::Reload(pipeline_id) => self.handle_reload(pipeline_id, can_gc),
+            ScriptThreadMessage::Reload(pipeline_id) => {
+                self.handle_reload(pipeline_id, CanGc::from_cx(cx))
+            },
             ScriptThreadMessage::Resize(id, size, size_type) => {
                 self.handle_resize_message(id, size, size_type);
             },
@@ -1799,7 +1830,7 @@ impl ScriptThread {
                 webview_id,
                 pipeline_id,
                 discard_browsing_context,
-                can_gc,
+                CanGc::from_cx(cx),
             ),
             ScriptThreadMessage::PaintMetric(
                 pipeline_id,
@@ -1811,10 +1842,10 @@ impl ScriptThread {
                 metric_type,
                 metric_value,
                 first_reflow,
-                can_gc,
+                CanGc::from_cx(cx),
             ),
             ScriptThreadMessage::MediaSessionAction(pipeline_id, action) => {
-                self.handle_media_session_action(pipeline_id, action, can_gc)
+                self.handle_media_session_action(pipeline_id, action, CanGc::from_cx(cx))
             },
             ScriptThreadMessage::SendInputEvent(webview_id, id, event) => {
                 self.handle_input_event(webview_id, id, event)
@@ -1851,7 +1882,7 @@ impl ScriptThread {
                     pipeline_id,
                     evaluation_id,
                     script,
-                    can_gc,
+                    CanGc::from_cx(cx),
                 );
             },
             ScriptThreadMessage::SendImageKeysBatch(pipeline_id, image_keys) => {
@@ -1882,10 +1913,14 @@ impl ScriptThread {
                 }
             },
             ScriptThreadMessage::RequestScreenshotReadiness(webview_id, pipeline_id) => {
-                self.handle_request_screenshot_readiness(webview_id, pipeline_id, can_gc);
+                self.handle_request_screenshot_readiness(
+                    webview_id,
+                    pipeline_id,
+                    CanGc::from_cx(cx),
+                );
             },
             ScriptThreadMessage::EmbedderControlResponse(id, response) => {
-                self.handle_embedder_control_response(id, response, can_gc);
+                self.handle_embedder_control_response(id, response, CanGc::from_cx(cx));
             },
             ScriptThreadMessage::SetUserContents(user_content_manager_id, user_contents) => {
                 self.user_contents_for_manager_id
@@ -1922,7 +1957,7 @@ impl ScriptThread {
     }
 
     #[cfg(feature = "webgpu")]
-    fn handle_msg_from_webgpu_server(&self, msg: WebGPUMsg) {
+    fn handle_msg_from_webgpu_server(&self, msg: WebGPUMsg, cx: &mut js::context::JSContext) {
         match msg {
             WebGPUMsg::FreeAdapter(id) => self.gpu_id_hub.free_adapter_id(id),
             WebGPUMsg::FreeDevice {
@@ -1968,14 +2003,14 @@ impl ScriptThread {
                 error,
             } => {
                 let global = self.documents.borrow().find_global(pipeline_id).unwrap();
-                let _ac = enter_realm(&*global);
+                let _ac = enter_auto_realm(cx, &*global);
                 global.handle_uncaptured_gpu_error(device, error);
             },
             _ => {},
         }
     }
 
-    fn handle_msg_from_script(&self, msg: MainThreadScriptMsg, can_gc: CanGc) {
+    fn handle_msg_from_script(&self, msg: MainThreadScriptMsg, cx: &mut js::context::JSContext) {
         match msg {
             MainThreadScriptMsg::Common(CommonScriptMsg::Task(_, task, pipeline_id, _)) => {
                 let _realm = pipeline_id.and_then(|id| {
@@ -2016,33 +2051,43 @@ impl ScriptThread {
                 control_id,
                 response,
             ) => {
-                self.handle_embedder_control_response(control_id, response, can_gc);
+                self.handle_embedder_control_response(control_id, response, CanGc::from_cx(cx));
             },
         }
     }
 
-    fn handle_msg_from_devtools(&self, msg: DevtoolScriptControlMsg, can_gc: CanGc) {
+    fn handle_msg_from_devtools(
+        &self,
+        msg: DevtoolScriptControlMsg,
+        cx: &mut js::context::JSContext,
+    ) {
         let documents = self.documents.borrow();
         match msg {
             DevtoolScriptControlMsg::EvaluateJS(id, s, reply) => match documents.find_window(id) {
                 Some(window) => {
                     let global = window.as_global_scope();
                     let _aes = AutoEntryScript::new(global);
-                    devtools::handle_evaluate_js(global, s, reply, can_gc)
+                    devtools::handle_evaluate_js(global, s, reply, CanGc::from_cx(cx))
                 },
                 None => warn!("Message sent to closed pipeline {}.", id),
             },
             DevtoolScriptControlMsg::GetRootNode(id, reply) => {
-                devtools::handle_get_root_node(&documents, id, reply, can_gc)
+                devtools::handle_get_root_node(&documents, id, reply, CanGc::from_cx(cx))
             },
             DevtoolScriptControlMsg::GetDocumentElement(id, reply) => {
-                devtools::handle_get_document_element(&documents, id, reply, can_gc)
+                devtools::handle_get_document_element(&documents, id, reply, CanGc::from_cx(cx))
             },
             DevtoolScriptControlMsg::GetChildren(id, node_id, reply) => {
-                devtools::handle_get_children(&documents, id, node_id, reply, can_gc)
+                devtools::handle_get_children(&documents, id, node_id, reply, CanGc::from_cx(cx))
             },
             DevtoolScriptControlMsg::GetAttributeStyle(id, node_id, reply) => {
-                devtools::handle_get_attribute_style(&documents, id, node_id, reply, can_gc)
+                devtools::handle_get_attribute_style(
+                    &documents,
+                    id,
+                    node_id,
+                    reply,
+                    CanGc::from_cx(cx),
+                )
             },
             DevtoolScriptControlMsg::GetStylesheetStyle(
                 id,
@@ -2051,25 +2096,43 @@ impl ScriptThread {
                 stylesheet,
                 reply,
             ) => devtools::handle_get_stylesheet_style(
-                &documents, id, node_id, selector, stylesheet, reply, can_gc,
+                &documents,
+                id,
+                node_id,
+                selector,
+                stylesheet,
+                reply,
+                CanGc::from_cx(cx),
             ),
             DevtoolScriptControlMsg::GetSelectors(id, node_id, reply) => {
-                devtools::handle_get_selectors(&documents, id, node_id, reply, can_gc)
+                devtools::handle_get_selectors(&documents, id, node_id, reply, CanGc::from_cx(cx))
             },
             DevtoolScriptControlMsg::GetComputedStyle(id, node_id, reply) => {
                 devtools::handle_get_computed_style(&documents, id, node_id, reply)
             },
             DevtoolScriptControlMsg::GetLayout(id, node_id, reply) => {
-                devtools::handle_get_layout(&documents, id, node_id, reply, can_gc)
+                devtools::handle_get_layout(&documents, id, node_id, reply, CanGc::from_cx(cx))
             },
             DevtoolScriptControlMsg::GetXPath(id, node_id, reply) => {
                 devtools::handle_get_xpath(&documents, id, node_id, reply)
             },
             DevtoolScriptControlMsg::ModifyAttribute(id, node_id, modifications) => {
-                devtools::handle_modify_attribute(&documents, id, node_id, modifications, can_gc)
+                devtools::handle_modify_attribute(
+                    &documents,
+                    id,
+                    node_id,
+                    modifications,
+                    CanGc::from_cx(cx),
+                )
             },
             DevtoolScriptControlMsg::ModifyRule(id, node_id, modifications) => {
-                devtools::handle_modify_rule(&documents, id, node_id, modifications, can_gc)
+                devtools::handle_modify_rule(
+                    &documents,
+                    id,
+                    node_id,
+                    modifications,
+                    CanGc::from_cx(cx),
+                )
             },
             DevtoolScriptControlMsg::WantsLiveNotifications(id, to_send) => match documents
                 .find_window(id)
@@ -2086,7 +2149,7 @@ impl ScriptThread {
             DevtoolScriptControlMsg::RequestAnimationFrame(id, name) => {
                 devtools::handle_request_animation_frame(&documents, id, name)
             },
-            DevtoolScriptControlMsg::Reload(id) => self.handle_reload(id, can_gc),
+            DevtoolScriptControlMsg::Reload(id) => self.handle_reload(id, CanGc::from_cx(cx)),
             DevtoolScriptControlMsg::GetCssDatabase(reply) => {
                 devtools::handle_get_css_database(reply)
             },
@@ -2103,7 +2166,7 @@ impl ScriptThread {
             },
             DevtoolScriptControlMsg::GetPossibleBreakpoints(spidermonkey_id, result_sender) => {
                 self.debugger_global.fire_get_possible_breakpoints(
-                    can_gc,
+                    CanGc::from_cx(cx),
                     spidermonkey_id,
                     result_sender,
                 );
@@ -2497,11 +2560,11 @@ impl ScriptThread {
     }
 
     // exit_fullscreen creates a new JS promise object, so we need to have entered a realm
-    fn handle_exit_fullscreen(&self, id: PipelineId, can_gc: CanGc) {
+    fn handle_exit_fullscreen(&self, id: PipelineId, cx: &mut js::context::JSContext) {
         let document = self.documents.borrow().find_document(id);
         if let Some(document) = document {
-            let _ac = enter_realm(&*document);
-            document.exit_fullscreen(can_gc);
+            let mut realm = enter_auto_realm(cx, &*document);
+            document.exit_fullscreen(CanGc::from_cx(&mut realm));
         }
     }
 

--- a/components/script_bindings/codegen/Bindings.conf
+++ b/components/script_bindings/codegen/Bindings.conf
@@ -808,7 +808,8 @@ DOMInterfaces = {
 },
 
 'XMLHttpRequest': {
-    'canGc': ['Abort', 'GetResponseXML', 'Response', 'Send'],
+    'canGc': ['Abort', 'GetResponseXML', 'Response'],
+    'cx': ['Send'],
 },
 
 'XPathEvaluator': {

--- a/components/script_bindings/realms.rs
+++ b/components/script_bindings/realms.rs
@@ -2,8 +2,10 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
+use std::ptr::NonNull;
+
 use js::jsapi::{GetCurrentRealmOrNull, JSAutoRealm};
-use js::realm::CurrentRealm;
+use js::realm::{AutoRealm, CurrentRealm};
 
 use crate::DomTypes;
 use crate::interfaces::GlobalScopeHelpers;
@@ -67,5 +69,15 @@ pub fn enter_realm<D: DomTypes>(object: &impl DomObject) -> JSAutoRealm {
     JSAutoRealm::new(
         *D::GlobalScope::get_cx(),
         object.reflector().get_jsobject().get(),
+    )
+}
+
+pub fn enter_auto_realm<'cx, D: DomTypes>(
+    cx: &'cx mut js::context::JSContext,
+    object: &impl DomObject,
+) -> AutoRealm<'cx> {
+    AutoRealm::new(
+        cx,
+        NonNull::new(object.reflector().get_jsobject().get()).unwrap(),
     )
 }


### PR DESCRIPTION
At the start of the script we create first (and only[^1]) safe `JSContext`, from where we should pass it down to every code that needs the cx. This PR brings it all the way down to message handlers. There is clear separation between functions that use new model `&mut JSContext` and the ones that use the old model (usually they take can_gc).

[^1]:  Another place of construction are SM hooks (that pass us down raw JSContext), but to reach that point we already needed to call another function that takes `&mut JSContext`, so one can look at this case as reentering/reborrowing (we derive new shorter `&mut JSContext` from the old one).

Testing: This is just refactor, but should covered by WPT tests.
Part of #40600 
