### PR TITLE
mach: linux bootstrap: Remove unused constant

### DIFF
--- a/python/servo/platform/linux.py
+++ b/python/servo/platform/linux.py
@@ -157,10 +157,6 @@ XBPS_PKGS = [
     "libxkbcommon-x11",
 ]
 
-GSTREAMER_URL = (
-    "https://github.com/servo/servo-build-deps/releases/download/linux/gstreamer-1.16-x86_64-linux-gnu.20190515.tar.gz"
-)
-
 
 class Linux(Base):
     def __init__(self, *args: str, **kwargs: Any) -> None:


### PR DESCRIPTION
The variable is not used anywhere and `_platform_bootstrap_gstreamer` raises an error telling the user to install gstreamer via their package manager on Linux.
Hence, we can just remove it.

Testing: Trivial, not required.
