### PR TITLE
script: Change some HashSets to FxHashSet

### DIFF
--- a/components/script/dom/notification.rs
+++ b/components/script/dom/notification.rs
@@ -2,7 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-use std::collections::HashSet;
 use std::rc::Rc;
 use std::sync::Arc;
 use std::time::{SystemTime, UNIX_EPOCH};
@@ -23,6 +22,7 @@ use net_traits::image_cache::{
 use net_traits::request::{Destination, RequestBuilder, RequestId};
 use net_traits::{FetchMetadata, FetchResponseMsg, NetworkError, ResourceFetchTiming};
 use pixels::RasterImage;
+use rustc_hash::FxHashSet;
 use servo_url::{ImmutableOrigin, ServoUrl};
 use uuid::Uuid;
 
@@ -104,7 +104,7 @@ pub(crate) struct Notification {
     actions: Vec<Action>,
     /// Pending image, icon, badge, action icon resource request's id
     #[no_trace] // RequestId is not traceable
-    pending_request_ids: DomRefCell<HashSet<RequestId>>,
+    pending_request_ids: DomRefCell<FxHashSet<RequestId>>,
     /// <https://notifications.spec.whatwg.org/#image-resource>
     #[ignore_malloc_size_of = "RasterImage"]
     #[no_trace]
@@ -242,7 +242,7 @@ impl Notification {
             tag,
             require_interaction,
             actions,
-            pending_request_ids: DomRefCell::new(HashSet::new()),
+            pending_request_ids: DomRefCell::new(Default::default()),
             image_resource: DomRefCell::new(None),
             icon_resource: DomRefCell::new(None),
             badge_resource: DomRefCell::new(None),

--- a/components/script/script_thread.rs
+++ b/components/script/script_thread.rs
@@ -308,7 +308,7 @@ pub struct ScriptThread {
 
     /// A list of pipelines containing documents that finished loading all their blocking
     /// resources during a turn of the event loop.
-    docs_with_no_blocking_loads: DomRefCell<HashSet<Dom<Document>>>,
+    docs_with_no_blocking_loads: DomRefCell<FxHashSet<Dom<Document>>>,
 
     /// <https://html.spec.whatwg.org/multipage/#custom-element-reactions-stack>
     custom_element_reaction_stack: Rc<CustomElementReactionStack>,
@@ -1127,7 +1127,7 @@ impl ScriptThread {
         // steps per doc in docs. Currently `<iframe>` resizing depends on a parent being able to
         // queue resize events on a child and have those run in the same call to this method, so
         // that needs to be sorted out to fix this.
-        let mut painters_generating_frames = HashSet::new();
+        let mut painters_generating_frames = FxHashSet::default();
         for pipeline_id in documents_in_order.iter() {
             let document = self
                 .documents


### PR DESCRIPTION
This changes 3 occurences of HashSet to FxHashSet for speed improvements:
- dom/notifications::pending_request_ids: Pending Request ids are Uuid::new_v4, hence, not user assignable.
- script_thread: painters_generating_frames: These are pipeline ids and, hence, ideal for FxHash.
- script_thread:: docs_with_no_blocking_loads: These are Dom<Document> and their hash is the ptr address, so ideal for FxHash.

Signed-off-by: Narfinger <Narfinger@users.noreply.github.com>

Testing: These do not change functionality.
