### PR TITLE
script: Remove `AsVoidPtr` and `AsCCharPtrPtr` traits

### DIFF
--- a/components/script/dom/windowproxy.rs
+++ b/components/script/dom/windowproxy.rs
@@ -739,7 +739,11 @@ impl WindowProxy {
             debug!("Transplanted proxy is {:p}.", new_js_proxy.get());
 
             // Transfer ownership of this browsing context from the old window proxy to the new one.
-            SetProxyReservedSlot(new_js_proxy.get(), 0, &PrivateValue(&raw const self as *const libc::c_void));
+            SetProxyReservedSlot(
+                new_js_proxy.get(),
+                0,
+                &PrivateValue(&raw const self as *const libc::c_void),
+            );
 
             // Notify the JS engine about the new window proxy binding.
             SetWindowProxy(*cx, window_jsobject, new_js_proxy.handle());

--- a/components/script/dom/windowproxy.rs
+++ b/components/script/dom/windowproxy.rs
@@ -742,7 +742,7 @@ impl WindowProxy {
             SetProxyReservedSlot(
                 new_js_proxy.get(),
                 0,
-                &PrivateValue(&raw const self as *const libc::c_void),
+                &PrivateValue(self as *const _ as *const libc::c_void),
             );
 
             // Notify the JS engine about the new window proxy binding.

--- a/components/script/dom/windowproxy.rs
+++ b/components/script/dom/windowproxy.rs
@@ -52,7 +52,7 @@ use crate::dom::bindings::reflector::{DomGlobal, DomObject, Reflector};
 use crate::dom::bindings::root::{Dom, DomRoot};
 use crate::dom::bindings::str::{DOMString, USVString};
 use crate::dom::bindings::trace::JSTraceable;
-use crate::dom::bindings::utils::{AsVoidPtr, get_array_index_from_id};
+use crate::dom::bindings::utils::get_array_index_from_id;
 use crate::dom::dissimilaroriginwindow::DissimilarOriginWindow;
 use crate::dom::document::Document;
 use crate::dom::element::Element;
@@ -215,7 +215,7 @@ impl WindowProxy {
             SetProxyReservedSlot(
                 js_proxy.get(),
                 0,
-                &PrivateValue((*window_proxy).as_void_ptr()),
+                &PrivateValue(&raw const (*window_proxy) as *const libc::c_void),
             );
 
             // Notify the JS engine about the new window proxy binding.
@@ -276,7 +276,7 @@ impl WindowProxy {
             SetProxyReservedSlot(
                 js_proxy.get(),
                 0,
-                &PrivateValue((*window_proxy).as_void_ptr()),
+                &PrivateValue(&raw const (*window_proxy) as *const libc::c_void),
             );
 
             // Notify the JS engine about the new window proxy binding.
@@ -739,7 +739,7 @@ impl WindowProxy {
             debug!("Transplanted proxy is {:p}.", new_js_proxy.get());
 
             // Transfer ownership of this browsing context from the old window proxy to the new one.
-            SetProxyReservedSlot(new_js_proxy.get(), 0, &PrivateValue(self.as_void_ptr()));
+            SetProxyReservedSlot(new_js_proxy.get(), 0, &PrivateValue(&raw const self as *const libc::c_void));
 
             // Notify the JS engine about the new window proxy binding.
             SetWindowProxy(*cx, window_jsobject, new_js_proxy.handle());

--- a/components/script_bindings/callback.rs
+++ b/components/script_bindings/callback.rs
@@ -26,7 +26,6 @@ use crate::reflector::DomObject;
 use crate::root::{Dom, DomRoot};
 use crate::script_runtime::{CanGc, JSContext};
 use crate::settings_stack::{GenericAutoEntryScript, GenericAutoIncumbentScript};
-use crate::utils::AsCCharPtrPtr;
 
 pub trait ThisReflector {
     fn jsobject(&self) -> *mut JSObject;
@@ -101,7 +100,7 @@ impl<D: DomTypes> CallbackObject<D> {
             assert!(AddRawValueRoot(
                 *cx,
                 self.permanent_js_root.get_unsafe(),
-                b"CallbackObject::root\n".as_c_char_ptr()
+                c"CallbackObject::root".as_ptr()
             ));
         }
     }

--- a/components/script_bindings/codegen/codegen.py
+++ b/components/script_bindings/codegen/codegen.py
@@ -4053,7 +4053,7 @@ let traps = ProxyTraps {{
     isConstructor: None,
 }};
 
-CreateProxyHandler(&traps, unsafe {{ Class.get() }}.as_void_ptr())\
+CreateProxyHandler(&traps, unsafe {{ Class.get() }} as *const _ as *const libc::c_void)\
 """)
 
 

--- a/components/script_bindings/import.rs
+++ b/components/script_bindings/import.rs
@@ -137,7 +137,7 @@ pub(crate) mod module {
     pub(crate) use crate::root::{MaybeUnreflectedDom, Root};
     pub(crate) use crate::script_runtime::CanGc;
     pub(crate) use crate::utils::{
-        AsVoidPtr, DOM_PROTO_UNFORGEABLE_HOLDER_SLOT, DOMClass, DOMJSClass, JSCLASS_DOM_GLOBAL,
+        DOM_PROTO_UNFORGEABLE_HOLDER_SLOT, DOMClass, DOMJSClass, JSCLASS_DOM_GLOBAL,
         ProtoOrIfaceArray, enumerate_global, enumerate_window, exception_to_promise,
         generic_getter, generic_lenient_getter, generic_lenient_setter, generic_method,
         generic_setter, generic_static_promise_method, get_array_index_from_id,

--- a/components/script_bindings/utils.rs
+++ b/components/script_bindings/utils.rs
@@ -556,16 +556,6 @@ pub(crate) unsafe fn trace_global(tracer: *mut JSTracer, obj: *mut JSObject) {
     }
 }
 
-// Generic method for returning libc::c_void from caller
-pub trait AsVoidPtr {
-    fn as_void_ptr(&self) -> *const libc::c_void;
-}
-impl<T> AsVoidPtr for T {
-    fn as_void_ptr(&self) -> *const libc::c_void {
-        self as *const T as *const libc::c_void
-    }
-}
-
 /// Enumerate lazy properties of a global object.
 /// Modeled after <https://github.com/mozilla/gecko-dev/blob/3fd619f47/dom/bindings/BindingUtils.cpp#L2814>
 pub(crate) unsafe extern "C" fn enumerate_global(

--- a/components/script_bindings/utils.rs
+++ b/components/script_bindings/utils.rs
@@ -566,17 +566,6 @@ impl<T> AsVoidPtr for T {
     }
 }
 
-// Generic method for returning c_char from caller
-pub(crate) trait AsCCharPtrPtr {
-    fn as_c_char_ptr(&self) -> *const c_char;
-}
-
-impl AsCCharPtrPtr for [u8] {
-    fn as_c_char_ptr(&self) -> *const c_char {
-        self as *const [u8] as *const c_char
-    }
-}
-
 /// Enumerate lazy properties of a global object.
 /// Modeled after <https://github.com/mozilla/gecko-dev/blob/3fd619f47/dom/bindings/BindingUtils.cpp#L2814>
 pub(crate) unsafe extern "C" fn enumerate_global(
@@ -613,7 +602,7 @@ pub(crate) unsafe extern "C" fn enumerate_window<D: DomTypes>(
         if !(interface.enabled)(&mut cx, obj) {
             continue;
         }
-        let s = JS_AtomizeStringN(cx.raw_cx(), name.as_c_char_ptr(), name.len());
+        let s = JS_AtomizeStringN(cx.raw_cx(), name.as_ptr() as *const c_char, name.len());
         rooted!(&in(cx) let id = StringId(s));
         if s.is_null() || !AppendToIdVector(props, id.handle().into()) {
             return false;


### PR DESCRIPTION
We migrated most uses some years ago, so let's finally remove them. It's more clear what we are doing if we inline stuff then hiding dangerous cast behind trait.

Testing: Covered by WPT, try run: https://github.com/sagudev/servo/actions/runs/21350967668