### PR TITLE
script: Start implementation of shared attribute processing for iframes

### DIFF
--- a/tests/wpt/meta/html/browsers/browsing-the-web/navigating-across-documents/initial-empty-document/iframe-nosrc.html.ini
+++ b/tests/wpt/meta/html/browsers/browsing-the-web/navigating-across-documents/initial-empty-document/iframe-nosrc.html.ini
@@ -2,8 +2,5 @@
   [window.open]
     expected: FAIL
 
-  [link click]
-    expected: FAIL
-
   [initial about:blank => non-initial about:blank (via location.href) => normal HTTP navigation]
     expected: FAIL

--- a/tests/wpt/meta/html/browsers/browsing-the-web/navigating-across-documents/initial-empty-document/iframe-src-aboutblank-navigate-immediately.html.ini
+++ b/tests/wpt/meta/html/browsers/browsing-the-web/navigating-across-documents/initial-empty-document/iframe-src-aboutblank-navigate-immediately.html.ini
@@ -1,9 +1,3 @@
 [iframe-src-aboutblank-navigate-immediately.html]
   [Navigating to a different document with window.open]
     expected: FAIL
-
-  [Navigating to a different document with link click]
-    expected: FAIL
-
-  [Navigating to a different document with form submission]
-    expected: FAIL

--- a/tests/wpt/meta/html/browsers/browsing-the-web/navigating-across-documents/initial-empty-document/iframe-src-aboutblank-wait-for-load.html.ini
+++ b/tests/wpt/meta/html/browsers/browsing-the-web/navigating-across-documents/initial-empty-document/iframe-src-aboutblank-wait-for-load.html.ini
@@ -1,6 +1,3 @@
 [iframe-src-aboutblank-wait-for-load.html]
-  [Navigating to a different document with src]
-    expected: FAIL
-
   [Navigating to a different document with window.open]
     expected: FAIL

--- a/tests/wpt/meta/html/browsers/browsing-the-web/navigating-across-documents/initial-empty-document/initial-content-replacement.html.ini
+++ b/tests/wpt/meta/html/browsers/browsing-the-web/navigating-across-documents/initial-empty-document/initial-content-replacement.html.ini
@@ -1,16 +1,4 @@
 [initial-content-replacement.html]
