### PR TITLE
script: Support safely using Promise objects from DOM Drop implementations

### DIFF
--- a/components/script/dom/globalscope.rs
+++ b/components/script/dom/globalscope.rs
@@ -3071,6 +3071,16 @@ impl GlobalScope {
         unreachable!();
     }
 
+    pub(crate) fn current_runtime(&self) -> Option<Rc<crate::script_runtime::Runtime>> {
+        if let Some(window) = self.downcast::<Window>() {
+            window.get_js_runtime()
+        } else if let Some(worker) = self.downcast::<WorkerGlobalScope>() {
+            worker.current_runtime()
+        } else {
+            unreachable!()
+        }
+    }
+
     pub(crate) fn runtime_handle(&self) -> ParentRuntime {
         if self.is::<Window>() {
             ScriptThread::runtime_handle()

--- a/components/script/dom/window.rs
+++ b/components/script/dom/window.rs
@@ -547,8 +547,8 @@ impl Window {
         unsafe { JSContext::from_ptr(js::rust::Runtime::get().unwrap().as_ptr()) }
     }
 
-    pub(crate) fn get_js_runtime(&self) -> Ref<'_, Option<Rc<Runtime>>> {
-        self.js_runtime.borrow()
+    pub(crate) fn get_js_runtime(&self) -> Option<Rc<Runtime>> {
+        self.js_runtime.borrow().clone()
     }
 
     pub(crate) fn main_thread_script_chan(&self) -> &Sender<MainThreadScriptMsg> {

--- a/components/script/dom/workers/workerglobalscope.rs
+++ b/components/script/dom/workers/workerglobalscope.rs
@@ -288,7 +288,7 @@ pub(crate) struct WorkerGlobalScope {
     closing: Arc<AtomicBool>,
     execution_ready: AtomicBool,
     #[ignore_malloc_size_of = "Defined in js"]
-    runtime: DomRefCell<Option<Runtime>>,
+    runtime: DomRefCell<Option<Rc<Runtime>>>,
     location: MutNullableDom<WorkerLocation>,
     navigator: MutNullableDom<WorkerNavigator>,
     #[no_trace]
@@ -379,7 +379,7 @@ impl WorkerGlobalScope {
             worker_url: DomRefCell::new(worker_url),
             closing,
             execution_ready: AtomicBool::new(false),
-            runtime: DomRefCell::new(Some(runtime)),
+            runtime: DomRefCell::new(Some(Rc::new(runtime))),
             location: Default::default(),
             navigator: Default::default(),
             policy_container: Default::default(),
@@ -417,6 +417,10 @@ impl WorkerGlobalScope {
     /// Returns a policy value that should be used by fetches initiated by this worker.
     pub(crate) fn insecure_requests_policy(&self) -> InsecureRequestsPolicy {
         self.insecure_requests_policy
+    }
+
+    pub(crate) fn current_runtime(&self) -> Option<Rc<Runtime>> {
+        self.runtime.borrow().clone()
     }
 
     /// Clear various items when the worker event-loop shuts-down.

--- a/components/script/script_runtime.rs
+++ b/components/script/script_runtime.rs
@@ -8,15 +8,15 @@
 #![expect(dead_code)]
 
 use core::ffi::c_char;
-use std::cell::Cell;
+use std::cell::{Cell, RefCell};
 use std::ffi::{CStr, CString};
 use std::io::{Write, stdout};
 use std::ops::{Deref, DerefMut};
 use std::os::raw::c_void;
-use std::rc::Rc;
+use std::rc::{Rc, Weak};
 use std::sync::Mutex;
 use std::time::{Duration, Instant};
-use std::{os, ptr, thread};
+use std::{mem, os, ptr, thread};
 
 use background_hang_monitor_api::ScriptHangAnnotation;
 use js::conversions::jsstr_to_string;
@@ -62,6 +62,7 @@ use script_bindings::script_runtime::{mark_runtime_dead, runtime_is_alive};
 use servo_config::{opts, pref};
 use style::thread_state::{self, ThreadState};
 
+use crate::dom::bindings::cell::DomRefCell;
 use crate::dom::bindings::codegen::Bindings::PromiseBinding::PromiseJobCallback;
 use crate::dom::bindings::codegen::Bindings::ResponseBinding::Response_Binding::ResponseMethods;
 use crate::dom::bindings::codegen::Bindings::ResponseBinding::ResponseType as DOMResponseType;
@@ -679,6 +680,10 @@ pub(crate) struct Runtime {
     #[ignore_malloc_size_of = "Type from mozjs"]
     job_queue: *mut JobQueue,
     script_event_loop_sender: Option<Box<ScriptEventLoopSender>>,
+
+    /// All Promise objects that need to be cleared up when the JS runtime is
+    /// shutting down.
+    promise_finalizer_registry: RefCell<PromiseFinalizerRegistry>,
 }
 
 impl Runtime {
@@ -972,6 +977,7 @@ impl Runtime {
             rt: runtime,
             microtask_queue,
             job_queue,
+            promise_finalizer_registry: Default::default(),
             script_event_loop_sender: (!script_event_loop_sender_pointer.is_null())
                 .then(|| unsafe { Box::from_raw(script_event_loop_sender_pointer) }),
         }
@@ -980,6 +986,10 @@ impl Runtime {
     pub(crate) fn thread_safe_js_context(&self) -> ThreadSafeJSContext {
         self.rt.thread_safe_js_context()
     }
+
+    pub(crate) fn register_promise_finalizer(&self) -> Rc<ClearablePromise> {
+        self.promise_finalizer_registry.borrow_mut().register()
+    }
 }
 
 impl Drop for Runtime {
@@ -987,6 +997,10 @@ impl Drop for Runtime {
     fn drop(&mut self) {
         // Clear our main microtask_queue.
         self.microtask_queue.clear();
+
+        self.promise_finalizer_registry
+            .borrow_mut()
+            .clear_all_promises();
 
         // Delete the RustJobQueue in mozjs, which will destroy our interrupt queues.
         unsafe {
@@ -1384,6 +1398,43 @@ impl Runnable {
         unsafe {
             DispatchableRun(cx, self.0, maybe_shutting_down);
         }
+    }
+}
+
+/// A piece of shared storage that is either empty or contains a Promise object.
+/// Any DOM object using this type is forced to consider that a previously-stored
+/// Promise object may no longer be available.
+pub(crate) type ClearablePromise = DomRefCell<Option<Rc<Promise>>>;
+
+#[derive(MallocSizeOf)]
+struct WeakPromise(#[ignore_malloc_size_of = "Owned by strong references"] Weak<ClearablePromise>);
+
+#[derive(Default, JSTraceable, MallocSizeOf)]
+/// A registry for Promise objects that must be usable from DOM object finalizers.
+/// To avoid the risk of crashes executing those finalizers at an unsafe time,
+/// this registry ensures that the references to the registered promise objects
+/// are cleaned up as part of tearing down the JS runtime, before the finalizers are invoked.
+struct PromiseFinalizerRegistry {
+    #[no_trace]
+    promises: Vec<WeakPromise>,
+}
+
+impl PromiseFinalizerRegistry {
+    fn clear_all_promises(&mut self) {
+        for WeakPromise(promise_storage) in mem::take(&mut self.promises) {
+            if let Some(promise_storage) = promise_storage.upgrade() {
+                *promise_storage.borrow_mut() = None;
+            }
+        }
+    }
+
+    fn register(&mut self) -> Rc<ClearablePromise> {
+        let promise_storage = Rc::new(ClearablePromise::default());
+        self.promises
+            .retain(|promise_storage| promise_storage.0.upgrade().is_some());
+        self.promises
+            .push(WeakPromise(Rc::downgrade(&promise_storage)));
+        promise_storage
     }
 }
 


### PR DESCRIPTION
Per #26488, we cannot safely interact with arbitrary DOM objects from a DOM object's Drop implementation, because the finalizer might be called during JS runtime teardown when the runtime is just sweeping all objects regardless of liveness. A common solution to that issue is using weak references to DOM objects, which allows us to observe if another DOM object is still valid when we want to use it.

Trying to use Promises from Drop implementations has the exact same problem, except that we can't use our DOM weak references implementation for them because they are native SpiderMonkey objects. Instead, this PR introduces an opt-in system that is more coarse-grained than per-object weak references—once JS runtime teardown begins, any conforming Drop implementation loses access to any Promise object it was holding on to. This shouldn't lead to any observable behaviour difference because we're already tearing down the world in this case, so promise reactions would never get a chance to run.

Testing: The timing of shutdown and the difficulty of observing the affected behaviour means that this particular fix is theoretical. However, existing tests validate the non-shutdown behaviour.
Fixes: part of #26488
