### PR TITLE
[26488] - Refactors GPUBuffer drop logic into DroppableGPUBuffer

### DIFF
--- a/components/script/dom/webgpu/gpubuffer.rs
+++ b/components/script/dom/webgpu/gpubuffer.rs
@@ -64,25 +64,98 @@ impl ActiveBufferMapping {
     }
 }
 
-#[dom_struct]
-pub(crate) struct GPUBuffer {
-    reflector_: Reflector,
+#[derive(JSTraceable, MallocSizeOf)]
+struct DroppableGPUBuffer {
     #[ignore_malloc_size_of = "defined in webgpu"]
     #[no_trace]
     channel: WebGPU,
-    label: DomRefCell<USVString>,
     #[no_trace]
     buffer: WebGPUBuffer,
-    device: Dom<GPUDevice>,
-    /// <https://gpuweb.github.io/gpuweb/#dom-gpubuffer-size>
-    size: GPUSize64,
-    /// <https://gpuweb.github.io/gpuweb/#dom-gpubuffer-usage>
-    usage: GPUFlagsConstant,
     /// <https://gpuweb.github.io/gpuweb/#dom-gpubuffer-pending_map-slot>
     #[conditional_malloc_size_of]
     pending_map: DomRefCell<Option<Rc<Promise>>>,
     /// <https://gpuweb.github.io/gpuweb/#dom-gpubuffer-mapping-slot>
     mapping: DomRefCell<Option<ActiveBufferMapping>>,
+}
+
+impl DroppableGPUBuffer {
+    pub(crate) fn id(&self) -> WebGPUBuffer {
+        self.buffer
+    }
+    fn pending_map(&self) -> &DomRefCell<Option<Rc<Promise>>> {
+        &self.pending_map
+    }
+
+    fn mapping(&self) -> &DomRefCell<Option<ActiveBufferMapping>> {
+        &self.mapping
+    }
+
+    fn unmap(&self) {
+        // Step 1
+        if let Some(promise) = self.pending_map().borrow_mut().take() {
+            promise.reject_error(Error::Abort(None), CanGc::note());
+        }
+        // Step 2
+        let mut mapping = self.mapping().borrow_mut().take();
+        let mapping = if let Some(mapping) = mapping.as_mut() {
+            mapping
+        } else {
+            return;
+        };
+
+        // Step 3
+        mapping.data.clear_views();
+        // Step 5&7
+        if let Err(e) = self.channel.0.send(WebGPURequest::UnmapBuffer {
+            buffer_id: self.id().0,
+            mapping: if mapping.mode >= GPUMapModeConstants::WRITE {
+                Some(Mapping {
+                    data: GenericSharedMemory::from_bytes(mapping.data.data()),
+                    range: mapping.range.clone(),
+                    mode: HostMap::Write,
+                })
+            } else {
+                None
+            },
+        }) {
+            warn!("Failed to send Buffer unmap ({:?}) ({})", self.id().0, e);
+        }
+    }
+
+    fn destroy(&self) {
+        // Step 1
+        self.unmap();
+        // Step 2
+        if let Err(e) = self
+            .channel
+            .0
+            .send(WebGPURequest::DestroyBuffer(self.id().0))
+        {
+            warn!(
+                "Failed to send WebGPURequest::DestroyBuffer({:?}) ({})",
+                self.id().0,
+                e
+            );
+        };
+    }
+}
+
+impl Drop for DroppableGPUBuffer {
+    fn drop(&mut self) {
+        self.destroy()
+    }
+}
+
+#[dom_struct]
+pub(crate) struct GPUBuffer {
+    reflector_: Reflector,
+    label: DomRefCell<USVString>,
+    device: Dom<GPUDevice>,
+    /// <https://gpuweb.github.io/gpuweb/#dom-gpubuffer-size>
+    size: GPUSize64,
+    /// <https://gpuweb.github.io/gpuweb/#dom-gpubuffer-usage>
+    usage: GPUFlagsConstant,
+    droppable: DroppableGPUBuffer,
 }
 
 impl GPUBuffer {
@@ -97,14 +170,16 @@ impl GPUBuffer {
     ) -> Self {
         Self {
             reflector_: Reflector::new(),
-            channel,
             label: DomRefCell::new(label),
             device: Dom::from_ref(device),
-            buffer,
-            pending_map: DomRefCell::new(None),
             size,
             usage,
-            mapping: DomRefCell::new(mapping),
+            droppable: DroppableGPUBuffer {
+                channel,
+                buffer,
+                pending_map: DomRefCell::new(None),
+                mapping: DomRefCell::new(mapping),
+            },
         }
     }
 
@@ -132,7 +207,7 @@ impl GPUBuffer {
 
 impl GPUBuffer {
     pub(crate) fn id(&self) -> WebGPUBuffer {
-        self.buffer
+        self.droppable.id()
     }
 
     /// <https://gpuweb.github.io/gpuweb/#dom-gpudevice-createbuffer>
@@ -183,61 +258,15 @@ impl GPUBuffer {
     }
 }
 
-impl Drop for GPUBuffer {
-    fn drop(&mut self) {
-        self.Destroy()
-    }
-}
-
 impl GPUBufferMethods<crate::DomTypeHolder> for GPUBuffer {
     /// <https://gpuweb.github.io/gpuweb/#dom-gpubuffer-unmap>
     fn Unmap(&self) {
-        // Step 1
-        if let Some(promise) = self.pending_map.borrow_mut().take() {
-            promise.reject_error(Error::Abort(None), CanGc::note());
-        }
-        // Step 2
-        let mut mapping = self.mapping.borrow_mut().take();
-        let mapping = if let Some(mapping) = mapping.as_mut() {
-            mapping
-        } else {
-            return;
-        };
-
-        // Step 3
-        mapping.data.clear_views();
-        // Step 5&7
-        if let Err(e) = self.channel.0.send(WebGPURequest::UnmapBuffer {
-            buffer_id: self.id().0,
-            mapping: if mapping.mode >= GPUMapModeConstants::WRITE {
-                Some(Mapping {
-                    data: GenericSharedMemory::from_bytes(mapping.data.data()),
-                    range: mapping.range.clone(),
-                    mode: HostMap::Write,
-                })
-            } else {
-                None
-            },
-        }) {
-            warn!("Failed to send Buffer unmap ({:?}) ({})", self.buffer.0, e);
-        }
+        self.droppable.unmap();
     }
 
     /// <https://gpuweb.github.io/gpuweb/#dom-gpubuffer-destroy>
     fn Destroy(&self) {
-        // Step 1
-        self.Unmap();
-        // Step 2
-        if let Err(e) = self
-            .channel
-            .0
-            .send(WebGPURequest::DestroyBuffer(self.buffer.0))
-        {
-            warn!(
-                "Failed to send WebGPURequest::DestroyBuffer({:?}) ({})",
-                self.buffer.0, e
-            );
-        };
+        self.droppable.destroy();
     }
 
     /// <https://gpuweb.github.io/gpuweb/#dom-gpubuffer-mapasync>
@@ -251,12 +280,12 @@ impl GPUBufferMethods<crate::DomTypeHolder> for GPUBuffer {
     ) -> Rc<Promise> {
         let promise = Promise::new_in_current_realm(comp, can_gc);
         // Step 2
-        if self.pending_map.borrow().is_some() {
+        if self.droppable.pending_map().borrow().is_some() {
             promise.reject_error(Error::Operation(None), can_gc);
             return promise;
         }
         // Step 4
-        *self.pending_map.borrow_mut() = Some(promise.clone());
+        *self.droppable.pending_map().borrow_mut() = Some(promise.clone());
         // Step 5
         let host_map = match mode {
             GPUMapModeConstants::READ => HostMap::Read,
@@ -276,17 +305,23 @@ impl GPUBufferMethods<crate::DomTypeHolder> for GPUBuffer {
             self,
             self.global().task_manager().dom_manipulation_task_source(),
         );
-        if let Err(e) = self.channel.0.send(WebGPURequest::BufferMapAsync {
-            callback,
-            buffer_id: self.buffer.0,
-            device_id: self.device.id().0,
-            host_map,
-            offset,
-            size,
-        }) {
+        if let Err(e) = self
+            .droppable
+            .channel
+            .0
+            .send(WebGPURequest::BufferMapAsync {
+                callback,
+                buffer_id: self.droppable.id().0,
+                device_id: self.device.id().0,
+                host_map,
+                offset,
+                size,
+            })
+        {
             warn!(
                 "Failed to send BufferMapAsync ({:?}) ({})",
-                self.buffer.0, e
+                self.droppable.id().0,
+                e
             );
             self.map_failure(&promise, can_gc);
             return promise;
@@ -309,7 +344,7 @@ impl GPUBufferMethods<crate::DomTypeHolder> for GPUBuffer {
             self.size.saturating_sub(offset)
         };
         // Step 2: validation
-        let mut mapping = self.mapping.borrow_mut();
+        let mut mapping = self.droppable.mapping().borrow_mut();
         let mapping = mapping.as_mut().ok_or(Error::Operation(None))?;
 
         let valid = offset % wgpu_types::MAP_ALIGNMENT == 0 &&
@@ -354,9 +389,9 @@ impl GPUBufferMethods<crate::DomTypeHolder> for GPUBuffer {
     /// <https://gpuweb.github.io/gpuweb/#dom-gpubuffer-mapstate>
     fn MapState(&self) -> GPUBufferMapState {
         // Step 1&2&3
-        if self.mapping.borrow().is_some() {
+        if self.droppable.mapping().borrow().is_some() {
             GPUBufferMapState::Mapped
-        } else if self.pending_map.borrow().is_some() {
+        } else if self.droppable.pending_map().borrow().is_some() {
             GPUBufferMapState::Pending
         } else {
             GPUBufferMapState::Unmapped
@@ -366,7 +401,7 @@ impl GPUBufferMethods<crate::DomTypeHolder> for GPUBuffer {
 
 impl GPUBuffer {
     fn map_failure(&self, p: &Rc<Promise>, can_gc: CanGc) {
-        let mut pending_map = self.pending_map.borrow_mut();
+        let mut pending_map = self.droppable.pending_map().borrow_mut();
         // Step 1
         if pending_map.as_ref() != Some(p) {
             assert!(p.is_rejected());
@@ -385,7 +420,7 @@ impl GPUBuffer {
     }
 
     fn map_success(&self, p: &Rc<Promise>, wgpu_mapping: Mapping, can_gc: CanGc) {
-        let mut pending_map = self.pending_map.borrow_mut();
+        let mut pending_map = self.droppable.pending_map().borrow_mut();
 
         // Step 1
         if pending_map.as_ref() != Some(p) {
@@ -414,7 +449,7 @@ impl GPUBuffer {
                 // Step 5
                 mapping.data.load(&wgpu_mapping.data);
                 // Step 6
-                self.mapping.borrow_mut().replace(mapping);
+                self.droppable.mapping().borrow_mut().replace(mapping);
                 // Step 7
                 pending_map.take();
                 p.resolve_native(&(), can_gc);

--- a/components/script_bindings/codegen/Bindings.conf
+++ b/components/script_bindings/codegen/Bindings.conf
@@ -307,7 +307,6 @@ DOMInterfaces = {
 'GPUBuffer': {
     'inRealms': ['MapAsync'],
     'canGc': ['GetMappedRange', 'MapAsync'],
-    'allowDropImpl': True,
 },
 
 'GPUCanvasContext': {


### PR DESCRIPTION
Moves the buffer dropping logic to a separate `DroppableGPUBuffer` struct.

Testing: No tests added
Fixes: Partially #26488 
