### PR TITLE
devtools: Improve serialization and remove mutability from NetworkEventActor

### DIFF
--- a/components/devtools/actors/watcher.rs
+++ b/components/devtools/actors/watcher.rs
@@ -180,7 +180,7 @@ pub struct WatcherActorMsg {
 
 pub struct WatcherActor {
     name: String,
-    browsing_context_actor: String,
+    pub browsing_context_actor: String,
     network_parent: String,
     target_configuration: String,
     thread_configuration: String,


### PR DESCRIPTION
Now `NetworkEventActor`'s methods take a non mutable reference to self (`add_request`, `add_response` and `add_security_info`). This actor now has three different `RefCells` inside (`request`, `response` and `security`), which group pieces of data that are updated separately via the public methods.

For the actor functionality itself, it now follows Firefox more closely. In the `resource-available` message it only sends the `*_available` fields (i.e. `response_headers_available`), deferring the actual data to the `get*` messages (i.e `getResponseHeaders`). There were also a few slight changes I noticed along the way that I tried to fix.

Simplify some repeated logic calculating header sizes and listing cookies.

`resource_updates` is updated to use `Serialize` structs instead of manually adding values to a map. This is more in line with the rest of the DevTools code and probably less prone to future errors.

Fix "Resource of network-event is missing a browsingContextID or innerWindowId attribute" error that shows multiple times each time the Network tab is open. Updated all messages to use the correct browsingContextID.

Testing: Manually compared all of the Network tab features to avoid regressions.
