### PR TITLE
deps: Update media crates to enable ogg playback.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8158,7 +8158,7 @@ dependencies = [
 [[package]]
 name = "servo-media"
 version = "0.1.0"
-source = "git+https://github.com/servo/media#0c7edc70be3141067bdaf38e8dc8e1bf6180e644"
+source = "git+https://github.com/servo/media#f384dbc4ff8b5c6f8db2c763306cbe2281d66391"
 dependencies = [
  "once_cell",
  "servo-media-audio",
@@ -8171,7 +8171,7 @@ dependencies = [
 [[package]]
 name = "servo-media-audio"
 version = "0.2.0"
-source = "git+https://github.com/servo/media#0c7edc70be3141067bdaf38e8dc8e1bf6180e644"
+source = "git+https://github.com/servo/media#f384dbc4ff8b5c6f8db2c763306cbe2281d66391"
 dependencies = [
  "byte-slice-cast",
  "euclid",
@@ -8192,7 +8192,7 @@ dependencies = [
 [[package]]
 name = "servo-media-derive"
 version = "0.1.0"
-source = "git+https://github.com/servo/media#0c7edc70be3141067bdaf38e8dc8e1bf6180e644"
+source = "git+https://github.com/servo/media#f384dbc4ff8b5c6f8db2c763306cbe2281d66391"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -8202,7 +8202,7 @@ dependencies = [
 [[package]]
 name = "servo-media-dummy"
 version = "0.1.0"
-source = "git+https://github.com/servo/media#0c7edc70be3141067bdaf38e8dc8e1bf6180e644"
+source = "git+https://github.com/servo/media#f384dbc4ff8b5c6f8db2c763306cbe2281d66391"
 dependencies = [
  "ipc-channel",
  "servo-media",
@@ -8216,7 +8216,7 @@ dependencies = [
 [[package]]
 name = "servo-media-gstreamer"
 version = "0.1.0"
-source = "git+https://github.com/servo/media#0c7edc70be3141067bdaf38e8dc8e1bf6180e644"
+source = "git+https://github.com/servo/media#f384dbc4ff8b5c6f8db2c763306cbe2281d66391"
 dependencies = [
  "byte-slice-cast",
  "glib",
@@ -8249,7 +8249,7 @@ dependencies = [
 [[package]]
 name = "servo-media-gstreamer-render"
 version = "0.1.0"
-source = "git+https://github.com/servo/media#0c7edc70be3141067bdaf38e8dc8e1bf6180e644"
+source = "git+https://github.com/servo/media#f384dbc4ff8b5c6f8db2c763306cbe2281d66391"
 dependencies = [
  "gstreamer",
  "gstreamer-video",
@@ -8259,7 +8259,7 @@ dependencies = [
 [[package]]
 name = "servo-media-gstreamer-render-android"
 version = "0.1.0"
-source = "git+https://github.com/servo/media#0c7edc70be3141067bdaf38e8dc8e1bf6180e644"
+source = "git+https://github.com/servo/media#f384dbc4ff8b5c6f8db2c763306cbe2281d66391"
 dependencies = [
  "glib",
  "gstreamer",
@@ -8273,7 +8273,7 @@ dependencies = [
 [[package]]
 name = "servo-media-gstreamer-render-unix"
 version = "0.1.0"
-source = "git+https://github.com/servo/media#0c7edc70be3141067bdaf38e8dc8e1bf6180e644"
+source = "git+https://github.com/servo/media#f384dbc4ff8b5c6f8db2c763306cbe2281d66391"
 dependencies = [
  "glib",
  "gstreamer",
@@ -8287,7 +8287,7 @@ dependencies = [
 [[package]]
 name = "servo-media-player"
 version = "0.1.0"
-source = "git+https://github.com/servo/media#0c7edc70be3141067bdaf38e8dc8e1bf6180e644"
+source = "git+https://github.com/servo/media#f384dbc4ff8b5c6f8db2c763306cbe2281d66391"
 dependencies = [
  "ipc-channel",
  "serde",
@@ -8299,7 +8299,7 @@ dependencies = [
 [[package]]
 name = "servo-media-streams"
 version = "0.1.0"
-source = "git+https://github.com/servo/media#0c7edc70be3141067bdaf38e8dc8e1bf6180e644"
+source = "git+https://github.com/servo/media#f384dbc4ff8b5c6f8db2c763306cbe2281d66391"
 dependencies = [
  "uuid",
 ]
@@ -8307,12 +8307,12 @@ dependencies = [
 [[package]]
 name = "servo-media-traits"
 version = "0.1.0"
-source = "git+https://github.com/servo/media#0c7edc70be3141067bdaf38e8dc8e1bf6180e644"
+source = "git+https://github.com/servo/media#f384dbc4ff8b5c6f8db2c763306cbe2281d66391"
 
 [[package]]
 name = "servo-media-webrtc"
 version = "0.1.0"
-source = "git+https://github.com/servo/media#0c7edc70be3141067bdaf38e8dc8e1bf6180e644"
+source = "git+https://github.com/servo/media#f384dbc4ff8b5c6f8db2c763306cbe2281d66391"
 dependencies = [
  "log",
  "servo-media-streams",

--- a/tests/wpt/meta/content-security-policy/media-src/media-src-7_2.html.ini
+++ b/tests/wpt/meta/content-security-policy/media-src/media-src-7_2.html.ini
@@ -1,7 +1,0 @@
-[media-src-7_2.html]
-  expected: TIMEOUT
-  [In-policy audio source element]
-    expected: FAIL
-
-  [Should not fire policy violation events]
-    expected: NOTRUN

--- a/tests/wpt/meta/html/semantics/embedded-content/media-elements/mime-types/canPlayType.html.ini
+++ b/tests/wpt/meta/html/semantics/embedded-content/media-elements/mime-types/canPlayType.html.ini
@@ -14,16 +14,10 @@
   [audio/mp4; codecs="mp4a.40.2" (optional)]
     expected: PRECONDITION_FAILED
 
-  [video/ogg; codecs="theora" (optional)]
-    expected: PRECONDITION_FAILED
-
   [video/mp4; codecs="avc1.64001E" (optional)]
     expected: PRECONDITION_FAILED
 
   [video/mp4 (optional)]
-    expected: PRECONDITION_FAILED
-
-  [video/ogg; codecs="vorbis" (optional)]
     expected: PRECONDITION_FAILED
 
   [audio/ogg; codecs="opus" (optional)]
@@ -48,7 +42,7 @@
     expected: PRECONDITION_FAILED
 
   [video/ogg (optional)]
-    expected: PRECONDITION_FAILED
+    expected: FAIL
 
   [audio/mp4 (optional)]
     expected: PRECONDITION_FAILED
@@ -57,12 +51,9 @@
     expected: FAIL
 
   [audio/ogg (optional)]
-    expected: PRECONDITION_FAILED
+    expected: FAIL
 
   [video/mp4; codecs="mp4a.40.2" (optional)]
-    expected: PRECONDITION_FAILED
-
-  [audio/ogg; codecs="vorbis" (optional)]
     expected: PRECONDITION_FAILED
 
   [video/ogg; codecs="opus" (optional)]
@@ -89,8 +80,8 @@
   [video/mp4 codecs order]
     expected: PRECONDITION_FAILED
 
-  [video/ogg codecs subset]
-    expected: PRECONDITION_FAILED
+  [audio/ogg with and without codecs]
+    expected: FAIL
 
-  [video/ogg codecs order]
-    expected: PRECONDITION_FAILED
+  [video/ogg with and without codecs]
+    expected: FAIL

--- a/tests/wpt/meta/resource-timing/initiator-type/audio.html.ini
+++ b/tests/wpt/meta/resource-timing/initiator-type/audio.html.ini
@@ -1,3 +1,0 @@
-[audio.html]
-  [The initiator type for <source src> with type 'audio/ogg' must be 'audio']
-    expected: FAIL


### PR DESCRIPTION
Pulls in the changes from https://github.com/servo/media/pull/485 to report that OGG sources are playable.

Testing: New passing tests that rely on OGG data.

https://github.com/servo/servo/actions/runs/20840537096