### PR TITLE
script: Include font-variation-settings on `parse_font_face_descriptors`

### DIFF
--- a/components/script/dom/css/fontface.rs
+++ b/components/script/dom/css/fontface.rs
@@ -103,7 +103,6 @@ fn parse_font_face_descriptors(
         weight,
     } = input_descriptors;
 
-    let _ = variationSettings; // TODO: Stylo doesn't parse font-variation-settings yet.
     let maybe_sources = sources.map_or_else(String::new, |sources| format!("src: {sources};"));
     let font_face_rule = format!(
         r"
@@ -114,6 +113,7 @@ fn parse_font_face_descriptors(
         font-feature-settings: {featureSettings};
         font-stretch: {stretch};
         font-style: {style};
+        font-variation-settings: {variationSettings};
         font-weight: {weight};
         line-gap-override: {lineGapOverride};
         unicode-range: {unicodeRange};

--- a/tests/wpt/tests/css/css-font-loading/fontface-font-variation-settings-persisted-js-api.html
+++ b/tests/wpt/tests/css/css-font-loading/fontface-font-variation-settings-persisted-js-api.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html>
+
+<head>
+  <title>Testing that variationSettings is persisted in the FontFace object</title>
+  <link rel="help" href="https://www.w3.org/TR/css-fonts-4/#propdef-font-variation-settings" />
+  <script src="/resources/testharness.js"></script>
+  <script src="/resources/testharnessreport.js"></script>
+</head>
+
+<body>
+  <script>
+    const face = new FontFace(
+      "wght",
+      'local("Ahem"), url("/fonts/Ahem.ttf")',
+      { variationSettings: "'wght' 850" }
+    );
+
+    test(() => {
+      assert_equals(face.variationSettings, "\"wght\" 850");
+    }, "Test FontFace variationSettings property");
+  </script>
+</body>
+
+</html>


### PR DESCRIPTION
Implementation for parsing the font-variation-settings and including them in the fontface rule-set, currently they are discarded and annotated with a TODO
Related: https://github.com/servo/servo/issues/41591

Testing: Tests are included for the changes to be implemented, as suggested they currently fail and thats the starting point.
