### PR TITLE
net: Implement redirect taint for requests

### DIFF
--- a/components/net/fetch/methods.rs
+++ b/components/net/fetch/methods.rs
@@ -588,7 +588,7 @@ pub async fn main_fetch(
         },
     };
 
-    // Step 13.
+    // Step 13. If recursive is true, then return response.
     if recursive_flag {
         return response;
     }
@@ -596,7 +596,7 @@ pub async fn main_fetch(
     // reborrow request to avoid double mutable borrow
     let request = &mut fetch_params.request;
 
-    // Step 14.
+    // Step 14. If response is not a network error and response is not a filtered response, then:
     let mut response = if !response.is_network_error() && response.internal_response.is_none() {
         // Substep 1.
         if request.response_tainting == ResponseTainting::CorsTainting {
@@ -675,6 +675,9 @@ pub async fn main_fetch(
             internal_response.url_list.clone_from(&request.url_list)
         }
 
+        // Step 17. Set internalResponse’s redirect taint to request’s redirect-taint.
+        internal_response.redirect_taint = request.redirect_taint_for_request();
+
         // Step 19. If response is not a network error and any of the following returns blocked
         // * should internalResponse to request be blocked as mixed content
         // * should internalResponse to request be blocked by Content Security Policy
@@ -745,7 +748,7 @@ pub async fn main_fetch(
         response
     };
 
-    // Step 19.
+    // Step 19. If response is not a network error and any of the following returns blocked
     let mut response_loaded = false;
     let mut response = if !response.is_network_error() && !request.integrity_metadata.is_empty() {
         // Step 19.1.

--- a/components/shared/net/response.rs
+++ b/components/shared/net/response.rs
@@ -58,6 +58,15 @@ impl ResponseBody {
     }
 }
 
+/// <https://fetch.spec.whatwg.org/#response-redirect-taint>
+#[derive(Clone, Copy, Debug, Default, Deserialize, MallocSizeOf, PartialEq, Serialize)]
+pub enum RedirectTaint {
+    #[default]
+    SameOrigin,
+    SameSite,
+    CrossSite,
+}
+
 /// [Cache state](https://fetch.spec.whatwg.org/#concept-response-cache-state)
 #[derive(Clone, Copy, Debug, Deserialize, MallocSizeOf, Serialize)]
 pub enum CacheState {
@@ -109,6 +118,8 @@ pub struct Response {
     pub https_state: HttpsState,
     pub tls_security_info: Option<TlsSecurityInfo>,
     pub referrer: Option<ServoUrl>,
+    /// <https://fetch.spec.whatwg.org/#response-redirect-taint>
+    pub redirect_taint: RedirectTaint,
     pub referrer_policy: ReferrerPolicy,
     /// [CORS-exposed header-name list](https://fetch.spec.whatwg.org/#concept-response-cors-exposed-header-name-list)
     pub cors_exposed_header_name_list: Vec<String>,
@@ -152,6 +163,7 @@ impl Response {
             aborted: Arc::new(AtomicBool::new(false)),
             resource_timing: Arc::new(Mutex::new(resource_timing)),
             range_requested: false,
+            redirect_taint: Default::default(),
         }
     }
 
@@ -187,6 +199,7 @@ impl Response {
                 ResourceTimingType::Error,
             ))),
             range_requested: false,
+            redirect_taint: Default::default(),
         }
     }
 


### PR DESCRIPTION
This updates the existing algorithm to handle three
cases rather than the previous two. The spec was updated
afterwards and wasn't reflected in the code yet.

The usage of `response.redirect_taint` is in [1],
but we don't implement that quite right either. However,
postponing that to a future PR to keep things manageable.

Part of #41807

[1]: https://fetch.spec.whatwg.org/#fetch-finale