### PR TITLE
deny: Ignore `GHSA-hcp2-x6j4-29j7` to unblock CI.

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -31,6 +31,10 @@ ignore = [
     # The crate `bincode` is unmaintained. This crate is now pinned in Servo.
     # See the comment above `bincode` entry in Cargo.toml.
     "RUSTSEC-2025-0141",
+    # The crate `ml-dsa 0.0.4` is the latest stable release.
+    # The attack complexity of this vulnerability is high,
+    # and no exploit is known yet.
+    "RUSTSEC-2025-0144"
 ]
 
 # This section is considered when running `cargo deny check licenses`

--- a/deny.toml
+++ b/deny.toml
@@ -34,7 +34,7 @@ ignore = [
     # The crate `ml-dsa 0.0.4` is the latest stable release.
     # The attack complexity of this vulnerability is high,
     # and no exploit is known yet.
-    "RUSTSEC-2025-0144"
+    "RUSTSEC-2025-0144",
 ]
 
 # This section is considered when running `cargo deny check licenses`


### PR DESCRIPTION
This vulnerability is just issued 3 hours ago. It is patched in >=0.1.0-rc.3, but we tried last week: it takes significant effort to upgrade: https://github.com/servo/servo/pull/42120#issuecomment-3793543197

Given that it blocks the CI, no exploit is known yet, and the high attack complexity, we should ignore it for now.