### PR TITLE
mach: Remove limits on the number of Rayon threads

### DIFF
--- a/python/wpt/run.py
+++ b/python/wpt/run.py
@@ -41,12 +41,6 @@ def set_if_none(args: dict, key: str, value: bool | int | str) -> None:
 def run_tests(default_binary_path: str, **kwargs: Any) -> int:
     print(f"Running WPT tests with {default_binary_path}")
 
-    # By default, Rayon selects the number of worker threads based on the
-    # available CPU count. This doesn't work very well when running tests on CI,
-    # since we run so many Servo processes in parallel. The result is a lot of
-    # extra timeouts. Instead, force Rayon to assume we are running on a 2 CPU
-    # environment.
-    os.environ["RAYON_RS_NUM_CPUS"] = "2"
     os.environ["RUST_BACKTRACE"] = "1"
     os.environ["HOST_FILE"] = os.path.join(SERVO_ROOT, "tests", "wpt", "hosts")
 


### PR DESCRIPTION
This limit was introduced for another CI system in 2017 and it seems
that tests run just fine without it, so I think we can just remove this.
In addition, this has caused problems for some developers locally [^1].

We now also have preferences to limit the maximum number of
threads in the thread pool (and have a default set, that prevents
spawning too many threads on machine with many cores).

[^1]: [#general > Browser not responding when running WPT tests](https://servo.zulipchat.com/#narrow/channel/263398-general/topic/Browser.20not.20responding.20when.20running.20WPT.20tests/with/567475990)

Try run: https://github.com/servo/servo/actions/runs/20914348749

Testing: This doesn't seem to harm WPT tests on CI, so that's the test.
