### PR TITLE
ci: Skip installing cargo-deny on self-hosted runners.

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -59,12 +59,7 @@ jobs:
           crate: taplo-cli
           locked: true
       - name: Install cargo-deny
-        # We need at least 0.18.6 due to #41845, but the fix in #41853
-        # can't land without first upgrading cargo-deny in self-hosted
-        # runners. So, use the action to install 0.19.0 on both GH and
-        # self-hosted runners for now and make this conditional again
-        # after https://github.com/servo/ci-runners/issues/98 is done.
-        # if: ${{ runner.environment != 'self-hosted' }}
+        if: ${{ runner.environment != 'self-hosted' }}
         uses: baptiste0928/cargo-install@v3
         with:
           crate: cargo-deny


### PR DESCRIPTION
It is no longer necessary to do this unconditionally since self-hosted runners [now have v0.19.0](https://github.com/servo/ci-runners/issues/98) of cargo-deny.

Testing: The CI run for this PR should validate that self-hosted runners skip the installation and use the preinstalled v0.19.0 successfully.

