### PR TITLE
layout: Add a query for getting the effective overflow of an element and use it in `script`

### DIFF
--- a/components/layout/layout_impl.rs
+++ b/components/layout/layout_impl.rs
@@ -22,8 +22,8 @@ use fonts::{FontContext, FontContextWebFontMethods, WebFontDocumentContext};
 use fonts_traits::StylesheetWebFontLoadFinishedCallback;
 use layout_api::wrapper_traits::LayoutNode;
 use layout_api::{
-    BoxAreaType, CSSPixelRectIterator, IFrameSizes, Layout, LayoutConfig, LayoutFactory,
-    OffsetParentResponse, PhysicalSides, PropertyRegistration, QueryMsg, ReflowGoal,
+    AxesOverflow, BoxAreaType, CSSPixelRectIterator, IFrameSizes, Layout, LayoutConfig,
+    LayoutFactory, OffsetParentResponse, PhysicalSides, PropertyRegistration, QueryMsg, ReflowGoal,
     ReflowPhasesRun, ReflowRequest, ReflowRequestRestyle, ReflowResult, ReflowStatistics,
     RegisterPropertyError, ScrollContainerQueryFlags, ScrollContainerResponse, TrustedNodeAddress,
     with_layout_state,
@@ -90,9 +90,9 @@ use crate::display_list::{DisplayListBuilder, HitTest, PaintTimingHandler, Stack
 use crate::query::{
     find_character_offset_in_fragment_descendants, get_the_text_steps, process_box_area_request,
     process_box_areas_request, process_client_rect_request, process_current_css_zoom_query,
-    process_node_scroll_area_request, process_offset_parent_query, process_padding_request,
-    process_resolved_font_style_query, process_resolved_style_request,
-    process_scroll_container_query,
+    process_effective_overflow_query, process_node_scroll_area_request,
+    process_offset_parent_query, process_padding_request, process_resolved_font_style_query,
+    process_resolved_style_request, process_scroll_container_query,
 };
 use crate::traversal::{RecalcStyle, compute_damage_and_rebuild_box_tree};
 use crate::{BoxTree, FragmentTree};
@@ -545,6 +545,14 @@ impl Layout for LayoutThread {
         })
     }
 
+    #[servo_tracing::instrument(skip_all)]
+    fn query_effective_overflow(&self, node: TrustedNodeAddress) -> Option<AxesOverflow> {
+        with_layout_state(|| {
+            let node = unsafe { ServoLayoutNode::new(&node).to_threadsafe() };
+            process_effective_overflow_query(node)
+        })
+    }
+    
     fn exit_now(&mut self) {}
 
     fn collect_reports(&self, reports: &mut Vec<Report>, ops: &mut MallocSizeOfOps) {
@@ -1711,6 +1719,7 @@ impl ReflowPhases {
                 QueryMsg::TextIndexQuery => Self::StackingContextTreeConstruction,
                 QueryMsg::ClientRectQuery |
                 QueryMsg::CurrentCSSZoomQuery |
+                QueryMsg::EffectiveOverflow |
                 QueryMsg::ElementInnerOuterTextQuery |
                 QueryMsg::InnerWindowDimensionsQuery |
                 QueryMsg::PaddingQuery |

--- a/components/layout/layout_impl.rs
+++ b/components/layout/layout_impl.rs
@@ -552,7 +552,7 @@ impl Layout for LayoutThread {
             process_effective_overflow_query(node)
         })
     }
-    
+
     fn exit_now(&mut self) {}
 
     fn collect_reports(&self, reports: &mut Vec<Report>, ops: &mut MallocSizeOfOps) {

--- a/components/layout/query.rs
+++ b/components/layout/query.rs
@@ -1464,3 +1464,17 @@ pub(crate) fn transform_au_rectangle(
     };
     outer_transformed_rect.map(|transformed_rect| f32_rect_to_au_rect(transformed_rect).cast_unit())
 }
