### PR TITLE
lint: Update deny.toml

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -165,9 +165,6 @@ skip = [
     # duplicated by async-io
     "rustix",
 
-    # duplicated by zbus-xml
-    "quick-xml",
-
     # duplicated by sea-query
     "heck",
 


### PR DESCRIPTION
`quick-xml` is no longer duplicated. Checking rest later.

Fixes: The case reported in #41845, but not the issue itself.