### PR TITLE
script: Check whether window is top level before looking for it in the `ScriptThread`

### DIFF
--- a/components/script/dom/intersectionobserver.rs
+++ b/components/script/dom/intersectionobserver.rs
@@ -453,7 +453,8 @@ impl IntersectionObserver {
                     //
                     // There are uncertainties whether the browsing context we should consider is the browsing
                     // context of the target or observer. <https://github.com/w3c/IntersectionObserver/issues/456>
-                    document.window().top_level_document()
+                    // TODO: This wouldn't work if top level document is in another ScriptThread.
+                    document.window().top_level_document_if_local()
                 } else if let Some(ElementOrDocument::Document(document)) = &self.root {
                     Some(document.clone())
                 } else {

--- a/components/script/dom/intersectionobserver.rs
+++ b/components/script/dom/intersectionobserver.rs
@@ -453,10 +453,7 @@ impl IntersectionObserver {
                     //
                     // There are uncertainties whether the browsing context we should consider is the browsing
                     // context of the target or observer. <https://github.com/w3c/IntersectionObserver/issues/456>
-                    document
-                        .window()
-                        .webview_window_proxy()
-                        .and_then(|window_proxy| window_proxy.document())
+                    document.window().top_level_document()
                 } else if let Some(ElementOrDocument::Document(document)) = &self.root {
                     Some(document.clone())
                 } else {

--- a/components/script/dom/window.rs
+++ b/components/script/dom/window.rs
@@ -649,7 +649,8 @@ impl Window {
     }
 
     /// Get the active [`Document`] of top-level browsing context, or return [`Window`]'s [`Document`]
-    /// if it's browing context is the top-level browsing context.
+    /// if it's browing context is the top-level browsing context. Returning none if the [`WindowProxy`]
+    /// is discarded or the [`Document`] is in another thread (having dissimilar origin).
     /// <https://html.spec.whatwg.org/multipage/#top-level-browsing-context>
     pub(crate) fn top_level_document(&self) -> Option<DomRoot<Document>> {
         let window_proxy = self.undiscarded_window_proxy()?;

--- a/components/script/dom/windowproxy.rs
+++ b/components/script/dom/windowproxy.rs
@@ -680,6 +680,10 @@ impl WindowProxy {
         result
     }
 
+    pub(crate) fn is_top_level(&self) -> bool {
+        self.browsing_context_id == self.webview_id
+    }
+
     /// Run [the focusing steps] with this browsing context.
     ///
     /// [the focusing steps]: https://html.spec.whatwg.org/multipage/#focusing-steps

--- a/components/script/dom/windowproxy.rs
+++ b/components/script/dom/windowproxy.rs
@@ -680,10 +680,6 @@ impl WindowProxy {
         result
     }
 
-    pub(crate) fn is_top_level(&self) -> bool {
-        self.browsing_context_id == self.webview_id
-    }
-
     /// Run [the focusing steps] with this browsing context.
     ///
     /// [the focusing steps]: https://html.spec.whatwg.org/multipage/#focusing-steps


### PR DESCRIPTION
Instead of immediately looking for the top-level browsing context's `Document` in the `ScriptThread`, check whether `Window` is top-level beforehand. This is a small optimization.

Testing: Existing WPTs (no behavior changes)