### PR TITLE
layout: Remove an unnecessary borrow in stacking context tree construction

### DIFF
--- a/components/layout/display_list/stacking_context.rs
+++ b/components/layout/display_list/stacking_context.rs
@@ -1378,10 +1378,10 @@ impl BoxFragment {
             );
         }
 
-        if matches!(&fragment, Fragment::Box(box_fragment) if matches!(
-            box_fragment.borrow().specific_layout_info(),
+        if matches!(
+            self.specific_layout_info(),
             Some(SpecificLayoutInfo::TableGridWithCollapsedBorders(_))
-        )) {
+        ) {
             stacking_context
                 .contents
                 .push(StackingContextContent::Fragment {


### PR DESCRIPTION
`fragment` is already borrowed here as `self`. `fragment` is just passed
in order to access the `Fragment` that contains the `self` inside an
`ArcRefCell`. This change removes the unecessary borrow and accesses the
`BoxFragment` directly.

Testing: This is a small optimization, so should be covered by existing tests.
