### PR TITLE
Update `servo.exe.manifest` for servoshell

### DIFF
--- a/ports/servoshell/platform/windows/servo.exe.manifest
+++ b/ports/servoshell/platform/windows/servo.exe.manifest
@@ -8,9 +8,6 @@
 
   <compatibility xmlns="urn:schemas-microsoft-com:compatibility.v1">
     <application>
-      <supportedOS Id="{35138b9a-5d96-4fbd-8e2d-a2440225f93a}"/> <!-- Windows 7 -->
-      <supportedOS Id="{4a2f28e3-53b9-4441-ba9c-d69d4a4a6e38}"/> <!-- Windows 8 -->
-      <supportedOS Id="{1f676c76-80e1-4239-95bb-83d0f6d0da78}"/> <!-- Windows 8.1 -->
       <supportedOS Id="{8e0f7a12-bfb3-4fe8-b9a5-48fd50a15a9a}"/> <!-- Windows 10 and 11 -->
     </application>
   </compatibility>

--- a/ports/servoshell/platform/windows/servo.exe.manifest
+++ b/ports/servoshell/platform/windows/servo.exe.manifest
@@ -11,7 +11,7 @@
       <supportedOS Id="{35138b9a-5d96-4fbd-8e2d-a2440225f93a}"/> <!-- Windows 7 -->
       <supportedOS Id="{4a2f28e3-53b9-4441-ba9c-d69d4a4a6e38}"/> <!-- Windows 8 -->
       <supportedOS Id="{1f676c76-80e1-4239-95bb-83d0f6d0da78}"/> <!-- Windows 8.1 -->
-      <supportedOS Id="{8e0f7a12-bfb3-4fe8-b9a5-48fd50a15a9a}"/> <!-- Windows 10 -->
+      <supportedOS Id="{8e0f7a12-bfb3-4fe8-b9a5-48fd50a15a9a}"/> <!-- Windows 10 and 11 -->
     </application>
   </compatibility>
 

--- a/ports/servoshell/platform/windows/servo.exe.manifest
+++ b/ports/servoshell/platform/windows/servo.exe.manifest
@@ -4,7 +4,7 @@
           xmlns:asmv3="urn:schemas-microsoft-com:asm.v3">
   <assemblyIdentity type="win32"
                     name="servo.Servo"
-                    version="0.1.0.0"/>
+                    version="0.0.4.0"/>
 
   <compatibility xmlns="urn:schemas-microsoft-com:compatibility.v1">
     <application>

--- a/python/servo/package_commands.py
+++ b/python/servo/package_commands.py
@@ -446,10 +446,9 @@ class PackageCommands(CommandBase):
                 print("To bypass this check, use --allow-dirty.")
                 return 1
         print("\r ➤  Bumping version number...")
-        # Todo: Also update assemblyIdentity.version in ports/servoshell/platform/windows/servo.exe.manifest
-        #   Note: assemblyIdentity requires 4 version components, while we usually use 3.
         replacements = {
             "ports/servoshell/Cargo.toml": r'^version ?= ?"(?P<version>.*?)"',
+            "ports/servoshell/platform/windows/servo.exe.manifest": r'assemblyIdentity[^\/>]+version="(?P<version>.*?).0\"[^\/>]*\/>',
             "support/windows/Servo.wxs.mako": r'<Product(.|\n)*Version="(?P<version>.*?)".*>',
             "Info.plist": r"<key>CFBundleShortVersionString</key>\n\s*<string>(?P<version>.*?)</string>",
             "support/android/apk/servoapp/build.gradle.kts": r'versionName\s*=\s*"(?P<version>.*?)"',


### PR DESCRIPTION
Bumps servoshell version to actual version and updates `./mach release` to update it.