### PR TITLE
script: Modify ModuleObject::handle() to return a handle with a lifetime

### DIFF
--- a/components/script/dom/html/htmlscriptelement.rs
+++ b/components/script/dom/html/htmlscriptelement.rs
@@ -1060,8 +1060,7 @@ impl HTMLScriptElement {
 
         if let Some(record) = record {
             rooted!(in(*GlobalScope::get_cx()) let mut rval = UndefinedValue());
-            let evaluated =
-                module_tree.execute_module(global, record, rval.handle_mut().into(), can_gc);
+            let evaluated = module_tree.execute_module(global, record, rval.handle_mut(), can_gc);
 
             if let Err(exception) = evaluated {
                 module_tree.set_rethrow_error(exception);


### PR DESCRIPTION
Changed the return type of `ModuleObject::handle()` to the original type of its contained handle by removing `.into()` call, as requested in the linked issue.

Additional changes are due to temporary borrows now sharing lifetime with returned handle reference.

Testing: No new tests needed, as the code is functionally the same after the changes. Verified with running `./mach test-build` and  `./mach test-unit` successfully.
Fixes: https://github.com/servo/servo/issues/42051