### PR TITLE
layout: Do not enable `letter-spacing` for cursive scripts

### DIFF
--- a/tests/wpt/meta/css/css-text/letter-spacing/letter-spacing-cursive-001.html.ini
+++ b/tests/wpt/meta/css/css-text/letter-spacing/letter-spacing-cursive-001.html.ini
@@ -1,2 +1,0 @@
-[letter-spacing-cursive-001.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-text/letter-spacing/letter-spacing-cursive-002.html.ini
+++ b/tests/wpt/meta/css/css-text/letter-spacing/letter-spacing-cursive-002.html.ini
@@ -1,2 +1,0 @@
-[letter-spacing-cursive-002.html]
-  expected: FAIL


### PR DESCRIPTION
This is specified in CSS Text 3.

Testing: This fixes a WPT test.
