### PR TITLE
script: More &mut JSContext in codegen

### DIFF
--- a/components/script/dom/bindings/utils.rs
+++ b/components/script/dom/bindings/utils.rs
@@ -133,12 +133,7 @@ pub(crate) const DOM_CALLBACKS: DOMCallbacks = DOMCallbacks {
 
 /// Eagerly define all relevant WebIDL interface constructors on the
 /// provided global object.
-pub(crate) fn define_all_exposed_interfaces(
-    global: &GlobalScope,
-    _in_realm: InRealm,
-    _can_gc: CanGc,
-) {
-    let cx = GlobalScope::get_cx();
+pub(crate) fn define_all_exposed_interfaces(cx: &mut CurrentRealm, global: &GlobalScope) {
     for (_, interface) in &InterfaceObjectMap::MAP {
         (interface.define)(cx, global.reflector().get_jsobject());
     }

--- a/components/script/dom/workers/dedicatedworkerglobalscope.rs
+++ b/components/script/dom/workers/dedicatedworkerglobalscope.rs
@@ -437,7 +437,7 @@ impl DedicatedWorkerGlobalScope {
                     init.storage_threads.clone(),
                     #[cfg(feature = "webgpu")]
                     gpu_id_hub.clone(),
-                    CanGc::from_cx(cx),
+                    cx,
                 );
                 debugger_global.execute(CanGc::from_cx(cx));
 

--- a/components/script/script_thread.rs
+++ b/components/script/script_thread.rs
@@ -941,7 +941,7 @@ impl ScriptThread {
             state.storage_threads.clone(),
             #[cfg(feature = "webgpu")]
             gpu_id_hub.clone(),
-            CanGc::from_cx(&mut cx),
+            &mut cx,
         );
 
         debugger_global.execute(CanGc::from_cx(&mut cx));

--- a/components/script_bindings/codegen/codegen.py
+++ b/components/script_bindings/codegen/codegen.py
@@ -3156,7 +3156,7 @@ class CGConstructorEnabled(CGAbstractMethod):
     def __init__(self, descriptor: Descriptor) -> None:
         CGAbstractMethod.__init__(self, descriptor,
                                   'ConstructorEnabled', 'bool',
-                                  [Argument("SafeJSContext", "aCx"),
+                                  [Argument("&mut JSContext", "cx"),
                                    Argument("HandleObject", "aObj")],
                                   templateArgs=['D: DomTypes'],
                                   pub=True)
@@ -3178,14 +3178,14 @@ class CGConstructorEnabled(CGAbstractMethod):
         func = iface.getExtendedAttribute("Func")
         if func:
             assert isinstance(func, list) and len(func) == 1
-            conditions.append(f"D::{func[0]}(aCx, aObj)")
+            conditions.append(f"D::{func[0]}(cx.into(), aObj)")
 
         secure = iface.getExtendedAttribute("SecureContext")
         if secure:
             conditions.append("""
-unsafe {
-    let in_realm_proof = AlreadyInRealm::assert_for_cx(aCx);
-    D::GlobalScope::from_context(*aCx, InRealm::Already(&in_realm_proof)).is_secure_context()
+{
+let realm = CurrentRealm::assert(cx);
+D::GlobalScope::from_current_realm(&realm).is_secure_context()
 }
 """)
 
@@ -4065,7 +4065,7 @@ class CGDefineDOMInterfaceMethod(CGAbstractMethod):
     def __init__(self, descriptor: Descriptor) -> None:
         assert descriptor.interface.hasInterfaceObject()
         args = [
-            Argument('SafeJSContext', 'cx'),
+            Argument('&mut JSContext', 'cx'),
             Argument('HandleObject', 'global'),
         ]
         CGAbstractMethod.__init__(self, descriptor, 'DefineDOMInterface',

--- a/components/script_bindings/codegen/codegen.py
+++ b/components/script_bindings/codegen/codegen.py
@@ -6887,7 +6887,7 @@ let global = D::GlobalScope::from_object(JS_CALLEE(cx.raw_cx(), vp).to_object())
             constructor = CGMethodCall(args, nativeName, True, self.descriptor, self.constructor)
             constructorCall = f"""
             call_default_constructor::<D>(
-                SafeJSContext::from_ptr(cx.raw_cx()),
+                &mut cx,
                 &args,
                 &global,
                 PrototypeList::ID::{MakeNativeName(self.descriptor.name)},

--- a/components/script_bindings/interface.rs
+++ b/components/script_bindings/interface.rs
@@ -592,11 +592,11 @@ pub(crate) fn get_per_interface_object_handle(
 }
 
 pub(crate) fn define_dom_interface(
-    cx: SafeJSContext,
+    cx: &mut js::context::JSContext,
     global: HandleObject,
     id: ProtoOrIfaceIndex,
     creator: unsafe fn(SafeJSContext, HandleObject, *mut ProtoOrIfaceArray),
-    enabled: fn(SafeJSContext, HandleObject) -> bool,
+    enabled: fn(&mut js::context::JSContext, HandleObject) -> bool,
 ) {
     assert!(!global.get().is_null());
 
@@ -604,8 +604,8 @@ pub(crate) fn define_dom_interface(
         return;
     }
 
-    rooted!(in(*cx) let mut proto = ptr::null_mut::<JSObject>());
-    get_per_interface_object_handle(cx, global, id, creator, proto.handle_mut());
+    rooted!(&in(cx) let mut proto = ptr::null_mut::<JSObject>());
+    get_per_interface_object_handle(cx.into(), global, id, creator, proto.handle_mut());
     assert!(!proto.is_null());
 }
 

--- a/components/script_bindings/interfaces.rs
+++ b/components/script_bindings/interfaces.rs
@@ -28,9 +28,9 @@ use crate::utils::ProtoOrIfaceArray;
 /// <https://github.com/mozilla/gecko-dev/blob/3fd619f47/dom/bindings/WebIDLGlobalNameHash.h#L24>
 pub struct Interface {
     /// Define the JS object for this interface on the given global.
-    pub define: fn(JSContext, HandleObject),
+    pub define: fn(&mut js::context::JSContext, HandleObject),
     /// Returns true if this interface's conditions are met for the given global.
-    pub enabled: fn(JSContext, HandleObject) -> bool,
+    pub enabled: fn(&mut js::context::JSContext, HandleObject) -> bool,
 }
 
 /// Operations that must be invoked from the generated bindings.


### PR DESCRIPTION
Reviewable per commit. First commit adds `&mut JSContext` to `call_default_constructor`. Second commit adds `&mut JSContext` to Interface, which in unfortunately required many changes (a lot of passing `&mut JSContext` down). 

Testing: Just a refactor, but should be covered by WPT
Part of #40600