### PR TITLE
devtools: Restrict visibility of actors in devtools 

### DIFF
--- a/components/devtools/actor.rs
+++ b/components/devtools/actor.rs
@@ -81,7 +81,7 @@ pub(crate) trait ActorEncode<T: Serialize>: Actor {
 
 /// Return value of `ActorRegistry::find` that allows seamless downcasting
 /// from `dyn Actor` to the concrete actor type.
-pub struct DowncastableActorArc<T> {
+pub(crate) struct DowncastableActorArc<T> {
     actor: Arc<dyn Actor>,
     _phantom: PhantomData<T>,
 }
@@ -95,7 +95,7 @@ impl<T: 'static> std::ops::Deref for DowncastableActorArc<T> {
 
 /// A list of known, owned actors.
 #[derive(Default)]
-pub struct ActorRegistry {
+pub(crate) struct ActorRegistry {
     actors: AtomicRefCell<HashMap<String, Arc<dyn Actor>>>,
     script_actors: AtomicRefCell<HashMap<String, String>>,
     /// Lookup table for SourceActor names associated with a given PipelineId.

--- a/components/devtools/actors/breakpoint.rs
+++ b/components/devtools/actors/breakpoint.rs
@@ -6,7 +6,7 @@ use crate::actor::{Actor, ActorEncode, ActorError, ActorRegistry};
 use crate::protocol::ClientRequest;
 use crate::{ActorMsg, EmptyReplyMsg};
 
-pub struct BreakpointListActor {
+pub(crate) struct BreakpointListActor {
     name: String,
 }
 

--- a/components/devtools/actors/browsing_context.rs
+++ b/components/devtools/actors/browsing_context.rs
@@ -90,7 +90,7 @@ enum TargetType {
 
 #[derive(Serialize)]
 #[serde(rename_all = "camelCase")]
-pub struct BrowsingContextActorMsg {
+pub(crate) struct BrowsingContextActorMsg {
     actor: String,
     title: String,
     url: String,
@@ -132,24 +132,25 @@ pub struct BrowsingContextActorMsg {
 /// view. To this extent, it contains a watcher actor that helps when communicating with the host,
 /// as well as resource actors that each perform one debugging function.
 pub(crate) struct BrowsingContextActor {
-    pub name: String,
+    name: String,
     pub title: AtomicRefCell<String>,
     pub url: AtomicRefCell<String>,
     /// This corresponds to webview_id
     pub browser_id: DevtoolsBrowserId,
     // TODO: Should these ids be atomic?
-    pub active_pipeline_id: AtomicRefCell<PipelineId>,
-    pub active_outer_window_id: AtomicRefCell<DevtoolsOuterWindowId>,
+    active_pipeline_id: AtomicRefCell<PipelineId>,
+    active_outer_window_id: AtomicRefCell<DevtoolsOuterWindowId>,
     pub browsing_context_id: DevtoolsBrowsingContextId,
-    pub accessibility: String,
+    accessibility: String,
     pub console: String,
-    pub css_properties: String,
-    pub inspector: String,
-    pub reflow: String,
-    pub style_sheets: String,
+    css_properties: String,
+    inspector: String,
+    reflow: String,
+    style_sheets: String,
     pub thread: String,
-    pub _tab: String,
+    _tab: String,
     pub script_chan: GenericSender<DevtoolScriptControlMsg>,
+
     pub streams: AtomicRefCell<HashMap<StreamId, TcpStream>>,
     pub watcher: String,
 }

--- a/components/devtools/actors/device.rs
+++ b/components/devtools/actors/device.rs
@@ -34,8 +34,8 @@ struct SystemInfo {
 
 include!(concat!(env!("OUT_DIR"), "/build_id.rs"));
 
-pub struct DeviceActor {
-    pub name: String,
+pub(crate) struct DeviceActor {
+    name: String,
 }
 
 impl Actor for DeviceActor {

--- a/components/devtools/actors/environment.rs
+++ b/components/devtools/actors/environment.rs
@@ -37,7 +37,7 @@ struct EnvironmentFunction {
 
 #[derive(Serialize)]
 #[serde(rename_all = "camelCase")]
-pub struct EnvironmentActorMsg {
+pub(crate) struct EnvironmentActorMsg {
     actor: String,
     #[serde(rename = "type")]
     type_: EnvironmentType,
@@ -57,7 +57,7 @@ pub struct EnvironmentActorMsg {
 /// Resposible for listing the bindings in an environment and assigning new values to them.
 /// Referenced by `FrameActor` when replying to `getEnvironment` messages.
 /// <https://searchfox.org/firefox-main/source/devtools/server/actors/environment.js>
-pub struct EnvironmentActor {
+pub(crate) struct EnvironmentActor {
     pub name: String,
     pub parent: Option<String>,
 }

--- a/components/devtools/actors/frame.rs
+++ b/components/devtools/actors/frame.rs
@@ -29,7 +29,7 @@ pub enum FrameState {
 }
 
 #[derive(Serialize)]
-pub struct FrameWhere {
+pub(crate) struct FrameWhere {
     actor: String,
     line: u32,
     column: u32,
@@ -37,7 +37,7 @@ pub struct FrameWhere {
 
 #[derive(Serialize)]
 #[serde(rename_all = "camelCase")]
-pub struct FrameActorMsg {
+pub(crate) struct FrameActorMsg {
     actor: String,
     #[serde(rename = "type")]
     type_: String,
@@ -52,9 +52,9 @@ pub struct FrameActorMsg {
 
 /// Represents an stack frame. Used by `ThreadActor` when replying to interrupt messages.
 /// <https://searchfox.org/firefox-main/source/devtools/server/actors/frame.js>
-pub struct FrameActor {
-    pub name: String,
-    pub source_actor: String,
+pub(crate) struct FrameActor {
+    name: String,
+    source_actor: String,
 }
 
 impl Actor for FrameActor {

--- a/components/devtools/actors/framerate.rs
+++ b/components/devtools/actors/framerate.rs
@@ -12,7 +12,7 @@ use devtools_traits::DevtoolScriptControlMsg;
 use crate::actor::{Actor, ActorRegistry};
 use crate::actors::timeline::HighResolutionStamp;
 
-pub struct FramerateActor {
+pub(crate) struct FramerateActor {
     name: String,
     pipeline_id: PipelineId,
     script_sender: GenericSender<DevtoolScriptControlMsg>,

--- a/components/devtools/actors/inspector.rs
+++ b/components/devtools/actors/inspector.rs
@@ -52,11 +52,11 @@ struct SupportsHighlightersReply {
     value: bool,
 }
 
-pub struct InspectorActor {
-    pub name: String,
-    pub highlighter: String,
-    pub page_style: String,
-    pub walker: String,
+pub(crate) struct InspectorActor {
+    name: String,
+    highlighter: String,
+    page_style: String,
+    walker: String,
 }
 
 impl Actor for InspectorActor {

--- a/components/devtools/actors/inspector/accessibility.rs
+++ b/components/devtools/actors/inspector/accessibility.rs
@@ -52,7 +52,7 @@ struct GetWalkerReply {
     walker: ActorMsg,
 }
 
-pub struct AccessibilityActor {
+pub(crate) struct AccessibilityActor {
     name: String,
 }
 
@@ -132,7 +132,7 @@ impl AccessibilityActor {
     }
 }
 
-pub struct SimulatorActor {
+pub(crate) struct SimulatorActor {
     name: String,
 }
 
@@ -142,7 +142,7 @@ impl Actor for SimulatorActor {
     }
 }
 
-pub struct AccessibleWalkerActor {
+pub(crate) struct AccessibleWalkerActor {
     name: String,
 }
 

--- a/components/devtools/actors/inspector/css_properties.rs
+++ b/components/devtools/actors/inspector/css_properties.rs
@@ -15,7 +15,7 @@ use crate::StreamId;
 use crate::actor::{Actor, ActorError, ActorRegistry};
 use crate::protocol::ClientRequest;
 
-pub struct CssPropertiesActor {
+pub(crate) struct CssPropertiesActor {
     name: String,
     properties: HashMap<String, CssDatabaseProperty>,
 }

--- a/components/devtools/actors/inspector/highlighter.rs
+++ b/components/devtools/actors/inspector/highlighter.rs
@@ -16,7 +16,7 @@ use crate::actors::inspector::InspectorActor;
 use crate::protocol::ClientRequest;
 use crate::{ActorMsg, EmptyReplyMsg, StreamId};
 
-pub struct HighlighterActor {
+pub(crate) struct HighlighterActor {
     pub name: String,
     pub script_sender: GenericSender<DevtoolScriptControlMsg>,
     pub pipeline: PipelineId,

--- a/components/devtools/actors/inspector/layout.rs
+++ b/components/devtools/actors/inspector/layout.rs
@@ -12,18 +12,18 @@ use crate::actor::{Actor, ActorEncode, ActorError, ActorRegistry};
 use crate::protocol::ClientRequest;
 use crate::{ActorMsg, StreamId};
 
-pub struct LayoutInspectorActor {
+pub(crate) struct LayoutInspectorActor {
     name: String,
 }
 
 #[derive(Serialize)]
-pub struct GetGridsReply {
+pub(crate) struct GetGridsReply {
     from: String,
     grids: Vec<String>,
 }
 
 #[derive(Serialize)]
-pub struct GetCurrentFlexboxReply {
+pub(crate) struct GetCurrentFlexboxReply {
     from: String,
     flexbox: Option<()>,
 }

--- a/components/devtools/actors/inspector/node.rs
+++ b/components/devtools/actors/inspector/node.rs
@@ -46,7 +46,7 @@ struct AttrMsg {
 
 #[derive(Clone, Serialize)]
 #[serde(rename_all = "camelCase")]
-pub struct NodeActorMsg {
+pub(crate) struct NodeActorMsg {
     pub actor: String,
 
     /// The ID of the shadow host of this node, if it is
@@ -99,10 +99,10 @@ pub struct NodeActorMsg {
     system_id: Option<String>,
 }
 
-pub struct NodeActor {
+pub(crate) struct NodeActor {
     name: String,
     pub script_chan: GenericSender<DevtoolScriptControlMsg>,
-    pub pipeline: PipelineId,
+    pipeline: PipelineId,
     pub walker: String,
     pub style_rules: AtomicRefCell<HashMap<(String, usize), String>>,
 }

--- a/components/devtools/actors/inspector/node.rs
+++ b/components/devtools/actors/inspector/node.rs
@@ -102,7 +102,7 @@ pub(crate) struct NodeActorMsg {
 pub(crate) struct NodeActor {
     name: String,
     pub script_chan: GenericSender<DevtoolScriptControlMsg>,
-    pipeline: PipelineId,
+    pub pipeline: PipelineId,
     pub walker: String,
     pub style_rules: AtomicRefCell<HashMap<(String, usize), String>>,
 }

--- a/components/devtools/actors/inspector/page_style.rs
+++ b/components/devtools/actors/inspector/page_style.rs
@@ -53,18 +53,18 @@ struct GetLayoutReply {
 }
 
 #[derive(Serialize)]
-pub struct IsPositionEditableReply {
-    pub from: String,
-    pub value: bool,
+pub(crate) struct IsPositionEditableReply {
+    from: String,
+    value: bool,
 }
 
 #[derive(Serialize)]
-pub struct PageStyleMsg {
+pub(crate) struct PageStyleMsg {
     pub actor: String,
     pub traits: HashMap<String, bool>,
 }
 
-pub struct PageStyleActor {
+pub(crate) struct PageStyleActor {
     pub name: String,
     pub script_chan: GenericSender<DevtoolScriptControlMsg>,
     pub pipeline: PipelineId,

--- a/components/devtools/actors/inspector/style_rule.rs
+++ b/components/devtools/actors/inspector/style_rule.rs
@@ -25,7 +25,7 @@ const ELEMENT_STYLE_TYPE: u32 = 100;
 
 #[derive(Serialize)]
 #[serde(rename_all = "camelCase")]
-pub struct AppliedRule {
+pub(crate) struct AppliedRule {
     actor: String,
     ancestor_data: Vec<()>,
     authored_text: String,
@@ -42,13 +42,13 @@ pub struct AppliedRule {
 }
 
 #[derive(Serialize)]
-pub struct IsUsed {
-    pub used: bool,
+pub(crate) struct IsUsed {
+    used: bool,
 }
 
 #[derive(Serialize)]
 #[serde(rename_all = "camelCase")]
-pub struct AppliedDeclaration {
+pub(crate) struct AppliedDeclaration {
     colon_offsets: Vec<i32>,
     is_name_valid: bool,
     is_used: IsUsed,
@@ -61,24 +61,24 @@ pub struct AppliedDeclaration {
 }
 
 #[derive(Serialize)]
-pub struct ComputedDeclaration {
+pub(crate) struct ComputedDeclaration {
     matched: bool,
     value: String,
 }
 
 #[derive(Serialize)]
 #[serde(rename_all = "camelCase")]
-pub struct StyleRuleActorTraits {
+pub(crate) struct StyleRuleActorTraits {
     pub can_set_rule_text: bool,
 }
 
 #[derive(Serialize)]
-pub struct StyleRuleActorMsg {
+pub(crate) struct StyleRuleActorMsg {
     from: String,
     rule: Option<AppliedRule>,
 }
 
-pub struct StyleRuleActor {
+pub(crate) struct StyleRuleActor {
     name: String,
     node: String,
     selector: Option<(String, usize)>,

--- a/components/devtools/actors/inspector/walker.rs
+++ b/components/devtools/actors/inspector/walker.rs
@@ -19,12 +19,12 @@ use crate::protocol::{ClientRequest, JsonPacketStream};
 use crate::{ActorMsg, EmptyReplyMsg, StreamId};
 
 #[derive(Serialize)]
-pub struct WalkerMsg {
-    pub actor: String,
-    pub root: NodeActorMsg,
+pub(crate) struct WalkerMsg {
+    actor: String,
+    root: NodeActorMsg,
 }
 
-pub struct WalkerActor {
+pub(crate) struct WalkerActor {
     pub name: String,
     pub mutations: AtomicRefCell<Vec<(AttrModification, String)>>,
     pub pipeline: PipelineId,

--- a/components/devtools/actors/long_string.rs
+++ b/components/devtools/actors/long_string.rs
@@ -10,14 +10,14 @@ use crate::protocol::ClientRequest;
 
 const INITIAL_LENGTH: usize = 500;
 
-pub struct LongStringActor {
+pub(crate) struct LongStringActor {
     name: String,
     full_string: String,
 }
 
 #[derive(Clone, Serialize)]
 #[serde(rename_all = "camelCase")]
-pub struct LongStringObj {
+pub(crate) struct LongStringObj {
     #[serde(rename = "type")]
     type_: String,
     actor: String,

--- a/components/devtools/actors/memory.rs
+++ b/components/devtools/actors/memory.rs
@@ -8,7 +8,7 @@ use crate::actor::{Actor, ActorRegistry};
 
 #[derive(Serialize)]
 #[serde(rename_all = "camelCase")]
-pub struct TimelineMemoryReply {
+pub(crate) struct TimelineMemoryReply {
     js_object_size: u64,
     js_string_size: u64,
     js_other_size: u64,
@@ -21,8 +21,8 @@ pub struct TimelineMemoryReply {
     non_js_milliseconds: f64,
 }
 
-pub struct MemoryActor {
-    pub name: String,
+pub(crate) struct MemoryActor {
+    name: String,
 }
 
 impl Actor for MemoryActor {

--- a/components/devtools/actors/network_event.rs
+++ b/components/devtools/actors/network_event.rs
@@ -30,7 +30,7 @@ use crate::network_handler::Cause;
 use crate::protocol::ClientRequest;
 
 #[derive(Default)]
-pub struct NetworkEventActor {
+pub(crate) struct NetworkEventActor {
     name: String,
     request: AtomicRefCell<Option<NetworkEventRequest>>,
     resource_id: u64,
@@ -41,7 +41,7 @@ pub struct NetworkEventActor {
 
 #[derive(Clone, Serialize)]
 #[serde(rename_all = "camelCase")]
-pub struct NetworkEventResource {
+pub(crate) struct NetworkEventResource {
     #[serde(rename = "browsingContextID")]
     browsing_context_id: u32,
     inner_window_id: u64,
@@ -51,7 +51,7 @@ pub struct NetworkEventResource {
 
 #[derive(Clone, Serialize)]
 #[serde(rename_all = "camelCase")]
-pub struct NetworkEventMsg {
+pub(crate) struct NetworkEventMsg {
     actor: String,
     #[serde(rename = "browsingContextID")]
     browsing_context_id: u32,
@@ -158,7 +158,7 @@ struct SecurityFields {
 
 #[derive(Clone, Serialize)]
 #[serde(rename_all = "camelCase")]
-pub struct ResourceUpdates {
+pub(crate) struct ResourceUpdates {
     http_version: String,
     #[serde(skip_serializing_if = "Option::is_none")]
     #[serde(flatten)]
@@ -190,13 +190,13 @@ struct ResponseContent {
 
 #[derive(Clone, Serialize)]
 #[serde(rename_all = "camelCase")]
-pub struct CacheDetails {
+pub(crate) struct CacheDetails {
     from_cache: bool,
     from_service_worker: bool,
 }
 
 #[derive(Clone, Default, Serialize)]
-pub struct Timings {
+pub(crate) struct Timings {
     blocked: usize,
     dns: usize,
     connect: usize,
@@ -325,7 +325,7 @@ struct NetworkEventResponse {
 }
 
 #[derive(Serialize)]
-pub struct CookieWrapper {
+pub(crate) struct CookieWrapper {
     name: String,
     value: String,
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/components/devtools/actors/object.rs
+++ b/components/devtools/actors/object.rs
@@ -7,14 +7,14 @@ use serde::Serialize;
 use crate::actor::{Actor, ActorEncode, ActorRegistry};
 
 #[derive(Serialize)]
-pub struct ObjectPreview {
+pub(crate) struct ObjectPreview {
     kind: String,
     url: String,
 }
 
 #[derive(Serialize)]
 #[serde(rename_all = "camelCase")]
-pub struct ObjectActorMsg {
+pub(crate) struct ObjectActorMsg {
     actor: String,
     #[serde(rename = "type")]
     type_: String,
@@ -27,9 +27,9 @@ pub struct ObjectActorMsg {
     preview: ObjectPreview,
 }
 
-pub struct ObjectActor {
-    pub name: String,
-    pub _uuid: String,
+pub(crate) struct ObjectActor {
+    name: String,
+    _uuid: String,
 }
 
 impl Actor for ObjectActor {

--- a/components/devtools/actors/pause.rs
+++ b/components/devtools/actors/pause.rs
@@ -6,7 +6,7 @@ use crate::actor::Actor;
 
 /// Referenced by `ThreadActor` when replying to `interupt` messages.
 /// <https://searchfox.org/firefox-main/source/devtools/server/actors/thread.js#1699>
-pub struct PauseActor {
+pub(crate) struct PauseActor {
     pub name: String,
 }
 

--- a/components/devtools/actors/performance.rs
+++ b/components/devtools/actors/performance.rs
@@ -9,7 +9,7 @@ use crate::StreamId;
 use crate::actor::{Actor, ActorError, ActorRegistry};
 use crate::protocol::{ActorDescription, ClientRequest, Method};
 
-pub struct PerformanceActor {
+pub(crate) struct PerformanceActor {
     name: String,
 }
 

--- a/components/devtools/actors/preference.rs
+++ b/components/devtools/actors/preference.rs
@@ -10,7 +10,7 @@ use crate::StreamId;
 use crate::actor::{Actor, ActorError, ActorRegistry};
 use crate::protocol::ClientRequest;
 
-pub struct PreferenceActor {
+pub(crate) struct PreferenceActor {
     name: String,
 }
 

--- a/components/devtools/actors/process.rs
+++ b/components/devtools/actors/process.rs
@@ -22,7 +22,7 @@ struct ListWorkersReply {
 
 #[derive(Serialize)]
 #[serde(rename_all = "camelCase")]
-pub struct ProcessActorMsg {
+pub(crate) struct ProcessActorMsg {
     actor: String,
     id: u32,
     is_parent: bool,
@@ -30,7 +30,7 @@ pub struct ProcessActorMsg {
     traits: DescriptorTraits,
 }
 
-pub struct ProcessActor {
+pub(crate) struct ProcessActor {
     name: String,
 }
 

--- a/components/devtools/actors/reflow.rs
+++ b/components/devtools/actors/reflow.rs
@@ -10,7 +10,7 @@ use crate::actor::{Actor, ActorError, ActorRegistry};
 use crate::protocol::ClientRequest;
 use crate::{EmptyReplyMsg, StreamId};
 
-pub struct ReflowActor {
+pub(crate) struct ReflowActor {
     name: String,
 }
 

--- a/components/devtools/actors/root.rs
+++ b/components/devtools/actors/root.rs
@@ -78,14 +78,14 @@ struct GetTabReply {
 
 #[derive(Serialize)]
 #[serde(rename_all = "camelCase")]
-pub struct RootActorMsg {
+pub(crate) struct RootActorMsg {
     from: String,
     application_type: String,
     traits: RootTraits,
 }
 
 #[derive(Serialize)]
-pub struct ProtocolDescriptionReply {
+pub(crate) struct ProtocolDescriptionReply {
     from: String,
     types: Types,
 }
@@ -103,7 +103,7 @@ struct ListServiceWorkerRegistrationsReply {
 }
 
 #[derive(Serialize)]
-pub struct Types {
+pub(crate) struct Types {
     performance: ActorDescription,
     device: ActorDescription,
 }
@@ -116,7 +116,7 @@ struct ListProcessesResponse {
 
 #[derive(Default, Serialize)]
 #[serde(rename_all = "camelCase")]
-pub struct DescriptorTraits {
+pub(crate) struct DescriptorTraits {
     pub(crate) watcher: bool,
     pub(crate) supports_reload_descriptor: bool,
 }
@@ -129,7 +129,7 @@ struct GetProcessResponse {
 }
 
 #[derive(Default)]
-pub struct RootActor {
+pub(crate) struct RootActor {
     active_tab: AtomicRefCell<Option<String>>,
     global_actors: GlobalActors,
     process: String,

--- a/components/devtools/actors/source.rs
+++ b/components/devtools/actors/source.rs
@@ -25,12 +25,12 @@ use crate::protocol::ClientRequest;
 #[derive(Clone, Debug, Eq, Ord, PartialEq, PartialOrd, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub(crate) struct SourceForm {
-    pub actor: String,
+    actor: String,
     /// URL of the script, or URL of the page for inline scripts.
-    pub url: String,
-    pub is_black_boxed: bool,
+    url: String,
+    is_black_boxed: bool,
     /// `introductionType` in SpiderMonkey `CompileOptionsWrapper`.
-    pub introduction_type: String,
+    introduction_type: String,
 }
 
 #[derive(Serialize)]
@@ -44,24 +44,24 @@ pub(crate) struct SourceManager {
 }
 
 #[derive(Clone, Debug)]
-pub struct SourceActor {
+pub(crate) struct SourceActor {
     /// Actor name.
-    pub name: String,
+    name: String,
 
     /// URL of the script, or URL of the page for inline scripts.
-    pub url: ServoUrl,
+    url: ServoUrl,
 
     /// The ‘black-boxed’ flag, which tells the debugger to avoid pausing inside this script.
     /// <https://firefox-source-docs.mozilla.org/devtools/backend/protocol.html#black-boxing-sources>
-    pub is_black_boxed: bool,
+    is_black_boxed: bool,
 
     pub content: AtomicRefCell<Option<String>>,
-    pub content_type: Option<String>,
+    content_type: Option<String>,
 
     // TODO: use it in #37667, then remove this allow
-    pub spidermonkey_id: u32,
+    spidermonkey_id: u32,
     /// `introductionType` in SpiderMonkey `CompileOptionsWrapper`.
-    pub introduction_type: String,
+    introduction_type: String,
 
     script_sender: GenericSender<DevtoolScriptControlMsg>,
 }

--- a/components/devtools/actors/stylesheets.rs
+++ b/components/devtools/actors/stylesheets.rs
@@ -16,8 +16,8 @@ struct GetStyleSheetsReply {
     style_sheets: Vec<u32>, // TODO: real JSON structure.
 }
 
-pub struct StyleSheetsActor {
-    pub name: String,
+pub(crate) struct StyleSheetsActor {
+    name: String,
 }
 
 impl Actor for StyleSheetsActor {

--- a/components/devtools/actors/tab.rs
+++ b/components/devtools/actors/tab.rs
@@ -22,7 +22,7 @@ use crate::{EmptyReplyMsg, StreamId};
 
 #[derive(Serialize)]
 #[serde(rename_all = "camelCase")]
-pub struct TabDescriptorActorMsg {
+pub(crate) struct TabDescriptorActorMsg {
     actor: String,
     /// This correspond to webview_id
     #[serde(rename = "browserId")]
@@ -67,7 +67,7 @@ struct GetWatcherReply {
     watcher: WatcherActorMsg,
 }
 
-pub struct TabDescriptorActor {
+pub(crate) struct TabDescriptorActor {
     name: String,
     browsing_context_actor: String,
     is_top_level_global: bool,

--- a/components/devtools/actors/thread.rs
+++ b/components/devtools/actors/thread.rs
@@ -49,8 +49,8 @@ struct ThreadInterruptedReply {
     type_: String,
 }
 
-pub struct ThreadActor {
-    pub name: String,
+pub(crate) struct ThreadActor {
+    name: String,
     pub source_manager: SourceManager,
 }
 

--- a/components/devtools/actors/timeline.rs
+++ b/components/devtools/actors/timeline.rs
@@ -24,7 +24,7 @@ use crate::actors::framerate::FramerateActor;
 use crate::actors::memory::{MemoryActor, TimelineMemoryReply};
 use crate::protocol::{ClientRequest, JsonPacketStream};
 
-pub struct TimelineActor {
+pub(crate) struct TimelineActor {
     name: String,
     script_sender: GenericSender<DevtoolScriptControlMsg>,
     marker_types: Vec<TimelineMarkerType>,
@@ -107,7 +107,7 @@ struct FramerateEmitterReply {
 /// with accuracy to microsecond that shows how much time has passed since
 /// actor registry inited
 /// analog <https://w3c.github.io/hr-time/#sec-DOMHighResTimeStamp>
-pub struct HighResolutionStamp(f64);
+pub(crate) struct HighResolutionStamp(f64);
 
 impl HighResolutionStamp {
     pub fn new(start_stamp: CrossProcessInstant, time: CrossProcessInstant) -> HighResolutionStamp {

--- a/components/devtools/actors/watcher.rs
+++ b/components/devtools/actors/watcher.rs
@@ -43,7 +43,7 @@ pub mod thread_configuration;
 /// <https://searchfox.org/mozilla-central/source/devtools/server/actors/watcher/session-context.js>
 #[derive(Serialize)]
 #[serde(rename_all = "camelCase")]
-pub struct SessionContext {
+pub(crate) struct SessionContext {
     is_server_target_switching_enabled: bool,
     supported_targets: HashMap<&'static str, bool>,
     supported_resources: HashMap<&'static str, bool>,
@@ -173,12 +173,12 @@ struct WatcherTraits {
 }
 
 #[derive(Serialize)]
-pub struct WatcherActorMsg {
+pub(crate) struct WatcherActorMsg {
     actor: String,
     traits: WatcherTraits,
 }
 
-pub struct WatcherActor {
+pub(crate) struct WatcherActor {
     name: String,
     pub browsing_context_actor: String,
     network_parent: String,
@@ -190,7 +190,7 @@ pub struct WatcherActor {
 
 #[derive(Clone, Serialize)]
 #[serde(rename_all = "camelCase")]
-pub struct WillNavigateMessage {
+pub(crate) struct WillNavigateMessage {
     #[serde(rename = "browsingContextID")]
     browsing_context_id: u32,
     inner_window_id: u32,

--- a/components/devtools/actors/watcher/network_parent.rs
+++ b/components/devtools/actors/watcher/network_parent.rs
@@ -8,7 +8,7 @@ use crate::actor::{Actor, ActorEncode, ActorError, ActorRegistry};
 use crate::protocol::ClientRequest;
 use crate::{ActorMsg, EmptyReplyMsg, StreamId};
 
-pub struct NetworkParentActor {
+pub(crate) struct NetworkParentActor {
     name: String,
 }
 

--- a/components/devtools/actors/watcher/target_configuration.rs
+++ b/components/devtools/actors/watcher/target_configuration.rs
@@ -20,18 +20,18 @@ use crate::{EmptyReplyMsg, RootActor, StreamId};
 
 #[derive(Serialize)]
 #[serde(rename_all = "camelCase")]
-pub struct TargetConfigurationTraits {
+pub(crate) struct TargetConfigurationTraits {
     supported_options: HashMap<&'static str, bool>,
 }
 
 #[derive(Serialize)]
-pub struct TargetConfigurationActorMsg {
+pub(crate) struct TargetConfigurationActorMsg {
     actor: String,
     configuration: HashMap<&'static str, bool>,
     traits: TargetConfigurationTraits,
 }
 
-pub struct TargetConfigurationActor {
+pub(crate) struct TargetConfigurationActor {
     name: String,
     configuration: HashMap<&'static str, bool>,
     supported_options: HashMap<&'static str, bool>,

--- a/components/devtools/actors/watcher/thread_configuration.rs
+++ b/components/devtools/actors/watcher/thread_configuration.rs
@@ -13,7 +13,7 @@ use crate::actor::{Actor, ActorEncode, ActorError, ActorRegistry};
 use crate::protocol::ClientRequest;
 use crate::{ActorMsg, EmptyReplyMsg, StreamId};
 
-pub struct ThreadConfigurationActor {
+pub(crate) struct ThreadConfigurationActor {
     name: String,
     _configuration: HashMap<&'static str, bool>,
 }

--- a/components/devtools/id.rs
+++ b/components/devtools/id.rs
@@ -7,9 +7,9 @@ use rustc_hash::FxHashMap;
 
 #[derive(Debug, Default)]
 pub(crate) struct IdMap {
-    pub(crate) browser_ids: FxHashMap<WebViewId, u32>,
-    pub(crate) browsing_context_ids: FxHashMap<BrowsingContextId, u32>,
-    pub(crate) outer_window_ids: FxHashMap<PipelineId, u32>,
+    browser_ids: FxHashMap<WebViewId, u32>,
+    browsing_context_ids: FxHashMap<BrowsingContextId, u32>,
+    outer_window_ids: FxHashMap<PipelineId, u32>,
 }
 
 impl IdMap {

--- a/components/devtools/lib.rs
+++ b/components/devtools/lib.rs
@@ -88,12 +88,12 @@ enum UniqueId {
 }
 
 #[derive(Serialize)]
-pub struct EmptyReplyMsg {
+pub(crate) struct EmptyReplyMsg {
     pub from: String,
 }
 
 #[derive(Serialize)]
-pub struct ActorMsg {
+pub(crate) struct ActorMsg {
     pub actor: String,
 }
 

--- a/components/devtools/network_handler.rs
+++ b/components/devtools/network_handler.rs
@@ -15,7 +15,7 @@ use crate::resource::{ResourceArrayType, ResourceAvailable};
 
 #[derive(Clone, Serialize)]
 #[serde(rename_all = "camelCase")]
-pub struct Cause {
+pub(crate) struct Cause {
     #[serde(rename = "type")]
     pub type_: String,
     pub loading_document_uri: Option<String>,

--- a/components/devtools/protocol.rs
+++ b/components/devtools/protocol.rs
@@ -16,14 +16,14 @@ use crate::actor::ActorError;
 
 #[derive(Serialize)]
 #[serde(rename_all = "camelCase")]
-pub struct ActorDescription {
+pub(crate) struct ActorDescription {
     pub category: &'static str,
     pub type_name: &'static str,
     pub methods: Vec<Method>,
 }
 
 #[derive(Serialize)]
-pub struct Method {
+pub(crate) struct Method {
     pub name: &'static str,
     pub request: Value,
     pub response: Value,
@@ -101,7 +101,7 @@ impl JsonPacketStream for TcpStream {
 ///
 /// It does not currently guarantee anything about messages sent via the [`TcpStream`] released via
 /// [`Self::try_clone_stream`] or the return value of [`Self::reply`].
-pub struct ClientRequest<'req, 'sent> {
+pub(crate) struct ClientRequest<'req, 'sent> {
     /// Client stream.
     stream: &'req mut TcpStream,
     /// Expected actor name.

--- a/components/devtools/resource.rs
+++ b/components/devtools/resource.rs
@@ -13,10 +13,10 @@ pub enum ResourceArrayType {
 
 #[derive(Serialize)]
 pub(crate) struct ResourceAvailableReply<T: Serialize> {
-    pub from: String,
+    from: String,
     #[serde(rename = "type")]
-    pub type_: String,
-    pub array: Vec<(String, Vec<T>)>,
+    type_: String,
+    array: Vec<(String, Vec<T>)>,
 }
 
 pub(crate) trait ResourceAvailable {


### PR DESCRIPTION
This change is to make visibility uniformly crate wide across all of the structs and their props within devtools.

Testing: Tested using `.\mach build -d` `.\mach fmt` `.\mach test-tidy` all passed 
Part of: #41893

