### PR TITLE
script: Add support for `:open` pseudo-class

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7989,7 +7989,7 @@ dependencies = [
 [[package]]
 name = "selectors"
 version = "0.35.0"
-source = "git+https://github.com/servo/stylo?rev=29123c1295b527ff5230afc2bcff53138cd884b5#29123c1295b527ff5230afc2bcff53138cd884b5"
+source = "git+https://github.com/servo/stylo?rev=63d8ef5c546deac25ed57e79b56ce3a887751a14#63d8ef5c546deac25ed57e79b56ce3a887751a14"
 dependencies = [
  "bitflags 2.10.0",
  "cssparser",
@@ -8296,7 +8296,7 @@ dependencies = [
 [[package]]
 name = "servo_arc"
 version = "0.4.3"
-source = "git+https://github.com/servo/stylo?rev=29123c1295b527ff5230afc2bcff53138cd884b5#29123c1295b527ff5230afc2bcff53138cd884b5"
+source = "git+https://github.com/servo/stylo?rev=63d8ef5c546deac25ed57e79b56ce3a887751a14#63d8ef5c546deac25ed57e79b56ce3a887751a14"
 dependencies = [
  "serde",
  "stable_deref_trait",
@@ -8845,7 +8845,7 @@ dependencies = [
 [[package]]
 name = "stylo"
 version = "0.11.0"
-source = "git+https://github.com/servo/stylo?rev=29123c1295b527ff5230afc2bcff53138cd884b5#29123c1295b527ff5230afc2bcff53138cd884b5"
+source = "git+https://github.com/servo/stylo?rev=63d8ef5c546deac25ed57e79b56ce3a887751a14#63d8ef5c546deac25ed57e79b56ce3a887751a14"
 dependencies = [
  "app_units",
  "arrayvec",
@@ -8900,7 +8900,7 @@ dependencies = [
 [[package]]
 name = "stylo_atoms"
 version = "0.11.0"
-source = "git+https://github.com/servo/stylo?rev=29123c1295b527ff5230afc2bcff53138cd884b5#29123c1295b527ff5230afc2bcff53138cd884b5"
+source = "git+https://github.com/servo/stylo?rev=63d8ef5c546deac25ed57e79b56ce3a887751a14#63d8ef5c546deac25ed57e79b56ce3a887751a14"
 dependencies = [
  "string_cache",
  "string_cache_codegen",
@@ -8909,12 +8909,12 @@ dependencies = [
 [[package]]
 name = "stylo_config"
 version = "0.11.0"
-source = "git+https://github.com/servo/stylo?rev=29123c1295b527ff5230afc2bcff53138cd884b5#29123c1295b527ff5230afc2bcff53138cd884b5"
+source = "git+https://github.com/servo/stylo?rev=63d8ef5c546deac25ed57e79b56ce3a887751a14#63d8ef5c546deac25ed57e79b56ce3a887751a14"
 
 [[package]]
 name = "stylo_derive"
 version = "0.11.0"
-source = "git+https://github.com/servo/stylo?rev=29123c1295b527ff5230afc2bcff53138cd884b5#29123c1295b527ff5230afc2bcff53138cd884b5"
+source = "git+https://github.com/servo/stylo?rev=63d8ef5c546deac25ed57e79b56ce3a887751a14#63d8ef5c546deac25ed57e79b56ce3a887751a14"
 dependencies = [
  "darling",
  "proc-macro2",
@@ -8926,7 +8926,7 @@ dependencies = [
 [[package]]
 name = "stylo_dom"
 version = "0.11.0"
-source = "git+https://github.com/servo/stylo?rev=29123c1295b527ff5230afc2bcff53138cd884b5#29123c1295b527ff5230afc2bcff53138cd884b5"
+source = "git+https://github.com/servo/stylo?rev=63d8ef5c546deac25ed57e79b56ce3a887751a14#63d8ef5c546deac25ed57e79b56ce3a887751a14"
 dependencies = [
  "bitflags 2.10.0",
  "stylo_malloc_size_of",
@@ -8935,7 +8935,7 @@ dependencies = [
 [[package]]
 name = "stylo_malloc_size_of"
 version = "0.11.0"
-source = "git+https://github.com/servo/stylo?rev=29123c1295b527ff5230afc2bcff53138cd884b5#29123c1295b527ff5230afc2bcff53138cd884b5"
+source = "git+https://github.com/servo/stylo?rev=63d8ef5c546deac25ed57e79b56ce3a887751a14#63d8ef5c546deac25ed57e79b56ce3a887751a14"
 dependencies = [
  "app_units",
  "cssparser",
@@ -8952,12 +8952,12 @@ dependencies = [
 [[package]]
 name = "stylo_static_prefs"
 version = "0.11.0"
-source = "git+https://github.com/servo/stylo?rev=29123c1295b527ff5230afc2bcff53138cd884b5#29123c1295b527ff5230afc2bcff53138cd884b5"
+source = "git+https://github.com/servo/stylo?rev=63d8ef5c546deac25ed57e79b56ce3a887751a14#63d8ef5c546deac25ed57e79b56ce3a887751a14"
 
 [[package]]
 name = "stylo_traits"
 version = "0.11.0"
-source = "git+https://github.com/servo/stylo?rev=29123c1295b527ff5230afc2bcff53138cd884b5#29123c1295b527ff5230afc2bcff53138cd884b5"
+source = "git+https://github.com/servo/stylo?rev=63d8ef5c546deac25ed57e79b56ce3a887751a14#63d8ef5c546deac25ed57e79b56ce3a887751a14"
 dependencies = [
  "app_units",
  "bitflags 2.10.0",
@@ -9369,7 +9369,7 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 [[package]]
 name = "to_shmem"
 version = "0.3.0"
-source = "git+https://github.com/servo/stylo?rev=29123c1295b527ff5230afc2bcff53138cd884b5#29123c1295b527ff5230afc2bcff53138cd884b5"
+source = "git+https://github.com/servo/stylo?rev=63d8ef5c546deac25ed57e79b56ce3a887751a14#63d8ef5c546deac25ed57e79b56ce3a887751a14"
 dependencies = [
  "cssparser",
  "servo_arc",
@@ -9382,7 +9382,7 @@ dependencies = [
 [[package]]
 name = "to_shmem_derive"
 version = "0.1.0"
-source = "git+https://github.com/servo/stylo?rev=29123c1295b527ff5230afc2bcff53138cd884b5#29123c1295b527ff5230afc2bcff53138cd884b5"
+source = "git+https://github.com/servo/stylo?rev=63d8ef5c546deac25ed57e79b56ce3a887751a14#63d8ef5c546deac25ed57e79b56ce3a887751a14"
 dependencies = [
  "darling",
  "proc-macro2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -157,7 +157,7 @@ script_traits = { path = "components/shared/script" }
 sea-query = { version = "1.0.0-rc.30", default-features = false, features = ["backend-sqlite", "derive"] }
 sea-query-rusqlite = { version = "0.8.0-rc.15" }
 sec1 = "0.7"
-selectors = { git = "https://github.com/servo/stylo", rev = "29123c1295b527ff5230afc2bcff53138cd884b5" }
+selectors = { git = "https://github.com/servo/stylo", rev = "63d8ef5c546deac25ed57e79b56ce3a887751a14" }
 serde = "1.0.228"
 serde_bytes = "0.11"
 serde_core = "1.0.226"
@@ -166,7 +166,7 @@ servo-media = { git = "https://github.com/servo/media", rev = "f384dbc4ff8b5c6f8
 servo-media-dummy = { git = "https://github.com/servo/media", rev = "f384dbc4ff8b5c6f8db2c763306cbe2281d66391" }
 servo-media-gstreamer = { git = "https://github.com/servo/media", rev = "f384dbc4ff8b5c6f8db2c763306cbe2281d66391" }
 servo-tracing = { path = "components/servo_tracing" }
-servo_arc = { git = "https://github.com/servo/stylo", rev = "29123c1295b527ff5230afc2bcff53138cd884b5" }
+servo_arc = { git = "https://github.com/servo/stylo", rev = "63d8ef5c546deac25ed57e79b56ce3a887751a14" }
 sha1 = "0.10"
 sha2 = "0.10"
 sha3 = "0.10"
@@ -175,12 +175,12 @@ smallvec = { version = "1.15", features = ["serde", "union"] }
 storage_traits = { path = "components/shared/storage" }
 string_cache = "0.9"
 strum = { version = "0.27", features = ["derive"] }
-stylo = { git = "https://github.com/servo/stylo", rev = "29123c1295b527ff5230afc2bcff53138cd884b5" }
-stylo_atoms = { git = "https://github.com/servo/stylo", rev = "29123c1295b527ff5230afc2bcff53138cd884b5" }
-stylo_config = { git = "https://github.com/servo/stylo", rev = "29123c1295b527ff5230afc2bcff53138cd884b5" }
-stylo_dom = { git = "https://github.com/servo/stylo", rev = "29123c1295b527ff5230afc2bcff53138cd884b5" }
-stylo_malloc_size_of = { git = "https://github.com/servo/stylo", rev = "29123c1295b527ff5230afc2bcff53138cd884b5" }
-stylo_traits = { git = "https://github.com/servo/stylo", rev = "29123c1295b527ff5230afc2bcff53138cd884b5" }
+stylo = { git = "https://github.com/servo/stylo", rev = "63d8ef5c546deac25ed57e79b56ce3a887751a14" }
+stylo_atoms = { git = "https://github.com/servo/stylo", rev = "63d8ef5c546deac25ed57e79b56ce3a887751a14" }
+stylo_config = { git = "https://github.com/servo/stylo", rev = "63d8ef5c546deac25ed57e79b56ce3a887751a14" }
+stylo_dom = { git = "https://github.com/servo/stylo", rev = "63d8ef5c546deac25ed57e79b56ce3a887751a14" }
+stylo_malloc_size_of = { git = "https://github.com/servo/stylo", rev = "63d8ef5c546deac25ed57e79b56ce3a887751a14" }
+stylo_traits = { git = "https://github.com/servo/stylo", rev = "63d8ef5c546deac25ed57e79b56ce3a887751a14" }
 surfman = { version = "0.11.0", features = ["chains"] }
 syn = { version = "2", default-features = false, features = ["clone-impls", "derive", "parsing"] }
 synstructure = "0.13"

--- a/components/script/dom/element.rs
+++ b/components/script/dom/element.rs
@@ -4872,6 +4872,7 @@ impl SelectorsElement for SelectorWrapper<'_> {
             NonTSPseudoClass::MozMeterOptimum |
             NonTSPseudoClass::MozMeterSubOptimum |
             NonTSPseudoClass::MozMeterSubSubOptimum |
+            NonTSPseudoClass::Open |
             NonTSPseudoClass::Optional |
             NonTSPseudoClass::OutOfRange |
             NonTSPseudoClass::PlaceholderShown |
@@ -5277,6 +5278,14 @@ impl Element {
 
     pub(crate) fn set_read_write_state(&self, value: bool) {
         self.set_state(ElementState::READWRITE, value)
+    }
+
+    pub(crate) fn open_state(&self) -> bool {
+        self.state.get().contains(ElementState::OPEN)
+    }
+
+    pub(crate) fn set_open_state(&self, value: bool) {
+        self.set_state(ElementState::OPEN, value);
     }
 
     pub(crate) fn placeholder_shown_state(&self) -> bool {

--- a/components/script/dom/html/htmldetailselement.rs
+++ b/components/script/dom/html/htmldetailselement.rs
@@ -485,6 +485,8 @@ impl VirtualMethods for HTMLDetailsElement {
                     ExclusivityConflictResolution::CloseExistingOpenElement,
                 );
             }
+
+            self.upcast::<Element>().set_open_state(self.Open());
         }
     }
 

--- a/components/script/dom/html/htmldialogelement.rs
+++ b/components/script/dom/html/htmldialogelement.rs
@@ -123,6 +123,7 @@ impl HTMLDialogElement {
 
         // Step 11. Add an open attribute to subject, whose value is the empty string.
         subject.set_bool_attribute(&local_name!("open"), true, can_gc);
+        subject.set_open_state(true);
 
         // TODO: Step 12. Assert: subject's close watcher is not null.
 
@@ -190,6 +191,7 @@ impl HTMLDialogElement {
 
         // Step 5. Remove subject's open attribute.
         subject.remove_attribute(&ns!(), &local_name!("open"), can_gc);
+        subject.set_open_state(false);
 
         // TODO: Step 6. If is modal of subject is true, then request an element to be removed from the top layer given subject.
 
@@ -331,6 +333,7 @@ impl HTMLDialogElementMethods<crate::DomTypeHolder> for HTMLDialogElement {
 
         // Step 6. Add an open attribute to this, whose value is the empty string.
         element.set_bool_attribute(&local_name!("open"), true, can_gc);
+        element.set_open_state(true);
 
         // TODO: Step 7. Set this's previously focused element to the focused element.
 

--- a/components/script/dom/html/htmlselectelement.rs
+++ b/components/script/dom/html/htmlselectelement.rs
@@ -399,9 +399,11 @@ impl HTMLSelectElement {
                 EmbedderControlRequest::SelectElement(options, selected_index),
                 None,
             );
+        self.upcast::<Element>().set_open_state(true);
     }
 
     pub(crate) fn handle_menu_response(&self, response: Option<usize>, can_gc: CanGc) {
+        self.upcast::<Element>().set_open_state(false);
         let Some(selected_value) = response else {
             return;
         };

--- a/components/script/layout_dom/element.rs
+++ b/components/script/layout_dom/element.rs
@@ -899,6 +899,7 @@ impl<'dom> ::selectors::Element for ServoLayoutElement<'dom> {
             NonTSPseudoClass::MozMeterOptimum |
             NonTSPseudoClass::MozMeterSubOptimum |
             NonTSPseudoClass::MozMeterSubSubOptimum |
+            NonTSPseudoClass::Open |
             NonTSPseudoClass::Optional |
             NonTSPseudoClass::OutOfRange |
             NonTSPseudoClass::PlaceholderShown |

--- a/tests/wpt/meta/css/css-shadow/part/pseudo-classes-after-part.html.ini
+++ b/tests/wpt/meta/css/css-shadow/part/pseudo-classes-after-part.html.ini
@@ -20,9 +20,6 @@
   ["::part(mypart):modal" should be a valid selector]
     expected: FAIL
 
-  ["::part(mypart):open" should be a valid selector]
-    expected: FAIL
-
   ["::part(mypart):past" should be a valid selector]
     expected: FAIL
 

--- a/tests/wpt/meta/css/selectors/open-pseudo.html.ini
+++ b/tests/wpt/meta/css/selectors/open-pseudo.html.ini
@@ -1,9 +1,3 @@
 [open-pseudo.html]
-  [The dialog element should support :open.]
-    expected: FAIL
-
-  [The details element should support :open.]
-    expected: FAIL
-
   [The select element should support :open.]
     expected: FAIL

--- a/tests/wpt/meta/css/selectors/selectors-4/details-open-pseudo-001.html.ini
+++ b/tests/wpt/meta/css/selectors/selectors-4/details-open-pseudo-001.html.ini
@@ -1,2 +1,0 @@
-[details-open-pseudo-001.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/selectors/selectors-4/details-open-pseudo-002.html.ini
+++ b/tests/wpt/meta/css/selectors/selectors-4/details-open-pseudo-002.html.ini
@@ -1,2 +1,0 @@
-[details-open-pseudo-002.html]
-  expected: FAIL

--- a/tests/wpt/meta/html/semantics/forms/the-select-element/customizable-select/select-dialog-mode-focus.optional.html.ini
+++ b/tests/wpt/meta/html/semantics/forms/the-select-element/customizable-select/select-dialog-mode-focus.optional.html.ini
@@ -1,4 +1,5 @@
 [select-dialog-mode-focus.optional.html]
+  expected: ERROR
   [In dialog mode the first focusable element should get focus.]
     expected: FAIL
 

--- a/tests/wpt/meta/html/semantics/forms/the-select-element/customizable-select/select-keyboard-focus-change-for-hidden-options.optional.html.ini
+++ b/tests/wpt/meta/html/semantics/forms/the-select-element/customizable-select/select-keyboard-focus-change-for-hidden-options.optional.html.ini
@@ -1,3 +1,4 @@
 [select-keyboard-focus-change-for-hidden-options.optional.html]
+  expected: ERROR
   [Hidden options should be skipped when changing focus using the up and down keys.]
     expected: FAIL

--- a/tests/wpt/meta/html/semantics/forms/the-select-element/customizable-select/select-pseudo-light-dismiss-invalidation.html.ini
+++ b/tests/wpt/meta/html/semantics/forms/the-select-element/customizable-select/select-pseudo-light-dismiss-invalidation.html.ini
@@ -1,3 +1,4 @@
 [select-pseudo-light-dismiss-invalidation.html]
+  expected: ERROR
   [select should not match :open when light dismissed.]
     expected: FAIL

--- a/tests/wpt/meta/html/semantics/forms/the-select-element/customizable-select/select-type-to-search.tentative.html.ini
+++ b/tests/wpt/meta/html/semantics/forms/the-select-element/customizable-select/select-type-to-search.tentative.html.ini
@@ -1,3 +1,4 @@
 [select-type-to-search.tentative.html]
+  expected: ERROR
   [Type to search should focus but not select an option until selection is confirmed.]
     expected: FAIL

--- a/tests/wpt/meta/html/semantics/forms/the-select-element/select-option-focusable.tentative.html.ini
+++ b/tests/wpt/meta/html/semantics/forms/the-select-element/select-option-focusable.tentative.html.ini
@@ -1,3 +1,4 @@
 [select-option-focusable.tentative.html]
+  expected: ERROR
   [Validate <option> is focusable when is a descendant of <select>]
     expected: FAIL

--- a/tests/wpt/meta/html/semantics/interactive-elements/the-dialog-element/dialog-open-pseudo-invalidation.html.ini
+++ b/tests/wpt/meta/html/semantics/interactive-elements/the-dialog-element/dialog-open-pseudo-invalidation.html.ini
@@ -1,2 +1,0 @@
-[dialog-open-pseudo-invalidation.html]
-  expected: FAIL


### PR DESCRIPTION
Add support for `:open` pseudo-class. This is supported on dialog, details and select elements.


Stylo PR: servo/stylo#297
Testing: WPTs but also `data:text/html,<select><option>123</option></select><style>:open { background-color: red; }</style>`. There are some tests that now error, these previously failed due to missing `:open` and now make it further along hitting test_driver.send_keys() which causes them to error
Fixes: #41277.

