### PR TITLE
Expose nested browsing context status in RequestClient

### DIFF
--- a/components/net/fetch/methods.rs
+++ b/components/net/fetch/methods.rs
@@ -1174,8 +1174,15 @@ fn should_upgrade_request_to_potentially_trustworthy(
             return true;
         }
 
-        // Step 2.2
-        // TODO If request’s client's target browsing context is a nested browsing context
+        // Step 2.2 If request’s client's target browsing context is a nested browsing context,
+        // skip the remaining substeps and continue upgrading request.
+        if request
+            .client
+            .as_ref()
+            .is_some_and(|client| client.is_nested_browsing_context)
+        {
+            return true;
+        }
 
         // Step 2.4
         // TODO : check for insecure navigation set after its implemention
@@ -1207,8 +1214,13 @@ fn should_upgrade_request_to_potentially_trustworthy(
         }
     }
 
-    // Step 4
-    request.insecure_requests_policy == InsecureRequestsPolicy::Upgrade
+    // Step 3. Let upgrade state be the result of executing
+    // §4.2 Should insecure requests be upgraded for client? upon request's client.
+    // Step 4. If upgrade state is "Do Not Upgrade", return without modifying request.
+    request
+        .client
+        .as_ref()
+        .is_some_and(|client| client.insecure_requests_policy == InsecureRequestsPolicy::Upgrade)
 }
 
 #[derive(Debug, PartialEq)]

--- a/components/script/dom/globalscope.rs
+++ b/components/script/dom/globalscope.rs
@@ -2603,14 +2603,17 @@ impl GlobalScope {
     pub(crate) fn request_client(&self) -> RequestClient {
         // Step 1.2.2. If global is a Window object and global’s navigable is not null,
         // then set request’s traversable for user prompts to global’s navigable’s traversable navigable.
-        let preloaded_resources = self
-            .downcast::<Window>()
+        let window = self.downcast::<Window>();
+        let preloaded_resources = window
             .map(|window: &Window| window.Document().preloaded_resources().clone())
             .unwrap_or_default();
+        let is_nested_browsing_context = window.is_some_and(|window| !window.is_top_level());
         RequestClient {
             preloaded_resources,
             policy_container: RequestPolicyContainer::PolicyContainer(self.policy_container()),
             origin: RequestOrigin::Origin(self.origin().immutable().clone()),
+            is_nested_browsing_context,
+            insecure_requests_policy: self.insecure_requests_policy(),
         }
     }
 

--- a/components/script/dom/globalscope.rs
+++ b/components/script/dom/globalscope.rs
@@ -2599,6 +2599,12 @@ impl GlobalScope {
         }
     }
 
+    /// <https://html.spec.whatwg.org/multipage/#nested-browsing-context>
+    pub(crate) fn is_nested_browsing_context(&self) -> bool {
+        self.downcast::<Window>()
+            .is_some_and(|window| !window.is_top_level())
+    }
+
     /// Part of <https://fetch.spec.whatwg.org/#populate-request-from-client>
     pub(crate) fn request_client(&self) -> RequestClient {
         // Step 1.2.2. If global is a Window object and global’s navigable is not null,

--- a/components/script/dom/websocket.rs
+++ b/components/script/dom/websocket.rs
@@ -294,7 +294,8 @@ impl WebSocketMethods<crate::DomTypeHolder> for WebSocket {
         .credentials_mode(CredentialsMode::Include)
         .cache_mode(CacheMode::NoCache)
         .policy_container(global.policy_container())
-        .redirect_mode(RedirectMode::Error);
+        .redirect_mode(RedirectMode::Error)
+        .client(global.request_client());
 
         let channels = FetchChannels::WebSocket {
             event_sender: resource_event_sender,

--- a/components/shared/net/request.rs
+++ b/components/shared/net/request.rs
@@ -208,6 +208,10 @@ pub struct RequestClient {
     pub policy_container: RequestPolicyContainer,
     /// <https://html.spec.whatwg.org/multipage/#concept-settings-object-origin>
     pub origin: Origin,
+    /// <https://html.spec.whatwg.org/multipage/#nested-browsing-context>
+    pub is_nested_browsing_context: bool,
+    /// <https://w3c.github.io/webappsec-upgrade-insecure-requests/#insecure-requests-policy>
+    pub insecure_requests_policy: InsecureRequestsPolicy,
 }
 
 /// <https://html.spec.whatwg.org/multipage/#system-visibility-state>

--- a/tests/wpt/meta/referrer-policy/generic/iframe-upgrade-request-to-cross-origin.sub.html.ini
+++ b/tests/wpt/meta/referrer-policy/generic/iframe-upgrade-request-to-cross-origin.sub.html.ini
@@ -1,5 +1,0 @@
-[iframe-upgrade-request-to-cross-origin.sub.html]
-  expected: TIMEOUT
-  [If an insecure iframe request is upgraded to https to be cross-origin, referrer policies that consider same-origin-ness should be applied correctly]
-    expected: TIMEOUT
-

--- a/tests/wpt/meta/referrer-policy/generic/iframe-upgrade-request-to-same-origin.sub.https.html.ini
+++ b/tests/wpt/meta/referrer-policy/generic/iframe-upgrade-request-to-same-origin.sub.https.html.ini
@@ -1,5 +1,0 @@
-[iframe-upgrade-request-to-same-origin.sub.https.html]
-  expected: TIMEOUT
-  [If an insecure iframe request is upgraded to https to be same-origin, referrer policies that consider same-origin-ness should be applied correctly]
-    expected: TIMEOUT
-

--- a/tests/wpt/meta/upgrade-insecure-requests/link-upgrade.sub.https.html.ini
+++ b/tests/wpt/meta/upgrade-insecure-requests/link-upgrade.sub.https.html.ini
@@ -2,9 +2,6 @@
   [./link-upgrade/basic-link-upgrade.sub.html]
     expected: TIMEOUT
 
-  [./link-upgrade/iframe-link-upgrade.sub.html]
-    expected: TIMEOUT
-
   [./link-upgrade/iframe-top-navigation-no-upgrade-1.sub.html]
     expected: TIMEOUT
 


### PR DESCRIPTION
implement step 2.2 of <https://w3c.github.io/webappsec-upgrade-insecure-requests/#upgrade-request> by adding an is_nested_browsing_context field to RequestClient

Testing: `./mach test-wpt tests/wpt/tests/upgrade-insecure-requests` and `./mach test-wpt tests/wpt/tests/mixed-content`
Fixes: #41639 