### PR TITLE
Prevent crashes from looking for newly registered actors

### DIFF
--- a/components/devtools/actors/inspector/page_style.rs
+++ b/components/devtools/actors/inspector/page_style.rs
@@ -193,10 +193,9 @@ impl PageStyleActor {
                             e.insert(name);
                             rule
                         },
-                        Entry::Occupied(e) => {
-                            let actor = registry.find::<StyleRuleActor>(e.get());
-                            actor.applied(registry)?
-                        },
+                        Entry::Occupied(e) => registry
+                            .apply(e.get(), |actor: &StyleRuleActor| actor.applied(registry))
+                            .expect("The name should match an actor")?,
                     };
                     if inherited.is_some() && rule.declarations.is_empty() {
                         return None;


### PR DESCRIPTION
Add methods to `ActorRegistry`:

- `try_find`: Searches an actor by name like `find`, but it doesn't panic, it returns an `Option` instead. _(For the future, would it be a good idea to prefer using a non panicking API like this?)_
- `apply`: Searches an actor by name, both in the `actors` and `new_actors` maps (the latter as a fallback). Then, it applies a function to it.

We can't easily make `find/try_find` search the `new_actors` map since we have to borrow it inside of the function, and we can't return a reference to the local variable. That's why I thought of having an `apply` where everything happens inside so there aren't lifetime issues.

Change `PageStyleActor` to use `apply` and prevent a panic then there was more than one rule.

Change the `T: Any` in `find/find_mut` to `T: Actor` since it seems more appropriate.

Testing: Manual testing with the case provided in #36228
Fixes: #36228
