### PR TITLE
net: Use the user locale for the Accept-Language header and navigator language

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -170,6 +170,7 @@ jobs:
         if: ${{ inputs.unit-tests }}
         env:
           NEXTEST_RETRIES: 2 # https://github.com/servo/servo/issues/30683
+          LANG: en-US
         run: ./mach test-unit --profile ${{ inputs.profile }} --nextest-profile ci
       # We upload the test-results to Codecov to help us identify flaky unit-tests.
       - name: Upload test results to Codecov
@@ -343,6 +344,7 @@ jobs:
         shell: bash
         env:
           NEXTEST_RETRIES: 2 # https://github.com/servo/servo/issues/30683
+          LANG: en-US
         run: |
           ./mach test-unit --code-coverage \
               --profile=${{ steps.options.outputs.cargo_profile }} \

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5777,8 +5777,10 @@ dependencies = [
  "rustls-pki-types",
  "serde",
  "servo_arc",
+ "servo_config",
  "servo_malloc_size_of",
  "servo_url",
+ "sys-locale",
  "tokio",
  "url",
  "uuid",
@@ -9067,6 +9069,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "sys-locale"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8eab9a99a024a169fe8a903cf9d4a3b3601109bcc13bd9e3c6fff259138626c4"
+dependencies = [
+ "libc",
 ]
 
 [[package]]

--- a/components/config/prefs.rs
+++ b/components/config/prefs.rs
@@ -211,6 +211,10 @@ pub struct Preferences {
     pub image_key_batch_size: i64,
     /// Whether or not the DOM inspector should show shadow roots of user-agent shadow trees
     pub inspector_show_servo_internal_shadow_roots: bool,
+    /// A locale tag (eg. es-ES) to use for language negotiation instead of the system locale.
+    /// An empty string represents no override.
+    /// TODO: Option<> support in PrefValue
+    pub intl_locale_override: String,
     pub js_asmjs_enabled: bool,
     pub js_asyncstack: bool,
     pub js_baseline_interpreter_enabled: bool,
@@ -419,6 +423,7 @@ impl Preferences {
             gfx_texture_swizzling_enabled: true,
             image_key_batch_size: 10,
             inspector_show_servo_internal_shadow_roots: false,
+            intl_locale_override: String::new(),
             js_asmjs_enabled: true,
             js_asyncstack: false,
             js_baseline_interpreter_enabled: true,

--- a/components/net/tests/fetch.rs
+++ b/components/net/tests/fetch.rs
@@ -1421,10 +1421,7 @@ fn test_fetch_with_devtools() {
 
     headers.insert(header::ACCEPT, HeaderValue::from_static("*/*"));
 
-    headers.insert(
-        header::ACCEPT_LANGUAGE,
-        HeaderValue::from_static("en-US,en;q=0.5"),
-    );
+    headers.insert(header::ACCEPT_LANGUAGE, HeaderValue::from_static("en-US"));
 
     headers.typed_insert::<UserAgent>(DEFAULT_USER_AGENT.parse().unwrap());
 

--- a/components/net/tests/http_loader.rs
+++ b/components/net/tests/http_loader.rs
@@ -203,10 +203,7 @@ fn test_check_default_headers_loaded_in_every_request() {
         HeaderValue::from_static("text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8"),
     );
 
-    headers.insert(
-        header::ACCEPT_LANGUAGE,
-        HeaderValue::from_static("en-US,en;q=0.5"),
-    );
+    headers.insert(header::ACCEPT_LANGUAGE, HeaderValue::from_static("en-US"));
 
     headers.typed_insert::<UserAgent>(crate::DEFAULT_USER_AGENT.parse().unwrap());
 
@@ -364,10 +361,7 @@ fn test_request_and_response_data_with_network_messages() {
         HeaderValue::from_static("text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8"),
     );
 
-    headers.insert(
-        header::ACCEPT_LANGUAGE,
-        HeaderValue::from_static("en-US,en;q=0.5"),
-    );
+    headers.insert(header::ACCEPT_LANGUAGE, HeaderValue::from_static("en-US"));
 
     headers.typed_insert::<UserAgent>(crate::DEFAULT_USER_AGENT.parse().unwrap());
 

--- a/components/script/dom/navigatorinfo.rs
+++ b/components/script/dom/navigatorinfo.rs
@@ -75,5 +75,5 @@ pub(crate) fn AppVersion() -> DOMString {
 
 #[expect(non_snake_case)]
 pub(crate) fn Language() -> DOMString {
-    DOMString::from("en-US")
+    DOMString::from(net_traits::get_current_locale().0.clone())
 }

--- a/components/shared/net/Cargo.toml
+++ b/components/shared/net/Cargo.toml
@@ -40,7 +40,9 @@ rustc-hash = { workspace = true }
 rustls-pki-types = { workspace = true }
 serde = { workspace = true }
 servo_arc = { workspace = true }
+servo_config = { path = "../../config" }
 servo_url = { path = "../../url" }
+sys-locale = "0.3"
 tokio = { workspace = true }
 url = { workspace = true }
 uuid = { workspace = true }

--- a/components/shared/net/lib.rs
+++ b/components/shared/net/lib.rs
@@ -1290,6 +1290,24 @@ pub fn http_percent_encode(bytes: &[u8]) -> String {
     percent_encoding::percent_encode(bytes, HTTP_VALUE).to_string()
 }
 
+/// Returns the cached current system locale, or en-US by default.
+pub fn get_current_locale() -> &'static (String, HeaderValue) {
+    static CURRENT_LOCALE: OnceLock<(String, HeaderValue)> = OnceLock::new();
+
+    CURRENT_LOCALE.get_or_init(|| {
+        let locale_override = servo_config::pref!(intl_locale_override);
+        let locale = if locale_override.is_empty() {
+            sys_locale::get_locale().unwrap_or_else(|| "en-US".into())
+        } else {
+            locale_override
+        };
+        let header_value = HeaderValue::from_str(&locale)
+            .ok()
+            .unwrap_or_else(|| HeaderValue::from_static("en-US"));
+        (locale, header_value)
+    })
+}
+
 /// Step 12 of <https://fetch.spec.whatwg.org/#concept-fetch>
 pub fn set_default_accept_language(headers: &mut HeaderMap) {
     // If request’s header list does not contain `Accept-Language`,
@@ -1298,11 +1316,8 @@ pub fn set_default_accept_language(headers: &mut HeaderMap) {
         return;
     }
 
-    // TODO(eijebong): Change this once typed headers are done
-    headers.insert(
-        header::ACCEPT_LANGUAGE,
-        HeaderValue::from_static("en-US,en;q=0.5"),
-    );
+    // To reduce fingerprinting we set only a single language.
+    headers.insert(header::ACCEPT_LANGUAGE, get_current_locale().1.clone());
 }
 
 pub static PRIVILEGED_SECRET: LazyLock<u32> = LazyLock::new(|| rng().next_u32());


### PR DESCRIPTION
That respects the user locale better than hardcoding en-US.  This can also be manually set with the `LANG` environment variable.

Testing: Manual testing with the devtools to check the header sent and the value of `navigator.language`

Fixes: #27210
