### PR TITLE
ohos CI: Add a proper name for scenario test screenshot artifacts

### DIFF
--- a/.github/workflows/ohos.yml
+++ b/.github/workflows/ohos.yml
@@ -427,4 +427,5 @@ jobs:
         if: ${{ steps.install_hap.outcome == 'success' && failure() }}
         uses: actions/upload-artifact@v5
         with:
+          name: hos-${{ inputs.profile }}-scenario-failures-screenshots
           path: "servo_scenario_*_error.jpg"


### PR DESCRIPTION
Right now it has no name. It is always called `artifact`: https://github.com/servo/servo/actions/runs/20628557553#artifacts.

What's worse, the merged commits usually has workflow which runs scenario tests with different profile, we end up only with one artifact: https://github.com/servo/servo/actions/runs/20620357631/job/59221319188
<img width="1295" height="141" alt="image" src="https://github.com/user-attachments/assets/955c7e2b-d0ad-4625-812d-1d9f4ba350b8" />