### PR TITLE
layout: Support text carets on empty lines in <textarea>

### DIFF
--- a/components/layout/display_list/mod.rs
+++ b/components/layout/display_list/mod.rs
@@ -794,7 +794,7 @@ impl Fragment {
             include_whitespace,
         );
 
-        if glyphs.is_empty() && fragment.offsets.is_none() {
+        if glyphs.is_empty() && !fragment.is_empty_for_text_cursor {
             return;
         }
 
@@ -1008,6 +1008,18 @@ impl Fragment {
 
         if offsets.character_range.start > shared_selection.character_range.end ||
             offsets.character_range.end < shared_selection.character_range.start
+        {
+            return;
+        }
+
+        // When there is an active selection, the line is empty, and there is a forced linebreak,
+        // layout will push an empty fragment in order to trigger painting of the cursor on an empty line.
+        // This code ensure that it is only painted if the cursor is on the starting index of the empty
+        // fragment.
+        if fragment.is_empty_for_text_cursor &&
+            !offsets
+                .character_range
+                .contains(&shared_selection.character_range.start)
         {
             return;
         }

--- a/components/layout/display_list/mod.rs
+++ b/components/layout/display_list/mod.rs
@@ -794,7 +794,7 @@ impl Fragment {
             include_whitespace,
         );
 
-        if glyphs.is_empty() {
+        if glyphs.is_empty() && fragment.offsets.is_none() {
             return;
         }
 

--- a/components/layout/flow/inline/line.rs
+++ b/components/layout/flow/inline/line.rs
@@ -535,7 +535,7 @@ impl LineItemLayout<'_, '_> {
     }
 
     fn layout_text_run(&mut self, text_item: TextRunLineItem) {
-        if text_item.text.is_empty() && text_item.offsets.is_none() {
+        if text_item.text.is_empty() && !text_item.is_empty_for_text_cursor {
             return;
         }
 
@@ -586,6 +586,7 @@ impl LineItemLayout<'_, '_> {
                 glyphs: text_item.text,
                 justification_adjustment: self.justification_adjustment,
                 offsets: text_item.offsets,
+                is_empty_for_text_cursor: text_item.is_empty_for_text_cursor,
             })),
             content_rect,
         ));
@@ -798,7 +799,7 @@ impl LineItem {
     }
 }
 
