### PR TITLE
webdriver: Remove orphan `Handler::num_pending_actions`

### DIFF
--- a/components/webdriver_server/actions.rs
+++ b/components/webdriver_server/actions.rs
@@ -245,8 +245,6 @@ impl Handler {
             pending_event_receivers.remove(index);
         }
 
-        self.num_pending_actions.set(0);
-
         Ok(())
     }
 

--- a/components/webdriver_server/lib.rs
+++ b/components/webdriver_server/lib.rs
@@ -183,9 +183,6 @@ struct Handler {
     /// TODO: Once we upgrade crossbeam-channel this can be replaced with a `WaitGroup`.
     pending_input_event_receivers: RefCell<Vec<Receiver<()>>>,
 
-    /// Number of pending actions of which WebDriver is waiting for responses.
-    num_pending_actions: Cell<u32>,
-
     /// Moves that are currently in-progress and need to be ticked.
     pending_pointer_moves: Vec<PendingPointerMove>,
 
@@ -472,7 +469,6 @@ impl Handler {
             default_preferences,
             pending_input_event_receivers: Default::default(),
             pending_pointer_moves: Default::default(),
-            num_pending_actions: Cell::new(0),
         }
     }
 

--- a/components/webdriver_server/lib.rs
+++ b/components/webdriver_server/lib.rs
@@ -14,7 +14,7 @@ mod timeout;
 mod user_prompt;
 
 use std::borrow::ToOwned;
-use std::cell::{Cell, LazyCell, RefCell};
+use std::cell::{LazyCell, RefCell};
 use std::collections::{BTreeMap, HashMap};
 use std::io::Cursor;
 use std::net::{SocketAddr, SocketAddrV4};


### PR DESCRIPTION
`Handler::num_pending_actions` has been a poor orphan since who-knows-when.
This also removes the only dependency on `Cell`.

Testing: This removes unused field. Covered by existing tests.