### PR TITLE
script: Move AES-CBC to individual submodule

### DIFF
--- a/components/script/dom/subtlecrypto.rs
+++ b/components/script/dom/subtlecrypto.rs
@@ -2,6 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
+mod aes_cbc_operation;
 mod aes_common;
 mod aes_ctr_operation;
 mod aes_ocb_operation;
@@ -4031,7 +4032,7 @@ impl NormalizedAlgorithm {
                 aes_ctr_operation::encrypt(algo, key, plaintext)
             },
             (ALG_AES_CBC, NormalizedAlgorithm::AesCbcParams(algo)) => {
-                aes_operation::encrypt_aes_cbc(algo, key, plaintext)
+                aes_cbc_operation::encrypt(algo, key, plaintext)
             },
             (ALG_AES_GCM, NormalizedAlgorithm::AesGcmParams(algo)) => {
                 aes_operation::encrypt_aes_gcm(algo, key, plaintext)
@@ -4055,7 +4056,7 @@ impl NormalizedAlgorithm {
                 aes_ctr_operation::decrypt(algo, key, ciphertext)
             },
             (ALG_AES_CBC, NormalizedAlgorithm::AesCbcParams(algo)) => {
-                aes_operation::decrypt_aes_cbc(algo, key, ciphertext)
+                aes_cbc_operation::decrypt(algo, key, ciphertext)
             },
             (ALG_AES_GCM, NormalizedAlgorithm::AesGcmParams(algo)) => {
                 aes_operation::decrypt_aes_gcm(algo, key, ciphertext)
@@ -4192,7 +4193,7 @@ impl NormalizedAlgorithm {
                     .map(CryptoKeyOrCryptoKeyPair::CryptoKey)
             },
             (ALG_AES_CBC, NormalizedAlgorithm::AesKeyGenParams(algo)) => {
-                aes_operation::generate_key_aes_cbc(global, algo, extractable, usages, can_gc)
+                aes_cbc_operation::generate_key(global, algo, extractable, usages, can_gc)
                     .map(CryptoKeyOrCryptoKeyPair::CryptoKey)
             },
             (ALG_AES_GCM, NormalizedAlgorithm::AesKeyGenParams(algo)) => {
@@ -4329,14 +4330,7 @@ impl NormalizedAlgorithm {
                 aes_ctr_operation::import_key(global, format, key_data, extractable, usages, can_gc)
             },
             (ALG_AES_CBC, NormalizedAlgorithm::Algorithm(_algo)) => {
-                aes_operation::import_key_aes_cbc(
-                    global,
-                    format,
-                    key_data,
-                    extractable,
-                    usages,
-                    can_gc,
-                )
+                aes_cbc_operation::import_key(global, format, key_data, extractable, usages, can_gc)
             },
             (ALG_AES_GCM, NormalizedAlgorithm::Algorithm(_algo)) => {
                 aes_operation::import_key_aes_gcm(
@@ -4465,7 +4459,7 @@ impl NormalizedAlgorithm {
                 aes_ctr_operation::get_key_length(algo)
             },
             (ALG_AES_CBC, NormalizedAlgorithm::AesDerivedKeyParams(algo)) => {
-                aes_operation::get_key_length_aes_cbc(algo)
+                aes_cbc_operation::get_key_length(algo)
             },
             (ALG_AES_GCM, NormalizedAlgorithm::AesDerivedKeyParams(algo)) => {
                 aes_operation::get_key_length_aes_gcm(algo)
@@ -4536,7 +4530,7 @@ fn perform_export_key_operation(format: KeyFormat, key: &CryptoKey) -> Result<Ex
         ALG_ED25519 => ed25519_operation::export_key(format, key),
         ALG_X25519 => x25519_operation::export_key(format, key),
         ALG_AES_CTR => aes_ctr_operation::export_key(format, key),
-        ALG_AES_CBC => aes_operation::export_key_aes_cbc(format, key),
+        ALG_AES_CBC => aes_cbc_operation::export_key(format, key),
         ALG_AES_GCM => aes_operation::export_key_aes_gcm(format, key),
         ALG_AES_KW => aes_operation::export_key_aes_kw(format, key),
         ALG_HMAC => hmac_operation::export_key(format, key),

--- a/components/script/dom/subtlecrypto/aes_cbc_operation.rs
+++ b/components/script/dom/subtlecrypto/aes_cbc_operation.rs
@@ -1,0 +1,232 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+use aes::cipher::crypto_common::Key;
+use aes::{Aes128, Aes192, Aes256};
+use cbc::{Decryptor, Encryptor};
+use cipher::block_padding::Pkcs7;
+use cipher::{BlockDecryptMut, BlockEncryptMut, KeyIvInit};
+
+use crate::dom::bindings::codegen::Bindings::CryptoKeyBinding::{KeyType, KeyUsage};
+use crate::dom::bindings::codegen::Bindings::SubtleCryptoBinding::KeyFormat;
+use crate::dom::bindings::error::Error;
+use crate::dom::bindings::root::DomRoot;
+use crate::dom::cryptokey::{CryptoKey, Handle};
+use crate::dom::globalscope::GlobalScope;
+use crate::dom::subtlecrypto::aes_common::AesAlgorithm;
+use crate::dom::subtlecrypto::{
+    ALG_AES_CBC, ExportedKey, KeyAlgorithmAndDerivatives, SubtleAesCbcParams,
+    SubtleAesDerivedKeyParams, SubtleAesKeyAlgorithm, SubtleAesKeyGenParams, aes_common,
+};
+use crate::script_runtime::CanGc;
+
+/// <https://w3c.github.io/webcrypto/#aes-cbc-operations-encrypt>
+pub(crate) fn encrypt(
+    normalized_algorithm: &SubtleAesCbcParams,
+    key: &CryptoKey,
+    plaintext: &[u8],
+) -> Result<Vec<u8>, Error> {
+    // Step 1. If the iv member of normalizedAlgorithm does not have a length of 16 bytes, then
+    // throw an OperationError.
+    if normalized_algorithm.iv.len() != 16 {
+        return Err(Error::Operation(Some(
+            "The initialization vector length is not 16 bytes".into(),
+        )));
+    }
+
+    // Step 2. Let paddedPlaintext be the result of adding padding octets to plaintext according to
+    // the procedure defined in Section 10.3 of [RFC2315], step 2, with a value of k of 16.
+    // Step 3. Let ciphertext be the result of performing the CBC Encryption operation described in
+    // Section 6.2 of [NIST-SP800-38A] using AES as the block cipher, the iv member of
+    // normalizedAlgorithm as the IV input parameter and paddedPlaintext as the input plaintext.
+    let iv = normalized_algorithm.iv.as_slice();
+    let ciphertext = match key.handle() {
+        Handle::Aes128Key(key) => {
+            let encryptor = Encryptor::<Aes128>::new(key, iv.into());
+            encryptor.encrypt_padded_vec_mut::<Pkcs7>(plaintext)
+        },
+        Handle::Aes192Key(key) => {
+            let encryptor = Encryptor::<Aes192>::new(key, iv.into());
+            encryptor.encrypt_padded_vec_mut::<Pkcs7>(plaintext)
+        },
+        Handle::Aes256Key(key) => {
+            let encryptor = Encryptor::<Aes256>::new(key, iv.into());
+            encryptor.encrypt_padded_vec_mut::<Pkcs7>(plaintext)
+        },
+        _ => {
+            return Err(Error::Operation(Some(
+                "The key handle is not representing an AES key".to_string(),
+            )));
+        },
+    };
+
+    // Step 4. Return ciphertext.
+    Ok(ciphertext)
+}
+
+/// <https://w3c.github.io/webcrypto/#aes-cbc-operations-decrypt>
+pub(crate) fn decrypt(
+    normalized_algorithm: &SubtleAesCbcParams,
+    key: &CryptoKey,
+    ciphertext: &[u8],
+) -> Result<Vec<u8>, Error> {
+    // Step 1. If the iv member of normalizedAlgorithm does not have a length of 16 bytes, then
+    // throw an OperationError.
+    if normalized_algorithm.iv.len() != 16 {
+        return Err(Error::Operation(Some(
+            "The initialization vector length is not 16 bytes".into(),
+        )));
+    }
+
+    // Step 2. If the length of ciphertext is zero or is not a multiple of 16 bytes, then throw an
+    // OperationError.
+    if ciphertext.is_empty() {
+        return Err(Error::Operation(Some("The ciphertext is empty".into())));
+    }
+    if ciphertext.len() % 16 != 0 {
+        return Err(Error::Operation(Some(
+            "The ciphertext length is not a multiple of 16 bytes".into(),
+        )));
+    }
+
+    // Step 3. Let paddedPlaintext be the result of performing the CBC Decryption operation
+    // described in Section 6.2 of [NIST-SP800-38A] using AES as the block cipher, the iv member of
+    // normalizedAlgorithm as the IV input parameter and ciphertext as the input ciphertext.
+    // Step 4. Let p be the value of the last octet of paddedPlaintext.
+    // Step 5. If p is zero or greater than 16, or if any of the last p octets of paddedPlaintext
+    // have a value which is not p, then throw an OperationError.
+    // Step 6. Let plaintext be the result of removing p octets from the end of paddedPlaintext.
+    let iv = normalized_algorithm.iv.as_slice();
+    let plaintext = match key.handle() {
+        Handle::Aes128Key(key) => {
+            let decryptor = Decryptor::<Aes128>::new(key, iv.into());
+            decryptor
+                .decrypt_padded_vec_mut::<Pkcs7>(ciphertext)
+                .map_err(|_| {
+                    Error::Operation(Some("Failed to perform AES-CBC decryption".to_string()))
+                })?
+        },
+        Handle::Aes192Key(key) => {
+            let decryptor = Decryptor::<Aes192>::new(key, iv.into());
+            decryptor
+                .decrypt_padded_vec_mut::<Pkcs7>(ciphertext)
+                .map_err(|_| {
+                    Error::Operation(Some("Failed to perform AES-CBC decryption".to_string()))
+                })?
+        },
+        Handle::Aes256Key(key) => {
+            let decryptor = Decryptor::<Aes256>::new(key, iv.into());
+            decryptor
+                .decrypt_padded_vec_mut::<Pkcs7>(ciphertext)
+                .map_err(|_| {
+                    Error::Operation(Some("Failed to perform AES-CBC decryption".to_string()))
+                })?
+        },
+        _ => {
+            return Err(Error::Operation(Some(
+                "The key handle is not representing an AES key".to_string(),
+            )));
+        },
+    };
+    // Step 7. Return plaintext.
+    Ok(plaintext)
+}
+
+/// <https://w3c.github.io/webcrypto/#aes-cbc-operations-generate-key>
+pub(crate) fn generate_key(
+    global: &GlobalScope,
+    normalized_algorithm: &SubtleAesKeyGenParams,
+    extractable: bool,
+    usages: Vec<KeyUsage>,
+    can_gc: CanGc,
+) -> Result<DomRoot<CryptoKey>, Error> {
+    aes_common::generate_key(
+        AesAlgorithm::AesCbc,
+        global,
+        normalized_algorithm,
+        extractable,
+        usages,
+        can_gc,
+    )
+}
+
+/// <https://w3c.github.io/webcrypto/#aes-cbc-operations-import-key>
+pub(crate) fn import_key(
+    global: &GlobalScope,
+    format: KeyFormat,
+    key_data: &[u8],
+    extractable: bool,
+    usages: Vec<KeyUsage>,
+    can_gc: CanGc,
+) -> Result<DomRoot<CryptoKey>, Error> {
+    // Step 1. Let keyData be the key data to be imported.
+
+    // Step 2. If usages contains an entry which is not one of "encrypt", "decrypt", "wrapKey" or
+    // "unwrapKey", then throw a SyntaxError.
+    if usages.iter().any(|usage| {
+        !matches!(
+            usage,
+            KeyUsage::Encrypt | KeyUsage::Decrypt | KeyUsage::WrapKey | KeyUsage::UnwrapKey
+        )
+    }) {
+        return Err(Error::Syntax(Some(
+            "Usages contains an entry which is not one of \"encrypt\", \"decrypt\", \"wrapKey\" \
+            or \"unwrapKey\""
+                .to_string(),
+        )));
+    }
+
+    // Step 3.
+    let data = aes_common::import_key_from_key_data(
+        AesAlgorithm::AesCbc,
+        format,
+        key_data,
+        extractable,
+        &usages,
+    )?;
+
+    // Step 4. Let key be a new CryptoKey object representing an AES key with value data.
+    // Step 5. Let algorithm be a new AesKeyAlgorithm.
+    // Step 6. Set the name attribute of algorithm to "AES-CBC".
+    // Step 7. Set the length attribute of algorithm to the length, in bits, of data.
+    // Step 8. Set the [[algorithm]] internal slot of key to algorithm.
+    let handle = match data.len() {
+        16 => Handle::Aes128Key(Key::<Aes128>::clone_from_slice(&data)),
+        24 => Handle::Aes192Key(Key::<Aes192>::clone_from_slice(&data)),
+        32 => Handle::Aes256Key(Key::<Aes256>::clone_from_slice(&data)),
+        _ => {
+            return Err(Error::Data(Some(
+                "The length in bits of data is not 128, 192 or 256".to_string(),
+            )));
+        },
+    };
+    let algorithm = SubtleAesKeyAlgorithm {
+        name: ALG_AES_CBC.to_string(),
+        length: data.len() as u16 * 8,
+    };
+    let key = CryptoKey::new(
+        global,
+        KeyType::Secret,
+        extractable,
+        KeyAlgorithmAndDerivatives::AesKeyAlgorithm(algorithm),
+        usages,
+        handle,
+        can_gc,
+    );
+
+    // Step 9. Return key.
+    Ok(key)
+}
+
+/// <https://w3c.github.io/webcrypto/#aes-cbc-operations-export-key>
+pub(crate) fn export_key(format: KeyFormat, key: &CryptoKey) -> Result<ExportedKey, Error> {
+    aes_common::export_key(AesAlgorithm::AesCbc, format, key)
+}
+
+/// <https://w3c.github.io/webcrypto/#aes-cbc-operations-get-key-length>
+pub(crate) fn get_key_length(
+    normalized_derived_key_algorithm: &SubtleAesDerivedKeyParams,
+) -> Result<Option<u32>, Error> {
+    aes_common::get_key_length(normalized_derived_key_algorithm)
+}


### PR DESCRIPTION
We previously introduced new infrastructure for sharing code in `aes_common.rs` among AES algorithms.

Similar to #41856 on AES-CTR, this patch makes AES-CBC algorithm adapt the new infrastructure, by moving the relevant code away from `aes_operation.rs` to its own `aes_cbc_operation.rs`, and calling AES common steps in the new `aes_common.rs`. The patch also does some refactoring on the encrypt and decrypt operations to get closer to specification.

Testing: Refactoring. Existing tests suffice.
Fixes: Part of #41763