### PR TITLE
layout: Support style inheritance for `display: contents` and `<slot>` elements

### DIFF
--- a/components/layout/cell.rs
+++ b/components/layout/cell.rs
@@ -27,6 +27,10 @@ impl<T> ArcRefCell<T> {
             value: Arc::downgrade(&self.value),
         }
     }
+
+    pub(crate) fn ptr_eq(&self, other: &Self) -> bool {
+        Arc::ptr_eq(&self.value, &other.value)
+    }
 }
 
 impl<T> Clone for ArcRefCell<T> {

--- a/components/layout/flow/inline/construct.rs
+++ b/components/layout/flow/inline/construct.rs
@@ -330,15 +330,23 @@ impl InlineFormattingContextBuilder {
         self.current_text_offset = new_range.end;
         self.text_segments.push(new_text);
 
+        let current_inline_styles = self.shared_inline_styles();
+
         if let Some(InlineItem::TextRun(text_run)) = self.inline_items.last() {
-            text_run.borrow_mut().text_range.end = new_range.end;
-            return;
+            if text_run
+                .borrow()
+                .inline_styles
+                .ptr_eq(&current_inline_styles)
+            {
+                text_run.borrow_mut().text_range.end = new_range.end;
+                return;
+            }
         }
 
         self.inline_items
             .push(InlineItem::TextRun(ArcRefCell::new(TextRun::new(
                 info.into(),
-                self.shared_inline_styles(),
+                current_inline_styles,
                 new_range,
             ))));
     }

--- a/components/layout/flow/inline/mod.rs
+++ b/components/layout/flow/inline/mod.rs
@@ -191,6 +191,12 @@ pub(crate) struct SharedInlineStyles {
     pub selected: SharedStyle,
 }
 
+impl SharedInlineStyles {
+    pub(crate) fn ptr_eq(&self, other: &Self) -> bool {
+        self.style.ptr_eq(&other.style) && self.selected.ptr_eq(&other.selected)
+    }
+}
+
 impl From<&NodeAndStyleInfo<'_>> for SharedInlineStyles {
     fn from(info: &NodeAndStyleInfo) -> Self {
         Self {

--- a/tests/wpt/meta/css/css-display/display-contents-dynamic-before-after-001.html.ini
+++ b/tests/wpt/meta/css/css-display/display-contents-dynamic-before-after-001.html.ini
@@ -1,2 +1,0 @@
-[display-contents-dynamic-before-after-001.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-display/display-contents-dynamic-inline-flex-001-inline.html.ini
+++ b/tests/wpt/meta/css/css-display/display-contents-dynamic-inline-flex-001-inline.html.ini
@@ -1,2 +1,0 @@
-[display-contents-dynamic-inline-flex-001-inline.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-display/display-contents-dynamic-inline-flex-001-none.html.ini
+++ b/tests/wpt/meta/css/css-display/display-contents-dynamic-inline-flex-001-none.html.ini
@@ -1,2 +1,0 @@
-[display-contents-dynamic-inline-flex-001-none.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-display/display-contents-fieldset.html.ini
+++ b/tests/wpt/meta/css/css-display/display-contents-fieldset.html.ini
@@ -1,0 +1,2 @@
+[display-contents-fieldset.html]
+  expected: FAIL

--- a/tests/wpt/meta/css/css-display/display-contents-first-line-002.html.ini
+++ b/tests/wpt/meta/css/css-display/display-contents-first-line-002.html.ini
@@ -1,2 +1,0 @@
-[display-contents-first-line-002.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-display/display-contents-inline-001.html.ini
+++ b/tests/wpt/meta/css/css-display/display-contents-inline-001.html.ini
@@ -1,2 +1,0 @@
-[display-contents-inline-001.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-display/display-contents-inline-flex-001.html.ini
+++ b/tests/wpt/meta/css/css-display/display-contents-inline-flex-001.html.ini
@@ -1,2 +1,0 @@
-[display-contents-inline-flex-001.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-display/display-contents-line-height.html.ini
+++ b/tests/wpt/meta/css/css-display/display-contents-line-height.html.ini
@@ -1,2 +1,0 @@
-[display-contents-line-height.html]
-  expected: FAIL


### PR DESCRIPTION
In DOM traversal, `display:contents `elements don't generate boxes, but their styles still need to apply to children.
`ModernContainerBuilder` now keeps track of `display:contents` ancestors during traversal then apply their style to text runs.

In `InlineFormattingContextBuilder::push_text` only use same style parent if both selected and current inline style are identical.

Testing: 

> PASS [expected FAIL] /css/css-display/display-contents-dynamic-before-after-001.html
> PASS [expected FAIL] /css/css-display/display-contents-dynamic-inline-flex-001-inline.html
> PASS [expected FAIL] /css/css-display/display-contents-dynamic-inline-flex-001-none.html
> FAIL [expected PASS] /css/css-display/display-contents-fieldset.html
> PASS [expected FAIL] /css/css-display/display-contents-first-line-002.html
> PASS [expected FAIL] /css/css-display/display-contents-inline-001.html
> PASS [expected FAIL] /css/css-display/display-contents-inline-flex-001.html
> PASS [expected FAIL] /css/css-display/display-contents-line-height.html

Fixes: https://github.com/servo/servo/issues/41797

cc: @xiaochengh 