### PR TITLE
webdriver: Test interactability for Element Clear

### DIFF
--- a/components/script/webdriver_handlers.rs
+++ b/components/script/webdriver_handlers.rs
@@ -1868,8 +1868,7 @@ pub(crate) fn handle_element_clear(
                 // TODO: Step 6 - 9: Implicit wait. In another PR.
                 // Wait until element become interactable and check.
 
-                // Step 10. If element is not interactable (neither keyboard-interactable nor
-                // pointer-interactable),
+                // Step 10. If element is not keyboard-interactable or not pointer-interactable,
                 // return error with error code element not interactable.
                 if !is_keyboard_interactable(&element) {
                     return Err(ErrorStatus::ElementNotInteractable);

--- a/components/script/webdriver_handlers.rs
+++ b/components/script/webdriver_handlers.rs
@@ -1865,8 +1865,26 @@ pub(crate) fn handle_element_clear(
                 // Step 5. Scroll Into View
                 scroll_into_view(&element, documents, &pipeline, can_gc);
 
-                // TODO: Step 6 - 10
+                // TODO: Step 6 - 9: Implicit wait. In another PR.
                 // Wait until element become interactable and check.
+
+                // Step 10. If element is not interactable (neither keyboard-interactable nor
+                // pointer-interactable),
+                // return error with error code element not interactable.
+                if !is_keyboard_interactable(&element) {
+                    return Err(ErrorStatus::ElementNotInteractable);
+                }
+
+                let paint_tree = get_element_pointer_interactable_paint_tree(
+                    &element,
+                    &documents
+                        .find_document(pipeline)
+                        .expect("Document existence guaranteed by `get_known_element`"),
+                    can_gc,
+                );
+                if !is_element_in_view(&element, &paint_tree) {
+                    return Err(ErrorStatus::ElementNotInteractable);
+                }
 
                 // Step 11
                 // TODO: Clear content editable elements

--- a/tests/wpt/meta/webdriver/tests/classic/element_clear/clear.py.ini
+++ b/tests/wpt/meta/webdriver/tests/classic/element_clear/clear.py.ini
@@ -2,9 +2,6 @@
   [test_no_browsing_context]
     expected: FAIL
 
-  [test_pointer_interactable]
-    expected: FAIL
-
   [test_contenteditable]
     expected: FAIL
 


### PR DESCRIPTION
Test interactability for Element Clear.

There is also a related spec change: https://github.com/w3c/webdriver/pull/1943 to match the implementation of vendors, and the reality.

Testing: New passing