### PR TITLE
script: Pass `&CStr` insted of `&str` in `{set,get}_dictionary_property`

### DIFF
--- a/components/script/dom/bytelengthqueuingstrategy.rs
+++ b/components/script/dom/bytelengthqueuingstrategy.rs
@@ -124,7 +124,7 @@ pub(crate) unsafe fn byte_length_queuing_strategy_size(
         get_dictionary_property(
             cx,
             object.handle(),
-            "byteLength",
+            c"byteLength",
             MutableHandleValue::from_raw(args.rval()),
             CanGc::note(),
         )

--- a/components/script/dom/messageport.rs
+++ b/components/script/dom/messageport.rs
@@ -221,11 +221,11 @@ impl MessagePort {
         type_.safe_to_jsval(cx, type_string.handle_mut(), can_gc);
 
         // Perform ! CreateDataProperty(message, "type", type).
-        set_dictionary_property(cx, message.handle(), "type", type_string.handle())
+        set_dictionary_property(cx, message.handle(), c"type", type_string.handle())
             .expect("Setting the message type should not fail.");
 
         // Perform ! CreateDataProperty(message, "value", value).
-        set_dictionary_property(cx, message.handle(), "value", value)
+        set_dictionary_property(cx, message.handle(), c"value", value)
             .expect("Setting the message value should not fail.");
 
         // Let targetPort be the port with which port is entangled, if any; otherwise let it be null.

--- a/components/script/dom/readablestream.rs
+++ b/components/script/dom/readablestream.rs
@@ -432,7 +432,7 @@ impl PipeTo {
             rooted!(in(*cx) let object = chunk.to_object());
             rooted!(in(*cx) let mut bytes = UndefinedValue());
             let has_value = unsafe {
-                get_dictionary_property(*cx, object.handle(), "value", bytes.handle_mut(), can_gc)
+                get_dictionary_property(*cx, object.handle(), c"value", bytes.handle_mut(), can_gc)
                     .expect("Chunk should have a value.")
             };
             if has_value {
@@ -2352,7 +2352,7 @@ pub(crate) unsafe fn get_type_and_value_from_message(
         get_dictionary_property(
             *cx,
             data_object.handle(),
-            "type",
+            c"type",
             type_.handle_mut(),
             can_gc,
         )
@@ -2360,7 +2360,7 @@ pub(crate) unsafe fn get_type_and_value_from_message(
     .expect("Getting the type should not fail.");
 
     // Let value be ! Get(data, "value").
-    unsafe { get_dictionary_property(*cx, data_object.handle(), "value", value, can_gc) }
+    unsafe { get_dictionary_property(*cx, data_object.handle(), c"value", value, can_gc) }
         .expect("Getting the value should not fail.");
 
     // Assert: type is a String.
@@ -2469,7 +2469,7 @@ pub(crate) fn get_read_promise_done(
     unsafe {
         rooted!(in(*cx) let object = v.to_object());
         rooted!(in(*cx) let mut done = UndefinedValue());
-        match get_dictionary_property(*cx, object.handle(), "done", done.handle_mut(), can_gc) {
+        match get_dictionary_property(*cx, object.handle(), c"done", done.handle_mut(), can_gc) {
             Ok(true) => match bool::safe_from_jsval(cx, done.handle(), (), can_gc) {
                 Ok(ConversionResult::Success(val)) => Ok(val),
                 Ok(ConversionResult::Failure(error)) => Err(Error::Type(error.to_string())),
@@ -2496,7 +2496,7 @@ pub(crate) fn get_read_promise_bytes(
     unsafe {
         rooted!(in(*cx) let object = v.to_object());
         rooted!(in(*cx) let mut bytes = UndefinedValue());
-        match get_dictionary_property(*cx, object.handle(), "value", bytes.handle_mut(), can_gc) {
+        match get_dictionary_property(*cx, object.handle(), c"value", bytes.handle_mut(), can_gc) {
             Ok(true) => {
                 match Vec::<u8>::safe_from_jsval(
                     cx,

--- a/components/script/dom/subtlecrypto.rs
+++ b/components/script/dom/subtlecrypto.rs
@@ -3879,7 +3879,7 @@ fn normalize_algorithm(
             alg_name
                 .as_str()
                 .safe_to_jsval(cx, alg_name_ptr.handle_mut(), can_gc);
-            set_dictionary_property(cx, obj.handle(), "name", alg_name_ptr.handle())
+            set_dictionary_property(cx, obj.handle(), c"name", alg_name_ptr.handle())
                 .map_err(|_| Error::JSFailed)?;
             let normalized_algorithm =
                 NormalizedAlgorithm::from_object_value(cx, value.handle(), desired_type, can_gc)?;

--- a/components/script/indexeddb.rs
+++ b/components/script/indexeddb.rs
@@ -336,7 +336,8 @@ pub(crate) fn evaluate_key_path_on_value(
                 // Step 1.3.4. Let p be ! ToString(i).
                 // Step 1.3.5. Let status be CreateDataProperty(result, p, key).
                 // Step 1.3.6. Assert: status is true.
-                set_dictionary_property(cx.into(), result.handle(), &i.to_string(), key.handle())
+                let i_cstr = std::ffi::CString::new(i.to_string()).unwrap();
+                set_dictionary_property(cx.into(), result.handle(), i_cstr.as_c_str(), key.handle())
                     .map_err(|_| Error::JSFailed)?;
 
                 // Step 1.3.7. Increase i by 1.

--- a/components/script/indexeddb.rs
+++ b/components/script/indexeddb.rs
@@ -337,8 +337,13 @@ pub(crate) fn evaluate_key_path_on_value(
                 // Step 1.3.5. Let status be CreateDataProperty(result, p, key).
                 // Step 1.3.6. Assert: status is true.
                 let i_cstr = std::ffi::CString::new(i.to_string()).unwrap();
-                set_dictionary_property(cx.into(), result.handle(), i_cstr.as_c_str(), key.handle())
-                    .map_err(|_| Error::JSFailed)?;
+                set_dictionary_property(
+                    cx.into(),
+                    result.handle(),
+                    i_cstr.as_c_str(),
+                    key.handle(),
+                )
+                .map_err(|_| Error::JSFailed)?;
 
                 // Step 1.3.7. Increase i by 1.
                 // Done by for loop with enumerate()

--- a/components/script_bindings/codegen/codegen.py
+++ b/components/script_bindings/codegen/codegen.py
@@ -7645,7 +7645,7 @@ impl{self.generic} Clone for {self.makeClassName(self.dictionary)}{self.genericS
             insertion = (
                 f"rooted!(in(cx) let mut {varName}_js = UndefinedValue());\n"
                 f"{varName}.to_jsval(cx, {varName}_js.handle_mut());\n"
-                f'set_dictionary_property(SafeJSContext::from_ptr(cx), obj.handle(), "{dictionaryName}", {varName}_js.handle()).unwrap();')
+                f'set_dictionary_property(SafeJSContext::from_ptr(cx), obj.handle(), c"{dictionaryName}", {varName}_js.handle()).unwrap();')
             return CGGeneric(insertion)
 
         def memberInsert(memberInfo: tuple[IDLArgument, JSToNativeConversionInfo]) -> CGThing:

--- a/components/script_bindings/codegen/codegen.py
+++ b/components/script_bindings/codegen/codegen.py
@@ -7774,7 +7774,7 @@ impl{self.generic} Clone for {self.makeClassName(self.dictionary)}{self.genericS
             "{\n"
             "    rooted!(&in(cx) let mut rval = UndefinedValue());\n"
             "    if get_dictionary_property(cx.raw_cx(), object.handle(), "
-            f'"{member.identifier.name}", '
+            f'c"{member.identifier.name}", '
             "rval.handle_mut(), can_gc)? && !rval.is_undefined() {\n"
             f"{indent(conversion)}\n"
             "    } else {\n"

--- a/components/script_bindings/utils.rs
+++ b/components/script_bindings/utils.rs
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-use std::ffi::{CStr, CString};
+use std::ffi::CStr;
 use std::os::raw::{c_char, c_void};
 use std::ptr::{self, NonNull};
 use std::slice;
@@ -245,14 +245,14 @@ pub(crate) unsafe fn find_enum_value<'a, T>(
 pub unsafe fn get_dictionary_property(
     cx: *mut JSContext,
     object: HandleObject,
-    property: &str,
+    property: &CStr,
     rval: MutableHandleValue,
     _can_gc: CanGc,
 ) -> Result<bool, ()> {
     unsafe fn has_property(
         cx: *mut JSContext,
         object: HandleObject,
-        property: &CString,
+        property: &CStr,
         found: &mut bool,
     ) -> bool {
         JS_HasProperty(cx, object, property.as_ptr(), found)
@@ -260,19 +260,18 @@ pub unsafe fn get_dictionary_property(
     unsafe fn get_property(
         cx: *mut JSContext,
         object: HandleObject,
-        property: &CString,
+        property: &CStr,
         value: MutableHandleValue,
     ) -> bool {
         JS_GetProperty(cx, object, property.as_ptr(), value)
     }
 
-    let property = CString::new(property).unwrap();
     if object.get().is_null() {
         return Ok(false);
     }
 
     let mut found = false;
-    if !has_property(cx, object, &property, &mut found) {
+    if !has_property(cx, object, property, &mut found) {
         return Err(());
     }
 
@@ -280,7 +279,7 @@ pub unsafe fn get_dictionary_property(
         return Ok(false);
     }
 
-    if !get_property(cx, object, &property, rval) {
+    if !get_property(cx, object, property, rval) {
         return Err(());
     }
 

--- a/components/script_bindings/utils.rs
+++ b/components/script_bindings/utils.rs
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-use std::ffi::CString;
+use std::ffi::{CStr, CString};
 use std::os::raw::{c_char, c_void};
 use std::ptr::{self, NonNull};
 use std::slice;
@@ -294,14 +294,13 @@ pub unsafe fn get_dictionary_property(
 pub fn set_dictionary_property(
     cx: SafeJSContext,
     object: HandleObject,
-    property: &str,
+    property: &CStr,
     value: HandleValue,
 ) -> Result<(), ()> {
     if object.get().is_null() {
         return Err(());
     }
 
-    let property = CString::new(property).unwrap();
     unsafe {
         if !JS_SetProperty(*cx, object, property.as_ptr(), value) {
             return Err(());


### PR DESCRIPTION
It's stupid to create rust strings in the first place to only convert them into C-style for SM anyway. Furthermore most of those strings are const literals (comp time strings), so now we will just store additional null byte within them and able to avoid any runtime conversions.
We should do this in more places.

Testing: Just refactor.
