### PR TITLE
script/storage: Switch remaining instances of bincode to postcard

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -382,7 +382,7 @@ dependencies = [
  "objc2-foundation 0.3.2",
  "parking_lot",
  "percent-encoding",
- "windows-sys 0.52.0",
+ "windows-sys 0.60.2",
  "x11rb",
 ]
 
@@ -1418,6 +1418,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "cobs"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fa961b519f0b462e3a3b4a34b64d119eeaca1d59af726fe450bbba07a9fc0a1"
+dependencies = [
+ "thiserror 2.0.17",
+]
+
+[[package]]
 name = "codespan-reporting"
 version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2397,6 +2406,18 @@ checksum = "491bdf728bf25ddd9ad60d4cf1c48588fa82c013a2440b91aa7fc43e34a07c32"
 dependencies = [
  "bytemuck",
 ]
+
+[[package]]
+name = "embedded-io"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef1a6892d9eef45c8fa6b9e0086428a2cca8491aca8f787c534a3d6d0bcb3ced"
+
+[[package]]
+name = "embedded-io"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edd0f118536f44f5ccd48bcb8b111bdc3de888b58c74639dfb034a357d0f206d"
 
 [[package]]
 name = "embedder_traits"
@@ -4107,7 +4128,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core 0.58.0",
+ "windows-core 0.61.2",
 ]
 
 [[package]]
