### PR TITLE
WebXR: Cleanup of WebXrReceiver/Sender/Channel to Ipc.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10530,6 +10530,7 @@ dependencies = [
  "crossbeam-channel",
  "euclid",
  "glow",
+ "ipc-channel",
  "log",
  "openxr",
  "raw-window-handle",

--- a/components/shared/webxr/events.rs
+++ b/components/shared/webxr/events.rs
@@ -3,11 +3,11 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 use euclid::RigidTransform3D;
+use ipc_channel::ipc::IpcSender;
 use serde::{Deserialize, Serialize};
 
 use crate::{
     ApiSpace, BaseSpace, Frame, InputFrame, InputId, InputSource, SelectEvent, SelectKind,
-    WebXrSender,
 };
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
@@ -45,7 +45,7 @@ pub enum Visibility {
 /// when no event callback has been set
 pub enum EventBuffer {
     Buffered(Vec<Event>),
-    Sink(WebXrSender<Event>),
+    Sink(IpcSender<Event>),
 }
 
 impl Default for EventBuffer {
@@ -64,7 +64,7 @@ impl EventBuffer {
         }
     }
 
-    pub fn upgrade(&mut self, dest: WebXrSender<Event>) {
+    pub fn upgrade(&mut self, dest: IpcSender<Event>) {
         if let EventBuffer::Buffered(ref mut events) = *self {
             for event in events.drain(..) {
                 let _ = dest.send(event);

--- a/components/shared/webxr/lib.rs
+++ b/components/shared/webxr/lib.rs
@@ -19,9 +19,6 @@ mod space;
 pub mod util;
 mod view;
 
-use std::thread;
-use std::time::Duration;
-
 pub use device::{DeviceAPI, DiscoveryAPI};
 pub use error::Error;
 pub use events::{Event, EventBuffer, Visibility};
@@ -32,9 +29,6 @@ pub use hittest::{
 };
 pub use input::{
     Handedness, InputFrame, InputId, InputSource, SelectEvent, SelectKind, TargetRayMode,
-};
-pub use ipc_channel::ipc::{
-    IpcReceiver as WebXrReceiver, IpcSender as WebXrSender, channel as webxr_channel,
 };
 pub use layer::{
     ContextId, GLContexts, GLTypes, LayerGrandManager, LayerGrandManagerAPI, LayerId, LayerInit,
@@ -55,22 +49,3 @@ pub use view::{
     CubeLeft, CubeRight, CubeTop, Display, Floor, Input, LEFT_EYE, LeftEye, Native, RIGHT_EYE,
     RightEye, SomeEye, VIEWER, View, Viewer, Viewport, Viewports, Views,
 };
-
-pub fn recv_timeout<T>(
-    receiver: &WebXrReceiver<T>,
-    timeout: Duration,
-) -> Result<T, ipc_channel::ipc::TryRecvError>
-where
-    T: serde::Serialize + for<'a> serde::Deserialize<'a>,
-{
-    // Sigh, polling, sigh.
-    let mut delay = timeout / 1000;
-    while delay < timeout {
-        if let Ok(msg) = receiver.try_recv() {
-            return Ok(msg);
-        }
-        thread::sleep(delay);
-        delay *= 2;
-    }
-    receiver.try_recv()
-}

--- a/components/shared/webxr/mock.rs
+++ b/components/shared/webxr/mock.rs
@@ -3,12 +3,13 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 use euclid::{Point2D, Rect, RigidTransform3D, Transform3D};
+use ipc_channel::ipc::{IpcReceiver, IpcSender};
 use serde::{Deserialize, Serialize};
 
 use crate::{
     DiscoveryAPI, Display, EntityType, Error, Floor, Handedness, Input, InputId, InputSource,
     LeftEye, Native, RightEye, SelectEvent, SelectKind, TargetRayMode, Triangle, Viewer, Viewport,
-    Visibility, WebXrReceiver, WebXrSender,
+    Visibility,
 };
 
 /// A trait for discovering mock XR devices
@@ -16,7 +17,7 @@ pub trait MockDiscoveryAPI<GL>: 'static {
     fn simulate_device_connection(
         &mut self,
         init: MockDeviceInit,
-        receiver: WebXrReceiver<MockDeviceMsg>,
+        receiver: IpcReceiver<MockDeviceMsg>,
     ) -> Result<Box<dyn DiscoveryAPI<GL>>, Error>;
 }
 
@@ -57,7 +58,7 @@ pub enum MockDeviceMsg {
     VisibilityChange(Visibility),
     SetWorld(MockWorld),
     ClearWorld,
-    Disconnect(WebXrSender<()>),
+    Disconnect(IpcSender<()>),
     SetBoundsGeometry(Vec<Point2D<f32, Floor>>),
     SimulateResetPose,
 }

--- a/components/shared/webxr/session.rs
+++ b/components/shared/webxr/session.rs
@@ -82,7 +82,7 @@ pub enum EnvironmentBlendMode {
 }
 
 // The messages that are sent from the content thread to the session thread.
-#[derive(Clone, Debug, Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize)]
 enum SessionMsg {
     CreateLayer(ContextId, LayerInit, IpcSender<Result<LayerId, Error>>),
     DestroyLayer(ContextId, LayerId),
@@ -417,8 +417,8 @@ where
     fn run_one_frame(&mut self) {
         let frame_count = self.frame_count;
         while frame_count == self.frame_count && self.running {
-            if let Ok(msg) = &self.receiver.try_recv_timeout(TIMEOUT) {
-                self.running = self.handle_msg((*msg).clone());
+            if let Ok(msg) = self.receiver.try_recv_timeout(TIMEOUT) {
+                self.running = self.handle_msg(msg);
             } else {
                 break;
             }

--- a/components/shared/webxr/session.rs
+++ b/components/shared/webxr/session.rs
@@ -6,13 +6,13 @@ use std::thread;
 use std::time::Duration;
 
 use euclid::{Point2D, Rect, RigidTransform3D, Size2D};
+use ipc_channel::ipc::{IpcReceiver, IpcSender, channel};
 use log::warn;
 use serde::{Deserialize, Serialize};
 
 use crate::{
     ContextId, DeviceAPI, Error, Event, Floor, Frame, FrameUpdateEvent, HitTestId, HitTestSource,
-    InputSource, LayerGrandManager, LayerId, LayerInit, Native, Viewport, Viewports, WebXrReceiver,
-    WebXrSender, webxr_channel,
+    InputSource, LayerGrandManager, LayerId, LayerInit, Native, Viewport, Viewports,
 };
 
 // How long to wait for an rAF.
@@ -82,25 +82,25 @@ pub enum EnvironmentBlendMode {
 }
 
 // The messages that are sent from the content thread to the session thread.
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 enum SessionMsg {
-    CreateLayer(ContextId, LayerInit, WebXrSender<Result<LayerId, Error>>),
+    CreateLayer(ContextId, LayerInit, IpcSender<Result<LayerId, Error>>),
     DestroyLayer(ContextId, LayerId),
     SetLayers(Vec<(ContextId, LayerId)>),
-    SetEventDest(WebXrSender<Event>),
+    SetEventDest(IpcSender<Event>),
     UpdateClipPlanes(/* near */ f32, /* far */ f32),
     StartRenderLoop,
     RenderAnimationFrame,
     RequestHitTest(HitTestSource),
     CancelHitTest(HitTestId),
-    UpdateFrameRate(f32, WebXrSender<f32>),
+    UpdateFrameRate(f32, IpcSender<f32>),
     Quit,
-    GetBoundsGeometry(WebXrSender<Option<Vec<Point2D<f32, Floor>>>>),
+    GetBoundsGeometry(IpcSender<Option<Vec<Point2D<f32, Floor>>>>),
 }
 
 #[derive(Serialize, Deserialize, Clone)]
 pub struct Quitter {
-    sender: WebXrSender<SessionMsg>,
+    sender: IpcSender<SessionMsg>,
 }
 
 impl Quitter {
@@ -116,7 +116,7 @@ impl Quitter {
 pub struct Session {
     floor_transform: Option<RigidTransform3D<f32, Native, Floor>>,
     viewports: Viewports,
-    sender: WebXrSender<SessionMsg>,
+    sender: IpcSender<SessionMsg>,
     environment_blend_mode: EnvironmentBlendMode,
     initial_inputs: Vec<InputSource>,
     granted_features: Vec<String>,
@@ -137,7 +137,7 @@ impl Session {
     }
 
     pub fn reference_space_bounds(&self) -> Option<Vec<Point2D<f32, Floor>>> {
-        let (sender, receiver) = webxr_channel().ok()?;
+        let (sender, receiver) = channel().ok()?;
         let _ = self.sender.send(SessionMsg::GetBoundsGeometry(sender));
         receiver.recv().ok()?
     }
@@ -168,7 +168,7 @@ impl Session {
     }
 
     pub fn create_layer(&self, context_id: ContextId, init: LayerInit) -> Result<LayerId, Error> {
-        let (sender, receiver) = webxr_channel().map_err(|_| Error::CommunicationError)?;
+        let (sender, receiver) = channel().map_err(|_| Error::CommunicationError)?;
         let _ = self
             .sender
             .send(SessionMsg::CreateLayer(context_id, init, sender));
@@ -194,7 +194,7 @@ impl Session {
         let _ = self.sender.send(SessionMsg::UpdateClipPlanes(near, far));
     }
 
-    pub fn set_event_dest(&mut self, dest: WebXrSender<Event>) {
+    pub fn set_event_dest(&mut self, dest: IpcSender<Event>) {
         let _ = self.sender.send(SessionMsg::SetEventDest(dest));
     }
 
@@ -226,7 +226,7 @@ impl Session {
         let _ = self.sender.send(SessionMsg::CancelHitTest(id));
     }
 
-    pub fn update_frame_rate(&mut self, rate: f32, sender: WebXrSender<f32>) {
+    pub fn update_frame_rate(&mut self, rate: f32, sender: IpcSender<f32>) {
         let _ = self.sender.send(SessionMsg::UpdateFrameRate(rate, sender));
     }
 
@@ -244,12 +244,12 @@ enum RenderState {
 
 /// For devices that want to do their own thread management, the `SessionThread` type is exposed.
 pub struct SessionThread<Device> {
-    receiver: WebXrReceiver<SessionMsg>,
-    sender: WebXrSender<SessionMsg>,
+    receiver: IpcReceiver<SessionMsg>,
+    sender: IpcSender<SessionMsg>,
     layers: Vec<(ContextId, LayerId)>,
     pending_layers: Option<Vec<(ContextId, LayerId)>>,
     frame_count: u64,
-    frame_sender: WebXrSender<Frame>,
+    frame_sender: IpcSender<Frame>,
     running: bool,
     device: Device,
     id: SessionId,
@@ -262,10 +262,10 @@ where
 {
     pub fn new(
         mut device: Device,
-        frame_sender: WebXrSender<Frame>,
+        frame_sender: IpcSender<Frame>,
         id: SessionId,
     ) -> Result<Self, Error> {
-        let (sender, receiver) = crate::webxr_channel().or(Err(Error::CommunicationError))?;
+        let (sender, receiver) = channel().or(Err(Error::CommunicationError))?;
         device.set_quitter(Quitter {
             sender: sender.clone(),
         });
@@ -417,8 +417,8 @@ where
     fn run_one_frame(&mut self) {
         let frame_count = self.frame_count;
         while frame_count == self.frame_count && self.running {
-            if let Ok(msg) = crate::recv_timeout(&self.receiver, TIMEOUT) {
-                self.running = self.handle_msg(msg);
+            if let Ok(msg) = &self.receiver.try_recv_timeout(TIMEOUT) {
+                self.running = self.handle_msg((*msg).clone());
             } else {
                 break;
             }
@@ -433,7 +433,7 @@ where
 /// A type for building XR sessions
 pub struct SessionBuilder<'a, GL> {
     sessions: &'a mut Vec<Box<dyn MainThreadSession>>,
-    frame_sender: WebXrSender<Frame>,
+    frame_sender: IpcSender<Frame>,
     layer_grand_manager: LayerGrandManager<GL>,
     id: SessionId,
 }
@@ -445,7 +445,7 @@ impl<'a, GL: 'static> SessionBuilder<'a, GL> {
 
     pub(crate) fn new(
         sessions: &'a mut Vec<Box<dyn MainThreadSession>>,
-        frame_sender: WebXrSender<Frame>,
+        frame_sender: IpcSender<Frame>,
         layer_grand_manager: LayerGrandManager<GL>,
         id: SessionId,
     ) -> Self {
@@ -463,7 +463,7 @@ impl<'a, GL: 'static> SessionBuilder<'a, GL> {
         Factory: 'static + FnOnce(LayerGrandManager<GL>) -> Result<Device, Error> + Send,
         Device: DeviceAPI,
     {
-        let (acks, ackr) = crate::webxr_channel().or(Err(Error::CommunicationError))?;
+        let (acks, ackr) = channel().or(Err(Error::CommunicationError))?;
         let frame_sender = self.frame_sender;
         let layer_grand_manager = self.layer_grand_manager;
         let id = self.id;

--- a/components/webxr/Cargo.toml
+++ b/components/webxr/Cargo.toml
@@ -28,6 +28,7 @@ crossbeam-channel = { workspace = true }
 euclid = { workspace = true }
 glow = { workspace = true }
 log = { workspace = true }
+ipc-channel = { workspace = true }
 openxr = { workspace = true, optional = true }
 raw-window-handle = { workspace = true }
 surfman = { workspace = true, features = ["chains", "sm-raw-window-handle-06"] }

--- a/components/webxr/glwindow/mod.rs
+++ b/components/webxr/glwindow/mod.rs
@@ -9,6 +9,7 @@ use euclid::{
     Angle, Point2D, Rect, RigidTransform3D, Rotation3D, Size2D, Transform3D, UnknownUnit, Vector3D,
 };
 use glow::{self as gl, Context as Gl, HasContext};
+use ipc_channel::ipc::IpcSender;
 use raw_window_handle::DisplayHandle;
 use surfman::chains::{PreserveBuffer, SwapChain, SwapChainAPI, SwapChains, SwapChainsAPI};
 use surfman::{
@@ -21,7 +22,7 @@ use webxr_api::{
     Display, Error, Event, EventBuffer, Floor, Frame, InputSource, LEFT_EYE, LayerGrandManager,
     LayerId, LayerInit, LayerManager, Native, Quitter, RIGHT_EYE, Session, SessionBuilder,
     SessionInit, SessionMode, SomeEye, VIEWER, View, Viewer, ViewerPose, Viewport, Viewports,
-    Views, WebXrSender,
+    Views,
 };
 
 use crate::{SurfmanGL, SurfmanLayerManager};
@@ -305,7 +306,7 @@ impl DeviceAPI for GlWindowDevice {
         vec![]
     }
 
-    fn set_event_dest(&mut self, dest: WebXrSender<Event>) {
+    fn set_event_dest(&mut self, dest: IpcSender<Event>) {
         self.events.upgrade(dest)
     }
 

--- a/components/webxr/openxr/mod.rs
+++ b/components/webxr/openxr/mod.rs
@@ -11,6 +11,7 @@ use std::{mem, thread};
 use euclid::{Point2D, Rect, RigidTransform3D, Rotation3D, Size2D, Transform3D, Vector3D};
 use glow::{self as gl, HasContext, PixelUnpackData};
 use interaction_profiles::{get_profiles_from_path, get_supported_interaction_profiles};
+use ipc_channel::ipc::IpcSender;
 use log::{error, warn};
 use openxr::sys::CompositionLayerPassthroughFB;
 use openxr::{
@@ -31,7 +32,7 @@ use webxr_api::{
     Floor, Frame, GLContexts, InputId, InputSource, LayerGrandManager, LayerId, LayerInit,
     LayerManager, LayerManagerAPI, LeftEye, Native, Quitter, RightEye, SelectKind,
     Session as WebXrSession, SessionBuilder, SessionInit, SessionMode, SubImage, SubImages, View,
-    ViewerPose, Viewport, Viewports, Views, Visibility, WebXrSender,
+    ViewerPose, Viewport, Viewports, Views, Visibility,
 };
 
 use crate::SurfmanGL;
@@ -1417,7 +1418,7 @@ impl DeviceAPI for OpenXrDevice {
         ]
     }
 
-    fn set_event_dest(&mut self, dest: WebXrSender<Event>) {
+    fn set_event_dest(&mut self, dest: IpcSender<Event>) {
         self.events.upgrade(dest)
     }
 


### PR DESCRIPTION
Followup from previous PR that now removes the separate type definitions.
WebXR components renamed their IpcSender/IpcReceiver and IpcChannel to WebXrReceiver/WebXrSender/WebXrChannel.

With the previous PR of always requiring ipc mode (which was already the case) this distinction is now useless.
In a followup, these are going to be replaced with GenericSender/Receiver.

Signed-off-by: Narfinger <Narfinger@users.noreply.github.com>

Testing: Just type renaming so compilation is the test.
