### PR TITLE
devtools: Show attached event listeners in inspector tab

### DIFF
--- a/components/devtools/actors/inspector/node.rs
+++ b/components/devtools/actors/inspector/node.rs
@@ -10,8 +10,8 @@ use std::collections::HashMap;
 use atomic_refcell::AtomicRefCell;
 use base::generic_channel::{self, GenericSender};
 use base::id::PipelineId;
-use malloc_size_of_derive::MallocSizeOf;
 use devtools_traits::{DevtoolScriptControlMsg, EventListenerInfo, NodeInfo, ShadowRootMode};
+use malloc_size_of_derive::MallocSizeOf;
 use serde::Serialize;
 use serde_json::{self, Map, Value};
 

--- a/components/devtools/actors/inspector/node.rs
+++ b/components/devtools/actors/inspector/node.rs
@@ -10,8 +10,8 @@ use std::collections::HashMap;
 use atomic_refcell::AtomicRefCell;
 use base::generic_channel::{self, GenericSender};
 use base::id::PipelineId;
-use devtools_traits::{DevtoolScriptControlMsg, NodeInfo, ShadowRootMode};
 use malloc_size_of_derive::MallocSizeOf;
+use devtools_traits::{DevtoolScriptControlMsg, EventListenerInfo, NodeInfo, ShadowRootMode};
 use serde::Serialize;
 use serde_json::{self, Map, Value};
 
@@ -26,6 +26,29 @@ const TEXT_NODE: u16 = 3;
 
 /// The maximum length of a text node for it to appear as an inline child in the inspector.
 const MAX_INLINE_LENGTH: usize = 50;
+
+#[derive(Serialize)]
+struct GetEventListenerInfoReply {
+    from: String,
+    events: Vec<DevtoolsEventListenerInfo>,
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+struct DevtoolsEventListenerInfo {
+    r#type: String,
+    handler: String,
+    origin: String,
+    tags: String,
+    capturing: bool,
+    // This will always be an empty object, we just need a value that serializes to "{}".
+    hide: Value,
+    native: bool,
+    source_actor: String,
+    enabled: bool,
+    is_user_defined: bool,
+    event_listener_info_id: String,
+}
 
 #[derive(Serialize)]
 struct GetUniqueSelectorReply {
@@ -98,6 +121,8 @@ pub(crate) struct NodeActorMsg {
     /// The `DOCTYPE` system identifier if this is a `DocumentType` node, `None` otherwise
     #[serde(skip_serializing_if = "Option::is_none")]
     system_id: Option<String>,
+
+    has_event_listeners: bool,
 }
 
 #[derive(MallocSizeOf)]
@@ -156,7 +181,29 @@ impl Actor for NodeActor {
                 let reply = EmptyReplyMsg { from: self.name() };
                 request.reply_final(&reply)?
             },
+            "getEventListenerInfo" => {
+                let target = msg
+                    .get("to")
+                    .ok_or(ActorError::MissingParameter)?
+                    .as_str()
+                    .ok_or(ActorError::BadParameterType)?;
 
+                let (tx, rx) = generic_channel::channel().ok_or(ActorError::Internal)?;
+                self.script_chan
+                    .send(DevtoolScriptControlMsg::GetEventListenerInfo(
+                        self.pipeline,
+                        registry.actor_to_script(target.to_owned()),
+                        tx,
+                    ))
+                    .unwrap();
+                let event_listeners = rx.recv().map_err(|_| ActorError::Internal)?;
+
+                let msg = GetEventListenerInfoReply {
+                    from: self.name(),
+                    events: event_listeners.into_iter().map(From::from).collect(),
+                };
+                request.reply_final(&msg)?
+            },
             "getUniqueSelector" => {
                 let (tx, rx) = generic_channel::channel().unwrap();
                 self.script_chan
@@ -333,6 +380,25 @@ impl NodeInfoToProtocol for NodeInfo {
             name: self.doctype_name,
             public_id: self.doctype_public_identifier,
             system_id: self.doctype_system_identifier,
+            has_event_listeners: self.has_event_listeners,
+        }
+    }
+}
+
+impl From<EventListenerInfo> for DevtoolsEventListenerInfo {
+    fn from(event_listener_info: EventListenerInfo) -> Self {
+        Self {
+            r#type: event_listener_info.event_type,
+            handler: "todo".to_owned(),
+            capturing: event_listener_info.capturing,
+            origin: "todo".to_owned(),
+            tags: "".to_owned(),
+            hide: Value::Object(Default::default()),
+            native: false,
+            source_actor: "todo".to_owned(),
+            enabled: true,
+            is_user_defined: false,
+            event_listener_info_id: "todo".to_owned(),
         }
     }
 }

--- a/components/script/dom/node.rs
+++ b/components/script/dom/node.rs
@@ -1436,6 +1436,7 @@ impl Node {
                 .map(DocumentType::system_id)
                 .cloned()
                 .map(String::from),
+            has_event_listeners: self.upcast::<EventTarget>().has_handlers(),
         }
     }
 

--- a/components/script/script_thread.rs
+++ b/components/script/script_thread.rs
@@ -2118,6 +2118,9 @@ impl ScriptThread {
                 },
                 None => warn!("Message sent to closed pipeline {}.", id),
             },
