### PR TITLE
script: Fix unneeded .to_owned()

### DIFF
--- a/components/script/dom/document.rs
+++ b/components/script/dom/document.rs
@@ -3486,7 +3486,7 @@ impl Document {
             match value {
                 // Step 3.1: If value is a TrustedHTML object, then append value's associated data to string.
                 TrustedHTMLOrString::TrustedHTML(trusted_html) => {
-                    strings.push(trusted_html.to_string().to_owned());
+                    strings.push(trusted_html.to_string());
                 },
                 TrustedHTMLOrString::String(str_) => {
                     // Step 2: Let isTrusted be false if text contains a string; otherwise true.


### PR DESCRIPTION
`.to_owned()` is unneeded with `.to_string()`, tiny cleanup
(plus ~meaningless perf/mem win).

Testing: `./mach build --use-crown`