### PR TITLE
layout: Limit LCP stopping to actual user input events.

### DIFF
--- a/components/paint/largest_contentful_paint_calculator.rs
+++ b/components/paint/largest_contentful_paint_calculator.rs
@@ -54,6 +54,7 @@ impl LargestContentfulPaintCalculator {
             .and_then(|container| container.calculate_largest_contentful_paint(paint_time))
     }
 
+    /// <https://www.w3.org/TR/largest-contentful-paint/#limitations>
     pub(crate) fn disable_for_webview(&mut self, webview_id: WebViewId) {
         self.disabled_lcp_for_webviews.insert(webview_id);
     }

--- a/components/paint/painter.rs
+++ b/components/paint/painter.rs
@@ -1290,12 +1290,14 @@ impl Painter {
                 InputEvent::MouseLeftViewport(_) => {
                     self.last_mouse_move_position = None;
                 },
-                _ => {},
+                _ => {
+                    // Disable LCP calculation on any other input event except mouse moves.
+                    self.lcp_calculator.disable_for_webview(webview_id);
+                },
             }
 
             webview_renderer.notify_input_event(&self.webrender_api, &self.needs_repaint, event);
         }
-        self.disable_lcp_calculation_for_webview(webview_id);
     }
 
     pub(crate) fn notify_scroll_event(
@@ -1307,7 +1309,8 @@ impl Painter {
         if let Some(webview_renderer) = self.webview_renderers.get_mut(&webview_id) {
             webview_renderer.notify_scroll_event(scroll, point);
         }
-        self.disable_lcp_calculation_for_webview(webview_id);
+        // Disable LCP calculation on any scroll event.
+        self.lcp_calculator.disable_for_webview(webview_id);
     }
 
     pub(crate) fn pinch_zoom(
@@ -1446,11 +1449,6 @@ impl Painter {
                     .set(PaintMetricState::Seen(epoch.into(), false));
             }
         };
-    }
-
-    /// Disable LCP feature when the user interacts with the page.
-    fn disable_lcp_calculation_for_webview(&mut self, webview_id: WebViewId) {
-        self.lcp_calculator.disable_for_webview(webview_id);
     }
 }
 

--- a/components/servo/tests/largest_contentful_paint.rs
+++ b/components/servo/tests/largest_contentful_paint.rs
@@ -7,9 +7,10 @@ mod common;
 
 use std::rc::Rc;
 
-use servo::{JSValue, WebViewBuilder};
+use servo::{InputEvent, JSValue, MouseMoveEvent, WebViewBuilder};
 use servo_config::prefs::Preferences;
 use url::Url;
+use webrender_api::units::DevicePoint;
 
 use crate::common::{
     ServoTest, WebViewDelegateImpl, evaluate_javascript,
@@ -69,4 +70,51 @@ fn test_largest_contentful_paint_js_api() {
     } else {
         panic!("No entries for Largest Contentful Paint were recorded.");
     }
+}
+
+#[test]
+fn test_largest_contentful_paint_js_api_with_mouse_move() {
+    let servo_test = ServoTest::new_with_builder(|builder| {
+        let mut preferences = Preferences::default();
+        preferences.largest_contentful_paint_enabled = true;
+        builder.preferences(preferences)
+    });
+
+    let delegate = Rc::new(WebViewDelegateImpl::default());
+    let webview = WebViewBuilder::new(servo_test.servo(), servo_test.rendering_context.clone())
+        .delegate(delegate.clone())
+        .url(
+            Url::parse(
+                "data:text/html,<!DOCTYPE html>\
+                <a href=\"https://servo.org\"><div style=\"width: 50px; height: 50px;\">Link</div></a> \
+                <div><img src=\"data:image/svg+xml,<svg width='50' height='50'><circle cx='25' cy='25' r='20' fill='green'/></svg>\"\
+                style=\"width: 50px; height: 50px;\"></div>"
+            )
+            .unwrap(),
+        )
+        .build();
+
+    // Simulate a mouse move movement.
+    webview.notify_input_event(InputEvent::MouseMove(MouseMoveEvent::new(
+        DevicePoint::new(10., 10.).into(),
+    )));
+
+    let lcp_script = "(async () => {
+        window.lcp = await new Promise(resolve => {
+            (new PerformanceObserver(entryList => {
+                resolve(entryList.getEntries()[0]);
+            }))
+            .observe({type: 'largest-contentful-paint', buffered: true});
+        })
+    })();";
+
+    if let Err(err) = evaluate_javascript(&servo_test, webview.clone(), lcp_script) {
+        panic!("Failed to evaluate LCP setup script: {:?}", err);
+    }
+
+    show_webview_and_wait_for_rendering_to_be_ready(&servo_test, &webview, &delegate);
+
+    // Read from a global variable used to store the result since evaluate_javascript doesn't handle Promises
+    let lcp = evaluate_javascript(&servo_test, webview.clone(), "window.lcp;");
+    assert_eq!(lcp, Ok(JSValue::Object(std::collections::HashMap::new())));
 }


### PR DESCRIPTION
This basically doesn't halt LCP on Mouse Move.

Reference: https://www.w3.org/TR/largest-contentful-paint/#limitations

Testing: `components/servo/tests/largest_contentful_paint.rs`
Fixes: #42534
