### PR TITLE
script: Create CSS parsing helpers to simplify `ParserContext` setup

### DIFF
--- a/components/script/css.rs
+++ b/components/script/css.rs
@@ -1,0 +1,78 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+//! Helpers for CSS value parsing.
+
+use style::context::QuirksMode;
+use style::error_reporting::ParseErrorReporter;
+use style::parser::ParserContext;
+use style::stylesheets::{CssRuleType, Origin, UrlExtraData};
+use style_traits::ParsingMode;
+
+use crate::dom::document::Document;
+
+/// Creates a `ParserContext` from the given document.
+///
+/// Automatically configures quirks mode and error reporter from the document.
+pub(crate) fn parser_context_for_document<'a>(
+    document: &'a Document,
+    rule_type: CssRuleType,
+    parsing_mode: ParsingMode,
+    url_data: &'a UrlExtraData,
+) -> ParserContext<'a> {
+    let quirks_mode = document.quirks_mode();
+    let error_reporter = document.window().css_error_reporter();
+
+    ParserContext::new(
+        Origin::Author,
+        url_data,
+        Some(rule_type),
+        parsing_mode,
+        quirks_mode,
+        /* namespaces = */ Default::default(),
+        Some(error_reporter),
+        None,
+    )
+}
+
+/// Like [`parser_context_for_document`], but with a custom error reporter.
+pub(crate) fn parser_context_for_document_with_reporter<'a>(
+    document: &'a Document,
+    rule_type: CssRuleType,
+    parsing_mode: ParsingMode,
+    url_data: &'a UrlExtraData,
+    error_reporter: &'a dyn ParseErrorReporter,
+) -> ParserContext<'a> {
+    let quirks_mode = document.quirks_mode();
+
+    ParserContext::new(
+        Origin::Author,
+        url_data,
+        Some(rule_type),
+        parsing_mode,
+        quirks_mode,
+        /* namespaces = */ Default::default(),
+        Some(error_reporter),
+        None,
+    )
+}
+
+/// Creates a `ParserContext` without a document, using no quirks mode
+/// and no error reporter.
+pub(crate) fn parser_context_for_anonymous_content<'a>(
+    rule_type: CssRuleType,
+    parsing_mode: ParsingMode,
+    url_data: &'a UrlExtraData,
+) -> ParserContext<'a> {
+    ParserContext::new(
+        Origin::Author,
+        url_data,
+        Some(rule_type),
+        parsing_mode,
+        QuirksMode::NoQuirks,
+        /* namespaces = */ Default::default(),
+        None,
+        None,
+    )
+}

--- a/components/script/dom/canvas/2d/canvas_state.rs
+++ b/components/script/dom/canvas/2d/canvas_state.rs
@@ -33,11 +33,9 @@ use range::Range;
 use servo_arc::Arc as ServoArc;
 use servo_url::{ImmutableOrigin, ServoUrl};
 use style::color::{AbsoluteColor, ColorFlags, ColorSpace};
-use style::context::QuirksMode;
-use style::parser::ParserContext;
 use style::properties::longhands::font_variant_caps::computed_value::T as FontVariantCaps;
 use style::properties::style_structs::Font;
-use style::stylesheets::{CssRuleType, Origin};
+use style::stylesheets::CssRuleType;
 use style::values::computed::font::FontStyle;
 use style::values::specified::color::Color;
 use style_traits::values::ToCss;
@@ -48,6 +46,7 @@ use webrender_api::ImageKey;
 
 use crate::canvas_context::{CanvasContext, OffscreenRenderingContext, RenderingContext};
 use crate::conversions::Convert;
