### PR TITLE
layout: get rid of some collect() calls

### DIFF
--- a/components/layout/flow/root.rs
+++ b/components/layout/flow/root.rs
@@ -247,7 +247,7 @@ impl BoxTree {
             &(&initial_containing_block).into(),
         );
 
-        let mut root_fragments = independent_layout.fragments.into_iter().collect::<Vec<_>>();
+        let mut root_fragments = independent_layout.fragments;
 
         // Zero box for `:root { display: none }`, one for the root element otherwise.
         assert!(root_fragments.len() <= 1);

--- a/components/layout/layout_impl.rs
+++ b/components/layout/layout_impl.rs
@@ -22,8 +22,8 @@ use fonts::{FontContext, FontContextWebFontMethods, WebFontDocumentContext};
 use fonts_traits::StylesheetWebFontLoadFinishedCallback;
 use layout_api::wrapper_traits::LayoutNode;
 use layout_api::{
-    BoxAreaType, IFrameSizes, Layout, LayoutConfig, LayoutDamage, LayoutFactory,
-    OffsetParentResponse, PhysicalSides, PropertyRegistration, QueryMsg, ReflowGoal,
+    BoxAreaType, CSSPixelRectIterator, IFrameSizes, Layout, LayoutConfig, LayoutDamage,
+    LayoutFactory, OffsetParentResponse, PhysicalSides, PropertyRegistration, QueryMsg, ReflowGoal,
     ReflowPhasesRun, ReflowRequest, ReflowRequestRestyle, ReflowResult, RegisterPropertyError,
     ScrollContainerQueryFlags, ScrollContainerResponse, TrustedNodeAddress,
 };
@@ -356,15 +356,11 @@ impl Layout for LayoutThread {
     ///
     /// See <https://drafts.csswg.org/cssom-view/#dom-element-getclientrects>.
     #[servo_tracing::instrument(skip_all)]
-    fn query_box_areas(
-        &self,
-        node: TrustedNodeAddress,
-        area: BoxAreaType,
-    ) -> Vec<Rect<Au, CSSPixel>> {
+    fn query_box_areas(&self, node: TrustedNodeAddress, area: BoxAreaType) -> CSSPixelRectIterator {
         // If we have not built a fragment tree yet, there is no way we have layout information for
         // this query, which can be run without forcing a layout (for IntersectionObserver).
         if self.fragment_tree.borrow().is_none() {
-            return vec![];
+            return Box::new(std::iter::empty());
         }
 
         let node = unsafe { ServoLayoutNode::new(&node) };

--- a/components/script/dom/element.rs
+++ b/components/script/dom/element.rs
@@ -3219,7 +3219,6 @@ impl ElementMethods<crate::DomTypeHolder> for Element {
         let win = self.owner_window();
         let raw_rects = self.upcast::<Node>().border_boxes();
         let rects: Vec<DomRoot<DOMRect>> = raw_rects
-            .iter()
             .map(|rect| {
                 DOMRect::new(
                     win.upcast(),

--- a/components/script/dom/node.rs
+++ b/components/script/dom/node.rs
@@ -26,8 +26,9 @@ use js::rust::HandleObject;
 use keyboard_types::Modifiers;
 use layout_api::wrapper_traits::SharedSelection;
 use layout_api::{
-    BoxAreaType, GenericLayoutData, HTMLCanvasData, HTMLMediaData, LayoutElementType,
-    LayoutNodeType, PhysicalSides, QueryMsg, SVGElementData, StyleData, TrustedNodeAddress,
+    BoxAreaType, CSSPixelRectIterator, GenericLayoutData, HTMLCanvasData, HTMLMediaData,
+    LayoutElementType, LayoutNodeType, PhysicalSides, QueryMsg, SVGElementData, StyleData,
+    TrustedNodeAddress,
 };
 use libc::{self, c_void, uintptr_t};
 use malloc_size_of::{MallocSizeOf, MallocSizeOfOps};
@@ -1038,7 +1039,7 @@ impl Node {
             .box_area_query(self, BoxAreaType::Padding, false)
     }
 
-    pub(crate) fn border_boxes(&self) -> Vec<Rect<Au, CSSPixel>> {
+    pub(crate) fn border_boxes(&self) -> CSSPixelRectIterator {
         self.owner_window()
             .box_areas_query(self, BoxAreaType::Border)
     }

--- a/components/script/dom/window.rs
+++ b/components/script/dom/window.rs
@@ -55,11 +55,11 @@ use js::rust::{
     MutableHandleValue,
 };
 use layout_api::{
-    BoxAreaType, ElementsFromPointFlags, ElementsFromPointResult, FragmentType, Layout,
-    LayoutImageDestination, PendingImage, PendingImageState, PendingRasterizationImage,
-    PhysicalSides, QueryMsg, ReflowGoal, ReflowPhasesRun, ReflowRequest, ReflowRequestRestyle,
-    RestyleReason, ScrollContainerQueryFlags, ScrollContainerResponse, TrustedNodeAddress,
-    combine_id_with_fragment_type,
+    BoxAreaType, CSSPixelRectIterator, ElementsFromPointFlags, ElementsFromPointResult,
+    FragmentType, Layout, LayoutImageDestination, PendingImage, PendingImageState,
+    PendingRasterizationImage, PhysicalSides, QueryMsg, ReflowGoal, ReflowPhasesRun, ReflowRequest,
+    ReflowRequestRestyle, RestyleReason, ScrollContainerQueryFlags, ScrollContainerResponse,
+    TrustedNodeAddress, combine_id_with_fragment_type,
 };
 use malloc_size_of::MallocSizeOf;
 use media::WindowGLContext;
@@ -2845,11 +2845,7 @@ impl Window {
         self.box_area_query_without_reflow(node, area, exclude_transform_and_inline)
     }
 
-    pub(crate) fn box_areas_query(
-        &self,
-        node: &Node,
-        area: BoxAreaType,
-    ) -> Vec<Rect<Au, CSSPixel>> {
+    pub(crate) fn box_areas_query(&self, node: &Node, area: BoxAreaType) -> CSSPixelRectIterator {
         self.layout_reflow(QueryMsg::BoxAreas);
         self.layout
             .borrow()

--- a/components/shared/layout/lib.rs
+++ b/components/shared/layout/lib.rs
@@ -346,11 +346,7 @@ pub trait Layout {
         area: BoxAreaType,
         exclude_transform_and_inline: bool,
     ) -> Option<Rect<Au, CSSPixel>>;
-    fn query_box_areas(
-        &self,
-        node: TrustedNodeAddress,
-        area: BoxAreaType,
-    ) -> Vec<Rect<Au, CSSPixel>>;
+    fn query_box_areas(&self, node: TrustedNodeAddress, area: BoxAreaType) -> CSSPixelRectIterator;
     fn query_client_rect(&self, node: TrustedNodeAddress) -> Rect<i32, CSSPixel>;
     fn query_current_css_zoom(&self, node: TrustedNodeAddress) -> f32;
     fn query_element_inner_outer_text(&self, node: TrustedNodeAddress) -> String;
@@ -416,6 +412,8 @@ pub enum BoxAreaType {
     Padding,
     Border,
 }
+
+pub type CSSPixelRectIterator = Box<dyn Iterator<Item = Rect<Au, CSSPixel>>>;
 
 #[derive(Default)]
 pub struct PhysicalSides {


### PR DESCRIPTION
Profiling a speedometer run showed significant time spent in some layout function in vector allocations. The main change is to switch the result of `query_box_areas()` from a Vec<T> to and iterator.

Testing: refactoring with no expected test changes
