### PR TITLE
script: Add a `Rope` type and use it for `TextInput`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -789,6 +789,7 @@ dependencies = [
  "servo_config",
  "servo_malloc_size_of",
  "time",
+ "unicode-segmentation",
  "webrender_api",
  "windows-sys 0.61.2",
 ]

--- a/components/script/dom/html/htmltextareaelement.rs
+++ b/components/script/dom/html/htmltextareaelement.rs
@@ -6,6 +6,7 @@ use std::cell::Cell;
 use std::default::Default;
 use std::ops::Range;
 
+use base::Lines;
 use base::text::{Utf8CodeUnitLength, Utf16CodeUnitLength};
 use dom_struct::dom_struct;
 use embedder_traits::{EmbedderControlRequest, InputMethodRequest, InputMethodType};
@@ -47,7 +48,7 @@ use crate::dom::validitystate::{ValidationFlags, ValidityState};
 use crate::dom::virtualmethods::VirtualMethods;
 use crate::script_runtime::CanGc;
 use crate::textinput::{
-    ClipboardEventFlags, Direction, IsComposing, KeyReaction, Lines, SelectionDirection, TextInput,
+    ClipboardEventFlags, IsComposing, KeyReaction, SelectionDirection, TextInput,
 };
 
 #[dom_struct]
@@ -383,7 +384,7 @@ impl HTMLTextAreaElementMethods<crate::DomTypeHolder> for HTMLTextAreaElement {
 
             if old_value != textinput.get_content() {
                 // Step 4
-                textinput.clear_selection_to_limit(Direction::Forward);
+                textinput.clear_selection_to_end();
             }
         }
 

