### PR TITLE
CI: Make HarmonyOS build job mandatory

### DIFF
--- a/.github/workflows/ohos.yml
+++ b/.github/workflows/ohos.yml
@@ -158,7 +158,6 @@ jobs:
   # if we figure out how to make hvigor build for harmonyos without the HOS commandline-tools installed.
   build-harmonyos-aarch64:
     name: HarmonyOS Build (aarch64)
-    continue-on-error: true
     runs-on: hos-builder
     if: github.repository == 'servo/servo'
     outputs:


### PR DESCRIPTION
This job was previously optional, since it doesn't have a fallback to github-hosted runners. However, this doesn't change much, since in practice if the runners are down, the merge queue will still wait for the job to complete (or fail the job after **24 hours**).

> If a job is labeled for a certain type of runner, but none matching that type are available, the job does not immediately fail at the time of queueing. Instead, the job will remain queued until the 24 hour timeout period expires.

See [self-hosted runners reference](https://docs.github.com/en/actions/reference/runners/self-hosted-runners)

On the other side, making this job mandatory, will also check the tracing feature builds fine (at least on ohos), since it is the only configuration that currently uses tracing when building. This would have prevented https://github.com/servo/servo/issues/41802

Testing: Not required / this is a ci configuration change.
