### PR TITLE
chore: suppress warnings when building without the testbinding feature

### DIFF
--- a/components/script/dom/debuggerglobalscope.rs
+++ b/components/script/dom/debuggerglobalscope.rs
@@ -33,7 +33,6 @@ use crate::dom::bindings::utils::define_all_exposed_interfaces;
 use crate::dom::debuggersetbreakpointevent::DebuggerSetBreakpointEvent;
 use crate::dom::globalscope::GlobalScope;
 use crate::dom::types::{DebuggerAddDebuggeeEvent, DebuggerGetPossibleBreakpointsEvent, Event};
-#[cfg(feature = "testbinding")]
 #[cfg(feature = "webgpu")]
 use crate::dom::webgpu::identityhub::IdentityHub;
 use crate::realms::{enter_auto_realm, enter_realm};

--- a/components/script/dom/worklet.rs
+++ b/components/script/dom/worklet.rs
@@ -118,6 +118,7 @@ impl Worklet {
         )
     }
 
+    #[cfg(feature = "testbinding")]
     pub(crate) fn worklet_id(&self) -> WorkletId {
         self.droppable_field.worklet_id
     }

--- a/components/script_bindings/codegen/codegen.py
+++ b/components/script_bindings/codegen/codegen.py
@@ -2968,7 +2968,7 @@ def DomTypes(descriptors: list[Descriptor],
             ]
     elements += [CGGeneric("}\n")]
     imports = [
-        CGGeneric("use crate::root::DomRoot;\n"),
+        CGGeneric("#[cfg(feature = \"testbinding\")] use crate::root::DomRoot;\n"),
         CGGeneric("use crate::domstring::DOMString;\n"),
     ]
     return CGList(imports + elements)

--- a/components/script_bindings/import.rs
+++ b/components/script_bindings/import.rs
@@ -103,9 +103,11 @@ pub(crate) mod module {
     pub(crate) use crate::codegen::{PrototypeList, RegisterBindings};
     pub(crate) use crate::constant::{ConstantSpec, ConstantVal};
     pub(crate) use crate::constructor::call_default_constructor;
+    #[cfg(feature = "testbinding")]
+    pub(crate) use crate::conversions::native_from_handlevalue;
     pub(crate) use crate::conversions::{
         DOM_OBJECT_SLOT, StringificationBehavior, is_array_like, jsid_to_string,
-        native_from_handlevalue, native_from_object_static,
+        native_from_object_static,
     };
     pub(crate) use crate::error::{Error, ErrorResult};
     pub(crate) use crate::finalize::{
@@ -121,14 +123,18 @@ pub(crate) mod module {
         define_guarded_properties, get_per_interface_object_handle, is_exposed_in,
     };
     pub(crate) use crate::iterable::{Iterable, IterableIterator, IteratorType};
-    pub(crate) use crate::like::{Maplike, Setlike};
+    #[cfg(feature = "testbinding")]
+    pub(crate) use crate::like::Maplike;
+    pub(crate) use crate::like::Setlike;
     pub(crate) use crate::mem::malloc_size_of_including_raw_self;
     pub(crate) use crate::namespace::{NamespaceObjectClass, create_namespace_object};
     pub(crate) use crate::proxyhandler::{
         ensure_expando_object, get_expando_object, set_property_descriptor,
     };
     pub(crate) use crate::realms::{AlreadyInRealm, InRealm};
-    pub(crate) use crate::root::{Dom, DomSlice, MaybeUnreflectedDom, Root};
+    #[cfg(feature = "testbinding")]
+    pub(crate) use crate::root::{Dom, DomSlice};
+    pub(crate) use crate::root::{MaybeUnreflectedDom, Root};
     pub(crate) use crate::script_runtime::CanGc;
     pub(crate) use crate::utils::{
         AsVoidPtr, DOM_PROTO_UNFORGEABLE_HOLDER_SLOT, DOMClass, DOMJSClass, JSCLASS_DOM_GLOBAL,


### PR DESCRIPTION
When building without the `testbinding` feature of `libservo`, we end up with these compilation warnings (and one error):

```
warning: unused import: `native_from_handlevalue`
   --> components/script_bindings/import.rs:108:9
    |
108 |         native_from_handlevalue, native_from_object_static,
    |         ^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: `#[warn(unused_imports)]` (part of `#[warn(unused)]`) on by default

warning: unused imports: `DomSlice` and `Dom`
   --> components/script_bindings/import.rs:131:34
    |
131 |     pub(crate) use crate::root::{Dom, DomSlice, MaybeUnreflectedDom, Root};
    |                                  ^^^  ^^^^^^^^

warning: unused import: `crate::root::DomRoot`
 --> /home/webbeef/servo/target/debug/build/script_bindings-9c5650a8d750af8f/out/DomTypes.rs:3:5
  |
3 | use crate::root::DomRoot;
  |     ^^^^^^^^^^^^^^^^^^^^

warning: unused import: `Maplike`
   --> components/script_bindings/import.rs:124:34
    |
124 |     pub(crate) use crate::like::{Maplike, Setlike};
    |                                  ^^^^^^^

warning: `script_bindings` (lib) generated 4 warnings (run `cargo fix --lib -p script_bindings` to apply 3 suggestions)
error[E0412]: cannot find type `IdentityHub` in this scope
  --> components/script/dom/debuggerglobalscope.rs:76:63
   |
76 |         #[cfg(feature = "webgpu")] gpu_id_hub: std::sync::Arc<IdentityHub>,
   |                                                               ^^^^^^^^^^^ not found in this scope
   |
help: consider importing this struct
   |
 5 + use crate::dom::identityhub::IdentityHub;
   |

warning: method `worklet_id` is never used
   --> components/script/dom/worklet.rs:121:19
    |
 95 | impl Worklet {
    | ------------ method in this implementation
...
121 |     pub(crate) fn worklet_id(&self) -> WorkletId {
    |                   ^^^^^^^^^^
    |
    = note: `#[warn(dead_code)]` (part of `#[warn(unused)]`) on by default
```

Testing: No test needed, this won't change the default builds.