+
+pub fn process_effective_overflow_query(
+    node: ServoThreadSafeLayoutNode<'_>,
+) -> Option<AxesOverflow> {
+    let fragments = node.fragments_for_pseudo(None);
+    let box_fragment = fragments.first()?.retrieve_box_fragment()?;
+    let box_fragment = box_fragment.borrow();
+
+    Some(
+        box_fragment
+            .style()
+            .effective_overflow(box_fragment.base.flags),
+    )
+}

--- a/components/layout/query.rs
+++ b/components/layout/query.rs
@@ -1465,7 +1465,7 @@ pub(crate) fn transform_au_rectangle(
     outer_transformed_rect.map(|transformed_rect| f32_rect_to_au_rect(transformed_rect).cast_unit())
 }
 
-pub fn process_effective_overflow_query(
+pub(crate) fn process_effective_overflow_query(
     node: ServoThreadSafeLayoutNode<'_>,
 ) -> Option<AxesOverflow> {
     let fragments = node.fragments_for_pseudo(None);

--- a/components/layout/style_ext.rs
+++ b/components/layout/style_ext.rs
@@ -685,9 +685,8 @@ impl ComputedValuesExt for ComputedValues {
 
     /// Whether or not the `overflow` value of this style establishes a scroll container.
     fn establishes_scroll_container(&self, fragment_flags: FragmentFlags) -> bool {
-        // Checking one axis suffices, because the computed value ensures that
-        // either both axes are scrollable, or none is scrollable.
-        self.effective_overflow(fragment_flags).x.is_scrollable()
+        self.effective_overflow(fragment_flags)
+            .establishes_scroll_container()
     }
 
     /// Returns true if this fragment establishes a new stacking context and false otherwise.

--- a/components/script/dom/element.rs
+++ b/components/script/dom/element.rs
@@ -567,14 +567,13 @@ impl Element {
         true
     }
 
-    /// <https://drafts.csswg.org/cssom-view/#scrolling-box>
-    fn has_scrolling_box(&self) -> bool {
+    /// <https://www.w3.org/TR/css-overflow-3/#scroll-container>
+    fn establish_scroll_container(&self) -> bool {
         // TODO: scrolling mechanism, such as scrollbar (We don't have scrollbar yet)
         //       self.has_scrolling_mechanism()
-        self.style().is_some_and(|style| {
-            style.get_box().clone_overflow_x().is_scrollable() ||
-                style.get_box().clone_overflow_y().is_scrollable()
-        })
+        self.upcast::<Node>()
+            .effective_overflow()
+            .is_some_and(|overflow| overflow.x.is_scrollable())
     }
 
     fn has_overflow(&self) -> bool {
@@ -2737,7 +2736,8 @@ impl Element {
         }
 
         // Step 10
-        if !self.has_css_layout_box() || !self.has_scrolling_box() || !self.has_overflow() {
+        if !self.has_css_layout_box() || !self.establish_scroll_container() || !self.has_overflow()
+        {
             return;
         }
 
@@ -3473,7 +3473,8 @@ impl ElementMethods<crate::DomTypeHolder> for Element {
         }
 
         // Step 10
-        if !self.has_css_layout_box() || !self.has_scrolling_box() || !self.has_overflow() {
+        if !self.has_css_layout_box() || !self.establish_scroll_container() || !self.has_overflow()
+        {
             return;
         }
 
@@ -3570,7 +3571,8 @@ impl ElementMethods<crate::DomTypeHolder> for Element {
         }
 
         // Step 10
-        if !self.has_css_layout_box() || !self.has_scrolling_box() || !self.has_overflow() {
+        if !self.has_css_layout_box() || !self.establish_scroll_container() || !self.has_overflow()
+        {
             return;
         }
 

--- a/components/script/dom/element.rs
+++ b/components/script/dom/element.rs
@@ -569,14 +569,14 @@ impl Element {
 
     /// Whether this element is styled such that it establish a scroll container.
     /// <https://www.w3.org/TR/css-overflow-3/#scroll-container>
-    fn establishes_scroll_container(&self) -> bool {
+    pub(crate) fn establishes_scroll_container(&self) -> bool {
         // CSS computed value has make sure that either both axis is scrollable or none is scrollable.
         self.upcast::<Node>()
             .effective_overflow()
             .is_some_and(|overflow| overflow.establishes_scroll_container())
     }
 
-    fn has_overflow(&self) -> bool {
+    pub(crate) fn has_overflow(&self) -> bool {
         self.ScrollHeight() > self.ClientHeight() || self.ScrollWidth() > self.ClientWidth()
     }
 
@@ -2737,7 +2737,7 @@ impl Element {
 
         // Step 10
         if !self.has_css_layout_box() ||
-            !self.establishes_scroll_container() ||
+            !self.upcast::<Node>().establishes_scrolling_box() ||
             !self.has_overflow()
         {
             return;
@@ -3476,7 +3476,7 @@ impl ElementMethods<crate::DomTypeHolder> for Element {
 
         // Step 10
         if !self.has_css_layout_box() ||
-            !self.establishes_scroll_container() ||
+            !self.upcast::<Node>().establishes_scrolling_box() ||
             !self.has_overflow()
         {
             return;
@@ -3576,7 +3576,7 @@ impl ElementMethods<crate::DomTypeHolder> for Element {
 
         // Step 10
         if !self.has_css_layout_box() ||
-            !self.establishes_scroll_container() ||
+            !self.upcast::<Node>().establishes_scrolling_box() ||
             !self.has_overflow()
         {
             return;

--- a/components/script/dom/element.rs
+++ b/components/script/dom/element.rs
@@ -567,17 +567,28 @@ impl Element {
         true
     }
 
-    /// Whether this element is styled such that it establish a scroll container.
+    /// Whether this element is styled such that it establishes a scroll container.
     /// <https://www.w3.org/TR/css-overflow-3/#scroll-container>
-    pub(crate) fn establishes_scroll_container(&self) -> bool {
-        // CSS computed value has make sure that either both axis is scrollable or none is scrollable.
+    pub fn establishes_scroll_container(&self) -> bool {
+        // The CSS computed value has made sure that either both axes are scrollable or none are scrollable.
         self.upcast::<Node>()
             .effective_overflow()
             .is_some_and(|overflow| overflow.establishes_scroll_container())
     }
 
-    pub(crate) fn has_overflow(&self) -> bool {
+    pub fn has_overflow(&self) -> bool {
         self.ScrollHeight() > self.ClientHeight() || self.ScrollWidth() > self.ClientWidth()
+    }
+
+    /// Whether or not this element has a scrolling box according to
+    /// <https://drafts.csswg.org/cssom-view/#scrolling-box>.
+    ///
+    /// This is true if:
+    ///  1. The element has a layout box.
+    ///  2. The style specifies that overflow should be scrollable (`auto`, `hidden` or `scroll`).
+    ///  3. The fragment actually has content that overflows the box.
+    fn has_scrolling_box(&self) -> bool {
+        self.has_css_layout_box() && self.establishes_scroll_container() && self.has_overflow()
     }
 
     pub(crate) fn shadow_root(&self) -> Option<DomRoot<ShadowRoot>> {
@@ -2736,7 +2747,7 @@ impl Element {
         }
 
         // Step 10
-        if !self.upcast::<Node>().establishes_scrolling_box() {
+        if !self.has_scrolling_box() {
             return;
         }
 
@@ -3472,7 +3483,7 @@ impl ElementMethods<crate::DomTypeHolder> for Element {
         }
 
         // Step 10
-        if !self.upcast::<Node>().establishes_scrolling_box() {
+        if !self.has_scrolling_box() {
             return;
         }
 
@@ -3569,7 +3580,7 @@ impl ElementMethods<crate::DomTypeHolder> for Element {
         }
 
         // Step 10
-        if !self.upcast::<Node>().establishes_scrolling_box() {
+        if !self.has_scrolling_box() {
             return;
         }
 

--- a/components/script/dom/element.rs
+++ b/components/script/dom/element.rs
@@ -569,14 +569,14 @@ impl Element {
 
     /// Whether this element is styled such that it establishes a scroll container.
     /// <https://www.w3.org/TR/css-overflow-3/#scroll-container>
-    pub fn establishes_scroll_container(&self) -> bool {
+    pub(crate) fn establishes_scroll_container(&self) -> bool {
         // The CSS computed value has made sure that either both axes are scrollable or none are scrollable.
         self.upcast::<Node>()
             .effective_overflow()
             .is_some_and(|overflow| overflow.establishes_scroll_container())
     }
 
-    pub fn has_overflow(&self) -> bool {
+    pub(crate) fn has_overflow(&self) -> bool {
         self.ScrollHeight() > self.ClientHeight() || self.ScrollWidth() > self.ClientWidth()
     }
 

--- a/components/script/dom/element.rs
+++ b/components/script/dom/element.rs
@@ -2736,10 +2736,7 @@ impl Element {
         }
 
         // Step 10
-        if !self.has_css_layout_box() ||
-            !self.upcast::<Node>().establishes_scrolling_box() ||
-            !self.has_overflow()
-        {
+        if !self.upcast::<Node>().establishes_scrolling_box() {
             return;
         }
 
@@ -3475,10 +3472,7 @@ impl ElementMethods<crate::DomTypeHolder> for Element {
         }
 
         // Step 10
-        if !self.has_css_layout_box() ||
-            !self.upcast::<Node>().establishes_scrolling_box() ||
-            !self.has_overflow()
-        {
+        if !self.upcast::<Node>().establishes_scrolling_box() {
             return;
         }
 
@@ -3575,10 +3569,7 @@ impl ElementMethods<crate::DomTypeHolder> for Element {
         }
 
         // Step 10
-        if !self.has_css_layout_box() ||
-            !self.upcast::<Node>().establishes_scrolling_box() ||
-            !self.has_overflow()
-        {
+        if !self.upcast::<Node>().establishes_scrolling_box() {
             return;
         }
 

--- a/components/script/dom/element.rs
+++ b/components/script/dom/element.rs
@@ -567,13 +567,13 @@ impl Element {
         true
     }
 
+    /// Whether this element is styled such that it establish a scroll container.
     /// <https://www.w3.org/TR/css-overflow-3/#scroll-container>
-    fn establish_scroll_container(&self) -> bool {
-        // TODO: scrolling mechanism, such as scrollbar (We don't have scrollbar yet)
-        //       self.has_scrolling_mechanism()
+    fn establishes_scroll_container(&self) -> bool {
+        // CSS computed value has make sure that either both axis is scrollable or none is scrollable.
         self.upcast::<Node>()
             .effective_overflow()
-            .is_some_and(|overflow| overflow.x.is_scrollable())
+            .is_some_and(|overflow| overflow.establishes_scroll_container())
     }
 
     fn has_overflow(&self) -> bool {
@@ -2736,7 +2736,9 @@ impl Element {
         }
 
         // Step 10
-        if !self.has_css_layout_box() || !self.establish_scroll_container() || !self.has_overflow()
+        if !self.has_css_layout_box() ||
+            !self.establishes_scroll_container() ||
+            !self.has_overflow()
         {
             return;
         }
@@ -3473,7 +3475,9 @@ impl ElementMethods<crate::DomTypeHolder> for Element {
         }
 
         // Step 10
-        if !self.has_css_layout_box() || !self.establish_scroll_container() || !self.has_overflow()
+        if !self.has_css_layout_box() ||
+            !self.establishes_scroll_container() ||
+            !self.has_overflow()
         {
             return;
         }
@@ -3571,7 +3575,9 @@ impl ElementMethods<crate::DomTypeHolder> for Element {
         }
 
         // Step 10
-        if !self.has_css_layout_box() || !self.establish_scroll_container() || !self.has_overflow()
+        if !self.has_css_layout_box() ||
+            !self.establishes_scroll_container() ||
+            !self.has_overflow()
         {
             return;
         }

--- a/components/script/dom/intersectionobserver.rs
+++ b/components/script/dom/intersectionobserver.rs
@@ -434,10 +434,13 @@ impl IntersectionObserver {
             // Handle if root is an element.
             Some(ElementOrDocument::Element(element)) => {
                 // TODO: recheck scrollbar approach and clip-path clipping from Chromium implementation.
-                if element.style().is_some_and(|style| {
-                    style.clone_overflow_x() != Overflow::Visible ||
-                        style.clone_overflow_y() != Overflow::Visible
-                }) {
+                if element
+                    .upcast::<Node>()
+                    .effective_overflow_without_reflow()
+                    .is_some_and(|overflow_axes| {
+                        overflow_axes.x != Overflow::Visible || overflow_axes.y != Overflow::Visible
+                    })
+                {
                     // > Otherwise, if the intersection root has a content clip, it’s the element’s padding area.
                     window.box_area_query_without_reflow(
                         &DomRoot::upcast::<Node>(element.clone()),

--- a/components/script/dom/node.rs
+++ b/components/script/dom/node.rs
@@ -3363,6 +3363,27 @@ impl Node {
         let _ = require_well_formed;
         self.xml_serialize(xml_serialize::TraversalScope::ChildrenOnly(None))
     }
+
+    /// Return true if this node establishes a "scrolling box".
+    pub(crate) fn establishes_scrolling_box(&self) -> bool {
+        // For now, `Document` represents the viewport.
+        //
+        // TODO: Is this the right thing to do? Maybe `Document` should be ignored and viewport
+        // should be represented by the root of the DOM flat tree.
+        if self.is::<Document>() {
+            return true;
+        }
+        let Some(element) = self.downcast::<Element>() else {
+            // Shadow roots and other nodes are not scrolling boxes.
+            return false;
+        };
+
+        // > Elements and viewports have an associated scrolling box if the element or viewport has a scrolling mechanism,
+        // > or it overflows its content area and the used value of the overflow-x or overflow-y property is not
+        // > overflow/hidden or overflow/clip. [CSS3-BOX]
+        // TODO: handle scrolling mechanism.
+        element.establishes_scroll_container() && element.has_overflow()
+    }
 }
 
 impl NodeMethods<crate::DomTypeHolder> for Node {

--- a/components/script/dom/node.rs
+++ b/components/script/dom/node.rs
@@ -3363,34 +3363,6 @@ impl Node {
         let _ = require_well_formed;
         self.xml_serialize(xml_serialize::TraversalScope::ChildrenOnly(None))
     }
-
-    /// Return true if this node establishes a "scrolling box".
-    pub(crate) fn establishes_scrolling_box(&self) -> bool {
-        // For now, `Document` represents the viewport.
-        //
-        // TODO: Is this the right thing to do? Maybe `Document` should be ignored and viewport
-        // should be represented by the root of the DOM flat tree.
-        if self.is::<Document>() {
-            return true;
-        }
-        let Some(element) = self.downcast::<Element>() else {
-            // Shadow roots and other nodes are not scrolling boxes.
-            return false;
-        };
-
-        // Element that has scrolling box must have a box as well.
-        if !element.has_css_layout_box() {
-            return true;
-        }
-
-        // > Elements and viewports have an associated scrolling box if the element or viewport has a scrolling mechanism,
-        // TODO: Handle checks for scrolling mechanism as required by spec.
-
-        // > or it overflows its content area and the used value of the overflow-x or overflow-y property is not
-        // > overflow/hidden or overflow/clip. [CSS3-BOX]
-        // The overflow-x and overflow-y scrolls is guaranteed as long as the element is a scroll container.
-        element.establishes_scroll_container() && element.has_overflow()
-    }
 }
 
 impl NodeMethods<crate::DomTypeHolder> for Node {

--- a/components/script/dom/node.rs
+++ b/components/script/dom/node.rs
@@ -3378,10 +3378,17 @@ impl Node {
             return false;
         };
 
+        // Element that has scrolling box must have a box as well.
+        if !element.has_css_layout_box() {
+            return true;
+        }
+
         // > Elements and viewports have an associated scrolling box if the element or viewport has a scrolling mechanism,
+        // TODO: Handle checks for scrolling mechanism as required by spec.
+
         // > or it overflows its content area and the used value of the overflow-x or overflow-y property is not
         // > overflow/hidden or overflow/clip. [CSS3-BOX]
-        // TODO: handle scrolling mechanism.
+        // The overflow-x and overflow-y scrolls is guaranteed as long as the element is a scroll container.
         element.establishes_scroll_container() && element.has_overflow()
     }
 }

--- a/components/script/dom/node.rs
+++ b/components/script/dom/node.rs
@@ -26,9 +26,9 @@ use js::rust::HandleObject;
 use keyboard_types::Modifiers;
 use layout_api::wrapper_traits::SharedSelection;
 use layout_api::{
-    BoxAreaType, CSSPixelRectIterator, GenericLayoutData, HTMLCanvasData, HTMLMediaData,
-    LayoutElementType, LayoutNodeType, PhysicalSides, QueryMsg, SVGElementData, StyleData,
-    TrustedNodeAddress, with_layout_state,
+    AxesOverflow, BoxAreaType, CSSPixelRectIterator, GenericLayoutData, HTMLCanvasData,
+    HTMLMediaData, LayoutElementType, LayoutNodeType, PhysicalSides, QueryMsg, SVGElementData,
+    StyleData, TrustedNodeAddress, with_layout_state,
 };
 use libc::{self, c_void, uintptr_t};
 use malloc_size_of::{MallocSizeOf, MallocSizeOfOps};
@@ -1038,6 +1038,15 @@ impl Node {
         // these steps."
         // "7. Return the width of the element’s scrolling area."
         window.scrolling_area_query(Some(self))
+    }
+
+    pub(crate) fn effective_overflow(&self) -> Option<AxesOverflow> {
+        self.owner_window().query_effective_overflow(self)
+    }
+
+    pub(crate) fn effective_overflow_without_reflow(&self) -> Option<AxesOverflow> {
+        self.owner_window()
+            .query_effective_overflow_without_reflow(self)
     }
 
     /// <https://dom.spec.whatwg.org/#dom-childnode-before>
@@ -3353,28 +3362,6 @@ impl Node {
         // TODO: xml5ever doesn't seem to want require_well_formed
         let _ = require_well_formed;
         self.xml_serialize(xml_serialize::TraversalScope::ChildrenOnly(None))
-    }
-
-    /// Return true if this node establishes a "scrolling box" for the purposes of `scrollIntoView`.
-    pub(crate) fn establishes_scrolling_box(&self) -> bool {
-        // For now, `Document` represents the viewport.
-        //
-        // TODO: Is this the right thing to do? Maybe `Document` should be ignored and viewport
-        // should be represented by the root of the DOM flat tree.
-        if self.is::<Document>() {
-            return true;
-        }
-        let Some(element) = self.downcast::<Element>() else {
-            // Shadow roots and other nodes are not scrolling boxes.
-            return false;
-        };
-        // TODO: This should ask layout whether or not the element establishes a scrolling
-        // box. This heuristic is wrong.
-        element.style().is_some_and(|style| {
-            let overflow_x = style.get_box().clone_overflow_x();
-            let overflow_y = style.get_box().clone_overflow_y();
-            overflow_x.is_scrollable() || overflow_y.is_scrollable()
-        })
     }
 }
 

--- a/components/script/dom/window.rs
+++ b/components/script/dom/window.rs
@@ -55,11 +55,12 @@ use js::rust::{
     MutableHandleValue,
 };
 use layout_api::{
-    BoxAreaType, CSSPixelRectIterator, ElementsFromPointFlags, ElementsFromPointResult,
-    FragmentType, Layout, LayoutImageDestination, PendingImage, PendingImageState,
-    PendingRasterizationImage, PhysicalSides, QueryMsg, ReflowGoal, ReflowPhasesRun, ReflowRequest,
-    ReflowRequestRestyle, ReflowStatistics, RestyleReason, ScrollContainerQueryFlags,
-    ScrollContainerResponse, TrustedNodeAddress, combine_id_with_fragment_type,
+    AxesOverflow, BoxAreaType, CSSPixelRectIterator, ElementsFromPointFlags,
+    ElementsFromPointResult, FragmentType, Layout, LayoutImageDestination, PendingImage,
+    PendingImageState, PendingRasterizationImage, PhysicalSides, QueryMsg, ReflowGoal,
+    ReflowPhasesRun, ReflowRequest, ReflowRequestRestyle, ReflowStatistics, RestyleReason,
+    ScrollContainerQueryFlags, ScrollContainerResponse, TrustedNodeAddress,
+    combine_id_with_fragment_type,
 };
 use malloc_size_of::MallocSizeOf;
 use media::WindowGLContext;
@@ -3021,6 +3022,20 @@ impl Window {
     ) -> Vec<ElementsFromPointResult> {
         self.layout_reflow(QueryMsg::ElementsFromPoint);
         self.layout().query_elements_from_point(point, flags)
+    }
+
+    pub(crate) fn query_effective_overflow(&self, node: &Node) -> Option<AxesOverflow> {
+        self.layout_reflow(QueryMsg::EffectiveOverflow);
+        self.query_effective_overflow_without_reflow(node)
+    }
+
+    pub(crate) fn query_effective_overflow_without_reflow(
+        &self,
+        node: &Node,
+    ) -> Option<AxesOverflow> {
+        self.layout
+            .borrow()
+            .query_effective_overflow(node.to_trusted_node_address())
     }
 
     pub(crate) fn hit_test_from_input_event(

--- a/components/shared/layout/lib.rs
+++ b/components/shared/layout/lib.rs
@@ -477,6 +477,13 @@ impl AxesOverflow {
             y: self.y.to_scrollable(),
         }
     }
+
+    /// Whether or not the `overflow` value establishes a scroll container.
+    pub fn establishes_scroll_container(&self) -> bool {
+        // Checking one axis suffices, because the computed value ensures that
+        // either both axes are scrollable, or none is scrollable.
+        self.x.is_scrollable()
+    }
 }
 
 #[derive(Clone)]

--- a/components/shared/layout/lib.rs
+++ b/components/shared/layout/lib.rs
@@ -389,6 +389,7 @@ pub trait Layout {
         point: LayoutPoint,
         flags: ElementsFromPointFlags,
     ) -> Vec<ElementsFromPointResult>;
+    fn query_effective_overflow(&self, node: TrustedNodeAddress) -> Option<AxesOverflow>;
     fn register_custom_property(
         &mut self,
         property_registration: PropertyRegistration,
@@ -490,6 +491,7 @@ pub enum QueryMsg {
     BoxAreas,
     ClientRectQuery,
     CurrentCSSZoomQuery,
+    EffectiveOverflow,
     ElementInnerOuterTextQuery,
     ElementsFromPoint,
     InnerWindowDimensionsQuery,

--- a/tests/wpt/meta/intersection-observer/containing-block.html.ini
+++ b/tests/wpt/meta/intersection-observer/containing-block.html.ini
@@ -2,5 +2,8 @@
   [Not in containing block and not intersecting.]
     expected: FAIL
 
-  [Not in containing block and intersecting.]
+  [In containing block and intersecting.]
+    expected: FAIL
+
+  [In containing block and not intersecting.]
     expected: FAIL

--- a/tests/wpt/meta/intersection-observer/isIntersecting-change-events.html.ini
+++ b/tests/wpt/meta/intersection-observer/isIntersecting-change-events.html.ini
@@ -1,0 +1,3 @@
+[isIntersecting-change-events.html]
+  [Add 4th target.]
+    expected: FAIL

--- a/tests/wpt/tests/intersection-observer/animating.html
+++ b/tests/wpt/tests/intersection-observer/animating.html
@@ -18,8 +18,8 @@ pre, #log {
 }
 @keyframes slideup {
   0% { transform: translateY(0) }
-  30% { transform: translateY(0) }
-  31% { transform: translateY(-2000px) }
+  50% { transform: translateY(0) }
+  51% { transform: translateY(-2000px) }
   100% { transform: translateY(-2000px) }
 }
 </style>
@@ -40,10 +40,10 @@ promise_test(t => {
         }
       });
     });
-    target.style.animation = "3s linear slideup";
+    target.style.animation = "4s linear slideup";
     setTimeout(() => {
-      reject("Did not get a not-intersecting notification within 2 seconds.");
-    }, 2000);
+      reject("Did not get a not-intersecting notification within 3 seconds.");
+    }, 3000);
     target.addEventListener("animationend", evt => {
       reject("animationend event fired before not-intersecting notification.");
     });

--- a/tests/wpt/tests/intersection-observer/root-is-table-with-overflow-scroll.html
+++ b/tests/wpt/tests/intersection-observer/root-is-table-with-overflow-scroll.html
@@ -1,0 +1,73 @@
+<!DOCTYPE html>
+<title>IntersectionObserver observing table with border and overflow scroll</title>
+<link rel="author" href="mailto:steven.novaryo@gmail.com" title="Steven Novaryo">
+<link rel="help" href="https://w3c.github.io/IntersectionObserver/#intersectionobserver-root-intersection-rectangle">
+<link rel="help" href="https://drafts.csswg.org/css-tables/#global-style-overrides">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="./resources/intersection-observer-test-utils.js"></script>
+
+<style>
+  #root {
+    box-sizing: border-box;
+    overflow: scroll;
+    border: 50px solid black;
+    will-change: transform;
+  }
+  #target {
+    display: inline-block;
+    width: 50px;
+    height: 50px;
+    position: absolute;
+    top: 300px;
+    left: 300px;
+    background-color: green;
+  }
+</style>
+<table id="root">
+  <tr>
+    <td>
+      <span id="target"></span>
+    </td>
+  </tr>
+</table>
+<script>
+var entries = [];
+var rootRect = root.getBoundingClientRect();
+
+runTestCycle(function() {
+  assert_true(!!target, "target exists");
+  var observer = new IntersectionObserver(function(changes) {
+    entries = entries.concat(changes)
+  }, { root: root });
+  observer.observe(target);
+  entries = entries.concat(observer.takeRecords());
+  assert_equals(entries.length, 0, "No initial notifications.");
+  runTestCycle(step0, "First rAF.");
+}, "IntersectionObserver observing an element inside a root table.");
+
+function step0() {
+  // To reduce the inconsistencies of the layout within different UAs we are calculating the offset dynamically.
+  var targetRect = target.getBoundingClientRect();
+  target.style.top = `${300 - (targetRect.top - rootRect.bottom + 50)}px`;
+  target.style.left = `${300 - (targetRect.left - rootRect.right + 50)}px`;
+  runTestCycle(step1, "Moving the target to the right bottom corner of the table.");
+  checkLastEntry(entries, 0, [
+    targetRect.left, targetRect.right, targetRect.top, targetRect.bottom,
+    0, 0, 0, 0,
+    rootRect.left, rootRect.right, rootRect.top, rootRect.bottom,
+    false
+  ]);
+}
+
+function step1() {
+  var targetRect = target.getBoundingClientRect();
+  checkLastEntry(entries, 1, [
+    targetRect.left, targetRect.right, targetRect.top, targetRect.bottom,
+    targetRect.left, targetRect.right, targetRect.top, targetRect.bottom,
+    rootRect.left, rootRect.right, rootRect.top, rootRect.bottom,
+    true
+  ]);
+}
+
+</script>


### PR DESCRIPTION
In layout calculation within script, Instead of relying on the computed values for overflow, query the overflow from layout for its used value to accurately reflect whether an element establish a scroll container. This query will be used for `IntersectionObserver` as well.

Testing: There are new `IntersectionObserver` WPT failures:
- `intersection-observer/isIntersecting-change-events.html`
- `intersection-observer/containing-block.html`

The failures are more than likely a false positive because intersection observation steps wasn't supposed to trigger a reflow, but it was before. It could be caused by the implementation of `IntersectionObserver` in major UAs being a little bit different from the spec in the calculation of `threshold` and `isIntersecting`  .