### PR TITLE
script: Complain to devtools when encoding meta tag is found after prescanning

### DIFF
--- a/components/script/dom/servoparser/mod.rs
+++ b/components/script/dom/servoparser/mod.rs
@@ -71,7 +71,7 @@ use crate::dom::html::htmlformelement::{FormControlElementHelpers, HTMLFormEleme
 use crate::dom::html::htmlimageelement::HTMLImageElement;
 use crate::dom::html::htmlscriptelement::{HTMLScriptElement, ScriptResult};
 use crate::dom::html::htmltemplateelement::HTMLTemplateElement;
-use crate::dom::node::{Node, ShadowIncluding};
+use crate::dom::node::{Node, NodeTraits, ShadowIncluding};
 use crate::dom::performance::performanceentry::PerformanceEntry;
 use crate::dom::performance::performancenavigationtiming::PerformanceNavigationTiming;
 use crate::dom::processinginstruction::ProcessingInstruction;
@@ -96,6 +96,10 @@ mod xml;
 
 use encoding::{NetworkDecoderState, NetworkSink};
 pub(crate) use html::serialize_html_fragment;
+
+const ENCODING_META_TAG_TOO_LATE_MESSAGE: &str = "An attempt to declare the encoding using a meta tag was found \
+too late, and the encoding was inferred instead. The meta tag needs to be moved into the <head> tag, into the first \
+1024 bytes";
 
 #[dom_struct]
 /// The parser maintains two input streams: one for input from script through
@@ -708,39 +712,48 @@ impl ServoParser {
             assert!(!self.aborted.get());
 
             self.document.window().reflow_if_reflow_timer_expired();
-            let script = match feed(&self.tokenizer) {
+            match feed(&self.tokenizer) {
                 TokenizerResult::Done => return,
-                TokenizerResult::EncodingIndicator(_) => continue,
-                TokenizerResult::Script(script) => script,
-            };
+                TokenizerResult::EncodingIndicator(_) => {
+                    self.document
+                        .owner_global()
+                        .complain_about_web_compatibility_issue(
+                            ENCODING_META_TAG_TOO_LATE_MESSAGE.to_owned(),
+                            self.document.url().as_str().to_owned(),
+                            self.get_current_line(),
+                            0,
+                        );
+                },
+                TokenizerResult::Script(script) => {
+                    // https://html.spec.whatwg.org/multipage/#parsing-main-incdata
+                    // branch "An end tag whose tag name is "script"
+                    // The spec says to perform the microtask checkpoint before
+                    // setting the insertion mode back from Text, but this is not
+                    // possible with the way servo and html5ever currently
+                    // relate to each other, and hopefully it is not observable.
+                    if is_execution_stack_empty() {
+                        self.document
+                            .window()
+                            .perform_a_microtask_checkpoint(can_gc);
+                    }
 
-            // https://html.spec.whatwg.org/multipage/#parsing-main-incdata
-            // branch "An end tag whose tag name is "script"
-            // The spec says to perform the microtask checkpoint before
-            // setting the insertion mode back from Text, but this is not
-            // possible with the way servo and html5ever currently
-            // relate to each other, and hopefully it is not observable.
-            if is_execution_stack_empty() {
-                self.document
-                    .window()
-                    .perform_a_microtask_checkpoint(can_gc);
-            }
+                    let script_nesting_level = self.script_nesting_level.get();
 
-            let script_nesting_level = self.script_nesting_level.get();
+                    self.script_nesting_level.set(script_nesting_level + 1);
+                    script.set_initial_script_text();
+                    let introduction_type_override =
+                        (script_nesting_level > 0).then_some(IntroductionType::INJECTED_SCRIPT);
+                    script.prepare(introduction_type_override, can_gc);
+                    self.script_nesting_level.set(script_nesting_level);
 
-            self.script_nesting_level.set(script_nesting_level + 1);
-            script.set_initial_script_text();
-            let introduction_type_override =
-                (script_nesting_level > 0).then_some(IntroductionType::INJECTED_SCRIPT);
-            script.prepare(introduction_type_override, can_gc);
-            self.script_nesting_level.set(script_nesting_level);
-
-            if self.document.has_pending_parsing_blocking_script() {
-                self.suspended.set(true);
-                return;
-            }
-            if self.aborted.get() {
-                return;
+                    if self.document.has_pending_parsing_blocking_script() {
+                        self.suspended.set(true);
+                        return;
+                    }
+                    if self.aborted.get() {
+                        return;
+                    }
+                },
             }
         }
     }


### PR DESCRIPTION
Properly supporting `<meta charset>` is hard because the specification and implementations disagree about what should be done when a meta tag is found after prescanning.  For example, if you load https://github.com/servo/servo/blob/main/tests/wpt/tests/html/syntax/charset/after-bogus-after-1kb.html in firefox then gecko will reject the meta tag, violating the spec. 

Related issues are  https://github.com/issues/created?issue=web-platform-tests%7Cwpt%7C56973 and https://github.com/whatwg/html/issues/6962.

This is change is therefore an alternative to https://github.com/servo/servo/pull/41430. Instead of reloading the page, we just send a message to the devtools telling the author to fix their page. This matches what gecko does on the testcase above.

The test expectations that change here are the result of unrelated changes in html5ever that haven't made their way into servo yet.

Testing: Devtools tests are hard to use so i only tested this manually

