### PR TITLE
Stylo: Fix mismatched_lifetime_syntaxes warnings

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8036,7 +8036,7 @@ dependencies = [
 [[package]]
 name = "selectors"
 version = "0.33.0"
-source = "git+https://github.com/servo/stylo?branch=2025-11-01#ee0b989dbe43a8e2e98fdb1be791cf22d1bac045"
+source = "git+https://github.com/servo/stylo?branch=2025-11-01#a47ab67cb00051bbbf089ab7ce9f409c1bb1e04e"
 dependencies = [
  "bitflags 2.10.0",
  "cssparser",
@@ -8343,7 +8343,7 @@ dependencies = [
 [[package]]
 name = "servo_arc"
 version = "0.4.3"
-source = "git+https://github.com/servo/stylo?branch=2025-11-01#ee0b989dbe43a8e2e98fdb1be791cf22d1bac045"
+source = "git+https://github.com/servo/stylo?branch=2025-11-01#a47ab67cb00051bbbf089ab7ce9f409c1bb1e04e"
 dependencies = [
  "serde",
  "stable_deref_trait",
@@ -8889,7 +8889,7 @@ dependencies = [
 [[package]]
 name = "stylo"
 version = "0.9.0"
-source = "git+https://github.com/servo/stylo?branch=2025-11-01#ee0b989dbe43a8e2e98fdb1be791cf22d1bac045"
+source = "git+https://github.com/servo/stylo?branch=2025-11-01#a47ab67cb00051bbbf089ab7ce9f409c1bb1e04e"
 dependencies = [
  "app_units",
  "arrayvec",
@@ -8946,7 +8946,7 @@ dependencies = [
 [[package]]
 name = "stylo_atoms"
 version = "0.9.0"
-source = "git+https://github.com/servo/stylo?branch=2025-11-01#ee0b989dbe43a8e2e98fdb1be791cf22d1bac045"
+source = "git+https://github.com/servo/stylo?branch=2025-11-01#a47ab67cb00051bbbf089ab7ce9f409c1bb1e04e"
 dependencies = [
  "string_cache",
  "string_cache_codegen",
@@ -8955,12 +8955,12 @@ dependencies = [
 [[package]]
 name = "stylo_config"
 version = "0.9.0"
-source = "git+https://github.com/servo/stylo?branch=2025-11-01#ee0b989dbe43a8e2e98fdb1be791cf22d1bac045"
+source = "git+https://github.com/servo/stylo?branch=2025-11-01#a47ab67cb00051bbbf089ab7ce9f409c1bb1e04e"
 
 [[package]]
 name = "stylo_derive"
 version = "0.9.0"
-source = "git+https://github.com/servo/stylo?branch=2025-11-01#ee0b989dbe43a8e2e98fdb1be791cf22d1bac045"
+source = "git+https://github.com/servo/stylo?branch=2025-11-01#a47ab67cb00051bbbf089ab7ce9f409c1bb1e04e"
 dependencies = [
  "darling",
  "proc-macro2",
@@ -8972,7 +8972,7 @@ dependencies = [
 [[package]]
 name = "stylo_dom"
 version = "0.9.0"
-source = "git+https://github.com/servo/stylo?branch=2025-11-01#ee0b989dbe43a8e2e98fdb1be791cf22d1bac045"
+source = "git+https://github.com/servo/stylo?branch=2025-11-01#a47ab67cb00051bbbf089ab7ce9f409c1bb1e04e"
 dependencies = [
  "bitflags 2.10.0",
  "stylo_malloc_size_of",
@@ -8981,7 +8981,7 @@ dependencies = [
 [[package]]
 name = "stylo_malloc_size_of"
 version = "0.9.0"
-source = "git+https://github.com/servo/stylo?branch=2025-11-01#ee0b989dbe43a8e2e98fdb1be791cf22d1bac045"
+source = "git+https://github.com/servo/stylo?branch=2025-11-01#a47ab67cb00051bbbf089ab7ce9f409c1bb1e04e"
 dependencies = [
  "app_units",
  "cssparser",
@@ -8998,12 +8998,12 @@ dependencies = [
 [[package]]
 name = "stylo_static_prefs"
 version = "0.9.0"
-source = "git+https://github.com/servo/stylo?branch=2025-11-01#ee0b989dbe43a8e2e98fdb1be791cf22d1bac045"
+source = "git+https://github.com/servo/stylo?branch=2025-11-01#a47ab67cb00051bbbf089ab7ce9f409c1bb1e04e"
 
 [[package]]
 name = "stylo_traits"
 version = "0.9.0"
-source = "git+https://github.com/servo/stylo?branch=2025-11-01#ee0b989dbe43a8e2e98fdb1be791cf22d1bac045"
+source = "git+https://github.com/servo/stylo?branch=2025-11-01#a47ab67cb00051bbbf089ab7ce9f409c1bb1e04e"
 dependencies = [
  "app_units",
  "bitflags 2.10.0",
@@ -9416,7 +9416,7 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 [[package]]
 name = "to_shmem"
 version = "0.3.0"
-source = "git+https://github.com/servo/stylo?branch=2025-11-01#ee0b989dbe43a8e2e98fdb1be791cf22d1bac045"
+source = "git+https://github.com/servo/stylo?branch=2025-11-01#a47ab67cb00051bbbf089ab7ce9f409c1bb1e04e"
 dependencies = [
  "cssparser",
  "servo_arc",
@@ -9429,7 +9429,7 @@ dependencies = [
 [[package]]
 name = "to_shmem_derive"
 version = "0.1.0"
-source = "git+https://github.com/servo/stylo?branch=2025-11-01#ee0b989dbe43a8e2e98fdb1be791cf22d1bac045"
+source = "git+https://github.com/servo/stylo?branch=2025-11-01#a47ab67cb00051bbbf089ab7ce9f409c1bb1e04e"
 dependencies = [
  "darling",
  "proc-macro2",


### PR DESCRIPTION
Bumps Stylo to https://github.com/servo/stylo/pull/284

Testing: Not needed, no behavior change
