### PR TITLE
layout: Properly account for transforms when finding glyph index

### DIFF
--- a/components/script/dom/window.rs
+++ b/components/script/dom/window.rs
@@ -3013,13 +3013,11 @@ impl Window {
         // now.
         let mouse_event = event.downcast::<MouseEvent>()?;
         let point_in_viewport = mouse_event.point_in_viewport()?.map(Au::from_f32_px);
-        let node_origin_in_viewport = node.content_box()?.origin;
-        let point_in_node = (point_in_viewport - node_origin_in_viewport.cast_unit()).to_point();
 
         self.layout_reflow(QueryMsg::TextIndexQuery);
         self.layout
             .borrow()
-            .query_text_index(node.to_trusted_node_address(), point_in_node)
+            .query_text_index(node.to_trusted_node_address(), point_in_viewport)
     }
 
     pub(crate) fn elements_from_point_query(

--- a/components/shared/compositing/display_list.rs
+++ b/components/shared/compositing/display_list.rs
@@ -624,6 +624,20 @@ impl ScrollTree {
             .root_to_node_transform
     }
 
+    /// Find the untransformed offset in the initial containing block of the nearest
+    /// inclusive ancestor reference frame for the given spatial tree node.
+    pub fn reference_frame_offset(&self, node_id: ScrollTreeNodeId) -> LayoutPoint {
+        let mut maybe_node_id = Some(node_id);
+        while let Some(node_id) = maybe_node_id {
+            let node = self.get_node(node_id);
+            if let SpatialTreeNodeInfo::ReferenceFrame(reference_frame) = &node.info {
+                return reference_frame.frame_origin_for_query;
+            }
+            maybe_node_id = node.parent;
+        }
+        Default::default()
+    }
+
     /// Find the cumulative offsets of sticky positioned boxes from the given node up to
     /// the root.
     pub fn cumulative_sticky_offsets(&self, node_id: ScrollTreeNodeId) -> LayoutVector2D {

--- a/tests/wpt/mozilla/meta/MANIFEST.json
+++ b/tests/wpt/mozilla/meta/MANIFEST.json
@@ -12973,6 +12973,15 @@
       }
      ]
     ],
+    "mousedown-edit-point-input-tranformed.html": [
+     "5c7e1e050c3883933dfa6c6c2984d74e3497ef60",
+     [
+      null,
+      {
+       "testdriver": true
+      }
+     ]
+    ],
     "mousedown-edit-point-textarea.html": [
      "a7f67227f48028f9d6fa88d5f92b325c9735710c",
      [

--- a/tests/wpt/mozilla/tests/input-events/mousedown-edit-point-input-tranformed.html
+++ b/tests/wpt/mozilla/tests/input-events/mousedown-edit-point-input-tranformed.html
@@ -1,0 +1,80 @@
+<!DOCTYPE html>
+<title>Clicking in a transformed &lt;input type=text&gt; should move the edit point</title>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/resources/testdriver.js"></script>
+<script src="/resources/testdriver-actions.js"></script>
+<script src="/resources/testdriver-vendor.js"></script>
+<link rel="stylesheet" type="text/css" href="/fonts/ahem.css" />
+
+<div style="padding: 100px">
+    <div style="transform-origin: 0; transform: scale(3); rotate: 90deg;">
+        <input id="target" style="color: rgba(0, 0, 0, 0.2); font: 10px/1 Ahem;" value="123456">
+    </div>
+</div>
+
+<script>
+// Get the bounding client rect of the given node, but give it a bit
+// of padding to account for borders and padding added by the text input.
+function getPaddedBoundingClientRect(node) {
+  const padding = 8;
+  let rectangle = node.getBoundingClientRect()
+  rectangle.x += padding;
+  rectangle.y += padding;
+  rectangle.width -= (padding * 2);
+  rectangle.height -= (padding * 2);
+  return rectangle;
+}
+
+promise_test(async test => {
+    let targetRect = getPaddedBoundingClientRect(target);
+
+    // This is the middle of the character height, but the input is rotated 90
+    // degrees so it is the x-axis.
+    let middleOfCharacterHeight = targetRect.left + (targetRect.width / 2);
+
+    await new test_driver.Actions()
+      .pointerMove(middleOfCharacterHeight, targetRect.top)
+      .pointerDown().pointerUp()
+          .send();
+    assert_equals(target.selectionStart, 0);
+    assert_equals(target.selectionEnd, 0);
+
+    await new test_driver.Actions()
+      .pointerMove(middleOfCharacterHeight, targetRect.top + (10 * 3))
+      .pointerDown().pointerUp()
+          .send();
+    assert_equals(target.selectionStart, 1);
+    assert_equals(target.selectionEnd, 1);
+
+    target.setSelectionRange(0, 0);
+
+    // Click on the right half of a character should move the cursor to the next index.
+    await new test_driver.Actions()
+      .pointerMove(middleOfCharacterHeight, targetRect.top + (7 * 3))
+      .pointerDown().pointerUp()
+          .send();
+    assert_equals(target.selectionStart, 1);
+    assert_equals(target.selectionEnd, 1);
+
+    target.setSelectionRange(0, 0);
+
+    // Click on the right half of a character should move the cursor to the next index.
+    await new test_driver.Actions()
+      .pointerMove(middleOfCharacterHeight, targetRect.top + (10 * 5 * 3))
+      .pointerDown().pointerUp()
+          .send();
+    assert_equals(target.selectionStart, 5);
+    assert_equals(target.selectionEnd, 5);
+
+    target.setSelectionRange(0, 0);
+
+    // Clicking past the end of the text should move the edit point to the end.
+    await new test_driver.Actions()
+      .pointerMove(middleOfCharacterHeight, targetRect.top + (10 * 7 * 3))
+      .pointerDown().pointerUp()
+          .send();
+    assert_equals(target.selectionStart, 6);
+    assert_equals(target.selectionEnd, 6);
+}, 'Mouse events move the edit point in transformed <input type=text>');
+</script>


### PR DESCRIPTION
This change makes it so that tranforms (including CSS transform and
scrolling) are properly accounted for when calculating glyph indices.
Containing block sizes are moved to `BaseFragment`. This should reduce
the size of the StackingContextTree a little.

Testing: A Servo-specific WPT-style test is added for this change.
