### PR TITLE
script: Fix timing of frozen base URL

### DIFF
--- a/components/script/dom/document.rs
+++ b/components/script/dom/document.rs
@@ -995,7 +995,10 @@ impl Document {
     /// Refresh the cached first base element in the DOM.
     /// <https://github.com/w3c/web-platform-tests/issues/2122>
     pub(crate) fn refresh_base_element(&self) {
-        let base = self
+        if let Some(base_element) = self.base_element.get() {
+            base_element.clear_frozen_base_url();
+        }
+        let new_base_element = self
             .upcast::<Node>()
             .traverse_preorder(ShadowIncluding::No)
             .filter_map(DomRoot::downcast::<HTMLBaseElement>)
@@ -1004,7 +1007,10 @@ impl Document {
                     .upcast::<Element>()
                     .has_attribute(&local_name!("href"))
             });
-        self.base_element.set(base.as_deref());
+        if let Some(ref new_base_element) = new_base_element {
+            new_base_element.set_frozen_base_url();
+        }
+        self.base_element.set(new_base_element.as_deref());
     }
 
     pub(crate) fn dom_count(&self) -> u32 {

--- a/components/script/dom/html/htmlbaseelement.rs
+++ b/components/script/dom/html/htmlbaseelement.rs
@@ -8,6 +8,7 @@ use js::rust::HandleObject;
 use servo_url::ServoUrl;
 
 use crate::dom::attr::Attr;
+use crate::dom::bindings::cell::DomRefCell;
 use crate::dom::bindings::codegen::Bindings::HTMLBaseElementBinding::HTMLBaseElementMethods;
 use crate::dom::bindings::inheritance::Castable;
 use crate::dom::bindings::root::DomRoot;
@@ -22,6 +23,10 @@ use crate::script_runtime::CanGc;
 #[dom_struct]
 pub(crate) struct HTMLBaseElement {
     htmlelement: HTMLElement,
+
+    /// <https://html.spec.whatwg.org/multipage/#frozen-base-url>
+    #[no_trace]
+    frozen_base_url: DomRefCell<Option<ServoUrl>>,
 }
 
 impl HTMLBaseElement {
@@ -32,6 +37,7 @@ impl HTMLBaseElement {
     ) -> HTMLBaseElement {
         HTMLBaseElement {
             htmlelement: HTMLElement::new_inherited(local_name, prefix, document),
+            frozen_base_url: Default::default(),
         }
     }
 
@@ -50,58 +56,76 @@ impl HTMLBaseElement {
         )
     }
 
-    /// <https://html.spec.whatwg.org/multipage/#frozen-base-url>
-    pub(crate) fn frozen_base_url(&self) -> ServoUrl {
-        let href = self
-            .upcast::<Element>()
-            .get_attribute(&ns!(), &local_name!("href"))
-            .expect(
-                "The frozen base url is only defined for base elements \
-                 that have a base url.",
-            );
-        let document = self.owner_document();
-        let base = document.fallback_base_url();
-        let parsed = base.join(&href.value());
-        parsed.unwrap_or(base)
+    pub(crate) fn clear_frozen_base_url(&self) {
+        *self.frozen_base_url.borrow_mut() = None;
     }
 
-    /// Update the cached base element in response to binding or unbinding from
-    /// a tree.
-    pub(crate) fn bind_unbind(&self, tree_in_doc: bool) {
-        if !tree_in_doc || self.upcast::<Node>().containing_shadow_root().is_some() {
+    /// <https://html.spec.whatwg.org/multipage/#set-the-frozen-base-url>
+    pub(crate) fn set_frozen_base_url(&self) {
+        // Step 1. Let document be element's node document.
+        let document = self.owner_document();
+        // Step 2. Let urlRecord be the result of parsing the value of element's href content attribute
+        // with document's fallback base URL, and document's character encoding. (Thus, the base element isn't affected by itself.)
+        let attr = self
+            .upcast::<Element>()
+            .get_attribute(&ns!(), &local_name!("href"));
+        let Some(href_value) = attr.as_ref().map(|attr| attr.value()) else {
+            unreachable!("Must always have a href set when setting frozen base URL");
+        };
+        let document_fallback_url = document.fallback_base_url();
+        let url_record = document_fallback_url.join(&href_value).ok();
+        // Step 3. If any of the following are true:
+        if
+        // urlRecord is failure;
+        url_record.as_ref().is_none_or(|url_record|
+            // urlRecord's scheme is "data" or "javascript"; or
+            url_record.scheme() == "data" || url_record.scheme() == "javascript")
+        // running Is base allowed for Document? on urlRecord and document returns "Blocked",
+        // TODO
+        {
+            // then set element's frozen base URL to document's fallback base URL and return.
+            *self.frozen_base_url.borrow_mut() = Some(document_fallback_url);
             return;
         }
+        // Step 4. Set element's frozen base URL to urlRecord.
+        *self.frozen_base_url.borrow_mut() = url_record;
+        // Step 5. Respond to base URL changes given document.
+        // TODO
+    }
 
-        if self.upcast::<Element>().has_attribute(&local_name!("href")) {
-            let document = self.owner_document();
-            document.refresh_base_element();
-        }
+    /// <https://html.spec.whatwg.org/multipage/#frozen-base-url>
+    pub(crate) fn frozen_base_url(&self) -> ServoUrl {
+        self.frozen_base_url
+            .borrow()
+            .clone()
+            .expect("Must only retrieve frozen base URL for valid base elements")
     }
 }
 
 impl HTMLBaseElementMethods<crate::DomTypeHolder> for HTMLBaseElement {
     /// <https://html.spec.whatwg.org/multipage/#dom-base-href>
     fn Href(&self) -> DOMString {
-        // Step 1.
+        // Step 1. Let document be element's node document.
         let document = self.owner_document();
 
-        // Step 2.
+        // Step 2. Let url be the value of the href attribute of this element, if it has one, and the empty string otherwise.
         let attr = self
             .upcast::<Element>()
             .get_attribute(&ns!(), &local_name!("href"));
         let value = attr.as_ref().map(|attr| attr.value());
         let url = value.as_ref().map_or("", |value| &**value);
 
-        // Step 3.
+        // Step 3. Let urlRecord be the result of parsing url with document's fallback base URL,
+        // and document's character encoding. (Thus, the base element isn't affected by other base elements or itself.)
         let url_record = document.fallback_base_url().join(url);
 
         match url_record {
             Err(_) => {
-                // Step 4.
+                // Step 4. If urlRecord is failure, return url.
                 url.into()
             },
             Ok(url_record) => {
-                // Step 5.
+                // Step 5. Return the serialization of urlRecord.
                 url_record.into_string().into()
             },
         }
@@ -120,18 +144,34 @@ impl VirtualMethods for HTMLBaseElement {
         self.super_type()
             .unwrap()
             .attribute_mutated(attr, mutation, can_gc);
+
+        // https://html.spec.whatwg.org/multipage/#frozen-base-url
         if *attr.local_name() == local_name!("href") {
-            self.owner_document().refresh_base_element();
+            // > The base element is the first base element in tree order with an href content attribute in its Document,
+            // > and its href content attribute is changed.
+            if self.frozen_base_url.borrow().is_some() && !mutation.is_removal() {
+                self.set_frozen_base_url();
+            } else {
+                // > The base element becomes the first base element in tree order with an href content attribute in its Document.
+                let document = self.owner_document();
+                document.refresh_base_element();
+            }
         }
     }
 
     fn bind_to_tree(&self, context: &BindContext, can_gc: CanGc) {
         self.super_type().unwrap().bind_to_tree(context, can_gc);
-        self.bind_unbind(context.tree_is_in_a_document_tree);
+        // https://html.spec.whatwg.org/multipage/#frozen-base-url
+        // > The base element becomes the first base element in tree order with an href content attribute in its Document.
+        let document = self.owner_document();
+        document.refresh_base_element();
     }
 
     fn unbind_from_tree(&self, context: &UnbindContext, can_gc: CanGc) {
         self.super_type().unwrap().unbind_from_tree(context, can_gc);
-        self.bind_unbind(context.tree_is_in_a_document_tree);
+        // https://html.spec.whatwg.org/multipage/#frozen-base-url
+        // > The base element becomes the first base element in tree order with an href content attribute in its Document.
+        let document = self.owner_document();
+        document.refresh_base_element();
     }
 }

--- a/tests/wpt/meta/html/semantics/document-metadata/the-base-element/base-data.html.ini
+++ b/tests/wpt/meta/html/semantics/document-metadata/the-base-element/base-data.html.ini
@@ -1,6 +1,0 @@
-[base-data.html]
-  [First <base> has a data: URL so fallback is used]
-    expected: FAIL
-
-  [Dynamically inserted first <base> has a data: URL so fallback is used]
-    expected: FAIL

--- a/tests/wpt/meta/html/semantics/document-metadata/the-base-element/base-javascript.html.ini
+++ b/tests/wpt/meta/html/semantics/document-metadata/the-base-element/base-javascript.html.ini
@@ -1,6 +1,0 @@
-[base-javascript.html]
-  [First <base> has a javascript: URL so fallback is used]
-    expected: FAIL
-
-  [Dynamically inserted first <base> has a javascript: URL so fallback is used]
-    expected: FAIL


### PR DESCRIPTION
Make it runs at the correct time and then also performs checks for its scheme. The CSP check is left for a follow-up PR.
