### PR TITLE
script: Ship `navigator.sendBeacon`

### DIFF
--- a/components/config/prefs.rs
+++ b/components/config/prefs.rs
@@ -137,8 +137,6 @@ pub struct Preferences {
     pub dom_mutation_observer_enabled: bool,
     // feature: Navigator.registerProtocolHandler() | #40615 | Web/API/Navigator/registerProtocolHandler
     pub dom_navigator_protocol_handlers_enabled: bool,
-    // feature: Navigator.sendBeacon() | #38302 | Web/API/Navigator/sendBeacon
-    pub dom_navigator_sendbeacon_enabled: bool,
     // feature: Notification API | #34841 | Web/API/Notifications_API
     pub dom_notification_enabled: bool,
     // feature: OffscreenCanvas | #34111 | Web/API/OffscreenCanvas
@@ -351,7 +349,6 @@ impl Preferences {
             dom_uievent_which_enabled: true,
             dom_mutation_observer_enabled: true,
             dom_navigator_protocol_handlers_enabled: false,
-            dom_navigator_sendbeacon_enabled: false,
             dom_notification_enabled: false,
             dom_parallel_css_parsing_enabled: true,
             dom_offscreen_canvas_enabled: false,

--- a/components/script_bindings/webidls/Navigator.webidl
+++ b/components/script_bindings/webidls/Navigator.webidl
@@ -79,8 +79,7 @@ partial interface Navigator {
 
 // https://w3c.github.io/beacon/#sendbeacon-method
 partial interface Navigator {
-  [Throws, Pref="dom_navigator_sendbeacon_enabled"]
-  boolean sendBeacon(USVString url, optional BodyInit? data = null);
+  [Throws] boolean sendBeacon(USVString url, optional BodyInit? data = null);
 };
 
 // https://html.spec.whatwg.org/multipage/#custom-handlers

--- a/ports/servoshell/prefs.rs
+++ b/ports/servoshell/prefs.rs
@@ -30,7 +30,6 @@ pub(crate) static EXPERIMENTAL_PREFS: &[&str] = &[
     "dom_fontface_enabled",
     "dom_intersection_observer_enabled",
     "dom_navigator_protocol_handlers_enabled",
-    "dom_navigator_sendbeacon_enabled",
     "dom_notification_enabled",
     "dom_offscreen_canvas_enabled",
     "dom_permissions_enabled",


### PR DESCRIPTION
With keep-alive requests implemented, this feature is now fully working. Some tests still fail on
header parsing, which is #36801

Fixes #38302
