### PR TITLE
Add support for `:-servo-list-box` pseudo class

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8010,7 +8010,7 @@ dependencies = [
 [[package]]
 name = "selectors"
 version = "0.35.0"
-source = "git+https://github.com/servo/stylo?rev=fce45cfa72008327d714575913bc9c968fa1446c#fce45cfa72008327d714575913bc9c968fa1446c"
+source = "git+https://github.com/servo/stylo?rev=refs%2Fpull%2F296%2Fhead#d9daf48a7d7a4b5a59cff08701474919df4fbf21"
 dependencies = [
  "bitflags 2.10.0",
  "cssparser",
@@ -8317,7 +8317,7 @@ dependencies = [
 [[package]]
 name = "servo_arc"
 version = "0.4.3"
-source = "git+https://github.com/servo/stylo?rev=fce45cfa72008327d714575913bc9c968fa1446c#fce45cfa72008327d714575913bc9c968fa1446c"
+source = "git+https://github.com/servo/stylo?rev=refs%2Fpull%2F296%2Fhead#d9daf48a7d7a4b5a59cff08701474919df4fbf21"
 dependencies = [
  "serde",
  "stable_deref_trait",
@@ -8866,7 +8866,7 @@ dependencies = [
 [[package]]
 name = "stylo"
 version = "0.11.0"
-source = "git+https://github.com/servo/stylo?rev=fce45cfa72008327d714575913bc9c968fa1446c#fce45cfa72008327d714575913bc9c968fa1446c"
+source = "git+https://github.com/servo/stylo?rev=refs%2Fpull%2F296%2Fhead#d9daf48a7d7a4b5a59cff08701474919df4fbf21"
 dependencies = [
  "app_units",
  "arrayvec",
@@ -8921,7 +8921,7 @@ dependencies = [
 [[package]]
 name = "stylo_atoms"
 version = "0.11.0"
-source = "git+https://github.com/servo/stylo?rev=fce45cfa72008327d714575913bc9c968fa1446c#fce45cfa72008327d714575913bc9c968fa1446c"
+source = "git+https://github.com/servo/stylo?rev=refs%2Fpull%2F296%2Fhead#d9daf48a7d7a4b5a59cff08701474919df4fbf21"
 dependencies = [
  "string_cache",
  "string_cache_codegen",
@@ -8930,12 +8930,12 @@ dependencies = [
 [[package]]
 name = "stylo_config"
 version = "0.11.0"
-source = "git+https://github.com/servo/stylo?rev=fce45cfa72008327d714575913bc9c968fa1446c#fce45cfa72008327d714575913bc9c968fa1446c"
+source = "git+https://github.com/servo/stylo?rev=refs%2Fpull%2F296%2Fhead#d9daf48a7d7a4b5a59cff08701474919df4fbf21"
 
 [[package]]
 name = "stylo_derive"
 version = "0.11.0"
-source = "git+https://github.com/servo/stylo?rev=fce45cfa72008327d714575913bc9c968fa1446c#fce45cfa72008327d714575913bc9c968fa1446c"
+source = "git+https://github.com/servo/stylo?rev=refs%2Fpull%2F296%2Fhead#d9daf48a7d7a4b5a59cff08701474919df4fbf21"
 dependencies = [
  "darling",
  "proc-macro2",
@@ -8947,7 +8947,7 @@ dependencies = [
 [[package]]
 name = "stylo_dom"
 version = "0.11.0"
-source = "git+https://github.com/servo/stylo?rev=fce45cfa72008327d714575913bc9c968fa1446c#fce45cfa72008327d714575913bc9c968fa1446c"
+source = "git+https://github.com/servo/stylo?rev=refs%2Fpull%2F296%2Fhead#d9daf48a7d7a4b5a59cff08701474919df4fbf21"
 dependencies = [
  "bitflags 2.10.0",
  "stylo_malloc_size_of",
@@ -8956,7 +8956,7 @@ dependencies = [
 [[package]]
 name = "stylo_malloc_size_of"
 version = "0.11.0"
-source = "git+https://github.com/servo/stylo?rev=fce45cfa72008327d714575913bc9c968fa1446c#fce45cfa72008327d714575913bc9c968fa1446c"
+source = "git+https://github.com/servo/stylo?rev=refs%2Fpull%2F296%2Fhead#d9daf48a7d7a4b5a59cff08701474919df4fbf21"
 dependencies = [
  "app_units",
  "cssparser",
@@ -8973,12 +8973,12 @@ dependencies = [
 [[package]]
 name = "stylo_static_prefs"
 version = "0.11.0"
-source = "git+https://github.com/servo/stylo?rev=fce45cfa72008327d714575913bc9c968fa1446c#fce45cfa72008327d714575913bc9c968fa1446c"
+source = "git+https://github.com/servo/stylo?rev=refs%2Fpull%2F296%2Fhead#d9daf48a7d7a4b5a59cff08701474919df4fbf21"
 
 [[package]]
 name = "stylo_traits"
 version = "0.11.0"
-source = "git+https://github.com/servo/stylo?rev=fce45cfa72008327d714575913bc9c968fa1446c#fce45cfa72008327d714575913bc9c968fa1446c"
+source = "git+https://github.com/servo/stylo?rev=refs%2Fpull%2F296%2Fhead#d9daf48a7d7a4b5a59cff08701474919df4fbf21"
 dependencies = [
  "app_units",
  "bitflags 2.10.0",
@@ -9390,7 +9390,7 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 [[package]]
 name = "to_shmem"
 version = "0.3.0"
-source = "git+https://github.com/servo/stylo?rev=fce45cfa72008327d714575913bc9c968fa1446c#fce45cfa72008327d714575913bc9c968fa1446c"
+source = "git+https://github.com/servo/stylo?rev=refs%2Fpull%2F296%2Fhead#d9daf48a7d7a4b5a59cff08701474919df4fbf21"
 dependencies = [
  "cssparser",
  "servo_arc",
@@ -9403,7 +9403,7 @@ dependencies = [
 [[package]]
 name = "to_shmem_derive"
 version = "0.1.0"
-source = "git+https://github.com/servo/stylo?rev=fce45cfa72008327d714575913bc9c968fa1446c#fce45cfa72008327d714575913bc9c968fa1446c"
+source = "git+https://github.com/servo/stylo?rev=refs%2Fpull%2F296%2Fhead#d9daf48a7d7a4b5a59cff08701474919df4fbf21"
 dependencies = [
  "darling",
  "proc-macro2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -152,7 +152,7 @@ script_traits = { path = "components/shared/script" }
 sea-query = { version = "1.0.0-rc.30", default-features = false, features = ["backend-sqlite", "derive"] }
 sea-query-rusqlite = { version = "0.8.0-rc.15" }
 sec1 = "0.7"
-selectors = { git = "https://github.com/servo/stylo", rev = "fce45cfa72008327d714575913bc9c968fa1446c" }
+selectors = { git = "https://github.com/servo/stylo", rev = "refs/pull/296/head" }
 serde = "1.0.228"
 serde_bytes = "0.11"
 serde_core = "1.0.226"
@@ -161,7 +161,7 @@ servo-media = { git = "https://github.com/servo/media", rev = "f384dbc4ff8b5c6f8
 servo-media-dummy = { git = "https://github.com/servo/media", rev = "f384dbc4ff8b5c6f8db2c763306cbe2281d66391" }
 servo-media-gstreamer = { git = "https://github.com/servo/media", rev = "f384dbc4ff8b5c6f8db2c763306cbe2281d66391" }
 servo-tracing = { path = "components/servo_tracing" }
-servo_arc = { git = "https://github.com/servo/stylo", rev = "fce45cfa72008327d714575913bc9c968fa1446c" }
+servo_arc = { git = "https://github.com/servo/stylo", rev = "refs/pull/296/head" }
 sha1 = "0.10"
 sha2 = "0.10"
 sha3 = "0.10"
@@ -170,12 +170,12 @@ smallvec = { version = "1.15", features = ["serde", "union"] }
 storage_traits = { path = "components/shared/storage" }
 string_cache = "0.9"
 strum = { version = "0.27", features = ["derive"] }
-stylo = { git = "https://github.com/servo/stylo", rev = "fce45cfa72008327d714575913bc9c968fa1446c" }
-stylo_atoms = { git = "https://github.com/servo/stylo", rev = "fce45cfa72008327d714575913bc9c968fa1446c" }
-stylo_config = { git = "https://github.com/servo/stylo", rev = "fce45cfa72008327d714575913bc9c968fa1446c" }
-stylo_dom = { git = "https://github.com/servo/stylo", rev = "fce45cfa72008327d714575913bc9c968fa1446c" }
-stylo_malloc_size_of = { git = "https://github.com/servo/stylo", rev = "fce45cfa72008327d714575913bc9c968fa1446c" }
-stylo_traits = { git = "https://github.com/servo/stylo", rev = "fce45cfa72008327d714575913bc9c968fa1446c" }
+stylo = { git = "https://github.com/servo/stylo", rev = "refs/pull/296/head" }
+stylo_atoms = { git = "https://github.com/servo/stylo", rev = "refs/pull/296/head" }
+stylo_config = { git = "https://github.com/servo/stylo", rev = "refs/pull/296/head" }
+stylo_dom = { git = "https://github.com/servo/stylo", rev = "refs/pull/296/head" }
+stylo_malloc_size_of = { git = "https://github.com/servo/stylo", rev = "refs/pull/296/head" }
+stylo_traits = { git = "https://github.com/servo/stylo", rev = "refs/pull/296/head" }
 surfman = { version = "0.11.0", features = ["chains"] }
 syn = { version = "2", default-features = false, features = ["clone-impls", "derive", "parsing"] }
 synstructure = "0.13"

--- a/components/layout/stylesheets/servo.css
+++ b/components/layout/stylesheets/servo.css
@@ -74,7 +74,7 @@ textarea::selection {
 
 /* Button type inputs */
 button,
-select,
+select:not(:-servo-list-box),
 input[type="button"],
 input[type="submit"],
 input[type="reset"],
@@ -97,7 +97,7 @@ input[type="file"]::before {
 }
 
 button:hover,
-select:hover,
+select:not(:-servo-list-box):hover,
 input[type="button"]:hover,
 input[type="submit"]:hover,
 input[type="reset"]:hover,
@@ -107,7 +107,7 @@ input[type="file"]:hover::before {
 }
 
 button:active,
-select:active,
+select:not(:-servo-list-box):active,
 input[type="button"]:active,
 input[type="submit"]:active,
 input[type="reset"]:active,
@@ -118,7 +118,7 @@ input[type="file"]:active::before {
 }
 
 button:focus,
-select:focus,
+select:not(:-servo-list-box):focus,
 input[type="button"]:focus,
 input[type="submit"]:focus,
 input[type="reset"]:focus,
@@ -128,7 +128,7 @@ input[type="file"]:focus::before {
 }
 
 button:disabled,
-select:disabled,
+select:not(:-servo-list-box):disabled,
 input[type="button"]:disabled,
 input[type="submit"]:disabled,
 input[type="reset"]:disabled,

--- a/components/script/dom/element.rs
+++ b/components/script/dom/element.rs
@@ -4879,6 +4879,7 @@ impl SelectorsElement for SelectorWrapper<'_> {
             NonTSPseudoClass::PopoverOpen |
             NonTSPseudoClass::ReadWrite |
             NonTSPseudoClass::Required |
+            NonTSPseudoClass::ServoListBox |
             NonTSPseudoClass::Target |
             NonTSPseudoClass::UserInvalid |
             NonTSPseudoClass::UserValid |
@@ -5270,6 +5271,14 @@ impl Element {
 
     pub(crate) fn set_disabled_state(&self, value: bool) {
         self.set_state(ElementState::DISABLED, value)
+    }
+
+    pub(crate) fn list_box_state(&self) -> bool {
+        self.state.get().contains(ElementState::LIST_BOX)
+    }
+
+    pub(crate) fn set_list_box_state(&self, value: bool) {
+        self.set_state(ElementState::LIST_BOX, value)
     }
 
     pub(crate) fn read_write_state(&self) -> bool {

--- a/components/script/dom/html/htmlselectelement.rs
+++ b/components/script/dom/html/htmlselectelement.rs
@@ -466,6 +466,14 @@ impl HTMLSelectElement {
             .filter_map(DomRoot::downcast::<Element>)
             .find(|element| element.local_name() == &local_name!("selectedcontent"))
     }
+
+    fn update_list_box_state(&self) {
+        let multiple = self.Multiple();
+        let size = self.Size();
+
+        let is_listbox = size > 1 || (size == 0 && multiple);
+        self.upcast::<Element>().set_list_box_state(is_listbox);
+    }
 }
 
 impl HTMLSelectElementMethods<crate::DomTypeHolder> for HTMLSelectElement {
@@ -710,6 +718,12 @@ impl VirtualMethods for HTMLSelectElement {
             },
             local_name!("form") => {
                 self.form_attribute_mutated(mutation, can_gc);
+            },
+            local_name!("multiple") => {
+                self.update_list_box_state();
+            },
+            local_name!("size") => {
+                self.update_list_box_state();
             },
             _ => {},
         }

--- a/components/script/layout_dom/element.rs
+++ b/components/script/layout_dom/element.rs
@@ -906,6 +906,7 @@ impl<'dom> ::selectors::Element for ServoLayoutElement<'dom> {
             NonTSPseudoClass::PopoverOpen |
             NonTSPseudoClass::ReadWrite |
             NonTSPseudoClass::Required |
+            NonTSPseudoClass::ServoListBox |
             NonTSPseudoClass::Target |
             NonTSPseudoClass::UserInvalid |
             NonTSPseudoClass::UserValid |


### PR DESCRIPTION
Add support for `:-servo-list-box` pseudo class

This applies to selects with a size greater than 1, and multiple select when no size is specified.

Existing select styles are applied only when this pseudo-class does not match.

Testing: Nothing yet but I suspect WPTs cover this in some form.
First step for [select as listboxes](https://github.com/servo/servo/issues/42076) 

Stylo PR: https://github.com/servo/stylo/pull/296