### PR TITLE
net: Remove exterior mutability from FileManager

### DIFF
--- a/components/net/fetch/methods.rs
+++ b/components/net/fetch/methods.rs
@@ -97,7 +97,7 @@ pub struct FetchContext {
     pub state: Arc<HttpState>,
     pub user_agent: String,
     pub devtools_chan: Option<Sender<DevtoolsControlMsg>>,
-    pub filemanager: Arc<Mutex<FileManager>>,
+    pub filemanager: FileManager,
     pub file_token: FileTokenCheck,
     pub request_interceptor: Arc<TokioMutex<RequestInterceptor>>,
     pub cancellation_listener: Arc<CancellationListener>,

--- a/components/net/protocols/blob.rs
+++ b/components/net/protocols/blob.rs
@@ -60,7 +60,7 @@ impl ProtocolHandler for BlobProtocolHander {
         *done_chan = Some((done_sender.clone(), done_receiver));
         *response.body.lock() = ResponseBody::Receiving(vec![]);
 
-        if let Err(err) = context.filemanager.lock().fetch_file(
+        if let Err(err) = context.filemanager.fetch_file(
             &mut done_sender,
             context.cancellation_listener.clone(),
             id,

--- a/components/net/protocols/file.rs
+++ b/components/net/protocols/file.rs
@@ -84,7 +84,7 @@ impl ProtocolHandler for FileProtocolHander {
 
                 *response.body.lock() = ResponseBody::Receiving(vec![]);
 
-                context.filemanager.lock().fetch_file_in_chunks(
+                context.filemanager.fetch_file_in_chunks(
                     &mut done_sender,
                     reader,
                     response.body.clone(),

--- a/components/net/resource_thread.rs
+++ b/components/net/resource_thread.rs
@@ -732,7 +732,7 @@ impl CoreResourceManager {
                 state: http_state,
                 user_agent: servo_config::pref!(user_agent),
                 devtools_chan,
-                filemanager: Arc::new(Mutex::new(filemanager)),
+                filemanager,
                 file_token,
                 request_interceptor: Arc::new(TokioMutex::new(request_interceptor)),
                 cancellation_listener,
@@ -770,7 +770,6 @@ impl CoreResourceManager {
             if let Some(id) = blob_url_file_id.as_ref() {
                 context
                     .filemanager
-                    .lock()
                     .invalidate_token(&context.file_token, id);
             }
         });
@@ -817,7 +816,7 @@ impl CoreResourceManager {
                         state: http_state,
                         user_agent: servo_config::pref!(user_agent),
                         devtools_chan,
-                        filemanager: Arc::new(Mutex::new(filemanager)),
+                        filemanager,
                         file_token: FileTokenCheck::NotRequired,
                         request_interceptor: Arc::new(TokioMutex::new(request_interceptor)),
                         cancellation_listener,

--- a/components/net/tests/fetch.rs
+++ b/components/net/tests/fetch.rs
@@ -187,7 +187,6 @@ fn test_fetch_blob() {
     let id = Uuid::new_v4();
     context
         .filemanager
-        .lock()
         .promote_memory(id.clone(), blob_buf, true, origin.origin());
     let url = ServoUrl::parse(&format!("blob:{}{}", origin.as_str(), id.simple())).unwrap();
 
@@ -749,7 +748,7 @@ fn test_fetch_with_hsts() {
         state: Arc::new(create_http_state(None)),
         user_agent: DEFAULT_USER_AGENT.into(),
         devtools_chan: None,
-        filemanager: Arc::new(Mutex::new(FileManager::new(embedder_proxy.clone()))),
+        filemanager: FileManager::new(embedder_proxy.clone()),
         file_token: FileTokenCheck::NotRequired,
         request_interceptor: Arc::new(TokioMutex::new(RequestInterceptor::new(embedder_proxy))),
         cancellation_listener: Arc::new(Default::default()),
@@ -812,7 +811,7 @@ fn test_load_adds_host_to_hsts_list_when_url_is_https() {
         state: Arc::new(create_http_state(None)),
         user_agent: DEFAULT_USER_AGENT.into(),
         devtools_chan: None,
-        filemanager: Arc::new(Mutex::new(FileManager::new(embedder_proxy.clone()))),
+        filemanager: FileManager::new(embedder_proxy.clone()),
         file_token: FileTokenCheck::NotRequired,
         request_interceptor: Arc::new(TokioMutex::new(RequestInterceptor::new(embedder_proxy))),
         cancellation_listener: Arc::new(Default::default()),
@@ -880,7 +879,7 @@ fn test_fetch_self_signed() {
         state: Arc::new(create_http_state(None)),
         user_agent: DEFAULT_USER_AGENT.into(),
         devtools_chan: None,
-        filemanager: Arc::new(Mutex::new(FileManager::new(embedder_proxy.clone()))),
+        filemanager: FileManager::new(embedder_proxy.clone()),
         file_token: FileTokenCheck::NotRequired,
         request_interceptor: Arc::new(TokioMutex::new(RequestInterceptor::new(embedder_proxy))),
         cancellation_listener: Arc::new(Default::default()),
@@ -1530,7 +1529,7 @@ fn test_fetch_request_intercepted() {
         state: Arc::new(create_http_state(None)),
         user_agent: DEFAULT_USER_AGENT.into(),
         devtools_chan: None,
-        filemanager: Arc::new(Mutex::new(FileManager::new(embedder_proxy.clone()))),
+        filemanager: FileManager::new(embedder_proxy.clone()),
         file_token: FileTokenCheck::NotRequired,
         request_interceptor: Arc::new(TokioMutex::new(RequestInterceptor::new(embedder_proxy))),
         cancellation_listener: Arc::new(Default::default()),

--- a/components/net/tests/main.rs
+++ b/components/net/tests/main.rs
@@ -135,7 +135,7 @@ fn new_fetch_context(
         state: Arc::new(create_http_state(Some(sender.clone()))),
         user_agent: DEFAULT_USER_AGENT.into(),
         devtools_chan,
-        filemanager: Arc::new(Mutex::new(FileManager::new(sender.clone()))),
+        filemanager: FileManager::new(sender.clone()),
         file_token: FileTokenCheck::NotRequired,
         request_interceptor: Arc::new(TokioMutex::new(RequestInterceptor::new(sender))),
         cancellation_listener: Arc::new(Default::default()),

--- a/ports/servoshell/desktop/protocols/resource.rs
+++ b/ports/servoshell/desktop/protocols/resource.rs
@@ -71,7 +71,7 @@ impl ResourceProtocolHandler {
 
             *response.body.lock() = ResponseBody::Receiving(vec![]);
 
-            context.filemanager.lock().fetch_file_in_chunks(
+            context.filemanager.fetch_file_in_chunks(
                 &mut done_sender,
                 reader,
                 response.body.clone(),

--- a/uv.lock
+++ b/uv.lock
@@ -864,12 +864,16 @@ wheels = [
 
 [[package]]
 name = "mozdebug"
-version = "0.3.1"
+version = "0.4.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "mozinfo" },
+    { name = "mozshellutil" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/18/ac/50d9345aae3b7cae3b33fe81d4d219fe85c59e3a8cc24c1386adde5d9e17/mozdebug-0.3.1.tar.gz", hash = "sha256:a765d4ce572dba25bae1b9849c170ac829e5d2f92ad968e6e527543ebdc83c67", size = 6286, upload-time = "2024-04-30T10:25:58.746Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/da/1c/41bd0f151db8dd371627b336c66d30b9215e53394c5a0aafa25832c04b70/mozdebug-0.4.0.tar.gz", hash = "sha256:93b32e96f3569ad367a583d62835a03aa606141d768306f5a420dad5e2dbbbe1", size = 6907, upload-time = "2026-01-19T08:43:18.412Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/17/54/a811b8f19be1d5b924044e8213abc66c12bee6295075355827d576b3553e/mozdebug-0.4.0-py2.py3-none-any.whl", hash = "sha256:3aca1931a7c95b8d086a04eda5c94a7c0379caef5142239f09a9a02c63f5130a", size = 6520, upload-time = "2026-01-19T08:43:17.181Z" },
+]
 
 [[package]]
 name = "mozfile"
@@ -918,6 +922,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/3a/72/ecf7be35e24065c5780412627f4269a8bdae71eb42823d1416ea6968db11/mozprocess-1.4.0.tar.gz", hash = "sha256:6dbb6ebb5e01d6bdf1b24202719ad298331885aee088375e7e4372cdf9d5bb98", size = 21642, upload-time = "2024-08-19T15:40:38.39Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/7c/a3/354e9f0c8b629319e6f6334beaf42e38eeb5ddc821c77e9082752b037d3f/mozprocess-1.4.0-py2.py3-none-any.whl", hash = "sha256:9a3b218dab0f1277275be7d89d673cd55b062519043a88a1a1a77eacefdfdf5e", size = 23105, upload-time = "2024-08-19T15:40:36.691Z" },
+]
+
+[[package]]
+name = "mozshellutil"
+version = "1.0.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/62/e9/a803b667df67ccc15f06b3690d1f794be1ea1afc93a1b3627f786077ff15/mozshellutil-1.0.0.tar.gz", hash = "sha256:8fa474d9f8c337835c0b022ddfaf86fb60c43d5488736d2f679508cea5ba70e2", size = 4182, upload-time = "2026-01-19T08:37:32.694Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/56/2b/6af95db5b6b346ae64ff8a351c4a9cf31ce9de0777e05f992f2edddfa69b/mozshellutil-1.0.0-py2.py3-none-any.whl", hash = "sha256:f1b149fd011a9da344d2e89603ce52fe0e2f4652e4625bde614abebfc4412124", size = 4135, upload-time = "2026-01-19T08:37:31.417Z" },
 ]
 
 [[package]]
@@ -1572,6 +1585,7 @@ dependencies = [
     { name = "mozinfo" },
     { name = "mozlog" },
     { name = "mozprocess" },
+    { name = "mozshellutil" },
     { name = "mozterm" },
     { name = "packaging" },
     { name = "pillow" },
@@ -1603,10 +1617,11 @@ requires-dist = [
     { name = "jsonschema", marker = "python_full_version < '3.9'", specifier = "==4.23.0" },
     { name = "jsonschema", marker = "python_full_version >= '3.9'", specifier = "==4.25.1" },
     { name = "mako", specifier = "==1.2.2" },
-    { name = "mozdebug", specifier = "==0.3.1" },
+    { name = "mozdebug", specifier = "==0.4.0" },
     { name = "mozinfo", specifier = "==1.2.3" },
     { name = "mozlog", specifier = "==8.0.0" },
     { name = "mozprocess", specifier = "==1.4.0" },
+    { name = "mozshellutil", specifier = "==1.0.0" },
     { name = "mozterm", specifier = "==1.0.0" },
     { name = "packaging", specifier = "==25.0" },
     { name = "pillow", marker = "python_full_version < '3.9'", specifier = "==10.4.0" },


### PR DESCRIPTION
This switches FileManager from being behind an Arc<Mutex<FileManager>>> to just FileManager.
This saves us the Arc and Mutex and the compiler makes sure that we do not have Race Conditions.

FileManager is already easily cloneable because it consist of store: Arc<> and GenericEmbedderProxy.

Testing: Compilation and unit tests are the tests.
