### PR TITLE
ohos CI: Skip failure screenshots on success.

### DIFF
--- a/.github/workflows/ohos.yml
+++ b/.github/workflows/ohos.yml
@@ -424,7 +424,7 @@ jobs:
         if: ${{ steps.install_hap.outcome == 'success' && ! cancelled() }}
         run: uv run ./etc/ci/scenario/servo_test_slide.py
       - name: Upload failure screenshots
-        if: ${{ steps.install_hap.outcome == 'success' && ! cancelled() }}
+        if: ${{ steps.install_hap.outcome == 'success' && failure() }}
         uses: actions/upload-artifact@v5
         with:
           path: "servo_scenario_*_error.jpg"


### PR DESCRIPTION
Prevents a warning message in CI, that there are no artifacts to upload, if no jobs failed.

Testing: Not tested, should be trivial.
