### PR TITLE
mach (Android): Use `CC` instead of forcing `CMake` to build `aws-lc-sys`

### DIFF
--- a/python/servo/platform/build_target.py
+++ b/python/servo/platform/build_target.py
@@ -230,6 +230,17 @@ class AndroidTarget(CrossBuildTarget):
         env["TARGET_CPP"] = to_ndk_bin("clang") + " -E"
         env["TARGET_CXX"] = to_ndk_bin("clang++")
 
+        target_triple = self.triple()
+        rust_target_triple = str(target_triple).replace("-", "_")
+
+        # These are required by `aws-lc-sys` due to a bug:
+        # https://github.com/aws/aws-lc-rs/issues/1025
+        ndk_clang = to_ndk_bin("clang")
+        ndk_clangxx = to_ndk_bin("clang++")
+
+        env[f"CC_{rust_target_triple}"] = ndk_clang
+        env[f"CXX_{rust_target_triple}"] = ndk_clangxx
+
         env["TARGET_AR"] = to_ndk_bin("llvm-ar")
         env["TARGET_RANLIB"] = to_ndk_bin("llvm-ranlib")
         env["TARGET_OBJCOPY"] = to_ndk_bin("llvm-objcopy")
@@ -260,15 +271,6 @@ class AndroidTarget(CrossBuildTarget):
         # These two variables are needed for the mozjs compilation.
         env["ANDROID_API_LEVEL"] = android_api
         env["ANDROID_NDK_HOME"] = env["ANDROID_NDK_ROOT"]
-
-        target_triple = self.triple()
-        rust_target_triple = str(target_triple).replace("-", "_")
-
-        ndk_clang = to_ndk_bin("clang")
-        ndk_clangxx = to_ndk_bin("clang++")
-
-        env[f"CC_{rust_target_triple}"] = ndk_clang
-        env[f"CXX_{rust_target_triple}"] = ndk_clangxx
 
         # The two variables set below are passed by our custom
         # support/android/toolchain.cmake to the NDK's CMake toolchain file

--- a/python/servo/platform/build_target.py
+++ b/python/servo/platform/build_target.py
@@ -261,10 +261,6 @@ class AndroidTarget(CrossBuildTarget):
         env["ANDROID_API_LEVEL"] = android_api
         env["ANDROID_NDK_HOME"] = env["ANDROID_NDK_ROOT"]
 
-        # This variable is needed for the aws-lc-rs compilation.
-        # See https://github.com/servo/servo/pull/41912#issuecomment-3752460352
-        env["AWS_LC_SYS_CMAKE_BUILDER"] = "1"
-
         # The two variables set below are passed by our custom
         # support/android/toolchain.cmake to the NDK's CMake toolchain file
         env["ANDROID_ABI"] = android_lib

--- a/python/servo/platform/build_target.py
+++ b/python/servo/platform/build_target.py
@@ -261,6 +261,15 @@ class AndroidTarget(CrossBuildTarget):
         env["ANDROID_API_LEVEL"] = android_api
         env["ANDROID_NDK_HOME"] = env["ANDROID_NDK_ROOT"]
 
+        target_triple = self.triple()
+        rust_target_triple = str(target_triple).replace("-", "_")
+
+        ndk_clang = to_ndk_bin("clang")
+        ndk_clangxx = to_ndk_bin("clang++")
+
+        env[f"CC_{rust_target_triple}"] = ndk_clang
+        env[f"CXX_{rust_target_triple}"] = ndk_clangxx
+
         # The two variables set below are passed by our custom
         # support/android/toolchain.cmake to the NDK's CMake toolchain file
         env["ANDROID_ABI"] = android_lib


### PR DESCRIPTION
In #41912, the bump of `aws-lc-sys` breaks the Android build, as it replaces CMake build with cc builder for all platforms. As fallback, we use CMake for Android only.

Another bump of it today #42226 is supposed to fix the issue:

> Fix building for older Android targets by [@​justsmth](https://github.com/justsmth) in [aws/aws-lc-rs#1013](https://redirect.github.com/aws/aws-lc-rs/pull/1013)

, but it [does not](https://github.com/servo/servo/actions/runs/21467527086/job/61832707394). 

After investigation, we properly set up environment variable to make sure  C/C++ compiler bundled with NDK can be used.
This makes Android consistent with other platforms.

Testing: https://github.com/servo/servo/actions/runs/21468482975/job/61835557765
