### PR TITLE
Base: Remove unneded cargo deny entries

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -90,7 +90,6 @@ deny = [
 skip = [
     "bitflags",
     "cookie",
-    "futures",
     "redox_syscall",
 
     # New versions of these dependencies is pulled in by GStreamer / GLib.
@@ -176,11 +175,6 @@ skip = [
     # Remove when cexpr updates its nom version
     # and bindgen updates the cexpr version
     "nom",
-
-    # duplicated by image 0.25
-    "cfg-expr",
-    "system-deps",
-    "target-lexicon",
 
     # duplicated by core-graphics
     "core-graphics-types",


### PR DESCRIPTION
These entries are not needed anymore so they can be removed.

Signed-off-by: Narfinger <Narfinger@users.noreply.github.com>


Testing: ./mach test-tidy still works.
