### PR TITLE
Bump servoshell to 0.0.5

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8410,7 +8410,7 @@ dependencies = [
 
 [[package]]
 name = "servoshell"
-version = "0.0.4"
+version = "0.0.5"
 dependencies = [
  "accesskit",
  "android_logger",

--- a/Info.plist
+++ b/Info.plist
@@ -17,7 +17,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.0.4</string>
+	<string>0.0.5</string>
 	<key>NSHighResolutionCapable</key>
 	<true/>
 	<key>NSPrincipalClass</key>

--- a/ports/servoshell/Cargo.toml
+++ b/ports/servoshell/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "servoshell"
 build = "build.rs"
-version = "0.0.4"
+version = "0.0.5"
 authors.workspace = true
 license.workspace = true
 edition.workspace = true

--- a/ports/servoshell/platform/windows/servo.exe.manifest
+++ b/ports/servoshell/platform/windows/servo.exe.manifest
@@ -4,7 +4,7 @@
           xmlns:asmv3="urn:schemas-microsoft-com:asm.v3">
   <assemblyIdentity type="win32"
                     name="servo.Servo"
-                    version="0.0.4.0"/>
+                    version="0.0.5.0"/>
 
   <compatibility xmlns="urn:schemas-microsoft-com:compatibility.v1">
     <application>

--- a/resources/resource_protocol/license.html
+++ b/resources/resource_protocol/license.html
@@ -71,217 +71,6 @@
                 <h3 id="Apache-2.0">Apache License 2.0</h3>
                     <p>
                         Used by
-                            <a href=" https://github.com/jtakakura/io-kit-rs ">io-kit-sys 0.4.1</a>
-                    </p>
-                <pre class="license-text">
-                                 Apache License
-                           Version 2.0, January 2004
-                        http://www.apache.org/licenses/
-
-   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
-
-   1. Definitions.
-
-      &quot;License&quot; shall mean the terms and conditions for use, reproduction,
-      and distribution as defined by Sections 1 through 9 of this document.
-
-      &quot;Licensor&quot; shall mean the copyright owner or entity authorized by
-      the copyright owner that is granting the License.
-
-      &quot;Legal Entity&quot; shall mean the union of the acting entity and all
-      other entities that control, are controlled by, or are under common
-      control with that entity. For the purposes of this definition,
-      &quot;control&quot; means (i) the power, direct or indirect, to cause the
-      direction or management of such entity, whether by contract or
-      otherwise, or (ii) ownership of fifty percent (50%) or more of the
-      outstanding shares, or (iii) beneficial ownership of such entity.
-
-      &quot;You&quot; (or &quot;Your&quot;) shall mean an individual or Legal Entity
-      exercising permissions granted by this License.
-
-      &quot;Source&quot; form shall mean the preferred form for making modifications,
-      including but not limited to software source code, documentation
-      source, and configuration files.
-
-      &quot;Object&quot; form shall mean any form resulting from mechanical
-      transformation or translation of a Source form, including but
-      not limited to compiled object code, generated documentation,
-      and conversions to other media types.
-
-      &quot;Work&quot; shall mean the work of authorship, whether in Source or
-      Object form, made available under the License, as indicated by a
-      copyright notice that is included in or attached to the work
-      (an example is provided in the Appendix below).
-
-      &quot;Derivative Works&quot; shall mean any work, whether in Source or Object
-      form, that is based on (or derived from) the Work and for which the
-      editorial revisions, annotations, elaborations, or other modifications
-      represent, as a whole, an original work of authorship. For the purposes
-      of this License, Derivative Works shall not include works that remain
-      separable from, or merely link (or bind by name) to the interfaces of,
-      the Work and Derivative Works thereof.
-
-      &quot;Contribution&quot; shall mean any work of authorship, including
-      the original version of the Work and any modifications or additions
-      to that Work or Derivative Works thereof, that is intentionally
-      submitted to Licensor for inclusion in the Work by the copyright owner
-      or by an individual or Legal Entity authorized to submit on behalf of
-      the copyright owner. For the purposes of this definition, &quot;submitted&quot;
-      means any form of electronic, verbal, or written communication sent
-      to the Licensor or its representatives, including but not limited to
-      communication on electronic mailing lists, source code control systems,
-      and issue tracking systems that are managed by, or on behalf of, the
-      Licensor for the purpose of discussing and improving the Work, but
-      excluding communication that is conspicuously marked or otherwise
-      designated in writing by the copyright owner as &quot;Not a Contribution.&quot;
-
-      &quot;Contributor&quot; shall mean Licensor and any individual or Legal Entity
-      on behalf of whom a Contribution has been received by Licensor and
-      subsequently incorporated within the Work.
-
-   2. Grant of Copyright License. Subject to the terms and conditions of
-      this License, each Contributor hereby grants to You a perpetual,
-      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
-      copyright license to reproduce, prepare Derivative Works of,
-      publicly display, publicly perform, sublicense, and distribute the
-      Work and such Derivative Works in Source or Object form.
-
-   3. Grant of Patent License. Subject to the terms and conditions of
-      this License, each Contributor hereby grants to You a perpetual,
-      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
-      (except as stated in this section) patent license to make, have made,
-      use, offer to sell, sell, import, and otherwise transfer the Work,
-      where such license applies only to those patent claims licensable
-      by such Contributor that are necessarily infringed by their
-      Contribution(s) alone or by combination of their Contribution(s)
-      with the Work to which such Contribution(s) was submitted. If You
-      institute patent litigation against any entity (including a
-      cross-claim or counterclaim in a lawsuit) alleging that the Work
-      or a Contribution incorporated within the Work constitutes direct
-      or contributory patent infringement, then any patent licenses
-      granted to You under this License for that Work shall terminate
-      as of the date such litigation is filed.
-
-   4. Redistribution. You may reproduce and distribute copies of the
-      Work or Derivative Works thereof in any medium, with or without
-      modifications, and in Source or Object form, provided that You
-      meet the following conditions:
-
-      (a) You must give any other recipients of the Work or
-          Derivative Works a copy of this License; and
-
-      (b) You must cause any modified files to carry prominent notices
-          stating that You changed the files; and
-
-      (c) You must retain, in the Source form of any Derivative Works
-          that You distribute, all copyright, patent, trademark, and
-          attribution notices from the Source form of the Work,
-          excluding those notices that do not pertain to any part of
-          the Derivative Works; and
-
-      (d) If the Work includes a &quot;NOTICE&quot; text file as part of its
-          distribution, then any Derivative Works that You distribute must
-          include a readable copy of the attribution notices contained
-          within such NOTICE file, excluding those notices that do not
-          pertain to any part of the Derivative Works, in at least one
-          of the following places: within a NOTICE text file distributed
-          as part of the Derivative Works; within the Source form or
-          documentation, if provided along with the Derivative Works; or,
-          within a display generated by the Derivative Works, if and
-          wherever such third-party notices normally appear. The contents
-          of the NOTICE file are for informational purposes only and
-          do not modify the License. You may add Your own attribution
-          notices within Derivative Works that You distribute, alongside
-          or as an addendum to the NOTICE text from the Work, provided
-          that such additional attribution notices cannot be construed
-          as modifying the License.
-
-      You may add Your own copyright statement to Your modifications and
-      may provide additional or different license terms and conditions
-      for use, reproduction, or distribution of Your modifications, or
-      for any such Derivative Works as a whole, provided Your use,
-      reproduction, and distribution of the Work otherwise complies with
-      the conditions stated in this License.
-
-   5. Submission of Contributions. Unless You explicitly state otherwise,
-      any Contribution intentionally submitted for inclusion in the Work
-      by You to the Licensor shall be under the terms and conditions of
-      this License, without any additional terms or conditions.
-      Notwithstanding the above, nothing herein shall supersede or modify
-      the terms of any separate license agreement you may have executed
-      with Licensor regarding such Contributions.
-
-   6. Trademarks. This License does not grant permission to use the trade
-      names, trademarks, service marks, or product names of the Licensor,
-      except as required for reasonable and customary use in describing the
-      origin of the Work and reproducing the content of the NOTICE file.
-
-   7. Disclaimer of Warranty. Unless required by applicable law or
-      agreed to in writing, Licensor provides the Work (and each
-      Contributor provides its Contributions) on an &quot;AS IS&quot; BASIS,
-      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
-      implied, including, without limitation, any warranties or conditions
-      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
-      PARTICULAR PURPOSE. You are solely responsible for determining the
-      appropriateness of using or redistributing the Work and assume any
-      risks associated with Your exercise of permissions under this License.
-
-   8. Limitation of Liability. In no event and under no legal theory,
-      whether in tort (including negligence), contract, or otherwise,
-      unless required by applicable law (such as deliberate and grossly
-      negligent acts) or agreed to in writing, shall any Contributor be
-      liable to You for damages, including any direct, indirect, special,
-      incidental, or consequential damages of any character arising as a
-      result of this License or out of the use or inability to use the
-      Work (including but not limited to damages for loss of goodwill,
-      work stoppage, computer failure or malfunction, or any and all
-      other commercial damages or losses), even if such Contributor
-      has been advised of the possibility of such damages.
-
-   9. Accepting Warranty or Additional Liability. While redistributing
-      the Work or Derivative Works thereof, You may choose to offer,
-      and charge a fee for, acceptance of support, warranty, indemnity,
-      or other liability obligations and/or rights consistent with this
-      License. However, in accepting such obligations, You may act only
-      on Your own behalf and on Your sole responsibility, not on behalf
-      of any other Contributor, and only if You agree to indemnify,
-      defend, and hold each Contributor harmless for any liability
-      incurred by, or claims asserted against, such Contributor by reason
-      of your accepting any such warranty or additional liability.
-
-   END OF TERMS AND CONDITIONS
-
-   APPENDIX: How to apply the Apache License to your work.
-
-      To apply the Apache License to your work, attach the following
-      boilerplate notice, with the fields enclosed by brackets &quot;[]&quot;
-      replaced with your own identifying information. (Don&#x27;t include
-      the brackets!)  The text should be enclosed in the appropriate
-      comment syntax for the file format. We also recommend that a
-      file or class name and description of purpose be included on the
-      same &quot;printed page&quot; as the copyright notice for easier
-      identification within third-party archives.
-
-    
-   Copyright (c) 2017-2018 Junji Takakura
-
-   Licensed under the Apache License, Version 2.0 (the &quot;License&quot;);
-   you may not use this file except in compliance with the License.
-   You may obtain a copy of the License at
-
-       http://www.apache.org/licenses/LICENSE-2.0
-
-   Unless required by applicable law or agreed to in writing, software
-   distributed under the License is distributed on an &quot;AS IS&quot; BASIS,
-   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-   See the License for the specific language governing permissions and
-   limitations under the License.
-</pre>
-            </li>
-            <li class="license">
-                <h3 id="Apache-2.0">Apache License 2.0</h3>
-                    <p>
-                        Used by
                             <a href=" https://github.com/jhpratt/num_threads ">num_threads 0.1.7</a>
                     </p>
                 <pre class="license-text">
@@ -2883,8 +2672,8 @@ Software.
                 <h3 id="Apache-2.0">Apache License 2.0</h3>
                     <h4>Used by:</h4>
                     <ul class="license-used-by">
-                        <li><a href=" https://github.com/google/zerocopy ">zerocopy-derive 0.8.31</a></li>
-                        <li><a href=" https://github.com/google/zerocopy ">zerocopy 0.8.31</a></li>
+                        <li><a href=" https://github.com/google/zerocopy ">zerocopy-derive 0.8.37</a></li>
+                        <li><a href=" https://github.com/google/zerocopy ">zerocopy 0.8.37</a></li>
                     </ul>
                 <pre class="license-text">                                 Apache License
                            Version 2.0, January 2004
@@ -4146,16 +3935,17 @@ Software.
                 <h3 id="Apache-2.0">Apache License 2.0</h3>
                     <h4>Used by:</h4>
                     <ul class="license-used-by">
-                        <li><a href=" https://github.com/rust-ammonia/rust-content-security-policy ">content-security-policy 0.5.4</a></li>
                         <li><a href=" https://github.com/rust-cli/anstyle.git ">anstream 0.6.21</a></li>
                         <li><a href=" https://github.com/rust-cli/anstyle.git ">anstyle-parse 0.2.7</a></li>
                         <li><a href=" https://github.com/rust-cli/anstyle.git ">anstyle-query 1.1.5</a></li>
                         <li><a href=" https://github.com/rust-cli/anstyle.git ">anstyle-wincon 3.0.11</a></li>
                         <li><a href=" https://github.com/rust-cli/anstyle.git ">anstyle 1.0.13</a></li>
-                        <li><a href=" https://github.com/clap-rs/clap ">clap 4.5.53</a></li>
-                        <li><a href=" https://github.com/clap-rs/clap ">clap_builder 4.5.53</a></li>
-                        <li><a href=" https://github.com/clap-rs/clap ">clap_lex 0.7.6</a></li>
+                        <li><a href=" https://github.com/clap-rs/clap ">clap 4.5.56</a></li>
+                        <li><a href=" https://github.com/clap-rs/clap ">clap_builder 4.5.56</a></li>
+                        <li><a href=" https://github.com/clap-rs/clap ">clap_lex 0.7.7</a></li>
+                        <li><a href=" https://github.com/jamesmunns/cobs.rs ">cobs 0.3.0</a></li>
                         <li><a href=" https://github.com/rust-cli/anstyle.git ">colorchoice 1.0.4</a></li>
+                        <li><a href=" https://github.com/rust-ammonia/rust-content-security-policy ">content-security-policy 0.6.0</a></li>
                         <li><a href=" https://github.com/srijs/rust-crc32fast ">crc32fast 1.5.0</a></li>
                         <li><a href=" https://github.com/rust-cli/env_logger ">env_filter 0.1.4</a></li>
                         <li><a href=" https://github.com/rust-cli/env_logger ">env_logger 0.11.8</a></li>
@@ -6271,7 +6061,7 @@ limitations under the License.
                     <h4>Used by:</h4>
                     <ul class="license-used-by">
                         <li><a href=" https://github.com/strawlab/iana-time-zone ">iana-time-zone-haiku 0.1.2</a></li>
-                        <li><a href=" https://github.com/strawlab/iana-time-zone ">iana-time-zone 0.1.64</a></li>
+                        <li><a href=" https://github.com/strawlab/iana-time-zone ">iana-time-zone 0.1.65</a></li>
                     </ul>
                 <pre class="license-text">                              Apache License
                         Version 2.0, January 2004
@@ -6900,7 +6690,7 @@ limitations under the License.
                 <h3 id="Apache-2.0">Apache License 2.0</h3>
                     <p>
                         Used by
-                            <a href=" https://github.com/rustls/pki-types ">rustls-pki-types 1.13.2</a>
+                            <a href=" https://github.com/rustls/pki-types ">rustls-pki-types 1.14.0</a>
                     </p>
                 <pre class="license-text">                              Apache License
                         Version 2.0, January 2004
@@ -7104,6 +6894,214 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 </pre>
+            </li>
+            <li class="license">
+                <h3 id="Apache-2.0">Apache License 2.0</h3>
+                    <p>
+                        Used by
+                            <a href=" https://github.com/RustCrypto/signatures ">ml-dsa 0.0.4</a>
+                    </p>
+                <pre class="license-text">                              Apache License
+                        Version 2.0, January 2004
+                     http://www.apache.org/licenses/
+
+TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+1. Definitions.
+
+   &quot;License&quot; shall mean the terms and conditions for use, reproduction,
+   and distribution as defined by Sections 1 through 9 of this document.
+
+   &quot;Licensor&quot; shall mean the copyright owner or entity authorized by
+   the copyright owner that is granting the License.
+
+   &quot;Legal Entity&quot; shall mean the union of the acting entity and all
+   other entities that control, are controlled by, or are under common
+   control with that entity. For the purposes of this definition,
+   &quot;control&quot; means (i) the power, direct or indirect, to cause the
+   direction or management of such entity, whether by contract or
+   otherwise, or (ii) ownership of fifty percent (50%) or more of the
+   outstanding shares, or (iii) beneficial ownership of such entity.
+
+   &quot;You&quot; (or &quot;Your&quot;) shall mean an individual or Legal Entity
+   exercising permissions granted by this License.
+
+   &quot;Source&quot; form shall mean the preferred form for making modifications,
+   including but not limited to software source code, documentation
+   source, and configuration files.
+
+   &quot;Object&quot; form shall mean any form resulting from mechanical
+   transformation or translation of a Source form, including but
+   not limited to compiled object code, generated documentation,
+   and conversions to other media types.
+
+   &quot;Work&quot; shall mean the work of authorship, whether in Source or
+   Object form, made available under the License, as indicated by a
+   copyright notice that is included in or attached to the work
+   (an example is provided in the Appendix below).
+
+   &quot;Derivative Works&quot; shall mean any work, whether in Source or Object
+   form, that is based on (or derived from) the Work and for which the
+   editorial revisions, annotations, elaborations, or other modifications
+   represent, as a whole, an original work of authorship. For the purposes
+   of this License, Derivative Works shall not include works that remain
+   separable from, or merely link (or bind by name) to the interfaces of,
+   the Work and Derivative Works thereof.
+
+   &quot;Contribution&quot; shall mean any work of authorship, including
+   the original version of the Work and any modifications or additions
+   to that Work or Derivative Works thereof, that is intentionally
+   submitted to Licensor for inclusion in the Work by the copyright owner
+   or by an individual or Legal Entity authorized to submit on behalf of
+   the copyright owner. For the purposes of this definition, &quot;submitted&quot;
+   means any form of electronic, verbal, or written communication sent
+   to the Licensor or its representatives, including but not limited to
+   communication on electronic mailing lists, source code control systems,
+   and issue tracking systems that are managed by, or on behalf of, the
+   Licensor for the purpose of discussing and improving the Work, but
+   excluding communication that is conspicuously marked or otherwise
+   designated in writing by the copyright owner as &quot;Not a Contribution.&quot;
+
+   &quot;Contributor&quot; shall mean Licensor and any individual or Legal Entity
+   on behalf of whom a Contribution has been received by Licensor and
+   subsequently incorporated within the Work.
+
+2. Grant of Copyright License. Subject to the terms and conditions of
+   this License, each Contributor hereby grants to You a perpetual,
+   worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+   copyright license to reproduce, prepare Derivative Works of,
+   publicly display, publicly perform, sublicense, and distribute the
+   Work and such Derivative Works in Source or Object form.
+
+3. Grant of Patent License. Subject to the terms and conditions of
+   this License, each Contributor hereby grants to You a perpetual,
+   worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+   (except as stated in this section) patent license to make, have made,
+   use, offer to sell, sell, import, and otherwise transfer the Work,
+   where such license applies only to those patent claims licensable
+   by such Contributor that are necessarily infringed by their
+   Contribution(s) alone or by combination of their Contribution(s)
+   with the Work to which such Contribution(s) was submitted. If You
+   institute patent litigation against any entity (including a
+   cross-claim or counterclaim in a lawsuit) alleging that the Work
+   or a Contribution incorporated within the Work constitutes direct
+   or contributory patent infringement, then any patent licenses
+   granted to You under this License for that Work shall terminate
+   as of the date such litigation is filed.
+
+4. Redistribution. You may reproduce and distribute copies of the
+   Work or Derivative Works thereof in any medium, with or without
+   modifications, and in Source or Object form, provided that You
+   meet the following conditions:
+
+   (a) You must give any other recipients of the Work or
+       Derivative Works a copy of this License; and
+
+   (b) You must cause any modified files to carry prominent notices
+       stating that You changed the files; and
+
+   (c) You must retain, in the Source form of any Derivative Works
+       that You distribute, all copyright, patent, trademark, and
+       attribution notices from the Source form of the Work,
+       excluding those notices that do not pertain to any part of
+       the Derivative Works; and
+
+   (d) If the Work includes a &quot;NOTICE&quot; text file as part of its
+       distribution, then any Derivative Works that You distribute must
+       include a readable copy of the attribution notices contained
+       within such NOTICE file, excluding those notices that do not
+       pertain to any part of the Derivative Works, in at least one
+       of the following places: within a NOTICE text file distributed
+       as part of the Derivative Works; within the Source form or
+       documentation, if provided along with the Derivative Works; or,
+       within a display generated by the Derivative Works, if and
+       wherever such third-party notices normally appear. The contents
+       of the NOTICE file are for informational purposes only and
+       do not modify the License. You may add Your own attribution
+       notices within Derivative Works that You distribute, alongside
+       or as an addendum to the NOTICE text from the Work, provided
+       that such additional attribution notices cannot be construed
+       as modifying the License.
+
+   You may add Your own copyright statement to Your modifications and
+   may provide additional or different license terms and conditions
+   for use, reproduction, or distribution of Your modifications, or
+   for any such Derivative Works as a whole, provided Your use,
+   reproduction, and distribution of the Work otherwise complies with
+   the conditions stated in this License.
+
+5. Submission of Contributions. Unless You explicitly state otherwise,
+   any Contribution intentionally submitted for inclusion in the Work
+   by You to the Licensor shall be under the terms and conditions of
+   this License, without any additional terms or conditions.
+   Notwithstanding the above, nothing herein shall supersede or modify
+   the terms of any separate license agreement you may have executed
+   with Licensor regarding such Contributions.
+
+6. Trademarks. This License does not grant permission to use the trade
+   names, trademarks, service marks, or product names of the Licensor,
+   except as required for reasonable and customary use in describing the
+   origin of the Work and reproducing the content of the NOTICE file.
+
+7. Disclaimer of Warranty. Unless required by applicable law or
+   agreed to in writing, Licensor provides the Work (and each
+   Contributor provides its Contributions) on an &quot;AS IS&quot; BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+   implied, including, without limitation, any warranties or conditions
+   of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+   PARTICULAR PURPOSE. You are solely responsible for determining the
+   appropriateness of using or redistributing the Work and assume any
+   risks associated with Your exercise of permissions under this License.
+
+8. Limitation of Liability. In no event and under no legal theory,
+   whether in tort (including negligence), contract, or otherwise,
+   unless required by applicable law (such as deliberate and grossly
+   negligent acts) or agreed to in writing, shall any Contributor be
+   liable to You for damages, including any direct, indirect, special,
+   incidental, or consequential damages of any character arising as a
+   result of this License or out of the use or inability to use the
+   Work (including but not limited to damages for loss of goodwill,
+   work stoppage, computer failure or malfunction, or any and all
+   other commercial damages or losses), even if such Contributor
+   has been advised of the possibility of such damages.
+
+9. Accepting Warranty or Additional Liability. While redistributing
+   the Work or Derivative Works thereof, You may choose to offer,
+   and charge a fee for, acceptance of support, warranty, indemnity,
+   or other liability obligations and/or rights consistent with this
+   License. However, in accepting such obligations, You may act only
+   on Your own behalf and on Your sole responsibility, not on behalf
+   of any other Contributor, and only if You agree to indemnify,
+   defend, and hold each Contributor harmless for any liability
+   incurred by, or claims asserted against, such Contributor by reason
+   of your accepting any such warranty or additional liability.
+
+END OF TERMS AND CONDITIONS
+
+APPENDIX: How to apply the Apache License to your work.
+
+   To apply the Apache License to your work, attach the following
+   boilerplate notice, with the fields enclosed by brackets &quot;[]&quot;
+   replaced with your own identifying information. (Don&#x27;t include
+   the brackets!)  The text should be enclosed in the appropriate
+   comment syntax for the file format. We also recommend that a
+   file or class name and description of purpose be included on the
+   same &quot;printed page&quot; as the copyright notice for easier
+   identification within third-party archives.
+
+Copyright 2024 Trail of Bits
+
+Licensed under the Apache License, Version 2.0 (the &quot;License&quot;);
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an &quot;AS IS&quot; BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.</pre>
             </li>
             <li class="license">
                 <h3 id="Apache-2.0">Apache License 2.0</h3>
@@ -7321,8 +7319,8 @@ limitations under the License.
                         <li><a href=" https://github.com/dcchut/async-recursion ">async-recursion 1.1.1</a></li>
                         <li><a href=" https://github.com/image-rs/image-gif ">gif 0.13.3</a></li>
                         <li><a href=" https://github.com/rust-windowing/keyboard-types ">keyboard-types 0.8.3</a></li>
-                        <li><a href=" https://github.com/RustCrypto/RSA ">rsa 0.9.9</a></li>
-                        <li><a href=" https://github.com/SeaQL/sea-query ">sea-query 1.0.0-rc.29</a></li>
+                        <li><a href=" https://github.com/RustCrypto/RSA ">rsa 0.9.10</a></li>
+                        <li><a href=" https://github.com/SeaQL/sea-query ">sea-query 1.0.0-rc.30</a></li>
                         <li><a href=" https://github.com/image-rs/weezl ">weezl 0.1.12</a></li>
                     </ul>
                 <pre class="license-text">                              Apache License
@@ -7532,15 +7530,12 @@ limitations under the License.</pre>
                     <h4>Used by:</h4>
                     <ul class="license-used-by">
                         <li><a href=" https://github.com/servo/stylo ">servo_arc 0.4.3</a></li>
-                        <li><a href=" https://github.com/servo/stylo ">stylo_malloc_size_of 0.9.0</a></li>
-                        <li><a href=" https://github.com/servo/webrender ">peek-poke-derive 0.3.0</a></li>
-                        <li><a href=" https://github.com/servo/webrender ">peek-poke 0.3.0</a></li>
-                        <li><a href=" https://crates.io/crates/wr_malloc_size_of ">wr_malloc_size_of 0.2.2</a></li>
+                        <li><a href=" https://github.com/servo/stylo ">stylo_malloc_size_of 0.11.0</a></li>
                         <li><a href=" https://crates.io/crates/servo_malloc_size_of ">servo_malloc_size_of 0.0.1</a></li>
                         <li><a href=" https://github.com/gimli-rs/addr2line ">addr2line 0.25.1</a></li>
                         <li><a href=" https://github.com/tkaitchuck/ahash ">ahash 0.8.12</a></li>
                         <li><a href=" https://github.com/rust-fuzz/arbitrary/ ">arbitrary 1.4.2</a></li>
-                        <li><a href=" https://github.com/vorner/arc-swap ">arc-swap 1.8.0</a></li>
+                        <li><a href=" https://github.com/vorner/arc-swap ">arc-swap 1.8.1</a></li>
                         <li><a href=" https://github.com/bluss/arrayvec ">arrayvec 0.7.6</a></li>
                         <li><a href=" https://github.com/smol-rs/async-channel ">async-channel 2.5.0</a></li>
                         <li><a href=" https://github.com/smol-rs/async-executor ">async-executor 1.13.3</a></li>
@@ -7558,11 +7553,11 @@ limitations under the License.</pre>
                         <li><a href=" https://github.com/bitflags/bitflags ">bitflags 2.10.0</a></li>
                         <li><a href=" https://github.com/tuffy/bitstream-io ">bitstream-io 2.6.0</a></li>
                         <li><a href=" https://github.com/smol-rs/blocking ">blocking 1.6.2</a></li>
-                        <li><a href=" https://github.com/pacak/bpaf ">bpaf 0.9.20</a></li>
-                        <li><a href=" https://github.com/pacak/bpaf ">bpaf_derive 0.5.17</a></li>
+                        <li><a href=" https://github.com/pacak/bpaf ">bpaf 0.9.22</a></li>
+                        <li><a href=" https://github.com/pacak/bpaf ">bpaf_derive 0.5.21</a></li>
                         <li><a href=" https://github.com/fitzgen/bumpalo ">bumpalo 3.19.1</a></li>
                         <li><a href=" https://github.com/japaric/cast.rs ">cast 0.3.0</a></li>
-                        <li><a href=" https://github.com/rust-lang/cc-rs ">cc 1.2.51</a></li>
+                        <li><a href=" https://github.com/rust-lang/cc-rs ">cc 1.2.55</a></li>
                         <li><a href=" https://github.com/jethrogb/rust-cexpr ">cexpr 0.6.0</a></li>
                         <li><a href=" https://github.com/rust-lang/cfg-if ">cfg-if 1.0.4</a></li>
                         <li><a href=" https://github.com/servo/cgl-rs ">cgl 0.3.2</a></li>
@@ -7588,18 +7583,17 @@ limitations under the License.</pre>
                         <li><a href=" https://github.com/env-logger-rs/env_logger/ ">env_logger 0.8.4</a></li>
                         <li><a href=" https://github.com/indexmap-rs/equivalent ">equivalent 1.0.2</a></li>
                         <li><a href=" https://github.com/lambda-fairy/rust-errno ">errno 0.3.14</a></li>
-                        <li><a href=" https://github.com/servo/euclid ">euclid 0.22.11</a></li>
+                        <li><a href=" https://github.com/servo/euclid ">euclid 0.22.13</a></li>
                         <li><a href=" https://github.com/smol-rs/event-listener-strategy ">event-listener-strategy 0.5.4</a></li>
                         <li><a href=" https://github.com/smol-rs/event-listener ">event-listener 5.4.1</a></li>
                         <li><a href=" https://github.com/smol-rs/fastrand ">fastrand 2.3.0</a></li>
-                        <li><a href=" https://github.com/alexcrichton/filetime ">filetime 0.2.26</a></li>
-                        <li><a href=" https://github.com/rust-lang/cc-rs ">find-msvc-tools 0.1.6</a></li>
+                        <li><a href=" https://github.com/alexcrichton/filetime ">filetime 0.2.27</a></li>
+                        <li><a href=" https://github.com/rust-lang/cc-rs ">find-msvc-tools 0.1.9</a></li>
                         <li><a href=" https://github.com/bluss/fixedbitset ">fixedbitset 0.1.9</a></li>
-                        <li><a href=" https://github.com/rust-lang/flate2-rs ">flate2 1.1.5</a></li>
+                        <li><a href=" https://github.com/rust-lang/flate2-rs ">flate2 1.1.8</a></li>
                         <li><a href=" https://github.com/servo/rust-fnv ">fnv 1.0.7</a></li>
                         <li><a href=" https://github.com/servo/rust-url ">form_urlencoded 1.2.2</a></li>
                         <li><a href=" https://github.com/servo/rust-freetype ">freetype 0.7.2</a></li>
-                        <li><a href=" https://github.com/servo/futf ">futf 0.1.5</a></li>
                         <li><a href=" https://github.com/smol-rs/futures-lite ">futures-lite 2.6.1</a></li>
                         <li><a href=" https://github.com/rust-lang-nursery/futures-rs ">futures 0.1.31</a></li>
                         <li><a href=" https://github.com/servo/gaol ">gaol 0.2.1</a></li>
@@ -7614,7 +7608,7 @@ limitations under the License.</pre>
                         <li><a href=" https://github.com/withoutboats/heck ">heck 0.4.1</a></li>
                         <li><a href=" https://github.com/withoutboats/heck ">heck 0.5.0</a></li>
                         <li><a href=" https://github.com/hermit-os/hermit-rs ">hermit-abi 0.5.2</a></li>
-                        <li><a href=" https://github.com/servo/html5ever ">html5ever 0.36.1</a></li>
+                        <li><a href=" https://github.com/servo/html5ever ">html5ever 0.38.0</a></li>
                         <li><a href=" https://github.com/seanmonstar/httparse ">httparse 1.10.1</a></li>
                         <li><a href=" https://github.com/rustls/hyper-rustls ">hyper-rustls 0.27.7</a></li>
                         <li><a href=" https://github.com/servo/rust-url/ ">idna 1.1.0</a></li>
@@ -7637,7 +7631,7 @@ limitations under the License.</pre>
                         <li><a href=" https://github.com/Amanieu/parking_lot ">lock_api 0.4.14</a></li>
                         <li><a href=" https://github.com/rust-lang/log ">log 0.4.29</a></li>
                         <li><a href=" https://github.com/bholley/malloc_size_of_derive ">malloc_size_of_derive 0.1.3</a></li>
-                        <li><a href=" https://github.com/servo/html5ever ">markup5ever 0.36.1</a></li>
+                        <li><a href=" https://github.com/servo/html5ever ">markup5ever 0.38.0</a></li>
                         <li><a href=" https://github.com/gfx-rs/metal-rs ">metal 0.32.0</a></li>
                         <li><a href=" https://github.com/hyperium/mime ">mime 0.3.17</a></li>
                         <li><a href=" https://github.com/dignifiedquire/num-bigint ">num-bigint-dig 0.8.6</a></li>
@@ -7651,18 +7645,21 @@ limitations under the License.</pre>
                         <li><a href=" https://github.com/seanmonstar/num_cpus ">num_cpus 1.17.0</a></li>
                         <li><a href=" https://github.com/gimli-rs/object ">object 0.37.3</a></li>
                         <li><a href=" https://github.com/matklad/once_cell ">once_cell 1.21.3</a></li>
-                        <li><a href=" https://github.com/alexcrichton/openssl-probe ">openssl-probe 0.2.0</a></li>
+                        <li><a href=" https://github.com/rustls/openssl-probe ">openssl-probe 0.2.1</a></li>
                         <li><a href=" https://github.com/danieldg/ordered-stream ">ordered-stream 0.2.0</a></li>
                         <li><a href=" https://github.com/bluss/ordermap ">ordermap 0.3.5</a></li>
                         <li><a href=" https://github.com/smol-rs/parking ">parking 2.2.1</a></li>
                         <li><a href=" https://github.com/Amanieu/parking_lot ">parking_lot 0.12.5</a></li>
                         <li><a href=" https://github.com/Amanieu/parking_lot ">parking_lot_core 0.9.12</a></li>
+                        <li><a href=" https://github.com/servo/webrender ">peek-poke-derive 0.3.0</a></li>
+                        <li><a href=" https://github.com/servo/webrender ">peek-poke 0.3.0</a></li>
                         <li><a href=" https://github.com/servo/rust-url/ ">percent-encoding 2.3.2</a></li>
                         <li><a href=" https://github.com/bluss/petgraph ">petgraph 0.4.13</a></li>
                         <li><a href=" https://github.com/smol-rs/piper ">piper 0.2.4</a></li>
                         <li><a href=" https://github.com/rust-lang/pkg-config-rs ">pkg-config 0.3.32</a></li>
                         <li><a href=" https://github.com/image-rs/image-png ">png 0.17.16</a></li>
                         <li><a href=" https://github.com/smol-rs/polling ">polling 3.11.0</a></li>
+                        <li><a href=" https://github.com/jamesmunns/postcard ">postcard 1.1.3</a></li>
                         <li><a href=" https://github.com/rayon-rs/rayon ">rayon-core 1.13.0</a></li>
                         <li><a href=" https://github.com/rayon-rs/rayon ">rayon 1.11.0</a></li>
                         <li><a href=" https://github.com/rust-lang/regex ">regex-automata 0.4.13</a></li>
@@ -7670,13 +7667,13 @@ limitations under the License.</pre>
                         <li><a href=" https://github.com/rust-lang/regex ">regex 1.12.2</a></li>
                         <li><a href=" https://github.com/ron-rs/ron ">ron 0.10.1</a></li>
                         <li><a href=" https://github.com/RazrFalcon/roxmltree ">roxmltree 0.20.0</a></li>
-                        <li><a href=" https://github.com/rust-lang/rustc-demangle ">rustc-demangle 0.1.26</a></li>
+                        <li><a href=" https://github.com/rust-lang/rustc-demangle ">rustc-demangle 0.1.27</a></li>
                         <li><a href=" https://github.com/rust-lang-nursery/rustc-hash ">rustc-hash 1.1.0</a></li>
                         <li><a href=" https://github.com/djc/rustc-version-rs ">rustc_version 0.4.1</a></li>
                         <li><a href=" https://github.com/bytecodealliance/rustix ">rustix 0.38.44</a></li>
                         <li><a href=" https://github.com/bytecodealliance/rustix ">rustix 1.1.2</a></li>
                         <li><a href=" https://github.com/rustls/rustls-native-certs ">rustls-native-certs 0.8.3</a></li>
-                        <li><a href=" https://github.com/rustls/rustls ">rustls 0.23.35</a></li>
+                        <li><a href=" https://github.com/rustls/rustls ">rustls 0.23.36</a></li>
                         <li><a href=" https://github.com/alexcrichton/scoped-tls ">scoped-tls 1.0.1</a></li>
                         <li><a href=" https://github.com/bluss/scopeguard ">scopeguard 1.2.0</a></li>
                         <li><a href=" https://github.com/kornelski/rust-security-framework ">security-framework-sys 2.15.0</a></li>
@@ -7697,13 +7694,13 @@ limitations under the License.</pre>
                         <li><a href=" https://github.com/gdesmott/system-deps ">system-deps 6.2.2</a></li>
                         <li><a href=" https://github.com/alexcrichton/tar-rs ">tar 0.4.44</a></li>
                         <li><a href=" https://github.com/Stebalien/tempfile ">tempfile 3.23.0</a></li>
-                        <li><a href=" https://github.com/servo/tendril ">tendril 0.4.3</a></li>
+                        <li><a href=" https://github.com/servo/html5ever ">tendril 0.5.0</a></li>
                         <li><a href=" https://github.com/tikv/jemallocator ">tikv-jemalloc-sys 0.6.1+5.3.0-1-ge13ca993e8ccb9ba9847cc330696e02839f328f7</a></li>
                         <li><a href=" https://github.com/tikv/jemallocator ">tikv-jemallocator 0.6.1</a></li>
                         <li><a href=" https://github.com/bheisler/TinyTemplate ">tinytemplate 1.2.1</a></li>
                         <li><a href=" https://github.com/harfbuzz/ttf-parser ">ttf-parser 0.25.1</a></li>
                         <li><a href=" https://github.com/snapview/tungstenite-rs ">tungstenite 0.28.0</a></li>
-                        <li><a href=" https://github.com/seanmonstar/unicase ">unicase 2.8.1</a></li>
+                        <li><a href=" https://github.com/seanmonstar/unicase ">unicase 2.9.0</a></li>
                         <li><a href=" https://github.com/RazrFalcon/unicode-bidi-mirroring ">unicode-bidi-mirroring 0.4.0</a></li>
                         <li><a href=" https://github.com/servo/unicode-bidi ">unicode-bidi 0.3.18</a></li>
                         <li><a href=" https://github.com/RazrFalcon/unicode-ccc ">unicode-ccc 0.4.0</a></li>
@@ -7711,8 +7708,8 @@ limitations under the License.</pre>
                         <li><a href=" https://github.com/unicode-rs/unicode-segmentation ">unicode-segmentation 1.12.0</a></li>
                         <li><a href=" https://github.com/RazrFalcon/unicode-vo ">unicode-vo 0.1.0</a></li>
                         <li><a href=" https://github.com/unicode-rs/unicode-width ">unicode-width 0.2.2</a></li>
-                        <li><a href=" https://github.com/servo/rust-url ">url 2.5.7</a></li>
-                        <li><a href=" https://github.com/uuid-rs/uuid ">uuid 1.19.0</a></li>
+                        <li><a href=" https://github.com/servo/rust-url ">url 2.5.8</a></li>
+                        <li><a href=" https://github.com/uuid-rs/uuid ">uuid 1.20.0</a></li>
                         <li><a href=" https://github.com/SergioBenitez/version_check ">version_check 0.9.5</a></li>
                         <li><a href=" https://github.com/bytecodealliance/wasi ">wasi 0.11.1+wasi-snapshot-preview1</a></li>
                         <li><a href=" https://github.com/wasm-bindgen/wasm-bindgen/tree/master/crates/futures ">wasm-bindgen-futures 0.4.55</a></li>
@@ -7721,10 +7718,11 @@ limitations under the License.</pre>
                         <li><a href=" https://github.com/wasm-bindgen/wasm-bindgen/tree/master/crates/shared ">wasm-bindgen-shared 0.2.105</a></li>
                         <li><a href=" https://github.com/wasm-bindgen/wasm-bindgen ">wasm-bindgen 0.2.105</a></li>
                         <li><a href=" https://github.com/wasm-bindgen/wasm-bindgen/tree/master/crates/web-sys ">web-sys 0.3.82</a></li>
-                        <li><a href=" https://github.com/servo/html5ever ">web_atoms 0.2.0</a></li>
-                        <li><a href=" https://github.com/bytecodealliance/wit-bindgen ">wit-bindgen 0.46.0</a></li>
+                        <li><a href=" https://github.com/servo/html5ever ">web_atoms 0.2.3</a></li>
+                        <li><a href=" https://github.com/bytecodealliance/wit-bindgen ">wit-bindgen 0.51.0</a></li>
+                        <li><a href=" https://crates.io/crates/wr_malloc_size_of ">wr_malloc_size_of 0.2.2</a></li>
                         <li><a href=" https://github.com/Stebalien/xattr ">xattr 1.6.1</a></li>
-                        <li><a href=" https://github.com/servo/html5ever ">xml5ever 0.36.1</a></li>
+                        <li><a href=" https://github.com/servo/html5ever ">xml5ever 0.38.0</a></li>
                     </ul>
                 <pre class="license-text">                              Apache License
                         Version 2.0, January 2004
@@ -8779,7 +8777,7 @@ limitations under the License.</pre>
                         <li><a href=" https://github.com/RustCrypto/block-ciphers ">aes 0.8.4</a></li>
                         <li><a href=" https://github.com/RustCrypto/password-hashes/tree/master/argon2 ">argon2 0.5.3</a></li>
                         <li><a href=" https://github.com/RustCrypto/formats/tree/master/base16ct ">base16ct 0.2.0</a></li>
-                        <li><a href=" https://github.com/RustCrypto/formats ">base64ct 1.8.1</a></li>
+                        <li><a href=" https://github.com/RustCrypto/formats ">base64ct 1.8.3</a></li>
                         <li><a href=" https://github.com/RustCrypto/hashes ">blake2 0.10.6</a></li>
                         <li><a href=" https://github.com/RustCrypto/utils ">block-buffer 0.10.4</a></li>
                         <li><a href=" https://github.com/RustCrypto/utils ">block-padding 0.3.3</a></li>
@@ -8799,9 +8797,11 @@ limitations under the License.</pre>
                         <li><a href=" https://github.com/RustCrypto/universal-hashes ">ghash 0.5.1</a></li>
                         <li><a href=" https://github.com/RustCrypto/MACs ">hmac 0.12.1</a></li>
                         <li><a href=" https://github.com/RustCrypto/hybrid-array ">hybrid-array 0.2.3</a></li>
+                        <li><a href=" https://github.com/RustCrypto/hybrid-array ">hybrid-array 0.3.1</a></li>
                         <li><a href=" https://github.com/RustCrypto/utils ">inout 0.1.4</a></li>
                         <li><a href=" https://github.com/RustCrypto/sponges/tree/master/keccak ">keccak 0.1.5</a></li>
-                        <li><a href=" https://github.com/RustCrypto/KEMs ">ml-kem 0.2.1</a></li>
+                        <li><a href=" https://github.com/RustCrypto/KEMs ">ml-kem 0.2.2</a></li>
+                        <li><a href=" https://github.com/RustCrypto/AEADs ">ocb3 0.1.0</a></li>
                         <li><a href=" https://github.com/RustCrypto/utils ">opaque-debug 0.3.1</a></li>
                         <li><a href=" https://github.com/RustCrypto/elliptic-curves/tree/master/p256 ">p256 0.13.2</a></li>
                         <li><a href=" https://github.com/RustCrypto/elliptic-curves/tree/master/p384 ">p384 0.13.1</a></li>
@@ -9434,7 +9434,7 @@ APPENDIX: How to apply the Apache License to your work.
                 <h3 id="Apache-2.0">Apache License 2.0</h3>
                     <h4>Used by:</h4>
                     <ul class="license-used-by">
-                        <li><a href=" https://github.com/rust-random/getrandom ">getrandom 0.2.16</a></li>
+                        <li><a href=" https://github.com/rust-random/getrandom ">getrandom 0.2.17</a></li>
                         <li><a href=" https://github.com/rust-random/getrandom ">getrandom 0.3.4</a></li>
                         <li><a href=" https://github.com/rust-random/rand ">rand_chacha 0.3.1</a></li>
                     </ul>
@@ -11627,7 +11627,7 @@ limitations under the License.
                 <h3 id="Apache-2.0">Apache License 2.0</h3>
                     <h4>Used by:</h4>
                     <ul class="license-used-by">
-                        <li><a href=" https://github.com/Lokathor/bytemuck ">bytemuck 1.24.0</a></li>
+                        <li><a href=" https://github.com/Lokathor/bytemuck ">bytemuck 1.25.0</a></li>
                         <li><a href=" https://github.com/Lokathor/bytemuck ">bytemuck_derive 1.10.2</a></li>
                     </ul>
                 <pre class="license-text">Apache License
@@ -12340,13 +12340,13 @@ limitations under the License.
                         <li><a href=" https://github.com/zrzka/anes-rs ">anes 0.1.6</a></li>
                         <li><a href=" https://github.com/dtolnay/anyhow ">anyhow 1.0.100</a></li>
                         <li><a href=" https://github.com/1Password/arboard ">arboard 3.6.1</a></li>
-                        <li><a href=" https://github.com/Nullus157/async-compression ">async-compression 0.4.36</a></li>
+                        <li><a href=" https://github.com/Nullus157/async-compression ">async-compression 0.4.37</a></li>
                         <li><a href=" https://github.com/dtolnay/async-trait ">async-trait 0.1.89</a></li>
                         <li><a href=" https://github.com/odilia-app/atspi ">atspi-proxies 0.9.0</a></li>
                         <li><a href=" https://github.com/jrmuizel/build-parallel ">build-parallel 0.1.2</a></li>
                         <li><a href=" https://github.com/emk/cesu8-rs ">cesu8 1.1.0</a></li>
                         <li><a href=" https://github.com/linebender/color ">color 0.3.2</a></li>
-                        <li><a href=" https://github.com/Nullus157/async-compression ">compression-codecs 0.4.35</a></li>
+                        <li><a href=" https://github.com/Nullus157/async-compression ">compression-codecs 0.4.36</a></li>
                         <li><a href=" https://github.com/Nullus157/async-compression ">compression-core 0.4.31</a></li>
                         <li><a href=" https://github.com/soc/directories-rs ">directories 6.0.0</a></li>
                         <li><a href=" https://github.com/dirs-dev/dirs-sys-rs ">dirs-sys 0.5.0</a></li>
@@ -12359,14 +12359,15 @@ limitations under the License.
                         <li><a href=" https://github.com/emilk/egui ">egui 0.33.3</a></li>
                         <li><a href=" https://github.com/emilk/egui/tree/main/crates/egui_glow ">egui_glow 0.33.3</a></li>
                         <li><a href=" https://github.com/emilk/egui/tree/main/crates/emath ">emath 0.33.3</a></li>
+                        <li><a href=" https://github.com/dtolnay/enumn ">enumn 0.1.14</a></li>
                         <li><a href=" https://github.com/emilk/egui/tree/main/crates/epaint ">epaint 0.33.3</a></li>
                         <li><a href=" https://github.com/emilk/egui/tree/main/crates/epaint_default_fonts ">epaint_default_fonts 0.33.3</a></li>
                         <li><a href=" https://github.com/nical/etagere ">etagere 0.2.15</a></li>
                         <li><a href=" https://github.com/image-rs/fdeflate ">fdeflate 0.3.7</a></li>
                         <li><a href=" https://github.com/linebender/fearless_simd ">fearless_simd 0.3.0</a></li>
                         <li><a href=" https://github.com/mit-plv/fiat-crypto ">fiat-crypto 0.2.9</a></li>
-                        <li><a href=" https://gitlab.com/gilrs-project/gilrs ">gilrs-core 0.6.6</a></li>
-                        <li><a href=" https://gitlab.com/gilrs-project/gilrs ">gilrs 0.11.0</a></li>
+                        <li><a href=" https://gitlab.com/gilrs-project/gilrs ">gilrs-core 0.6.7</a></li>
+                        <li><a href=" https://gitlab.com/gilrs-project/gilrs ">gilrs 0.11.1</a></li>
                         <li><a href=" https://github.com/brendanzab/gl-rs/ ">gl_generator 0.14.0</a></li>
                         <li><a href=" https://github.com/zakarumych/gpu-alloc ">gpu-alloc-types 0.3.0</a></li>
                         <li><a href=" https://github.com/zakarumych/gpu-alloc ">gpu-alloc 0.6.0</a></li>
@@ -12381,11 +12382,9 @@ limitations under the License.
                         <li><a href=" https://github.com/dtolnay/itoa ">itoa 1.0.17</a></li>
                         <li><a href=" https://github.com/RustCrypto/traits/tree/master/kem ">kem 0.3.0-pre.0</a></li>
                         <li><a href=" https://github.com/brendanzab/gl-rs/ ">khronos_api 3.1.0</a></li>
-                        <li><a href=" https://github.com/rust-lang/libc ">libc 0.2.178</a></li>
+                        <li><a href=" https://github.com/rust-lang/libc ">libc 0.2.180</a></li>
                         <li><a href=" https://github.com/linebender/raw_resource_handle ">linebender_resource_handle 0.1.1</a></li>
                         <li><a href=" https://github.com/LukasKalbertodt/litrs ">litrs 1.0.0</a></li>
-                        <li><a href=" https://github.com/reem/rust-mac.git ">mac 0.1.1</a></li>
-                        <li><a href=" https://github.com/JohnTitor/mach2 ">mach2 0.4.3</a></li>
                         <li><a href=" https://github.com/JohnTitor/mach2 ">mach2 0.6.0</a></li>
                         <li><a href=" https://github.com/Frommi/miniz_oxide/tree/master/miniz_oxide ">miniz_oxide 0.8.9</a></li>
                         <li><a href=" https://github.com/gfx-rs/wgpu ">naga 26.0.0</a></li>
@@ -12418,13 +12417,13 @@ limitations under the License.
                         <li><a href=" https://github.com/taiki-e/pin-project ">pin-project-internal 1.1.10</a></li>
                         <li><a href=" https://github.com/taiki-e/pin-project-lite ">pin-project-lite 0.2.16</a></li>
                         <li><a href=" https://github.com/taiki-e/pin-project ">pin-project 1.1.10</a></li>
-                        <li><a href=" https://github.com/taiki-e/portable-atomic ">portable-atomic-util 0.2.4</a></li>
-                        <li><a href=" https://github.com/taiki-e/portable-atomic ">portable-atomic 1.13.0</a></li>
+                        <li><a href=" https://github.com/taiki-e/portable-atomic ">portable-atomic-util 0.2.5</a></li>
+                        <li><a href=" https://github.com/taiki-e/portable-atomic ">portable-atomic 1.13.1</a></li>
                         <li><a href=" https://github.com/dtolnay/prettyplease ">prettyplease 0.2.37</a></li>
-                        <li><a href=" https://github.com/dtolnay/proc-macro2 ">proc-macro2 1.0.104</a></li>
+                        <li><a href=" https://github.com/dtolnay/proc-macro2 ">proc-macro2 1.0.106</a></li>
                         <li><a href=" https://github.com/aclysma/profiling ">profiling-procmacros 1.0.17</a></li>
                         <li><a href=" https://github.com/aclysma/profiling ">profiling 1.0.17</a></li>
-                        <li><a href=" https://github.com/dtolnay/quote ">quote 1.0.42</a></li>
+                        <li><a href=" https://github.com/dtolnay/quote ">quote 1.0.44</a></li>
                         <li><a href=" https://github.com/r-efi/r-efi ">r-efi 5.3.0</a></li>
                         <li><a href=" https://github.com/rust-random/rand ">rand 0.8.5</a></li>
                         <li><a href=" https://github.com/rust-random/rand ">rand 0.9.2</a></li>
@@ -12436,31 +12435,31 @@ limitations under the License.
                         <li><a href=" https://github.com/rustls/rustls-platform-verifier ">rustls-platform-verifier-android 0.1.1</a></li>
                         <li><a href=" https://github.com/dtolnay/rustversion ">rustversion 1.0.22</a></li>
                         <li><a href=" https://github.com/dtolnay/ryu ">ryu 1.0.22</a></li>
-                        <li><a href=" https://github.com/SeaQL/sea-query ">sea-query-derive 1.0.0-rc.11</a></li>
+                        <li><a href=" https://github.com/SeaQL/sea-query ">sea-query-derive 1.0.0-rc.12</a></li>
                         <li><a href=" https://github.com/SeaQL/sea-query ">sea-query-rusqlite 0.8.0-rc.15</a></li>
                         <li><a href=" https://github.com/dtolnay/semver ">semver 1.0.27</a></li>
                         <li><a href=" https://github.com/serde-rs/serde ">serde 1.0.228</a></li>
                         <li><a href=" https://github.com/serde-rs/bytes ">serde_bytes 0.11.19</a></li>
                         <li><a href=" https://github.com/serde-rs/serde ">serde_core 1.0.228</a></li>
                         <li><a href=" https://github.com/serde-rs/serde ">serde_derive 1.0.228</a></li>
-                        <li><a href=" https://github.com/serde-rs/json ">serde_json 1.0.148</a></li>
+                        <li><a href=" https://github.com/serde-rs/json ">serde_json 1.0.149</a></li>
                         <li><a href=" https://github.com/dtolnay/serde-repr ">serde_repr 0.1.20</a></li>
                         <li><a href=" https://github.com/serde-rs/test ">serde_test 1.0.177</a></li>
                         <li><a href=" https://github.com/nox/serde_urlencoded ">serde_urlencoded 0.7.1</a></li>
                         <li><a href=" https://github.com/comex/rust-shlex ">shlex 1.3.0</a></li>
-                        <li><a href=" https://github.com/jedisct1/rust-siphash ">siphasher 1.0.1</a></li>
+                        <li><a href=" https://github.com/jedisct1/rust-siphash ">siphasher 1.0.2</a></li>
                         <li><a href=" https://github.com/gfx-rs/rspirv ">spirv 0.3.0+sdk-1.3.268.0</a></li>
                         <li><a href=" https://github.com/nical/rust_debug ">svg_fmt 0.4.5</a></li>
-                        <li><a href=" https://github.com/dtolnay/syn ">syn 2.0.111</a></li>
+                        <li><a href=" https://github.com/dtolnay/syn ">syn 2.0.114</a></li>
                         <li><a href=" https://github.com/Actyx/sync_wrapper ">sync_wrapper 1.0.2</a></li>
                         <li><a href=" https://github.com/gankra/thin-vec ">thin-vec 0.2.14</a></li>
                         <li><a href=" https://github.com/dtolnay/thiserror ">thiserror-impl 1.0.69</a></li>
                         <li><a href=" https://github.com/dtolnay/thiserror ">thiserror-impl 2.0.17</a></li>
                         <li><a href=" https://github.com/dtolnay/thiserror ">thiserror 1.0.69</a></li>
                         <li><a href=" https://github.com/dtolnay/thiserror ">thiserror 2.0.17</a></li>
-                        <li><a href=" https://github.com/time-rs/time ">time-core 0.1.6</a></li>
-                        <li><a href=" https://github.com/time-rs/time ">time-macros 0.2.24</a></li>
-                        <li><a href=" https://github.com/time-rs/time ">time 0.3.44</a></li>
+                        <li><a href=" https://github.com/time-rs/time ">time-core 0.1.7</a></li>
+                        <li><a href=" https://github.com/time-rs/time ">time-macros 0.2.25</a></li>
+                        <li><a href=" https://github.com/time-rs/time ">time 0.3.45</a></li>
                         <li><a href=" https://github.com/open-i18n/rust-unic/ ">unic-char-property 0.9.0</a></li>
                         <li><a href=" https://github.com/open-i18n/rust-unic/ ">unic-char-range 0.9.0</a></li>
                         <li><a href=" https://github.com/open-i18n/rust-unic/ ">unic-common 0.9.0</a></li>
@@ -12472,7 +12471,7 @@ limitations under the License.
                         <li><a href=" https://github.com/alacritty/vte ">utf8parse 0.2.2</a></li>
                         <li><a href=" https://github.com/linebender/vello ">vello_common 0.0.4</a></li>
                         <li><a href=" https://github.com/linebender/vello ">vello_cpu 0.0.4</a></li>
-                        <li><a href=" https://github.com/bytecodealliance/wasi-rs ">wasip2 1.0.1+wasi-0.2.4</a></li>
+                        <li><a href=" https://github.com/bytecodealliance/wasi-rs ">wasip2 1.0.2+wasi-0.2.9</a></li>
                         <li><a href=" https://github.com/gfx-rs/wgpu ">wgpu-core-deps-apple 26.0.0</a></li>
                         <li><a href=" https://github.com/gfx-rs/wgpu ">wgpu-core-deps-emscripten 26.0.0</a></li>
                         <li><a href=" https://github.com/gfx-rs/wgpu ">wgpu-core-deps-windows-linux-android 26.0.0</a></li>
@@ -12567,10 +12566,10 @@ limitations under the License.
                 <h3 id="Apache-2.0">Apache License 2.0</h3>
                     <p>
                         Used by
-                            <a href=" https://github.com/chronotope/chrono ">chrono 0.4.42</a>
+                            <a href=" https://github.com/chronotope/chrono ">chrono 0.4.43</a>
                     </p>
                 <pre class="license-text">Rust-chrono is dual-licensed under The MIT License [1] and
-Apache 2.0 License [2]. Copyright (c) 2014--2025, Kang Seonghoon and
+Apache 2.0 License [2]. Copyright (c) 2014--2026, Kang Seonghoon and
 contributors.
 
 Nota Bene: This is same as the Rust Project&#x27;s own license.
@@ -13611,8 +13610,8 @@ express Statement of Purpose.
                 <h3 id="CDLA-Permissive-2.0">Community Data License Agreement Permissive 2.0</h3>
                     <h4>Used by:</h4>
                     <ul class="license-used-by">
-                        <li><a href=" https://github.com/rustls/webpki-roots ">webpki-root-certs 1.0.4</a></li>
-                        <li><a href=" https://github.com/rustls/webpki-roots ">webpki-roots 1.0.4</a></li>
+                        <li><a href=" https://github.com/rustls/webpki-roots ">webpki-root-certs 1.0.5</a></li>
+                        <li><a href=" https://github.com/rustls/webpki-roots ">webpki-roots 1.0.5</a></li>
                     </ul>
                 <pre class="license-text"># Community Data License Agreement - Permissive - Version 2.0
 
@@ -13681,7 +13680,7 @@ insights.
                 <h3 id="ISC">ISC License</h3>
                     <p>
                         Used by
-                            <a href=" https://github.com/aws/aws-lc-rs ">aws-lc-sys 0.35.0</a>
+                            <a href=" https://github.com/aws/aws-lc-rs ">aws-lc-sys 0.37.0</a>
                     </p>
                 <pre class="license-text">/* Copyright (c) 2018, Google Inc.
  *
@@ -13796,7 +13795,7 @@ THIS SOFTWARE.
                 <h3 id="ISC">ISC License</h3>
                     <p>
                         Used by
-                            <a href=" https://github.com/rustls/webpki ">rustls-webpki 0.103.8</a>
+                            <a href=" https://github.com/rustls/webpki ">rustls-webpki 0.103.9</a>
                     </p>
                 <pre class="license-text">Except as otherwise noted, this project is licensed under the following
 (ISC-style) terms:
@@ -13823,7 +13822,7 @@ third-party/chromium/LICENSE.
                 <h3 id="ISC">ISC License</h3>
                     <p>
                         Used by
-                            <a href=" https://github.com/aws/aws-lc-rs ">aws-lc-rs 1.15.2</a>
+                            <a href=" https://github.com/aws/aws-lc-rs ">aws-lc-rs 1.15.4</a>
                     </p>
                 <pre class="license-text">ISC License:
 
@@ -14000,39 +13999,6 @@ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
-</pre>
-            </li>
-            <li class="license">
-                <h3 id="MIT">MIT License</h3>
-                    <p>
-                        Used by
-                            <a href=" https://github.com/SimonSapin/rust-std-candidates ">matches 0.1.10</a>
-                    </p>
-                <pre class="license-text">Copyright (c) 2014-2016 Simon Sapin
-
-Permission is hereby granted, free of charge, to any
-person obtaining a copy of this software and associated
-documentation files (the &quot;Software&quot;), to deal in the
-Software without restriction, including without
-limitation the rights to use, copy, modify, merge,
-publish, distribute, sublicense, and/or sell copies of
-the Software, and to permit persons to whom the Software
-is furnished to do so, subject to the following
-conditions:
-
-The above copyright notice and this permission notice
-shall be included in all copies or substantial portions
-of the Software.
-
-THE SOFTWARE IS PROVIDED &quot;AS IS&quot;, WITHOUT WARRANTY OF
-ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED
-TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
-PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT
-SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
-CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
-OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR
-IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-DEALINGS IN THE SOFTWARE.
 </pre>
             </li>
             <li class="license">
@@ -14262,14 +14228,14 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
                 <h3 id="MIT">MIT License</h3>
                     <h4>Used by:</h4>
                     <ul class="license-used-by">
-                        <li><a href=" https://github.com/smithay/wayland-rs ">wayland-backend 0.3.11</a></li>
-                        <li><a href=" https://github.com/smithay/wayland-rs ">wayland-client 0.31.11</a></li>
-                        <li><a href=" https://github.com/smithay/wayland-rs ">wayland-cursor 0.31.11</a></li>
-                        <li><a href=" https://github.com/smithay/wayland-rs ">wayland-protocols-plasma 0.3.9</a></li>
-                        <li><a href=" https://github.com/smithay/wayland-rs ">wayland-protocols-wlr 0.3.9</a></li>
-                        <li><a href=" https://github.com/smithay/wayland-rs ">wayland-protocols 0.32.9</a></li>
-                        <li><a href=" https://github.com/smithay/wayland-rs ">wayland-scanner 0.31.7</a></li>
-                        <li><a href=" https://github.com/smithay/wayland-rs ">wayland-sys 0.31.7</a></li>
+                        <li><a href=" https://github.com/smithay/wayland-rs ">wayland-backend 0.3.12</a></li>
+                        <li><a href=" https://github.com/smithay/wayland-rs ">wayland-client 0.31.12</a></li>
+                        <li><a href=" https://github.com/smithay/wayland-rs ">wayland-cursor 0.31.12</a></li>
+                        <li><a href=" https://github.com/smithay/wayland-rs ">wayland-protocols-plasma 0.3.10</a></li>
+                        <li><a href=" https://github.com/smithay/wayland-rs ">wayland-protocols-wlr 0.3.10</a></li>
+                        <li><a href=" https://github.com/smithay/wayland-rs ">wayland-protocols 0.32.10</a></li>
+                        <li><a href=" https://github.com/smithay/wayland-rs ">wayland-scanner 0.31.8</a></li>
+                        <li><a href=" https://github.com/smithay/wayland-rs ">wayland-sys 0.31.8</a></li>
                     </ul>
                 <pre class="license-text">Copyright (c) 2015 Elinor Berger
 
@@ -14371,7 +14337,7 @@ THE SOFTWARE IS PROVIDED &quot;AS IS&quot;, WITHOUT WARRANTY OF ANY KIND, EXPRES
                 <h3 id="MIT">MIT License</h3>
                     <p>
                         Used by
-                            <a href=" https://github.com/sdroege/async-tungstenite ">async-tungstenite 0.32.0</a>
+                            <a href=" https://github.com/sdroege/async-tungstenite ">async-tungstenite 0.32.1</a>
                     </p>
                 <pre class="license-text">Copyright (c) 2017 Daniel Abramov
 Copyright (c) 2017 Alexey Galakhov
@@ -14717,7 +14683,7 @@ THE SOFTWARE.
                 <h3 id="MIT">MIT License</h3>
                     <p>
                         Used by
-                            <a href=" https://github.com/tokio-rs/slab ">slab 0.4.11</a>
+                            <a href=" https://github.com/tokio-rs/slab ">slab 0.4.12</a>
                     </p>
                 <pre class="license-text">Copyright (c) 2019 Carl Lerche
 
@@ -14820,7 +14786,7 @@ DEALINGS IN THE SOFTWARE.
                     <ul class="license-used-by">
                         <li><a href=" https://github.com/tower-rs/tower ">tower-layer 0.3.3</a></li>
                         <li><a href=" https://github.com/tower-rs/tower ">tower-service 0.3.3</a></li>
-                        <li><a href=" https://github.com/tower-rs/tower ">tower 0.5.2</a></li>
+                        <li><a href=" https://github.com/tower-rs/tower ">tower 0.5.3</a></li>
                     </ul>
                 <pre class="license-text">Copyright (c) 2019 Tower Contributors
 
@@ -15054,12 +15020,12 @@ THE SOFTWARE.
                 <h3 id="MIT">MIT License</h3>
                     <h4>Used by:</h4>
                     <ul class="license-used-by">
-                        <li><a href=" https://github.com/z-galaxy/zbus/ ">zbus 5.12.0</a></li>
-                        <li><a href=" https://github.com/z-galaxy/zbus/ ">zbus_macros 5.12.0</a></li>
-                        <li><a href=" https://github.com/dbus2/zbus/ ">zbus_names 4.2.0</a></li>
-                        <li><a href=" https://github.com/dbus2/zbus/ ">zbus_xml 5.0.2</a></li>
-                        <li><a href=" https://github.com/dbus2/zbus/ ">zvariant 5.8.0</a></li>
-                        <li><a href=" https://github.com/dbus2/zbus/ ">zvariant_derive 5.8.0</a></li>
+                        <li><a href=" https://github.com/z-galaxy/zbus/ ">zbus 5.13.2</a></li>
+                        <li><a href=" https://github.com/z-galaxy/zbus/ ">zbus_macros 5.13.2</a></li>
+                        <li><a href=" https://github.com/z-galaxy/zbus/ ">zbus_names 4.3.1</a></li>
+                        <li><a href=" https://github.com/z-galaxy/zbus/ ">zbus_xml 5.1.0</a></li>
+                        <li><a href=" https://github.com/z-galaxy/zbus/ ">zvariant 5.9.2</a></li>
+                        <li><a href=" https://github.com/z-galaxy/zbus/ ">zvariant_derive 5.9.2</a></li>
                     </ul>
                 <pre class="license-text">Copyright (c) 2024 Zeeshan Ali Khan &amp; zbus contributors
 
@@ -15865,13 +15831,13 @@ SOFTWARE.</pre>
                         <li><a href=" http://github.com/SSheldon/rust-block ">block 0.1.6</a></li>
                         <li><a href=" http://github.com/SSheldon/rust-dispatch ">dispatch 0.2.0</a></li>
                         <li><a href=" https://github.com/rust-windowing/winit ">dpi 0.1.2</a></li>
-                        <li><a href=" https://github.com/rust-lang/compiler-builtins ">libm 0.2.15</a></li>
+                        <li><a href=" https://github.com/rust-lang/compiler-builtins ">libm 0.2.16</a></li>
                         <li><a href=" https://github.com/SSheldon/malloc_buf ">malloc_buf 0.0.6</a></li>
-                        <li><a href=" https://github.com/ohos-rs/ohos-rs ">napi-build-ohos 1.1.5</a></li>
-                        <li><a href=" https://github.com/ohos-rs/ohos-rs ">napi-derive-backend-ohos 1.1.5</a></li>
-                        <li><a href=" https://github.com/ohos-rs/ohos-rs ">napi-derive-ohos 1.1.5</a></li>
-                        <li><a href=" https://github.com/ohos-rs/ohos-rs ">napi-ohos 1.1.5</a></li>
-                        <li><a href=" https://github.com/ohos-rs/ohos-rs ">napi-sys-ohos 1.1.5</a></li>
+                        <li><a href=" https://github.com/ohos-rs/ohos-rs ">napi-build-ohos 1.1.6</a></li>
+                        <li><a href=" https://github.com/ohos-rs/ohos-rs ">napi-derive-backend-ohos 1.1.6</a></li>
+                        <li><a href=" https://github.com/ohos-rs/ohos-rs ">napi-derive-ohos 1.1.6</a></li>
+                        <li><a href=" https://github.com/ohos-rs/ohos-rs ">napi-ohos 1.1.6</a></li>
+                        <li><a href=" https://github.com/ohos-rs/ohos-rs ">napi-sys-ohos 1.1.6</a></li>
                         <li><a href=" https://github.com/rust-bakery/nom ">nom-language 0.1.0</a></li>
                         <li><a href=" https://github.com/madsmtm/objc2 ">objc-sys 0.3.5</a></li>
                         <li><a href=" https://github.com/madsmtm/objc2 ">objc2-app-kit 0.2.2</a></li>
@@ -15942,9 +15908,9 @@ SOFTWARE.
                 <h3 id="MIT">MIT License</h3>
                     <h4>Used by:</h4>
                     <ul class="license-used-by">
-                        <li><a href=" https://github.com/tokio-rs/tokio ">tokio-stream 0.1.17</a></li>
-                        <li><a href=" https://github.com/tokio-rs/tokio ">tokio-util 0.7.17</a></li>
-                        <li><a href=" https://github.com/tokio-rs/tokio ">tokio 1.48.0</a></li>
+                        <li><a href=" https://github.com/tokio-rs/tokio ">tokio-stream 0.1.18</a></li>
+                        <li><a href=" https://github.com/tokio-rs/tokio ">tokio-util 0.7.18</a></li>
+                        <li><a href=" https://github.com/tokio-rs/tokio ">tokio 1.49.0</a></li>
                     </ul>
                 <pre class="license-text">MIT License
 
@@ -16094,8 +16060,8 @@ SOFTWARE.
                         <li><a href=" https://github.com/AltF02/x11-rs.git ">x11-dl 2.21.0</a></li>
                         <li><a href=" https://github.com/luukvanderduim/zbus-lockstep ">zbus-lockstep-macros 0.5.2</a></li>
                         <li><a href=" https://github.com/luukvanderduim/zbus-lockstep ">zbus-lockstep 0.5.2</a></li>
-                        <li><a href=" https://github.com/dtolnay/zmij ">zmij 1.0.3</a></li>
-                        <li><a href=" https://github.com/dbus2/zbus/ ">zvariant_utils 3.2.1</a></li>
+                        <li><a href=" https://github.com/dtolnay/zmij ">zmij 1.0.19</a></li>
+                        <li><a href=" https://github.com/z-galaxy/zbus/ ">zvariant_utils 3.3.0</a></li>
                     </ul>
                 <pre class="license-text">Permission is hereby granted, free of charge, to any
 person obtaining a copy of this software and associated
@@ -16211,7 +16177,7 @@ SOFTWARE.
                     <h4>Used by:</h4>
                     <ul class="license-used-by">
                         <li><a href=" https://github.com/kornelski/xml-rs ">xml-rs 0.8.28</a></li>
-                        <li><a href=" https://github.com/kornelski/xml-rs ">xml 1.2.0</a></li>
+                        <li><a href=" https://github.com/kornelski/xml-rs ">xml 1.2.1</a></li>
                     </ul>
                 <pre class="license-text">The MIT License (MIT)
 
@@ -16276,7 +16242,7 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
                         <li><a href=" https://github.com/image-rs/byteorder-lite ">byteorder-lite 0.1.0</a></li>
                         <li><a href=" https://github.com/BurntSushi/byteorder ">byteorder 1.5.0</a></li>
                         <li><a href=" https://github.com/BurntSushi/fst ">fst 0.4.7</a></li>
-                        <li><a href=" https://github.com/BurntSushi/jiff ">jiff 0.2.17</a></li>
+                        <li><a href=" https://github.com/BurntSushi/jiff ">jiff 0.2.18</a></li>
                         <li><a href=" https://github.com/BurntSushi/memchr ">memchr 2.7.6</a></li>
                         <li><a href=" https://github.com/BurntSushi/quickcheck ">quickcheck 1.0.3</a></li>
                         <li><a href=" https://github.com/BurntSushi/walkdir ">walkdir 2.5.0</a></li>
@@ -16397,7 +16363,7 @@ THE SOFTWARE.
                 <h3 id="MIT">MIT License</h3>
                     <p>
                         Used by
-                            <a href=" https://gitlab.redox-os.org/redox-os/orbclient ">orbclient 0.3.49</a>
+                            <a href=" https://gitlab.redox-os.org/redox-os/orbclient ">orbclient 0.3.50</a>
                     </p>
                 <pre class="license-text">The MIT License (MIT)
 
@@ -16426,7 +16392,7 @@ SOFTWARE.
                 <h3 id="MIT">MIT License</h3>
                     <p>
                         Used by
-                            <a href=" https://github.com/ia0/data-encoding ">data-encoding 2.9.0</a>
+                            <a href=" https://github.com/ia0/data-encoding ">data-encoding 2.10.0</a>
                     </p>
                 <pre class="license-text">The MIT License (MIT)
 
@@ -16884,11 +16850,10 @@ SOFTWARE.</pre>
             </li>
             <li class="license">
                 <h3 id="MIT">MIT License</h3>
-                    <h4>Used by:</h4>
-                    <ul class="license-used-by">
-                        <li><a href=" https://github.com/tafia/quick-xml ">quick-xml 0.36.2</a></li>
-                        <li><a href=" https://github.com/tafia/quick-xml ">quick-xml 0.37.5</a></li>
-                    </ul>
+                    <p>
+                        Used by
+                            <a href=" https://github.com/tafia/quick-xml ">quick-xml 0.38.4</a>
+                    </p>
                 <pre class="license-text">The MIT License (MIT)
 
 Copyright (c) 2016 Johann Tuffe
@@ -18853,32 +18818,26 @@ Exhibit B - &quot;Incompatible With Secondary Licenses&quot; Notice
                         <li><a href=" https://crates.io/crates/servo-media-traits ">servo-media-traits 0.1.0</a></li>
                         <li><a href=" https://crates.io/crates/servo-media-webrtc ">servo-media-webrtc 0.1.0</a></li>
                         <li><a href=" https://crates.io/crates/servo-media ">servo-media 0.1.0</a></li>
-                        <li><a href=" https://github.com/servo/stylo ">stylo 0.9.0</a></li>
-                        <li><a href=" https://github.com/servo/stylo ">selectors 0.33.0</a></li>
-                        <li><a href=" https://github.com/servo/stylo ">stylo_atoms 0.9.0</a></li>
-                        <li><a href=" https://github.com/servo/stylo ">stylo_config 0.9.0</a></li>
-                        <li><a href=" https://github.com/servo/stylo ">stylo_derive 0.9.0</a></li>
-                        <li><a href=" https://github.com/servo/stylo ">stylo_dom 0.9.0</a></li>
-                        <li><a href=" https://github.com/servo/stylo ">stylo_static_prefs 0.9.0</a></li>
-                        <li><a href=" https://github.com/servo/stylo ">stylo_traits 0.9.0</a></li>
+                        <li><a href=" https://github.com/servo/stylo ">stylo 0.11.0</a></li>
+                        <li><a href=" https://github.com/servo/stylo ">selectors 0.35.0</a></li>
+                        <li><a href=" https://github.com/servo/stylo ">stylo_atoms 0.11.0</a></li>
+                        <li><a href=" https://github.com/servo/stylo ">stylo_config 0.11.0</a></li>
+                        <li><a href=" https://github.com/servo/stylo ">stylo_derive 0.11.0</a></li>
+                        <li><a href=" https://github.com/servo/stylo ">stylo_dom 0.11.0</a></li>
+                        <li><a href=" https://github.com/servo/stylo ">stylo_static_prefs 0.11.0</a></li>
+                        <li><a href=" https://github.com/servo/stylo ">stylo_traits 0.11.0</a></li>
                         <li><a href=" https://github.com/servo/stylo ">to_shmem 0.3.0</a></li>
                         <li><a href=" https://github.com/servo/stylo ">to_shmem_derive 0.1.0</a></li>
-                        <li><a href=" https://github.com/servo/webrender ">webrender 0.68.0</a></li>
-                        <li><a href=" https://github.com/servo/webrender ">webrender_api 0.68.0</a></li>
-                        <li><a href=" https://github.com/servo/webrender ">webrender_build 0.0.2</a></li>
-                        <li><a href=" https://crates.io/crates/wr_glyph_rasterizer ">wr_glyph_rasterizer 0.1.0</a></li>
                         <li><a href=" https://crates.io/crates/servo_allocator ">servo_allocator 0.0.1</a></li>
                         <li><a href=" https://crates.io/crates/background_hang_monitor ">background_hang_monitor 0.0.1</a></li>
                         <li><a href=" https://crates.io/crates/bluetooth ">bluetooth 0.0.1</a></li>
                         <li><a href=" https://crates.io/crates/canvas ">canvas 0.0.1</a></li>
-                        <li><a href=" https://crates.io/crates/compositing ">compositing 0.0.1</a></li>
                         <li><a href=" https://crates.io/crates/servo_config ">servo_config 0.0.1</a></li>
                         <li><a href=" https://crates.io/crates/servo_config_macro ">servo_config_macro 0.0.1</a></li>
                         <li><a href=" https://crates.io/crates/constellation ">constellation 0.0.1</a></li>
                         <li><a href=" https://crates.io/crates/deny_public_fields ">deny_public_fields 0.0.1</a></li>
                         <li><a href=" https://crates.io/crates/devtools ">devtools 0.0.1</a></li>
                         <li><a href=" https://crates.io/crates/dom_struct ">dom_struct 0.0.1</a></li>
-                        <li><a href=" https://crates.io/crates/domobject_derive ">domobject_derive 0.0.1</a></li>
                         <li><a href=" https://crates.io/crates/fonts ">fonts 0.0.1</a></li>
                         <li><a href=" https://crates.io/crates/servo_geometry ">servo_geometry 0.0.1</a></li>
                         <li><a href=" https://crates.io/crates/jstraceable_derive ">jstraceable_derive 0.0.1</a></li>
@@ -18886,9 +18845,9 @@ Exhibit B - &quot;Incompatible With Secondary Licenses&quot; Notice
                         <li><a href=" https://crates.io/crates/media ">media 0.0.1</a></li>
                         <li><a href=" https://crates.io/crates/metrics ">metrics 0.0.1</a></li>
                         <li><a href=" https://crates.io/crates/net ">net 0.0.1</a></li>
+                        <li><a href=" https://crates.io/crates/paint ">paint 0.0.1</a></li>
                         <li><a href=" https://crates.io/crates/pixels ">pixels 0.0.1</a></li>
                         <li><a href=" https://crates.io/crates/profile ">profile 0.0.1</a></li>
-                        <li><a href=" https://crates.io/crates/range ">range 0.0.1</a></li>
                         <li><a href=" https://crates.io/crates/script ">script 0.0.1</a></li>
                         <li><a href=" https://crates.io/crates/script_bindings ">script_bindings 0.0.1</a></li>
                         <li><a href=" https://crates.io/crates/libservo ">libservo 0.0.1</a></li>
@@ -18897,13 +18856,13 @@ Exhibit B - &quot;Incompatible With Secondary Licenses&quot; Notice
                         <li><a href=" https://crates.io/crates/base ">base 0.0.1</a></li>
                         <li><a href=" https://crates.io/crates/bluetooth_traits ">bluetooth_traits 0.0.1</a></li>
                         <li><a href=" https://crates.io/crates/canvas_traits ">canvas_traits 0.0.1</a></li>
-                        <li><a href=" https://crates.io/crates/compositing_traits ">compositing_traits 0.0.1</a></li>
                         <li><a href=" https://crates.io/crates/constellation_traits ">constellation_traits 0.0.1</a></li>
                         <li><a href=" https://crates.io/crates/devtools_traits ">devtools_traits 0.0.1</a></li>
                         <li><a href=" https://crates.io/crates/embedder_traits ">embedder_traits 0.0.1</a></li>
                         <li><a href=" https://crates.io/crates/fonts_traits ">fonts_traits 0.0.1</a></li>
                         <li><a href=" https://crates.io/crates/layout_api ">layout_api 0.0.1</a></li>
                         <li><a href=" https://crates.io/crates/net_traits ">net_traits 0.0.1</a></li>
+                        <li><a href=" https://crates.io/crates/paint_api ">paint_api 0.0.1</a></li>
                         <li><a href=" https://crates.io/crates/profile_traits ">profile_traits 0.0.1</a></li>
                         <li><a href=" https://crates.io/crates/script_traits ">script_traits 0.0.1</a></li>
                         <li><a href=" https://crates.io/crates/storage_traits ">storage_traits 0.0.1</a></li>
@@ -18917,7 +18876,7 @@ Exhibit B - &quot;Incompatible With Secondary Licenses&quot; Notice
                         <li><a href=" https://crates.io/crates/webgpu ">webgpu 0.0.1</a></li>
                         <li><a href=" https://crates.io/crates/webxr ">webxr 0.0.1</a></li>
                         <li><a href=" https://crates.io/crates/xpath ">xpath 0.0.1</a></li>
-                        <li><a href=" https://crates.io/crates/servoshell ">servoshell 0.0.4</a></li>
+                        <li><a href=" https://crates.io/crates/servoshell ">servoshell 0.0.5</a></li>
                         <li><a href=" https://crates.io/crates/deny_public_fields_tests ">deny_public_fields_tests 0.0.1</a></li>
                         <li><a href=" https://crates.io/crates/malloc_size_of_tests ">malloc_size_of_tests 0.0.1</a></li>
                         <li><a href=" https://crates.io/crates/profile_tests ">profile_tests 0.0.1</a></li>
@@ -18925,9 +18884,13 @@ Exhibit B - &quot;Incompatible With Secondary Licenses&quot; Notice
                         <li><a href=" https://crates.io/crates/style_tests ">style_tests 0.0.1</a></li>
                         <li><a href=" https://github.com/servo/app_units ">app_units 0.7.8</a></li>
                         <li><a href=" https://github.com/servo/dwrote-rs ">dwrote 0.11.5</a></li>
-                        <li><a href=" https://github.com/servo/mozjs/ ">mozjs_sys 0.140.5-7</a></li>
+                        <li><a href=" https://github.com/servo/mozjs/ ">mozjs_sys 0.140.5-10</a></li>
                         <li><a href=" https://github.com/soc/option-ext.git ">option-ext 0.2.0</a></li>
                         <li><a href=" https://hg.mozilla.org/mozilla-central/file/tip/testing/webdriver ">webdriver 0.53.0</a></li>
+                        <li><a href=" https://github.com/servo/webrender ">webrender 0.68.0</a></li>
+                        <li><a href=" https://github.com/servo/webrender ">webrender_api 0.68.0</a></li>
+                        <li><a href=" https://github.com/servo/webrender ">webrender_build 0.68.0</a></li>
+                        <li><a href=" https://crates.io/crates/wr_glyph_rasterizer ">wr_glyph_rasterizer 0.68.0</a></li>
                     </ul>
                 <pre class="license-text">Mozilla Public License Version 2.0
 &#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;
@@ -19308,7 +19271,7 @@ Exhibit B - &quot;Incompatible With Secondary Licenses&quot; Notice
                 <h3 id="MPL-2.0">Mozilla Public License 2.0</h3>
                     <p>
                         Used by
-                            <a href=" https://github.com/servo/mozjs/ ">mozjs 0.14.4</a>
+                            <a href=" https://github.com/servo/mozjs/ ">mozjs 0.14.8</a>
                     </p>
                 <pre class="license-text">Mozilla Public License Version 2.0
 &#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;
@@ -19813,7 +19776,7 @@ OTHER DEALINGS IN THE FONT SOFTWARE.
                 <h3 id="OpenSSL">OpenSSL License</h3>
                     <p>
                         Used by
-                            <a href=" https://github.com/aws/aws-lc-rs ">aws-lc-sys 0.35.0</a>
+                            <a href=" https://github.com/aws/aws-lc-rs ">aws-lc-sys 0.37.0</a>
                     </p>
                 <pre class="license-text">/* Copyright (C) 1995-1998 Eric Young (eay@cryptsoft.com)
  * All rights reserved.

--- a/support/android/apk/servoapp/build.gradle.kts
+++ b/support/android/apk/servoapp/build.gradle.kts
@@ -17,7 +17,7 @@ android {
         minSdk = 30
         targetSdk = 33
         versionCode = generatedVersionCode
-        versionName = "0.0.4"
+        versionName = "0.0.5"
     }
 
     compileOptions {

--- a/support/openharmony/entry/oh-package.json5
+++ b/support/openharmony/entry/oh-package.json5
@@ -5,7 +5,7 @@
   "name": "servoshell",
   "description": "Please describe the basic information.",
   "main": "",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "dependencies": {
     "libservoshell.so": "file:./src/main/cpp/types/libentry"
   }

--- a/support/openharmony/oh-package.json5
+++ b/support/openharmony/oh-package.json5
@@ -8,6 +8,6 @@
   "name": "servoshell",
   "description": "Servo browser shell",
   "main": "",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "dependencies": {}
 }

--- a/support/windows/Servo.wxs.mako
+++ b/support/windows/Servo.wxs.mako
@@ -6,7 +6,7 @@
            UpgradeCode="060cd15d-eab1-4614-b438-3988e3efdcf1"
            Language="1033"
            Codepage="1252"
-           Version="0.0.4">
+           Version="0.0.5">
     <Package Id="*"
              Keywords="Installer"
              Description="Servo Tech Demo Installer"


### PR DESCRIPTION
This version bump is a bit delayed, since I forgot to open the PR before FOSDEM. The actual release will thus likely not be based on this commit, but backported to the release branch, to stay in sync with our monthly report.
There still has been no resolution on the `0.1` version bump situation, hence another bump of the patch version.

Testing: Not required
