### PR TITLE
webgpu: Fix borrow hazards in GPUBuffer

### DIFF
--- a/components/script/dom/html/htmlstyleelement.rs
+++ b/components/script/dom/html/htmlstyleelement.rs
@@ -210,7 +210,6 @@ impl HTMLStyleElement {
     //
     // With the reuse of `StylesheetContent` for same stylesheet string content,
     // this function has a bit difference with `HTMLLinkElement::set_stylesheet` now.
-    #[cfg_attr(crown, expect(crown::unrooted_must_root))]
     pub(crate) fn set_stylesheet(
         &self,
         s: Arc<Stylesheet>,


### PR DESCRIPTION
And fix a lint related to #41815 

Testing: `./mach build --use-crown`
Fixes: #42001
