### PR TITLE
script: Take &CStr instead of &str in get_property_jsval

### DIFF
--- a/components/script/dom/bindings/error.rs
+++ b/components/script/dom/bindings/error.rs
@@ -4,7 +4,6 @@
 
 //! Utilities to throw exceptions from Rust bindings.
 
-use std::ffi::CString;
 use std::ptr::NonNull;
 use std::slice::from_raw_parts;
 
@@ -429,13 +428,12 @@ pub(crate) fn javascript_error_info_from_error_info(
         }
 
         rooted!(in(*cx) let object = value.to_object());
-        let stack_name = CString::new("stack").unwrap();
         rooted!(in(*cx) let mut stack_value = UndefinedValue());
         if unsafe {
             !JS_GetProperty(
                 *cx,
                 object.handle().into(),
-                stack_name.as_ptr(),
+                c"stack".as_ptr(),
                 stack_value.handle_mut().into(),
             )
         } {

--- a/components/script/dom/paintworkletglobalscope.rs
+++ b/components/script/dom/paintworkletglobalscope.rs
@@ -516,17 +516,17 @@ impl PaintWorkletGlobalScopeMethods<crate::DomTypeHolder> for PaintWorkletGlobal
 
         // Step 4-6.
         let mut property_names: Vec<String> =
-            get_property(cx, paint_obj.handle(), "inputProperties", ())?.unwrap_or_default();
+            get_property(cx, paint_obj.handle(), c"inputProperties", ())?.unwrap_or_default();
         let properties = property_names.drain(..).map(Atom::from).collect();
 
         // Step 7-9.
         let input_arguments: Vec<String> =
-            get_property(cx, paint_obj.handle(), "inputArguments", ())?.unwrap_or_default();
+            get_property(cx, paint_obj.handle(), c"inputArguments", ())?.unwrap_or_default();
 
         // TODO: Steps 10-11.
 
         // Steps 12-13.
-        let alpha: bool = get_property(cx, paint_obj.handle(), "alpha", ())?.unwrap_or(true);
+        let alpha: bool = get_property(cx, paint_obj.handle(), c"alpha", ())?.unwrap_or(true);
 
         // Step 14
         if unsafe { !IsConstructor(paint_obj.get()) } {
@@ -535,7 +535,7 @@ impl PaintWorkletGlobalScopeMethods<crate::DomTypeHolder> for PaintWorkletGlobal
 
         // Steps 15-16
         rooted!(in(*cx) let mut prototype = UndefinedValue());
-        get_property_jsval(cx, paint_obj.handle(), "prototype", prototype.handle_mut())?;
+        get_property_jsval(cx, paint_obj.handle(), c"prototype", prototype.handle_mut())?;
         if !prototype.is_object() {
             return Err(Error::Type(String::from("Prototype is not an object.")));
         }
@@ -543,7 +543,12 @@ impl PaintWorkletGlobalScopeMethods<crate::DomTypeHolder> for PaintWorkletGlobal
 
         // Steps 17-18
         rooted!(in(*cx) let mut paint_function = UndefinedValue());
-        get_property_jsval(cx, prototype.handle(), "paint", paint_function.handle_mut())?;
+        get_property_jsval(
+            cx,
+            prototype.handle(),
+            c"paint",
+            paint_function.handle_mut(),
+        )?;
         if !paint_function.is_object() || unsafe { !IsCallable(paint_function.to_object()) } {
             return Err(Error::Type(String::from("Paint function is not callable.")));
         }

--- a/components/script/indexeddb.rs
+++ b/components/script/indexeddb.rs
@@ -390,7 +390,7 @@ pub(crate) fn evaluate_key_path_on_value(
                             get_property_jsval(
                                 cx.into(),
                                 object.handle(),
-                                "length",
+                                c"length",
                                 current_value.handle_mut(),
                             )?;
 


### PR DESCRIPTION
This change modifies `get_property_jsval` and `get_property` to take a `&CStr` instead of `&str`, to avoid conversion between the two in many places.

Testing: Covered by existing tests
Part of https://github.com/servo/servo/issues/42126
