### PR TITLE
script: Allow selecting text in input fields with the mouse

### DIFF
--- a/components/script/dom/window.rs
+++ b/components/script/dom/window.rs
@@ -3006,12 +3006,11 @@ impl Window {
     pub(crate) fn text_index_query_on_node_for_event(
         &self,
         node: &Node,
-        event: &Event,
+        mouse_event: &MouseEvent,
     ) -> Option<usize> {
         // dispatch_key_event (document.rs) triggers a click event when releasing
         // the space key. There's no nice way to catch this so let's use this for
         // now.
-        let mouse_event = event.downcast::<MouseEvent>()?;
         let point_in_viewport = mouse_event.point_in_viewport()?.map(Au::from_f32_px);
 
         self.layout_reflow(QueryMsg::TextIndexQuery);

--- a/tests/wpt/mozilla/meta/MANIFEST.json
+++ b/tests/wpt/mozilla/meta/MANIFEST.json
@@ -12990,6 +12990,24 @@
       }
      ]
     ],
+    "mouse-text-selection-input-text.html": [
+     "c140004ae89fb8a73fb2a4d3c78382dde6134a07",
+     [
+      null,
+      {
+       "testdriver": true
+      }
+     ]
+    ],
+    "mouse-text-selection-textarea.html": [
+     "f059a1dac29b36dec238580438b75138c8c89db9",
+     [
+      null,
+      {
+       "testdriver": true
+      }
+     ]
+    ],
     "mousedown-edit-point-input-text.html": [
      "69faa576c30300845a6e621c3b51093eae2a1c01",
      [

--- a/tests/wpt/mozilla/tests/input-events/mouse-text-selection-input-text.html
+++ b/tests/wpt/mozilla/tests/input-events/mouse-text-selection-input-text.html
@@ -1,0 +1,87 @@
+<!DOCTYPE html>
+<title>Basic selection of text via the mouse in &lt;input type=text&gt;</title>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/resources/testdriver.js"></script>
+<script src="/resources/testdriver-actions.js"></script>
+<script src="/resources/testdriver-vendor.js"></script>
+<link rel="stylesheet" type="text/css" href="/fonts/ahem.css" />
+
+<input id="target" style="font: 50px/1 Ahem;" value="123456">
+
+<script>
+promise_test(async test => {
+    let targetRect = target.getBoundingClientRect();
+    let verticalCenterOfLine = targetRect.top + (targetRect.height / 2);
+
+    // Click somewhere else to avoid double-clicking.
+    await new test_driver.Actions()
+      .pointerMove(500, 500)
+      .pointerDown()
+      .pointerUp()
+      .send();
+
+    await new test_driver.Actions()
+      .pointerMove(targetRect.left + 1, verticalCenterOfLine)
+      .pointerDown()
+      .pointerMove(targetRect.left + (50 * 5), verticalCenterOfLine)
+      .pointerUp()
+      .send();
+    assert_equals(target.selectionStart, 0);
+    assert_equals(target.selectionEnd, 5);
+    assert_equals(target.selectionDirection, "forward");
+    target.setSelectionRange(0, 0);
+
+    // Click somewhere else to avoid double-clicking.
+    await new test_driver.Actions()
+      .pointerMove(500, 500)
+      .pointerDown()
+      .pointerUp()
+      .send();
+
+    await new test_driver.Actions()
+      .pointerMove(targetRect.left + (50 * 5), verticalCenterOfLine)
+      .pointerDown()
+      .pointerMove(targetRect.left + 1, verticalCenterOfLine)
+      .pointerUp()
+      .send();
+    assert_equals(target.selectionStart, 0);
+    assert_equals(target.selectionEnd, 5);
+    assert_equals(target.selectionDirection, "backward");
+    target.setSelectionRange(0, 0);
+});
+
+promise_test(async test => {
+    let targetRect = target.getBoundingClientRect();
+    let verticalCenterOfLine = targetRect.top + (targetRect.height / 2);
+
+    // Click somewhere else to avoid double-clicking.
+    await new test_driver.Actions()
+      .pointerMove(500, 500)
+      .pointerDown()
+      .pointerUp()
+      .send();
+
+    let actions = new test_driver.Actions();
+    let middleButtonOptions = { button: actions.ButtonType.MIDDLE };
+    await actions
+      .pointerMove(targetRect.left + 1, verticalCenterOfLine)
+      .pointerDown()
+      .pointerMove(targetRect.left + (50 * 3), verticalCenterOfLine)
+      .pointerDown(middleButtonOptions)
+      .pointerUp(middleButtonOptions)
+      .pointerMove(targetRect.left + (50 * 5), verticalCenterOfLine)
+      .pointerUp()
+      .send();
+    assert_equals(target.selectionStart, 0);
+    assert_equals(target.selectionEnd, 3);
+    target.setSelectionRange(0, 0);
+
+    // Click somewhere else to avoid double-clicking.
+    await new test_driver.Actions()
+      .pointerMove(500, 500)
+      .pointerDown()
+      .pointerUp()
+      .send();
+}, "Middle button click should cancel ongoing text selection via drag");
+</script>

--- a/tests/wpt/mozilla/tests/input-events/mouse-text-selection-textarea.html
+++ b/tests/wpt/mozilla/tests/input-events/mouse-text-selection-textarea.html
@@ -1,0 +1,158 @@
+<!DOCTYPE html>
+<title>Clicking in &lt;textarea&gt; should move the edit point</title>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/resources/testdriver.js"></script>
+<script src="/resources/testdriver-actions.js"></script>
+<script src="/resources/testdriver-vendor.js"></script>
+<link rel="stylesheet" type="text/css" href="/fonts/ahem.css" />
+
+<textarea id="target" style="color: rgba(255, 0, 0, 0.2); height: 500px; width: 500px;  font: 50px/1 Ahem;">
+12345
+12345
+12345
+12345
+</textarea>
+
+<script>
+promise_test(async test => {
+    let targetRect = target.getBoundingClientRect();
+    let middleOfFirstLine = (50 / 2) + targetRect.top;
+    let middleOfThirdLine = (50 * 2) + 25 + targetRect.top;
+
+    // Click somewhere else to avoid double-clicking.
+    await new test_driver.Actions()
+      .pointerMove(500, 500)
+      .pointerDown()
+      .pointerUp()
+      .send();
+
+    await new test_driver.Actions()
+      .pointerMove(targetRect.left + 10, middleOfFirstLine)
+      .pointerDown()
+      .pointerMove(targetRect.left + (50 * 5), middleOfFirstLine)
+      .pointerUp()
+      .send();
+    assert_equals(target.selectionStart, 0);
+    assert_equals(target.selectionEnd, 5);
+    assert_equals(target.selectionDirection, "forward");
+    target.setSelectionRange(0, 0);
+
+    // Click somewhere else to avoid double-clicking.
+    await new test_driver.Actions()
+      .pointerMove(500, 500)
+      .pointerDown()
+      .pointerUp()
+      .send();
+
+    await new test_driver.Actions()
+      .pointerMove(targetRect.left + (50 * 3), middleOfFirstLine)
+      .pointerDown()
+      .pointerMove(targetRect.left + (50 * 3), middleOfThirdLine)
+      .pointerUp()
+      .send();
+
+    assert_equals(target.selectionStart, 3);
+    assert_equals(target.selectionEnd, 15);
+    assert_equals(target.selectionDirection, "forward");
+    target.setSelectionRange(0, 0);
+
+    // Click somewhere else to avoid double-clicking.
+    await new test_driver.Actions()
+      .pointerMove(500, 500)
+      .pointerDown()
+      .pointerUp()
+      .send();
+
+    await new test_driver.Actions()
+      .pointerMove(targetRect.left + (50 * 3), middleOfThirdLine)
+      .pointerDown()
+      .pointerMove(targetRect.left + (50 * 3), middleOfFirstLine)
+      .pointerUp()
+      .send();
+
+    assert_equals(target.selectionStart, 3);
+    assert_equals(target.selectionEnd, 15);
+    assert_equals(target.selectionDirection, "backward");
+    target.setSelectionRange(0, 0);
+
+    // Click somewhere else to avoid double-clicking.
+    await new test_driver.Actions()
+      .pointerMove(500, 500)
+      .pointerDown()
+      .pointerUp()
+      .send();
+
+    // Now select well past the text in the box. This should select to the end.
+    await new test_driver.Actions()
+      .pointerMove(targetRect.left + 10, middleOfFirstLine)
+      .pointerDown()
+      .pointerMove(targetRect.right - 15, targetRect.bottom - 15)
+      .pointerUp()
+      .send();
+    assert_equals(target.selectionStart, 0);
+    assert_equals(target.selectionEnd, 24);
+    assert_equals(target.selectionDirection, "forward");
+    target.setSelectionRange(0, 0);
+
+});
+
+promise_test(async test => {
+    let targetRect = target.getBoundingClientRect();
+    let middleOfFirstLine = (50 / 2) + targetRect.top;
+
+    // Click somewhere else to avoid double-clicking.
+    await new test_driver.Actions()
+      .pointerMove(500, 500)
+      .pointerDown()
+      .pointerUp()
+      .send();
+
+    let actions = new test_driver.Actions();
+    let middleButtonOptions = { button: actions.ButtonType.MIDDLE };
+    await actions
+      .pointerMove(targetRect.left + 1, middleOfFirstLine)
+      .pointerDown()
+      .pointerMove(targetRect.left + (50 * 3), middleOfFirstLine)
+      .pointerDown(middleButtonOptions)
+      .pointerUp(middleButtonOptions)
+      .pointerMove(targetRect.left + (50 * 5), middleOfFirstLine)
+      .pointerUp()
+      .send();
+    assert_equals(target.selectionStart, 0);
+    assert_equals(target.selectionEnd, 3);
+    target.setSelectionRange(0, 0);
+
+    // Click somewhere else to avoid double-clicking.
+    await new test_driver.Actions()
+      .pointerMove(500, 500)
+      .pointerDown()
+      .pointerUp()
+      .send();
+}, "Middle button click should cancel ongoing text selection via drag");
+
+promise_test(async test => {
+    let targetRect = target.getBoundingClientRect();
+    let middleOfFirstLine = (50 / 2) + targetRect.top;
+    let middleOfThirdLine = (50 * 2) + 25 + targetRect.top;
+
+    // Click somewhere else to avoid double-clicking.
+    await new test_driver.Actions()
+      .pointerMove(500, 500)
+      .pointerDown()
+      .pointerUp()
+      .send();
+
+    await new test_driver.Actions()
+      .pointerMove(targetRect.left + 1, middleOfFirstLine)
+      .pointerDown()
+      .pointerUp()
+      .pointerDown()
+      .pointerMove(targetRect.left + (50 * 3), middleOfThirdLine)
+      .pointerUp()
+      .send();
+    assert_equals(target.selectionStart, 0);
+    assert_equals(target.selectionEnd, 15);
+    target.setSelectionRange(0, 0);
+}, "Double-clicking should select word and allow beginning a text selection drag");
+</script>


### PR DESCRIPTION
This change adds basic support for selecting text via dragging the mouse
in text inputs. This is currently handled entirely inside of text
inputs, but will be integrated into a more global drag handler when that
is implemented in the `DocumentEventHandler`. This means that events
that happen outside of the text input currently don't update the
selection.

Testing: This adds Servo-specific WPT-style tests. There are WPT tests
that test this sort of behavior, but I believe they rely on selection
events, which we have no implemented yet (we will soon).
