### PR TITLE
devtools: Handle pause in the debugger

### DIFF
--- a/components/devtools/actors/browsing_context.rs
+++ b/components/devtools/actors/browsing_context.rs
@@ -240,7 +240,7 @@ impl BrowsingContextActor {
 
         let tabdesc = TabDescriptorActor::new(actors, name.clone(), is_top_level_global);
 
-        let thread = ThreadActor::new(actors.new_name::<ThreadActor>());
+        let thread = ThreadActor::new(actors.new_name::<ThreadActor>(), script_sender.clone());
 
         let watcher = WatcherActor::new(
             actors,

--- a/components/devtools/actors/console.rs
+++ b/components/devtools/actors/console.rs
@@ -186,7 +186,7 @@ impl ConsoleActor {
             ActorValue { class, uuid } => {
                 // TODO: Make initial ActorValue message include these properties?
                 let mut m = Map::new();
-                let actor = ObjectActor::register(registry, uuid);
+                let actor = ObjectActor::register(registry, Some(uuid));
 
                 m.insert("type".to_owned(), Value::String("object".to_owned()));
                 m.insert("class".to_owned(), Value::String(class));
@@ -199,6 +199,7 @@ impl ConsoleActor {
         };
 
         // TODO: Catch and return exception values from JS evaluation
+        // TODO: This should have a has_exception field
         let reply = EvaluateJSReply {
             from: self.name(),
             input,

--- a/components/devtools/actors/frame.rs
+++ b/components/devtools/actors/frame.rs
@@ -45,8 +45,7 @@ pub(crate) struct FrameActorMsg {
     display_name: String,
     oldest: bool,
     state: FrameState,
-    #[serde(rename = "this")]
-    this_: ObjectActorMsg,
+    this: ObjectActorMsg,
     #[serde(rename = "where")]
     where_: FrameWhere,
 }
@@ -132,7 +131,7 @@ impl ActorEncode<FrameActorMsg> for FrameActor {
             async_cause,
             // TODO: Should be optional
             display_name: self.frame_result.display_name.clone(),
-            this_: registry.encode::<ObjectActor, _>(&self.object_actor),
+            this: registry.encode::<ObjectActor, _>(&self.object_actor),
             oldest: self.frame_result.oldest,
             state,
             where_: FrameWhere {

--- a/components/devtools/actors/frame.rs
+++ b/components/devtools/actors/frame.rs
@@ -2,15 +2,14 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-// TODO: Remove once the actor is used
-#![expect(dead_code)]
-
+use devtools_traits::PauseFrameResult;
 use serde::Serialize;
 use serde_json::{Map, Value};
 
 use crate::StreamId;
 use crate::actor::{Actor, ActorEncode, ActorError, ActorRegistry};
 use crate::actors::environment::{EnvironmentActor, EnvironmentActorMsg};
+use crate::actors::object::{ObjectActor, ObjectActorMsg};
 use crate::protocol::ClientRequest;
 
 #[derive(Serialize)]
@@ -24,8 +23,8 @@ struct FrameEnvironmentReply {
 #[serde(rename_all = "kebab-case")]
 pub enum FrameState {
     OnStack,
-    Suspended,
-    Dead,
+    _Suspended,
+    _Dead,
 }
 
 #[derive(Serialize)]
@@ -46,6 +45,8 @@ pub(crate) struct FrameActorMsg {
     display_name: String,
     oldest: bool,
     state: FrameState,
+    #[serde(rename = "this")]
+    this_: ObjectActorMsg,
     #[serde(rename = "where")]
     where_: FrameWhere,
 }
@@ -54,7 +55,9 @@ pub(crate) struct FrameActorMsg {
 /// <https://searchfox.org/firefox-main/source/devtools/server/actors/frame.js>
 pub(crate) struct FrameActor {
     name: String,
+    object_actor: String,
     source_actor: String,
+    frame_result: PauseFrameResult,
 }
 
 impl Actor for FrameActor {
@@ -82,7 +85,9 @@ impl Actor for FrameActor {
                     environment: environment.encode(registry),
                 };
                 registry.register(environment);
-                request.reply_final(&msg)?
+                // This reply has a `type` field but it doesn't need a followup,
+                // unlike most messages. We need to skip the validity check.
+                request.reply_unchecked(&msg)?;
             },
             _ => return Err(ActorError::UnrecognizedPacketType),
         };
@@ -90,8 +95,28 @@ impl Actor for FrameActor {
     }
 }
 
+impl FrameActor {
+    pub fn register(
+        registry: &ActorRegistry,
+        source_actor: String,
+        frame_result: PauseFrameResult,
+    ) -> String {
+        let object_actor = ObjectActor::register(registry, None);
+
+        let name = registry.new_name::<Self>();
+        let actor = Self {
+            name: name.clone(),
+            object_actor,
+            source_actor,
+            frame_result,
+        };
+        registry.register::<Self>(actor);
+        name
+    }
+}
+
 impl ActorEncode<FrameActorMsg> for FrameActor {
-    fn encode(&self, _: &ActorRegistry) -> FrameActorMsg {
+    fn encode(&self, registry: &ActorRegistry) -> FrameActorMsg {
         // TODO: Handle other states
         let state = FrameState::OnStack;
         let async_cause = if let FrameState::OnStack = state {
@@ -99,18 +124,21 @@ impl ActorEncode<FrameActorMsg> for FrameActor {
         } else {
             Some("await".into())
         };
+        // <https://searchfox.org/firefox-main/source/devtools/docs/user/debugger-api/debugger.frame/index.rst>
         FrameActorMsg {
             actor: self.name(),
-            type_: "call".into(),
+            type_: self.frame_result.type_.clone(),
             arguments: vec![],
             async_cause,
-            display_name: "".into(), // TODO: get display name
-            oldest: true,
+            // TODO: Should be optional
+            display_name: self.frame_result.display_name.clone(),
+            this_: registry.encode::<ObjectActor, _>(&self.object_actor),
+            oldest: self.frame_result.oldest,
             state,
             where_: FrameWhere {
                 actor: self.source_actor.clone(),
-                line: 1, // TODO: get from breakpoint?
-                column: 1,
+                line: self.frame_result.line,
+                column: self.frame_result.column,
             },
         }
     }

--- a/components/devtools/actors/object.rs
+++ b/components/devtools/actors/object.rs
@@ -29,7 +29,7 @@ pub(crate) struct ObjectActorMsg {
 
 pub(crate) struct ObjectActor {
     name: String,
-    _uuid: String,
+    _uuid: Option<String>,
 }
 
 impl Actor for ObjectActor {
@@ -42,12 +42,21 @@ impl Actor for ObjectActor {
 }
 
 impl ObjectActor {
-    pub fn register(registry: &ActorRegistry, uuid: String) -> String {
+    pub fn register(registry: &ActorRegistry, uuid: Option<String>) -> String {
+        let Some(uuid) = uuid else {
+            let name = registry.new_name::<Self>();
+            let actor = ObjectActor {
+                name: name.clone(),
+                _uuid: None,
+            };
+            registry.register(actor);
+            return name;
+        };
         if !registry.script_actor_registered(uuid.clone()) {
             let name = registry.new_name::<Self>();
             let actor = ObjectActor {
                 name: name.clone(),
-                _uuid: uuid.clone(),
+                _uuid: Some(uuid.clone()),
             };
 
             registry.register_script_actor(uuid, name.clone());
@@ -74,7 +83,7 @@ impl ActorEncode<ObjectActorMsg> for ObjectActor {
             is_error: false,
             preview: ObjectPreview {
                 kind: "ObjectWithURL".into(),
-                url: "".into(),
+                url: "".into(), // TODO: Use the correct url
             },
         }
     }

--- a/components/devtools/actors/source.rs
+++ b/components/devtools/actors/source.rs
@@ -46,6 +46,26 @@ pub(crate) struct SourceManager {
 }
 
 impl SourceManager {
+    pub fn new() -> Self {
+        Self {
+            source_actor_names: AtomicRefCell::new(BTreeSet::default()),
+        }
+    }
+
+    pub fn add_source(&self, actor_name: &str) {
+        self.source_actor_names
+            .borrow_mut()
+            .insert(actor_name.to_owned());
+    }
+
+    pub fn source_forms(&self, actors: &ActorRegistry) -> Vec<SourceForm> {
+        self.source_actor_names
+            .borrow()
+            .iter()
+            .map(|actor_name| actors.find::<SourceActor>(actor_name).source_form())
+            .collect()
+    }
+
     pub fn find_source(
         &self,
         registry: &ActorRegistry,
@@ -118,28 +138,6 @@ struct GetBreakpointPositionsQuery {
 #[derive(Deserialize)]
 struct GetBreakpointPositionsRequest {
     query: GetBreakpointPositionsQuery,
-}
-
-impl SourceManager {
-    pub fn new() -> Self {
-        Self {
-            source_actor_names: AtomicRefCell::new(BTreeSet::default()),
-        }
-    }
-
-    pub fn add_source(&self, actor_name: &str) {
-        self.source_actor_names
-            .borrow_mut()
-            .insert(actor_name.to_owned());
-    }
-
-    pub fn source_forms(&self, actors: &ActorRegistry) -> Vec<SourceForm> {
-        self.source_actor_names
-            .borrow()
-            .iter()
-            .map(|actor_name| actors.find::<SourceActor>(actor_name).source_form())
-            .collect()
-    }
 }
 
 impl SourceActor {

--- a/components/devtools/lib.rs
+++ b/components/devtools/lib.rs
@@ -352,7 +352,7 @@ impl DevtoolsInstance {
             assert!(self.pipelines.contains_key(&pipeline_id));
             assert!(self.browsing_contexts.contains_key(&browsing_context_id));
 
-            let thread = ThreadActor::new(actors.new_name::<ThreadActor>());
+            let thread = ThreadActor::new(actors.new_name::<ThreadActor>(), script_sender.clone());
             let thread_name = thread.name();
             actors.register(thread);
 

--- a/components/devtools/protocol.rs
+++ b/components/devtools/protocol.rs
@@ -142,6 +142,15 @@ impl<'req> ClientRequest<'req, '_> {
     /// allowing other messages to be sent after replying to a request.
     pub fn reply<T: Serialize>(self, reply: &T) -> Result<&'req mut TcpStream, ActorError> {
         debug_assert!(self.is_valid_reply(reply), "Message is not a valid reply");
+        self.reply_unchecked(reply)
+    }
+
+    /// Like `reply`, but it doesn't check if it is a valid reply.
+    /// Sometimes the client breaks the rules and expects an out of form message.
+    pub fn reply_unchecked<T: Serialize>(
+        self,
+        reply: &T,
+    ) -> Result<&'req mut TcpStream, ActorError> {
         self.stream.write_json_packet(reply)?;
         *self.sent = true;
         Ok(self.stream)
@@ -149,7 +158,6 @@ impl<'req> ClientRequest<'req, '_> {
 
     /// Like `reply`, but for cases where the actor no longer needs the stream.
     pub fn reply_final<T: Serialize>(self, reply: &T) -> Result<(), ActorError> {
-        debug_assert!(self.is_valid_reply(reply), "Message is not a valid reply");
         let _stream = self.reply(reply)?;
         Ok(())
     }

--- a/components/script/dom/debuggerglobalscope.rs
+++ b/components/script/dom/debuggerglobalscope.rs
@@ -162,7 +162,7 @@ impl DebuggerGlobalScope {
             can_gc,
         ));
         assert!(
-            DomRoot::upcast::<Event>(event).fire(self.upcast(), can_gc),
+            event.fire(self.upcast(), can_gc),
             "Guaranteed by DebuggerAddDebuggeeEvent::new"
         );
     }
@@ -185,7 +185,7 @@ impl DebuggerGlobalScope {
             can_gc,
         ));
         assert!(
-            DomRoot::upcast::<Event>(event).fire(self.upcast(), can_gc),
+            event.fire(self.upcast(), can_gc),
             "Guaranteed by DebuggerGetPossibleBreakpointsEvent::new"
         );
     }
@@ -205,7 +205,7 @@ impl DebuggerGlobalScope {
             can_gc,
         ));
         assert!(
-            DomRoot::upcast::<Event>(event).fire(self.upcast(), can_gc),
+            event.fire(self.upcast(), can_gc),
             "Guaranteed by DebuggerSetBreakpointEvent::new"
         );
     }
@@ -222,7 +222,7 @@ impl DebuggerGlobalScope {
         );
         let event = DomRoot::upcast::<Event>(DebuggerPauseEvent::new(self.upcast(), can_gc));
         assert!(
-            DomRoot::upcast::<Event>(event).fire(self.upcast(), can_gc),
+            event.fire(self.upcast(), can_gc),
             "Guaranteed by DebuggerPauseEvent::new"
         );
     }

--- a/components/script/dom/debuggerglobalscope.rs
+++ b/components/script/dom/debuggerglobalscope.rs
@@ -26,10 +26,12 @@ use servo_url::{ImmutableOrigin, MutableOrigin, ServoUrl};
 use storage_traits::StorageThreads;
 
 use crate::dom::bindings::codegen::Bindings::DebuggerGlobalScopeBinding;
+use crate::dom::bindings::codegen::Bindings::DebuggerPauseEventBinding::PauseFrameResult;
 use crate::dom::bindings::error::report_pending_exception;
 use crate::dom::bindings::inheritance::Castable;
 use crate::dom::bindings::root::DomRoot;
 use crate::dom::bindings::utils::define_all_exposed_interfaces;
+use crate::dom::debuggerpauseevent::DebuggerPauseEvent;
 use crate::dom::debuggersetbreakpointevent::DebuggerSetBreakpointEvent;
 use crate::dom::globalscope::GlobalScope;
 use crate::dom::types::{DebuggerAddDebuggeeEvent, DebuggerGetPossibleBreakpointsEvent, Event};
@@ -51,7 +53,7 @@ pub(crate) struct DebuggerGlobalScope {
     get_possible_breakpoints_result_sender:
         RefCell<Option<GenericSender<Vec<devtools_traits::RecommendedBreakpointLocation>>>>,
     #[no_trace]
-    set_breakpoint_result_sender: RefCell<Option<GenericSender<bool>>>,
+    get_frame_result_sender: RefCell<Option<GenericSender<devtools_traits::PauseFrameResult>>>,
 }
 
 impl DebuggerGlobalScope {
@@ -98,7 +100,7 @@ impl DebuggerGlobalScope {
             ),
             devtools_to_script_sender,
             get_possible_breakpoints_result_sender: RefCell::new(None),
-            set_breakpoint_result_sender: RefCell::new(None),
+            get_frame_result_sender: RefCell::new(None),
         });
         let global = DebuggerGlobalScopeBinding::Wrap::<crate::DomTypeHolder>(cx.into(), global);
 
@@ -205,6 +207,23 @@ impl DebuggerGlobalScope {
         assert!(
             DomRoot::upcast::<Event>(event).fire(self.upcast(), can_gc),
             "Guaranteed by DebuggerSetBreakpointEvent::new"
+        );
+    }
+
+    pub(crate) fn fire_pause(
+        &self,
+        can_gc: CanGc,
+        result_sender: GenericSender<devtools_traits::PauseFrameResult>,
+    ) {
+        assert!(
+            self.get_frame_result_sender
+                .replace(Some(result_sender))
+                .is_none()
+        );
+        let event = DomRoot::upcast::<Event>(DebuggerPauseEvent::new(self.upcast(), can_gc));
+        assert!(
+            DomRoot::upcast::<Event>(event).fire(self.upcast(), can_gc),
+            "Guaranteed by DebuggerPauseEvent::new"
         );
     }
 }
@@ -327,5 +346,23 @@ impl DebuggerGlobalScopeMethods<crate::DomTypeHolder> for DebuggerGlobalScope {
                 })
                 .collect(),
         );
+    }
+
+    fn GetFrameResult(&self, event: &DebuggerPauseEvent, result: &PauseFrameResult) {
+        info!("GetFrameResult: {event:?} {result:?}");
+        let sender = self
+            .get_frame_result_sender
+            .take()
+            .expect("Guaranteed by Self::fire_get_frame()");
+        let _ = sender.send(devtools_traits::PauseFrameResult {
+            column: result.column,
+            display_name: result.displayName.clone().into(),
+            line: result.line,
+            on_stack: result.onStack,
+            oldest: result.oldest,
+            terminated: result.terminated,
+            type_: result.type_.clone().into(),
+            url: result.url.clone().into(),
+        });
     }
 }

--- a/components/script/dom/debuggerpauseevent.rs
+++ b/components/script/dom/debuggerpauseevent.rs
@@ -1,0 +1,46 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+use std::fmt::Debug;
+
+use dom_struct::dom_struct;
+
+use crate::dom::bindings::codegen::Bindings::DebuggerPauseEventBinding::DebuggerPauseEventMethods;
+use crate::dom::bindings::codegen::Bindings::EventBinding::Event_Binding::EventMethods;
+use crate::dom::bindings::reflector::reflect_dom_object;
+use crate::dom::bindings::root::DomRoot;
+use crate::dom::event::Event;
+use crate::dom::types::GlobalScope;
+use crate::script_runtime::CanGc;
+
+#[dom_struct]
+/// Event for Rust → JS calls in [`crate::dom::DebuggerGlobalScope`].
+pub(crate) struct DebuggerPauseEvent {
+    event: Event,
+}
+
+impl DebuggerPauseEvent {
+    pub(crate) fn new(debugger_global: &GlobalScope, can_gc: CanGc) -> DomRoot<Self> {
+        let result = Box::new(Self {
+            event: Event::new_inherited(),
+        });
+        let result = reflect_dom_object(result, debugger_global, can_gc);
+        result.event.init_event("pause".into(), false, false);
+
+        result
+    }
+}
+
+impl DebuggerPauseEventMethods<crate::DomTypeHolder> for DebuggerPauseEvent {
+    // check-tidy: no specs after this line
+    fn IsTrusted(&self) -> bool {
+        self.event.IsTrusted()
+    }
+}
+
+impl Debug for DebuggerPauseEvent {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("DebuggerPauseEvent").finish()
+    }
+}

--- a/components/script/dom/mod.rs
+++ b/components/script/dom/mod.rs
@@ -263,6 +263,7 @@ pub(crate) mod datatransferitemlist;
 pub(crate) mod debuggeradddebuggeeevent;
 pub(crate) mod debuggergetpossiblebreakpointsevent;
 pub(crate) mod debuggerglobalscope;
+pub(crate) mod debuggerpauseevent;
 pub(crate) mod debuggersetbreakpointevent;
 pub(crate) mod decompressionstream;
 pub(crate) mod defaultteereadrequest;

--- a/components/script/script_thread.rs
+++ b/components/script/script_thread.rs
@@ -2182,6 +2182,10 @@ impl ScriptThread {
                     offset,
                 );
             },
+            DevtoolScriptControlMsg::Pause(result_sender) => {
+                self.debugger_global
+                    .fire_pause(CanGc::from_cx(cx), result_sender);
+            },
         }
     }
 

--- a/components/script_bindings/codegen/Bindings.conf
+++ b/components/script_bindings/codegen/Bindings.conf
@@ -974,6 +974,10 @@ Dictionaries = {
     'derives': ['Debug'],
 },
 
+'PauseFrameResult': {
+    'derives': ['Debug'],
+},
+
 'Report': {
     'derives': ['Clone', 'MallocSizeOf'],
 },

--- a/components/script_bindings/webidls/DebuggerPauseEvent.webidl
+++ b/components/script_bindings/webidls/DebuggerPauseEvent.webidl
@@ -1,0 +1,25 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+// This interface is entirely internal to Servo, and should not be accessible to
+// web pages.
+[Exposed=DebuggerGlobalScope]
+interface DebuggerPauseEvent : Event {};
+
+partial interface DebuggerGlobalScope {
+    undefined getFrameResult(
+        DebuggerPauseEvent event,
+        PauseFrameResult result);
+};
+
+dictionary PauseFrameResult {
+    required unsigned long column;
+    required DOMString displayName;
+    required unsigned long line;
+    required boolean onStack;
+    required boolean oldest;
+    required boolean terminated;
+    required DOMString type_;
+    required DOMString url;
+};

--- a/components/shared/devtools/lib.rs
+++ b/components/shared/devtools/lib.rs
@@ -309,6 +309,7 @@ pub enum DevtoolScriptControlMsg {
 
     GetPossibleBreakpoints(u32, GenericSender<Vec<RecommendedBreakpointLocation>>),
     SetBreakpoint(u32, u32, u32),
+    Pause(GenericSender<PauseFrameResult>),
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -622,4 +623,18 @@ pub struct RecommendedBreakpointLocation {
     pub line_number: u32,
     pub column_number: u32,
     pub is_step_start: bool,
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct PauseFrameResult {
+    pub column: u32,
+    pub display_name: String,
+    pub line: u32,
+    pub on_stack: bool,
+    pub oldest: bool,
+    pub terminated: bool,
+    #[serde(rename = "type")]
+    pub type_: String,
+    pub url: String,
 }

--- a/resources/debugger.js
+++ b/resources/debugger.js
@@ -77,3 +77,24 @@ addEventListener("setBreakpoint", event => {
     }
     setBreakpointRecursive(script);
 });
+
+// <https://firefox-source-docs.mozilla.org/js/Debugger/Debugger.Frame.html>
+addEventListener("pause", event => {
+    dbg.onEnterFrame = function(frame) {
+        dbg.onEnterFrame = undefined;
+        // TODO: Some properties throw if terminated is true
+        // TODO: Check if start line / column is correct or we need the proper breakpoint
+        let result = {
+           // TODO: arguments: frame.arguments,
+           column: frame.script.startColumn,
+           displayName: frame.script.displayName,
+           line: frame.script.startLine,
+           onStack: frame.onStack,
+           oldest: frame.older == null,
+           terminated: frame.terminated,
+           type_: frame.type,
+           url: frame.script.url,
+        };
+        getFrameResult(event, result);
+    };
+});


### PR DESCRIPTION
Add an event listener for `pause` to `debugger.js` and the necessary glue to access it from the `devtools` crate. This returns important information to know where we are paused, such as the source location and frame state.

Fix frame and object actor encoding into messages. Use information from `debugger.js` to correctly fill the fields.

Add a new `frames` list to the thread actor and handle the `frames` message.

Fix `getEnvironment` reply in the frame actor. It is out of form (has a `type` field but it doesn't require a followup empty message, it already counts as a reply), so we need to handle it specially.

Note: For now we are focusing on the protocol side of the debugger, and this patch only shows where the pause would happen. Pausing Servo itself will happen in a followup.

![Debugger showing the line where execution would be paused](https://github.com/user-attachments/assets/c007f205-0ccd-47f1-ad0b-81b7415e8211)

Testing: `mach test-devtools` and manual testing. No errors (apart from #42006).
Part of: #36027