### PR TITLE
script: Move more steps of AES algorithms to `aes_common` module

### DIFF
--- a/components/script/dom/subtlecrypto/aes_cbc_operation.rs
+++ b/components/script/dom/subtlecrypto/aes_cbc_operation.rs
@@ -2,13 +2,12 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-use aes::cipher::crypto_common::Key;
 use aes::{Aes128, Aes192, Aes256};
 use cbc::{Decryptor, Encryptor};
 use cipher::block_padding::Pkcs7;
 use cipher::{BlockDecryptMut, BlockEncryptMut, KeyIvInit};
 
-use crate::dom::bindings::codegen::Bindings::CryptoKeyBinding::{KeyType, KeyUsage};
+use crate::dom::bindings::codegen::Bindings::CryptoKeyBinding::KeyUsage;
 use crate::dom::bindings::codegen::Bindings::SubtleCryptoBinding::KeyFormat;
 use crate::dom::bindings::error::Error;
 use crate::dom::bindings::root::DomRoot;
@@ -16,8 +15,7 @@ use crate::dom::cryptokey::{CryptoKey, Handle};
 use crate::dom::globalscope::GlobalScope;
 use crate::dom::subtlecrypto::aes_common::AesAlgorithm;
 use crate::dom::subtlecrypto::{
-    ALG_AES_CBC, ExportedKey, KeyAlgorithmAndDerivatives, SubtleAesCbcParams,
-    SubtleAesDerivedKeyParams, SubtleAesKeyAlgorithm, SubtleAesKeyGenParams, aes_common,
+    ExportedKey, SubtleAesCbcParams, SubtleAesDerivedKeyParams, SubtleAesKeyGenParams, aes_common,
 };
 use crate::script_runtime::CanGc;
 
@@ -160,63 +158,15 @@ pub(crate) fn import_key(
     usages: Vec<KeyUsage>,
     can_gc: CanGc,
 ) -> Result<DomRoot<CryptoKey>, Error> {
-    // Step 1. Let keyData be the key data to be imported.
-
-    // Step 2. If usages contains an entry which is not one of "encrypt", "decrypt", "wrapKey" or
-    // "unwrapKey", then throw a SyntaxError.
-    if usages.iter().any(|usage| {
-        !matches!(
-            usage,
-            KeyUsage::Encrypt | KeyUsage::Decrypt | KeyUsage::WrapKey | KeyUsage::UnwrapKey
-        )
-    }) {
-        return Err(Error::Syntax(Some(
-            "Usages contains an entry which is not one of \"encrypt\", \"decrypt\", \"wrapKey\" \
-            or \"unwrapKey\""
-                .to_string(),
-        )));
-    }
-
-    // Step 3.
-    let data = aes_common::import_key_from_key_data(
+    aes_common::import_key(
         AesAlgorithm::AesCbc,
+        global,
         format,
         key_data,
         extractable,
-        &usages,
-    )?;
-
-    // Step 4. Let key be a new CryptoKey object representing an AES key with value data.
-    // Step 5. Let algorithm be a new AesKeyAlgorithm.
-    // Step 6. Set the name attribute of algorithm to "AES-CBC".
-    // Step 7. Set the length attribute of algorithm to the length, in bits, of data.
-    // Step 8. Set the [[algorithm]] internal slot of key to algorithm.
-    let handle = match data.len() {
-        16 => Handle::Aes128Key(Key::<Aes128>::clone_from_slice(&data)),
-        24 => Handle::Aes192Key(Key::<Aes192>::clone_from_slice(&data)),
-        32 => Handle::Aes256Key(Key::<Aes256>::clone_from_slice(&data)),
-        _ => {
-            return Err(Error::Data(Some(
-                "The length in bits of data is not 128, 192 or 256".to_string(),
-            )));
-        },
-    };
-    let algorithm = SubtleAesKeyAlgorithm {
-        name: ALG_AES_CBC.to_string(),
-        length: data.len() as u16 * 8,
-    };
-    let key = CryptoKey::new(
-        global,
-        KeyType::Secret,
-        extractable,
-        KeyAlgorithmAndDerivatives::AesKeyAlgorithm(algorithm),
         usages,
-        handle,
         can_gc,
-    );
-
-    // Step 9. Return key.
-    Ok(key)
+    )
 }
 
 /// <https://w3c.github.io/webcrypto/#aes-cbc-operations-export-key>

