### PR TITLE
script: Consider a selection collapsed when the edit point equals the selection origin

### DIFF
--- a/components/script/dom/document_embedder_controls.rs
+++ b/components/script/dom/document_embedder_controls.rs
@@ -309,7 +309,7 @@ impl DocumentEmbedderControls {
         }
 
         if let Some(text_input_element) = &text_input_element {
-            let has_selection = text_input_element.has_selection();
+            let has_selection = text_input_element.has_uncollapsed_selection();
 
             info.flags
                 .insert(ContextMenuElementInformationFlags::EditableText);
@@ -527,12 +527,12 @@ impl Node {
 }
 
 impl Element {
-    fn has_selection(&self) -> bool {
+    fn has_uncollapsed_selection(&self) -> bool {
         self.downcast::<HTMLTextAreaElement>()
-            .map(TextControlElement::has_selection)
+            .map(TextControlElement::has_uncollapsed_selection)
             .or(self
                 .downcast::<HTMLInputElement>()
-                .map(TextControlElement::has_selection))
+                .map(TextControlElement::has_uncollapsed_selection))
             .unwrap_or_default()
     }
 

--- a/components/script/dom/html/htmlinputelement.rs
+++ b/components/script/dom/html/htmlinputelement.rs
@@ -1588,8 +1588,8 @@ impl TextControlElement for HTMLInputElement {
         self.renders_as_text_input_widget() && !self.textinput.borrow().get_content().is_empty()
     }
 
-    fn has_selection(&self) -> bool {
-        self.textinput.borrow().has_selection()
+    fn has_uncollapsed_selection(&self) -> bool {
+        self.textinput.borrow().has_uncollapsed_selection()
     }
 
     fn set_dirty_value_flag(&self, value: bool) {

--- a/components/script/dom/html/htmltextareaelement.rs
+++ b/components/script/dom/html/htmltextareaelement.rs
@@ -270,8 +270,8 @@ impl TextControlElement for HTMLTextAreaElement {
         !self.textinput.borrow().get_content().is_empty()
     }
 
-    fn has_selection(&self) -> bool {
-        self.textinput.borrow().has_selection()
+    fn has_uncollapsed_selection(&self) -> bool {
+        self.textinput.borrow().has_uncollapsed_selection()
     }
 
     fn set_dirty_value_flag(&self, value: bool) {

--- a/components/script/dom/textcontrol.rs
+++ b/components/script/dom/textcontrol.rs
@@ -23,7 +23,7 @@ use crate::textinput::{SelectionDirection, SelectionState, TextInput};
 pub(crate) trait TextControlElement: DerivedFrom<EventTarget> + DerivedFrom<Node> {
     fn selection_api_applies(&self) -> bool;
     fn has_selectable_text(&self) -> bool;
-    fn has_selection(&self) -> bool;
+    fn has_uncollapsed_selection(&self) -> bool;
     fn set_dirty_value_flag(&self, value: bool);
     fn select_all(&self);
 }

--- a/tests/wpt/mozilla/meta/MANIFEST.json
+++ b/tests/wpt/mozilla/meta/MANIFEST.json
@@ -12919,6 +12919,15 @@
     ]
    },
    "input-events": {
+    "collapsed-selection-input-text.html": [
+     "c80ddeff12b0ebc6568c03dabe848ac57e44737b",
+     [
+      null,
+      {
+       "testdriver": true
+      }
+     ]
+    ],
     "dblclick-events-fired-every-two-clicks.html": [
      "9ad53ceaf05018bb48e4ff2424da4e45fbca6be6",
      [

--- a/tests/wpt/mozilla/tests/input-events/collapsed-selection-input-text.html
+++ b/tests/wpt/mozilla/tests/input-events/collapsed-selection-input-text.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<title>Equal selection origin and edit points should be treated as a collapsed selection</title>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/resources/testdriver.js"></script>
+<script src="/resources/testdriver-actions.js"></script>
+<script src="/resources/testdriver-vendor.js"></script>
+<link rel="stylesheet" type="text/css" href="/fonts/ahem.css" />
+
+<input id="target" style="font: 50px/1 Ahem;" value="123456">
+
+<script>
+promise_test(async test => {
+    target.focus();
+    target.setSelectionRange(2, 2);
+
+    const arrowRight = "\uE014";
+    await test_driver.send_keys(document.body, arrowRight);
+
+    // The selection should be treated as collapsed which means that pressing
+    // the right arrow should move the edit point rather than collapsing the
+    // selection.
+    assert_equals(target.selectionStart, 3);
+    assert_equals(target.selectionEnd, 3);
+}, 'Equal selection origin and edit points should be treated as a collapsed selection');
+</script>


### PR DESCRIPTION
In text inputs, the edit point can be equal to a non-`None` selection
origin for a variety of reasons such as when the selection is set by a
DOM API or when a composition event inserts a zero length string. In
both of these cases, we should treat the selection as collapsed. It is
important to do this because for the purposes of arrow key movement and
context menu entries, we should think of the text input as not having a
selection at all.

Testing: This change adds a Servo-specific WPT test, as key press behavior is
platform specific.
