### PR TITLE
script: Pass more CStr(ing) instead of rust strings

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5587,9 +5587,9 @@ dependencies = [
 
 [[package]]
 name = "mozjs"
-version = "0.14.8"
+version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36f3329b0f19f40511bd7266d68ffbedf6d3d59157451927ec8d58ea010f6cda"
+checksum = "af2c1ff3ebff6f4276c66c82af601ad97a2fe9a2e9e0b5b43a38843c929046af"
 dependencies = [
  "bindgen",
  "cc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -110,7 +110,7 @@ imsz = "0.4"
 indexmap = { version = "2.11.4", features = ["std"] }
 ipc-channel = { version = "0.21" }
 itertools = "0.14"
-js = { package = "mozjs", version = "=0.14.8", default-features = false, features = ["libz-sys", "intl"] }
+js = { package = "mozjs", version = "=0.15.0", default-features = false, features = ["libz-sys", "intl"] }
 keyboard-types = { version = "0.8.3", features = ["serde", "webdriver"] }
 kurbo = { version = "0.12", features = ["euclid"] }
 layout_api = { path = "components/shared/layout" }

--- a/components/script/dom/bindings/error.rs
+++ b/components/script/dom/bindings/error.rs
@@ -21,6 +21,7 @@ use js::jsval::UndefinedValue;
 use js::rust::wrappers::{JS_ErrorFromException, JS_GetPendingException, JS_SetPendingException};
 use js::rust::{HandleObject, HandleValue, MutableHandleValue, describe_scripted_caller};
 use libc::c_uint;
+use script_bindings::cformat;
 use script_bindings::conversions::SafeToJSValConvertible;
 pub(crate) use script_bindings::error::*;
 use script_bindings::root::DomRoot;
@@ -82,11 +83,13 @@ pub(crate) fn throw_dom_exception(
 
         Err(JsEngineError::Type(message)) => unsafe {
             assert!(!JS_IsExceptionPending(*cx));
+            let message = cformat!("{message}");
             throw_type_error(*cx, &message);
         },
 
         Err(JsEngineError::Range(message)) => unsafe {
             assert!(!JS_IsExceptionPending(*cx));
+            let message = cformat!("{message}");
             throw_range_error(*cx, &message);
         },
 

--- a/components/script/dom/bluetooth/bluetooth.rs
+++ b/components/script/dom/bluetooth/bluetooth.rs
@@ -636,7 +636,9 @@ impl PermissionAlgorithm for Bluetooth {
             .set(ObjectValue(permission_descriptor_obj));
         match BluetoothPermissionDescriptor::new(cx, property.handle(), can_gc) {
             Ok(ConversionResult::Success(descriptor)) => Ok(descriptor),
-            Ok(ConversionResult::Failure(error)) => Err(Error::Type(error.into_owned())),
+            Ok(ConversionResult::Failure(error)) => Err(Error::Type(
+                String::from_utf8_lossy(error.as_ref().to_bytes()).into_owned(),
+            )),
             Err(_) => Err(Error::Type(String::from(BT_DESC_CONVERSION_ERROR))),
         }
     }

--- a/components/script/dom/customelementregistry.rs
+++ b/components/script/dom/customelementregistry.rs
@@ -267,7 +267,9 @@ impl CustomElementRegistry {
         );
         match conversion {
             Ok(ConversionResult::Success(attributes)) => Ok(attributes),
-            Ok(ConversionResult::Failure(error)) => Err(Error::Type(error.into())),
+            Ok(ConversionResult::Failure(error)) => Err(Error::Type(
+                String::from_utf8_lossy(error.as_ref().to_bytes()).into_owned(),
+            )),
             _ => Err(Error::JSFailed),
         }
     }
@@ -305,7 +307,9 @@ impl CustomElementRegistry {
         );
         match conversion {
             Ok(ConversionResult::Success(flag)) => Ok(flag),
-            Ok(ConversionResult::Failure(error)) => Err(Error::Type(error.into())),
+            Ok(ConversionResult::Failure(error)) => Err(Error::Type(
+                String::from_utf8_lossy(error.as_ref().to_bytes()).into_owned(),
+            )),
             _ => Err(Error::JSFailed),
         }
     }
@@ -343,7 +347,9 @@ impl CustomElementRegistry {
         );
         match conversion {
             Ok(ConversionResult::Success(attributes)) => Ok(attributes),
-            Ok(ConversionResult::Failure(error)) => Err(Error::Type(error.into())),
+            Ok(ConversionResult::Failure(error)) => Err(Error::Type(
+                String::from_utf8_lossy(error.as_ref().to_bytes()).into_owned(),
+            )),
             _ => Err(Error::JSFailed),
         }
     }

