### PR TITLE
Refactor allow to expect

### DIFF
--- a/components/allocator/lib.rs
+++ b/components/allocator/lib.rs
@@ -45,11 +45,11 @@ unsafe extern "C" fn enclosing_size_impl(ptr: *const c_void) -> usize {
     size
 }
 
-#[allow(non_upper_case_globals)]
+#[expect(non_upper_case_globals)]
 #[cfg(feature = "allocation-tracking")]
 pub static enclosing_size: Option<EnclosingSizeFn> = Some(crate::enclosing_size_impl);
 
-#[allow(non_upper_case_globals)]
+#[expect(non_upper_case_globals)]
 #[cfg(not(feature = "allocation-tracking"))]
 pub static enclosing_size: Option<EnclosingSizeFn> = None;
 

--- a/components/devtools/actors/frame.rs
+++ b/components/devtools/actors/frame.rs
@@ -3,7 +3,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 // TODO: Remove once the actor is used
-#![allow(dead_code)]
+#![expect(dead_code)]
 
 use serde::Serialize;
 use serde_json::{Map, Value};

--- a/components/devtools/actors/pause.rs
+++ b/components/devtools/actors/pause.rs
@@ -5,7 +5,7 @@
 use crate::actor::Actor;
 
 // TODO: Remove once the actor is used.
