### PR TITLE
WebXR feature flag cleanup

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10535,7 +10535,6 @@ dependencies = [
  "log",
  "openxr",
  "raw-window-handle",
- "serde",
  "surfman",
  "webxr-api",
  "winapi",

--- a/components/constellation/Cargo.toml
+++ b/components/constellation/Cargo.toml
@@ -65,7 +65,7 @@ webgpu = { path = "../webgpu" }
 webgpu_traits = { workspace = true }
 webrender = { workspace = true }
 webrender_api = { workspace = true }
-webxr-api = { workspace = true, features = ["ipc"] }
+webxr-api = { workspace = true }
 
 [target.'cfg(any(target_os="macos", all(not(target_os = "windows"), not(target_os = "ios"), not(target_os="android"), not(target_env="ohos"), not(target_arch="arm"), not(target_arch="aarch64"))))'.dependencies]
 gaol = "0.2.1"

--- a/components/script/Cargo.toml
+++ b/components/script/Cargo.toml
@@ -162,7 +162,7 @@ uuid = { workspace = true, features = ["serde"] }
 webdriver = { workspace = true }
 webgpu_traits = { workspace = true }
 webrender_api = { workspace = true }
-webxr-api = { workspace = true, features = ["ipc"], optional = true }
+webxr-api = { workspace = true, optional = true }
 wgpu-core = { workspace = true }
 wgpu-types = { workspace = true }
 x25519-dalek = { workspace = true }

--- a/components/servo/Cargo.toml
+++ b/components/servo/Cargo.toml
@@ -139,13 +139,13 @@ webxr = { path = "../webxr", optional = true }
 
 [target.'cfg(not(any(target_os = "android", target_env = "ohos")))'.dependencies]
 arboard = { workspace = true, optional = true }
-webxr = { path = "../webxr", features = ["ipc", "glwindow", "headless"] }
+webxr = { path = "../webxr", features = ["glwindow", "headless"] }
 
 [target.'cfg(all(not(target_os = "windows"), not(target_os = "ios"), not(target_os = "android"), not(target_env = "ohos"), not(target_arch = "arm"), not(target_arch = "aarch64")))'.dependencies]
 gaol = "0.2.1"
 
 [target.'cfg(target_os = "windows")'.dependencies]
-webxr = { path = "../webxr", features = ["ipc", "glwindow", "headless", "openxr-api"] }
+webxr = { path = "../webxr", features = ["glwindow", "headless", "openxr-api"] }
 
 [dev-dependencies]
 http = { workspace = true }

--- a/components/shared/canvas/Cargo.toml
+++ b/components/shared/canvas/Cargo.toml
@@ -30,4 +30,4 @@ servo_config = { path = "../../config" }
 strum = { workspace = true }
 stylo = { workspace = true }
 webrender_api = { workspace = true }
-webxr-api = { workspace = true, features = ["ipc"] }
+webxr-api = { workspace = true }

--- a/components/shared/script/Cargo.toml
+++ b/components/shared/script/Cargo.toml
@@ -47,4 +47,4 @@ stylo_atoms = { workspace = true }
 stylo_traits = { workspace = true }
 webgpu_traits = { workspace = true, optional = true }
 webrender_api = { workspace = true }
-webxr-api = { workspace = true, features = ["ipc"] }
+webxr-api = { workspace = true }

--- a/components/shared/webxr/Cargo.toml
+++ b/components/shared/webxr/Cargo.toml
@@ -15,12 +15,9 @@ but adapted to Rust design patterns.'''
 [lib]
 path = "lib.rs"
 
-[features]
-ipc = ["serde", "ipc-channel", "euclid/serde"]
-
 [dependencies]
 embedder_traits = { workspace = true }
+ipc-channel = { workspace = true }
 euclid = { workspace = true }
-ipc-channel = { workspace = true, optional = true }
+serde = { workspace = true }
 log = { workspace = true }
-serde = { workspace = true, optional = true }

--- a/components/shared/webxr/device.rs
+++ b/components/shared/webxr/device.rs
@@ -5,11 +5,12 @@
 //! Traits to be implemented by backends
 
 use euclid::{Point2D, RigidTransform3D};
+use ipc_channel::ipc::IpcSender;
 
 use crate::{
     ContextId, EnvironmentBlendMode, Error, Event, Floor, Frame, HitTestId, HitTestSource,
     InputSource, LayerId, LayerInit, Native, Quitter, Session, SessionBuilder, SessionInit,
-    SessionMode, Viewports, WebXrSender,
+    SessionMode, Viewports,
 };
 
 /// A trait for discovering XR devices
@@ -47,7 +48,7 @@ pub trait DeviceAPI: 'static {
     fn initial_inputs(&self) -> Vec<InputSource>;
 
     /// Sets the event handling channel
-    fn set_event_dest(&mut self, dest: WebXrSender<Event>);
+    fn set_event_dest(&mut self, dest: IpcSender<Event>);
 
     /// Quit the session
     fn quit(&mut self);

--- a/components/shared/webxr/error.rs
+++ b/components/shared/webxr/error.rs
@@ -2,15 +2,13 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-#[cfg(feature = "ipc")]
 use serde::{Deserialize, Serialize};
 
 /// Errors that can be produced by XR.
 
 // TODO: this is currently incomplete!
 
-#[derive(Debug)]
-#[cfg_attr(feature = "ipc", derive(Serialize, Deserialize))]
+#[derive(Debug, Serialize, Deserialize)]
 pub enum Error {
     NoMatchingDevice,
     CommunicationError,

--- a/components/shared/webxr/events.rs
+++ b/components/shared/webxr/events.rs
@@ -3,14 +3,14 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 use euclid::RigidTransform3D;
+use serde::{Deserialize, Serialize};
 
 use crate::{
     ApiSpace, BaseSpace, Frame, InputFrame, InputId, InputSource, SelectEvent, SelectKind,
     WebXrSender,
 };
 
-#[derive(Clone, Debug)]
-#[cfg_attr(feature = "ipc", derive(serde::Serialize, serde::Deserialize))]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 #[expect(clippy::large_enum_variant)]
 pub enum Event {
     /// Input source connected
@@ -31,8 +31,7 @@ pub enum Event {
     ReferenceSpaceChanged(BaseSpace, RigidTransform3D<f32, ApiSpace, ApiSpace>),
 }
 
-#[derive(Clone, Copy, Debug)]
-#[cfg_attr(feature = "ipc", derive(serde::Serialize, serde::Deserialize))]
+#[derive(Clone, Copy, Debug, Serialize, Deserialize)]
 pub enum Visibility {
     /// Session fully displayed to user
     Visible,

--- a/components/shared/webxr/frame.rs
+++ b/components/shared/webxr/frame.rs
@@ -3,6 +3,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 use euclid::RigidTransform3D;
+use serde::{Deserialize, Serialize};
 
 use crate::{
     Floor, HitTestId, HitTestResult, InputFrame, Native, SubImages, Viewer, Viewports, Views,
@@ -11,8 +12,7 @@ use crate::{
 /// The per-frame data that is provided by the device.
 /// <https://www.w3.org/TR/webxr/#xrframe>
 // TODO: other fields?
-#[derive(Clone, Debug)]
-#[cfg_attr(feature = "ipc", derive(serde::Serialize, serde::Deserialize))]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct Frame {
     /// The pose information of the viewer
     pub pose: Option<ViewerPose>,
@@ -32,16 +32,14 @@ pub struct Frame {
     pub predicted_display_time: f64,
 }
 
-#[derive(Clone, Debug)]
-#[cfg_attr(feature = "ipc", derive(serde::Serialize, serde::Deserialize))]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub enum FrameUpdateEvent {
     UpdateFloorTransform(Option<RigidTransform3D<f32, Native, Floor>>),
     UpdateViewports(Viewports),
     HitTestSourceAdded(HitTestId),
 }
 
-#[derive(Clone, Debug)]
-#[cfg_attr(feature = "ipc", derive(serde::Serialize, serde::Deserialize))]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct ViewerPose {
     /// The transform from the viewer to native coordinates
     ///

--- a/components/shared/webxr/hand.rs
+++ b/components/shared/webxr/hand.rs
@@ -3,15 +3,14 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 use euclid::RigidTransform3D;
+use serde::{Deserialize, Serialize};
 
 use crate::Native;
 
-#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
-#[cfg_attr(feature = "ipc", derive(serde::Serialize, serde::Deserialize))]
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq, Serialize, Deserialize)]
 pub struct HandSpace;
 
-#[derive(Clone, Debug, Default)]
-#[cfg_attr(feature = "ipc", derive(serde::Serialize, serde::Deserialize))]
+#[derive(Clone, Debug, Default, Serialize, Deserialize)]
 pub struct Hand<J> {
     pub wrist: Option<J>,
     pub thumb_metacarpal: Option<J>,
@@ -24,8 +23,7 @@ pub struct Hand<J> {
     pub little: Finger<J>,
 }
 
-#[derive(Clone, Debug, Default)]
-#[cfg_attr(feature = "ipc", derive(serde::Serialize, serde::Deserialize))]
+#[derive(Clone, Debug, Default, Serialize, Deserialize)]
 pub struct Finger<J> {
     pub metacarpal: Option<J>,
     pub phalanx_proximal: Option<J>,
@@ -34,8 +32,7 @@ pub struct Finger<J> {
     pub phalanx_tip: Option<J>,
 }
 
-#[derive(Clone, Copy, Debug)]
-#[cfg_attr(feature = "ipc", derive(serde::Serialize, serde::Deserialize))]
+#[derive(Clone, Copy, Debug, Serialize, Deserialize)]
 pub struct JointFrame {
     pub pose: RigidTransform3D<f32, HandSpace, Native>,
     pub radius: f32,
@@ -102,8 +99,7 @@ impl<J> Finger<J> {
     }
 }
 
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
-#[cfg_attr(feature = "ipc", derive(serde::Serialize, serde::Deserialize))]
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize, Deserialize)]
 pub enum FingerJoint {
     Metacarpal,
     PhalanxProximal,
@@ -112,8 +108,7 @@ pub enum FingerJoint {
     PhalanxTip,
 }
 
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
-#[cfg_attr(feature = "ipc", derive(serde::Serialize, serde::Deserialize))]
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize, Deserialize)]
 pub enum Joint {
     Wrist,
     ThumbMetacarpal,

--- a/components/shared/webxr/hittest.rs
+++ b/components/shared/webxr/hittest.rs
@@ -5,11 +5,11 @@
 use std::iter::FromIterator;
 
 use euclid::{Point3D, RigidTransform3D, Rotation3D, Vector3D};
+use serde::{Deserialize, Serialize};
 
 use crate::{ApiSpace, Native, Space};
 
-#[derive(Clone, Copy, Debug)]
-#[cfg_attr(feature = "ipc", derive(serde::Serialize, serde::Deserialize))]
+#[derive(Clone, Copy, Debug, Serialize, Deserialize)]
 /// <https://immersive-web.github.io/hit-test/#xrray>
 pub struct Ray<Space> {
     /// The origin of the ray
@@ -18,8 +18,7 @@ pub struct Ray<Space> {
     pub direction: Vector3D<f32, Space>,
 }
 
-#[derive(Clone, Copy, Debug)]
-#[cfg_attr(feature = "ipc", derive(serde::Serialize, serde::Deserialize))]
+#[derive(Clone, Copy, Debug, Serialize, Deserialize)]
 /// <https://immersive-web.github.io/hit-test/#enumdef-xrhittesttrackabletype>
 pub enum EntityType {
     Point,
@@ -27,8 +26,7 @@ pub enum EntityType {
     Mesh,
 }
 
-#[derive(Clone, Copy, Debug)]
-#[cfg_attr(feature = "ipc", derive(serde::Serialize, serde::Deserialize))]
+#[derive(Clone, Copy, Debug, Serialize, Deserialize)]
 /// <https://immersive-web.github.io/hit-test/#dictdef-xrhittestoptionsinit>
 pub struct HitTestSource {
     pub id: HitTestId,
@@ -37,12 +35,10 @@ pub struct HitTestSource {
     pub types: EntityTypes,
 }
 
-#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
-#[cfg_attr(feature = "ipc", derive(serde::Serialize, serde::Deserialize))]
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq, Serialize, Deserialize)]
 pub struct HitTestId(pub u32);
 
-#[derive(Clone, Copy, Debug, Default)]
-#[cfg_attr(feature = "ipc", derive(serde::Serialize, serde::Deserialize))]
+#[derive(Clone, Copy, Debug, Default, Serialize, Deserialize)]
 /// Vec<EntityType>, but better
 pub struct EntityTypes {
     pub point: bool,
@@ -50,20 +46,17 @@ pub struct EntityTypes {
     pub mesh: bool,
 }
 
-#[derive(Clone, Copy, Debug)]
-#[cfg_attr(feature = "ipc", derive(serde::Serialize, serde::Deserialize))]
+#[derive(Clone, Copy, Debug, Serialize, Deserialize)]
 pub struct HitTestResult {
     pub id: HitTestId,
     pub space: RigidTransform3D<f32, HitTestSpace, Native>,
 }
 
-#[derive(Clone, Copy, Debug)]
-#[cfg_attr(feature = "ipc", derive(serde::Serialize, serde::Deserialize))]
+#[derive(Clone, Copy, Debug, Serialize, Deserialize)]
 /// The coordinate space of a hit test result
 pub struct HitTestSpace;
 
-#[derive(Clone, Copy, Debug)]
-#[cfg_attr(feature = "ipc", derive(serde::Serialize, serde::Deserialize))]
+#[derive(Clone, Copy, Debug, Serialize, Deserialize)]
 pub struct Triangle {
     pub first: Point3D<f32, Native>,
     pub second: Point3D<f32, Native>,

--- a/components/shared/webxr/input.rs
+++ b/components/shared/webxr/input.rs
@@ -3,23 +3,21 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 use euclid::RigidTransform3D;
+use serde::{Deserialize, Serialize};
 
 use crate::{Hand, Input, JointFrame, Native};
 
-#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
-#[cfg_attr(feature = "ipc", derive(serde::Serialize, serde::Deserialize))]
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq, Serialize, Deserialize)]
 pub struct InputId(pub u32);
 
-#[derive(Clone, Copy, Debug)]
-#[cfg_attr(feature = "ipc", derive(serde::Serialize, serde::Deserialize))]
+#[derive(Clone, Copy, Debug, Serialize, Deserialize)]
 pub enum Handedness {
     None,
     Left,
     Right,
 }
 
-#[derive(Clone, Copy, Debug)]
-#[cfg_attr(feature = "ipc", derive(serde::Serialize, serde::Deserialize))]
+#[derive(Clone, Copy, Debug, Serialize, Deserialize)]
 pub enum TargetRayMode {
     Gaze,
     TrackedPointer,
@@ -27,8 +25,7 @@ pub enum TargetRayMode {
     TransientPointer,
 }
 
-#[derive(Clone, Debug)]
-#[cfg_attr(feature = "ipc", derive(serde::Serialize, serde::Deserialize))]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct InputSource {
     pub handedness: Handedness,
     pub target_ray_mode: TargetRayMode,
@@ -38,8 +35,7 @@ pub struct InputSource {
     pub profiles: Vec<String>,
 }
 
-#[derive(Clone, Debug)]
-#[cfg_attr(feature = "ipc", derive(serde::Serialize, serde::Deserialize))]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct InputFrame {
     pub id: InputId,
     pub target_ray_origin: Option<RigidTransform3D<f32, Input, Native>>,
@@ -52,8 +48,7 @@ pub struct InputFrame {
     pub input_changed: bool,
 }
 
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
-#[cfg_attr(feature = "ipc", derive(serde::Serialize, serde::Deserialize))]
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize, Deserialize)]
 pub enum SelectEvent {
     /// Selection started
     Start,
@@ -63,8 +58,7 @@ pub enum SelectEvent {
     Select,
 }
 
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
-#[cfg_attr(feature = "ipc", derive(serde::Serialize, serde::Deserialize))]
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize, Deserialize)]
 pub enum SelectKind {
     Select,
     Squeeze,

--- a/components/shared/webxr/layer.rs
+++ b/components/shared/webxr/layer.rs
@@ -7,15 +7,12 @@ use std::num::NonZeroU32;
 use std::sync::atomic::{AtomicUsize, Ordering};
 
 use euclid::{Rect, Size2D};
+use serde::{Deserialize, Serialize};
 
 use crate::{Error, Viewport, Viewports};
 
-#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
-#[cfg_attr(feature = "ipc", derive(Deserialize, Serialize))]
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq, Deserialize, Serialize)]
 pub struct ContextId(pub u64);
-
-#[cfg(feature = "ipc")]
-use serde::{Deserialize, Serialize};
 
 pub trait GLTypes {
     type Device;
@@ -198,8 +195,7 @@ impl<GL: GLTypes> LayerManagerFactory<GL> {
     }
 }
 
-#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
-#[cfg_attr(feature = "ipc", derive(Deserialize, Serialize))]
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq, Deserialize, Serialize)]
 pub struct LayerId(usize);
 
 static NEXT_LAYER_ID: AtomicUsize = AtomicUsize::new(0);
@@ -210,8 +206,7 @@ impl Default for LayerId {
     }
 }
 
-#[derive(Clone, Copy, Debug)]
-#[cfg_attr(feature = "ipc", derive(Deserialize, Serialize))]
+#[derive(Clone, Copy, Debug, Deserialize, Serialize)]
 pub enum LayerInit {
     /// <https://www.w3.org/TR/webxr/#dictdef-xrwebgllayerinit>
     WebGLLayer {
@@ -255,8 +250,7 @@ impl LayerInit {
 }
 
 /// <https://immersive-web.github.io/layers/#enumdef-xrlayerlayout>
-#[derive(Clone, Copy, Debug)]
-#[cfg_attr(feature = "ipc", derive(Deserialize, Serialize))]
+#[derive(Clone, Copy, Debug, Deserialize, Serialize)]
 pub enum LayerLayout {
     // TODO: Default
     // Allocates one texture
@@ -267,8 +261,7 @@ pub enum LayerLayout {
     StereoTopBottom,
 }
 
-#[derive(Clone, Debug)]
-#[cfg_attr(feature = "ipc", derive(Deserialize, Serialize))]
+#[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct SubImages {
     pub layer_id: LayerId,
     pub sub_image: Option<SubImage>,
@@ -276,8 +269,7 @@ pub struct SubImages {
 }
 
 /// <https://immersive-web.github.io/layers/#xrsubimagetype>
-#[derive(Clone, Debug)]
-#[cfg_attr(feature = "ipc", derive(Deserialize, Serialize))]
+#[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct SubImage {
     pub color_texture: Option<NonZeroU32>,
     pub depth_stencil_texture: Option<NonZeroU32>,

--- a/components/shared/webxr/lib.rs
+++ b/components/shared/webxr/lib.rs
@@ -19,9 +19,6 @@ mod space;
 pub mod util;
 mod view;
 
-#[cfg(not(feature = "ipc"))]
-pub use std::sync::mpsc::{RecvTimeoutError, WebXrReceiver, WebXrSender};
-#[cfg(feature = "ipc")]
 use std::thread;
 use std::time::Duration;
 
@@ -36,12 +33,9 @@ pub use hittest::{
 pub use input::{
     Handedness, InputFrame, InputId, InputSource, SelectEvent, SelectKind, TargetRayMode,
 };
-#[cfg(feature = "ipc")]
-pub use ipc_channel::ipc::IpcReceiver as WebXrReceiver;
-#[cfg(feature = "ipc")]
-pub use ipc_channel::ipc::IpcSender as WebXrSender;
-#[cfg(feature = "ipc")]
-pub use ipc_channel::ipc::channel as webxr_channel;
+pub use ipc_channel::ipc::{
+    IpcReceiver as WebXrReceiver, IpcSender as WebXrSender, channel as webxr_channel,
+};
 pub use layer::{
     ContextId, GLContexts, GLTypes, LayerGrandManager, LayerGrandManagerAPI, LayerId, LayerInit,
     LayerLayout, LayerManager, LayerManagerAPI, LayerManagerFactory, SubImage, SubImages,
@@ -62,20 +56,6 @@ pub use view::{
     RightEye, SomeEye, VIEWER, View, Viewer, Viewport, Viewports, Views,
 };
 
-#[cfg(not(feature = "ipc"))]
-pub fn webxr_channel<T>() -> Result<(WebXrWebXrSender<T>, WebXrWebXrReceiver<T>), ()> {
-    Ok(std::sync::mpsc::channel())
-}
-
-#[cfg(not(feature = "ipc"))]
-pub fn recv_timeout<T>(
-    receiver: &WebXrReceiver<T>,
-    timeout: Duration,
-) -> Result<T, RecvTimeoutError> {
-    receiver.recv_timeout(timeout)
-}
-
-#[cfg(feature = "ipc")]
 pub fn recv_timeout<T>(
     receiver: &WebXrReceiver<T>,
     timeout: Duration,

--- a/components/shared/webxr/mock.rs
+++ b/components/shared/webxr/mock.rs
@@ -3,7 +3,6 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 use euclid::{Point2D, Rect, RigidTransform3D, Transform3D};
-#[cfg(feature = "ipc")]
 use serde::{Deserialize, Serialize};
 
 use crate::{
@@ -21,8 +20,7 @@ pub trait MockDiscoveryAPI<GL>: 'static {
     ) -> Result<Box<dyn DiscoveryAPI<GL>>, Error>;
 }
 
-#[derive(Clone, Debug)]
-#[cfg_attr(feature = "ipc", derive(Serialize, Deserialize))]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct MockDeviceInit {
     pub floor_origin: Option<RigidTransform3D<f32, Floor, Native>>,
     pub supports_inline: bool,
@@ -34,8 +32,7 @@ pub struct MockDeviceInit {
     pub world: Option<MockWorld>,
 }
 
-#[derive(Clone, Debug)]
-#[cfg_attr(feature = "ipc", derive(Serialize, Deserialize))]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct MockViewInit<Eye> {
     pub transform: RigidTransform3D<f32, Viewer, Eye>,
     pub projection: Transform3D<f32, Eye, Display>,
@@ -44,15 +41,13 @@ pub struct MockViewInit<Eye> {
     pub fov: Option<(f32, f32, f32, f32)>,
 }
 
-#[derive(Clone, Debug)]
-#[cfg_attr(feature = "ipc", derive(Serialize, Deserialize))]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub enum MockViewsInit {
     Mono(MockViewInit<Viewer>),
     Stereo(MockViewInit<LeftEye>, MockViewInit<RightEye>),
 }
 
-#[derive(Debug)]
-#[cfg_attr(feature = "ipc", derive(Serialize, Deserialize))]
+#[derive(Debug, Serialize, Deserialize)]
 pub enum MockDeviceMsg {
     SetViewerOrigin(Option<RigidTransform3D<f32, Viewer, Native>>),
     SetFloorOrigin(Option<RigidTransform3D<f32, Floor, Native>>),
@@ -67,8 +62,7 @@ pub enum MockDeviceMsg {
     SimulateResetPose,
 }
 
-#[derive(Clone, Debug)]
-#[cfg_attr(feature = "ipc", derive(Serialize, Deserialize))]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct MockInputInit {
     pub source: InputSource,
     pub pointer_origin: Option<RigidTransform3D<f32, Input, Native>>,
@@ -76,8 +70,7 @@ pub struct MockInputInit {
     pub supported_buttons: Vec<MockButton>,
 }
 
-#[derive(Debug)]
-#[cfg_attr(feature = "ipc", derive(Serialize, Deserialize))]
+#[derive(Debug, Serialize, Deserialize)]
 pub enum MockInputMsg {
     SetHandedness(Handedness),
     SetTargetRayMode(TargetRayMode),
@@ -94,21 +87,18 @@ pub enum MockInputMsg {
     UpdateButtonState(MockButton),
 }
 
-#[derive(Clone, Debug)]
-#[cfg_attr(feature = "ipc", derive(Serialize, Deserialize))]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct MockRegion {
     pub faces: Vec<Triangle>,
     pub ty: EntityType,
 }
 
-#[derive(Clone, Debug)]
-#[cfg_attr(feature = "ipc", derive(Serialize, Deserialize))]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct MockWorld {
     pub regions: Vec<MockRegion>,
 }
 
-#[derive(Clone, Debug, PartialEq)]
-#[cfg_attr(feature = "ipc", derive(Serialize, Deserialize))]
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub enum MockButtonType {
     Grip,
     Touchpad,
@@ -117,8 +107,7 @@ pub enum MockButtonType {
     OptionalThumbstick,
 }
 
-#[derive(Clone, Debug)]
-#[cfg_attr(feature = "ipc", derive(Serialize, Deserialize))]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct MockButton {
     pub button_type: MockButtonType,
     pub pressed: bool,

--- a/components/shared/webxr/session.rs
+++ b/components/shared/webxr/session.rs
@@ -7,7 +7,6 @@ use std::time::Duration;
 
 use euclid::{Point2D, Rect, RigidTransform3D, Size2D};
 use log::warn;
-#[cfg(feature = "ipc")]
 use serde::{Deserialize, Serialize};
 
 use crate::{
@@ -20,8 +19,7 @@ use crate::{
 static TIMEOUT: Duration = Duration::from_millis(5);
 
 /// <https://www.w3.org/TR/webxr/#xrsessionmode-enum>
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
-#[cfg_attr(feature = "ipc", derive(Serialize, Deserialize))]
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize, Deserialize)]
 pub enum SessionMode {
     Inline,
     ImmersiveVR,
@@ -29,8 +27,7 @@ pub enum SessionMode {
 }
 
 /// <https://immersive-web.github.io/webxr/#dictdef-xrsessioninit>
-#[derive(Clone, Debug, Eq, PartialEq)]
-#[cfg_attr(feature = "ipc", derive(Serialize, Deserialize))]
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
 pub struct SessionInit {
     pub required_features: Vec<String>,
     pub optional_features: Vec<String>,
@@ -77,8 +74,7 @@ impl SessionInit {
 }
 
 /// <https://immersive-web.github.io/webxr-ar-module/#xrenvironmentblendmode-enum>
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
-#[cfg_attr(feature = "ipc", derive(Serialize, Deserialize))]
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize, Deserialize)]
 pub enum EnvironmentBlendMode {
     Opaque,
     AlphaBlend,
@@ -86,8 +82,7 @@ pub enum EnvironmentBlendMode {
 }
 
 // The messages that are sent from the content thread to the session thread.
-#[derive(Debug)]
-#[cfg_attr(feature = "ipc", derive(Serialize, Deserialize))]
+#[derive(Debug, Serialize, Deserialize)]
 enum SessionMsg {
     CreateLayer(ContextId, LayerInit, WebXrSender<Result<LayerId, Error>>),
     DestroyLayer(ContextId, LayerId),
@@ -103,8 +98,7 @@ enum SessionMsg {
     GetBoundsGeometry(WebXrSender<Option<Vec<Point2D<f32, Floor>>>>),
 }
 
-#[cfg_attr(feature = "ipc", derive(Serialize, Deserialize))]
-#[derive(Clone)]
+#[derive(Serialize, Deserialize, Clone)]
 pub struct Quitter {
     sender: WebXrSender<SessionMsg>,
 }
@@ -118,7 +112,7 @@ impl Quitter {
 /// An object that represents an XR session.
 /// This is owned by the content thread.
 /// <https://www.w3.org/TR/webxr/#xrsession-interface>
-#[cfg_attr(feature = "ipc", derive(Serialize, Deserialize))]
+#[derive(Serialize, Deserialize)]
 pub struct Session {
     floor_transform: Option<RigidTransform3D<f32, Native, Floor>>,
     viewports: Viewports,
@@ -130,8 +124,7 @@ pub struct Session {
     supported_frame_rates: Vec<f32>,
 }
 
-#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
-#[cfg_attr(feature = "ipc", derive(Deserialize, Serialize))]
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq, Deserialize, Serialize)]
 pub struct SessionId(pub(crate) u32);
 
 impl Session {

--- a/components/shared/webxr/space.rs
+++ b/components/shared/webxr/space.rs
@@ -3,17 +3,16 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 use euclid::RigidTransform3D;
+use serde::{Deserialize, Serialize};
 
 use crate::{InputId, Joint};
 
-#[derive(Clone, Copy, Debug)]
-#[cfg_attr(feature = "ipc", derive(serde::Serialize, serde::Deserialize))]
+#[derive(Clone, Copy, Debug, Serialize, Deserialize)]
 /// A stand-in type for "the space isn't statically known since
 /// it comes from client side code"
 pub struct ApiSpace;
 
-#[derive(Clone, Copy, Debug, PartialEq)]
-#[cfg_attr(feature = "ipc", derive(serde::Serialize, serde::Deserialize))]
+#[derive(Clone, Copy, Debug, PartialEq, Serialize, Deserialize)]
 pub enum BaseSpace {
     Local,
     Floor,
@@ -24,8 +23,7 @@ pub enum BaseSpace {
     Joint(InputId, Joint),
 }
 
-#[derive(Clone, Copy, Debug)]
-#[cfg_attr(feature = "ipc", derive(serde::Serialize, serde::Deserialize))]
+#[derive(Clone, Copy, Debug, Serialize, Deserialize)]
 pub struct Space {
     pub base: BaseSpace,
     pub offset: RigidTransform3D<f32, ApiSpace, ApiSpace>,

--- a/components/shared/webxr/util.rs
+++ b/components/shared/webxr/util.rs
@@ -3,11 +3,11 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 use euclid::Transform3D;
+use serde::{Deserialize, Serialize};
 
 use crate::{FrameUpdateEvent, HitTestId, HitTestSource};
 
-#[derive(Clone, Copy, Debug)]
-#[cfg_attr(feature = "ipc", derive(serde::Serialize, serde::Deserialize))]
+#[derive(Clone, Copy, Debug, Serialize, Deserialize)]
 pub struct ClipPlanes {
     pub near: f32,
     pub far: f32,
@@ -43,8 +43,7 @@ impl ClipPlanes {
     }
 }
 
-#[derive(Clone, Debug, Default)]
-#[cfg_attr(feature = "ipc", derive(serde::Serialize, serde::Deserialize))]
+#[derive(Clone, Debug, Default, Serialize, Deserialize)]
 /// Holds on to hit tests
 pub struct HitTestList {
     tests: Vec<HitTestSource>,

--- a/components/shared/webxr/view.rs
+++ b/components/shared/webxr/view.rs
@@ -7,61 +7,50 @@
 use std::marker::PhantomData;
 
 use euclid::{Rect, RigidTransform3D, Transform3D};
-#[cfg(feature = "ipc")]
 use serde::{Deserialize, Serialize};
 
 /// The coordinate space of the viewer
 /// <https://immersive-web.github.io/webxr/#dom-xrreferencespacetype-viewer>
-#[derive(Clone, Copy, Debug)]
-#[cfg_attr(feature = "ipc", derive(Serialize, Deserialize))]
+#[derive(Clone, Copy, Debug, Serialize, Deserialize)]
 pub enum Viewer {}
 
 /// The coordinate space of the floor
 /// <https://immersive-web.github.io/webxr/#dom-xrreferencespacetype-local-floor>
-#[derive(Clone, Copy, Debug)]
-#[cfg_attr(feature = "ipc", derive(Serialize, Deserialize))]
+#[derive(Clone, Copy, Debug, Serialize, Deserialize)]
 pub enum Floor {}
 
 /// The coordinate space of the left eye
 /// <https://immersive-web.github.io/webxr/#dom-xreye-left>
-#[derive(Clone, Copy, Debug)]
-#[cfg_attr(feature = "ipc", derive(Serialize, Deserialize))]
+#[derive(Clone, Copy, Debug, Serialize, Deserialize)]
 pub enum LeftEye {}
 
 /// The coordinate space of the right eye
 /// <https://immersive-web.github.io/webxr/#dom-xreye-right>
-#[derive(Clone, Copy, Debug)]
-#[cfg_attr(feature = "ipc", derive(Serialize, Deserialize))]
+#[derive(Clone, Copy, Debug, Serialize, Deserialize)]
 pub enum RightEye {}
 
 /// The coordinate space of the left frustrum of a cubemap
-#[derive(Clone, Copy, Debug)]
-#[cfg_attr(feature = "ipc", derive(Serialize, Deserialize))]
+#[derive(Clone, Copy, Debug, Serialize, Deserialize)]
 pub enum CubeLeft {}
 
 /// The coordinate space of the right frustrum of a cubemap
-#[derive(Clone, Copy, Debug)]
-#[cfg_attr(feature = "ipc", derive(Serialize, Deserialize))]
+#[derive(Clone, Copy, Debug, Serialize, Deserialize)]
 pub enum CubeRight {}
 
 /// The coordinate space of the top frustrum of a cubemap
-#[derive(Clone, Copy, Debug)]
-#[cfg_attr(feature = "ipc", derive(Serialize, Deserialize))]
+#[derive(Clone, Copy, Debug, Serialize, Deserialize)]
 pub enum CubeTop {}
 
 /// The coordinate space of the bottom frustrum of a cubemap
-#[derive(Clone, Copy, Debug)]
-#[cfg_attr(feature = "ipc", derive(Serialize, Deserialize))]
+#[derive(Clone, Copy, Debug, Serialize, Deserialize)]
 pub enum CubeBottom {}
 
 /// The coordinate space of the back frustrum of a cubemap
-#[derive(Clone, Copy, Debug)]
-#[cfg_attr(feature = "ipc", derive(Serialize, Deserialize))]
+#[derive(Clone, Copy, Debug, Serialize, Deserialize)]
 pub enum CubeBack {}
 
 /// Pattern-match on eyes
-#[derive(Clone, Copy, Debug)]
-#[cfg_attr(feature = "ipc", derive(Serialize, Deserialize))]
+#[derive(Clone, Copy, Debug, Serialize, Deserialize)]
 pub struct SomeEye<Eye>(u8, PhantomData<Eye>);
 pub const LEFT_EYE: SomeEye<LeftEye> = SomeEye(0, PhantomData);
 pub const RIGHT_EYE: SomeEye<RightEye> = SomeEye(1, PhantomData);
@@ -80,32 +69,27 @@ impl<Eye1, Eye2> PartialEq<SomeEye<Eye2>> for SomeEye<Eye1> {
 
 /// The native 3D coordinate space of the device
 /// This is not part of the webvr specification.
-#[derive(Clone, Copy, Debug)]
-#[cfg_attr(feature = "ipc", derive(Serialize, Deserialize))]
+#[derive(Clone, Copy, Debug, Serialize, Deserialize)]
 pub enum Native {}
 
 /// The normalized device coordinate space, where the display
 /// is from (-1,-1) to (1,1).
 // TODO: are we OK assuming that we can use the same coordinate system for all displays?
-#[derive(Clone, Copy, Debug)]
-#[cfg_attr(feature = "ipc", derive(Serialize, Deserialize))]
+#[derive(Clone, Copy, Debug, Serialize, Deserialize)]
 pub enum Display {}
 
 /// The unnormalized device coordinate space, where the display
 /// is from (0,0) to (w,h), measured in pixels.
 // TODO: are we OK assuming that we can use the same coordinate system for all displays?
-#[derive(Clone, Copy, Debug)]
-#[cfg_attr(feature = "ipc", derive(Serialize, Deserialize))]
+#[derive(Clone, Copy, Debug, Serialize, Deserialize)]
 pub enum Viewport {}
 
 /// The coordinate space of an input device
-#[derive(Clone, Copy, Debug)]
-#[cfg_attr(feature = "ipc", derive(Serialize, Deserialize))]
+#[derive(Clone, Copy, Debug, Serialize, Deserialize)]
 pub enum Input {}
 
 /// The coordinate space of a secondary capture view
-#[derive(Clone, Copy, Debug)]
-#[cfg_attr(feature = "ipc", derive(Serialize, Deserialize))]
+#[derive(Clone, Copy, Debug, Serialize, Deserialize)]
 pub enum Capture {}
 
 /// For each eye, the pose of that eye,
@@ -113,8 +97,7 @@ pub enum Capture {}
 /// For stereo displays, we have a `View<LeftEye>` and a `View<RightEye>`.
 /// For mono displays, we hagve a `View<Viewer>`
 /// <https://immersive-web.github.io/webxr/#xrview>
-#[derive(Clone, Debug)]
-#[cfg_attr(feature = "ipc", derive(Serialize, Deserialize))]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct View<Eye> {
     pub transform: RigidTransform3D<f32, Eye, Native>,
     pub projection: Transform3D<f32, Eye, Display>,
@@ -139,8 +122,7 @@ impl<Eye> View<Eye> {
 }
 
 /// Whether a device is mono or stereo, and the views it supports.
-#[derive(Clone, Debug)]
-#[cfg_attr(feature = "ipc", derive(Serialize, Deserialize))]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 #[expect(clippy::large_enum_variant)]
 pub enum Views {
     /// Mono view for inline VR, viewport and projection matrices are calculated by client
@@ -161,8 +143,7 @@ pub enum Views {
 /// A list of viewports per-eye in the order of fields in Views.
 ///
 /// Not all must be in active use.
-#[derive(Clone, Debug)]
-#[cfg_attr(feature = "ipc", derive(Serialize, Deserialize))]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct Viewports {
     pub viewports: Vec<Rect<i32, Viewport>>,
 }

--- a/components/webgl/Cargo.toml
+++ b/components/webgl/Cargo.toml
@@ -33,5 +33,5 @@ rustc-hash = { workspace = true }
 surfman = { workspace = true }
 webrender = { workspace = true }
 webrender_api = { workspace = true }
-webxr = { path = "../webxr", features = ["ipc"], optional = true }
-webxr-api = { workspace = true, features = ["ipc"], optional = true }
+webxr = { path = "../webxr", optional = true }
+webxr-api = { workspace = true, optional = true }

--- a/components/webxr/Cargo.toml
+++ b/components/webxr/Cargo.toml
@@ -20,7 +20,6 @@ default = ["x11"]
 angle = ["surfman/sm-angle"]
 glwindow = []
 headless = []
-ipc = ["webxr-api/ipc", "serde"]
 openxr-api = ["angle", "openxr", "winapi", "wio", "surfman/sm-angle-default"]
 x11 = ["surfman/sm-x11"]
 
@@ -31,7 +30,6 @@ glow = { workspace = true }
 log = { workspace = true }
 openxr = { workspace = true, optional = true }
 raw-window-handle = { workspace = true }
-serde = { workspace = true, optional = true }
 surfman = { workspace = true, features = ["chains", "sm-raw-window-handle-06"] }
 webxr-api = { workspace = true }
 


### PR DESCRIPTION
This PR is best explained via looking at the Cargo.toml files.

webxr/webxr-api have the feature flag "ipc". This is required by important crates such as script and canvas. The only distinction was made in servo which does not use the ipc for android/ohos but because servo depends on script, this was essentially useless.

This PR removes the feature flag and cleans up the code related to it.

Testing: Compilation is the test.
