### PR TITLE
net: Remove NetworkError::Internal

### DIFF
--- a/components/net/fetch/methods.rs
+++ b/components/net/fetch/methods.rs
@@ -55,9 +55,6 @@ use crate::protocols::{ProtocolRegistry, is_url_potentially_trustworthy};
 use crate::request_interceptor::RequestInterceptor;
 use crate::subresource_integrity::is_response_integrity_valid;
 
-const PARTIAL_RESPONSE_TO_NON_RANGE_REQUEST_ERROR: &str = "Refusing to provide partial response\
-from earlier ranged request to API that did not make a range request";
-
 pub type Target<'a> = &'a mut (dyn FetchTaskTarget + Send);
 
 #[derive(Clone, Deserialize, Serialize)]
@@ -673,9 +670,8 @@ pub async fn main_fetch(
             !request.headers.contains_key(RANGE)
         {
             // Defer rebinding result
-            blocked_error_response = Response::network_error(NetworkError::Internal(
-                PARTIAL_RESPONSE_TO_NON_RANGE_REQUEST_ERROR.to_string(),
-            ));
+            blocked_error_response =
+                Response::network_error(NetworkError::PartialResponseToNonRangeRequestError);
             &blocked_error_response
         } else {
             internal_response

--- a/components/net/http_loader.rs
+++ b/components/net/http_loader.rs
@@ -844,7 +844,7 @@ async fn obtain_response(
 
         let mut request = match request {
             Ok(request) => request,
-            Err(e) => return Err(NetworkError::from_http_error(&e)),
+            Err(error) => return Err(NetworkError::HttpError(error.to_string())),
         };
         *request.headers_mut() = headers.clone();
 
@@ -2044,8 +2044,10 @@ async fn http_network_fetch(
             .await
             {
                 Ok(response) => response,
-                Err(e) => {
-                    return Response::network_internal_error(e.to_string());
+                Err(error) => {
+                    return Response::network_error(NetworkError::WebsocketConnectionFailure(
+                        format!("{error:?}"),
+                    ));
                 },
             };
 

--- a/components/net/protocols/blob.rs
+++ b/components/net/protocols/blob.rs
@@ -77,7 +77,9 @@ impl ProtocolHandler for BlobProtocolHander {
                 },
                 _ => format!("{:?}", err),
             };
-            return Box::pin(ready(Response::network_error(NetworkError::Internal(err))));
+            return Box::pin(ready(Response::network_error(
+                NetworkError::BlobURLStoreError(err),
+            )));
         };
 
         Box::pin(ready(response))

--- a/components/net/protocols/mod.rs
+++ b/components/net/protocols/mod.rs
@@ -213,7 +213,7 @@ impl ProtocolHandler for WebPageContentProtocolHandler {
         // Step 8. Let resultURL be the result of parsing handlerURLString.
         let Ok(result_url) = ServoUrl::parse(&handler_url_string) else {
             return Box::pin(future::ready(Response::network_error(
-                NetworkError::Internal("Failed to parse substituted protocol handler url".into()),
+                NetworkError::ProtocolHandlerSubstitutionError,
             )));
         };
         // Ensure we did a proper substitution with a HTTP result

--- a/components/net/tests/image_cache.rs
+++ b/components/net/tests/image_cache.rs
@@ -276,18 +276,12 @@ fn test_notify_pending_response_network_error() {
 
     cache.notify_pending_response(
         id,
-        FetchResponseMsg::ProcessResponse(
-            create_request_id(),
-            Err(NetworkError::Internal("Network error".into())),
-        ),
+        FetchResponseMsg::ProcessResponse(create_request_id(), Err(NetworkError::InvalidMethod)),
     );
 
     cache.notify_pending_response(
         id,
-        FetchResponseMsg::ProcessResponseEOF(
-            create_request_id(),
-            Err(NetworkError::Internal("Network error".into())),
-        ),
+        FetchResponseMsg::ProcessResponseEOF(create_request_id(), Err(NetworkError::InvalidMethod)),
     );
 
     let result = cache.get_cached_image_status(url, origin, None);
@@ -356,18 +350,12 @@ fn test_image_listener_on_network_error() {
 
     cache.notify_pending_response(
         id,
-        FetchResponseMsg::ProcessResponse(
-            create_request_id(),
-            Err(NetworkError::Internal("Network error".into())),
-        ),
+        FetchResponseMsg::ProcessResponse(create_request_id(), Err(NetworkError::InvalidMethod)),
     );
 
     cache.notify_pending_response(
         id,
-        FetchResponseMsg::ProcessResponseEOF(
-            create_request_id(),
-            Err(NetworkError::Internal("Network error".into())),
-        ),
+        FetchResponseMsg::ProcessResponseEOF(create_request_id(), Err(NetworkError::InvalidMethod)),
     );
 
     match receiver.recv_timeout(std::time::Duration::from_millis(100)) {

--- a/components/script/dom/servoparser/mod.rs
+++ b/components/script/dom/servoparser/mod.rs
@@ -1310,7 +1310,9 @@ impl FetchResponseListener for ParserContext {
                     let page = page.replace("${bytes}", encoded_bytes.as_str());
                     page.replace("${secret}", &net_traits::PRIVILEGED_SECRET.to_string())
                 },
-                NetworkError::Internal(reason) |
+                NetworkError::BlobURLStoreError(reason) |
+                NetworkError::WebsocketConnectionFailure(reason) |
+                NetworkError::HttpError(reason) |
                 NetworkError::ResourceLoadError(reason) |
                 NetworkError::MimeType(reason) => {
                     let page = resources::read_string(Resource::NetErrorHTML);
@@ -1339,7 +1341,9 @@ impl FetchResponseListener for ParserContext {
                 NetworkError::MixedContent |
                 NetworkError::CacheError |
                 NetworkError::InvalidPort |
-                NetworkError::LocalDirectoryError => {
+                NetworkError::LocalDirectoryError |
+                NetworkError::PartialResponseToNonRangeRequestError |
+                NetworkError::ProtocolHandlerSubstitutionError => {
                     let page = resources::read_string(Resource::NetErrorHTML);
                     page.replace("${reason}", &format!("{:?}", error))
                 },

--- a/components/servo/lib.rs
+++ b/components/servo/lib.rs
@@ -90,11 +90,11 @@ pub mod protocol_handler {
     pub use net::fetch::methods::{DoneChannel, FetchContext};
     pub use net::filemanager_thread::FILE_CHUNK_SIZE;
     pub use net::protocols::{ProtocolHandler, ProtocolRegistry};
-    pub use net_traits::ResourceFetchTiming;
     pub use net_traits::filemanager_thread::RelativePos;
     pub use net_traits::http_status::HttpStatus;
     pub use net_traits::request::Request;
     pub use net_traits::response::{Response, ResponseBody};
+    pub use net_traits::{NetworkError, ResourceFetchTiming};
 
     pub use crate::webview_delegate::ProtocolHandlerRegistration;
 }

--- a/components/shared/net/response.rs
+++ b/components/shared/net/response.rs
@@ -190,10 +190,6 @@ impl Response {
         }
     }
 
-    pub fn network_internal_error<T: Into<String>>(msg: T) -> Response {
-        Self::network_error(NetworkError::Internal(msg.into()))
-    }
-
     pub fn url(&self) -> Option<&ServoUrl> {
         self.url.as_ref()
     }

--- a/ports/servoshell/desktop/protocols/servo.rs
+++ b/ports/servoshell/desktop/protocols/servo.rs
@@ -15,8 +15,8 @@ use std::pin::Pin;
 use headers::{ContentType, HeaderMapExt};
 use servo::UserAgentPlatform;
 use servo::protocol_handler::{
-    DoneChannel, FetchContext, ProtocolHandler, Request, ResourceFetchTiming, Response,
-    ResponseBody,
+    DoneChannel, FetchContext, NetworkError, ProtocolHandler, Request, ResourceFetchTiming,
+    Response, ResponseBody,
 };
 
 use crate::desktop::protocols::resource::ResourceProtocolHandler;
@@ -78,8 +78,8 @@ impl ProtocolHandler for ServoProtocolHandler {
                 json_response(request, format!("\"{user_agent}\""))
             },
 
-            _ => Box::pin(std::future::ready(Response::network_internal_error(
-                "Invalid shortcut",
+            _ => Box::pin(std::future::ready(Response::network_error(
+                NetworkError::ResourceLoadError("Invalid shortcut".to_owned()),
             ))),
         }
     }


### PR DESCRIPTION
Rather than this catch-all (which I copy-pasted from a usage where I should have introduced a specific enum value), we now should always use one of the enum values. If one does not exist, then it should be added as such.

Follow-up for #36434

Testing: it builds