### PR TITLE
tidy: Improve `check_shell` substitution lint

### DIFF
--- a/python/tidy/tests/shell_tidy.sh
+++ b/python/tidy/tests/shell_tidy.sh
@@ -12,3 +12,9 @@ if [ -z "${some_var}" ]; then
   echo "should have used [["
 fi
 [ -z "${another_var}" ]
+# Using $@, $1 etc. shouldn't trigger.
+echo "$@"
+if [[ -n "$1" ]]; then
+  echo "parameter 1 is $1"
+fi
+echo "item1 item2 item3" | awk '{$1=$1;print}'


### PR DESCRIPTION
Probably we should use a proper linter like `shellcheck`, but in the meantime make the lint slightly smarter, so that it doesn't complaint about e.g. `$1`. This is especially a problem when adding scripts which use `awk`, since our lint is quite stupid and doesn't understand `''` strings.
This fixes linting, for a simple new script introduced in https://github.com/servo/servo/pull/41775

Testing: ./mach test-tidy still passes. 

