### PR TITLE
script: Some failed requests should record resource timing entries

### DIFF
--- a/components/fonts/font_context.rs
+++ b/components/fonts/font_context.rs
@@ -1055,7 +1055,7 @@ impl RemoteWebFontDownloader {
                 }
                 DownloaderResponseResult::InProcess
             },
-            FetchResponseMsg::ProcessResponseEOF(_, response) => {
+            FetchResponseMsg::ProcessResponseEOF(_, response, timing) => {
                 trace!(
                     "@font-face {} EOF={:?}",
                     self.web_font_family_name, response
@@ -1068,10 +1068,7 @@ impl RemoteWebFontDownloader {
                     .expect("must have download state before termination")
                     .document_context
                     .network_timing_handler
-                    .submit_timing(
-                        ServoUrl::from_url(self.url.as_ref().clone()),
-                        response.unwrap(),
-                    );
+                    .submit_timing(ServoUrl::from_url(self.url.as_ref().clone()), timing);
                 DownloaderResponseResult::Finished
             },
         }

--- a/components/net/image_cache.rs
+++ b/components/net/image_cache.rs
@@ -1033,7 +1033,7 @@ impl ImageCache for ImageCacheImpl {
                     }
                 }
             },
-            (FetchResponseMsg::ProcessResponseEOF(_, result), key) => {
+            (FetchResponseMsg::ProcessResponseEOF(_, result, _), key) => {
                 debug!("Received EOF for {:?}", key);
                 match result {
                     Ok(_) => {

--- a/components/net/tests/image_cache.rs
+++ b/components/net/tests/image_cache.rs
@@ -243,7 +243,7 @@ fn test_notify_pending_response_complete() {
 
     cache.notify_pending_response(
         id,
-        FetchResponseMsg::ProcessResponseEOF(create_request_id(), Ok(create_timing())),
+        FetchResponseMsg::ProcessResponseEOF(create_request_id(), Ok(()), create_timing()),
     );
 
     loop {
@@ -281,7 +281,11 @@ fn test_notify_pending_response_network_error() {
 
     cache.notify_pending_response(
         id,
-        FetchResponseMsg::ProcessResponseEOF(create_request_id(), Err(NetworkError::InvalidMethod)),
+        FetchResponseMsg::ProcessResponseEOF(
+            create_request_id(),
+            Err(NetworkError::InvalidMethod),
+            create_timing(),
+        ),
     );
 
     let result = cache.get_cached_image_status(url, origin, None);
@@ -317,7 +321,7 @@ fn test_image_listener_on_complete_response() {
 
     cache.notify_pending_response(
         id,
-        FetchResponseMsg::ProcessResponseEOF(create_request_id(), Ok(create_timing())),
+        FetchResponseMsg::ProcessResponseEOF(create_request_id(), Ok(()), create_timing()),
     );
 
     loop {
@@ -355,7 +359,11 @@ fn test_image_listener_on_network_error() {
 
     cache.notify_pending_response(
         id,
-        FetchResponseMsg::ProcessResponseEOF(create_request_id(), Err(NetworkError::InvalidMethod)),
+        FetchResponseMsg::ProcessResponseEOF(
+            create_request_id(),
+            Err(NetworkError::InvalidMethod),
+            create_timing(),
+        ),
     );
 
     match receiver.recv_timeout(std::time::Duration::from_millis(100)) {
@@ -446,7 +454,7 @@ fn test_multiple_listeners_same_image() {
 
     cache.notify_pending_response(
         id,
-        FetchResponseMsg::ProcessResponseEOF(create_request_id(), Ok(create_timing())),
+        FetchResponseMsg::ProcessResponseEOF(create_request_id(), Ok(()), create_timing()),
     );
 
     loop {
@@ -492,7 +500,7 @@ fn test_cached_image_reuse() {
 
     cache.notify_pending_response(
         id,
-        FetchResponseMsg::ProcessResponseEOF(create_request_id(), Ok(create_timing())),
+        FetchResponseMsg::ProcessResponseEOF(create_request_id(), Ok(()), create_timing()),
     );
 
     loop {
@@ -532,7 +540,7 @@ fn test_svg_rasterization() {
 
     cache.notify_pending_response(
         id,
-        FetchResponseMsg::ProcessResponseEOF(create_request_id(), Ok(create_timing())),
+        FetchResponseMsg::ProcessResponseEOF(create_request_id(), Ok(()), create_timing()),
     );
 
     let vec_img = loop {
@@ -584,7 +592,7 @@ fn test_rasterization_listener() {
 
     cache.notify_pending_response(
         id,
-        FetchResponseMsg::ProcessResponseEOF(create_request_id(), Ok(create_timing())),
+        FetchResponseMsg::ProcessResponseEOF(create_request_id(), Ok(()), create_timing()),
     );
 
     let vec_img = loop {

--- a/components/script/dom/eventsource.rs
+++ b/components/script/dom/eventsource.rs
@@ -447,10 +447,11 @@ impl FetchResponseListener for EventSourceContext {
         if self.incomplete_utf8.take().is_some() {
             self.parse("\u{FFFD}".chars(), CanGc::note());
         }
-        if let Ok(response) = response {
+        if response.is_ok() {
             self.reestablish_the_connection();
-            network_listener::submit_timing(&self, &response, CanGc::note());
         }
+
+        network_listener::submit_timing(&self, &response, CanGc::note());
     }
 
     fn process_csp_violations(&mut self, _request_id: RequestId, violations: Vec<Violation>) {

--- a/components/script/dom/eventsource.rs
+++ b/components/script/dom/eventsource.rs
@@ -442,7 +442,8 @@ impl FetchResponseListener for EventSourceContext {
     fn process_response_eof(
         mut self,
         _: RequestId,
-        response: Result<ResourceFetchTiming, NetworkError>,
+        response: Result<(), NetworkError>,
+        timing: ResourceFetchTiming,
     ) {
         if self.incomplete_utf8.take().is_some() {
             self.parse("\u{FFFD}".chars(), CanGc::note());
@@ -451,7 +452,7 @@ impl FetchResponseListener for EventSourceContext {
             self.reestablish_the_connection();
         }
 
-        network_listener::submit_timing(&self, &response, CanGc::note());
+        network_listener::submit_timing(&self, &response, &timing, CanGc::note());
     }
 
     fn process_csp_violations(&mut self, _request_id: RequestId, violations: Vec<Violation>) {

--- a/components/script/dom/html/htmlimageelement.rs
+++ b/components/script/dom/html/htmlimageelement.rs
@@ -307,13 +307,14 @@ impl FetchResponseListener for ImageContext {
     fn process_response_eof(
         self,
         request_id: RequestId,
-        response: Result<ResourceFetchTiming, NetworkError>,
+        response: Result<(), NetworkError>,
+        timing: ResourceFetchTiming,
     ) {
         self.image_cache.notify_pending_response(
             self.id,
-            FetchResponseMsg::ProcessResponseEOF(request_id, response.clone()),
+            FetchResponseMsg::ProcessResponseEOF(request_id, response.clone(), timing.clone()),
         );
-        network_listener::submit_timing(&self, &response, CanGc::note());
+        network_listener::submit_timing(&self, &response, &timing, CanGc::note());
     }
 
     fn process_csp_violations(&mut self, _request_id: RequestId, violations: Vec<Violation>) {

--- a/components/script/dom/html/htmlimageelement.rs
+++ b/components/script/dom/html/htmlimageelement.rs
@@ -313,9 +313,7 @@ impl FetchResponseListener for ImageContext {
             self.id,
             FetchResponseMsg::ProcessResponseEOF(request_id, response.clone()),
         );
-        if let Ok(response) = response {
-            network_listener::submit_timing(&self, &response, CanGc::note());
-        }
+        network_listener::submit_timing(&self, &response, CanGc::note());
     }
 
     fn process_csp_violations(&mut self, _request_id: RequestId, violations: Vec<Violation>) {

--- a/components/script/dom/html/htmllinkelement.rs
+++ b/components/script/dom/html/htmllinkelement.rs
@@ -1038,9 +1038,7 @@ impl FetchResponseListener for FaviconFetchContext {
             self.id,
             FetchResponseMsg::ProcessResponseEOF(request_id, response.clone()),
         );
-        if let Ok(response) = response {
-            submit_timing(&self, &response, CanGc::note());
-        }
+        submit_timing(&self, &response, CanGc::note());
     }
 
     fn process_csp_violations(&mut self, _request_id: RequestId, violations: Vec<Violation>) {

--- a/components/script/dom/html/htmllinkelement.rs
+++ b/components/script/dom/html/htmllinkelement.rs
@@ -810,7 +810,7 @@ impl HTMLLinkElement {
     /// <https://html.spec.whatwg.org/multipage/#link-type-preload:fetch-and-process-the-linked-resource-2>
     pub(crate) fn fire_event_after_response(
         &self,
-        response: Result<ResourceFetchTiming, NetworkError>,
+        response: Result<(), NetworkError>,
         can_gc: CanGc,
     ) {
         // Step 3.1 If response is a network error, fire an event named error at el.
@@ -1032,13 +1032,14 @@ impl FetchResponseListener for FaviconFetchContext {
     fn process_response_eof(
         self,
         request_id: RequestId,
-        response: Result<ResourceFetchTiming, NetworkError>,
+        response: Result<(), NetworkError>,
+        timing: ResourceFetchTiming,
     ) {
         self.image_cache.notify_pending_response(
             self.id,
-            FetchResponseMsg::ProcessResponseEOF(request_id, response.clone()),
+            FetchResponseMsg::ProcessResponseEOF(request_id, response.clone(), timing.clone()),
         );
-        submit_timing(&self, &response, CanGc::note());
+        submit_timing(&self, &response, &timing, CanGc::note());
     }
 
     fn process_csp_violations(&mut self, _request_id: RequestId, violations: Vec<Violation>) {

--- a/components/script/dom/html/htmlmediaelement.rs
+++ b/components/script/dom/html/htmlmediaelement.rs
@@ -3825,7 +3825,12 @@ impl FetchResponseListener for HTMLMediaElementFetchListener {
         }
     }
 
-    fn process_response_eof(self, _: RequestId, status: Result<ResourceFetchTiming, NetworkError>) {
+    fn process_response_eof(
+        self,
+        _: RequestId,
+        status: Result<(), NetworkError>,
+        timing: ResourceFetchTiming,
+    ) {
         let element = self.element.root();
 
         // <https://html.spec.whatwg.org/multipage/#media-data-processing-steps-list>
@@ -3884,7 +3889,7 @@ impl FetchResponseListener for HTMLMediaElementFetchListener {
             element.media_data_processing_failure_steps();
         }
 
-        network_listener::submit_timing(&self, &status, CanGc::note());
+        network_listener::submit_timing(&self, &status, &timing, CanGc::note());
     }
 
     fn process_csp_violations(&mut self, _request_id: RequestId, violations: Vec<Violation>) {

--- a/components/script/dom/html/htmlmediaelement.rs
+++ b/components/script/dom/html/htmlmediaelement.rs
@@ -3884,9 +3884,7 @@ impl FetchResponseListener for HTMLMediaElementFetchListener {
             element.media_data_processing_failure_steps();
         }
 
-        if let Ok(response) = status {
-            network_listener::submit_timing(&self, &response, CanGc::note());
-        }
+        network_listener::submit_timing(&self, &status, CanGc::note());
     }
 
     fn process_csp_violations(&mut self, _request_id: RequestId, violations: Vec<Violation>) {

--- a/components/script/dom/html/htmlscriptelement.rs
+++ b/components/script/dom/html/htmlscriptelement.rs
@@ -375,7 +375,8 @@ impl FetchResponseListener for ClassicContext {
     fn process_response_eof(
         mut self,
         _: RequestId,
-        response: Result<ResourceFetchTiming, NetworkError>,
+        response: Result<(), NetworkError>,
+        timing: ResourceFetchTiming,
     ) {
         match (response.as_ref(), self.status.as_ref()) {
             (Err(error), _) | (_, Err(error)) => {
@@ -389,7 +390,7 @@ impl FetchResponseListener for ClassicContext {
                 );
 
                 // Resource timing is expected to be available before "error" or "load" events are fired.
-                network_listener::submit_timing(&self, &response, CanGc::note());
+                network_listener::submit_timing(&self, &response, &timing, CanGc::note());
                 return;
             },
             _ => {},
@@ -470,7 +471,7 @@ impl FetchResponseListener for ClassicContext {
         );
         // }
 
-        network_listener::submit_timing(&self, &response, CanGc::note());
+        network_listener::submit_timing(&self, &response, &timing, CanGc::note());
     }
 
     fn process_csp_violations(&mut self, _request_id: RequestId, violations: Vec<Violation>) {

--- a/components/script/dom/html/htmlscriptelement.rs
+++ b/components/script/dom/html/htmlscriptelement.rs
@@ -389,9 +389,7 @@ impl FetchResponseListener for ClassicContext {
                 );
 
                 // Resource timing is expected to be available before "error" or "load" events are fired.
-                if let Ok(response) = &response {
-                    network_listener::submit_timing(&self, response, CanGc::note());
-                }
+                network_listener::submit_timing(&self, &response, CanGc::note());
                 return;
             },
             _ => {},
@@ -472,9 +470,7 @@ impl FetchResponseListener for ClassicContext {
         );
         // }
 
-        if let Ok(response) = response {
-            network_listener::submit_timing(&self, &response, CanGc::note());
-        }
+        network_listener::submit_timing(&self, &response, CanGc::note());
     }
 
     fn process_csp_violations(&mut self, _request_id: RequestId, violations: Vec<Violation>) {

--- a/components/script/dom/html/htmlvideoelement.rs
+++ b/components/script/dom/html/htmlvideoelement.rs
@@ -453,9 +453,7 @@ impl FetchResponseListener for PosterFrameFetchContext {
             self.id,
             FetchResponseMsg::ProcessResponseEOF(request_id, response.clone()),
         );
-        if let Ok(response) = response {
-            network_listener::submit_timing(&self, &response, CanGc::note());
-        }
+        network_listener::submit_timing(&self, &response, CanGc::note());
     }
 
     fn process_csp_violations(&mut self, _request_id: RequestId, violations: Vec<Violation>) {

--- a/components/script/dom/html/htmlvideoelement.rs
+++ b/components/script/dom/html/htmlvideoelement.rs
@@ -447,13 +447,14 @@ impl FetchResponseListener for PosterFrameFetchContext {
     fn process_response_eof(
         self,
         request_id: RequestId,
-        response: Result<ResourceFetchTiming, NetworkError>,
+        response: Result<(), NetworkError>,
+        timing: ResourceFetchTiming,
     ) {
         self.image_cache.notify_pending_response(
             self.id,
-            FetchResponseMsg::ProcessResponseEOF(request_id, response.clone()),
+            FetchResponseMsg::ProcessResponseEOF(request_id, response.clone(), timing.clone()),
         );
-        network_listener::submit_timing(&self, &response, CanGc::note());
+        network_listener::submit_timing(&self, &response, &timing, CanGc::note());
     }
 
     fn process_csp_violations(&mut self, _request_id: RequestId, violations: Vec<Violation>) {

--- a/components/script/dom/navigator.rs
+++ b/components/script/dom/navigator.rs
@@ -617,9 +617,10 @@ impl FetchResponseListener for BeaconFetchListener {
     fn process_response_eof(
         self,
         _: RequestId,
-        response: Result<ResourceFetchTiming, NetworkError>,
+        response: Result<(), NetworkError>,
+        timing: ResourceFetchTiming,
     ) {
-        submit_timing(&self, &response, CanGc::note());
+        submit_timing(&self, &response, &timing, CanGc::note());
     }
 
     fn process_csp_violations(&mut self, _request_id: RequestId, violations: Vec<Violation>) {

--- a/components/script/dom/navigator.rs
+++ b/components/script/dom/navigator.rs
@@ -619,9 +619,7 @@ impl FetchResponseListener for BeaconFetchListener {
         _: RequestId,
         response: Result<ResourceFetchTiming, NetworkError>,
     ) {
-        if let Ok(response) = response {
-            submit_timing(&self, &response, CanGc::note());
-        }
+        submit_timing(&self, &response, CanGc::note());
     }
 
     fn process_csp_violations(&mut self, _request_id: RequestId, violations: Vec<Violation>) {

--- a/components/script/dom/notification.rs
+++ b/components/script/dom/notification.rs
@@ -783,9 +783,7 @@ impl FetchResponseListener for ResourceFetchListener {
             self.pending_image_id,
             FetchResponseMsg::ProcessResponseEOF(request_id, response.clone()),
         );
-        if let Ok(response) = response {
-            network_listener::submit_timing(&self, &response, CanGc::note());
-        }
+        network_listener::submit_timing(&self, &response, CanGc::note());
     }
 
     fn process_csp_violations(&mut self, _request_id: RequestId, violations: Vec<Violation>) {

--- a/components/script/dom/notification.rs
+++ b/components/script/dom/notification.rs
@@ -777,13 +777,14 @@ impl FetchResponseListener for ResourceFetchListener {
     fn process_response_eof(
         self,
         request_id: RequestId,
-        response: Result<ResourceFetchTiming, NetworkError>,
+        response: Result<(), NetworkError>,
+        timing: ResourceFetchTiming,
     ) {
         self.image_cache.notify_pending_response(
             self.pending_image_id,
-            FetchResponseMsg::ProcessResponseEOF(request_id, response.clone()),
+            FetchResponseMsg::ProcessResponseEOF(request_id, response.clone(), timing.clone()),
         );
-        network_listener::submit_timing(&self, &response, CanGc::note());
+        network_listener::submit_timing(&self, &response, &timing, CanGc::note());
     }
 
     fn process_csp_violations(&mut self, _request_id: RequestId, violations: Vec<Violation>) {

--- a/components/script/dom/processingoptions.rs
+++ b/components/script/dom/processingoptions.rs
@@ -518,9 +518,7 @@ impl FetchResponseListener for LinkFetchContext {
             );
         }
 
-        if let Ok(ref response) = response_result {
-            submit_timing(&self, response, CanGc::note());
-        }
+        submit_timing(&self, &response_result, CanGc::note());
 
         // Step 11.6. If processResponse is given, then call processResponse with response.
         //

--- a/components/script/dom/processingoptions.rs
+++ b/components/script/dom/processingoptions.rs
@@ -487,13 +487,14 @@ impl FetchResponseListener for LinkFetchContext {
     fn process_response_eof(
         mut self,
         _: RequestId,
-        response_result: Result<ResourceFetchTiming, NetworkError>,
+        response_result: Result<(), NetworkError>,
+        timing: ResourceFetchTiming,
     ) {
         // Steps for https://html.spec.whatwg.org/multipage/#preload
         if let LinkFetchContextType::Preload(key) = &self.type_ {
-            let response = if let Ok(resource_timing) = &response_result {
+            let response = if response_result.is_ok() {
                 // Step 11.1. If bodyBytes is a byte sequence, then set response's body to bodyBytes as a body.
-                let response = Response::new(self.url.clone(), resource_timing.clone());
+                let response = Response::new(self.url.clone(), timing.clone());
                 *response.body.lock() = ResponseBody::Done(std::mem::take(&mut self.response_body));
                 response
             } else {
@@ -518,7 +519,7 @@ impl FetchResponseListener for LinkFetchContext {
             );
         }
 
-        submit_timing(&self, &response_result, CanGc::note());
+        submit_timing(&self, &response_result, &timing, CanGc::note());
 
         // Step 11.6. If processResponse is given, then call processResponse with response.
         //

--- a/components/script/dom/reportingendpoint.rs
+++ b/components/script/dom/reportingendpoint.rs
@@ -333,9 +333,7 @@ impl FetchResponseListener for CSPReportEndpointFetchListener {
         _: RequestId,
         response: Result<ResourceFetchTiming, NetworkError>,
     ) {
-        if let Ok(response) = response {
-            submit_timing(&self, &response, CanGc::note());
-        }
+        submit_timing(&self, &response, CanGc::note());
     }
 
     fn process_csp_violations(&mut self, _request_id: RequestId, _violations: Vec<Violation>) {}

--- a/components/script/dom/reportingendpoint.rs
+++ b/components/script/dom/reportingendpoint.rs
@@ -331,9 +331,10 @@ impl FetchResponseListener for CSPReportEndpointFetchListener {
     fn process_response_eof(
         self,
         _: RequestId,
-        response: Result<ResourceFetchTiming, NetworkError>,
+        response: Result<(), NetworkError>,
+        timing: ResourceFetchTiming,
     ) {
-        submit_timing(&self, &response, CanGc::note());
+        submit_timing(&self, &response, &timing, CanGc::note());
     }
 
     fn process_csp_violations(&mut self, _request_id: RequestId, _violations: Vec<Violation>) {}

--- a/components/script/dom/servoparser/mod.rs
+++ b/components/script/dom/servoparser/mod.rs
@@ -1387,7 +1387,8 @@ impl FetchResponseListener for ParserContext {
     fn process_response_eof(
         mut self,
         _: RequestId,
-        status: Result<ResourceFetchTiming, NetworkError>,
+        status: Result<(), NetworkError>,
+        timing: ResourceFetchTiming,
     ) {
         let parser = match self.parser.as_ref() {
             Some(parser) => parser.root(),
@@ -1411,10 +1412,8 @@ impl FetchResponseListener for ParserContext {
 
         let _realm = enter_realm(&*parser);
 
-        if let Ok(resource_timing) = &status {
-            parser
-                .document
-                .set_redirect_count(resource_timing.redirect_count);
+        if status.is_ok() {
+            parser.document.set_redirect_count(timing.redirect_count);
         }
 
         parser.last_chunk_received.set(true);

--- a/components/script/dom/window.rs
+++ b/components/script/dom/window.rs
@@ -966,7 +966,8 @@ impl NetworkTimingHandler for FontNetworkTimingHandler {
                     url,
                     global
                 },
-                &Ok(response),
+                &Ok(()),
+                &response,
                 CanGc::note(),
             );
         }));

--- a/components/script/dom/window.rs
+++ b/components/script/dom/window.rs
@@ -966,7 +966,7 @@ impl NetworkTimingHandler for FontNetworkTimingHandler {
                     url,
                     global
                 },
-                &response,
+                &Ok(response),
                 CanGc::note(),
             );
         }));

--- a/components/script/dom/workers/workerglobalscope.rs
+++ b/components/script/dom/workers/workerglobalscope.rs
@@ -241,9 +241,7 @@ impl FetchResponseListener for ScriptFetchContext {
         // Step 6 Run onComplete given script.
         scope.on_complete(Some(script), self.worker.clone(), cx);
 
-        if let Ok(response) = response {
-            submit_timing(&self, &response, CanGc::from_cx(cx));
-        }
+        submit_timing(&self, &response, CanGc::from_cx(cx));
     }
 
     fn process_csp_violations(

--- a/components/script/dom/workers/workerglobalscope.rs
+++ b/components/script/dom/workers/workerglobalscope.rs
@@ -158,7 +158,8 @@ impl FetchResponseListener for ScriptFetchContext {
     fn process_response_eof(
         mut self,
         _request_id: RequestId,
-        response: Result<ResourceFetchTiming, NetworkError>,
+        response: Result<(), NetworkError>,
+        timing: ResourceFetchTiming,
     ) {
         #[expect(unsafe_code)]
         let mut cx = unsafe { script_bindings::script_runtime::temp_cx() };
@@ -241,7 +242,7 @@ impl FetchResponseListener for ScriptFetchContext {
         // Step 6 Run onComplete given script.
         scope.on_complete(Some(script), self.worker.clone(), cx);
 
-        submit_timing(&self, &response, CanGc::from_cx(cx));
+        submit_timing(&self, &response, &timing, CanGc::from_cx(cx));
     }
 
     fn process_csp_violations(

--- a/components/script/dom/xmlhttprequest.rs
+++ b/components/script/dom/xmlhttprequest.rs
@@ -127,9 +127,10 @@ impl FetchResponseListener for XHRContext {
     fn process_response_eof(
         self,
         _: RequestId,
-        response: Result<ResourceFetchTiming, NetworkError>,
+        response: Result<(), NetworkError>,
+        timing: ResourceFetchTiming,
     ) {
-        network_listener::submit_timing(&self, &response, CanGc::note());
+        network_listener::submit_timing(&self, &response, &timing, CanGc::note());
 
         let rv = self.xhr.root().process_response_complete(
             self.gen_id,

--- a/components/script/dom/xmlhttprequest.rs
+++ b/components/script/dom/xmlhttprequest.rs
@@ -129,9 +129,7 @@ impl FetchResponseListener for XHRContext {
         _: RequestId,
         response: Result<ResourceFetchTiming, NetworkError>,
     ) {
-        if let Ok(ref response) = response {
-            network_listener::submit_timing(&self, response, CanGc::note());
-        }
+        network_listener::submit_timing(&self, &response, CanGc::note());
 
         let rv = self.xhr.root().process_response_complete(
             self.gen_id,

--- a/components/script/fetch.rs
+++ b/components/script/fetch.rs
@@ -18,8 +18,7 @@ use net_traits::request::{
 };
 use net_traits::{
     CoreResourceMsg, CoreResourceThread, FetchChannels, FetchMetadata, FetchResponseMsg,
-    FilteredMetadata, Metadata, NetworkError, ResourceFetchTiming, ResourceTimingType,
-    cancel_async_fetch,
+    FilteredMetadata, Metadata, NetworkError, ResourceFetchTiming, cancel_async_fetch,
 };
 use rustc_hash::FxHashMap;
 use serde::{Deserialize, Serialize};
@@ -631,11 +630,7 @@ impl FetchResponseListener for FetchContext {
         // ... trailerObject is not supported in Servo yet.
 
         // navigation submission is handled in servoparser/mod.rs
-        if let Ok(response) = response {
-            if response.timing_type == ResourceTimingType::Resource {
-                network_listener::submit_timing(&self, &response, CanGc::note());
-            }
-        }
+        network_listener::submit_timing(&self, &response, CanGc::note());
     }
 
     fn process_csp_violations(&mut self, _request_id: RequestId, violations: Vec<Violation>) {
@@ -683,9 +678,7 @@ impl FetchResponseListener for FetchLaterListener {
         _: RequestId,
         response: Result<ResourceFetchTiming, NetworkError>,
     ) {
-        if let Ok(response) = response {
-            network_listener::submit_timing(&self, &response, CanGc::note());
-        }
+        network_listener::submit_timing(&self, &response, CanGc::note());
     }
 
     fn process_csp_violations(&mut self, _request_id: RequestId, violations: Vec<Violation>) {

--- a/components/script/layout_image.rs
+++ b/components/script/layout_image.rs
@@ -62,9 +62,7 @@ impl FetchResponseListener for LayoutImageContext {
             self.id,
             FetchResponseMsg::ProcessResponseEOF(request_id, response.clone()),
         );
-        if let Ok(response) = response {
-            network_listener::submit_timing(&self, &response, CanGc::note());
-        }
+        network_listener::submit_timing(&self, &response, CanGc::note());
     }
 
     fn process_csp_violations(&mut self, _request_id: RequestId, violations: Vec<Violation>) {

--- a/components/script/layout_image.rs
+++ b/components/script/layout_image.rs
@@ -56,13 +56,14 @@ impl FetchResponseListener for LayoutImageContext {
     fn process_response_eof(
         self,
         request_id: RequestId,
-        response: Result<ResourceFetchTiming, NetworkError>,
+        response: Result<(), NetworkError>,
+        timing: ResourceFetchTiming,
     ) {
         self.cache.notify_pending_response(
             self.id,
-            FetchResponseMsg::ProcessResponseEOF(request_id, response.clone()),
+            FetchResponseMsg::ProcessResponseEOF(request_id, response.clone(), timing.clone()),
         );
-        network_listener::submit_timing(&self, &response, CanGc::note());
+        network_listener::submit_timing(&self, &response, &timing, CanGc::note());
     }
 
     fn process_csp_violations(&mut self, _request_id: RequestId, violations: Vec<Violation>) {

--- a/components/script/network_listener.rs
+++ b/components/script/network_listener.rs
@@ -29,35 +29,33 @@ pub(crate) trait ResourceTimingListener {
 
 pub(crate) fn submit_timing<T: ResourceTimingListener>(
     listener: &T,
-    resource_timing_result: &Result<ResourceFetchTiming, NetworkError>,
+    result: &Result<(), NetworkError>,
+    resource_timing: &ResourceFetchTiming,
     can_gc: CanGc,
 ) {
-    let resource_timing = match resource_timing_result {
-        Ok(resource_timing) => resource_timing,
-        // https://www.w3.org/TR/resource-timing/#resources-included-in-the-performanceresourcetiming-interface
-        // If a resource fetch is aborted because it failed a fetch precondition
-        // (e.g. mixed content, CORS restriction, CSP policy, etc), then this resource
-        // will not be included as a PerformanceResourceTiming object in
-        // the Performance Timeline.
-        Err(
-            NetworkError::ContentSecurityPolicy |
-            NetworkError::MixedContent |
-            NetworkError::SubresourceIntegrity |
-            NetworkError::Nosniff |
-            NetworkError::InvalidPort |
-            NetworkError::CorsGeneral |
-            NetworkError::CrossOriginResponse |
-            NetworkError::CorsCredentials |
-            NetworkError::CorsAllowMethods |
-            NetworkError::CorsAllowHeaders |
-            NetworkError::CorsMethod |
-            NetworkError::CorsAuthorization |
-            NetworkError::CorsHeaders,
-        ) => {
-            return;
-        },
-        Err(_) => &ResourceFetchTiming::new(ResourceTimingType::Error),
-    };
+    // https://www.w3.org/TR/resource-timing/#resources-included-in-the-performanceresourcetiming-interface
+    // If a resource fetch is aborted because it failed a fetch precondition
+    // (e.g. mixed content, CORS restriction, CSP policy, etc), then this resource
+    // will not be included as a PerformanceResourceTiming object in
+    // the Performance Timeline.
+    if let Err(
+        NetworkError::ContentSecurityPolicy |
+        NetworkError::MixedContent |
+        NetworkError::SubresourceIntegrity |
+        NetworkError::Nosniff |
+        NetworkError::InvalidPort |
+        NetworkError::CorsGeneral |
+        NetworkError::CrossOriginResponse |
+        NetworkError::CorsCredentials |
+        NetworkError::CorsAllowMethods |
+        NetworkError::CorsAllowHeaders |
+        NetworkError::CorsMethod |
+        NetworkError::CorsAuthorization |
+        NetworkError::CorsHeaders,
+    ) = &result
+    {
+        return;
+    }
 
     // Resource timings should only be submitted for the initial preload request,
     // not for the request that consumes the preload: https://github.com/whatwg/html/issues/12047
@@ -126,7 +124,8 @@ pub(crate) trait FetchResponseListener: Send + 'static {
     fn process_response_eof(
         self,
         request_id: RequestId,
-        response: Result<ResourceFetchTiming, NetworkError>,
+        response: Result<(), NetworkError>,
+        timing: ResourceFetchTiming,
     );
     fn process_csp_violations(&mut self, request_id: RequestId, violations: Vec<Violation>);
 }
@@ -172,9 +171,9 @@ impl<Listener: FetchResponseListener> NetworkListener<Listener> {
                     FetchResponseMsg::ProcessResponseChunk(request_id, data) => {
                         fetch_listener.process_response_chunk(request_id, data.0)
                     },
-                    FetchResponseMsg::ProcessResponseEOF(request_id, resource_timing_result) => {
+                    FetchResponseMsg::ProcessResponseEOF(request_id, result, timing) => {
                         if let Some(fetch_listener) = context.take() {
-                            fetch_listener.process_response_eof(request_id, resource_timing_result);
+                            fetch_listener.process_response_eof(request_id, result, timing);
                         };
                     },
                     FetchResponseMsg::ProcessCspViolations(request_id, violations) => {

--- a/components/script/script_module.rs
+++ b/components/script/script_module.rs
@@ -1350,9 +1350,7 @@ impl FetchResponseListener for ModuleContext {
             },
         }
 
-        if let Ok(response) = response {
-            network_listener::submit_timing(&self, &response, CanGc::note());
-        }
+        network_listener::submit_timing(&self, &response, CanGc::note());
     }
 
     fn process_csp_violations(&mut self, _request_id: RequestId, violations: Vec<Violation>) {

--- a/components/script/script_module.rs
+++ b/components/script/script_module.rs
@@ -1236,7 +1236,8 @@ impl FetchResponseListener for ModuleContext {
     fn process_response_eof(
         mut self,
         _: RequestId,
-        response: Result<ResourceFetchTiming, NetworkError>,
+        response: Result<(), NetworkError>,
+        timing: ResourceFetchTiming,
     ) {
         let global = self.owner.global();
 
@@ -1350,7 +1351,7 @@ impl FetchResponseListener for ModuleContext {
             },
         }
 
-        network_listener::submit_timing(&self, &response, CanGc::note());
+        network_listener::submit_timing(&self, &response, &timing, CanGc::note());
     }
 
     fn process_csp_violations(&mut self, _request_id: RequestId, violations: Vec<Violation>) {

--- a/components/script/script_thread.rs
+++ b/components/script/script_thread.rs
@@ -3629,8 +3629,8 @@ impl ScriptThread {
             FetchResponseMsg::ProcessResponseChunk(request_id, chunk) => {
                 self.handle_fetch_chunk(pipeline_id, request_id, chunk.0)
             },
-            FetchResponseMsg::ProcessResponseEOF(request_id, eof) => {
-                self.handle_fetch_eof(pipeline_id, request_id, eof)
+            FetchResponseMsg::ProcessResponseEOF(request_id, eof, timing) => {
+                self.handle_fetch_eof(pipeline_id, request_id, eof, timing)
             },
             FetchResponseMsg::ProcessCspViolations(request_id, violations) => {
                 self.handle_csp_violations(pipeline_id, request_id, violations)
@@ -3677,7 +3677,8 @@ impl ScriptThread {
         &self,
         id: PipelineId,
         request_id: RequestId,
-        eof: Result<ResourceFetchTiming, NetworkError>,
+        eof: Result<(), NetworkError>,
+        timing: ResourceFetchTiming,
     ) {
         let idx = self
             .incomplete_parser_contexts
@@ -3688,7 +3689,7 @@ impl ScriptThread {
 
         if let Some(idx) = idx {
             let (_, context) = self.incomplete_parser_contexts.0.borrow_mut().remove(idx);
-            context.process_response_eof(request_id, eof);
+            context.process_response_eof(request_id, eof, timing);
         }
     }
 
@@ -3787,7 +3788,8 @@ impl ScriptThread {
         context.process_response_chunk(dummy_request_id, chunk);
         context.process_response_eof(
             dummy_request_id,
-            Ok(ResourceFetchTiming::new(ResourceTimingType::None)),
+            Ok(()),
+            ResourceFetchTiming::new(ResourceTimingType::None),
         );
     }
 
@@ -3817,7 +3819,8 @@ impl ScriptThread {
         context.process_response_chunk(dummy_request_id, chunk);
         context.process_response_eof(
             dummy_request_id,
-            Ok(ResourceFetchTiming::new(ResourceTimingType::None)),
+            Ok(()),
+            ResourceFetchTiming::new(ResourceTimingType::None),
         );
     }
 

--- a/components/script/security_manager.rs
+++ b/components/script/security_manager.rs
@@ -200,9 +200,10 @@ impl FetchResponseListener for CSPReportUriFetchListener {
     fn process_response_eof(
         self,
         _: RequestId,
-        response: Result<ResourceFetchTiming, NetworkError>,
+        response: Result<(), NetworkError>,
+        timing: ResourceFetchTiming,
     ) {
-        submit_timing(&self, &response, CanGc::note())
+        submit_timing(&self, &response, &timing, CanGc::note())
     }
 
     fn process_csp_violations(&mut self, _request_id: RequestId, _violations: Vec<Violation>) {}

--- a/components/script/security_manager.rs
+++ b/components/script/security_manager.rs
@@ -202,9 +202,7 @@ impl FetchResponseListener for CSPReportUriFetchListener {
         _: RequestId,
         response: Result<ResourceFetchTiming, NetworkError>,
     ) {
-        if let Ok(response) = response {
-            submit_timing(&self, &response, CanGc::note())
-        }
+        submit_timing(&self, &response, CanGc::note())
     }
 
     fn process_csp_violations(&mut self, _request_id: RequestId, _violations: Vec<Violation>) {}

--- a/components/script/stylesheet_loader.rs
+++ b/components/script/stylesheet_loader.rs
@@ -313,12 +313,12 @@ impl FetchResponseListener for StylesheetContext {
             .map(|metadata| metadata.status == http::StatusCode::OK)
             .unwrap_or(false);
 
-        let Ok(response) = status else {
+        network_listener::submit_timing(&self, &status, CanGc::note());
+
+        let Ok(_response) = status else {
             self.do_post_parse_tasks(successful, None);
             return;
         };
-
-        network_listener::submit_timing(&self, &response, CanGc::note());
 
         let Some(metadata) = self.metadata.as_ref() else {
             self.do_post_parse_tasks(successful, None);

--- a/components/script/stylesheet_loader.rs
+++ b/components/script/stylesheet_loader.rs
@@ -303,7 +303,8 @@ impl FetchResponseListener for StylesheetContext {
     fn process_response_eof(
         mut self,
         _: RequestId,
-        status: Result<ResourceFetchTiming, NetworkError>,
+        status: Result<(), NetworkError>,
+        timing: ResourceFetchTiming,
     ) {
         // FIXME: Revisit once consensus is reached at:
         // https://github.com/whatwg/html/issues/1142
@@ -313,7 +314,7 @@ impl FetchResponseListener for StylesheetContext {
             .map(|metadata| metadata.status == http::StatusCode::OK)
             .unwrap_or(false);
 
-        network_listener::submit_timing(&self, &status, CanGc::note());
+        network_listener::submit_timing(&self, &status, &timing, CanGc::note());
 
         let Ok(_response) = status else {
             self.do_post_parse_tasks(successful, None);

--- a/tests/wpt/meta/mixed-content/imageset.https.sub.html.ini
+++ b/tests/wpt/meta/mixed-content/imageset.https.sub.html.ini
@@ -1,3 +1,0 @@
-[imageset.https.sub.html]
-  [Makes sure imageset blockable resources are not downloaded]
-    expected: FAIL

--- a/tests/wpt/meta/preload/preconnect.html.ini
+++ b/tests/wpt/meta/preload/preconnect.html.ini
@@ -1,4 +1,0 @@
-[preconnect.html]
-  expected: TIMEOUT
-  [Test that preconnect reduces connection time to zero]
-    expected: TIMEOUT

--- a/tests/wpt/meta/preload/subresource-integrity.html.ini
+++ b/tests/wpt/meta/preload/subresource-integrity.html.ini
@@ -44,27 +44,6 @@
   [Same-origin script with non-matching digest reuses preload with no digest but fails.]
     expected: FAIL
 
-  [Same-origin style with incorrect hash.]
-    expected: FAIL
-
-  [Same-origin style with sha256 match, sha512 mismatch]
-    expected: FAIL
-
-  [<crossorigin='anonymous'> style with incorrect hash, ACAO: *]
-    expected: FAIL
-
-  [<crossorigin='use-credentials'> style with incorrect hash CORS-eligible]
-    expected: FAIL
-
-  [<crossorigin='anonymous'> style with CORS-ineligible resource]
-    expected: FAIL
-
-  [Cross-origin style, not CORS request, with correct hash]
-    expected: FAIL
-
-  [Cross-origin style, not CORS request, with hash mismatch]
-    expected: FAIL
-
   [Same-origin style with non-matching digest does not re-use preload with matching digest.]
     expected: FAIL
 
@@ -78,25 +57,4 @@
     expected: FAIL
 
   [Same-origin style with non-matching digest reuses preload with no digest but fails.]
-    expected: FAIL
-
-  [Same-origin image with incorrect hash.]
-    expected: FAIL
-
-  [Same-origin image with sha256 match, sha512 mismatch]
-    expected: FAIL
-
-  [<crossorigin='anonymous'> image with incorrect hash, ACAO: *]
-    expected: FAIL
-
-  [<crossorigin='use-credentials'> image with incorrect hash CORS-eligible]
-    expected: FAIL
-
-  [<crossorigin='anonymous'> image with CORS-ineligible resource]
-    expected: FAIL
-
-  [Cross-origin image, not CORS request, with correct hash]
-    expected: FAIL
-
-  [Cross-origin image, not CORS request, with hash mismatch]
     expected: FAIL

--- a/tests/wpt/meta/resource-timing/content-type-minimization.html.ini
+++ b/tests/wpt/meta/resource-timing/content-type-minimization.html.ini
@@ -130,88 +130,88 @@
     expected: FAIL
 
   [mime-type 16 : text/html;charset=\x0bgbk]
-    expected: TIMEOUT
+    expected: FAIL
 
   [mime-type 17 : text/html;charset=\x0cgbk]
-    expected: NOTRUN
+    expected: FAIL
 
   [mime-type 18 : text/html;\x0bcharset=gbk]
-    expected: NOTRUN
+    expected: FAIL
 
   [mime-type 19 : text/html;\x0ccharset=gbk]
-    expected: NOTRUN
+    expected: FAIL
 
   [mime-type 21 : text/html;charset='gbk']
-    expected: NOTRUN
+    expected: FAIL
 
   [mime-type 22 : text/html;charset='gbk]
-    expected: NOTRUN
+    expected: FAIL
 
   [mime-type 23 : text/html;charset=gbk']
-    expected: NOTRUN
+    expected: FAIL
 
   [mime-type 24 : text/html;charset=';charset=GBK]
-    expected: NOTRUN
+    expected: FAIL
 
   [mime-type 26 : text/html;test;charset=gbk]
-    expected: NOTRUN
+    expected: FAIL
 
   [mime-type 27 : text/html;test=;charset=gbk]
-    expected: NOTRUN
+    expected: FAIL
 
   [mime-type 28 : text/html;';charset=gbk]
-    expected: NOTRUN
+    expected: FAIL
 
   [mime-type 29 : text/html;";charset=gbk]
-    expected: NOTRUN
+    expected: FAIL
 
   [mime-type 30 : text/html ; ; charset=gbk]
-    expected: NOTRUN
+    expected: FAIL
 
   [mime-type 31 : text/html;;;;charset=gbk]
-    expected: NOTRUN
+    expected: FAIL
 
   [mime-type 32 : text/html;charset= ";charset=GBK]
-    expected: NOTRUN
+    expected: FAIL
 
   [mime-type 33 : text/html;charset=";charset=foo";charset=GBK]
-    expected: NOTRUN
+    expected: FAIL
 
   [mime-type 35 : text/html;charset="gbk"]
-    expected: NOTRUN
+    expected: FAIL
 
   [mime-type 36 : text/html;charset="gbk]
-    expected: NOTRUN
+    expected: FAIL
 
   [mime-type 37 : text/html;charset=gbk"]
-    expected: NOTRUN
+    expected: FAIL
 
   [mime-type 38 : text/html;charset=" gbk"]
-    expected: NOTRUN
+    expected: FAIL
 
   [mime-type 39 : text/html;charset="gbk "]
-    expected: NOTRUN
+    expected: FAIL
 
   [mime-type 40 : text/html;charset="\\ gbk"]
-    expected: NOTRUN
+    expected: FAIL
 
   [mime-type 41 : text/html;charset="\\g\\b\\k"]
-    expected: NOTRUN
+    expected: FAIL
 
   [mime-type 42 : text/html;charset="gbk"x]
-    expected: NOTRUN
+    expected: FAIL
 
   [mime-type 43 : text/html;charset="";charset=GBK]
-    expected: NOTRUN
+    expected: FAIL
 
   [mime-type 44 : text/html;charset=";charset=GBK]
-    expected: NOTRUN
+    expected: FAIL
 
   [mime-type 46 : text/html;charset={gbk}]
-    expected: NOTRUN
+    expected: FAIL
 
   [mime-type 48 : text/html;0123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789=x;charset=gbk]
-    expected: NOTRUN
+    expected: FAIL
 
   [mime-type 69 : text/html;test=ÿ;charset=gbk]
-    expected: NOTRUN
+    expected: FAIL

--- a/tests/wpt/meta/resource-timing/entries-for-network-errors.sub.https.html.ini
+++ b/tests/wpt/meta/resource-timing/entries-for-network-errors.sub.https.html.ini
@@ -1,5 +1,4 @@
 [entries-for-network-errors.sub.https.html]
-  expected: TIMEOUT
   [A ResourceTiming entry should be created for network error of type failed cross-origin requests]
     expected: FAIL
 
@@ -13,10 +12,10 @@
     expected: FAIL
 
   [A ResourceTiming entry should be created for network error of type only-if-cached resource that was not cached]
-    expected: TIMEOUT
+    expected: FAIL
 
   [A ResourceTiming entry should be created for network error of type too many redirects]
-    expected: NOTRUN
+    expected: FAIL
 
   [A ResourceTiming entry should be created for network error of type network error for ORB-blocked response]
-    expected: NOTRUN
+    expected: FAIL

--- a/tests/wpt/meta/resource-timing/resource_timing_content_length.html.ini
+++ b/tests/wpt/meta/resource-timing/resource_timing_content_length.html.ini
@@ -4,11 +4,10 @@
     expected: FAIL
 
   [encodedBodySize should be equal to the actual byte size of the content when no header present]
-    expected: TIMEOUT
+    expected: FAIL
 
   [encodedBodySize should be equal to the actual byte size of the content when header value is lower than actual content]
-    expected: NOTRUN
+    expected: FAIL
 
   [encodedBodySize should be equal to the actual byte size of the content when header value is higher than actual content]
-    expected: NOTRUN
-
+    expected: FAIL


### PR DESCRIPTION
Some failed requests should record resource timing entries

Testing: ./mach test-wpt tests/wpt/tests/resource-timing/entries-for-network-errors.sub.https.html
Fixes: https://github.com/servo/servo/issues/41667