--- a/components/script/dom/textcontrol.rs
+++ b/components/script/dom/textcontrol.rs
@@ -322,13 +322,11 @@ impl<'a, E: TextControlElement> TextControlSelection<'a, E> {
     }
 
     fn start(&self) -> Utf16CodeUnitLength {
-        let textinput = self.textinput.borrow();
-        textinput.text_point_to_utf16_offset(textinput.selection_start())
+        self.textinput.borrow().selection_start_utf16()
     }
 
     fn end(&self) -> Utf16CodeUnitLength {
-        let textinput = self.textinput.borrow();
-        textinput.text_point_to_utf16_offset(textinput.selection_end())
+        self.textinput.borrow().selection_end_utf16()
     }
 
     fn direction(&self) -> SelectionDirection {

--- a/components/script/test.rs
+++ b/components/script/test.rs
@@ -71,9 +71,7 @@ pub mod timeranges {
 
 pub mod textinput {
     pub use crate::clipboard_provider::ClipboardProvider;
-    pub use crate::textinput::{
-        Direction, Lines, Selection, SelectionDirection, TextInput, TextPoint,
-    };
+    pub use crate::textinput::{Direction, SelectionDirection, TextInput};
 }
 
 pub mod encoding_detection {

--- a/components/script/textinput.rs
+++ b/components/script/textinput.rs
@@ -4,17 +4,15 @@
 
 //! Common handling of keyboard input and state management for text input controls
 
-use std::borrow::ToOwned;
-use std::cmp::min;
 use std::default::Default;
 use std::ops::Range;
 
 use base::text::{Utf8CodeUnitLength, Utf16CodeUnitLength};
+use base::{Lines, Rope, RopeIndex, RopeMovement, RopeSlice};
 use bitflags::bitflags;
 use keyboard_types::{Key, KeyState, Modifiers, NamedKey, ShortcutMatcher};
 use script_bindings::match_domstring_ascii;
 use script_bindings::trace::CustomTraceable;
-use unicode_segmentation::UnicodeSegmentation;
 
 use crate::clipboard_provider::ClipboardProvider;
 use crate::dom::bindings::codegen::Bindings::EventBinding::Event_Binding::EventMethods;
@@ -64,53 +62,28 @@ impl From<SelectionDirection> for DOMString {
     }
 }
 
-#[derive(Clone, Copy, Debug, Default, JSTraceable, MallocSizeOf, PartialEq, PartialOrd)]
-pub struct TextPoint {
-    /// 0-based line number
-    pub line: usize,
-    /// 0-based column number in bytes
-    pub index: Utf8CodeUnitLength,
-}
-
-impl TextPoint {
-    pub fn new(line: usize, index: Utf8CodeUnitLength) -> Self {
-        Self { line, index }
-    }
-
-    /// Returns a TextPoint constrained to be a valid location within lines
-    fn constrain_to(&self, lines: &[DOMString]) -> TextPoint {
-        let line = min(self.line, lines.len() - 1);
-
-        TextPoint {
-            line,
-            index: min(self.index, lines[line].len_utf8()),
-        }
-    }
-}
-
 #[derive(Clone, Copy, PartialEq)]
 pub(crate) struct SelectionState {
-    start: TextPoint,
-    end: TextPoint,
+    start: RopeIndex,
+    end: RopeIndex,
     direction: SelectionDirection,
 }
 
 /// Encapsulated state for handling keyboard input in a single or multiline text input control.
 #[derive(JSTraceable, MallocSizeOf)]
 pub struct TextInput<T: ClipboardProvider> {
-    /// Current text input content, split across lines without trailing '\n'
-    lines: Vec<DOMString>,
+    #[no_trace]
+    rope: Rope,
 
     /// Current cursor input point
-    edit_point: TextPoint,
+    #[no_trace]
+    edit_point: RopeIndex,
 
     /// The current selection goes from the selection_origin until the edit_point. Note that the
     /// selection_origin may be after the edit_point, in the case of a backward selection.
-    selection_origin: Option<TextPoint>,
+    #[no_trace]
+    selection_origin: Option<RopeIndex>,
     selection_direction: SelectionDirection,
-
-    /// Is this a multiline input?
-    multiline: bool,
 
     #[ignore_malloc_size_of = "Can't easily measure this generic type"]
     clipboard_provider: T,
@@ -216,13 +189,6 @@ impl ClipboardEventReaction {
     }
 }
 
-/// Control whether this control should allow multiple lines.
-#[derive(Eq, PartialEq)]
-pub enum Lines {
-    Single,
-    Multiple,
-}
-
 /// The direction in which to delete a character.
 #[derive(Clone, Copy, Eq, PartialEq)]
 pub enum Direction {
@@ -235,17 +201,6 @@ pub enum Direction {
 pub(crate) const CMD_OR_CONTROL: Modifiers = Modifiers::META;
 #[cfg(not(target_os = "macos"))]
 pub(crate) const CMD_OR_CONTROL: Modifiers = Modifiers::CONTROL;
-
-/// The length in bytes of the first n characters in a UTF-8 string.
-///
-/// If the string has fewer than n characters, returns the length of the whole string.
-/// If n is 0, returns 0
-fn len_of_first_n_chars(text: &DOMString, n: usize) -> Utf8CodeUnitLength {
-    match text.str().char_indices().take(n).last() {
-        Some((index, ch)) => Utf8CodeUnitLength(index + ch.len_utf8()),
-        None => Utf8CodeUnitLength::zero(),
-    }
-}
 
 /// The length in bytes of the first n code units in a string when encoded in UTF-16.
 ///
@@ -263,43 +218,6 @@ fn len_of_first_n_code_units(text: &DOMString, n: Utf16CodeUnitLength) -> Utf8Co
     utf8_len
 }
 
-/// A `Chars`-like iterator for [`TextInput`].
-pub(crate) struct TextInputChars<'a, T: ClipboardProvider> {
-    /// The underlying [`TextInput`] of this iteration.
-    text_input: &'a TextInput<T>,
-    /// The `TextPoint` of the next character to be produced.
-    current_point: TextPoint,
-}
-
-impl<'a, T: ClipboardProvider> Iterator for TextInputChars<'a, T> {
-    type Item = char;
-
-    fn next(&mut self) -> Option<Self::Item> {
-        let num_lines = self.text_input.lines.len();
-        if self.current_point.line >= num_lines {
-            return None;
-        }
-
-        let line = &self.text_input.lines[self.current_point.line];
-
-        // Return a `\n` at the end of every line except the last one.
-        if self.current_point.index == line.len_utf8() && self.current_point.line + 1 < num_lines {
-            self.current_point.index += Utf8CodeUnitLength(1);
-            return Some('\n');
-        }
-        if self.current_point.index >= line.len_utf8() {
-            self.current_point.line += 1;
-            self.current_point.index = Utf8CodeUnitLength::zero();
-            return self.next();
-        }
-
-        assert!(self.current_point.line < self.text_input.lines.len());
-        let character = line.str()[self.current_point.index.0..].chars().nth(0);
-        self.current_point.index += Utf8CodeUnitLength(character.map(char::len_utf8).unwrap_or(1));
-        character
-    }
-}
-
 impl<T: ClipboardProvider> TextInput<T> {
     /// Instantiate a new text input control
     pub fn new(
@@ -310,32 +228,29 @@ impl<T: ClipboardProvider> TextInput<T> {
         min_length: Option<Utf16CodeUnitLength>,
         selection_direction: SelectionDirection,
     ) -> TextInput<T> {
-        let mut text_input = Self {
-            lines: vec![],
+        Self {
+            rope: Rope::new(initial, lines),
             edit_point: Default::default(),
             selection_origin: None,
-            multiline: lines == Lines::Multiple,
             clipboard_provider,
             max_length,
             min_length,
             selection_direction,
             was_last_change_by_set_content: true,
-        };
-        text_input.set_content(initial);
-        text_input
+        }
     }
 
-    pub fn edit_point(&self) -> TextPoint {
+    pub fn edit_point(&self) -> RopeIndex {
         self.edit_point
     }
 
-    pub fn selection_origin(&self) -> Option<TextPoint> {
+    pub fn selection_origin(&self) -> Option<RopeIndex> {
         self.selection_origin
     }
 
     /// The selection origin, or the edit point if there is no selection. Note that the selection
     /// origin may be after the edit point, in the case of a backward selection.
-    pub fn selection_origin_or_edit_point(&self) -> TextPoint {
+    pub fn selection_origin_or_edit_point(&self) -> RopeIndex {
         self.selection_origin.unwrap_or(self.edit_point)
     }
 
@@ -359,16 +274,21 @@ impl<T: ClipboardProvider> TextInput<T> {
     /// Remove a character at the current editing point
     ///
     /// Returns true if any character was deleted
-    pub fn delete_char(&mut self, dir: Direction) -> bool {
+    pub fn delete_char(&mut self, direction: Direction) -> bool {
         if self.selection_origin.is_none() || self.selection_origin == Some(self.edit_point) {
-            self.adjust_horizontal_by_one(dir, Selection::Selected);
+            let amount = match direction {
+                Direction::Forward => 1,
+                Direction::Backward => -1,
+            };
+            self.modify_selection(amount, RopeMovement::Grapheme);
         }
+
         if self.selection_start() == self.selection_end() {
-            false
-        } else {
-            self.replace_selection(&DOMString::new());
-            true
+            return false;
         }
+
+        self.replace_selection(&DOMString::new());
+        true
     }
 
     /// Insert a character at the current editing point
@@ -387,7 +307,7 @@ impl<T: ClipboardProvider> TextInput<T> {
 
     /// The start of the selection (or the edit point, if there is no selection). Always less than
     /// or equal to selection_end(), regardless of the selection direction.
-    pub fn selection_start(&self) -> TextPoint {
+    pub fn selection_start(&self) -> RopeIndex {
         match self.selection_direction {
             SelectionDirection::None | SelectionDirection::Forward => {
                 self.selection_origin_or_edit_point()
@@ -396,42 +316,37 @@ impl<T: ClipboardProvider> TextInput<T> {
         }
     }
 
+    pub(crate) fn selection_start_utf16(&self) -> Utf16CodeUnitLength {
+        self.rope.index_to_utf16_offset(self.selection_start())
+    }
+
     /// The byte offset of the selection_start()
-    pub fn selection_start_offset(&self) -> Utf8CodeUnitLength {
-        self.text_point_to_utf8_offset(self.selection_start())
+    fn selection_start_offset(&self) -> Utf8CodeUnitLength {
+        self.rope.index_to_utf8_offset(self.selection_start())
     }
 
     /// The end of the selection (or the edit point, if there is no selection). Always greater
     /// than or equal to selection_start(), regardless of the selection direction.
-    pub fn selection_end(&self) -> TextPoint {
+    pub fn selection_end(&self) -> RopeIndex {
         match self.selection_direction {
             SelectionDirection::None | SelectionDirection::Forward => self.edit_point,
             SelectionDirection::Backward => self.selection_origin_or_edit_point(),
         }
     }
 
-    /// The byte offset of the selection_end()
-    pub fn selection_end_offset(&self) -> Utf8CodeUnitLength {
-        self.text_point_to_utf8_offset(self.selection_end())
+    pub(crate) fn selection_end_utf16(&self) -> Utf16CodeUnitLength {
+        self.rope.index_to_utf16_offset(self.selection_end())
     }
 
-    pub(crate) fn chars<'a>(&'a self) -> TextInputChars<'a, T> {
-        TextInputChars {
-            text_input: self,
-            current_point: TextPoint::default(),
-        }
+    /// The byte offset of the selection_end()
+    pub fn selection_end_offset(&self) -> Utf8CodeUnitLength {
+        self.rope.index_to_utf8_offset(self.selection_end())
     }
 
     /// Whether or not there is an active selection (the selection may be zero-length)
     #[inline]
     pub(crate) fn has_selection(&self) -> bool {
         self.selection_origin.is_some()
-    }
-
-    /// Returns a tuple of (start, end) giving the bounds of the current selection. start is always
-    /// less than or equal to end.
-    pub fn sorted_selection_bounds(&self) -> (TextPoint, TextPoint) {
-        (self.selection_start(), self.selection_end())
     }
 
     /// Return the selection range as byte offsets from the start of the content.
@@ -456,25 +371,26 @@ impl<T: ClipboardProvider> TextInput<T> {
             "edit_point: {:?}, selection_origin: {:?}, direction: {:?}",
             self.edit_point, self.selection_origin, self.selection_direction
         );
-        if let Some(begin) = self.selection_origin {
-            debug_assert!(begin.line < self.lines.len());
-            debug_assert!(begin.index <= self.lines[begin.line].len_utf8());
 
+        debug_assert_eq!(self.edit_point, self.rope.clamp_index(self.edit_point));
+        if let Some(selection_origin) = self.selection_origin {
+            debug_assert_eq!(selection_origin, self.rope.clamp_index(selection_origin));
             match self.selection_direction {
                 SelectionDirection::None | SelectionDirection::Forward => {
-                    debug_assert!(begin <= self.edit_point)
+                    debug_assert!(selection_origin <= self.edit_point)
                 },
-
-                SelectionDirection::Backward => debug_assert!(self.edit_point <= begin),
+                SelectionDirection::Backward => debug_assert!(self.edit_point <= selection_origin),
             }
         }
+    }
 
-        debug_assert!(self.edit_point.line < self.lines.len());
-        debug_assert!(self.edit_point.index <= self.lines[self.edit_point.line].len_utf8());
+    fn selection_slice(&self) -> RopeSlice<'_> {
+        self.rope
+            .slice(Some(self.selection_start()), Some(self.selection_end()))
     }
 
     pub(crate) fn get_selection_text(&self) -> Option<String> {
-        let text = self.fold_selection_slices(String::new(), |s, slice| s.push_str(slice));
+        let text: String = self.selection_slice().into();
         if text.is_empty() {
             return None;
         }
@@ -483,37 +399,12 @@ impl<T: ClipboardProvider> TextInput<T> {
 
     /// The length of the selected text in UTF-16 code units.
     fn selection_utf16_len(&self) -> Utf16CodeUnitLength {
-        self.fold_selection_slices(Utf16CodeUnitLength::zero(), |len, slice| {
-            *len += Utf16CodeUnitLength(slice.chars().map(char::len_utf16).sum::<usize>())
-        })
-    }
-
-    /// Run the callback on a series of slices that, concatenated, make up the selected text.
-    ///
-    /// The accumulator `acc` can be mutated by the callback, and will be returned at the end.
-    fn fold_selection_slices<B, F: FnMut(&mut B, &str)>(&self, mut acc: B, mut f: F) -> B {
-        if self.has_selection() {
-            let (start, end) = self.sorted_selection_bounds();
-            let Utf8CodeUnitLength(start_offset) = start.index;
-            let Utf8CodeUnitLength(end_offset) = end.index;
-
-            if start.line == end.line {
-                f(
-                    &mut acc,
-                    &self.lines[start.line].str()[start_offset..end_offset],
-                )
-            } else {
-                f(&mut acc, &self.lines[start.line].str()[start_offset..]);
-                for line in &self.lines[start.line + 1..end.line] {
-                    f(&mut acc, "\n");
-                    f(&mut acc, &line.str());
-                }
-                f(&mut acc, "\n");
-                f(&mut acc, &self.lines[end.line].str()[..end_offset])
-            }
-        }
-
-        acc
+        Utf16CodeUnitLength(
+            self.selection_slice()
+                .chars()
+                .map(char::len_utf16)
+                .sum::<usize>(),
+        )
     }
 
     pub fn replace_selection(&mut self, insert: &DOMString) {
@@ -521,184 +412,72 @@ impl<T: ClipboardProvider> TextInput<T> {
             return;
         }
 
-        let allowed_to_insert_count = if let Some(max_length) = self.max_length {
-            let len_after_selection_replaced =
+        let string_to_insert = if let Some(max_length) = self.max_length {
+            let utf16_length_without_selection =
                 self.len_utf16().saturating_sub(self.selection_utf16_len());
-            max_length.saturating_sub(len_after_selection_replaced)
+            let utf16_length_that_can_be_inserted =
+                max_length.saturating_sub(utf16_length_without_selection);
+            let Utf8CodeUnitLength(last_char_index) =
+                len_of_first_n_code_units(insert, utf16_length_that_can_be_inserted);
+            &insert.str()[..last_char_index]
         } else {
-            Utf16CodeUnitLength(usize::MAX)
+            &insert.str()
         };
 
-        let Utf8CodeUnitLength(last_char_index) =
-            len_of_first_n_code_units(insert, allowed_to_insert_count);
-        let to_insert = &insert.str()[..last_char_index];
+        let start = self.selection_start();
+        let end = self.selection_end();
+        let end_index_of_insertion = self.rope.replace_range(start..end, string_to_insert);
 
-        let (start, end) = self.sorted_selection_bounds();
-        let Utf8CodeUnitLength(start_offset) = start.index;
-        let Utf8CodeUnitLength(end_offset) = end.index;
-
-        let new_lines = {
-            let prefix = &self.lines[start.line].str()[..start_offset];
-            let suffix = &self.lines[end.line].str()[end_offset..];
-            let lines_prefix = &self.lines[..start.line];
-            let lines_suffix = &self.lines[end.line + 1..];
-
-            let mut insert_lines = if self.multiline {
-                to_insert.split('\n').map(DOMString::from).collect()
-            } else {
-                vec![DOMString::from(to_insert)]
-            };
-
-            // FIXME(ajeffrey): efficient append for DOMStrings
-            let mut new_line = prefix.to_owned();
-
-            new_line.push_str(&insert_lines[0].str());
-            insert_lines[0] = DOMString::from(new_line);
-
-            let last_insert_lines_index = insert_lines.len() - 1;
-            self.edit_point.index = insert_lines[last_insert_lines_index].len_utf8();
-            self.edit_point.line = start.line + last_insert_lines_index;
-
-            // FIXME(ajeffrey): efficient append for DOMStrings
-            insert_lines[last_insert_lines_index].push_str(suffix);
-
-            let mut new_lines = vec![];
-            new_lines.extend_from_slice(lines_prefix);
-            new_lines.extend_from_slice(&insert_lines);
-            new_lines.extend_from_slice(lines_suffix);
-            new_lines
-        };
-
-        self.lines = new_lines;
         self.was_last_change_by_set_content = false;
         self.clear_selection();
-        self.assert_ok_selection();
+        self.edit_point = end_index_of_insertion;
     }
 
-    /// Return the length in bytes of the current line under the editing point.
-    pub fn current_line_length(&self) -> Utf8CodeUnitLength {
-        self.lines[self.edit_point.line].len_utf8()
-    }
-
-    /// Adjust the editing point position by a given number of lines. The resulting column is
-    /// as close to the original column position as possible.
-    pub fn adjust_vertical(&mut self, adjust: isize, select: Selection) {
-        if !self.multiline {
+    pub fn modify_edit_point(&mut self, amount: isize, movement: RopeMovement) {
+        if amount == 0 {
             return;
         }
 
-        if select == Selection::Selected {
-            if self.selection_origin.is_none() {
-                self.selection_origin = Some(self.edit_point);
-            }
-        } else {
+        // When moving by lines or if we do not have a selection, we do actually move
+        // the edit point from its position.
+        if matches!(movement, RopeMovement::Line) || !self.has_selection() {
             self.clear_selection();
-        }
-
-        assert!(self.edit_point.line < self.lines.len());
-
-        let target_line: isize = self.edit_point.line as isize + adjust;
-
-        if target_line < 0 {
-            self.edit_point.line = 0;
-            self.edit_point.index = Utf8CodeUnitLength::zero();
-            if self.selection_origin.is_some() &&
-                (self.selection_direction == SelectionDirection::None ||
-                    self.selection_direction == SelectionDirection::Forward)
-            {
-                self.selection_origin = Some(TextPoint {
-                    line: 0,
-                    index: Utf8CodeUnitLength::zero(),
-                });
-            }
-            return;
-        } else if target_line as usize >= self.lines.len() {
-            self.edit_point.line = self.lines.len() - 1;
-            self.edit_point.index = self.current_line_length();
-            if self.selection_origin.is_some() &&
-                (self.selection_direction == SelectionDirection::Backward)
-            {
-                self.selection_origin = Some(self.edit_point);
-            }
+            self.edit_point = self.rope.move_by(self.edit_point, movement, amount);
             return;
         }
 
-        let Utf8CodeUnitLength(edit_index) = self.edit_point.index;
-        let col = self.lines[self.edit_point.line].str()[..edit_index]
-            .chars()
-            .count();
-        self.edit_point.line = target_line as usize;
-        // NOTE: this adjusts to the nearest complete Unicode codepoint, rather than grapheme cluster
-        self.edit_point.index = len_of_first_n_chars(&self.lines[self.edit_point.line], col);
-        if let Some(origin) = self.selection_origin {
-            if ((self.selection_direction == SelectionDirection::None ||
-                self.selection_direction == SelectionDirection::Forward) &&
-                self.edit_point <= origin) ||
-                (self.selection_direction == SelectionDirection::Backward &&
-                    origin <= self.edit_point)
-            {
-                self.selection_origin = Some(self.edit_point);
-            }
-        }
-        self.assert_ok_selection();
+        // If there's a selection and we are moving by words or characters, we just collapse
+        // the selection in the direction of the motion.
+        let new_edit_point = if amount > 0 {
+            self.selection_end()
+        } else {
+            self.selection_start()
+        };
+        self.clear_selection();
+        self.edit_point = new_edit_point;
     }
 
-    /// Adjust the editing point position by a given number of bytes. If the adjustment
-    /// requested is larger than is available in the current line, the editing point is
-    /// adjusted vertically and the process repeats with the remaining adjustment requested.
-    pub fn adjust_horizontal(
+    pub fn modify_selection(&mut self, amount: isize, movement: RopeMovement) {
+        let old_edit_point = self.edit_point;
+        self.edit_point = self.rope.move_by(old_edit_point, movement, amount);
+
+        if self.selection_origin.is_none() {
+            self.selection_origin = Some(old_edit_point);
+        }
+        self.update_selection_direction();
+    }
+
+    pub fn modify_selection_or_edit_point(
         &mut self,
-        adjust: Utf8CodeUnitLength,
-        direction: Direction,
+        amount: isize,
+        movement: RopeMovement,
         select: Selection,
     ) {
-        if self.adjust_selection_for_horizontal_change(direction, select) {
-            return;
+        match select {
+            Selection::Selected => self.modify_selection(amount, movement),
+            Selection::NotSelected => self.modify_edit_point(amount, movement),
         }
-        self.perform_horizontal_adjustment(adjust, direction, select);
-    }
-
-    /// Adjust the editing point position by exactly one grapheme cluster. If the edit point
-    /// is at the beginning of the line and the direction is "Backward" or the edit point is at
-    /// the end of the line and the direction is "Forward", a vertical adjustment is made
-    pub fn adjust_horizontal_by_one(&mut self, direction: Direction, select: Selection) {
-        if self.adjust_selection_for_horizontal_change(direction, select) {
-            return;
-        }
-        let adjust = {
-            let current_line = self.lines[self.edit_point.line].str();
-            let Utf8CodeUnitLength(current_offset) = self.edit_point.index;
-            let next_ch = match direction {
-                Direction::Forward => current_line[current_offset..].graphemes(true).next(),
-                Direction::Backward => current_line[..current_offset].graphemes(true).next_back(),
-            };
-            match next_ch {
-                Some(c) => Utf8CodeUnitLength(c.len()),
-                None => Utf8CodeUnitLength::one(), // Going to the next line is a "one byte" offset
-            }
-        };
-        self.perform_horizontal_adjustment(adjust, direction, select);
-    }
-
-    /// Return whether to cancel the caret move
-    fn adjust_selection_for_horizontal_change(
-        &mut self,
-        adjust: Direction,
-        select: Selection,
-    ) -> bool {
-        if select == Selection::Selected {
-            if self.selection_origin.is_none() {
-                self.selection_origin = Some(self.edit_point);
-            }
-        } else if self.has_selection() {
-            self.edit_point = match adjust {
-                Direction::Backward => self.selection_start(),
-                Direction::Forward => self.selection_end(),
-            };
-            self.clear_selection();
-            return true;
-        }
-        false
+        self.assert_ok_selection();
     }
 
     /// Update the field selection_direction.
@@ -717,76 +496,25 @@ impl<T: ClipboardProvider> TextInput<T> {
         }
     }
 
-    fn perform_horizontal_adjustment(
-        &mut self,
-        adjust: Utf8CodeUnitLength,
-        direction: Direction,
-        select: Selection,
-    ) {
-        match direction {
-            Direction::Backward => {
-                let remaining = self.edit_point.index;
-                if adjust > remaining && self.edit_point.line > 0 {
-                    // Preserve the current selection origin because `adjust_vertical`
-                    // modifies `selection_origin`. Since we are moving backward instead of
-                    // highlighting vertically, we need to restore it after adjusting the line.
-                    let selection_origin_temp = self.selection_origin;
-                    self.adjust_vertical(-1, select);
-                    self.edit_point.index = self.current_line_length();
-                    // Restore the original selection origin to maintain expected behavior.
-                    self.selection_origin = selection_origin_temp;
-                    // one shift is consumed by the change of line, hence the -1
-                    self.adjust_horizontal(
-                        adjust.saturating_sub(remaining + Utf8CodeUnitLength::one()),
-                        direction,
-                        select,
-                    );
-                } else {
-                    self.edit_point.index = remaining.saturating_sub(adjust);
-                }
-            },
-            Direction::Forward => {
-                let remaining = self
-                    .current_line_length()
-                    .saturating_sub(self.edit_point.index);
-                if adjust > remaining && self.lines.len() > self.edit_point.line + 1 {
-                    self.adjust_vertical(1, select);
-                    self.edit_point.index = Utf8CodeUnitLength::zero();
-                    // one shift is consumed by the change of line, hence the -1
-                    self.adjust_horizontal(
-                        adjust.saturating_sub(remaining + Utf8CodeUnitLength::one()),
-                        direction,
-                        select,
-                    );
-                } else {
-                    self.edit_point.index =
-                        min(self.current_line_length(), self.edit_point.index + adjust);
-                }
-            },
-        };
-        self.update_selection_direction();
-        self.assert_ok_selection();
-    }
-
     /// Deal with a newline input.
     pub fn handle_return(&mut self) -> KeyReaction {
-        if !self.multiline {
-            KeyReaction::TriggerDefaultAction
-        } else {
-            self.insert_char('\n');
-            KeyReaction::DispatchInput(None, IsComposing::NotComposing, InputType::InsertLineBreak)
+        match self.rope.mode() {
+            Lines::Multiple => {
+                self.insert_char('\n');
+                KeyReaction::DispatchInput(
+                    None,
+                    IsComposing::NotComposing,
+                    InputType::InsertLineBreak,
+                )
+            },
+            Lines::Single => KeyReaction::TriggerDefaultAction,
         }
     }
 
     /// Select all text in the input control.
     pub fn select_all(&mut self) {
-        self.selection_origin = Some(TextPoint {
-            line: 0,
-            index: Utf8CodeUnitLength::zero(),
-        });
-        let last_line = self.lines.len() - 1;
-        self.edit_point.line = last_line;
-        self.edit_point.index = self.lines[last_line].len_utf8();
+        self.selection_origin = Some(RopeIndex::default());
+        self.edit_point = self.rope.last_index();
         self.selection_direction = SelectionDirection::Forward;
         self.assert_ok_selection();
     }
@@ -798,114 +526,14 @@ impl<T: ClipboardProvider> TextInput<T> {
     }
 
     /// Remove the current selection and set the edit point to the end of the content.
-    pub(crate) fn clear_selection_to_limit(&mut self, direction: Direction) {
+    pub(crate) fn clear_selection_to_end(&mut self) {
         self.clear_selection();
-        self.adjust_horizontal_to_limit(direction, Selection::NotSelected);
+        self.edit_point = self.rope.last_index();
     }
 
-    pub fn adjust_horizontal_by_word(&mut self, direction: Direction, select: Selection) {
-        if self.adjust_selection_for_horizontal_change(direction, select) {
-            return;
-        }
-        let shift_increment: Utf8CodeUnitLength = {
-            let current_index = self.edit_point.index;
-            let current_line_index = self.edit_point.line;
-            let current_line = self.lines[current_line_index].str();
-            let mut newline_adjustment = Utf8CodeUnitLength::zero();
-            let mut shift_temp = Utf8CodeUnitLength::zero();
-            match direction {
-                Direction::Backward => {
-                    let previous_line = current_line_index
-                        .checked_sub(1)
-                        .and_then(|index| self.lines.get(index))
-                        .map(|s| s.str());
-
-                    let input: &str;
-                    if current_index == Utf8CodeUnitLength::zero() && current_line_index > 0 {
-                        input = previous_line.as_ref().unwrap();
-                        newline_adjustment = Utf8CodeUnitLength::one();
-                    } else {
-                        let Utf8CodeUnitLength(remaining) = current_index;
-                        input = &current_line[..remaining];
-                    }
-
-                    let mut iter = input.split_word_bounds().rev();
-                    loop {
-                        match iter.next() {
-                            None => break,
-                            Some(x) => {
-                                shift_temp += Utf8CodeUnitLength(x.len());
-                                if x.chars().any(|x| x.is_alphabetic() || x.is_numeric()) {
-                                    break;
-                                }
-                            },
-                        }
-                    }
-                },
-                Direction::Forward => {
-                    let input: &str;
-                    let next_line = self.lines.get(current_line_index + 1).map(|s| s.str());
-                    let remaining = self.current_line_length().saturating_sub(current_index);
-                    if remaining == Utf8CodeUnitLength::zero() &&
-                        self.lines.len() > self.edit_point.line + 1
-                    {
-                        input = next_line.as_ref().unwrap();
-                        newline_adjustment = Utf8CodeUnitLength::one();
-                    } else {
-                        let Utf8CodeUnitLength(current_offset) = current_index;
-                        input = &current_line[current_offset..];
-                    }
-
-                    let mut iter = input.split_word_bounds();
-                    loop {
-                        match iter.next() {
-                            None => break,
-                            Some(x) => {
-                                shift_temp += Utf8CodeUnitLength(x.len());
-                                if x.chars().any(|x| x.is_alphabetic() || x.is_numeric()) {
-                                    break;
-                                }
-                            },
-                        }
-                    }
-                },
-            };
-
-            shift_temp + newline_adjustment
-        };
-
-        self.adjust_horizontal(shift_increment, direction, select);
-    }
-
-    pub fn adjust_horizontal_to_line_end(&mut self, direction: Direction, select: Selection) {
-        if self.adjust_selection_for_horizontal_change(direction, select) {
-            return;
-        }
-        let shift: usize = {
-            let current_line = &self.lines[self.edit_point.line];
-            let Utf8CodeUnitLength(current_offset) = self.edit_point.index;
-            match direction {
-                Direction::Backward => current_line.str()[..current_offset].len(),
-                Direction::Forward => current_line.str()[current_offset..].len(),
-            }
-        };
-        self.perform_horizontal_adjustment(Utf8CodeUnitLength(shift), direction, select);
-    }
-
-    pub(crate) fn adjust_horizontal_to_limit(&mut self, direction: Direction, select: Selection) {
-        if self.adjust_selection_for_horizontal_change(direction, select) {
-            return;
-        }
-        match direction {
-            Direction::Backward => {
-                self.edit_point.line = 0;
-                self.edit_point.index = Utf8CodeUnitLength::zero();
-            },
-            Direction::Forward => {
-                self.edit_point.line = &self.lines.len() - 1;
-                self.edit_point.index = (self.lines[&self.lines.len() - 1]).len_utf8();
-            },
-        }
+    pub(crate) fn clear_selection_to_start(&mut self) {
+        self.clear_selection();
+        self.edit_point = Default::default();
     }
 
     /// Process a given `KeyboardEvent` and return an action for the caller to execute.
@@ -931,27 +559,27 @@ impl<T: ClipboardProvider> TextInput<T> {
         mods.remove(Modifiers::SHIFT);
         ShortcutMatcher::new(KeyState::Down, key.clone(), mods)
             .shortcut(Modifiers::CONTROL | Modifiers::ALT, 'B', || {
-                self.adjust_horizontal_by_word(Direction::Backward, maybe_select);
+                self.modify_selection_or_edit_point(-1, RopeMovement::Word, maybe_select);
                 KeyReaction::RedrawSelection
             })
             .shortcut(Modifiers::CONTROL | Modifiers::ALT, 'F', || {
-                self.adjust_horizontal_by_word(Direction::Forward, maybe_select);
+                self.modify_selection_or_edit_point(1, RopeMovement::Word, maybe_select);
                 KeyReaction::RedrawSelection
             })
             .shortcut(Modifiers::CONTROL | Modifiers::ALT, 'A', || {
-                self.adjust_horizontal_to_line_end(Direction::Backward, maybe_select);
+                self.modify_selection_or_edit_point(-1, RopeMovement::LineStartOrEnd, maybe_select);
                 KeyReaction::RedrawSelection
             })
             .shortcut(Modifiers::CONTROL | Modifiers::ALT, 'E', || {
-                self.adjust_horizontal_to_line_end(Direction::Forward, maybe_select);
+                self.modify_selection_or_edit_point(1, RopeMovement::LineStartOrEnd, maybe_select);
                 KeyReaction::RedrawSelection
             })
             .optional_shortcut(macos, Modifiers::CONTROL, 'A', || {
-                self.adjust_horizontal_to_line_end(Direction::Backward, maybe_select);
+                self.modify_selection_or_edit_point(-1, RopeMovement::LineStartOrEnd, maybe_select);
                 KeyReaction::RedrawSelection
             })
             .optional_shortcut(macos, Modifiers::CONTROL, 'E', || {
-                self.adjust_horizontal_to_line_end(Direction::Forward, maybe_select);
+                self.modify_selection_or_edit_point(1, RopeMovement::LineStartOrEnd, maybe_select);
                 KeyReaction::RedrawSelection
             })
             .shortcut(CMD_OR_CONTROL, 'A', || {
@@ -1015,7 +643,11 @@ impl<T: ClipboardProvider> TextInput<T> {
                 Modifiers::META,
                 Key::Named(NamedKey::ArrowLeft),
                 || {
-                    self.adjust_horizontal_to_line_end(Direction::Backward, maybe_select);
+                    self.modify_selection_or_edit_point(
+                        -1,
+                        RopeMovement::LineStartOrEnd,
+                        maybe_select,
+                    );
                     KeyReaction::RedrawSelection
                 },
             )
@@ -1024,7 +656,11 @@ impl<T: ClipboardProvider> TextInput<T> {
                 Modifiers::META,
                 Key::Named(NamedKey::ArrowRight),
                 || {
-                    self.adjust_horizontal_to_line_end(Direction::Forward, maybe_select);
+                    self.modify_selection_or_edit_point(
+                        1,
+                        RopeMovement::LineStartOrEnd,
+                        maybe_select,
+                    );
                     KeyReaction::RedrawSelection
                 },
             )
@@ -1033,7 +669,11 @@ impl<T: ClipboardProvider> TextInput<T> {
                 Modifiers::META,
                 Key::Named(NamedKey::ArrowUp),
                 || {
-                    self.adjust_horizontal_to_limit(Direction::Backward, maybe_select);
+                    self.modify_selection_or_edit_point(
+                        -1,
+                        RopeMovement::RopeStartOrEnd,
+                        maybe_select,
+                    );
                     KeyReaction::RedrawSelection
                 },
             )
@@ -1042,32 +682,36 @@ impl<T: ClipboardProvider> TextInput<T> {
                 Modifiers::META,
                 Key::Named(NamedKey::ArrowDown),
                 || {
-                    self.adjust_horizontal_to_limit(Direction::Forward, maybe_select);
+                    self.modify_selection_or_edit_point(
+                        1,
+                        RopeMovement::RopeStartOrEnd,
+                        maybe_select,
+                    );
                     KeyReaction::RedrawSelection
                 },
             )
             .shortcut(Modifiers::ALT, Key::Named(NamedKey::ArrowLeft), || {
-                self.adjust_horizontal_by_word(Direction::Backward, maybe_select);
+                self.modify_selection_or_edit_point(-1, RopeMovement::Word, maybe_select);
                 KeyReaction::RedrawSelection
             })
             .shortcut(Modifiers::ALT, Key::Named(NamedKey::ArrowRight), || {
-                self.adjust_horizontal_by_word(Direction::Forward, maybe_select);
+                self.modify_selection_or_edit_point(1, RopeMovement::Word, maybe_select);
                 KeyReaction::RedrawSelection
             })
             .shortcut(Modifiers::empty(), Key::Named(NamedKey::ArrowLeft), || {
-                self.adjust_horizontal_by_one(Direction::Backward, maybe_select);
+                self.modify_selection_or_edit_point(-1, RopeMovement::Grapheme, maybe_select);
                 KeyReaction::RedrawSelection
             })
             .shortcut(Modifiers::empty(), Key::Named(NamedKey::ArrowRight), || {
-                self.adjust_horizontal_by_one(Direction::Forward, maybe_select);
+                self.modify_selection_or_edit_point(1, RopeMovement::Grapheme, maybe_select);
                 KeyReaction::RedrawSelection
             })
             .shortcut(Modifiers::empty(), Key::Named(NamedKey::ArrowUp), || {
-                self.adjust_vertical(-1, maybe_select);
+                self.modify_selection_or_edit_point(-1, RopeMovement::Line, maybe_select);
                 KeyReaction::RedrawSelection
             })
             .shortcut(Modifiers::empty(), Key::Named(NamedKey::ArrowDown), || {
-                self.adjust_vertical(1, maybe_select);
+                self.modify_selection_or_edit_point(1, RopeMovement::Line, maybe_select);
                 KeyReaction::RedrawSelection
             })
             .shortcut(Modifiers::empty(), Key::Named(NamedKey::Enter), || {
@@ -1078,21 +722,24 @@ impl<T: ClipboardProvider> TextInput<T> {
                 Modifiers::empty(),
                 Key::Named(NamedKey::Home),
                 || {
-                    self.edit_point.index = Utf8CodeUnitLength::zero();
+                    self.modify_selection_or_edit_point(
+                        -1,
+                        RopeMovement::RopeStartOrEnd,
+                        maybe_select,
+                    );
                     KeyReaction::RedrawSelection
                 },
             )
             .optional_shortcut(macos, Modifiers::empty(), Key::Named(NamedKey::End), || {
-                self.edit_point.index = self.current_line_length();
-                self.assert_ok_selection();
+                self.modify_selection_or_edit_point(1, RopeMovement::RopeStartOrEnd, maybe_select);
                 KeyReaction::RedrawSelection
             })
             .shortcut(Modifiers::empty(), Key::Named(NamedKey::PageUp), || {
-                self.adjust_vertical(-28, maybe_select);
+                self.modify_selection_or_edit_point(-28, RopeMovement::Line, maybe_select);
                 KeyReaction::RedrawSelection
             })
             .shortcut(Modifiers::empty(), Key::Named(NamedKey::PageDown), || {
-                self.adjust_vertical(28, maybe_select);
+                self.modify_selection_or_edit_point(28, RopeMovement::Line, maybe_select);
                 KeyReaction::RedrawSelection
             })
             .otherwise(|| {
@@ -1144,162 +791,29 @@ impl<T: ClipboardProvider> TextInput<T> {
 
     /// Whether the content is empty.
     pub(crate) fn is_empty(&self) -> bool {
-        self.lines.len() <= 1 && self.lines.first().is_none_or(|line| line.is_empty())
+        self.rope.is_empty()
     }
 
     /// The total number of code units required to encode the content in utf16.
     pub(crate) fn len_utf16(&self) -> Utf16CodeUnitLength {
-        Utf16CodeUnitLength(self.chars().map(char::len_utf16).sum())
+        self.rope.len_utf16()
     }
 
     /// Get the current contents of the text input. Multiple lines are joined by \n.
     pub fn get_content(&self) -> DOMString {
-        let mut content = "".to_owned();
-        for (i, line) in self.lines.iter().enumerate() {
-            content.push_str(&line.str());
-            if i < self.lines.len() - 1 {
-                content.push('\n');
-            }
-        }
-        DOMString::from(content)
-    }
-
-    /// Get a reference to the contents of a single-line text input. Panics if self is a multiline input.
-    pub(crate) fn single_line_content(&self) -> &DOMString {
-        assert!(!self.multiline);
-        &self.lines[0]
+        self.rope.contents().into()
     }
 
     /// Set the current contents of the text input. If this is control supports multiple lines,
     /// any \n encountered will be stripped and force a new logical line.
     pub fn set_content(&mut self, content: DOMString) {
-        self.lines = if self.multiline {
-            // https://html.spec.whatwg.org/multipage/#textarea-line-break-normalisation-transformation
-            content
-                .str()
-                .replace("\r\n", "\n")
-                .split(['\n', '\r'])
-                .map(DOMString::from)
-                .collect()
-        } else {
-            vec![content]
-        };
-
+        self.rope = Rope::new(content, self.rope.mode());
         self.was_last_change_by_set_content = true;
-        self.edit_point = self.edit_point.constrain_to(&self.lines);
 
-        if let Some(origin) = self.selection_origin {
-            self.selection_origin = Some(origin.constrain_to(&self.lines));
-        }
-        self.assert_ok_selection();
-    }
-
-    /// Given a [`TextPoint`] normalize it, meaning that its indices are all bounded
-    /// by the actual size of the value stored in this [`TextInput`].
-    fn normalize_text_point(&self, text_point: TextPoint) -> TextPoint {
-        let line = match self.lines.len() {
-            0 => return Default::default(),
-            num_lines => text_point.line.min(num_lines - 1),
-        };
-
-        // This may appear a bit odd as we are adding an index to the end of the line,
-        // but `TextPoint` isn't just an offset to a UTF-8 code point, but also can
-        // serve as the end of an exclusive range so there is one more index at the end
-        // that is still valid.
-        let mut line_length_utf8 = self.lines[line].len_utf8();
-        if line != self.lines.len() - 1 {
-            line_length_utf8 += Utf8CodeUnitLength(1); // Add a character for the '\n'.
-        }
-
-        TextPoint {
-            line,
-            index: text_point.index.min(line_length_utf8),
-        }
-    }
-
-    /// Convert a TextPoint into a byte offset from the start of the content.
-    pub fn text_point_to_utf8_offset(&self, text_point: TextPoint) -> Utf8CodeUnitLength {
-        let text_point = self.normalize_text_point(text_point);
-        self.lines
-            .iter()
-            .take(text_point.line)
-            .map(
-                |line| line.len_utf8() + Utf8CodeUnitLength::one(), // +1 for the \n
-            )
-            .sum::<Utf8CodeUnitLength>() +
-            text_point.index
-    }
-
-    pub fn text_point_to_utf16_offset(&self, text_point: TextPoint) -> Utf16CodeUnitLength {
-        let text_point = self.normalize_text_point(text_point);
-        let final_line = self.lines[text_point.line].str();
-
-        // The offset might be past the end of the line due to being an exclusive offset and
-        // also the fact that every line has a virtual newline at the end (apart from the last).
-        let (slice_length, extra_offset) = if text_point.index.0 > final_line.len() {
-            (final_line.len(), Utf16CodeUnitLength(1))
-        } else {
-            (text_point.index.0, Utf16CodeUnitLength::zero())
-        };
-        let final_line_offset = extra_offset +
-            Utf16CodeUnitLength(
-                final_line[0..slice_length]
-                    .chars()
-                    .map(char::len_utf16)
-                    .sum(),
-            );
-
-        self.lines
-            .iter()
-            .take(text_point.line)
-            .map(
-                |line| line.len_utf16() + Utf16CodeUnitLength::one(), // +1 for the \n
-            )
-            .sum::<Utf16CodeUnitLength>() +
-            final_line_offset
-    }
-
-    /// Convert a byte offset from the start of the content into a TextPoint.
-    fn utf8_offset_to_text_point(&self, abs_point: Utf8CodeUnitLength) -> TextPoint {
-        let mut index = abs_point;
-        let mut line = 0;
-        let last_line_idx = self.lines.len() - 1;
-        self.lines
-            .iter()
-            .enumerate()
-            .fold(Utf8CodeUnitLength::zero(), |acc, (i, val)| {
-                if i != last_line_idx {
-                    let line_end = val.len_utf8();
-                    let new_acc = acc + line_end + Utf8CodeUnitLength::one();
-                    if abs_point >= new_acc && index > line_end {
-                        index = index.saturating_sub(line_end + Utf8CodeUnitLength::one());
-                        line += 1;
-                    }
-                    new_acc
-                } else {
-                    acc
-                }
-            });
-
-        TextPoint { line, index }
-    }
-
-    pub fn utf16_offset_to_utf8_offset(
-        &self,
-        utf16_offset: Utf16CodeUnitLength,
-    ) -> Utf8CodeUnitLength {
-        let mut current_utf16_offset = Utf16CodeUnitLength::zero();
-        let mut current_utf8_offset = Utf8CodeUnitLength::zero();
-
-        for character in self.chars() {
-            let utf16_length = character.len_utf16();
-            if current_utf16_offset + Utf16CodeUnitLength(utf16_length) > utf16_offset {
-                return current_utf8_offset;
-            }
-            current_utf8_offset += Utf8CodeUnitLength(character.len_utf8());
-            current_utf16_offset += Utf16CodeUnitLength(utf16_length);
-        }
-        current_utf8_offset
+        self.edit_point = self.rope.clamp_index(self.edit_point());
+        self.selection_origin = self
+            .selection_origin
+            .map(|selection_origin| self.rope.clamp_index(selection_origin));
     }
 
     pub fn set_selection_range_utf16(
@@ -1309,8 +823,8 @@ impl<T: ClipboardProvider> TextInput<T> {
         direction: SelectionDirection,
     ) {
         self.set_selection_range_utf8(
-            self.utf16_offset_to_utf8_offset(start),
-            self.utf16_offset_to_utf8_offset(end),
+            self.rope.utf16_offset_to_utf8_offset(start),
+            self.rope.utf16_offset_to_utf8_offset(end),
             direction,
         );
     }
@@ -1333,27 +847,15 @@ impl<T: ClipboardProvider> TextInput<T> {
 
         match direction {
             SelectionDirection::None | SelectionDirection::Forward => {
-                self.selection_origin = Some(self.utf8_offset_to_text_point(start));
-                self.edit_point = self.utf8_offset_to_text_point(end);
+                self.selection_origin = Some(self.rope.utf8_offset_to_rope_index(start));
+                self.edit_point = self.rope.utf8_offset_to_rope_index(end);
             },
             SelectionDirection::Backward => {
-                self.selection_origin = Some(self.utf8_offset_to_text_point(end));
-                self.edit_point = self.utf8_offset_to_text_point(start);
+                self.selection_origin = Some(self.rope.utf8_offset_to_rope_index(end));
+                self.edit_point = self.rope.utf8_offset_to_rope_index(start);
             },
         }
         self.assert_ok_selection();
-    }
-
-    /// Set the edit point index position based off of a given grapheme cluster offset
-    pub fn set_edit_point_index(&mut self, index: usize) {
-        let byte_offset = self.lines[self.edit_point.line]
-            .str()
-            .graphemes(true)
-            .take(index)
-            .fold(Utf8CodeUnitLength::zero(), |acc, x| {
-                acc + Utf8CodeUnitLength(x.len())
-            });
-        self.edit_point.index = byte_offset;
     }
 
     /// This implements step 3 onward from:

--- a/components/shared/base/Cargo.toml
+++ b/components/shared/base/Cargo.toml
@@ -27,6 +27,7 @@ time = { workspace = true }
 webrender_api = { workspace = true }
 log = { workspace = true }
 regex = { workspace = true }
+unicode-segmentation = { workspace = true }
 
 [target.'cfg(any(target_os = "macos", target_os = "ios"))'.dependencies]
 mach2 = { workspace = true }

--- a/components/shared/base/lib.rs
+++ b/components/shared/base/lib.rs
@@ -13,6 +13,7 @@ pub mod cross_process_instant;
 pub mod generic_channel;
 pub mod id;
 pub mod print_tree;
+mod rope;
 pub mod text;
 pub mod threadpool;
 mod unicode_block;
@@ -24,6 +25,7 @@ use std::path::Path;
 use ipc_channel::ipc::{IpcError, IpcSender};
 use log::{trace, warn};
 use malloc_size_of_derive::MallocSizeOf;
+pub use rope::{Lines, Rope, RopeChars, RopeIndex, RopeMovement, RopeSlice};
 use serde::{Deserialize, Serialize};
 use webrender_api::Epoch as WebRenderEpoch;
 

--- a/components/shared/base/rope.rs
+++ b/components/shared/base/rope.rs
@@ -1,0 +1,722 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+use std::iter::once;
+use std::ops::Range;
+
+use malloc_size_of_derive::MallocSizeOf;
+use rayon::iter::Either;
+use unicode_segmentation::UnicodeSegmentation;
+
+use crate::text::{Utf8CodeUnitLength, Utf16CodeUnitLength};
+
+#[derive(Clone, Copy, MallocSizeOf)]
+pub enum Lines {
+    Single,
+    Multiple,
+}
+
+impl Lines {
+    fn contents_vec(&self, contents: impl Into<String>) -> Vec<String> {
+        match self {
+            Self::Multiple => {
+                // https://html.spec.whatwg.org/multipage/#textarea-line-break-normalisation-transformation
+                let mut contents: Vec<_> = contents
+                    .into()
+                    .replace("\r\n", "\n")
+                    .split(['\n', '\r'])
+                    .map(|line| format!("{line}\n"))
+                    .collect();
+                // The last line should not have a newline.
+                if let Some(last_line) = contents.last_mut() {
+                    last_line.truncate(last_line.len() - 1);
+                }
+                contents
+            },
+            Self::Single => {
+                vec![contents.into()]
+            },
+        }
+    }
+}
+
+/// Describes a unit of movement for [`Rope::move_by`].
+pub enum RopeMovement {
+    Grapheme,
+    Word,
+    Line,
+    LineStartOrEnd,
+    RopeStartOrEnd,
+}
+
+/// An implementation of a [rope data structure], composed of lines of
+/// owned strings. This is used to implement text controls in Servo.
+///
+/// [rope data structure]: https://en.wikipedia.org/wiki/Rope_(data_structure)
+#[derive(MallocSizeOf)]
+pub struct Rope {
+    /// The lines of the rope. Each line is an owned string that ends with a newline
+    /// (`\n`), apart from the last line which has no trailing newline.
+    lines: Vec<String>,
+    /// The type of [`Rope`] this is. When in multi-line mode, the [`Rope`] will
+    /// automatically split all inserted text into lines and incorporate them into
+    /// the [`Rope`]. When in single line mode, the inserted text should not have any
+    /// newlines.
+    mode: Lines,
+}
+
+impl Rope {
+    pub fn new(contents: impl Into<String>, mode: Lines) -> Self {
+        Self {
+            lines: mode.contents_vec(contents),
+            mode,
+        }
+    }
+
+    pub fn mode(&self) -> Lines {
+        self.mode
+    }
+
+    pub fn contents(&self) -> String {
+        self.lines.join("")
+    }
+
+    pub fn last_index(&self) -> RopeIndex {
+        let line_index = self.lines.len() - 1;
+        RopeIndex::new(line_index, self.line(line_index).len())
+    }
+
+    /// Replace the given range of [`RopeIndex`]s with the given string. Returns the
+    /// [`RopeIndex`] of the end of the insertion.
+    pub fn replace_range(
+        &mut self,
+        mut range: Range<RopeIndex>,
+        string: impl Into<String>,
+    ) -> RopeIndex {
+        range.start = self.clamp_index(range.start);
+        range.end = self.clamp_index(range.end);
+        assert!(range.start <= range.end);
+
+        let start_index = range.start;
+        self.delete_range(range);
+
+        let mut new_contents = self.mode.contents_vec(string);
+        let Some(first_line_of_new_contents) = new_contents.first() else {
+            return start_index;
+        };
+
+        if new_contents.len() == 1 {
+            self.line_for_index_mut(start_index)
+                .insert_str(start_index.code_point, first_line_of_new_contents);
+            return RopeIndex::new(
+                start_index.line,
+                start_index.code_point + first_line_of_new_contents.len(),
+            );
+        }
+
+        let start_line = self.line_for_index_mut(start_index);
+        let last_line = new_contents.last().expect("Should have at least one line");
+        let last_index = RopeIndex::new(
+            start_index.line + new_contents.len().saturating_sub(1),
+            last_line.len(),
+        );
+
+        let remaining_string = start_line.split_off(start_index.code_point);
+        start_line.push_str(first_line_of_new_contents);
+        new_contents
+            .last_mut()
+            .expect("Should have at least one line")
+            .push_str(&remaining_string);
+
+        let splice_index = start_index.line + 1;
+        self.lines
+            .splice(splice_index..splice_index, new_contents.into_iter().skip(1));
+        last_index
+    }
+
+    fn delete_range(&mut self, mut range: Range<RopeIndex>) {
+        range.start = self.clamp_index(range.start);
+        range.end = self.clamp_index(range.end);
+        assert!(range.start <= range.end);
+
+        if range.start.line == range.end.line {
+            self.line_for_index_mut(range.start)
+                .replace_range(range.start.code_point..range.end.code_point, "");
+            return;
+        }
+
+        // Remove the start line and any before the last line.
+        let removed_lines = self.lines.splice(range.start.line..range.end.line, []);
+        let first_line = removed_lines
+            .into_iter()
+            .nth(0)
+            .expect("Should have removed at least one line");
+
+        let first_line_prefix = &first_line[0..range.start.code_point];
+        let new_end_line = range.start.line;
+        self.lines[new_end_line].replace_range(0..range.end.code_point, first_line_prefix);
+    }
+
+    /// Create a [`RopeSlice`] for this [`Rope`] from `start` to `end`. If either of
+    /// these is `None`, then the slice will extend to the extent of the rope.
+    pub fn slice<'a>(&'a self, start: Option<RopeIndex>, end: Option<RopeIndex>) -> RopeSlice<'a> {
+        RopeSlice {
+            rope: self,
+            start: start.unwrap_or_default(),
+            end: end.unwrap_or_else(|| self.last_index()),
+        }
+    }
+
+    pub fn chars<'a>(&'a self) -> RopeChars<'a> {
+        self.slice(None, None).chars()
+    }
+
+    /// Return `true` if the [`Rope`] is empty or false otherwise. This will also
+    /// return `true` if the contents of the [`Rope`] are a single empty line.
+    pub fn is_empty(&self) -> bool {
+        self.lines.first().is_none_or(String::is_empty)
+    }
+
+    /// The total number of code units required to encode the content in utf16.
+    pub fn len_utf16(&self) -> Utf16CodeUnitLength {
+        Utf16CodeUnitLength(self.chars().map(char::len_utf16).sum())
+    }
+
+    fn line(&self, index: usize) -> &str {
+        &self.lines[index]
+    }
+
+    fn line_for_index(&self, index: RopeIndex) -> &String {
+        &self.lines[index.line]
+    }
+
+    fn line_for_index_mut(&mut self, index: RopeIndex) -> &mut String {
+        &mut self.lines[index.line]
+    }
+
+    fn last_index_in_line(&self, line: usize) -> RopeIndex {
+        if line >= self.lines.len() - 1 {
+            return self.last_index();
+        }
+        RopeIndex {
+            line,
+            code_point: self.line(line).len() - 1,
+        }
+    }
+
+    /// Return a [`RopeIndex`] which points to the start of the subsequent line.
+    /// If the given [`RopeIndex`] is already on the final line, this will return
+    /// the final index of the entire [`Rope`].
+    fn start_of_following_line(&self, index: RopeIndex) -> RopeIndex {
+        if index.line >= self.lines.len() - 1 {
+            return self.last_index();
+        }
+        RopeIndex::new(index.line + 1, 0)
+    }
+
+    /// Return a [`RopeIndex`] which points to the end of preceding line. If already
+    /// at the end of the first line, this will return the start index of the entire
+    /// [`Rope`].
+    fn end_of_preceding_line(&self, index: RopeIndex) -> RopeIndex {
+        if index.line == 0 {
+            return Default::default();
+        }
+        let line_index = index.line.saturating_sub(1);
+        RopeIndex::new(line_index, self.line(line_index).len())
+    }
+
+    pub fn move_by(&self, origin: RopeIndex, unit: RopeMovement, amount: isize) -> RopeIndex {
+        if amount == 0 {
+            return origin;
+        }
+
+        match unit {
+            RopeMovement::Grapheme | RopeMovement::Word => {
+                self.move_by_iterator(origin, unit, amount)
+            },
+            RopeMovement::Line => self.move_by_lines(origin, amount),
+            RopeMovement::LineStartOrEnd => {
+                if amount >= 0 {
+                    self.last_index_in_line(origin.line)
+                } else {
+                    RopeIndex::new(origin.line, 0)
+                }
+            },
+            RopeMovement::RopeStartOrEnd => {
+                if amount >= 0 {
+                    self.last_index()
+                } else {
+                    Default::default()
+                }
+            },
+        }
+    }
+
+    fn move_by_lines(&self, origin: RopeIndex, lines_to_move: isize) -> RopeIndex {
+        let new_line_index = (origin.line as isize) + lines_to_move;
+        if new_line_index < 0 {
+            return Default::default();
+        }
+        if new_line_index > (self.lines.len() - 1) as isize {
+            return self.last_index();
+        }
+
+        let new_line_index = new_line_index.unsigned_abs();
+        let char_count = self.line(origin.line)[0..origin.code_point].chars().count();
+        let new_code_point_index = self
+            .line(new_line_index)
+            .char_indices()
+            .take(char_count)
+            .last()
+            .map(|(byte_index, character)| byte_index + character.len_utf8())
+            .unwrap_or_default();
+        RopeIndex::new(new_line_index, new_code_point_index)
+            .min(self.last_index_in_line(new_line_index))
+    }
+
+    fn move_by_iterator(&self, origin: RopeIndex, unit: RopeMovement, amount: isize) -> RopeIndex {
+        assert_ne!(amount, 0);
+        let (boundary_value, slice) = if amount > 0 {
+            (self.last_index(), self.slice(Some(origin), None))
+        } else {
+            (RopeIndex::default(), self.slice(None, Some(origin)))
+        };
+
+        let iterator = match unit {
+            RopeMovement::Grapheme => slice.grapheme_indices(),
+            RopeMovement::Word => slice.word_indices(),
+            _ => unreachable!("Should not be called for other movement types"),
+        };
+        let iterator = if amount > 0 {
+            Either::Left(iterator)
+        } else {
+            Either::Right(iterator.rev())
+        };
+
+        let mut iterations = amount.unsigned_abs();
+        for (mut index, _) in iterator {
+            iterations = iterations.saturating_sub(1);
+            if iterations == 0 {
+                // Instead of returning offsets for the absolute end of a line, return the
+                // start offset for the next line.
+                if index.code_point >= self.line_for_index(index).len() {
+                    index = self.start_of_following_line(index);
+                }
+                return index;
+            }
+        }
+
+        boundary_value
+    }
+
+    /// Given a [`RopeIndex`], clamp it, meaning that its indices are all bound by the
+    /// actual size of the line and the number of lines in this [`Rope`].
+    pub fn clamp_index(&self, rope_index: RopeIndex) -> RopeIndex {
+        let last_line = self.lines.len().saturating_sub(1);
+        let line_index = rope_index.line.min(last_line);
+
+        // This may appear a bit odd as we are adding an index to the end of the line,
+        // but `RopeIndex` isn't just an offset to a UTF-8 code point, but also can
+        // serve as the end of an exclusive range so there is one more index at the end
+        // that is still valid.
+        //
+        // Lines other than the last line have a trailing newline. We do not want to allow
+        // an index past the trailing newline.
+        let line_length_utf8 = if line_index == last_line {
+            self.lines[line_index].len()
+        } else {
+            self.lines[line_index].len() - 1
+        };
+
+        RopeIndex::new(line_index, rope_index.code_point.min(line_length_utf8))
+    }
+
+    /// Convert a [`RopeIndex`] into a byte offset from the start of the content.
+    pub fn index_to_utf8_offset(&self, rope_index: RopeIndex) -> Utf8CodeUnitLength {
+        let rope_index = self.clamp_index(rope_index);
+        Utf8CodeUnitLength(
+            self.lines
+                .iter()
+                .take(rope_index.line)
+                .map(String::len)
+                .sum::<usize>() +
+                rope_index.code_point,
+        )
+    }
+
+    pub fn index_to_utf16_offset(&self, rope_index: RopeIndex) -> Utf16CodeUnitLength {
+        let rope_index = self.clamp_index(rope_index);
+        let final_line = self.line(rope_index.line);
+
+        // The offset might be past the end of the line due to being an exclusive offset.
+        let final_line_offset = Utf16CodeUnitLength(
+            final_line[0..rope_index.code_point]
+                .chars()
+                .map(char::len_utf16)
+                .sum(),
+        );
+
+        self.lines
+            .iter()
+            .take(rope_index.line)
+            .map(|line| Utf16CodeUnitLength(line.chars().map(char::len_utf16).sum()))
+            .sum::<Utf16CodeUnitLength>() +
+            final_line_offset
+    }
+
+    /// Convert a byte offset from the start of the content into a [`RopeIndex`].
+    pub fn utf8_offset_to_rope_index(&self, utf8_offset: Utf8CodeUnitLength) -> RopeIndex {
+        let mut current_utf8_offset = utf8_offset.0;
+        for (line_index, line) in self.lines.iter().enumerate() {
+            if current_utf8_offset == 0 || current_utf8_offset < line.len() {
+                return RopeIndex::new(line_index, current_utf8_offset);
+            }
+            current_utf8_offset -= line.len();
+        }
+        self.last_index()
+    }
+
+    pub fn utf16_offset_to_utf8_offset(
+        &self,
+        utf16_offset: Utf16CodeUnitLength,
+    ) -> Utf8CodeUnitLength {
+        let mut current_utf16_offset = Utf16CodeUnitLength::zero();
+        let mut current_utf8_offset = Utf8CodeUnitLength::zero();
+
+        for character in self.chars() {
+            let utf16_length = character.len_utf16();
+            if current_utf16_offset + Utf16CodeUnitLength(utf16_length) > utf16_offset {
+                return current_utf8_offset;
+            }
+            current_utf8_offset += Utf8CodeUnitLength(character.len_utf8());
+            current_utf16_offset += Utf16CodeUnitLength(utf16_length);
+        }
+        current_utf8_offset
+    }
+}
+
+/// An index into a [`Rope`] data structure. Used to efficiently identify a particular
+/// position in a [`Rope`]. As [`Rope`] always uses Rust strings interally, code point
+/// indices represented in a [`RopeIndex`] are assumed to be UTF-8 code points (one byte
+/// each).
+///
+/// Note that it is possible for a [`RopeIndex`] to point past the end of the last line,
+/// as it can be used in exclusive ranges. In lines other than the last line, it should
+/// always refer to offsets before the trailing newline.
+#[derive(Clone, Copy, Debug, Default, Eq, MallocSizeOf, PartialEq, PartialOrd, Ord)]
+pub struct RopeIndex {
+    /// The index of the line that this [`RopeIndex`] refers to.
+    pub line: usize,
+    /// The index of the code point on the [`RopeIndex`]'s line in UTF-8 code
+    /// points.
+    ///
+    /// Note: This is not a `Utf8CodeUnitLength` in order to avoid continually having
+    /// to unpack the inner value.
+    pub code_point: usize,
+}
+
+impl RopeIndex {
+    pub fn new(line: usize, code_point: usize) -> Self {
+        Self { line, code_point }
+    }
+}
+
+/// A slice of a [`Rope`]. This can be used to to iterate over a subset of characters of a
+/// [`Rope`] or to return the content of the [`RopeSlice`] as a `String`.
+pub struct RopeSlice<'a> {
+    /// The underlying [`Rope`] of this [`RopeSlice`]
+    rope: &'a Rope,
+    /// The inclusive `RopeIndex` of the start of this [`RopeSlice`].
+    start: RopeIndex,
+    /// The exclusive end `RopeIndex` of this [`RopeSlice`].
+    end: RopeIndex,
+}
+
+impl From<RopeSlice<'_>> for String {
+    fn from(slice: RopeSlice<'_>) -> Self {
+        if slice.start.line == slice.end.line {
+            slice.rope.line_for_index(slice.start)[slice.start.code_point..slice.end.code_point]
+                .into()
+        } else {
+            once(&slice.rope.line_for_index(slice.start)[slice.start.code_point..])
+                .chain(
+                    (slice.start.line + 1..slice.end.line)
+                        .map(|line_index| slice.rope.line(line_index)),
+                )
+                .chain(once(
+                    &slice.rope.line_for_index(slice.end)[..slice.end.code_point],
+                ))
+                .collect()
+        }
+    }
+}
+
+impl<'a> RopeSlice<'a> {
+    pub fn chars(self) -> RopeChars<'a> {
+        RopeChars {
+            movement_iterator: RopeMovementIterator {
+                slice: self,
+                end_of_forward_motion: |_, string| {
+                    let (offset, character) = string.char_indices().next()?;
+                    Some((offset + character.len_utf8(), character))
+                },
+                start_of_backward_motion: |_, string: &str| string.char_indices().next_back(),
+            },
+        }
+    }
+
+    fn grapheme_indices(self) -> RopeMovementIterator<'a, &'a str> {
+        RopeMovementIterator {
+            slice: self,
+            end_of_forward_motion: |_, string| {
+                let (offset, grapheme) = string.grapheme_indices(true).next()?;
+                Some((offset + grapheme.len(), grapheme))
+            },
+            start_of_backward_motion: |_, string| string.grapheme_indices(true).next_back(),
+        }
+    }
+
+    fn word_indices(self) -> RopeMovementIterator<'a, &'a str> {
+        RopeMovementIterator {
+            slice: self,
+            end_of_forward_motion: |_, string| {
+                let (offset, word) = string.unicode_word_indices().next()?;
+                Some((offset + word.len(), word))
+            },
+            start_of_backward_motion: |_, string| string.unicode_word_indices().next_back(),
+        }
+    }
+}
+
+/// A generic movement iterator for a [`Rope`]. This can move in both directions. Note
+/// than when moving forward and backward, the indices returned for each unit are
+/// different. When moving forward, the end of the unit of movement is returned and when
+/// moving backward the start of the unit of movement is returned. This matches the
+/// expected behavior when interactively moving through editable text.
+struct RopeMovementIterator<'a, T> {
+    slice: RopeSlice<'a>,
+    end_of_forward_motion: fn(&RopeSlice, &'a str) -> Option<(usize, T)>,
+    start_of_backward_motion: fn(&RopeSlice, &'a str) -> Option<(usize, T)>,
+}
+
+impl<T> Iterator for RopeMovementIterator<'_, T> {
+    type Item = (RopeIndex, T);
+
+    fn next(&mut self) -> Option<Self::Item> {
+        // If the two indices have crossed over, iteration is done.
+        if self.slice.start >= self.slice.end {
+            return None;
+        }
+
+        assert!(self.slice.start.line < self.slice.rope.lines.len());
+        let line = self.slice.rope.line_for_index(self.slice.start);
+
+        if self.slice.start.code_point < line.len() + 1 {
+            if let Some((end_offset, value)) =
+                (self.end_of_forward_motion)(&self.slice, &line[self.slice.start.code_point..])
+            {
+                self.slice.start.code_point += end_offset;
+                return Some((self.slice.start, value));
+            }
+        }
+
+        // Advance the line as we are at the end of the line.
+        self.slice.start = self.slice.rope.start_of_following_line(self.slice.start);
+        self.next()
+    }
+}
+
+impl<T> DoubleEndedIterator for RopeMovementIterator<'_, T> {
+    fn next_back(&mut self) -> Option<Self::Item> {
+        // If the two indices have crossed over, iteration is done.
+        if self.slice.end <= self.slice.start {
+            return None;
+        }
+
+        let line = self.slice.rope.line_for_index(self.slice.end);
+        if self.slice.end.code_point > 0 {
+            if let Some((new_start_index, value)) =
+                (self.start_of_backward_motion)(&self.slice, &line[..self.slice.end.code_point])
+            {
+                self.slice.end.code_point = new_start_index;
+                return Some((self.slice.end, value));
+            }
+        }
+
+        // Decrease the line index as we are at the start of the line.
+        self.slice.end = self.slice.rope.end_of_preceding_line(self.slice.end);
+        self.next_back()
+    }
+}
+
+/// A `Chars`-like iterator for [`Rope`].
+pub struct RopeChars<'a> {
+    movement_iterator: RopeMovementIterator<'a, char>,
+}
+
+impl Iterator for RopeChars<'_> {
+    type Item = char;
+    fn next(&mut self) -> Option<Self::Item> {
+        Some(self.movement_iterator.next()?.1)
+    }
+}
+
+impl DoubleEndedIterator for RopeChars<'_> {
+    fn next_back(&mut self) -> Option<Self::Item> {
+        Some(self.movement_iterator.next_back()?.1)
+    }
+}
+
+#[test]
+fn test_rope_index_conversion_to_utf8_offset() {
+    let rope = Rope::new("A\nBB\nCCC\nDDDD", Lines::Multiple);
+    assert_eq!(
+        rope.index_to_utf8_offset(RopeIndex::new(0, 0)),
+        Utf8CodeUnitLength(0),
+    );
+    assert_eq!(
+        rope.index_to_utf8_offset(RopeIndex::new(0, 1)),
+        Utf8CodeUnitLength(1),
+    );
+    assert_eq!(
+        rope.index_to_utf8_offset(RopeIndex::new(0, 10)),
+        Utf8CodeUnitLength(1),
+        "RopeIndex with offset past the end of the line should return final offset in line",
+    );
+    assert_eq!(
+        rope.index_to_utf8_offset(RopeIndex::new(1, 0)),
+        Utf8CodeUnitLength(2),
+    );
+    assert_eq!(
+        rope.index_to_utf8_offset(RopeIndex::new(1, 2)),
+        Utf8CodeUnitLength(4),
+    );
+
+    assert_eq!(
+        rope.index_to_utf8_offset(RopeIndex::new(3, 0)),
+        Utf8CodeUnitLength(9),
+    );
+    assert_eq!(
+        rope.index_to_utf8_offset(RopeIndex::new(3, 3)),
+        Utf8CodeUnitLength(12),
+    );
+    assert_eq!(
+        rope.index_to_utf8_offset(RopeIndex::new(3, 4)),
+        Utf8CodeUnitLength(13),
+        "There should be no newline at the end of the TextInput",
+    );
+    assert_eq!(
+        rope.index_to_utf8_offset(RopeIndex::new(3, 40)),
+        Utf8CodeUnitLength(13),
+        "There should be no newline at the end of the TextInput",
+    );
+}
+
+#[test]
+fn test_rope_index_conversion_to_utf16_offset() {
+    let rope = Rope::new("A\nBB\nCCC\n家家", Lines::Multiple);
+    assert_eq!(
+        rope.index_to_utf16_offset(RopeIndex::new(0, 0)),
+        Utf16CodeUnitLength(0),
+    );
+    assert_eq!(
+        rope.index_to_utf16_offset(RopeIndex::new(0, 1)),
+        Utf16CodeUnitLength(1),
+    );
+    assert_eq!(
+        rope.index_to_utf16_offset(RopeIndex::new(0, 10)),
+        Utf16CodeUnitLength(1),
+        "RopeIndex with offset past the end of the line should return final offset in line",
+    );
+    assert_eq!(
+        rope.index_to_utf16_offset(RopeIndex::new(3, 0)),
+        Utf16CodeUnitLength(9),
+    );
+
+    assert_eq!(
+        rope.index_to_utf16_offset(RopeIndex::new(3, 3)),
+        Utf16CodeUnitLength(10),
+        "3 code unit UTF-8 encodede character"
+    );
+    assert_eq!(
+        rope.index_to_utf16_offset(RopeIndex::new(3, 6)),
+        Utf16CodeUnitLength(11),
+    );
+    assert_eq!(
+        rope.index_to_utf16_offset(RopeIndex::new(3, 20)),
+        Utf16CodeUnitLength(11),
+    );
+}
+
+#[test]
+fn test_utf16_offset_to_utf8_offset() {
+    let rope = Rope::new("A\nBB\nCCC\n家家", Lines::Multiple);
+    assert_eq!(
+        rope.utf16_offset_to_utf8_offset(Utf16CodeUnitLength(0)),
+        Utf8CodeUnitLength(0),
+    );
+    assert_eq!(
+        rope.utf16_offset_to_utf8_offset(Utf16CodeUnitLength(1)),
+        Utf8CodeUnitLength(1),
+    );
+    assert_eq!(
+        rope.utf16_offset_to_utf8_offset(Utf16CodeUnitLength(2)),
+        Utf8CodeUnitLength(2),
+        "Offset past the end of the line",
+    );
+    assert_eq!(
+        rope.utf16_offset_to_utf8_offset(Utf16CodeUnitLength(9)),
+        Utf8CodeUnitLength(9),
+    );
+
+    assert_eq!(
+        rope.utf16_offset_to_utf8_offset(Utf16CodeUnitLength(10)),
+        Utf8CodeUnitLength(12),
+        "3 code unit UTF-8 encodede character"
+    );
+    assert_eq!(
+        rope.utf16_offset_to_utf8_offset(Utf16CodeUnitLength(11)),
+        Utf8CodeUnitLength(15),
+    );
+    assert_eq!(
+        rope.utf16_offset_to_utf8_offset(Utf16CodeUnitLength(300)),
+        Utf8CodeUnitLength(15),
+    );
+}
+
+#[test]
+fn test_rope_delete_slice() {
+    let mut rope = Rope::new("ABC\nDEF\n", Lines::Multiple);
+    rope.delete_range(RopeIndex::new(0, 1)..RopeIndex::new(0, 2));
+    assert_eq!(rope.contents(), "AC\nDEF\n");
+
+    // Trying to delete beyond the last index of the line should note remove any trailing
+    // newlines from the rope.
+    let mut rope = Rope::new("ABC\nDEF\n", Lines::Multiple);
+    rope.delete_range(RopeIndex::new(0, 3)..RopeIndex::new(0, 4));
+    assert_eq!(rope.lines, ["ABC\n", "DEF\n", ""]);
+
+    let mut rope = Rope::new("ABC\nDEF\n", Lines::Multiple);
+    rope.delete_range(RopeIndex::new(0, 0)..RopeIndex::new(0, 4));
+    assert_eq!(rope.lines, ["\n", "DEF\n", ""]);
+
+    let mut rope = Rope::new("A\nBB\nCCC", Lines::Multiple);
+    rope.delete_range(RopeIndex::new(0, 2)..RopeIndex::new(1, 0));
+    assert_eq!(rope.lines, ["ABB\n", "CCC"]);
+}
+
+#[test]
+fn test_rope_replace_slice() {
+    let mut rope = Rope::new("AAA\nBBB\nCCC", Lines::Multiple);
+    rope.replace_range(RopeIndex::new(0, 1)..RopeIndex::new(0, 2), "x");
+    assert_eq!(rope.contents(), "AxA\nBBB\nCCC",);
+
+    let mut rope = Rope::new("A\nBB\nCCC", Lines::Multiple);
+    rope.replace_range(RopeIndex::new(0, 2)..RopeIndex::new(1, 0), "D");
+    assert_eq!(rope.lines, ["ADBB\n", "CCC"]);
+
+    let mut rope = Rope::new("AAA\nBBB\nCCC\nDDD", Lines::Multiple);
+    rope.replace_range(RopeIndex::new(0, 2)..RopeIndex::new(2, 1), "x");
+    assert_eq!(rope.lines, ["AAxCC\n", "DDD"]);
+}

--- a/tests/unit/script/textinput.rs
+++ b/tests/unit/script/textinput.rs
@@ -8,11 +8,10 @@
 // except according to those terms.
 
 use base::text::{Utf8CodeUnitLength, Utf16CodeUnitLength};
+use base::{Lines, RopeIndex, RopeMovement};
 use keyboard_types::{Key, Modifiers, NamedKey};
 use script::test::DOMString;
-use script::test::textinput::{
-    ClipboardProvider, Direction, Lines, Selection, SelectionDirection, TextInput, TextPoint,
-};
+use script::test::textinput::{ClipboardProvider, Direction, SelectionDirection, TextInput};
 
 pub struct DummyClipboardContext {
     content: String,
@@ -72,25 +71,15 @@ fn test_textinput_when_inserting_multiple_lines_over_a_selection_respects_max_le
         SelectionDirection::None,
     );
 
-    textinput.adjust_horizontal(
-        Utf8CodeUnitLength::one(),
-        Direction::Forward,
-        Selection::NotSelected,
-    );
-    textinput.adjust_horizontal(
-        Utf8CodeUnitLength(3),
-        Direction::Forward,
-        Selection::Selected,
-    );
-    textinput.adjust_vertical(1, Selection::Selected);
+    textinput.modify_edit_point(1, RopeMovement::Grapheme);
+    textinput.modify_selection(3, RopeMovement::Grapheme);
+    textinput.modify_selection(1, RopeMovement::Line);
 
     // Selection is now "hello\n
     //                    ------
     //                   world"
     //                   ----
-
-    textinput.insert_string("cruel\nterrible\nbad".to_string());
-
+    textinput.insert_string("cruel\nterrible\nbad");
     assert_eq!(textinput.get_content(), "hcruel\nterrible\nd");
 }
 
@@ -105,9 +94,8 @@ fn test_textinput_when_inserting_multiple_lines_still_respects_max_length() {
         SelectionDirection::None,
     );
 
-    textinput.adjust_vertical(1, Selection::NotSelected);
-    textinput.insert_string("cruel\nterrible".to_string());
-
+    textinput.modify_edit_point(1, RopeMovement::Line);
+    textinput.insert_string("cruel\nterrible");
     assert_eq!(textinput.get_content(), "hello\ncruel\nworld");
 }
 
@@ -157,16 +145,8 @@ fn test_single_line_textinput_with_max_length_doesnt_allow_appending_characters_
         SelectionDirection::None,
     );
 
-    textinput.adjust_horizontal(
-        Utf8CodeUnitLength::one(),
-        Direction::Forward,
-        Selection::NotSelected,
-    );
-    textinput.adjust_horizontal(
-        Utf8CodeUnitLength(3),
-        Direction::Forward,
-        Selection::Selected,
-    );
+    textinput.modify_edit_point(1, RopeMovement::Grapheme);
+    textinput.modify_selection(3, RopeMovement::Grapheme);
 
     // Selection is now "abcde"
     //                    ---
@@ -187,16 +167,8 @@ fn test_single_line_textinput_with_max_length_allows_deletion_when_replacing_a_s
         SelectionDirection::None,
     );
 
-    textinput.adjust_horizontal(
-        Utf8CodeUnitLength::one(),
-        Direction::Forward,
-        Selection::NotSelected,
-    );
-    textinput.adjust_horizontal(
-        Utf8CodeUnitLength(2),
-        Direction::Forward,
-        Selection::Selected,
-    );
+    textinput.modify_edit_point(1, RopeMovement::Grapheme);
+    textinput.modify_selection(2, RopeMovement::Grapheme);
 
     // Selection is now "abcde"
     //                    --
@@ -280,28 +252,20 @@ fn test_single_line_textinput_with_max_length_doesnt_allow_appending_characters_
 #[test]
 fn test_textinput_delete_char() {
     let mut textinput = text_input(Lines::Single, "abcdefg");
-    textinput.adjust_horizontal(
-        Utf8CodeUnitLength(2),
-        Direction::Forward,
-        Selection::NotSelected,
-    );
+    textinput.modify_edit_point(2, RopeMovement::Grapheme);
     textinput.delete_char(Direction::Backward);
     assert_eq!(textinput.get_content(), "acdefg");
 
     textinput.delete_char(Direction::Forward);
     assert_eq!(textinput.get_content(), "adefg");
 
-    textinput.adjust_horizontal(
-        Utf8CodeUnitLength(2),
-        Direction::Forward,
-        Selection::Selected,
-    );
+    textinput.modify_selection(2, RopeMovement::Grapheme);
     textinput.delete_char(Direction::Forward);
     assert_eq!(textinput.get_content(), "afg");
 
     let mut textinput = text_input(Lines::Single, "a🌠b");
     // Same as "Right" key
-    textinput.adjust_horizontal_by_one(Direction::Forward, Selection::NotSelected);
+    textinput.modify_edit_point(1, RopeMovement::Grapheme);
     textinput.delete_char(Direction::Forward);
     // Not splitting surrogate pairs.
     assert_eq!(textinput.get_content(), "ab");
@@ -319,74 +283,41 @@ fn test_textinput_delete_char() {
 #[test]
 fn test_textinput_insert_char() {
     let mut textinput = text_input(Lines::Single, "abcdefg");
-    textinput.adjust_horizontal(
-        Utf8CodeUnitLength(2),
-        Direction::Forward,
-        Selection::NotSelected,
-    );
+    textinput.modify_edit_point(2, RopeMovement::Grapheme);
     textinput.insert_char('a');
     assert_eq!(textinput.get_content(), "abacdefg");
 
-    textinput.adjust_horizontal(
-        Utf8CodeUnitLength(2),
-        Direction::Forward,
-        Selection::Selected,
-    );
+    textinput.modify_selection(2, RopeMovement::Grapheme);
     textinput.insert_char('b');
     assert_eq!(textinput.get_content(), "ababefg");
 
     let mut textinput = text_input(Lines::Single, "a🌠c");
     // Same as "Right" key
-    textinput.adjust_horizontal_by_one(Direction::Forward, Selection::NotSelected);
-    textinput.adjust_horizontal_by_one(Direction::Forward, Selection::NotSelected);
+    textinput.modify_edit_point(2, RopeMovement::Grapheme);
     textinput.insert_char('b');
     // Not splitting surrogate pairs.
     assert_eq!(textinput.get_content(), "a🌠bc");
 }
 
 #[test]
-fn test_textinput_get_sorted_selection() {
+fn test_textinput_selection_boundaries() {
     let mut textinput = text_input(Lines::Single, "abcdefg");
-    textinput.adjust_horizontal(
-        Utf8CodeUnitLength(2),
-        Direction::Forward,
-        Selection::NotSelected,
-    );
-    textinput.adjust_horizontal(
-        Utf8CodeUnitLength(2),
-        Direction::Forward,
-        Selection::Selected,
-    );
-    let (start, end) = textinput.sorted_selection_bounds();
-    assert_eq!(start.index, Utf8CodeUnitLength(2));
-    assert_eq!(end.index, Utf8CodeUnitLength(4));
+    textinput.modify_edit_point(2, RopeMovement::Grapheme);
+    textinput.modify_selection(2, RopeMovement::Grapheme);
+    assert_eq!(textinput.selection_start(), RopeIndex::new(0, 2));
+    assert_eq!(textinput.selection_end(), RopeIndex::new(0, 4));
 
     textinput.clear_selection();
-
-    textinput.adjust_horizontal(
-        Utf8CodeUnitLength(2),
-        Direction::Backward,
-        Selection::Selected,
-    );
-    let (start, end) = textinput.sorted_selection_bounds();
-    assert_eq!(start.index, Utf8CodeUnitLength(2));
-    assert_eq!(end.index, Utf8CodeUnitLength(4));
+    textinput.modify_selection(-2, RopeMovement::Grapheme);
+    assert_eq!(textinput.selection_start(), RopeIndex::new(0, 2));
+    assert_eq!(textinput.selection_end(), RopeIndex::new(0, 4));
 }
 
 #[test]
 fn test_textinput_replace_selection() {
     let mut textinput = text_input(Lines::Single, "abcdefg");
-    textinput.adjust_horizontal(
-        Utf8CodeUnitLength(2),
-        Direction::Forward,
-        Selection::NotSelected,
-    );
-    textinput.adjust_horizontal(
-        Utf8CodeUnitLength(2),
-        Direction::Forward,
-        Selection::Selected,
-    );
-
+    textinput.modify_edit_point(2, RopeMovement::Grapheme);
+    textinput.modify_selection(2, RopeMovement::Grapheme);
     textinput.replace_selection(&DOMString::from("xyz"));
     assert_eq!(textinput.get_content(), "abxyzefg");
 }
@@ -394,173 +325,110 @@ fn test_textinput_replace_selection() {
 #[test]
 fn test_textinput_replace_selection_multibyte_char() {
     let mut textinput = text_input(Lines::Single, "é");
-    textinput.adjust_horizontal_by_one(Direction::Forward, Selection::Selected);
-
+    textinput.modify_selection(1, RopeMovement::Grapheme);
     textinput.replace_selection(&DOMString::from("e"));
     assert_eq!(textinput.get_content(), "e");
 }
 
 #[test]
-fn test_textinput_current_line_length() {
-    let mut textinput = text_input(Lines::Multiple, "abc\nde\nf");
-    assert_eq!(textinput.current_line_length(), Utf8CodeUnitLength(3));
-
-    textinput.adjust_vertical(1, Selection::NotSelected);
-    assert_eq!(textinput.current_line_length(), Utf8CodeUnitLength(2));
-
-    textinput.adjust_vertical(1, Selection::NotSelected);
-    assert_eq!(textinput.current_line_length(), Utf8CodeUnitLength::one());
-}
-
-#[test]
 fn test_textinput_adjust_vertical() {
     let mut textinput = text_input(Lines::Multiple, "abc\nde\nf");
-    textinput.adjust_horizontal(
-        Utf8CodeUnitLength(3),
-        Direction::Forward,
-        Selection::NotSelected,
-    );
-    textinput.adjust_vertical(1, Selection::NotSelected);
-    assert_eq!(textinput.edit_point().line, 1);
-    assert_eq!(textinput.edit_point().index, Utf8CodeUnitLength(2));
+    textinput.modify_edit_point(3, RopeMovement::Grapheme);
+    textinput.modify_edit_point(1, RopeMovement::Line);
+    assert_eq!(textinput.edit_point(), RopeIndex::new(1, 2));
 
-    textinput.adjust_vertical(-1, Selection::NotSelected);
-    assert_eq!(textinput.edit_point().line, 0);
-    assert_eq!(textinput.edit_point().index, Utf8CodeUnitLength(2));
+    textinput.modify_edit_point(-1, RopeMovement::Line);
+    assert_eq!(textinput.edit_point(), RopeIndex::new(0, 2));
 
-    textinput.adjust_vertical(2, Selection::NotSelected);
-    assert_eq!(textinput.edit_point().line, 2);
-    assert_eq!(textinput.edit_point().index, Utf8CodeUnitLength(1));
+    textinput.modify_edit_point(2, RopeMovement::Line);
+    assert_eq!(textinput.edit_point(), RopeIndex::new(2, 1));
 
-    textinput.adjust_vertical(-1, Selection::Selected);
-    assert_eq!(textinput.edit_point().line, 1);
-    assert_eq!(textinput.edit_point().index, Utf8CodeUnitLength(1));
+    textinput.modify_edit_point(-1, RopeMovement::Line);
+    assert_eq!(textinput.edit_point(), RopeIndex::new(1, 1));
 }
 
 #[test]
 fn test_textinput_adjust_vertical_multibyte() {
     let mut textinput = text_input(Lines::Multiple, "áé\nae");
+    textinput.modify_edit_point(1, RopeMovement::Grapheme);
+    assert_eq!(textinput.edit_point(), RopeIndex::new(0, 2));
 
-    textinput.adjust_horizontal_by_one(Direction::Forward, Selection::NotSelected);
-    assert_eq!(textinput.edit_point().line, 0);
-    assert_eq!(textinput.edit_point().index, Utf8CodeUnitLength(2));
-
-    textinput.adjust_vertical(1, Selection::NotSelected);
-    assert_eq!(textinput.edit_point().line, 1);
-    assert_eq!(textinput.edit_point().index, Utf8CodeUnitLength(1));
+    textinput.modify_edit_point(1, RopeMovement::Line);
+    assert_eq!(textinput.edit_point(), RopeIndex::new(1, 1));
 }
 
 #[test]
 fn test_textinput_adjust_horizontal() {
     let mut textinput = text_input(Lines::Multiple, "abc\nde\nf");
-    textinput.adjust_horizontal(
-        Utf8CodeUnitLength(4),
-        Direction::Forward,
-        Selection::NotSelected,
-    );
-    assert_eq!(textinput.edit_point().line, 1);
-    assert_eq!(textinput.edit_point().index, Utf8CodeUnitLength::zero());
+    textinput.modify_edit_point(4, RopeMovement::Grapheme);
+    assert_eq!(textinput.edit_point(), RopeIndex::new(1, 0));
 
-    textinput.adjust_horizontal(
-        Utf8CodeUnitLength::one(),
-        Direction::Forward,
-        Selection::NotSelected,
-    );
-    assert_eq!(textinput.edit_point().line, 1);
-    assert_eq!(textinput.edit_point().index, Utf8CodeUnitLength(1));
+    textinput.modify_edit_point(1, RopeMovement::Grapheme);
+    assert_eq!(textinput.edit_point(), RopeIndex::new(1, 1));
 
-    textinput.adjust_horizontal(
-        Utf8CodeUnitLength(2),
-        Direction::Forward,
-        Selection::NotSelected,
-    );
-    assert_eq!(textinput.edit_point().line, 2);
-    assert_eq!(textinput.edit_point().index, Utf8CodeUnitLength::zero());
+    textinput.modify_edit_point(2, RopeMovement::Grapheme);
+    assert_eq!(textinput.edit_point(), RopeIndex::new(2, 0));
 
-    textinput.adjust_horizontal(
-        Utf8CodeUnitLength::one(),
-        Direction::Backward,
-        Selection::NotSelected,
-    );
-    assert_eq!(textinput.edit_point().line, 1);
-    assert_eq!(textinput.edit_point().index, Utf8CodeUnitLength(2));
+    textinput.modify_edit_point(-1, RopeMovement::Grapheme);
+    assert_eq!(textinput.edit_point(), RopeIndex::new(1, 2));
 }
 
 #[test]
 fn test_textinput_adjust_horizontal_by_word() {
     // Test basic case of movement word by word based on UAX#29 rules
     let mut textinput = text_input(Lines::Single, "abc def");
-    textinput.adjust_horizontal_by_word(Direction::Forward, Selection::NotSelected);
-    textinput.adjust_horizontal_by_word(Direction::Forward, Selection::NotSelected);
-    assert_eq!(textinput.edit_point().line, 0);
-    assert_eq!(textinput.edit_point().index, Utf8CodeUnitLength(7));
-    textinput.adjust_horizontal_by_word(Direction::Backward, Selection::NotSelected);
-    assert_eq!(textinput.edit_point().line, 0);
-    assert_eq!(textinput.edit_point().index, Utf8CodeUnitLength(4));
-    textinput.adjust_horizontal_by_word(Direction::Backward, Selection::NotSelected);
-    assert_eq!(textinput.edit_point().line, 0);
-    assert_eq!(textinput.edit_point().index, Utf8CodeUnitLength::zero());
+    textinput.modify_edit_point(2, RopeMovement::Word);
+    assert_eq!(textinput.edit_point(), RopeIndex::new(0, 7));
+    textinput.modify_edit_point(-1, RopeMovement::Word);
+    assert_eq!(textinput.edit_point(), RopeIndex::new(0, 4));
+    textinput.modify_edit_point(-1, RopeMovement::Word);
+    assert_eq!(textinput.edit_point(), RopeIndex::new(0, 0));
 
     // Test new line case of movement word by word based on UAX#29 rules
     let mut textinput_2 = text_input(Lines::Multiple, "abc\ndef");
-    textinput_2.adjust_horizontal_by_word(Direction::Forward, Selection::NotSelected);
-    textinput_2.adjust_horizontal_by_word(Direction::Forward, Selection::NotSelected);
-    assert_eq!(textinput_2.edit_point().line, 1);
-    assert_eq!(textinput_2.edit_point().index, Utf8CodeUnitLength(3));
-    textinput_2.adjust_horizontal_by_word(Direction::Backward, Selection::NotSelected);
-    assert_eq!(textinput_2.edit_point().line, 1);
-    assert_eq!(textinput_2.edit_point().index, Utf8CodeUnitLength::zero());
-    textinput_2.adjust_horizontal_by_word(Direction::Backward, Selection::NotSelected);
-    assert_eq!(textinput_2.edit_point().line, 0);
-    assert_eq!(textinput_2.edit_point().index, Utf8CodeUnitLength::zero());
+    textinput_2.modify_edit_point(2, RopeMovement::Word);
+    assert_eq!(textinput_2.edit_point(), RopeIndex::new(1, 3));
+    textinput_2.modify_edit_point(-1, RopeMovement::Word);
+    assert_eq!(textinput_2.edit_point(), RopeIndex::new(1, 0));
+    textinput_2.modify_edit_point(-1, RopeMovement::Word);
+    assert_eq!(textinput_2.edit_point(), RopeIndex::new(0, 0));
 
     // Test non-standard sized characters case of movement word by word based on UAX#29 rules
     let mut textinput_3 = text_input(Lines::Single, "áéc d🌠bc");
-    textinput_3.adjust_horizontal_by_word(Direction::Forward, Selection::NotSelected);
-    assert_eq!(textinput_3.edit_point().line, 0);
-    assert_eq!(textinput_3.edit_point().index, Utf8CodeUnitLength(5));
-    textinput_3.adjust_horizontal_by_word(Direction::Forward, Selection::NotSelected);
-    assert_eq!(textinput_3.edit_point().line, 0);
-    assert_eq!(textinput_3.edit_point().index, Utf8CodeUnitLength(7));
-    textinput_3.adjust_horizontal_by_word(Direction::Forward, Selection::NotSelected);
-    assert_eq!(textinput_3.edit_point().line, 0);
-    assert_eq!(textinput_3.edit_point().index, Utf8CodeUnitLength(13));
-    textinput_3.adjust_horizontal_by_word(Direction::Backward, Selection::NotSelected);
-    assert_eq!(textinput_3.edit_point().line, 0);
-    assert_eq!(textinput_3.edit_point().index, Utf8CodeUnitLength(11));
-    textinput_3.adjust_horizontal_by_word(Direction::Backward, Selection::NotSelected);
-    assert_eq!(textinput_3.edit_point().line, 0);
-    assert_eq!(textinput_3.edit_point().index, Utf8CodeUnitLength(6));
+    textinput_3.modify_edit_point(1, RopeMovement::Word);
+    assert_eq!(textinput_3.edit_point(), RopeIndex::new(0, 5));
+    textinput_3.modify_edit_point(1, RopeMovement::Word);
+    assert_eq!(textinput_3.edit_point(), RopeIndex::new(0, 7));
+    textinput_3.modify_edit_point(1, RopeMovement::Word);
+    assert_eq!(textinput_3.edit_point(), RopeIndex::new(0, 13));
+    textinput_3.modify_edit_point(-1, RopeMovement::Word);
+    assert_eq!(textinput_3.edit_point(), RopeIndex::new(0, 11));
+    textinput_3.modify_edit_point(-1, RopeMovement::Word);
+    assert_eq!(textinput_3.edit_point(), RopeIndex::new(0, 6));
 }
 
 #[test]
 fn test_textinput_adjust_horizontal_to_line_end() {
     // Test standard case of movement to end based on UAX#29 rules
     let mut textinput = text_input(Lines::Single, "abc def");
-    textinput.adjust_horizontal_to_line_end(Direction::Forward, Selection::NotSelected);
-    assert_eq!(textinput.edit_point().line, 0);
-    assert_eq!(textinput.edit_point().index, Utf8CodeUnitLength(7));
+    textinput.modify_edit_point(1, RopeMovement::LineStartOrEnd);
+    assert_eq!(textinput.edit_point(), RopeIndex::new(0, 7));
 
     // Test new line case of movement to end based on UAX#29 rules
     let mut textinput_2 = text_input(Lines::Multiple, "abc\ndef");
-    textinput_2.adjust_horizontal_to_line_end(Direction::Forward, Selection::NotSelected);
-    assert_eq!(textinput_2.edit_point().line, 0);
-    assert_eq!(textinput_2.edit_point().index, Utf8CodeUnitLength(3));
-    textinput_2.adjust_horizontal_to_line_end(Direction::Forward, Selection::NotSelected);
-    assert_eq!(textinput_2.edit_point().line, 0);
-    assert_eq!(textinput_2.edit_point().index, Utf8CodeUnitLength(3));
-    textinput_2.adjust_horizontal_to_line_end(Direction::Backward, Selection::NotSelected);
-    assert_eq!(textinput_2.edit_point().line, 0);
-    assert_eq!(textinput_2.edit_point().index, Utf8CodeUnitLength::zero());
+    textinput_2.modify_edit_point(1, RopeMovement::LineStartOrEnd);
+    assert_eq!(textinput_2.edit_point(), RopeIndex::new(0, 3));
+    textinput_2.modify_edit_point(1, RopeMovement::LineStartOrEnd);
+    assert_eq!(textinput_2.edit_point(), RopeIndex::new(0, 3));
+    textinput_2.modify_edit_point(-1, RopeMovement::LineStartOrEnd);
+    assert_eq!(textinput_2.edit_point(), RopeIndex::new(0, 0));
 
     // Test non-standard sized characters case of movement to end based on UAX#29 rules
     let mut textinput_3 = text_input(Lines::Single, "áéc d🌠bc");
-    textinput_3.adjust_horizontal_to_line_end(Direction::Forward, Selection::NotSelected);
-    assert_eq!(textinput_3.edit_point().line, 0);
-    assert_eq!(textinput_3.edit_point().index, Utf8CodeUnitLength(13));
-    textinput_3.adjust_horizontal_to_line_end(Direction::Backward, Selection::NotSelected);
-    assert_eq!(textinput_3.edit_point().line, 0);
-    assert_eq!(textinput_3.edit_point().index, Utf8CodeUnitLength::zero());
+    textinput_3.modify_edit_point(1, RopeMovement::LineStartOrEnd);
+    assert_eq!(textinput_3.edit_point(), RopeIndex::new(0, 13));
+    textinput_3.modify_edit_point(-1, RopeMovement::LineStartOrEnd);
+    assert_eq!(textinput_3.edit_point(), RopeIndex::new(0, 0));
 }
 
 #[test]
@@ -569,64 +437,56 @@ fn test_navigation_keyboard_shortcuts() {
 
     // Test that CMD + Right moves to the end of the current line.
     textinput.handle_keydown_aux(Key::Named(NamedKey::ArrowRight), Modifiers::META, true);
-    assert_eq!(textinput.edit_point().index, Utf8CodeUnitLength(11));
+    assert_eq!(textinput.edit_point().code_point, 11);
     // Test that CMD + Right moves to the beginning of the current line.
     textinput.handle_keydown_aux(Key::Named(NamedKey::ArrowLeft), Modifiers::META, true);
-    assert_eq!(textinput.edit_point().index, Utf8CodeUnitLength::zero());
+    assert_eq!(textinput.edit_point().code_point, 0);
     // Test that CTRL + ALT + E moves to the end of the current line also.
     textinput.handle_keydown_aux(
         Key::Character("e".to_owned()),
         Modifiers::CONTROL | Modifiers::ALT,
         true,
     );
-    assert_eq!(textinput.edit_point().index, Utf8CodeUnitLength(11));
+    assert_eq!(textinput.edit_point().code_point, 11);
     // Test that CTRL + ALT + A moves to the beginning of the current line also.
     textinput.handle_keydown_aux(
         Key::Character("a".to_owned()),
         Modifiers::CONTROL | Modifiers::ALT,
         true,
     );
-    assert_eq!(textinput.edit_point().index, Utf8CodeUnitLength::zero());
+    assert_eq!(textinput.edit_point().code_point, 0);
 
     // Test that ALT + Right moves to the end of the word.
     textinput.handle_keydown_aux(Key::Named(NamedKey::ArrowRight), Modifiers::ALT, true);
-    assert_eq!(textinput.edit_point().index, Utf8CodeUnitLength(5));
+    assert_eq!(textinput.edit_point().code_point, 5);
     // Test that CTRL + ALT + F moves to the end of the word also.
     textinput.handle_keydown_aux(
         Key::Character("f".to_owned()),
         Modifiers::CONTROL | Modifiers::ALT,
         true,
     );
-    assert_eq!(textinput.edit_point().index, Utf8CodeUnitLength(11));
+    assert_eq!(textinput.edit_point().code_point, 11);
     // Test that ALT + Left moves to the end of the word.
     textinput.handle_keydown_aux(Key::Named(NamedKey::ArrowLeft), Modifiers::ALT, true);
-    assert_eq!(textinput.edit_point().index, Utf8CodeUnitLength(6));
+    assert_eq!(textinput.edit_point().code_point, 6);
     // Test that CTRL + ALT + B moves to the end of the word also.
     textinput.handle_keydown_aux(
         Key::Character("b".to_owned()),
         Modifiers::CONTROL | Modifiers::ALT,
         true,
     );
-    assert_eq!(textinput.edit_point().index, Utf8CodeUnitLength::zero());
+    assert_eq!(textinput.edit_point().code_point, 0);
 }
 
 #[test]
 fn test_textinput_handle_return() {
     let mut single_line_textinput = text_input(Lines::Single, "abcdef");
-    single_line_textinput.adjust_horizontal(
-        Utf8CodeUnitLength(3),
-        Direction::Forward,
-        Selection::NotSelected,
-    );
+    single_line_textinput.modify_edit_point(3, RopeMovement::Grapheme);
     single_line_textinput.handle_return();
     assert_eq!(single_line_textinput.get_content(), "abcdef");
 
     let mut multi_line_textinput = text_input(Lines::Multiple, "abcdef");
-    multi_line_textinput.adjust_horizontal(
-        Utf8CodeUnitLength(3),
-        Direction::Forward,
-        Selection::NotSelected,
-    );
+    multi_line_textinput.modify_edit_point(3, RopeMovement::Grapheme);
     multi_line_textinput.handle_return();
     assert_eq!(multi_line_textinput.get_content(), "abc\ndef");
 }
@@ -634,12 +494,10 @@ fn test_textinput_handle_return() {
 #[test]
 fn test_textinput_select_all() {
     let mut textinput = text_input(Lines::Multiple, "abc\nde\nf");
-    assert_eq!(textinput.edit_point().line, 0);
-    assert_eq!(textinput.edit_point().index, Utf8CodeUnitLength::zero());
+    assert_eq!(textinput.edit_point(), RopeIndex::new(0, 0));
 
     textinput.select_all();
-    assert_eq!(textinput.edit_point().line, 2);
-    assert_eq!(textinput.edit_point().index, Utf8CodeUnitLength(1));
+    assert_eq!(textinput.edit_point(), RopeIndex::new(2, 1));
 }
 
 #[test]
@@ -658,21 +516,14 @@ fn test_textinput_set_content() {
 
     textinput.set_content(DOMString::from("abc\nf"));
     assert_eq!(textinput.get_content(), "abc\nf");
+    assert_eq!(textinput.edit_point(), RopeIndex::new(0, 0));
 
-    assert_eq!(textinput.edit_point().line, 0);
-    assert_eq!(textinput.edit_point().index, Utf8CodeUnitLength::zero());
+    textinput.modify_edit_point(3, RopeMovement::Grapheme);
+    assert_eq!(textinput.edit_point(), RopeIndex::new(0, 3));
 
-    textinput.adjust_horizontal(
-        Utf8CodeUnitLength(3),
-        Direction::Forward,
-        Selection::Selected,
-    );
-    assert_eq!(textinput.edit_point().line, 0);
-    assert_eq!(textinput.edit_point().index, Utf8CodeUnitLength(3));
     textinput.set_content(DOMString::from("de"));
     assert_eq!(textinput.get_content(), "de");
-    assert_eq!(textinput.edit_point().line, 0);
-    assert_eq!(textinput.edit_point().index, Utf8CodeUnitLength(2));
+    assert_eq!(textinput.edit_point(), RopeIndex::new(0, 2));
 }
 
 #[test]
@@ -691,7 +542,7 @@ fn test_clipboard_paste() {
         SelectionDirection::None,
     );
     assert_eq!(textinput.get_content(), "defg");
-    assert_eq!(textinput.edit_point().index, Utf8CodeUnitLength::zero());
+    assert_eq!(textinput.edit_point().code_point, 0);
     textinput.handle_keydown_aux(Key::Character("v".to_owned()), MODIFIERS, false);
     assert_eq!(textinput.get_content(), "abcdefg");
 }
@@ -701,124 +552,28 @@ fn test_textinput_cursor_position_correct_after_clearing_selection() {
     let mut textinput = text_input(Lines::Single, "abcdef");
 
     // Single line - Forward
-    textinput.adjust_horizontal(
-        Utf8CodeUnitLength(3),
-        Direction::Forward,
-        Selection::Selected,
-    );
-    textinput.adjust_horizontal(
-        Utf8CodeUnitLength::one(),
-        Direction::Forward,
-        Selection::NotSelected,
-    );
-    assert_eq!(textinput.edit_point().index, Utf8CodeUnitLength(3));
-
-    textinput.adjust_horizontal(
-        Utf8CodeUnitLength(3),
-        Direction::Backward,
-        Selection::NotSelected,
-    );
-    textinput.adjust_horizontal(
-        Utf8CodeUnitLength(3),
-        Direction::Forward,
-        Selection::Selected,
-    );
-    textinput.adjust_horizontal_by_one(Direction::Forward, Selection::NotSelected);
-    assert_eq!(textinput.edit_point().index, Utf8CodeUnitLength(3));
+    textinput.modify_selection(3, RopeMovement::Grapheme);
+    textinput.modify_edit_point(1, RopeMovement::Grapheme);
+    assert_eq!(textinput.edit_point(), RopeIndex::new(0, 3));
 
     // Single line - Backward
-    textinput.adjust_horizontal(
-        Utf8CodeUnitLength(3),
-        Direction::Backward,
-        Selection::NotSelected,
-    );
-    textinput.adjust_horizontal(
-        Utf8CodeUnitLength(3),
-        Direction::Forward,
-        Selection::Selected,
-    );
-    textinput.adjust_horizontal(
-        Utf8CodeUnitLength::one(),
-        Direction::Backward,
-        Selection::NotSelected,
-    );
-    assert_eq!(textinput.edit_point().index, Utf8CodeUnitLength::zero());
-
-    textinput.adjust_horizontal(
-        Utf8CodeUnitLength(3),
-        Direction::Backward,
-        Selection::NotSelected,
-    );
-    textinput.adjust_horizontal(
-        Utf8CodeUnitLength(3),
-        Direction::Forward,
-        Selection::Selected,
-    );
-    textinput.adjust_horizontal_by_one(Direction::Backward, Selection::NotSelected);
-    assert_eq!(textinput.edit_point().index, Utf8CodeUnitLength::zero());
+    textinput.modify_edit_point(-3, RopeMovement::Grapheme);
+    textinput.modify_selection(3, RopeMovement::Grapheme);
+    textinput.modify_edit_point(-1, RopeMovement::Grapheme);
+    assert_eq!(textinput.edit_point(), RopeIndex::new(0, 0));
 
     let mut textinput = text_input(Lines::Multiple, "abc\nde\nf");
 
     // Multiline - Forward
-    textinput.adjust_horizontal(
-        Utf8CodeUnitLength(4),
-        Direction::Forward,
-        Selection::Selected,
-    );
-    textinput.adjust_horizontal(
-        Utf8CodeUnitLength::one(),
-        Direction::Forward,
-        Selection::NotSelected,
-    );
-    assert_eq!(textinput.edit_point().index, Utf8CodeUnitLength::zero());
-    assert_eq!(textinput.edit_point().line, 1);
-
-    textinput.adjust_horizontal(
-        Utf8CodeUnitLength(4),
-        Direction::Backward,
-        Selection::NotSelected,
-    );
-    textinput.adjust_horizontal(
-        Utf8CodeUnitLength(4),
-        Direction::Forward,
-        Selection::Selected,
-    );
-    textinput.adjust_horizontal_by_one(Direction::Forward, Selection::NotSelected);
-    assert_eq!(textinput.edit_point().index, Utf8CodeUnitLength::zero());
-    assert_eq!(textinput.edit_point().line, 1);
+    textinput.modify_selection(4, RopeMovement::Grapheme);
+    textinput.modify_edit_point(1, RopeMovement::Grapheme);
+    assert_eq!(textinput.edit_point(), RopeIndex::new(1, 0));
 
     // Multiline - Backward
-    textinput.adjust_horizontal(
-        Utf8CodeUnitLength(4),
-        Direction::Backward,
-        Selection::NotSelected,
-    );
-    textinput.adjust_horizontal(
-        Utf8CodeUnitLength(4),
-        Direction::Forward,
-        Selection::Selected,
-    );
-    textinput.adjust_horizontal(
-        Utf8CodeUnitLength::one(),
-        Direction::Backward,
-        Selection::NotSelected,
-    );
-    assert_eq!(textinput.edit_point().index, Utf8CodeUnitLength::zero());
-    assert_eq!(textinput.edit_point().line, 0);
-
-    textinput.adjust_horizontal(
-        Utf8CodeUnitLength(4),
-        Direction::Backward,
-        Selection::NotSelected,
-    );
-    textinput.adjust_horizontal(
-        Utf8CodeUnitLength(4),
-        Direction::Forward,
-        Selection::Selected,
-    );
-    textinput.adjust_horizontal_by_one(Direction::Backward, Selection::NotSelected);
-    assert_eq!(textinput.edit_point().index, Utf8CodeUnitLength::zero());
-    assert_eq!(textinput.edit_point().line, 0);
+    textinput.modify_edit_point(-4, RopeMovement::Grapheme);
+    textinput.modify_selection(4, RopeMovement::Grapheme);
+    textinput.modify_edit_point(-1, RopeMovement::Grapheme);
+    assert_eq!(textinput.edit_point(), RopeIndex::new(0, 0));
 }
 
 #[test]
@@ -829,35 +584,23 @@ fn test_textinput_set_selection_with_direction() {
         Utf8CodeUnitLength(6),
         SelectionDirection::Forward,
     );
-    assert_eq!(textinput.edit_point().line, 0);
-    assert_eq!(textinput.edit_point().index, Utf8CodeUnitLength(6));
+    assert_eq!(textinput.edit_point(), RopeIndex::new(0, 6));
     assert_eq!(textinput.selection_direction(), SelectionDirection::Forward);
-
     assert!(textinput.selection_origin().is_some());
-    assert_eq!(textinput.selection_origin().unwrap().line, 0);
-    assert_eq!(
-        textinput.selection_origin().unwrap().index,
-        Utf8CodeUnitLength(2)
-    );
+    assert_eq!(textinput.selection_origin().unwrap(), RopeIndex::new(0, 2));
 
     textinput.set_selection_range_utf8(
         Utf8CodeUnitLength(2),
         Utf8CodeUnitLength(6),
         SelectionDirection::Backward,
     );
-    assert_eq!(textinput.edit_point().line, 0);
-    assert_eq!(textinput.edit_point().index, Utf8CodeUnitLength(2));
+    assert_eq!(textinput.edit_point(), RopeIndex::new(0, 2));
     assert_eq!(
         textinput.selection_direction(),
         SelectionDirection::Backward
     );
-
     assert!(textinput.selection_origin().is_some());
-    assert_eq!(textinput.selection_origin().unwrap().line, 0);
-    assert_eq!(
-        textinput.selection_origin().unwrap().index,
-        Utf8CodeUnitLength(6)
-    );
+    assert_eq!(textinput.selection_origin().unwrap(), RopeIndex::new(0, 6));
 
     textinput = text_input(Lines::Multiple, "\n\n");
     textinput.set_selection_range_utf8(
@@ -865,16 +608,10 @@ fn test_textinput_set_selection_with_direction() {
         Utf8CodeUnitLength(1),
         SelectionDirection::Forward,
     );
-    assert_eq!(textinput.edit_point().line, 1);
-    assert_eq!(textinput.edit_point().index, Utf8CodeUnitLength::zero());
+    assert_eq!(textinput.edit_point(), RopeIndex::new(1, 0));
     assert_eq!(textinput.selection_direction(), SelectionDirection::Forward);
-
     assert!(textinput.selection_origin().is_some());
-    assert_eq!(textinput.selection_origin().unwrap().line, 0);
-    assert_eq!(
-        textinput.selection_origin().unwrap().index,
-        Utf8CodeUnitLength::zero()
-    );
+    assert_eq!(textinput.selection_origin().unwrap(), RopeIndex::new(0, 0));
 
     textinput = text_input(Lines::Multiple, "\n");
     textinput.set_selection_range_utf8(
@@ -882,26 +619,11 @@ fn test_textinput_set_selection_with_direction() {
         Utf8CodeUnitLength(1),
         SelectionDirection::Forward,
     );
-    assert_eq!(textinput.edit_point().line, 1);
-    assert_eq!(textinput.edit_point().index, Utf8CodeUnitLength::zero());
+
+    assert_eq!(textinput.edit_point(), RopeIndex::new(1, 0));
     assert_eq!(textinput.selection_direction(), SelectionDirection::Forward);
-
     assert!(textinput.selection_origin().is_some());
-    assert_eq!(textinput.selection_origin().unwrap().line, 0);
-    assert_eq!(
-        textinput.selection_origin().unwrap().index,
-        Utf8CodeUnitLength::zero()
-    );
-}
-
-#[test]
-fn test_textinput_unicode_handling() {
-    let mut textinput = text_input(Lines::Single, "éèùµ$£");
-    assert_eq!(textinput.edit_point().index, Utf8CodeUnitLength::zero());
-    textinput.set_edit_point_index(1);
-    assert_eq!(textinput.edit_point().index, Utf8CodeUnitLength(2));
-    textinput.set_edit_point_index(4);
-    assert_eq!(textinput.edit_point().index, Utf8CodeUnitLength(8));
+    assert_eq!(textinput.selection_origin().unwrap(), RopeIndex::new(0, 0));
 }
 
 #[test]
@@ -909,26 +631,11 @@ fn test_selection_bounds() {
     let mut textinput = text_input(Lines::Single, "abcdef");
 
     assert_eq!(
-        TextPoint {
-            line: 0,
-            index: Utf8CodeUnitLength::zero()
-        },
+        RopeIndex::new(0, 0),
         textinput.selection_origin_or_edit_point()
     );
-    assert_eq!(
-        TextPoint {
-            line: 0,
-            index: Utf8CodeUnitLength::zero()
-        },
-        textinput.selection_start()
-    );
-    assert_eq!(
-        TextPoint {
-            line: 0,
-            index: Utf8CodeUnitLength::zero()
-        },
-        textinput.selection_end()
-    );
+    assert_eq!(RopeIndex::new(0, 0), textinput.selection_start());
+    assert_eq!(RopeIndex::new(0, 0), textinput.selection_end());
 
     textinput.set_selection_range_utf8(
         Utf8CodeUnitLength(2),
@@ -936,32 +643,11 @@ fn test_selection_bounds() {
         SelectionDirection::Forward,
     );
     assert_eq!(
-        TextPoint {
-            line: 0,
-            index: Utf8CodeUnitLength(2)
-        },
+        RopeIndex::new(0, 2),
         textinput.selection_origin_or_edit_point()
     );
-    assert_eq!(
-        TextPoint {
-            line: 0,
-            index: Utf8CodeUnitLength(2)
-        },
-        textinput.selection_start()
-    );
-    assert_eq!(
-        TextPoint {
-            line: 0,
-            index: Utf8CodeUnitLength(5)
-        },
-        textinput.selection_end()
-    );
-
-    let selection_start_offset = textinput.text_point_to_utf8_offset(textinput.selection_start());
-    assert_eq!(Utf8CodeUnitLength(2), selection_start_offset);
-
-    let selection_end_offset = textinput.text_point_to_utf8_offset(textinput.selection_end());
-    assert_eq!(Utf8CodeUnitLength(5), selection_end_offset);
+    assert_eq!(RopeIndex::new(0, 2), textinput.selection_start());
+    assert_eq!(RopeIndex::new(0, 5), textinput.selection_end());
 
     textinput.set_selection_range_utf8(
         Utf8CodeUnitLength(3),
@@ -969,32 +655,11 @@ fn test_selection_bounds() {
         SelectionDirection::Backward,
     );
     assert_eq!(
-        TextPoint {
-            line: 0,
-            index: Utf8CodeUnitLength(6)
-        },
+        RopeIndex::new(0, 6),
         textinput.selection_origin_or_edit_point()
     );
-    assert_eq!(
-        TextPoint {
-            line: 0,
-            index: Utf8CodeUnitLength(3)
-        },
-        textinput.selection_start()
-    );
-    assert_eq!(
-        TextPoint {
-            line: 0,
-            index: Utf8CodeUnitLength(6)
-        },
-        textinput.selection_end()
-    );
-
-    let selection_start_offset = textinput.text_point_to_utf8_offset(textinput.selection_start());
-    assert_eq!(Utf8CodeUnitLength(3), selection_start_offset);
-
-    let selection_end_offset = textinput.text_point_to_utf8_offset(textinput.selection_end());
-    assert_eq!(Utf8CodeUnitLength(6), selection_end_offset);
+    assert_eq!(RopeIndex::new(0, 3), textinput.selection_start());
+    assert_eq!(RopeIndex::new(0, 6), textinput.selection_end());
 
     textinput = text_input(Lines::Multiple, "\n\n");
     textinput.set_selection_range_utf8(
@@ -1003,26 +668,11 @@ fn test_selection_bounds() {
         SelectionDirection::Forward,
     );
     assert_eq!(
-        TextPoint {
-            line: 0,
-            index: Utf8CodeUnitLength::zero()
-        },
+        RopeIndex::new(0, 0),
         textinput.selection_origin_or_edit_point()
     );
-    assert_eq!(
-        TextPoint {
-            line: 0,
-            index: Utf8CodeUnitLength::zero()
-        },
-        textinput.selection_start()
-    );
-    assert_eq!(
-        TextPoint {
-            line: 1,
-            index: Utf8CodeUnitLength::zero()
-        },
-        textinput.selection_end()
-    );
+    assert_eq!(RopeIndex::new(0, 0), textinput.selection_start());
+    assert_eq!(RopeIndex::new(1, 0), textinput.selection_end());
 }
 
 #[test]
@@ -1035,20 +685,8 @@ fn test_select_all() {
     );
     textinput.select_all();
     assert_eq!(textinput.selection_direction(), SelectionDirection::Forward);
-    assert_eq!(
-        TextPoint {
-            line: 0,
-            index: Utf8CodeUnitLength::zero()
-        },
-        textinput.selection_start()
-    );
-    assert_eq!(
-        TextPoint {
-            line: 0,
-            index: Utf8CodeUnitLength(3)
-        },
-        textinput.selection_end()
-    );
+    assert_eq!(RopeIndex::new(0, 0), textinput.selection_start());
+    assert_eq!(RopeIndex::new(0, 3), textinput.selection_end());
 }
 
 #[test]
@@ -1057,121 +695,4 @@ fn test_backspace_in_textarea_at_beginning_of_line() {
     textinput.handle_keydown_aux(Key::Named(NamedKey::ArrowDown), Modifiers::empty(), false);
     textinput.handle_keydown_aux(Key::Named(NamedKey::Backspace), Modifiers::empty(), false);
     assert_eq!(textinput.get_content(), DOMString::from("first line"));
-}
-
-#[test]
-fn test_text_point_conversion_to_utf8_offset() {
-    let textinput = text_input(Lines::Multiple, "A\nBB\nCCC\nDDDD");
-    assert_eq!(
-        textinput.text_point_to_utf8_offset(TextPoint::new(0, Utf8CodeUnitLength(0))),
-        Utf8CodeUnitLength(0),
-    );
-    assert_eq!(
-        textinput.text_point_to_utf8_offset(TextPoint::new(0, Utf8CodeUnitLength(1))),
-        Utf8CodeUnitLength(1),
-    );
-    assert_eq!(
-        textinput.text_point_to_utf8_offset(TextPoint::new(0, Utf8CodeUnitLength(10))),
-        Utf8CodeUnitLength(2),
-        "TextPoint with offset past the end of the line should return final offset in line",
-    );
-    assert_eq!(
-        textinput.text_point_to_utf8_offset(TextPoint::new(1, Utf8CodeUnitLength(0))),
-        Utf8CodeUnitLength(2),
-    );
-    assert_eq!(
-        textinput.text_point_to_utf8_offset(TextPoint::new(1, Utf8CodeUnitLength(2))),
-        Utf8CodeUnitLength(4),
-    );
-
-    assert_eq!(
-        textinput.text_point_to_utf8_offset(TextPoint::new(3, Utf8CodeUnitLength(0))),
-        Utf8CodeUnitLength(9),
-    );
-    assert_eq!(
-        textinput.text_point_to_utf8_offset(TextPoint::new(3, Utf8CodeUnitLength(3))),
-        Utf8CodeUnitLength(12),
-    );
-    assert_eq!(
-        textinput.text_point_to_utf8_offset(TextPoint::new(3, Utf8CodeUnitLength(4))),
-        Utf8CodeUnitLength(13),
-        "There should be no newline at the end of the TextInput",
-    );
-    assert_eq!(
-        textinput.text_point_to_utf8_offset(TextPoint::new(3, Utf8CodeUnitLength(40))),
-        Utf8CodeUnitLength(13),
-        "There should be no newline at the end of the TextInput",
-    );
-}
-
-#[test]
-fn test_text_point_conversion_to_utf16_offset() {
-    let textinput = text_input(Lines::Multiple, "A\nBB\nCCC\n家家");
-    assert_eq!(
-        textinput.text_point_to_utf16_offset(TextPoint::new(0, Utf8CodeUnitLength(0))),
-        Utf16CodeUnitLength(0),
-    );
-    assert_eq!(
-        textinput.text_point_to_utf16_offset(TextPoint::new(0, Utf8CodeUnitLength(1))),
-        Utf16CodeUnitLength(1),
-    );
-    assert_eq!(
-        textinput.text_point_to_utf16_offset(TextPoint::new(0, Utf8CodeUnitLength(10))),
-        Utf16CodeUnitLength(2),
-        "TextPoint with offset past the end of the line should return final offset in line",
-    );
-    assert_eq!(
-        textinput.text_point_to_utf16_offset(TextPoint::new(3, Utf8CodeUnitLength(0))),
-        Utf16CodeUnitLength(9),
-    );
-
-    assert_eq!(
-        textinput.text_point_to_utf16_offset(TextPoint::new(3, Utf8CodeUnitLength(3))),
-        Utf16CodeUnitLength(10),
-        "3 code unit UTF-8 encodede character"
-    );
-    assert_eq!(
-        textinput.text_point_to_utf16_offset(TextPoint::new(3, Utf8CodeUnitLength(6))),
-        Utf16CodeUnitLength(11),
-    );
-    assert_eq!(
-        textinput.text_point_to_utf16_offset(TextPoint::new(3, Utf8CodeUnitLength(20))),
-        Utf16CodeUnitLength(11),
-    );
-}
-
-#[test]
-fn test_utf16_offset_to_utf8_offset() {
-    let textinput = text_input(Lines::Multiple, "A\nBB\nCCC\n家家");
-    assert_eq!(
-        textinput.utf16_offset_to_utf8_offset(Utf16CodeUnitLength(0)),
-        Utf8CodeUnitLength(0),
-    );
-    assert_eq!(
-        textinput.utf16_offset_to_utf8_offset(Utf16CodeUnitLength(1)),
-        Utf8CodeUnitLength(1),
-    );
-    assert_eq!(
-        textinput.utf16_offset_to_utf8_offset(Utf16CodeUnitLength(2)),
-        Utf8CodeUnitLength(2),
-        "Offset past the end of the line",
-    );
-    assert_eq!(
-        textinput.utf16_offset_to_utf8_offset(Utf16CodeUnitLength(9)),
-        Utf8CodeUnitLength(9),
-    );
-
-    assert_eq!(
-        textinput.utf16_offset_to_utf8_offset(Utf16CodeUnitLength(10)),
-        Utf8CodeUnitLength(12),
-        "3 code unit UTF-8 encodede character"
-    );
-    assert_eq!(
-        textinput.utf16_offset_to_utf8_offset(Utf16CodeUnitLength(11)),
-        Utf8CodeUnitLength(15),
-    );
-    assert_eq!(
-        textinput.utf16_offset_to_utf8_offset(Utf16CodeUnitLength(300)),
-        Utf8CodeUnitLength(15),
-    );
 }


### PR DESCRIPTION
`TextInput` internally stores a rope of text content, one segment for
each line. This change separates out the rope into a separate `Rope`
data structure that can be shared with other parts of Servo.

`TextInput` needs to move through text content in a variety of ways,
depending on the keys pressed when interacting with a text area. This
change provides a unified movement API in both `Rope` and in
`TextInput` ensuring that selection is handled consistently (apart from
a few minor quirks [^1]). This simplifies the code an improves
interactive behavior.

[^1]: One of these quirks is that the edit point will move to
directional end of the motion when collapsing a selection, but only when
moving by grapheme or word (and not by line). These quirks existed in an
undocumented way previously and they are preserved with code comments.

Testing: This is covered by existing unit tests (updated for the new API) and
the WPT suite.
