### PR TITLE
mach: Force the use of arm64 Python when running with Windows on arm64

### DIFF
--- a/mach.bat
+++ b/mach.bat
@@ -1,4 +1,8 @@
 @echo off
 
+REM UV defaults to x86_64 Python on Arm64, so we need to override that.
+REM https://github.com/astral-sh/uv/issues/12906
+if "%PROCESSOR_ARCHITECTURE%"=="ARM64" ( set UV_PYTHON=arm64 )
+
 set workdir=%~dp0
 uv run --frozen python %workdir%mach %*

--- a/mach.ps1
+++ b/mach.ps1
@@ -23,4 +23,10 @@ if ($arguments.Count -gt 0) {
     }
 }
 
+# UV defaults to x86_64 Python on Arm64, so we need to override that.
+# https://github.com/astral-sh/uv/issues/12906
+if ([System.Runtime.InteropServices.RuntimeInformation]::OSArchitecture -eq 'Arm64') {
+    $env:UV_PYTHON='arm64'
+}
+
 uv run --frozen python (Join-Path $workdir "mach") @arguments


### PR DESCRIPTION
There is currently [a bug in UV](https://github.com/astral-sh/uv/issues/12906) that results in it using the x64 flavor of Python when running on Arm64 Windows. This then causes all Python scripts to believe they are on an x64 device and so Server installs the wrong dependencies and builds for the wrong architecture.

Testing: Local on my Arm64 Windows device
Contributes to fixing #40611
