### PR TITLE
fonts: Store shaping output per-character rather than per-code point

### DIFF
--- a/components/fonts/font.rs
+++ b/components/fonts/font.rs
@@ -411,7 +411,7 @@ impl Font {
             debug!("shape_text: Using Harfbuzz.");
             self.shaper
                 .get_or_init(|| Shaper::new(self))
-                .shape_text(text, options)
+                .shape_text(self, text, options)
         };
 
         let shaped_text = Arc::new(glyphs);

--- a/components/fonts/glyph.rs
+++ b/components/fonts/glyph.rs
@@ -2,20 +2,17 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-use std::cmp::{Ordering, PartialOrd};
-use std::iter::once;
-use std::sync::Arc;
+use std::fmt;
 use std::vec::Vec;
-use std::{fmt, mem};
 
 use app_units::Au;
 use euclid::default::Point2D;
 use euclid::num::Zero;
-use fonts_traits::{ByteIndex, TextByteRange};
 use itertools::Either;
-use log::debug;
 use malloc_size_of_derive::MallocSizeOf;
 use serde::{Deserialize, Serialize};
+
+use crate::{GlyphShapingResult, ShapedGlyph, ShapingFlags, ShapingOptions};
 
 /// GlyphEntry is a port of Gecko's CompressedGlyph scheme for storing glyph data compactly.
 ///
@@ -26,17 +23,13 @@ use serde::{Deserialize, Serialize};
 /// glyph offsets), we pack the glyph count into GlyphEntry, and store the other glyph information
 /// in DetailedGlyphStore.
 #[derive(Clone, Copy, Debug, Deserialize, MallocSizeOf, PartialEq, Serialize)]
