### PR TITLE
webdriver: Remove last dependency on `RefCell`

### DIFF
--- a/components/webdriver_server/actions.rs
+++ b/components/webdriver_server/actions.rs
@@ -232,9 +232,8 @@ impl Handler {
         }
     }
 
-    fn wait_for_input_event_handled(&self) -> Result<(), ErrorStatus> {
-        let pending_receivers =
-            std::mem::take(&mut *self.pending_input_event_receivers.borrow_mut());
+    fn wait_for_input_event_handled(&mut self) -> Result<(), ErrorStatus> {
+        let pending_receivers = std::mem::take(&mut self.pending_input_event_receivers);
 
         for receiver in pending_receivers {
             let _ = receiver.recv();
@@ -668,7 +667,7 @@ impl Handler {
 
     /// <https://w3c.github.io/webdriver/#dfn-dispatch-a-scroll-action>
     fn dispatch_scroll_action(
-        &self,
+        &mut self,
         input_id: &str,
         action: &WheelScrollAction,
         tick_duration: u64,
@@ -751,7 +750,7 @@ impl Handler {
     /// <https://w3c.github.io/webdriver/#dfn-perform-a-scroll>
     #[expect(clippy::too_many_arguments)]
     fn perform_scroll(
-        &self,
+        &mut self,
         duration: u64,
         x: f64,
         y: f64,

--- a/components/webdriver_server/lib.rs
+++ b/components/webdriver_server/lib.rs
@@ -14,7 +14,7 @@ mod timeout;
 mod user_prompt;
 
 use std::borrow::ToOwned;
-use std::cell::{LazyCell, RefCell};
+use std::cell::LazyCell;
 use std::collections::{BTreeMap, HashMap};
 use std::io::Cursor;
 use std::net::{SocketAddr, SocketAddrV4};
@@ -181,7 +181,7 @@ struct Handler {
     /// Once these receivers receive a response, we know that the event has been handled.
     ///
     /// TODO: Once we upgrade crossbeam-channel this can be replaced with a `WaitGroup`.
-    pending_input_event_receivers: RefCell<Vec<Receiver<()>>>,
+    pending_input_event_receivers: Vec<Receiver<()>>,
 
     /// Moves that are currently in-progress and need to be ticked.
     pending_pointer_moves: Vec<PendingPointerMove>,
@@ -494,7 +494,7 @@ impl Handler {
         ));
     }
 
-    fn send_blocking_input_event_to_embedder(&self, input_event: InputEvent) {
+    fn send_blocking_input_event_to_embedder(&mut self, input_event: InputEvent) {
         let (result_sender, result_receiver) = unbounded();
         if self
             .send_message_to_embedder(WebDriverCommandMsg::InputEvent(
@@ -504,9 +504,7 @@ impl Handler {
             ))
             .is_ok()
         {
-            self.pending_input_event_receivers
-                .borrow_mut()
-                .push(result_receiver);
+            self.pending_input_event_receivers.push(result_receiver);
         }
     }
 


### PR DESCRIPTION
`pending_input_event_receivers` is the last thing that uses `RefCell`. 
This PR improves safety as we rely on static check, and performance slightly too.

Testing: Just refactor.