### PR TITLE
tests: Enable largest-contentful-paint tests.

### DIFF
--- a/tests/wpt/include.ini
+++ b/tests/wpt/include.ini
@@ -202,6 +202,8 @@ skip: true
   skip: false
 [js]
   skip: false
+[largest-contentful-paint]
+  skip: false
 [mediasession]
   skip: false
 [mimesniff]

--- a/tests/wpt/meta/largest-contentful-paint/__dir__.ini
+++ b/tests/wpt/meta/largest-contentful-paint/__dir__.ini
@@ -1,0 +1,1 @@
+prefs: [largest_contentful_paint_enabled: true]

--- a/tests/wpt/meta/largest-contentful-paint/animated/observe-animated-image-gif.tentative.html.ini
+++ b/tests/wpt/meta/largest-contentful-paint/animated/observe-animated-image-gif.tentative.html.ini
@@ -1,0 +1,4 @@
+[observe-animated-image-gif.tentative.html]
+  expected: TIMEOUT
+  [Same origin animated image is observable and has a first frame.]
+    expected: TIMEOUT

--- a/tests/wpt/meta/largest-contentful-paint/animated/observe-animated-image-webp.tentative.html.ini
+++ b/tests/wpt/meta/largest-contentful-paint/animated/observe-animated-image-webp.tentative.html.ini
@@ -1,0 +1,4 @@
+[observe-animated-image-webp.tentative.html]
+  expected: TIMEOUT
+  [Same origin animated image is observable and has a first frame.]
+    expected: TIMEOUT

--- a/tests/wpt/meta/largest-contentful-paint/animated/observe-animated-image.tentative.html.ini
+++ b/tests/wpt/meta/largest-contentful-paint/animated/observe-animated-image.tentative.html.ini
@@ -1,0 +1,4 @@
+[observe-animated-image.tentative.html]
+  expected: TIMEOUT
+  [Same origin animated image is observable and has a first frame.]
+    expected: TIMEOUT

--- a/tests/wpt/meta/largest-contentful-paint/animated/observe-cross-origin-animated-image.tentative.html.ini
+++ b/tests/wpt/meta/largest-contentful-paint/animated/observe-cross-origin-animated-image.tentative.html.ini
@@ -1,0 +1,4 @@
+[observe-cross-origin-animated-image.tentative.html]
+  expected: TIMEOUT
+  [Same origin animated image is observable and has a first frame.]
+    expected: TIMEOUT

--- a/tests/wpt/meta/largest-contentful-paint/animated/observe-cross-origin-tao-animated-image.tentative.html.ini
+++ b/tests/wpt/meta/largest-contentful-paint/animated/observe-cross-origin-tao-animated-image.tentative.html.ini
@@ -1,0 +1,4 @@
+[observe-cross-origin-tao-animated-image.tentative.html]
+  expected: TIMEOUT
+  [Same origin animated image is observable and has a first frame.]
+    expected: TIMEOUT

--- a/tests/wpt/meta/largest-contentful-paint/animated/observe-non-animated-image.tentative.html.ini
+++ b/tests/wpt/meta/largest-contentful-paint/animated/observe-non-animated-image.tentative.html.ini
@@ -1,0 +1,4 @@
+[observe-non-animated-image.tentative.html]
+  expected: TIMEOUT
+  [Same origin animated image is observable and has a first frame.]
+    expected: TIMEOUT

--- a/tests/wpt/meta/largest-contentful-paint/animated/observe-video.tentative.html.ini
+++ b/tests/wpt/meta/largest-contentful-paint/animated/observe-video.tentative.html.ini
@@ -1,0 +1,4 @@
+[observe-video.tentative.html]
+  expected: TIMEOUT
+  [Same origin animated image is observable and has a first frame.]
+    expected: TIMEOUT

--- a/tests/wpt/meta/largest-contentful-paint/background-image-set-image.html.ini
+++ b/tests/wpt/meta/largest-contentful-paint/background-image-set-image.html.ini
@@ -1,0 +1,4 @@
+[background-image-set-image.html]
+  expected: ERROR
+  [Background image-set images should be eligible for LCP candidates]
+    expected: FAIL