-#[allow(dead_code)]
+#[expect(dead_code)]
 /// Referenced by `ThreadActor` when replying to `interupt` messages.
 /// <https://searchfox.org/firefox-main/source/devtools/server/actors/thread.js#1699>
 pub struct PauseActor {

--- a/components/domobject_derive/lib.rs
+++ b/components/domobject_derive/lib.rs
@@ -112,7 +112,7 @@ fn expand_dom_object(input: syn::DeriveInput) -> proc_macro2::TokenStream {
         proc_macro2::Span::call_site(),
     );
     let tokens = quote! {
-        #[allow(non_upper_case_globals)]
+        #[expect(non_upper_case_globals)]
         const #dummy_const: () = { #dummy_items };
         #items
     };

--- a/components/fonts/lib.rs
+++ b/components/fonts/lib.rs
@@ -74,10 +74,10 @@ impl FallbackFontSelectionOptions {
             // of the emoji presentation selectors above).
             _ if matches!(
                 character.emoji_status(),
-                EmojiStatus::EmojiPresentation
-                    | EmojiStatus::EmojiPresentationAndModifierBase
-                    | EmojiStatus::EmojiPresentationAndEmojiComponent
-                    | EmojiStatus::EmojiPresentationAndModifierAndEmojiComponent
+                EmojiStatus::EmojiPresentation |
+                    EmojiStatus::EmojiPresentationAndModifierBase |
+                    EmojiStatus::EmojiPresentationAndEmojiComponent |
+                    EmojiStatus::EmojiPresentationAndModifierAndEmojiComponent
             ) =>
             {
                 EmojiPresentationPreference::Emoji

--- a/components/fonts/lib.rs
+++ b/components/fonts/lib.rs
@@ -45,7 +45,7 @@ pub(crate) enum EmojiPresentationPreference {
 pub struct FallbackFontSelectionOptions {
     pub(crate) character: char,
     pub(crate) presentation_preference: EmojiPresentationPreference,
-    #[cfg_attr(any(target_os = "android", target_os = "windows"), allow(dead_code))]
+    #[cfg_attr(any(target_os = "android", target_os = "windows"), expect(dead_code))]
     pub(crate) lang: Option<String>,
 }
 
@@ -74,10 +74,10 @@ impl FallbackFontSelectionOptions {
             // of the emoji presentation selectors above).
             _ if matches!(
                 character.emoji_status(),
-                EmojiStatus::EmojiPresentation |
-                    EmojiStatus::EmojiPresentationAndModifierBase |
-                    EmojiStatus::EmojiPresentationAndEmojiComponent |
-                    EmojiStatus::EmojiPresentationAndModifierAndEmojiComponent
+                EmojiStatus::EmojiPresentation
+                    | EmojiStatus::EmojiPresentationAndModifierBase
+                    | EmojiStatus::EmojiPresentationAndEmojiComponent
+                    | EmojiStatus::EmojiPresentationAndModifierAndEmojiComponent
             ) =>
             {
                 EmojiPresentationPreference::Emoji

--- a/components/script/dom/bindings/buffer_source.rs
+++ b/components/script/dom/bindings/buffer_source.rs
@@ -388,7 +388,7 @@ where
         }
     }
     /// <https://streams.spec.whatwg.org/#abstract-opdef-cloneasuint8array>
-    #[allow(unsafe_code)]
+    #[expect(unsafe_code)]
     pub(crate) fn clone_as_uint8_array(
         &self,
         cx: JSContext,
@@ -552,8 +552,8 @@ where
         match &self.buffer_source {
             BufferSource::ArrayBufferView(heap) | BufferSource::ArrayBuffer(heap) => {
                 match &from_buffer.buffer_source {
-                    BufferSource::ArrayBufferView(from_heap) |
-                    BufferSource::ArrayBuffer(from_heap) => {
+                    BufferSource::ArrayBufferView(from_heap)
+                    | BufferSource::ArrayBuffer(from_heap) => {
                         if std::ptr::eq(heap.get(), from_heap.get()) {
                             return false;
                         }
@@ -597,8 +597,8 @@ where
         match &self.buffer_source {
             BufferSource::ArrayBufferView(heap) | BufferSource::ArrayBuffer(heap) => unsafe {
                 match &from_buffer.buffer_source {
-                    BufferSource::ArrayBufferView(from_heap) |
-                    BufferSource::ArrayBuffer(from_heap) => ArrayBufferCopyData(
+                    BufferSource::ArrayBufferView(from_heap)
+                    | BufferSource::ArrayBuffer(from_heap) => ArrayBufferCopyData(
                         *cx,
                         heap.handle().into(),
                         dest_start,

--- a/components/script/dom/bindings/buffer_source.rs
+++ b/components/script/dom/bindings/buffer_source.rs
@@ -552,8 +552,8 @@ where
         match &self.buffer_source {
             BufferSource::ArrayBufferView(heap) | BufferSource::ArrayBuffer(heap) => {
                 match &from_buffer.buffer_source {
-                    BufferSource::ArrayBufferView(from_heap)
-                    | BufferSource::ArrayBuffer(from_heap) => {
+                    BufferSource::ArrayBufferView(from_heap) |
+                    BufferSource::ArrayBuffer(from_heap) => {
                         if std::ptr::eq(heap.get(), from_heap.get()) {
                             return false;
                         }
@@ -597,8 +597,8 @@ where
         match &self.buffer_source {
             BufferSource::ArrayBufferView(heap) | BufferSource::ArrayBuffer(heap) => unsafe {
                 match &from_buffer.buffer_source {
-                    BufferSource::ArrayBufferView(from_heap)
-                    | BufferSource::ArrayBuffer(from_heap) => ArrayBufferCopyData(
+                    BufferSource::ArrayBufferView(from_heap) |
+                    BufferSource::ArrayBuffer(from_heap) => ArrayBufferCopyData(
                         *cx,
                         heap.handle().into(),
                         dest_start,

--- a/components/script/dom/byteteeunderlyingsource.rs
+++ b/components/script/dom/byteteeunderlyingsource.rs
@@ -178,8 +178,8 @@ impl ByteTeeUnderlyingSource {
                     byte_reader
                         .get()
                         .expect("Reader should be set.")
-                        .get_num_read_into_requests() ==
-                        0
+                        .get_num_read_into_requests()
+                        == 0
                 );
 
                 // Release BYOB reader.
@@ -297,8 +297,8 @@ impl ByteTeeUnderlyingSource {
                     default_reader
                         .get()
                         .expect("Reader should be set.")
-                        .get_num_read_requests() ==
-                        0
+                        .get_num_read_requests()
+                        == 0
                 );
 
                 // Perform ! ReadableStreamDefaultReaderRelease(reader).
@@ -431,7 +431,7 @@ impl ByteTeeUnderlyingSource {
     /// Let cancel1Algorithm be the following steps, taking a reason argument
     /// and
     /// Let cancel2Algorithm be the following steps, taking a reason argument
-    #[allow(unsafe_code)]
+    #[expect(unsafe_code)]
     pub(crate) fn cancel_algorithm(
         &self,
         reason: SafeHandleValue,
@@ -470,7 +470,7 @@ impl ByteTeeUnderlyingSource {
         }
     }
 
-    #[allow(unsafe_code)]
+    #[expect(unsafe_code)]
     fn resolve_cancel_promise(&self, can_gc: CanGc) {
         // Let compositeReason be ! CreateArrayFromList(« reason_1, reason_2 »).
         let cx = GlobalScope::get_cx();

--- a/components/script/dom/byteteeunderlyingsource.rs
+++ b/components/script/dom/byteteeunderlyingsource.rs
@@ -431,7 +431,6 @@ impl ByteTeeUnderlyingSource {
     /// Let cancel1Algorithm be the following steps, taking a reason argument
     /// and
     /// Let cancel2Algorithm be the following steps, taking a reason argument
-    #[expect(unsafe_code)]
     pub(crate) fn cancel_algorithm(
         &self,
         reason: SafeHandleValue,

--- a/components/script/dom/byteteeunderlyingsource.rs
+++ b/components/script/dom/byteteeunderlyingsource.rs
@@ -178,8 +178,8 @@ impl ByteTeeUnderlyingSource {
                     byte_reader
                         .get()
                         .expect("Reader should be set.")
-                        .get_num_read_into_requests()
-                        == 0
+                        .get_num_read_into_requests() ==
+                        0
                 );
 
                 // Release BYOB reader.
@@ -297,8 +297,8 @@ impl ByteTeeUnderlyingSource {
                     default_reader
                         .get()
                         .expect("Reader should be set.")
-                        .get_num_read_requests()
-                        == 0
+                        .get_num_read_requests() ==
+                        0
                 );
 
                 // Perform ! ReadableStreamDefaultReaderRelease(reader).

--- a/components/script/dom/commandevent.rs
+++ b/components/script/dom/commandevent.rs
@@ -44,7 +44,7 @@ impl CommandEvent {
     }
 
     #[allow(clippy::too_many_arguments)]
-    #[allow(dead_code)]
+    #[expect(dead_code)]
     pub(crate) fn new(
         window: &Window,
         type_: Atom,

--- a/components/script/dom/commandevent.rs
+++ b/components/script/dom/commandevent.rs
@@ -44,22 +44,6 @@ impl CommandEvent {
     }
 
     #[allow(clippy::too_many_arguments)]
-    #[expect(dead_code)]
-    pub(crate) fn new(
-        window: &Window,
-        type_: Atom,
-        bubbles: EventBubbles,
-        cancelable: EventCancelable,
-        source: Option<DomRoot<Element>>,
-        command: DOMString,
-        can_gc: CanGc,
-    ) -> DomRoot<CommandEvent> {
-        Self::new_with_proto(
-            window, None, type_, bubbles, cancelable, source, command, can_gc,
-        )
-    }
-
-    #[allow(clippy::too_many_arguments)]
     fn new_with_proto(
         window: &Window,
         proto: Option<HandleObject>,

--- a/components/script/dom/webgl/webglrenderingcontext.rs
+++ b/components/script/dom/webgl/webglrenderingcontext.rs
@@ -483,8 +483,8 @@ impl WebGLRenderingContext {
         };
         match self.current_program.get() {
             Some(ref program)
-                if program.id() == location.program_id() &&
-                    program.link_generation() == location.link_generation() => {},
+                if program.id() == location.program_id()
+                    && program.link_generation() == location.link_generation() => {},
             _ => return self.webgl_error(InvalidOperation),
         }
         handle_potential_webgl_error!(self, f(location));
@@ -597,8 +597,8 @@ impl WebGLRenderingContext {
     ) -> bool {
         if self
             .extension_manager
-            .is_filterable(data_type.as_gl_constant()) ||
-            !texture.is_using_linear_filtering()
+            .is_filterable(data_type.as_gl_constant())
+            || !texture.is_using_linear_filtering()
         {
             return true;
         }
@@ -640,13 +640,13 @@ impl WebGLRenderingContext {
     fn validate_stencil_actions(&self, action: u32) -> bool {
         matches!(
             action,
-            0 | constants::KEEP |
-                constants::REPLACE |
-                constants::INCR |
-                constants::DECR |
-                constants::INVERT |
-                constants::INCR_WRAP |
-                constants::DECR_WRAP
+            0 | constants::KEEP
+                | constants::REPLACE
+                | constants::INCR
+                | constants::DECR
+                | constants::INVERT
+                | constants::INCR_WRAP
+                | constants::DECR_WRAP
         )
     }
 
@@ -815,9 +815,9 @@ impl WebGLRenderingContext {
         // or FLOAT, a Float32Array must be supplied.
         // If the types do not match, an INVALID_OPERATION error is generated.
         let data_type_matches = data.as_ref().is_none_or(|buffer| {
-            Some(data_type.sized_data_type()) ==
-                array_buffer_type_to_sized_type(buffer.get_array_type()) &&
-                data_type.required_webgl_version() <= self.webgl_version()
+            Some(data_type.sized_data_type())
+                == array_buffer_type_to_sized_type(buffer.get_array_type())
+                && data_type.required_webgl_version() <= self.webgl_version()
         });
 
         if !data_type_matches {
@@ -935,10 +935,10 @@ impl WebGLRenderingContext {
         //   - xoffset or yoffset is less than 0
         //   - x offset plus the width is greater than the texture width
         //   - y offset plus the height is greater than the texture height
-        if xoffset < 0 ||
-            (xoffset as u32 + pixels.size().width) > image_info.width() ||
-            yoffset < 0 ||
-            (yoffset as u32 + pixels.size().height) > image_info.height()
+        if xoffset < 0
+            || (xoffset as u32 + pixels.size().width) > image_info.width()
+            || yoffset < 0
+            || (yoffset as u32 + pixels.size().height) > image_info.height()
         {
             return self.webgl_error(InvalidValue);
         }
@@ -950,8 +950,8 @@ impl WebGLRenderingContext {
         }
 
         // See https://www.khronos.org/registry/webgl/specs/latest/2.0/#4.1.6
-        if self.webgl_version() == WebGLVersion::WebGL1 &&
-            data_type != image_info.data_type().unwrap()
+        if self.webgl_version() == WebGLVersion::WebGL1
+            && data_type != image_info.data_type().unwrap()
         {
             return self.webgl_error(InvalidOperation);
         }
@@ -993,13 +993,13 @@ impl WebGLRenderingContext {
         primcount: i32,
     ) -> WebGLResult<()> {
         match mode {
-            constants::POINTS |
-            constants::LINE_STRIP |
-            constants::LINE_LOOP |
-            constants::LINES |
-            constants::TRIANGLE_STRIP |
-            constants::TRIANGLE_FAN |
-            constants::TRIANGLES => {},
+            constants::POINTS
+            | constants::LINE_STRIP
+            | constants::LINE_LOOP
+            | constants::LINES
+            | constants::TRIANGLE_STRIP
+            | constants::TRIANGLE_FAN
+            | constants::TRIANGLES => {},
             _ => {
                 return Err(InvalidEnum);
             },
@@ -1062,13 +1062,13 @@ impl WebGLRenderingContext {
         primcount: i32,
     ) -> WebGLResult<()> {
         match mode {
-            constants::POINTS |
-            constants::LINE_STRIP |
-            constants::LINE_LOOP |
-            constants::LINES |
-            constants::TRIANGLE_STRIP |
-            constants::TRIANGLE_FAN |
-            constants::TRIANGLES => {},
+            constants::POINTS
+            | constants::LINE_STRIP
+            | constants::LINE_LOOP
+            | constants::LINES
+            | constants::TRIANGLE_STRIP
+            | constants::TRIANGLE_FAN
+            | constants::TRIANGLES => {},
             _ => {
                 return Err(InvalidEnum);
             },
@@ -1425,11 +1425,11 @@ impl WebGLRenderingContext {
     ) -> WebGLResult<()> {
         self.validate_ownership(program)?;
 
-        if program.is_deleted() ||
-            !program.is_linked() ||
-            self.context_id() != location.context_id() ||
-            program.id() != location.program_id() ||
-            program.link_generation() != location.link_generation()
+        if program.is_deleted()
+            || !program.is_linked()
+            || self.context_id() != location.context_id()
+            || program.id() != location.program_id()
+            || program.link_generation() != location.link_generation()
         {
             return Err(InvalidOperation);
         }
@@ -1730,22 +1730,22 @@ impl WebGLRenderingContext {
     ) {
         self.with_location(location, |location| {
             match location.type_() {
-                constants::BOOL |
-                constants::INT |
-                constants::SAMPLER_2D |
-                WebGL2RenderingContextConstants::SAMPLER_2D_ARRAY |
-                WebGL2RenderingContextConstants::SAMPLER_3D |
-                constants::SAMPLER_CUBE => {},
+                constants::BOOL
+                | constants::INT
+                | constants::SAMPLER_2D
+                | WebGL2RenderingContextConstants::SAMPLER_2D_ARRAY
+                | WebGL2RenderingContextConstants::SAMPLER_3D
+                | constants::SAMPLER_CUBE => {},
                 _ => return Err(InvalidOperation),
             }
 
             let val = self.uniform_vec_section_int(val, src_offset, src_length, 1, location)?;
 
             match location.type_() {
-                constants::SAMPLER_2D |
-                constants::SAMPLER_CUBE |
-                WebGL2RenderingContextConstants::SAMPLER_2D_ARRAY |
-                WebGL2RenderingContextConstants::SAMPLER_3D => {
+                constants::SAMPLER_2D
+                | constants::SAMPLER_CUBE
+                | WebGL2RenderingContextConstants::SAMPLER_2D_ARRAY
+                | WebGL2RenderingContextConstants::SAMPLER_3D => {
                     for &v in val
                         .iter()
                         .take(cmp::min(location.size().unwrap_or(1) as usize, val.len()))
@@ -2093,7 +2093,7 @@ pub(crate) fn capture_webgl_backtrace() -> WebGLCommandBacktrace {
 }
 
 #[cfg(feature = "webgl_backtrace")]
-#[cfg_attr(feature = "webgl_backtrace", allow(unsafe_code))]
+#[cfg_attr(feature = "webgl_backtrace", expect(unsafe_code))]
 pub(crate) fn capture_webgl_backtrace() -> WebGLCommandBacktrace {
     let bt = Backtrace::new();
     unsafe {
@@ -2948,10 +2948,10 @@ impl WebGLRenderingContextMethods<crate::DomTypeHolder> for WebGLRenderingContex
         //   - xoffset or yoffset is less than 0
         //   - x offset plus the width is greater than the texture width
         //   - y offset plus the height is greater than the texture height
-        if xoffset < 0 ||
-            (xoffset as u32 + width) > image_info.width() ||
-            yoffset < 0 ||
-            (yoffset as u32 + height) > image_info.height()
+        if xoffset < 0
+            || (xoffset as u32 + width) > image_info.width()
+            || yoffset < 0
+            || (yoffset as u32 + height) > image_info.height()
         {
             self.webgl_error(InvalidValue);
             return;
@@ -2974,11 +2974,11 @@ impl WebGLRenderingContextMethods<crate::DomTypeHolder> for WebGLRenderingContex
     /// <https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.11>
     fn Clear(&self, mask: u32) {
         handle_potential_webgl_error!(self, self.validate_framebuffer(), return);
-        if mask &
-            !(constants::DEPTH_BUFFER_BIT |
-                constants::STENCIL_BUFFER_BIT |
-                constants::COLOR_BUFFER_BIT) !=
-            0
+        if mask
+            & !(constants::DEPTH_BUFFER_BIT
+                | constants::STENCIL_BUFFER_BIT
+                | constants::COLOR_BUFFER_BIT)
+            != 0
         {
             return self.webgl_error(InvalidValue);
         }
@@ -3028,14 +3028,14 @@ impl WebGLRenderingContextMethods<crate::DomTypeHolder> for WebGLRenderingContex
     /// <https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.3>
     fn DepthFunc(&self, func: u32) {
         match func {
-            constants::NEVER |
-            constants::LESS |
-            constants::EQUAL |
-            constants::LEQUAL |
-            constants::GREATER |
-            constants::NOTEQUAL |
-            constants::GEQUAL |
-            constants::ALWAYS => self.send_command(WebGLCommand::DepthFunc(func)),
+            constants::NEVER
+            | constants::LESS
+            | constants::EQUAL
+            | constants::LEQUAL
+            | constants::GREATER
+            | constants::NOTEQUAL
+            | constants::GEQUAL
+            | constants::ALWAYS => self.send_command(WebGLCommand::DepthFunc(func)),
             _ => self.webgl_error(InvalidEnum),
         }
     }
@@ -3341,10 +3341,10 @@ impl WebGLRenderingContextMethods<crate::DomTypeHolder> for WebGLRenderingContex
         let attachment_matches = match attachment {
             // constants::MAX_COLOR_ATTACHMENTS ... gl::COLOR_ATTACHMENT0 |
             // constants::BACK |
-            constants::COLOR_ATTACHMENT0 |
-            constants::DEPTH_STENCIL_ATTACHMENT |
-            constants::DEPTH_ATTACHMENT |
-            constants::STENCIL_ATTACHMENT => true,
+            constants::COLOR_ATTACHMENT0
+            | constants::DEPTH_STENCIL_ATTACHMENT
+            | constants::DEPTH_ATTACHMENT
+            | constants::STENCIL_ATTACHMENT => true,
             _ => false,
         };
         let pname_matches = match pname {
@@ -3357,10 +3357,10 @@ impl WebGLRenderingContextMethods<crate::DomTypeHolder> for WebGLRenderingContex
             // constants::FRAMEBUFFER_ATTACHMENT_RED_SIZE |
             // constants::FRAMEBUFFER_ATTACHMENT_STENCIL_SIZE |
             // constants::FRAMEBUFFER_ATTACHMENT_TEXTURE_LAYER |
-            constants::FRAMEBUFFER_ATTACHMENT_OBJECT_NAME |
-            constants::FRAMEBUFFER_ATTACHMENT_OBJECT_TYPE |
-            constants::FRAMEBUFFER_ATTACHMENT_TEXTURE_CUBE_MAP_FACE |
-            constants::FRAMEBUFFER_ATTACHMENT_TEXTURE_LEVEL => true,
+            constants::FRAMEBUFFER_ATTACHMENT_OBJECT_NAME
+            | constants::FRAMEBUFFER_ATTACHMENT_OBJECT_TYPE
+            | constants::FRAMEBUFFER_ATTACHMENT_TEXTURE_CUBE_MAP_FACE
+            | constants::FRAMEBUFFER_ATTACHMENT_TEXTURE_LEVEL => true,
             _ => false,
         };
 
@@ -3373,15 +3373,15 @@ impl WebGLRenderingContextMethods<crate::DomTypeHolder> for WebGLRenderingContex
             Some(attachment_root) => match attachment_root {
                 WebGLFramebufferAttachmentRoot::Renderbuffer(_) => matches!(
                     pname,
-                    constants::FRAMEBUFFER_ATTACHMENT_OBJECT_TYPE |
-                        constants::FRAMEBUFFER_ATTACHMENT_OBJECT_NAME
+                    constants::FRAMEBUFFER_ATTACHMENT_OBJECT_TYPE
+                        | constants::FRAMEBUFFER_ATTACHMENT_OBJECT_NAME
                 ),
                 WebGLFramebufferAttachmentRoot::Texture(_) => matches!(
                     pname,
-                    constants::FRAMEBUFFER_ATTACHMENT_OBJECT_TYPE |
-                        constants::FRAMEBUFFER_ATTACHMENT_OBJECT_NAME |
-                        constants::FRAMEBUFFER_ATTACHMENT_TEXTURE_LEVEL |
-                        constants::FRAMEBUFFER_ATTACHMENT_TEXTURE_CUBE_MAP_FACE
+                    constants::FRAMEBUFFER_ATTACHMENT_OBJECT_TYPE
+                        | constants::FRAMEBUFFER_ATTACHMENT_OBJECT_NAME
+                        | constants::FRAMEBUFFER_ATTACHMENT_TEXTURE_LEVEL
+                        | constants::FRAMEBUFFER_ATTACHMENT_TEXTURE_CUBE_MAP_FACE
                 ),
             },
             _ => matches!(pname, constants::FRAMEBUFFER_ATTACHMENT_OBJECT_TYPE),
@@ -3440,15 +3440,15 @@ impl WebGLRenderingContextMethods<crate::DomTypeHolder> for WebGLRenderingContex
 
         let pname_matches = matches!(
             pname,
-            constants::RENDERBUFFER_WIDTH |
-                constants::RENDERBUFFER_HEIGHT |
-                constants::RENDERBUFFER_INTERNAL_FORMAT |
-                constants::RENDERBUFFER_RED_SIZE |
-                constants::RENDERBUFFER_GREEN_SIZE |
-                constants::RENDERBUFFER_BLUE_SIZE |
-                constants::RENDERBUFFER_ALPHA_SIZE |
-                constants::RENDERBUFFER_DEPTH_SIZE |
-                constants::RENDERBUFFER_STENCIL_SIZE
+            constants::RENDERBUFFER_WIDTH
+                | constants::RENDERBUFFER_HEIGHT
+                | constants::RENDERBUFFER_INTERNAL_FORMAT
+                | constants::RENDERBUFFER_RED_SIZE
+                | constants::RENDERBUFFER_GREEN_SIZE
+                | constants::RENDERBUFFER_BLUE_SIZE
+                | constants::RENDERBUFFER_ALPHA_SIZE
+                | constants::RENDERBUFFER_DEPTH_SIZE
+                | constants::RENDERBUFFER_STENCIL_SIZE
         );
 
         if !target_matches || !pname_matches {
@@ -3581,12 +3581,12 @@ impl WebGLRenderingContextMethods<crate::DomTypeHolder> for WebGLRenderingContex
         }
 
         match precision_type {
-            constants::LOW_FLOAT |
-            constants::MEDIUM_FLOAT |
-            constants::HIGH_FLOAT |
-            constants::LOW_INT |
-            constants::MEDIUM_INT |
-            constants::HIGH_INT => (),
+            constants::LOW_FLOAT
+            | constants::MEDIUM_FLOAT
+            | constants::HIGH_FLOAT
+            | constants::LOW_INT
+            | constants::MEDIUM_INT
+            | constants::HIGH_INT => (),
             _ => {
                 self.webgl_error(InvalidEnum);
                 return None;
@@ -3761,8 +3761,8 @@ impl WebGLRenderingContextMethods<crate::DomTypeHolder> for WebGLRenderingContex
 
     /// <https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.3>
     fn Hint(&self, target: u32, mode: u32) {
-        if target != constants::GENERATE_MIPMAP_HINT &&
-            !self.extension_manager.is_hint_target_enabled(target)
+        if target != constants::GENERATE_MIPMAP_HINT
+            && !self.extension_manager.is_hint_target_enabled(target)
         {
             return self.webgl_error(InvalidEnum);
         }
@@ -4006,14 +4006,14 @@ impl WebGLRenderingContextMethods<crate::DomTypeHolder> for WebGLRenderingContex
     /// <https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.3>
     fn StencilFunc(&self, func: u32, ref_: i32, mask: u32) {
         match func {
-            constants::NEVER |
-            constants::LESS |
-            constants::EQUAL |
-            constants::LEQUAL |
-            constants::GREATER |
-            constants::NOTEQUAL |
-            constants::GEQUAL |
-            constants::ALWAYS => self.send_command(WebGLCommand::StencilFunc(func, ref_, mask)),
+            constants::NEVER
+            | constants::LESS
+            | constants::EQUAL
+            | constants::LEQUAL
+            | constants::GREATER
+            | constants::NOTEQUAL
+            | constants::GEQUAL
+            | constants::ALWAYS => self.send_command(WebGLCommand::StencilFunc(func, ref_, mask)),
             _ => self.webgl_error(InvalidEnum),
         }
     }
@@ -4026,14 +4026,14 @@ impl WebGLRenderingContextMethods<crate::DomTypeHolder> for WebGLRenderingContex
         }
 
         match func {
-            constants::NEVER |
-            constants::LESS |
-            constants::EQUAL |
-            constants::LEQUAL |
-            constants::GREATER |
-            constants::NOTEQUAL |
-            constants::GEQUAL |
-            constants::ALWAYS => {
+            constants::NEVER
+            | constants::LESS
+            | constants::EQUAL
+            | constants::LEQUAL
+            | constants::GREATER
+            | constants::NOTEQUAL
+            | constants::GEQUAL
+            | constants::ALWAYS => {
                 self.send_command(WebGLCommand::StencilFuncSeparate(face, func, ref_, mask))
             },
             _ => self.webgl_error(InvalidEnum),
@@ -4057,9 +4057,9 @@ impl WebGLRenderingContextMethods<crate::DomTypeHolder> for WebGLRenderingContex
 
     /// <https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.3>
     fn StencilOp(&self, fail: u32, zfail: u32, zpass: u32) {
-        if self.validate_stencil_actions(fail) &&
-            self.validate_stencil_actions(zfail) &&
-            self.validate_stencil_actions(zpass)
+        if self.validate_stencil_actions(fail)
+            && self.validate_stencil_actions(zfail)
+            && self.validate_stencil_actions(zpass)
         {
             self.send_command(WebGLCommand::StencilOp(fail, zfail, zpass));
         } else {
@@ -4074,9 +4074,9 @@ impl WebGLRenderingContextMethods<crate::DomTypeHolder> for WebGLRenderingContex
             _ => return self.webgl_error(InvalidEnum),
         }
 
-        if self.validate_stencil_actions(fail) &&
-            self.validate_stencil_actions(zfail) &&
-            self.validate_stencil_actions(zpass)
+        if self.validate_stencil_actions(fail)
+            && self.validate_stencil_actions(zfail)
+            && self.validate_stencil_actions(zpass)
         {
             self.send_command(WebGLCommand::StencilOpSeparate(face, fail, zfail, zpass))
         } else {
@@ -4122,10 +4122,10 @@ impl WebGLRenderingContextMethods<crate::DomTypeHolder> for WebGLRenderingContex
         self.with_location(location, |location| {
             match location.type_() {
                 constants::BOOL | constants::INT => {},
-                constants::SAMPLER_2D |
-                WebGL2RenderingContextConstants::SAMPLER_3D |
-                WebGL2RenderingContextConstants::SAMPLER_2D_ARRAY |
-                constants::SAMPLER_CUBE => {
+                constants::SAMPLER_2D
+                | WebGL2RenderingContextConstants::SAMPLER_3D
+                | WebGL2RenderingContextConstants::SAMPLER_2D_ARRAY
+                | constants::SAMPLER_CUBE => {
                     if val < 0 || val as u32 >= self.limits.max_combined_texture_image_units {
                         return Err(InvalidValue);
                     }
@@ -4323,11 +4323,11 @@ impl WebGLRenderingContextMethods<crate::DomTypeHolder> for WebGLRenderingContex
                 .safe_to_jsval(cx, rval, CanGc::note()),
             constants::BOOL_VEC4 => uniform_get(triple, WebGLCommand::GetUniformBool4)
                 .safe_to_jsval(cx, rval, CanGc::note()),
-            constants::INT |
-            constants::SAMPLER_2D |
-            constants::SAMPLER_CUBE |
-            WebGL2RenderingContextConstants::SAMPLER_2D_ARRAY |
-            WebGL2RenderingContextConstants::SAMPLER_3D => {
+            constants::INT
+            | constants::SAMPLER_2D
+            | constants::SAMPLER_CUBE
+            | WebGL2RenderingContextConstants::SAMPLER_2D_ARRAY
+            | WebGL2RenderingContextConstants::SAMPLER_3D => {
                 rval.set(Int32Value(uniform_get(triple, WebGLCommand::GetUniformInt)))
             },
             constants::INT_VEC2 => unsafe {
@@ -5111,13 +5111,13 @@ impl Textures {
             TexImageTarget::Texture2D => active_unit.tex_2d.get(),
             TexImageTarget::Texture2DArray => active_unit.tex_2d_array.get(),
             TexImageTarget::Texture3D => active_unit.tex_3d.get(),
-            TexImageTarget::CubeMap |
-            TexImageTarget::CubeMapPositiveX |
-            TexImageTarget::CubeMapNegativeX |
-            TexImageTarget::CubeMapPositiveY |
-            TexImageTarget::CubeMapNegativeY |
-            TexImageTarget::CubeMapPositiveZ |
-            TexImageTarget::CubeMapNegativeZ => active_unit.tex_cube_map.get(),
+            TexImageTarget::CubeMap
+            | TexImageTarget::CubeMapPositiveX
+            | TexImageTarget::CubeMapNegativeX
+            | TexImageTarget::CubeMapPositiveY
+            | TexImageTarget::CubeMapNegativeY
+            | TexImageTarget::CubeMapPositiveZ
+            | TexImageTarget::CubeMapNegativeZ => active_unit.tex_cube_map.get(),
         }
     }
 
@@ -5254,12 +5254,12 @@ fn array_buffer_type_to_sized_type(type_: Type) -> Option<SizedDataType> {
         Type::Int16 => Some(SizedDataType::Int16),
         Type::Int32 => Some(SizedDataType::Int32),
         Type::Float32 => Some(SizedDataType::Float32),
-        Type::Float16 |
-        Type::Float64 |
-        Type::BigInt64 |
-        Type::BigUint64 |
-        Type::MaxTypedArrayViewType |
-        Type::Int64 |
-        Type::Simd128 => None,
+        Type::Float16
+        | Type::Float64
+        | Type::BigInt64
+        | Type::BigUint64
+        | Type::MaxTypedArrayViewType
+        | Type::Int64
+        | Type::Simd128 => None,
     }
 }

--- a/components/script/dom/webgl/webglrenderingcontext.rs
+++ b/components/script/dom/webgl/webglrenderingcontext.rs
@@ -483,8 +483,8 @@ impl WebGLRenderingContext {
         };
         match self.current_program.get() {
             Some(ref program)
-                if program.id() == location.program_id()
-                    && program.link_generation() == location.link_generation() => {},
+                if program.id() == location.program_id() &&
+                    program.link_generation() == location.link_generation() => {},
             _ => return self.webgl_error(InvalidOperation),
         }
         handle_potential_webgl_error!(self, f(location));
@@ -597,8 +597,8 @@ impl WebGLRenderingContext {
     ) -> bool {
         if self
             .extension_manager
-            .is_filterable(data_type.as_gl_constant())
-            || !texture.is_using_linear_filtering()
+            .is_filterable(data_type.as_gl_constant()) ||
+            !texture.is_using_linear_filtering()
         {
             return true;
         }
@@ -640,13 +640,13 @@ impl WebGLRenderingContext {
     fn validate_stencil_actions(&self, action: u32) -> bool {
         matches!(
             action,
-            0 | constants::KEEP
-                | constants::REPLACE
-                | constants::INCR
-                | constants::DECR
-                | constants::INVERT
-                | constants::INCR_WRAP
-                | constants::DECR_WRAP
+            0 | constants::KEEP |
+                constants::REPLACE |
+                constants::INCR |
+                constants::DECR |
+                constants::INVERT |
+                constants::INCR_WRAP |
+                constants::DECR_WRAP
         )
     }
 
@@ -815,9 +815,9 @@ impl WebGLRenderingContext {
         // or FLOAT, a Float32Array must be supplied.
         // If the types do not match, an INVALID_OPERATION error is generated.
         let data_type_matches = data.as_ref().is_none_or(|buffer| {
-            Some(data_type.sized_data_type())
-                == array_buffer_type_to_sized_type(buffer.get_array_type())
-                && data_type.required_webgl_version() <= self.webgl_version()
+            Some(data_type.sized_data_type()) ==
+                array_buffer_type_to_sized_type(buffer.get_array_type()) &&
+                data_type.required_webgl_version() <= self.webgl_version()
         });
 
         if !data_type_matches {
@@ -935,10 +935,10 @@ impl WebGLRenderingContext {
         //   - xoffset or yoffset is less than 0
         //   - x offset plus the width is greater than the texture width
         //   - y offset plus the height is greater than the texture height
-        if xoffset < 0
-            || (xoffset as u32 + pixels.size().width) > image_info.width()
-            || yoffset < 0
-            || (yoffset as u32 + pixels.size().height) > image_info.height()
+        if xoffset < 0 ||
+            (xoffset as u32 + pixels.size().width) > image_info.width() ||
+            yoffset < 0 ||
+            (yoffset as u32 + pixels.size().height) > image_info.height()
         {
             return self.webgl_error(InvalidValue);
         }
@@ -950,8 +950,8 @@ impl WebGLRenderingContext {
         }
 
         // See https://www.khronos.org/registry/webgl/specs/latest/2.0/#4.1.6
-        if self.webgl_version() == WebGLVersion::WebGL1
-            && data_type != image_info.data_type().unwrap()
+        if self.webgl_version() == WebGLVersion::WebGL1 &&
+            data_type != image_info.data_type().unwrap()
         {
             return self.webgl_error(InvalidOperation);
         }
@@ -993,13 +993,13 @@ impl WebGLRenderingContext {
         primcount: i32,
     ) -> WebGLResult<()> {
         match mode {
-            constants::POINTS
-            | constants::LINE_STRIP
-            | constants::LINE_LOOP
-            | constants::LINES
-            | constants::TRIANGLE_STRIP
-            | constants::TRIANGLE_FAN
-            | constants::TRIANGLES => {},
+            constants::POINTS |
+            constants::LINE_STRIP |
+            constants::LINE_LOOP |
+            constants::LINES |
+            constants::TRIANGLE_STRIP |
+            constants::TRIANGLE_FAN |
+            constants::TRIANGLES => {},
             _ => {
                 return Err(InvalidEnum);
             },
@@ -1062,13 +1062,13 @@ impl WebGLRenderingContext {
         primcount: i32,
     ) -> WebGLResult<()> {
         match mode {
-            constants::POINTS
-            | constants::LINE_STRIP
-            | constants::LINE_LOOP
-            | constants::LINES
-            | constants::TRIANGLE_STRIP
-            | constants::TRIANGLE_FAN
-            | constants::TRIANGLES => {},
+            constants::POINTS |
+            constants::LINE_STRIP |
+            constants::LINE_LOOP |
+            constants::LINES |
+            constants::TRIANGLE_STRIP |
+            constants::TRIANGLE_FAN |
+            constants::TRIANGLES => {},
             _ => {
                 return Err(InvalidEnum);
             },
@@ -1425,11 +1425,11 @@ impl WebGLRenderingContext {
     ) -> WebGLResult<()> {
         self.validate_ownership(program)?;
 
-        if program.is_deleted()
-            || !program.is_linked()
-            || self.context_id() != location.context_id()
-            || program.id() != location.program_id()
-            || program.link_generation() != location.link_generation()
+        if program.is_deleted() ||
+            !program.is_linked() ||
+            self.context_id() != location.context_id() ||
+            program.id() != location.program_id() ||
+            program.link_generation() != location.link_generation()
         {
             return Err(InvalidOperation);
         }
@@ -1730,22 +1730,22 @@ impl WebGLRenderingContext {
     ) {
         self.with_location(location, |location| {
             match location.type_() {
-                constants::BOOL
-                | constants::INT
-                | constants::SAMPLER_2D
-                | WebGL2RenderingContextConstants::SAMPLER_2D_ARRAY
-                | WebGL2RenderingContextConstants::SAMPLER_3D
-                | constants::SAMPLER_CUBE => {},
+                constants::BOOL |
+                constants::INT |
+                constants::SAMPLER_2D |
+                WebGL2RenderingContextConstants::SAMPLER_2D_ARRAY |
+                WebGL2RenderingContextConstants::SAMPLER_3D |
+                constants::SAMPLER_CUBE => {},
                 _ => return Err(InvalidOperation),
             }
 
             let val = self.uniform_vec_section_int(val, src_offset, src_length, 1, location)?;
 
             match location.type_() {
-                constants::SAMPLER_2D
-                | constants::SAMPLER_CUBE
-                | WebGL2RenderingContextConstants::SAMPLER_2D_ARRAY
-                | WebGL2RenderingContextConstants::SAMPLER_3D => {
+                constants::SAMPLER_2D |
+                constants::SAMPLER_CUBE |
+                WebGL2RenderingContextConstants::SAMPLER_2D_ARRAY |
+                WebGL2RenderingContextConstants::SAMPLER_3D => {
                     for &v in val
                         .iter()
                         .take(cmp::min(location.size().unwrap_or(1) as usize, val.len()))
@@ -2948,10 +2948,10 @@ impl WebGLRenderingContextMethods<crate::DomTypeHolder> for WebGLRenderingContex
         //   - xoffset or yoffset is less than 0
         //   - x offset plus the width is greater than the texture width
         //   - y offset plus the height is greater than the texture height
-        if xoffset < 0
-            || (xoffset as u32 + width) > image_info.width()
-            || yoffset < 0
-            || (yoffset as u32 + height) > image_info.height()
+        if xoffset < 0 ||
+            (xoffset as u32 + width) > image_info.width() ||
+            yoffset < 0 ||
+            (yoffset as u32 + height) > image_info.height()
         {
             self.webgl_error(InvalidValue);
             return;
@@ -2974,11 +2974,11 @@ impl WebGLRenderingContextMethods<crate::DomTypeHolder> for WebGLRenderingContex
     /// <https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.11>
     fn Clear(&self, mask: u32) {
         handle_potential_webgl_error!(self, self.validate_framebuffer(), return);
-        if mask
-            & !(constants::DEPTH_BUFFER_BIT
-                | constants::STENCIL_BUFFER_BIT
-                | constants::COLOR_BUFFER_BIT)
-            != 0
+        if mask &
+            !(constants::DEPTH_BUFFER_BIT |
+                constants::STENCIL_BUFFER_BIT |
+                constants::COLOR_BUFFER_BIT) !=
+            0
         {
             return self.webgl_error(InvalidValue);
         }
@@ -3028,14 +3028,14 @@ impl WebGLRenderingContextMethods<crate::DomTypeHolder> for WebGLRenderingContex
     /// <https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.3>
     fn DepthFunc(&self, func: u32) {
         match func {
-            constants::NEVER
-            | constants::LESS
-            | constants::EQUAL
-            | constants::LEQUAL
-            | constants::GREATER
-            | constants::NOTEQUAL
-            | constants::GEQUAL
-            | constants::ALWAYS => self.send_command(WebGLCommand::DepthFunc(func)),
+            constants::NEVER |
+            constants::LESS |
+            constants::EQUAL |
+            constants::LEQUAL |
+            constants::GREATER |
+            constants::NOTEQUAL |
+            constants::GEQUAL |
+            constants::ALWAYS => self.send_command(WebGLCommand::DepthFunc(func)),
             _ => self.webgl_error(InvalidEnum),
         }
     }
@@ -3341,10 +3341,10 @@ impl WebGLRenderingContextMethods<crate::DomTypeHolder> for WebGLRenderingContex
         let attachment_matches = match attachment {
             // constants::MAX_COLOR_ATTACHMENTS ... gl::COLOR_ATTACHMENT0 |
             // constants::BACK |
-            constants::COLOR_ATTACHMENT0
-            | constants::DEPTH_STENCIL_ATTACHMENT
-            | constants::DEPTH_ATTACHMENT
-            | constants::STENCIL_ATTACHMENT => true,
+            constants::COLOR_ATTACHMENT0 |
+            constants::DEPTH_STENCIL_ATTACHMENT |
+            constants::DEPTH_ATTACHMENT |
+            constants::STENCIL_ATTACHMENT => true,
             _ => false,
         };
         let pname_matches = match pname {
@@ -3357,10 +3357,10 @@ impl WebGLRenderingContextMethods<crate::DomTypeHolder> for WebGLRenderingContex
             // constants::FRAMEBUFFER_ATTACHMENT_RED_SIZE |
             // constants::FRAMEBUFFER_ATTACHMENT_STENCIL_SIZE |
             // constants::FRAMEBUFFER_ATTACHMENT_TEXTURE_LAYER |
-            constants::FRAMEBUFFER_ATTACHMENT_OBJECT_NAME
-            | constants::FRAMEBUFFER_ATTACHMENT_OBJECT_TYPE
-            | constants::FRAMEBUFFER_ATTACHMENT_TEXTURE_CUBE_MAP_FACE
-            | constants::FRAMEBUFFER_ATTACHMENT_TEXTURE_LEVEL => true,
+            constants::FRAMEBUFFER_ATTACHMENT_OBJECT_NAME |
+            constants::FRAMEBUFFER_ATTACHMENT_OBJECT_TYPE |
+            constants::FRAMEBUFFER_ATTACHMENT_TEXTURE_CUBE_MAP_FACE |
+            constants::FRAMEBUFFER_ATTACHMENT_TEXTURE_LEVEL => true,
             _ => false,
         };
 
@@ -3373,15 +3373,15 @@ impl WebGLRenderingContextMethods<crate::DomTypeHolder> for WebGLRenderingContex
             Some(attachment_root) => match attachment_root {
                 WebGLFramebufferAttachmentRoot::Renderbuffer(_) => matches!(
                     pname,
-                    constants::FRAMEBUFFER_ATTACHMENT_OBJECT_TYPE
-                        | constants::FRAMEBUFFER_ATTACHMENT_OBJECT_NAME
+                    constants::FRAMEBUFFER_ATTACHMENT_OBJECT_TYPE |
+                        constants::FRAMEBUFFER_ATTACHMENT_OBJECT_NAME
                 ),
                 WebGLFramebufferAttachmentRoot::Texture(_) => matches!(
                     pname,
-                    constants::FRAMEBUFFER_ATTACHMENT_OBJECT_TYPE
-                        | constants::FRAMEBUFFER_ATTACHMENT_OBJECT_NAME
-                        | constants::FRAMEBUFFER_ATTACHMENT_TEXTURE_LEVEL
-                        | constants::FRAMEBUFFER_ATTACHMENT_TEXTURE_CUBE_MAP_FACE
+                    constants::FRAMEBUFFER_ATTACHMENT_OBJECT_TYPE |
+                        constants::FRAMEBUFFER_ATTACHMENT_OBJECT_NAME |
+                        constants::FRAMEBUFFER_ATTACHMENT_TEXTURE_LEVEL |
+                        constants::FRAMEBUFFER_ATTACHMENT_TEXTURE_CUBE_MAP_FACE
                 ),
             },
             _ => matches!(pname, constants::FRAMEBUFFER_ATTACHMENT_OBJECT_TYPE),
@@ -3440,15 +3440,15 @@ impl WebGLRenderingContextMethods<crate::DomTypeHolder> for WebGLRenderingContex
 
         let pname_matches = matches!(
             pname,
-            constants::RENDERBUFFER_WIDTH
-                | constants::RENDERBUFFER_HEIGHT
-                | constants::RENDERBUFFER_INTERNAL_FORMAT
-                | constants::RENDERBUFFER_RED_SIZE
-                | constants::RENDERBUFFER_GREEN_SIZE
-                | constants::RENDERBUFFER_BLUE_SIZE
-                | constants::RENDERBUFFER_ALPHA_SIZE
-                | constants::RENDERBUFFER_DEPTH_SIZE
-                | constants::RENDERBUFFER_STENCIL_SIZE
+            constants::RENDERBUFFER_WIDTH |
+                constants::RENDERBUFFER_HEIGHT |
+                constants::RENDERBUFFER_INTERNAL_FORMAT |
+                constants::RENDERBUFFER_RED_SIZE |
+                constants::RENDERBUFFER_GREEN_SIZE |
+                constants::RENDERBUFFER_BLUE_SIZE |
+                constants::RENDERBUFFER_ALPHA_SIZE |
+                constants::RENDERBUFFER_DEPTH_SIZE |
+                constants::RENDERBUFFER_STENCIL_SIZE
         );
 
         if !target_matches || !pname_matches {
@@ -3581,12 +3581,12 @@ impl WebGLRenderingContextMethods<crate::DomTypeHolder> for WebGLRenderingContex
         }
 
         match precision_type {
-            constants::LOW_FLOAT
-            | constants::MEDIUM_FLOAT
-            | constants::HIGH_FLOAT
-            | constants::LOW_INT
-            | constants::MEDIUM_INT
-            | constants::HIGH_INT => (),
+            constants::LOW_FLOAT |
+            constants::MEDIUM_FLOAT |
+            constants::HIGH_FLOAT |
+            constants::LOW_INT |
+            constants::MEDIUM_INT |
+            constants::HIGH_INT => (),
             _ => {
                 self.webgl_error(InvalidEnum);
                 return None;
@@ -3761,8 +3761,8 @@ impl WebGLRenderingContextMethods<crate::DomTypeHolder> for WebGLRenderingContex
 
     /// <https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.3>
     fn Hint(&self, target: u32, mode: u32) {
-        if target != constants::GENERATE_MIPMAP_HINT
-            && !self.extension_manager.is_hint_target_enabled(target)
+        if target != constants::GENERATE_MIPMAP_HINT &&
+            !self.extension_manager.is_hint_target_enabled(target)
         {
             return self.webgl_error(InvalidEnum);
         }
@@ -4006,14 +4006,14 @@ impl WebGLRenderingContextMethods<crate::DomTypeHolder> for WebGLRenderingContex
     /// <https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.3>
     fn StencilFunc(&self, func: u32, ref_: i32, mask: u32) {
         match func {
-            constants::NEVER
-            | constants::LESS
-            | constants::EQUAL
-            | constants::LEQUAL
-            | constants::GREATER
-            | constants::NOTEQUAL
-            | constants::GEQUAL
-            | constants::ALWAYS => self.send_command(WebGLCommand::StencilFunc(func, ref_, mask)),
+            constants::NEVER |
+            constants::LESS |
+            constants::EQUAL |
+            constants::LEQUAL |
+            constants::GREATER |
+            constants::NOTEQUAL |
+            constants::GEQUAL |
+            constants::ALWAYS => self.send_command(WebGLCommand::StencilFunc(func, ref_, mask)),
             _ => self.webgl_error(InvalidEnum),
         }
     }
@@ -4026,14 +4026,14 @@ impl WebGLRenderingContextMethods<crate::DomTypeHolder> for WebGLRenderingContex
         }
 
         match func {
-            constants::NEVER
-            | constants::LESS
-            | constants::EQUAL
-            | constants::LEQUAL
-            | constants::GREATER
-            | constants::NOTEQUAL
-            | constants::GEQUAL
-            | constants::ALWAYS => {
+            constants::NEVER |
+            constants::LESS |
+            constants::EQUAL |
+            constants::LEQUAL |
+            constants::GREATER |
+            constants::NOTEQUAL |
+            constants::GEQUAL |
+            constants::ALWAYS => {
                 self.send_command(WebGLCommand::StencilFuncSeparate(face, func, ref_, mask))
             },
             _ => self.webgl_error(InvalidEnum),
@@ -4057,9 +4057,9 @@ impl WebGLRenderingContextMethods<crate::DomTypeHolder> for WebGLRenderingContex
 
     /// <https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.3>
     fn StencilOp(&self, fail: u32, zfail: u32, zpass: u32) {
-        if self.validate_stencil_actions(fail)
-            && self.validate_stencil_actions(zfail)
-            && self.validate_stencil_actions(zpass)
+        if self.validate_stencil_actions(fail) &&
+            self.validate_stencil_actions(zfail) &&
+            self.validate_stencil_actions(zpass)
         {
             self.send_command(WebGLCommand::StencilOp(fail, zfail, zpass));
         } else {
@@ -4074,9 +4074,9 @@ impl WebGLRenderingContextMethods<crate::DomTypeHolder> for WebGLRenderingContex
             _ => return self.webgl_error(InvalidEnum),
         }
 
-        if self.validate_stencil_actions(fail)
-            && self.validate_stencil_actions(zfail)
-            && self.validate_stencil_actions(zpass)
+        if self.validate_stencil_actions(fail) &&
+            self.validate_stencil_actions(zfail) &&
+            self.validate_stencil_actions(zpass)
         {
             self.send_command(WebGLCommand::StencilOpSeparate(face, fail, zfail, zpass))
         } else {
@@ -4122,10 +4122,10 @@ impl WebGLRenderingContextMethods<crate::DomTypeHolder> for WebGLRenderingContex
         self.with_location(location, |location| {
             match location.type_() {
                 constants::BOOL | constants::INT => {},
-                constants::SAMPLER_2D
-                | WebGL2RenderingContextConstants::SAMPLER_3D
-                | WebGL2RenderingContextConstants::SAMPLER_2D_ARRAY
-                | constants::SAMPLER_CUBE => {
+                constants::SAMPLER_2D |
+                WebGL2RenderingContextConstants::SAMPLER_3D |
+                WebGL2RenderingContextConstants::SAMPLER_2D_ARRAY |
+                constants::SAMPLER_CUBE => {
                     if val < 0 || val as u32 >= self.limits.max_combined_texture_image_units {
                         return Err(InvalidValue);
                     }
@@ -4323,11 +4323,11 @@ impl WebGLRenderingContextMethods<crate::DomTypeHolder> for WebGLRenderingContex
                 .safe_to_jsval(cx, rval, CanGc::note()),
             constants::BOOL_VEC4 => uniform_get(triple, WebGLCommand::GetUniformBool4)
                 .safe_to_jsval(cx, rval, CanGc::note()),
-            constants::INT
-            | constants::SAMPLER_2D
-            | constants::SAMPLER_CUBE
-            | WebGL2RenderingContextConstants::SAMPLER_2D_ARRAY
-            | WebGL2RenderingContextConstants::SAMPLER_3D => {
+            constants::INT |
+            constants::SAMPLER_2D |
+            constants::SAMPLER_CUBE |
+            WebGL2RenderingContextConstants::SAMPLER_2D_ARRAY |
+            WebGL2RenderingContextConstants::SAMPLER_3D => {
                 rval.set(Int32Value(uniform_get(triple, WebGLCommand::GetUniformInt)))
             },
             constants::INT_VEC2 => unsafe {
@@ -5111,13 +5111,13 @@ impl Textures {
             TexImageTarget::Texture2D => active_unit.tex_2d.get(),
             TexImageTarget::Texture2DArray => active_unit.tex_2d_array.get(),
             TexImageTarget::Texture3D => active_unit.tex_3d.get(),
-            TexImageTarget::CubeMap
-            | TexImageTarget::CubeMapPositiveX
-            | TexImageTarget::CubeMapNegativeX
-            | TexImageTarget::CubeMapPositiveY
-            | TexImageTarget::CubeMapNegativeY
-            | TexImageTarget::CubeMapPositiveZ
-            | TexImageTarget::CubeMapNegativeZ => active_unit.tex_cube_map.get(),
+            TexImageTarget::CubeMap |
+            TexImageTarget::CubeMapPositiveX |
+            TexImageTarget::CubeMapNegativeX |
+            TexImageTarget::CubeMapPositiveY |
+            TexImageTarget::CubeMapNegativeY |
+            TexImageTarget::CubeMapPositiveZ |
+            TexImageTarget::CubeMapNegativeZ => active_unit.tex_cube_map.get(),
         }
     }
 
@@ -5254,12 +5254,12 @@ fn array_buffer_type_to_sized_type(type_: Type) -> Option<SizedDataType> {
         Type::Int16 => Some(SizedDataType::Int16),
         Type::Int32 => Some(SizedDataType::Int32),
         Type::Float32 => Some(SizedDataType::Float32),
-        Type::Float16
-        | Type::Float64
-        | Type::BigInt64
-        | Type::BigUint64
-        | Type::MaxTypedArrayViewType
-        | Type::Int64
-        | Type::Simd128 => None,
+        Type::Float16 |
+        Type::Float64 |
+        Type::BigInt64 |
+        Type::BigUint64 |
+        Type::MaxTypedArrayViewType |
+        Type::Int64 |
+        Type::Simd128 => None,
     }
 }

--- a/components/script/dom/workers/dedicatedworkerglobalscope.rs
+++ b/components/script/dom/workers/dedicatedworkerglobalscope.rs
@@ -290,7 +290,7 @@ impl DedicatedWorkerGlobalScope {
         }
     }
 
-    #[expect(unsafe_code, clippy::too_many_arguments)]
+    #[expect(clippy::too_many_arguments)]
     pub(crate) fn new(
         init: WorkerGlobalScopeInit,
         webview_id: WebViewId,

--- a/components/script/dom/workers/dedicatedworkerglobalscope.rs
+++ b/components/script/dom/workers/dedicatedworkerglobalscope.rs
@@ -290,7 +290,7 @@ impl DedicatedWorkerGlobalScope {
         }
     }
 
-    #[allow(unsafe_code, clippy::too_many_arguments)]
+    #[expect(unsafe_code, clippy::too_many_arguments)]
     pub(crate) fn new(
         init: WorkerGlobalScopeInit,
         webview_id: WebViewId,

--- a/components/script/fetch.rs
+++ b/components/script/fetch.rs
@@ -348,7 +348,7 @@ fn queue_deferred_fetch(
 }
 
 /// <https://fetch.spec.whatwg.org/#dom-window-fetchlater>
-#[allow(non_snake_case, unsafe_code)]
+#[expect(non_snake_case, unsafe_code)]
 pub(crate) fn FetchLater(
     window: &Window,
     input: RequestInfo,
@@ -759,8 +759,8 @@ pub(crate) fn load_whole_resource(
                 }
                 return Ok((metadata, buf, muted_errors));
             },
-            FetchResponseMsg::ProcessResponse(_, Err(e)) |
-            FetchResponseMsg::ProcessResponseEOF(_, Err(e)) => return Err(e),
+            FetchResponseMsg::ProcessResponse(_, Err(e))
+            | FetchResponseMsg::ProcessResponseEOF(_, Err(e)) => return Err(e),
             FetchResponseMsg::ProcessCspViolations(_, violations) => {
                 csp_violations_processor.process_csp_violations(violations);
             },

--- a/components/script/fetch.rs
+++ b/components/script/fetch.rs
@@ -759,8 +759,8 @@ pub(crate) fn load_whole_resource(
                 }
                 return Ok((metadata, buf, muted_errors));
             },
-            FetchResponseMsg::ProcessResponse(_, Err(e))
-            | FetchResponseMsg::ProcessResponseEOF(_, Err(e)) => return Err(e),
+            FetchResponseMsg::ProcessResponse(_, Err(e)) |
+            FetchResponseMsg::ProcessResponseEOF(_, Err(e)) => return Err(e),
             FetchResponseMsg::ProcessCspViolations(_, violations) => {
                 csp_violations_processor.process_csp_violations(violations);
             },

--- a/components/script_bindings/codegen/codegen.py
+++ b/components/script_bindings/codegen/codegen.py
@@ -7472,7 +7472,7 @@ class CGNonNamespacedEnum(CGThing):
         entries = [f"{names[0]} = {first}"] + names[1:]
 
         # Append a Last.
-        entries.append(f'#[allow(dead_code)] Last = {first + len(entries)}')
+        entries.append(f'#[expect(dead_code)] Last = {first + len(entries)}')
 
         # Indent.
         entries = [f'    {e}' for e in entries]
@@ -9159,7 +9159,7 @@ class GlobalGenRoots():
             if base in topTypes:
                 typeIdCode.append(CGGeneric(f"""
 impl {base} {{
-    #[allow(dead_code)]
+    #[expect(dead_code)]
     pub(crate) fn type_id(&self) -> &'static {base}TypeId {{
         unsafe {{
             &get_dom_class(self.reflector().get_jsobject().get())

--- a/components/script_bindings/codegen/codegen.py
+++ b/components/script_bindings/codegen/codegen.py
@@ -7900,7 +7900,7 @@ class CGRegisterProxyHandlers(CGThing):
         )
         self.root = CGList([
             CGGeneric(
-                "#[allow(non_upper_case_globals)]\n"
+                "#[expect(non_upper_case_globals)]\n"
                 "pub(crate) mod proxy_handlers {\n"
                 f"{body}}}\n"
             ),

--- a/components/script_bindings/codegen/codegen.py
+++ b/components/script_bindings/codegen/codegen.py
@@ -9159,7 +9159,7 @@ class GlobalGenRoots():
             if base in topTypes:
                 typeIdCode.append(CGGeneric(f"""
 impl {base} {{
-    #[expect(dead_code)]
+    #[allow(dead_code)]
     pub(crate) fn type_id(&self) -> &'static {base}TypeId {{
         unsafe {{
             &get_dom_class(self.reflector().get_jsobject().get())

--- a/components/script_bindings/codegen/codegen.py
+++ b/components/script_bindings/codegen/codegen.py
@@ -7472,7 +7472,7 @@ class CGNonNamespacedEnum(CGThing):
         entries = [f"{names[0]} = {first}"] + names[1:]
 
         # Append a Last.
-        entries.append(f'#[expect(dead_code)] Last = {first + len(entries)}')
+        entries.append(f'#[allow(dead_code)] Last = {first + len(entries)}')
 
         # Indent.
         entries = [f'    {e}' for e in entries]

--- a/components/script_bindings/codegen/codegen.py
+++ b/components/script_bindings/codegen/codegen.py
@@ -7472,7 +7472,7 @@ class CGNonNamespacedEnum(CGThing):
         entries = [f"{names[0]} = {first}"] + names[1:]
 
         # Append a Last.
-        entries.append(f'#[allow(dead_code)] Last = {first + len(entries)}')
+        entries.append(f'Last = {first + len(entries)}')
 
         # Indent.
         entries = [f'    {e}' for e in entries]

--- a/components/servo/tests/common/mod.rs
+++ b/components/servo/tests/common/mod.rs
@@ -140,7 +140,7 @@ impl WebViewDelegate for WebViewDelegateImpl {
     }
 }
 
-#[expect(dead_code)]
+#[allow(dead_code)] // Used by some tests and not others
 pub(crate) fn evaluate_javascript(
     servo_test: &ServoTest,
     webview: WebView,

--- a/components/servo/tests/common/mod.rs
+++ b/components/servo/tests/common/mod.rs
@@ -88,7 +88,7 @@ pub(crate) struct WebViewDelegateImpl {
     pub(crate) number_of_controls_hidden: Cell<usize>,
 }
 
-#[expect(dead_code)]
+#[allow(dead_code)] // Used by some tests and not others
 impl WebViewDelegateImpl {
     pub(crate) fn reset(&self) {
         self.url_changed.set(false);

--- a/components/servo/tests/common/mod.rs
+++ b/components/servo/tests/common/mod.rs
@@ -88,7 +88,7 @@ pub(crate) struct WebViewDelegateImpl {
     pub(crate) number_of_controls_hidden: Cell<usize>,
 }
 
-#[allow(dead_code)]
+#[expect(dead_code)]
 impl WebViewDelegateImpl {
     pub(crate) fn reset(&self) {
         self.url_changed.set(false);
@@ -140,7 +140,7 @@ impl WebViewDelegate for WebViewDelegateImpl {
     }
 }
 
-#[allow(dead_code)]
+#[expect(dead_code)]
 pub(crate) fn evaluate_javascript(
     servo_test: &ServoTest,
     webview: WebView,

--- a/ports/servoshell/egl/app.rs
+++ b/ports/servoshell/egl/app.rs
@@ -261,7 +261,7 @@ pub struct App {
     platform_window: Rc<EmbeddedPlatformWindow>,
 }
 
-#[allow(unused)]
+#[expect(unused)]
 impl App {
     pub(super) fn new(init: AppInitOptions) -> Rc<Self> {
         let mut servo_builder = ServoBuilder::default()

--- a/ports/servoshell/egl/app.rs
+++ b/ports/servoshell/egl/app.rs
@@ -618,7 +618,7 @@ pub(crate) struct XrDiscoveryWebXrRegistry {
 }
 
 #[cfg(feature = "webxr")]
-#[cfg_attr(target_env = "ohos", allow(dead_code))]
+#[cfg_attr(target_env = "ohos", expect(dead_code))]
 impl XrDiscoveryWebXrRegistry {
     pub(crate) fn new(xr_discovery: Option<servo::webxr::Discovery>) -> Self {
         Self {

--- a/ports/servoshell/egl/app.rs
+++ b/ports/servoshell/egl/app.rs
@@ -618,7 +618,6 @@ pub(crate) struct XrDiscoveryWebXrRegistry {
 }
 
 #[cfg(feature = "webxr")]
-#[cfg_attr(target_env = "ohos", expect(dead_code))]
 impl XrDiscoveryWebXrRegistry {
     pub(crate) fn new(xr_discovery: Option<servo::webxr::Discovery>) -> Self {
         Self {

--- a/ports/servoshell/egl/ohos/mod.rs
+++ b/ports/servoshell/egl/ohos/mod.rs
@@ -812,7 +812,7 @@ fn register_xcomponent_callbacks(env: &Env, xcomponent: &Object) -> napi_ohos::R
     Ok(())
 }
 
-#[allow(unused)]
+#[expect(unused)]
 fn debug_jsobject(obj: &Object, obj_name: &str) -> napi_ohos::Result<()> {
     let names = obj.get_property_names()?;
     error!("Getting property names of object {obj_name}");
@@ -1053,7 +1053,7 @@ impl Ime for ServoIme {
     }
 }
 
-#[allow(unused)]
+#[expect(unused)]
 impl HostTrait for HostCallbacks {
     fn show_alert(&self, message: String) {
         // forward it to tracing

--- a/ports/servoshell/prefs.rs
+++ b/ports/servoshell/prefs.rs
@@ -42,7 +42,7 @@ pub(crate) static EXPERIMENTAL_PREFS: &[&str] = &[
     "layout_variable_fonts_enabled",
 ];
 
-#[cfg_attr(any(target_os = "android", target_env = "ohos"), allow(dead_code))]
+#[cfg_attr(any(target_os = "android", target_env = "ohos"), expect(dead_code))]
 #[derive(Clone)]
 pub(crate) struct ServoShellPreferences {
     /// A URL to load when starting servoshell.
@@ -213,7 +213,7 @@ pub fn read_prefs_map(txt: &str) -> HashMap<String, PrefValue> {
 }
 
 #[expect(clippy::large_enum_variant)]
-#[cfg_attr(any(target_os = "android", target_env = "ohos"), allow(dead_code))]
+#[cfg_attr(any(target_os = "android", target_env = "ohos"), expect(dead_code))]
 pub(crate) enum ArgumentParsingResult {
     ChromeProcess(Opts, Preferences, ServoShellPreferences),
     ContentProcess(String),

--- a/ports/servoshell/test.rs
+++ b/ports/servoshell/test.rs
@@ -225,8 +225,8 @@ fn test_cmd_and_location_bar_url() {
 fn test_url_any_os(
     input: &str,
     location: &str,
-    #[allow(unused)] if_exists: &str,
-    #[allow(unused)] if_exists_windows: &str,
+    #[cfg_attr(target_os = "windows", expect(unused))] if_exists: &str,
+    #[cfg_attr(not(target_os = "windows"), expect(unused))] if_exists_windows: &str,
     otherwise: &str,
 ) {
     #[cfg(not(target_os = "windows"))]

--- a/ports/servoshell/test.rs
+++ b/ports/servoshell/test.rs
@@ -222,17 +222,25 @@ fn test_cmd_and_location_bar_url() {
 }
 
 /// Like [test_url] but will produce test for Windows or non Windows using `#[cfg(target_os)]` internally.
+#[cfg(not(target_os = "windows"))]
 fn test_url_any_os(
     input: &str,
     location: &str,
-    #[cfg_attr(target_os = "windows", expect(unused))] if_exists: &str,
-    #[cfg_attr(not(target_os = "windows"), expect(unused))] if_exists_windows: &str,
+    if_exists: &str,
+    _if_exists_windows: &str,
     otherwise: &str,
 ) {
-    #[cfg(not(target_os = "windows"))]
     test_url(input, location, if_exists, otherwise);
+}
 
-    #[cfg(target_os = "windows")]
+#[cfg(target_os = "windows")]
+fn test_url_any_os(
+    input: &str,
+    location: &str,
+    _if_exists: &str,
+    if_exists_windows: &str,
+    otherwise: &str,
+) {
     test_url(input, location, if_exists_windows, otherwise);
 }
 

--- a/support/crown/tests/compile-fail/missing_allow_in_rc.rs
+++ b/support/crown/tests/compile-fail/missing_allow_in_rc.rs
@@ -3,7 +3,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 //@rustc-env:RUSTC_BOOTSTRAP=1
 
-#![allow(dead_code)]
+#![expect(dead_code)]
 
 use std::rc::Rc;
 

--- a/support/crown/tests/compile-fail/missing_unrooted_interior.rs
+++ b/support/crown/tests/compile-fail/missing_unrooted_interior.rs
@@ -3,7 +3,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 //@rustc-env:RUSTC_BOOTSTRAP=1
 
-#![allow(dead_code)]
+#![expect(dead_code)]
 
 #[crown::unrooted_must_root_lint::must_root]
 struct MustBeRooted;

--- a/support/crown/tests/compile-fail/missing_unrooted_interior_on_trait.rs
+++ b/support/crown/tests/compile-fail/missing_unrooted_interior_on_trait.rs
@@ -3,7 +3,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 //@rustc-env:RUSTC_BOOTSTRAP=1
 
-#![allow(dead_code)]
+#![expect(dead_code)]
 
 trait TypeHolderTrait {
     #[crown::unrooted_must_root_lint::must_root]

--- a/support/crown/tests/run-pass/alias-projection-ignored.rs
+++ b/support/crown/tests/run-pass/alias-projection-ignored.rs
@@ -3,7 +3,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 //@rustc-env:RUSTC_BOOTSTRAP=1
 
-#![allow(dead_code)]
+#![expect(dead_code)]
 
 fn main() {}
 

--- a/support/crown/tests/run-pass/allow_interior_trait.rs
+++ b/support/crown/tests/run-pass/allow_interior_trait.rs
@@ -3,7 +3,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 //@rustc-env:RUSTC_BOOTSTRAP=1
 
-#![allow(dead_code)]
+#![expect(dead_code)]
 
 trait TypeHolderTrait {
     #[crown::unrooted_must_root_lint::must_root]

--- a/support/crown/tests/run-pass/allow_trait_in_rc.rs
+++ b/support/crown/tests/run-pass/allow_trait_in_rc.rs
@@ -3,7 +3,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 //@rustc-env:RUSTC_BOOTSTRAP=1
 
-#![allow(dead_code)]
+#![expect(dead_code)]
 
 use std::rc::Rc;
 

--- a/support/crown/tests/run-pass/allowed_interior.rs
+++ b/support/crown/tests/run-pass/allowed_interior.rs
@@ -3,7 +3,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 //@rustc-env:RUSTC_BOOTSTRAP=1
 
-#![allow(dead_code)]
+#![expect(dead_code)]
 
 #[crown::unrooted_must_root_lint::must_root]
 struct MustBeRooted;

--- a/support/crown/tests/run-pass/cfg_crown.rs
+++ b/support/crown/tests/run-pass/cfg_crown.rs
@@ -3,7 +3,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 //@rustc-env:RUSTC_BOOTSTRAP=1
 
-#![allow(dead_code)]
+#![expect(dead_code)]
 
 const _: () = assert!(cfg!(crown), "cfg(crown) not set!");
 

--- a/third_party/blurmac/src/framework.rs
+++ b/third_party/blurmac/src/framework.rs
@@ -9,7 +9,7 @@ use std::os::raw::{c_char, c_int, c_uint};
 
 use objc2::runtime::{BOOL, Class, Object};
 
-#[allow(non_upper_case_globals)]
+#[expect(non_upper_case_globals)]
 pub const nil: *mut Object = 0 as *mut Object;
 
 pub mod ns {


### PR DESCRIPTION
Replace `allow` with `expect` lints for `unused`, `unsafe_code`, `dead_code`, and `non_upper_case_globals`.

Testing: So far just check it compiled on `x86_64-linux` on NixOS. Need to use the module `system.fontconfig.enable = true;` I think in my NixOS config.
Part of: #40383 

Searching `allow\(.*\)` for `.rs` files shows the following. for (total_results:total_files) went from `707:386` to  `675:368`, a reduction of `32:18`.

How many files is too many files per PR? I feel like the 20-30 I have is too big.

