### PR TITLE
CI: Refactor nightly release process

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -6,13 +6,6 @@ on:
         required: false
         default: "release"
         type: string
-      upload:
-        required: false
-        default: false
-        type: boolean
-      github-release-id:
-        required: false
-        type: string
       bencher:
         required: false
         default: false
@@ -117,31 +110,11 @@ jobs:
           name: cargo-timings-android-${{ matrix.target }}-${{ inputs.profile }}
           # Using a wildcard here ensures that the archive includes the path.
           path: target/cargo-timings-*
-      - name: Upload nightly
-        if: ${{ inputs.upload && contains(matrix.target, 'aarch64') }}
-        run: |
-          ./mach upload-nightly android \
-            --secret-from-environment \
-            --github-release-id ${{ inputs.github-release-id }}
-        env:
-          S3_UPLOAD_CREDENTIALS: ${{ secrets.S3_UPLOAD_CREDENTIALS }}
-          NIGHTLY_REPO_TOKEN: ${{ secrets.NIGHTLY_REPO_TOKEN }}
-          NIGHTLY_REPO: ${{ github.repository_owner }}/servo-nightly-builds
-      - name: Generate artifact attestation for APK
-        if: ${{ inputs.upload }}
-        uses: actions/attest-build-provenance@v1
-        with:
-          subject-path: target/android/${{ matrix.target }}/${{ inputs.profile }}/servoapp.apk
       - name: Upload APK artifact
         uses: actions/upload-artifact@v4
         with:
           name: ${{ inputs.profile }}-binary-android-${{ matrix.target }}
           path: target/android/${{ matrix.target }}/${{ inputs.profile }}/servoapp.apk
-      - name: Generate artifact attestation for AAR
-        if: ${{ inputs.upload }}
-        uses: actions/attest-build-provenance@v1
-        with:
-          subject-path: target/android/${{ matrix.target }}/${{ inputs.profile }}/servoview.aar
       - name: Upload AAR artifact
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -34,7 +34,7 @@ jobs:
           # <https://github.com/servo/servo/settings/variables/actions>
           NO_SELF_HOSTED_RUNNERS: ${{ vars.NO_SELF_HOSTED_RUNNERS }}
           # Any other boolean conditions that disable self-hosted runners go here.
-          force-github-hosted-runner: ${{ inputs.upload || inputs.force-github-hosted-runner }}
+          force-github-hosted-runner: ${{ inputs.force-github-hosted-runner }}
 
   lint:
     needs:

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -33,13 +33,6 @@ on:
         required: false
         default: false
         type: boolean
-      upload:
-        required: false
-        default: false
-        type: boolean
-      github-release-id:
-        required: false
-        type: string
       force-github-hosted-runner:
         required: false
         type: boolean
@@ -82,10 +75,6 @@ on:
         required: false
         default: false
         type: boolean
-      upload:
-        required: false
-        default: false
-        type: boolean
       force-github-hosted-runner:
         required: false
         type: boolean
@@ -125,7 +114,7 @@ jobs:
           # <https://github.com/servo/servo/settings/variables/actions>
           NO_SELF_HOSTED_RUNNERS: ${{ vars.NO_SELF_HOSTED_RUNNERS }}
           # Any other boolean conditions that disable self-hosted runners go here.
-          force-github-hosted-runner: ${{ inputs.upload || inputs.force-github-hosted-runner }}
+          force-github-hosted-runner: ${{ inputs.force-github-hosted-runner }}
 
   build:
     needs:
@@ -211,16 +200,6 @@ jobs:
         with:
           name: ${{ inputs.profile }}-binary-linux
           path: target/${{ inputs.profile }}/servo-tech-demo.tar.gz
-      - name: Upload nightly
-        if: ${{ inputs.upload }}
-        run: |
-          ./mach upload-nightly linux \
-            --secret-from-environment \
-            --github-release-id ${{ inputs.github-release-id }}
-        env:
-          S3_UPLOAD_CREDENTIALS: ${{ secrets.S3_UPLOAD_CREDENTIALS }}
-          NIGHTLY_REPO_TOKEN: ${{ secrets.NIGHTLY_REPO_TOKEN }}
-          NIGHTLY_REPO: ${{ github.repository_owner }}/servo-nightly-builds
 
   wpt-2020:
     if: ${{ inputs.wpt }}

--- a/.github/workflows/mac-arm64.yml
+++ b/.github/workflows/mac-arm64.yml
@@ -26,13 +26,6 @@ on:
         required: false
         default: false
         type: boolean
-      upload:
-        required: false
-        default: false
-        type: boolean
-      github-release-id:
-        required: false
-        type: string
       force-github-hosted-runner:
           required: false
           type: boolean
@@ -60,10 +53,6 @@ on:
         default: false
         type: boolean
       build-libservo:
-        required: false
-        default: false
-        type: boolean
-      upload:
         required: false
         default: false
         type: boolean
@@ -185,16 +174,6 @@ jobs:
         with:
           name: ${{ inputs.profile }}-binary-mac-arm64
           path: target/${{ inputs.profile }}/servo-tech-demo.dmg
