### PR TITLE
layout: Fix size of anonymous not marked as depending on block constraints

### DIFF
--- a/components/layout/flow/mod.rs
+++ b/components/layout/flow/mod.rs
@@ -1160,7 +1160,12 @@ pub(crate) fn layout_in_flow_non_replaced_block_level_same_formatting_context(
     };
 
     let mut base_fragment_info = base.base_fragment_info;
-    if depends_on_block_constraints {
+
+    // An anonymous block doesn't establish a containing block for its contents. Therefore,
+    // if its contents depend on block constraints, its block size (which is intrinsic) also
+    // depends on block constraints.
+    let is_anonymous = matches!(base.style.pseudo(), Some(PseudoElement::ServoAnonymousBox));
+    if depends_on_block_constraints || (is_anonymous && flow_layout.depends_on_block_constraints) {
         base_fragment_info
             .flags
             .insert(FragmentFlags::SIZE_DEPENDS_ON_BLOCK_CONSTRAINTS_AND_CAN_BE_CHILD_OF_FLEX_ITEM);

--- a/tests/wpt/tests/css/css-flexbox/percentage-heights-020.html
+++ b/tests/wpt/tests/css/css-flexbox/percentage-heights-020.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Flexbox: percentage in inline-level inside anonymous block inside flex item</title>
+<link rel="author" title="Oriol Brufau" href="mailto:obrufau@igalia.com">
+<link rel="help" href="https://github.com/servo/servo/issues/41629">
+<link rel="match" href="../reference/ref-filled-green-200px-square.html">
+<meta name="assert" content="The <canvas> size is 200 x 200">
+
+<style>
+#flex-container {
+  display: flex;
+  flex-direction: column;
+}
+#flex-item {
+  width: 200px;
+  height: 200px;
+  background: red;
+}
+#target {
+  height: 100%;
+  background: green;
+}
+</style>
+
+<p>Test passes if there is a filled green square and <strong>no red</strong>.</p>
+
+<div id="flex-container">
+  <div id="flex-item">
+    <div><!-- This wraps the inline-level canvas inside an anonymous block --></div>
+    <canvas id="target" width="100" height="100"></canvas>
+  </div>
+</div>


### PR DESCRIPTION
An anonymous block box doesn't establish a containing block for its contents. Therefore, if its contents depend on block constraints, we need to mark it as having a size that depends on block constraints.

Testing: Adding new test
Fixes: #41629
