### PR TITLE
Plumb accessibility tree updates from layout to embedder

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -23,6 +23,10 @@ name = "accesskit"
 version = "0.21.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf203f9d3bd8f29f98833d1fbef628df18f759248a547e7e01cfbf63cda36a99"
+dependencies = [
+ "enumn",
+ "serde",
+]
 
 [[package]]
 name = "accesskit_atspi_common"
@@ -998,9 +1002,9 @@ dependencies = [
 
 [[package]]
 name = "bpaf"
-version = "0.9.21"
+version = "0.9.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03878050524c710d1e1e056e2aae592d65d52b39b237968df2e369e9e4ac1905"
+checksum = "4ffe12d9bbc54238745f1749c5a18dc5759e03c235618dd05554a9be350390b1"
 dependencies = [
  "bpaf_derive",
 ]
@@ -2472,6 +2476,7 @@ dependencies = [
 name = "embedder_traits"
 version = "0.0.1"
 dependencies = [
+ "accesskit",
  "base",
  "bitflags 2.10.0",
  "cookie 0.18.1",
@@ -2548,6 +2553,17 @@ name = "enumflags2_derive"
 version = "0.7.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67c78a4d8fdf9953a5c9d458f9efe940fd97a0cab0941c075a813ac594733827"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "enumn"
+version = "0.1.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f9ed6b3789237c8a0c1c505af1c7eb2c560df6186f01b098c3a1064ea532f38"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4975,6 +4991,7 @@ dependencies = [
 name = "layout"
 version = "0.0.1"
 dependencies = [
+ "accesskit",
  "app_units",
  "atomic_refcell",
  "base",
@@ -5133,6 +5150,7 @@ dependencies = [
 name = "libservo"
 version = "0.0.1"
 dependencies = [
+ "accesskit",
  "arboard",
  "background_hang_monitor",
  "base",
@@ -7858,6 +7876,7 @@ dependencies = [
 name = "script_traits"
 version = "0.0.1"
 dependencies = [
+ "accesskit",
  "background_hang_monitor_api",
  "base",
  "bluetooth_traits",
@@ -8381,6 +8400,7 @@ dependencies = [
 name = "servoshell"
 version = "0.0.4"
 dependencies = [
+ "accesskit",
  "android_logger",
  "backtrace",
  "base",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,7 @@ publish = false
 rust-version = "1.86.0"
 
 [workspace.dependencies]
+accesskit = { version = "0.21.1", features = ["serde"] }
 accountable-refcell = "0.2.2"
 aes = "0.8.4"
 aes-gcm = "0.10.3"

--- a/components/layout/Cargo.toml
+++ b/components/layout/Cargo.toml
@@ -17,6 +17,7 @@ doctest = false
 tracing = ["dep:tracing"]
 
 [dependencies]
+accesskit = { workspace = true }
 app_units = { workspace = true }
 atomic_refcell = { workspace = true }
 base = { workspace = true }

--- a/components/script/messaging.rs
+++ b/components/script/messaging.rs
@@ -104,6 +104,7 @@ impl MixedMessage {
                 ScriptThreadMessage::EmbedderControlResponse(id, _) => Some(id.pipeline_id),
                 ScriptThreadMessage::SetUserContents(..) => None,
                 ScriptThreadMessage::DestroyUserContentManager(..) => None,
+                ScriptThreadMessage::AccessibilityTreeUpdate(..) => None,
             },
             MixedMessage::FromScript(inner_msg) => match inner_msg {
                 MainThreadScriptMsg::Common(CommonScriptMsg::Task(_, _, pipeline_id, _)) => {

--- a/components/script/script_thread.rs
+++ b/components/script/script_thread.rs
@@ -1923,6 +1923,11 @@ impl ScriptThread {
                     .borrow_mut()
                     .remove(&user_content_manager_id);
             },
+            ScriptThreadMessage::AccessibilityTreeUpdate(webview_id, tree_update) => {
+                let _ = self.senders.pipeline_to_embedder_sender.send(
+                    EmbedderMsg::AccessibilityTreeUpdate(webview_id, tree_update),
+                );
+            },
         }
     }
 

--- a/components/servo/Cargo.toml
+++ b/components/servo/Cargo.toml
@@ -73,6 +73,7 @@ webxr = [
 ]
 
 [dependencies]
+accesskit = { workspace = true }
 background_hang_monitor = { path = "../background_hang_monitor" }
 base = { workspace = true }
 bitflags = { workspace = true }

--- a/components/servo/lib.rs
+++ b/components/servo/lib.rs
@@ -26,6 +26,7 @@ mod webview_delegate;
 
 // These are Servo's public exports. Everything (apart from a couple exceptions below)
 // should be exported at the root. See <https://github.com/servo/servo/issues/18475>.
+pub use accesskit::{Node as AccessKitNode, TreeUpdate as AccessKitTreeUpdate};
 pub use base::generic_channel::GenericSender;
 pub use base::id::WebViewId;
 pub use compositing::WebRenderDebugOption;

--- a/components/servo/lib.rs
+++ b/components/servo/lib.rs
@@ -26,7 +26,7 @@ mod webview_delegate;
 
 // These are Servo's public exports. Everything (apart from a couple exceptions below)
 // should be exported at the root. See <https://github.com/servo/servo/issues/18475>.
-pub use accesskit::{Node as AccessKitNode, TreeUpdate as AccessKitTreeUpdate};
+pub use accesskit;
 pub use base::generic_channel::GenericSender;
 pub use base::id::WebViewId;
 pub use compositing::WebRenderDebugOption;

--- a/components/servo/servo.rs
+++ b/components/servo/servo.rs
@@ -638,6 +638,13 @@ impl ServoInner {
                     warn!("Failed to respond to GetScreenMetrics: {error}");
                 }
             },
+            EmbedderMsg::AccessibilityTreeUpdate(webview_id, tree_update) => {
+                if let Some(webview) = self.get_webview_handle(webview_id) {
+                    webview
+                        .delegate()
+                        .notify_accessibility_tree_update(webview, tree_update);
+                }
+            },
         }
     }
 }

--- a/components/servo/webview_delegate.rs
+++ b/components/servo/webview_delegate.rs
@@ -974,6 +974,14 @@ pub trait WebViewDelegate {
     /// A console message was logged by content in this [`WebView`].
     /// <https://developer.mozilla.org/en-US/docs/Web/API/Console_API>
     fn show_console_message(&self, _webview: WebView, _level: ConsoleLogLevel, _message: String) {}
+
+    /// There are new accessibility tree updates from this [`WebView`].
+    fn notify_accessibility_tree_update(
+        &self,
+        _webview: WebView,
+        _tree_update: accesskit::TreeUpdate,
+    ) {
+    }
 }
 
 pub(crate) struct DefaultWebViewDelegate;

--- a/components/shared/embedder/Cargo.toml
+++ b/components/shared/embedder/Cargo.toml
@@ -18,6 +18,7 @@ baked-default-resources = []
 gamepad = []
 
 [dependencies]
+accesskit = { workspace = true }
 base = { workspace = true }
 bitflags = { workspace = true }
 cookie = { workspace = true }

--- a/components/shared/embedder/lib.rs
+++ b/components/shared/embedder/lib.rs
@@ -531,6 +531,8 @@ pub enum EmbedderMsg {
     /// Inform the embedding layer that a particular `InputEvent` was handled by Servo
     /// and the embedder can continue processing it, if necessary.
     InputEventHandled(WebViewId, InputEventId, InputEventResult),
+    /// Send the embedder an accessibility tree update.
+    AccessibilityTreeUpdate(WebViewId, accesskit::TreeUpdate),
 }
 
 impl Debug for EmbedderMsg {

--- a/components/shared/script/Cargo.toml
+++ b/components/shared/script/Cargo.toml
@@ -16,6 +16,7 @@ bluetooth = ["bluetooth_traits"]
 webgpu = ["webgpu_traits"]
 
 [dependencies]
+accesskit = { workspace = true }
 background_hang_monitor_api = { workspace = true }
 base = { workspace = true }
 bluetooth_traits = { workspace = true, optional = true }

--- a/components/shared/script/lib.rs
+++ b/components/shared/script/lib.rs
@@ -305,6 +305,8 @@ pub enum ScriptThreadMessage {
     /// Release all data for the given `UserContentManagerId` from the `ScriptThread`'s
     /// `user_contents_for_manager_id` map.
     DestroyUserContentManager(UserContentManagerId),
+    /// Send the embedder an accessibility tree update.
+    AccessibilityTreeUpdate(WebViewId, accesskit::TreeUpdate),
 }
 
 impl fmt::Debug for ScriptThreadMessage {

--- a/ports/servoshell/Cargo.toml
+++ b/ports/servoshell/Cargo.toml
@@ -56,6 +56,7 @@ webgpu = ["libservo/webgpu"]
 webxr = ["libservo/webxr"]
 
 [dependencies]
+accesskit = { workspace = true }
 bpaf = { version = "0.9.21", features = ["derive"] }
 cfg-if = { workspace = true }
 crossbeam-channel = { workspace = true }

--- a/ports/servoshell/desktop/app.rs
+++ b/ports/servoshell/desktop/app.rs
@@ -213,7 +213,7 @@ impl ApplicationHandler<AppEvent> for App {
             .and_then(|window_id| state.window(ServoShellWindowId::from(u64::from(window_id))))
         {
             if let Some(headed_window) = window.platform_window().as_headed_window() {
-                headed_window.handle_winit_app_event(app_event);
+                headed_window.handle_winit_app_event(&window, app_event);
             }
         }
 

--- a/ports/servoshell/desktop/gui.rs
+++ b/ports/servoshell/desktop/gui.rs
@@ -609,10 +609,7 @@ impl Gui {
         self.context.egui_ctx.set_zoom_factor(factor);
     }
 
-    pub(crate) fn notify_accessibility_tree_update(
-        &mut self,
-        _updater: impl FnOnce() -> accesskit::TreeUpdate,
-    ) {
+    pub(crate) fn notify_accessibility_tree_update(&mut self, _tree_update: accesskit::TreeUpdate) {
         // TODO(#41930): Forward this update to `self.context.egui_winit.accesskit`
     }
 }

--- a/ports/servoshell/desktop/gui.rs
+++ b/ports/servoshell/desktop/gui.rs
@@ -608,6 +608,13 @@ impl Gui {
     pub(crate) fn set_zoom_factor(&self, factor: f32) {
         self.context.egui_ctx.set_zoom_factor(factor);
     }
+
+    pub(crate) fn notify_accessibility_tree_update(
+        &mut self,
+        _updater: impl FnOnce() -> accesskit::TreeUpdate,
+    ) {
+        // TODO(#41930): Forward this update to `self.context.egui_winit.accesskit`
+    }
 }
 
 fn embedder_image_to_egui_image(image: &Image) -> egui::ColorImage {

--- a/ports/servoshell/desktop/headed_window.rs
+++ b/ports/servoshell/desktop/headed_window.rs
@@ -1141,7 +1141,7 @@ impl PlatformWindow for HeadedWindow {
     ) {
         self.gui
             .borrow_mut()
-            .notify_accessibility_tree_update(|| tree_update);
+            .notify_accessibility_tree_update(tree_update);
     }
 }
 

--- a/ports/servoshell/desktop/headed_window.rs
+++ b/ports/servoshell/desktop/headed_window.rs
@@ -756,8 +756,10 @@ impl HeadedWindow {
         }
     }
 
-    pub(crate) fn handle_winit_app_event(&self, app_event: AppEvent) {
+    pub(crate) fn handle_winit_app_event(&self, _window: &ServoShellWindow, app_event: AppEvent) {
         if let AppEvent::Accessibility(ref event) = app_event {
+            // TODO(#41930): Forward accesskit_winit::WindowEvent events to Servo where appropriate
+
             if self
                 .gui
                 .borrow_mut()
@@ -1130,6 +1132,16 @@ impl PlatformWindow for HeadedWindow {
     fn show_console_message(&self, level: servo::ConsoleLogLevel, message: &str) {
         println!("{message}");
         log::log!(level.into(), "{message}");
+    }
+
+    fn notify_accessibility_tree_update(
+        &self,
+        _webview: WebView,
+        tree_update: accesskit::TreeUpdate,
+    ) {
+        self.gui
+            .borrow_mut()
+            .notify_accessibility_tree_update(|| tree_update);
     }
 }
 

--- a/ports/servoshell/running_app_state.rs
+++ b/ports/servoshell/running_app_state.rs
@@ -819,6 +819,15 @@ impl WebViewDelegate for RunningAppState {
         self.platform_window_for_webview_id(webview.id())
             .show_console_message(level, &message);
     }
+
+    fn notify_accessibility_tree_update(
+        &self,
+        webview: WebView,
+        tree_update: accesskit::TreeUpdate,
+    ) {
+        self.platform_window_for_webview_id(webview.id())
+            .notify_accessibility_tree_update(webview, tree_update);
+    }
 }
 
 struct ServoShellServoDelegate;

--- a/ports/servoshell/window.rs
+++ b/ports/servoshell/window.rs
@@ -433,4 +433,6 @@ pub(crate) trait PlatformWindow {
     fn as_headed_window(&self) -> Option<&crate::egl::app::EmbeddedPlatformWindow> {
         None
     }
+
+    fn notify_accessibility_tree_update(&self, _: WebView, _: accesskit::TreeUpdate) {}
 }


### PR DESCRIPTION
this patch adds some new methods and messages that allow layout to send the embedder [accessibility tree updates](https://docs.rs/accesskit/0.22.0/accesskit/struct.TreeUpdate.html):

- layout —[ ScriptThreadMessage::AccessibilityTreeUpdate ]→ script
- script —[ EmbedderMsg::AccessibilityTreeUpdate ]→ libservo
- libservo —[ WebViewDelegate::notify_accessibility_tree_update() ]→ servoshell
- servoshell —[ PlatformWindow::notify_accessibility_tree_update() ]→ servoshell
- servoshell —[ Gui::notify_accessibility_tree_update() ]→ servoshell

Testing: none yet, no functional change
Fixes: part of #4344 