### PR TITLE
servo: Remove `Servo::constellation_sender`

### DIFF
--- a/components/servo/servo.rs
+++ b/components/servo/servo.rs
@@ -908,10 +908,6 @@ impl Servo {
             .send(EmbedderToConstellationMessage::CreateMemoryReport(snd));
     }
 
-    pub fn constellation_sender(&self) -> Sender<EmbedderToConstellationMessage> {
-        self.0.constellation_proxy.sender()
-    }
-
     pub fn execute_webdriver_command(&self, command: WebDriverCommandMsg) {
         self.0
             .constellation_proxy


### PR DESCRIPTION
This shouldn't be public, and does not appear to be used anywhere.

Testing: Build-only change.