### PR TITLE
libservo: Extend `SiteDataManager::clear_site_data` to clear localStorage

### DIFF
--- a/components/servo/site_data_manager.rs
+++ b/components/servo/site_data_manager.rs
@@ -178,14 +178,17 @@ impl SiteDataManager {
     ///
     /// The clearing is restricted to the provided `storage_types` bitflags.
     /// Both public and private browsing data are affected.
-    ///
-    /// TODO: At present this method can only clear cookies and sessionStorage
-    /// data for the specified sites. Support for localStorage will be added
-    /// in a follow-up.
     pub fn clear_site_data(&self, sites: &[&str], storage_types: StorageType) {
         if storage_types.contains(StorageType::Cookies) {
             self.public_resource_threads.clear_cookies_for_sites(sites);
             self.private_resource_threads.clear_cookies_for_sites(sites);
+        }
+
+        if storage_types.contains(StorageType::Local) {
+            self.public_storage_threads
+                .clear_webstorage_for_sites(WebStorageType::Local, sites);
+            self.private_storage_threads
+                .clear_webstorage_for_sites(WebStorageType::Local, sites);
         }
 
         if storage_types.contains(StorageType::Session) {

--- a/components/servo/tests/site_data_manager.rs
+++ b/components/servo/tests/site_data_manager.rs
@@ -356,6 +356,109 @@ fn test_clear_site_data_cookies() {
 }
 
 #[test]
+fn test_clear_site_data_local() {
+    let webview_test = WebViewTest::new();
+
+    let site_data_manager = webview_test.servo().site_data_manager();
+
+    let sites = site_data_manager.site_data(StorageType::all());
+    assert_eq!(sites.len(), 0);
+
+    let steps: &[TestSiteDataStep] = &[
+        (
+            SiteData::new("site-data-0.test", StorageType::Cookies),
+            None,
+        ),
+        (SiteData::new("site-data-1a.test", StorageType::Local), None),
+        (SiteData::new("site-data-1b.test", StorageType::Local), None),
+        (SiteData::new("site-data-1c.test", StorageType::Local), None),
+        (
+            SiteData::new("site-data-2.test", StorageType::Session),
+            None,
+        ),
+        (
+            SiteData::new(
+                "site-data-3.test",
+                StorageType::Cookies | StorageType::Local | StorageType::Session,
+            ),
+            None,
+        ),
+    ];
+
+    run_test_site_data_steps(&webview_test, steps);
+
+    let sites = site_data_manager.site_data(StorageType::all());
+    assert_eq!(
+        &sites,
+        &[
+            SiteData::new("site-data-0.test", StorageType::Cookies),
+            SiteData::new("site-data-1a.test", StorageType::Local),
+            SiteData::new("site-data-1b.test", StorageType::Local),
+            SiteData::new("site-data-1c.test", StorageType::Local),
+            SiteData::new("site-data-2.test", StorageType::Session),
+            SiteData::new(
+                "site-data-3.test",
+                StorageType::Cookies | StorageType::Local | StorageType::Session
+            ),
+        ]
+    );
+
+    site_data_manager.clear_site_data(&["site-data-1.test"], StorageType::Local);
+
+    let sites = site_data_manager.site_data(StorageType::all());
+    assert_eq!(
+        &sites,
+        &[
+            SiteData::new("site-data-0.test", StorageType::Cookies),
+            SiteData::new("site-data-1a.test", StorageType::Local),
+            SiteData::new("site-data-1b.test", StorageType::Local),
+            SiteData::new("site-data-1c.test", StorageType::Local),
+            SiteData::new("site-data-2.test", StorageType::Session),
+            SiteData::new(
+                "site-data-3.test",
+                StorageType::Cookies | StorageType::Local | StorageType::Session
+            ),
+        ]
+    );
+
+    site_data_manager.clear_site_data(&["site-data-1a.test"], StorageType::Local);
+
+    let sites = site_data_manager.site_data(StorageType::all());
+    assert_eq!(
+        &sites,
+        &[
+            SiteData::new("site-data-0.test", StorageType::Cookies),
+            SiteData::new("site-data-1b.test", StorageType::Local),
+            SiteData::new("site-data-1c.test", StorageType::Local),
+            SiteData::new("site-data-2.test", StorageType::Session),
+            SiteData::new(
+                "site-data-3.test",
+                StorageType::Cookies | StorageType::Local | StorageType::Session
+            ),
+        ]
+    );
+
+    site_data_manager.clear_site_data(
+        &["site-data-1c.test", "site-data-3.test"],
+        StorageType::Local,
+    );
+
+    let sites = site_data_manager.site_data(StorageType::all());
+    assert_eq!(
+        &sites,
+        &[
+            SiteData::new("site-data-0.test", StorageType::Cookies),
+            SiteData::new("site-data-1b.test", StorageType::Local),
+            SiteData::new("site-data-2.test", StorageType::Session),
+            SiteData::new(
+                "site-data-3.test",
+                StorageType::Cookies | StorageType::Session
+            ),
+        ]
+    );
+}
+
+#[test]
 fn test_clear_site_data_session() {
     let webview_test = WebViewTest::new();
 

--- a/components/storage/tests/webstorage.rs
+++ b/components/storage/tests/webstorage.rs
@@ -11,13 +11,13 @@ use storage_traits::StorageThreads;
 use storage_traits::webstorage_thread::{WebStorageThreadMsg, WebStorageType};
 use tempfile::TempDir;
 
-pub struct WebStorageTest {
+pub(crate) struct WebStorageTest {
     tmp_dir: Option<TempDir>,
     threads: StorageThreads,
 }
 
 impl WebStorageTest {
-    pub fn new() -> Self {
+    pub(crate) fn new() -> Self {
         let tmp_dir = tempfile::tempdir().unwrap();
         let config_dir = tmp_dir.path().to_path_buf();
         let mem_profiler_chan = profile_mem::Profiler::create();
@@ -29,7 +29,7 @@ impl WebStorageTest {
         }
     }
 
-    pub fn new_in_memory() -> Self {
+    pub(crate) fn new_in_memory() -> Self {
         let mem_profiler_chan = profile_mem::Profiler::create();
         let threads = storage::new_storage_threads(mem_profiler_chan, None);
 
@@ -39,7 +39,7 @@ impl WebStorageTest {
         }
     }
 
-    pub fn restart(mut self) -> Self {
+    pub(crate) fn restart(mut self) -> Self {
         let tmp_dir = self.tmp_dir.take();
         let config_dir = tmp_dir.as_ref().map(|d| d.path().to_path_buf());
         let mem_profiler_chan = profile_mem::Profiler::create();
@@ -51,11 +51,11 @@ impl WebStorageTest {
         }
     }
 
-    pub fn threads(&self) -> StorageThreads {
+    pub(crate) fn threads(&self) -> StorageThreads {
         self.threads.clone()
     }
 
-    pub fn length(&self, storage_type: WebStorageType, url: &ServoUrl) -> usize {
+    pub(crate) fn length(&self, storage_type: WebStorageType, url: &ServoUrl) -> usize {
         let (sender, receiver) = base_channel::channel().unwrap();
         self.threads
             .send(WebStorageThreadMsg::Length(
@@ -68,7 +68,12 @@ impl WebStorageTest {
         receiver.recv().unwrap()
     }
 
-    pub fn key(&self, storage_type: WebStorageType, url: &ServoUrl, index: u32) -> Option<String> {
+    pub(crate) fn key(
+        &self,
+        storage_type: WebStorageType,
+        url: &ServoUrl,
+        index: u32,
+    ) -> Option<String> {
         let (sender, receiver) = base_channel::channel().unwrap();
         self.threads
             .send(WebStorageThreadMsg::Key(
@@ -82,7 +87,7 @@ impl WebStorageTest {
         receiver.recv().unwrap()
     }
 
-    pub fn keys(&self, storage_type: WebStorageType, url: &ServoUrl) -> Vec<String> {
+    pub(crate) fn keys(&self, storage_type: WebStorageType, url: &ServoUrl) -> Vec<String> {
         let (sender, receiver) = base_channel::channel().unwrap();
         self.threads
             .send(WebStorageThreadMsg::Keys(
@@ -95,7 +100,7 @@ impl WebStorageTest {
         receiver.recv().unwrap()
     }
 
-    pub fn get_item(
+    pub(crate) fn get_item(
         &self,
         storage_type: WebStorageType,
         url: &ServoUrl,
@@ -114,7 +119,7 @@ impl WebStorageTest {
         receiver.recv().unwrap()
     }
 
-    pub fn set_item(
+    pub(crate) fn set_item(
         &self,
         storage_type: WebStorageType,
         url: &ServoUrl,
@@ -135,7 +140,7 @@ impl WebStorageTest {
         receiver.recv().unwrap()
     }
 
-    pub fn remove_item(
+    pub(crate) fn remove_item(
         &self,
         storage_type: WebStorageType,
         url: &ServoUrl,
@@ -154,7 +159,7 @@ impl WebStorageTest {
         receiver.recv().unwrap()
     }
 
-    pub fn clear(&self, storage_type: WebStorageType, url: &ServoUrl) -> bool {
+    pub(crate) fn clear(&self, storage_type: WebStorageType, url: &ServoUrl) -> bool {
         let (sender, receiver) = base_channel::channel().unwrap();
         self.threads
             .send(WebStorageThreadMsg::Clear(

--- a/components/storage/webstorage/mod.rs
+++ b/components/storage/webstorage/mod.rs
@@ -624,8 +624,8 @@ impl WebStorageManager {
                             .get_origin_location(&origin)
                             .expect("Should always be able to get origin location.");
 
-                        if let Err(e) = std::fs::remove_dir_all(&origin_location) {
-                            warn!("Failed to delete origin location: {:?}", e);
+                        if let Err(error) = std::fs::remove_dir_all(&origin_location) {
+                            warn!("Failed to delete origin location: {:?}", error);
                             self.local_storage_origins.ensure_origin_descriptor(&origin);
                         }
                     }

--- a/components/storage/webstorage/mod.rs
+++ b/components/storage/webstorage/mod.rs
@@ -614,7 +614,28 @@ impl WebStorageManager {
                 });
             },
             WebStorageType::Local => {
-                // TODO: Implement clering site data for localStorage
+                let origins = self.local_storage_origins.take_origins_for_sites(sites);
+
+                if self.config_dir.is_some() {
+                    for origin in origins {
+                        self.environments.remove(&origin);
+
+                        let origin_location = self
+                            .get_origin_location(&origin)
+                            .expect("Should always be able to get origin location.");
+
+                        if let Err(e) = std::fs::remove_dir_all(&origin_location) {
+                            warn!("Failed to delete origin location: {:?}", e);
+                            self.local_storage_origins.ensure_origin_descriptor(&origin);
+                        }
+                    }
+
+                    self.save_local_storage_origins();
+                } else {
+                    for origin in origins {
+                        self.environments.remove(&origin);
+                    }
+                }
             },
         }
     }


### PR DESCRIPTION
localStorage entries are identified via their associated origins found for the
given sites. This brings localStorage in line with cookies and sessionStorage,
which were already handled by the API.
    
Both public and private browsing contexts are included in the clearing
operation.
    
The necessary support and testing has been added to the storage crate to clear
localStorage data.

Testing: New unit tests and a new integration test have been added.