### PR TITLE
layout: Track parentage in the box tree

### DIFF
--- a/components/layout/flexbox/layout.rs
+++ b/components/layout/flexbox/layout.rs
@@ -27,6 +27,7 @@ use super::geom::{FlexAxis, FlexRelativeRect, FlexRelativeSides, FlexRelativeVec
 use super::{FlexContainer, FlexContainerConfig, FlexItemBox, FlexLevelBox};
 use crate::cell::ArcRefCell;
 use crate::context::LayoutContext;
+use crate::dom::WeakLayoutBox;
 use crate::formatting_contexts::Baselines;
 use crate::fragment_tree::{
     BoxFragment, CollapsedBlockMargins, Fragment, FragmentFlags, SpecificLayoutInfo,
@@ -1003,6 +1004,14 @@ impl FlexContainer {
     #[inline]
     pub(crate) fn layout_style(&self) -> LayoutStyle<'_> {
         LayoutStyle::Default(&self.style)
+    }
+
+    pub(crate) fn attached_to_tree(&self, layout_box: WeakLayoutBox) {
+        for child in &self.children {
+            child.borrow_mut().with_base_mut(|base| {
+                base.parent_box.replace(layout_box.clone());
+            });
+        }
     }
 }
 

--- a/components/layout/flexbox/mod.rs
+++ b/components/layout/flexbox/mod.rs
@@ -19,7 +19,7 @@ use crate::PropagatedBoxTreeData;
 use crate::cell::ArcRefCell;
 use crate::construct_modern::{ModernContainerBuilder, ModernItemKind};
 use crate::context::LayoutContext;
-use crate::dom::LayoutBox;
+use crate::dom::{LayoutBox, WeakLayoutBox};
 use crate::dom_traversal::{NodeAndStyleInfo, NonReplacedContents};
 use crate::formatting_contexts::IndependentFormattingContext;
 use crate::fragment_tree::BaseFragmentInfo;
@@ -196,6 +196,18 @@ impl FlexLevelBox {
             FlexLevelBox::OutOfFlowAbsolutelyPositionedBox(positioned_box) => {
                 callback(&mut positioned_box.borrow_mut().context.base)
             },
+        }
+    }
+
+    pub(crate) fn attached_to_tree(&self, layout_box: WeakLayoutBox) {
+        match self {
+            Self::FlexItem(flex_item_box) => flex_item_box
+                .independent_formatting_context
+                .attached_to_tree(layout_box),
+            Self::OutOfFlowAbsolutelyPositionedBox(positioned_box) => positioned_box
+                .borrow_mut()
+                .context
+                .attached_to_tree(layout_box),
         }
     }
 }

--- a/components/layout/flow/inline/text_run.rs
+++ b/components/layout/flow/inline/text_run.rs
@@ -28,6 +28,7 @@ use xi_unicode::linebreak_property;
 use super::line_breaker::LineBreaker;
 use super::{InlineFormattingContextLayout, SharedInlineStyles};
 use crate::context::LayoutContext;
+use crate::dom::WeakLayoutBox;
 use crate::fragment_tree::BaseFragmentInfo;
 
 // These constants are the xi-unicode line breaking classes that are defined in
@@ -329,6 +330,10 @@ pub(crate) struct TextRun {
     /// original text node in the DOM for the text.
     pub base_fragment_info: BaseFragmentInfo,
 
+    /// A weak reference to the parent of this layout box. This becomes valid as soon
+    /// as the *parent* of this box is added to the tree.
+    pub parent_box: Option<WeakLayoutBox>,
+
     /// The [`crate::SharedStyle`] from this [`TextRun`]s parent element. This is
     /// shared so that incremental layout can simply update the parent element and
     /// this [`TextRun`] will be updated automatically.
@@ -356,6 +361,7 @@ impl TextRun {
     ) -> Self {
         Self {
             base_fragment_info,
+            parent_box: None,
             inline_styles,
             text_range,
             shaped_text: Vec::new(),

--- a/components/layout/layout_box_base.rs
+++ b/components/layout/layout_box_base.rs
@@ -12,6 +12,7 @@ use servo_arc::Arc;
 use style::properties::ComputedValues;
 
 use crate::context::LayoutContext;
+use crate::dom::{LayoutBox, WeakLayoutBox};
 use crate::formatting_contexts::Baselines;
 use crate::fragment_tree::{BaseFragmentInfo, CollapsedBlockMargins, Fragment, SpecificLayoutInfo};
 use crate::positioned::PositioningContext;
@@ -33,6 +34,7 @@ pub(crate) struct LayoutBoxBase {
     pub outer_inline_content_sizes_depend_on_content: AtomicBool,
     pub cached_layout_result: AtomicRefCell<Option<Box<CacheableLayoutResultAndInputs>>>,
     pub fragments: AtomicRefCell<Vec<Fragment>>,
+    pub parent_box: Option<WeakLayoutBox>,
 }
 
 impl LayoutBoxBase {
@@ -44,6 +46,7 @@ impl LayoutBoxBase {
             outer_inline_content_sizes_depend_on_content: AtomicBool::new(true),
             cached_layout_result: AtomicRefCell::default(),
             fragments: AtomicRefCell::default(),
+            parent_box: None,
         }
     }
 
@@ -95,6 +98,11 @@ impl LayoutBoxBase {
                 base.repair_style(new_style);
             }
         }
+    }
+
+    #[expect(unused)]
+    pub(crate) fn parent_box(&self) -> Option<LayoutBox> {
+        self.parent_box.as_ref().and_then(WeakLayoutBox::upgrade)
     }
 }
 

