### PR TITLE
[26488] - Moves drop logic to inner struct for GPUBindGroupLayout

### DIFF
--- a/components/script_bindings/codegen/Bindings.conf
+++ b/components/script_bindings/codegen/Bindings.conf
@@ -304,10 +304,6 @@ DOMInterfaces = {
     'canGc': ['RequestDevice'],
 },
 
-'GPUBindGroupLayout': {
-    'allowDropImpl': True,
-},
-
 'GPUBuffer': {
     'inRealms': ['MapAsync'],
     'canGc': ['GetMappedRange', 'MapAsync'],


### PR DESCRIPTION
Moves the drop logic for `GPUBindGroupLayout` to an inner struct `DroppableGPUBindGroupLayout`.

Testing: No tests added
Fixes: Partially #26488 
