### PR TITLE
devtools: Remove find_mut and make all actors immutable

### DIFF
--- a/components/devtools/actor.rs
+++ b/components/devtools/actor.rs
@@ -65,14 +65,10 @@ pub(crate) trait Actor: Any + ActorAsAny + Send {
 
 pub(crate) trait ActorAsAny {
     fn actor_as_any(&self) -> &dyn Any;
-    fn actor_as_any_mut(&mut self) -> &mut dyn Any;
 }
 
 impl<T: Actor> ActorAsAny for T {
     fn actor_as_any(&self) -> &dyn Any {
-        self
-    }
-    fn actor_as_any_mut(&mut self) -> &mut dyn Any {
         self
     }
 }
@@ -163,12 +159,6 @@ impl ActorRegistry {
     pub fn find<'a, T: Any>(&'a self, name: &str) -> &'a T {
         let actor = self.actors.get(name).unwrap();
         actor.actor_as_any().downcast_ref::<T>().unwrap()
-    }
-
-    /// Find an actor by registered name
-    pub fn find_mut<'a, T: Any>(&'a mut self, name: &str) -> &'a mut T {
-        let actor = self.actors.get_mut(name).unwrap();
-        actor.actor_as_any_mut().downcast_mut::<T>().unwrap()
     }
 
     /// Find an actor by registered name and return its serialization

--- a/components/devtools/actors/source.rs
+++ b/components/devtools/actors/source.rs
@@ -55,7 +55,7 @@ pub struct SourceActor {
     /// <https://firefox-source-docs.mozilla.org/devtools/backend/protocol.html#black-boxing-sources>
     pub is_black_boxed: bool,
 
-    pub content: Option<String>,
+    pub content: RefCell<Option<String>>,
     pub content_type: Option<String>,
 
     // TODO: use it in #37667, then remove this allow
@@ -127,7 +127,7 @@ impl SourceActor {
         SourceActor {
             name,
             url,
-            content,
+            content: RefCell::new(content),
             content_type,
             is_black_boxed: false,
             spidermonkey_id,
@@ -201,6 +201,7 @@ impl Actor for SourceActor {
                     // become available later (e.g. after a fetch)?
                     source: self
                         .content
+                        .borrow()
                         .as_deref()
                         .unwrap_or("<!-- not available; please reload! -->")
                         .to_owned(),

--- a/components/devtools/actors/tab.rs
+++ b/components/devtools/actors/tab.rs
@@ -139,8 +139,8 @@ impl TabDescriptorActor {
         is_top_level_global: bool,
     ) -> TabDescriptorActor {
         let name = actors.new_name::<Self>();
-        let root = actors.find_mut::<RootActor>("root");
-        root.tabs.push(name.clone());
+        let root = actors.find::<RootActor>("root");
+        root.tabs.borrow_mut().push(name.clone());
         TabDescriptorActor {
             name,
             browsing_context_actor,

--- a/components/devtools/actors/timeline.rs
+++ b/components/devtools/actors/timeline.rs
@@ -336,7 +336,7 @@ impl Emitter {
         if let Some(ref actor_name) = self.framerate_actor {
             let mut lock = self.registry.lock();
             let registry = lock.as_mut().unwrap();
-            let framerate_actor = registry.find_mut::<FramerateActor>(actor_name);
+            let framerate_actor = registry.find::<FramerateActor>(actor_name);
             let framerate_reply = FramerateEmitterReply {
                 type_: "framerate".to_owned(),
                 from: framerate_actor.name(),

--- a/components/devtools/actors/watcher.rs
+++ b/components/devtools/actors/watcher.rs
@@ -250,7 +250,7 @@ impl Actor for WatcherActor {
 
                     target.frame_update(&mut request);
                 } else if target_type == "worker" {
-                    for worker_name in &root.workers {
+                    for worker_name in &*root.workers.borrow() {
                         let worker_msg = WatchTargetsReply {
                             from: self.name(),
                             type_: "target-available-form".into(),
@@ -317,7 +317,7 @@ impl Actor for WatcherActor {
                                 &mut request,
                             );
 
-                            for worker_name in &root.workers {
+                            for worker_name in &*root.workers.borrow() {
                                 let worker = registry.find::<WorkerActor>(worker_name);
                                 let thread = registry.find::<ThreadActor>(&worker.thread);
 

--- a/components/devtools/lib.rs
+++ b/components/devtools/lib.rs
@@ -292,8 +292,8 @@ impl DevtoolsInstance {
     }
 
     fn handle_framerate_tick(&self, actor_name: String, tick: f64) {
-        let mut actors = self.registry.lock().unwrap();
-        let framerate_actor = actors.find_mut::<FramerateActor>(&actor_name);
+        let actors = self.registry.lock().unwrap();
+        let framerate_actor = actors.find::<FramerateActor>(&actor_name);
         framerate_actor.add_tick(tick);
     }
 
@@ -356,8 +356,8 @@ impl DevtoolsInstance {
                 script_chan: script_sender,
                 streams: Default::default(),
             };
-            let root = actors.find_mut::<RootActor>("root");
-            root.workers.push(worker.name.clone());
+            let root = actors.find::<RootActor>("root");
+            root.tabs.borrow_mut().push(worker.name.clone());
 
             self.actor_workers.insert(id, worker_name.clone());
             actors.register(worker);
@@ -570,7 +570,7 @@ impl DevtoolsInstance {
             };
 
             let thread_actor_name = actors.find::<WorkerActor>(worker_actor_name).thread.clone();
-            let thread_actor = actors.find_mut::<ThreadActor>(&thread_actor_name);
+            let thread_actor = actors.find::<ThreadActor>(&thread_actor_name);
 
             thread_actor.source_manager.add_source(&source_actor_name);
 
@@ -597,8 +597,7 @@ impl DevtoolsInstance {
                 browsing_context.thread.clone()
             };
 
-            let thread_actor = actors.find_mut::<ThreadActor>(&thread_actor_name);
-
+            let thread_actor = actors.find::<ThreadActor>(&thread_actor_name);
             thread_actor.source_manager.add_source(&source_actor_name);
 
             // Notify browsing context about the new source
@@ -619,9 +618,10 @@ impl DevtoolsInstance {
         let mut actors = self.registry.lock().unwrap();
 
         for actor_name in actors.source_actor_names_for_pipeline(pipeline_id) {
-            let source_actor: &mut SourceActor = actors.find_mut(&actor_name);
-            if source_actor.content.is_none() {
-                source_actor.content = Some(source_content.clone());
+            let source_actor = actors.find::<SourceActor>(&actor_name);
+            let mut content = source_actor.content.borrow_mut();
+            if content.is_none() {
+                *content = Some(source_content.clone());
             }
         }
 


### PR DESCRIPTION
Remove `find_mut` from `ActorRegistry`. Force that all actors must be immutable after being inserted in the registry, only allowing changes through internal mutability.

First step in refactoring `ActorRegistry` to make it more reliable, easier to use and less error prone.

Depends on #41741. `NetworkEventActor` was more complicated to refactor and it needed special care so it is split into its own change.

Testing: This patch doesn't change behaviour.