### PR TITLE
Lint: Fix some wrong compile-time expectations for OHOS

### DIFF
--- a/components/background_hang_monitor/sampler.rs
+++ b/components/background_hang_monitor/sampler.rs
@@ -39,7 +39,7 @@ impl Default for NativeStack {
 }
 
 impl NativeStack {
-    #[cfg_attr(target_os = "windows", expect(dead_code))]
+    #[cfg_attr(any(target_os = "windows", target_env = "ohos"), expect(dead_code))]
     pub fn process_register(
         &mut self,
         instruction_ptr: *mut std::ffi::c_void,

--- a/components/fonts/platform/freetype/ohos/font_list.rs
+++ b/components/fonts/platform/freetype/ohos/font_list.rs
@@ -33,7 +33,6 @@ static OHOS_FONTS_DIR: &str = env!("OHOS_SDK_FONTS_DIR");
 #[cfg(not(ohos_mock))]
 static OHOS_FONTS_DIR: &str = "/system/fonts";
 
-#[expect(unused)]
 #[derive(Clone, Copy, Debug, Default)]
 // HarmonyOS only comes in Condensed and Normal variants
 enum FontWidth {


### PR DESCRIPTION
FontWidth is actually used.
`process_register` is not.

Testing: Warning is gone. No other change.
