### PR TITLE
script: use `&mut JSContext` in `Window::PostMessage`

### DIFF
--- a/components/script_bindings/codegen/Bindings.conf
+++ b/components/script_bindings/codegen/Bindings.conf
@@ -792,6 +792,7 @@ DOMInterfaces = {
     'inRealms': ['Fetch', 'GetOpener', 'WebdriverCallback'],
     'additionalTraits': ['crate::interfaces::WindowHelpers'],
     'realm': ['CreateImageBitmap', 'CreateImageBitmap_'],
+    'cx': ['PostMessage', 'PostMessage_']
 },
 
 'WindowProxy' : {


### PR DESCRIPTION
Replace `crate::script_runtime::JSContext` with `js::context::JSContext` in `Window::PostMessage`'s API.

Testing: Builds and runs locally.
Part of: https://github.com/servo/servo/issues/42347
