### PR TITLE
script: Fix last remaining base element test

### DIFF
--- a/tests/wpt/meta/html/semantics/document-metadata/the-base-element/base_multiple.html.ini
+++ b/tests/wpt/meta/html/semantics/document-metadata/the-base-element/base_multiple.html.ini
@@ -1,3 +1,0 @@
-[base_multiple.html]
-  [The attributes of the a element must be affected by the first base element]
-    expected: FAIL


### PR DESCRIPTION
This was the last failure in this directory. To fix it, I had to spelunk into a couple of places:

1. We shouldn't use the `base_element()` of the document, but select the first base element, regardless if it has an empty href or not
2. We didn't implement target checking for elements. Only some values are valid and an empty target (which the test also confusingly uses) is not valid. Hence, it should fallback to the base element
3. We weren't sanitizing the value in case it contains an ASCII tab or newline + U+003C. This is true for both the form target as well as for other link elements.

All in all, added a lot more specification text to figure out what was going on.