### PR TITLE
script: Consolidate global initialization for fetch requests

### DIFF
--- a/components/script/dom/document.rs
+++ b/components/script/dom/document.rs
@@ -1905,15 +1905,6 @@ impl Document {
             .insert(key, preload_id);
     }
 
-    /// Add the policy container and HTTPS state to a given request.
-    ///
-    /// TODO: Can this hapen for all requests that go through the document?
-    pub(crate) fn prepare_request(&self, request: RequestBuilder) -> RequestBuilder {
-        request
-            .policy_container(self.policy_container().to_owned())
-            .https_state(self.https_state.get())
-    }
-
     pub(crate) fn fetch<Listener: FetchResponseListener>(
         &self,
         load: LoadType,

--- a/components/script/dom/eventsource.rs
+++ b/components/script/dom/eventsource.rs
@@ -36,7 +36,7 @@ use crate::dom::eventtarget::EventTarget;
 use crate::dom::globalscope::GlobalScope;
 use crate::dom::messageevent::MessageEvent;
 use crate::dom::performance::performanceresourcetiming::InitiatorType;
-use crate::fetch::{FetchCanceller, create_a_potential_cors_request};
+use crate::fetch::{FetchCanceller, RequestWithGlobalScope, create_a_potential_cors_request};
 use crate::network_listener::{self, FetchResponseListener, ResourceTimingListener};
 use crate::realms::enter_realm;
 use crate::script_runtime::CanGc;
@@ -577,13 +577,8 @@ impl EventSourceMethods<crate::DomTypeHolder> for EventSource {
             Some(cors_attribute_state),
             Some(true),
             global.get_referrer(),
-            global.insecure_requests_policy(),
-            global.has_trustworthy_ancestor_or_current_origin(),
-            global.policy_container(),
-            global.request_client(),
         )
-        .origin(global.origin().immutable().clone())
-        .pipeline_id(Some(global.pipeline_id()));
+        .with_global_scope(global);
 
         // Step 10 User agents may set (`Accept`, `text/event-stream`) in request's header list.
         // TODO(eijebong): Replace once typed headers allow it

--- a/components/script/dom/html/htmlimageelement.rs
+++ b/components/script/dom/html/htmlimageelement.rs
@@ -77,7 +77,7 @@ use crate::dom::performance::performanceresourcetiming::InitiatorType;
 use crate::dom::promise::Promise;
 use crate::dom::virtualmethods::VirtualMethods;
 use crate::dom::window::Window;
-use crate::fetch::create_a_potential_cors_request;
+use crate::fetch::{RequestWithGlobalScope, create_a_potential_cors_request};
 use crate::microtask::{Microtask, MicrotaskRunnable};
 use crate::network_listener::{self, FetchResponseListener, ResourceTimingListener};
 use crate::realms::enter_realm;
@@ -443,13 +443,8 @@ impl HTMLImageElement {
             cors_setting_for_element(self.upcast()),
             None,
             global.get_referrer(),
-            document.insecure_requests_policy(),
-            document.has_trustworthy_ancestor_or_current_origin(),
-            global.policy_container(),
-            global.request_client(),
         )
-        .origin(document.origin().immutable().clone())
-        .pipeline_id(Some(document.global().pipeline_id()))
+        .with_global_scope(&global)
         .referrer_policy(referrer_policy_for_element(self.upcast()));
 
         if self.uses_srcset_or_picture() {

--- a/components/script/dom/html/htmlmediaelement.rs
+++ b/components/script/dom/html/htmlmediaelement.rs
@@ -101,7 +101,7 @@ use crate::dom::url::URL;
 use crate::dom::videotrack::VideoTrack;
 use crate::dom::videotracklist::VideoTrackList;
 use crate::dom::virtualmethods::VirtualMethods;
-use crate::fetch::{FetchCanceller, create_a_potential_cors_request};
+use crate::fetch::{FetchCanceller, RequestWithGlobalScope, create_a_potential_cors_request};
 use crate::microtask::{Microtask, MicrotaskRunnable};
 use crate::network_listener::{self, FetchResponseListener, ResourceTimingListener};
 use crate::realms::{InRealm, enter_realm};
@@ -1433,14 +1433,9 @@ impl HTMLMediaElement {
             cors_setting,
             None,
             global.get_referrer(),
-            document.insecure_requests_policy(),
-            document.has_trustworthy_ancestor_or_current_origin(),
-            global.policy_container(),
-            global.request_client(),
         )
+        .with_global_scope(&global)
         .headers(headers)
-        .origin(document.origin().immutable().clone())
-        .pipeline_id(Some(self.global().pipeline_id()))
         .referrer_policy(document.get_referrer_policy());
 
         let mut current_fetch_context = self.current_fetch_context.borrow_mut();

--- a/components/script/dom/html/htmlvideoelement.rs
+++ b/components/script/dom/html/htmlvideoelement.rs
@@ -40,7 +40,7 @@ use crate::dom::html::htmlmediaelement::{HTMLMediaElement, NetworkState, ReadySt
 use crate::dom::node::{Node, NodeDamage, NodeTraits};
 use crate::dom::performance::performanceresourcetiming::InitiatorType;
 use crate::dom::virtualmethods::VirtualMethods;
-use crate::fetch::FetchCanceller;
+use crate::fetch::{FetchCanceller, RequestWithGlobalScope};
 use crate::network_listener::{self, FetchResponseListener, ResourceTimingListener};
 use crate::script_runtime::CanGc;
 
@@ -235,12 +235,7 @@ impl HTMLVideoElement {
         .destination(Destination::Image)
         .credentials_mode(CredentialsMode::Include)
         .use_url_credentials(true)
-        .origin(document.origin().immutable().clone())
-        .pipeline_id(Some(global.pipeline_id()))
-        .insecure_requests_policy(document.insecure_requests_policy())
-        .has_trustworthy_ancestor_origin(document.has_trustworthy_ancestor_origin())
-        .policy_container(document.policy_container().to_owned())
-        .client(global.request_client());
+        .with_global_scope(&global);
 
         // Step 6. Fetch request. This must delay the load event of the element's node document.
         // This delay must be independent from the ones created by HTMLMediaElement during

--- a/components/script/dom/notification.rs
+++ b/components/script/dom/notification.rs
@@ -55,7 +55,7 @@ use crate::dom::permissions::{PermissionAlgorithm, Permissions, descriptor_permi
 use crate::dom::promise::Promise;
 use crate::dom::serviceworkerglobalscope::ServiceWorkerGlobalScope;
 use crate::dom::serviceworkerregistration::ServiceWorkerRegistration;
-use crate::fetch::create_a_potential_cors_request;
+use crate::fetch::{RequestWithGlobalScope, create_a_potential_cors_request};
 use crate::network_listener::{self, FetchResponseListener, ResourceTimingListener};
 use crate::script_runtime::{CanGc, JSContext as SafeJSContext};
 
@@ -814,13 +814,8 @@ impl Notification {
             None, // TODO: check which CORS should be used
             None,
             global.get_referrer(),
-            global.insecure_requests_policy(),
-            global.has_trustworthy_ancestor_or_current_origin(),
-            global.policy_container(),
-            global.request_client(),
         )
-        .origin(global.origin().immutable().clone())
-        .pipeline_id(Some(global.pipeline_id()))
+        .with_global_scope(global)
     }
 
     /// <https://notifications.spec.whatwg.org/#fetch-steps>

--- a/components/script/dom/processingoptions.rs
+++ b/components/script/dom/processingoptions.rs
@@ -209,11 +209,11 @@ impl LinkProcessingOptions {
             self.cross_origin,
             None,
             self.referrer,
-            self.insecure_requests_policy,
-            self.has_trustworthy_ancestor_origin,
-            self.policy_container,
-            self.request_client,
         )
+        .insecure_requests_policy(self.insecure_requests_policy)
+        .has_trustworthy_ancestor_origin(self.has_trustworthy_ancestor_origin)
+        .policy_container(self.policy_container)
+        .client(self.request_client)
         .initiator(Initiator::Link)
         .origin(self.origin)
         .integrity_metadata(self.integrity)

--- a/components/script/dom/reportingendpoint.rs
+++ b/components/script/dom/reportingendpoint.rs
@@ -26,7 +26,7 @@ use crate::dom::csp::Violation;
 use crate::dom::csppolicyviolationreport::serialize_disposition;
 use crate::dom::globalscope::GlobalScope;
 use crate::dom::performance::performanceresourcetiming::InitiatorType;
-use crate::fetch::create_a_potential_cors_request;
+use crate::fetch::{RequestWithGlobalScope, create_a_potential_cors_request};
 use crate::network_listener::{FetchResponseListener, ResourceTimingListener, submit_timing};
 use crate::script_runtime::CanGc;
 
@@ -203,11 +203,8 @@ impl SendReportsToEndpoints for GlobalScope {
             None,
             None,
             self.get_referrer(),
-            self.insecure_requests_policy(),
-            self.has_trustworthy_ancestor_or_current_origin(),
-            self.policy_container(),
-            self.request_client(),
         )
+        .with_global_scope(self)
         .method(http::Method::POST)
         .body(request_body)
         .origin(origin)

--- a/components/script/dom/request.rs
+++ b/components/script/dom/request.rs
@@ -39,6 +39,7 @@ use crate::dom::globalscope::GlobalScope;
 use crate::dom::headers::{Guard, Headers};
 use crate::dom::promise::Promise;
 use crate::dom::readablestream::ReadableStream;
+use crate::fetch::RequestWithGlobalScope;
 use crate::script_runtime::CanGc;
 
 #[dom_struct]
@@ -570,13 +571,7 @@ impl Request {
 
 fn net_request_from_global(global: &GlobalScope, url: ServoUrl) -> NetTraitsRequest {
     RequestBuilder::new(global.webview_id(), url, global.get_referrer())
-        .origin(global.get_url().origin())
-        .pipeline_id(Some(global.pipeline_id()))
-        .https_state(global.get_https_state())
-        .insecure_requests_policy(global.insecure_requests_policy())
-        .has_trustworthy_ancestor_origin(global.has_trustworthy_ancestor_or_current_origin())
-        .policy_container(global.policy_container())
-        .client(global.request_client())
+        .with_global_scope(global)
         .build()
 }
 

--- a/components/script/dom/servoparser/prefetch.rs
+++ b/components/script/dom/servoparser/prefetch.rs
@@ -148,8 +148,6 @@ impl TokenSink for PrefetchSink {
                         self.webview_id,
                         url,
                         cors_setting,
-                        self.origin.clone(),
-                        self.pipeline_id,
                         ScriptFetchOptions {
                             referrer: self.referrer.clone(),
                             referrer_policy: self.referrer_policy,
@@ -158,11 +156,13 @@ impl TokenSink for PrefetchSink {
                             credentials_mode: CredentialsMode::CredentialsSameOrigin,
                             parser_metadata: ParserMetadata::ParserInserted,
                         },
-                        self.insecure_requests_policy,
-                        self.has_trustworthy_ancestor_origin,
-                        self.policy_container.clone(),
-                        self.request_client.clone(),
-                    );
+                    )
+                    .insecure_requests_policy(self.insecure_requests_policy)
+                    .has_trustworthy_ancestor_origin(self.has_trustworthy_ancestor_origin)
+                    .policy_container(self.policy_container.clone())
+                    .client(self.request_client.clone())
+                    .origin(self.origin.clone())
+                    .pipeline_id(Some(self.pipeline_id));
                     let _ = self
                         .resource_threads
                         .send(CoreResourceMsg::Fetch(request, FetchChannels::Prefetch));
@@ -179,11 +179,11 @@ impl TokenSink for PrefetchSink {
                         self.get_cors_settings(tag, local_name!("crossorigin")),
                         None,
                         self.referrer.clone(),
-                        self.insecure_requests_policy,
-                        self.has_trustworthy_ancestor_origin,
-                        self.policy_container.clone(),
-                        self.request_client.clone(),
                     )
+                    .insecure_requests_policy(self.insecure_requests_policy)
+                    .has_trustworthy_ancestor_origin(self.has_trustworthy_ancestor_origin)
+                    .policy_container(self.policy_container.clone())
+                    .client(self.request_client.clone())
                     .origin(self.origin.clone())
                     .pipeline_id(Some(self.pipeline_id))
                     .referrer_policy(self.get_referrer_policy(tag, local_name!("referrerpolicy")));
@@ -216,11 +216,11 @@ impl TokenSink for PrefetchSink {
                                 cors_setting,
                                 None,
                                 self.referrer.clone(),
-                                self.insecure_requests_policy,
-                                self.has_trustworthy_ancestor_origin,
-                                self.policy_container.clone(),
-                                self.request_client.clone(),
                             )
+                            .insecure_requests_policy(self.insecure_requests_policy)
+                            .has_trustworthy_ancestor_origin(self.has_trustworthy_ancestor_origin)
+                            .policy_container(self.policy_container.clone())
+                            .client(self.request_client.clone())
                             .origin(self.origin.clone())
                             .pipeline_id(Some(self.pipeline_id))
                             .referrer_policy(referrer_policy)

--- a/components/script/dom/websocket.rs
+++ b/components/script/dom/websocket.rs
@@ -44,6 +44,7 @@ use crate::dom::eventtarget::EventTarget;
 use crate::dom::globalscope::GlobalScope;
 use crate::dom::messageevent::MessageEvent;
 use crate::dom::window::Window;
+use crate::fetch::RequestWithGlobalScope;
 use crate::script_runtime::CanGc;
 use crate::task::TaskOnce;
 use crate::task_source::SendableTaskSource;
@@ -283,9 +284,7 @@ impl WebSocketMethods<crate::DomTypeHolder> for WebSocket {
             url_record.clone(),
             Referrer::NoReferrer,
         )
-        .origin(global.origin().immutable().clone())
-        .insecure_requests_policy(global.insecure_requests_policy())
-        .has_trustworthy_ancestor_origin(global.has_trustworthy_ancestor_or_current_origin())
+        .with_global_scope(global)
         .mode(RequestMode::WebSocket {
             protocols,
             original_url: url_record,
@@ -293,9 +292,7 @@ impl WebSocketMethods<crate::DomTypeHolder> for WebSocket {
         .service_workers_mode(ServiceWorkersMode::None)
         .credentials_mode(CredentialsMode::Include)
         .cache_mode(CacheMode::NoCache)
-        .policy_container(global.policy_container())
-        .redirect_mode(RedirectMode::Error)
-        .client(global.request_client());
+        .redirect_mode(RedirectMode::Error);
 
         let channels = FetchChannels::WebSocket {
             event_sender: resource_event_sender,

--- a/components/script/dom/workers/workerglobalscope.rs
+++ b/components/script/dom/workers/workerglobalscope.rs
@@ -78,7 +78,7 @@ use crate::dom::window::{base64_atob, base64_btoa};
 use crate::dom::worker::TrustedWorkerAddress;
 use crate::dom::workerlocation::WorkerLocation;
 use crate::dom::workernavigator::WorkerNavigator;
-use crate::fetch::{CspViolationsProcessor, Fetch, load_whole_resource};
+use crate::fetch::{CspViolationsProcessor, Fetch, RequestWithGlobalScope, load_whole_resource};
 use crate::messaging::{CommonScriptMsg, ScriptEventLoopReceiver, ScriptEventLoopSender};
 use crate::microtask::{Microtask, MicrotaskQueue, UserMicrotask};
 use crate::network_listener::{FetchResponseListener, ResourceTimingListener, submit_timing};
@@ -699,13 +699,7 @@ impl WorkerGlobalScopeMethods<crate::DomTypeHolder> for WorkerGlobalScope {
             .credentials_mode(CredentialsMode::Include)
             .parser_metadata(ParserMetadata::NotParserInserted)
             .use_url_credentials(true)
-            .origin(global_scope.origin().immutable().clone())
-            .insecure_requests_policy(self.insecure_requests_policy())
-            .policy_container(global_scope.policy_container())
-            .has_trustworthy_ancestor_origin(
-                global_scope.has_trustworthy_ancestor_or_current_origin(),
-            )
-            .pipeline_id(Some(self.upcast::<GlobalScope>().pipeline_id()));
+            .with_global_scope(global_scope);
 
             // https://html.spec.whatwg.org/multipage/#fetch-a-classic-worker-imported-script
             let (url, bytes, muted_errors) = match load_whole_resource(

--- a/components/script/dom/xmlhttprequest.rs
+++ b/components/script/dom/xmlhttprequest.rs
@@ -73,7 +73,7 @@ use crate::dom::window::Window;
 use crate::dom::workerglobalscope::WorkerGlobalScope;
 use crate::dom::xmlhttprequesteventtarget::XMLHttpRequestEventTarget;
 use crate::dom::xmlhttprequestupload::XMLHttpRequestUpload;
-use crate::fetch::FetchCanceller;
+use crate::fetch::{FetchCanceller, RequestWithGlobalScope};
 use crate::mime::{APPLICATION, CHARSET, HTML, MimeExt, TEXT, XML};
 use crate::network_listener::{self, FetchResponseListener, ResourceTimingListener};
 use crate::script_runtime::{CanGc, JSContext};
@@ -692,13 +692,8 @@ impl XMLHttpRequestMethods<crate::DomTypeHolder> for XMLHttpRequest {
         .use_cors_preflight(self.upload_listener.get())
         .credentials_mode(credentials_mode)
         .use_url_credentials(use_url_credentials)
-        .origin(global.origin().immutable().clone())
-        .referrer_policy(self.referrer_policy)
-        .insecure_requests_policy(global.insecure_requests_policy())
-        .has_trustworthy_ancestor_origin(global.has_trustworthy_ancestor_or_current_origin())
-        .client(global.request_client())
-        .policy_container(global.policy_container())
-        .pipeline_id(Some(global.pipeline_id()));
+        .with_global_scope(&global)
+        .referrer_policy(self.referrer_policy);
 
         // step 4 (second half)
         if let Some(content_type) = content_type {

--- a/components/script/layout_image.rs
+++ b/components/script/layout_image.rs
@@ -21,6 +21,7 @@ use crate::dom::document::Document;
 use crate::dom::globalscope::GlobalScope;
 use crate::dom::node::{Node, NodeTraits};
 use crate::dom::performance::performanceresourcetiming::InitiatorType;
+use crate::fetch::RequestWithGlobalScope;
 use crate::network_listener::{self, FetchResponseListener, ResourceTimingListener};
 use crate::script_runtime::CanGc;
 
@@ -98,13 +99,8 @@ pub(crate) fn fetch_image_for_layout(
 
     let global = node.owner_global();
     let request = RequestBuilder::new(Some(document.webview_id()), url, global.get_referrer())
-        .origin(document.origin().immutable().clone())
         .destination(Destination::Image)
-        .pipeline_id(Some(global.pipeline_id()))
-        .insecure_requests_policy(document.insecure_requests_policy())
-        .has_trustworthy_ancestor_origin(document.has_trustworthy_ancestor_origin())
-        .policy_container(document.policy_container().to_owned())
-        .client(global.request_client());
+        .with_global_scope(&global);
 
     // Layout image loads do not delay the document load event.
     document.fetch_background(request, context);

--- a/components/script/security_manager.rs
+++ b/components/script/security_manager.rs
@@ -25,7 +25,7 @@ use crate::dom::performance::performanceresourcetiming::InitiatorType;
 use crate::dom::reportingobserver::ReportingObserver;
 use crate::dom::securitypolicyviolationevent::SecurityPolicyViolationEvent;
 use crate::dom::types::GlobalScope;
-use crate::fetch::create_a_potential_cors_request;
+use crate::fetch::{RequestWithGlobalScope, create_a_potential_cors_request};
 use crate::network_listener::{FetchResponseListener, ResourceTimingListener, submit_timing};
 use crate::script_runtime::CanGc;
 use crate::task::TaskOnce;
@@ -115,14 +115,10 @@ impl CSPViolationReportTask {
                 None,
                 None,
                 global.get_referrer(),
-                global.insecure_requests_policy(),
-                global.has_trustworthy_ancestor_or_current_origin(),
-                global.policy_container(),
-                global.request_client(),
             )
+            .with_global_scope(&global)
             .method(http::Method::POST)
             .body(request_body)
-            .origin(global.origin().immutable().clone())
             .credentials_mode(CredentialsMode::CredentialsSameOrigin)
             .headers(headers);
             // Step 3.4.2.4. Fetch request. The result will be ignored.

--- a/components/script/stylesheet_loader.rs
+++ b/components/script/stylesheet_loader.rs
@@ -42,7 +42,7 @@ use crate::dom::node::NodeTraits;
 use crate::dom::performance::performanceresourcetiming::InitiatorType;
 use crate::dom::shadowroot::ShadowRoot;
 use crate::dom::window::CSSErrorReporter;
-use crate::fetch::create_a_potential_cors_request;
+use crate::fetch::{RequestWithGlobalScope, create_a_potential_cors_request};
 use crate::messaging::{CommonScriptMsg, MainThreadScriptMsg};
 use crate::network_listener::{self, FetchResponseListener, ResourceTimingListener};
 use crate::script_runtime::{CanGc, ScriptThreadEventCategory};
@@ -477,15 +477,9 @@ impl ElementStylesheetLoader<'_> {
             cors_setting,
             None,
             global.get_referrer(),
-            document.insecure_requests_policy(),
-            document.has_trustworthy_ancestor_or_current_origin(),
-            global.policy_container(),
-            global.request_client(),
         )
-        .origin(document.origin().immutable().clone())
-        .pipeline_id(Some(element.global().pipeline_id()))
+        .with_global_scope(&global)
         .referrer_policy(referrer_policy)
-        .client(global.request_client())
         .integrity_metadata(integrity_metadata);
 
         document.fetch(LoadType::Stylesheet(url), request, context);


### PR DESCRIPTION
Rather than having each callside specifying the relevant
information from the GlobalScope, do this via a trait instead.
This would have saved us quite a bit of test debugging
since we would often forget to set relevant information
from the global context for a request.

Now, in the future when we need additional information from
the globalscope for a request, we only need to update this
method to make that happen.

Previously it would also sometimes use `document`, but
calling the relevant information on either `document` or
`globalscope` doesn't matter, since the `globalscope`
defers to the value from the `document` anyways.