### PR TITLE
webdriver: Consolidates synchronous and asynchrounous script execution

### DIFF
--- a/components/script/script_thread.rs
+++ b/components/script/script_thread.rs
@@ -2493,17 +2493,12 @@ impl ScriptThread {
                 webdriver_handlers::handle_remove_load_status_sender(&documents, pipeline_id)
             },
             // https://github.com/servo/servo/issues/23535
-            // These two Script messages need different treatment since the JS script might mutate
+            // The Script messages need different treatment since the JS script might mutate
             // `self.documents`, which would conflict with the immutable borrow of it that
             // occurs for the rest of the messages.
             // We manually drop the immutable borrow first, and quickly
             // end the borrow of documents to avoid runtime error.
-            WebDriverScriptCommand::ExecuteScript(script, reply) => {
-                let window = documents.find_window(pipeline_id);
-                drop(documents);
-                webdriver_handlers::handle_execute_script(window, script, reply, can_gc);
-            },
-            WebDriverScriptCommand::ExecuteAsyncScript(script, reply) => {
+            WebDriverScriptCommand::ExecuteScriptWithCallback(script, reply) => {
                 let window = documents.find_window(pipeline_id);
                 drop(documents);
                 webdriver_handlers::handle_execute_async_script(window, script, reply, can_gc);

--- a/components/script/webdriver_handlers.rs
+++ b/components/script/webdriver_handlers.rs
@@ -88,7 +88,7 @@ use crate::dom::types::ShadowRoot;
 use crate::dom::validitystate::ValidationFlags;
 use crate::dom::window::Window;
 use crate::dom::xmlserializer::XMLSerializer;
-use crate::realms::{AlreadyInRealm, InRealm, enter_realm};
+use crate::realms::{InRealm, enter_realm};
 use crate::script_runtime::{CanGc, JSContext as SafeJSContext};
 use crate::script_thread::ScriptThread;
 

--- a/components/shared/embedder/webdriver.rs
+++ b/components/shared/embedder/webdriver.rs
@@ -168,8 +168,7 @@ pub enum WebDriverScriptCommand {
     DeleteCookies(GenericSender<Result<(), ErrorStatus>>),
     DeleteCookie(String, GenericSender<Result<(), ErrorStatus>>),
     ElementClear(String, GenericSender<Result<(), ErrorStatus>>),
-    ExecuteScript(String, GenericSender<WebDriverJSResult>),
-    ExecuteAsyncScript(String, GenericSender<WebDriverJSResult>),
+    ExecuteScriptWithCallback(String, GenericSender<WebDriverJSResult>),
     FindElementsCSSSelector(String, GenericSender<Result<Vec<String>, ErrorStatus>>),
     FindElementsLinkText(
         String,

--- a/components/webdriver_server/lib.rs
+++ b/components/webdriver_server/lib.rs
@@ -2095,7 +2095,7 @@ impl Handler {
               .catch((r) => window.webdriverException(r));
             }})();"#,
         );
-        error!("{}", script);
+        debug!("{}", script);
 
         // Step 2. If session's current browsing context is no longer open,
         // return error with error code no such window.

--- a/ports/servoshell/running_app_state.rs
+++ b/ports/servoshell/running_app_state.rs
@@ -523,8 +523,7 @@ impl RunningAppState {
 
     pub(crate) fn handle_webdriver_script_command(&self, script_command: &WebDriverScriptCommand) {
         match script_command {
-            WebDriverScriptCommand::ExecuteScript(_webview_id, response_sender) |
-            WebDriverScriptCommand::ExecuteAsyncScript(_webview_id, response_sender) => {
+            WebDriverScriptCommand::ExecuteScriptWithCallback(_webview_id, response_sender) => {
                 // Give embedder a chance to interrupt the script command.
                 // Webdriver only handles 1 script command at a time, so we can
                 // safely set a new interrupt sender and remove the previous one here.


### PR DESCRIPTION
Follow-up to #41823.
Now that we always execute JS with callback, we can safely remove the obsolete sync script handler.

- Rename `ExecuteAsyncScript` to `ExecuteScriptWithCallback`
- Remove `ExecuteScript` related logic.
- Rewrite async callback wrapper to simplify things.

Testing: I expect no change in behaviour. See if WPT tests agree with it.