### PR TITLE
script: Clear layout data on shadow root during `attachShadow`

### DIFF
--- a/components/script/dom/element.rs
+++ b/components/script/dom/element.rs
@@ -685,6 +685,12 @@ impl Element {
             can_gc,
         );
 
+        // This is not in the specification, but this is where we ensure that the
+        // non-shadow-tree children of `self` no longer have layout boxes as they are no
+        // longer in the flat tree.
+        let node = self.upcast::<Node>();
+        node.remove_layout_boxes_from_subtree();
+
         // Step 6. Set shadow's delegates focus to delegatesFocus
         shadow_root.set_delegates_focus(delegates_focus);
 
@@ -712,7 +718,6 @@ impl Element {
         let bind_context = BindContext::new(self.upcast(), IsShadowTree::Yes);
         shadow_root.bind_to_tree(&bind_context, can_gc);
 
-        let node = self.upcast::<Node>();
         node.dirty(NodeDamage::Other);
 
         Ok(shadow_root)

--- a/components/script/dom/node.rs
+++ b/components/script/dom/node.rs
@@ -360,6 +360,15 @@ impl Node {
         Node::replace_all(Some(fragment.upcast()), target, can_gc);
     }
 
+    /// Clear this [`Node`]'s layout data and also clear the layout data of all children.
+    /// Note that clears layout data from all non-flat tree descendants and flat tree
+    /// descendants.
+    pub(crate) fn remove_layout_boxes_from_subtree(&self) {
+        for node in self.traverse_preorder(ShadowIncluding::Yes) {
+            node.layout_data.borrow_mut().take();
+        }
+    }
+
     pub(crate) fn clean_up_style_and_layout_data(&self) {
         self.owner_doc().cancel_animations_for_node(self);
         self.style_data.borrow_mut().take();

--- a/tests/wpt/tests/html/interaction/focus/focus-after-attach-shadow-crash.html
+++ b/tests/wpt/tests/html/interaction/focus/focus-after-attach-shadow-crash.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<link rel="help" href="https://github.com/servo/servo/issues/42215">
+<style>
+  #outer { overflow: hidden; }
+</style>
+<div id="outer"><span id="inner" tabindex="1">hello</span></div>
+<script>
+  window.addEventListener("load", _ => {
+    document.body.attachShadow({mode: "open"});
+    inner.focus();
+  });
+</script>


### PR DESCRIPTION
When a node has `attachShadow()` successfully called on it, its
descendants are no longer in the flat tree. This change makes it so that
the layout data of these descendants is cleared during `attachShadow()`
so that the node is no longer considered to have a layout box.

Testing: This change includes a new WPT crash test.
Fixes: #42215.
