### PR TITLE
Sync mach bootstrap package list to the book automatically.

### DIFF
--- a/.github/workflows/book-export.yml
+++ b/.github/workflows/book-export.yml
@@ -1,0 +1,71 @@
+name: Book Export
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  upstream:
+    # Run job only on servo/servo
+    if: github.repository == 'servo/servo'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out Servo
+        uses: actions/checkout@v6
+        with:
+          sparse-checkout: |
+            python/servo/platform/linux_packages
+          fetch-depth: '2'
+      - name: Check out Servo book
+        uses: actions/checkout@v6
+        with:
+          path: book
+          repository: 'servo/book'
+      - name: Check for changes
+        working-directory: python/servo/platform/linux_packages
+        id: changes
+        run: |
+          # Note: This check assumes the action only runs on `main`.
+          if git diff --quiet HEAD HEAD^ -- . ; then
+            echo "No changes detected, exiting."
+            echo "CHANGES=false" >> $GITHUB_OUTPUT
+          else
+            echo "Changes detected, exporting book."
+            ./generate_pkg_list.sh apt/apt_common.txt > ${{github.workspace}}/book/src/building/linux_packages/apt_common.txt
+            ./generate_pkg_list.sh apt/apt_ubuntu_only.txt > ${{github.workspace}}/book/src/building/linux_packages/apt_ubuntu_only.txt
+            ./generate_pkg_list.sh dnf/dnf_base.txt > ${{github.workspace}}/book/src/building/linux_packages/dnf_base.txt
+            ./generate_pkg_list.sh xbps/xbps_base.txt > ${{github.workspace}}/book/src/building/linux_packages/xbps_base.txt
+            echo "CHANGES=true" >> $GITHUB_OUTPUT
+          fi
+      - name: Commit changes
+        working-directory: book
+        if: ${{ steps.changes.outputs.CHANGES == 'true'}}
+        run: |
+          git config --local user.email "ghbot+book-sync@servo.org"
+          git config --local user.name "Book Sync Bot"
+          git add src/building/linux_packages/
+          git commit -m "linux: Update dependency list based on servo@${GITHUB_SHA::7}"
+          git remote add servo-bot-fork https://github.com/servo-bot/book.git
+      - name: Push changes
+        if: ${{ steps.changes.outputs.CHANGES == 'true'}}
+        # Pin to SHA of v1.0.0 to reduce supply chain attack risk.
+        uses: ad-m/github-push-action@77c5b412c50b723d2a4fbc6d71fb5723bcd439aa
+        with:
+          branch: linux_pkgs_sync_${{ github.sha }}
+          directory: book
+          repository: servo-bot/book
+          github_token: ${{ secrets.BOOK_SYNC_TOKEN }}
+      - name: Open PR
+        if: ${{ steps.changes.outputs.CHANGES == 'true'}}
+        env:
+          GH_TOKEN: ${{ secrets.BOOK_SYNC_TOKEN }}
+          UPDATE_BRANCH: linux_pkgs_sync_${{ github.sha }}
+        working-directory: book
+        run: |
+          BODY=$(cat <<EOF
+          Update dependency list based on servo@${GITHUB_SHA::7}
+          EOF
+          )
+          gh pr create \
+            --title "Sync Linux packages with servo/servo (${GITHUB_SHA::7})" \
+            --body "$BODY" --head ${{ env.UPDATE_BRANCH }}

--- a/.github/workflows/book-export.yml
+++ b/.github/workflows/book-export.yml
@@ -21,6 +21,7 @@ jobs:
         with:
           path: book
           repository: 'servo/book'
+          token: ${{ secrets.BOOK_SYNC_TOKEN }}
       - name: Check for changes
         working-directory: python/servo/platform/linux_packages
         id: changes
@@ -45,7 +46,6 @@ jobs:
           git config --local user.name "Book Sync Bot"
           git add src/building/linux_packages/
           git commit -m "linux: Update dependency list based on servo@${GITHUB_SHA::7}"
-          git remote add servo-bot-fork https://github.com/servo-bot/book.git
       - name: Push changes
         if: ${{ steps.changes.outputs.CHANGES == 'true'}}
         # Pin to SHA of v1.0.0 to reduce supply chain attack risk.

--- a/.github/workflows/book-export.yml
+++ b/.github/workflows/book-export.yml
@@ -68,4 +68,5 @@ jobs:
           )
           gh pr create \
             --title "Sync Linux packages with servo/servo (${GITHUB_SHA::7})" \
+            --repo servo/book \
             --body "$BODY" --head servo-bot:${{ env.UPDATE_BRANCH }}

--- a/.github/workflows/book-export.yml
+++ b/.github/workflows/book-export.yml
@@ -68,4 +68,4 @@ jobs:
           )
           gh pr create \
             --title "Sync Linux packages with servo/servo (${GITHUB_SHA::7})" \
-            --body "$BODY" --head ${{ env.UPDATE_BRANCH }}
+            --body "$BODY" --head servo-bot:${{ env.UPDATE_BRANCH }}

