### PR TITLE
webdriver: Wait indefinitely with `None` timeout

### DIFF
--- a/components/webdriver_server/lib.rs
+++ b/components/webdriver_server/lib.rs
@@ -1398,7 +1398,9 @@ impl Handler {
         let (implicit_wait, sleep_interval) = {
             let timeouts = self.session()?.session_timeouts();
             (
-                Duration::from_millis(timeouts.implicit_wait.unwrap_or(u64::MAX)),
+                timeouts
+                    .implicit_wait
+                    .map_or(Duration::MAX, Duration::from_millis),
                 Duration::from_millis(timeouts.sleep_interval),
             )
         };
@@ -2070,12 +2072,12 @@ impl Handler {
 
         self.browsing_context_script_command(cmd, VerifyBrowsingContextIsOpen::No)?;
 
-        let timeout_duration = Duration::from_millis(
-            self.session()?
-                .session_timeouts()
-                .script
-                .unwrap_or(u64::MAX),
-        );
+        let timeout_duration = self
+            .session()?
+            .session_timeouts()
+            .script
+            .map_or(Duration::MAX, Duration::from_millis);
+
         let result = wait_for_script_ipc_response_with_timeout(receiver, timeout_duration)?;
 
         self.javascript_evaluation_result_to_webdriver_response(result)
@@ -2118,12 +2120,11 @@ impl Handler {
             VerifyBrowsingContextIsOpen::No,
         )?;
 
-        let timeout_duration = Duration::from_millis(
-            self.session()?
-                .session_timeouts()
-                .script
-                .unwrap_or(u64::MAX),
-        );
+        let timeout_duration = self
+            .session()?
+            .session_timeouts()
+            .script
+            .map_or(Duration::MAX, Duration::from_millis);
         let result = wait_for_script_ipc_response_with_timeout(receiver, timeout_duration)?;
 
         self.javascript_evaluation_result_to_webdriver_response(result)

--- a/components/webdriver_server/lib.rs
+++ b/components/webdriver_server/lib.rs
@@ -75,7 +75,7 @@ use webdriver::server::{self, Session, SessionTeardownKind, WebDriverHandler};
 
 use crate::actions::{ELEMENT_CLICK_BUTTON, InputSourceState, PointerInputState};
 use crate::session::{PageLoadStrategy, WebDriverSession};
-use crate::timeout::{DEFAULT_PAGE_LOAD_TIMEOUT, SCREENSHOT_TIMEOUT};
+use crate::timeout::{DEFAULT_IMPLICIT_WAIT, DEFAULT_PAGE_LOAD_TIMEOUT, SCREENSHOT_TIMEOUT};
 
 fn extension_routes() -> Vec<(Method, &'static str, ServoExtensionRoute)> {
     vec![
@@ -639,7 +639,7 @@ impl Handler {
                 self.session_mut()?.set_webview_id(webview_id);
                 self.session_mut()?
                     .set_browsing_context_id(BrowsingContextId::from(webview_id));
-                let _ = self.wait_document_ready(Some(3000));
+                let _ = self.wait_document_ready(Some(DEFAULT_PAGE_LOAD_TIMEOUT));
             },
         };
 
@@ -1398,7 +1398,7 @@ impl Handler {
         let (implicit_wait, sleep_interval) = {
             let timeouts = self.session()?.session_timeouts();
             (
-                Duration::from_millis(timeouts.implicit_wait.unwrap_or(0)),
+                Duration::from_millis(timeouts.implicit_wait.unwrap_or(u64::MAX)),
                 Duration::from_millis(timeouts.sleep_interval),
             )
         };
@@ -1925,10 +1925,11 @@ impl Handler {
         // FIXME: The specification says that all of these values can be `null`, but the `webdriver` crate
         // only supports setting `script` as null. When set to null, report these values as being the
         // default ones for now.
+        // Waiting for version bump together with geckodriver.
         let timeouts = TimeoutsResponse {
             script: timeouts.script,
             page_load: timeouts.page_load.unwrap_or(DEFAULT_PAGE_LOAD_TIMEOUT),
-            implicit: timeouts.implicit_wait.unwrap_or(0),
+            implicit: timeouts.implicit_wait.unwrap_or(DEFAULT_IMPLICIT_WAIT),
         };
 
         Ok(WebDriverResponse::Timeouts(timeouts))
@@ -2069,11 +2070,12 @@ impl Handler {
 
         self.browsing_context_script_command(cmd, VerifyBrowsingContextIsOpen::No)?;
 
-        let timeout_duration = self
-            .session()?
-            .session_timeouts()
-            .script
-            .map(Duration::from_millis);
+        let timeout_duration = Duration::from_millis(
+            self.session()?
+                .session_timeouts()
+                .script
+                .unwrap_or(u64::MAX),
+        );
         let result = wait_for_script_ipc_response_with_timeout(receiver, timeout_duration)?;
 
         self.javascript_evaluation_result_to_webdriver_response(result)
@@ -2116,11 +2118,12 @@ impl Handler {
             VerifyBrowsingContextIsOpen::No,
         )?;
 
-        let timeout_duration = self
-            .session()?
-            .session_timeouts()
-            .script
-            .map(Duration::from_millis);
+        let timeout_duration = Duration::from_millis(
+            self.session()?
+                .session_timeouts()
+                .script
+                .unwrap_or(u64::MAX),
+        );
         let result = wait_for_script_ipc_response_with_timeout(receiver, timeout_duration)?;
 
         self.javascript_evaluation_result_to_webdriver_response(result)
@@ -2797,14 +2800,11 @@ where
 
 fn wait_for_script_ipc_response_with_timeout<T>(
     receiver: GenericReceiver<T>,
-    timeout: Option<Duration>,
+    timeout: Duration,
 ) -> Result<T, WebDriverError>
 where
     T: for<'de> Deserialize<'de> + Serialize,
 {
-    let Some(timeout) = timeout else {
-        return wait_for_ipc_response(receiver);
-    };
     receiver
         .try_recv_timeout(timeout)
         .map_err(|error| match error {

--- a/components/webdriver_server/timeout.rs
+++ b/components/webdriver_server/timeout.rs
@@ -24,6 +24,8 @@ pub(crate) const DEFAULT_IMPLICIT_WAIT: u64 = 0;
 /// timed out.
 pub(crate) const SCREENSHOT_TIMEOUT: Duration = Duration::from_secs(10);
 
+/// <https://w3c.github.io/webdriver/#dfn-timeouts-configuration>
+/// A `None` timeout means waiting indefinitely.
 pub(crate) struct TimeoutsConfiguration {
     pub(crate) script: Option<u64>,
     pub(crate) page_load: Option<u64>,

--- a/tests/wpt/tests/webdriver/tests/classic/execute_async_script/promise.py
+++ b/tests/wpt/tests/webdriver/tests/classic/execute_async_script/promise.py
@@ -116,3 +116,33 @@ def test_promise_reject_timeout(session):
         resolve(promise);
         """)
     assert_error(response, "script timeout")
+
+
+def test_promise_resolve_timeout_none(session):
+    session.timeouts.script = None
+    response = execute_async_script(session, """
+        let resolve = arguments[0];
+        let promise = new Promise(
+            (resolve) => setTimeout(
+                () => resolve('foobar'),
+                200
+            )
+        );
+        resolve(promise);
+        """)
+    assert_success(response, "foobar")
+
+
+def test_promise_reject_timeout_none(session):
+    session.timeouts.script = None
+    response = execute_async_script(session, """
+        let resolve = arguments[0];
+        let promise = new Promise(
+            (resolve, reject) => setTimeout(
+                () => reject(new Error('my error')),
+                200
+            )
+        );
+        resolve(promise);
+        """)
+    assert_error(response, "javascript error")

--- a/tests/wpt/tests/webdriver/tests/classic/execute_script/promise.py
+++ b/tests/wpt/tests/webdriver/tests/classic/execute_script/promise.py
@@ -100,3 +100,29 @@ def test_promise_reject_timeout(session):
         );
         """)
     assert_error(response, "script timeout")
+
+
+def test_promise_resolve_timeout_none(session):
+    session.timeouts.script = None
+    response = execute_script(session, """
+        return new Promise(
+            (resolve) => setTimeout(
+                () => resolve('foobar'),
+                200
+            )
+        );
+        """)
+    assert_success(response, "foobar")
+
+
+def test_promise_reject_timeout_none(session):
+    session.timeouts.script = None
+    response = execute_script(session, """
+        return new Promise(
+            (resolve, reject) => setTimeout(
+                () => reject(new Error('my error')),
+                200
+            )
+        );
+        """)
+    assert_error(response, "javascript error")


### PR DESCRIPTION
So far for `None` [timeout](https://w3c.github.io/webdriver/#dfn-timeouts-configuration), we've treated it effectively as no wait which is wrong: https://github.com/web-platform-tests/wpt/pull/57332#issuecomment-3804242966.

This PR makes all `None` timeouts wait indefinitely. The funny part is, we somehow have only done it correctly for `pageload`: https://w3c.github.io/webdriver/#dfn-timeouts-configuration

Testing: We add test for script execution with `None` script timeout.