### PR TITLE
script: Skip some steps when determining encoding for XML document

### DIFF
--- a/tests/wpt/meta/encoding/utf-32-from-win1252.html.ini
+++ b/tests/wpt/meta/encoding/utf-32-from-win1252.html.ini
@@ -1,3 +1,0 @@
-[utf-32-from-win1252.html]
-  [Expect resources/utf-32-big-endian-bom.xml to parse as UTF-8]
-    expected: FAIL

--- a/tests/wpt/meta/encoding/utf-32.html.ini
+++ b/tests/wpt/meta/encoding/utf-32.html.ini
@@ -1,3 +1,0 @@
-[utf-32.html]
-  [Expect resources/utf-32-big-endian-bom.xml to parse as UTF-8]
-    expected: FAIL


### PR DESCRIPTION
XML documents do not use the "determine the encoding" algorithm. As far as I can tell, it is unspecified how they should determine the encoding instead. We now check the BOM, `Content-Type` header and prescan for an xml encoding declaration (but don't inherit encodings from iframes or attempt to determine the encoding from heuristics).

Testing: New tests start to pass
Part of https://github.com/servo/servo/issues/6414
