### PR TITLE
script: Ignore platform mouse move events that do not change the cursor location

### DIFF
--- a/components/script/dom/document_event_handler.rs
+++ b/components/script/dom/document_event_handler.rs
@@ -428,6 +428,13 @@ impl DocumentEventHandler {
             return;
         };
 
+        let old_mouse_move_point = self
+            .most_recent_mousemove_point
+            .replace(Some(hit_test_result.point_in_frame));
+        if old_mouse_move_point == Some(hit_test_result.point_in_frame) {
+            return;
+        }
+
         // Update the cursor when the mouse moves, if it has changed.
         self.set_cursor(Some(hit_test_result.cursor));
 
@@ -537,8 +544,6 @@ impl DocumentEventHandler {
         .fire(new_target.upcast(), can_gc);
 
         self.update_current_hover_target_and_status(Some(new_target));
-        self.most_recent_mousemove_point
-            .set(Some(hit_test_result.point_in_frame));
     }
 
     fn update_current_hover_target_and_status(&self, new_hover_target: Option<DomRoot<Element>>) {

--- a/tests/wpt/mozilla/meta/MANIFEST.json
+++ b/tests/wpt/mozilla/meta/MANIFEST.json
@@ -13016,6 +13016,15 @@
        "testdriver": true
       }
      ]
+    ],
+    "spurious-mouse-move-events.html": [
+     "9cfa22aaf90a0d3399fd03a80aa87dd0f16f76d6",
+     [
+      null,
+      {
+       "testdriver": true
+      }
+     ]
     ]
    },
    "mozilla": {

--- a/tests/wpt/mozilla/tests/input-events/spurious-mouse-move-events.html
+++ b/tests/wpt/mozilla/tests/input-events/spurious-mouse-move-events.html
@@ -1,0 +1,35 @@
+
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <title>mousemove events that do not change the cursor position are ignored</title>
+    <link rel="author" title="Martin Robinson" href="mailto:mrobinson@igalia.com" />
+    <script src="/resources/testharness.js"></script>
+    <script src="/resources/testharnessreport.js"></script>
+    <script src="/resources/testdriver.js"></script>
+    <script src="/resources/testdriver-actions.js"></script>
+    <script src="/resources/testdriver-vendor.js"></script>
+  </head>
+  <body>
+    <div id="target" style="width: 100px; height: 100px;"></div>
+    <script>
+        promise_test(async (t) => {
+            const target = document.getElementById("target");
+            const eventWatcher = new EventWatcher(t, target, ["mousemove", "click"]);
+
+            // We should only receive a single "mousemove" event if the cursor does not move.
+            const eventPromise = eventWatcher.wait_for(["mousemove", "click"]);
+
+            const actions_promise = await new test_driver.Actions()
+              .pointerMove(10, 10, {origin: target})
+              .pointerMove(10, 10, {origin: target})
+              .pointerMove(10, 10, {origin: target})
+              .pointerMove(10, 10, {origin: target})
+              .pointerDown().pointerUp()
+              .send();
+            await eventPromise;
+        });
+    </script>
+  </body>
+</html>


### PR DESCRIPTION
winit on macOS seems to send a mousemove event right before mouse button
up events. This interferes with interactive use of text boxes -- for
instance double-clicking to select the hovered word. This change makes it so
that mouse move events that do not change the cursor location are
ignored.

Testing: This change adds a Servo-specific WPT-style test.
