### PR TITLE
webdriver: Dispatch embedder `TouchEventType::Move`

### DIFF
--- a/components/webdriver_server/lib.rs
+++ b/components/webdriver_server/lib.rs
@@ -30,9 +30,9 @@ use cookie::{CookieBuilder, Expiration, SameSite};
 use crossbeam_channel::{Receiver, RecvTimeoutError, Sender, after, select, unbounded};
 use embedder_traits::{
     CustomHandlersAutomationMode, EventLoopWaker, ImeEvent, InputEvent, JSValue,
-    JavaScriptEvaluationError, JavaScriptEvaluationResultSerializationError, MouseButton,
-    NewWindowTypeHint, WebDriverCommandMsg, WebDriverFrameId, WebDriverJSResult,
-    WebDriverLoadStatus, WebDriverScriptCommand,
+    JavaScriptEvaluationError, JavaScriptEvaluationResultSerializationError, NewWindowTypeHint,
+    WebDriverCommandMsg, WebDriverFrameId, WebDriverJSResult, WebDriverLoadStatus,
+    WebDriverScriptCommand,
 };
 use euclid::{Point2D, Rect, Size2D};
 use http::method::Method;
@@ -73,7 +73,7 @@ use webdriver::response::{
 };
 use webdriver::server::{self, Session, SessionTeardownKind, WebDriverHandler};
 
-use crate::actions::{InputSourceState, PointerInputState};
+use crate::actions::{ELEMENT_CLICK_BUTTON, InputSourceState, PointerInputState};
 use crate::session::{PageLoadStrategy, WebDriverSession};
 use crate::timeout::{DEFAULT_PAGE_LOAD_TIMEOUT, SCREENSHOT_TIMEOUT};
 
