### PR TITLE
26488 - Moves WebGLRenderingContext cleanup to a dedicated struct

### DIFF
--- a/components/script_bindings/codegen/Bindings.conf
+++ b/components/script_bindings/codegen/Bindings.conf
@@ -743,7 +743,6 @@ DOMInterfaces = {
 'WebGLRenderingContext': {
     'canGc': ['MakeXRCompatible'],
     'weakReferenceable': True,
-    'allowDropImpl': True,
 },
 
 'WebGL2RenderingContext': {


### PR DESCRIPTION
Refactors the WebGLRenderingContext to manage resource cleanup via a dedicated `DroppableWebGLRenderingContext` struct.

Testing: This task is only a refactor, no tests added
Fixes: partially #26488 
