### PR TITLE
net: Devtools Channel does not need mutability.

### DIFF
--- a/components/net/fetch/methods.rs
+++ b/components/net/fetch/methods.rs
@@ -97,7 +97,7 @@ pub type SharedInflightKeepAliveRecords =
 pub struct FetchContext {
     pub state: Arc<HttpState>,
     pub user_agent: String,
-    pub devtools_chan: Option<Arc<Mutex<Sender<DevtoolsControlMsg>>>>,
+    pub devtools_chan: Option<Sender<DevtoolsControlMsg>>,
     pub filemanager: Arc<Mutex<FileManager>>,
     pub file_token: FileTokenCheck,
     pub request_interceptor: Arc<TokioMutex<RequestInterceptor>>,

--- a/components/net/resource_thread.rs
+++ b/components/net/resource_thread.rs
@@ -680,7 +680,7 @@ impl CoreResourceManager {
         protocols: Arc<ProtocolRegistry>,
     ) {
         let http_state = http_state.clone();
-        let dc = self.devtools_sender.clone();
+        let devtools_chan = self.devtools_sender.clone();
         let filemanager = self.filemanager.clone();
         let request_interceptor = self.request_interceptor.clone();
 
@@ -731,7 +731,7 @@ impl CoreResourceManager {
             let context = FetchContext {
                 state: http_state,
                 user_agent: servo_config::pref!(user_agent),
-                devtools_chan: dc,
+                devtools_chan,
                 filemanager: Arc::new(Mutex::new(filemanager)),
                 file_token,
                 request_interceptor: Arc::new(TokioMutex::new(request_interceptor)),
@@ -787,7 +787,7 @@ impl CoreResourceManager {
         protocols: Arc<ProtocolRegistry>,
     ) {
         let http_state = http_state.clone();
-        let dc = self.devtools_sender.clone();
+        let devtools_chan = self.devtools_sender.clone();
         let filemanager = self.filemanager.clone();
         let request_interceptor = self.request_interceptor.clone();
 
@@ -816,7 +816,7 @@ impl CoreResourceManager {
                     let context = FetchContext {
                         state: http_state,
                         user_agent: servo_config::pref!(user_agent),
-                        devtools_chan: dc,
+                        devtools_chan,
                         filemanager: Arc::new(Mutex::new(filemanager)),
                         file_token: FileTokenCheck::NotRequired,
                         request_interceptor: Arc::new(TokioMutex::new(request_interceptor)),

--- a/components/net/resource_thread.rs
+++ b/components/net/resource_thread.rs
@@ -731,7 +731,7 @@ impl CoreResourceManager {
             let context = FetchContext {
                 state: http_state,
                 user_agent: servo_config::pref!(user_agent),
-                devtools_chan: dc.map(|dc| Arc::new(Mutex::new(dc))),
+                devtools_chan: dc,
                 filemanager: Arc::new(Mutex::new(filemanager)),
                 file_token,
                 request_interceptor: Arc::new(TokioMutex::new(request_interceptor)),
@@ -816,7 +816,7 @@ impl CoreResourceManager {
                     let context = FetchContext {
                         state: http_state,
                         user_agent: servo_config::pref!(user_agent),
-                        devtools_chan: dc.map(|dc| Arc::new(Mutex::new(dc))),
+                        devtools_chan: dc,
                         filemanager: Arc::new(Mutex::new(filemanager)),
                         file_token: FileTokenCheck::NotRequired,
                         request_interceptor: Arc::new(TokioMutex::new(request_interceptor)),

--- a/components/net/tests/main.rs
+++ b/components/net/tests/main.rs
@@ -134,7 +134,7 @@ fn new_fetch_context(
     FetchContext {
         state: Arc::new(create_http_state(Some(sender.clone()))),
         user_agent: DEFAULT_USER_AGENT.into(),
-        devtools_chan: dc.map(|dc| Arc::new(Mutex::new(dc))),
+        devtools_chan: dc,
         filemanager: Arc::new(Mutex::new(FileManager::new(sender.clone()))),
         file_token: FileTokenCheck::NotRequired,
         request_interceptor: Arc::new(TokioMutex::new(RequestInterceptor::new(sender))),

--- a/components/net/tests/main.rs
+++ b/components/net/tests/main.rs
@@ -126,7 +126,7 @@ fn create_http_state(fc: Option<GenericEmbedderProxy<NetToEmbedderMsg>>) -> Http
 }
 
 fn new_fetch_context(
-    dc: Option<Sender<DevtoolsControlMsg>>,
+    devtools_chan: Option<Sender<DevtoolsControlMsg>>,
     fc: Option<GenericEmbedderProxy<NetToEmbedderMsg>>,
 ) -> FetchContext {
     let sender = fc.unwrap_or_else(|| create_generic_embedder_proxy());
@@ -134,7 +134,7 @@ fn new_fetch_context(
     FetchContext {
         state: Arc::new(create_http_state(Some(sender.clone()))),
         user_agent: DEFAULT_USER_AGENT.into(),
-        devtools_chan: dc,
+        devtools_chan,
         filemanager: Arc::new(Mutex::new(FileManager::new(sender.clone()))),
         file_token: FileTokenCheck::NotRequired,
         request_interceptor: Arc::new(TokioMutex::new(RequestInterceptor::new(sender))),


### PR DESCRIPTION
Devtools Channel does not need mutability. Hence, we do not need an Arc<Mutex<_>>.

As the underlying channel is a Crossbeam Sender the clone should be relatively cheap.

Signed-off-by: Narfinger <Narfinger@users.noreply.github.com>

Testing: Thanks to rust compilation means correctness.
