### PR TITLE
script: Set `MouseEvent` properties according to the UI Events specification

### DIFF
--- a/tests/wpt/meta/uievents/mouse/attributes.html.ini
+++ b/tests/wpt/meta/uievents/mouse/attributes.html.ini
@@ -1,3 +1,0 @@
-[attributes.html]
-  [MouseEvent attributes]
-    expected: FAIL


### PR DESCRIPTION
The UI Events specification has a table of UIEvents which describes the
properties that they must have. Importantly, this includes whether the
event should bubble, be cancelable, and be composed. The code was not
following this specification, so this changes centralizes where they are
set.

In addition, it makes the code that finds the event target consistent
with whether or not it is `ShadowIncluding`.

Finally the `MouseEvent` constructors are renamed so that it is clear
what they are used for.

Testing: This change causes one WPT test to start passing.
