### PR TITLE
script: Check same-origin-domain when evaluating javscript: URLs.

### DIFF
--- a/components/script/dom/html/htmlformelement.rs
+++ b/components/script/dom/html/htmlformelement.rs
@@ -872,7 +872,7 @@ impl HTMLFormElement {
         // Step 21
         let target_window = target_document.window();
         let mut load_data = LoadData::new(
-            LoadOrigin::Script(doc.origin().immutable().clone()),
+            LoadOrigin::Script(doc.origin().snapshot()),
             action_components,
             None,
             target_window.as_global_scope().get_referrer(),

--- a/components/script/dom/html/htmliframeelement.rs
+++ b/components/script/dom/html/htmliframeelement.rs
@@ -273,7 +273,7 @@ impl HTMLIFrameElement {
             let window = self.owner_window();
             let pipeline_id = Some(window.pipeline_id());
             let mut load_data = LoadData::new(
-                LoadOrigin::Script(document.origin().immutable().clone()),
+                LoadOrigin::Script(document.origin().snapshot()),
                 url,
                 pipeline_id,
                 window.as_global_scope().get_referrer(),
@@ -369,7 +369,7 @@ impl HTMLIFrameElement {
 
         let propagate_encoding_to_child_document = url.origin().same_origin(window.origin());
         let mut load_data = LoadData::new(
-            LoadOrigin::Script(document.origin().immutable().clone()),
+            LoadOrigin::Script(document.origin().snapshot()),
             url,
             creator_pipeline_id,
             window.as_global_scope().get_referrer(),
@@ -413,7 +413,7 @@ impl HTMLIFrameElement {
         let window = self.owner_window();
         let pipeline_id = Some(window.pipeline_id());
         let mut load_data = LoadData::new(
-            LoadOrigin::Script(document.origin().immutable().clone()),
+            LoadOrigin::Script(document.origin().snapshot()),
             url,
             pipeline_id,
             window.as_global_scope().get_referrer(),

--- a/components/script/dom/location.rs
+++ b/components/script/dom/location.rs
@@ -128,7 +128,7 @@ impl Location {
             NavigationType::ReloadByConstellation => DomRoot::from_ref(&*self.window),
         };
         let (load_origin, creator_pipeline_id) = (
-            navigation_origin_window.origin().immutable().clone(),
+            navigation_origin_window.origin().snapshot(),
             Some(navigation_origin_window.pipeline_id()),
         );
 

--- a/components/script/dom/security/csp.rs
+++ b/components/script/dom/security/csp.rs
@@ -111,7 +111,7 @@ impl CspReporting for Option<CspList> {
         let mut request = Request {
             url: load_data.url.clone().into_url(),
             origin: match &load_data.load_origin {
-                LoadOrigin::Script(immutable_origin) => immutable_origin.clone().into_url_origin(),
+                LoadOrigin::Script(origin) => origin.immutable().clone().into_url_origin(),
                 _ => Origin::new_opaque(),
             },
             // TODO: populate this field correctly

--- a/components/script/dom/window.rs
+++ b/components/script/dom/window.rs
@@ -3138,7 +3138,7 @@ impl Window {
             Some(self.IsSecureContext())
         };
         LoadData::new(
-            LoadOrigin::Script(self.origin().immutable().clone()),
+            LoadOrigin::Script(self.origin().snapshot()),
             url,
             Some(pipeline_id),
             Referrer::ReferrerUrl(source_document.url()),

--- a/components/script/dom/windowproxy.rs
+++ b/components/script/dom/windowproxy.rs
@@ -314,7 +314,7 @@ impl WindowProxy {
             .expect("A WindowProxy creating an auxiliary to have an active document");
         let blank_url = ServoUrl::parse("about:blank").ok().unwrap();
         let load_data = LoadData::new(
-            LoadOrigin::Script(document.origin().immutable().clone()),
+            LoadOrigin::Script(document.origin().snapshot()),
             blank_url,
             // This has the effect of ensuring that the new `about:blank` URL has the
             // same origin as the `Document` that is creating the new browsing context.
@@ -558,7 +558,7 @@ impl WindowProxy {
             // with referrerPolicy set to referrerPolicy and exceptionsEnabled set to true.
             // FIXME: referrerPolicy may not be used properly here. exceptionsEnabled not used.
             let mut load_data = LoadData::new(
-                LoadOrigin::Script(existing_document.origin().immutable().clone()),
+                LoadOrigin::Script(existing_document.origin().snapshot()),
                 url,
                 Some(target_window.pipeline_id()),
                 referrer,
@@ -577,6 +577,7 @@ impl WindowProxy {
                 // Check CSP and report violations to the source (existing) window
                 if !ScriptThread::can_navigate_to_javascript_url(
                     &existing_global,
+                    target_window.as_global_scope(),
                     &mut load_data,
                     None,
                     can_gc,

--- a/components/script/links.rs
+++ b/components/script/links.rs
@@ -436,7 +436,7 @@ pub(crate) fn follow_hyperlink(
         let pipeline_id = target_window.as_global_scope().pipeline_id();
         let secure = target_window.as_global_scope().is_secure_context();
         let load_data = LoadData::new(
-            LoadOrigin::Script(document.origin().immutable().clone()),
+            LoadOrigin::Script(document.origin().snapshot()),
             url,
             Some(pipeline_id),
             referrer,

--- a/components/shared/constellation/from_script_message.rs
+++ b/components/shared/constellation/from_script_message.rs
@@ -35,7 +35,7 @@ use profile_traits::mem::MemoryReportResult;
 use profile_traits::{mem, time as profile_time};
 use rustc_hash::FxHashMap;
 use serde::{Deserialize, Serialize};
-use servo_url::{ImmutableOrigin, ServoUrl};
+use servo_url::{ImmutableOrigin, OriginSnapshot, ServoUrl};
 use storage_traits::StorageThreads;
 use storage_traits::webstorage_thread::WebStorageType;
 use strum::IntoStaticStr;
@@ -77,7 +77,7 @@ pub enum LoadOrigin {
     /// A load originating in webdriver.
     WebDriver,
     /// A load originating in script.
-    Script(ImmutableOrigin),
+    Script(OriginSnapshot),
 }
 
 /// can be passed to `LoadUrl` to load a page with GET/POST

--- a/components/url/lib.rs
+++ b/components/url/lib.rs
@@ -23,7 +23,7 @@ use servo_arc::Arc;
 pub use url::Host;
 use url::{Position, Url};
 
-pub use crate::origin::{ImmutableOrigin, MutableOrigin, OpaqueOrigin};
+pub use crate::origin::{ImmutableOrigin, MutableOrigin, OpaqueOrigin, OriginSnapshot};
 
 const DATA_URL_DISPLAY_LENGTH: usize = 40;
 

--- a/tests/wpt/meta/html/browsers/browsing-the-web/navigating-across-documents/javascript-url-security-check-failure.sub.html.ini
+++ b/tests/wpt/meta/html/browsers/browsing-the-web/navigating-across-documents/javascript-url-security-check-failure.sub.html.ini
@@ -1,9 +1,0 @@
-[javascript-url-security-check-failure.sub.html]
-  [cross-origin, setting src]
-    expected: FAIL
-
-  [cross-origin-domain but same-origin, setting src]
-    expected: FAIL
-
-  [cross-origin-domain but same-origin, setting location.href]
-    expected: FAIL

--- a/tests/wpt/meta/html/browsers/browsing-the-web/navigating-across-documents/javascript-url-security-check-same-origin-domain.sub.html.ini
+++ b/tests/wpt/meta/html/browsers/browsing-the-web/navigating-across-documents/javascript-url-security-check-same-origin-domain.sub.html.ini
@@ -1,4 +1,3 @@
 [javascript-url-security-check-same-origin-domain.sub.html]
-  expected: TIMEOUT
   [javascript: URL security check for same-origin-domain but not same-origin]
-    expected: TIMEOUT
+    expected: FAIL


### PR DESCRIPTION
These changes introduce a new OriginSnapshot type, which is an immutable version of MutableOrigin (ie. an origin that includes an optional domain modifier). This is now propagated as part of LoadData's origin, allowing us to perform the same-origin-domain check for javascript: URLs as needed.

Testing: Newly-passing tests.