-  [Content synchronously added to <iframe> with src='' won't get replaced]
-    expected: FAIL
-
-  [Content synchronously added to <iframe> with src='about:blank' won't get replaced]
-    expected: FAIL
-
-  [Content synchronously added to <iframe> with src='about:blank#foo' won't get replaced]
-    expected: FAIL
-
-  [Content synchronously added to <iframe> with src='about:blank?foo' won't get replaced]
-    expected: FAIL
-
   [Content synchronously added to window.open('about:blank')-ed document won't get replaced]
     expected: FAIL
 

--- a/tests/wpt/meta/html/browsers/browsing-the-web/navigating-across-documents/initial-empty-document/load-event-iframe-element.html.ini
+++ b/tests/wpt/meta/html/browsers/browsing-the-web/navigating-across-documents/initial-empty-document/load-event-iframe-element.html.ini
@@ -1,13 +1,4 @@
 [load-event-iframe-element.html]
-  [load event fires synchronously on <iframe> element created with no src]
-    expected: FAIL
-
-  [load event fires synchronously on <iframe> element created with src='']
-    expected: FAIL
-
-  [load event fires synchronously on <iframe> element created with src='about:blank']
-    expected: FAIL
-
   [load event fires synchronously on <iframe> element created with src='about:blank#foo']
     expected: FAIL
 

--- a/tests/wpt/meta/html/browsers/browsing-the-web/navigating-across-documents/initial-empty-document/load-pageshow-events-iframe-contentWindow.html.ini
+++ b/tests/wpt/meta/html/browsers/browsing-the-web/navigating-across-documents/initial-empty-document/load-pageshow-events-iframe-contentWindow.html.ini
@@ -7,3 +7,9 @@
 
   [load & pageshow events do not fire on contentWindow of <iframe> element created with src='about:blank#foo']
     expected: FAIL
+
+  [load & pageshow events do not fire on contentWindow of <iframe> element created with src='']
+    expected: FAIL
+
+  [load & pageshow events do not fire on contentWindow of <iframe> element created with src='about:blank']
+    expected: FAIL

--- a/tests/wpt/meta/html/browsers/browsing-the-web/navigating-across-documents/initial-empty-document/load-pageshow-events-window-open.html.ini
+++ b/tests/wpt/meta/html/browsers/browsing-the-web/navigating-across-documents/initial-empty-document/load-pageshow-events-window-open.html.ini
@@ -10,6 +10,3 @@
 
   [load event does not fire on window.open('about:blank?foo')]
     expected: FAIL
-
-  [load event does not fire on window.open('about:blank')]
-    expected: FAIL

--- a/tests/wpt/meta/html/browsers/history/joint-session-history/joint-session-history-remove-iframe.html.ini
+++ b/tests/wpt/meta/html/browsers/history/joint-session-history/joint-session-history-remove-iframe.html.ini
@@ -1,3 +1,0 @@
-[joint-session-history-remove-iframe.html]
-  [Joint session history length does not include entries from a removed iframe.]
-    expected: FAIL

--- a/tests/wpt/meta/html/browsers/the-window-object/window-reuse-in-nested-browsing-contexts.tentative.html.ini
+++ b/tests/wpt/meta/html/browsers/the-window-object/window-reuse-in-nested-browsing-contexts.tentative.html.ini
@@ -14,3 +14,8 @@
   [synchronously navigate iframe with initial src == "".]
     expected: FAIL
 
+  [after the first iframe load event, navigate iframe with initial src == "".]
+    expected: FAIL
+
+  [after the first iframe load event, navigate iframe with initial src == "about:blank".]
+    expected: FAIL

--- a/tests/wpt/meta/html/infrastructure/urls/base-url/document-base-url-changes-about-srcdoc-2.https.html.ini
+++ b/tests/wpt/meta/html/infrastructure/urls/base-url/document-base-url-changes-about-srcdoc-2.https.html.ini
@@ -1,4 +1,0 @@
-[document-base-url-changes-about-srcdoc-2.https.html]
-  expected: TIMEOUT
-  [wrapper promise test for timeout.]
-    expected: TIMEOUT

--- a/tests/wpt/meta/html/semantics/embedded-content/the-iframe-element/iframe-nosrc.html.ini
+++ b/tests/wpt/meta/html/semantics/embedded-content/the-iframe-element/iframe-nosrc.html.ini
@@ -1,3 +1,0 @@
-[iframe-nosrc.html]
-  [load event of iframe should not be fired after processing the element]
-    expected: FAIL

--- a/tests/wpt/meta/html/user-activation/detached-iframe.html.ini
+++ b/tests/wpt/meta/html/user-activation/detached-iframe.html.ini
@@ -1,0 +1,3 @@
+[detached-iframe.html]
+  [navigator.userActivation retains state even if global is removed]
+    expected: FAIL

--- a/tests/wpt/meta/shadow-dom/focus/focus-method-delegatesFocus-nested-browsing-context.html.ini
+++ b/tests/wpt/meta/shadow-dom/focus/focus-method-delegatesFocus-nested-browsing-context.html.ini
@@ -1,2 +1,0 @@
-[focus-method-delegatesFocus-nested-browsing-context.html]
-  expected: ERROR

--- a/tests/wpt/meta/xhr/open-url-multi-window-6.htm.ini
+++ b/tests/wpt/meta/xhr/open-url-multi-window-6.htm.ini
@@ -1,3 +1,2 @@
 [open-url-multi-window-6.htm]
-  [XMLHttpRequest: open() in document that is not fully active (but may be active) should throw]
-    expected: FAIL
+  expected: CRASH


### PR DESCRIPTION
Start with implementing the new algorithms per the spec. This fixes the case where the load event should be fired, but only if a src exists and it is about:blank and it is connected for the very first time.

Part of #31973