### PR TITLE
Revert "Build/Canvas: Vello or Vello CPU feature flags (#41686)"

### DIFF
--- a/components/canvas/lib.rs
+++ b/components/canvas/lib.rs
@@ -7,12 +7,6 @@
 
 mod backend;
 
-#[cfg(any(
-    not(any(feature = "vello", feature = "vello_cpu")),
-    all(feature = "vello", feature = "vello_cpu")
-))]
-compile_error!("Either feature \"vello\" or \"vello_cpu\" must be enabled for this crate.");
-
 #[cfg(any(feature = "vello", feature = "vello_cpu"))]
 mod peniko_conversions;
 


### PR DESCRIPTION
This reverts commit fb239a1f4ae73dde27fe5cfd08a3efc05d7631b7 (#41686).

This change makes it impossible to enable both canvas backends at the
same time which isn't a problem at all.
