### PR TITLE
Correct path to twin `find_python()` functions in `servo` and `script_bindings` `build.rs`

### DIFF
--- a/components/script_bindings/build.rs
+++ b/components/script_bindings/build.rs
@@ -84,7 +84,7 @@ impl phf_shared::PhfHash for Bytes<'_> {
 ///
 /// More details: <https://book.servo.org/hacking/setting-up-your-environment.html#check-tools>
 ///
-/// Note: This function should be kept in sync with the version in `components/script/build.rs`
+/// Note: This function should be kept in sync with the version in `components/servo/build.rs`
 fn find_python() -> Command {
     let mut command = Command::new("uv");
     command.args(["run", "--no-project", "python"]);

--- a/components/servo/build.rs
+++ b/components/servo/build.rs
@@ -31,7 +31,7 @@ fn main() {
 ///
 /// More details: <https://book.servo.org/hacking/setting-up-your-environment.html#check-tools>
 ///
-/// Note: This function should be kept in sync with the version in `components/script/build.rs`
+/// Note: This function should be kept in sync with the version in `components/script_bindings/build.rs`
 fn find_python() -> Command {
     let mut command = Command::new("uv");
     command.args(["run", "--no-project", "python"]);


### PR DESCRIPTION
Just fixed a discrepancy in comments I noticed, the files were moved around in https://github.com/servo/servo/pull/35157
