### PR TITLE
Use published CSP crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1649,8 +1649,9 @@ dependencies = [
 
 [[package]]
 name = "content-security-policy"
-version = "0.5.4"
-source = "git+https://github.com/servo/rust-content-security-policy?branch=servo-csp#22b2831433f306ad22420dca4f5ff685b7fe4cc5"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52efb49c92268e4dcb64ea15d6733630f91bda721ef093f2e83959ea4fa241c0"
 dependencies = [
  "base64 0.22.1",
  "bitflags 2.10.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -59,7 +59,7 @@ chrono = { version = "0.4", features = ["serde"] }
 cipher = { version = "0.4.4", features = ["alloc"] }
 compositing_traits = { path = "components/shared/compositing" }
 constellation_traits = { path = "components/shared/constellation" }
-content-security-policy = { git = "https://github.com/servo/rust-content-security-policy", branch = "servo-csp", features = ["serde"] }
+content-security-policy = { version = "0.6.0", features = ["serde"] }
 cookie = { package = "cookie", version = "0.18" }
 crossbeam-channel = "0.5"
 cssparser = { version = "0.36", features = ["serde"] }


### PR DESCRIPTION
All commits in our fork have landed upstream and they have published 0.6.0 containing those fixes. Therefore, this update should be a noop.
