### PR TITLE
script: Add error messages for cSHAKE and HKDF

### DIFF
--- a/components/script/dom/subtlecrypto/cshake_operation.rs
+++ b/components/script/dom/subtlecrypto/cshake_operation.rs
@@ -49,7 +49,11 @@ pub(crate) fn digest(
             hasher.update(message);
             hasher.finalize_boxed(length / 8).to_vec()
         },
-        _ => return Err(Error::NotSupported(None)),
+        algorithm_name => {
+            return Err(Error::NotSupported(Some(format!(
+                "{algorithm_name} is not supported"
+            ))));
+        },
     };
 
     // Step 6. Return result.


### PR DESCRIPTION
Add all the missing error messages for `hkdf_operation.rs` and `cshake_operation.rs` (one message only). Tried to follow the style of existing messages and used an existing message for the HKDF-expand operation. Related to #40756.

Testing: No tests added.

