### PR TITLE
script: Use global's origin in Request constructor.

### DIFF
--- a/components/script/dom/request.rs
+++ b/components/script/dom/request.rs
@@ -147,8 +147,7 @@ impl Request {
         }
 
         // Step 7. Let origin be this’s relevant settings object’s origin.
-        // TODO: `entry settings object` is not implemented yet.
-        let origin = base_url.origin();
+        let origin = global.origin().immutable();
 
         // Step 8. Let traversableForUserPrompts be "client".
         let mut traversable_for_user_prompts = TraversableForUserPrompts::Client;
@@ -241,7 +240,7 @@ impl Request {
                     if (parsed_referrer.cannot_be_a_base() &&
                         parsed_referrer.scheme() == "about" &&
                         parsed_referrer.path() == "client") ||
-                        parsed_referrer.origin() != origin
+                        parsed_referrer.origin() != *origin
                     {
                         // then set request’s referrer to "client".
                         request.referrer = global.get_referrer();

--- a/tests/wpt/meta/referrer-policy/generic/inheritance/iframe-inheritance-javascript.html.ini
+++ b/tests/wpt/meta/referrer-policy/generic/inheritance/iframe-inheritance-javascript.html.ini
@@ -1,3 +1,0 @@
-[iframe-inheritance-javascript.html]
-  [Referrer Policy: iframes with javascript url reuse referrer policy 1]
-    expected: FAIL


### PR DESCRIPTION
There are subtle differences between a global's origin and its URL's origin, and it's easy to hit them with special URLs like about:blank. The code being replaced was written before we has separate origins for globals.

Testing: Newly passing WPT test.
