### PR TITLE
Bump python dependencies to minimum required for Arm64 Windows

### DIFF
--- a/tests/wpt/tests/tools/webtransport/h3/webtransport_h3_server.py
+++ b/tests/wpt/tests/tools/webtransport/h3/webtransport_h3_server.py
@@ -1,3 +1,4 @@
+import aioquic
 import asyncio
 import contextlib
 import logging
@@ -380,13 +381,14 @@ class WebTransportSession:
         """
         stream_id = self._http.create_webtransport_stream(
             session_id=self.session_id, is_unidirectional=False)
-        # TODO(bashi): Remove this workaround when aioquic supports receiving
-        # data on server-initiated bidirectional streams.
-        stream = self._http._get_or_create_stream(stream_id)
-        assert stream.frame_type is None
-        assert stream.session_id is None
-        stream.frame_type = FrameType.WEBTRANSPORT_STREAM
-        stream.session_id = self.session_id
+        if aioquic.__version__ <= "1.2.0":
+            # TODO(bashi): Remove this workaround when aioquic supports receiving
+            # data on server-initiated bidirectional streams.
+            stream = self._http._get_or_create_stream(stream_id)
+            assert stream.frame_type is None
+            assert stream.session_id is None
+            stream.frame_type = FrameType.WEBTRANSPORT_STREAM
+            stream.session_id = self.session_id
         return stream_id
 
     def send_stream_data(self,

--- a/tests/wpt/tests/tools/webtransport/h3/webtransport_h3_server.py
+++ b/tests/wpt/tests/tools/webtransport/h3/webtransport_h3_server.py
@@ -1,4 +1,3 @@
-import aioquic
 import asyncio
 import contextlib
 import logging
@@ -12,13 +11,11 @@ from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple, cast
 from urllib.parse import urlparse
 
-from packaging.version import Version
-
 from aioquic.buffer import Buffer
 from aioquic.asyncio import QuicConnectionProtocol, serve
 from aioquic.asyncio.client import connect
 from aioquic.asyncio.protocol import QuicStreamAdapter
-from aioquic.h3.connection import H3_ALPN, FrameType, H3Connection, ProtocolError, SettingsError
+from aioquic.h3.connection import H3_ALPN, FrameType, H3Connection, H3Stream, ProtocolError, SettingsError
 from aioquic.h3.events import H3Event, HeadersReceived, WebTransportStreamDataReceived, DatagramReceived, DataReceived
 from aioquic.quic.configuration import QuicConfiguration
 from aioquic.quic.connection import logger as quic_connection_logger
@@ -384,18 +381,18 @@ class WebTransportSession:
         stream_id = self._http.create_webtransport_stream(
             session_id=self.session_id, is_unidirectional=False)
         # TODO(bashi): Remove this workaround when aioquic supports receiving
-        # data on server-initiated bidirectional streams.
-        stream_cm = self._http._get_or_create_stream(stream_id)
-        if Version(aioquic.__version__) <= Version("1.2.0"):
-            # Older aioquic returns the stream directly rather than a context
-            # manager. The stream is freshly created here and not yet ended, so
-            # the seeded state persists for incoming client data.
-            stream_cm = contextlib.nullcontext(stream_cm)
-        with stream_cm as stream:
-            assert stream.frame_type is None
-            assert stream.session_id is None
-            stream.frame_type = FrameType.WEBTRANSPORT_STREAM
-            stream.session_id = self.session_id
+        # data on server-initiated bidirectional streams. The public API for
+        # accessing the stream object differs between aioquic versions, so seed
+        # the internal stream state directly. The stream is freshly created
+        # here, so the seeded state persists for incoming client data.
+        stream = self._http._stream.get(stream_id)
+        if stream is None:
+            stream = H3Stream(stream_id)
+            self._http._stream[stream_id] = stream
+        assert stream.frame_type is None
+        assert stream.session_id is None
+        stream.frame_type = FrameType.WEBTRANSPORT_STREAM
+        stream.session_id = self.session_id
         return stream_id
 
     def send_stream_data(self,

--- a/tests/wpt/tests/tools/webtransport/h3/webtransport_h3_server.py
+++ b/tests/wpt/tests/tools/webtransport/h3/webtransport_h3_server.py
@@ -12,6 +12,8 @@ from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple, cast
 from urllib.parse import urlparse
 
+from packaging.version import Version
+
 from aioquic.buffer import Buffer
 from aioquic.asyncio import QuicConnectionProtocol, serve
 from aioquic.asyncio.client import connect
@@ -381,10 +383,15 @@ class WebTransportSession:
         """
         stream_id = self._http.create_webtransport_stream(
             session_id=self.session_id, is_unidirectional=False)
