### PR TITLE
layout: Add support for `-webkit-text-security`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8020,7 +8020,7 @@ dependencies = [
 [[package]]
 name = "selectors"
 version = "0.35.0"
-source = "git+https://github.com/servo/stylo?rev=85779486eadb93aec0a23a14cf74827acb387622#85779486eadb93aec0a23a14cf74827acb387622"
+source = "git+https://github.com/servo/stylo?rev=fce45cfa72008327d714575913bc9c968fa1446c#fce45cfa72008327d714575913bc9c968fa1446c"
 dependencies = [
  "bitflags 2.10.0",
  "cssparser",
@@ -8327,7 +8327,7 @@ dependencies = [
 [[package]]
 name = "servo_arc"
 version = "0.4.3"
-source = "git+https://github.com/servo/stylo?rev=85779486eadb93aec0a23a14cf74827acb387622#85779486eadb93aec0a23a14cf74827acb387622"
+source = "git+https://github.com/servo/stylo?rev=fce45cfa72008327d714575913bc9c968fa1446c#fce45cfa72008327d714575913bc9c968fa1446c"
 dependencies = [
  "serde",
  "stable_deref_trait",
@@ -8876,7 +8876,7 @@ dependencies = [
 [[package]]
 name = "stylo"
 version = "0.11.0"
-source = "git+https://github.com/servo/stylo?rev=85779486eadb93aec0a23a14cf74827acb387622#85779486eadb93aec0a23a14cf74827acb387622"
+source = "git+https://github.com/servo/stylo?rev=fce45cfa72008327d714575913bc9c968fa1446c#fce45cfa72008327d714575913bc9c968fa1446c"
 dependencies = [
  "app_units",
  "arrayvec",
@@ -8931,7 +8931,7 @@ dependencies = [
 [[package]]
 name = "stylo_atoms"
 version = "0.11.0"
-source = "git+https://github.com/servo/stylo?rev=85779486eadb93aec0a23a14cf74827acb387622#85779486eadb93aec0a23a14cf74827acb387622"
+source = "git+https://github.com/servo/stylo?rev=fce45cfa72008327d714575913bc9c968fa1446c#fce45cfa72008327d714575913bc9c968fa1446c"
 dependencies = [
  "string_cache",
  "string_cache_codegen",
@@ -8940,12 +8940,12 @@ dependencies = [
 [[package]]
 name = "stylo_config"
 version = "0.11.0"
-source = "git+https://github.com/servo/stylo?rev=85779486eadb93aec0a23a14cf74827acb387622#85779486eadb93aec0a23a14cf74827acb387622"
+source = "git+https://github.com/servo/stylo?rev=fce45cfa72008327d714575913bc9c968fa1446c#fce45cfa72008327d714575913bc9c968fa1446c"
 
 [[package]]
 name = "stylo_derive"
 version = "0.11.0"
-source = "git+https://github.com/servo/stylo?rev=85779486eadb93aec0a23a14cf74827acb387622#85779486eadb93aec0a23a14cf74827acb387622"
+source = "git+https://github.com/servo/stylo?rev=fce45cfa72008327d714575913bc9c968fa1446c#fce45cfa72008327d714575913bc9c968fa1446c"
 dependencies = [
  "darling",
  "proc-macro2",
@@ -8957,7 +8957,7 @@ dependencies = [
 [[package]]
 name = "stylo_dom"
 version = "0.11.0"
-source = "git+https://github.com/servo/stylo?rev=85779486eadb93aec0a23a14cf74827acb387622#85779486eadb93aec0a23a14cf74827acb387622"
+source = "git+https://github.com/servo/stylo?rev=fce45cfa72008327d714575913bc9c968fa1446c#fce45cfa72008327d714575913bc9c968fa1446c"
 dependencies = [
  "bitflags 2.10.0",
  "stylo_malloc_size_of",
@@ -8966,7 +8966,7 @@ dependencies = [
 [[package]]
 name = "stylo_malloc_size_of"
 version = "0.11.0"
-source = "git+https://github.com/servo/stylo?rev=85779486eadb93aec0a23a14cf74827acb387622#85779486eadb93aec0a23a14cf74827acb387622"
+source = "git+https://github.com/servo/stylo?rev=fce45cfa72008327d714575913bc9c968fa1446c#fce45cfa72008327d714575913bc9c968fa1446c"
 dependencies = [
  "app_units",
  "cssparser",
@@ -8983,12 +8983,12 @@ dependencies = [
 [[package]]
 name = "stylo_static_prefs"
 version = "0.11.0"
-source = "git+https://github.com/servo/stylo?rev=85779486eadb93aec0a23a14cf74827acb387622#85779486eadb93aec0a23a14cf74827acb387622"
+source = "git+https://github.com/servo/stylo?rev=fce45cfa72008327d714575913bc9c968fa1446c#fce45cfa72008327d714575913bc9c968fa1446c"
 
 [[package]]
 name = "stylo_traits"
 version = "0.11.0"
-source = "git+https://github.com/servo/stylo?rev=85779486eadb93aec0a23a14cf74827acb387622#85779486eadb93aec0a23a14cf74827acb387622"
+source = "git+https://github.com/servo/stylo?rev=fce45cfa72008327d714575913bc9c968fa1446c#fce45cfa72008327d714575913bc9c968fa1446c"
 dependencies = [
  "app_units",
  "bitflags 2.10.0",
@@ -9400,7 +9400,7 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 [[package]]
 name = "to_shmem"
 version = "0.3.0"
-source = "git+https://github.com/servo/stylo?rev=85779486eadb93aec0a23a14cf74827acb387622#85779486eadb93aec0a23a14cf74827acb387622"
+source = "git+https://github.com/servo/stylo?rev=fce45cfa72008327d714575913bc9c968fa1446c#fce45cfa72008327d714575913bc9c968fa1446c"
 dependencies = [
  "cssparser",
  "servo_arc",
@@ -9413,7 +9413,7 @@ dependencies = [
 [[package]]
 name = "to_shmem_derive"
 version = "0.1.0"
-source = "git+https://github.com/servo/stylo?rev=85779486eadb93aec0a23a14cf74827acb387622#85779486eadb93aec0a23a14cf74827acb387622"
+source = "git+https://github.com/servo/stylo?rev=fce45cfa72008327d714575913bc9c968fa1446c#fce45cfa72008327d714575913bc9c968fa1446c"
 dependencies = [
  "darling",
  "proc-macro2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -152,7 +152,7 @@ script_traits = { path = "components/shared/script" }
 sea-query = { version = "1.0.0-rc.30", default-features = false, features = ["backend-sqlite", "derive"] }
 sea-query-rusqlite = { version = "0.8.0-rc.15" }
 sec1 = "0.7"
-selectors = { git = "https://github.com/servo/stylo", rev = "85779486eadb93aec0a23a14cf74827acb387622" }
+selectors = { git = "https://github.com/servo/stylo", rev = "fce45cfa72008327d714575913bc9c968fa1446c" }
 serde = "1.0.228"
 serde_bytes = "0.11"
 serde_core = "1.0.226"
@@ -161,7 +161,7 @@ servo-media = { git = "https://github.com/servo/media", rev = "f384dbc4ff8b5c6f8
 servo-media-dummy = { git = "https://github.com/servo/media", rev = "f384dbc4ff8b5c6f8db2c763306cbe2281d66391" }
 servo-media-gstreamer = { git = "https://github.com/servo/media", rev = "f384dbc4ff8b5c6f8db2c763306cbe2281d66391" }
 servo-tracing = { path = "components/servo_tracing" }
-servo_arc = { git = "https://github.com/servo/stylo", rev = "85779486eadb93aec0a23a14cf74827acb387622" }
+servo_arc = { git = "https://github.com/servo/stylo", rev = "fce45cfa72008327d714575913bc9c968fa1446c" }
 sha1 = "0.10"
 sha2 = "0.10"
 sha3 = "0.10"
@@ -170,12 +170,12 @@ smallvec = { version = "1.15", features = ["serde", "union"] }
 storage_traits = { path = "components/shared/storage" }
 string_cache = "0.9"
 strum = { version = "0.27", features = ["derive"] }
-stylo = { git = "https://github.com/servo/stylo", rev = "85779486eadb93aec0a23a14cf74827acb387622" }
-stylo_atoms = { git = "https://github.com/servo/stylo", rev = "85779486eadb93aec0a23a14cf74827acb387622" }
-stylo_config = { git = "https://github.com/servo/stylo", rev = "85779486eadb93aec0a23a14cf74827acb387622" }
-stylo_dom = { git = "https://github.com/servo/stylo", rev = "85779486eadb93aec0a23a14cf74827acb387622" }
-stylo_malloc_size_of = { git = "https://github.com/servo/stylo", rev = "85779486eadb93aec0a23a14cf74827acb387622" }
-stylo_traits = { git = "https://github.com/servo/stylo", rev = "85779486eadb93aec0a23a14cf74827acb387622" }
+stylo = { git = "https://github.com/servo/stylo", rev = "fce45cfa72008327d714575913bc9c968fa1446c" }
+stylo_atoms = { git = "https://github.com/servo/stylo", rev = "fce45cfa72008327d714575913bc9c968fa1446c" }
+stylo_config = { git = "https://github.com/servo/stylo", rev = "fce45cfa72008327d714575913bc9c968fa1446c" }
+stylo_dom = { git = "https://github.com/servo/stylo", rev = "fce45cfa72008327d714575913bc9c968fa1446c" }
+stylo_malloc_size_of = { git = "https://github.com/servo/stylo", rev = "fce45cfa72008327d714575913bc9c968fa1446c" }
+stylo_traits = { git = "https://github.com/servo/stylo", rev = "fce45cfa72008327d714575913bc9c968fa1446c" }
 surfman = { version = "0.11.0", features = ["chains"] }
 syn = { version = "2", default-features = false, features = ["clone-impls", "derive", "parsing"] }
 synstructure = "0.13"

--- a/tests/wpt/mozilla/meta/MANIFEST.json
+++ b/tests/wpt/mozilla/meta/MANIFEST.json
@@ -7210,6 +7210,45 @@
       {}
      ]
     ],
+    "webkit-text-security-001.html": [
+     "ae62566d359c33d0ed5098d0df0b12f61e0cfe84",
+     [
+      null,
+      [
+       [
+        "/_mozilla/css/webkit-text-security-001-ref.html",
+        "=="
+       ]
+      ],
+      {}
+     ]
+    ],
+    "webkit-text-security-002.html": [
+     "b0285460912ef1bc0db6105a732c463dcf195814",
+     [
+      null,
+      [
+       [
+        "/_mozilla/css/webkit-text-security-002-ref.html",
+        "=="
+       ]
+      ],
+      {}
+     ]
+    ],
+    "webkit-text-security-003.html": [
+     "74da342d13cb063fdad2ac18abe2e8fb3d5391f1",
+     [
+      null,
+      [
+       [
+        "/_mozilla/css/webkit-text-security-003-ref.html",
+        "=="
+       ]
+      ],
+      {}
+     ]
+    ],
     "white-space-mixed-002.htm": [
      "70fd5baf403e2f78572abb49cd4f37ab51fa2dc5",
      [
@@ -10474,6 +10513,18 @@
     ],
     "visibility_hidden_ref.html": [
      "8f0a447ccb8175a8278438537e7597ad5116393b",
+     []
+    ],
+    "webkit-text-security-001-ref.html": [
+     "97d8482882c44afc8a8db20ccf2a591f32111040",
+     []
+    ],
+    "webkit-text-security-002-ref.html": [
+     "eefbc9ebedfb33b1d7bf5d8538ee050bfc92f5ad",
+     []
+    ],
+    "webkit-text-security-003-ref.html": [
+     "67d97c15ad3419936adba8da2df635040d1ded33",
      []
     ],
     "white-space-mixed-002-ref.htm": [

--- a/tests/wpt/mozilla/tests/css/webkit-text-security-001-ref.html
+++ b/tests/wpt/mozilla/tests/css/webkit-text-security-001-ref.html
@@ -1,0 +1,8 @@
+<!DOCTYPE html>
+<title>Basic support for `-webkit-text-security` property</title>
+<link rel="help" href="https://developer.mozilla.org/en-US/docs/Web/CSS/Reference/Webkit_extensions">
+
+<input value="○○○○○○○">
+<input value="●●●●●●●">
+<input value="■■■■■■■">
+<input value="abc def">

--- a/tests/wpt/mozilla/tests/css/webkit-text-security-001.html
+++ b/tests/wpt/mozilla/tests/css/webkit-text-security-001.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<title>Basic support for `-webkit-text-security` property</title>
+<link rel="help" href="https://developer.mozilla.org/en-US/docs/Web/CSS/Reference/Webkit_extensions">
+<link rel="match" href="webkit-text-security-001-ref.html">
+
+<input style="-webkit-text-security: circle" value="abc def">
+<input style="-webkit-text-security: disc" value="abc def">
+<input style="-webkit-text-security: square" value="abc def">
+<input style="-webkit-text-security: none" value="abc def">

--- a/tests/wpt/mozilla/tests/css/webkit-text-security-002-ref.html
+++ b/tests/wpt/mozilla/tests/css/webkit-text-security-002-ref.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<title>Basic support for `-webkit-text-security` property</title>
+<link rel="help" href="https://developer.mozilla.org/en-US/docs/Web/CSS/Reference/Webkit_extensions">
+
+<textarea style="-webkit-text-security: circle">
+○○○○○○○
+
+○○○○○○○
+</textarea>
+
+<textarea style="-webkit-text-security: disc">
+●●●●●●●
+
+●●●●●●●
+</textarea>
+
+<textarea style="-webkit-text-security: square">
+■■■■■■■
+
+■■■■■■■
+</textarea>
+
+<textarea>
+abc def
+
+abc def
+</textarea>

--- a/tests/wpt/mozilla/tests/css/webkit-text-security-002.html
+++ b/tests/wpt/mozilla/tests/css/webkit-text-security-002.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<title>Basic support for `-webkit-text-security` property in textarea</title>
+<link rel="help" href="https://developer.mozilla.org/en-US/docs/Web/CSS/Reference/Webkit_extensions">
+<link rel="match" href="webkit-text-security-002-ref.html">
+
+<textarea style="-webkit-text-security: circle">
+abc def
+
+abc def
+</textarea>
+
+<textarea style="-webkit-text-security: disc">
+abc def
+
+abc def
+</textarea>
+
+<textarea style="-webkit-text-security: square">
+abc def
+
+abc def
+</textarea>
+
+<textarea>
+abc def
+
+abc def
+</textarea>

--- a/tests/wpt/mozilla/tests/css/webkit-text-security-003-ref.html
+++ b/tests/wpt/mozilla/tests/css/webkit-text-security-003-ref.html
@@ -1,0 +1,7 @@
+<!DOCTYPE html>
+<title>Basic support for `-webkit-text-security` inherits properly</title>
+<link rel="help" href="https://developer.mozilla.org/en-US/docs/Web/CSS/Reference/Webkit_extensions">
+
+
+<div>○○○<br/>○○○<br/>○○○<br/></div>
+

--- a/tests/wpt/mozilla/tests/css/webkit-text-security-003.html
+++ b/tests/wpt/mozilla/tests/css/webkit-text-security-003.html
@@ -1,0 +1,7 @@
+<!DOCTYPE html>
+<title>Basic support for `-webkit-text-security` inherits properly</title>
+<link rel="help" href="https://developer.mozilla.org/en-US/docs/Web/CSS/Reference/Webkit_extensions">
+<link rel="match" href="webkit-text-security-003-ref.html">
+
+<div style="-webkit-text-security: circle">ABC<br/>ABC<br/>ABC<br/></div>
+


### PR DESCRIPTION
This change adds support for the unspecified `-webkit-text-security`
property. All major browsers support this property. The benefit of
adding this property is that the first addition of a prefixed CSS
property will allow us to start running MotionMark.

This depends on servo/stylo#295.

Testing: Three new Servo-specific tests are added for this change. There
are a few `-webkit-text-security` tests in WPT, but they do not seem
to test basic functionality.
