### PR TITLE
devtools: implement `clearBreakpoint`

### DIFF
--- a/components/devtools/actors/source.rs
+++ b/components/devtools/actors/source.rs
@@ -15,7 +15,7 @@ use servo_url::ServoUrl;
 
 use crate::StreamId;
 use crate::actor::{Actor, ActorError, ActorRegistry, DowncastableActorArc};
-use crate::actors::breakpoint::SetBreakpointRequestLocation;
+use crate::actors::breakpoint::BreakpointRequestLocation;
 use crate::protocol::ClientRequest;
 
 /// A `sourceForm` as used in responses to thread `sources` requests.
@@ -131,8 +131,8 @@ struct GetBreakpointPositionsCompressedReply {
 
 #[derive(Deserialize)]
 struct GetBreakpointPositionsQuery {
-    start: SetBreakpointRequestLocation,
-    end: SetBreakpointRequestLocation,
+    start: BreakpointRequestLocation,
+    end: BreakpointRequestLocation,
 }
 
 #[derive(Deserialize)]

--- a/components/script/dom/debuggerclearbreakpointevent.rs
+++ b/components/script/dom/debuggerclearbreakpointevent.rs
@@ -1,0 +1,76 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+use std::fmt::Debug;
+
+use dom_struct::dom_struct;
+use script_bindings::codegen::GenericBindings::DebuggerClearBreakpointEventBinding::DebuggerClearBreakpointEventMethods;
+
+use crate::dom::bindings::codegen::Bindings::EventBinding::Event_Binding::EventMethods;
+use crate::dom::bindings::reflector::reflect_dom_object;
+use crate::dom::bindings::root::DomRoot;
+use crate::dom::event::Event;
+use crate::dom::types::GlobalScope;
+use crate::script_runtime::CanGc;
+
+#[dom_struct]
+/// Event for Rust → JS calls in [`crate::dom::DebuggerGlobalScope`].
+pub(crate) struct DebuggerClearBreakpointEvent {
+    event: Event,
+    spidermonkey_id: u32,
+    script_id: u32,
+    offset: u32,
+}
+
+impl DebuggerClearBreakpointEvent {
+    pub(crate) fn new(
+        debugger_global: &GlobalScope,
+        spidermonkey_id: u32,
+        script_id: u32,
+        offset: u32,
+        can_gc: CanGc,
+    ) -> DomRoot<Self> {
+        let result = Box::new(Self {
+            event: Event::new_inherited(),
+            spidermonkey_id,
+            script_id,
+            offset,
+        });
+        let result = reflect_dom_object(result, debugger_global, can_gc);
+        result
+            .event
+            .init_event("clearBreakpoint".into(), false, false);
+
+        result
+    }
+}
+
+impl DebuggerClearBreakpointEventMethods<crate::DomTypeHolder> for DebuggerClearBreakpointEvent {
+    // check-tidy: no specs after this line
+    fn SpidermonkeyId(&self) -> u32 {
+        self.spidermonkey_id
+    }
+
+    fn ScriptId(&self) -> u32 {
+        self.script_id
+    }
+
+    fn Offset(&self) -> u32 {
+        self.offset
+    }
+
+    fn IsTrusted(&self) -> bool {
+        self.event.IsTrusted()
+    }
+}
+
+impl Debug for DebuggerClearBreakpointEvent {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("DebuggerClearBreakpointEvent")
+            .field("spidermonkey_id", &self.spidermonkey_id)
+            .field("script_id", &self.script_id)
+            .field("offset", &self.offset)
+            .finish()
+    }
+}

--- a/components/script/dom/debuggerglobalscope.rs
+++ b/components/script/dom/debuggerglobalscope.rs
@@ -31,6 +31,7 @@ use crate::dom::bindings::error::report_pending_exception;
 use crate::dom::bindings::inheritance::Castable;
 use crate::dom::bindings::root::DomRoot;
 use crate::dom::bindings::utils::define_all_exposed_interfaces;
+use crate::dom::debuggerclearbreakpointevent::DebuggerClearBreakpointEvent;
 use crate::dom::debuggerpauseevent::DebuggerPauseEvent;
 use crate::dom::debuggersetbreakpointevent::DebuggerSetBreakpointEvent;
 use crate::dom::globalscope::GlobalScope;
@@ -223,6 +224,26 @@ impl DebuggerGlobalScope {
         assert!(
             event.fire(self.upcast(), can_gc),
             "Guaranteed by DebuggerPauseEvent::new"
+        );
+    }
+
+    pub(crate) fn fire_clear_breakpoint(
+        &self,
+        can_gc: CanGc,
+        spidermonkey_id: u32,
+        script_id: u32,
+        offset: u32,
+    ) {
+        let event = DomRoot::upcast::<Event>(DebuggerClearBreakpointEvent::new(
+            self.upcast(),
+            spidermonkey_id,
+            script_id,
+            offset,
+            can_gc,
+        ));
+        assert!(
+            event.fire(self.upcast(), can_gc),
+            "Guaranteed by DebuggerClearBreakpointEvent::new"
         );
     }
 }

