### PR TITLE
net: Cleanup some visibility and unused async

### DIFF
--- a/components/net/http_loader.rs
+++ b/components/net/http_loader.rs
@@ -1639,8 +1639,7 @@ async fn http_network_or_cache_fetch(
                 // since the network response will be replaced by the revalidated stored one.
                 *done_chan = None;
                 if let Some(guard) = cache_guard.try_as_mut() {
-                    response =
-                        refresh(http_request, forward_response.clone(), done_chan, guard).await;
+                    response = refresh(http_request, forward_response.clone(), done_chan, guard);
                 }
 
                 if let Some(response) = &mut response {
@@ -1658,7 +1657,7 @@ async fn http_network_or_cache_fetch(
                 if http_request.cache_mode != CacheMode::NoStore {
                     // Step 10.5.2 Store httpRequest and forwardResponse in httpCache, as per the
                     //             "Storing Responses in Caches" chapter of HTTP Caching.
-                    cache_guard.insert(http_request, forward_response).await;
+                    cache_guard.insert(http_request, forward_response);
                 }
             }
             false

--- a/components/net/tests/http_cache.rs
+++ b/components/net/tests/http_cache.rs
@@ -36,7 +36,7 @@ async fn test_refreshing_resource_sets_done_chan_the_appropriate_value() {
         // First, store the 'normal' response.
         let mut resource = {
             let guard = cache.get_or_guard(CacheKey::new(&request)).await;
-            guard.insert(&request, &response).await;
+            guard.insert(&request, &response);
             cache.get_or_guard(CacheKey::new(&request)).await
         };
         // Second, mutate the response into a 304 response, and refresh the stored one.
@@ -48,8 +48,7 @@ async fn test_refreshing_resource_sets_done_chan_the_appropriate_value() {
             response.clone(),
             &mut done_chan,
             resource.try_as_mut().unwrap(),
-        )
-        .await;
+        );
         // Ensure a resource was found, and refreshed.
         assert!(refreshed_response.is_some());
         match body {


### PR DESCRIPTION
This cleans up some visibility for the http-cache and removes an async that was not used.

Testing: Does not change functionality so compilation and test compilations are enough.
