### PR TITLE
tests: Enable paint-timing tests

### DIFF
--- a/tests/wpt/include.ini
+++ b/tests/wpt/include.ini
@@ -210,6 +210,8 @@ skip: true
   skip: false
 [page-visibility]
   skip: false
+[paint-timing]
+  skip: false
 [performance-timeline]
   skip: false
 [permissions]

--- a/tests/wpt/meta/paint-timing/fcp-only/fcp-background-size.html.ini
+++ b/tests/wpt/meta/paint-timing/fcp-only/fcp-background-size.html.ini
@@ -1,0 +1,4 @@
+[fcp-background-size.html]
+  expected: TIMEOUT
+  [First contentful paint fires due to background size.]
+    expected: TIMEOUT

--- a/tests/wpt/meta/paint-timing/fcp-only/fcp-bg-image-set.html.ini
+++ b/tests/wpt/meta/paint-timing/fcp-only/fcp-bg-image-set.html.ini
@@ -1,0 +1,4 @@
+[fcp-bg-image-set.html]
+  expected: TIMEOUT
+  [First contentful paint fires due to background image in image-set.]
+    expected: TIMEOUT

--- a/tests/wpt/meta/paint-timing/fcp-only/fcp-bg-image-two-steps.html.ini
+++ b/tests/wpt/meta/paint-timing/fcp-only/fcp-bg-image-two-steps.html.ini
@@ -1,0 +1,4 @@
+[fcp-bg-image-two-steps.html]
+  expected: TIMEOUT
+  [First contentful paint fires for background image only when visible.]
+    expected: TIMEOUT

--- a/tests/wpt/meta/paint-timing/fcp-only/fcp-document-opacity-image.html.ini
+++ b/tests/wpt/meta/paint-timing/fcp-only/fcp-document-opacity-image.html.ini
@@ -1,0 +1,4 @@
+[fcp-document-opacity-image.html]
+  expected: TIMEOUT
+  [Test that FCP after opacity change is not a larger value than LCP]
+    expected: TIMEOUT

--- a/tests/wpt/meta/paint-timing/fcp-only/fcp-document-opacity-text.html.ini
+++ b/tests/wpt/meta/paint-timing/fcp-only/fcp-document-opacity-text.html.ini
@@ -1,0 +1,3 @@
+[fcp-document-opacity-text.html]
+  [Test that FCP after opacity change is not a larger value than LCP]
+    expected: FAIL

--- a/tests/wpt/meta/paint-timing/fcp-only/fcp-ignore-from-subframe.html.ini
+++ b/tests/wpt/meta/paint-timing/fcp-only/fcp-ignore-from-subframe.html.ini
@@ -1,0 +1,3 @@
+[fcp-ignore-from-subframe.html]
+  [Parent frame should not fire own paint-timing events for subframes.]
+    expected: FAIL

--- a/tests/wpt/meta/paint-timing/fcp-only/fcp-invisible-3d-rotate-descendant.html.ini
+++ b/tests/wpt/meta/paint-timing/fcp-only/fcp-invisible-3d-rotate-descendant.html.ini
@@ -1,0 +1,3 @@
+[fcp-invisible-3d-rotate-descendant.html]
+  [First contentful paint fires due to its ancestor getting rotating into view.]
+    expected: FAIL

--- a/tests/wpt/meta/paint-timing/fcp-only/fcp-invisible-3d-rotate.html.ini
+++ b/tests/wpt/meta/paint-timing/fcp-only/fcp-invisible-3d-rotate.html.ini
@@ -1,0 +1,3 @@
+[fcp-invisible-3d-rotate.html]
+  [First contentful paint fires due to 3d rotation into view.]
+    expected: FAIL

--- a/tests/wpt/meta/paint-timing/fcp-only/fcp-invisible-scale.html.ini
+++ b/tests/wpt/meta/paint-timing/fcp-only/fcp-invisible-scale.html.ini
@@ -1,0 +1,4 @@
+[fcp-invisible-scale.html]
+  expected: TIMEOUT
+  [First contentful paint fires due to scale becoming positive.]
+    expected: TIMEOUT

--- a/tests/wpt/meta/paint-timing/fcp-only/fcp-opacity-descendant.html.ini
+++ b/tests/wpt/meta/paint-timing/fcp-only/fcp-opacity-descendant.html.ini
@@ -1,0 +1,3 @@
+[fcp-opacity-descendant.html]
+  [First contentful paint fires due to its ancestor getting positive opacity.]
+    expected: FAIL

--- a/tests/wpt/meta/paint-timing/fcp-only/fcp-opacity.html.ini
+++ b/tests/wpt/meta/paint-timing/fcp-only/fcp-opacity.html.ini
@@ -1,0 +1,4 @@
+[fcp-opacity.html]
+  expected: TIMEOUT
+  [First contentful paint fires due to opacity-revealed element.]
+    expected: TIMEOUT

--- a/tests/wpt/meta/paint-timing/fcp-only/fcp-out-of-bounds-translate.html.ini
+++ b/tests/wpt/meta/paint-timing/fcp-only/fcp-out-of-bounds-translate.html.ini
@@ -1,0 +1,4 @@
+[fcp-out-of-bounds-translate.html]
+  expected: TIMEOUT
+  [First contentful paint fires due to transform-based intersection with document.]
+    expected: TIMEOUT

--- a/tests/wpt/meta/paint-timing/fcp-only/fcp-out-of-bounds.html.ini
+++ b/tests/wpt/meta/paint-timing/fcp-only/fcp-out-of-bounds.html.ini
@@ -1,0 +1,4 @@
+[fcp-out-of-bounds.html]
+  expected: TIMEOUT
+  [First contentful paint fires due to intersection with document.]
+    expected: TIMEOUT

