### PR TITLE
layout: Add support for clicking past the end of multiline inputs

### DIFF
--- a/components/layout/layout_impl.rs
+++ b/components/layout/layout_impl.rs
@@ -90,9 +90,8 @@ use crate::context::{CachedImageOrError, ImageResolver, LayoutContext};
 use crate::display_list::{
     DisplayListBuilder, HitTest, LargestContentfulPaintCandidateCollector, StackingContextTree,
 };
-use crate::dom::NodeExt;
 use crate::query::{
-    find_glyph_offset_in_fragment, get_the_text_steps, process_box_area_request,
+    find_glyph_offset_in_fragment_descendants, get_the_text_steps, process_box_area_request,
     process_box_areas_request, process_client_rect_request, process_current_css_zoom_query,
     process_node_scroll_area_request, process_offset_parent_query, process_padding_request,
     process_resolved_font_style_query, process_resolved_style_request,
@@ -486,9 +485,7 @@ impl Layout for LayoutThread {
         point_in_node: Point2D<Au, CSSPixel>,
     ) -> Option<usize> {
         let node = unsafe { ServoLayoutNode::new(&node).to_threadsafe() };
-        node.fragments_for_pseudo(None)
-            .iter()
-            .find_map(|fragment| find_glyph_offset_in_fragment(fragment, point_in_node, true))
+        find_glyph_offset_in_fragment_descendants(&node, point_in_node)
     }
 
     #[servo_tracing::instrument(skip_all)]

--- a/tests/wpt/mozilla/meta/MANIFEST.json
+++ b/tests/wpt/mozilla/meta/MANIFEST.json
@@ -12965,7 +12965,7 @@
      ]
     ],
     "mousedown-edit-point-textarea.html": [
-     "54b6e42625373e1a71e6a62f8bc40c12909bed52",
+     "de2e68a2b92ccae40ad6b062569a03121d597ae3",
      [
       null,
       {

--- a/tests/wpt/mozilla/tests/input-events/mousedown-edit-point-textarea.html
+++ b/tests/wpt/mozilla/tests/input-events/mousedown-edit-point-textarea.html
@@ -60,8 +60,8 @@ promise_test(async test => {
       .pointerMove(targetRect.left + (50 * 7), middleOfFirstLine)
       .pointerDown().pointerUp()
           .send();
-    assert_equals(target.selectionStart, 24);
-    assert_equals(target.selectionEnd, 24);
+    assert_equals(target.selectionStart, 5);
+    assert_equals(target.selectionEnd, 5);
 
     target.setSelectionRange(0, 0);
 
@@ -105,6 +105,14 @@ promise_test(async test => {
     // Clicking past the end of the text should move the edit point to the end.
     await new test_driver.Actions()
       .pointerMove(targetRect.left + (50 * 7), middleOfThirdLine)
+      .pointerDown().pointerUp()
+          .send();
+    assert_equals(target.selectionStart, 17);
+    assert_equals(target.selectionEnd, 17);
+
+    // Clicking past the end of the last line should move the edit point to the end.
+    await new test_driver.Actions()
+      .pointerMove(targetRect.left + 10, targetRect.top + (50 * 4) + 20)
       .pointerDown().pointerUp()
           .send();
     assert_equals(target.selectionStart, 24);


### PR DESCRIPTION
Make it so that clicking past the end of the text of a multiline input,
moves the edit point to the end of that line. Now we evaluate all
potential target `TextFragment`s and find the most appropriate one,
putting the edit point there.

Testing: This updates expected test results for the `<textarea>` clicking tests.