--- a/components/script/dom/subtlecrypto/aes_ctr_operation.rs
+++ b/components/script/dom/subtlecrypto/aes_ctr_operation.rs
@@ -2,12 +2,11 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-use aes::cipher::crypto_common::Key;
 use aes::{Aes128, Aes192, Aes256};
 use cipher::{KeyIvInit, StreamCipher};
 use ctr::Ctr128BE;
 
-use crate::dom::bindings::codegen::Bindings::CryptoKeyBinding::{KeyType, KeyUsage};
+use crate::dom::bindings::codegen::Bindings::CryptoKeyBinding::KeyUsage;
 use crate::dom::bindings::codegen::Bindings::SubtleCryptoBinding::KeyFormat;
 use crate::dom::bindings::error::Error;
 use crate::dom::bindings::root::DomRoot;
@@ -15,8 +14,7 @@ use crate::dom::cryptokey::{CryptoKey, Handle};
 use crate::dom::globalscope::GlobalScope;
 use crate::dom::subtlecrypto::aes_common::AesAlgorithm;
 use crate::dom::subtlecrypto::{
-    ALG_AES_CTR, ExportedKey, KeyAlgorithmAndDerivatives, SubtleAesCtrParams,
-    SubtleAesDerivedKeyParams, SubtleAesKeyAlgorithm, SubtleAesKeyGenParams, aes_common,
+    ExportedKey, SubtleAesCtrParams, SubtleAesDerivedKeyParams, SubtleAesKeyGenParams, aes_common,
 };
 use crate::script_runtime::CanGc;
 
@@ -159,63 +157,15 @@ pub(crate) fn import_key(
     usages: Vec<KeyUsage>,
     can_gc: CanGc,
 ) -> Result<DomRoot<CryptoKey>, Error> {
-    // Step 1. Let keyData be the key data to be imported.
-
-    // Step 2. If usages contains an entry which is not one of "encrypt", "decrypt", "wrapKey" or
-    // "unwrapKey", then throw a SyntaxError.
-    if usages.iter().any(|usage| {
-        !matches!(
-            usage,
-            KeyUsage::Encrypt | KeyUsage::Decrypt | KeyUsage::WrapKey | KeyUsage::UnwrapKey
-        )
-    }) {
-        return Err(Error::Syntax(Some(
-            "Usages contains an entry which is not one of \"encrypt\", \"decrypt\", \"wrapKey\" \
-            or \"unwrapKey\""
-                .to_string(),
-        )));
-    }
-
-    // Step 3.
-    let data = aes_common::import_key_from_key_data(
+    aes_common::import_key(
         AesAlgorithm::AesCtr,
+        global,
         format,
         key_data,
         extractable,
-        &usages,
-    )?;
-
-    // Step 4. Let key be a new CryptoKey object representing an AES key with value data.
-    // Step 5. Let algorithm be a new AesKeyAlgorithm.
-    // Step 6. Set the name attribute of algorithm to "AES-CTR".
-    // Step 7. Set the length attribute of algorithm to the length, in bits, of data.
-    // Step 8. Set the [[algorithm]] internal slot of key to algorithm.
-    let handle = match data.len() {
-        16 => Handle::Aes128Key(Key::<Aes128>::clone_from_slice(&data)),
-        24 => Handle::Aes192Key(Key::<Aes192>::clone_from_slice(&data)),
-        32 => Handle::Aes256Key(Key::<Aes256>::clone_from_slice(&data)),
-        _ => {
-            return Err(Error::Data(Some(
-                "The length in bits of data is not 128, 192 or 256".to_string(),
-            )));
-        },
-    };
-    let algorithm = SubtleAesKeyAlgorithm {
-        name: ALG_AES_CTR.to_string(),
-        length: data.len() as u16 * 8,
-    };
-    let key = CryptoKey::new(
-        global,
-        KeyType::Secret,
-        extractable,
-        KeyAlgorithmAndDerivatives::AesKeyAlgorithm(algorithm),
         usages,
-        handle,
         can_gc,
-    );
-
-    // Step 9. Return key.
-    Ok(key)
+    )
 }
 
 /// <https://w3c.github.io/webcrypto/#aes-ctr-operations-export-key>

