### PR TITLE
script: Implement "Location-navigate a location"

### DIFF
--- a/components/constellation/constellation.rs
+++ b/components/constellation/constellation.rs
@@ -3582,8 +3582,8 @@ where
             "{}: Loading ({}replacing): {}",
             source_id,
             match history_handling {
-                NavigationHistoryBehavior::Push => "",
-                NavigationHistoryBehavior::Replace => "not ",
+                NavigationHistoryBehavior::Push => "not ",
+                NavigationHistoryBehavior::Replace => "",
                 NavigationHistoryBehavior::Auto => "unsure if ",
             },
             load_data.url,

--- a/components/script/dom/location.rs
+++ b/components/script/dom/location.rs
@@ -344,21 +344,15 @@ impl LocationMethods<crate::DomTypeHolder> for Location {
     fn Replace(&self, url: USVString, can_gc: CanGc) -> ErrorResult {
         // Step 1: If this Location object's relevant Document is null, then return.
         if self.has_document() {
-            // Step 2: Parse url relative to the entry settings object. If that failed,
-            // throw a "SyntaxError" DOMException.
+            // Step 2. Let urlRecord be the result of encoding-parsing a URL given url, relative to the entry settings object.
             let base_url = self.entry_settings_object().api_base_url();
             let url = match base_url.join(&url.0) {
                 Ok(url) => url,
+                // Step 3. If urlRecord is failure, then throw a "SyntaxError" DOMException.
                 Err(_) => return Err(Error::Syntax(None)),
             };
-            // Step 3: Location-object navigate to the resulting URL record with
-            // the replacement flag set.
-            self.navigate(
-                url,
-                NavigationHistoryBehavior::Replace,
-                NavigationType::Normal,
-                can_gc,
-            );
+            // Step 4. Location-object navigate this to urlRecord given "replace".
+            self.navigate_a_location(url, NavigationHistoryBehavior::Replace, can_gc);
         }
         Ok(())
     }

--- a/components/script/dom/location.rs
+++ b/components/script/dom/location.rs
@@ -61,6 +61,46 @@ impl Location {
         reflect_dom_object(Box::new(Location::new_inherited(window)), window, can_gc)
     }
 
+    /// <https://html.spec.whatwg.org/multipage/#location-object-navigate>
+    fn navigate_a_location(
+        &self,
+        url: ServoUrl,
+        history_handling: NavigationHistoryBehavior,
+        can_gc: CanGc,
+    ) {
+        // Step 1. Let navigable be location's relevant global object's navigable.
+        let navigable = &self.window;
+        // Step 2. Let sourceDocument be the incumbent global object's associated Document.
+        let incumbent_global = GlobalScope::incumbent().expect("no incumbent global object");
+        let incumbent_window = incumbent_global.as_window();
+        let source_document = incumbent_window.Document();
+        // Step 3. If location's relevant Document is not yet completely loaded,
+        // and the incumbent global object does not have transient activation, then set historyHandling to "replace".
+        let history_handling = if !navigable.Document().completely_loaded() {
+            NavigationHistoryBehavior::Replace
+        } else {
+            history_handling
+        };
+        // Step 4. Navigate navigable to url using sourceDocument, with exceptionsEnabled set to true and historyHandling set to historyHandling.
+        let secure_context = if incumbent_window.is_top_level() {
+            None
+        } else {
+            Some(incumbent_global.is_secure_context())
+        };
+        let load_data = LoadData::new(
+            LoadOrigin::Script(incumbent_window.origin().immutable().clone()),
+            url,
+            Some(navigable.pipeline_id()),
+            Referrer::ReferrerUrl(source_document.url()),
+            source_document.get_referrer_policy(),
+            secure_context,
+            Some(source_document.insecure_requests_policy()),
+            source_document.has_trustworthy_ancestor_origin(),
+            source_document.creation_sandboxing_flag_set_considering_parent_iframe(),
+        );
+        navigable.load_url(history_handling, false, load_data, can_gc);
+    }
+
     /// Navigate the relevant `Document`'s browsing context.
     ///
     /// This is ostensibly an implementation of
@@ -414,23 +454,18 @@ impl LocationMethods<crate::DomTypeHolder> for Location {
 
     /// <https://html.spec.whatwg.org/multipage/#dom-location-href>
     fn SetHref(&self, value: USVString, can_gc: CanGc) -> ErrorResult {
-        // Step 1: If this Location object's relevant Document is null, then return.
+        // Step 1. If this's relevant Document is null, then return.
         if self.has_document() {
             // Note: no call to self.check_same_origin_domain()
             // Step 2: Let url be the result of encoding-parsing a URL given the given value, relative to the entry settings object.
-            // Step 3: If url is failure, then throw a "SyntaxError" DOMException.
             let base_url = self.entry_settings_object().api_base_url();
             let url = match base_url.join(&value.0) {
                 Ok(url) => url,
+                // Step 3: If url is failure, then throw a "SyntaxError" DOMException.
                 Err(e) => return Err(Error::Syntax(Some(format!("Couldn't parse URL: {}", e)))),
             };
             // Step 4: Location-object navigate this to url.
-            self.navigate(
-                url,
-                NavigationHistoryBehavior::Push,
-                NavigationType::Normal,
-                can_gc,
-            );
+            self.navigate_a_location(url, NavigationHistoryBehavior::Auto, can_gc);
         }
         Ok(())
     }

--- a/components/script/dom/location.rs
+++ b/components/script/dom/location.rs
@@ -76,6 +76,8 @@ impl Location {
         let source_document = incumbent_window.Document();
         // Step 3. If location's relevant Document is not yet completely loaded,
         // and the incumbent global object does not have transient activation, then set historyHandling to "replace".
+        //
+        // TODO: check for transient activation
         let history_handling = if !navigable.Document().completely_loaded() {
             NavigationHistoryBehavior::Replace
         } else {

--- a/tests/wpt/meta/html/browsers/browsing-the-web/navigating-across-documents/initial-empty-document/iframe-src-204-fragment.html.ini
+++ b/tests/wpt/meta/html/browsers/browsing-the-web/navigating-across-documents/initial-empty-document/iframe-src-204-fragment.html.ini
@@ -2,9 +2,6 @@
   [src]
     expected: FAIL
 
-  [location.href]
-    expected: FAIL
-
   [location.assign]
     expected: FAIL
 

--- a/tests/wpt/meta/html/browsers/browsing-the-web/navigating-across-documents/initial-empty-document/window-open-204-fragment.html.ini
+++ b/tests/wpt/meta/html/browsers/browsing-the-web/navigating-across-documents/initial-empty-document/window-open-204-fragment.html.ini
@@ -1,6 +1,3 @@
 [window-open-204-fragment.html]
-  [location.href]
-    expected: FAIL
-
   [location.assign]
     expected: FAIL

--- a/tests/wpt/meta/html/browsers/browsing-the-web/navigating-across-documents/replace-before-load/location-setter-during-load.html.ini
+++ b/tests/wpt/meta/html/browsers/browsing-the-web/navigating-across-documents/replace-before-load/location-setter-during-load.html.ini
@@ -1,9 +1,10 @@
 [location-setter-during-load.html]
+  expected: TIMEOUT
   [href]
-    expected: FAIL
+    expected: TIMEOUT
 
   [search]
-    expected: FAIL
+    expected: NOTRUN
 
   [hash]
-    expected: FAIL
+    expected: NOTRUN

--- a/tests/wpt/meta/html/browsers/browsing-the-web/navigating-across-documents/replace-before-load/location-setter-during-pageshow.html.ini
+++ b/tests/wpt/meta/html/browsers/browsing-the-web/navigating-across-documents/replace-before-load/location-setter-during-pageshow.html.ini
@@ -1,9 +1,10 @@
 [location-setter-during-pageshow.html]
+  expected: TIMEOUT
   [href]
-    expected: FAIL
+    expected: TIMEOUT
 
   [search]
-    expected: FAIL
+    expected: NOTRUN
 
   [hash]
-    expected: FAIL
+    expected: NOTRUN

--- a/tests/wpt/meta/html/browsers/browsing-the-web/unloading-documents/prompt/004.html.ini
+++ b/tests/wpt/meta/html/browsers/browsing-the-web/unloading-documents/prompt/004.html.ini
@@ -1,0 +1,2 @@
+[004.html]
+  expected: TIMEOUT

--- a/tests/wpt/meta/html/browsers/history/the-history-interface/traverse-during-beforeunload.html.ini
+++ b/tests/wpt/meta/html/browsers/history/the-history-interface/traverse-during-beforeunload.html.ini
@@ -1,4 +1,0 @@
-[traverse-during-beforeunload.html]
-  expected: TIMEOUT
-  [Traversing the history during beforeunload]
-    expected: TIMEOUT

--- a/tests/wpt/meta/html/browsers/history/the-location-interface/assign_before_load.html.ini
+++ b/tests/wpt/meta/html/browsers/history/the-location-interface/assign_before_load.html.ini
@@ -1,3 +1,0 @@
-[assign_before_load.html]
-  [Assignment to location before document is completely loaded]
-    expected: FAIL

--- a/tests/wpt/meta/html/browsers/history/the-location-interface/location_replace_session_history.html.ini
+++ b/tests/wpt/meta/html/browsers/history/the-location-interface/location_replace_session_history.html.ini
@@ -1,0 +1,2 @@
+[location_replace_session_history.html]
+  expected: TIMEOUT

--- a/tests/wpt/meta/html/browsers/history/the-location-interface/scripted_click_assign_during_load.html.ini
+++ b/tests/wpt/meta/html/browsers/history/the-location-interface/scripted_click_assign_during_load.html.ini
@@ -1,3 +1,0 @@
-[scripted_click_assign_during_load.html]
-  [Assignment to location with click during load]
-    expected: FAIL

--- a/tests/wpt/meta/html/browsers/history/the-location-interface/scripted_form_submit_assign_during_load.html.ini
+++ b/tests/wpt/meta/html/browsers/history/the-location-interface/scripted_form_submit_assign_during_load.html.ini
@@ -1,3 +1,0 @@
-[scripted_form_submit_assign_during_load.html]
-  [Assignment to location with form submit during load]
-    expected: FAIL


### PR DESCRIPTION
The existing implementation in `Location::navigate` differs
a lot from the existing spec. Therefore, let's incrementally
make it closer match the spec by implementing the first
step for `SetHref`.

Testing: WPT
Part of #41807