--- a/components/script/dom/documentorshadowroot.rs
+++ b/components/script/dom/documentorshadowroot.rs
@@ -446,7 +446,9 @@ impl DocumentOrShadowRoot {
                     owner,
                 )
             },
-            Ok(ConversionResult::Failure(msg)) => Err(Error::Type(msg.to_string())),
+            Ok(ConversionResult::Failure(msg)) => Err(Error::Type(
+                String::from_utf8_lossy(msg.as_ref().to_bytes()).into_owned(),
+            )),
             Err(_) => Err(Error::Type(
                 "The provided value is not a sequence of 'CSSStylesheet'.".to_owned(),
             )),

--- a/components/script/dom/eventtarget.rs
+++ b/components/script/dom/eventtarget.rs
@@ -18,6 +18,7 @@ use js::jsval::JSVal;
 use js::rust::{CompileOptionsWrapper, HandleObject, transform_u16_to_source_text};
 use libc::c_char;
 use rustc_hash::FxBuildHasher;
+use script_bindings::cformat;
 use servo_url::ServoUrl;
 use style::str::HTML_SPACE_CHARACTERS;
 use stylo_atoms::Atom;
@@ -759,9 +760,8 @@ impl EventTarget {
         let args = if is_error { ERROR_ARG_NAMES } else { ARG_NAMES };
 
         let cx = GlobalScope::get_cx();
-        let options = unsafe {
-            CompileOptionsWrapper::new_raw(*cx, &handler.url.to_string(), handler.line as u32)
-        };
+        let url = cformat!("{}", handler.url);
+        let options = unsafe { CompileOptionsWrapper::new_raw(*cx, url, handler.line as u32) };
 
         // Step 3.9, subsection Scope steps 1-6
         let scopechain = js::rust::EnvironmentChain::new(*cx, SupportUnscopables::Yes);

--- a/components/script/dom/global_scope_script_execution.rs
+++ b/components/script/dom/global_scope_script_execution.rs
@@ -17,6 +17,7 @@ use js::rust::wrappers::{
     JS_ExecuteScript, JS_GetPendingException, JS_GetScriptPrivate, JS_SetPendingException,
 };
 use js::rust::{CompileOptionsWrapper, MutableHandleValue, transform_str_to_source_text};
+use script_bindings::cformat;
 use servo_url::ServoUrl;
 
 use crate::dom::bindings::codegen::Bindings::WindowBinding::WindowMethods;
@@ -258,6 +259,9 @@ pub(crate) fn compile_script(
     line_number: u32,
     introduction_type: Option<&'static CStr>,
 ) -> *mut JSScript {
+    // TODO: pass filename as CString to avoid allocation
+    // See https://github.com/servo/servo/issues/42126
+    let filename = cformat!("{filename}");
     let mut options = unsafe { CompileOptionsWrapper::new_raw(*cx, filename, line_number) };
     if let Some(introduction_type) = introduction_type {
         options.set_introduction_type(introduction_type);

--- a/components/script/dom/permissions.rs
+++ b/components/script/dom/permissions.rs
@@ -231,7 +231,9 @@ impl PermissionAlgorithm for Permissions {
             .set(ObjectValue(permission_descriptor_obj));
         match PermissionDescriptor::new(cx, property.handle(), can_gc) {
             Ok(ConversionResult::Success(descriptor)) => Ok(descriptor),
-            Ok(ConversionResult::Failure(error)) => Err(Error::Type(error.into_owned())),
+            Ok(ConversionResult::Failure(error)) => Err(Error::Type(
+                String::from_utf8_lossy(error.as_ref().to_bytes()).into_owned(),
+            )),
             Err(_) => Err(Error::JSFailed),
         }
     }

--- a/components/script/dom/promise.rs
+++ b/components/script/dom/promise.rs
@@ -416,7 +416,7 @@ impl FromJSValConvertibleRc for Promise {
         value: HandleValue,
     ) -> Result<ConversionResult<Rc<Promise>>, ()> {
         if value.get().is_null() {
-            return Ok(ConversionResult::Failure("null not allowed".into()));
+            return Ok(ConversionResult::Failure(c"null not allowed".into()));
         }
 
         let cx = unsafe { SafeJSContext::from_ptr(cx) };

--- a/components/script/dom/stream/bytelengthqueuingstrategy.rs
+++ b/components/script/dom/stream/bytelengthqueuingstrategy.rs
@@ -104,7 +104,7 @@ pub(crate) unsafe fn byte_length_queuing_strategy_size(
         unsafe {
             throw_type_error(
                 cx,
-                "ByteLengthQueuingStrategy size called with undefined or nulll",
+                c"ByteLengthQueuingStrategy size called with undefined or nulll",
             )
         };
         return false;

--- a/components/script/dom/stream/readablestream.rs
+++ b/components/script/dom/stream/readablestream.rs
@@ -2129,7 +2129,11 @@ impl ReadableStreamMethods<crate::DomTypeHolder> for ReadableStream {
             rooted!(in(*cx) let obj_val = ObjectValue(underlying_source_obj.get()));
             match JsUnderlyingSource::new(cx, obj_val.handle(), can_gc) {
                 Ok(ConversionResult::Success(val)) => val,
-                Ok(ConversionResult::Failure(error)) => return Err(Error::Type(error.to_string())),
+                Ok(ConversionResult::Failure(error)) => {
+                    return Err(Error::Type(
+                        String::from_utf8_lossy(error.as_ref().to_bytes()).into_owned(),
+                    ));
+                },
                 _ => {
                     return Err(Error::JSFailed);
                 },
@@ -2472,7 +2476,9 @@ pub(crate) fn get_read_promise_done(
         match get_dictionary_property(*cx, object.handle(), c"done", done.handle_mut(), can_gc) {
             Ok(true) => match bool::safe_from_jsval(cx, done.handle(), (), can_gc) {
                 Ok(ConversionResult::Success(val)) => Ok(val),
-                Ok(ConversionResult::Failure(error)) => Err(Error::Type(error.to_string())),
+                Ok(ConversionResult::Failure(error)) => Err(Error::Type(
+                    String::from_utf8_lossy(error.as_ref().to_bytes()).into_owned(),
+                )),
                 _ => Err(Error::Type("Unknown format for done property.".to_string())),
             },
             Ok(false) => Err(Error::Type("Promise has no done property.".to_string())),
@@ -2505,7 +2511,9 @@ pub(crate) fn get_read_promise_bytes(
                     can_gc,
                 ) {
                     Ok(ConversionResult::Success(val)) => Ok(val),
-                    Ok(ConversionResult::Failure(error)) => Err(Error::Type(error.to_string())),
+                    Ok(ConversionResult::Failure(error)) => Err(Error::Type(
+                        String::from_utf8_lossy(error.as_ref().to_bytes()).into_owned(),
+                    )),
                     _ => Err(Error::Type("Unknown format for bytes read.".to_string())),
                 }
             },
@@ -2525,7 +2533,9 @@ pub(crate) fn bytes_from_chunk_jsval(
 ) -> Result<Vec<u8>, Error> {
     match Vec::<u8>::safe_from_jsval(cx, chunk.handle(), ConversionBehavior::EnforceRange, can_gc) {
         Ok(ConversionResult::Success(vec)) => Ok(vec),
-        Ok(ConversionResult::Failure(error)) => Err(Error::Type(error.to_string())),
+        Ok(ConversionResult::Failure(error)) => Err(Error::Type(
+            String::from_utf8_lossy(error.as_ref().to_bytes()).into_owned(),
+        )),
         _ => Err(Error::Type("Unknown format for bytes read.".to_string())),
     }
 }

--- a/components/script/dom/stream/transformstream.rs
+++ b/components/script/dom/stream/transformstream.rs
@@ -986,7 +986,11 @@ impl TransformStreamMethods<crate::DomTypeHolder> for TransformStream {
             rooted!(in(*cx) let obj_val = ObjectValue(transformer_obj.get()));
             match Transformer::new(cx, obj_val.handle(), can_gc) {
                 Ok(ConversionResult::Success(val)) => val,
-                Ok(ConversionResult::Failure(error)) => return Err(Error::Type(error.to_string())),
+                Ok(ConversionResult::Failure(error)) => {
+                    return Err(Error::Type(
+                        String::from_utf8_lossy(error.as_ref().to_bytes()).into_owned(),
+                    ));
+                },
                 _ => {
                     return Err(Error::JSFailed);
                 },

--- a/components/script/dom/stream/writablestream.rs
+++ b/components/script/dom/stream/writablestream.rs
@@ -1032,7 +1032,11 @@ impl WritableStreamMethods<crate::DomTypeHolder> for WritableStream {
             rooted!(in(*cx) let obj_val = ObjectValue(underlying_sink_obj.get()));
             match UnderlyingSink::new(cx, obj_val.handle(), can_gc) {
                 Ok(ConversionResult::Success(val)) => val,
-                Ok(ConversionResult::Failure(error)) => return Err(Error::Type(error.to_string())),
+                Ok(ConversionResult::Failure(error)) => {
+                    return Err(Error::Type(
+                        String::from_utf8_lossy(error.as_ref().to_bytes()).into_owned(),
+                    ));
+                },
                 _ => {
                     return Err(Error::JSFailed);
                 },

--- a/components/script/dom/subtlecrypto.rs
+++ b/components/script/dom/subtlecrypto.rs
@@ -3004,7 +3004,9 @@ where
     let conversion = T::safe_from_jsval(cx, value, (), can_gc).map_err(|_| Error::JSFailed)?;
     match conversion {
         ConversionResult::Success(dictionary) => Ok(dictionary),
-        ConversionResult::Failure(error) => Err(Error::Type(error.into())),
+        ConversionResult::Failure(error) => Err(Error::Type(
+            String::from_utf8_lossy(error.as_ref().to_bytes()).into_owned(),
+        )),
     }
 }
 
@@ -3147,7 +3149,9 @@ impl JsonWebKeyExt for JsonWebKey {
         let key = match JsonWebKey::new(cx, result.handle(), CanGc::note()) {
             Ok(ConversionResult::Success(key)) => key,
             Ok(ConversionResult::Failure(error)) => {
-                return Err(Error::Type(error.to_string()));
+                return Err(Error::Type(
+                    String::from_utf8_lossy(error.as_ref().to_bytes()).into_owned(),
+                ));
             },
             Err(()) => {
                 return Err(Error::JSFailed);

--- a/components/script/script_module.rs
+++ b/components/script/script_module.rs
@@ -47,6 +47,7 @@ use net_traits::request::{
     CredentialsMode, Destination, ParserMetadata, Referrer, RequestBuilder, RequestId, RequestMode,
 };
 use net_traits::{FetchMetadata, Metadata, NetworkError, ReferrerPolicy, ResourceFetchTiming};
+use script_bindings::cformat;
 use script_bindings::domstring::BytesView;
 use script_bindings::error::Fallible;
 use script_bindings::trace::CustomTraceable;
@@ -310,8 +311,9 @@ impl ModuleTree {
             loaded_modules: DomRefCell::new(IndexMap::new()),
         };
 
+        let c_url = cformat!("{url}");
         let mut compile_options =
-            unsafe { CompileOptionsWrapper::new_raw(*cx, url.as_str(), line_number) };
+            unsafe { CompileOptionsWrapper::new_raw(*cx, c_url, line_number) };
         if let Some(introduction_type) = introduction_type {
             compile_options.set_introduction_type(introduction_type);
         }
@@ -391,7 +393,8 @@ impl ModuleTree {
         // Step 3. Set script's base URL and fetch options to null.
         // Note: We don't need to call `SetModulePrivate` for json scripts
 
-        let mut compile_options = unsafe { CompileOptionsWrapper::new_raw(*cx, url.as_str(), 1) };
+        let c_url = cformat!("{url}");
+        let mut compile_options = unsafe { CompileOptionsWrapper::new_raw(*cx, c_url, 1) };
         if let Some(introduction_type) = introduction_type {
             compile_options.set_introduction_type(introduction_type);
         }

--- a/components/script_bindings/conversions.rs
+++ b/components/script_bindings/conversions.rs
@@ -192,7 +192,7 @@ impl FromJSValConvertible for ByteString {
         let char_vec = slice::from_raw_parts(chars, length);
 
         if char_vec.iter().any(|&c| c > 0xFF) {
-            throw_type_error(cx, "Invalid ByteString");
+            throw_type_error(cx, c"Invalid ByteString");
             Err(())
         } else {
             Ok(ConversionResult::Success(ByteString::new(
@@ -222,7 +222,7 @@ impl<T: DomObject + IDLInterface> FromJSValConvertible for DomRoot<T> {
         Ok(
             match root_from_handlevalue(value, SafeJSContext::from_ptr(cx)) {
                 Ok(result) => ConversionResult::Success(result),
-                Err(()) => ConversionResult::Failure("value is not an object".into()),
+                Err(()) => ConversionResult::Failure(c"value is not an object".into()),
             },
         )
     }
@@ -451,7 +451,7 @@ impl<T: Float + FromJSValConvertible<Config = ()>> FromJSValConvertible for Fini
         match Finite::new(result) {
             Some(v) => Ok(ConversionResult::Success(v)),
             None => {
-                throw_type_error(cx, "this argument is not a finite floating-point value");
+                throw_type_error(cx, c"this argument is not a finite floating-point value");
                 Err(())
             },
         }

--- a/components/script_bindings/error.rs
+++ b/components/script_bindings/error.rs
@@ -103,7 +103,7 @@ pub fn throw_invalid_this(cx: SafeJSContext, proto_id: u16) {
         .as_bytes()
         .to_vec();
     vec.extend_from_slice(proto_id_to_name(proto_id).as_bytes());
-    let error = CString::new(vec).unwrap();
+    let error = CString::new(vec).expect("WebIDL name should not contain nul byte");
     unsafe { throw_type_error(*cx, &error) };
 }
 
@@ -111,7 +111,7 @@ pub fn throw_constructor_without_new(cx: SafeJSContext, name: &str) {
     debug_assert!(unsafe { !JS_IsExceptionPending(*cx) });
     let mut error = name.as_bytes().to_vec();
     error.extend_from_slice(b" constructor: 'new' is required");
-    let error = CString::new(error).unwrap();
+    let error = CString::new(error).expect("WebIDL name should not contain nul byte");
     unsafe { throw_type_error(*cx, &error) };
 }
 
@@ -138,7 +138,7 @@ macro_rules! cformat {
                     }
                 }
                 std::ffi::CString::new(out)
-            }).unwrap()
+            }).expect("nul bytes should be replaced")
         }
     }
 }

--- a/components/script_bindings/interface.rs
+++ b/components/script_bindings/interface.rs
@@ -540,7 +540,7 @@ unsafe extern "C" fn invalid_constructor(
     _argc: libc::c_uint,
     _vp: *mut JSVal,
 ) -> bool {
-    throw_type_error(cx, "Illegal constructor.");
+    throw_type_error(cx, c"Illegal constructor.");
     false
 }
 
@@ -549,7 +549,7 @@ unsafe extern "C" fn non_new_constructor(
     _argc: libc::c_uint,
     _vp: *mut JSVal,
 ) -> bool {
-    throw_type_error(cx, "This constructor needs to be called with `new`.");
+    throw_type_error(cx, c"This constructor needs to be called with `new`.");
     false
 }
 

--- a/components/script_bindings/record.rs
+++ b/components/script_bindings/record.rs
@@ -42,7 +42,7 @@ impl RecordKey for DOMString {
     unsafe fn from_id(cx: *mut JSContext, id: HandleId) -> Result<ConversionResult<Self>, ()> {
         match jsid_to_string(cx, id) {
             Some(s) => Ok(ConversionResult::Success(s)),
-            None => Ok(ConversionResult::Failure("Failed to get DOMString".into())),
+            None => Ok(ConversionResult::Failure(c"Failed to get DOMString".into())),
         }
     }
 }
@@ -119,7 +119,7 @@ where
     ) -> Result<ConversionResult<Self>, ()> {
         if !value.is_object() {
             return Ok(ConversionResult::Failure(
-                "Record value was not an object".into(),
+                c"Record value was not an object".into(),
             ));
         }
 


### PR DESCRIPTION
This is companion to https://github.com/servo/mozjs/pull/703 which makes mozjs to use CStr(ing) in the API (where we would silently do conversion in mozjs). This way we can avoid rust string -> c string allocations.

In the followup PR we should switch Error::Type and Error::Range to also use CStrings internally, as they are converted to CString for throwing JS exceptions (other get thrown as DomException object, which uses rust string internally - although this gets converted to JSString somewhere).

Testing: It should be just refactor without any side effects so there should be no changes to WPT results.
Try run: https://github.com/sagudev/servo/actions/runs/21328878448
Part of #42126
