### PR TITLE
layout: Ensure that anonymous flex items are properly stored in a `BoxSlot`

### DIFF
--- a/components/layout/construct_modern.rs
+++ b/components/layout/construct_modern.rs
@@ -12,7 +12,7 @@ use style::selector_parser::PseudoElement;
 
 use crate::PropagatedBoxTreeData;
 use crate::context::LayoutContext;
-use crate::dom::{BoxSlot, LayoutBox};
+use crate::dom::{BoxSlot, LayoutBox, NodeExt};
 use crate::dom_traversal::{Contents, NodeAndStyleInfo, TraversalHandler};
 use crate::flow::inline::construct::InlineFormattingContextBuilder;
 use crate::flow::{BlockContainer, BlockFormattingContext};
@@ -68,6 +68,7 @@ impl<'dom> ModernContainerJob<'dom> {
                 let block_formatting_context = BlockFormattingContext::from_block_container(
                     BlockContainer::InlineFormattingContext(inline_formatting_context),
                 );
+
                 let info: &NodeAndStyleInfo = anonymous_info;
                 let formatting_context = IndependentFormattingContext::new(
                     LayoutBoxBase::new(info.into(), info.style.clone()),
@@ -77,7 +78,7 @@ impl<'dom> ModernContainerJob<'dom> {
                 Some(ModernItem {
                     kind: ModernItemKind::InFlow(formatting_context),
                     order: 0,
-                    box_slot: None,
+                    box_slot: anonymous_info.node.box_slot(),
                 })
             },
             ModernContainerJob::ElementOrPseudoElement {
@@ -103,7 +104,7 @@ impl<'dom> ModernContainerJob<'dom> {
                     return Some(ModernItem {
                         kind: ModernItemKind::ReusedBox(layout_box),
                         order,
-                        box_slot: Some(box_slot),
+                        box_slot,
                     });
                 }
 
@@ -131,7 +132,7 @@ impl<'dom> ModernContainerJob<'dom> {
                 Some(ModernItem {
                     kind,
                     order,
-                    box_slot: Some(box_slot),
+                    box_slot,
                 })
             },
         }
@@ -164,7 +165,7 @@ pub(crate) enum ModernItemKind {
 pub(crate) struct ModernItem<'dom> {
     pub kind: ModernItemKind,
     pub order: i32,
-    pub box_slot: Option<BoxSlot<'dom>>,
+    pub box_slot: BoxSlot<'dom>,
 }
 
 impl<'dom> TraversalHandler<'dom> for ModernContainerBuilder<'_, 'dom> {

--- a/components/layout/flexbox/mod.rs
+++ b/components/layout/flexbox/mod.rs
@@ -113,7 +113,7 @@ impl FlexContainer {
         let children = items
             .into_iter()
             .map(|item| {
-                let box_ = match item.kind {
+                let flex_item_box = match item.kind {
                     ModernItemKind::InFlow(independent_formatting_context) => ArcRefCell::new(
                         FlexLevelBox::FlexItem(FlexItemBox::new(independent_formatting_context)),
                     ),
@@ -131,11 +131,9 @@ impl FlexContainer {
                     },
                 };
 
-                if let Some(box_slot) = item.box_slot {
-                    box_slot.set(LayoutBox::FlexLevel(box_.clone()));
-                }
-
-                box_
+                item.box_slot
+                    .set(LayoutBox::FlexLevel(flex_item_box.clone()));
+                flex_item_box
             })
             .collect();
 

--- a/components/layout/taffy/mod.rs
+++ b/components/layout/taffy/mod.rs
@@ -44,7 +44,7 @@ impl TaffyContainer {
         let children = items
             .into_iter()
             .map(|item| {
-                let box_ = match item.kind {
+                let taffy_item_box = match item.kind {
                     ModernItemKind::InFlow(independent_formatting_context) => {
                         ArcRefCell::new(TaffyItemBox::new(TaffyItemBoxInner::InFlowBox(
                             independent_formatting_context,
@@ -64,11 +64,8 @@ impl TaffyContainer {
                     },
                 };
 
-                if let Some(box_slot) = item.box_slot {
-                    box_slot.set(LayoutBox::TaffyItemBox(box_.clone()));
-                }
-
-                box_
+                item.box_slot.set(LayoutBox::TaffyItemBox(taffy_item_box.clone()));
+                taffy_item_box
             })
             .collect();
 

--- a/tests/wpt/tests/css/css-flexbox/anonymous-flex-item-restyle.html
+++ b/tests/wpt/tests/css/css-flexbox/anonymous-flex-item-restyle.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<html class="reftest-wait">
+<meta charset="utf-8">
+<title>CSS Flexbox Test: Flex item - anonymous flex items should be restyled properly</title>
+<link rel="author" title="Martin Robinson" href="mailto:mrobinson@igalia.com">
+<link rel="help" href="https://drafts.csswg.org/css-flexbox/#flex-items">
+<link rel="match" href="../reference/ref-filled-green-100px-square.xht">
+<link rel="stylesheet" type="text/css" href="/fonts/ahem.css"
+
+
+<body>
+    <style>
+        .green { color: green; }
+        div {
+            display: flex;
+            font: 100px/1 Ahem;
+            color: red
+        }
+    </style>
+
+    <p>Test passes if there is a filled green square and <strong>no red</strong>.</p>
+    <div id="flex">X</div>
+
+    <script>
+        window.onload = () => {
+            flex.offsetLeft;
+            flex.classList.add("green")
+            document.documentElement.classList.remove("reftest-wait")
+        }
+    </script>
+</body>
+</html>


### PR DESCRIPTION
When a flex container has text children, those children are wrapped in
an anonymous box and used as flex items. These anonymous boxes must be
stored into `BoxSlot`s so that their style is repairable during
incremental layout.

Testing: This change includes a new WPT test.
Fixes: #41947.
