### PR TITLE
libservo: Allow the embedder to activate accessibility

### DIFF
--- a/components/constellation/constellation.rs
+++ b/components/constellation/constellation.rs
@@ -511,7 +511,7 @@ pub struct Constellation<STF, SWF> {
     pub(crate) user_contents_for_manager_id: FxHashMap<UserContentManagerId, UserContents>,
 
     /// Whether accessibility trees are being built and sent to the underlying platform.
-    accessibility_active: bool,
+    pub(crate) accessibility_active: bool,
 }
 
 /// State needed to construct a constellation.

--- a/components/constellation/constellation.rs
+++ b/components/constellation/constellation.rs
@@ -1197,11 +1197,7 @@ where
         {
             let _ = pipeline
                 .event_loop
-                .send(ScriptThreadMessage::SetAccessibilityActive(
-                    webview_id,
-                    pipeline.id,
-                    true,
-                ));
+                .send(ScriptThreadMessage::SetAccessibilityActive(true));
         }
 
         // If this context is a nested container, attach it to parent pipeline.
@@ -3046,16 +3042,8 @@ where
 
     fn set_accessibility_active(&mut self, active: bool) {
         self.accessibility_active = active;
-        for browsing_context in self.browsing_contexts.values_mut() {
-            if let Some(pipeline) = self.pipelines.get(&browsing_context.pipeline_id) {
-                let _ = pipeline
-                    .event_loop
-                    .send(ScriptThreadMessage::SetAccessibilityActive(
-                        browsing_context.webview_id,
-                        pipeline.id,
-                        active,
-                    ));
-            }
+        for event_loop in self.event_loops() {
+            let _ = event_loop.send(ScriptThreadMessage::SetAccessibilityActive(active));
         }
     }
 

--- a/components/constellation/constellation.rs
+++ b/components/constellation/constellation.rs
@@ -509,6 +509,9 @@ pub struct Constellation<STF, SWF> {
     /// to the `UserContents` need to be forwared to all the `ScriptThread`s that host
     /// the relevant `WebView`.
     pub(crate) user_contents_for_manager_id: FxHashMap<UserContentManagerId, UserContents>,
+
+    /// Whether accessibility trees are being built and sent to the underlying platform.
+    accessibility_active: bool,
 }
 
 /// State needed to construct a constellation.
@@ -727,6 +730,7 @@ where
                     pending_viewport_changes: Default::default(),
                     screenshot_readiness_requests: Vec::new(),
                     user_contents_for_manager_id: Default::default(),
+                    accessibility_active: false,
                 };
 
                 constellation.run();
@@ -1188,6 +1192,18 @@ where
         self.browsing_contexts
             .insert(browsing_context_id, browsing_context);
 
+        if self.accessibility_active &&
+            let Some(pipeline) = self.pipelines.get(&pipeline_id)
+        {
+            let _ = pipeline
+                .event_loop
+                .send(ScriptThreadMessage::SetAccessibilityActive(
+                    webview_id,
+                    pipeline.id,
+                    true,
+                ));
+        }
+
         // If this context is a nested container, attach it to parent pipeline.
         if let Some(parent_pipeline_id) = parent_pipeline_id {
             if let Some(parent) = self.pipelines.get_mut(&parent_pipeline_id) {
@@ -1551,6 +1567,9 @@ where
             },
             EmbedderToConstellationMessage::UpdatePinchZoomInfos(pipeline_id, pinch_zoom) => {
                 self.handle_update_pinch_zoom_infos(pipeline_id, pinch_zoom);
+            },
+            EmbedderToConstellationMessage::SetAccessibilityActive(active) => {
+                self.set_accessibility_active(active);
             },
         }
     }
