### PR TITLE
devtools: Implement ActorEncode and clean inspector sub-actors

### DIFF
--- a/components/devtools/actors/browsing_context.rs
+++ b/components/devtools/actors/browsing_context.rs
@@ -229,14 +229,7 @@ impl BrowsingContextActor {
         .unwrap_or_default();
         let css_properties = CssPropertiesActor::new(actors.new_name("css-properties"), properties);
 
-        let inspector = InspectorActor {
-            name: actors.new_name("inspector"),
-            walker: RefCell::new(None),
-            page_style: RefCell::new(None),
-            highlighter: RefCell::new(None),
-            script_chan: script_sender.clone(),
-            browsing_context: name.clone(),
-        };
+        let inspector = InspectorActor::register(actors, pipeline_id, script_sender.clone());
 
         let reflow = ReflowActor::new(actors.new_name("reflow"));
 
@@ -264,7 +257,7 @@ impl BrowsingContextActor {
             accessibility: accessibility.name(),
             console,
             css_properties: css_properties.name(),
-            inspector: inspector.name(),
+            inspector,
             reflow: reflow.name(),
             streams: RefCell::new(HashMap::new()),
             style_sheets: style_sheets.name(),
@@ -275,7 +268,6 @@ impl BrowsingContextActor {
 
         actors.register(accessibility);
         actors.register(css_properties);
-        actors.register(inspector);
         actors.register(reflow);
         actors.register(style_sheets);
         actors.register(tabdesc);

--- a/components/devtools/actors/inspector/highlighter.rs
+++ b/components/devtools/actors/inspector/highlighter.rs
@@ -11,14 +11,9 @@ use devtools_traits::DevtoolScriptControlMsg;
 use serde::Serialize;
 use serde_json::{self, Map, Value};
 
-use crate::actor::{Actor, ActorError, ActorRegistry};
+use crate::actor::{Actor, ActorEncode, ActorError, ActorRegistry};
 use crate::protocol::ClientRequest;
-use crate::{EmptyReplyMsg, StreamId};
-
-#[derive(Serialize)]
-pub struct HighlighterMsg {
-    pub actor: String,
-}
+use crate::{ActorMsg, EmptyReplyMsg, StreamId};
 
 pub struct HighlighterActor {
     pub name: String,
@@ -107,5 +102,11 @@ impl HighlighterActor {
                 node_id,
             ))
             .unwrap();
+    }
+}
+
+impl ActorEncode<ActorMsg> for HighlighterActor {
+    fn encode(&self, _: &ActorRegistry) -> ActorMsg {
+        ActorMsg { actor: self.name() }
     }
 }

--- a/components/devtools/actors/inspector/page_style.rs
+++ b/components/devtools/actors/inspector/page_style.rs
@@ -17,7 +17,7 @@ use serde::Serialize;
 use serde_json::{self, Map, Value};
 
 use crate::StreamId;
-use crate::actor::{Actor, ActorError, ActorRegistry};
+use crate::actor::{Actor, ActorEncode, ActorError, ActorRegistry};
 use crate::actors::inspector::node::NodeActor;
 use crate::actors::inspector::style_rule::{AppliedRule, ComputedDeclaration, StyleRuleActor};
 use crate::actors::inspector::walker::{WalkerActor, find_child};
@@ -148,7 +148,7 @@ impl PageStyleActor {
             node.pipeline,
             target,
             registry,
-            &walker.root_node.actor,
+            &walker.root(registry)?.actor,
             vec![],
             |msg| msg.actor == target,
         )
@@ -358,5 +358,19 @@ impl PageStyleActor {
             value: false,
         };
         request.reply_final(&msg)
+    }
+}
+
+impl ActorEncode<PageStyleMsg> for PageStyleActor {
+    fn encode(&self, _: &ActorRegistry) -> PageStyleMsg {
+        PageStyleMsg {
+            actor: self.name(),
+            traits: HashMap::from([
+                ("fontStretchLevel4".into(), true),
+                ("fontStyleLevel4".into(), true),
+                ("fontVariations".into(), true),
+                ("fontWeightLevel4".into(), true),
+            ]),
+        }
     }
 }


### PR DESCRIPTION
Inspector sub-actors (walker, highlighter and page-style) had an overly complicated creation mechanism using `RefCell<Option<...>>` and instantiating these actors afterwards. Since the client always asks for the three actors and instantiating them isn't that expensive, we aren't saving anything from delaying this, and it introduces unnecessary complexity.

For `*Msg`, make inspector sub-actors follow the rest and implement `ActorEncode` instead of manually creating the struct in `handle_message`.

Note that this change doesn't fix the issue with navigation/reloading breaking the inspector. I am planning to send a patch for that, but it is cleaner to separate this refactor and merge it before.

Testing: Manually test that the inspector still works.
