### PR TITLE
layout: Fix intrinsic size of block-in-inline not marked as depending on block constraints

### DIFF
--- a/components/layout/flow/inline/mod.rs
+++ b/components/layout/flow/inline/mod.rs
@@ -2597,6 +2597,8 @@ impl<'layout_data> ContentSizesComputation<'layout_data> {
                     },
                     |_aspect_ratio| None,
                 );
+                self.depends_on_block_constraints |=
+                    inline_content_sizes_result.depends_on_block_constraints;
                 self.current_line = inline_content_sizes_result.sizes;
                 self.forced_line_break();
             },

--- a/tests/wpt/tests/css/css-flexbox/percentage-heights-023.html
+++ b/tests/wpt/tests/css/css-flexbox/percentage-heights-023.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Flexbox: percentage in block-level inside inline inside flex item</title>
+<link rel="author" title="Oriol Brufau" href="mailto:obrufau@igalia.com">
+<link rel="help" href="https://github.com/servo/servo/issues/41630">
+<link rel="match" href="../reference/ref-filled-green-200px-square.html">
+<meta name="assert" content="The <canvas> size is 200 x 200">
+
+<style>
+#flex-container {
+  display: flex;
+  flex-direction: column;
+}
+#flex-item {
+  width: max-content;
+  height: 200px;
+  background: red;
+}
+#target {
+  display: block;
+  height: 100%;
+  background: green;
+}
+</style>
+
+<p>Test passes if there is a filled green square and <strong>no red</strong>.</p>
+
+<div id="flex-container">
+  <div id="flex-item">
+    <span id="inline">
+      <canvas id="target" width="400" height="400"></canvas>
+    </span>
+  </div>
+</div>


### PR DESCRIPTION
When a block-level that depends on block constraints is inside an inline formatting context, then the intrinsic size of the entire IFC needs to be marked as depending on block constraints too.

Testing: Adding new test
Fixes: #41630
