### PR TITLE
tests: Enable css-font-loading tests.

### DIFF
--- a/tests/wpt/include.ini
+++ b/tests/wpt/include.ini
@@ -55,8 +55,6 @@ skip: true
     skip: true
   [css-fill-stroke]
     skip: true
-  [css-font-loading]
-    skip: true
   [css-forced-color-adjust]
     skip: true
   [css-gcpm]

--- a/tests/wpt/meta/css/css-font-loading/font-face-reject.html.ini
+++ b/tests/wpt/meta/css/css-font-loading/font-face-reject.html.ini
@@ -1,0 +1,4 @@
+[font-face-reject.html]
+  expected: TIMEOUT
+  [font-face-reject]
+    expected: TIMEOUT

--- a/tests/wpt/meta/css/css-font-loading/fontface-descriptor-updates.html.ini
+++ b/tests/wpt/meta/css/css-font-loading/fontface-descriptor-updates.html.ini
@@ -1,0 +1,2 @@
+[fontface-descriptor-updates.html]
+  expected: FAIL

--- a/tests/wpt/meta/css/css-font-loading/fontface-fonts-loading.html.ini
+++ b/tests/wpt/meta/css/css-font-loading/fontface-fonts-loading.html.ini
@@ -1,0 +1,3 @@
+[fontface-fonts-loading.html]
+  [document.fonts.ready is replaced as new fonts are loaded]
+    expected: FAIL

--- a/tests/wpt/meta/css/css-font-loading/fontface-invalid-family.tentative.html.ini
+++ b/tests/wpt/meta/css/css-font-loading/fontface-invalid-family.tentative.html.ini
@@ -1,0 +1,19 @@
+[fontface-invalid-family.tentative.html]
+  expected: ERROR
+  [family: content:Segoe UI]
+    expected: FAIL
+
+  [family: sans-serif]
+    expected: FAIL
+
+  [family: A, B]
+    expected: FAIL
+
+  [family: inherit]
+    expected: FAIL
+
+  [family: a 1]
+    expected: FAIL
+
+  [family: ]
+    expected: FAIL

--- a/tests/wpt/meta/css/css-font-loading/fontface-loadingevent.html.ini
+++ b/tests/wpt/meta/css/css-font-loading/fontface-loadingevent.html.ini
@@ -1,0 +1,3 @@
+[fontface-loadingevent.html]
+  [FontFaceSet fires correct loading event]
+    expected: FAIL

--- a/tests/wpt/meta/css/css-font-loading/fontface-override-descriptors.html.ini
+++ b/tests/wpt/meta/css/css-font-loading/fontface-override-descriptors.html.ini
@@ -1,0 +1,2 @@
+[fontface-override-descriptors.html]
+  expected: FAIL

--- a/tests/wpt/meta/css/css-font-loading/fontface-size-adjust-descriptor.html.ini
+++ b/tests/wpt/meta/css/css-font-loading/fontface-size-adjust-descriptor.html.ini
@@ -1,0 +1,2 @@
+[fontface-size-adjust-descriptor.html]
+  expected: FAIL

--- a/tests/wpt/meta/css/css-font-loading/fontfaceset-add-css-connected.html.ini
+++ b/tests/wpt/meta/css/css-font-loading/fontfaceset-add-css-connected.html.ini
@@ -1,0 +1,3 @@
+[fontfaceset-add-css-connected.html]
+  [fontfaceset-add-css-connected]
+    expected: FAIL

--- a/tests/wpt/meta/css/css-font-loading/fontfaceset-clear-css-connected.html.ini
+++ b/tests/wpt/meta/css/css-font-loading/fontfaceset-clear-css-connected.html.ini
@@ -1,0 +1,3 @@
+[fontfaceset-clear-css-connected.html]
+  [fontfaceset-clear-css-connected]
+    expected: FAIL

--- a/tests/wpt/meta/css/css-font-loading/fontfaceset-delete-css-connected.html.ini
+++ b/tests/wpt/meta/css/css-font-loading/fontfaceset-delete-css-connected.html.ini
@@ -1,0 +1,3 @@
+[fontfaceset-delete-css-connected.html]
+  [fontfaceset-delete-css-connected]
+    expected: FAIL

--- a/tests/wpt/meta/css/css-font-loading/fontfaceset-has.html.ini
+++ b/tests/wpt/meta/css/css-font-loading/fontfaceset-has.html.ini
@@ -1,0 +1,3 @@
+[fontfaceset-has.html]
+  [fontfaceset-has]
+    expected: FAIL

