### PR TITLE
script: Add basic memory pressure reporting to SpiderMonkey

### DIFF
--- a/components/domobject_derive/lib.rs
+++ b/components/domobject_derive/lib.rs
@@ -54,8 +54,8 @@ fn expand_dom_object(input: syn::DeriveInput) -> proc_macro2::TokenStream {
         }
 
         impl #impl_generics crate::MutDomObject for #name #ty_generics #where_clause {
-            unsafe fn init_reflector(&self, obj: *mut js::jsapi::JSObject) {
-                self.#first_field_name.init_reflector(obj);
+            unsafe fn init_reflector(&self, obj: *mut js::jsapi::JSObject, size: usize) {
+                self.#first_field_name.init_reflector(obj, size);
             }
         }
 

--- a/components/domobject_derive/lib.rs
+++ b/components/domobject_derive/lib.rs
@@ -54,8 +54,8 @@ fn expand_dom_object(input: syn::DeriveInput) -> proc_macro2::TokenStream {
         }
 
         impl #impl_generics crate::MutDomObject for #name #ty_generics #where_clause {
-            unsafe fn init_reflector(&self, obj: *mut js::jsapi::JSObject, size: usize) {
-                self.#first_field_name.init_reflector(obj, size);
+            unsafe fn init_reflector<Actual>(&self, obj: *mut js::jsapi::JSObject) {
+                self.#first_field_name.init_reflector::<Actual>(obj);
             }
         }
 

--- a/components/script/dom/canvas/2d/canvasrenderingcontext2d.rs
+++ b/components/script/dom/canvas/2d/canvasrenderingcontext2d.rs
@@ -110,8 +110,9 @@ impl CanvasContext for CanvasRenderingContext2D {
     }
 
     fn resize(&self) {
-        self.reflector_
-            .set_new_size(self.size().cast::<usize>().area() + size_of::<Box<Self>>() + size_of::<Self>());
+        self.reflector_.set_new_size(
+            self.size().cast::<usize>().area() + size_of::<Box<Self>>() + size_of::<Self>(),
+        );
         self.canvas_state.set_bitmap_dimensions(self.size().cast());
     }
 

--- a/components/script/dom/canvas/2d/canvasrenderingcontext2d.rs
+++ b/components/script/dom/canvas/2d/canvasrenderingcontext2d.rs
@@ -110,6 +110,8 @@ impl CanvasContext for CanvasRenderingContext2D {
     }
 
     fn resize(&self) {
+        self.reflector_
+            .set_new_size(self.size().cast::<usize>().area() + size_of::<Box<Self>>() + size_of::<Self>());
         self.canvas_state.set_bitmap_dimensions(self.size().cast());
     }
 

--- a/components/script/dom/canvas/2d/canvasrenderingcontext2d.rs
+++ b/components/script/dom/canvas/2d/canvasrenderingcontext2d.rs
@@ -7,6 +7,7 @@ use canvas_traits::canvas::{Canvas2dMsg, CanvasId};
 use dom_struct::dom_struct;
 use euclid::default::Size2D;
 use pixels::Snapshot;
+use script_bindings::reflector::AssociatedMemory;
 use servo_url::ServoUrl;
 use webrender_api::ImageKey;
 
@@ -39,7 +40,7 @@ use crate::script_runtime::CanGc;
 // https://html.spec.whatwg.org/multipage/#canvasrenderingcontext2d
 #[dom_struct]
 pub(crate) struct CanvasRenderingContext2D {
-    reflector_: Reflector,
+    reflector_: Reflector<AssociatedMemory>,
     canvas: HTMLCanvasElementOrOffscreenCanvas,
     canvas_state: CanvasState,
 }
@@ -110,9 +111,8 @@ impl CanvasContext for CanvasRenderingContext2D {
     }
 
     fn resize(&self) {
-        self.reflector_.set_new_size(
-            self.size().cast::<usize>().area() + size_of::<Box<Self>>() + size_of::<Self>(),
-        );
+        self.reflector_
+            .update_memory_size(self, self.size().cast::<usize>().area());
         self.canvas_state.set_bitmap_dimensions(self.size().cast());
     }
 

