### PR TITLE
devtools: Fix failures in `mach test-devtools`

### DIFF
--- a/components/devtools/actors/source.rs
+++ b/components/devtools/actors/source.rs
@@ -281,9 +281,9 @@ impl Actor for SourceActor {
                     // Line number are one-based. Column numbers are zero-based.
                     // FIXME: the docs say column numbers are one-based, but this appears to be incorrect.
                     // <https://firefox-source-docs.mozilla.org/devtools/backend/protocol.html#source-locations>
-                    if let Some((start, end)) = &query &&
-                        (location.line_number < start.line || location.line_number > end.line)
-                    {
+                    if query.as_ref().is_some_and(|(start, end)| {
+                        location.line_number < start.line || location.line_number > end.line
+                    }) {
                         continue;
                     }
                     positions

--- a/components/devtools/resource.rs
+++ b/components/devtools/resource.rs
@@ -39,10 +39,6 @@ pub(crate) trait ResourceAvailable {
         array_type: ResourceArrayType,
         stream: &mut S,
     ) {
-        if resources.is_empty() {
-            return;
-        }
-
         let msg = ResourceAvailableReply::<T> {
             from: self.actor_name(),
             type_: match array_type {


### PR DESCRIPTION
Make the `start` and `end` parameters in `getBreakpointPositionsCompressed` optional.

Send a resource array even if it is empty.

Testing: Ran `mach test-devtools`.
