### PR TITLE
wpt/UT: Disable `https_proxy` for local tests

### DIFF
--- a/components/servo/tests/common/mod.rs
+++ b/components/servo/tests/common/mod.rs
@@ -55,6 +55,7 @@ impl ServoTest {
         // Set the proxy to null as the tests will all be on localhost, hence, proxy might interfer.
         let mut preferences = Preferences::default();
         preferences.network_http_proxy_uri = String::new();
+        preferences.network_https_proxy_uri = String::new();
 
         let builder = ServoBuilder::default()
             .preferences(preferences)

--- a/python/wpt/run.py
+++ b/python/wpt/run.py
@@ -81,14 +81,19 @@ def run_tests(default_binary_path: str, multiprocess: bool, **kwargs: Any) -> in
         kwargs.setdefault("binary_args", ["-M"])
 
     given_http_proxy_uri = False
+    given_https_proxy_uri = False
     if prefs:
         for pref in prefs:
             kwargs["binary_args"].append("--pref=" + pref)
             given_http_proxy_uri |= "network_http_proxy_uri" in pref
+            given_https_proxy_uri |= "network_https_proxy_uri" in pref
     # We clearly dictates no proxy unless users know what they are doing.
     # This is to override potential default http_proxy/https_proxy.
     if not given_http_proxy_uri:
         kwargs["binary_args"].append("--pref=network_http_proxy_uri=")
+
+    if not given_https_proxy_uri:
+        kwargs["binary_args"].append("--pref=network_https_proxy_uri=")
 
     if not kwargs.get("no_default_test_types"):
         test_types = {


### PR DESCRIPTION
This helps buddies from MI5, MI6, NSA etc. to run tests behind proxy.

Testing: Tested locally behind proxy. For some reason, I already set `127.0.0.1` and `localhost` in `no_proxy`, but it does not work.
Fixes: #42321
