### PR TITLE
fetch: Preserve AbortError on repeated body consumption for errored stream

### DIFF
--- a/tests/wpt/meta/fetch/api/abort/general.any.js.ini
+++ b/tests/wpt/meta/fetch/api/abort/general.any.js.ini
@@ -5,10 +5,5 @@
   expected: ERROR
 
 [general.any.html]
-  [Call text() twice on aborted response]
-    expected: FAIL
-
 
 [general.any.worker.html]
-  [Call text() twice on aborted response]
-    expected: FAIL


### PR DESCRIPTION
Testing: more tests/wpt/meta/fetch/api/abort/general.any.js.ini pass.
