### PR TITLE
script: Add error messages in `ed25519_operation.rs`

### DIFF
--- a/components/script/dom/subtlecrypto/ed25519_operation.rs
+++ b/components/script/dom/subtlecrypto/ed25519_operation.rs
@@ -537,7 +537,7 @@ pub(crate) fn export_key(format: KeyFormat, key: &CryptoKey) -> Result<ExportedK
                 .to_pkcs8v1()
                 .map_err(|_| {
                     Error::Operation(Some(
-                        "Failed to serialize the key into a PKCS format".into(),
+                        "Failed to serialize the key into a PKCS#8 format".into(),
                     ))
                 })?;
 


### PR DESCRIPTION
Add all the missing error messages in `ed25519_operation.rs`. Followed the other implementations of `importKey`, `exportKey` and others to try and follow the same style. Related to #40756.

Testing: No tests added, did some manual tests