@@ -3022,6 +3041,21 @@ where
         match event.event.state {
             KeyState::Down => self.active_keyboard_modifiers.insert(modified_modifier),
             KeyState::Up => self.active_keyboard_modifiers.remove(modified_modifier),
+        }
+    }
+
+    fn set_accessibility_active(&mut self, active: bool) {
+        self.accessibility_active = active;
+        for browsing_context in self.browsing_contexts.values_mut() {
+            if let Some(pipeline) = self.pipelines.get(&browsing_context.pipeline_id) {
+                let _ = pipeline
+                    .event_loop
+                    .send(ScriptThreadMessage::SetAccessibilityActive(
+                        browsing_context.webview_id,
+                        pipeline.id,
+                        active,
+                    ));
+            }
         }
     }
 

--- a/components/constellation/constellation.rs
+++ b/components/constellation/constellation.rs
@@ -3044,6 +3044,9 @@ where
         if !(pref!(accessibility_enabled)) {
             return;
         }
+        if active == self.accessibility_active {
+            return;
+        }
 
         self.accessibility_active = active;
         for event_loop in self.event_loops() {

--- a/components/constellation/constellation.rs
+++ b/components/constellation/constellation.rs
@@ -3041,6 +3041,10 @@ where
     }
 
     fn set_accessibility_active(&mut self, active: bool) {
+        if !(pref!(accessibility_enabled)) {
+            return;
+        }
+
         self.accessibility_active = active;
         for event_loop in self.event_loops() {
             let _ = event_loop.send(ScriptThreadMessage::SetAccessibilityActive(active));

--- a/components/constellation/constellation.rs
+++ b/components/constellation/constellation.rs
@@ -1192,12 +1192,12 @@ where
         self.browsing_contexts
             .insert(browsing_context_id, browsing_context);
 
-        if self.accessibility_active &&
-            let Some(pipeline) = self.pipelines.get(&pipeline_id)
-        {
-            let _ = pipeline
-                .event_loop
-                .send(ScriptThreadMessage::SetAccessibilityActive(true));
+        if self.accessibility_active {
+            if let Some(pipeline) = self.pipelines.get(&pipeline_id) {
+                let _ = pipeline
+                    .event_loop
+                    .send(ScriptThreadMessage::SetAccessibilityActive(true));
+            }
         }
 
         // If this context is a nested container, attach it to parent pipeline.

--- a/components/constellation/event_loop.rs
+++ b/components/constellation/event_loop.rs
@@ -111,6 +111,7 @@ impl EventLoop {
             player_context: WindowGLContext::get(),
             privileged_urls: constellation.privileged_urls.clone(),
             user_contents_for_manager_id: constellation.user_contents_for_manager_id.clone(),
+            accessibility_active: constellation.accessibility_active,
         };
 
         let event_loop = if opts::get().multiprocess {

--- a/components/constellation/tracing.rs
+++ b/components/constellation/tracing.rs
@@ -83,6 +83,7 @@ mod from_embedder {
                 Self::EmbedderControlResponse(..) => target!("EmbedderControlResponse"),
                 Self::UserContentManagerAction(..) => target!("UserContentManagerAction"),
                 Self::UpdatePinchZoomInfos(..) => target!("UpdatePinchZoomInfos"),
+                Self::SetAccessibilityActive(..) => target!("SetAccessibilityActive"),
             }
         }
     }

--- a/components/layout/layout_impl.rs
+++ b/components/layout/layout_impl.rs
@@ -709,6 +709,8 @@ impl Layout for LayoutThread {
 
         Ok(())
     }
+
+    fn set_accessibility_active(&self, _active: bool) {}
 }
 
 impl LayoutThread {

--- a/components/layout/layout_impl.rs
+++ b/components/layout/layout_impl.rs
@@ -208,6 +208,10 @@ pub struct LayoutThread {
 
     /// Handler for all Paint Timings
     paint_timing_handler: RefCell<Option<PaintTimingHandler>>,
+
+    /// Whether accessibility is active in this layout.
+    /// (Note: this is a temporary field which will be replaced with an optional accessibility tree member.)
+    accessibility_active: Cell<bool>,
 }
 
 pub struct LayoutFactoryImpl();
@@ -710,7 +714,9 @@ impl Layout for LayoutThread {
         Ok(())
     }
 
-    fn set_accessibility_active(&self, _active: bool) {}
+    fn set_accessibility_active(&self, active: bool) {
+        self.accessibility_active.replace(active);
+    }
 }
 
 impl LayoutThread {
@@ -766,6 +772,7 @@ impl LayoutThread {
             previously_highlighted_dom_node: Cell::new(None),
             paint_timing_handler: Default::default(),
             user_stylesheets: config.user_stylesheets,
+            accessibility_active: Cell::new(config.accessibility_active),
         }
     }
 

--- a/components/layout/layout_impl.rs
+++ b/components/layout/layout_impl.rs
@@ -715,6 +715,10 @@ impl Layout for LayoutThread {
     }
 
     fn set_accessibility_active(&self, active: bool) {
+        if !(pref!(accessibility_enabled)) {
+            return;
+        }
+
         self.accessibility_active.replace(active);
     }
 }

