### PR TITLE
fonts: Create resource timing entries when loading web fonts (#41660)

### DIFF
--- a/components/fonts/lib.rs
+++ b/components/fonts/lib.rs
@@ -21,7 +21,8 @@ pub use font::{
     ShapingOptions,
 };
 pub use font_context::{
-    CspViolationHandler, FontContext, FontContextWebFontMethods, WebFontDocumentContext,
+    CspViolationHandler, FontContext, FontContextWebFontMethods, NetworkTimingHandler,
+    WebFontDocumentContext,
 };
 pub use font_store::FontTemplates;
 pub use fonts_traits::*;

--- a/components/script/dom/performance/performanceresourcetiming.rs
+++ b/components/script/dom/performance/performanceresourcetiming.rs
@@ -27,6 +27,7 @@ use crate::script_runtime::CanGc;
 #[derive(Debug, JSTraceable, MallocSizeOf, PartialEq)]
 pub(crate) enum InitiatorType {
     Beacon,
+    Css,
     LocalName(String),
     Navigation,
     XMLHttpRequest,
@@ -193,6 +194,7 @@ impl PerformanceResourceTimingMethods<crate::DomTypeHolder> for PerformanceResou
     fn InitiatorType(&self) -> DOMString {
         match self.initiator_type {
             InitiatorType::Beacon => DOMString::from("beacon"),
+            InitiatorType::Css => DOMString::from("css"),
             InitiatorType::LocalName(ref n) => DOMString::from(n.clone()),
             InitiatorType::Navigation => DOMString::from("navigation"),
             InitiatorType::XMLHttpRequest => DOMString::from("xmlhttprequest"),

--- a/components/script/dom/window.rs
+++ b/components/script/dom/window.rs
@@ -1022,7 +1022,7 @@ impl FetchResponseListener for FontFetchListener {
 
 impl ResourceTimingListener for FontFetchListener {
     fn resource_timing_information(&self) -> (InitiatorType, ServoUrl) {
-        (InitiatorType::Other, self.url.clone())
+        (InitiatorType::Css, self.url.clone())
     }
 
     fn resource_timing_global(&self) -> DomRoot<GlobalScope> {

--- a/components/script/dom/window.rs
+++ b/components/script/dom/window.rs
@@ -186,7 +186,7 @@ use crate::dom::workletglobalscope::WorkletGlobalScopeType;
 use crate::layout_image::fetch_image_for_layout;
 use crate::messaging::{MainThreadScriptMsg, ScriptEventLoopReceiver, ScriptEventLoopSender};
 use crate::microtask::{Microtask, UserMicrotask};
-use crate::network_listener::{FetchResponseListener, ResourceTimingListener, submit_timing};
+use crate::network_listener::{ResourceTimingListener, submit_timing};
 use crate::realms::{InRealm, enter_realm};
 use crate::script_runtime::{CanGc, JSContext, Runtime};
 use crate::script_thread::ScriptThread;
@@ -984,40 +984,6 @@ impl NetworkTimingHandler for FontNetworkTimingHandler {
 struct FontFetchListener {
     global: Trusted<GlobalScope>,
     url: ServoUrl,
-}
-
-impl FetchResponseListener for FontFetchListener {
-    fn process_request_body(&mut self, _request_id: net_traits::request::RequestId) {}
-
-    fn process_request_eof(&mut self, _request_id: net_traits::request::RequestId) {}
-
-    fn process_response(
-        &mut self,
-        _request_id: net_traits::request::RequestId,
-        _metadata: Result<net_traits::FetchMetadata, net_traits::NetworkError>,
-    ) {
-    }
-
-    fn process_response_chunk(
-        &mut self,
-        _request_id: net_traits::request::RequestId,
-        _chunk: Vec<u8>,
-    ) {
-    }
-
-    fn process_response_eof(
-        self,
-        _request_id: net_traits::request::RequestId,
-        _response: Result<ResourceFetchTiming, net_traits::NetworkError>,
-    ) {
-    }
-
-    fn process_csp_violations(
-        &mut self,
-        _request_id: net_traits::request::RequestId,
-        _violations: Vec<Violation>,
-    ) {
-    }
 }
 
 impl ResourceTimingListener for FontFetchListener {

--- a/components/script/network_listener.rs
+++ b/components/script/network_listener.rs
@@ -27,7 +27,7 @@ pub(crate) trait ResourceTimingListener {
     fn resource_timing_global(&self) -> DomRoot<GlobalScope>;
 }
 
-pub(crate) fn submit_timing<T: ResourceTimingListener + FetchResponseListener>(
+pub(crate) fn submit_timing<T: ResourceTimingListener>(
     listener: &T,
     resource_timing: &ResourceFetchTiming,
     can_gc: CanGc,

--- a/tests/wpt/meta/css/css-fonts/font-display/font-display-failure-fallback.html.ini
+++ b/tests/wpt/meta/css/css-fonts/font-display/font-display-failure-fallback.html.ini
@@ -1,3 +1,0 @@
-[font-display-failure-fallback.html]
-  [Fallback for font failure period]
-    expected: FAIL

--- a/tests/wpt/meta/preload/preload-font-crossorigin.html.ini
+++ b/tests/wpt/meta/preload/preload-font-crossorigin.html.ini
@@ -1,6 +1,0 @@
-[preload-font-crossorigin.html]
-  [Same origin font preload without crossorigin attribute]
-    expected: FAIL
-
-  [Cross origin font preload without crossorigin attribute]
-    expected: FAIL

--- a/tests/wpt/meta/preload/subresource-integrity-font.html.ini
+++ b/tests/wpt/meta/preload/subresource-integrity-font.html.ini
@@ -47,9 +47,6 @@
   [Cross-origin, not CORS request, with incorrect sha256.]
     expected: FAIL
 
-  [Cross-origin, not CORS request, with empty integrity.]
-    expected: FAIL
-
   [<crossorigin="use-credentials"> Cross-origin with correct sha256 hash, CORS-eligible.]
     expected: FAIL
 

--- a/tests/wpt/meta/resource-timing/TAO-match.html.ini
+++ b/tests/wpt/meta/resource-timing/TAO-match.html.ini
@@ -13,37 +13,25 @@
     expected: FAIL
 
   [The timing allow check algorithm will pass when the Timing-Allow-Origin header value list contains a wildcard. (font)]
-    expected: TIMEOUT
-
-  [The timing allow check algorithm will fail when the Timing-Allow-Origin header value list contains a null origin. (font)]
-    expected: NOTRUN
+    expected: FAIL
 
   [The timing allow check algorithm will pass when the Timing-Allow-Origin header value list contains multiple wildcards. (font)]
-    expected: NOTRUN
-
-  [The timing allow check algorithm will fail when the Timing-Allow-Origin header value contains only the uppercased origin. (font)]
-    expected: NOTRUN
-
-  [The timing allow check algorithm will fail when the Timing-Allow-Origin header value contains the origin, a space, then a wildcard. (font)]
-    expected: NOTRUN
-
-  [The timing allow check algorithm will fail when the Timing-Allow-Origin header is not present. (font)]
-    expected: NOTRUN
+    expected: FAIL
 
   [The timing allow check algorithm will pass when the Timing-Allow-Origin header value contains only the origin. (iframe)]
-    expected: NOTRUN
+    expected: FAIL
 
   [The timing allow check algorithm will pass when the Timing-Allow-Origin header value contains only a wildcard. (iframe)]
-    expected: NOTRUN
+    expected: FAIL
 
   [The timing allow check algorithm will pass when the Timing-Allow-Origin header value list contains a case-sensitive match. (iframe)]
-    expected: NOTRUN
+    expected: FAIL
 
   [The timing allow check algorithm will pass when the Timing-Allow-Origin header value list contains the origin and a wildcard. (iframe)]
-    expected: NOTRUN
+    expected: FAIL
 
   [The timing allow check algorithm will pass when the Timing-Allow-Origin header value list contains a wildcard. (iframe)]
-    expected: NOTRUN
+    expected: TIMEOUT
 
   [The timing allow check algorithm will fail when the Timing-Allow-Origin header value list contains a null origin. (iframe)]
     expected: NOTRUN

--- a/tests/wpt/meta/resource-timing/initiator-type/dynamic-insertion.html.ini
+++ b/tests/wpt/meta/resource-timing/initiator-type/dynamic-insertion.html.ini
@@ -1,6 +1,3 @@
 [dynamic-insertion.html]
-  [A font should have the 'css' initiator type.]
-    expected: FAIL
-
   [A iframe should have the 'iframe' initiator type.]
     expected: FAIL

--- a/tests/wpt/meta/resource-timing/initiator-type/link.html.ini
+++ b/tests/wpt/meta/resource-timing/initiator-type/link.html.ini
@@ -2,9 +2,6 @@
   [The initiator type for css resources embedded in css must be 'css']
     expected: FAIL
 
-  [The initiator type for font resources embedded in css must be 'css']
-    expected: FAIL
-
   [The initiator type for image resources embedded in css must be 'css']
     expected: FAIL
 

--- a/tests/wpt/meta/resource-timing/initiator-type/style.html.ini
+++ b/tests/wpt/meta/resource-timing/initiator-type/style.html.ini
@@ -7,6 +7,3 @@
 
   [The initiator type for 'list-style-image' attributes in <style> elements must be 'css']
     expected: FAIL
-
-  [The initiator type for '@font-face' resources must be 'css']
-    expected: FAIL

--- a/tests/wpt/meta/resource-timing/nextHopProtocol-is-tao-protected.https.html.ini
+++ b/tests/wpt/meta/resource-timing/nextHopProtocol-is-tao-protected.https.html.ini
@@ -1,13 +1,9 @@
 [nextHopProtocol-is-tao-protected.https.html]
-  expected: TIMEOUT
   [Add TAO-less iframe from remote origin. Make sure nextHopProtocol is the empty string]
     expected: TIMEOUT
 
   [Add TAO'd iframe from remote origin. Make sure nextHopProtocol is not the empty string]
     expected: NOTRUN
-
-  [Fetch TAO-less font from remote origin. Make sure nextHopProtocol is the empty string.]
-    expected: FAIL
 
   [Fetch TAO'd font from remote origin. Make sure nextHopProtocol is not the empty string.]
     expected: FAIL
@@ -22,31 +18,19 @@
     expected: FAIL
 
   [Fetch TAO-less object from remote origin. Make sure nextHopProtocol is the empty string.]
-    expected: TIMEOUT
+    expected: FAIL
 
   [Fetch TAO'd object from remote origin. Make sure nextHopProtocol is not the empty string.]
-    expected: NOTRUN
+    expected: FAIL
 
   [Fetch TAO'd script from remote origin. Make sure nextHopProtocol is not the empty string.]
-    expected: NOTRUN
+    expected: FAIL
 
   [Fetch TAO'd stylesheet from remote origin. Make sure nextHopProtocol is not the empty string.]
-    expected: NOTRUN
+    expected: FAIL
 
   [Fetch TAO'd synchronous xhr from remote origin. Make sure nextHopProtocol is not the empty string.]
-    expected: NOTRUN
+    expected: FAIL
 
   [Fetch TAO'd asynchronous xhr from remote origin. Make sure nextHopProtocol is not the empty string.]
-    expected: NOTRUN
-
-  [Fetch TAO-less script from remote origin. Make sure nextHopProtocol is the empty string.]
-    expected: NOTRUN
-
-  [Fetch TAO-less stylesheet from remote origin. Make sure nextHopProtocol is the empty string.]
-    expected: NOTRUN
-
-  [Fetch TAO-less synchronous xhr from remote origin. Make sure nextHopProtocol is the empty string.]
-    expected: NOTRUN
-
-  [Fetch TAO-less asynchronous xhr from remote origin. Make sure nextHopProtocol is the empty string.]
-    expected: NOTRUN
+    expected: FAIL

--- a/tests/wpt/meta/resource-timing/response-status-code.html.ini
+++ b/tests/wpt/meta/resource-timing/response-status-code.html.ini
@@ -238,37 +238,37 @@
     expected: FAIL
 
   [This test validates the response status of resources. 79]
-    expected: TIMEOUT
+    expected: FAIL
 
   [This test validates the response status of resources. 80]
-    expected: NOTRUN
+    expected: FAIL
 
   [This test validates the response status of resources. 81]
-    expected: NOTRUN
+    expected: FAIL
 
   [This test validates the response status of resources. 82]
-    expected: NOTRUN
+    expected: FAIL
 
   [This test validates the response status of resources. 83]
-    expected: NOTRUN
+    expected: FAIL
 
   [This test validates the response status of resources. 84]
-    expected: NOTRUN
+    expected: FAIL
 
   [This test validates the response status of resources. 85]
-    expected: NOTRUN
+    expected: FAIL
 
   [This test validates the response status of resources. 86]
-    expected: NOTRUN
+    expected: FAIL
 
   [This test validates the response status of resources. 87]
-    expected: NOTRUN
+    expected: FAIL
 
   [This test validates the response status of resources. 88]
-    expected: NOTRUN
+    expected: FAIL
 
   [This test validates the response status of resources. 89]
-    expected: NOTRUN
+    expected: TIMEOUT
 
   [This test validates the response status of resources. 90]
     expected: NOTRUN


### PR DESCRIPTION
Add a callback on `WebFontDocumentContext` to create resource timing entries, this callback is then used to call `submit_timing`, using a shim listener, as this function requires a listener.

Testing: Using `./mach test-wpt tests/wpt/tests/preload/preload-resource-match.https.html`
Fixes: #41660
