### PR TITLE
net: Move listing of directories to async code

### DIFF
--- a/components/net/websocket_loader.rs
+++ b/components/net/websocket_loader.rs
@@ -46,7 +46,7 @@ use crate::http_loader::HttpState;
 /// and `Cookie` headers as appropriate.
 /// Returns an error if any header values are invalid or tungstenite cannot create
 /// the desired request.
-pub(crate) fn create_handshake_request(
+pub fn create_handshake_request(
     request: RequestBuilder,
     http_state: Arc<HttpState>,
 ) -> Result<net_traits::request::Request, Error> {

--- a/components/net/websocket_loader.rs
+++ b/components/net/websocket_loader.rs
@@ -46,7 +46,7 @@ use crate::http_loader::HttpState;
 /// and `Cookie` headers as appropriate.
 /// Returns an error if any header values are invalid or tungstenite cannot create
 /// the desired request.
-pub fn create_handshake_request(
+pub(crate) fn create_handshake_request(
     request: RequestBuilder,
     http_state: Arc<HttpState>,
 ) -> Result<net_traits::request::Request, Error> {


### PR DESCRIPTION
Listing directory and constructing the list is another prime candidate to switch from blocking code to async code.
This PR does this.

Of note is the change in type for ProtocolHandler::load which now has a lifetime bounded by Request and self and the Response has a similar lifetime bound.

Signed-off-by: Narfinger <Narfinger@users.noreply.github.com>

Testing: Looking at directories still works.
