### PR TITLE
script: Notify `PinchZoom` resizes to `ScriptThread`'s `VisualViewport`

### DIFF
--- a/components/constellation/constellation.rs
+++ b/components/constellation/constellation.rs
@@ -149,7 +149,7 @@ use net::image_cache::ImageCacheFactoryImpl;
 use net_traits::pub_domains::registered_domain_name;
 use net_traits::{self, AsyncRuntime, ResourceThreads, exit_fetch_thread, start_fetch_thread};
 use paint_api::{
-    PaintMessage, PaintProxy, PinchZoomDetails, PipelineExitSource, SendableFrameTree,
+    PaintMessage, PaintProxy, PinchZoomInfos, PipelineExitSource, SendableFrameTree,
     WebRenderExternalImageIdManager,
 };
 use profile_traits::mem::ProfilerMsg;
@@ -1549,8 +1549,8 @@ where
             ) => {
                 self.handle_user_content_manager_action(user_content_manager_id, action);
             },
-            EmbedderToConstellationMessage::UpdatePinchZoomDetails(pipeline_id, pinch_zoom) => {
-                self.handle_update_pinch_zoom_details(pipeline_id, pinch_zoom);
+            EmbedderToConstellationMessage::UpdatePinchZoomInfos(pipeline_id, pinch_zoom) => {
+                self.handle_update_pinch_zoom_infos(pipeline_id, pinch_zoom);
             },
         }
     }
@@ -5637,10 +5637,10 @@ where
         }
     }
 