+            DevtoolScriptControlMsg::GetEventListenerInfo(id, node, reply) => {
+                devtools::handle_get_event_listener_info(&documents, id, &node, reply)
+            },
             DevtoolScriptControlMsg::GetRootNode(id, reply) => {
                 devtools::handle_get_root_node(&documents, id, reply, CanGc::from_cx(cx))
             },

--- a/components/shared/devtools/lib.rs
+++ b/components/shared/devtools/lib.rs
@@ -175,6 +175,8 @@ pub struct NodeInfo {
 
     /// The `DOCTYPE` system identifier if this is a `DocumentType` node, `None` otherwise
     pub doctype_system_identifier: Option<String>,
+
+    pub has_event_listeners: bool,
 }
 
 pub struct StartedTimelineMarker {
@@ -273,6 +275,8 @@ pub enum DevtoolScriptControlMsg {
     ),
     /// Retrieve the computed CSS style properties for the given node.
     GetComputedStyle(PipelineId, String, GenericSender<Option<Vec<NodeStyle>>>),
+    /// Get information about event listeners on a node.
+    GetEventListenerInfo(PipelineId, String, GenericSender<Vec<EventListenerInfo>>),
     /// Retrieve the computed layout properties of the given node in the given pipeline.
     GetLayout(
         PipelineId,
@@ -554,4 +558,10 @@ pub struct PauseFrameResult {
     #[serde(rename = "type")]
     pub type_: String,
     pub url: String,
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct EventListenerInfo {
+    pub event_type: String,
+    pub capturing: bool,
 }

--- a/python/servo/devtools_tests.py
+++ b/python/servo/devtools_tests.py
@@ -19,6 +19,9 @@ from geckordp.actors.watcher import WatcherActor
 from geckordp.actors.web_console import WebConsoleActor
 from geckordp.actors.resources import Resources
 from geckordp.actors.events import Events
+from geckordp.actors.inspector import InspectorActor
+from geckordp.actors.walker import WalkerActor
+from geckordp.actors.node import NodeActor
 from geckordp.rdp_client import RDPClient
 import http.server
 import os.path
@@ -774,6 +777,21 @@ class DevtoolsTests(unittest.IsolatedAsyncioTestCase):
                 {"configurable": False, "enumerable": True, "value": "true", "writable": True},
             )
 
+    def test_inspector_event_listeners(self):
+        self.run_servoshell(url=f"{self.base_urls[0]}/inspector/event_listeners.html")
+        with Devtools.connect() as devtools:
+            inspector = InspectorActor(devtools.client, devtools.targets[0]["inspectorActor"])
+            walker = WalkerActor(devtools.client, inspector.get_walker()["actor"])
+            document_element = walker.document_element("")["actor"]
+
+            button = walker.query_selector(document_element, "button")["node"]
+            span = walker.query_selector(document_element, "span")["node"]
+            div = walker.query_selector(document_element, "div")["node"]
+
+            self.assert_event_listeners(button, [{"type": "click", "capturing": False}], devtools)
+            self.assert_event_listeners(span, [{"type": "hover", "capturing": True}], devtools)
+            self.assert_event_listeners(div, None, devtools)
+
     # Sets `base_url` and `web_server` and `web_server_thread`.
     @classmethod
     def setUpClass(cls):
@@ -861,6 +879,20 @@ class DevtoolsTests(unittest.IsolatedAsyncioTestCase):
             cls.web_server_threads = None
         if cls.base_urls is not None:
             cls.base_urls = None
+
+    def assert_event_listeners(self, node: dict, expected_listeners: Optional[Any], devtools: Devtools):
+        if expected_listeners is None:
+            self.assertFalse(node["hasEventListeners"])
+            return
+
+        self.assertTrue(node["hasEventListeners"])
+        nodeActor = NodeActor(devtools.client, node["actor"])
+        event_listener_info = nodeActor.get_event_listener_info()
+        self.assertEqual(len(event_listener_info), len(expected_listeners))
+
+        for expected_listener, actual_listener in zip(expected_listeners, event_listener_info):
+            for key, value in expected_listener.items():
+                self.assertEqual(actual_listener[key], value)
 
     def assert_sources_list(
         self, expected_sources_by_target: Counter[FrozenMultiset[Source]], *, devtools: Optional[Devtools] = None

--- a/python/servo/devtools_tests/inspector/event_listeners.html
+++ b/python/servo/devtools_tests/inspector/event_listeners.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<button>Button</button>
+<span></span>
+<div></div>
+
+<script>
+  document.querySelector("button").addEventListener("click", () => {}, false)
+  document.querySelector("span").addEventListener("hover", () => {}, true)
+</script>


### PR DESCRIPTION
This change makes the devtools inspector show any event listeners that are attached to a node. The primary motivation is making the devtools more useful for debugging real-world websites.

<img width="536" height="268" alt="image" src="https://github.com/user-attachments/assets/5ba13e41-14b4-4202-b994-eadff5d1c6b5" />

You can also click on the event listener to show some more info, though most of that (everything except the event type and the event phase) is currently just placeholder text:

<img width="1360" height="456" alt="image" src="https://github.com/user-attachments/assets/ec025847-43fc-489c-8b26-46afb6dada64" />


Testing: This change adds a new test