--- a/components/layout/taffy/layout.rs
+++ b/components/layout/taffy/layout.rs
@@ -18,6 +18,7 @@ use super::{
 };
 use crate::cell::ArcRefCell;
 use crate::context::LayoutContext;
+use crate::dom::WeakLayoutBox;
 use crate::formatting_contexts::{Baselines, IndependentFormattingContext};
 use crate::fragment_tree::{
     BoxFragment, CollapsedBlockMargins, Fragment, FragmentFlags, SpecificLayoutInfo,
@@ -592,5 +593,13 @@ impl TaffyContainer {
     #[inline]
     pub(crate) fn layout_style(&self) -> LayoutStyle<'_> {
         LayoutStyle::Default(&self.style)
+    }
+
+    pub(crate) fn attached_to_tree(&self, layout_box: WeakLayoutBox) {
+        for child in &self.children {
+            child.borrow_mut().with_base_mut(|base| {
+                base.parent_box.replace(layout_box.clone());
+            });
+        }
     }
 }

--- a/components/layout/taffy/mod.rs
+++ b/components/layout/taffy/mod.rs
@@ -17,7 +17,7 @@ use crate::PropagatedBoxTreeData;
 use crate::cell::ArcRefCell;
 use crate::construct_modern::{ModernContainerBuilder, ModernItemKind};
 use crate::context::LayoutContext;
-use crate::dom::LayoutBox;
+use crate::dom::{LayoutBox, WeakLayoutBox};
 use crate::dom_traversal::{NodeAndStyleInfo, NonReplacedContents};
 use crate::formatting_contexts::IndependentFormattingContext;
 use crate::fragment_tree::Fragment;
@@ -172,6 +172,18 @@ impl TaffyItemBox {
         match &self.taffy_level_box {
             TaffyItemBoxInner::InFlowBox(fc) => fc.is_replaced(),
             TaffyItemBoxInner::OutOfFlowAbsolutelyPositionedBox(_) => false,
+        }
+    }
+
+    pub(crate) fn attached_to_tree(&self, layout_box: WeakLayoutBox) {
+        match &self.taffy_level_box {
+            TaffyItemBoxInner::InFlowBox(formatting_context) => {
+                formatting_context.attached_to_tree(layout_box)
+            },
+            TaffyItemBoxInner::OutOfFlowAbsolutelyPositionedBox(positioned_box) => positioned_box
+                .borrow_mut()
+                .context
+                .attached_to_tree(layout_box),
         }
     }
 }

--- a/components/malloc_size_of/lib.rs
+++ b/components/malloc_size_of/lib.rs
@@ -696,6 +696,14 @@ impl<T: MallocSizeOf> MallocConditionalSizeOf for Rc<T> {
     }
 }
 
+impl<T: MallocSizeOf> MallocSizeOf for std::sync::Weak<T> {
+    fn size_of(&self, _: &mut MallocSizeOfOps) -> usize {
+        // A weak reference to the data necessarily has another strong reference
+        // somewhere else where it can be measured or...it's been released and is zero.
+        0
+    }
+}
+
 /// If a mutex is stored directly as a member of a data type that is being measured,
 /// it is the unique owner of its contents and deserves to be measured.
 ///


### PR DESCRIPTION
This patch adds a weak reference to the parent box in `LayoutBoxBase`, so that boxes can refer to their parent. This will help during future changes for incremental layout.

Testing: Not needed, no behavior change
