### PR TITLE
webgl: Get rid of a silly `expect(unused)`

### DIFF
--- a/components/webgl/webgl_thread.rs
+++ b/components/webgl/webgl_thread.rs
@@ -892,9 +892,6 @@ impl WebGLThread {
                 .contains(ContextAttributeFlags::ALPHA);
             self.update_webrender_image_for_context(context_id, size, has_alpha, canvas_epoch);
         }
-
-        #[expect(unused)]
-        let mut end_swap = 0;
     }
 
     /// Which access mode to use


### PR DESCRIPTION
The function ends right after this declaration. Instead of ignoring the fact that its unused, let's remove it.