### PR TITLE
layout: Consider `iframe` for `first-paint`

### DIFF
--- a/components/layout/display_list/mod.rs
+++ b/components/layout/display_list/mod.rs
@@ -739,10 +739,6 @@ impl Fragment {
                 let style = iframe.base.style();
                 match style.get_inherited_box().visibility {
                     Visibility::Visible => {
-                        // From <https://www.w3.org/TR/paint-timing/#mark-paint-timing>:
-                        // > A parent frame should not be aware of the paint events from its child iframes, and
-                        // > vice versa. This means that a frame that contains just iframes will have first paint
-                        // > (due to the enclosing boxes of the iframes) but no first contentful paint.
                         let rect = iframe
                             .base
                             .rect
@@ -758,6 +754,15 @@ impl Fragment {
                             },
                             iframe.pipeline_id.into(),
                             true,
+                        );
+                        // From <https://www.w3.org/TR/paint-timing/#mark-paint-timing>:
+                        // > A parent frame should not be aware of the paint events from its child iframes, and
+                        // > vice versa. This means that a frame that contains just iframes will have first paint
+                        // > (due to the enclosing boxes of the iframes) but no first contentful paint.
+                        builder.check_if_paintable(
+                            rect.to_webrender(),
+                            common.clip_rect,
+                            style.clone_opacity(),
                         );
                     },
                     Visibility::Hidden => (),

--- a/tests/wpt/meta/paint-timing/first-paint-only/child-painting-first-image.html.ini
+++ b/tests/wpt/meta/paint-timing/first-paint-only/child-painting-first-image.html.ini
@@ -1,3 +1,0 @@
-[child-painting-first-image.html]
-  [Parent frame ignores paint-timing events fired from child image rendering.]
-    expected: FAIL

--- a/tests/wpt/meta/paint-timing/first-paint-only/sibling-painting-first-image.html.ini
+++ b/tests/wpt/meta/paint-timing/first-paint-only/sibling-painting-first-image.html.ini
@@ -1,3 +1,0 @@
-[sibling-painting-first-image.html]
-  [Frame ignores paint-timing events fired from sibling frame.]
-    expected: FAIL


### PR DESCRIPTION
`iframe` should be considered for `first-paint`. 

TODO of: #42975
Synced: https://github.com/web-platform-tests/wpt/pull/58243
Refer for some history: #42498

Testing: 

- `wpt/paint-timing/first-paint-only/child-painting-first-image.html`
- `wpt/paint-timing/first-paint-only/sibling-painting-first-image.html`

Fixes: #42455
