### PR TITLE
fix(background_hang_monitor): Use DummySampler on Windows ARM64

### DIFF
--- a/components/background_hang_monitor/lib.rs
+++ b/components/background_hang_monitor/lib.rs
@@ -36,6 +36,10 @@ pub use self::background_hang_monitor::*;
             target_env = "musl"
         )
     ),
+    all(
+        target_os = "windows",
+        target_arch = "aarch64"
+    ),
 ))]
 pub(crate) use crate::sampler::DummySampler as SamplerImpl;
 #[cfg(all(

--- a/components/background_hang_monitor/lib.rs
+++ b/components/background_hang_monitor/lib.rs
@@ -36,10 +36,7 @@ pub use self::background_hang_monitor::*;
             target_env = "musl"
         )
     ),
-    all(
-        target_os = "windows",
-        target_arch = "aarch64"
-    ),
+    all(target_os = "windows", target_arch = "aarch64"),
 ))]
 pub(crate) use crate::sampler::DummySampler as SamplerImpl;
 #[cfg(all(


### PR DESCRIPTION
Windows ARM64 (aarch64, MSVC) does not support native profiling. PR updates platform configuration to route Windows ARM64 to DummySampler, aligning it with other unsupported targets (e.g., Linux musl) and fixing build compatibility.

PR #42312
- Updates platform configuration + conditional compilation
- Background hang monitor (lib.rs) now selects DummySampler on Windows ARM64
- Uses DummySampler as SamplerImpl for aarch64 Windows

build/compatibility fix only.