### PR TITLE
script: Expose `toJSON` on `LargestContentfulPaint`

### DIFF
--- a/components/config/prefs.rs
+++ b/components/config/prefs.rs
@@ -253,6 +253,7 @@ pub struct Preferences {
     pub js_wasm_enabled: bool,
     pub js_wasm_ion_enabled: bool,
     pub js_werror_enabled: bool,
+    // feature: Largest Contentful Paint | #42000 | Web/API/LargestContentfulPaint
     pub largest_contentful_paint_enabled: bool,
     pub layout_animations_test_enabled: bool,
     // feature: CSS Multicol | #22397 | Web/CSS/Guides/Multicol_layout

--- a/components/script_bindings/webidls/LargestContentfulPaint.webidl
+++ b/components/script_bindings/webidls/LargestContentfulPaint.webidl
@@ -6,10 +6,11 @@
  * https://w3c.github.io/largest-contentful-paint/#sec-largest-contentful-paint-interface
  */
 
-[Exposed=Window]
+[Exposed=Window, Pref="largest_contentful_paint_enabled"]
 interface LargestContentfulPaint : PerformanceEntry {
     readonly attribute DOMHighResTimeStamp loadTime;
     readonly attribute DOMHighResTimeStamp renderTime;
     readonly attribute unsigned long size;
     readonly attribute Element? element;
+    [Default] object toJSON();
 };

--- a/components/servo/Cargo.toml
+++ b/components/servo/Cargo.toml
@@ -156,6 +156,10 @@ tracing = { workspace = true }
 winit = { workspace = true }
 
 [[test]]
+name = "largest_contentful_paint"
+path = "tests/largest_contentful_paint.rs"
+
+[[test]]
 name = "network_manager"
 
 [[test]]

--- a/components/servo/tests/largest_contentful_paint.rs
+++ b/components/servo/tests/largest_contentful_paint.rs
@@ -1,0 +1,72 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+//! Largest Contententful Paint JS API unit tests.
+mod common;
+
+use std::rc::Rc;
+
+use servo::{JSValue, WebViewBuilder};
+use servo_config::prefs::Preferences;
+use url::Url;
+
+use crate::common::{
+    ServoTest, WebViewDelegateImpl, evaluate_javascript,
+    show_webview_and_wait_for_rendering_to_be_ready,
+};
+
+#[test]
+fn test_largest_contentful_paint_js_api() {
+    let servo_test = ServoTest::new_with_builder(|builder| {
+        let mut preferences = Preferences::default();
+        preferences.largest_contentful_paint_enabled = true;
+        builder.preferences(preferences)
+    });
+
+    let delegate = Rc::new(WebViewDelegateImpl::default());
+    let webview = WebViewBuilder::new(servo_test.servo(), servo_test.rendering_context.clone())
+        .delegate(delegate.clone())
+        .url(
+            Url::parse(
+                "data:text/html,<!DOCTYPE html>\
+                <a href=\"https://servo.org\"><div style=\"width: 50px; height: 50px;\">Link</div></a> \
+                <div><img src=\"data:image/svg+xml,<svg width='50' height='50'><circle cx='25' cy='25' r='20' fill='green'/></svg>\"\
+                style=\"width: 50px; height: 50px;\"></div>"
+            )
+            .unwrap(),
+        )
+        .build();
+
+    let lcp_script = "(async () => {
+        window.lcp = await new Promise(resolve => {
+            (new PerformanceObserver(entryList => {
+                resolve(entryList.getEntries()[0]);
+            }))
+            .observe({type: 'largest-contentful-paint', buffered: true});
+        })
+    })();";
+
+    if let Err(err) = evaluate_javascript(&servo_test, webview.clone(), lcp_script) {
+        panic!("Failed to evaluate LCP setup script: {:?}", err);
+    }
+
+    show_webview_and_wait_for_rendering_to_be_ready(&servo_test, &webview, &delegate);
+
+    // Read from a global variable used to store the result since evaluate_javascript doesn't handle Promises
+    let lcp = evaluate_javascript(&servo_test, webview.clone(), "window.lcp.toJSON();");
+
+    if let Ok(JSValue::Object(obj)) = lcp {
+        assert_eq!(obj.get("name"), Some(JSValue::String("".into())).as_ref());
+        assert_eq!(obj.get("duration"), Some(JSValue::Number(0.0)).as_ref());
+        assert_eq!(
+            obj.get("entryType"),
+            Some(JSValue::String("largest-contentful-paint".into())).as_ref()
+        );
+        assert_eq!(obj.get("size"), Some(JSValue::Number(2500.0)).as_ref());
+        assert!(obj.get("renderTime").is_some());
+        assert!(obj.get("loadTime").is_some());
+    } else {
+        panic!("No entries for Largest Contentful Paint were recorded.");
+    }
+}

--- a/tests/wpt/mozilla/meta/MANIFEST.json
+++ b/tests/wpt/mozilla/meta/MANIFEST.json
@@ -13971,7 +13971,7 @@
      ]
     ],
     "interfaces.https.html": [
-     "5b66f476e120ce2788e908b276cadfc028f21058",
+     "b9f02aaa2e94912f98ba18b4b6e3086f7bfd8eb0",
      [
       null,
       {}

--- a/tests/wpt/mozilla/tests/mozilla/interfaces.https.html
+++ b/tests/wpt/mozilla/tests/mozilla/interfaces.https.html
@@ -237,7 +237,6 @@ test_interfaces([
   "IntersectionObserver",
   "IntersectionObserverEntry",
   "KeyboardEvent",
-  "LargestContentfulPaint",
   "Location",
   "MediaElementAudioSourceNode",
   "MediaError",


### PR DESCRIPTION
This PR targets on adding JSON to `IDL` to show all supported values in JS API.

This was missed during implementation. Screenshot Attached for JS API 

Testing: `components/servo/tests/largest_contentful_paint.rs` 
Fixes: None, this is just an refinement.

<img width="772" height="360" alt="Screenshot from 2026-01-19 17-13-20" src="https://github.com/user-attachments/assets/1730f3f6-423c-466c-b0d4-976d35d82827" />

