### PR TITLE
layout: Store `FontMetrics` in an `Arc`

### DIFF
--- a/components/fonts/font.rs
+++ b/components/fonts/font.rs
@@ -179,24 +179,9 @@ pub struct FontMetrics {
 impl FontMetrics {
     /// Create an empty [`FontMetrics`] mainly to be used in situations where
     /// no font can be found.
-    pub fn empty() -> Self {
-        Self {
-            underline_size: Au::zero(),
-            underline_offset: Au::zero(),
-            strikeout_size: Au::zero(),
-            strikeout_offset: Au::zero(),
-            leading: Au::zero(),
-            x_height: Au::zero(),
-            em_size: Au::zero(),
-            ascent: Au::zero(),
-            descent: Au::zero(),
-            max_advance: Au::zero(),
-            average_advance: Au::zero(),
-            line_gap: Au::zero(),
-            zero_horizontal_advance: None,
-            ic_horizontal_advance: None,
-            space_advance: Au::zero(),
-        }
+    pub fn empty() -> Arc<Self> {
+        static EMPTY: OnceLock<Arc<FontMetrics>> = OnceLock::new();
+        EMPTY.get_or_init(Default::default).clone()
     }
 }
 
@@ -223,7 +208,7 @@ impl malloc_size_of::MallocSizeOf for CachedShapeData {
 pub struct Font {
     pub(crate) handle: PlatformFont,
     pub(crate) template: FontTemplateRef,
-    pub metrics: FontMetrics,
+    pub metrics: Arc<FontMetrics>,
     pub descriptor: FontDescriptor,
 
     /// The data for this font. And the index of the font within the data (in case it's a TTC)
@@ -299,7 +284,7 @@ impl Font {
             &data,
             synthetic_bold,
         )?;
-        let metrics = handle.metrics();
+        let metrics = Arc::new(handle.metrics());
 
         Ok(Font {
             handle,

--- a/components/layout/flow/inline/inline_box.rs
+++ b/components/layout/flow/inline/inline_box.rs
@@ -2,6 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
+use std::sync::Arc;
 use std::vec::IntoIter;
 
 use app_units::Au;
@@ -217,7 +218,7 @@ impl InlineBoxContainerState {
         containing_block: &ContainingBlock,
         layout_context: &LayoutContext,
         parent_container: &InlineContainerState,
-        font_metrics: Option<&FontMetrics>,
+        font_metrics: Option<Arc<FontMetrics>>,
     ) -> Self {
         let style = inline_box.base.style.clone();
         let pbm = inline_box

--- a/components/layout/flow/inline/line.rs
+++ b/components/layout/flow/inline/line.rs
@@ -2,6 +2,8 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
+use std::sync::Arc;
+
 use app_units::Au;
 use bitflags::bitflags;
 use fonts::{ByteIndex, FontMetrics, GlyphStore};
@@ -788,7 +790,7 @@ pub(super) struct TextRunLineItem {
     pub base_fragment_info: BaseFragmentInfo,
     pub inline_styles: SharedInlineStyles,
     pub text: Vec<std::sync::Arc<GlyphStore>>,
-    pub font_metrics: FontMetrics,
+    pub font_metrics: Arc<FontMetrics>,
     pub font_key: FontInstanceKey,
     /// The BiDi level of this [`TextRunLineItem`] to enable reordering.
     pub bidi_level: Level,

--- a/components/layout/fragment_tree/fragment.rs
+++ b/components/layout/fragment_tree/fragment.rs
@@ -65,7 +65,8 @@ pub(crate) struct CollapsedMargin {
 pub(crate) struct TextFragment {
     pub base: BaseFragment,
     pub selected_style: SharedStyle,
-    pub font_metrics: FontMetrics,
+    #[conditional_malloc_size_of]
+    pub font_metrics: Arc<FontMetrics>,
     pub font_key: FontInstanceKey,
     #[conditional_malloc_size_of]
     pub glyphs: Vec<Arc<GlyphStore>>,


### PR DESCRIPTION
This decreases the size of `TextFragment` by 66 bits and also allows
sharing empty metrics for text runs without fonts. Many `TextFragments`
should share the same font so these 66 bits should reflect reality even
though the `FontMetrics` is now stored on the heap.

Testing: This should not change behavior so is covered by existing tests.
