### PR TITLE
wpt: Unskip `css-properties-values-api` tests

### DIFF
--- a/tests/wpt/include.ini
+++ b/tests/wpt/include.ini
@@ -84,8 +84,6 @@ skip: true
     skip: true
   [css-parser-api]
     skip: true
-  [css-properties-values-api]
-    skip: true
   [css-rhythm]
     skip: true
   [css-round-display]

--- a/tests/wpt/meta/css/css-properties-values-api/animate-invalid.html.ini
+++ b/tests/wpt/meta/css/css-properties-values-api/animate-invalid.html.ini
@@ -1,0 +1,3 @@
+[animate-invalid.html]
+  [Do not crash when animating to unresolved var()]
+    expected: FAIL

--- a/tests/wpt/meta/css/css-properties-values-api/animation/custom-property-animation-angle-comma-list.html.ini
+++ b/tests/wpt/meta/css/css-properties-values-api/animation/custom-property-animation-angle-comma-list.html.ini
@@ -1,0 +1,18 @@
+[custom-property-animation-angle-comma-list.html]
+  [Animating a custom property of type <angle>#]
+    expected: FAIL
+
+  [Animating a custom property of type <angle># with a single keyframe]
+    expected: FAIL
+
+  [Animating a custom property of type <angle># with additivity]
+    expected: FAIL
+
+  [Animating a custom property of type <angle># with a single keyframe and additivity]
+    expected: FAIL
+
+  [Animating a custom property of type <angle># with iterationComposite]
+    expected: FAIL
+
+  [Animating a custom property of type <angle># with different lengths is discrete]
+    expected: FAIL

--- a/tests/wpt/meta/css/css-properties-values-api/animation/custom-property-animation-angle-space-list.html.ini
+++ b/tests/wpt/meta/css/css-properties-values-api/animation/custom-property-animation-angle-space-list.html.ini
@@ -1,0 +1,18 @@
+[custom-property-animation-angle-space-list.html]
+  [Animating a custom property of type <angle>+]
+    expected: FAIL
+
+  [Animating a custom property of type <angle>+ with a single keyframe]
+    expected: FAIL
+
+  [Animating a custom property of type <angle>+ with additivity]
+    expected: FAIL
+
+  [Animating a custom property of type <angle>+ with a single keyframe and additivity]
+    expected: FAIL
+
+  [Animating a custom property of type <angle>+ with iterationComposite]
+    expected: FAIL
+
+  [Animating a custom property of type <angle>+ with different lengths is discrete]
+    expected: FAIL

--- a/tests/wpt/meta/css/css-properties-values-api/animation/custom-property-animation-angle.html.ini
+++ b/tests/wpt/meta/css/css-properties-values-api/animation/custom-property-animation-angle.html.ini
@@ -1,0 +1,15 @@
+[custom-property-animation-angle.html]
+  [Animating a custom property of type <angle>]
+    expected: FAIL
+
+  [Animating a custom property of type <angle> with a single keyframe]
+    expected: FAIL
+
+  [Animating a custom property of type <angle> with additivity]
+    expected: FAIL
+
+  [Animating a custom property of type <angle> with a single keyframe and additivity]
+    expected: FAIL
+
+  [Animating a custom property of type <angle> with iterationComposite]
+    expected: FAIL

--- a/tests/wpt/meta/css/css-properties-values-api/animation/custom-property-animation-color-comma-list.html.ini
+++ b/tests/wpt/meta/css/css-properties-values-api/animation/custom-property-animation-color-comma-list.html.ini
@@ -1,0 +1,18 @@
+[custom-property-animation-color-comma-list.html]
+  [Animating a custom property of type <color>#]
+    expected: FAIL
+
+  [Animating a custom property of type <color># with a single keyframe]
+    expected: FAIL
+
+  [Animating a custom property of type <color># with additivity]
+    expected: FAIL
+
+  [Animating a custom property of type <color># with a single keyframe and additivity]
+    expected: FAIL
+
+  [Animating a custom property of type <color># with iterationComposite]
+    expected: FAIL
+
+  [Animating a custom property of type <color># with different lengths is discrete]
+    expected: FAIL

--- a/tests/wpt/meta/css/css-properties-values-api/animation/custom-property-animation-color-space-list.html.ini
+++ b/tests/wpt/meta/css/css-properties-values-api/animation/custom-property-animation-color-space-list.html.ini
@@ -1,0 +1,18 @@
+[custom-property-animation-color-space-list.html]
+  [Animating a custom property of type <color>+]
+    expected: FAIL
+
+  [Animating a custom property of type <color>+ with a single keyframe]
+    expected: FAIL
+
+  [Animating a custom property of type <color>+ with additivity]
+    expected: FAIL
+
+  [Animating a custom property of type <color>+ with a single keyframe and additivity]
+    expected: FAIL
+
+  [Animating a custom property of type <color>+ with iterationComposite]
+    expected: FAIL
+
+  [Animating a custom property of type <color>+ with different lengths is discrete]
+    expected: FAIL

--- a/tests/wpt/meta/css/css-properties-values-api/animation/custom-property-animation-color.html.ini
+++ b/tests/wpt/meta/css/css-properties-values-api/animation/custom-property-animation-color.html.ini
@@ -1,0 +1,15 @@
+[custom-property-animation-color.html]
+  [Animating a custom property of type <color>]
+    expected: FAIL
+
+  [Animating a custom property of type <color> with a single keyframe]
+    expected: FAIL
+
+  [Animating a custom property of type <color> with additivity]
+    expected: FAIL
+
+  [Animating a custom property of type <color> with a single keyframe and additivity]
+    expected: FAIL
+
+  [Animating a custom property of type <color> with iterationComposite]
+    expected: FAIL

--- a/tests/wpt/meta/css/css-properties-values-api/animation/custom-property-animation-custom-ident.html.ini
+++ b/tests/wpt/meta/css/css-properties-values-api/animation/custom-property-animation-custom-ident.html.ini
@@ -1,0 +1,9 @@
+[custom-property-animation-custom-ident.html]
+  [Animating a custom property of type <custom-ident> is discrete]
+    expected: FAIL
+
+  [Animating a custom property of type <custom-ident>+ is discrete]
+    expected: FAIL
+
+  [Animating a custom property of type <custom-ident># is discrete]
+    expected: FAIL

--- a/tests/wpt/meta/css/css-properties-values-api/animation/custom-property-animation-image.html.ini
+++ b/tests/wpt/meta/css/css-properties-values-api/animation/custom-property-animation-image.html.ini
@@ -1,0 +1,9 @@
+[custom-property-animation-image.html]
+  [Animating a custom property of type <image> is discrete]
+    expected: FAIL
+
+  [Animating a custom property of type <image>+ is discrete]
+    expected: FAIL
+
+  [Animating a custom property of type <image># is discrete]
+    expected: FAIL

--- a/tests/wpt/meta/css/css-properties-values-api/animation/custom-property-animation-inherited-used-by-standard-property.html.ini
+++ b/tests/wpt/meta/css/css-properties-values-api/animation/custom-property-animation-inherited-used-by-standard-property.html.ini
@@ -1,0 +1,3 @@
+[custom-property-animation-inherited-used-by-standard-property.html]
+  [Animating an inherited CSS variable on a parent is reflected on a standard property using that variable as a value on a child]
+    expected: FAIL

--- a/tests/wpt/meta/css/css-properties-values-api/animation/custom-property-animation-integer-comma-list.html.ini
+++ b/tests/wpt/meta/css/css-properties-values-api/animation/custom-property-animation-integer-comma-list.html.ini
@@ -1,0 +1,18 @@
+[custom-property-animation-integer-comma-list.html]
+  [Animating a custom property of type <integer>#]
+    expected: FAIL
+
+  [Animating a custom property of type <integer># with a single keyframe]
+    expected: FAIL
+
+  [Animating a custom property of type <integer># with additivity]
+    expected: FAIL
+
+  [Animating a custom property of type <integer># with a single keyframe and additivity]
+    expected: FAIL
+
+  [Animating a custom property of type <integer># with iterationComposite]
+    expected: FAIL
+
+  [Animating a custom property of type <integer># with different lengths is discrete]
+    expected: FAIL

--- a/tests/wpt/meta/css/css-properties-values-api/animation/custom-property-animation-integer-space-list.html.ini
+++ b/tests/wpt/meta/css/css-properties-values-api/animation/custom-property-animation-integer-space-list.html.ini
@@ -1,0 +1,18 @@
+[custom-property-animation-integer-space-list.html]
+  [Animating a custom property of type <integer>+]
+    expected: FAIL
+
+  [Animating a custom property of type <integer>+ with a single keyframe]
+    expected: FAIL
+
+  [Animating a custom property of type <integer>+ with additivity]
+    expected: FAIL
+
+  [Animating a custom property of type <integer>+ with a single keyframe and additivity]
+    expected: FAIL
+
+  [Animating a custom property of type <integer>+ with iterationComposite]
+    expected: FAIL
+
+  [Animating a custom property of type <integer>+ with different lengths is discrete]
+    expected: FAIL

--- a/tests/wpt/meta/css/css-properties-values-api/animation/custom-property-animation-integer.html.ini
+++ b/tests/wpt/meta/css/css-properties-values-api/animation/custom-property-animation-integer.html.ini
@@ -1,0 +1,15 @@
+[custom-property-animation-integer.html]
+  [Animating a custom property of type <integer>]
+    expected: FAIL
+
+  [Animating a custom property of type <integer> with a single keyframe]
+    expected: FAIL
+
+  [Animating a custom property of type <integer> with additivity]
+    expected: FAIL
+
+  [Animating a custom property of type <integer> with a single keyframe and additivity]
+    expected: FAIL
+
+  [Animating a custom property of type <integer> with iterationComposite]
+    expected: FAIL

--- a/tests/wpt/meta/css/css-properties-values-api/animation/custom-property-animation-length-comma-list.html.ini
+++ b/tests/wpt/meta/css/css-properties-values-api/animation/custom-property-animation-length-comma-list.html.ini
@@ -1,0 +1,18 @@
+[custom-property-animation-length-comma-list.html]
+  [Animating a custom property of type <length>#]
+    expected: FAIL
+
+  [Animating a custom property of type <length># with a single keyframe]
+    expected: FAIL
+
+  [Animating a custom property of type <length># with additivity]
+    expected: FAIL
+
+  [Animating a custom property of type <length># with a single keyframe and additivity]
+    expected: FAIL
+
+  [Animating a custom property of type <length># with iterationComposite]
+    expected: FAIL
+
+  [Animating a custom property of type <length># with different lengths is discrete]
+    expected: FAIL

--- a/tests/wpt/meta/css/css-properties-values-api/animation/custom-property-animation-length-percentage-comma-list.html.ini
+++ b/tests/wpt/meta/css/css-properties-values-api/animation/custom-property-animation-length-percentage-comma-list.html.ini
@@ -1,0 +1,18 @@
+[custom-property-animation-length-percentage-comma-list.html]
+  [Animating a custom property of type <length-percentage>#]
+    expected: FAIL
+
+  [Animating a custom property of type <length-percentage># with a single keyframe]
+    expected: FAIL
+
+  [Animating a custom property of type <length-percentage># with additivity]
+    expected: FAIL
+
+  [Animating a custom property of type <length-percentage># with a single keyframe and additivity]
+    expected: FAIL
+
+  [Animating a custom property of type <length-percentage># with iterationComposite]
+    expected: FAIL
+
+  [Animating a custom property of type <length-percentage># with different lengths is discrete]
+    expected: FAIL

--- a/tests/wpt/meta/css/css-properties-values-api/animation/custom-property-animation-length-percentage-space-list.html.ini
+++ b/tests/wpt/meta/css/css-properties-values-api/animation/custom-property-animation-length-percentage-space-list.html.ini
@@ -1,0 +1,18 @@
+[custom-property-animation-length-percentage-space-list.html]
+  [Animating a custom property of type <length-percentage>+]
+    expected: FAIL
+
+  [Animating a custom property of type <length-percentage>+ with a single keyframe]
+    expected: FAIL
+
+  [Animating a custom property of type <length-percentage>+ with additivity]
+    expected: FAIL
+
+  [Animating a custom property of type <length-percentage>+ with a single keyframe and additivity]
+    expected: FAIL
+
+  [Animating a custom property of type <length-percentage>+ with iterationComposite]
+    expected: FAIL
+
+  [Animating a custom property of type <length-percentage>+ with different lengths is discrete]
+    expected: FAIL

--- a/tests/wpt/meta/css/css-properties-values-api/animation/custom-property-animation-length-percentage.html.ini
+++ b/tests/wpt/meta/css/css-properties-values-api/animation/custom-property-animation-length-percentage.html.ini
@@ -1,0 +1,15 @@
+[custom-property-animation-length-percentage.html]
+  [Animating a custom property of type <length-percentage>]
+    expected: FAIL
+
+  [Animating a custom property of type <length-percentage> with a single keyframe]
+    expected: FAIL
+
+  [Animating a custom property of type <length-percentage> with additivity]
+    expected: FAIL
+
+  [Animating a custom property of type <length-percentage> with a single keyframe and additivity]
+    expected: FAIL
+
+  [Animating a custom property of type <length-percentage> with iterationComposite]
+    expected: FAIL

--- a/tests/wpt/meta/css/css-properties-values-api/animation/custom-property-animation-length-space-list.html.ini
+++ b/tests/wpt/meta/css/css-properties-values-api/animation/custom-property-animation-length-space-list.html.ini
@@ -1,0 +1,18 @@
+[custom-property-animation-length-space-list.html]
+  [Animating a custom property of type <length>+]
+    expected: FAIL
+
+  [Animating a custom property of type <length>+ with a single keyframe]
+    expected: FAIL
+
+  [Animating a custom property of type <length>+ with additivity]
+    expected: FAIL
+
+  [Animating a custom property of type <length>+ with a single keyframe and additivity]
+    expected: FAIL
+
+  [Animating a custom property of type <length>+ with iterationComposite]
+    expected: FAIL
+
+  [Animating a custom property of type <length>+ with different lengths is discrete]
+    expected: FAIL

--- a/tests/wpt/meta/css/css-properties-values-api/animation/custom-property-animation-length.html.ini
+++ b/tests/wpt/meta/css/css-properties-values-api/animation/custom-property-animation-length.html.ini
@@ -1,0 +1,15 @@
+[custom-property-animation-length.html]
+  [Animating a custom property of type <length>]
+    expected: FAIL
+
+  [Animating a custom property of type <length> with a single keyframe]
+    expected: FAIL
+
+  [Animating a custom property of type <length> with additivity]
+    expected: FAIL
+
+  [Animating a custom property of type <length> with a single keyframe and additivity]
+    expected: FAIL
+
+  [Animating a custom property of type <length> with iterationComposite]
+    expected: FAIL

--- a/tests/wpt/meta/css/css-properties-values-api/animation/custom-property-animation-list-type-mismatch.html.ini
+++ b/tests/wpt/meta/css/css-properties-values-api/animation/custom-property-animation-list-type-mismatch.html.ini
@@ -1,0 +1,3 @@
+[custom-property-animation-list-type-mismatch.html]
+  [Animating a custom property allowing multiple list types with two mismatching types]
+    expected: FAIL

--- a/tests/wpt/meta/css/css-properties-values-api/animation/custom-property-animation-non-inherited-used-by-standard-property.html.ini
+++ b/tests/wpt/meta/css/css-properties-values-api/animation/custom-property-animation-non-inherited-used-by-standard-property.html.ini
@@ -1,0 +1,3 @@
+[custom-property-animation-non-inherited-used-by-standard-property.html]
+  [Animating a non-inherited CSS variable is reflected on a standard property using that variable as a value]
+    expected: FAIL

--- a/tests/wpt/meta/css/css-properties-values-api/animation/custom-property-animation-number-comma-list.html.ini
+++ b/tests/wpt/meta/css/css-properties-values-api/animation/custom-property-animation-number-comma-list.html.ini
@@ -1,0 +1,18 @@
+[custom-property-animation-number-comma-list.html]
+  [Animating a custom property of type <number>#]
+    expected: FAIL
+
+  [Animating a custom property of type <number># with a single keyframe]
+    expected: FAIL
+
+  [Animating a custom property of type <number># with additivity]
+    expected: FAIL
+
+  [Animating a custom property of type <number># with a single keyframe and additivity]
+    expected: FAIL
+
+  [Animating a custom property of type <number># with iterationComposite]
+    expected: FAIL
+
+  [Animating a custom property of type <number># with different lengths is discrete]
+    expected: FAIL

--- a/tests/wpt/meta/css/css-properties-values-api/animation/custom-property-animation-number-space-list.html.ini
+++ b/tests/wpt/meta/css/css-properties-values-api/animation/custom-property-animation-number-space-list.html.ini
@@ -1,0 +1,18 @@
+[custom-property-animation-number-space-list.html]
+  [Animating a custom property of type <number>+]
+    expected: FAIL
+
+  [Animating a custom property of type <number>+ with a single keyframe]
+    expected: FAIL
+
+  [Animating a custom property of type <number>+ with additivity]
+    expected: FAIL
+
+  [Animating a custom property of type <number>+ with a single keyframe and additivity]
+    expected: FAIL
+
+  [Animating a custom property of type <number>+ with iterationComposite]
+    expected: FAIL
+
+  [Animating a custom property of type <number>+ with different lengths is discrete]
+    expected: FAIL

--- a/tests/wpt/meta/css/css-properties-values-api/animation/custom-property-animation-number.html.ini
+++ b/tests/wpt/meta/css/css-properties-values-api/animation/custom-property-animation-number.html.ini
@@ -1,0 +1,15 @@
+[custom-property-animation-number.html]
+  [Animating a custom property of type <number>]
+    expected: FAIL
+
+  [Animating a custom property of type <number> with a single keyframe]
+    expected: FAIL
+
+  [Animating a custom property of type <number> with additivity]
+    expected: FAIL
+
+  [Animating a custom property of type <number> with a single keyframe and additivity]
+    expected: FAIL
+
+  [Animating a custom property of type <number> with iterationComposite]
+    expected: FAIL

--- a/tests/wpt/meta/css/css-properties-values-api/animation/custom-property-animation-percentage-comma-list.html.ini
+++ b/tests/wpt/meta/css/css-properties-values-api/animation/custom-property-animation-percentage-comma-list.html.ini
@@ -1,0 +1,18 @@
+[custom-property-animation-percentage-comma-list.html]
+  [Animating a custom property of type <percentage>#]
+    expected: FAIL
+
+  [Animating a custom property of type <percentage># with a single keyframe]
+    expected: FAIL
+
+  [Animating a custom property of type <percentage># with additivity]
+    expected: FAIL
+
+  [Animating a custom property of type <percentage># with a single keyframe and additivity]
+    expected: FAIL
+
+  [Animating a custom property of type <percentage># with iterationComposite]
+    expected: FAIL
+
+  [Animating a custom property of type <percentage># with different lengths is discrete]
+    expected: FAIL

--- a/tests/wpt/meta/css/css-properties-values-api/animation/custom-property-animation-percentage-space-list.html.ini
+++ b/tests/wpt/meta/css/css-properties-values-api/animation/custom-property-animation-percentage-space-list.html.ini
@@ -1,0 +1,18 @@
+[custom-property-animation-percentage-space-list.html]
+  [Animating a custom property of type <percentage>+]
+    expected: FAIL
+
+  [Animating a custom property of type <percentage>+ with a single keyframe]
+    expected: FAIL
+
+  [Animating a custom property of type <percentage>+ with additivity]
+    expected: FAIL
+
+  [Animating a custom property of type <percentage>+ with a single keyframe and additivity]
+    expected: FAIL
+
+  [Animating a custom property of type <percentage>+ with iterationComposite]
+    expected: FAIL
+
+  [Animating a custom property of type <percentage>+ with different lengths is discrete]
+    expected: FAIL

--- a/tests/wpt/meta/css/css-properties-values-api/animation/custom-property-animation-percentage.html.ini
+++ b/tests/wpt/meta/css/css-properties-values-api/animation/custom-property-animation-percentage.html.ini
@@ -1,0 +1,15 @@
+[custom-property-animation-percentage.html]
+  [Animating a custom property of type <percentage>]
+    expected: FAIL
+
+  [Animating a custom property of type <percentage> with a single keyframe]
+    expected: FAIL
+
+  [Animating a custom property of type <percentage> with additivity]
+    expected: FAIL
+
+  [Animating a custom property of type <percentage> with a single keyframe and additivity]
+    expected: FAIL
+
+  [Animating a custom property of type <percentage> with iterationComposite]
+    expected: FAIL

--- a/tests/wpt/meta/css/css-properties-values-api/animation/custom-property-animation-resolution-comma-list.html.ini
+++ b/tests/wpt/meta/css/css-properties-values-api/animation/custom-property-animation-resolution-comma-list.html.ini
@@ -1,0 +1,18 @@
+[custom-property-animation-resolution-comma-list.html]
+  [Animating a custom property of type <resolution>#]
+    expected: FAIL
+
+  [Animating a custom property of type <resolution># with a single keyframe]
+    expected: FAIL
+
+  [Animating a custom property of type <resolution># with additivity]
+    expected: FAIL
+
+  [Animating a custom property of type <resolution># with a single keyframe and additivity]
+    expected: FAIL
+
+  [Animating a custom property of type <resolution># with iterationComposite]
+    expected: FAIL
+
+  [Animating a custom property of type <resolution># with different lengths is discrete]
+    expected: FAIL

--- a/tests/wpt/meta/css/css-properties-values-api/animation/custom-property-animation-resolution-space-list.html.ini
+++ b/tests/wpt/meta/css/css-properties-values-api/animation/custom-property-animation-resolution-space-list.html.ini
@@ -1,0 +1,18 @@
+[custom-property-animation-resolution-space-list.html]
+  [Animating a custom property of type <resolution>+]
+    expected: FAIL
+
+  [Animating a custom property of type <resolution>+ with a single keyframe]
+    expected: FAIL
+
+  [Animating a custom property of type <resolution>+ with additivity]
+    expected: FAIL
+
+  [Animating a custom property of type <resolution>+ with a single keyframe and additivity]
+    expected: FAIL
+
+  [Animating a custom property of type <resolution>+ with iterationComposite]
+    expected: FAIL
+
+  [Animating a custom property of type <resolution>+ with different lengths is discrete]
+    expected: FAIL

--- a/tests/wpt/meta/css/css-properties-values-api/animation/custom-property-animation-resolution.html.ini
+++ b/tests/wpt/meta/css/css-properties-values-api/animation/custom-property-animation-resolution.html.ini
@@ -1,0 +1,15 @@
+[custom-property-animation-resolution.html]
+  [Animating a custom property of type <resolution>]
+    expected: FAIL
+
+  [Animating a custom property of type <resolution> with a single keyframe]
+    expected: FAIL
+
+  [Animating a custom property of type <resolution> with additivity]
+    expected: FAIL
+
+  [Animating a custom property of type <resolution> with a single keyframe and additivity]
+    expected: FAIL
+
+  [Animating a custom property of type <resolution> with iterationComposite]
+    expected: FAIL

--- a/tests/wpt/meta/css/css-properties-values-api/animation/custom-property-animation-time-comma-list.html.ini
+++ b/tests/wpt/meta/css/css-properties-values-api/animation/custom-property-animation-time-comma-list.html.ini
@@ -1,0 +1,18 @@
+[custom-property-animation-time-comma-list.html]
+  [Animating a custom property of type <time>#]
+    expected: FAIL
+
+  [Animating a custom property of type <time># with a single keyframe]
+    expected: FAIL
+
+  [Animating a custom property of type <time># with additivity]
+    expected: FAIL
+
+  [Animating a custom property of type <time># with a single keyframe and additivity]
+    expected: FAIL
+
+  [Animating a custom property of type <time># with iterationComposite]
+    expected: FAIL
+
+  [Animating a custom property of type <time># with different lengths is discrete]
+    expected: FAIL

--- a/tests/wpt/meta/css/css-properties-values-api/animation/custom-property-animation-time-space-list.html.ini
+++ b/tests/wpt/meta/css/css-properties-values-api/animation/custom-property-animation-time-space-list.html.ini
@@ -1,0 +1,18 @@
+[custom-property-animation-time-space-list.html]
+  [Animating a custom property of type <time>+]
+    expected: FAIL
+
+  [Animating a custom property of type <time>+ with a single keyframe]
+    expected: FAIL
+
+  [Animating a custom property of type <time>+ with additivity]
+    expected: FAIL
+
+  [Animating a custom property of type <time>+ with a single keyframe and additivity]
+    expected: FAIL
+
+  [Animating a custom property of type <time>+ with iterationComposite]
+    expected: FAIL
+
+  [Animating a custom property of type <time>+ with different lengths is discrete]
+    expected: FAIL

--- a/tests/wpt/meta/css/css-properties-values-api/animation/custom-property-animation-time.html.ini
+++ b/tests/wpt/meta/css/css-properties-values-api/animation/custom-property-animation-time.html.ini
@@ -1,0 +1,15 @@
+[custom-property-animation-time.html]
+  [Animating a custom property of type <time>]
+    expected: FAIL
+
+  [Animating a custom property of type <time> with a single keyframe]
+    expected: FAIL
+
+  [Animating a custom property of type <time> with additivity]
+    expected: FAIL
+
+  [Animating a custom property of type <time> with a single keyframe and additivity]
+    expected: FAIL
+
+  [Animating a custom property of type <time> with iterationComposite]
+    expected: FAIL

--- a/tests/wpt/meta/css/css-properties-values-api/animation/custom-property-animation-transform-function.html.ini
+++ b/tests/wpt/meta/css/css-properties-values-api/animation/custom-property-animation-transform-function.html.ini
@@ -1,0 +1,15 @@
+[custom-property-animation-transform-function.html]
+  [Animating a custom property of type <transform-function>]
+    expected: FAIL
+
+  [Animating a custom property of type <transform-function> with a single keyframe]
+    expected: FAIL
+
+  [Animating a custom property of type <transform-function> with additivity]
+    expected: FAIL
+
+  [Animating a custom property of type <transform-function> with a single keyframe and additivity]
+    expected: FAIL
+
+  [Animating a custom property of type <transform-function> with iterationComposite]
+    expected: FAIL

--- a/tests/wpt/meta/css/css-properties-values-api/animation/custom-property-animation-transform-list-multiple-values.html.ini
+++ b/tests/wpt/meta/css/css-properties-values-api/animation/custom-property-animation-transform-list-multiple-values.html.ini
@@ -1,0 +1,18 @@
+[custom-property-animation-transform-list-multiple-values.html]
+  [Animating a custom property of type <transform-list> containing multiple values]
+    expected: FAIL
+
+  [Animating a custom property of type <transform-list> containing multiple values with a single keyframe]
+    expected: FAIL
+
+  [Animating a custom property of type <transform-list> containing multiple values with additivity]
+    expected: FAIL
+
+  [Animating a custom property of type <transform-list> containing multiple values with a single keyframe and additivity]
+    expected: FAIL
+
+  [Animating a custom property of type <transform-list> containing multiple values with iterationComposite]
+    expected: FAIL
+
+  [Animating a custom property of type <transform-list> containing multiple values and with mismatching list lengths]
+    expected: FAIL

--- a/tests/wpt/meta/css/css-properties-values-api/animation/custom-property-animation-transform-list-single-values.html.ini
+++ b/tests/wpt/meta/css/css-properties-values-api/animation/custom-property-animation-transform-list-single-values.html.ini
@@ -1,0 +1,15 @@
+[custom-property-animation-transform-list-single-values.html]
+  [Animating a custom property of type <transform-list> containing a single value]
+    expected: FAIL
+
+  [Animating a custom property of type <transform-list> containing a single value with a single keyframe]
+    expected: FAIL
+
+  [Animating a custom property of type <transform-list> containing a single value with additivity]
+    expected: FAIL
+
+  [Animating a custom property of type <transform-list> containing a single value with a single keyframe and additivity]
+    expected: FAIL
+
+  [Animating a custom property of type <transform-list> containing a single value with iterationComposite]
+    expected: FAIL

--- a/tests/wpt/meta/css/css-properties-values-api/animation/custom-property-animation-transform-none.tentative.html.ini
+++ b/tests/wpt/meta/css/css-properties-values-api/animation/custom-property-animation-transform-none.tentative.html.ini
@@ -1,0 +1,6 @@
+[custom-property-animation-transform-none.tentative.html]
+  [Animating a custom property of type "<transform-list>|none" from "none" to <transform-list> value]
+    expected: FAIL
+
+  [Animating a custom property of type "<transform-function>|none" from "none" to <transform-function> value]
+    expected: FAIL

--- a/tests/wpt/meta/css/css-properties-values-api/animation/custom-property-animation-url.html.ini
+++ b/tests/wpt/meta/css/css-properties-values-api/animation/custom-property-animation-url.html.ini
@@ -1,0 +1,9 @@
+[custom-property-animation-url.html]
+  [Animating a custom property of type <url> is discrete]
+    expected: FAIL
+
+  [Animating a custom property of type <url>+ is discrete]
+    expected: FAIL
+
+  [Animating a custom property of type <url># is discrete]
+    expected: FAIL

--- a/tests/wpt/meta/css/css-properties-values-api/animation/custom-property-animation-used-in-shorthand.html.ini
+++ b/tests/wpt/meta/css/css-properties-values-api/animation/custom-property-animation-used-in-shorthand.html.ini
@@ -1,0 +1,3 @@
+[custom-property-animation-used-in-shorthand.html]
+  [Animated custom property is applied in a shorthand property.]
+    expected: FAIL

--- a/tests/wpt/meta/css/css-properties-values-api/animation/custom-property-transition-angle.html.ini
+++ b/tests/wpt/meta/css/css-properties-values-api/animation/custom-property-transition-angle.html.ini
@@ -1,0 +1,3 @@
+[custom-property-transition-angle.html]
+  [A custom property of type <angle> can yield a CSS Transition]
+    expected: FAIL

--- a/tests/wpt/meta/css/css-properties-values-api/animation/custom-property-transition-color.html.ini
+++ b/tests/wpt/meta/css/css-properties-values-api/animation/custom-property-transition-color.html.ini
@@ -1,0 +1,3 @@
+[custom-property-transition-color.html]
+  [A custom property of type <color> can yield a CSS Transition]
+    expected: FAIL

--- a/tests/wpt/meta/css/css-properties-values-api/animation/custom-property-transition-custom-ident.html.ini
+++ b/tests/wpt/meta/css/css-properties-values-api/animation/custom-property-transition-custom-ident.html.ini
@@ -1,0 +1,3 @@
+[custom-property-transition-custom-ident.html]
+  [A custom property of type <custom-ident> can yield a discrete CSS Transition]
+    expected: FAIL

--- a/tests/wpt/meta/css/css-properties-values-api/animation/custom-property-transition-image.html.ini
+++ b/tests/wpt/meta/css/css-properties-values-api/animation/custom-property-transition-image.html.ini
@@ -1,0 +1,3 @@
+[custom-property-transition-image.html]
+  [A custom property of type <image> can yield a CSS Transition]
+    expected: FAIL

--- a/tests/wpt/meta/css/css-properties-values-api/animation/custom-property-transition-inherited-used-by-standard-property.html.ini
+++ b/tests/wpt/meta/css/css-properties-values-api/animation/custom-property-transition-inherited-used-by-standard-property.html.ini
@@ -1,0 +1,3 @@
+[custom-property-transition-inherited-used-by-standard-property.html]
+  [Running a transition an inherited CSS variable is reflected on a standard property using that variable as a value]
+    expected: FAIL

--- a/tests/wpt/meta/css/css-properties-values-api/animation/custom-property-transition-integer.html.ini
+++ b/tests/wpt/meta/css/css-properties-values-api/animation/custom-property-transition-integer.html.ini
@@ -1,0 +1,3 @@
+[custom-property-transition-integer.html]
+  [A custom property of type <integer> can yield a CSS Transition]
+    expected: FAIL

--- a/tests/wpt/meta/css/css-properties-values-api/animation/custom-property-transition-length-percentage.html.ini
+++ b/tests/wpt/meta/css/css-properties-values-api/animation/custom-property-transition-length-percentage.html.ini
@@ -1,0 +1,3 @@
+[custom-property-transition-length-percentage.html]
+  [A custom property of type <length-percentage> can yield a CSS Transition]
+    expected: FAIL

--- a/tests/wpt/meta/css/css-properties-values-api/animation/custom-property-transition-length.html.ini
+++ b/tests/wpt/meta/css/css-properties-values-api/animation/custom-property-transition-length.html.ini
@@ -1,0 +1,6 @@
+[custom-property-transition-length.html]
+  [A custom property of type <length> can yield a CSS Transition]
+    expected: FAIL
+
+  [The to value of a custom property to a random floating-point number can yield a CSS Transition]
+    expected: FAIL

--- a/tests/wpt/meta/css/css-properties-values-api/animation/custom-property-transition-mismatched-inherited-property-numbers.html.ini
+++ b/tests/wpt/meta/css/css-properties-values-api/animation/custom-property-transition-mismatched-inherited-property-numbers.html.ini
@@ -1,0 +1,3 @@
+[custom-property-transition-mismatched-inherited-property-numbers.html]
+  [Using a single "transition-property" value set to a custom property and two "transition-duration" values correctly yields a CSS Transition when the transition properties are set on a parent and the child inherits.]
+    expected: FAIL

--- a/tests/wpt/meta/css/css-properties-values-api/animation/custom-property-transition-mismatched-list.html.ini
+++ b/tests/wpt/meta/css/css-properties-values-api/animation/custom-property-transition-mismatched-list.html.ini
@@ -1,0 +1,72 @@
+[custom-property-transition-mismatched-list.html]
+  [A custom property of type <angle># yields a discrete CSS Transition if the lists do not contain the same number of values]
+    expected: FAIL
+
+  [A custom property of type <angle>+ yields a discrete CSS Transition if the lists do not contain the same number of values]
+    expected: FAIL
+
+  [A custom property of type <color># yields a discrete CSS Transition if the lists do not contain the same number of values]
+    expected: FAIL
+
+  [A custom property of type <color>+ yields a discrete CSS Transition if the lists do not contain the same number of values]
+    expected: FAIL
+
+  [A custom property of type <custom-ident># yields a discrete CSS Transition if the lists do not contain the same number of values]
+    expected: FAIL
+
+  [A custom property of type <custom-ident>+ yields a discrete CSS Transition if the lists do not contain the same number of values]
+    expected: FAIL
+
+  [A custom property of type <image># yields a discrete CSS Transition if the lists do not contain the same number of values]
+    expected: FAIL
+
+  [A custom property of type <image>+ yields a discrete CSS Transition if the lists do not contain the same number of values]
+    expected: FAIL
+
+  [A custom property of type <integer># yields a discrete CSS Transition if the lists do not contain the same number of values]
+    expected: FAIL
+
+  [A custom property of type <integer>+ yields a discrete CSS Transition if the lists do not contain the same number of values]
+    expected: FAIL
+
+  [A custom property of type <length-percentage># yields a discrete CSS Transition if the lists do not contain the same number of values]
+    expected: FAIL
+
+  [A custom property of type <length-percentage>+ yields a discrete CSS Transition if the lists do not contain the same number of values]
+    expected: FAIL
+
+  [A custom property of type <length># yields a discrete CSS Transition if the lists do not contain the same number of values]
+    expected: FAIL
+
+  [A custom property of type <length>+ yields a discrete CSS Transition if the lists do not contain the same number of values]
+    expected: FAIL
+
+  [A custom property of type <number># yields a discrete CSS Transition if the lists do not contain the same number of values]
+    expected: FAIL
+
+  [A custom property of type <number>+ yields a discrete CSS Transition if the lists do not contain the same number of values]
+    expected: FAIL
+
+  [A custom property of type <percentage># yields a discrete CSS Transition if the lists do not contain the same number of values]
+    expected: FAIL
+
+  [A custom property of type <percentage>+ yields a discrete CSS Transition if the lists do not contain the same number of values]
+    expected: FAIL
+
+  [A custom property of type <resolution># yields a discrete CSS Transition if the lists do not contain the same number of values]
+    expected: FAIL
+
+  [A custom property of type <resolution>+ yields a discrete CSS Transition if the lists do not contain the same number of values]
+    expected: FAIL
+
+  [A custom property of type <time># yields a discrete CSS Transition if the lists do not contain the same number of values]
+    expected: FAIL
+
+  [A custom property of type <time>+ yields a discrete CSS Transition if the lists do not contain the same number of values]
+    expected: FAIL
+
+  [A custom property of type <url># yields a discrete CSS Transition if the lists do not contain the same number of values]
+    expected: FAIL
+
+  [A custom property of type <url>+ yields a discrete CSS Transition if the lists do not contain the same number of values]
+    expected: FAIL

--- a/tests/wpt/meta/css/css-properties-values-api/animation/custom-property-transition-mismatched-property-numbers.html.ini
+++ b/tests/wpt/meta/css/css-properties-values-api/animation/custom-property-transition-mismatched-property-numbers.html.ini
@@ -1,0 +1,3 @@
+[custom-property-transition-mismatched-property-numbers.html]
+  [Using a single "transition-property" value set to a custom property and two "transition-duration" values correctly yields a CSS Transition.]
+    expected: FAIL

--- a/tests/wpt/meta/css/css-properties-values-api/animation/custom-property-transition-non-inherited-used-by-standard-property.html.ini
+++ b/tests/wpt/meta/css/css-properties-values-api/animation/custom-property-transition-non-inherited-used-by-standard-property.html.ini
@@ -1,0 +1,3 @@
+[custom-property-transition-non-inherited-used-by-standard-property.html]
+  [Running a transition a non-inherited CSS variable is reflected on a standard property using that variable as a value]
+    expected: FAIL

--- a/tests/wpt/meta/css/css-properties-values-api/animation/custom-property-transition-number-percentage.html.ini
+++ b/tests/wpt/meta/css/css-properties-values-api/animation/custom-property-transition-number-percentage.html.ini
@@ -1,0 +1,3 @@
+[custom-property-transition-number-percentage.html]
+  [A custom property with <number>|<percentage> syntax should not transition between values of the different types]
+    expected: FAIL

--- a/tests/wpt/meta/css/css-properties-values-api/animation/custom-property-transition-number.html.ini
+++ b/tests/wpt/meta/css/css-properties-values-api/animation/custom-property-transition-number.html.ini
@@ -1,0 +1,6 @@
+[custom-property-transition-number.html]
+  [A custom property of type <number> can yield a CSS Transition]
+    expected: FAIL
+
+  [The to value of a custom property to a random floating-point number can yield a CSS Transition]
+    expected: FAIL

--- a/tests/wpt/meta/css/css-properties-values-api/animation/custom-property-transition-percentage.html.ini
+++ b/tests/wpt/meta/css/css-properties-values-api/animation/custom-property-transition-percentage.html.ini
@@ -1,0 +1,3 @@
+[custom-property-transition-percentage.html]
+  [A custom property of type <percentage> can yield a CSS Transition]
+    expected: FAIL

--- a/tests/wpt/meta/css/css-properties-values-api/animation/custom-property-transition-property-all.html.ini
+++ b/tests/wpt/meta/css/css-properties-values-api/animation/custom-property-transition-property-all.html.ini
@@ -1,0 +1,3 @@
+[custom-property-transition-property-all.html]
+  [A custom property can yield a CSS Transition with transition-property: all]
+    expected: FAIL

--- a/tests/wpt/meta/css/css-properties-values-api/animation/custom-property-transition-resolution.html.ini
+++ b/tests/wpt/meta/css/css-properties-values-api/animation/custom-property-transition-resolution.html.ini
@@ -1,0 +1,3 @@
+[custom-property-transition-resolution.html]
+  [A custom property of type <resolution> can yield a CSS Transition]
+    expected: FAIL

--- a/tests/wpt/meta/css/css-properties-values-api/animation/custom-property-transition-time.html.ini
+++ b/tests/wpt/meta/css/css-properties-values-api/animation/custom-property-transition-time.html.ini
@@ -1,0 +1,3 @@
+[custom-property-transition-time.html]
+  [A custom property of type <time> can yield a CSS Transition]
+    expected: FAIL

--- a/tests/wpt/meta/css/css-properties-values-api/animation/custom-property-transition-transform-function-box-size.tentative.html.ini
+++ b/tests/wpt/meta/css/css-properties-values-api/animation/custom-property-transition-transform-function-box-size.tentative.html.ini
@@ -1,0 +1,3 @@
+[custom-property-transition-transform-function-box-size.tentative.html]
+  [A custom property of type <transform-function> yields a CSS Transition using the mix function for a box size dependent matrix interpolation]
+    expected: FAIL

--- a/tests/wpt/meta/css/css-properties-values-api/animation/custom-property-transition-transform-function-matrix.html.ini
+++ b/tests/wpt/meta/css/css-properties-values-api/animation/custom-property-transition-transform-function-matrix.html.ini
@@ -1,0 +1,3 @@
+[custom-property-transition-transform-function-matrix.html]
+  [A custom property of type <transform-function> can yield a CSS Transition between different function types]
+    expected: FAIL

--- a/tests/wpt/meta/css/css-properties-values-api/animation/custom-property-transition-transform-function-none.tentative.html.ini
+++ b/tests/wpt/meta/css/css-properties-values-api/animation/custom-property-transition-transform-function-none.tentative.html.ini
@@ -1,0 +1,3 @@
+[custom-property-transition-transform-function-none.tentative.html]
+  [A custom property keyword none is not a <transform-function> value and is not interpolable with <transform-function> values]
+    expected: FAIL

--- a/tests/wpt/meta/css/css-properties-values-api/animation/custom-property-transition-transform-function-to-list.html.ini
+++ b/tests/wpt/meta/css/css-properties-values-api/animation/custom-property-transition-transform-function-to-list.html.ini
@@ -1,0 +1,3 @@
+[custom-property-transition-transform-function-to-list.html]
+  [A custom property cannot yield a CSS Transition from <transform-function> to <transform-list>]
+    expected: FAIL

--- a/tests/wpt/meta/css/css-properties-values-api/animation/custom-property-transition-transform-function.html.ini
+++ b/tests/wpt/meta/css/css-properties-values-api/animation/custom-property-transition-transform-function.html.ini
@@ -1,0 +1,3 @@
+[custom-property-transition-transform-function.html]
+  [A custom property of type <transform-function> can yield a CSS Transition]
+    expected: FAIL

--- a/tests/wpt/meta/css/css-properties-values-api/animation/custom-property-transition-transform-list-box-size.tentative.html.ini
+++ b/tests/wpt/meta/css/css-properties-values-api/animation/custom-property-transition-transform-list-box-size.tentative.html.ini
@@ -1,0 +1,3 @@
+[custom-property-transition-transform-list-box-size.tentative.html]
+  [A custom property of type <transform-list> yields a CSS Transition using the mix function for a box size dependent matrix interpolation]
+    expected: FAIL

--- a/tests/wpt/meta/css/css-properties-values-api/animation/custom-property-transition-transform-list-matrix.html.ini
+++ b/tests/wpt/meta/css/css-properties-values-api/animation/custom-property-transition-transform-list-matrix.html.ini
@@ -1,0 +1,3 @@
+[custom-property-transition-transform-list-matrix.html]
+  [A custom property of type <transform-list> can yield a CSS Transition between different function types]
+    expected: FAIL

--- a/tests/wpt/meta/css/css-properties-values-api/animation/custom-property-transition-transform-list-none.tentative.html.ini
+++ b/tests/wpt/meta/css/css-properties-values-api/animation/custom-property-transition-transform-list-none.tentative.html.ini
@@ -1,0 +1,3 @@
+[custom-property-transition-transform-list-none.tentative.html]
+  [A custom property keyword none is not a <transform-list> value and is not interpolable with <transform-list> values]
+    expected: FAIL

--- a/tests/wpt/meta/css/css-properties-values-api/animation/custom-property-transition-transform-list.html.ini
+++ b/tests/wpt/meta/css/css-properties-values-api/animation/custom-property-transition-transform-list.html.ini
@@ -1,0 +1,3 @@
+[custom-property-transition-transform-list.html]
+  [A custom property of type <transform-list> can yield a CSS Transition]
+    expected: FAIL

--- a/tests/wpt/meta/css/css-properties-values-api/animation/custom-property-transition-url.html.ini
+++ b/tests/wpt/meta/css/css-properties-values-api/animation/custom-property-transition-url.html.ini
@@ -1,0 +1,3 @@
+[custom-property-transition-url.html]
+  [A custom property of type <url> can yield a discrete CSS Transition]
+    expected: FAIL

--- a/tests/wpt/meta/css/css-properties-values-api/animation/registered-neutral-keyframe.html.ini
+++ b/tests/wpt/meta/css/css-properties-values-api/animation/registered-neutral-keyframe.html.ini
@@ -1,0 +1,3 @@
+[registered-neutral-keyframe.html]
+  [CSS Animations neutral keyframes on registered custom properties should produce the underlying value]
+    expected: FAIL

--- a/tests/wpt/meta/css/css-properties-values-api/animation/registered-var-to-registered-animating.html.ini
+++ b/tests/wpt/meta/css/css-properties-values-api/animation/registered-var-to-registered-animating.html.ini
@@ -1,0 +1,3 @@
+[registered-var-to-registered-animating.html]
+  [Animated registered custom properties can var() reference other animated registered custom properties across separate Animations.]
+    expected: FAIL

--- a/tests/wpt/meta/css/css-properties-values-api/at-property-animation.html.ini
+++ b/tests/wpt/meta/css/css-properties-values-api/at-property-animation.html.ini
@@ -1,0 +1,57 @@
+[at-property-animation.html]
+  [@keyframes works with @property]
+    expected: FAIL
+
+  [@keyframes picks up the latest @property in the document]
+    expected: FAIL
+
+  [Ongoing animation picks up redeclared custom property]
+    expected: FAIL
+
+  [Ongoing animation matches new keyframes against the current registration]
+    expected: FAIL
+
+  [Ongoing animation picks up redeclared intial value]
+    expected: FAIL
+
+  [Ongoing animation picks up redeclared inherits flag]
+    expected: FAIL
+
+  [Ongoing animation picks up redeclared meaning of 'unset']
+    expected: FAIL
+
+  [Transitioning from initial value]
+    expected: FAIL
+
+  [Transitioning from specified value]
+    expected: FAIL
+
+  [Transition triggered by initial value change]
+    expected: FAIL
+
+  [No transition when changing types]
+    expected: FAIL
+
+  [No transition when removing @property rule]
+    expected: FAIL
+
+  [Ongoing transition reverts to its initial state]
+    expected: FAIL
+
+  [Unregistered properties referencing animated properties update correctly.]
+    expected: FAIL
+
+  [Registered properties referencing animated properties update correctly.]
+    expected: FAIL
+
+  [CSS animation setting "inherit" for a custom property on a keyframe is responsive to changing that custom property on the parent.]
+    expected: FAIL
+
+  [JS-originated animation setting "inherit" for a custom property on a keyframe is responsive to changing that custom property on the parent.]
+    expected: FAIL
+
+  [CSS animation setting "currentColor" for a custom property on a keyframe is responsive to changing "color" on the parent.]
+    expected: FAIL
+
+  [JS-originated animation setting "currentColor" for a custom property on a keyframe is responsive to changing "color" on the parent.]
+    expected: FAIL

--- a/tests/wpt/meta/css/css-properties-values-api/at-property-cssom.html.ini
+++ b/tests/wpt/meta/css/css-properties-values-api/at-property-cssom.html.ini
@@ -1,0 +1,96 @@
+[at-property-cssom.html]
+  [Rule for --valid has expected cssText]
+    expected: FAIL
+
+  [Rule for --valid-reverse has expected cssText]
+    expected: FAIL
+
+  [Rule for --valid-universal has expected cssText]
+    expected: FAIL
+
+  [Rule for --valid-whitespace has expected cssText]
+    expected: FAIL
+
+  [Rule for --vALId has expected cssText]
+    expected: FAIL
+
+  [Rule for --no-initial-universal-value has expected cssText]
+    expected: FAIL
+
+  [Rule for --tab\ttab has expected cssText]
+    expected: FAIL
+
+  [CSSRule.type returns 0]
+    expected: FAIL
+
+  [Rule for --valid returns expected value for CSSPropertyRule.name]
+    expected: FAIL
+
+  [Rule for --valid-reverse returns expected value for CSSPropertyRule.name]
+    expected: FAIL
+
+  [Rule for --valid-universal returns expected value for CSSPropertyRule.name]
+    expected: FAIL
+
+  [Rule for --valid-whitespace returns expected value for CSSPropertyRule.name]
+    expected: FAIL
+
+  [Rule for --vALId returns expected value for CSSPropertyRule.name]
+    expected: FAIL
+
+  [Rule for --no-initial-universal-value returns expected value for CSSPropertyRule.name]
+    expected: FAIL
+
+  [Rule for --valid returns expected value for CSSPropertyRule.syntax]
+    expected: FAIL
+
+  [Rule for --valid-reverse returns expected value for CSSPropertyRule.syntax]
+    expected: FAIL
+
+  [Rule for --valid-universal returns expected value for CSSPropertyRule.syntax]
+    expected: FAIL
+
+  [Rule for --valid-whitespace returns expected value for CSSPropertyRule.syntax]
+    expected: FAIL
+
+  [Rule for --vALId returns expected value for CSSPropertyRule.syntax]
+    expected: FAIL
+
+  [Rule for --no-initial-universal-value returns expected value for CSSPropertyRule.syntax]
+    expected: FAIL
+
+  [Rule for --valid returns expected value for CSSPropertyRule.inherits]
+    expected: FAIL
+
+  [Rule for --valid-reverse returns expected value for CSSPropertyRule.inherits]
+    expected: FAIL
+
+  [Rule for --valid-universal returns expected value for CSSPropertyRule.inherits]
+    expected: FAIL
+
+  [Rule for --valid-whitespace returns expected value for CSSPropertyRule.inherits]
+    expected: FAIL
+
+  [Rule for --vALId returns expected value for CSSPropertyRule.inherits]
+    expected: FAIL
+
+  [Rule for --no-initial-universal-value returns expected value for CSSPropertyRule.inherits]
+    expected: FAIL
+
+  [Rule for --valid returns expected value for CSSPropertyRule.initialValue]
+    expected: FAIL
+
+  [Rule for --valid-reverse returns expected value for CSSPropertyRule.initialValue]
+    expected: FAIL
+
+  [Rule for --valid-universal returns expected value for CSSPropertyRule.initialValue]
+    expected: FAIL
+
+  [Rule for --valid-whitespace returns expected value for CSSPropertyRule.initialValue]
+    expected: FAIL
+
+  [Rule for --vALId returns expected value for CSSPropertyRule.initialValue]
+    expected: FAIL
+
+  [Rule for --no-initial-universal-value returns expected value for CSSPropertyRule.initialValue]
+    expected: FAIL

--- a/tests/wpt/meta/css/css-properties-values-api/at-property-optional-initial-value.html.ini
+++ b/tests/wpt/meta/css/css-properties-values-api/at-property-optional-initial-value.html.ini
@@ -1,0 +1,3 @@
+[at-property-optional-initial-value.html]
+  [@property with empty initial-value should use space character]
+    expected: FAIL

--- a/tests/wpt/meta/css/css-properties-values-api/at-property-shadow.html.ini
+++ b/tests/wpt/meta/css/css-properties-values-api/at-property-shadow.html.ini
@@ -1,0 +1,3 @@
+[at-property-shadow.html]
+  [@property rules in shadow trees should be globally registered]
+    expected: FAIL

--- a/tests/wpt/meta/css/css-properties-values-api/at-property-stylesheets.html.ini
+++ b/tests/wpt/meta/css/css-properties-values-api/at-property-stylesheets.html.ini
@@ -1,0 +1,15 @@
+[at-property-stylesheets.html]
+  [@property detected when stylesheet appears]
+    expected: FAIL
+
+  [@property removal detected when last @property rule disappears]
+    expected: FAIL
+
+  [@property detected in second stylesheet]
+    expected: FAIL
+
+  [@property removal detected with removal of second stylesheet]
+    expected: FAIL
+
+  [@property removal detected with removal of first stylesheet]
+    expected: FAIL

--- a/tests/wpt/meta/css/css-properties-values-api/at-property-typedom.html.ini
+++ b/tests/wpt/meta/css/css-properties-values-api/at-property-typedom.html.ini
@@ -1,0 +1,6 @@
+[at-property-typedom.html]
+  [Properties declared with @property reify correctly]
+    expected: FAIL
+
+  [Re-declaring a property with a different type affects reification]
+    expected: FAIL

--- a/tests/wpt/meta/css/css-properties-values-api/at-property-viewport-units-dynamic.html.ini
+++ b/tests/wpt/meta/css/css-properties-values-api/at-property-viewport-units-dynamic.html.ini
@@ -1,0 +1,3 @@
+[at-property-viewport-units-dynamic.html]
+  [@property: viewport units in initial value (dynamic)]
+    expected: FAIL

--- a/tests/wpt/meta/css/css-properties-values-api/at-property-viewport-units.html.ini
+++ b/tests/wpt/meta/css/css-properties-values-api/at-property-viewport-units.html.ini
@@ -1,0 +1,72 @@
+[at-property-viewport-units.html]
+  [10vw is 40px]
+    expected: FAIL
+
+  [10vh is 20px]
+    expected: FAIL
+
+  [10vi is 40px]
+    expected: FAIL
+
+  [10vb is 20px]
+    expected: FAIL
+
+  [10vmin is 20px]
+    expected: FAIL
+
+  [10vmax is 40px]
+    expected: FAIL
+
+  [10svw is 40px]
+    expected: FAIL
+
+  [10svh is 20px]
+    expected: FAIL
+
+  [10svi is 40px]
+    expected: FAIL
+
+  [10svb is 20px]
+    expected: FAIL
+
+  [10svmin is 20px]
+    expected: FAIL
+
+  [10svmax is 40px]
+    expected: FAIL
+
+  [10lvw is 40px]
+    expected: FAIL
+
+  [10lvh is 20px]
+    expected: FAIL
+
+  [10lvi is 40px]
+    expected: FAIL
+
+  [10lvb is 20px]
+    expected: FAIL
+
+  [10lvmin is 20px]
+    expected: FAIL
+
+  [10lvmax is 40px]
+    expected: FAIL
+
+  [10dvw is 40px]
+    expected: FAIL
+
+  [10dvh is 20px]
+    expected: FAIL
+
+  [10dvi is 40px]
+    expected: FAIL
+
+  [10dvb is 20px]
+    expected: FAIL
+
+  [10dvmin is 20px]
+    expected: FAIL
+
+  [10dvmax is 40px]
+    expected: FAIL

--- a/tests/wpt/meta/css/css-properties-values-api/at-property.html.ini
+++ b/tests/wpt/meta/css/css-properties-values-api/at-property.html.ini
@@ -1,0 +1,171 @@
+[at-property.html]
+  [Attribute 'syntax' returns expected value for ["<color>"\]]
+    expected: FAIL
+
+  [Attribute 'syntax' returns expected value for ["<color> | none"\]]
+    expected: FAIL
+
+  [Attribute 'syntax' returns expected value for ["<color># | <image> | none"\]]
+    expected: FAIL
+
+  [Attribute 'syntax' returns expected value for ["foo | <length>#"\]]
+    expected: FAIL
+
+  [Attribute 'syntax' returns expected value for ["foo | bar | baz"\]]
+    expected: FAIL
+
+  [Attribute 'syntax' returns expected value for ["notasyntax"\]]
+    expected: FAIL
+
+  [Attribute 'syntax' returns expected value for ["*"\]]
+    expected: FAIL
+
+  [Attribute 'syntax' returns expected value for [" * "\]]
+    expected: FAIL
+
+  [Attribute 'syntax' returns expected value for ["* "\]]
+    expected: FAIL
+
+  [Attribute 'syntax' returns expected value for ["\t*\t"\]]
+    expected: FAIL
+
+  [Attribute 'syntax' returns expected value for ["red"\]]
+    expected: FAIL
+
+  [Attribute 'initial-value' returns expected value for [10px\]]
+    expected: FAIL
+
+  [Attribute 'initial-value' returns expected value for [rgb(1, 2, 3)\]]
+    expected: FAIL
+
+  [Attribute 'initial-value' returns expected value for [red\]]
+    expected: FAIL
+
+  [Attribute 'initial-value' returns expected value for [foo\]]
+    expected: FAIL
+
+  [Attribute 'initial-value' returns expected value for [foo(){}\]]
+    expected: FAIL
+
+  [Attribute 'inherits' returns expected value for [true\]]
+    expected: FAIL
+
+  [Attribute 'inherits' returns expected value for [false\]]
+    expected: FAIL
+
+  [Rule applied [*, foo(){}, false\]]
+    expected: FAIL
+
+  [Rule applied [<angle>, 42deg, false\]]
+    expected: FAIL
+
+  [Rule applied [<angle>, 1turn, false\]]
+    expected: FAIL
+
+  [Rule applied [<color>, green, false\]]
+    expected: FAIL
+
+  [Rule applied [<color>, rgb(1, 2, 3), false\]]
+    expected: FAIL
+
+  [Rule applied [<image>, url("http://a/"), false\]]
+    expected: FAIL
+
+  [Rule applied [<integer>, 5, false\]]
+    expected: FAIL
+
+  [Rule applied [<length-percentage>, 10px, false\]]
+    expected: FAIL
+
+  [Rule applied [<length-percentage>, 10%, false\]]
+    expected: FAIL
+
+  [Rule applied [<length-percentage>, calc(10% + 10px), false\]]
+    expected: FAIL
+
+  [Rule applied [<length>, 10px, false\]]
+    expected: FAIL
+
+  [Rule applied [<number>, 2.5, false\]]
+    expected: FAIL
+
+  [Rule applied [<percentage>, 10%, false\]]
+    expected: FAIL
+
+  [Rule applied [<resolution>, 50dppx, false\]]
+    expected: FAIL
+
+  [Rule applied [<resolution>, 96dpi, false\]]
+    expected: FAIL
+
+  [Rule applied [<time>, 10s, false\]]
+    expected: FAIL
+
+  [Rule applied [<time>, 1000ms, false\]]
+    expected: FAIL
+
+  [Rule applied [<transform-function>, rotateX(0deg), false\]]
+    expected: FAIL
+
+  [Rule applied [<transform-list>, rotateX(0deg), false\]]
+    expected: FAIL
+
+  [Rule applied [<transform-list>, rotateX(0deg) translateX(10px), false\]]
+    expected: FAIL
+
+  [Rule applied [<url>, url("http://a/"), false\]]
+    expected: FAIL
+
+  [Rule applied [<string>, 'foo bar', false\]]
+    expected: FAIL
+
+  [Rule applied [<string>,  'foo bar' , false\]]
+    expected: FAIL
+
+  [Rule applied [<string>, '"foo" bar', false\]]
+    expected: FAIL
+
+  [Rule applied [<string>, "bar baz", false\]]
+    expected: FAIL
+
+  [Rule applied [<string>, "bar 'baz'", false\]]
+    expected: FAIL
+
+  [Rule applied [<string>+, 'foo' 'bar', false\]]
+    expected: FAIL
+
+  [Rule applied [<string>#, 'foo', 'bar', false\]]
+    expected: FAIL
+
+  [Rule applied [<string>+ | <string>#, 'foo' 'bar', false\]]
+    expected: FAIL
+
+  [Rule applied [<string>+ | <string>#,  'foo' 'bar', false\]]
+    expected: FAIL
+
+  [Rule applied [<string>+ | <string>#, 'foo' "bar", false\]]
+    expected: FAIL
+
+  [Rule applied [<string># | <string>+, 'foo', 'bar', false\]]
+    expected: FAIL
+
+  [Rule applied [<string># | <string>+, 'foo', 'bar' , false\]]
+    expected: FAIL
+
+  [Rule applied [<string># | <string>+, "foo", 'bar', false\]]
+    expected: FAIL
+
+  [Rule applied [<color>, tomato, false\]]
+    expected: FAIL
+
+  [Rule applied [<color>, tomato, true\]]
+    expected: FAIL
+
+  [Non-inherited properties do not inherit]
+    expected: FAIL
+
+  [Initial values substituted as computed value]
+    expected: FAIL
+
+  [Initial value may be omitted for universal registration]
+    expected: FAIL

--- a/tests/wpt/meta/css/css-properties-values-api/determine-registration.html.ini
+++ b/tests/wpt/meta/css/css-properties-values-api/determine-registration.html.ini
@@ -1,0 +1,39 @@
+[determine-registration.html]
+  [@property determines the registration when uncontested]
+    expected: FAIL
+
+  [@property later in document order wins]
+    expected: FAIL
+
+  [@property later in document order wins (overridding definition with inherits=true)]
+    expected: FAIL
+
+  [@property later in document order wins (overridding definition with inherits=false)]
+    expected: FAIL
+
+  [@property later in stylesheet wins]
+    expected: FAIL
+
+  [@property registrations are cleared when rule removed]
+    expected: FAIL
+
+  [Computed value becomes token sequence when @property is removed]
+    expected: FAIL
+
+  [Inherited status is reflected in computed styles when @property is removed]
+    expected: FAIL
+
+  [Invalid @property rule (missing syntax) does not overwrite previous valid rule]
+    expected: FAIL
+
+  [Invalid @property rule (missing inherits descriptor) does not overwrite previous valid rule]
+    expected: FAIL
+
+  [Invalid @property rule (missing initial-value) does not overwrite previous valid rule]
+    expected: FAIL
+
+  [Previous invalid rule does not prevent valid rule from causing registration]
+    expected: FAIL
+
+  [Unknown descriptors are ignored and do not invalidate rule]
+    expected: FAIL

--- a/tests/wpt/meta/css/css-properties-values-api/font-size-animation.html.ini
+++ b/tests/wpt/meta/css/css-properties-values-api/font-size-animation.html.ini
@@ -1,0 +1,3 @@
+[font-size-animation.html]
+  [Animating font-size handled identically for standard and custom properties]
+    expected: FAIL

--- a/tests/wpt/meta/css/css-properties-values-api/get-computed-style-enumeration.html.ini
+++ b/tests/wpt/meta/css/css-properties-values-api/get-computed-style-enumeration.html.ini
@@ -1,0 +1,9 @@
+[get-computed-style-enumeration.html]
+  [Custom properties specified on the node exposed when enumerating computed style.]
+    expected: FAIL
+
+  [Inherited custom properties specified on the parent exposed when enumerating computed style.]
+    expected: FAIL
+
+  [Unspecified properties with initial values exposed when enumerating computed style.]
+    expected: FAIL

--- a/tests/wpt/meta/css/css-properties-values-api/idlharness.html.ini
+++ b/tests/wpt/meta/css/css-properties-values-api/idlharness.html.ini
@@ -1,0 +1,30 @@
+[idlharness.html]
+  [CSSPropertyRule interface: existence and properties of interface object]
+    expected: FAIL
+
+  [CSSPropertyRule interface object length]
+    expected: FAIL
+
+  [CSSPropertyRule interface object name]
+    expected: FAIL
+
+  [CSSPropertyRule interface: existence and properties of interface prototype object]
+    expected: FAIL
+
+  [CSSPropertyRule interface: existence and properties of interface prototype object's "constructor" property]
+    expected: FAIL
+
+  [CSSPropertyRule interface: existence and properties of interface prototype object's @@unscopables property]
+    expected: FAIL
+
+  [CSSPropertyRule interface: attribute name]
+    expected: FAIL
+
+  [CSSPropertyRule interface: attribute syntax]
+    expected: FAIL
+
+  [CSSPropertyRule interface: attribute inherits]
+    expected: FAIL
+
+  [CSSPropertyRule interface: attribute initialValue]
+    expected: FAIL

--- a/tests/wpt/meta/css/css-properties-values-api/initial-value-unit-arithmetic.html.ini
+++ b/tests/wpt/meta/css/css-properties-values-api/initial-value-unit-arithmetic.html.ini
@@ -1,0 +1,3 @@
+[initial-value-unit-arithmetic.html]
+  [syntax:'<length>', initialValue:'calc(5px * 3px / 6px)' is valid]
+    expected: FAIL

--- a/tests/wpt/meta/css/css-properties-values-api/property-cascade.html.ini
+++ b/tests/wpt/meta/css/css-properties-values-api/property-cascade.html.ini
@@ -1,0 +1,3 @@
+[property-cascade.html]
+  [Registering a property does not affect cascade]
+    expected: FAIL

--- a/tests/wpt/meta/css/css-properties-values-api/register-property-sign-mixed-lengths.html.ini
+++ b/tests/wpt/meta/css/css-properties-values-api/register-property-sign-mixed-lengths.html.ini
@@ -1,0 +1,15 @@
+[register-property-sign-mixed-lengths.html]
+  [syntax:'<number>', initialValue:'calc(15 + (sign(100vh - 10px) * 5))' is valid]
+    expected: FAIL
+
+  [syntax:'<integer>', initialValue:'calc(15 + (sign(100vh - 10px) * 5))' is valid]
+    expected: FAIL
+
+  [syntax:'<angle>', initialValue:'calc(15deg + (sign(100vh - 10px) * 5deg))' is valid]
+    expected: FAIL
+
+  [syntax:'<time>', initialValue:'calc(15s + (sign(100vh - 10px) * 5s))' is valid]
+    expected: FAIL
+
+  [syntax:'<resolution>', initialValue:'calc(15dppx + (sign(100vh - 10px) * 5dpi))' is valid]
+    expected: FAIL

--- a/tests/wpt/meta/css/css-properties-values-api/register-property.html.ini
+++ b/tests/wpt/meta/css/css-properties-values-api/register-property.html.ini
@@ -1,0 +1,3 @@
+[register-property.html]
+  [Registering a property should not cause a transition]
+    expected: FAIL

--- a/tests/wpt/meta/css/css-properties-values-api/registered-property-change-style-001.html.ini
+++ b/tests/wpt/meta/css/css-properties-values-api/registered-property-change-style-001.html.ini
@@ -1,0 +1,6 @@
+[registered-property-change-style-001.html]
+  [New registered property declaration]
+    expected: FAIL
+
+  [Registered property overrides a previous declaration ]
+    expected: FAIL

--- a/tests/wpt/meta/css/css-properties-values-api/registered-property-change-style-002.html.ini
+++ b/tests/wpt/meta/css/css-properties-values-api/registered-property-change-style-002.html.ini
@@ -1,0 +1,2 @@
+[registered-property-change-style-002.html]
+  expected: FAIL

--- a/tests/wpt/meta/css/css-properties-values-api/registered-property-computation-color-001.html.ini
+++ b/tests/wpt/meta/css/css-properties-values-api/registered-property-computation-color-001.html.ini
@@ -1,0 +1,2 @@
+[registered-property-computation-color-001.html]
+  expected: FAIL

--- a/tests/wpt/meta/css/css-properties-values-api/registered-property-computation-color-002.html.ini
+++ b/tests/wpt/meta/css/css-properties-values-api/registered-property-computation-color-002.html.ini
@@ -1,0 +1,2 @@
+[registered-property-computation-color-002.html]
+  expected: FAIL

--- a/tests/wpt/meta/css/css-properties-values-api/registered-property-computation-color-004.html.ini
+++ b/tests/wpt/meta/css/css-properties-values-api/registered-property-computation-color-004.html.ini
@@ -1,0 +1,2 @@
+[registered-property-computation-color-004.html]
+  expected: FAIL

--- a/tests/wpt/meta/css/css-properties-values-api/registered-property-computation-color-005.html.ini
+++ b/tests/wpt/meta/css/css-properties-values-api/registered-property-computation-color-005.html.ini
@@ -1,0 +1,2 @@
+[registered-property-computation-color-005.html]
+  expected: FAIL

--- a/tests/wpt/meta/css/css-properties-values-api/registered-property-computation.html.ini
+++ b/tests/wpt/meta/css/css-properties-values-api/registered-property-computation.html.ini
@@ -1,0 +1,21 @@
+[registered-property-computation.html]
+  [<length> values are computed correctly [10lh\]]
+    expected: FAIL
+
+  [<color> values are computed correctly [currentcolor\]]
+    expected: FAIL
+
+  [<color> values are computed correctly [color-mix(in srgb, currentcolor, red)\]]
+    expected: FAIL
+
+  [<color> values are computed correctly [color-mix(in srgb, currentcolor, #ffffff 70%)\]]
+    expected: FAIL
+
+  [<color> values are computed correctly [color-mix(in srgb, currentcolor 20%, #ffffff 20%)\]]
+    expected: FAIL
+
+  [<color> values are computed correctly [light-dark(currentcolor, red)\]]
+    expected: FAIL
+
+  [<color> values are computed correctly [color(from currentcolor srgb b g r)\]]
+    expected: FAIL

--- a/tests/wpt/meta/css/css-properties-values-api/registered-property-crosstalk.html.ini
+++ b/tests/wpt/meta/css/css-properties-values-api/registered-property-crosstalk.html.ini
@@ -1,0 +1,3 @@
+[registered-property-crosstalk.html]
+  [Only #c should be affected by --x:42]
+    expected: FAIL

--- a/tests/wpt/meta/css/css-properties-values-api/registered-property-cssom.html.ini
+++ b/tests/wpt/meta/css/css-properties-values-api/registered-property-cssom.html.ini
@@ -1,0 +1,6 @@
+[registered-property-cssom.html]
+  [Formerly valid values are still readable from inline styles but are computed as the unset value]
+    expected: FAIL
+
+  [Values can be removed from inline styles]
+    expected: FAIL

--- a/tests/wpt/meta/css/css-properties-values-api/registered-property-ident-function.html.ini
+++ b/tests/wpt/meta/css/css-properties-values-api/registered-property-ident-function.html.ini
@@ -1,0 +1,3 @@
+[registered-property-ident-function.html]
+  [The ident() function is resolved in a registered custom property]
+    expected: FAIL

--- a/tests/wpt/meta/css/css-properties-values-api/registered-property-initial.html.ini
+++ b/tests/wpt/meta/css/css-properties-values-api/registered-property-initial.html.ini
@@ -1,0 +1,45 @@
+[registered-property-initial.html]
+  [Initial value for <length> correctly computed [1in\]]
+    expected: FAIL
+
+  [Initial value for <length> correctly computed [2.54cm\]]
+    expected: FAIL
+
+  [Initial value for <length> correctly computed [25.4mm\]]
+    expected: FAIL
+
+  [Initial value for <length> correctly computed [6pc\]]
+    expected: FAIL
+
+  [Initial value for <length> correctly computed [72pt\]]
+    expected: FAIL
+
+  [Initial value for <percentage> correctly computed [calc(10% + 20%)\]]
+    expected: FAIL
+
+  [Initial value for <length-percentage> correctly computed [calc(1in + 10% + 4px)\]]
+    expected: FAIL
+
+  [Initial value for <color> correctly computed [pink, inherits\]]
+    expected: FAIL
+
+  [Initial value for <color> correctly computed [purple\]]
+    expected: FAIL
+
+  [Initial value for <transform-function> correctly computed [rotate(42deg)\]]
+    expected: FAIL
+
+  [Initial value for <transform-list> correctly computed [scale(calc(2 + 2))\]]
+    expected: FAIL
+
+  [Initial value for <transform-list> correctly computed [scale(calc(2 + 1)) translateX(calc(3px + 1px))\]]
+    expected: FAIL
+
+  [Initial value for <url> correctly computed [url(a)\]]
+    expected: FAIL
+
+  [Initial value for <url>+ correctly computed [url(a) url(a)\]]
+    expected: FAIL
+
+  [Initial inherited value can be substituted [purple, color\]]
+    expected: FAIL

--- a/tests/wpt/meta/css/css-properties-values-api/registered-property-revert.html.ini
+++ b/tests/wpt/meta/css/css-properties-values-api/registered-property-revert.html.ini
@@ -1,0 +1,6 @@
+[registered-property-revert.html]
+  [Non-inherited registered custom property can be reverted in animation]
+    expected: FAIL
+
+  [Inherited registered custom property can be reverted in animation]
+    expected: FAIL

--- a/tests/wpt/meta/css/css-properties-values-api/resolved-color-value.html.ini
+++ b/tests/wpt/meta/css/css-properties-values-api/resolved-color-value.html.ini
@@ -1,0 +1,3 @@
+[resolved-color-value.html]
+  [Resolved <color> value with sibling-index()]
+    expected: FAIL

--- a/tests/wpt/meta/css/css-properties-values-api/typedom.html.ini
+++ b/tests/wpt/meta/css/css-properties-values-api/typedom.html.ini
@@ -1,0 +1,4 @@
+[typedom.html]
+  expected: ERROR
+  [Computed * is reified as CSSUnparsedValue]
+    expected: FAIL

--- a/tests/wpt/meta/css/css-properties-values-api/unit-cycles.html.ini
+++ b/tests/wpt/meta/css/css-properties-values-api/unit-cycles.html.ini
@@ -1,0 +1,12 @@
+[unit-cycles.html]
+  [Lengths with lh units may not be referenced from font-size]
+    expected: FAIL
+
+  [Lengths with lh units may not be referenced from line-height]
+    expected: FAIL
+
+  [Fallback may not use line-height-relative units]
+    expected: FAIL
+
+  [Fallback not triggered while inside lh unit cycle]
+    expected: FAIL

--- a/tests/wpt/meta/css/css-properties-values-api/var-reference-registered-properties.html.ini
+++ b/tests/wpt/meta/css/css-properties-values-api/var-reference-registered-properties.html.ini
@@ -1,0 +1,3 @@
+[var-reference-registered-properties.html]
+  [Invalid values for registered properties are serialized as the empty string]
+    expected: FAIL


### PR DESCRIPTION
This will allow us to see the test improvements from #42136.

Testing: Existing WPT
