### PR TITLE
layout: Handle block-in-inline dependency on block constraints

### DIFF
--- a/components/layout/flow/inline/mod.rs
+++ b/components/layout/flow/inline/mod.rs
@@ -235,6 +235,12 @@ impl AnonymousBlockBox {
                 },
             );
 
+        // If this Fragment's layout depends on the block size of the containing block,
+        // then the entire layout of the inline formatting context does as well.
+        layout.depends_on_block_constraints |= fragment.base.flags.contains(
+            FragmentFlags::SIZE_DEPENDS_ON_BLOCK_CONSTRAINTS_AND_CAN_BE_CHILD_OF_FLEX_ITEM,
+        );
+
         let mut fragment = Fragment::Box(ArcRefCell::new(fragment));
         layout.placement_state.place_fragment_and_update_baseline(
             &mut fragment,

--- a/tests/wpt/tests/css/css-flexbox/percentage-heights-021.html
+++ b/tests/wpt/tests/css/css-flexbox/percentage-heights-021.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Flexbox: percentage in block-level inside inline inside flex item</title>
+<link rel="author" title="Oriol Brufau" href="mailto:obrufau@igalia.com">
+<link rel="help" href="https://drafts.csswg.org/css-flexbox-1/#algo-stretch">
+<link rel="help" href="https://github.com/servo/servo/issues/41623">
+<link rel="match" href="../reference/ref-filled-green-200px-square.html">
+<meta name="assert" content="When the 2nd flex item is stretched to fill the flex line,
+  it needs to be laid out again, and the percentage should now resolve against 200px.">
+
+<p>Test passes if there is a filled green square and <strong>no red</strong>.</p>
+
+<div style="display: flex">
+  <div style="height: 200px"></div>
+  <div style="background: red">
+    <span>
+      <div style="width: 200px; height: 100%; background: green"></div>
+    </span>
+  </div>
+</div>


### PR DESCRIPTION
When a block-level that depends on block constraints is inside an inline formatting context, then the entire layout of the IFC needs to be marked as depending on block constraints too.

Testing: Adding new test
Fixes: #41623
