### PR TITLE
script: Include click count as the `detail` of `mouseup` and `mousedown` events

### DIFF
--- a/components/script/dom/mouseevent.rs
+++ b/components/script/dom/mouseevent.rs
@@ -255,6 +255,7 @@ impl MouseEvent {
 
     /// Create a [MouseEvent] triggered by the embedder
     /// <https://w3c.github.io/uievents/#create-a-cancelable-mouseevent-id>
+    #[expect(clippy::too_many_arguments)]
     pub(crate) fn for_platform_mouse_event(
         event_type_string: &'static str,
         event: embedder_traits::MouseButtonEvent,
@@ -262,6 +263,7 @@ impl MouseEvent {
         window: &Window,
         hit_test_result: &HitTestResult,
         modifiers: Modifiers,
+        click_count: usize,
         can_gc: CanGc,
     ) -> DomRoot<Self> {
         let client_point = hit_test_result.point_in_frame.to_i32();
@@ -269,14 +271,13 @@ impl MouseEvent {
             .point_relative_to_initial_containing_block
             .to_i32();
 
-        let click_count = 1;
         let mouse_event = MouseEvent::new(
             window,
             event_type_string.into(),
             EventBubbles::Bubbles,
             EventCancelable::Cancelable,
             Some(window),
-            click_count,
+            click_count as i32,
             client_point, // TODO: Get real screen coordinates?
             client_point,
             page_point,

--- a/components/shared/embedder/input_events.rs
+++ b/components/shared/embedder/input_events.rs
@@ -152,7 +152,7 @@ impl MouseButtonEvent {
     }
 }
 
-#[derive(Clone, Copy, Debug, Deserialize, PartialEq, Serialize)]
+#[derive(Clone, Copy, Debug, Deserialize, MallocSizeOf, PartialEq, Serialize)]
 pub enum MouseButton {
     Left,
     Middle,

--- a/tests/wpt/meta/webdriver/tests/classic/perform_actions/pointer_pause_dblclick.py.ini
+++ b/tests/wpt/meta/webdriver/tests/classic/perform_actions/pointer_pause_dblclick.py.ini
@@ -1,3 +1,0 @@
-[pointer_pause_dblclick.py]
-  [test_dblclick_with_pause_after_second_pointerdown]
-    expected: FAIL

--- a/tests/wpt/mozilla/meta/MANIFEST.json
+++ b/tests/wpt/mozilla/meta/MANIFEST.json
@@ -12919,6 +12919,15 @@
     ]
    },
    "input-events": {
+    "dblclick-events-fired-every-two-clicks.html": [
+     "9ad53ceaf05018bb48e4ff2424da4e45fbca6be6",
+     [
+      null,
+      {
+       "testdriver": true
+      }
+     ]
+    ],
     "input-events-textarea-cut-paste.html": [
      "7e1151d222b5a5210921345a3e60434194cd1794",
      [
@@ -12930,6 +12939,15 @@
     ],
     "input-events-textarea-typing.html": [
      "19d8f6be9537f4a286471ddd483a75c01a34e912",
+     [
+      null,
+      {
+       "testdriver": true
+      }
+     ]
+    ],
+    "mouse-button-events-detail-increases-indefinitely.html": [
+     "6bf57fe3accad4d3cbfb454e10f31b0a8540b5a5",
      [
       null,
       {

--- a/tests/wpt/mozilla/tests/input-events/dblclick-events-fired-every-two-clicks.html
+++ b/tests/wpt/mozilla/tests/input-events/dblclick-events-fired-every-two-clicks.html
@@ -1,0 +1,64 @@
+
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <title>dblclick event is fired for every two mouse click events</title>
+    <link rel="author" title="Martin Robinson" href="mailto:mrobinson@igalia.com" />
+    <script src="/resources/testharness.js"></script>
+    <script src="/resources/testharnessreport.js"></script>
+    <script src="/resources/testdriver.js"></script>
+    <script src="/resources/testdriver-actions.js"></script>
+    <script src="/resources/testdriver-vendor.js"></script>
+    <style>
+    #target
+    {
+        background-color: green;
+        width: 200px;
+        height: 200px;
+    }
+    </style>
+  </head>
+  <body>
+    <div id="target"></div>
+    <script>
+        /// This tests that "dblclick" is fired for every two mouse events and that
+        /// the detail is always 2, no matter how many clicks are fired.
+        promise_test(async (t) => {
+            const target = document.getElementById("target");
+            const event_watcher = new EventWatcher(t, target, ["click", "dblclick"]);
+
+            const actions_promise = new test_driver.Actions()
+              .pointerMove(0, 0, {origin: target})
+              .pointerDown().pointerUp()
+              .pointerDown().pointerUp()
+              .pointerDown().pointerUp()
+              .pointerDown().pointerUp()
+              .pointerDown().pointerUp()
+              .pointerDown().pointerUp()
+              .send();
+
+            // Make sure the test finishes after all the input actions are completed.
+            t.add_cleanup(() => actions_promise);
+
+            const event = await event_watcher.wait_for([
+                // First click.
+                "click",
+                // Second click.
+                "click", "dblclick",
+                // Third click.
+                "click",
+                // Fourth click.
+                "click", "dblclick",
+                // Fifth click.
+                "click",
+                // Sixth click.
+                "click", "dblclick"
+            ]);
+            assert_equals(event.type, "dblclick");
+            assert_equals(event.target, target);
+            assert_equals(event.detail, 2);
+        });
+    </script>
+  </body>
+</html>

--- a/tests/wpt/mozilla/tests/input-events/mouse-button-events-detail-increases-indefinitely.html
+++ b/tests/wpt/mozilla/tests/input-events/mouse-button-events-detail-increases-indefinitely.html
@@ -1,0 +1,81 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <title>Mout button event counts the number of clicks indefinintely</title>
+    <link rel="author" title="Martin Robinson" href="mailto:mrobinson@igalia.com" />
+    <script src="/resources/testharness.js"></script>
+    <script src="/resources/testharnessreport.js"></script>
+    <script src="/resources/testdriver.js"></script>
+    <script src="/resources/testdriver-actions.js"></script>
+    <script src="/resources/testdriver-vendor.js"></script>
+    <style>
+    #target
+    {
+        background-color: green;
+        width: 200px;
+        height: 200px;
+    }
+    </style>
+  </head>
+  <body>
+    <div id="target"></div>
+    <script>
+        promise_test(async (t) => {
+            const target = document.getElementById("target");
+            let clickCount = 0;
+            target.addEventListener("click", (event) => {
+                assert_equals(clickCount + 1, event.detail);
+                clickCount = event.detail;
+            });
+
+            const event_watcher = new EventWatcher(t, target, ["click"]);
+            const actionsPromise = new test_driver.Actions()
+              .pointerMove(0, 0, {origin: target})
+              .pointerDown().pointerUp()
+              .pointerDown().pointerUp()
+              .pointerDown().pointerUp()
+              .pointerDown().pointerUp()
+              .pointerDown().pointerUp()
+              .pointerDown().pointerUp()
+              .send();
+
+            // Make sure the test finishes after all the input actions are completed.
+            t.add_cleanup(() => actionsPromise);
+
+            const event = await event_watcher.wait_for(["click", "click", "click", "click", "click", "click"]);
+            assert_equals(clickCount, 6);
+        }, "'detail' count for click events for left button increases indefinitely");
+
+        promise_test(async (t) => {
+            const target = document.getElementById("target");
+            let clickCount = 0;
+            target.addEventListener("mouseup", (event) => {
+                assert_equals(clickCount + 1, event.detail);
+                clickCount = event.detail;
+            });
+
+            // Also listen for `click` events here to ensure they are not fired for right button events.
+            const event_watcher = new EventWatcher(t, target, ["mouseup", "click"]);
+            const actions = new test_driver.Actions();
+            let options = { button: actions.ButtonType.RIGHT };
+            const actionsPromise = actions
+              .pointerMove(0, 0, {origin: target})
+              .pointerDown(options).pointerUp(options)
+              .pointerDown(options).pointerUp(options)
+              .pointerDown(options).pointerUp(options)
+              .pointerDown(options).pointerUp(options)
+              .pointerDown(options).pointerUp(options)
+              .pointerDown(options).pointerUp(options)
+              .send();
+
+            // Make sure the test finishes after all the input actions are completed.
+            t.add_cleanup(() => actionsPromise);
+
+            const event = await event_watcher.wait_for(["mouseup", "mouseup", "mouseup", "mouseup", "mouseup", "mouseup"]);
+            assert_equals(clickCount, 6);
+        }, "'detail' for mouseup events for right button clicks increase indefinitely");
+
+    </script>
+  </body>
+</html>


### PR DESCRIPTION
This change improves the counting of clicks for mouse button events by
ensuring that `detail` property of those events includes the click
count. This `detail` differs from that of `dblclick` events where the
`detail` is always 2. In addition, it ensures that the click count can
increase for mouse buttons that do not cause `click` and `dblclick`
events (such as the right mouse button).

Testing: This change adds two Servo-specific WPT-style tests. While this
behavior is specified a bit, the details are implementation specific.
