### PR TITLE
devtools: Support sending js objects to firefox devtools from console.log

### DIFF
--- a/components/devtools/lib.rs
+++ b/components/devtools/lib.rs
@@ -35,7 +35,7 @@ use serde::Serialize;
 
 use crate::actor::{Actor, ActorRegistry};
 use crate::actors::browsing_context::BrowsingContextActor;
-use crate::actors::console::{ConsoleActor, ConsoleResource, Root};
+use crate::actors::console::{ConsoleActor, ConsoleResource, DevtoolsConsoleMessage, Root};
 use crate::actors::framerate::FramerateActor;
 use crate::actors::network_event::NetworkEventActor;
 use crate::actors::root::RootActor;
@@ -237,11 +237,15 @@ impl DevtoolsInstance {
                     pipeline_id,
                     console_message,
                     worker_id,
-                )) => self.handle_console_resource(
-                    pipeline_id,
-                    worker_id,
-                    ConsoleResource::ConsoleMessage(console_message.into()),
-                ),
+                )) => {
+                    let console_message =
+                        DevtoolsConsoleMessage::new(console_message, &self.registry);
+                    self.handle_console_resource(
+                        pipeline_id,
+                        worker_id,
+                        ConsoleResource::ConsoleMessage(console_message),
+                    );
+                },
                 DevtoolsControlMsg::FromScript(ScriptToDevtoolsControlMsg::ClearConsole(
                     pipeline_id,
                     worker_id,
@@ -277,11 +281,13 @@ impl DevtoolsInstance {
                         arguments: vec![css_error.msg.into()],
                         stacktrace: None,
                     };
+                    let console_message =
+                        DevtoolsConsoleMessage::new(console_message, &self.registry);
 
                     self.handle_console_resource(
                         pipeline_id,
                         None,
-                        ConsoleResource::ConsoleMessage(console_message.into()),
+                        ConsoleResource::ConsoleMessage(console_message),
                     )
                 },
                 DevtoolsControlMsg::FromChrome(ChromeToDevtoolsControlMsg::NetworkEvent(

--- a/components/script/dom/console.rs
+++ b/components/script/dom/console.rs
@@ -178,7 +178,7 @@ fn console_object_from_handle_value(
         GetPropertyKeys(
             *cx,
             object.handle(),
-            jsapi::JSITER_OWNONLY | jsapi::JSITER_SYMBOLS,
+            jsapi::JSITER_OWNONLY | jsapi::JSITER_SYMBOLS | jsapi::JSITER_HIDDEN,
             ids.handle_mut(),
         )
     } {
@@ -225,9 +225,9 @@ fn console_object_from_handle_value(
 
         own_properties.push(ConsoleArgumentPropertyValue {
             key,
-            configurable: descriptor.hasConfigurable_(),
-            enumerable: descriptor.hasEnumerable_(),
-            writable: descriptor.hasWritable_(),
+            configurable: descriptor.hasConfigurable_() && descriptor.configurable_(),
+            enumerable: descriptor.hasEnumerable_() && descriptor.enumerable_(),
+            writable: descriptor.hasWritable_() && descriptor.writable_(),
             value: console_argument_from_handle_value(cx, property.handle()),
         });
     }

--- a/components/script/dom/console.rs
+++ b/components/script/dom/console.rs
@@ -7,8 +7,8 @@ use std::ptr::{self, NonNull};
 use std::slice;
 
 use devtools_traits::{
-    ConsoleArgument, ConsoleLogLevel, ConsoleMessage, ConsoleMessageFields,
-    ScriptToDevtoolsControlMsg, StackFrame, get_time_stamp,
+    ConsoleArgument, ConsoleArgumentObject, ConsoleArgumentPropertyValue, ConsoleLogLevel,
+    ConsoleMessage, ConsoleMessageFields, ScriptToDevtoolsControlMsg, StackFrame, get_time_stamp,
 };
 use embedder_traits::EmbedderMsg;
 use js::conversions::jsstr_to_string;
@@ -154,9 +154,88 @@ fn console_argument_from_handle_value(cx: JSContext, handle_value: HandleValue) 
         return ConsoleArgument::Number(number);
     }
 
+    if handle_value.is_object() {
+        if let Some(console_argument_object) = console_object_from_handle_value(cx, handle_value) {
+            return ConsoleArgument::Object(console_argument_object);
+        }
+    }
+
     // FIXME: Handle more complex argument types here
     let stringified_value = stringify_handle_value(handle_value);
     ConsoleArgument::String(stringified_value.into())
+}
+
+#[expect(unsafe_code)]
+fn console_object_from_handle_value(
+    cx: JSContext,
+    handle_value: HandleValue,
+) -> Option<ConsoleArgumentObject> {
+    rooted!(in(*cx) let object = handle_value.to_object());
+
+    let mut own_properties = Vec::new();
+    let mut ids = unsafe { IdVector::new(*cx) };
+    if !unsafe {
+        GetPropertyKeys(
+            *cx,
+            object.handle(),
+            jsapi::JSITER_OWNONLY | jsapi::JSITER_SYMBOLS,
+            ids.handle_mut(),
+        )
+    } {
+        return None;
+    }
+
+    for id in ids.iter() {
+        rooted!(in(*cx) let id = *id);
+        rooted!(in(*cx) let mut descriptor = PropertyDescriptor::default());
+
+        let mut is_none = false;
+        if !unsafe {
+            JS_GetOwnPropertyDescriptorById(
+                *cx,
+                object.handle(),
+                id.handle(),
+                descriptor.handle_mut(),
+                &mut is_none,
+            )
+        } {
+            return None;
+        }
+
+        rooted!(in(*cx) let mut property = UndefinedValue());
+        if !unsafe { JS_GetPropertyById(*cx, object.handle(), id.handle(), property.handle_mut()) }
+        {
+            return None;
+        }
+
+        let key = if id.is_string() || id.is_symbol() || id.is_int() {
+            rooted!(in(*cx) let mut key_value = UndefinedValue());
+            let raw_id: jsapi::HandleId = id.handle().into();
+            if !unsafe { JS_IdToValue(*cx, *raw_id.ptr, key_value.handle_mut()) } {
+                continue;
+            }
+            rooted!(in(*cx) let js_string = key_value.to_string());
+            let Some(js_string) = NonNull::new(js_string.get()) else {
+                continue;
+            };
+            unsafe { jsstr_to_string(*cx, js_string) }
+        } else {
+            continue;
+        };
+
+        own_properties.push(ConsoleArgumentPropertyValue {
+            key,
+            configurable: descriptor.hasConfigurable_(),
+            enumerable: descriptor.hasEnumerable_(),
+            writable: descriptor.hasWritable_(),
+            value: console_argument_from_handle_value(cx, property.handle()),
+        });
+    }
+
+    Some(ConsoleArgumentObject {
+        class: "Object".to_owned(),
+        own_properties,
+    })
 }
 
 #[expect(unsafe_code)]

--- a/components/script/dom/console.rs
+++ b/components/script/dom/console.rs
@@ -15,7 +15,7 @@ use js::conversions::jsstr_to_string;
 use js::jsapi::{self, ESClass, PropertyDescriptor};
 use js::jsval::{Int32Value, UndefinedValue};
 use js::rust::wrappers::{
-    GetBuiltinClass, GetPropertyKeys, JS_GetOwnPropertyDescriptorById, JS_GetPropertyById,
+    GetBuiltinClass, GetPropertyKeys, IsArray, JS_GetOwnPropertyDescriptorById, JS_GetPropertyById,
     JS_IdToValue, JS_Stringify, JS_ValueToSource,
 };
 use js::rust::{
@@ -171,6 +171,11 @@ fn console_object_from_handle_value(
     handle_value: HandleValue,
 ) -> Option<ConsoleArgumentObject> {
     rooted!(in(*cx) let object = handle_value.to_object());
+
+    let mut is_array = false;
+    if unsafe { IsArray(*cx, object.handle(), &mut is_array) } || is_array {
+        return None;
+    }
 
     let mut own_properties = Vec::new();
     let mut ids = unsafe { IdVector::new(*cx) };

--- a/components/shared/devtools/lib.rs
+++ b/components/shared/devtools/lib.rs
@@ -364,6 +364,23 @@ pub enum ConsoleArgument {
     String(String),
     Integer(i32),
     Number(f64),
+    Object(ConsoleArgumentObject),
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct ConsoleArgumentObject {
+    pub class: String,
+    pub own_properties: Vec<ConsoleArgumentPropertyValue>,
+}
+
+/// A property on a JS object passed as a console argument.
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct ConsoleArgumentPropertyValue {
+    pub key: String,
+    pub configurable: bool,
+    pub enumerable: bool,
+    pub writable: bool,
+    pub value: ConsoleArgument,
 }
 
 impl From<String> for ConsoleArgument {

--- a/python/servo/devtools_tests/console/log_object.html
+++ b/python/servo/devtools_tests/console/log_object.html
@@ -1,0 +1,26 @@
+<script>
+let log_object = () => {
+  let object = {};
+  Object.defineProperty(object, "foo", {
+      enumerable: true,
+      writable: true,
+      configurable: true
+  });
+
+  // "object.bar" should be shown in the console despite being non-enumerable
+  Object.defineProperty(object, "bar", {
+      enumerable: false,
+      writable: true,
+      configurable: true
+  });
+  Object.defineProperty(object, "baz", {
+      enumerable: true,
+      writable: true,
+      configurable: false
+  });
+  object.foo = 1;
+  object.bar = "servo";
+  object.baz = true
+  console.log(object);
+};
+</script>


### PR DESCRIPTION
This allows us to `console.log` objects from JS and have a preview of them appear in the console.
Interacting with said preview doesn't work yet, because the devtools object actor is a stub.

<img width="600" height="78" alt="image" src="https://github.com/user-attachments/assets/d896471f-3982-4406-94d4-b13eebabe337" />

Testing: This change adds a test