### PR TITLE
etc: Fix blink_perf_test's parsing and output for ci compatability

### DIFF
--- a/etc/blink-perf-test-runner/main.py
+++ b/etc/blink-perf-test-runner/main.py
@@ -184,25 +184,22 @@ def main():
             for file in files:
                 if test_file(file):
                     filePath = os.path.join(os.path.abspath(root), file)
-                    if "many-block-children-rebuild-box-tree.html" in filePath:
-                        result = test("file://" + filePath, webdriver)
-                        if result == AbortReason.Panic:
-                            print("Restarting servo")
-                            start_servo(args.webdriver, args.servo_path)
-                        elif result == AbortReason.NotFound:
-                            pass
-                        else:
-                            combined_result = {}
-                            combined_result["value"] = result.value
-                            combined_result["lower_value"] = result.lower_value
-                            combined_result["upper_value"] = result.upper_value
+                    result = test("file://" + filePath, webdriver)
+                    if result == AbortReason.Panic:
+                        print("Restarting servo")
+                        start_servo(args.webdriver, args.servo_path)
+                    elif result == AbortReason.NotFound:
+                        pass
+                    else:
+                        combined_result = {}
+                        combined_result["value"] = result.value
+                        combined_result["lower_value"] = result.lower_value
+                        combined_result["upper_value"] = result.upper_value
 
-                            if result.unit == "ms":
-                                final_result[canonical_test_path(filePath, args.prepend)] = {"ms": combined_result}
-                            else:
-                                final_result[canonical_test_path(filePath, args.prepend)] = {
-                                    "throughput": combined_result
-                                }
+                        if result.unit == "ms":
+                            final_result[canonical_test_path(filePath, args.prepend)] = {"ms": combined_result}
+                        else:
+                            final_result[canonical_test_path(filePath, args.prepend)] = {"throughput": combined_result}
 
     print(final_result)
     write_file(final_result)

--- a/etc/blink-perf-test-runner/main.py
+++ b/etc/blink-perf-test-runner/main.py
@@ -85,7 +85,7 @@ def kill_servo():
     subprocess.Popen(["killall", "servo"])
 
 
-_PATTERN = re.compile(
+_REGEX_RESULTS_LOG_ELEMENT = re.compile(
     r"""
 Time:\s+
 values\s+[0-9.,\s]+(?P<unit>ms|runs\/s)\s+
@@ -118,12 +118,12 @@ def test(s: str, driver: webdriver.Remote) -> TestResult | AbortReason:
         for i in range(MAX_WAIT_TIME):
             element = driver.find_element(By.ID, "log")
             text = element.text
-            m = _PATTERN.search(text)
-            if m:
-                avg_line = float(m.group("avg"))
-                min_line = float(m.group("min"))
-                max_line = float(m.group("max"))
-                unit = m.group("unit")
+            results_log_groups = _REGEX_RESULTS_LOG_ELEMENT.search(text)
+            if results_log_groups:
+                avg_line = float(results_log_groups.group("avg"))
+                min_line = float(results_log_groups.group("min"))
+                max_line = float(results_log_groups.group("max"))
+                unit = results_log_groups.group("unit")
             if avg_line is not None and min_line is not None and max_line is not None and unit is not None:
                 return TestResult(value=avg_line, lower_value=min_line, upper_value=max_line, unit=unit)
             time.sleep(1)
@@ -133,6 +133,7 @@ def test(s: str, driver: webdriver.Remote) -> TestResult | AbortReason:
     except Exception as e:
         print(f"Some other exception for this test case: {e}")
         return AbortReason.Panic
+    print("Wait for valid log element timed out. Could not find valid log.")
     return AbortReason.NotFound
 
 
@@ -180,7 +181,7 @@ def main():
     time.sleep(2)
     if webdriver:
         webdriver.implicitly_wait(30)
-        for root, dir, files in os.walk("tests/blink_perf_tests/perf_tests/layout", onerror=oswalk_error):
+        for root, _, files in os.walk("tests/blink_perf_tests/perf_tests/layout", onerror=oswalk_error):
             for file in files:
                 if test_file(file):
                     filePath = os.path.join(os.path.abspath(root), file)
@@ -196,10 +197,14 @@ def main():
                         combined_result["lower_value"] = result.lower_value
                         combined_result["upper_value"] = result.upper_value
 
+                        bencher_unit = "other"
+
                         if result.unit == "ms":
-                            final_result[canonical_test_path(filePath, args.prepend)] = {"ms": combined_result}
-                        else:
-                            final_result[canonical_test_path(filePath, args.prepend)] = {"throughput": combined_result}
+                            bencher_unit = "ms"
+                        elif result.unit == "runs/s":
+                            bencher_unit = "throughput"
+
+                        final_result[canonical_test_path(filePath, args.prepend)] = {bencher_unit: combined_result}
 
     print(final_result)
     write_file(final_result)

--- a/etc/blink-perf-test-runner/main.py
+++ b/etc/blink-perf-test-runner/main.py
@@ -85,7 +85,7 @@ def kill_servo():
     subprocess.Popen(["killall", "servo"])
 
 
-_REGEX_RESULTS_LOG_ELEMENT = re.compile(
+REGEX_RESULTS_LOG_ELEMENT = re.compile(
     r"""
 Time:\s+
 values\s+[0-9.,\s]+(?P<unit>ms|runs\/s)\s+
@@ -118,7 +118,7 @@ def test(s: str, driver: webdriver.Remote) -> TestResult | AbortReason:
         for i in range(MAX_WAIT_TIME):
             element = driver.find_element(By.ID, "log")
             text = element.text
-            results_log_groups = _REGEX_RESULTS_LOG_ELEMENT.search(text)
+            results_log_groups = REGEX_RESULTS_LOG_ELEMENT.search(text)
             if results_log_groups:
                 avg_line = float(results_log_groups.group("avg"))
                 min_line = float(results_log_groups.group("min"))
@@ -197,12 +197,14 @@ def main():
                         combined_result["lower_value"] = result.lower_value
                         combined_result["upper_value"] = result.upper_value
 
-                        bencher_unit = "other"
+                        bencher_unit = None
 
                         if result.unit == "ms":
                             bencher_unit = "ms"
                         elif result.unit == "runs/s":
                             bencher_unit = "throughput"
+                        else:
+                            bencher_unit = "other"
 
                         final_result[canonical_test_path(filePath, args.prepend)] = {bencher_unit: combined_result}
 


### PR DESCRIPTION
This PR fixes the blink_perf_test_runner's issues with parsing in
* flexbox-lots-of-data.html
* nested-blocks-with-percent-height-and-max-height.html
And also changes `results.json` values from str to float to be compatible with bencher.dev format

Testing: run `uv run etc/blink-perf-test-runner/main.py -w 13002 ./target/production/servo` to get results.json
