### PR TITLE
script: Use document origin instead of URL when manipulating blobs.

### DIFF
--- a/components/net/tests/fetch.rs
+++ b/components/net/tests/fetch.rs
@@ -188,7 +188,7 @@ fn test_fetch_blob() {
         id.clone(),
         blob_buf,
         true,
-        "http://www.example.org".into(),
+        origin.origin(),
     );
     let url = ServoUrl::parse(&format!("blob:{}{}", origin.as_str(), id.simple())).unwrap();
 

--- a/components/net/tests/fetch.rs
+++ b/components/net/tests/fetch.rs
@@ -184,12 +184,10 @@ fn test_fetch_blob() {
     let origin = ServoUrl::parse("http://www.example.org/").unwrap();
 
     let id = Uuid::new_v4();
-    context.filemanager.lock().promote_memory(
-        id.clone(),
-        blob_buf,
-        true,
-        origin.origin(),
-    );
+    context
+        .filemanager
+        .lock()
+        .promote_memory(id.clone(), blob_buf, true, origin.origin());
     let url = ServoUrl::parse(&format!("blob:{}{}", origin.as_str(), id.simple())).unwrap();
 
     let request = RequestBuilder::new(Some(TEST_WEBVIEW_ID), url.clone(), Referrer::NoReferrer)

--- a/components/net/tests/filemanager_thread.rs
+++ b/components/net/tests/filemanager_thread.rs
@@ -42,7 +42,7 @@ fn test_filemanager() {
         .read_to_end(&mut test_file_content)
         .expect("Read components/net/tests/test.jpeg error");
 
-    let origin = ServoUrl::parse("test.com").unwrap().origin();
+    let origin = ServoUrl::parse("http://test.com").unwrap().origin();
 
     {
         // Try to select a dummy file "components/net/tests/test.jpeg"

--- a/components/net/tests/filemanager_thread.rs
+++ b/components/net/tests/filemanager_thread.rs
@@ -19,6 +19,7 @@ use net_traits::filemanager_thread::{
     FileManagerThreadError, FileManagerThreadMsg, ReadFileProgress,
 };
 use servo_config::prefs::Preferences;
+use servo_url::ServoUrl;
 use tokio::task::yield_now;
 
 use crate::create_embedder_proxy_and_receiver;
@@ -41,7 +42,7 @@ fn test_filemanager() {
         .read_to_end(&mut test_file_content)
         .expect("Read components/net/tests/test.jpeg error");
 
-    let origin = "test.com".to_string();
+    let origin = ServoUrl::parse("test.com").unwrap().origin();
 
     {
         // Try to select a dummy file "components/net/tests/test.jpeg"

--- a/components/script/dom/html/htmlinputelement.rs
+++ b/components/script/dom/html/htmlinputelement.rs
@@ -28,7 +28,6 @@ use js::jsapi::{
 use js::jsval::UndefinedValue;
 use js::rust::wrappers::{CheckRegExpSyntax, ExecuteRegExpNoStatics, ObjectIsRegExp};
 use js::rust::{HandleObject, MutableHandleObject};
-use net_traits::blob_url_store::get_blob_origin;
 use script_bindings::codegen::GenericBindings::AttrBinding::AttrMethods;
 use script_bindings::codegen::GenericBindings::CharacterDataBinding::CharacterDataMethods;
 use script_bindings::codegen::GenericBindings::DocumentBinding::DocumentMethods;
@@ -2416,7 +2415,7 @@ impl HTMLInputElement {
             .show_embedder_control(
                 ControlElement::FileInput(DomRoot::from_ref(self)),
                 EmbedderControlRequest::FilePicker(FilePickerRequest {
-                    origin: get_blob_origin(&self.owner_window().get_url()),
+                    origin: self.owner_window().origin().immutable().clone(),
                     current_paths,
                     filter_patterns: filter_from_accept(&self.Accept()),
                     allow_select_multiple: self.Multiple(),

--- a/components/shared/embedder/embedder_controls.rs
+++ b/components/shared/embedder/embedder_controls.rs
@@ -12,6 +12,7 @@ use base::generic_channel::GenericSender;
 use base::id::{PipelineId, WebViewId};
 use bitflags::bitflags;
 use serde::{Deserialize, Serialize};
+use servo_url::ImmutableOrigin;
 use url::Url;
 use uuid::Uuid;
 
@@ -144,7 +145,7 @@ pub struct FilterPattern(pub String);
 
 #[derive(Debug, Deserialize, Serialize)]
 pub struct FilePickerRequest {
-    pub origin: String,
+    pub origin: ImmutableOrigin,
     pub current_paths: Vec<PathBuf>,
     pub filter_patterns: Vec<FilterPattern>,
     pub allow_select_multiple: bool,

--- a/tests/wpt/meta/html/webappapis/dynamic-markup-insertion/opening-the-input-stream/location-set-and-document-open.html.ini
+++ b/tests/wpt/meta/html/webappapis/dynamic-markup-insertion/opening-the-input-stream/location-set-and-document-open.html.ini
@@ -1,3 +1,0 @@
-[location-set-and-document-open.html]
-  [Location sets should cancel current navigation and prevent later document.open() from doing anything]
-    expected: FAIL


### PR DESCRIPTION
Retrieving the origin from the document's URL means the wrong origin can be returned for documents like about:blank or about:srcdoc.

Testing: Newly-passing test involving a srcdoc and blob.