### PR TITLE
script: Init and pass down &mut JSContext in script-related threads

### DIFF
--- a/components/script/dom/globalscope.rs
+++ b/components/script/dom/globalscope.rs
@@ -3075,7 +3075,7 @@ impl GlobalScope {
             return ScriptThread::process_event(msg, cx);
         }
         if let Some(worker) = self.downcast::<WorkerGlobalScope>() {
-            return worker.process_event(msg);
+            return worker.process_event(msg, cx);
         }
         unreachable!();
     }

--- a/components/script/dom/workers/workerglobalscope.rs
+++ b/components/script/dom/workers/workerglobalscope.rs
@@ -1005,14 +1005,18 @@ impl WorkerGlobalScope {
     /// Process a single event as if it were the next event
     /// in the queue for this worker event-loop.
     /// Returns a boolean indicating whether further events should be processed.
-    pub(crate) fn process_event(&self, msg: CommonScriptMsg) -> bool {
+    pub(crate) fn process_event(
+        &self,
+        msg: CommonScriptMsg,
+        cx: &mut js::context::JSContext,
+    ) -> bool {
         if self.is_closing() {
             return false;
         }
         match msg {
             CommonScriptMsg::Task(_, task, _, _) => task.run_box(),
             CommonScriptMsg::CollectReports(reports_chan) => {
-                let cx = self.get_cx();
+                let cx: JSContext = cx.into();
                 perform_memory_report(|ops| {
                     let reports = cx.get_reports(format!("url({})", self.get_url()), ops);
                     reports_chan.send(ProcessReports::new(reports));

--- a/components/script/script_runtime.rs
+++ b/components/script/script_runtime.rs
@@ -698,6 +698,14 @@ impl Runtime {
         unsafe { Self::new_with_parent(None, main_thread_sender) }
     }
 
+    #[allow(unsafe_code)]
+    /// ## Safety
+    /// - only one `JSContext` can exist on the thread at a time (see note in [js::context::JSContext::from_ptr])
+    /// - the `JSContext` must not outlive the `Runtime`
+    pub(crate) unsafe fn cx(&self) -> js::context::JSContext {
+        unsafe { js::context::JSContext::from_ptr(RustRuntime::get().unwrap()) }
+    }
+
     /// Create a new runtime, optionally with the given [`ParentRuntime`] and [`SendableTaskSource`]
     /// for networking.
     ///

--- a/components/script/script_thread.rs
+++ b/components/script/script_thread.rs
@@ -941,7 +941,7 @@ impl ScriptThread {
             state.storage_threads.clone(),
             #[cfg(feature = "webgpu")]
             gpu_id_hub.clone(),
-            CanGc::note(),
+            CanGc::from_cx(&mut cx),
         );
 
         debugger_global.execute(CanGc::from_cx(&mut cx));


### PR DESCRIPTION
1. removed `ScriptThread::get_safe_cx` in favor of `Runtime::cx` (this intentionally shadows [RustRuntime::cx](https://doc.servo.org/mozjs/rust/struct.Runtime.html#method.cx), which is not really safe with all other stuff that happen in servo).
2. passed down cx from `ScriptThread::new` to accommodate those changes (we also need to pass cx for some other stuff).
3. we create JSContext in workers/worklets, so we can pass all the way down to https://github.com/servo/servo/blob/6ccc47f4c9c1b566b7ad866c2cad468538268716/components/script/dom/workers/workerglobalscope.rs#L1013 (so we can get &mut JSContext in tasks).

So with this PR, we prepared all entry points of JSContext (or other should actually be reentering via SM callback or passed down from the root one in the thread).

Testing: No changes just safety, but it should be covered by WPT
Part of #40600 