--- a/tests/wpt/meta/paint-timing/fcp-only/fcp-pseudo-element-opacity.html.ini
+++ b/tests/wpt/meta/paint-timing/fcp-only/fcp-pseudo-element-opacity.html.ini
@@ -1,0 +1,3 @@
+[fcp-pseudo-element-opacity.html]
+  [First contentful paint fires due to pseudo-element getting positive opacity.]
+    expected: FAIL

--- a/tests/wpt/meta/paint-timing/fcp-only/fcp-svg.html.ini
+++ b/tests/wpt/meta/paint-timing/fcp-only/fcp-svg.html.ini
@@ -1,0 +1,3 @@
+[fcp-svg.html]
+  [First contentful paint fires when SVG becomes contentful.]
+    expected: FAIL

--- a/tests/wpt/meta/paint-timing/fcp-only/fcp-text-input.html.ini
+++ b/tests/wpt/meta/paint-timing/fcp-only/fcp-text-input.html.ini
@@ -1,0 +1,3 @@
+[fcp-text-input.html]
+  [Text input should become contentful when its value is non-empty]
+    expected: FAIL

--- a/tests/wpt/meta/paint-timing/fcp-only/fcp-typographic-pseudo.html.ini
+++ b/tests/wpt/meta/paint-timing/fcp-only/fcp-typographic-pseudo.html.ini
@@ -1,0 +1,3 @@
+[fcp-typographic-pseudo.html]
+  [First contentful paint fires only when some of the text is visible, considering ::first-letter.]
+    expected: FAIL

--- a/tests/wpt/meta/paint-timing/fcp-only/svg-in-iframe.html.ini
+++ b/tests/wpt/meta/paint-timing/fcp-only/svg-in-iframe.html.ini
@@ -1,0 +1,3 @@
+[svg-in-iframe.html]
+  [SVG in an iframe does not trigger FCP in the main frame]
+    expected: FAIL

--- a/tests/wpt/meta/paint-timing/idlharness.window.js.ini
+++ b/tests/wpt/meta/paint-timing/idlharness.window.js.ini
@@ -1,0 +1,18 @@
+[idlharness.window.html]
+  [PerformancePaintTiming interface: operation toJSON()]
+    expected: FAIL
+
+  [PerformancePaintTiming interface: attribute paintTime]
+    expected: FAIL
+
+  [PerformancePaintTiming interface: attribute presentationTime]
+    expected: FAIL
+
+  [PerformancePaintTiming interface: default toJSON operation on paintTiming]
+    expected: FAIL
+
+  [PerformancePaintTiming interface: paintTiming must inherit property "paintTime" with the proper type]
+    expected: FAIL
+
+  [PerformancePaintTiming interface: paintTiming must inherit property "presentationTime" with the proper type]
+    expected: FAIL

--- a/tests/wpt/meta/paint-timing/paint-timing-mixin-to-json.html.ini
+++ b/tests/wpt/meta/paint-timing/paint-timing-mixin-to-json.html.ini
@@ -1,0 +1,3 @@
+[paint-timing-mixin-to-json.html]
+  [Paint timing entries should serialize paintTime and presentationTime with toJSON]
+    expected: FAIL

--- a/tests/wpt/meta/paint-timing/paint-timing-mixin.html.ini
+++ b/tests/wpt/meta/paint-timing/paint-timing-mixin.html.ini
@@ -1,0 +1,3 @@
+[paint-timing-mixin.html]
+  [Paint timing entries should expose paintTime and presentationTime]
+    expected: FAIL

--- a/tests/wpt/meta/paint-timing/with-first-paint/border-image.html.ini
+++ b/tests/wpt/meta/paint-timing/with-first-paint/border-image.html.ini
@@ -1,0 +1,4 @@
+[border-image.html]
+  expected: TIMEOUT
+  [Border image triggers First Contentful Paint.]
+    expected: TIMEOUT

--- a/tests/wpt/meta/paint-timing/with-first-paint/child-painting-first-image.html.ini
+++ b/tests/wpt/meta/paint-timing/with-first-paint/child-painting-first-image.html.ini
@@ -1,0 +1,3 @@
+[child-painting-first-image.html]
+  [Parent frame ignores paint-timing events fired from child image rendering.]
+    expected: FAIL

--- a/tests/wpt/meta/paint-timing/with-first-paint/first-contentful-bg-image.html.ini
+++ b/tests/wpt/meta/paint-timing/with-first-paint/first-contentful-bg-image.html.ini
@@ -1,0 +1,4 @@
+[first-contentful-bg-image.html]
+  expected: TIMEOUT
+  [First contentful paint fires due to background image render.]
+    expected: TIMEOUT

--- a/tests/wpt/meta/paint-timing/with-first-paint/mask-image.html.ini
+++ b/tests/wpt/meta/paint-timing/with-first-paint/mask-image.html.ini
@@ -1,0 +1,4 @@
+[mask-image.html]
+  expected: TIMEOUT
+  [Mask image triggers First Contentful Paint.]
+    expected: TIMEOUT

--- a/tests/wpt/meta/paint-timing/with-first-paint/sibling-painting-first-image.html.ini
+++ b/tests/wpt/meta/paint-timing/with-first-paint/sibling-painting-first-image.html.ini
@@ -1,0 +1,3 @@
+[sibling-painting-first-image.html]
+  [Frame ignores paint-timing events fired from sibling frame.]
+    expected: FAIL


### PR DESCRIPTION
We have a implementation of PaintTiming , so we should run the tests associated with them.

Testing: New tests enabled.