### PR TITLE
script: Implement navigate to fragment algorithm

### DIFF
--- a/components/script/dom/history.rs
+++ b/components/script/dom/history.rs
@@ -100,7 +100,7 @@ impl History {
 
         // Step 8
         if let Some(fragment) = url.fragment() {
-            document.check_and_scroll_fragment(fragment);
+            document.scroll_to_the_fragment(fragment);
         }
 
         // Step 11

--- a/components/script/dom/html/htmlmetaelement.rs
+++ b/components/script/dom/html/htmlmetaelement.rs
@@ -163,11 +163,11 @@ impl HTMLMetaElement {
             return;
         }
 
-        // 2
+        // Step 2. Let input be the value of the element's content attribute.
         let content = self.Content();
-        // 1
+        // Step 1. If the meta element has no content attribute, or if that attribute's value is the empty string, then return.
         if !content.is_empty() {
-            // 3
+            // Step 3. Run the shared declarative refresh steps with the meta element's node document, input, and the meta element.
             self.owner_document()
                 .shared_declarative_refresh_steps(&content.as_bytes());
         }

--- a/tests/wpt/meta/html/browsers/browsing-the-web/history-traversal/hash-empty-string.html.ini
+++ b/tests/wpt/meta/html/browsers/browsing-the-web/history-traversal/hash-empty-string.html.ini
@@ -1,3 +1,0 @@
-[hash-empty-string.html]
-  [changing the hash from an empty string to an empty string does not trigger a hashchange event]
-    expected: FAIL

--- a/tests/wpt/meta/html/browsers/browsing-the-web/navigating-across-documents/initial-empty-document/iframe-src-204-fragment.html.ini
+++ b/tests/wpt/meta/html/browsers/browsing-the-web/navigating-across-documents/initial-empty-document/iframe-src-204-fragment.html.ini
@@ -2,11 +2,5 @@
   [src]
     expected: FAIL
 
-  [location.assign]
-    expected: FAIL
-
   [window.open]
-    expected: FAIL
-
-  [link click]
     expected: FAIL

--- a/tests/wpt/meta/html/browsers/browsing-the-web/navigating-across-documents/initial-empty-document/window-open-204-fragment.html.ini
+++ b/tests/wpt/meta/html/browsers/browsing-the-web/navigating-across-documents/initial-empty-document/window-open-204-fragment.html.ini
@@ -1,3 +1,0 @@
-[window-open-204-fragment.html]
-  [location.assign]
-    expected: FAIL

--- a/tests/wpt/meta/html/browsers/browsing-the-web/scroll-to-fragid/scroll-frag-percent-encoded.html.ini
+++ b/tests/wpt/meta/html/browsers/browsing-the-web/scroll-to-fragid/scroll-frag-percent-encoded.html.ini
@@ -1,3 +1,0 @@
-[scroll-frag-percent-encoded.html]
-  [Fragment Navigation: fragment id should be percent-decoded]
-    expected: FAIL

--- a/tests/wpt/meta/html/browsers/browsing-the-web/scroll-to-fragid/scroll-to-anchor-name.html.ini
+++ b/tests/wpt/meta/html/browsers/browsing-the-web/scroll-to-fragid/scroll-to-anchor-name.html.ini
@@ -1,3 +1,0 @@
-[scroll-to-anchor-name.html]
-  [Fragment Navigation: scroll to anchor name is lower priority than equal id]
-    expected: FAIL

--- a/tests/wpt/meta/html/browsers/browsing-the-web/scroll-to-fragid/scroll-to-id-top.html.ini
+++ b/tests/wpt/meta/html/browsers/browsing-the-web/scroll-to-fragid/scroll-to-id-top.html.ini
@@ -1,3 +1,0 @@
-[scroll-to-id-top.html]
-  [Fragment Navigation: TOP is a valid element id, which overrides navigating to top of the document]
-    expected: FAIL

--- a/tests/wpt/meta/html/browsers/browsing-the-web/scroll-to-fragid/scroll-to-top.html.ini
+++ b/tests/wpt/meta/html/browsers/browsing-the-web/scroll-to-fragid/scroll-to-top.html.ini
@@ -1,3 +1,0 @@
-[scroll-to-top.html]
-  [Fragment Navigation: When fragid is TOP scroll to the top of the document]
-    expected: FAIL

--- a/tests/wpt/meta/html/browsers/history/the-location-interface/location_hash_set_empty_string.html.ini
+++ b/tests/wpt/meta/html/browsers/history/the-location-interface/location_hash_set_empty_string.html.ini
@@ -1,3 +1,0 @@
-[location_hash_set_empty_string.html]
-  [window.location.hash is an empty string]
-    expected: FAIL


### PR DESCRIPTION
Part of the navigate algorithm, it now performs the
fragment navigation after the history_behavior is
determined. It also updates the scrolling algorithm
to reflect what the specification expects.

With these changes, the test from the issue now
correctly scrolls to `Target`, but it doesn't update
the `scrollY` value for `window` and hence still
fails the test.

Part of #41807