--- a/components/script/dom/promise.rs
+++ b/components/script/dom/promise.rs
@@ -85,6 +85,8 @@ impl PromiseHelper for Rc<Promise> {
 impl Drop for Promise {
     #[expect(unsafe_code)]
     fn drop(&mut self) {
+        let reflector = script_bindings::reflector::DomObject::reflector(self);
+        reflector.drop_memory(self);
         unsafe {
             let object = self.permanent_js_root.get().to_object();
             assert!(!object.is_null());

--- a/components/script/dom/promise.rs
+++ b/components/script/dom/promise.rs
@@ -140,7 +140,7 @@ impl Promise {
                 permanent_js_root: Heap::default(),
             };
             let promise = Rc::new(promise);
-            promise.init_reflector(obj.get());
+            promise.init_reflector(obj.get(), size_of::<Promise>());
             promise.initialize(cx);
             promise
         }

--- a/components/script/dom/promise.rs
+++ b/components/script/dom/promise.rs
@@ -140,7 +140,7 @@ impl Promise {
                 permanent_js_root: Heap::default(),
             };
             let promise = Rc::new(promise);
-            promise.init_reflector(obj.get(), size_of::<Promise>());
+            promise.init_reflector::<Promise>(obj.get());
             promise.initialize(cx);
             promise
         }

--- a/components/script/dom/webgl/webglquery.rs
+++ b/components/script/dom/webgl/webglquery.rs
@@ -184,6 +184,8 @@ impl WebGLQuery {
 
 impl Drop for WebGLQuery {
     fn drop(&mut self) {
+        let reflector = script_bindings::reflector::DomObject::reflector(self);
+        reflector.drop_memory(self);
         self.delete(Operation::Fallible);
     }
 }

--- a/components/script/dom/webgl/webglrenderbuffer.rs
+++ b/components/script/dom/webgl/webglrenderbuffer.rs
@@ -280,6 +280,8 @@ impl WebGLRenderbuffer {
 
 impl Drop for WebGLRenderbuffer {
     fn drop(&mut self) {
+        let reflector = script_bindings::reflector::DomObject::reflector(self);
+        reflector.drop_memory(self);
         self.delete(Operation::Fallible);
     }
 }

--- a/components/script/dom/webgl/webglsampler.rs
+++ b/components/script/dom/webgl/webglsampler.rs
@@ -181,6 +181,8 @@ impl WebGLSampler {
 
 impl Drop for WebGLSampler {
     fn drop(&mut self) {
+        let reflector = script_bindings::reflector::DomObject::reflector(self);
+        reflector.drop_memory(self);
         self.delete(Operation::Fallible);
     }
 }

--- a/components/script/dom/webgl/webglshader.rs
+++ b/components/script/dom/webgl/webglshader.rs
@@ -283,6 +283,8 @@ impl WebGLShader {
 
 impl Drop for WebGLShader {
     fn drop(&mut self) {
+        let reflector = script_bindings::reflector::DomObject::reflector(self);
+        reflector.drop_memory(self);
         self.mark_for_deletion(Operation::Fallible);
     }
 }

--- a/components/script/dom/webgl/webglsync.rs
+++ b/components/script/dom/webgl/webglsync.rs
@@ -130,6 +130,8 @@ impl WebGLSync {
 
 impl Drop for WebGLSync {
     fn drop(&mut self) {
+        let reflector = script_bindings::reflector::DomObject::reflector(self);
+        reflector.drop_memory(self);
         self.delete(Operation::Fallible);
     }
 }

--- a/components/script/dom/webgl/webgltexture.rs
+++ b/components/script/dom/webgl/webgltexture.rs
@@ -589,6 +589,8 @@ impl WebGLTexture {
 
 impl Drop for WebGLTexture {
     fn drop(&mut self) {
+        let reflector = script_bindings::reflector::DomObject::reflector(self);
+        reflector.drop_memory(self);
         self.delete(Operation::Fallible);
     }
 }

--- a/components/script/dom/webgl/webgltransformfeedback.rs
+++ b/components/script/dom/webgl/webgltransformfeedback.rs
@@ -127,6 +127,8 @@ impl WebGLTransformFeedback {
 
 impl Drop for WebGLTransformFeedback {
     fn drop(&mut self) {
+        let reflector = script_bindings::reflector::DomObject::reflector(self);
+        reflector.drop_memory(self);
         self.delete(Operation::Fallible);
     }
 }

--- a/components/script/dom/webgpu/gpubuffer.rs
+++ b/components/script/dom/webgpu/gpubuffer.rs
@@ -185,7 +185,9 @@ impl GPUBuffer {
 
 impl Drop for GPUBuffer {
     fn drop(&mut self) {
-        self.Destroy()
+        self.Destroy();
+        let reflector = script_bindings::reflector::DomObject::reflector(self);
+        reflector.drop_memory(self);
     }
 }
 

--- a/components/script/dom/webgpu/gpucommandbuffer.rs
+++ b/components/script/dom/webgpu/gpucommandbuffer.rs
@@ -69,6 +69,8 @@ impl Drop for GPUCommandBuffer {
                 self.command_buffer.0, e
             );
         }
+        let reflector = script_bindings::reflector::DomObject::reflector(self);
+        reflector.drop_memory(self);
     }
 }
 

--- a/components/script/dom/webgpu/gpucomputepassencoder.rs
+++ b/components/script/dom/webgpu/gpucomputepassencoder.rs
@@ -155,5 +155,7 @@ impl Drop for GPUComputePassEncoder {
         {
             warn!("Failed to send WebGPURequest::DropComputePass with {e:?}");
         }
+        let reflector = script_bindings::reflector::DomObject::reflector(self);
+        reflector.drop_memory(self);
     }
 }

--- a/components/script/dom/webgpu/gpucomputepipeline.rs
+++ b/components/script/dom/webgpu/gpucomputepipeline.rs
@@ -158,5 +158,7 @@ impl Drop for GPUComputePipeline {
                 self.compute_pipeline.0, e
             );
         };
+        let reflector = script_bindings::reflector::DomObject::reflector(self);
+        reflector.drop_memory(self);
     }
 }

--- a/components/script/dom/webgpu/gpudevice.rs
+++ b/components/script/dom/webgpu/gpudevice.rs
@@ -738,5 +738,7 @@ impl Drop for GPUDevice {
         {
             warn!("Failed to send DropDevice ({:?}) ({})", self.device.0, e);
         }
+        let reflector = script_bindings::reflector::DomObject::reflector(self);
+        reflector.drop_memory(self);
     }
 }

--- a/components/script/dom/webgpu/gpupipelinelayout.rs
+++ b/components/script/dom/webgpu/gpupipelinelayout.rs
@@ -144,5 +144,7 @@ impl Drop for GPUPipelineLayout {
                 self.pipeline_layout.0, e
             );
         }
+        let reflector = script_bindings::reflector::DomObject::reflector(self);
+        reflector.drop_memory(self);
     }
 }

