### PR TITLE
webdriver: Unify "Element Click" for touch & mouse + Improve PointerMove compliance

### DIFF
--- a/components/webdriver_server/lib.rs
+++ b/components/webdriver_server/lib.rs
@@ -50,12 +50,10 @@ use servo_url::ServoUrl;
 use style_traits::CSSPixel;
 use time::OffsetDateTime;
 use uuid::Uuid;
-#[cfg(not(any(target_env = "ohos", target_os = "android")))]
-use webdriver::actions::PointerMoveAction;
 use webdriver::actions::{
     ActionSequence, ActionsType, KeyAction, KeyActionItem, KeyDownAction, KeyUpAction,
-    PointerAction, PointerActionItem, PointerActionParameters, PointerDownAction, PointerOrigin,
-    PointerType, PointerUpAction,
+    PointerAction, PointerActionItem, PointerActionParameters, PointerDownAction,
+    PointerMoveAction, PointerOrigin, PointerType, PointerUpAction,
 };
 use webdriver::capabilities::CapabilitiesMatching;
 use webdriver::command::{
@@ -2301,7 +2299,6 @@ impl Handler {
 
     /// <https://w3c.github.io/webdriver/#element-click>
     /// Step 8 for elements other than <option>,
-    #[cfg(not(any(target_env = "ohos", target_os = "android")))]
     fn perform_element_click(&mut self, element: String) -> WebDriverResult<WebDriverResponse> {
         // Step 8.1 - 8.4: Create UUID, create input source "pointer".
         let id = Uuid::new_v4().to_string();

--- a/tests/wpt/meta/touch-events/mouseevents-after-touchend.tentative.html.ini
+++ b/tests/wpt/meta/touch-events/mouseevents-after-touchend.tentative.html.ini
@@ -2,12 +2,6 @@
   [Single tap should cause a click]
     expected: FAIL
 
-  [Single tap whose touchstart is consumed should not cause a click]
-    expected: FAIL
-
-  [Single tap whose touchend is consumed should not cause a click]
-    expected: FAIL
-
   [Double tap should cause single-click twice or a double-click]
     expected: FAIL
 
@@ -15,7 +9,4 @@
     expected: FAIL
 
   [Tapping too far points should not cause a dblclick]
-    expected: FAIL
-
-  [Multi tap should not cause mouse events]
     expected: FAIL


### PR DESCRIPTION
Testing: This should fix the quirky behaviour where we use mousemove
 to change pointer status for touch/pen. 
You can see the new WPT passing.

Fixes: #41250
Fixes: Part of #41620
Fixes: Part of #41725
