### PR TITLE
servoshell: ohos: Fix crash when hiding IME

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6333,9 +6333,9 @@ dependencies = [
 
 [[package]]
 name = "ohos-ime"
-version = "0.4.1"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae9cc8a2e61a650628e2a84381df464a7529286ba186ba659a8c550b51125e01"
+checksum = "e3d9911e7da9c4d59d9438fc8612afa4a109825f7a90a30a0df2c9a5bb7aedce"
 dependencies = [
  "log",
  "ohos-ime-sys",

--- a/ports/servoshell/Cargo.toml
+++ b/ports/servoshell/Cargo.toml
@@ -96,7 +96,7 @@ napi-derive-ohos = "1.1.4"
 napi-ohos = "1.1.4"
 ohos-abilitykit-sys = { version = "0.1.4", features = ["api-14"] }
 ohos-deviceinfo = "0.1.0"
-ohos-ime = "0.4.1"
+ohos-ime = "0.4.2"
 ohos-ime-sys = "0.2.3"
 ohos-vsync = "0.1.3"
 ohos-window-manager-sys = { version = "0.1", features = ["api-14"] }


### PR DESCRIPTION
Bump ohos-ime, which fixes a crash due to a segfault when hiding the IME.
The actual code changes can be found in the [upstream PR](https://github.com/openharmony-rs/ohos-ime/pull/11)

Testing: Manually tested the fix with the issue reproducer.
Fixes: #41535