@@ -2334,14 +2334,14 @@ impl Handler {
         // Step 8.11. Construct pointer down action.
         // Step 8.12. Set a property button to 0 on pointer down action.
         let pointer_down_action = PointerDownAction {
-            button: i16::from(MouseButton::Left) as u64,
+            button: ELEMENT_CLICK_BUTTON,
             ..Default::default()
         };
 
         // Step 8.13. Construct pointer up action.
         // Step 8.14. Set a property button to 0 on pointer up action.
         let pointer_up_action = PointerUpAction {
-            button: i16::from(MouseButton::Left) as u64,
+            button: ELEMENT_CLICK_BUTTON,
             ..Default::default()
         };
 

--- a/tests/wpt/meta/css/cssom-view/visual-scrollIntoView-001.html.ini
+++ b/tests/wpt/meta/css/cssom-view/visual-scrollIntoView-001.html.ini
@@ -1,3 +1,4 @@
 [visual-scrollIntoView-001.html]
+  expected: CRASH
   [Element.scrollIntoView scrolls visually]
     expected: FAIL

--- a/tests/wpt/meta/css/cssom-view/visual-scrollIntoView-002.html.ini
+++ b/tests/wpt/meta/css/cssom-view/visual-scrollIntoView-002.html.ini
@@ -1,3 +1,4 @@
 [visual-scrollIntoView-002.html]
+  expected: CRASH
   [Element.scrollIntoView scrolls visually to a position: fixed element with non-zero layout scroll offset]
     expected: FAIL

--- a/tests/wpt/meta/css/cssom-view/visual-scrollIntoView-003.html.ini
+++ b/tests/wpt/meta/css/cssom-view/visual-scrollIntoView-003.html.ini
@@ -1,3 +1,4 @@
 [visual-scrollIntoView-003.html]
+  expected: CRASH
   [Element.scrollIntoView scrolls visually to an element in nested position: fixed elements]
     expected: FAIL

--- a/tests/wpt/meta/dom/events/non-cancelable-when-passive/non-passive-touchmove-event-listener-on-body.html.ini
+++ b/tests/wpt/meta/dom/events/non-cancelable-when-passive/non-passive-touchmove-event-listener-on-body.html.ini
@@ -1,3 +1,0 @@
-[non-passive-touchmove-event-listener-on-body.html]
-  [non-passive touchmove event listener on body]
-    expected: FAIL

--- a/tests/wpt/meta/dom/events/non-cancelable-when-passive/non-passive-touchmove-event-listener-on-div.html.ini
+++ b/tests/wpt/meta/dom/events/non-cancelable-when-passive/non-passive-touchmove-event-listener-on-div.html.ini
@@ -1,3 +1,0 @@
-[non-passive-touchmove-event-listener-on-div.html]
-  [non-passive touchmove event listener on div]
-    expected: FAIL

--- a/tests/wpt/meta/dom/events/non-cancelable-when-passive/non-passive-touchmove-event-listener-on-document.html.ini
+++ b/tests/wpt/meta/dom/events/non-cancelable-when-passive/non-passive-touchmove-event-listener-on-document.html.ini
@@ -1,3 +1,0 @@
-[non-passive-touchmove-event-listener-on-document.html]
-  [non-passive touchmove event listener on document]
-    expected: FAIL

--- a/tests/wpt/meta/dom/events/non-cancelable-when-passive/non-passive-touchmove-event-listener-on-root.html.ini
+++ b/tests/wpt/meta/dom/events/non-cancelable-when-passive/non-passive-touchmove-event-listener-on-root.html.ini
@@ -1,3 +1,0 @@
-[non-passive-touchmove-event-listener-on-root.html]
-  [non-passive touchmove event listener on root]
-    expected: FAIL

--- a/tests/wpt/meta/dom/events/scrolling/scrollend-event-fires-on-visual-viewport.html.ini
+++ b/tests/wpt/meta/dom/events/scrolling/scrollend-event-fires-on-visual-viewport.html.ini
@@ -1,2 +1,2 @@
 [scrollend-event-fires-on-visual-viewport.html]
-  expected: ERROR
+  expected: CRASH

--- a/tests/wpt/meta/pointerevents/pointerevent_change-touch-action-onpointerdown_touch.html.ini
+++ b/tests/wpt/meta/pointerevents/pointerevent_change-touch-action-onpointerdown_touch.html.ini
@@ -1,3 +1,0 @@
-[pointerevent_change-touch-action-onpointerdown_touch.html]
-  [scroll should be received before the test finishes]
-    expected: FAIL

--- a/tests/wpt/meta/pointerevents/pointerevent_touch-action-auto-css_touch.html.ini
+++ b/tests/wpt/meta/pointerevents/pointerevent_touch-action-auto-css_touch.html.ini
@@ -1,4 +1,0 @@
-[pointerevent_touch-action-auto-css_touch.html]
-  expected: TIMEOUT
-  [touch-action attribute test]
-    expected: NOTRUN

--- a/tests/wpt/meta/pointerevents/pointerevent_touch-action-button-none-test_touch.html.ini
+++ b/tests/wpt/meta/pointerevents/pointerevent_touch-action-button-none-test_touch.html.ini
@@ -1,3 +1,3 @@
-[pointerevent_touch-action-span-none-test_touch.html]
+[pointerevent_touch-action-button-none-test_touch.html]
   [touch-action attribute test in element]
     expected: FAIL

--- a/tests/wpt/meta/pointerevents/pointerevent_touch-action-inherit_child-auto-child-none_touch.html.ini
+++ b/tests/wpt/meta/pointerevents/pointerevent_touch-action-inherit_child-auto-child-none_touch.html.ini
@@ -1,4 +1,3 @@
 [pointerevent_touch-action-inherit_child-auto-child-none_touch.html]
-  expected: ERROR
   [touch-action attribute test]
-    expected: NOTRUN
+    expected: FAIL

--- a/tests/wpt/meta/pointerevents/pointerevent_touch-action-inherit_child-none_touch.html.ini
+++ b/tests/wpt/meta/pointerevents/pointerevent_touch-action-inherit_child-none_touch.html.ini
@@ -1,4 +1,3 @@
 [pointerevent_touch-action-inherit_child-none_touch.html]
-  expected: ERROR
   [touch-action attribute test]
-    expected: NOTRUN
+    expected: FAIL

--- a/tests/wpt/meta/pointerevents/pointerevent_touch-action-inherit_child-pan-x-child-pan-y_touch.html.ini
+++ b/tests/wpt/meta/pointerevents/pointerevent_touch-action-inherit_child-pan-x-child-pan-y_touch.html.ini
@@ -1,4 +1,3 @@
 [pointerevent_touch-action-inherit_child-pan-x-child-pan-y_touch.html]
-  expected: ERROR
   [touch-action attribute test]
-    expected: NOTRUN
+    expected: FAIL

--- a/tests/wpt/meta/pointerevents/pointerevent_touch-action-inherit_highest-parent-none_touch.html.ini
+++ b/tests/wpt/meta/pointerevents/pointerevent_touch-action-inherit_highest-parent-none_touch.html.ini
@@ -1,4 +1,0 @@
-[pointerevent_touch-action-inherit_highest-parent-none_touch.html]
-  expected: TIMEOUT
-  [touch-action attribute test]
-    expected: NOTRUN

--- a/tests/wpt/meta/pointerevents/pointerevent_touch-action-none-css_touch.html.ini
+++ b/tests/wpt/meta/pointerevents/pointerevent_touch-action-none-css_touch.html.ini
@@ -1,4 +1,3 @@
 [pointerevent_touch-action-none-css_touch.html]
-  expected: ERROR
   [touch-action attribute test]
-    expected: NOTRUN
+    expected: FAIL

--- a/tests/wpt/meta/pointerevents/pointerevent_touch-action-none-on-body-when-style-propagates-to-viewport_touch.html.ini
+++ b/tests/wpt/meta/pointerevents/pointerevent_touch-action-none-on-body-when-style-propagates-to-viewport_touch.html.ini
@@ -1,0 +1,3 @@
+[pointerevent_touch-action-none-on-body-when-style-propagates-to-viewport_touch.html]
+  [touch-action none on body when style propagates to viewport]
+    expected: FAIL

--- a/tests/wpt/meta/pointerevents/pointerevent_touch-action-pan-x-pan-y_touch.html.ini
+++ b/tests/wpt/meta/pointerevents/pointerevent_touch-action-pan-x-pan-y_touch.html.ini
@@ -1,4 +1,0 @@
-[pointerevent_touch-action-pan-x-pan-y_touch.html]
-  expected: TIMEOUT
-  [touch-action attribute test]
-    expected: NOTRUN

--- a/tests/wpt/meta/pointerevents/pointerevent_touch-action-table-none-test_touch.html.ini
+++ b/tests/wpt/meta/pointerevents/pointerevent_touch-action-table-none-test_touch.html.ini
@@ -4,4 +4,4 @@
     expected: FAIL
 
   [touch-action attribute test on the row]
-    expected: NOTRUN
+    expected: TIMEOUT

--- a/tests/wpt/meta/touch-events/multi-touch-interactions.html.ini
+++ b/tests/wpt/meta/touch-events/multi-touch-interactions.html.ini
@@ -1,5 +1,5 @@
 [multi-touch-interactions.html]
-  expected: TIMEOUT
+  expected: CRASH
   [touchmove event received]
     expected: NOTRUN
 

--- a/tests/wpt/meta/visual-viewport/page-and-offset-in-iframe.html.ini
+++ b/tests/wpt/meta/visual-viewport/page-and-offset-in-iframe.html.ini
@@ -1,3 +1,4 @@
 [page-and-offset-in-iframe.html]
+  expected: CRASH
   [VisualViewport page and offset values in iframe]
     expected: FAIL

--- a/tests/wpt/meta/visual-viewport/scroll-event-order.html.ini
+++ b/tests/wpt/meta/visual-viewport/scroll-event-order.html.ini
@@ -1,3 +1,4 @@
 [scroll-event-order.html]
+  expected: CRASH
   [Scroll event ordering]
     expected: FAIL


### PR DESCRIPTION
Fixes: #41725 
Fixes: #41620 
Fixes: #39264
Fixes: #41250

Testing: Multiple new passing. Several tests that NOT RUN starts running.
Several new CRASH are actually
```
 0:25.43 INFO Browser not responding, setting status to CRASH
 0:25.43 TEST_END: CRASH, expected OK
```
, which is no regression because these tests were FAIL, ERROR or TIMEOUT.