### PR TITLE
webdriver: Insert correct cancel action object

### DIFF
--- a/components/webdriver_server/actions.rs
+++ b/components/webdriver_server/actions.rs
@@ -287,7 +287,15 @@ impl Handler {
                         ActionItem::Pointer(PointerActionItem::Pointer(PointerAction::Up(
                             PointerUpAction {
                                 button: pointer_down_action.button,
-                                ..Default::default()
+                                width: pointer_down_action.width,
+                                height: pointer_down_action.height,
+                                pressure: pointer_down_action.pressure,
+                                tangentialPressure: pointer_down_action.tangentialPressure,
+                                tiltX: pointer_down_action.tiltX,
+                                tiltY: pointer_down_action.tiltY,
+                                twist: pointer_down_action.twist,
+                                altitudeAngle: pointer_down_action.altitudeAngle,
+                                azimuthAngle: pointer_down_action.azimuthAngle,
                             },
                         ))),
                     ));


### PR DESCRIPTION
Testing: This is not testable right now in Servo:
This needs those special fields of PointerEvents, which depends on #41290, which furhter depends on #41801.
After all those, we would need to find a way to pass these fields to constellation/compositor/script, since #41290 only assigns default values to special fields.

Fixes: #41816