--- a/.github/workflows/book-export.yml
+++ b/.github/workflows/book-export.yml
@@ -58,7 +58,7 @@ jobs:
       - name: Open PR
         if: ${{ steps.changes.outputs.CHANGES == 'true'}}
         env:
-          GH_TOKEN: ${{ secrets.BOOK_SYNC_TOKEN }}
+          GH_TOKEN: ${{ secrets.BOOK_SYNC_CREATE_PR_TOKEN }}
           UPDATE_BRANCH: linux_pkgs_sync_${{ github.sha }}
         working-directory: book
         run: |

--- a/.github/workflows/book-export.yml
+++ b/.github/workflows/book-export.yml
@@ -45,7 +45,7 @@ jobs:
           git config --local user.email "ghbot+book-sync@servo.org"
           git config --local user.name "Book Sync Bot"
           git add src/building/linux_packages/
-          git commit -m "linux: Update dependency list based on servo@${GITHUB_SHA::7}"
+          git commit -m "linux: Update dependency list based on servo@${GITHUB_SHA::13}"
       - name: Push changes
         if: ${{ steps.changes.outputs.CHANGES == 'true'}}
         # Pin to SHA of v1.0.0 to reduce supply chain attack risk.

--- a/.github/workflows/book-export.yml
+++ b/.github/workflows/book-export.yml
@@ -58,10 +58,10 @@ jobs:
         working-directory: book
         run: |
           BODY=$(cat <<EOF
-          Update dependency list based on servo/servo@${GITHUB_SHA::13}
+          Update dependency list based on servo/servo@${GITHUB_SHA}
           EOF
           )
           gh pr create \
-            --title "Sync Linux packages with servo/servo (${GITHUB_SHA::13})" \
+            --title "Sync Linux packages with servo (${GITHUB_SHA::7})" \
             --repo servo/book \
             --body "$BODY" --head servo-bot:${{ env.UPDATE_BRANCH }}

--- a/.github/workflows/book-export.yml
+++ b/.github/workflows/book-export.yml
@@ -45,7 +45,7 @@ jobs:
           git config --local user.email "ghbot+book-sync@servo.org"
           git config --local user.name "Book Sync Bot"
           git add src/building/linux_packages/
-          git commit -m "linux: Update dependency list based on servo@${GITHUB_SHA::13}"
+          git commit -m "linux: Update dependency list based on servo/servo@${GITHUB_SHA::13}"
       - name: Push changes
         if: ${{ steps.changes.outputs.CHANGES == 'true'}}
         working-directory: book
@@ -58,10 +58,10 @@ jobs:
         working-directory: book
         run: |
           BODY=$(cat <<EOF
-          Update dependency list based on servo@${GITHUB_SHA::7}
+          Update dependency list based on servo/servo@${GITHUB_SHA::13}
           EOF
           )
           gh pr create \
-            --title "Sync Linux packages with servo/servo (${GITHUB_SHA::7})" \
+            --title "Sync Linux packages with servo/servo (${GITHUB_SHA::13})" \
             --repo servo/book \
             --body "$BODY" --head servo-bot:${{ env.UPDATE_BRANCH }}

--- a/.github/workflows/book-export.yml
+++ b/.github/workflows/book-export.yml
@@ -48,13 +48,8 @@ jobs:
           git commit -m "linux: Update dependency list based on servo@${GITHUB_SHA::13}"
       - name: Push changes
         if: ${{ steps.changes.outputs.CHANGES == 'true'}}
-        # Pin to SHA of v1.0.0 to reduce supply chain attack risk.
-        uses: ad-m/github-push-action@77c5b412c50b723d2a4fbc6d71fb5723bcd439aa
-        with:
-          branch: linux_pkgs_sync_${{ github.sha }}
-          directory: book
-          repository: servo-bot/book
-          github_token: ${{ secrets.BOOK_SYNC_TOKEN }}
+        working-directory: book
+        run: git push 'https://${{ secrets.BOOK_SYNC_TOKEN }}@github.com/servo-bot/book.git' 'HEAD:linux_pkgs_sync_${{ github.sha }}'
       - name: Open PR
         if: ${{ steps.changes.outputs.CHANGES == 'true'}}
         env:


### PR DESCRIPTION
Follow-up to https://github.com/servo/servo/pull/41775
This allows syncing our package list to the book automatically, keeping the documented required packages in sync with what bootstrap installs.

We use two personal access token of the `servo-bot` account. One PAT with the Resource-owner `servo-bot` for the repository `servo-bot/book`, to push the branch to the bots fork. This PAT should be created with the following permissions:
Choose "Only select repositories", select the forked book repo and give the token Contents: Read and write permissions. 
The second PAT must have the resource owner `servo`, and access to the repository `servo/servo` as well as the permissions "Pull-Request: Read and Write".

This split has the advantag of limiting the PAT permissions for the upstream repo, avoiding `Content: Write` permissions for the `servo/book` repository.

Testing: Manually tested by letting the action run on this branch. [successfull run](https://github.com/servo/servo/actions/runs/22387422307/job/64800999782?pr=42063), [created upstream PR](https://github.com/servo/book/pull/207)

