### PR TITLE
devtools: Compute Actor base name per type

### DIFF
--- a/components/devtools/actor.rs
+++ b/components/devtools/actor.rs
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-use std::any::Any;
+use std::any::{Any, type_name};
 use std::cell::{Cell, RefCell};
 use std::collections::HashMap;
 use std::mem;
@@ -173,11 +173,21 @@ impl ActorRegistry {
         panic!("couldn't find actor named {}", actor)
     }
 
+    /// Create a name prefix for each actor type.
+    /// While not needed for unique ids as each actor already has a different
+    /// suffix, it can be used to visually identify actors in the logs.
+    pub fn base_name<T: Actor>() -> &'static str {
+        let prefix = type_name::<T>();
+        prefix.split("::").last().unwrap_or(prefix)
+    }
+
     /// Create a unique name based on a monotonically increasing suffix
-    pub fn new_name(&self, prefix: &str) -> String {
+    /// TODO: Merge this with `register/register_later` and don't allow to
+    /// create new names without registering an actor.
+    pub fn new_name<T: Actor>(&self) -> String {
         let suffix = self.next.get();
         self.next.set(suffix + 1);
-        format!("{}{}", prefix, suffix)
+        format!("{}{}", Self::base_name::<T>(), suffix)
     }
 
     /// Add an actor to the registry of known actors that can receive messages.

--- a/components/devtools/actors/browsing_context.rs
+++ b/components/devtools/actors/browsing_context.rs
@@ -212,14 +212,14 @@ impl BrowsingContextActor {
         script_sender: GenericSender<DevtoolScriptControlMsg>,
         actors: &mut ActorRegistry,
     ) -> BrowsingContextActor {
-        let name = actors.new_name("target");
+        let name = actors.new_name::<BrowsingContextActor>();
         let DevtoolsPageInfo {
             title,
             url,
             is_top_level_global,
         } = page_info;
 
-        let accessibility = AccessibilityActor::new(actors.new_name("accessibility"));
+        let accessibility = AccessibilityActor::new(actors.new_name::<AccessibilityActor>());
 
         let properties = (|| {
             let (properties_sender, properties_receiver) = generic_channel::channel()?;
@@ -227,17 +227,18 @@ impl BrowsingContextActor {
             properties_receiver.recv().ok()
         })()
         .unwrap_or_default();
-        let css_properties = CssPropertiesActor::new(actors.new_name("css-properties"), properties);
+        let css_properties =
+            CssPropertiesActor::new(actors.new_name::<CssPropertiesActor>(), properties);
 
         let inspector = InspectorActor::register(actors, pipeline_id, script_sender.clone());
 
-        let reflow = ReflowActor::new(actors.new_name("reflow"));
+        let reflow = ReflowActor::new(actors.new_name::<ReflowActor>());
 
-        let style_sheets = StyleSheetsActor::new(actors.new_name("stylesheets"));
+        let style_sheets = StyleSheetsActor::new(actors.new_name::<StyleSheetsActor>());
 
         let tabdesc = TabDescriptorActor::new(actors, name.clone(), is_top_level_global);
 
-        let thread = ThreadActor::new(actors.new_name("thread"));
+        let thread = ThreadActor::new(actors.new_name::<ThreadActor>());
 
         let watcher = WatcherActor::new(
             actors,

--- a/components/devtools/actors/frame.rs
+++ b/components/devtools/actors/frame.rs
@@ -74,7 +74,7 @@ impl Actor for FrameActor {
         match msg_type {
             "getEnvironment" => {
                 let environment = EnvironmentActor {
-                    name: registry.new_name("environment"),
+                    name: registry.new_name::<EnvironmentActor>(),
                     parent: None,
                 };
                 let msg = FrameEnvironmentReply {

--- a/components/devtools/actors/framerate.rs
+++ b/components/devtools/actors/framerate.rs
@@ -32,7 +32,7 @@ impl FramerateActor {
         pipeline_id: PipelineId,
         script_sender: GenericSender<DevtoolScriptControlMsg>,
     ) -> String {
-        let actor_name = registry.new_name("framerate");
+        let actor_name = registry.new_name::<Self>();
         let mut actor = FramerateActor {
             name: actor_name.clone(),
             pipeline_id,

--- a/components/devtools/actors/inspector.rs
+++ b/components/devtools/actors/inspector.rs
@@ -121,26 +121,26 @@ impl InspectorActor {
         script_chan: GenericSender<DevtoolScriptControlMsg>,
     ) -> String {
         let highlighter = HighlighterActor {
-            name: registry.new_name("highlighter"),
+            name: registry.new_name::<HighlighterActor>(),
             script_sender: script_chan.clone(),
             pipeline,
         };
 
         let page_style = PageStyleActor {
-            name: registry.new_name("page-style"),
+            name: registry.new_name::<PageStyleActor>(),
             script_chan: script_chan.clone(),
             pipeline,
         };
 
         let walker = WalkerActor {
-            name: registry.new_name("walker"),
+            name: registry.new_name::<WalkerActor>(),
             mutations: RefCell::new(vec![]),
             script_chan,
             pipeline,
         };
 
         let actor = Self {
-            name: registry.new_name("inspector"),
+            name: registry.new_name::<InspectorActor>(),
             highlighter: highlighter.name(),
             page_style: page_style.name(),
             walker: walker.name(),

--- a/components/devtools/actors/inspector/accessibility.rs
+++ b/components/devtools/actors/inspector/accessibility.rs
@@ -89,10 +89,13 @@ impl Actor for AccessibilityActor {
             },
             "getSimulator" => {
                 // TODO: Create actual simulator
-                let simulator = registry.new_name("simulator");
+                let actor = registry.new_name::<SimulatorActor>();
+                registry.register_later(SimulatorActor {
+                    name: actor.clone(),
+                });
                 let msg = GetSimulatorReply {
                     from: self.name(),
-                    simulator: ActorMsg { actor: simulator },
+                    simulator: ActorMsg { actor },
                 };
                 request.reply_final(&msg)?
             },
@@ -107,10 +110,13 @@ impl Actor for AccessibilityActor {
             },
             "getWalker" => {
                 // TODO: Create actual accessible walker
-                let walker = registry.new_name("accesiblewalker");
+                let actor = registry.new_name::<AccessibleWalkerActor>();
+                registry.register_later(AccessibleWalkerActor {
+                    name: actor.clone(),
+                });
                 let msg = GetWalkerReply {
                     from: self.name(),
-                    walker: ActorMsg { actor: walker },
+                    walker: ActorMsg { actor },
                 };
                 request.reply_final(&msg)?
             },
@@ -123,5 +129,25 @@ impl Actor for AccessibilityActor {
 impl AccessibilityActor {
     pub fn new(name: String) -> Self {
         Self { name }
+    }
+}
+
+pub struct SimulatorActor {
+    name: String,
+}
+
+impl Actor for SimulatorActor {
+    fn name(&self) -> String {
+        self.name.clone()
+    }
+}
+
+pub struct AccessibleWalkerActor {
+    name: String,
+}
+
+impl Actor for AccessibleWalkerActor {
+    fn name(&self) -> String {
+        self.name.clone()
     }
 }

--- a/components/devtools/actors/inspector/highlighter.rs
+++ b/components/devtools/actors/inspector/highlighter.rs
@@ -12,6 +12,7 @@ use serde::Serialize;
 use serde_json::{self, Map, Value};
 
 use crate::actor::{Actor, ActorEncode, ActorError, ActorRegistry};
+use crate::actors::inspector::InspectorActor;
 use crate::protocol::ClientRequest;
 use crate::{ActorMsg, EmptyReplyMsg, StreamId};
 
@@ -55,7 +56,7 @@ impl Actor for HighlighterActor {
                     return Err(ActorError::BadParameterType);
                 };
 
-                if node_actor_name.starts_with("inspector") {
+                if node_actor_name.starts_with(ActorRegistry::base_name::<InspectorActor>()) {
                     // TODO: For some reason, the client initially asks us to highlight
                     // the inspector? Investigate what this is supposed to mean.
                     let msg = ShowReply {

--- a/components/devtools/actors/inspector/node.rs
+++ b/components/devtools/actors/inspector/node.rs
@@ -230,7 +230,7 @@ impl NodeInfoToProtocol for NodeInfo {
     ) -> NodeActorMsg {
         let get_or_register_node_actor = |id: &str| {
             if !actors.script_actor_registered(id.to_string()) {
-                let name = actors.new_name("node");
+                let name = actors.new_name::<NodeActor>();
                 actors.register_script_actor(id.to_string(), name.clone());
 
                 let node_actor = NodeActor {

--- a/components/devtools/actors/inspector/page_style.rs
+++ b/components/devtools/actors/inspector/page_style.rs
@@ -181,7 +181,7 @@ impl PageStyleActor {
                 .filter_map(move |selector| {
                     let rule = match node_actor.style_rules.borrow_mut().entry(selector) {
                         Entry::Vacant(e) => {
-                            let name = registry.new_name("style-rule");
+                            let name = registry.new_name::<StyleRuleActor>();
                             let actor = StyleRuleActor::new(
                                 name.clone(),
                                 node_actor.name(),
@@ -237,7 +237,7 @@ impl PageStyleActor {
             .entry(("".into(), usize::MAX))
         {
             Entry::Vacant(e) => {
-                let name = registry.new_name("style-rule");
+                let name = registry.new_name::<StyleRuleActor>();
                 let actor = StyleRuleActor::new(name.clone(), target.into(), None);
                 let computed = actor.computed(registry)?;
                 registry.register_later(actor);

--- a/components/devtools/actors/inspector/walker.rs
+++ b/components/devtools/actors/inspector/walker.rs
@@ -197,7 +197,7 @@ impl Actor for WalkerActor {
             },
             "getLayoutInspector" => {
                 // TODO: Create actual layout inspector actor
-                let layout = LayoutInspectorActor::new(registry.new_name("layout"));
+                let layout = LayoutInspectorActor::new(registry.new_name::<LayoutInspectorActor>());
                 let actor = layout.encode(registry);
                 registry.register_later(layout);
 

--- a/components/devtools/actors/long_string.rs
+++ b/components/devtools/actors/long_string.rs
@@ -72,7 +72,7 @@ impl Actor for LongStringActor {
 
 impl LongStringActor {
     pub fn new(registry: &ActorRegistry, full_string: String) -> Self {
-        let name = registry.new_name("longStringActor");
+        let name = registry.new_name::<Self>();
         LongStringActor { name, full_string }
     }
 

--- a/components/devtools/actors/memory.rs
+++ b/components/devtools/actors/memory.rs
@@ -34,7 +34,7 @@ impl Actor for MemoryActor {
 impl MemoryActor {
     /// return name of actor
     pub fn create(registry: &ActorRegistry) -> String {
-        let actor_name = registry.new_name("memory");
+        let actor_name = registry.new_name::<Self>();
         let actor = MemoryActor {
             name: actor_name.clone(),
         };

--- a/components/devtools/actors/object.rs
+++ b/components/devtools/actors/object.rs
@@ -44,7 +44,7 @@ impl Actor for ObjectActor {
 impl ObjectActor {
     pub fn register(registry: &ActorRegistry, uuid: String) -> String {
         if !registry.script_actor_registered(uuid.clone()) {
-            let name = registry.new_name("object");
+            let name = registry.new_name::<Self>();
             let actor = ObjectActor {
                 name: name.clone(),
                 _uuid: uuid.clone(),

--- a/components/devtools/actors/pause.rs
+++ b/components/devtools/actors/pause.rs
@@ -4,8 +4,6 @@
 
 use crate::actor::Actor;
 
-// TODO: Remove once the actor is used.
-#[expect(dead_code)]
 /// Referenced by `ThreadActor` when replying to `interupt` messages.
 /// <https://searchfox.org/firefox-main/source/devtools/server/actors/thread.js#1699>
 pub struct PauseActor {

--- a/components/devtools/actors/root.rs
+++ b/components/devtools/actors/root.rs
@@ -268,12 +268,12 @@ impl RootActor {
     /// Registers the root actor and its global actors (those not associated with a specific target).
     pub fn register(registry: &mut ActorRegistry) {
         // Global actors
-        let device = DeviceActor::new(registry.new_name("device"));
-        let perf = PerformanceActor::new(registry.new_name("perf"));
-        let preference = PreferenceActor::new(registry.new_name("preference"));
+        let device = DeviceActor::new(registry.new_name::<DeviceActor>());
+        let perf = PerformanceActor::new(registry.new_name::<PerformanceActor>());
+        let preference = PreferenceActor::new(registry.new_name::<PreferenceActor>());
 
         // Process descriptor
-        let process = ProcessActor::new(registry.new_name("process"));
+        let process = ProcessActor::new(registry.new_name::<ProcessActor>());
 
         // Root actor
         let root = Self {

--- a/components/devtools/actors/source.rs
+++ b/components/devtools/actors/source.rs
@@ -147,7 +147,7 @@ impl SourceActor {
         introduction_type: String,
         script_sender: GenericSender<DevtoolScriptControlMsg>,
     ) -> &SourceActor {
-        let source_actor_name = actors.new_name("source");
+        let source_actor_name = actors.new_name::<Self>();
 
         let source_actor = SourceActor::new(
             source_actor_name.clone(),

--- a/components/devtools/actors/tab.rs
+++ b/components/devtools/actors/tab.rs
@@ -138,7 +138,7 @@ impl TabDescriptorActor {
         browsing_context_actor: String,
         is_top_level_global: bool,
     ) -> TabDescriptorActor {
-        let name = actors.new_name("tab-description");
+        let name = actors.new_name::<Self>();
         let root = actors.find_mut::<RootActor>("root");
         root.tabs.push(name.clone());
         TabDescriptorActor {

--- a/components/devtools/actors/thread.rs
+++ b/components/devtools/actors/thread.rs
@@ -7,6 +7,7 @@ use serde_json::{Map, Value};
 
 use super::source::{SourceManager, SourcesReply};
 use crate::actor::{Actor, ActorError, ActorRegistry};
+use crate::actors::pause::PauseActor;
 use crate::protocol::{ClientRequest, JsonPacketStream};
 use crate::{EmptyReplyMsg, StreamId};
 
@@ -77,10 +78,14 @@ impl Actor for ThreadActor {
     ) -> Result<(), ActorError> {
         match msg_type {
             "attach" => {
+                let pause = registry.new_name::<PauseActor>();
+                registry.register_later(PauseActor {
+                    name: pause.clone(),
+                });
                 let msg = ThreadAttached {
                     from: self.name(),
                     type_: "paused".to_owned(),
-                    actor: registry.new_name("pause"),
+                    actor: pause,
                     frame: 0,
                     error: 0,
                     recording_endpoint: 0,

--- a/components/devtools/actors/watcher.rs
+++ b/components/devtools/actors/watcher.rs
@@ -393,15 +393,15 @@ impl WatcherActor {
         browsing_context_actor: String,
         session_context: SessionContext,
     ) -> Self {
-        let network_parent = NetworkParentActor::new(actors.new_name("network-parent"));
+        let network_parent = NetworkParentActor::new(actors.new_name::<NetworkParentActor>());
         let target_configuration =
-            TargetConfigurationActor::new(actors.new_name("target-configuration"));
+            TargetConfigurationActor::new(actors.new_name::<TargetConfigurationActor>());
         let thread_configuration =
-            ThreadConfigurationActor::new(actors.new_name("thread-configuration"));
-        let breakpoint_list = BreakpointListActor::new(actors.new_name("breakpoint-list"));
+            ThreadConfigurationActor::new(actors.new_name::<ThreadConfigurationActor>());
+        let breakpoint_list = BreakpointListActor::new(actors.new_name::<BreakpointListActor>());
 
         let watcher = Self {
-            name: actors.new_name("watcher"),
+            name: actors.new_name::<WatcherActor>(),
             browsing_context_actor,
             network_parent: network_parent.name(),
             target_configuration: target_configuration.name(),

--- a/components/devtools/lib.rs
+++ b/components/devtools/lib.rs
@@ -338,17 +338,17 @@ impl DevtoolsInstance {
         let devtools_browsing_context_id = id_map.browsing_context_id(browsing_context_id);
         let devtools_outer_window_id = id_map.outer_window_id(pipeline_id);
 
-        let console_name = actors.new_name("console");
+        let console_name = actors.new_name::<ConsoleActor>();
 
         let parent_actor = if let Some(id) = worker_id {
             assert!(self.pipelines.contains_key(&pipeline_id));
             assert!(self.browsing_contexts.contains_key(&browsing_context_id));
 
-            let thread = ThreadActor::new(actors.new_name("thread"));
+            let thread = ThreadActor::new(actors.new_name::<ThreadActor>());
             let thread_name = thread.name();
             actors.register(thread);
 
-            let worker_name = actors.new_name("worker");
+            let worker_name = actors.new_name::<WorkerActor>();
             let worker = WorkerActor {
                 name: worker_name.clone(),
                 console: console_name.clone(),
@@ -534,7 +534,7 @@ impl DevtoolsInstance {
         let resource_id = self.next_resource_id;
         self.next_resource_id += 1;
 
-        let actor_name = actors.new_name("netevent");
+        let actor_name = actors.new_name::<NetworkEventActor>();
         let actor = NetworkEventActor::new(actor_name.clone(), resource_id, watcher_name);
 
         self.actor_requests.insert(request_id, actor_name.clone());


### PR DESCRIPTION
Replace the previously hardcoded "name prefix" strings for actors with [`type_name`](https://doc.rust-lang.org/std/any/fn.type_name.html).

Note that we aren't using the prefix directly as an unique identifier, and `type_name` wouldn't be suitable for that. The suffix is an incremental counter shared across all actors, so that alone is enough to differentiate them.

The purpose of the prefix is to visually inspect the logs and see what actors are involved. With this change the prefix will be slightly different: "InspectorActor11" vs "inspector11", but that shouldn't affect behaviour.

The eventual goal is to remove `new_name` and force the use of `register/register_later` to create an actor. This is however a bit more complicated, see #41768.

While I'd love to add `base_name` directly to the `Actor` trait, that would unfortunately mean that it wouldn't be [dyn compatible](https://doc.rust-lang.org/reference/items/traits.html#dyn-compatibility). There are workarounds for this like separating the trait in two and implementing it automatically, but I feel that would be too convoluted.

Testing: Manual testing, this patch shouldn't change behaviour.
Part of: #41768
