### PR TITLE
devtools: Fix panic when getting AutoMargins of node without style

### DIFF
--- a/components/shared/devtools/lib.rs
+++ b/components/shared/devtools/lib.rs
@@ -210,6 +210,7 @@ pub struct ComputedNodeLayout {
     pub z_index: String,
     pub box_sizing: String,
 
+    #[serde(rename = "autoMargins")]
     pub auto_margins: AutoMargins,
     pub margin_top: String,
     pub margin_right: String,

--- a/components/shared/devtools/lib.rs
+++ b/components/shared/devtools/lib.rs
@@ -203,7 +203,7 @@ pub struct NodeStyle {
 
 /// The properties of a DOM node as computed by layout.
 #[derive(Debug, Deserialize, Serialize)]
-#[serde(rename_all = "camelCase")]
+#[serde(rename_all = "kebab-case")]
 pub struct ComputedNodeLayout {
     pub display: String,
     pub position: String,
@@ -230,12 +230,16 @@ pub struct ComputedNodeLayout {
     pub height: f32,
 }
 
-#[derive(Debug, Deserialize, Serialize)]
+#[derive(Debug, Default, Deserialize, Serialize)]
 pub struct AutoMargins {
-    pub top: bool,
-    pub right: bool,
-    pub bottom: bool,
-    pub left: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub top: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub right: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub bottom: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub left: Option<String>,
 }
 
 /// Messages to process in a particular script thread, as instructed by a devtools client.


### PR DESCRIPTION
Fix a panic when calling `determine_auto_margins` for nodes without `.style()`. Now it returns an empty `AutoMargins` (all options set to `None`), which matches the behaviour in Firefox:

```json
"autoMargins": {}
"autoMargins": {"top": "auto", "bottom": "auto", "left": "auto", "right": "auto"}
```

Refactor `GetLayoutReply` and `ComputedNodeLayout` to take advantage of serde's flatten feature, making the serialization much cleaner.

Testing: Manual testing with the example provided in the issue.
Fixes: #41743