-        if aioquic.__version__ <= "1.2.0":
-            # TODO(bashi): Remove this workaround when aioquic supports receiving
-            # data on server-initiated bidirectional streams.
-            stream = self._http._get_or_create_stream(stream_id)
+        # TODO(bashi): Remove this workaround when aioquic supports receiving
+        # data on server-initiated bidirectional streams.
+        stream_cm = self._http._get_or_create_stream(stream_id)
+        if Version(aioquic.__version__) <= Version("1.2.0"):
+            # Older aioquic returns the stream directly rather than a context
+            # manager. The stream is freshly created here and not yet ended, so
+            # the seeded state persists for incoming client data.
+            stream_cm = contextlib.nullcontext(stream_cm)
+        with stream_cm as stream:
             assert stream.frame_type is None
             assert stream.session_id is None
             stream.frame_type = FrameType.WEBTRANSPORT_STREAM

--- a/tests/wpt/tests/tools/webtransport/requirements.txt
+++ b/tests/wpt/tests/tools/webtransport/requirements.txt
@@ -1,1 +1,3 @@
-aioquic==1.2.0
+aioquic==1.3.0; python_version >= "3.10"
+aioquic==1.2.0; python_version < "3.10"
+cryptography==46

--- a/tests/wpt/tests/tools/wptrunner/requirements.txt
+++ b/tests/wpt/tests/tools/wptrunner/requirements.txt
@@ -10,4 +10,6 @@ pillow==12.1.1; python_version >= '3.10'
 requests==2.32.3
 types-requests==2.32.0.20241016
 urllib3==2.6.3
-aioquic==1.2.0
+aioquic==1.3.0; python_version >= "3.10"
+aioquic==1.2.0; python_version < "3.10"
+cryptography==46

--- a/tests/wpt/tests/tools/wptrunner/requirements_chromium.txt
+++ b/tests/wpt/tests/tools/wptrunner/requirements_chromium.txt
@@ -1,1 +1,3 @@
-aioquic==1.2.0
+aioquic==1.3.0; python_version >= "3.10"
+aioquic==1.2.0; python_version < "3.10"
+cryptography==46

--- a/uv.lock
+++ b/uv.lock
@@ -1,6 +1,11 @@
 version = 1
 revision = 3
 requires-python = ">=3.11"
+resolution-markers = [
+    "python_full_version >= '3.14' and platform_python_implementation != 'PyPy'",
+    "python_full_version < '3.14' and platform_python_implementation != 'PyPy'",
+    "platform_python_implementation == 'PyPy'",
+]
 
 [[package]]
 name = "aiohappyeyeballs"
