### PR TITLE
libservo: Expand the `UserContentManager` API.

### DIFF
--- a/components/layout/layout_impl.rs
+++ b/components/layout/layout_impl.rs
@@ -51,7 +51,6 @@ use style::context::{
 };
 use style::custom_properties::{SpecifiedValue, parse_name};
 use style::dom::{OpaqueNode, ShowSubtreeDataAndPrimaryValues, TElement, TNode};
-use style::error_reporting::RustLogReporter;
 use style::font_metrics::FontMetrics;
 use style::global_style_data::GLOBAL_STYLE_DATA;
 use style::invalidation::element::restyle_hints::RestyleHint;
@@ -68,7 +67,7 @@ use style::selector_parser::{PseudoElement, RestyleDamage, SnapshotMap};
 use style::servo::media_queries::FontMetricsProvider;
 use style::shared_lock::{SharedRwLock, SharedRwLockReadGuard, StylesheetGuards};
 use style::stylesheets::{
-    CustomMediaMap, DocumentStyleSheet, Origin, Stylesheet, StylesheetInDocument, UrlExtraData,
+    CustomMediaMap, DocumentStyleSheet, Origin, Stylesheet, StylesheetInDocument,
     UserAgentStylesheets,
 };
 use style::stylist::Stylist;
@@ -150,6 +149,11 @@ pub struct LayoutThread {
 
     /// Whether or not user agent stylesheets have been added to the Stylist or not.
     have_added_user_agent_stylesheets: bool,
+
+    // A vector of parsed `DocumentStyleSheet`s representing the corresponding `UserStyleSheet`s
+    // associated with the `WebView` to which this `Layout` belongs. The `DocumentStylesheet`s might
+    // be shared with `Layout`s in the same `ScriptThread`.
+    user_stylesheets: Rc<Vec<DocumentStyleSheet>>,
 
     /// Whether or not this [`LayoutImpl`]'s [`Device`] has changed since the last restyle.
     /// If it has, a restyle is pending.
@@ -765,6 +769,7 @@ impl LayoutThread {
             debug: opts::get().debug.clone(),
             previously_highlighted_dom_node: Cell::new(None),
             lcp_candidate_collector: Default::default(),
+            user_stylesheets: config.user_stylesheets,
         }
     }
 
