### PR TITLE
paint: Do not unwrap in `stop_fling_if_needed` to fix pinch zoom panic

### DIFF
--- a/components/paint/touch.rs
+++ b/components/paint/touch.rs
@@ -401,12 +401,17 @@ impl TouchHandler {
 
     pub(crate) fn stop_fling_if_needed(&mut self) {
         let current_sequence_id = self.current_sequence_id;
-        let touch_sequence = self.get_current_touch_sequence_mut();
+        let Some(touch_sequence) = self.try_get_current_touch_sequence_mut() else {
+            debug!(
+                "Touch sequence already removed before stoping potential flinging during Paint update"
+            );
+            return;
+        };
         let Flinging { .. } = touch_sequence.state else {
             return;
         };
         let _span = profile_traits::info_span!("TouchHandler::FlingEnd").entered();
-        debug!("Stopping fling in touch sequence {current_sequence_id:?}");
+        debug!("Stopping flinging in touch sequence {current_sequence_id:?}");
         touch_sequence.state = Finished;
         // If we were flinging previously, there could still be a touch_up event result
         // coming in after we stopped flinging


### PR DESCRIPTION
Touch sequence may have already been removed before stopping potential fling during Paint update. 
This can happen when we touch up both fingers quickly after the touch move, 
before updates are performed in Paint.
We should not play with fire and `unwrap`.

Testing: Tested with Android, ohos and WebDriver. I can no longer replicate the panic with Pinch Zoom.
Fixes: #42320, which is very verbose but provides the entire story.