### PR TITLE
build.rs: try harder to find a suitable python

### DIFF
--- a/components/script_bindings/build.rs
+++ b/components/script_bindings/build.rs
@@ -112,7 +112,7 @@ fn find_python() -> Command {
     println!(
         "cargo:warning=`uv` not found - Falling back to the default python! \
         If the build fails, please install uv and make sure it is in your PATH or make sure \
-        to provision the python environment with all necessary dependencies."
+        to provision a python environment >= python 3.11."
     );
 
     let python3 = Command::new("python3");

--- a/components/script_bindings/build.rs
+++ b/components/script_bindings/build.rs
@@ -78,20 +78,59 @@ impl phf_shared::PhfHash for Bytes<'_> {
     }
 }
 
-/// Tries to find a suitable python, which in Servo is always `uv run python` unless we are running
-/// as a descendant of `uv run python`. In that case, we can use either `uv run python` or `python`
-/// (uv does not provide a `python3` on Windows).
+fn try_python_command(mut command: Command) -> Result<Command, String> {
+    let command_result = command.output();
+
+    if let Ok(output) = command_result {
+        return if output.status.success() {
+            Ok(command)
+        } else {
+            Err(format!(
+                "`{command:?}` failed with {}",
+                String::from_utf8_lossy(&output.stderr)
+            ))
+        };
+    }
+    Err(format!("`{command:?}` failed to run (is it installed?)"))
+}
+
+/// Tries to find a suitable python, which in Servo is always `uv run python`.
 ///
-/// More details: <https://book.servo.org/hacking/setting-up-your-environment.html#check-tools>
+/// To be accommodating to different environments, which may manage python differently, we fallback
+/// to `python3` and `python` in that order.
 ///
 /// Note: This function should be kept in sync with the version in `components/servo/build.rs`
 fn find_python() -> Command {
     let mut command = Command::new("uv");
     command.args(["run", "python"]);
 
-    if command.output().is_ok_and(|out| out.status.success()) {
+    let command_result = try_python_command(command).inspect_err(|e| println!("cargo:warning={e}"));
+    if let Ok(command) = command_result {
         return command;
     }
 
-    panic!("Can't find python (tried `{command:?}`)! Is uv installed and in PATH?")
+    println!(
+        "cargo:warning=`uv` not found - Falling back to the default python! \
+        If the build fails, please install uv and make sure it is in your PATH or make sure \
+        to provision the python environment with all necessary dependencies."
+    );
+
+    let python3 = Command::new("python3");
+    let python3_result = try_python_command(python3);
+    if let Ok(command) = python3_result {
+        return command;
+    }
+
+    let python = Command::new("python");
+    let python_result = try_python_command(python);
+    if let Ok(command) = python_result {
+        return command;
+    }
+
+    // We first try `python` before printing an error for `python3`, since python3 is often missing
+    // provided via python on Windows (but not necessarily on linux).
+    println!("cargo:warning={}", python3_result.unwrap_err());
+    println!("cargo:warning={}", python_result.unwrap_err());
+
+    panic!("No suitable python found! Tried: `uv run python`, `python3`, `python`.");
 }

--- a/components/servo/build.rs
+++ b/components/servo/build.rs
@@ -59,7 +59,7 @@ fn find_python() -> Command {
     println!(
         "cargo:warning=`uv` not found - Falling back to the default python! \
         If the build fails, please install uv and make sure it is in your PATH or make sure \
-        to provision the python environment with all necessary dependencies."
+        to provision a python environment >= python 3.11."
     );
 
     let python3 = Command::new("python3");

--- a/components/servo/build.rs
+++ b/components/servo/build.rs
@@ -25,20 +25,59 @@ fn main() {
     }
 }
 
-/// Tries to find a suitable python, which in Servo is always `uv run python` unless we are running
-/// as a descendant of `uv run python`. In that case, we can use either `uv run python` or `python`
-/// (uv does not provide a `python3` on Windows).
+fn try_python_command(mut command: Command) -> Result<Command, String> {
+    let command_result = command.output();
+
+    if let Ok(output) = command_result {
+        return if output.status.success() {
+            Ok(command)
+        } else {
+            Err(format!(
+                "`{command:?}` failed with {}",
+                String::from_utf8_lossy(&output.stderr)
+            ))
+        };
+    }
+    Err(format!("`{command:?}` failed to run (is it installed?)"))
+}
+
+/// Tries to find a suitable python, which in Servo is always `uv run python`.
 ///
-/// More details: <https://book.servo.org/hacking/setting-up-your-environment.html#check-tools>
+/// To be accommodating to different environments, which may manage python differently, we fallback
+/// to `python3` and `python` in that order.
 ///
 /// Note: This function should be kept in sync with the version in `components/script_bindings/build.rs`
 fn find_python() -> Command {
     let mut command = Command::new("uv");
     command.args(["run", "python"]);
 
-    if command.output().is_ok_and(|out| out.status.success()) {
+    let command_result = try_python_command(command).inspect_err(|e| println!("cargo:warning={e}"));
+    if let Ok(command) = command_result {
         return command;
     }
 
-    panic!("Can't find python (tried `{command:?}`)! Is uv installed and in PATH?")
+    println!(
+        "cargo:warning=`uv` not found - Falling back to the default python! \
+        If the build fails, please install uv and make sure it is in your PATH or make sure \
+        to provision the python environment with all necessary dependencies."
+    );
+
+    let python3 = Command::new("python3");
+    let python3_result = try_python_command(python3);
+    if let Ok(command) = python3_result {
+        return command;
+    }
+
+    let python = Command::new("python");
+    let python_result = try_python_command(python);
+    if let Ok(command) = python_result {
+        return command;
+    }
+
+    // We first try `python` before printing an error for `python3`, since python3 is often missing
+    // provided via python on Windows (but not necessarily on linux).
+    println!("cargo:warning={}", python3_result.unwrap_err());
+    println!("cargo:warning={}", python_result.unwrap_err());
+
+    panic!("No suitable python found! Tried: `uv run python`, `python3`, `python`.");
 }


### PR DESCRIPTION
Other embedders might not want to use `uv` and manage python in a different way. This is not recommended by us, and we add warning messages that clearly recommend using uv, but allow using regular python. This will work if the embedder installs the necessary python dependencies.

We provide more information in the output as to what exactly failed, e.g. if `uv` was not installed, or if `uv run python` executed, but failed at runtime.

The documentation of `find_python` was also updated. The link to the book was outdated, and I don't think we currently document the set of python dependencies needed for building servo. This can be improved by follow-up PRs, e.g. using `uv run --script`.

Testing: No changes to the default `uv run` flow - The new python fallback is not particularly tested, and may have issues. However, the newly added warnings would help debugging any issues.

This might help shine a bit more light on #42122

