### PR TITLE
Properly implement flex formatting context style repair

### DIFF
--- a/components/layout/flexbox/mod.rs
+++ b/components/layout/flexbox/mod.rs
@@ -146,9 +146,17 @@ impl FlexContainer {
         }
     }
 
-    pub(crate) fn repair_style(&mut self, new_style: &ServoArc<ComputedValues>) {
+    pub(crate) fn repair_style(
+        &mut self,
+        context: &SharedStyleContext,
+        node: &ServoThreadSafeLayoutNode,
+        new_style: &ServoArc<ComputedValues>,
+    ) {
         self.config = FlexContainerConfig::new(new_style);
         self.style = new_style.clone();
+        for kid in self.children.iter_mut() {
+            kid.borrow_mut().repair_style(context, node, new_style);
+        }
     }
 }
 

--- a/components/layout/formatting_contexts.rs
+++ b/components/layout/formatting_contexts.rs
@@ -253,7 +253,7 @@ impl IndependentFormattingContext {
                 block_formatting_context.repair_style(node, new_style);
             },
             IndependentFormattingContextContents::Flex(flex_container) => {
-                flex_container.repair_style(new_style)
+                flex_container.repair_style(context, node, new_style)
             },
             IndependentFormattingContextContents::Grid(taffy_container) => {
                 taffy_container.repair_style(new_style)

--- a/tests/wpt/tests/css/css-display/display-flex-inside-parent-ref.html
+++ b/tests/wpt/tests/css/css-display/display-flex-inside-parent-ref.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<head>
+    <meta charset="utf-8">
+    <title>CSS Test: display: flex inside a parent container</title>
+    <link rel="author" title="Shubham Gupta" href="mailto:shubham.gupta@chromium.org">
+    <link rel="help" href="https://www.w3.org/TR/css-flexbox-1/#flex-items">
+    <style type="text/css">
+        .overide.current {
+            color: #d8232a
+        }
+
+        .current {
+            display: flex;
+            background: #f4f6f9;
+            color: #008000
+        }
+    </style>
+</head>
+
+<body>
+    <h1>CSS Test: display: flex inside a parent container</h1>
+    <p>Test passes if A is in red color</p>
+    <div class="overide current">A</div>
+</body>
+</html>

--- a/tests/wpt/tests/css/css-display/display-flex-inside-parent.html
+++ b/tests/wpt/tests/css/css-display/display-flex-inside-parent.html
@@ -1,0 +1,36 @@
+<!DOCTYPE html>
+<html class=reftest-wait>
+<head>
+  <meta charset="utf-8">
+  <title>CSS Test: display: flex inside a parent container</title>
+  <link rel="author" title="Shubham Gupta" href="mailto:shubham.gupta@chromium.org">
+  <link rel="help" href="https://www.w3.org/TR/css-flexbox-1/#flex-items">
+  <link rel="match" href="display-flex-inside-parent-ref.html">
+  <script src="/common/reftest-wait.js"></script>
+
+  <style type="text/css">
+    .overide.current {
+      color: #d8232a
+    }
+
+    .current {
+      display: flex;
+      background: #f4f6f9;
+      color: #008000
+    }
+  </style>
+</head>
+
+<body>
+  <h1>CSS Test: display: flex inside a parent container</h1>
+  <p>Test passes if A is in red color</p>
+  <div class=" current">A</div>
+  <script>
+    function runTest() {
+      const text = document.getElementsByClassName("current");
+      text[0].className = "overide current";
+    }
+    onload = () => runTest();
+  </script>
+</body>
+</html>


### PR DESCRIPTION
This repairs the style of children of FlexContainer. 

Reference: https://www.w3.org/TR/css-flexbox-1/#flex-items
Last line of Example 2

<img width="967" height="84" alt="Screenshot from 2026-01-16 14-49-49" src="https://github.com/user-attachments/assets/ef25c017-2eb3-4f47-aee7-be0e04f02412" />


Testing: `wpt/tests/css/css-display/display-flex-inside-parent.html`
Fixes: #41947
