### PR TITLE
webxr: Switch most of the uses of `ipc-channel` to `GenericChannel`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10505,12 +10505,13 @@ dependencies = [
 name = "webxr"
 version = "0.0.1"
 dependencies = [
+ "base",
  "crossbeam-channel",
  "euclid",
  "glow",
- "ipc-channel",
  "log",
  "openxr",
+ "profile_traits",
  "raw-window-handle",
  "surfman",
  "webxr-api",
@@ -10522,10 +10523,12 @@ dependencies = [
 name = "webxr-api"
 version = "0.0.1"
 dependencies = [
+ "base",
  "embedder_traits",
  "euclid",
  "ipc-channel",
  "log",
+ "profile_traits",
  "serde",
 ]
 

--- a/components/script/dom/webxr/fakexrinputcontroller.rs
+++ b/components/script/dom/webxr/fakexrinputcontroller.rs
@@ -2,8 +2,8 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
+use base::generic_channel::GenericSender;
 use dom_struct::dom_struct;
-use ipc_channel::ipc::IpcSender;
 use webxr_api::{
     Handedness, InputId, MockButton, MockButtonType, MockDeviceMsg, MockInputMsg, SelectEvent,
     SelectKind, TargetRayMode,
@@ -28,9 +28,8 @@ use crate::script_runtime::CanGc;
 #[dom_struct]
 pub(crate) struct FakeXRInputController {
     reflector: Reflector,
-    #[ignore_malloc_size_of = "defined in ipc-channel"]
     #[no_trace]
-    sender: IpcSender<MockDeviceMsg>,
+    sender: GenericSender<MockDeviceMsg>,
     #[ignore_malloc_size_of = "defined in webxr-api"]
     #[no_trace]
     id: InputId,
@@ -38,7 +37,7 @@ pub(crate) struct FakeXRInputController {
 
 impl FakeXRInputController {
     pub(crate) fn new_inherited(
-        sender: IpcSender<MockDeviceMsg>,
+        sender: GenericSender<MockDeviceMsg>,
         id: InputId,
     ) -> FakeXRInputController {
         FakeXRInputController {
@@ -50,7 +49,7 @@ impl FakeXRInputController {
 
     pub(crate) fn new(
         global: &GlobalScope,
-        sender: IpcSender<MockDeviceMsg>,
+        sender: GenericSender<MockDeviceMsg>,
         id: InputId,
         can_gc: CanGc,
     ) -> DomRoot<FakeXRInputController> {

--- a/components/shared/profile/generic_callback.rs
+++ b/components/shared/profile/generic_callback.rs
@@ -8,7 +8,7 @@ use serde::{Deserialize, Serialize};
 use crate::time::{ProfilerCategory, ProfilerChan};
 use crate::time_profile;
 
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct GenericCallback<T>
 where
     T: Serialize + Send + 'static,

--- a/components/shared/webxr/Cargo.toml
+++ b/components/shared/webxr/Cargo.toml
@@ -16,8 +16,10 @@ but adapted to Rust design patterns.'''
 path = "lib.rs"
 
 [dependencies]
+base = { workspace = true }
 embedder_traits = { workspace = true }
 ipc-channel = { workspace = true }
+profile_traits = { workspace = true }
 euclid = { workspace = true }
 serde = { workspace = true }
 log = { workspace = true }

--- a/components/shared/webxr/device.rs
+++ b/components/shared/webxr/device.rs
@@ -5,7 +5,7 @@
 //! Traits to be implemented by backends
 
 use euclid::{Point2D, RigidTransform3D};
-use ipc_channel::ipc::IpcSender;
+use profile_traits::generic_callback::GenericCallback as ProfileGenericCallback;
 
 use crate::{
     ContextId, EnvironmentBlendMode, Error, Event, Floor, Frame, HitTestId, HitTestSource,
@@ -48,7 +48,7 @@ pub trait DeviceAPI: 'static {
     fn initial_inputs(&self) -> Vec<InputSource>;
 
     /// Sets the event handling channel
-    fn set_event_dest(&mut self, dest: IpcSender<Event>);
+    fn set_event_dest(&mut self, dest: ProfileGenericCallback<Event>);
 
     /// Quit the session
     fn quit(&mut self);

--- a/components/shared/webxr/events.rs
+++ b/components/shared/webxr/events.rs
@@ -3,7 +3,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 use euclid::RigidTransform3D;
-use ipc_channel::ipc::IpcSender;
+use profile_traits::generic_callback::GenericCallback as ProfileGenericCallback;
 use serde::{Deserialize, Serialize};
 
 use crate::{
@@ -45,7 +45,7 @@ pub enum Visibility {
 /// when no event callback has been set
 pub enum EventBuffer {
     Buffered(Vec<Event>),
-    Sink(IpcSender<Event>),
+    Sink(ProfileGenericCallback<Event>),
 }
 
 impl Default for EventBuffer {
@@ -64,7 +64,7 @@ impl EventBuffer {
         }
     }
 
-    pub fn upgrade(&mut self, dest: IpcSender<Event>) {
+    pub fn upgrade(&mut self, dest: ProfileGenericCallback<Event>) {
         if let EventBuffer::Buffered(ref mut events) = *self {
             for event in events.drain(..) {
                 let _ = dest.send(event);

--- a/components/shared/webxr/mock.rs
+++ b/components/shared/webxr/mock.rs
@@ -2,8 +2,9 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
+use base::generic_channel::GenericReceiver;
 use euclid::{Point2D, Rect, RigidTransform3D, Transform3D};
-use ipc_channel::ipc::{IpcReceiver, IpcSender};
+use profile_traits::generic_callback::GenericCallback as ProfileGenericCallback;
 use serde::{Deserialize, Serialize};
 
 use crate::{
@@ -17,7 +18,7 @@ pub trait MockDiscoveryAPI<GL>: 'static {
     fn simulate_device_connection(
         &mut self,
         init: MockDeviceInit,
-        receiver: IpcReceiver<MockDeviceMsg>,
+        receiver: GenericReceiver<MockDeviceMsg>,
     ) -> Result<Box<dyn DiscoveryAPI<GL>>, Error>;
 }
 
@@ -58,7 +59,7 @@ pub enum MockDeviceMsg {
     VisibilityChange(Visibility),
     SetWorld(MockWorld),
     ClearWorld,
-    Disconnect(IpcSender<()>),
+    Disconnect(ProfileGenericCallback<()>),
     SetBoundsGeometry(Vec<Point2D<f32, Floor>>),
     SimulateResetPose,
 }

--- a/components/shared/webxr/session.rs
+++ b/components/shared/webxr/session.rs
@@ -82,7 +82,7 @@ pub enum EnvironmentBlendMode {
 }
 
 // The messages that are sent from the content thread to the session thread.
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 enum SessionMsg {
     CreateLayer(ContextId, LayerInit, IpcSender<Result<LayerId, Error>>),
     DestroyLayer(ContextId, LayerId),
@@ -417,8 +417,8 @@ where
     fn run_one_frame(&mut self) {
         let frame_count = self.frame_count;
         while frame_count == self.frame_count && self.running {
-            if let Ok(msg) = self.receiver.try_recv_timeout(TIMEOUT) {
-                self.running = self.handle_msg(msg);
+            if let Ok(msg) = &self.receiver.try_recv_timeout(TIMEOUT) {
+                self.running = self.handle_msg((*msg).clone());
             } else {
                 break;
             }

--- a/components/webxr/Cargo.toml
+++ b/components/webxr/Cargo.toml
@@ -24,11 +24,12 @@ openxr-api = ["angle", "openxr", "winapi", "wio", "surfman/sm-angle-default"]
 x11 = ["surfman/sm-x11"]
 
 [dependencies]
+base = { workspace = true }
 crossbeam-channel = { workspace = true }
 euclid = { workspace = true }
 glow = { workspace = true }
+profile_traits = { workspace = true }
 log = { workspace = true }
-ipc-channel = { workspace = true }
 openxr = { workspace = true, optional = true }
 raw-window-handle = { workspace = true }
 surfman = { workspace = true, features = ["chains", "sm-raw-window-handle-06"] }

--- a/components/webxr/glwindow/mod.rs
+++ b/components/webxr/glwindow/mod.rs
@@ -9,7 +9,7 @@ use euclid::{
     Angle, Point2D, Rect, RigidTransform3D, Rotation3D, Size2D, Transform3D, UnknownUnit, Vector3D,
 };
 use glow::{self as gl, Context as Gl, HasContext};
-use ipc_channel::ipc::IpcSender;
+use profile_traits::generic_callback::GenericCallback as ProfileGenericCallback;
 use raw_window_handle::DisplayHandle;
 use surfman::chains::{PreserveBuffer, SwapChain, SwapChainAPI, SwapChains, SwapChainsAPI};
 use surfman::{
@@ -306,7 +306,7 @@ impl DeviceAPI for GlWindowDevice {
         vec![]
     }
 
-    fn set_event_dest(&mut self, dest: IpcSender<Event>) {
+    fn set_event_dest(&mut self, dest: ProfileGenericCallback<Event>) {
         self.events.upgrade(dest)
     }
 

--- a/components/webxr/headless/mod.rs
+++ b/components/webxr/headless/mod.rs
@@ -6,8 +6,9 @@ use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex};
 use std::thread;
 
+use base::generic_channel::GenericReceiver;
 use euclid::{Point2D, RigidTransform3D};
-use ipc_channel::ipc::{IpcReceiver, IpcSender};
+use profile_traits::generic_callback::GenericCallback as ProfileGenericCallback;
 use surfman::chains::SwapChains;
 use webxr_api::util::{self, ClipPlanes, HitTestList};
 use webxr_api::{
@@ -83,7 +84,7 @@ impl MockDiscoveryAPI<SurfmanGL> for HeadlessMockDiscovery {
     fn simulate_device_connection(
         &mut self,
         init: MockDeviceInit,
-        receiver: IpcReceiver<MockDeviceMsg>,
+        receiver: GenericReceiver<MockDeviceMsg>,
     ) -> Result<Box<dyn DiscoveryAPI<SurfmanGL>>, Error> {
         if !self.enabled.load(Ordering::Relaxed) {
             return Err(Error::NoMatchingDevice);
@@ -120,7 +121,7 @@ impl MockDiscoveryAPI<SurfmanGL> for HeadlessMockDiscovery {
     }
 }
 
-fn run_loop(receiver: IpcReceiver<MockDeviceMsg>, data: Arc<Mutex<HeadlessDeviceData>>) {
+fn run_loop(receiver: GenericReceiver<MockDeviceMsg>, data: Arc<Mutex<HeadlessDeviceData>>) {
     while let Ok(msg) = receiver.recv() {
         if !data.lock().expect("Mutex poisoned").handle_msg(msg) {
             break;
@@ -296,7 +297,7 @@ impl DeviceAPI for HeadlessDevice {
         vec![]
     }
 
-    fn set_event_dest(&mut self, dest: IpcSender<Event>) {
+    fn set_event_dest(&mut self, dest: ProfileGenericCallback<Event>) {
         self.with_per_session(|s| s.events.upgrade(dest))
     }
 

--- a/components/webxr/openxr/mod.rs
+++ b/components/webxr/openxr/mod.rs
@@ -8,7 +8,6 @@ use std::sync::{Arc, Mutex};
 use std::time::Duration;
 use std::{mem, thread};
 
-use base::generic_channel::GenericSender;
 use euclid::{Point2D, Rect, RigidTransform3D, Rotation3D, Size2D, Transform3D, Vector3D};
 use glow::{self as gl, HasContext, PixelUnpackData};
 use interaction_profiles::{get_profiles_from_path, get_supported_interaction_profiles};
@@ -22,6 +21,7 @@ use openxr::{
     ReferenceSpaceType, SecondaryEndInfo, Session, Space, Swapchain, SwapchainCreateFlags,
     SwapchainCreateInfo, SwapchainUsageFlags, SystemId, Vector3f, Version, ViewConfigurationType,
 };
+use profile_traits::generic_callback::GenericCallback as ProfileGenericCallback;
 use surfman::{
     Context as SurfmanContext, Device as SurfmanDevice, Error as SurfmanError, SurfaceTexture,
 };
@@ -1418,7 +1418,7 @@ impl DeviceAPI for OpenXrDevice {
         ]
     }
 
-    fn set_event_dest(&mut self, dest: GenericSender<Event>) {
+    fn set_event_dest(&mut self, dest: ProfileGenericCallback<Event>) {
         self.events.upgrade(dest)
     }
 

--- a/components/webxr/openxr/mod.rs
+++ b/components/webxr/openxr/mod.rs
@@ -8,6 +8,7 @@ use std::sync::{Arc, Mutex};
 use std::time::Duration;
 use std::{mem, thread};
 
+use base::generic_channel::GenericSender;
 use euclid::{Point2D, Rect, RigidTransform3D, Rotation3D, Size2D, Transform3D, Vector3D};
 use glow::{self as gl, HasContext, PixelUnpackData};
 use interaction_profiles::{get_profiles_from_path, get_supported_interaction_profiles};
@@ -21,7 +22,6 @@ use openxr::{
     ReferenceSpaceType, SecondaryEndInfo, Session, Space, Swapchain, SwapchainCreateFlags,
     SwapchainCreateInfo, SwapchainUsageFlags, SystemId, Vector3f, Version, ViewConfigurationType,
 };
-use base::generic_channel::GenericSender;
 use surfman::{
     Context as SurfmanContext, Device as SurfmanDevice, Error as SurfmanError, SurfaceTexture,
 };

--- a/components/webxr/openxr/mod.rs
+++ b/components/webxr/openxr/mod.rs
@@ -21,7 +21,7 @@ use openxr::{
     ReferenceSpaceType, SecondaryEndInfo, Session, Space, Swapchain, SwapchainCreateFlags,
     SwapchainCreateInfo, SwapchainUsageFlags, SystemId, Vector3f, Version, ViewConfigurationType,
 };
-use profile_traits::generic_callback::GenericCallback;
+use base::generic_channel::GenericSender;
 use surfman::{
     Context as SurfmanContext, Device as SurfmanDevice, Error as SurfmanError, SurfaceTexture,
 };

--- a/components/webxr/openxr/mod.rs
+++ b/components/webxr/openxr/mod.rs
@@ -11,7 +11,6 @@ use std::{mem, thread};
 use euclid::{Point2D, Rect, RigidTransform3D, Rotation3D, Size2D, Transform3D, Vector3D};
 use glow::{self as gl, HasContext, PixelUnpackData};
 use interaction_profiles::{get_profiles_from_path, get_supported_interaction_profiles};
-use ipc_channel::ipc::IpcSender;
 use log::{error, warn};
 use openxr::sys::CompositionLayerPassthroughFB;
 use openxr::{
@@ -22,6 +21,7 @@ use openxr::{
     ReferenceSpaceType, SecondaryEndInfo, Session, Space, Swapchain, SwapchainCreateFlags,
     SwapchainCreateInfo, SwapchainUsageFlags, SystemId, Vector3f, Version, ViewConfigurationType,
 };
+use profile_traits::generic_callback::GenericCallback;
 use surfman::{
     Context as SurfmanContext, Device as SurfmanDevice, Error as SurfmanError, SurfaceTexture,
 };
@@ -1418,7 +1418,7 @@ impl DeviceAPI for OpenXrDevice {
         ]
     }
 
-    fn set_event_dest(&mut self, dest: IpcSender<Event>) {
+    fn set_event_dest(&mut self, dest: GenericSender<Event>) {
         self.events.upgrade(dest)
     }
 


### PR DESCRIPTION
Switch most of the uses of IpcChannel to GenericChannel.

Currently there is still one major usage of IpcChannel in the frame_sender. This will be a more complicated change,
hence, should have extra scrutinee.


Requires https://github.com/servo/servo/pull/41771

Testing: Like all GenericChannels, this is mostly type changes
