### PR TITLE
devtools: Correctly cache console messages

### DIFF
--- a/components/devtools/actors/console.rs
+++ b/components/devtools/actors/console.rs
@@ -8,6 +8,7 @@
 
 use std::collections::HashMap;
 use std::net::TcpStream;
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::time::{SystemTime, UNIX_EPOCH};
 
 use atomic_refcell::AtomicRefCell;
@@ -16,11 +17,7 @@ use base::id::TEST_PIPELINE_ID;
 use devtools_traits::EvaluateJSReply::{
     ActorValue, BooleanValue, NullValue, NumberValue, StringValue, VoidValue,
 };
-use devtools_traits::{
-    CachedConsoleMessage, CachedConsoleMessageTypes, ConsoleClearMessage, ConsoleLog,
-    ConsoleMessage, DevtoolScriptControlMsg, PageError,
-};
-use log::debug;
+use devtools_traits::{ConsoleResource, DevtoolScriptControlMsg};
 use serde::Serialize;
 use serde_json::{self, Map, Number, Value};
 use uuid::Uuid;
@@ -33,42 +30,9 @@ use crate::protocol::{ClientRequest, JsonPacketStream};
 use crate::resource::{ResourceArrayType, ResourceAvailable};
 use crate::{EmptyReplyMsg, StreamId, UniqueId};
 
-trait EncodableConsoleMessage {
-    fn encode(&self) -> serde_json::Result<String>;
-}
-
-impl EncodableConsoleMessage for CachedConsoleMessage {
-    fn encode(&self) -> serde_json::Result<String> {
-        match *self {
-            CachedConsoleMessage::PageError(ref a) => serde_json::to_string(a),
-            CachedConsoleMessage::ConsoleLog(ref a) => serde_json::to_string(a),
-        }
-    }
-}
-
 #[derive(Serialize)]
