### PR TITLE
devtools: Hide `extension-backgroundscript-status` warning

### DIFF
--- a/components/devtools/actors/root.rs
+++ b/components/devtools/actors/root.rs
@@ -265,14 +265,12 @@ impl Actor for RootActor {
 
             "watchResources" => {
                 // TODO: Respond to watch resource requests
-                let msg = EmptyReplyMsg { from: self.name() };
-                request.reply_final(&msg)?
+                request.reply_final(&EmptyReplyMsg { from: self.name() })?
             },
 
             "unwatchResources" => {
                 // TODO: Respond to unwatch resource requests
-                let msg = EmptyReplyMsg { from: self.name() };
-                request.reply_final(&msg)?
+                request.reply_final(&EmptyReplyMsg { from: self.name() })?
             },
 
             _ => return Err(ActorError::UnrecognizedPacketType),


### PR DESCRIPTION
A warning has been showing up every time the DevTools client was connected in Firefox Browser Console. Now not only the watcher can watch resources, the root actor can too. Firefox was complaining about [`extensions-backgroundscript-status`](https://searchfox.org/firefox-main/source/devtools/server/actors/resources/extensions-backgroundscript-status.js). We don't have extensions running in the background, but even if we set it to false, the warning persists. So instead this patch adds boilerplate to "handle" this watch request.

Testing: Manual testing
