### PR TITLE
devtools: Consolidate register/register_later

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2100,6 +2100,7 @@ dependencies = [
 name = "devtools"
 version = "0.0.1"
 dependencies = [
+ "atomic_refcell",
  "base",
  "base64 0.22.1",
  "chrono",

--- a/components/devtools/Cargo.toml
+++ b/components/devtools/Cargo.toml
@@ -12,6 +12,7 @@ name = "devtools"
 path = "lib.rs"
 
 [dependencies]
+atomic_refcell = { workspace = true }
 base = { workspace = true }
 base64 = { workspace = true }
 chrono = { workspace = true }

--- a/components/devtools/actor.rs
+++ b/components/devtools/actor.rs
@@ -48,7 +48,7 @@ impl ActorError {
 /// A common trait for all devtools actors that encompasses an immutable name
 /// and the ability to process messages that are directed to particular actors.
 /// TODO: ensure the name is immutable
-pub(crate) trait Actor: Any + ActorAsAny + Send {
+pub(crate) trait Actor: Any + ActorAsAny + Send + Sync {
     fn handle_message(
         &self,
         request: ClientRequest,

--- a/components/devtools/actor.rs
+++ b/components/devtools/actor.rs
@@ -163,7 +163,12 @@ impl ActorRegistry {
 
     /// Find an actor by registered name
     pub fn find<T: Actor>(&self, name: &str) -> DowncastableActorArc<T> {
-        let actor = self.actors.borrow().get(name).unwrap().clone();
+        let actor = self
+            .actors
+            .borrow()
+            .get(name)
+            .expect("Should never look for a nonexistent actor")
+            .clone();
         DowncastableActorArc {
             actor,
             _phantom: PhantomData,

--- a/components/devtools/actor.rs
+++ b/components/devtools/actor.rs
@@ -5,8 +5,9 @@
 use std::any::{Any, type_name};
 use std::cell::{Cell, RefCell};
 use std::collections::HashMap;
-use std::mem;
+use std::marker::PhantomData;
 use std::net::TcpStream;
+use std::sync::Arc;
 
 use base::id::PipelineId;
 use log::{debug, warn};
@@ -77,25 +78,35 @@ pub(crate) trait ActorEncode<T: Serialize>: Actor {
     fn encode(&self, registry: &ActorRegistry) -> T;
 }
 
+/// Return value of `ActorRegistry::find` that allows seamless downcasting
+/// from `dyn Actor` to the concrete actor type.
+pub struct DowncastableActorArc<T> {
+    actor: Arc<dyn Actor>,
+    _phantom: PhantomData<T>,
+}
+
+impl<T: 'static> std::ops::Deref for DowncastableActorArc<T> {
+    type Target = T;
+    fn deref(&self) -> &Self::Target {
+        self.actor.actor_as_any().downcast_ref::<T>().unwrap()
+    }
+}
+
 /// A list of known, owned actors.
 #[derive(Default)]
 pub struct ActorRegistry {
-    actors: HashMap<String, Box<dyn Actor>>,
-    new_actors: RefCell<Vec<Box<dyn Actor>>>,
-    old_actors: RefCell<Vec<String>>,
+    actors: RefCell<HashMap<String, Arc<dyn Actor>>>,
     script_actors: RefCell<HashMap<String, String>>,
-
     /// Lookup table for SourceActor names associated with a given PipelineId.
     source_actor_names: RefCell<HashMap<PipelineId, Vec<String>>>,
     /// Lookup table for inline source content associated with a given PipelineId.
     inline_source_content: RefCell<HashMap<PipelineId, String>>,
-
     next: Cell<u32>,
 }
 
 impl ActorRegistry {
     pub(crate) fn cleanup(&self, stream_id: StreamId) {
-        for actor in self.actors.values() {
+        for actor in self.actors.borrow().values() {
             actor.cleanup(stream_id);
         }
     }
@@ -144,21 +155,19 @@ impl ActorRegistry {
     }
 
     /// Add an actor to the registry of known actors that can receive messages.
-    pub(crate) fn register<T: Actor>(&mut self, actor: T) {
-        self.actors.insert(actor.name(), Box::new(actor));
-    }
-
-    /// Add an actor to the registry that can receive messages.
-    /// It won't be available until after the next message is processed.
-    pub(crate) fn register_later<T: Actor>(&self, actor: T) {
-        let mut actors = self.new_actors.borrow_mut();
-        actors.push(Box::new(actor));
+    pub(crate) fn register<T: Actor>(&self, actor: T) {
+        self.actors
+            .borrow_mut()
+            .insert(actor.name(), Arc::new(actor));
     }
 
     /// Find an actor by registered name
-    pub fn find<'a, T: Any>(&'a self, name: &str) -> &'a T {
-        let actor = self.actors.get(name).unwrap();
-        actor.actor_as_any().downcast_ref::<T>().unwrap()
+    pub fn find<T: Actor>(&self, name: &str) -> DowncastableActorArc<T> {
+        let actor = self.actors.borrow().get(name).unwrap().clone();
+        DowncastableActorArc {
+            actor,
+            _phantom: PhantomData,
+        }
     }
 
     /// Find an actor by registered name and return its serialization
@@ -169,7 +178,7 @@ impl ActorRegistry {
     /// Attempt to process a message as directed by its `to` property. If the actor is not found, does not support the
     /// message, or failed to handle the message, send an error reply instead.
     pub(crate) fn handle_message(
-        &mut self,
+        &self,
         msg: &Map<String, Value>,
         stream: &mut TcpStream,
         stream_id: StreamId,
@@ -182,7 +191,11 @@ impl ActorRegistry {
             },
         };
 
-        match self.actors.get(to) {
+        let actor = {
+            let actors_map = self.actors.borrow();
+            actors_map.get(to).cloned()
+        };
+        match actor {
             None => {
                 // <https://firefox-source-docs.mozilla.org/devtools/backend/protocol.html#packets>
                 let msg = json!({ "from": to, "error": "noSuchActor" });
@@ -202,25 +215,11 @@ impl ActorRegistry {
                 }
             },
         }
-        let new_actors = mem::take(&mut *self.new_actors.borrow_mut());
-        for actor in new_actors.into_iter() {
-            self.actors.insert(actor.name().to_owned(), actor);
-        }
-
-        let old_actors = mem::take(&mut *self.old_actors.borrow_mut());
-        for name in old_actors {
-            self.drop_actor(name);
-        }
         Ok(())
     }
 
-    pub fn drop_actor(&mut self, name: String) {
-        self.actors.remove(&name);
-    }
-
-    pub fn drop_actor_later(&self, name: String) {
-        let mut actors = self.old_actors.borrow_mut();
-        actors.push(name);
+    pub fn remove(&self, name: String) {
+        self.actors.borrow_mut().remove(&name);
     }
 
     pub fn register_source_actor(&self, pipeline_id: PipelineId, actor_name: &str) {
@@ -231,15 +230,15 @@ impl ActorRegistry {
             .push(actor_name.to_owned());
     }
 
-    pub fn source_actor_names_for_pipeline(&mut self, pipeline_id: PipelineId) -> Vec<String> {
-        if let Some(source_actor_names) = self.source_actor_names.borrow_mut().get(&pipeline_id) {
-            return source_actor_names.clone();
-        }
-
-        vec![]
+    pub fn source_actor_names_for_pipeline(&self, pipeline_id: PipelineId) -> Vec<String> {
+        self.source_actor_names
+            .borrow_mut()
+            .get(&pipeline_id)
+            .cloned()
+            .unwrap_or_default()
     }
 
-    pub fn set_inline_source_content(&mut self, pipeline_id: PipelineId, content: String) {
+    pub fn set_inline_source_content(&self, pipeline_id: PipelineId, content: String) {
         assert!(
             self.inline_source_content
                 .borrow_mut()
@@ -248,7 +247,7 @@ impl ActorRegistry {
         );
     }
 
-    pub fn inline_source_content(&mut self, pipeline_id: PipelineId) -> Option<String> {
+    pub fn inline_source_content(&self, pipeline_id: PipelineId) -> Option<String> {
         self.inline_source_content
             .borrow()
             .get(&pipeline_id)

--- a/components/devtools/actors/browsing_context.rs
+++ b/components/devtools/actors/browsing_context.rs
@@ -337,11 +337,11 @@ impl BrowsingContextActor {
             .map_err(|_| ())
     }
 
-    pub fn pipeline_id(&self) -> PipelineId {
+    pub(crate) fn pipeline_id(&self) -> PipelineId {
         *self.active_pipeline_id.borrow()
     }
 
-    pub fn outer_window_id(&self) -> DevtoolsOuterWindowId {
+    pub(crate) fn outer_window_id(&self) -> DevtoolsOuterWindowId {
         *self.active_outer_window_id.borrow()
     }
 }

--- a/components/devtools/actors/browsing_context.rs
+++ b/components/devtools/actors/browsing_context.rs
@@ -210,7 +210,7 @@ impl BrowsingContextActor {
         pipeline_id: PipelineId,
         outer_window_id: DevtoolsOuterWindowId,
         script_sender: GenericSender<DevtoolScriptControlMsg>,
-        actors: &mut ActorRegistry,
+        actors: &ActorRegistry,
     ) -> BrowsingContextActor {
         let name = actors.new_name::<BrowsingContextActor>();
         let DevtoolsPageInfo {

--- a/components/devtools/actors/console.rs
+++ b/components/devtools/actors/console.rs
@@ -138,13 +138,15 @@ pub(crate) struct ConsoleActor {
 }
 
 impl ConsoleActor {
-    fn script_chan<'a>(
-        &self,
-        registry: &'a ActorRegistry,
-    ) -> &'a GenericSender<DevtoolScriptControlMsg> {
+    fn script_chan(&self, registry: &ActorRegistry) -> GenericSender<DevtoolScriptControlMsg> {
         match &self.root {
-            Root::BrowsingContext(bc) => &registry.find::<BrowsingContextActor>(bc).script_chan,
-            Root::DedicatedWorker(worker) => &registry.find::<WorkerActor>(worker).script_chan,
+            Root::BrowsingContext(bc) => registry
+                .find::<BrowsingContextActor>(bc)
+                .script_chan
+                .clone(),
+            Root::DedicatedWorker(worker) => {
+                registry.find::<WorkerActor>(worker).script_chan.clone()
+            },
         }
     }
 

--- a/components/devtools/actors/console.rs
+++ b/components/devtools/actors/console.rs
@@ -140,8 +140,8 @@ pub(crate) struct ConsoleActor {
 impl ConsoleActor {
     fn script_chan(&self, registry: &ActorRegistry) -> GenericSender<DevtoolScriptControlMsg> {
         match &self.root {
-            Root::BrowsingContext(bc) => registry
-                .find::<BrowsingContextActor>(bc)
+            Root::BrowsingContext(browsing_context) => registry
+                .find::<BrowsingContextActor>(browsing_context)
                 .script_chan
                 .clone(),
             Root::DedicatedWorker(worker) => {
@@ -152,10 +152,14 @@ impl ConsoleActor {
 
     fn current_unique_id(&self, registry: &ActorRegistry) -> UniqueId {
         match &self.root {
-            Root::BrowsingContext(bc) => {
-                UniqueId::Pipeline(registry.find::<BrowsingContextActor>(bc).pipeline_id())
+            Root::BrowsingContext(browsing_context) => UniqueId::Pipeline(
+                registry
+                    .find::<BrowsingContextActor>(browsing_context)
+                    .pipeline_id(),
+            ),
+            Root::DedicatedWorker(worker) => {
+                UniqueId::Worker(registry.find::<WorkerActor>(worker).worker_id)
             },
-            Root::DedicatedWorker(w) => UniqueId::Worker(registry.find::<WorkerActor>(w).worker_id),
         }
     }
 

--- a/components/devtools/actors/frame.rs
+++ b/components/devtools/actors/frame.rs
@@ -81,7 +81,7 @@ impl Actor for FrameActor {
                     from: self.name(),
                     environment: environment.encode(registry),
                 };
-                registry.register_later(environment);
+                registry.register(environment);
                 request.reply_final(&msg)?
             },
             _ => return Err(ActorError::UnrecognizedPacketType),

--- a/components/devtools/actors/framerate.rs
+++ b/components/devtools/actors/framerate.rs
@@ -42,7 +42,7 @@ impl FramerateActor {
         };
 
         actor.start_recording();
-        registry.register_later(actor);
+        registry.register(actor);
         actor_name
     }
 

--- a/components/devtools/actors/framerate.rs
+++ b/components/devtools/actors/framerate.rs
@@ -2,8 +2,9 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-use std::cell::RefCell;
+use std::mem;
 
+use atomic_refcell::AtomicRefCell;
 use base::generic_channel::GenericSender;
 use base::id::PipelineId;
 use devtools_traits::DevtoolScriptControlMsg;
@@ -16,7 +17,7 @@ pub struct FramerateActor {
     pipeline_id: PipelineId,
     script_sender: GenericSender<DevtoolScriptControlMsg>,
     is_recording: bool,
-    ticks: RefCell<Vec<HighResolutionStamp>>,
+    ticks: AtomicRefCell<Vec<HighResolutionStamp>>,
 }
 
 impl Actor for FramerateActor {
@@ -58,7 +59,7 @@ impl FramerateActor {
     }
 
     pub fn take_pending_ticks(&self) -> Vec<HighResolutionStamp> {
-        self.ticks.take()
+        mem::take(&mut self.ticks.borrow_mut())
     }
 
     fn start_recording(&mut self) {

--- a/components/devtools/actors/inspector.rs
+++ b/components/devtools/actors/inspector.rs
@@ -116,7 +116,7 @@ impl InspectorActor {
     // TODO: Passing the pipeline id here isn't correct. We should query the browsing
     // context for the active pipeline, otherwise reloading or navigating will break the inspector.
     pub fn register(
-        registry: &mut ActorRegistry,
+        registry: &ActorRegistry,
         pipeline: PipelineId,
         script_chan: GenericSender<DevtoolScriptControlMsg>,
     ) -> String {

--- a/components/devtools/actors/inspector.rs
+++ b/components/devtools/actors/inspector.rs
@@ -4,8 +4,7 @@
 
 //! Liberally derived from the [Firefox JS implementation](http://mxr.mozilla.org/mozilla-central/source/toolkit/devtools/server/actors/inspector.js).
 
-use std::cell::RefCell;
-
+use atomic_refcell::AtomicRefCell;
 use base::generic_channel::GenericSender;
 use base::id::PipelineId;
 use devtools_traits::DevtoolScriptControlMsg;
@@ -134,7 +133,7 @@ impl InspectorActor {
 
         let walker = WalkerActor {
             name: registry.new_name::<WalkerActor>(),
-            mutations: RefCell::new(vec![]),
+            mutations: AtomicRefCell::new(vec![]),
             script_chan,
             pipeline,
         };

--- a/components/devtools/actors/inspector/accessibility.rs
+++ b/components/devtools/actors/inspector/accessibility.rs
@@ -90,7 +90,7 @@ impl Actor for AccessibilityActor {
             "getSimulator" => {
                 // TODO: Create actual simulator
                 let actor = registry.new_name::<SimulatorActor>();
-                registry.register_later(SimulatorActor {
+                registry.register(SimulatorActor {
                     name: actor.clone(),
                 });
                 let msg = GetSimulatorReply {
@@ -111,7 +111,7 @@ impl Actor for AccessibilityActor {
             "getWalker" => {
                 // TODO: Create actual accessible walker
                 let actor = registry.new_name::<AccessibleWalkerActor>();
-                registry.register_later(AccessibleWalkerActor {
+                registry.register(AccessibleWalkerActor {
                     name: actor.clone(),
                 });
                 let msg = GetWalkerReply {

--- a/components/devtools/actors/inspector/node.rs
+++ b/components/devtools/actors/inspector/node.rs
@@ -5,9 +5,9 @@
 //! This actor represents one DOM node. It is created by the Walker actor when it is traversing the
 //! document tree.
 
-use std::cell::RefCell;
 use std::collections::HashMap;
 
+use atomic_refcell::AtomicRefCell;
 use base::generic_channel::{self, GenericSender};
 use base::id::PipelineId;
 use devtools_traits::{DevtoolScriptControlMsg, NodeInfo, ShadowRootMode};
@@ -104,7 +104,7 @@ pub struct NodeActor {
     pub script_chan: GenericSender<DevtoolScriptControlMsg>,
     pub pipeline: PipelineId,
     pub walker: String,
-    pub style_rules: RefCell<HashMap<(String, usize), String>>,
+    pub style_rules: AtomicRefCell<HashMap<(String, usize), String>>,
 }
 
 impl Actor for NodeActor {
@@ -238,7 +238,7 @@ impl NodeInfoToProtocol for NodeInfo {
                     script_chan: script_chan.clone(),
                     pipeline,
                     walker: walker.clone(),
-                    style_rules: RefCell::new(HashMap::new()),
+                    style_rules: AtomicRefCell::new(HashMap::new()),
                 };
                 actors.register(node_actor);
                 name

--- a/components/devtools/actors/inspector/node.rs
+++ b/components/devtools/actors/inspector/node.rs
@@ -240,7 +240,7 @@ impl NodeInfoToProtocol for NodeInfo {
                     walker: walker.clone(),
                     style_rules: RefCell::new(HashMap::new()),
                 };
-                actors.register_later(node_actor);
+                actors.register(node_actor);
                 name
             } else {
                 actors.script_to_actor(id.to_string())

--- a/components/devtools/actors/inspector/page_style.rs
+++ b/components/devtools/actors/inspector/page_style.rs
@@ -164,7 +164,7 @@ impl PageStyleActor {
                             );
                             let rule = actor.applied(registry)?;
 
-                            registry.register_later(actor);
+                            registry.register(actor);
                             e.insert(name);
                             rule
                         },
@@ -215,7 +215,7 @@ impl PageStyleActor {
                 let name = registry.new_name::<StyleRuleActor>();
                 let actor = StyleRuleActor::new(name.clone(), target.into(), None);
                 let computed = actor.computed(registry)?;
-                registry.register_later(actor);
+                registry.register(actor);
                 e.insert(name);
                 Some(computed)
             },

--- a/components/devtools/actors/inspector/walker.rs
+++ b/components/devtools/actors/inspector/walker.rs
@@ -4,8 +4,7 @@
 
 //! The walker actor is responsible for traversing the DOM tree in various ways to create new nodes
 
-use std::cell::RefCell;
-
+use atomic_refcell::AtomicRefCell;
 use base::generic_channel::{self, GenericSender};
 use base::id::PipelineId;
 use devtools_traits::DevtoolScriptControlMsg::{GetChildren, GetDocumentElement, GetRootNode};
@@ -27,7 +26,7 @@ pub struct WalkerMsg {
 
 pub struct WalkerActor {
     pub name: String,
-    pub mutations: RefCell<Vec<(AttrModification, String)>>,
+    pub mutations: AtomicRefCell<Vec<(AttrModification, String)>>,
     pub pipeline: PipelineId,
     pub script_chan: GenericSender<DevtoolScriptControlMsg>,
 }

--- a/components/devtools/actors/inspector/walker.rs
+++ b/components/devtools/actors/inspector/walker.rs
@@ -199,7 +199,7 @@ impl Actor for WalkerActor {
                 // TODO: Create actual layout inspector actor
                 let layout = LayoutInspectorActor::new(registry.new_name::<LayoutInspectorActor>());
                 let actor = layout.encode(registry);
-                registry.register_later(layout);
+                registry.register(layout);
 
                 let msg = GetLayoutInspectorReply {
                     from: self.name(),

--- a/components/devtools/actors/memory.rs
+++ b/components/devtools/actors/memory.rs
@@ -39,7 +39,7 @@ impl MemoryActor {
             name: actor_name.clone(),
         };
 
-        registry.register_later(actor);
+        registry.register(actor);
         actor_name
     }
 

--- a/components/devtools/actors/network_event.rs
+++ b/components/devtools/actors/network_event.rs
@@ -467,7 +467,7 @@ impl Actor for NetworkEventActor {
                         let body_string = String::from_utf8_lossy(body).to_string();
                         let long_string = LongStringActor::new(registry, body_string);
                         let value = long_string.long_string_obj();
-                        registry.register_later(long_string);
+                        registry.register(long_string);
                         (None, serde_json::to_value(value).unwrap())
                     } else {
                         let b64 = STANDARD.encode(&body.0);

--- a/components/devtools/actors/object.rs
+++ b/components/devtools/actors/object.rs
@@ -51,7 +51,7 @@ impl ObjectActor {
             };
 
             registry.register_script_actor(uuid, name.clone());
-            registry.register_later(actor);
+            registry.register(actor);
 
             name
         } else {

--- a/components/devtools/actors/root.rs
+++ b/components/devtools/actors/root.rs
@@ -9,8 +9,7 @@
 //!
 //! [Firefox JS implementation]: https://searchfox.org/mozilla-central/source/devtools/server/actors/root.js
 
-use std::cell::RefCell;
-
+use atomic_refcell::AtomicRefCell;
 use serde::Serialize;
 use serde_json::{Map, Value, json};
 
@@ -128,11 +127,11 @@ struct GetProcessResponse {
 
 #[derive(Default)]
 pub struct RootActor {
-    active_tab: RefCell<Option<String>>,
+    active_tab: AtomicRefCell<Option<String>>,
     global_actors: GlobalActors,
     process: String,
-    pub tabs: RefCell<Vec<String>>,
-    pub workers: RefCell<Vec<String>>,
+    pub tabs: AtomicRefCell<Vec<String>>,
+    pub workers: AtomicRefCell<Vec<String>>,
 }
 
 impl Actor for RootActor {

--- a/components/devtools/actors/source.rs
+++ b/components/devtools/actors/source.rs
@@ -2,9 +2,9 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-use std::cell::RefCell;
 use std::collections::{BTreeMap, BTreeSet};
 
+use atomic_refcell::AtomicRefCell;
 use base::generic_channel::{GenericSender, channel};
 use base::id::PipelineId;
 use devtools_traits::DevtoolScriptControlMsg;
@@ -40,7 +40,7 @@ pub(crate) struct SourcesReply {
 }
 
 pub(crate) struct SourceManager {
-    source_actor_names: RefCell<BTreeSet<String>>,
+    source_actor_names: AtomicRefCell<BTreeSet<String>>,
 }
 
 #[derive(Clone, Debug)]
@@ -55,7 +55,7 @@ pub struct SourceActor {
     /// <https://firefox-source-docs.mozilla.org/devtools/backend/protocol.html#black-boxing-sources>
     pub is_black_boxed: bool,
 
-    pub content: RefCell<Option<String>>,
+    pub content: AtomicRefCell<Option<String>>,
     pub content_type: Option<String>,
 
     // TODO: use it in #37667, then remove this allow
@@ -95,7 +95,7 @@ struct GetBreakpointPositionsCompressedReply {
 impl SourceManager {
     pub fn new() -> Self {
         Self {
-            source_actor_names: RefCell::new(BTreeSet::default()),
+            source_actor_names: AtomicRefCell::new(BTreeSet::default()),
         }
     }
 
@@ -127,7 +127,7 @@ impl SourceActor {
         SourceActor {
             name,
             url,
-            content: RefCell::new(content),
+            content: AtomicRefCell::new(content),
             content_type,
             is_black_boxed: false,
             spidermonkey_id,

--- a/components/devtools/actors/source.rs
+++ b/components/devtools/actors/source.rs
@@ -138,7 +138,7 @@ impl SourceActor {
 
     #[expect(clippy::too_many_arguments)]
     pub fn new_registered(
-        actors: &mut ActorRegistry,
+        actors: &ActorRegistry,
         pipeline_id: PipelineId,
         url: ServoUrl,
         content: Option<String>,
@@ -146,7 +146,7 @@ impl SourceActor {
         spidermonkey_id: u32,
         introduction_type: String,
         script_sender: GenericSender<DevtoolScriptControlMsg>,
-    ) -> &SourceActor {
+    ) -> String {
         let source_actor_name = actors.new_name::<Self>();
 
         let source_actor = SourceActor::new(
@@ -161,7 +161,7 @@ impl SourceActor {
         actors.register(source_actor);
         actors.register_source_actor(pipeline_id, &source_actor_name);
 
-        actors.find(&source_actor_name)
+        source_actor_name
     }
 
     pub fn source_form(&self) -> SourceForm {

--- a/components/devtools/actors/tab.rs
+++ b/components/devtools/actors/tab.rs
@@ -134,7 +134,7 @@ impl Actor for TabDescriptorActor {
 
 impl TabDescriptorActor {
     pub(crate) fn new(
-        actors: &mut ActorRegistry,
+        actors: &ActorRegistry,
         browsing_context_actor: String,
         is_top_level_global: bool,
     ) -> TabDescriptorActor {

--- a/components/devtools/actors/tab.rs
+++ b/components/devtools/actors/tab.rs
@@ -118,7 +118,7 @@ impl Actor for TabDescriptorActor {
             "reloadDescriptor" => {
                 // There is an extra bypassCache parameter that we don't currently use.
                 let ctx_actor = registry.find::<BrowsingContextActor>(&self.browsing_context_actor);
-                let pipeline = ctx_actor.active_pipeline_id.get();
+                let pipeline = ctx_actor.pipeline_id();
                 ctx_actor
                     .script_chan
                     .send(DevtoolScriptControlMsg::Reload(pipeline))
@@ -168,7 +168,7 @@ impl ActorEncode<TabDescriptorActorMsg> for TabDescriptorActor {
             browser_id: ctx_actor.browser_id.value(),
             browsing_context_id: ctx_actor.browsing_context_id.value(),
             is_zombie_tab: false,
-            outer_window_id: ctx_actor.active_outer_window_id.get().value(),
+            outer_window_id: ctx_actor.outer_window_id().value(),
             selected: false,
             title,
             traits: DescriptorTraits {

--- a/components/devtools/actors/thread.rs
+++ b/components/devtools/actors/thread.rs
@@ -79,7 +79,7 @@ impl Actor for ThreadActor {
         match msg_type {
             "attach" => {
                 let pause = registry.new_name::<PauseActor>();
-                registry.register_later(PauseActor {
+                registry.register(PauseActor {
                     name: pause.clone(),
                 });
                 let msg = ThreadAttached {

--- a/components/devtools/actors/timeline.rs
+++ b/components/devtools/actors/timeline.rs
@@ -4,12 +4,12 @@
 
 #![expect(dead_code)]
 
-use std::cell::RefCell;
 use std::net::TcpStream;
 use std::sync::{Arc, Mutex};
 use std::thread;
 use std::time::Duration;
 
+use atomic_refcell::AtomicRefCell;
 use base::cross_process_instant::CrossProcessInstant;
 use base::generic_channel::{self, GenericReceiver, GenericSender};
 use base::id::PipelineId;
@@ -30,9 +30,9 @@ pub struct TimelineActor {
     marker_types: Vec<TimelineMarkerType>,
     pipeline_id: PipelineId,
     is_recording: Arc<Mutex<bool>>,
-    stream: RefCell<Option<TcpStream>>,
-    framerate_actor: RefCell<Option<String>>,
-    memory_actor: RefCell<Option<String>>,
+    stream: AtomicRefCell<Option<TcpStream>>,
+    framerate_actor: AtomicRefCell<Option<String>>,
+    memory_actor: AtomicRefCell<Option<String>>,
     registry: Arc<Mutex<ActorRegistry>>,
     start_stamp: CrossProcessInstant,
 }
@@ -143,9 +143,9 @@ impl TimelineActor {
             marker_types,
             script_sender,
             is_recording: Arc::new(Mutex::new(false)),
-            stream: RefCell::new(None),
-            framerate_actor: RefCell::new(None),
-            memory_actor: RefCell::new(None),
+            stream: AtomicRefCell::new(None),
+            framerate_actor: AtomicRefCell::new(None),
+            memory_actor: AtomicRefCell::new(None),
             start_stamp: CrossProcessInstant::now(),
             registry,
         }

--- a/components/devtools/actors/timeline.rs
+++ b/components/devtools/actors/timeline.rs
@@ -266,11 +266,11 @@ impl Actor for TimelineActor {
 
                 // TODO: move this to the cleanup method.
                 if let Some(ref actor_name) = *self.framerate_actor.borrow() {
-                    registry.drop_actor_later(actor_name.clone());
+                    registry.remove(actor_name.clone());
                 }
 
                 if let Some(ref actor_name) = *self.memory_actor.borrow() {
-                    registry.drop_actor_later(actor_name.clone());
+                    registry.remove(actor_name.clone());
                 }
 
                 **self.is_recording.lock().as_mut().unwrap() = false;

--- a/components/devtools/actors/watcher.rs
+++ b/components/devtools/actors/watcher.rs
@@ -389,7 +389,7 @@ impl ResourceAvailable for WatcherActor {
 
 impl WatcherActor {
     pub fn new(
-        actors: &mut ActorRegistry,
+        actors: &ActorRegistry,
         browsing_context_actor: String,
         session_context: SessionContext,
     ) -> Self {

--- a/components/devtools/actors/worker.rs
+++ b/components/devtools/actors/worker.rs
@@ -2,10 +2,10 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-use std::cell::RefCell;
 use std::collections::HashMap;
 use std::net::TcpStream;
 
+use atomic_refcell::AtomicRefCell;
 use base::generic_channel::GenericSender;
 use base::id::TEST_PIPELINE_ID;
 use devtools_traits::DevtoolScriptControlMsg::WantsLiveNotifications;
@@ -35,7 +35,7 @@ pub(crate) struct WorkerActor {
     pub url: ServoUrl,
     pub type_: WorkerType,
     pub script_chan: GenericSender<DevtoolScriptControlMsg>,
-    pub streams: RefCell<HashMap<StreamId, TcpStream>>,
+    pub streams: AtomicRefCell<HashMap<StreamId, TcpStream>>,
 }
 
 impl ResourceAvailable for WorkerActor {

--- a/components/devtools/lib.rs
+++ b/components/devtools/lib.rs
@@ -118,7 +118,7 @@ pub fn start_server(port: u16, embedder: EmbedderProxy) -> Sender<DevtoolsContro
 pub(crate) struct StreamId(u32);
 
 struct DevtoolsInstance {
-    registry: Arc<Mutex<ActorRegistry>>,
+    registry: Arc<ActorRegistry>,
     id_map: Arc<Mutex<IdMap>>,
     browsing_contexts: FxHashMap<BrowsingContextId, String>,
     receiver: Receiver<DevtoolsControlMsg>,
@@ -160,7 +160,7 @@ impl DevtoolsInstance {
         RootActor::register(&mut registry);
 
         let instance = Self {
-            registry: Arc::new(Mutex::new(registry)),
+            registry: Arc::new(registry),
             id_map: Arc::new(Mutex::new(IdMap::default())),
             browsing_contexts: FxHashMap::default(),
             pipelines: FxHashMap::default(),
@@ -206,7 +206,6 @@ impl DevtoolsInstance {
 
                     // Inform every browsing context of the new stream
                     for name in self.browsing_contexts.values() {
-                        let actors = actors.lock().unwrap();
                         let browsing_context = actors.find::<BrowsingContextActor>(name);
                         let mut streams = browsing_context.streams.borrow_mut();
                         streams.insert(id, stream.try_clone().unwrap());
@@ -292,14 +291,14 @@ impl DevtoolsInstance {
     }
 
     fn handle_framerate_tick(&self, actor_name: String, tick: f64) {
-        let actors = self.registry.lock().unwrap();
+        let actors = &self.registry;
         let framerate_actor = actors.find::<FramerateActor>(&actor_name);
         framerate_actor.add_tick(tick);
     }
 
     fn handle_navigate(&self, browsing_context_id: BrowsingContextId, state: NavigationState) {
         let actor_name = self.browsing_contexts.get(&browsing_context_id).unwrap();
-        let actors = self.registry.lock().unwrap();
+        let actors = &self.registry;
         let actor = actors.find::<BrowsingContextActor>(actor_name);
         let mut id_map = self.id_map.lock().expect("Mutex poisoned");
         if let NavigationState::Start(url) = &state {
@@ -327,7 +326,7 @@ impl DevtoolsInstance {
         script_sender: GenericSender<DevtoolScriptControlMsg>,
         page_info: DevtoolsPageInfo,
     ) {
-        let actors = self.registry.lock().unwrap();
+        let actors = &self.registry;
 
         let (browsing_context_id, pipeline_id, worker_id, webview_id) = ids;
         let id_map = &mut self.id_map.lock().expect("Mutex poisoned");
@@ -377,7 +376,7 @@ impl DevtoolsInstance {
                         pipeline_id,
                         devtools_outer_window_id,
                         script_sender,
-                        &actors,
+                        actors,
                     );
                     let name = browsing_context_actor.name();
                     actors.register(browsing_context_actor);
@@ -412,7 +411,7 @@ impl DevtoolsInstance {
             Some(name) => name,
             None => return,
         };
-        let actors = self.registry.lock().unwrap();
+        let actors = &self.registry;
         let browsing_context = actors.find::<BrowsingContextActor>(name);
         browsing_context.title_changed(pipeline_id, title);
     }
@@ -427,11 +426,11 @@ impl DevtoolsInstance {
             Some(name) => name,
             None => return,
         };
-        let actors = self.registry.lock().unwrap();
+        let actors = &self.registry;
         let console_actor = actors.find::<ConsoleActor>(&console_actor_name);
         let id = worker_id.map_or(UniqueId::Pipeline(pipeline_id), UniqueId::Worker);
         for stream in self.connections.values_mut() {
-            console_actor.handle_page_error(page_error.clone(), id.clone(), &actors, stream);
+            console_actor.handle_page_error(page_error.clone(), id.clone(), actors, stream);
         }
     }
 
@@ -445,11 +444,11 @@ impl DevtoolsInstance {
             Some(name) => name,
             None => return,
         };
-        let actors = self.registry.lock().unwrap();
+        let actors = &self.registry;
         let console_actor = actors.find::<ConsoleActor>(&console_actor_name);
         let id = worker_id.map_or(UniqueId::Pipeline(pipeline_id), UniqueId::Worker);
         for stream in self.connections.values_mut() {
-            console_actor.handle_console_api(console_message.clone(), id.clone(), &actors, stream);
+            console_actor.handle_console_api(console_message.clone(), id.clone(), actors, stream);
         }
     }
 
@@ -458,11 +457,11 @@ impl DevtoolsInstance {
             Some(name) => name,
             None => return,
         };
-        let actors = self.registry.lock().unwrap();
+        let actors = &self.registry;
         let console_actor = actors.find::<ConsoleActor>(&console_actor_name);
         let id = worker_id.map_or(UniqueId::Pipeline(pipeline_id), UniqueId::Worker);
         for stream in self.connections.values_mut() {
-            console_actor.send_clear_message(id.clone(), &actors, stream);
+            console_actor.send_clear_message(id.clone(), actors, stream);
         }
     }
 
@@ -471,7 +470,7 @@ impl DevtoolsInstance {
         pipeline_id: PipelineId,
         worker_id: Option<WorkerId>,
     ) -> Option<String> {
-        let actors = self.registry.lock().unwrap();
+        let actors = &self.registry;
         if let Some(worker_id) = worker_id {
             let actor_name = self.actor_workers.get(&worker_id)?;
             Some(actors.find::<WorkerActor>(actor_name).console.clone())
@@ -506,8 +505,6 @@ impl DevtoolsInstance {
         };
         let watcher_name = self
             .registry
-            .lock()
-            .unwrap()
             .find::<BrowsingContextActor>(browsing_context_actor_name)
             .watcher
             .clone();
@@ -527,7 +524,7 @@ impl DevtoolsInstance {
 
     /// Create a new NetworkEventActor for a given request ID and watcher name.
     fn create_network_event_actor(&mut self, request_id: String, watcher_name: String) -> String {
-        let actors = self.registry.lock().unwrap();
+        let actors = &self.registry;
         let resource_id = self.next_resource_id;
         self.next_resource_id += 1;
 
@@ -546,13 +543,13 @@ impl DevtoolsInstance {
         pipeline_id: PipelineId,
         source_info: SourceInfo,
     ) {
-        let actors = self.registry.lock().unwrap();
+        let actors = &self.registry;
 
         let source_content = source_info
             .content
             .or_else(|| actors.inline_source_content(pipeline_id));
         let source_actor = SourceActor::new_registered(
-            &actors,
+            actors,
             pipeline_id,
             source_info.url,
             source_content,
@@ -614,7 +611,7 @@ impl DevtoolsInstance {
     }
 
     fn handle_update_source_content(&mut self, pipeline_id: PipelineId, source_content: String) {
-        let actors = self.registry.lock().unwrap();
+        let actors = &self.registry;
 
         for actor_name in actors.source_actor_names_for_pipeline(pipeline_id) {
             let source_actor = actors.find::<SourceActor>(&actor_name);
@@ -659,12 +656,9 @@ fn allow_devtools_client(stream: &mut TcpStream, embedder: &EmbedderProxy, token
 }
 
 /// Process the input from a single devtools client until EOF.
-fn handle_client(actors: Arc<Mutex<ActorRegistry>>, mut stream: TcpStream, stream_id: StreamId) {
+fn handle_client(actors: Arc<ActorRegistry>, mut stream: TcpStream, stream_id: StreamId) {
     log::info!("Connection established to {}", stream.peer_addr().unwrap());
-    let msg = {
-        let actors = actors.lock().unwrap();
-        actors.encode::<RootActor, _>("root")
-    };
+    let msg = actors.encode::<RootActor, _>("root");
     if let Err(error) = stream.write_json_packet(&msg) {
         warn!("Failed to send initial packet from root actor: {error:?}");
         return;
@@ -673,11 +667,9 @@ fn handle_client(actors: Arc<Mutex<ActorRegistry>>, mut stream: TcpStream, strea
     loop {
         match stream.read_json_packet() {
             Ok(Some(json_packet)) => {
-                if let Err(()) = actors.lock().unwrap().handle_message(
-                    json_packet.as_object().unwrap(),
-                    &mut stream,
-                    stream_id,
-                ) {
+                if let Err(()) =
+                    actors.handle_message(json_packet.as_object().unwrap(), &mut stream, stream_id)
+                {
                     log::error!("Devtools actor stopped responding");
                     let _ = stream.shutdown(Shutdown::Both);
                     break;
@@ -694,5 +686,5 @@ fn handle_client(actors: Arc<Mutex<ActorRegistry>>, mut stream: TcpStream, strea
         }
     }
 
-    actors.lock().unwrap().cleanup(stream_id);
+    actors.cleanup(stream_id);
 }

--- a/components/devtools/network_handler.rs
+++ b/components/devtools/network_handler.rs
@@ -3,7 +3,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 use std::net::TcpStream;
-use std::sync::{Arc, Mutex};
+use std::sync::Arc;
 
 use devtools_traits::NetworkEvent;
 use serde::Serialize;
@@ -22,12 +22,11 @@ pub struct Cause {
 }
 
 pub(crate) fn handle_network_event(
-    actors: Arc<Mutex<ActorRegistry>>,
+    actors: Arc<ActorRegistry>,
     netevent_actor_name: String,
     mut connections: Vec<TcpStream>,
     network_event: NetworkEvent,
 ) {
-    let actors = actors.lock().unwrap();
     let actor = actors.find::<NetworkEventActor>(&netevent_actor_name);
     let watcher = actors.find::<WatcherActor>(&actor.watcher);
 


### PR DESCRIPTION
Replace `RefCell` with `AtomicRefCell` for structs implementing Actor, making them `Sync`.

Consolidate `register` and `register_later` into a single function, removing the need to wait for a loop before accessing newly created actors.

Now `ActorRegsitry` has improved locking. Instead of locking the entire struct, each member can be locked separately. Additionally, since `find` now returns `Arc`, we can `find` and `register` multiple actors depending on each other, since the lock is only needed for the operation and we can keep the reference after that.

Depends on: #41741, #41744
Testing: Manual testing