--- a/components/script/dom/webgpu/gpurenderbundle.rs
+++ b/components/script/dom/webgpu/gpurenderbundle.rs
@@ -93,5 +93,7 @@ impl Drop for GPURenderBundle {
                 self.render_bundle.0, e
             );
         }
+        let reflector = script_bindings::reflector::DomObject::reflector(self);
+        reflector.drop_memory(self);
     }
 }

--- a/components/script/dom/webgpu/gpurenderpassencoder.rs
+++ b/components/script/dom/webgpu/gpurenderpassencoder.rs
@@ -248,5 +248,7 @@ impl Drop for GPURenderPassEncoder {
         {
             warn!("Failed to send WebGPURequest::DropRenderPass with {e:?}");
         }
+        let reflector = script_bindings::reflector::DomObject::reflector(self);
+        reflector.drop_memory(self);
     }
 }

--- a/components/script/dom/webgpu/gpurenderpipeline.rs
+++ b/components/script/dom/webgpu/gpurenderpipeline.rs
@@ -147,5 +147,7 @@ impl Drop for GPURenderPipeline {
                 self.render_pipeline.0, e
             );
         };
+        let reflector = script_bindings::reflector::DomObject::reflector(self);
+        reflector.drop_memory(self);
     }
 }

--- a/components/script/dom/webgpu/gpusampler.rs
+++ b/components/script/dom/webgpu/gpusampler.rs
@@ -148,5 +148,7 @@ impl Drop for GPUSampler {
         {
             warn!("Failed to send DropSampler ({:?}) ({})", self.sampler.0, e);
         }
+        let reflector = script_bindings::reflector::DomObject::reflector(self);
+        reflector.drop_memory(self);
     }
 }

