### PR TITLE
ohos CI: pass through results of optional jobs to try-label result

### DIFF
--- a/.github/workflows/dispatch-workflow.yml
+++ b/.github/workflows/dispatch-workflow.yml
@@ -32,6 +32,10 @@ on:
       coverage:
         required: true
         type: boolean
+    outputs:
+      ohos_optional_job_status:
+        description: "The status of the optional jobs in the ohos workflow"
+        value: ${{ jobs.ohos.outputs.optional_job_status }}
 
 jobs:
   win:

--- a/.github/workflows/ohos.yml
+++ b/.github/workflows/ohos.yml
@@ -17,7 +17,10 @@ on:
         required: false
         default: false
         type: boolean
-
+    outputs:
+      optional_job_status:
+        description: "Status of optional jobs (as an object)"
+        value: ${{ jobs.collect-job-results.outputs.collected_job_status }}
   workflow_dispatch:
     inputs:
       profile:
@@ -194,6 +197,8 @@ jobs:
     runs-on: hos-runner
     if: github.repository == 'servo/servo' && needs.build-harmonyos-aarch64.outputs.job_status == 'success'
     needs: build-harmonyos-aarch64
+    outputs:
+      job_status: ${{ steps.result.outputs.JOB_STATUS }}
     steps:
       - uses: actions/download-artifact@v4
         with:
@@ -248,6 +253,10 @@ jobs:
           [[ $servo_pid =~ ^[0-9]+$ ]] || { echo "It looks like servo crashed!" ; exit 1; }
           # If the grep fails, then the trace output for the "page loaded" prompt is missing
           grep 'tracing_mark_write.*PageLoadEndedPrompt' test_output/servo.ftrace
+      - name: Save result as job output
+        id: result
+        if: always()
+        run: echo "JOB_STATUS=${{ job.status }}" | tee $GITHUB_OUTPUT
 
   bench-harmonyos-aarch64:
     name: Benching HarmonyOS aarch64
@@ -257,6 +266,8 @@ jobs:
     continue-on-error: true
     runs-on: hos-runner
     needs: test-harmonyos-aarch64
+    outputs:
+      job_status: ${{ steps.result.outputs.JOB_STATUS }}
     if: github.repository == 'servo/servo' && needs.build-harmonyos-aarch64.outputs.job_status == 'success'
     steps:
       - uses: actions/download-artifact@v4
@@ -376,6 +387,10 @@ jobs:
                       --github-actions '${{ secrets.GITHUB_TOKEN }}' \
                       --testbed="${{steps.hdc_product_name.outputs.MODEL_NAME}}" \
                       $RUN_BENCHER_OPTIONS
+      - name: Save result as job output
+        id: result
+        if: always()
+        run: echo "JOB_STATUS=${{ job.status }}" | tee $GITHUB_OUTPUT
 
 
   scenario-test-harmonyos:
@@ -384,6 +399,8 @@ jobs:
     runs-on: hos-runner
     if: github.repository == 'servo/servo' && needs.build-harmonyos-aarch64.outputs.job_status == 'success'
     needs: build-harmonyos-aarch64
+    outputs:
+      job_status: ${{ steps.result.outputs.JOB_STATUS }}
     env:
       # This will ensure the scenario pyproject.toml is picked up and the correct venv used.
       UV_PROJECT: "etc/ci/scenario"
@@ -429,3 +446,28 @@ jobs:
         with:
           name: hos-${{ inputs.profile }}-scenario-failures-screenshots
           path: "servo_scenario_*_error.jpg"
+      - name: Save result as job output
+        id: result
+        if: always()
+        run: echo "JOB_STATUS=${{ job.status }}" | tee $GITHUB_OUTPUT
+
+  # This job is used to collect the result (success/failure) of all jobs in the workflow that use
+  # `continue-on-error: true`. This allows us to pass throw information about failed "optional" jobs,
+  # to the try-label parser, so it can include the information in the try-label comment.
+  collect-job-results:
+    name: Collect Job Results
+    runs-on: ubuntu-latest
+    needs: [build-harmonyos-aarch64, bench-harmonyos-aarch64, test-harmonyos-aarch64, scenario-test-harmonyos]
+    outputs:
+      collected_job_status: ${{ steps.result.outputs.JOB_RESULTS_JSON }}
+    steps:
+      - name: Save result as job output
+        id: result
+        run: |
+          JSON_FMT='{"build-harmonyos-aarch64":{"result":"%s"},"bench-harmonyos-aarch64":{"result":"%s"},"test-harmonyos-aarch64":{"result":"%s"},"scenario-test-harmonyos":{"result":"%s"}}'
+          printf "JOB_RESULTS_JSON=$JSON_FMT" \
+                  "${{ needs.build-harmonyos-aarch64.outputs.job_status }}" \
+                  "${{ needs.bench-harmonyos-aarch64.outputs.job_status }}" \
+                  "${{ needs.test-harmonyos-aarch64.outputs.job_status }}" \
+                  "${{ needs.scenario-test-harmonyos.outputs.job_status }}" \
+            >> $GITHUB_OUTPUT

