### PR TITLE
script: Simplify `TextInput::new`

### DIFF
--- a/components/script/dom/html/htmlinputelement.rs
+++ b/components/script/dom/html/htmlinputelement.rs
@@ -85,9 +85,7 @@ use crate::dom::validitystate::{ValidationFlags, ValidityState};
 use crate::dom::virtualmethods::VirtualMethods;
 use crate::realms::enter_realm;
 use crate::script_runtime::{CanGc, JSContext as SafeJSContext};
-use crate::textinput::{
-    ClipboardEventFlags, IsComposing, KeyReaction, Lines, SelectionDirection, TextInput,
-};
+use crate::textinput::{ClipboardEventFlags, IsComposing, KeyReaction, Lines, TextInput};
 
 const DEFAULT_SUBMIT_VALUE: &str = "Submit";
 const DEFAULT_RESET_VALUE: &str = "Reset";
@@ -690,9 +688,6 @@ impl HTMLInputElement {
                     embedder_sender,
                     webview_id: document.webview_id(),
                 },
-                None,
-                None,
-                SelectionDirection::None,
             )),
             value_dirty: Cell::new(false),
             sanitization_flag: Cell::new(true),

--- a/components/script/dom/html/htmltextareaelement.rs
+++ b/components/script/dom/html/htmltextareaelement.rs
@@ -49,9 +49,7 @@ use crate::dom::validation::{Validatable, is_barred_by_datalist_ancestor};
 use crate::dom::validitystate::{ValidationFlags, ValidityState};
 use crate::dom::virtualmethods::VirtualMethods;
 use crate::script_runtime::CanGc;
-use crate::textinput::{
-    ClipboardEventFlags, IsComposing, KeyReaction, Lines, SelectionDirection, TextInput,
-};
+use crate::textinput::{ClipboardEventFlags, IsComposing, KeyReaction, Lines, TextInput};
 
 #[dom_struct]
 pub(crate) struct HTMLTextAreaElement {
@@ -145,9 +143,6 @@ impl HTMLTextAreaElement {
                     embedder_sender,
                     webview_id: document.webview_id(),
                 },
-                None,
-                None,
-                SelectionDirection::None,
             )),
             value_dirty: Cell::new(false),
             form_owner: Default::default(),

--- a/components/script/textinput.rs
+++ b/components/script/textinput.rs
@@ -250,23 +250,16 @@ fn len_of_first_n_code_units(text: &DOMString, n: Utf16CodeUnitLength) -> Utf8Co
 
 impl<T: ClipboardProvider> TextInput<T> {
     /// Instantiate a new text input control
-    pub fn new(
-        lines: Lines,
-        initial: DOMString,
-        clipboard_provider: T,
-        max_length: Option<Utf16CodeUnitLength>,
-        min_length: Option<Utf16CodeUnitLength>,
-        selection_direction: SelectionDirection,
-    ) -> TextInput<T> {
+    pub fn new(lines: Lines, initial: DOMString, clipboard_provider: T) -> TextInput<T> {
         Self {
             rope: Rope::new(initial),
             mode: lines,
             edit_point: Default::default(),
             selection_origin: None,
             clipboard_provider,
-            max_length,
-            min_length,
-            selection_direction,
+            max_length: Default::default(),
+            min_length: Default::default(),
+            selection_direction: SelectionDirection::None,
             was_last_change_by_set_content: true,
         }
     }
@@ -289,11 +282,11 @@ impl<T: ClipboardProvider> TextInput<T> {
         self.selection_direction
     }
 
-    pub(crate) fn set_max_length(&mut self, length: Option<Utf16CodeUnitLength>) {
+    pub fn set_max_length(&mut self, length: Option<Utf16CodeUnitLength>) {
         self.max_length = length;
     }
 
-    pub(crate) fn set_min_length(&mut self, length: Option<Utf16CodeUnitLength>) {
+    pub fn set_min_length(&mut self, length: Option<Utf16CodeUnitLength>) {
         self.min_length = length;
     }
 

--- a/tests/unit/script/textinput.rs
+++ b/tests/unit/script/textinput.rs
@@ -36,14 +36,7 @@ impl ClipboardProvider for DummyClipboardContext {
 }
 
 fn text_input(lines: Lines, s: &str) -> TextInput<DummyClipboardContext> {
-    TextInput::new(
-        lines,
-        DOMString::from(s),
-        DummyClipboardContext::new(""),
-        None,
-        None,
-        SelectionDirection::None,
-    )
+    TextInput::new(lines, DOMString::from(s), DummyClipboardContext::new(""))
 }
 
 #[test]
@@ -52,11 +45,9 @@ fn test_set_content_ignores_max_length() {
         Lines::Single,
         DOMString::from(""),
         DummyClipboardContext::new(""),
-        Some(Utf16CodeUnitLength::one()),
-        None,
-        SelectionDirection::None,
     );
 
+    textinput.set_max_length(Some(Utf16CodeUnitLength::one()));
     textinput.set_content(DOMString::from("mozilla rocks"));
     assert_eq!(textinput.get_content(), DOMString::from("mozilla rocks"));
 }
@@ -67,11 +58,9 @@ fn test_textinput_when_inserting_multiple_lines_over_a_selection_respects_max_le
         Lines::Multiple,
         DOMString::from("hello\nworld"),
         DummyClipboardContext::new(""),
-        Some(Utf16CodeUnitLength(17)),
-        None,
-        SelectionDirection::None,
     );
 
+    textinput.set_max_length(Some(Utf16CodeUnitLength(17)));
     textinput.modify_edit_point(1, RopeMovement::Grapheme);
     textinput.modify_selection(3, RopeMovement::Grapheme);
     textinput.modify_selection(1, RopeMovement::Line);
@@ -90,11 +79,9 @@ fn test_textinput_when_inserting_multiple_lines_still_respects_max_length() {
         Lines::Multiple,
         DOMString::from("hello\nworld"),
         DummyClipboardContext::new(""),
-        Some(Utf16CodeUnitLength(17)),
-        None,
-        SelectionDirection::None,
     );
 
+    textinput.set_max_length(Some(Utf16CodeUnitLength(17)));
     textinput.modify_edit_point(1, RopeMovement::Line);
     textinput.insert("cruel\nterrible");
     assert_eq!(textinput.get_content(), "hello\ncruel\nworld");
@@ -107,13 +94,10 @@ fn test_textinput_when_content_is_already_longer_than_max_length_and_theres_no_s
         Lines::Single,
         DOMString::from("abc"),
         DummyClipboardContext::new(""),
-        Some(Utf16CodeUnitLength::one()),
-        None,
-        SelectionDirection::None,
     );
 
+    textinput.set_max_length(Some(Utf16CodeUnitLength::one()));
     textinput.insert('a');
-
     assert_eq!(textinput.get_content(), "abc");
 }
 