--- a/components/script/dom/subtlecrypto/aes_gcm_operation.rs
+++ b/components/script/dom/subtlecrypto/aes_gcm_operation.rs
@@ -9,7 +9,7 @@ use aes_gcm::aead::AeadMutInPlace;
 use aes_gcm::{AesGcm, KeyInit};
 use cipher::{ArrayLength, BlockCipher, BlockEncrypt, BlockSizeUser};
 
-use crate::dom::bindings::codegen::Bindings::CryptoKeyBinding::{KeyType, KeyUsage};
+use crate::dom::bindings::codegen::Bindings::CryptoKeyBinding::KeyUsage;
 use crate::dom::bindings::codegen::Bindings::SubtleCryptoBinding::KeyFormat;
 use crate::dom::bindings::error::Error;
 use crate::dom::bindings::root::DomRoot;
@@ -17,8 +17,7 @@ use crate::dom::cryptokey::{CryptoKey, Handle};
 use crate::dom::globalscope::GlobalScope;
 use crate::dom::subtlecrypto::aes_common::AesAlgorithm;
 use crate::dom::subtlecrypto::{
-    ALG_AES_GCM, ExportedKey, KeyAlgorithmAndDerivatives, SubtleAesDerivedKeyParams,
-    SubtleAesGcmParams, SubtleAesKeyAlgorithm, SubtleAesKeyGenParams, aes_common,
+    ExportedKey, SubtleAesDerivedKeyParams, SubtleAesGcmParams, SubtleAesKeyGenParams, aes_common,
 };
 use crate::script_runtime::CanGc;
 
@@ -570,63 +569,15 @@ pub(crate) fn import_key(
     usages: Vec<KeyUsage>,
     can_gc: CanGc,
 ) -> Result<DomRoot<CryptoKey>, Error> {
-    // Step 1. Let keyData be the key data to be imported.
-
-    // Step 2. If usages contains an entry which is not one of "encrypt", "decrypt", "wrapKey" or
-    // "unwrapKey", then throw a SyntaxError.
-    if usages.iter().any(|usage| {
-        !matches!(
-            usage,
-            KeyUsage::Encrypt | KeyUsage::Decrypt | KeyUsage::WrapKey | KeyUsage::UnwrapKey
-        )
-    }) {
-        return Err(Error::Syntax(Some(
-            "Usages contains an entry which is not one of \"encrypt\", \"decrypt\", \"wrapKey\" \
-            or \"unwrapKey\""
-                .to_string(),
-        )));
-    }
-
-    // Step 3.
-    let data = aes_common::import_key_from_key_data(
+    aes_common::import_key(
         AesAlgorithm::AesGcm,
+        global,
         format,
         key_data,
         extractable,
-        &usages,
-    )?;
-
-    // Step 4. Let key be a new CryptoKey object representing an AES key with value data.
-    // Step 5. Let algorithm be a new AesKeyAlgorithm.
-    // Step 6. Set the name attribute of algorithm to "AES-GCM".
-    // Step 7. Set the length attribute of algorithm to the length, in bits, of data.
-    // Step 8. Set the [[algorithm]] internal slot of key to algorithm.
-    let handle = match data.len() {
-        16 => Handle::Aes128Key(Key::<Aes128>::clone_from_slice(&data)),
-        24 => Handle::Aes192Key(Key::<Aes192>::clone_from_slice(&data)),
-        32 => Handle::Aes256Key(Key::<Aes256>::clone_from_slice(&data)),
-        _ => {
-            return Err(Error::Data(Some(
-                "The length in bits of data is not 128, 192 or 256".to_string(),
-            )));
-        },
-    };
-    let algorithm = SubtleAesKeyAlgorithm {
-        name: ALG_AES_GCM.to_string(),
-        length: data.len() as u16 * 8,
-    };
-    let key = CryptoKey::new(
-        global,
-        KeyType::Secret,
-        extractable,
-        KeyAlgorithmAndDerivatives::AesKeyAlgorithm(algorithm),
         usages,
-        handle,
         can_gc,
-    );
-
-    // Step 9. Return key.
-    Ok(key)
+    )
 }
 
 /// <https://w3c.github.io/webcrypto/#aes-gcm-operations-export-key>

