### PR TITLE
servoshell: Support formatting key,value pairs of events via hitrace on ohos

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3966,6 +3966,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1f08b27f2170156e182b2c3e340d68d087b34b2479366986c4e2e5339d73fe18"
 dependencies = [
  "hitrace-sys",
+ "tracing-core",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -94,7 +94,7 @@ gstreamer-video = "0.24"
 gstreamer-webrtc = { version = "0.24", features = ["v1_18"] }
 harfbuzz-sys = "0.6.1"
 headers = "0.4"
-hitrace = { version="0.1.6", features = ["api-19", "tracing-rs"] }
+hitrace = { version = "0.1.6", features = ["api-19", "tracing-rs"] }
 hkdf = "0.12"
 html5ever = "0.38"
 http = "1.4"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -94,7 +94,7 @@ gstreamer-video = "0.24"
 gstreamer-webrtc = { version = "0.24", features = ["v1_18"] }
 harfbuzz-sys = "0.6.1"
 headers = "0.4"
-hitrace = { path = "/home/am/dev/hitrace/hitrace", features = ["api-19", "tracing-level-conversion"] }
+hitrace = { version="0.1.6", features = ["api-19", "tracing-rs"] }
 hkdf = "0.12"
 html5ever = "0.38"
 http = "1.4"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -94,7 +94,7 @@ gstreamer-video = "0.24"
 gstreamer-webrtc = { version = "0.24", features = ["v1_18"] }
 harfbuzz-sys = "0.6.1"
 headers = "0.4"
-hitrace = {path="/home/am/dev/hitrace/hitrace", features=["api-19", "tracing-level-conversion"]}
+hitrace = { path = "/home/am/dev/hitrace/hitrace", features = ["api-19", "tracing-level-conversion"] }
 hkdf = "0.12"
 html5ever = "0.38"
 http = "1.4"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -94,7 +94,7 @@ gstreamer-video = "0.24"
 gstreamer-webrtc = { version = "0.24", features = ["v1_18"] }
 harfbuzz-sys = "0.6.1"
 headers = "0.4"
-hitrace = "0.1.6"
+hitrace = {path="/home/am/dev/hitrace/hitrace", features=["api-19", "tracing-level-conversion"]}
 hkdf = "0.12"
 html5ever = "0.38"
 http = "1.4"

--- a/ports/servoshell/lib.rs
+++ b/ports/servoshell/lib.rs
@@ -3,10 +3,6 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 use cfg_if::cfg_if;
-#[cfg(feature = "tracing")]
-use tracing::Event;
-#[cfg(feature = "tracing")]
-use tracing_subscriber::layer::Context;
 
 #[cfg(test)]
 mod test;

--- a/ports/servoshell/lib.rs
+++ b/ports/servoshell/lib.rs
@@ -3,8 +3,10 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 use cfg_if::cfg_if;
+#[cfg(feature = "tracing")]
 use tracing::Event;
-use tracing_subscriber::layer::Context; 
+#[cfg(feature = "tracing")]
+use tracing_subscriber::layer::Context;
 
 #[cfg(test)]
 mod test;

--- a/ports/servoshell/lib.rs
+++ b/ports/servoshell/lib.rs
@@ -3,6 +3,8 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 use cfg_if::cfg_if;
+use tracing::Event;
+use tracing_subscriber::layer::Context; 
 
 #[cfg(test)]
 mod test;

--- a/ports/servoshell/lib.rs
+++ b/ports/servoshell/lib.rs
@@ -199,7 +199,7 @@ cfg_if! {
                     &std::ffi::CString::new(key_value_string)
                         .expect("Failed to convert str to CString"),
                 );
-                
+
                 hitrace::finish_trace();
             }
 

--- a/ports/servoshell/lib.rs
+++ b/ports/servoshell/lib.rs
@@ -186,17 +186,17 @@ cfg_if! {
             fn on_event(&self, event: &tracing::Event<'_>, _ctx: tracing_subscriber::layer::Context<'_, S>) {
                 let mut key_value_string: String = String::new();
 
-                key_value_string.push_str(&format!("target={}",event.metadata().target()));
-
                 event.record(&mut |field: &tracing::field::Field, value: &dyn std::fmt::Debug| {
-                    key_value_string.push_str(&format!(",{}={:?}",field.name(),value));
+                    if field.name() != "servo_profiling" {
+                        key_value_string.push_str(&format!("{}={:?},",field.name(),value));
+                    }
                 });
 
                 hitrace::start_trace_ex(
                     (*event.metadata().level()).into(),
                     &std::ffi::CString::new(event.metadata().name())
                         .expect("Failed to convert str to CString"),
-                    &std::ffi::CString::new(key_value_string)
+                    &std::ffi::CString::new(key_value_string.trim_end_matches(","))
                         .expect("Failed to convert str to CString"),
                 );
 

--- a/ports/servoshell/lib.rs
+++ b/ports/servoshell/lib.rs
@@ -184,10 +184,22 @@ cfg_if! {
             }
 
             fn on_event(&self, event: &tracing::Event<'_>, _ctx: tracing_subscriber::layer::Context<'_, S>) {
-                hitrace::start_trace(
+                let mut key_value_string: String = String::new();
+
+                key_value_string.push_str(&format!("target={}",event.metadata().target()));
+
+                event.record(&mut |field: &tracing::field::Field, value: &dyn std::fmt::Debug| {
+                    key_value_string.push_str(&format!(",{}={:?}",field.name(),value));
+                });
+
+                hitrace::start_trace_ex(
+                    (*event.metadata().level()).into(),
                     &std::ffi::CString::new(event.metadata().name())
                         .expect("Failed to convert str to CString"),
+                    &std::ffi::CString::new(key_value_string)
+                        .expect("Failed to convert str to CString"),
                 );
+                
                 hitrace::finish_trace();
             }
 


### PR DESCRIPTION
`start_trace_ex` includes not only name, but fields and values of the trace

Testing: I've passed LargestContentfulPaint pref and got it in the hitrace.