@@ -124,13 +108,10 @@ fn test_multi_line_textinput_with_maxlength_doesnt_allow_appending_characters_wh
         Lines::Multiple,
         DOMString::from("abc\nd"),
         DummyClipboardContext::new(""),
-        Some(Utf16CodeUnitLength(5)),
-        None,
-        SelectionDirection::None,
     );
 
+    textinput.set_max_length(Some(Utf16CodeUnitLength(5)));
     textinput.insert('a');
-
     assert_eq!(textinput.get_content(), "abc\nd");
 }
 
@@ -141,11 +122,9 @@ fn test_single_line_textinput_with_max_length_doesnt_allow_appending_characters_
         Lines::Single,
         DOMString::from("abcde"),
         DummyClipboardContext::new(""),
-        Some(Utf16CodeUnitLength(5)),
-        None,
-        SelectionDirection::None,
     );
 
+    textinput.set_max_length(Some(Utf16CodeUnitLength(5)));
     textinput.modify_edit_point(1, RopeMovement::Grapheme);
     textinput.modify_selection(3, RopeMovement::Grapheme);
 
@@ -163,11 +142,9 @@ fn test_single_line_textinput_with_max_length_allows_deletion_when_replacing_a_s
         Lines::Single,
         DOMString::from("abcde"),
         DummyClipboardContext::new(""),
-        Some(Utf16CodeUnitLength(1)),
-        None,
-        SelectionDirection::None,
     );
 
+    textinput.set_max_length(Some(Utf16CodeUnitLength(1)));
     textinput.modify_edit_point(1, RopeMovement::Grapheme);
     textinput.modify_selection(2, RopeMovement::Grapheme);
 
@@ -185,11 +162,9 @@ fn test_single_line_textinput_with_max_length_multibyte() {
         Lines::Single,
         DOMString::from(""),
         DummyClipboardContext::new(""),
-        Some(Utf16CodeUnitLength(2)),
-        None,
-        SelectionDirection::None,
     );
 
+    textinput.set_max_length(Some(Utf16CodeUnitLength(2)));
     textinput.insert('á');
     assert_eq!(textinput.get_content(), "á");
     textinput.insert('é');
@@ -204,11 +179,9 @@ fn test_single_line_textinput_with_max_length_multi_code_unit() {
         Lines::Single,
         DOMString::from(""),
         DummyClipboardContext::new(""),
-        Some(Utf16CodeUnitLength(3)),
-        None,
-        SelectionDirection::None,
     );
 
+    textinput.set_max_length(Some(Utf16CodeUnitLength(3)));
     textinput.insert('\u{10437}');
     assert_eq!(textinput.get_content(), "\u{10437}");
     textinput.insert('\u{10437}');
@@ -225,11 +198,9 @@ fn test_single_line_textinput_with_max_length_inside_char() {
         Lines::Single,
         DOMString::from("\u{10437}"),
         DummyClipboardContext::new(""),
-        Some(Utf16CodeUnitLength::one()),
-        None,
-        SelectionDirection::None,
     );
 
+    textinput.set_max_length(Some(Utf16CodeUnitLength::one()));
     textinput.insert('x');
     assert_eq!(textinput.get_content(), "\u{10437}");
 }
@@ -241,11 +212,9 @@ fn test_single_line_textinput_with_max_length_doesnt_allow_appending_characters_
         Lines::Single,
         DOMString::from("a"),
         DummyClipboardContext::new(""),
-        Some(Utf16CodeUnitLength::one()),
-        None,
-        SelectionDirection::None,
     );
 
+    textinput.set_max_length(Some(Utf16CodeUnitLength::one()));
     textinput.insert('b');
     assert_eq!(textinput.get_content(), "a");
 }
@@ -564,9 +533,6 @@ fn test_clipboard_paste() {
         Lines::Single,
         DOMString::from("defg"),
         DummyClipboardContext::new("abc"),
-        None,
-        None,
-        SelectionDirection::None,
     );
     assert_eq!(textinput.get_content(), "defg");
     assert_eq!(textinput.edit_point().code_point, 0);


### PR DESCRIPTION
This constructors takes more arguments than it needs to. The three
arguments removed are almost always the default values. The exception is
in the unit tests. In this change those calls are modified to use
`set_max_length` like is done in the actual script code.

Testing: This is just a simplification of the code, so should be covered
by existing tests.