--- a/components/script/dom/mod.rs
+++ b/components/script/dom/mod.rs
@@ -255,6 +255,7 @@ pub(crate) mod datatransfer;
 pub(crate) mod datatransferitem;
 pub(crate) mod datatransferitemlist;
 pub(crate) mod debuggeradddebuggeeevent;
+pub(crate) mod debuggerclearbreakpointevent;
 pub(crate) mod debuggergetpossiblebreakpointsevent;
 pub(crate) mod debuggerglobalscope;
 pub(crate) mod debuggerpauseevent;

--- a/components/script/script_thread.rs
+++ b/components/script/script_thread.rs
@@ -2181,6 +2181,14 @@ impl ScriptThread {
                     offset,
                 );
             },
+            DevtoolScriptControlMsg::ClearBreakpoint(spidermonkey_id, script_id, offset) => {
+                self.debugger_global.fire_clear_breakpoint(
+                    CanGc::from_cx(cx),
+                    spidermonkey_id,
+                    script_id,
+                    offset,
+                );
+            },
             DevtoolScriptControlMsg::Pause(result_sender) => {
                 self.debugger_global
                     .fire_pause(CanGc::from_cx(cx), result_sender);

--- a/components/script_bindings/webidls/DebuggerClearBreakpointEvent.webidl
+++ b/components/script_bindings/webidls/DebuggerClearBreakpointEvent.webidl
@@ -1,0 +1,12 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+// This interface is entirely internal to Servo, and should not be accessible to
+// web pages.
+[Exposed=DebuggerGlobalScope]
+interface DebuggerClearBreakpointEvent : Event {
+    readonly attribute unsigned long spidermonkeyId;
+    readonly attribute unsigned long scriptId;
+    readonly attribute unsigned long offset;
+};

--- a/components/shared/devtools/lib.rs
+++ b/components/shared/devtools/lib.rs
@@ -309,6 +309,7 @@ pub enum DevtoolScriptControlMsg {
 
     GetPossibleBreakpoints(u32, GenericSender<Vec<RecommendedBreakpointLocation>>),
     SetBreakpoint(u32, u32, u32),
+    ClearBreakpoint(u32, u32, u32),
     Pause(GenericSender<PauseFrameResult>),
 }
 

--- a/resources/debugger.js
+++ b/resources/debugger.js
@@ -100,6 +100,7 @@ addEventListener("pause", event => {
 });
 
 // <https://firefox-source-docs.mozilla.org/js/Debugger/Debugger.Script.html#clearbreakpoint-handler-offset>
+// There may be more than one breakpoint at the same offset with different handlers, but we don’t handle that case for now.
 addEventListener("clearBreakpoint", event => {
     const {spidermonkeyId, scriptId, offset} = event;
     const script = sourceIdsToScripts.get(spidermonkeyId);
@@ -107,7 +108,7 @@ addEventListener("clearBreakpoint", event => {
     function setClearBreakpointRecursive(script) {
         if (script.sourceStart == scriptId) {
             // <https://firefox-source-docs.mozilla.org/js/Debugger/Debugger.Script.html#clearallbreakpoints-offset>
-            // If the instance refers to a JSScript, remove all breakpoints set in this script
+            // If the instance refers to a JSScript, remove all breakpoints set in this script at that offset.
             script.clearAllBreakpoints(offset);
             return;
         }

--- a/resources/debugger.js
+++ b/resources/debugger.js
@@ -98,3 +98,22 @@ addEventListener("pause", event => {
         getFrameResult(event, result);
     };
 });
+
+// <https://firefox-source-docs.mozilla.org/js/Debugger/Debugger.Script.html#clearbreakpoint-handler-offset>
+addEventListener("clearBreakpoint", event => {
+    const {spidermonkeyId, scriptId, offset} = event;
+    const script = sourceIdsToScripts.get(spidermonkeyId);
+
+    function setClearBreakpointRecursive(script) {
+        if (script.sourceStart == scriptId) {
+            // <https://firefox-source-docs.mozilla.org/js/Debugger/Debugger.Script.html#clearallbreakpoints-offset>
+            // If the instance refers to a JSScript, remove all breakpoints set in this script
+            script.clearAllBreakpoints(offset);
+            return;
+        }
+        for (const child of script.getChildScripts()) {
+            setClearBreakpointRecursive(child);
+        }
+    }
+    setClearBreakpointRecursive(script);
+});


### PR DESCRIPTION
Add an event listener for `clearBreakpoint` to `debugger.js` and the necessary glue to access it from the `devtools` crate.

Testing: `./mach test-devtools` and manual testing.
Fixes: Part of: https://github.com/servo/servo/issues/36027
