### PR TITLE
layout: Use `-servo-checkmark`instead of `::before` for checkbox and radio inputs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7983,7 +7983,7 @@ dependencies = [
 [[package]]
 name = "selectors"
 version = "0.35.0"
-source = "git+https://github.com/servo/stylo?rev=44bf70c4215dde5997aa835081d7320c1f533c95#44bf70c4215dde5997aa835081d7320c1f533c95"
+source = "git+https://github.com/servo/stylo?rev=refs%2Fpull%2F290%2Fhead#13bab5e680935daabddb142387b2e6bd8c5e3d99"
 dependencies = [
  "bitflags 2.10.0",
  "cssparser",
@@ -8290,7 +8290,7 @@ dependencies = [
 [[package]]
 name = "servo_arc"
 version = "0.4.3"
-source = "git+https://github.com/servo/stylo?rev=44bf70c4215dde5997aa835081d7320c1f533c95#44bf70c4215dde5997aa835081d7320c1f533c95"
+source = "git+https://github.com/servo/stylo?rev=refs%2Fpull%2F290%2Fhead#13bab5e680935daabddb142387b2e6bd8c5e3d99"
 dependencies = [
  "serde",
  "stable_deref_trait",
@@ -8839,7 +8839,7 @@ dependencies = [
 [[package]]
 name = "stylo"
 version = "0.11.0"
-source = "git+https://github.com/servo/stylo?rev=44bf70c4215dde5997aa835081d7320c1f533c95#44bf70c4215dde5997aa835081d7320c1f533c95"
+source = "git+https://github.com/servo/stylo?rev=refs%2Fpull%2F290%2Fhead#13bab5e680935daabddb142387b2e6bd8c5e3d99"
 dependencies = [
  "app_units",
  "arrayvec",
@@ -8894,7 +8894,7 @@ dependencies = [
 [[package]]
 name = "stylo_atoms"
 version = "0.11.0"
-source = "git+https://github.com/servo/stylo?rev=44bf70c4215dde5997aa835081d7320c1f533c95#44bf70c4215dde5997aa835081d7320c1f533c95"
+source = "git+https://github.com/servo/stylo?rev=refs%2Fpull%2F290%2Fhead#13bab5e680935daabddb142387b2e6bd8c5e3d99"
 dependencies = [
  "string_cache",
  "string_cache_codegen",
@@ -8903,12 +8903,12 @@ dependencies = [
 [[package]]
 name = "stylo_config"
 version = "0.11.0"
-source = "git+https://github.com/servo/stylo?rev=44bf70c4215dde5997aa835081d7320c1f533c95#44bf70c4215dde5997aa835081d7320c1f533c95"
+source = "git+https://github.com/servo/stylo?rev=refs%2Fpull%2F290%2Fhead#13bab5e680935daabddb142387b2e6bd8c5e3d99"
 
 [[package]]
 name = "stylo_derive"
 version = "0.11.0"
-source = "git+https://github.com/servo/stylo?rev=44bf70c4215dde5997aa835081d7320c1f533c95#44bf70c4215dde5997aa835081d7320c1f533c95"
+source = "git+https://github.com/servo/stylo?rev=refs%2Fpull%2F290%2Fhead#13bab5e680935daabddb142387b2e6bd8c5e3d99"
 dependencies = [
  "darling",
  "proc-macro2",
@@ -8920,7 +8920,7 @@ dependencies = [
 [[package]]
 name = "stylo_dom"
 version = "0.11.0"
-source = "git+https://github.com/servo/stylo?rev=44bf70c4215dde5997aa835081d7320c1f533c95#44bf70c4215dde5997aa835081d7320c1f533c95"
+source = "git+https://github.com/servo/stylo?rev=refs%2Fpull%2F290%2Fhead#13bab5e680935daabddb142387b2e6bd8c5e3d99"
 dependencies = [
  "bitflags 2.10.0",
  "stylo_malloc_size_of",
@@ -8929,7 +8929,7 @@ dependencies = [
 [[package]]
 name = "stylo_malloc_size_of"
 version = "0.11.0"
-source = "git+https://github.com/servo/stylo?rev=44bf70c4215dde5997aa835081d7320c1f533c95#44bf70c4215dde5997aa835081d7320c1f533c95"
+source = "git+https://github.com/servo/stylo?rev=refs%2Fpull%2F290%2Fhead#13bab5e680935daabddb142387b2e6bd8c5e3d99"
 dependencies = [
  "app_units",
  "cssparser",
@@ -8946,12 +8946,12 @@ dependencies = [
 [[package]]
 name = "stylo_static_prefs"
 version = "0.11.0"
-source = "git+https://github.com/servo/stylo?rev=44bf70c4215dde5997aa835081d7320c1f533c95#44bf70c4215dde5997aa835081d7320c1f533c95"
+source = "git+https://github.com/servo/stylo?rev=refs%2Fpull%2F290%2Fhead#13bab5e680935daabddb142387b2e6bd8c5e3d99"
 
 [[package]]
 name = "stylo_traits"
 version = "0.11.0"
-source = "git+https://github.com/servo/stylo?rev=44bf70c4215dde5997aa835081d7320c1f533c95#44bf70c4215dde5997aa835081d7320c1f533c95"
+source = "git+https://github.com/servo/stylo?rev=refs%2Fpull%2F290%2Fhead#13bab5e680935daabddb142387b2e6bd8c5e3d99"
 dependencies = [
  "app_units",
  "bitflags 2.10.0",
@@ -9363,7 +9363,7 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 [[package]]
 name = "to_shmem"
 version = "0.3.0"
-source = "git+https://github.com/servo/stylo?rev=44bf70c4215dde5997aa835081d7320c1f533c95#44bf70c4215dde5997aa835081d7320c1f533c95"
+source = "git+https://github.com/servo/stylo?rev=refs%2Fpull%2F290%2Fhead#13bab5e680935daabddb142387b2e6bd8c5e3d99"
 dependencies = [
  "cssparser",
  "servo_arc",
@@ -9376,7 +9376,7 @@ dependencies = [
 [[package]]
 name = "to_shmem_derive"
 version = "0.1.0"
-source = "git+https://github.com/servo/stylo?rev=44bf70c4215dde5997aa835081d7320c1f533c95#44bf70c4215dde5997aa835081d7320c1f533c95"
+source = "git+https://github.com/servo/stylo?rev=refs%2Fpull%2F290%2Fhead#13bab5e680935daabddb142387b2e6bd8c5e3d99"
 dependencies = [
  "darling",
  "proc-macro2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -157,7 +157,7 @@ script_traits = { path = "components/shared/script" }
 sea-query = { version = "1.0.0-rc.30", default-features = false, features = ["backend-sqlite", "derive"] }
 sea-query-rusqlite = { version = "0.8.0-rc.15" }
 sec1 = "0.7"
-selectors = { git = "https://github.com/servo/stylo", rev = "44bf70c4215dde5997aa835081d7320c1f533c95" }
+selectors = { git = "https://github.com/servo/stylo", rev = "refs/pull/290/head" }
 serde = "1.0.228"
 serde_bytes = "0.11"
 serde_core = "1.0.226"
@@ -166,7 +166,7 @@ servo-media = { git = "https://github.com/servo/media", rev = "f384dbc4ff8b5c6f8
 servo-media-dummy = { git = "https://github.com/servo/media", rev = "f384dbc4ff8b5c6f8db2c763306cbe2281d66391" }
 servo-media-gstreamer = { git = "https://github.com/servo/media", rev = "f384dbc4ff8b5c6f8db2c763306cbe2281d66391" }
 servo-tracing = { path = "components/servo_tracing" }
-servo_arc = { git = "https://github.com/servo/stylo", rev = "44bf70c4215dde5997aa835081d7320c1f533c95" }
+servo_arc = { git = "https://github.com/servo/stylo", rev = "refs/pull/290/head" }
 sha1 = "0.10"
 sha2 = "0.10"
 sha3 = "0.10"
@@ -175,12 +175,12 @@ smallvec = { version = "1.15", features = ["serde", "union"] }
 storage_traits = { path = "components/shared/storage" }
 string_cache = "0.9"
 strum = { version = "0.27", features = ["derive"] }
-stylo = { git = "https://github.com/servo/stylo", rev = "44bf70c4215dde5997aa835081d7320c1f533c95" }
-stylo_atoms = { git = "https://github.com/servo/stylo", rev = "44bf70c4215dde5997aa835081d7320c1f533c95" }
-stylo_config = { git = "https://github.com/servo/stylo", rev = "44bf70c4215dde5997aa835081d7320c1f533c95" }
-stylo_dom = { git = "https://github.com/servo/stylo", rev = "44bf70c4215dde5997aa835081d7320c1f533c95" }
-stylo_malloc_size_of = { git = "https://github.com/servo/stylo", rev = "44bf70c4215dde5997aa835081d7320c1f533c95" }
-stylo_traits = { git = "https://github.com/servo/stylo", rev = "44bf70c4215dde5997aa835081d7320c1f533c95" }
+stylo = { git = "https://github.com/servo/stylo", rev = "refs/pull/290/head" }
+stylo_atoms = { git = "https://github.com/servo/stylo", rev = "refs/pull/290/head" }
+stylo_config = { git = "https://github.com/servo/stylo", rev = "refs/pull/290/head" }
+stylo_dom = { git = "https://github.com/servo/stylo", rev = "refs/pull/290/head" }
+stylo_malloc_size_of = { git = "https://github.com/servo/stylo", rev = "refs/pull/290/head" }
+stylo_traits = { git = "https://github.com/servo/stylo", rev = "refs/pull/290/head" }
 surfman = { version = "0.11.0", features = ["chains"] }
 syn = { version = "2", default-features = false, features = ["clone-impls", "derive", "parsing"] }
 synstructure = "0.13"

--- a/components/layout/stylesheets/servo.css
+++ b/components/layout/stylesheets/servo.css
@@ -202,7 +202,7 @@ input[type="checkbox"] {
   overflow: hidden;
 }
 
-input[type="checkbox"]::before {
+input[type="checkbox"]::-servo-checkmark {
   content: "";
   font-size: 12px;
   position: absolute;
@@ -211,15 +211,15 @@ input[type="checkbox"]::before {
   transform: translate(-50%, -50%);
 }
 
-input[type="checkbox"]:disabled::before {
+input[type="checkbox"]:disabled::-servo-checkmark {
   color: grey;
 }
 
-input[type="checkbox"]:checked::before {
+input[type="checkbox"]:checked::-servo-checkmark {
   content: "✔";
 }
 
-input[type="checkbox"]:indeterminate::before {
+input[type="checkbox"]:indeterminate::-servo-checkmark {
   content: "—";
 }
 
@@ -239,7 +239,7 @@ input[type="radio"] {
   outline-offset: 0.4px;
 }
 
-input[type="radio"]::before {
+input[type="radio"]::-servo-checkmark {
   content: "";
   background: transparent;
 
@@ -255,11 +255,11 @@ input[type="radio"]::before {
   border-radius: 50%;
 }
 
-input[type="radio"]:checked::before {
+input[type="radio"]:checked::-servo-checkmark {
   background: black;
 }
 
-input[type="radio"]:checked:disabled::before {
+input[type="radio"]:checked:disabled::-servo-checkmark {
   background: grey;
 }
 

--- a/components/script/dom/window.rs
+++ b/components/script/dom/window.rs
@@ -1861,6 +1861,9 @@ impl WindowMethods<crate::DomTypeHolder> for Window {
             },
             Some(ref pseudo) if pseudo == "::selection" => Some(PseudoElement::Selection),
             Some(ref pseudo) if pseudo == "::marker" => Some(PseudoElement::Marker),
+            Some(ref pseudo) if pseudo == "::-servo-checkmark" => {
+                Some(PseudoElement::ServoCheckmark)
+            },
             Some(ref pseudo) if pseudo.starts_with(':') => {
                 // Step 3.2: If type is failure, or is a ::slotted() or ::part()
                 // pseudo-element, let obj be null.


### PR DESCRIPTION
Use ServoCheckmark instead of Before for checkbox and radio inputs

This swaps ::before for ::-servo-checkmark in the UA stylesheet.

Testing: No observable change.
Fixes: #42089 

Stylo PR: https://github.com/servo/stylo/pull/290