### PR TITLE
script: add JSContext as argument to methods in XMLHttpRequest

### DIFF
--- a/components/script/dom/xmlhttprequest.rs
+++ b/components/script/dom/xmlhttprequest.rs
@@ -776,7 +776,8 @@ impl XMLHttpRequestMethods<crate::DomTypeHolder> for XMLHttpRequest {
     }
 
     /// <https://xhr.spec.whatwg.org/#the-abort()-method>
-    fn Abort(&self, can_gc: CanGc) {
+    fn Abort(&self, cx: &mut js::context::JSContext) {
+        let can_gc = CanGc::from_cx(cx);
         // Step 1
         self.terminate_ongoing_fetch();
         // Step 2
@@ -976,7 +977,11 @@ impl XMLHttpRequestMethods<crate::DomTypeHolder> for XMLHttpRequest {
     }
 
     /// <https://xhr.spec.whatwg.org/#the-responsexml-attribute>
-    fn GetResponseXML(&self, can_gc: CanGc) -> Fallible<Option<DomRoot<Document>>> {
+    fn GetResponseXML(
+        &self,
+        cx: &mut js::context::JSContext,
+    ) -> Fallible<Option<DomRoot<Document>>> {
+        let can_gc = CanGc::from_cx(cx);
         match self.response_type.get() {
             XMLHttpRequestResponseType::_empty | XMLHttpRequestResponseType::Document => {
                 // Step 3

--- a/components/script_bindings/codegen/Bindings.conf
+++ b/components/script_bindings/codegen/Bindings.conf
@@ -808,8 +808,8 @@ DOMInterfaces = {
 },
 
 'XMLHttpRequest': {
-    'canGc': ['Abort', 'GetResponseXML', 'Response'],
-    'cx': ['Send'],
+    'canGc': ['Response'],
+    'cx': ['Abort', 'GetResponseXML', 'Send'],
 },
 
 'XPathEvaluator': {


### PR DESCRIPTION
script: add JSContext as argument to methods in XMLHttpRequest

Testing: These changes do not require tests because they are a refactor.
Addresses part of https://github.com/servo/servo/issues/40600