--- a/tests/wpt/meta/css/css-font-loading/fontfaceset-load-css-wide-keywords.html.ini
+++ b/tests/wpt/meta/css/css-font-loading/fontfaceset-load-css-wide-keywords.html.ini
@@ -1,0 +1,73 @@
+[fontfaceset-load-css-wide-keywords.html]
+  expected: ERROR
+  [Loading CSS-wide keyword "initial" causes SyntaxError (document)]
+    expected: FAIL
+
+  [Loading CSS-wide keyword "initial" causes SyntaxError (worker)]
+    expected: TIMEOUT
+
+  [Loading CSS-wide keyword "inherit" causes SyntaxError (document)]
+    expected: NOTRUN
+
+  [Loading CSS-wide keyword "inherit" causes SyntaxError (worker)]
+    expected: NOTRUN
+
+  [Loading CSS-wide keyword "unset" causes SyntaxError (document)]
+    expected: NOTRUN
+
+  [Loading CSS-wide keyword "unset" causes SyntaxError (worker)]
+    expected: NOTRUN
+
+  [Loading CSS-wide keyword "default" causes SyntaxError (document)]
+    expected: NOTRUN
+
+  [Loading CSS-wide keyword "default" causes SyntaxError (worker)]
+    expected: NOTRUN
+
+  [Loading CSS-wide keyword "revert" causes SyntaxError (document)]
+    expected: NOTRUN
+
+  [Loading CSS-wide keyword "revert" causes SyntaxError (worker)]
+    expected: NOTRUN
+
+  [Loading CSS-wide keyword "revert-layer" causes SyntaxError (document)]
+    expected: NOTRUN
+
+  [Loading CSS-wide keyword "revert-layer" causes SyntaxError (worker)]
+    expected: NOTRUN
+
+  [Loading value with CSS-wide keyword "initial" causes SyntaxError (document)]
+    expected: NOTRUN
+
+  [Loading value with CSS-wide keyword "initial" causes SyntaxError (worker)]
+    expected: NOTRUN
+
+  [Loading value with CSS-wide keyword "inherit" causes SyntaxError (document)]
+    expected: NOTRUN
+
+  [Loading value with CSS-wide keyword "inherit" causes SyntaxError (worker)]
+    expected: NOTRUN
+
+  [Loading value with CSS-wide keyword "unset" causes SyntaxError (document)]
+    expected: NOTRUN
+
+  [Loading value with CSS-wide keyword "unset" causes SyntaxError (worker)]
+    expected: NOTRUN
+
+  [Loading value with CSS-wide keyword "default" causes SyntaxError (document)]
+    expected: NOTRUN
+
+  [Loading value with CSS-wide keyword "default" causes SyntaxError (worker)]
+    expected: NOTRUN
+
+  [Loading value with CSS-wide keyword "revert" causes SyntaxError (document)]
+    expected: NOTRUN
+
+  [Loading value with CSS-wide keyword "revert" causes SyntaxError (worker)]
+    expected: NOTRUN
+
+  [Loading value with CSS-wide keyword "revert-layer" causes SyntaxError (document)]
+    expected: NOTRUN
+
+  [Loading value with CSS-wide keyword "revert-layer" causes SyntaxError (worker)]
+    expected: NOTRUN

--- a/tests/wpt/meta/css/css-font-loading/fontfaceset-load-var.html.ini
+++ b/tests/wpt/meta/css/css-font-loading/fontfaceset-load-var.html.ini
@@ -1,0 +1,13 @@
+[fontfaceset-load-var.html]
+  expected: ERROR
+  [Loading "var(--x) serif" causes SyntaxError (document)]
+    expected: FAIL
+
+  [Loading "var(--x, 10px) serif" causes SyntaxError (document)]
+    expected: FAIL
+
+  [Loading "var(--x) serif" causes SyntaxError (worker)]
+    expected: TIMEOUT
+
+  [Loading "var(--x, 10px) serif" causes SyntaxError (worker)]
+    expected: NOTRUN

--- a/tests/wpt/meta/css/css-font-loading/fontfaceset-update-after-stylesheet-change.html.ini
+++ b/tests/wpt/meta/css/css-font-loading/fontfaceset-update-after-stylesheet-change.html.ini
@@ -1,0 +1,3 @@
+[fontfaceset-update-after-stylesheet-change.html]
+  [fontfaceset-update-after-stylesheet-change]
+    expected: FAIL

