### PR TITLE
script: Do not consider a node an ancestor of itself in `Node::is_ancestor_of`

### DIFF
--- a/components/script/dom/node.rs
+++ b/components/script/dom/node.rs
@@ -919,8 +919,8 @@ impl Node {
         self == child || self.is_ancestor_of(child)
     }
 
-    pub(crate) fn is_ancestor_of(&self, child: &Node) -> bool {
-        let mut current = &MutNullableDom::new(Some(child));
+    pub(crate) fn is_ancestor_of(&self, possible_descendant: &Node) -> bool {
+        let mut current = &possible_descendant.parent_node;
         let mut done = false;
 
         while let Some(node) = current.if_is_some(|node| {

--- a/tests/wpt/tests/html/semantics/forms/the-select-element/select-add-optgroup-before-argument-is-select-crash.html
+++ b/tests/wpt/tests/html/semantics/forms/the-select-element/select-add-optgroup-before-argument-is-select-crash.html
@@ -1,0 +1,7 @@
+<!DOCTYPE html>
+<link rel=help href="https://github.com/servo/servo/issues/41080">
+<script>
+  const select = document.createElement("select");
+  const optgroup = document.createElement("optgroup");
+  select.options.add(optgroup, select);
+</script>


### PR DESCRIPTION
This change fixes a crash in options collections due to the fact that a
`<select>` element was being considered an ancestor of itself. This
regression likely introduced in #40776.

This change also fills in the specification text for
`HTMLOptionCollect::Add`.

Testing: This change adds a WPT crash test.
Fixes: #41080.
