### PR TITLE
layout: Fix intrinsic contribution of anonymous not marked as depending on block constraints

### DIFF
--- a/components/layout/sizing.rs
+++ b/components/layout/sizing.rs
@@ -189,6 +189,10 @@ pub(crate) fn outer_inline(
                 };
             ConstraintSpace::new(block_size, style, aspect_ratio)
         } else {
+            // Even if the size doesn't directly depend on block constraints, since this box
+            // doesn't establish a containing block, its contents can depend on its block
+            // constraints. And thus have a dependency via the intrinsic size.
+            depends_on_block_constraints = true;
             // This assumes that there is no preferred aspect ratio, or that there is no
             // block size constraint to be transferred so the ratio is irrelevant.
             // We only get into here for anonymous blocks, for which the assumption holds.

--- a/tests/wpt/tests/css/css-flexbox/percentage-heights-022.html
+++ b/tests/wpt/tests/css/css-flexbox/percentage-heights-022.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Flexbox: percentage in inline-level inside anonymous block inside flex item</title>
+<link rel="author" title="Oriol Brufau" href="mailto:obrufau@igalia.com">
+<link rel="help" href="https://github.com/servo/servo/issues/41633">
+<link rel="match" href="../reference/ref-filled-green-200px-square.html">
+<meta name="assert" content="The <canvas> size is 200 x 200">
+
+<style>
+#flex-container {
+  display: flex;
+  flex-direction: column;
+}
+#flex-item {
+  width: max-content;
+  height: 200px;
+  background: red;
+}
+#target {
+  height: 100%;
+  background: green;
+}
+</style>
+
+<p>Test passes if there is a filled green square and <strong>no red</strong>.</p>
+
+<div id="flex-container">
+  <div id="flex-item">
+    <div><!-- This wraps the inline-level canvas inside an anonymous block --></div>
+    <canvas id="target" width="400" height="400"></canvas>
+  </div>
+</div>


### PR DESCRIPTION
An anonymous block box doesn't establish a containing block for its contents. Therefore, if its contents depend on block constraints, we need to mark its intrinsic contribution as depending on block constraints.

Testing: Adding new test
Fixes: #41633