--- a/tests/wpt/meta/css/css-font-loading/fontfacesetloadevent-constructor.html.ini
+++ b/tests/wpt/meta/css/css-font-loading/fontfacesetloadevent-constructor.html.ini
@@ -1,0 +1,7 @@
+[fontfacesetloadevent-constructor.html]
+  expected: ERROR
+  [FontFaceSetLoadEvent constructor without FontFaceSetLoadEventInit dictionary]
+    expected: FAIL
+
+  [FontFaceSetLoadEvent constructor with FontFaceSetLoadEventInit dictionary]
+    expected: FAIL

--- a/tests/wpt/meta/css/css-font-loading/idlharness.https.html.ini
+++ b/tests/wpt/meta/css/css-font-loading/idlharness.https.html.ini
@@ -1,0 +1,228 @@
+[idlharness.https.html]
+  [idl_test setup]
+    expected: FAIL
+
+  [FontFace interface: attribute features]
+    expected: FAIL
+
+  [FontFace interface: attribute variations]
+    expected: FAIL
+
+  [FontFace interface: attribute palettes]
+    expected: FAIL
+
+  [FontFace interface: fontFace must inherit property "features" with the proper type]
+    expected: FAIL
+
+  [FontFace interface: fontFace must inherit property "variations" with the proper type]
+    expected: FAIL
+
+  [FontFace interface: fontFace must inherit property "palettes" with the proper type]
+    expected: FAIL
+
+  [FontFaceFeatures interface: existence and properties of interface object]
+    expected: FAIL
+
+  [FontFaceFeatures interface object length]
+    expected: FAIL
+
+  [FontFaceFeatures interface object name]
+    expected: FAIL
+
+  [FontFaceFeatures interface: existence and properties of interface prototype object]
+    expected: FAIL
+
+  [FontFaceFeatures interface: existence and properties of interface prototype object's "constructor" property]
+    expected: FAIL
+
+  [FontFaceFeatures interface: existence and properties of interface prototype object's @@unscopables property]
+    expected: FAIL
+
+  [FontFaceVariationAxis interface: existence and properties of interface object]
+    expected: FAIL
+
+  [FontFaceVariationAxis interface object length]
+    expected: FAIL
+
+  [FontFaceVariationAxis interface object name]
+    expected: FAIL
+
+  [FontFaceVariationAxis interface: existence and properties of interface prototype object]
+    expected: FAIL
+
+  [FontFaceVariationAxis interface: existence and properties of interface prototype object's "constructor" property]
+    expected: FAIL
+
+  [FontFaceVariationAxis interface: existence and properties of interface prototype object's @@unscopables property]
+    expected: FAIL
+
+  [FontFaceVariationAxis interface: attribute name]
+    expected: FAIL
+
+  [FontFaceVariationAxis interface: attribute axisTag]
+    expected: FAIL
+
+  [FontFaceVariationAxis interface: attribute minimumValue]
+    expected: FAIL
+
+  [FontFaceVariationAxis interface: attribute maximumValue]
+    expected: FAIL
+
+  [FontFaceVariationAxis interface: attribute defaultValue]
+    expected: FAIL
+
+  [FontFaceVariations interface: existence and properties of interface object]
+    expected: FAIL
+
+  [FontFaceVariations interface object length]
+    expected: FAIL
+
+  [FontFaceVariations interface object name]
+    expected: FAIL
+
+  [FontFaceVariations interface: existence and properties of interface prototype object]
+    expected: FAIL
+
+  [FontFaceVariations interface: existence and properties of interface prototype object's "constructor" property]
+    expected: FAIL
+
+  [FontFaceVariations interface: existence and properties of interface prototype object's @@unscopables property]
+    expected: FAIL
+
+  [FontFaceVariations interface: setlike<FontFaceVariationAxis>]
+    expected: FAIL
+
+  [FontFacePalette interface: existence and properties of interface object]
+    expected: FAIL
+
+  [FontFacePalette interface object length]
+    expected: FAIL
+
+  [FontFacePalette interface object name]
+    expected: FAIL
+
+  [FontFacePalette interface: existence and properties of interface prototype object]
+    expected: FAIL
+
+  [FontFacePalette interface: existence and properties of interface prototype object's "constructor" property]
+    expected: FAIL
+
+  [FontFacePalette interface: existence and properties of interface prototype object's @@unscopables property]
+    expected: FAIL
+
+  [FontFacePalette interface: iterable<DOMString>]
+    expected: FAIL
+
+  [FontFacePalette interface: attribute length]
+    expected: FAIL
+
+  [FontFacePalette interface: attribute usableWithLightBackground]
+    expected: FAIL
+
+  [FontFacePalette interface: attribute usableWithDarkBackground]
+    expected: FAIL
+
+  [FontFacePalettes interface: existence and properties of interface object]
+    expected: FAIL
+
+  [FontFacePalettes interface object length]
+    expected: FAIL
+
+  [FontFacePalettes interface object name]
+    expected: FAIL
+
+  [FontFacePalettes interface: existence and properties of interface prototype object]
+    expected: FAIL
+
+  [FontFacePalettes interface: existence and properties of interface prototype object's "constructor" property]
+    expected: FAIL
+
+  [FontFacePalettes interface: existence and properties of interface prototype object's @@unscopables property]
+    expected: FAIL
+
+  [FontFacePalettes interface: iterable<FontFacePalette>]
+    expected: FAIL
+
+  [FontFacePalettes interface: attribute length]
+    expected: FAIL
+
+  [FontFaceSetLoadEvent interface: existence and properties of interface object]
+    expected: FAIL
+
+  [FontFaceSetLoadEvent interface object length]
+    expected: FAIL
+
+  [FontFaceSetLoadEvent interface object name]
+    expected: FAIL
+
+  [FontFaceSetLoadEvent interface: existence and properties of interface prototype object]
+    expected: FAIL
+
+  [FontFaceSetLoadEvent interface: existence and properties of interface prototype object's "constructor" property]
+    expected: FAIL
+
+  [FontFaceSetLoadEvent interface: existence and properties of interface prototype object's @@unscopables property]
+    expected: FAIL
+
+  [FontFaceSetLoadEvent interface: attribute fontfaces]
+    expected: FAIL
+
+  [FontFaceSetLoadEvent must be primary interface of fontFaceSetLoadEvent]
+    expected: FAIL
+
+  [Stringification of fontFaceSetLoadEvent]
+    expected: FAIL
+
+  [FontFaceSetLoadEvent interface: fontFaceSetLoadEvent must inherit property "fontfaces" with the proper type]
+    expected: FAIL
+
+  [FontFaceSet interface: setlike<FontFace>]
+    expected: FAIL
+
+  [FontFaceSet interface: operation delete(FontFace)]
+    expected: FAIL
+
+  [FontFaceSet interface: operation clear()]
+    expected: FAIL
+
+  [FontFaceSet interface: attribute onloading]
+    expected: FAIL
+
+  [FontFaceSet interface: attribute onloadingdone]
+    expected: FAIL
+
+  [FontFaceSet interface: attribute onloadingerror]
+    expected: FAIL
+
+  [FontFaceSet interface: operation check(CSSOMString, optional CSSOMString)]
+    expected: FAIL
+
+  [FontFaceSet interface: attribute status]
+    expected: FAIL
+
+  [FontFaceSet interface: document.fonts must inherit property "delete(FontFace)" with the proper type]
+    expected: FAIL
+
+  [FontFaceSet interface: calling delete(FontFace) on document.fonts with too few arguments must throw TypeError]
+    expected: FAIL
+
+  [FontFaceSet interface: document.fonts must inherit property "clear()" with the proper type]
+    expected: FAIL
+
+  [FontFaceSet interface: document.fonts must inherit property "onloading" with the proper type]
+    expected: FAIL
+
+  [FontFaceSet interface: document.fonts must inherit property "onloadingdone" with the proper type]
+    expected: FAIL
+
+  [FontFaceSet interface: document.fonts must inherit property "onloadingerror" with the proper type]
+    expected: FAIL
+
+  [FontFaceSet interface: document.fonts must inherit property "check(CSSOMString, optional CSSOMString)" with the proper type]
+    expected: FAIL
+
+  [FontFaceSet interface: calling check(CSSOMString, optional CSSOMString) on document.fonts with too few arguments must throw TypeError]
+    expected: FAIL
+
+  [FontFaceSet interface: document.fonts must inherit property "status" with the proper type]
+    expected: FAIL

--- a/tests/wpt/meta/css/css-font-loading/nonexistent-file-url.html.ini
+++ b/tests/wpt/meta/css/css-font-loading/nonexistent-file-url.html.ini
@@ -1,0 +1,3 @@
+[nonexistent-file-url.html]
+  [nonexistent-file-url]
+    expected: FAIL


### PR DESCRIPTION
We have a partial implementation of FontFace and FontFaceSet, so we should run the tests associated with them.

Testing: New tests enabled.