### PR TITLE
libservo: Add initial support for `SiteDataManager::clear_site_data`

### DIFF
--- a/components/net/resource_thread.rs
+++ b/components/net/resource_thread.rs
@@ -399,6 +399,13 @@ impl ResourceChannelManager {
                     cancellation_listener.cancel();
                 }
             },
+            CoreResourceMsg::DeleteCookiesForSites(sites, sender) => {
+                http_state
+                    .cookie_jar
+                    .write()
+                    .delete_cookies_for_sites(&sites);
+                let _ = sender.send(());
+            },
             CoreResourceMsg::DeleteCookies(request, sender) => {
                 http_state
                     .cookie_jar

--- a/components/servo/site_data_manager.rs
+++ b/components/servo/site_data_manager.rs
@@ -174,6 +174,21 @@ impl SiteDataManager {
         result
     }
 
+    /// Clear site data for the given sites.
+    ///
+    /// The clearing is restricted to the provided `storage_types` bitflags.
+    /// Both public and private browsing data are affected.
+    ///
+    /// TODO: At present this method can only clear cookies for the specified
+    /// sites. Support for additional storage categories (e.g. localStorage
+    /// and sessionStorage) will be added in follow-up patches.
+    pub fn clear_site_data(&self, sites: &[&str], storage_types: StorageType) {
+        if storage_types.contains(StorageType::Cookies) {
+            self.public_resource_threads.clear_cookies_for_sites(sites);
+            self.private_resource_threads.clear_cookies_for_sites(sites);
+        }
+    }
+
     pub fn clear_cookies(&self) {
         self.public_resource_threads.clear_cookies();
         self.private_resource_threads.clear_cookies();

--- a/components/servo/tests/site_data_manager.rs
+++ b/components/servo/tests/site_data_manager.rs
@@ -247,6 +247,115 @@ fn test_site_data() {
 }
 
 #[test]
+fn test_clear_site_data_cookies() {
+    let webview_test = WebViewTest::new();
+
+    let site_data_manager = webview_test.servo().site_data_manager();
+
+    let sites = site_data_manager.site_data(StorageType::all());
+    assert_eq!(sites.len(), 0);
+
+    let steps: &[TestSiteDataStep] = &[
+        (
+            SiteData::new("site-data-0a.test", StorageType::Cookies),
+            None,
+        ),
+        (
+            SiteData::new("site-data-0b.test", StorageType::Cookies),
+            None,
+        ),
+        (
+            SiteData::new("site-data-0c.test", StorageType::Cookies),
+            None,
+        ),
+        (SiteData::new("site-data-1.test", StorageType::Local), None),
+        (
+            SiteData::new("site-data-2.test", StorageType::Session),
+            None,
+        ),
+        (
+            SiteData::new(
+                "site-data-3.test",
+                StorageType::Cookies | StorageType::Local | StorageType::Session,
+            ),
+            None,
+        ),
+    ];
+
+    run_test_site_data_steps(&webview_test, steps);
+
+    let sites = site_data_manager.site_data(StorageType::all());
+    assert_eq!(
+        &sites,
+        &[
+            SiteData::new("site-data-0a.test", StorageType::Cookies),
+            SiteData::new("site-data-0b.test", StorageType::Cookies),
+            SiteData::new("site-data-0c.test", StorageType::Cookies),
+            SiteData::new("site-data-1.test", StorageType::Local),
+            SiteData::new("site-data-2.test", StorageType::Session),
+            SiteData::new(
+                "site-data-3.test",
+                StorageType::Cookies | StorageType::Local | StorageType::Session
+            ),
+        ]
+    );
+
+    site_data_manager.clear_site_data(&["site-data-0.test"], StorageType::Cookies);
+
+    let sites = site_data_manager.site_data(StorageType::all());
+    assert_eq!(
+        &sites,
+        &[
+            SiteData::new("site-data-0a.test", StorageType::Cookies),
+            SiteData::new("site-data-0b.test", StorageType::Cookies),
+            SiteData::new("site-data-0c.test", StorageType::Cookies),
+            SiteData::new("site-data-1.test", StorageType::Local),
+            SiteData::new("site-data-2.test", StorageType::Session),
+            SiteData::new(
+                "site-data-3.test",
+                StorageType::Cookies | StorageType::Local | StorageType::Session
+            ),
+        ]
+    );
+
+    site_data_manager.clear_site_data(&["site-data-0a.test"], StorageType::Cookies);
+
+    let sites = site_data_manager.site_data(StorageType::all());
+    assert_eq!(
+        &sites,
+        &[
+            SiteData::new("site-data-0b.test", StorageType::Cookies),
+            SiteData::new("site-data-0c.test", StorageType::Cookies),
+            SiteData::new("site-data-1.test", StorageType::Local),
+            SiteData::new("site-data-2.test", StorageType::Session),
+            SiteData::new(
+                "site-data-3.test",
+                StorageType::Cookies | StorageType::Local | StorageType::Session
+            ),
+        ]
+    );
+
+    site_data_manager.clear_site_data(
+        &["site-data-0c.test", "site-data-3.test"],
+        StorageType::Cookies,
+    );
+
+    let sites = site_data_manager.site_data(StorageType::all());
+    assert_eq!(
+        &sites,
+        &[
+            SiteData::new("site-data-0b.test", StorageType::Cookies),
+            SiteData::new("site-data-1.test", StorageType::Local),
+            SiteData::new("site-data-2.test", StorageType::Session),
+            SiteData::new(
+                "site-data-3.test",
+                StorageType::Local | StorageType::Session
+            ),
+        ]
+    );
+}
+
+#[test]
 fn test_clear_cookies() {
     let servo_test = ServoTest::new();
 

--- a/components/shared/net/lib.rs
+++ b/components/shared/net/lib.rs
@@ -532,6 +532,15 @@ impl ResourceThreads {
         receiver.recv().unwrap()
     }
 
+    pub fn clear_cookies_for_sites(&self, sites: &[&str]) {
+        let sites = sites.iter().map(|site| site.to_string()).collect();
+        let (sender, receiver) = generic_channel::channel().unwrap();
+        let _ = self
+            .core_thread
+            .send(CoreResourceMsg::DeleteCookiesForSites(sites, sender));
+        let _ = receiver.recv();
+    }
+
     pub fn clear_cookies(&self) {
         let (sender, receiver) = ipc::channel().unwrap();
         let _ = self
@@ -620,6 +629,7 @@ pub enum CoreResourceMsg {
     ),
     GetCookieDataForUrlAsync(CookieStoreId, ServoUrl, Option<String>),
     GetAllCookieDataForUrlAsync(CookieStoreId, ServoUrl, Option<String>),
+    DeleteCookiesForSites(Vec<String>, GenericSender<()>),
     DeleteCookies(Option<ServoUrl>, Option<IpcSender<()>>),
     DeleteCookie(ServoUrl, String),
     DeleteCookieAsync(CookieStoreId, ServoUrl, String),


### PR DESCRIPTION
Introduce initial support for site-scoped data clearing by enabling removal of
cookies for a given set of sites.

The API clears cookies across both public and private browsing contexts, and is
gated by the `StorageType` bitflags. At this stage only the `Cookies` category
is supported. Support for additional storage types (such as localStorage and
sessionStorage) will be added in a follow-up.

Testing: A new integration test has been added.
