### PR TITLE
devcontainer: Use our own dockerfile

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,48 @@
+# Dockerfile for the servo devcontainer environment.
+# Note that the build-context is the repository root.
+# We use a multi-stage build to keep the final image size down.
+
+# We use a prebuilt image for `uv` to speed up builds and later copy the artifacts
+# into the final stage.
+FROM ghcr.io/astral-sh/uv:latest AS uv
+
+FROM ubuntu:24.04 AS base
+
+# Install apt dependencies.
+RUN --mount=type=bind,source=python/servo/platform/linux_packages,target=/tmp/linux_packages,readonly \
+    apt-get update \
+    &&  /tmp/linux_packages/generate_pkg_list.sh /tmp/linux_packages/apt/* | xargs apt-get install -y --no-install-recommends \
+    && curl --version
+
+# Please keep `RUST_VERSION` in sync with the `rust-toolchain.toml` file.
+ENV RUSTUP_HOME=/usr/local/rustup \
+    CARGO_HOME=/usr/local/cargo \
+    PATH=/usr/local/cargo/bin:$PATH \
+    UV_TOOL_BIN_DIR=/usr/local/bin \
+    RUST_VERSION=1.91.0
+
+# Keep the list of components in sync with `rust-toolchain.toml` file.
+RUN curl https://sh.rustup.rs -sSf \
+        | sh -s -- --default-toolchain ${RUST_VERSION} -y --component clippy,llvm-tools,llvm-tools-preview,rustc-dev,rustfmt,rust-src \
+    && \
+    rustup --version; \
+    cargo --version; \
+    rustc --version;
+
+# prebuilt rust tools we use
+FROM base AS rust_builder
+
+# TODO: We would need to use `ARG` and install specific versions, to ensure
+# that the tools are updated and not always cached.
+RUN cargo install cargo-deny cargo-nextest taplo-cli cargo-about --locked
+
+
+FROM base AS final
+
+COPY --from=rust_builder \
+    /usr/local/cargo/bin/cargo-deny \
+    /usr/local/cargo/bin/cargo-nextest \
+    /usr/local/cargo/bin/taplo \
+    /usr/local/cargo/bin/cargo-about \
+    /usr/local/cargo/bin/
+COPY --from=uv /uv /uvx /bin/

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -2,33 +2,17 @@
 // README at: https://github.com/devcontainers/templates/tree/main/src/ubuntu
 {
 	"name": "Ubuntu",
-	"image": "mcr.microsoft.com/devcontainers/base:noble",
-	"features": {
-		"ghcr.io/devcontainers/features/rust:1": {
-			"version": "1.91.0",
-			"profile": "default",
-			"components": "clippy,llvm-tools,rustc-dev,rust-analyzer,rust-src,rustfmt"
-		},
-		"ghcr.io/devcontainers-extra/features/uv:1": {
-			"version": "latest"
-		}
+	"build": {
+		"dockerfile": "Dockerfile",
+		"context": ".."
 	},
-	// Uncomment the following when using podman (rootless)
-	// Update the uid and gid, to your local users uid and gid (run `echo $UID` and `echo $GID`)
-	// "runArgs": ["--userns=keep-id:uid=1000,gid=1000"],
-	// "containerUser": "vscode",
-	
-	// Uncomment the following when using rootless docker 
-	// "containerUser": "root",
-	// "remoteUser": "root",
-	// "updateRemoteUserUID": false,
 
 
-	// Use 'postCreateCommand' to run commands after the container is created.
-	// This takes more time on the first run compared to pulling a prebuilt image layer,
-	// but makes sure the bootstrapped dependencies are always up to date.
+	// Most dependencies are installed in the image, but we run mach bootstrap to ensure
+	// the environment matches what's expected in the current servo version, which might 
+	// have changed since the image was built.
 	"postCreateCommand":
-		"./mach bootstrap --force",
+		"./mach bootstrap --yes",
 
 	"containerEnv": {
 		"CC": "clang",

--- a/python/servo/platform/linux_packages/apt/apt_common.txt
+++ b/python/servo/platform/linux_packages/apt/apt_common.txt
@@ -4,6 +4,7 @@
 # Please keep these in sync with the packages in the book, using the instructions in the README.md
 # in this folder.
 build-essential
+ca-certificates
 ccache
 clang
 cmake


### PR DESCRIPTION
Switch to using our own dockerfile, and install the required dependencies into our image.
In follow-ups we can build the docker image in CI, so that users can download a prebuilt docker image to save time.

Testing: Manually tested by opening servo in the devcontainer and running `./mach build`