--- a/components/script/dom/webgpu/gpushadermodule.rs
+++ b/components/script/dom/webgpu/gpushadermodule.rs
@@ -159,5 +159,7 @@ impl Drop for GPUShaderModule {
                 self.shader_module.0, e
             );
         }
+        let reflector = script_bindings::reflector::DomObject::reflector(self);
+        reflector.drop_memory(self);
     }
 }

--- a/components/script/dom/webgpu/gputexture.rs
+++ b/components/script/dom/webgpu/gputexture.rs
@@ -119,6 +119,8 @@ impl Drop for GPUTexture {
                 self.texture.0, e
             );
         };
+        let reflector = script_bindings::reflector::DomObject::reflector(self);
+        reflector.drop_memory(self);
     }
 }
 

--- a/components/script/dom/webgpu/gputextureview.rs
+++ b/components/script/dom/webgpu/gputextureview.rs
@@ -93,5 +93,7 @@ impl Drop for GPUTextureView {
                 self.texture_view.0, e
             );
         }
+        let reflector = script_bindings::reflector::DomObject::reflector(self);
+        reflector.drop_memory(self);
     }
 }

--- a/components/script/dom/windowproxy.rs
+++ b/components/script/dom/windowproxy.rs
@@ -222,7 +222,10 @@ impl WindowProxy {
                 window_proxy,
                 js_proxy.get()
             );
-            window_proxy.reflector.set_jsobject(js_proxy.get());
+            window_proxy.reflector.set_jsobject(
+                js_proxy.get(),
+                size_of::<WindowProxy>() + size_of::<Box<WindowProxy>>(),
+            );
             DomRoot::from_ref(&*Box::into_raw(window_proxy))
         }
     }
@@ -283,7 +286,10 @@ impl WindowProxy {
                 window_proxy,
                 js_proxy.get()
             );
-            window_proxy.reflector.set_jsobject(js_proxy.get());
+            window_proxy.reflector.set_jsobject(
+                js_proxy.get(),
+                size_of::<WindowProxy>() + size_of::<Box<WindowProxy>>(),
+            );
             DomRoot::from_ref(&*Box::into_raw(window_proxy))
         }
     }

