### PR TITLE
script: Extend AES-GCM in WebCrypto to support more tag lengths

### DIFF
--- a/components/script/dom/subtlecrypto/aes_gcm_operation.rs
+++ b/components/script/dom/subtlecrypto/aes_gcm_operation.rs
@@ -410,16 +410,34 @@ pub(crate) fn decrypt(
     //
     // NOTE: We currently support:
     // - IV: 96-bit, 128-bit, 256-bit
-    // - Tag length: 128-bit
+    // - Tag length: 96-bit, 104-bit, 112-bit, 120-bit, 128-bit
+    //
+    // NOTE: We currently do not support 32-bit and 64-bit tag length in decryption since the crate
+    // `aes-gcm` does not support 32-bit and 64-bit tag length.
     let iv = normalized_algorithm.iv.as_slice();
     let plaintext = match key.handle() {
         Handle::Aes128Key(key) => match (iv.len(), tag_length) {
             // 96-bit nonce
+            (12, 96) => gcm_decrypt::<Aes128, U12, U12>(key, ciphertext, iv, additional_data)?,
+            (12, 104) => gcm_decrypt::<Aes128, U12, U13>(key, ciphertext, iv, additional_data)?,
+            (12, 112) => gcm_decrypt::<Aes128, U12, U14>(key, ciphertext, iv, additional_data)?,
+            (12, 120) => gcm_decrypt::<Aes128, U12, U15>(key, ciphertext, iv, additional_data)?,
             (12, 128) => gcm_decrypt::<Aes128, U12, U16>(key, ciphertext, iv, additional_data)?,
+
             // 128-bit nonce
+            (16, 96) => gcm_decrypt::<Aes128, U16, U12>(key, ciphertext, iv, additional_data)?,
+            (16, 104) => gcm_decrypt::<Aes128, U16, U13>(key, ciphertext, iv, additional_data)?,
+            (16, 112) => gcm_decrypt::<Aes128, U16, U14>(key, ciphertext, iv, additional_data)?,
+            (16, 120) => gcm_decrypt::<Aes128, U16, U15>(key, ciphertext, iv, additional_data)?,
             (16, 128) => gcm_decrypt::<Aes128, U16, U16>(key, ciphertext, iv, additional_data)?,
+
             // 256-bit nonce
+            (32, 96) => gcm_decrypt::<Aes128, U32, U12>(key, ciphertext, iv, additional_data)?,
+            (32, 104) => gcm_decrypt::<Aes128, U32, U13>(key, ciphertext, iv, additional_data)?,
+            (32, 112) => gcm_decrypt::<Aes128, U32, U14>(key, ciphertext, iv, additional_data)?,
+            (32, 120) => gcm_decrypt::<Aes128, U32, U15>(key, ciphertext, iv, additional_data)?,
             (32, 128) => gcm_decrypt::<Aes128, U32, U16>(key, ciphertext, iv, additional_data)?,
+
             _ => {
                 return Err(Error::Operation(Some(format!(
                     "Unsupported iv size ({}-bit) and/or tag length ({}-bit)",
@@ -430,11 +448,26 @@ pub(crate) fn decrypt(
         },
         Handle::Aes192Key(key) => match (iv.len(), tag_length) {
             // 96-bit nonce
+            (12, 96) => gcm_decrypt::<Aes192, U12, U12>(key, ciphertext, iv, additional_data)?,
+            (12, 104) => gcm_decrypt::<Aes192, U12, U13>(key, ciphertext, iv, additional_data)?,
+            (12, 112) => gcm_decrypt::<Aes192, U12, U14>(key, ciphertext, iv, additional_data)?,
+            (12, 120) => gcm_decrypt::<Aes192, U12, U15>(key, ciphertext, iv, additional_data)?,
             (12, 128) => gcm_decrypt::<Aes192, U12, U16>(key, ciphertext, iv, additional_data)?,
+
             // 128-bit nonce
+            (16, 96) => gcm_decrypt::<Aes192, U16, U12>(key, ciphertext, iv, additional_data)?,
+            (16, 104) => gcm_decrypt::<Aes192, U16, U13>(key, ciphertext, iv, additional_data)?,
+            (16, 112) => gcm_decrypt::<Aes192, U16, U14>(key, ciphertext, iv, additional_data)?,
+            (16, 120) => gcm_decrypt::<Aes192, U16, U15>(key, ciphertext, iv, additional_data)?,
             (16, 128) => gcm_decrypt::<Aes192, U16, U16>(key, ciphertext, iv, additional_data)?,
+
             // 256-bit nonce
+            (32, 96) => gcm_decrypt::<Aes192, U32, U12>(key, ciphertext, iv, additional_data)?,
+            (32, 104) => gcm_decrypt::<Aes192, U32, U13>(key, ciphertext, iv, additional_data)?,
+            (32, 112) => gcm_decrypt::<Aes192, U32, U14>(key, ciphertext, iv, additional_data)?,
+            (32, 120) => gcm_decrypt::<Aes192, U32, U15>(key, ciphertext, iv, additional_data)?,
             (32, 128) => gcm_decrypt::<Aes192, U32, U16>(key, ciphertext, iv, additional_data)?,
+
             _ => {
                 return Err(Error::Operation(Some(format!(
                     "Unsupported iv size ({}-bit) and/or tag length ({}-bit)",
@@ -445,11 +478,26 @@ pub(crate) fn decrypt(
         },
         Handle::Aes256Key(key) => match (iv.len(), tag_length) {
             // 96-bit nonce
+            (12, 96) => gcm_decrypt::<Aes256, U12, U12>(key, ciphertext, iv, additional_data)?,
+            (12, 104) => gcm_decrypt::<Aes256, U12, U13>(key, ciphertext, iv, additional_data)?,
+            (12, 112) => gcm_decrypt::<Aes256, U12, U14>(key, ciphertext, iv, additional_data)?,
+            (12, 120) => gcm_decrypt::<Aes256, U12, U15>(key, ciphertext, iv, additional_data)?,
             (12, 128) => gcm_decrypt::<Aes256, U12, U16>(key, ciphertext, iv, additional_data)?,
+
             // 128-bit nonce
+            (16, 96) => gcm_decrypt::<Aes256, U16, U12>(key, ciphertext, iv, additional_data)?,
+            (16, 104) => gcm_decrypt::<Aes256, U16, U13>(key, ciphertext, iv, additional_data)?,
+            (16, 112) => gcm_decrypt::<Aes256, U16, U14>(key, ciphertext, iv, additional_data)?,
+            (16, 120) => gcm_decrypt::<Aes256, U16, U15>(key, ciphertext, iv, additional_data)?,
             (16, 128) => gcm_decrypt::<Aes256, U16, U16>(key, ciphertext, iv, additional_data)?,
+
             // 256-bit nonce
+            (32, 96) => gcm_decrypt::<Aes256, U32, U12>(key, ciphertext, iv, additional_data)?,
+            (32, 104) => gcm_decrypt::<Aes256, U32, U13>(key, ciphertext, iv, additional_data)?,
+            (32, 112) => gcm_decrypt::<Aes256, U32, U14>(key, ciphertext, iv, additional_data)?,
+            (32, 120) => gcm_decrypt::<Aes256, U32, U15>(key, ciphertext, iv, additional_data)?,
             (32, 128) => gcm_decrypt::<Aes256, U32, U16>(key, ciphertext, iv, additional_data)?,
+
             _ => {
                 return Err(Error::Operation(Some(format!(
                     "Unsupported iv size ({}-bit) and/or tag length ({}-bit)",

--- a/tests/wpt/meta/WebCryptoAPI/encrypt_decrypt/aes_gcm.https.any.js.ini
+++ b/tests/wpt/meta/WebCryptoAPI/encrypt_decrypt/aes_gcm.https.any.js.ini
@@ -11,30 +11,6 @@
   [AES-GCM 128-bit key, no additional data, 64-bit tag, 96-bit iv decryption]
     expected: FAIL
 
-  [AES-GCM 128-bit key, 96-bit tag, 96-bit iv decryption]
-    expected: FAIL
-
-  [AES-GCM 128-bit key, no additional data, 96-bit tag, 96-bit iv decryption]
-    expected: FAIL
-
-  [AES-GCM 128-bit key, 104-bit tag, 96-bit iv decryption]
-    expected: FAIL
-
-  [AES-GCM 128-bit key, no additional data, 104-bit tag, 96-bit iv decryption]
-    expected: FAIL
-
-  [AES-GCM 128-bit key, 112-bit tag, 96-bit iv decryption]
-    expected: FAIL
-
-  [AES-GCM 128-bit key, no additional data, 112-bit tag, 96-bit iv decryption]
-    expected: FAIL
-
-  [AES-GCM 128-bit key, 120-bit tag, 96-bit iv decryption]
-    expected: FAIL
-
-  [AES-GCM 128-bit key, no additional data, 120-bit tag, 96-bit iv decryption]
-    expected: FAIL
-
   [AES-GCM 192-bit key, 32-bit tag, 96-bit iv decryption]
     expected: FAIL
 
@@ -45,30 +21,6 @@
     expected: FAIL
 
   [AES-GCM 192-bit key, no additional data, 64-bit tag, 96-bit iv decryption]
-    expected: FAIL
-
-  [AES-GCM 192-bit key, 96-bit tag, 96-bit iv decryption]
-    expected: FAIL
-
-  [AES-GCM 192-bit key, no additional data, 96-bit tag, 96-bit iv decryption]
-    expected: FAIL
-
-  [AES-GCM 192-bit key, 104-bit tag, 96-bit iv decryption]
-    expected: FAIL
-
-  [AES-GCM 192-bit key, no additional data, 104-bit tag, 96-bit iv decryption]
-    expected: FAIL
-
-  [AES-GCM 192-bit key, 112-bit tag, 96-bit iv decryption]
-    expected: FAIL
-
-  [AES-GCM 192-bit key, no additional data, 112-bit tag, 96-bit iv decryption]
-    expected: FAIL
-
-  [AES-GCM 192-bit key, 120-bit tag, 96-bit iv decryption]
-    expected: FAIL
-
-  [AES-GCM 192-bit key, no additional data, 120-bit tag, 96-bit iv decryption]
     expected: FAIL
 
   [AES-GCM 256-bit key, 32-bit tag, 96-bit iv decryption]
@@ -83,30 +35,6 @@
   [AES-GCM 256-bit key, no additional data, 64-bit tag, 96-bit iv decryption]
     expected: FAIL
 
-  [AES-GCM 256-bit key, 96-bit tag, 96-bit iv decryption]
-    expected: FAIL
-
-  [AES-GCM 256-bit key, no additional data, 96-bit tag, 96-bit iv decryption]
-    expected: FAIL
-
-  [AES-GCM 256-bit key, 104-bit tag, 96-bit iv decryption]
-    expected: FAIL
-
-  [AES-GCM 256-bit key, no additional data, 104-bit tag, 96-bit iv decryption]
-    expected: FAIL
-
-  [AES-GCM 256-bit key, 112-bit tag, 96-bit iv decryption]
-    expected: FAIL
-
-  [AES-GCM 256-bit key, no additional data, 112-bit tag, 96-bit iv decryption]
-    expected: FAIL
-
-  [AES-GCM 256-bit key, 120-bit tag, 96-bit iv decryption]
-    expected: FAIL
-
-  [AES-GCM 256-bit key, no additional data, 120-bit tag, 96-bit iv decryption]
-    expected: FAIL
-
   [AES-GCM 128-bit key, 32-bit tag, 96-bit iv decryption with altered ciphertext]
     expected: FAIL
 
@@ -117,30 +45,6 @@
     expected: FAIL
 
   [AES-GCM 128-bit key, no additional data, 64-bit tag, 96-bit iv decryption with altered ciphertext]
-    expected: FAIL
-
-  [AES-GCM 128-bit key, 96-bit tag, 96-bit iv decryption with altered ciphertext]
-    expected: FAIL
-
-  [AES-GCM 128-bit key, no additional data, 96-bit tag, 96-bit iv decryption with altered ciphertext]
-    expected: FAIL
-
-  [AES-GCM 128-bit key, 104-bit tag, 96-bit iv decryption with altered ciphertext]
-    expected: FAIL
-
-  [AES-GCM 128-bit key, no additional data, 104-bit tag, 96-bit iv decryption with altered ciphertext]
-    expected: FAIL
-
-  [AES-GCM 128-bit key, 112-bit tag, 96-bit iv decryption with altered ciphertext]
-    expected: FAIL
-
-  [AES-GCM 128-bit key, no additional data, 112-bit tag, 96-bit iv decryption with altered ciphertext]
-    expected: FAIL
-
-  [AES-GCM 128-bit key, 120-bit tag, 96-bit iv decryption with altered ciphertext]
-    expected: FAIL
-
-  [AES-GCM 128-bit key, no additional data, 120-bit tag, 96-bit iv decryption with altered ciphertext]
     expected: FAIL
 
   [AES-GCM 192-bit key, 32-bit tag, 96-bit iv decryption with altered ciphertext]
@@ -155,30 +59,6 @@
   [AES-GCM 192-bit key, no additional data, 64-bit tag, 96-bit iv decryption with altered ciphertext]
     expected: FAIL
 
-  [AES-GCM 192-bit key, 96-bit tag, 96-bit iv decryption with altered ciphertext]
-    expected: FAIL
-
-  [AES-GCM 192-bit key, no additional data, 96-bit tag, 96-bit iv decryption with altered ciphertext]
-    expected: FAIL
-
-  [AES-GCM 192-bit key, 104-bit tag, 96-bit iv decryption with altered ciphertext]
-    expected: FAIL
-
-  [AES-GCM 192-bit key, no additional data, 104-bit tag, 96-bit iv decryption with altered ciphertext]
-    expected: FAIL
-
-  [AES-GCM 192-bit key, 112-bit tag, 96-bit iv decryption with altered ciphertext]
-    expected: FAIL
-
-  [AES-GCM 192-bit key, no additional data, 112-bit tag, 96-bit iv decryption with altered ciphertext]
-    expected: FAIL
-
-  [AES-GCM 192-bit key, 120-bit tag, 96-bit iv decryption with altered ciphertext]
-    expected: FAIL
-
-  [AES-GCM 192-bit key, no additional data, 120-bit tag, 96-bit iv decryption with altered ciphertext]
-    expected: FAIL
-
   [AES-GCM 256-bit key, 32-bit tag, 96-bit iv decryption with altered ciphertext]
     expected: FAIL
 
@@ -189,30 +69,6 @@
     expected: FAIL
 
   [AES-GCM 256-bit key, no additional data, 64-bit tag, 96-bit iv decryption with altered ciphertext]
-    expected: FAIL
-
-  [AES-GCM 256-bit key, 96-bit tag, 96-bit iv decryption with altered ciphertext]
-    expected: FAIL
-
-  [AES-GCM 256-bit key, no additional data, 96-bit tag, 96-bit iv decryption with altered ciphertext]
-    expected: FAIL
-
-  [AES-GCM 256-bit key, 104-bit tag, 96-bit iv decryption with altered ciphertext]
-    expected: FAIL
-
-  [AES-GCM 256-bit key, no additional data, 104-bit tag, 96-bit iv decryption with altered ciphertext]
-    expected: FAIL
-
-  [AES-GCM 256-bit key, 112-bit tag, 96-bit iv decryption with altered ciphertext]
-    expected: FAIL
-
-  [AES-GCM 256-bit key, no additional data, 112-bit tag, 96-bit iv decryption with altered ciphertext]
-    expected: FAIL
-
-  [AES-GCM 256-bit key, 120-bit tag, 96-bit iv decryption with altered ciphertext]
-    expected: FAIL
-
-  [AES-GCM 256-bit key, no additional data, 120-bit tag, 96-bit iv decryption with altered ciphertext]
     expected: FAIL
 
 
@@ -229,30 +85,6 @@
   [AES-GCM 128-bit key, no additional data, 64-bit tag, 96-bit iv decryption]
     expected: FAIL
 
-  [AES-GCM 128-bit key, 96-bit tag, 96-bit iv decryption]
-    expected: FAIL
-
-  [AES-GCM 128-bit key, no additional data, 96-bit tag, 96-bit iv decryption]
-    expected: FAIL
-
-  [AES-GCM 128-bit key, 104-bit tag, 96-bit iv decryption]
-    expected: FAIL
-
-  [AES-GCM 128-bit key, no additional data, 104-bit tag, 96-bit iv decryption]
-    expected: FAIL
-
-  [AES-GCM 128-bit key, 112-bit tag, 96-bit iv decryption]
-    expected: FAIL
-
-  [AES-GCM 128-bit key, no additional data, 112-bit tag, 96-bit iv decryption]
-    expected: FAIL
-
-  [AES-GCM 128-bit key, 120-bit tag, 96-bit iv decryption]
-    expected: FAIL
-
-  [AES-GCM 128-bit key, no additional data, 120-bit tag, 96-bit iv decryption]
-    expected: FAIL
-
   [AES-GCM 192-bit key, 32-bit tag, 96-bit iv decryption]
     expected: FAIL
 
@@ -263,30 +95,6 @@
     expected: FAIL
 
   [AES-GCM 192-bit key, no additional data, 64-bit tag, 96-bit iv decryption]
-    expected: FAIL
-
-  [AES-GCM 192-bit key, 96-bit tag, 96-bit iv decryption]
-    expected: FAIL
-
-  [AES-GCM 192-bit key, no additional data, 96-bit tag, 96-bit iv decryption]
-    expected: FAIL
-
-  [AES-GCM 192-bit key, 104-bit tag, 96-bit iv decryption]
-    expected: FAIL
-
-  [AES-GCM 192-bit key, no additional data, 104-bit tag, 96-bit iv decryption]
-    expected: FAIL
-
-  [AES-GCM 192-bit key, 112-bit tag, 96-bit iv decryption]
-    expected: FAIL
-
-  [AES-GCM 192-bit key, no additional data, 112-bit tag, 96-bit iv decryption]
-    expected: FAIL
-
-  [AES-GCM 192-bit key, 120-bit tag, 96-bit iv decryption]
-    expected: FAIL
-
-  [AES-GCM 192-bit key, no additional data, 120-bit tag, 96-bit iv decryption]
     expected: FAIL
 
   [AES-GCM 256-bit key, 32-bit tag, 96-bit iv decryption]
@@ -301,30 +109,6 @@
   [AES-GCM 256-bit key, no additional data, 64-bit tag, 96-bit iv decryption]
     expected: FAIL
 
-  [AES-GCM 256-bit key, 96-bit tag, 96-bit iv decryption]
-    expected: FAIL
-
-  [AES-GCM 256-bit key, no additional data, 96-bit tag, 96-bit iv decryption]
-    expected: FAIL
-
-  [AES-GCM 256-bit key, 104-bit tag, 96-bit iv decryption]
-    expected: FAIL
-
-  [AES-GCM 256-bit key, no additional data, 104-bit tag, 96-bit iv decryption]
-    expected: FAIL
-
-  [AES-GCM 256-bit key, 112-bit tag, 96-bit iv decryption]
-    expected: FAIL
-
-  [AES-GCM 256-bit key, no additional data, 112-bit tag, 96-bit iv decryption]
-    expected: FAIL
-
-  [AES-GCM 256-bit key, 120-bit tag, 96-bit iv decryption]
-    expected: FAIL
-
-  [AES-GCM 256-bit key, no additional data, 120-bit tag, 96-bit iv decryption]
-    expected: FAIL
-
   [AES-GCM 128-bit key, 32-bit tag, 96-bit iv decryption with altered ciphertext]
     expected: FAIL
 
@@ -335,30 +119,6 @@
     expected: FAIL
 
   [AES-GCM 128-bit key, no additional data, 64-bit tag, 96-bit iv decryption with altered ciphertext]
-    expected: FAIL
-
-  [AES-GCM 128-bit key, 96-bit tag, 96-bit iv decryption with altered ciphertext]
-    expected: FAIL
-
-  [AES-GCM 128-bit key, no additional data, 96-bit tag, 96-bit iv decryption with altered ciphertext]
-    expected: FAIL
-
-  [AES-GCM 128-bit key, 104-bit tag, 96-bit iv decryption with altered ciphertext]
-    expected: FAIL
-
-  [AES-GCM 128-bit key, no additional data, 104-bit tag, 96-bit iv decryption with altered ciphertext]
-    expected: FAIL
-
-  [AES-GCM 128-bit key, 112-bit tag, 96-bit iv decryption with altered ciphertext]
-    expected: FAIL
-
-  [AES-GCM 128-bit key, no additional data, 112-bit tag, 96-bit iv decryption with altered ciphertext]
-    expected: FAIL
-
-  [AES-GCM 128-bit key, 120-bit tag, 96-bit iv decryption with altered ciphertext]
-    expected: FAIL
-
-  [AES-GCM 128-bit key, no additional data, 120-bit tag, 96-bit iv decryption with altered ciphertext]
     expected: FAIL
 
   [AES-GCM 192-bit key, 32-bit tag, 96-bit iv decryption with altered ciphertext]
@@ -373,30 +133,6 @@
   [AES-GCM 192-bit key, no additional data, 64-bit tag, 96-bit iv decryption with altered ciphertext]
     expected: FAIL
 
-  [AES-GCM 192-bit key, 96-bit tag, 96-bit iv decryption with altered ciphertext]
-    expected: FAIL
-
-  [AES-GCM 192-bit key, no additional data, 96-bit tag, 96-bit iv decryption with altered ciphertext]
-    expected: FAIL
-
-  [AES-GCM 192-bit key, 104-bit tag, 96-bit iv decryption with altered ciphertext]
-    expected: FAIL
-
-  [AES-GCM 192-bit key, no additional data, 104-bit tag, 96-bit iv decryption with altered ciphertext]
-    expected: FAIL
-
-  [AES-GCM 192-bit key, 112-bit tag, 96-bit iv decryption with altered ciphertext]
-    expected: FAIL
-
-  [AES-GCM 192-bit key, no additional data, 112-bit tag, 96-bit iv decryption with altered ciphertext]
-    expected: FAIL
-
-  [AES-GCM 192-bit key, 120-bit tag, 96-bit iv decryption with altered ciphertext]
-    expected: FAIL
-
-  [AES-GCM 192-bit key, no additional data, 120-bit tag, 96-bit iv decryption with altered ciphertext]
-    expected: FAIL
-
   [AES-GCM 256-bit key, 32-bit tag, 96-bit iv decryption with altered ciphertext]
     expected: FAIL
 
@@ -407,28 +143,4 @@
     expected: FAIL
 
   [AES-GCM 256-bit key, no additional data, 64-bit tag, 96-bit iv decryption with altered ciphertext]
-    expected: FAIL
-
-  [AES-GCM 256-bit key, 96-bit tag, 96-bit iv decryption with altered ciphertext]
-    expected: FAIL
-
-  [AES-GCM 256-bit key, no additional data, 96-bit tag, 96-bit iv decryption with altered ciphertext]
-    expected: FAIL
-
-  [AES-GCM 256-bit key, 104-bit tag, 96-bit iv decryption with altered ciphertext]
-    expected: FAIL
-
-  [AES-GCM 256-bit key, no additional data, 104-bit tag, 96-bit iv decryption with altered ciphertext]
-    expected: FAIL
-
-  [AES-GCM 256-bit key, 112-bit tag, 96-bit iv decryption with altered ciphertext]
-    expected: FAIL
-
-  [AES-GCM 256-bit key, no additional data, 112-bit tag, 96-bit iv decryption with altered ciphertext]
-    expected: FAIL
-
-  [AES-GCM 256-bit key, 120-bit tag, 96-bit iv decryption with altered ciphertext]
-    expected: FAIL
-
-  [AES-GCM 256-bit key, no additional data, 120-bit tag, 96-bit iv decryption with altered ciphertext]
     expected: FAIL

--- a/tests/wpt/meta/WebCryptoAPI/encrypt_decrypt/aes_gcm_256_iv.https.any.js.ini
+++ b/tests/wpt/meta/WebCryptoAPI/encrypt_decrypt/aes_gcm_256_iv.https.any.js.ini
@@ -11,30 +11,6 @@
   [AES-GCM 128-bit key, no additional data, 64-bit tag, 256-bit iv decryption]
     expected: FAIL
 
-  [AES-GCM 128-bit key, 96-bit tag, 256-bit iv decryption]
-    expected: FAIL
-
-  [AES-GCM 128-bit key, no additional data, 96-bit tag, 256-bit iv decryption]
-    expected: FAIL
-
-  [AES-GCM 128-bit key, 104-bit tag, 256-bit iv decryption]
-    expected: FAIL
-
-  [AES-GCM 128-bit key, no additional data, 104-bit tag, 256-bit iv decryption]
-    expected: FAIL
-
-  [AES-GCM 128-bit key, 112-bit tag, 256-bit iv decryption]
-    expected: FAIL
-
-  [AES-GCM 128-bit key, no additional data, 112-bit tag, 256-bit iv decryption]
-    expected: FAIL
-
-  [AES-GCM 128-bit key, 120-bit tag, 256-bit iv decryption]
-    expected: FAIL
-
-  [AES-GCM 128-bit key, no additional data, 120-bit tag, 256-bit iv decryption]
-    expected: FAIL
-
   [AES-GCM 192-bit key, 32-bit tag, 256-bit iv decryption]
     expected: FAIL
 
@@ -45,30 +21,6 @@
     expected: FAIL
 
   [AES-GCM 192-bit key, no additional data, 64-bit tag, 256-bit iv decryption]
-    expected: FAIL
-
-  [AES-GCM 192-bit key, 96-bit tag, 256-bit iv decryption]
-    expected: FAIL
-
-  [AES-GCM 192-bit key, no additional data, 96-bit tag, 256-bit iv decryption]
-    expected: FAIL
-
-  [AES-GCM 192-bit key, 104-bit tag, 256-bit iv decryption]
-    expected: FAIL
-
-  [AES-GCM 192-bit key, no additional data, 104-bit tag, 256-bit iv decryption]
-    expected: FAIL
-
-  [AES-GCM 192-bit key, 112-bit tag, 256-bit iv decryption]
-    expected: FAIL
-
-  [AES-GCM 192-bit key, no additional data, 112-bit tag, 256-bit iv decryption]
-    expected: FAIL
-
-  [AES-GCM 192-bit key, 120-bit tag, 256-bit iv decryption]
-    expected: FAIL
-
-  [AES-GCM 192-bit key, no additional data, 120-bit tag, 256-bit iv decryption]
     expected: FAIL
 
   [AES-GCM 256-bit key, 32-bit tag, 256-bit iv decryption]
@@ -83,30 +35,6 @@
   [AES-GCM 256-bit key, no additional data, 64-bit tag, 256-bit iv decryption]
     expected: FAIL
 
-  [AES-GCM 256-bit key, 96-bit tag, 256-bit iv decryption]
-    expected: FAIL
-
-  [AES-GCM 256-bit key, no additional data, 96-bit tag, 256-bit iv decryption]
-    expected: FAIL
-
-  [AES-GCM 256-bit key, 104-bit tag, 256-bit iv decryption]
-    expected: FAIL
-
-  [AES-GCM 256-bit key, no additional data, 104-bit tag, 256-bit iv decryption]
-    expected: FAIL
-
-  [AES-GCM 256-bit key, 112-bit tag, 256-bit iv decryption]
-    expected: FAIL
-
-  [AES-GCM 256-bit key, no additional data, 112-bit tag, 256-bit iv decryption]
-    expected: FAIL
-
-  [AES-GCM 256-bit key, 120-bit tag, 256-bit iv decryption]
-    expected: FAIL
-
-  [AES-GCM 256-bit key, no additional data, 120-bit tag, 256-bit iv decryption]
-    expected: FAIL
-
   [AES-GCM 128-bit key, 32-bit tag, 256-bit iv decryption with altered ciphertext]
     expected: FAIL
 
@@ -117,30 +45,6 @@
     expected: FAIL
 
   [AES-GCM 128-bit key, no additional data, 64-bit tag, 256-bit iv decryption with altered ciphertext]
-    expected: FAIL
-
-  [AES-GCM 128-bit key, 96-bit tag, 256-bit iv decryption with altered ciphertext]
-    expected: FAIL
-
-  [AES-GCM 128-bit key, no additional data, 96-bit tag, 256-bit iv decryption with altered ciphertext]
-    expected: FAIL
-
-  [AES-GCM 128-bit key, 104-bit tag, 256-bit iv decryption with altered ciphertext]
-    expected: FAIL
-
-  [AES-GCM 128-bit key, no additional data, 104-bit tag, 256-bit iv decryption with altered ciphertext]
-    expected: FAIL
-
-  [AES-GCM 128-bit key, 112-bit tag, 256-bit iv decryption with altered ciphertext]
-    expected: FAIL
-
-  [AES-GCM 128-bit key, no additional data, 112-bit tag, 256-bit iv decryption with altered ciphertext]
-    expected: FAIL
-
-  [AES-GCM 128-bit key, 120-bit tag, 256-bit iv decryption with altered ciphertext]
-    expected: FAIL
-
-  [AES-GCM 128-bit key, no additional data, 120-bit tag, 256-bit iv decryption with altered ciphertext]
     expected: FAIL
 
   [AES-GCM 192-bit key, 32-bit tag, 256-bit iv decryption with altered ciphertext]
@@ -155,30 +59,6 @@
   [AES-GCM 192-bit key, no additional data, 64-bit tag, 256-bit iv decryption with altered ciphertext]
     expected: FAIL
 
-  [AES-GCM 192-bit key, 96-bit tag, 256-bit iv decryption with altered ciphertext]
-    expected: FAIL
-
-  [AES-GCM 192-bit key, no additional data, 96-bit tag, 256-bit iv decryption with altered ciphertext]
-    expected: FAIL
-
-  [AES-GCM 192-bit key, 104-bit tag, 256-bit iv decryption with altered ciphertext]
-    expected: FAIL
-
-  [AES-GCM 192-bit key, no additional data, 104-bit tag, 256-bit iv decryption with altered ciphertext]
-    expected: FAIL
-
-  [AES-GCM 192-bit key, 112-bit tag, 256-bit iv decryption with altered ciphertext]
-    expected: FAIL
-
-  [AES-GCM 192-bit key, no additional data, 112-bit tag, 256-bit iv decryption with altered ciphertext]
-    expected: FAIL
-
-  [AES-GCM 192-bit key, 120-bit tag, 256-bit iv decryption with altered ciphertext]
-    expected: FAIL
-
-  [AES-GCM 192-bit key, no additional data, 120-bit tag, 256-bit iv decryption with altered ciphertext]
-    expected: FAIL
-
   [AES-GCM 256-bit key, 32-bit tag, 256-bit iv decryption with altered ciphertext]
     expected: FAIL
 
@@ -189,30 +69,6 @@
     expected: FAIL
 
   [AES-GCM 256-bit key, no additional data, 64-bit tag, 256-bit iv decryption with altered ciphertext]
-    expected: FAIL
-
-  [AES-GCM 256-bit key, 96-bit tag, 256-bit iv decryption with altered ciphertext]
-    expected: FAIL
-
-  [AES-GCM 256-bit key, no additional data, 96-bit tag, 256-bit iv decryption with altered ciphertext]
-    expected: FAIL
-
-  [AES-GCM 256-bit key, 104-bit tag, 256-bit iv decryption with altered ciphertext]
-    expected: FAIL
-
-  [AES-GCM 256-bit key, no additional data, 104-bit tag, 256-bit iv decryption with altered ciphertext]
-    expected: FAIL
-
-  [AES-GCM 256-bit key, 112-bit tag, 256-bit iv decryption with altered ciphertext]
-    expected: FAIL
-
-  [AES-GCM 256-bit key, no additional data, 112-bit tag, 256-bit iv decryption with altered ciphertext]
-    expected: FAIL
-
-  [AES-GCM 256-bit key, 120-bit tag, 256-bit iv decryption with altered ciphertext]
-    expected: FAIL
-
-  [AES-GCM 256-bit key, no additional data, 120-bit tag, 256-bit iv decryption with altered ciphertext]
     expected: FAIL
 
 
@@ -229,30 +85,6 @@
   [AES-GCM 128-bit key, no additional data, 64-bit tag, 256-bit iv decryption]
     expected: FAIL
 
-  [AES-GCM 128-bit key, 96-bit tag, 256-bit iv decryption]
-    expected: FAIL
-
-  [AES-GCM 128-bit key, no additional data, 96-bit tag, 256-bit iv decryption]
-    expected: FAIL
-
-  [AES-GCM 128-bit key, 104-bit tag, 256-bit iv decryption]
-    expected: FAIL
-
-  [AES-GCM 128-bit key, no additional data, 104-bit tag, 256-bit iv decryption]
-    expected: FAIL
-
-  [AES-GCM 128-bit key, 112-bit tag, 256-bit iv decryption]
-    expected: FAIL
-
-  [AES-GCM 128-bit key, no additional data, 112-bit tag, 256-bit iv decryption]
-    expected: FAIL
-
-  [AES-GCM 128-bit key, 120-bit tag, 256-bit iv decryption]
-    expected: FAIL
-
-  [AES-GCM 128-bit key, no additional data, 120-bit tag, 256-bit iv decryption]
-    expected: FAIL
-
   [AES-GCM 192-bit key, 32-bit tag, 256-bit iv decryption]
     expected: FAIL
 
@@ -263,30 +95,6 @@
     expected: FAIL
 
   [AES-GCM 192-bit key, no additional data, 64-bit tag, 256-bit iv decryption]
-    expected: FAIL
-
-  [AES-GCM 192-bit key, 96-bit tag, 256-bit iv decryption]
-    expected: FAIL
-
-  [AES-GCM 192-bit key, no additional data, 96-bit tag, 256-bit iv decryption]
-    expected: FAIL
-
-  [AES-GCM 192-bit key, 104-bit tag, 256-bit iv decryption]
-    expected: FAIL
-
-  [AES-GCM 192-bit key, no additional data, 104-bit tag, 256-bit iv decryption]
-    expected: FAIL
-
-  [AES-GCM 192-bit key, 112-bit tag, 256-bit iv decryption]
-    expected: FAIL
-
-  [AES-GCM 192-bit key, no additional data, 112-bit tag, 256-bit iv decryption]
-    expected: FAIL
-
-  [AES-GCM 192-bit key, 120-bit tag, 256-bit iv decryption]
-    expected: FAIL
-
-  [AES-GCM 192-bit key, no additional data, 120-bit tag, 256-bit iv decryption]
     expected: FAIL
 
   [AES-GCM 256-bit key, 32-bit tag, 256-bit iv decryption]
@@ -301,30 +109,6 @@
   [AES-GCM 256-bit key, no additional data, 64-bit tag, 256-bit iv decryption]
     expected: FAIL
 
-  [AES-GCM 256-bit key, 96-bit tag, 256-bit iv decryption]
-    expected: FAIL
-
-  [AES-GCM 256-bit key, no additional data, 96-bit tag, 256-bit iv decryption]
-    expected: FAIL
-
-  [AES-GCM 256-bit key, 104-bit tag, 256-bit iv decryption]
-    expected: FAIL
-
-  [AES-GCM 256-bit key, no additional data, 104-bit tag, 256-bit iv decryption]
-    expected: FAIL
-
-  [AES-GCM 256-bit key, 112-bit tag, 256-bit iv decryption]
-    expected: FAIL
-
-  [AES-GCM 256-bit key, no additional data, 112-bit tag, 256-bit iv decryption]
-    expected: FAIL
-
-  [AES-GCM 256-bit key, 120-bit tag, 256-bit iv decryption]
-    expected: FAIL
-
-  [AES-GCM 256-bit key, no additional data, 120-bit tag, 256-bit iv decryption]
-    expected: FAIL
-
   [AES-GCM 128-bit key, 32-bit tag, 256-bit iv decryption with altered ciphertext]
     expected: FAIL
 
@@ -335,30 +119,6 @@
     expected: FAIL
 
   [AES-GCM 128-bit key, no additional data, 64-bit tag, 256-bit iv decryption with altered ciphertext]
-    expected: FAIL
-
-  [AES-GCM 128-bit key, 96-bit tag, 256-bit iv decryption with altered ciphertext]
-    expected: FAIL
-
-  [AES-GCM 128-bit key, no additional data, 96-bit tag, 256-bit iv decryption with altered ciphertext]
-    expected: FAIL
-
-  [AES-GCM 128-bit key, 104-bit tag, 256-bit iv decryption with altered ciphertext]
-    expected: FAIL
-
-  [AES-GCM 128-bit key, no additional data, 104-bit tag, 256-bit iv decryption with altered ciphertext]
-    expected: FAIL
-
-  [AES-GCM 128-bit key, 112-bit tag, 256-bit iv decryption with altered ciphertext]
-    expected: FAIL
-
-  [AES-GCM 128-bit key, no additional data, 112-bit tag, 256-bit iv decryption with altered ciphertext]
-    expected: FAIL
-
-  [AES-GCM 128-bit key, 120-bit tag, 256-bit iv decryption with altered ciphertext]
-    expected: FAIL
-
-  [AES-GCM 128-bit key, no additional data, 120-bit tag, 256-bit iv decryption with altered ciphertext]
     expected: FAIL
 
   [AES-GCM 192-bit key, 32-bit tag, 256-bit iv decryption with altered ciphertext]
@@ -373,30 +133,6 @@
   [AES-GCM 192-bit key, no additional data, 64-bit tag, 256-bit iv decryption with altered ciphertext]
     expected: FAIL
 
-  [AES-GCM 192-bit key, 96-bit tag, 256-bit iv decryption with altered ciphertext]
-    expected: FAIL
-
-  [AES-GCM 192-bit key, no additional data, 96-bit tag, 256-bit iv decryption with altered ciphertext]
-    expected: FAIL
-
-  [AES-GCM 192-bit key, 104-bit tag, 256-bit iv decryption with altered ciphertext]
-    expected: FAIL
-
-  [AES-GCM 192-bit key, no additional data, 104-bit tag, 256-bit iv decryption with altered ciphertext]
-    expected: FAIL
-
-  [AES-GCM 192-bit key, 112-bit tag, 256-bit iv decryption with altered ciphertext]
-    expected: FAIL
-
-  [AES-GCM 192-bit key, no additional data, 112-bit tag, 256-bit iv decryption with altered ciphertext]
-    expected: FAIL
-
-  [AES-GCM 192-bit key, 120-bit tag, 256-bit iv decryption with altered ciphertext]
-    expected: FAIL
-
-  [AES-GCM 192-bit key, no additional data, 120-bit tag, 256-bit iv decryption with altered ciphertext]
-    expected: FAIL
-
   [AES-GCM 256-bit key, 32-bit tag, 256-bit iv decryption with altered ciphertext]
     expected: FAIL
 
@@ -407,28 +143,4 @@
     expected: FAIL
 
   [AES-GCM 256-bit key, no additional data, 64-bit tag, 256-bit iv decryption with altered ciphertext]
-    expected: FAIL
-
-  [AES-GCM 256-bit key, 96-bit tag, 256-bit iv decryption with altered ciphertext]
-    expected: FAIL
-
-  [AES-GCM 256-bit key, no additional data, 96-bit tag, 256-bit iv decryption with altered ciphertext]
-    expected: FAIL
-
-  [AES-GCM 256-bit key, 104-bit tag, 256-bit iv decryption with altered ciphertext]
-    expected: FAIL
-
-  [AES-GCM 256-bit key, no additional data, 104-bit tag, 256-bit iv decryption with altered ciphertext]
-    expected: FAIL
-
-  [AES-GCM 256-bit key, 112-bit tag, 256-bit iv decryption with altered ciphertext]
-    expected: FAIL
-
-  [AES-GCM 256-bit key, no additional data, 112-bit tag, 256-bit iv decryption with altered ciphertext]
-    expected: FAIL
-
-  [AES-GCM 256-bit key, 120-bit tag, 256-bit iv decryption with altered ciphertext]
-    expected: FAIL
-
-  [AES-GCM 256-bit key, no additional data, 120-bit tag, 256-bit iv decryption with altered ciphertext]
     expected: FAIL


### PR DESCRIPTION
We currently only support 128-bit tags for AES-GCM authenticated decryption. This patch expands support to 96-bit, 104-bit, 112-bit, and 120-bit tags.

The specification recommends supporting 32-bit and 64-bit tags as well. However, the `aes-gcm` crate currently does not support them. We may need to look for a workaround or wait for updates from the upstream project.

Testing: Pass some WPT tests that were expected to fail.