--- a/tests/wpt/meta/largest-contentful-paint/broken-image-icon.html.ini
+++ b/tests/wpt/meta/largest-contentful-paint/broken-image-icon.html.ini
@@ -1,0 +1,4 @@
+[broken-image-icon.html]
+  expected: ERROR
+  [The broken image icon should not emit an LCP entry.]
+    expected: TIMEOUT

--- a/tests/wpt/meta/largest-contentful-paint/contracted-image.html.ini
+++ b/tests/wpt/meta/largest-contentful-paint/contracted-image.html.ini
@@ -1,0 +1,3 @@
+[contracted-image.html]
+  [Largest Contentful Paint: |size| attribute is bounded by display size.]
+    expected: FAIL

--- a/tests/wpt/meta/largest-contentful-paint/cross-origin-image.sub.html.ini
+++ b/tests/wpt/meta/largest-contentful-paint/cross-origin-image.sub.html.ini
@@ -1,0 +1,3 @@
+[cross-origin-image.sub.html]
+  [Cross-origin image is observable, with renderTime equal to 0.]
+    expected: FAIL

--- a/tests/wpt/meta/largest-contentful-paint/element-only-when-fully-active.html.ini
+++ b/tests/wpt/meta/largest-contentful-paint/element-only-when-fully-active.html.ini
@@ -1,0 +1,4 @@
+[element-only-when-fully-active.html]
+  expected: TIMEOUT
+  [Only expose element attribute for fully active documents]
+    expected: NOTRUN

--- a/tests/wpt/meta/largest-contentful-paint/expanded-image.html.ini
+++ b/tests/wpt/meta/largest-contentful-paint/expanded-image.html.ini
@@ -1,0 +1,3 @@
+[expanded-image.html]
+  [Largest Contentful Paint: |size| attribute is bounded by intrinsic size.]
+    expected: FAIL

--- a/tests/wpt/meta/largest-contentful-paint/first-letter-background.html.ini
+++ b/tests/wpt/meta/largest-contentful-paint/first-letter-background.html.ini
@@ -1,0 +1,4 @@
+[first-letter-background.html]
+  expected: TIMEOUT
+  [Largest Contentful Paint: first-letter is observable.]
+    expected: TIMEOUT

--- a/tests/wpt/meta/largest-contentful-paint/first-paint-equals-lcp-text.html.ini
+++ b/tests/wpt/meta/largest-contentful-paint/first-paint-equals-lcp-text.html.ini
@@ -1,0 +1,4 @@
+[first-paint-equals-lcp-text.html]
+  expected: TIMEOUT
+  [FCP and LCP are the same when there is a single text element in the page.]
+    expected: TIMEOUT

--- a/tests/wpt/meta/largest-contentful-paint/idlharness.html.ini
+++ b/tests/wpt/meta/largest-contentful-paint/idlharness.html.ini
@@ -1,0 +1,15 @@
+[idlharness.html]
+  [LargestContentfulPaint interface: attribute id]
+    expected: FAIL
+
+  [LargestContentfulPaint interface: attribute url]
+    expected: FAIL
+
+  [LargestContentfulPaint interface: lcp must inherit property "id" with the proper type]
+    expected: FAIL
+
+  [LargestContentfulPaint interface: lcp must inherit property "url" with the proper type]
+    expected: FAIL
+
+  [LargestContentfulPaint interface: default toJSON operation on lcp]
+    expected: FAIL

--- a/tests/wpt/meta/largest-contentful-paint/image-TAO.sub.html.ini
+++ b/tests/wpt/meta/largest-contentful-paint/image-TAO.sub.html.ini
@@ -1,0 +1,3 @@
+[image-TAO.sub.html]
+  [Cross-origin elements with valid TAO have correct renderTime, with invalid TAO have renderTime set to 0.]
+    expected: FAIL

--- a/tests/wpt/meta/largest-contentful-paint/image-inside-svg.html.ini
+++ b/tests/wpt/meta/largest-contentful-paint/image-inside-svg.html.ini
@@ -1,0 +1,3 @@
+[image-inside-svg.html]
+  [Image inside SVG is observable.]
+    expected: FAIL

