### PR TITLE
net: Align redirect HTTP Fetch with spec comments

### DIFF
--- a/components/net/http_loader.rs
+++ b/components/net/http_loader.rs
@@ -995,45 +995,40 @@ pub async fn http_fetch(
 
     // TODO: Step 5: cross-origin resource policy check
 
-    // Step 6
+    // Step 6. If internalResponse’s status is a redirect status:
     if response
         .actual_response()
         .status
         .try_code()
         .is_some_and(is_redirect_status)
     {
-        // Substep 1.
+        // Step 6.1. If internalResponse’s status is not 303, request’s body is non-null,
+        // and the connection uses HTTP/2, then user agents may, and are even encouraged to,
+        // transmit an RST_STREAM frame.
         if response.actual_response().status != StatusCode::SEE_OTHER {
             // TODO: send RST_STREAM frame
         }
 
-        // Substep 2-3.
-        let mut location = response
-            .actual_response()
-            .headers
-            .get(header::LOCATION)
-            .and_then(|v| {
-                HeaderValue::to_str(v)
-                    .map(|l| {
-                        ServoUrl::parse_with_base(response.actual_response().url(), l)
-                            .map_err(|err| err.to_string())
-                    })
-                    .ok()
-            });
-
-        // Substep 4.
-        if let Some(Ok(ref mut location)) = location {
-            if location.fragment().is_none() {
-                let current_url = request.current_url();
-                location.set_fragment(current_url.fragment());
-            }
-        }
-        response.actual_response_mut().location_url = location;
-
-        // Substep 5.
+        // Step 6.2. Switch on request’s redirect mode:
         response = match request.redirect_mode {
+            // Step 6.2."error".1. Set response to a network error.
             RedirectMode::Error => Response::network_error(NetworkError::RedirectError),
-            RedirectMode::Manual => response.to_filtered(ResponseType::OpaqueRedirect),
+            RedirectMode::Manual => {
+                // Step 6.2."manual".1. If request’s mode is "navigate", then set fetchParams’s controller’s
+                // next manual redirect steps to run HTTP-redirect fetch given fetchParams and response.
+                if request.mode == RequestMode::Navigate {
+                    // TODO: We don't implement Fetch controller. Instead, we update the location url
+                    // of the response here and don't call `http_redirect_fetch`. That's get called later.
+                    // Once we have a fetch controller here, we should update the code as specced.
+                    let location_url =
+                        location_url_for_response(&response, request.current_url().fragment());
+                    response.actual_response_mut().location_url = location_url;
+                    response
+                } else {
+                    // Step 6.2."manual".2. Otherwise, set response to an opaque-redirect filtered response whose internal response is internalResponse.
+                    response.to_filtered(ResponseType::OpaqueRedirect)
+                }
+            },
             RedirectMode::Follow => {
                 // set back to default
                 response.return_internal = true;
@@ -1086,12 +1081,58 @@ impl Drop for RedirectEndTimer {
     }
 }
 
+/// <https://fetch.spec.whatwg.org/#request-body-header-name>
+static REQUEST_BODY_HEADER_NAMES: &[HeaderName] = &[
+    CONTENT_ENCODING,
+    CONTENT_LANGUAGE,
+    CONTENT_LOCATION,
+    CONTENT_TYPE,
+];
+
+/// <https://fetch.spec.whatwg.org/#concept-response-location-url>
+fn location_url_for_response(
+    response: &Response,
+    request_fragment: Option<&str>,
+) -> Option<Result<ServoUrl, String>> {
+    // Step 1. If response’s status is not a redirect status, then return null.
+    assert!(
+        response
+            .actual_response()
+            .status
+            .try_code()
+            .is_some_and(is_redirect_status)
+    );
+    // Step 2. Let location be the result of extracting header list values given `Location` and response’s header list.
+    let mut location = response
+        .actual_response()
+        .headers
+        .get(header::LOCATION)
+        .and_then(|header_value| {
+            HeaderValue::to_str(header_value)
+                .map(|location_string| {
+                    // Step 3. If location is a header value, then set location to the result of parsing location with response’s URL.
+                    ServoUrl::parse_with_base(response.actual_response().url(), location_string)
+                        .map_err(|error| error.to_string())
+                })
+                .ok()
+        });
+
+    // Step 4. If location is a URL whose fragment is null, then set location’s fragment to requestFragment.
+    if let Some(Ok(ref mut location)) = location {
+        if location.fragment().is_none() {
+            location.set_fragment(request_fragment);
+        }
+    }
+    // Step 5. Return location.
+    location
+}
+
 /// [HTTP redirect fetch](https://fetch.spec.whatwg.org#http-redirect-fetch)
 #[async_recursion]
 pub async fn http_redirect_fetch(
     fetch_params: &mut FetchParams,
     cache: &mut CorsCache,
-    response: Response,
+    mut response: Response,
     cors_flag: bool,
     target: Target<'async_recursion>,
     done_chan: &mut DoneChannel,
@@ -1099,23 +1140,27 @@ pub async fn http_redirect_fetch(
 ) -> Response {
     let mut redirect_end_timer = RedirectEndTimer(Some(context.timing.clone()));
 
-    // Step 1: Let request be fetchParams’s request.
+    // Step 1. Let request be fetchParams’s request.
     let request = &mut fetch_params.request;
 
+    // Step 2. Let internalResponse be response, if response is not a filtered response; otherwise response’s internal response.
     assert!(response.return_internal);
 
-    let location_url = response.actual_response().location_url.clone();
+    // Step 3. Let locationURL be internalResponse’s location URL given request’s current URL’s fragment.
+    let location_url = location_url_for_response(&response, request.current_url().fragment());
+    response.actual_response_mut().location_url = location_url.clone();
+
     let location_url = match location_url {
-        // Step 2
+        // Step 4. If locationURL is null, then return response.
         None => return response,
-        // Step 3
+        // Step 5. If locationURL is failure, then return a network error.
         Some(Err(err)) => {
             return Response::network_error(NetworkError::ResourceLoadError(
                 "Location URL parse failure: ".to_owned() + &err,
             ));
         },
-        // Step 4
-        Some(Ok(ref url)) if !matches!(url.scheme(), "http" | "https") => {
+        // Step 6. If locationURL’s scheme is not an HTTP(S) scheme, then return a network error.
+        Some(Ok(url)) if !matches!(url.scheme(), "http" | "https") => {
             return Response::network_error(NetworkError::UnsupportedScheme);
         },
         Some(Ok(url)) => url,
@@ -1156,7 +1201,8 @@ pub async fn http_redirect_fetch(
     // Step 8: Increase request’s redirect count by 1.
     request.redirect_count += 1;
 
-    // Step 9
+    // Step 9. If request’s mode is "cors", locationURL includes credentials,
+    // and request’s origin is not same origin with locationURL’s origin, then return a network error.
     let same_origin = match request.origin {
         Origin::Origin(ref origin) => *origin == location_url.origin(),
         Origin::Client => panic!(
@@ -1171,12 +1217,11 @@ pub async fn http_redirect_fetch(
         return Response::network_error(NetworkError::CorsCredentials);
     }
 
-    // Step 9
     if cors_flag && location_url.origin() != request.current_url().origin() {
         request.origin = Origin::Origin(ImmutableOrigin::new_opaque());
     }
 
-    // Step 10
+    // Step 10. If request’s response tainting is "cors" and locationURL includes credentials, then return a network error.
     if cors_flag && has_credentials {
         return Response::network_error(NetworkError::CorsCredentials);
     }
@@ -1189,29 +1234,26 @@ pub async fn http_redirect_fetch(
         return Response::network_error(NetworkError::ConnectionFailure);
     }
 
-    // Step 12
+    // Step 12. If one of the following is true
     if response
         .actual_response()
         .status
         .try_code()
         .is_some_and(|code| {
+            // internalResponse’s status is 301 or 302 and request’s method is `POST`
             ((code == StatusCode::MOVED_PERMANENTLY || code == StatusCode::FOUND) &&
                 request.method == Method::POST) ||
+                // internalResponse’s status is 303 and request’s method is not `GET` or `HEAD`
                 (code == StatusCode::SEE_OTHER &&
                     request.method != Method::HEAD &&
                     request.method != Method::GET)
         })
     {
-        // Step 12.1
+        // Step 12.1. Set request’s method to `GET` and request’s body to null.
         request.method = Method::GET;
         request.body = None;
-        // Step 12.2
-        for name in &[
-            CONTENT_ENCODING,
-            CONTENT_LANGUAGE,
-            CONTENT_LOCATION,
-            CONTENT_TYPE,
-        ] {
+        // Step 12.2. For each headerName of request-body-header name, delete headerName from request’s header list.
+        for name in REQUEST_BODY_HEADER_NAMES {
             request.headers.remove(name);
         }
     }


### PR DESCRIPTION
While debugging failing WPT tests related to redirects, I realised that the implementation was out-of-sync with the spec. Add the relevant comments and refactor according to what the order of the spec expects.

Testing: no observable behavior
Part of #41807