### PR TITLE
Draft: ohos CI: pass through results of optional jobs to try-label resut

### DIFF
--- a/.github/workflows/dispatch-workflow.yml
+++ b/.github/workflows/dispatch-workflow.yml
@@ -32,6 +32,10 @@ on:
       coverage:
         required: true
         type: boolean
+    outputs:
+      ohos_optional_job_status:
+        description: "The status of the optional jobs in the ohos workflow"
+        value: ${{ jobs.ohos.outputs.optional_job_status }}
 
 jobs:
   win:
@@ -113,3 +117,14 @@ jobs:
     with:
       profile: ${{ inputs.profile }}
       bencher: ${{ inputs.bencher }}
+
+#  collect_optional_job_status:
+#    # Currently only the ohos workflow has optional jobs, where we want to report failure.
+#    # We actually just want to pass the results up to the caller workflow, but we need a dummy job to do that,
+#    # since reusable workflows can't re-export outputs.
+#    if: ${{ inputs.workflow == 'ohos' }}
+#    name: Collect optional job results
+#    needs: [ohos]
+#    runs-on: ubuntu-latest
+#    steps:
+#      -

--- a/.github/workflows/ohos.yml
+++ b/.github/workflows/ohos.yml
@@ -17,7 +17,10 @@ on:
         required: false
         default: false
         type: boolean
-
+    outputs:
+      optional_job_status:
+        description: "Status of optional jobs (as an object)"
+        value: ${{ jobs.collect-job-results.outputs.collected_job_status }}
   workflow_dispatch:
     inputs:
       profile:
@@ -194,6 +197,8 @@ jobs:
     runs-on: hos-runner
     if: github.repository == 'servo/servo' && needs.build-harmonyos-aarch64.outputs.job_status == 'success'
     needs: build-harmonyos-aarch64
+    outputs:
+      job_status: ${{ steps.result.outputs.JOB_STATUS }}
     steps:
       - uses: actions/download-artifact@v4
         with:
@@ -248,6 +253,10 @@ jobs:
           [[ $servo_pid =~ ^[0-9]+$ ]] || { echo "It looks like servo crashed!" ; exit 1; }
           # If the grep fails, then the trace output for the "page loaded" prompt is missing
           grep 'tracing_mark_write.*PageLoadEndedPrompt' test_output/servo.ftrace
+      - name: Save result as job output
+        id: result
+        if: always()
+        run: echo "JOB_STATUS=${{ job.status }}" | tee $GITHUB_OUTPUT
 
   bench-harmonyos-aarch64:
     name: Benching HarmonyOS aarch64
@@ -257,6 +266,8 @@ jobs:
     continue-on-error: true
     runs-on: hos-runner
     needs: test-harmonyos-aarch64
+    outputs:
+      job_status: ${{ steps.result.outputs.JOB_STATUS }}
     if: github.repository == 'servo/servo' && needs.build-harmonyos-aarch64.outputs.job_status == 'success'
     steps:
       - uses: actions/download-artifact@v4
@@ -376,6 +387,10 @@ jobs:
                       --github-actions '${{ secrets.GITHUB_TOKEN }}' \
                       --testbed="${{steps.hdc_product_name.outputs.MODEL_NAME}}" \
                       $RUN_BENCHER_OPTIONS
+      - name: Save result as job output
+        id: result
+        if: always()
+        run: echo "JOB_STATUS=${{ job.status }}" | tee $GITHUB_OUTPUT
 
 
   scenario-test-harmonyos:
@@ -384,6 +399,8 @@ jobs:
     runs-on: hos-runner
     if: github.repository == 'servo/servo' && needs.build-harmonyos-aarch64.outputs.job_status == 'success'
     needs: build-harmonyos-aarch64
+    outputs:
+      job_status: ${{ steps.result.outputs.JOB_STATUS }}
     env:
       # This will ensure the scenario pyproject.toml is picked up and the correct venv used.
       UV_PROJECT: "etc/ci/scenario"
@@ -428,3 +445,26 @@ jobs:
         uses: actions/upload-artifact@v5
         with:
           path: "servo_scenario_*_error.jpg"
+      - name: Save result as job output
+        id: result
+        if: always()
+        run: echo "JOB_STATUS=${{ job.status }}" | tee $GITHUB_OUTPUT
+
+  # This job is used to collect the result (success/failure) of all jobs in the workflow that use
+  # `continue-on-error: true`. This allows us to pass throw information about failed "optional" jobs,
+  # to the try-label parser, so it can include the information in the try-label comment.
+  collect-job-results:
+    name: Collect Job Results
+    runs-on: ubuntu-latest
+    needs: [bench-harmonyos-aarch64, test-harmonyos-aarch64, scenario-test-harmonyos]
+    outputs:
+      collected_job_status: ${{ steps.result.outputs.JOB_RESULTS_JSON }}
+    steps:
+      - name: Save result as job output
+        id: result
+        run: |
+          JSON_FMT='{"bench-harmonyos-aarch64-result":%s,"test-harmonyos-aarch64":%s,"scenario-test-harmonyos":%s}'
+          printf "JOB_RESULTS_JSON=$JSON_FMT" "${{ needs.bench-harmonyos-aarch64.outputs.job_status }}" \
+                  "${{ needs.test-harmonyos-aarch64.outputs.job_status }}" \
+                  "${{ needs.scenario-test-harmonyos.outputs.job_status }}" \
+            >> $GITHUB_OUTPUT

--- a/.github/workflows/ohos.yml
+++ b/.github/workflows/ohos.yml
@@ -424,7 +424,7 @@ jobs:
         if: ${{ steps.install_hap.outcome == 'success' && ! cancelled() }}
         run: uv run ./etc/ci/scenario/servo_test_slide.py
       - name: Upload failure screenshots
-        if: ${{ steps.install_hap.outcome == 'success' && ! cancelled() }}
+        if: ${{ steps.install_hap.outcome == 'success' && failure() }}
         uses: actions/upload-artifact@v5
         with:
           path: "servo_scenario_*_error.jpg"

--- a/.github/workflows/try-label.yml
+++ b/.github/workflows/try-label.yml
@@ -139,6 +139,10 @@ jobs:
     runs-on: ubuntu-latest
     if: ${{ always() && needs.parse-comment.outputs.try_string }}
     steps:
+      - name: Optional results
+        run: |
+          echo "ohos try status: ${{ needs.run-try.outputs.ohos_optional_job_status }}"
+          ${{ contains(needs.run-try.outputs.ohos_optional_job_status.*, 'failure') && 'echo "::error optional jobs failed."' }}
       - name: Success
         if: ${{ !contains(needs.*.result, 'failure') && !contains(needs.*.result, 'cancelled') }}
         uses: actions/github-script@v7


### PR DESCRIPTION
This allows the try result comment to notify the user if jobs, which don't block the MQ failed when running try-label jobs. 

Testing: Pending ...
Fixes: https://github.com/servo/servo/issues/40589