### PR TITLE
script: Remove redundant realm entering

### DIFF
--- a/components/script/script_thread.rs
+++ b/components/script/script_thread.rs
@@ -1340,11 +1340,6 @@ impl ScriptThread {
                 .borrow_mut()
                 .dispatch_completed_timers();
 
-            let _realm = event.pipeline_id().map(|id| {
-                let global = self.documents.borrow().find_global(id);
-                global.map(|global| enter_realm(&*global))
-            });
-
             // https://html.spec.whatwg.org/multipage/#event-loop-processing-model step 7
             match event {
                 // This has to be handled before the ResizeMsg below,


### PR DESCRIPTION
`spawn_pipeline` does not need realm entered and `handle_fullscreen_exit` does realm entering on it's own: https://github.com/servo/servo/blob/133c9b4266aa245c7b78ce16a703072749e4bd8a/components/script/script_thread.rs#L2503

try run: https://github.com/sagudev/servo/actions/runs/20567048851

