### PR TITLE
Indexeddb: move opening of connection message handling to factory

### DIFF
--- a/components/script/dom/indexeddb/idbfactory.rs
+++ b/components/script/dom/indexeddb/idbfactory.rs
@@ -144,7 +144,7 @@ impl IDBFactory {
     }
 
     /// <https://w3c.github.io/IndexedDB/#dom-idbfactory-open>
-    /// The error dispatching part from within a task part. 
+    /// The error dispatching part from within a task part.
     fn dispatch_error(&self, name: DBName, request_id: Uuid, dom_exception: Error, can_gc: CanGc) {
         // Step 5.3.1: If result is an error, then:
         let request = {
@@ -170,10 +170,10 @@ impl IDBFactory {
         request.set_error(Some(dom_exception), can_gc);
 
         // Step 5.3.1.3: Set request’s done flag to true.
-        // TODO. 
+        // TODO.
 
-        // Step 5.3.1.4: Fire an event named error at request 
-        // with its bubbles 
+        // Step 5.3.1.4: Fire an event named error at request
+        // with its bubbles
         // and cancelable attributes initialized to true.
         let event = Event::new(
             &global,
@@ -198,7 +198,7 @@ impl IDBFactory {
         {
             let mut pending = self.pending_connections.borrow_mut();
             let outer = pending.entry(DBName(name.to_string())).or_default();
-            outer.insert(request_id.clone(), Dom::from_ref(request));
+            outer.insert(request_id, Dom::from_ref(request));
         }
 
         let response_listener = Trusted::new(self);
@@ -212,7 +212,7 @@ impl IDBFactory {
         let callback = GenericCallback::new(global.time_profiler_chan().clone(), move |message| {
             let response_listener = response_listener.clone();
             let name = name_copy.clone();
-            let request_id = request_id.clone();
+            let request_id = request_id;
             let backend_result = match message {
                 Ok(inner) => inner,
                 Err(err) => Err(BackendError::DbErr(format!("{err:?}"))),

--- a/components/script/dom/indexeddb/idbfactory.rs
+++ b/components/script/dom/indexeddb/idbfactory.rs
@@ -143,13 +143,10 @@ impl IDBFactory {
         );
     }
 
-    // Step 2.1 If result is an error,
-    // set request’s result to undefined,
-    // set request’s error to result,
-    // set request’s done flag,
-    // and fire an event named error at request
-    // with its bubbles and cancelable attributes initialized to true.
+    /// <https://w3c.github.io/IndexedDB/#dom-idbfactory-open>
+    /// The error dispatching part from within a task part. 
     fn dispatch_error(&self, name: DBName, request_id: Uuid, dom_exception: Error, can_gc: CanGc) {
+        // Step 5.3.1: If result is an error, then:
         let request = {
             let mut pending = self.pending_connections.borrow_mut();
             let Some(entry) = pending.get_mut(&name) else {
@@ -165,8 +162,19 @@ impl IDBFactory {
             request.as_rooted()
         };
         let global = request.global();
+
+        // Step 5.3.1.1: Set request’s result to undefined.
         request.set_result(HandleValue::undefined());
+
+        // Step 5.3.1.2: Set request’s error to result.
         request.set_error(Some(dom_exception), can_gc);
+
+        // Step 5.3.1.3: Set request’s done flag to true.
+        // TODO. 
+
+        // Step 5.3.1.4: Fire an event named error at request 
+        // with its bubbles 
+        // and cancelable attributes initialized to true.
         let event = Event::new(
             &global,
             Atom::from("error"),

--- a/components/script/dom/indexeddb/idbopendbrequest.rs
+++ b/components/script/dom/indexeddb/idbopendbrequest.rs
@@ -134,7 +134,7 @@ impl IDBOpenDBRequest {
     }
 
     pub(crate) fn set_connection(&self, connection: &IDBDatabase) {
-        self.pending_connection.set(Some(&connection));
+        self.pending_connection.set(Some(connection));
     }
 
     /// <https://w3c.github.io/IndexedDB/#upgrade-a-database>

--- a/components/storage/indexeddb/mod.rs
+++ b/components/storage/indexeddb/mod.rs
@@ -880,10 +880,13 @@ impl IndexedDBManager {
             // Note: done above with `open_connections`.
 
             // Step 10.2: For each entry of openConnections
-            for conn in open_connections
+            for _conn in open_connections
                 .into_iter()
                 .filter(|conn| conn.close_pending)
-            {}
+            {
+                // TODO: queue a database task to fire a version change event
+                // named versionchange at entry with db’s version and version.
+            }
 
             // that does not have its close pending flag set to true,
             // queue a database task to fire a version change event

--- a/components/storage/indexeddb/mod.rs
+++ b/components/storage/indexeddb/mod.rs
@@ -347,6 +347,16 @@ struct VersionUpgrade {
     new: u64,
 }
 
+/// <https://w3c.github.io/IndexedDB/#connection>
+#[derive(Clone, Eq, Hash, PartialEq)]
+struct Connection {
+    /// <https://w3c.github.io/IndexedDB/#connection-version>
+    version: u64,
+
+    /// <https://w3c.github.io/IndexedDB/#connection-close-pending-flag>
+    close_pending: bool,
+}
+
 struct IndexedDBManager {
     port: GenericReceiver<IndexedDBThreadMsg>,
     idb_base_dir: PathBuf,
@@ -361,6 +371,9 @@ struct IndexedDBManager {
 
     /// <https://w3c.github.io/IndexedDB/#connection-queue>
     connection_queues: HashMap<IndexedDBDescription, VecDeque<OpenRequest>>,
+
+    /// <https://w3c.github.io/IndexedDB/#connection>
+    connections: HashMap<IndexedDBDescription, HashSet<Connection>>,
 }
 
 impl IndexedDBManager {
@@ -382,6 +395,7 @@ impl IndexedDBManager {
             thread_pool: Arc::new(ThreadPool::new(thread_count, "IndexedDB".to_string())),
             serial_number_counter: 0,
             connection_queues: Default::default(),
+            connections: Default::default(),
         }
     }
 }
@@ -849,15 +863,28 @@ impl IndexedDBManager {
             return;
         }
 
-        // Let connection be a new connection to db.
-        // Set connection’s version to version.
-        // TODO: track connections in the backend(each script `IDBDatabase` should have a matching connection).
+        // Step 8: Let connection be a new connection to db.
+        // Step 9: Set connection’s version to version.
+        let connection = Connection {
+            version,
+            close_pending: false,
+        };
+        let entry = self.connections.entry(idb_description.clone()).or_default();
+        let open_connections = entry.clone();
+        entry.insert(connection);
 
         // Step 10: If db’s version is less than version, then:
         if db_version < version {
             // Step 10.1: Let openConnections be the set of all connections,
             // except connection, associated with db.
+            // Note: done above with `open_connections`.
+
             // Step 10.2: For each entry of openConnections
+            for conn in open_connections
+                .into_iter()
+                .filter(|conn| conn.close_pending)
+            {}
+
             // that does not have its close pending flag set to true,
             // queue a database task to fire a version change event
             // named versionchange at entry with db’s version and version.


### PR DESCRIPTION
Move the message handling related to opening new connections to the factory, and store open request on it. This is a first step towards tracking connections and allowing two-way messaging regarding them. 

Also the very beginnings of tracking connections on the backend.

Testing: WPT
Fixes: Part of https://github.com/servo/servo/issues/40983