### PR TITLE
layout: Ensure legacy alignment-related presentational hints match specification

### DIFF
--- a/components/layout/stylesheets/presentational-hints.css
+++ b/components/layout/stylesheets/presentational-hints.css
@@ -135,34 +135,43 @@ hr[color], hr[noshade] { border-style: solid; }
 
 iframe[frameborder="0"], iframe[frameborder=no i] { border: none; }
 
-embed[align=left i], iframe[align=left i], img[type=image i][align=left i], object[align=left i] {
+/* https://html.spec.whatwg.org/multipage/rendering.html#attributes-for-embedded-content-and-images */
+embed[align=left i], iframe[align=left i], img[align=left i],
+input[type=image i][align=left i], object[align=left i] {
   float: left;
 }
-embed[align=right i], iframe[align=right i], img[type=image i][align=right i], object[align=right i] {
+
+embed[align=right i], iframe[align=right i], img[align=right i],
+input[type=image i][align=right i], object[align=right i] {
   float: right;
 }
-embed[align=top i], iframe[align=top i], img[type=image i][align=top i], object[align=top i] {
+
+embed[align=top i], iframe[align=top i], img[align=top i],
+input[type=image i][align=top i], object[align=top i] {
   vertical-align: top;
 }
-embed[align=baseline i], iframe[align=baseline i], img[type=image i][align=baseline i], object[align=baseline i] {
+
+embed[align=baseline i], iframe[align=baseline i], img[align=baseline i],
+input[type=image i][align=baseline i], object[align=baseline i] {
   vertical-align: baseline;
 }
-embed[align=texttop i], iframe[align=texttop i], img[type=image i][align=texttop i], object[align=texttop i] {
+
+embed[align=texttop i], iframe[align=texttop i], img[align=texttop i],
+input[type=image i][align=texttop i], object[align=texttop i] {
   vertical-align: text-top;
 }
-embed[align=absmiddle i], iframe[align=absmiddle i], img[type=image i][align=absmiddle i], object[align=absmiddle i],
-embed[align=abscenter i], iframe[align=abscenter i], img[type=image i][align=abscenter i], object[align=abscenter i] {
+
+embed[align=absmiddle i], iframe[align=absmiddle i], img[align=absmiddle i],
+input[type=image i][align=absmiddle i], object[align=absmiddle i],
+embed[align=abscenter i], iframe[align=abscenter i], img[align=abscenter i],
+input[type=image i][align=abscenter i], object[align=abscenter i] {
   vertical-align: middle;
 }
-embed[align=bottom i], iframe[align=bottom i], img[type=image i][align=bottom i], object[align=bottom i] {
+
+embed[align=bottom i], iframe[align=bottom i], img[align=bottom i],
+input[type=image i][align=bottom i], object[align=bottom i] {
   vertical-align: bottom;
 }
-/*
-FIXME:
-:matches(embed, iframe, img, input[type=image i], object):matches([align=center i], [align=middle i]) {
-  vertical-align: "aligns the vertical middle of the element with the parent element's baseline."
-}
-*/
 
 /*
 
@@ -264,4 +273,3 @@ Extra
   https://html.spec.whatwg.org/multipage/#rendered-legend
 
 */
-

--- a/tests/wpt/meta/html/rendering/replaced-elements/attributes-for-embedded-content-and-images/align.html.ini
+++ b/tests/wpt/meta/html/rendering/replaced-elements/attributes-for-embedded-content-and-images/align.html.ini
@@ -1,22 +1,4 @@
 [align.html]
-  [align=left on replaced elements]
-    expected: FAIL
-
-  [align=right on replaced elements]
-    expected: FAIL
-
-  [align=top on replaced elements]
-    expected: FAIL
-
-  [align=texttop on replaced elements]
-    expected: FAIL
-
-  [align=absmiddle on replaced elements]
-    expected: FAIL
-
-  [align=abscenter on replaced elements]
-    expected: FAIL
-
   [align=absbottom on replaced elements]
     expected: FAIL
 
@@ -24,4 +6,7 @@
     expected: FAIL
 
   [align=center on replaced elements]
+    expected: FAIL
+
+  [align=bottom on replaced elements]
     expected: FAIL

--- a/tests/wpt/meta/html/rendering/replaced-elements/attributes-for-embedded-content-and-images/embedded-and-images-presentational-hints-ascii-case-insensitive.html.ini
+++ b/tests/wpt/meta/html/rendering/replaced-elements/attributes-for-embedded-content-and-images/embedded-and-images-presentational-hints-ascii-case-insensitive.html.ini
@@ -1,9 +1,3 @@
 [embedded-and-images-presentational-hints-ascii-case-insensitive.html]
   [keyword absbottom]
     expected: FAIL
-
-  [keyword abscenter]
-    expected: FAIL
-
-  [keyword absmiddle]
-    expected: FAIL

--- a/tests/wpt/meta/html/rendering/replaced-elements/attributes-for-embedded-content-and-images/input-align-right-1.html.ini
+++ b/tests/wpt/meta/html/rendering/replaced-elements/attributes-for-embedded-content-and-images/input-align-right-1.html.ini
@@ -1,2 +1,0 @@
-[input-align-right-1.html]
-  expected: FAIL

--- a/tests/wpt/meta/html/rendering/replaced-elements/attributes-for-embedded-content-and-images/input-align-right-2.html.ini
+++ b/tests/wpt/meta/html/rendering/replaced-elements/attributes-for-embedded-content-and-images/input-align-right-2.html.ini
@@ -1,2 +1,0 @@
-[input-align-right-2.html]
-  expected: FAIL


### PR DESCRIPTION
The legacy alignment presentation hints differed from the specification
in a way that was breaking them when dealing with `<img>`. The culprit
seems to be the selector `img[type = image i]` which seems a little
nonsensical. This change makes the CSS in `presentational-hints.css`
match what is found in the specification.

There is still an issue with "bottom" alignment of replaced elements and
more investigation is necessary to understand what specified or
unspecified behavior we are failing to implement.

Testing: This fixes a variety of WPT tests.
Fixes: #41048.
