### PR TITLE
webdriver: Allow Promise for synchronous script execution

### DIFF
--- a/components/webdriver_server/lib.rs
+++ b/components/webdriver_server/lib.rs
@@ -2037,7 +2037,7 @@ impl Handler {
         let script = format!(
             r#"(async function() {{
                 try {{
-                    let result = (function() {{
+                    let result = (async function() {{
                         {func_body}
                     }})({});
                     let value = await result;

--- a/components/webdriver_server/lib.rs
+++ b/components/webdriver_server/lib.rs
@@ -2030,14 +2030,25 @@ impl Handler {
         // Step 1. Let body and arguments be the result of trying to extract the script arguments
         // from a request with argument parameters.
         let (func_body, args_string) = self.extract_script_arguments(parameters)?;
+
         // This is pretty ugly; we really want something that acts like
         // new Function() and then takes the resulting function and executes
         // it with a vec of arguments.
         let script = format!(
-            "(function() {{ {}\n }})({})",
-            func_body,
+            r#"(async function() {{
+                try {{
+                    let result = (function() {{
+                        {func_body}
+                    }})({});
+                    let value = await result;
+                    window.webdriverCallback(value);
+                }} catch (err) {{
+                    window.webdriverException(err);
+                }}
+            }})();"#,
             args_string.join(", ")
         );
+
         debug!("{}", script);
 
         // Step 2. If session's current browsing context is no longer open,
@@ -2048,7 +2059,8 @@ impl Handler {
         self.handle_any_user_prompts(self.webview_id()?)?;
 
         let (sender, receiver) = generic_channel::channel().unwrap();
-        let cmd = WebDriverScriptCommand::ExecuteScript(script, sender);
+        let cmd = WebDriverScriptCommand::ExecuteAsyncScript(script, sender);
+
         self.browsing_context_script_command(cmd, VerifyBrowsingContextIsOpen::No)?;
 
         let timeout_duration = self

--- a/tests/wpt/meta/webdriver/tests/classic/execute_script/promise.py.ini
+++ b/tests/wpt/meta/webdriver/tests/classic/execute_script/promise.py.ini
@@ -1,3 +1,0 @@
-[promise.py]
-  [test_await_promise_resolve]
-    expected: FAIL

--- a/tests/wpt/meta/webdriver/tests/classic/execute_script/promise.py.ini
+++ b/tests/wpt/meta/webdriver/tests/classic/execute_script/promise.py.ini
@@ -1,27 +1,3 @@
 [promise.py]
-  [test_promise_resolve]
-    expected: FAIL
-
-  [test_promise_resolve_delayed]
-    expected: FAIL
-
-  [test_promise_all_resolve]
-    expected: FAIL
-
   [test_await_promise_resolve]
-    expected: FAIL
-
-  [test_promise_resolve_timeout]
-    expected: FAIL
-
-  [test_promise_reject]
-    expected: FAIL
-
-  [test_promise_reject_delayed]
-    expected: FAIL
-
-  [test_promise_all_reject]
-    expected: FAIL
-
-  [test_promise_reject_timeout]
     expected: FAIL


### PR DESCRIPTION
When a promise is given, it must be honoured.

Testing: `/classic/execute_script/promise.py` fully pass.