### PR TITLE
[26488] Refactors GPUCanvasContext to manage context dropping.

### DIFF
--- a/components/script_bindings/codegen/Bindings.conf
+++ b/components/script_bindings/codegen/Bindings.conf
@@ -308,7 +308,6 @@ DOMInterfaces = {
 
 'GPUCanvasContext': {
     'weakReferenceable': True,
-    'allowDropImpl': True,
 },
 
 'GPUCommandBuffer': {


### PR DESCRIPTION
Moves the `Drop` implementation for `GPUCanvasContext` to a new `DroppableGPUCanvasContext` struct.

This ensures the context destruction logic is correctly handled, as the `GPUCanvasContext` struct itself is a DOM struct and should not have a drop implementation. This change aligns with the requirement that DOM types should not implement Drop.

Testing: No tests added
Fixes: #26488 
