### PR TITLE
paint: Unify scrolling/pinch zoom behaviour across platforms

### DIFF
--- a/components/paint/touch.rs
+++ b/components/paint/touch.rs
@@ -40,10 +40,7 @@ impl TouchSequenceId {
     }
 }
 
-// TODO: All `_SCREEN_PX` units below are currently actually used as `DevicePixel`
-// without multiplying with the `hidpi_factor`. This should be fixed and the
-// constants adjusted accordingly.
-/// Minimum number of `DeviceIndependentPixel` to begin touch scrolling.
+/// Minimum number of `DeviceIndependentPixel` to begin touch scrolling/Pinching.
 const TOUCH_PAN_MIN_SCREEN_PX: f32 = 20.0;
 /// Factor by which the flinging velocity changes on each tick.
 const FLING_SCALING_FACTOR: f32 = 0.95;
@@ -423,6 +420,7 @@ impl TouchHandler {
         &mut self,
         id: TouchId,
         point: Point2D<f32, DevicePixel>,
+        scale: f32,
     ) -> Option<ScrollZoomEvent> {
         // As `TouchHandler` is per `WebViewRenderer` which is per `WebView` we might get a Touch Sequence Move that
         // started with a down on a different webview. As the touch_sequence id is only changed on touch_down this
@@ -458,8 +456,8 @@ impl TouchHandler {
                         point,
                         event_count: 1,
                     }))
-                } else if delta.x.abs() > TOUCH_PAN_MIN_SCREEN_PX ||
-                    delta.y.abs() > TOUCH_PAN_MIN_SCREEN_PX
+                } else if delta.x.abs() > TOUCH_PAN_MIN_SCREEN_PX * scale ||
+                    delta.y.abs() > TOUCH_PAN_MIN_SCREEN_PX * scale
                 {
                     let _span = profile_traits::info_span!(
                         "TouchHandler::ScrollBegin",
@@ -488,8 +486,8 @@ impl TouchHandler {
             },
             2 => {
                 if touch_sequence.state == Pinching ||
-                    delta.x.abs() > TOUCH_PAN_MIN_SCREEN_PX ||
-                    delta.y.abs() > TOUCH_PAN_MIN_SCREEN_PX
+                    delta.x.abs() > TOUCH_PAN_MIN_SCREEN_PX * scale ||
+                    delta.y.abs() > TOUCH_PAN_MIN_SCREEN_PX * scale
                 {
                     touch_sequence.state = Pinching;
                     let (d0, _) = touch_sequence.pinch_distance_and_center();

--- a/components/paint/touch.rs
+++ b/components/paint/touch.rs
@@ -41,7 +41,7 @@ impl TouchSequenceId {
 }
 
 /// Minimum number of `DeviceIndependentPixel` to begin touch scrolling/Pinching.
-const TOUCH_PAN_MIN_SCREEN_PX: f32 = 20.0;
+const TOUCH_PAN_MIN_SCREEN_PX: f32 = 10.0;
 /// Factor by which the flinging velocity changes on each tick.
 const FLING_SCALING_FACTOR: f32 = 0.95;
 /// Minimum velocity required for transitioning to fling when panning ends.

--- a/components/paint/webview_renderer.rs
+++ b/components/paint/webview_renderer.rs
@@ -451,7 +451,12 @@ impl WebViewRenderer {
         let point = event
             .point
             .as_device_point(self.device_pixels_per_page_pixel());
-        let action = self.touch_handler.on_touch_move(event.id, point);
+        let action = self.touch_handler.on_touch_move(
+            event.id,
+            point,
+            self.device_pixels_per_page_pixel_not_including_pinch_zoom()
+                .get(),
+        );
         if let Some(action) = action {
             // if first move processed and allowed, we directly process the move event,
             // without waiting for the script handler.

--- a/tests/wpt/tests/touch-events/pinch-zoom-change.html
+++ b/tests/wpt/tests/touch-events/pinch-zoom-change.html
@@ -1,0 +1,53 @@
+<!DOCTYPE html>
+<html>
+
+<head>
+  <meta charset="utf-8">
+  <title>Pinch-zoom immediately followed by touch-up stability</title>
+  <link rel=help href="https://github.com/servo/servo/issues/42320">
+  <link rel="author" title="Euclid Ye" href="mailto:yezhizhenjiakang@gmail.com">
+  <meta name="assert" content="The page should not crash and the visual state should change after a pinch-zoom.">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <script src="/resources/testharness.js"></script>
+  <script src="/resources/testharnessreport.js"></script>
+  <script src="/resources/testdriver.js"></script>
+  <script src="/resources/testdriver-actions.js"></script>
+  <script src="/resources/testdriver-vendor.js"></script>
+  <style>
+    body {
+      height: 200vh;
+      width: 200vw;
+      margin: 0;
+      overflow: hidden;
+    }
+
+    #rect {
+      width: 100px;
+      height: 100px;
+      background: blue;
+    }
+  </style>
+</head>
+
+<body>
+  <div id="rect"></div>
+  <script> promise_test(async () => {
+      const x = 200, y = 200;
+      const initialScale = window.visualViewport.scale;
+      // Perform pinch zoom with 0 pause, to trigger previous crash.
+      await new test_driver.Actions(defaultTickDuration = 0)
+        .addPointer("f1", "touch")
+        .addPointer("f2", "touch")
+        .pointerMove(x, y, { origin: "viewport", sourceName: "f1" })
+        .pointerMove(x + 10, y + 10, { origin: "viewport", sourceName: "f2" })
+        .pointerDown({ sourceName: "f1" })
+        .pointerDown({ sourceName: "f2" })
+        .pointerMove(x - 30, y - 30, { origin: "viewport", sourceName: "f1", duration: 0 })
+        .pointerMove(x + 30, y + 30, { origin: "viewport", sourceName: "f2", duration: 0 })
+        .pointerUp({ sourceName: "f1" })
+        .pointerUp({ sourceName: "f2" }).send();
+      assert_not_equals(window.visualViewport.scale, initialScale, "Scale should have changed");
+    }) </script>
+</body>
+
+</html>


### PR DESCRIPTION
There has been a weird discrepancy between headed/headless test automation, 
as stated in #42386 and https://github.com/servo/servo/issues/42320#issuecomment-3846005540. 
The problem identified is more general than the intial issue: 
we need to use CSS Pixel and Device Pixel consistently in these cases.

- Convert threshold unit to ensure cross-platform consistency.
- Adjust `TOUCH_PAN_MIN_SCREEN_PX`: this is tested on Android/Ohos,
to match the pinch/scrolling threshold of Firefox/Chrome.

This is critical for test automation which always relies on CSS pixel.

Testing: Added which ensures pinch zoom does happen, and there is no crash for #42320.
Fixes: #42386
