### PR TITLE
fonts: Store `ByteIndex` as a `usize`

### DIFF
--- a/components/fonts/font.rs
+++ b/components/fonts/font.rs
@@ -481,7 +481,7 @@ impl Font {
             });
 
             let glyph = GlyphData::new(glyph_id, advance, offset, true, true);
-            glyphs.add_glyph_for_byte_index(ByteIndex(i as isize), character, &glyph);
+            glyphs.add_glyph_for_byte_index(ByteIndex(i), character, &glyph);
             prev_glyph_id = Some(glyph_id);
         }
         glyphs.finalize_changes();

--- a/components/fonts/shapers/mod.rs
+++ b/components/fonts/shapers/mod.rs
@@ -153,7 +153,7 @@ fn shape_text_harfbuzz<ShapedGlyphData: HarfBuzzShapedGlyphData>(
 
         // Now byte_range is the ligature clump formed by the glyphs in glyph_span.
         // We will save these glyphs to the glyph store at the index of the first byte.
-        let byte_idx = ByteIndex(byte_range.start as isize);
+        let byte_idx = ByteIndex(byte_range.start);
 
         if glyph_span.len() == 1 {
             // Fast path: 1-to-1 mapping of byte offset to single glyph.

--- a/components/layout/flow/inline/text_run.rs
+++ b/components/layout/flow/inline/text_run.rs
@@ -160,7 +160,7 @@ impl TextRunSegment {
                 ifc.process_soft_wrap_opportunity();
             }
 
-            let range_start = byte_processed + ByteIndex(self.range.start as isize);
+            let range_start = byte_processed + ByteIndex(self.range.start);
             ifc.push_glyph_store_to_unbreakable_segment(
                 run.glyph_store.clone(),
                 text_run,
@@ -183,10 +183,7 @@ impl TextRunSegment {
             glyph_store: self
                 .font
                 .shape_text(&formatting_context_text[range.clone()], options),
-            range: TextByteRange::new(
-                ByteIndex(range.start as isize),
-                ByteIndex(range.end as isize),
-            ),
+            range: TextByteRange::new(ByteIndex(range.start), ByteIndex(range.end)),
         });
     }
 

--- a/components/script/layout_dom/node.rs
+++ b/components/script/layout_dom/node.rs
@@ -383,12 +383,8 @@ impl<'dom> ThreadSafeLayoutNode<'dom> for ServoThreadSafeLayoutNode<'dom> {
     fn selection(&self) -> Option<TextByteRange> {
         let this = unsafe { self.get_jsmanaged() };
 
-        this.selection().map(|range| {
-            TextByteRange::new(
-                ByteIndex(range.start as isize),
-                ByteIndex(range.end as isize),
-            )
-        })
+        this.selection()
+            .map(|range| TextByteRange::new(ByteIndex(range.start), ByteIndex(range.end)))
     }
 
     fn image_url(&self) -> Option<ServoUrl> {

--- a/components/shared/fonts/lib.rs
+++ b/components/shared/fonts/lib.rs
@@ -9,7 +9,7 @@ mod font_identifier;
 mod font_template;
 mod system_font_service_proxy;
 
-use std::ops::{Deref, Neg, Range};
+use std::ops::{Deref, Range};
 use std::sync::Arc;
 
 use base::generic_channel::GenericSharedMemory;
@@ -40,20 +40,11 @@ use webrender_api::euclid::num::One;
     Serialize,
     Zero,
 )]
-pub struct ByteIndex(pub isize);
+pub struct ByteIndex(pub usize);
 
-impl From<ByteIndex> for usize {
-    fn from(value: ByteIndex) -> Self {
-        value.0 as usize
-    }
-}
-
-impl Neg for ByteIndex {
-    type Output = Self;
-
-    #[inline]
-    fn neg(self) -> Self {
-        Self(-self.0)
+impl ByteIndex {
+    pub fn get(&self) -> usize {
+        self.0
     }
 }
 


### PR DESCRIPTION
This value is supposed to represent a UTF-8 code point offset or
length. It should never be negative and we often need to convert it to a
`usize`, so we can store it as a `usize`.

Testing: This should not change behavior so existing tests should suffice.
