### PR TITLE
layout: Consider margin of preceding block when placing abspos inside inline

### DIFF
--- a/components/layout/flow/inline/line.rs
+++ b/components/layout/flow/inline/line.rs
@@ -654,18 +654,20 @@ impl LineItemLayout<'_, '_> {
         // absolutely positioned element. If it's `inline` it would be placed inline
         // at the top of the line, but if it's block it would be placed in a new
         // block position after the linebox established by this line.
+        let block_position = self.layout.placement_state.current_margin.solve() -
+            self.current_state.parent_offset.block;
         let initial_start_corner =
             if style.get_box().original_display.outside() == DisplayOutside::Inline {
                 // Top of the line at the current inline position.
                 LogicalVec2 {
                     inline: self.current_state.inline_advance,
-                    block: -self.current_state.parent_offset.block,
+                    block: block_position,
                 }
             } else {
                 // After the bottom of the line at the start of the inline formatting context.
                 LogicalVec2 {
                     inline: -self.current_state.parent_offset.inline,
-                    block: self.line_metrics.block_size - self.current_state.parent_offset.block,
+                    block: block_position + self.line_metrics.block_size,
                 }
             };
 

--- a/tests/wpt/tests/css/CSS2/positioning/abspos-029.html
+++ b/tests/wpt/tests/css/CSS2/positioning/abspos-029.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<title>CSS Test: CSS Absolute Positioning: static position after previous margin, within inline formatting context</title>
+<link rel="author" title="Oriol Brufau" href="mailto:obrufau@igalia.com">
+<link rel="help" href="http://www.w3.org/TR/CSS21/visuren.html#comp-abspos">
+<link rel="help" href="https://github.com/servo/servo/issues/41625">
+<link rel="match" href="abspos-001-ref.xht">
+<!-- This is like abspos-001.xht, but placing everything inside an inline element -->
+
+<style>
+/* Set Up Conditions */
+* { margin: 0; padding: 0; border: 0;
+    position: static; float: none; display: block;
+    top: auto; left: auto; right: auto; bottom: auto; }
+head { display: none; }
+body { padding: 1em; }
+
+/* Test */
+.inline { display: inline }
+.margin { margin-bottom: 2em; }
+.abs { position: absolute; background: green; z-index: 1; height: 1em; width: 10em; }
+.flow { background: red; height: 1em; width: 10em; }
+</style>
+
+<span class="inline">
+  <div class="margin">Test passes if there is a green stripe and no red.</div>
+  <div class="abs"></div>
+  <div class="flow"></div>
+</span>


### PR DESCRIPTION
Now that we may have block-level boxes inside an inline formatting context, absolutely positioned boxes need to consider their margin.

Testing: Adding new test
Fixes: #41625
