### PR TITLE
servoshell: Surrender focus when clicking on the WebView on desktop

### DIFF
--- a/ports/servoshell/desktop/gui.rs
+++ b/ports/servoshell/desktop/gui.rs
@@ -133,6 +133,14 @@ impl Gui {
             .memory(|memory| memory.focused().is_some())
     }
 
+    pub(crate) fn surrender_focus(&self) {
+        self.context.egui_ctx.memory_mut(|memory| {
+            if let Some(focused) = memory.focused() {
+                memory.surrender_focus(focused);
+            }
+        });
+    }
+
     pub(crate) fn on_window_event(
         &mut self,
         winit_window: &Window,

--- a/ports/servoshell/desktop/headed_window.rs
+++ b/ports/servoshell/desktop/headed_window.rs
@@ -614,7 +614,10 @@ impl HeadedWindow {
                 consumed = true;
             },
             WindowEvent::MouseWheel { .. } | WindowEvent::MouseInput { .. }
-                if !forward_mouse_event_to_egui(None) => {},
+                if !forward_mouse_event_to_egui(None) =>
+            {
+                self.gui.borrow().surrender_focus();
+            },
             WindowEvent::KeyboardInput { .. } if !self.gui.borrow().has_keyboard_focus() => {
                 // Keyboard events should go to the WebView unless some other GUI
                 // component has keyboard focus.


### PR DESCRIPTION
Clicking on the WebView should move focus from the egui interface to the
WebView, so that any subsequent keyboard events are sent there.

Testing: We do not have tests for this layer of servoshell and these kind of
interactions are difficult to test without a live test runner.
Fixes: #42073
Fixes: #41681
