### PR TITLE
script: Update mozjs to include with more safe wrappers and debugmozjs artifacts

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5529,9 +5529,9 @@ dependencies = [
 
 [[package]]
 name = "mozjs"
-version = "0.14.5"
+version = "0.14.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "617dd52981f630de01897f5a4014153efb6b9fcab1c5fd14f3e39f334f2d2939"
+checksum = "36f3329b0f19f40511bd7266d68ffbedf6d3d59157451927ec8d58ea010f6cda"
 dependencies = [
  "bindgen",
  "cc",
@@ -5544,9 +5544,9 @@ dependencies = [
 
 [[package]]
 name = "mozjs_sys"
-version = "0.140.5-7"
+version = "0.140.5-10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb69af2717202d31083deaeac10e38fd0f43c5cce07f2a067316e6a764517fa7"
+checksum = "7047586e1b71e6405d42e4dfcefdcea209fea39adf2f60122bf72f192e19fbd1"
 dependencies = [
  "bindgen",
  "cc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -106,7 +106,7 @@ imsz = "0.4"
 indexmap = { version = "2.11.4", features = ["std"] }
 ipc-channel = "0.20.2"
 itertools = "0.14"
-js = { package = "mozjs", version = "=0.14.5", default-features = false, features = ["libz-sys", "intl"] }
+js = { package = "mozjs", version = "=0.14.8", default-features = false, features = ["libz-sys", "intl"] }
 keyboard-types = { version = "0.8.3", features = ["serde", "webdriver"] }
 kurbo = { version = "0.12", features = ["euclid"] }
 layout_api = { path = "components/shared/layout" }

--- a/components/script/dom/bindings/utils.rs
+++ b/components/script/dom/bindings/utils.rs
@@ -14,7 +14,6 @@ use js::jsapi::{
 };
 use js::realm::CurrentRealm;
 use js::rust::{HandleObject, MutableHandleValue, get_object_class, is_dom_class};
-use script_bindings::conversions::SafeToJSValConvertible;
 use script_bindings::interfaces::{DomHelpers, Interface};
 use script_bindings::settings_stack::StackEntry;
 
@@ -60,7 +59,12 @@ pub(crate) fn to_frozen_array<T: ToJSValConvertible>(
     mut rval: MutableHandleValue,
     can_gc: CanGc,
 ) {
-    convertibles.safe_to_jsval(cx, rval.reborrow(), can_gc);
+    script_bindings::conversions::SafeToJSValConvertible::safe_to_jsval(
+        convertibles,
+        cx,
+        rval.reborrow(),
+        can_gc,
+    );
 
     rooted!(in(*cx) let obj = rval.to_object());
     unsafe { JS_FreezeObject(*cx, RawHandleObject::from(obj.handle())) };

--- a/components/script/dom/globalscope.rs
+++ b/components/script/dom/globalscope.rs
@@ -8,7 +8,7 @@ use std::collections::hash_map::Entry;
 use std::collections::{HashMap, HashSet, VecDeque};
 use std::ffi::CStr;
 use std::mem;
-use std::ops::Index;
+use std::ops::{Deref, Index};
 use std::ptr::NonNull;
 use std::rc::Rc;
 use std::sync::Arc;
@@ -1510,7 +1510,7 @@ impl GlobalScope {
             if let Ok(ports) = structuredclone::read(self, data, message_clone.handle_mut(), can_gc)
             {
                 // Note: if this port is used to transfer a stream, we handle the events in Rust.
-                if let Some(transform) = cross_realm_transform.as_ref() {
+                if let Some(transform) = cross_realm_transform.deref().as_ref() {
                     match transform {
                         // Add a handler for port’s message event with the following steps:
                         // from <https://streams.spec.whatwg.org/#abstract-opdef-setupcrossrealmtransformreadable>
@@ -1545,7 +1545,7 @@ impl GlobalScope {
                         can_gc,
                     );
                 }
-            } else if let Some(transform) = cross_realm_transform.as_ref() {
+            } else if let Some(transform) = cross_realm_transform.deref().as_ref() {
                 match transform {
                     // Add a handler for port’s messageerror event with the following steps:
                     // from <https://streams.spec.whatwg.org/#abstract-opdef-setupcrossrealmtransformreadable>


### PR DESCRIPTION
This bump includes
some new safe wrappers: https://github.com/servo/mozjs/pull/699 https://github.com/servo/mozjs/pull/700
debugmozjs artifacts: https://github.com/servo/mozjs/pull/544
rooted macros with vectors: https://github.com/servo/mozjs/pull/697

Testing: Done in mozjs repo.