### PR TITLE
deps: Let rustls use default feature flags

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -150,7 +150,7 @@ regex = "1.12"
 resvg = "0.45.0"
 rsa = { version = "0.9.10", features = ["sha1", "sha2"] }
 rustc-hash = "2.1.1"
-rustls = { version = "0.23", default-features = false, features = ["logging", "std", "tls12"] }
+rustls = { version = "0.23" }
 rustls-pki-types = "1.14"
 rustls-platform-verifier = "0.6.2"
 script_traits = { path = "components/shared/script" }


### PR DESCRIPTION
The default flags for rustls allow use of post quantum cryptography. And did not increase the binary size by any noticable amount.
I think it is ok to trust the rustls maintainers to have good defaults.

Signed-off-by: Narfinger <Narfinger@users.noreply.github.com>

Testing: This flag is just additive.
