### PR TITLE
devtools: Remove unsupported serde annotations from `shared/devtools.rs`

### DIFF
--- a/components/devtools/actors/watcher.rs
+++ b/components/devtools/actors/watcher.rs
@@ -12,9 +12,9 @@
 
 use std::collections::HashMap;
 use std::net::TcpStream;
-use std::time::{SystemTime, UNIX_EPOCH};
 
 use base::id::BrowsingContextId;
+use devtools_traits::get_time_stamp;
 use log::warn;
 use serde::Serialize;
 use serde_json::{Map, Value};
@@ -196,7 +196,7 @@ pub(crate) struct WillNavigateMessage {
     browsing_context_id: u32,
     inner_window_id: u32,
     name: String,
-    time: u128,
+    time: u64,
     is_frame_switching: bool,
     #[serde(rename = "newURI")]
     new_uri: ServoUrl,
@@ -293,11 +293,7 @@ impl Actor for WatcherActor {
                                     has_native_console_api: None,
                                     name: name.into(),
                                     new_uri: None,
-                                    time: SystemTime::now()
-                                        .duration_since(UNIX_EPOCH)
-                                        .unwrap_or_default()
-                                        .as_millis()
-                                        as u64,
+                                    time: get_time_stamp(),
                                     title: Some(target.title.borrow().clone()),
                                     url: Some(target.url.borrow().clone()),
                                 };
@@ -454,10 +450,7 @@ impl WatcherActor {
             browsing_context_id: id_map.browsing_context_id(browsing_context_id).value(),
             inner_window_id: 0, // TODO: set this to the correct value
             name: "will-navigate".to_string(),
-            time: SystemTime::now()
-                .duration_since(UNIX_EPOCH)
-                .unwrap_or_default()
-                .as_millis(),
+            time: get_time_stamp(),
             is_frame_switching: false, // TODO: Implement frame switching
             new_uri: url,
         };

--- a/components/script/dom/globalscope.rs
+++ b/components/script/dom/globalscope.rs
@@ -14,7 +14,7 @@ use std::rc::Rc;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::thread::JoinHandle;
-use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
+use std::time::{Duration, Instant};
 
 use base::generic_channel;
 use base::generic_channel::{GenericCallback, GenericSend};
@@ -29,7 +29,7 @@ use constellation_traits::{
 use content_security_policy::CspList;
 use content_security_policy::sandboxing_directive::SandboxingFlagSet;
 use crossbeam_channel::Sender;
-use devtools_traits::{PageError, ScriptToDevtoolsControlMsg};
+use devtools_traits::{PageError, ScriptToDevtoolsControlMsg, get_time_stamp};
 use dom_struct::dom_struct;
 use embedder_traits::{EmbedderMsg, JavaScriptEvaluationError, ScriptToEmbedderChan};
 use fonts::FontContext;
@@ -2807,16 +2807,7 @@ impl GlobalScope {
                             source_name: error_info.filename.clone(),
                             line_number: error_info.lineno,
                             column_number: error_info.column,
-                            category: "script".to_string(),
-                            time_stamp: SystemTime::now()
-                                .duration_since(UNIX_EPOCH)
-                                .unwrap_or_default()
-                                .as_millis() as u64,
-                            error: true,
-                            warning: false,
-                            info: false,
-                            private: false,
-                            stacktrace: None,
+                            time_stamp: get_time_stamp(),
                         },
                     ));
                 }


### PR DESCRIPTION
There were some `#[serde(untagged)]` and `#[serde(skip*)]` annotations in the shared devtools types. These are needed for correct JSON serialization when sending messages to Firefox, but they fail in multiprocess mode since we are sharing them through the IPC channel with bincode, which doesn't support certain serde tags.

The workaround is to keep all shared types free from problematic annotations, and defining wrapping types that are only used in the devtools crate.

One instance are console messages and page errors. They have been moved to `console.rs`, with `shared/devtools` only keeping the parts that are needed for communication between threads.

The other instance are auto margins. Now the final message is built in `page_style.rs`.

Apologies since both of them were introduced by me, I wasn't aware that we were limited by bincode in multiprocess mode. A warning has been added to `shared/devtools` listing the problematic annotations that shouldn't be used in this file.

Testing: `mach test-devtools` and manual testing using `--multiprocess`.
Fixes: #42170