--- a/.github/workflows/try-label.yml
+++ b/.github/workflows/try-label.yml
@@ -139,37 +139,29 @@ jobs:
     runs-on: ubuntu-latest
     if: ${{ always() && needs.parse-comment.outputs.try_string }}
     steps:
-      - name: Success
-        if: ${{ !contains(needs.*.result, 'failure') && !contains(needs.*.result, 'cancelled') }}
-        uses: actions/github-script@v7
-        with:
-          script: |
-              const url = context.serverUrl +
-                "/" + context.repo.owner +
-                "/" + context.repo.repo +
-                "/actions/runs/" + context.runId;
-              const formattedURL = "[#" + context.runId + "](" + url + ")";
-              github.rest.issues.createComment({
-                issue_number: context.issue.number,
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                body: "✨ Try run (" + formattedURL + ") " + "succeeded.",
-              });
-      - name: Failure
-        if: ${{ contains(needs.*.result, 'failure') }}
-        uses: actions/github-script@v7
-        with:
-          script: |
-              const url = context.serverUrl +
-                "/" + context.repo.owner +
-                "/" + context.repo.repo +
-                "/actions/runs/" + context.runId;
-              const formattedURL = "[#" + context.runId + "](" + url + ")";
-              github.rest.issues.createComment({
-                issue_number: context.issue.number,
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                body: "⚠️ Try run (" + formattedURL + ") " + "failed.",
-              });
-
-
+      - name: Post PR Comment with results
+        env:
+          PR_NUMBER: ${{ github.event.number }}
+          ACTIONS_RUN_URL: "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          REQUIRED_MQ_JOBS_SUCCEEDED=${{ !contains(needs.*.result, 'failure') && !contains(needs.*.result, 'cancelled') }}
+          # Using `contains()` on the output object doesn't seem to work, so we convert to JSON and use
+          # jq at runtime to check the fields of the optional jobs.
+          OPTIONAL_JOB_STATUS_JSON="${{toJSON(needs.run-try.outputs.ohos_optional_job_status)}}"
+          OPTIONAL_JOBS_SUCCEEDED=$(echo "${OPTIONAL_JOB_STATUS_JSON}" | jq 'all(.[].result == "success"; .)')
+          # The variables expand to `true` or `false`, which can be directly run to evaluate the condition.
+          if ${REQUIRED_MQ_JOBS_SUCCEEDED} && ${OPTIONAL_JOBS_SUCCEEDED} ; then
+            RESULT_EMOJI="✨"
+            TRY_RESULT="succeeded."
+          elif ${REQUIRED_MQ_JOBS_SUCCEEDED} ; then
+            RESULT_EMOJI="⚠️"
+            TRY_RESULT="succeeded with failures of jobs that don't block the Merge Queue. Please check the workflow run for details."
+          elif ${{ contains(needs.*.result, 'failure') }} ; then
+            RESULT_EMOJI="⚠️"
+            TRY_RESULT="failed!"
+          else
+            RESULT_EMOJI="⚠️"
+            TRY_RESULT="cancelled."
+          fi  
+          gh pr comment ${PR_NUMBER} --repo ${{ github.repository }} --body "${RESULT_EMOJI} Try run ([#${{ github.run_id }}](${ACTIONS_RUN_URL})) ${TRY_RESULT}"


### PR DESCRIPTION
This allows the try result comment to notify the user if jobs, which don't block the MQ failed when running try-label jobs.

Testing: Tested by adding two `DROP ME` commits, which change the trigger from pull_request_target to `push`, which allows us to test the workflow, while retaining access to self-hosted runners and PR comment permissions. These commits will be removed before merging, and should be ignored during review.
See https://github.com/servo/servo/pull/41601#issuecomment-3703918698 for a comment created with an optional job failing (by patching the job to fail). 
Fixes: https://github.com/servo/servo/issues/40589