### PR TITLE
layout: Fix interaction of `overflow-clip-margin` and `border-radius`

### DIFF
--- a/tests/wpt/tests/css/css-overflow/overflow-clip-margin-border-radius-002-ref.html
+++ b/tests/wpt/tests/css/css-overflow/overflow-clip-margin-border-radius-002-ref.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Reference: overflow-clip-margin with border-radius</title>
+<link rel="author" title="Oriol Brufau" href="obrufau@igalia.com">
+<style>
+div {
+  display: inline-block;
+  font-size: 10px;
+  background: black;
+  vertical-align: middle;
+}
+</style>
+<div style="width:  2em; height:  2em; margin: 5em; border-radius: 0em"></div>
+<div style="width:  4em; height:  4em; margin: 4em; border-radius: 1em"></div>
+<div style="width:  6em; height:  6em; margin: 3em; border-radius: 2em"></div>
+<div style="width:  8em; height:  8em; margin: 2em; border-radius: 3em"></div>
+<div style="width: 10em; height: 10em; margin: 1em; border-radius: 4em"></div>

--- a/tests/wpt/tests/css/css-overflow/overflow-clip-margin-border-radius-002.html
+++ b/tests/wpt/tests/css/css-overflow/overflow-clip-margin-border-radius-002.html
@@ -1,0 +1,37 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Test: overflow-clip-margin with border-radius</title>
+<link rel="author" title="Oriol Brufau" href="mailto:obrufau@igalia.com">
+<link rel="help" href="https://drafts.csswg.org/css-overflow-4/#overflow-clip-margin">
+<link rel="help" href="https://drafts.csswg.org/css-backgrounds-3/#shadow-shape">
+<link rel="help" href="https://drafts.csswg.org/css-backgrounds-3/#border-radius">
+<link rel="help" href="https://github.com/servo/servo/issues/41907">
+<link rel="match" href="overflow-clip-margin-border-radius-002-ref.html">
+<meta name="fuzzy" content="maxDifference=0-1;totalPixels=0-7">
+<style>
+div {
+  display: inline-block;
+  font-size: 10px;
+  width: 2em;
+  height: 2em;
+  padding: 2em;
+  border: 2em solid transparent;
+  margin: 1em;
+  border-radius: 4em;
+  overflow: clip;
+  vertical-align: middle;
+}
+div::before {
+  content: "";
+  display: block;
+  height: 18em;
+  width: 18em;
+  margin: -8em 0 0 -8em;
+  background: black;
+}
+</style>
+<div style="overflow-clip-margin: content-box 0em"></div>
+<div style="overflow-clip-margin: content-box 1em"></div>
+<div style="overflow-clip-margin: padding-box 0em"></div>
+<div style="overflow-clip-margin: padding-box 1em"></div>
+<div style="overflow-clip-margin:  border-box 0em"></div>


### PR DESCRIPTION
The `border-radius` values refer to the border box. For the purpose of `overflow-clip`, we were just adjusting by the `overflow-clip-margin` offset, without considering that this offset may not refer to the border box (in fact, it defaults to the padding box).

To fix it, we need to subtract the border when the offset refers to the padding box, and subtract the border and padding when it refers to the content box.

This implies that each axis can end up with a different offset, so this modifies `offset_radii()` accordingly. And then, `inner_radii()` is no longer needed.

Testing: Adding new test
Fixes: #41907
