### PR TITLE
layout: Properly propagate baselines of flex items that do not participate in baseline alignment

### DIFF
--- a/components/layout/flexbox/layout.rs
+++ b/components/layout/flexbox/layout.rs
@@ -115,9 +115,12 @@ struct FlexItemLayoutResult {
     fragments: Vec<Fragment>,
     positioning_context: PositioningContext,
 
+    /// Baselines from the item’s content, relative to the item’s margin box.
+    /// Used only for baseline propagation to parent layout contexts.
     content_baselines_relative_to_margin_box: Baselines,
 
-    // Either the first or the last baseline, depending on ‘align-self’.
+    /// This is the single baseline this item uses for flex alignment.
+    /// Either the first or the last baseline or None, depending on ‘align-self’.
     flex_alignment_baseline_relative_to_margin_box: Option<Au>,
 
     // The content size of this layout in the block axis. This is known before layout

--- a/tests/wpt/meta/css/css-align/baseline-rules/synthesized-baseline-flexbox-001.html.ini
+++ b/tests/wpt/meta/css/css-align/baseline-rules/synthesized-baseline-flexbox-001.html.ini
@@ -1,0 +1,12 @@
+[synthesized-baseline-flexbox-001.html]
+  [.wrapper 4]
+    expected: FAIL
+
+  [.wrapper 5]
+    expected: FAIL
+
+  [.wrapper 6]
+    expected: FAIL
+
+  [.wrapper 7]
+    expected: FAIL

--- a/tests/wpt/meta/css/css-flexbox/alignment/flex-align-baseline-flex-001.html.ini
+++ b/tests/wpt/meta/css/css-flexbox/alignment/flex-align-baseline-flex-001.html.ini
@@ -1,10 +1,4 @@
 [flex-align-baseline-flex-001.html]
-  [.target > * 1]
-    expected: FAIL
-
-  [.target > * 7]
-    expected: FAIL
-
   [.target > * 9]
     expected: FAIL
 
@@ -12,12 +6,6 @@
     expected: FAIL
 
   [.target > * 15]
-    expected: FAIL
-
-  [.target > * 17]
-    expected: FAIL
-
-  [.target > * 23]
     expected: FAIL
 
   [.target > * 27]
@@ -51,4 +39,22 @@
     expected: FAIL
 
   [.target > * 47]
+    expected: FAIL
+
+  [.target > * 3]
+    expected: FAIL
+
+  [.target > * 5]
+    expected: FAIL
+
+  [.target > * 13]
+    expected: FAIL
+
+  [.target > * 19]
+    expected: FAIL
+
+  [.target > * 21]
+    expected: FAIL
+
+  [.target > * 29]
     expected: FAIL

--- a/tests/wpt/meta/css/css-flexbox/alignment/flex-align-baseline-flex-001.html.ini
+++ b/tests/wpt/meta/css/css-flexbox/alignment/flex-align-baseline-flex-001.html.ini
@@ -41,19 +41,7 @@
   [.target > * 47]
     expected: FAIL
 
-  [.target > * 3]
-    expected: FAIL
-
-  [.target > * 5]
-    expected: FAIL
-
   [.target > * 13]
-    expected: FAIL
-
-  [.target > * 19]
-    expected: FAIL
-
-  [.target > * 21]
     expected: FAIL
 
   [.target > * 29]

--- a/tests/wpt/meta/css/css-flexbox/baseline-outside-flex-item.html.ini
+++ b/tests/wpt/meta/css/css-flexbox/baseline-outside-flex-item.html.ini
@@ -1,0 +1,2 @@
+[baseline-outside-flex-item.html]
+  expected: FAIL

--- a/tests/wpt/meta/css/css-flexbox/baseline-outside-flex-item.html.ini
+++ b/tests/wpt/meta/css/css-flexbox/baseline-outside-flex-item.html.ini
@@ -1,2 +1,0 @@
-[baseline-outside-flex-item.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-flexbox/flex-inline.html.ini
+++ b/tests/wpt/meta/css/css-flexbox/flex-inline.html.ini
@@ -1,2 +1,0 @@
-[flex-inline.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-flexbox/flexbox-baseline-multi-item-horiz-001a.html.ini
+++ b/tests/wpt/meta/css/css-flexbox/flexbox-baseline-multi-item-horiz-001a.html.ini
@@ -1,2 +1,0 @@
-[flexbox-baseline-multi-item-horiz-001a.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-flexbox/flexbox-baseline-multi-item-horiz-001b.html.ini
+++ b/tests/wpt/meta/css/css-flexbox/flexbox-baseline-multi-item-horiz-001b.html.ini
@@ -1,2 +1,0 @@
-[flexbox-baseline-multi-item-horiz-001b.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-flexbox/flexbox-baseline-multi-line-horiz-001.html.ini
+++ b/tests/wpt/meta/css/css-flexbox/flexbox-baseline-multi-line-horiz-001.html.ini
@@ -1,2 +1,0 @@
-[flexbox-baseline-multi-line-horiz-001.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-flexbox/flexbox-baseline-single-item-001a.html.ini
+++ b/tests/wpt/meta/css/css-flexbox/flexbox-baseline-single-item-001a.html.ini
@@ -1,2 +1,0 @@
-[flexbox-baseline-single-item-001a.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-flexbox/flexbox_inline.html.ini
+++ b/tests/wpt/meta/css/css-flexbox/flexbox_inline.html.ini
@@ -1,2 +1,0 @@
-[flexbox_inline.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-grid/alignment/grid-align-baseline-flex-001.html.ini
+++ b/tests/wpt/meta/css/css-grid/alignment/grid-align-baseline-flex-001.html.ini
@@ -67,3 +67,9 @@
 
   [.target > * 47]
     expected: FAIL
+
+  [.target > * 2]
+    expected: FAIL
+
+  [.target > * 25]
+    expected: FAIL

--- a/tests/wpt/meta/css/css-grid/alignment/grid-baseline-003.html.ini
+++ b/tests/wpt/meta/css/css-grid/alignment/grid-baseline-003.html.ini
@@ -1,2 +1,0 @@
-[grid-baseline-003.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-inline/baseline-source/baseline-source-first-001.html.ini
+++ b/tests/wpt/meta/css/css-inline/baseline-source/baseline-source-first-001.html.ini
@@ -16,6 +16,3 @@
 
   [.target > * 21]
     expected: FAIL
-
-  [.target > * 11]
-    expected: FAIL

--- a/tests/wpt/meta/css/css-inline/baseline-source/baseline-source-first-001.html.ini
+++ b/tests/wpt/meta/css/css-inline/baseline-source/baseline-source-first-001.html.ini
@@ -16,3 +16,6 @@
 
   [.target > * 21]
     expected: FAIL
+
+  [.target > * 11]
+    expected: FAIL

--- a/tests/wpt/meta/css/css-lists/list-and-flex-001.html.ini
+++ b/tests/wpt/meta/css/css-lists/list-and-flex-001.html.ini
@@ -1,2 +1,0 @@
-[list-and-flex-001.html]
-  expected: FAIL

--- a/tests/wpt/meta/html/rendering/the-details-element/summary-display-inline-flex.html.ini
+++ b/tests/wpt/meta/html/rendering/the-details-element/summary-display-inline-flex.html.ini
@@ -1,2 +1,0 @@
-[summary-display-inline-flex.html]
-  expected: FAIL


### PR DESCRIPTION
Fix baseline propagation from flex containers

Flex item layout previously conflated baselines that got propagated and baseline alignment within flex.

Testing: Before and after layout of the manual test cases.

[test.html](https://github.com/user-attachments/files/24796669/test.html) (from original issue)

<img width="645" height="464" alt="image" src="https://github.com/user-attachments/assets/57ef6fe7-963c-44b7-96ef-6c81132c9b96" />

[test2.html](https://github.com/user-attachments/files/24796679/test2.html) (from Oriol's comment)

<img width="164" height="299" alt="image" src="https://github.com/user-attachments/assets/54dc8cf6-8b0c-4077-8eca-fd18b11f2584" />


Fixes: #41905 
