### PR TITLE
layout: Avoid passing `BoxSlot` when we have a `NodeAndStyleInfo`

### DIFF
--- a/components/layout/construct_modern.rs
+++ b/components/layout/construct_modern.rs
@@ -12,7 +12,7 @@ use style::selector_parser::PseudoElement;
 
 use crate::PropagatedBoxTreeData;
 use crate::context::LayoutContext;
-use crate::dom::{BoxSlot, LayoutBox};
+use crate::dom::{BoxSlot, LayoutBox, NodeExt};
 use crate::dom_traversal::{Contents, NodeAndStyleInfo, TraversalHandler};
 use crate::flow::inline::construct::InlineFormattingContextBuilder;
 use crate::flow::{BlockContainer, BlockFormattingContext};
@@ -38,7 +38,6 @@ enum ModernContainerJob<'dom> {
         info: NodeAndStyleInfo<'dom>,
         display: DisplayGeneratingBox,
         contents: Contents,
-        box_slot: BoxSlot<'dom>,
     },
     TextRuns(Vec<ModernContainerTextRun<'dom>>),
 }
@@ -84,7 +83,6 @@ impl<'dom> ModernContainerJob<'dom> {
                 info,
                 display,
                 contents,
-                box_slot,
             } => {
                 let is_abspos = info.style.get_box().position.is_absolutely_positioned();
                 let order = if is_abspos {
@@ -93,6 +91,7 @@ impl<'dom> ModernContainerJob<'dom> {
                     info.style.clone_order()
                 };
 
+                let box_slot = info.node.box_slot();
                 if let Some(layout_box) = box_slot
                     .take_layout_box_if_undamaged(info.damage)
                     .and_then(|layout_box| match &layout_box {
@@ -181,7 +180,6 @@ impl<'dom> TraversalHandler<'dom> for ModernContainerBuilder<'_, 'dom> {
         info: &NodeAndStyleInfo<'dom>,
         display: DisplayGeneratingBox,
         contents: Contents,
-        box_slot: BoxSlot<'dom>,
     ) {
         self.wrap_any_text_in_anonymous_block_container();
 
@@ -189,7 +187,6 @@ impl<'dom> TraversalHandler<'dom> for ModernContainerBuilder<'_, 'dom> {
             info: info.clone(),
             display,
             contents,
-            box_slot,
         })
     }
 }

--- a/components/layout/dom_traversal.rs
+++ b/components/layout/dom_traversal.rs
@@ -20,7 +20,7 @@ use style::values::generics::counters::{Content, ContentItem};
 use style::values::specified::Quotes;
 
 use crate::context::LayoutContext;
-use crate::dom::{BoxSlot, LayoutBox, NodeExt};
+use crate::dom::{LayoutBox, NodeExt};
 use crate::flow::inline::SharedInlineStyles;
 use crate::quotes::quotes_for_lang;
 use crate::replaced::ReplacedContents;
@@ -109,7 +109,6 @@ pub(super) trait TraversalHandler<'dom> {
         info: &NodeAndStyleInfo<'dom>,
         display: DisplayGeneratingBox,
         contents: Contents,
-        box_slot: BoxSlot<'dom>,
     );
 
     /// Notify the handler that we are about to recurse into a `display: contents` element.
@@ -185,8 +184,7 @@ fn traverse_element<'dom>(
         Display::GeneratingBox(display) => {
             let contents = Contents::for_element(element, context);
             let display = display.used_value_for_contents(&contents);
-            let box_slot = element.box_slot();
-            handler.handle_element(&info, display, contents, box_slot);
+            handler.handle_element(&info, display, contents);
         },
     }
 }
@@ -223,9 +221,8 @@ fn traverse_eager_pseudo_element<'dom>(
         },
         Display::GeneratingBox(display) => {
             let items = generate_pseudo_element_content(&pseudo_element_info, context);
-            let box_slot = pseudo_element_info.node.box_slot();
             let contents = Contents::for_pseudo_element(items);
-            handler.handle_element(&pseudo_element_info, display, contents, box_slot);
+            handler.handle_element(&pseudo_element_info, display, contents);
         },
     }
 }
@@ -256,12 +253,7 @@ fn traverse_pseudo_element_contents<'dom>(
                     Display::from(anonymous_info.style.get_box().display) ==
                         Display::GeneratingBox(display_inline)
                 );
-                handler.handle_element(
-                    anonymous_info,
-                    display_inline,
-                    Contents::Replaced(contents),
-                    anonymous_info.node.box_slot(),
-                )
+                handler.handle_element(anonymous_info, display_inline, Contents::Replaced(contents))
             },
         }
     }


### PR DESCRIPTION
In a bunch of places we were passing `BoxSlot` as a function parameter or struct field, even though we had a `NodeAndStyleInfo`, from which we can get the `BoxSlot`.

Testing: Not needed, no behavior change