### PR TITLE
Unit Tests: Disable proxy for local tests

### DIFF
--- a/components/servo/tests/common/mod.rs
+++ b/components/servo/tests/common/mod.rs
@@ -12,8 +12,8 @@ use compositing_traits::rendering_context::{RenderingContext, SoftwareRenderingC
 use dpi::PhysicalSize;
 use embedder_traits::EventLoopWaker;
 use servo::{
-    EmbedderControl, JSValue, JavaScriptEvaluationError, LoadStatus, Servo, ServoBuilder,
-    SimpleDialog, WebView, WebViewDelegate,
+    EmbedderControl, JSValue, JavaScriptEvaluationError, LoadStatus, Preferences, Servo,
+    ServoBuilder, SimpleDialog, WebView, WebViewDelegate,
 };
 
 pub struct ServoTest {
@@ -52,7 +52,12 @@ impl ServoTest {
         }
 
         let user_event_triggered = Arc::new(AtomicBool::new(false));
+        // Set the proxy to null as the tests will all be on localhost, hence, proxy might interfer.
+        let mut preferences = Preferences::default();
+        preferences.network_http_proxy_uri = String::new();
+
         let builder = ServoBuilder::default()
+            .preferences(preferences)
             .event_loop_waker(Box::new(EventLoopWakerImpl(user_event_triggered)));
         let builder = customize(builder);
         Self {


### PR DESCRIPTION
As per https://github.com/servo/servo/issues/41687 we currently have a very simple proxy model without any respect to NO_PROXY. Hence, things such as localhost and 127.0.0.1 might be forwarded to the proxy which probably will not respond correctly.

This sets the preference for the ServoTest to not have any proxy (as it will be taken from the default environment variable otherwise).

Signed-off-by: Narfinger <Narfinger@users.noreply.github.com>

Testing: Run tests which previously did not work and now works.
Fixes: Unit Tests run on proxy machines produced wrong results.
