### PR TITLE
script: Move AES-GCM to individual submodule

### DIFF
--- a/components/script/dom/subtlecrypto.rs
+++ b/components/script/dom/subtlecrypto.rs
@@ -5,6 +5,7 @@
 mod aes_cbc_operation;
 mod aes_common;
 mod aes_ctr_operation;
+mod aes_gcm_operation;
 mod aes_ocb_operation;
 mod aes_operation;
 mod argon2_operation;
@@ -4035,7 +4036,7 @@ impl NormalizedAlgorithm {
                 aes_cbc_operation::encrypt(algo, key, plaintext)
             },
             (ALG_AES_GCM, NormalizedAlgorithm::AesGcmParams(algo)) => {
-                aes_operation::encrypt_aes_gcm(algo, key, plaintext)
+                aes_gcm_operation::encrypt(algo, key, plaintext)
             },
             (ALG_AES_OCB, NormalizedAlgorithm::AeadParams(algo)) => {
                 aes_ocb_operation::encrypt(algo, key, plaintext)
@@ -4059,7 +4060,7 @@ impl NormalizedAlgorithm {
                 aes_cbc_operation::decrypt(algo, key, ciphertext)
             },
             (ALG_AES_GCM, NormalizedAlgorithm::AesGcmParams(algo)) => {
-                aes_operation::decrypt_aes_gcm(algo, key, ciphertext)
+                aes_gcm_operation::decrypt(algo, key, ciphertext)
             },
             (ALG_AES_OCB, NormalizedAlgorithm::AeadParams(algo)) => {
                 aes_ocb_operation::decrypt(algo, key, ciphertext)
@@ -4197,7 +4198,7 @@ impl NormalizedAlgorithm {
                     .map(CryptoKeyOrCryptoKeyPair::CryptoKey)
             },
             (ALG_AES_GCM, NormalizedAlgorithm::AesKeyGenParams(algo)) => {
-                aes_operation::generate_key_aes_gcm(global, algo, extractable, usages, can_gc)
+                aes_gcm_operation::generate_key(global, algo, extractable, usages, can_gc)
                     .map(CryptoKeyOrCryptoKeyPair::CryptoKey)
             },
             (ALG_AES_KW, NormalizedAlgorithm::AesKeyGenParams(algo)) => {
@@ -4333,14 +4334,7 @@ impl NormalizedAlgorithm {
                 aes_cbc_operation::import_key(global, format, key_data, extractable, usages, can_gc)
             },
             (ALG_AES_GCM, NormalizedAlgorithm::Algorithm(_algo)) => {
-                aes_operation::import_key_aes_gcm(
-                    global,
-                    format,
-                    key_data,
-                    extractable,
-                    usages,
-                    can_gc,
-                )
+                aes_gcm_operation::import_key(global, format, key_data, extractable, usages, can_gc)
             },
             (ALG_AES_KW, NormalizedAlgorithm::Algorithm(_algo)) => {
                 aes_operation::import_key_aes_kw(
@@ -4462,7 +4456,7 @@ impl NormalizedAlgorithm {
                 aes_cbc_operation::get_key_length(algo)
             },
             (ALG_AES_GCM, NormalizedAlgorithm::AesDerivedKeyParams(algo)) => {
-                aes_operation::get_key_length_aes_gcm(algo)
+                aes_gcm_operation::get_key_length(algo)
             },
             (ALG_AES_KW, NormalizedAlgorithm::AesDerivedKeyParams(algo)) => {
                 aes_operation::get_key_length_aes_kw(algo)
@@ -4531,7 +4525,7 @@ fn perform_export_key_operation(format: KeyFormat, key: &CryptoKey) -> Result<Ex
         ALG_X25519 => x25519_operation::export_key(format, key),
         ALG_AES_CTR => aes_ctr_operation::export_key(format, key),
         ALG_AES_CBC => aes_cbc_operation::export_key(format, key),
-        ALG_AES_GCM => aes_operation::export_key_aes_gcm(format, key),
+        ALG_AES_GCM => aes_gcm_operation::export_key(format, key),
         ALG_AES_KW => aes_operation::export_key_aes_kw(format, key),
         ALG_HMAC => hmac_operation::export_key(format, key),
         ALG_ML_KEM_512 | ALG_ML_KEM_768 | ALG_ML_KEM_1024 => {

--- a/components/script/dom/subtlecrypto/aes_gcm_operation.rs
+++ b/components/script/dom/subtlecrypto/aes_gcm_operation.rs
@@ -1,0 +1,594 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+use aes::cipher::crypto_common::Key;
+use aes::cipher::typenum::{U12, U13, U14, U15, U16, U32};
+use aes::{Aes128, Aes192, Aes256};
+use aes_gcm::aead::AeadMutInPlace;
+use aes_gcm::{AesGcm, KeyInit};
+use cipher::{ArrayLength, BlockCipher, BlockEncrypt, BlockSizeUser};
+
+use crate::dom::bindings::codegen::Bindings::CryptoKeyBinding::{KeyType, KeyUsage};
+use crate::dom::bindings::codegen::Bindings::SubtleCryptoBinding::KeyFormat;
+use crate::dom::bindings::error::Error;
+use crate::dom::bindings::root::DomRoot;
+use crate::dom::cryptokey::{CryptoKey, Handle};
+use crate::dom::globalscope::GlobalScope;
+use crate::dom::subtlecrypto::aes_common::AesAlgorithm;
+use crate::dom::subtlecrypto::{
+    ALG_AES_GCM, ExportedKey, KeyAlgorithmAndDerivatives, SubtleAesDerivedKeyParams,
+    SubtleAesGcmParams, SubtleAesKeyAlgorithm, SubtleAesKeyGenParams, aes_common,
+};
+use crate::script_runtime::CanGc;
+
+/// <https://w3c.github.io/webcrypto/#aes-gcm-operations-encrypt>
+pub(crate) fn encrypt(
+    normalized_algorithm: &SubtleAesGcmParams,
+    key: &CryptoKey,
+    plaintext: &[u8],
+) -> Result<Vec<u8>, Error> {
+    // Step 1. If plaintext has a length greater than 2^39 - 256 bytes, then throw an
+    // OperationError.
+    if plaintext.len() as u64 > (1 << 39) - 256 {
+        return Err(Error::Operation(Some("The plaintext is too long".into())));
+    }
+
+    // Step 2. If the iv member of normalizedAlgorithm has a length greater than 2^64 - 1 bytes,
+    // then throw an OperationError.
+    if normalized_algorithm.iv.len() > u64::MAX as usize {
+        return Err(Error::Operation(Some(
+            "The iv member of normalizedAlgorithm is too long".into(),
+        )));
+    }
+
+    // Step 3. If the additionalData member of normalizedAlgorithm is present and has a length
+    // greater than 2^64 - 1 bytes, then throw an OperationError.
+    if normalized_algorithm
+        .additional_data
+        .as_ref()
+        .is_some_and(|data| data.len() > u64::MAX as usize)
+    {
+        return Err(Error::Operation(Some(
+            "The additional authentication data is too long".into(),
+        )));
+    }
+
+    // Step 4.
+    // If the tagLength member of normalizedAlgorithm is not present:
+    //     Let tagLength be 128.
+    // If the tagLength member of normalizedAlgorithm is one of 32, 64, 96, 104, 112, 120 or 128:
+    //     Let tagLength be equal to the tagLength member of normalizedAlgorithm
+    // Otherwise:
+    //     throw an OperationError.
+    let tag_length = match normalized_algorithm.tag_length {
+        None => 128,
+        Some(tag_length) if matches!(tag_length, 32 | 64 | 96 | 104 | 112 | 120 | 128) => {
+            tag_length
+        },
+        _ => {
+            return Err(Error::Operation(Some(
+                "The tagLength member of normalizedAlgorithm is present, \
+                and not one of 32, 64, 96, 104, 112, 120 or 128"
+                    .to_string(),
+            )));
+        },
+    };
+
+    // Step 5. Let additionalData be the additionalData member of normalizedAlgorithm if present or
+    // an empty byte sequence otherwise.
+    let additional_data = normalized_algorithm
+        .additional_data
+        .as_deref()
+        .unwrap_or_default();
+
+    // Step 6. Let C and T be the outputs that result from performing the Authenticated Encryption
+    // Function described in Section 7.1 of [NIST-SP800-38D] using AES as the block cipher, the iv
+    // member of normalizedAlgorithm as the IV input parameter, additionalData as the A input
+    // parameter, tagLength as the t pre-requisite and plaintext as the input plaintext.
+    // Step 7. Let ciphertext be equal to C | T, where '|' denotes concatenation.
+    //
+    // NOTE: We currently support:
+    // - IV: 96-bit, 128-bit, 256-bit
+    // - Tag length: 32-bit, 64-bit, 96-bit, 104-bit, 112-bit, 120-bit, 128-bit
+    //
+    // NOTE: The crate `aes-gcm` does not directly support 32-bit and 64-bit tag length. Our
+    // workaround is to perform the Authenticated Encryption Function using 96-bit tag length, and
+    // then remove the last 64 bits for 32-bit tag length, and remove last 32 bits for 64-bit tag
+    // length, from the ciphertext.
+    let iv = normalized_algorithm.iv.as_slice();
+    let ciphertext = match key.handle() {
+        Handle::Aes128Key(key) => match (iv.len(), tag_length) {
+            // 96-bit nonce
+            (12, 32) => {
+                let mut ciphertext =
+                    gcm_encrypt::<Aes128, U12, U12>(key, plaintext, iv, additional_data)?;
+                ciphertext.truncate(ciphertext.len() - 8);
+                ciphertext
+            },
+            (12, 64) => {
+                let mut ciphertext =
+                    gcm_encrypt::<Aes128, U12, U12>(key, plaintext, iv, additional_data)?;
+                ciphertext.truncate(ciphertext.len() - 4);
+                ciphertext
+            },
+            (12, 96) => gcm_encrypt::<Aes128, U12, U12>(key, plaintext, iv, additional_data)?,
+            (12, 104) => gcm_encrypt::<Aes128, U12, U13>(key, plaintext, iv, additional_data)?,
+            (12, 112) => gcm_encrypt::<Aes128, U12, U14>(key, plaintext, iv, additional_data)?,
+            (12, 120) => gcm_encrypt::<Aes128, U12, U15>(key, plaintext, iv, additional_data)?,
+            (12, 128) => gcm_encrypt::<Aes128, U12, U16>(key, plaintext, iv, additional_data)?,
+
+            // 128-bit nonce
+            (16, 32) => {
+                let mut ciphertext =
+                    gcm_encrypt::<Aes128, U16, U12>(key, plaintext, iv, additional_data)?;
+                ciphertext.truncate(ciphertext.len() - 8);
+                ciphertext
+            },
+            (16, 64) => {
+                let mut ciphertext =
+                    gcm_encrypt::<Aes128, U16, U12>(key, plaintext, iv, additional_data)?;
+                ciphertext.truncate(ciphertext.len() - 4);
+                ciphertext
+            },
+            (16, 96) => gcm_encrypt::<Aes128, U16, U12>(key, plaintext, iv, additional_data)?,
+            (16, 104) => gcm_encrypt::<Aes128, U16, U13>(key, plaintext, iv, additional_data)?,
+            (16, 112) => gcm_encrypt::<Aes128, U16, U14>(key, plaintext, iv, additional_data)?,
+            (16, 120) => gcm_encrypt::<Aes128, U16, U15>(key, plaintext, iv, additional_data)?,
+            (16, 128) => gcm_encrypt::<Aes128, U16, U16>(key, plaintext, iv, additional_data)?,
+
+            // 256-bit nonce
+            (32, 32) => {
+                let mut ciphertext =
+                    gcm_encrypt::<Aes128, U32, U12>(key, plaintext, iv, additional_data)?;
+                ciphertext.truncate(ciphertext.len() - 8);
+                ciphertext
+            },
+            (32, 64) => {
+                let mut ciphertext =
+                    gcm_encrypt::<Aes128, U32, U12>(key, plaintext, iv, additional_data)?;
+                ciphertext.truncate(ciphertext.len() - 4);
+                ciphertext
+            },
+            (32, 96) => gcm_encrypt::<Aes128, U32, U12>(key, plaintext, iv, additional_data)?,
+            (32, 104) => gcm_encrypt::<Aes128, U32, U13>(key, plaintext, iv, additional_data)?,
+            (32, 112) => gcm_encrypt::<Aes128, U32, U14>(key, plaintext, iv, additional_data)?,
+            (32, 120) => gcm_encrypt::<Aes128, U32, U15>(key, plaintext, iv, additional_data)?,
+            (32, 128) => gcm_encrypt::<Aes128, U32, U16>(key, plaintext, iv, additional_data)?,
+            _ => {
+                return Err(Error::Operation(Some(format!(
+                    "Unsupported iv size ({}-bit) and/or tag length ({}-bit)",
+                    iv.len() * 8,
+                    tag_length
+                ))));
+            },
+        },
+        Handle::Aes192Key(key) => match (iv.len(), tag_length) {
+            // 96-bit nonce
+            (12, 32) => {
+                let mut ciphertext =
+                    gcm_encrypt::<Aes192, U12, U12>(key, plaintext, iv, additional_data)?;
+                ciphertext.truncate(ciphertext.len() - 8);
+                ciphertext
+            },
+            (12, 64) => {
+                let mut ciphertext =
+                    gcm_encrypt::<Aes192, U12, U12>(key, plaintext, iv, additional_data)?;
+                ciphertext.truncate(ciphertext.len() - 4);
+                ciphertext
+            },
+            (12, 96) => gcm_encrypt::<Aes192, U12, U12>(key, plaintext, iv, additional_data)?,
+            (12, 104) => gcm_encrypt::<Aes192, U12, U13>(key, plaintext, iv, additional_data)?,
+            (12, 112) => gcm_encrypt::<Aes192, U12, U14>(key, plaintext, iv, additional_data)?,
+            (12, 120) => gcm_encrypt::<Aes192, U12, U15>(key, plaintext, iv, additional_data)?,
+            (12, 128) => gcm_encrypt::<Aes192, U12, U16>(key, plaintext, iv, additional_data)?,
+
+            // 128-bit nonce
+            (16, 32) => {
+                let mut ciphertext =
+                    gcm_encrypt::<Aes192, U16, U12>(key, plaintext, iv, additional_data)?;
+                ciphertext.truncate(ciphertext.len() - 8);
+                ciphertext
+            },
+            (16, 64) => {
+                let mut ciphertext =
+                    gcm_encrypt::<Aes192, U16, U12>(key, plaintext, iv, additional_data)?;
+                ciphertext.truncate(ciphertext.len() - 4);
+                ciphertext
+            },
+            (16, 96) => gcm_encrypt::<Aes192, U16, U12>(key, plaintext, iv, additional_data)?,
+            (16, 104) => gcm_encrypt::<Aes192, U16, U13>(key, plaintext, iv, additional_data)?,
+            (16, 112) => gcm_encrypt::<Aes192, U16, U14>(key, plaintext, iv, additional_data)?,
+            (16, 120) => gcm_encrypt::<Aes192, U16, U15>(key, plaintext, iv, additional_data)?,
+            (16, 128) => gcm_encrypt::<Aes192, U16, U16>(key, plaintext, iv, additional_data)?,
+
+            // 256-bit nonce
+            (32, 32) => {
+                let mut ciphertext =
+                    gcm_encrypt::<Aes192, U32, U12>(key, plaintext, iv, additional_data)?;
+                ciphertext.truncate(ciphertext.len() - 8);
+                ciphertext
+            },
+            (32, 64) => {
+                let mut ciphertext =
+                    gcm_encrypt::<Aes192, U32, U12>(key, plaintext, iv, additional_data)?;
+                ciphertext.truncate(ciphertext.len() - 4);
+                ciphertext
+            },
+            (32, 96) => gcm_encrypt::<Aes192, U32, U12>(key, plaintext, iv, additional_data)?,
+            (32, 104) => gcm_encrypt::<Aes192, U32, U13>(key, plaintext, iv, additional_data)?,
+            (32, 112) => gcm_encrypt::<Aes192, U32, U14>(key, plaintext, iv, additional_data)?,
+            (32, 120) => gcm_encrypt::<Aes192, U32, U15>(key, plaintext, iv, additional_data)?,
+            (32, 128) => gcm_encrypt::<Aes192, U32, U16>(key, plaintext, iv, additional_data)?,
+            _ => {
+                return Err(Error::Operation(Some(format!(
+                    "Unsupported iv size ({}-bit) and/or tag length ({}-bit)",
+                    iv.len() * 8,
+                    tag_length
+                ))));
+            },
+        },
+        Handle::Aes256Key(key) => match (iv.len(), tag_length) {
+            // 96-bit nonce
+            (12, 32) => {
+                let mut ciphertext =
+                    gcm_encrypt::<Aes256, U12, U12>(key, plaintext, iv, additional_data)?;
+                ciphertext.truncate(ciphertext.len() - 8);
+                ciphertext
+            },
+            (12, 64) => {
+                let mut ciphertext =
+                    gcm_encrypt::<Aes256, U12, U12>(key, plaintext, iv, additional_data)?;
+                ciphertext.truncate(ciphertext.len() - 4);
+                ciphertext
+            },
+            (12, 96) => gcm_encrypt::<Aes256, U12, U12>(key, plaintext, iv, additional_data)?,
+            (12, 104) => gcm_encrypt::<Aes256, U12, U13>(key, plaintext, iv, additional_data)?,
+            (12, 112) => gcm_encrypt::<Aes256, U12, U14>(key, plaintext, iv, additional_data)?,
+            (12, 120) => gcm_encrypt::<Aes256, U12, U15>(key, plaintext, iv, additional_data)?,
+            (12, 128) => gcm_encrypt::<Aes256, U12, U16>(key, plaintext, iv, additional_data)?,
+
+            // 128-bit nonce
+            (16, 32) => {
+                let mut ciphertext =
+                    gcm_encrypt::<Aes256, U16, U12>(key, plaintext, iv, additional_data)?;
+                ciphertext.truncate(ciphertext.len() - 8);
+                ciphertext
+            },
+            (16, 64) => {
+                let mut ciphertext =
+                    gcm_encrypt::<Aes256, U16, U12>(key, plaintext, iv, additional_data)?;
+                ciphertext.truncate(ciphertext.len() - 4);
+                ciphertext
+            },
+            (16, 96) => gcm_encrypt::<Aes256, U16, U12>(key, plaintext, iv, additional_data)?,
+            (16, 104) => gcm_encrypt::<Aes256, U16, U13>(key, plaintext, iv, additional_data)?,
+            (16, 112) => gcm_encrypt::<Aes256, U16, U14>(key, plaintext, iv, additional_data)?,
+            (16, 120) => gcm_encrypt::<Aes256, U16, U15>(key, plaintext, iv, additional_data)?,
+            (16, 128) => gcm_encrypt::<Aes256, U16, U16>(key, plaintext, iv, additional_data)?,
+
+            // 256-bit nonce
+            (32, 32) => {
+                let mut ciphertext =
+                    gcm_encrypt::<Aes256, U32, U12>(key, plaintext, iv, additional_data)?;
+                ciphertext.truncate(ciphertext.len() - 8);
+                ciphertext
+            },
+            (32, 64) => {
+                let mut ciphertext =
+                    gcm_encrypt::<Aes256, U32, U12>(key, plaintext, iv, additional_data)?;
+                ciphertext.truncate(ciphertext.len() - 4);
+                ciphertext
+            },
+            (32, 96) => gcm_encrypt::<Aes256, U32, U12>(key, plaintext, iv, additional_data)?,
+            (32, 104) => gcm_encrypt::<Aes256, U32, U13>(key, plaintext, iv, additional_data)?,
+            (32, 112) => gcm_encrypt::<Aes256, U32, U14>(key, plaintext, iv, additional_data)?,
+            (32, 120) => gcm_encrypt::<Aes256, U32, U15>(key, plaintext, iv, additional_data)?,
+            (32, 128) => gcm_encrypt::<Aes256, U32, U16>(key, plaintext, iv, additional_data)?,
+            _ => {
+                return Err(Error::Operation(Some(format!(
+                    "Unsupported iv size ({}-bit) and/or tag length ({}-bit)",
+                    iv.len() * 8,
+                    tag_length
+                ))));
+            },
+        },
+        _ => {
+            return Err(Error::Operation(Some(
+                "The key handle is not representing an AES key".to_string(),
+            )));
+        },
+    };
+
+    // Step 8. Return ciphertext.
+    Ok(ciphertext)
+}
+
+/// Helper for Step 6 and 7 of <https://w3c.github.io/webcrypto/#aes-gcm-operations-encrypt>
+fn gcm_encrypt<Aes, NonceSize, TagSize>(
+    key: &Key<Aes>,
+    plaintext: &[u8],
+    iv: &[u8],
+    additional_data: &[u8],
+) -> Result<Vec<u8>, Error>
+where
+    Aes: BlockCipher + BlockSizeUser<BlockSize = U16> + BlockEncrypt + KeyInit,
+    NonceSize: ArrayLength<u8>,
+    TagSize: aes_gcm::TagSize,
+{
+    let mut ciphertext = plaintext.to_vec();
+
+    let mut cipher = AesGcm::<Aes, NonceSize, TagSize>::new(key);
+    cipher
+        .encrypt_in_place(iv.into(), additional_data, &mut ciphertext)
+        .map_err(|_| {
+            Error::Operation(Some(
+                "AES-GCM failed to perform the Authenticated Encryption Function".to_string(),
+            ))
+        })?;
+
+    Ok(ciphertext)
+}
+
+/// <https://w3c.github.io/webcrypto/#aes-gcm-operations-decrypt>
+pub(crate) fn decrypt(
+    normalized_algorithm: &SubtleAesGcmParams,
+    key: &CryptoKey,
+    ciphertext: &[u8],
+) -> Result<Vec<u8>, Error> {
+    // Step 1.
+    // If the tagLength member of normalizedAlgorithm is not present:
+    //     Let tagLength be 128.
+    // If the tagLength member of normalizedAlgorithm is one of 32, 64, 96, 104, 112, 120 or 128:
+    //     Let tagLength be equal to the tagLength member of normalizedAlgorithm
+    // Otherwise:
+    //     throw an OperationError.
+    let tag_length = match normalized_algorithm.tag_length {
+        None => 128,
+        Some(tag_length) if matches!(tag_length, 32 | 64 | 96 | 104 | 112 | 120 | 128) => {
+            tag_length
+        },
+        _ => {
+            return Err(Error::Operation(Some(
+                "The tagLength member of normalizedAlgorithm is present, \
+                and not one of 32, 64, 96, 104, 112, 120 or 128"
+                    .to_string(),
+            )));
+        },
+    };
+
+    // Step 2. If ciphertext has a length in bits less than tagLength, then throw an
+    // OperationError.
+    if ciphertext.len() * 8 < tag_length as usize {
+        return Err(Error::Operation(Some(
+            "The ciphertext is shorter than the tag".into(),
+        )));
+    }
+
+    // Step 2. If the iv member of normalizedAlgorithm has a length greater than 2^64 - 1 bytes,
+    // then throw an OperationError.
+    if normalized_algorithm.iv.len() > u64::MAX as usize {
+        return Err(Error::Operation(Some(
+            "The iv member of normalizedAlgorithm is too long".into(),
+        )));
+    }
+
+    // Step 3. If the additionalData member of normalizedAlgorithm is present and has a length
+    // greater than 2^64 - 1 bytes, then throw an OperationError.
+    if normalized_algorithm
+        .additional_data
+        .as_ref()
+        .is_some_and(|data| data.len() > u64::MAX as usize)
+    {
+        return Err(Error::Operation(Some(
+            "The additional authentication data is too long".into(),
+        )));
+    }
+
+    // Step 5. Let tag be the last tagLength bits of ciphertext.
+    // Step 6. Let actualCiphertext be the result of removing the last tagLength bits from
+    // ciphertext.
+    // NOTE: aes_gcm splits the ciphertext for us
+
+    // Step 7. Let additionalData be the additionalData member of normalizedAlgorithm if present or
+    // an empty byte sequence otherwise.
+    let additional_data = normalized_algorithm
+        .additional_data
+        .as_deref()
+        .unwrap_or_default();
+
+    // Step 8. Perform the Authenticated Decryption Function described in Section 7.2 of
+    // [NIST-SP800-38D] using AES as the block cipher, the iv member of normalizedAlgorithm as the
+    // IV input parameter, additionalData as the A input parameter, tagLength as the t
+    // pre-requisite, actualCiphertext as the input ciphertext, C and tag as the authentication
+    // tag, T.
+    //
+    // If the result of the algorithm is the indication of inauthenticity, "FAIL":
+    //     throw an OperationError
+    // Otherwise:
+    //     Let plaintext be the output P of the Authenticated Decryption Function.
+    //
+    // NOTE: We currently support:
+    // - IV: 96-bit, 128-bit, 256-bit
+    // - Tag length: 128-bit
+    let iv = normalized_algorithm.iv.as_slice();
+    let plaintext = match key.handle() {
+        Handle::Aes128Key(key) => match (iv.len(), tag_length) {
+            // 96-bit nonce
+            (12, 128) => gcm_decrypt::<Aes128, U12, U16>(key, ciphertext, iv, additional_data)?,
+            // 128-bit nonce
+            (16, 128) => gcm_decrypt::<Aes128, U16, U16>(key, ciphertext, iv, additional_data)?,
+            // 256-bit nonce
+            (32, 128) => gcm_decrypt::<Aes128, U32, U16>(key, ciphertext, iv, additional_data)?,
+            _ => {
+                return Err(Error::Operation(Some(format!(
+                    "Unsupported iv size ({}-bit) and/or tag length ({}-bit)",
+                    iv.len() * 8,
+                    tag_length
+                ))));
+            },
+        },
+        Handle::Aes192Key(key) => match (iv.len(), tag_length) {
+            // 96-bit nonce
+            (12, 128) => gcm_decrypt::<Aes192, U12, U16>(key, ciphertext, iv, additional_data)?,
+            // 128-bit nonce
+            (16, 128) => gcm_decrypt::<Aes192, U16, U16>(key, ciphertext, iv, additional_data)?,
+            // 256-bit nonce
+            (32, 128) => gcm_decrypt::<Aes192, U32, U16>(key, ciphertext, iv, additional_data)?,
+            _ => {
+                return Err(Error::Operation(Some(format!(
+                    "Unsupported iv size ({}-bit) and/or tag length ({}-bit)",
+                    iv.len() * 8,
+                    tag_length
+                ))));
+            },
+        },
+        Handle::Aes256Key(key) => match (iv.len(), tag_length) {
+            // 96-bit nonce
+            (12, 128) => gcm_decrypt::<Aes256, U12, U16>(key, ciphertext, iv, additional_data)?,
+            // 128-bit nonce
+            (16, 128) => gcm_decrypt::<Aes256, U16, U16>(key, ciphertext, iv, additional_data)?,
+            // 256-bit nonce
+            (32, 128) => gcm_decrypt::<Aes256, U32, U16>(key, ciphertext, iv, additional_data)?,
+            _ => {
+                return Err(Error::Operation(Some(format!(
+                    "Unsupported iv size ({}-bit) and/or tag length ({}-bit)",
+                    iv.len() * 8,
+                    tag_length
+                ))));
+            },
+        },
+        _ => {
+            return Err(Error::Operation(Some(
+                "The key handle is not representing an AES key".to_string(),
+            )));
+        },
+    };
+
+    // Step 9. Return plaintext.
+    Ok(plaintext)
+}
+
+/// Helper for Step 8 of <https://w3c.github.io/webcrypto/#aes-gcm-operations-decrypt>
+fn gcm_decrypt<Aes, NonceSize, TagSize>(
+    key: &Key<Aes>,
+    ciphertext: &[u8],
+    iv: &[u8],
+    additional_data: &[u8],
+) -> Result<Vec<u8>, Error>
+where
+    Aes: BlockCipher + BlockSizeUser<BlockSize = U16> + BlockEncrypt + KeyInit,
+    NonceSize: ArrayLength<u8>,
+    TagSize: aes_gcm::TagSize,
+{
+    let mut plaintext = ciphertext.to_vec();
+
+    let mut cipher = AesGcm::<Aes, NonceSize, TagSize>::new(key);
+    cipher
+        .decrypt_in_place(iv.into(), additional_data, &mut plaintext)
+        .map_err(|_| {
+            Error::Operation(Some(
+                "AES-GCM failed to perform the Authenticated Decryption Function".to_string(),
+            ))
+        })?;
+
+    Ok(plaintext)
+}
+
+/// <https://w3c.github.io/webcrypto/#aes-gcm-operations-generate-key>
+pub(crate) fn generate_key(
+    global: &GlobalScope,
+    normalized_algorithm: &SubtleAesKeyGenParams,
+    extractable: bool,
+    usages: Vec<KeyUsage>,
+    can_gc: CanGc,
+) -> Result<DomRoot<CryptoKey>, Error> {
+    aes_common::generate_key(
+        AesAlgorithm::AesGcm,
+        global,
+        normalized_algorithm,
+        extractable,
+        usages,
+        can_gc,
+    )
+}
+
+/// <https://w3c.github.io/webcrypto/#aes-gcm-operations-import-key>
+pub(crate) fn import_key(
+    global: &GlobalScope,
+    format: KeyFormat,
+    key_data: &[u8],
+    extractable: bool,
+    usages: Vec<KeyUsage>,
+    can_gc: CanGc,
+) -> Result<DomRoot<CryptoKey>, Error> {
+    // Step 1. Let keyData be the key data to be imported.
+
+    // Step 2. If usages contains an entry which is not one of "encrypt", "decrypt", "wrapKey" or
+    // "unwrapKey", then throw a SyntaxError.
+    if usages.iter().any(|usage| {
+        !matches!(
+            usage,
+            KeyUsage::Encrypt | KeyUsage::Decrypt | KeyUsage::WrapKey | KeyUsage::UnwrapKey
+        )
+    }) {
+        return Err(Error::Syntax(Some(
+            "Usages contains an entry which is not one of \"encrypt\", \"decrypt\", \"wrapKey\" \
+            or \"unwrapKey\""
+                .to_string(),
+        )));
+    }
+
+    // Step 3.
+    let data = aes_common::import_key_from_key_data(
+        AesAlgorithm::AesGcm,
+        format,
+        key_data,
+        extractable,
+        &usages,
+    )?;
+
+    // Step 4. Let key be a new CryptoKey object representing an AES key with value data.
+    // Step 5. Let algorithm be a new AesKeyAlgorithm.
+    // Step 6. Set the name attribute of algorithm to "AES-GCM".
+    // Step 7. Set the length attribute of algorithm to the length, in bits, of data.
+    // Step 8. Set the [[algorithm]] internal slot of key to algorithm.
+    let handle = match data.len() {
+        16 => Handle::Aes128Key(Key::<Aes128>::clone_from_slice(&data)),
+        24 => Handle::Aes192Key(Key::<Aes192>::clone_from_slice(&data)),
+        32 => Handle::Aes256Key(Key::<Aes256>::clone_from_slice(&data)),
+        _ => {
+            return Err(Error::Data(Some(
+                "The length in bits of data is not 128, 192 or 256".to_string(),
+            )));
+        },
+    };
+    let algorithm = SubtleAesKeyAlgorithm {
+        name: ALG_AES_GCM.to_string(),
+        length: data.len() as u16 * 8,
+    };
+    let key = CryptoKey::new(
+        global,
+        KeyType::Secret,
+        extractable,
+        KeyAlgorithmAndDerivatives::AesKeyAlgorithm(algorithm),
+        usages,
+        handle,
+        can_gc,
+    );
+
+    // Step 9. Return key.
+    Ok(key)
+}
+
+/// <https://w3c.github.io/webcrypto/#aes-gcm-operations-export-key>
+pub(crate) fn export_key(format: KeyFormat, key: &CryptoKey) -> Result<ExportedKey, Error> {
+    aes_common::export_key(AesAlgorithm::AesGcm, format, key)
+}
+
+/// <https://w3c.github.io/webcrypto/#aes-gcm-operations-get-key-length>
+pub(crate) fn get_key_length(
+    normalized_derived_key_algorithm: &SubtleAesDerivedKeyParams,
+) -> Result<Option<u32>, Error> {
+    aes_common::get_key_length(normalized_derived_key_algorithm)
+}


### PR DESCRIPTION
We previously introduced new infrastructure for sharing code in `aes_common.rs` among AES algorithms.

Similar to #41856 on AES-CTR and #41883 on AES-CBC, this patch makes AES-GCM algorithm adapt the new infrastructure, by moving the relevant code away from `aes_operation.rs` to its own `aes_gcm_operation.rs`, and calling AES common steps in the new `aes_common.rs`.

The patch also re-wrote the encrypt and decrypt operations of AES-GCM to properly handle different tag lengths. This helps extend our support on more tag lengths later, in order pass more WPT tests.

Testing: Refactoring. Existing tests suffice.
Fixes: Part of #41763