### PR TITLE
cargo: Move shared tokio dependency to the root

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -188,6 +188,8 @@ tikv-jemallocator = "0.6.1"
 time = { package = "time", version = "0.3", features = ["large-dates", "local-offset", "serde"] }
 tokio = "1"
 tokio-rustls = { version = "0.26", default-features = false, features = ["logging"] }
+tokio-stream = "0.1"
+tokio-util = { version = "0.7.12", default-features = false }
 tower = { version = "0.5", default-features = false, features = ["util"] }
 tracing = "0.1.44"
 tracing-perfetto = "0.1.5"

--- a/components/net/Cargo.toml
+++ b/components/net/Cargo.toml
@@ -73,8 +73,8 @@ sha2 = "0.10"
 time = { workspace = true }
 tokio = { workspace = true, features = ["macros", "rt-multi-thread", "sync"] }
 tokio-rustls = { workspace = true }
-tokio-stream = "0.1"
-tokio-util = { version = "0.7.12", default-features = false, features = ["codec", "io"] }
+tokio-stream = { workspace = true }
+tokio-util = { workspace = true, features = ["codec", "io"] }
 tower = { workspace = true }
 tungstenite = { workspace = true }
 url = { workspace = true }

--- a/components/storage/Cargo.toml
+++ b/components/storage/Cargo.toml
@@ -32,8 +32,8 @@ storage_traits = { workspace = true }
 tempfile = "3"
 tokio = { workspace = true, features = ["macros", "rt-multi-thread", "sync"] }
 tokio-rustls = { workspace = true }
-tokio-stream = "0.1"
-tokio-util = { version = "0.7.12", default-features = false, features = ["codec", "io"] }
+tokio-stream = { workspace = true }
+tokio-util = { workspace = true, features = ["codec", "io"] }
 uuid = { workspace = true }
 
 [dev-dependencies]


### PR DESCRIPTION
There would be a follow up to bump all tokio dependencies together with bot, as we see three separate PRs today. What a waste of electricity.

Testing: If it builds and binary size stays same as previous, it works.
