### PR TITLE
paint/net: Use new functionality in IpcSharedMemory to take the value

### DIFF
--- a/components/compositing/painter.rs
+++ b/components/compositing/painter.rs
@@ -1022,6 +1022,8 @@ impl Painter {
             .prepare_screenshot_requests_for_render(self)
     }
 
+
+    #[servo_tracing::instrument(skip_all)]
     pub(crate) fn update_images(&mut self, updates: SmallVec<[ImageUpdate; 1]>) {
         let mut txn = Transaction::new();
         for update in updates {

--- a/components/net/http_loader.rs
+++ b/components/net/http_loader.rs
@@ -665,7 +665,7 @@ impl BodySink {
                 let sender = sender.clone();
                 spawn_task(async move {
                     let _ = sender
-                        .send(Ok(Frame::data(Bytes::copy_from_slice(&bytes))))
+                        .send(Ok(Frame::data(bytes.take().unwrap().into())))
                         .await;
                 });
             },

--- a/components/servo/Cargo.toml
+++ b/components/servo/Cargo.toml
@@ -46,6 +46,7 @@ testbinding = ["script/testbinding"]
 tracing = [
     "dep:tracing",
     "compositing/tracing",
+    "compositing_traits/tracing",
     "constellation/tracing",
     "fonts/tracing",
     "layout/tracing",

--- a/components/shared/compositing/Cargo.toml
+++ b/components/shared/compositing/Cargo.toml
@@ -13,6 +13,7 @@ path = "lib.rs"
 
 [features]
 no-wgl = ["surfman/sm-angle-default"]
+tracing = ["dep:tracing"]
 
 [dependencies]
 base = { workspace = true }
@@ -29,6 +30,8 @@ image = { workspace = true }
 ipc-channel = { workspace = true }
 log = { workspace = true }
 malloc_size_of = { workspace = true }
+servo-tracing = { workspace = true }
+tracing = {workspace = true, optional = true}
 malloc_size_of_derive = { workspace = true }
 parking_lot = { workspace = true }
 profile_traits = { path = '../profile' }

--- a/components/shared/compositing/lib.rs
+++ b/components/shared/compositing/lib.rs
@@ -742,7 +742,7 @@ pub enum SerializableImageData {
 }
 
 impl From<SerializableImageData> for ImageData {
-    #[servo_tracing::instrument(name="SerializableImageData_to_ImageData", skip_all)]
+    #[servo_tracing::instrument(name="ImageData::from(SerializableImageData)", skip_all)]
     fn from(value: SerializableImageData) -> Self {
         match value {
             SerializableImageData::Raw(shared_memory) => ImageData::new(shared_memory.take().expect("Could not get data")),

--- a/components/shared/compositing/lib.rs
+++ b/components/shared/compositing/lib.rs
@@ -742,9 +742,10 @@ pub enum SerializableImageData {
 }
 
 impl From<SerializableImageData> for ImageData {
+    #[servo_tracing::instrument(name="SerializableImageData_to_ImageData", skip_all)]
     fn from(value: SerializableImageData) -> Self {
         match value {
-            SerializableImageData::Raw(shared_memory) => ImageData::new(shared_memory.to_vec()),
+            SerializableImageData::Raw(shared_memory) => ImageData::new(shared_memory.take().expect("Could not get data")),
             SerializableImageData::External(image) => ImageData::External(image),
         }
     }


### PR DESCRIPTION
As explanined in the companion PR https://github.com/servo/ipc-channel/pull/433 copying the slice when we already have it in single process mode can be quite expensive.
This uses the new functionality to make Painter and one part in net more efficient.

Needs: https://github.com/servo/ipc-channel/pull/433

Signed-off-by: Narfinger <Narfinger@users.noreply.github.com>

Testing: Browsed a website and did not notice any crashes or unwrap errors.
