### PR TITLE
script: Prevent activation of disabled select elements

### DIFF
--- a/components/layout/stylesheets/servo.css
+++ b/components/layout/stylesheets/servo.css
@@ -330,6 +330,11 @@ select {
   appearance: auto;
 }
 
+select:disabled {
+    color: gray;
+    border-color: gray;
+}
+
 /* Matches https://searchfox.org/mozilla-central/rev/a1f4cb9fc03d81be41ca2ba81294592df784364d/layout/style/res/forms.css#120-132 */
 input,
 textarea,

--- a/components/script/dom/html/htmlselectelement.rs
+++ b/components/script/dom/html/htmlselectelement.rs
@@ -833,7 +833,7 @@ impl Activatable for HTMLSelectElement {
     }
 
     fn is_instance_activatable(&self) -> bool {
-        true
+        !self.upcast::<Element>().disabled_state()
     }
 
     fn activation_behavior(&self, _event: &Event, _target: &EventTarget, _can_gc: CanGc) {

--- a/tests/wpt/meta/html/semantics/disabled-elements/event-propagate-disabled.tentative.html.ini
+++ b/tests/wpt/meta/html/semantics/disabled-elements/event-propagate-disabled.tentative.html.ini
@@ -1,51 +1,11 @@
 [event-propagate-disabled.tentative.html]
-  expected: ERROR
   [Trusted click on <input>, observed from <input>]
     expected: FAIL
 
   [Trusted click on <input>, observed from <body>]
     expected: FAIL
 
-  [Dispatch new MouseEvent() on <input>, observed from <input>]
-    expected: FAIL
-
-  [Dispatch new MouseEvent() on <input>, observed from <body>]
-    expected: FAIL
-
-  [Dispatch new PointerEvent() on <input>, observed from <input>]
-    expected: FAIL
-
-  [Dispatch new PointerEvent() on <input>, observed from <body>]
-    expected: FAIL
-
-  [click() on <input>, observed from <input>]
-    expected: FAIL
-
-  [click() on <input>, observed from <body>]
-    expected: FAIL
-
   [Trusted click on <select disabled=""></select>, observed from <select>]
-    expected: FAIL
-
-  [Trusted click on <select disabled=""></select>, observed from <body>]
-    expected: FAIL
-
-  [Dispatch new MouseEvent() on <select disabled=""></select>, observed from <select>]
-    expected: FAIL
-
-  [Dispatch new MouseEvent() on <select disabled=""></select>, observed from <body>]
-    expected: FAIL
-
-  [Dispatch new PointerEvent() on <select disabled=""></select>, observed from <select>]
-    expected: FAIL
-
-  [Dispatch new PointerEvent() on <select disabled=""></select>, observed from <body>]
-    expected: FAIL
-
-  [click() on <select disabled=""></select>, observed from <select>]
-    expected: FAIL
-
-  [click() on <select disabled=""></select>, observed from <body>]
     expected: FAIL
 
   [Trusted click on <select disabled="">\n    <!-- <option> can't be clicked as it doesn't have its own painting area -->\n    <option>foo</option>\n  </select>, observed from <select>]
@@ -54,46 +14,10 @@
   [Trusted click on <select disabled="">\n    <!-- <option> can't be clicked as it doesn't have its own painting area -->\n    <option>foo</option>\n  </select>, observed from <body>]
     expected: FAIL
 
-  [Dispatch new MouseEvent() on <select disabled="">\n    <!-- <option> can't be clicked as it doesn't have its own painting area -->\n    <option>foo</option>\n  </select>, observed from <select>]
-    expected: FAIL
-
-  [Dispatch new MouseEvent() on <select disabled="">\n    <!-- <option> can't be clicked as it doesn't have its own painting area -->\n    <option>foo</option>\n  </select>, observed from <body>]
-    expected: FAIL
-
-  [Dispatch new PointerEvent() on <select disabled="">\n    <!-- <option> can't be clicked as it doesn't have its own painting area -->\n    <option>foo</option>\n  </select>, observed from <select>]
-    expected: FAIL
-
-  [Dispatch new PointerEvent() on <select disabled="">\n    <!-- <option> can't be clicked as it doesn't have its own painting area -->\n    <option>foo</option>\n  </select>, observed from <body>]
-    expected: FAIL
-
-  [click() on <select disabled="">\n    <!-- <option> can't be clicked as it doesn't have its own painting area -->\n    <option>foo</option>\n  </select>, observed from <select>]
-    expected: FAIL
-
-  [click() on <select disabled="">\n    <!-- <option> can't be clicked as it doesn't have its own painting area -->\n    <option>foo</option>\n  </select>, observed from <body>]
-    expected: FAIL
-
   [Trusted click on <fieldset disabled="">Text</fieldset>, observed from <fieldset>]
     expected: FAIL
 
   [Trusted click on <fieldset disabled="">Text</fieldset>, observed from <body>]
-    expected: FAIL
-
-  [Dispatch new MouseEvent() on <fieldset disabled="">Text</fieldset>, observed from <fieldset>]
-    expected: FAIL
-
-  [Dispatch new MouseEvent() on <fieldset disabled="">Text</fieldset>, observed from <body>]
-    expected: FAIL
-
-  [Dispatch new PointerEvent() on <fieldset disabled="">Text</fieldset>, observed from <fieldset>]
-    expected: FAIL
-
-  [Dispatch new PointerEvent() on <fieldset disabled="">Text</fieldset>, observed from <body>]
-    expected: FAIL
-
-  [click() on <fieldset disabled="">Text</fieldset>, observed from <fieldset>]
-    expected: FAIL
-
-  [click() on <fieldset disabled="">Text</fieldset>, observed from <body>]
     expected: FAIL
 
   [Trusted click on <fieldset disabled=""><span class="target">Span</span></fieldset>, observed from <span>]
@@ -105,55 +29,7 @@
   [Trusted click on <fieldset disabled=""><span class="target">Span</span></fieldset>, observed from <body>]
     expected: FAIL
 
-  [Dispatch new MouseEvent() on <fieldset disabled=""><span class="target">Span</span></fieldset>, observed from <span>]
-    expected: FAIL
-
-  [Dispatch new MouseEvent() on <fieldset disabled=""><span class="target">Span</span></fieldset>, observed from <fieldset>]
-    expected: FAIL
-
-  [Dispatch new MouseEvent() on <fieldset disabled=""><span class="target">Span</span></fieldset>, observed from <body>]
-    expected: FAIL
-
-  [Dispatch new PointerEvent() on <fieldset disabled=""><span class="target">Span</span></fieldset>, observed from <span>]
-    expected: FAIL
-
-  [Dispatch new PointerEvent() on <fieldset disabled=""><span class="target">Span</span></fieldset>, observed from <fieldset>]
-    expected: FAIL
-
-  [Dispatch new PointerEvent() on <fieldset disabled=""><span class="target">Span</span></fieldset>, observed from <body>]
-    expected: FAIL
-
-  [click() on <fieldset disabled=""><span class="target">Span</span></fieldset>, observed from <span>]
-    expected: FAIL
-
-  [click() on <fieldset disabled=""><span class="target">Span</span></fieldset>, observed from <fieldset>]
-    expected: FAIL
-
-  [click() on <fieldset disabled=""><span class="target">Span</span></fieldset>, observed from <body>]
-    expected: FAIL
-
   [Trusted click on <button disabled="">Text</button>, observed from <button>]
-    expected: FAIL
-
-  [Trusted click on <button disabled="">Text</button>, observed from <body>]
-    expected: FAIL
-
-  [Dispatch new MouseEvent() on <button disabled="">Text</button>, observed from <button>]
-    expected: FAIL
-
-  [Dispatch new MouseEvent() on <button disabled="">Text</button>, observed from <body>]
-    expected: FAIL
-
-  [Dispatch new PointerEvent() on <button disabled="">Text</button>, observed from <button>]
-    expected: FAIL
-
-  [Dispatch new PointerEvent() on <button disabled="">Text</button>, observed from <body>]
-    expected: FAIL
-
-  [click() on <button disabled="">Text</button>, observed from <button>]
-    expected: FAIL
-
-  [click() on <button disabled="">Text</button>, observed from <body>]
     expected: FAIL
 
   [Trusted click on <button disabled=""><span class="target">Span</span></button>, observed from <span>]
@@ -165,103 +41,13 @@
   [Trusted click on <button disabled=""><span class="target">Span</span></button>, observed from <body>]
     expected: FAIL
 
-  [Dispatch new MouseEvent() on <button disabled=""><span class="target">Span</span></button>, observed from <span>]
-    expected: FAIL
-
-  [Dispatch new MouseEvent() on <button disabled=""><span class="target">Span</span></button>, observed from <button>]
-    expected: FAIL
-
-  [Dispatch new MouseEvent() on <button disabled=""><span class="target">Span</span></button>, observed from <body>]
-    expected: FAIL
-
-  [Dispatch new PointerEvent() on <button disabled=""><span class="target">Span</span></button>, observed from <span>]
-    expected: FAIL
-
-  [Dispatch new PointerEvent() on <button disabled=""><span class="target">Span</span></button>, observed from <button>]
-    expected: FAIL
-
-  [Dispatch new PointerEvent() on <button disabled=""><span class="target">Span</span></button>, observed from <body>]
-    expected: FAIL
-
-  [click() on <button disabled=""><span class="target">Span</span></button>, observed from <span>]
-    expected: FAIL
-
-  [click() on <button disabled=""><span class="target">Span</span></button>, observed from <button>]
-    expected: FAIL
-
-  [click() on <button disabled=""><span class="target">Span</span></button>, observed from <body>]
-    expected: FAIL
-
   [Trusted click on <textarea disabled=""></textarea>, observed from <textarea>]
-    expected: FAIL
-
-  [Trusted click on <textarea disabled=""></textarea>, observed from <body>]
-    expected: FAIL
-
-  [Dispatch new MouseEvent() on <textarea disabled=""></textarea>, observed from <textarea>]
-    expected: FAIL
-
-  [Dispatch new MouseEvent() on <textarea disabled=""></textarea>, observed from <body>]
-    expected: FAIL
-
-  [Dispatch new PointerEvent() on <textarea disabled=""></textarea>, observed from <textarea>]
-    expected: FAIL
-
-  [Dispatch new PointerEvent() on <textarea disabled=""></textarea>, observed from <body>]
-    expected: FAIL
-
-  [click() on <textarea disabled=""></textarea>, observed from <textarea>]
-    expected: FAIL
-
-  [click() on <textarea disabled=""></textarea>, observed from <body>]
     expected: FAIL
 
   [Trusted click on <input disabled="" type="button">, observed from <input>]
     expected: FAIL
 
-  [Trusted click on <input disabled="" type="button">, observed from <body>]
-    expected: FAIL
-
-  [Dispatch new MouseEvent() on <input disabled="" type="button">, observed from <input>]
-    expected: FAIL
-
-  [Dispatch new MouseEvent() on <input disabled="" type="button">, observed from <body>]
-    expected: FAIL
-
-  [Dispatch new PointerEvent() on <input disabled="" type="button">, observed from <input>]
-    expected: FAIL
-
-  [Dispatch new PointerEvent() on <input disabled="" type="button">, observed from <body>]
-    expected: FAIL
-
-  [click() on <input disabled="" type="button">, observed from <input>]
-    expected: FAIL
-
-  [click() on <input disabled="" type="button">, observed from <body>]
-    expected: FAIL
-
   [Trusted click on <input disabled="" type="checkbox">, observed from <input>]
-    expected: FAIL
-
-  [Trusted click on <input disabled="" type="checkbox">, observed from <body>]
-    expected: FAIL
-
-  [Dispatch new MouseEvent() on <input disabled="" type="checkbox">, observed from <input>]
-    expected: FAIL
-
-  [Dispatch new MouseEvent() on <input disabled="" type="checkbox">, observed from <body>]
-    expected: FAIL
-
-  [Dispatch new PointerEvent() on <input disabled="" type="checkbox">, observed from <input>]
-    expected: FAIL
-
-  [Dispatch new PointerEvent() on <input disabled="" type="checkbox">, observed from <body>]
-    expected: FAIL
-
-  [click() on <input disabled="" type="checkbox">, observed from <input>]
-    expected: FAIL
-
-  [click() on <input disabled="" type="checkbox">, observed from <body>]
     expected: FAIL
 
   [Trusted click on <input disabled="" type="color" value="#000000">, observed from <input>]
@@ -270,46 +56,10 @@
   [Trusted click on <input disabled="" type="color" value="#000000">, observed from <body>]
     expected: FAIL
 
-  [Dispatch new MouseEvent() on <input disabled="" type="color" value="#000000">, observed from <input>]
-    expected: FAIL
-
-  [Dispatch new MouseEvent() on <input disabled="" type="color" value="#000000">, observed from <body>]
-    expected: FAIL
-
-  [Dispatch new PointerEvent() on <input disabled="" type="color" value="#000000">, observed from <input>]
-    expected: FAIL
-
-  [Dispatch new PointerEvent() on <input disabled="" type="color" value="#000000">, observed from <body>]
-    expected: FAIL
-
-  [click() on <input disabled="" type="color" value="#000000">, observed from <input>]
-    expected: FAIL
-
-  [click() on <input disabled="" type="color" value="#000000">, observed from <body>]
-    expected: FAIL
-
   [Trusted click on <input disabled="" type="date">, observed from <input>]
     expected: FAIL
 
   [Trusted click on <input disabled="" type="date">, observed from <body>]
-    expected: FAIL
-
-  [Dispatch new MouseEvent() on <input disabled="" type="date">, observed from <input>]
-    expected: FAIL
-
-  [Dispatch new MouseEvent() on <input disabled="" type="date">, observed from <body>]
-    expected: FAIL
-
-  [Dispatch new PointerEvent() on <input disabled="" type="date">, observed from <input>]
-    expected: FAIL
-
-  [Dispatch new PointerEvent() on <input disabled="" type="date">, observed from <body>]
-    expected: FAIL
-
-  [click() on <input disabled="" type="date">, observed from <input>]
-    expected: FAIL
-
-  [click() on <input disabled="" type="date">, observed from <body>]
     expected: FAIL
 
   [Trusted click on <input disabled="" type="datetime-local">, observed from <input>]
@@ -318,94 +68,16 @@
   [Trusted click on <input disabled="" type="datetime-local">, observed from <body>]
     expected: FAIL
 
-  [Dispatch new MouseEvent() on <input disabled="" type="datetime-local">, observed from <input>]
-    expected: FAIL
-
-  [Dispatch new MouseEvent() on <input disabled="" type="datetime-local">, observed from <body>]
-    expected: FAIL
-
-  [Dispatch new PointerEvent() on <input disabled="" type="datetime-local">, observed from <input>]
-    expected: FAIL
-
-  [Dispatch new PointerEvent() on <input disabled="" type="datetime-local">, observed from <body>]
-    expected: FAIL
-
-  [click() on <input disabled="" type="datetime-local">, observed from <input>]
-    expected: FAIL
-
-  [click() on <input disabled="" type="datetime-local">, observed from <body>]
-    expected: FAIL
-
   [Trusted click on <input disabled="" type="email">, observed from <input>]
     expected: FAIL
 
   [Trusted click on <input disabled="" type="email">, observed from <body>]
     expected: FAIL
 
-  [Dispatch new MouseEvent() on <input disabled="" type="email">, observed from <input>]
-    expected: FAIL
-
-  [Dispatch new MouseEvent() on <input disabled="" type="email">, observed from <body>]
-    expected: FAIL
-
-  [Dispatch new PointerEvent() on <input disabled="" type="email">, observed from <input>]
-    expected: FAIL
-
-  [Dispatch new PointerEvent() on <input disabled="" type="email">, observed from <body>]
-    expected: FAIL
-
-  [click() on <input disabled="" type="email">, observed from <input>]
-    expected: FAIL
-
-  [click() on <input disabled="" type="email">, observed from <body>]
-    expected: FAIL
-
   [Trusted click on <input disabled="" type="file">, observed from <input>]
     expected: FAIL
 
-  [Trusted click on <input disabled="" type="file">, observed from <body>]
-    expected: FAIL
-
-  [Dispatch new MouseEvent() on <input disabled="" type="file">, observed from <input>]
-    expected: FAIL
-
-  [Dispatch new MouseEvent() on <input disabled="" type="file">, observed from <body>]
-    expected: FAIL
-
-  [Dispatch new PointerEvent() on <input disabled="" type="file">, observed from <input>]
-    expected: FAIL
-
-  [Dispatch new PointerEvent() on <input disabled="" type="file">, observed from <body>]
-    expected: FAIL
-
-  [click() on <input disabled="" type="file">, observed from <input>]
-    expected: FAIL
-
-  [click() on <input disabled="" type="file">, observed from <body>]
-    expected: FAIL
-
   [Trusted click on <input disabled="" type="image">, observed from <input>]
-    expected: FAIL
-
-  [Trusted click on <input disabled="" type="image">, observed from <body>]
-    expected: FAIL
-
-  [Dispatch new MouseEvent() on <input disabled="" type="image">, observed from <input>]
-    expected: FAIL
-
-  [Dispatch new MouseEvent() on <input disabled="" type="image">, observed from <body>]
-    expected: FAIL
-
-  [Dispatch new PointerEvent() on <input disabled="" type="image">, observed from <input>]
-    expected: FAIL
-
-  [Dispatch new PointerEvent() on <input disabled="" type="image">, observed from <body>]
-    expected: FAIL
-
-  [click() on <input disabled="" type="image">, observed from <input>]
-    expected: FAIL
-
-  [click() on <input disabled="" type="image">, observed from <body>]
     expected: FAIL
 
   [Trusted click on <input disabled="" type="month">, observed from <input>]
@@ -414,46 +86,10 @@
   [Trusted click on <input disabled="" type="month">, observed from <body>]
     expected: FAIL
 
-  [Dispatch new MouseEvent() on <input disabled="" type="month">, observed from <input>]
-    expected: FAIL
-
-  [Dispatch new MouseEvent() on <input disabled="" type="month">, observed from <body>]
-    expected: FAIL
-
-  [Dispatch new PointerEvent() on <input disabled="" type="month">, observed from <input>]
-    expected: FAIL
-
-  [Dispatch new PointerEvent() on <input disabled="" type="month">, observed from <body>]
-    expected: FAIL
-
-  [click() on <input disabled="" type="month">, observed from <input>]
-    expected: FAIL
-
-  [click() on <input disabled="" type="month">, observed from <body>]
-    expected: FAIL
-
   [Trusted click on <input disabled="" type="number">, observed from <input>]
     expected: FAIL
 
   [Trusted click on <input disabled="" type="number">, observed from <body>]
-    expected: FAIL
-
-  [Dispatch new MouseEvent() on <input disabled="" type="number">, observed from <input>]
-    expected: FAIL
-
-  [Dispatch new MouseEvent() on <input disabled="" type="number">, observed from <body>]
-    expected: FAIL
-
-  [Dispatch new PointerEvent() on <input disabled="" type="number">, observed from <input>]
-    expected: FAIL
-
-  [Dispatch new PointerEvent() on <input disabled="" type="number">, observed from <body>]
-    expected: FAIL
-
-  [click() on <input disabled="" type="number">, observed from <input>]
-    expected: FAIL
-
-  [click() on <input disabled="" type="number">, observed from <body>]
     expected: FAIL
 
   [Trusted click on <input disabled="" type="password">, observed from <input>]
@@ -462,46 +98,7 @@
   [Trusted click on <input disabled="" type="password">, observed from <body>]
     expected: FAIL
 
-  [Dispatch new MouseEvent() on <input disabled="" type="password">, observed from <input>]
-    expected: FAIL
-
-  [Dispatch new MouseEvent() on <input disabled="" type="password">, observed from <body>]
-    expected: FAIL
-
-  [Dispatch new PointerEvent() on <input disabled="" type="password">, observed from <input>]
-    expected: FAIL
-
-  [Dispatch new PointerEvent() on <input disabled="" type="password">, observed from <body>]
-    expected: FAIL
-
-  [click() on <input disabled="" type="password">, observed from <input>]
-    expected: FAIL
-
-  [click() on <input disabled="" type="password">, observed from <body>]
-    expected: FAIL
-
   [Trusted click on <input disabled="" type="radio">, observed from <input>]
-    expected: FAIL
-
-  [Trusted click on <input disabled="" type="radio">, observed from <body>]
-    expected: FAIL
-
-  [Dispatch new MouseEvent() on <input disabled="" type="radio">, observed from <input>]
-    expected: FAIL
-
-  [Dispatch new MouseEvent() on <input disabled="" type="radio">, observed from <body>]
-    expected: FAIL
-
-  [Dispatch new PointerEvent() on <input disabled="" type="radio">, observed from <input>]
-    expected: FAIL
-
-  [Dispatch new PointerEvent() on <input disabled="" type="radio">, observed from <body>]
-    expected: FAIL
-
-  [click() on <input disabled="" type="radio">, observed from <input>]
-    expected: FAIL
-
-  [click() on <input disabled="" type="radio">, observed from <body>]
     expected: FAIL
 
   [Trusted click on <input disabled="" type="range" value="0">, observed from <input>]
@@ -510,70 +107,13 @@
   [Trusted click on <input disabled="" type="range" value="0">, observed from <body>]
     expected: FAIL
 
-  [Dispatch new MouseEvent() on <input disabled="" type="range" value="0">, observed from <input>]
-    expected: FAIL
-
-  [Dispatch new MouseEvent() on <input disabled="" type="range" value="0">, observed from <body>]
-    expected: FAIL
-
-  [Dispatch new PointerEvent() on <input disabled="" type="range" value="0">, observed from <input>]
-    expected: FAIL
-
-  [Dispatch new PointerEvent() on <input disabled="" type="range" value="0">, observed from <body>]
-    expected: FAIL
-
-  [click() on <input disabled="" type="range" value="0">, observed from <input>]
-    expected: FAIL
-
-  [click() on <input disabled="" type="range" value="0">, observed from <body>]
-    expected: FAIL
-
   [Trusted click on <input disabled="" type="range" value="50">, observed from <input>]
     expected: FAIL
 
   [Trusted click on <input disabled="" type="range" value="50">, observed from <body>]
     expected: FAIL
 
-  [Dispatch new MouseEvent() on <input disabled="" type="range" value="50">, observed from <input>]
-    expected: FAIL
-
-  [Dispatch new MouseEvent() on <input disabled="" type="range" value="50">, observed from <body>]
-    expected: FAIL
-
-  [Dispatch new PointerEvent() on <input disabled="" type="range" value="50">, observed from <input>]
-    expected: FAIL
-
-  [Dispatch new PointerEvent() on <input disabled="" type="range" value="50">, observed from <body>]
-    expected: FAIL
-
-  [click() on <input disabled="" type="range" value="50">, observed from <input>]
-    expected: FAIL
-
-  [click() on <input disabled="" type="range" value="50">, observed from <body>]
-    expected: FAIL
-
   [Trusted click on <input disabled="" type="reset">, observed from <input>]
-    expected: FAIL
-
-  [Trusted click on <input disabled="" type="reset">, observed from <body>]
-    expected: FAIL
-
-  [Dispatch new MouseEvent() on <input disabled="" type="reset">, observed from <input>]
-    expected: FAIL
-
-  [Dispatch new MouseEvent() on <input disabled="" type="reset">, observed from <body>]
-    expected: FAIL
-
-  [Dispatch new PointerEvent() on <input disabled="" type="reset">, observed from <input>]
-    expected: FAIL
-
-  [Dispatch new PointerEvent() on <input disabled="" type="reset">, observed from <body>]
-    expected: FAIL
-
-  [click() on <input disabled="" type="reset">, observed from <input>]
-    expected: FAIL
-
-  [click() on <input disabled="" type="reset">, observed from <body>]
     expected: FAIL
 
   [Trusted click on <input disabled="" type="search">, observed from <input>]
@@ -582,46 +122,7 @@
   [Trusted click on <input disabled="" type="search">, observed from <body>]
     expected: FAIL
 
-  [Dispatch new MouseEvent() on <input disabled="" type="search">, observed from <input>]
-    expected: FAIL
-
-  [Dispatch new MouseEvent() on <input disabled="" type="search">, observed from <body>]
-    expected: FAIL
-
-  [Dispatch new PointerEvent() on <input disabled="" type="search">, observed from <input>]
-    expected: FAIL
-
-  [Dispatch new PointerEvent() on <input disabled="" type="search">, observed from <body>]
-    expected: FAIL
-
-  [click() on <input disabled="" type="search">, observed from <input>]
-    expected: FAIL
-
-  [click() on <input disabled="" type="search">, observed from <body>]
-    expected: FAIL
-
   [Trusted click on <input disabled="" type="submit">, observed from <input>]
-    expected: FAIL
-
-  [Trusted click on <input disabled="" type="submit">, observed from <body>]
-    expected: FAIL
-
-  [Dispatch new MouseEvent() on <input disabled="" type="submit">, observed from <input>]
-    expected: FAIL
-
-  [Dispatch new MouseEvent() on <input disabled="" type="submit">, observed from <body>]
-    expected: FAIL
-
-  [Dispatch new PointerEvent() on <input disabled="" type="submit">, observed from <input>]
-    expected: FAIL
-
-  [Dispatch new PointerEvent() on <input disabled="" type="submit">, observed from <body>]
-    expected: FAIL
-
-  [click() on <input disabled="" type="submit">, observed from <input>]
-    expected: FAIL
-
-  [click() on <input disabled="" type="submit">, observed from <body>]
     expected: FAIL
 
   [Trusted click on <input disabled="" type="tel">, observed from <input>]
@@ -630,46 +131,10 @@
   [Trusted click on <input disabled="" type="tel">, observed from <body>]
     expected: FAIL
 
-  [Dispatch new MouseEvent() on <input disabled="" type="tel">, observed from <input>]
-    expected: FAIL
-
-  [Dispatch new MouseEvent() on <input disabled="" type="tel">, observed from <body>]
-    expected: FAIL
-
-  [Dispatch new PointerEvent() on <input disabled="" type="tel">, observed from <input>]
-    expected: FAIL
-
-  [Dispatch new PointerEvent() on <input disabled="" type="tel">, observed from <body>]
-    expected: FAIL
-
-  [click() on <input disabled="" type="tel">, observed from <input>]
-    expected: FAIL
-
-  [click() on <input disabled="" type="tel">, observed from <body>]
-    expected: FAIL
-
   [Trusted click on <input disabled="" type="text">, observed from <input>]
     expected: FAIL
 
   [Trusted click on <input disabled="" type="text">, observed from <body>]
-    expected: FAIL
-
-  [Dispatch new MouseEvent() on <input disabled="" type="text">, observed from <input>]
-    expected: FAIL
-
-  [Dispatch new MouseEvent() on <input disabled="" type="text">, observed from <body>]
-    expected: FAIL
-
-  [Dispatch new PointerEvent() on <input disabled="" type="text">, observed from <input>]
-    expected: FAIL
-
-  [Dispatch new PointerEvent() on <input disabled="" type="text">, observed from <body>]
-    expected: FAIL
-
-  [click() on <input disabled="" type="text">, observed from <input>]
-    expected: FAIL
-
-  [click() on <input disabled="" type="text">, observed from <body>]
     expected: FAIL
 
   [Trusted click on <input disabled="" type="time">, observed from <input>]
@@ -678,46 +143,10 @@
   [Trusted click on <input disabled="" type="time">, observed from <body>]
     expected: FAIL
 
-  [Dispatch new MouseEvent() on <input disabled="" type="time">, observed from <input>]
-    expected: FAIL
-
-  [Dispatch new MouseEvent() on <input disabled="" type="time">, observed from <body>]
-    expected: FAIL
-
-  [Dispatch new PointerEvent() on <input disabled="" type="time">, observed from <input>]
-    expected: FAIL
-
-  [Dispatch new PointerEvent() on <input disabled="" type="time">, observed from <body>]
-    expected: FAIL
-
-  [click() on <input disabled="" type="time">, observed from <input>]
-    expected: FAIL
-
-  [click() on <input disabled="" type="time">, observed from <body>]
-    expected: FAIL
-
   [Trusted click on <input disabled="" type="url">, observed from <input>]
     expected: FAIL
 
   [Trusted click on <input disabled="" type="url">, observed from <body>]
-    expected: FAIL
-
-  [Dispatch new MouseEvent() on <input disabled="" type="url">, observed from <input>]
-    expected: FAIL
-
-  [Dispatch new MouseEvent() on <input disabled="" type="url">, observed from <body>]
-    expected: FAIL
-
-  [Dispatch new PointerEvent() on <input disabled="" type="url">, observed from <input>]
-    expected: FAIL
-
-  [Dispatch new PointerEvent() on <input disabled="" type="url">, observed from <body>]
-    expected: FAIL
-
-  [click() on <input disabled="" type="url">, observed from <input>]
-    expected: FAIL
-
-  [click() on <input disabled="" type="url">, observed from <body>]
     expected: FAIL
 
   [Trusted click on <input disabled="" type="week">, observed from <input>]
@@ -726,44 +155,5 @@
   [Trusted click on <input disabled="" type="week">, observed from <body>]
     expected: FAIL
 
-  [Dispatch new MouseEvent() on <input disabled="" type="week">, observed from <input>]
-    expected: FAIL
-
-  [Dispatch new MouseEvent() on <input disabled="" type="week">, observed from <body>]
-    expected: FAIL
-
-  [Dispatch new PointerEvent() on <input disabled="" type="week">, observed from <input>]
-    expected: FAIL
-
-  [Dispatch new PointerEvent() on <input disabled="" type="week">, observed from <body>]
-    expected: FAIL
-
-  [click() on <input disabled="" type="week">, observed from <input>]
-    expected: FAIL
-
-  [click() on <input disabled="" type="week">, observed from <body>]
-    expected: FAIL
-
   [Trusted click on <my-control disabled="">Text</my-control>, observed from <my-control>]
-    expected: FAIL
-
-  [Trusted click on <my-control disabled="">Text</my-control>, observed from <body>]
-    expected: FAIL
-
-  [Dispatch new MouseEvent() on <my-control disabled="">Text</my-control>, observed from <my-control>]
-    expected: FAIL
-
-  [Dispatch new MouseEvent() on <my-control disabled="">Text</my-control>, observed from <body>]
-    expected: FAIL
-
-  [Dispatch new PointerEvent() on <my-control disabled="">Text</my-control>, observed from <my-control>]
-    expected: FAIL
-
-  [Dispatch new PointerEvent() on <my-control disabled="">Text</my-control>, observed from <body>]
-    expected: FAIL
-
-  [click() on <my-control disabled="">Text</my-control>, observed from <my-control>]
-    expected: FAIL
-
-  [click() on <my-control disabled="">Text</my-control>, observed from <body>]
     expected: FAIL


### PR DESCRIPTION
This change also adjusts the styles of disabled select elements such that the text appears grayed out, like in firefox:
<img width="480" height="84" alt="image" src="https://github.com/user-attachments/assets/d36325f5-c811-492b-9510-7a32efd5fd7b" />


Testing: No tests. I think it would be possible to write a webdriver test for this? It didn't seem worth the effort, if someone can point me to the relevant resources then I'm happy to write one ^^

Fixes: https://github.com/servo/servo/issues/42075
