### PR TITLE
net: Implement LazyGenericCallback and use it in websocket

### DIFF
--- a/components/net/fetch/methods.rs
+++ b/components/net/fetch/methods.rs
@@ -6,6 +6,7 @@ use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::{io, mem, str};
 
+use base::generic_channel::CallbackSetter;
 use base::id::PipelineId;
 use base64::Engine as _;
 use base64::engine::general_purpose;
@@ -16,7 +17,7 @@ use embedder_traits::resources::{self, Resource};
 use headers::{AccessControlExposeHeaders, ContentType, HeaderMapExt};
 use http::header::{self, HeaderMap, HeaderName, RANGE};
 use http::{HeaderValue, Method, StatusCode};
-use ipc_channel::ipc::{self, IpcReceiver, IpcSender};
+use ipc_channel::ipc::{self, IpcSender};
 use log::{debug, trace, warn};
 use malloc_size_of_derive::MallocSizeOf;
 use mime::{self, Mime};
@@ -70,13 +71,13 @@ pub enum Data {
 
 pub struct WebSocketChannel {
     pub sender: IpcSender<WebSocketNetworkEvent>,
-    pub receiver: Option<IpcReceiver<WebSocketDomAction>>,
+    pub receiver: Option<CallbackSetter<WebSocketDomAction>>,
 }
 
 impl WebSocketChannel {
     pub fn new(
         sender: IpcSender<WebSocketNetworkEvent>,
-        receiver: Option<IpcReceiver<WebSocketDomAction>>,
+        receiver: Option<CallbackSetter<WebSocketDomAction>>,
     ) -> Self {
         Self { sender, receiver }
     }

--- a/components/net/resource_thread.rs
+++ b/components/net/resource_thread.rs
@@ -12,14 +12,16 @@ use std::path::{Path, PathBuf};
 use std::sync::{Arc, Weak};
 use std::thread;
 
-use base::generic_channel::{self, GenericReceiver, GenericReceiverSet, GenericSelectionResult};
+use base::generic_channel::{
+    self, CallbackSetter, GenericReceiver, GenericReceiverSet, GenericSelectionResult,
+};
 use base::id::CookieStoreId;
 use cookie::Cookie;
 use crossbeam_channel::Sender;
 use devtools_traits::DevtoolsControlMsg;
 use embedder_traits::GenericEmbedderProxy;
 use hyper_serde::Serde;
-use ipc_channel::ipc::{IpcReceiver, IpcSender};
+use ipc_channel::ipc::IpcSender;
 use log::{debug, trace, warn};
 use net_traits::blob_url_store::parse_blob_url;
 use net_traits::filemanager_thread::FileTokenCheck;
@@ -780,7 +782,7 @@ impl CoreResourceManager {
         &self,
         mut request: RequestBuilder,
         event_sender: IpcSender<WebSocketNetworkEvent>,
-        action_receiver: IpcReceiver<WebSocketDomAction>,
+        action_receiver: CallbackSetter<WebSocketDomAction>,
         http_state: &Arc<HttpState>,
         cancellation_listener: Arc<CancellationListener>,
         protocols: Arc<ProtocolRegistry>,

--- a/components/script/dom/websocket.rs
+++ b/components/script/dom/websocket.rs
@@ -6,9 +6,9 @@ use std::borrow::ToOwned;
 use std::cell::Cell;
 use std::ptr::{self, NonNull};
 
+use base::generic_channel::{LazyCallback, lazy_callback};
 use constellation_traits::BlobImpl;
 use dom_struct::dom_struct;
-use ipc_channel::ipc::{self, IpcReceiver, IpcSender};
 use ipc_channel::router::ROUTER;
 use js::jsapi::JSObject;
 use js::jsval::UndefinedValue;
@@ -108,20 +108,20 @@ pub(crate) struct WebSocket {
     buffered_amount: Cell<u64>,
     clearing_buffer: Cell<bool>, // Flag to tell if there is a running thread to clear buffered_amount
     #[no_trace]
-    sender: IpcSender<WebSocketDomAction>,
+    callback: LazyCallback<WebSocketDomAction>,
     binary_type: Cell<BinaryType>,
     protocol: DomRefCell<String>, // Subprotocol selected by server
 }
 
 impl WebSocket {
-    fn new_inherited(url: ServoUrl, sender: IpcSender<WebSocketDomAction>) -> WebSocket {
+    fn new_inherited(url: ServoUrl, callback: LazyCallback<WebSocketDomAction>) -> WebSocket {
         WebSocket {
             eventtarget: EventTarget::new_inherited(),
             url,
             ready_state: Cell::new(WebSocketRequestState::Connecting),
             buffered_amount: Cell::new(0),
             clearing_buffer: Cell::new(false),
-            sender,
+            callback,
             binary_type: Cell::new(BinaryType::Blob),
             protocol: DomRefCell::new("".to_owned()),
         }
@@ -131,7 +131,7 @@ impl WebSocket {
         global: &GlobalScope,
         proto: Option<HandleObject>,
         url: ServoUrl,
-        sender: IpcSender<WebSocketDomAction>,
+        sender: LazyCallback<WebSocketDomAction>,
         can_gc: CanGc,
     ) -> DomRoot<WebSocket> {
         let websocket = reflect_dom_object_with_proto(
@@ -263,14 +263,9 @@ impl WebSocketMethods<crate::DomTypeHolder> for WebSocket {
         }
 
         // Create the interface for communication with the resource thread
-        let (dom_action_sender, resource_action_receiver): (
-            IpcSender<WebSocketDomAction>,
-            IpcReceiver<WebSocketDomAction>,
-        ) = ipc::channel().unwrap();
-        let (resource_event_sender, dom_event_receiver): (
-            IpcSender<WebSocketNetworkEvent>,
-            ProfiledIpc::IpcReceiver<WebSocketNetworkEvent>,
-        ) = ProfiledIpc::channel(global.time_profiler_chan().clone()).unwrap();
+        let (dom_action_sender, resource_action_receiver) = lazy_callback();
+        let (resource_event_sender, dom_event_receiver) =
+            ProfiledIpc::channel(global.time_profiler_chan().clone()).unwrap();
 
         // Step 12. Establish a WebSocket connection given urlRecord, protocols, and client.
         let ws = WebSocket::new(global, proto, url_record.clone(), dom_action_sender, can_gc);
@@ -390,7 +385,7 @@ impl WebSocketMethods<crate::DomTypeHolder> for WebSocket {
 
         if send_data {
             let _ = self
-                .sender
+                .callback
                 .send(WebSocketDomAction::SendMessage(MessageData::Text(data.0)));
         }
 
@@ -409,7 +404,7 @@ impl WebSocketMethods<crate::DomTypeHolder> for WebSocket {
         if send_data {
             let bytes = blob.get_bytes().unwrap_or_default();
             let _ = self
-                .sender
+                .callback
                 .send(WebSocketDomAction::SendMessage(MessageData::Binary(bytes)));
         }
 
@@ -424,7 +419,7 @@ impl WebSocketMethods<crate::DomTypeHolder> for WebSocket {
 
         if send_data {
             let _ = self
-                .sender
+                .callback
                 .send(WebSocketDomAction::SendMessage(MessageData::Binary(bytes)));
         }
         Ok(())
@@ -438,7 +433,7 @@ impl WebSocketMethods<crate::DomTypeHolder> for WebSocket {
 
         if send_data {
             let _ = self
-                .sender
+                .callback
                 .send(WebSocketDomAction::SendMessage(MessageData::Binary(bytes)));
         }
         Ok(())
@@ -482,7 +477,7 @@ impl WebSocketMethods<crate::DomTypeHolder> for WebSocket {
                 // Kick off _Start the WebSocket Closing Handshake_
                 // https://tools.ietf.org/html/rfc6455#section-7.1.2
                 let reason = reason.map(|reason| reason.0);
-                let _ = self.sender.send(WebSocketDomAction::Close(code, reason));
+                let _ = self.callback.send(WebSocketDomAction::Close(code, reason));
             },
         }
         Ok(()) // Return Ok

--- a/components/shared/base/generic_channel.rs
+++ b/components/shared/base/generic_channel.rs
@@ -21,6 +21,8 @@ use servo_config::opts;
 
 mod callback;
 pub use callback::GenericCallback;
+mod lazy_callback;
+pub use lazy_callback::{CallbackSetter, LazyCallback, lazy_callback};
 mod oneshot;
 mod shared_memory;
 pub use oneshot::{GenericOneshotReceiver, GenericOneshotSender, oneshot};

--- a/components/shared/base/generic_channel/lazy_callback.rs
+++ b/components/shared/base/generic_channel/lazy_callback.rs
@@ -1,0 +1,303 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+//! # Lazy Callbacks
+//!
+//! When constructing callbacks we sometimes have a large distance between where the callback is setup and where
+//! the initial callback will be called. Refactoring of this code is sometimes not possible.
+//! Here we provide [LazyCallback]. We use 'lazy_callback()' to generate a [LazyCallback] and a [CallbackSetter].
+//! The [LazyCallback] works like a [GenericCallback] and can be used to send messages.
+//! The [CallbackSetter] has a single consuming method of 'set_callback' which will set the callback that the [LazyCallback]
+//! will then execute on messages send to it.
+//!
+//! This is achieved with having the LazyCallback having a back channel in single process mode that sets the [GenericCallback].
+//! Hence, this is slightly less efficient than a [GenericCallback]
+
+use std::cell::{OnceCell, RefCell};
+use std::fmt;
+use std::marker::PhantomData;
+
+use ipc_channel::ErrorKind;
+use ipc_channel::ipc::{IpcReceiver, IpcSender};
+use ipc_channel::router::ROUTER;
+use serde::de::VariantAccess;
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
+use servo_config::opts;
+
+use crate::generic_channel::{GenericCallback, SendError, SendResult};
+
+/// Basic struct for [LazyCallback]
+pub struct LazyCallback<T: Serialize + for<'de> Deserialize<'de> + Send + 'static>(
+    LazyCallbackVariants<T>,
+);
+
+enum LazyCallbackVariants<T>
+where
+    T: Serialize + Send + 'static,
+{
+    InProcess {
+        callback_receiver: RefCell<Option<crossbeam_channel::Receiver<GenericCallback<T>>>>,
+        callback: OnceCell<GenericCallback<T>>,
+    },
+    Ipc(IpcSender<T>),
+}
+
+impl<T> LazyCallback<T>
+where
+    T: Serialize + for<'de> Deserialize<'de> + Send + 'static,
+{
+    /// Send messages to the callback. This might block until the callback is set via the 'CallbackSetter'
+    pub fn send(&self, value: T) -> SendResult {
+        match &self.0 {
+            LazyCallbackVariants::InProcess {
+                callback_receiver,
+                callback,
+            } => {
+                let cb = callback.get_or_init(|| {
+                    callback_receiver
+                        .borrow_mut()
+                        .take()
+                        .unwrap()
+                        .recv()
+                        .unwrap()
+                });
+                cb.send(value)
+            },
+            LazyCallbackVariants::Ipc(ipc_sender) => {
+                ipc_sender.send(value).map_err(|error| match *error {
+                    ErrorKind::Io(_) => SendError::Disconnected,
+                    serialization_error => {
+                        SendError::SerializationError(serialization_error.to_string())
+                    },
+                })
+            },
+        }
+    }
+}
+
+pub struct CallbackSetter<T: Serialize + Send + 'static>(CallbackSetterVariants<T>);
+
+impl<T: Serialize + Send> fmt::Debug for CallbackSetter<T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_tuple("CallbackSetter").finish()
+    }
+}
+
+impl<T> Serialize for CallbackSetter<T>
+where
+    T: Serialize + Send + 'static,
+{
+    fn serialize<S: Serializer>(&self, s: S) -> Result<S::Ok, S::Error> {
+        match &self.0 {
+            CallbackSetterVariants::Ipc(sender) => {
+                s.serialize_newtype_variant("CallbackSetter", 0, "Ipc", sender)
+            },
+            // The only reason we need / want serialization in single-process mode is to support
+            // sending GenericCallbacks over existing IPC channels. This allows us to
+            // incrementally port IPC channels to the GenericChannel, without needing to follow a
+            // top-to-bottom approach.
+            // Long-term we can remove this branch in the code again and replace it with
+            // unreachable, since likely all IPC channels would be GenericChannels.
+            CallbackSetterVariants::InProcess(wrapped_callback) => {
+                if opts::get().multiprocess {
+                    return Err(serde::ser::Error::custom(
+                        "InProcess callback setter can't be serialized in multiprocess mode",
+                    ));
+                }
+                // Due to the signature of `serialize` we need to clone the Arc to get an owned
+                // pointer we can leak.
+                // We additionally need to Box to get a thin pointer.
+                let cloned_callback = Box::new(wrapped_callback.clone());
+                let sender_clone_addr = Box::leak(cloned_callback) as *mut _ as usize;
+                s.serialize_newtype_variant("CallbackSetter", 1, "InProcess", &sender_clone_addr)
+            },
+        }
+    }
+}
+
+struct LazyCallbackSetterVisitor<T> {
+    marker: PhantomData<T>,
+}
+
+impl<'de, T> serde::de::Visitor<'de> for LazyCallbackSetterVisitor<T>
+where
+    T: Serialize + Deserialize<'de> + Send + 'static,
+{
+    type Value = CallbackSetter<T>;
+
+    fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+        formatter.write_str("a GenericCallback variant")
+    }
+
+    fn visit_enum<A>(self, data: A) -> Result<Self::Value, A::Error>
+    where
+        A: serde::de::EnumAccess<'de>,
+    {
+        #[derive(Deserialize)]
+        enum LazyCallbackSetterVariantNames {
+            Ipc,
+            InProcess,
+        }
+
+        let (variant_name, variant_data): (LazyCallbackSetterVariantNames, _) = data.variant()?;
+
+        match variant_name {
+            LazyCallbackSetterVariantNames::Ipc => variant_data
+                .newtype_variant::<IpcReceiver<T>>()
+                .map(|receiver| CallbackSetter(CallbackSetterVariants::Ipc(receiver))),
+            LazyCallbackSetterVariantNames::InProcess => {
+                if opts::get().multiprocess {
+                    return Err(serde::de::Error::custom(
+                        "InProcess callback found in multiprocess mode",
+                    ));
+                }
+                let addr = variant_data.newtype_variant::<usize>()?;
+                let ptr = addr as *mut _;
+                // SAFETY: We know we are in the same address space as the sender, so we can safely
+                // reconstruct the Arc, that we previously leaked with `into_raw` during
+                // serialization.
+                // Attention: Code reviewers should carefully compare the deserialization here
+                // with the serialization above.
+                #[expect(unsafe_code)]
+                let callback = unsafe { Box::from_raw(ptr) };
+                Ok(CallbackSetter(CallbackSetterVariants::InProcess(*callback)))
+            },
+        }
+    }
+}
+
+impl<'a, T> Deserialize<'a> for CallbackSetter<T>
+where
+    T: Serialize + Deserialize<'a> + Send + 'static,
+{
+    fn deserialize<D>(d: D) -> Result<CallbackSetter<T>, D::Error>
+    where
+        D: Deserializer<'a>,
+    {
+        d.deserialize_enum(
+            "GenericCallback",
+            &["CrossProcess", "InProcess"],
+            LazyCallbackSetterVisitor {
+                marker: PhantomData,
+            },
+        )
+    }
+}
+
+enum CallbackSetterVariants<T>
+where
+    T: Serialize + Send + 'static,
+{
+    InProcess(crossbeam_channel::Sender<GenericCallback<T>>),
+    Ipc(IpcReceiver<T>),
+}
+
+impl<T> CallbackSetter<T>
+where
+    T: Serialize + for<'de> Deserialize<'de> + Send + 'static,
+{
+    /// This sets the callback.
+    pub fn set_callback<F: FnMut(Result<T, ipc_channel::Error>) + Send + 'static>(
+        self,
+        callback: F,
+    ) {
+        match self.0 {
+            CallbackSetterVariants::InProcess(sender) => {
+                let callback = GenericCallback::new(callback).expect("Could not create callback");
+                sender.send(callback).expect("Could not send callback");
+            },
+            CallbackSetterVariants::Ipc(ipc_receiver) => {
+                ROUTER.add_typed_route(ipc_receiver, Box::new(callback));
+            },
+        }
+    }
+}
+
+/// This function should never be exported.
+fn lazy_callback_inprocess<T>() -> (LazyCallback<T>, CallbackSetter<T>)
+where
+    T: Serialize + for<'de> Deserialize<'de> + Send + 'static,
+{
+    let (callback_sender, callback_receiver) = crossbeam_channel::bounded(1);
+    let lazycallback = LazyCallback(LazyCallbackVariants::InProcess {
+        callback_receiver: RefCell::new(Some(callback_receiver)),
+        callback: OnceCell::new(),
+    });
+
+    let callback_setter = CallbackSetter(CallbackSetterVariants::InProcess(callback_sender));
+
+    (lazycallback, callback_setter)
+}
+
+/// This function should never be exported.
+fn lazy_callback_ipc<T>() -> (LazyCallback<T>, CallbackSetter<T>)
+where
+    T: Serialize + for<'de> Deserialize<'de> + Send + 'static,
+{
+    let (sender, receiver) = ipc_channel::ipc::channel().expect("Could not create channel");
+    let callback = LazyCallback(LazyCallbackVariants::Ipc(sender));
+    let callback_setter = CallbackSetter(CallbackSetterVariants::Ipc(receiver));
+    (callback, callback_setter)
+}
+
+/// A LazyCallback is a Callback that will be initialized at a later date.
+/// We return the 'LazyCallback' which is a GenericCallback.
+/// We also return a 'CallbackSetter' where the callback can be set at a later date.
+pub fn lazy_callback<T>() -> (LazyCallback<T>, CallbackSetter<T>)
+where
+    T: Serialize + for<'de> Deserialize<'de> + Send + 'static,
+{
+    if opts::get().multiprocess || opts::get().force_ipc {
+        lazy_callback_ipc()
+    } else {
+        lazy_callback_inprocess()
+    }
+}
+
+#[cfg(test)]
+mod single_process_callback_test {
+    use crate::generic_channel::lazy_callback::{lazy_callback_inprocess, lazy_callback_ipc};
+
+    #[test]
+    fn lazy_callback_simple_inprocess() {
+        let (callback, callback_setter) = lazy_callback_inprocess();
+
+        let t1 = std::thread::spawn(move || {
+            callback.send(true).expect("Could not send");
+        });
+
+        let (sender, receiver) = crossbeam_channel::bounded(1);
+        let t2 = std::thread::spawn(move || {
+            std::thread::sleep(std::time::Duration::from_secs(1));
+            callback_setter.set_callback(move |value| {
+                sender.send(value).expect("Could not send");
+            });
+        });
+
+        t1.join().expect("error joining thread");
+        t2.join().expect("error joining thread");
+        assert_eq!(receiver.recv().unwrap().unwrap(), true);
+    }
+
+    #[test]
+    fn lazy_callback_simple_ipc() {
+        let (callback, callback_setter) = lazy_callback_ipc();
+
+        let t1 = std::thread::spawn(move || {
+            callback.send(true).expect("Could not send");
+        });
+
+        let (sender, receiver) = crossbeam_channel::bounded(1);
+        let t2 = std::thread::spawn(move || {
+            std::thread::sleep(std::time::Duration::from_secs(1));
+            callback_setter.set_callback(move |value| {
+                sender.send(value).expect("Could not send");
+            });
+        });
+
+        t1.join().expect("error joining thread");
+        t2.join().expect("error joining thread");
+        assert_eq!(receiver.recv().unwrap().unwrap(), true);
+    }
+}

--- a/components/shared/base/generic_channel/lazy_callback.rs
+++ b/components/shared/base/generic_channel/lazy_callback.rs
@@ -18,9 +18,10 @@ use std::cell::{OnceCell, RefCell};
 use std::fmt;
 use std::marker::PhantomData;
 
-use ipc_channel::ErrorKind;
 use ipc_channel::ipc::{IpcReceiver, IpcSender};
 use ipc_channel::router::ROUTER;
+use malloc_size_of::{MallocSizeOf as MallocSizeOfTrait, MallocSizeOfOps};
+use malloc_size_of_derive::MallocSizeOf;
 use serde::de::VariantAccess;
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use servo_config::opts;
@@ -28,6 +29,7 @@ use servo_config::opts;
 use crate::generic_channel::{GenericCallback, SendError, SendResult};
 
 /// Basic struct for [LazyCallback]
+#[derive(MallocSizeOf)]
 pub struct LazyCallback<T: Serialize + for<'de> Deserialize<'de> + Send + 'static>(
     LazyCallbackVariants<T>,
 );
@@ -41,6 +43,21 @@ where
         callback: OnceCell<GenericCallback<T>>,
     },
     Ipc(IpcSender<T>),
+}
+
+impl<T> MallocSizeOfTrait for LazyCallbackVariants<T>
+where
+    T: Serialize + Send + 'static,
+{
+    fn size_of(&self, ops: &mut MallocSizeOfOps) -> usize {
+        match self {
+            LazyCallbackVariants::InProcess {
+                callback_receiver,
+                callback,
+            } => callback_receiver.size_of(ops) + callback.size_of(ops),
+            LazyCallbackVariants::Ipc(_) => 0,
+        }
+    }
 }
 
 impl<T> LazyCallback<T>
@@ -65,10 +82,12 @@ where
                 cb.send(value)
             },
             LazyCallbackVariants::Ipc(ipc_sender) => {
-                ipc_sender.send(value).map_err(|error| match *error {
-                    ErrorKind::Io(_) => SendError::Disconnected,
-                    serialization_error => {
-                        SendError::SerializationError(serialization_error.to_string())
+                ipc_sender.send(value).map_err(|error| match error {
+                    ipc_channel::IpcError::SerializationError(ser_de_error) => {
+                        SendError::SerializationError(ser_de_error.to_string())
+                    },
+                    ipc_channel::IpcError::Io(_) | ipc_channel::IpcError::Disconnected => {
+                        SendError::Disconnected
                     },
                 })
             },
@@ -198,9 +217,9 @@ where
     T: Serialize + for<'de> Deserialize<'de> + Send + 'static,
 {
     /// This sets the callback.
-    pub fn set_callback<F: FnMut(Result<T, ipc_channel::Error>) + Send + 'static>(
+    pub fn set_callback<F: FnMut(Result<T, ipc_channel::IpcError>) + Send + 'static>(
         self,
-        callback: F,
+        mut callback: F,
     ) {
         match self.0 {
             CallbackSetterVariants::InProcess(sender) => {
@@ -208,7 +227,10 @@ where
                 sender.send(callback).expect("Could not send callback");
             },
             CallbackSetterVariants::Ipc(ipc_receiver) => {
-                ROUTER.add_typed_route(ipc_receiver, Box::new(callback));
+                let new_callback = move |msg: Result<T, ipc_channel::SerDeError>| {
+                    callback(msg.map_err(|error| error.into()))
+                };
+                ROUTER.add_typed_route(ipc_receiver, Box::new(new_callback));
             },
         }
     }

--- a/components/shared/base/generic_channel/lazy_callback.rs
+++ b/components/shared/base/generic_channel/lazy_callback.rs
@@ -4,8 +4,8 @@
 
 //! # Lazy Callbacks
 //!
-//! When constructing callbacks we sometimes have a large distance between where the callback is setup and where
-//! the initial callback will be called. Refactoring of this code is sometimes not possible.
+//! When constructing callbacks we sometimes have a large distance between where the channel for the callback
+//! is created and where the initial callback will be created. Refactoring of this code is sometimes not possible.
 //! Here we provide [LazyCallback]. We use 'lazy_callback()' to generate a [LazyCallback] and a [CallbackSetter].
 //! The [LazyCallback] works like a [GenericCallback] and can be used to execute callbacks in the receiver process.
 //! The [CallbackSetter] has a single consuming method of 'set_callback' which will set the callback that the [LazyCallback]

--- a/components/shared/base/generic_channel/lazy_callback.rs
+++ b/components/shared/base/generic_channel/lazy_callback.rs
@@ -7,7 +7,7 @@
 //! When constructing callbacks we sometimes have a large distance between where the callback is setup and where
 //! the initial callback will be called. Refactoring of this code is sometimes not possible.
 //! Here we provide [LazyCallback]. We use 'lazy_callback()' to generate a [LazyCallback] and a [CallbackSetter].
-//! The [LazyCallback] works like a [GenericCallback] and can be used to send messages.
+//! The [LazyCallback] works like a [GenericCallback] and can be used to execute callbacks in the receiver process.
 //! The [CallbackSetter] has a single consuming method of 'set_callback' which will set the callback that the [LazyCallback]
 //! will then execute on messages send to it.
 //!

--- a/components/shared/base/generic_channel/lazy_callback.rs
+++ b/components/shared/base/generic_channel/lazy_callback.rs
@@ -71,15 +71,18 @@ where
                 callback_receiver,
                 callback,
             } => {
-                let cb = callback.get_or_init(|| {
-                    callback_receiver
-                        .borrow_mut()
-                        .take()
-                        .unwrap()
-                        .recv()
-                        .unwrap()
-                });
-                cb.send(value)
+                if let Some(cb) = callback.get() {
+                    cb.send(value)
+                } else {
+                    // Init callback
+                    if let Ok(cb) = callback_receiver.borrow_mut().take().unwrap().recv() {
+                        let _ = callback.set(cb);
+                        callback.get().unwrap().send(value)
+                    } else {
+                        log::error!("Could not get callback. Callback_receiver already dropped");
+                        SendResult::Err(SendError::Disconnected)
+                    }
+                }
             },
             LazyCallbackVariants::Ipc(ipc_sender) => {
                 ipc_sender.send(value).map_err(|error| match error {
@@ -282,7 +285,7 @@ where
 #[cfg(test)]
 mod single_process_callback_test {
     use crate::generic_channel::lazy_callback::{lazy_callback_inprocess, lazy_callback_ipc};
-
+    use crate::generic_channel::{CallbackSetter, LazyCallback};
     fn test_lazy_callback(callback: LazyCallback<bool>, callback_setter: CallbackSetter<bool>) {
         let t1 = std::thread::spawn(move || {
             callback.send(true).expect("Could not send");

--- a/components/shared/base/generic_channel/lazy_callback.rs
+++ b/components/shared/base/generic_channel/lazy_callback.rs
@@ -26,7 +26,7 @@ use serde::de::VariantAccess;
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use servo_config::opts;
 
-use crate::generic_channel::{GenericCallback, SendError, SendResult};
+use crate::generic_channel::{GenericCallback, SendError, SendResult, use_ipc};
 
 /// Basic struct for [LazyCallback]
 #[derive(MallocSizeOf)]
@@ -119,7 +119,7 @@ where
             // Long-term we can remove this branch in the code again and replace it with
             // unreachable, since likely all IPC channels would be GenericChannels.
             CallbackSetterVariants::InProcess(wrapped_callback) => {
-                if opts::get().multiprocess {
+                if use_ipc() {
                     return Err(serde::ser::Error::custom(
                         "InProcess callback setter can't be serialized in multiprocess mode",
                     ));
@@ -166,7 +166,7 @@ where
                 .newtype_variant::<IpcReceiver<T>>()
                 .map(|receiver| CallbackSetter(CallbackSetterVariants::Ipc(receiver))),
             LazyCallbackSetterVariantNames::InProcess => {
-                if opts::get().multiprocess {
+                if use_ipc() {
                     return Err(serde::de::Error::custom(
                         "InProcess callback found in multiprocess mode",
                     ));
@@ -174,7 +174,7 @@ where
                 let addr = variant_data.newtype_variant::<usize>()?;
                 let ptr = addr as *mut _;
                 // SAFETY: We know we are in the same address space as the sender, so we can safely
-                // reconstruct the Arc, that we previously leaked with `into_raw` during
+                // reconstruct the Box, that we previously leaked with `into_raw` during
                 // serialization.
                 // Attention: Code reviewers should carefully compare the deserialization here
                 // with the serialization above.
@@ -224,7 +224,9 @@ where
         match self.0 {
             CallbackSetterVariants::InProcess(sender) => {
                 let callback = GenericCallback::new(callback).expect("Could not create callback");
-                sender.send(callback).expect("Could not send callback");
+                if sender.send(callback).is_err() {
+                    log::error!("Could not send callback, sender was already dropped");
+                }
             },
             CallbackSetterVariants::Ipc(ipc_receiver) => {
                 let new_callback = move |msg: Result<T, ipc_channel::SerDeError>| {
@@ -281,10 +283,7 @@ where
 mod single_process_callback_test {
     use crate::generic_channel::lazy_callback::{lazy_callback_inprocess, lazy_callback_ipc};
 
-    #[test]
-    fn lazy_callback_simple_inprocess() {
-        let (callback, callback_setter) = lazy_callback_inprocess();
-
+    fn test_lazy_callback(callback: LazyCallback<bool>, callback_setter: CallbackSetter<bool>) {
         let t1 = std::thread::spawn(move || {
             callback.send(true).expect("Could not send");
         });
@@ -303,23 +302,14 @@ mod single_process_callback_test {
     }
 
     #[test]
+    fn lazy_callback_simple_inprocess() {
+        let (callback, callback_setter) = lazy_callback_inprocess();
+        test_lazy_callback(callback, callback_setter);
+    }
+
+    #[test]
     fn lazy_callback_simple_ipc() {
         let (callback, callback_setter) = lazy_callback_ipc();
-
-        let t1 = std::thread::spawn(move || {
-            callback.send(true).expect("Could not send");
-        });
-
-        let (sender, receiver) = crossbeam_channel::bounded(1);
-        let t2 = std::thread::spawn(move || {
-            std::thread::sleep(std::time::Duration::from_secs(1));
-            callback_setter.set_callback(move |value| {
-                sender.send(value).expect("Could not send");
-            });
-        });
-
-        t1.join().expect("error joining thread");
-        t2.join().expect("error joining thread");
-        assert_eq!(receiver.recv().unwrap().unwrap(), true);
+        test_lazy_callback(callback, callback_setter);
     }
 }

--- a/components/shared/net/lib.rs
+++ b/components/shared/net/lib.rs
@@ -9,7 +9,9 @@ use std::sync::{LazyLock, OnceLock};
 use std::thread::{self, JoinHandle};
 
 use base::cross_process_instant::CrossProcessInstant;
-use base::generic_channel::{self, GenericOneshotSender, GenericSend, GenericSender, SendResult};
+use base::generic_channel::{
+    self, CallbackSetter, GenericOneshotSender, GenericSend, GenericSender, SendResult,
+};
 use base::id::{CookieStoreId, HistoryStateId, PipelineId};
 use content_security_policy::{self as csp};
 use cookie::Cookie;
@@ -18,7 +20,7 @@ use headers::{ContentType, HeaderMapExt, ReferrerPolicy as ReferrerPolicyHeader}
 use http::{HeaderMap, HeaderValue, StatusCode, header};
 use hyper_serde::Serde;
 use hyper_util::client::legacy::Error as HyperError;
-use ipc_channel::ipc::{self, IpcReceiver, IpcSender};
+use ipc_channel::ipc::{self, IpcSender};
 use ipc_channel::router::ROUTER;
 use malloc_size_of::malloc_size_of_is_0;
 use malloc_size_of_derive::MallocSizeOf;
@@ -599,7 +601,7 @@ pub enum FetchChannels {
     ResponseMsg(IpcSender<FetchResponseMsg>),
     WebSocket {
         event_sender: IpcSender<WebSocketNetworkEvent>,
-        action_receiver: IpcReceiver<WebSocketDomAction>,
+        action_receiver: CallbackSetter<WebSocketDomAction>,
     },
     /// If the fetch is just being done to populate the cache,
     /// not because the data is needed now.

--- a/components/shared/net/lib.rs
+++ b/components/shared/net/lib.rs
@@ -580,7 +580,7 @@ pub enum MessageData {
     Binary(Vec<u8>),
 }
 
-#[derive(Debug, Deserialize, Serialize)]
+#[derive(Debug, Deserialize, Serialize, MallocSizeOf)]
 pub enum WebSocketDomAction {
     SendMessage(MessageData),
     Close(Option<u16>, Option<String>),


### PR DESCRIPTION
We introduce a new type of callback, LazyGenericCallback and use it in websocket initialization.

The basic requirement is that for websocket the place where the callback is called and where it is constructed are over several functions, including async functions. To make this generic, we implement LazyGenericCallback and a GeneralCallbackSetter. The CallbackSetter can be used to set the callback which then will be transfered to the LazyGenericCallback which calls it on messages send to it.

Finally, we use this to "Generify" the initialization of WebSockets.

Signed-off-by: Narfinger <Narfinger@users.noreply.github.com>

Testing: We have new tests for LazyGenericCallback and wpt test run here: https://github.com/Narfinger/servo/actions/runs/21246091767