@@ -960,11 +965,25 @@ impl LayoutThread {
         snapshot_map: &SnapshotMap,
     ) {
         if !self.have_added_user_agent_stylesheets {
+            // TODO: The field `user_or_user_agent_stylesheets` should only contain the user agent
+            // stylesheets as user stylesheets are specified separately. Potentially the struct in
+            // stylo should be renamed so that the field is no longer implies user stylesheets are
+            // set here.
             for stylesheet in &ua_stylesheets.user_or_user_agent_stylesheets {
                 self.stylist
                     .append_stylesheet(stylesheet.clone(), guards.ua_or_user);
                 self.load_all_web_fonts_from_stylesheet_with_guard(
                     stylesheet,
+                    guards.ua_or_user,
+                    &reflow_request.document_context,
+                );
+            }
+
+            for user_stylesheet in self.user_stylesheets.iter() {
+                self.stylist
+                    .append_stylesheet(user_stylesheet.clone(), guards.ua_or_user);
+                self.load_all_web_fonts_from_stylesheet_with_guard(
+                    user_stylesheet,
                     guards.ua_or_user,
                     &reflow_request.document_context,
                 );
@@ -1431,7 +1450,7 @@ fn get_ua_stylesheets() -> Result<UserAgentStylesheets, &'static str> {
 
     // FIXME: presentational-hints.css should be at author origin with zero specificity.
     //        (Does it make a difference?)
-    let mut user_or_user_agent_stylesheets = vec![
+    let user_agent_stylesheets = vec![
         parse_ua_stylesheet(shared_lock, "user-agent.css", USER_AGENT_CSS)?,
         parse_ua_stylesheet(shared_lock, "servo.css", SERVO_CSS)?,
         parse_ua_stylesheet(
@@ -1441,29 +1460,12 @@ fn get_ua_stylesheets() -> Result<UserAgentStylesheets, &'static str> {
         )?,
     ];
 
-    for (contents, url) in &opts::get().user_stylesheets {
-        user_or_user_agent_stylesheets.push(DocumentStyleSheet(ServoArc::new(
-            Stylesheet::from_bytes(
-                contents,
-                UrlExtraData(url.get_arc()),
-                None,
-                None,
-                Origin::User,
-                ServoArc::new(shared_lock.wrap(MediaList::empty())),
-                shared_lock.clone(),
-                None,
-                Some(&RustLogReporter),
-                QuirksMode::NoQuirks,
-            ),
-        )));
-    }
-
     let quirks_mode_stylesheet =
         parse_ua_stylesheet(shared_lock, "quirks-mode.css", QUIRKS_MODE_CSS)?;
 
     Ok(UserAgentStylesheets {
         shared_lock: shared_lock.clone(),
-        user_or_user_agent_stylesheets,
+        user_or_user_agent_stylesheets: user_agent_stylesheets,
         quirks_mode_stylesheet,
     })
 }

--- a/components/script/dom/userscripts.rs
+++ b/components/script/dom/userscripts.rs
@@ -24,8 +24,8 @@ pub(crate) fn load_script(head: &HTMLHeadElement) {
         let global_scope = win.as_global_scope();
         for user_script in userscripts {
             _ = global_scope.evaluate_js_on_global(
-                user_script.script.into(),
-                &user_script.source_file.map(|path| path.to_string_lossy().to_string()).unwrap_or_default(),
+                user_script.script().into(),
+                &user_script.source_file().map(|path| path.to_string_lossy().to_string()).unwrap_or_default(),
                 None,
                 rval.handle_mut(),
                 CanGc::note(),

--- a/components/servo/user_content_manager.rs
+++ b/components/servo/user_content_manager.rs
@@ -2,8 +2,10 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
+use std::rc::Rc;
+
 use constellation_traits::{EmbedderToConstellationMessage, UserContentManagerAction};
-use embedder_traits::user_contents::{UserContentManagerId, UserScript};
+use embedder_traits::user_contents::{UserContentManagerId, UserScript, UserStyleSheet};
 
 use crate::Servo;
 
@@ -29,11 +31,38 @@ impl UserContentManager {
         self.id
     }
 
-    pub fn add_script(&self, user_script: UserScript) {
+    pub fn add_script(&self, user_script: Rc<UserScript>) {
         self.servo.constellation_proxy().send(
             EmbedderToConstellationMessage::UserContentManagerAction(
                 self.id,
-                UserContentManagerAction::AddUserScript(user_script),
+                UserContentManagerAction::AddUserScript((*user_script).clone()),
+            ),
+        );
+    }
+
+    pub fn remove_script(&self, user_script: Rc<UserScript>) {
+        self.servo.constellation_proxy().send(
+            EmbedderToConstellationMessage::UserContentManagerAction(
+                self.id,
+                UserContentManagerAction::RemoveUserScript(user_script.id()),
+            ),
+        );
+    }
+
+    pub fn add_stylesheet(&self, user_stylesheet: Rc<UserStyleSheet>) {
+        self.servo.constellation_proxy().send(
+            EmbedderToConstellationMessage::UserContentManagerAction(
+                self.id,
+                UserContentManagerAction::AddUserStyleSheet((*user_stylesheet).clone()),
+            ),
+        );
+    }
+
+    pub fn remove_stylesheet(&self, user_stylesheet: Rc<UserStyleSheet>) {
+        self.servo.constellation_proxy().send(
+            EmbedderToConstellationMessage::UserContentManagerAction(
+                self.id,
+                UserContentManagerAction::RemoveUserStyleSheet(user_stylesheet.id()),
             ),
         );
     }

--- a/components/shared/constellation/lib.rs
+++ b/components/shared/constellation/lib.rs
@@ -18,7 +18,9 @@ use std::time::Duration;
 use base::cross_process_instant::CrossProcessInstant;
 use base::generic_channel::GenericCallback;
 use base::id::{MessagePortId, PipelineId, ScriptEventLoopId, WebViewId};
-use embedder_traits::user_contents::{UserContentManagerId, UserScript};
+use embedder_traits::user_contents::{
+    UserContentManagerId, UserScript, UserScriptId, UserStyleSheet, UserStyleSheetId,
+};
 use embedder_traits::{
     EmbedderControlId, EmbedderControlResponse, InputEventAndId, JavaScriptEvaluationId,
     MediaSessionActionType, NewWebViewDetails, PaintHitTestResult, Theme, TraversalId,
@@ -120,6 +122,9 @@ pub enum EmbedderToConstellationMessage {
 pub enum UserContentManagerAction {
     AddUserScript(UserScript),
     DestroyUserContentManager,
+    RemoveUserScript(UserScriptId),
+    AddUserStyleSheet(UserStyleSheet),
+    RemoveUserStyleSheet(UserStyleSheetId),
 }
 
 /// A description of a paint metric that is sent from the Servo renderer to the

--- a/components/shared/embedder/user_contents.rs
+++ b/components/shared/embedder/user_contents.rs
@@ -8,6 +8,7 @@ use std::sync::atomic::{AtomicU32, Ordering};
 use malloc_size_of::MallocSizeOfOps;
 use malloc_size_of_derive::MallocSizeOf;
 use serde::{Deserialize, Serialize};
+use url::Url;
 
 static USER_CONTENT_MANAGER_ID: AtomicU32 = AtomicU32::new(1);
 
@@ -23,6 +24,7 @@ impl UserContentManagerId {
 #[derive(Clone, Debug, Default, Deserialize, MallocSizeOf, Serialize)]
 pub struct UserContents {
     pub scripts: Vec<UserScript>,
+    pub stylesheets: Vec<UserStyleSheet>,
 }
 
 impl UserContents {
@@ -31,16 +33,102 @@ impl UserContents {
     }
 }
 
+static USER_STYLE_SHEET_ID: AtomicU32 = AtomicU32::new(1);
+
+#[doc(hidden)]
+#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, MallocSizeOf, PartialEq, Serialize)]
+pub struct UserStyleSheetId(u32);
+
+impl UserStyleSheetId {
+    fn next() -> Self {
+        UserStyleSheetId(USER_STYLE_SHEET_ID.fetch_add(1, Ordering::Relaxed))
+    }
+}
+
+#[derive(Clone, Debug, Deserialize, MallocSizeOf, Serialize)]
+pub struct UserStyleSheet {
+    id: UserStyleSheetId,
+    source: String,
+    url: Url,
+}
+
+impl UserStyleSheet {
+    /// Create a new `UserStyleSheet` for the given source and url representing its location. The
+    /// `url` can be a local file url.
+    pub fn new(source: String, url: Url) -> Self {
+        Self {
+            id: UserStyleSheetId::next(),
+            source,
+            url,
+        }
+    }
+
+    #[doc(hidden)]
+    pub fn id(&self) -> UserStyleSheetId {
+        self.id
+    }
+
+    /// Return a reference to the source string of this `UserStyleSheet`.
+    pub fn source(&self) -> &String {
+        &self.source
+    }
+
+    /// Return the source url of this `UserStyleSheet`.
+    pub fn url(&self) -> Url {
+        self.url.clone()
+    }
+}
+
+static USER_SCRIPT_ID: AtomicU32 = AtomicU32::new(1);
+
+#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, MallocSizeOf, PartialEq, Serialize)]
+pub struct UserScriptId(u32);
+
+impl UserScriptId {
+    fn next() -> Self {
+        UserScriptId(USER_SCRIPT_ID.fetch_add(1, Ordering::Relaxed))
+    }
+}
+
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct UserScript {
-    pub script: String,
-    pub source_file: Option<PathBuf>,
+    id: UserScriptId,
+    script: String,
+    source_file: Option<PathBuf>,
+}
+
+impl UserScript {
+    /// Create a new `UserStyleSheet` for the given source string and an optional `PathBuf` representing
+    /// the location of the script on disk.
+    pub fn new(script: String, source_file: Option<PathBuf>) -> Self {
+        Self {
+            id: UserScriptId::next(),
+            script,
+            source_file,
+        }
+    }
+
+    #[doc(hidden)]
+    pub fn id(&self) -> UserScriptId {
+        self.id
+    }
+
+    /// Returns the optional path that represents the location of this `UserScript`.
+    pub fn source_file(&self) -> Option<PathBuf> {
+        self.source_file.clone()
+    }
+
+    // Returns a reference to the source string of this `UserScript`.
+    pub fn script(&self) -> &String {
+        &self.script
+    }
 }
 
 // Maybe we should implement `MallocSizeOf` for `PathBuf` in `malloc_size_of` crate?
 impl malloc_size_of::MallocSizeOf for UserScript {
     fn size_of(&self, ops: &mut MallocSizeOfOps) -> usize {
         let mut sum = 0;
+        sum += self.id.0.size_of(ops);
         sum += self.script.size_of(ops);
         if let Some(path) = &self.source_file {
             sum += unsafe { ops.malloc_size_of(path.as_path()) };
@@ -51,9 +139,6 @@ impl malloc_size_of::MallocSizeOf for UserScript {
 
 impl<T: Into<String>> From<T> for UserScript {
     fn from(script: T) -> Self {
-        UserScript {
-            script: script.into(),
-            source_file: None,
-        }
+        UserScript::new(script.into(), None)
     }
 }

--- a/components/shared/layout/lib.rs
+++ b/components/shared/layout/lib.rs
@@ -12,6 +12,7 @@ mod layout_damage;
 pub mod wrapper_traits;
 
 use std::any::Any;
+use std::rc::Rc;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicIsize, AtomicU64, Ordering};
 use std::thread::JoinHandle;
@@ -54,7 +55,7 @@ use style::properties::style_structs::Font;
 use style::properties::{ComputedValues, PropertyId};
 use style::selector_parser::{PseudoElement, RestyleDamage, Snapshot};
 use style::str::char_is_whitespace;
-use style::stylesheets::{Stylesheet, UrlExtraData};
+use style::stylesheets::{DocumentStyleSheet, Stylesheet, UrlExtraData};
 use style::values::computed::Overflow;
 use style_traits::CSSPixel;
 use webrender_api::units::{DeviceIntSize, LayoutPoint, LayoutVector2D};
@@ -234,6 +235,7 @@ pub struct LayoutConfig {
     pub time_profiler_chan: time::ProfilerChan,
     pub paint_api: CrossProcessPaintApi,
     pub viewport_details: ViewportDetails,
+    pub user_stylesheets: Rc<Vec<DocumentStyleSheet>>,
     pub theme: Theme,
 }
 


### PR DESCRIPTION
The patch adds the following functionality to the per-WebView `UserContentManager` API.
- Removing a `UserScript` at that was previously added.
- Adding a new `UserStyleSheet` representing a user-origin style sheet. allow removing user script
- Removing a previously added `UserStyleSheet`.

There might be scope for some improvements in the API:
- `UserScript` and `UserStyleSheet` have different ways of representing the source location - a `PathBuf` and `Url` respectively. This is due to how those values are used by the underlying evaluation APIs in script and stylo. More investigation is needed here and could be addressed in future patches.

Testing: New unit tests are added for the user stylesheet APIs. Existing tests have been updated to test the removal of user scripts.
