### PR TITLE
libservo: Fix dead code warning and fix two typos in unit tests

### DIFF
--- a/components/servo/tests/common/mod.rs
+++ b/components/servo/tests/common/mod.rs
@@ -22,10 +22,6 @@ pub struct ServoTest {
 }
 
 impl ServoTest {
-    pub(crate) fn new() -> Self {
-        Self::new_with_builder(|builder| builder)
-    }
-
     pub(crate) fn new_with_builder<F>(customize: F) -> Self
     where
         F: FnOnce(ServoBuilder) -> ServoBuilder,
@@ -52,7 +48,7 @@ impl ServoTest {
         }
 
         let user_event_triggered = Arc::new(AtomicBool::new(false));
-        // Set the proxy to null as the tests will all be on localhost, hence, proxy might interfer.
+        // Set the proxy to null as the tests will all be on localhost, hence, proxy might interfere.
         let mut preferences = Preferences::default();
         preferences.network_http_proxy_uri = String::new();
         preferences.network_https_proxy_uri = String::new();
@@ -184,7 +180,7 @@ pub(crate) fn show_webview_and_wait_for_rendering_to_be_ready(
 
     delegate.reset();
 
-    // Trigger a change to the display of the document, so that we get at last one
+    // Trigger a change to the display of the document, so that we get at least one
     // new frame after load is complete.
     let _ = evaluate_javascript(
         &servo_test,

--- a/components/servo/tests/common/mod.rs
+++ b/components/servo/tests/common/mod.rs
@@ -22,7 +22,6 @@ pub struct ServoTest {
 }
 
 impl ServoTest {
-    #[expect(dead_code)] // Used by some tests and not others
     pub(crate) fn new() -> Self {
         Self::new_with_builder(|b| b)
     }
@@ -200,5 +199,3 @@ pub(crate) fn show_webview_and_wait_for_rendering_to_be_ready(
     let captured_delegate = delegate.clone();
     servo_test.spin(move || !captured_delegate.new_frame_ready.get());
 }
-
-

--- a/components/servo/tests/common/mod.rs
+++ b/components/servo/tests/common/mod.rs
@@ -23,7 +23,7 @@ pub struct ServoTest {
 
 impl ServoTest {
     pub(crate) fn new() -> Self {
-        Self::new_with_builder(|b| b)
+        Self::new_with_builder(|builder| builder)
     }
 
     pub(crate) fn new_with_builder<F>(customize: F) -> Self

--- a/components/servo/tests/common/mod.rs
+++ b/components/servo/tests/common/mod.rs
@@ -22,6 +22,7 @@ pub struct ServoTest {
 }
 
 impl ServoTest {
+    #[expect(dead_code)] // Used by some tests and not others
     pub(crate) fn new() -> Self {
         Self::new_with_builder(|builder| builder)
     }

--- a/components/servo/tests/common/mod.rs
+++ b/components/servo/tests/common/mod.rs
@@ -22,6 +22,11 @@ pub struct ServoTest {
 }
 
 impl ServoTest {
+    #[expect(dead_code)] // Used by some tests and not others
+    pub(crate) fn new() -> Self {
+        Self::new_with_builder(|b| b)
+    }
+
     pub(crate) fn new_with_builder<F>(customize: F) -> Self
     where
         F: FnOnce(ServoBuilder) -> ServoBuilder,
@@ -195,3 +200,5 @@ pub(crate) fn show_webview_and_wait_for_rendering_to_be_ready(
     let captured_delegate = delegate.clone();
     servo_test.spin(move || !captured_delegate.new_frame_ready.get());
 }
+
+


### PR DESCRIPTION
This PR addresses a dead code warning removed during test builds by ensuring the servo test helper constructor is exercised. None of the functional behaviors are changed and this only improves test clarity and keeps the compiler output warning-free.

Fixes: #42364