### PR TITLE
script: use `&mut JSContext` inside workers `PostMessage` api

### DIFF
--- a/components/script_bindings/codegen/Bindings.conf
+++ b/components/script_bindings/codegen/Bindings.conf
@@ -180,6 +180,10 @@ DOMInterfaces = {
     'useSystemCompartment': True,
 },
 
+'DedicatedWorkerGlobalScope': {
+    'cx': ['PostMessage', 'PostMessage_'],
+},
+
 'Document': {
     'additionalTraits': ["crate::interfaces::DocumentHelpers"],
     'canGc': ['Close', 'CreateElement', 'CreateElementNS', 'ImportNode', 'ParseHTMLUnsafe', 'SetTitle', 'Write', 'Writeln', 'CreateEvent', 'CreateRange', 'Open', 'Open_', 'CreateComment', 'CreateAttribute', 'CreateAttributeNS', 'CreateDocumentFragment', 'CreateTextNode', 'CreateCDATASection', 'CreateProcessingInstruction', 'Prepend', 'Append', 'ReplaceChildren', 'SetBgColor', 'SetFgColor', 'Fonts', 'ExitFullscreen', 'CreateExpression', 'CreateNSResolver', 'Evaluate', 'StyleSheets', 'Implementation', 'GetElementsByTagName', 'GetElementsByTagNameNS', 'GetElementsByClassName', 'AdoptNode', 'CreateNodeIterator', 'SetBody', 'GetElementsByName', 'Images', 'Embeds', 'Plugins', 'Links', 'Forms', 'Scripts', 'Anchors', 'Applets', 'Children', 'GetSelection', 'NamedGetter', 'AdoptedStyleSheets', 'SetAdoptedStyleSheets'],
@@ -676,9 +680,12 @@ DOMInterfaces = {
     'canGc': ['Collapse', 'CollapseToEnd', 'CollapseToStart', 'Extend', 'SelectAllChildren', 'SetBaseAndExtent', 'SetPosition'],
 },
 
+'ServiceWorker': {
+    'cx': ['PostMessage', 'PostMessage_'],
+},
+
 'ServiceWorkerContainer': {
     'realm': ['Register'],
-    'canGc': ['Register'],
 },
 
 'ServoInternals': {
@@ -790,6 +797,10 @@ DOMInterfaces = {
 'WindowProxy' : {
     'path': 'crate::dom::windowproxy::WindowProxy',
     'register': False,
+},
+
+'Worker': {
+    'cx': ['PostMessage', 'PostMessage_'],
 },
 
 'WorkerGlobalScope': {


### PR DESCRIPTION
Switch `PostMessage` of `Worker`, `DedicatedWorkerGlobalScope` and `ServiceWoker` to use `&mut JSContext`, propagating it to `post_message_impl`.

Testing: A successful build is enough
