### PR TITLE
devtools: Handle the `setBreakpoint` message.

### DIFF
--- a/components/devtools/actors/breakpoint.rs
+++ b/components/devtools/actors/breakpoint.rs
@@ -2,12 +2,18 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
+use base::generic_channel::channel;
+use devtools_traits::DevtoolScriptControlMsg;
+
 use crate::actor::{Actor, ActorEncode, ActorError, ActorRegistry};
+use crate::actors::browsing_context::BrowsingContextActor;
+use crate::actors::thread::ThreadActor;
 use crate::protocol::ClientRequest;
 use crate::{ActorMsg, EmptyReplyMsg};
 
 pub(crate) struct BreakpointListActor {
     name: String,
+    browsing_context: String,
 }
 
 impl Actor for BreakpointListActor {
@@ -18,9 +24,9 @@ impl Actor for BreakpointListActor {
     fn handle_message(
         &self,
         request: ClientRequest,
-        _registry: &crate::actor::ActorRegistry,
+        registry: &crate::actor::ActorRegistry,
         msg_type: &str,
-        _msg: &serde_json::Map<String, serde_json::Value>,
+        msg: &serde_json::Map<String, serde_json::Value>,
         _stream_id: crate::StreamId,
     ) -> Result<(), ActorError> {
         match msg_type {
@@ -28,6 +34,43 @@ impl Actor for BreakpointListActor {
             // Seems to be infallible, unlike the thread actor’s `setBreakpoint`.
             // <https://firefox-source-docs.mozilla.org/devtools/backend/protocol.html#breakpoints>
             "setBreakpoint" => {
+                let location = msg.get("location");
+                let column = location
+                    .and_then(|location| location.get("column"))
+                    .and_then(|column| column.as_number())
+                    .and_then(|column| column.as_u64())
+                    .ok_or(ActorError::Internal)?;
+                let line = location
+                    .and_then(|location| location.get("line"))
+                    .and_then(|line| line.as_number())
+                    .and_then(|line| line.as_u64())
+                    .ok_or(ActorError::Internal)?;
+                let source_url = location
+                    .and_then(|location| location.get("sourceUrl"))
+                    .and_then(|source_url| source_url.as_str())
+                    .ok_or(ActorError::Internal)?;
+
+                let browsing_context =
+                    registry.find::<BrowsingContextActor>(&self.browsing_context);
+                let thread = registry.find::<ThreadActor>(&browsing_context.thread);
+                let source = thread
+                    .source_manager
+                    .find_source(registry, source_url)
+                    .ok_or(ActorError::Internal)?;
+                let offset = source.find_offset(column as u32, line as u32);
+
+                // set-breakpoint
+                let (tx, rx) = channel().ok_or(ActorError::Internal)?;
+                source
+                    .script_sender
+                    .send(DevtoolScriptControlMsg::SetBreakpoint(
+                        source.spidermonkey_id,
+                        offset,
+                        tx,
+                    ))
+                    .map_err(|_| ActorError::Internal)?;
+                let _ = rx.recv().map_err(|_| ActorError::Internal)?;
+
                 let msg = EmptyReplyMsg { from: self.name() };
                 request.reply_final(&msg)?
             },
@@ -46,8 +89,11 @@ impl Actor for BreakpointListActor {
 }
 
 impl BreakpointListActor {
-    pub fn new(name: String) -> Self {
-        Self { name }
+    pub fn new(name: String, browsing_context: String) -> Self {
+        Self {
+            name,
+            browsing_context,
+        }
     }
 }
 

--- a/components/devtools/actors/watcher.rs
+++ b/components/devtools/actors/watcher.rs
@@ -420,7 +420,10 @@ impl WatcherActor {
             TargetConfigurationActor::new(actors.new_name::<TargetConfigurationActor>());
         let thread_configuration =
             ThreadConfigurationActor::new(actors.new_name::<ThreadConfigurationActor>());
-        let breakpoint_list = BreakpointListActor::new(actors.new_name::<BreakpointListActor>());
+        let breakpoint_list = BreakpointListActor::new(
+            actors.new_name::<BreakpointListActor>(),
+            browsing_context_actor.clone(),
+        );
 
         let watcher = Self {
             name: actors.new_name::<WatcherActor>(),

--- a/components/script/dom/debuggerglobalscope.rs
+++ b/components/script/dom/debuggerglobalscope.rs
@@ -192,17 +192,13 @@ impl DebuggerGlobalScope {
         &self,
         can_gc: CanGc,
         spidermonkey_id: u32,
+        script_id: u32,
         offset: u32,
-        result_sender: GenericSender<bool>,
     ) {
-        assert!(
-            self.set_breakpoint_result_sender
-                .replace(Some(result_sender))
-                .is_none()
-        );
         let event = DomRoot::upcast::<Event>(DebuggerSetBreakpointEvent::new(
             self.upcast(),
             spidermonkey_id,
+            script_id,
             offset,
             can_gc,
         ));
@@ -323,6 +319,7 @@ impl DebuggerGlobalScopeMethods<crate::DomTypeHolder> for DebuggerGlobalScope {
             result
                 .into_iter()
                 .map(|entry| devtools_traits::RecommendedBreakpointLocation {
+                    script_id: entry.scriptId,
                     offset: entry.offset,
                     line_number: entry.lineNumber,
                     column_number: entry.columnNumber,
@@ -330,14 +327,5 @@ impl DebuggerGlobalScopeMethods<crate::DomTypeHolder> for DebuggerGlobalScope {
                 })
                 .collect(),
         );
-    }
-
-    fn SetBreakpointResult(&self, event: &DebuggerSetBreakpointEvent, result: bool) {
-        info!("SetBreakpointResult: {event:?} {result:?}");
-        let sender = self
-            .set_breakpoint_result_sender
-            .take()
-            .expect("Guaranteed by Self::fire_set_breakpoint()");
-        let _ = sender.send(result);
     }
 }

--- a/components/script/dom/debuggerglobalscope.rs
+++ b/components/script/dom/debuggerglobalscope.rs
@@ -30,6 +30,7 @@ use crate::dom::bindings::error::report_pending_exception;
 use crate::dom::bindings::inheritance::Castable;
 use crate::dom::bindings::root::DomRoot;
 use crate::dom::bindings::utils::define_all_exposed_interfaces;
+use crate::dom::debuggersetbreakpointevent::DebuggerSetBreakpointEvent;
 use crate::dom::globalscope::GlobalScope;
 use crate::dom::types::{DebuggerAddDebuggeeEvent, DebuggerGetPossibleBreakpointsEvent, Event};
 #[cfg(feature = "testbinding")]
@@ -49,6 +50,8 @@ pub(crate) struct DebuggerGlobalScope {
     #[no_trace]
     get_possible_breakpoints_result_sender:
         RefCell<Option<GenericSender<Vec<devtools_traits::RecommendedBreakpointLocation>>>>,
+    #[no_trace]
+    set_breakpoint_result_sender: RefCell<Option<GenericSender<bool>>>,
 }
 
 impl DebuggerGlobalScope {
@@ -95,6 +98,7 @@ impl DebuggerGlobalScope {
             ),
             devtools_to_script_sender,
             get_possible_breakpoints_result_sender: RefCell::new(None),
+            set_breakpoint_result_sender: RefCell::new(None),
         });
         let global = DebuggerGlobalScopeBinding::Wrap::<crate::DomTypeHolder>(cx.into(), global);
 
@@ -181,6 +185,30 @@ impl DebuggerGlobalScope {
         assert!(
             DomRoot::upcast::<Event>(event).fire(self.upcast(), can_gc),
             "Guaranteed by DebuggerGetPossibleBreakpointsEvent::new"
+        );
+    }
+
+    pub(crate) fn fire_set_breakpoint(
+        &self,
+        can_gc: CanGc,
+        spidermonkey_id: u32,
+        offset: u32,
+        result_sender: GenericSender<bool>,
+    ) {
+        assert!(
+            self.set_breakpoint_result_sender
+                .replace(Some(result_sender))
+                .is_none()
+        );
+        let event = DomRoot::upcast::<Event>(DebuggerSetBreakpointEvent::new(
+            self.upcast(),
+            spidermonkey_id,
+            offset,
+            can_gc,
+        ));
+        assert!(
+            DomRoot::upcast::<Event>(event).fire(self.upcast(), can_gc),
+            "Guaranteed by DebuggerSetBreakpointEvent::new"
         );
     }
 }
@@ -302,5 +330,14 @@ impl DebuggerGlobalScopeMethods<crate::DomTypeHolder> for DebuggerGlobalScope {
                 })
                 .collect(),
         );
+    }
+
+    fn SetBreakpointResult(&self, event: &DebuggerSetBreakpointEvent, result: bool) {
+        info!("SetBreakpointResult: {event:?} {result:?}");
+        let sender = self
+            .set_breakpoint_result_sender
+            .take()
+            .expect("Guaranteed by Self::fire_set_breakpoint()");
+        let _ = sender.send(result);
     }
 }

--- a/components/script/dom/debuggersetbreakpointevent.rs
+++ b/components/script/dom/debuggersetbreakpointevent.rs
@@ -19,6 +19,7 @@ use crate::script_runtime::CanGc;
 pub(crate) struct DebuggerSetBreakpointEvent {
     event: Event,
     spidermonkey_id: u32,
+    script_id: u32,
     offset: u32,
 }
 
@@ -26,12 +27,14 @@ impl DebuggerSetBreakpointEvent {
     pub(crate) fn new(
         debugger_global: &GlobalScope,
         spidermonkey_id: u32,
+        script_id: u32,
         offset: u32,
         can_gc: CanGc,
     ) -> DomRoot<Self> {
         let result = Box::new(Self {
             event: Event::new_inherited(),
             spidermonkey_id,
+            script_id,
             offset,
         });
         let result = reflect_dom_object(result, debugger_global, can_gc);
@@ -49,6 +52,10 @@ impl DebuggerSetBreakpointEventMethods<crate::DomTypeHolder> for DebuggerSetBrea
         self.spidermonkey_id
     }
 
+    fn ScriptId(&self) -> u32 {
+        self.script_id
+    }
+
     fn Offset(&self) -> u32 {
         self.offset
     }
@@ -62,6 +69,7 @@ impl Debug for DebuggerSetBreakpointEvent {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("DebuggerSetBreakpointEvent")
             .field("spidermonkey_id", &self.spidermonkey_id)
+            .field("script_id", &self.script_id)
             .field("offset", &self.offset)
             .finish()
     }

--- a/components/script/dom/debuggersetbreakpointevent.rs
+++ b/components/script/dom/debuggersetbreakpointevent.rs
@@ -1,0 +1,68 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+use std::fmt::Debug;
+
+use dom_struct::dom_struct;
+
+use crate::dom::bindings::codegen::Bindings::DebuggerSetBreakpointEventBinding::DebuggerSetBreakpointEventMethods;
+use crate::dom::bindings::codegen::Bindings::EventBinding::Event_Binding::EventMethods;
+use crate::dom::bindings::reflector::reflect_dom_object;
+use crate::dom::bindings::root::DomRoot;
+use crate::dom::event::Event;
+use crate::dom::types::GlobalScope;
+use crate::script_runtime::CanGc;
+
+#[dom_struct]
+/// Event for Rust → JS calls in [`crate::dom::DebuggerGlobalScope`].
+pub(crate) struct DebuggerSetBreakpointEvent {
+    event: Event,
+    spidermonkey_id: u32,
+    offset: u32,
+}
+
+impl DebuggerSetBreakpointEvent {
+    pub(crate) fn new(
+        debugger_global: &GlobalScope,
+        spidermonkey_id: u32,
+        offset: u32,
+        can_gc: CanGc,
+    ) -> DomRoot<Self> {
+        let result = Box::new(Self {
+            event: Event::new_inherited(),
+            spidermonkey_id,
+            offset,
+        });
+        let result = reflect_dom_object(result, debugger_global, can_gc);
+        result
+            .event
+            .init_event("setBreakpoint".into(), false, false);
+
+        result
+    }
+}
+
+impl DebuggerSetBreakpointEventMethods<crate::DomTypeHolder> for DebuggerSetBreakpointEvent {
+    // check-tidy: no specs after this line
+    fn SpidermonkeyId(&self) -> u32 {
+        self.spidermonkey_id
+    }
+
+    fn Offset(&self) -> u32 {
+        self.offset
+    }
+
+    fn IsTrusted(&self) -> bool {
+        self.event.IsTrusted()
+    }
+}
+
+impl Debug for DebuggerSetBreakpointEvent {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("DebuggerSetBreakpointEvent")
+            .field("spidermonkey_id", &self.spidermonkey_id)
+            .field("offset", &self.offset)
+            .finish()
+    }
+}

--- a/components/script/dom/mod.rs
+++ b/components/script/dom/mod.rs
@@ -263,6 +263,7 @@ pub(crate) mod datatransferitemlist;
 pub(crate) mod debuggeradddebuggeeevent;
 pub(crate) mod debuggergetpossiblebreakpointsevent;
 pub(crate) mod debuggerglobalscope;
+pub(crate) mod debuggersetbreakpointevent;
 pub(crate) mod decompressionstream;
 pub(crate) mod defaultteereadrequest;
 pub(crate) mod defaultteeunderlyingsource;

--- a/components/script/script_thread.rs
+++ b/components/script/script_thread.rs
@@ -2162,6 +2162,14 @@ impl ScriptThread {
                     result_sender,
                 );
             },
+            DevtoolScriptControlMsg::SetBreakpoint(spidermonkey_id, offset, result_sender) => {
+                self.debugger_global.fire_set_breakpoint(
+                    CanGc::from_cx(cx),
+                    spidermonkey_id,
+                    offset,
+                    result_sender,
+                );
+            },
         }
     }
 