-struct StartedListenersTraits;
-
-#[derive(Serialize)]
-#[serde(rename_all = "camelCase")]
-struct StartedListenersReply {
-    from: String,
-    native_console_api: bool,
-    started_listeners: Vec<String>,
-    traits: StartedListenersTraits,
-}
-
-#[derive(Serialize)]
-struct GetCachedMessagesReply {
-    from: String,
-    messages: Vec<Map<String, Value>>,
-}
-
-#[derive(Serialize)]
-#[serde(rename_all = "camelCase")]
-struct StopListenersReply {
-    from: String,
-    stopped_listeners: Vec<String>,
+pub struct ConsoleClearMessage {
+    pub level: String,
 }
 
 #[derive(Serialize)]
@@ -120,12 +84,6 @@ struct SetPreferencesReply {
     updated: Vec<String>,
 }
 
-#[derive(Serialize)]
-#[serde(rename_all = "camelCase")]
-struct PageErrorWrapper {
-    page_error: PageError,
-}
-
 pub(crate) enum Root {
     BrowsingContext(String),
     DedicatedWorker(String),
@@ -134,7 +92,8 @@ pub(crate) enum Root {
 pub(crate) struct ConsoleActor {
     pub name: String,
     pub root: Root,
-    pub cached_events: AtomicRefCell<HashMap<UniqueId, Vec<CachedConsoleMessage>>>,
+    pub cached_events: AtomicRefCell<HashMap<UniqueId, Vec<ConsoleResource>>>,
+    pub only_cache: AtomicBool,
 }
 
 impl ConsoleActor {
@@ -250,9 +209,9 @@ impl ConsoleActor {
         std::result::Result::Ok(reply)
     }
 
-    pub(crate) fn handle_page_error(
+    pub(crate) fn handle_console_resource(
         &self,
-        page_error: PageError,
+        resource: ConsoleResource,
         id: UniqueId,
         registry: &ActorRegistry,
         stream: &mut TcpStream,
@@ -261,37 +220,16 @@ impl ConsoleActor {
             .borrow_mut()
             .entry(id.clone())
             .or_default()
-            .push(CachedConsoleMessage::PageError(page_error.clone()));
-        if id == self.current_unique_id(registry) {
-            if let Root::BrowsingContext(bc) = &self.root {
-                registry.find::<BrowsingContextActor>(bc).resource_array(
-                    PageErrorWrapper { page_error },
-                    "error-message".into(),
-                    ResourceArrayType::Available,
-                    stream,
-                )
-            };
+            .push(resource.clone());
+        if self.only_cache.load(Ordering::Relaxed) {
+            return;
         }
-    }
-
-    pub(crate) fn handle_console_api(
-        &self,
-        console_message: ConsoleMessage,
-        id: UniqueId,
-        registry: &ActorRegistry,
-        stream: &mut TcpStream,
-    ) {
-        let log_message: ConsoleLog = console_message.into();
-        self.cached_events
-            .borrow_mut()
-            .entry(id.clone())
-            .or_default()
-            .push(CachedConsoleMessage::ConsoleLog(log_message.clone()));
+        let resource_type = resource.resource_type();
         if id == self.current_unique_id(registry) {
             if let Root::BrowsingContext(bc) = &self.root {
                 registry.find::<BrowsingContextActor>(bc).resource_array(
-                    log_message,
-                    "console-message".into(),
+                    resource,
+                    resource_type,
                     ResourceArrayType::Available,
                     stream,
                 )
@@ -318,6 +256,23 @@ impl ConsoleActor {
             };
         }
     }
+
+    pub(crate) fn get_cached_messages(
+        &self,
+        registry: &ActorRegistry,
+        resource: &str,
+    ) -> Vec<ConsoleResource> {
+        let id = self.current_unique_id(registry);
+        let cached_events = self.cached_events.borrow();
+        let Some(events) = cached_events.get(&id) else {
+            return vec![];
+        };
+        events
+            .iter()
+            .filter(|event| event.resource_type() == resource)
+            .cloned()
+            .collect()
+    }
 }
 
 impl Actor for ConsoleActor {
@@ -334,95 +289,11 @@ impl Actor for ConsoleActor {
         _id: StreamId,
     ) -> Result<(), ActorError> {
         match msg_type {
-            "clearMessagesCache" => {
+            "clearMessagesCacheAsync" => {
                 self.cached_events
                     .borrow_mut()
                     .remove(&self.current_unique_id(registry));
-                // FIXME: need to send a reply here!
-                return Err(ActorError::UnrecognizedPacketType);
-            },
-
-            "getCachedMessages" => {
-                let str_types = msg
-                    .get("messageTypes")
-                    .unwrap()
-                    .as_array()
-                    .unwrap()
-                    .iter()
-                    .map(|json_type| json_type.as_str().unwrap());
-                let mut message_types = CachedConsoleMessageTypes::empty();
-                for str_type in str_types {
-                    match str_type {
-                        "PageError" => message_types.insert(CachedConsoleMessageTypes::PAGE_ERROR),
-                        "ConsoleAPI" => {
-                            message_types.insert(CachedConsoleMessageTypes::CONSOLE_API)
-                        },
-                        s => debug!("unrecognized message type requested: \"{}\"", s),
-                    };
-                }
-                let mut messages = vec![];
-                for event in self
-                    .cached_events
-                    .borrow()
-                    .get(&self.current_unique_id(registry))
-                    .unwrap_or(&vec![])
-                    .iter()
-                {
-                    let include = match event {
-                        CachedConsoleMessage::PageError(_)
-                            if message_types.contains(CachedConsoleMessageTypes::PAGE_ERROR) =>
-                        {
-                            true
-                        },
-                        CachedConsoleMessage::ConsoleLog(_)
-                            if message_types.contains(CachedConsoleMessageTypes::CONSOLE_API) =>
-                        {
-                            true
-                        },
-                        _ => false,
-                    };
-                    if include {
-                        let json_string = event.encode().unwrap();
-                        let json = serde_json::from_str::<Value>(&json_string).unwrap();
-                        messages.push(json.as_object().unwrap().to_owned())
-                    }
-                }
-
-                let msg = GetCachedMessagesReply {
-                    from: self.name(),
-                    messages,
-                };
-                request.reply_final(&msg)?
-            },
-
-            "startListeners" => {
-                // TODO: actually implement listener filters that support starting/stopping
-                let listeners = msg.get("listeners").unwrap().as_array().unwrap().to_owned();
-                let msg = StartedListenersReply {
-                    from: self.name(),
-                    native_console_api: true,
-                    started_listeners: listeners
-                        .into_iter()
-                        .map(|s| s.as_str().unwrap().to_owned())
-                        .collect(),
-                    traits: StartedListenersTraits,
-                };
-                request.reply_final(&msg)?
-            },
-
-            "stopListeners" => {
-                // TODO: actually implement listener filters that support starting/stopping
-                let msg = StopListenersReply {
-                    from: self.name(),
-                    stopped_listeners: msg
-                        .get("listeners")
-                        .unwrap()
-                        .as_array()
-                        .unwrap_or(&vec![])
-                        .iter()
-                        .map(|listener| listener.as_str().unwrap().to_owned())
-                        .collect(),
-                };
+                let msg = EmptyReplyMsg { from: self.name() };
                 request.reply_final(&msg)?
             },
 
@@ -482,14 +353,9 @@ impl Actor for ConsoleActor {
                 request.reply_final(&msg)?
             },
 
-            "clearMessagesCacheAsync" => {
-                self.cached_events
-                    .borrow_mut()
-                    .remove(&self.current_unique_id(registry));
-                let msg = EmptyReplyMsg { from: self.name() };
-                request.reply_final(&msg)?
-            },
-
+            // NOTE: Do not handle `startListeners`, it is a legacy API.
+            // Instead, enable the resource in `WatcherActor::supported_resources`
+            // and handle the messages there.
             _ => return Err(ActorError::UnrecognizedPacketType),
         };
         Ok(())

--- a/components/devtools/actors/watcher.rs
+++ b/components/devtools/actors/watcher.rs
@@ -12,6 +12,7 @@
 
 use std::collections::HashMap;
 use std::net::TcpStream;
+use std::sync::atomic::Ordering;
 use std::time::{SystemTime, UNIX_EPOCH};
 
 use base::id::BrowsingContextId;
@@ -26,6 +27,7 @@ use super::thread::ThreadActor;
 use super::worker::WorkerActorMsg;
 use crate::actor::{Actor, ActorEncode, ActorError, ActorRegistry};
 use crate::actors::browsing_context::{BrowsingContextActor, BrowsingContextActorMsg};
+use crate::actors::console::ConsoleActor;
 use crate::actors::root::RootActor;
 use crate::actors::watcher::target_configuration::{
     TargetConfigurationActor, TargetConfigurationActorMsg,
@@ -70,7 +72,7 @@ impl SessionContext {
                 ("css-change", true),
                 ("css-message", false),
                 ("css-registered-properties", false),
-                ("document-event", false),
+                ("document-event", true),
                 ("Cache", false),
                 ("cookies", false),
                 ("error-message", true),
@@ -78,7 +80,7 @@ impl SessionContext {
                 ("indexed-db", false),
                 ("local-storage", false),
                 ("session-storage", false),
-                ("platform-message", false),
+                ("platform-message", true),
                 ("network-event", true),
                 ("network-event-stacktrace", false),
                 ("reflow", true),
@@ -289,7 +291,7 @@ impl Actor for WatcherActor {
                             //       Figure out if there needs work to be done here, ensure the page is loaded
                             for &name in ["dom-loading", "dom-interactive", "dom-complete"].iter() {
                                 let event = DocumentEvent {
-                                    has_native_console_api: Some(true),
+                                    has_native_console_api: None,
                                     name: name.into(),
                                     new_uri: None,
                                     time: SystemTime::now()
@@ -302,7 +304,7 @@ impl Actor for WatcherActor {
                                 };
                                 target.resource_array(
                                     event,
-                                    "document-event".into(),
+                                    resource.into(),
                                     ResourceArrayType::Available,
                                     &mut request,
                                 );
@@ -312,7 +314,7 @@ impl Actor for WatcherActor {
                             let thread_actor = registry.find::<ThreadActor>(&target.thread);
                             target.resources_array(
                                 thread_actor.source_manager.source_forms(registry),
-                                "source".into(),
+                                resource.into(),
                                 ResourceArrayType::Available,
                                 &mut request,
                             );
@@ -323,13 +325,34 @@ impl Actor for WatcherActor {
 
                                 worker.resources_array(
                                     thread.source_manager.source_forms(registry),
-                                    "source".into(),
+                                    resource.into(),
                                     ResourceArrayType::Available,
                                     &mut request,
                                 );
                             }
                         },
-                        "console-message" | "error-message" => {},
+                        "console-message" | "error-message" => {
+                            let console = registry.find::<ConsoleActor>(&target.console);
+                            console.only_cache.store(false, Ordering::Relaxed);
+                            target.resources_array(
+                                console.get_cached_messages(registry, resource),
+                                resource.into(),
+                                ResourceArrayType::Available,
+                                &mut request,
+                            );
+
+                            for worker_name in &*root.workers.borrow() {
+                                let worker = registry.find::<WorkerActor>(worker_name);
+                                let console = registry.find::<ConsoleActor>(&worker.console);
+
+                                worker.resources_array(
+                                    console.get_cached_messages(registry, resource),
+                                    resource.into(),
+                                    ResourceArrayType::Available,
+                                    &mut request,
+                                );
+                            }
+                        },
                         "network-event" => {},
                         _ => warn!("resource {} not handled yet", resource),
                     }

--- a/components/devtools/actors/watcher.rs
+++ b/components/devtools/actors/watcher.rs
@@ -333,7 +333,7 @@ impl Actor for WatcherActor {
                         },
                         "console-message" | "error-message" => {
                             let console = registry.find::<ConsoleActor>(&target.console);
-                            console.only_cache.store(false, Ordering::Relaxed);
+                            console.should_send_messages.store(true, Ordering::Relaxed);
                             target.resources_array(
                                 console.get_cached_messages(registry, resource),
                                 resource.into(),

--- a/components/devtools/actors/watcher.rs
+++ b/components/devtools/actors/watcher.rs
@@ -12,7 +12,6 @@
 
 use std::collections::HashMap;
 use std::net::TcpStream;
-use std::sync::atomic::Ordering;
 use std::time::{SystemTime, UNIX_EPOCH};
 
 use base::id::BrowsingContextId;
@@ -333,7 +332,7 @@ impl Actor for WatcherActor {
                         },
                         "console-message" | "error-message" => {
                             let console = registry.find::<ConsoleActor>(&target.console);
-                            console.should_send_messages.store(true, Ordering::Relaxed);
+                            console.received_first_message_from_client();
                             target.resources_array(
                                 console.get_cached_messages(registry, resource),
                                 resource.into(),

--- a/components/devtools/lib.rs
+++ b/components/devtools/lib.rs
@@ -407,9 +407,9 @@ impl DevtoolsInstance {
 
         let console = ConsoleActor {
             name: console_name,
-            cached_events: Default::default(),
             root: parent_actor,
-            only_cache: true.into(),
+            cached_events: Default::default(),
+            should_send_messages: false.into(),
         };
 
         actors.register(console);

--- a/components/devtools/lib.rs
+++ b/components/devtools/lib.rs
@@ -22,9 +22,9 @@ use base::generic_channel::{self, GenericSender};
 use base::id::{BrowsingContextId, PipelineId, WebViewId};
 use crossbeam_channel::{Receiver, Sender, unbounded};
 use devtools_traits::{
-    ChromeToDevtoolsControlMsg, ConsoleLogLevel, ConsoleMessage, ConsoleMessageBuilder,
+    ChromeToDevtoolsControlMsg, ConsoleLogLevel, ConsoleMessageBuilder, ConsoleResource,
     DevtoolScriptControlMsg, DevtoolsControlMsg, DevtoolsPageInfo, NavigationState, NetworkEvent,
-    PageError, ScriptToDevtoolsControlMsg, SourceInfo, WorkerId,
+    ScriptToDevtoolsControlMsg, SourceInfo, WorkerId,
 };
 use embedder_traits::{AllowOrDeny, EmbedderMsg, EmbedderProxy};
 use log::{trace, warn};
@@ -237,7 +237,11 @@ impl DevtoolsInstance {
                     pipeline_id,
                     console_message,
                     worker_id,
-                )) => self.handle_console_message(pipeline_id, worker_id, console_message),
+                )) => self.handle_console_resource(
+                    pipeline_id,
+                    worker_id,
+                    ConsoleResource::ConsoleMessage(console_message),
+                ),
                 DevtoolsControlMsg::FromScript(ScriptToDevtoolsControlMsg::ClearConsole(
                     pipeline_id,
                     worker_id,
@@ -253,7 +257,11 @@ impl DevtoolsInstance {
                 DevtoolsControlMsg::FromScript(ScriptToDevtoolsControlMsg::ReportPageError(
                     pipeline_id,
                     page_error,
-                )) => self.handle_page_error(pipeline_id, None, page_error),
+                )) => self.handle_console_resource(
+                    pipeline_id,
+                    None,
+                    ConsoleResource::PageError(page_error.into()),
+                ),
                 DevtoolsControlMsg::FromScript(ScriptToDevtoolsControlMsg::ReportCSSError(
                     pipeline_id,
                     css_error,
@@ -266,7 +274,11 @@ impl DevtoolsInstance {
                     );
                     console_message.add_argument(css_error.msg.into());
 
-                    self.handle_console_message(pipeline_id, None, console_message.finish())
+                    self.handle_console_resource(
+                        pipeline_id,
+                        None,
+                        ConsoleResource::ConsoleMessage(console_message.finish()),
+                    )
                 },
                 DevtoolsControlMsg::FromChrome(ChromeToDevtoolsControlMsg::NetworkEvent(
                     request_id,
@@ -397,6 +409,7 @@ impl DevtoolsInstance {
             name: console_name,
             cached_events: Default::default(),
             root: parent_actor,
+            only_cache: true.into(),
         };
 
         actors.register(console);
@@ -416,11 +429,11 @@ impl DevtoolsInstance {
         browsing_context.title_changed(pipeline_id, title);
     }
 
-    fn handle_page_error(
+    fn handle_console_resource(
         &mut self,
         pipeline_id: PipelineId,
         worker_id: Option<WorkerId>,
-        page_error: PageError,
+        resource: ConsoleResource,
     ) {
         let console_actor_name = match self.find_console_actor(pipeline_id, worker_id) {
             Some(name) => name,
@@ -430,25 +443,7 @@ impl DevtoolsInstance {
         let console_actor = actors.find::<ConsoleActor>(&console_actor_name);
         let id = worker_id.map_or(UniqueId::Pipeline(pipeline_id), UniqueId::Worker);
         for stream in self.connections.values_mut() {
-            console_actor.handle_page_error(page_error.clone(), id.clone(), actors, stream);
-        }
-    }
-
-    fn handle_console_message(
-        &mut self,
-        pipeline_id: PipelineId,
-        worker_id: Option<WorkerId>,
-        console_message: ConsoleMessage,
-    ) {
-        let console_actor_name = match self.find_console_actor(pipeline_id, worker_id) {
-            Some(name) => name,
-            None => return,
-        };
-        let actors = &self.registry;
-        let console_actor = actors.find::<ConsoleActor>(&console_actor_name);
-        let id = worker_id.map_or(UniqueId::Pipeline(pipeline_id), UniqueId::Worker);
-        for stream in self.connections.values_mut() {
-            console_actor.handle_console_api(console_message.clone(), id.clone(), actors, stream);
+            console_actor.handle_console_resource(resource.clone(), id.clone(), actors, stream);
         }
     }
 

--- a/components/devtools/lib.rs
+++ b/components/devtools/lib.rs
@@ -409,7 +409,7 @@ impl DevtoolsInstance {
             name: console_name,
             root: parent_actor,
             cached_events: Default::default(),
-            should_send_messages: false.into(),
+            client_ready_to_receive_messages: false.into(),
         };
 
         actors.register(console);

--- a/components/devtools/resource.rs
+++ b/components/devtools/resource.rs
@@ -39,6 +39,10 @@ pub(crate) trait ResourceAvailable {
         array_type: ResourceArrayType,
         stream: &mut S,
     ) {
+        if resources.is_empty() {
+            return;
+        }
+
         let msg = ResourceAvailableReply::<T> {
             from: self.actor_name(),
             type_: match array_type {

--- a/components/script/dom/globalscope.rs
+++ b/components/script/dom/globalscope.rs
@@ -2499,32 +2499,6 @@ impl GlobalScope {
         self.devtools_chan.as_ref()
     }
 
-    pub(crate) fn issue_page_warning(&self, warning: &str) {
-        if let Some(ref chan) = self.devtools_chan {
-            let _ = chan.send(ScriptToDevtoolsControlMsg::ReportPageError(
-                self.pipeline_id,
-                PageError {
-                    type_: "PageError".to_string(),
-                    error_message: warning.to_string(),
-                    source_name: self.get_url().to_string(),
-                    line_text: "".to_string(),
-                    line_number: 0,
-                    column_number: 0,
-                    category: "script".to_string(),
-                    time_stamp: SystemTime::now()
-                        .duration_since(UNIX_EPOCH)
-                        .unwrap_or_default()
-                        .as_millis() as u64,
-                    error: false,
-                    warning: true,
-                    exception: true,
-                    strict: false,
-                    private: false,
-                },
-            ));
-        }
-    }
-
     /// Get a sender to the memory profiler thread.
     pub(crate) fn mem_profiler_chan(&self) -> &profile_mem::ProfilerChan {
         &self.mem_profiler_chan
@@ -2852,10 +2826,8 @@ impl GlobalScope {
                     let _ = chan.send(ScriptToDevtoolsControlMsg::ReportPageError(
                         self.pipeline_id,
                         PageError {
-                            type_: "PageError".to_string(),
                             error_message: error_info.message.clone(),
                             source_name: error_info.filename.clone(),
-                            line_text: "".to_string(), // TODO
                             line_number: error_info.lineno,
                             column_number: error_info.column,
                             category: "script".to_string(),
@@ -2865,9 +2837,9 @@ impl GlobalScope {
                                 .as_millis() as u64,
                             error: true,
                             warning: false,
-                            exception: true,
-                            strict: false,
+                            info: false,
                             private: false,
+                            stacktrace: None,
                         },
                     ));
                 }

--- a/components/shared/devtools/lib.rs
+++ b/components/shared/devtools/lib.rs
@@ -336,7 +336,7 @@ pub struct StackFrame {
     pub column_number: u32,
     pub line_number: u32,
     // Not implemented in Servo
-    // source_id: String,
+    // source_id
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -359,8 +359,8 @@ pub struct ConsoleMessage {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub stacktrace: Option<Vec<StackFrame>>,
     // Not implemented in Servo
-    // inner_window_id: u32,
-    // source_id: String,
+    // inner_window_id
+    // source_id
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -379,10 +379,10 @@ pub struct PageError {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub stacktrace: Option<Vec<StackFrame>>,
     // Not implemented in Servo
-    // inner_window_id: u32,
-    // source_id: String,
-    // has_exception: bool,
-    // exception: Option<{...}>,
+    // inner_window_id
+    // source_id
+    // has_exception
+    // exception
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize)]

--- a/components/shared/embedder/lib.rs
+++ b/components/shared/embedder/lib.rs
@@ -386,6 +386,7 @@ impl Image {
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(rename_all = "lowercase")]
 pub enum ConsoleLogLevel {
     Log,
     Debug,


### PR DESCRIPTION
Fix caching before the console is opened and stop sending messages prematurely.

Fix line numbers not showing in console messages because of a missing `rename_all`.

Remove `getCachedMessages` in favour of sending a list of messages as a reply to the `watchResources` for `console-message`/`error-message` in the watcher.

Remove `startListeners` and `stopListeners`. These are legacy methods of watching properties before the watcher actor. It is preferred to enable properties in `supported_resources` in the watcher than to use these messages.

Remove `clearMessagesCache`, only `clearMessagesCacheAsync` seems to be used now. Add a reply to `clearMessagesCacheAsync`.

Simplify a bit the structs for console messages and prefer serde's annotations to manual serialization. Merge `handle_console_message` and `handle_page_error`, and improve the usability of `ConsoleResource`.

Fix some fields in console messages. We are missing `source_id` for now. This will be easier to add after better support for source actors.  We are also missing stack traces.

| Before | After |
| --- | --- |
| ![Console message list starting at 5 and counting up, showing the file location but not the line number](https://github.com/user-attachments/assets/b21159b4-1a95-46aa-9337-0004a922837c) | ![Console message list starting at 1, showing both the file location and line number. It says "Connected here" at message number 4](https://github.com/user-attachments/assets/f8ea1a7c-9262-4fa2-a882-cad35af9c2dc) |

Testing: Manual testing
Fixes: #26666