### PR TITLE
cargo: Move `sea-query*` to root and update as group

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -41,6 +41,10 @@ updates:
     objc2-related:
       patterns:
         - "objc2*"
+    sea-query-related:
+      patterns:
+        - "sea-query"
+        - "sea-query-rusqlite"
     serde-related:
       patterns:
         - "serde"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7894,9 +7894,9 @@ dependencies = [
 
 [[package]]
 name = "sea-query"
-version = "1.0.0-rc.26"
+version = "1.0.0-rc.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57e54859a85b278c00edfd617649bd12850a2d820b181603127d4b011f97b946"
+checksum = "93948054fb2d208555a96d03d2c887591deb42ffe3210eedbd8a3234c6fb6d34"
 dependencies = [
  "inherent",
  "sea-query-derive",
@@ -7918,9 +7918,9 @@ dependencies = [
 
 [[package]]
 name = "sea-query-rusqlite"
-version = "0.8.0-rc.14"
+version = "0.8.0-rc.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "235ec9a4f534a32cf4ec1dfea7f3cf36b8a686da956b6e146d64aed932d184c1"
+checksum = "9d42855d86ace6f5d9e425b65a8035d45c64e001db87a254ecfd87f226b4b0f7"
 dependencies = [
  "rusqlite",
  "sea-query",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -148,6 +148,8 @@ rustls = { version = "0.23", default-features = false, features = ["logging", "s
 rustls-pki-types = "1.13"
 rustls-platform-verifier = "0.6.2"
 script_traits = { path = "components/shared/script" }
+sea-query = { version = "1.0.0-rc.29", default-features = false, features = ["backend-sqlite", "derive"] }
+sea-query-rusqlite = { version = "0.8.0-rc.15" }
 sec1 = "0.7"
 selectors = { git = "https://github.com/servo/stylo", branch = "2025-11-01" }
 serde = "1.0.228"

--- a/components/storage/Cargo.toml
+++ b/components/storage/Cargo.toml
@@ -22,8 +22,8 @@ log = { workspace = true }
 profile_traits = { workspace = true }
 rusqlite = { version = "0.37", features = ["bundled"] }
 rustc-hash = { workspace = true }
-sea-query = { version = "1.0.0-rc.23", default-features = false, features = ["backend-sqlite", "derive"] }
-sea-query-rusqlite = { version = "0.8.0-rc.14" }
+sea-query = { workspace = true }
+sea-query-rusqlite = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 servo_config = { path = "../config" }


### PR DESCRIPTION
- Update sea-query 1.0.0-rc.26 -> 1.0.0-rc.29
- Update sea-query-rusqlite 0.8.0-rc.14 -> 0.8.0-rc.15
- Move both to the root so that dependabot can update them.
- Create a group for dependabot rules.

Testing: It builds.
Fixes: #41573 
