### PR TITLE
script/dom: Remove unused creator-related methods from WindowProxy.

### DIFF
--- a/components/script/dom/mod.rs
+++ b/components/script/dom/mod.rs
@@ -470,7 +470,6 @@ pub(crate) mod transformstreamdefaultcontroller;
 pub(crate) mod wheelevent;
 #[expect(dead_code)]
 pub(crate) mod window;
-#[expect(dead_code)]
 pub(crate) mod windowproxy;
 pub(crate) mod workers;
 pub(crate) use self::workers::*;

--- a/components/script/dom/windowproxy.rs
+++ b/components/script/dom/windowproxy.rs
@@ -423,28 +423,6 @@ impl WindowProxy {
         self.creator_base_url.clone()
     }
 
-    pub(crate) fn has_creator_base_url(&self) -> bool {
-        self.creator_base_url.is_some()
-    }
-
-    /// <https://html.spec.whatwg.org/multipage/#creator-url>
-    pub(crate) fn creator_url(&self) -> Option<ServoUrl> {
-        self.creator_url.clone()
-    }
-
-    pub(crate) fn has_creator_url(&self) -> bool {
-        self.creator_base_url.is_some()
-    }
-
-    /// <https://html.spec.whatwg.org/multipage/#creator-origin>
-    pub(crate) fn creator_origin(&self) -> Option<ImmutableOrigin> {
-        self.creator_origin.clone()
-    }
-
-    pub(crate) fn has_creator_origin(&self) -> bool {
-        self.creator_origin.is_some()
-    }
-
     #[expect(unsafe_code)]
     // https://html.spec.whatwg.org/multipage/#dom-opener
     pub(crate) fn opener(


### PR DESCRIPTION
Methods were unused and removed from the HTML spec.

Testing: Verified with ./mach build and ./mach test-unit. Without errors or warnings.
Fixes: #41835