### PR TITLE
script: Remove pointless rename.

### DIFF
--- a/components/script/dom/workers/workerglobalscope.rs
+++ b/components/script/dom/workers/workerglobalscope.rs
@@ -27,7 +27,7 @@ use mime::Mime;
 use net_traits::policy_container::PolicyContainer;
 use net_traits::request::{
     CredentialsMode, Destination, InsecureRequestsPolicy, ParserMetadata,
-    RequestBuilder as NetRequestInit, RequestId,
+    RequestBuilder, RequestId,
 };
 use net_traits::{FetchMetadata, Metadata, NetworkError, ReferrerPolicy, ResourceFetchTiming};
 use profile_traits::mem::{ProcessReports, perform_memory_report};
@@ -691,7 +691,7 @@ impl WorkerGlobalScopeMethods<crate::DomTypeHolder> for WorkerGlobalScope {
 
         for url in urls {
             let global_scope = self.upcast::<GlobalScope>();
-            let request = NetRequestInit::new(
+            let request = RequestBuilder::new(
                 global_scope.webview_id(),
                 url.clone(),
                 global_scope.get_referrer(),

--- a/components/script/dom/workers/workerglobalscope.rs
+++ b/components/script/dom/workers/workerglobalscope.rs
@@ -26,8 +26,7 @@ use js::rust::{HandleValue, MutableHandleValue, ParentRuntime};
 use mime::Mime;
 use net_traits::policy_container::PolicyContainer;
 use net_traits::request::{
-    CredentialsMode, Destination, InsecureRequestsPolicy, ParserMetadata,
-    RequestBuilder, RequestId,
+    CredentialsMode, Destination, InsecureRequestsPolicy, ParserMetadata, RequestBuilder, RequestId,
 };
 use net_traits::{FetchMetadata, Metadata, NetworkError, ReferrerPolicy, ResourceFetchTiming};
 use profile_traits::mem::{ProcessReports, perform_memory_report};

--- a/components/script/layout_image.rs
+++ b/components/script/layout_image.rs
@@ -9,7 +9,7 @@
 use std::sync::Arc;
 
 use net_traits::image_cache::{ImageCache, PendingImageId};
-use net_traits::request::{Destination, RequestBuilder as FetchRequestInit, RequestId};
+use net_traits::request::{Destination, RequestBuilder, RequestId};
 use net_traits::{FetchMetadata, FetchResponseMsg, NetworkError, ResourceFetchTiming};
 use servo_url::ServoUrl;
 
@@ -97,7 +97,7 @@ pub(crate) fn fetch_image_for_layout(
     };
 
     let global = node.owner_global();
-    let request = FetchRequestInit::new(Some(document.webview_id()), url, global.get_referrer())
+    let request = RequestBuilder::new(Some(document.webview_id()), url, global.get_referrer())
         .origin(document.origin().immutable().clone())
         .destination(Destination::Image)
         .pipeline_id(Some(global.pipeline_id()))


### PR DESCRIPTION
There's no naming conflict, and nowhere else the name NetRequestInit. All it does is increase confusion. 

Testing: No runtime changes.