### PR TITLE
script: Style the `<select>` button to be as tall as other buttons

### DIFF
--- a/components/script/dom/html/htmlselectelement.rs
+++ b/components/script/dom/html/htmlselectelement.rs
@@ -59,14 +59,17 @@ const DEFAULT_SELECT_SIZE: u32 = 0;
 const SELECT_BOX_STYLE: &str = "
     display: flex;
     align-items: center;
-    height: 100%;
 ";
 
 const TEXT_CONTAINER_STYLE: &str = "flex: 1;";
 
 const CHEVRON_CONTAINER_STYLE: &str = "
-    font-size: 16px;
-    margin: 4px;
+    width: 0;
+    height: 0;
+    margin-inline-start: 5px;
+    border-left: 5px solid transparent;
+    border-right: 5px solid transparent;
+    border-top: 5px solid black;
 ";
 
 #[derive(JSTraceable, MallocSizeOf)]
@@ -307,9 +310,6 @@ impl HTMLSelectElement {
             CHEVRON_CONTAINER_STYLE.into(),
             can_gc,
         );
-        chevron_container
-            .upcast::<Node>()
-            .set_text_content_for_element(Some("▾".into()), can_gc);
         select_box
             .upcast::<Node>()
             .AppendChild(chevron_container.upcast::<Node>(), can_gc)


### PR DESCRIPTION
This makes it so that the `<select>` button has its height determined by
the font size and not the size of the line that it is on. This improves
the display of the button next to other buttons.

Instead of relying on a fallback font to render the chevron, do this
using CSS border tricks, which ensure a consistent height of the button.
Let the flexbox determine its own height naturally so that it responds
to font size.

Testing: There is currently no way to test `<select>` button rendering other than manual tests.
