### PR TITLE
CI: update OHOS hitrace-bench version

### DIFF
--- a/.github/workflows/ohos.yml
+++ b/.github/workflows/ohos.yml
@@ -36,7 +36,7 @@ env:
   SHELL: /bin/bash
   CARGO_INCREMENTAL: 0
   BENCHER_PROJECT: ${{ vars.BENCHER_PROJECT || 'servo' }}
-  HITRACE_BENCH_VERSION: 0.9.0
+  HITRACE_BENCH_VERSION: 0.9.1
 
 jobs:
   build:
@@ -359,9 +359,9 @@ jobs:
         run: jq --compact-output --slurp add speedometer.json bench.json > combined-bencher.json
       - name: Uploading to bencher.dev
         # Post to bencher if at least one of the benchmarks succeeded.
-        if: | 
-          ${{ !cancelled() && steps.setup_complete.outcome == 'success' 
-                && (steps.hitrace_bench.outcome == 'success' 
+        if: |
+          ${{ !cancelled() && steps.setup_complete.outcome == 'success'
+                && (steps.hitrace_bench.outcome == 'success'
                       || steps.speedometer.outcome == 'success')
           }}
         # Note: That e.g. `--start-point` is ignored if it is an empty string,


### PR DESCRIPTION
The logs hitrace-bench reads will change soon with new phone versions. This updates this to read the new and old log files.

Signed-off-by: Narfinger <Narfinger@users.noreply.github.com>

Testing: Succesful run here: https://github.com/Narfinger/servo/actions/runs/21169416072 Note that the step failing is only for uploading to bencher because of wrong permissions.