--- a/components/script_bindings/codegen/Bindings.conf
+++ b/components/script_bindings/codegen/Bindings.conf
@@ -88,6 +88,7 @@ DOMInterfaces = {
 
 'CanvasRenderingContext2D': {
     'canGc': ['GetTransform','GetImageData', 'CreateImageData', 'CreateImageData_', 'MeasureText', 'CreateLinearGradient', 'CreatePattern', 'CreateRadialGradient'],
+    'overrideMemoryUsage': True,
 },
 
 'CharacterData': {

--- a/components/script_bindings/codegen/configuration.py
+++ b/components/script_bindings/codegen/configuration.py
@@ -301,6 +301,7 @@ class Descriptor(DescriptorProvider):
         self.weakReferenceable = desc.get('weakReferenceable', False)
         self.useSystemCompartment = desc.get('useSystemCompartment', False)
         self.allowDropImpl = desc.get('allowDropImpl', False)
+        self.overrideMemoryUsage = desc.get('overrideMemoryUsage', False)
 
         # If we're concrete, we need to crawl our ancestor interfaces and mark
         # them as having a concrete descendant.

--- a/components/script_bindings/reflector.rs
+++ b/components/script_bindings/reflector.rs
@@ -59,6 +59,7 @@ impl Reflector {
 
     pub fn set_new_size(&self, size: usize) {
         let obj = self.object.get();
+        assert!(!obj.is_null());
         let size = NonZeroUsize::new(size);
         if self.size.get() != size {
             if let Some(old_size) = self.size.get() {

--- a/components/script_bindings/root.rs
+++ b/components/script_bindings/root.rs
@@ -281,7 +281,9 @@ where
         let ptr = self.as_ptr();
         drop(self);
         let root = DomRoot::from_ref(unsafe { &*ptr });
-        unsafe { root.init_reflector(obj) };
+        // Ideally we would measure the shallow size of T here,
+        // but we don't have a way to do that currently.
+        unsafe { root.init_reflector(obj, size_of::<T>() + size_of::<Box<T>>()) };
         root
     }
 }

--- a/components/script_bindings/root.rs
+++ b/components/script_bindings/root.rs
@@ -281,9 +281,7 @@ where
         let ptr = self.as_ptr();
         drop(self);
         let root = DomRoot::from_ref(unsafe { &*ptr });
-        // Ideally we would measure the shallow size of T here,
-        // but we don't have a way to do that currently.
-        unsafe { root.init_reflector(obj, size_of::<T>() + size_of::<Box<T>>()) };
+        unsafe { root.init_reflector::<T>(obj) };
         root
     }
 }

--- a/tests/unit/script/size_of.rs
+++ b/tests/unit/script/size_of.rs
@@ -29,11 +29,11 @@ macro_rules! sizeof_checker (
 );
 
 // Update the sizes here
-sizeof_checker!(size_event_target, EventTarget, 56);
-sizeof_checker!(size_node, Node, 176);
-sizeof_checker!(size_element, Element, 352);
-sizeof_checker!(size_htmlelement, HTMLElement, 368);
-sizeof_checker!(size_div, HTMLDivElement, 368);
-sizeof_checker!(size_span, HTMLSpanElement, 368);
-sizeof_checker!(size_text, Text, 208);
-sizeof_checker!(size_characterdata, CharacterData, 208);
+sizeof_checker!(size_event_target, EventTarget, 48);
+sizeof_checker!(size_node, Node, 168);
+sizeof_checker!(size_element, Element, 344);
+sizeof_checker!(size_htmlelement, HTMLElement, 360);
+sizeof_checker!(size_div, HTMLDivElement, 360);
+sizeof_checker!(size_span, HTMLSpanElement, 360);
+sizeof_checker!(size_text, Text, 200);
+sizeof_checker!(size_characterdata, CharacterData, 200);

--- a/tests/unit/script/size_of.rs
+++ b/tests/unit/script/size_of.rs
@@ -29,11 +29,11 @@ macro_rules! sizeof_checker (
 );
 
 // Update the sizes here
-sizeof_checker!(size_event_target, EventTarget, 48);
-sizeof_checker!(size_node, Node, 168);
-sizeof_checker!(size_element, Element, 344);
-sizeof_checker!(size_htmlelement, HTMLElement, 360);
-sizeof_checker!(size_div, HTMLDivElement, 360);
-sizeof_checker!(size_span, HTMLSpanElement, 360);
-sizeof_checker!(size_text, Text, 200);
-sizeof_checker!(size_characterdata, CharacterData, 200);
+sizeof_checker!(size_event_target, EventTarget, 56);
+sizeof_checker!(size_node, Node, 176);
+sizeof_checker!(size_element, Element, 352);
+sizeof_checker!(size_htmlelement, HTMLElement, 368);
+sizeof_checker!(size_div, HTMLDivElement, 368);
+sizeof_checker!(size_span, HTMLSpanElement, 368);
+sizeof_checker!(size_text, Text, 208);
+sizeof_checker!(size_characterdata, CharacterData, 208);


### PR DESCRIPTION
By reporting memory usage of rust objects back to SM it can trigger GC sooner and release more memory (I hope that we could use this to avoid OOB in webgpu in the future).

Currently we use simple `size_of::<DomStruct>() + size_of::<Box<DomStruct>>()` but it's possible to override reported memory with `update_memory_size(self, nbytes);` on reflector. This is mostly useful for canvases and buffers which usually have large associated data.

Testing: None, but I am wondering if we can connect this to `about:memory`.
Fixes: #42168
