### PR TITLE
net: Remove CoreResourceManager ThreadPool

### DIFF
--- a/components/config/prefs.rs
+++ b/components/config/prefs.rs
@@ -310,8 +310,6 @@ pub struct Preferences {
     pub threadpools_webstorage_workers_max: i64,
     /// Maximum number of workers for the Networking async runtime thread pool
     pub threadpools_async_runtime_workers_max: i64,
-    /// Maximum number of workers for the Core Resource Manager
-    pub threadpools_resource_workers_max: i64,
     /// Maximum number of workers for webrender
     pub threadpools_webrender_workers_max: i64,
     /// The user-agent to use for Servo. This can also be set via [`UserAgentPlatform`] in
@@ -490,7 +488,6 @@ impl Preferences {
             threadpools_image_cache_workers_max: 4,
             threadpools_indexeddb_workers_max: 4,
             threadpools_webstorage_workers_max: 4,
-            threadpools_resource_workers_max: 4,
             threadpools_webrender_workers_max: 4,
             webgl_testing_context_creation_error: false,
             user_agent: String::new(),

--- a/components/net/tests/fetch.rs
+++ b/components/net/tests/fetch.rs
@@ -8,12 +8,11 @@ use std::fs;
 use std::iter::FromIterator;
 use std::path::Path;
 use std::str::FromStr;
+use std::sync::Arc;
 use std::sync::atomic::{AtomicUsize, Ordering};
-use std::sync::{Arc, Weak};
 use std::time::{Duration, SystemTime};
 
 use base::id::{TEST_PIPELINE_ID, TEST_WEBVIEW_ID};
-use base::threadpool::ThreadPool;
 use content_security_policy as csp;
 use crossbeam_channel::{Sender, unbounded};
 use devtools_traits::{HttpRequest as DevtoolsHttpRequest, HttpResponse as DevtoolsHttpResponse};
@@ -172,7 +171,7 @@ fn test_fetch_blob() {
         fn process_csp_violations(&mut self, _: &Request, _: Vec<csp::Violation>) {}
     }
 
-    let context = new_fetch_context(None, None, None);
+    let context = new_fetch_context(None, None);
 
     let bytes = b"content";
     let blob_buf = BlobBuf {
@@ -238,9 +237,7 @@ fn test_file() {
         .policy_container(Default::default())
         .build();
 
-    let pool = ThreadPool::new(1, "CoreResourceTestPool".to_string());
-    let pool_handle = Arc::new(pool);
-    let mut context = new_fetch_context(None, None, Some(Arc::downgrade(&pool_handle)));
+    let mut context = new_fetch_context(None, None);
     let fetch_response = fetch_with_context(request, &mut context);
 
     // We should see an opaque-filtered response.
@@ -753,10 +750,7 @@ fn test_fetch_with_hsts() {
         state: Arc::new(create_http_state(None)),
         user_agent: DEFAULT_USER_AGENT.into(),
         devtools_chan: None,
-        filemanager: Arc::new(Mutex::new(FileManager::new(
-            embedder_proxy.clone(),
-            Weak::new(),
-        ))),
+        filemanager: Arc::new(Mutex::new(FileManager::new(embedder_proxy.clone()))),
         file_token: FileTokenCheck::NotRequired,
         request_interceptor: Arc::new(Mutex::new(RequestInterceptor::new(embedder_proxy))),
         cancellation_listener: Arc::new(Default::default()),
@@ -819,10 +813,7 @@ fn test_load_adds_host_to_hsts_list_when_url_is_https() {
         state: Arc::new(create_http_state(None)),
         user_agent: DEFAULT_USER_AGENT.into(),
         devtools_chan: None,
-        filemanager: Arc::new(Mutex::new(FileManager::new(
-            embedder_proxy.clone(),
-            Weak::new(),
-        ))),
+        filemanager: Arc::new(Mutex::new(FileManager::new(embedder_proxy.clone()))),
         file_token: FileTokenCheck::NotRequired,
         request_interceptor: Arc::new(Mutex::new(RequestInterceptor::new(embedder_proxy))),
         cancellation_listener: Arc::new(Default::default()),
@@ -890,10 +881,7 @@ fn test_fetch_self_signed() {
         state: Arc::new(create_http_state(None)),
         user_agent: DEFAULT_USER_AGENT.into(),
         devtools_chan: None,
-        filemanager: Arc::new(Mutex::new(FileManager::new(
-            embedder_proxy.clone(),
-            Weak::new(),
-        ))),
+        filemanager: Arc::new(Mutex::new(FileManager::new(embedder_proxy.clone()))),
         file_token: FileTokenCheck::NotRequired,
         request_interceptor: Arc::new(Mutex::new(RequestInterceptor::new(embedder_proxy))),
         cancellation_listener: Arc::new(Default::default()),
@@ -1281,7 +1269,7 @@ fn test_response_cache_status_is_local() {
         .build();
 
     // Use the same HttpCache for both fetches.
-    let mut context = new_fetch_context(None, None, None);
+    let mut context = new_fetch_context(None, None);
 
     // Cold request - response should come from the server.
     let initial_response = fetch_with_context(request.clone(), &mut context);
@@ -1322,7 +1310,7 @@ fn test_response_cache_status_is_validated() {
         .build();
 
     // Use the same HttpCache for both fetches.
-    let mut context = new_fetch_context(None, None, None);
+    let mut context = new_fetch_context(None, None);
 
     // Cold request - response should come from the server.
     let initial_response = fetch_with_context(request.clone(), &mut context);
@@ -1543,10 +1531,7 @@ fn test_fetch_request_intercepted() {
         state: Arc::new(create_http_state(None)),
         user_agent: DEFAULT_USER_AGENT.into(),
         devtools_chan: None,
-        filemanager: Arc::new(Mutex::new(FileManager::new(
-            embedder_proxy.clone(),
-            Weak::new(),
-        ))),
+        filemanager: Arc::new(Mutex::new(FileManager::new(embedder_proxy.clone()))),
         file_token: FileTokenCheck::NotRequired,
         request_interceptor: Arc::new(Mutex::new(RequestInterceptor::new(embedder_proxy))),
         cancellation_listener: Arc::new(Default::default()),

--- a/components/net/tests/filemanager_thread.rs
+++ b/components/net/tests/filemanager_thread.rs
@@ -5,11 +5,9 @@
 use std::fs::File;
 use std::io::Read;
 use std::path::PathBuf;
-use std::sync::Arc;
 
 use base::Epoch;
 use base::id::{TEST_PIPELINE_ID, TEST_WEBVIEW_ID};
-use base::threadpool::ThreadPool;
 use embedder_traits::{
     EmbedderControlId, EmbedderControlResponse, EmbedderMsg, FilePickerRequest, FilterPattern,
 };
@@ -29,10 +27,8 @@ fn test_filemanager() {
     preferences.dom_testing_html_input_element_select_files_enabled = true;
     servo_config::prefs::set(preferences);
 
-    let pool = ThreadPool::new(1, "CoreResourceTestPool".to_string());
-    let pool_handle = Arc::new(pool);
     let (embedder_proxy, embedder_receiver) = create_embedder_proxy_and_receiver();
-    let filemanager = FileManager::new(embedder_proxy, Arc::downgrade(&pool_handle));
+    let filemanager = FileManager::new(embedder_proxy);
 
     // Try to open a dummy file "components/net/tests/test.jpeg" in tree
     let mut handler = File::open("tests/test.jpeg").expect("test.jpeg is stolen");

--- a/components/net/tests/http_loader.rs
+++ b/components/net/tests/http_loader.rs
@@ -709,7 +709,7 @@ fn test_load_doesnt_add_host_to_hsts_list_when_url_is_http_even_if_hsts_headers_
         .policy_container(Default::default())
         .build();
 
-    let mut context = new_fetch_context(None, None, None);
+    let mut context = new_fetch_context(None, None);
     let response = fetch_with_context(request, &mut context);
 
     let _ = server.close();
@@ -745,7 +745,7 @@ fn test_load_sets_cookies_in_the_resource_manager_when_it_get_set_cookie_header_
         };
     let (server, url) = make_server(handler);
 
-    let mut context = new_fetch_context(None, None, None);
+    let mut context = new_fetch_context(None, None);
 
     assert_cookie_for_domain(&context.state.cookie_jar, url.as_str(), None);
 
@@ -792,7 +792,7 @@ fn test_load_sets_requests_cookies_header_for_url_by_getting_cookies_from_the_re
         };
     let (server, url) = make_server(handler);
 
-    let mut context = new_fetch_context(None, None, None);
+    let mut context = new_fetch_context(None, None);
 
     {
         let mut cookie_jar = context.state.cookie_jar.write();
@@ -842,7 +842,7 @@ fn test_load_sends_cookie_if_nonhttp() {
         };
     let (server, url) = make_server(handler);
 
-    let mut context = new_fetch_context(None, None, None);
+    let mut context = new_fetch_context(None, None);
 
     {
         let mut cookie_jar = context.state.cookie_jar.write();
@@ -893,7 +893,7 @@ fn test_cookie_set_with_httponly_should_not_be_available_using_getcookiesforurl(
         };
     let (server, url) = make_server(handler);
 
-    let mut context = new_fetch_context(None, None, None);
+    let mut context = new_fetch_context(None, None);
 
     assert_cookie_for_domain(&context.state.cookie_jar, url.as_str(), None);
 
@@ -947,7 +947,7 @@ fn test_when_cookie_received_marked_secure_is_ignored_for_http() {
         };
     let (server, url) = make_server(handler);
 
-    let mut context = new_fetch_context(None, None, None);
+    let mut context = new_fetch_context(None, None);
 
     assert_cookie_for_domain(&context.state.cookie_jar, url.as_str(), None);
 
@@ -1370,7 +1370,7 @@ fn test_redirect_from_x_to_y_provides_y_cookies_from_y() {
     let url_y = ServoUrl::parse(&format!("http://mozilla.org:{}/org/", port)).unwrap();
     *shared_url_y_clone.lock() = Some(url_y.clone());
 
-    let mut context = new_fetch_context(None, None, None);
+    let mut context = new_fetch_context(None, None);
     {
         let mut cookie_jar = context.state.cookie_jar.write();
         let cookie_x = ServoCookie::new_wrapped(
@@ -1488,7 +1488,7 @@ fn test_if_auth_creds_not_in_url_but_in_cache_it_sets_it() {
         .policy_container(Default::default())
         .build();
 
-    let mut context = new_fetch_context(None, None, None);
+    let mut context = new_fetch_context(None, None);
 
     let auth_entry = AuthCacheEntry {
         user_name: "username".to_owned(),
@@ -1627,12 +1627,7 @@ fn test_fetch_compressed_response_update_count() {
         update_count: 0,
     };
     let response_update_count = spawn_blocking_task::<_, Response>(async move {
-        methods::fetch(
-            request,
-            &mut target,
-            &mut new_fetch_context(None, None, None),
-        )
-        .await;
+        methods::fetch(request, &mut target, &mut new_fetch_context(None, None)).await;
         receiver.await.unwrap()
     });
 
@@ -1705,7 +1700,7 @@ fn test_user_credentials_prompt_when_proxy_authentication_is_required() {
         }),
     );
 
-    let mut context = new_fetch_context(None, Some(embedder_proxy), None);
+    let mut context = new_fetch_context(None, Some(embedder_proxy));
 
     let response = fetch_with_context(request, &mut context);
 
@@ -1762,7 +1757,7 @@ fn test_prompt_credentials_when_client_receives_unauthorized_response() {
             password: "test".into(),
         }),
     );
-    let mut context = new_fetch_context(None, Some(embedder_proxy), None);
+    let mut context = new_fetch_context(None, Some(embedder_proxy));
 
     let response = fetch_with_context(request, &mut context);
 
@@ -1818,7 +1813,7 @@ fn test_dont_prompt_credentials_when_unauthorized_response_contains_no_www_authe
             }
         }
     });
-    let mut context = new_fetch_context(None, Some(embedder_proxy), None);
+    let mut context = new_fetch_context(None, Some(embedder_proxy));
 
     let response = fetch_with_context(request, &mut context);
 
@@ -1865,7 +1860,7 @@ fn test_prompt_credentials_user_cancels_dialog_input() {
 
     let (embedder_proxy, embedder_receiver) = create_embedder_proxy_and_receiver();
     let _ = receive_credential_prompt_msgs(embedder_receiver, None);
-    let mut context = new_fetch_context(None, Some(embedder_proxy), None);
+    let mut context = new_fetch_context(None, Some(embedder_proxy));
 
     let response = fetch_with_context(request, &mut context);
 
@@ -1918,7 +1913,7 @@ fn test_prompt_credentials_user_input_incorrect_credentials() {
             password: "test".into(),
         }),
     );
-    let mut context = new_fetch_context(None, Some(embedder_proxy), None);
+    let mut context = new_fetch_context(None, Some(embedder_proxy));
 
     let response = fetch_with_context(request, &mut context);
 
@@ -1971,7 +1966,7 @@ fn test_prompt_credentials_user_input_incorrect_mode() {
             password: "test".into(),
         }),
     );
-    let mut context = new_fetch_context(None, Some(embedder_proxy), None);
+    let mut context = new_fetch_context(None, Some(embedder_proxy));
 
     let response = fetch_with_context(request, &mut context);
 
@@ -2012,7 +2007,7 @@ fn test_security_info_for_https_connection() {
 
     let (devtools_sender, devtools_receiver) = unbounded();
 
-    let mut context = new_fetch_context(Some(devtools_sender), None, None);
+    let mut context = new_fetch_context(Some(devtools_sender), None);
 
     // The server certificate is self-signed, so we need to add an override
     // so that the connection works properly.
@@ -2094,7 +2089,7 @@ fn test_no_security_info_for_http_connection() {
         .policy_container(Default::default())
         .build();
 
-    let mut context = new_fetch_context(Some(devtools_sender), None, None);
+    let mut context = new_fetch_context(Some(devtools_sender), None);
 
     let response = fetch_with_context(request, &mut context);
     server.close();


### PR DESCRIPTION
CoreResourceManager had a ThreadPool that was only used for reading files as the fetching is handled via tokio.
Keeping 4 threads around on the chance that the user wants to read a local file seems a bit much.

This removes the threadpool and just uses the standard thread::spawn functionality.

Signed-off-by: Narfinger <Narfinger@users.noreply.github.com>

Testing: Local file opening still works.
