### PR TITLE
script: Implement full logic for script-blocking stylesheets

### DIFF
--- a/components/script/dom/html/htmlelement.rs
+++ b/components/script/dom/html/htmlelement.rs
@@ -53,6 +53,7 @@ use crate::dom::html::htmlhtmlelement::HTMLHtmlElement;
 use crate::dom::html::htmlinputelement::{HTMLInputElement, InputType};
 use crate::dom::html::htmllabelelement::HTMLLabelElement;
 use crate::dom::html::htmltextareaelement::HTMLTextAreaElement;
+use crate::dom::medialist::MediaList;
 use crate::dom::node::{
     BindContext, Node, NodeTraits, ShadowIncluding, UnbindContext, from_untrusted_node_address,
 };
@@ -149,6 +150,18 @@ impl HTMLElement {
 
         // Step 2: Replace all with fragment within element.
         Node::replace_all(Some(fragment.upcast()), self.upcast::<Node>(), can_gc);
+    }
+
+    /// <https://html.spec.whatwg.org/multipage/#matches-the-environment>
+    pub(crate) fn media_attribute_matches_media_environment(&self) -> bool {
+        // A string matches the environment of the user if it is the empty string,
+        // a string consisting of only ASCII whitespace, or is a media query list that
+        // matches the user's environment according to the definitions given in Media Queries. [MQ]
+        self.upcast::<Element>()
+            .get_attribute(&ns!(), &local_name!("media"))
+            .is_none_or(|media| {
+                MediaList::matches_environment(&self.owner_document(), &media.value())
+            })
     }
 }
 

--- a/components/script/dom/html/htmllinkelement.rs
+++ b/components/script/dom/html/htmllinkelement.rs
@@ -878,6 +878,12 @@ impl StylesheetOwner for HTMLLinkElement {
         self.parser_inserted.get()
     }
 
+    /// <https://html.spec.whatwg.org/multipage/#link-type-stylesheet:implicitly-potentially-render-blocking>
+    fn potentially_render_blocking(&self) -> bool {
+        // > A link element of this type is implicitly potentially render-blocking if the element was created by its node document's parser.
+        self.parser_inserted()
+    }
+
     fn referrer_policy(&self) -> ReferrerPolicy {
         if self.RelList(CanGc::note()).Contains("noreferrer".into()) {
             return ReferrerPolicy::NoReferrer;

--- a/components/script/dom/html/htmlstyleelement.rs
+++ b/components/script/dom/html/htmlstyleelement.rs
@@ -415,6 +415,12 @@ impl StylesheetOwner for HTMLStyleElement {
         self.parser_inserted.get()
     }
 
+    /// <https://html.spec.whatwg.org/multipage/#the-style-element:implicitly-potentially-render-blocking>
+    fn potentially_render_blocking(&self) -> bool {
+        // > A style element is implicitly potentially render-blocking if the element was created by its node document's parser.
+        self.parser_inserted()
+    }
+
     fn referrer_policy(&self) -> ReferrerPolicy {
         ReferrerPolicy::EmptyString
     }

--- a/tests/wpt/meta/html/dom/render-blocking/parser-inserted-style-element.html.ini
+++ b/tests/wpt/meta/html/dom/render-blocking/parser-inserted-style-element.html.ini
@@ -1,3 +1,0 @@
-[parser-inserted-style-element.html]
-  [Rendering is blocked before render-blocking resources are loaded]
-    expected: FAIL

--- a/tests/wpt/meta/html/dom/render-blocking/remove-attr-style-keeps-blocking.html.ini
+++ b/tests/wpt/meta/html/dom/render-blocking/remove-attr-style-keeps-blocking.html.ini
@@ -1,3 +1,0 @@
-[remove-attr-style-keeps-blocking.html]
-  [Rendering is blocked before render-blocking resources are loaded]
-    expected: FAIL


### PR DESCRIPTION
We only implemented the first part (parser_inserted), but
weren't checking any of the other cases.

Testing: WPT
Part of #22715 