### PR TITLE
ci: Disable self-hosted WPT runs

### DIFF
--- a/.github/workflows/linux-wpt.yml
+++ b/.github/workflows/linux-wpt.yml
@@ -61,7 +61,7 @@ jobs:
           # <https://github.com/servo/servo/settings/variables/actions>
           NO_SELF_HOSTED_RUNNERS: ${{ vars.NO_SELF_HOSTED_RUNNERS }}
           # Any other boolean conditions that disable self-hosted runners go here.
-          force-github-hosted-runner: ${{ inputs.wpt-args != '' }}
+          force-github-hosted-runner: true
   linux-wpt:
     needs:
       - runner-select


### PR DESCRIPTION
This has caused a regression in job time. This change disables the
self-hosted WPT runners until the regression is addressed.

Testing: This is a CI change so it is the test of itself.
Fixes: #42121.
