### PR TITLE
script: Drop `ModuleTree` `network_error` and simplify pending fetches logic

### DIFF
--- a/components/script/dom/globalscope.rs
+++ b/components/script/dom/globalscope.rs
@@ -2401,10 +2401,12 @@ impl GlobalScope {
         &self.consumed_rejections
     }
 
-    pub(crate) fn get_module_map(
-        &self,
-    ) -> &DomRefCell<HashMapTracedValues<ServoUrl, ModuleStatus>> {
-        &self.module_map
+    pub(crate) fn set_module_map(&self, url: ServoUrl, module: ModuleStatus) {
+        self.module_map.borrow_mut().insert(url, module);
+    }
+
+    pub(crate) fn get_module_map_entry(&self, url: &ServoUrl) -> Option<ModuleStatus> {
+        self.module_map.borrow().get(url).cloned()
     }
 
     #[expect(unsafe_code)]

--- a/components/script/dom/globalscope.rs
+++ b/components/script/dom/globalscope.rs
@@ -147,7 +147,7 @@ use crate::microtask::Microtask;
 use crate::network_listener::{FetchResponseListener, NetworkListener};
 use crate::realms::{InRealm, enter_realm};
 use crate::script_module::{
-    ImportMap, ModuleScript, ModuleTree, ResolvedModule, RethrowError, ScriptFetchOptions,
+    ImportMap, ModuleScript, ModuleStatus, ResolvedModule, RethrowError, ScriptFetchOptions,
 };
 use crate::script_runtime::{CanGc, JSContext as SafeJSContext, ThreadSafeJSContext};
 use crate::script_thread::{ScriptThread, with_script_thread};
@@ -253,7 +253,7 @@ pub(crate) struct GlobalScope {
     /// module map is used when importing JavaScript modules
     /// <https://html.spec.whatwg.org/multipage/#concept-settings-object-module-map>
     #[ignore_malloc_size_of = "mozjs"]
-    module_map: DomRefCell<HashMapTracedValues<ServoUrl, Rc<ModuleTree>>>,
+    module_map: DomRefCell<HashMapTracedValues<ServoUrl, ModuleStatus>>,
 
     /// For providing instructions to an optional devtools server.
     #[no_trace]
@@ -2401,18 +2401,10 @@ impl GlobalScope {
         &self.consumed_rejections
     }
 
-    pub(crate) fn set_module_map(&self, url: ServoUrl, module: ModuleTree) {
-        self.module_map.borrow_mut().insert(url, Rc::new(module));
-    }
-
     pub(crate) fn get_module_map(
         &self,
-    ) -> &DomRefCell<HashMapTracedValues<ServoUrl, Rc<ModuleTree>>> {
+    ) -> &DomRefCell<HashMapTracedValues<ServoUrl, ModuleStatus>> {
         &self.module_map
-    }
-
-    pub(crate) fn get_module_tree(&self, url: &ServoUrl) -> Option<Rc<ModuleTree>> {
-        self.module_map.borrow().get(url).cloned()
     }
 
     #[expect(unsafe_code)]

--- a/components/script/dom/html/htmlscriptelement.rs
+++ b/components/script/dom/html/htmlscriptelement.rs
@@ -42,7 +42,6 @@ use crate::dom::bindings::reflector::DomGlobal;
 use crate::dom::bindings::root::{Dom, DomRoot, MutNullableDom};
 use crate::dom::bindings::settings_stack::AutoEntryScript;
 use crate::dom::bindings::str::DOMString;
-use crate::dom::bindings::trace::NoTrace;
 use crate::dom::csp::{CspReporting, GlobalCspReporting, InlineCheckType, Violation};
 use crate::dom::document::Document;
 use crate::dom::element::{
@@ -292,7 +291,7 @@ fn finish_fetching_a_classic_script(
     document.finish_load(LoadType::Script(url), can_gc);
 }
 
-pub(crate) type ScriptResult = Result<Script, NoTrace<NetworkError>>;
+pub(crate) type ScriptResult = Result<Script, ()>;
 
 // TODO merge classic and module scripts
 #[derive(JSTraceable, MallocSizeOf)]
@@ -380,12 +379,13 @@ impl FetchResponseListener for ClassicContext {
     ) {
         match (response.as_ref(), self.status.as_ref()) {
             (Err(error), _) | (_, Err(error)) => {
+                error!("Fetching classic script failed {:?}", error);
                 // Step 6, response is an error.
                 finish_fetching_a_classic_script(
                     &self.elem.root(),
                     self.kind,
                     self.url.clone(),
-                    Err(NoTrace(error.clone())),
+                    Err(()),
                     CanGc::note(),
                 );
 
@@ -956,8 +956,7 @@ impl HTMLScriptElement {
         // TODO: Step 3. Unblock rendering on el.
         let script = match result {
             // Step 4. If el's result is null, then fire an event named error at el, and return.
-            Err(e) => {
-                warn!("error loading script {:?}", e);
+            Err(_) => {
                 self.dispatch_error_event(can_gc);
                 return;
             },

--- a/components/script/dom/html/htmlscriptelement.rs
+++ b/components/script/dom/html/htmlscriptelement.rs
@@ -1049,8 +1049,7 @@ impl HTMLScriptElement {
         // Step 6.
         {
             let module_error = module_tree.get_rethrow_error().borrow();
-            let network_error = module_tree.get_network_error();
-            if module_error.is_some() && network_error.is_none() {
+            if module_error.is_some() {
                 module_tree.report_error(global, can_gc);
                 return;
             }

--- a/components/script/module_loading.rs
+++ b/components/script/module_loading.rs
@@ -450,12 +450,12 @@ pub(crate) fn host_load_imported_module(
 
         // Step 9.1. If loadState is not undefined and loadState.[[ErrorToRethrow]] is null,
         // set loadState.[[ErrorToRethrow]] to resolutionError.
-        if let Some(load_state) = load_state {
+        load_state.as_ref().inspect(|load_state| {
             load_state
                 .error_to_rethrow
                 .borrow_mut()
                 .get_or_insert(resolution_error.clone());
-        }
+        });
 
         // Step 9.2. Perform FinishLoadingImportedModule(referrer, moduleRequest, payload, ThrowCompletion(resolutionError)).
         finish_loading_imported_module(
@@ -488,44 +488,41 @@ pub(crate) fn host_load_imported_module(
         ),
     };
 
-    let on_single_fetch_complete = move |global: &GlobalScope, module_tree: Rc<ModuleTree>| {
-        // Step 1. Let completion be null.
-        // Step 2. If moduleScript is null, then set completion to ThrowCompletion(a new TypeError).
-        let completion = if module_tree.get_network_error().is_some() {
-            Err(gen_type_error(
-                global,
-                Error::Type("Module fetching failed".to_string()),
-                CanGc::note(),
-            ))
-        } else {
-            // Step 3. Otherwise, if moduleScript's parse error is not null, then:
-            // Step 3.1 Let parseError be moduleScript's parse error.
-            if let Some(parse_error) = module_tree.get_parse_error() {
-                // Step 3.3 If loadState is not undefined and loadState.[[ErrorToRethrow]] is null,
-                // set loadState.[[ErrorToRethrow]] to parseError.
-                if let Some(load_state) = load_state {
-                    load_state
-                        .error_to_rethrow
-                        .borrow_mut()
-                        .get_or_insert(parse_error.clone());
-                }
+    let on_single_fetch_complete =
+        move |global: &GlobalScope, module_tree: Option<Rc<ModuleTree>>| {
+            // Step 1. Let completion be null.
+            let completion = match module_tree {
+                // Step 2. If moduleScript is null, then set completion to ThrowCompletion(a new TypeError).
+                None => Err(gen_type_error(
+                    global,
+                    Error::Type("Module fetching failed".to_string()),
+                    CanGc::note(),
+                )),
+                Some(module_tree) => {
+                    // Step 3. Otherwise, if moduleScript's parse error is not null, then:
+                    // Step 3.1 Let parseError be moduleScript's parse error.
+                    if let Some(parse_error) = module_tree.get_parse_error() {
+                        // Step 3.3 If loadState is not undefined and loadState.[[ErrorToRethrow]] is null,
+                        // set loadState.[[ErrorToRethrow]] to parseError.
+                        load_state.as_ref().inspect(|load_state| {
+                            load_state
+                                .error_to_rethrow
+                                .borrow_mut()
+                                .get_or_insert(parse_error.clone());
+                        });
 
-                // Step 3.2 Set completion to ThrowCompletion(parseError).
-                Err(parse_error.clone())
-            } else {
-                assert!(
-                    module_tree
-                        .get_record()
-                        .is_some_and(|record| !record.handle().is_null())
-                );
-                // Step 4. Otherwise, set completion to NormalCompletion(moduleScript's record).
-                Ok(module_tree)
-            }
+                        // Step 3.2 Set completion to ThrowCompletion(parseError).
+                        Err(parse_error.clone())
+                    } else {
+                        // Step 4. Otherwise, set completion to NormalCompletion(moduleScript's record).
+                        Ok(module_tree)
+                    }
+                },
+            };
+
+            // Step 5. Perform FinishLoadingImportedModule(referrer, moduleRequest, payload, completion).
+            finish_loading_imported_module(global, referrer_module, specifier, payload, completion);
         };
-
-        // Step 5. Perform FinishLoadingImportedModule(referrer, moduleRequest, payload, completion).
-        finish_loading_imported_module(global, referrer_module, specifier, payload, completion);
-    };
 
     // Step 14 Fetch a single imported module script given url, fetchClient, destination, fetchOptions, settingsObject,
     // fetchReferrer, moduleRequest, and onSingleFetchComplete as defined below.
@@ -547,7 +544,7 @@ fn fetch_a_single_imported_module_script(
     destination: Destination,
     options: ScriptFetchOptions,
     referrer: Referrer,
-    on_complete: impl FnOnce(&GlobalScope, Rc<ModuleTree>) + 'static,
+    on_complete: impl FnOnce(&GlobalScope, Option<Rc<ModuleTree>>) + 'static,
 ) {
     // TODO Step 1. Assert: moduleRequest.[[Attributes]] does not contain any Record entry such that entry.[[Key]] is not "type",
     // because we only asked for "type" attributes in HostGetSupportedImportAttributes.


### PR DESCRIPTION
Since we use `NetworkError` just for logging reasons, we don't really need to pass it around; instead lets follow spec more closely and pass a `None` on network failures.
Make more explicit if a `modulemap` entry is currently fetching or ready.

Testing: No functional change, covered by existing tests