--- a/tests/wpt/meta/largest-contentful-paint/image-not-fully-visible.html.ini
+++ b/tests/wpt/meta/largest-contentful-paint/image-not-fully-visible.html.ini
@@ -1,0 +1,3 @@
+[image-not-fully-visible.html]
+  [The intersectionRect of an img element overflowing is computed correctly]
+    expected: FAIL

--- a/tests/wpt/meta/largest-contentful-paint/image-removed-before-load.html.ini
+++ b/tests/wpt/meta/largest-contentful-paint/image-removed-before-load.html.ini
@@ -1,0 +1,3 @@
+[image-removed-before-load.html]
+  [Largest Contentful Paint: image removed before loaded does not produce entry.]
+    expected: FAIL

--- a/tests/wpt/meta/largest-contentful-paint/image-src-change.html.ini
+++ b/tests/wpt/meta/largest-contentful-paint/image-src-change.html.ini
@@ -1,0 +1,4 @@
+[image-src-change.html]
+  expected: ERROR
+  [Largest Contentful Paint: changing src causes a new entry to be dispatched.]
+    expected: TIMEOUT

--- a/tests/wpt/meta/largest-contentful-paint/image-sw-same-origin.https.html.ini
+++ b/tests/wpt/meta/largest-contentful-paint/image-sw-same-origin.https.html.ini
@@ -1,0 +1,3 @@
+[image-sw-same-origin.https.html]
+  [Same-origin images served from a service-worker should have a correct renderTime]
+    expected: FAIL

--- a/tests/wpt/meta/largest-contentful-paint/image-upscaling-empty-url.html.ini
+++ b/tests/wpt/meta/largest-contentful-paint/image-upscaling-empty-url.html.ini
@@ -1,0 +1,31 @@
+[image-upscaling-empty-url.html]
+  expected: TIMEOUT
+  [Non-scaled image should report the natural size]
+    expected: TIMEOUT
+
+  [A downscaled image (width/height) should report the displayed size]
+    expected: NOTRUN
+
+  [A downscaled image (using scale) should report the displayed size]
+    expected: NOTRUN
+
+  [An upscaled image (width/height) should report the natural size]
+    expected: NOTRUN
+
+  [An upscaled image (using scale) should report the natural size]
+    expected: NOTRUN
+
+  [An upscaled image (using object-size) should report the natural size]
+    expected: NOTRUN
+
+  [Intersecting element with partial-intersecting image to report image intersection]
+    expected: NOTRUN
+
+  [A background image larger than the container should report the container size]
+    expected: NOTRUN
+
+  [A background image smaller than the container should report the natural size]
+    expected: NOTRUN
+
+  [A scaled-down background image should report the background size]
+    expected: NOTRUN

--- a/tests/wpt/meta/largest-contentful-paint/image-upscaling.html.ini
+++ b/tests/wpt/meta/largest-contentful-paint/image-upscaling.html.ini
@@ -1,0 +1,31 @@
+[image-upscaling.html]
+  expected: TIMEOUT
+  [Non-scaled image should report the natural size]
+    expected: TIMEOUT
+
+  [A downscaled image (width/height) should report the displayed size]
+    expected: NOTRUN
+
+  [A downscaled image (using scale) should report the displayed size]
+    expected: NOTRUN
+
+  [An upscaled image (width/height) should report the natural size]
+    expected: NOTRUN
+
+  [An upscaled image (using scale) should report the natural size]
+    expected: NOTRUN
+
+  [An upscaled image (using object-size) should report the natural size]
+    expected: NOTRUN
+
+  [Intersecting element with partial-intersecting image to report image intersection]
+    expected: NOTRUN
+
+  [A background image larger than the container should report the container size]
+    expected: NOTRUN
+
+  [A background image smaller than the container should report the natural size]
+    expected: NOTRUN
+
+  [A scaled-down background image should report the background size]
+    expected: NOTRUN

--- a/tests/wpt/meta/largest-contentful-paint/initially-invisible-images.html.ini
+++ b/tests/wpt/meta/largest-contentful-paint/initially-invisible-images.html.ini
@@ -1,0 +1,3 @@
+[initially-invisible-images.html]
+  [Image visibility: out-of-viewport images are observable by LargestContentfulPaint once they become visible.]
+    expected: FAIL

