### PR TITLE
layout: Offset scrollable overflow hit test item by containing block

### DIFF
--- a/components/layout/display_list/mod.rs
+++ b/components/layout/display_list/mod.rs
@@ -1102,7 +1102,12 @@ impl<'a> BuilderForBoxFragment<'a> {
             self.fragment.style().get_inherited_ui().pointer_events !=
                 style::computed_values::pointer_events::T::None
         {
-            self.build_hit_test(builder, self.fragment.scrollable_overflow().to_webrender());
+            self.build_hit_test(
+                builder,
+                self.fragment
+                    .offset_by_containing_block(&self.fragment.scrollable_overflow())
+                    .to_webrender(),
+            );
             return;
         }
         if self.is_collapsed_table_borders {

--- a/tests/wpt/tests/css/css-overflow/overflow-auto-scrolling-with-margins.html
+++ b/tests/wpt/tests/css/css-overflow/overflow-auto-scrolling-with-margins.html
@@ -1,6 +1,5 @@
 <!doctype html>
-<meta charset=utf-8>
-<title>Should be able to scroll an element that is offset by the ancestor's margin</title>
+<title>Should be able to interactively scroll an overflow: auto element with a margin</title>
 <link rel="help" href="https://github.com/servo/servo/pull/41707">
 <link rel="author" title="Jo Steven Novaryo" href="mailto:steven.novaryo@gmail.com">
 <script src=/resources/testharness.js></script>
@@ -20,7 +19,7 @@
   overflow: auto;
   scrollbar-width: none;
 }
-#target {
+#item {
   position: relative;
   top: 50px;
   left: 50px;
@@ -30,7 +29,7 @@
 }
 </style>
 <div id="scroller">
-  <div id="target">
+  <div id="item">
   </div>
 </div>
 
@@ -38,18 +37,15 @@
   promise_test(async (t) => {
     await waitForCompositorCommit();
     let rect = scroller.getBoundingClientRect();
-    const actions = new test_driver.Actions().scroll(rect.left+10, rect.top+10, 1000, 1000);
+    const actions = new test_driver.Actions().scroll(rect.left + 10, rect.top + 10, 1000, 1000);
     actions.send();
 
     let scroll_delta_promise = new Promise((resolve) => {
-      let onscroll = (evt) => {
-        resolve([scroller.scrollLeft, scroller.scrollTop]);
-      }
-      scroller.addEventListener("scroll", onscroll);
+      scroller.addEventListener("scroll", () => resolve([scroller.scrollLeft, scroller.scrollTop]));
     });
 
     let [horizontal_delta, vertical_delta] = await scroll_delta_promise;
-    assert_not_equals(horizontal_delta, 0, "Element horizontally scrolled");
-    assert_not_equals(vertical_delta, 0, "Element vertically scrolled");
-  }, "Element that is offset by the margin of it's ancestor should be able to be scrolled");
+    assert_equals(horizontal_delta, 50, "Element scrolled horizontally");
+    assert_equals(vertical_delta, 50, "Element scrolled vertically");
+  }, "Margins should not interfere with interactive scrolling of a scroll container");
 </script>

--- a/tests/wpt/tests/css/css-overflow/scroll-element-affected-by-parent-margin.html
+++ b/tests/wpt/tests/css/css-overflow/scroll-element-affected-by-parent-margin.html
@@ -1,0 +1,55 @@
+<!doctype html>
+<meta charset=utf-8>
+<title>Should be able to scroll an element that is offset by the ancestor's margin</title>
+<link rel="help" href="https://github.com/servo/servo/pull/41707">
+<link rel="author" title="Jo Steven Novaryo" href="mailto:steven.novaryo@gmail.com">
+<script src=/resources/testharness.js></script>
+<script src=/resources/testharnessreport.js></script>
+<script src="/resources/testdriver.js"></script>
+<script src="/resources/testdriver-vendor.js"></script>
+<script src="/resources/testdriver-actions.js"></script>
+<script src="/dom/events/scrolling/scroll_support.js"></script>
+<style>
+#scroller {
+  display: block;
+  margin-top: 200px;
+  margin-left: 200px;
+  width: 50px;
+  height: 50px;
+  background-color: red;
+  overflow: auto;
+  scrollbar-width: none;
+}
+#target {
+  position: relative;
+  top: 50px;
+  left: 50px;
+  width: 50px;
+  height: 50px;
+  background-color: green;
+}
+</style>
+<div id="scroller">
+  <div id="target">
+  </div>
+</div>
+
+<script>
+  promise_test(async (t) => {
+    await waitForCompositorCommit();
+    let rect = scroller.getBoundingClientRect();
+    const actions = new test_driver.Actions().scroll(rect.left+10, rect.top+10, 1000, 1000);
+    actions.send();
+
+    let scroll_delta_promise = new Promise((resolve) => {
+      let onscroll = (evt) => {
+        resolve([scroller.scrollLeft, scroller.scrollTop]);
+      }
+      scroller.addEventListener("scroll", onscroll);
+    });
+
+    let [horizontal_delta, vertical_delta] = await scroll_delta_promise;
+    assert_not_equals(horizontal_delta, 0, "Element horizontally scrolled");
+    assert_not_equals(vertical_delta, 0, "Element vertically scrolled");
+  }, "Element that is offset by the margin of it's ancestor should be able to be scrolled");
+</script>


### PR DESCRIPTION
Following the other item, offset the hit test scrollable overflow rectangle by the containing block.

This fix a bug that caused a very quirky behavior where we couldn't scroll a scroll container that is that is being offset by a certain amount by the ancestors.

Testing: Testdriver WPT