### PR TITLE
script: Move AES-CTR to individual submodule

### DIFF
--- a/components/script/dom/subtlecrypto.rs
+++ b/components/script/dom/subtlecrypto.rs
@@ -3,6 +3,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 mod aes_common;
+mod aes_ctr_operation;
 mod aes_ocb_operation;
 mod aes_operation;
 mod argon2_operation;
@@ -4027,7 +4028,7 @@ impl NormalizedAlgorithm {
                 rsa_oaep_operation::encrypt(algo, key, plaintext)
             },
             (ALG_AES_CTR, NormalizedAlgorithm::AesCtrParams(algo)) => {
-                aes_operation::encrypt_aes_ctr(algo, key, plaintext)
+                aes_ctr_operation::encrypt(algo, key, plaintext)
             },
             (ALG_AES_CBC, NormalizedAlgorithm::AesCbcParams(algo)) => {
                 aes_operation::encrypt_aes_cbc(algo, key, plaintext)
@@ -4051,7 +4052,7 @@ impl NormalizedAlgorithm {
                 rsa_oaep_operation::decrypt(algo, key, ciphertext)
             },
             (ALG_AES_CTR, NormalizedAlgorithm::AesCtrParams(algo)) => {
-                aes_operation::decrypt_aes_ctr(algo, key, ciphertext)
+                aes_ctr_operation::decrypt(algo, key, ciphertext)
             },
             (ALG_AES_CBC, NormalizedAlgorithm::AesCbcParams(algo)) => {
                 aes_operation::decrypt_aes_cbc(algo, key, ciphertext)
@@ -4187,7 +4188,7 @@ impl NormalizedAlgorithm {
                     .map(CryptoKeyOrCryptoKeyPair::CryptoKeyPair)
             },
             (ALG_AES_CTR, NormalizedAlgorithm::AesKeyGenParams(algo)) => {
-                aes_operation::generate_key_aes_ctr(global, algo, extractable, usages, can_gc)
+                aes_ctr_operation::generate_key(global, algo, extractable, usages, can_gc)
                     .map(CryptoKeyOrCryptoKeyPair::CryptoKey)
             },
             (ALG_AES_CBC, NormalizedAlgorithm::AesKeyGenParams(algo)) => {
@@ -4325,14 +4326,7 @@ impl NormalizedAlgorithm {
                 x25519_operation::import_key(global, format, key_data, extractable, usages, can_gc)
             },
             (ALG_AES_CTR, NormalizedAlgorithm::Algorithm(_algo)) => {
-                aes_operation::import_key_aes_ctr(
-                    global,
-                    format,
-                    key_data,
-                    extractable,
-                    usages,
-                    can_gc,
-                )
+                aes_ctr_operation::import_key(global, format, key_data, extractable, usages, can_gc)
             },
             (ALG_AES_CBC, NormalizedAlgorithm::Algorithm(_algo)) => {
                 aes_operation::import_key_aes_cbc(
@@ -4468,7 +4462,7 @@ impl NormalizedAlgorithm {
     fn get_key_length(&self) -> Result<Option<u32>, Error> {
         match (self.name(), self) {
             (ALG_AES_CTR, NormalizedAlgorithm::AesDerivedKeyParams(algo)) => {
-                aes_operation::get_key_length_aes_ctr(algo)
+                aes_ctr_operation::get_key_length(algo)
             },
             (ALG_AES_CBC, NormalizedAlgorithm::AesDerivedKeyParams(algo)) => {
                 aes_operation::get_key_length_aes_cbc(algo)
@@ -4541,7 +4535,7 @@ fn perform_export_key_operation(format: KeyFormat, key: &CryptoKey) -> Result<Ex
         ALG_ECDH => ecdh_operation::export_key(format, key),
         ALG_ED25519 => ed25519_operation::export_key(format, key),
         ALG_X25519 => x25519_operation::export_key(format, key),
-        ALG_AES_CTR => aes_operation::export_key_aes_ctr(format, key),
+        ALG_AES_CTR => aes_ctr_operation::export_key(format, key),
         ALG_AES_CBC => aes_operation::export_key_aes_cbc(format, key),
         ALG_AES_GCM => aes_operation::export_key_aes_gcm(format, key),
         ALG_AES_KW => aes_operation::export_key_aes_kw(format, key),

--- a/components/script/dom/subtlecrypto/aes_common.rs
+++ b/components/script/dom/subtlecrypto/aes_common.rs
@@ -274,6 +274,7 @@ pub(crate) fn import_key_from_key_data(
     Ok(data)
 }
 
+/// <https://w3c.github.io/webcrypto/#aes-ctr-operations-export-key>
 /// <https://wicg.github.io/webcrypto-modern-algos/#aes-ocb-operations-export-key>
 pub(crate) fn export_key(
     aes_algorithm: AesAlgorithm,

--- a/components/script/dom/subtlecrypto/aes_ctr_operation.rs
+++ b/components/script/dom/subtlecrypto/aes_ctr_operation.rs
@@ -1,0 +1,231 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+use aes::cipher::crypto_common::Key;
+use aes::{Aes128, Aes192, Aes256};
+use cipher::{KeyIvInit, StreamCipher};
+use ctr::Ctr128BE;
+
+use crate::dom::bindings::codegen::Bindings::CryptoKeyBinding::{KeyType, KeyUsage};
+use crate::dom::bindings::codegen::Bindings::SubtleCryptoBinding::KeyFormat;
+use crate::dom::bindings::error::Error;
+use crate::dom::bindings::root::DomRoot;
+use crate::dom::cryptokey::{CryptoKey, Handle};
+use crate::dom::globalscope::GlobalScope;
+use crate::dom::subtlecrypto::aes_common::AesAlgorithm;
+use crate::dom::subtlecrypto::{
+    ALG_AES_CTR, ExportedKey, KeyAlgorithmAndDerivatives, SubtleAesCtrParams,
+    SubtleAesDerivedKeyParams, SubtleAesKeyAlgorithm, SubtleAesKeyGenParams, aes_common,
+};
+use crate::script_runtime::CanGc;
+
+/// <https://w3c.github.io/webcrypto/#aes-ctr-operations-encrypt>
+pub(crate) fn encrypt(
+    normalized_algorithm: &SubtleAesCtrParams,
+    key: &CryptoKey,
+    plaintext: &[u8],
+) -> Result<Vec<u8>, Error> {
+    // Step 1. If the counter member of normalizedAlgorithm does not have a length of 16 bytes,
+    // then throw an OperationError.
+    if normalized_algorithm.counter.len() != 16 {
+        return Err(Error::Operation(Some(
+            "The initial counter block length is not 16 bytes".into(),
+        )));
+    }
+
+    // Step 2. If the length member of normalizedAlgorithm is zero or is greater than 128, then
+    // throw an OperationError.
+    if normalized_algorithm.length == 0 {
+        return Err(Error::Operation(Some("The counter length is zero".into())));
+    }
+    if normalized_algorithm.length > 128 {
+        return Err(Error::Operation(Some(
+            "The counter length is greater than 128".into(),
+        )));
+    }
+
+    // Step 3. Let ciphertext be the result of performing the CTR Encryption operation described in
+    // Section 6.5 of [NIST-SP800-38A] using AES as the block cipher, the counter member of
+    // normalizedAlgorithm as the initial value of the counter block, the length member of
+    // normalizedAlgorithm as the input parameter m to the standard counter block incrementing
+    // function defined in Appendix B.1 of [NIST-SP800-38A] and plaintext as the input plaintext.
+    let iv = normalized_algorithm.counter.as_slice();
+    let mut ciphertext = plaintext.to_vec();
+    match key.handle() {
+        Handle::Aes128Key(key) => {
+            let mut cipher = Ctr128BE::<Aes128>::new(key, iv.into());
+            cipher.apply_keystream(&mut ciphertext);
+        },
+        Handle::Aes192Key(key) => {
+            let mut cipher = Ctr128BE::<Aes192>::new(key, iv.into());
+            cipher.apply_keystream(&mut ciphertext);
+        },
+        Handle::Aes256Key(key) => {
+            let mut cipher = Ctr128BE::<Aes256>::new(key, iv.into());
+            cipher.apply_keystream(&mut ciphertext);
+        },
+        _ => {
+            return Err(Error::Operation(Some(
+                "The key handle is not representing an AES key".to_string(),
+            )));
+        },
+    };
+
+    // Step 4. Return ciphertext.
+    Ok(ciphertext)
+}
+
+/// <https://w3c.github.io/webcrypto/#aes-ctr-operations-decrypt>
+pub(crate) fn decrypt(
+    normalized_algorithm: &SubtleAesCtrParams,
+    key: &CryptoKey,
+    ciphertext: &[u8],
+) -> Result<Vec<u8>, Error> {
+    // Step 1. If the counter member of normalizedAlgorithm does not have a length of 16 bytes,
+    // then throw an OperationError.
+    if normalized_algorithm.counter.len() != 16 {
+        return Err(Error::Operation(Some(
+            "The initial counter block length is not 16 bytes".into(),
+        )));
+    }
+
+    // Step 2. If the length member of normalizedAlgorithm is zero or is greater than 128, then
+    // throw an OperationError.
+    if normalized_algorithm.length == 0 {
+        return Err(Error::Operation(Some("The counter length is zero".into())));
+    }
+    if normalized_algorithm.length > 128 {
+        return Err(Error::Operation(Some(
+            "The counter length is greater than 128".into(),
+        )));
+    }
+
+    // Step 3. Let plaintext be the result of performing the CTR Decryption operation described in
+    // Section 6.5 of [NIST-SP800-38A] using AES as the block cipher, the counter member of
+    // normalizedAlgorithm as the initial value of the counter block, the length member of
+    // normalizedAlgorithm as the input parameter m to the standard counter block incrementing
+    // function defined in Appendix B.1 of [NIST-SP800-38A] and ciphertext as the input ciphertext.
+    let iv = normalized_algorithm.counter.as_slice();
+    let mut plaintext = ciphertext.to_vec();
+    match key.handle() {
+        Handle::Aes128Key(key) => {
+            let mut cipher = Ctr128BE::<Aes128>::new(key, iv.into());
+            cipher.apply_keystream(&mut plaintext);
+        },
+        Handle::Aes192Key(key) => {
+            let mut cipher = Ctr128BE::<Aes192>::new(key, iv.into());
+            cipher.apply_keystream(&mut plaintext);
+        },
+        Handle::Aes256Key(key) => {
+            let mut cipher = Ctr128BE::<Aes256>::new(key, iv.into());
+            cipher.apply_keystream(&mut plaintext);
+        },
+        _ => {
+            return Err(Error::Operation(Some(
+                "The key handle is not representing an AES key".to_string(),
+            )));
+        },
+    };
+
+    // Step 4. Return plaintext.
+    Ok(plaintext)
+}
+
+/// <https://w3c.github.io/webcrypto/#aes-ctr-operations-generate-key>
+pub(crate) fn generate_key(
+    global: &GlobalScope,
+    normalized_algorithm: &SubtleAesKeyGenParams,
+    extractable: bool,
+    usages: Vec<KeyUsage>,
+    can_gc: CanGc,
+) -> Result<DomRoot<CryptoKey>, Error> {
+    aes_common::generate_key(
+        AesAlgorithm::AesCtr,
+        global,
+        normalized_algorithm,
+        extractable,
+        usages,
+        can_gc,
+    )
+}
+
+/// <https://w3c.github.io/webcrypto/#aes-ctr-operations-import-key>
+pub(crate) fn import_key(
+    global: &GlobalScope,
+    format: KeyFormat,
+    key_data: &[u8],
+    extractable: bool,
+    usages: Vec<KeyUsage>,
+    can_gc: CanGc,
+) -> Result<DomRoot<CryptoKey>, Error> {
+    // Step 1. Let keyData be the key data to be imported.
+
+    // Step 2. If usages contains an entry which is not one of "encrypt", "decrypt", "wrapKey" or
+    // "unwrapKey", then throw a SyntaxError.
+    if usages.iter().any(|usage| {
+        !matches!(
+            usage,
+            KeyUsage::Encrypt | KeyUsage::Decrypt | KeyUsage::WrapKey | KeyUsage::UnwrapKey
+        )
+    }) {
+        return Err(Error::Syntax(Some(
+            "Usages contains an entry which is not one of \"encrypt\", \"decrypt\", \"wrapKey\" \
+            or \"unwrapKey\""
+                .to_string(),
+        )));
+    }
+
+    // Step 3.
+    let data = aes_common::import_key_from_key_data(
+        AesAlgorithm::AesCtr,
+        format,
+        key_data,
+        extractable,
+        &usages,
+    )?;
+
+    // Step 4. Let key be a new CryptoKey object representing an AES key with value data.
+    // Step 5. Let algorithm be a new AesKeyAlgorithm.
+    // Step 6. Set the name attribute of algorithm to "AES-CTR".
+    // Step 7. Set the length attribute of algorithm to the length, in bits, of data.
+    // Step 8. Set the [[algorithm]] internal slot of key to algorithm.
+    let handle = match data.len() {
+        16 => Handle::Aes128Key(Key::<Aes128>::clone_from_slice(&data)),
+        24 => Handle::Aes192Key(Key::<Aes192>::clone_from_slice(&data)),
+        32 => Handle::Aes256Key(Key::<Aes256>::clone_from_slice(&data)),
+        _ => {
+            return Err(Error::Data(Some(
+                "The length in bits of data is not 128, 192 or 256".to_string(),
+            )));
+        },
+    };
+    let algorithm = SubtleAesKeyAlgorithm {
+        name: ALG_AES_CTR.to_string(),
+        length: data.len() as u16 * 8,
+    };
+    let key = CryptoKey::new(
+        global,
+        KeyType::Secret,
+        extractable,
+        KeyAlgorithmAndDerivatives::AesKeyAlgorithm(algorithm),
+        usages,
+        handle,
+        can_gc,
+    );
+
+    // Step 9. Return key.
+    Ok(key)
+}
+
+/// <https://w3c.github.io/webcrypto/#aes-ctr-operations-export-key>
+pub(crate) fn export_key(format: KeyFormat, key: &CryptoKey) -> Result<ExportedKey, Error> {
+    aes_common::export_key(AesAlgorithm::AesCtr, format, key)
+}
+
+/// <https://w3c.github.io/webcrypto/#aes-ctr-operations-get-key-length>
+pub(crate) fn get_key_length(
+    normalized_derived_key_algorithm: &SubtleAesDerivedKeyParams,
+) -> Result<Option<u32>, Error> {
+    aes_common::get_key_length(normalized_derived_key_algorithm)
+}


### PR DESCRIPTION
#41762 introduced new infrastructure for sharing code in `aes_common.rs` among AES algorithms.

This patch makes AES-CTR algorithm adopt the new infrastructure, by moving the relevant code away from `aes_operation.rs` to its own `aes_ctr_operation.rs`, with refactoring for adaptation.

Testing: Refactoring. Existing tests suffice.
Fixes: Part of #41763