--- a/tests/wpt/meta/largest-contentful-paint/larger-text.html.ini
+++ b/tests/wpt/meta/largest-contentful-paint/larger-text.html.ini
@@ -1,0 +1,4 @@
+[larger-text.html]
+  expected: TIMEOUT
+  [Largest Contentful Paint: largest text is reported.]
+    expected: TIMEOUT

--- a/tests/wpt/meta/largest-contentful-paint/loadTime-after-appendChild.html.ini
+++ b/tests/wpt/meta/largest-contentful-paint/loadTime-after-appendChild.html.ini
@@ -1,0 +1,3 @@
+[loadTime-after-appendChild.html]
+  [Image loadTime occurs after appendChild is called.]
+    expected: FAIL

--- a/tests/wpt/meta/largest-contentful-paint/multiple-image-same-src.html.ini
+++ b/tests/wpt/meta/largest-contentful-paint/multiple-image-same-src.html.ini
@@ -1,0 +1,3 @@
+[multiple-image-same-src.html]
+  [Largest Contentful Paint:dynamically appended image with different dimensions but same src triggers new entry.]
+    expected: FAIL

--- a/tests/wpt/meta/largest-contentful-paint/multiple-redirects-TAO.html.ini
+++ b/tests/wpt/meta/largest-contentful-paint/multiple-redirects-TAO.html.ini
@@ -1,0 +1,3 @@
+[multiple-redirects-TAO.html]
+  [Cross-origin images with passing/failing TAO should/shouldn't have its renderTime set.]
+    expected: FAIL

--- a/tests/wpt/meta/largest-contentful-paint/observe-after-untrusted-scroll.html.ini
+++ b/tests/wpt/meta/largest-contentful-paint/observe-after-untrusted-scroll.html.ini
@@ -1,0 +1,3 @@
+[observe-after-untrusted-scroll.html]
+  [Same-origin image after a JS initiated scroll event is observable.]
+    expected: FAIL

--- a/tests/wpt/meta/largest-contentful-paint/observe-css-generated-image.html.ini
+++ b/tests/wpt/meta/largest-contentful-paint/observe-css-generated-image.html.ini
@@ -1,0 +1,3 @@
+[observe-css-generated-image.html]
+  [Largest Contentful Paint: CSS generated image is observable.]
+    expected: FAIL

--- a/tests/wpt/meta/largest-contentful-paint/observe-css-generated-text.html.ini
+++ b/tests/wpt/meta/largest-contentful-paint/observe-css-generated-text.html.ini
@@ -1,0 +1,9 @@
+[observe-css-generated-text.html]
+  [CSS generated text is observable as a LargestContentfulPaint candidate]
+    expected: FAIL
+
+  [Text generated with CSS using content:attr() is observable as a LargestContentfulPaint candidate]
+    expected: FAIL
+
+  [CSS generated text on a inline element is observable as a LargestContentfulPaint candidate]
+    expected: FAIL

--- a/tests/wpt/meta/largest-contentful-paint/observe-image.html.ini
+++ b/tests/wpt/meta/largest-contentful-paint/observe-image.html.ini
@@ -1,0 +1,3 @@
+[observe-image.html]
+  [Same-origin image is observable.]
+    expected: FAIL

--- a/tests/wpt/meta/largest-contentful-paint/observe-mathml.html.ini
+++ b/tests/wpt/meta/largest-contentful-paint/observe-mathml.html.ini
@@ -1,0 +1,4 @@
+[observe-mathml.html]
+  expected: TIMEOUT
+  [Element rendered by MathML is observable]
+    expected: TIMEOUT

--- a/tests/wpt/meta/largest-contentful-paint/observe-random-namespace.html.ini
+++ b/tests/wpt/meta/largest-contentful-paint/observe-random-namespace.html.ini
@@ -1,0 +1,4 @@
+[observe-random-namespace.html]
+  expected: TIMEOUT
+  [Element created with different namespace is observable]
+    expected: TIMEOUT

--- a/tests/wpt/meta/largest-contentful-paint/observe-svg-background-image.html.ini
+++ b/tests/wpt/meta/largest-contentful-paint/observe-svg-background-image.html.ini
@@ -1,0 +1,3 @@
+[observe-svg-background-image.html]
+  [Same-origin SVG background image is observable.]
+    expected: FAIL

--- a/tests/wpt/meta/largest-contentful-paint/observe-svg-data-uri-background-image.html.ini
+++ b/tests/wpt/meta/largest-contentful-paint/observe-svg-data-uri-background-image.html.ini
@@ -1,0 +1,3 @@
+[observe-svg-data-uri-background-image.html]
+  [Data-URI background SVG image is observable.]
+    expected: FAIL

--- a/tests/wpt/meta/largest-contentful-paint/observe-svg-data-uri-image.html.ini
+++ b/tests/wpt/meta/largest-contentful-paint/observe-svg-data-uri-image.html.ini
@@ -1,0 +1,3 @@
+[observe-svg-data-uri-image.html]
+  [Same-origin image is observable.]
+    expected: FAIL

--- a/tests/wpt/meta/largest-contentful-paint/observe-svg-image.html.ini
+++ b/tests/wpt/meta/largest-contentful-paint/observe-svg-image.html.ini
@@ -1,0 +1,3 @@
+[observe-svg-image.html]
+  [Same-origin image is observable.]
+    expected: FAIL

--- a/tests/wpt/meta/largest-contentful-paint/observe-text.html.ini
+++ b/tests/wpt/meta/largest-contentful-paint/observe-text.html.ini
@@ -1,0 +1,4 @@
+[observe-text.html]
+  expected: TIMEOUT
+  [Text element is observable as a LargestContentfulPaint candidate.]
+    expected: TIMEOUT

--- a/tests/wpt/meta/largest-contentful-paint/placeholder-image.html.ini
+++ b/tests/wpt/meta/largest-contentful-paint/placeholder-image.html.ini
@@ -1,0 +1,4 @@
+[placeholder-image.html]
+  expected: TIMEOUT
+  [Largest Contentful Paint: changing src causes a new entry to be dispatched.]
+    expected: TIMEOUT

--- a/tests/wpt/meta/largest-contentful-paint/redirects-tao-star.html.ini
+++ b/tests/wpt/meta/largest-contentful-paint/redirects-tao-star.html.ini
@@ -1,0 +1,3 @@
+[redirects-tao-star.html]
+  [Cross-origin image without TAO should not have its renderTime set, with full TAO it should.]
+    expected: FAIL

--- a/tests/wpt/meta/largest-contentful-paint/repeated-image.html.ini
+++ b/tests/wpt/meta/largest-contentful-paint/repeated-image.html.ini
@@ -1,0 +1,3 @@
+[repeated-image.html]
+  [Repeated image produces different timestamps.]
+    expected: FAIL

--- a/tests/wpt/meta/largest-contentful-paint/resized-image-not-reconsidered.html.ini
+++ b/tests/wpt/meta/largest-contentful-paint/resized-image-not-reconsidered.html.ini
@@ -1,0 +1,3 @@
+[resized-image-not-reconsidered.html]
+  [Resized image should not be reconsidered as LCP]
+    expected: FAIL

--- a/tests/wpt/meta/largest-contentful-paint/same-origin-redirects.html.ini
+++ b/tests/wpt/meta/largest-contentful-paint/same-origin-redirects.html.ini
@@ -1,0 +1,3 @@
+[same-origin-redirects.html]
+  [Same-origin image redirect without TAO should have its renderTime set.]
+    expected: FAIL

--- a/tests/wpt/meta/largest-contentful-paint/text-with-display-style.html.ini
+++ b/tests/wpt/meta/largest-contentful-paint/text-with-display-style.html.ini
@@ -1,0 +1,4 @@
+[text-with-display-style.html]
+  expected: TIMEOUT
+  [Text with display style is observable.]
+    expected: TIMEOUT

--- a/tests/wpt/meta/largest-contentful-paint/toJSON.html.ini
+++ b/tests/wpt/meta/largest-contentful-paint/toJSON.html.ini
@@ -1,0 +1,4 @@
+[toJSON.html]
+  expected: TIMEOUT
+  [Test toJSON() in LargestContentfulPaint.]
+    expected: TIMEOUT

--- a/tests/wpt/meta/largest-contentful-paint/transparent-text-with-shadow.html.ini
+++ b/tests/wpt/meta/largest-contentful-paint/transparent-text-with-shadow.html.ini
@@ -1,0 +1,4 @@
+[transparent-text-with-shadow.html]
+  expected: TIMEOUT
+  [Transparent text with shadow decoration should not be excluded from LCP.]
+    expected: TIMEOUT

--- a/tests/wpt/meta/largest-contentful-paint/transparent-text-with-text-stroke.html.ini
+++ b/tests/wpt/meta/largest-contentful-paint/transparent-text-with-text-stroke.html.ini
@@ -1,0 +1,4 @@
+[transparent-text-with-text-stroke.html]
+  expected: TIMEOUT
+  [Transparent text with text stroke decoration should not be excluded from LCP.]
+    expected: TIMEOUT

--- a/tests/wpt/meta/largest-contentful-paint/transparent-text.html.ini
+++ b/tests/wpt/meta/largest-contentful-paint/transparent-text.html.ini
@@ -1,0 +1,3 @@
+[transparent-text.html]
+  [Transparent text should not be LCP.]
+    expected: FAIL

--- a/tests/wpt/meta/largest-contentful-paint/update-on-style-change.html.ini
+++ b/tests/wpt/meta/largest-contentful-paint/update-on-style-change.html.ini
@@ -1,0 +1,4 @@
+[update-on-style-change.html]
+  expected: TIMEOUT
+  [LargestContentfulPaint entries should NOT be emitted for updates to previous LargestContentfulPaint elements.]
+    expected: TIMEOUT

--- a/tests/wpt/meta/largest-contentful-paint/video-data-uri.html.ini
+++ b/tests/wpt/meta/largest-contentful-paint/video-data-uri.html.ini
@@ -1,0 +1,3 @@
+[video-data-uri.html]
+  [Video of data URI src should trigger an LCP entry to be emitted.]
+    expected: FAIL

--- a/tests/wpt/meta/largest-contentful-paint/video-play-after-poster.html.ini
+++ b/tests/wpt/meta/largest-contentful-paint/video-play-after-poster.html.ini
@@ -1,0 +1,3 @@
+[video-play-after-poster.html]
+  [Video with poster should not emit a second LCP entry after playing.]
+    expected: FAIL

--- a/tests/wpt/meta/largest-contentful-paint/video-poster.html.ini
+++ b/tests/wpt/meta/largest-contentful-paint/video-poster.html.ini
@@ -1,0 +1,3 @@
+[video-poster.html]
+  [Able to observe a video's poster image.]
+    expected: FAIL

--- a/tests/wpt/meta/largest-contentful-paint/web-font-styled-text-resize-block.html.ini
+++ b/tests/wpt/meta/largest-contentful-paint/web-font-styled-text-resize-block.html.ini
@@ -1,0 +1,3 @@
+[web-font-styled-text-resize-block.html]
+  [LCP should be not updated if the web font styled text resize occurs during the block period.]
+    expected: FAIL

--- a/tests/wpt/meta/largest-contentful-paint/web-font-styled-text-resize-swap-smaller.html.ini
+++ b/tests/wpt/meta/largest-contentful-paint/web-font-styled-text-resize-swap-smaller.html.ini
@@ -1,0 +1,3 @@
+[web-font-styled-text-resize-swap-smaller.html]
+  [LCP should be not updated if the web font styled text resizes to be smaller during the swap period]
+    expected: FAIL

--- a/tests/wpt/meta/largest-contentful-paint/web-font-styled-text-resize-swap-subnode.html.ini
+++ b/tests/wpt/meta/largest-contentful-paint/web-font-styled-text-resize-swap-subnode.html.ini
@@ -1,0 +1,3 @@
+[web-font-styled-text-resize-swap-subnode.html]
+  [LCP should be updated if the web font styled text resizes to be larger during the swap period]
+    expected: FAIL

--- a/tests/wpt/meta/largest-contentful-paint/web-font-styled-text-resize-swap.html.ini
+++ b/tests/wpt/meta/largest-contentful-paint/web-font-styled-text-resize-swap.html.ini
@@ -1,0 +1,3 @@
+[web-font-styled-text-resize-swap.html]
+  [LCP should be updated if the web font styled text resizes to be larger during the swap period]
+    expected: FAIL


### PR DESCRIPTION
We have a partial implementation of LargestContentfulPaint , so we should run the tests associated with them.

Testing: New tests enabled.
