### PR TITLE
Increase stylo stack size in asan and debug builds

### DIFF
--- a/python/servo/build_commands.py
+++ b/python/servo/build_commands.py
@@ -142,13 +142,6 @@ class MachCommands(CommandBase):
 
         if sanitizer.is_some():
             self.build_sanitizer_env(env, opts, kwargs, target_triple, sanitizer)
-
-        if build_type.is_dev():
-            # Increase stylo thread stack size to 2 MiB for debug builds since the stack usage is higher
-            # and crashes have been reported. The default is 512 KiB.
-            # Note: This is placed after `build_sanitizer_env()` so that the higher stack size with ASAN takes
-            # priority over the debug build stack size, which matters for ASAN builds with the debug profile.
-            env["SERVO_STYLE_THREAD_STACK_SIZE_KB"] = env.get("SERVO_STYLE_THREAD_STACK_SIZE_KB", str(2 * 1024))
         build_start = time()
 
         if host != target_triple and "windows" in target_triple:
@@ -311,7 +304,7 @@ class MachCommands(CommandBase):
 
             # Set servo style thread stack size to 8 MB for ASAN builds since the stack usage is higher.
             # We don't care about efficiency, we just want to avoid crashes.
-            env["SERVO_STYLE_THREAD_STACK_SIZE_KB"] = env.get("SERVO_STYLE_THREAD_STACK_SIZE_KB", str(1024 * 8))
+            env["SERVO_STYLE_THREAD_STACK_SIZE_KB"] = str(1024 * 8)
 
             # asan replaces system allocator with asan allocator
             # we need to make sure that we do not replace it with jemalloc

--- a/python/servo/command_base.py
+++ b/python/servo/command_base.py
@@ -537,6 +537,11 @@ class CommandBase(object):
                 print("Hint: Ninja-build is available on github at: https://github.com/ninja-build/ninja/releases")
                 exit(1)
 
+        if self.config["build"]["mode"] in ["", "dev"]:
+            # Increase stylo thread stack size to 2 MiB for debug builds since the stack usage is higher
+            # and crashes have been reported. The default is 512 KiB.
+            env["SERVO_STYLE_THREAD_STACK_SIZE_KB"] = env.get("SERVO_STYLE_THREAD_STACK_SIZE_KB", str(2 * 1024))
+
         return env
 
     @staticmethod


### PR DESCRIPTION
This bumps stylo to allow configuring the stack size of the stylo threads, which fixes crashes with asan and debug builds.

Testing: Manual testing with `--with-asan` and with the debug profile.
Fixes: #40814
