### PR TITLE
libservo: Extend `SiteDataManager::clear_site_data` to clear sessionStorage

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8765,6 +8765,7 @@ dependencies = [
  "libc",
  "log",
  "malloc_size_of_derive",
+ "net_traits",
  "profile",
  "profile_traits",
  "rusqlite",

--- a/components/servo/site_data_manager.rs
+++ b/components/servo/site_data_manager.rs
@@ -179,13 +179,20 @@ impl SiteDataManager {
     /// The clearing is restricted to the provided `storage_types` bitflags.
     /// Both public and private browsing data are affected.
     ///
-    /// TODO: At present this method can only clear cookies for the specified
-    /// sites. Support for additional storage categories (e.g. localStorage
-    /// and sessionStorage) will be added in follow-up patches.
+    /// TODO: At present this method can only clear cookies and sessionStorage
+    /// data for the specified sites. Support for localStorage will be added
+    /// in a follow-up.
     pub fn clear_site_data(&self, sites: &[&str], storage_types: StorageType) {
         if storage_types.contains(StorageType::Cookies) {
             self.public_resource_threads.clear_cookies_for_sites(sites);
             self.private_resource_threads.clear_cookies_for_sites(sites);
+        }
+
+        if storage_types.contains(StorageType::Session) {
+            self.public_storage_threads
+                .clear_webstorage_for_sites(WebStorageType::Session, sites);
+            self.private_storage_threads
+                .clear_webstorage_for_sites(WebStorageType::Session, sites);
         }
     }
 

--- a/components/servo/tests/site_data_manager.rs
+++ b/components/servo/tests/site_data_manager.rs
@@ -356,6 +356,115 @@ fn test_clear_site_data_cookies() {
 }
 
 #[test]
+fn test_clear_site_data_session() {
+    let webview_test = WebViewTest::new();
+
+    let site_data_manager = webview_test.servo().site_data_manager();
+
+    let sites = site_data_manager.site_data(StorageType::all());
+    assert_eq!(sites.len(), 0);
+
+    let steps: &[TestSiteDataStep] = &[
+        (
+            SiteData::new("site-data-0.test", StorageType::Cookies),
+            None,
+        ),
+        (SiteData::new("site-data-1.test", StorageType::Local), None),
+        (
+            SiteData::new("site-data-2a.test", StorageType::Session),
+            None,
+        ),
+        (
+            SiteData::new("site-data-2b.test", StorageType::Session),
+            None,
+        ),
+        (
+            SiteData::new("site-data-2c.test", StorageType::Session),
+            None,
+        ),
+        (
+            SiteData::new(
+                "site-data-3.test",
+                StorageType::Cookies | StorageType::Local | StorageType::Session,
+            ),
+            None,
+        ),
+    ];
+
+    run_test_site_data_steps(&webview_test, steps);
+
+    let sites = site_data_manager.site_data(StorageType::all());
+    assert_eq!(
+        &sites,
+        &[
+            SiteData::new("site-data-0.test", StorageType::Cookies),
+            SiteData::new("site-data-1.test", StorageType::Local),
+            SiteData::new("site-data-2a.test", StorageType::Session),
+            SiteData::new("site-data-2b.test", StorageType::Session),
+            SiteData::new("site-data-2c.test", StorageType::Session),
+            SiteData::new(
+                "site-data-3.test",
+                StorageType::Cookies | StorageType::Local | StorageType::Session
+            ),
+        ]
+    );
+
+    site_data_manager.clear_site_data(&["site-data-2.test"], StorageType::Session);
+
+    let sites = site_data_manager.site_data(StorageType::all());
+    assert_eq!(
+        &sites,
+        &[
+            SiteData::new("site-data-0.test", StorageType::Cookies),
+            SiteData::new("site-data-1.test", StorageType::Local),
+            SiteData::new("site-data-2a.test", StorageType::Session),
+            SiteData::new("site-data-2b.test", StorageType::Session),
+            SiteData::new("site-data-2c.test", StorageType::Session),
+            SiteData::new(
+                "site-data-3.test",
+                StorageType::Cookies | StorageType::Local | StorageType::Session
+            ),
+        ]
+    );
+
+    site_data_manager.clear_site_data(&["site-data-2a.test"], StorageType::Session);
+
+    let sites = site_data_manager.site_data(StorageType::all());
+    assert_eq!(
+        &sites,
+        &[
+            SiteData::new("site-data-0.test", StorageType::Cookies),
+            SiteData::new("site-data-1.test", StorageType::Local),
+            SiteData::new("site-data-2b.test", StorageType::Session),
+            SiteData::new("site-data-2c.test", StorageType::Session),
+            SiteData::new(
+                "site-data-3.test",
+                StorageType::Cookies | StorageType::Local | StorageType::Session
+            ),
+        ]
+    );
+
+    site_data_manager.clear_site_data(
+        &["site-data-2c.test", "site-data-3.test"],
+        StorageType::Session,
+    );
+
+    let sites = site_data_manager.site_data(StorageType::all());
+    assert_eq!(
+        &sites,
+        &[
+            SiteData::new("site-data-0.test", StorageType::Cookies),
+            SiteData::new("site-data-1.test", StorageType::Local),
+            SiteData::new("site-data-2b.test", StorageType::Session),
+            SiteData::new(
+                "site-data-3.test",
+                StorageType::Cookies | StorageType::Local
+            ),
+        ]
+    );
+}
+
+#[test]
 fn test_clear_cookies() {
     let servo_test = ServoTest::new();
 

--- a/components/shared/storage/lib.rs
+++ b/components/shared/storage/lib.rs
@@ -34,12 +34,26 @@ impl StorageThreads {
         }
     }
 
+    // TODO: Consider changing to `webstorage_sites`
     pub fn webstorage_origins(&self, storage_type: WebStorageType) -> Vec<OriginDescriptor> {
         let (sender, receiver) = generic_channel::channel().unwrap();
         let _ = self
             .web_storage_thread
             .send(WebStorageThreadMsg::ListOrigins(sender, storage_type));
         receiver.recv().unwrap()
+    }
+
+    pub fn clear_webstorage_for_sites(&self, storage_type: WebStorageType, sites: &[&str]) {
+        let sites = sites.iter().map(|site| site.to_string()).collect();
+        let (sender, receiver) = generic_channel::channel().unwrap();
+        let _ = self
+            .web_storage_thread
+            .send(WebStorageThreadMsg::ClearDataForSites(
+                sender,
+                storage_type,
+                sites,
+            ));
+        let _ = receiver.recv();
     }
 }
 

--- a/components/shared/storage/webstorage_thread.rs
+++ b/components/shared/storage/webstorage_thread.rs
@@ -89,7 +89,12 @@ pub enum WebStorageThreadMsg {
     },
 
     /// gets the list of origin descriptors for given storage type
+    ///
+    /// TODO: Consider returning `Vec<SiteDescriptor>`
     ListOrigins(GenericSender<Vec<OriginDescriptor>>, WebStorageType),
+
+    /// clears storage data for given storage type and sites, affecting all matching origins
+    ClearDataForSites(GenericSender<()>, WebStorageType, Vec<String>),
 
     /// send a reply when done cleaning up thread resources and then shut it down
     Exit(GenericSender<()>),

--- a/components/storage/Cargo.toml
+++ b/components/storage/Cargo.toml
@@ -17,6 +17,7 @@ base = { workspace = true }
 bincode = { workspace = true }
 malloc_size_of = { workspace = true }
 malloc_size_of_derive = { workspace = true }
+net_traits = { workspace = true }
 libc = { workspace = true }
 log = { workspace = true }
 profile_traits = { workspace = true }


### PR DESCRIPTION
sessionStorage entries are identified via their associated origins and removed
across all browsing contexts. This brings sessionStorage in line with cookies,
which were already handled by the API.

Both public and private browsing contexts are included in the clearing
operation.

The necessary support has been added to the storage crate to clear WebStorage
data.

Testing: A new integration test has been added.
