### PR TITLE
Upgrade MSRV to Rust 1.88

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ publish = false
 # Please also note, that the **default** Rust version in rust-toolchain.toml may be
 # bumped freely.
 # Skip 1.90 which causes mis-compilation: https://github.com/rust-lang/rust/issues/147265
-rust-version = "1.86.0"
+rust-version = "1.88.0"
 
 [workspace.dependencies]
 accountable-refcell = "0.2.2"

--- a/components/bluetooth/lib.rs
+++ b/components/bluetooth/lib.rs
@@ -100,11 +100,10 @@ fn matches_filter(device: &BluetoothDevice, filter: &BluetoothScanfilter) -> boo
     }
 
     // Step 1.
-    if let Some(name) = filter.get_name() {
-        if device.get_name().ok() != Some(name.to_string()) {
+    if let Some(name) = filter.get_name()
+        && device.get_name().ok() != Some(name.to_string()) {
             return false;
         }
-    }
 
     // Step 2.
     if !filter.get_name_prefix().is_empty() {
@@ -118,15 +117,14 @@ fn matches_filter(device: &BluetoothDevice, filter: &BluetoothScanfilter) -> boo
     }
 
     // Step 3.
-    if !filter.get_services().is_empty() {
-        if let Ok(device_uuids) = device.get_uuids() {
+    if !filter.get_services().is_empty()
+        && let Ok(device_uuids) = device.get_uuids() {
             for service in filter.get_services() {
                 if !device_uuids.iter().any(|x| x == service) {
                     return false;
                 }
             }
         }
-    }
 
     // Step 4.
     if let Some(manufacturer_data) = filter.get_manufacturer_data() {
@@ -727,30 +725,28 @@ impl BluetoothManager {
                     return Err(BluetoothError::InvalidState);
                 }
                 // Step 6.
-                if let Some(ref uuid) = uuid {
-                    if !self
+                if let Some(ref uuid) = uuid
+                    && !self
                         .allowed_services
                         .get(&id)
                         .is_some_and(|s| s.contains(uuid))
                     {
                         return Err(BluetoothError::Security);
                     }
-                }
                 let mut services = self.get_and_cache_gatt_services(&mut adapter, &id);
                 if let Some(uuid) = uuid {
                     services.retain(|e| e.get_uuid().unwrap_or_default() == uuid);
                 }
                 let mut services_vec = vec![];
                 for service in services {
-                    if service.is_primary().unwrap_or(false) {
-                        if let Ok(uuid) = service.get_uuid() {
+                    if service.is_primary().unwrap_or(false)
+                        && let Ok(uuid) = service.get_uuid() {
                             services_vec.push(BluetoothServiceMsg {
                                 uuid,
                                 is_primary: true,
                                 instance_id: service.get_id(),
                             });
                         }
-                    }
                 }
                 // Step 7.
                 if services_vec.is_empty() {

--- a/components/compositing/painter.rs
+++ b/components/compositing/painter.rs
@@ -1413,14 +1413,12 @@ impl Painter {
         if self
             .lcp_calculator
             .append_lcp_candidate(webview_id, pipeline_id.into(), lcp_candidate)
-        {
-            if let Some(webview_renderer) = self.webview_renderers.get_mut(&webview_id) {
+            && let Some(webview_renderer) = self.webview_renderers.get_mut(&webview_id) {
                 webview_renderer
                     .ensure_pipeline_details(pipeline_id)
                     .largest_contentful_paint_metric
                     .set(PaintMetricState::Seen(epoch.into(), false));
-            }
-        };
+            };
     }
 
     /// Disable LCP feature when the user interacts with the page.

--- a/components/compositing/touch.rs
+++ b/components/compositing/touch.rs
@@ -290,11 +290,10 @@ impl TouchHandler {
 
     // try to remove touch sequence, if touch sequence end and not has pending action.
     pub(crate) fn try_remove_touch_sequence(&mut self, sequence_id: TouchSequenceId) {
-        if let Some(sequence) = self.touch_sequence_map.get(&sequence_id) {
-            if sequence.pending_touch_move_actions.is_empty() && sequence.state == Finished {
+        if let Some(sequence) = self.touch_sequence_map.get(&sequence_id)
+            && sequence.pending_touch_move_actions.is_empty() && sequence.state == Finished {
                 self.touch_sequence_map.remove(&sequence_id);
             }
-        }
     }
 
     pub(crate) fn remove_touch_sequence(&mut self, sequence_id: TouchSequenceId) {
@@ -511,11 +510,10 @@ impl TouchHandler {
         };
         // If the touch action is not `NoAction` and the first move has not been processed,
         //  set pending_touch_move_action.
-        if let Some(action) = action {
-            if touch_sequence.prevent_move == TouchMoveAllowed::Pending {
+        if let Some(action) = action
+            && touch_sequence.prevent_move == TouchMoveAllowed::Pending {
                 touch_sequence.add_pending_touch_move_action(action);
             }
-        }
 
         action
     }
@@ -643,14 +641,13 @@ impl TouchHandler {
         value: PaintHitTestResult,
         device_pixels_per_page: Scale<f32, CSSPixel, DevicePixel>,
     ) {
-        if let Some(sequence) = self.touch_sequence_map.get_mut(&self.current_sequence_id) {
-            if sequence.hit_test_result_cache.is_none() {
+        if let Some(sequence) = self.touch_sequence_map.get_mut(&self.current_sequence_id)
+            && sequence.hit_test_result_cache.is_none() {
                 sequence.hit_test_result_cache = Some(HitTestResultCache {
                     value,
                     device_pixels_per_page,
                 });
             }
-        }
     }
 
     pub(crate) fn add_pending_touch_input_event(

--- a/components/compositing/webview_renderer.rs
+++ b/components/compositing/webview_renderer.rs
@@ -588,15 +588,14 @@ impl WebViewRenderer {
                     );
                     self.touch_handler
                         .set_handling_touch_move(self.touch_handler.current_sequence_id, false);
-                    if let Some(info) = self.touch_handler.get_touch_sequence_mut(sequence_id) {
-                        if info.prevent_move == TouchMoveAllowed::Pending {
+                    if let Some(info) = self.touch_handler.get_touch_sequence_mut(sequence_id)
+                        && info.prevent_move == TouchMoveAllowed::Pending {
                             info.prevent_move = TouchMoveAllowed::Allowed;
                             if let TouchSequenceState::PendingFling { velocity, point } = info.state
                             {
                                 info.state = TouchSequenceState::Flinging { velocity, point }
                             }
                         }
-                    }
                 },
                 TouchEventType::Up => {
                     let Some(info) = self.touch_handler.get_touch_sequence_mut(sequence_id) else {
@@ -1049,14 +1048,13 @@ impl WebViewRenderer {
                 );
         }
 
-        if let Some(wheel_event) = self.pending_wheel_events.remove(&id) {
-            if !result.contains(InputEventResult::DefaultPrevented) {
+        if let Some(wheel_event) = self.pending_wheel_events.remove(&id)
+            && !result.contains(InputEventResult::DefaultPrevented) {
                 // A scroll delta for a wheel event is the inverse of the wheel delta.
                 let scroll_delta =
                     DeviceVector2D::new(-wheel_event.delta.x as f32, -wheel_event.delta.y as f32);
                 self.notify_scroll_event(Scroll::Delta(scroll_delta.into()), wheel_event.point);
             }
-        }
     }
 }
 

--- a/components/config/opts.rs
+++ b/components/config/opts.rs
@@ -140,11 +140,10 @@ impl DiagnosticsLogging {
         // Disabled for production builds
         #[cfg(debug_assertions)]
         {
-            if let Ok(diagnostics_var) = std::env::var("SERVO_DIAGNOSTICS") {
-                if let Err(error) = config.extend_from_string(&diagnostics_var) {
+            if let Ok(diagnostics_var) = std::env::var("SERVO_DIAGNOSTICS")
+                && let Err(error) = config.extend_from_string(&diagnostics_var) {
                     eprintln!("Could not parse debug logging option: {error}");
                 }
-            }
         }
 
         config

--- a/components/constellation/event_loop.rs
+++ b/components/constellation/event_loop.rs
@@ -204,11 +204,10 @@ impl EventLoop {
         &self,
         message: &BackgroundHangMonitorControlMsg,
     ) {
-        if let Some(background_hang_monitor_sender) = &self.background_hang_monitor_sender {
-            if let Err(error) = background_hang_monitor_sender.send(message.clone()) {
+        if let Some(background_hang_monitor_sender) = &self.background_hang_monitor_sender
+            && let Err(error) = background_hang_monitor_sender.send(message.clone()) {
                 error!("Could not send message ({message:?}) to BHM: {error}");
             }
-        }
     }
 }
 

--- a/components/devtools/actors/console.rs
+++ b/components/devtools/actors/console.rs
@@ -233,8 +233,8 @@ impl ConsoleActor {
             return;
         }
         let resource_type = resource.resource_type();
-        if id == self.current_unique_id(registry) {
-            if let Root::BrowsingContext(bc) = &self.root {
+        if id == self.current_unique_id(registry)
+            && let Root::BrowsingContext(bc) = &self.root {
                 registry.find::<BrowsingContextActor>(bc).resource_array(
                     resource,
                     resource_type,
@@ -242,7 +242,6 @@ impl ConsoleActor {
                     stream,
                 )
             };
-        }
     }
 
     pub(crate) fn send_clear_message(
@@ -251,8 +250,8 @@ impl ConsoleActor {
         registry: &ActorRegistry,
         stream: &mut TcpStream,
     ) {
-        if id == self.current_unique_id(registry) {
-            if let Root::BrowsingContext(bc) = &self.root {
+        if id == self.current_unique_id(registry)
+            && let Root::BrowsingContext(bc) = &self.root {
                 registry.find::<BrowsingContextActor>(bc).resource_array(
                     ConsoleClearMessage {
                         level: "clear".to_owned(),
@@ -262,7 +261,6 @@ impl ConsoleActor {
                     stream,
                 )
             };
-        }
     }
 
     pub(crate) fn get_cached_messages(

--- a/components/devtools/actors/timeline.rs
+++ b/components/devtools/actors/timeline.rs
@@ -215,15 +215,14 @@ impl Actor for TimelineActor {
                 *self.stream.borrow_mut() = request.try_clone_stream().ok();
 
                 // init memory actor
-                if let Some(with_memory) = msg.get("withMemory") {
-                    if let Some(true) = with_memory.as_bool() {
+                if let Some(with_memory) = msg.get("withMemory")
+                    && let Some(true) = with_memory.as_bool() {
                         *self.memory_actor.borrow_mut() = Some(MemoryActor::create(registry));
                     }
-                }
 
                 // init framerate actor
-                if let Some(with_ticks) = msg.get("withTicks") {
-                    if let Some(true) = with_ticks.as_bool() {
+                if let Some(with_ticks) = msg.get("withTicks")
+                    && let Some(true) = with_ticks.as_bool() {
                         let framerate_actor = Some(FramerateActor::create(
                             registry,
                             self.pipeline_id,
@@ -231,7 +230,6 @@ impl Actor for TimelineActor {
                         ));
                         *self.framerate_actor.borrow_mut() = framerate_actor;
                     }
-                }
 
                 let emitter = Emitter::new(
                     self.name(),

--- a/components/devtools/lib.rs
+++ b/components/devtools/lib.rs
@@ -631,17 +631,14 @@ fn allow_devtools_client(stream: &mut TcpStream, embedder: &EmbedderProxy, token
     stream.set_read_timeout(Some(timeout)).unwrap();
     let peek = stream.peek(&mut buf);
     stream.set_read_timeout(None).unwrap();
-    if let Ok(len) = peek {
-        if len == buf.len() {
-            if let Ok(s) = std::str::from_utf8(&buf) {
-                if s == token {
+    if let Ok(len) = peek
+        && len == buf.len()
+            && let Ok(s) = std::str::from_utf8(&buf)
+                && s == token {
                     // Consume the message as it was relevant to us.
                     let _ = stream.read_exact(&mut buf);
                     return true;
-                }
-            }
-        }
-    };
+                };
 
     // No token found. Prompt user
     let (request_sender, request_receiver) =

--- a/components/fonts/font.rs
+++ b/components/fonts/font.rs
@@ -652,13 +652,12 @@ impl FontGroup {
             return font_or_synthesized_small_caps(font);
         }
 
-        if let Some(ref first_fallback) = first_fallback {
-            if char_in_template(first_fallback.template.clone()) &&
+        if let Some(ref first_fallback) = first_fallback
+            && char_in_template(first_fallback.template.clone()) &&
                 font_has_glyph_and_presentation(first_fallback)
             {
                 return font_or_synthesized_small_caps(first_fallback.clone());
             }
-        }
 
         if let Some(font) = self.find_fallback(
             font_context,

--- a/components/layout/display_list/mod.rs
+++ b/components/layout/display_list/mod.rs
@@ -596,8 +596,8 @@ impl Fragment {
     ) {
         let spatial_id = builder.spatial_id(builder.current_scroll_node_id);
         let clip_chain_id = builder.clip_chain_id(builder.current_clip_id);
-        if let Some(inspector_highlight) = &mut builder.inspector_highlight {
-            if self.tag() == Some(inspector_highlight.tag) {
+        if let Some(inspector_highlight) = &mut builder.inspector_highlight
+            && self.tag() == Some(inspector_highlight.tag) {
                 inspector_highlight.register_fragment_of_highlighted_dom_node(
                     self,
                     spatial_id,
@@ -605,7 +605,6 @@ impl Fragment {
                     containing_block,
                 );
             }
-        }
 
         match self {
             Fragment::Box(box_fragment) | Fragment::Float(box_fragment) => {

--- a/components/layout/flexbox/layout.rs
+++ b/components/layout/flexbox/layout.rs
@@ -1444,13 +1444,12 @@ impl InitialFlexLineLayout<'_> {
 
     /// <https://drafts.csswg.org/css-flexbox/#algo-cross-line>
     fn cross_size<'items>(items: &'items [FlexLineItem<'items>], flex_context: &FlexContext) -> Au {
-        if flex_context.config.container_is_single_line {
-            if let SizeConstraint::Definite(size) =
+        if flex_context.config.container_is_single_line
+            && let SizeConstraint::Definite(size) =
                 flex_context.container_inner_size_constraint.cross
             {
                 return size;
             }
-        }
 
         let mut max_ascent = Au::zero();
         let mut max_descent = Au::zero();

--- a/components/layout/flow/construct.rs
+++ b/components/layout/flow/construct.rs
@@ -168,8 +168,8 @@ impl BlockContainer {
     ) -> BlockContainer {
         let mut builder = BlockContainerBuilder::new(context, info, propagated_data);
 
-        if is_list_item {
-            if let Some((marker_info, marker_contents)) = crate::lists::make_marker(context, info) {
+        if is_list_item
+            && let Some((marker_info, marker_contents)) = crate::lists::make_marker(context, info) {
                 match marker_info.style.clone_list_style_position() {
                     ListStylePosition::Inside => {
                         builder.handle_list_item_marker_inside(&marker_info, marker_contents)
@@ -181,7 +181,6 @@ impl BlockContainer {
                     ),
                 }
             }
-        }
 
         contents.traverse(context, info, &mut builder);
         builder.finish()
@@ -481,8 +480,8 @@ impl<'dom> BlockContainerBuilder<'dom, '_> {
             inline_builder.inline_items.last().unwrap().clone(),
         ));
 
-        if is_list_item {
-            if let Some((marker_info, marker_contents)) =
+        if is_list_item
+            && let Some((marker_info, marker_contents)) =
                 crate::lists::make_marker(self.context, info)
             {
                 // Ignore `list-style-position` here:
@@ -490,7 +489,6 @@ impl<'dom> BlockContainerBuilder<'dom, '_> {
                 // https://drafts.csswg.org/css-lists/#list-style-position-outside
                 self.handle_list_item_marker_inside(&marker_info, marker_contents)
             }
-        }
 
         // `unwrap` doesn’t panic here because `is_replaced` returned `false`.
         non_replaced_contents.traverse(self.context, info, self);
@@ -616,8 +614,8 @@ impl<'dom> BlockContainerBuilder<'dom, '_> {
         contents: Contents,
         box_slot: BoxSlot<'dom>,
     ) {
-        if let Some(builder) = self.inline_formatting_context_builder.as_mut() {
-            if !builder.is_empty {
+        if let Some(builder) = self.inline_formatting_context_builder.as_mut()
+            && !builder.is_empty {
                 let constructor = || {
                     ArcRefCell::new(FloatBox::construct(
                         self.context,
@@ -632,7 +630,6 @@ impl<'dom> BlockContainerBuilder<'dom, '_> {
                 box_slot.set(LayoutBox::InlineLevel(inline_level_box));
                 return;
             }
-        }
 
         let kind = BlockLevelCreator::OutOfFlowFloatBox {
             contents,
@@ -682,14 +679,13 @@ impl BlockLevelJob<'_> {
 
         // If this `BlockLevelBox` is undamaged and it has been laid out before, reuse
         // the old one, while being sure to clear the layout cache.
-        if !info.damage.has_box_damage() {
-            if let Some(block_level_box) = match &*self.box_slot.slot.borrow() {
+        if !info.damage.has_box_damage()
+            && let Some(block_level_box) = match &*self.box_slot.slot.borrow() {
                 Some(LayoutBox::BlockLevel(block_level_box)) => Some(block_level_box.clone()),
                 _ => None,
             } {
                 return block_level_box;
             }
-        }
 
         let block_level_box = match self.kind {
             BlockLevelCreator::SameFormattingContextBlock(intermediate_block_container) => {

--- a/components/layout/flow/float.rs
+++ b/components/layout/flow/float.rs
@@ -828,9 +828,9 @@ impl FloatBandLink {
     ///     A   B          B   R
     /// ```
     fn skew(&self) -> FloatBandLink {
-        if let Some(ref this) = self.0 {
-            if let Some(ref left) = this.left.0 {
-                if this.level == left.level {
+        if let Some(ref this) = self.0
+            && let Some(ref left) = this.left.0
+                && this.level == left.level {
                     return FloatBandLink(Some(Arc::new(FloatBandNode {
                         level: this.level,
                         left: left.left.clone(),
@@ -843,8 +843,6 @@ impl FloatBandLink {
                         }))),
                     })));
                 }
-            }
-        }
 
         (*self).clone()
     }
@@ -858,10 +856,10 @@ impl FloatBandLink {
     ///         B   X    A   B
     /// ```
     fn split(&self) -> FloatBandLink {
-        if let Some(ref this) = self.0 {
-            if let Some(ref right) = this.right.0 {
-                if let Some(ref right_right) = right.right.0 {
-                    if this.level == right_right.level {
+        if let Some(ref this) = self.0
+            && let Some(ref right) = this.right.0
+                && let Some(ref right_right) = right.right.0
+                    && this.level == right_right.level {
                         return FloatBandLink(Some(Arc::new(FloatBandNode {
                             level: this.level + 1,
                             left: FloatBandLink(Some(Arc::new(FloatBandNode {
@@ -874,9 +872,6 @@ impl FloatBandLink {
                             right: right.right.clone(),
                         })));
                     }
-                }
-            }
-        }
 
         (*self).clone()
     }

--- a/components/layout/flow/inline/construct.rs
+++ b/components/layout/flow/inline/construct.rs
@@ -206,14 +206,13 @@ impl InlineFormattingContextBuilder {
         assert!(self.currently_processing_inline_box());
         self.contains_floats = self.contains_floats || block_level_box.borrow().contains_floats();
 
-        if let Some(InlineItem::AnonymousBlock(anonymous_block)) = self.inline_items.last() {
-            if let BlockContainer::BlockLevelBoxes(ref mut block_level_boxes) =
+        if let Some(InlineItem::AnonymousBlock(anonymous_block)) = self.inline_items.last()
+            && let BlockContainer::BlockLevelBoxes(ref mut block_level_boxes) =
                 anonymous_block.borrow_mut().contents
             {
                 block_level_boxes.push(block_level_box);
                 return;
             }
-        }
         let info = &block_builder_info
             .with_pseudo_element(layout_context, PseudoElement::ServoAnonymousBox)
             .expect("Should never fail to create anonymous box");
@@ -646,8 +645,8 @@ pub(crate) fn capitalize_string(string: &str, allow_word_at_start: bool) -> Stri
         let current_byte_index = byte_index;
         byte_index += character.len_utf8();
 
-        if let Some(next_index) = bounds.peek() {
-            if *next_index == current_byte_index {
+        if let Some(next_index) = bounds.peek()
+            && *next_index == current_byte_index {
                 bounds.next();
 
                 if current_byte_index != 0 || allow_word_at_start {
@@ -655,7 +654,6 @@ pub(crate) fn capitalize_string(string: &str, allow_word_at_start: bool) -> Stri
                     continue;
                 }
             }
-        }
 
         output_string.push(character);
     }

--- a/components/layout/flow/inline/mod.rs
+++ b/components/layout/flow/inline/mod.rs
@@ -2483,11 +2483,10 @@ impl FloatBox {
 
 fn place_pending_floats(ifc: &mut InlineFormattingContextLayout, line_items: &mut [LineItem]) {
     for item in line_items.iter_mut() {
-        if let LineItem::Float(_, float_line_item) = item {
-            if float_line_item.needs_placement {
+        if let LineItem::Float(_, float_line_item) = item
+            && float_line_item.needs_placement {
                 ifc.place_float_fragment(&mut float_line_item.fragment.borrow_mut());
             }
-        }
     }
 }
 

--- a/components/layout/flow/inline/text_run.rs
+++ b/components/layout/flow/inline/text_run.rs
@@ -506,11 +506,10 @@ impl TextRun {
             };
 
             // If the existing segment is compatible with the character, keep going.
-            if let Some(current) = current.as_mut() {
-                if current.update_if_compatible(layout_context, &font, script, bidi_level) {
+            if let Some(current) = current.as_mut()
+                && current.update_if_compatible(layout_context, &font, script, bidi_level) {
                     continue;
                 }
-            }
 
             // Add the new segment and finish the existing one, if we had one. If the first
             // characters in the run were control characters we may be creating the first

--- a/components/layout/flow/root.rs
+++ b/components/layout/flow/root.rs
@@ -113,11 +113,10 @@ impl BoxTree {
 
         root_box.borrow_mut().with_base_mut(|base| {
             let root_overflow = AxesOverflow::from(&*base.style);
-            if root_overflow.x == Overflow::Visible && root_overflow.y == Overflow::Visible {
-                if let Some(body_overflow) = propagate_from_body() {
+            if root_overflow.x == Overflow::Visible && root_overflow.y == Overflow::Visible
+                && let Some(body_overflow) = propagate_from_body() {
                     return body_overflow;
                 }
-            }
             base.base_fragment_info
                 .flags
                 .insert(FragmentFlags::PROPAGATED_OVERFLOW_TO_VIEWPORT);

--- a/components/layout/layout_impl.rs
+++ b/components/layout/layout_impl.rs
@@ -1317,9 +1317,9 @@ impl LayoutThread {
             &stacking_context_tree.paint_info,
             built_display_list,
         );
-        if let Some(lcp_candidate_collector) = lcp_candidate_collector.as_mut() {
-            if lcp_candidate_collector.did_lcp_candidate_update {
-                if let Some(lcp_candidate) = lcp_candidate_collector.largest_contentful_paint() {
+        if let Some(lcp_candidate_collector) = lcp_candidate_collector.as_mut()
+            && lcp_candidate_collector.did_lcp_candidate_update
+                && let Some(lcp_candidate) = lcp_candidate_collector.largest_contentful_paint() {
                     self.paint_api.send_lcp_candidate(
                         lcp_candidate,
                         self.webview_id,
@@ -1328,8 +1328,6 @@ impl LayoutThread {
                     );
                     lcp_candidate_collector.did_lcp_candidate_update = false;
                 }
-            }
-        }
 
         let (keys, instance_keys) = self
             .font_context

--- a/components/layout/positioned.rs
+++ b/components/layout/positioned.rs
@@ -222,7 +222,6 @@ impl PositioningContext {
             return;
         }
 
-        // TODO: This could potentially use `extract_if` when that is stabilized.
         let (mut boxes_to_layout, mut boxes_to_continue_hoisting) = self
             .absolutes
             .drain(..)

--- a/components/layout/query.rs
+++ b/components/layout/query.rs
@@ -370,13 +370,11 @@ pub fn process_resolved_style_request(
         // > resolved value special case properties.
         //
         // > When an element generates a grid container box...
-        if display.inside() == DisplayInside::Grid {
-            if let Some(SpecificLayoutInfo::Grid(info)) = specific_layout_info {
-                if let Some(value) = resolve_grid_template(&info, style, longhand_id) {
+        if display.inside() == DisplayInside::Grid
+            && let Some(SpecificLayoutInfo::Grid(info)) = specific_layout_info
+                && let Some(value) = resolve_grid_template(&info, style, longhand_id) {
                     return value;
                 }
-            }
-        }
 
         // https://drafts.csswg.org/cssom/#resolved-value-special-case-property-like-height
         // > If the property applies to the element or pseudo-element and the resolved value of the

--- a/components/layout/replaced.rs
+++ b/components/layout/replaced.rs
@@ -138,15 +138,14 @@ impl ReplacedContents {
         node: ServoThreadSafeLayoutNode<'_>,
         context: &LayoutContext,
     ) -> Option<Self> {
-        if let Some(ref data_attribute_string) = node.as_typeless_object_with_data_attribute() {
-            if let Some(url) = try_to_parse_image_data_url(data_attribute_string) {
+        if let Some(ref data_attribute_string) = node.as_typeless_object_with_data_attribute()
+            && let Some(url) = try_to_parse_image_data_url(data_attribute_string) {
                 return Self::from_image_url(
                     node,
                     context,
                     &ComputedUrl::Valid(ServoArc::new(url)),
                 );
             }
-        }
 
         let (kind, natural_size) = {
             if let Some((image, natural_size_in_dots)) = node.as_image() {

--- a/components/layout/traversal.rs
+++ b/components/layout/traversal.rs
@@ -122,12 +122,11 @@ pub(crate) fn compute_damage_and_repair_style_inner(
         original_element_damage = element_data.damage;
         element_damage = original_element_damage | damage_from_parent;
 
-        if let Some(ref style) = element_data.styles.primary {
-            if style.get_box().display == Display::None {
+        if let Some(ref style) = element_data.styles.primary
+            && style.get_box().display == Display::None {
                 element_data.damage = element_damage;
                 return element_damage;
             }
-        }
     }
 
     // If we are reconstructing this node, then all of the children should be reconstructed as well.

--- a/components/net/cookie.rs
+++ b/components/net/cookie.rs
@@ -351,18 +351,16 @@ impl ServoCookie {
             if self.cookie.domain() != domain {
                 return false;
             }
-        } else if let (Some(domain), Some(cookie_domain)) = (domain, &self.cookie.domain()) {
-            if !ServoCookie::domain_match(domain, cookie_domain) {
+        } else if let (Some(domain), Some(cookie_domain)) = (domain, &self.cookie.domain())
+            && !ServoCookie::domain_match(domain, cookie_domain) {
                 return false;
             }
-        }
 
         // The retrieval's URI's path path-matches the cookie's path.
-        if let Some(cookie_path) = self.cookie.path() {
-            if !ServoCookie::path_match(url.path(), cookie_path) {
+        if let Some(cookie_path) = self.cookie.path()
+            && !ServoCookie::path_match(url.path(), cookie_path) {
                 return false;
             }
-        }
 
         // If the cookie's secure-only-flag is true, then the retrieval's URI must denote a "secure" connection
         if self.cookie.secure().unwrap_or(false) && !url.is_secure_scheme() {
@@ -500,8 +498,8 @@ impl ServoCookie {
         let (_, date_tokens) = cookie_date(string_in_bytes).ok()?;
         for date_token in date_tokens {
             // Step 2.1. If the found-time flag is not set and the token matches the time production,
-            if time_value.is_none() {
-                if let Ok((_, result)) = time(date_token) {
+            if time_value.is_none()
+                && let Ok((_, result)) = time(date_token) {
                     // set the found-time flag and set the hour-value, minute-value, and
                     // second-value to the numbers denoted by the digits in the date-token,
                     // respectively.
@@ -515,23 +513,21 @@ impl ServoCookie {
                     // Skip the remaining sub-steps and continue to the next date-token.
                     continue;
                 }
-            }
 
             // Step 2.2. If the found-day-of-month flag is not set and the date-token matches the
             // day-of-month production,
-            if day_of_month_value.is_none() {
-                if let Ok((_, result)) = day_of_month(date_token) {
+            if day_of_month_value.is_none()
+                && let Ok((_, result)) = day_of_month(date_token) {
                     // set the found-day-of-month flag and set the day-of-month-value to the number
                     // denoted by the date-token.
                     day_of_month_value = parse_ascii_u8(result);
                     // Skip the remaining sub-steps and continue to the next date-token.
                     continue;
                 }
-            }
 
             // Step 2.3. If the found-month flag is not set and the date-token matches the month production,
-            if month_value.is_none() {
-                if let Ok((_, result)) = month(date_token) {
+            if month_value.is_none()
+                && let Ok((_, result)) = month(date_token) {
                     // set the found-month flag and set the month-value to the month denoted by the date-token.
                     month_value = match std::str::from_utf8(result)
                         .unwrap()
@@ -555,34 +551,30 @@ impl ServoCookie {
                     // Skip the remaining sub-steps and continue to the next date-token.
                     continue;
                 }
-            }
 
             // Step 2.4. If the found-year flag is not set and the date-token matches the year production,
-            if year_value.is_none() {
-                if let Ok((_, result)) = year(date_token) {
+            if year_value.is_none()
+                && let Ok((_, result)) = year(date_token) {
                     // set the found-year flag and set the year-value to the number denoted by the date-token.
                     year_value = parse_ascii_i32(result);
                     // Skip the remaining sub-steps and continue to the next date-token.
                     continue;
                 }
-            }
         }
 
         // Step 3. If the year-value is greater than or equal to 70 and less than or equal to 99,
         // increment the year-value by 1900.
-        if let Some(value) = year_value {
-            if (70..=99).contains(&value) {
+        if let Some(value) = year_value
+            && (70..=99).contains(&value) {
                 year_value = Some(value + 1900);
             }
-        }
 
         // Step 4. If the year-value is greater than or equal to 0 and less than or equal to 69,
         // increment the year-value by 2000.
-        if let Some(value) = year_value {
-            if (0..=69).contains(&value) {
+        if let Some(value) = year_value
+            && (0..=69).contains(&value) {
                 year_value = Some(value + 2000);
             }
-        }
 
         // Step 5. Abort these steps and fail to parse the cookie-date if:
         // * at least one of the found-day-of-month, found-month, found-year, or found-time flags is not set,
@@ -594,25 +586,22 @@ impl ServoCookie {
             return None;
         }
         // * the day-of-month-value is less than 1 or greater than 31,
-        if let Some(value) = day_of_month_value {
-            if !(1..=31).contains(&value) {
+        if let Some(value) = day_of_month_value
+            && !(1..=31).contains(&value) {
                 return None;
             }
-        }
         // * the year-value is less than 1601,
-        if let Some(value) = year_value {
-            if value < 1601 {
+        if let Some(value) = year_value
+            && value < 1601 {
                 return None;
             }
-        }
         // * the hour-value is greater than 23,
         // * the minute-value is greater than 59, or
         // * the second-value is greater than 59.
-        if let Some((hour_value, minute_value, second_value)) = time_value {
-            if hour_value > 23 || minute_value > 59 || second_value > 59 {
+        if let Some((hour_value, minute_value, second_value)) = time_value
+            && (hour_value > 23 || minute_value > 59 || second_value > 59) {
                 return None;
             }
-        }
 
         // Step 6. Let the parsed-cookie-date be the date whose day-of-month, month, year, hour,
         // minute, and second (in UTC) are the day-of-month-value, the month-value, the year-value,

--- a/components/net/fetch/methods.rs
+++ b/components/net/fetch/methods.rs
@@ -882,11 +882,10 @@ impl RangeRequestBounds {
     pub fn get_final(&self, len: Option<u64>) -> Result<RelativePos, &'static str> {
         match self {
             RangeRequestBounds::Final(pos) => {
-                if let Some(len) = len {
-                    if pos.start <= len as i64 {
+                if let Some(len) = len
+                    && pos.start <= len as i64 {
                         return Ok(*pos);
                     }
-                }
                 Err("Tried to process RangeRequestBounds::Final without len")
             },
             RangeRequestBounds::Pending(offset) => Ok(RelativePos::from_opts(

--- a/components/net/hsts.rs
+++ b/components/net/hsts.rs
@@ -243,8 +243,8 @@ impl HstsList {
             return;
         }
 
-        if let Some(header) = headers.typed_get::<StrictTransportSecurity>() {
-            if let Some(host) = url.domain() {
+        if let Some(header) = headers.typed_get::<StrictTransportSecurity>()
+            && let Some(host) = url.domain() {
                 let include_subdomains = if header.include_subdomains() {
                     IncludeSubdomains::Included
                 } else {
@@ -263,6 +263,5 @@ impl HstsList {
                     self.push(entry);
                 }
             }
-        }
     }
 }

--- a/components/net/http_cache.rs
+++ b/components/net/http_cache.rs
@@ -180,11 +180,10 @@ fn response_is_cacheable(metadata: &Metadata) -> bool {
             return true;
         }
     }
-    if let Some(pragma) = headers.typed_get::<Pragma>() {
-        if pragma.is_no_cache() {
+    if let Some(pragma) = headers.typed_get::<Pragma>()
+        && pragma.is_no_cache() {
             return false;
         }
-    }
     is_cacheable
 }
 
@@ -260,11 +259,10 @@ fn get_response_expiry(response: &Response) -> Duration {
             return heuristic_freshness;
         }
         // Other status codes can only use heuristic freshness if the public cache directive is present.
-        if let Some(ref directives) = response.headers.typed_get::<CacheControl>() {
-            if directives.public() {
+        if let Some(ref directives) = response.headers.typed_get::<CacheControl>()
+            && directives.public() {
                 return heuristic_freshness;
             }
-        }
     }
     // Requires validation upon first use as default.
     Duration::ZERO
@@ -723,20 +721,16 @@ pub(crate) async fn invalidate(
         .headers
         .get(header::LOCATION)
         .map(HeaderValue::to_str)
-    {
-        if request.current_url().join(location).is_ok() {
+        && request.current_url().join(location).is_ok() {
             invalidate_cached_resources(cached_resources).await;
         }
-    }
     if let Some(Ok(content_location)) = response
         .headers
         .get(header::CONTENT_LOCATION)
         .map(HeaderValue::to_str)
-    {
-        if request.current_url().join(content_location).is_ok() {
+        && request.current_url().join(content_location).is_ok() {
             invalidate_cached_resources(cached_resources).await;
         }
-    }
     invalidate_cached_resources(cached_resources).await;
 }
 

--- a/components/net/http_loader.rs
+++ b/components/net/http_loader.rs
@@ -1120,11 +1120,10 @@ fn location_url_for_response(
         });
 
     // Step 4. If location is a URL whose fragment is null, then set location’s fragment to requestFragment.
-    if let Some(Ok(ref mut location)) = location {
-        if location.fragment().is_none() {
+    if let Some(Ok(ref mut location)) = location
+        && location.fragment().is_none() {
             location.set_fragment(request_fragment);
         }
-    }
     // Step 5. Return location.
     location
 }
@@ -1401,8 +1400,8 @@ async fn http_network_or_cache_fetch(
     }
 
     // Step 8.10 If contentLength is non-null and httpRequest’s keepalive is true, then:
-    if http_request.keep_alive {
-        if let Some(content_length) = content_length {
+    if http_request.keep_alive
+        && let Some(content_length) = content_length {
             // Step 8.10.1. Let inflightKeepaliveBytes be 0.
             // Step 8.10.2. Let group be httpRequest’s client’s fetch group.
             // Step 8.10.3. Let inflightRecords be the set of fetch records
@@ -1438,7 +1437,6 @@ async fn http_network_or_cache_fetch(
                 return Response::network_error(NetworkError::TooManyInFlightKeepAliveRequests);
             }
         }
-    }
 
     // Step 8.11: If httpRequest’s referrer is a URL, then:
     match http_request.referrer {
@@ -1467,11 +1465,10 @@ async fn http_network_or_cache_fetch(
 
     // Step 8.14: If httpRequest’s initiator is "prefetch", then set a structured field value given
     // (`Sec-Purpose`, the token "prefetch") in httpRequest’s header list.
-    if http_request.initiator == Initiator::Prefetch {
-        if let Ok(value) = HeaderValue::from_str("prefetch") {
+    if http_request.initiator == Initiator::Prefetch
+        && let Ok(value) = HeaderValue::from_str("prefetch") {
             http_request.headers.insert("Sec-Purpose", value);
         }
-    }
 
     // Step 8.15: If httpRequest’s header list does not contain `User-Agent`, then user agents
     // should append (`User-Agent`, default `User-Agent` value) to httpRequest’s header list.
@@ -1527,11 +1524,10 @@ async fn http_network_or_cache_fetch(
 
     // Step 8.19: If httpRequest’s header list contains `Range`, then append (`Accept-Encoding`,
     // `identity`) to httpRequest’s header list.
-    if http_request.headers.contains_key(header::RANGE) {
-        if let Ok(value) = HeaderValue::from_str("identity") {
+    if http_request.headers.contains_key(header::RANGE)
+        && let Ok(value) = HeaderValue::from_str("identity") {
             http_request.headers.insert("Accept-Encoding", value);
         }
-    }
 
     // Step 8.20: Modify httpRequest’s header list per HTTP. Do not append a given header if
     // httpRequest’s header list contains that header’s name.
@@ -1559,11 +1555,10 @@ async fn http_network_or_cache_fetch(
             let mut authorization_value = None;
 
             // Substep 4
-            if let Some(basic) = auth_from_cache(&context.state.auth_cache, &current_url.origin()) {
-                if !http_request.use_url_credentials || !has_credentials(&current_url) {
+            if let Some(basic) = auth_from_cache(&context.state.auth_cache, &current_url.origin())
+                && (!http_request.use_url_credentials || !has_credentials(&current_url)) {
                     authorization_value = Some(basic);
                 }
-            }
 
             // Substep 5
             if authentication_fetch_flag &&
@@ -2183,12 +2178,11 @@ async fn http_network_fetch(
             .host_str()
             .is_some_and(|host| context.state.hsts_list.read().is_host_secure(host));
 
-        if url.scheme() == "https" {
-            if let Some(sts) = res.headers().typed_get::<StrictTransportSecurity>() {
+        if url.scheme() == "https"
+            && let Some(sts) = res.headers().typed_get::<StrictTransportSecurity>() {
                 // max-age > 0 enables HSTS, max-age = 0 disables it (RFC 6797 Section 6.1.1)
                 hsts_enabled = sts.max_age().as_secs() > 0;
             }
-        }
         response.tls_security_info = Some(build_tls_security_info(handshake_info, hsts_enabled));
     }
 
@@ -2673,11 +2667,10 @@ fn append_a_request_origin_header(request: &mut Request) {
                 ReferrerPolicy::StrictOriginWhenCrossOrigin => {
                     // If request’s origin is a tuple origin, its scheme is "https", and
                     // request’s current URL’s scheme is not "https", then set serializedOrigin to `null`.
-                    if let ImmutableOrigin::Tuple(scheme, _, _) = &request_origin {
-                        if scheme == "https" && request.current_url().scheme() != "https" {
+                    if let ImmutableOrigin::Tuple(scheme, _, _) = &request_origin
+                        && scheme == "https" && request.current_url().scheme() != "https" {
                             serialized_origin = headers::Origin::NULL;
                         }
-                    }
                 },
                 ReferrerPolicy::SameOrigin => {
                     // If request’s origin is not same origin with request’s current URL’s origin,

--- a/components/net/subresource_integrity.rs
+++ b/components/net/subresource_integrity.rs
@@ -105,12 +105,11 @@ pub fn get_strongest_metadata(integrity_metadata_list: Vec<SriEntry>) -> Vec<Sri
             get_prioritized_hash_function(&integrity_metadata.alg, &current_algorithm);
         if prioritized_hash.is_none() {
             result.push(integrity_metadata.clone());
-        } else if let Some(algorithm) = prioritized_hash {
-            if algorithm != current_algorithm {
+        } else if let Some(algorithm) = prioritized_hash
+            && algorithm != current_algorithm {
                 result = vec![integrity_metadata.clone()];
                 current_algorithm = algorithm;
             }
-        }
     }
 
     result

--- a/components/net/websocket_loader.rs
+++ b/components/net/websocket_loader.rs
@@ -145,13 +145,12 @@ fn process_ws_response(
         if !ServoCookie::is_valid_name_or_value(cookie_bytes) {
             continue;
         }
-        if let Ok(s) = std::str::from_utf8(cookie_bytes) {
-            if let Some(cookie) =
+        if let Ok(s) = std::str::from_utf8(cookie_bytes)
+            && let Some(cookie) =
                 ServoCookie::from_cookie_string(s, resource_url, CookieSource::HTTP)
             {
                 jar.push(cookie, resource_url, CookieSource::HTTP);
             }
-        }
     }
 
     http_state

--- a/components/pixels/lib.rs
+++ b/components/pixels/lib.rs
@@ -177,14 +177,14 @@ pub fn rgba8_get_rect(pixels: &[u8], size: Size2D<u32>, rect: Rect<u32>) -> Cow<
 
 // TODO(pcwalton): Speed up with SIMD, or better yet, find some way to not do this.
 pub fn rgba8_byte_swap_colors_inplace(pixels: &mut [u8]) {
-    assert!(pixels.len() % 4 == 0);
+    assert!(pixels.len().is_multiple_of(4));
     for rgba in pixels.chunks_mut(4) {
         rgba.swap(0, 2);
     }
 }
 
 pub fn rgba8_byte_swap_and_premultiply_inplace(pixels: &mut [u8]) {
-    assert!(pixels.len() % 4 == 0);
+    assert!(pixels.len().is_multiple_of(4));
     for rgba in pixels.chunks_mut(4) {
         let b = rgba[0];
         rgba[0] = multiply_u8_color(rgba[2], rgba[3]);
@@ -195,7 +195,7 @@ pub fn rgba8_byte_swap_and_premultiply_inplace(pixels: &mut [u8]) {
 
 /// Returns true if the pixels were found to be completely opaque.
 pub fn rgba8_premultiply_inplace(pixels: &mut [u8]) -> bool {
-    assert!(pixels.len() % 4 == 0);
+    assert!(pixels.len().is_multiple_of(4));
     let mut is_opaque = true;
     for rgba in pixels.chunks_mut(4) {
         rgba[0] = multiply_u8_color(rgba[0], rgba[3]);

--- a/components/script/devtools.rs
+++ b/components/script/devtools.rs
@@ -164,13 +164,12 @@ pub(crate) fn handle_get_children(
                 .collect();
 
             let mut children = vec![];
-            if let Some(shadow_root) = parent.downcast::<Element>().and_then(Element::shadow_root) {
-                if !shadow_root.is_user_agent_widget() ||
-                    pref!(inspector_show_servo_internal_shadow_roots)
+            if let Some(shadow_root) = parent.downcast::<Element>().and_then(Element::shadow_root)
+                && (!shadow_root.is_user_agent_widget() ||
+                    pref!(inspector_show_servo_internal_shadow_roots))
                 {
                     children.push(shadow_root.upcast::<Node>().summarize(can_gc));
                 }
-            }
             let children_iter = parent.children().enumerate().filter_map(|(i, child)| {
                 // Filter whitespace only text nodes that are not inline level
                 // https://firefox-source-docs.mozilla.org/devtools-user/page_inspector/how_to/examine_and_edit_html/index.html#whitespace-only-text-nodes

--- a/components/script/dom/audio/audiobuffer.rs
+++ b/components/script/dom/audio/audiobuffer.rs
@@ -287,11 +287,10 @@ impl AudioBufferMethods<crate::DomTypeHolder> for AudioBuffer {
             {
                 return Err(Error::IndexSize(None));
             }
-        } else if let Some(ref shared_channels) = *self.shared_channels.borrow() {
-            if let Some(shared_channel) = shared_channels.buffers.get(channel_number) {
+        } else if let Some(ref shared_channels) = *self.shared_channels.borrow()
+            && let Some(shared_channel) = shared_channels.buffers.get(channel_number) {
                 dest.extend_from_slice(&shared_channel.as_slice()[offset..offset + bytes_to_copy]);
             }
-        }
 
         destination.update(&dest);
 

--- a/components/script/dom/audio/audiobuffersourcenode.rs
+++ b/components/script/dom/audio/audiobuffersourcenode.rs
@@ -159,8 +159,8 @@ impl AudioBufferSourceNodeMethods<crate::DomTypeHolder> for AudioBufferSourceNod
         self.buffer.set(new_buffer);
 
         // Step 5.
-        if self.source_node.has_start() {
-            if let Some(buffer) = self.buffer.get() {
+        if self.source_node.has_start()
+            && let Some(buffer) = self.buffer.get() {
                 let buffer = buffer.get_channels();
                 if buffer.is_some() {
                     self.source_node
@@ -170,7 +170,6 @@ impl AudioBufferSourceNodeMethods<crate::DomTypeHolder> for AudioBufferSourceNod
                         ));
                 }
             }
-        }
 
         Ok(())
     }
@@ -234,19 +233,17 @@ impl AudioBufferSourceNodeMethods<crate::DomTypeHolder> for AudioBufferSourceNod
         offset: Option<Finite<f64>>,
         duration: Option<Finite<f64>>,
     ) -> Fallible<()> {
-        if let Some(offset) = offset {
-            if *offset < 0. {
+        if let Some(offset) = offset
+            && *offset < 0. {
                 return Err(Error::Range("'offset' must be a positive value".to_owned()));
             }
-        }
 
-        if let Some(duration) = duration {
-            if *duration < 0. {
+        if let Some(duration) = duration
+            && *duration < 0. {
                 return Err(Error::Range(
                     "'duration' must be a positive value".to_owned(),
                 ));
             }
-        }
 
         if let Some(buffer) = self.buffer.get() {
             let buffer = buffer.get_channels();

--- a/components/script/dom/audio/audiotrack.rs
+++ b/components/script/dom/audio/audiotrack.rs
@@ -116,11 +116,10 @@ impl AudioTrackMethods<crate::DomTypeHolder> for AudioTrack {
 
     /// <https://html.spec.whatwg.org/multipage/#dom-audiotrack-enabled>
     fn SetEnabled(&self, value: bool) {
-        if let Some(list) = self.track_list.borrow().as_ref() {
-            if let Some(idx) = list.find(self) {
+        if let Some(list) = self.track_list.borrow().as_ref()
+            && let Some(idx) = list.find(self) {
                 list.set_enabled(idx, value);
             }
-        }
         self.set_enabled(value);
     }
 }

--- a/components/script/dom/bluetooth/bluetooth.rs
+++ b/components/script/dom/bluetooth/bluetooth.rs
@@ -675,11 +675,10 @@ impl PermissionAlgorithm for Bluetooth {
         // Step 6.
         for allowed_device in allowed_devices.iter() {
             // Step 6.1.
-            if let Some(ref id) = descriptor.deviceId {
-                if &allowed_device.deviceId != id {
+            if let Some(ref id) = descriptor.deviceId
+                && &allowed_device.deviceId != id {
                     continue;
                 }
-            }
             let device_id = String::from(allowed_device.deviceId.str());
 
             // Step 6.2.

--- a/components/script/dom/canvas/imagedata.rs
+++ b/components/script/dom/canvas/imagedata.rs
@@ -317,13 +317,13 @@ impl ImageDataMethods<crate::DomTypeHolder> for ImageData {
         }
         // 3. If length is not a nonzero integral multiple of bytesPerPixel,
         // then throw an "InvalidStateError" DOMException.
-        if length % bytes_per_pixel != 0 {
+        if !length.is_multiple_of(bytes_per_pixel) {
             return Err(Error::InvalidState(None));
         }
         // 4. Let length be length divided by bytesPerPixel.
         let length = length / bytes_per_pixel;
         // 5. If length is not an integral multiple of sw, then throw an "IndexSizeError" DOMException.
-        if sw == 0 || length % sw as usize != 0 {
+        if sw == 0 || !length.is_multiple_of(sw as usize) {
             return Err(Error::IndexSize(None));
         }
         // 6. Let height be length divided by sw.

--- a/components/script/dom/characterdata.rs
+++ b/components/script/dom/characterdata.rs
@@ -91,12 +91,11 @@ impl CharacterData {
         // If this is a Text node, we might need to re-parse (say, if our parent
         // is a <style> element.) We don't need to if this is a Comment or
         // ProcessingInstruction.
-        if self.is::<Text>() {
-            if let Some(parent_node) = node.GetParentNode() {
+        if self.is::<Text>()
+            && let Some(parent_node) = node.GetParentNode() {
                 let mutation = ChildrenMutation::ChangeText;
                 vtable_for(&parent_node).children_changed(&mutation, CanGc::note());
             }
-        }
     }
 
     // Queue a MutationObserver record before changing the content.

--- a/components/script/dom/console.rs
+++ b/components/script/dom/console.rs
@@ -272,11 +272,10 @@ fn stringify_handle_value(message: HandleValue) -> DOMString {
             }
             parents.push(value_bits);
 
-            if value.is_object() {
-                if let Some(repr) = maybe_stringify_dom_object(cx, value) {
+            if value.is_object()
+                && let Some(repr) = maybe_stringify_dom_object(cx, value) {
                     return repr;
                 }
-            }
             unsafe { stringify_object_from_handle_value(*cx, value, parents) }
         }
         stringify_inner(cx, message, Vec::new())

--- a/components/script/dom/cookiestore.rs
+++ b/components/script/dom/cookiestore.rs
@@ -259,8 +259,8 @@ impl CookieStoreMethods<crate::DomTypeHolder> for CookieStore {
 
             // 6.2. If this’s relevant global object is a Window object and parsed does not equal url with exclude fragments set to true,
             // then return a promise rejected with a TypeError.
-            if let Some(_window) = DomRoot::downcast::<Window>(self.global()) {
-                if parsed_url
+            if let Some(_window) = DomRoot::downcast::<Window>(self.global())
+                && parsed_url
                     .as_ref()
                     .is_ok_and(|parsed| !parsed.is_equal_excluding_fragments(&creation_url))
                 {
@@ -270,7 +270,6 @@ impl CookieStoreMethods<crate::DomTypeHolder> for CookieStore {
                     );
                     return p;
                 }
-            }
 
             // 6.3. If parsed’s origin and url’s origin are not the same origin,
             // then return a promise rejected with a TypeError.
@@ -373,8 +372,8 @@ impl CookieStoreMethods<crate::DomTypeHolder> for CookieStore {
 
             // If this’s relevant global object is a Window object and parsed does not equal url with exclude fragments set to true,
             // then return a promise rejected with a TypeError.
-            if let Some(_window) = DomRoot::downcast::<Window>(self.global()) {
-                if parsed_url
+            if let Some(_window) = DomRoot::downcast::<Window>(self.global())
+                && parsed_url
                     .as_ref()
                     .is_ok_and(|parsed| !parsed.is_equal_excluding_fragments(&creation_url))
                 {
@@ -384,7 +383,6 @@ impl CookieStoreMethods<crate::DomTypeHolder> for CookieStore {
                     );
                     return p;
                 }
-            }
 
             // 5.3. If parsed’s origin and url’s origin are not the same origin,
             // then return a promise rejected with a TypeError.

--- a/components/script/dom/customelementregistry.rs
+++ b/components/script/dom/customelementregistry.rs
@@ -919,8 +919,8 @@ pub(crate) fn upgrade_element(
     }
 
     // Step 9: handle with form-associated custom element
-    if let Some(html_element) = element.downcast::<HTMLElement>() {
-        if html_element.is_form_associated_custom_element() {
+    if let Some(html_element) = element.downcast::<HTMLElement>()
+        && html_element.is_form_associated_custom_element() {
             // We know this element is is form-associated, so we can use the implementation of
             // `FormControl` for HTMLElement, which makes that assumption.
             // Step 9.1: Reset the form owner of element
@@ -954,7 +954,6 @@ pub(crate) fn upgrade_element(
                 )
             }
         }
-    }
 
     // Step 10
     element.set_custom_element_state(CustomElementState::Custom);

--- a/components/script/dom/document.rs
+++ b/components/script/dom/document.rs
@@ -959,11 +959,10 @@ impl Document {
         // FIXME: This should check the dirty bit on the document,
         // not the document element. Needs some layout changes to make
         // that workable.
-        if let Some(root) = self.GetDocumentElement() {
-            if root.upcast::<Node>().has_dirty_descendants() {
+        if let Some(root) = self.GetDocumentElement()
+            && root.upcast::<Node>().has_dirty_descendants() {
                 condition.insert(RestyleReason::DOMChanged);
             }
-        }
 
         if !self.pending_restyles.borrow().is_empty() {
             condition.insert(RestyleReason::PendingRestyles);
@@ -1433,8 +1432,8 @@ impl Document {
         trace_focus_chain("Old", old_focused_filtered, old_focus_state);
         trace_focus_chain("New", new_focused_filtered, new_focus_state);
 
-        if old_focused_filtered != new_focused_filtered {
-            if let Some(elem) = &old_focused_filtered {
+        if old_focused_filtered != new_focused_filtered
+            && let Some(elem) = &old_focused_filtered {
                 let node = elem.upcast::<Node>();
                 elem.set_focus_state(false);
                 // FIXME: pass appropriate relatedTarget
@@ -1442,7 +1441,6 @@ impl Document {
                     self.fire_focus_event(FocusEventType::Blur, node.upcast(), None, can_gc);
                 }
             }
-        }
 
         if old_focus_state != new_focus_state && !new_focus_state {
             self.fire_focus_event(FocusEventType::Blur, self.global().upcast(), None, can_gc);
@@ -1455,8 +1453,8 @@ impl Document {
             self.fire_focus_event(FocusEventType::Focus, self.global().upcast(), None, can_gc);
         }
 
-        if old_focused_filtered != new_focused_filtered {
-            if let Some(elem) = &new_focused_filtered {
+        if old_focused_filtered != new_focused_filtered
+            && let Some(elem) = &new_focused_filtered {
                 elem.set_focus_state(true);
                 let node = elem.upcast::<Node>();
                 // FIXME: pass appropriate relatedTarget
@@ -1484,7 +1482,6 @@ impl Document {
                     );
                 }
             }
-        }
 
         if focus_initiator != FocusInitiator::Local {
             return;

--- a/components/script/dom/document_embedder_controls.rs
+++ b/components/script/dom/document_embedder_controls.rs
@@ -243,25 +243,21 @@ impl DocumentEmbedderControls {
             .node
             .inclusive_ancestors(ShadowIncluding::Yes)
         {
-            if anchor_element.is_none() {
-                if let Some(candidate_anchor_element) = node.downcast::<HTMLAnchorElement>() {
-                    if candidate_anchor_element.is_instance_activatable() {
+            if anchor_element.is_none()
+                && let Some(candidate_anchor_element) = node.downcast::<HTMLAnchorElement>()
+                    && candidate_anchor_element.is_instance_activatable() {
                         anchor_element = Some(DomRoot::from_ref(candidate_anchor_element));
                     }
-                }
-            }
 
-            if image_element.is_none() {
-                if let Some(candidate_image_element) = node.downcast::<HTMLImageElement>() {
+            if image_element.is_none()
+                && let Some(candidate_image_element) = node.downcast::<HTMLImageElement>() {
                     image_element = Some(DomRoot::from_ref(candidate_image_element))
                 }
-            }
 
-            if text_input_element.is_none() {
-                if let Some(candidate_text_input_element) = node.as_text_input() {
+            if text_input_element.is_none()
+                && let Some(candidate_text_input_element) = node.as_text_input() {
                     text_input_element = Some(candidate_text_input_element);
                 }
-            }
         }
 
         let mut info = ContextMenuElementInformation::default();

--- a/components/script/dom/document_event_handler.rs
+++ b/components/script/dom/document_event_handler.rs
@@ -562,8 +562,8 @@ impl DocumentEventHandler {
 
         // If the new hover target is an anchor with a status value, inform the embedder
         // of the new value.
-        if let Some(target) = self.current_hover_target.get() {
-            if let Some(anchor) = target
+        if let Some(target) = self.current_hover_target.get()
+            && let Some(anchor) = target
                 .upcast::<Node>()
                 .inclusive_ancestors(ShadowIncluding::No)
                 .find_map(DomRoot::downcast::<HTMLAnchorElement>)
@@ -575,7 +575,6 @@ impl DocumentEventHandler {
                     .send_to_embedder(EmbedderMsg::Status(self.window.webview_id(), status));
                 return;
             }
-        }
 
         // No state was set above, which means that the new value of the status in the embedder
         // should be `None`. Set that now. If `previous_hover_target` is `None` that means this
@@ -801,7 +800,7 @@ impl DocumentEventHandler {
         //
         // We follow the latter approach here, considering that every sequence of
         // even numbered clicks is a series of double clicks.
-        if click_count % 2 == 0 {
+        if click_count.is_multiple_of(2) {
             MouseEvent::for_platform_mouse_event(
                 "dblclick",
                 event,
@@ -1099,12 +1098,10 @@ impl DocumentEventHandler {
         if (keyboard_event.event.key == Key::Named(NamedKey::Enter) ||
             keyboard_event.event.code == Code::Space) &&
             keyboard_event.event.state == KeyState::Up
-        {
-            if let Some(elem) = target.downcast::<Element>() {
+            && let Some(elem) = target.downcast::<Element>() {
                 elem.upcast::<Node>()
                     .fire_synthetic_pointer_event_not_trusted(DOMString::from("click"), can_gc);
             }
-        }
 
         flags.into()
     }
@@ -1288,12 +1285,11 @@ impl DocumentEventHandler {
             .queue(task!(gamepad_disconnected: move || {
                 let window = trusted_window.root();
                 let navigator = window.Navigator();
-                if let Some(gamepad) = navigator.get_gamepad(index) {
-                    if window.Document().is_fully_active() {
+                if let Some(gamepad) = navigator.get_gamepad(index)
+                    && window.Document().is_fully_active() {
                         gamepad.update_connected(false, gamepad.exposed(), CanGc::note());
                         navigator.remove_gamepad(index);
                     }
-                }
             }));
     }
 

--- a/components/script/dom/documentorshadowroot.rs
+++ b/components/script/dom/documentorshadowroot.rs
@@ -219,11 +219,10 @@ impl DocumentOrShadowRoot {
             .collect();
 
         // Step 4
-        if let Some(root_element) = document_element {
-            if elements.last() != Some(&root_element) {
+        if let Some(root_element) = document_element
+            && elements.last() != Some(&root_element) {
                 elements.push(root_element);
             }
-        }
 
         // Step 5
         elements

--- a/components/script/dom/element.rs
+++ b/components/script/dom/element.rs
@@ -530,8 +530,8 @@ impl Element {
 
         // " - body’s parent element’s computed value of the overflow-x or
         //     overflow-y properties is neither visible nor clip."
-        if let Some(parent) = node.GetParentElement() {
-            if let Some(style) = parent.style() {
+        if let Some(parent) = node.GetParentElement()
+            && let Some(style) = parent.style() {
                 let mut overflow_x = style.get_box().clone_overflow_x();
                 let mut overflow_y = style.get_box().clone_overflow_y();
 
@@ -550,17 +550,15 @@ impl Element {
                     return false;
                 }
             };
-        }
 
         // " - body’s computed value of the overflow-x or overflow-y properties
         //     is neither visible nor clip."
-        if let Some(style) = self.style() {
-            if !style.get_box().clone_overflow_x().is_scrollable() &&
+        if let Some(style) = self.style()
+            && !style.get_box().clone_overflow_x().is_scrollable() &&
                 !style.get_box().clone_overflow_y().is_scrollable()
             {
                 return false;
-            }
-        };
+            };
 
         true
     }
@@ -765,11 +763,10 @@ impl Element {
                 _ => {},
             }
         }
-        if let Some(parent) = self.upcast::<Node>().GetParentNode() {
-            if let Some(elem) = parent.downcast::<Element>() {
+        if let Some(parent) = self.upcast::<Node>().GetParentNode()
+            && let Some(elem) = parent.downcast::<Element>() {
                 return elem.is_translate_enabled();
             }
-        }
         true
     }
 
@@ -1106,8 +1103,8 @@ impl<'dom> LayoutElementHelpers<'dom> for LayoutDom<'dom, Element> {
         if is_element_affected_by_legacy_background_presentational_hint(
             self.namespace(),
             self.local_name(),
-        ) {
-            if let Some(url) = self
+        )
+            && let Some(url) = self
                 .get_attr_for_layout(&ns!(), &local_name!("background"))
                 .and_then(AttrValue::as_resolved_url)
                 .cloned()
@@ -1118,7 +1115,6 @@ impl<'dom> LayoutElementHelpers<'dom> for LayoutDom<'dom, Element> {
                     ),
                 ));
             }
-        }
 
         let color = if let Some(this) = self.downcast::<HTMLFontElement>() {
             this.get_color()
@@ -1277,11 +1273,10 @@ impl<'dom> LayoutElementHelpers<'dom> for LayoutDom<'dom, Element> {
 
         // Aspect ratio when providing both width and height.
         // https://html.spec.whatwg.org/multipage/#attributes-for-embedded-content-and-images
-        if self.downcast::<HTMLImageElement>().is_some() ||
-            self.downcast::<HTMLVideoElement>().is_some()
-        {
-            if let LengthOrPercentageOrAuto::Length(width) = width {
-                if let LengthOrPercentageOrAuto::Length(height) = height {
+        if (self.downcast::<HTMLImageElement>().is_some() ||
+            self.downcast::<HTMLVideoElement>().is_some())
+            && let LengthOrPercentageOrAuto::Length(width) = width
+                && let LengthOrPercentageOrAuto::Length(height) = height {
                     let width_value = NonNegative(specified::Number::new(width.to_f32_px()));
                     let height_value = NonNegative(specified::Number::new(height.to_f32_px()));
                     let aspect_ratio = specified::position::AspectRatio {
@@ -1290,8 +1285,6 @@ impl<'dom> LayoutElementHelpers<'dom> for LayoutDom<'dom, Element> {
                     };
                     push(PropertyDeclaration::AspectRatio(aspect_ratio));
                 }
-            }
-        }
 
         let cols = self
             .downcast::<HTMLTextAreaElement>()
@@ -1720,11 +1713,10 @@ impl Element {
         {
             let element = node.downcast::<Element>()?;
             // Step 1.
-            if *element.namespace() == namespace {
-                if let Some(prefix) = element.GetPrefix() {
+            if *element.namespace() == namespace
+                && let Some(prefix) = element.GetPrefix() {
                     return Some(prefix);
                 }
-            }
 
             // Step 2.
             for attr in element.attrs.borrow().iter() {
@@ -2477,11 +2469,10 @@ impl Element {
 
         // Step 2. If attr’s element is neither null nor element,
         // throw an "InUseAttributeError" DOMException.
-        if let Some(owner) = attr.GetOwnerElement() {
-            if &*owner != self {
+        if let Some(owner) = attr.GetOwnerElement()
+            && &*owner != self {
                 return Err(Error::InUseAttribute(None));
             }
-        }
 
         let vtable = vtable_for(self.upcast());
 
@@ -4563,11 +4554,10 @@ impl VirtualMethods for Element {
                 doc.register_element_id(self, id.clone(), can_gc);
             }
         }
-        if let Some(ref name) = self.name_attribute() {
-            if self.containing_shadow_root().is_none() {
+        if let Some(ref name) = self.name_attribute()
+            && self.containing_shadow_root().is_none() {
                 doc.register_element_name(self, name.clone());
             }
-        }
 
         // This is used for layout optimization.
         doc.increment_dom_count();
@@ -4606,11 +4596,10 @@ impl VirtualMethods for Element {
                 doc.unregister_element_id(self, value.clone(), can_gc);
             }
         }
-        if let Some(ref value) = self.name_attribute() {
-            if self.containing_shadow_root().is_none() {
+        if let Some(ref value) = self.name_attribute()
+            && self.containing_shadow_root().is_none() {
                 doc.unregister_element_name(self, value.clone());
             }
-        }
         // This is used for layout optimization.
         doc.decrement_dom_count();
     }
@@ -4625,20 +4614,18 @@ impl VirtualMethods for Element {
             // All children of this node need to be restyled when any child changes.
             self.upcast::<Node>().dirty(NodeDamage::Other);
         } else {
-            if flags.intersects(ElementSelectorFlags::HAS_SLOW_SELECTOR_LATER_SIBLINGS) {
-                if let Some(next_child) = mutation.next_child() {
+            if flags.intersects(ElementSelectorFlags::HAS_SLOW_SELECTOR_LATER_SIBLINGS)
+                && let Some(next_child) = mutation.next_child() {
                     for child in next_child.inclusively_following_siblings() {
                         if child.is::<Element>() {
                             child.dirty(NodeDamage::Other);
                         }
                     }
                 }
-            }
-            if flags.intersects(ElementSelectorFlags::HAS_EDGE_CHILD_SELECTOR) {
-                if let Some(child) = mutation.modified_edge_element() {
+            if flags.intersects(ElementSelectorFlags::HAS_EDGE_CHILD_SELECTOR)
+                && let Some(child) = mutation.modified_edge_element() {
                     child.dirty(NodeDamage::Other);
                 }
-            }
         }
     }
 
@@ -4933,8 +4920,8 @@ impl SelectorsElement for SelectorWrapper<'_> {
 
         // Handle flags that apply to the parent.
         let parent_flags = flags.for_parent();
-        if !parent_flags.is_empty() {
-            if let Some(p) = self.parent_element() {
+        if !parent_flags.is_empty()
+            && let Some(p) = self.parent_element() {
                 #[expect(unsafe_code)]
                 unsafe {
                     Dom::from_ref(&**p)
@@ -4942,7 +4929,6 @@ impl SelectorsElement for SelectorWrapper<'_> {
                         .insert_selector_flags(parent_flags);
                 }
             }
-        }
     }
 
     fn add_element_unique_hashes(&self, filter: &mut BloomFilter) -> bool {
@@ -4999,11 +4985,9 @@ impl Element {
             .as_ref()
             .and_then(|data| data.client_rect.as_ref())
             .and_then(|rect| rect.get().ok())
-        {
-            if doc.restyle_reason().is_empty() {
+            && doc.restyle_reason().is_empty() {
                 return rect;
             }
-        }
 
         let mut rect = self.upcast::<Node>().client_rect();
         let in_quirks_mode = doc.quirks_mode() == QuirksMode::Quirks;
@@ -5176,11 +5160,10 @@ impl Element {
             None => {
                 let node = self.upcast::<Node>();
                 for node in node.ancestors() {
-                    if let Some(node) = node.downcast::<Element>() {
-                        if node.as_maybe_activatable().is_some() {
+                    if let Some(node) = node.downcast::<Element>()
+                        && node.as_maybe_activatable().is_some() {
                             return Some(DomRoot::from_ref(node));
                         }
-                    }
                 }
                 None
             },
@@ -5340,14 +5323,13 @@ impl Element {
             return;
         }
         let node = self.upcast::<Node>();
-        if let Some(ref parent) = node.GetParentNode() {
-            if parent.is::<HTMLOptGroupElement>() &&
+        if let Some(ref parent) = node.GetParentNode()
+            && parent.is::<HTMLOptGroupElement>() &&
                 parent.downcast::<Element>().unwrap().disabled_state()
             {
                 self.set_disabled_state(true);
                 self.set_enabled_state(false);
             }
-        }
     }
 
     pub(crate) fn check_disabled_attribute(&self) {

--- a/components/script/dom/event.rs
+++ b/components/script/dom/event.rs
@@ -345,13 +345,11 @@ impl Event {
 
             // Step 6.5. If isActivationEvent is true and target has activation behavior,
             // then set activationTarget to target.
-            if is_activation_event {
-                if let Some(element) = target.downcast::<Element>() {
-                    if element.as_maybe_activatable().is_some() {
+            if is_activation_event
+                && let Some(element) = target.downcast::<Element>()
+                    && element.as_maybe_activatable().is_some() {
                         activation_target = Some(DomRoot::from_ref(element));
                     }
-                }
-            }
 
             // Step 6.6. Let slottable be target, if target is a slottable and is assigned, and null otherwise.
             let mut slottable = if target
@@ -428,13 +426,11 @@ impl Event {
                 if parent.is::<Window>() || root_is_shadow_inclusive_ancestor {
                     // Step 6.9.6.1. If isActivationEvent is true, event’s bubbles attribute is true, activationTarget
                     // is null, and parent has activation behavior, then set activationTarget to parent.
-                    if is_activation_event && activation_target.is_none() && self.bubbles.get() {
-                        if let Some(element) = parent.downcast::<Element>() {
-                            if element.as_maybe_activatable().is_some() {
+                    if is_activation_event && activation_target.is_none() && self.bubbles.get()
+                        && let Some(element) = parent.downcast::<Element>()
+                            && element.as_maybe_activatable().is_some() {
                                 activation_target = Some(DomRoot::from_ref(element));
                             }
-                        }
-                    }
 
                     // Step 6.9.6.2. Append to an event path with event, parent, null, relatedTarget, touchTargets,
                     // and slot-in-closed-tree.
@@ -458,13 +454,11 @@ impl Event {
 
                     // Step 6.9.8.2. If isActivationEvent is true, activationTarget is null, and target has
                     // activation behavior, then set activationTarget to target.
-                    if is_activation_event && activation_target.is_none() {
-                        if let Some(element) = parent.downcast::<Element>() {
-                            if element.as_maybe_activatable().is_some() {
+                    if is_activation_event && activation_target.is_none()
+                        && let Some(element) = parent.downcast::<Element>()
+                            && element.as_maybe_activatable().is_some() {
                                 activation_target = Some(DomRoot::from_ref(element));
                             }
-                        }
-                    }
 
                     // Step 6.9.8.3. Append to an event path with event, parent, target, relatedTarget,
                     // touchTargets, and slot-in-closed-tree.
@@ -596,14 +590,12 @@ impl Event {
         // Compare:
         // https://w3c.github.io/uievents/#default-action
         // https://dom.spec.whatwg.org/#action-versus-occurance
-        if !self.DefaultPrevented() {
-            if let Some(target) = self.GetTarget() {
-                if let Some(node) = target.downcast::<Node>() {
+        if !self.DefaultPrevented()
+            && let Some(target) = self.GetTarget()
+                && let Some(node) = target.downcast::<Node>() {
                     let vtable = vtable_for(node);
                     vtable.handle_event(self, can_gc);
                 }
-            }
-        }
 
         // Step 8. Set event’s currentTarget attribute to null.
         self.current_target.set(None);

--- a/components/script/dom/eventsource.rs
+++ b/components/script/dom/eventsource.rs
@@ -232,11 +232,10 @@ impl EventSourceContext {
             return;
         }
         // Step 3
-        if let Some(last) = self.data.pop() {
-            if last != '\n' {
+        if let Some(last) = self.data.pop()
+            && last != '\n' {
                 self.data.push(last);
             }
-        }
         // Step 6
         let type_ = if !self.event_type.is_empty() {
             Atom::from(self.event_type.clone())

--- a/components/script/dom/eventtarget.rs
+++ b/components/script/dom/eventtarget.rs
@@ -324,8 +324,8 @@ impl CompiledEventListener {
             CompiledEventListener::Handler(ref handler) => {
                 match *handler {
                     CommonEventHandler::ErrorEventHandler(ref handler) => {
-                        if let Some(event) = event.downcast::<ErrorEvent>() {
-                            if object.is::<Window>() || object.is::<WorkerGlobalScope>() {
+                        if let Some(event) = event.downcast::<ErrorEvent>()
+                            && (object.is::<Window>() || object.is::<WorkerGlobalScope>()) {
                                 let cx = GlobalScope::get_cx();
                                 rooted!(in(*cx) let mut error: JSVal);
                                 event.Error(cx, error.handle_mut());
@@ -342,16 +342,14 @@ impl CompiledEventListener {
                                     can_gc,
                                 );
                                 // Step 4
-                                if let Ok(()) = return_value {
-                                    if rooted_return_value.handle().is_boolean() &&
+                                if let Ok(()) = return_value
+                                    && rooted_return_value.handle().is_boolean() &&
                                         rooted_return_value.handle().to_boolean()
                                     {
                                         event.upcast::<Event>().PreventDefault();
                                     }
-                                }
                                 return;
                             }
-                        }
 
                         rooted!(in(*GlobalScope::get_cx()) let mut rooted_return_value: JSVal);
                         let _ = handler.Call_(
@@ -643,11 +641,10 @@ impl EventTarget {
     pub(crate) fn remove_listener(&self, ty: &Atom, entry: &Rc<RefCell<EventListenerEntry>>) {
         let mut handlers = self.handlers.borrow_mut();
 
-        if let Some(entries) = handlers.get_mut(ty) {
-            if let Some(position) = entries.iter().position(|e| *e == *entry) {
+        if let Some(entries) = handlers.get_mut(ty)
+            && let Some(position) = entries.iter().position(|e| *e == *entry) {
                 entries.remove(position).borrow_mut().removed = true;
             }
-        }
     }
 
     /// Determines the `passive` attribute of an associated event listener
@@ -1077,11 +1074,10 @@ impl EventTarget {
             if !a_root.is::<ShadowRoot>() {
                 return a;
             }
-            if let Some(b_node) = b.downcast::<Node>() {
-                if a_root.is_shadow_including_inclusive_ancestor_of(b_node) {
+            if let Some(b_node) = b.downcast::<Node>()
+                && a_root.is_shadow_including_inclusive_ancestor_of(b_node) {
                     return a;
                 }
-            }
 
             // Step 2. Set A to A’s root’s host.
             a = DomRoot::from_ref(

--- a/components/script/dom/globalscope.rs
+++ b/components/script/dom/globalscope.rs
@@ -1316,18 +1316,16 @@ impl GlobalScope {
             // Step 7, a few preliminary steps.
 
             // - Check the worker is not closing.
-            if let Some(worker) = self.downcast::<WorkerGlobalScope>() {
-                if worker.is_closing() {
+            if let Some(worker) = self.downcast::<WorkerGlobalScope>()
+                && worker.is_closing() {
                     return;
                 }
-            }
 
             // - Check the associated document is fully-active.
-            if let Some(window) = self.downcast::<Window>() {
-                if !window.Document().is_fully_active() {
+            if let Some(window) = self.downcast::<Window>()
+                && !window.Document().is_fully_active() {
                     return;
                 }
-            }
 
             // - Check for a case-sensitive match for the name of the channel.
             let channel_name = DOMString::from_string(channel_name);

--- a/components/script/dom/html/htmlanchorelement.rs
+++ b/components/script/dom/html/htmlanchorelement.rs
@@ -339,8 +339,8 @@ impl Activatable for HTMLAnchorElement {
 
         // Step 1: If the target of the click event is an img element with an ismap attribute
         // specified, then server-side image map processing must be performed.
-        if let Some(element) = target.downcast::<Element>() {
-            if target.is::<HTMLImageElement>() && element.has_attribute(&local_name!("ismap")) {
+        if let Some(element) = target.downcast::<Element>()
+            && target.is::<HTMLImageElement>() && element.has_attribute(&local_name!("ismap")) {
                 let target_node = element.upcast::<Node>();
                 let rect = target_node.border_box().unwrap_or_default();
                 ismap_suffix = Some(format!(
@@ -349,7 +349,6 @@ impl Activatable for HTMLAnchorElement {
                     mouse_event.ClientY().to_f32().unwrap() - rect.origin.y.to_f32_px()
                 ))
             }
-        }
 
         // Step 2.
         // TODO: Download the link is `download` attribute is set.

--- a/components/script/dom/html/htmlcollection.rs
+++ b/components/script/dom/html/htmlcollection.rs
@@ -445,14 +445,13 @@ impl HTMLCollectionMethods<crate::DomTypeHolder> for HTMLCollection {
                 }
             }
             // Step 2.2
-            if *elem.namespace() == ns!(html) {
-                if let Some(name_atom) = elem.get_name() {
+            if *elem.namespace() == ns!(html)
+                && let Some(name_atom) = elem.get_name() {
                     let name_str = DOMString::from(&*name_atom);
                     if !result.contains(&name_str) {
                         result.push(name_str)
                     }
                 }
-            }
         }
 
         // Step 3

--- a/components/script/dom/html/htmldetailselement.rs
+++ b/components/script/dom/html/htmldetailselement.rs
@@ -521,13 +521,12 @@ impl VirtualMethods for HTMLDetailsElement {
         }
 
         let was_already_in_shadow_tree = context.is_shadow_tree == IsShadowTree::Yes;
-        if !was_already_in_shadow_tree {
-            if let Some(shadow_root) = self.containing_shadow_root() {
+        if !was_already_in_shadow_tree
+            && let Some(shadow_root) = self.containing_shadow_root() {
                 shadow_root
                     .details_name_groups()
                     .register_details_element(self);
             }
-        }
 
         // Step 1. Ensure details exclusivity by closing the given element if needed given insertedNode.
         self.ensure_details_exclusivity(ExclusivityConflictResolution::CloseThisElement);
@@ -542,14 +541,13 @@ impl VirtualMethods for HTMLDetailsElement {
                 .unregister_details_element(self.Name(), self);
         }
 
-        if !self.upcast::<Node>().is_in_a_shadow_tree() {
-            if let Some(old_shadow_root) = self.containing_shadow_root() {
+        if !self.upcast::<Node>().is_in_a_shadow_tree()
+            && let Some(old_shadow_root) = self.containing_shadow_root() {
                 // If we used to be in a shadow root, but aren't anymore, then unregister this details
                 // element.
                 old_shadow_root
                     .details_name_groups()
                     .unregister_details_element(self.Name(), self);
             }
-        }
     }
 }

--- a/components/script/dom/html/htmlelement.rs
+++ b/components/script/dom/html/htmlelement.rs
@@ -578,11 +578,10 @@ impl HTMLElementMethods<crate::DomTypeHolder> for HTMLElement {
 
         // Step 7: If next is non-null and next's previous sibling is a Text node, then merge with
         // the next text node given next's previous sibling.
-        if let Some(next_sibling) = next {
-            if let Some(node) = next_sibling.GetPreviousSibling() {
+        if let Some(next_sibling) = next
+            && let Some(node) = next_sibling.GetPreviousSibling() {
                 Self::merge_with_the_next_text_node(node, can_gc);
             }
-        }
 
         // Step 8: If previous is a Text node, then merge with the next text node given previous.
         if let Some(previous) = previous {
@@ -951,11 +950,10 @@ impl HTMLElement {
             return Some("rtl".to_owned());
         }
 
-        if let Some(input) = self.downcast::<HTMLInputElement>() {
-            if input.input_type() == InputType::Tel {
+        if let Some(input) = self.downcast::<HTMLInputElement>()
+            && input.input_type() == InputType::Tel {
                 return Some("ltr".to_owned());
             }
-        }
 
         if element_direction == "auto" {
             if let Some(directionality) = self

--- a/components/script/dom/html/htmlformelement.rs
+++ b/components/script/dom/html/htmlformelement.rs
@@ -1062,14 +1062,13 @@ impl HTMLFormElement {
 
         // Note the pending form navigation if this is an iframe;
         // necessary for deciding whether to run the iframe load event steps.
-        if let Some(window_proxy) = target.undiscarded_window_proxy() {
-            if let Some(frame) = window_proxy
+        if let Some(window_proxy) = target.undiscarded_window_proxy()
+            && let Some(frame) = window_proxy
                 .frame_element()
                 .and_then(|e| e.downcast::<HTMLIFrameElement>())
             {
                 frame.note_pending_navigation()
             }
-        }
 
         // 4. Queue an element task on the DOM manipulation task source
         // given the form element and the following steps:
@@ -1131,8 +1130,8 @@ impl HTMLFormElement {
             if let Some(validatable) = elem.as_maybe_validatable() {
                 error!("Validation error: {}", validatable.validation_message());
             }
-            if first {
-                if let Some(html_elem) = elem.downcast::<HTMLElement>() {
+            if first
+                && let Some(html_elem) = elem.downcast::<HTMLElement>() {
                     // Step 3.1: User agents may focus one of those elements in the process,
                     // by running the focusing steps for that element,
                     // and may change the scrolling position of the document, or perform
@@ -1142,7 +1141,6 @@ impl HTMLFormElement {
                     html_elem.Focus(&FocusOptions::default(), can_gc);
                     first = false;
                 }
-            }
         }
 
         // If it's form-associated and has a validation anchor, point the
@@ -1653,8 +1651,8 @@ pub(crate) trait FormControl: DomObject {
                 new_owner.add_control(self, can_gc);
             }
             // https://html.spec.whatwg.org/multipage/#custom-element-reactions:reset-the-form-owner
-            if let Some(html_elem) = elem.downcast::<HTMLElement>() {
-                if html_elem.is_form_associated_custom_element() {
+            if let Some(html_elem) = elem.downcast::<HTMLElement>()
+                && html_elem.is_form_associated_custom_element() {
                     ScriptThread::enqueue_callback_reaction(
                         elem,
                         CallbackReaction::FormAssociated(
@@ -1663,7 +1661,6 @@ pub(crate) trait FormControl: DomObject {
                         None,
                     )
                 }
-            }
             self.set_form_owner(new_owner.as_deref());
         }
     }

--- a/components/script/dom/html/htmliframeelement.rs
+++ b/components/script/dom/html/htmliframeelement.rs
@@ -153,8 +153,8 @@ impl HTMLIFrameElement {
 
         if load_data.url.scheme() == "javascript" {
             let window_proxy = self.GetContentWindow();
-            if let Some(window_proxy) = window_proxy {
-                if !ScriptThread::navigate_to_javascript_url(
+            if let Some(window_proxy) = window_proxy
+                && !ScriptThread::navigate_to_javascript_url(
                     &document.global(),
                     &window_proxy.global(),
                     &mut load_data,
@@ -163,7 +163,6 @@ impl HTMLIFrameElement {
                 ) {
                     return;
                 }
-            }
         }
 
         match load_data.js_eval_result {
@@ -301,15 +300,14 @@ impl HTMLIFrameElement {
         // Note: the spec says to set the name 'when the nested browsing context is created'.
         // The current implementation sets the name on the window,
         // when the iframe attributes are first processed.
-        if mode == ProcessingMode::FirstTime {
-            if let Some(window) = self.GetContentWindow() {
+        if mode == ProcessingMode::FirstTime
+            && let Some(window) = self.GetContentWindow() {
                 window.set_name(
                     self.upcast::<Element>()
                         .get_name()
                         .map_or(DOMString::from(""), |n| DOMString::from(&*n)),
                 );
             }
-        }
 
         if mode == ProcessingMode::FirstTime &&
             !self.upcast::<Element>().has_attribute(&local_name!("src"))
@@ -346,8 +344,8 @@ impl HTMLIFrameElement {
         // against simple typo self-includes but nothing more elaborate.
         let mut ancestor = window.GetParent();
         while let Some(a) = ancestor {
-            if let Some(ancestor_url) = a.document().map(|d| d.url()) {
-                if ancestor_url.scheme() == url.scheme() &&
+            if let Some(ancestor_url) = a.document().map(|d| d.url())
+                && ancestor_url.scheme() == url.scheme() &&
                     ancestor_url.username() == url.username() &&
                     ancestor_url.password() == url.password() &&
                     ancestor_url.host() == url.host() &&
@@ -357,7 +355,6 @@ impl HTMLIFrameElement {
                 {
                     return;
                 }
-            }
             ancestor = a.parent().map(DomRoot::from_ref);
         }
 

--- a/components/script/dom/html/htmlimageelement.rs
+++ b/components/script/dom/html/htmlimageelement.rs
@@ -265,14 +265,13 @@ impl FetchResponseListener for ImageContext {
         });
 
         // Step 14.5 of https://html.spec.whatwg.org/multipage/#img-environment-changes
-        if let Some(metadata) = metadata.as_ref() {
-            if let Some(ref content_type) = metadata.content_type {
+        if let Some(metadata) = metadata.as_ref()
+            && let Some(ref content_type) = metadata.content_type {
                 let mime: Mime = content_type.clone().into_inner().into();
                 if mime.type_() == mime::MULTIPART && mime.subtype().as_str() == "x-mixed-replace" {
                     self.aborted = true;
                 }
             }
-        }
 
         let status = metadata
             .as_ref()
@@ -724,11 +723,10 @@ impl HTMLImageElement {
 
             // Step 5.6. If child has a media attribute, and its value does not match the
             // environment, continue to the next child.
-            if let Some(media) = element.get_attribute(&ns!(), &local_name!("media")) {
-                if !MediaList::matches_environment(&element.owner_document(), &media.value()) {
+            if let Some(media) = element.get_attribute(&ns!(), &local_name!("media"))
+                && !MediaList::matches_environment(&element.owner_document(), &media.value()) {
                     continue;
                 }
-            }
 
             // Step 5.7. Parse child's sizes attribute with img, and let source set's source size be
             // the returned value.
@@ -738,11 +736,10 @@ impl HTMLImageElement {
 
             // Step 5.8. If child has a type attribute, and its value is an unknown or unsupported
             // MIME type, continue to the next child.
-            if let Some(type_) = element.get_attribute(&ns!(), &local_name!("type")) {
-                if !is_supported_image_mime_type(&type_.value()) {
+            if let Some(type_) = element.get_attribute(&ns!(), &local_name!("type"))
+                && !is_supported_image_mime_type(&type_.value()) {
                     continue;
                 }
-            }
 
             // Step 5.9. If child has width or height attributes, set el's dimension attribute
             // source to child. Otherwise, set el's dimension attribute source to el.

--- a/components/script/dom/html/htmlinputelement.rs
+++ b/components/script/dom/html/htmlinputelement.rs
@@ -261,11 +261,10 @@ impl TextInputWidgetShadowTree {
             (true, _) => "\u{200B}".into(),
         };
 
-        if let Some(character_data) = self.value_character_data() {
-            if character_data.Data() != value_text {
+        if let Some(character_data) = self.value_character_data()
+            && character_data.Data() != value_text {
                 character_data.SetData(value_text);
             }
-        }
     }
 }
 
@@ -1082,11 +1081,10 @@ impl HTMLInputElement {
             // Step 4. If the element has a minimum and a maximum and there is no value greater than or equal to the
             // element's minimum and less than or equal to the element's maximum that, when subtracted from the step
             // base, is an integral multiple of the allowed value step, then return.
-            if let Some(stepped_minimum) = self.stepped_minimum() {
-                if stepped_minimum > max {
+            if let Some(stepped_minimum) = self.stepped_minimum()
+                && stepped_minimum > max {
                     return Ok(());
                 }
-            }
         }
 
         // Step 5. If applying the algorithm to convert a string to a number to the string given
@@ -1134,20 +1132,18 @@ impl HTMLInputElement {
         // Step 8. If the element has a minimum, and value is less than that minimum, then set value to the smallest
         // value that, when subtracted from the step base, is an integral multiple of the allowed value step, and that
         // is more than or equal to that minimum.
-        if let Some(min) = minimum {
-            if value < min {
+        if let Some(min) = minimum
+            && value < min {
                 value = self.stepped_minimum().unwrap_or(value);
             }
-        }
 
         // Step 9. If the element has a maximum, and value is greater than that maximum, then set value to the largest
         // value that, when subtracted from the step base, is an integral multiple of the allowed value step, and that
         // is less than or equal to that maximum.
-        if let Some(max) = maximum {
-            if value > max {
+        if let Some(max) = maximum
+            && value > max {
                 value = self.stepped_maximum().unwrap_or(value);
             }
-        }
 
         // Step 10. If either the method invoked was the stepDown() method and value is greater than
         // valueBeforeStepping, or the method invoked was the stepUp() method and value is less than
@@ -1379,17 +1375,15 @@ impl HTMLInputElement {
             }
         } else {
             // https://html.spec.whatwg.org/multipage/#the-min-and-max-attributes%3Asuffering-from-an-underflow-2
-            if let Some(min_value) = min_value {
-                if value_as_number < min_value {
+            if let Some(min_value) = min_value
+                && value_as_number < min_value {
                     failed_flags.insert(ValidationFlags::RANGE_UNDERFLOW);
                 }
-            }
             // https://html.spec.whatwg.org/multipage/#the-min-and-max-attributes%3Asuffering-from-an-overflow-2
-            if let Some(max_value) = max_value {
-                if value_as_number > max_value {
+            if let Some(max_value) = max_value
+                && value_as_number > max_value {
                     failed_flags.insert(ValidationFlags::RANGE_OVERFLOW);
                 }
-            }
         }
 
         // https://html.spec.whatwg.org/multipage/#the-step-attribute%3Asuffering-from-a-step-mismatch
@@ -2500,16 +2494,14 @@ impl HTMLInputElement {
                     let mut fval = *fval;
                     // comparing max first, because if they contradict
                     // the spec wants min to be the one that applies
-                    if let Some(max) = self.maximum() {
-                        if fval > max {
+                    if let Some(max) = self.maximum()
+                        && fval > max {
                             fval = max;
                         }
-                    }
-                    if let Some(min) = self.minimum() {
-                        if fval < min {
+                    if let Some(min) = self.minimum()
+                        && fval < min {
                             fval = min;
                         }
-                    }
                     // https://html.spec.whatwg.org/multipage/#range-state-(type=range):suffering-from-a-step-mismatch
                     // Spec does not describe this in a way that lends itself to
                     // reproducible handling of floating-point rounding;
@@ -2527,16 +2519,14 @@ impl HTMLInputElement {
                             // but if after snapping we're now outside min..max
                             // we have to adjust! (adjusting to min last because
                             // that "wins" over max in the spec)
-                            if let Some(stepped_maximum) = self.stepped_maximum() {
-                                if fval > stepped_maximum {
+                            if let Some(stepped_maximum) = self.stepped_maximum()
+                                && fval > stepped_maximum {
                                     fval = stepped_maximum;
                                 }
-                            }
-                            if let Some(stepped_minimum) = self.stepped_minimum() {
-                                if fval < stepped_minimum {
+                            if let Some(stepped_minimum) = self.stepped_minimum()
+                                && fval < stepped_minimum {
                                     fval = stepped_minimum;
                                 }
-                            }
                         }
                     }
                     *value = DOMString::from(fval.to_string());
@@ -2836,11 +2826,10 @@ impl HTMLInputElement {
             // element's selected files."
             //
             // Note: This is annoying.
-            if self.Multiple() {
-                if let Some(filelist) = self.filelist.get() {
+            if self.Multiple()
+                && let Some(filelist) = self.filelist.get() {
                     files = filelist.iter_files().map(|file| file.as_rooted()).collect();
                 }
-            }
 
             let number_files_selected = response.as_ref().map(Vec::len).unwrap_or_default();
             pending_webdriver_reponse.finish(number_files_selected);

--- a/components/script/dom/html/htmllabelelement.rs
+++ b/components/script/dom/html/htmllabelelement.rs
@@ -132,11 +132,10 @@ impl HTMLLabelElementMethods<crate::DomTypeHolder> for HTMLLabelElement {
             });
         // We now have the element that we would return, but only return it
         // if it's labelable.
-        if let Some(ref maybe_labelable) = maybe_found {
-            if maybe_labelable.is_labelable_element() {
+        if let Some(ref maybe_labelable) = maybe_found
+            && maybe_labelable.is_labelable_element() {
                 return maybe_found;
             }
-        }
         None
     }
 }

--- a/components/script/dom/html/htmllinkelement.rs
+++ b/components/script/dom/html/htmllinkelement.rs
@@ -295,11 +295,10 @@ impl VirtualMethods for HTMLLinkElement {
                 // https://html.spec.whatwg.org/multipage/#link-type-preload
                 // When the as attribute of the link element of an external resource link
                 // that is already browsing-context connected is changed.
-                if self.relations.get().contains(LinkRelations::PRELOAD) {
-                    if let AttributeMutation::Set(Some(_), _) = mutation {
+                if self.relations.get().contains(LinkRelations::PRELOAD)
+                    && let AttributeMutation::Set(Some(_), _) = mutation {
                         self.handle_preload_url();
                     }
-                }
             },
             local_name!("type") => {
                 // https://html.spec.whatwg.org/multipage/#link-type-stylesheet
@@ -611,11 +610,10 @@ impl HTMLLinkElement {
         if !disabled {
             self.is_explicitly_enabled.set(true);
         }
-        if let Some(stylesheet) = self.get_stylesheet() {
-            if stylesheet.set_disabled(disabled) {
+        if let Some(stylesheet) = self.get_stylesheet()
+            && stylesheet.set_disabled(disabled) {
                 self.stylesheet_list_owner().invalidate_stylesheets();
             }
-        }
     }
 
     fn handle_favicon_url(&self, href: &str) {

--- a/components/script/dom/html/htmlmediaelement.rs
+++ b/components/script/dom/html/htmlmediaelement.rs
@@ -712,13 +712,11 @@ impl HTMLMediaElement {
                     error!("Could not play media: {error:?}");
                 }
             }
-        } else if is_playing {
-            if let Some(ref player) = *self.player.borrow() {
-                if let Err(error) = player.lock().unwrap().pause() {
+        } else if is_playing
+            && let Some(ref player) = *self.player.borrow()
+                && let Err(error) = player.lock().unwrap().pause() {
                     error!("Could not pause player: {error:?}");
                 }
-            }
-        }
     }
 
     /// Marks that element as delaying the load event or not.
@@ -1210,12 +1208,11 @@ impl HTMLMediaElement {
         // Step 9.children.3. If candidate has a media attribute whose value does not match the
         // environment, then end the synchronous section, and jump down to the failed with elements
         // step below.
-        if let Some(media) = element.get_attribute(&ns!(), &local_name!("media")) {
-            if !MediaList::matches_environment(&element.owner_document(), &media.value()) {
+        if let Some(media) = element.get_attribute(&ns!(), &local_name!("media"))
+            && !MediaList::matches_environment(&element.owner_document(), &media.value()) {
                 self.load_from_source_child_failure_steps(source);
                 return;
             }
-        }
 
         // Step 9.children.4. Let urlRecord be the result of encoding-parsing a URL given
         // candidate's src attribute's value, relative to candidate's node document when the src
@@ -1231,12 +1228,11 @@ impl HTMLMediaElement {
         // type (including any codecs described by the codecs parameter, for types that define that
         // parameter), represents a type that the user agent knows it cannot render, then end the
         // synchronous section, and jump down to the failed with elements step below.
-        if let Some(type_) = element.get_attribute(&ns!(), &local_name!("type")) {
-            if ServoMedia::get().can_play_type(&type_.value()) == SupportsMediaType::No {
+        if let Some(type_) = element.get_attribute(&ns!(), &local_name!("type"))
+            && ServoMedia::get().can_play_type(&type_.value()) == SupportsMediaType::No {
                 self.load_from_source_child_failure_steps(source);
                 return;
             }
-        }
 
         // Reset the media player before loading the next source child.
         self.reset_media_player();
@@ -1619,11 +1615,10 @@ impl HTMLMediaElement {
                     // Step 5. Fire an event named error at the media element.
                     this.upcast::<EventTarget>().fire_event(atom!("error"), CanGc::note());
 
-                    if let Some(ref player) = *this.player.borrow() {
-                        if let Err(error) = player.lock().unwrap().stop() {
+                    if let Some(ref player) = *this.player.borrow()
+                        && let Err(error) = player.lock().unwrap().stop() {
                             error!("Could not stop player: {error:?}");
                         }
-                    }
 
                     // Step 6. Reject pending play promises with promises and a "NotSupportedError"
                     // DOMException.
@@ -2027,11 +2022,10 @@ impl HTMLMediaElement {
         // Step 11. Set the current playback position to the new playback position.
         self.current_playback_position.set(time);
 
-        if let Some(ref player) = *self.player.borrow() {
-            if let Err(error) = player.lock().unwrap().seek(time) {
+        if let Some(ref player) = *self.player.borrow()
+            && let Err(error) = player.lock().unwrap().seek(time) {
                 error!("Could not seek player: {error:?}");
             }
-        }
 
         self.current_seek_position.set(time);
 
@@ -2179,11 +2173,10 @@ impl HTMLMediaElement {
             return;
         }
 
-        if let Some(ref player) = *self.player.borrow() {
-            if let Err(error) = player.lock().unwrap().stop() {
+        if let Some(ref player) = *self.player.borrow()
+            && let Err(error) = player.lock().unwrap().stop() {
                 error!("Could not stop player: {error:?}");
             }
-        }
 
         *self.player.borrow_mut() = None;
         self.video_renderer.lock().unwrap().reset();
@@ -2195,19 +2188,17 @@ impl HTMLMediaElement {
     }
 
     pub(crate) fn set_audio_track(&self, idx: usize, enabled: bool) {
-        if let Some(ref player) = *self.player.borrow() {
-            if let Err(error) = player.lock().unwrap().set_audio_track(idx as i32, enabled) {
+        if let Some(ref player) = *self.player.borrow()
+            && let Err(error) = player.lock().unwrap().set_audio_track(idx as i32, enabled) {
                 warn!("Could not set audio track {error:?}");
             }
-        }
     }
 
     pub(crate) fn set_video_track(&self, idx: usize, enabled: bool) {
-        if let Some(ref player) = *self.player.borrow() {
-            if let Err(error) = player.lock().unwrap().set_video_track(idx as i32, enabled) {
+        if let Some(ref player) = *self.player.borrow()
+            && let Err(error) = player.lock().unwrap().set_video_track(idx as i32, enabled) {
                 warn!("Could not set video track: {error:?}");
             }
-        }
     }
 
     /// <https://html.spec.whatwg.org/multipage/#direction-of-playback>
@@ -2393,11 +2384,10 @@ impl HTMLMediaElement {
             // enable, then set enable to true, otherwise, set enable to false.
             if let Some(servo_url) = self.resource_url.borrow().as_ref() {
                 let fragment = MediaFragmentParser::from(servo_url);
-                if let Some(id) = fragment.id() {
-                    if audio_track.id() == id {
+                if let Some(id) = fragment.id()
+                    && audio_track.id() == id {
                         audio_track_list.set_enabled(audio_track_list.len() - 1, true);
                     }
-                }
 
                 if fragment.tracks().contains(&audio_track.kind().into()) {
                     audio_track_list.set_enabled(audio_track_list.len() - 1, true);
@@ -2458,8 +2448,8 @@ impl HTMLMediaElement {
             // information that would facilitate the selection of specific video tracks to
             // improve the user's experience, then: if this video track is the first such video
             // track, then set enable to true, otherwise, set enable to false.
-            if let Some(track) = video_track_list.item(0) {
-                if let Some(servo_url) = self.resource_url.borrow().as_ref() {
+            if let Some(track) = video_track_list.item(0)
+                && let Some(servo_url) = self.resource_url.borrow().as_ref() {
                     let fragment = MediaFragmentParser::from(servo_url);
                     if let Some(id) = fragment.id() {
                         if track.id() == id {
@@ -2469,7 +2459,6 @@ impl HTMLMediaElement {
                         video_track_list.set_selected(0, true);
                     }
                 }
-            }
 
             // Step 5. If enable is still unknown, then, if the media element does not yet have a
             // selected video track, then set enable to true, otherwise, set enable to false.
@@ -2559,8 +2548,8 @@ impl HTMLMediaElement {
         // is still false, seek to that time.
         if let Some(servo_url) = self.resource_url.borrow().as_ref() {
             let fragment = MediaFragmentParser::from(servo_url);
-            if let Some(initial_playback_position) = fragment.start() {
-                if initial_playback_position > 0. &&
+            if let Some(initial_playback_position) = fragment.start()
+                && initial_playback_position > 0. &&
                     initial_playback_position < self.duration.get() &&
                     !jumped
                 {
@@ -2569,7 +2558,6 @@ impl HTMLMediaElement {
                         /* approximate_for_speed */ false,
                     )
                 }
-            }
         }
 
         // Step 12. If there is no enabled audio track, then enable an audio track. This will cause
@@ -2648,8 +2636,8 @@ impl HTMLMediaElement {
         // The media engine signals that the source needs more data. If we already have a valid
         // fetch request, we do nothing. Otherwise, if we have no request and the previous request
         // was cancelled because we got an EnoughData event, we restart fetching where we left.
-        if let Some(ref current_fetch_context) = *self.current_fetch_context.borrow() {
-            if let Some(reason) = current_fetch_context.cancel_reason() {
+        if let Some(ref current_fetch_context) = *self.current_fetch_context.borrow()
+            && let Some(reason) = current_fetch_context.cancel_reason() {
                 // XXX(ferjm) Ideally we should just create a fetch request from
                 // where we left. But keeping track of the exact next byte that the
                 // media backend expects is not the easiest task, so I'm simply
@@ -2663,10 +2651,9 @@ impl HTMLMediaElement {
                 }
                 return;
             }
-        }
 
-        if let Some(ref mut current_fetch_context) = *self.current_fetch_context.borrow_mut() {
-            if let Err(e) = {
+        if let Some(ref mut current_fetch_context) = *self.current_fetch_context.borrow_mut()
+            && let Err(e) = {
                 let mut data_source = current_fetch_context.data_source().borrow_mut();
                 data_source.set_locked(false);
                 data_source.process_into_player_from_queue(self.player.borrow().as_ref().unwrap())
@@ -2679,7 +2666,6 @@ impl HTMLMediaElement {
                     current_fetch_context.cancel(CancelReason::Backoff);
                 }
             }
-        }
     }
 
     fn playback_enough_data(&self) {
@@ -2687,11 +2673,10 @@ impl HTMLMediaElement {
         // to avoid excessive buffer queueing, so we cancel the ongoing fetch request if we are able
         // to restart it from where we left. Otherwise, we continue the current fetch request,
         // assuming that some frames will be dropped.
-        if let Some(ref mut current_fetch_context) = *self.current_fetch_context.borrow_mut() {
-            if current_fetch_context.is_seekable() {
+        if let Some(ref mut current_fetch_context) = *self.current_fetch_context.borrow_mut()
+            && current_fetch_context.is_seekable() {
                 current_fetch_context.cancel(CancelReason::Backoff);
             }
-        }
     }
 
     fn playback_position_changed(&self, position: f64) {
@@ -3000,11 +2985,10 @@ impl HTMLMediaElementMethods<crate::DomTypeHolder> for HTMLMediaElement {
 
         self.muted.set(value);
 
-        if let Some(ref player) = *self.player.borrow() {
-            if let Err(error) = player.lock().unwrap().set_mute(value) {
+        if let Some(ref player) = *self.player.borrow()
+            && let Err(error) = player.lock().unwrap().set_mute(value) {
                 warn!("Could not set mute state: {error:?}");
             }
-        }
 
         // The user agent must queue a media element task given the media element to fire an event
         // named volumechange at the media element.
@@ -3172,13 +3156,11 @@ impl HTMLMediaElementMethods<crate::DomTypeHolder> for HTMLMediaElement {
         // change the playback speed.
         self.playback_rate.set(*value);
 
-        if self.is_potentially_playing() {
-            if let Some(ref player) = *self.player.borrow() {
-                if let Err(error) = player.lock().unwrap().set_playback_rate(*value) {
+        if self.is_potentially_playing()
+            && let Some(ref player) = *self.player.borrow()
+                && let Err(error) = player.lock().unwrap().set_playback_rate(*value) {
                     warn!("Could not set the playback rate: {error:?}");
                 }
-            }
-        }
 
         // The user agent must queue a media element task given the media element to fire an event
         // named ratechange at the media element.
@@ -3328,11 +3310,10 @@ impl HTMLMediaElementMethods<crate::DomTypeHolder> for HTMLMediaElement {
 
         self.volume.set(*value);
 
-        if let Some(ref player) = *self.player.borrow() {
-            if let Err(error) = player.lock().unwrap().set_volume(*value) {
+        if let Some(ref player) = *self.player.borrow()
+            && let Err(error) = player.lock().unwrap().set_volume(*value) {
                 warn!("Could not set the volume: {error:?}");
             }
-        }
 
         // The user agent must queue a media element task given the media element to fire an event
         // named volumechange at the media element.
@@ -3732,8 +3713,8 @@ impl FetchResponseListener for HTMLMediaElementFetchListener {
             current_fetch_context.set_origin_clean(origin_clean);
         }
 
-        if let Some(metadata) = metadata.as_ref() {
-            if let Some(headers) = metadata.headers.as_ref() {
+        if let Some(metadata) = metadata.as_ref()
+            && let Some(headers) = metadata.headers.as_ref() {
                 // For range requests we get the size of the media asset from the Content-Range
                 // header. Otherwise, we get it from the Content-Length header.
                 let content_length =
@@ -3746,17 +3727,15 @@ impl FetchResponseListener for HTMLMediaElementFetchListener {
                     };
 
                 // We only set the expected input size if it changes.
-                if content_length != self.expected_content_length {
-                    if let Some(content_length) = content_length {
+                if content_length != self.expected_content_length
+                    && let Some(content_length) = content_length {
                         self.expected_content_length = Some(content_length);
                     }
-                }
             }
-        }
 
         // Explicit media player initialization with live/seekable source.
-        if let Some(expected_content_length) = self.expected_content_length {
-            if let Err(e) = element
+        if let Some(expected_content_length) = self.expected_content_length
+            && let Err(e) = element
                 .player
                 .borrow()
                 .as_ref()
@@ -3767,7 +3746,6 @@ impl FetchResponseListener for HTMLMediaElementFetchListener {
             {
                 warn!("Could not set player input size {:?}", e);
             }
-        }
     }
 
     fn process_response_chunk(&mut self, _: RequestId, chunk: Vec<u8>) {
@@ -3847,8 +3825,8 @@ impl FetchResponseListener for HTMLMediaElementFetchListener {
                 // start and stop positions without the total size of the stream is not
                 // possible. As fallback the media player perform seek with BYTES format
                 // and initiate seek request via "seek-data" callback with required offset.
-                if self.expected_content_length.is_none() {
-                    if let Err(e) = element
+                if self.expected_content_length.is_none()
+                    && let Err(e) = element
                         .player
                         .borrow()
                         .as_ref()
@@ -3859,7 +3837,6 @@ impl FetchResponseListener for HTMLMediaElementFetchListener {
                     {
                         warn!("Could not set player input size {:?}", e);
                     }
-                }
 
                 let mut data_source = current_fetch_context.data_source().borrow_mut();
 
@@ -3915,11 +3892,10 @@ impl FetchResponseListener for HTMLMediaElementFetchListener {
 
         // Whether the current fetch request was cancelled due to a network or decoding error, or
         // was aborted by the user.
-        if let Some(cancel_reason) = current_fetch_context.cancel_reason() {
-            if matches!(*cancel_reason, CancelReason::Error | CancelReason::Abort) {
+        if let Some(cancel_reason) = current_fetch_context.cancel_reason()
+            && matches!(*cancel_reason, CancelReason::Error | CancelReason::Abort) {
                 return false;
             }
-        }
 
         true
     }

--- a/components/script/dom/html/htmlmetaelement.rs
+++ b/components/script/dom/html/htmlmetaelement.rs
@@ -150,11 +150,10 @@ impl HTMLMetaElement {
 
     /// <https://html.spec.whatwg.org/multipage/#attr-meta-http-equiv-content-security-policy>
     fn apply_csp_list(&self) {
-        if let Some(parent) = self.upcast::<Node>().GetParentElement() {
-            if let Some(head) = parent.downcast::<HTMLHeadElement>() {
+        if let Some(parent) = self.upcast::<Node>().GetParentElement()
+            && let Some(head) = parent.downcast::<HTMLHeadElement>() {
                 head.set_content_security_policy();
             }
-        }
     }
 
     /// <https://html.spec.whatwg.org/multipage/#shared-declarative-refresh-steps>

--- a/components/script/dom/html/htmloptionelement.rs
+++ b/components/script/dom/html/htmloptionelement.rs
@@ -393,15 +393,12 @@ impl VirtualMethods for HTMLOptionElement {
         if !self
             .upcast::<Element>()
             .has_attribute(&local_name!("label"))
-        {
-            if let Some(owner_select) = self.owner_select_element() {
-                if owner_select
+            && let Some(owner_select) = self.owner_select_element()
+                && owner_select
                     .selected_option()
                     .is_some_and(|selected_option| self == &*selected_option)
                 {
                     owner_select.update_shadow_tree(can_gc);
                 }
-            }
-        }
     }
 }

--- a/components/script/dom/html/htmlscriptelement.rs
+++ b/components/script/dom/html/htmlscriptelement.rs
@@ -1203,13 +1203,11 @@ impl VirtualMethods for HTMLScriptElement {
         self.super_type()
             .unwrap()
             .attribute_mutated(attr, mutation, can_gc);
-        if *attr.local_name() == local_name!("src") {
-            if let AttributeMutation::Set(..) = mutation {
-                if !self.parser_inserted.get() && self.upcast::<Node>().is_connected() {
+        if *attr.local_name() == local_name!("src")
+            && let AttributeMutation::Set(..) = mutation
+                && !self.parser_inserted.get() && self.upcast::<Node>().is_connected() {
                     self.prepare(Some(IntroductionType::INJECTED_SCRIPT), can_gc);
                 }
-            }
-        }
     }
 
     /// <https://html.spec.whatwg.org/multipage/#script-processing-model:the-script-element-26>

--- a/components/script/dom/html/htmlselectelement.rs
+++ b/components/script/dom/html/htmlselectelement.rs
@@ -206,11 +206,10 @@ impl HTMLSelectElement {
 
         if let Some(last_selected) = last_selected {
             last_selected.set_selectedness(true);
-        } else if self.display_size() == 1 {
-            if let Some(first_enabled) = first_enabled {
+        } else if self.display_size() == 1
+            && let Some(first_enabled) = first_enabled {
                 first_enabled.set_selectedness(true);
             }
-        }
     }
 
     pub(crate) fn push_form_data(&self, data_set: &mut Vec<FormDatum>) {
@@ -747,13 +746,12 @@ impl VirtualMethods for HTMLSelectElement {
 
     fn handle_event(&self, event: &Event, can_gc: CanGc) {
         self.super_type().unwrap().handle_event(event, can_gc);
-        if let Some(event) = event.downcast::<FocusEvent>() {
-            if *event.upcast::<Event>().type_() != *"blur" {
+        if let Some(event) = event.downcast::<FocusEvent>()
+            && *event.upcast::<Event>().type_() != *"blur" {
                 self.owner_document()
                     .embedder_controls()
                     .hide_embedder_control(self.upcast());
             }
-        }
     }
 }
 

--- a/components/script/dom/html/htmlslotelement.rs
+++ b/components/script/dom/html/htmlslotelement.rs
@@ -399,11 +399,10 @@ impl Slottable {
                 .upcast::<Node>()
                 .traverse_preorder(ShadowIncluding::No)
             {
-                if let Some(slot) = node.downcast::<HTMLSlotElement>() {
-                    if slot.manually_assigned_nodes.borrow().contains(self) {
+                if let Some(slot) = node.downcast::<HTMLSlotElement>()
+                    && slot.manually_assigned_nodes.borrow().contains(self) {
                         return Some(DomRoot::from_ref(slot));
                     }
-                }
             }
             return None;
         }
@@ -497,11 +496,10 @@ impl VirtualMethods for HTMLSlotElement {
         }
 
         let was_already_in_shadow_tree = context.is_shadow_tree == IsShadowTree::Yes;
-        if !was_already_in_shadow_tree {
-            if let Some(shadow_root) = self.containing_shadow_root() {
+        if !was_already_in_shadow_tree
+            && let Some(shadow_root) = self.containing_shadow_root() {
                 shadow_root.register_slot(self);
             }
-        }
     }
 
     fn unbind_from_tree(&self, context: &UnbindContext, can_gc: CanGc) {
@@ -509,12 +507,11 @@ impl VirtualMethods for HTMLSlotElement {
             s.unbind_from_tree(context, can_gc);
         }
 
-        if !self.upcast::<Node>().is_in_a_shadow_tree() {
-            if let Some(old_shadow_root) = self.containing_shadow_root() {
+        if !self.upcast::<Node>().is_in_a_shadow_tree()
+            && let Some(old_shadow_root) = self.containing_shadow_root() {
                 // If we used to be in a shadow root, but aren't anymore, then unregister this slot
                 old_shadow_root.unregister_slot(self.Name(), self);
             }
-        }
     }
 }
 

--- a/components/script/dom/html/htmlsourceelement.rs
+++ b/components/script/dom/html/htmlsourceelement.rs
@@ -86,30 +86,28 @@ impl VirtualMethods for HTMLSourceElement {
                 // <https://html.spec.whatwg.org/multipage/#reacting-to-dom-mutations>
                 // The element's parent is a picture element and a source element that is a previous
                 // sibling has its srcset, sizes, media, type attributes set, changed, or removed.
-                if let Some(parent) = self.upcast::<Node>().GetParentElement() {
-                    if parent.is::<HTMLPictureElement>() {
+                if let Some(parent) = self.upcast::<Node>().GetParentElement()
+                    && parent.is::<HTMLPictureElement>() {
                         let next_sibling_iterator = self.upcast::<Node>().following_siblings();
                         HTMLSourceElement::iterate_next_html_image_element_siblings(
                             next_sibling_iterator,
                             |image| image.update_the_image_data(can_gc),
                         );
                     }
-                }
             },
             &local_name!("width") | &local_name!("height") => {
                 // Note: Despite being explicitly stated in the specification that any width or
                 // height attributes changes (set, changed, removed) of the source element should be
                 // counted as relevant mutation for the sibling image element, these attributes
                 // affect only the style presentational hints of the image element.
-                if let Some(parent) = self.upcast::<Node>().GetParentElement() {
-                    if parent.is::<HTMLPictureElement>() {
+                if let Some(parent) = self.upcast::<Node>().GetParentElement()
+                    && parent.is::<HTMLPictureElement>() {
                         let next_sibling_iterator = self.upcast::<Node>().following_siblings();
                         HTMLSourceElement::iterate_next_html_image_element_siblings(
                             next_sibling_iterator,
                             |image| image.upcast::<Node>().dirty(NodeDamage::Other),
                         );
                     }
-                }
             },
             _ => {},
         }
@@ -160,15 +158,14 @@ impl VirtualMethods for HTMLSourceElement {
 
         // Step 1. If oldParent is a picture element, then for each child of oldParent's children,
         // if child is an img element, then count this as a relevant mutation for child.
-        if context.parent.is::<HTMLPictureElement>() && !self.upcast::<Node>().has_parent() {
-            if let Some(next_sibling) = context.next_sibling {
+        if context.parent.is::<HTMLPictureElement>() && !self.upcast::<Node>().has_parent()
+            && let Some(next_sibling) = context.next_sibling {
                 let next_sibling_iterator = next_sibling.inclusively_following_siblings();
                 HTMLSourceElement::iterate_next_html_image_element_siblings(
                     next_sibling_iterator,
                     |image| image.update_the_image_data(can_gc),
                 );
             }
-        }
     }
 }
 

--- a/components/script/dom/html/htmlstyleelement.rs
+++ b/components/script/dom/html/htmlstyleelement.rs
@@ -343,15 +343,14 @@ impl VirtualMethods for HTMLStyleElement {
         }
 
         if attr.name() == "type" {
-            if let AttributeMutation::Set(Some(old_value), _) = mutation {
-                if **old_value == **attr.value() {
+            if let AttributeMutation::Set(Some(old_value), _) = mutation
+                && **old_value == **attr.value() {
                     return;
                 }
-            }
             self.remove_stylesheet();
             self.parse_own_css();
-        } else if attr.name() == "media" {
-            if let Some(ref stylesheet) = *self.stylesheet.borrow_mut() {
+        } else if attr.name() == "media"
+            && let Some(ref stylesheet) = *self.stylesheet.borrow_mut() {
                 let shared_lock = node.owner_doc().style_shared_lock().clone();
                 let mut guard = shared_lock.write();
                 let media = stylesheet.media.write_with(&mut guard);
@@ -361,7 +360,6 @@ impl VirtualMethods for HTMLStyleElement {
                 };
                 self.owner_document().invalidate_stylesheets();
             }
-        }
     }
 }
 

--- a/components/script/dom/html/htmltableelement.rs
+++ b/components/script/dom/html/htmltableelement.rs
@@ -120,11 +120,10 @@ impl HTMLTableElement {
     where
         P: FnMut(&DomRoot<Element>) -> bool,
     {
-        if let Some(e) = section {
-            if e.upcast::<Element>().local_name() != atom {
+        if let Some(e) = section
+            && e.upcast::<Element>().local_name() != atom {
                 return Err(Error::HierarchyRequest(None));
             }
-        }
 
         self.delete_first_section_of_type(atom, can_gc);
 

--- a/components/script/dom/indexeddb/idbdatabase.rs
+++ b/components/script/dom/indexeddb/idbdatabase.rs
@@ -209,11 +209,10 @@ impl IDBDatabaseMethods<crate::DomTypeHolder> for IDBDatabase {
         let key_path = options.keyPath.as_ref();
 
         // Step 5
-        if let Some(path) = key_path {
-            if !is_valid_key_path(path)? {
+        if let Some(path) = key_path
+            && !is_valid_key_path(path)? {
                 return Err(Error::Syntax(None));
             }
-        }
 
         // Step 6
         if self.object_store_names.borrow().contains(&name) {

--- a/components/script/dom/media/mediadevices.rs
+++ b/components/script/dom/media/mediadevices.rs
@@ -56,20 +56,18 @@ impl MediaDevicesMethods<crate::DomTypeHolder> for MediaDevices {
         let p = Promise::new_in_current_realm(comp, can_gc);
         let media = ServoMedia::get();
         let stream = MediaStream::new(&self.global(), can_gc);
-        if let Some(constraints) = convert_constraints(&constraints.audio) {
-            if let Some(audio) = media.create_audioinput_stream(constraints) {
+        if let Some(constraints) = convert_constraints(&constraints.audio)
+            && let Some(audio) = media.create_audioinput_stream(constraints) {
                 let track =
                     MediaStreamTrack::new(&self.global(), audio, MediaStreamType::Audio, can_gc);
                 stream.add_track(&track);
             }
-        }
-        if let Some(constraints) = convert_constraints(&constraints.video) {
-            if let Some(video) = media.create_videoinput_stream(constraints) {
+        if let Some(constraints) = convert_constraints(&constraints.video)
+            && let Some(video) = media.create_videoinput_stream(constraints) {
                 let track =
                     MediaStreamTrack::new(&self.global(), video, MediaStreamType::Video, can_gc);
                 stream.add_track(&track);
             }
-        }
 
         p.resolve_native(&stream, can_gc);
         p

--- a/components/script/dom/messageport.rs
+++ b/components/script/dom/messageport.rs
@@ -140,11 +140,10 @@ impl MessagePort {
             }
 
             // Step 4
-            if let Some(target_id) = target_port.as_ref() {
-                if port.message_port_id() == target_id {
+            if let Some(target_id) = target_port.as_ref()
+                && port.message_port_id() == target_id {
                     doomed = true;
                 }
-            }
         }
 
         // Step 5

--- a/components/script/dom/notification.rs
+++ b/components/script/dom/notification.rs
@@ -660,7 +660,7 @@ fn validate_and_normalize_vibration_pattern(
 
     // If the length of the pattern is even and not zero then the last entry in the pattern will
     // have no effect so an implementation can remove it from the pattern at this point.
-    if pattern.len() % 2 == 0 && !pattern.is_empty() {
+    if pattern.len().is_multiple_of(2) && !pattern.is_empty() {
         pattern.pop();
     }
 
@@ -820,35 +820,31 @@ impl Notification {
     /// <https://notifications.spec.whatwg.org/#fetch-steps>
     fn fetch_resources_and_show_when_ready(&self) {
         let mut pending_requests: Vec<(RequestBuilder, ResourceType)> = vec![];
-        if let Some(image_url) = &self.image {
-            if let Ok(url) = ServoUrl::parse(image_url) {
+        if let Some(image_url) = &self.image
+            && let Ok(url) = ServoUrl::parse(image_url) {
                 let request = self.build_resource_request(&url);
                 self.pending_request_ids.borrow_mut().insert(request.id);
                 pending_requests.push((request, ResourceType::Image));
             }
-        }
-        if let Some(icon_url) = &self.icon {
-            if let Ok(url) = ServoUrl::parse(icon_url) {
+        if let Some(icon_url) = &self.icon
+            && let Ok(url) = ServoUrl::parse(icon_url) {
                 let request = self.build_resource_request(&url);
                 self.pending_request_ids.borrow_mut().insert(request.id);
                 pending_requests.push((request, ResourceType::Icon));
             }
-        }
-        if let Some(badge_url) = &self.badge {
-            if let Ok(url) = ServoUrl::parse(badge_url) {
+        if let Some(badge_url) = &self.badge
+            && let Ok(url) = ServoUrl::parse(badge_url) {
                 let request = self.build_resource_request(&url);
                 self.pending_request_ids.borrow_mut().insert(request.id);
                 pending_requests.push((request, ResourceType::Badge));
             }
-        }
         for action in self.actions.iter() {
-            if let Some(icon_url) = &action.icon_url {
-                if let Ok(url) = ServoUrl::parse(icon_url) {
+            if let Some(icon_url) = &action.icon_url
+                && let Ok(url) = ServoUrl::parse(icon_url) {
                     let request = self.build_resource_request(&url);
                     self.pending_request_ids.borrow_mut().insert(request.id);
                     pending_requests.push((request, ResourceType::ActionIcon(action.id.clone())));
                 }
-            }
         }
 
         for (request, resource_type) in pending_requests {

--- a/components/script/dom/permissions.rs
+++ b/components/script/dom/permissions.rs
@@ -322,11 +322,10 @@ pub(crate) fn descriptor_permission_state(
     // relevant global object has an associated Document run the following step:
     //   1. Let document be settings' relevant global object's associated Document.
     //   2. If document is not allowed to use feature, return "denied".
-    if let Some(window) = global_scope.downcast::<Window>() {
-        if !window.Document().allowed_to_use_feature(feature) {
+    if let Some(window) = global_scope.downcast::<Window>()
+        && !window.Document().allowed_to_use_feature(feature) {
             return PermissionState::Denied;
         }
-    }
 
     // Step 5. Let key be the result of generating a permission key for descriptor with settings.
     // Step 6. Let entry be the result of getting a permission store entry with descriptor and key.

--- a/components/script/dom/processingoptions.rs
+++ b/components/script/dom/processingoptions.rs
@@ -396,11 +396,10 @@ pub(crate) fn process_link_headers(
             continue;
         }
         // Step 2.5. If attribs["media"] exists and attribs["media"] does not match the environment, then continue.
-        if let Some(media) = link_object.value_for_key_in_link_header("media") {
-            if !MediaList::matches_environment(document, media) {
+        if let Some(media) = link_object.value_for_key_in_link_header("media")
+            && !MediaList::matches_environment(document, media) {
                 continue;
             }
-        }
         // Step 2.6. Let options be a new link processing options with
         let mut options = LinkProcessingOptions {
             href: link_object.url.clone(),

--- a/components/script/dom/quotaexceedederror.rs
+++ b/components/script/dom/quotaexceedederror.rs
@@ -92,11 +92,10 @@ impl QuotaExceededErrorMethods<crate::DomTypeHolder> for QuotaExceededError {
         }
         // If this’s quota is not null, this’s requested is not null, and this’s requested
         // is less than this’s quota, then throw a RangeError.
-        if let (Some(quota), Some(requested)) = (options.quota, options.requested) {
-            if *requested < *quota {
+        if let (Some(quota), Some(requested)) = (options.quota, options.requested)
+            && *requested < *quota {
                 return Err(Error::Range("requested is less than quota".to_string()));
             }
-        }
         Ok(reflect_dom_object_with_proto(
             Box::new(QuotaExceededError::new_inherited(
                 message,

--- a/components/script/dom/range.rs
+++ b/components/script/dom/range.rs
@@ -610,8 +610,8 @@ impl RangeMethods<crate::DomTypeHolder> for Range {
             return Ok(fragment);
         }
 
-        if end_node == start_node {
-            if let Some(cdata) = start_node.downcast::<CharacterData>() {
+        if end_node == start_node
+            && let Some(cdata) = start_node.downcast::<CharacterData>() {
                 // Steps 4.1-2.
                 let data = cdata
                     .SubstringData(start_offset, end_offset - start_offset)
@@ -622,7 +622,6 @@ impl RangeMethods<crate::DomTypeHolder> for Range {
                 // Step 4.4
                 return Ok(fragment);
             }
-        }
 
         // Steps 5-12.
         let ContainedChildren {
@@ -716,8 +715,8 @@ impl RangeMethods<crate::DomTypeHolder> for Range {
             return Ok(fragment);
         }
 
-        if end_node == start_node {
-            if let Some(end_data) = end_node.downcast::<CharacterData>() {
+        if end_node == start_node
+            && let Some(end_data) = end_node.downcast::<CharacterData>() {
                 // Step 4.1.
                 let clone = end_node.CloneNode(/* deep */ true, can_gc)?;
                 // Step 4.2.
@@ -733,7 +732,6 @@ impl RangeMethods<crate::DomTypeHolder> for Range {
                 // Step 4.5.
                 return Ok(fragment);
             }
-        }
 
         // Steps 5-12.
         let ContainedChildren {
@@ -946,14 +944,13 @@ impl RangeMethods<crate::DomTypeHolder> for Range {
         let end_offset = self.end_offset();
 
         // Step 3.
-        if start_node == end_node {
-            if let Some(text) = start_node.downcast::<CharacterData>() {
+        if start_node == end_node
+            && let Some(text) = start_node.downcast::<CharacterData>() {
                 if end_offset > start_offset {
                     self.report_change();
                 }
                 return text.ReplaceData(start_offset, end_offset - start_offset, DOMString::new());
             }
-        }
 
         // Step 4.
         rooted_vec!(let mut contained_children);

--- a/components/script/dom/readablebytestreamcontroller.rs
+++ b/components/script/dom/readablebytestreamcontroller.rs
@@ -887,8 +887,7 @@ impl ReadableByteStreamController {
 
             // If the remainder after dividing firstPendingPullInto’s bytes filled by
             // firstPendingPullInto’s element size is not 0,
-            if first_pending_pull_into.bytes_filled.get() % first_pending_pull_into.element_size !=
-                0
+            if !first_pending_pull_into.bytes_filled.get().is_multiple_of(first_pending_pull_into.element_size)
             {
                 // needed to drop the borrow and avoid BorrowMutError
                 drop(pending_pull_intos);
@@ -1153,7 +1152,7 @@ impl ReadableByteStreamController {
             // Assert: the remainder after dividing pullIntoDescriptor’s bytes filled
             // by pullIntoDescriptor’s element size is 0.
             assert!(
-                pull_into_descriptor.bytes_filled.get() % pull_into_descriptor.element_size == 0
+                pull_into_descriptor.bytes_filled.get().is_multiple_of(pull_into_descriptor.element_size)
             );
 
             // Set done to true.
@@ -1202,7 +1201,7 @@ impl ReadableByteStreamController {
         assert!(bytes_filled <= pull_into_descriptor.byte_length);
 
         // Assert: the remainder after dividing bytesFilled by elementSize is 0.
-        assert!(bytes_filled % element_size == 0);
+        assert!(bytes_filled.is_multiple_of(element_size));
 
         // Let buffer be ! TransferArrayBuffer(pullIntoDescriptor’s buffer).
         let buffer = pull_into_descriptor

--- a/components/script/dom/response.rs
+++ b/components/script/dom/response.rs
@@ -444,8 +444,8 @@ fn initialize_response(
 
         // 6.3 If body’s type is non-null and response’s header list does not contain `Content-Type`,
         // then append (`Content-Type`, body’s type) to response’s header list.
-        if let Some(content_type_contents) = &body.content_type {
-            if !response
+        if let Some(content_type_contents) = &body.content_type
+            && !response
                 .Headers(can_gc)
                 .Has(ByteString::new(b"Content-Type".to_vec()))
                 .unwrap()
@@ -454,8 +454,7 @@ fn initialize_response(
                     ByteString::new(b"Content-Type".to_vec()),
                     ByteString::new(content_type_contents.as_bytes().to_vec()),
                 )?;
-            }
-        };
+            };
     } else {
         // Reset FetchResponse to an in-memory stream with empty byte sequence here for
         // no-init-body case. This is because the Response/Body types here do not hold onto a

--- a/components/script/dom/selection.rs
+++ b/components/script/dom/selection.rs
@@ -60,11 +60,10 @@ impl Selection {
         // If we are setting to literally the same Range object
         // (not just the same positions), then there's nothing changing
         // and no task to queue.
-        if let Some(existing) = self.range.get() {
-            if &*existing == range {
+        if let Some(existing) = self.range.get()
+            && &*existing == range {
                 return;
             }
-        }
         self.range.set(Some(range));
         range.associate_selection(self);
         self.queue_selectionchange_task();
@@ -214,12 +213,11 @@ impl SelectionMethods<crate::DomTypeHolder> for Selection {
 
     /// <https://w3c.github.io/selection-api/#dom-selection-removerange>
     fn RemoveRange(&self, range: &Range) -> ErrorResult {
-        if let Some(own_range) = self.range.get() {
-            if &*own_range == range {
+        if let Some(own_range) = self.range.get()
+            && &*own_range == range {
                 self.clear_range();
                 return Ok(());
             }
-        }
         Err(Error::NotFound(None))
     }
 

--- a/components/script/dom/servoparser/encoding.rs
+++ b/components/script/dom/servoparser/encoding.rs
@@ -139,15 +139,14 @@ impl DetectingState {
             // Step 6.2 If parentDocument's origin is same origin with d's origin and parentDocument's character encoding
             // is not UTF-16BE/LE, then return parentDocument's character encoding, with the confidence tentative.
             // NOTE: This should not happen for XML documents
-            if let Some(encoding) = self.encoding_of_container_document {
-                if encoding != UTF_16LE && encoding != UTF_16BE {
+            if let Some(encoding) = self.encoding_of_container_document
+                && encoding != UTF_16LE && encoding != UTF_16BE {
                     log::debug!(
                         "Inferred encoding to be that of the container document, which is {}",
                         encoding.name()
                     );
                     return Some(encoding);
                 }
-            }
 
             // Step 7. Otherwise, if the user agent has information on the likely encoding for this page, e.g.
             // based on the encoding of the page when it was last visited, then return that encoding,
@@ -409,14 +408,13 @@ pub fn prescan_the_byte_stream_to_determine_the_encoding(
                         // giving the attribute's value as the string to parse. If a character encoding
                         // is returned, and if charset is still set to null, let charset be the encoding
                         // returned, and set need pragma to true.
-                        if charset.is_none() {
-                            if let Some(extracted_charset) =
+                        if charset.is_none()
+                            && let Some(extracted_charset) =
                                 extract_a_character_encoding_from_a_meta_element(&attribute.value)
                             {
                                 need_pragma = Some(true);
                                 charset = Some(extracted_charset);
                             }
-                        }
                     },
                     // If the attribute's name is "charset"
                     b"charset" if !have_seen_charset_attribute => {

--- a/components/script/dom/servoparser/html.rs
+++ b/components/script/dom/servoparser/html.rs
@@ -136,13 +136,12 @@ fn start_element<S: Serializer>(element: &Element, serializer: &mut S) -> io::Re
 
     // The "is" value of an element is treated as if it was an attribute and it is serialized before all
     // other attributes. If the element already has an "is" attribute then the "is" value is ignored.
-    if !element.has_attribute(&LocalName::from("is")) {
-        if let Some(is_value) = element.get_is() {
+    if !element.has_attribute(&LocalName::from("is"))
+        && let Some(is_value) = element.get_is() {
             let qualified_name = QualName::new(None, ns!(), LocalName::from("is"));
 
             attributes.push((qualified_name, AttrValue::String(is_value.to_string())));
         }
-    }
 
     // Collect all the "normal" attributes
     attributes.extend(element.attrs().iter().map(|attr| {

--- a/components/script/dom/servoparser/prefetch.rs
+++ b/components/script/dom/servoparser/prefetch.rs
@@ -195,9 +195,9 @@ impl TokenSink for PrefetchSink {
                 TokenSinkResult::Continue
             },
             (TagKind::StartTag, &local_name!("link")) if self.prefetching.get() => {
-                if let Some(rel) = self.get_attr(tag, local_name!("rel")) {
-                    if rel.value.eq_ignore_ascii_case("stylesheet") {
-                        if let Some(url) = self.get_url(tag, local_name!("href")) {
+                if let Some(rel) = self.get_attr(tag, local_name!("rel"))
+                    && rel.value.eq_ignore_ascii_case("stylesheet")
+                        && let Some(url) = self.get_url(tag, local_name!("href")) {
                             debug!("Prefetch {} {}", tag.name, url);
                             let cors_setting =
                                 self.get_cors_settings(tag, local_name!("crossorigin"));
@@ -230,8 +230,6 @@ impl TokenSink for PrefetchSink {
                                 .resource_threads
                                 .send(CoreResourceMsg::Fetch(request, FetchChannels::Prefetch));
                         }
-                    }
-                }
                 TokenSinkResult::Continue
             },
             (TagKind::StartTag, &local_name!("script")) => {
@@ -243,12 +241,11 @@ impl TokenSink for PrefetchSink {
                 TokenSinkResult::Script(PrefetchHandle)
             },
             (TagKind::StartTag, &local_name!("base")) => {
-                if let Some(url) = self.get_url(tag, local_name!("href")) {
-                    if self.base_url.borrow().is_none() {
+                if let Some(url) = self.get_url(tag, local_name!("href"))
+                    && self.base_url.borrow().is_none() {
                         debug!("Setting base {}", url);
                         *self.base_url.borrow_mut() = Some(url);
                     }
-                }
                 TokenSinkResult::Continue
             },
             _ => TokenSinkResult::Continue,

--- a/components/script/dom/subtlecrypto.rs
+++ b/components/script/dom/subtlecrypto.rs
@@ -1653,12 +1653,11 @@ impl SubtleCryptoMethods<crate::DomTypeHolder> for SubtleCrypto {
                 // Otherwise:
                 //     Let key be bytes.
                 let cx = GlobalScope::get_cx();
-                if format == KeyFormat::Jwk {
-                    if let Err(error) = JsonWebKey::parse(cx, &bytes) {
+                if format == KeyFormat::Jwk
+                    && let Err(error) = JsonWebKey::parse(cx, &bytes) {
                         subtle.reject_promise_with_error(promise, error);
                         return;
                     }
-                }
                 let key = bytes;
 
                 // Step 16. Let result be the result of performing the import key operation
@@ -3200,11 +3199,10 @@ impl JsonWebKeyExt for JsonWebKey {
             }
             // 2. The "use" and "key_ops" JWK members SHOULD NOT be used together; however, if both
             //    are used, the information they convey MUST be consistent.
-            if let Some(ref use_) = self.use_ {
-                if key_ops.iter().any(|op| op != use_) {
+            if let Some(ref use_) = self.use_
+                && key_ops.iter().any(|op| op != use_) {
                     return Err(Error::Data(None));
                 }
-            }
 
             // or does not contain all of the specified usages values
             let key_ops_as_usages = self.get_usages_from_key_ops()?;

--- a/components/script/dom/subtlecrypto/aes_cbc_operation.rs
+++ b/components/script/dom/subtlecrypto/aes_cbc_operation.rs
@@ -84,7 +84,7 @@ pub(crate) fn decrypt(
     if ciphertext.is_empty() {
         return Err(Error::Operation(Some("The ciphertext is empty".into())));
     }
-    if ciphertext.len() % 16 != 0 {
+    if !ciphertext.len().is_multiple_of(16) {
         return Err(Error::Operation(Some(
             "The ciphertext length is not a multiple of 16 bytes".into(),
         )));

--- a/components/script/dom/subtlecrypto/aes_operation.rs
+++ b/components/script/dom/subtlecrypto/aes_operation.rs
@@ -25,7 +25,7 @@ use crate::script_runtime::CanGc;
 /// <https://w3c.github.io/webcrypto/#aes-kw-operations-wrap-key>
 pub(crate) fn wrap_key_aes_kw(key: &CryptoKey, plaintext: &[u8]) -> Result<Vec<u8>, Error> {
     // Step 1. If plaintext is not a multiple of 64 bits in length, then throw an OperationError.
-    if plaintext.len() % 8 != 0 {
+    if !plaintext.len().is_multiple_of(8) {
         return Err(Error::Operation(Some(
             "The plaintext bit-length is not a multiple of 64".into(),
         )));

--- a/components/script/dom/subtlecrypto/ml_dsa_operation.rs
+++ b/components/script/dom/subtlecrypto/ml_dsa_operation.rs
@@ -1106,20 +1106,18 @@ fn convert_seed_to_handles(
     let handles = match algo_name {
         ALG_ML_DSA_44 => {
             let key_pair = MlDsa44::key_gen_internal(&seed);
-            if let Some(private_key_bytes) = private_key_bytes {
-                if private_key_bytes != key_pair.signing_key().encode().as_slice() {
+            if let Some(private_key_bytes) = private_key_bytes
+                && private_key_bytes != key_pair.signing_key().encode().as_slice() {
                     return Err(Error::Data(Some(
                         "The expanded private key does not match the seed".to_string(),
                     )));
                 }
-            }
-            if let Some(public_key_bytes) = public_key_bytes {
-                if public_key_bytes != key_pair.verifying_key().encode().as_slice() {
+            if let Some(public_key_bytes) = public_key_bytes
+                && public_key_bytes != key_pair.verifying_key().encode().as_slice() {
                     return Err(Error::Data(Some(
                         "The public key does not match the seed".to_string(),
                     )));
                 }
-            }
 
             (
                 Handle::MlDsa44PrivateKey(seed),
@@ -1128,20 +1126,18 @@ fn convert_seed_to_handles(
         },
         ALG_ML_DSA_65 => {
             let key_pair = MlDsa65::key_gen_internal(&seed);
-            if let Some(private_key_bytes) = private_key_bytes {
-                if private_key_bytes != key_pair.signing_key().encode().as_slice() {
+            if let Some(private_key_bytes) = private_key_bytes
+                && private_key_bytes != key_pair.signing_key().encode().as_slice() {
                     return Err(Error::Data(Some(
                         "The expanded private key does not match the seed".to_string(),
                     )));
                 }
-            }
-            if let Some(public_key_bytes) = public_key_bytes {
-                if public_key_bytes != key_pair.verifying_key().encode().as_slice() {
+            if let Some(public_key_bytes) = public_key_bytes
+                && public_key_bytes != key_pair.verifying_key().encode().as_slice() {
                     return Err(Error::Data(Some(
                         "The public key does not match the seed".to_string(),
                     )));
                 }
-            }
 
             (
                 Handle::MlDsa65PrivateKey(seed),
@@ -1150,20 +1146,18 @@ fn convert_seed_to_handles(
         },
         ALG_ML_DSA_87 => {
             let key_pair = MlDsa87::key_gen_internal(&seed);
-            if let Some(private_key_bytes) = private_key_bytes {
-                if private_key_bytes != key_pair.signing_key().encode().as_slice() {
+            if let Some(private_key_bytes) = private_key_bytes
+                && private_key_bytes != key_pair.signing_key().encode().as_slice() {
                     return Err(Error::Data(Some(
                         "The expanded private key does not match the seed".to_string(),
                     )));
                 }
-            }
-            if let Some(public_key_bytes) = public_key_bytes {
-                if public_key_bytes != key_pair.verifying_key().encode().as_slice() {
+            if let Some(public_key_bytes) = public_key_bytes
+                && public_key_bytes != key_pair.verifying_key().encode().as_slice() {
                     return Err(Error::Data(Some(
                         "The public key does not match the seed".to_string(),
                     )));
                 }
-            }
 
             (
                 Handle::MlDsa87PrivateKey(seed),

--- a/components/script/dom/subtlecrypto/ml_kem_operation.rs
+++ b/components/script/dom/subtlecrypto/ml_kem_operation.rs
@@ -1213,20 +1213,18 @@ fn convert_seed_to_handles(
     let handles = match algo_name {
         ALG_ML_KEM_512 => {
             let (decapsulation_key, encapsulation_key) = MlKem512::generate_deterministic(&d, &z);
-            if let Some(private_key_bytes) = private_key_bytes {
-                if private_key_bytes != decapsulation_key.as_bytes().as_slice() {
+            if let Some(private_key_bytes) = private_key_bytes
+                && private_key_bytes != decapsulation_key.as_bytes().as_slice() {
                     return Err(Error::Data(Some(
                         "The expanded private key does not match the seed".to_string(),
                     )));
                 }
-            }
-            if let Some(public_key_bytes) = public_key_bytes {
-                if public_key_bytes != encapsulation_key.as_bytes().as_slice() {
+            if let Some(public_key_bytes) = public_key_bytes
+                && public_key_bytes != encapsulation_key.as_bytes().as_slice() {
                     return Err(Error::Data(Some(
                         "The public key does not match the seed".to_string(),
                     )));
                 }
-            }
 
             (
                 Handle::MlKem512PrivateKey((d, z)),
@@ -1235,20 +1233,18 @@ fn convert_seed_to_handles(
         },
         ALG_ML_KEM_768 => {
             let (decapsulation_key, encapsulation_key) = MlKem768::generate_deterministic(&d, &z);
-            if let Some(private_key_bytes) = private_key_bytes {
-                if private_key_bytes != decapsulation_key.as_bytes().as_slice() {
+            if let Some(private_key_bytes) = private_key_bytes
+                && private_key_bytes != decapsulation_key.as_bytes().as_slice() {
                     return Err(Error::Data(Some(
                         "The expanded private key does not match the seed".to_string(),
                     )));
                 }
-            }
-            if let Some(public_key_bytes) = public_key_bytes {
-                if public_key_bytes != encapsulation_key.as_bytes().as_slice() {
+            if let Some(public_key_bytes) = public_key_bytes
+                && public_key_bytes != encapsulation_key.as_bytes().as_slice() {
                     return Err(Error::Data(Some(
                         "The public key does not match the seed".to_string(),
                     )));
                 }
-            }
 
             (
                 Handle::MlKem768PrivateKey((d, z)),
@@ -1257,20 +1253,18 @@ fn convert_seed_to_handles(
         },
         ALG_ML_KEM_1024 => {
             let (decapsulation_key, encapsulation_key) = MlKem1024::generate_deterministic(&d, &z);
-            if let Some(private_key_bytes) = private_key_bytes {
-                if private_key_bytes != decapsulation_key.as_bytes().as_slice() {
+            if let Some(private_key_bytes) = private_key_bytes
+                && private_key_bytes != decapsulation_key.as_bytes().as_slice() {
                     return Err(Error::Data(Some(
                         "The expanded private key does not match the seed".to_string(),
                     )));
                 }
-            }
-            if let Some(public_key_bytes) = public_key_bytes {
-                if public_key_bytes != encapsulation_key.as_bytes().as_slice() {
+            if let Some(public_key_bytes) = public_key_bytes
+                && public_key_bytes != encapsulation_key.as_bytes().as_slice() {
                     return Err(Error::Data(Some(
                         "The public key does not match the seed".to_string(),
                     )));
                 }
-            }
 
             (
                 Handle::MlKem1024PrivateKey((d, z)),

--- a/components/script/dom/svg/svgimageelement.rs
+++ b/components/script/dom/svg/svgimageelement.rs
@@ -75,11 +75,9 @@ impl VirtualMethods for SVGImageElement {
             .attribute_mutated(attr, mutation, can_gc);
         if attr.local_name() == &local_name!("href") &&
             matches!(attr.namespace(), &ns!() | &ns!(xlink))
-        {
-            if let AttributeMutation::Set(..) = mutation {
+            && let AttributeMutation::Set(..) = mutation {
                 self.fetch_image_resource();
             }
-        }
     }
 
     fn attribute_affects_presentational_hints(&self, attr: &Attr) -> bool {

--- a/components/script/dom/svg/svgsvgelement.rs
+++ b/components/script/dom/svg/svgsvgelement.rs
@@ -92,13 +92,11 @@ impl SVGSVGElement {
         let root_node = self.upcast::<Node>();
 
         for node in root_node.traverse_preorder(ShadowIncluding::No) {
-            if let Some(element) = node.downcast::<Element>() {
-                if element.local_name() == &local_name!("use") {
-                    if let Some(cloned) = self.process_single_use_element(element, can_gc) {
+            if let Some(element) = node.downcast::<Element>()
+                && element.local_name() == &local_name!("use")
+                    && let Some(cloned) = self.process_single_use_element(element, can_gc) {
                         cloned_nodes.push(cloned);
                     }
-                }
-            }
         }
 
         cloned_nodes

--- a/components/script/dom/url.rs
+++ b/components/script/dom/url.rs
@@ -203,9 +203,9 @@ impl URLMethods<crate::DomTypeHolder> for URL {
         // this method call does nothing. User agents may display a message on the error console.
         let origin = get_blob_origin(&global.get_url());
 
-        if let Ok(url) = ServoUrl::parse(&url.str()) {
-            if url.fragment().is_none() && origin == get_blob_origin(&url) {
-                if let Ok((id, _)) = parse_blob_url(&url) {
+        if let Ok(url) = ServoUrl::parse(&url.str())
+            && url.fragment().is_none() && origin == get_blob_origin(&url)
+                && let Ok((id, _)) = parse_blob_url(&url) {
                     let resource_threads = global.resource_threads();
                     let (tx, rx) = ipc::channel(global.time_profiler_chan().clone()).unwrap();
                     let msg = FileManagerThreadMsg::RevokeBlobURL(id, origin, tx);
@@ -213,8 +213,6 @@ impl URLMethods<crate::DomTypeHolder> for URL {
 
                     let _ = rx.recv().unwrap();
                 }
-            }
-        }
     }
 
     /// <https://url.spec.whatwg.org/#dom-url-hash>

--- a/components/script/dom/validitystate.rs
+++ b/components/script/dom/validitystate.rs
@@ -157,11 +157,10 @@ impl ValidityState {
             self.element.set_state(ElementState::INVALID, false);
         }
 
-        if let Some(form_control) = self.element.as_maybe_form_control() {
-            if let Some(form_owner) = form_control.form_owner() {
+        if let Some(form_control) = self.element.as_maybe_form_control()
+            && let Some(form_owner) = form_control.form_owner() {
                 form_owner.update_validity(can_gc);
             }
-        }
 
         if let Some(fieldset) = self
             .element

--- a/components/script/dom/videotrack.rs
+++ b/components/script/dom/videotrack.rs
@@ -116,11 +116,10 @@ impl VideoTrackMethods<crate::DomTypeHolder> for VideoTrack {
 
     /// <https://html.spec.whatwg.org/multipage/#dom-videotrack-selected>
     fn SetSelected(&self, value: bool) {
-        if let Some(list) = self.track_list.borrow().as_ref() {
-            if let Some(idx) = list.find(self) {
+        if let Some(list) = self.track_list.borrow().as_ref()
+            && let Some(idx) = list.find(self) {
                 list.set_selected(idx, value);
             }
-        }
         self.set_selected(value);
     }
 }

--- a/components/script/dom/videotracklist.rs
+++ b/components/script/dom/videotracklist.rs
@@ -103,11 +103,10 @@ impl VideoTrackList {
 
     pub(crate) fn add(&self, track: &VideoTrack) {
         self.tracks.borrow_mut().push(Dom::from_ref(track));
-        if track.selected() {
-            if let Some(idx) = self.selected_index() {
+        if track.selected()
+            && let Some(idx) = self.selected_index() {
                 self.set_selected(idx, false);
             }
-        }
         track.add_track_list(self);
     }
 

--- a/components/script/dom/vttcue.rs
+++ b/components/script/dom/vttcue.rs
@@ -150,11 +150,10 @@ impl VTTCueMethods<crate::DomTypeHolder> for VTTCue {
 
     /// <https://w3c.github.io/webvtt/#dom-vttcue-position>
     fn SetPosition(&self, value: VTTCueBinding::LineAndPositionSetting) -> ErrorResult {
-        if let VTTCueBinding::LineAndPositionSetting::Double(x) = value {
-            if *x < 0_f64 || *x > 100_f64 {
+        if let VTTCueBinding::LineAndPositionSetting::Double(x) = value
+            && (*x < 0_f64 || *x > 100_f64) {
                 return Err(Error::IndexSize(None));
             }
-        }
 
         *self.position.borrow_mut() = value.into();
         Ok(())

--- a/components/script/dom/webgl/extensions/extensions.rs
+++ b/components/script/dom/webgl/extensions/extensions.rs
@@ -217,11 +217,10 @@ impl WebGLExtensions {
             .borrow()
             .iter()
             .filter(|v| {
-                if let WebGLExtensionSpec::Specific(version) = v.1.spec() {
-                    if self.webgl_version != version {
+                if let WebGLExtensionSpec::Specific(version) = v.1.spec()
+                    && self.webgl_version != version {
                         return false;
                     }
-                }
                 v.1.is_supported(self)
             })
             .map(|ref v| v.1.name())

--- a/components/script/dom/webgl/validations/tex_image_2d.rs
+++ b/components/script/dom/webgl/validations/tex_image_2d.rs
@@ -421,7 +421,7 @@ pub(crate) struct CommonCompressedTexImage2DValidatorResult {
 }
 
 fn valid_s3tc_dimension(level: u32, side_length: u32, block_size: u32) -> bool {
-    (side_length % block_size == 0) || (level > 0 && [0, 1, 2].contains(&side_length))
+    side_length.is_multiple_of(block_size) || (level > 0 && [0, 1, 2].contains(&side_length))
 }
 
 fn valid_compressed_data_len(
@@ -452,9 +452,9 @@ fn is_subimage_blockaligned(
     let block_width = compression.block_width as u32;
     let block_height = compression.block_height as u32;
 
-    (xoffset % block_width == 0 && yoffset % block_height == 0) &&
-        (width % block_width == 0 || xoffset + width == tex_info.width()) &&
-        (height % block_height == 0 || yoffset + height == tex_info.height())
+    (xoffset.is_multiple_of(block_width) && yoffset.is_multiple_of(block_height)) &&
+        (width.is_multiple_of(block_width) || xoffset + width == tex_info.width()) &&
+        (height.is_multiple_of(block_height) || yoffset + height == tex_info.height())
 }
 
 impl WebGLValidator for CommonCompressedTexImage2DValidator<'_> {

--- a/components/script/dom/webgl/webgl2renderingcontext.rs
+++ b/components/script/dom/webgl/webgl2renderingcontext.rs
@@ -3174,12 +3174,10 @@ impl WebGL2RenderingContextMethods<crate::DomTypeHolder> for WebGL2RenderingCont
         // side ArrayBufferView.
         if let (Some(AlphaTreatment::Premultiply), YAxisTreatment::Flipped) =
             (alpha_treatment, y_axis_treatment)
-        {
-            if src_data.is_some() {
+            && src_data.is_some() {
                 self.base.webgl_error(InvalidOperation);
                 return Ok(());
             }
-        }
         let tex_source = TexPixels::from_array(
             buff,
             Size2D::new(width, height),
@@ -3265,12 +3263,11 @@ impl WebGL2RenderingContextMethods<crate::DomTypeHolder> for WebGL2RenderingCont
             },
         };
 
-        if let Some(tf_buffer) = self.bound_transform_feedback_buffer.get() {
-            if pixel_unpack_buffer == tf_buffer {
+        if let Some(tf_buffer) = self.bound_transform_feedback_buffer.get()
+            && pixel_unpack_buffer == tf_buffer {
                 self.base.webgl_error(InvalidOperation);
                 return Ok(());
             }
-        }
 
         if pbo_offset < 0 || pbo_offset as usize > pixel_unpack_buffer.capacity() {
             self.base.webgl_error(InvalidValue);
@@ -3821,11 +3818,10 @@ impl WebGL2RenderingContextMethods<crate::DomTypeHolder> for WebGL2RenderingCont
                     },
                     _ => unreachable!(),
                 };
-                if let Some(stored_query) = slot.get() {
-                    if stored_query.target() == query.target() {
+                if let Some(stored_query) = slot.get()
+                    && stored_query.target() == query.target() {
                         slot.set(None);
                     }
-                }
             }
 
             query.delete(Operation::Infallible);
@@ -3942,11 +3938,10 @@ impl WebGL2RenderingContextMethods<crate::DomTypeHolder> for WebGL2RenderingCont
                 None
             },
         };
-        if let Some(query) = active_query.as_ref() {
-            if query.target() != Some(target) {
+        if let Some(query) = active_query.as_ref()
+            && query.target() != Some(target) {
                 return None;
             }
-        }
         active_query
     }
 
@@ -4238,12 +4233,11 @@ impl WebGL2RenderingContextMethods<crate::DomTypeHolder> for WebGL2RenderingCont
                     self.base.webgl_error(InvalidOperation);
                     return;
                 }
-                if let Some(current_tf) = self.current_transform_feedback.get() {
-                    if current_tf.is_active() && !current_tf.is_paused() {
+                if let Some(current_tf) = self.current_transform_feedback.get()
+                    && current_tf.is_active() && !current_tf.is_paused() {
                         self.base.webgl_error(InvalidOperation);
                         return;
                     }
-                }
                 transform_feedback.bind(&self.base, target);
                 self.current_transform_feedback
                     .set(Some(transform_feedback));

--- a/components/script/dom/webgl/webglbuffer.rs
+++ b/components/script/dom/webgl/webglbuffer.rs
@@ -220,13 +220,12 @@ impl WebGLBuffer {
 
     /// <https://registry.khronos.org/webgl/specs/latest/2.0/#5.1>
     fn can_bind_to(&self, new_target: u32) -> bool {
-        if let Some(current_target) = self.target.get() {
-            if [current_target, new_target]
+        if let Some(current_target) = self.target.get()
+            && [current_target, new_target]
                 .contains(&WebGLRenderingContextConstants::ELEMENT_ARRAY_BUFFER)
             {
                 return target_is_copy_buffer(new_target) || new_target == current_target;
             }
-        }
         true
     }
 

--- a/components/script/dom/webgl/webglframebuffer.rs
+++ b/components/script/dom/webgl/webglframebuffer.rs
@@ -336,11 +336,10 @@ impl WebGLFramebuffer {
             }
         }
 
-        if let Some(format) = format {
-            if constraints.all(|c| *c != format) {
+        if let Some(format) = format
+            && constraints.all(|c| *c != format) {
                 return Err(constants::FRAMEBUFFER_INCOMPLETE_ATTACHMENT);
             }
-        }
 
         Ok(())
     }
@@ -571,20 +570,18 @@ impl WebGLFramebuffer {
             ];
             let mut clear_bits = 0;
             for &(attachment, bits) in &attachments {
-                if let Some(ref att) = *attachment.borrow() {
-                    if att.needs_initialization() {
+                if let Some(ref att) = *attachment.borrow()
+                    && att.needs_initialization() {
                         att.mark_initialized();
                         clear_bits |= bits;
                     }
-                }
             }
             for attachment in self.colors.iter() {
-                if let Some(ref att) = *attachment.borrow() {
-                    if att.needs_initialization() {
+                if let Some(ref att) = *attachment.borrow()
+                    && att.needs_initialization() {
                         att.mark_initialized();
                         clear_bits |= constants::COLOR_BUFFER_BIT;
                     }
-                }
             }
 
             if let Some(context) = self.upcast().context() {

--- a/components/script/dom/webgl/webglquery.rs
+++ b/components/script/dom/webgl/webglquery.rs
@@ -60,11 +60,10 @@ impl WebGLQuery {
         if self.marked_for_deletion.get() {
             return Err(InvalidOperation);
         }
-        if let Some(current_target) = self.gl_target.get() {
-            if current_target != target {
+        if let Some(current_target) = self.gl_target.get()
+            && current_target != target {
                 return Err(InvalidOperation);
             }
-        }
         match target {
             constants::ANY_SAMPLES_PASSED |
             constants::ANY_SAMPLES_PASSED_CONSERVATIVE |
@@ -85,11 +84,10 @@ impl WebGLQuery {
         if self.marked_for_deletion.get() {
             return Err(InvalidOperation);
         }
-        if let Some(current_target) = self.gl_target.get() {
-            if current_target != target {
+        if let Some(current_target) = self.gl_target.get()
+            && current_target != target {
                 return Err(InvalidOperation);
             }
-        }
         match target {
             constants::ANY_SAMPLES_PASSED |
             constants::ANY_SAMPLES_PASSED_CONSERVATIVE |

--- a/components/script/dom/webgl/webgltexture.rs
+++ b/components/script/dom/webgl/webgltexture.rs
@@ -272,11 +272,10 @@ impl WebGLTexture {
     pub(crate) fn is_invalid(&self) -> bool {
         // https://immersive-web.github.io/layers/#xrwebglsubimagetype
         #[cfg(feature = "webxr")]
-        if let WebGLTextureOwner::WebXR(ref session) = self.owner {
-            if session.is_outside_raf() {
+        if let WebGLTextureOwner::WebXR(ref session) = self.owner
+            && session.is_outside_raf() {
                 return true;
             }
-        }
         self.is_deleted.get()
     }
 

--- a/components/script/dom/webgpu/gpubuffer.rs
+++ b/components/script/dom/webgpu/gpubuffer.rs
@@ -312,7 +312,7 @@ impl GPUBufferMethods<crate::DomTypeHolder> for GPUBuffer {
         let mut mapping = self.mapping.borrow_mut();
         let mapping = mapping.as_mut().ok_or(Error::Operation(None))?;
 
-        let valid = offset % wgpu_types::MAP_ALIGNMENT == 0 &&
+        let valid = offset.is_multiple_of(wgpu_types::MAP_ALIGNMENT) &&
             range_size % wgpu_types::COPY_BUFFER_ALIGNMENT == 0 &&
             offset >= mapping.range.start &&
             offset + range_size <= mapping.range.end;

--- a/components/script/dom/webgpu/gpuqueue.rs
+++ b/components/script/dom/webgpu/gpuqueue.rs
@@ -129,7 +129,7 @@ impl GPUQueueMethods<crate::DomTypeHolder> for GPUQueue {
 
         // Step 4
         let valid = data_offset + content_size <= data_size as u64 &&
-            content_size * sizeof_element as u64 % wgpu_types::COPY_BUFFER_ALIGNMENT == 0;
+            (content_size * sizeof_element as u64).is_multiple_of(wgpu_types::COPY_BUFFER_ALIGNMENT);
         if !valid {
             return Err(Error::Operation(None));
         }

--- a/components/script/dom/webrtc/rtcpeerconnection.rs
+++ b/components/script/dom/webrtc/rtcpeerconnection.rs
@@ -189,8 +189,8 @@ impl RTCPeerConnection {
         );
         let signaller = this.make_signaller();
         *this.controller.borrow_mut() = Some(ServoMedia::get().create_webrtc(signaller));
-        if let Some(ref servers) = config.iceServers {
-            if let Some(server) = servers.first() {
+        if let Some(ref servers) = config.iceServers
+            && let Some(server) = servers.first() {
                 let server = match server.urls {
                     StringOrStringSequence::String(ref s) => Some(s.clone()),
                     StringOrStringSequence::StringSequence(ref s) => s.first().cloned(),
@@ -208,7 +208,6 @@ impl RTCPeerConnection {
                         .configure(server.to_string(), policy);
                 }
             }
-        }
         this
     }
 

--- a/components/script/dom/websocket.rs
+++ b/components/script/dom/websocket.rs
@@ -451,12 +451,11 @@ impl WebSocketMethods<crate::DomTypeHolder> for WebSocket {
                 return Err(Error::InvalidAccess(None));
             }
         }
-        if let Some(ref reason) = reason {
-            if reason.0.len() > 123 {
+        if let Some(ref reason) = reason
+            && reason.0.len() > 123 {
                 // reason cannot be larger than 123 bytes
                 return Err(Error::Syntax(Some("Reason too long".to_string())));
             }
-        }
 
         match self.ready_state.get() {
             WebSocketRequestState::Closing | WebSocketRequestState::Closed => {}, // Do nothing

--- a/components/script/dom/webxr/xrsession.rs
+++ b/components/script/dom/webxr/xrsession.rs
@@ -672,11 +672,10 @@ impl XRSessionMethods<crate::DomTypeHolder> for XRSession {
             return Err(Error::InvalidState(None));
         }
         // Step 3:
-        if let Some(Some(ref layer)) = init.baseLayer {
-            if Dom::from_ref(layer.session()) != Dom::from_ref(self) {
+        if let Some(Some(ref layer)) = init.baseLayer
+            && Dom::from_ref(layer.session()) != Dom::from_ref(self) {
                 return Err(Error::InvalidState(None));
             }
-        }
 
         // Step 4:
         if init.inlineVerticalFieldOfView.is_some() && self.is_immersive() {

--- a/components/script/dom/webxr/xrsystem.rs
+++ b/components/script/dom/webxr/xrsystem.rs
@@ -88,14 +88,13 @@ impl XRSystem {
     /// <https://immersive-web.github.io/webxr/#ref-for-eventdef-xrsession-end>
     pub(crate) fn end_session(&self, session: &XRSession) {
         // Step 3
-        if let Some(active) = self.active_immersive_session.get() {
-            if Dom::from_ref(&*active) == Dom::from_ref(session) {
+        if let Some(active) = self.active_immersive_session.get()
+            && Dom::from_ref(&*active) == Dom::from_ref(session) {
                 self.active_immersive_session.set(None);
                 // Dirty the canvas, since it has been skipping this step whilst in immersive
                 // mode
                 session.dirty_layers();
             }
-        }
         self.active_inline_sessions
             .borrow_mut()
             .retain(|sess| Dom::from_ref(&**sess) != Dom::from_ref(session));

--- a/components/script/dom/webxr/xrview.rs
+++ b/components/script/dom/webxr/xrview.rs
@@ -128,12 +128,11 @@ impl XRViewMethods<crate::DomTypeHolder> for XRView {
 
     /// <https://www.w3.org/TR/webxr/#dom-xrview-requestviewportscale>
     fn RequestViewportScale(&self, scale: Option<Finite<f64>>) {
-        if let Some(scale) = scale {
-            if *scale > 0.0 {
+        if let Some(scale) = scale
+            && *scale > 0.0 {
                 let clamped_scale = scale.clamp(0.0, 1.0);
                 self.requested_viewport_scale.set(clamped_scale);
             }
-        }
     }
 
     /// <https://www.w3.org/TR/webxr-ar-module-1/#dom-xrview-isfirstpersonobserver>

--- a/components/script/dom/window.rs
+++ b/components/script/dom/window.rs
@@ -2428,11 +2428,10 @@ impl Window {
         // nullify the window_proxy.
         if let Some(proxy) = self.window_proxy.get() {
             let pipeline_id = self.pipeline_id();
-            if let Some(currently_active) = proxy.currently_active() {
-                if currently_active == pipeline_id {
+            if let Some(currently_active) = proxy.currently_active()
+                && currently_active == pipeline_id {
                     self.window_proxy.set(None);
                 }
-            }
         }
 
         if let Some(performance) = self.performance.get() {
@@ -3160,11 +3159,10 @@ impl Window {
         // Step 4 and 5
         let pipeline_id = self.pipeline_id();
         let window_proxy = self.window_proxy();
-        if let Some(active) = window_proxy.currently_active() {
-            if pipeline_id == active && doc.is_prompting_or_unloading() {
+        if let Some(active) = window_proxy.currently_active()
+            && pipeline_id == active && doc.is_prompting_or_unloading() {
                 return;
             }
-        }
 
         // Step 23. Let unloadPromptCanceled be the result of checking if unloading
         // is canceled for navigable's active document's inclusive descendant navigables.
@@ -3775,11 +3773,10 @@ impl Window {
             let document = this.Document();
 
             // Step 7.1.
-            if let Some(ref target_origin) = target_origin {
-                if !target_origin.same_origin(document.origin()) {
+            if let Some(ref target_origin) = target_origin
+                && !target_origin.same_origin(document.origin()) {
                     return;
                 }
-            }
 
             // Steps 7.2.-7.5.
             let cx = this.get_cx();

--- a/components/script/dom/windowproxy.rs
+++ b/components/script/dom/windowproxy.rs
@@ -395,11 +395,10 @@ impl WindowProxy {
     /// <https://html.spec.whatwg.org/multipage/#delaying-load-events-mode>
     pub(crate) fn stop_delaying_load_events_mode(&self) {
         self.delaying_load_events_mode.set(false);
-        if let Some(document) = self.document() {
-            if !document.loader().events_inhibited() {
+        if let Some(document) = self.document()
+            && !document.loader().events_inhibited() {
                 ScriptThread::mark_document_with_no_blocked_loads(&document);
             }
-        }
     }
 
     // https://html.spec.whatwg.org/multipage/#disowned-its-opener
@@ -754,13 +753,12 @@ impl WindowProxy {
     }
 
     pub(crate) fn set_currently_active(&self, window: &Window, can_gc: CanGc) {
-        if let Some(pipeline_id) = self.currently_active() {
-            if pipeline_id == window.pipeline_id() {
+        if let Some(pipeline_id) = self.currently_active()
+            && pipeline_id == window.pipeline_id() {
                 return debug!(
                     "Attempt to set the currently active window to the currently active window."
                 );
             }
-        }
 
         let global_scope = window.as_global_scope();
         self.set_window(global_scope, WindowProxyHandler::proxy_handler(), can_gc);

--- a/components/script/dom/worklet.rs
+++ b/components/script/dom/worklet.rs
@@ -582,13 +582,12 @@ impl WorkletThread {
                     self.process_control(control, cx);
                 }
                 self.gc(cx);
-            } else if self.control_buffer.is_none() {
-                if let Ok(control) = self.control_receiver.try_recv() {
+            } else if self.control_buffer.is_none()
+                && let Ok(control) = self.control_receiver.try_recv() {
                     self.control_buffer = Some(control);
                     let msg = WorkletData::StartSwapRoles(self.role.sender.clone());
                     let _ = self.cold_backup_sender.send(msg);
                 }
-            }
             // If we are tight on memory, and we're a backup then perform a gc.
             // If we are tight on memory, and we're the primary then try to become the hot backup.
             // Hopefully this happens soon!

--- a/components/script/dom/xmlhttprequest.rs
+++ b/components/script/dom/xmlhttprequest.rs
@@ -328,11 +328,10 @@ impl XMLHttpRequestMethods<crate::DomTypeHolder> for XMLHttpRequest {
         password: Option<USVString>,
     ) -> ErrorResult {
         // Step 1
-        if let Some(window) = DomRoot::downcast::<Window>(self.global()) {
-            if !window.Document().is_fully_active() {
+        if let Some(window) = DomRoot::downcast::<Window>(self.global())
+            && !window.Document().is_fully_active() {
                 return Err(Error::InvalidState(None));
             }
-        }
 
         // Step 5
         // FIXME(seanmonstar): use a Trie instead?
@@ -719,8 +718,8 @@ impl XMLHttpRequestMethods<crate::DomTypeHolder> for XMLHttpRequest {
 
             if !content_type_set {
                 let ct = request.headers.typed_get::<ContentType>();
-                if let Some(ct) = ct {
-                    if let Some(encoding) = encoding {
+                if let Some(ct) = ct
+                    && let Some(encoding) = encoding {
                         let mime: Mime = ct.to_string().parse().unwrap();
                         for param in mime.parameters.iter() {
                             if param.0 == CHARSET && !param.1.eq_ignore_ascii_case(encoding) {
@@ -750,7 +749,6 @@ impl XMLHttpRequestMethods<crate::DomTypeHolder> for XMLHttpRequest {
                             }
                         }
                     }
-                }
             }
         }
 

--- a/components/script/fetch.rs
+++ b/components/script/fetch.rs
@@ -184,22 +184,20 @@ fn abort_fetch_call(
     // Step 1. Reject promise with error.
     promise.reject(cx, abort_reason, can_gc);
     // Step 2. If request’s body is non-null and is readable, then cancel request’s body with error.
-    if let Some(body) = request.body() {
-        if body.is_readable() {
+    if let Some(body) = request.body()
+        && body.is_readable() {
             body.cancel(cx, global, abort_reason, can_gc);
         }
-    }
     // Step 3. If responseObject is null, then return.
     // Step 4. Let response be responseObject’s response.
     let Some(response) = response_object else {
         return;
     };
     // Step 5. If response’s body is non-null and is readable, then error response’s body with error.
-    if let Some(body) = response.body() {
-        if body.is_readable() {
+    if let Some(body) = response.body()
+        && body.is_readable() {
             body.error(abort_reason, can_gc);
         }
-    }
 }
 
 /// <https://fetch.spec.whatwg.org/#dom-global-fetch>
@@ -396,11 +394,10 @@ pub(crate) fn FetchLater(
         return Err(Error::Type("URL is not trustworthy".to_owned()));
     }
     // Step 10. If request’s body is not null, and request’s body length is null or zero, then throw a TypeError.
-    if let Some(body) = request.body.as_ref() {
-        if body.len().is_none_or(|len| len == 0) {
+    if let Some(body) = request.body.as_ref()
+        && body.len().is_none_or(|len| len == 0) {
             return Err(Error::Type("Body is empty".to_owned()));
         }
-    }
     // Step 11. If the available deferred-fetch quota given request’s client and request’s URL’s
     // origin is less than request’s total request length, then throw a "QuotaExceededError" DOMException.
     let quota = document.available_deferred_fetch_quota(request.url().origin());

--- a/components/script/indexeddb.rs
+++ b/components/script/indexeddb.rs
@@ -400,41 +400,38 @@ pub(crate) fn evaluate_key_path_on_value(
                 }
 
                 // If value is a Blob and identifier is "size"
-                if identifier == "size" {
-                    if let Ok(blob) = root_from_handlevalue::<Blob>(current_value.handle(), cx) {
+                if identifier == "size"
+                    && let Ok(blob) = root_from_handlevalue::<Blob>(current_value.handle(), cx) {
                         // Let value be a Number equal to value’s size.
                         blob.Size()
                             .safe_to_jsval(cx, current_value.handle_mut(), CanGc::note());
 
                         continue;
                     }
-                }
 
                 // If value is a Blob and identifier is "type"
-                if identifier == "type" {
-                    if let Ok(blob) = root_from_handlevalue::<Blob>(current_value.handle(), cx) {
+                if identifier == "type"
+                    && let Ok(blob) = root_from_handlevalue::<Blob>(current_value.handle(), cx) {
                         // Let value be a String equal to value’s type.
                         blob.Type()
                             .safe_to_jsval(cx, current_value.handle_mut(), CanGc::note());
 
                         continue;
                     }
-                }
 
                 // If value is a File and identifier is "name"
-                if identifier == "name" {
-                    if let Ok(file) = root_from_handlevalue::<File>(current_value.handle(), cx) {
+                if identifier == "name"
+                    && let Ok(file) = root_from_handlevalue::<File>(current_value.handle(), cx) {
                         // Let value be a String equal to value’s name.
                         file.name()
                             .safe_to_jsval(cx, current_value.handle_mut(), CanGc::note());
 
                         continue;
                     }
-                }
 
                 // If value is a File and identifier is "lastModified"
-                if identifier == "lastModified" {
-                    if let Ok(file) = root_from_handlevalue::<File>(current_value.handle(), cx) {
+                if identifier == "lastModified"
+                    && let Ok(file) = root_from_handlevalue::<File>(current_value.handle(), cx) {
                         // Let value be a Number equal to value’s lastModified.
                         file.LastModified().safe_to_jsval(
                             cx,
@@ -444,11 +441,10 @@ pub(crate) fn evaluate_key_path_on_value(
 
                         continue;
                     }
-                }
 
                 // If value is a File and identifier is "lastModifiedDate"
-                if identifier == "lastModifiedDate" {
-                    if let Ok(file) = root_from_handlevalue::<File>(current_value.handle(), cx) {
+                if identifier == "lastModifiedDate"
+                    && let Ok(file) = root_from_handlevalue::<File>(current_value.handle(), cx) {
                         // Let value be a new Date object with [[DateValue]] internal slot equal to value’s lastModified.
                         let time = ClippedTime {
                             t: file.LastModified() as f64,
@@ -463,7 +459,6 @@ pub(crate) fn evaluate_key_path_on_value(
 
                         continue;
                     }
-                }
 
                 // Otherwise
                 unsafe {

--- a/components/script/layout_dom/element.rs
+++ b/components/script/layout_dom/element.rs
@@ -976,11 +976,10 @@ impl<'dom> ::selectors::Element for ServoLayoutElement<'dom> {
 
         // Handle flags that apply to the parent.
         let parent_flags = flags.for_parent();
-        if !parent_flags.is_empty() {
-            if let Some(p) = self.as_node().parent_element() {
+        if !parent_flags.is_empty()
+            && let Some(p) = self.as_node().parent_element() {
                 p.element.insert_selector_flags(flags);
             }
-        }
     }
 
     fn add_element_unique_hashes(&self, filter: &mut BloomFilter) -> bool {
@@ -1283,11 +1282,10 @@ impl ::selectors::Element for ServoThreadSafeLayoutElement<'_> {
 
         // Handle flags that apply to the parent.
         let parent_flags = flags.for_parent();
-        if !parent_flags.is_empty() {
-            if let Some(p) = self.element.parent_element() {
+        if !parent_flags.is_empty()
+            && let Some(p) = self.element.parent_element() {
                 p.element.insert_selector_flags(flags);
             }
-        }
     }
 
     fn add_element_unique_hashes(&self, filter: &mut BloomFilter) -> bool {

--- a/components/script/script_thread.rs
+++ b/components/script/script_thread.rs
@@ -1664,8 +1664,8 @@ impl ScriptThread {
         };
         let task_duration = start.elapsed();
         for (doc_id, doc) in self.documents.borrow().iter() {
-            if let Some(pipeline_id) = pipeline_id {
-                if pipeline_id == doc_id && task_duration.as_nanos() > MAX_TASK_NS {
+            if let Some(pipeline_id) = pipeline_id
+                && pipeline_id == doc_id && task_duration.as_nanos() > MAX_TASK_NS {
                     if self.print_pwm {
                         println!(
                             "Task took longer than max allowed ({:?}) {:?}",
@@ -1675,7 +1675,6 @@ impl ScriptThread {
                     }
                     doc.start_tti();
                 }
-            }
             doc.record_tti_if_necessary();
         }
         value
@@ -3836,8 +3835,8 @@ impl ScriptThread {
             return;
         };
 
-        if let Some(global) = self.documents.borrow().find_global(pipeline_id) {
-            if global.live_devtools_updates() {
+        if let Some(global) = self.documents.borrow().find_global(pipeline_id)
+            && global.live_devtools_updates() {
                 let css_error = CSSError {
                     filename,
                     line,
@@ -3847,7 +3846,6 @@ impl ScriptThread {
                 let message = ScriptToDevtoolsControlMsg::ReportCSSError(pipeline_id, css_error);
                 sender.send(message).unwrap();
             }
-        }
     }
 
     fn handle_reload(&self, pipeline_id: PipelineId, can_gc: CanGc) {

--- a/components/script/serviceworker_manager.rs
+++ b/components/script/serviceworker_manager.rs
@@ -276,16 +276,13 @@ impl ServiceWorkerManager {
     }
 
     fn handle_message_from_resource(&mut self, mediator: CustomResponseMediator) -> bool {
-        if serviceworker_enabled() {
-            if let Some(scope) = self.get_matching_scope(&mediator.load_url) {
-                if let Some(registration) = self.registrations.get(&scope) {
-                    if let Some(ref worker) = registration.active_worker {
+        if serviceworker_enabled()
+            && let Some(scope) = self.get_matching_scope(&mediator.load_url)
+                && let Some(registration) = self.registrations.get(&scope)
+                    && let Some(ref worker) = registration.active_worker {
                         worker.send_message(ServiceWorkerScriptMsg::Response(mediator));
                         return true;
                     }
-                }
-            }
-        }
         let _ = mediator.response_chan.send(None);
         true
     }
@@ -303,11 +300,10 @@ impl ServiceWorkerManager {
                 // TODO: https://w3c.github.io/ServiceWorker/#terminate-service-worker
             },
             ServiceWorkerMsg::ForwardDOMMessage(msg, scope_url) => {
-                if let Some(registration) = self.registrations.get_mut(&scope_url) {
-                    if let Some(ref worker) = registration.active_worker {
+                if let Some(registration) = self.registrations.get_mut(&scope_url)
+                    && let Some(ref worker) = registration.active_worker {
                         worker.forward_dom_message(msg);
                     }
-                }
             },
             ServiceWorkerMsg::ScheduleJob(job) => match job.job_type {
                 JobType::Register => {
@@ -396,14 +392,13 @@ impl ServiceWorkerManager {
             let newest_worker = registration.get_newest_worker();
 
             // Step 4.
-            if let Some(worker) = newest_worker {
-                if worker.script_url != job.script_url {
+            if let Some(worker) = newest_worker
+                && worker.script_url != job.script_url {
                     let _ = job
                         .client
                         .send(JobResult::RejectPromise(JobError::TypeError));
                     return;
                 }
-            }
 
             let scope_things = job
                 .scope_things

--- a/components/script/stylesheet_loader.rs
+++ b/components/script/stylesheet_loader.rs
@@ -101,8 +101,8 @@ impl StylesheetContext {
         };
 
         let mut style_content = std::mem::take(&mut self.data);
-        if let Some((input, mut output)) = create_temp_files() {
-            if execute_js_beautify(
+        if let Some((input, mut output)) = create_temp_files()
+            && execute_js_beautify(
                 input.path(),
                 output.try_clone().unwrap(),
                 BeautifyFileType::Css,
@@ -110,7 +110,6 @@ impl StylesheetContext {
                 output.seek(std::io::SeekFrom::Start(0)).unwrap();
                 output.read_to_end(&mut style_content).unwrap();
             }
-        }
         match create_output_file(unminified_dir, &file_url, None) {
             Ok(mut file) => {
                 file.write_all(&style_content).unwrap();

--- a/components/script/task_queue.rs
+++ b/components/script/task_queue.rs
@@ -152,12 +152,11 @@ impl<T: QueuedTaskConversion> TaskQueue<T> {
                 self.msg_queue.borrow_mut().push_back(msg);
                 continue;
             }
-            if let Some(pipeline_id) = msg.pipeline_id() {
-                if !fully_active.contains(&pipeline_id) {
+            if let Some(pipeline_id) = msg.pipeline_id()
+                && !fully_active.contains(&pipeline_id) {
                     self.store_task_for_inactive_pipeline(msg, &pipeline_id);
                     continue;
                 }
-            }
             // Immediately send non-throttled tasks for processing.
             self.msg_queue.borrow_mut().push_back(msg);
         }
@@ -243,8 +242,8 @@ impl<T: QueuedTaskConversion> TaskQueue<T> {
                     let msg = T::from_queued_task(queued_task);
 
                     // Hold back tasks for currently inactive documents.
-                    if let Some(pipeline_id) = msg.pipeline_id() {
-                        if !fully_active.contains(&pipeline_id) {
+                    if let Some(pipeline_id) = msg.pipeline_id()
+                        && !fully_active.contains(&pipeline_id) {
                             self.store_task_for_inactive_pipeline(msg, &pipeline_id);
                             // Reduce the length of throttles,
                             // but don't add the task to "msg_queue",
@@ -252,7 +251,6 @@ impl<T: QueuedTaskConversion> TaskQueue<T> {
                             throttled_length -= 1;
                             continue;
                         }
-                    }
 
                     // Make the task available for the event-loop to handle as a message.
                     self.msg_queue.borrow_mut().push_back(msg);

--- a/components/script/webdriver_handlers.rs
+++ b/components/script/webdriver_handlers.rs
@@ -197,11 +197,10 @@ fn get_known_shadow_root(
 
     // Step 3. If node is not null and node does not implement ShadowRoot
     // return error with error code no such shadow root.
-    if let Some(ref node) = node {
-        if !node.is::<ShadowRoot>() {
+    if let Some(ref node) = node
+        && !node.is::<ShadowRoot>() {
             return Err(ErrorStatus::NoSuchShadowRoot);
         }
-    }
 
     // Step 4.1. If node is null return error with error code detached shadow root.
     let Some(node) = node else {
@@ -251,11 +250,10 @@ fn get_known_element(
 
     // Step 3. If node is not null and node does not implement Element
     // return error with error code no such element.
-    if let Some(ref node) = node {
-        if !node.is::<Element>() {
+    if let Some(ref node) = node
+        && !node.is::<Element>() {
             return Err(ErrorStatus::NoSuchElement);
         }
-    }
     // Step 4.1. If node is null return error with error code stale element reference.
     let Some(node) = node else {
         return Err(ErrorStatus::StaleElementReference);
@@ -1810,11 +1808,10 @@ fn clear_a_resettable_element(element: &Element, can_gc: CanGc) -> Result<(), Er
             if input_element.Value().is_empty() {
                 return Ok(());
             }
-        } else if let Some(textarea_element) = element.downcast::<HTMLTextAreaElement>() {
-            if textarea_element.Value().is_empty() {
+        } else if let Some(textarea_element) = element.downcast::<HTMLTextAreaElement>()
+            && textarea_element.Value().is_empty() {
                 return Ok(());
             }
-        }
     }
 
     // Step 3. Invoke the focusing steps for the element.
@@ -1923,11 +1920,10 @@ pub(crate) fn handle_element_click(
             get_known_element(documents, pipeline, element_id).and_then(|element| {
                 // Step 4. If the element is an input element in the file upload state
                 // return error with error code invalid argument.
-                if let Some(input_element) = element.downcast::<HTMLInputElement>() {
-                    if input_element.input_type() == InputType::File {
+                if let Some(input_element) = element.downcast::<HTMLInputElement>()
+                    && input_element.input_type() == InputType::File {
                         return Err(ErrorStatus::InvalidArgument);
                     }
-                }
 
                 let Some(container) = get_container(&element) else {
                     return Err(ErrorStatus::UnknownError);

--- a/components/servo/webview_delegate.rs
+++ b/components/servo/webview_delegate.rs
@@ -256,14 +256,13 @@ impl InterceptedWebResourceLoad {
 
 impl Drop for InterceptedWebResourceLoad {
     fn drop(&mut self) {
-        if !self.finished {
-            if let Err(error) = self
+        if !self.finished
+            && let Err(error) = self
                 .response_sender
                 .send(WebResourceResponseMsg::FinishLoad)
             {
                 self.error_sender.raise_response_send_error(error);
             }
-        }
     }
 }
 

--- a/components/shared/base/rope.rs
+++ b/components/shared/base/rope.rs
@@ -512,14 +512,13 @@ impl<T> Iterator for RopeMovementIterator<'_, T> {
         assert!(self.slice.start.line < self.slice.rope.lines.len());
         let line = self.slice.rope.line_for_index(self.slice.start);
 
-        if self.slice.start.code_point < line.len() + 1 {
-            if let Some((end_offset, value)) =
+        if self.slice.start.code_point < line.len() + 1
+            && let Some((end_offset, value)) =
                 (self.end_of_forward_motion)(&self.slice, &line[self.slice.start.code_point..])
             {
                 self.slice.start.code_point += end_offset;
                 return Some((self.slice.start, value));
             }
-        }
 
         // Advance the line as we are at the end of the line.
         self.slice.start = self.slice.rope.start_of_following_line(self.slice.start);
@@ -535,14 +534,13 @@ impl<T> DoubleEndedIterator for RopeMovementIterator<'_, T> {
         }
 
         let line = self.slice.rope.line_for_index(self.slice.end);
-        if self.slice.end.code_point > 0 {
-            if let Some((new_start_index, value)) =
+        if self.slice.end.code_point > 0
+            && let Some((new_start_index, value)) =
                 (self.start_of_backward_motion)(&self.slice, &line[..self.slice.end.code_point])
             {
                 self.slice.end.code_point = new_start_index;
                 return Some((self.slice.end, value));
             }
-        }
 
         // Decrease the line index as we are at the start of the line.
         self.slice.end = self.slice.rope.end_of_preceding_line(self.slice.end);

--- a/components/shared/compositing/display_list.rs
+++ b/components/shared/compositing/display_list.rs
@@ -112,8 +112,8 @@ impl StickyNodeInfo {
         // handling the bottom margin case. Note that the "don't have a sticky-top offset"
         // case includes the case where we *had* a sticky-top offset but we reduced it to
         // zero in the above block.
-        if sticky_offset.y <= 0.0 {
-            if let Some(margin) = self.margins.bottom {
+        if sticky_offset.y <= 0.0
+            && let Some(margin) = self.margins.bottom {
                 // If sticky_offset.y is nonzero that means we must have set it
                 // in the sticky-top handling code above, so this item must have
                 // both top and bottom sticky margins. We adjust the item's rect
@@ -131,7 +131,6 @@ impl StickyNodeInfo {
                     sticky_offset.y += bottom_viewport_edge - sticky_rect.max.y;
                 }
             }
-        }
 
         // Same as above, but for the x-axis.
         if let Some(margin) = self.margins.left {
@@ -141,8 +140,8 @@ impl StickyNodeInfo {
             }
         }
 
-        if sticky_offset.x <= 0.0 {
-            if let Some(margin) = self.margins.right {
+        if sticky_offset.x <= 0.0
+            && let Some(margin) = self.margins.right {
                 sticky_rect.min.x += sticky_offset.x;
                 sticky_rect.max.x += sticky_offset.x;
                 let right_viewport_edge = viewport_rect.max.x - margin;
@@ -150,7 +149,6 @@ impl StickyNodeInfo {
                     sticky_offset.x += right_viewport_edge - sticky_rect.max.x;
                 }
             }
-        }
 
         // The total "sticky offset" and the extra amount we computed as a result of
         // scrolling, stored in sticky_offset needs to be clamped to the provided bounds.
@@ -562,11 +560,10 @@ impl ScrollTree {
         offsets: &FxHashMap<ExternalScrollId, LayoutVector2D>,
     ) {
         for node in self.nodes.iter_mut() {
-            if let SpatialTreeNodeInfo::Scroll(ref mut scroll_info) = node.info {
-                if let Some(offset) = offsets.get(&scroll_info.external_id) {
+            if let SpatialTreeNodeInfo::Scroll(ref mut scroll_info) = node.info
+                && let Some(offset) = offsets.get(&scroll_info.external_id) {
                     scroll_info.scroll_to_offset(*offset, ScrollType::Script);
                 }
-            }
         }
 
         self.invalidate_cached_transforms();

--- a/components/shared/compositing/lib.rs
+++ b/components/shared/compositing/lib.rs
@@ -226,11 +226,10 @@ impl CrossProcessPaintApi {
         callback: Option<Box<dyn Fn(PaintMessage) + Send + 'static>>,
     ) -> Self {
         let callback = GenericCallback::new(move |msg| {
-            if let Some(ref handler) = callback {
-                if let Ok(paint_message) = msg {
+            if let Some(ref handler) = callback
+                && let Ok(paint_message) = msg {
                     handler(paint_message);
                 }
-            }
         })
         .unwrap();
         Self(callback)

--- a/components/shared/net/fetch/headers.rs
+++ b/components/shared/net/fetch/headers.rs
@@ -135,11 +135,10 @@ fn collect_http_quoted_string(position: &mut Peekable<Chars>, extract_value: boo
 
     // Step 3, 4
     let should_be_quote = position.next();
-    if let Some(ch) = should_be_quote {
-        if !extract_value {
+    if let Some(ch) = should_be_quote
+        && !extract_value {
             value.push(ch)
         }
-    }
 
     // Step 5: While true:
     loop {

--- a/components/shared/net/mime_classifier.rs
+++ b/components/shared/net/mime_classifier.rs
@@ -465,7 +465,7 @@ impl Mp4Matcher {
             ((data[2] as u32) << 8) |
             (data[3] as u32)) as usize;
         // Step 5. If length is less than box-size or if box-size modulo 4 is not equal to 0, return false.
-        if (data.len() < box_size) || (box_size % 4 != 0) {
+        if (data.len() < box_size) || !box_size.is_multiple_of(4) {
             return false;
         }
 

--- a/components/shared/net/request.rs
+++ b/components/shared/net/request.rs
@@ -1170,8 +1170,8 @@ fn validate_range_header(value: &str) -> bool {
         let start = parts.next();
         let end = parts.next();
 
-        if let Some(start) = start {
-            if let Ok(start_num) = start.parse::<u64>() {
+        if let Some(start) = start
+            && let Ok(start_num) = start.parse::<u64>() {
                 return match end {
                     Some(e) if !e.is_empty() => {
                         e.parse::<u64>().is_ok_and(|end_num| start_num <= end_num)
@@ -1179,7 +1179,6 @@ fn validate_range_header(value: &str) -> bool {
                     _ => true,
                 };
             }
-        }
     }
     false
 }

--- a/components/shared/profile/time.rs
+++ b/components/shared/profile/time.rs
@@ -22,11 +22,10 @@ pub struct ProfilerChan(pub Option<GenericSender<ProfilerMsg>>);
 
 impl ProfilerChan {
     pub fn send(&self, msg: ProfilerMsg) {
-        if let Some(sender) = &self.0 {
-            if let Err(e) = sender.send(msg) {
+        if let Some(sender) = &self.0
+            && let Err(e) = sender.send(msg) {
                 warn!("Error communicating with the time profiler thread: {}", e);
             }
-        }
     }
 }
 

--- a/components/storage/indexeddb/engines/sqlite.rs
+++ b/components/storage/indexeddb/engines/sqlite.rs
@@ -368,11 +368,10 @@ impl KvsEngine for SqliteEngine {
     fn delete_database(self) -> Result<(), Self::Error> {
         // attempt to close the connection first
         let _ = self.connection.close();
-        if self.db_path.exists() {
-            if let Err(e) = std::fs::remove_dir_all(self.db_path.parent().unwrap()) {
+        if self.db_path.exists()
+            && let Err(e) = std::fs::remove_dir_all(self.db_path.parent().unwrap()) {
                 error!("Failed to delete database: {:?}", e);
             }
-        }
         Ok(())
     }
 

--- a/components/storage/indexeddb/mod.rs
+++ b/components/storage/indexeddb/mod.rs
@@ -128,11 +128,10 @@ impl<E: KvsEngine> IndexedDBEnvironment<E> {
 
         // We have a sender if the transaction is started manually, and they
         // probably want to know when it is finished
-        if let Some(sender) = sender {
-            if sender.send(Ok(())).is_err() {
+        if let Some(sender) = sender
+            && sender.send(Ok(())).is_err() {
                 warn!("IDBTransaction starter dropped its channel");
             }
-        }
     }
 
     fn has_key_generator(&self, store_name: &str) -> bool {
@@ -478,12 +477,11 @@ impl IndexedDBManager {
             };
             let mut pruned = false;
             let front_is_pending = queue.front().map(|record| record.is_pending());
-            if let Some(is_pending) = front_is_pending {
-                if !is_pending {
+            if let Some(is_pending) = front_is_pending
+                && !is_pending {
                     queue.pop_front().expect("Queue has a non-pending item.");
                     pruned = true
                 }
-            }
             (queue.is_empty(), pruned)
         };
         if is_empty {
@@ -541,11 +539,10 @@ impl IndexedDBManager {
                 };
                 for open_request in queue.drain(0..) {
                     let old = open_request.abort();
-                    if version_to_revert.is_none() {
-                        if let Some(old) = old {
+                    if version_to_revert.is_none()
+                        && let Some(old) = old {
                             version_to_revert = Some(old);
                         }
-                    }
                 }
             }
             if let Some(version) = version_to_revert {

--- a/components/storage/shared/mod.rs
+++ b/components/storage/shared/mod.rs
@@ -28,11 +28,10 @@ pub const DB_IN_MEMORY_PRAGMAS: [&str; 1] = ["PRAGMA cache_size = 2000;"];
 pub(crate) fn is_sqlite_disk_full_error(error: &RusqliteError) -> bool {
     fn has_enospc(mut source: Option<&(dyn StdError + 'static)>) -> bool {
         while let Some(err) = source {
-            if let Some(io_err) = err.downcast_ref::<std::io::Error>() {
-                if io_err.raw_os_error() == Some(ENOSPC) {
+            if let Some(io_err) = err.downcast_ref::<std::io::Error>()
+                && io_err.raw_os_error() == Some(ENOSPC) {
                     return true;
                 }
-            }
             source = err.source();
         }
         false

--- a/components/url/origin.rs
+++ b/components/url/origin.rs
@@ -112,11 +112,10 @@ impl ImmutableOrigin {
             // * origin’s host is "localhost" or "localhost."
             // * origin’s host ends with ".localhost" or ".localhost."
             // then return "Potentially Trustworthy".
-            if let Host::Domain(domain) = host {
-                if domain == "localhost" || domain.ends_with(".localhost") {
+            if let Host::Domain(domain) = host
+                && (domain == "localhost" || domain.ends_with(".localhost")) {
                     return true;
                 }
-            }
         }
         // 9. Return "Not Trustworthy".
         false

--- a/components/webdriver_server/lib.rs
+++ b/components/webdriver_server/lib.rs
@@ -1861,11 +1861,10 @@ impl Handler {
         if let Some(ref path) = params.path {
             cookie_builder = cookie_builder.path(path.clone());
         }
-        if let Some(ref expiry) = params.expiry {
-            if let Ok(datetime) = OffsetDateTime::from_unix_timestamp(expiry.0 as i64) {
+        if let Some(ref expiry) = params.expiry
+            && let Ok(datetime) = OffsetDateTime::from_unix_timestamp(expiry.0 as i64) {
                 cookie_builder = cookie_builder.expires(datetime);
             }
-        }
         if let Some(ref same_site) = params.sameSite {
             cookie_builder = match same_site.as_str() {
                 "None" => Ok(cookie_builder.same_site(SameSite::None)),

--- a/components/webgl/webgl_thread.rs
+++ b/components/webgl/webgl_thread.rs
@@ -909,12 +909,11 @@ impl WebGLThread {
     ) -> Option<&GLContextData> {
         let data = self.contexts.get(&context_id);
 
-        if let Some(data) = data {
-            if Some(context_id) != self.bound_context_id {
+        if let Some(data) = data
+            && Some(context_id) != self.bound_context_id {
                 data.device.make_context_current(&data.ctx).unwrap();
                 self.bound_context_id = Some(context_id);
             }
-        }
 
         data
     }
@@ -925,12 +924,11 @@ impl WebGLThread {
         context_id: WebGLContextId,
     ) -> Option<&mut GLContextData> {
         let data = self.contexts.get_mut(&context_id);
-        if let Some(ref data) = data {
-            if Some(context_id) != self.bound_context_id {
+        if let Some(ref data) = data
+            && Some(context_id) != self.bound_context_id {
                 data.device.make_context_current(&data.ctx).unwrap();
                 self.bound_context_id = Some(context_id);
             }
-        }
 
         data
     }

--- a/components/webgpu/wgpu_thread.rs
+++ b/components/webgpu/wgpu_thread.rs
@@ -973,8 +973,8 @@ impl WGPU {
                     },
                     WebGPURequest::UnmapBuffer { buffer_id, mapping } => {
                         let global = &self.global;
-                        if let Some(mapping) = mapping {
-                            if let Ok((slice_pointer, range_size)) = global.buffer_get_mapped_range(
+                        if let Some(mapping) = mapping
+                            && let Ok((slice_pointer, range_size)) = global.buffer_get_mapped_range(
                                 buffer_id,
                                 mapping.range.start,
                                 Some(mapping.range.end - mapping.range.start),
@@ -987,7 +987,6 @@ impl WGPU {
                                 }
                                 .copy_from_slice(&mapping.data);
                             }
-                        }
                         // Ignore result because this operation always succeed from user perspective
                         let _result = global.buffer_unmap(buffer_id);
                     },

--- a/ports/servoshell/backtrace.rs
+++ b/ports/servoshell/backtrace.rs
@@ -77,11 +77,10 @@ impl fmt::Debug for Print {
                         result = Err(e)
                     }
                 });
-                if !any_symbol {
-                    if let Err(e) = frame_fmt.print_raw(frame.ip(), None, None, None) {
+                if !any_symbol
+                    && let Err(e) = frame_fmt.print_raw(frame.ip(), None, None, None) {
                         result = Err(e)
                     }
-                }
                 result.is_ok()
             });
             result?;

--- a/ports/servoshell/desktop/app.rs
+++ b/ports/servoshell/desktop/app.rs
@@ -190,11 +190,10 @@ impl ApplicationHandler<AppEvent> for App {
             return;
         };
 
-        if let Some(window) = state.window(ServoShellWindowId::from(u64::from(window_id))) {
-            if let Some(headed_window) = window.platform_window().as_headed_window() {
+        if let Some(window) = state.window(ServoShellWindowId::from(u64::from(window_id)))
+            && let Some(headed_window) = window.platform_window().as_headed_window() {
                 headed_window.handle_winit_window_event(state.clone(), window, window_event);
             }
-        }
 
         if !self.pump_servo_event_loop(event_loop.into()) {
             event_loop.exit();
@@ -211,11 +210,9 @@ impl ApplicationHandler<AppEvent> for App {
         if let Some(window) = app_event
             .window_id()
             .and_then(|window_id| state.window(ServoShellWindowId::from(u64::from(window_id))))
-        {
-            if let Some(headed_window) = window.platform_window().as_headed_window() {
+            && let Some(headed_window) = window.platform_window().as_headed_window() {
                 headed_window.handle_winit_app_event(app_event);
             }
-        }
 
         if !self.pump_servo_event_loop(event_loop.into()) {
             event_loop.exit();

--- a/ports/servoshell/desktop/dialog.rs
+++ b/ports/servoshell/desktop/dialog.rs
@@ -226,11 +226,10 @@ impl Dialog {
                     );
                 });
 
-                if !is_open {
-                    if let Some(alert_dialog) = maybe_alert_dialog.take() {
+                if !is_open
+                    && let Some(alert_dialog) = maybe_alert_dialog.take() {
                         alert_dialog.confirm();
                     }
-                }
                 is_open
             },
             Dialog::Confirm(maybe_confirm_dialog) => {
@@ -684,12 +683,11 @@ impl Dialog {
                         is_open = false;
                     }
 
-                    if let Some(action) = selected_action {
-                        if let Some(context_menu) = menu.take() {
+                    if let Some(action) = selected_action
+                        && let Some(context_menu) = menu.take() {
                             context_menu.select(action);
                             return false;
                         }
-                    }
                 }
                 is_open
             },

--- a/ports/servoshell/desktop/gui.rs
+++ b/ports/servoshell/desktop/gui.rs
@@ -385,8 +385,8 @@ impl Gui {
                                         location_field.request_focus();
                                     }
                                     // Select address bar text when it's focused (click or shortcut).
-                                    if location_field.gained_focus() {
-                                        if let Some(mut state) =
+                                    if location_field.gained_focus()
+                                        && let Some(mut state) =
                                             TextEditState::load(ui.ctx(), location_id)
                                         {
                                             // Select the whole input.
@@ -396,7 +396,6 @@ impl Gui {
                                             )));
                                             state.store(ui.ctx(), location_id);
                                         }
-                                    }
                                     // Navigate to address when enter is pressed in the address bar.
                                     if location_field.lost_focus() &&
                                         ui.input(|i| i.clone().key_pressed(Key::Enter))

--- a/ports/servoshell/desktop/headed_window.rs
+++ b/ports/servoshell/desktop/headed_window.rs
@@ -641,15 +641,14 @@ impl HeadedWindow {
 
         if !consumed {
             // Make sure to handle early resize events even when there are no webviews yet
-            if let WindowEvent::Resized(new_inner_size) = event {
-                if self.inner_size.get() != new_inner_size {
+            if let WindowEvent::Resized(new_inner_size) = event
+                && self.inner_size.get() != new_inner_size {
                     self.inner_size.set(new_inner_size);
                     // This should always be set to inner size
                     // because we are resizing `SurfmanRenderingContext`.
                     // See https://github.com/servo/servo/issues/38369#issuecomment-3138378527
                     self.window_rendering_context.resize(new_inner_size);
                 }
-            }
 
             if let Some(webview) = window.active_webview() {
                 match event {
@@ -757,15 +756,14 @@ impl HeadedWindow {
     }
 
     pub(crate) fn handle_winit_app_event(&self, app_event: AppEvent) {
-        if let AppEvent::Accessibility(ref event) = app_event {
-            if self
+        if let AppEvent::Accessibility(ref event) = app_event
+            && self
                 .gui
                 .borrow_mut()
                 .handle_accesskit_event(&event.window_event)
             {
                 self.winit_window.request_redraw();
             }
-        }
     }
 }
 

--- a/ports/servoshell/running_app_state.rs
+++ b/ports/servoshell/running_app_state.rs
@@ -327,11 +327,10 @@ impl RunningAppState {
                 return true;
             }
 
-            if let Some(focused_window) = self.focused_window() {
-                if Rc::ptr_eq(window, &focused_window) {
+            if let Some(focused_window) = self.focused_window()
+                && Rc::ptr_eq(window, &focused_window) {
                     *self.focused_window.borrow_mut() = None;
                 }
-            }
             false
         });
     }


### PR DESCRIPTION
This also fixes all new clippy warnings via `cargo clippy --fix --all`. The majority
of these changes are due to Rust now allowing the combination of `if let` with other
conditions. I have also used `extract_if` in a few places. There are other callsites
with comments about `extract_if`, but converting them was not straightforward
so I've left those for a followup.

Testing: This should not change behavior so is covered by existing tests.
