### PR TITLE
fonts: Ensure detailed glyphs are also added to the glyph buffer

### DIFF
--- a/components/fonts/glyph.rs
+++ b/components/fonts/glyph.rs
@@ -454,6 +454,8 @@ impl GlyphStore {
             character_count,
             is_word_separator,
         });
+        self.glyphs
+            .push(GlyphEntry::complex(self.detailed_glyphs.len() - 1));
     }
 
     fn extend_previous_glyph_by_character(&mut self) {

--- a/tests/wpt/meta/css/WOFF2/header-totalsfntsize-001.xht.ini
+++ b/tests/wpt/meta/css/WOFF2/header-totalsfntsize-001.xht.ini
@@ -1,0 +1,2 @@
+[header-totalsfntsize-001.xht]
+  expected: FAIL

--- a/tests/wpt/meta/css/WOFF2/tabledata-glyf-bbox-001.xht.ini
+++ b/tests/wpt/meta/css/WOFF2/tabledata-glyf-bbox-001.xht.ini
@@ -1,0 +1,2 @@
+[tabledata-glyf-bbox-001.xht]
+  expected: FAIL

--- a/tests/wpt/meta/css/WOFF2/tabledata-glyf-origlength-003.xht.ini
+++ b/tests/wpt/meta/css/WOFF2/tabledata-glyf-origlength-003.xht.ini
@@ -1,0 +1,2 @@
+[tabledata-glyf-origlength-003.xht]
+  expected: FAIL

--- a/tests/wpt/meta/css/css-fonts/math-script-level-and-math-style/math-script-level-auto-and-math-style-002.tentative.html.ini
+++ b/tests/wpt/meta/css/css-fonts/math-script-level-and-math-style/math-script-level-auto-and-math-style-002.tentative.html.ini
@@ -1,0 +1,2 @@
+[math-script-level-auto-and-math-style-002.tentative.html]
+  expected: FAIL

--- a/tests/wpt/meta/css/css-text/shaping/shaping-arabic-diacritics-001.html.ini
+++ b/tests/wpt/meta/css/css-text/shaping/shaping-arabic-diacritics-001.html.ini
@@ -1,2 +1,0 @@
-[shaping-arabic-diacritics-001.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-text/text-transform/text-transform-upperlower-006.html.ini
+++ b/tests/wpt/meta/css/css-text/text-transform/text-transform-upperlower-006.html.ini
@@ -1,2 +1,0 @@
-[text-transform-upperlower-006.html]
-  expected: FAIL


### PR DESCRIPTION
This changes fixes a major issue with #42105 where detailed glyphs were
added to the detailed glyph vector, but did not have corresponding
entries in the glyph buffer.

Testing: This undoes some of the test result changes from #42105. It
turns out that some were real regressions.