-    fn handle_update_pinch_zoom_details(
+    fn handle_update_pinch_zoom_infos(
         &self,
         pipeline_id: PipelineId,
-        pinch_zoom_details: PinchZoomDetails,
+        pinch_zoom_infos: PinchZoomInfos,
     ) {
         let Some(pipeline) = self.pipelines.get(&pipeline_id) else {
             warn!("Discarding pinch zoom update for unknown pipeline");
@@ -5648,9 +5648,9 @@ where
         };
         if let Err(error) = pipeline
             .event_loop
-            .send(ScriptThreadMessage::UpdatePinchZoomDetails(
+            .send(ScriptThreadMessage::UpdatePinchZoomInfos(
                 pipeline_id,
-                pinch_zoom_details,
+                pinch_zoom_infos,
             ))
         {
             warn!("Could not send pinch zoom update to pipeline: {pipeline_id:?}: {error:?}");

--- a/components/constellation/tracing.rs
+++ b/components/constellation/tracing.rs
@@ -82,7 +82,7 @@ mod from_embedder {
                 Self::RequestScreenshotReadiness(..) => target!("RequestScreenshotReadiness"),
                 Self::EmbedderControlResponse(..) => target!("EmbedderControlResponse"),
                 Self::UserContentManagerAction(..) => target!("UserContentManagerAction"),
-                Self::UpdatePinchZoomDetails(..) => target!("UpdatePinchZoomDetails"),
+                Self::UpdatePinchZoomInfos(..) => target!("UpdatePinchZoomInfos"),
             }
         }
     }

--- a/components/constellation/tracing.rs
+++ b/components/constellation/tracing.rs
@@ -82,6 +82,7 @@ mod from_embedder {
                 Self::RequestScreenshotReadiness(..) => target!("RequestScreenshotReadiness"),
                 Self::EmbedderControlResponse(..) => target!("EmbedderControlResponse"),
                 Self::UserContentManagerAction(..) => target!("UserContentManagerAction"),
+                Self::UpdatePinchZoomDetails(..) => target!("UpdatePinchZoomDetails"),
             }
         }
     }

--- a/components/paint/pinch_zoom.rs
+++ b/components/paint/pinch_zoom.rs
@@ -4,7 +4,7 @@
 
 use embedder_traits::Scroll;
 use euclid::{Point2D, Rect, Scale, Transform2D, Vector2D};
-use paint_api::PinchZoomDetails;
+use paint_api::PinchZoomInfos;
 use style_traits::CSSPixel;
 use webrender_api::units::{DevicePixel, DevicePoint, DeviceRect, DeviceSize, DeviceVector2D};
 
@@ -151,12 +151,12 @@ impl PinchZoom {
         remaining
     }
 
-    /// Get the [`PinchZoomDetails`] from this [`PinchZoom`] state.
-    pub(crate) fn get_pinch_zoom_details_for_script(
+    /// Get the [`PinchZoomInfos`] from this [`PinchZoom`] state.
+    pub(crate) fn get_pinch_zoom_infos_for_script(
         &self,
         viewport_scale: Scale<f32, CSSPixel, DevicePixel>,
-    ) -> PinchZoomDetails {
-        PinchZoomDetails {
+    ) -> PinchZoomInfos {
+        PinchZoomInfos {
             zoom_factor: Scale::new(self.zoom_factor),
             rect: self.pinch_zoom_rect_relative_to_unscaled_viewport() / viewport_scale,
         }

--- a/components/paint/pinch_zoom.rs
+++ b/components/paint/pinch_zoom.rs
@@ -41,7 +41,7 @@ impl PinchZoom {
 
     /// The boundary of the pinch zoom viewport relative to the unscaled viewport. For the
     /// script's `VisualViewport` interface and calculations (such as scroll).
-    pub fn pinch_zoom_rect_relative_to_unscaled_viewport(&self) -> Rect<f32, DevicePixel> {
+    fn pinch_zoom_rect_relative_to_unscaled_viewport(&self) -> Rect<f32, DevicePixel> {
         let rect = Rect::new(
             Point2D::origin(),
             self.unscaled_viewport_size.to_vector().to_size(),
@@ -151,7 +151,7 @@ impl PinchZoom {
         remaining
     }
 
-    /// Get the [`PinchZoomDetails`] from this [`PinchZoom`] state. Perserving only the rectangle and the scale factor.
+    /// Get the [`PinchZoomDetails`] from this [`PinchZoom`] state.
     pub(crate) fn get_pinch_zoom_details_for_script(
         &self,
         viewport_scale: Scale<f32, CSSPixel, DevicePixel>,

--- a/components/paint/webview_renderer.rs
+++ b/components/paint/webview_renderer.rs
@@ -779,7 +779,7 @@ impl WebViewRenderer {
         // Additionally notify pinch zoom update to the script.
         let pinch_zoom_result = self.set_pinch_zoom(new_pinch_zoom);
         if pinch_zoom_result == PinchZoomResult::DidPinchZoom {
-            self.send_pinch_zoom_details_to_script();
+            self.send_pinch_zoom_infos_to_script();
         }
 
         (pinch_zoom_result, scroll_result)
@@ -898,7 +898,7 @@ impl WebViewRenderer {
         self.dispatch_scroll_event(external_scroll_id, hit_test_result.clone());
 
         if pinch_zoom_result == PinchZoomResult::DidNotPinchZoom {
-            self.send_pinch_zoom_details_to_script();
+            self.send_pinch_zoom_infos_to_script();
         }
 
         let scroll_result = ScrollResult {
@@ -910,18 +910,18 @@ impl WebViewRenderer {
     }
 
     /// Send [`PinchZoom`] update to the script's root pipeline.
-    fn send_pinch_zoom_details_to_script(&self) {
+    fn send_pinch_zoom_infos_to_script(&self) {
         // Pinch-zoom is applicable only to the root pipeline.
         let Some(pipeline_id) = self.root_pipeline_id else {
             return;
         };
 
-        let pinch_zoom_details = self.pinch_zoom.get_pinch_zoom_details_for_script(
+        let pinch_zoom_infos = self.pinch_zoom.get_pinch_zoom_infos_for_script(
             self.device_pixels_per_page_pixel_not_including_pinch_zoom(),
         );
 
         let _ = self.embedder_to_constellation_sender.send(
-            EmbedderToConstellationMessage::UpdatePinchZoomDetails(pipeline_id, pinch_zoom_details),
+            EmbedderToConstellationMessage::UpdatePinchZoomInfos(pipeline_id, pinch_zoom_infos),
         );
     }
 
@@ -1036,7 +1036,7 @@ impl WebViewRenderer {
         if old_rect.size() != self.rect.size() {
             self.send_window_size_message();
             self.pinch_zoom.resize_unscaled_viewport(new_rect);
-            self.send_pinch_zoom_details_to_script();
+            self.send_pinch_zoom_infos_to_script();
         }
         old_rect != self.rect
     }

--- a/components/paint/webview_renderer.rs
+++ b/components/paint/webview_renderer.rs
@@ -776,7 +776,13 @@ impl WebViewRenderer {
             self.touch_handler.stop_fling_if_needed();
         }
 
-        (self.set_pinch_zoom(new_pinch_zoom), scroll_result)
+        // Additionally notify pinch zoom update to the script.
+        let pinch_zoom_result = self.set_pinch_zoom(new_pinch_zoom);
+        if pinch_zoom_result == PinchZoomResult::DidPinchZoom {
+            self.send_pinch_zoom_details_to_script();
+        }
+
+        (pinch_zoom_result, scroll_result)
     }
 
     /// Perform a hit test at the given [`DevicePoint`] and apply the [`Scroll`]
@@ -891,12 +897,32 @@ impl WebViewRenderer {
         self.send_scroll_positions_to_layout_for_pipeline(root_pipeline_id);
         self.dispatch_scroll_event(external_scroll_id, hit_test_result.clone());
 
+        if pinch_zoom_result == PinchZoomResult::DidNotPinchZoom {
+            self.send_pinch_zoom_details_to_script();
+        }
+
         let scroll_result = ScrollResult {
             hit_test_result,
             external_scroll_id,
             offset,
         };
         (pinch_zoom_result, vec![scroll_result])
+    }
+
+    /// Send [`PinchZoom`] update to the script's root pipeline.
+    fn send_pinch_zoom_details_to_script(&self) {
+        // Pinch-zoom is applicable only to the root pipeline.
+        let Some(pipeline_id) = self.root_pipeline_id else {
+            return;
+        };
+
+        let pinch_zoom_details = self.pinch_zoom.get_pinch_zoom_details_for_script(
+            self.device_pixels_per_page_pixel_not_including_pinch_zoom(),
+        );
+
+        let _ = self.embedder_to_constellation_sender.send(
+            EmbedderToConstellationMessage::UpdatePinchZoomDetails(pipeline_id, pinch_zoom_details),
+        );
     }
 
     fn dispatch_scroll_event(
@@ -1010,6 +1036,7 @@ impl WebViewRenderer {
         if old_rect.size() != self.rect.size() {
             self.send_window_size_message();
             self.pinch_zoom.resize_unscaled_viewport(new_rect);
+            self.send_pinch_zoom_details_to_script();
         }
         old_rect != self.rect
     }

--- a/components/script/dom/visualviewport.rs
+++ b/components/script/dom/visualviewport.rs
@@ -7,7 +7,7 @@ use std::cell::Cell;
 use bitflags::bitflags;
 use dom_struct::dom_struct;
 use euclid::{Rect, Scale, Size2D};
-use paint_api::PinchZoomDetails;
+use paint_api::PinchZoomInfos;
 use script_bindings::codegen::GenericBindings::VisualViewportBinding::VisualViewportMethods;
 use script_bindings::codegen::GenericBindings::WindowBinding::WindowMethods;
 use script_bindings::num::Finite;
@@ -96,13 +96,13 @@ impl VisualViewport {
         state
     }
 
-    /// Update the [`VisualViewport`] state based on a new [`PinchZoomDetails`].
-    pub(crate) fn update_from_pinch_zoom_details(
+    /// Update the [`VisualViewport`] state based on a new [`PinchZoomInfos`].
+    pub(crate) fn update_from_pinch_zoom_infos(
         &self,
-        pinch_zoom_details: PinchZoomDetails,
+        pinch_zoom_infos: PinchZoomInfos,
     ) -> VisualViewportChanges {
-        let old_rect = self.viewport_rect.replace(pinch_zoom_details.rect);
-        let old_scale = self.scale.replace(pinch_zoom_details.zoom_factor);
+        let old_rect = self.viewport_rect.replace(pinch_zoom_infos.rect);
+        let old_scale = self.scale.replace(pinch_zoom_infos.zoom_factor);
 
         self.check_for_update(old_rect, old_scale)
     }

--- a/components/script/dom/window.rs
+++ b/components/script/dom/window.rs
@@ -70,7 +70,7 @@ use net_traits::image_cache::{
 use net_traits::request::Referrer;
 use net_traits::{ResourceFetchTiming, ResourceThreads};
 use num_traits::ToPrimitive;
-use paint_api::CrossProcessPaintApi;
+use paint_api::{CrossProcessPaintApi, PinchZoomDetails};
 use profile_traits::generic_channel as ProfiledGenericChannel;
 use profile_traits::mem::ProfilerChan as MemProfilerChan;
 use profile_traits::time::ProfilerChan as TimeProfilerChan;
@@ -176,7 +176,7 @@ use crate::dom::storage::Storage;
 use crate::dom::testrunner::TestRunner;
 use crate::dom::trustedtypepolicyfactory::TrustedTypePolicyFactory;
 use crate::dom::types::{ImageBitmap, MouseEvent, UIEvent};
-use crate::dom::visualviewport::VisualViewport;
+use crate::dom::visualviewport::{VisualViewport, VisualViewportChanges};
 use crate::dom::webgl::webglrenderingcontext::WebGLCommandSender;
 #[cfg(feature = "webgpu")]
 use crate::dom::webgpu::identityhub::IdentityHub;
@@ -471,6 +471,9 @@ pub(crate) struct Window {
     /// Visual viewport interface that is associated to this [`Window`].
     /// <https://drafts.csswg.org/cssom-view/#dom-window-visualviewport>
     visual_viewport: MutNullableDom<VisualViewport>,
+
+    /// [`VisualViewport`] dimension changed and we need to process it on the next tick.
+    has_changed_visual_viewport_dimension: Cell<bool>,
 }
 
 impl Window {
@@ -1664,7 +1667,7 @@ impl WindowMethods<crate::DomTypeHolder> for Window {
     }
 
     /// <https://drafts.csswg.org/cssom-view/#dom-window-visualviewport>
-    fn GetVisualViewport(&self, can_gc: CanGc) -> Option<DomRoot<VisualViewport>> {
+    fn GetVisualViewport(&self) -> Option<DomRoot<VisualViewport>> {
         // > If the associated document is fully active, the visualViewport attribute must return the
         // > VisualViewport object associated with the Window object’s associated document. Otherwise,
         // > it must return null.
@@ -1672,10 +1675,7 @@ impl WindowMethods<crate::DomTypeHolder> for Window {
             return None;
         }
 
-        // TODO(#41341): we are only initializing the visual viewport here, but it is never updated.
-        Some(self.visual_viewport.or_init(|| {
-            VisualViewport::new_from_layout_viewport(self, self.viewport_details().size, can_gc)
-        }))
+        Some(self.visual_viewport())
     }
 
     /// <https://html.spec.whatwg.org/multipage/#dom-windowbase64-btoa>
@@ -3267,6 +3267,31 @@ impl Window {
         self.viewport_details.get()
     }
 
+    /// Initialize [`VisualViewport`] for a window. By default it's dimension is identical to layout viewport.
+    pub(crate) fn init_visual_viewport(&self, can_gc: CanGc) {
+        self.visual_viewport.set(Some(
+            &VisualViewport::new_from_layout_viewport(self, self.viewport_details().size, can_gc)
+                .as_traced(),
+        ));
+    }
+
+    pub(crate) fn visual_viewport(&self) -> DomRoot<VisualViewport> {
+        self.visual_viewport
+            .get()
+            .expect("Visual viewport is not initialized!")
+    }
+
+    /// Update the [`VisualViewport`] of this [`Window`] and note the changes to be processed in the event loop.
+    pub(crate) fn set_visual_viewport(&self, pinch_zoom_details: PinchZoomDetails) {
+        let visual_viewport = self.visual_viewport();
+        let changes = visual_viewport.update_from_pinch_zoom_details(pinch_zoom_details);
+
+        if changes.intersects(VisualViewportChanges::DimensionChanged) {
+            self.has_changed_visual_viewport_dimension.set(true);
+        }
+        // TODO(stevennovaryo): additionally handle the visual viewport scroll event here
+    }
+
     /// Get the theme of this [`Window`].
     pub(crate) fn theme(&self) -> Theme {
         self.theme.get()
@@ -3383,11 +3408,11 @@ impl Window {
         self.parent_info.is_none()
     }
 
-    /// An implementation of:
+    /// Layout viewport part of:
     /// <https://drafts.csswg.org/cssom-view/#document-run-the-resize-steps>
     ///
-    /// Returns true if there were any pending resize events.
-    pub(crate) fn run_the_resize_steps(&self, can_gc: CanGc) -> bool {
+    /// Handle the pending viewport resize.
+    fn run_resize_steps_for_layout_viewport(&self, can_gc: CanGc) -> bool {
         let Some((new_size, size_type)) = self.take_unhandled_resize_event() else {
             return false;
         };
@@ -3432,6 +3457,36 @@ impl Window {
         }
 
         true
+    }
+
+    /// An implementation of:
+    /// <https://drafts.csswg.org/cssom-view/#document-run-the-resize-steps>
+    ///
+    /// Returns true if there were any pending viewport resize events.
+    pub(crate) fn run_the_resize_steps(&self, can_gc: CanGc) -> bool {
+        let layout_viewport_resized = self.run_resize_steps_for_layout_viewport(can_gc);
+
+        if self.has_changed_visual_viewport_dimension.get() {
+            let visual_viewport = self.visual_viewport();
+
+            let uievent = UIEvent::new(
+                self,
+                DOMString::from("resize"),
+                EventBubbles::DoesNotBubble,
+                EventCancelable::NotCancelable,
+                Some(self),
+                0i32,
+                0u32,
+                can_gc,
+            );
+            uievent
+                .upcast::<Event>()
+                .fire(visual_viewport.upcast(), can_gc);
+
+            self.has_changed_visual_viewport_dimension.set(false);
+        }
+
+        layout_viewport_resized
     }
 
     /// Evaluate media query lists and report changes
@@ -3714,6 +3769,7 @@ impl Window {
             has_pending_screenshot_readiness_request: Default::default(),
             visual_viewport: Default::default(),
             weak_script_thread,
+            has_changed_visual_viewport_dimension: Default::default(),
         });
 
         WindowBinding::Wrap::<crate::DomTypeHolder>(GlobalScope::get_cx(), win)

--- a/components/script/dom/window.rs
+++ b/components/script/dom/window.rs
@@ -70,7 +70,7 @@ use net_traits::image_cache::{
 use net_traits::request::Referrer;
 use net_traits::{ResourceFetchTiming, ResourceThreads};
 use num_traits::ToPrimitive;
-use paint_api::{CrossProcessPaintApi, PinchZoomDetails};
+use paint_api::{CrossProcessPaintApi, PinchZoomInfos};
 use profile_traits::generic_channel as ProfiledGenericChannel;
 use profile_traits::mem::ProfilerChan as MemProfilerChan;
 use profile_traits::time::ProfilerChan as TimeProfilerChan;
@@ -3276,19 +3276,19 @@ impl Window {
     /// Update the [`VisualViewport`] of this [`Window`] if necessary and note the changes to be processed in the event loop.
     pub(crate) fn maybe_update_visual_viewport(
         &self,
-        pinch_zoom_details: PinchZoomDetails,
+        pinch_zoom_infos: PinchZoomInfos,
         can_gc: CanGc,
     ) {
         // We doesn't need to do anything if the following condition is fulfilled. Since there are no JS listener
         // to fire and we could reconstruct visual viewport from layout viewport in case JS access it.
-        if pinch_zoom_details.rect == Rect::from_size(self.viewport_details().size) &&
+        if pinch_zoom_infos.rect == Rect::from_size(self.viewport_details().size) &&
             self.visual_viewport.get().is_none()
         {
             return;
         }
 
         let visual_viewport = self.get_or_init_visual_viewport(can_gc);
-        let changes = visual_viewport.update_from_pinch_zoom_details(pinch_zoom_details);
+        let changes = visual_viewport.update_from_pinch_zoom_infos(pinch_zoom_infos);
 
         if changes.intersects(VisualViewportChanges::DimensionChanged) {
             self.has_changed_visual_viewport_dimension.set(true);

--- a/components/script/iframe_collection.rs
+++ b/components/script/iframe_collection.rs
@@ -8,6 +8,7 @@ use base::id::BrowsingContextId;
 use constellation_traits::{IFrameSizeMsg, ScriptToConstellationMessage, WindowSizeType};
 use embedder_traits::ViewportDetails;
 use layout_api::IFrameSizes;
+use paint_api::PinchZoomDetails;
 use rustc_hash::FxHashMap;
 
 use crate::dom::bindings::inheritance::Castable;
@@ -136,6 +137,13 @@ impl IFrameCollection {
                         viewport_details,
                         WindowSizeType::Resize,
                     );
+                    // Additionally, update the `VisualViewport` of the `Iframe`. This allows us
+                    // to process the resize for `VisualViewport` in the corrent timing. Note that
+                    // `VisualViewport` for iframes would practically follow layout viewport.
+                    script_thread.handle_update_pinch_zoom_details(
+                        iframe_size.pipeline_id,
+                        PinchZoomDetails::new_from_viewport_size(viewport_details.size),
+                    )
                 });
 
                 let old_viewport_details =

--- a/components/script/iframe_collection.rs
+++ b/components/script/iframe_collection.rs
@@ -10,6 +10,7 @@ use embedder_traits::ViewportDetails;
 use layout_api::IFrameSizes;
 use paint_api::PinchZoomDetails;
 use rustc_hash::FxHashMap;
+use script_bindings::script_runtime::CanGc;
 
 use crate::dom::bindings::inheritance::Castable;
 use crate::dom::bindings::root::{Dom, DomRoot};
@@ -143,6 +144,9 @@ impl IFrameCollection {
                     script_thread.handle_update_pinch_zoom_details(
                         iframe_size.pipeline_id,
                         PinchZoomDetails::new_from_viewport_size(viewport_details.size),
+                        // Theoritically it wouldn't do GC since it is impossible to initialize
+                        // the `VisualViewport` interface here.
+                        CanGc::note(),
                     )
                 });
 

--- a/components/script/iframe_collection.rs
+++ b/components/script/iframe_collection.rs
@@ -8,7 +8,7 @@ use base::id::BrowsingContextId;
 use constellation_traits::{IFrameSizeMsg, ScriptToConstellationMessage, WindowSizeType};
 use embedder_traits::ViewportDetails;
 use layout_api::IFrameSizes;
-use paint_api::PinchZoomDetails;
+use paint_api::PinchZoomInfos;
 use rustc_hash::FxHashMap;
 use script_bindings::script_runtime::CanGc;
 
@@ -141,9 +141,9 @@ impl IFrameCollection {
                     // Additionally, update the `VisualViewport` of the `Iframe`. This allows us
                     // to process the resize for `VisualViewport` in the corrent timing. Note that
                     // `VisualViewport` for iframes would practically follow layout viewport.
-                    script_thread.handle_update_pinch_zoom_details(
+                    script_thread.handle_update_pinch_zoom_infos(
                         iframe_size.pipeline_id,
-                        PinchZoomDetails::new_from_viewport_size(viewport_details.size),
+                        PinchZoomInfos::new_from_viewport_size(viewport_details.size),
                         // Theoritically it wouldn't do GC since it is impossible to initialize
                         // the `VisualViewport` interface here.
                         CanGc::note(),

--- a/components/script/messaging.rs
+++ b/components/script/messaging.rs
@@ -105,6 +105,7 @@ impl MixedMessage {
                 ScriptThreadMessage::SetUserContents(..) => None,
                 ScriptThreadMessage::DestroyUserContentManager(..) => None,
                 ScriptThreadMessage::AccessibilityTreeUpdate(..) => None,
+                ScriptThreadMessage::UpdatePinchZoomDetails(id, _) => Some(*id),
             },
             MixedMessage::FromScript(inner_msg) => match inner_msg {
                 MainThreadScriptMsg::Common(CommonScriptMsg::Task(_, _, pipeline_id, _)) => {

--- a/components/script/messaging.rs
+++ b/components/script/messaging.rs
@@ -105,7 +105,7 @@ impl MixedMessage {
                 ScriptThreadMessage::SetUserContents(..) => None,
                 ScriptThreadMessage::DestroyUserContentManager(..) => None,
                 ScriptThreadMessage::AccessibilityTreeUpdate(..) => None,
-                ScriptThreadMessage::UpdatePinchZoomDetails(id, _) => Some(*id),
+                ScriptThreadMessage::UpdatePinchZoomInfos(id, _) => Some(*id),
             },
             MixedMessage::FromScript(inner_msg) => match inner_msg {
                 MainThreadScriptMsg::Common(CommonScriptMsg::Task(_, _, pipeline_id, _)) => {

--- a/components/script/script_thread.rs
+++ b/components/script/script_thread.rs
@@ -1936,7 +1936,7 @@ impl ScriptThread {
                 );
             },
             ScriptThreadMessage::UpdatePinchZoomDetails(id, pinch_zoom_details) => {
-                self.handle_update_pinch_zoom_details(id, pinch_zoom_details);
+                self.handle_update_pinch_zoom_details(id, pinch_zoom_details, CanGc::from_cx(cx));
             },
         }
     }
@@ -3498,9 +3498,6 @@ impl ScriptThread {
             window.set_throttled(true);
         }
 
-        // Initializing [`VisualViewport`] here allow us to monitor it's changes as soon as possible.
-        window.init_visual_viewport(can_gc);
-
         document.get_current_parser().unwrap()
     }
 
@@ -4061,13 +4058,14 @@ impl ScriptThread {
         &self,
         pipeline_id: PipelineId,
         pinch_zoom_details: PinchZoomDetails,
+        can_gc: CanGc,
     ) {
         let Some(window) = self.documents.borrow().find_window(pipeline_id) else {
             warn!("Visual viewport update for closed pipeline {pipeline_id}.");
             return;
         };
 
-        window.set_visual_viewport(pinch_zoom_details);
+        window.maybe_update_visual_viewport(pinch_zoom_details, can_gc);
     }
 }
 

--- a/components/script/script_thread.rs
+++ b/components/script/script_thread.rs
@@ -79,7 +79,7 @@ use net_traits::{
     FetchMetadata, FetchResponseMsg, Metadata, NetworkError, ResourceFetchTiming, ResourceThreads,
     ResourceTimingType,
 };
-use paint_api::{CrossProcessPaintApi, PinchZoomDetails, PipelineExitSource};
+use paint_api::{CrossProcessPaintApi, PinchZoomInfos, PipelineExitSource};
 use percent_encoding::percent_decode;
 use profile_traits::mem::{ProcessReports, ReportsChan, perform_memory_report};
 use profile_traits::time::ProfilerCategory;
@@ -1935,8 +1935,8 @@ impl ScriptThread {
                     EmbedderMsg::AccessibilityTreeUpdate(webview_id, tree_update),
                 );
             },
-            ScriptThreadMessage::UpdatePinchZoomDetails(id, pinch_zoom_details) => {
-                self.handle_update_pinch_zoom_details(id, pinch_zoom_details, CanGc::from_cx(cx));
+            ScriptThreadMessage::UpdatePinchZoomInfos(id, pinch_zoom_infos) => {
+                self.handle_update_pinch_zoom_infos(id, pinch_zoom_infos, CanGc::from_cx(cx));
             },
         }
     }
@@ -4054,10 +4054,10 @@ impl ScriptThread {
             .handle_embedder_control_response(id, response, can_gc);
     }
 
-    pub(crate) fn handle_update_pinch_zoom_details(
+    pub(crate) fn handle_update_pinch_zoom_infos(
         &self,
         pipeline_id: PipelineId,
-        pinch_zoom_details: PinchZoomDetails,
+        pinch_zoom_infos: PinchZoomInfos,
         can_gc: CanGc,
     ) {
         let Some(window) = self.documents.borrow().find_window(pipeline_id) else {
@@ -4065,7 +4065,7 @@ impl ScriptThread {
             return;
         };
 
-        window.maybe_update_visual_viewport(pinch_zoom_details, can_gc);
+        window.maybe_update_visual_viewport(pinch_zoom_infos, can_gc);
     }
 }
 

--- a/components/script_bindings/codegen/Bindings.conf
+++ b/components/script_bindings/codegen/Bindings.conf
@@ -778,7 +778,7 @@ DOMInterfaces = {
 },
 
 'Window': {
-    'canGc': ['CookieStore', 'Fetch', 'FetchLater', 'Open', 'ReportError', 'Screen', 'SetInterval', 'SetTimeout', 'Stop', 'StructuredClone', 'TrustedTypes', 'WebdriverCallback', 'WebdriverException'],
+    'canGc': ['CookieStore', 'Fetch', 'FetchLater', 'GetVisualViewport', 'Open', 'ReportError', 'Screen', 'SetInterval', 'SetTimeout', 'Stop', 'StructuredClone', 'TrustedTypes', 'WebdriverCallback', 'WebdriverException'],
     'inRealms': ['Fetch', 'GetOpener', 'WebdriverCallback'],
     'additionalTraits': ['crate::interfaces::WindowHelpers'],
     'realm': ['CreateImageBitmap', 'CreateImageBitmap_'],

--- a/components/script_bindings/codegen/Bindings.conf
+++ b/components/script_bindings/codegen/Bindings.conf
@@ -778,7 +778,7 @@ DOMInterfaces = {
 },
 
 'Window': {
-    'canGc': ['CookieStore', 'Fetch', 'FetchLater', 'Open', 'ReportError', 'Screen', 'SetInterval', 'SetTimeout', 'Stop', 'StructuredClone', 'TrustedTypes', 'WebdriverCallback', 'WebdriverException', 'GetVisualViewport'],
+    'canGc': ['CookieStore', 'Fetch', 'FetchLater', 'Open', 'ReportError', 'Screen', 'SetInterval', 'SetTimeout', 'Stop', 'StructuredClone', 'TrustedTypes', 'WebdriverCallback', 'WebdriverException'],
     'inRealms': ['Fetch', 'GetOpener', 'WebdriverCallback'],
     'additionalTraits': ['crate::interfaces::WindowHelpers'],
     'realm': ['CreateImageBitmap', 'CreateImageBitmap_'],

--- a/components/shared/constellation/lib.rs
+++ b/components/shared/constellation/lib.rs
@@ -26,6 +26,7 @@ use embedder_traits::{
 };
 pub use from_script_message::*;
 use malloc_size_of_derive::MallocSizeOf;
+use paint_api::PinchZoomDetails;
 use paint_api::largest_contentful_paint_candidate::LargestContentfulPaintType;
 use profile_traits::mem::MemoryReportResult;
 use rustc_hash::FxHashMap;
@@ -112,6 +113,8 @@ pub enum EmbedderToConstellationMessage {
     EmbedderControlResponse(EmbedderControlId, EmbedderControlResponse),
     /// An action to perform on the given `UserContentManagerId`.
     UserContentManagerAction(UserContentManagerId, UserContentManagerAction),
+    /// Update pinch zoom details stored in the top level window
+    UpdatePinchZoomDetails(PipelineId, PinchZoomDetails),
 }
 
 pub enum UserContentManagerAction {

--- a/components/shared/constellation/lib.rs
+++ b/components/shared/constellation/lib.rs
@@ -26,7 +26,7 @@ use embedder_traits::{
 };
 pub use from_script_message::*;
 use malloc_size_of_derive::MallocSizeOf;
-use paint_api::PinchZoomDetails;
+use paint_api::PinchZoomInfos;
 use paint_api::largest_contentful_paint_candidate::LargestContentfulPaintType;
 use profile_traits::mem::MemoryReportResult;
 use rustc_hash::FxHashMap;
@@ -114,7 +114,7 @@ pub enum EmbedderToConstellationMessage {
     /// An action to perform on the given `UserContentManagerId`.
     UserContentManagerAction(UserContentManagerId, UserContentManagerAction),
     /// Update pinch zoom details stored in the top level window
-    UpdatePinchZoomDetails(PipelineId, PinchZoomDetails),
+    UpdatePinchZoomInfos(PipelineId, PinchZoomInfos),
 }
 
 pub enum UserContentManagerAction {

--- a/components/shared/paint/lib.rs
+++ b/components/shared/paint/lib.rs
@@ -773,11 +773,11 @@ bitflags! {
     }
 }
 
-/// A [`PinchZoomDetails`] for a root [`Pipeline`] of an [`WebView`]. For any [`Pipeline`]
+/// A [`PinchZoomInfos`] for a root [`Pipeline`] of an [`WebView`]. For any [`Pipeline`]
 /// that is not a root, it should follow the viewport description of its pipeline since
 /// pinch-zoom and resizing due to overlay UIs are not applicable there.
 #[derive(Clone, Copy, Debug, Deserialize, PartialEq, Serialize)]
-pub struct PinchZoomDetails {
+pub struct PinchZoomInfos {
     /// The zoom factor (or pinch-zoom).
     pub zoom_factor: Scale<f32, DevicePixel, DevicePixel>,
 
@@ -785,8 +785,8 @@ pub struct PinchZoomDetails {
     pub rect: Rect<f32, CSSPixel>,
 }
 
-impl PinchZoomDetails {
-    /// New initial [`PinchZoomDetails`] without any pinch-zoom or resizing from a viewport size
+impl PinchZoomInfos {
+    /// New initial [`PinchZoomInfos`] without any pinch-zoom or resizing from a viewport size
     /// for a nested pipeline or newly initialized root pipeline.
     pub fn new_from_viewport_size(size: Size2D<f32, CSSPixel>) -> Self {
         Self {

--- a/components/shared/script/lib.rs
+++ b/components/shared/script/lib.rs
@@ -39,7 +39,7 @@ use malloc_size_of_derive::MallocSizeOf;
 use media::WindowGLContext;
 use net_traits::ResourceThreads;
 use paint_api::largest_contentful_paint_candidate::LargestContentfulPaintType;
-use paint_api::{CrossProcessPaintApi, PinchZoomDetails};
+use paint_api::{CrossProcessPaintApi, PinchZoomInfos};
 use pixels::PixelFormat;
 use profile_traits::mem;
 use rustc_hash::FxHashMap;
@@ -308,7 +308,7 @@ pub enum ScriptThreadMessage {
     AccessibilityTreeUpdate(WebViewId, accesskit::TreeUpdate),
     /// Update the pinch zoom details of a pipeline. Each `Window` stores a `VisualViewport` DOM
     /// instance that gets updated according to the changes from the `Compositor``.
-    UpdatePinchZoomDetails(PipelineId, PinchZoomDetails),
+    UpdatePinchZoomInfos(PipelineId, PinchZoomInfos),
 }
 
 impl fmt::Debug for ScriptThreadMessage {

--- a/components/shared/script/lib.rs
+++ b/components/shared/script/lib.rs
@@ -38,8 +38,8 @@ use keyboard_types::Modifiers;
 use malloc_size_of_derive::MallocSizeOf;
 use media::WindowGLContext;
 use net_traits::ResourceThreads;
-use paint_api::CrossProcessPaintApi;
 use paint_api::largest_contentful_paint_candidate::LargestContentfulPaintType;
+use paint_api::{CrossProcessPaintApi, PinchZoomDetails};
 use pixels::PixelFormat;
 use profile_traits::mem;
 use rustc_hash::FxHashMap;
@@ -306,6 +306,9 @@ pub enum ScriptThreadMessage {
     DestroyUserContentManager(UserContentManagerId),
     /// Send the embedder an accessibility tree update.
     AccessibilityTreeUpdate(WebViewId, accesskit::TreeUpdate),
+    /// Update the pinch zoom details of a pipeline. Each `Window` stores a `VisualViewport` DOM
+    /// instances that gets updated according to the changes from the `Compositor``.
+    UpdatePinchZoomDetails(PipelineId, PinchZoomDetails),
 }
 
 impl fmt::Debug for ScriptThreadMessage {

--- a/components/shared/script/lib.rs
+++ b/components/shared/script/lib.rs
@@ -307,7 +307,7 @@ pub enum ScriptThreadMessage {
     /// Send the embedder an accessibility tree update.
     AccessibilityTreeUpdate(WebViewId, accesskit::TreeUpdate),
     /// Update the pinch zoom details of a pipeline. Each `Window` stores a `VisualViewport` DOM
-    /// instances that gets updated according to the changes from the `Compositor``.
+    /// instance that gets updated according to the changes from the `Compositor``.
     UpdatePinchZoomDetails(PipelineId, PinchZoomDetails),
 }
 

--- a/tests/wpt/meta/visual-viewport/resize-event-order.html.ini
+++ b/tests/wpt/meta/visual-viewport/resize-event-order.html.ini
@@ -1,6 +1,3 @@
 [resize-event-order.html]
   [Popup: DOMWindow resize fired before VisualViewport.]
     expected: FAIL
-
-  [iframe: DOMWindow resize fired before VisualViewport.]
-    expected: FAIL

--- a/tests/wpt/meta/visual-viewport/viewport-resize-event-on-iframe-show.html.ini
+++ b/tests/wpt/meta/visual-viewport/viewport-resize-event-on-iframe-show.html.ini
@@ -1,3 +1,0 @@
-[viewport-resize-event-on-iframe-show.html]
-  [Resize event fired when an iframe is shown.]
-    expected: FAIL

--- a/tests/wpt/meta/visual-viewport/viewport-resize-event-on-iframe-size-change.html.ini
+++ b/tests/wpt/meta/visual-viewport/viewport-resize-event-on-iframe-size-change.html.ini
@@ -1,3 +1,0 @@
-[viewport-resize-event-on-iframe-size-change.html]
-  [Resize event fired when an iframe is resized.]
-    expected: FAIL


### PR DESCRIPTION
Continuing the implementation of `VisualViewport`, the resizing of `PinchZoom` should be notified to `ScriptThread` to update the `VisualViewport` interface and to fire the appropriate JS event. Top level `Window`/`Pipeline` would have a `VisualViewport` interface that mirrors the `PinchZoom` viewport, while nested `Window` would have a default value that represent layout viewport of the relevant iframe. The `VisualViewport` of an iframe is updated after each reflow that calculate the rectangle of the iframe.

The updates of DOM's `VisualViewport` occurs immediately (instead of waiting for the event loop like the viewport) but integrates with the event loop for the JS events. This behavior would helps with the fact that `VisualViewport` needs to be updated both when it is scrolled or resized.

Testing: Existing WPTs and new unit test.
Part of: https://github.com/servo/servo/issues/41341