--- a/components/script/script_thread.rs
+++ b/components/script/script_thread.rs
@@ -2162,12 +2162,12 @@ impl ScriptThread {
                     result_sender,
                 );
             },
-            DevtoolScriptControlMsg::SetBreakpoint(spidermonkey_id, offset, result_sender) => {
+            DevtoolScriptControlMsg::SetBreakpoint(spidermonkey_id, script_id, offset) => {
                 self.debugger_global.fire_set_breakpoint(
                     CanGc::from_cx(cx),
                     spidermonkey_id,
+                    script_id,
                     offset,
-                    result_sender,
                 );
             },
         }

--- a/components/script_bindings/webidls/DebuggerGetPossibleBreakpointsEvent.webidl
+++ b/components/script_bindings/webidls/DebuggerGetPossibleBreakpointsEvent.webidl
@@ -17,6 +17,7 @@ partial interface DebuggerGlobalScope {
 
 // <https://firefox-source-docs.mozilla.org/js/Debugger/Debugger.Script.html#getpossiblebreakpoints-query>
 dictionary RecommendedBreakpointLocation {
+    required unsigned long scriptId;
     required unsigned long offset;
     required unsigned long lineNumber;
     required unsigned long columnNumber;

--- a/components/script_bindings/webidls/DebuggerSetBreakpointEvent.webidl
+++ b/components/script_bindings/webidls/DebuggerSetBreakpointEvent.webidl
@@ -1,0 +1,17 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+// This interface is entirely internal to Servo, and should not be accessible to
+// web pages.
+[Exposed=DebuggerGlobalScope]
+interface DebuggerSetBreakpointEvent : Event {
+    readonly attribute unsigned long spidermonkeyId;
+    readonly attribute unsigned long offset;
+};
+
+partial interface DebuggerGlobalScope {
+    undefined setBreakpointResult(
+        DebuggerSetBreakpointEvent event,
+        boolean result);
+};

--- a/components/script_bindings/webidls/DebuggerSetBreakpointEvent.webidl
+++ b/components/script_bindings/webidls/DebuggerSetBreakpointEvent.webidl
@@ -7,11 +7,6 @@
 [Exposed=DebuggerGlobalScope]
 interface DebuggerSetBreakpointEvent : Event {
     readonly attribute unsigned long spidermonkeyId;
+    readonly attribute unsigned long scriptId;
     readonly attribute unsigned long offset;
-};
-
-partial interface DebuggerGlobalScope {
-    undefined setBreakpointResult(
-        DebuggerSetBreakpointEvent event,
-        boolean result);
 };

--- a/components/shared/devtools/lib.rs
+++ b/components/shared/devtools/lib.rs
@@ -308,6 +308,7 @@ pub enum DevtoolScriptControlMsg {
     HighlightDomNode(PipelineId, Option<String>),
 
     GetPossibleBreakpoints(u32, GenericSender<Vec<RecommendedBreakpointLocation>>),
+    SetBreakpoint(u32, u32, GenericSender<bool>),
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize)]

--- a/components/shared/devtools/lib.rs
+++ b/components/shared/devtools/lib.rs
@@ -308,7 +308,7 @@ pub enum DevtoolScriptControlMsg {
     HighlightDomNode(PipelineId, Option<String>),
 
     GetPossibleBreakpoints(u32, GenericSender<Vec<RecommendedBreakpointLocation>>),
-    SetBreakpoint(u32, u32, GenericSender<bool>),
+    SetBreakpoint(u32, u32, u32),
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -617,6 +617,7 @@ pub struct SourceInfo {
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct RecommendedBreakpointLocation {
+    pub script_id: u32,
     pub offset: u32,
     pub line_number: u32,
     pub column_number: u32,

--- a/resources/debugger.js
+++ b/resources/debugger.js
@@ -50,3 +50,23 @@ addEventListener("getPossibleBreakpoints", event => {
     }
     getPossibleBreakpointsResult(event, getPossibleBreakpointsRecursive(script));
 });
+
+addEventListener("setBreakpoint", event => {
+    const {spidermonkeyId, offset} = event;
+    const script = sourceIdsToScripts.get(spidermonkeyId);
+    function breakpointHandler(...args) {
+        // TODO: notify script to pause
+        // tell spidermonkey to pause
+       return {throw: "1"}
+    }
+
+    function getPossibleBreakpointsRecursive(script) {
+        script.setBreakpoint(offset, { hit: breakpointHandler })
+        for (const child of script.getChildScripts()) {
+            getPossibleBreakpointsRecursive(child)
+        }
+    }
+
+    getPossibleBreakpointsRecursive(script);
+    setBreakpointResult(event, true)
+});

--- a/resources/debugger.js
+++ b/resources/debugger.js
@@ -54,6 +54,7 @@ addEventListener("getPossibleBreakpoints", event => {
 addEventListener("setBreakpoint", event => {
     const {spidermonkeyId, offset} = event;
     const script = sourceIdsToScripts.get(spidermonkeyId);
+    // <https://firefox-source-docs.mozilla.org/js/Debugger/Conventions.html#resumption-values>
     function breakpointHandler(...args) {
         // TODO: notify script to pause
         // tell spidermonkey to pause


### PR DESCRIPTION
Listen for `setBreakpoint` on `debugger.js` and add the relevant WebIDLs and Servo counterparts to trigger this event and notify SpiderMonkey.

Implement `find_source` for `SourceManager` and `find_offset` for `SourceActor`.

Testing: Manual testing and `./mach test-devtools` (note, the latter seems to have some failing tests, we are investigating this, but this patch doesn't add any new failure).
Fixes: Part of #36027
