### PR TITLE
webdriver: Reset prefs to the values present at server start.

### DIFF
--- a/ports/servoshell/desktop/app.rs
+++ b/ports/servoshell/desktop/app.rs
@@ -122,6 +122,7 @@ impl App {
             self.servoshell_preferences.clone(),
             self.waker.clone(),
             user_content_manager,
+            self.preferences.clone(),
         ));
         running_state.open_window(platform_window, self.initial_url.as_url().clone());
 

--- a/ports/servoshell/egl/app.rs
+++ b/ports/servoshell/egl/app.rs
@@ -271,7 +271,7 @@ impl App {
     pub(super) fn new(init: AppInitOptions) -> Rc<Self> {
         let mut servo_builder = ServoBuilder::default()
             .opts(init.opts)
-            .preferences(init.preferences)
+            .preferences(init.preferences.clone())
             .event_loop_waker(init.event_loop_waker.clone());
         #[cfg(feature = "webxr")]
         let servo_builder = servo_builder
@@ -290,6 +290,7 @@ impl App {
             init.servoshell_preferences,
             init.event_loop_waker,
             user_content_manager,
+            init.preferences,
         ));
 
         Rc::new(Self {

--- a/ports/servoshell/running_app_state.rs
+++ b/ports/servoshell/running_app_state.rs
@@ -19,10 +19,10 @@ use servo::{
     AllowOrDenyRequest, AuthenticationRequest, CSSPixel, ConsoleLogLevel, CreateNewWebViewRequest,
     DeviceIntPoint, DeviceIntSize, EmbedderControl, EmbedderControlId, EventLoopWaker,
     GenericSender, InputEvent, InputEventId, InputEventResult, JSValue, LoadStatus,
-    MediaSessionEvent, PermissionRequest, PrefValue, ScreenshotCaptureError, Servo, ServoDelegate,
-    ServoError, TraversalId, UserContentManager, WebDriverCommandMsg, WebDriverJSResult,
-    WebDriverLoadStatus, WebDriverScriptCommand, WebDriverSenders, WebView, WebViewDelegate,
-    WebViewId, pref,
+    MediaSessionEvent, PermissionRequest, PrefValue, Preferences, ScreenshotCaptureError, Servo,
+    ServoDelegate, ServoError, TraversalId, UserContentManager, WebDriverCommandMsg,
+    WebDriverJSResult, WebDriverLoadStatus, WebDriverScriptCommand, WebDriverSenders, WebView,
+    WebViewDelegate, WebViewId, pref,
 };
 use url::Url;
 
@@ -205,6 +205,7 @@ impl RunningAppState {
         servoshell_preferences: ServoShellPreferences,
         event_loop_waker: Box<dyn EventLoopWaker>,
         user_content_manager: Rc<UserContentManager>,
+        default_preferences: Preferences,
     ) -> Self {
         servo.set_delegate(Rc::new(ServoShellServoDelegate));
 
@@ -217,7 +218,12 @@ impl RunningAppState {
 
         let webdriver_receiver = servoshell_preferences.webdriver_port.get().map(|port| {
             let (embedder_sender, embedder_receiver) = unbounded();
-            webdriver_server::start_server(port, embedder_sender, event_loop_waker);
+            webdriver_server::start_server(
+                port,
+                embedder_sender,
+                event_loop_waker,
+                default_preferences,
+            );
             embedder_receiver
         });
 

--- a/resources/wpt-prefs.json
+++ b/resources/wpt-prefs.json
@@ -1,7 +1,5 @@
 {
-  "dom_adoptedstylesheet_enabled": true,
   "dom_webxr_test": true,
-  "dom_visual_viewport_enabled": true,
   "gfx_text_antialiasing_enabled": false,
   "dom_testutils_enabled": true
 }


### PR DESCRIPTION
The test harness attempts to reset preferences to default values when running a test in which previously-set preferences are no longer set. This leads to confusing interactions with any preference customizations that are present, such as `--pref whatever` or `--prefs-file something.json`, which are not considered when calculating the default. This PR changes that: whatever preference values are present when the webdriver server starts is treated as the default value.

Testing: This is a servo-specific webdriver extension, and we're fixing an interaction with the test harness. I don't see another way to test this besides observing the impact on our test results.
Fixes: #42043
