### PR TITLE
script: WeakReferenceable as Rc-ed dom_struct

### DIFF
--- a/components/script/dom/abort/abortsignal.rs
+++ b/components/script/dom/abort/abortsignal.rs
@@ -16,7 +16,7 @@ use js::rust::wrappers2::JS_SetPendingException;
 use js::rust::{HandleObject, HandleValue, MutableHandleValue};
 use script_bindings::cell::DomRefCell;
 use script_bindings::inheritance::Castable;
-use script_bindings::reflector::reflect_dom_object_with_proto_and_cx;
+use script_bindings::reflector::reflect_weak_referenceable_dom_object_with_proto;
 use script_bindings::weakref::WeakRef;
 
 use crate::dom::bindings::codegen::Bindings::AbortSignalBinding::AbortSignalMethods;
@@ -108,11 +108,11 @@ impl AbortSignal {
         global: &GlobalScope,
         proto: Option<HandleObject>,
     ) -> DomRoot<AbortSignal> {
-        reflect_dom_object_with_proto_and_cx(
-            Box::new(AbortSignal::new_inherited()),
+        reflect_weak_referenceable_dom_object_with_proto(
+            cx,
+            Rc::new(AbortSignal::new_inherited()),
             global,
             proto,
-            cx,
         )
     }
 

--- a/components/script/dom/bindings/import.rs
+++ b/components/script/dom/bindings/import.rs
@@ -4,6 +4,7 @@
 
 pub(crate) mod base {
     pub(crate) use std::ptr;
+    pub(crate) use std::rc::Rc;
 
     pub(crate) use js::context::JSContext;
     #[expect(unused_imports)]
@@ -14,7 +15,9 @@ pub(crate) mod base {
 pub(crate) mod module {
     pub(crate) use script_bindings::codegen::PrototypeList;
     pub(crate) use script_bindings::conversions::IDLInterface;
-    pub(crate) use script_bindings::reflector::{DomObjectIteratorWrap, DomObjectWrap, Reflector};
+    pub(crate) use script_bindings::reflector::{
+        DomObjectIteratorWrap, DomObjectWrap, Reflector, WeakReferenceableDomObjectWrap,
+    };
     pub(crate) use script_bindings::utils::DOMClass;
 
     pub(crate) use super::base::*;

--- a/components/script/dom/eventsource.rs
+++ b/components/script/dom/eventsource.rs
@@ -4,6 +4,7 @@
 
 use std::cell::Cell;
 use std::mem;
+use std::rc::Rc;
 use std::str::{Chars, FromStr};
 use std::time::Duration;
 
@@ -20,7 +21,7 @@ use net_traits::request::{CacheMode, CorsSettings, Destination, RequestBuilder, 
 use net_traits::{FetchMetadata, FilteredMetadata, NetworkError, ResourceFetchTiming};
 use script_bindings::cell::DomRefCell;
 use script_bindings::conversions::SafeToJSValConvertible;
-use script_bindings::reflector::reflect_dom_object_with_proto_and_cx;
+use script_bindings::reflector::reflect_weak_referenceable_dom_object_with_proto;
 use servo_url::ServoUrl;
 use stylo_atoms::Atom;
 
@@ -531,11 +532,11 @@ impl EventSource {
         url: ServoUrl,
         with_credentials: bool,
     ) -> DomRoot<EventSource> {
-        reflect_dom_object_with_proto_and_cx(
-            Box::new(EventSource::new_inherited(url, with_credentials)),
+        reflect_weak_referenceable_dom_object_with_proto(
+            cx,
+            Rc::new(EventSource::new_inherited(url, with_credentials)),
             global,
             proto,
-            cx,
         )
     }
 

--- a/components/script/dom/file/blob.rs
+++ b/components/script/dom/file/blob.rs
@@ -14,7 +14,7 @@ use js::rust::HandleObject;
 use js::typedarray::{ArrayBufferU8, Uint8};
 use net_traits::filemanager_thread::RelativePos;
 use rustc_hash::FxHashMap;
-use script_bindings::reflector::{Reflector, reflect_dom_object_with_proto_and_cx};
+use script_bindings::reflector::{Reflector, reflect_weak_referenceable_dom_object_with_proto};
 use servo_base::id::{BlobId, BlobIndex};
 use servo_constellation_traits::{BlobData, BlobImpl};
 use uuid::Uuid;
@@ -57,11 +57,11 @@ impl Blob {
         proto: Option<HandleObject>,
         blob_impl: BlobImpl,
     ) -> DomRoot<Blob> {
-        let dom_blob = reflect_dom_object_with_proto_and_cx(
-            Box::new(Blob::new_inherited(&blob_impl)),
+        let dom_blob = reflect_weak_referenceable_dom_object_with_proto(
+            cx,
+            Rc::new(Blob::new_inherited(&blob_impl)),
             global,
             proto,
-            cx,
         );
         global.track_blob(&dom_blob, blob_impl);
         dom_blob

--- a/components/script/dom/file/file.rs
+++ b/components/script/dom/file/file.rs
@@ -2,13 +2,14 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
+use std::rc::Rc;
 use std::time::SystemTime;
 
 use dom_struct::dom_struct;
 use embedder_traits::SelectedFile;
 use js::context::JSContext;
 use js::rust::HandleObject;
-use script_bindings::reflector::reflect_dom_object_with_proto_and_cx;
+use script_bindings::reflector::reflect_weak_referenceable_dom_object_with_proto;
 use servo_base::id::{FileId, FileIndex};
 use servo_constellation_traits::{BlobImpl, SerializableFile};
 use time::{Duration, OffsetDateTime};
@@ -80,8 +81,9 @@ impl File {
         modified: Option<SystemTime>,
         webkit_relative_path: USVString,
     ) -> DomRoot<File> {
-        let file = reflect_dom_object_with_proto_and_cx(
-            Box::new(File::new_inherited(
+        let file = reflect_weak_referenceable_dom_object_with_proto(
+            cx,
+            Rc::new(File::new_inherited(
                 &blob_impl,
                 name,
                 modified,
@@ -89,7 +91,6 @@ impl File {
             )),
             global,
             proto,
-            cx,
         );
         global.track_file(&file, blob_impl);
         file

--- a/components/script/dom/globalscope/messageport.rs
+++ b/components/script/dom/globalscope/messageport.rs
@@ -14,7 +14,7 @@ use js::rust::wrappers2::JS_NewObject;
 use js::rust::{CustomAutoRooter, CustomAutoRooterGuard, HandleValue};
 use rustc_hash::FxHashMap;
 use script_bindings::conversions::SafeToJSValConvertible;
-use script_bindings::reflector::reflect_dom_object_with_cx;
+use script_bindings::reflector::reflect_weak_referenceable_dom_object;
 use servo_base::id::{MessagePortId, MessagePortIndex};
 use servo_constellation_traits::{MessagePortImpl, PortMessageTask};
 
@@ -58,7 +58,11 @@ impl MessagePort {
     /// <https://html.spec.whatwg.org/multipage/#create-a-new-messageport-object>
     pub(crate) fn new(cx: &mut JSContext, owner: &GlobalScope) -> DomRoot<MessagePort> {
         let port_id = MessagePortId::new();
-        reflect_dom_object_with_cx(Box::new(MessagePort::new_inherited(port_id)), owner, cx)
+        reflect_weak_referenceable_dom_object(
+            cx,
+            Rc::new(MessagePort::new_inherited(port_id)),
+            owner,
+        )
     }
 
     /// Create a new port for an incoming transfer-received one.
@@ -68,15 +72,15 @@ impl MessagePort {
         transferred_port: MessagePortId,
         entangled_port: Option<MessagePortId>,
     ) -> DomRoot<MessagePort> {
-        reflect_dom_object_with_cx(
-            Box::new(MessagePort {
+        reflect_weak_referenceable_dom_object(
+            cx,
+            Rc::new(MessagePort {
                 message_port_id: transferred_port,
                 eventtarget: EventTarget::new_inherited(),
                 detached: Cell::new(false),
                 entangled_port: RefCell::new(entangled_port),
             }),
             owner,
-            cx,
         )
     }
 

--- a/components/script/dom/html/htmlaudioelement.rs
+++ b/components/script/dom/html/htmlaudioelement.rs
@@ -2,6 +2,8 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
+use std::rc::Rc;
+
 use dom_struct::dom_struct;
 use html5ever::{LocalName, Prefix, QualName, local_name, ns};
 use js::context::JSContext;
@@ -42,9 +44,9 @@ impl HTMLAudioElement {
         document: &Document,
         proto: Option<HandleObject>,
     ) -> DomRoot<HTMLAudioElement> {
-        Node::reflect_node_with_proto(
+        Node::reflect_weak_referenceable_node_with_proto(
             cx,
-            Box::new(HTMLAudioElement::new_inherited(
+            Rc::new(HTMLAudioElement::new_inherited(
                 local_name, prefix, document,
             )),
             document,

--- a/components/script/dom/html/htmlcanvaselement.rs
+++ b/components/script/dom/html/htmlcanvaselement.rs
@@ -110,9 +110,9 @@ impl HTMLCanvasElement {
         document: &Document,
         proto: Option<HandleObject>,
     ) -> DomRoot<HTMLCanvasElement> {
-        Node::reflect_node_with_proto(
+        Node::reflect_weak_referenceable_node_with_proto(
             cx,
-            Box::new(HTMLCanvasElement::new_inherited(
+            Rc::new(HTMLCanvasElement::new_inherited(
                 local_name, prefix, document,
             )),
             document,

--- a/components/script/dom/html/htmlvideoelement.rs
+++ b/components/script/dom/html/htmlvideoelement.rs
@@ -95,9 +95,9 @@ impl HTMLVideoElement {
         document: &Document,
         proto: Option<HandleObject>,
     ) -> DomRoot<HTMLVideoElement> {
-        Node::reflect_node_with_proto(
+        Node::reflect_weak_referenceable_node_with_proto(
             cx,
-            Box::new(HTMLVideoElement::new_inherited(
+            Rc::new(HTMLVideoElement::new_inherited(
                 local_name, prefix, document,
             )),
             document,

--- a/components/script/dom/media/mediaquerylist.rs
+++ b/components/script/dom/media/mediaquerylist.rs
@@ -7,7 +7,7 @@ use std::rc::Rc;
 
 use dom_struct::dom_struct;
 use js::context::JSContext;
-use script_bindings::reflector::reflect_dom_object_with_cx;
+use script_bindings::reflector::reflect_weak_referenceable_dom_object;
 use style::media_queries::MediaList;
 use style::stylesheets::CustomMediaEvaluator;
 use style_traits::ToCss;
@@ -52,10 +52,10 @@ impl MediaQueryList {
         document: &Document,
         media_query_list: MediaList,
     ) -> DomRoot<MediaQueryList> {
-        reflect_dom_object_with_cx(
-            Box::new(MediaQueryList::new_inherited(document, media_query_list)),
-            document.window(),
+        reflect_weak_referenceable_dom_object(
             cx,
+            Rc::new(MediaQueryList::new_inherited(document, media_query_list)),
+            document.window(),
         )
     }
 }

--- a/components/script/dom/node/node.rs
+++ b/components/script/dom/node/node.rs
@@ -9,6 +9,7 @@ use std::cmp::Ordering;
 use std::default::Default;
 use std::f64::consts::PI;
 use std::ops::Deref;
+use std::rc::Rc;
 use std::slice::from_ref;
 use std::{cmp, fmt, iter};
 
@@ -36,7 +37,10 @@ use script_bindings::codegen::GenericBindings::ElementBinding::ElementMethods;
 use script_bindings::codegen::GenericBindings::EventBinding::EventMethods;
 use script_bindings::codegen::GenericBindings::ProcessingInstructionBinding::ProcessingInstructionMethods;
 use script_bindings::codegen::InheritTypes::{DocumentFragmentTypeId, TextTypeId};
-use script_bindings::reflector::{DomObject, DomObjectWrap, reflect_dom_object_with_proto_and_cx};
+use script_bindings::reflector::{
+    DomObject, DomObjectWrap, WeakReferenceableDomObjectWrap, reflect_dom_object_with_proto_and_cx,
+    reflect_weak_referenceable_dom_object_with_proto,
+};
 use script_traits::DocumentActivity;
 use servo_base::id::PipelineId;
 use servo_config::pref;
@@ -2213,6 +2217,19 @@ impl Node {
     {
         let window = document.window();
         reflect_dom_object_with_proto_and_cx(node, window, proto, cx)
+    }
+
+    pub(crate) fn reflect_weak_referenceable_node_with_proto<N>(
+        cx: &mut JSContext,
+        node: Rc<N>,
+        document: &Document,
+        proto: Option<HandleObject>,
+    ) -> DomRoot<N>
+    where
+        N: DerivedFrom<Node> + DomObject + WeakReferenceableDomObjectWrap<crate::DomTypeHolder>,
+    {
+        let window = document.window();
+        reflect_weak_referenceable_dom_object_with_proto(cx, node, window, proto)
     }
 
     pub(crate) fn new_inherited(doc: &Document) -> Node {

--- a/components/script/dom/range/range.rs
+++ b/components/script/dom/range/range.rs
@@ -5,6 +5,7 @@
 use std::cell::RefCell;
 use std::cmp::{Ordering, PartialOrd};
 use std::iter;
+use std::rc::Rc;
 
 use app_units::Au;
 use dom_struct::dom_struct;
@@ -14,7 +15,7 @@ use js::jsapi::JSTracer;
 use js::rust::HandleObject;
 use script_bindings::cell::DomRefCell;
 use script_bindings::dom::UnrootedDom;
-use script_bindings::reflector::reflect_dom_object_with_proto_and_cx;
+use script_bindings::reflector::reflect_weak_referenceable_dom_object_with_proto;
 use style_traits::CSSPixel;
 
 use crate::dom::abstractrange::{AbstractRange, BoundaryPoint, bp_position};
@@ -124,8 +125,9 @@ impl Range {
         end_container: &Node,
         end_offset: u32,
     ) -> DomRoot<Range> {
-        let range = reflect_dom_object_with_proto_and_cx(
-            Box::new(Range::new_inherited(
+        let range = reflect_weak_referenceable_dom_object_with_proto(
+            cx,
+            Rc::new(Range::new_inherited(
                 start_container,
                 start_offset,
                 end_container,
@@ -133,7 +135,6 @@ impl Range {
             )),
             document.window(),
             proto,
-            cx,
         );
         start_container.ranges().push(WeakRef::new(&range));
         if start_container != end_container {

--- a/components/script/dom/range/staticrange.rs
+++ b/components/script/dom/range/staticrange.rs
@@ -2,10 +2,12 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
+use std::rc::Rc;
+
 use dom_struct::dom_struct;
 use js::context::JSContext;
 use js::rust::HandleObject;
-use script_bindings::reflector::reflect_dom_object_with_proto_and_cx;
+use script_bindings::reflector::reflect_weak_referenceable_dom_object_with_proto;
 
 use crate::dom::abstractrange::AbstractRange;
 use crate::dom::bindings::codegen::Bindings::StaticRangeBinding::{
@@ -55,8 +57,9 @@ impl StaticRange {
         proto: Option<HandleObject>,
         init: &StaticRangeInit,
     ) -> DomRoot<StaticRange> {
-        reflect_dom_object_with_proto_and_cx(
-            Box::new(StaticRange::new_inherited(
+        reflect_weak_referenceable_dom_object_with_proto(
+            cx,
+            Rc::new(StaticRange::new_inherited(
                 &init.startContainer,
                 init.startOffset,
                 &init.endContainer,
@@ -64,7 +67,6 @@ impl StaticRange {
             )),
             document.window(),
             proto,
-            cx,
         )
     }
 }

--- a/components/script/dom/url/url.rs
+++ b/components/script/dom/url/url.rs
@@ -3,6 +3,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 use std::default::Default;
+use std::rc::Rc;
 
 use dom_struct::dom_struct;
 use js::context::JSContext;
@@ -13,7 +14,7 @@ use net_traits::filemanager_thread::FileManagerThreadMsg;
 use profile_traits::generic_channel;
 use script_bindings::cell::DomRefCell;
 use script_bindings::cformat;
-use script_bindings::reflector::{Reflector, reflect_dom_object_with_proto_and_cx};
+use script_bindings::reflector::{Reflector, reflect_weak_referenceable_dom_object_with_proto};
 use servo_base::generic_channel::GenericSend;
 use servo_url::{ImmutableOrigin, ServoUrl};
 use url::Url;
@@ -58,7 +59,12 @@ impl URL {
         proto: Option<HandleObject>,
         url: ServoUrl,
     ) -> DomRoot<URL> {
-        reflect_dom_object_with_proto_and_cx(Box::new(URL::new_inherited(url)), global, proto, cx)
+        reflect_weak_referenceable_dom_object_with_proto(
+            cx,
+            Rc::new(URL::new_inherited(url)),
+            global,
+            proto,
+        )
     }
 
     pub(crate) fn query_pairs(&self) -> Vec<(String, String)> {

--- a/components/script/dom/webgl/webglrenderingcontext.rs
+++ b/components/script/dom/webgl/webglrenderingcontext.rs
@@ -3,7 +3,6 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 use std::cell::Cell;
-#[cfg(feature = "webxr")]
 use std::rc::Rc;
 use std::{cmp, ptr};
 

--- a/components/script/dom/webgl/webglrenderingcontext.rs
+++ b/components/script/dom/webgl/webglrenderingcontext.rs
@@ -23,7 +23,9 @@ use js::typedarray::{
 use pixels::{self, Alpha, PixelFormat, Snapshot, SnapshotPixelFormat};
 use script_bindings::cell::{DomRefCell, Ref, RefMut};
 use script_bindings::conversions::SafeToJSValConvertible;
-use script_bindings::reflector::{AssociatedMemory, Reflector, reflect_dom_object_with_cx};
+use script_bindings::reflector::{
+    AssociatedMemory, Reflector, reflect_weak_referenceable_dom_object,
+};
 use serde::{Deserialize, Serialize};
 use servo_base::generic_channel::GenericSharedMemory;
 use servo_base::{Epoch, generic_channel};
@@ -301,7 +303,11 @@ impl WebGLRenderingContext {
             size,
             attrs,
         ) {
-            Ok(ctx) => Some(reflect_dom_object_with_cx(Box::new(ctx), window, cx)),
+            Ok(ctx) => Some(reflect_weak_referenceable_dom_object(
+                cx,
+                Rc::new(ctx),
+                window,
+            )),
             Err(msg) => {
                 error!("Couldn't create WebGLRenderingContext: {}", msg);
                 let event = WebGLContextEvent::new(

--- a/components/script/dom/webgl/webglshader.rs
+++ b/components/script/dom/webgl/webglshader.rs
@@ -5,13 +5,14 @@
 // https://www.khronos.org/registry/webgl/specs/latest/1.0/webgl.idl
 use std::cell::Cell;
 use std::os::raw::c_int;
+use std::rc::Rc;
 use std::sync::Once;
 
 use dom_struct::dom_struct;
 use js::context::JSContext;
 use mozangle::shaders::{BuiltInResources, CompileOptions, Output, ShaderValidator};
 use script_bindings::cell::DomRefCell;
-use script_bindings::reflector::reflect_dom_object_with_cx;
+use script_bindings::reflector::reflect_weak_referenceable_dom_object;
 use script_bindings::weakref::WeakRef;
 use servo_canvas_traits::webgl::{
     GLLimits, GlType, WebGLCommand, WebGLError, WebGLResult, WebGLSLVersion, WebGLShaderId,
@@ -119,10 +120,10 @@ impl WebGLShader {
         id: WebGLShaderId,
         shader_type: u32,
     ) -> DomRoot<Self> {
-        reflect_dom_object_with_cx(
-            Box::new(WebGLShader::new_inherited(context, id, shader_type)),
-            &*context.global(),
+        reflect_weak_referenceable_dom_object(
             cx,
+            Rc::new(WebGLShader::new_inherited(context, id, shader_type)),
+            &*context.global(),
         )
     }
 }

--- a/components/script/dom/webgpu/gpucanvascontext.rs
+++ b/components/script/dom/webgpu/gpucanvascontext.rs
@@ -4,6 +4,7 @@
 
 use std::borrow::Cow;
 use std::cell::{Cell, RefCell};
+use std::rc::Rc;
 
 use arrayvec::ArrayVec;
 use dom_struct::dom_struct;
@@ -11,7 +12,7 @@ use js::context::JSContext;
 use pixels::Snapshot;
 use script_bindings::cformat;
 use script_bindings::codegen::GenericBindings::WebGPUBinding::GPUTextureFormat;
-use script_bindings::reflector::{Reflector, reflect_dom_object_with_cx};
+use script_bindings::reflector::{Reflector, reflect_weak_referenceable_dom_object};
 use servo_base::{Epoch, generic_channel};
 use webgpu_traits::{
     ContextConfiguration, PRESENTATION_BUFFER_COUNT, PendingTexture, WebGPU, WebGPUContextId,
@@ -127,14 +128,14 @@ impl GPUCanvasContext {
         canvas: &HTMLCanvasElement,
         channel: WebGPU,
     ) -> DomRoot<Self> {
-        reflect_dom_object_with_cx(
-            Box::new(GPUCanvasContext::new_inherited(
+        reflect_weak_referenceable_dom_object(
+            cx,
+            Rc::new(GPUCanvasContext::new_inherited(
                 global,
                 HTMLCanvasElementOrOffscreenCanvas::HTMLCanvasElement(Dom::from_ref(canvas)),
                 channel,
             )),
             global,
-            cx,
         )
     }
 }

--- a/components/script/dom/webgpu/gpudevice.rs
+++ b/components/script/dom/webgpu/gpudevice.rs
@@ -12,7 +12,7 @@ use js::jsapi::{HandleObject, Heap, JSObject};
 use js::realm::CurrentRealm;
 use script_bindings::cell::DomRefCell;
 use script_bindings::cformat;
-use script_bindings::reflector::reflect_dom_object_with_cx;
+use script_bindings::reflector::reflect_weak_referenceable_dom_object;
 use webgpu_traits::{
     PopError, WebGPU, WebGPUComputePipeline, WebGPUComputePipelineResponse, WebGPUDevice,
     WebGPUPoppedErrorScopeResponse, WebGPUQueue, WebGPURenderPipeline,
@@ -167,8 +167,9 @@ impl GPUDevice {
         let features = GPUSupportedFeatures::Constructor(cx, global, None, features).unwrap();
         let adapter_info = GPUAdapterInfo::clone_from(cx, global, &adapter.Info());
         let lost_promise = Promise::new(cx, global);
-        let device = reflect_dom_object_with_cx(
-            Box::new(GPUDevice::new_inherited(
+        let device = reflect_weak_referenceable_dom_object(
+            cx,
+            Rc::new(GPUDevice::new_inherited(
                 channel,
                 adapter,
                 &features,
@@ -180,7 +181,6 @@ impl GPUDevice {
                 lost_promise,
             )),
             global,
-            cx,
         );
         queue.set_device(cx, &device);
         device.extensions.set(*extensions);

--- a/components/script/dom/webrtc/rtcpeerconnection.rs
+++ b/components/script/dom/webrtc/rtcpeerconnection.rs
@@ -11,7 +11,7 @@ use js::realm::CurrentRealm;
 use js::rust::HandleObject;
 use rustc_hash::FxHashMap;
 use script_bindings::cell::DomRefCell;
-use script_bindings::reflector::reflect_dom_object_with_proto_and_cx;
+use script_bindings::reflector::reflect_weak_referenceable_dom_object_with_proto;
 use servo_media::ServoMedia;
 use servo_media::streams::MediaStreamType;
 use servo_media::streams::registry::MediaStreamId;
@@ -183,11 +183,11 @@ impl RTCPeerConnection {
         proto: Option<HandleObject>,
         config: &RTCConfiguration,
     ) -> DomRoot<RTCPeerConnection> {
-        let this = reflect_dom_object_with_proto_and_cx(
-            Box::new(RTCPeerConnection::new_inherited()),
+        let this = reflect_weak_referenceable_dom_object_with_proto(
+            cx,
+            Rc::new(RTCPeerConnection::new_inherited()),
             window,
             proto,
-            cx,
         );
         let signaller = this.make_signaller();
         *this.controller.borrow_mut() = Some(ServoMedia::get().create_webrtc(signaller));

--- a/components/script/dom/websocket.rs
+++ b/components/script/dom/websocket.rs
@@ -5,6 +5,7 @@
 use std::borrow::ToOwned;
 use std::cell::Cell;
 use std::ptr::{self, NonNull};
+use std::rc::Rc;
 
 use dom_struct::dom_struct;
 use ipc_channel::router::ROUTER;
@@ -25,7 +26,7 @@ use net_traits::{
 use profile_traits::ipc as ProfiledIpc;
 use script_bindings::cell::DomRefCell;
 use script_bindings::conversions::SafeToJSValConvertible;
-use script_bindings::reflector::{DomObject, reflect_dom_object_with_proto_and_cx};
+use script_bindings::reflector::{DomObject, reflect_weak_referenceable_dom_object_with_proto};
 use servo_base::generic_channel::{LazyCallback, lazy_callback};
 use servo_constellation_traits::BlobImpl;
 use servo_url::{ImmutableOrigin, ServoUrl};
@@ -136,11 +137,11 @@ impl WebSocket {
         url: ServoUrl,
         sender: LazyCallback<WebSocketDomAction>,
     ) -> DomRoot<WebSocket> {
-        let websocket = reflect_dom_object_with_proto_and_cx(
-            Box::new(WebSocket::new_inherited(url, sender)),
+        let websocket = reflect_weak_referenceable_dom_object_with_proto(
+            cx,
+            Rc::new(WebSocket::new_inherited(url, sender)),
             global,
             proto,
-            cx,
         );
         if let Some(window) = global.downcast::<Window>() {
             window.Document().track_websocket(&websocket);

--- a/components/script/dom/webxr/xrsession.rs
+++ b/components/script/dom/webxr/xrsession.rs
@@ -8,7 +8,7 @@ use std::f64::consts::{FRAC_PI_2, PI};
 use std::rc::Rc;
 use std::{mem, ptr};
 
-use script_bindings::reflector::reflect_dom_object_with_cx;
+use script_bindings::reflector::reflect_weak_referenceable_dom_object;
 use servo_base::cross_process_instant::CrossProcessInstant;
 use dom_struct::dom_struct;
 use js::context::JSContext;
@@ -165,15 +165,15 @@ impl XRSession {
         };
         let render_state = XRRenderState::new(cx, window, 0.1, 1000.0, ivfov, None, Vec::new());
         let input_sources = XRInputSourceArray::new(cx, window);
-        let ret = reflect_dom_object_with_cx(
-            Box::new(XRSession::new_inherited(
+        let ret = reflect_weak_referenceable_dom_object(
+            cx,
+            Rc::new(XRSession::new_inherited(
                 session,
                 &render_state,
                 &input_sources,
                 mode,
             )),
             window,
-            cx,
         );
         ret.attach_event_handler();
         ret.setup_raf_loop(frame_receiver);

--- a/components/script_bindings/codegen/codegen.py
+++ b/components/script_bindings/codegen/codegen.py
@@ -2669,8 +2669,6 @@ class CGDOMJSClass(CGThing):
                 args["resolveHook"] = "Some(resolve_global)"
                 args["mayResolveHook"] = "Some(may_resolve_global)"
             args["traceHook"] = "js::jsapi::JS_GlobalObjectTraceHook"
-        elif self.descriptor.weakReferenceable:
-            args["slots"] = "2"
         return f"""
 static CLASS_OPS: ThreadUnsafeOnceLock<JSClassOps> = ThreadUnsafeOnceLock::new();
 pub static Class: ThreadUnsafeOnceLock<DOMJSClass> = ThreadUnsafeOnceLock::new();
@@ -3041,7 +3039,10 @@ def DomTypes(descriptors: list[Descriptor],
                 ]
 
             if descriptor.concrete and not descriptor.isGlobal():
-                traits += ["crate::reflector::DomObjectWrap<Self>"]
+                if descriptor.weakReferenceable:
+                    traits += ["crate::reflector::WeakReferenceableDomObjectWrap<Self>"]
+                else:
+                    traits += ["crate::reflector::DomObjectWrap<Self>"]
 
         if not descriptor.interface.isCallback() and not descriptor.interface.isIteratorInterface():
             nonConstMembers = [m for m in descriptor.interface.members if not m.isConst()]
@@ -3359,7 +3360,7 @@ class CGWrapMethod(CGAbstractMethod):
         args = [Argument('&mut JSContext', 'cx'),
                 Argument('&D::GlobalScope', 'scope'),
                 Argument('Option<HandleObject>', 'given_proto'),
-                Argument(f"Box<{descriptor.concreteType}>", 'object')]
+                Argument(f"{'Rc' if descriptor.weakReferenceable else 'Box'}<{descriptor.concreteType}>", 'object')]
         retval = f'DomRoot<{descriptor.concreteType}>'
         CGAbstractMethod.__init__(self, descriptor, 'Wrap', retval, args,
                                   pub=True, unsafe=True,
@@ -3376,7 +3377,6 @@ class CGWrapMethod(CGAbstractMethod):
 
         is_proxy = python_bool_to_rust(self.descriptor.proxy)
         cross_origin = python_bool_to_rust(self.descriptor.proxy and self.descriptor.isMaybeCrossOriginObject())
-        weak_referenceable = python_bool_to_rust(self.descriptor.weakReferenceable)
         if self.descriptor.proxy:
             proxy_handler = f"Some(RegisterBindings::proxy_handlers::{self.descriptor.interface.identifier.name}.load(std::sync::atomic::Ordering::Acquire))"
         else:
@@ -3392,7 +3392,6 @@ class CGWrapMethod(CGAbstractMethod):
                 let init = crate::wrap::WrapConfig {{
                     is_maybe_cross_origin_object: {cross_origin},
                     is_proxy: {is_proxy},
-                    weak_referenceable: {weak_referenceable},
                     proxy_handler: {proxy_handler},
                     prototype_id: {prototype_id},
                     class: {c},
@@ -3401,7 +3400,7 @@ class CGWrapMethod(CGAbstractMethod):
                     has_legacy_unforgeable_members: {python_bool_to_rust(self.descriptor.hasLegacyUnforgeableMembers)},
                 }};
 
-                crate::wrap::wrap::<_, D>(cx, scope, given_proto, object, init)
+                crate::wrap::wrap::<_, D>(cx, scope, given_proto, Root::new(MaybeUnreflectedDom::from_{"rc" if self.descriptor.weakReferenceable else "box"}(object)), init)
         """)
 
 
@@ -3551,6 +3550,29 @@ impl DomObjectWrap<crate::DomTypeHolder> for {firstCap(ifaceName)} {{
         &GlobalScope,
         Option<HandleObject>,
         Box<Self>,
+    ) -> Root<Dom<Self>> = {bindingModule}::Wrap::<crate::DomTypeHolder>;
+}}
+"""
+
+
+class CGWeakReferenceableDomObjectWrap(CGThing):
+    """
+    Class for codegen of an implementation of the WeakReferenceableDomObjectWrap trait.
+    """
+    def __init__(self, descriptor: Descriptor) -> None:
+        CGThing.__init__(self)
+        self.descriptor = descriptor
+
+    def define(self) -> str:
+        ifaceName = self.descriptor.interface.identifier.name
+        bindingModule = f"crate::dom::bindings::codegen::GenericBindings::{toBindingPath(self.descriptor)}"
+        return f"""
+impl WeakReferenceableDomObjectWrap<crate::DomTypeHolder> for {firstCap(ifaceName)} {{
+    const WRAP: unsafe fn(
+        &mut JSContext,
+        &GlobalScope,
+        Option<HandleObject>,
+        Rc<Self>,
     ) -> Root<Dom<Self>> = {bindingModule}::Wrap::<crate::DomTypeHolder>;
 }}
 """
@@ -6861,7 +6883,7 @@ def finalizeHook(descriptor: Descriptor, hookName: str, context: str) -> str:
     if descriptor.isGlobal():
         release = "finalize_global(obj, this);"
     elif descriptor.weakReferenceable:
-        release = "finalize_weak_referenceable(obj, this);"
+        release = "finalize_weak_referenceable(this);"
     else:
         release = "finalize_common(this);"
     return release
@@ -8061,7 +8083,10 @@ class CGConcreteBindingRoot(CGThing):
             if d.interface.isIteratorInterface():
                 cgthings.append(CGDomObjectIteratorWrap(d))
             elif d.concrete and not d.isGlobal():
-                cgthings.append(CGDomObjectWrap(d))
+                if d.weakReferenceable:
+                    cgthings.append(CGWeakReferenceableDomObjectWrap(d))
+                else:
+                    cgthings.append(CGDomObjectWrap(d))
 
             if d.weakReferenceable:
                 cgthings.append(CGWeakReferenceableTrait(d))
@@ -9272,6 +9297,7 @@ impl {base} {{
         descriptors = config.getDescriptors(register=True, isCallback=False)
         topTypes = []
         hierarchy = defaultdict(list)
+        weak_referenceable: set[str] = {d.name for d in descriptors if d.weakReferenceable}
         for descriptor in descriptors:
             name = descriptor.name
             upcast = descriptor.hasDescendants()
@@ -9283,6 +9309,12 @@ impl {base} {{
             if downcast:
                 assert descriptor.interface.parent is not None
                 hierarchy[descriptor.interface.parent.identifier.name].append(name)
+
+                if descriptor.interface.parent.identifier.name in weak_referenceable and not descriptor.weakReferenceable:
+                    raise Exception(f"Interface {name} derives from "
+                                    f"{descriptor.interface.parent.identifier.name}, "
+                                    f"which is weak referenceable, so {name} must "
+                                    f"also be weak referenceable.")
 
         typeIdCode: list = []
         topTypeVariants = [

--- a/components/script_bindings/reflector.rs
+++ b/components/script_bindings/reflector.rs
@@ -3,6 +3,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 use std::cell::Cell;
+use std::rc::Rc;
 
 use js::context::JSContext;
 use js::jsapi::{AddAssociatedMemory, Heap, JSObject, MemoryUse, RemoveAssociatedMemory};
@@ -239,6 +240,20 @@ pub trait DomObjectWrap<D: DomTypes>: Sized + DomObject + DomGlobalGeneric<D> {
     ) -> Root<Dom<Self>>;
 }
 
+/// A trait to provide a function pointer to wrap function for DOM objects.
+pub trait WeakReferenceableDomObjectWrap<D: DomTypes>:
+    Sized + DomObject + DomGlobalGeneric<D>
+{
+    /// Function pointer to the general wrap function type
+    #[expect(clippy::type_complexity)]
+    const WRAP: unsafe fn(
+        &mut js::context::JSContext,
+        &D::GlobalScope,
+        Option<HandleObject>,
+        Rc<Self>,
+    ) -> Root<Dom<Self>>;
+}
+
 /// A trait to provide a function pointer to wrap function for
 /// DOM iterator interfaces.
 pub trait DomObjectIteratorWrap<D: DomTypes>: DomObjectWrap<D> + JSTraceable + Iterable {
@@ -308,6 +323,37 @@ pub fn reflect_dom_object_with_proto_and_cx<D, T, U>(
 where
     D: DomTypes,
     T: DomObject + DomObjectWrap<D>,
+    U: DerivedFrom<D::GlobalScope>,
+{
+    let global_scope = global.upcast();
+    unsafe { T::WRAP(cx, global_scope, proto, obj) }
+}
+
+/// Create the reflector for a new DOM object and yield ownership to the
+/// reflector.
+pub fn reflect_weak_referenceable_dom_object<D, T, U>(
+    cx: &mut JSContext,
+    obj: Rc<T>,
+    global: &U,
+) -> DomRoot<T>
+where
+    D: DomTypes,
+    T: DomObject + WeakReferenceableDomObjectWrap<D>,
+    U: DerivedFrom<D::GlobalScope>,
+{
+    let global_scope = global.upcast();
+    unsafe { T::WRAP(cx, global_scope, None, obj) }
+}
+
+pub fn reflect_weak_referenceable_dom_object_with_proto<D, T, U>(
+    cx: &mut JSContext,
+    obj: Rc<T>,
+    global: &U,
+    proto: Option<HandleObject>,
+) -> DomRoot<T>
+where
+    D: DomTypes,
+    T: DomObject + WeakReferenceableDomObjectWrap<D>,
     U: DerivedFrom<D::GlobalScope>,
 {
     let global_scope = global.upcast();

--- a/components/script_bindings/root.rs
+++ b/components/script_bindings/root.rs
@@ -5,6 +5,7 @@
 use std::cell::UnsafeCell;
 use std::hash::{Hash, Hasher};
 use std::ops::Deref;
+use std::rc::Rc;
 use std::{fmt, mem, ptr};
 
 use js::gc::{Handle, Traceable as JSTraceable};
@@ -257,6 +258,16 @@ where
     pub unsafe fn from_box(value: Box<T>) -> Self {
         Self {
             ptr: Box::leak(value).into(),
+        }
+    }
+
+    /// Create a new MaybeUnreflectedDom value from the given RCed DOM object.
+    ///
+    /// # Safety
+    /// TODO: unclear why this is marked unsafe.
+    pub unsafe fn from_rc(value: Rc<T>) -> Self {
+        Self {
+            ptr: ptr::NonNull::new(Rc::into_raw(value) as *mut T).unwrap(),
         }
     }
 }

--- a/components/script_bindings/weakref.rs
+++ b/components/script_bindings/weakref.rs
@@ -11,73 +11,30 @@
 //! slot. When all associated `WeakRef` values are dropped, the
 //! `WeakBox` itself is dropped too.
 
-use std::cell::Cell;
 use std::hash::{Hash, Hasher};
-use std::ops::Drop;
+use std::rc::{Rc, Weak};
 use std::{mem, ptr};
 
-use js::glue::JS_GetReservedSlot;
-use js::jsapi::{JS_SetReservedSlot, JSTracer};
-use js::jsval::{PrivateValue, UndefinedValue};
-use libc::c_void;
+use js::jsapi::JSTracer;
 use malloc_size_of::{MallocSizeOf, MallocSizeOfOps};
 
 use crate::JSTraceable;
 use crate::reflector::DomObject;
 use crate::root::DomRoot;
 
-/// The index of the slot wherein a pointer to the weak holder cell is
-/// stored for weak-referenceable bindings. We use slot 1 for holding it,
-/// this is unsafe for globals, we disallow weak-referenceable globals
-/// directly in codegen.
-pub(crate) const DOM_WEAK_SLOT: u32 = 1;
-
 /// A weak reference to a JS-managed DOM object.
+#[derive(Clone)]
 #[cfg_attr(crown, crown::unrooted_must_root_lint::allow_unrooted_interior)]
-pub struct WeakRef<T: WeakReferenceable> {
-    ptr: ptr::NonNull<WeakBox<T>>,
-}
-
-/// The inner box of weak references, public for the finalization in codegen.
-#[cfg_attr(crown, crown::unrooted_must_root_lint::must_root)]
-pub struct WeakBox<T: WeakReferenceable> {
-    /// The reference count. When it reaches zero, the `value` field should
-    /// have already been set to `None`. The pointee contributes one to the count.
-    pub count: Cell<usize>,
-    /// The pointer to the JS-managed object, set to None when it is collected.
-    pub value: Cell<Option<ptr::NonNull<T>>>,
-}
+pub struct WeakRef<T: WeakReferenceable>(Weak<T>);
 
 /// Trait implemented by weak-referenceable interfaces.
 pub trait WeakReferenceable: DomObject + Sized {
     /// Downgrade a DOM object reference to a weak one.
     fn downgrade(&self) -> WeakRef<Self> {
-        unsafe {
-            let object = self.reflector().get_jsobject().get();
-            let mut slot = UndefinedValue();
-            JS_GetReservedSlot(object, DOM_WEAK_SLOT, &mut slot);
-            let mut ptr = slot.to_private() as *mut WeakBox<Self>;
-            if ptr.is_null() {
-                trace!("Creating new WeakBox holder for {:p}.", self);
-                ptr = Box::into_raw(Box::new(WeakBox {
-                    count: Cell::new(1),
-                    value: Cell::new(Some(ptr::NonNull::from(self))),
-                }));
-                let val = PrivateValue(ptr as *const c_void);
-                JS_SetReservedSlot(object, DOM_WEAK_SLOT, &val);
-            }
-            let box_ = &*ptr;
-            assert!(box_.value.get().is_some());
-            let new_count = box_.count.get() + 1;
-            trace!(
-                "Incrementing WeakBox refcount for {:p} to {}.",
-                self, new_count
-            );
-            box_.count.set(new_count);
-            WeakRef {
-                ptr: ptr::NonNull::new_unchecked(ptr),
-            }
-        }
+        let rc = unsafe { Rc::from_raw(self as *const Self) };
+        let weak = WeakRef(Rc::downgrade(&rc));
+        mem::forget(rc);
+        weak
     }
 }
 
@@ -85,7 +42,7 @@ impl<T: WeakReferenceable> Eq for WeakRef<T> {}
 
 impl<T: WeakReferenceable> Hash for WeakRef<T> {
     fn hash<H: Hasher>(&self, state: &mut H) {
-        self.ptr.hash(state);
+        self.0.as_ptr().hash(state);
     }
 }
 
@@ -99,26 +56,12 @@ impl<T: WeakReferenceable> WeakRef<T> {
 
     /// DomRoot a weak reference. Returns `None` if the object was already collected.
     pub fn root(&self) -> Option<DomRoot<T>> {
-        unsafe { &*self.ptr.as_ptr() }
-            .value
-            .get()
-            .map(|ptr| unsafe { DomRoot::from_ref(&*ptr.as_ptr()) })
+        self.0.upgrade().map(|x| DomRoot::from_ref(&*x))
     }
 
     /// Return whether the weakly-referenced object is still alive.
     pub fn is_alive(&self) -> bool {
-        unsafe { &*self.ptr.as_ptr() }.value.get().is_some()
-    }
-}
-
-impl<T: WeakReferenceable> Clone for WeakRef<T> {
-    fn clone(&self) -> WeakRef<T> {
-        unsafe {
-            let box_ = &*self.ptr.as_ptr();
-            let new_count = box_.count.get() + 1;
-            box_.count.set(new_count);
-            WeakRef { ptr: self.ptr }
-        }
+        self.0.strong_count() > 0
     }
 }
 
@@ -130,20 +73,15 @@ impl<T: WeakReferenceable> MallocSizeOf for WeakRef<T> {
 
 impl<T: WeakReferenceable> PartialEq for WeakRef<T> {
     fn eq(&self, other: &Self) -> bool {
-        unsafe {
-            (*self.ptr.as_ptr()).value.get().map(ptr::NonNull::as_ptr) ==
-                (*other.ptr.as_ptr()).value.get().map(ptr::NonNull::as_ptr)
-        }
+        self.0.ptr_eq(&other.0)
     }
 }
 
 impl<T: WeakReferenceable> PartialEq<T> for WeakRef<T> {
     fn eq(&self, other: &T) -> bool {
-        unsafe {
-            match self.ptr.as_ref().value.get() {
-                Some(ptr) => ptr::eq(ptr.as_ptr(), other),
-                None => false,
-            }
+        match self.0.upgrade() {
+            Some(ptr) => ptr::eq(Rc::as_ptr(&ptr), other),
+            None => false,
         }
     }
 }
@@ -151,23 +89,5 @@ impl<T: WeakReferenceable> PartialEq<T> for WeakRef<T> {
 unsafe impl<T: WeakReferenceable> JSTraceable for WeakRef<T> {
     unsafe fn trace(&self, _: *mut JSTracer) {
         // Do nothing.
-    }
-}
-
-impl<T: WeakReferenceable> Drop for WeakRef<T> {
-    fn drop(&mut self) {
-        unsafe {
-            let (count, value) = {
-                let weak_box = &*self.ptr.as_ptr();
-                assert!(weak_box.count.get() > 0);
-                let count = weak_box.count.get() - 1;
-                weak_box.count.set(count);
-                (count, weak_box.value.get())
-            };
-            if count == 0 {
-                assert!(value.is_none());
-                mem::drop(Box::from_raw(self.ptr.as_ptr()));
-            }
-        }
     }
 }

--- a/components/script_bindings/wrap.rs
+++ b/components/script_bindings/wrap.rs
@@ -22,7 +22,6 @@ use crate::import::module::JS_GetReservedSlot;
 use crate::proxyhandler::ensure_expando_object;
 use crate::root::{DomRoot, MaybeUnreflectedDom, Root};
 use crate::utils::DOM_PROTO_UNFORGEABLE_HOLDER_SLOT;
-use crate::weakref::DOM_WEAK_SLOT;
 use crate::{DomObject, DomTypes, MutDomObject};
 
 type ProtoObjectFn = fn(&mut js::context::JSContext, HandleObject, MutableHandleObject);
@@ -31,7 +30,6 @@ type ProtoObjectFn = fn(&mut js::context::JSContext, HandleObject, MutableHandle
 pub(crate) struct WrapConfig {
     pub(crate) is_maybe_cross_origin_object: bool,
     pub(crate) is_proxy: bool,
-    pub(crate) weak_referenceable: bool,
     pub(crate) proxy_handler: Option<*const c_void>,
     pub(crate) prototype_id: PrototypeList::ID,
     pub(crate) class: Option<&'static JSClass>,
@@ -46,12 +44,10 @@ pub(crate) unsafe fn wrap<T: MutDomObject, D: DomTypes>(
     cx: &mut JSContext,
     scope: &D::GlobalScope,
     given_proto: Option<js::rust::Handle<*mut JSObject>>,
-    object: Box<T>,
+    raw: Root<MaybeUnreflectedDom<T>>,
     config: WrapConfig,
 ) -> DomRoot<T> {
     unsafe {
-        let raw = Root::new(MaybeUnreflectedDom::from_box(object));
-
         let scope = scope.reflector().get_jsobject();
         assert!(!scope.get().is_null());
         assert!(((*get_object_class(scope.get())).flags & JSCLASS_IS_GLOBAL) != 0);
@@ -113,11 +109,6 @@ pub(crate) unsafe fn wrap<T: MutDomObject, D: DomTypes>(
                 &PrivateValue(raw.as_ptr() as *const libc::c_void),
             );
         };
-
-        if config.weak_referenceable {
-            let val = PrivateValue(ptr::null());
-            JS_SetReservedSlot(obj.get(), DOM_WEAK_SLOT, &val);
-        }
 
         let root = raw.reflect_with(obj.get());
         root.reflector().set_proto_id(config.prototype_id as u16);


### PR DESCRIPTION
Before weakrefs were implemented as Boxed dom_struct that has dom slot with WeakBox (something like Rc) from which weakrefs derive. Instead we should Rced dom_struct. This removes some nasty unsafe code and frees weakref dom slot.

We need to enforce that if parent is weakreferenceable then child must be too (because it needs to have rc stuff above in memory not box stuff). This should have been enforce this in older weakref model too, but fortunately all children were already weakreferenceable.

NOTE FOR REVIEWERS: changes in script_bindings crate are interesting, changes in script crate are mechanical and boring.

Testing: Should be covered by WPT tests
Fixes: #42278 