-      - name: Upload nightly
-        if: ${{ inputs.upload }}
-        run: |
-          ./mach upload-nightly mac-arm64 --secret-from-environment \
-            --github-release-id ${{ inputs.github-release-id }}
-        env:
-          S3_UPLOAD_CREDENTIALS: ${{ secrets.S3_UPLOAD_CREDENTIALS }}
-          GITHUB_HOMEBREW_TOKEN: ${{ secrets.HOMEBREW_TOKEN }}
-          NIGHTLY_REPO_TOKEN: ${{ secrets.NIGHTLY_REPO_TOKEN }}
-          NIGHTLY_REPO: ${{ github.repository_owner }}/servo-nightly-builds
       - name: Build package for target
         run: gtar -czf target.tar.gz target/${{ inputs.profile }}/servo target/${{ inputs.profile }}/lib/*.dylib resources
       - name: Upload package for target

--- a/.github/workflows/mac.yml
+++ b/.github/workflows/mac.yml
@@ -26,13 +26,6 @@ on:
         required: false
         default: false
         type: boolean
-      upload:
-        required: false
-        default: false
-        type: boolean
-      github-release-id:
-        required: false
-        type: string
       force-github-hosted-runner:
           required: false
           type: boolean
@@ -60,10 +53,6 @@ on:
         default: false
         type: boolean
       build-libservo:
-        required: false
-        default: false
-        type: boolean
-      upload:
         required: false
         default: false
         type: boolean
@@ -193,16 +182,6 @@ jobs:
         with:
           name: ${{ inputs.profile }}-binary-mac
           path: target/${{ inputs.profile }}/servo-tech-demo.dmg
-      - name: Upload nightly
-        if: ${{ inputs.upload }}
-        run: |
-          ./mach upload-nightly mac --secret-from-environment \
-            --github-release-id ${{ inputs.github-release-id }}
-        env:
-          S3_UPLOAD_CREDENTIALS: ${{ secrets.S3_UPLOAD_CREDENTIALS }}
-          GITHUB_HOMEBREW_TOKEN: ${{ secrets.HOMEBREW_TOKEN }}
-          NIGHTLY_REPO_TOKEN: ${{ secrets.NIGHTLY_REPO_TOKEN }}
-          NIGHTLY_REPO: ${{ github.repository_owner }}/servo-nightly-builds
       - name: Build package for target
         run: gtar -czf target.tar.gz target/${{ inputs.profile }}/servo target/${{ inputs.profile }}/lib/*.dylib resources
       - name: Upload package for target

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -96,12 +96,6 @@ jobs:
     steps:
       - uses: actions/checkout@v6
         with:
-          sparse-checkout: |
-            .github
-            python
-            .
-            tests/wpt/tests/tools/requirements_tests.txt
-            tests/wpt/tests/tools/wptrunner/requirements.txt
           fetch-depth: '1'
       - name: Setup Python
         uses: ./.github/actions/setup-python
@@ -142,12 +136,6 @@ jobs:
     steps:
       - uses: actions/checkout@v6
         with:
-          sparse-checkout: |
-            .github
-            python
-            .
-            tests/wpt/tests/tools/requirements_tests.txt
-            tests/wpt/tests/tools/wptrunner/requirements.txt
           fetch-depth: '1'
       - name: Setup Python
         uses: ./.github/actions/setup-python
@@ -183,12 +171,6 @@ jobs:
     steps:
       - uses: actions/checkout@v6
         with:
-          sparse-checkout: |
-            .github
-            python
-            .
-            tests/wpt/tests/tools/requirements_tests.txt
-            tests/wpt/tests/tools/wptrunner/requirements.txt
           fetch-depth: '1'
       - name: Setup Python
         uses: ./.github/actions/setup-python
@@ -226,12 +208,6 @@ jobs:
     steps:
       - uses: actions/checkout@v6
         with:
-          sparse-checkout: |
-            .github
-            python
-            .
-            tests/wpt/tests/tools/requirements_tests.txt
-            tests/wpt/tests/tools/wptrunner/requirements.txt
           fetch-depth: '1'
       - name: Setup Python
         uses: ./.github/actions/setup-python
@@ -270,12 +246,6 @@ jobs:
     steps:
       - uses: actions/checkout@v6
         with:
-          sparse-checkout: |
-            .github
-            python
-            .
-            tests/wpt/tests/tools/requirements_tests.txt
-            tests/wpt/tests/tools/wptrunner/requirements.txt
           fetch-depth: '1'
       - name: Setup Python
         uses: ./.github/actions/setup-python
@@ -329,12 +299,6 @@ jobs:
     steps:
       - uses: actions/checkout@v6
         with:
-          sparse-checkout: |
-            .github
-            python
-            .
-            tests/wpt/tests/tools/requirements_tests.txt
-            tests/wpt/tests/tools/wptrunner/requirements.txt
           fetch-depth: '1'
       - name: Setup Python
         uses: ./.github/actions/setup-python

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -251,10 +251,10 @@ jobs:
           fetch-depth: '1'
       - uses: actions/download-artifact@v7
         with:
-          name: release-binary-android-aarch64
+          name: release-binary-android-aarch64-linux-android
       - uses: actions/download-artifact@v7
         with:
-          name: release-library-android-aarch64
+          name: release-library-android-aarch64-linux-android
       - name: Generate artifact attestation for APK
         uses: actions/attest-build-provenance@v3
         with:

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -76,19 +76,45 @@ jobs:
       - upload-android
       - upload-ohos
 
-  upload-win:
+  build-win:
     # This job is only useful when run on upstream servo.
     if: github.repository == 'servo/servo' || github.event_name == 'workflow_dispatch'
-    name: Upload nightly (Windows)
-    needs:
-      - create-draft-release
+    name: Build nightly (Windows)
     uses: ./.github/workflows/windows.yml
     with:
       profile: "production"
-      upload: true
-      github-release-id: ${{ needs.create-draft-release.outputs.release-id }}
+      upload_zip: true
       force-github-hosted-runner: true  # <https://github.com/servo/servo/issues/33296>
-    secrets: inherit
+
+  upload-win:
+    # This job is only useful when run on upstream servo.
+    if: github.repository == 'servo/servo' || github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-latest
+    needs:
+      - create-draft-release
+      - build-win
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          sparse-checkout: |
+            python
+            .
+          fetch-depth: '1'
+      - uses: actions/download-artifact@v7
+        with:
+          name: ${{ inputs.profile }}-binary-windows
+      - uses: actions/download-artifact@v7
+        with:
+          name: ${{ inputs.profile }}-binary-windows-zip
+      - name: Upload nightly
+        run: |
+          .\mach upload-nightly windows-msvc --secret-from-environment `
+            --github-release-id ${{ needs.create-draft-release.outputs.release-id }}
+        env:
+          S3_UPLOAD_CREDENTIALS: ${{ secrets.S3_UPLOAD_CREDENTIALS }}
+          NIGHTLY_REPO_TOKEN: ${{ secrets.NIGHTLY_REPO_TOKEN }}
+          NIGHTLY_REPO: ${{ github.repository_owner }}/servo-nightly-builds
+
 
   upload-mac:
     # This job is only useful when run on upstream servo.

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -100,6 +100,8 @@ jobs:
             python
             .
           fetch-depth: '1'
+      - name: Setup Python
+        uses: ./.github/actions/setup-python
       - uses: actions/download-artifact@v7
         with:
           name: production-binary-windows
@@ -141,6 +143,8 @@ jobs:
             python
             .
           fetch-depth: '1'
+      - name: Setup Python
+        uses: ./.github/actions/setup-python
       - uses: actions/download-artifact@v7
         with:
           name: production-binary-mac
@@ -177,6 +181,8 @@ jobs:
             python
             .
           fetch-depth: '1'
+      - name: Setup Python
+        uses: ./.github/actions/setup-python
       - uses: actions/download-artifact@v7
         with:
           name: production-binary-mac-arm64
@@ -215,6 +221,8 @@ jobs:
             python
             .
           fetch-depth: '1'
+      - name: Setup Python
+        uses: ./.github/actions/setup-python
       - uses: actions/download-artifact@v7
         with:
           name: production-binary-linux
@@ -254,6 +262,8 @@ jobs:
             python
             .
           fetch-depth: '1'
+      - name: Setup Python
+        uses: ./.github/actions/setup-python
       - uses: actions/download-artifact@v7
         with:
           name: release-binary-android-aarch64-linux-android
@@ -308,6 +318,8 @@ jobs:
             python
             .
           fetch-depth: '1'
+      - name: Setup Python
+        uses: ./.github/actions/setup-python
       - uses: actions/download-artifact@v7
         with:
           name: production-library-ohos-aarch64-unknown-linux-ohos

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -109,7 +109,9 @@ jobs:
       - name: Upload nightly
         run: |
           ./mach upload-nightly windows-msvc --secret-from-environment
-            --github-release-id ${{ needs.create-draft-release.outputs.release-id }}
+            --github-release-id ${{ needs.create-draft-release.outputs.release-id }} \
+            Servo.exe \
+            Servo.zip
         env:
           S3_UPLOAD_CREDENTIALS: ${{ secrets.S3_UPLOAD_CREDENTIALS }}
           NIGHTLY_REPO_TOKEN: ${{ secrets.NIGHTLY_REPO_TOKEN }}
@@ -145,7 +147,8 @@ jobs:
       - name: Upload nightly
         run: |
           ./mach upload-nightly mac --secret-from-environment
-            --github-release-id ${{ needs.create-draft-release.outputs.release-id }}
+            --github-release-id ${{ needs.create-draft-release.outputs.release-id }} \
+            servo-tech-demo.dmg
         env:
           S3_UPLOAD_CREDENTIALS: ${{ secrets.S3_UPLOAD_CREDENTIALS }}
           NIGHTLY_REPO_TOKEN: ${{ secrets.NIGHTLY_REPO_TOKEN }}
@@ -180,7 +183,8 @@ jobs:
       - name: Upload nightly
         run: |
           ./mach upload-nightly mac-arm64 --secret-from-environment
-            --github-release-id ${{ needs.create-draft-release.outputs.release-id }}
+            --github-release-id ${{ needs.create-draft-release.outputs.release-id }} \
+            servo-tech-demo.dmg
         env:
           S3_UPLOAD_CREDENTIALS: ${{ secrets.S3_UPLOAD_CREDENTIALS }}
           # TODO: this appears unused, can we remove it?
@@ -217,7 +221,8 @@ jobs:
       - name: Upload nightly
         run: |
           ./mach upload-nightly linux --secret-from-environment
-            --github-release-id ${{ needs.create-draft-release.outputs.release-id }}
+            --github-release-id ${{ needs.create-draft-release.outputs.release-id }} \
+            servo-tech-demo.tar.gz
         env:
           S3_UPLOAD_CREDENTIALS: ${{ secrets.S3_UPLOAD_CREDENTIALS }}
           NIGHTLY_REPO_TOKEN: ${{ secrets.NIGHTLY_REPO_TOKEN }}
@@ -258,16 +263,18 @@ jobs:
       - name: Generate artifact attestation for APK
         uses: actions/attest-build-provenance@v3
         with:
-          subject-path: target/android/aarch64-linux-android/release/servoapp.apk
+          subject-path: servoapp.apk
       - name: Generate artifact attestation for AAR
         uses: actions/attest-build-provenance@v3
         with:
-          subject-path: target/android/aarch64-linux-android/release/servoview.aar
+          subject-path: servoview.aar
       - name: Upload nightly
         run: |
           ./mach upload-nightly android \
             --secret-from-environment \
-            --github-release-id ${{ needs.create-draft-release.outputs.release-id }}
+            --github-release-id ${{ needs.create-draft-release.outputs.release-id }} \
+            servoapp.apk \
+            servoview.aar
         env:
           S3_UPLOAD_CREDENTIALS: ${{ secrets.S3_UPLOAD_CREDENTIALS }}
           NIGHTLY_REPO_TOKEN: ${{ secrets.NIGHTLY_REPO_TOKEN }}
@@ -307,19 +314,21 @@ jobs:
       - name: Generate artifact attestation for shared library
         uses: actions/attest-build-provenance@v3
         with:
-          subject-path: target/aarch64-unknown-linux-ohos/production/libservoshell.so
+          subject-path: libservoshell.so
       - uses: actions/download-artifact@v7
         with:
           name: production-binary-ohos-aarch64-unknown-linux-ohos
       - name: Generate artifact attestation for HAP
         uses: actions/attest-build-provenance@v3
         with:
-          subject-path: target/openharmony/aarch64-unknown-linux-ohos/production/entry/build/default/outputs/default/servoshell-default-signed.hap
+          subject-path: servoshell-default-signed.hap
       - name: Upload nightly
         run: |
           ./mach upload-nightly ohos \
             --secret-from-environment \
-            --github-release-id ${{ needs.create-draft-release.outputs.release-id }}
+            --github-release-id ${{ needs.create-draft-release.outputs.release-id }} \
+            libservoshell.so \
+            servoshell-default-signed.hap
         env:
           S3_UPLOAD_CREDENTIALS: ${{ secrets.S3_UPLOAD_CREDENTIALS }}
           NIGHTLY_REPO_TOKEN: ${{ secrets.NIGHTLY_REPO_TOKEN }}

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -102,10 +102,10 @@ jobs:
           fetch-depth: '1'
       - uses: actions/download-artifact@v7
         with:
-          name: ${{ inputs.profile }}-binary-windows
+          name: production-binary-windows
       - uses: actions/download-artifact@v7
         with:
-          name: ${{ inputs.profile }}-binary-windows-zip
+          name: production-binary-windows-zip
       - name: Upload nightly
         run: |
           .\mach upload-nightly windows-msvc --secret-from-environment `
@@ -141,7 +141,7 @@ jobs:
           fetch-depth: '1'
       - uses: actions/download-artifact@v7
         with:
-          name: ${{ inputs.profile }}-binary-mac
+          name: production-binary-mac
       - name: Upload nightly
         run: |
           .\mach upload-nightly mac --secret-from-environment `
@@ -176,7 +176,7 @@ jobs:
           fetch-depth: '1'
       - uses: actions/download-artifact@v7
         with:
-          name: ${{ inputs.profile }}-binary-mac-arm64
+          name: production-binary-mac-arm64
       - name: Upload nightly
         run: |
           .\mach upload-nightly mac-arm64 --secret-from-environment `
@@ -213,7 +213,7 @@ jobs:
           fetch-depth: '1'
       - uses: actions/download-artifact@v7
         with:
-          name: ${{ inputs.profile }}-binary-linux
+          name: production-binary-linux
       - name: Upload nightly
         run: |
           .\mach upload-nightly linux --secret-from-environment `
@@ -251,18 +251,18 @@ jobs:
           fetch-depth: '1'
       - uses: actions/download-artifact@v7
         with:
-          name: ${{ inputs.profile }}-binary-android-aarch64
+          name: release-binary-android-aarch64
       - uses: actions/download-artifact@v7
         with:
-          name: ${{ inputs.profile }}-library-android-aarch64
+          name: release-library-android-aarch64
       - name: Generate artifact attestation for APK
         uses: actions/attest-build-provenance@v3
         with:
-          subject-path: target/android/${{ matrix.target }}/${{ inputs.profile }}/servoapp.apk
+          subject-path: target/android/aarch64-linux-android/release/servoapp.apk
       - name: Generate artifact attestation for AAR
         uses: actions/attest-build-provenance@v3
         with:
-          subject-path: target/android/${{ matrix.target }}/${{ inputs.profile }}/servoview.aar
+          subject-path: target/android/aarch64-linux-android/release/servoview.aar
       - name: Upload nightly
         run: |
           ./mach upload-nightly android \
@@ -303,18 +303,18 @@ jobs:
           fetch-depth: '1'
       - uses: actions/download-artifact@v7
         with:
-          name: ${{ inputs.profile }}-library-ohos-aarch64-unknown-linux-ohos
+          name: production-library-ohos-aarch64-unknown-linux-ohos
       - name: Generate artifact attestation for shared library
         uses: actions/attest-build-provenance@v3
         with:
           subject-path: target/aarch64-unknown-linux-ohos/production/libservoshell.so
       - uses: actions/download-artifact@v7
         with:
-          name: ${{ inputs.profile }}-binary-ohos-aarch64-unknown-linux-ohos
+          name: production-binary-ohos-aarch64-unknown-linux-ohos
       - name: Generate artifact attestation for HAP
         uses: actions/attest-build-provenance@v3
         with:
-          subject-path: target/openharmony/aarch64-unknown-linux-ohos/${{ inputs.profile }}/entry/build/default/outputs/default/servoshell-default-signed.hap
+          subject-path: target/openharmony/aarch64-unknown-linux-ohos/production/entry/build/default/outputs/default/servoshell-default-signed.hap
       - name: Upload nightly
         run: |
           ./mach upload-nightly ohos \

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -100,6 +100,8 @@ jobs:
             .github
             python
             .
+            tests/wpt/tests/tools/requirements_tests.txt
+            tests/wpt/tests/tools/wptrunner/requirements.txt
           fetch-depth: '1'
       - name: Setup Python
         uses: ./.github/actions/setup-python
@@ -144,6 +146,8 @@ jobs:
             .github
             python
             .
+            tests/wpt/tests/tools/requirements_tests.txt
+            tests/wpt/tests/tools/wptrunner/requirements.txt
           fetch-depth: '1'
       - name: Setup Python
         uses: ./.github/actions/setup-python
@@ -183,6 +187,8 @@ jobs:
             .github
             python
             .
+            tests/wpt/tests/tools/requirements_tests.txt
+            tests/wpt/tests/tools/wptrunner/requirements.txt
           fetch-depth: '1'
       - name: Setup Python
         uses: ./.github/actions/setup-python
@@ -224,6 +230,8 @@ jobs:
             .github
             python
             .
+            tests/wpt/tests/tools/requirements_tests.txt
+            tests/wpt/tests/tools/wptrunner/requirements.txt
           fetch-depth: '1'
       - name: Setup Python
         uses: ./.github/actions/setup-python
@@ -266,6 +274,8 @@ jobs:
             .github
             python
             .
+            tests/wpt/tests/tools/requirements_tests.txt
+            tests/wpt/tests/tools/wptrunner/requirements.txt
           fetch-depth: '1'
       - name: Setup Python
         uses: ./.github/actions/setup-python
@@ -323,6 +333,8 @@ jobs:
             .github
             python
             .
+            tests/wpt/tests/tools/requirements_tests.txt
+            tests/wpt/tests/tools/wptrunner/requirements.txt
           fetch-depth: '1'
       - name: Setup Python
         uses: ./.github/actions/setup-python

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -116,19 +116,40 @@ jobs:
           NIGHTLY_REPO: ${{ github.repository_owner }}/servo-nightly-builds
 
 
-  upload-mac:
+  build-mac:
     # This job is only useful when run on upstream servo.
     if: github.repository == 'servo/servo' || github.event_name == 'workflow_dispatch'
-    name: Upload nightly (macOS)
-    needs:
-      - create-draft-release
+    name: Build nightly (macOS)
     uses: ./.github/workflows/mac.yml
     with:
       profile: "production"
-      upload: true
-      github-release-id: ${{ needs.create-draft-release.outputs.release-id }}
       force-github-hosted-runner: true  # <https://github.com/servo/servo/issues/33296>
-    secrets: inherit
+
+  upload-mac:
+    # This job is only useful when run on upstream servo.
+    if: github.repository == 'servo/servo' || github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-latest
+    needs:
+      - create-draft-release
+      - build-mac
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          sparse-checkout: |
+            python
+            .
+          fetch-depth: '1'
+      - uses: actions/download-artifact@v7
+        with:
+          name: ${{ inputs.profile }}-binary-mac
+      - name: Upload nightly
+        run: |
+          .\mach upload-nightly mac --secret-from-environment `
+            --github-release-id ${{ needs.create-draft-release.outputs.release-id }}
+        env:
+          S3_UPLOAD_CREDENTIALS: ${{ secrets.S3_UPLOAD_CREDENTIALS }}
+          NIGHTLY_REPO_TOKEN: ${{ secrets.NIGHTLY_REPO_TOKEN }}
+          NIGHTLY_REPO: ${{ github.repository_owner }}/servo-nightly-builds
 
   upload-mac-arm64:
     # This job is only useful when run on upstream servo.

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -151,19 +151,42 @@ jobs:
           NIGHTLY_REPO_TOKEN: ${{ secrets.NIGHTLY_REPO_TOKEN }}
           NIGHTLY_REPO: ${{ github.repository_owner }}/servo-nightly-builds
 
-  upload-mac-arm64:
+  build-mac-arm64:
     # This job is only useful when run on upstream servo.
     if: github.repository == 'servo/servo' || github.event_name == 'workflow_dispatch'
-    name: Upload nightly (macOS Arm64)
-    needs:
-      - create-draft-release
+    name: Build nightly (macOS Arm64)
     uses: ./.github/workflows/mac-arm64.yml
     with:
       profile: "production"
-      upload: true
-      github-release-id: ${{ needs.create-draft-release.outputs.release-id }}
       force-github-hosted-runner: true  # <https://github.com/servo/servo/issues/33296>
-    secrets: inherit
+
+  upload-mac-arm64:
+    # This job is only useful when run on upstream servo.
+    if: github.repository == 'servo/servo' || github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-latest
+    needs:
+      - create-draft-release
+      - build-mac-arm64
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          sparse-checkout: |
+            python
+            .
+          fetch-depth: '1'
+      - uses: actions/download-artifact@v7
+        with:
+          name: ${{ inputs.profile }}-binary-mac-arm64
+      - name: Upload nightly
+        run: |
+          .\mach upload-nightly mac-arm64 --secret-from-environment `
+            --github-release-id ${{ needs.create-draft-release.outputs.release-id }}
+        env:
+          S3_UPLOAD_CREDENTIALS: ${{ secrets.S3_UPLOAD_CREDENTIALS }}
+          # TODO: this appears unused, can we remove it?
+          GITHUB_HOMEBREW_TOKEN: ${{ secrets.HOMEBREW_TOKEN }}
+          NIGHTLY_REPO_TOKEN: ${{ secrets.NIGHTLY_REPO_TOKEN }}
+          NIGHTLY_REPO: ${{ github.repository_owner }}/servo-nightly-builds
 
   upload-linux:
     # This job is only useful when run on upstream servo.

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -97,6 +97,7 @@ jobs:
       - uses: actions/checkout@v6
         with:
           sparse-checkout: |
+            .github
             python
             .
           fetch-depth: '1'
@@ -140,6 +141,7 @@ jobs:
       - uses: actions/checkout@v6
         with:
           sparse-checkout: |
+            .github
             python
             .
           fetch-depth: '1'
@@ -178,6 +180,7 @@ jobs:
       - uses: actions/checkout@v6
         with:
           sparse-checkout: |
+            .github
             python
             .
           fetch-depth: '1'
@@ -218,6 +221,7 @@ jobs:
       - uses: actions/checkout@v6
         with:
           sparse-checkout: |
+            .github
             python
             .
           fetch-depth: '1'
@@ -259,6 +263,7 @@ jobs:
       - uses: actions/checkout@v6
         with:
           sparse-checkout: |
+            .github
             python
             .
           fetch-depth: '1'
@@ -315,6 +320,7 @@ jobs:
       - uses: actions/checkout@v6
         with:
           sparse-checkout: |
+            .github
             python
             .
           fetch-depth: '1'

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -188,19 +188,40 @@ jobs:
           NIGHTLY_REPO_TOKEN: ${{ secrets.NIGHTLY_REPO_TOKEN }}
           NIGHTLY_REPO: ${{ github.repository_owner }}/servo-nightly-builds
 
-  upload-linux:
+  build-linux:
     # This job is only useful when run on upstream servo.
     if: github.repository == 'servo/servo' || github.event_name == 'workflow_dispatch'
-    name: Upload nightly (Linux)
-    needs:
-      - create-draft-release
+    name: Build nightly (Linux)
     uses: ./.github/workflows/linux.yml
     with:
       profile: "production"
-      upload: true
-      github-release-id: ${{ needs.create-draft-release.outputs.release-id }}
       force-github-hosted-runner: true  # <https://github.com/servo/servo/issues/33296>
-    secrets: inherit
+
+  upload-linux:
+    # This job is only useful when run on upstream servo.
+    if: github.repository == 'servo/servo' || github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-latest
+    needs:
+      - create-draft-release
+      - build-linux
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          sparse-checkout: |
+            python
+            .
+          fetch-depth: '1'
+      - uses: actions/download-artifact@v7
+        with:
+          name: ${{ inputs.profile }}-binary-linux
+      - name: Upload nightly
+        run: |
+          .\mach upload-nightly linux --secret-from-environment `
+            --github-release-id ${{ needs.create-draft-release.outputs.release-id }}
+        env:
+          S3_UPLOAD_CREDENTIALS: ${{ secrets.S3_UPLOAD_CREDENTIALS }}
+          NIGHTLY_REPO_TOKEN: ${{ secrets.NIGHTLY_REPO_TOKEN }}
+          NIGHTLY_REPO: ${{ github.repository_owner }}/servo-nightly-builds
 
   build-android:
     # This job is only useful when run on upstream servo.

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -108,7 +108,7 @@ jobs:
           name: production-binary-windows-zip
       - name: Upload nightly
         run: |
-          .\mach upload-nightly windows-msvc --secret-from-environment
+          ./mach upload-nightly windows-msvc --secret-from-environment
             --github-release-id ${{ needs.create-draft-release.outputs.release-id }}
         env:
           S3_UPLOAD_CREDENTIALS: ${{ secrets.S3_UPLOAD_CREDENTIALS }}
@@ -144,7 +144,7 @@ jobs:
           name: production-binary-mac
       - name: Upload nightly
         run: |
-          .\mach upload-nightly mac --secret-from-environment
+          ./mach upload-nightly mac --secret-from-environment
             --github-release-id ${{ needs.create-draft-release.outputs.release-id }}
         env:
           S3_UPLOAD_CREDENTIALS: ${{ secrets.S3_UPLOAD_CREDENTIALS }}
@@ -179,7 +179,7 @@ jobs:
           name: production-binary-mac-arm64
       - name: Upload nightly
         run: |
-          .\mach upload-nightly mac-arm64 --secret-from-environment
+          ./mach upload-nightly mac-arm64 --secret-from-environment
             --github-release-id ${{ needs.create-draft-release.outputs.release-id }}
         env:
           S3_UPLOAD_CREDENTIALS: ${{ secrets.S3_UPLOAD_CREDENTIALS }}
@@ -216,7 +216,7 @@ jobs:
           name: production-binary-linux
       - name: Upload nightly
         run: |
-          .\mach upload-nightly linux --secret-from-environment
+          ./mach upload-nightly linux --secret-from-environment
             --github-release-id ${{ needs.create-draft-release.outputs.release-id }}
         env:
           S3_UPLOAD_CREDENTIALS: ${{ secrets.S3_UPLOAD_CREDENTIALS }}

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -274,18 +274,53 @@ jobs:
           NIGHTLY_REPO: ${{ github.repository_owner }}/servo-nightly-builds
 
 
-  upload-ohos:
+  build-ohos:
     # This job is only useful when run on upstream servo.
     if: github.repository == 'servo/servo' || github.event_name == 'workflow_dispatch'
-    name: Upload nightly (OpenHarmony)
-    needs:
-      - create-draft-release
-    permissions:
-      id-token: write
-      attestations: write
+    name: Build nightly (OpenHarmony)
     uses: ./.github/workflows/ohos.yml
     with:
       profile: "production"
-      upload: true
-      github-release-id: ${{ needs.create-draft-release.outputs.release-id }}
+      upload_library: true
     secrets: inherit
+
+  upload-ohos:
+    # This job is only useful when run on upstream servo.
+    if: github.repository == 'servo/servo' || github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      attestations: write
+    needs:
+      - create-draft-release
+      - build-ohos
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          sparse-checkout: |
+            python
+            .
+          fetch-depth: '1'
+      - uses: actions/download-artifact@v7
+        with:
+          name: ${{ inputs.profile }}-library-ohos-aarch64-unknown-linux-ohos
+      - name: Generate artifact attestation for shared library
+        uses: actions/attest-build-provenance@v3
+        with:
+          subject-path: target/aarch64-unknown-linux-ohos/production/libservoshell.so
+      - uses: actions/download-artifact@v7
+        with:
+          name: ${{ inputs.profile }}-binary-ohos-aarch64-unknown-linux-ohos
+      - name: Generate artifact attestation for HAP
+        uses: actions/attest-build-provenance@v3
+        with:
+          subject-path: target/openharmony/aarch64-unknown-linux-ohos/${{ inputs.profile }}/entry/build/default/outputs/default/servoshell-default-signed.hap
+      - name: Upload nightly
+        run: |
+          ./mach upload-nightly ohos \
+            --secret-from-environment \
+            --github-release-id ${{ needs.create-draft-release.outputs.release-id }}
+        env:
+          S3_UPLOAD_CREDENTIALS: ${{ secrets.S3_UPLOAD_CREDENTIALS }}
+          NIGHTLY_REPO_TOKEN: ${{ secrets.NIGHTLY_REPO_TOKEN }}
+          NIGHTLY_REPO: ${{ github.repository_owner }}/servo-nightly-builds

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -158,21 +158,56 @@ jobs:
       force-github-hosted-runner: true  # <https://github.com/servo/servo/issues/33296>
     secrets: inherit
 
-  upload-android:
+  build-android:
     # This job is only useful when run on upstream servo.
     if: github.repository == 'servo/servo' || github.event_name == 'workflow_dispatch'
-    name: Upload nightly (Android)
-    needs:
-      - create-draft-release
-    permissions:
-      id-token: write
-      attestations: write
+    name: Build nightly (Android)
     uses: ./.github/workflows/android.yml
     with:
       profile: "release"
-      upload: true
-      github-release-id: ${{ needs.create-draft-release.outputs.release-id }}
     secrets: inherit
+
+  upload-android:
+    # This job is only useful when run on upstream servo.
+    if: github.repository == 'servo/servo' || github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      attestations: write
+    needs:
+      - create-draft-release
+      - build-android
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          sparse-checkout: |
+            python
+            .
+          fetch-depth: '1'
+      - uses: actions/download-artifact@v7
+        with:
+          name: ${{ inputs.profile }}-binary-android-aarch64
+      - uses: actions/download-artifact@v7
+        with:
+          name: ${{ inputs.profile }}-library-android-aarch64
+      - name: Generate artifact attestation for APK
+        uses: actions/attest-build-provenance@v3
+        with:
+          subject-path: target/android/${{ matrix.target }}/${{ inputs.profile }}/servoapp.apk
+      - name: Generate artifact attestation for AAR
+        uses: actions/attest-build-provenance@v3
+        with:
+          subject-path: target/android/${{ matrix.target }}/${{ inputs.profile }}/servoview.aar
+      - name: Upload nightly
+        run: |
+          ./mach upload-nightly android \
+            --secret-from-environment \
+            --github-release-id ${{ needs.create-draft-release.outputs.release-id }}
+        env:
+          S3_UPLOAD_CREDENTIALS: ${{ secrets.S3_UPLOAD_CREDENTIALS }}
+          NIGHTLY_REPO_TOKEN: ${{ secrets.NIGHTLY_REPO_TOKEN }}
+          NIGHTLY_REPO: ${{ github.repository_owner }}/servo-nightly-builds
+
 
   upload-ohos:
     # This job is only useful when run on upstream servo.

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -108,7 +108,7 @@ jobs:
           name: production-binary-windows-zip
       - name: Upload nightly
         run: |
-          .\mach upload-nightly windows-msvc --secret-from-environment `
+          .\mach upload-nightly windows-msvc --secret-from-environment
             --github-release-id ${{ needs.create-draft-release.outputs.release-id }}
         env:
           S3_UPLOAD_CREDENTIALS: ${{ secrets.S3_UPLOAD_CREDENTIALS }}
@@ -144,7 +144,7 @@ jobs:
           name: production-binary-mac
       - name: Upload nightly
         run: |
-          .\mach upload-nightly mac --secret-from-environment `
+          .\mach upload-nightly mac --secret-from-environment
             --github-release-id ${{ needs.create-draft-release.outputs.release-id }}
         env:
           S3_UPLOAD_CREDENTIALS: ${{ secrets.S3_UPLOAD_CREDENTIALS }}
@@ -179,7 +179,7 @@ jobs:
           name: production-binary-mac-arm64
       - name: Upload nightly
         run: |
-          .\mach upload-nightly mac-arm64 --secret-from-environment `
+          .\mach upload-nightly mac-arm64 --secret-from-environment
             --github-release-id ${{ needs.create-draft-release.outputs.release-id }}
         env:
           S3_UPLOAD_CREDENTIALS: ${{ secrets.S3_UPLOAD_CREDENTIALS }}
@@ -216,7 +216,7 @@ jobs:
           name: production-binary-linux
       - name: Upload nightly
         run: |
-          .\mach upload-nightly linux --secret-from-environment `
+          .\mach upload-nightly linux --secret-from-environment
             --github-release-id ${{ needs.create-draft-release.outputs.release-id }}
         env:
           S3_UPLOAD_CREDENTIALS: ${{ secrets.S3_UPLOAD_CREDENTIALS }}

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -107,7 +107,7 @@ jobs:
           name: production-binary-windows-zip
       - name: Upload nightly
         run: |
-          ./mach upload-nightly windows-msvc --secret-from-environment
+          ./mach upload-nightly windows-msvc --secret-from-environment \
             --github-release-id ${{ needs.create-draft-release.outputs.release-id }} \
             Servo.exe \
             Servo.zip
@@ -144,7 +144,7 @@ jobs:
           name: production-binary-mac
       - name: Upload nightly
         run: |
-          ./mach upload-nightly mac --secret-from-environment
+          ./mach upload-nightly mac --secret-from-environment \
             --github-release-id ${{ needs.create-draft-release.outputs.release-id }} \
             servo-tech-demo.dmg
         env:
@@ -179,7 +179,7 @@ jobs:
           name: production-binary-mac-arm64
       - name: Upload nightly
         run: |
-          ./mach upload-nightly mac-arm64 --secret-from-environment
+          ./mach upload-nightly mac-arm64 --secret-from-environment \
             --github-release-id ${{ needs.create-draft-release.outputs.release-id }} \
             servo-tech-demo.dmg
         env:
@@ -216,7 +216,7 @@ jobs:
           name: production-binary-linux
       - name: Upload nightly
         run: |
-          ./mach upload-nightly linux --secret-from-environment
+          ./mach upload-nightly linux --secret-from-environment \
             --github-release-id ${{ needs.create-draft-release.outputs.release-id }} \
             servo-tech-demo.tar.gz
         env:

--- a/.github/workflows/ohos.yml
+++ b/.github/workflows/ohos.yml
@@ -86,7 +86,7 @@ jobs:
         id: signing_config
         env:
           SIGNING_MATERIAL: ${{ secrets.SERVO_OHOS_SIGNING_MATERIAL }}
-        if: ${{ inputs.upload || env.SIGNING_MATERIAL != '' }} # Allows the build to pass on forks.
+        if: ${{ env.SIGNING_MATERIAL != '' }} # Allows the build to pass on forks.
         run: |
           cd ~
           echo "${SIGNING_MATERIAL}" | base64 -d > servo-ohos-material.zip

--- a/.github/workflows/ohos.yml
+++ b/.github/workflows/ohos.yml
@@ -6,13 +6,10 @@ on:
         required: false
         default: "release"
         type: string
-      upload:
+      upload_library:
         required: false
         default: false
         type: boolean
-      github-release-id:
-        required: false
-        type: string
       bencher:
         required: false
         default: false
@@ -109,21 +106,12 @@ jobs:
           name: cargo-timings-ohos-${{ matrix.target }}-${{ inputs.profile }}
           # Using a wildcard here ensures that the archive includes the path.
           path: target/cargo-timings-*
-      - name: Upload nightly
-        if: ${{ inputs.upload && contains(matrix.target, 'aarch64') }}
-        run: |
-          ./mach upload-nightly ohos \
-            --secret-from-environment \
-            --github-release-id ${{ inputs.github-release-id }}
-        env:
-          S3_UPLOAD_CREDENTIALS: ${{ secrets.S3_UPLOAD_CREDENTIALS }}
-          NIGHTLY_REPO_TOKEN: ${{ secrets.NIGHTLY_REPO_TOKEN }}
-          NIGHTLY_REPO: ${{ github.repository_owner }}/servo-nightly-builds
-      - name: Generate artifact attestation for HAP
-        if: ${{ inputs.upload }}
-        uses: actions/attest-build-provenance@v1
+      - name: Upload shared library
+        if: ${{ inputs.upload_library }}
+        uses: actions/upload-artifact@v4
         with:
-          subject-path: target/openharmony/${{ matrix.target }}/${{ inputs.profile }}/entry/build/default/outputs/default/servoshell-default-signed.hap
+          name: ${{ inputs.profile }}-library-ohos-${{ matrix.target }}
+          path: target/aarch64-unknown-linux-ohos/production/libservoshell.so
       - name: Upload signed HAP artifact
         if: ${{ env.SERVO_OHOS_SIGNING_CONFIG != '' }} # Build output has different name if not signed.
         uses: actions/upload-artifact@v4

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -19,13 +19,10 @@ on:
         required: false
         default: false
         type: boolean
-      upload:
+      upload_zip:
         required: false
         default: false
         type: boolean
-      github-release-id:
-        required: false
-        type: string
       force-github-hosted-runner:
         required: false
         type: boolean
@@ -46,10 +43,6 @@ on:
         default: false
         type: boolean
       build-libservo:
-        required: false
-        default: false
-        type: boolean
-      upload:
         required: false
         default: false
         type: boolean
@@ -195,24 +188,22 @@ jobs:
           path: C:\\a\\servo\\servo\\target\\cargo-timings-*
       - name: Build mach package
         run: .\mach package --profile ${{ inputs.profile }}
+      # These files are available
+      # MSI Installer: C:\a\servo\servo\target\${{ inputs.profile }}\msi\Installer.msi
+      # Bundle: C:\a\servo\servo\target\${{ inputs.profile }}\msi\Servo.exe
+      # Zip: C:\a\servo\servo\target\${{ inputs.profile }}\msi\Servo.zip
       - name: Upload artifact for mach package
         uses: actions/upload-artifact@v4
         with:
           name: ${{ inputs.profile }}-binary-windows
-          # These files are available
-          # MSI Installer: C:\a\servo\servo\target\${{ inputs.profile }}\msi\Installer.msi
-          # Bundle: C:\a\servo\servo\target\${{ inputs.profile }}\msi\Servo.exe
-          # Zip: C:\a\servo\servo\target\${{ inputs.profile }}\msi\Servo.zip
           path: C:\\a\\servo\\servo\\target\\${{ inputs.profile }}\\msi\\Servo.exe
-      - name: Upload nightly
-        if: ${{ inputs.upload }}
-        run: |
-          .\mach upload-nightly windows-msvc --secret-from-environment `
-            --github-release-id ${{ inputs.github-release-id }}
-        env:
-          S3_UPLOAD_CREDENTIALS: ${{ secrets.S3_UPLOAD_CREDENTIALS }}
-          NIGHTLY_REPO_TOKEN: ${{ secrets.NIGHTLY_REPO_TOKEN }}
-          NIGHTLY_REPO: ${{ github.repository_owner }}/servo-nightly-builds
+      - name: Upload artifact for mach package (zip)
+        uses: actions/upload-artifact@v4
+        if: ${{ inputs.upload_zip }}
+        with:
+          name: ${{ inputs.profile }}-binary-windows-zip
+          path: C:\\a\\servo\\servo\\target\\${{ inputs.profile }}\\msi\\Servo.zip
+
   bencher:
     needs: ["build"]
     if: ${{ inputs.bencher && inputs.profile != 'debug' && github.event_name != 'workflow_dispatch' && github.event_name != 'merge_group' }}

--- a/python/servo/package_commands.py
+++ b/python/servo/package_commands.py
@@ -12,7 +12,6 @@ import random
 from typing import List
 
 import time
-from collections.abc import Generator
 from github import Github
 
 import hashlib
@@ -42,7 +41,7 @@ from servo.command_base import (
     CommandBase,
     is_windows,
 )
-from servo.util import delete, get_target_dir
+from servo.util import delete
 
 from python.servo.platform.build_target import SanitizerKind
 from servo.platform.build_target import is_android, is_openharmony

--- a/python/servo/package_commands.py
+++ b/python/servo/package_commands.py
@@ -9,6 +9,8 @@
 
 from datetime import datetime
 import random
+from typing import List
+
 import time
 from collections.abc import Generator
 from github import Github
@@ -44,38 +46,6 @@ from servo.util import delete, get_target_dir
 
 from python.servo.platform.build_target import SanitizerKind
 from servo.platform.build_target import is_android, is_openharmony
-
-PACKAGES = {
-    "android": [
-        "android/aarch64-linux-android/release/servoapp.apk",
-        "android/aarch64-linux-android/release/servoview.aar",
-    ],
-    "linux": [
-        "production/servo-tech-demo.tar.gz",
-    ],
-    "mac": [
-        "production/servo-tech-demo.dmg",
-    ],
-    "mac-arm64": [
-        "production/servo-tech-demo.dmg",
-    ],
-    "windows-msvc": [
-        r"production\msi\Servo.exe",
-        r"production\msi\Servo.zip",
-    ],
-    "ohos": [
-        "aarch64-unknown-linux-ohos/production/libservoshell.so",
-        "openharmony/aarch64-unknown-linux-ohos/production/entry/build/"
-        + "default/outputs/default/servoshell-default-signed.hap",
-    ],
-}
-
-
-def packages_for_platform(platform: str) -> Generator[str]:
-    target_dir = get_target_dir()
-
-    for package in PACKAGES[platform]:
-        yield path.join(target_dir, package)
 
 
 def listfiles(directory: str) -> list[str]:
@@ -455,14 +425,17 @@ class PackageCommands(CommandBase):
         return subprocess.call(exec_command, env=env)
 
     @Command("upload-nightly", description="Upload Servo nightly to S3", category="package")
-    @CommandArgument("platform", choices=PACKAGES.keys(), help="Package platform type to upload")
+    @CommandArgument("platform", help="Package platform type to upload")
     @CommandArgument(
         "--secret-from-environment", action="store_true", help="Retrieve the appropriate secrets from the environment."
     )
     @CommandArgument(
         "--github-release-id", default=None, type=int, help="The github release to upload the nightly builds."
     )
-    def upload_nightly(self, platform: str, secret_from_environment: bool, github_release_id: int | None) -> int:
+    @CommandArgument("packages", nargs="+", help="The packages to upload.")
+    def upload_nightly(
+        self, platform: str, secret_from_environment: bool, github_release_id: int | None, packages: List[str]
+    ) -> int:
         import boto3
 
         def get_s3_secret() -> tuple:
@@ -565,8 +538,11 @@ class PackageCommands(CommandBase):
             )
 
         timestamp = datetime.utcnow().replace(microsecond=0)
-        for package in packages_for_platform(platform):
+        for package in packages:
+            # TODO: This if feels like it should not be necessary. Let's add a warning, and make this an
+            # error later.
             if path.isdir(package):
+                print("Warning: Skipping directory: {}".format(package), file=sys.stderr)
                 continue
             if not path.isfile(package):
                 print("Could not find package for {} at {}".format(platform, package), file=sys.stderr)


### PR DESCRIPTION
This change moves the upload and attestation steps to the nightly workflow. This results in overall slightly more code, but reduces the amount of code that has access to extra privileges. 

Additionally, this refactoring will allow to easily change the target repo for the nightly release, i.e. allowing us to reuse the nightly workflow for our monthly releases in the servo/servo repo (in a follow-up PR).

We change upload_nightly to get an additional `packages` parameter, that we use instead of a hardcoded table of expected packages per platform.
`download-artifact` doesn't preserve the whole directory structure, so it would be a bit cumbersome to preserve that.
Since we anyway only use the upload script in CI, we can just directly specify the packages in the CI, which also makes things slightly more flexibel if we want to add new packages or platforms.

There are still more improvements to come, specifically also to the `upload_nightly` script, with the goal to minimize the amount of code that needs to be trusted.

Testing: Manually triggering the [release workflow](https://github.com/servo/servo/actions/runs/20996682863/job/60358012404) via workflow-dispatch.

