### PR TITLE
webdriver: Fix outdated timeouts test and remove redundant check

### DIFF
--- a/components/webdriver_server/actions.rs
+++ b/components/webdriver_server/actions.rs
@@ -26,14 +26,12 @@ use webdriver::actions::{
 };
 use webdriver::error::{ErrorStatus, WebDriverError};
 
+use crate::timeout::MAXIMUM_SAFE_INTEGER;
 use crate::{Handler, VerifyBrowsingContextIsOpen, WebElement, wait_for_oneshot_response};
 
 // Interval between wheelScroll and pointerMove increments in ms, based on common vsync
 static POINTERMOVE_INTERVAL: u64 = 17;
 static WHEELSCROLL_INTERVAL: u64 = 17;
-
-// https://262.ecma-international.org/6.0/#sec-number.max_safe_integer
-static MAXIMUM_SAFE_INTEGER: u64 = 9_007_199_254_740_991;
 
 // A single action, corresponding to an `action object` in the spec.
 // In the spec, `action item` refers to a plain JSON object.

--- a/components/webdriver_server/actions.rs
+++ b/components/webdriver_server/actions.rs
@@ -34,7 +34,7 @@ static WHEELSCROLL_INTERVAL: u64 = 17;
 
 /// <https://262.ecma-international.org/6.0/#sec-number.max_safe_integer>
 /// 2^53 - 1
-pub(crate) static MAXIMUM_SAFE_INTEGER: u64 = 9_007_199_254_740_991;
+static MAXIMUM_SAFE_INTEGER: u64 = 9_007_199_254_740_991;
 
 // A single action, corresponding to an `action object` in the spec.
 // In the spec, `action item` refers to a plain JSON object.

--- a/components/webdriver_server/actions.rs
+++ b/components/webdriver_server/actions.rs
@@ -26,12 +26,15 @@ use webdriver::actions::{
 };
 use webdriver::error::{ErrorStatus, WebDriverError};
 
-use crate::timeout::MAXIMUM_SAFE_INTEGER;
 use crate::{Handler, VerifyBrowsingContextIsOpen, WebElement, wait_for_oneshot_response};
 
 // Interval between wheelScroll and pointerMove increments in ms, based on common vsync
 static POINTERMOVE_INTERVAL: u64 = 17;
 static WHEELSCROLL_INTERVAL: u64 = 17;
+
+/// <https://262.ecma-international.org/6.0/#sec-number.max_safe_integer>
+/// 2^53 - 1
+pub(crate) static MAXIMUM_SAFE_INTEGER: u64 = 9_007_199_254_740_991;
 
 // A single action, corresponding to an `action object` in the spec.
 // In the spec, `action item` refers to a plain JSON object.

