### PR TITLE
net: Set a timeout for connecting

### DIFF
--- a/components/config/prefs.rs
+++ b/components/config/prefs.rs
@@ -274,8 +274,10 @@ pub struct Preferences {
     pub media_glvideo_enabled: bool,
     /// Enable a non-standard event handler for verifying behavior of media elements during tests.
     pub media_testing_enabled: bool,
-    /// The default timeout set for the connection in seconds. This will be evenly divided to all resolved ip addresses,
-    /// e.g., if we have a timeout of 20 and 4 resolved ip addresses, each ip address will have a connection timeout of 5s.
+    /// The default timeout set for establishing a network connection in seconds. This amount
+    /// if for the entire process of connecting to an address. For instance, if a particular host is
+    /// associated with multiple IP addresses, this timeout will be divided equally among
+    /// each IP address.
     pub network_connection_timeout: u64,
     pub network_enforce_tls_enabled: bool,
     pub network_enforce_tls_localhost: bool,

--- a/components/config/prefs.rs
+++ b/components/config/prefs.rs
@@ -274,7 +274,8 @@ pub struct Preferences {
     pub media_glvideo_enabled: bool,
     /// Enable a non-standard event handler for verifying behavior of media elements during tests.
     pub media_testing_enabled: bool,
-    /// The default timeout set for the connection in seconds. This will be evenly divided to all resolved ip addresses.
+    /// The default timeout set for the connection in seconds. This will be evenly divided to all resolved ip addresses,
+    /// e.g., if we have a timeout of 20 and 4 resolved ip addresses, each ip address will have a connection timeout of 5s.
     pub network_connection_timeout: u64,
     pub network_enforce_tls_enabled: bool,
     pub network_enforce_tls_localhost: bool,

--- a/components/config/prefs.rs
+++ b/components/config/prefs.rs
@@ -274,6 +274,8 @@ pub struct Preferences {
     pub media_glvideo_enabled: bool,
     /// Enable a non-standard event handler for verifying behavior of media elements during tests.
     pub media_testing_enabled: bool,
+    /// The default timeout set for the connection in seconds. This will be evenly divided to all resolved ip addresses.
+    pub network_connection_timeout: u64,
     pub network_enforce_tls_enabled: bool,
     pub network_enforce_tls_localhost: bool,
     pub network_enforce_tls_onion: bool,
@@ -466,6 +468,7 @@ impl Preferences {
             layout_writing_mode_enabled: false,
             media_glvideo_enabled: false,
             media_testing_enabled: false,
+            network_connection_timeout: 15,
             network_enforce_tls_enabled: false,
             network_enforce_tls_localhost: false,
             network_enforce_tls_onion: false,

--- a/components/net/connector.rs
+++ b/components/net/connector.rs
@@ -5,6 +5,7 @@
 use std::collections::hash_map::HashMap;
 use std::convert::TryFrom;
 use std::sync::Arc;
+use std::time::Duration;
 use std::{fmt, io};
 
 use futures::task::{Context, Poll};
@@ -49,6 +50,7 @@ impl ServoHttpConnector {
         let mut inner = HyperHttpConnector::new();
         inner.enforce_http(false);
         inner.set_happy_eyeballs_timeout(None);
+        inner.set_connect_timeout(Some(Duration::from_secs(pref!(network_connection_timeout))));
         ServoHttpConnector { inner }
     }
 }


### PR DESCRIPTION
This PR sets a timeout for the connecting part of hyper that is configurable via the prefs.
The timeout is currently set to 15 seconds which should be enough.


This fixes an interesting potential hang for the following specific situation:
- Load a Document that has some subresource (such as images) from a String.
- The subresource is on a domain that a restricted internet might not resolve.
- The connection hangs and does not change the LoadStatus of the document as it is blocked by the subresource.

Testing: This fixes issues with the 'test_contextual_context_menu_items' when running with a misbehaving proxy.
