### PR TITLE
constellation: Change most of the channels to be GenericChannels

### DIFF
--- a/components/constellation/broadcastchannel.rs
+++ b/components/constellation/broadcastchannel.rs
@@ -13,7 +13,7 @@ use servo_url::ImmutableOrigin;
 
 #[derive(Default)]
 pub(crate) struct BroadcastChannels {
-    /// A map of broadcast routers to their IPC sender.
+    /// A map of broadcast routers to their Generic sender.
     routers: FxHashMap<BroadcastChannelRouterId, IpcSender<BroadcastChannelMsg>>,
 
     /// A map of origin to a map of channel name to a list of relevant routers.

--- a/components/constellation/serviceworker.rs
+++ b/components/constellation/serviceworker.rs
@@ -2,9 +2,9 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
+use base::generic_channel::GenericSender;
 use constellation_traits::{SWManagerSenders, ServiceWorkerManagerFactory};
 use ipc_channel::Error;
-use ipc_channel::ipc::IpcSender;
 use serde::{Deserialize, Serialize};
 use servo_config::opts::{self, Opts};
 use servo_config::prefs;
@@ -22,14 +22,14 @@ pub struct ServiceWorkerUnprivilegedContent {
     pub prefs: Box<Preferences>,
     senders: SWManagerSenders,
     origin: ImmutableOrigin,
-    lifeline_sender: Option<IpcSender<()>>,
+    lifeline_sender: Option<GenericSender<()>>,
 }
 
 impl ServiceWorkerUnprivilegedContent {
     pub fn new(
         senders: SWManagerSenders,
         origin: ImmutableOrigin,
-        lifeline_sender: Option<IpcSender<()>>,
+        lifeline_sender: Option<GenericSender<()>>,
     ) -> ServiceWorkerUnprivilegedContent {
         ServiceWorkerUnprivilegedContent {
             opts: (*opts::get()).clone(),

--- a/components/net/tests/resource_thread.rs
+++ b/components/net/tests/resource_thread.rs
@@ -5,7 +5,6 @@
 use std::net::IpAddr;
 
 use base::generic_channel;
-use ipc_channel::ipc;
 use net::connector::CACertificates;
 use net::protocols::ProtocolRegistry;
 use net::resource_thread::new_core_resource_thread;
@@ -24,7 +23,7 @@ fn ip(s: &str) -> IpAddr {
 fn test_exit() {
     let (tx, _rx) = generic_channel::channel().unwrap();
     let (mtx, _mrx) = generic_channel::channel().unwrap();
-    let (sender, receiver) = ipc::channel().unwrap();
+    let (sender, receiver) = generic_channel::oneshot().unwrap();
     let (resource_thread, _private_resource_thread) = new_core_resource_thread(
         None,
         ProfilerChan(Some(tx)),

--- a/components/script/dom/canvas/2d/canvas_state.rs
+++ b/components/script/dom/canvas/2d/canvas_state.rs
@@ -28,7 +28,6 @@ use ipc_channel::ipc;
 use net_traits::image_cache::{ImageCache, ImageResponse};
 use net_traits::request::CorsSettings;
 use pixels::{Snapshot, SnapshotAlphaMode, SnapshotPixelFormat};
-use profile_traits::ipc as profiled_ipc;
 use range::Range;
 use servo_arc::Arc as ServoArc;
 use servo_url::{ImmutableOrigin, ServoUrl};
@@ -222,7 +221,7 @@ impl CanvasState {
     pub(super) fn new(global: &GlobalScope, size: Size2D<u64>) -> Option<CanvasState> {
         debug!("Creating new canvas rendering context.");
         let (sender, receiver) =
-            profiled_ipc::channel(global.time_profiler_chan().clone()).unwrap();
+            profile_traits::generic_channel::channel(global.time_profiler_chan().clone()).unwrap();
         let script_to_constellation_chan = global.script_to_constellation_chan();
         debug!("Asking constellation to create new canvas thread.");
         let size = adjust_canvas_size(size);

--- a/components/script/dom/history.rs
+++ b/components/script/dom/history.rs
@@ -15,8 +15,7 @@ use js::jsapi::Heap;
 use js::jsval::{JSVal, NullValue, UndefinedValue};
 use js::rust::{HandleValue, MutableHandleValue};
 use net_traits::CoreResourceMsg;
-use profile_traits::ipc;
-use profile_traits::ipc::channel;
+use profile_traits::{generic_channel, ipc};
 use servo_url::ServoUrl;
 
 use crate::dom::bindings::codegen::Bindings::HistoryBinding::HistoryMethods;
@@ -347,8 +346,11 @@ impl HistoryMethods<crate::DomTypeHolder> for History {
             return Err(Error::Security(None));
         }
 
-        let (sender, recv) = channel(self.global().time_profiler_chan().clone())
-            .map_err(|_| Error::InvalidState(None))?;
+        let Some((sender, recv)) =
+            generic_channel::channel(self.global().time_profiler_chan().clone())
+        else {
+            return Err(Error::InvalidState(None));
+        };
 
         let msg = ScriptToConstellationMessage::JointSessionHistoryLength(sender);
 

--- a/components/shared/constellation/from_script_message.rs
+++ b/components/shared/constellation/from_script_message.rs
@@ -553,7 +553,7 @@ pub enum ScriptToConstellationMessage {
     /// A new message-port was created or transferred, with corresponding control-sender.
     NewMessagePort(MessagePortRouterId, MessagePortId),
     /// A global has started managing message-ports
-    NewMessagePortRouter(MessagePortRouterId, IpcSender<MessagePortMsg>),
+    NewMessagePortRouter(MessagePortRouterId, GenericCallback<MessagePortMsg>),
     /// A global has stopped managing message-ports
     RemoveMessagePortRouter(MessagePortRouterId),
     /// A task requires re-routing to an already shipped message-port.
@@ -598,7 +598,7 @@ pub enum ScriptToConstellationMessage {
     /// 2D canvases may use the GPU and we don't want to give untrusted content access to the GPU.)
     CreateCanvasPaintThread(
         UntypedSize2D<u64>,
-        IpcSender<Option<(GenericSender<CanvasMsg>, CanvasId)>>,
+        GenericSender<Option<(GenericSender<CanvasMsg>, CanvasId)>>,
     ),
     /// Notifies the constellation that this pipeline is requesting focus.
     ///
@@ -660,7 +660,7 @@ pub enum ScriptToConstellationMessage {
     /// Inform the constellation of a replaced history state.
     ReplaceHistoryState(HistoryStateId, ServoUrl),
     /// Gets the length of the joint session history from the constellation.
-    JointSessionHistoryLength(IpcSender<u32>),
+    JointSessionHistoryLength(GenericSender<u32>),
     /// Notification that this iframe should be removed.
     /// Returns a list of pipelines which were closed.
     RemoveIFrame(BrowsingContextId, IpcSender<Vec<PipelineId>>),

--- a/components/shared/net/lib.rs
+++ b/components/shared/net/lib.rs
@@ -9,7 +9,7 @@ use std::sync::{LazyLock, OnceLock};
 use std::thread::{self, JoinHandle};
 
 use base::cross_process_instant::CrossProcessInstant;
-use base::generic_channel::{self, GenericSend, GenericSender, SendResult};
+use base::generic_channel::{self, GenericOneshotSender, GenericSend, GenericSender, SendResult};
 use base::id::{CookieStoreId, HistoryStateId, PipelineId};
 use content_security_policy::{self as csp};
 use cookie::Cookie;
@@ -654,7 +654,7 @@ pub enum CoreResourceMsg {
     TotalSizeOfInFlightKeepAliveRecords(PipelineId, GenericSender<u64>),
     /// Break the load handler loop, send a reply when done cleaning up local resources
     /// and exit
-    Exit(IpcSender<()>),
+    Exit(GenericOneshotSender<()>),
     CollectMemoryReport(ReportsChan),
 }
 


### PR DESCRIPTION
Changed most of the channels to be GenericChannels in constellation.

Signed-off-by: Narfinger <Narfinger@users.noreply.github.com>

Testing: As usual this should be tested via the type system.
