### PR TITLE
perf tests: Fix minor issues in blink layout tests runner

### DIFF
--- a/etc/blink-perf-test-runner/README.md
+++ b/etc/blink-perf-test-runner/README.md
@@ -1,6 +1,11 @@
 # Readme
 
-Run with:
-"uv run main.py SERVO_BINARY servo/tests/blink_perf_tests/perf_tests/layout/"
+Run from the root servo directory with:
+```shell
+uv run etc/blink-perf-test-runner/main.py SERVO_BINARY [--webdriver port] [--prepend name]
+```
 It will return a results.json in bencher bmf format.
 Not every test currently produces an output.
+The `--prepend` argument can be used to prepend e.g. a cargo `profile` name to the result keys.
+This should be done when uploading to bencher, in order to distinguish measurements with different
+cargo profiles.

--- a/etc/blink-perf-test-runner/main.py
+++ b/etc/blink-perf-test-runner/main.py
@@ -23,7 +23,7 @@ import time
 from selenium import webdriver
 from selenium.webdriver.common.by import By
 from selenium.webdriver.common.options import ArgOptions
-from urllib3.exceptions import ProtocolError
+from urllib3.exceptions import ProtocolError, MaxRetryError
 from selenium.common.exceptions import NoSuchElementException
 
 from enum import Enum
@@ -53,7 +53,7 @@ def create_driver(webdriver_port: int, timeout: int = 3) -> webdriver.Remote | N
     while driver is None and time.time() - start_time < timeout:
         try:
             driver = webdriver.Remote(command_executor=f"http://127.0.0.1:{webdriver_port}", options=options)
-        except (ConnectionError, ProtocolError):
+        except (ConnectionError, ProtocolError, MaxRetryError):
             time.sleep(0.2)
         except Exception as e:
             print(f"Unexpected exception when creating webdriver: {e}, {type(e)}")
@@ -139,7 +139,7 @@ def main():
     parser = argparse.ArgumentParser(description="Run Blink Perf Tests on Servo Instance.")
     parser.add_argument("servo_path", type=str, help="the servo binary")
     parser.add_argument(
-        "-w", "--webdriver", default=7000, type=int, action="store", help="The webdriver port servo will listen on."
+        "-w", "--webdriver", default=7123, type=int, action="store", help="The webdriver port servo will listen on."
     )
     parser.add_argument(
         "-p",


### PR DESCRIPTION
- Catch MaxRetryError exception and retry, to avoid logging warnings. This was observed on macos and can happen during startup of servo.
- Change the default port, since 7000 was reported by multiple people to cause "port in use" errors.

Testing: Manual testing

