### PR TITLE
servoshell: Support tracing-rs events when using hitrace

### DIFF
--- a/ports/servoshell/lib.rs
+++ b/ports/servoshell/lib.rs
@@ -3,10 +3,6 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 use cfg_if::cfg_if;
-#[cfg(feature = "tracing")]
-use tracing::Event;
-#[cfg(feature = "tracing")]
-use tracing_subscriber::layer::Context;
 
 #[cfg(test)]
 mod test;
@@ -195,8 +191,7 @@ cfg_if! {
                 }
             }
 
-            fn on_event(&self, event: &Event<'_>, _ctx: Context<'_, S>) {
-                log::info!("hitrace on_event: {event:?}");
+            fn on_event(&self, event: &tracing::Event<'_>, _ctx: tracing_subscriber::layer::Context<'_, S>) {
                 hitrace::start_trace(
                     &std::ffi::CString::new(event.metadata().name())
                         .expect("Failed to convert str to CString"),

--- a/ports/servoshell/lib.rs
+++ b/ports/servoshell/lib.rs
@@ -3,8 +3,10 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 use cfg_if::cfg_if;
+#[cfg(feature = "tracing")]
 use tracing::Event;
-use tracing_subscriber::layer::Context; 
+#[cfg(feature = "tracing")]
+use tracing_subscriber::layer::Context;
 
 #[cfg(test)]
 mod test;

--- a/ports/servoshell/lib.rs
+++ b/ports/servoshell/lib.rs
@@ -3,6 +3,8 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 use cfg_if::cfg_if;
+use tracing::Event;
+use tracing_subscriber::layer::Context; 
 
 #[cfg(test)]
 mod test;
@@ -190,6 +192,16 @@ cfg_if! {
                     }
                 }
             }
+
+            fn on_event(&self, event: &Event<'_>, _ctx: Context<'_, S>) {
+                log::info!("hitrace on_event: {event:?}");
+                hitrace::start_trace(
+                    &std::ffi::CString::new(event.metadata().name())
+                        .expect("Failed to convert str to CString"),
+                );
+                hitrace::finish_trace();
+            }
+
 
             fn on_exit(&self, id: &Id, ctx: tracing_subscriber::layer::Context<'_, S>) {
                 if let Some(metadata) = ctx.metadata(id) {


### PR DESCRIPTION
Small addition of "on_event" for HiTrace

When using the tracing-perfetto backend, servo did trace LargestContentfullPaint, (LCP) but when using hitrace, the traces lacked the LCP. This was due to the tracing subscriber implementation not handling tracing-rs events.

More on `on_event` can be found here: https://docs.rs/tracing-subscriber/latest/tracing_subscriber/layer/trait.Layer.html#method.on_event

Testing: manually tested by adding and removing `--psn=--pref=largest_contentful_paint_enabled=true`
