### PR TITLE
script: Allow `<input type=button>` to be activatable

### DIFF
--- a/components/script/dom/html/htmlinputelement.rs
+++ b/components/script/dom/html/htmlinputelement.rs
@@ -3421,9 +3421,13 @@ impl Activatable for HTMLInputElement {
             // https://html.spec.whatwg.org/multipage/#reset-button-state-(type=reset):input-activation-behavior
             // https://html.spec.whatwg.org/multipage/#file-upload-state-(type=file):input-activation-behavior
             // https://html.spec.whatwg.org/multipage/#image-button-state-(type=image):input-activation-behavior
-            InputType::Submit | InputType::Reset | InputType::File | InputType::Image => {
-                self.is_mutable()
-            },
+            //
+            // Although they do not have implicit activation behaviors, `type=button` is an activatable input event.
+            InputType::Submit |
+            InputType::Reset |
+            InputType::File |
+            InputType::Image |
+            InputType::Button => self.is_mutable(),
             // https://html.spec.whatwg.org/multipage/#checkbox-state-(type=checkbox):input-activation-behavior
             // https://html.spec.whatwg.org/multipage/#radio-button-state-(type=radio):input-activation-behavior
             // https://html.spec.whatwg.org/multipage/#color-state-(type=color):input-activation-behavior

--- a/tests/wpt/meta/html/semantics/forms/form-submission-0/form-double-submit-input-type-change.html.ini
+++ b/tests/wpt/meta/html/semantics/forms/form-submission-0/form-double-submit-input-type-change.html.ini
@@ -37,6 +37,3 @@
 
   [default submit action should supersede input onclick submit() and change the input type from range to submit]
     expected: FAIL
-
-  [default submit action should supersede input onclick submit() and change the input type from button to submit]
-    expected: FAIL

--- a/tests/wpt/meta/html/semantics/interactive-elements/the-summary-element/interactive-content.html.ini
+++ b/tests/wpt/meta/html/semantics/interactive-elements/the-summary-element/interactive-content.html.ini
@@ -14,9 +14,6 @@
   [Clicking an <img> with a 'usemap' attribute doesn't open <details>]
     expected: FAIL
 
-  [Clicking an <input type=button> doesn't open <details>]
-    expected: FAIL
-
   [Clicking an <input type=text> doesn't open <details>]
     expected: FAIL
 


### PR DESCRIPTION
Although these type of inputs do not have an activation behavior (the
behavior of their clicks are up to the page), they should still get the
"active" node state when they are pressed. This allows the `:active`
pseudo-selector to work on them, making press highlights work.

Testing: This fixes two WPT subtests.
