### PR TITLE
webdriver: Dispatch embedder `TouchEventType::Move`

### DIFF
--- a/components/webdriver_server/actions.rs
+++ b/components/webdriver_server/actions.rs
@@ -567,11 +567,9 @@ impl Handler {
                                 TouchId(*pointer_id as i32),
                                 point,
                             ));
-                            if last {
-                                self.send_blocking_input_event_to_embedder(input_event);
-                            } else {
-                                self.send_input_event_to_embedder(input_event);
-                            }
+                            // We should NOT block here. TouchMove is special, and may never
+                            // be forwarded to constellation and handled.
+                            self.send_input_event_to_embedder(input_event);
                         }
                     },
                 }

--- a/components/webdriver_server/actions.rs
+++ b/components/webdriver_server/actions.rs
@@ -28,9 +28,13 @@ use webdriver::error::{ErrorStatus, WebDriverError};
 
 use crate::{Handler, VerifyBrowsingContextIsOpen, WebElement, wait_for_oneshot_response};
 
-// Interval between wheelScroll and pointerMove increments in ms, based on common vsync
+/// Interval between wheelScroll and pointerMove increments in ms, based on common vsync
 static POINTERMOVE_INTERVAL: u64 = 17;
 static WHEELSCROLL_INTERVAL: u64 = 17;
+
+/// <https://w3c.github.io/webdriver/#dfn-element-click>
+/// This is hard-coded as 0 in spec.
+pub(crate) static ELEMENT_CLICK_BUTTON: u64 = 0;
 
 /// <https://262.ecma-international.org/6.0/#sec-number.max_safe_integer>
 /// 2^53 - 1
@@ -532,13 +536,14 @@ impl Handler {
                 x: current_x,
                 y: current_y,
                 subtype,
-                ..
-            } = *self.get_pointer_input_state(source_id);
+                pressed,
+                pointer_id,
+            } = self.get_pointer_input_state(source_id);
 
             // Step 7. If x != current x or y != current y, run the following steps:
             // FIXME: Actually "last" should not be checked here based on spec.
