### PR TITLE
script: Do not adjust the edit point in text fields when non-primary buttons are pressed

### DIFF
--- a/tests/wpt/mozilla/meta/MANIFEST.json
+++ b/tests/wpt/mozilla/meta/MANIFEST.json
@@ -12965,7 +12965,7 @@
      ]
     ],
     "mousedown-edit-point-input-text.html": [
-     "24e1852fd98d80807852bf9c45dae1c5063b064a",
+     "69faa576c30300845a6e621c3b51093eae2a1c01",
      [
       null,
       {
@@ -12974,7 +12974,7 @@
      ]
     ],
     "mousedown-edit-point-textarea.html": [
-     "de2e68a2b92ccae40ad6b062569a03121d597ae3",
+     "a7f67227f48028f9d6fa88d5f92b325c9735710c",
      [
       null,
       {

--- a/tests/wpt/mozilla/tests/input-events/mousedown-edit-point-input-text.html
+++ b/tests/wpt/mozilla/tests/input-events/mousedown-edit-point-input-text.html
@@ -12,17 +12,17 @@
 <script>
 promise_test(async test => {
     let targetRect = target.getBoundingClientRect();
-    let middleOfBlock = targetRect.top + (targetRect.height / 2);
+    let verticalCenterOfLine = targetRect.top + (targetRect.height / 2);
 
     await new test_driver.Actions()
-      .pointerMove(targetRect.left + 1, middleOfBlock)
+      .pointerMove(targetRect.left + 1, verticalCenterOfLine)
       .pointerDown().pointerUp()
           .send();
     assert_equals(target.selectionStart, 0);
     assert_equals(target.selectionEnd, 0);
 
     await new test_driver.Actions()
-      .pointerMove(targetRect.left + 50, middleOfBlock)
+      .pointerMove(targetRect.left + 50, verticalCenterOfLine)
       .pointerDown().pointerUp()
           .send();
     assert_equals(target.selectionStart, 1);
@@ -32,7 +32,7 @@ promise_test(async test => {
 
     // Click on the right half of a character should move the cursor to the next index.
     await new test_driver.Actions()
-      .pointerMove(targetRect.left + 40, middleOfBlock)
+      .pointerMove(targetRect.left + 40, verticalCenterOfLine)
       .pointerDown().pointerUp()
           .send();
     assert_equals(target.selectionStart, 1);
@@ -42,7 +42,7 @@ promise_test(async test => {
 
     // Click on the right half of a character should move the cursor to the next index.
     await new test_driver.Actions()
-      .pointerMove(targetRect.left + (50 * 5), middleOfBlock)
+      .pointerMove(targetRect.left + (50 * 5), verticalCenterOfLine)
       .pointerDown().pointerUp()
           .send();
     assert_equals(target.selectionStart, 5);
@@ -52,10 +52,26 @@ promise_test(async test => {
 
     // Clicking past the end of the text should move the edit point to the end.
     await new test_driver.Actions()
-      .pointerMove(targetRect.left + (50 * 7), middleOfBlock)
+      .pointerMove(targetRect.left + (50 * 7), verticalCenterOfLine)
       .pointerDown().pointerUp()
           .send();
     assert_equals(target.selectionStart, 6);
     assert_equals(target.selectionEnd, 6);
 }, 'Mouse events move the edit point in <input type=text>');
+
+promise_test(async test => {
+    let targetRect = target.getBoundingClientRect();
+    let verticalCenterOfLine = targetRect.top + (targetRect.height / 2);
+
+    target.setSelectionRange(2, 5);
+
+    const actions = new test_driver.Actions();
+    let options = { button: actions.ButtonType.RIGHT };
+    await actions
+      .pointerMove(targetRect.left + 2, verticalCenterOfLine)
+      .pointerDown(options).pointerUp(options)
+          .send();
+    assert_equals(target.selectionStart, 2);
+    assert_equals(target.selectionEnd, 5);
+}, 'Non-primary mouse buttons should not adjust the edit point in <input type=text>');
 </script>

--- a/tests/wpt/mozilla/tests/input-events/mousedown-edit-point-textarea.html
+++ b/tests/wpt/mozilla/tests/input-events/mousedown-edit-point-textarea.html
@@ -17,8 +17,8 @@
 <script>
 promise_test(async test => {
     let targetRect = target.getBoundingClientRect();
-
     let middleOfFirstLine = (50 / 2) + targetRect.top;
+
     await new test_driver.Actions()
       .pointerMove(targetRect.left + 10, middleOfFirstLine)
       .pointerDown().pointerUp()
@@ -118,4 +118,20 @@ promise_test(async test => {
     assert_equals(target.selectionStart, 24);
     assert_equals(target.selectionEnd, 24);
 }, 'Mouse events move the edit point in <textarea>');
+
+promise_test(async test => {
+    let targetRect = target.getBoundingClientRect();
+    let middleOfFirstLine = (50 / 2) + targetRect.top;
+
+    target.setSelectionRange(2, 5);
+
+    const actions = new test_driver.Actions();
+    let options = { button: actions.ButtonType.RIGHT };
+    await actions
+      .pointerMove(targetRect.left + 2, middleOfFirstLine)
+      .pointerDown(options).pointerUp(options)
+          .send();
+    assert_equals(target.selectionStart, 2);
+    assert_equals(target.selectionEnd, 5);
+}, 'Non-primary mouse buttons should not adjust the edit point in <textarea>');
 </script>


### PR DESCRIPTION
We should not move the text cursor or change the text selection when
non-primary (such as the right) mouse buttons are pressed. Doing so
interferes with the common operations:

1. Select text
2. Open context menu
3. Copy text

This change fixes that.

Testing: New WPT-style tests are added.
