### PR TITLE
devtools: Fix devtools source content being empty for small documents

### DIFF
--- a/components/script/dom/servoparser/mod.rs
+++ b/components/script/dom/servoparser/mod.rs
@@ -639,7 +639,7 @@ impl ServoParser {
         if self.last_chunk_received.get() {
             let chunk = self.network_decoder.borrow_mut().finish(&self.document);
             if !chunk.is_empty() {
-                self.network_input.push_back(chunk);
+                self.push_tendril_input_chunk(chunk);
             }
         }
 


### PR DESCRIPTION
When the network decoder's `finish()` returns decoded content in `parse_sync`, it was being added to the parsing input but not captured for devtools. This ensures the content is also captured for the devtools Sources panel.

Testing: We have tests for this in devtools_tests.py. They were failing before this change. I ran locally and it passed now. With this all DevTools tests are passing!
