### PR TITLE
script: Pass `&mut JSContext` to tasks

### DIFF
--- a/components/script/dom/bluetooth/bluetooth.rs
+++ b/components/script/dom/bluetooth/bluetooth.rs
@@ -267,9 +267,9 @@ pub(crate) fn response_async<T: AsyncBluetoothListener + DomObject + 'static>(
             where
                 T: AsyncBluetoothListener + DomObject,
             {
-                fn run_once(self) {
+                fn run_once(self, cx: &mut js::context::JSContext) {
                     let mut context = self.context.lock().unwrap();
-                    context.response(self.action, CanGc::note());
+                    context.response(self.action, CanGc::from_cx(cx));
                 }
             }
 

--- a/components/script/dom/document.rs
+++ b/components/script/dom/document.rs
@@ -3817,6 +3817,7 @@ impl Document {
             .set(self.script_and_layout_blockers.get() + 1);
     }
 
+    #[expect(unsafe_code)]
     /// Terminate the period in which JS or layout is disallowed from running.
     /// If no further blockers remain, any delayed tasks in the queue will
     /// be executed in queue order until the queue is empty.
@@ -3827,7 +3828,8 @@ impl Document {
         while self.script_and_layout_blockers.get() == 0 && !self.delayed_tasks.borrow().is_empty()
         {
             let task = self.delayed_tasks.borrow_mut().remove(0);
-            task.run_box();
+            let mut cx = unsafe { script_bindings::script_runtime::temp_cx() };
+            task.run_box(&mut cx);
         }
     }
 

--- a/components/script/dom/element.rs
+++ b/components/script/dom/element.rs
@@ -5457,7 +5457,7 @@ impl ElementPerformFullscreenEnter {
 
 impl TaskOnce for ElementPerformFullscreenEnter {
     #[cfg_attr(crown, allow(crown::unrooted_must_root))]
-    fn run_once(self) {
+    fn run_once(self, cx: &mut js::context::JSContext) {
         let element = self.element.root();
         let promise = self.promise.root();
         let document = element.owner_document();
@@ -5466,10 +5466,10 @@ impl TaskOnce for ElementPerformFullscreenEnter {
         if self.error || !element.fullscreen_element_ready_check() {
             document
                 .upcast::<EventTarget>()
-                .fire_event(atom!("fullscreenerror"), CanGc::note());
+                .fire_event(atom!("fullscreenerror"), CanGc::from_cx(cx));
             promise.reject_error(
                 Error::Type(String::from("fullscreen is not connected")),
-                CanGc::note(),
+                CanGc::from_cx(cx),
             );
             return;
         }
@@ -5482,10 +5482,10 @@ impl TaskOnce for ElementPerformFullscreenEnter {
         // Step 7.6
         document
             .upcast::<EventTarget>()
-            .fire_event(atom!("fullscreenchange"), CanGc::note());
+            .fire_event(atom!("fullscreenchange"), CanGc::from_cx(cx));
 
         // Step 7.7
-        promise.resolve_native(&(), CanGc::note());
+        promise.resolve_native(&(), CanGc::from_cx(cx));
     }
 }
 
@@ -5505,7 +5505,7 @@ impl ElementPerformFullscreenExit {
 
 impl TaskOnce for ElementPerformFullscreenExit {
     #[cfg_attr(crown, allow(crown::unrooted_must_root))]
-    fn run_once(self) {
+    fn run_once(self, cx: &mut js::context::JSContext) {
         let element = self.element.root();
         let document = element.owner_document();
         // TODO Step 9.1-5
@@ -5516,10 +5516,10 @@ impl TaskOnce for ElementPerformFullscreenExit {
         // Step 9.8
         document
             .upcast::<EventTarget>()
-            .fire_event(atom!("fullscreenchange"), CanGc::note());
+            .fire_event(atom!("fullscreenchange"), CanGc::from_cx(cx));
 
         // Step 9.10
-        self.promise.root().resolve_native(&(), CanGc::note());
+        self.promise.root().resolve_native(&(), CanGc::from_cx(cx));
     }
 }
 

--- a/components/script/dom/event.rs
+++ b/components/script/dom/event.rs
@@ -1143,7 +1143,7 @@ pub(crate) struct EventTask {
 }
 
 impl TaskOnce for EventTask {
-    fn run_once(self) {
+    fn run_once(self, cx: &mut js::context::JSContext) {
         let target = self.target.root();
         let bubbles = self.bubbles;
         let cancelable = self.cancelable;
@@ -1152,7 +1152,7 @@ impl TaskOnce for EventTask {
             bubbles,
             cancelable,
             EventComposed::NotComposed,
-            CanGc::note(),
+            CanGc::from_cx(cx),
         );
     }
 }
@@ -1164,9 +1164,9 @@ pub(crate) struct SimpleEventTask {
 }
 
 impl TaskOnce for SimpleEventTask {
-    fn run_once(self) {
+    fn run_once(self, cx: &mut js::context::JSContext) {
         let target = self.target.root();
-        target.fire_event(self.name, CanGc::note());
+        target.fire_event(self.name, CanGc::from_cx(cx));
     }
 }
 

--- a/components/script/dom/filereader.rs
+++ b/components/script/dom/filereader.rs
@@ -48,8 +48,8 @@ pub(crate) enum FileReadingTask {
 }
 
 impl TaskOnce for FileReadingTask {
-    fn run_once(self) {
-        self.handle_task(CanGc::note());
+    fn run_once(self, cx: &mut js::context::JSContext) {
+        self.handle_task(CanGc::from_cx(cx));
     }
 }
 

--- a/components/script/dom/node.rs
+++ b/components/script/dom/node.rs
@@ -2719,11 +2719,11 @@ impl Node {
         // we use a delayed task that will run as soon as Node::insert removes its
         // script/layout blocker.
         parent_document.add_delayed_task(
-            task!(PostConnectionSteps: |static_node_list: SmallVec<[DomRoot<Node>; 4]>| {
+            task!(PostConnectionSteps: |cx, static_node_list: SmallVec<[DomRoot<Node>; 4]>| {
                 // Step 12. For each node of staticNodeList, if node is connected, then run the
                 //          post-connection steps with node.
                 for node in static_node_list {
-                    vtable_for(&node).post_connection_steps(CanGc::note());
+                    vtable_for(&node).post_connection_steps(CanGc::from_cx(cx));
                 }
             }),
         );

--- a/components/script/dom/workers/serviceworker.rs
+++ b/components/script/dom/workers/serviceworker.rs
@@ -164,7 +164,7 @@ impl ServiceWorkerMethods<crate::DomTypeHolder> for ServiceWorker {
 
 impl TaskOnce for SimpleWorkerErrorHandler<ServiceWorker> {
     #[cfg_attr(crown, allow(crown::unrooted_must_root))]
-    fn run_once(self) {
-        ServiceWorker::dispatch_simple_error(self.addr, CanGc::note());
+    fn run_once(self, cx: &mut js::context::JSContext) {
+        ServiceWorker::dispatch_simple_error(self.addr, CanGc::from_cx(cx));
     }
 }

--- a/components/script/dom/workers/worker.rs
+++ b/components/script/dom/workers/worker.rs
@@ -325,7 +325,7 @@ impl WorkerMethods<crate::DomTypeHolder> for Worker {
 
 impl TaskOnce for SimpleWorkerErrorHandler<Worker> {
     #[cfg_attr(crown, allow(crown::unrooted_must_root))]
-    fn run_once(self) {
-        Worker::dispatch_simple_error(self.addr, CanGc::note());
+    fn run_once(self, cx: &mut js::context::JSContext) {
+        Worker::dispatch_simple_error(self.addr, CanGc::from_cx(cx));
     }
 }

--- a/components/script/dom/workers/workerglobalscope.rs
+++ b/components/script/dom/workers/workerglobalscope.rs
@@ -1007,7 +1007,7 @@ impl WorkerGlobalScope {
             return false;
         }
         match msg {
-            CommonScriptMsg::Task(_, task, _, _) => task.run_box(),
+            CommonScriptMsg::Task(_, task, _, _) => task.run_box(cx),
             CommonScriptMsg::CollectReports(reports_chan) => {
                 let cx: JSContext = cx.into();
                 perform_memory_report(|ops| {

--- a/components/script/links.rs
+++ b/components/script/links.rs
@@ -447,9 +447,9 @@ pub(crate) fn follow_hyperlink(
             document.creation_sandboxing_flag_set_considering_parent_iframe(),
         );
         let target = Trusted::new(target_window);
-        let task = task!(navigate_follow_hyperlink: move || {
+        let task = task!(navigate_follow_hyperlink: move |cx| {
             debug!("following hyperlink to {}", load_data.url);
-            target.root().load_url(history_handling, false, load_data, CanGc::note());
+            target.root().load_url(history_handling, false, load_data, CanGc::from_cx(cx));
         });
         target_document
             .owner_global()

--- a/components/script/script_module.rs
+++ b/components/script/script_module.rs
@@ -1028,9 +1028,9 @@ impl ModuleHandler {
 }
 
 impl Callback for ModuleHandler {
-    fn callback(&self, _cx: &mut CurrentRealm, _v: HandleValue) {
+    fn callback(&self, cx: &mut CurrentRealm, _v: HandleValue) {
         let task = self.task.borrow_mut().take().unwrap();
-        task.run_box();
+        task.run_box(cx);
     }
 }
 

--- a/components/script/script_thread.rs
+++ b/components/script/script_thread.rs
@@ -2009,7 +2009,7 @@ impl ScriptThread {
                     let global = self.documents.borrow().find_global(id);
                     global.map(|global| enter_realm(&*global))
                 });
-                task.run_box()
+                task.run_box(cx)
             },
             MainThreadScriptMsg::Common(CommonScriptMsg::CollectReports(chan)) => {
                 self.collect_reports(chan)

--- a/components/script/security_manager.rs
+++ b/components/script/security_manager.rs
@@ -138,11 +138,11 @@ impl CSPViolationReportTask {
 /// <https://w3c.github.io/webappsec-csp/#report-violation>
 /// > Queue a task to run the following steps:
 impl TaskOnce for CSPViolationReportTask {
-    fn run_once(self) {
+    fn run_once(self, cx: &mut js::context::JSContext) {
         // > If target implements EventTarget, fire an event named securitypolicyviolation
         // > that uses the SecurityPolicyViolationEvent interface
         // > at target with its attributes initialized as follows:
-        self.fire_violation_event(CanGc::note());
+        self.fire_violation_event(CanGc::from_cx(cx));
         // Step 3.4. If violation’s policy’s directive set contains a directive named "report-uri" directive:
         if let Some(report_uri_directive) = self
             .violation_policy

--- a/components/script/task.rs
+++ b/components/script/task.rs
@@ -77,19 +77,19 @@ pub(crate) trait NonSendTaskOnce: crate::JSTraceable {
 pub(crate) trait TaskBox: Send {
     fn name(&self) -> &'static str;
 
-    fn run_box(self: Box<Self>);
+    fn run_box(self: Box<Self>, cx: &mut js::context::JSContext);
 }
 
 /// A boxed version of `NonSendTaskOnce`.
 pub(crate) trait NonSendTaskBox: crate::JSTraceable {
-    fn run_box(self: Box<Self>);
+    fn run_box(self: Box<Self>, cx: &mut js::context::JSContext);
 }
 
 impl<T> NonSendTaskBox for T
 where
     T: NonSendTaskOnce,
 {
-    fn run_box(self: Box<Self>) {
+    fn run_box(self: Box<Self>, _cx: &mut js::context::JSContext) {
         self.run_once()
     }
 }
@@ -102,7 +102,7 @@ where
         TaskOnce::name(self)
     }
 
-    fn run_box(self: Box<Self>) {
+    fn run_box(self: Box<Self>, _cx: &mut js::context::JSContext) {
         self.run_once()
     }
 }

--- a/components/script_bindings/script_runtime.rs
+++ b/components/script_bindings/script_runtime.rs
@@ -68,6 +68,18 @@ pub fn mark_runtime_dead() {
     THREAD_ACTIVE.with(|t| t.set(false));
 }
 
+/// Get the current JSContext for the running thread.
+///
+/// ## Safety
+/// Using this function is unsafe because no other JSContext may be constructed apart from initial ones,
+/// but because we are still working on passing down &mut SafeJSContext references,
+/// this function is provided as temporary workaround/placeholder.
+///
+/// As such all it's usages will need to be eventually replaced with proper &mut SafeJSContext references.
+pub unsafe fn temp_cx() -> SafeJSContext {
+    unsafe { SafeJSContext::from_ptr(js::rust::Runtime::get().unwrap()) }
+}
+
 #[derive(Clone, Copy, Debug)]
 /// A compile-time marker that there are operations that could trigger a JS garbage collection
 /// operation within the current stack frame. It is trivially copyable, so it should be passed


### PR DESCRIPTION
This change is reviewable per commits:
In first commit we added `&mut JSContext` to `run_box` (it is very hard to bring `&mut JSContext` to `remove_script_and_layout_blocker`).
In second commit we pass `&mut JSContext` to `run_once`.
In third commit we added support for accepting `&mut JSContext` in closures of `task!` macro and lastly we demo new macro invocations (to ensure they actually compile)

Testing: Just refactor, but should be covered by WPT
Part of #40600