-            if x != current_x || y != current_y || last {
-                // Step 7.1. Let buttons be equal to input state's buttons property.
+            if x != *current_x || y != *current_y || last {
+                // Step 7.1. Let buttons be equal to input state's pressed property.
                 // Step 7.2. Perform implementation-specific action dispatch steps
                 let point = WebViewPoint::Page(Point2D::new(x as f32, y as f32));
 
@@ -556,7 +561,18 @@ impl Handler {
                     // In the case where the pointerType is "pen" or "touch", and buttons is empty,
                     // this may be a no-op.
                     PointerType::Touch | PointerType::Pen => {
-                        // TODO: Handle the case where buttons is non-empty.
+                        if pressed.contains(&ELEMENT_CLICK_BUTTON) {
+                            let input_event = InputEvent::Touch(TouchEvent::new(
+                                TouchEventType::Move,
+                                TouchId(*pointer_id as i32),
+                                point,
+                            ));
+                            if last {
+                                self.send_blocking_input_event_to_embedder(input_event);
+                            } else {
+                                self.send_input_event_to_embedder(input_event);
+                            }
+                        }
                     },
                 }
 

--- a/components/webdriver_server/lib.rs
+++ b/components/webdriver_server/lib.rs
@@ -30,9 +30,9 @@ use cookie::{CookieBuilder, Expiration, SameSite};
 use crossbeam_channel::{Receiver, RecvTimeoutError, Sender, after, select, unbounded};
 use embedder_traits::{
     CustomHandlersAutomationMode, EventLoopWaker, ImeEvent, InputEvent, JSValue,
-    JavaScriptEvaluationError, JavaScriptEvaluationResultSerializationError, MouseButton,
-    NewWindowTypeHint, WebDriverCommandMsg, WebDriverFrameId, WebDriverJSResult,
-    WebDriverLoadStatus, WebDriverScriptCommand,
+    JavaScriptEvaluationError, JavaScriptEvaluationResultSerializationError, NewWindowTypeHint,
+    WebDriverCommandMsg, WebDriverFrameId, WebDriverJSResult, WebDriverLoadStatus,
+    WebDriverScriptCommand,
 };
 use euclid::{Point2D, Rect, Size2D};
 use http::method::Method;
@@ -73,7 +73,7 @@ use webdriver::response::{
 };
 use webdriver::server::{self, Session, SessionTeardownKind, WebDriverHandler};
 
-use crate::actions::{InputSourceState, PointerInputState};
+use crate::actions::{ELEMENT_CLICK_BUTTON, InputSourceState, PointerInputState};
 use crate::session::{PageLoadStrategy, WebDriverSession};
 use crate::timeout::{DEFAULT_PAGE_LOAD_TIMEOUT, SCREENSHOT_TIMEOUT};
 
@@ -2334,14 +2334,14 @@ impl Handler {
         // Step 8.11. Construct pointer down action.
         // Step 8.12. Set a property button to 0 on pointer down action.
         let pointer_down_action = PointerDownAction {
-            button: i16::from(MouseButton::Left) as u64,
+            button: ELEMENT_CLICK_BUTTON,
             ..Default::default()
         };
 
         // Step 8.13. Construct pointer up action.
         // Step 8.14. Set a property button to 0 on pointer up action.
         let pointer_up_action = PointerUpAction {
-            button: i16::from(MouseButton::Left) as u64,
+            button: ELEMENT_CLICK_BUTTON,
             ..Default::default()
         };
 

--- a/tests/wpt/meta/css/cssom-view/visual-scrollIntoView-001.html.ini
+++ b/tests/wpt/meta/css/cssom-view/visual-scrollIntoView-001.html.ini
@@ -1,3 +1,4 @@
 [visual-scrollIntoView-001.html]
+  expected: CRASH
   [Element.scrollIntoView scrolls visually]
     expected: FAIL

--- a/tests/wpt/meta/css/cssom-view/visual-scrollIntoView-002.html.ini
+++ b/tests/wpt/meta/css/cssom-view/visual-scrollIntoView-002.html.ini
@@ -1,3 +1,4 @@
 [visual-scrollIntoView-002.html]
+  expected: CRASH
   [Element.scrollIntoView scrolls visually to a position: fixed element with non-zero layout scroll offset]
     expected: FAIL

--- a/tests/wpt/meta/css/cssom-view/visual-scrollIntoView-003.html.ini
+++ b/tests/wpt/meta/css/cssom-view/visual-scrollIntoView-003.html.ini
@@ -1,3 +1,4 @@
 [visual-scrollIntoView-003.html]
+  expected: CRASH
   [Element.scrollIntoView scrolls visually to an element in nested position: fixed elements]
     expected: FAIL

--- a/tests/wpt/meta/dom/events/non-cancelable-when-passive/non-passive-touchmove-event-listener-on-body.html.ini
+++ b/tests/wpt/meta/dom/events/non-cancelable-when-passive/non-passive-touchmove-event-listener-on-body.html.ini
@@ -1,3 +1,0 @@
-[non-passive-touchmove-event-listener-on-body.html]
-  [non-passive touchmove event listener on body]
-    expected: FAIL

--- a/tests/wpt/meta/dom/events/non-cancelable-when-passive/non-passive-touchmove-event-listener-on-div.html.ini
+++ b/tests/wpt/meta/dom/events/non-cancelable-when-passive/non-passive-touchmove-event-listener-on-div.html.ini
@@ -1,3 +1,0 @@
-[non-passive-touchmove-event-listener-on-div.html]
-  [non-passive touchmove event listener on div]
-    expected: FAIL

--- a/tests/wpt/meta/dom/events/non-cancelable-when-passive/non-passive-touchmove-event-listener-on-document.html.ini
+++ b/tests/wpt/meta/dom/events/non-cancelable-when-passive/non-passive-touchmove-event-listener-on-document.html.ini
@@ -1,3 +1,0 @@
-[non-passive-touchmove-event-listener-on-document.html]
-  [non-passive touchmove event listener on document]
-    expected: FAIL

--- a/tests/wpt/meta/dom/events/non-cancelable-when-passive/non-passive-touchmove-event-listener-on-root.html.ini
+++ b/tests/wpt/meta/dom/events/non-cancelable-when-passive/non-passive-touchmove-event-listener-on-root.html.ini
@@ -1,3 +1,0 @@
-[non-passive-touchmove-event-listener-on-root.html]
-  [non-passive touchmove event listener on root]
-    expected: FAIL

--- a/tests/wpt/meta/dom/events/scrolling/overscroll-event-fired-to-scrolled-element.tentative.html.ini
+++ b/tests/wpt/meta/dom/events/scrolling/overscroll-event-fired-to-scrolled-element.tentative.html.ini
@@ -1,4 +1,4 @@
 [overscroll-event-fired-to-scrolled-element.tentative.html]
-  expected: TIMEOUT
+  expected: CRASH
   [Tests that the scrolled element gets overscroll event after fully scrolling by touch.]
     expected: TIMEOUT

--- a/tests/wpt/meta/dom/events/scrolling/scrollend-event-fired-after-snap.html.ini
+++ b/tests/wpt/meta/dom/events/scrolling/scrollend-event-fired-after-snap.html.ini
@@ -1,5 +1,5 @@
 [scrollend-event-fired-after-snap.html]
-  expected: TIMEOUT
+  expected: CRASH
   [Tests that scrollend is fired after scroll snap animation completion.]
     expected: TIMEOUT
 

--- a/tests/wpt/meta/dom/events/scrolling/scrollend-event-fires-on-visual-viewport.html.ini
+++ b/tests/wpt/meta/dom/events/scrolling/scrollend-event-fires-on-visual-viewport.html.ini
@@ -1,2 +1,2 @@
 [scrollend-event-fires-on-visual-viewport.html]
-  expected: ERROR
+  expected: CRASH

--- a/tests/wpt/meta/pointerevents/coalesced_events_attributes_on_redispatch.https.html.ini
+++ b/tests/wpt/meta/pointerevents/coalesced_events_attributes_on_redispatch.https.html.ini
@@ -5,12 +5,12 @@
 
 
 [coalesced_events_attributes_on_redispatch.https.html?pen]
-  expected: TIMEOUT
+  expected: CRASH
   [Coalesced list in pointerdown/move/up events]
     expected: TIMEOUT
 
 
 [coalesced_events_attributes_on_redispatch.https.html?touch]
-  expected: TIMEOUT
+  expected: CRASH
   [Coalesced list in pointerdown/move/up events]
     expected: TIMEOUT

--- a/tests/wpt/meta/pointerevents/coalesced_events_attributes_under_load.https.optional.html.ini
+++ b/tests/wpt/meta/pointerevents/coalesced_events_attributes_under_load.https.optional.html.ini
@@ -5,12 +5,12 @@
 
 
 [coalesced_events_attributes_under_load.https.optional.html?touch]
-  expected: TIMEOUT
+  expected: CRASH
   [Coalesced pointermoves under load]
     expected: TIMEOUT
 
 
 [coalesced_events_attributes_under_load.https.optional.html?pen]
-  expected: TIMEOUT
+  expected: CRASH
   [Coalesced pointermoves under load]
     expected: TIMEOUT

--- a/tests/wpt/meta/pointerevents/compat/pointerevent_touch_target_after_pointerdown_target_removed.tentative.html.ini
+++ b/tests/wpt/meta/pointerevents/compat/pointerevent_touch_target_after_pointerdown_target_removed.tentative.html.ini
@@ -1,4 +1,5 @@
 [pointerevent_touch_target_after_pointerdown_target_removed.tentative.html]
+  expected: CRASH
   [After a pointerdown listener removes its target, touch events should be fired on the touchstart target even though an orphan and pointer events should be fired on the parent]
     expected: FAIL
 

--- a/tests/wpt/meta/pointerevents/pointerevent_boundary_events_in_capturing.html.ini
+++ b/tests/wpt/meta/pointerevents/pointerevent_boundary_events_in_capturing.html.ini
@@ -1,5 +1,5 @@
 [pointerevent_boundary_events_in_capturing.html?pen]
-  expected: TIMEOUT
+  expected: CRASH
   [Boundary events around pointer capture and release]
     expected: TIMEOUT
 
@@ -11,6 +11,6 @@
 
 
 [pointerevent_boundary_events_in_capturing.html?touch]
-  expected: TIMEOUT
+  expected: CRASH
   [Boundary events around pointer capture and release]
     expected: TIMEOUT

--- a/tests/wpt/meta/pointerevents/pointerevent_capture_touch_and_release_at_got_capture.html.ini
+++ b/tests/wpt/meta/pointerevents/pointerevent_capture_touch_and_release_at_got_capture.html.ini
@@ -1,3 +1,4 @@
 [pointerevent_capture_touch_and_release_at_got_capture.html]
+  expected: CRASH
   [A pointerout should be fired on the capturing element after losing the capture]
     expected: FAIL

--- a/tests/wpt/meta/pointerevents/pointerevent_change-touch-action-onpointerdown_touch.html.ini
+++ b/tests/wpt/meta/pointerevents/pointerevent_change-touch-action-onpointerdown_touch.html.ini
@@ -1,3 +1,4 @@
 [pointerevent_change-touch-action-onpointerdown_touch.html]
+  expected: CRASH
   [scroll should be received before the test finishes]
     expected: FAIL

--- a/tests/wpt/meta/pointerevents/pointerevent_disabled_form_control.html.ini
+++ b/tests/wpt/meta/pointerevents/pointerevent_disabled_form_control.html.ini
@@ -5,7 +5,7 @@
 
 
 [pointerevent_disabled_form_control.html?touch]
-  expected: TIMEOUT
+  expected: CRASH
   [touch pointerevent attributes]
     expected: NOTRUN
 

--- a/tests/wpt/meta/pointerevents/pointerevent_element_haspointercapture.html.ini
+++ b/tests/wpt/meta/pointerevents/pointerevent_element_haspointercapture.html.ini
@@ -1,11 +1,11 @@
 [pointerevent_element_haspointercapture.html?touch]
-  expected: TIMEOUT
+  expected: CRASH
   [hasPointerCapture]
     expected: NOTRUN
 
 
 [pointerevent_element_haspointercapture.html?pen]
-  expected: TIMEOUT
+  expected: CRASH
   [hasPointerCapture]
     expected: NOTRUN
 

--- a/tests/wpt/meta/pointerevents/pointerevent_fractional_coordinates.html.ini
+++ b/tests/wpt/meta/pointerevents/pointerevent_fractional_coordinates.html.ini
@@ -1,4 +1,5 @@
 [pointerevent_fractional_coordinates.html?touch]
+  expected: CRASH
   [touch]
     expected: FAIL
 

--- a/tests/wpt/meta/pointerevents/pointerevent_pointercancel_touch.html.ini
+++ b/tests/wpt/meta/pointerevents/pointerevent_pointercancel_touch.html.ini
@@ -1,4 +1,4 @@
 [pointerevent_pointercancel_touch.html]
-  expected: TIMEOUT
+  expected: CRASH
   [pointercancel event received]
     expected: NOTRUN

--- a/tests/wpt/meta/pointerevents/pointerevent_pointerleave_after_pointercancel_touch.html.ini
+++ b/tests/wpt/meta/pointerevents/pointerevent_pointerleave_after_pointercancel_touch.html.ini
@@ -1,4 +1,4 @@
 [pointerevent_pointerleave_after_pointercancel_touch.html]
-  expected: TIMEOUT
+  expected: CRASH
   [pointerleave event received]
     expected: NOTRUN

--- a/tests/wpt/meta/pointerevents/pointerevent_pointermove_isprimary_same_as_pointerdown.html.ini
+++ b/tests/wpt/meta/pointerevents/pointerevent_pointermove_isprimary_same_as_pointerdown.html.ini
@@ -5,6 +5,6 @@
 
 
 [pointerevent_pointermove_isprimary_same_as_pointerdown.html?touch]
-  expected: TIMEOUT
+  expected: CRASH
   [pointermove has same isPrimary as last pointerdown]
     expected: NOTRUN

--- a/tests/wpt/meta/pointerevents/pointerevent_pointerout_after_pointercancel_touch.html.ini
+++ b/tests/wpt/meta/pointerevents/pointerevent_pointerout_after_pointercancel_touch.html.ini
@@ -1,4 +1,4 @@
 [pointerevent_pointerout_after_pointercancel_touch.html]
-  expected: TIMEOUT
+  expected: CRASH
   [pointerout event received]
     expected: NOTRUN

--- a/tests/wpt/meta/pointerevents/pointerevent_pointerrawupdate_coalesced_events_attributes.https.html.ini
+++ b/tests/wpt/meta/pointerevents/pointerevent_pointerrawupdate_coalesced_events_attributes.https.html.ini
@@ -5,12 +5,12 @@
 
 
 [pointerevent_pointerrawupdate_coalesced_events_attributes.https.html?pen]
-  expected: TIMEOUT
+  expected: CRASH
   [Simple test for getCoalescedEvents() of `pointerrawupdate`]
     expected: TIMEOUT
 
 
 [pointerevent_pointerrawupdate_coalesced_events_attributes.https.html?touch]
-  expected: TIMEOUT
+  expected: CRASH
   [Simple test for getCoalescedEvents() of `pointerrawupdate`]
     expected: TIMEOUT

--- a/tests/wpt/meta/pointerevents/pointerevent_range_input.html.ini
+++ b/tests/wpt/meta/pointerevents/pointerevent_range_input.html.ini
@@ -17,7 +17,7 @@
 
 
 [pointerevent_range_input.html?touch]
-  expected: TIMEOUT
+  expected: CRASH
   [Horizontal drag on a horizontal slider.]
     expected: TIMEOUT
 

--- a/tests/wpt/meta/pointerevents/pointerevent_releasepointercapture_events_to_original_target.html.ini
+++ b/tests/wpt/meta/pointerevents/pointerevent_releasepointercapture_events_to_original_target.html.ini
@@ -1,5 +1,5 @@
 [pointerevent_releasepointercapture_events_to_original_target.html?pen]
-  expected: TIMEOUT
+  expected: CRASH
   [pen got/lost pointercapture: subsequent events to target]
     expected: NOTRUN
 
@@ -11,6 +11,6 @@
 
 
 [pointerevent_releasepointercapture_events_to_original_target.html?touch]
-  expected: TIMEOUT
+  expected: CRASH
   [touch got/lost pointercapture: subsequent events to target]
     expected: NOTRUN

--- a/tests/wpt/meta/pointerevents/pointerevent_releasepointercapture_onpointercancel_touch.html.ini
+++ b/tests/wpt/meta/pointerevents/pointerevent_releasepointercapture_onpointercancel_touch.html.ini
@@ -1,4 +1,4 @@
 [pointerevent_releasepointercapture_onpointercancel_touch.html]
-  expected: TIMEOUT
+  expected: CRASH
   [pointer capture is released on pointercancel]
     expected: NOTRUN

--- a/tests/wpt/meta/pointerevents/pointerevent_releasepointercapture_pointerup_touch.html.ini
+++ b/tests/wpt/meta/pointerevents/pointerevent_releasepointercapture_pointerup_touch.html.ini
@@ -1,4 +1,4 @@
 [pointerevent_releasepointercapture_pointerup_touch.html]
-  expected: TIMEOUT
+  expected: CRASH
   [releasePointerCapture on pointerup]
     expected: NOTRUN

--- a/tests/wpt/meta/pointerevents/pointerevent_releasepointercapture_release_right_after_capture.html.ini
+++ b/tests/wpt/meta/pointerevents/pointerevent_releasepointercapture_release_right_after_capture.html.ini
@@ -1,11 +1,11 @@
 [pointerevent_releasepointercapture_release_right_after_capture.html?touch]
-  expected: TIMEOUT
+  expected: CRASH
   [Release pointer capture right after setpointercapture]
     expected: NOTRUN
 
 
 [pointerevent_releasepointercapture_release_right_after_capture.html?pen]
-  expected: TIMEOUT
+  expected: CRASH
   [Release pointer capture right after setpointercapture]
     expected: NOTRUN
 

--- a/tests/wpt/meta/pointerevents/pointerevent_sequence_at_implicit_release_on_drag.html.ini
+++ b/tests/wpt/meta/pointerevents/pointerevent_sequence_at_implicit_release_on_drag.html.ini
@@ -1,3 +1,4 @@
 [pointerevent_sequence_at_implicit_release_on_drag.html]
+  expected: CRASH
   [touch Event sequence at implicit release on drag]
     expected: FAIL

--- a/tests/wpt/meta/pointerevents/pointerevent_setpointercapture_override_pending_capture_element.html.ini
+++ b/tests/wpt/meta/pointerevents/pointerevent_setpointercapture_override_pending_capture_element.html.ini
@@ -5,12 +5,12 @@
 
 
 [pointerevent_setpointercapture_override_pending_capture_element.html?pen]
-  expected: TIMEOUT
+  expected: CRASH
   [setPointerCapture: override the pending pointer capture element]
     expected: NOTRUN
 
 
 [pointerevent_setpointercapture_override_pending_capture_element.html?touch]
-  expected: TIMEOUT
+  expected: CRASH
   [setPointerCapture: override the pending pointer capture element]
     expected: NOTRUN

--- a/tests/wpt/meta/pointerevents/pointerevent_setpointercapture_to_same_element_twice.html.ini
+++ b/tests/wpt/meta/pointerevents/pointerevent_setpointercapture_to_same_element_twice.html.ini
@@ -1,4 +1,5 @@
 [pointerevent_setpointercapture_to_same_element_twice.html?pen]
+  expected: CRASH
   [A repeated setPointerCapture call does not redispatch capture events]
     expected: FAIL
 
@@ -15,6 +16,7 @@
 
 
 [pointerevent_setpointercapture_to_same_element_twice.html?touch]
+  expected: CRASH
   [A repeated setPointerCapture call does not redispatch capture events]
     expected: FAIL
 

--- a/tests/wpt/meta/pointerevents/pointerevent_touch-action-auto-css_touch.html.ini
+++ b/tests/wpt/meta/pointerevents/pointerevent_touch-action-auto-css_touch.html.ini
@@ -1,4 +1,4 @@
 [pointerevent_touch-action-auto-css_touch.html]
-  expected: TIMEOUT
+  expected: CRASH
   [touch-action attribute test]
     expected: NOTRUN

--- a/tests/wpt/meta/pointerevents/pointerevent_touch-action-button-none-test_touch.html.ini
+++ b/tests/wpt/meta/pointerevents/pointerevent_touch-action-button-none-test_touch.html.ini
@@ -1,0 +1,2 @@
+[pointerevent_touch-action-button-none-test_touch.html]
+  expected: CRASH

--- a/tests/wpt/meta/pointerevents/pointerevent_touch-action-inherit_child-auto-child-none_touch.html.ini
+++ b/tests/wpt/meta/pointerevents/pointerevent_touch-action-inherit_child-auto-child-none_touch.html.ini
@@ -1,4 +1,4 @@
 [pointerevent_touch-action-inherit_child-auto-child-none_touch.html]
-  expected: ERROR
+  expected: CRASH
   [touch-action attribute test]
     expected: NOTRUN

--- a/tests/wpt/meta/pointerevents/pointerevent_touch-action-inherit_child-none_touch.html.ini
+++ b/tests/wpt/meta/pointerevents/pointerevent_touch-action-inherit_child-none_touch.html.ini
@@ -1,4 +1,4 @@
 [pointerevent_touch-action-inherit_child-none_touch.html]
-  expected: ERROR
+  expected: CRASH
   [touch-action attribute test]
     expected: NOTRUN

--- a/tests/wpt/meta/pointerevents/pointerevent_touch-action-inherit_child-pan-x-child-pan-x_touch.html.ini
+++ b/tests/wpt/meta/pointerevents/pointerevent_touch-action-inherit_child-pan-x-child-pan-x_touch.html.ini
@@ -1,4 +1,4 @@
 [pointerevent_touch-action-inherit_child-pan-x-child-pan-x_touch.html]
-  expected: ERROR
+  expected: CRASH
   [touch-action attribute test]
     expected: NOTRUN

--- a/tests/wpt/meta/pointerevents/pointerevent_touch-action-inherit_child-pan-x-child-pan-y_touch.html.ini
+++ b/tests/wpt/meta/pointerevents/pointerevent_touch-action-inherit_child-pan-x-child-pan-y_touch.html.ini
@@ -1,4 +1,4 @@
 [pointerevent_touch-action-inherit_child-pan-x-child-pan-y_touch.html]
-  expected: ERROR
+  expected: CRASH
   [touch-action attribute test]
     expected: NOTRUN

--- a/tests/wpt/meta/pointerevents/pointerevent_touch-action-inherit_highest-parent-none_touch.html.ini
+++ b/tests/wpt/meta/pointerevents/pointerevent_touch-action-inherit_highest-parent-none_touch.html.ini
@@ -1,4 +1,4 @@
 [pointerevent_touch-action-inherit_highest-parent-none_touch.html]
-  expected: TIMEOUT
+  expected: CRASH
   [touch-action attribute test]
     expected: NOTRUN

--- a/tests/wpt/meta/pointerevents/pointerevent_touch-action-modified_touch.html.ini
+++ b/tests/wpt/meta/pointerevents/pointerevent_touch-action-modified_touch.html.ini
@@ -1,4 +1,4 @@
 [pointerevent_touch-action-modified_touch.html]
-  expected: TIMEOUT
+  expected: CRASH
   [No scrolling after deleting touch-action:none after pointerdown]
     expected: TIMEOUT

--- a/tests/wpt/meta/pointerevents/pointerevent_touch-action-none-css_touch.html.ini
+++ b/tests/wpt/meta/pointerevents/pointerevent_touch-action-none-css_touch.html.ini
@@ -1,4 +1,4 @@
 [pointerevent_touch-action-none-css_touch.html]
-  expected: ERROR
+  expected: CRASH
   [touch-action attribute test]
     expected: NOTRUN

--- a/tests/wpt/meta/pointerevents/pointerevent_touch-action-none-on-body-when-style-propagates-to-viewport_touch.html.ini
+++ b/tests/wpt/meta/pointerevents/pointerevent_touch-action-none-on-body-when-style-propagates-to-viewport_touch.html.ini
@@ -1,0 +1,2 @@
+[pointerevent_touch-action-none-on-body-when-style-propagates-to-viewport_touch.html]
+  expected: CRASH

--- a/tests/wpt/meta/pointerevents/pointerevent_touch-action-pan-down-css_touch.html.ini
+++ b/tests/wpt/meta/pointerevents/pointerevent_touch-action-pan-down-css_touch.html.ini
@@ -1,4 +1,4 @@
 [pointerevent_touch-action-pan-down-css_touch.html]
-  expected: ERROR
+  expected: CRASH
   [touch-action attribute test]
     expected: NOTRUN

--- a/tests/wpt/meta/pointerevents/pointerevent_touch-action-pan-left-css_touch.html.ini
+++ b/tests/wpt/meta/pointerevents/pointerevent_touch-action-pan-left-css_touch.html.ini
@@ -1,4 +1,4 @@
 [pointerevent_touch-action-pan-left-css_touch.html]
-  expected: ERROR
+  expected: CRASH
   [touch-action attribute test]
     expected: NOTRUN

--- a/tests/wpt/meta/pointerevents/pointerevent_touch-action-pan-right-css_touch.html.ini
+++ b/tests/wpt/meta/pointerevents/pointerevent_touch-action-pan-right-css_touch.html.ini
@@ -1,4 +1,4 @@
 [pointerevent_touch-action-pan-right-css_touch.html]
-  expected: ERROR
+  expected: CRASH
   [touch-action attribute test]
     expected: NOTRUN

--- a/tests/wpt/meta/pointerevents/pointerevent_touch-action-pan-up-css_touch.html.ini
+++ b/tests/wpt/meta/pointerevents/pointerevent_touch-action-pan-up-css_touch.html.ini
@@ -1,4 +1,4 @@
 [pointerevent_touch-action-pan-up-css_touch.html]
-  expected: ERROR
+  expected: CRASH
   [touch-action attribute test]
     expected: NOTRUN

--- a/tests/wpt/meta/pointerevents/pointerevent_touch-action-pan-x-css_touch.html.ini
+++ b/tests/wpt/meta/pointerevents/pointerevent_touch-action-pan-x-css_touch.html.ini
@@ -1,4 +1,4 @@
 [pointerevent_touch-action-pan-x-css_touch.html]
-  expected: ERROR
+  expected: CRASH
   [touch-action attribute test]
     expected: NOTRUN

--- a/tests/wpt/meta/pointerevents/pointerevent_touch-action-pan-x-pan-y-pan-y_touch.html.ini
+++ b/tests/wpt/meta/pointerevents/pointerevent_touch-action-pan-x-pan-y-pan-y_touch.html.ini
@@ -1,4 +1,4 @@
 [pointerevent_touch-action-pan-x-pan-y-pan-y_touch.html]
-  expected: ERROR
+  expected: CRASH
   [touch-action attribute test]
     expected: NOTRUN

--- a/tests/wpt/meta/pointerevents/pointerevent_touch-action-pan-x-pan-y_touch.html.ini
+++ b/tests/wpt/meta/pointerevents/pointerevent_touch-action-pan-x-pan-y_touch.html.ini
@@ -1,4 +1,4 @@
 [pointerevent_touch-action-pan-x-pan-y_touch.html]
-  expected: TIMEOUT
+  expected: CRASH
   [touch-action attribute test]
     expected: NOTRUN

--- a/tests/wpt/meta/pointerevents/pointerevent_touch-action-pan-y-css_touch.html.ini
+++ b/tests/wpt/meta/pointerevents/pointerevent_touch-action-pan-y-css_touch.html.ini
@@ -1,4 +1,4 @@
 [pointerevent_touch-action-pan-y-css_touch.html]
-  expected: ERROR
+  expected: CRASH
   [touch-action attribute test]
     expected: NOTRUN

--- a/tests/wpt/meta/pointerevents/pointerevent_touch-action-span-none-test_touch.html.ini
+++ b/tests/wpt/meta/pointerevents/pointerevent_touch-action-span-none-test_touch.html.ini
@@ -1,3 +1,4 @@
 [pointerevent_touch-action-span-none-test_touch.html]
+  expected: CRASH
   [touch-action attribute test in element]
     expected: FAIL

--- a/tests/wpt/meta/pointerevents/pointerevent_touch-action-table-none-test_touch.html.ini
+++ b/tests/wpt/meta/pointerevents/pointerevent_touch-action-table-none-test_touch.html.ini
@@ -1,5 +1,5 @@
 [pointerevent_touch-action-table-none-test_touch.html]
-  expected: TIMEOUT
+  expected: CRASH
   [touch-action attribute test on the cell]
     expected: FAIL
 

--- a/tests/wpt/meta/pointerevents/pointerevent_touch-propagates-when-target-is-video_touch.html.ini
+++ b/tests/wpt/meta/pointerevents/pointerevent_touch-propagates-when-target-is-video_touch.html.ini
@@ -1,4 +1,4 @@
 [pointerevent_touch-propagates-when-target-is-video_touch.html]
-  expected: TIMEOUT
+  expected: CRASH
   [Touch-generated events should propagate to the parent when a video element is the target]
     expected: TIMEOUT

--- a/tests/wpt/meta/touch-events/multi-touch-interactions.html.ini
+++ b/tests/wpt/meta/touch-events/multi-touch-interactions.html.ini
@@ -1,5 +1,5 @@
 [multi-touch-interactions.html]
-  expected: TIMEOUT
+  expected: CRASH
   [touchmove event received]
     expected: NOTRUN
 

--- a/tests/wpt/meta/touch-events/multi-touch-interfaces.html.ini
+++ b/tests/wpt/meta/touch-events/multi-touch-interfaces.html.ini
@@ -1,5 +1,5 @@
 [multi-touch-interfaces.html]
-  expected: TIMEOUT
+  expected: CRASH
   [touchmove event received]
     expected: NOTRUN
 

--- a/tests/wpt/meta/visual-viewport/page-and-offset-in-iframe.html.ini
+++ b/tests/wpt/meta/visual-viewport/page-and-offset-in-iframe.html.ini
@@ -1,3 +1,4 @@
 [page-and-offset-in-iframe.html]
+  expected: CRASH
   [VisualViewport page and offset values in iframe]
     expected: FAIL

--- a/tests/wpt/meta/visual-viewport/scroll-event-order.html.ini
+++ b/tests/wpt/meta/visual-viewport/scroll-event-order.html.ini
@@ -1,3 +1,4 @@
 [scroll-event-order.html]
+  expected: CRASH
   [Scroll event ordering]
     expected: FAIL

--- a/tests/wpt/meta/webdriver/tests/classic/perform_actions/pointer_pen.py.ini
+++ b/tests/wpt/meta/webdriver/tests/classic/perform_actions/pointer_pen.py.ini
@@ -1,4 +1,5 @@
 [pointer_pen.py]
+  expected: TIMEOUT
   [test_no_browsing_context]
     expected: FAIL
 

--- a/tests/wpt/meta/webdriver/tests/classic/perform_actions/pointer_touch.py.ini
+++ b/tests/wpt/meta/webdriver/tests/classic/perform_actions/pointer_touch.py.ini
@@ -1,4 +1,5 @@
 [pointer_touch.py]
+  expected: TIMEOUT
   [test_no_browsing_context]
     expected: FAIL
 


### PR DESCRIPTION
Fixes: #41725 
Fixes: #41620 

Testing: New passing in 
- `/dom/events/non-cancelable-when-passive/non-passive-touchmove-event-listener-on-body.html`
- `/dom/events/non-cancelable-when-passive/non-passive-touchmove-event-listener-on-div.html`
- `/dom/events/non-cancelable-when-passive/non-passive-touchmove-event-listener-on-document.html`
- `/dom/events/non-cancelable-when-passive/non-passive-touchmove-event-listener-on-root.html`

Crash Explanation: It is not CRASH, but actually no response.
```
 0:26.67 INFO Browser not responding, setting status to CRASH
 0:26.67 TEST_END: CRASH, expected OK
```
These tests never succeeded, mostly due to missing pointer events implementation in Servo. This is unlike https://github.com/servo/servo/pull/41067, where we actually panic. This is another proof that we got it right this time, as we never touchmove without active point now:
https://github.com/servo/servo/blob/271c85910f2aa5f29f13207eb8e3aa7582bfd89b/components/compositing/touch.rs#L436


