### PR TITLE
[26488] - Refactors GPUBindGroup drop implementation

### DIFF
--- a/components/script_bindings/codegen/Bindings.conf
+++ b/components/script_bindings/codegen/Bindings.conf
@@ -304,10 +304,6 @@ DOMInterfaces = {
     'canGc': ['RequestDevice'],
 },
 
-'GPUBindGroup': {
-    'allowDropImpl': True,
-},
-
 'GPUBindGroupLayout': {
     'allowDropImpl': True,
 },


### PR DESCRIPTION
Moves the drop implementation for `GPUBindGroup` to a separate `DroppableGPUBindGroup` struct.

Testing: No tests added
Fixes: partially #26488 
