### PR TITLE
devcontainer: Use copy instead of mount for package list

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -9,8 +9,9 @@ FROM ghcr.io/astral-sh/uv:latest AS uv
 FROM ubuntu:24.04 AS base
 
 # Install apt dependencies.
-RUN --mount=type=bind,source=python/servo/platform/linux_packages,target=/tmp/linux_packages,readonly,z \
-    apt-get update \
+# We need to copy because permissions on selinux systems might be different.
+COPY python/servo/platform/linux_packages /tmp/linux_packages
+RUN apt-get update \
     &&  /tmp/linux_packages/generate_pkg_list.sh /tmp/linux_packages/apt/* | xargs apt-get install -y --no-install-recommends \
     && curl --version
 

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -9,7 +9,6 @@ FROM ghcr.io/astral-sh/uv:latest AS uv
 FROM ubuntu:24.04 AS base
 
 # Install apt dependencies.
-# We need to copy because permissions on selinux systems might be different.
 COPY python/servo/platform/linux_packages /tmp/linux_packages
 RUN apt-get update \
     &&  /tmp/linux_packages/generate_pkg_list.sh /tmp/linux_packages/apt/* | xargs apt-get install -y --no-install-recommends \

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -9,7 +9,7 @@ FROM ghcr.io/astral-sh/uv:latest AS uv
 FROM ubuntu:24.04 AS base
 
 # Install apt dependencies.
-RUN --mount=type=bind,source=python/servo/platform/linux_packages,target=/tmp/linux_packages,readonly \
+RUN --mount=type=bind,source=python/servo/platform/linux_packages,target=/tmp/linux_packages,readonly,z \
     apt-get update \
     &&  /tmp/linux_packages/generate_pkg_list.sh /tmp/linux_packages/apt/* | xargs apt-get install -y --no-install-recommends \
     && curl --version


### PR DESCRIPTION
Selinux enabled systems have stricter permissions and a bind mount might not work correctly. Hence, we copy the package list.

Signed-off-by: Narfinger <Narfinger@users.noreply.github.com>

Testing: Build the devcontainer on fedora machine.
