### PR TITLE
script: Add navigator.pdfViewerEnabled

### DIFF
--- a/components/script/dom/navigator.rs
+++ b/components/script/dom/navigator.rs
@@ -386,6 +386,11 @@ impl NavigatorMethods<crate::DomTypeHolder> for Navigator {
         false
     }
 
+    /// <https://html.spec.whatwg.org/multipage/#dom-navigator-pdfviewerenabled>
+    fn PdfViewerEnabled(&self) -> bool {
+        false
+    }
+
     /// <https://w3c.github.io/ServiceWorker/#navigator-service-worker-attribute>
     fn ServiceWorker(&self) -> DomRoot<ServiceWorkerContainer> {
         self.service_worker

--- a/components/script_bindings/webidls/Navigator.webidl
+++ b/components/script_bindings/webidls/Navigator.webidl
@@ -54,6 +54,7 @@ interface mixin NavigatorPlugins {
   [SameObject] readonly attribute PluginArray plugins;
   [SameObject] readonly attribute MimeTypeArray mimeTypes;
   boolean javaEnabled();
+  readonly attribute boolean pdfViewerEnabled;
 };
 
 // https://html.spec.whatwg.org/multipage/#navigatorcookies

--- a/tests/wpt/meta/html/dom/idlharness.https.html.ini
+++ b/tests/wpt/meta/html/dom/idlharness.https.html.ini
@@ -4841,16 +4841,10 @@
   [Navigator interface: attribute oscpu]
     expected: FAIL
 
-  [Navigator interface: attribute pdfViewerEnabled]
-    expected: FAIL
-
   [Navigator interface: window.navigator must inherit property "userActivation" with the proper type]
     expected: FAIL
 
   [Navigator interface: window.navigator must inherit property "oscpu" with the proper type]
-    expected: FAIL
-
-  [Navigator interface: window.navigator must inherit property "pdfViewerEnabled" with the proper type]
     expected: FAIL
 
   [SharedWorker interface: existence and properties of interface object]

--- a/tests/wpt/meta/html/webappapis/system-state-and-capabilities/the-navigator-object/plugins-and-mimetypes.html.ini
+++ b/tests/wpt/meta/html/webappapis/system-state-and-capabilities/the-navigator-object/plugins-and-mimetypes.html.ini
@@ -1,3 +1,0 @@
-[plugins-and-mimetypes.html]
-  [navigator.pdfViewerEnabled exists]
-    expected: FAIL


### PR DESCRIPTION
Servo doesn't have a pdf viewer, so we simply set the property to `false`.

Testing: New tests start to pass
