### PR TITLE
script: Implement all user agent widgets for form controls with shadow DOM

### DIFF
--- a/components/layout/dom_traversal.rs
+++ b/components/layout/dom_traversal.rs
@@ -134,29 +134,16 @@ fn traverse_children_of<'dom>(
         traverse_eager_pseudo_element(PseudoElement::Before, parent_element_info, context, handler);
     }
 
-    // TODO(stevennovaryo): In the past we are rendering text input as a normal element,
-    //                      and the processing of text is happening here. Remove this
-    //                      special case after the implementation of UA Shadow DOM for
-    //                      all affected input elements.
-    if parent_element_info.node.is_text_input() {
-        let node_text_content = parent_element_info.node.node_text_content();
-        if node_text_content.is_empty() {
-            handler.handle_text(parent_element_info, "\u{200B}".into());
-        } else {
-            handler.handle_text(parent_element_info, node_text_content);
-        }
-    } else {
-        for child in parent_element_info.node.children() {
-            if child.is_text_node() {
-                let info = NodeAndStyleInfo::new(
-                    child,
-                    child.style(&context.style_context),
-                    child.take_restyle_damage(),
-                );
-                handler.handle_text(&info, child.node_text_content());
-            } else if child.is_element() {
-                traverse_element(child, context, handler);
-            }
+    for child in parent_element_info.node.children() {
+        if child.is_text_node() {
+            let info = NodeAndStyleInfo::new(
+                child,
+                child.style(&context.style_context),
+                child.take_restyle_damage(),
+            );
+            handler.handle_text(&info, child.text_content());
+        } else if child.is_element() {
+            traverse_element(child, context, handler);
         }
     }
 

--- a/components/layout/query.rs
+++ b/components/layout/query.rs
@@ -1050,7 +1050,7 @@ fn rendered_text_collection_steps(
                     }
                 }
 
-                let text_content = node.to_threadsafe().node_text_content();
+                let text_content = node.to_threadsafe().text_content();
 
                 let white_space_collapse = style.clone_white_space_collapse();
                 let preserve_whitespace = white_space_collapse == WhiteSpaceCollapseValue::Preserve;
@@ -1127,7 +1127,7 @@ fn rendered_text_collection_steps(
                 // If we don't have a parent element then there's no style data available,
                 // in this (pretty unlikely) case we just return the Text fragment as is.
                 items.push(InnerOrOuterTextItem::Text(
-                    node.to_threadsafe().node_text_content().into(),
+                    node.to_threadsafe().text_content().into(),
                 ));
             }
         },

--- a/components/script/dom/document_embedder_controls.rs
+++ b/components/script/dom/document_embedder_controls.rs
@@ -516,7 +516,7 @@ impl Node {
     fn as_text_input(&self) -> Option<DomRoot<Element>> {
         if let Some(input_element) = self
             .downcast::<HTMLInputElement>()
-            .filter(|input_element| input_element.is_textual_widget())
+            .filter(|input_element| input_element.renders_as_text_input_widget())
         {
             return Some(DomRoot::from_ref(input_element.upcast::<Element>()));
         }

--- a/components/script/dom/filelist.rs
+++ b/components/script/dom/filelist.rs
@@ -6,7 +6,6 @@ use std::slice::Iter;
 
 use dom_struct::dom_struct;
 
-use super::bindings::root::{LayoutDom, ToLayout};
 use crate::dom::bindings::codegen::Bindings::FileListBinding::FileListMethods;
 use crate::dom::bindings::reflector::{Reflector, reflect_dom_object};
 use crate::dom::bindings::root::{Dom, DomRoot};
@@ -68,25 +67,5 @@ impl FileListMethods<crate::DomTypeHolder> for FileList {
     // check-tidy: no specs after this line
     fn IndexedGetter(&self, index: u32) -> Option<DomRoot<File>> {
         self.Item(index)
-    }
-}
-
-pub(crate) trait LayoutFileListHelpers<'dom> {
-    fn file_for_layout(&self, index: u32) -> Option<&File>;
-    fn len(&self) -> usize;
-}
-
-#[expect(unsafe_code)]
-impl<'dom> LayoutFileListHelpers<'dom> for LayoutDom<'dom, FileList> {
-    fn len(&self) -> usize {
-        self.unsafe_get().list.len()
-    }
-    fn file_for_layout(&self, index: u32) -> Option<&File> {
-        let list = &self.unsafe_get().list;
-        if (index as usize) < list.len() {
-            Some(unsafe { list[index as usize].to_layout().unsafe_get() })
-        } else {
-            None
-        }
     }
 }