--- a/components/webdriver_server/session.rs
+++ b/components/webdriver_server/session.rs
@@ -230,7 +230,7 @@ impl Handler {
         // and value serialize the timeouts configuration with session's session timeouts.
         capabilities.insert(
             "timeouts".to_string(),
-            json!(serialize_timeouts_configuration(&session.timeouts)),
+            serialize_timeouts_configuration(&session.timeouts),
         );
 
         // Step 10. Process any extension capabilities in capabilities in an implementation-defined manner

--- a/components/webdriver_server/timeout.rs
+++ b/components/webdriver_server/timeout.rs
@@ -69,8 +69,9 @@ pub(crate) fn deserialize_as_timeouts_configuration(
             *target = match value {
                 Value::Null => None,
                 Value::Number(num) => Some(
-                    num.as_u64()
-                        .expect("Number already validated when parsing requests"),
+                    num.as_f64()
+                        .expect("Number already validated when parsing requests")
+                        as u64,
                 ),
                 _ => unreachable!("This has been validated when parsing requests"),
             };

--- a/components/webdriver_server/timeout.rs
+++ b/components/webdriver_server/timeout.rs
@@ -24,10 +24,6 @@ pub(crate) const DEFAULT_IMPLICIT_WAIT: u64 = 0;
 /// timed out.
 pub(crate) const SCREENSHOT_TIMEOUT: Duration = Duration::from_secs(10);
 
-/// https://262.ecma-international.org/6.0/#sec-number.max_safe_integer
-/// 2^53 - 1
-pub(crate) static MAXIMUM_SAFE_INTEGER: u64 = 9_007_199_254_740_991;
-
 pub(crate) struct TimeoutsConfiguration {
     pub(crate) script: Option<u64>,
     pub(crate) page_load: Option<u64>,
@@ -72,21 +68,11 @@ pub(crate) fn deserialize_as_timeouts_configuration(
             //  - "implicit": Set configuration's implicit wait timeout to value.
             *target = match value {
                 Value::Null => None,
-                Value::Number(num) => match num.as_u64() {
-                    Some(val) if val <= MAXIMUM_SAFE_INTEGER => Some(val),
-                    _ => {
-                        return Err(WebDriverError::new(
-                            ErrorStatus::InvalidArgument,
-                            format!("Invalid value for {}", key),
-                        ));
-                    },
-                },
-                _ => {
-                    return Err(WebDriverError::new(
-                        ErrorStatus::InvalidArgument,
-                        format!("Invalid value type for {}", key),
-                    ));
-                },
+                Value::Number(num) => Some(
+                    num.as_u64()
+                        .expect("Number already validated when parsing requests"),
+                ),
+                _ => unreachable!("This has been validated when parsing requests"),
             };
         }
 

--- a/tests/wpt/meta/webdriver/tests/classic/new_session/timeouts.py.ini
+++ b/tests/wpt/meta/webdriver/tests/classic/new_session/timeouts.py.ini
@@ -4,3 +4,30 @@
 
   [test_timeouts[timeouts2\]]
     expected: FAIL
+
+  [test_timeouts[implicit-None\]]
+    expected: FAIL
+
+  [test_timeouts[implicit-0\]]
+    expected: FAIL
+
+  [test_timeouts[implicit-3000\]]
+    expected: FAIL
+
+  [test_timeouts[pageLoad-None\]]
+    expected: FAIL
+
+  [test_timeouts[pageLoad-0\]]
+    expected: FAIL
+
+  [test_timeouts[pageLoad-3000\]]
+    expected: FAIL
+
+  [test_timeouts[script-None\]]
+    expected: FAIL
+
+  [test_timeouts[script-0\]]
+    expected: FAIL
+
+  [test_timeouts[script-3000\]]
+    expected: FAIL

--- a/tests/wpt/meta/webdriver/tests/classic/new_session/timeouts.py.ini
+++ b/tests/wpt/meta/webdriver/tests/classic/new_session/timeouts.py.ini
@@ -1,0 +1,6 @@
+[timeouts.py]
+  [test_timeouts[timeouts1\]]
+    expected: FAIL
+
+  [test_timeouts[timeouts2\]]
+    expected: FAIL

--- a/tests/wpt/tests/webdriver/tests/classic/new_session/support/create.py
+++ b/tests/wpt/tests/webdriver/tests/classic/new_session/support/create.py
@@ -83,7 +83,6 @@ invalid_data = [
         {"page load": 10},
         {" pageLoad": 10},
         {"pageLoad ": 10},
-        {"pageLoad": None},
         {"pageLoad": False},
         {"pageLoad": []},
         {"pageLoad": "10"},

--- a/tests/wpt/tests/webdriver/tests/classic/new_session/timeouts.py
+++ b/tests/wpt/tests/webdriver/tests/classic/new_session/timeouts.py
@@ -20,7 +20,7 @@ def test_timeouts(new_session, add_browser_capabilities, key, value):
     value = assert_success(response)
     assert value["capabilities"]["timeouts"] == timeouts
 
-@pytest.mark.parametrize("value", [MAX_SAFE_INTEGER + 1, -11])
+@pytest.mark.parametrize("value", [MAX_SAFE_INTEGER + 1, -1])
 @pytest.mark.parametrize("key", ["implicit", "pageLoad", "script"])
 def test_invalid_timeouts(new_session, add_browser_capabilities, key, value):
     timeouts = {key: value}

--- a/tests/wpt/tests/webdriver/tests/classic/new_session/timeouts.py
+++ b/tests/wpt/tests/webdriver/tests/classic/new_session/timeouts.py
@@ -22,7 +22,20 @@ def test_timeouts(new_session, add_browser_capabilities, key, value):
 
 @pytest.mark.parametrize("value", [MAX_SAFE_INTEGER + 1, -1])
 @pytest.mark.parametrize("key", ["implicit", "pageLoad", "script"])
-def test_invalid_timeouts(new_session, add_browser_capabilities, key, value):
+def test_invalid_timeouts_value(new_session, add_browser_capabilities, key, value):
+    timeouts = {key: value}
+
+    response, _ = new_session({
+        "capabilities": {
+            "alwaysMatch": add_browser_capabilities({"timeouts": timeouts})
+        }
+    })
+
+    assert_error(response, "invalid argument")
+
+@pytest.mark.parametrize("value", ["foo", False, [], {}])
+@pytest.mark.parametrize("key", ["implicit", "pageLoad", "script"])
+def test_invalid_timeouts_type(new_session, add_browser_capabilities, key, value):
     timeouts = {key: value}
 
     response, _ = new_session({

--- a/tests/wpt/tests/webdriver/tests/classic/new_session/timeouts.py
+++ b/tests/wpt/tests/webdriver/tests/classic/new_session/timeouts.py
@@ -20,11 +20,15 @@ def test_timeouts(new_session, add_browser_capabilities, key, value):
     value = assert_success(response)
     assert value["capabilities"]["timeouts"] == timeouts
 
-@pytest.mark.parametrize("timeouts", [
-    {"implicit": None, "pageLoad": MAX_SAFE_INTEGER + 2,"script": 30000},
-    {"implicit": MAX_SAFE_INTEGER + 2, "pageLoad": None,"script": 30000},
-    {"implicit": None, "pageLoad": None,"script": MAX_SAFE_INTEGER + 2}
-])
-def test_invalid_timeouts(new_session, add_browser_capabilities, timeouts):
-    response, _ = new_session({"capabilities": {"alwaysMatch": add_browser_capabilities({"timeouts": timeouts})}})
+@pytest.mark.parametrize("value", [MAX_SAFE_INTEGER + 1, -11])
+@pytest.mark.parametrize("key", ["implicit", "pageLoad", "script"])
+def test_invalid_timeouts(new_session, add_browser_capabilities, key, value):
+    timeouts = {key: value}
+
+    response, _ = new_session({
+        "capabilities": {
+            "alwaysMatch": add_browser_capabilities({"timeouts": timeouts})
+        }
+    })
+
     assert_error(response, "invalid argument")

--- a/tests/wpt/tests/webdriver/tests/classic/new_session/timeouts.py
+++ b/tests/wpt/tests/webdriver/tests/classic/new_session/timeouts.py
@@ -12,13 +12,10 @@ def test_default_values(session):
     assert timeouts["script"] == 30000
 
 
-@pytest.mark.parametrize("timeouts", [
-    {"implicit": 444, "pageLoad": 300000,"script": 30000},
-    {"implicit": 0, "pageLoad": None,"script": 30000},
-    {"implicit": None, "pageLoad": 300000,"script": 444},
-    {"implicit": 0, "pageLoad": 300000,"script": None},
-])
-def test_timeouts(new_session, add_browser_capabilities, timeouts):
+@pytest.mark.parametrize("value", [None, 0, 3000])
+@pytest.mark.parametrize("key", ["implicit", "pageLoad", "script"])
+def test_timeouts(new_session, add_browser_capabilities, key, value):
+    timeouts = {key: value}
     response, _ = new_session({"capabilities": {"alwaysMatch": add_browser_capabilities({"timeouts": timeouts})}})
     value = assert_success(response)
     assert value["capabilities"]["timeouts"] == timeouts

--- a/tests/wpt/tests/webdriver/tests/classic/new_session/timeouts.py
+++ b/tests/wpt/tests/webdriver/tests/classic/new_session/timeouts.py
@@ -2,6 +2,7 @@ import pytest
 
 from tests.support.asserts import assert_success, assert_error
 
+MAX_SAFE_INTEGER = 2**53 - 1
 
 def test_default_values(session):
     timeouts = session.capabilities["timeouts"]
@@ -13,8 +14,8 @@ def test_default_values(session):
 
 @pytest.mark.parametrize("timeouts", [
     {"implicit": 444, "pageLoad": 300000,"script": 30000},
-    {"implicit": 0, "pageLoad": 444,"script": 30000},
-    {"implicit": 0, "pageLoad": 300000,"script": 444},
+    {"implicit": 0, "pageLoad": None,"script": 30000},
+    {"implicit": None, "pageLoad": 300000,"script": 444},
     {"implicit": 0, "pageLoad": 300000,"script": None},
 ])
 def test_timeouts(new_session, add_browser_capabilities, timeouts):
@@ -23,9 +24,9 @@ def test_timeouts(new_session, add_browser_capabilities, timeouts):
     assert value["capabilities"]["timeouts"] == timeouts
 
 @pytest.mark.parametrize("timeouts", [
-    {"implicit": None, "pageLoad": 300000,"script": 30000},
-    {"implicit": 0, "pageLoad": None,"script": 30000},
-    {"implicit": None, "pageLoad": None,"script": None}
+    {"implicit": None, "pageLoad": MAX_SAFE_INTEGER + 2,"script": 30000},
+    {"implicit": MAX_SAFE_INTEGER + 2, "pageLoad": None,"script": 30000},
+    {"implicit": None, "pageLoad": None,"script": MAX_SAFE_INTEGER + 2}
 ])
 def test_invalid_timeouts(new_session, add_browser_capabilities, timeouts):
     response, _ = new_session({"capabilities": {"alwaysMatch": add_browser_capabilities({"timeouts": timeouts})}})


### PR DESCRIPTION
Initially the attempt is to validate params according to spec. But it turns out validation is already done at [webdriver crate](https://hg-edge.mozilla.org/mozilla-central/file/tip/testing/webdriver/src/capabilities.rs#l368) so I reverted the change.

But Chrome/Firefox are not compliant with spec: https://wpt.fyi/results/webdriver/tests/classic/new_session/timeouts.py?label=experimental&label=master&aligned. They only allow `script timeouts` to be `None` but not `pageLoad` and `implicit`, which is how the test is currently written.

Testing: Updated the test to be compliant with spec. New failures are because it is validated at [webdriver crate](https://hg-edge.mozilla.org/mozilla-central/file/tip/testing/webdriver/src/capabilities.rs#l377).
