### PR TITLE
net: Transform filemanager to async code

### DIFF
--- a/components/net/tests/filemanager_thread.rs
+++ b/components/net/tests/filemanager_thread.rs
@@ -12,17 +12,20 @@ use embedder_traits::{
     EmbedderControlId, EmbedderControlResponse, EmbedderMsg, FilePickerRequest, FilterPattern,
 };
 use ipc_channel::ipc;
+use net::async_runtime::{async_runtime_initialized, init_async_runtime};
 use net::filemanager_thread::FileManager;
 use net_traits::blob_url_store::BlobURLStoreError;
 use net_traits::filemanager_thread::{
     FileManagerThreadError, FileManagerThreadMsg, ReadFileProgress,
 };
 use servo_config::prefs::Preferences;
+use tokio::task::yield_now;
 
 use crate::create_embedder_proxy_and_receiver;
 
 #[test]
 fn test_filemanager() {
+    let _runtime = init_async_runtime();
     let mut preferences = Preferences::default();
     preferences.dom_testing_html_input_element_select_files_enabled = true;
     servo_config::prefs::set(preferences);


### PR DESCRIPTION
This transform the filemanager code to simple async code. With the removal of the thread pool in https://github.com/servo/servo/pull/41740
the we used std::thread::spawn for the two usages of the thread pool.
This changes these to use the already existing async runtime and spawns the tasks on this.

This is a very simple change and does not use all the functionality we have from the runtime but hopefully have enough points to yield back to the runtime.

Signed-off-by: Narfinger <Narfinger@users.noreply.github.com>

Testing: Browsing files locally seems to work on WPT tests are here: https://github.com/Narfinger/servo/actions/runs/20956841091
