### PR TITLE
webdriver: Support interspersed pointerMove actions via event queue

### DIFF
--- a/components/webdriver_server/actions.rs
+++ b/components/webdriver_server/actions.rs
@@ -68,7 +68,7 @@ pub(crate) enum InputSourceState {
 }
 
 pub(crate) struct PendingPointerMove {
-    pointer_id: u32,
+    input_id: &str,
     duration: u64,
     start_x: f64,
     start_y: f64,
@@ -636,9 +636,8 @@ impl Handler {
         // parallelism required by spec.
         // This conveniently unify the wait interval between ticks.
         self.pending_pointer_moves
-            .borrow_mut()
             .push(PendingPointerMove {
-                pointer_id: *pointer_id,
+                input_id,
                 duration,
                 start_x,
                 start_y,

--- a/components/webdriver_server/lib.rs
+++ b/components/webdriver_server/lib.rs
@@ -187,7 +187,7 @@ struct Handler {
     num_pending_actions: Cell<u32>,
 
     /// Moves that are currently in-progress and need to be ticked.
-    pending_pointer_moves: RefCell<Vec<PendingPointerMove>>,
+    pending_pointer_moves: Vec<PendingPointerMove>,
 
     /// The base set of preferences to treat as default when resetting.
     default_preferences: Preferences,

--- a/components/webdriver_server/lib.rs
+++ b/components/webdriver_server/lib.rs
@@ -471,6 +471,7 @@ impl Handler {
             event_loop_waker,
             default_preferences,
             pending_input_event_receivers: Default::default(),
+            pending_pointer_moves: Default::default(),
             num_pending_actions: Cell::new(0),
         }
     }

--- a/components/webdriver_server/lib.rs
+++ b/components/webdriver_server/lib.rs
@@ -73,7 +73,9 @@ use webdriver::response::{
 };
 use webdriver::server::{self, Session, SessionTeardownKind, WebDriverHandler};
 
-use crate::actions::{ELEMENT_CLICK_BUTTON, InputSourceState, PointerInputState};
+use crate::actions::{
+    ELEMENT_CLICK_BUTTON, InputSourceState, PendingPointerMove, PointerInputState,
+};
 use crate::session::{PageLoadStrategy, WebDriverSession};
 use crate::timeout::{DEFAULT_IMPLICIT_WAIT, DEFAULT_PAGE_LOAD_TIMEOUT, SCREENSHOT_TIMEOUT};
 
@@ -183,6 +185,9 @@ struct Handler {
 
     /// Number of pending actions of which WebDriver is waiting for responses.
     num_pending_actions: Cell<u32>,
+
+    /// Moves that are currently in-progress and need to be ticked.
+    pending_pointer_moves: RefCell<Vec<PendingPointerMove>>,
 
     /// The base set of preferences to treat as default when resetting.
     default_preferences: Preferences,


### PR DESCRIPTION
For `pointerMove` with duration, we need to wait asynchronously and execute in parallel for subsequent moves.
But we never did this correctly: we waited in a blocking way which broke the whole point of tick: making sure we simultaneously perform actions from multiple sources within a single unit time.

To avoid async borrow-checker hell, we achieve the same effect using a event queue.

> Spec: The initial pointer movement is performed synchronously. This ensures determinism in the sequence of the first event triggered by each action in the tick.
> 
> Subsequent movements (if any) are performed asynchronously. This allows events from two [pointerMove](https://w3c.github.io/webdriver/#dfn-pointermove) actions in the tick to be interspersed.

Testing: Existing WPT tests not affected, which is a good sign. This fixes a potential **deadlock**: https://github.com/servo/servo/pull/42289#issuecomment-3838895081.
Fixes: #42235
This is a pre-requisite to #41923: multi-touch support.