### PR TITLE
devtools: Register workers in workers list, not tabs

### DIFF
--- a/components/devtools/lib.rs
+++ b/components/devtools/lib.rs
@@ -356,7 +356,7 @@ impl DevtoolsInstance {
                 streams: Default::default(),
             };
             let root = actors.find::<RootActor>("root");
-            root.tabs.borrow_mut().push(worker.name.clone());
+            root.workers.borrow_mut().push(worker.name.clone());
 
             self.actor_workers.insert(id, worker_name.clone());
             actors.register(worker);


### PR DESCRIPTION
Devtools tests are failing on `./mach test-devtools`. Regression from #41744 

Testing: Manually tested