### PR TITLE
Expand set of permanent network failures to include all fetch preconditions

### DIFF
--- a/components/script/network_listener.rs
+++ b/components/script/network_listener.rs
@@ -38,23 +38,10 @@ pub(crate) fn submit_timing<T: ResourceTimingListener>(
     // (e.g. mixed content, CORS restriction, CSP policy, etc), then this resource
     // will not be included as a PerformanceResourceTiming object in
     // the Performance Timeline.
-    if let Err(
-        NetworkError::ContentSecurityPolicy |
-        NetworkError::MixedContent |
-        NetworkError::SubresourceIntegrity |
-        NetworkError::Nosniff |
-        NetworkError::InvalidPort |
-        NetworkError::CorsGeneral |
-        NetworkError::CrossOriginResponse |
-        NetworkError::CorsCredentials |
-        NetworkError::CorsAllowMethods |
-        NetworkError::CorsAllowHeaders |
-        NetworkError::CorsMethod |
-        NetworkError::CorsAuthorization |
-        NetworkError::CorsHeaders,
-    ) = &result
-    {
-        return;
+    if let Err(error) = &result {
+        if error.is_permanent_failure() {
+            return;
+        }
     }
 
     // Resource timings should only be submitted for the initial preload request,

--- a/components/shared/net/lib.rs
+++ b/components/shared/net/lib.rs
@@ -1247,9 +1247,19 @@ impl NetworkError {
     pub fn is_permanent_failure(&self) -> bool {
         matches!(
             self,
-            NetworkError::InvalidPort |
+            NetworkError::ContentSecurityPolicy |
                 NetworkError::MixedContent |
-                NetworkError::ContentSecurityPolicy |
+                NetworkError::SubresourceIntegrity |
+                NetworkError::Nosniff |
+                NetworkError::InvalidPort |
+                NetworkError::CorsGeneral |
+                NetworkError::CrossOriginResponse |
+                NetworkError::CorsCredentials |
+                NetworkError::CorsAllowMethods |
+                NetworkError::CorsAllowHeaders |
+                NetworkError::CorsMethod |
+                NetworkError::CorsAuthorization |
+                NetworkError::CorsHeaders |
                 NetworkError::UnsupportedScheme
         )
     }

--- a/tests/wpt/meta/eventsource/eventsource-cross-origin.window.js.ini
+++ b/tests/wpt/meta/eventsource/eventsource-cross-origin.window.js.ini
@@ -1,9 +1,0 @@
-[eventsource-cross-origin.window.html]
-  [EventSource: cross-origin allow-origin: http://example.org should fail]
-    expected: FAIL
-
-  [EventSource: cross-origin allow-origin:'' should fail]
-    expected: FAIL
-
-  [EventSource: cross-origin No allow-origin should fail]
-    expected: FAIL


### PR DESCRIPTION
Testing: `./mach test-wpt tests/wpt/tests/eventsource`
Fixes: #42092 
