### PR TITLE
base: Set github revisions in Cargo.toml

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6638,7 +6638,7 @@ checksum = "b867cad97c0791bbd3aaa6472142568c6c9e8f71937e98379f584cfb0cf35bec"
 [[package]]
 name = "peek-poke"
 version = "0.3.0"
-source = "git+https://github.com/servo/webrender?branch=0.68#6cafc606096db4715a6119a6e16391aed9af47a5"
+source = "git+https://github.com/servo/webrender?rev=6cafc606096db4715a6119a6e16391aed9af47a5#6cafc606096db4715a6119a6e16391aed9af47a5"
 dependencies = [
  "euclid",
  "peek-poke-derive",
@@ -6647,7 +6647,7 @@ dependencies = [
 [[package]]
 name = "peek-poke-derive"
 version = "0.3.0"
-source = "git+https://github.com/servo/webrender?branch=0.68#6cafc606096db4715a6119a6e16391aed9af47a5"
+source = "git+https://github.com/servo/webrender?rev=6cafc606096db4715a6119a6e16391aed9af47a5#6cafc606096db4715a6119a6e16391aed9af47a5"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -7997,7 +7997,7 @@ dependencies = [
 [[package]]
 name = "selectors"
 version = "0.35.0"
-source = "git+https://github.com/servo/stylo?branch=2026-01-01#71737ad5c8b29c143a6c992af6222833f5d38b43"
+source = "git+https://github.com/servo/stylo?rev=71737ad5c8b29c143a6c992af6222833f5d38b43#71737ad5c8b29c143a6c992af6222833f5d38b43"
 dependencies = [
  "bitflags 2.10.0",
  "cssparser",
@@ -8117,7 +8117,7 @@ dependencies = [
 [[package]]
 name = "servo-media"
 version = "0.1.0"
-source = "git+https://github.com/servo/media#f384dbc4ff8b5c6f8db2c763306cbe2281d66391"
+source = "git+https://github.com/servo/media?rev=f384dbc4ff8b5c6f8db2c763306cbe2281d66391#f384dbc4ff8b5c6f8db2c763306cbe2281d66391"
 dependencies = [
  "once_cell",
  "servo-media-audio",
@@ -8130,7 +8130,7 @@ dependencies = [
 [[package]]
 name = "servo-media-audio"
 version = "0.2.0"
-source = "git+https://github.com/servo/media#f384dbc4ff8b5c6f8db2c763306cbe2281d66391"
+source = "git+https://github.com/servo/media?rev=f384dbc4ff8b5c6f8db2c763306cbe2281d66391#f384dbc4ff8b5c6f8db2c763306cbe2281d66391"
 dependencies = [
  "byte-slice-cast",
  "euclid",
@@ -8151,7 +8151,7 @@ dependencies = [
 [[package]]
 name = "servo-media-derive"
 version = "0.1.0"
-source = "git+https://github.com/servo/media#f384dbc4ff8b5c6f8db2c763306cbe2281d66391"
+source = "git+https://github.com/servo/media?rev=f384dbc4ff8b5c6f8db2c763306cbe2281d66391#f384dbc4ff8b5c6f8db2c763306cbe2281d66391"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -8161,7 +8161,7 @@ dependencies = [
 [[package]]
 name = "servo-media-dummy"
 version = "0.1.0"
-source = "git+https://github.com/servo/media#f384dbc4ff8b5c6f8db2c763306cbe2281d66391"
+source = "git+https://github.com/servo/media?rev=f384dbc4ff8b5c6f8db2c763306cbe2281d66391#f384dbc4ff8b5c6f8db2c763306cbe2281d66391"
 dependencies = [
  "ipc-channel",
  "servo-media",
@@ -8175,7 +8175,7 @@ dependencies = [
 [[package]]
 name = "servo-media-gstreamer"
 version = "0.1.0"
-source = "git+https://github.com/servo/media#f384dbc4ff8b5c6f8db2c763306cbe2281d66391"
+source = "git+https://github.com/servo/media?rev=f384dbc4ff8b5c6f8db2c763306cbe2281d66391#f384dbc4ff8b5c6f8db2c763306cbe2281d66391"
 dependencies = [
  "byte-slice-cast",
  "glib",
@@ -8208,7 +8208,7 @@ dependencies = [
 [[package]]
 name = "servo-media-gstreamer-render"
 version = "0.1.0"
-source = "git+https://github.com/servo/media#f384dbc4ff8b5c6f8db2c763306cbe2281d66391"
+source = "git+https://github.com/servo/media?rev=f384dbc4ff8b5c6f8db2c763306cbe2281d66391#f384dbc4ff8b5c6f8db2c763306cbe2281d66391"
 dependencies = [
  "gstreamer",
  "gstreamer-video",
@@ -8218,7 +8218,7 @@ dependencies = [
 [[package]]
 name = "servo-media-gstreamer-render-android"
 version = "0.1.0"
-source = "git+https://github.com/servo/media#f384dbc4ff8b5c6f8db2c763306cbe2281d66391"
+source = "git+https://github.com/servo/media?rev=f384dbc4ff8b5c6f8db2c763306cbe2281d66391#f384dbc4ff8b5c6f8db2c763306cbe2281d66391"
 dependencies = [
  "glib",
  "gstreamer",
@@ -8232,7 +8232,7 @@ dependencies = [
 [[package]]
 name = "servo-media-gstreamer-render-unix"
 version = "0.1.0"
-source = "git+https://github.com/servo/media#f384dbc4ff8b5c6f8db2c763306cbe2281d66391"
+source = "git+https://github.com/servo/media?rev=f384dbc4ff8b5c6f8db2c763306cbe2281d66391#f384dbc4ff8b5c6f8db2c763306cbe2281d66391"
 dependencies = [
  "glib",
  "gstreamer",
@@ -8246,7 +8246,7 @@ dependencies = [
 [[package]]
 name = "servo-media-player"
 version = "0.1.0"
-source = "git+https://github.com/servo/media#f384dbc4ff8b5c6f8db2c763306cbe2281d66391"
+source = "git+https://github.com/servo/media?rev=f384dbc4ff8b5c6f8db2c763306cbe2281d66391#f384dbc4ff8b5c6f8db2c763306cbe2281d66391"
 dependencies = [
  "ipc-channel",
  "serde",
@@ -8258,7 +8258,7 @@ dependencies = [
 [[package]]
 name = "servo-media-streams"
 version = "0.1.0"
-source = "git+https://github.com/servo/media#f384dbc4ff8b5c6f8db2c763306cbe2281d66391"
+source = "git+https://github.com/servo/media?rev=f384dbc4ff8b5c6f8db2c763306cbe2281d66391#f384dbc4ff8b5c6f8db2c763306cbe2281d66391"
 dependencies = [
  "uuid",
 ]
@@ -8266,12 +8266,12 @@ dependencies = [
 [[package]]
 name = "servo-media-traits"
 version = "0.1.0"
-source = "git+https://github.com/servo/media#f384dbc4ff8b5c6f8db2c763306cbe2281d66391"
+source = "git+https://github.com/servo/media?rev=f384dbc4ff8b5c6f8db2c763306cbe2281d66391#f384dbc4ff8b5c6f8db2c763306cbe2281d66391"
 
 [[package]]
 name = "servo-media-webrtc"
 version = "0.1.0"
-source = "git+https://github.com/servo/media#f384dbc4ff8b5c6f8db2c763306cbe2281d66391"
+source = "git+https://github.com/servo/media?rev=f384dbc4ff8b5c6f8db2c763306cbe2281d66391#f384dbc4ff8b5c6f8db2c763306cbe2281d66391"
 dependencies = [
  "log",
  "servo-media-streams",
@@ -8304,7 +8304,7 @@ dependencies = [
 [[package]]
 name = "servo_arc"
 version = "0.4.3"
-source = "git+https://github.com/servo/stylo?branch=2026-01-01#71737ad5c8b29c143a6c992af6222833f5d38b43"
+source = "git+https://github.com/servo/stylo?rev=71737ad5c8b29c143a6c992af6222833f5d38b43#71737ad5c8b29c143a6c992af6222833f5d38b43"
 dependencies = [
  "serde",
  "stable_deref_trait",
@@ -8852,7 +8852,7 @@ dependencies = [
 [[package]]
 name = "stylo"
 version = "0.11.0"
-source = "git+https://github.com/servo/stylo?branch=2026-01-01#71737ad5c8b29c143a6c992af6222833f5d38b43"
+source = "git+https://github.com/servo/stylo?rev=71737ad5c8b29c143a6c992af6222833f5d38b43#71737ad5c8b29c143a6c992af6222833f5d38b43"
 dependencies = [
  "app_units",
  "arrayvec",
@@ -8907,7 +8907,7 @@ dependencies = [
 [[package]]
 name = "stylo_atoms"
 version = "0.11.0"
-source = "git+https://github.com/servo/stylo?branch=2026-01-01#71737ad5c8b29c143a6c992af6222833f5d38b43"
+source = "git+https://github.com/servo/stylo?rev=71737ad5c8b29c143a6c992af6222833f5d38b43#71737ad5c8b29c143a6c992af6222833f5d38b43"
 dependencies = [
  "string_cache",
  "string_cache_codegen",
@@ -8916,12 +8916,12 @@ dependencies = [
 [[package]]
 name = "stylo_config"
 version = "0.11.0"
-source = "git+https://github.com/servo/stylo?branch=2026-01-01#71737ad5c8b29c143a6c992af6222833f5d38b43"
+source = "git+https://github.com/servo/stylo?rev=71737ad5c8b29c143a6c992af6222833f5d38b43#71737ad5c8b29c143a6c992af6222833f5d38b43"
 
 [[package]]
 name = "stylo_derive"
 version = "0.11.0"
-source = "git+https://github.com/servo/stylo?branch=2026-01-01#71737ad5c8b29c143a6c992af6222833f5d38b43"
+source = "git+https://github.com/servo/stylo?rev=71737ad5c8b29c143a6c992af6222833f5d38b43#71737ad5c8b29c143a6c992af6222833f5d38b43"
 dependencies = [
  "darling",
  "proc-macro2",
@@ -8933,7 +8933,7 @@ dependencies = [
 [[package]]
 name = "stylo_dom"
 version = "0.11.0"
-source = "git+https://github.com/servo/stylo?branch=2026-01-01#71737ad5c8b29c143a6c992af6222833f5d38b43"
+source = "git+https://github.com/servo/stylo?rev=71737ad5c8b29c143a6c992af6222833f5d38b43#71737ad5c8b29c143a6c992af6222833f5d38b43"
 dependencies = [
  "bitflags 2.10.0",
  "stylo_malloc_size_of",
@@ -8942,7 +8942,7 @@ dependencies = [
 [[package]]
 name = "stylo_malloc_size_of"
 version = "0.11.0"
-source = "git+https://github.com/servo/stylo?branch=2026-01-01#71737ad5c8b29c143a6c992af6222833f5d38b43"
+source = "git+https://github.com/servo/stylo?rev=71737ad5c8b29c143a6c992af6222833f5d38b43#71737ad5c8b29c143a6c992af6222833f5d38b43"
 dependencies = [
  "app_units",
  "cssparser",
@@ -8959,12 +8959,12 @@ dependencies = [
 [[package]]
 name = "stylo_static_prefs"
 version = "0.11.0"
-source = "git+https://github.com/servo/stylo?branch=2026-01-01#71737ad5c8b29c143a6c992af6222833f5d38b43"
+source = "git+https://github.com/servo/stylo?rev=71737ad5c8b29c143a6c992af6222833f5d38b43#71737ad5c8b29c143a6c992af6222833f5d38b43"
 
 [[package]]
 name = "stylo_traits"
 version = "0.11.0"
-source = "git+https://github.com/servo/stylo?branch=2026-01-01#71737ad5c8b29c143a6c992af6222833f5d38b43"
+source = "git+https://github.com/servo/stylo?rev=71737ad5c8b29c143a6c992af6222833f5d38b43#71737ad5c8b29c143a6c992af6222833f5d38b43"
 dependencies = [
  "app_units",
  "bitflags 2.10.0",
@@ -9377,7 +9377,7 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 [[package]]
 name = "to_shmem"
 version = "0.3.0"
-source = "git+https://github.com/servo/stylo?branch=2026-01-01#71737ad5c8b29c143a6c992af6222833f5d38b43"
+source = "git+https://github.com/servo/stylo?rev=71737ad5c8b29c143a6c992af6222833f5d38b43#71737ad5c8b29c143a6c992af6222833f5d38b43"
 dependencies = [
  "cssparser",
  "servo_arc",
@@ -9390,7 +9390,7 @@ dependencies = [
 [[package]]
 name = "to_shmem_derive"
 version = "0.1.0"
-source = "git+https://github.com/servo/stylo?branch=2026-01-01#71737ad5c8b29c143a6c992af6222833f5d38b43"
+source = "git+https://github.com/servo/stylo?rev=71737ad5c8b29c143a6c992af6222833f5d38b43#71737ad5c8b29c143a6c992af6222833f5d38b43"
 dependencies = [
  "darling",
  "proc-macro2",
@@ -10419,7 +10419,7 @@ dependencies = [
 [[package]]
 name = "webrender"
 version = "0.68.0"
-source = "git+https://github.com/servo/webrender?branch=0.68#6cafc606096db4715a6119a6e16391aed9af47a5"
+source = "git+https://github.com/servo/webrender?rev=6cafc606096db4715a6119a6e16391aed9af47a5#6cafc606096db4715a6119a6e16391aed9af47a5"
 dependencies = [
  "allocator-api2",
  "bincode",
@@ -10455,7 +10455,7 @@ dependencies = [
 [[package]]
 name = "webrender_api"
 version = "0.68.0"
-source = "git+https://github.com/servo/webrender?branch=0.68#6cafc606096db4715a6119a6e16391aed9af47a5"
+source = "git+https://github.com/servo/webrender?rev=6cafc606096db4715a6119a6e16391aed9af47a5#6cafc606096db4715a6119a6e16391aed9af47a5"
 dependencies = [
  "app_units",
  "bitflags 2.10.0",
@@ -10474,7 +10474,7 @@ dependencies = [
 [[package]]
 name = "webrender_build"
 version = "0.0.2"
-source = "git+https://github.com/servo/webrender?branch=0.68#6cafc606096db4715a6119a6e16391aed9af47a5"
+source = "git+https://github.com/servo/webrender?rev=6cafc606096db4715a6119a6e16391aed9af47a5#6cafc606096db4715a6119a6e16391aed9af47a5"
 dependencies = [
  "bitflags 2.10.0",
  "lazy_static",
@@ -11191,7 +11191,7 @@ checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
 [[package]]
 name = "wr_glyph_rasterizer"
 version = "0.1.0"
-source = "git+https://github.com/servo/webrender?branch=0.68#6cafc606096db4715a6119a6e16391aed9af47a5"
+source = "git+https://github.com/servo/webrender?rev=6cafc606096db4715a6119a6e16391aed9af47a5#6cafc606096db4715a6119a6e16391aed9af47a5"
 dependencies = [
  "core-foundation 0.9.4",
  "core-graphics",
@@ -11216,7 +11216,7 @@ dependencies = [
 [[package]]
 name = "wr_malloc_size_of"
 version = "0.2.2"
-source = "git+https://github.com/servo/webrender?branch=0.68#6cafc606096db4715a6119a6e16391aed9af47a5"
+source = "git+https://github.com/servo/webrender?rev=6cafc606096db4715a6119a6e16391aed9af47a5#6cafc606096db4715a6119a6e16391aed9af47a5"
 dependencies = [
  "app_units",
  "euclid",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -157,16 +157,16 @@ script_traits = { path = "components/shared/script" }
 sea-query = { version = "1.0.0-rc.29", default-features = false, features = ["backend-sqlite", "derive"] }
 sea-query-rusqlite = { version = "0.8.0-rc.15" }
 sec1 = "0.7"
-selectors = { git = "https://github.com/servo/stylo", branch = "2026-01-01" }
+selectors = { git = "https://github.com/servo/stylo", rev = "71737ad5c8b29c143a6c992af6222833f5d38b43" }
 serde = "1.0.228"
 serde_bytes = "0.11"
 serde_core = "1.0.226"
 serde_json = "1.0"
-servo-media = { git = "https://github.com/servo/media" }
-servo-media-dummy = { git = "https://github.com/servo/media" }
-servo-media-gstreamer = { git = "https://github.com/servo/media" }
+servo-media = { git = "https://github.com/servo/media", rev = "f384dbc4ff8b5c6f8db2c763306cbe2281d66391" }
+servo-media-dummy = { git = "https://github.com/servo/media", rev = "f384dbc4ff8b5c6f8db2c763306cbe2281d66391" }
+servo-media-gstreamer = { git = "https://github.com/servo/media", rev = "f384dbc4ff8b5c6f8db2c763306cbe2281d66391" }
 servo-tracing = { path = "components/servo_tracing" }
-servo_arc = { git = "https://github.com/servo/stylo", branch = "2026-01-01" }
+servo_arc = { git = "https://github.com/servo/stylo", rev = "71737ad5c8b29c143a6c992af6222833f5d38b43" }
 sha1 = "0.10"
 sha2 = "0.10"
 sha3 = "0.10"
@@ -175,12 +175,12 @@ smallvec = { version = "1.15", features = ["serde", "union"] }
 storage_traits = { path = "components/shared/storage" }
 string_cache = "0.9"
 strum = { version = "0.27", features = ["derive"] }
-stylo = { git = "https://github.com/servo/stylo", branch = "2026-01-01" }
-stylo_atoms = { git = "https://github.com/servo/stylo", branch = "2026-01-01" }
-stylo_config = { git = "https://github.com/servo/stylo", branch = "2026-01-01" }
-stylo_dom = { git = "https://github.com/servo/stylo", branch = "2026-01-01" }
-stylo_malloc_size_of = { git = "https://github.com/servo/stylo", branch = "2026-01-01" }
-stylo_traits = { git = "https://github.com/servo/stylo", branch = "2026-01-01" }
+stylo = { git = "https://github.com/servo/stylo", rev = "71737ad5c8b29c143a6c992af6222833f5d38b43" }
+stylo_atoms = { git = "https://github.com/servo/stylo", rev = "71737ad5c8b29c143a6c992af6222833f5d38b43" }
+stylo_config = { git = "https://github.com/servo/stylo", rev = "71737ad5c8b29c143a6c992af6222833f5d38b43" }
+stylo_dom = { git = "https://github.com/servo/stylo", rev = "71737ad5c8b29c143a6c992af6222833f5d38b43" }
+stylo_malloc_size_of = { git = "https://github.com/servo/stylo", rev = "71737ad5c8b29c143a6c992af6222833f5d38b43" }
+stylo_traits = { git = "https://github.com/servo/stylo", rev = "71737ad5c8b29c143a6c992af6222833f5d38b43" }
 surfman = { version = "0.11.0", features = ["chains"] }
 syn = { version = "2", default-features = false, features = ["clone-impls", "derive", "parsing"] }
 synstructure = "0.13"
@@ -211,8 +211,8 @@ vello_cpu = "0.0.4"
 webdriver = "0.53.0"
 webgpu_traits = { path = "components/shared/webgpu" }
 webpki-roots = "1.0"
-webrender = { git = "https://github.com/servo/webrender", branch = "0.68", features = ["capture"] }
-webrender_api = { git = "https://github.com/servo/webrender", branch = "0.68" }
+webrender = { git = "https://github.com/servo/webrender", rev = "6cafc606096db4715a6119a6e16391aed9af47a5", features = ["capture"] }
+webrender_api = { git = "https://github.com/servo/webrender", rev = "6cafc606096db4715a6119a6e16391aed9af47a5" }
 webxr-api = { path = "components/shared/webxr" }
 wgpu-core = "26"
 wgpu-types = "26"
@@ -220,7 +220,7 @@ winapi = "0.3"
 windows-sys = "0.61"
 winit = "0.30.12"
 wio = "0.2"
-wr_malloc_size_of = { git = "https://github.com/servo/webrender", branch = "0.68" }
+wr_malloc_size_of = { git = "https://github.com/servo/webrender", rev = "6cafc606096db4715a6119a6e16391aed9af47a5" }
 x25519-dalek = { version = "2.0.1", features = ["static_secrets"] }
 xi-unicode = "0.3.0"
 xml5ever = "0.36.1"


### PR DESCRIPTION
This takes the github revisions from the current Cargo.lock file and puts them as required in the Cargo.toml.

Testing: It compiles.
Fixes: https://github.com/servo/servo/issues/42027

Signed-off-by: Narfinger <Narfinger@users.noreply.github.com>
