### PR TITLE
script: Support different colorspaces for `<input type=color>`

### DIFF
--- a/components/script/dom/html/htmlinputelement.rs
+++ b/components/script/dom/html/htmlinputelement.rs
@@ -1653,7 +1653,7 @@ impl HTMLInputElementMethods<crate::DomTypeHolder> for HTMLInputElement {
         self.value_changed(can_gc);
     }
 
-    // https://html.spec.whatwg.org/multipage/input.html#attr-input-colorspace
+    // https://html.spec.whatwg.org/multipage/#attr-input-colorspace
     make_enumerated_getter!(
         ColorSpace,
         "colorspace",
@@ -1662,7 +1662,7 @@ impl HTMLInputElementMethods<crate::DomTypeHolder> for HTMLInputElement {
         invalid => "limited-srgb"
     );
 
-    // https://html.spec.whatwg.org/multipage/input.html#attr-input-colorspace
+    // https://html.spec.whatwg.org/multipage/#attr-input-colorspace
     make_setter!(SetColorSpace, "colorspace");
 
     // https://html.spec.whatwg.org/multipage/#dom-input-readonly
@@ -3255,7 +3255,7 @@ impl VirtualMethods for HTMLInputElement {
                 self.form_attribute_mutated(mutation, can_gc);
             },
             local_name!("alpha") | local_name!("colorspace") => {
-                // https://html.spec.whatwg.org/multipage/input.html#attr-input-colorspace
+                // https://html.spec.whatwg.org/multipage/#attr-input-colorspace
                 // > Whenever the element's alpha or colorspace attributes are changed,
                 // the user agent must run update a color well control color given the element.
                 let mut textinput = self.textinput.borrow_mut();

--- a/components/script/dom/html/htmlinputelement.rs
+++ b/components/script/dom/html/htmlinputelement.rs
@@ -307,12 +307,7 @@ impl ColorInputShadowTree {
     }
 
     fn update(&self, input_element: &HTMLInputElement, can_gc: CanGc) {
-        let mut value = input_element.Value();
-        if value.str().is_valid_simple_color_string() {
-            value.make_ascii_lowercase();
-        } else {
-            value = DOMString::from("#000000");
-        }
+        let value = input_element.Value();
         let style = format!("background-color: {value}");
         self.color_value
             .set_string_attribute(&local_name!("style"), style.into(), can_gc);
@@ -2585,25 +2580,10 @@ impl HTMLInputElement {
 
         // Step 3. Let color be the result of parsing value.
         // Step 4. If color is failure, then set color to opaque black.
-        // TODO: Use a dummy url here, like gecko
-        // https://searchfox.org/firefox-main/rev/3eaf7e2acf8186eb7aa579561eaa1312cb89132b/servo/ports/geckolib/glue.rs#8931
-        let urlextradata = self.owner_document().url().as_url().to_owned().into();
-        let context = ParserContext::new(
-            Origin::Author,
-            &urlextradata,
-            Some(CssRuleType::Style),
-            ParsingMode::DEFAULT,
-            QuirksMode::NoQuirks,
-            Default::default(),
-            None,
-            None,
+        let color = parse_color_value(
+            &value.str(),
+            self.owner_document().url().as_url().to_owned(),
         );
-        let input = value.str();
-        let mut input = ParserInput::new(&input);
-        let mut input = Parser::new(&mut input);
-        let color = Color::parse_and_compute(&context, &mut input, None)
-            .map(|computed_color| computed_color.resolve_to_absolute(&AbsoluteColor::BLACK))
-            .unwrap_or(AbsoluteColor::BLACK);
 
         // Step 5. Set element's value to the result of serializing a color well control color
         // given element and color.
@@ -2910,10 +2890,15 @@ impl HTMLInputElement {
         if self.input_type() == InputType::Color {
             let document = self.owner_document();
             let current_value = self.Value();
+            let current_color = parse_color_value(
+                &current_value.str(),
+                self.owner_document().url().as_url().to_owned(),
+            )
+            .to_color_space(ColorSpace::Srgb);
             let current_color = RgbColor {
-                red: u8::from_str_radix(&current_value.str()[1..3], 16).unwrap(),
-                green: u8::from_str_radix(&current_value.str()[3..5], 16).unwrap(),
-                blue: u8::from_str_radix(&current_value.str()[5..7], 16).unwrap(),
+                red: (current_color.components.0 * 255.0).round() as u8,
+                green: (current_color.components.1 * 255.0).round() as u8,
+                blue: (current_color.components.2 * 255.0).round() as u8,
             };
             document.embedder_controls().show_embedder_control(
                 ControlElement::ColorInput(DomRoot::from_ref(self)),
@@ -2927,6 +2912,7 @@ impl HTMLInputElement {
         let Some(selected_color) = response else {
             return;
         };
+
         let formatted_color = format!(
             "#{:0>2x}{:0>2x}{:0>2x}",
             selected_color.red, selected_color.green, selected_color.blue
@@ -3911,4 +3897,25 @@ impl PendingWebDriverResponse {
             let _ = self.response_sender.send(Err(ErrorStatus::InvalidArgument));
         }
     }
+}
+
+fn parse_color_value(value: &str, url: Url) -> AbsoluteColor {
+    // TODO: Use a dummy url here, like gecko
+    // https://searchfox.org/firefox-main/rev/3eaf7e2acf8186eb7aa579561eaa1312cb89132b/servo/ports/geckolib/glue.rs#8931
+    let urlextradata = url.into();
+    let context = ParserContext::new(
+        Origin::Author,
+        &urlextradata,
+        Some(CssRuleType::Style),
+        ParsingMode::DEFAULT,
+        QuirksMode::NoQuirks,
+        Default::default(),
+        None,
+        None,
+    );
+    let mut input = ParserInput::new(value);
+    let mut input = Parser::new(&mut input);
+    Color::parse_and_compute(&context, &mut input, None)
+        .map(|computed_color| computed_color.resolve_to_absolute(&AbsoluteColor::BLACK))
+        .unwrap_or(AbsoluteColor::BLACK)
 }

--- a/components/script_bindings/webidls/HTMLInputElement.webidl
+++ b/components/script_bindings/webidls/HTMLInputElement.webidl
@@ -18,6 +18,7 @@ interface HTMLInputElement : HTMLElement {
   [CEReactions]
            attribute boolean defaultChecked;
            attribute boolean checked;
+  [CEReactions] attribute DOMString colorSpace;
   [CEReactions]
            attribute DOMString dirName;
   [CEReactions]

--- a/tests/wpt/meta/html/dom/idlharness.https.html.ini
+++ b/tests/wpt/meta/html/dom/idlharness.https.html.ini
@@ -5893,9 +5893,6 @@
   [HTMLInputElement interface: attribute autocomplete]
     expected: FAIL
 
-  [HTMLInputElement interface: attribute colorSpace]
-    expected: FAIL
-
   [HTMLInputElement interface: attribute height]
     expected: FAIL
 
@@ -5921,9 +5918,6 @@
     expected: FAIL
 
   [HTMLInputElement interface: document.createElement("input") must inherit property "autocomplete" with the proper type]
-    expected: FAIL
-
-  [HTMLInputElement interface: document.createElement("input") must inherit property "colorSpace" with the proper type]
     expected: FAIL
 
   [HTMLInputElement interface: document.createElement("input") must inherit property "height" with the proper type]
@@ -5953,9 +5947,6 @@
   [HTMLInputElement interface: createInput("text") must inherit property "autocomplete" with the proper type]
     expected: FAIL
 
-  [HTMLInputElement interface: createInput("text") must inherit property "colorSpace" with the proper type]
-    expected: FAIL
-
   [HTMLInputElement interface: createInput("text") must inherit property "height" with the proper type]
     expected: FAIL
 
@@ -5981,9 +5972,6 @@
     expected: FAIL
 
   [HTMLInputElement interface: createInput("hidden") must inherit property "autocomplete" with the proper type]
-    expected: FAIL
-
-  [HTMLInputElement interface: createInput("hidden") must inherit property "colorSpace" with the proper type]
     expected: FAIL
 
   [HTMLInputElement interface: createInput("hidden") must inherit property "height" with the proper type]
@@ -6013,9 +6001,6 @@
   [HTMLInputElement interface: createInput("search") must inherit property "autocomplete" with the proper type]
     expected: FAIL
 
-  [HTMLInputElement interface: createInput("search") must inherit property "colorSpace" with the proper type]
-    expected: FAIL
-
   [HTMLInputElement interface: createInput("search") must inherit property "height" with the proper type]
     expected: FAIL
 
@@ -6041,9 +6026,6 @@
     expected: FAIL
 
   [HTMLInputElement interface: createInput("tel") must inherit property "autocomplete" with the proper type]
-    expected: FAIL
-
-  [HTMLInputElement interface: createInput("tel") must inherit property "colorSpace" with the proper type]
     expected: FAIL
 
   [HTMLInputElement interface: createInput("tel") must inherit property "height" with the proper type]
@@ -6073,9 +6055,6 @@
   [HTMLInputElement interface: createInput("url") must inherit property "autocomplete" with the proper type]
     expected: FAIL
 
-  [HTMLInputElement interface: createInput("url") must inherit property "colorSpace" with the proper type]
-    expected: FAIL
-
   [HTMLInputElement interface: createInput("url") must inherit property "height" with the proper type]
     expected: FAIL
 
@@ -6101,9 +6080,6 @@
     expected: FAIL
 
   [HTMLInputElement interface: createInput("email") must inherit property "autocomplete" with the proper type]
-    expected: FAIL
-
-  [HTMLInputElement interface: createInput("email") must inherit property "colorSpace" with the proper type]
     expected: FAIL
 
   [HTMLInputElement interface: createInput("email") must inherit property "height" with the proper type]
@@ -6133,9 +6109,6 @@
   [HTMLInputElement interface: createInput("password") must inherit property "autocomplete" with the proper type]
     expected: FAIL
 
-  [HTMLInputElement interface: createInput("password") must inherit property "colorSpace" with the proper type]
-    expected: FAIL
-
   [HTMLInputElement interface: createInput("password") must inherit property "height" with the proper type]
     expected: FAIL
 
@@ -6161,9 +6134,6 @@
     expected: FAIL
 
   [HTMLInputElement interface: createInput("date") must inherit property "autocomplete" with the proper type]
-    expected: FAIL
-
-  [HTMLInputElement interface: createInput("date") must inherit property "colorSpace" with the proper type]
     expected: FAIL
 
   [HTMLInputElement interface: createInput("date") must inherit property "height" with the proper type]
@@ -6193,9 +6163,6 @@
   [HTMLInputElement interface: createInput("month") must inherit property "autocomplete" with the proper type]
     expected: FAIL
 
-  [HTMLInputElement interface: createInput("month") must inherit property "colorSpace" with the proper type]
-    expected: FAIL
-
   [HTMLInputElement interface: createInput("month") must inherit property "height" with the proper type]
     expected: FAIL
 
@@ -6221,9 +6188,6 @@
     expected: FAIL
 
   [HTMLInputElement interface: createInput("week") must inherit property "autocomplete" with the proper type]
-    expected: FAIL
-
-  [HTMLInputElement interface: createInput("week") must inherit property "colorSpace" with the proper type]
     expected: FAIL
 
   [HTMLInputElement interface: createInput("week") must inherit property "height" with the proper type]
@@ -6253,9 +6217,6 @@
   [HTMLInputElement interface: createInput("time") must inherit property "autocomplete" with the proper type]
     expected: FAIL
 
-  [HTMLInputElement interface: createInput("time") must inherit property "colorSpace" with the proper type]
-    expected: FAIL
-
   [HTMLInputElement interface: createInput("time") must inherit property "height" with the proper type]
     expected: FAIL
 
@@ -6281,9 +6242,6 @@
     expected: FAIL
 
   [HTMLInputElement interface: createInput("datetime-local") must inherit property "autocomplete" with the proper type]
-    expected: FAIL
-
-  [HTMLInputElement interface: createInput("datetime-local") must inherit property "colorSpace" with the proper type]
     expected: FAIL
 
   [HTMLInputElement interface: createInput("datetime-local") must inherit property "height" with the proper type]
@@ -6313,9 +6271,6 @@
   [HTMLInputElement interface: createInput("number") must inherit property "autocomplete" with the proper type]
     expected: FAIL
 
-  [HTMLInputElement interface: createInput("number") must inherit property "colorSpace" with the proper type]
-    expected: FAIL
-
   [HTMLInputElement interface: createInput("number") must inherit property "height" with the proper type]
     expected: FAIL
 
@@ -6341,9 +6296,6 @@
     expected: FAIL
 
   [HTMLInputElement interface: createInput("range") must inherit property "autocomplete" with the proper type]
-    expected: FAIL
-
-  [HTMLInputElement interface: createInput("range") must inherit property "colorSpace" with the proper type]
     expected: FAIL
 
   [HTMLInputElement interface: createInput("range") must inherit property "height" with the proper type]
@@ -6373,9 +6325,6 @@
   [HTMLInputElement interface: createInput("color") must inherit property "autocomplete" with the proper type]
     expected: FAIL
 
-  [HTMLInputElement interface: createInput("color") must inherit property "colorSpace" with the proper type]
-    expected: FAIL
-
   [HTMLInputElement interface: createInput("color") must inherit property "height" with the proper type]
     expected: FAIL
 
@@ -6401,9 +6350,6 @@
     expected: FAIL
 
   [HTMLInputElement interface: createInput("checkbox") must inherit property "autocomplete" with the proper type]
-    expected: FAIL
-
-  [HTMLInputElement interface: createInput("checkbox") must inherit property "colorSpace" with the proper type]
     expected: FAIL
 
   [HTMLInputElement interface: createInput("checkbox") must inherit property "height" with the proper type]
@@ -6433,9 +6379,6 @@
   [HTMLInputElement interface: createInput("radio") must inherit property "autocomplete" with the proper type]
     expected: FAIL
 
-  [HTMLInputElement interface: createInput("radio") must inherit property "colorSpace" with the proper type]
-    expected: FAIL
-
   [HTMLInputElement interface: createInput("radio") must inherit property "height" with the proper type]
     expected: FAIL
 
@@ -6461,9 +6404,6 @@
     expected: FAIL
 
   [HTMLInputElement interface: createInput("file") must inherit property "autocomplete" with the proper type]
-    expected: FAIL
-
-  [HTMLInputElement interface: createInput("file") must inherit property "colorSpace" with the proper type]
     expected: FAIL
 
   [HTMLInputElement interface: createInput("file") must inherit property "height" with the proper type]
@@ -6493,9 +6433,6 @@
   [HTMLInputElement interface: createInput("submit") must inherit property "autocomplete" with the proper type]
     expected: FAIL
 
-  [HTMLInputElement interface: createInput("submit") must inherit property "colorSpace" with the proper type]
-    expected: FAIL
-
   [HTMLInputElement interface: createInput("submit") must inherit property "height" with the proper type]
     expected: FAIL
 
@@ -6521,9 +6458,6 @@
     expected: FAIL
 
   [HTMLInputElement interface: createInput("image") must inherit property "autocomplete" with the proper type]
-    expected: FAIL
-
-  [HTMLInputElement interface: createInput("image") must inherit property "colorSpace" with the proper type]
     expected: FAIL
 
   [HTMLInputElement interface: createInput("image") must inherit property "height" with the proper type]
@@ -6553,9 +6487,6 @@
   [HTMLInputElement interface: createInput("reset") must inherit property "autocomplete" with the proper type]
     expected: FAIL
 
-  [HTMLInputElement interface: createInput("reset") must inherit property "colorSpace" with the proper type]
-    expected: FAIL
-
   [HTMLInputElement interface: createInput("reset") must inherit property "height" with the proper type]
     expected: FAIL
 
@@ -6581,9 +6512,6 @@
     expected: FAIL
 
   [HTMLInputElement interface: createInput("button") must inherit property "autocomplete" with the proper type]
-    expected: FAIL
-
-  [HTMLInputElement interface: createInput("button") must inherit property "colorSpace" with the proper type]
     expected: FAIL
 
   [HTMLInputElement interface: createInput("button") must inherit property "height" with the proper type]

--- a/tests/wpt/meta/html/semantics/forms/the-input-element/color-attributes.window.js.ini
+++ b/tests/wpt/meta/html/semantics/forms/the-input-element/color-attributes.window.js.ini
@@ -1,6 +1,3 @@
 [color-attributes.window.html]
   [<input type=color>: alpha attribute]
     expected: FAIL
-
-  [<input type=color>: colorspace attribute]
-    expected: FAIL

--- a/tests/wpt/meta/html/semantics/forms/the-input-element/color.window.js.ini
+++ b/tests/wpt/meta/html/semantics/forms/the-input-element/color.window.js.ini
@@ -8,13 +8,7 @@
   [Testing the empty string with color space 'limited-srgb' and with alpha (value)]
     expected: FAIL
 
-  [Testing the empty string with color space 'display-p3' and  without alpha (setAttribute("value"))]
-    expected: FAIL
-
   [Testing the empty string with color space 'display-p3' and  without alpha (value)]
-    expected: FAIL
-
-  [Testing the empty string with color space 'display-p3' and with alpha (setAttribute("value"))]
     expected: FAIL
 
   [Testing the empty string with color space 'display-p3' and with alpha (value)]
@@ -29,13 +23,7 @@
   [Testing no value with color space 'limited-srgb' and with alpha (value)]
     expected: FAIL
 
-  [Testing no value with color space 'display-p3' and  without alpha (setAttribute("value"))]
-    expected: FAIL
-
   [Testing no value with color space 'display-p3' and  without alpha (value)]
-    expected: FAIL
-
-  [Testing no value with color space 'display-p3' and with alpha (setAttribute("value"))]
     expected: FAIL
 
   [Testing no value with color space 'display-p3' and with alpha (value)]
@@ -50,13 +38,7 @@
   [Testing '#ffffff' with color space 'limited-srgb' and with alpha (value)]
     expected: FAIL
 
-  [Testing '#ffffff' with color space 'display-p3' and  without alpha (setAttribute("value"))]
-    expected: FAIL
-
   [Testing '#ffffff' with color space 'display-p3' and  without alpha (value)]
-    expected: FAIL
-
-  [Testing '#ffffff' with color space 'display-p3' and with alpha (setAttribute("value"))]
     expected: FAIL
 
   [Testing '#ffffff' with color space 'display-p3' and with alpha (value)]
@@ -69,9 +51,6 @@
     expected: FAIL
 
   [Testing '#ffffff08' with color space 'limited-srgb' and with alpha (value)]
-    expected: FAIL
-
-  [Testing '#ffffff08' with color space 'display-p3' and  without alpha (setAttribute("value"))]
     expected: FAIL
 
   [Testing '#ffffff08' with color space 'display-p3' and  without alpha (value)]
@@ -92,13 +71,7 @@
   [Testing '#FFFFFF' with color space 'limited-srgb' and with alpha (value)]
     expected: FAIL
 
-  [Testing '#FFFFFF' with color space 'display-p3' and  without alpha (setAttribute("value"))]
-    expected: FAIL
-
   [Testing '#FFFFFF' with color space 'display-p3' and  without alpha (value)]
-    expected: FAIL
-
-  [Testing '#FFFFFF' with color space 'display-p3' and with alpha (setAttribute("value"))]
     expected: FAIL
 
   [Testing '#FFFFFF' with color space 'display-p3' and with alpha (value)]
@@ -113,13 +86,7 @@
   [Testing '#0F0F0F' with color space 'limited-srgb' and with alpha (value)]
     expected: FAIL
 
-  [Testing '#0F0F0F' with color space 'display-p3' and  without alpha (setAttribute("value"))]
-    expected: FAIL
-
   [Testing '#0F0F0F' with color space 'display-p3' and  without alpha (value)]
-    expected: FAIL
-
-  [Testing '#0F0F0F' with color space 'display-p3' and with alpha (setAttribute("value"))]
     expected: FAIL
 
   [Testing '#0F0F0F' with color space 'display-p3' and with alpha (value)]
@@ -134,13 +101,7 @@
   [Testing '#fff' with color space 'limited-srgb' and with alpha (value)]
     expected: FAIL
 
-  [Testing '#fff' with color space 'display-p3' and  without alpha (setAttribute("value"))]
-    expected: FAIL
-
   [Testing '#fff' with color space 'display-p3' and  without alpha (value)]
-    expected: FAIL
-
-  [Testing '#fff' with color space 'display-p3' and with alpha (setAttribute("value"))]
     expected: FAIL
 
   [Testing '#fff' with color space 'display-p3' and with alpha (value)]
@@ -155,13 +116,7 @@
   [Testing 'fffffff' with color space 'limited-srgb' and with alpha (value)]
     expected: FAIL
 
-  [Testing 'fffffff' with color space 'display-p3' and  without alpha (setAttribute("value"))]
-    expected: FAIL
-
   [Testing 'fffffff' with color space 'display-p3' and  without alpha (value)]
-    expected: FAIL
-
-  [Testing 'fffffff' with color space 'display-p3' and with alpha (setAttribute("value"))]
     expected: FAIL
 
   [Testing 'fffffff' with color space 'display-p3' and with alpha (value)]
@@ -176,13 +131,7 @@
   [Testing '#gggggg' with color space 'limited-srgb' and with alpha (value)]
     expected: FAIL
 
-  [Testing '#gggggg' with color space 'display-p3' and  without alpha (setAttribute("value"))]
-    expected: FAIL
-
   [Testing '#gggggg' with color space 'display-p3' and  without alpha (value)]
-    expected: FAIL
-
-  [Testing '#gggggg' with color space 'display-p3' and with alpha (setAttribute("value"))]
     expected: FAIL
 
   [Testing '#gggggg' with color space 'display-p3' and with alpha (value)]
@@ -197,13 +146,7 @@
   [Testing 'foobar' with color space 'limited-srgb' and with alpha (value)]
     expected: FAIL
 
-  [Testing 'foobar' with color space 'display-p3' and  without alpha (setAttribute("value"))]
-    expected: FAIL
-
   [Testing 'foobar' with color space 'display-p3' and  without alpha (value)]
-    expected: FAIL
-
-  [Testing 'foobar' with color space 'display-p3' and with alpha (setAttribute("value"))]
     expected: FAIL
 
   [Testing 'foobar' with color space 'display-p3' and with alpha (value)]
@@ -218,13 +161,7 @@
   [Testing '#ffffff\x00' with color space 'limited-srgb' and with alpha (value)]
     expected: FAIL
 
-  [Testing '#ffffff\x00' with color space 'display-p3' and  without alpha (setAttribute("value"))]
-    expected: FAIL
-
   [Testing '#ffffff\x00' with color space 'display-p3' and  without alpha (value)]
-    expected: FAIL
-
-  [Testing '#ffffff\x00' with color space 'display-p3' and with alpha (setAttribute("value"))]
     expected: FAIL
 
   [Testing '#ffffff\x00' with color space 'display-p3' and with alpha (value)]
@@ -239,13 +176,7 @@
   [Testing '#ffffff;' with color space 'limited-srgb' and with alpha (value)]
     expected: FAIL
 
-  [Testing '#ffffff;' with color space 'display-p3' and  without alpha (setAttribute("value"))]
-    expected: FAIL
-
   [Testing '#ffffff;' with color space 'display-p3' and  without alpha (value)]
-    expected: FAIL
-
-  [Testing '#ffffff;' with color space 'display-p3' and with alpha (setAttribute("value"))]
     expected: FAIL
 
   [Testing '#ffffff;' with color space 'display-p3' and with alpha (value)]
@@ -260,13 +191,7 @@
   [Testing ' #ffffff' with color space 'limited-srgb' and with alpha (value)]
     expected: FAIL
 
-  [Testing ' #ffffff' with color space 'display-p3' and  without alpha (setAttribute("value"))]
-    expected: FAIL
-
   [Testing ' #ffffff' with color space 'display-p3' and  without alpha (value)]
-    expected: FAIL
-
-  [Testing ' #ffffff' with color space 'display-p3' and with alpha (setAttribute("value"))]
     expected: FAIL
 
   [Testing ' #ffffff' with color space 'display-p3' and with alpha (value)]
@@ -281,13 +206,7 @@
   [Testing '#ffffff ' with color space 'limited-srgb' and with alpha (value)]
     expected: FAIL
 
-  [Testing '#ffffff ' with color space 'display-p3' and  without alpha (setAttribute("value"))]
-    expected: FAIL
-
   [Testing '#ffffff ' with color space 'display-p3' and  without alpha (value)]
-    expected: FAIL
-
-  [Testing '#ffffff ' with color space 'display-p3' and with alpha (setAttribute("value"))]
     expected: FAIL
 
   [Testing '#ffffff ' with color space 'display-p3' and with alpha (value)]
@@ -302,13 +221,7 @@
   [Testing ' #ffffff ' with color space 'limited-srgb' and with alpha (value)]
     expected: FAIL
 
-  [Testing ' #ffffff ' with color space 'display-p3' and  without alpha (setAttribute("value"))]
-    expected: FAIL
-
   [Testing ' #ffffff ' with color space 'display-p3' and  without alpha (value)]
-    expected: FAIL
-
-  [Testing ' #ffffff ' with color space 'display-p3' and with alpha (setAttribute("value"))]
     expected: FAIL
 
   [Testing ' #ffffff ' with color space 'display-p3' and with alpha (value)]
@@ -323,13 +236,7 @@
   [Testing 'crimson' with color space 'limited-srgb' and with alpha (value)]
     expected: FAIL
 
-  [Testing 'crimson' with color space 'display-p3' and  without alpha (setAttribute("value"))]
-    expected: FAIL
-
   [Testing 'crimson' with color space 'display-p3' and  without alpha (value)]
-    expected: FAIL
-
-  [Testing 'crimson' with color space 'display-p3' and with alpha (setAttribute("value"))]
     expected: FAIL
 
   [Testing 'crimson' with color space 'display-p3' and with alpha (value)]
@@ -344,13 +251,7 @@
   [Testing 'bisque' with color space 'limited-srgb' and with alpha (value)]
     expected: FAIL
 
-  [Testing 'bisque' with color space 'display-p3' and  without alpha (setAttribute("value"))]
-    expected: FAIL
-
   [Testing 'bisque' with color space 'display-p3' and  without alpha (value)]
-    expected: FAIL
-
-  [Testing 'bisque' with color space 'display-p3' and with alpha (setAttribute("value"))]
     expected: FAIL
 
   [Testing 'bisque' with color space 'display-p3' and with alpha (value)]
@@ -365,13 +266,7 @@
   [Testing 'currentColor' with color space 'limited-srgb' and with alpha (value)]
     expected: FAIL
 
-  [Testing 'currentColor' with color space 'display-p3' and  without alpha (setAttribute("value"))]
-    expected: FAIL
-
   [Testing 'currentColor' with color space 'display-p3' and  without alpha (value)]
-    expected: FAIL
-
-  [Testing 'currentColor' with color space 'display-p3' and with alpha (setAttribute("value"))]
     expected: FAIL
 
   [Testing 'currentColor' with color space 'display-p3' and with alpha (value)]
@@ -384,9 +279,6 @@
     expected: FAIL
 
   [Testing 'transparent' with color space 'limited-srgb' and with alpha (value)]
-    expected: FAIL
-
-  [Testing 'transparent' with color space 'display-p3' and  without alpha (setAttribute("value"))]
     expected: FAIL
 
   [Testing 'transparent' with color space 'display-p3' and  without alpha (value)]
@@ -407,13 +299,7 @@
   [Testing 'inherit' with color space 'limited-srgb' and with alpha (value)]
     expected: FAIL
 
-  [Testing 'inherit' with color space 'display-p3' and  without alpha (setAttribute("value"))]
-    expected: FAIL
-
   [Testing 'inherit' with color space 'display-p3' and  without alpha (value)]
-    expected: FAIL
-
-  [Testing 'inherit' with color space 'display-p3' and with alpha (setAttribute("value"))]
     expected: FAIL
 
   [Testing 'inherit' with color space 'display-p3' and with alpha (value)]
@@ -428,13 +314,7 @@
   [Testing 'rgb(1,1,1)' with color space 'limited-srgb' and with alpha (value)]
     expected: FAIL
 
-  [Testing 'rgb(1,1,1)' with color space 'display-p3' and  without alpha (setAttribute("value"))]
-    expected: FAIL
-
   [Testing 'rgb(1,1,1)' with color space 'display-p3' and  without alpha (value)]
-    expected: FAIL
-
-  [Testing 'rgb(1,1,1)' with color space 'display-p3' and with alpha (setAttribute("value"))]
     expected: FAIL
 
   [Testing 'rgb(1,1,1)' with color space 'display-p3' and with alpha (value)]
@@ -449,13 +329,7 @@
   [Testing 'rgb(1,1,1,1)' with color space 'limited-srgb' and with alpha (value)]
     expected: FAIL
 
-  [Testing 'rgb(1,1,1,1)' with color space 'display-p3' and  without alpha (setAttribute("value"))]
-    expected: FAIL
-
   [Testing 'rgb(1,1,1,1)' with color space 'display-p3' and  without alpha (value)]
-    expected: FAIL
-
-  [Testing 'rgb(1,1,1,1)' with color space 'display-p3' and with alpha (setAttribute("value"))]
     expected: FAIL
 
   [Testing 'rgb(1,1,1,1)' with color space 'display-p3' and with alpha (value)]
@@ -468,9 +342,6 @@
     expected: FAIL
 
   [Testing 'rgb(1,1,1,0.5)' with color space 'limited-srgb' and with alpha (value)]
-    expected: FAIL
-
-  [Testing 'rgb(1,1,1,0.5)' with color space 'display-p3' and  without alpha (setAttribute("value"))]
     expected: FAIL
 
   [Testing 'rgb(1,1,1,0.5)' with color space 'display-p3' and  without alpha (value)]
@@ -491,13 +362,7 @@
   [Testing '#FFFFFὊ9' with color space 'limited-srgb' and with alpha (value)]
     expected: FAIL
 
-  [Testing '#FFFFFὊ9' with color space 'display-p3' and  without alpha (setAttribute("value"))]
-    expected: FAIL
-
   [Testing '#FFFFFὊ9' with color space 'display-p3' and  without alpha (value)]
-    expected: FAIL
-
-  [Testing '#FFFFFὊ9' with color space 'display-p3' and with alpha (setAttribute("value"))]
     expected: FAIL
 
   [Testing '#FFFFFὊ9' with color space 'display-p3' and with alpha (value)]
@@ -507,10 +372,4 @@
     expected: FAIL
 
   [Display P3 colors can be out-of-bounds]
-    expected: FAIL
-
-  [Setting colorspace by setAttribute should update the value]
-    expected: FAIL
-
-  [Setting alpha by setAttribute should update the value]
     expected: FAIL


### PR DESCRIPTION
This change adds support for the `colorspace` attribute on color inputs and implements serialization of the input value accordingly.

The color picker from servoshell doesn't yet support non-rgb colorspaces (and neither does the embedding API), so we convert to and from rgb when communicating with the embedder.

Testing: New tests start to pass

