### PR TITLE
servoshell: Remove `HeadedWindow`-specific methods from `PlatformWindow`

### DIFF
--- a/ports/servoshell/desktop/mod.rs
+++ b/ports/servoshell/desktop/mod.rs
@@ -13,7 +13,7 @@ pub(crate) mod event_loop;
 pub(crate) mod gamepad;
 pub mod geometry;
 mod gui;
-mod headed_window;
+pub(crate) mod headed_window;
 mod headless_window;
 mod keyutils;
 mod protocols;

--- a/ports/servoshell/egl/app.rs
+++ b/ports/servoshell/egl/app.rs
@@ -25,7 +25,7 @@ use crate::prefs::ServoShellPreferences;
 use crate::running_app_state::{RunningAppState, UserInterfaceCommand};
 use crate::window::{PlatformWindow, ServoShellWindow, ServoShellWindowId};
 
-pub(super) struct EmbeddedPlatformWindow {
+pub(crate) struct EmbeddedPlatformWindow {
     host: Box<dyn HostTrait>,
     rendering_context: Rc<WindowRenderingContext>,
     refresh_driver: Rc<VsyncRefreshDriver>,
@@ -47,6 +47,10 @@ pub(super) struct EmbeddedPlatformWindow {
 }
 
 impl PlatformWindow for EmbeddedPlatformWindow {
+    fn as_headed_window(&self) -> Option<&Self> {
+        Some(self)
+    }
+
     fn id(&self) -> ServoShellWindowId {
         0.into()
     }

--- a/ports/servoshell/egl/mod.rs
+++ b/ports/servoshell/egl/mod.rs
@@ -4,7 +4,7 @@
 
 #[cfg(target_os = "android")]
 mod android;
-mod app;
+pub(crate) mod app;
 #[cfg(feature = "gamepad")]
 pub(crate) mod gamepad;
 mod host_trait;

--- a/ports/servoshell/running_app_state.rs
+++ b/ports/servoshell/running_app_state.rs
@@ -247,18 +247,17 @@ impl RunningAppState {
         platform_window: Rc<dyn PlatformWindow>,
         initial_url: Url,
     ) -> Rc<ServoShellWindow> {
-        let has_winit_window = platform_window.has_winit_window();
-        let window = Rc::new(ServoShellWindow::new(platform_window));
-
-        // For [`HeadedWindow`], it is up to the `winit::event::WindowEvent::Focused`.
-        // Otherwise, newly created windows are automatically focused.
-        if !has_winit_window {
-            self.focus_window(window.clone());
-        }
+        let window = Rc::new(ServoShellWindow::new(platform_window.clone()));
         window.create_and_activate_toplevel_webview(self.clone(), initial_url);
         self.windows
             .borrow_mut()
             .insert(window.id(), window.clone());
+
+        // If the window already has platform focus, mark it as focused in our application state.
+        if platform_window.has_platform_focus() {
+            self.focus_window(window.clone());
+        }
+
         window
     }
 

--- a/ports/servoshell/window.rs
+++ b/ports/servoshell/window.rs
@@ -366,26 +366,6 @@ pub(crate) trait PlatformWindow {
     fn update_user_interface_state(&self, _: &RunningAppState, _: &ServoShellWindow) -> bool {
         false
     }
-    /// Handle a winit [`WindowEvent`]. Returns `true` if the event loop should continue
-    /// and `false` otherwise.
-    ///
-    /// TODO: This should be handled internally in the winit window if possible so that it
-    /// makes more sense when we are mixing headed and headless windows.
-    #[cfg(not(any(target_os = "android", target_env = "ohos")))]
-    fn handle_winit_window_event(
-        &self,
-        _: Rc<RunningAppState>,
-        _: Rc<ServoShellWindow>,
-        _: winit::event::WindowEvent,
-    ) {
-    }
-    /// Handle a winit [`AppEvent`]. Returns `true` if the event loop should continue and
-    /// `false` otherwise.
-    ///
-    /// TODO: This should be handled internally in the winit window if possible so that it
-    /// makes more sense when we are mixing headed and headless windows.
-    #[cfg(not(any(target_os = "android", target_env = "ohos")))]
-    fn handle_winit_app_event(&self, _: crate::desktop::event_loop::AppEvent) {}
     /// Request that the window redraw itself. It is up to the window to do this
     /// once the windowing system is ready. If this is a headless window, the redraw
     /// will happen immediately.
@@ -413,6 +393,9 @@ pub(crate) trait PlatformWindow {
     fn window_rect(&self) -> DeviceIndependentIntRect;
     fn maximize(&self, _: &WebView) {}
     fn focus(&self) {}
+    fn has_platform_focus(&self) -> bool {
+        true
+    }
 
     fn show_embedder_control(&self, _: WebViewId, _: EmbedderControl) {}
     fn hide_embedder_control(&self, _: WebViewId, _: EmbedderControlId) {}
@@ -438,7 +421,16 @@ pub(crate) trait PlatformWindow {
     fn notify_media_session_event(&self, _: MediaSessionEvent) {}
     fn notify_crashed(&self, _: WebView, _reason: String, _backtrace: Option<String>) {}
     fn show_console_message(&self, _level: ConsoleLogLevel, _message: &str) {}
-    fn has_winit_window(&self) -> bool {
-        false
+
+    #[cfg(not(any(target_os = "android", target_env = "ohos")))]
+    /// If this window is a headed window, access the concrete type.
+    fn as_headed_window(&self) -> Option<&crate::desktop::headed_window::HeadedWindow> {
+        None
+    }
+
+    #[cfg(any(target_os = "android", target_env = "ohos"))]
+    /// If this window is a headed window, access the concrete type.
+    fn as_headed_window(&self) -> Option<&crate::egl::app::EmbeddedPlatformWindow> {
+        None
     }
 }


### PR DESCRIPTION
Instead of having `HeadedWindow`-specific methods here, just expose a
way to access the concrete type of a window. This is also exposed for
embedded ports and unused. They will use it in an upcoming change.

Testing: This shouldn't change behavior and is thus covered by existing tests.
