### PR TITLE
script: Add check for IntersectionObserver to not connect to the same document multiple times.

### DIFF
--- a/components/script/dom/intersectionobserver.rs
+++ b/components/script/dom/intersectionobserver.rs
@@ -124,7 +124,7 @@ impl IntersectionObserver {
             thresholds: Default::default(),
             delay: Default::default(),
             track_visibility: Default::default(),
-            is_connected: Cell::new(false),
+            connected_to_document: Cell::new(false),
         }
     }
 
@@ -407,16 +407,16 @@ impl IntersectionObserver {
     /// Connect the observer itself into owner doc if it is unconnected.
     /// If the [`IntersectionObserver`] is already connected, do nothing.
     fn connect_to_owner(&self) {
-        if !self.is_connected.get() {
+        if !self.connected_to_document.get() {
             self.owner_doc.add_intersection_observer(self);
-            self.is_connected.set(true);
+            self.connected_to_document.set(true);
         }
     }
 
     /// Disconnect the observer itself from owner doc.
     /// If not connected to a [`Document`], do nothing.
     fn disconnect_from_owner(&self) {
-        if self.is_connected.get() {
+        if self.connected_to_document.get() {
             self.owner_doc.remove_intersection_observer(self);
         }
     }
@@ -758,9 +758,6 @@ impl IntersectionObserverMethods<crate::DomTypeHolder> for IntersectionObserver 
     /// <https://w3c.github.io/IntersectionObserver/#dom-intersectionobserver-observe>
     fn Observe(&self, target: &Element) {
         self.observe_target_element(target);
-
-        // Connect to owner doc to be accessed in the event loop.
-        self.connect_to_owner();
     }
 
     /// > Run the unobserve a target Element algorithm, providing this and target.

--- a/components/script/dom/intersectionobserver.rs
+++ b/components/script/dom/intersectionobserver.rs
@@ -101,7 +101,7 @@ pub(crate) struct IntersectionObserver {
     track_visibility: Cell<bool>,
 
     /// Whether or not this [`IntersectionObserver`] is connected to its owning [`Document`].
-    is_connected: Cell<bool>,
+    connected_to_document: Cell<bool>,
 }
 
 impl IntersectionObserver {

--- a/components/script/dom/intersectionobserver.rs
+++ b/components/script/dom/intersectionobserver.rs
@@ -414,7 +414,7 @@ impl IntersectionObserver {
     }
 
     /// Disconnect the observer itself from owner doc.
-    /// We we were already disconnected from the observer
+    /// If not connected to a [`Document`], do nothing.
     fn disconnect_from_owner(&self) {
         if self.is_connected.get() {
             self.owner_doc.remove_intersection_observer(self);

--- a/components/script/dom/intersectionobserver.rs
+++ b/components/script/dom/intersectionobserver.rs
@@ -99,6 +99,9 @@ pub(crate) struct IntersectionObserver {
 
     /// <https://w3c.github.io/IntersectionObserver/#dom-intersectionobserver-trackvisibility-slot>
     track_visibility: Cell<bool>,
+
+    /// Are we connected to the owner document
+    is_connected: Cell<bool>,
 }
 
 impl IntersectionObserver {
@@ -121,6 +124,7 @@ impl IntersectionObserver {
             thresholds: Default::default(),
             delay: Default::default(),
             track_visibility: Default::default(),
+            is_connected: Cell::new(false),
         }
     }
 
@@ -276,7 +280,7 @@ impl IntersectionObserver {
         target.add_initial_intersection_observer_registration(self);
 
         if self.observation_targets.borrow().is_empty() {
-            self.connect_to_owner_unchecked();
+            self.connect_to_owner();
         }
 
         // Step 4
@@ -310,7 +314,7 @@ impl IntersectionObserver {
 
         // Should disconnect from owner if it is not observing anything.
         if self.observation_targets.borrow().is_empty() {
-            self.disconnect_from_owner_unchecked();
+            self.disconnect_from_owner();
         }
     }
 
@@ -401,15 +405,20 @@ impl IntersectionObserver {
     }
 
     /// Connect the observer itself into owner doc if it is unconnected.
-    /// It would not check whether the observer is already connected or not inside the doc.
-    fn connect_to_owner_unchecked(&self) {
-        self.owner_doc.add_intersection_observer(self);
+    /// We check if we are already connected
+    fn connect_to_owner(&self) {
+        if !self.is_connected.get() {
+            self.owner_doc.add_intersection_observer(self);
+            self.is_connected.set(true);
+        }
     }
 
     /// Disconnect the observer itself from owner doc.
-    /// It would not check whether the observer is already disconnected or not inside the doc.
-    fn disconnect_from_owner_unchecked(&self) {
-        self.owner_doc.remove_intersection_observer(self);
+    /// We we were already disconnected from the observer
+    fn disconnect_from_owner(&self) {
+        if self.is_connected.get() {
+            self.owner_doc.remove_intersection_observer(self);
+        }
     }
 
     /// > The root intersection rectangle for an IntersectionObserver is
@@ -751,7 +760,7 @@ impl IntersectionObserverMethods<crate::DomTypeHolder> for IntersectionObserver 
         self.observe_target_element(target);
 
         // Connect to owner doc to be accessed in the event loop.
-        self.connect_to_owner_unchecked();
+        self.connect_to_owner();
     }
 
     /// > Run the unobserve a target Element algorithm, providing this and target.
@@ -773,7 +782,7 @@ impl IntersectionObserverMethods<crate::DomTypeHolder> for IntersectionObserver 
         self.observation_targets.borrow_mut().clear();
 
         // We should remove this observer from the event loop.
-        self.disconnect_from_owner_unchecked();
+        self.disconnect_from_owner();
     }
 
     /// <https://w3c.github.io/IntersectionObserver/#dom-intersectionobserver-takerecords>

--- a/components/script/dom/intersectionobserver.rs
+++ b/components/script/dom/intersectionobserver.rs
@@ -405,7 +405,7 @@ impl IntersectionObserver {
     }
 
     /// Connect the observer itself into owner doc if it is unconnected.
-    /// We check if we are already connected
+    /// If the [`IntersectionObserver`] is already connected, do nothing.
     fn connect_to_owner(&self) {
         if !self.is_connected.get() {
             self.owner_doc.add_intersection_observer(self);

--- a/components/script/dom/intersectionobserver.rs
+++ b/components/script/dom/intersectionobserver.rs
@@ -100,7 +100,7 @@ pub(crate) struct IntersectionObserver {
     /// <https://w3c.github.io/IntersectionObserver/#dom-intersectionobserver-trackvisibility-slot>
     track_visibility: Cell<bool>,
 
-    /// Are we connected to the owner document
+    /// Whether or not this [`IntersectionObserver`] is connected to its owning [`Document`].
     is_connected: Cell<bool>,
 }
 


### PR DESCRIPTION
Previous IntersectionObserver had only connect_to_owner_unchecked method. We replace this with a checked method to not add the same IntersectionObserver to the same document multiple times.

This should improve performance as the same IntersectionObserver was tested multiple times.

Signed-off-by: Narfinger <Narfinger@users.noreply.github.com>

Testing: Compilation and println statements to see if we do not add us again to the document.
