### PR TITLE
Build/Canvas: Vello or Vello CPU feature flags

### DIFF
--- a/components/canvas/lib.rs
+++ b/components/canvas/lib.rs
@@ -7,6 +7,12 @@
 
 mod backend;
 
+#[cfg(any(
+    not(any(feature = "vello", feature = "vello_cpu")),
+    all(feature = "vello", feature = "vello_cpu")
+))]
+compile_error!("Either feature \"vello\" or \"vello_cpu\" must be enabled for this crate.");
+
 #[cfg(any(feature = "vello", feature = "vello_cpu"))]
 mod peniko_conversions;
 


### PR DESCRIPTION
Simple compile time check for only allowing one backend to be enabled. The error messages are sadly still full of other random errors but at least if people scroll up enough they are going to see the compile error.

Signed-off-by: Narfinger <Narfinger@users.noreply.github.com>

Testing: Tested with both flags and without both flags and both time we get an error.
Fixes: https://github.com/servo/servo/issues/40779
