### PR TITLE
script: Add selection behavior for double and triple click in text fields

### DIFF
--- a/tests/wpt/mozilla/meta/MANIFEST.json
+++ b/tests/wpt/mozilla/meta/MANIFEST.json
@@ -12928,6 +12928,15 @@
       }
      ]
     ],
+    "double-and-triple-click-in-text-input.html": [
+     "d7437745507c6cf0570de6b382d56a9502a7b005",
+     [
+      null,
+      {
+       "testdriver": true
+      }
+     ]
+    ],
     "input-events-textarea-cut-paste.html": [
      "7e1151d222b5a5210921345a3e60434194cd1794",
      [

--- a/tests/wpt/mozilla/tests/input-events/double-and-triple-click-in-text-input.html
+++ b/tests/wpt/mozilla/tests/input-events/double-and-triple-click-in-text-input.html
@@ -1,0 +1,113 @@
+<!DOCTYPE html>
+<title>Clicking in &lt;input type=text&gt; should move the edit point</title>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/resources/testdriver.js"></script>
+<script src="/resources/testdriver-actions.js"></script>
+<script src="/resources/testdriver-vendor.js"></script>
+<link rel="stylesheet" type="text/css" href="/fonts/ahem.css" />
+
+<input id="inputTarget" style="font: 50px/1 Ahem;" value="123456 ABCDEF">
+
+<textarea id="textareaTarget" style="font: 50px/1 Ahem;">
+    LOL AB
+    LOL AB
+</textarea>
+
+<script>
+
+// Get the bounding client rect of the given node, but give it a bit
+// of padding to account for borders and padding added by the text input.
+function getPaddedBoundingClientRect(node) {
+  const padding = 5;
+  let rectangle = node.getBoundingClientRect()
+  rectangle.x += padding;
+  rectangle.y += padding;
+  rectangle.width -= (padding * 2);
+  rectangle.height -= (padding * 2);
+  return rectangle;
+}
+
+promise_test(async test => {
+    let targetRect = getPaddedBoundingClientRect(inputTarget);
+    let middleOfBlock = targetRect.top + (targetRect.height / 2);
+
+    await new test_driver.Actions()
+      .pointerMove(targetRect.left + 25, middleOfBlock)
+      .pointerDown().pointerUp()
+      .pointerDown().pointerUp()
+          .send();
+    assert_equals(inputTarget.selectionStart, 0);
+    assert_equals(inputTarget.selectionEnd, 6);
+
+    inputTarget.setSelectionRange(0, 0);
+
+    // Double clicking on whitespace selects first word, but not whitespace.
+    await new test_driver.Actions()
+      .pointerMove(targetRect.left + (50 * 5) + 25, middleOfBlock)
+      .pointerDown().pointerUp()
+      .pointerDown().pointerUp()
+          .send();
+    assert_equals(inputTarget.selectionStart, 0);
+    assert_equals(inputTarget.selectionEnd, 6);
+
+    inputTarget.setSelectionRange(0, 0);
+
+    // Triple clicking on line selects whole line.
+    await new test_driver.Actions()
+      .pointerMove(targetRect.left + 40, middleOfBlock)
+      .pointerDown().pointerUp()
+      .pointerDown().pointerUp()
+      .pointerDown().pointerUp()
+          .send();
+    assert_equals(inputTarget.selectionStart, 0);
+    assert_equals(inputTarget.selectionEnd, 13);
+}, 'Double and triple click in <input type=text> work as expected');
+
+promise_test(async test => {
+    let targetRect = getPaddedBoundingClientRect(textareaTarget);
+
+    // Double clicking on whitespace preceding line select whitespace and first word.
+    await new test_driver.Actions()
+      .pointerMove(targetRect.left + 25, targetRect.top + 25)
+      .pointerDown().pointerUp()
+      .pointerDown().pointerUp()
+          .send();
+    assert_equals(textareaTarget.selectionStart, 0);
+    assert_equals(textareaTarget.selectionEnd, 7);
+
+    textareaTarget.setSelectionRange(0, 0);
+
+    // Triple clicking on word selects entire line.
+    await new test_driver.Actions()
+      .pointerMove(targetRect.left + 25, targetRect.top + 25)
+      .pointerDown().pointerUp()
+      .pointerDown().pointerUp()
+      .pointerDown().pointerUp()
+          .send();
+    assert_equals(textareaTarget.selectionStart, 0);
+    assert_equals(textareaTarget.selectionEnd, 10);
+
+    textareaTarget.setSelectionRange(0, 0);
+
+    // Double clicking on word in second line selects word.
+    await new test_driver.Actions()
+      .pointerMove(targetRect.left + (5 * 50), targetRect.top + 75)
+      .pointerDown().pointerUp()
+      .pointerDown().pointerUp()
+          .send();
+    assert_equals(textareaTarget.selectionStart, 15);
+    assert_equals(textareaTarget.selectionEnd, 18);
+
+    // Triple clicking on line in second line selects entire line.
+    await new test_driver.Actions()
+      .pointerMove(targetRect.left + (5 * 50), targetRect.top + 75)
+      .pointerDown().pointerUp()
+      .pointerDown().pointerUp()
+      .pointerDown().pointerUp()
+          .send();
+    assert_equals(textareaTarget.selectionStart, 11);
+    assert_equals(textareaTarget.selectionEnd, 21);
+}, 'Double and triple click in <textarea> work as expected');
+</script>
+</script>


### PR DESCRIPTION
This change adds support for updating the selection when double and
triple clicking in text fields. Double clicking selects the most
relevant word while triple clicking selects the entire line.

Testing: This change adds unit tests for `Rope` as well as a
Servo-specific WPT style test. These behaviors are platform
dependent.