@@ -115,7 +120,7 @@ wheels = [
 
 [[package]]
 name = "aioquic"
-version = "1.2.0"
+version = "1.3.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "certifi" },
@@ -124,15 +129,19 @@ dependencies = [
     { name = "pyopenssl" },
     { name = "service-identity" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/4b/1a/bf10b2c57c06c7452b685368cb1ac90565a6e686e84ec6f84465fb8f78f4/aioquic-1.2.0.tar.gz", hash = "sha256:f91263bb3f71948c5c8915b4d50ee370004f20a416f67fab3dcc90556c7e7199", size = 179891, upload-time = "2024-07-06T23:27:09.301Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/6b/0c/858bb02e0ff96b40735b09ed7be25690197851e4c1bcde51af3348c851fc/aioquic-1.3.0.tar.gz", hash = "sha256:28d070b2183e3e79afa9d4e7bd558960d0d53aeb98bc0cf0a358b279ba797c92", size = 181923, upload-time = "2025-10-11T09:16:30.91Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/19/03/1c385739e504c70ab2a66a4bc0e7cd95cee084b374dcd4dc97896378400b/aioquic-1.2.0-cp38-abi3-macosx_10_9_x86_64.whl", hash = "sha256:3e23964dfb04526ade6e66f5b7cd0c830421b8138303ab60ba6e204015e7cb0b", size = 1753473, upload-time = "2024-07-06T23:26:20.809Z" },
-    { url = "https://files.pythonhosted.org/packages/6a/1f/4d1c40714db65be828e1a1e2cce7f8f4b252be67d89f2942f86a1951826c/aioquic-1.2.0-cp38-abi3-macosx_11_0_arm64.whl", hash = "sha256:84d733332927b76218a3b246216104116f766f5a9b2308ec306cd017b3049660", size = 2083563, upload-time = "2024-07-06T23:26:24.254Z" },
-    { url = "https://files.pythonhosted.org/packages/15/48/56a8c9083d1deea4ccaf1cbf5a91a396b838b4a0f8650f4e9f45c7879a38/aioquic-1.2.0-cp38-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:2466499759b31ea4f1d17f4aeb1f8d4297169e05e3c1216d618c9757f4dd740d", size = 2555697, upload-time = "2024-07-06T23:26:26.16Z" },
-    { url = "https://files.pythonhosted.org/packages/0f/93/fa4c981a8a8a903648d4cd6e12c0fca7f44e3ef4ba15a8b99a26af05b868/aioquic-1.2.0-cp38-abi3-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:cd75015462ca5070a888110dc201f35a9f4c7459f9201b77adc3c06013611bb8", size = 2149089, upload-time = "2024-07-06T23:26:28.277Z" },
-    { url = "https://files.pythonhosted.org/packages/b0/0f/4a280923313b831892caaa45348abea89e7dd2e4422a86699bb0e506b1dd/aioquic-1.2.0-cp38-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:43ae3b11d43400a620ca0b4b4885d12b76a599c2cbddba755f74bebfa65fe587", size = 2205221, upload-time = "2024-07-06T23:26:30.682Z" },
-    { url = "https://files.pythonhosted.org/packages/d2/6b/a6a1d1762ce06f13b68f524bb9c5f4d6ca7cda9b072d7e744626b89b77be/aioquic-1.2.0-cp38-abi3-win32.whl", hash = "sha256:910d8c91da86bba003d491d15deaeac3087d1b9d690b9edc1375905d8867b742", size = 1214037, upload-time = "2024-07-06T23:26:32.651Z" },
-    { url = "https://files.pythonhosted.org/packages/dd/aa/e8a8a75c93dee0ab229df3c2d17f63cd44d0ad5ee8540e2ec42779ce3a39/aioquic-1.2.0-cp38-abi3-win_amd64.whl", hash = "sha256:e3dcfb941004333d477225a6689b55fc7f905af5ee6a556eb5083be0354e653a", size = 1530339, upload-time = "2024-07-06T23:26:34.753Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/41/9a6cf092f2d21768091969dccd4723270f4cd8138d00097160d9c8eabeb8/aioquic-1.3.0-cp310-abi3-macosx_10_9_x86_64.whl", hash = "sha256:59da070ff0f55a54f5623c9190dbc86638daa0bcf84bbdb11ebe507abc641435", size = 1922701, upload-time = "2025-10-11T09:16:10.971Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/ea/ac91850a3e6c915802d8c0ee782f966ddfaeed9f870696c1cdb98b25c9a1/aioquic-1.3.0-cp310-abi3-macosx_11_0_arm64.whl", hash = "sha256:48590fa38ec13f01a3d4e44fb3cfd373661094c9c7248f3c54d2d9512b6c3469", size = 2240281, upload-time = "2025-10-11T09:16:12.895Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/65/383f3b3921e1d6b9b757bff3c805c24f7180eda690aecb5e8df50eb7b028/aioquic-1.3.0-cp310-abi3-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:019b16580d53541b5d77b4a44a61966921156554fad2536d74895713c800caa5", size = 2752433, upload-time = "2025-10-11T09:16:14.724Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/00/66f9a2f95db35ccbe1d9384d44beae28072fceec6ca0ffa29f6c640516c2/aioquic-1.3.0-cp310-abi3-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:396e5f53f6ddb27713d9b5bb11d8f0f842e42857b7e671c5ae203bf618528550", size = 2445180, upload-time = "2025-10-11T09:16:17.136Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/7a/f020815b9fa6ea9b83354deb213b90a25fd01466f5a8e517e1c0e672be8c/aioquic-1.3.0-cp310-abi3-manylinux_2_28_i686.whl", hash = "sha256:4098afc6337adf19bdb54474f6c37983988e7bfa407892a277259c32eb664b00", size = 2361800, upload-time = "2025-10-11T09:16:18.685Z" },
+    { url = "https://files.pythonhosted.org/packages/87/be/a141aafe8984ed380e610397d606a9d9818ef30ce352aa9ede048a966d81/aioquic-1.3.0-cp310-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:48292279a248422b6289fffd82159eba8d8b35ff4b1f660b9f74ff85e10ca265", size = 2797515, upload-time = "2025-10-11T09:16:20.451Z" },
+    { url = "https://files.pythonhosted.org/packages/52/50/b421e7aedff4a96840bf8734c2c11c18a8434c780c0cb59dff7f0906cee8/aioquic-1.3.0-cp310-abi3-musllinux_1_2_i686.whl", hash = "sha256:0538acdfbf839d87b175676664737c248cd51f1a2295c5fef8e131ddde478a86", size = 2388628, upload-time = "2025-10-11T09:16:21.661Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/f4/3c674f4608883e7fc7212f067c599d1321b0c5dd45bda5c77ab5a1e73924/aioquic-1.3.0-cp310-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:a8881239801279188e33ced6f9849cedf033325a48a6f44d7e55e583abc555a3", size = 2465059, upload-time = "2025-10-11T09:16:23.474Z" },
+    { url = "https://files.pythonhosted.org/packages/23/f2/7b1908feffb29b89d2f6d4adc583e83543cd559676354f85c5b4b77a6428/aioquic-1.3.0-cp310-abi3-win32.whl", hash = "sha256:ba30016244e45d9222fdd1fbd4e8b0e5f6811e81a5d0643475ad7024a537274a", size = 1326532, upload-time = "2025-10-11T09:16:25.971Z" },
+    { url = "https://files.pythonhosted.org/packages/82/45/4e47404984d65ee31cc9e1370f1fbc4e8c92b25da71f61429dbdba437246/aioquic-1.3.0-cp310-abi3-win_amd64.whl", hash = "sha256:2d7957ba14a6c5efcc14fdc685ccda7ecf0ad048c410a2bdcad1b63bf9527e8e", size = 1675068, upload-time = "2025-10-11T09:16:27.258Z" },
+    { url = "https://files.pythonhosted.org/packages/43/60/a8cb5f85c5a6a3cc630124a45644ca5a0ab3eecae2df558b6e0ab7847e1c/aioquic-1.3.0-cp310-abi3-win_arm64.whl", hash = "sha256:9d15a89213d38cbc4679990fa5151af8ea02655a1d6ce5ec972b0a6af74d5f1c", size = 1234825, upload-time = "2025-10-11T09:16:28.994Z" },
 ]
 
 [[package]]
@@ -225,7 +234,7 @@ name = "cffi"
 version = "2.0.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "pycparser", marker = "implementation_name != 'PyPy'" },
+    { name = "pycparser", marker = "implementation_name != 'PyPy' and platform_python_implementation != 'PyPy'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/eb/56/b1ba7935a17738ae8453301356628e8147c79dbb825bcbc73dc7401f9846/cffi-2.0.0.tar.gz", hash = "sha256:44d1b5909021139fe36001ae048dbdde8214afa20200eda0f64c068cac5d5529", size = 523588, upload-time = "2025-09-08T23:24:04.541Z" }
 wheels = [
@@ -1797,6 +1806,7 @@ dependencies = [
     { name = "aioquic" },
     { name = "blessed" },
     { name = "colorama" },
+    { name = "cryptography" },
     { name = "distro" },
     { name = "flake8" },
     { name = "flask" },
@@ -1840,9 +1850,10 @@ dependencies = [
 
 [package.metadata]
 requires-dist = [
-    { name = "aioquic", specifier = "==1.2.0" },
+    { name = "aioquic", specifier = "==1.3.0" },
     { name = "blessed", specifier = "==1.20.0" },
     { name = "colorama", specifier = "==0.3.7" },
+    { name = "cryptography", specifier = "==46" },
     { name = "distro", specifier = "==1.4" },
     { name = "flake8", marker = "python_full_version < '3.9'", specifier = "==5.0.4" },
     { name = "flake8", marker = "python_full_version >= '3.9'", specifier = "==6.1.0" },


### PR DESCRIPTION
GitHub only recently added Arm64 Windows runners, so only recent Python packages tend to have a Wheel for Arm64 Windows.

This change bumps the Python dependencies to version with Arm64 Wheels:
```
aioquic==1.3.0
cryptography==46
```

Testing: Ran Python locally on my Arm64 Windows device.
Contributes to fixing #40611
