### PR TITLE
26488 - Moves CookieStore drop logic to a separate struct

### DIFF
--- a/components/script_bindings/codegen/Bindings.conf
+++ b/components/script_bindings/codegen/Bindings.conf
@@ -104,7 +104,6 @@ DOMInterfaces = {
 
 'CookieStore': {
     'canGc': ['Set', 'Set_', 'Get', 'Get_', 'GetAll', 'GetAll_', 'Delete', 'Delete_'],
-    'allowDropImpl': True,
 },
 
 'CountQueuingStrategy': {


### PR DESCRIPTION
Refactors the `CookieStore` to use a separate `DroppableCookieStore` struct for handling the drop logic.

Testing: No tests added
Fixes: Partially #26488 