--- a/components/script/messaging.rs
+++ b/components/script/messaging.rs
@@ -106,6 +106,7 @@ impl MixedMessage {
                 ScriptThreadMessage::DestroyUserContentManager(..) => None,
                 ScriptThreadMessage::AccessibilityTreeUpdate(..) => None,
                 ScriptThreadMessage::UpdatePinchZoomInfos(id, _) => Some(*id),
+                ScriptThreadMessage::SetAccessibilityActive(_webview_id, id, ..) => Some(*id),
             },
             MixedMessage::FromScript(inner_msg) => match inner_msg {
                 MainThreadScriptMsg::Common(CommonScriptMsg::Task(_, _, pipeline_id, _)) => {

--- a/components/script/messaging.rs
+++ b/components/script/messaging.rs
@@ -106,7 +106,7 @@ impl MixedMessage {
                 ScriptThreadMessage::DestroyUserContentManager(..) => None,
                 ScriptThreadMessage::AccessibilityTreeUpdate(..) => None,
                 ScriptThreadMessage::UpdatePinchZoomInfos(id, _) => Some(*id),
-                ScriptThreadMessage::SetAccessibilityActive(_webview_id, id, ..) => Some(*id),
+                ScriptThreadMessage::SetAccessibilityActive(..) => None,
             },
             MixedMessage::FromScript(inner_msg) => match inner_msg {
                 MainThreadScriptMsg::Common(CommonScriptMsg::Task(_, _, pipeline_id, _)) => {

--- a/components/script/script_thread.rs
+++ b/components/script/script_thread.rs
@@ -407,6 +407,10 @@ pub struct ScriptThread {
     /// A list of URLs that can access privileged internal APIs.
     #[no_trace]
     privileged_urls: Vec<ServoUrl>,
+
+    /// Whether accessibility is active. If true, each Layout will maintain an accessibility tree
+    /// and send accessibility updates to the embedder.
+    accessibility_active: Cell<bool>,
 }
 
 struct BHMExitSignal {
@@ -1038,6 +1042,7 @@ impl ScriptThread {
                     debugger_paused: Cell::new(false),
                     privileged_urls: state.privileged_urls,
                     this: weak_script_thread.clone(),
+                    accessibility_active: Cell::new(state.accessibility_active),
                 }
             }),
             cx,
@@ -3345,6 +3350,7 @@ impl ScriptThread {
             viewport_details: incomplete.viewport_details,
             user_stylesheets,
             theme: incomplete.theme,
+            accessibility_active: self.accessibility_active.get(),
         };
 
         // Create the window and document objects.
@@ -3637,6 +3643,7 @@ impl ScriptThread {
     }
 
     fn set_accessibility_active(&self, active: bool) {
+        self.accessibility_active.replace(active);
         for (_, document) in self.documents.borrow().iter() {
             let window = document.window();
             let layout = window.layout();

--- a/components/script/script_thread.rs
+++ b/components/script/script_thread.rs
@@ -1966,6 +1966,9 @@ impl ScriptThread {
             ScriptThreadMessage::UpdatePinchZoomInfos(id, pinch_zoom_infos) => {
                 self.handle_update_pinch_zoom_infos(id, pinch_zoom_infos, CanGc::from_cx(cx));
             },
+            ScriptThreadMessage::SetAccessibilityActive(webview_id, pipeline_id, active) => {
+                self.set_accessibility_active(webview_id, pipeline_id, active);
+            },
         }
     }
 
@@ -3631,6 +3634,21 @@ impl ScriptThread {
             return;
         };
         document.event_handler().note_pending_input_event(event);
+    }
+
+    fn set_accessibility_active(
+        &self,
+        _webview_id: WebViewId,
+        pipeline_id: PipelineId,
+        active: bool,
+    ) {
+        let Some(document) = self.documents.borrow().find_document(pipeline_id) else {
+            warn!("Set accessibility active/inactive sent to closed pipeline {pipeline_id}.");
+            return;
+        };
+        let window = document.window();
+        let layout = window.layout();
+        layout.set_accessibility_active(active);
     }
 
     /// Handle a "navigate an iframe" message from the constellation.

--- a/components/script/script_thread.rs
+++ b/components/script/script_thread.rs
@@ -92,7 +92,7 @@ use script_traits::{
     UpdatePipelineIdReason,
 };
 use servo_arc::Arc as ServoArc;
-use servo_config::{opts, prefs};
+use servo_config::{opts, pref, prefs};
 use servo_url::{ImmutableOrigin, MutableOrigin, OriginSnapshot, ServoUrl};
 use storage_traits::StorageThreads;
 use storage_traits::webstorage_thread::WebStorageType;
@@ -3643,6 +3643,10 @@ impl ScriptThread {
     }
 
     fn set_accessibility_active(&self, active: bool) {
+        if !(pref!(accessibility_enabled)) {
+            return;
+        }
+
         self.accessibility_active.replace(active);
         for (_, document) in self.documents.borrow().iter() {
             let window = document.window();

--- a/components/script/script_thread.rs
+++ b/components/script/script_thread.rs
@@ -1966,8 +1966,8 @@ impl ScriptThread {
             ScriptThreadMessage::UpdatePinchZoomInfos(id, pinch_zoom_infos) => {
                 self.handle_update_pinch_zoom_infos(id, pinch_zoom_infos, CanGc::from_cx(cx));
             },
-            ScriptThreadMessage::SetAccessibilityActive(webview_id, pipeline_id, active) => {
-                self.set_accessibility_active(webview_id, pipeline_id, active);
+            ScriptThreadMessage::SetAccessibilityActive(active) => {
+                self.set_accessibility_active(active);
             },
         }
     }
@@ -3636,19 +3636,12 @@ impl ScriptThread {
         document.event_handler().note_pending_input_event(event);
     }
 
-    fn set_accessibility_active(
-        &self,
-        _webview_id: WebViewId,
-        pipeline_id: PipelineId,
-        active: bool,
-    ) {
-        let Some(document) = self.documents.borrow().find_document(pipeline_id) else {
-            warn!("Set accessibility active/inactive sent to closed pipeline {pipeline_id}.");
-            return;
-        };
-        let window = document.window();
-        let layout = window.layout();
-        layout.set_accessibility_active(active);
+    fn set_accessibility_active(&self, active: bool) {
+        for (_, document) in self.documents.borrow().iter() {
+            let window = document.window();
+            let layout = window.layout();
+            layout.set_accessibility_active(active);
+        }
     }
 
     /// Handle a "navigate an iframe" message from the constellation.

--- a/components/script/script_thread.rs
+++ b/components/script/script_thread.rs
@@ -3647,7 +3647,11 @@ impl ScriptThread {
             return;
         }
 
-        self.accessibility_active.replace(active);
+        let old_value = self.accessibility_active.replace(active);
+        if active == old_value {
+            return;
+        }
+
         for (_, document) in self.documents.borrow().iter() {
             document.window().layout().set_accessibility_active(active);
         }

--- a/components/script/script_thread.rs
+++ b/components/script/script_thread.rs
@@ -3649,9 +3649,7 @@ impl ScriptThread {
 
         self.accessibility_active.replace(active);
         for (_, document) in self.documents.borrow().iter() {
-            let window = document.window();
-            let layout = window.layout();
-            layout.set_accessibility_active(active);
+            document.window().layout().set_accessibility_active(active);
         }
     }
 

--- a/components/servo/servo.rs
+++ b/components/servo/servo.rs
@@ -928,6 +928,14 @@ impl Servo {
         self.0.site_data_manager.borrow()
     }
 
+    pub fn set_accessibility_active(&self, active: bool) {
+        self.0
+            .constellation_proxy
+            .send(EmbedderToConstellationMessage::SetAccessibilityActive(
+                active,
+            ));
+    }
+
     pub(crate) fn paint<'a>(&'a self) -> Ref<'a, Paint> {
         self.0.paint.borrow()
     }

--- a/components/shared/constellation/lib.rs
+++ b/components/shared/constellation/lib.rs
@@ -116,6 +116,8 @@ pub enum EmbedderToConstellationMessage {
     UserContentManagerAction(UserContentManagerId, UserContentManagerAction),
     /// Update pinch zoom details stored in the top level window
     UpdatePinchZoomInfos(PipelineId, PinchZoomInfos),
+    /// Activate or deactivate accessibility features.
+    SetAccessibilityActive(bool),
 }
 
 pub enum UserContentManagerAction {

--- a/components/shared/layout/lib.rs
+++ b/components/shared/layout/lib.rs
@@ -391,6 +391,8 @@ pub trait Layout {
         &mut self,
         property_registration: PropertyRegistration,
     ) -> Result<(), RegisterPropertyError>;
+
+    fn set_accessibility_active(&self, active: bool);
 }
 
 /// This trait is part of `layout_api` because it depends on both `script_traits`

--- a/components/shared/layout/lib.rs
+++ b/components/shared/layout/lib.rs
@@ -237,6 +237,7 @@ pub struct LayoutConfig {
     pub viewport_details: ViewportDetails,
     pub user_stylesheets: Rc<Vec<DocumentStyleSheet>>,
     pub theme: Theme,
+    pub accessibility_active: bool,
 }
 
 pub struct PropertyRegistration {

--- a/components/shared/script/lib.rs
+++ b/components/shared/script/lib.rs
@@ -307,7 +307,7 @@ pub enum ScriptThreadMessage {
     /// instance that gets updated according to the changes from the `Compositor``.
     UpdatePinchZoomInfos(PipelineId, PinchZoomInfos),
     /// Activate or deactivate accessibility features.
-    SetAccessibilityActive(WebViewId, PipelineId, bool),
+    SetAccessibilityActive(bool),
 }
 
 impl fmt::Debug for ScriptThreadMessage {

--- a/components/shared/script/lib.rs
+++ b/components/shared/script/lib.rs
@@ -389,6 +389,8 @@ pub struct InitialScriptState {
     pub privileged_urls: Vec<ServoUrl>,
     /// A copy of constellation's `UserContentManagerId` to `UserContents` map.
     pub user_contents_for_manager_id: FxHashMap<UserContentManagerId, UserContents>,
+    /// Whether this script should be initialized with accessibility already active.
+    pub accessibility_active: bool,
 }
 
 /// Errors from executing a paint worklet

--- a/components/shared/script/lib.rs
+++ b/components/shared/script/lib.rs
@@ -306,6 +306,8 @@ pub enum ScriptThreadMessage {
     /// Update the pinch zoom details of a pipeline. Each `Window` stores a `VisualViewport` DOM
     /// instance that gets updated according to the changes from the `Compositor``.
     UpdatePinchZoomInfos(PipelineId, PinchZoomInfos),
+    /// Activate or deactivate accessibility features.
+    SetAccessibilityActive(WebViewId, PipelineId, bool),
 }
 
 impl fmt::Debug for ScriptThreadMessage {


### PR DESCRIPTION
this patch adds a Servo::set_accessibility_active() method that embedders can use to tell Servo to start building and sending accessibility trees to the platform, as long as the pref is enabled (#42333). doing so sets a global flag in the constellation, which is then propagated to the layout of all existing and future pipelines.

Testing: none yet, no functional change
Fixes: part of #4344