### PR TITLE
Retry EventSource after temporary failures using `is_permanent_failure`

### DIFF
--- a/components/script/dom/eventsource.rs
+++ b/components/script/dom/eventsource.rs
@@ -387,15 +387,14 @@ impl FetchResponseListener for EventSourceContext {
                 // Step 15.4 announce the connection and interpret res's body line by line.
                 self.announce_the_connection();
             },
-            Err(_) => {
+            Err(error) => {
                 // Step 15.2 if res is a network error, then reestablish the connection, unless
                 // the user agent knows that to be futile, in which case the user agent may
                 // fail the connection.
-
-                // WPT tests consider a non-http(s) scheme to be futile.
-                match self.event_source.root().url.scheme() {
-                    "http" | "https" => self.reestablish_the_connection(),
-                    _ => self.fail_the_connection(),
+                if error.is_permanent_failure() {
+                    self.fail_the_connection()
+                } else {
+                    self.reestablish_the_connection()
                 }
             },
         }

--- a/components/shared/net/lib.rs
+++ b/components/shared/net/lib.rs
@@ -1187,6 +1187,16 @@ impl fmt::Debug for NetworkError {
 }
 
 impl NetworkError {
+    pub fn is_permanent_failure(&self) -> bool {
+        matches!(
+            self,
+            NetworkError::InvalidPort |
+                NetworkError::MixedContent |
+                NetworkError::ContentSecurityPolicy |
+                NetworkError::UnsupportedScheme
+        )
+    }
+
     pub fn from_hyper_error(error: &HyperError, certificate: Option<CertificateDer>) -> Self {
         let error_string = error.to_string();
         match certificate {

--- a/tests/wpt/meta/content-security-policy/connect-src/connect-src-eventsource-blocked.sub.html.ini
+++ b/tests/wpt/meta/content-security-policy/connect-src/connect-src-eventsource-blocked.sub.html.ini
@@ -1,3 +1,0 @@
-[connect-src-eventsource-blocked.sub.html]
-  [Expecting logs: ["blocked","violated-directive=connect-src"\]]
-    expected: FAIL


### PR DESCRIPTION
add `is_permanent_failure` method in `NetworkError` and call it from the `EventSource` instead of the current match against the url's scheme

Testing: `./mach test-wpt tests/wpt/tests/eventsource`
Fixes: #41634
