### PR TITLE
dom: dirty the input element when the filepicker returns selection

### DIFF
--- a/components/script/dom/html/htmlinputelement.rs
+++ b/components/script/dom/html/htmlinputelement.rs
@@ -1424,6 +1424,7 @@ impl HTMLInputElement {
         match self.input_type() {
             _ if self.is_textual_widget() => self.update_textual_shadow_tree(can_gc),
             InputType::Color => self.update_color_shadow_tree(can_gc),
+            InputType::File => self.upcast::<Node>().dirty(NodeDamage::Other),
             _ => {},
         }
     }


### PR DESCRIPTION
Force the input node to be dirty to update the displayed valued based on file selection.

Testing: manual testing
Fixes: https://github.com/servo/servo/issues/41610
