### PR TITLE
script: Correctly handle Reflector with AssociatedMemory and remove associated memory in finalize instead of drop

### DIFF
--- a/components/dom_struct/lib.rs
+++ b/components/dom_struct/lib.rs
@@ -12,8 +12,9 @@ use crate::domobject::expand_dom_object;
 
 #[proc_macro_attribute]
 pub fn dom_struct(args: TokenStream, input: TokenStream) -> TokenStream {
-    if !args.is_empty() {
-        panic!("#[dom_struct] takes no arguments");
+    let associated_memory = args.to_string().contains("associated_memory");
+    if !associated_memory && !args.is_empty() {
+        panic!("#[dom_struct] only takes 'associated_memory' as an argument");
     }
     let attributes = quote! {
         #[derive(deny_public_fields::DenyPublicFields, JSTraceable, MallocSizeOf)]
@@ -29,7 +30,7 @@ pub fn dom_struct(args: TokenStream, input: TokenStream) -> TokenStream {
     let item: Item = syn::parse(output).unwrap();
 
     if let Item::Struct(s) = item {
-        let expanded_dom_object = expand_dom_object(s.clone());
+        let expanded_dom_object = expand_dom_object(s.clone(), associated_memory);
         let s2 = quote! { #s #expanded_dom_object };
         if !s.generics.params.is_empty() {
             return s2.into();

--- a/components/script/dom/canvas/2d/canvasrenderingcontext2d.rs
+++ b/components/script/dom/canvas/2d/canvasrenderingcontext2d.rs
@@ -38,7 +38,7 @@ use crate::dom::textmetrics::TextMetrics;
 use crate::script_runtime::CanGc;
 
 // https://html.spec.whatwg.org/multipage/#canvasrenderingcontext2d
-#[dom_struct]
+#[dom_struct(associated_memory)]
 pub(crate) struct CanvasRenderingContext2D {
     reflector_: Reflector<AssociatedMemory>,
     canvas: HTMLCanvasElementOrOffscreenCanvas,

--- a/components/script/dom/canvas/2d/offscreencanvasrenderingcontext2d.rs
+++ b/components/script/dom/canvas/2d/offscreencanvasrenderingcontext2d.rs
@@ -34,7 +34,7 @@ use crate::dom::path2d::Path2D;
 use crate::dom::textmetrics::TextMetrics;
 use crate::script_runtime::CanGc;
 
-#[dom_struct]
+#[dom_struct(associated_memory)]
 pub(crate) struct OffscreenCanvasRenderingContext2D {
     context: CanvasRenderingContext2D,
 }

--- a/components/script/dom/html/htmlformelement.rs
+++ b/components/script/dom/html/htmlformelement.rs
@@ -1599,7 +1599,7 @@ impl FormSubmitterElement<'_> {
     }
 }
 
-pub(crate) trait FormControl: DomObject {
+pub(crate) trait FormControl: DomObject<ReflectorType = ()> {
     fn form_owner(&self) -> Option<DomRoot<HTMLFormElement>>;
 
     fn set_form_owner(&self, form: Option<&HTMLFormElement>);

--- a/components/script/dom/promise.rs
+++ b/components/script/dom/promise.rs
@@ -85,8 +85,7 @@ impl PromiseHelper for Rc<Promise> {
 impl Drop for Promise {
     #[expect(unsafe_code)]
     fn drop(&mut self) {
-        let reflector = script_bindings::reflector::DomObject::reflector(self);
-        reflector.drop_memory(self);
+        self.reflector.drop_memory(self);
         unsafe {
             let object = self.permanent_js_root.get().to_object();
             assert!(!object.is_null());

--- a/components/script/dom/webgl/webglquery.rs
+++ b/components/script/dom/webgl/webglquery.rs
@@ -184,8 +184,6 @@ impl WebGLQuery {
 
 impl Drop for WebGLQuery {
     fn drop(&mut self) {
-        let reflector = script_bindings::reflector::DomObject::reflector(self);
-        reflector.drop_memory(self);
         self.delete(Operation::Fallible);
     }
 }

--- a/components/script/dom/webgl/webglrenderbuffer.rs
+++ b/components/script/dom/webgl/webglrenderbuffer.rs
@@ -280,8 +280,6 @@ impl WebGLRenderbuffer {
 
 impl Drop for WebGLRenderbuffer {
     fn drop(&mut self) {
-        let reflector = script_bindings::reflector::DomObject::reflector(self);
-        reflector.drop_memory(self);
         self.delete(Operation::Fallible);
     }
 }

--- a/components/script/dom/webgl/webglsampler.rs
+++ b/components/script/dom/webgl/webglsampler.rs
@@ -181,8 +181,6 @@ impl WebGLSampler {
 
 impl Drop for WebGLSampler {
     fn drop(&mut self) {
-        let reflector = script_bindings::reflector::DomObject::reflector(self);
-        reflector.drop_memory(self);
         self.delete(Operation::Fallible);
     }
 }

--- a/components/script/dom/webgl/webglshader.rs
+++ b/components/script/dom/webgl/webglshader.rs
@@ -283,8 +283,6 @@ impl WebGLShader {
 
 impl Drop for WebGLShader {
     fn drop(&mut self) {
-        let reflector = script_bindings::reflector::DomObject::reflector(self);
-        reflector.drop_memory(self);
         self.mark_for_deletion(Operation::Fallible);
     }
 }

--- a/components/script/dom/webgl/webglsync.rs
+++ b/components/script/dom/webgl/webglsync.rs
@@ -130,8 +130,6 @@ impl WebGLSync {
 
 impl Drop for WebGLSync {
     fn drop(&mut self) {
-        let reflector = script_bindings::reflector::DomObject::reflector(self);
-        reflector.drop_memory(self);
         self.delete(Operation::Fallible);
     }
 }

--- a/components/script/dom/webgl/webgltexture.rs
+++ b/components/script/dom/webgl/webgltexture.rs
@@ -589,8 +589,6 @@ impl WebGLTexture {
 
 impl Drop for WebGLTexture {
     fn drop(&mut self) {
-        let reflector = script_bindings::reflector::DomObject::reflector(self);
-        reflector.drop_memory(self);
         self.delete(Operation::Fallible);
     }
 }

--- a/components/script/dom/webgl/webgltransformfeedback.rs
+++ b/components/script/dom/webgl/webgltransformfeedback.rs
@@ -127,8 +127,6 @@ impl WebGLTransformFeedback {
 
 impl Drop for WebGLTransformFeedback {
     fn drop(&mut self) {
-        let reflector = script_bindings::reflector::DomObject::reflector(self);
-        reflector.drop_memory(self);
         self.delete(Operation::Fallible);
     }
 }

--- a/components/script/dom/webgpu/gpubuffer.rs
+++ b/components/script/dom/webgpu/gpubuffer.rs
@@ -186,8 +186,6 @@ impl GPUBuffer {
 impl Drop for GPUBuffer {
     fn drop(&mut self) {
         self.Destroy();
-        let reflector = script_bindings::reflector::DomObject::reflector(self);
-        reflector.drop_memory(self);
     }
 }
 

--- a/components/script/dom/webgpu/gpucommandbuffer.rs
+++ b/components/script/dom/webgpu/gpucommandbuffer.rs
@@ -69,8 +69,6 @@ impl Drop for GPUCommandBuffer {
                 self.command_buffer.0, e
             );
         }
-        let reflector = script_bindings::reflector::DomObject::reflector(self);
-        reflector.drop_memory(self);
     }
 }
 

--- a/components/script/dom/webgpu/gpucomputepassencoder.rs
+++ b/components/script/dom/webgpu/gpucomputepassencoder.rs
@@ -155,7 +155,5 @@ impl Drop for GPUComputePassEncoder {
         {
             warn!("Failed to send WebGPURequest::DropComputePass with {e:?}");
         }
-        let reflector = script_bindings::reflector::DomObject::reflector(self);
-        reflector.drop_memory(self);
     }
 }

--- a/components/script/dom/webgpu/gpucomputepipeline.rs
+++ b/components/script/dom/webgpu/gpucomputepipeline.rs
@@ -158,7 +158,5 @@ impl Drop for GPUComputePipeline {
                 self.compute_pipeline.0, e
             );
         };
-        let reflector = script_bindings::reflector::DomObject::reflector(self);
-        reflector.drop_memory(self);
     }
 }

--- a/components/script/dom/webgpu/gpudevice.rs
+++ b/components/script/dom/webgpu/gpudevice.rs
@@ -738,7 +738,5 @@ impl Drop for GPUDevice {
         {
             warn!("Failed to send DropDevice ({:?}) ({})", self.device.0, e);
         }
-        let reflector = script_bindings::reflector::DomObject::reflector(self);
-        reflector.drop_memory(self);
     }
 }

--- a/components/script/dom/webgpu/gpupipelinelayout.rs
+++ b/components/script/dom/webgpu/gpupipelinelayout.rs
@@ -144,7 +144,5 @@ impl Drop for GPUPipelineLayout {
                 self.pipeline_layout.0, e
             );
         }
-        let reflector = script_bindings::reflector::DomObject::reflector(self);
-        reflector.drop_memory(self);
     }
 }

--- a/components/script/dom/webgpu/gpurenderbundle.rs
+++ b/components/script/dom/webgpu/gpurenderbundle.rs
@@ -93,7 +93,5 @@ impl Drop for GPURenderBundle {
                 self.render_bundle.0, e
             );
         }
-        let reflector = script_bindings::reflector::DomObject::reflector(self);
-        reflector.drop_memory(self);
     }
 }

--- a/components/script/dom/webgpu/gpurenderpassencoder.rs
+++ b/components/script/dom/webgpu/gpurenderpassencoder.rs
@@ -248,7 +248,5 @@ impl Drop for GPURenderPassEncoder {
         {
             warn!("Failed to send WebGPURequest::DropRenderPass with {e:?}");
         }
-        let reflector = script_bindings::reflector::DomObject::reflector(self);
-        reflector.drop_memory(self);
     }
 }

--- a/components/script/dom/webgpu/gpurenderpipeline.rs
+++ b/components/script/dom/webgpu/gpurenderpipeline.rs
@@ -147,7 +147,5 @@ impl Drop for GPURenderPipeline {
                 self.render_pipeline.0, e
             );
         };
-        let reflector = script_bindings::reflector::DomObject::reflector(self);
-        reflector.drop_memory(self);
     }
 }

--- a/components/script/dom/webgpu/gpusampler.rs
+++ b/components/script/dom/webgpu/gpusampler.rs
@@ -148,7 +148,5 @@ impl Drop for GPUSampler {
         {
             warn!("Failed to send DropSampler ({:?}) ({})", self.sampler.0, e);
         }
-        let reflector = script_bindings::reflector::DomObject::reflector(self);
-        reflector.drop_memory(self);
     }
 }

--- a/components/script/dom/webgpu/gpushadermodule.rs
+++ b/components/script/dom/webgpu/gpushadermodule.rs
@@ -159,7 +159,5 @@ impl Drop for GPUShaderModule {
                 self.shader_module.0, e
             );
         }