-#[derive(MallocSizeOf)]
+#[derive(Debug, MallocSizeOf)]
 pub(crate) struct TextRunOffsets {
     /// The selection range of the containing inline formatting context.
     #[ignore_malloc_size_of = "This is stored primarily in the DOM"]
@@ -819,6 +820,9 @@ pub(super) struct TextRunLineItem {
     /// When necessary, this field store the [`TextRunOffsets`] for a particular
     /// [`TextRunLineItem`]. This is currently only used inside of text inputs.
     pub offsets: Option<Box<TextRunOffsets>>,
+    /// Whether or not this [`TextFragment`] is an empty fragment added for the
+    /// benefit of placing a text cursor on an otherwise empty editable line.
+    pub is_empty_for_text_cursor: bool,
 }
 
 impl TextRunLineItem {

--- a/components/layout/flow/inline/line.rs
+++ b/components/layout/flow/inline/line.rs
@@ -535,7 +535,7 @@ impl LineItemLayout<'_, '_> {
     }
 
     fn layout_text_run(&mut self, text_item: TextRunLineItem) {
-        if text_item.text.is_empty() {
+        if text_item.text.is_empty() && text_item.offsets.is_none() {
             return;
         }
 

--- a/components/layout/flow/inline/mod.rs
+++ b/components/layout/flow/inline/mod.rs
@@ -129,7 +129,7 @@ use crate::flow::{
 };
 use crate::formatting_contexts::{Baselines, IndependentFormattingContext};
 use crate::fragment_tree::{
-    BaseFragmentInfo, BoxFragment, CollapsedMargin, Fragment, FragmentFlags, PositioningFragment,
+    BoxFragment, CollapsedMargin, Fragment, FragmentFlags, PositioningFragment,
 };
 use crate::geom::{LogicalRect, LogicalSides1D, LogicalVec2, ToLogical};
 use crate::layout_box_base::LayoutBoxBase;
@@ -888,7 +888,7 @@ struct InlineFormattingContextLayout<'layout_data> {
     /// as soon as we encounter the `<br>` the `<span>`'s ending inline borders would be
     /// placed on the second line, because we add those borders in
     /// [`InlineFormattingContextLayout::finish_inline_box()`].
-    linebreak_before_new_content: Option<DeferredLineBreak>,
+    linebreak_before_new_content: bool,
 
     /// When a `<br>` element has `clear`, this needs to be applied after the linebreak,
     /// which will be processed *after* the `<br>` element is processed. This member
@@ -915,14 +915,6 @@ struct InlineFormattingContextLayout<'layout_data> {
     /// by the boundary between two characters, the text-wrap-mode property of their nearest
     /// common ancestor is used.
     text_wrap_mode: TextWrapMode,
-}
-
-struct DeferredLineBreak {
-    base_fragment_info: BaseFragmentInfo,
-    inline_styles: SharedInlineStyles,
-    font: FontRef,
-    bidi_level: Level,
-    offsets: Option<TextRunOffsets>,
 }
 
 impl InlineFormattingContextLayout<'_> {
@@ -1526,7 +1518,7 @@ impl InlineFormattingContextLayout<'_> {
         inline_would_overflow
     }
 
-    fn defer_forced_line_break(&mut self, line_break: DeferredLineBreak) {
+    fn defer_forced_line_break(&mut self) {
         // If the current portion of the unbreakable segment does not fit on the current line
         // we need to put it on a new line *before* actually triggering the hard line break.
         if !self.unbreakable_segment_fits_on_line() {
@@ -1534,7 +1526,7 @@ impl InlineFormattingContextLayout<'_> {
         }
 
         // Defer the actual line break until we've cleared all ending inline boxes.
-        self.linebreak_before_new_content = Some(line_break);
+        self.linebreak_before_new_content = true;
 
         // In quirks mode, the line-height isn't automatically added to the line. If we consider a
         // forced line break a kind of preserved white space, quirks mode requires that we add the
@@ -1558,24 +1550,14 @@ impl InlineFormattingContextLayout<'_> {
         }
     }
 
-    fn possibly_flush_deferred_forced_line_break(&mut self, is_ifc_end: bool) {
-        if let Some(line_break) = self.linebreak_before_new_content.take() {
-            self.push_glyph_store_to_unbreakable_segment(
-                None,
-                line_break.base_fragment_info,
-                line_break.inline_styles,
-                &line_break.font,
-                line_break.bidi_level,
-                line_break.offsets,
-            );
-
-            if !is_ifc_end {
-                self.commit_current_segment_to_line();
-                self.process_line_break(true /* forced_line_break */);
-            }
-
-            self.linebreak_before_new_content = None;
+    fn possibly_flush_deferred_forced_line_break(&mut self) {
+        if !self.linebreak_before_new_content {
+            return;
         }
+
+        self.commit_current_segment_to_line();
+        self.process_line_break(true /* forced_line_break */);
+        self.linebreak_before_new_content = false;
     }
 
     fn push_line_item_to_unbreakable_segment(&mut self, line_item: LineItem) {
@@ -1585,23 +1567,15 @@ impl InlineFormattingContextLayout<'_> {
 
     fn push_glyph_store_to_unbreakable_segment(
         &mut self,
-        glyph_store: Option<Arc<GlyphStore>>,
-        base_fragment_info: BaseFragmentInfo,
-        inline_styles: SharedInlineStyles,
+        glyph_store: Arc<GlyphStore>,
+        text_run: &TextRun,
         font: &FontRef,
         bidi_level: Level,
         offsets: Option<TextRunOffsets>,
     ) {
-        let inline_advance = glyph_store
-            .as_ref()
-            .map(|gs| gs.total_advance())
-            .unwrap_or_default();
-        let flags = if glyph_store
-            .as_ref()
-            .map(|gs| gs.is_whitespace())
-            .unwrap_or(false)
-        {
-            SegmentContentFlags::from(inline_styles.style.borrow().get_inherited_text())
+        let inline_advance = glyph_store.total_advance();
+        let flags = if glyph_store.is_whitespace() {
+            SegmentContentFlags::from(text_run.inline_styles.style.borrow().get_inherited_text())
         } else {
             SegmentContentFlags::empty()
         };
@@ -1648,31 +1622,65 @@ impl InlineFormattingContextLayout<'_> {
         self.update_unbreakable_segment_for_new_content(&block_contribution, inline_advance, flags);
 
         let current_inline_box_identifier = self.current_inline_box_identifier();
-        if let Some(glyphs) = &glyph_store {
-            if let Some(LineItem::TextRun(inline_box_identifier, line_item)) =
-                self.current_line_segment.line_items.last_mut()
+        if let Some(LineItem::TextRun(inline_box_identifier, line_item)) =
+            self.current_line_segment.line_items.last_mut()
+        {
+            if *inline_box_identifier == current_inline_box_identifier &&
+                line_item.merge_if_possible(font_key, bidi_level, &glyph_store, &offsets)
             {
-                if *inline_box_identifier == current_inline_box_identifier &&
-                    line_item.merge_if_possible(font_key, bidi_level, glyphs, &offsets)
-                {
-                    return;
-                }
+                return;
             }
         }
 
-        let text = glyph_store.map(|gs| vec![gs]).unwrap_or_default();
         self.push_line_item_to_unbreakable_segment(LineItem::TextRun(
             current_inline_box_identifier,
             TextRunLineItem {
-                text,
-                base_fragment_info,
-                inline_styles,
+                text: vec![glyph_store],
+                base_fragment_info: text_run.base_fragment_info,
+                inline_styles: text_run.inline_styles.clone(),
                 font_metrics: font_metrics.clone(),
                 font_key,
                 bidi_level,
                 offsets: offsets.map(Box::new),
+                is_empty_for_text_cursor: false,
             },
         ));
+    }
+
+    /// If the current unbreakable line segment is empty and this [`InlineFormattingContext`] has a
+    /// selection, push [`LineItem::TextRun`]. This is used as a placeholder for rendering cursors
+    /// on empty lines.
+    fn possibly_push_empty_text_run_to_unbreakable_segment(
+        &mut self,
+        text_run: &TextRun,
+        font: &FontRef,
+        bidi_level: Level,
+        offsets: Option<TextRunOffsets>,
+    ) {
+        if offsets.is_none() || self.current_line_segment.has_content {
+            return;
+        }
+
+        let font_metrics = &font.metrics;
+        let font_key = font.key(
+            self.layout_context.painter_id,
+            &self.layout_context.font_context,
+        );
+
+        self.push_line_item_to_unbreakable_segment(LineItem::TextRun(
+            self.current_inline_box_identifier(),
+            TextRunLineItem {
+                text: Default::default(),
+                base_fragment_info: text_run.base_fragment_info,
+                inline_styles: text_run.inline_styles.clone(),
+                font_metrics: font_metrics.clone(),
+                font_key,
+                bidi_level,
+                offsets: offsets.map(Box::new),
+                is_empty_for_text_cursor: true,
+            },
+        ));
+        self.current_line_segment.has_content = true;
     }
 
     fn update_unbreakable_segment_for_new_content(
@@ -2005,7 +2013,7 @@ impl InlineFormattingContext {
             inline_box_state_stack: Vec::new(),
             inline_box_states: Vec::with_capacity(self.inline_boxes.len()),
             current_line_segment: UnbreakableSegmentUnderConstruction::new(),
-            linebreak_before_new_content: None,
+            linebreak_before_new_content: false,
             deferred_br_clear: Clear::None,
             have_deferred_soft_wrap_opportunity: false,
             depends_on_block_constraints: false,
@@ -2016,7 +2024,7 @@ impl InlineFormattingContext {
         for item in self.inline_items.iter() {
             // Any new box should flush a pending hard line break.
             if !matches!(item, InlineItem::EndInlineBox) {
-                layout.possibly_flush_deferred_forced_line_break(false);
+                layout.possibly_flush_deferred_forced_line_break();
             }
 
             match item {
@@ -2053,7 +2061,6 @@ impl InlineFormattingContext {
             }
         }
 
-        layout.possibly_flush_deferred_forced_line_break(true);
         layout.finish_last_line();
         let (content_block_size, collapsible_margins_in_children, baselines) =
             layout.placement_state.finish();

--- a/components/layout/flow/inline/mod.rs
+++ b/components/layout/flow/inline/mod.rs
@@ -129,7 +129,7 @@ use crate::flow::{
 };
 use crate::formatting_contexts::{Baselines, IndependentFormattingContext};
 use crate::fragment_tree::{
-    BoxFragment, CollapsedMargin, Fragment, FragmentFlags, PositioningFragment,
+    BaseFragmentInfo, BoxFragment, CollapsedMargin, Fragment, FragmentFlags, PositioningFragment,
 };
 use crate::geom::{LogicalRect, LogicalSides1D, LogicalVec2, ToLogical};
 use crate::layout_box_base::LayoutBoxBase;
@@ -888,7 +888,7 @@ struct InlineFormattingContextLayout<'layout_data> {
     /// as soon as we encounter the `<br>` the `<span>`'s ending inline borders would be
     /// placed on the second line, because we add those borders in
     /// [`InlineFormattingContextLayout::finish_inline_box()`].
-    linebreak_before_new_content: bool,
+    linebreak_before_new_content: Option<DeferredLineBreak>,
 
     /// When a `<br>` element has `clear`, this needs to be applied after the linebreak,
     /// which will be processed *after* the `<br>` element is processed. This member
@@ -915,6 +915,14 @@ struct InlineFormattingContextLayout<'layout_data> {
     /// by the boundary between two characters, the text-wrap-mode property of their nearest
     /// common ancestor is used.
     text_wrap_mode: TextWrapMode,
+}
+
+struct DeferredLineBreak {
+    base_fragment_info: BaseFragmentInfo,
+    inline_styles: SharedInlineStyles,
+    font: FontRef,
+    bidi_level: Level,
+    offsets: Option<TextRunOffsets>,
 }
 
 impl InlineFormattingContextLayout<'_> {
@@ -1518,7 +1526,7 @@ impl InlineFormattingContextLayout<'_> {
         inline_would_overflow
     }
 
-    fn defer_forced_line_break(&mut self) {
+    fn defer_forced_line_break(&mut self, line_break: DeferredLineBreak) {
         // If the current portion of the unbreakable segment does not fit on the current line
         // we need to put it on a new line *before* actually triggering the hard line break.
         if !self.unbreakable_segment_fits_on_line() {
@@ -1526,7 +1534,7 @@ impl InlineFormattingContextLayout<'_> {
         }
 
         // Defer the actual line break until we've cleared all ending inline boxes.
-        self.linebreak_before_new_content = true;
+        self.linebreak_before_new_content = Some(line_break);
 
         // In quirks mode, the line-height isn't automatically added to the line. If we consider a
         // forced line break a kind of preserved white space, quirks mode requires that we add the
@@ -1550,14 +1558,24 @@ impl InlineFormattingContextLayout<'_> {
         }
     }
 
-    fn possibly_flush_deferred_forced_line_break(&mut self) {
-        if !self.linebreak_before_new_content {
-            return;
-        }
+    fn possibly_flush_deferred_forced_line_break(&mut self, is_ifc_end: bool) {
+        if let Some(line_break) = self.linebreak_before_new_content.take() {
+            self.push_glyph_store_to_unbreakable_segment(
+                None,
+                line_break.base_fragment_info,
+                line_break.inline_styles,
+                &line_break.font,
+                line_break.bidi_level,
+                line_break.offsets,
+            );
 
-        self.commit_current_segment_to_line();
-        self.process_line_break(true /* forced_line_break */);
-        self.linebreak_before_new_content = false;
+            if !is_ifc_end {
+                self.commit_current_segment_to_line();
+                self.process_line_break(true /* forced_line_break */);
+            }
+
+            self.linebreak_before_new_content = None;
+        }
     }
 
     fn push_line_item_to_unbreakable_segment(&mut self, line_item: LineItem) {
@@ -1567,15 +1585,23 @@ impl InlineFormattingContextLayout<'_> {
 
     fn push_glyph_store_to_unbreakable_segment(
         &mut self,
-        glyph_store: Arc<GlyphStore>,
-        text_run: &TextRun,
+        glyph_store: Option<Arc<GlyphStore>>,
+        base_fragment_info: BaseFragmentInfo,
+        inline_styles: SharedInlineStyles,
         font: &FontRef,
         bidi_level: Level,
         offsets: Option<TextRunOffsets>,
     ) {
-        let inline_advance = glyph_store.total_advance();
-        let flags = if glyph_store.is_whitespace() {
-            SegmentContentFlags::from(text_run.inline_styles.style.borrow().get_inherited_text())
+        let inline_advance = glyph_store
+            .as_ref()
+            .map(|gs| gs.total_advance())
+            .unwrap_or_default();
+        let flags = if glyph_store
+            .as_ref()
+            .map(|gs| gs.is_whitespace())
+            .unwrap_or(false)
+        {
+            SegmentContentFlags::from(inline_styles.style.borrow().get_inherited_text())
         } else {
             SegmentContentFlags::empty()
         };
@@ -1622,22 +1648,25 @@ impl InlineFormattingContextLayout<'_> {
         self.update_unbreakable_segment_for_new_content(&block_contribution, inline_advance, flags);
 
         let current_inline_box_identifier = self.current_inline_box_identifier();
-        if let Some(LineItem::TextRun(inline_box_identifier, line_item)) =
-            self.current_line_segment.line_items.last_mut()
-        {
-            if *inline_box_identifier == current_inline_box_identifier &&
-                line_item.merge_if_possible(font_key, bidi_level, &glyph_store, &offsets)
+        if let Some(glyphs) = &glyph_store {
+            if let Some(LineItem::TextRun(inline_box_identifier, line_item)) =
+                self.current_line_segment.line_items.last_mut()
             {
-                return;
+                if *inline_box_identifier == current_inline_box_identifier &&
+                    line_item.merge_if_possible(font_key, bidi_level, glyphs, &offsets)
+                {
+                    return;
+                }
             }
         }
 
+        let text = glyph_store.map(|gs| vec![gs]).unwrap_or_default();
         self.push_line_item_to_unbreakable_segment(LineItem::TextRun(
             current_inline_box_identifier,
             TextRunLineItem {
-                text: vec![glyph_store],
-                base_fragment_info: text_run.base_fragment_info,
-                inline_styles: text_run.inline_styles.clone(),
+                text,
+                base_fragment_info,
+                inline_styles,
                 font_metrics: font_metrics.clone(),
                 font_key,
                 bidi_level,
@@ -1976,7 +2005,7 @@ impl InlineFormattingContext {
             inline_box_state_stack: Vec::new(),
             inline_box_states: Vec::with_capacity(self.inline_boxes.len()),
             current_line_segment: UnbreakableSegmentUnderConstruction::new(),
-            linebreak_before_new_content: false,
+            linebreak_before_new_content: None,
             deferred_br_clear: Clear::None,
             have_deferred_soft_wrap_opportunity: false,
             depends_on_block_constraints: false,
@@ -1987,7 +2016,7 @@ impl InlineFormattingContext {
         for item in self.inline_items.iter() {
             // Any new box should flush a pending hard line break.
             if !matches!(item, InlineItem::EndInlineBox) {
-                layout.possibly_flush_deferred_forced_line_break();
+                layout.possibly_flush_deferred_forced_line_break(false);
             }
 
             match item {
@@ -2024,6 +2053,7 @@ impl InlineFormattingContext {
             }
         }
 
+        layout.possibly_flush_deferred_forced_line_break(true);
         layout.finish_last_line();
         let (content_block_size, collapsible_margins_in_children, baselines) =
             layout.placement_state.finish();

--- a/components/layout/flow/inline/text_run.rs
+++ b/components/layout/flow/inline/text_run.rs
@@ -28,7 +28,6 @@ use super::line_breaker::LineBreaker;
 use super::{InlineFormattingContextLayout, SharedInlineStyles};
 use crate::context::LayoutContext;
 use crate::dom::WeakLayoutBox;
-use crate::flow::inline::DeferredLineBreak;
 use crate::flow::inline::line::TextRunOffsets;
 use crate::fragment_tree::BaseFragmentInfo;
 
@@ -147,57 +146,47 @@ impl TextRunSegment {
 
         let mut character_range_start = self.character_range.start;
         for (run_index, run) in self.runs.iter().enumerate() {
-            ifc.possibly_flush_deferred_forced_line_break(false);
+            ifc.possibly_flush_deferred_forced_line_break();
+
+            let new_character_range_end = character_range_start + run.character_count();
+            let offsets = ifc
+                .ifc
+                .shared_selection
+                .clone()
+                .map(|shared_selection| TextRunOffsets {
+                    shared_selection,
+                    character_range: character_range_start..new_character_range_end,
+                });
 
             // If this whitespace forces a line break, queue up a hard line break the next time we
             // see any content. We don't line break immediately, because we'd like to finish processing
             // any ongoing inline boxes before ending the line.
             if run.is_single_preserved_newline() {
-                let offsets =
-                    ifc.ifc
-                        .shared_selection
-                        .clone()
-                        .map(|shared_selection| TextRunOffsets {
-                            shared_selection,
-                            character_range: character_range_start..character_range_start,
-                        });
-
-                ifc.defer_forced_line_break(DeferredLineBreak {
-                    base_fragment_info: text_run.base_fragment_info,
-                    inline_styles: text_run.inline_styles.clone(),
-                    font: self.font.clone(),
-                    bidi_level: self.bidi_level,
-                    offsets,
-                });
-                character_range_start += run.character_count();
-            } else {
-                // Break before each unbreakable run in this TextRun, except the first unless the
-                // linebreaker was set to break before the first run.
-                if run_index != 0 || soft_wrap_policy == SegmentStartSoftWrapPolicy::Force {
-                    ifc.process_soft_wrap_opportunity();
-                }
-
-                let new_character_range_end = character_range_start + run.character_count();
-
-                let offsets =
-                    ifc.ifc
-                        .shared_selection
-                        .clone()
-                        .map(|shared_selection| TextRunOffsets {
-                            shared_selection,
-                            character_range: character_range_start..new_character_range_end,
-                        });
-
-                ifc.push_glyph_store_to_unbreakable_segment(
-                    Some(run.clone()),
-                    text_run.base_fragment_info,
-                    text_run.inline_styles.clone(),
+                ifc.possibly_push_empty_text_run_to_unbreakable_segment(
+                    text_run,
                     &self.font,
                     self.bidi_level,
                     offsets,
                 );
                 character_range_start = new_character_range_end;
+                ifc.defer_forced_line_break();
+                continue;
             }
+
+            // Break before each unbreakable run in this TextRun, except the first unless the
+            // linebreaker was set to break before the first run.
+            if run_index != 0 || soft_wrap_policy == SegmentStartSoftWrapPolicy::Force {
+                ifc.process_soft_wrap_opportunity();
+            }
+
+            ifc.push_glyph_store_to_unbreakable_segment(
+                run.clone(),
+                text_run,
+                &self.font,
+                self.bidi_level,
+                offsets,
+            );
+            character_range_start = new_character_range_end;
         }
     }
 

--- a/components/layout/fragment_tree/fragment.rs
+++ b/components/layout/fragment_tree/fragment.rs
@@ -77,6 +77,9 @@ pub(crate) struct TextFragment {
     /// When necessary, this field store the [`TextRunOffsets`] for a particular
     /// [`TextRunLineItem`]. This is currently only used inside of text inputs.
     pub offsets: Option<Box<TextRunOffsets>>,
+    /// Whether or not this [`TextFragment`] is an empty fragment added for the
+    /// benefit of placing a text cursor on an otherwise empty editable line.
+    pub is_empty_for_text_cursor: bool,
 }
 
 #[derive(MallocSizeOf)]

--- a/tests/wpt/mozilla/meta/MANIFEST.json
+++ b/tests/wpt/mozilla/meta/MANIFEST.json
@@ -282,6 +282,19 @@
       {}
      ]
     ],
+    "textarea-caret-following-linebreak-blank-line.html": [
+     "c6cfb2563e8fa736bf85dcadb7d20e862a4b5d52",
+     [
+      null,
+      [
+       [
+        "/_mozilla/appearance/textarea-caret-following-linebreak-blank-line-ref.html",
+        "=="
+       ]
+      ],
+      {}
+     ]
+    ],
     "textarea-caret-following-linebreak.html": [
      "55bc06e372e9ce8ad4d62d368a644c1f1cd3ffd9",
      [
@@ -8355,6 +8368,10 @@
     },
     "text-advance-less-than-ink-clipping-ref.html": [
      "af9ec609b175040a66756fb6ce00d81a2e5707ec",
+     []
+    ],
+    "textarea-caret-following-linebreak-blank-line-ref.html": [
+     "5e70ba743b12012fe3b1116414107cf50ef6a8ab",
      []
     ],
     "textarea-caret-following-linebreak-ref.html": [

--- a/tests/wpt/mozilla/tests/appearance/textarea-caret-following-linebreak-blank-line-ref.html
+++ b/tests/wpt/mozilla/tests/appearance/textarea-caret-following-linebreak-blank-line-ref.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <style>
+    textarea {
+        caret-animation: manual;
+    }
+    </style>
+</head>
+<body>
+    <textarea cols=50 rows="5">Caret should render below&#13;&ZeroWidthSpace;&#13;Caret should render above</textarea>
+    <script>
+        const textarea = document.getElementsByTagName('textarea')[0];
+        textarea.setSelectionRange(27, 27);
+        textarea.focus();
+    </script>
+</body>

--- a/tests/wpt/mozilla/tests/appearance/textarea-caret-following-linebreak-blank-line.html
+++ b/tests/wpt/mozilla/tests/appearance/textarea-caret-following-linebreak-blank-line.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <link rel="match" href="textarea-caret-following-linebreak-blank-line-ref.html">
+    <style>
+    textarea {
+        caret-animation: manual;
+    }
+    </style>
+</head>
+<body>
+    <textarea cols=50 rows="5">Caret should render below&#13;&#13;Caret should render above</textarea>
+    <script>
+        const textarea = document.getElementsByTagName('textarea')[0];
+        textarea.setSelectionRange(26, 26);
+        textarea.focus();
+    </script>
+</body>


### PR DESCRIPTION
This PR modifies the text layout in such a way that text carets can render on empty lines (other than the first if the textarea is empty). Zero-length segments are added to support caret rendering. The last line, if it is without content, does not currently render a caret correctly

This corresponds to cases 0, 1, and 3 in #41338

Testing: WPT subset `tests/wpt/tests/css/css-text/` ran as expected, one internal WPT test was added
Fixes: Partially addresses https://github.com/servo/servo/issues/41338