### PR TITLE
mach: Upgrade `cargo-deny` and report unknown errors in `test-tidy`

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -59,7 +59,12 @@ jobs:
           crate: taplo-cli
           locked: true
       - name: Install cargo-deny
-        if: ${{ runner.environment != 'self-hosted' }}
+        # We need at least 0.18.6 due to #41845, but the fix in #41853
+        # can't land without first upgrading cargo-deny in self-hosted
+        # runners. So, use the action to install 0.19.0 on both GH and
+        # self-hosted runners for now and make this conditional again
+        # after https://github.com/servo/ci-runners/issues/98 is done.
+        # if: ${{ runner.environment != 'self-hosted' }}
         uses: baptiste0928/cargo-install@v3
         with:
           crate: cargo-deny

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -63,7 +63,7 @@ jobs:
         uses: baptiste0928/cargo-install@v3
         with:
           crate: cargo-deny
-          version: 0.18.3
+          version: 0.19.0
           locked: true
       - name: Bootstrap dependencies
         if: ${{ runner.environment != 'self-hosted' }}

--- a/deny.toml
+++ b/deny.toml
@@ -28,6 +28,9 @@ ignore = [
     # cryptographic secret via side channel. Wait for a patch in stable
     # release version from upstream.
     "RUSTSEC-2023-0071",
+    # The crate `bincode` is unmaintained. This crate is now pinned in Servo.
+    # See the comment above `bincode` entry in Cargo.toml.
+    "RUSTSEC-2025-0141",
 ]
 
 # This section is considered when running `cargo deny check licenses`
@@ -193,6 +196,18 @@ skip = [
     # 0.3.0 and ml-dsa releases the next version 0.1.0, we can remove
     # this.
     "hybrid-array",
+
+
+    # The following 5 duplicates were introduced when Servo's CI was failing to
+    # detect duplicates introduced in automatic dependabot PRs (#38945). They
+    # are added here to allow the fix for this issue to land as a priority.
+    # These need to be investigated separately to see if the duplication can be
+    # avoided.
+    "libloading",
+    "futures",
+    "cfg-expr",
+    "system-deps",
+    "target-lexicon",
 ]
 
 # github.com organizations to allow git sources for

--- a/python/servo/platform/base.py
+++ b/python/servo/platform/base.py
@@ -92,16 +92,16 @@ class Base:
         def cargo_deny_installed() -> bool:
             if force or not shutil.which("cargo-deny"):
                 return False
-            # Tidy needs at least version 0.18.1 installed.
+            # Tidy needs at least version 0.18.6 installed.
             result = subprocess.run(["cargo-deny", "--version"], encoding="utf-8", capture_output=True)
             (major, minor, micro) = result.stdout.strip().split(" ")[1].split(".", 2)
-            return (int(major), int(minor), int(micro)) >= (0, 18, 1)
+            return (int(major), int(minor), int(micro)) >= (0, 18, 6)
 
         if cargo_deny_installed():
             return False
 
         print(" * Installing cargo-deny...")
-        if subprocess.call(["cargo", "install", "cargo-deny@0.18.3", "--locked"]) != 0:
+        if subprocess.call(["cargo", "install", "cargo-deny@0.19.0", "--locked"]) != 0:
             raise EnvironmentError("Installation of cargo-deny failed.")
         return True
 

--- a/python/tidy/tidy.py
+++ b/python/tidy/tidy.py
@@ -506,6 +506,11 @@ def run_cargo_deny_lints() -> Iterator[tuple[str, int, str]]:
         elif error_severity in ["warning", "error"]:
             errors.append((CARGO_DENY_CONFIG_FILE, line, f"{message}: {span}"))
 
+    # If there are no known errors but cargo-deny still failed, ensure test-tidy also fails.
+    if len(errors) == 0 and result.returncode != 0:
+        errors.append((CARGO_DENY_CONFIG_FILE, 1,
+                       f"Unknown error when running `cargo-deny`. See the full output:\n f{result.stderr}"))
+
     for error in errors:
         yield error
 

--- a/python/tidy/tidy.py
+++ b/python/tidy/tidy.py
@@ -508,8 +508,13 @@ def run_cargo_deny_lints() -> Iterator[tuple[str, int, str]]:
 
     # If there are no known errors but cargo-deny still failed, ensure test-tidy also fails.
     if len(errors) == 0 and result.returncode != 0:
-        errors.append((CARGO_DENY_CONFIG_FILE, 1,
-                       f"Unknown error when running `cargo-deny`. See the full output:\n f{result.stderr}"))
+        errors.append(
+            (
+                CARGO_DENY_CONFIG_FILE,
+                1,
+                f"Unknown error when running `cargo-deny`. See the full output:\n f{result.stderr}",
+            )
+        )
 
     for error in errors:
         yield error

--- a/shell.nix
+++ b/shell.nix
@@ -8,7 +8,7 @@ with import (builtins.fetchTarball {
   # NixOS users: if servoshell crashes with an assertion failure in surfman’s x11/connection.rs,
   # eglInitialize() may be failing, or you may be building with an incompatible version of glibc.
   # Use your system nixpkgs here, change `llvmPackages` below if necessary, then do a clean build.
-  url = "https://github.com/NixOS/nixpkgs/archive/a8d610af3f1a5fb71e23e08434d8d61a466fc942.tar.gz";
+  url = "https://github.com/NixOS/nixpkgs/archive/ffbc9f8cbaacfb331b6017d5a5abb21a492c9a38.tar.gz";
 }) {
   overlays = [
     (import (builtins.fetchTarball {


### PR DESCRIPTION
The versions of `cargo-deny` older than 0.18.6 have a bug which causes the executions of `cargo-deny check` to prematurely fail when reading the advisory db (https://github.com/EmbarkStudios/cargo-deny/issues/804).

This error is ignored by `test-tidy` since the error message doesn't have the expected JSON fields, causing `test-tidy` to succeed even when there are valid issues in `deny.toml` or `Cargo.lock`.

So upgrade the `cargo-deny` version  installed by `mach` to be the latest version and ensure that at least the version with the fix is installed on the system. Also fix the `test-tidy` code to always fail when the exit code from `cargo-deny` is non-zero.

This patch also updates `deny.toml` to include exceptions to allow `./mach test-tidy` to pass. Some of these need to be investigated separately from this change.

Fixes #41845.
Fixes #38945.

Testing: Tested locally on NixOS.

