### PR TITLE
script_bindings: add generic type to webidl record typedefs containing dom interfaces

### DIFF
--- a/components/script_bindings/codegen/codegen.py
+++ b/components/script_bindings/codegen/codegen.py
@@ -197,7 +197,7 @@ def containsDomInterface(t: IDLObject, logging: bool = False) -> bool:
     if t.isSequence():
         assert isinstance(t, IDLSequenceType)
         return containsDomInterface(t.inner)
-    if hasattr(t, "isRecord") and t.isRecord():
+    if t.isRecord():
         assert isinstance(t, IDLRecordType)
         return containsDomInterface(t.inner)
     return False

--- a/components/script_bindings/codegen/codegen.py
+++ b/components/script_bindings/codegen/codegen.py
@@ -197,6 +197,9 @@ def containsDomInterface(t: IDLObject, logging: bool = False) -> bool:
     if t.isSequence():
         assert isinstance(t, IDLSequenceType)
         return containsDomInterface(t.inner)
+    if hasattr(t, "isRecord") and t.isRecord():
+        assert isinstance(t, IDLRecordType)
+        return containsDomInterface(t.inner)
     return False
 
 


### PR DESCRIPTION
when generating rust bindings for webidl typedef, the `<D>` generic Type would not be added for record<Key, DomInterface> because `containsDomInterface` does not take record into account. This change add the is_Record check in `containsDomInterface`, so `typedef record<Key, DomInterface>` can be successfully build.

Testing: Manually tested with https://github.com/servo/servo/issues/42362, and building from scratch with `./mach build` is successful.
Fixes: https://github.com/servo/servo/issues/42362
