### PR TITLE
mach: Break the shackle that restricts cross-compilation from Windows

### DIFF
--- a/python/servo/command_base.py
+++ b/python/servo/command_base.py
@@ -536,11 +536,6 @@ class CommandBase(object):
                 print("Error: Cross-compiling servo on windows requires the Ninja tool to be installed and in PATH.")
                 print("Hint: Ninja-build is available on github at: https://github.com/ninja-build/ninja/releases")
                 exit(1)
-            # `tr` is also required by the CMake build rules of `aws-lc-rs`
-            if shutil.which("tr") is None:
-                print("Error: Cross-compiling servo on windows requires the `tr` tool, which was not found.")
-                print("Hint: Try running ./mach from `git bash` instead of powershell.")
-                exit(1)
 
         return env
 


### PR DESCRIPTION
I never forget that day: @dependabot updates aws-lc-rs, and cross-compilation Servo from Windows fails. We were left with two options:
1. Get a local clone of aws-lc-rs, and modify it in a hacky way
2. Use Git Bash, but still has to set up MSYS2 etc.

Later, we've been restricted since #36070 to only use option 2 due to restrictions imposed here. But the system is innocent, and it is aws-lc-rs's responsibility to fix the rules. Still, @d-desiatkin and I believed that day would come, when we would return justice to the victim.

Freedom is better served late than never. It is now working normally since aws-lc-rs has fixed the rules.