### PR TITLE
deps: Bump wayland-related together

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -60,6 +60,9 @@ updates:
       patterns:
         - "async-tungstenite"
         - "tungstenite"
+    wayland-related:
+      patterns:
+        - "wayland*"
   ignore:
   # Ignore all stylo crates as their upgrades are coordinated via companion PRs.
   - dependency-name: selectors

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -62,7 +62,7 @@ updates:
         - "tungstenite"
     wayland-related:
       patterns:
-        - "wayland*"
+        - "wayland-*"
   ignore:
   # Ignore all stylo crates as their upgrades are coordinated via companion PRs.
   - dependency-name: selectors


### PR DESCRIPTION
Very often, we have consecutive @dependabot PRs that bumps wayland stuff individually. This often results in wasted effort: the empty commit here 7414a5ff9aa5c9ab5e3ebd44c5b63890b2d338d1 which has non-empty PR, as it is just bumped by the parent PR.