### PR TITLE
script: Move adapter dropping to a dedicated struct

### DIFF
--- a/components/script_bindings/codegen/Bindings.conf
+++ b/components/script_bindings/codegen/Bindings.conf
@@ -302,7 +302,6 @@ DOMInterfaces = {
 'GPUAdapter': {
     'inRealms': ['RequestDevice'],
     'canGc': ['RequestDevice'],
-    'allowDropImpl': True,
 },
 
 'GPUBindGroup': {


### PR DESCRIPTION
Moves the adapter dropping logic from the `GPUAdapter` struct to a new `DroppableGPUAdapter` struct.

Testing: No tests added.
Fixes: Partially #26488 
