### PR TITLE
CI: use git log to obtain latest commit SHA

### DIFF
--- a/etc/ci/report_aggregated_expected_results.py
+++ b/etc/ci/report_aggregated_expected_results.py
@@ -190,7 +190,7 @@ def get_pr_number() -> Optional[str]:
 
 
 def get_commit_sha() -> str:
-    return subprocess.check_output(["git", "rev-parse", "HEAD"]).decode("utf-8").strip()
+    return subprocess.check_output(["git", "log", "-1", "--format=%H"]).decode("utf-8").strip()
 
 
 def create_github_reports(body: str, tag: str = ""):


### PR DESCRIPTION
`git rev-parse HEAD` returns wrong value for some reason, so let's use `git log -1 --format=%H` that is also used by checkout action.

Testing: Try label run reports proper commit: https://github.com/servo/servo/actions/runs/20983860831/job/60315834713#step:9:1567
Fixes: #41489 
