### PR TITLE
servoshell: Bump version number to 0.1.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8412,7 +8412,7 @@ dependencies = [
 
 [[package]]
 name = "servoshell"
-version = "0.0.4"
+version = "0.1.0"
 dependencies = [
  "android_logger",
  "backtrace",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8412,7 +8412,7 @@ dependencies = [
 
 [[package]]
 name = "servoshell"
-version = "0.0.3"
+version = "0.0.4"
 dependencies = [
  "android_logger",
  "backtrace",

--- a/Info.plist
+++ b/Info.plist
@@ -17,7 +17,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.0.4</string>
+	<string>0.1.0</string>
 	<key>NSHighResolutionCapable</key>
 	<true/>
 	<key>NSPrincipalClass</key>

--- a/Info.plist
+++ b/Info.plist
@@ -17,7 +17,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.0.3</string>
+	<string>0.0.4</string>
 	<key>NSHighResolutionCapable</key>
 	<true/>
 	<key>NSPrincipalClass</key>

--- a/ports/servoshell/Cargo.toml
+++ b/ports/servoshell/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "servoshell"
 build = "build.rs"
-version = "0.0.4"
+version = "0.1.0"
 authors.workspace = true
 license.workspace = true
 edition.workspace = true

--- a/ports/servoshell/Cargo.toml
+++ b/ports/servoshell/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "servoshell"
 build = "build.rs"
-version = "0.0.3"
+version = "0.0.4"
 authors.workspace = true
 license.workspace = true
 edition.workspace = true

--- a/resources/resource_protocol/license.html
+++ b/resources/resource_protocol/license.html
@@ -18917,7 +18917,7 @@ Exhibit B - &quot;Incompatible With Secondary Licenses&quot; Notice
                         <li><a href=" https://crates.io/crates/webgpu ">webgpu 0.0.1</a></li>
                         <li><a href=" https://crates.io/crates/webxr ">webxr 0.0.1</a></li>
                         <li><a href=" https://crates.io/crates/xpath ">xpath 0.0.1</a></li>
-                        <li><a href=" https://crates.io/crates/servoshell ">servoshell 0.0.4</a></li>
+                        <li><a href=" https://crates.io/crates/servoshell ">servoshell 0.1.0</a></li>
                         <li><a href=" https://crates.io/crates/deny_public_fields_tests ">deny_public_fields_tests 0.0.1</a></li>
                         <li><a href=" https://crates.io/crates/malloc_size_of_tests ">malloc_size_of_tests 0.0.1</a></li>
                         <li><a href=" https://crates.io/crates/profile_tests ">profile_tests 0.0.1</a></li>

--- a/resources/resource_protocol/license.html
+++ b/resources/resource_protocol/license.html
@@ -56,9 +56,9 @@
             <li><a href="#ISC">ISC License</a></li>
             <li><a href="#BSD-2-Clause">BSD 2-Clause &quot;Simplified&quot; License</a></li>
             <li><a href="#BSL-1.0">Boost Software License 1.0</a></li>
+            <li><a href="#CDLA-Permissive-2.0">Community Data License Agreement Permissive 2.0</a></li>
             <li><a href="#Zlib">zlib License</a></li>
             <li><a href="#CC0-1.0">Creative Commons Zero v1.0 Universal</a></li>
-            <li><a href="#CDLA-Permissive-2.0">Community Data License Agreement Permissive 2.0</a></li>
             <li><a href="#NCSA">University of Illinois/NCSA Open Source License</a></li>
             <li><a href="#OFL-1.1">SIL Open Font License 1.1</a></li>
             <li><a href="#OpenSSL">OpenSSL License</a></li>
@@ -1543,13 +1543,14 @@
                     <h4>Used by:</h4>
                     <ul class="license-used-by">
                         <li><a href=" https://github.com/psychon/as-raw-xcb-connection ">as-raw-xcb-connection 1.0.1</a></li>
+                        <li><a href=" https://github.com/hsivonen/chardetng ">chardetng 0.1.17</a></li>
                         <li><a href=" https://github.com/hsivonen/encoding_c ">encoding_c 0.9.8</a></li>
                         <li><a href=" https://github.com/hsivonen/encoding_c_mem ">encoding_c_mem 0.2.6</a></li>
                         <li><a href=" https://github.com/hsivonen/encoding_rs ">encoding_rs 0.8.35</a></li>
                         <li><a href=" https://github.com/linebender/kurbo ">kurbo 0.11.3</a></li>
                         <li><a href=" https://github.com/linebender/kurbo ">kurbo 0.12.0</a></li>
                         <li><a href=" https://github.com/paritytech/nohash-hasher ">nohash-hasher 0.2.0</a></li>
-                        <li><a href=" https://github.com/Ralith/openxrs ">openxr-sys 0.11.0</a></li>
+                        <li><a href=" https://github.com/Ralith/openxrs ">openxr-sys 0.12.0</a></li>
                         <li><a href=" https://github.com/nvzqz/static-assertions-rs ">static_assertions 1.1.0</a></li>
                         <li><a href=" https://github.com/Lokathor/tinyvec ">tinyvec 1.10.0</a></li>
                         <li><a href=" https://github.com/hsivonen/utf16_iter ">utf16_iter 1.0.5</a></li>
@@ -1558,7 +1559,7 @@
                         <li><a href=" https://github.com/psychon/x11rb ">x11rb-protocol 0.13.2</a></li>
                         <li><a href=" https://github.com/psychon/x11rb ">x11rb 0.13.2</a></li>
                         <li><a href=" https://github.com/RustCrypto/utils ">zeroize 1.8.2</a></li>
-                        <li><a href=" https://github.com/RustCrypto/utils/tree/master/zeroize/derive ">zeroize_derive 1.4.2</a></li>
+                        <li><a href=" https://github.com/RustCrypto/utils/tree/master/zeroize/derive ">zeroize_derive 1.4.3</a></li>
                     </ul>
                 <pre class="license-text">
                                  Apache License
@@ -3516,6 +3517,7 @@ Software.
                         <li><a href=" https://github.com/enarx/ciborium ">ciborium 0.2.2</a></li>
                         <li><a href=" https://github.com/brendanzab/codespan ">codespan-reporting 0.12.0</a></li>
                         <li><a href=" https://github.com/kornelski/imgref ">imgref 1.12.0</a></li>
+                        <li><a href=" https://github.com/rustls/rustls-platform-verifier ">rustls-platform-verifier 0.6.2</a></li>
                     </ul>
                 <pre class="license-text">                                 Apache License
                            Version 2.0, January 2004
@@ -4174,7 +4176,7 @@ Software.
                         <li><a href=" https://github.com/toml-rs/toml ">toml_datetime 0.7.3</a></li>
                         <li><a href=" https://github.com/toml-rs/toml ">toml_edit 0.22.27</a></li>
                         <li><a href=" https://github.com/toml-rs/toml ">toml_edit 0.23.7</a></li>
-                        <li><a href=" https://github.com/toml-rs/toml ">toml_parser 1.0.4</a></li>
+                        <li><a href=" https://github.com/toml-rs/toml ">toml_parser 1.0.6+spec-1.1.0</a></li>
                         <li><a href=" https://github.com/toml-rs/toml ">toml_write 0.1.2</a></li>
                         <li><a href=" https://github.com/gifnksm/topological-sort-rs ">topological-sort 0.1.0</a></li>
                     </ul>
@@ -6898,7 +6900,7 @@ limitations under the License.
                 <h3 id="Apache-2.0">Apache License 2.0</h3>
                     <p>
                         Used by
-                            <a href=" https://github.com/rustls/pki-types ">rustls-pki-types 1.13.0</a>
+                            <a href=" https://github.com/rustls/pki-types ">rustls-pki-types 1.13.2</a>
                     </p>
                 <pre class="license-text">                              Apache License
                         Version 2.0, January 2004
@@ -7319,7 +7321,8 @@ limitations under the License.
                         <li><a href=" https://github.com/dcchut/async-recursion ">async-recursion 1.1.1</a></li>
                         <li><a href=" https://github.com/image-rs/image-gif ">gif 0.13.3</a></li>
                         <li><a href=" https://github.com/rust-windowing/keyboard-types ">keyboard-types 0.8.3</a></li>
-                        <li><a href=" https://github.com/SeaQL/sea-query ">sea-query 1.0.0-rc.22</a></li>
+                        <li><a href=" https://github.com/RustCrypto/RSA ">rsa 0.9.9</a></li>
+                        <li><a href=" https://github.com/SeaQL/sea-query ">sea-query 1.0.0-rc.29</a></li>
                         <li><a href=" https://github.com/image-rs/weezl ">weezl 0.1.12</a></li>
                     </ul>
                 <pre class="license-text">                              Apache License
@@ -7537,12 +7540,12 @@ limitations under the License.</pre>
                         <li><a href=" https://github.com/gimli-rs/addr2line ">addr2line 0.25.1</a></li>
                         <li><a href=" https://github.com/tkaitchuck/ahash ">ahash 0.8.12</a></li>
                         <li><a href=" https://github.com/rust-fuzz/arbitrary/ ">arbitrary 1.4.2</a></li>
-                        <li><a href=" https://github.com/vorner/arc-swap ">arc-swap 1.7.1</a></li>
+                        <li><a href=" https://github.com/vorner/arc-swap ">arc-swap 1.8.0</a></li>
                         <li><a href=" https://github.com/bluss/arrayvec ">arrayvec 0.7.6</a></li>
                         <li><a href=" https://github.com/smol-rs/async-channel ">async-channel 2.5.0</a></li>
                         <li><a href=" https://github.com/smol-rs/async-executor ">async-executor 1.13.3</a></li>
                         <li><a href=" https://github.com/smol-rs/async-io ">async-io 2.6.0</a></li>
-                        <li><a href=" https://github.com/smol-rs/async-lock ">async-lock 3.4.1</a></li>
+                        <li><a href=" https://github.com/smol-rs/async-lock ">async-lock 3.4.2</a></li>
                         <li><a href=" https://github.com/smol-rs/async-process ">async-process 2.5.0</a></li>
                         <li><a href=" https://github.com/smol-rs/async-signal ">async-signal 0.2.13</a></li>
                         <li><a href=" https://github.com/smol-rs/async-task ">async-task 4.7.1</a></li>
@@ -7557,13 +7560,13 @@ limitations under the License.</pre>
                         <li><a href=" https://github.com/smol-rs/blocking ">blocking 1.6.2</a></li>
                         <li><a href=" https://github.com/pacak/bpaf ">bpaf 0.9.20</a></li>
                         <li><a href=" https://github.com/pacak/bpaf ">bpaf_derive 0.5.17</a></li>
-                        <li><a href=" https://github.com/fitzgen/bumpalo ">bumpalo 3.19.0</a></li>
+                        <li><a href=" https://github.com/fitzgen/bumpalo ">bumpalo 3.19.1</a></li>
                         <li><a href=" https://github.com/japaric/cast.rs ">cast 0.3.0</a></li>
-                        <li><a href=" https://github.com/rust-lang/cc-rs ">cc 1.2.48</a></li>
+                        <li><a href=" https://github.com/rust-lang/cc-rs ">cc 1.2.51</a></li>
                         <li><a href=" https://github.com/jethrogb/rust-cexpr ">cexpr 0.6.0</a></li>
                         <li><a href=" https://github.com/rust-lang/cfg-if ">cfg-if 1.0.4</a></li>
                         <li><a href=" https://github.com/servo/cgl-rs ">cgl 0.3.2</a></li>
-                        <li><a href=" https://github.com/rust-lang/cmake-rs ">cmake 0.1.54</a></li>
+                        <li><a href=" https://github.com/rust-lang/cmake-rs ">cmake 0.1.57</a></li>
                         <li><a href=" https://github.com/smol-rs/concurrent-queue ">concurrent-queue 2.5.0</a></li>
                         <li><a href=" https://github.com/servo/core-foundation-rs ">core-foundation-sys 0.8.7</a></li>
                         <li><a href=" https://github.com/servo/core-foundation-rs ">core-foundation 0.10.1</a></li>
@@ -7590,7 +7593,7 @@ limitations under the License.</pre>
                         <li><a href=" https://github.com/smol-rs/event-listener ">event-listener 5.4.1</a></li>
                         <li><a href=" https://github.com/smol-rs/fastrand ">fastrand 2.3.0</a></li>
                         <li><a href=" https://github.com/alexcrichton/filetime ">filetime 0.2.26</a></li>
-                        <li><a href=" https://github.com/rust-lang/cc-rs ">find-msvc-tools 0.1.5</a></li>
+                        <li><a href=" https://github.com/rust-lang/cc-rs ">find-msvc-tools 0.1.6</a></li>
                         <li><a href=" https://github.com/bluss/fixedbitset ">fixedbitset 0.1.9</a></li>
                         <li><a href=" https://github.com/rust-lang/flate2-rs ">flate2 1.1.5</a></li>
                         <li><a href=" https://github.com/servo/rust-fnv ">fnv 1.0.7</a></li>
@@ -7607,6 +7610,7 @@ limitations under the License.</pre>
                         <li><a href=" https://github.com/zkcrypto/group ">group 0.13.0</a></li>
                         <li><a href=" https://github.com/servo/rust-harfbuzz ">harfbuzz-sys 0.6.1</a></li>
                         <li><a href=" https://github.com/rust-lang/hashbrown ">hashbrown 0.15.5</a></li>
+                        <li><a href=" https://github.com/rust-lang/hashbrown ">hashbrown 0.16.0</a></li>
                         <li><a href=" https://github.com/withoutboats/heck ">heck 0.4.1</a></li>
                         <li><a href=" https://github.com/withoutboats/heck ">heck 0.5.0</a></li>
                         <li><a href=" https://github.com/hermit-os/hermit-rs ">hermit-abi 0.5.2</a></li>
@@ -7631,20 +7635,23 @@ limitations under the License.</pre>
                         <li><a href=" https://github.com/sunfishcode/linux-raw-sys ">linux-raw-sys 0.11.0</a></li>
                         <li><a href=" https://github.com/sunfishcode/linux-raw-sys ">linux-raw-sys 0.4.15</a></li>
                         <li><a href=" https://github.com/Amanieu/parking_lot ">lock_api 0.4.14</a></li>
-                        <li><a href=" https://github.com/rust-lang/log ">log 0.4.28</a></li>
+                        <li><a href=" https://github.com/rust-lang/log ">log 0.4.29</a></li>
                         <li><a href=" https://github.com/bholley/malloc_size_of_derive ">malloc_size_of_derive 0.1.3</a></li>
                         <li><a href=" https://github.com/servo/html5ever ">markup5ever 0.36.1</a></li>
                         <li><a href=" https://github.com/gfx-rs/metal-rs ">metal 0.32.0</a></li>
                         <li><a href=" https://github.com/hyperium/mime ">mime 0.3.17</a></li>
+                        <li><a href=" https://github.com/dignifiedquire/num-bigint ">num-bigint-dig 0.8.6</a></li>
                         <li><a href=" https://github.com/rust-num/num-bigint ">num-bigint 0.4.6</a></li>
                         <li><a href=" https://github.com/rust-num/num-complex ">num-complex 0.2.4</a></li>
                         <li><a href=" https://github.com/rust-num/num-derive ">num-derive 0.4.2</a></li>
                         <li><a href=" https://github.com/rust-num/num-integer ">num-integer 0.1.46</a></li>
+                        <li><a href=" https://github.com/rust-num/num-iter ">num-iter 0.1.45</a></li>
                         <li><a href=" https://github.com/rust-num/num-rational ">num-rational 0.4.2</a></li>
                         <li><a href=" https://github.com/rust-num/num-traits ">num-traits 0.2.19</a></li>
                         <li><a href=" https://github.com/seanmonstar/num_cpus ">num_cpus 1.17.0</a></li>
                         <li><a href=" https://github.com/gimli-rs/object ">object 0.37.3</a></li>
                         <li><a href=" https://github.com/matklad/once_cell ">once_cell 1.21.3</a></li>
+                        <li><a href=" https://github.com/alexcrichton/openssl-probe ">openssl-probe 0.2.0</a></li>
                         <li><a href=" https://github.com/danieldg/ordered-stream ">ordered-stream 0.2.0</a></li>
                         <li><a href=" https://github.com/bluss/ordermap ">ordermap 0.3.5</a></li>
                         <li><a href=" https://github.com/smol-rs/parking ">parking 2.2.1</a></li>
@@ -7668,12 +7675,14 @@ limitations under the License.</pre>
                         <li><a href=" https://github.com/djc/rustc-version-rs ">rustc_version 0.4.1</a></li>
                         <li><a href=" https://github.com/bytecodealliance/rustix ">rustix 0.38.44</a></li>
                         <li><a href=" https://github.com/bytecodealliance/rustix ">rustix 1.1.2</a></li>
-                        <li><a href=" https://github.com/rustls/pemfile ">rustls-pemfile 2.2.0</a></li>
+                        <li><a href=" https://github.com/rustls/rustls-native-certs ">rustls-native-certs 0.8.3</a></li>
                         <li><a href=" https://github.com/rustls/rustls ">rustls 0.23.35</a></li>
                         <li><a href=" https://github.com/alexcrichton/scoped-tls ">scoped-tls 1.0.1</a></li>
                         <li><a href=" https://github.com/bluss/scopeguard ">scopeguard 1.2.0</a></li>
+                        <li><a href=" https://github.com/kornelski/rust-security-framework ">security-framework-sys 2.15.0</a></li>
+                        <li><a href=" https://github.com/kornelski/rust-security-framework ">security-framework 3.5.1</a></li>
                         <li><a href=" https://github.com/adjivas/sig ">sig 1.0.0</a></li>
-                        <li><a href=" https://github.com/vorner/signal-hook ">signal-hook-registry 1.4.7</a></li>
+                        <li><a href=" https://github.com/vorner/signal-hook ">signal-hook-registry 1.4.8</a></li>
                         <li><a href=" https://github.com/linebender/simplecss ">simplecss 0.2.2</a></li>
                         <li><a href=" https://github.com/servo/smallbitvec ">smallbitvec 2.6.0</a></li>
                         <li><a href=" https://github.com/servo/rust-smallvec ">smallvec 1.15.1</a></li>
@@ -7703,7 +7712,7 @@ limitations under the License.</pre>
                         <li><a href=" https://github.com/RazrFalcon/unicode-vo ">unicode-vo 0.1.0</a></li>
                         <li><a href=" https://github.com/unicode-rs/unicode-width ">unicode-width 0.2.2</a></li>
                         <li><a href=" https://github.com/servo/rust-url ">url 2.5.7</a></li>
-                        <li><a href=" https://github.com/uuid-rs/uuid ">uuid 1.18.1</a></li>
+                        <li><a href=" https://github.com/uuid-rs/uuid ">uuid 1.19.0</a></li>
                         <li><a href=" https://github.com/SergioBenitez/version_check ">version_check 0.9.5</a></li>
                         <li><a href=" https://github.com/bytecodealliance/wasi ">wasi 0.11.1+wasi-snapshot-preview1</a></li>
                         <li><a href=" https://github.com/wasm-bindgen/wasm-bindgen/tree/master/crates/futures ">wasm-bindgen-futures 0.4.55</a></li>
@@ -8770,7 +8779,7 @@ limitations under the License.</pre>
                         <li><a href=" https://github.com/RustCrypto/block-ciphers ">aes 0.8.4</a></li>
                         <li><a href=" https://github.com/RustCrypto/password-hashes/tree/master/argon2 ">argon2 0.5.3</a></li>
                         <li><a href=" https://github.com/RustCrypto/formats/tree/master/base16ct ">base16ct 0.2.0</a></li>
-                        <li><a href=" https://github.com/RustCrypto/formats ">base64ct 1.8.0</a></li>
+                        <li><a href=" https://github.com/RustCrypto/formats ">base64ct 1.8.1</a></li>
                         <li><a href=" https://github.com/RustCrypto/hashes ">blake2 0.10.6</a></li>
                         <li><a href=" https://github.com/RustCrypto/utils ">block-buffer 0.10.4</a></li>
                         <li><a href=" https://github.com/RustCrypto/utils ">block-padding 0.3.3</a></li>
@@ -8784,18 +8793,22 @@ limitations under the License.</pre>
                         <li><a href=" https://github.com/RustCrypto/traits ">crypto-common 0.1.7</a></li>
                         <li><a href=" https://github.com/RustCrypto/block-modes ">ctr 0.9.2</a></li>
                         <li><a href=" https://github.com/RustCrypto/formats/tree/master/der ">der 0.7.10</a></li>
+                        <li><a href=" https://github.com/RustCrypto/formats/tree/master/der/derive ">der_derive 0.7.3</a></li>
                         <li><a href=" https://github.com/RustCrypto/traits ">digest 0.10.7</a></li>
                         <li><a href=" https://github.com/RustCrypto/traits/tree/master/elliptic-curve ">elliptic-curve 0.13.8</a></li>
                         <li><a href=" https://github.com/RustCrypto/universal-hashes ">ghash 0.5.1</a></li>
                         <li><a href=" https://github.com/RustCrypto/MACs ">hmac 0.12.1</a></li>
+                        <li><a href=" https://github.com/RustCrypto/hybrid-array ">hybrid-array 0.2.3</a></li>
                         <li><a href=" https://github.com/RustCrypto/utils ">inout 0.1.4</a></li>
                         <li><a href=" https://github.com/RustCrypto/sponges/tree/master/keccak ">keccak 0.1.5</a></li>
+                        <li><a href=" https://github.com/RustCrypto/KEMs ">ml-kem 0.2.1</a></li>
                         <li><a href=" https://github.com/RustCrypto/utils ">opaque-debug 0.3.1</a></li>
                         <li><a href=" https://github.com/RustCrypto/elliptic-curves/tree/master/p256 ">p256 0.13.2</a></li>
                         <li><a href=" https://github.com/RustCrypto/elliptic-curves/tree/master/p384 ">p384 0.13.1</a></li>
                         <li><a href=" https://github.com/RustCrypto/elliptic-curves/tree/master/p521 ">p521 0.13.3</a></li>
                         <li><a href=" https://github.com/RustCrypto/traits/tree/master/password-hash ">password-hash 0.5.0</a></li>
                         <li><a href=" https://github.com/RustCrypto/formats/tree/master/pem-rfc7468 ">pem-rfc7468 0.7.0</a></li>
+                        <li><a href=" https://github.com/RustCrypto/formats/tree/master/pkcs1 ">pkcs1 0.7.5</a></li>
                         <li><a href=" https://github.com/RustCrypto/formats/tree/master/pkcs8 ">pkcs8 0.10.2</a></li>
                         <li><a href=" https://github.com/RustCrypto/universal-hashes ">poly1305 0.8.0</a></li>
                         <li><a href=" https://github.com/RustCrypto/universal-hashes ">polyval 0.6.2</a></li>
@@ -9842,7 +9855,7 @@ limitations under the License.
                 <h3 id="Apache-2.0">Apache License 2.0</h3>
                     <p>
                         Used by
-                            <a href=" https://github.com/unicode-rs/unicode-script ">unicode-script 0.5.7</a>
+                            <a href=" https://github.com/unicode-rs/unicode-script ">unicode-script 0.5.8</a>
                     </p>
                 <pre class="license-text">                              Apache License
                         Version 2.0, January 2004
@@ -11403,7 +11416,7 @@ limitations under the License.
                     <h4>Used by:</h4>
                     <ul class="license-used-by">
                         <li><a href=" https://github.com/mmastrac/rust-ctor ">ctor-proc-macro 0.0.7</a></li>
-                        <li><a href=" https://github.com/mmastrac/rust-ctor ">ctor 0.6.1</a></li>
+                        <li><a href=" https://github.com/mmastrac/rust-ctor ">ctor 0.6.3</a></li>
                         <li><a href=" https://github.com/mmastrac/rust-ctor ">dtor-proc-macro 0.0.6</a></li>
                         <li><a href=" https://github.com/mmastrac/rust-ctor ">dtor 0.1.1</a></li>
                     </ul>
@@ -12327,27 +12340,27 @@ limitations under the License.
                         <li><a href=" https://github.com/zrzka/anes-rs ">anes 0.1.6</a></li>
                         <li><a href=" https://github.com/dtolnay/anyhow ">anyhow 1.0.100</a></li>
                         <li><a href=" https://github.com/1Password/arboard ">arboard 3.6.1</a></li>
-                        <li><a href=" https://github.com/Nullus157/async-compression ">async-compression 0.4.34</a></li>
+                        <li><a href=" https://github.com/Nullus157/async-compression ">async-compression 0.4.36</a></li>
                         <li><a href=" https://github.com/dtolnay/async-trait ">async-trait 0.1.89</a></li>
                         <li><a href=" https://github.com/odilia-app/atspi ">atspi-proxies 0.9.0</a></li>
                         <li><a href=" https://github.com/jrmuizel/build-parallel ">build-parallel 0.1.2</a></li>
                         <li><a href=" https://github.com/emk/cesu8-rs ">cesu8 1.1.0</a></li>
                         <li><a href=" https://github.com/linebender/color ">color 0.3.2</a></li>
-                        <li><a href=" https://github.com/Nullus157/async-compression ">compression-codecs 0.4.33</a></li>
+                        <li><a href=" https://github.com/Nullus157/async-compression ">compression-codecs 0.4.35</a></li>
                         <li><a href=" https://github.com/Nullus157/async-compression ">compression-core 0.4.31</a></li>
                         <li><a href=" https://github.com/soc/directories-rs ">directories 6.0.0</a></li>
                         <li><a href=" https://github.com/dirs-dev/dirs-sys-rs ">dirs-sys 0.5.0</a></li>
                         <li><a href=" https://github.com/soc/dirs-rs ">dirs 6.0.0</a></li>
                         <li><a href=" https://github.com/slint-ui/document-features ">document-features 0.2.12</a></li>
-                        <li><a href=" https://github.com/dtolnay/dtoa ">dtoa 1.0.10</a></li>
+                        <li><a href=" https://github.com/dtolnay/dtoa ">dtoa 1.0.11</a></li>
                         <li><a href=" https://gitlab.com/kornelski/dunce ">dunce 1.0.5</a></li>
-                        <li><a href=" https://github.com/emilk/egui ">ecolor 0.33.2</a></li>
-                        <li><a href=" https://github.com/emilk/egui/tree/main/crates/egui-winit ">egui-winit 0.33.2</a></li>
-                        <li><a href=" https://github.com/emilk/egui ">egui 0.33.2</a></li>
-                        <li><a href=" https://github.com/emilk/egui/tree/main/crates/egui_glow ">egui_glow 0.33.2</a></li>
-                        <li><a href=" https://github.com/emilk/egui/tree/main/crates/emath ">emath 0.33.2</a></li>
-                        <li><a href=" https://github.com/emilk/egui/tree/main/crates/epaint ">epaint 0.33.2</a></li>
-                        <li><a href=" https://github.com/emilk/egui/tree/main/crates/epaint_default_fonts ">epaint_default_fonts 0.33.2</a></li>
+                        <li><a href=" https://github.com/emilk/egui ">ecolor 0.33.3</a></li>
+                        <li><a href=" https://github.com/emilk/egui/tree/main/crates/egui-winit ">egui-winit 0.33.3</a></li>
+                        <li><a href=" https://github.com/emilk/egui ">egui 0.33.3</a></li>
+                        <li><a href=" https://github.com/emilk/egui/tree/main/crates/egui_glow ">egui_glow 0.33.3</a></li>
+                        <li><a href=" https://github.com/emilk/egui/tree/main/crates/emath ">emath 0.33.3</a></li>
+                        <li><a href=" https://github.com/emilk/egui/tree/main/crates/epaint ">epaint 0.33.3</a></li>
+                        <li><a href=" https://github.com/emilk/egui/tree/main/crates/epaint_default_fonts ">epaint_default_fonts 0.33.3</a></li>
                         <li><a href=" https://github.com/nical/etagere ">etagere 0.2.15</a></li>
                         <li><a href=" https://github.com/image-rs/fdeflate ">fdeflate 0.3.7</a></li>
                         <li><a href=" https://github.com/linebender/fearless_simd ">fearless_simd 0.3.0</a></li>
@@ -12360,18 +12373,20 @@ limitations under the License.
                         <li><a href=" https://github.com/zakarumych/gpu-descriptor ">gpu-descriptor-types 0.2.0</a></li>
                         <li><a href=" https://github.com/zakarumych/gpu-descriptor ">gpu-descriptor 0.3.2</a></li>
                         <li><a href=" https://github.com/VoidStarKat/half-rs ">half 2.7.1</a></li>
-                        <li><a href=" https://github.com/openharmony-rs/ohos-sys ">hilog-sys 0.1.6</a></li>
+                        <li><a href=" https://github.com/openharmony-rs/ohos-sys ">hilog-sys 0.1.7</a></li>
                         <li><a href=" https://github.com/TedDriggs/ident_case ">ident_case 1.0.1</a></li>
                         <li><a href=" https://github.com/image-rs/image-webp ">image-webp 0.2.4</a></li>
                         <li><a href=" https://github.com/image-rs/image ">image 0.25.6</a></li>
                         <li><a href=" https://github.com/dtolnay/inherent ">inherent 1.0.13</a></li>
-                        <li><a href=" https://github.com/dtolnay/itoa ">itoa 1.0.15</a></li>
+                        <li><a href=" https://github.com/dtolnay/itoa ">itoa 1.0.17</a></li>
+                        <li><a href=" https://github.com/RustCrypto/traits/tree/master/kem ">kem 0.3.0-pre.0</a></li>
                         <li><a href=" https://github.com/brendanzab/gl-rs/ ">khronos_api 3.1.0</a></li>
-                        <li><a href=" https://github.com/rust-lang/libc ">libc 0.2.177</a></li>
+                        <li><a href=" https://github.com/rust-lang/libc ">libc 0.2.178</a></li>
                         <li><a href=" https://github.com/linebender/raw_resource_handle ">linebender_resource_handle 0.1.1</a></li>
                         <li><a href=" https://github.com/LukasKalbertodt/litrs ">litrs 1.0.0</a></li>
                         <li><a href=" https://github.com/reem/rust-mac.git ">mac 0.1.1</a></li>
                         <li><a href=" https://github.com/JohnTitor/mach2 ">mach2 0.4.3</a></li>
+                        <li><a href=" https://github.com/JohnTitor/mach2 ">mach2 0.6.0</a></li>
                         <li><a href=" https://github.com/Frommi/miniz_oxide/tree/master/miniz_oxide ">miniz_oxide 0.8.9</a></li>
                         <li><a href=" https://github.com/gfx-rs/wgpu ">naga 26.0.0</a></li>
                         <li><a href=" https://github.com/rust-windowing/android-ndk-rs ">ndk-context 0.1.1</a></li>
@@ -12388,25 +12403,25 @@ limitations under the License.
                         <li><a href=" https://github.com/madsmtm/objc2 ">objc2-io-surface 0.3.2</a></li>
                         <li><a href=" https://github.com/madsmtm/objc2 ">objc2-metal 0.3.2</a></li>
                         <li><a href=" https://github.com/madsmtm/objc2 ">objc2-quartz-core 0.3.2</a></li>
-                        <li><a href=" https://github.com/openharmony-rs/ohos-sys ">ohos-abilitykit-sys 0.1.2</a></li>
-                        <li><a href=" https://github.com/openharmony-rs/ohos-sys ">ohos-deviceinfo-sys 0.1.5</a></li>
+                        <li><a href=" https://github.com/openharmony-rs/ohos-sys ">ohos-abilitykit-sys 0.1.4</a></li>
+                        <li><a href=" https://github.com/openharmony-rs/ohos-sys ">ohos-deviceinfo-sys 0.1.6</a></li>
                         <li><a href=" https://github.com/openharmony-rs/ohos-deviceinfo ">ohos-deviceinfo 0.1.0</a></li>
-                        <li><a href=" https://github.com/openharmony-rs/ohos-sys ">ohos-ime-sys 0.2.2</a></li>
-                        <li><a href=" https://github.com/openharmony-rs/ohos-ime ">ohos-ime 0.4.0</a></li>
-                        <li><a href=" https://github.com/openharmony-rs/ohos-sys ">ohos-sys-opaque-types 0.1.7</a></li>
-                        <li><a href=" https://github.com/openharmony-rs/ohos-sys ">ohos-vsync-sys 0.1.4</a></li>
+                        <li><a href=" https://github.com/openharmony-rs/ohos-sys ">ohos-ime-sys 0.2.3</a></li>
+                        <li><a href=" https://github.com/openharmony-rs/ohos-ime ">ohos-ime 0.4.2</a></li>
+                        <li><a href=" https://github.com/openharmony-rs/ohos-sys ">ohos-sys-opaque-types 0.1.8</a></li>
+                        <li><a href=" https://github.com/openharmony-rs/ohos-sys ">ohos-vsync-sys 0.1.5</a></li>
                         <li><a href=" https://github.com/openharmony-rs/ohos-vsync ">ohos-vsync 0.1.3</a></li>
-                        <li><a href=" https://github.com/openharmony-rs/ohos-sys ">ohos-window-manager-sys 0.1.2</a></li>
-                        <li><a href=" https://github.com/Ralith/openxrs ">openxr 0.19.0</a></li>
+                        <li><a href=" https://github.com/openharmony-rs/ohos-sys ">ohos-window-manager-sys 0.1.3</a></li>
+                        <li><a href=" https://github.com/Ralith/openxrs ">openxr 0.20.0</a></li>
                         <li><a href=" https://github.com/alexheretic/owned-ttf-parser ">owned_ttf_parser 0.25.1</a></li>
                         <li><a href=" https://github.com/dtolnay/paste ">paste 1.0.15</a></li>
                         <li><a href=" https://github.com/taiki-e/pin-project ">pin-project-internal 1.1.10</a></li>
                         <li><a href=" https://github.com/taiki-e/pin-project-lite ">pin-project-lite 0.2.16</a></li>
                         <li><a href=" https://github.com/taiki-e/pin-project ">pin-project 1.1.10</a></li>
                         <li><a href=" https://github.com/taiki-e/portable-atomic ">portable-atomic-util 0.2.4</a></li>
-                        <li><a href=" https://github.com/taiki-e/portable-atomic ">portable-atomic 1.11.1</a></li>
+                        <li><a href=" https://github.com/taiki-e/portable-atomic ">portable-atomic 1.13.0</a></li>
                         <li><a href=" https://github.com/dtolnay/prettyplease ">prettyplease 0.2.37</a></li>
-                        <li><a href=" https://github.com/dtolnay/proc-macro2 ">proc-macro2 1.0.103</a></li>
+                        <li><a href=" https://github.com/dtolnay/proc-macro2 ">proc-macro2 1.0.104</a></li>
                         <li><a href=" https://github.com/aclysma/profiling ">profiling-procmacros 1.0.17</a></li>
                         <li><a href=" https://github.com/aclysma/profiling ">profiling 1.0.17</a></li>
                         <li><a href=" https://github.com/dtolnay/quote ">quote 1.0.42</a></li>
@@ -12418,16 +12433,17 @@ limitations under the License.
                         <li><a href=" https://github.com/rust-windowing/raw-window-handle ">raw-window-handle 0.6.2</a></li>
                         <li><a href=" https://github.com/linebender/resvg ">resvg 0.45.1</a></li>
                         <li><a href=" https://github.com/rust-lang/rustc-hash ">rustc-hash 2.1.1</a></li>
+                        <li><a href=" https://github.com/rustls/rustls-platform-verifier ">rustls-platform-verifier-android 0.1.1</a></li>
                         <li><a href=" https://github.com/dtolnay/rustversion ">rustversion 1.0.22</a></li>
-                        <li><a href=" https://github.com/dtolnay/ryu ">ryu 1.0.20</a></li>
+                        <li><a href=" https://github.com/dtolnay/ryu ">ryu 1.0.22</a></li>
                         <li><a href=" https://github.com/SeaQL/sea-query ">sea-query-derive 1.0.0-rc.11</a></li>
-                        <li><a href=" https://github.com/SeaQL/sea-query ">sea-query-rusqlite 0.8.0-rc.8</a></li>
+                        <li><a href=" https://github.com/SeaQL/sea-query ">sea-query-rusqlite 0.8.0-rc.15</a></li>
                         <li><a href=" https://github.com/dtolnay/semver ">semver 1.0.27</a></li>
                         <li><a href=" https://github.com/serde-rs/serde ">serde 1.0.228</a></li>
                         <li><a href=" https://github.com/serde-rs/bytes ">serde_bytes 0.11.19</a></li>
                         <li><a href=" https://github.com/serde-rs/serde ">serde_core 1.0.228</a></li>
                         <li><a href=" https://github.com/serde-rs/serde ">serde_derive 1.0.228</a></li>
-                        <li><a href=" https://github.com/serde-rs/json ">serde_json 1.0.145</a></li>
+                        <li><a href=" https://github.com/serde-rs/json ">serde_json 1.0.148</a></li>
                         <li><a href=" https://github.com/dtolnay/serde-repr ">serde_repr 0.1.20</a></li>
                         <li><a href=" https://github.com/serde-rs/test ">serde_test 1.0.177</a></li>
                         <li><a href=" https://github.com/nox/serde_urlencoded ">serde_urlencoded 0.7.1</a></li>
@@ -12465,7 +12481,7 @@ limitations under the License.
                         <li><a href=" https://github.com/gfx-rs/wgpu ">wgpu-types 26.0.0</a></li>
                         <li><a href=" https://github.com/retep998/winapi-rs ">winapi-i686-pc-windows-gnu 0.4.0</a></li>
                         <li><a href=" https://github.com/retep998/winapi-rs ">winapi-x86_64-pc-windows-gnu 0.4.0</a></li>
-                        <li><a href=" https://github.com/openharmony-rs/ohos-sys ">xcomponent-sys 0.3.4</a></li>
+                        <li><a href=" https://github.com/openharmony-rs/ohos-sys ">xcomponent-sys 0.3.5</a></li>
                         <li><a href=" https://github.com/google/xi-editor ">xi-unicode 0.3.0</a></li>
                         <li><a href=" https://github.com/gyscos/zstd-rs ">zstd-safe 7.2.4</a></li>
                         <li><a href=" https://github.com/gyscos/zstd-rs ">zstd-sys 2.0.16+zstd.1.5.7</a></li>
@@ -13593,10 +13609,11 @@ express Statement of Purpose.
             </li>
             <li class="license">
                 <h3 id="CDLA-Permissive-2.0">Community Data License Agreement Permissive 2.0</h3>
-                    <p>
-                        Used by
-                            <a href=" https://github.com/rustls/webpki-roots ">webpki-roots 1.0.4</a>
-                    </p>
+                    <h4>Used by:</h4>
+                    <ul class="license-used-by">
+                        <li><a href=" https://github.com/rustls/webpki-roots ">webpki-root-certs 1.0.4</a></li>
+                        <li><a href=" https://github.com/rustls/webpki-roots ">webpki-roots 1.0.4</a></li>
+                    </ul>
                 <pre class="license-text"># Community Data License Agreement - Permissive - Version 2.0
 
 This is the Community Data License Agreement - Permissive, Version
@@ -13664,7 +13681,7 @@ insights.
                 <h3 id="ISC">ISC License</h3>
                     <p>
                         Used by
-                            <a href=" https://github.com/aws/aws-lc-rs ">aws-lc-sys 0.34.0</a>
+                            <a href=" https://github.com/aws/aws-lc-rs ">aws-lc-sys 0.35.0</a>
                     </p>
                 <pre class="license-text">/* Copyright (c) 2018, Google Inc.
  *
@@ -13756,10 +13773,11 @@ THIS SOFTWARE.
             </li>
             <li class="license">
                 <h3 id="ISC">ISC License</h3>
-                    <p>
-                        Used by
-                            <a href=" https://github.com/nagisa/rust_libloading/ ">libloading 0.8.9</a>
-                    </p>
+                    <h4>Used by:</h4>
+                    <ul class="license-used-by">
+                        <li><a href=" https://github.com/nagisa/rust_libloading/ ">libloading 0.8.9</a></li>
+                        <li><a href=" https://github.com/nagisa/rust_libloading/ ">libloading 0.9.0</a></li>
+                    </ul>
                 <pre class="license-text">Copyright © 2015, Simonas Kazlauskas
 
 Permission to use, copy, modify, and/or distribute this software for any purpose with or without
@@ -13805,7 +13823,7 @@ third-party/chromium/LICENSE.
                 <h3 id="ISC">ISC License</h3>
                     <p>
                         Used by
-                            <a href=" https://github.com/aws/aws-lc-rs ">aws-lc-rs 1.15.1</a>
+                            <a href=" https://github.com/aws/aws-lc-rs ">aws-lc-rs 1.15.2</a>
                     </p>
                 <pre class="license-text">ISC License:
 
@@ -13933,7 +13951,7 @@ THE SOFTWARE.
                 <h3 id="MIT">MIT License</h3>
                     <p>
                         Used by
-                            <a href=" https://github.com/tokio-rs/mio ">mio 1.1.0</a>
+                            <a href=" https://github.com/tokio-rs/mio ">mio 1.1.1</a>
                     </p>
                 <pre class="license-text">Copyright (c) 2014 Carl Lerche and other MIO contributors
 
@@ -14333,6 +14351,21 @@ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.</pre>
+            </li>
+            <li class="license">
+                <h3 id="MIT">MIT License</h3>
+                    <p>
+                        Used by
+                            <a href=" https://github.com/steffengy/schannel-rs ">schannel 0.1.28</a>
+                    </p>
+                <pre class="license-text">Copyright (c) 2015 steffengy
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the &quot;Software&quot;), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED &quot;AS IS&quot;, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+</pre>
             </li>
             <li class="license">
                 <h3 id="MIT">MIT License</h3>
@@ -14751,8 +14784,8 @@ DEALINGS IN THE SOFTWARE.
                     <h4>Used by:</h4>
                     <ul class="license-used-by">
                         <li><a href=" https://github.com/tokio-rs/tracing ">tracing-attributes 0.1.31</a></li>
-                        <li><a href=" https://github.com/tokio-rs/tracing ">tracing-core 0.1.35</a></li>
-                        <li><a href=" https://github.com/tokio-rs/tracing ">tracing 0.1.43</a></li>
+                        <li><a href=" https://github.com/tokio-rs/tracing ">tracing-core 0.1.36</a></li>
+                        <li><a href=" https://github.com/tokio-rs/tracing ">tracing 0.1.44</a></li>
                     </ul>
                 <pre class="license-text">Copyright (c) 2019 Tokio Contributors
 
@@ -14994,7 +15027,7 @@ SOFTWARE.
                 <h3 id="MIT">MIT License</h3>
                     <p>
                         Used by
-                            <a href=" https://github.com/hyperium/hyper-util ">hyper-util 0.1.18</a>
+                            <a href=" https://github.com/hyperium/hyper-util ">hyper-util 0.1.19</a>
                     </p>
                 <pre class="license-text">Copyright (c) 2023-2025 Sean McArthur
 
@@ -15626,6 +15659,35 @@ SOFTWARE.
                 <h3 id="MIT">MIT License</h3>
                     <p>
                         Used by
+                            <a href=" https://github.com/arthurprs/quick-cache ">quick_cache 0.6.18</a>
+                    </p>
+                <pre class="license-text">MIT License
+
+Copyright (c) 2022 Arthur Silva
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the &quot;Software&quot;), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED &quot;AS IS&quot;, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+</pre>
+            </li>
+            <li class="license">
+                <h3 id="MIT">MIT License</h3>
+                    <p>
+                        Used by
                             <a href=" https://github.com/PolyMeilex/sctk-adwaita ">sctk-adwaita 0.10.1</a>
                     </p>
                 <pre class="license-text">MIT License
@@ -15684,7 +15746,7 @@ SOFTWARE.
                 <h3 id="MIT">MIT License</h3>
                     <p>
                         Used by
-                            <a href=" https://gitlab.redox-os.org/redox-os/libredox.git ">libredox 0.1.10</a>
+                            <a href=" https://gitlab.redox-os.org/redox-os/libredox.git ">libredox 0.1.12</a>
                     </p>
                 <pre class="license-text">MIT License
 
@@ -15771,7 +15833,7 @@ SOFTWARE.</pre>
                 <h3 id="MIT">MIT License</h3>
                     <p>
                         Used by
-                            <a href=" https://github.com/rutrum/convert-case ">convert_case 0.8.0</a>
+                            <a href=" https://github.com/rutrum/convert-case ">convert_case 0.10.0</a>
                     </p>
                 <pre class="license-text">MIT License
 
@@ -15805,11 +15867,11 @@ SOFTWARE.</pre>
                         <li><a href=" https://github.com/rust-windowing/winit ">dpi 0.1.2</a></li>
                         <li><a href=" https://github.com/rust-lang/compiler-builtins ">libm 0.2.15</a></li>
                         <li><a href=" https://github.com/SSheldon/malloc_buf ">malloc_buf 0.0.6</a></li>
-                        <li><a href=" https://github.com/ohos-rs/ohos-rs ">napi-build-ohos 1.1.4</a></li>
-                        <li><a href=" https://github.com/ohos-rs/ohos-rs ">napi-derive-backend-ohos 1.1.4</a></li>
-                        <li><a href=" https://github.com/ohos-rs/ohos-rs ">napi-derive-ohos 1.1.4</a></li>
-                        <li><a href=" https://github.com/ohos-rs/ohos-rs ">napi-ohos 1.1.4</a></li>
-                        <li><a href=" https://github.com/ohos-rs/ohos-rs ">napi-sys-ohos 1.1.4</a></li>
+                        <li><a href=" https://github.com/ohos-rs/ohos-rs ">napi-build-ohos 1.1.5</a></li>
+                        <li><a href=" https://github.com/ohos-rs/ohos-rs ">napi-derive-backend-ohos 1.1.5</a></li>
+                        <li><a href=" https://github.com/ohos-rs/ohos-rs ">napi-derive-ohos 1.1.5</a></li>
+                        <li><a href=" https://github.com/ohos-rs/ohos-rs ">napi-ohos 1.1.5</a></li>
+                        <li><a href=" https://github.com/ohos-rs/ohos-rs ">napi-sys-ohos 1.1.5</a></li>
                         <li><a href=" https://github.com/rust-bakery/nom ">nom-language 0.1.0</a></li>
                         <li><a href=" https://github.com/madsmtm/objc2 ">objc-sys 0.3.5</a></li>
                         <li><a href=" https://github.com/madsmtm/objc2 ">objc2-app-kit 0.2.2</a></li>
@@ -15911,7 +15973,7 @@ SOFTWARE.
                 <h3 id="MIT">MIT License</h3>
                     <p>
                         Used by
-                            <a href=" https://github.com/mcountryman/simd-adler32 ">simd-adler32 0.3.7</a>
+                            <a href=" https://github.com/mcountryman/simd-adler32 ">simd-adler32 0.3.8</a>
                     </p>
                 <pre class="license-text">MIT License
 
@@ -16030,8 +16092,9 @@ SOFTWARE.
                         <li><a href=" https://github.com/zeenix/endi ">endi 1.1.1</a></li>
                         <li><a href=" https://github.com/sunfishcode/is-terminal ">is-terminal 0.4.17</a></li>
                         <li><a href=" https://github.com/AltF02/x11-rs.git ">x11-dl 2.21.0</a></li>
-                        <li><a href=" https://github.com/luukvanderduim/zbus-lockstep ">zbus-lockstep-macros 0.5.1</a></li>
+                        <li><a href=" https://github.com/luukvanderduim/zbus-lockstep ">zbus-lockstep-macros 0.5.2</a></li>
                         <li><a href=" https://github.com/luukvanderduim/zbus-lockstep ">zbus-lockstep 0.5.2</a></li>
+                        <li><a href=" https://github.com/dtolnay/zmij ">zmij 1.0.3</a></li>
                         <li><a href=" https://github.com/dbus2/zbus/ ">zvariant_utils 3.2.1</a></li>
                     </ul>
                 <pre class="license-text">Permission is hereby granted, free of charge, to any
@@ -16089,6 +16152,34 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
                 <h3 id="MIT">MIT License</h3>
                     <p>
                         Used by
+                            <a href=" https://github.com/mvdnes/spin-rs.git ">spin 0.9.8</a>
+                    </p>
+                <pre class="license-text">The MIT License (MIT)
+
+Copyright (c) 2014 Mathijs van de Nes
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the &quot;Software&quot;), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED &quot;AS IS&quot;, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.</pre>
+            </li>
+            <li class="license">
+                <h3 id="MIT">MIT License</h3>
+                    <p>
+                        Used by
                             <a href=" https://github.com/PistonDevelopers/freetype-sys.git ">freetype-sys 0.20.1</a>
                     </p>
                 <pre class="license-text">The MIT License (MIT)
@@ -16117,10 +16208,11 @@ SOFTWARE.
             </li>
             <li class="license">
                 <h3 id="MIT">MIT License</h3>
-                    <p>
-                        Used by
-                            <a href=" https://github.com/kornelski/xml-rs ">xml-rs 0.8.28</a>
-                    </p>
+                    <h4>Used by:</h4>
+                    <ul class="license-used-by">
+                        <li><a href=" https://github.com/kornelski/xml-rs ">xml-rs 0.8.28</a></li>
+                        <li><a href=" https://github.com/kornelski/xml-rs ">xml 1.2.0</a></li>
+                    </ul>
                 <pre class="license-text">The MIT License (MIT)
 
 Copyright (c) 2014 Vladimir Matveev
@@ -16184,7 +16276,7 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
                         <li><a href=" https://github.com/image-rs/byteorder-lite ">byteorder-lite 0.1.0</a></li>
                         <li><a href=" https://github.com/BurntSushi/byteorder ">byteorder 1.5.0</a></li>
                         <li><a href=" https://github.com/BurntSushi/fst ">fst 0.4.7</a></li>
-                        <li><a href=" https://github.com/BurntSushi/jiff ">jiff 0.2.16</a></li>
+                        <li><a href=" https://github.com/BurntSushi/jiff ">jiff 0.2.17</a></li>
                         <li><a href=" https://github.com/BurntSushi/memchr ">memchr 2.7.6</a></li>
                         <li><a href=" https://github.com/BurntSushi/quickcheck ">quickcheck 1.0.3</a></li>
                         <li><a href=" https://github.com/BurntSushi/walkdir ">walkdir 2.5.0</a></li>
@@ -16364,8 +16456,8 @@ SOFTWARE.
                 <h3 id="MIT">MIT License</h3>
                     <h4>Used by:</h4>
                     <ul class="license-used-by">
-                        <li><a href=" https://github.com/JelteF/derive_more ">derive_more-impl 2.0.1</a></li>
-                        <li><a href=" https://github.com/JelteF/derive_more ">derive_more 2.0.1</a></li>
+                        <li><a href=" https://github.com/JelteF/derive_more ">derive_more-impl 2.1.1</a></li>
+                        <li><a href=" https://github.com/JelteF/derive_more ">derive_more 2.1.1</a></li>
                     </ul>
                 <pre class="license-text">The MIT License (MIT)
 
@@ -18761,7 +18853,6 @@ Exhibit B - &quot;Incompatible With Secondary Licenses&quot; Notice
                         <li><a href=" https://crates.io/crates/servo-media-traits ">servo-media-traits 0.1.0</a></li>
                         <li><a href=" https://crates.io/crates/servo-media-webrtc ">servo-media-webrtc 0.1.0</a></li>
                         <li><a href=" https://crates.io/crates/servo-media ">servo-media 0.1.0</a></li>
-                        <li><a href=" https://github.com/servo/mozjs/ ">mozjs_sys 0.140.5-5</a></li>
                         <li><a href=" https://github.com/servo/stylo ">stylo 0.9.0</a></li>
                         <li><a href=" https://github.com/servo/stylo ">selectors 0.33.0</a></li>
                         <li><a href=" https://github.com/servo/stylo ">stylo_atoms 0.9.0</a></li>
@@ -18826,8 +18917,7 @@ Exhibit B - &quot;Incompatible With Secondary Licenses&quot; Notice
                         <li><a href=" https://crates.io/crates/webgpu ">webgpu 0.0.1</a></li>
                         <li><a href=" https://crates.io/crates/webxr ">webxr 0.0.1</a></li>
                         <li><a href=" https://crates.io/crates/xpath ">xpath 0.0.1</a></li>
-                        <li><a href=" https://crates.io/crates/servoshell ">servoshell 0.0.3</a></li>
-                        <li><a href=" https://crates.io/crates/task_info ">task_info 0.0.1</a></li>
+                        <li><a href=" https://crates.io/crates/servoshell ">servoshell 0.0.4</a></li>
                         <li><a href=" https://crates.io/crates/deny_public_fields_tests ">deny_public_fields_tests 0.0.1</a></li>
                         <li><a href=" https://crates.io/crates/malloc_size_of_tests ">malloc_size_of_tests 0.0.1</a></li>
                         <li><a href=" https://crates.io/crates/profile_tests ">profile_tests 0.0.1</a></li>
@@ -18835,6 +18925,7 @@ Exhibit B - &quot;Incompatible With Secondary Licenses&quot; Notice
                         <li><a href=" https://crates.io/crates/style_tests ">style_tests 0.0.1</a></li>
                         <li><a href=" https://github.com/servo/app_units ">app_units 0.7.8</a></li>
                         <li><a href=" https://github.com/servo/dwrote-rs ">dwrote 0.11.5</a></li>
+                        <li><a href=" https://github.com/servo/mozjs/ ">mozjs_sys 0.140.5-7</a></li>
                         <li><a href=" https://github.com/soc/option-ext.git ">option-ext 0.2.0</a></li>
                         <li><a href=" https://hg.mozilla.org/mozilla-central/file/tip/testing/webdriver ">webdriver 0.53.0</a></li>
                     </ul>
@@ -19217,7 +19308,7 @@ Exhibit B - &quot;Incompatible With Secondary Licenses&quot; Notice
                 <h3 id="MPL-2.0">Mozilla Public License 2.0</h3>
                     <p>
                         Used by
-                            <a href=" https://github.com/servo/mozjs/ ">mozjs 0.14.2</a>
+                            <a href=" https://github.com/servo/mozjs/ ">mozjs 0.14.4</a>
                     </p>
                 <pre class="license-text">Mozilla Public License Version 2.0
 &#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;
@@ -19622,7 +19713,7 @@ THE SOFTWARE IS PROVIDED &quot;AS IS&quot;, WITHOUT WARRANTY OF ANY KIND, EXPRES
                 <h3 id="OFL-1.1">SIL Open Font License 1.1</h3>
                     <p>
                         Used by
-                            <a href=" https://github.com/emilk/egui/tree/main/crates/epaint_default_fonts ">epaint_default_fonts 0.33.2</a>
+                            <a href=" https://github.com/emilk/egui/tree/main/crates/epaint_default_fonts ">epaint_default_fonts 0.33.3</a>
                     </p>
                 <pre class="license-text">This Font Software is licensed under the SIL Open Font License,
 Version 1.1.
@@ -19722,7 +19813,7 @@ OTHER DEALINGS IN THE FONT SOFTWARE.
                 <h3 id="OpenSSL">OpenSSL License</h3>
                     <p>
                         Used by
-                            <a href=" https://github.com/aws/aws-lc-rs ">aws-lc-sys 0.34.0</a>
+                            <a href=" https://github.com/aws/aws-lc-rs ">aws-lc-sys 0.35.0</a>
                     </p>
                 <pre class="license-text">/* Copyright (C) 1995-1998 Eric Young (eay@cryptsoft.com)
  * All rights reserved.
@@ -19896,7 +19987,7 @@ int SSL_add_dir_cert_subjects_to_stack(STACK_OF(X509_NAME) *stack,
                 <h3 id="Ubuntu-font-1.0">Ubuntu Font Licence v1.0</h3>
                     <p>
                         Used by
-                            <a href=" https://github.com/emilk/egui/tree/main/crates/epaint_default_fonts ">epaint_default_fonts 0.33.2</a>
+                            <a href=" https://github.com/emilk/egui/tree/main/crates/epaint_default_fonts ">epaint_default_fonts 0.33.3</a>
                     </p>
                 <pre class="license-text">-------------------------------
 UBUNTU FONT LICENCE Version 1.0
@@ -20125,7 +20216,7 @@ ICU 1.8.1 to ICU 57.1 © 1995-2016 International Business Machines Corporation a
                 <h3 id="Zlib">zlib License</h3>
                     <p>
                         Used by
-                            <a href=" https://github.com/orlp/slotmap ">slotmap 1.0.7</a>
+                            <a href=" https://github.com/orlp/slotmap ">slotmap 1.1.1</a>
                     </p>
                 <pre class="license-text">Copyright (c) 2021 Orson Peters &lt;orsonpeters@gmail.com&gt;
 

--- a/support/android/apk/servoapp/build.gradle.kts
+++ b/support/android/apk/servoapp/build.gradle.kts
@@ -17,7 +17,7 @@ android {
         minSdk = 30
         targetSdk = 33
         versionCode = generatedVersionCode
-        versionName = "0.0.4"
+        versionName = "0.1.0"
     }
 
     compileOptions {

--- a/support/android/apk/servoapp/build.gradle.kts
+++ b/support/android/apk/servoapp/build.gradle.kts
@@ -17,7 +17,7 @@ android {
         minSdk = 30
         targetSdk = 33
         versionCode = generatedVersionCode
-        versionName = "0.0.3"
+        versionName = "0.0.4"
     }
 
     compileOptions {

--- a/support/openharmony/entry/oh-package.json5
+++ b/support/openharmony/entry/oh-package.json5
@@ -5,7 +5,7 @@
   "name": "servoshell",
   "description": "Please describe the basic information.",
   "main": "",
-  "version": "0.0.4",
+  "version": "0.1.0",
   "dependencies": {
     "libservoshell.so": "file:./src/main/cpp/types/libentry"
   }

--- a/support/openharmony/entry/oh-package.json5
+++ b/support/openharmony/entry/oh-package.json5
@@ -5,7 +5,7 @@
   "name": "servoshell",
   "description": "Please describe the basic information.",
   "main": "",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "dependencies": {
     "libservoshell.so": "file:./src/main/cpp/types/libentry"
   }

--- a/support/openharmony/oh-package.json5
+++ b/support/openharmony/oh-package.json5
@@ -8,6 +8,6 @@
   "name": "servoshell",
   "description": "Servo browser shell",
   "main": "",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "dependencies": {}
 }

--- a/support/openharmony/oh-package.json5
+++ b/support/openharmony/oh-package.json5
@@ -8,6 +8,6 @@
   "name": "servoshell",
   "description": "Servo browser shell",
   "main": "",
-  "version": "0.0.4",
+  "version": "0.1.0",
   "dependencies": {}
 }

--- a/support/windows/Servo.wxs.mako
+++ b/support/windows/Servo.wxs.mako
@@ -6,7 +6,7 @@
            UpgradeCode="060cd15d-eab1-4614-b438-3988e3efdcf1"
            Language="1033"
            Codepage="1252"
-           Version="0.0.3">
+           Version="0.0.4">
     <Package Id="*"
              Keywords="Installer"
              Description="Servo Tech Demo Installer"

--- a/support/windows/Servo.wxs.mako
+++ b/support/windows/Servo.wxs.mako
@@ -6,7 +6,7 @@
            UpgradeCode="060cd15d-eab1-4614-b438-3988e3efdcf1"
            Language="1033"
            Codepage="1252"
-           Version="0.0.4">
+           Version="0.1.0">
     <Package Id="*"
              Keywords="Installer"
              Description="Servo Tech Demo Installer"


### PR DESCRIPTION
Alternative to https://github.com/servo/servo/pull/41589. 

Testing: Not required