+use crate::css::parser_context_for_anonymous_content;
 use crate::dom::bindings::cell::DomRefCell;
 use crate::dom::bindings::codegen::Bindings::CanvasRenderingContext2DBinding::{
     CanvasDirection, CanvasFillRule, CanvasImageSource, CanvasLineCap, CanvasLineJoin,
@@ -2516,16 +2515,8 @@ pub(super) fn parse_color(
     let mut input = ParserInput::new(&string);
     let mut parser = Parser::new(&mut input);
     let url = Url::parse("about:blank").unwrap().into();
-    let context = ParserContext::new(
-        Origin::Author,
-        &url,
-        Some(CssRuleType::Style),
-        ParsingMode::DEFAULT,
-        QuirksMode::NoQuirks,
-        /* namespaces = */ Default::default(),
-        None,
-        None,
-    );
+    let context =
+        parser_context_for_anonymous_content(CssRuleType::Style, ParsingMode::DEFAULT, &url);
     match Color::parse_and_compute(&context, &mut parser, None) {
         Some(color) => {
             // TODO: https://github.com/whatwg/html/issues/1099

--- a/components/script/dom/css/css.rs
+++ b/components/script/dom/css/css.rs
@@ -6,12 +6,11 @@ use cssparser::{Parser, ParserInput, serialize_identifier};
 use dom_struct::dom_struct;
 use layout_api::{PropertyRegistration, RegisterPropertyError};
 use script_bindings::codegen::GenericBindings::CSSBinding::PropertyDefinition;
-use style::context::QuirksMode;
-use style::parser::ParserContext;
 use style::stylesheets::supports_rule::{Declaration, parse_condition_or_declaration};
-use style::stylesheets::{CssRuleType, Origin, UrlExtraData};
+use style::stylesheets::{CssRuleType, UrlExtraData};
 use style_traits::ParsingMode;
 
+use crate::css::parser_context_for_anonymous_content;
 use crate::dom::bindings::codegen::Bindings::CSSBinding::CSSMethods;
 use crate::dom::bindings::codegen::Bindings::WindowBinding::Window_Binding::WindowMethods;
 use crate::dom::bindings::error::{Error, Fallible};
@@ -43,15 +42,10 @@ impl CSSMethods<crate::DomTypeHolder> for CSS {
         decl.push_str(&value.str());
         let decl = Declaration(decl);
         let url_data = UrlExtraData(win.Document().url().get_arc());
-        let context = ParserContext::new(
-            Origin::Author,
-            &url_data,
-            Some(CssRuleType::Style),
+        let context = parser_context_for_anonymous_content(
+            CssRuleType::Style,
             ParsingMode::DEFAULT,
-            QuirksMode::NoQuirks,
-            /* namespaces = */ Default::default(),
-            None,
-            None,
+            &url_data,
         );
         decl.eval(&context)
     }
@@ -67,15 +61,10 @@ impl CSSMethods<crate::DomTypeHolder> for CSS {
         };
 
         let url_data = UrlExtraData(win.Document().url().get_arc());
-        let context = ParserContext::new(
-            Origin::Author,
-            &url_data,
-            Some(CssRuleType::Style),
+        let context = parser_context_for_anonymous_content(
+            CssRuleType::Style,
             ParsingMode::DEFAULT,
-            QuirksMode::NoQuirks,
-            /* namespaces = */ Default::default(),
-            None,
-            None,
+            &url_data,
         );
         cond.eval(&context)
     }

--- a/components/script/dom/dommatrixreadonly.rs
+++ b/components/script/dom/dommatrixreadonly.rs
@@ -18,9 +18,11 @@ use js::rust::{CustomAutoRooterGuard, HandleObject, ToString};
 use js::typedarray::{Float32Array, Float64Array, HeapFloat32Array, HeapFloat64Array};
 use rustc_hash::FxHashMap;
 use script_bindings::trace::RootedTraceableBox;
-use style::parser::ParserContext;
+use style::stylesheets::CssRuleType;
+use style_traits::ParsingMode;
 use url::Url;
 
+use crate::css::parser_context_for_anonymous_content;
 use crate::dom::bindings::buffer_source::create_buffer_source;
 use crate::dom::bindings::cell::{DomRefCell, Ref};
 use crate::dom::bindings::codegen::Bindings::DOMMatrixBinding::{
@@ -1213,16 +1215,8 @@ pub(crate) fn transform_to_matrix(value: String) -> Fallible<(bool, Transform3D<
     let mut input = ParserInput::new(&value);
     let mut parser = Parser::new(&mut input);
     let url_data = Url::parse("about:blank").unwrap().into();
-    let context = ParserContext::new(
-        ::style::stylesheets::Origin::Author,
-        &url_data,
-        Some(::style::stylesheets::CssRuleType::Style),
-        ::style_traits::ParsingMode::DEFAULT,
-        ::style::context::QuirksMode::NoQuirks,
-        /* namespaces = */ Default::default(),
-        None,
-        None,
-    );
+    let context =
+        parser_context_for_anonymous_content(CssRuleType::Style, ParsingMode::DEFAULT, &url_data);
 
     let transform = match parser.parse_entirely(|t| transform::parse(&context, t)) {
         Ok(result) => result,

--- a/components/script/dom/html/htmlimageelement.rs
+++ b/components/script/dom/html/htmlimageelement.rs
@@ -32,13 +32,12 @@ use rustc_hash::FxHashSet;
 use servo_url::ServoUrl;
 use servo_url::origin::MutableOrigin;
 use style::attr::{AttrValue, LengthOrPercentageOrAuto, parse_unsigned_integer};
-use style::context::QuirksMode;
-use style::parser::ParserContext;
-use style::stylesheets::{CssRuleType, Origin};
+use style::stylesheets::CssRuleType;
 use style::values::specified::source_size_list::SourceSizeList;
 use style_traits::ParsingMode;
 use url::Url;
 
+use crate::css::parser_context_for_anonymous_content;
 use crate::document_loader::{LoadBlocker, LoadType};
 use crate::dom::activation::Activatable;
 use crate::dom::attr::Attr;
@@ -1739,18 +1738,10 @@ fn parse_a_sizes_attribute(value: &str) -> SourceSizeList {
     let mut input = ParserInput::new(value);
     let mut parser = Parser::new(&mut input);
     let url_data = Url::parse("about:blank").unwrap().into();
-    let context = ParserContext::new(
-        Origin::Author,
-        &url_data,
-        Some(CssRuleType::Style),
-        // FIXME(emilio): why ::empty() instead of ::DEFAULT? Also, what do
-        // browsers do regarding quirks-mode in a media list?
-        ParsingMode::empty(),
-        QuirksMode::NoQuirks,
-        /* namespaces = */ Default::default(),
-        None,
-        None,
-    );
+    // FIXME(emilio): why ::empty() instead of ::DEFAULT? Also, what do
+    // browsers do regarding quirks-mode in a media list?
+    let context =
+        parser_context_for_anonymous_content(CssRuleType::Style, ParsingMode::empty(), &url_data);
     SourceSizeList::parse(&context, &mut parser)
 }
 

--- a/components/script/dom/intersectionobserver.rs
+++ b/components/script/dom/intersectionobserver.rs
@@ -13,14 +13,14 @@ use dom_struct::dom_struct;
 use euclid::default::{Rect, SideOffsets2D, Size2D};
 use js::rust::{HandleObject, MutableHandleValue};
 use layout_api::BoxAreaType;
-use style::context::QuirksMode;
-use style::parser::{Parse, ParserContext};
-use style::stylesheets::{CssRuleType, Origin};
+use style::parser::Parse;
+use style::stylesheets::CssRuleType;
 use style::values::computed::Overflow;
 use style::values::specified::intersection_observer::IntersectionObserverMargin;
 use style_traits::{ParsingMode, ToCss};
 use url::Url;
 
+use crate::css::parser_context_for_anonymous_content;
 use crate::dom::bindings::callback::ExceptionHandling;
 use crate::dom::bindings::cell::DomRefCell;
 use crate::dom::bindings::codegen::Bindings::IntersectionObserverBinding::{
@@ -836,16 +836,8 @@ fn parse_a_margin(value: Option<&DOMString>) -> Result<IntersectionObserverMargi
     let mut parser = Parser::new(&mut input);
 
     let url = Url::parse("about:blank").unwrap().into();
-    let context = ParserContext::new(
-        Origin::Author,
-        &url,
-        Some(CssRuleType::Style),
-        ParsingMode::DEFAULT,
-        QuirksMode::NoQuirks,
-        /* namespaces = */ Default::default(),
-        None,
-        None,
-    );
+    let context =
+        parser_context_for_anonymous_content(CssRuleType::Style, ParsingMode::DEFAULT, &url);
 
     parser
         .parse_entirely(|p| IntersectionObserverMargin::parse(&context, p))

--- a/components/script/lib.rs
+++ b/components/script/lib.rs
@@ -22,6 +22,7 @@ extern crate stylo_atoms;
 
 mod animation_timeline;
 mod animations;
+mod css;
 mod script_window_proxies;
 #[macro_use]
 mod task;


### PR DESCRIPTION
Creates a new `css.rs` module in `components/script` with helper functions for CSS value parsing.
Callers no longer need to manually specify document URL, quirks mode, and error reporter. 

Testing: `./mach check`
Fixes: #41541
