### PR TITLE
base: When normalizing `RopeIndex` ensure it does not intersect a character

### DIFF
--- a/components/script/textinput.rs
+++ b/components/script/textinput.rs
@@ -407,9 +407,12 @@ impl<T: ClipboardProvider> TextInput<T> {
             self.edit_point, self.selection_origin, self.selection_direction
         );
 
-        debug_assert_eq!(self.edit_point, self.rope.clamp_index(self.edit_point));
+        debug_assert_eq!(self.edit_point, self.rope.normalize_index(self.edit_point));
         if let Some(selection_origin) = self.selection_origin {
-            debug_assert_eq!(selection_origin, self.rope.clamp_index(selection_origin));
+            debug_assert_eq!(
+                selection_origin,
+                self.rope.normalize_index(selection_origin)
+            );
             match self.selection_direction {
                 SelectionDirection::None | SelectionDirection::Forward => {
                     debug_assert!(selection_origin <= self.edit_point)
@@ -950,10 +953,10 @@ impl<T: ClipboardProvider> TextInput<T> {
         );
         self.was_last_change_by_set_content = true;
 
-        self.edit_point = self.rope.clamp_index(self.edit_point());
+        self.edit_point = self.rope.normalize_index(self.edit_point());
         self.selection_origin = self
             .selection_origin
-            .map(|selection_origin| self.rope.clamp_index(selection_origin));
+            .map(|selection_origin| self.rope.normalize_index(selection_origin));
     }
 
     pub fn set_selection_range_utf16(

--- a/tests/wpt/tests/html/semantics/forms/the-textarea-element/textarea-selection-range-intersects-character-crash.html
+++ b/tests/wpt/tests/html/semantics/forms/the-textarea-element/textarea-selection-range-intersects-character-crash.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<title>A selection range that intersects a character should not cause a crash</title>
+<link rel="help" href="https://github.com/servo/servo/issues/42217">
+
+<textarea id="textarea">A</textarea>
+<script>
+  textarea.setSelectionRange(1, 1);
+  textarea.defaultValue = String.fromCodePoint(301146);
+  textarea.selectionStart;
+</script>


### PR DESCRIPTION
When doing operations on `RopeIndex` that need to make slices of lines,
this change makes it so that the resulting index does not intersect a
character. This is important because Rust will panic if you attempt to
slice a string that way.

Testing: This change adds a WPT crash test and a `Rope` unit test.
Fixes: #42217.
