### PR TITLE
net: Fix other ownership loop

### DIFF
--- a/components/net/fetch/methods.rs
+++ b/components/net/fetch/methods.rs
@@ -938,7 +938,8 @@ fn handle_allowcert_request(request: &mut Request, context: &FetchContext) -> io
     };
 
     let stream = body.take_stream();
-    let stream = stream.lock();
+    let lock = stream.lock();
+    let stream = lock.as_ref().unwrap();
     let (body_chan, body_port) = ipc::channel().unwrap();
     let _ = stream.send(BodyChunkRequest::Connect(body_chan));
     let _ = stream.send(BodyChunkRequest::Chunk);

--- a/components/net/http_loader.rs
+++ b/components/net/http_loader.rs
@@ -699,12 +699,13 @@ async fn obtain_response(
 
             {
                 let mut lock = chunk_requester.lock();
-                let requester = lock.as_mut().unwrap();
-                let _ = requester.send(BodyChunkRequest::Connect(body_chan));
+                if let Some(requester) = lock.as_mut() {
+                    let _ = requester.send(BodyChunkRequest::Connect(body_chan));
 
-                // https://fetch.spec.whatwg.org/#concept-request-transmit-body
-                // Request the first chunk, corresponding to Step 3 and 4.
-                let _ = requester.send(BodyChunkRequest::Chunk);
+                    // https://fetch.spec.whatwg.org/#concept-request-transmit-body
+                    // Request the first chunk, corresponding to Step 3 and 4.
+                    let _ = requester.send(BodyChunkRequest::Chunk);
+                }
             }
 
             let devtools_bytes = devtools_bytes.clone();

--- a/components/script/body.rs
+++ b/components/script/body.rs
@@ -222,17 +222,15 @@ impl TransmitBodyConnectHandler {
     /// Otherwise, the following cycle will happen: The control sender is owned by us which keeps the control receiver
     /// alive in the router which keeps us alive.
     fn stop_reading(&mut self, reason: StopReading) {
-        let bytes_sender = self
-            .bytes_sender
-            .take()
-            .expect("Stop reading called multiple times on TransmitBodyConnectHandler.");
-        match reason {
-            StopReading::Error => {
-                let _ = bytes_sender.send(BodyChunkResponse::Error);
-            },
-            StopReading::Done => {
-                let _ = bytes_sender.send(BodyChunkResponse::Done);
-            },
+        if let Some(bytes_sender) = self.bytes_sender.take() {
+            match reason {
+                StopReading::Error => {
+                    let _ = bytes_sender.send(BodyChunkResponse::Error);
+                },
+                StopReading::Done => {
+                    let _ = bytes_sender.send(BodyChunkResponse::Done);
+                },
+            }
         }
         let _ = self.control_sender.take();
     }

--- a/components/shared/net/request.rs
+++ b/components/shared/net/request.rs
@@ -316,7 +316,7 @@ pub enum BodyChunkRequest {
 pub struct RequestBody {
     /// Net's channel to communicate with script re this body.
     #[ignore_malloc_size_of = "Channels are hard"]
-    chan: Arc<Mutex<IpcSender<BodyChunkRequest>>>,
+    chan: Arc<Mutex<Option<IpcSender<BodyChunkRequest>>>>,
     /// <https://fetch.spec.whatwg.org/#concept-body-source>
     source: BodySource,
     /// <https://fetch.spec.whatwg.org/#concept-body-total-bytes>
@@ -325,12 +325,12 @@ pub struct RequestBody {
 
 impl RequestBody {
     pub fn new(
-        chan: IpcSender<BodyChunkRequest>,
+        chan: Arc<Mutex<Option<IpcSender<BodyChunkRequest>>>>,
         source: BodySource,
         total_bytes: Option<usize>,
     ) -> Self {
         RequestBody {
-            chan: Arc::new(Mutex::new(chan)),
+            chan: chan,
             source,
             total_bytes,
         }
@@ -338,6 +338,7 @@ impl RequestBody {
 
     /// Step 12 of <https://fetch.spec.whatwg.org/#concept-http-redirect-fetch>
     pub fn extract_source(&mut self) {
+        /*
         match self.source {
             BodySource::Null => panic!("Null sources should never be re-directed."),
             BodySource::Object => {
@@ -347,9 +348,10 @@ impl RequestBody {
                 *selfchan = chan;
             },
         }
+        */
     }
 
-    pub fn take_stream(&self) -> Arc<Mutex<IpcSender<BodyChunkRequest>>> {
+    pub fn take_stream(&self) -> Arc<Mutex<Option<IpcSender<BodyChunkRequest>>>> {
         self.chan.clone()
     }
 
@@ -1252,5 +1254,9 @@ pub fn create_request_body_with_content(content: &str) -> RequestBody {
         }),
     );
 
-    RequestBody::new(chunk_request_sender, BodySource::Object, Some(content_len))
+    RequestBody::new(
+        Arc::new(Mutex::new(Some(chunk_request_sender))),
+        BodySource::Object,
+        Some(content_len),
+    )
 }

--- a/components/shared/net/request.rs
+++ b/components/shared/net/request.rs
@@ -295,6 +295,8 @@ pub enum BodyChunkResponse {
 /// Messages used to implement <https://fetch.spec.whatwg.org/#concept-request-transmit-body>
 /// which are sent from net to script
 /// (with the exception of Done, which is sent from script to script).
+/// Using these in combination with ROUTER is dangerous and can lead to ownership loops
+/// that are not apparent.
 #[derive(Debug, Deserialize, Serialize)]
 pub enum BodyChunkRequest {
     /// Connect a fetch in `net`, with a stream of bytes from `script`.


### PR DESCRIPTION
This is a companion to https://github.com/servo/servo/pull/42183.

As described in the extensive comment we were creating an ownership loop which because it included file descriptors lead to resource exhaustion. `TransmitBodyConnectHandler` owned body_chan which owned body_port which owned chunk_requester which owned `TransmitBodyConnectHandler`.

Testing: Normal websites seem to work and the WPT test run is here: https://github.com/Narfinger/servo/actions/runs/21403280670
Fixes: More potential ownership loops regarding https://github.com/servo/servo/issues/41202
