### PR TITLE
script: Don't let LossyDecoder handle the BOM

### DIFF
--- a/components/script/dom/servoparser/encoding.rs
+++ b/components/script/dom/servoparser/encoding.rs
@@ -217,8 +217,8 @@ impl NetworkDecoderState {
                     document.set_encoding(encoding);
                     let buffered_bytes = mem::take(&mut encoding_detector.buffered_bytes);
                     *self = Self::Decoding(DecodingState {
-                        decoder: Some(LossyDecoder::new_encoding_rs(
-                            encoding,
+                        decoder: Some(LossyDecoder::new_from_encoding_rs_decoder(
+                            encoding.new_decoder_without_bom_handling(),
                             NetworkSink::default(),
                         )),
                         encoding,
@@ -245,7 +245,10 @@ impl NetworkDecoderState {
                 let encoding = encoding_detector.finish(document);
                 document.set_encoding(encoding);
                 let buffered_bytes = mem::take(&mut encoding_detector.buffered_bytes);
-                let mut decoder = LossyDecoder::new_encoding_rs(encoding, NetworkSink::default());
+                let mut decoder = LossyDecoder::new_from_encoding_rs_decoder(
+                    encoding.new_decoder_without_bom_handling(),
+                    NetworkSink::default(),
+                );
                 decoder.process(ByteTendril::from(&*buffered_bytes));
                 *self = Self::Decoding(DecodingState {
                     // Important to set `None` here to indicate that we're done decoding

--- a/tests/wpt/meta/encoding/remove-only-one-bom.html.ini
+++ b/tests/wpt/meta/encoding/remove-only-one-bom.html.ini
@@ -1,6 +1,0 @@
-[remove-only-one-bom.html]
-  [Should have removed only one BOM from frame 1]
-    expected: FAIL
-
-  [Should have removed only one BOM from frame 2]
-    expected: FAIL


### PR DESCRIPTION
We already handle BOMs when detecting the encoding. The decoder itself should not touch the BOMs in any way.

This fixes the case when there are multiple BOMs at the start of the document and we incorrectly remove all of them.

Depends on https://github.com/servo/html5ever/pull/704

Testing: New tests start to pass

