### PR TITLE
layout: Handle zero-sized positioning areas when laying out a dimension for `background-repeat`

### DIFF
--- a/components/layout/display_list/background.rs
+++ b/components/layout/display_list/background.rs
@@ -297,7 +297,9 @@ fn layout_1d(
     // > | zero).
     if let Repeat::Round = repeat {
         let round = |number: f32| number.round().max(1.0);
-        *tile_size = positioning_area_size / round(positioning_area_size / *tile_size);
+        if positioning_area_size != 0.0 {
+            *tile_size = positioning_area_size / round(positioning_area_size / *tile_size);
+        }
     }
     // https://drafts.csswg.org/css-backgrounds/#background-position
     let mut position = position

--- a/tests/wpt/tests/css/css-backgrounds/background-repeat-round-empty-crash.html
+++ b/tests/wpt/tests/css/css-backgrounds/background-repeat-round-empty-crash.html
@@ -1,0 +1,6 @@
+<!DOCTYPE html>
+<link rel=help href="https://github.com/servo/servo/issues/42216">
+<style>
+  #span { background-image: url(data:image/gif;base64,R0lGODlhEAAQAMQAAORHHOVSKudfOulrSOp3WOyDZu6QdvCchPGolfO0o/XBs/fNwfjZ0frl3/zy7////wAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAACH5BAkAABAALAAAAAAQABAAAAVVICSOZGlCQAosJ6mu7fiyZeKqNKToQGDsM8hBADgUXoGAiqhSvp5QAnQKGIgUhwFUYLCVDFCrKUE1lBavAViFIDlTImb5Gm2hB0SlBCB0Uj); background-repeat: round round; border-right-style: solid; }
+</style>
+<span id="span"></span>


### PR DESCRIPTION
The specification says that the rounding of the tile size should only happen
when the positioning size is not zero. This change makes us follow the
specification in this case.

Testing: This PR adds a new WPT crash test.
Fixes: #42216
