### PR TITLE
layout: Handle selection during display list construction

### DIFF
--- a/components/layout/dom_traversal.rs
+++ b/components/layout/dom_traversal.rs
@@ -4,7 +4,6 @@
 
 use std::borrow::Cow;
 
-use fonts::TextByteRange;
 use html5ever::LocalName;
 use layout_api::wrapper_traits::{
     PseudoElementChain, ThreadSafeLayoutElement, ThreadSafeLayoutNode,
@@ -64,10 +63,6 @@ impl<'dom> NodeAndStyleInfo<'dom> {
             style,
             damage: self.damage,
         })
-    }
-
-    pub(crate) fn get_selection_range(&self) -> Option<TextByteRange> {
-        self.node.selection()
     }
 }
 

--- a/components/script/layout_dom/node.rs
+++ b/components/script/layout_dom/node.rs
@@ -9,10 +9,9 @@ use std::fmt;
 use std::iter::FusedIterator;
 
 use base::id::{BrowsingContextId, PipelineId};
-use fonts::TextByteRange;
-use fonts_traits::ByteIndex;
 use layout_api::wrapper_traits::{
-    LayoutDataTrait, LayoutNode, PseudoElementChain, ThreadSafeLayoutElement, ThreadSafeLayoutNode,
+    LayoutDataTrait, LayoutNode, PseudoElementChain, SharedSelection, ThreadSafeLayoutElement,
+    ThreadSafeLayoutNode,
 };
 use layout_api::{
     GenericLayoutData, HTMLCanvasData, HTMLMediaData, LayoutElementType, LayoutNodeType,
@@ -380,11 +379,9 @@ impl<'dom> ThreadSafeLayoutNode<'dom> for ServoThreadSafeLayoutNode<'dom> {
         unsafe { self.get_jsmanaged().text_content() }
     }
 
-    fn selection(&self) -> Option<TextByteRange> {
+    fn selection(&self) -> Option<SharedSelection> {
         let this = unsafe { self.get_jsmanaged() };
-
         this.selection()
-            .map(|range| TextByteRange::new(ByteIndex(range.start), ByteIndex(range.end)))
     }
 
     fn image_url(&self) -> Option<ServoUrl> {

--- a/components/shared/base/text.rs
+++ b/components/shared/base/text.rs
@@ -3,7 +3,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 use std::iter::Sum;
-use std::ops::{Add, AddAssign, Range, Sub, SubAssign};
+use std::ops::{Add, AddAssign, Sub, SubAssign};
 
 use malloc_size_of_derive::MallocSizeOf;
 
@@ -65,10 +65,6 @@ macro_rules! unicode_length_type {
 
             pub fn one() -> Self {
                 Self(1)
-            }
-
-            pub fn unwrap_range(byte_range: Range<Self>) -> Range<usize> {
-                byte_range.start.0..byte_range.end.0
             }
 
             pub fn saturating_sub(self, value: Self) -> Self {

--- a/components/shared/fonts/lib.rs
+++ b/components/shared/fonts/lib.rs
@@ -50,7 +50,7 @@ impl ByteIndex {
 
 /// A range of UTF-8 bytes in a text run. This is used to identify glyphs in a `GlyphRun`
 /// by their original character byte offsets in the text.
-#[derive(Clone, Debug, Default, Deserialize, MallocSizeOf, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, MallocSizeOf, PartialEq, Serialize)]
 pub struct TextByteRange(Range<ByteIndex>);
 
 impl TextByteRange {

--- a/tests/wpt/meta/css/css-overflow/text-overflow-ellipsis-editing-input.html.ini
+++ b/tests/wpt/meta/css/css-overflow/text-overflow-ellipsis-editing-input.html.ini
@@ -1,0 +1,2 @@
+[text-overflow-ellipsis-editing-input.html]
+  expected: FAIL


### PR DESCRIPTION
Instead of handling selection in text input during box tree / fragment
tree construction, fully handle it during display list construction.
This means that when the selection changes in script, it updates
automatically in the `FragmentTree` and only a new display list is
necessary. This avoids a layout while changing the selection in text
fields.

Testing: This fixes a few rendering issues, but these are very hard
to isolate and test for. It causes one test to start failing, but this is
because a cursor that wasn't rendered properly now starts showing
up.
Fixes: #41920.
