### PR TITLE
script: support JSON modules

### DIFF
--- a/components/script/dom/globalscope.rs
+++ b/components/script/dom/globalscope.rs
@@ -147,7 +147,8 @@ use crate::microtask::Microtask;
 use crate::network_listener::{FetchResponseListener, NetworkListener};
 use crate::realms::{InRealm, enter_realm};
 use crate::script_module::{
-    ImportMap, ModuleScript, ModuleStatus, ResolvedModule, RethrowError, ScriptFetchOptions,
+    ImportMap, ModuleRequest, ModuleScript, ModuleStatus, ResolvedModule, RethrowError,
+    ScriptFetchOptions,
 };
 use crate::script_runtime::{CanGc, JSContext as SafeJSContext, ThreadSafeJSContext};
 use crate::script_thread::{ScriptThread, with_script_thread};
@@ -253,7 +254,7 @@ pub(crate) struct GlobalScope {
     /// module map is used when importing JavaScript modules
     /// <https://html.spec.whatwg.org/multipage/#concept-settings-object-module-map>
     #[ignore_malloc_size_of = "mozjs"]
-    module_map: DomRefCell<HashMapTracedValues<ServoUrl, ModuleStatus>>,
+    module_map: DomRefCell<HashMapTracedValues<ModuleRequest, ModuleStatus>>,
 
     /// For providing instructions to an optional devtools server.
     #[no_trace]
@@ -2401,12 +2402,12 @@ impl GlobalScope {
         &self.consumed_rejections
     }
 
-    pub(crate) fn set_module_map(&self, url: ServoUrl, module: ModuleStatus) {
-        self.module_map.borrow_mut().insert(url, module);
+    pub(crate) fn set_module_map(&self, request: ModuleRequest, module: ModuleStatus) {
+        self.module_map.borrow_mut().insert(request, module);
     }
 
-    pub(crate) fn get_module_map_entry(&self, url: &ServoUrl) -> Option<ModuleStatus> {
-        self.module_map.borrow().get(url).cloned()
+    pub(crate) fn get_module_map_entry(&self, request: &ModuleRequest) -> Option<ModuleStatus> {
+        self.module_map.borrow().get(request).cloned()
     }
 
     #[expect(unsafe_code)]

--- a/components/script/module_loading.rs
+++ b/components/script/module_loading.rs
@@ -13,12 +13,12 @@ use std::collections::HashSet;
 use std::rc::Rc;
 
 use js::conversions::jsstr_to_string;
-use js::jsapi::{HandleValue as RawHandleValue, IsCyclicModule, JSObject};
+use js::jsapi::{HandleValue as RawHandleValue, IsCyclicModule, JSObject, ModuleType};
 use js::jsval::{ObjectValue, UndefinedValue};
 use js::realm::CurrentRealm;
 use js::rust::wrappers::{
-    GetModuleNamespace, GetRequestedModuleSpecifier, GetRequestedModulesCount, JS_GetModulePrivate,
-    ModuleEvaluate,
+    GetModuleNamespace, GetRequestedModuleSpecifier, GetRequestedModuleType,
+    GetRequestedModulesCount, JS_GetModulePrivate, ModuleEvaluate,
 };
 use js::rust::{HandleValue, IntoHandle};
 use net_traits::request::{Destination, Referrer};
@@ -145,6 +145,7 @@ fn inner_module_loading(
             // i. If AllImportAttributesSupported(request.[[Attributes]]) is false, then
             // Note: Gecko will call hasFirstUnsupportedAttributeKey on each module request,
             // GetRequestedModuleSpecifier will do it for us.
+            // In addition it will also check if specifier has an unknown module type.
             let jsstr = unsafe { GetRequestedModuleSpecifier(*cx, module_handle, index) };
 
             if jsstr.is_null() {
@@ -164,10 +165,12 @@ fn inner_module_loading(
             } else {
                 let specifier =
                     unsafe { jsstr_to_string(*cx, std::ptr::NonNull::new(jsstr).unwrap()) };
+                let module_type = unsafe { GetRequestedModuleType(*cx, module_handle, index) };
 
                 // ii. Else if module.[[LoadedModules]] contains a LoadedModuleRequest Record record
                 // such that ModuleRequestsEqual(record, request) is true, then
-                let loaded_module = module.find_descendant_inside_module_map(global, &specifier);
+                let loaded_module =
+                    module.find_descendant_inside_module_map(global, &specifier, module_type);
 
                 match loaded_module {
                     // 1. Perform InnerModuleLoading(state, record.[[Module]]).
@@ -183,6 +186,7 @@ fn inner_module_loading(
                             Some(module.clone()),
                             referrer.handle().into_handle(),
                             specifier,
+                            module_type,
                             state.load_state.clone(),
                             Payload::GraphRecord(state.clone()),
                         );
@@ -407,6 +411,7 @@ pub(crate) fn host_load_imported_module(
     referrer_module: Option<Rc<ModuleTree>>,
     referrer: RawHandleValue,
     specifier: String,
+    module_type: ModuleType,
     load_state: Option<Rc<LoadState>>,
     payload: Payload,
 ) {
@@ -541,12 +546,14 @@ pub(crate) fn host_load_imported_module(
     // Step 14 Fetch a single imported module script given url, fetchClient, destination, fetchOptions, settingsObject,
     // fetchReferrer, moduleRequest, and onSingleFetchComplete as defined below.
     // If loadState is not undefined and loadState.[[PerformFetch]] is not null, pass loadState.[[PerformFetch]] along as well.
+    // Note: we don't have access to the requested `ModuleObject`, so we pass only it's type.
     fetch_a_single_imported_module_script(
         url.unwrap(),
         fetch_client,
         destination,
         fetch_options,
         fetch_referrer,
+        module_type,
         on_single_fetch_complete,
     );
 }
@@ -558,6 +565,7 @@ fn fetch_a_single_imported_module_script(
     destination: Destination,
     options: ScriptFetchOptions,
     referrer: Referrer,
+    module_type: ModuleType,
     on_complete: impl FnOnce(Option<Rc<ModuleTree>>) + 'static,
 ) {
     // TODO Step 1. Assert: moduleRequest.[[Attributes]] does not contain any Record entry such that entry.[[Key]] is not "type",
@@ -565,8 +573,10 @@ fn fetch_a_single_imported_module_script(
 
     // TODO Step 2. Let moduleType be the result of running the module type from module request steps given moduleRequest.
 
-    // TODO Step 3. If the result of running the module type allowed steps given moduleType and settingsObject is false,
+    // Step 3. If the result of running the module type allowed steps given moduleType and settingsObject is false,
     // then run onComplete given null, and return.
+    // Note: We don't support CSS modules, and if module type was an unknown one,
+    // we would've bailed out earlier inside `inner_module_loading`.
 
     // Step 4. Fetch a single module script given url, fetchClient, destination, options, settingsObject, referrer,
     // moduleRequest, false, and onComplete. If performFetch was given, pass it along as well.
@@ -576,6 +586,7 @@ fn fetch_a_single_imported_module_script(
         destination,
         options,
         referrer,
+        Some(module_type),
         false,
         Some(IntroductionType::IMPORTED_MODULE),
         on_complete,

--- a/components/script/module_loading.rs
+++ b/components/script/module_loading.rs
@@ -575,8 +575,10 @@ fn fetch_a_single_imported_module_script(
 
     // Step 3. If the result of running the module type allowed steps given moduleType and settingsObject is false,
     // then run onComplete given null, and return.
-    // Note: We don't support CSS modules, and if module type was an unknown one,
-    // we would've bailed out earlier inside `inner_module_loading`.
+    match module_type {
+        ModuleType::Unknown => return on_complete(None),
+        ModuleType::JavaScript | ModuleType::JSON => (),
+    }
 
     // Step 4. Fetch a single module script given url, fetchClient, destination, options, settingsObject, referrer,
     // moduleRequest, false, and onComplete. If performFetch was given, pass it along as well.

--- a/components/script/module_loading.rs
+++ b/components/script/module_loading.rs
@@ -546,7 +546,7 @@ pub(crate) fn host_load_imported_module(
     // Step 14 Fetch a single imported module script given url, fetchClient, destination, fetchOptions, settingsObject,
     // fetchReferrer, moduleRequest, and onSingleFetchComplete as defined below.
     // If loadState is not undefined and loadState.[[PerformFetch]] is not null, pass loadState.[[PerformFetch]] along as well.
-    // Note: we don't have access to the requested `ModuleObject`, so we pass only it's type.
+    // Note: we don't have access to the requested `ModuleObject`, so we pass only its type.
     fetch_a_single_imported_module_script(
         url.unwrap(),
         fetch_client,

--- a/components/script/script_module.rs
+++ b/components/script/script_module.rs
@@ -360,7 +360,7 @@ impl ModuleTree {
     }
 
     #[expect(unsafe_code)]
-    /// <https://html.spec.whatwg.org/multipage/webappapis.html#creating-a-json-module-script>
+    /// <https://html.spec.whatwg.org/multipage/#creating-a-json-module-script>
     /// Although the CanGc argument appears unused, it represents the GC operations that
     /// can occur as part of compiling a script.
     fn crate_a_json_module_script(
@@ -888,14 +888,6 @@ impl ResourceTimingListener for ModuleContext {
     }
 }
 
-// TODO MimeClassifier::is_json is wrong?
-/// <https://mimesniff.spec.whatwg.org/#json-mime-type>
-fn is_json_mime_type(mime: &Mime) -> bool {
-    (mime.essence_str() == "application/json") ||
-        (mime.essence_str() == "text/json") ||
-        mime.suffix() == Some(mime::JSON)
-}
-
 #[expect(unsafe_code)]
 #[expect(non_snake_case)]
 /// A function to register module hooks (e.g. listening on resolving modules,
@@ -1282,7 +1274,7 @@ pub(crate) fn fetch_a_single_module_script(
     // when inspecting moduleRequest.[[Attributes]] in HostLoadImportedModule or fetch a single imported module script.
 
     // Step 4. Let moduleMap be settingsObject's module map.
-    let module_request = (url.clone(), module_type.clone());
+    let module_request = (url.clone(), module_type);
     let entry = global.get_module_map_entry(&module_request);
 
     let pending = match entry {

--- a/components/script/script_module.rs
+++ b/components/script/script_module.rs
@@ -888,6 +888,14 @@ impl ResourceTimingListener for ModuleContext {
     }
 }
 
+// TODO MimeClassifier::is_json is wrong?
+/// <https://mimesniff.spec.whatwg.org/#json-mime-type>
+fn is_json_mime_type(mime: &Mime) -> bool {
+    (mime.essence_str() == "application/json") ||
+        (mime.essence_str() == "text/json") ||
+        mime.suffix() == Some(mime::JSON)
+}
+
 #[expect(unsafe_code)]
 #[expect(non_snake_case)]
 /// A function to register module hooks (e.g. listening on resolving modules,

--- a/components/script/script_module.rs
+++ b/components/script/script_module.rs
@@ -1336,13 +1336,17 @@ pub(crate) fn fetch_a_single_module_script(
 
     // Step 8. Let request be a new request whose URL is url, mode is "cors", referrer is referrer, and client is fetchClient.
 
-    // Step 9. Set request's destination to the result of running the fetch destination from module type steps given destination and moduleType.
-
     // Step 10. If destination is "worker", "sharedworker", or "serviceworker", and isTopLevel is true,
     // then set request's mode to "same-origin".
     let mode = match destination {
         Destination::Worker | Destination::SharedWorker if is_top_level => RequestMode::SameOrigin,
         _ => RequestMode::CorsMode,
+    };
+
+    // Step 9. Set request's destination to the result of running the fetch destination from module type steps given destination and moduleType.
+    let destination = match module_type {
+        ModuleType::JSON => Destination::Json,
+        ModuleType::JavaScript | ModuleType::Unknown => destination,
     };
 
     // TODO Step 11. Set request's initiator type to "script".

--- a/components/shared/net/mime_classifier.rs
+++ b/components/shared/net/mime_classifier.rs
@@ -309,8 +309,8 @@ impl MimeClassifier {
     /// <https://mimesniff.spec.whatwg.org/#json-mime-type>
     pub fn is_json(mt: &Mime) -> bool {
         mt.suffix() == Some(mime::JSON) ||
-            (mt.subtype() == mime::JSON &&
-                (mt.type_() == mime::APPLICATION || mt.type_() == mime::TEXT))
+            mt.essence_str() == "application/json" ||
+            mt.essence_str() == "text/json"
     }
 
     /// <https://mimesniff.spec.whatwg.org/#font-mime-type>

--- a/tests/wpt/include.ini
+++ b/tests/wpt/include.ini
@@ -184,8 +184,6 @@ skip: true
       skip: false
       [the-script-element]
         skip: false
-        [json-module]
-          skip: true
         [moving-between-documents]
           skip: true
 [imagebitmap-renderingcontext]

--- a/tests/wpt/meta/content-security-policy/connect-src/connect-src-json-import-allowed.sub.html.ini
+++ b/tests/wpt/meta/content-security-policy/connect-src/connect-src-json-import-allowed.sub.html.ini
@@ -1,3 +1,0 @@
-[connect-src-json-import-allowed.sub.html]
-  [import should be allowed]
-    expected: FAIL

--- a/tests/wpt/meta/content-security-policy/connect-src/connect-src-json-import-blocked.sub.html.ini
+++ b/tests/wpt/meta/content-security-policy/connect-src/connect-src-json-import-blocked.sub.html.ini
@@ -1,4 +1,0 @@
-[connect-src-json-import-blocked.sub.html]
-  expected: TIMEOUT
-  [connect-src-json-import-blocked]
-    expected: TIMEOUT

--- a/tests/wpt/meta/fetch/metadata/generated/script-json-module-import-static.https.sub.html.ini
+++ b/tests/wpt/meta/fetch/metadata/generated/script-json-module-import-static.https.sub.html.ini
@@ -1,51 +1,6 @@
 [script-json-module-import-static.https.sub.html]
-  [sec-fetch-site - Same origin]
-    expected: FAIL
-
-  [sec-fetch-site - Cross-site]
-    expected: FAIL
-
-  [sec-fetch-site - Same site]
-    expected: FAIL
-
-  [sec-fetch-site - Same-Origin -> Cross-Site -> Same-Origin redirect]
-    expected: FAIL
-
   [sec-fetch-site - Same-Origin -> Same-Site -> Same-Origin redirect]
     expected: FAIL
 
-  [sec-fetch-site - Cross-Site -> Same Origin]
-    expected: FAIL
-
-  [sec-fetch-site - Cross-Site -> Same-Site]
-    expected: FAIL
-
-  [sec-fetch-site - Cross-Site -> Cross-Site]
-    expected: FAIL
-
-  [sec-fetch-site - Same-Origin -> Same Origin]
-    expected: FAIL
-
-  [sec-fetch-site - Same-Origin -> Same-Site]
-    expected: FAIL
-
-  [sec-fetch-site - Same-Origin -> Cross-Site]
-    expected: FAIL
-
   [sec-fetch-site - Same-Site -> Same Origin]
-    expected: FAIL
-
-  [sec-fetch-site - Same-Site -> Same-Site]
-    expected: FAIL
-
-  [sec-fetch-site - Same-Site -> Cross-Site]
-    expected: FAIL
-
-  [sec-fetch-mode]
-    expected: FAIL
-
-  [sec-fetch-dest]
-    expected: FAIL
-
-  [sec-fetch-user]
     expected: FAIL

--- a/tests/wpt/meta/fetch/metadata/generated/script-json-module-import-static.sub.html.ini
+++ b/tests/wpt/meta/fetch/metadata/generated/script-json-module-import-static.sub.html.ini
@@ -1,54 +1,6 @@
 [script-json-module-import-static.sub.html]
-  [sec-fetch-site - Not sent to non-trustworthy same-origin destination]
-    expected: FAIL
-
-  [sec-fetch-site - Not sent to non-trustworthy same-site destination]
-    expected: FAIL
-
-  [sec-fetch-site - Not sent to non-trustworthy cross-site destination]
-    expected: FAIL
-
-  [sec-fetch-mode - Not sent to non-trustworthy same-origin destination]
-    expected: FAIL
-
-  [sec-fetch-mode - Not sent to non-trustworthy same-site destination]
-    expected: FAIL
-
-  [sec-fetch-mode - Not sent to non-trustworthy cross-site destination]
-    expected: FAIL
-
-  [sec-fetch-dest - Not sent to non-trustworthy same-origin destination]
-    expected: FAIL
-
-  [sec-fetch-dest - Not sent to non-trustworthy same-site destination]
-    expected: FAIL
-
-  [sec-fetch-dest - Not sent to non-trustworthy cross-site destination]
-    expected: FAIL
-
-  [sec-fetch-user - Not sent to non-trustworthy same-origin destination]
-    expected: FAIL
-
-  [sec-fetch-user - Not sent to non-trustworthy same-site destination]
-    expected: FAIL
-
-  [sec-fetch-user - Not sent to non-trustworthy cross-site destination]
-    expected: FAIL
-
-  [sec-fetch-storage-access - Not sent to non-trustworthy same-origin destination]
-    expected: FAIL
-
-  [sec-fetch-storage-access - Not sent to non-trustworthy same-site destination]
-    expected: FAIL
-
-  [sec-fetch-storage-access - Not sent to non-trustworthy cross-site destination]
-    expected: FAIL
-
   [sec-fetch-site - HTTPS downgrade (header not sent)]
     expected: FAIL
 
   [sec-fetch-site - HTTPS upgrade]
-    expected: FAIL
-
-  [sec-fetch-site - HTTPS downgrade-upgrade]
     expected: FAIL

--- a/tests/wpt/meta/html/semantics/scripting-1/the-script-element/css-module/css-module-worker-test.html.ini
+++ b/tests/wpt/meta/html/semantics/scripting-1/the-script-element/css-module/css-module-worker-test.html.ini
@@ -1,6 +1,3 @@
 [css-module-worker-test.html]
   [A dynamic import CSS Module within a web worker should not load.]
     expected: TIMEOUT
-
-  [A dynamic import CSS Module within a web worker should not load and should not attempt to fetch the module.]
-    expected: FAIL

--- a/tests/wpt/meta/html/semantics/scripting-1/the-script-element/import-attributes/dynamic-import-with-attributes-argument.any.js.ini
+++ b/tests/wpt/meta/html/semantics/scripting-1/the-script-element/import-attributes/dynamic-import-with-attributes-argument.any.js.ini
@@ -2,10 +2,5 @@
   expected: ERROR
 
 [dynamic-import-with-attributes-argument.any.html]
-  [Dynamic import with an unsupported type attribute should fail]
-    expected: FAIL
-
 
 [dynamic-import-with-attributes-argument.any.worker.html]
-  [Dynamic import with an unsupported type attribute should fail]
-    expected: FAIL

--- a/tests/wpt/meta/html/semantics/scripting-1/the-script-element/json-module/charset-bom.any.js.ini
+++ b/tests/wpt/meta/html/semantics/scripting-1/the-script-element/json-module/charset-bom.any.js.ini
@@ -1,0 +1,18 @@
+[charset-bom.any.worker.html]
+  [UTF-16BE BOM should result in parse error in JSON module script]
+    expected: FAIL
+
+  [UTF-16LE BOM should result in parse error in JSON module script]
+    expected: FAIL
+
+
+[charset-bom.any.html]
+  [UTF-16BE BOM should result in parse error in JSON module script]
+    expected: FAIL
+
+  [UTF-16LE BOM should result in parse error in JSON module script]
+    expected: FAIL
+
+
+[charset-bom.any.sharedworker.html]
+  expected: ERROR

--- a/tests/wpt/meta/html/semantics/scripting-1/the-script-element/json-module/invalid-content-type.any.js.ini
+++ b/tests/wpt/meta/html/semantics/scripting-1/the-script-element/json-module/invalid-content-type.any.js.ini
@@ -1,0 +1,2 @@
+[invalid-content-type.any.sharedworker.html]
+  expected: ERROR

--- a/tests/wpt/meta/html/semantics/scripting-1/the-script-element/json-module/json-module-service-worker-test.https.html.ini
+++ b/tests/wpt/meta/html/semantics/scripting-1/the-script-element/json-module/json-module-service-worker-test.https.html.ini
@@ -1,0 +1,7 @@
+[json-module-service-worker-test.https.html]
+  expected: ERROR
+  [Trying to register a service worker with a top-level JSON Module should fail]
+    expected: NOTRUN
+
+  [JSON Module dynamic import should not load within the context of a service worker]
+    expected: NOTRUN

--- a/tests/wpt/meta/html/semantics/scripting-1/the-script-element/json-module/non-object.any.js.ini
+++ b/tests/wpt/meta/html/semantics/scripting-1/the-script-element/json-module/non-object.any.js.ini
@@ -1,0 +1,2 @@
+[non-object.any.sharedworker.html]
+  expected: ERROR

--- a/tests/wpt/meta/html/semantics/scripting-1/the-script-element/json-module/repeated-imports.any.js.ini
+++ b/tests/wpt/meta/html/semantics/scripting-1/the-script-element/json-module/repeated-imports.any.js.ini
@@ -1,0 +1,2 @@
+[repeated-imports.any.sharedworker.html]
+  expected: ERROR

--- a/tests/wpt/meta/html/semantics/scripting-1/the-script-element/module/dynamic-import/microtasks/css-import-in-worker.any.js.ini
+++ b/tests/wpt/meta/html/semantics/scripting-1/the-script-element/module/dynamic-import/microtasks/css-import-in-worker.any.js.ini
@@ -2,5 +2,3 @@
   expected: ERROR
 
 [css-import-in-worker.any.worker.html]
-  [import() should not drain the microtask queue if it fails because of the 'type: css' attribute in a worker]
-    expected: FAIL

--- a/tests/wpt/meta/html/semantics/scripting-1/the-script-element/module/dynamic-import/microtasks/with-import-assertions.any.js.ini
+++ b/tests/wpt/meta/html/semantics/scripting-1/the-script-element/module/dynamic-import/microtasks/with-import-assertions.any.js.ini
@@ -1,11 +1,6 @@
 [with-import-assertions.any.worker.html]
-  [import() should not drain the microtask queue if it fails while validating the 'type' attribute]
-    expected: FAIL
-
 
 [with-import-assertions.any.sharedworker.html]
   expected: ERROR
 
 [with-import-assertions.any.html]
-  [import() should not drain the microtask queue if it fails while validating the 'type' attribute]
-    expected: FAIL


### PR DESCRIPTION
With import attributes enabled we can now support non javascript modules, for now we are limited to json ones.
Switch `GlobalScope` `modulemap` to be keyed by the tuple url and module's type.

Testing: Enabled a new directory, new tests should pass
