### PR TITLE
script: Fix handling changes to relevant attributes for stylesheets

### DIFF
--- a/components/script/dom/html/htmllinkelement.rs
+++ b/components/script/dom/html/htmllinkelement.rs
@@ -159,9 +159,9 @@ impl HTMLLinkElement {
 
     #[cfg_attr(crown, expect(crown::unrooted_must_root))]
     fn remove_stylesheet(&self) {
-        if let Some(s) = self.stylesheet.borrow_mut().take() {
+        if let Some(stylesheet) = self.stylesheet.borrow_mut().take() {
             let owner = self.stylesheet_list_owner();
-            owner.remove_stylesheet(StylesheetSource::Element(Dom::from_ref(self.upcast())), &s);
+            owner.remove_stylesheet(StylesheetSource::Element(Dom::from_ref(self.upcast())), &stylesheet);
             self.clean_stylesheet_ownership();
             owner.invalidate_stylesheets();
         }

--- a/components/script/dom/html/htmllinkelement.rs
+++ b/components/script/dom/html/htmllinkelement.rs
@@ -160,8 +160,11 @@ impl HTMLLinkElement {
     #[cfg_attr(crown, expect(crown::unrooted_must_root))]
     fn remove_stylesheet(&self) {
         if let Some(stylesheet) = self.stylesheet.borrow_mut().take() {
-            let owner = self.stylesheet_list_owner();
-            owner.remove_stylesheet(StylesheetSource::Element(Dom::from_ref(self.upcast())), &stylesheet);
+            let owner = self.stylesheet_list_owner()
+            owner.remove_stylesheet(
+                StylesheetSource::Element(Dom::from_ref(self.upcast())),
+                &stylesheet,
+            );
             self.clean_stylesheet_ownership();
             owner.invalidate_stylesheets();
         }

--- a/components/script/dom/html/htmllinkelement.rs
+++ b/components/script/dom/html/htmllinkelement.rs
@@ -157,18 +157,28 @@ impl HTMLLinkElement {
         self.request_generation_id.get()
     }
 
+    #[cfg_attr(crown, expect(crown::unrooted_must_root))]
+    fn remove_stylesheet(&self) {
+        if let Some(s) = self.stylesheet.borrow_mut().take() {
+            let owner = self.stylesheet_list_owner();
+            owner.remove_stylesheet(StylesheetSource::Element(Dom::from_ref(self.upcast())), &s);
+            self.clean_stylesheet_ownership();
+            owner.invalidate_stylesheets();
+        }
+    }
+
     // FIXME(emilio): These methods are duplicated with
     // HTMLStyleElement::set_stylesheet.
     #[cfg_attr(crown, expect(crown::unrooted_must_root))]
-    pub(crate) fn set_stylesheet(&self, s: Arc<Stylesheet>) {
-        let stylesheets_owner = self.stylesheet_list_owner();
-        if let Some(ref s) = *self.stylesheet.borrow() {
-            stylesheets_owner
-                .remove_stylesheet(StylesheetSource::Element(Dom::from_ref(self.upcast())), s)
+    pub(crate) fn set_stylesheet(&self, new_stylesheet: Arc<Stylesheet>) {
+        let owner = self.stylesheet_list_owner();
+        if let Some(old_stylesheet) = self.stylesheet.borrow_mut().replace(new_stylesheet.clone()) {
+            owner.remove_stylesheet(
+                StylesheetSource::Element(Dom::from_ref(self.upcast())),
+                &old_stylesheet,
+            );
         }
-        *self.stylesheet.borrow_mut() = Some(s.clone());
-        self.clean_stylesheet_ownership();
-        stylesheets_owner.add_owned_stylesheet(self.upcast(), s);
+        owner.add_owned_stylesheet(self.upcast(), new_stylesheet);
     }
 
     pub(crate) fn get_stylesheet(&self) -> Option<Arc<Stylesheet>> {
@@ -248,18 +258,37 @@ impl VirtualMethods for HTMLLinkElement {
         }
         match *local_name {
             local_name!("rel") | local_name!("rev") => {
+                let previous_relations = self.relations.get();
                 self.relations
                     .set(LinkRelations::for_element(self.upcast()));
-            },
-            local_name!("href") => {
-                if is_removal {
+
+                // If relations haven't changed, we shouldn't do anything
+                if previous_relations == self.relations.get() {
                     return;
                 }
-                // https://html.spec.whatwg.org/multipage/#link-type-stylesheet
-                // When the href attribute of the link element of an external resource link
-                // that is already browsing-context connected is changed.
+
+                // https://html.spec.whatwg.org/multipage/#link-type-stylesheet:fetch-and-process-the-linked-resource
+                // > When the external resource link is created on a link element that is already browsing-context connected.
                 if self.relations.get().contains(LinkRelations::STYLESHEET) {
-                    self.handle_stylesheet_url(&attr.value());
+                    self.handle_stylesheet_url();
+                } else {
+                    self.remove_stylesheet();
+                }
+            },
+            local_name!("href") => {
+                // https://html.spec.whatwg.org/multipage/#attr-link-href
+                // > If both the href and imagesrcset attributes are absent, then the element does not define a link.
+                if is_removal {
+                    if self.relations.get().contains(LinkRelations::STYLESHEET) {
+                        self.remove_stylesheet();
+                    }
+                    return;
+                }
+                // https://html.spec.whatwg.org/multipage/#link-type-stylesheet:fetch-and-process-the-linked-resource
+                // > When the href attribute of the link element of an external resource link
+                // > that is already browsing-context connected is changed.
+                if self.relations.get().contains(LinkRelations::STYLESHEET) {
+                    self.handle_stylesheet_url();
                 }
 
                 if self.relations.get().contains(LinkRelations::ICON) {
@@ -295,7 +324,7 @@ impl VirtualMethods for HTMLLinkElement {
                 // When the crossorigin attribute of the link element of an external resource link
                 // that is already browsing-context connected is set, changed, or removed.
                 if self.relations.get().contains(LinkRelations::STYLESHEET) {
-                    self.handle_stylesheet_url(&attr.value());
+                    self.handle_stylesheet_url();
                 }
             },
             local_name!("as") => {
@@ -309,7 +338,7 @@ impl VirtualMethods for HTMLLinkElement {
                 }
             },
             local_name!("type") => {
-                // https://html.spec.whatwg.org/multipage/#link-type-stylesheet
+                // https://html.spec.whatwg.org/multipage/#link-type-stylesheet:fetch-and-process-the-linked-resource
                 // When the type attribute of the link element of an external resource link that
                 // is already browsing-context connected is set or changed to a value that does
                 // not or no longer matches the Content-Type metadata of the previous obtained
@@ -317,7 +346,7 @@ impl VirtualMethods for HTMLLinkElement {
                 //
                 // TODO: Match Content-Type metadata to check if it needs to be updated
                 if self.relations.get().contains(LinkRelations::STYLESHEET) {
-                    self.handle_stylesheet_url(&attr.value());
+                    self.handle_stylesheet_url();
                 }
 
                 // https://html.spec.whatwg.org/multipage/#link-type-preload
@@ -379,8 +408,10 @@ impl VirtualMethods for HTMLLinkElement {
 
             if let Some(href) = get_attr(element, &local_name!("href")) {
                 let relations = self.relations.get();
+                // https://html.spec.whatwg.org/multipage/#link-type-stylesheet:fetch-and-process-the-linked-resource
+                // > When the external resource link's link element becomes browsing-context connected.
                 if relations.contains(LinkRelations::STYLESHEET) {
-                    self.handle_stylesheet_url(&href);
+                    self.handle_stylesheet_url();
                 }
 
                 if relations.contains(LinkRelations::ICON) {
@@ -403,11 +434,7 @@ impl VirtualMethods for HTMLLinkElement {
             s.unbind_from_tree(context, can_gc);
         }
 
-        if let Some(s) = self.stylesheet.borrow_mut().take() {
-            self.clean_stylesheet_ownership();
-            self.stylesheet_list_owner()
-                .remove_stylesheet(StylesheetSource::Element(Dom::from_ref(self.upcast())), &s);
-        }
+        self.remove_stylesheet();
     }
 }
 
@@ -581,27 +608,28 @@ impl HTMLLinkElement {
     }
 
     /// <https://html.spec.whatwg.org/multipage/#concept-link-obtain>
-    fn handle_stylesheet_url(&self, href: &str) {
+    fn handle_stylesheet_url(&self) {
         let document = self.owner_document();
         if document.browsing_context().is_none() {
             return;
         }
 
+        let element = self.upcast::<Element>();
+
         // Step 1.
+        let href = element.get_string_attribute(&local_name!("href"));
         if href.is_empty() {
             return;
         }
 
         // Step 2.
-        let link_url = match document.base_url().join(href) {
+        let link_url = match document.base_url().join(&href.str()) {
             Ok(url) => url,
             Err(e) => {
                 debug!("Parsing url {} failed: {}", href, e);
                 return;
             },
         };
-
-        let element = self.upcast::<Element>();
 
         // Step 3
         let cors_setting = cors_setting_for_element(element);

--- a/components/script/dom/html/htmllinkelement.rs
+++ b/components/script/dom/html/htmllinkelement.rs
@@ -160,7 +160,7 @@ impl HTMLLinkElement {
     #[cfg_attr(crown, expect(crown::unrooted_must_root))]
     fn remove_stylesheet(&self) {
         if let Some(stylesheet) = self.stylesheet.borrow_mut().take() {
-            let owner = self.stylesheet_list_owner()
+            let owner = self.stylesheet_list_owner();
             owner.remove_stylesheet(
                 StylesheetSource::Element(Dom::from_ref(self.upcast())),
                 &stylesheet,

--- a/components/script/links.rs
+++ b/components/script/links.rs
@@ -28,7 +28,7 @@ bitflags::bitflags! {
     /// attribute.
     ///
     /// Refer to <https://html.spec.whatwg.org/multipage/#linkTypes> for more information.
-    #[derive(Clone, Copy, Debug)]
+    #[derive(Clone, Copy, Debug, PartialEq)]
     pub(crate) struct LinkRelations: u32 {
         /// <https://html.spec.whatwg.org/multipage/#rel-alternate>
         const ALTERNATE = 1;

--- a/tests/wpt/meta/css/cssom/HTMLLinkElement-disabled-005.html.ini
+++ b/tests/wpt/meta/css/cssom/HTMLLinkElement-disabled-005.html.ini
@@ -1,5 +1,0 @@
-[HTMLLinkElement-disabled-005.html]
-  expected: TIMEOUT
-  [HTMLLinkElement.disabled's explicitly enabled state persists regardless of rel]
-    expected: TIMEOUT
-

--- a/tests/wpt/meta/html/semantics/document-metadata/the-link-element/link-multiple-load-events.html.ini
+++ b/tests/wpt/meta/html/semantics/document-metadata/the-link-element/link-multiple-load-events.html.ini
@@ -4,6 +4,3 @@
 
   [<link> cannot request the same resource twice by touching the 'type' attribute, if its value never changes]
     expected: FAIL
-
-  [<link> load event can fire twice for the same href resource, based on 'rel' attribute mutations]
-    expected: FAIL

--- a/tests/wpt/meta/preload/preload-in-data-doc.html.ini
+++ b/tests/wpt/meta/preload/preload-in-data-doc.html.ini
@@ -1,2 +1,0 @@
-[preload-in-data-doc.html]
-  expected: FAIL

--- a/tests/wpt/tests/html/semantics/document-metadata/the-link-element/link-type-attribute-crash.html
+++ b/tests/wpt/tests/html/semantics/document-metadata/the-link-element/link-type-attribute-crash.html
@@ -1,0 +1,7 @@
+<!DOCTYPE html>
+<link rel=help href="https://github.com/servo/servo/issues/42259">
+<link id="link" rel="stylesheet" href="data:text/css,div { background-color: green !important; }">
+<script>
+  link.type = "text/css";
+  link.type = "text/css";
+</script>

--- a/tests/wpt/tests/html/semantics/document-metadata/the-link-element/stylesheet-remove-href-ref.html
+++ b/tests/wpt/tests/html/semantics/document-metadata/the-link-element/stylesheet-remove-href-ref.html
@@ -1,0 +1,8 @@
+<!doctype html>
+<meta charset="utf-8">
+<style>
+  p {
+    color: green;
+  }
+</style>
+<p>This text should be green on a white background

--- a/tests/wpt/tests/html/semantics/document-metadata/the-link-element/stylesheet-remove-href.html
+++ b/tests/wpt/tests/html/semantics/document-metadata/the-link-element/stylesheet-remove-href.html
@@ -1,0 +1,18 @@
+<!doctype html>
+<meta charset="utf-8">
+<title>Removing href should remove previously applied styles</title>
+<link rel=match href=stylesheet-change-href-ref.html>
+<style>
+p {
+  color: green;
+}
+</style>
+<script>
+  function removeHref() {
+    var elem = document.getElementById('stylesheet');
+    elem.removeAttribute('href');
+    elem.onload = null;
+  }
+</script>
+<link id=stylesheet rel=stylesheet href="resources/bad.css" onload="removeHref()">
+<p>This text should be green on a white background


### PR DESCRIPTION
We weren't removing stylesheets when we should be doing so. This most notably happens when the stylesheet no longer has a href or its "rel" changes.

The crash is also fixed, since the issue was that we were passing the value of the attribute that was changed as if it were an href. However, if we set the type attribute, then that's not the href.

To fix that, we now retrieve the href inside the method so we always have the correct value.

Fixes #42259