-pub(crate) struct GlyphEntry {
+pub struct GlyphEntry {
     value: u32,
 }
 
 impl GlyphEntry {
     fn new(value: u32) -> GlyphEntry {
         GlyphEntry { value }
-    }
-
-    fn initial() -> GlyphEntry {
-        GlyphEntry::new(0)
     }
 
     // Creates a GlyphEntry for the common case
@@ -51,22 +44,9 @@ impl GlyphEntry {
         GlyphEntry::new(id_mask | advance_mask | FLAG_IS_SIMPLE_GLYPH)
     }
 
-    // Create a GlyphEntry for uncommon case; should be accompanied by
-    // initialization of the actual DetailedGlyph data in DetailedGlyphStore
-    fn complex(starts_cluster: bool, starts_ligature: bool, glyph_count: usize) -> GlyphEntry {
-        assert!(glyph_count <= u16::MAX as usize);
-
-        debug!(
-            "creating complex glyph entry: starts_cluster={}, starts_ligature={}, \
-             glyph_count={}",
-            starts_cluster, starts_ligature, glyph_count
-        );
-
-        GlyphEntry::new(glyph_count as u32)
-    }
-
-    fn is_initial(&self) -> bool {
-        *self == GlyphEntry::initial()
+    fn complex(detailed_glyph_index: usize) -> GlyphEntry {
+        assert!(detailed_glyph_index as u32 <= u32::MAX >> 1);
+        GlyphEntry::new(detailed_glyph_index as u32)
     }
 }
 
@@ -88,9 +68,6 @@ const GLYPH_ID_MASK: u32 = 0x0000FFFF;
 // or more detailed glyphs associated with them. They are stored in a
 // side array so that there is a 1:1 mapping of GlyphEntry to
 // unicode char.
-
-// The number of detailed glyphs for this char.
-const GLYPH_COUNT_MASK: u32 = 0x0000FFFF;
 
 fn is_simple_glyph_id(id: GlyphId) -> bool {
     (id & GLYPH_ID_MASK) == id
@@ -131,11 +108,8 @@ impl GlyphEntry {
         self.value |= FLAG_CHAR_IS_WORD_SEPARATOR;
     }
 
-    fn glyph_count(&self) -> usize {
-        if self.is_simple() {
-            return 1;
-        }
-        (self.value & GLYPH_COUNT_MASK) as usize
+    fn detailed_glyph_index(&self) -> usize {
+        self.value as usize
     }
 
     #[inline(always)]
@@ -149,199 +123,20 @@ impl GlyphEntry {
     }
 }
 
-// Stores data for a detailed glyph, in the case that several glyphs
-// correspond to one character, or the glyph's data couldn't be packed.
-#[derive(Clone, Copy, Debug, Deserialize, MallocSizeOf, Serialize)]
-struct DetailedGlyph {
-    id: GlyphId,
-    // glyph's advance, in the text's direction (LTR or RTL)
-    advance: Au,
-    // glyph's offset from the font's em-box (from top-left)
-    offset: Point2D<Au>,
-}
-
-impl DetailedGlyph {
-    fn new(id: GlyphId, advance: Au, offset: Point2D<Au>) -> DetailedGlyph {
-        DetailedGlyph {
-            id,
-            advance,
-            offset,
-        }
-    }
-}
-
-#[derive(Clone, Copy, Debug, Deserialize, Eq, MallocSizeOf, PartialEq, Serialize)]
-struct DetailedGlyphRecord {
-    // source string offset/GlyphEntry offset in the TextRun
-    entry_offset: ByteIndex,
-    // offset into the detailed glyphs buffer
-    detail_offset: usize,
-}
-
-impl Ord for DetailedGlyphRecord {
-    fn cmp(&self, other: &DetailedGlyphRecord) -> Ordering {
-        self.entry_offset.cmp(&other.entry_offset)
-    }
-}
-
-impl PartialOrd for DetailedGlyphRecord {
-    fn partial_cmp(&self, other: &DetailedGlyphRecord) -> Option<Ordering> {
-        Some(self.cmp(other))
-    }
-}
-
-// Manages the lookup table for detailed glyphs. Sorting is deferred
-// until a lookup is actually performed; this matches the expected
-// usage pattern of setting/appending all the detailed glyphs, and
-// then querying without setting.
 #[derive(Clone, Deserialize, MallocSizeOf, Serialize)]
-struct DetailedGlyphStore {
-    // TODO(pcwalton): Allocation of this buffer is expensive. Consider a small-vector
-    // optimization.
-    detail_buffer: Vec<DetailedGlyph>,
-    // TODO(pcwalton): Allocation of this buffer is expensive. Consider a small-vector
-    // optimization.
-    detail_lookup: Vec<DetailedGlyphRecord>,
-    lookup_is_sorted: bool,
-}
-
-impl<'a> DetailedGlyphStore {
-    fn new() -> DetailedGlyphStore {
-        DetailedGlyphStore {
-            detail_buffer: vec![], // TODO: default size?
-            detail_lookup: vec![],
-            lookup_is_sorted: false,
-        }
-    }
-
-    fn add_detailed_glyphs_for_entry(&mut self, entry_offset: ByteIndex, glyphs: &[DetailedGlyph]) {
-        let entry = DetailedGlyphRecord {
-            entry_offset,
-            detail_offset: self.detail_buffer.len(),
-        };
-
-        debug!(
-            "Adding entry[off={:?}] for detailed glyphs: {:?}",
-            entry_offset, glyphs
-        );
-
-        debug_assert!(!self.detail_lookup.contains(&entry));
-        self.detail_lookup.push(entry);
-        self.detail_buffer.extend_from_slice(glyphs);
-        self.lookup_is_sorted = false;
-    }
-
-    fn detailed_glyphs_for_entry(
-        &'a self,
-        entry_offset: ByteIndex,
-        count: usize,
-    ) -> &'a [DetailedGlyph] {
-        debug!(
-            "Requesting detailed glyphs[n={}] for entry[off={:?}]",
-            count, entry_offset
-        );
-
-        // FIXME: Is this right? --pcwalton
-        // TODO: should fix this somewhere else
-        if count == 0 {
-            return &self.detail_buffer[0..0];
-        }
-
-        assert!(count <= self.detail_buffer.len());
-        assert!(self.lookup_is_sorted);
-
-        let key = DetailedGlyphRecord {
-            entry_offset,
-            detail_offset: 0, // unused
-        };
-
-        let i = self
-            .detail_lookup
-            .binary_search(&key)
-            .expect("Invalid index not found in detailed glyph lookup table!");
-        let main_detail_offset = self.detail_lookup[i].detail_offset;
-        assert!(main_detail_offset + count <= self.detail_buffer.len());
-        // return a slice into the buffer
-        &self.detail_buffer[main_detail_offset..main_detail_offset + count]
-    }
-
-    fn detailed_glyph_with_index(
-        &'a self,
-        entry_offset: ByteIndex,
-        detail_offset: u16,
-    ) -> &'a DetailedGlyph {
-        assert!((detail_offset as usize) <= self.detail_buffer.len());
-        assert!(self.lookup_is_sorted);
-
-        let key = DetailedGlyphRecord {
-            entry_offset,
-            detail_offset: 0, // unused
-        };
-
-        let i = self
-            .detail_lookup
-            .binary_search(&key)
-            .expect("Invalid index not found in detailed glyph lookup table!");
-        let main_detail_offset = self.detail_lookup[i].detail_offset;
-        assert!(main_detail_offset + (detail_offset as usize) < self.detail_buffer.len());
-        &self.detail_buffer[main_detail_offset + (detail_offset as usize)]
-    }
-
-    fn ensure_sorted(&mut self) {
-        if self.lookup_is_sorted {
-            return;
-        }
-
-        // Sorting a unique vector is surprisingly hard. The following
-        // code is a good argument for using DVecs, but they require
-        // immutable locations thus don't play well with freezing.
-
-        // Thar be dragons here. You have been warned. (Tips accepted.)
-        let mut unsorted_records: Vec<DetailedGlyphRecord> = vec![];
-        mem::swap(&mut self.detail_lookup, &mut unsorted_records);
-        let mut mut_records: Vec<DetailedGlyphRecord> = unsorted_records;
-        mut_records.sort_by(|a, b| {
-            if a < b {
-                Ordering::Less
-            } else {
-                Ordering::Greater
-            }
-        });
-        let mut sorted_records = mut_records;
-        mem::swap(&mut self.detail_lookup, &mut sorted_records);
-
-        self.lookup_is_sorted = true;
-    }
-}
-
-// This struct is used by GlyphStore clients to provide new glyph data.
-// It should be allocated on the stack and passed by reference to GlyphStore.
-#[derive(Clone, Copy, Debug)]
-pub(crate) struct GlyphData {
-    id: GlyphId,
+pub struct DetailedGlyphEntry {
+    /// The id of the this glyph within the font.
+    id: u32,
+    /// The advance that this glyphs needs ie the distance between where this
+    /// glyph is painted and the next is painted.
     advance: Au,
-    offset: Point2D<Au>,
-    cluster_start: bool,
-    ligature_start: bool,
-}
-
-impl GlyphData {
-    /// Creates a new entry for one glyph.
-    pub(crate) fn new(
-        id: GlyphId,
-        advance: Au,
-        offset: Option<Point2D<Au>>,
-        cluster_start: bool,
-        ligature_start: bool,
-    ) -> GlyphData {
-        GlyphData {
-            id,
-            advance,
-            offset: offset.unwrap_or(Point2D::zero()),
-            cluster_start,
-            ligature_start,
-        }
-    }
+    /// The physical offset that this glyph should be painted with.
+    offset: Option<Point2D<Au>>,
+    /// The number of character this glyph corresponds to in the original string.
+    /// This might be zero and this might be more than one.
+    character_count: usize,
+    /// Whether or not the originating character for this glyph was a word separator
+    is_word_separator: bool,
 }
 
 // This enum is a proxy that's provided to GlyphStore clients when iterating
@@ -350,56 +145,51 @@ impl GlyphData {
 // values as they are needed from the GlyphStore, using provided offsets.
 #[derive(Clone, Copy)]
 pub enum GlyphInfo<'a> {
-    Simple(&'a GlyphStore, ByteIndex),
-    Detail(&'a GlyphStore, ByteIndex, u16),
+    Simple(&'a GlyphEntry),
+    Detail(&'a DetailedGlyphEntry),
 }
 
 impl GlyphInfo<'_> {
     pub fn id(self) -> GlyphId {
         match self {
-            GlyphInfo::Simple(store, entry_i) => store.entry_buffer[entry_i.get()].id(),
-            GlyphInfo::Detail(store, entry_i, detail_j) => {
-                store
-                    .detail_store
-                    .detailed_glyph_with_index(entry_i, detail_j)
-                    .id
-            },
+            GlyphInfo::Simple(entry) => entry.id(),
+            GlyphInfo::Detail(entry) => entry.id,
         }
     }
 
     #[inline(always)]
     pub fn advance(self) -> Au {
         match self {
-            GlyphInfo::Simple(store, entry_i) => store.entry_buffer[entry_i.get()].advance(),
-            GlyphInfo::Detail(store, entry_i, detail_j) => {
-                store
-                    .detail_store
-                    .detailed_glyph_with_index(entry_i, detail_j)
-                    .advance
-            },
+            GlyphInfo::Simple(entry) => entry.advance(),
+            GlyphInfo::Detail(entry) => entry.advance,
         }
     }
 
     #[inline]
     pub fn offset(self) -> Option<Point2D<Au>> {
         match self {
-            GlyphInfo::Simple(_, _) => None,
-            GlyphInfo::Detail(store, entry_i, detail_j) => Some(
-                store
-                    .detail_store
-                    .detailed_glyph_with_index(entry_i, detail_j)
-                    .offset,
-            ),
+            GlyphInfo::Simple(..) => None,
+            GlyphInfo::Detail(entry) => entry.offset,
         }
     }
 
+    #[inline]
     pub fn char_is_word_separator(self) -> bool {
-        let (store, entry_i) = match self {
-            GlyphInfo::Simple(store, entry_i) => (store, entry_i),
-            GlyphInfo::Detail(store, entry_i, _) => (store, entry_i),
-        };
+        match self {
+            GlyphInfo::Simple(entry) => entry.char_is_word_separator(),
+            GlyphInfo::Detail(entry) => entry.is_word_separator,
+        }
+    }
 
-        store.char_is_word_separator(entry_i)
+    /// The number of characters that this glyph corresponds to. This may be more
+    /// than one when a single glyph is produced for multiple characters. This may
+    /// be zero when multiple glyphs are produced for a single character.
+    #[inline]
+    pub fn character_count(self) -> usize {
+        match self {
+            GlyphInfo::Simple(..) => 1,
+            GlyphInfo::Detail(entry) => entry.character_count,
+        }
     }
 }
 
@@ -425,24 +215,24 @@ impl GlyphInfo<'_> {
 pub struct GlyphStore {
     // TODO(pcwalton): Allocation of this buffer is expensive. Consider a small-vector
     // optimization.
-    /// A buffer of glyphs within the text run, in the order in which they
-    /// appear in the input text.
-    /// Any changes will also need to be reflected in
-    /// transmute_entry_buffer_to_u32_buffer().
-    entry_buffer: Vec<GlyphEntry>,
-    /// A store of the detailed glyph data. Detailed glyphs contained in the
-    /// `entry_buffer` point to locations in this data structure.
-    detail_store: DetailedGlyphStore,
+    /// A collection of [`GlyphEntry`]s within the [`GlyphStore`]. Each [`GlyphEntry`]
+    /// maybe simple or detailed. When detailed, there will be a corresponding entry
+    /// in [`Self::detailed_glyphs`].
+    glyphs: Vec<GlyphEntry>,
+
+    /// A vector of glyphs that cannot fit within a single [`GlyphEntry`] or that
+    /// correspond to 0 or more than 1 character in the original string.
+    detailed_glyphs: Vec<DetailedGlyphEntry>,
 
     /// A cache of the advance of the entire glyph store.
     total_advance: Au,
 
+    /// The number of characters that correspond to the glyphs in this [`GlyphStore`]
+    total_characters: usize,
+
     /// A cache of the number of word separators in the entire glyph store.
     /// See <https://drafts.csswg.org/css-text/#word-separator>.
     total_word_separators: usize,
-
-    /// Used to check if fast path should be used in glyph iteration.
-    has_detailed_glyphs: bool,
 
     /// Whether or not this glyph store contains only glyphs for whitespace.
     is_whitespace: bool,
@@ -456,33 +246,73 @@ pub struct GlyphStore {
     /// preserved newline.
     is_single_preserved_newline: bool,
 
+    /// Whether or not this [`GlyphStore`] has right-to-left text, which has implications
+    /// about the order of the glyphs in the store.
     is_rtl: bool,
 }
 
 impl GlyphStore {
-    /// Initializes the glyph store, but doesn't actually shape anything.
+    /// Initializes the glyph store with the given capacity, but doesn't actually add any glyphs.
     ///
     /// Use the `add_*` methods to store glyph data.
-    pub(crate) fn new(
-        length: usize,
-        is_whitespace: bool,
-        ends_with_whitespace: bool,
-        is_single_preserved_newline: bool,
-        is_rtl: bool,
-    ) -> GlyphStore {
-        assert!(length > 0);
-
-        GlyphStore {
-            entry_buffer: vec![GlyphEntry::initial(); length],
-            detail_store: DetailedGlyphStore::new(),
+    pub(crate) fn new(text: &str, length: usize, options: &ShapingOptions) -> Self {
+        Self {
+            glyphs: Vec::with_capacity(length),
+            detailed_glyphs: Default::default(),
             total_advance: Au::zero(),
+            total_characters: 0,
             total_word_separators: 0,
-            has_detailed_glyphs: false,
-            is_whitespace,
-            ends_with_whitespace,
-            is_single_preserved_newline,
-            is_rtl,
+            is_whitespace: options
+                .flags
+                .contains(ShapingFlags::IS_WHITESPACE_SHAPING_FLAG),
+            ends_with_whitespace: options
+                .flags
+                .contains(ShapingFlags::ENDS_WITH_WHITESPACE_SHAPING_FLAG),
+            is_single_preserved_newline: text.len() == 1 && text.starts_with('\n'),
+            is_rtl: options.flags.contains(ShapingFlags::RTL_FLAG),
         }
+    }
+
+    pub(crate) fn with_shaped_glyph_data(
+        text: &str,
+        options: &ShapingOptions,
+        shaped_glyph_data: &impl GlyphShapingResult,
+    ) -> Self {
+        let mut characters = if !options.flags.contains(ShapingFlags::RTL_FLAG) {
+            Either::Left(text.char_indices())
+        } else {
+            Either::Right(text.char_indices().rev())
+        };
+
+        let mut previous_character_offset = None;
+        let mut glyph_store = GlyphStore::new(text, shaped_glyph_data.len(), options);
+        for shaped_glyph in shaped_glyph_data.iter() {
+            // The glyph "cluster" (HarfBuzz terminology) is the byte offset in the string that
+            // this glyph corresponds to. More than one glyph can share a cluster.
+            let glyph_cluster = shaped_glyph.string_byte_offset;
+
+            if let Some(previous_character_offset) = previous_character_offset {
+                if previous_character_offset == glyph_cluster {
+                    glyph_store.add_glyph_for_current_character(&shaped_glyph)
+                }
+            }
+
+            for (next_character_offset, next_character) in &mut characters {
+                if next_character_offset == glyph_cluster {
+                    previous_character_offset = Some(next_character_offset);
+                    glyph_store.add_glyph(next_character, &shaped_glyph);
+                    break;
+                }
+                glyph_store.extend_previous_glyph_by_character()
+            }
+        }
+
+        // Consume any remaining characters that belong to the more-recently added glyph.
+        for (_, _) in characters {
+            glyph_store.extend_previous_glyph_by_character();
+        }
+
+        glyph_store
     }
 
     #[inline]
@@ -490,210 +320,183 @@ impl GlyphStore {
         self.total_advance
     }
 
+    /// Return the number of glyphs stored in this [`GlyphStore`].
     #[inline]
-    pub fn len(&self) -> ByteIndex {
-        ByteIndex(self.entry_buffer.len())
+    pub fn len(&self) -> usize {
+        self.glyphs.len()
     }
 
+    /// Whether or not this [`GlyphStore`] has any glyphs.
     #[inline]
-    pub fn glyph_count(&self) -> usize {
-        self.entry_buffer.iter().map(GlyphEntry::glyph_count).sum()
+    pub fn is_empty(&self) -> bool {
+        self.glyphs.is_empty()
     }
 
+    /// The number of characters (`char`) from the original string that produced this
+    /// [`GlyphStore`].
+    #[inline]
+    pub fn character_count(&self) -> usize {
+        self.total_characters
+    }
+
+    /// Whether or not this [`GlyphStore`] is entirely whitepsace.
     #[inline]
     pub fn is_whitespace(&self) -> bool {
         self.is_whitespace
     }
 
+    /// Whether or not this [`GlyphStore`] is a single preserved newline.
+    #[inline]
+    pub fn is_single_preserved_newline(&self) -> bool {
+        self.is_single_preserved_newline
+    }
+
+    /// Whether or not this [`GlyphStore`] ends with whitespace.
     #[inline]
     pub fn ends_with_whitespace(&self) -> bool {
         self.ends_with_whitespace
     }
 
+    /// The number of word separators in this [`GlyphStore`].
     #[inline]
     pub fn total_word_separators(&self) -> usize {
         self.total_word_separators
     }
 
-    pub(crate) fn finalize_changes(&mut self) {
-        self.detail_store.ensure_sorted();
-        self.cache_total_advance_and_word_separators()
+    /// The number of characters that were consumed to produce this [`GlyphStore`]. Some
+    /// characters correpond to more than one glyph and some glyphs correspond to more than
+    /// one character.
+    #[inline]
+    pub fn total_characters(&self) -> usize {
+        self.total_characters
     }
 
-    #[inline(never)]
-    fn cache_total_advance_and_word_separators(&mut self) {
-        let mut total_advance = Au::zero();
-        let mut total_word_separators = 0;
-        for glyph in
-            self.iter_glyphs_for_byte_range(TextByteRange::new(ByteIndex::zero(), self.len()))
-        {
-            total_advance += glyph.advance();
-            if glyph.char_is_word_separator() {
-                total_word_separators += 1;
-            }
+    /// Adds glyph that corresponds to a single character (as far we know) in the originating string.
+    #[inline]
+    pub(crate) fn add_glyph(&mut self, character: char, shaped_glyph_entry: &ShapedGlyph) {
+        if !shaped_glyph_entry.can_be_simple_glyph() {
+            self.add_detailed_glyph(shaped_glyph_entry, Some(character), 1);
+            return;
         }
-        self.total_advance = total_advance;
-        self.total_word_separators = total_word_separators;
-    }
 
-    /// Adds a single glyph.
-    pub(crate) fn add_glyph_for_byte_index(
-        &mut self,
-        i: ByteIndex,
-        character: char,
-        data: &GlyphData,
-    ) {
-        let glyph_is_compressible = is_simple_glyph_id(data.id) &&
-            is_simple_advance(data.advance) &&
-            data.offset == Point2D::zero() &&
-            data.cluster_start; // others are stored in detail buffer
-
-        debug_assert!(data.ligature_start); // can't compress ligature continuation glyphs.
-        debug_assert!(i < self.len());
-
-        let mut entry = if glyph_is_compressible {
-            GlyphEntry::simple(data.id, data.advance)
-        } else {
-            let glyph = &[DetailedGlyph::new(data.id, data.advance, data.offset)];
-            self.has_detailed_glyphs = true;
-            self.detail_store.add_detailed_glyphs_for_entry(i, glyph);
-            GlyphEntry::complex(data.cluster_start, data.ligature_start, 1)
-        };
+        let mut simple_glyph_entry =
+            GlyphEntry::simple(shaped_glyph_entry.glyph_id, shaped_glyph_entry.advance);
 
         // This list is taken from the non-exhaustive list of word separator characters in
         // the CSS Text Module Level 3 Spec:
         // See https://drafts.csswg.org/css-text/#word-separator
-        if matches!(
-            character,
-            ' ' |
-            '\u{00A0}' | // non-breaking space
-            '\u{1361}' | // Ethiopic word space
-            '\u{10100}' | // Aegean word separator
-            '\u{10101}' | // Aegean word separator
-            '\u{1039F}' | // Ugartic word divider
-            '\u{1091F}' // Phoenician word separator
-        ) {
-            entry.set_char_is_word_separator();
+        if character_is_word_separator(character) {
+            self.total_word_separators += 1;
+            simple_glyph_entry.set_char_is_word_separator();
         }
 
-        self.entry_buffer[i.get()] = entry;
+        self.total_characters += 1;
+        self.total_advance += shaped_glyph_entry.advance;
+        self.glyphs.push(simple_glyph_entry)
     }
 
-    pub(crate) fn add_glyphs_for_byte_index(
+    fn add_detailed_glyph(
         &mut self,
-        i: ByteIndex,
-        data_for_glyphs: &[GlyphData],
+        shaped_glyph_entry: &ShapedGlyph,
+        character: Option<char>,
+        character_count: usize,
     ) {
-        assert!(i < self.len());
-        assert!(!data_for_glyphs.is_empty());
+        self.total_advance += shaped_glyph_entry.advance;
 
-        let glyph_count = data_for_glyphs.len();
+        let is_word_separator = character.is_some_and(character_is_word_separator);
+        if is_word_separator {
+            self.total_word_separators += 1;
+        }
 
-        let first_glyph_data = data_for_glyphs[0];
-        let glyphs_vec: Vec<DetailedGlyph> = (0..glyph_count)
-            .map(|i| {
-                DetailedGlyph::new(
-                    data_for_glyphs[i].id,
-                    data_for_glyphs[i].advance,
-                    data_for_glyphs[i].offset,
-                )
-            })
-            .collect();
-
-        self.has_detailed_glyphs = true;
-        self.detail_store
-            .add_detailed_glyphs_for_entry(i, &glyphs_vec);
-
-        let entry = GlyphEntry::complex(
-            first_glyph_data.cluster_start,
-            first_glyph_data.ligature_start,
-            glyph_count,
-        );
-
-        debug!(
-            "Adding multiple glyphs[idx={:?}, count={}]: {:?}",
-            i, glyph_count, entry
-        );
-
-        self.entry_buffer[i.get()] = entry;
+        self.total_characters += character_count;
+        self.detailed_glyphs.push(DetailedGlyphEntry {
+            id: shaped_glyph_entry.glyph_id,
+            advance: shaped_glyph_entry.advance,
+            offset: shaped_glyph_entry.offset,
+            character_count,
+            is_word_separator,
+        });
     }
 
-    #[inline]
-    pub fn iter_glyphs_for_byte_range(
-        &self,
-        range: TextByteRange,
-    ) -> impl Iterator<Item = GlyphInfo<'_>> + use<'_> {
-        if range.start >= self.len() {
-            panic!("iter_glyphs_for_range: range.begin beyond length!");
-        }
-        if range.end > self.len() {
-            panic!("iter_glyphs_for_range: range.end beyond length!");
+    fn extend_previous_glyph_by_character(&mut self) {
+        let detailed_glyph_index = self.ensure_last_glyph_is_detailed();
+        let detailed_glyph = self
+            .detailed_glyphs
+            .get_mut(detailed_glyph_index)
+            .expect("GlyphEntry should have valid index to detailed glyph");
+        detailed_glyph.character_count += 1;
+        self.total_characters += 1;
+    }
+
+    fn add_glyph_for_current_character(&mut self, shaped_glyph_entry: &ShapedGlyph) {
+        // Add a detailed glyph entry for this new glyph, but it corresponds to a character
+        // we have already started processing. It should not contribute any character count.
+        self.add_detailed_glyph(shaped_glyph_entry, None, 0);
+    }
+
+    /// If the last glyph added to this [`GlyphStore`] was a simple glyph, convert it to a
+    /// detailed one. In either case, return the index into [`Self::detailed_glyphs`] for
+    /// the most recently added glyph.
+    fn ensure_last_glyph_is_detailed(&mut self) -> usize {
+        let last_glyph = self
+            .glyphs
+            .last_mut()
+            .expect("Should never call this before any glyphs have been added.");
+        if !last_glyph.is_simple() {
+            return last_glyph.detailed_glyph_index();
         }
 
-        let range_it = if self.is_rtl {
-            Either::Left(range.rev())
-        } else {
-            Either::Right(range)
-        };
+        self.detailed_glyphs.push(DetailedGlyphEntry {
+            id: last_glyph.id(),
+            advance: last_glyph.advance(),
+            offset: Default::default(),
+            character_count: 1,
+            is_word_separator: last_glyph.char_is_word_separator(),
+        });
 
-        range_it.into_iter().flat_map(move |range_idx| {
-            let entry = self.entry_buffer[range_idx.get()];
-            let result = if entry.is_simple() {
-                Either::Left(once(GlyphInfo::Simple(self, range_idx)))
+        let detailed_glyph_index = self.detailed_glyphs.len() - 1;
+        *last_glyph = GlyphEntry::complex(detailed_glyph_index);
+        detailed_glyph_index
+    }
+
+    pub fn glyphs(&self) -> impl Iterator<Item = GlyphInfo<'_>> + use<'_> {
+        self.glyphs.iter().map(|entry| {
+            if entry.is_simple() {
+                GlyphInfo::Simple(entry)
             } else {
-                // Slow path for complex glyphs
-                let glyphs = self
-                    .detail_store
-                    .detailed_glyphs_for_entry(range_idx, entry.glyph_count());
-
-                let complex_glyph_range =
-                    TextByteRange::new(ByteIndex::zero(), ByteIndex(glyphs.len()));
-                Either::Right(complex_glyph_range.map(move |i| {
-                    GlyphInfo::Detail(self, range_idx, i.get() as u16 /* ??? */)
-                }))
-            };
-
-            result.into_iter()
+                GlyphInfo::Detail(&self.detailed_glyphs[entry.detailed_glyph_index()])
+            }
         })
     }
+}
 
-    #[inline]
-    pub fn advance_for_byte_range(&self, range: TextByteRange, extra_word_spacing: Au) -> Au {
-        if range.start == ByteIndex(0) && range.end == self.len() {
-            self.total_advance + extra_word_spacing * (self.total_word_separators as i32)
-        } else {
-            self.advance_for_byte_range_simple_glyphs(range, extra_word_spacing)
-        }
+impl ShapedGlyph {
+    fn can_be_simple_glyph(&self) -> bool {
+        is_simple_glyph_id(self.glyph_id) &&
+            is_simple_advance(self.advance) &&
+            self.offset
+                .is_none_or(|offset| offset == Default::default())
     }
+}
 
-    #[inline]
-    pub(crate) fn advance_for_byte_range_simple_glyphs(
-        &self,
-        range: TextByteRange,
-        extra_word_spacing: Au,
-    ) -> Au {
-        self.iter_glyphs_for_byte_range(range)
-            .map(|glyph| {
-                if glyph.char_is_word_separator() {
-                    glyph.advance() + extra_word_spacing
-                } else {
-                    glyph.advance()
-                }
-            })
-            .sum()
-    }
-
-    pub(crate) fn char_is_word_separator(&self, i: ByteIndex) -> bool {
-        assert!(i < self.len());
-        self.entry_buffer[i.get()].char_is_word_separator()
-    }
+fn character_is_word_separator(character: char) -> bool {
+    let is_word_separator = matches!(
+        character,
+        ' ' |
+                '\u{00A0}' | // non-breaking space
+                '\u{1361}' | // Ethiopic word space
+                '\u{10100}' | // Aegean word separator
+                '\u{10101}' | // Aegean word separator
+                '\u{1039F}' | // Ugartic word divider
+                '\u{1091F}' // Phoenician word separator
+    );
+    is_word_separator
 }
 
 impl fmt::Debug for GlyphStore {
     fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
         writeln!(formatter, "GlyphStore:")?;
-        let mut detailed_buffer = self.detail_store.detail_buffer.iter();
-        for entry in self.entry_buffer.iter() {
+        for entry in self.glyphs.iter() {
             if entry.is_simple() {
                 writeln!(
                     formatter,
@@ -702,38 +505,15 @@ impl fmt::Debug for GlyphStore {
                     entry.advance()
                 )?;
                 continue;
+            } else {
+                let detailed_glyph = &self.detailed_glyphs[entry.detailed_glyph_index()];
+                writeln!(
+                    formatter,
+                    "  detailed id={:?} advance={:?} characters={:?}",
+                    detailed_glyph.id, detailed_glyph.advance, detailed_glyph.character_count,
+                )?;
             }
-            if entry.is_initial() {
-                continue;
-            }
-            write!(formatter, "  complex...")?;
-            if detailed_buffer.next().is_none() {
-                continue;
-            }
-            writeln!(
-                formatter,
-                "  detailed id={:?} advance={:?}",
-                entry.id(),
-                entry.advance()
-            )?;
         }
         Ok(())
-    }
-}
-
-/// A single series of glyphs within a text run.
-#[derive(Clone, Debug, Deserialize, MallocSizeOf, Serialize)]
-pub struct GlyphRun {
-    /// The glyphs.
-    #[conditional_malloc_size_of]
-    pub glyph_store: Arc<GlyphStore>,
-    /// The byte range of characters in the containing run.
-    pub range: TextByteRange,
-}
-
-impl GlyphRun {
-    #[inline]
-    pub fn is_single_preserved_newline(&self) -> bool {
-        self.glyph_store.is_single_preserved_newline
     }
 }

--- a/components/fonts/lib.rs
+++ b/components/fonts/lib.rs
@@ -27,7 +27,7 @@ pub use font_context::{
 pub use font_store::FontTemplates;
 pub use fonts_traits::*;
 pub(crate) use glyph::*;
-pub use glyph::{GlyphInfo, GlyphRun, GlyphStore};
+pub use glyph::{GlyphInfo, GlyphStore};
 pub use platform::font_list::fallback_font_families;
 pub(crate) use shapers::*;
 pub use system_font_service::SystemFontService;

--- a/components/fonts/shapers/harfbuzz.rs
+++ b/components/fonts/shapers/harfbuzz.rs
@@ -28,7 +28,7 @@ use harfbuzz_sys::{
 use num_traits::Zero;
 use read_fonts::types::Tag;
 
-use super::{HarfBuzzShapedGlyphData, ShapedGlyphEntry, unicode_script_to_iso15924_tag};
+use super::{GlyphShapingResult, ShapedGlyph, unicode_script_to_iso15924_tag};
 use crate::platform::font::FontTable;
 use crate::{
     BASE, Font, FontBaseline, FontTableMethods, GlyphId, GlyphStore, KERN, LIGA, ShapingFlags,
@@ -38,14 +38,14 @@ use crate::{
 const HB_OT_TAG_DEFAULT_SCRIPT: hb_tag_t = u32::from_be_bytes(Tag::new(b"DFLT").to_be_bytes());
 const HB_OT_TAG_DEFAULT_LANGUAGE: hb_tag_t = u32::from_be_bytes(Tag::new(b"dflt").to_be_bytes());
 
-pub(crate) struct ShapedGlyphData {
+pub(crate) struct HarfbuzzGlyphShapingResult {
     count: usize,
     buffer: *mut hb_buffer_t,
     glyph_infos: *mut hb_glyph_info_t,
     pos_infos: *mut hb_glyph_position_t,
 }
 
-impl ShapedGlyphData {
+impl HarfbuzzGlyphShapingResult {
     /// Create a new [`ShapedGlyphData`] from the given HarfBuzz buffer.
     ///
     /// # Safety
@@ -53,7 +53,7 @@ impl ShapedGlyphData {
     /// - Passing an invalid buffer pointer to this function results in undefined behavior.
     /// - This function takes ownership of the buffer and the ShapedGlyphData destroys the buffer when dropped
     ///   so the pointer must an owned pointer and must not be used after being passed to this function
-    unsafe fn new(buffer: *mut hb_buffer_t) -> ShapedGlyphData {
+    unsafe fn new(buffer: *mut hb_buffer_t) -> HarfbuzzGlyphShapingResult {
         let mut glyph_count = 0;
         let glyph_infos = unsafe { hb_buffer_get_glyph_infos(buffer, &mut glyph_count) };
         assert!(!glyph_infos.is_null());
@@ -62,7 +62,7 @@ impl ShapedGlyphData {
         assert!(!pos_infos.is_null());
         assert_eq!(glyph_count, pos_count);
 
-        ShapedGlyphData {
+        HarfbuzzGlyphShapingResult {
             count: glyph_count as usize,
             buffer,
             glyph_infos,
@@ -71,35 +71,35 @@ impl ShapedGlyphData {
     }
 }
 
-impl Drop for ShapedGlyphData {
+impl Drop for HarfbuzzGlyphShapingResult {
     fn drop(&mut self) {
         unsafe { hb_buffer_destroy(self.buffer) }
     }
 }
 
-impl HarfBuzzShapedGlyphData for ShapedGlyphData {
-    #[inline]
-    fn len(&self) -> usize {
-        self.count
-    }
+struct ShapedGlyphIterator<'a> {
+    shaped_glyph_data: &'a HarfbuzzGlyphShapingResult,
+    current_glyph_offset: usize,
+    y_position: Au,
+}
 
-    #[inline(always)]
-    fn byte_offset_of_glyph(&self, i: usize) -> u32 {
-        assert!(i < self.count);
+impl<'a> Iterator for ShapedGlyphIterator<'a> {
+    type Item = ShapedGlyph;
 
-        unsafe {
-            let glyph_info_i = self.glyph_infos.add(i);
-            (*glyph_info_i).cluster
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.current_glyph_offset >= self.shaped_glyph_data.count {
+            return None;
         }
-    }
-
-    /// Returns shaped glyph data for one glyph, and updates the y-position of the pen.
-    fn entry_for_glyph(&self, i: usize, y_pos: &mut Au) -> ShapedGlyphEntry {
-        assert!(i < self.count);
 
         unsafe {
-            let glyph_info_i = self.glyph_infos.add(i);
-            let pos_info_i = self.pos_infos.add(i);
+            let glyph_info_i = self
+                .shaped_glyph_data
+                .glyph_infos
+                .add(self.current_glyph_offset);
+            let pos_info_i = self
+                .shaped_glyph_data
+                .pos_infos
+                .add(self.current_glyph_offset);
             let x_offset = Shaper::fixed_to_float((*pos_info_i).x_offset);
             let y_offset = Shaper::fixed_to_float((*pos_info_i).y_offset);
             let x_advance = Shaper::fixed_to_float((*pos_info_i).x_advance);
@@ -115,17 +115,34 @@ impl HarfBuzzShapedGlyphData for ShapedGlyphData {
             } else {
                 // adjust the pen..
                 if y_advance > Au::zero() {
-                    *y_pos -= y_advance;
+                    self.y_position -= y_advance;
                 }
 
-                Some(Point2D::new(x_offset, *y_pos - y_offset))
+                Some(Point2D::new(x_offset, self.y_position - y_offset))
             };
 
-            ShapedGlyphEntry {
-                codepoint: (*glyph_info_i).codepoint as GlyphId,
+            self.current_glyph_offset += 1;
+            Some(ShapedGlyph {
+                glyph_id: (*glyph_info_i).codepoint as GlyphId,
+                string_byte_offset: (*glyph_info_i).cluster as usize,
                 advance: x_advance,
                 offset,
-            }
+            })
+        }
+    }
+}
+
+impl GlyphShapingResult for HarfbuzzGlyphShapingResult {
+    #[inline]
+    fn len(&self) -> usize {
+        self.count
+    }
+
+    fn iter(&self) -> impl Iterator<Item = ShapedGlyph> {
+        ShapedGlyphIterator {
+            shaped_glyph_data: self,
+            current_glyph_offset: 0,
+            y_position: Au::zero(),
         }
     }
 }
@@ -209,7 +226,11 @@ impl Shaper {
     }
 
     /// Calculate the layout metrics associated with the given text with the [`Shaper`]s font.
-    fn shaped_glyph_data(&self, text: &str, options: &ShapingOptions) -> ShapedGlyphData {
+    fn shaped_glyph_data(
+        &self,
+        text: &str,
+        options: &ShapingOptions,
+    ) -> HarfbuzzGlyphShapingResult {
         unsafe {
             let hb_buffer: *mut hb_buffer_t = hb_buffer_create();
             hb_buffer_set_direction(
@@ -264,18 +285,12 @@ impl Shaper {
                 features.len() as u32,
             );
 
-            ShapedGlyphData::new(hb_buffer)
+            HarfbuzzGlyphShapingResult::new(hb_buffer)
         }
     }
 
-    fn font(&self) -> &Font {
-        unsafe { &(*self.font) }
-    }
-
-    pub(crate) fn shape_text(&self, text: &str, options: &ShapingOptions, glyphs: &mut GlyphStore) {
-        let glyph_data = self.shaped_glyph_data(text, options);
-        let font = self.font();
-        super::shape_text_harfbuzz(&glyph_data, font, text, options, glyphs);
+    pub(crate) fn shape_text(&self, text: &str, options: &ShapingOptions) -> GlyphStore {
+        GlyphStore::with_shaped_glyph_data(text, options, &self.shaped_glyph_data(text, options))
     }
 
     pub(crate) fn baseline(&self) -> Option<FontBaseline> {

--- a/components/fonts/shapers/mod.rs
+++ b/components/fonts/shapers/mod.rs
@@ -24,6 +24,7 @@ fn unicode_script_to_iso15924_tag(script: unicode_script::Script) -> u32 {
     u32::from_be_bytes(bytes)
 }
 
+#[derive(Debug)]
 pub(crate) struct ShapedGlyph {
     /// The actual glyph to render for this [`ShapedGlyph`].
     pub glyph_id: GlyphId,
@@ -42,6 +43,8 @@ pub(crate) struct ShapedGlyph {
 pub(crate) trait GlyphShapingResult {
     /// The number of shaped glyphs
     fn len(&self) -> usize;
+    /// Whether or not the result is right-to-left.
+    fn is_rtl(&self) -> bool;
     /// An iterator of the shaped glyphs of this data.
     fn iter(&self) -> impl Iterator<Item = ShapedGlyph>;
 }

--- a/components/fonts/shapers/mod.rs
+++ b/components/fonts/shapers/mod.rs
@@ -3,19 +3,12 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 mod harfbuzz;
-use std::cmp;
 
 use app_units::Au;
-use base::text::is_bidi_control;
 use euclid::default::Point2D;
-use fonts_traits::ByteIndex;
 pub(crate) use harfbuzz::Shaper;
-use log::debug;
-use num_traits::Zero as _;
 
-const NO_GLYPH: i32 = -1;
-
-use crate::{Font, GlyphData, GlyphId, GlyphStore, ShapingOptions, advance_for_shaped_glyph};
+use crate::GlyphId;
 
 /// Utility function to convert a `unicode_script::Script` enum into the corresponding `c_uint` tag that
 /// harfbuzz uses to represent unicode scipts.
@@ -31,189 +24,24 @@ fn unicode_script_to_iso15924_tag(script: unicode_script::Script) -> u32 {
     u32::from_be_bytes(bytes)
 }
 
-struct ShapedGlyphEntry {
-    codepoint: GlyphId,
-    advance: Au,
-    offset: Option<Point2D<Au>>,
+pub(crate) struct ShapedGlyph {
+    /// The actual glyph to render for this [`ShapedGlyph`].
+    pub glyph_id: GlyphId,
+    /// The original byte offset in the input buffer of the character that this
+    /// glyph belongs to. More than one glyph can share the same character and
+    /// one character can produce multiple glyphs.
+    pub string_byte_offset: usize,
+    /// The advance the direction of the writing mode that this glyph needs.
+    pub advance: Au,
+    /// An offset that should be applied when rendering this glyph.
+    pub offset: Option<Point2D<Au>>,
 }
 
 /// Holds the results of shaping. Abstracts over HarfBuzz and HarfRust which return data in very similar
 /// form but with different types
-trait HarfBuzzShapedGlyphData {
+pub(crate) trait GlyphShapingResult {
     /// The number of shaped glyphs
     fn len(&self) -> usize;
-    /// The byte offset of the shaped glyph in the souce text
-    fn byte_offset_of_glyph(&self, i: usize) -> u32;
-    /// Returns shaped glyph data for one glyph, and updates the y-position of the pen.
-    fn entry_for_glyph(&self, i: usize, y_pos: &mut Au) -> ShapedGlyphEntry;
-}
-
-/// Shape text using an `impl HarfBuzzShaper`
-fn shape_text_harfbuzz<ShapedGlyphData: HarfBuzzShapedGlyphData>(
-    glyph_data: &ShapedGlyphData,
-    font: &Font,
-    text: &str,
-    options: &ShapingOptions,
-    glyphs: &mut GlyphStore,
-) {
-    let glyph_count = glyph_data.len();
-    let byte_max = text.len();
-
-    debug!(
-        "Shaped text[byte count={}], got back {} glyph info records.",
-        byte_max, glyph_count
-    );
-
-    // make map of what chars have glyphs
-    let mut byte_to_glyph = vec![NO_GLYPH; byte_max];
-
-    debug!("(glyph idx) -> (text byte offset)");
-    for i in 0..glyph_data.len() {
-        let loc = glyph_data.byte_offset_of_glyph(i) as usize;
-        if loc < byte_max {
-            byte_to_glyph[loc] = i as i32;
-        } else {
-            debug!(
-                "ERROR: tried to set out of range byte_to_glyph: idx={}, glyph idx={}",
-                loc, i
-            );
-        }
-        debug!("{} -> {}", i, loc);
-    }
-
-    debug!("text: {:?}", text);
-    debug!("(char idx): char->(glyph index):");
-    for (i, ch) in text.char_indices() {
-        debug!("{}: {:?} --> {}", i, ch, byte_to_glyph[i]);
-    }
-
-    let mut glyph_span = 0..0;
-    let mut byte_range = 0..0;
-
-    let mut y_pos = Au::zero();
-
-    // main loop over each glyph. each iteration usually processes 1 glyph and 1+ chars.
-    // in cases with complex glyph-character associations, 2+ glyphs and 1+ chars can be
-    // processed.
-    while glyph_span.start < glyph_count {
-        debug!("Processing glyph at idx={}", glyph_span.start);
-        glyph_span.end = glyph_span.start;
-        byte_range.end = glyph_data.byte_offset_of_glyph(glyph_span.start) as usize;
-
-        while byte_range.end < byte_max {
-            byte_range.end += 1;
-            // Extend the byte range to include any following byte without its own glyph.
-            while byte_range.end < byte_max && byte_to_glyph[byte_range.end] == NO_GLYPH {
-                byte_range.end += 1;
-            }
-
-            // Extend the glyph range to include all glyphs covered by bytes processed so far.
-            let mut max_glyph_idx = glyph_span.end;
-            for glyph_idx in &byte_to_glyph[byte_range.clone()] {
-                if *glyph_idx != NO_GLYPH {
-                    max_glyph_idx = cmp::max(*glyph_idx as usize + 1, max_glyph_idx);
-                }
-            }
-            if max_glyph_idx > glyph_span.end {
-                glyph_span.end = max_glyph_idx;
-                debug!("Extended glyph span to {:?}", glyph_span);
-            }
-
-            // if there's just one glyph, then we don't need further checks.
-            if glyph_span.len() == 1 {
-                break;
-            }
-
-            // if no glyphs were found yet, extend the char byte range more.
-            if glyph_span.is_empty() {
-                continue;
-            }
-
-            // If byte_range now includes all the byte offsets found in glyph_span, then we
-            // have found a contiguous "cluster" and can stop extending it.
-            let mut all_glyphs_are_within_cluster: bool = true;
-            for j in glyph_span.clone() {
-                let loc = glyph_data.byte_offset_of_glyph(j) as usize;
-                if !(byte_range.start <= loc && loc < byte_range.end) {
-                    all_glyphs_are_within_cluster = false;
-                    break;
-                }
-            }
-            if all_glyphs_are_within_cluster {
-                break;
-            }
-
-            // Otherwise, the bytes we have seen so far correspond to a non-contiguous set of
-            // glyphs.  Keep extending byte_range until we fill in all the holes in the glyph
-            // span or reach the end of the text.
-        }
-
-        assert!(!byte_range.is_empty());
-        assert!(!glyph_span.is_empty());
-
-        // Now byte_range is the ligature clump formed by the glyphs in glyph_span.
-        // We will save these glyphs to the glyph store at the index of the first byte.
-        let byte_idx = ByteIndex(byte_range.start);
-
-        if glyph_span.len() == 1 {
-            // Fast path: 1-to-1 mapping of byte offset to single glyph.
-            //
-            // TODO(Issue #214): cluster ranges need to be computed before
-            // shaping, and then consulted here.
-            // for now, just pretend that every character is a cluster start.
-            // (i.e., pretend there are no combining character sequences).
-            // 1-to-1 mapping of character to glyph also treated as ligature start.
-            //
-            // NB: When we acquire the ability to handle ligatures that cross word boundaries,
-            // we'll need to do something special to handle `word-spacing` properly.
-            let character = text[byte_range.clone()].chars().next().unwrap();
-            if is_bidi_control(character) {
-                // Don't add any glyphs for bidi control chars
-            } else {
-                let (glyph_id, advance, offset) = if character == '\t' {
-                    // Treat tabs in pre-formatted text as a fixed number of spaces. The glyph id does
-                    // not matter here as Servo doesn't render any glyphs for whitespace.
-                    //
-                    // TODO: Proper tab stops. This should happen in layout and be based on the
-                    // size of the space character of the inline formatting context.
-                    (
-                        font.glyph_index(' ').unwrap_or(0),
-                        font.metrics.space_advance * 8,
-                        Default::default(),
-                    )
-                } else {
-                    let shape = glyph_data.entry_for_glyph(glyph_span.start, &mut y_pos);
-                    let advance = advance_for_shaped_glyph(shape.advance, character, options);
-                    (shape.codepoint, advance, shape.offset)
-                };
-
-                let data = GlyphData::new(glyph_id, advance, offset, true, true);
-                glyphs.add_glyph_for_byte_index(byte_idx, character, &data);
-            }
-        } else {
-            // collect all glyphs to be assigned to the first character.
-            let mut datas = vec![];
-
-            for glyph_i in glyph_span.clone() {
-                let shape = glyph_data.entry_for_glyph(glyph_i, &mut y_pos);
-                datas.push(GlyphData::new(
-                    shape.codepoint,
-                    shape.advance,
-                    shape.offset,
-                    true, // treat as cluster start
-                    glyph_i > glyph_span.start,
-                ));
-                // all but first are ligature continuations
-            }
-            // now add the detailed glyph entry.
-            glyphs.add_glyphs_for_byte_index(byte_idx, &datas);
-        }
-
-        glyph_span.start = glyph_span.end;
-        byte_range.start = byte_range.end;
-    }
-
-    // this must be called after adding all glyph data; it sorts the
-    // lookup table for finding detailed glyphs by associated char index.
-    glyphs.finalize_changes();
+    /// An iterator of the shaped glyphs of this data.
+    fn iter(&self) -> impl Iterator<Item = ShapedGlyph>;
 }

--- a/components/layout/display_list/mod.rs
+++ b/components/layout/display_list/mod.rs
@@ -8,7 +8,7 @@ use std::sync::Arc;
 use app_units::{AU_PER_PX, Au};
 use base::id::ScrollTreeNodeId;
 use clip::{Clip, ClipId};
-use euclid::{Point2D, Scale, SideOffsets2D, Size2D, Rect, UnknownUnit, Vector2D};
+use euclid::{Point2D, Rect, Scale, SideOffsets2D, Size2D, UnknownUnit, Vector2D};
 use fonts::GlyphStore;
 use gradient::WebRenderGradient;
 use net_traits::image_cache::Image as CachedImage;

--- a/components/layout/flow/inline/mod.rs
+++ b/components/layout/flow/inline/mod.rs
@@ -74,7 +74,7 @@ pub mod line;
 mod line_breaker;
 pub mod text_run;
 
-use std::cell::{Cell, OnceCell, RefCell};
+use std::cell::{OnceCell, RefCell};
 use std::mem;
 use std::rc::Rc;
 use std::sync::Arc;
@@ -809,9 +809,6 @@ struct InlineContainerState {
 
     /// The font metrics of the non-fallback font for this container.
     font_metrics: Arc<FontMetrics>,
-
-    /// The current count of glyphs added to the inline container.
-    number_of_glyphs: Cell<usize>,
 }
 
 struct InlineFormattingContextLayout<'layout_data> {
@@ -2054,7 +2051,7 @@ impl InlineFormattingContext {
                 let parent_style = text_run.inline_styles.style.borrow();
                 text_run.shaped_text.iter().all(|segment| {
                     segment.runs.iter().all(|run| {
-                        run.glyph_store.is_whitespace() &&
+                        run.is_whitespace() &&
                             !run.is_single_preserved_newline() &&
                             !matches!(
                                 parent_style.get_inherited_text().white_space_collapse,
@@ -2153,7 +2150,6 @@ impl InlineContainerState {
             strut_block_sizes,
             baseline_offset,
             font_metrics,
-            number_of_glyphs: Default::default(),
         }
     }
 
@@ -2665,8 +2661,8 @@ impl<'layout_data> ContentSizesComputation<'layout_data> {
                             self.line_break_opportunity();
                         }
 
-                        let advance = run.glyph_store.total_advance();
-                        if run.glyph_store.is_whitespace() {
+                        let advance = run.total_advance();
+                        if run.is_whitespace() {
                             // If this run is a forced line break, we *must* break the line
                             // and start measuring from the inline origin once more.
                             if run.is_single_preserved_newline() {
@@ -2704,7 +2700,7 @@ impl<'layout_data> ContentSizesComputation<'layout_data> {
                         // but for `white-space: break-spaces` we place the first whitespace
                         // with the preceding text. That prevents a line break before that
                         // first space, but we still need to allow a line break after it.
-                        if can_wrap && run.glyph_store.ends_with_whitespace() {
+                        if can_wrap && run.ends_with_whitespace() {
                             self.line_break_opportunity();
                         }
                     }

--- a/components/layout/layout_impl.rs
+++ b/components/layout/layout_impl.rs
@@ -90,7 +90,7 @@ use crate::display_list::{
     DisplayListBuilder, HitTest, LargestContentfulPaintCandidateCollector, StackingContextTree,
 };
 use crate::query::{
-    find_glyph_offset_in_fragment_descendants, get_the_text_steps, process_box_area_request,
+    find_character_offset_in_fragment_descendants, get_the_text_steps, process_box_area_request,
     process_box_areas_request, process_client_rect_request, process_current_css_zoom_query,
     process_node_scroll_area_request, process_offset_parent_query, process_padding_request,
     process_resolved_font_style_query, process_resolved_style_request,
@@ -490,7 +490,7 @@ impl Layout for LayoutThread {
         let node = unsafe { ServoLayoutNode::new(&node).to_threadsafe() };
         let stacking_context_tree = self.stacking_context_tree.borrow_mut();
         let stacking_context_tree = stacking_context_tree.as_ref()?;
-        find_glyph_offset_in_fragment_descendants(&node, stacking_context_tree, point_in_node)
+        find_character_offset_in_fragment_descendants(&node, stacking_context_tree, point_in_node)
     }
 
     #[servo_tracing::instrument(skip_all)]

--- a/components/layout/query.rs
+++ b/components/layout/query.rs
@@ -1304,7 +1304,7 @@ fn rendered_text_collection_steps(
     items
 }
 
-pub fn find_glyph_offset_in_fragment_descendants(
+pub fn find_character_offset_in_fragment_descendants(
     node: &ServoThreadSafeLayoutNode,
     stacking_context_tree: &StackingContextTree,
     point_in_viewport: Point2D<Au, CSSPixel>,
@@ -1360,7 +1360,7 @@ pub fn find_glyph_offset_in_fragment_descendants(
     }
 
     closest_relative_fragment.map(|(_, point_in_parent, text_fragment)| {
-        text_fragment.borrow().glyph_offset(point_in_parent)
+        text_fragment.borrow().character_offset(point_in_parent)
     })
 }
 

--- a/components/script/dom/canvas/2d/canvas_state.rs
+++ b/components/script/dom/canvas/2d/canvas_state.rs
@@ -21,8 +21,8 @@ use cssparser::{Parser, ParserInput};
 use euclid::default::{Point2D, Rect, Size2D, Transform2D};
 use euclid::{Vector2D, vec2};
 use fonts::{
-    ByteIndex, FontBaseline, FontContext, FontGroup, FontIdentifier, FontMetrics, FontRef,
-    LAST_RESORT_GLYPH_ADVANCE, ShapingFlags, ShapingOptions, TextByteRange,
+    FontBaseline, FontContext, FontGroup, FontIdentifier, FontMetrics, FontRef,
+    LAST_RESORT_GLYPH_ADVANCE, ShapingFlags, ShapingOptions,
 };
 use ipc_channel::ipc;
 use net_traits::image_cache::{ImageCache, ImageResponse};
@@ -2465,7 +2465,7 @@ impl UnshapedTextRun<'_> {
         let mut advance = 0.0;
         let mut bounds = None;
         let glyphs_and_positions = glyphs
-            .iter_glyphs_for_byte_range(TextByteRange::new(ByteIndex(0), glyphs.len()))
+            .glyphs()
             .map(|glyph| {
                 let glyph_offset = glyph.offset().unwrap_or(Point2D::zero());
                 let glyph_and_position = GlyphAndPosition {

--- a/components/script/dom/html/htmltextareaelement.rs
+++ b/components/script/dom/html/htmltextareaelement.rs
@@ -294,14 +294,21 @@ impl TextControlElement for HTMLTextAreaElement {
     fn maybe_update_shared_selection(&self) {
         let offsets = self.textinput.borrow().sorted_selection_offsets_range();
         let (start, end) = (offsets.start.0, offsets.end.0);
-        let shared_selection = ScriptSelection {
-            range: TextByteRange::new(ByteIndex(start), ByteIndex(end)),
-            enabled: self.upcast::<Element>().focus_state(),
-        };
-        if shared_selection == *self.shared_selection.borrow() {
+        let range = TextByteRange::new(ByteIndex(start), ByteIndex(end));
+        let enabled = self.upcast::<Element>().focus_state();
+
+        let mut shared_selection = self.shared_selection.borrow_mut();
+        if range == shared_selection.range && enabled == shared_selection.enabled {
             return;
         }
-        *self.shared_selection.borrow_mut() = shared_selection;
+        *shared_selection = ScriptSelection {
+            range,
+            character_range: self
+                .textinput
+                .borrow()
+                .sorted_selection_character_offsets_range(),
+            enabled,
+        };
         self.owner_window().layout().set_needs_new_display_list();
     }
 }

--- a/components/script/textinput.rs
+++ b/components/script/textinput.rs
@@ -383,6 +383,14 @@ impl<T: ClipboardProvider> TextInput<T> {
         self.selection_start_offset()..self.selection_end_offset()
     }
 
+    /// Return the selection range as character offsets from the start of the content.
+    ///
+    /// If there is no selection, returns an empty range at the edit point.
+    pub(crate) fn sorted_selection_character_offsets_range(&self) -> Range<usize> {
+        self.rope.index_to_character_offset(self.selection_start())..
+            self.rope.index_to_character_offset(self.selection_end())
+    }
+
     /// The state of the current selection. Can be used to compare whether selection state has changed.
     pub(crate) fn selection_state(&self) -> SelectionState {
         SelectionState {
@@ -832,7 +840,7 @@ impl<T: ClipboardProvider> TextInput<T> {
             .map(|grapheme_index| {
                 self.rope.move_by(
                     Default::default(),
-                    RopeMovement::Grapheme,
+                    RopeMovement::Character,
                     grapheme_index as isize,
                 )
             })

--- a/components/shared/base/rope.rs
+++ b/components/shared/base/rope.rs
@@ -425,6 +425,11 @@ impl Rope {
         let line = self.line_for_index(index);
         line[index.code_point..].chars().next()
     }
+
+    fn character_before(&self, index: RopeIndex) -> Option<char> {
+        let line = self.line_for_index(index);
+        line[..index.code_point].chars().next_back()
+    }
 }
 
 /// An index into a [`Rope`] data structure. Used to efficiently identify a particular
@@ -608,7 +613,7 @@ impl Iterator for RopeChars<'_> {
     fn next(&mut self) -> Option<Self::Item> {
         self.movement_iterator
             .next()
-            .and_then(|index| self.movement_iterator.slice.rope.character_at(index))
+            .and_then(|index| self.movement_iterator.slice.rope.character_before(index))
     }
 }
 

--- a/components/shared/layout/lib.rs
+++ b/components/shared/layout/lib.rs
@@ -374,6 +374,7 @@ pub trait Layout {
         animation_timeline_value: f64,
     ) -> Option<ServoArc<Font>>;
     fn query_scrolling_area(&self, node: Option<TrustedNodeAddress>) -> Rect<i32, CSSPixel>;
+    /// Find the character offset of the point in the given node, if it has text content.
     fn query_text_index(
         &self,
         node: TrustedNodeAddress,

--- a/components/shared/layout/wrapper_traits.rs
+++ b/components/shared/layout/wrapper_traits.rs
@@ -6,6 +6,7 @@
 
 use std::borrow::Cow;
 use std::fmt::Debug;
+use std::ops::Range;
 
 use atomic_refcell::{AtomicRef, AtomicRefCell};
 use base::id::{BrowsingContextId, PipelineId};
@@ -440,6 +441,8 @@ impl PseudoElementChain {
 pub struct ScriptSelection {
     /// The range of this selection in the DOM node that manages it.
     pub range: TextByteRange,
+    /// The character range of this selection in the DOM node that manages it.
+    pub character_range: Range<usize>,
     /// Whether or not this selection is enabled. Selections may be disabled
     /// when their node loses focus.
     pub enabled: bool,

--- a/tests/wpt/meta/css/WOFF2/header-totalsfntsize-001.xht.ini
+++ b/tests/wpt/meta/css/WOFF2/header-totalsfntsize-001.xht.ini
@@ -1,2 +1,0 @@
-[header-totalsfntsize-001.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/WOFF2/tabledata-glyf-bbox-001.xht.ini
+++ b/tests/wpt/meta/css/WOFF2/tabledata-glyf-bbox-001.xht.ini
@@ -1,2 +1,0 @@
-[tabledata-glyf-bbox-001.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/WOFF2/tabledata-glyf-origlength-003.xht.ini
+++ b/tests/wpt/meta/css/WOFF2/tabledata-glyf-origlength-003.xht.ini
@@ -1,2 +1,0 @@
-[tabledata-glyf-origlength-003.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-fonts/font-feature-settings-tibetan.html.ini
+++ b/tests/wpt/meta/css/css-fonts/font-feature-settings-tibetan.html.ini
@@ -1,0 +1,2 @@
+[font-feature-settings-tibetan.html]
+  expected: FAIL

--- a/tests/wpt/meta/css/css-fonts/math-script-level-and-math-style/math-script-level-auto-and-math-style-002.tentative.html.ini
+++ b/tests/wpt/meta/css/css-fonts/math-script-level-and-math-style/math-script-level-auto-and-math-style-002.tentative.html.ini
@@ -1,2 +1,0 @@
-[math-script-level-auto-and-math-style-002.tentative.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-text/letter-spacing/letter-spacing-bengali-yaphala-001.html.ini
+++ b/tests/wpt/meta/css/css-text/letter-spacing/letter-spacing-bengali-yaphala-001.html.ini
@@ -1,0 +1,2 @@
+[letter-spacing-bengali-yaphala-001.html]
+  expected: FAIL

--- a/tests/wpt/meta/css/css-text/letter-spacing/letter-spacing-cursive-001.html.ini
+++ b/tests/wpt/meta/css/css-text/letter-spacing/letter-spacing-cursive-001.html.ini
@@ -1,0 +1,2 @@
+[letter-spacing-cursive-001.html]
+  expected: FAIL

--- a/tests/wpt/meta/css/css-text/shaping/shaping-arabic-diacritics-001.html.ini
+++ b/tests/wpt/meta/css/css-text/shaping/shaping-arabic-diacritics-001.html.ini
@@ -1,0 +1,2 @@
+[shaping-arabic-diacritics-001.html]
+  expected: FAIL

--- a/tests/wpt/meta/css/css-text/text-transform/text-transform-upperlower-006.html.ini
+++ b/tests/wpt/meta/css/css-text/text-transform/text-transform-upperlower-006.html.ini
@@ -1,0 +1,2 @@
+[text-transform-upperlower-006.html]
+  expected: FAIL


### PR DESCRIPTION
This change is a reworking of the shaping code and simplification of the
`GlyphRun` data structure.

The shaper was written between 2012 and 2014 against an early version of
Rust. It was originally written to have a single glyph entry per UTF-8
code point. This is useful when you always need to iterate through
glyphs based on UTF-8 code points. Unfortunately, this required a
tri-level data structure to hold detailed glyphs and meant that CJK
characters took over 3x the memory usage of ASCII characters. In
addition, iterating through glyphs (the most common and basic operation
on shaped text) required doing a lookup involving a binary search for
detailed glyphs (ones that had large advances or mapped to more or less
than a single UTF-8 code point).

The new design of the `GlyphStore` is instead based on `chars` in the
input string. These are tracked during layout so that the resulting
glyph output can be interpreted relatively to its original character
offset in the containing IFC. We are already dealing with IFC text on a
per-character basis for a variety of reasons (such as text
transformation and whitespace collapse). In addition, we will now able to
implement mapping between the character offsets before and after layout
transformations of the original DOM string.

Now the penalty of more complex glyph iteration is only paid when
transforming glyph offsets to character offsets. Currently this is only
done for selections and clicking in text boxes, both of which are much
less common than layout.

This change does not properly handle selections in RTL text, though
rendering and basic selection and visual movement works (though buggy).

It does not seem like this affects the performance of shaping based on
measurement using the text shaping performance counters. This likely
means that the performance of shaping is dominated on our machines by
HarfBuzz. We noticed no performance degradation in Speedometer when run
on a M3 Mac.

Followup work:
 - Properly handle selection in RTL text.
 - Support mapping from original DOM character offsets to offsets in
   layout after text transformation and whitespace collapse. This is now
   possible.

Testing: This causes some tests to pass and a few to fail. This is likely
due to the fact that we are handling glyphs more consistently while
shaping. Of the new failures:
 - `letter-spacing-bengali-yaphala-001.html`, `letter-spacing-cursive-001.html`, `font-feature-settings-tibetan.html` where passing before probably because we were not applying letter spacing to detailed glyphs. These scripts should not have letter spacing applied to them, because they are cursive -- which we never implemented properly. It will be handled in a a followup.
 - `shaping-arabic-diacritics-001.html`: This was a false pass. The tests verifies that Arabic diacritics are applied to NBSP. This wasn't happening before nor after this change, but the results matched anyway. Now they don't, but before and after are equally broken.
 - 
Fixes: #216
Part of #35540.

