### PR TITLE
script: Do not track outdated oustanding loads for stylesheets.

### DIFF
--- a/components/script/dom/html/htmllinkelement.rs
+++ b/components/script/dom/html/htmllinkelement.rs
@@ -629,6 +629,7 @@ impl HTMLLinkElement {
 
         self.request_generation_id
             .set(self.request_generation_id.get().increment());
+        self.pending_loads.set(0);
 
         let loader = ElementStylesheetLoader::new(self.upcast());
         loader.load(

--- a/components/script/stylesheet_loader.rs
+++ b/components/script/stylesheet_loader.rs
@@ -379,13 +379,6 @@ impl FetchResponseListener for StylesheetContext {
             if !self.contributes_to_the_styling_processing_model(&element) {
                 // Step 2.1. Remove el from el's node document's script-blocking style sheet set.
                 self.decrement_load_and_render_blockers(&document);
-                let owner = element
-                    .upcast::<Element>()
-                    .as_stylesheet_owner()
-                    .expect("Stylesheet not loaded by <style> or <link> element!");
-                // Always consider ignored loads as successful, as they shouldn't cause any subsequent
-                // successful loads to fire an "error" event.
-                owner.load_finished(true);
                 document.finish_load(LoadType::Stylesheet(self.url), CanGc::note());
                 // Step 2.2. Return.
                 return;


### PR DESCRIPTION
The `HTMLLinkElement::pending_loads` field should only be used to track outstanding loads for the current generation; any loads from previous generations can be ignored. This avoids confusion about when to dispatch load/error events. See https://github.com/servo/servo/issues/42187#issuecomment-3808888585 for more details about how the timing of multiple loads for the same `<link>` element resulted in intermittent timeouts in one WPT test.

Testing: Intermittent failure did not appear within 75 runs; previously reproduced within 15.
Fixes: #42187
