### PR TITLE
layout: Add unit types to most layout queries

### DIFF
--- a/components/geometry/lib.rs
+++ b/components/geometry/lib.rs
@@ -6,7 +6,7 @@ use std::f32;
 
 use app_units::{Au, MAX_AU, MIN_AU};
 use euclid::default::{Point2D as UntypedPoint2D, Rect as UntypedRect, Size2D as UntypedSize2D};
-use euclid::{Box2D, Length, Point2D, Scale, SideOffsets2D, Size2D, Vector2D};
+use euclid::{Box2D, Length, Point2D, Rect, Scale, SideOffsets2D, Size2D, Vector2D};
 use malloc_size_of_derive::MallocSizeOf;
 use webrender::FastTransform;
 use webrender_api::units::{
@@ -94,8 +94,8 @@ impl MaxRect for LayoutRect {
 }
 
 /// A helper function to convert a rect of `f32` pixels to a rect of app units.
-pub fn f32_rect_to_au_rect(rect: UntypedRect<f32>) -> UntypedRect<Au> {
-    UntypedRect::new(
+pub fn f32_rect_to_au_rect<T>(rect: Rect<f32, T>) -> Rect<Au, T> {
+    Rect::new(
         Point2D::new(
             Au::from_f32_px(rect.origin.x),
             Au::from_f32_px(rect.origin.y),
@@ -108,8 +108,8 @@ pub fn f32_rect_to_au_rect(rect: UntypedRect<f32>) -> UntypedRect<Au> {
 }
 
 /// A helper function to convert a rect of `Au` pixels to a rect of f32 units.
-pub fn au_rect_to_f32_rect(rect: UntypedRect<Au>) -> UntypedRect<f32> {
-    UntypedRect::new(
+pub fn au_rect_to_f32_rect<T>(rect: Rect<Au, T>) -> Rect<f32, T> {
+    Rect::new(
         Point2D::new(rect.origin.x.to_f32_px(), rect.origin.y.to_f32_px()),
         Size2D::new(rect.size.width.to_f32_px(), rect.size.height.to_f32_px()),
     )

--- a/components/layout/display_list/largest_contenful_paint_candidate_collector.rs
+++ b/components/layout/display_list/largest_contenful_paint_candidate_collector.rs
@@ -42,13 +42,13 @@ impl LargestContentfulPaintCandidateCollector {
             .intersection(&clip_rect)
             .unwrap_or(LayoutRect::zero());
         let transformed_rect = transform_au_rectangle(
-            f32_rect_to_au_rect(clipped_rect.to_rect().to_untyped()),
+            f32_rect_to_au_rect(clipped_rect.to_rect().cast_unit()),
             transform,
         )
         .unwrap_or_default();
         let transformed_rect = au_rect_to_f32_rect(transformed_rect);
         let visual_rect = transformed_rect
-            .intersection(&self.viewport_rect.to_rect().to_untyped())
+            .intersection(&self.viewport_rect.to_rect().cast_unit())
             .unwrap_or(Rect::zero());
         let area = visual_rect.size.width * visual_rect.size.height;
         if area == 0.0 {

--- a/components/layout/fragment_tree/box_fragment.rs
+++ b/components/layout/fragment_tree/box_fragment.rs
@@ -418,7 +418,7 @@ impl BoxFragment {
             .and_then(|transform| {
                 transform.outer_transformed_rect(&overflow.to_webrender().to_rect())
             })
-            .map(|transformed_rect| f32_rect_to_au_rect(transformed_rect.to_untyped()).cast_unit())
+            .map(|transformed_rect| f32_rect_to_au_rect(transformed_rect).cast_unit())
             .unwrap_or(overflow)
     }
 

--- a/components/layout/fragment_tree/fragment.rs
+++ b/components/layout/fragment_tree/fragment.rs
@@ -8,7 +8,7 @@ use app_units::Au;
 use atomic_refcell::{AtomicRef, AtomicRefMut};
 use base::id::PipelineId;
 use base::print_tree::PrintTree;
-use euclid::{Point2D, Rect, Size2D, UnknownUnit};
+use euclid::{Point2D, Rect, Size2D};
 use fonts::{ByteIndex, FontMetrics, GlyphStore, TextByteRange};
 use layout_api::BoxAreaType;
 use malloc_size_of_derive::MallocSizeOf;
@@ -241,7 +241,7 @@ impl Fragment {
         }
     }
 
-    pub(crate) fn client_rect(&self) -> Rect<i32, UnknownUnit> {
+    pub(crate) fn client_rect(&self) -> Rect<i32, CSSPixel> {
         let rect = match self {
             Fragment::Box(fragment) | Fragment::Float(fragment) => {
                 // https://drafts.csswg.org/cssom-view/#dom-element-clienttop
@@ -267,8 +267,7 @@ impl Fragment {
                 }
             },
             _ => return Rect::zero(),
-        }
-        .to_untyped();
+        };
 
         let rect = Rect::new(
             Point2D::new(rect.origin.x.to_f32_px(), rect.origin.y.to_f32_px()),

--- a/components/layout/layout_impl.rs
+++ b/components/layout/layout_impl.rs
@@ -19,8 +19,7 @@ use compositing_traits::CrossProcessPaintApi;
 use compositing_traits::display_list::ScrollType;
 use cssparser::ParserInput;
 use embedder_traits::{Theme, ViewportDetails};
-use euclid::default::Rect as UntypedRect;
-use euclid::{Point2D, Scale, Size2D};
+use euclid::{Point2D, Rect, Scale, Size2D};
 use fonts::{FontContext, FontContextWebFontMethods, WebFontDocumentContext};
 use fonts_traits::StylesheetWebFontLoadFinishedCallback;
 use layout_api::wrapper_traits::LayoutNode;
@@ -326,7 +325,7 @@ impl Layout for LayoutThread {
         node: TrustedNodeAddress,
         area: BoxAreaType,
         exclude_transform_and_inline: bool,
-    ) -> Option<UntypedRect<Au>> {
+    ) -> Option<Rect<Au, CSSPixel>> {
         // If we have not built a fragment tree yet, there is no way we have layout information for
         // this query, which can be run without forcing a layout (for IntersectionObserver).
         if self.fragment_tree.borrow().is_none() {
@@ -351,7 +350,11 @@ impl Layout for LayoutThread {
     ///
     /// See <https://drafts.csswg.org/cssom-view/#dom-element-getclientrects>.
     #[servo_tracing::instrument(skip_all)]
-    fn query_box_areas(&self, node: TrustedNodeAddress, area: BoxAreaType) -> Vec<UntypedRect<Au>> {
+    fn query_box_areas(
+        &self,
+        node: TrustedNodeAddress,
+        area: BoxAreaType,
+    ) -> Vec<Rect<Au, CSSPixel>> {
         // If we have not built a fragment tree yet, there is no way we have layout information for
         // this query, which can be run without forcing a layout (for IntersectionObserver).
         if self.fragment_tree.borrow().is_none() {
@@ -367,7 +370,7 @@ impl Layout for LayoutThread {
     }
 
     #[servo_tracing::instrument(skip_all)]
-    fn query_client_rect(&self, node: TrustedNodeAddress) -> UntypedRect<i32> {
+    fn query_client_rect(&self, node: TrustedNodeAddress) -> Rect<i32, CSSPixel> {
         let node = unsafe { ServoLayoutNode::new(&node) };
         process_client_rect_request(node.to_threadsafe())
     }
@@ -473,7 +476,7 @@ impl Layout for LayoutThread {
     }
 
     #[servo_tracing::instrument(skip_all)]
-    fn query_scrolling_area(&self, node: Option<TrustedNodeAddress>) -> UntypedRect<i32> {
+    fn query_scrolling_area(&self, node: Option<TrustedNodeAddress>) -> Rect<i32, CSSPixel> {
         let node = node.map(|node| unsafe { ServoLayoutNode::new(&node).to_threadsafe() });
         process_node_scroll_area_request(node, self.fragment_tree.borrow().clone())
     }

--- a/components/script/dom/element.rs
+++ b/components/script/dom/element.rs
@@ -16,7 +16,7 @@ use app_units::Au;
 use cssparser::match_ignore_ascii_case;
 use devtools_traits::AttrInfo;
 use dom_struct::dom_struct;
-use euclid::default::{Rect, Size2D};
+use euclid::Rect;
 use html5ever::serialize::TraversalScope;
 use html5ever::serialize::TraversalScope::{ChildrenOnly, IncludeNode};
 use html5ever::{LocalName, Namespace, Prefix, QualName, local_name, namespace_prefix, ns};
@@ -57,6 +57,7 @@ use style::values::generics::position::PreferredRatio;
 use style::values::generics::ratio::Ratio;
 use style::values::{AtomIdent, AtomString, CSSFloat, computed, specified};
 use style::{ArcSlice, CaseSensitivityExt, dom_apis, thread_state};
+use style_traits::CSSPixel;
 use stylo_atoms::Atom;
 use stylo_dom::ElementState;
 use xml5ever::serialize::TraversalScope::{
@@ -861,7 +862,7 @@ impl Element {
         block: ScrollAxisState,
         inline: ScrollAxisState,
         container: Option<&Element>,
-        inner_target_rect: Option<Rect<Au>>,
+        inner_target_rect: Option<Rect<Au, CSSPixel>>,
     ) {
         let get_target_rect = || match inner_target_rect {
             None => self.upcast::<Node>().border_box().unwrap_or_default(),
@@ -4994,7 +4995,7 @@ impl Element {
             .inspect(|states| states.for_each_state(callback));
     }
 
-    pub(crate) fn client_rect(&self) -> Rect<i32> {
+    pub(crate) fn client_rect(&self) -> Rect<i32, CSSPixel> {
         let doc = self.node.owner_doc();
 
         if let Some(rect) = self
@@ -5014,8 +5015,7 @@ impl Element {
         if (in_quirks_mode && doc.GetBody().as_deref() == self.downcast::<HTMLElement>()) ||
             (!in_quirks_mode && self.is_document_element())
         {
-            let viewport_dimensions = doc.window().viewport_details().size.round().to_i32();
-            rect.size = Size2D::<i32>::new(viewport_dimensions.width, viewport_dimensions.height);
+            rect.size = doc.window().viewport_details().size.round().to_i32();
         }
 
         self.ensure_rare_data().client_rect = Some(self.owner_window().cache_layout_value(rect));

--- a/components/script/dom/node.rs
+++ b/components/script/dom/node.rs
@@ -17,8 +17,8 @@ use bitflags::bitflags;
 use devtools_traits::NodeInfo;
 use dom_struct::dom_struct;
 use embedder_traits::UntrustedNodeAddress;
-use euclid::Point2D;
-use euclid::default::{Rect, Size2D};
+use euclid::default::Size2D;
+use euclid::{Point2D, Rect};
 use html5ever::serialize::HtmlSerializer;
 use html5ever::{Namespace, Prefix, QualName, ns, serialize as html_serialize};
 use js::jsapi::JSObject;
@@ -51,6 +51,7 @@ use style::dom::OpaqueNode;
 use style::properties::ComputedValues;
 use style::selector_parser::{PseudoElement, SelectorImpl, SelectorParser};
 use style::stylesheets::{Stylesheet, UrlExtraData};
+use style_traits::CSSPixel;
 use uuid::Uuid;
 use xml5ever::{local_name, serialize as xml_serialize};
 
@@ -991,33 +992,33 @@ impl Node {
         self.owner_window().padding_query_without_reflow(self)
     }
 
-    pub(crate) fn content_box(&self) -> Option<Rect<Au>> {
+    pub(crate) fn content_box(&self) -> Option<Rect<Au, CSSPixel>> {
         self.owner_window()
             .box_area_query(self, BoxAreaType::Content, false)
     }
 
-    pub(crate) fn border_box(&self) -> Option<Rect<Au>> {
+    pub(crate) fn border_box(&self) -> Option<Rect<Au, CSSPixel>> {
         self.owner_window()
             .box_area_query(self, BoxAreaType::Border, false)
     }
 
-    pub(crate) fn padding_box(&self) -> Option<Rect<Au>> {
+    pub(crate) fn padding_box(&self) -> Option<Rect<Au, CSSPixel>> {
         self.owner_window()
             .box_area_query(self, BoxAreaType::Padding, false)
     }
 
-    pub(crate) fn border_boxes(&self) -> Vec<Rect<Au>> {
+    pub(crate) fn border_boxes(&self) -> Vec<Rect<Au, CSSPixel>> {
         self.owner_window()
             .box_areas_query(self, BoxAreaType::Border)
     }
 
-    pub(crate) fn client_rect(&self) -> Rect<i32> {
+    pub(crate) fn client_rect(&self) -> Rect<i32, CSSPixel> {
         self.owner_window().client_rect_query(self)
     }
 
     /// <https://drafts.csswg.org/cssom-view/#dom-element-scrollwidth>
     /// <https://drafts.csswg.org/cssom-view/#dom-element-scrollheight>
-    pub(crate) fn scroll_area(&self) -> Rect<i32> {
+    pub(crate) fn scroll_area(&self) -> Rect<i32, CSSPixel> {
         // "1. Let document be the element’s node document.""
         let document = self.owner_doc();
 
@@ -1029,7 +1030,7 @@ impl Node {
         // "3. Let viewport width/height be the width of the viewport excluding the width/height of the
         // scroll bar, if any, or zero if there is no viewport."
         let window = document.window();
-        let viewport = Size2D::new(window.InnerWidth(), window.InnerHeight());
+        let viewport = Size2D::new(window.InnerWidth(), window.InnerHeight()).cast_unit();
 
         let in_quirks_mode = document.quirks_mode() == QuirksMode::Quirks;
         let is_root = self.downcast::<Element>().is_some_and(|e| e.is_root());

--- a/components/script/dom/range.rs
+++ b/components/script/dom/range.rs
@@ -6,9 +6,12 @@ use std::cell::RefCell;
 use std::cmp::{Ordering, PartialOrd};
 use std::iter;
 
+use app_units::Au;
 use dom_struct::dom_struct;
+use euclid::Rect;
 use js::jsapi::JSTracer;
 use js::rust::HandleObject;
+use style_traits::CSSPixel;
 
 use crate::dom::abstractrange::{AbstractRange, BoundaryPoint, bp_position};
 use crate::dom::bindings::cell::DomRefCell;
@@ -329,9 +332,7 @@ impl Range {
         self.abstract_range().Collapsed()
     }
 
-    fn client_rects(
-        &self,
-    ) -> impl Iterator<Item = euclid::Rect<app_units::Au, euclid::UnknownUnit>> {
+    fn client_rects(&self) -> impl Iterator<Item = Rect<Au, CSSPixel>> {
         // FIXME: For text nodes that are only partially selected, this should return the client
         // rect of the selected part, not the whole text node.
         let start = self.start_container();

--- a/components/script/dom/raredata.rs
+++ b/components/script/dom/raredata.rs
@@ -4,8 +4,9 @@
 
 use std::rc::Rc;
 
-use euclid::default::Rect;
+use euclid::Rect;
 use style::selector_parser::PseudoElement;
+use style_traits::CSSPixel;
 use stylo_atoms::Atom;
 
 use crate::dom::bindings::root::{Dom, MutNullableDom};
@@ -78,7 +79,7 @@ pub(crate) struct ElementRareData {
     pub(crate) name_attribute: Option<Atom>,
     /// The client rect reported by layout.
     #[no_trace]
-    pub(crate) client_rect: Option<LayoutValue<Rect<i32>>>,
+    pub(crate) client_rect: Option<LayoutValue<Rect<i32, CSSPixel>>>,
     /// <https://html.spec.whatwg.org/multipage#elementinternals>
     pub(crate) element_internals: Option<Dom<ElementInternals>>,
 

--- a/components/script/dom/resizeobserver.rs
+++ b/components/script/dom/resizeobserver.rs
@@ -6,12 +6,12 @@ use std::rc::Rc;
 
 use app_units::Au;
 use dom_struct::dom_struct;
-use euclid::Size2D;
-use euclid::default::Rect;
 use euclid::num::Zero;
+use euclid::{Rect, Size2D};
 use html5ever::ns;
 use js::rust::HandleObject;
 use layout_api::BoxAreaType;
+use style_traits::CSSPixel;
 
 use crate::dom::bindings::callback::ExceptionHandling;
 use crate::dom::bindings::cell::DomRefCell;
@@ -371,7 +371,10 @@ fn calculate_depth_for_node(target: &Element) -> ResizeObservationDepth {
 /// For `ResizeObserverBoxOptions::Content_box` and `ResizeObserverBoxOptions::Border_box`,
 /// the values will be in `px`. For `ResizeObserverBoxOptions::Device_pixel_content_box` they
 /// will be in integral device pixels.
-fn calculate_box_size(target: &Element, observed_box: &ResizeObserverBoxOptions) -> Rect<f64> {
+fn calculate_box_size(
+    target: &Element,
+    observed_box: &ResizeObserverBoxOptions,
+) -> Rect<f64, CSSPixel> {
     match observed_box {
         ResizeObserverBoxOptions::Content_box => {
             // Note: only taking first fragment,

--- a/components/script/dom/scrolling_box.rs
+++ b/components/script/dom/scrolling_box.rs
@@ -5,13 +5,13 @@
 use std::cell::Cell;
 
 use app_units::Au;
-use euclid::Vector2D;
-use euclid::default::Rect;
+use euclid::{Rect, Vector2D};
 use layout_api::{AxesOverflow, ScrollContainerQueryFlags};
 use script_bindings::codegen::GenericBindings::WindowBinding::ScrollBehavior;
 use script_bindings::inheritance::Castable;
 use script_bindings::root::DomRoot;
 use style::values::computed::Overflow;
+use style_traits::CSSPixel;
 use webrender_api::units::{LayoutSize, LayoutVector2D};
 
 use crate::dom::bindings::codegen::Bindings::ElementBinding::ScrollLogicalPosition;
@@ -190,7 +190,7 @@ impl ScrollingBox {
         &self,
         block: ScrollAxisState,
         inline: ScrollAxisState,
-        target_rect: Rect<Au>,
+        target_rect: Rect<Au, CSSPixel>,
     ) -> LayoutVector2D {
         let device_pixel_ratio = self.node().owner_window().device_pixel_ratio().get();
         let to_pixel = |value: Au| value.to_nearest_pixel(device_pixel_ratio);
@@ -199,7 +199,7 @@ impl ScrollingBox {
         // > Let target bounding border box be the box represented by the return value
         // > of invoking Element’s getBoundingClientRect(), if target is an Element,
         // > or Range’s getBoundingClientRect(), if target is a Range.
-        let target_top_left = target_rect.origin.map(to_pixel).to_untyped();
+        let target_top_left = target_rect.origin.map(to_pixel);
         let target_bottom_right = target_rect.max().map(to_pixel);
 
         // The rest of the steps diverge from the specification here, but essentially try

--- a/components/script/dom/window.rs
+++ b/components/script/dom/window.rs
@@ -42,7 +42,7 @@ use embedder_traits::{
     WebDriverJSResult, WebDriverLoadStatus,
 };
 use euclid::default::Rect as UntypedRect;
-use euclid::{Point2D, Scale, Size2D, Vector2D};
+use euclid::{Point2D, Rect, Scale, Size2D, Vector2D};
 use fonts::{CspViolationHandler, FontContext, NetworkTimingHandler, WebFontDocumentContext};
 use js::glue::DumpJSStack;
 use js::jsapi::{
@@ -2818,7 +2818,7 @@ impl Window {
         node: &Node,
         area: BoxAreaType,
         exclude_transform_and_inline: bool,
-    ) -> Option<UntypedRect<Au>> {
+    ) -> Option<Rect<Au, CSSPixel>> {
         let layout = self.layout.borrow();
         layout.ensure_stacking_context_tree(self.viewport_details.get());
         layout.query_box_area(
@@ -2833,19 +2833,23 @@ impl Window {
         node: &Node,
         area: BoxAreaType,
         exclude_transform_and_inline: bool,
-    ) -> Option<UntypedRect<Au>> {
+    ) -> Option<Rect<Au, CSSPixel>> {
         self.layout_reflow(QueryMsg::BoxArea);
         self.box_area_query_without_reflow(node, area, exclude_transform_and_inline)
     }
 
-    pub(crate) fn box_areas_query(&self, node: &Node, area: BoxAreaType) -> Vec<UntypedRect<Au>> {
+    pub(crate) fn box_areas_query(
+        &self,
+        node: &Node,
+        area: BoxAreaType,
+    ) -> Vec<Rect<Au, CSSPixel>> {
         self.layout_reflow(QueryMsg::BoxAreas);
         self.layout
             .borrow()
             .query_box_areas(node.to_trusted_node_address(), area)
     }
 
-    pub(crate) fn client_rect_query(&self, node: &Node) -> UntypedRect<i32> {
+    pub(crate) fn client_rect_query(&self, node: &Node) -> Rect<i32, CSSPixel> {
         self.layout_reflow(QueryMsg::ClientRectQuery);
         self.layout
             .borrow()
@@ -2861,7 +2865,7 @@ impl Window {
 
     /// Find the scroll area of the given node, if it is not None. If the node
     /// is None, find the scroll area of the viewport.
-    pub(crate) fn scrolling_area_query(&self, node: Option<&Node>) -> UntypedRect<i32> {
+    pub(crate) fn scrolling_area_query(&self, node: Option<&Node>) -> Rect<i32, CSSPixel> {
         self.layout_reflow(QueryMsg::ScrollingAreaOrOffsetQuery);
         self.layout
             .borrow()
@@ -2955,7 +2959,7 @@ impl Window {
     pub(crate) fn offset_parent_query(
         &self,
         node: &Node,
-    ) -> (Option<DomRoot<Element>>, UntypedRect<Au>) {
+    ) -> (Option<DomRoot<Element>>, Rect<Au, CSSPixel>) {
         self.layout_reflow(QueryMsg::OffsetParentQuery);
         let response = self
             .layout

--- a/components/shared/layout/lib.rs
+++ b/components/shared/layout/lib.rs
@@ -26,8 +26,7 @@ use base::id::{BrowsingContextId, PipelineId, WebViewId};
 use bitflags::bitflags;
 use compositing_traits::CrossProcessPaintApi;
 use embedder_traits::{Cursor, Theme, UntrustedNodeAddress, ViewportDetails};
-use euclid::Point2D;
-use euclid::default::Rect;
+use euclid::{Point2D, Rect};
 use fonts::{FontContext, WebFontDocumentContext};
 pub use layout_damage::LayoutDamage;
 use libc::c_void;
@@ -342,9 +341,13 @@ pub trait Layout {
         node: TrustedNodeAddress,
         area: BoxAreaType,
         exclude_transform_and_inline: bool,
-    ) -> Option<Rect<Au>>;
-    fn query_box_areas(&self, node: TrustedNodeAddress, area: BoxAreaType) -> Vec<Rect<Au>>;
-    fn query_client_rect(&self, node: TrustedNodeAddress) -> Rect<i32>;
+    ) -> Option<Rect<Au, CSSPixel>>;
+    fn query_box_areas(
+        &self,
+        node: TrustedNodeAddress,
+        area: BoxAreaType,
+    ) -> Vec<Rect<Au, CSSPixel>>;
+    fn query_client_rect(&self, node: TrustedNodeAddress) -> Rect<i32, CSSPixel>;
     fn query_current_css_zoom(&self, node: TrustedNodeAddress) -> f32;
     fn query_element_inner_outer_text(&self, node: TrustedNodeAddress) -> String;
     fn query_offset_parent(&self, node: TrustedNodeAddress) -> OffsetParentResponse;
@@ -370,7 +373,7 @@ pub trait Layout {
         animations: DocumentAnimationSet,
         animation_timeline_value: f64,
     ) -> Option<ServoArc<Font>>;
-    fn query_scrolling_area(&self, node: Option<TrustedNodeAddress>) -> Rect<i32>;
+    fn query_scrolling_area(&self, node: Option<TrustedNodeAddress>) -> Rect<i32, CSSPixel>;
     fn query_text_index(
         &self,
         node: TrustedNodeAddress,
@@ -420,7 +423,7 @@ pub struct PhysicalSides {
 #[derive(Clone, Default)]
 pub struct OffsetParentResponse {
     pub node_address: Option<UntrustedNodeAddress>,
-    pub rect: Rect<Au>,
+    pub rect: Rect<Au, CSSPixel>,
 }
 
 bitflags! {


### PR DESCRIPTION
This change makes it so that the euclid types returned from layout
queries use the `CSSPixel` unit type when appropriate. The minimal set
of changes are also made to avoid having to convert these types to the
`UnknownUnit` in other places. There is still some casting that has to
happen to deal with the difference between Stylo's `CSSPixel` and
WebRender's `LayoutPixel`, but a followup changes will try to switch to
using one or the other.

Testing: This should not change behavior, so is covered by existing tests.
