### PR TITLE
fonts: Fix loading local web font

### DIFF
--- a/components/fonts/font_context.rs
+++ b/components/fonts/font_context.rs
@@ -899,7 +899,6 @@ impl RemoteWebFontDownloader {
             url.clone().into(),
             Referrer::ReferrerUrl(document_context.document_url.clone()),
         )
-        .origin(document_context.document_url.origin())
         .destination(Destination::Font)
         .mode(RequestMode::CorsMode)
         .credentials_mode(CredentialsMode::CredentialsSameOrigin)


### PR DESCRIPTION
When you open a local file that attempts to load a web font, previously it would trigger an assertion on the origin of the request being unequal to the
client.

We would set both the origin of the request as well as the client explicitly for fonts. Instead,
`request.populate_request_from_client` is supposed to initialize that.

Therefore, remove the explicit origin and instead rely on the client origin.

Fixes #41713
Testing: This only affects file URLs which are not well covered by automated tests