### PR TITLE
script: Do not allow pasting newlines in single line text boxes

### DIFF
--- a/components/script/dom/html/htmlinputelement.rs
+++ b/components/script/dom/html/htmlinputelement.rs
@@ -10,9 +10,9 @@ use std::ptr::NonNull;
 use std::str::FromStr;
 use std::{f64, ptr};
 
+use base::RopeMovement;
 use base::generic_channel::GenericSender;
 use base::text::{Utf8CodeUnitLength, Utf16CodeUnitLength};
-use base::{Lines, RopeMovement};
 use dom_struct::dom_struct;
 use embedder_traits::{
     EmbedderControlRequest, FilePickerRequest, FilterPattern, InputMethodRequest, InputMethodType,
@@ -88,7 +88,7 @@ use crate::dom::virtualmethods::VirtualMethods;
 use crate::realms::enter_realm;
 use crate::script_runtime::{CanGc, JSContext as SafeJSContext};
 use crate::textinput::{
-    ClipboardEventFlags, IsComposing, KeyReaction, SelectionDirection, TextInput,
+    ClipboardEventFlags, IsComposing, KeyReaction, Lines, SelectionDirection, TextInput,
 };
 
 const DEFAULT_SUBMIT_VALUE: &str = "Submit";

--- a/components/script/dom/html/htmltextareaelement.rs
+++ b/components/script/dom/html/htmltextareaelement.rs
@@ -6,8 +6,8 @@ use std::cell::{Cell, RefCell};
 use std::default::Default;
 use std::ops::Range;
 
+use base::RopeMovement;
 use base::text::{Utf8CodeUnitLength, Utf16CodeUnitLength};
-use base::{Lines, RopeMovement};
 use dom_struct::dom_struct;
 use embedder_traits::{EmbedderControlRequest, InputMethodRequest, InputMethodType};
 use html5ever::{LocalName, Prefix, local_name, ns};
@@ -51,7 +51,7 @@ use crate::dom::validitystate::{ValidationFlags, ValidityState};
 use crate::dom::virtualmethods::VirtualMethods;
 use crate::script_runtime::CanGc;
 use crate::textinput::{
-    ClipboardEventFlags, IsComposing, KeyReaction, SelectionDirection, TextInput,
+    ClipboardEventFlags, IsComposing, KeyReaction, Lines, SelectionDirection, TextInput,
 };
 
 #[dom_struct]

--- a/components/shared/base/lib.rs
+++ b/components/shared/base/lib.rs
@@ -25,7 +25,7 @@ use std::path::Path;
 use ipc_channel::ipc::{IpcError, IpcSender};
 use log::{trace, warn};
 use malloc_size_of_derive::MallocSizeOf;
-pub use rope::{Lines, Rope, RopeChars, RopeIndex, RopeMovement, RopeSlice};
+pub use rope::{Rope, RopeChars, RopeIndex, RopeMovement, RopeSlice};
 use serde::{Deserialize, Serialize};
 use webrender_api::Epoch as WebRenderEpoch;
 


### PR DESCRIPTION
This change moves all single versus multiline input handling to script.
It didn't really belong in `Rope`. In addition, it ensures that all
insertions into single line text boxes are sanitized by replacing
linebreaks with spaces.

Testing: As pasting is hard to test with a WPT-style test, this changes includes new unit tests.