@@ -6501,7 +6522,6 @@ name = "paint"
 version = "0.0.1"
 dependencies = [
  "base",
- "bincode",
  "bitflags 2.10.0",
  "canvas_traits",
  "constellation_traits",
@@ -6542,7 +6562,6 @@ name = "paint_api"
 version = "0.0.1"
 dependencies = [
  "base",
- "bincode",
  "bitflags 2.10.0",
  "crossbeam-channel",
  "dpi",
@@ -6938,6 +6957,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d8a2f0d8d040d7848a709caf78912debcc3f33ee4b3cac47d73d1e1069e83507"
 dependencies = [
  "portable-atomic",
+]
+
+[[package]]
+name = "postcard"
+version = "1.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6764c3b5dd454e283a30e6dfe78e9b31096d9e32036b5d1eaac7a6119ccb9a24"
+dependencies = [
+ "cobs",
+ "embedded-io 0.4.0",
+ "embedded-io 0.6.1",
+ "serde",
 ]
 
 [[package]]
@@ -7689,7 +7720,6 @@ dependencies = [
  "base",
  "base64 0.22.1",
  "base64ct",
- "bincode",
  "bitflags 2.10.0",
  "bluetooth_traits",
  "brotli",
@@ -7761,6 +7791,7 @@ dependencies = [
  "phf",
  "pixels",
  "pkcs8",
+ "postcard",
  "profile_traits",
  "rand 0.9.2",
  "regex",
@@ -8714,11 +8745,11 @@ name = "storage"
 version = "0.0.1"
 dependencies = [
  "base",
- "bincode",
  "libc",
  "log",
  "malloc_size_of_derive",
  "net_traits",
+ "postcard",
  "profile",
  "profile_traits",
  "rusqlite",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,12 +40,6 @@ backtrace = "0.3"
 base = { path = "components/shared/base" }
 base64 = "0.22.1"
 base64ct = { version = "1.8", features = ["alloc"] }
-# bincode 1.3.3 is the last known good version of bincode 1.
-# The crate was declared finished and won't receive further updates by the author.
-# Since the git history was rewritten by the author, any bump of this crate should
-# be reviewed carefully by doing a manual diff based on the crates.io version,
-# before doing **any** bump to this dependency to rule out a supply chain attack.
-bincode = "=1.3.3"
 bitflags = "2.10"
 bluetooth_traits = { path = "components/shared/bluetooth" }
 brotli = "8.0.2"
@@ -139,6 +133,7 @@ parking_lot = { version = "0.12", features = ["serde"] }
 peniko = "0.5"
 percent-encoding = "2.3"
 pkcs8 = { version = "0.10", features = ["rand_core"] }
+postcard = { version = "1.1.3", default-features = false, features = ["use-std"] }
 proc-macro2 = "1"
 profile_traits = { path = "components/shared/profile" }
 quote = "1"

--- a/components/paint/Cargo.toml
+++ b/components/paint/Cargo.toml
@@ -23,7 +23,6 @@ panic = "deny"
 
 [dependencies]
 base = { workspace = true }
-bincode = { workspace = true }
 bitflags = { workspace = true }
 canvas_traits = { workspace = true }
 constellation_traits = { workspace = true }

--- a/components/script/Cargo.toml
+++ b/components/script/Cargo.toml
@@ -46,7 +46,6 @@ backtrace = { workspace = true }
 base = { workspace = true }
 base64 = { workspace = true }
 base64ct = { workspace = true }
-bincode = { workspace = true }
 bitflags = { workspace = true }
 bluetooth_traits = { workspace = true, optional = true }
 brotli = { workspace = true }
@@ -118,6 +117,7 @@ percent-encoding = { workspace = true }
 phf = "0.13"
 pixels = { path = "../pixels" }
 pkcs8 = { workspace = true }
+postcard = { workspace = true }
 profile_traits = { workspace = true }
 rand = { workspace = true }
 regex = { workspace = true }

--- a/components/script/dom/bindings/principals.rs
+++ b/components/script/dom/bindings/principals.rs
@@ -32,7 +32,7 @@ pub(crate) unsafe extern "C" fn write_jsprincipal(
     };
     let obj = unsafe { ServoJSPrincipalsRef::from_raw_nonnull(principal) };
     let origin = obj.origin();
-    let Ok(bytes_of_origin) = bincode::serialize(&origin) else {
+    let Ok(bytes_of_origin) = postcard::to_stdvec(&origin) else {
         return false;
     };
     let Ok(len) = bytes_of_origin.len().try_into() else {
@@ -76,7 +76,7 @@ pub(crate) unsafe extern "C" fn read_jsprincipal(
         }
     }
 
-    let Ok(origin) = bincode::deserialize(&bytes[..]) else {
+    let Ok(origin) = postcard::from_bytes(&bytes[..]) else {
         return false;
     };
     let principal = ServoJSPrincipals::new::<DomTypeHolder>(&origin);

--- a/components/script/dom/indexeddb/idbcursor.rs
+++ b/components/script/dom/indexeddb/idbcursor.rs
@@ -484,7 +484,7 @@ pub(crate) fn iterate_cursor(
         // Step 13.1. Let serialized be found record’s referenced value.
         // Step 13.2. Set cursor’s value to ! StructuredDeserialize(serialized, targetRealm)
         rooted!(&in(cx) let mut new_cursor_value = UndefinedValue());
-        bincode::deserialize(&found_record.value)
+        postcard::from_bytes(&found_record.value)
             .map_err(|_| Error::Data(None))
             .and_then(|data| {
                 structuredclone::read(

--- a/components/script/dom/indexeddb/idbobjectstore.rs
+++ b/components/script/dom/indexeddb/idbobjectstore.rs
@@ -252,7 +252,7 @@ impl IDBObjectStore {
 
         // Step 10. Let clone be a clone of value in targetRealm during transaction. Rethrow any exceptions.
         let cloned_value = structuredclone::write(cx.into(), value, None)?;
-        let Ok(serialized_value) = bincode::serialize(&cloned_value) else {
+        let Ok(serialized_value) = postcard::to_stdvec(&cloned_value) else {
             return Err(Error::InvalidState(None));
         };
         // Step 12. Let operation be an algorithm to run store a record into an object store with store, clone, key, and no-overwrite flag.

--- a/components/script/dom/indexeddb/idbrequest.rs
+++ b/components/script/dom/indexeddb/idbrequest.rs
@@ -146,7 +146,7 @@ impl RequestListener {
                     array.safe_to_jsval(cx, answer.handle_mut());
                 },
                 IdbResult::Value(serialized_data) => {
-                    let result = bincode::deserialize(&serialized_data)
+                    let result = postcard::from_bytes(&serialized_data)
                         .map_err(|_| Error::Data(None))
                         .and_then(|data| {
                             structuredclone::read(
@@ -165,7 +165,7 @@ impl RequestListener {
                 IdbResult::Values(serialized_values) => {
                     rooted!(&in(cx) let mut values = vec![JSVal::default(); serialized_values.len()]);
                     for (i, serialized_data) in serialized_values.into_iter().enumerate() {
-                        let result = bincode::deserialize(&serialized_data)
+                        let result = postcard::from_bytes(&serialized_data)
                             .map_err(|_| Error::Data(None))
                             .and_then(|data| {
                                 structuredclone::read(

--- a/components/shared/paint/Cargo.toml
+++ b/components/shared/paint/Cargo.toml
@@ -17,7 +17,6 @@ tracing = ["dep:tracing"]
 
 [dependencies]
 base = { workspace = true }
-bincode = { workspace = true }
 bitflags = { workspace = true }
 crossbeam-channel = { workspace = true }
 dpi = { workspace = true }

--- a/components/storage/Cargo.toml
+++ b/components/storage/Cargo.toml
@@ -14,12 +14,12 @@ path = "lib.rs"
 
 [dependencies]
 base = { workspace = true }
-bincode = { workspace = true }
 malloc_size_of = { workspace = true }
 malloc_size_of_derive = { workspace = true }
 net_traits = { workspace = true }
 libc = { workspace = true }
 log = { workspace = true }
+postcard = { workspace = true }
 profile_traits = { workspace = true }
 rusqlite = { version = "0.37", features = ["bundled"] }
 rustc-hash = { workspace = true }


### PR DESCRIPTION
Because of the deprecation of bincode we are switching to postcard (which will already be used by ipc-channel).
This changes all usages to postcard.

Sadly there are still some dependencies using bincode, so we are probably increasing the binary size.

Currently we do not modify the deny.toml because we have dependencies that depend on bincode.

Testing: Compilation should be enough for test.
