### PR TITLE
script: Evict stale SVGs from image cache

### DIFF
--- a/components/layout/context.rs
+++ b/components/layout/context.rs
@@ -221,10 +221,11 @@ impl ImageResolver {
         image_id: PendingImageId,
         size: DeviceIntSize,
         node: OpaqueNode,
+        svg_id: Option<String>,
     ) -> Option<RasterImage> {
         let result = self
             .image_cache
-            .rasterize_vector_image(image_id, size, None);
+            .rasterize_vector_image(image_id, size, svg_id);
         if result.is_none() {
             self.pending_rasterization_images
                 .lock()

--- a/components/layout/context.rs
+++ b/components/layout/context.rs
@@ -222,7 +222,9 @@ impl ImageResolver {
         size: DeviceIntSize,
         node: OpaqueNode,
     ) -> Option<RasterImage> {
-        let result = self.image_cache.rasterize_vector_image(image_id, size);
+        let result = self
+            .image_cache
+            .rasterize_vector_image(image_id, size, None);
         if result.is_none() {
             self.pending_rasterization_images
                 .lock()

--- a/components/layout/display_list/mod.rs
+++ b/components/layout/display_list/mod.rs
@@ -1333,6 +1333,7 @@ impl<'a> BuilderForBoxFragment<'a> {
                                     vector_image.id,
                                     size,
                                     node,
+                                    vector_image.svg_id,
                                 )
                             })
                             .and_then(|rasterized_image| rasterized_image.id)

--- a/components/layout/layout_impl.rs
+++ b/components/layout/layout_impl.rs
@@ -301,6 +301,12 @@ impl Layout for LayoutThread {
             .remove_all_web_fonts_from_stylesheet(&stylesheet);
     }
 
+    #[servo_tracing::instrument(skip_all)]
+    fn remove_cached_image(&mut self, url: &ServoUrl) {
+        let mut resolved_images_cache = self.resolved_images_cache.write();
+        resolved_images_cache.remove(url);
+    }
+
     /// Return the resolved values of this node's padding rect.
     #[servo_tracing::instrument(skip_all)]
     fn query_padding(&self, node: TrustedNodeAddress) -> Option<PhysicalSides> {

--- a/components/layout/replaced.rs
+++ b/components/layout/replaced.rs
@@ -284,7 +284,10 @@ impl ReplacedContents {
             .ok();
 
         let vector_image = result.map(|result| match result {
-            Image::Vector(vector_image) => vector_image,
+            Image::Vector(mut vector_image) => {
+                vector_image.svg_id = Some(svg_data.svg_id);
+                vector_image
+            },
             _ => unreachable!("SVG element can't contain a raster image."),
         });
 
@@ -443,7 +446,12 @@ impl ReplacedContents {
                         let tag = self.base_fragment_info.tag?;
                         layout_context
                             .image_resolver
-                            .rasterize_vector_image(vector_image.id, size, tag.node)
+                            .rasterize_vector_image(
+                                vector_image.id,
+                                size,
+                                tag.node,
+                                vector_image.svg_id.clone(),
+                            )
                             .and_then(|i| i.id)
                     },
                 })
@@ -532,7 +540,12 @@ impl ReplacedContents {
                 let tag = self.base_fragment_info.tag.unwrap();
                 layout_context
                     .image_resolver
-                    .rasterize_vector_image(vector_image.id, raster_size, tag.node)
+                    .rasterize_vector_image(
+                        vector_image.id,
+                        raster_size,
+                        tag.node,
+                        vector_image.svg_id.clone(),
+                    )
                     .and_then(|image| image.id)
                     .map(|image_key| {
                         Fragment::Image(ArcRefCell::new(ImageFragment {

--- a/components/net/image_cache.rs
+++ b/components/net/image_cache.rs
@@ -502,11 +502,8 @@ impl ImageCacheStore {
             if self
                 .key_cache
                 .evicted_images
-                .contains(&(pending_id, requested_size))
+                .remove(&(pending_id, requested_size))
             {
-                self.key_cache
-                    .evicted_images
-                    .remove(&(pending_id, requested_size));
                 return;
             }
         };

--- a/components/net/image_cache.rs
+++ b/components/net/image_cache.rs
@@ -619,6 +619,16 @@ impl ImageCacheStore {
         }
     }
 
+    fn remove_loaded_image(
+        &mut self,
+        url: &ServoUrl,
+        origin: &ImmutableOrigin,
+        cors_setting: &Option<CorsSettings>,
+    ) {
+        self.completed_loads
+            .remove(&(url.clone(), origin.clone(), *cors_setting));
+    }
+
     /// Return a completed image if it exists, or None if there is no complete load
     /// or the complete load is not fully decoded or is unavailable.
     fn get_completed_image_if_available(
@@ -1001,6 +1011,16 @@ impl ImageCache for ImageCacheImpl {
     fn add_listener(&self, listener: ImageLoadListener) {
         let mut store = self.store.lock();
         self.add_listener_with_store(&mut store, listener);
+    }
+
+    fn evict_completed_image(
+        &self,
+        url: &ServoUrl,
+        origin: &ImmutableOrigin,
+        cors_setting: &Option<CorsSettings>,
+    ) {
+        let mut store = self.store.lock();
+        store.remove_loaded_image(url, origin, cors_setting);
     }
 
     fn evict_rasterized_image(&self, svg_id: &str) {

--- a/components/net/image_cache.rs
+++ b/components/net/image_cache.rs
@@ -904,9 +904,9 @@ impl ImageCache for ImageCacheImpl {
             return None;
         };
 
-        if let Some(svg_id) = svg_id {
+        if let Some(svg_uuid) = svg_uuid {
             if let Some(old_mapped_image_id) =
-                self.svg_id_image_id_map.lock().insert(svg_id, image_id)
+                self.svg_id_image_id_map.lock().insert(svg_uuid, image_id)
             {
                 store.vector_images.remove(&old_mapped_image_id);
                 store

--- a/components/net/image_cache.rs
+++ b/components/net/image_cache.rs
@@ -1129,6 +1129,8 @@ impl ImageCache for ImageCacheImpl {
                         .as_ref()
                         .and_then(|metadata| metadata.content_type.clone())
                         .map(|content_type| content_type.into_inner().into());
+                } else {
+                    debug!("Pending load for id {:?} already evicted from cache", id);
                 }
             },
             (FetchResponseMsg::ProcessResponseChunk(_, data), _) => {
@@ -1151,6 +1153,8 @@ impl ImageCache for ImageCacheImpl {
                             pending_load.metadata = Some(img_metadata);
                         }
                     }
+                } else {
+                    debug!("Pending load for id {:?} already evicted from cache", id);
                 }
             },
             (FetchResponseMsg::ProcessResponseEOF(_, result, _), key) => {
@@ -1182,6 +1186,8 @@ impl ImageCache for ImageCacheImpl {
                                 debug!("Image decoded");
                                 local_store.lock().handle_decoder(msg);
                             });
+                        } else {
+                            debug!("Pending load for id {:?} already evicted from cache", id);
                         }
                     },
                     Err(error) => {

--- a/components/net/tests/image_cache.rs
+++ b/components/net/tests/image_cache.rs
@@ -559,7 +559,7 @@ fn test_svg_rasterization() {
     };
 
     let size = webrender_api::units::DeviceIntSize::new(100, 100);
-    cache.rasterize_vector_image(vec_img.id, size);
+    cache.rasterize_vector_image(vec_img.id, size, None);
 }
 
 #[test]
@@ -620,7 +620,7 @@ fn test_rasterization_listener() {
         }
     });
 
-    cache.rasterize_vector_image(vec_img.id, size);
+    cache.rasterize_vector_image(vec_img.id, size, None);
 
     cache.add_rasterization_complete_listener(TEST_PIPELINE_ID, vec_img.id, size, callback);
 

--- a/components/script/dom/html/htmllinkelement.rs
+++ b/components/script/dom/html/htmllinkelement.rs
@@ -784,7 +784,7 @@ impl HTMLLinkElement {
 
                 let image_cache = window.image_cache();
                 if let Some(raster_image) =
-                    image_cache.rasterize_vector_image(vector_image.id, size)
+                    image_cache.rasterize_vector_image(vector_image.id, size, None)
                 {
                     send_rasterized_favicon_to_embedder(&raster_image);
                 } else {

--- a/components/script/dom/svg/svgsvgelement.rs
+++ b/components/script/dom/svg/svgsvgelement.rs
@@ -57,6 +57,7 @@ impl SVGSVGElement {
         }
     }
 
+    #[cfg_attr(crown, allow(crown::unrooted_must_root))]
     pub(crate) fn new(
         local_name: LocalName,
         prefix: Option<Prefix>,
@@ -256,6 +257,9 @@ impl VirtualMethods for SVGSVGElement {
             s.unbind_from_tree(context, can_gc);
         }
         let owner_window = self.owner_window();
+        self.owner_window()
+            .image_cache()
+            .evict_rasterized_image(&self.uuid);
         let data_url = self.cached_serialized_data_url.borrow().clone();
         if let Some(Ok(url)) = data_url {
             owner_window.layout_mut().remove_cached_image(&url);
@@ -266,8 +270,5 @@ impl VirtualMethods for SVGSVGElement {
             );
         }
         self.invalidate_cached_serialized_subtree();
-        self.owner_window()
-            .image_cache()
-            .evict_rasterized_image(&self.uuid);
     }
 }

--- a/components/script/dom/svg/svgsvgelement.rs
+++ b/components/script/dom/svg/svgsvgelement.rs
@@ -168,6 +168,7 @@ pub(crate) trait LayoutSVGSVGElementHelpers<'dom> {
 impl<'dom> LayoutSVGSVGElementHelpers<'dom> for LayoutDom<'dom, SVGSVGElement> {
     #[expect(unsafe_code)]
     fn data(self) -> SVGElementData<'dom> {
+        let svg_id = self.unsafe_get().uuid.clone();
         let element = self.upcast::<Element>();
         let width = element.get_attr_for_layout(&ns!(), &local_name!("width"));
         let height = element.get_attr_for_layout(&ns!(), &local_name!("height"));
@@ -182,6 +183,7 @@ impl<'dom> LayoutSVGSVGElementHelpers<'dom> for LayoutDom<'dom, SVGSVGElement> {
             width,
             height,
             view_box,
+            svg_id,
         }
     }
 }

--- a/components/script/dom/svg/svgsvgelement.rs
+++ b/components/script/dom/svg/svgsvgelement.rs
@@ -14,6 +14,7 @@ use style::parser::ParserContext;
 use style::stylesheets::Origin;
 use style::values::specified::Length;
 use style_traits::ParsingMode;
+use uuid::Uuid;
 use xml5ever::serialize::TraversalScope;
 
 use crate::dom::attr::Attr;
@@ -35,6 +36,7 @@ use crate::script_runtime::CanGc;
 #[dom_struct]
 pub(crate) struct SVGSVGElement {
     svggraphicselement: SVGGraphicsElement,
+    uuid: String,
     // The XML source of subtree rooted at this SVG element, serialized into
     // a base64 encoded `data:` url. This is cached to avoid recomputation
     // on each layout and must be invalidated when the subtree changes.
@@ -50,6 +52,7 @@ impl SVGSVGElement {
     ) -> SVGSVGElement {
         SVGSVGElement {
             svggraphicselement: SVGGraphicsElement::new_inherited(local_name, prefix, document),
+            uuid: Uuid::new_v4().to_string(),
             cached_serialized_data_url: Default::default(),
         }
     }

--- a/components/script/dom/svg/svgsvgelement.rs
+++ b/components/script/dom/svg/svgsvgelement.rs
@@ -28,6 +28,7 @@ use crate::dom::document::Document;
 use crate::dom::element::{AttributeMutation, Element, LayoutElementHelpers};
 use crate::dom::node::{
     ChildrenMutation, CloneChildrenFlag, Node, NodeDamage, NodeTraits, ShadowIncluding,
+    UnbindContext,
 };
 use crate::dom::svg::svggraphicselement::SVGGraphicsElement;
 use crate::dom::virtualmethods::VirtualMethods;

--- a/components/script/dom/svg/svgsvgelement.rs
+++ b/components/script/dom/svg/svgsvgelement.rs
@@ -27,7 +27,7 @@ use crate::dom::bindings::str::DOMString;
 use crate::dom::document::Document;
 use crate::dom::element::{AttributeMutation, Element, LayoutElementHelpers};
 use crate::dom::node::{
-    ChildrenMutation, CloneChildrenFlag, Node, NodeDamage, NodeTraits, ShadowIncluding,
+    ChildrenMutation, CloneChildrenFlag, Node, NodeDamage, NodeTraits, ShadowIncluding
 };
 use crate::dom::svg::svggraphicselement::SVGGraphicsElement;
 use crate::dom::virtualmethods::VirtualMethods;
@@ -249,5 +249,11 @@ impl VirtualMethods for SVGSVGElement {
         }
 
         self.invalidate_cached_serialized_subtree();
+    }
+
+    fn unbind_from_tree(&self, _context: &UnbindContext<'_>, _can_gc: CanGc) {
+        self.owner_window()
+            .image_cache()
+            .evict_rasterized_image(&self.uuid);
     }
 }

--- a/components/script/dom/svg/svgsvgelement.rs
+++ b/components/script/dom/svg/svgsvgelement.rs
@@ -27,7 +27,7 @@ use crate::dom::bindings::str::DOMString;
 use crate::dom::document::Document;
 use crate::dom::element::{AttributeMutation, Element, LayoutElementHelpers};
 use crate::dom::node::{
-    ChildrenMutation, CloneChildrenFlag, Node, NodeDamage, NodeTraits, ShadowIncluding
+    ChildrenMutation, CloneChildrenFlag, Node, NodeDamage, NodeTraits, ShadowIncluding,
 };
 use crate::dom::svg::svggraphicselement::SVGGraphicsElement;
 use crate::dom::virtualmethods::VirtualMethods;

--- a/components/shared/layout/lib.rs
+++ b/components/shared/layout/lib.rs
@@ -138,6 +138,7 @@ pub struct SVGElementData<'dom> {
     pub source: Option<Result<ServoUrl, ()>>,
     pub width: Option<&'dom AttrValue>,
     pub height: Option<&'dom AttrValue>,
+    pub svg_id: String,
     pub view_box: Option<&'dom AttrValue>,
 }
 

--- a/components/shared/layout/lib.rs
+++ b/components/shared/layout/lib.rs
@@ -305,6 +305,9 @@ pub trait Layout {
     /// Removes a stylesheet from the Layout.
     fn remove_stylesheet(&mut self, stylesheet: ServoArc<Stylesheet>);
 
+    /// Removes an image from the Layout image resolver cache.
+    fn remove_cached_image(&mut self, image_url: &ServoUrl);
+
     /// Requests a reflow.
     fn reflow(&mut self, reflow_request: ReflowRequest) -> Option<ReflowResult>;
 

--- a/components/shared/net/image_cache.rs
+++ b/components/shared/net/image_cache.rs
@@ -220,6 +220,14 @@ pub trait ImageCache: Sync + Send {
     /// Removes the rasterized image from the image_cache, identified by the id of the SVG
     fn evict_rasterized_image(&self, svg_id: &str);
 
+    /// Removes the completed image from the image_cache, identified by url, origin, and cors
+    fn evict_completed_image(
+        &self,
+        url: &ServoUrl,
+        origin: &ImmutableOrigin,
+        cors_setting: &Option<CorsSettings>,
+    );
+
     /// Synchronously get the broken image icon for this [`ImageCache`]. This will
     /// allocate space for this icon and upload it to WebRender.
     fn get_broken_image_icon(&self) -> Option<Arc<RasterImage>>;

--- a/components/shared/net/image_cache.rs
+++ b/components/shared/net/image_cache.rs
@@ -37,6 +37,7 @@ pub enum Image {
 #[derive(Clone, Debug, Deserialize, MallocSizeOf, Serialize)]
 pub struct VectorImage {
     pub id: VectorImageId,
+    pub svg_id: Option<String>,
     pub metadata: ImageMetadata,
     pub cors_status: CorsStatus,
 }

--- a/components/shared/net/image_cache.rs
+++ b/components/shared/net/image_cache.rs
@@ -202,7 +202,7 @@ pub trait ImageCache: Sync + Send {
         &self,
         image_id: VectorImageId,
         size: DeviceIntSize,
-        svg_uuid: Option<String>,
+        svg_id: Option<String>,
     ) -> Option<RasterImage>;
 
     /// Adds a new listener to be notified once the given `image_id` has been rasterized at
@@ -216,6 +216,9 @@ pub trait ImageCache: Sync + Send {
         size: DeviceIntSize,
         callback: ImageCacheResponseCallback,
     );
+
+    /// Removes the rasterized image from the image_cache, identified by the id of the SVG
+    fn evict_rasterized_image(&self, svg_id: &str);
 
     /// Synchronously get the broken image icon for this [`ImageCache`]. This will
     /// allocate space for this icon and upload it to WebRender.

--- a/components/shared/net/image_cache.rs
+++ b/components/shared/net/image_cache.rs
@@ -201,6 +201,7 @@ pub trait ImageCache: Sync + Send {
         &self,
         image_id: VectorImageId,
         size: DeviceIntSize,
+        svg_uuid: Option<String>,
     ) -> Option<RasterImage>;
 
     /// Adds a new listener to be notified once the given `image_id` has been rasterized at


### PR DESCRIPTION
Parsed and vectorized representations of SVGs in the image cache are never evicted when SVGs are updated, leading to stale SVGs staying in the image cache alongside updated ones. This PR:
- adds a stringified uuid field to SVGSVGElement
- adds a map of `SVGSVGElement` uuid to `PendingImageId` in `ImageCacheImpl`
- adds an optional argument for the uuid to `ImageCacheImpl::rasterize_vector_image`, which, if provided, removes any existing parsed svgs associated with the uuid and stores a new entry of uuid -> `PendingImageId`
- implements `unbind_from_tree` on SVGSVGElement, which clears the associated images/representations from the image_cache (from `vector_images`, `rasterized_vector_images`, and `completed_loads`) as well as from the layout image resolver image cache.

Testing: Each of the following documents should display their (very flashy) content correctly and memory usage should stay constant
<details>
<summary>Changing SVGSVGElement</summary>

```

<svg height="100" width="100" xmlns="http://www.w3.org/2000/svg">
  <circle id="c" r="1" cx="50" cy="50" fill="red" />
</svg>
<script>
let c = document.querySelector("#c");
let r = 1;
setInterval(() => {
  r += 1;
  c.setAttribute("r", r.toString());
  let tmp = document.createTextNode("ignored");
  c.parentNode.appendChild(tmp);
  tmp.remove();
}, 100);
</script>

```

</details>
<details>
<summary>Unbinding SVGSVGElements</summary>

```

<div id="parent_div">
  <svg id="test" height="100" width="100" xmlns="http://www.w3.org/2000/svg">
    <circle id="c" r="10" cx="50" cy="50" fill="red" />
  </svg>
</div>
<script>
  let div = document.querySelector("#parent_div");
  let svg_html_string = div.innerHTML;
  let svg = document.querySelector("#test");
  let r = 10;
  setInterval(() => {
    svg.remove();
    div.innerHTML = svg_html_string;
    svg = document.querySelector("#test");
    let circle = document.querySelector("#c");
    r += 1;
    circle.setAttribute("r", r.toString());
  }, 100);
</script>

```

</details>
<details>
<summary>Unbinding SVGSVGElements (and rebinding the same SVG)</summary>

This didn't work until I also evicted the associated image from the layout image resolver image cache and the image cache's `completed_loads` on SVGSVGElement unbind, so it seems like a useful, if a bit redundant, test.

```

<div id="parent_div">
  <svg id="test" height="100" width="100" xmlns="http://www.w3.org/2000/svg">
    <circle id="c" r="10" cx="50" cy="50" fill="red" />
  </svg>
</div>
<script>
  let div = document.querySelector("#parent_div");
  let svg_html_string = div.innerHTML;
  let svg = document.querySelector("#test");
  let r = 10;
  setInterval(() => {
    svg.remove();
    div.innerHTML = svg_html_string;
    svg = document.querySelector("#test");
  }, 100);
</script>

```

</details>

Fixes: #41070 
