### PR TITLE
script: Replace uses of `RootedVec<JSVal>` with `Rooted<Vec<JSVal>>`.

### DIFF
--- a/components/script/dom/indexeddb/idbrequest.rs
+++ b/components/script/dom/indexeddb/idbrequest.rs
@@ -142,7 +142,12 @@ impl RequestListener {
                 IdbResult::Keys(keys) => {
                     rooted!(in(*cx) let mut array = vec![JSVal::default(); keys.len()]);
                     for (i, key) in keys.into_iter().enumerate() {
-                        key_type_to_jsval(GlobalScope::get_cx(), &key, array.handle_mut_at(i), can_gc);
+                        key_type_to_jsval(
+                            GlobalScope::get_cx(),
+                            &key,
+                            array.handle_mut_at(i),
+                            can_gc,
+                        );
                     }
                     array.safe_to_jsval(cx, answer.handle_mut(), can_gc);
                 },
@@ -164,7 +169,12 @@ impl RequestListener {
                         let result = bincode::deserialize(&serialized_data)
                             .map_err(|_| Error::Data(None))
                             .and_then(|data| {
-                                structuredclone::read(&global, data, values.handle_mut_at(i), can_gc)
+                                structuredclone::read(
+                                    &global,
+                                    data,
+                                    values.handle_mut_at(i),
+                                    can_gc,
+                                )
                             });
                         if let Err(e) = result {
                             warn!("Error reading structuredclone data");

--- a/components/script/dom/indexeddb/idbrequest.rs
+++ b/components/script/dom/indexeddb/idbrequest.rs
@@ -140,11 +140,9 @@ impl RequestListener {
                     key_type_to_jsval(GlobalScope::get_cx(), &key, answer.handle_mut(), can_gc)
                 },
                 IdbResult::Keys(keys) => {
-                    rooted_vec!(let mut array);
-                    for key in keys.into_iter() {
-                        rooted!(in(*cx) let mut val = UndefinedValue());
-                        key_type_to_jsval(GlobalScope::get_cx(), &key, val.handle_mut(), can_gc);
-                        array.push(Heap::boxed(val.get()));
+                    rooted!(in(*cx) let mut array = vec![JSVal::default(); keys.len()]);
+                    for (i, key) in keys.into_iter().enumerate() {
+                        key_type_to_jsval(GlobalScope::get_cx(), &key, array.handle_mut_at(i), can_gc);
                     }
                     array.safe_to_jsval(cx, answer.handle_mut(), can_gc);
                 },
@@ -161,20 +159,18 @@ impl RequestListener {
                     };
                 },
                 IdbResult::Values(serialized_values) => {
-                    rooted_vec!(let mut values);
-                    for serialized_data in serialized_values.into_iter() {
-                        rooted!(in(*cx) let mut val = UndefinedValue());
+                    rooted!(in(*cx) let mut values = vec![JSVal::default(); serialized_values.len()]);
+                    for (i, serialized_data) in serialized_values.into_iter().enumerate() {
                         let result = bincode::deserialize(&serialized_data)
                             .map_err(|_| Error::Data(None))
                             .and_then(|data| {
-                                structuredclone::read(&global, data, val.handle_mut(), can_gc)
+                                structuredclone::read(&global, data, values.handle_mut_at(i), can_gc)
                             });
                         if let Err(e) = result {
                             warn!("Error reading structuredclone data");
                             Self::handle_async_request_error(&global, cx, request, e);
                             return;
                         };
-                        values.push(Heap::boxed(val.get()));
                     }
                     values.safe_to_jsval(cx, answer.handle_mut(), can_gc);
                 },

--- a/components/script/indexeddb.rs
+++ b/components/script/indexeddb.rs
@@ -8,9 +8,9 @@ use std::ptr;
 use itertools::Itertools;
 use js::conversions::jsstr_to_string;
 use js::jsapi::{
-    ClippedTime, ESClass, GetArrayLength, GetBuiltinClass, Heap, IsArrayBufferObject,
-    JS_GetStringLength, JS_HasOwnPropertyById, JS_IndexToId, JS_IsArrayBufferViewObject,
-    JS_NewObject, NewDateObject, PropertyKey,
+    ClippedTime, ESClass, GetArrayLength, GetBuiltinClass, IsArrayBufferObject, JS_GetStringLength,
+    JS_HasOwnPropertyById, JS_IndexToId, JS_IsArrayBufferViewObject, JS_NewObject, NewDateObject,
+    PropertyKey,
 };
 use js::jsval::{DoubleValue, JSVal, UndefinedValue};
 use js::rust::wrappers::{IsArrayObject, JS_GetProperty, JS_HasOwnProperty, JS_IsIdentifier};
@@ -53,11 +53,9 @@ pub fn key_type_to_jsval(
             date.safe_to_jsval(cx, result, can_gc);
         },
         IndexedDBKeyType::Array(a) => {
-            rooted_vec!(let mut values);
-            for key in a {
-                rooted!(in(*cx) let mut value: JSVal);
-                key_type_to_jsval(cx, key, value.handle_mut(), can_gc);
-                values.push(Heap::boxed(value.get()));
+            rooted!(in(*cx) let mut values = vec![JSVal::default(); a.len()]);
+            for (i, key) in a.iter().enumerate() {
+                key_type_to_jsval(cx, key, values.handle_mut_at(i), can_gc);
             }
             values.safe_to_jsval(cx, result, can_gc);
         },

--- a/components/script_bindings/codegen/codegen.py
+++ b/components/script_bindings/codegen/codegen.py
@@ -8651,7 +8651,7 @@ class CallbackMember(CGNativeMember):
         argval = arg.identifier.name
 
         if arg.variadic:
-            argval = f"{argval}[idx].get()"
+            argval = f"{argval}.get()"
             jsvalIndex = f"{i} + idx"
         else:
             jsvalIndex = f"{i}"
@@ -8662,8 +8662,9 @@ class CallbackMember(CGNativeMember):
             successCode="",
             pre="")
         if arg.variadic:
+            argname = arg.identifier.name
             conversion = (
-                f"for idx in 0..{arg.identifier.name}.len() {{\n"
+                f"for (idx, {argname}) in {argname}.iter().enumerate() {{\n"
                 f"{CGIndenter(CGGeneric(conversion)).define()}\n}}"
             )
         elif arg.optional and not arg.defaultValue:


### PR DESCRIPTION
This replaces uses of our custom RootedVec type that were storing JS GC values with stack rooting that is better integrated with the engine. This ensures that storing nursery-allocated objects in these vectors is handled correctly during GC, unlike our RootedVec implementation which trips an assertion in debug mozjs builds.

Testing: No observable difference in non-mozjs builds.
Fixes: part of #40141
