### PR TITLE
indexeddb: fix crash in worker abort

### DIFF
--- a/components/storage/indexeddb/mod.rs
+++ b/components/storage/indexeddb/mod.rs
@@ -291,17 +291,10 @@ impl OpenRequest {
                 version: _,
                 pending_upgrade,
             } => {
-                let Some(VersionUpgrade { old, new: _ }) = pending_upgrade else {
-                    debug_assert!(
-                        false,
-                        "A pending open request should have a pending upgrade."
-                    );
-                    return None;
-                };
                 if sender.send(Ok(OpenDatabaseResult::AbortError)).is_err() {
                     error!("Failed to send OpenDatabaseResult::Connection to script.");
                 };
-                Some(*old)
+                pending_upgrade.as_ref().map(|upgrade| upgrade.old)
             },
             OpenRequest::Delete {
                 sender,


### PR DESCRIPTION
When an open request is aborted, it does not always already have a pending upgrade, so we should not make the assertion.

Testing: /IndexedDB/worker-termination-aborts-upgrade.window.html
Fixes: https://github.com/servo/servo/issues/41918
