### PR TITLE
CODEOWNERS: Add jschwe & yezhizhen as CI scenario tests owners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -7,6 +7,9 @@
 /components/fonts/platform/freetype/ohos/   @jschwe
 /.github/workflows/ohos.yml                 @jschwe
 
+# Reviewers for CI WebDriver scenario tests related code
+/etc/ci/scenario                            @jschwe @yezhizhen
+
 # Reviewers for compositing-related code
 /components/compositing @mrobinson
 


### PR DESCRIPTION
These are Selenium driven WebDriver scenario tests, with no owners atm. 
Right now all test cases are for OpenHarmony, but can be extended to other platforms in the future if needed.