### PR TITLE
Rename pauseCompositor/resumeCompositor in JNIServo

### DIFF
--- a/support/android/apk/servoview/src/main/java/org/servo/servoview/JNIServo.java
+++ b/support/android/apk/servoview/src/main/java/org/servo/servoview/JNIServo.java
@@ -62,8 +62,8 @@ public class JNIServo {
 
     public native void click(float x, float y);
 
-    public native void pauseCompositor();
-    public native void resumeCompositor(Surface surface, ServoCoordinates coords);
+    public native void pausePainting();
+    public native void resumePainting(Surface surface, ServoCoordinates coords);
 
     public native void mediaSessionAction(int action);
 

--- a/support/android/apk/servoview/src/main/java/org/servo/servoview/Servo.java
+++ b/support/android/apk/servoview/src/main/java/org/servo/servoview/Servo.java
@@ -121,11 +121,11 @@ public class Servo {
         mRunCallback.inGLThread(() -> mJNI.click(x, y));
     }
 
-    public void pauseCompositor() {
-        mRunCallback.inGLThread(() -> mJNI.pauseCompositor());
+    public void pausePainting() {
+        mRunCallback.inGLThread(() -> mJNI.pausePainting());
     }
-    public void resumeCompositor(Surface surface, ServoCoordinates coords) {
-        mRunCallback.inGLThread(() -> mJNI.resumeCompositor(surface, coords));
+    public void resumePainting(Surface surface, ServoCoordinates coords) {
+        mRunCallback.inGLThread(() -> mJNI.resumePainting(surface, coords));
     }
 
     public void suspend(boolean suspended) {

--- a/support/android/apk/servoview/src/main/java/org/servo/servoview/ServoView.java
+++ b/support/android/apk/servoview/src/main/java/org/servo/servoview/ServoView.java
@@ -241,7 +241,7 @@ public class ServoView extends SurfaceView
                         options, mServoView, mServoView, mClient, mActivity, surface);
             } else {
                 mPaused = false;
-                mServoView.mServo.resumeCompositor(surface, coords);
+                mServoView.mServo.resumePainting(surface, coords);
             }
 
             Choreographer.getInstance().postFrameCallback(mServoView);
@@ -259,7 +259,7 @@ public class ServoView extends SurfaceView
         public void surfaceDestroyed(SurfaceHolder holder) {
             Log.d(LOGTAG, "GLThread::surfaceDestroyed");
             mPaused = true;
-            mServoView.mServo.pauseCompositor();
+            mServoView.mServo.pausePainting();
         }
 
         public void shutdown() {


### PR DESCRIPTION
pauseCompositor/resumeCompositor have been renamed topausePainting/resumePainting in 824f551. This renames the Java methods to fix the regression.

Testing: Built servoview.aar and tested in Android app.
Fixes #41826
