### PR TITLE
Use ServoPickerIcon instead of shadow root contents for selects picker icon

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7157,7 +7157,7 @@ dependencies = [
 [[package]]
 name = "selectors"
 version = "0.36.0"
-source = "git+https://github.com/servo/stylo?rev=f00c109074832b7fa7be52bbbf8f4987d24e323b#f00c109074832b7fa7be52bbbf8f4987d24e323b"
+source = "git+https://github.com/servo/stylo?rev=refs%2Fpull%2F291%2Fhead#172a1be378af6c70acfe0b9c0e3aef8467a69ed7"
 dependencies = [
  "bitflags 2.11.0",
  "cssparser",
@@ -8799,7 +8799,7 @@ dependencies = [
 [[package]]
 name = "servo_arc"
 version = "0.4.3"
-source = "git+https://github.com/servo/stylo?rev=f00c109074832b7fa7be52bbbf8f4987d24e323b#f00c109074832b7fa7be52bbbf8f4987d24e323b"
+source = "git+https://github.com/servo/stylo?rev=refs%2Fpull%2F291%2Fhead#172a1be378af6c70acfe0b9c0e3aef8467a69ed7"
 dependencies = [
  "serde",
  "stable_deref_trait",
@@ -9219,7 +9219,7 @@ dependencies = [
 [[package]]
 name = "stylo"
 version = "0.13.0"
-source = "git+https://github.com/servo/stylo?rev=f00c109074832b7fa7be52bbbf8f4987d24e323b#f00c109074832b7fa7be52bbbf8f4987d24e323b"
+source = "git+https://github.com/servo/stylo?rev=refs%2Fpull%2F291%2Fhead#172a1be378af6c70acfe0b9c0e3aef8467a69ed7"
 dependencies = [
  "app_units",
  "arrayvec",
@@ -9275,7 +9275,7 @@ dependencies = [
 [[package]]
 name = "stylo_atoms"
 version = "0.13.0"
-source = "git+https://github.com/servo/stylo?rev=f00c109074832b7fa7be52bbbf8f4987d24e323b#f00c109074832b7fa7be52bbbf8f4987d24e323b"
+source = "git+https://github.com/servo/stylo?rev=refs%2Fpull%2F291%2Fhead#172a1be378af6c70acfe0b9c0e3aef8467a69ed7"
 dependencies = [
  "string_cache",
  "string_cache_codegen",
@@ -9284,7 +9284,7 @@ dependencies = [
 [[package]]
 name = "stylo_derive"
 version = "0.13.0"
-source = "git+https://github.com/servo/stylo?rev=f00c109074832b7fa7be52bbbf8f4987d24e323b#f00c109074832b7fa7be52bbbf8f4987d24e323b"
+source = "git+https://github.com/servo/stylo?rev=refs%2Fpull%2F291%2Fhead#172a1be378af6c70acfe0b9c0e3aef8467a69ed7"
 dependencies = [
  "darling",
  "proc-macro2",
@@ -9296,7 +9296,7 @@ dependencies = [
 [[package]]
 name = "stylo_dom"
 version = "0.13.0"
-source = "git+https://github.com/servo/stylo?rev=f00c109074832b7fa7be52bbbf8f4987d24e323b#f00c109074832b7fa7be52bbbf8f4987d24e323b"
+source = "git+https://github.com/servo/stylo?rev=refs%2Fpull%2F291%2Fhead#172a1be378af6c70acfe0b9c0e3aef8467a69ed7"
 dependencies = [
  "bitflags 2.11.0",
  "stylo_malloc_size_of",
@@ -9305,7 +9305,7 @@ dependencies = [
 [[package]]
 name = "stylo_malloc_size_of"
 version = "0.13.0"
-source = "git+https://github.com/servo/stylo?rev=f00c109074832b7fa7be52bbbf8f4987d24e323b#f00c109074832b7fa7be52bbbf8f4987d24e323b"
+source = "git+https://github.com/servo/stylo?rev=refs%2Fpull%2F291%2Fhead#172a1be378af6c70acfe0b9c0e3aef8467a69ed7"
 dependencies = [
  "app_units",
  "cssparser",
@@ -9322,12 +9322,12 @@ dependencies = [
 [[package]]
 name = "stylo_static_prefs"
 version = "0.13.0"
-source = "git+https://github.com/servo/stylo?rev=f00c109074832b7fa7be52bbbf8f4987d24e323b#f00c109074832b7fa7be52bbbf8f4987d24e323b"
+source = "git+https://github.com/servo/stylo?rev=refs%2Fpull%2F291%2Fhead#172a1be378af6c70acfe0b9c0e3aef8467a69ed7"
 
 [[package]]
 name = "stylo_traits"
 version = "0.13.0"
-source = "git+https://github.com/servo/stylo?rev=f00c109074832b7fa7be52bbbf8f4987d24e323b#f00c109074832b7fa7be52bbbf8f4987d24e323b"
+source = "git+https://github.com/servo/stylo?rev=refs%2Fpull%2F291%2Fhead#172a1be378af6c70acfe0b9c0e3aef8467a69ed7"
 dependencies = [
  "app_units",
  "bitflags 2.11.0",
@@ -9749,7 +9749,7 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 [[package]]
 name = "to_shmem"
 version = "0.3.0"
-source = "git+https://github.com/servo/stylo?rev=f00c109074832b7fa7be52bbbf8f4987d24e323b#f00c109074832b7fa7be52bbbf8f4987d24e323b"
+source = "git+https://github.com/servo/stylo?rev=refs%2Fpull%2F291%2Fhead#172a1be378af6c70acfe0b9c0e3aef8467a69ed7"
 dependencies = [
  "cssparser",
  "servo_arc",
@@ -9762,7 +9762,7 @@ dependencies = [
 [[package]]
 name = "to_shmem_derive"
 version = "0.1.0"
-source = "git+https://github.com/servo/stylo?rev=f00c109074832b7fa7be52bbbf8f4987d24e323b#f00c109074832b7fa7be52bbbf8f4987d24e323b"
+source = "git+https://github.com/servo/stylo?rev=refs%2Fpull%2F291%2Fhead#172a1be378af6c70acfe0b9c0e3aef8467a69ed7"
 dependencies = [
  "darling",
  "proc-macro2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -172,7 +172,7 @@ script_traits = { package = "servo-script-traits", path = "components/shared/scr
 sea-query = { version = "1.0.0-rc.31", default-features = false, features = ["backend-sqlite", "derive"] }
 sea-query-rusqlite = { version = "0.8.0-rc.15" }
 sec1 = "0.7"
-selectors = { git = "https://github.com/servo/stylo", rev = "f00c109074832b7fa7be52bbbf8f4987d24e323b" }
+selectors = { git = "https://github.com/servo/stylo", rev = "refs/pull/291/head" }
 serde = "1.0.228"
 serde_bytes = "0.11"
 serde_core = "1.0.226"
@@ -181,7 +181,7 @@ servo-media = { path = "components/media/servo-media" }
 servo-media-dummy = { path = "components/media/backends/dummy" }
 servo-media-gstreamer = { path = "components/media/backends/gstreamer" }
 servo-tracing = { path = "components/servo_tracing" }
-servo_arc = { git = "https://github.com/servo/stylo", rev = "f00c109074832b7fa7be52bbbf8f4987d24e323b" }
+servo_arc = { git = "https://github.com/servo/stylo", rev = "refs/pull/291/head" }
 sha1 = "0.10"
 sha2 = "0.10"
 sha3 = "0.10"
@@ -190,12 +190,12 @@ smallvec = { version = "1.15", features = ["serde", "union"] }
 storage_traits = { package = "servo-storage-traits", path = "components/shared/storage" }
 string_cache = "0.9"
 strum = { version = "0.28", features = ["derive"] }
-stylo = { git = "https://github.com/servo/stylo", rev = "f00c109074832b7fa7be52bbbf8f4987d24e323b" }
-stylo_atoms = { git = "https://github.com/servo/stylo", rev = "f00c109074832b7fa7be52bbbf8f4987d24e323b" }
-stylo_dom = { git = "https://github.com/servo/stylo", rev = "f00c109074832b7fa7be52bbbf8f4987d24e323b" }
-stylo_malloc_size_of = { git = "https://github.com/servo/stylo", rev = "f00c109074832b7fa7be52bbbf8f4987d24e323b" }
-stylo_static_prefs = { git = "https://github.com/servo/stylo", rev = "f00c109074832b7fa7be52bbbf8f4987d24e323b" }
-stylo_traits = { git = "https://github.com/servo/stylo", rev = "f00c109074832b7fa7be52bbbf8f4987d24e323b" }
+stylo = { git = "https://github.com/servo/stylo", rev = "refs/pull/291/head" }
+stylo_atoms = { git = "https://github.com/servo/stylo", rev = "refs/pull/291/head" }
+stylo_dom = { git = "https://github.com/servo/stylo", rev = "refs/pull/291/head" }
+stylo_malloc_size_of = { git = "https://github.com/servo/stylo", rev = "refs/pull/291/head" }
+stylo_static_prefs = { git = "https://github.com/servo/stylo", rev = "refs/pull/291/head" }
+stylo_traits = { git = "https://github.com/servo/stylo", rev = "refs/pull/291/head" }
 surfman = { version = "0.11.0", features = ["chains"] }
 syn = { version = "2", default-features = false, features = ["clone-impls", "derive", "parsing"] }
 synstructure = "0.13"

--- a/components/layout/dom_traversal.rs
+++ b/components/layout/dom_traversal.rs
@@ -132,6 +132,8 @@ fn traverse_children_of<'dom>(
 
     if is_element {
         traverse_eager_pseudo_element(PseudoElement::After, parent_element_info, context, handler);
+
+        traverse_picker_icon_pseudo_element(parent_element_info, context, handler);
     }
 }
 
@@ -196,6 +198,48 @@ fn traverse_eager_pseudo_element<'dom>(
             let box_slot = pseudo_element_info.node.box_slot();
             let shared_inline_styles =
                 SharedInlineStyles::from_info_and_context(&pseudo_element_info, context);
+            box_slot.set(LayoutBox::DisplayContents(shared_inline_styles.clone()));
+
+            handler.enter_display_contents(shared_inline_styles);
+            traverse_pseudo_element_contents(&pseudo_element_info, context, handler, items);
+            handler.leave_display_contents();
+        },
+        Display::GeneratingBox(display) => {
+            let items = generate_pseudo_element_content(&pseudo_element_info, context);
+            let box_slot = pseudo_element_info.node.box_slot();
+            let contents = Contents::for_pseudo_element(items);
+            handler.handle_element(&pseudo_element_info, display, contents, box_slot);
+        },
+    }
+}
+
+fn traverse_picker_icon_pseudo_element<'dom>(
+    info: &NodeAndStyleInfo<'dom>,
+    context: &LayoutContext,
+    handler: &mut impl TraversalHandler<'dom>,
+) {
+    let Some(element) = info.node.as_element() else {
+        return;
+    };
+
+    if !matches!(element.type_id(), Some(LayoutNodeType::Element(LayoutElementType::HTMLSelectElement))) {
+        return;
+    }
+
+    let Some(pseudo_element_info) = info.with_pseudo_element(context, PseudoElement::ServoPickerIcon) else {
+        return;
+    };
+
+    if pseudo_element_info.style.ineffective_content_property() {
+        return;
+    }
+
+    match Display::from(pseudo_element_info.style.get_box().display) {
+        Display::None => {},
+        Display::Contents => {
+            let items = generate_pseudo_element_content(&pseudo_element_info, context);
+            let box_slot = pseudo_element_info.node.box_slot();
+            let shared_inline_styles: SharedInlineStyles = (&pseudo_element_info).into();
             box_slot.set(LayoutBox::DisplayContents(shared_inline_styles.clone()));
 
             handler.enter_display_contents(shared_inline_styles);

--- a/components/layout/dom_traversal.rs
+++ b/components/layout/dom_traversal.rs
@@ -222,11 +222,18 @@ fn traverse_picker_icon_pseudo_element<'dom>(
         return;
     };
 
-    if !matches!(element.type_id(), Some(LayoutNodeType::Element(LayoutElementType::HTMLSelectElement))) {
+    if !matches!(
+        element.type_id(),
+        Some(LayoutNodeType::Element(
+            LayoutElementType::HTMLSelectElement
+        ))
+    ) {
         return;
     }
 
-    let Some(pseudo_element_info) = info.with_pseudo_element(context, PseudoElement::ServoPickerIcon) else {
+    let Some(pseudo_element_info) =
+        info.with_pseudo_element(context, PseudoElement::ServoPickerIcon)
+    else {
         return;
     };
 
@@ -239,7 +246,8 @@ fn traverse_picker_icon_pseudo_element<'dom>(
         Display::Contents => {
             let items = generate_pseudo_element_content(&pseudo_element_info, context);
             let box_slot = pseudo_element_info.node.box_slot();
-            let shared_inline_styles: SharedInlineStyles = (&pseudo_element_info).into();
+            let shared_inline_styles =
+                SharedInlineStyles::from_info_and_context(&pseudo_element_info, context);
             box_slot.set(LayoutBox::DisplayContents(shared_inline_styles.clone()));
 
             handler.enter_display_contents(shared_inline_styles);

--- a/components/layout/stylesheets/servo.css
+++ b/components/layout/stylesheets/servo.css
@@ -140,10 +140,18 @@ input[type="file"]:disabled::before {
 }
 
 select::-servo-picker-icon {
-  content: "▾";
+  content: " ";
+  background-image: url('<svg xmlns="http://www.w3.org/2000/svg" width="180" height="180" viewBox="0 0 180 180"> <path d="M0 12h180L90 167z" style="fill:currentcolor"/> </svg>');
+  background-size: 100%;
+  background-repeat: no-repeat;
+  background-position: center;
+  width: 0.75em;
+  height: 0.75em;
   vertical-align: middle;
   line-height: 1;
   margin-inline-start: 5px;
+
+  display: inline-block;
 }
 
 input[type="file"]::before {

--- a/components/layout/stylesheets/servo.css
+++ b/components/layout/stylesheets/servo.css
@@ -139,6 +139,15 @@ input[type="file"]:disabled::before {
   color: grey;
 }
 
+select::-servo-picker-icon {
+  content: "▾";
+  vertical-align: middle;
+  line-height: 1;
+  margin: 4px;
+
+  font-size: 16px;
+}
+
 input[type="file"]::before {
   content: "Choose File";
   display: inline-block;

--- a/components/layout/stylesheets/servo.css
+++ b/components/layout/stylesheets/servo.css
@@ -143,9 +143,7 @@ select::-servo-picker-icon {
   content: "▾";
   vertical-align: middle;
   line-height: 1;
-  margin: 4px;
-
-  font-size: 16px;
+  margin-inline-start: 5px;
 }
 
 input[type="file"]::before {

--- a/components/script/dom/html/htmlselectelement.rs
+++ b/components/script/dom/html/htmlselectelement.rs
@@ -61,7 +61,6 @@ const SELECT_BOX_STYLE: &str = "
     display: inline-flex;
     align-items: center;
     vertical-align: middle;
-    height: 100%;
 ";
 
 const TEXT_CONTAINER_STYLE: &str = "flex: 1;";

--- a/components/script/dom/html/htmlselectelement.rs
+++ b/components/script/dom/html/htmlselectelement.rs
@@ -58,17 +58,13 @@ use crate::script_runtime::CanGc;
 const DEFAULT_SELECT_SIZE: u32 = 0;
 
 const SELECT_BOX_STYLE: &str = "
-    display: flex;
+    display: inline-flex;
     align-items: center;
+    vertical-align: middle;
     height: 100%;
 ";
 
 const TEXT_CONTAINER_STYLE: &str = "flex: 1;";
-
-const CHEVRON_CONTAINER_STYLE: &str = "
-    font-size: 16px;
-    margin: 4px;
-";
 
 #[derive(JSTraceable, MallocSizeOf)]
 struct OptionsFilter;
@@ -312,28 +308,6 @@ impl HTMLSelectElement {
         text_container
             .upcast::<Node>()
             .AppendChild(text.upcast::<Node>(), can_gc)
-            .unwrap();
-
-        let chevron_container = Element::create(
-            QualName::new(None, ns!(html), local_name!("div")),
-            None,
-            &document,
-            ElementCreator::ScriptCreated,
-            CustomElementCreationMode::Asynchronous,
-            None,
-            can_gc,
-        );
-        chevron_container.set_string_attribute(
-            &local_name!("style"),
-            CHEVRON_CONTAINER_STYLE.into(),
-            can_gc,
-        );
-        chevron_container
-            .upcast::<Node>()
-            .set_text_content_for_element(Some("▾".into()), can_gc);
-        select_box
-            .upcast::<Node>()
-            .AppendChild(chevron_container.upcast::<Node>(), can_gc)
             .unwrap();
 
         root.upcast::<Node>()

--- a/components/script/dom/window.rs
+++ b/components/script/dom/window.rs
@@ -1858,6 +1858,7 @@ impl WindowMethods<crate::DomTypeHolder> for Window {
             Some(ref pseudo) if pseudo == "::selection" => Some(PseudoElement::Selection),
             Some(ref pseudo) if pseudo == "::marker" => Some(PseudoElement::Marker),
             Some(ref pseudo) if pseudo == "::placeholder" => Some(PseudoElement::Placeholder),
+            Some(ref pseudo) if pseudo == "::-servo-picker-icon" => Some(PseudoElement::ServoPickerIcon),
             Some(ref pseudo) if pseudo.starts_with(':') => {
                 // Step 3.2: If type is failure, or is a ::slotted() or ::part()
                 // pseudo-element, let obj be null.

--- a/components/script/dom/window.rs
+++ b/components/script/dom/window.rs
@@ -1858,7 +1858,9 @@ impl WindowMethods<crate::DomTypeHolder> for Window {
             Some(ref pseudo) if pseudo == "::selection" => Some(PseudoElement::Selection),
             Some(ref pseudo) if pseudo == "::marker" => Some(PseudoElement::Marker),
             Some(ref pseudo) if pseudo == "::placeholder" => Some(PseudoElement::Placeholder),
-            Some(ref pseudo) if pseudo == "::-servo-picker-icon" => Some(PseudoElement::ServoPickerIcon),
+            Some(ref pseudo) if pseudo == "::-servo-picker-icon" => {
+                Some(PseudoElement::ServoPickerIcon)
+            },
             Some(ref pseudo) if pseudo.starts_with(':') => {
                 // Step 3.2: If type is failure, or is a ::slotted() or ::part()
                 // pseudo-element, let obj be null.


### PR DESCRIPTION
This now uses a `::-servo-picker-icon` for select's chevron icon.

It slightly tweaks selects styling to achieve this but I think it's an improvement.

Testing: Tested with https://demo.lukewarlow.dev/css-forms.html (and the test case added in https://github.com/servo/servo/pull/42085

| Before | After |
| ------|------|
| <img width="522" height="267" alt="image" src="https://github.com/user-attachments/assets/7cc2d840-3384-4a6c-8945-0277cfb4096d" /> | <img width="505" height="247" alt="image" src="https://github.com/user-attachments/assets/15b7a610-9e03-47c9-b5fc-ae0ec6e38baa" /> |


Stylo PR: https://github.com/servo/stylo/pull/291