-        let reflector = script_bindings::reflector::DomObject::reflector(self);
-        reflector.drop_memory(self);
     }
 }

--- a/components/script/dom/webgpu/gputexture.rs
+++ b/components/script/dom/webgpu/gputexture.rs
@@ -119,8 +119,6 @@ impl Drop for GPUTexture {
                 self.texture.0, e
             );
         };
-        let reflector = script_bindings::reflector::DomObject::reflector(self);
-        reflector.drop_memory(self);
     }
 }
 

--- a/components/script/dom/webgpu/gputextureview.rs
+++ b/components/script/dom/webgpu/gputextureview.rs
@@ -93,7 +93,5 @@ impl Drop for GPUTextureView {
                 self.texture_view.0, e
             );
         }
-        let reflector = script_bindings::reflector::DomObject::reflector(self);
-        reflector.drop_memory(self);
     }
 }

--- a/components/script/dom/windowproxy.rs
+++ b/components/script/dom/windowproxy.rs
@@ -135,12 +135,6 @@ pub(crate) struct WindowProxy {
     script_window_proxies: Rc<ScriptWindowProxies>,
 }
 
-impl Drop for WindowProxy {
-    fn drop(&mut self) {
-        self.reflector.drop_memory(self);
-    }
-}
-
 impl WindowProxy {
     fn new_inherited(
         browsing_context_id: BrowsingContextId,

--- a/components/script/lib.rs
+++ b/components/script/lib.rs
@@ -86,5 +86,7 @@ pub(crate) use crate::dom::bindings::codegen::DomTypeHolder::DomTypeHolder;
 // Since they are used in derive macros,
 // it is useful that they are accessible at the root of the crate.
 pub(crate) use crate::dom::bindings::inheritance::HasParent;
-pub(crate) use crate::dom::bindings::reflector::{DomObject, MutDomObject, Reflector};
+pub(crate) use crate::dom::bindings::reflector::{
+    AssociatedMemory, DomObject, MutDomObject, Reflector,
+};
 pub(crate) use crate::dom::bindings::trace::{CustomTraceable, JSTraceable};

--- a/components/script_bindings/codegen/Bindings.conf
+++ b/components/script_bindings/codegen/Bindings.conf
@@ -88,7 +88,6 @@ DOMInterfaces = {
 
 'CanvasRenderingContext2D': {
     'canGc': ['GetTransform','GetImageData', 'CreateImageData', 'CreateImageData_', 'MeasureText', 'CreateLinearGradient', 'CreatePattern', 'CreateRadialGradient'],
-    'overrideMemoryUsage': True,
 },
 
 'CharacterData': {

--- a/components/script_bindings/codegen/codegen.py
+++ b/components/script_bindings/codegen/codegen.py
@@ -7162,16 +7162,9 @@ class CGForbidDrop(CGThing):
         self.code = f"""
 impl Drop for {firstCap(descriptor.interface.identifier.name)} {{
     fn drop(&mut self) {{
+    }}
+}}
 """
-        if not descriptor.interface.isNamespace():
-            self.code += """
-        let reflector = script_bindings::reflector::DomObject::reflector(self);
-        reflector.drop_memory(self);
-            """
-        self.code += """
-    }
-}
-        """
 
     def define(self) -> str:
         return self.code

--- a/components/script_bindings/codegen/codegen.py
+++ b/components/script_bindings/codegen/codegen.py
@@ -2612,10 +2612,8 @@ class CGAssertInheritance(CGThing):
         parentName = ""
         if parent:
             parentName = parent.identifier.name
-        elif not self.descriptor.overrideMemoryUsage:
-            parentName = "Reflector"
         else:
-            parentName = "Reflector<script_bindings::reflector::AssociatedMemory>"
+            parentName = "Reflector<_>"
 
         selfName = self.descriptor.interface.identifier.name
 

--- a/components/script_bindings/codegen/configuration.py
+++ b/components/script_bindings/codegen/configuration.py
@@ -301,7 +301,6 @@ class Descriptor(DescriptorProvider):
         self.weakReferenceable = desc.get('weakReferenceable', False)
         self.useSystemCompartment = desc.get('useSystemCompartment', False)
         self.allowDropImpl = desc.get('allowDropImpl', False)
-        self.overrideMemoryUsage = desc.get('overrideMemoryUsage', False)
 
         # If we're concrete, we need to crawl our ancestor interfaces and mark
         # them as having a concrete descendant.

--- a/components/script_bindings/conversions.rs
+++ b/components/script_bindings/conversions.rs
@@ -202,7 +202,7 @@ impl FromJSValConvertible for ByteString {
     }
 }
 
-impl ToJSValConvertible for Reflector {
+impl<T> ToJSValConvertible for Reflector<T> {
     unsafe fn to_jsval(&self, cx: *mut JSContext, mut rval: MutableHandleValue) {
         let obj = self.get_jsobject().get();
         assert!(!obj.is_null());

--- a/components/script_bindings/reflector.rs
+++ b/components/script_bindings/reflector.rs
@@ -121,20 +121,24 @@ impl Reflector<AssociatedMemory> {
 
 /// A trait to provide access to the `Reflector` for a DOM object.
 pub trait DomObject: js::gc::Traceable + 'static {
+    type ReflectorType: AssociatedMemorySize;
     /// Returns the receiver's reflector.
-    fn reflector(&self) -> &Reflector;
+    fn reflector(&self) -> &Reflector<Self::ReflectorType>;
 }
 
 impl DomObject for Reflector<()> {
-    fn reflector(&self) -> &Reflector<()> {
+    type ReflectorType = ();
+
+    fn reflector(&self) -> &Reflector<Self::ReflectorType> {
         self
     }
 }
 
 impl DomObject for Reflector<AssociatedMemory> {
-    fn reflector(&self) -> &Reflector<()> {
-        // SAFETY: This is safe because we are only shortening the size of struct.
-        unsafe { std::mem::transmute(self) }
+    type ReflectorType = AssociatedMemory;
+
+    fn reflector(&self) -> &Reflector<Self::ReflectorType> {
+        self
     }
 }
 

--- a/components/script_bindings/reflector.rs
+++ b/components/script_bindings/reflector.rs
@@ -97,7 +97,7 @@ impl<T: AssociatedMemorySize> Reflector<T> {
         size_of::<D>() + size_of::<Box<D>>() + self.size.size()
     }
 
-    /// This function should be called from Drop of the DOM objects
+    /// This function should be called from finalize of the DOM objects
     pub fn drop_memory<D>(&self, d: &D) {
         unsafe {
             RemoveAssociatedMemory(self.object.get(), self.rust_size(d), MemoryUse::DOMBinding);

--- a/components/script_bindings/root.rs
+++ b/components/script_bindings/root.rs
@@ -74,13 +74,16 @@ where
         // so we need this shenanigan to actually trace the reflector of the
         // T pointer in Dom<T>.
         #[cfg_attr(crown, expect(crown::unrooted_must_root))]
-        struct ReflectorStackRoot(Reflector);
-        unsafe impl JSTraceable for ReflectorStackRoot {
+        struct ReflectorStackRoot<T>(Reflector<T>);
+        unsafe impl<T> JSTraceable for ReflectorStackRoot<T> {
             unsafe fn trace(&self, tracer: *mut JSTracer) {
                 unsafe { trace_reflector(tracer, "on stack", &self.0) };
             }
         }
-        unsafe { &*(self.reflector() as *const Reflector as *const ReflectorStackRoot) }
+        unsafe {
+            &*(self.reflector() as *const Reflector<T::ReflectorType>
+                as *const ReflectorStackRoot<T::ReflectorType>)
+        }
     }
 }
 

--- a/components/script_bindings/trace.rs
+++ b/components/script_bindings/trace.rs
@@ -42,7 +42,11 @@ use crate::str::USVString;
 ///
 /// # Safety
 /// tracer must point to a valid, non-null JS tracer.
-pub unsafe fn trace_reflector(tracer: *mut JSTracer, description: &str, reflector: &Reflector) {
+pub unsafe fn trace_reflector<T>(
+    tracer: *mut JSTracer,
+    description: &str,
+    reflector: &Reflector<T>,
+) {
     trace!("tracing reflector {}", description);
     unsafe { trace_object(tracer, description, reflector.rootable()) }
 }


### PR DESCRIPTION
Reviewable per commits:

As noted in https://github.com/servo/servo/pull/42180#discussion_r2749861902 transmuting `&Reflector<AssociatedMemory>` to `&Reflector<()>` will ignore AssociatedMemory information and thus it will not remove extra associated memory. By returning `&Reflector<Self::ReflectorType>` from `DomObject::reflector()` we will preserve this information and thus correctly handle cases with associated memory. We also do not need `overrideMemoryUsage` in bindings.conf anymore. 🎉

Instead of removing associated memory in drop code we should do it as part of finalizers, otherwise we have problems in nested (inherited) structs, where drop is run for both parent and child, but we only added associated memory for child (on init_reflector) which already included size of parent. The only exception here is promise, because it is RCed and not finalized.

Testing: Tested locally that it fixes speedometer.
Fixes #42269 
