### PR TITLE
net: Support no_proxy and https_proxy

### DIFF
--- a/components/config/prefs.rs
+++ b/components/config/prefs.rs
@@ -285,6 +285,8 @@ pub struct Preferences {
     /// A url for a https proxy. We treat an empty string as no proxy.
     pub network_https_proxy_uri: String,
     /// The domains for which we will not have a proxy. No effect if `network_http_proxy_uri` is not set.
+    /// The exact behavior is given by
+    /// <https://docs.rs/hyper-util/latest/hyper_util/client/proxy/matcher/struct.Builder.html#method.no>
     pub network_http_no_proxy: String,
     /// The weight of the http memory cache
     /// Notice that this is not equal to the number of different urls in the cache.

--- a/components/config/prefs.rs
+++ b/components/config/prefs.rs
@@ -282,6 +282,8 @@ pub struct Preferences {
     pub network_http_cache_disabled: bool,
     /// A url for a http proxy. We treat an empty string as no proxy.
     pub network_http_proxy_uri: String,
+    /// The domains for which we will not have a proxy. No effect if `network_http_proxy_uri` is not set.
+    pub network_http_no_proxy: String,
     /// The weight of the http memory cache
     /// Notice that this is not equal to the number of different urls in the cache.
     pub network_http_cache_size: u64,
@@ -474,6 +476,7 @@ impl Preferences {
             network_enforce_tls_onion: false,
             network_http_cache_disabled: false,
             network_http_proxy_uri: String::new(),
+            network_http_no_proxy: String::new(),
             network_http_cache_size: 5000,
             network_local_directory_listing_enabled: true,
             network_mime_sniff: false,
@@ -499,11 +502,14 @@ impl Default for Preferences {
     fn default() -> Self {
         let mut preferences = Self::const_default();
         preferences.user_agent = UserAgentPlatform::default().to_user_agent_string();
-        if let Ok(proxy_uri) = std::env::var("http_proxy") {
+        if let Ok(proxy_uri) = std::env::var("http_proxy").or_else(|_| std::env::var("HTTP_PROXY"))
+        {
             preferences.network_http_proxy_uri = proxy_uri;
-        } else if let Ok(proxy_uri) = std::env::var("HTTP_PROXY") {
-            preferences.network_http_proxy_uri = proxy_uri;
+            if let Ok(no_proxy) = std::env::var("no_proxy").or_else(|_| std::env::var("NO_PROXY")) {
+                preferences.network_http_no_proxy = no_proxy
+            }
         }
+
         preferences
     }
 }

--- a/components/config/prefs.rs
+++ b/components/config/prefs.rs
@@ -282,6 +282,8 @@ pub struct Preferences {
     pub network_http_cache_disabled: bool,
     /// A url for a http proxy. We treat an empty string as no proxy.
     pub network_http_proxy_uri: String,
+    /// A url for a https proxy. We treat an empty string as no proxy.
+    pub network_https_proxy_uri: String,
     /// The domains for which we will not have a proxy. No effect if `network_http_proxy_uri` is not set.
     pub network_http_no_proxy: String,
     /// The weight of the http memory cache
@@ -476,6 +478,7 @@ impl Preferences {
             network_enforce_tls_onion: false,
             network_http_cache_disabled: false,
             network_http_proxy_uri: String::new(),
+            network_https_proxy_uri: String::new(),
             network_http_no_proxy: String::new(),
             network_http_cache_size: 5000,
             network_local_directory_listing_enabled: true,
@@ -505,9 +508,14 @@ impl Default for Preferences {
         if let Ok(proxy_uri) = std::env::var("http_proxy").or_else(|_| std::env::var("HTTP_PROXY"))
         {
             preferences.network_http_proxy_uri = proxy_uri;
-            if let Ok(no_proxy) = std::env::var("no_proxy").or_else(|_| std::env::var("NO_PROXY")) {
-                preferences.network_http_no_proxy = no_proxy
-            }
+        }
+        if let Ok(proxy_uri) =
+            std::env::var("https_proxy").or_else(|_| std::env::var("HTTPS_PROXY"))
+        {
+            preferences.network_https_proxy_uri = proxy_uri;
+        }
+        if let Ok(no_proxy) = std::env::var("no_proxy").or_else(|_| std::env::var("NO_PROXY")) {
+            preferences.network_http_no_proxy = no_proxy
         }
 
         preferences


### PR DESCRIPTION
This now respects the no_proxy and https_proxy variables with a matching pref (read from the environment).

We now have a new ProxyConnector which uses the hyper_util match to either construct a Tunnel or clone the ServoHttpConnector inside.

This could potentially be slower if every connection is proxied as we redo the tunnel for every new connection. I think this is how the structure is intended to be used as
technically the http_proxy variable can have different proxy assignments per uri.

Signed-off-by: Narfinger <Narfinger@users.noreply.github.com>

Testing: Tested via setting the no_proxy variable and testing those websites vs proxied websites.
Fixes: https://github.com/servo/servo/issues/41687
