### PR TITLE
Update details to support `::details-content` pseudo element.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7985,7 +7985,7 @@ dependencies = [
 [[package]]
 name = "selectors"
 version = "0.35.0"
-source = "git+https://github.com/servo/stylo?rev=3a8f37620e387cc6d4cef933cab1d83d0b09a76a#3a8f37620e387cc6d4cef933cab1d83d0b09a76a"
+source = "git+https://github.com/servo/stylo?rev=29123c1295b527ff5230afc2bcff53138cd884b5#29123c1295b527ff5230afc2bcff53138cd884b5"
 dependencies = [
  "bitflags 2.10.0",
  "cssparser",
@@ -8292,7 +8292,7 @@ dependencies = [
 [[package]]
 name = "servo_arc"
 version = "0.4.3"
-source = "git+https://github.com/servo/stylo?rev=3a8f37620e387cc6d4cef933cab1d83d0b09a76a#3a8f37620e387cc6d4cef933cab1d83d0b09a76a"
+source = "git+https://github.com/servo/stylo?rev=29123c1295b527ff5230afc2bcff53138cd884b5#29123c1295b527ff5230afc2bcff53138cd884b5"
 dependencies = [
  "serde",
  "stable_deref_trait",
@@ -8841,7 +8841,7 @@ dependencies = [
 [[package]]
 name = "stylo"
 version = "0.11.0"
-source = "git+https://github.com/servo/stylo?rev=3a8f37620e387cc6d4cef933cab1d83d0b09a76a#3a8f37620e387cc6d4cef933cab1d83d0b09a76a"
+source = "git+https://github.com/servo/stylo?rev=29123c1295b527ff5230afc2bcff53138cd884b5#29123c1295b527ff5230afc2bcff53138cd884b5"
 dependencies = [
  "app_units",
  "arrayvec",
@@ -8896,7 +8896,7 @@ dependencies = [
 [[package]]
 name = "stylo_atoms"
 version = "0.11.0"
-source = "git+https://github.com/servo/stylo?rev=3a8f37620e387cc6d4cef933cab1d83d0b09a76a#3a8f37620e387cc6d4cef933cab1d83d0b09a76a"
+source = "git+https://github.com/servo/stylo?rev=29123c1295b527ff5230afc2bcff53138cd884b5#29123c1295b527ff5230afc2bcff53138cd884b5"
 dependencies = [
  "string_cache",
  "string_cache_codegen",
@@ -8905,12 +8905,12 @@ dependencies = [
 [[package]]
 name = "stylo_config"
 version = "0.11.0"
-source = "git+https://github.com/servo/stylo?rev=3a8f37620e387cc6d4cef933cab1d83d0b09a76a#3a8f37620e387cc6d4cef933cab1d83d0b09a76a"
+source = "git+https://github.com/servo/stylo?rev=29123c1295b527ff5230afc2bcff53138cd884b5#29123c1295b527ff5230afc2bcff53138cd884b5"
 
 [[package]]
 name = "stylo_derive"
 version = "0.11.0"
-source = "git+https://github.com/servo/stylo?rev=3a8f37620e387cc6d4cef933cab1d83d0b09a76a#3a8f37620e387cc6d4cef933cab1d83d0b09a76a"
+source = "git+https://github.com/servo/stylo?rev=29123c1295b527ff5230afc2bcff53138cd884b5#29123c1295b527ff5230afc2bcff53138cd884b5"
 dependencies = [
  "darling",
  "proc-macro2",
@@ -8922,7 +8922,7 @@ dependencies = [
 [[package]]
 name = "stylo_dom"
 version = "0.11.0"
-source = "git+https://github.com/servo/stylo?rev=3a8f37620e387cc6d4cef933cab1d83d0b09a76a#3a8f37620e387cc6d4cef933cab1d83d0b09a76a"
+source = "git+https://github.com/servo/stylo?rev=29123c1295b527ff5230afc2bcff53138cd884b5#29123c1295b527ff5230afc2bcff53138cd884b5"
 dependencies = [
  "bitflags 2.10.0",
  "stylo_malloc_size_of",
@@ -8931,7 +8931,7 @@ dependencies = [
 [[package]]
 name = "stylo_malloc_size_of"
 version = "0.11.0"
-source = "git+https://github.com/servo/stylo?rev=3a8f37620e387cc6d4cef933cab1d83d0b09a76a#3a8f37620e387cc6d4cef933cab1d83d0b09a76a"
+source = "git+https://github.com/servo/stylo?rev=29123c1295b527ff5230afc2bcff53138cd884b5#29123c1295b527ff5230afc2bcff53138cd884b5"
 dependencies = [
  "app_units",
  "cssparser",
@@ -8948,12 +8948,12 @@ dependencies = [
 [[package]]
 name = "stylo_static_prefs"
 version = "0.11.0"
-source = "git+https://github.com/servo/stylo?rev=3a8f37620e387cc6d4cef933cab1d83d0b09a76a#3a8f37620e387cc6d4cef933cab1d83d0b09a76a"
+source = "git+https://github.com/servo/stylo?rev=29123c1295b527ff5230afc2bcff53138cd884b5#29123c1295b527ff5230afc2bcff53138cd884b5"
 
 [[package]]
 name = "stylo_traits"
 version = "0.11.0"
-source = "git+https://github.com/servo/stylo?rev=3a8f37620e387cc6d4cef933cab1d83d0b09a76a#3a8f37620e387cc6d4cef933cab1d83d0b09a76a"
+source = "git+https://github.com/servo/stylo?rev=29123c1295b527ff5230afc2bcff53138cd884b5#29123c1295b527ff5230afc2bcff53138cd884b5"
 dependencies = [
  "app_units",
  "bitflags 2.10.0",
@@ -9365,7 +9365,7 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 [[package]]
 name = "to_shmem"
 version = "0.3.0"
-source = "git+https://github.com/servo/stylo?rev=3a8f37620e387cc6d4cef933cab1d83d0b09a76a#3a8f37620e387cc6d4cef933cab1d83d0b09a76a"
+source = "git+https://github.com/servo/stylo?rev=29123c1295b527ff5230afc2bcff53138cd884b5#29123c1295b527ff5230afc2bcff53138cd884b5"
 dependencies = [
  "cssparser",
  "servo_arc",
@@ -9378,7 +9378,7 @@ dependencies = [
 [[package]]
 name = "to_shmem_derive"
 version = "0.1.0"
-source = "git+https://github.com/servo/stylo?rev=3a8f37620e387cc6d4cef933cab1d83d0b09a76a#3a8f37620e387cc6d4cef933cab1d83d0b09a76a"
+source = "git+https://github.com/servo/stylo?rev=29123c1295b527ff5230afc2bcff53138cd884b5#29123c1295b527ff5230afc2bcff53138cd884b5"
 dependencies = [
  "darling",
  "proc-macro2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -157,7 +157,7 @@ script_traits = { path = "components/shared/script" }
 sea-query = { version = "1.0.0-rc.30", default-features = false, features = ["backend-sqlite", "derive"] }
 sea-query-rusqlite = { version = "0.8.0-rc.15" }
 sec1 = "0.7"
-selectors = { git = "https://github.com/servo/stylo", rev = "3a8f37620e387cc6d4cef933cab1d83d0b09a76a" }
+selectors = { git = "https://github.com/servo/stylo", rev = "29123c1295b527ff5230afc2bcff53138cd884b5" }
 serde = "1.0.228"
 serde_bytes = "0.11"
 serde_core = "1.0.226"
@@ -166,7 +166,7 @@ servo-media = { git = "https://github.com/servo/media", rev = "f384dbc4ff8b5c6f8
 servo-media-dummy = { git = "https://github.com/servo/media", rev = "f384dbc4ff8b5c6f8db2c763306cbe2281d66391" }
 servo-media-gstreamer = { git = "https://github.com/servo/media", rev = "f384dbc4ff8b5c6f8db2c763306cbe2281d66391" }
 servo-tracing = { path = "components/servo_tracing" }
-servo_arc = { git = "https://github.com/servo/stylo", rev = "3a8f37620e387cc6d4cef933cab1d83d0b09a76a" }
+servo_arc = { git = "https://github.com/servo/stylo", rev = "29123c1295b527ff5230afc2bcff53138cd884b5" }
 sha1 = "0.10"
 sha2 = "0.10"
 sha3 = "0.10"
@@ -175,12 +175,12 @@ smallvec = { version = "1.15", features = ["serde", "union"] }
 storage_traits = { path = "components/shared/storage" }
 string_cache = "0.9"
 strum = { version = "0.27", features = ["derive"] }
-stylo = { git = "https://github.com/servo/stylo", rev = "3a8f37620e387cc6d4cef933cab1d83d0b09a76a" }
-stylo_atoms = { git = "https://github.com/servo/stylo", rev = "3a8f37620e387cc6d4cef933cab1d83d0b09a76a" }
-stylo_config = { git = "https://github.com/servo/stylo", rev = "3a8f37620e387cc6d4cef933cab1d83d0b09a76a" }
-stylo_dom = { git = "https://github.com/servo/stylo", rev = "3a8f37620e387cc6d4cef933cab1d83d0b09a76a" }
-stylo_malloc_size_of = { git = "https://github.com/servo/stylo", rev = "3a8f37620e387cc6d4cef933cab1d83d0b09a76a" }
-stylo_traits = { git = "https://github.com/servo/stylo", rev = "3a8f37620e387cc6d4cef933cab1d83d0b09a76a" }
+stylo = { git = "https://github.com/servo/stylo", rev = "29123c1295b527ff5230afc2bcff53138cd884b5" }
+stylo_atoms = { git = "https://github.com/servo/stylo", rev = "29123c1295b527ff5230afc2bcff53138cd884b5" }
+stylo_config = { git = "https://github.com/servo/stylo", rev = "29123c1295b527ff5230afc2bcff53138cd884b5" }
+stylo_dom = { git = "https://github.com/servo/stylo", rev = "29123c1295b527ff5230afc2bcff53138cd884b5" }
+stylo_malloc_size_of = { git = "https://github.com/servo/stylo", rev = "29123c1295b527ff5230afc2bcff53138cd884b5" }
+stylo_traits = { git = "https://github.com/servo/stylo", rev = "29123c1295b527ff5230afc2bcff53138cd884b5" }
 surfman = { version = "0.11.0", features = ["chains"] }
 syn = { version = "2", default-features = false, features = ["clone-impls", "derive", "parsing"] }
 synstructure = "0.13"

--- a/components/layout/stylesheets/servo.css
+++ b/components/layout/stylesheets/servo.css
@@ -306,9 +306,13 @@ details[open]::-servo-details-summary {
   list-style: disclosure-open;
 }
 
-*|*::-servo-details-content {
-  margin-left: 40px;
-  overflow: hidden;
+details::details-content {
+  /* TODO: This should be "display: block; content-visibility: hidden;",
+  but servo does not support content-visibility yet */
+  display: none;
+}
+
+details[open]::details-content {
   display: block;
 }
 

--- a/components/script/layout_dom/element.rs
+++ b/components/script/layout_dom/element.rs
@@ -1117,7 +1117,7 @@ impl<'dom> ThreadSafeLayoutElement<'dom> for ServoThreadSafeLayoutElement<'dom> 
 ///
 /// Lazy pseudo-elements in Servo only allows selectors using safe properties,
 /// i.e., local_name, attributes, so they can only be used for **private**
-/// pseudo-elements (like `::-servo-details-content`).
+/// pseudo-elements (like `::details-content`).
 ///
 /// Probably a few more of this functions can be implemented (like `has_class`, etc.),
 /// but they have no use right now.

--- a/tests/wpt/meta/css/css-conditional/at-supports-selector-details-content.html.ini
+++ b/tests/wpt/meta/css/css-conditional/at-supports-selector-details-content.html.ini
@@ -1,2 +1,0 @@
-[at-supports-selector-details-content.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-conditional/js/CSS-supports-details-content-pseudo-parsing.html.ini
+++ b/tests/wpt/meta/css/css-conditional/js/CSS-supports-details-content-pseudo-parsing.html.ini
@@ -1,7 +1,4 @@
 [CSS-supports-details-content-pseudo-parsing.html]
-  [selector() function accepts ::details-content]
-    expected: FAIL
-
   [selector() function accepts ::details-content followed by ::before]
     expected: FAIL
 

--- a/tests/wpt/meta/css/css-shadow/part/pseudo-elements-after-part.html.ini
+++ b/tests/wpt/meta/css/css-shadow/part/pseudo-elements-after-part.html.ini
@@ -2,9 +2,6 @@
   ["::part(mypart)::cue" should be a valid selector]
     expected: FAIL
 
-  ["::part(mypart)::details-content" should be a valid selector]
-    expected: FAIL
-
   ["::part(mypart)::file-selector-button" should be a valid selector]
     expected: FAIL
 

--- a/tests/wpt/meta/html/rendering/the-details-element/details-blockification.html.ini
+++ b/tests/wpt/meta/html/rendering/the-details-element/details-blockification.html.ini
@@ -1,3 +1,0 @@
-[details-blockification.html]
-  [Summary and content should have display:block computed value]
-    expected: FAIL

--- a/tests/wpt/meta/html/rendering/the-details-element/details-display-type-001.html.ini
+++ b/tests/wpt/meta/html/rendering/the-details-element/details-display-type-001.html.ini
@@ -1,2 +1,0 @@
-[details-display-type-001.html]
-  expected: FAIL

--- a/tests/wpt/meta/html/rendering/the-details-element/details-pseudo-elements-001.html.ini
+++ b/tests/wpt/meta/html/rendering/the-details-element/details-pseudo-elements-001.html.ini
@@ -1,2 +1,0 @@
-[details-pseudo-elements-001.html]
-  expected: FAIL

--- a/tests/wpt/meta/html/rendering/the-details-element/details-pseudo-elements-002.html.ini
+++ b/tests/wpt/meta/html/rendering/the-details-element/details-pseudo-elements-002.html.ini
@@ -1,2 +1,0 @@
-[details-pseudo-elements-002.html]
-  expected: FAIL

--- a/tests/wpt/meta/html/rendering/the-details-element/details-pseudo-elements-003.html.ini
+++ b/tests/wpt/meta/html/rendering/the-details-element/details-pseudo-elements-003.html.ini
@@ -1,2 +1,0 @@
-[details-pseudo-elements-003.html]
-  expected: FAIL

--- a/tests/wpt/meta/html/rendering/the-details-element/details-summary-display-inline-001.html.ini
+++ b/tests/wpt/meta/html/rendering/the-details-element/details-summary-display-inline-001.html.ini
@@ -1,2 +1,0 @@
-[details-summary-display-inline-001.html]
-  expected: FAIL


### PR DESCRIPTION
Update details to support `::details-content` pseudo element.

This is currently not element-backed but will support the basic styling.

This replaces the existing `::-servo-details-content` styling.

Testing: WPTs and manually using https://demo.lukewarlow.dev/css-forms.html

<img width="159" height="66" alt="image" src="https://github.com/user-attachments/assets/8e72e7f3-2b49-43c6-9a4e-dbea0586739e" />

Stylo PR: https://github.com/servo/stylo/pull/292