### PR TITLE
CI: force GitHub hosted runners if wpt-args is not empty

### DIFF
--- a/.github/workflows/linux-wpt.yml
+++ b/.github/workflows/linux-wpt.yml
@@ -61,7 +61,7 @@ jobs:
           # <https://github.com/servo/servo/settings/variables/actions>
           NO_SELF_HOSTED_RUNNERS: ${{ vars.NO_SELF_HOSTED_RUNNERS }}
           # Any other boolean conditions that disable self-hosted runners go here.
-          force-github-hosted-runner: ${{ inputs.upload || inputs.force-github-hosted-runner }}
+          force-github-hosted-runner: ${{ inputs.wpt-args != '' }}
   linux-wpt:
     needs:
       - runner-select


### PR DESCRIPTION
This will prevent running webgpu runs on self-hosted, as they are too slow and would slow the queue down. I also noticed that existing conditions for forcing github hosted runners were actually invalid (I think something might got lost in rebase), so I removed them.

Fixes: https://github.com/servo/servo/pull/41062#issuecomment-3773159746