--- a/components/script/dom/html/htmlformelement.rs
+++ b/components/script/dom/html/htmlformelement.rs
@@ -1372,7 +1372,10 @@ impl HTMLFormElement {
                 NodeTypeId::Element(ElementTypeId::HTMLElement(
                     HTMLElementTypeId::HTMLTextAreaElement,
                 )) => {
-                    child.downcast::<HTMLTextAreaElement>().unwrap().reset();
+                    child
+                        .downcast::<HTMLTextAreaElement>()
+                        .unwrap()
+                        .reset(can_gc);
                 },
                 NodeTypeId::Element(ElementTypeId::HTMLElement(
                     HTMLElementTypeId::HTMLOutputElement,

--- a/components/script/dom/html/htmlinputelement.rs
+++ b/components/script/dom/html/htmlinputelement.rs
@@ -100,7 +100,7 @@ const DEFAULT_FILE_INPUT_VALUE: &str = "No file chosen";
 #[derive(Clone, JSTraceable, MallocSizeOf)]
 #[cfg_attr(crown, crown::unrooted_must_root_lint::must_root)]
 struct TextValueShadowTree {
-    value: DomRefCell<Dom<Text>>,
+    value: Dom<Text>,
 }
 
 impl TextValueShadowTree {
@@ -108,13 +108,12 @@ impl TextValueShadowTree {
         let value = Text::new(Default::default(), &shadow_root.owner_document(), can_gc);
         Node::replace_all(Some(value.upcast()), shadow_root, can_gc);
         Self {
-            value: DomRefCell::new(value.as_traced()),
+            value: value.as_traced(),
         }
     }
 
     fn update(&self, input_element: &HTMLInputElement) {
-        let text = self.value.borrow_mut();
-        let character_data = text.upcast::<CharacterData>();
+        let character_data = self.value.upcast::<CharacterData>();
         let value = input_element.value_for_shadow_dom();
         if character_data.Data() != value {
             character_data.SetData(value);

--- a/components/script/dom/html/htmlinputelement.rs
+++ b/components/script/dom/html/htmlinputelement.rs
@@ -2,7 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-use std::borrow::Cow;
 use std::cell::{Cell, RefCell};
 use std::cmp::Ordering;
 use std::ops::Range;
@@ -30,6 +29,7 @@ use js::jsval::UndefinedValue;
 use js::rust::wrappers::{CheckRegExpSyntax, ExecuteRegExpNoStatics, ObjectIsRegExp};
 use js::rust::{HandleObject, MutableHandleObject};
 use net_traits::blob_url_store::get_blob_origin;
+use script_bindings::codegen::GenericBindings::AttrBinding::AttrMethods;
 use script_bindings::codegen::GenericBindings::CharacterDataBinding::CharacterDataMethods;
 use script_bindings::codegen::GenericBindings::DocumentBinding::DocumentMethods;
 use script_bindings::domstring::parse_floating_point_number;
@@ -61,13 +61,11 @@ use crate::dom::clipboardevent::{ClipboardEvent, ClipboardEventType};
 use crate::dom::compositionevent::CompositionEvent;
 use crate::dom::document::Document;
 use crate::dom::document_embedder_controls::ControlElement;
-use crate::dom::element::{
-    AttributeMutation, CustomElementCreationMode, Element, ElementCreator, LayoutElementHelpers,
-};
+use crate::dom::element::{AttributeMutation, CustomElementCreationMode, Element, ElementCreator};
 use crate::dom::event::{Event, EventBubbles, EventCancelable, EventComposed};
 use crate::dom::eventtarget::EventTarget;
 use crate::dom::file::File;
-use crate::dom::filelist::{FileList, LayoutFileListHelpers};
+use crate::dom::filelist::FileList;
 use crate::dom::globalscope::GlobalScope;
 use crate::dom::html::htmldatalistelement::HTMLDataListElement;
 use crate::dom::html::htmlelement::HTMLElement;
@@ -82,7 +80,7 @@ use crate::dom::node::{
     BindContext, CloneChildrenFlag, Node, NodeDamage, NodeTraits, ShadowIncluding, UnbindContext,
 };
 use crate::dom::nodelist::NodeList;
-use crate::dom::shadowroot::ShadowRoot;
+use crate::dom::text::Text;
 use crate::dom::textcontrol::{TextControlElement, TextControlSelection};
 use crate::dom::types::{CharacterData, FocusEvent};
 use crate::dom::validation::{Validatable, is_barred_by_datalist_ancestor};
@@ -98,6 +96,29 @@ const DEFAULT_SUBMIT_VALUE: &str = "Submit";
 const DEFAULT_RESET_VALUE: &str = "Reset";
 const PASSWORD_REPLACEMENT_CHAR: char = '●';
 const DEFAULT_FILE_INPUT_VALUE: &str = "No file chosen";
+
+#[derive(Clone, JSTraceable, MallocSizeOf)]
+#[cfg_attr(crown, crown::unrooted_must_root_lint::must_root)]
+struct TextValueShadowTree {
+    value: DomRefCell<Dom<Text>>,
+}
+
+impl TextValueShadowTree {
+    fn new(shadow_root: &Node, can_gc: CanGc) -> Self {
+        let value = Text::new(Default::default(), &shadow_root.owner_document(), can_gc);
+        Node::replace_all(Some(value.upcast()), shadow_root, can_gc);
+        Self {
+            value: DomRefCell::new(value.as_traced()),
+        }
+    }
+
+    fn update(&self, input_element: &HTMLInputElement) {
+        self.value
+            .borrow_mut()
+            .upcast::<CharacterData>()
+            .SetData(input_element.value_for_shadow_dom());
+    }
+}
 
 #[derive(Clone, JSTraceable, MallocSizeOf)]
 #[cfg_attr(crown, crown::unrooted_must_root_lint::must_root)]
@@ -120,13 +141,45 @@ const DEFAULT_FILE_INPUT_VALUE: &str = "No file chosen";
 //                      they would try to vertically align <input> text baseline with the baseline of other
 //                      TextNode within an inline flow. Another example is the horizontal scroll.
 // FIXME(#38263): Refactor these logics into a TextControl wrapper that would decouple all textual input.
-struct InputTypeTextShadowTree {
+struct TextInputWidgetShadowTree {
     inner_container: Dom<Element>,
     text_container: Dom<Element>,
     placeholder_container: DomRefCell<Option<Dom<Element>>>,
 }
 
-impl InputTypeTextShadowTree {
+impl TextInputWidgetShadowTree {
+    fn new(shadow_root: &Node, can_gc: CanGc) -> Self {
+        let document = shadow_root.owner_document();
+        let inner_container = Element::create(
+            QualName::new(None, ns!(html), local_name!("div")),
+            None,
+            &document,
+            ElementCreator::ScriptCreated,
+            CustomElementCreationMode::Asynchronous,
+            None,
+            can_gc,
+        );
+
+        Node::replace_all(Some(inner_container.upcast()), shadow_root.upcast(), can_gc);
+        inner_container
+            .upcast::<Node>()
+            .set_implemented_pseudo_element(PseudoElement::ServoTextControlInnerContainer);
+
+        let text_container = create_ua_widget_div_with_text_node(
+            &document,
+            inner_container.upcast(),
+            PseudoElement::ServoTextControlInnerEditor,
+            false,
+            can_gc,
+        );
+
+        Self {
+            inner_container: inner_container.as_traced(),
+            text_container: text_container.as_traced(),
+            placeholder_container: DomRefCell::new(None),
+        }
+    }
+
     /// Initialize the placeholder container only when it is necessary. This would help the performance of input
     /// element with shadow dom that is quite bulky.
     fn init_placeholder_container_if_necessary(&self, host: &HTMLInputElement, can_gc: CanGc) {
@@ -147,6 +200,56 @@ impl InputTypeTextShadowTree {
             .as_traced(),
         );
     }
+
+    fn update_placeholder(&self, input_element: &HTMLInputElement, can_gc: CanGc) {
+        self.init_placeholder_container_if_necessary(input_element, can_gc);
+        let Some(ref placeholder_container) = *self.placeholder_container.borrow() else {
+            return;
+        };
+
+        // We are finding and updating the CharacterData child directly to optimize the update.
+        placeholder_container
+            .upcast::<Node>()
+            .GetFirstChild()
+            .expect("UA widget text container without child")
+            .downcast::<CharacterData>()
+            .expect("First child is not a CharacterData node")
+            .SetData(input_element.placeholder.borrow().clone());
+    }
+
+    // TODO(stevennovaryo): The rest of textual input shadow dom structure should act
+    // like an exstension to this one.
+    fn update(&self, input_element: &HTMLInputElement) {
+        // The addition of zero-width space here forces the text input to have an inline formatting
+        // context that might otherwise be trimmed if there's no text. This is important to ensure
+        // that the input element is at least as tall as the line gap of the caret:
+        // <https://drafts.csswg.org/css-ui/#element-with-default-preferred-size>.
+        //
+        // This is also used to ensure that the caret will still be rendered when the input is empty.
+        // TODO: Could append `<br>` element to prevent collapses and avoid this hack, but we would
+        //       need to fix the rendering of caret beforehand.
+        let value = input_element.Value();
+        let value_text = match (value.is_empty(), input_element.input_type()) {
+            // For a password input, we replace all of the character with its replacement char.
+            (false, InputType::Password) => value
+                .str()
+                .chars()
+                .map(|_| PASSWORD_REPLACEMENT_CHAR)
+                .collect::<String>()
+                .into(),
+            (false, _) => value,
+            (true, _) => "\u{200B}".into(),
+        };
+
+        // We are finding and updating the CharacterData child directly to optimize the update.
+        self.text_container
+            .upcast::<Node>()
+            .GetFirstChild()
+            .expect("UA widget text container without child")
+            .downcast::<CharacterData>()
+            .expect("First child is not a CharacterData node")
+            .SetData(value_text);
+    }
 }
 
 #[derive(Clone, JSTraceable, MallocSizeOf)]
@@ -155,17 +258,95 @@ impl InputTypeTextShadowTree {
 ///
 /// The shadow tree consists of a single div with the currently selected color as
 /// the background.
-struct InputTypeColorShadowTree {
+struct ColorInputShadowTree {
     color_value: Dom<Element>,
+}
+
+impl ColorInputShadowTree {
+    fn new(shadow_root: &Node, can_gc: CanGc) -> Self {
+        let color_value = Element::create(
+            QualName::new(None, ns!(html), local_name!("div")),
+            None,
+            &shadow_root.owner_document(),
+            ElementCreator::ScriptCreated,
+            CustomElementCreationMode::Asynchronous,
+            None,
+            can_gc,
+        );
+
+        Node::replace_all(Some(color_value.upcast()), shadow_root.upcast(), can_gc);
+        color_value
+            .upcast::<Node>()
+            .set_implemented_pseudo_element(PseudoElement::ColorSwatch);
+
+        Self {
+            color_value: color_value.as_traced(),
+        }
+    }
+
+    fn update(&self, input_element: &HTMLInputElement, can_gc: CanGc) {
+        let mut value = input_element.Value();
+        if value.str().is_valid_simple_color_string() {
+            value.make_ascii_lowercase();
+        } else {
+            value = DOMString::from("#000000");
+        }
+        let style = format!("background-color: {value}");
+        self.color_value
+            .set_string_attribute(&local_name!("style"), style.into(), can_gc);
+    }
 }
 
 #[derive(Clone, JSTraceable, MallocSizeOf)]
 #[cfg_attr(crown, crown::unrooted_must_root_lint::must_root)]
 #[non_exhaustive]
-enum ShadowTree {
-    Text(InputTypeTextShadowTree),
-    Color(InputTypeColorShadowTree),
+enum InputElementShadowTree {
+    ColorInput(ColorInputShadowTree),
+    TextInput(TextInputWidgetShadowTree),
+    TextValue(TextValueShadowTree),
     // TODO: Add shadow trees for other input types (range etc) here
+}
+
+impl InputElementShadowTree {
+    fn new(input_element: &HTMLInputElement, can_gc: CanGc) -> Self {
+        let element = input_element.upcast::<Element>();
+        let shadow_root = element
+            .shadow_root()
+            .unwrap_or_else(|| element.attach_ua_shadow_root(true, can_gc));
+        let shadow_root = shadow_root.upcast();
+
+        if input_element.input_type() == InputType::Color {
+            return Self::ColorInput(ColorInputShadowTree::new(shadow_root, can_gc));
+        }
+        if input_element.renders_as_text_input_widget() {
+            return Self::TextInput(TextInputWidgetShadowTree::new(shadow_root, can_gc));
+        }
+        Self::TextValue(TextValueShadowTree::new(shadow_root, can_gc))
+    }
+
+    fn is_valid_for_element(&self, input_element: &HTMLInputElement) -> bool {
+        match self {
+            InputElementShadowTree::ColorInput(_) => input_element.input_type() == InputType::Color,
+            InputElementShadowTree::TextInput(_) => input_element.renders_as_text_input_widget(),
+            _ => true,
+        }
+    }
+
+    fn update_placeholder_contents(&self, input_element: &HTMLInputElement, can_gc: CanGc) {
+        if let InputElementShadowTree::TextInput(shadow_tree) = self {
+            shadow_tree.update_placeholder(input_element, can_gc);
+        }
+    }
+
+    fn update(&self, input_element: &HTMLInputElement, can_gc: CanGc) {
+        match self {
+            InputElementShadowTree::ColorInput(shadow_tree) => {
+                shadow_tree.update(input_element, can_gc)
+            },
+            InputElementShadowTree::TextInput(shadow_tree) => shadow_tree.update(input_element),
+            InputElementShadowTree::TextValue(shadow_tree) => shadow_tree.update(input_element),
+        }
+    }
 }
 
 /// Create a div element with a text node within an UA Widget and either append or prepend it to
@@ -441,7 +622,7 @@ pub(crate) struct HTMLInputElement {
     form_owner: MutNullableDom<HTMLFormElement>,
     labels_node_list: MutNullableDom<NodeList>,
     validity_state: MutNullableDom<ValidityState>,
-    shadow_tree: DomRefCell<Option<ShadowTree>>,
+    shadow_tree: DomRefCell<Option<InputElementShadowTree>>,
     #[no_trace]
     pending_webdriver_response: RefCell<Option<PendingWebDriverResponse>>,
 }
@@ -1207,141 +1388,27 @@ impl HTMLInputElement {
         failed_flags
     }
 
-    /// Return a reference to the ShadowRoot that this element is a host of,
-    /// or create one if none exists.
-    // FIXME(stevennovaryo): We should encapsulate the logics for the initiation and maintainance of
-    //                       form UA widget inside another struct.
-    fn shadow_root(&self, can_gc: CanGc) -> DomRoot<ShadowRoot> {
-        self.upcast::<Element>()
-            .shadow_root()
-            .unwrap_or_else(|| self.upcast::<Element>().attach_ua_shadow_root(true, can_gc))
-    }
-
-    fn create_text_shadow_tree(&self, can_gc: CanGc) {
-        let document = self.owner_document();
-        let shadow_root = self.shadow_root(can_gc);
-        Node::replace_all(None, shadow_root.upcast::<Node>(), can_gc);
-
-        let inner_container = Element::create(
-            QualName::new(None, ns!(html), local_name!("div")),
-            None,
-            &document,
-            ElementCreator::ScriptCreated,
-            CustomElementCreationMode::Asynchronous,
-            None,
-            can_gc,
-        );
-        shadow_root
-            .upcast::<Node>()
-            .AppendChild(inner_container.upcast::<Node>(), can_gc)
-            .unwrap();
-        inner_container
-            .upcast::<Node>()
-            .set_implemented_pseudo_element(PseudoElement::ServoTextControlInnerContainer);
-
-        let text_container = create_ua_widget_div_with_text_node(
-            &document,
-            inner_container.upcast::<Node>(),
-            PseudoElement::ServoTextControlInnerEditor,
-            false,
-            can_gc,
-        );
-
-        let _ = self
-            .shadow_tree
-            .borrow_mut()
-            .insert(ShadowTree::Text(InputTypeTextShadowTree {
-                inner_container: inner_container.as_traced(),
-                text_container: text_container.as_traced(),
-                placeholder_container: DomRefCell::new(None),
-            }));
-    }
-
-    fn text_shadow_tree(&self, can_gc: CanGc) -> Ref<'_, InputTypeTextShadowTree> {
-        let has_text_shadow_tree = self
-            .shadow_tree
-            .borrow()
-            .as_ref()
-            .is_some_and(|shadow_tree| matches!(shadow_tree, ShadowTree::Text(_)));
-        if !has_text_shadow_tree {
-            self.create_text_shadow_tree(can_gc);
-        }
-
-        let shadow_tree = self.shadow_tree.borrow();
-        Ref::filter_map(shadow_tree, |shadow_tree| {
-            let shadow_tree = shadow_tree.as_ref()?;
-            match shadow_tree {
-                ShadowTree::Text(text_tree) => Some(text_tree),
-                _ => None,
+    /// Get the shadow tree for this [`HTMLInputElement`], if it is created and valid, otherwise
+    /// recreate the shadow tree and return it.
+    fn get_or_create_shadow_tree(&self, can_gc: CanGc) -> Ref<'_, InputElementShadowTree> {
+        {
+            if let Ok(shadow_tree) = Ref::filter_map(self.shadow_tree.borrow(), |shadow_tree| {
+                shadow_tree
+                    .as_ref()
+                    .filter(|shadow_tree| shadow_tree.is_valid_for_element(self))
+            }) {
+                return shadow_tree;
             }
-        })
-        .ok()
-        .expect("UA shadow tree was not created")
-    }
-
-    fn create_color_shadow_tree(&self, can_gc: CanGc) {
-        let document = self.owner_document();
-        let shadow_root = self.shadow_root(can_gc);
-        Node::replace_all(None, shadow_root.upcast::<Node>(), can_gc);
-
-        let color_value = Element::create(
-            QualName::new(None, ns!(html), local_name!("div")),
-            None,
-            &document,
-            ElementCreator::ScriptCreated,
-            CustomElementCreationMode::Asynchronous,
-            None,
-            can_gc,
-        );
-        shadow_root
-            .upcast::<Node>()
-            .AppendChild(color_value.upcast::<Node>(), can_gc)
-            .unwrap();
-        color_value
-            .upcast::<Node>()
-            .set_implemented_pseudo_element(PseudoElement::ColorSwatch);
-
-        let _ = self
-            .shadow_tree
-            .borrow_mut()
-            .insert(ShadowTree::Color(InputTypeColorShadowTree {
-                color_value: color_value.as_traced(),
-            }));
-    }
-
-    /// Get a handle to the shadow tree for this input, assuming it's [InputType] is `Color`.
-    ///
-    /// If the input is not currently a shadow host, a new shadow tree will be created.
-    ///
-    /// If the input is a shadow host for a different kind of shadow tree then the old
-    /// tree will be removed and a new one will be created.
-    fn color_shadow_tree(&self, can_gc: CanGc) -> Ref<'_, InputTypeColorShadowTree> {
-        let has_color_shadow_tree = self
-            .shadow_tree
-            .borrow()
-            .as_ref()
-            .is_some_and(|shadow_tree| matches!(shadow_tree, ShadowTree::Color(_)));
-        if !has_color_shadow_tree {
-            self.create_color_shadow_tree(can_gc);
         }
-
-        let shadow_tree = self.shadow_tree.borrow();
-        Ref::filter_map(shadow_tree, |shadow_tree| {
-            let shadow_tree = shadow_tree.as_ref()?;
-            match shadow_tree {
-                ShadowTree::Color(color_tree) => Some(color_tree),
-                _ => None,
-            }
-        })
-        .ok()
-        .expect("UA shadow tree was not created")
+        *self.shadow_tree.borrow_mut() = Some(InputElementShadowTree::new(self, can_gc));
+        self.get_or_create_shadow_tree(can_gc)
     }
 
-    /// Should this input type render as a basic text UA widget.
-    // TODO(#38251): Ideally, the most basic shadow dom should cover only `text`, `password`, `url`, `tel`,
-    //               and `email`. But we are leaving the others textual inputs here while tackling them one
-    //               by one.
-    pub(crate) fn is_textual_widget(&self) -> bool {
+    /// Whether this input type renders as a basic text input widget.
+    ///
+    /// TODO(#38251): This should eventually only include `text`, `password`, `url`, `tel`,
+    /// and `email`, but the others do not yet have a custom shadow DOM implementation.
+    pub(crate) fn renders_as_text_input_widget(&self) -> bool {
         matches!(
             self.input_type(),
             InputType::Date |
@@ -1358,74 +1425,6 @@ impl HTMLInputElement {
                 InputType::Url |
                 InputType::Week
         )
-    }
-
-    /// Construct the most basic shadow tree structure for textual input.
-    /// TODO(stevennovaryo): The rest of textual input shadow dom structure should act like an
-    ///                       exstension to this one.
-    fn update_textual_shadow_tree(&self, can_gc: CanGc) {
-        // Should only do this for textual input widget.
-        debug_assert!(self.is_textual_widget());
-
-        let text_shadow_tree = self.text_shadow_tree(can_gc);
-        let value = self.Value();
-
-        // The addition of zero-width space here forces the text input to have an inline formatting
-        // context that might otherwise be trimmed if there's no text. This is important to ensure
-        // that the input element is at least as tall as the line gap of the caret:
-        // <https://drafts.csswg.org/css-ui/#element-with-default-preferred-size>.
-        //
-        // This is also used to ensure that the caret will still be rendered when the input is empty.
-        // TODO: Could append `<br>` element to prevent collapses and avoid this hack, but we would
-        //       need to fix the rendering of caret beforehand.
-        let value_text = match (value.is_empty(), self.input_type()) {
-            // For a password input, we replace all of the character with its replacement char.
-            (false, InputType::Password) => value
-                .str()
-                .chars()
-                .map(|_| PASSWORD_REPLACEMENT_CHAR)
-                .collect::<String>()
-                .into(),
-            (false, _) => value,
-            (true, _) => "\u{200B}".into(),
-        };
-
-        // We are finding and updating the CharacterData child directly to optimize the update.
-        text_shadow_tree
-            .text_container
-            .upcast::<Node>()
-            .GetFirstChild()
-            .expect("UA widget text container without child")
-            .downcast::<CharacterData>()
-            .expect("First child is not a CharacterData node")
-            .SetData(value_text);
-    }
-
-    fn update_color_shadow_tree(&self, can_gc: CanGc) {
-        // Should only do this for `type=color` input.
-        debug_assert_eq!(self.input_type(), InputType::Color);
-
-        let color_shadow_tree = self.color_shadow_tree(can_gc);
-        let mut value = self.Value();
-        if value.str().is_valid_simple_color_string() {
-            value.make_ascii_lowercase();
-        } else {
-            value = DOMString::from("#000000");
-        }
-        let style = format!("background-color: {value}");
-        color_shadow_tree.color_value.set_string_attribute(
-            &local_name!("style"),
-            style.into(),
-            can_gc,
-        );
-    }
-
-    fn update_shadow_tree(&self, can_gc: CanGc) {
-        match self.input_type() {
-            _ if self.is_textual_widget() => self.update_textual_shadow_tree(can_gc),
-            InputType::Color => self.update_color_shadow_tree(can_gc),
-            _ => {},
-        }
     }
 
     fn may_have_embedder_control(&self) -> bool {
@@ -1459,11 +1458,49 @@ impl HTMLInputElement {
             KeyReaction::Nothing => (),
         }
     }
+
+    /// Return a string that represents the contents of the element in its displayed shadow DOM.
+    fn value_for_shadow_dom(&self) -> DOMString {
+        let input_type = self.input_type();
+        match input_type {
+            InputType::Checkbox |
+            InputType::Radio |
+            InputType::Image |
+            InputType::Hidden |
+            InputType::Range => "".into(),
+            InputType::File => {
+                let Some(filelist) = self.filelist.get() else {
+                    return DEFAULT_FILE_INPUT_VALUE.into();
+                };
+                let length = filelist.Length();
+                if length > 1 {
+                    return format!("{length} files").into();
+                }
+
+                let Some(first_item) = filelist.Item(0) else {
+                    return DEFAULT_FILE_INPUT_VALUE.into();
+                };
+                first_item.name().to_string().into()
+            },
+            _ => {
+                if let Some(attribute_value) = self
+                    .upcast::<Element>()
+                    .get_attribute(&ns!(), &local_name!("value"))
+                    .map(|attribute| attribute.Value())
+                {
+                    return attribute_value;
+                }
+                match input_type {
+                    InputType::Submit => DEFAULT_SUBMIT_VALUE.into(),
+                    InputType::Reset => DEFAULT_RESET_VALUE.into(),
+                    _ => "".into(),
+                }
+            },
+        }
+    }
 }
 
 pub(crate) trait LayoutHTMLInputElementHelpers<'dom> {
-    /// Return a string that represents the contents of the element for layout.
-    fn value_for_layout(self) -> Cow<'dom, str>;
     fn size_for_layout(self) -> u32;
     fn selection_for_layout(self) -> Option<Range<usize>>;
 }
@@ -1477,9 +1514,6 @@ impl<'dom> LayoutDom<'dom, HTMLInputElement> {
                 .borrow_for_layout()
                 .get_content()
         }
-    }
-    fn get_filelist(self) -> Option<LayoutDom<'dom, FileList>> {
-        unsafe { self.unsafe_get().filelist.get_inner_as_layout() }
     }
 
     fn input_type(self) -> InputType {
@@ -1497,55 +1531,6 @@ impl<'dom> LayoutDom<'dom, HTMLInputElement> {
 }
 
 impl<'dom> LayoutHTMLInputElementHelpers<'dom> for LayoutDom<'dom, HTMLInputElement> {
-    /// In the past, we are handling the display of <input> element inside the dom tree traversal.
-    /// With the introduction of shadow DOM, these implementations will be replaced one by one
-    /// and these will be obselete,
-    fn value_for_layout(self) -> Cow<'dom, str> {
-        fn get_raw_attr_value<'dom>(
-            input: LayoutDom<'dom, HTMLInputElement>,
-            default: &'static str,
-        ) -> Cow<'dom, str> {
-            input
-                .upcast::<Element>()
-                .get_attr_val_for_layout(&ns!(), &local_name!("value"))
-                .unwrap_or(default)
-                .into()
-        }
-
-        match self.input_type() {
-            InputType::Checkbox | InputType::Radio | InputType::Image | InputType::Hidden => {
-                "".into()
-            },
-            InputType::File => {
-                let filelist = self.get_filelist();
-                match filelist {
-                    Some(filelist) => {
-                        let length = filelist.len();
-                        if length == 0 {
-                            DEFAULT_FILE_INPUT_VALUE.into()
-                        } else if length == 1 {
-                            match filelist.file_for_layout(0) {
-                                Some(file) => file.name().to_string().into(),
-                                None => DEFAULT_FILE_INPUT_VALUE.into(),
-                            }
-                        } else {
-                            format!("{} files", length).into()
-                        }
-                    },
-                    None => DEFAULT_FILE_INPUT_VALUE.into(),
-                }
-            },
-            InputType::Button => get_raw_attr_value(self, ""),
-            InputType::Submit => get_raw_attr_value(self, DEFAULT_SUBMIT_VALUE),
-            InputType::Reset => get_raw_attr_value(self, DEFAULT_RESET_VALUE),
-            // FIXME(#22728): input `type=range` has yet to be implemented.
-            InputType::Range => "".into(),
-            _ => {
-                unreachable!("Input with shadow tree should use internal shadow tree for layout");
-            },
-        }
-    }
-
     /// Textual input, specifically text entry and domain specific input has
     /// a default preferred size.
     ///
@@ -1607,7 +1592,7 @@ impl TextControlElement for HTMLInputElement {
     // Types omitted which could theoretically be included if they were
     // rendered as a text control: file
     fn has_selectable_text(&self) -> bool {
-        self.is_textual_widget() && !self.textinput.borrow().get_content().is_empty()
+        self.renders_as_text_input_widget() && !self.textinput.borrow().get_content().is_empty()
     }
 
     fn has_selection(&self) -> bool {
@@ -2380,29 +2365,14 @@ impl HTMLInputElement {
 
     // Update the placeholder text in the text shadow tree.
     // To increase the performance, we would only do this when it is necessary.
-    fn update_text_shadow_tree_placeholder(&self, can_gc: CanGc) {
-        if !self.is_textual_widget() {
+    fn update_placeholder_contents(&self, can_gc: CanGc) {
+        // This an optimization to not eagerly create input element shadow trees when
+        // the placeholder does not apply.
+        if !self.renders_as_text_input_widget() {
             return;
         }
-
-        let text_shadow_tree = self.text_shadow_tree(can_gc);
-        text_shadow_tree.init_placeholder_container_if_necessary(self, can_gc);
-
-        let Some(ref placeholder_container) = *text_shadow_tree.placeholder_container.borrow()
-        else {
-            // No update is necesssary.
-            return;
-        };
-        let placeholder_text = self.placeholder.borrow().clone();
-
-        // We are finding and updating the CharacterData child directly to optimize the update.
-        placeholder_container
-            .upcast::<Node>()
-            .GetFirstChild()
-            .expect("UA widget text container without child")
-            .downcast::<CharacterData>()
-            .expect("First child is not a CharacterData node")
-            .SetData(placeholder_text);
+        self.get_or_create_shadow_tree(can_gc)
+            .update_placeholder_contents(self, can_gc);
     }
 
     pub(crate) fn select_files_for_webdriver(
@@ -2805,7 +2775,7 @@ impl HTMLInputElement {
 
     fn value_changed(&self, can_gc: CanGc) {
         self.update_related_validity_states(can_gc);
-        self.update_shadow_tree(can_gc);
+        self.get_or_create_shadow_tree(can_gc).update(self, can_gc);
     }
 
     /// <https://html.spec.whatwg.org/multipage/#show-the-picker,-if-applicable>
@@ -2909,7 +2879,7 @@ impl HTMLInputElement {
         // The focus state can afect the selection (see `selection_for_layout()`),
         // thus dirty the node so that it is laid out again.
         // TODO: Selection changes shouldn't require a new layout.
-        if self.is_textual_widget() {
+        if self.renders_as_text_input_widget() {
             self.upcast::<Node>().dirty(NodeDamage::ContentOrHeritage);
         }
 
@@ -3080,7 +3050,7 @@ impl VirtualMethods for HTMLInputElement {
                 }
 
                 self.update_placeholder_shown_state();
-                self.update_text_shadow_tree_placeholder(can_gc);
+                self.update_placeholder_contents(can_gc);
             },
             // FIXME(stevennovaryo): This is only reachable by Default and DefaultOn value mode. While others
             //                       are being handled in [Self::SetValue]. Should we merge this two together?
@@ -3134,7 +3104,7 @@ impl VirtualMethods for HTMLInputElement {
                     }
                 }
                 self.update_placeholder_shown_state();
-                self.update_text_shadow_tree_placeholder(can_gc);
+                self.update_placeholder_contents(can_gc);
             },
             local_name!("readonly") => {
                 if self.input_type().is_textual() {

--- a/components/script/dom/html/htmltextareaelement.rs
+++ b/components/script/dom/html/htmltextareaelement.rs
@@ -246,6 +246,12 @@ impl HTMLTextAreaElement {
                 .replace("\r\n", "\n")
                 .replace('\r', "\n")
                 .into()
+        } else if textinput_content.is_empty() {
+            // The addition of zero-width space here forces the text input to have an inline formatting
+            // context that might otherwise be trimmed if there's no text. This is important to ensure
+            // that the input element is at least as tall as the line gap of the caret:
+            // <https://drafts.csswg.org/css-ui/#element-with-default-preferred-size>.
+            "\u{200B}".into()
         } else {
             textinput_content
         };

--- a/components/script/dom/html/htmltextareaelement.rs
+++ b/components/script/dom/html/htmltextareaelement.rs
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-use std::cell::Cell;
+use std::cell::{Cell, RefCell};
 use std::default::Default;
 use std::ops::Range;
 
@@ -12,6 +12,8 @@ use dom_struct::dom_struct;
 use embedder_traits::{EmbedderControlRequest, InputMethodRequest, InputMethodType};
 use html5ever::{LocalName, Prefix, local_name, ns};
 use js::rust::HandleObject;
+use script_bindings::codegen::GenericBindings::CharacterDataBinding::CharacterDataMethods;
+use script_bindings::root::Dom;
 use style::attr::AttrValue;
 use stylo_dom::ElementState;
 
@@ -41,8 +43,9 @@ use crate::dom::node::{
     BindContext, ChildrenMutation, CloneChildrenFlag, Node, NodeDamage, NodeTraits, UnbindContext,
 };
 use crate::dom::nodelist::NodeList;
+use crate::dom::text::Text;
 use crate::dom::textcontrol::{TextControlElement, TextControlSelection};
-use crate::dom::types::FocusEvent;
+use crate::dom::types::{CharacterData, FocusEvent};
 use crate::dom::validation::{Validatable, is_barred_by_datalist_ancestor};
 use crate::dom::validitystate::{ValidationFlags, ValidityState};
 use crate::dom::virtualmethods::VirtualMethods;
@@ -56,16 +59,18 @@ pub(crate) struct HTMLTextAreaElement {
     htmlelement: HTMLElement,
     #[no_trace]
     textinput: DomRefCell<TextInput<EmbedderClipboardProvider>>,
-    placeholder: DomRefCell<String>,
+    placeholder: RefCell<String>,
     // https://html.spec.whatwg.org/multipage/#concept-textarea-dirty
     value_dirty: Cell<bool>,
     form_owner: MutNullableDom<HTMLFormElement>,
     labels_node_list: MutNullableDom<NodeList>,
     validity_state: MutNullableDom<ValidityState>,
+    /// A DOM [`Text`] node that is the stored in the root of this [`HTMLTextArea`]'s
+    /// shadow tree. This how content from the text area is exposed to layout.
+    shadow_node: DomRefCell<Option<Dom<Text>>>,
 }
 
 pub(crate) trait LayoutHTMLTextAreaElementHelpers {
-    fn value_for_layout(self) -> String;
     fn selection_for_layout(self) -> Option<Range<usize>>;
     fn get_cols(self) -> u32;
     fn get_rows(self) -> u32;
@@ -73,15 +78,6 @@ pub(crate) trait LayoutHTMLTextAreaElementHelpers {
 
 #[expect(unsafe_code)]
 impl<'dom> LayoutDom<'dom, HTMLTextAreaElement> {
-    fn textinput_content(self) -> DOMString {
-        unsafe {
-            self.unsafe_get()
-                .textinput
-                .borrow_for_layout()
-                .get_content()
-        }
-    }
-
     fn textinput_sorted_selection_offsets_range(self) -> Range<Utf8CodeUnitLength> {
         unsafe {
             self.unsafe_get()
@@ -90,24 +86,9 @@ impl<'dom> LayoutDom<'dom, HTMLTextAreaElement> {
                 .sorted_selection_offsets_range()
         }
     }
-
-    fn placeholder(self) -> &'dom str {
-        unsafe { self.unsafe_get().placeholder.borrow_for_layout() }
-    }
 }
 
 impl LayoutHTMLTextAreaElementHelpers for LayoutDom<'_, HTMLTextAreaElement> {
-    fn value_for_layout(self) -> String {
-        let text = self.textinput_content();
-        if text.is_empty() {
-            // FIXME(nox): Would be cool to not allocate a new string if the
-            // placeholder is single line, but that's an unimportant detail.
-            self.placeholder().replace("\r\n", "\n").replace('\r', "\n")
-        } else {
-            text.into()
-        }
-    }
-
     fn selection_for_layout(self) -> Option<Range<usize>> {
         if !self.upcast::<Element>().focus_state() {
             return None;
@@ -157,7 +138,7 @@ impl HTMLTextAreaElement {
                 prefix,
                 document,
             ),
-            placeholder: DomRefCell::new(String::new()),
+            placeholder: Default::default(),
             textinput: DomRefCell::new(TextInput::new(
                 Lines::Multiple,
                 DOMString::new(),
@@ -173,6 +154,7 @@ impl HTMLTextAreaElement {
             form_owner: Default::default(),
             labels_node_list: Default::default(),
             validity_state: Default::default(),
+            shadow_node: Default::default(),
         }
     }
 
@@ -197,13 +179,6 @@ impl HTMLTextAreaElement {
     pub(crate) fn auto_directionality(&self) -> String {
         let value: String = self.Value().to_string();
         HTMLInputElement::directionality_from_value(&value)
-    }
-
-    fn update_placeholder_shown_state(&self) {
-        let has_placeholder = !self.placeholder.borrow().is_empty();
-        let has_value = !self.textinput.borrow().is_empty();
-        let el = self.upcast::<Element>();
-        el.set_placeholder_shown_state(has_placeholder && !has_value);
     }
 
     // https://html.spec.whatwg.org/multipage/#concept-fe-mutable
@@ -239,6 +214,45 @@ impl HTMLTextAreaElement {
                 );
         } else {
             unreachable!("Got unexpected FocusEvent {event_type:?}");
+        }
+    }
+
+    fn handle_text_content_changed(&self, can_gc: CanGc) {
+        self.validity_state(can_gc)
+            .perform_validation_and_update(ValidationFlags::all(), can_gc);
+
+        let textinput_content = self.textinput.borrow().get_content();
+        let element = self.upcast::<Element>();
+        let placeholder_shown =
+            textinput_content.is_empty() && !self.placeholder.borrow().is_empty();
+        element.set_placeholder_shown_state(placeholder_shown);
+
+        let shadow_root = element
+            .shadow_root()
+            .unwrap_or_else(|| element.attach_ua_shadow_root(true, can_gc));
+        let mut shadow_node = self.shadow_node.borrow_mut();
+        let shadow_node = shadow_node.get_or_insert_with(|| {
+            let shadow_node = Text::new(Default::default(), &shadow_root.owner_document(), can_gc);
+            Node::replace_all(Some(shadow_node.upcast()), shadow_root.upcast(), can_gc);
+            shadow_node.as_traced()
+        });
+
+        let content = if placeholder_shown {
+            // FIXME(nox): Would be cool to not allocate a new string if the
+            // placeholder is single line, but that's an unimportant detail.
+            self.placeholder
+                .borrow()
+                .replace("\r\n", "\n")
+                .replace('\r', "\n")
+                .into()
+        } else {
+            textinput_content
+        };
+
+        let character_data = shadow_node.upcast::<CharacterData>();
+        if character_data.Data() != content {
+            character_data.SetData(content);
+            self.upcast::<Node>().dirty(NodeDamage::ContentOrHeritage);
         }
     }
 }
@@ -359,7 +373,7 @@ impl HTMLTextAreaElementMethods<crate::DomTypeHolder> for HTMLTextAreaElement {
         // if the element's dirty value flag is false, then the element's
         // raw value must be set to the value of the element's textContent IDL attribute
         if !self.value_dirty.get() {
-            self.reset();
+            self.reset(can_gc);
         }
     }
 
@@ -370,27 +384,23 @@ impl HTMLTextAreaElementMethods<crate::DomTypeHolder> for HTMLTextAreaElement {
 
     /// <https://html.spec.whatwg.org/multipage/#dom-textarea-value>
     fn SetValue(&self, value: DOMString, can_gc: CanGc) {
-        {
-            let mut textinput = self.textinput.borrow_mut();
+        // Step 1: Let oldAPIValue be this element's API value.
+        let old_api_value = self.Value();
 
-            // Step 1
-            let old_value = textinput.get_content();
+        // Step 2:  Set this element's raw value to the new value.
+        self.textinput.borrow_mut().set_content(value);
 
-            // Step 2
-            textinput.set_content(value);
+        // Step 3: Set this element's dirty value flag to true.
+        self.value_dirty.set(true);
 
-            // Step 3
-            self.value_dirty.set(true);
-
-            if old_value != textinput.get_content() {
-                // Step 4
-                textinput.clear_selection_to_end();
-            }
+        // Step 4: If the new API value is different from oldAPIValue, then move
+        // the text entry cursor position to the end of the text control,
+        // unselecting any selected text and resetting the selection direction to
+        // "none".
+        if old_api_value != self.Value() {
+            self.textinput.borrow_mut().clear_selection_to_end();
+            self.handle_text_content_changed(can_gc);
         }
-
-        self.validity_state(can_gc)
-            .perform_validation_and_update(ValidationFlags::all(), can_gc);
-        self.upcast::<Node>().dirty(NodeDamage::Other);
     }
 
     /// <https://html.spec.whatwg.org/multipage/#dom-textarea-textlength>
@@ -508,11 +518,11 @@ impl HTMLTextAreaElement {
         self.textinput.borrow_mut().set_content(DOMString::from(""));
     }
 
-    pub(crate) fn reset(&self) {
+    pub(crate) fn reset(&self, can_gc: CanGc) {
         // https://html.spec.whatwg.org/multipage/#the-textarea-element:concept-form-reset-control
-        let mut textinput = self.textinput.borrow_mut();
-        textinput.set_content(self.DefaultValue());
         self.value_dirty.set(false);
+        self.textinput.borrow_mut().set_content(self.DefaultValue());
+        self.handle_text_content_changed(can_gc);
     }
 
     #[cfg_attr(crown, allow(crown::unrooted_must_root))]
@@ -520,7 +530,7 @@ impl HTMLTextAreaElement {
         TextControlSelection::new(self, &self.textinput)
     }
 
-    fn handle_key_reaction(&self, action: KeyReaction, event: &Event) {
+    fn handle_key_reaction(&self, action: KeyReaction, event: &Event, can_gc: CanGc) {
         match action {
             KeyReaction::TriggerDefaultAction => (),
             KeyReaction::DispatchInput(text, is_composing, input_type) => {
@@ -533,8 +543,7 @@ impl HTMLTextAreaElement {
                     );
                 }
                 self.value_dirty.set(true);
-                self.update_placeholder_shown_state();
-                self.upcast::<Node>().dirty(NodeDamage::Other);
+                self.handle_text_content_changed(can_gc);
                 event.mark_as_handled();
             },
             KeyReaction::RedrawSelection => {
@@ -609,7 +618,7 @@ impl VirtualMethods for HTMLTextAreaElement {
                         placeholder.push_str(attr.value().as_ref());
                     }
                 }
-                self.update_placeholder_shown_state();
+                self.handle_text_content_changed(can_gc);
             },
             local_name!("readonly") => {
                 let el = self.upcast::<Element>();
@@ -706,7 +715,7 @@ impl VirtualMethods for HTMLTextAreaElement {
             s.children_changed(mutation, can_gc);
         }
         if !self.value_dirty.get() {
-            self.reset();
+            self.reset(can_gc);
         }
     }
 
@@ -723,7 +732,7 @@ impl VirtualMethods for HTMLTextAreaElement {
                 // This can't be inlined, as holding on to textinput.borrow_mut()
                 // during self.implicit_submission will cause a panic.
                 let action = self.textinput.borrow_mut().handle_keydown(kevent);
-                self.handle_key_reaction(action, event);
+                self.handle_key_reaction(action, event, can_gc);
             }
         } else if event.type_() == atom!("keypress") && !event.DefaultPrevented() {
             // keypress should be deprecated and replaced by beforeinput.
@@ -739,14 +748,14 @@ impl VirtualMethods for HTMLTextAreaElement {
                         .textinput
                         .borrow_mut()
                         .handle_compositionend(compositionevent);
-                    self.handle_key_reaction(action, event);
+                    self.handle_key_reaction(action, event, can_gc);
                     self.upcast::<Node>().dirty(NodeDamage::Other);
                 } else if event.type_() == atom!("compositionupdate") {
                     let action = self
                         .textinput
                         .borrow_mut()
                         .handle_compositionupdate(compositionevent);
-                    self.handle_key_reaction(action, event);
+                    self.handle_key_reaction(action, event, can_gc);
                     self.upcast::<Node>().dirty(NodeDamage::Other);
                 }
                 event.mark_as_handled();
@@ -774,7 +783,7 @@ impl VirtualMethods for HTMLTextAreaElement {
                 );
             }
             if !flags.is_empty() {
-                self.upcast::<Node>().dirty(NodeDamage::ContentOrHeritage);
+                self.handle_text_content_changed(can_gc);
             }
         } else if let Some(event) = event.downcast::<FocusEvent>() {
             self.handle_focus_event(event);
@@ -788,7 +797,7 @@ impl VirtualMethods for HTMLTextAreaElement {
         self.super_type().unwrap().pop();
 
         // https://html.spec.whatwg.org/multipage/#the-textarea-element:stack-of-open-elements
-        self.reset();
+        self.reset(CanGc::note());
     }
 }
 

--- a/components/script/layout_dom/node.rs
+++ b/components/script/layout_dom/node.rs
@@ -273,10 +273,6 @@ impl<'dom> ServoThreadSafeLayoutNode<'dom> {
                 self.node.node.is_text_container_of_single_line_input())
     }
 
-    pub fn is_text_input(&self) -> bool {
-        self.node.node.is_text_input()
-    }
-
     pub fn selected_style(&self) -> Arc<ComputedValues> {
         let Some(element) = self.as_element() else {
             // TODO(stshine): What should the selected style be for text?
@@ -380,7 +376,7 @@ impl<'dom> ThreadSafeLayoutNode<'dom> for ServoThreadSafeLayoutNode<'dom> {
         self.node
     }
 
-    fn node_text_content(self) -> Cow<'dom, str> {
+    fn text_content(self) -> Cow<'dom, str> {
         unsafe { self.get_jsmanaged().text_content() }
     }
 

--- a/components/shared/layout/wrapper_traits.rs
+++ b/components/shared/layout/wrapper_traits.rs
@@ -201,7 +201,10 @@ pub trait ThreadSafeLayoutNode<'dom>: Clone + Copy + Debug + NodeInfo + PartialE
     /// data flags, and we have this annoying trait separation between script and layout :-(
     fn unsafe_get(self) -> Self::ConcreteNode;
 
-    fn node_text_content(self) -> Cow<'dom, str>;
+    /// Get the text content of this node, if it is a text node.
+    ///
+    /// Note: This should only be called on text nodes.
+    fn text_content(self) -> Cow<'dom, str>;
 
     /// If selection intersects this node, return it. Otherwise, returns `None`.
     fn selection(&self) -> Option<Range<ByteIndex>>;

--- a/tests/wpt/meta/css/css-overflow/text-overflow-ellipsis-editing-input.html.ini
+++ b/tests/wpt/meta/css/css-overflow/text-overflow-ellipsis-editing-input.html.ini
@@ -1,2 +1,0 @@
-[text-overflow-ellipsis-editing-input.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-tables/table-model-fixup-2.html.ini
+++ b/tests/wpt/meta/css/css-tables/table-model-fixup-2.html.ini
@@ -20,13 +20,7 @@
   [Replaced elements outside a table cannot be table-row and are considered inline -- input=text elements]
     expected: FAIL
 
-  [Replaced elements outside a table cannot be table-row and are considered inline -- input=button elements]
-    expected: FAIL
-
   [Replaced elements outside a table cannot be table-row-group and are considered inline -- input=text elements]
-    expected: FAIL
-
-  [Replaced elements outside a table cannot be table-row-group and are considered inline -- input=button elements]
     expected: FAIL
 
   [Replaced elements outside a table cannot be table-caption and are considered inline -- input=text elements]

--- a/tests/wpt/meta/html/semantics/forms/constraints/form-validation-validity-textarea-defaultValue.html.ini
+++ b/tests/wpt/meta/html/semantics/forms/constraints/form-validation-validity-textarea-defaultValue.html.ini
@@ -1,6 +1,0 @@
-[form-validation-validity-textarea-defaultValue.html]
-  [Default validity based on emptiness]
-    expected: FAIL
-
-  [Setting textarea.defaultValue should not trigger validation]
-    expected: FAIL


### PR DESCRIPTION
This change makes it so that all form controls are implemented with
shadow DOM, completely removing the legacy text content and selection
code paths for form controls. The motivation for this change is:

- to allow properly hit testing against the text nodes of `<textarea>`
  and other widgets. This is important for implementing mouse-based
  selection on the page.
- to simplify the way that form controls are implemented in general and
  to prepare the way for proper implementations of the user interface of
  other controls.

Testing: This should not change observable behavior at the moment,so
should be covered by existing WPT tests.
