### PR TITLE
script: Add support for setting the edit point with the mouse in `<input>` and `<textarea>`

### DIFF
--- a/components/layout/flow/inline/line.rs
+++ b/components/layout/flow/inline/line.rs
@@ -577,6 +577,7 @@ impl LineItemLayout<'_, '_> {
                 font_metrics: text_item.font_metrics,
                 font_key: text_item.font_key,
                 glyphs: text_item.text,
+                starting_glyph_offset: text_item.starting_glyph_offset,
                 justification_adjustment: self.justification_adjustment,
                 selection_range: text_item.selection_range,
             })),
@@ -790,6 +791,9 @@ pub(super) struct TextRunLineItem {
     pub inline_styles: SharedInlineStyles,
     pub text: Vec<std::sync::Arc<GlyphStore>>,
     pub font_metrics: Arc<FontMetrics>,
+    /// The glyph offset of the starting glyph of this [`TextFragment`] within
+    /// its parent inline box.
+    pub starting_glyph_offset: usize,
     pub font_key: FontInstanceKey,
     /// The BiDi level of this [`TextRunLineItem`] to enable reordering.
     pub bidi_level: Level,

--- a/components/layout/flow/inline/mod.rs
+++ b/components/layout/flow/inline/mod.rs
@@ -74,7 +74,7 @@ pub mod line;
 mod line_breaker;
 pub mod text_run;
 
-use std::cell::{OnceCell, RefCell};
+use std::cell::{Cell, OnceCell, RefCell};
 use std::mem;
 use std::rc::Rc;
 use std::sync::Arc;
@@ -707,6 +707,9 @@ pub(super) struct InlineContainerState {
 
     /// The font metrics of the non-fallback font for this container.
     font_metrics: Arc<FontMetrics>,
+
+    /// The current count of glyphs added to the inline container.
+    number_of_glyphs: Cell<usize>,
 }
 
 pub(super) struct InlineFormattingContextLayout<'layout_data> {
@@ -1453,6 +1456,7 @@ impl InlineFormattingContextLayout<'_> {
         font: &FontRef,
         bidi_level: Level,
         range: TextByteRange,
+        starting_glyph_offset: usize,
     ) {
         let inline_advance = glyph_store.total_advance();
         let flags = if glyph_store.is_whitespace() {
@@ -1539,6 +1543,7 @@ impl InlineFormattingContextLayout<'_> {
             current_inline_box_identifier,
             TextRunLineItem {
                 text: vec![glyph_store],
+                starting_glyph_offset,
                 base_fragment_info: text_run.base_fragment_info,
                 inline_styles: text_run.inline_styles.clone(),
                 font_metrics: font_metrics.clone(),
@@ -2048,6 +2053,7 @@ impl InlineContainerState {
             strut_block_sizes,
             baseline_offset,
             font_metrics,
+            number_of_glyphs: Default::default(),
         }
     }
 

--- a/components/script/dom/mouseevent.rs
+++ b/components/script/dom/mouseevent.rs
@@ -249,8 +249,8 @@ impl MouseEvent {
         self.uievent.set_which(w);
     }
 
-    pub(crate) fn point_in_target(&self) -> Option<Point2D<f32, CSSPixel>> {
-        self.point_in_target.get()
+    pub(crate) fn point_in_viewport(&self) -> Option<Point2D<f32, CSSPixel>> {
+        Some(self.client_point.get().to_f32())
     }
 
     /// Create a [MouseEvent] triggered by the embedder

--- a/components/servo/tests/webview.rs
+++ b/components/servo/tests/webview.rs
@@ -612,7 +612,7 @@ fn test_show_and_hide_ime() {
         .build();
 
     show_webview_and_wait_for_rendering_to_be_ready(&servo_test, &webview, &delegate);
-    click_at_point(&webview, Point2D::new(50., 50.));
+    click_at_point(&webview, Point2D::new(100., 100.));
 
     // The form control should be shown.
     let captured_delegate = delegate.clone();
@@ -627,7 +627,7 @@ fn test_show_and_hide_ime() {
 
         assert_eq!(ime.input_method_type(), InputMethodType::Text);
         assert_eq!(ime.text(), "servo");
-        assert_eq!(ime.insertion_point(), Some(0));
+        assert_eq!(ime.insertion_point(), Some(5));
     }
 
     click_at_point(&webview, Point2D::new(300., 300.));

--- a/components/shared/layout/lib.rs
+++ b/components/shared/layout/lib.rs
@@ -27,7 +27,7 @@ use bitflags::bitflags;
 use compositing_traits::CrossProcessPaintApi;
 use embedder_traits::{Cursor, Theme, UntrustedNodeAddress, ViewportDetails};
 use euclid::Point2D;
-use euclid::default::{Point2D as UntypedPoint2D, Rect};
+use euclid::default::Rect;
 use fonts::{FontContext, WebFontDocumentContext};
 pub use layout_damage::LayoutDamage;
 use libc::c_void;
@@ -348,7 +348,11 @@ pub trait Layout {
         animation_timeline_value: f64,
     ) -> Option<ServoArc<Font>>;
     fn query_scrolling_area(&self, node: Option<TrustedNodeAddress>) -> Rect<i32>;
-    fn query_text_indext(&self, node: OpaqueNode, point: UntypedPoint2D<f32>) -> Option<usize>;
+    fn query_text_index(
+        &self,
+        node: TrustedNodeAddress,
+        point: Point2D<Au, CSSPixel>,
+    ) -> Option<usize>;
     fn query_elements_from_point(
         &self,
         point: LayoutPoint,

--- a/tests/wpt/mozilla/meta/MANIFEST.json
+++ b/tests/wpt/mozilla/meta/MANIFEST.json
@@ -12954,6 +12954,24 @@
        "testdriver": true
       }
      ]
+    ],
+    "mousedown-edit-point-input-text.html": [
+     "24e1852fd98d80807852bf9c45dae1c5063b064a",
+     [
+      null,
+      {
+       "testdriver": true
+      }
+     ]
+    ],
+    "mousedown-edit-point-textarea.html": [
+     "54b6e42625373e1a71e6a62f8bc40c12909bed52",
+     [
+      null,
+      {
+       "testdriver": true
+      }
+     ]
     ]
    },
    "mozilla": {

--- a/tests/wpt/mozilla/tests/input-events/mousedown-edit-point-input-text.html
+++ b/tests/wpt/mozilla/tests/input-events/mousedown-edit-point-input-text.html
@@ -1,0 +1,61 @@
+<!DOCTYPE html>
+<title>Clicking in &lt;input type=text&gt; should move the edit point</title>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/resources/testdriver.js"></script>
+<script src="/resources/testdriver-actions.js"></script>
+<script src="/resources/testdriver-vendor.js"></script>
+<link rel="stylesheet" type="text/css" href="/fonts/ahem.css" />
+
+<input id="target" style="font: 50px/1 Ahem;" value="123456">
+
+<script>
+promise_test(async test => {
+    let targetRect = target.getBoundingClientRect();
+    let middleOfBlock = targetRect.top + (targetRect.height / 2);
+
+    await new test_driver.Actions()
+      .pointerMove(targetRect.left + 1, middleOfBlock)
+      .pointerDown().pointerUp()
+          .send();
+    assert_equals(target.selectionStart, 0);
+    assert_equals(target.selectionEnd, 0);
+
+    await new test_driver.Actions()
+      .pointerMove(targetRect.left + 50, middleOfBlock)
+      .pointerDown().pointerUp()
+          .send();
+    assert_equals(target.selectionStart, 1);
+    assert_equals(target.selectionEnd, 1);
+
+    target.setSelectionRange(0, 0);
+
+    // Click on the right half of a character should move the cursor to the next index.
+    await new test_driver.Actions()
+      .pointerMove(targetRect.left + 40, middleOfBlock)
+      .pointerDown().pointerUp()
+          .send();
+    assert_equals(target.selectionStart, 1);
+    assert_equals(target.selectionEnd, 1);
+
+    target.setSelectionRange(0, 0);
+
+    // Click on the right half of a character should move the cursor to the next index.
+    await new test_driver.Actions()
+      .pointerMove(targetRect.left + (50 * 5), middleOfBlock)
+      .pointerDown().pointerUp()
+          .send();
+    assert_equals(target.selectionStart, 5);
+    assert_equals(target.selectionEnd, 5);
+
+    target.setSelectionRange(0, 0);
+
+    // Clicking past the end of the text should move the edit point to the end.
+    await new test_driver.Actions()
+      .pointerMove(targetRect.left + (50 * 7), middleOfBlock)
+      .pointerDown().pointerUp()
+          .send();
+    assert_equals(target.selectionStart, 6);
+    assert_equals(target.selectionEnd, 6);
+}, 'Mouse events move the edit point in <input type=text>');
+</script>

--- a/tests/wpt/mozilla/tests/input-events/mousedown-edit-point-textarea.html
+++ b/tests/wpt/mozilla/tests/input-events/mousedown-edit-point-textarea.html
@@ -1,0 +1,113 @@
+<!DOCTYPE html>
+<title>Clicking in &lt;textarea&gt; should move the edit point</title>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/resources/testdriver.js"></script>
+<script src="/resources/testdriver-actions.js"></script>
+<script src="/resources/testdriver-vendor.js"></script>
+<link rel="stylesheet" type="text/css" href="/fonts/ahem.css" />
+
+<textarea id="target" style="color: rgba(255, 0, 0, 0.2); height: 1000px; font: 50px/1 Ahem;">
+12345
+12345
+12345
+12345
+</textarea>
+
+<script>
+promise_test(async test => {
+    let targetRect = target.getBoundingClientRect();
+
+    let middleOfFirstLine = (50 / 2) + targetRect.top;
+    await new test_driver.Actions()
+      .pointerMove(targetRect.left + 10, middleOfFirstLine)
+      .pointerDown().pointerUp()
+          .send();
+    assert_equals(target.selectionStart, 0);
+    assert_equals(target.selectionEnd, 0);
+
+    await new test_driver.Actions()
+      .pointerMove(targetRect.left + 50, middleOfFirstLine)
+      .pointerDown().pointerUp()
+          .send();
+    assert_equals(target.selectionStart, 1);
+    assert_equals(target.selectionEnd, 1);
+
+    target.setSelectionRange(0, 0);
+
+    // Click on the right half of a character should move the cursor to the next index.
+    await new test_driver.Actions()
+      .pointerMove(targetRect.left + 40, middleOfFirstLine)
+      .pointerDown().pointerUp()
+          .send();
+    assert_equals(target.selectionStart, 1);
+    assert_equals(target.selectionEnd, 1);
+
+    target.setSelectionRange(0, 0);
+
+    // Click on the right half of a character should move the cursor to the next index.
+    await new test_driver.Actions()
+      .pointerMove(targetRect.left + (50 * 5), middleOfFirstLine)
+      .pointerDown().pointerUp()
+          .send();
+    assert_equals(target.selectionStart, 5);
+    assert_equals(target.selectionEnd, 5);
+
+    target.setSelectionRange(0, 0);
+
+    // Clicking past the end of the text should move the edit point to the end.
+    await new test_driver.Actions()
+      .pointerMove(targetRect.left + (50 * 7), middleOfFirstLine)
+      .pointerDown().pointerUp()
+          .send();
+    assert_equals(target.selectionStart, 24);
+    assert_equals(target.selectionEnd, 24);
+
+    target.setSelectionRange(0, 0);
+
+    let middleOfThirdLine = (50 * 2) + 25 + targetRect.top;
+    await new test_driver.Actions()
+      .pointerMove(targetRect.left + 10, middleOfThirdLine)
+      .pointerDown().pointerUp()
+          .send();
+    assert_equals(target.selectionStart, 12);
+    assert_equals(target.selectionEnd, 12);
+
+    await new test_driver.Actions()
+      .pointerMove(targetRect.left + 50, middleOfThirdLine)
+      .pointerDown().pointerUp()
+          .send();
+    assert_equals(target.selectionStart, 13);
+    assert_equals(target.selectionEnd, 13);
+
+    target.setSelectionRange(0, 0);
+
+    // Click on the right half of a character should move the cursor to the next index.
+    await new test_driver.Actions()
+      .pointerMove(targetRect.left + 40, middleOfThirdLine)
+      .pointerDown().pointerUp()
+          .send();
+    assert_equals(target.selectionStart, 13);
+    assert_equals(target.selectionEnd, 13);
+
+    target.setSelectionRange(0, 0);
+
+    // Click on the right half of a character should move the cursor to the next index.
+    await new test_driver.Actions()
+      .pointerMove(targetRect.left + (50 * 5), middleOfThirdLine)
+      .pointerDown().pointerUp()
+          .send();
+    assert_equals(target.selectionStart, 17);
+    assert_equals(target.selectionEnd, 17);
+
+    target.setSelectionRange(0, 0);
+
+    // Clicking past the end of the text should move the edit point to the end.
+    await new test_driver.Actions()
+      .pointerMove(targetRect.left + (50 * 7), middleOfThirdLine)
+      .pointerDown().pointerUp()
+          .send();
+    assert_equals(target.selectionStart, 24);
+    assert_equals(target.selectionEnd, 24);
+}, 'Mouse events move the edit point in <textarea>');
+</script>


### PR DESCRIPTION
This change updates and implements the old `query_text_index` layout
query to properly look for the glyph index of a point within a node's
`Fragment`s. This should work properly with the shadow DOM of both
`<input>` and `<textarea>` elements. In particular, multiple lines are
supported.

Caveats:
 - `<input>` and `<textarea>` that are transformed are currently not
   supported. This will happen in a followup.
 - For multi-line inputs, we should be finding the text offset of the
   nearest line that is within the block range of the click. This will
   happen in a followup.

Testing: This change adds two Servo-specific WPT-style tests. These are
Servo-specific because the behavior of clicking in text fields isn't
fully specified.

Fixes: #35432
Fixes: #10083