--- a/components/script/dom/subtlecrypto/aes_kw_operation.rs
+++ b/components/script/dom/subtlecrypto/aes_kw_operation.rs
@@ -2,11 +2,10 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-use aes::cipher::crypto_common::Key;
 use aes::{Aes128, Aes192, Aes256};
 use aes_kw::Kek;
 
-use crate::dom::bindings::codegen::Bindings::CryptoKeyBinding::{KeyType, KeyUsage};
+use crate::dom::bindings::codegen::Bindings::CryptoKeyBinding::KeyUsage;
 use crate::dom::bindings::codegen::Bindings::SubtleCryptoBinding::KeyFormat;
 use crate::dom::bindings::error::Error;
 use crate::dom::bindings::root::DomRoot;
@@ -14,8 +13,7 @@ use crate::dom::cryptokey::{CryptoKey, Handle};
 use crate::dom::globalscope::GlobalScope;
 use crate::dom::subtlecrypto::aes_common::AesAlgorithm;
 use crate::dom::subtlecrypto::{
-    ALG_AES_KW, ExportedKey, KeyAlgorithmAndDerivatives, SubtleAesDerivedKeyParams,
-    SubtleAesKeyAlgorithm, SubtleAesKeyGenParams, aes_common,
+    ExportedKey, SubtleAesDerivedKeyParams, SubtleAesKeyGenParams, aes_common,
 };
 use crate::script_runtime::CanGc;
 
@@ -136,63 +134,15 @@ pub(crate) fn import_key(
     usages: Vec<KeyUsage>,
     can_gc: CanGc,
 ) -> Result<DomRoot<CryptoKey>, Error> {
-    // Step 1. Let keyData be the key data to be imported.
-
-    // Step 2. If usages contains an entry which is not one of "encrypt", "decrypt", "wrapKey" or
-    // "unwrapKey", then throw a SyntaxError.
-    if usages.iter().any(|usage| {
-        !matches!(
-            usage,
-            KeyUsage::Encrypt | KeyUsage::Decrypt | KeyUsage::WrapKey | KeyUsage::UnwrapKey
-        )
-    }) {
-        return Err(Error::Syntax(Some(
-            "Usages contains an entry which is not one of \"encrypt\", \"decrypt\", \"wrapKey\" \
-            or \"unwrapKey\""
-                .to_string(),
-        )));
-    }
-
-    // Step 3.
-    let data = aes_common::import_key_from_key_data(
+    aes_common::import_key(
         AesAlgorithm::AesKw,
+        global,
         format,
         key_data,
         extractable,
-        &usages,
-    )?;
-
-    // Step 4. Let key be a new CryptoKey object representing an AES key with value data.
-    // Step 5. Let algorithm be a new AesKeyAlgorithm.
-    // Step 6. Set the name attribute of algorithm to "AES-KW".
-    // Step 7. Set the length attribute of algorithm to the length, in bits, of data.
-    // Step 8. Set the [[algorithm]] internal slot of key to algorithm.
-    let handle = match data.len() {
-        16 => Handle::Aes128Key(Key::<Aes128>::clone_from_slice(&data)),
-        24 => Handle::Aes192Key(Key::<Aes192>::clone_from_slice(&data)),
-        32 => Handle::Aes256Key(Key::<Aes256>::clone_from_slice(&data)),
-        _ => {
-            return Err(Error::Data(Some(
-                "The length in bits of data is not 128, 192 or 256".to_string(),
-            )));
-        },
-    };
-    let algorithm = SubtleAesKeyAlgorithm {
-        name: ALG_AES_KW.to_string(),
-        length: data.len() as u16 * 8,
-    };
-    let key = CryptoKey::new(
-        global,
-        KeyType::Secret,
-        extractable,
-        KeyAlgorithmAndDerivatives::AesKeyAlgorithm(algorithm),
         usages,
-        handle,
         can_gc,
-    );
-
-    // Step 9. Return key.
-    Ok(key)
+    )
 }
 
 /// <https://w3c.github.io/webcrypto/#aes-kw-operations-export-key>


### PR DESCRIPTION
Move some common/similar steps of the import key operations of AES-CTR, AES-CBC, AES-GCM, AES-KW and AES-OCB to the shared module `aes_common`.

Some comments are also added to the shared module `aes_common` to explain the small difference in the specification of AES-OCB operations.

Testing: Refactoring. Existing tests suffice.
