### PR TITLE
layout: Do not consider pseudo-elements widgets for the purposes of replaced content

### DIFF
--- a/components/layout/formatting_contexts.rs
+++ b/components/layout/formatting_contexts.rs
@@ -92,9 +92,9 @@ impl IndependentFormattingContext {
             Contents::Replaced(contents) => {
                 base_fragment_info.flags.insert(FragmentFlags::IS_REPLACED);
                 // Some replaced elements can have inner widgets, e.g. `<video controls>`.
-                let widget = node_and_style_info
-                    .node
-                    .as_element()
+                let widget = Some(node_and_style_info.node)
+                    .filter(|node| node.pseudo_element_chain().is_empty())
+                    .and_then(|node| node.as_element())
                     .and_then(|element| element.shadow_root())
                     .is_some_and(|shadow_root| shadow_root.is_ua_widget())
                     .then(|| {

--- a/tests/wpt/tests/html/rendering/the-details-element/details-display-list-item-crash.html
+++ b/tests/wpt/tests/html/rendering/the-details-element/details-display-list-item-crash.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<html>
+<head>
+<style>
+    details {
+        display: list-item;
+        list-style-image: url('data:image/svg+xml,<svg xmlns="http://www.w3.org/2000/svg"></svg>');
+    }
+</style>
+</head>
+<body>
+<!-- This test passes if it does not crash. -->
+
+<details></details>
+<script>
+    window.reload();
+</script>
+</body>

--- a/tests/wpt/tests/html/rendering/the-details-element/details-display-list-item-crash.html
+++ b/tests/wpt/tests/html/rendering/the-details-element/details-display-list-item-crash.html
@@ -1,7 +1,8 @@
 <!DOCTYPE html>
-<meta charset="utf-8">
 <html>
 <head>
+<meta charset="utf-8">
+<link rel="help" href="https://github.com/servo/servo/issues/41231">
 <style>
     details {
         display: list-item;
@@ -17,3 +18,4 @@
     window.reload();
 </script>
 </body>
+</html>


### PR DESCRIPTION
When an element has an image content value or list-style-image value they end up duplicating the content of the element inside the generated '::marker'.

This is caused by code inside IndependentFormattingContext for user agent widgets (all user agent shadow dom), this code is specifically aimed at video and audio elements.

This patch adapts that code to be more specific to elements without a pseudo-element chain (e.g. audio and video)

Testing: newly added test crashes on main servo (slightly flakily), but passes consistently now.
Fixes: #42329 
Fixes: #41231
