### PR TITLE
ci: Use checkout SHA for WPT GitHub check

### DIFF
--- a/.github/workflows/linux-wpt.yml
+++ b/.github/workflows/linux-wpt.yml
@@ -128,7 +128,13 @@ jobs:
           pattern: wpt-filtered-logs-linux-*
           delete-merged: true
       - uses: actions/checkout@v5
-        if: ${{ !cancelled() && !inputs.wpt-sync-from-upstream }}
+        if: ${{ !cancelled() && !inputs.wpt-sync-from-upstream && github.event_name != 'pull_request_target' }}
+      # This is necessary to checkout the pull request if this run was triggered via a
+      # `pull_request_target` event.
+      - uses: actions/checkout@v5
+        if: ${{ !cancelled() && !inputs.wpt-sync-from-upstream && github.event_name == 'pull_request_target' }}
+        with:
+          ref: refs/pull/${{ github.event.number }}/head
       - uses: actions/download-artifact@v4
         if: ${{ !cancelled() && !inputs.wpt-sync-from-upstream }}
         with:

--- a/etc/ci/report_aggregated_expected_results.py
+++ b/etc/ci/report_aggregated_expected_results.py
@@ -190,7 +190,7 @@ def get_pr_number() -> Optional[str]:
 
 
 def get_commit() -> str:
-    return subprocess.check_output(['git', 'rev-parse', 'HEAD']).decode("utf-8").strip()
+    return subprocess.check_output(["git", "rev-parse", "HEAD"]).decode("utf-8").strip()
 
 
 def create_github_reports(body: str, tag: str = ""):

--- a/etc/ci/report_aggregated_expected_results.py
+++ b/etc/ci/report_aggregated_expected_results.py
@@ -189,7 +189,7 @@ def get_pr_number() -> Optional[str]:
     return None
 
 
-def get_commit() -> str:
+def get_commit_sha() -> str:
     return subprocess.check_output(["git", "rev-parse", "HEAD"]).decode("utf-8").strip()
 
 
@@ -222,7 +222,7 @@ def create_github_reports(body: str, tag: str = ""):
     repo = github_context["repository"]
     data = {
         "name": tag,
-        "head_sha": get_commit(),
+        "head_sha": get_commit_sha(),
         "status": "completed",
         "started_at": datetime.utcnow().replace(microsecond=0).isoformat() + "Z",
         "conclusion": conclusion,

--- a/etc/ci/report_aggregated_expected_results.py
+++ b/etc/ci/report_aggregated_expected_results.py
@@ -189,6 +189,10 @@ def get_pr_number() -> Optional[str]:
     return None
 
 
+def get_commit() -> str:
+    return subprocess.check_output(['git', 'rev-parse', 'HEAD']).decode("utf-8").strip()
+
+
 def create_github_reports(body: str, tag: str = ""):
     # GitHub will set a special environment variable which points to a file where
     # a job summary can be appended. This is produced in addition to the GitHub
@@ -213,14 +217,12 @@ def create_github_reports(body: str, tag: str = ""):
 
     github_token = os.environ.get("GITHUB_TOKEN")
     github_context = json.loads(os.environ.get("GITHUB_CONTEXT", "{}"))
-    if "sha" not in github_context:
-        return None
     if "repository" not in github_context:
         return None
     repo = github_context["repository"]
     data = {
         "name": tag,
-        "head_sha": github_context["sha"],
+        "head_sha": get_commit(),
         "status": "completed",
         "started_at": datetime.utcnow().replace(microsecond=0).isoformat() + "Z",
         "conclusion": conclusion,


### PR DESCRIPTION
This is alternative to https://github.com/servo/servo/pull/41491 with actual fix. Instead of using `github.sha` which has sha of workflow commit (which is wrong when doing try labels) we use actual checkout commit.

Fixes: #41489
