### PR TITLE
profile: Implement MallocSizeOf for GenericCallback

### DIFF
--- a/components/shared/base/generic_channel.rs
+++ b/components/shared/base/generic_channel.rs
@@ -196,8 +196,11 @@ impl<T: Serialize> GenericSender<T> {
 }
 
 impl<T: Serialize> MallocSizeOf for GenericSender<T> {
-    fn size_of(&self, _ops: &mut MallocSizeOfOps) -> usize {
-        0
+    fn size_of(&self, ops: &mut MallocSizeOfOps) -> usize {
+        match &self.0 {
+            GenericSenderVariants::Ipc(ipc_sender) => ipc_sender.size_of(ops),
+            GenericSenderVariants::Crossbeam(sender) => sender.size_of(ops),
+        }
     }
 }
 

--- a/components/shared/profile/generic_callback.rs
+++ b/components/shared/profile/generic_callback.rs
@@ -3,12 +3,13 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 use base::generic_channel::SendResult;
+use malloc_size_of_derive::MallocSizeOf;
 use serde::{Deserialize, Serialize};
 
 use crate::time::{ProfilerCategory, ProfilerChan};
 use crate::time_profile;
 
-#[derive(Clone, Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize, MallocSizeOf)]
 pub struct GenericCallback<T>
 where
     T: Serialize + Send + 'static,

--- a/components/shared/profile/time.rs
+++ b/components/shared/profile/time.rs
@@ -17,7 +17,7 @@ pub struct TimerMetadata {
     pub incremental: TimerMetadataReflowType,
 }
 
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, MallocSizeOf)]
 pub struct ProfilerChan(pub Option<GenericSender<ProfilerMsg>>);
 
 impl ProfilerChan {


### PR DESCRIPTION
Implement MallocSizeOf for profile::GenericCallback.

Additionally, we implement a more acurate version of MallocSizeOf for GenericSender.

Signed-off-by: Narfinger <Narfinger@users.noreply.github.com>

Testing: Implementing traits do not need tests.
Fixes: https://github.com/servo/servo/issues/42110
