### PR TITLE
script: Enable module scripts import attributes

### DIFF
--- a/components/script/script_runtime.rs
+++ b/components/script/script_runtime.rs
@@ -856,6 +856,7 @@ impl Runtime {
         } else {
             AsmJSOption::DisabledByAsmJSPref
         };
+        cx_opts.compileOptions_.set_importAttributes_(true);
         let wasm_enabled = pref!(js_wasm_enabled);
         cx_opts.set_wasm_(wasm_enabled);
         if wasm_enabled {

--- a/tests/wpt/meta/content-security-policy/connect-src/connect-src-json-import-allowed.sub.html.ini
+++ b/tests/wpt/meta/content-security-policy/connect-src/connect-src-json-import-allowed.sub.html.ini
@@ -1,2 +1,3 @@
 [connect-src-json-import-allowed.sub.html]
-  expected: ERROR
+  [import should be allowed]
+    expected: FAIL

--- a/tests/wpt/meta/content-security-policy/connect-src/connect-src-json-import-blocked.sub.html.ini
+++ b/tests/wpt/meta/content-security-policy/connect-src/connect-src-json-import-blocked.sub.html.ini
@@ -1,2 +1,4 @@
 [connect-src-json-import-blocked.sub.html]
-  expected: ERROR
+  expected: TIMEOUT
+  [connect-src-json-import-blocked]
+    expected: TIMEOUT

--- a/tests/wpt/meta/content-security-policy/style-src/import-style-allowed.sub.html.ini
+++ b/tests/wpt/meta/content-security-policy/style-src/import-style-allowed.sub.html.ini
@@ -1,2 +1,3 @@
 [import-style-allowed.sub.html]
-  expected: ERROR
+  [import should be allowed]
+    expected: FAIL

--- a/tests/wpt/meta/content-security-policy/style-src/import-style-blocked.sub.html.ini
+++ b/tests/wpt/meta/content-security-policy/style-src/import-style-blocked.sub.html.ini
@@ -1,2 +1,4 @@
 [import-style-blocked.sub.html]
-  expected: ERROR
+  expected: TIMEOUT
+  [import-style-blocked]
+    expected: TIMEOUT

--- a/tests/wpt/meta/fetch/metadata/generated/script-json-module-import-static.https.sub.html.ini
+++ b/tests/wpt/meta/fetch/metadata/generated/script-json-module-import-static.https.sub.html.ini
@@ -1,5 +1,4 @@
 [script-json-module-import-static.https.sub.html]
-  expected: ERROR
   [sec-fetch-site - Same origin]
     expected: FAIL
 

--- a/tests/wpt/meta/fetch/metadata/generated/script-json-module-import-static.sub.html.ini
+++ b/tests/wpt/meta/fetch/metadata/generated/script-json-module-import-static.sub.html.ini
@@ -1,5 +1,4 @@
 [script-json-module-import-static.sub.html]
-  expected: ERROR
   [sec-fetch-site - Not sent to non-trustworthy same-origin destination]
     expected: FAIL
 

--- a/tests/wpt/meta/html/semantics/scripting-1/the-script-element/css-module/css-module-worker-test.html.ini
+++ b/tests/wpt/meta/html/semantics/scripting-1/the-script-element/css-module/css-module-worker-test.html.ini
@@ -1,10 +1,6 @@
 [css-module-worker-test.html]
-  expected: TIMEOUT
   [A dynamic import CSS Module within a web worker should not load.]
     expected: TIMEOUT
 
   [A dynamic import CSS Module within a web worker should not load and should not attempt to fetch the module.]
-    expected: TIMEOUT
-
-  [An attempt to load a CSS module as a worker should fail.]
-    expected: NOTRUN
+    expected: FAIL

--- a/tests/wpt/meta/html/semantics/scripting-1/the-script-element/css-module/import-css-module-dynamic.html.ini
+++ b/tests/wpt/meta/html/semantics/scripting-1/the-script-element/css-module/import-css-module-dynamic.html.ini
@@ -1,2 +1,3 @@
 [import-css-module-dynamic.html]
-  expected: ERROR
+  [Load a CSS module with dynamic import()]
+    expected: FAIL

--- a/tests/wpt/meta/html/semantics/scripting-1/the-script-element/import-attributes/dynamic-import-with-attributes-argument.any.js.ini
+++ b/tests/wpt/meta/html/semantics/scripting-1/the-script-element/import-attributes/dynamic-import-with-attributes-argument.any.js.ini
@@ -2,7 +2,10 @@
   expected: ERROR
 
 [dynamic-import-with-attributes-argument.any.html]
-  expected: ERROR
+  [Dynamic import with an unsupported type attribute should fail]
+    expected: FAIL
+
 
 [dynamic-import-with-attributes-argument.any.worker.html]
-  expected: ERROR
+  [Dynamic import with an unsupported type attribute should fail]
+    expected: FAIL

--- a/tests/wpt/meta/html/semantics/scripting-1/the-script-element/import-attributes/empty-attributes-clause.html.ini
+++ b/tests/wpt/meta/html/semantics/scripting-1/the-script-element/import-attributes/empty-attributes-clause.html.ini
@@ -1,4 +1,0 @@
-[empty-attributes-clause.html]
-  expected: ERROR
-  [Test that no error occurs when an empty import attributes clause is provided.]
-    expected: FAIL

--- a/tests/wpt/meta/html/semantics/scripting-1/the-script-element/import-attributes/invalid-type-attribute-error.html.ini
+++ b/tests/wpt/meta/html/semantics/scripting-1/the-script-element/import-attributes/invalid-type-attribute-error.html.ini
@@ -1,3 +1,0 @@
-[invalid-type-attribute-error.html]
-  [Test that invalid module type attribute leads to TypeError on window.]
-    expected: FAIL

--- a/tests/wpt/meta/html/semantics/scripting-1/the-script-element/module/dynamic-import/microtasks/css-import-in-worker.any.js.ini
+++ b/tests/wpt/meta/html/semantics/scripting-1/the-script-element/module/dynamic-import/microtasks/css-import-in-worker.any.js.ini
@@ -2,4 +2,5 @@
   expected: ERROR
 
 [css-import-in-worker.any.worker.html]
-  expected: ERROR
+  [import() should not drain the microtask queue if it fails because of the 'type: css' attribute in a worker]
+    expected: FAIL

--- a/tests/wpt/meta/html/semantics/scripting-1/the-script-element/module/dynamic-import/microtasks/with-import-assertions.any.js.ini
+++ b/tests/wpt/meta/html/semantics/scripting-1/the-script-element/module/dynamic-import/microtasks/with-import-assertions.any.js.ini
@@ -1,8 +1,11 @@
 [with-import-assertions.any.worker.html]
-  expected: ERROR
+  [import() should not drain the microtask queue if it fails while validating the 'type' attribute]
+    expected: FAIL
+
 
 [with-import-assertions.any.sharedworker.html]
   expected: ERROR
 
 [with-import-assertions.any.html]
-  expected: ERROR
+  [import() should not drain the microtask queue if it fails while validating the 'type' attribute]
+    expected: FAIL


### PR DESCRIPTION
While working on #42138 I found out that import attributes are an opt-in feature, which can be enabled by `ContextOptionsRef`'s `compileOptions_`.
This is likely the reason why `GetRequestedModuleSpecifier` wouldn't fail.
Now we catch any `GetRequestedModuleSpecifier` exception and pass it to `load_state`.

Testing: Covered by existing tests
