### PR TITLE
Layout: add initial support for text-overflow: ellipsis

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -383,7 +383,7 @@ dependencies = [
  "objc2-foundation 0.3.2",
  "parking_lot",
  "percent-encoding",
- "windows-sys 0.60.2",
+ "windows-sys 0.52.0",
  "x11rb",
 ]
 
@@ -7157,7 +7157,7 @@ dependencies = [
 [[package]]
 name = "selectors"
 version = "0.36.0"
-source = "git+https://github.com/servo/stylo?rev=f00c109074832b7fa7be52bbbf8f4987d24e323b#f00c109074832b7fa7be52bbbf8f4987d24e323b"
+source = "git+https://github.com/RichardTjokroutomo/stylo.git?branch=txt-overflow#080adb21acc877427b6d15bd87f339ed49028c37"
 dependencies = [
  "bitflags 2.11.0",
  "cssparser",
@@ -8799,7 +8799,7 @@ dependencies = [
 [[package]]
 name = "servo_arc"
 version = "0.4.3"
-source = "git+https://github.com/servo/stylo?rev=f00c109074832b7fa7be52bbbf8f4987d24e323b#f00c109074832b7fa7be52bbbf8f4987d24e323b"
+source = "git+https://github.com/RichardTjokroutomo/stylo.git?branch=txt-overflow#080adb21acc877427b6d15bd87f339ed49028c37"
 dependencies = [
  "serde",
  "stable_deref_trait",
@@ -9219,7 +9219,7 @@ dependencies = [
 [[package]]
 name = "stylo"
 version = "0.13.0"
-source = "git+https://github.com/servo/stylo?rev=f00c109074832b7fa7be52bbbf8f4987d24e323b#f00c109074832b7fa7be52bbbf8f4987d24e323b"
+source = "git+https://github.com/RichardTjokroutomo/stylo.git?branch=txt-overflow#080adb21acc877427b6d15bd87f339ed49028c37"
 dependencies = [
  "app_units",
  "arrayvec",
@@ -9275,7 +9275,7 @@ dependencies = [
 [[package]]
 name = "stylo_atoms"
 version = "0.13.0"
-source = "git+https://github.com/servo/stylo?rev=f00c109074832b7fa7be52bbbf8f4987d24e323b#f00c109074832b7fa7be52bbbf8f4987d24e323b"
+source = "git+https://github.com/RichardTjokroutomo/stylo.git?branch=txt-overflow#080adb21acc877427b6d15bd87f339ed49028c37"
 dependencies = [
  "string_cache",
  "string_cache_codegen",
@@ -9284,7 +9284,7 @@ dependencies = [
 [[package]]
 name = "stylo_derive"
 version = "0.13.0"
-source = "git+https://github.com/servo/stylo?rev=f00c109074832b7fa7be52bbbf8f4987d24e323b#f00c109074832b7fa7be52bbbf8f4987d24e323b"
+source = "git+https://github.com/RichardTjokroutomo/stylo.git?branch=txt-overflow#080adb21acc877427b6d15bd87f339ed49028c37"
 dependencies = [
  "darling",
  "proc-macro2",
@@ -9296,7 +9296,7 @@ dependencies = [
 [[package]]
 name = "stylo_dom"
 version = "0.13.0"
-source = "git+https://github.com/servo/stylo?rev=f00c109074832b7fa7be52bbbf8f4987d24e323b#f00c109074832b7fa7be52bbbf8f4987d24e323b"
+source = "git+https://github.com/RichardTjokroutomo/stylo.git?branch=txt-overflow#080adb21acc877427b6d15bd87f339ed49028c37"
 dependencies = [
  "bitflags 2.11.0",
  "stylo_malloc_size_of",
@@ -9305,7 +9305,7 @@ dependencies = [
 [[package]]
 name = "stylo_malloc_size_of"
 version = "0.13.0"
-source = "git+https://github.com/servo/stylo?rev=f00c109074832b7fa7be52bbbf8f4987d24e323b#f00c109074832b7fa7be52bbbf8f4987d24e323b"
+source = "git+https://github.com/RichardTjokroutomo/stylo.git?branch=txt-overflow#080adb21acc877427b6d15bd87f339ed49028c37"
 dependencies = [
  "app_units",
  "cssparser",
@@ -9322,12 +9322,12 @@ dependencies = [
 [[package]]
 name = "stylo_static_prefs"
 version = "0.13.0"
-source = "git+https://github.com/servo/stylo?rev=f00c109074832b7fa7be52bbbf8f4987d24e323b#f00c109074832b7fa7be52bbbf8f4987d24e323b"
+source = "git+https://github.com/RichardTjokroutomo/stylo.git?branch=txt-overflow#080adb21acc877427b6d15bd87f339ed49028c37"
 
 [[package]]
 name = "stylo_traits"
 version = "0.13.0"
-source = "git+https://github.com/servo/stylo?rev=f00c109074832b7fa7be52bbbf8f4987d24e323b#f00c109074832b7fa7be52bbbf8f4987d24e323b"
+source = "git+https://github.com/RichardTjokroutomo/stylo.git?branch=txt-overflow#080adb21acc877427b6d15bd87f339ed49028c37"
 dependencies = [
  "app_units",
  "bitflags 2.11.0",
@@ -9749,7 +9749,7 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 [[package]]
 name = "to_shmem"
 version = "0.3.0"
-source = "git+https://github.com/servo/stylo?rev=f00c109074832b7fa7be52bbbf8f4987d24e323b#f00c109074832b7fa7be52bbbf8f4987d24e323b"
+source = "git+https://github.com/RichardTjokroutomo/stylo.git?branch=txt-overflow#080adb21acc877427b6d15bd87f339ed49028c37"
 dependencies = [
  "cssparser",
  "servo_arc",
@@ -9762,7 +9762,7 @@ dependencies = [
 [[package]]
 name = "to_shmem_derive"
 version = "0.1.0"
-source = "git+https://github.com/servo/stylo?rev=f00c109074832b7fa7be52bbbf8f4987d24e323b#f00c109074832b7fa7be52bbbf8f4987d24e323b"
+source = "git+https://github.com/RichardTjokroutomo/stylo.git?branch=txt-overflow#080adb21acc877427b6d15bd87f339ed49028c37"
 dependencies = [
  "darling",
  "proc-macro2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -326,15 +326,15 @@ egui-winit = { git = "https://github.com/emilk/egui.git", rev = "5d8f393335e0517
 #
 # Or for Stylo:
 #
-# [patch."https://github.com/servo/stylo"]
-# selectors = { path = "../stylo/selectors" }
-# servo_arc = { path = "../stylo/servo_arc" }
-# stylo = { path = "../stylo/style" }
-# stylo_atoms = { path = "../stylo/stylo_atoms" }
-# stylo_dom = { path = "../stylo/stylo_dom" }
-# stylo_malloc_size_of = { path = "../stylo/malloc_size_of" }
-# stylo_static_prefs = { path = "../stylo/stylo_static_prefs" }
-# stylo_traits = { path = "../stylo/style_traits" }
+[patch."https://github.com/servo/stylo"]
+selectors = { git = "https://github.com/RichardTjokroutomo/stylo.git", branch = "txt-overflow" }
+servo_arc = { git = "https://github.com/RichardTjokroutomo/stylo.git", branch = "txt-overflow" }
+stylo = { git = "https://github.com/RichardTjokroutomo/stylo.git", branch = "txt-overflow" }
+stylo_atoms = { git = "https://github.com/RichardTjokroutomo/stylo.git", branch = "txt-overflow" }
+stylo_dom = { git = "https://github.com/RichardTjokroutomo/stylo.git", branch = "txt-overflow" }
+stylo_malloc_size_of = { git = "https://github.com/RichardTjokroutomo/stylo.git", branch = "txt-overflow" }
+stylo_static_prefs = { git = "https://github.com/RichardTjokroutomo/stylo.git", branch = "txt-overflow" }
+stylo_traits = { git = "https://github.com/RichardTjokroutomo/stylo.git", branch = "txt-overflow" }
 #
 # Or for another Git dependency:
 #

--- a/components/layout/display_list/hit_test.rs
+++ b/components/layout/display_list/hit_test.rs
@@ -321,6 +321,17 @@ impl Fragment {
                     Cursor::Text,
                 )
             },
+            Fragment::ElidedText(elided_text) => {
+                // TODO(richardtjokroutomo): hit tests should not hit elided text (overflowing text that got replaced with overflow indicator). Handle this in the future.
+                let text = &elided_text.borrow().text_fragment;
+                hit_test_fragment_inner(
+                    &text.base.style(),
+                    text.base.rect,
+                    BorderRadius::zero(),
+                    FragmentFlags::empty(),
+                    Cursor::Text,
+                )
+            },
             _ => false,
         }
     }

--- a/components/layout/display_list/mod.rs
+++ b/components/layout/display_list/mod.rs
@@ -761,7 +761,33 @@ impl Fragment {
                         builder,
                         containing_block,
                         text_decorations,
+                        None,
                     ),
+                    Visibility::Hidden => (),
+                    Visibility::Collapse => (),
+                }
+            },
+            Fragment::ElidedText(elided_text) => {
+                let elided_text = &*elided_text.borrow();
+                if elided_text.fully_elided {
+                    return;
+                }
+                match elided_text
+                    .text_fragment
+                    .base
+                    .style()
+                    .get_inherited_box()
+                    .visibility
+                {
+                    Visibility::Visible => {
+                        self.build_display_list_for_text_fragment(
+                            &elided_text.text_fragment,
+                            builder,
+                            containing_block,
+                            text_decorations,
+                            Some((elided_text.original_advance, elided_text.boundary)),
+                        );
+                    },
                     Visibility::Hidden => (),
                     Visibility::Collapse => (),
                 }
@@ -775,6 +801,7 @@ impl Fragment {
         builder: &mut DisplayListBuilder,
         containing_block: &PhysicalRect<Au>,
         text_decorations: &Arc<Vec<FragmentTextDecoration>>,
+        overflow_indicator_data: Option<(Au, Au)>, // TODO: Make the signature Option<(Au, (Au, Au))> once two sided `text-overflow: ellipsis` has been supported
     ) {
         // NB: The order of painting text components (CSS Text Decoration Module Level 3) is:
         // shadows, underline, overline, text, text-emphasis, and then line-through.
@@ -792,6 +819,7 @@ impl Fragment {
             baseline_origin,
             fragment.justification_adjustment,
             include_whitespace,
+            overflow_indicator_data,
         );
 
         if glyphs.is_empty() && !fragment.is_empty_for_text_cursor {
@@ -1806,12 +1834,20 @@ fn glyphs(
     mut baseline_origin: PhysicalPoint<Au>,
     justification_adjustment: Au,
     include_whitespace: bool,
+    // (original_advance, maximum advance before eliding)
+    additional_data: Option<(Au, Au)>, // TODO: Make the signature Option<(Au, (Au, Au))> once two sided `text-overflow: ellipsis` has been supported.
 ) -> (Vec<GlyphInstance>, Au) {
     let mut glyphs = vec![];
     let mut largest_advance = Au::zero();
+    let mut total_advance = Au::zero();
+
+    if let Some((original_inline_advance, _)) = additional_data {
+        total_advance += original_inline_advance
+    };
 
     for run in glyph_runs {
         for glyph in run.glyphs() {
+            total_advance += glyph.advance();
             if !run.is_whitespace() || include_whitespace {
                 let glyph_offset = glyph.offset().unwrap_or(Point2D::zero());
                 let point = LayoutPoint::new(
@@ -1822,7 +1858,14 @@ fn glyphs(
                     index: glyph.id(),
                     point,
                 };
-                glyphs.push(glyph_instance);
+                match additional_data {
+                    Some((_, boundaries)) => {
+                        if total_advance <= boundaries {
+                            glyphs.push(glyph_instance);
+                        }
+                    },
+                    None => glyphs.push(glyph_instance),
+                }
             }
 
             if glyph.char_is_word_separator() {

--- a/components/layout/display_list/stacking_context.rs
+++ b/components/layout/display_list/stacking_context.rs
@@ -968,7 +968,10 @@ impl Fragment {
                     text_decorations,
                 );
             },
-            Fragment::Text(_) | Fragment::Image(_) | Fragment::IFrame(_) => {
+            Fragment::Text(_) |
+            Fragment::Image(_) |
+            Fragment::IFrame(_) |
+            Fragment::ElidedText(_) => {
                 stacking_context
                     .contents
                     .push(StackingContextContent::Fragment {

--- a/components/layout/flow/inline/line.rs
+++ b/components/layout/flow/inline/line.rs
@@ -7,7 +7,8 @@ use std::sync::Arc;
 
 use app_units::Au;
 use bitflags::bitflags;
-use fonts::{FontMetrics, GlyphStore};
+use euclid::Point2D;
+use fonts::{FontMetrics, FontRef, GlyphStore, ShapingFlags, ShapingOptions};
 use itertools::Either;
 use layout_api::wrapper_traits::SharedSelection;
 use malloc_size_of_derive::MallocSizeOf;
@@ -19,12 +20,16 @@ use style::values::generics::box_::BaselineShiftKeyword;
 use style::values::specified::align::AlignFlags;
 use style::values::specified::box_::DisplayOutside;
 use unicode_bidi::{BidiInfo, Level};
+use unicode_script::Script;
 use webrender_api::FontInstanceKey;
 
 use super::inline_box::{InlineBoxContainerState, InlineBoxIdentifier, InlineBoxTreePathToken};
 use super::{InlineFormattingContextLayout, LineBlockSizes, SharedInlineStyles, line_height};
 use crate::cell::ArcRefCell;
-use crate::fragment_tree::{BaseFragment, BaseFragmentInfo, BoxFragment, Fragment, TextFragment};
+use crate::flow::inline::text_run::TextRunSegment;
+use crate::fragment_tree::{
+    BaseFragment, BaseFragmentInfo, BoxFragment, ElidedTextFragment, Fragment, TextFragment,
+};
 use crate::geom::{
     LogicalRect, LogicalVec2, PhysicalRect, ToLogical, ToLogicalWithContainingBlock,
 };
@@ -167,6 +172,7 @@ impl LineItemLayout<'_, '_> {
         effective_block_advance: &LineBlockSizes,
         justification_adjustment: Au,
         is_phantom_line: bool,
+        can_be_elided: bool,
     ) -> Vec<Fragment> {
         let baseline_offset = effective_block_advance.find_baseline_offset();
         LineItemLayout {
@@ -184,7 +190,7 @@ impl LineItemLayout<'_, '_> {
             justification_adjustment,
             is_phantom_line,
         }
-        .layout(line_items)
+        .layout(line_items, can_be_elided)
     }
 
     /// Start and end inline boxes in tree order, so that it reflects the given inline box.
@@ -212,13 +218,27 @@ impl LineItemLayout<'_, '_> {
         }
     }
 
-    pub(super) fn layout(&mut self, mut line_items: Vec<LineItem>) -> Vec<Fragment> {
+    pub(super) fn layout(
+        &mut self,
+        mut line_items: Vec<LineItem>,
+        can_be_elided: bool,
+    ) -> Vec<Fragment> {
         let mut last_level = Level::ltr();
+        let mut total_line_advance = Au(0);
         let levels: Vec<_> = line_items
             .iter()
             .map(|item| {
                 let level = match item {
-                    LineItem::TextRun(_, text_run) => text_run.bidi_level,
+                    LineItem::TextRun(_, text_run) => {
+                        if can_be_elided {
+                            total_line_advance += text_run
+                                .text
+                                .iter()
+                                .map(|glyph_store| glyph_store.total_advance())
+                                .sum();
+                        }
+                        text_run.bidi_level
+                    },
                     // TODO: This level needs either to be last_level, or if there were
                     // unicode characters inserted for the inline box, we need to get the
                     // level from them.
@@ -254,6 +274,20 @@ impl LineItemLayout<'_, '_> {
         } else {
             Either::Right(line_items.into_iter().rev())
         };
+        let overflow_indicator_data = if self.check_if_must_be_elided(
+            can_be_elided,
+            total_line_advance,
+            total_line_advance,
+        ) {
+            self.form_overflow_indicator("\u{2026}")
+        } else {
+            None
+        };
+        let mut cumulative_advance = Au(0);
+        let mut overflow_indicator_total_advance = Au(0);
+        if let Some((ref overflow_indicator_segment, _, _)) = overflow_indicator_data {
+            overflow_indicator_total_advance += overflow_indicator_segment.runs[0].total_advance();
+        }
 
         for item in line_item_iterator.into_iter().by_ref() {
             // When preparing to lay out a new line item, start and end inline boxes, so that the current
@@ -276,7 +310,29 @@ impl LineItemLayout<'_, '_> {
                         .flags
                         .insert(LineLayoutInlineContainerFlags::HAD_INLINE_END_PBM);
                 },
-                LineItem::TextRun(_, text_run) => self.layout_text_run(text_run),
+                LineItem::TextRun(_, text_run) => {
+                    if self.check_if_must_be_elided(
+                        can_be_elided,
+                        total_line_advance,
+                        total_line_advance,
+                    ) {
+                        cumulative_advance += text_run
+                            .text
+                            .iter()
+                            .map(|glyph_store| glyph_store.total_advance())
+                            .sum();
+                    }
+
+                    self.layout_text_run(
+                        text_run,
+                        self.check_if_must_be_elided(
+                            can_be_elided,
+                            cumulative_advance + overflow_indicator_total_advance,
+                            total_line_advance,
+                        ),
+                        &overflow_indicator_data,
+                    )
+                },
                 LineItem::Atomic(_, atomic) => self.layout_atomic(atomic),
                 LineItem::AbsolutelyPositioned(_, absolute) => self.layout_absolute(absolute),
                 LineItem::Float(_, float) => self.layout_float(float),
@@ -302,10 +358,20 @@ impl LineItemLayout<'_, '_> {
                 if let Some(mut base) = fragment.base_mut() {
                     base.rect = logical_rect.as_physical(Some(containing_block));
                 }
-
                 fragment
             })
             .collect()
+    }
+
+    fn check_if_must_be_elided(
+        &self,
+        can_be_elided: bool,
+        cumulative_advance: Au, // total advance of all text items so far + advance of overflow indicator
+        total_line_advance: Au,
+    ) -> bool {
+        can_be_elided &&
+            (total_line_advance > self.containing_block().size.inline) &&
+            (cumulative_advance > self.containing_block().size.inline)
     }
 
     fn current_positioning_context_mut(&mut self) -> &mut PositioningContext {
@@ -534,7 +600,12 @@ impl LineItemLayout<'_, '_> {
         }
     }
 
-    fn layout_text_run(&mut self, text_item: TextRunLineItem) {
+    fn layout_text_run(
+        &mut self,
+        text_item: TextRunLineItem,
+        must_be_elided: bool,
+        overflow_indicator_data: &Option<(TextRunSegment, FontRef, FontInstanceKey)>,
+    ) {
         if text_item.text.is_empty() && !text_item.is_empty_for_text_cursor {
             return;
         }
@@ -572,9 +643,86 @@ impl LineItemLayout<'_, '_> {
             },
         };
 
+        let original_inline_advance = self.current_state.inline_advance;
         self.current_state.inline_advance += inline_advance;
-        self.current_state.fragments.push((
-            Fragment::Text(ArcRefCell::new(TextFragment {
+
+        if !must_be_elided || original_inline_advance >= self.current_state.inline_advance {
+            self.current_state.fragments.push((
+                Fragment::Text(ArcRefCell::new(TextFragment {
+                    base: BaseFragment::new(
+                        text_item.base_fragment_info,
+                        text_item.inline_styles.style.clone().into(),
+                        PhysicalRect::zero(),
+                    ),
+                    selected_style: text_item.inline_styles.selected.clone(),
+                    font_metrics: text_item.font_metrics,
+                    font_key: text_item.font_key,
+                    glyphs: text_item.text,
+                    justification_adjustment: self.justification_adjustment,
+                    offsets: text_item.offsets,
+                    is_empty_for_text_cursor: text_item.is_empty_for_text_cursor,
+                })),
+                content_rect,
+            ));
+        } else {
+            // 1. Unpack overflow indicator data & create some local variables
+            let (overflow_indicator_textrun_segment, font, font_instance_key) =
+                overflow_indicator_data
+                    .as_ref()
+                    .expect("If the else block hits, then the tuple must exist.");
+            let overflow_indicator_font = font.clone();
+            let overflow_indicator_font_instance_key = *font_instance_key;
+            let overflow_indicator_total_advance =
+                overflow_indicator_textrun_segment.runs[0].total_advance();
+            let inline_target =
+                self.containing_block().size.inline - overflow_indicator_total_advance; // TODO: Consider margin and such.
+
+            // 2. form the bounding box of the overflow indicator
+            // 2.1. Find the inline start corner (if horizontal, then starting x pos), denoted as `inline_start`.
+            // `inline_target` is the minimum value for `inline_start`.
+            // The inline start corner of the ellipsis bounding box must be between
+            // `inline_target` & `self.layout.containing_block.size.inline`.
+            // With the current implementation,
+            // `overflow_textrun_segment.runs` is never empty since it is the glyph store of the ellipsis glyph.
+            let mut inline_start = original_inline_advance;
+            let mut found = false;
+
+            for store in &text_item.text {
+                for glyph in store.glyphs() {
+                    if !found &&
+                        inline_start +
+                            glyph.advance() +
+                            glyph.offset().unwrap_or(Point2D::zero()).x <=
+                            inline_target
+                    {
+                        inline_start += glyph.advance();
+                        inline_start += glyph.offset().unwrap_or(Point2D::zero()).x;
+                    } else {
+                        found = true;
+                    }
+                }
+            }
+
+            // 2.2. Create the bounding box of the ellipsis text fragment.
+            // When computing `start_corner.block`,
+            // This uses the same logic used in `LineItemLayout::layout_text_run`,
+            // the difference is that I am using the `ascent` of the IFC.
+            let overflow_indicator_start_corner = LogicalVec2 {
+                inline: inline_start,
+                block: self.current_state.baseline_offset -
+                    overflow_indicator_font.metrics.ascent -
+                    self.current_state.parent_offset.block,
+            };
+            let overflow_indicator_content_rect = LogicalRect {
+                start_corner: overflow_indicator_start_corner,
+                size: LogicalVec2 {
+                    block: overflow_indicator_font.metrics.line_gap,
+                    inline: overflow_indicator_total_advance,
+                },
+            };
+
+            // create text fragment
+            let text_fragment = TextFragment {
                 base: BaseFragment::new(
                     text_item.base_fragment_info,
                     text_item.inline_styles.style.clone().into(),
@@ -585,13 +733,135 @@ impl LineItemLayout<'_, '_> {
                 font_key: text_item.font_key,
                 glyphs: text_item.text,
                 justification_adjustment: self.justification_adjustment,
-                offsets: text_item.offsets,
+                offsets: text_item.offsets.clone(),
                 is_empty_for_text_cursor: text_item.is_empty_for_text_cursor,
-            })),
-            content_rect,
-        ));
+            };
+
+            // create elided text fragment
+            self.current_state.fragments.push((
+                Fragment::ElidedText(ArcRefCell::new(ElidedTextFragment {
+                    text_fragment,
+                    fully_elided: original_inline_advance >= inline_target,
+                    original_advance: original_inline_advance,
+                    boundary: inline_target,
+                })),
+                content_rect,
+            ));
+
+            // create overflow indicator text fragment
+            if original_inline_advance <= inline_target {
+                self.current_state.fragments.push((
+                    Fragment::Text(ArcRefCell::new(TextFragment {
+                        base: BaseFragment::new(
+                            text_item.base_fragment_info,
+                            self.layout.ifc.shared_inline_styles.style.clone().into(),
+                            PhysicalRect::zero(),
+                        ),
+                        selected_style: self.layout.ifc.shared_inline_styles.style.clone(),
+                        font_metrics: overflow_indicator_font.metrics.clone(),
+                        font_key: overflow_indicator_font_instance_key,
+                        glyphs: overflow_indicator_textrun_segment.runs.clone(),
+                        justification_adjustment: self.justification_adjustment,
+                        offsets: text_item.offsets,
+                        is_empty_for_text_cursor: text_item.is_empty_for_text_cursor,
+                    })),
+                    overflow_indicator_content_rect,
+                ));
+            }
+        }
     }
 
+    fn form_overflow_indicator(
+        &mut self,
+        overflow_indicator_text: &str,
+    ) -> Option<(TextRunSegment, FontRef, FontInstanceKey)> {
+        // CSS specs (for `text-overflow: ellipsis`):
+        // 1. The ellipsis is styled and baseline-aligned according to the block.
+        // 2. Render an ellipsis character (U+2026) to represent clipped inline content.
+        // Implementations may substitute a more language, script,
+        // or writing-mode appropriate ellipsis character, or three dots "..."
+        // if the ellipsis character is unavailable.
+        // <https://www.w3.org/TR/css-ui-3/#text-overflow>
+        // TODO: add the fallback three dots.
+
+        // 1. Create the arguments needed to create a `TextRunSegment`
+        let overflow_indicator_char = overflow_indicator_text.chars().next().unwrap();
+
+        let overflow_indicator_script = Script::from(overflow_indicator_char);
+        let overflow_indicator_bidi = BidiInfo::new(overflow_indicator_text, None);
+        let overflow_indicator_bidi_level = overflow_indicator_bidi.levels[0];
+        let overflow_indicator_start_byte_index: usize = 0;
+
+        // According to spec # 1, we should use the styling of the block.
+        // In the context of Servo, this corresponds to the IFC of current `TextRunSegment`.
+        let overflow_indicator_font_context = &self.layout.layout_context.font_context;
+        let overflow_indicator_painter_id = self.layout.layout_context.painter_id;
+
+        let overflow_indicator_font_group = overflow_indicator_font_context
+            .font_group(self.layout.containing_block().style.clone().clone_font());
+
+        let x_lang = self
+            .layout
+            .ifc
+            .shared_inline_styles
+            .style
+            .borrow()
+            .clone__x_lang();
+
+        let overflow_indicator_font = match overflow_indicator_font_group.find_by_codepoint(
+            overflow_indicator_font_context,
+            overflow_indicator_char,
+            None,
+            x_lang.clone(),
+        ) {
+            Some(font) => font,
+            None => overflow_indicator_font_group.first(overflow_indicator_font_context)?,
+        };
+
+        let overflow_font_instance_key = overflow_indicator_font.key(
+            overflow_indicator_painter_id,
+            overflow_indicator_font_context,
+        );
+
+        // 2. Create the `TextRunSegment`
+        let mut overflow_indicator_textrun_segment = TextRunSegment::new(
+            overflow_indicator_font.clone(),
+            overflow_indicator_script,
+            overflow_indicator_bidi_level,
+            overflow_indicator_start_byte_index,
+            0,
+        );
+
+        // 3. Create arguments for shaping, which will be done by `shape_and_push_range()`
+        // one possible concern is RTL for `text-overflow: string`. However, this won't be an issue,
+        // because RTL won't affect the ordering of the glyph.
+        // For example, if text-overflow: '123', then RTL won't reverse it to '321'
+        let overflow_indicator_flags = ShapingFlags::empty();
+
+        let overflow_indicator_shaping_options = ShapingOptions {
+            // CSS specs doesn't mention anything, but for Firefox, even for `text-overflow: <string>`,
+            // any string with more than one character is considered as one, so `letter-spacing`
+            // is irrelevant.
+            letter_spacing: None,
+            word_spacing: Au(0), // No word spacing.
+            script: overflow_indicator_textrun_segment.script,
+            flags: overflow_indicator_flags,
+        };
+
+        // 4. Shape text
+        overflow_indicator_textrun_segment.shape_and_push_range(
+            &(0..overflow_indicator_text.len()),
+            overflow_indicator_text,
+            &overflow_indicator_shaping_options,
+        );
+
+        // Return
+        Some((
+            overflow_indicator_textrun_segment,
+            overflow_indicator_font,
+            overflow_font_instance_key,
+        ))
+    }
     fn layout_atomic(&mut self, atomic: AtomicLineItem) {
         // The initial `start_corner` of the Fragment is only the PaddingBorderMargin sum start
         // offset, which is the sum of the start component of the padding, border, and margin.
@@ -799,7 +1069,7 @@ impl LineItem {
     }
 }
 
-#[derive(Debug, MallocSizeOf)]
+#[derive(Debug, MallocSizeOf, Clone)]
 pub(crate) struct TextRunOffsets {
     /// The selection range of the containing inline formatting context.
     #[ignore_malloc_size_of = "This is stored primarily in the DOM"]

--- a/components/layout/flow/inline/mod.rs
+++ b/components/layout/flow/inline/mod.rs
@@ -96,6 +96,7 @@ use script::layout_dom::ServoThreadSafeLayoutNode;
 use servo_arc::Arc as ServoArc;
 use style::Zero;
 use style::computed_values::line_break::T as LineBreak;
+use style::computed_values::overflow_x::T as Overflow_X;
 use style::computed_values::text_wrap_mode::T as TextWrapMode;
 use style::computed_values::white_space_collapse::T as WhiteSpaceCollapse;
 use style::computed_values::word_break::T as WordBreak;
@@ -105,8 +106,8 @@ use style::properties::style_structs::InheritedText;
 use style::values::computed::BaselineShift;
 use style::values::generics::box_::BaselineShiftKeyword;
 use style::values::generics::font::LineHeight;
-use style::values::specified::box_::BaselineSource;
-use style::values::specified::text::TextAlignKeyword;
+use style::values::specified::box_::{BaselineSource, DisplayInside};
+use style::values::specified::text::{TextAlignKeyword, TextOverflowSide};
 use style::values::specified::{AlignmentBaseline, TextAlignLast, TextJustify};
 use text_run::{
     TextRun, XI_LINE_BREAKING_CLASS_GL, XI_LINE_BREAKING_CLASS_WJ, XI_LINE_BREAKING_CLASS_ZWJ,
@@ -1167,6 +1168,15 @@ impl InlineFormattingContextLayout<'_> {
 
         let baseline_offset = effective_block_advance.find_baseline_offset();
         let start_positioning_context_length = self.positioning_context.len();
+        let ifc_style = self.ifc.shared_inline_styles.style.borrow();
+
+        let can_be_elided = match &ifc_style.get_text().text_overflow.second {
+            TextOverflowSide::Clip => false,
+            TextOverflowSide::Ellipsis => true,
+            TextOverflowSide::String(_s) => false, // TODO(richardtjokroutomo): add support for text-overflow: string in future PR
+        } && (ifc_style.get_box().overflow_x != Overflow_X::Visible) && // TODO: Use logical coordinates (block, inline) instead of physical ones (x, y)
+            (ifc_style.get_box().display.inside() == DisplayInside::Flow);
+
         let fragments = LineItemLayout::layout_line_items(
             self,
             line_to_layout.line_items,
@@ -1174,6 +1184,7 @@ impl InlineFormattingContextLayout<'_> {
             &effective_block_advance,
             justification_adjustment,
             is_phantom_line,
+            can_be_elided,
         );
 
         if !is_phantom_line {

--- a/components/layout/flow/inline/text_run.rs
+++ b/components/layout/flow/inline/text_run.rs
@@ -81,7 +81,7 @@ pub(crate) struct TextRunSegment {
 }
 
 impl TextRunSegment {
-    fn new(
+    pub(super) fn new(
         font: FontRef,
         script: Script,
         bidi_level: Level,
@@ -190,7 +190,7 @@ impl TextRunSegment {
         }
     }
 
-    fn shape_and_push_range(
+    pub(super) fn shape_and_push_range(
         &mut self,
         range: &Range<usize>,
         formatting_context_text: &str,

--- a/components/layout/fragment_tree/fragment.rs
+++ b/components/layout/fragment_tree/fragment.rs
@@ -48,6 +48,7 @@ pub(crate) enum Fragment {
     Text(ArcRefCell<TextFragment>),
     Image(ArcRefCell<ImageFragment>),
     IFrame(ArcRefCell<IFrameFragment>),
+    ElidedText(ArcRefCell<ElidedTextFragment>),
 }
 
 #[derive(Clone, MallocSizeOf)]
@@ -63,7 +64,7 @@ pub(crate) struct CollapsedMargin {
     min_negative: Au,
 }
 
-#[derive(MallocSizeOf)]
+#[derive(MallocSizeOf, Clone)]
 pub(crate) struct TextFragment {
     pub base: BaseFragment,
     pub selected_style: SharedStyle,
@@ -80,6 +81,18 @@ pub(crate) struct TextFragment {
     /// Whether or not this [`TextFragment`] is an empty fragment added for the
     /// benefit of placing a text cursor on an otherwise empty editable line.
     pub is_empty_for_text_cursor: bool,
+}
+
+/// [`ElidedTextFragment`] is a superset of [`TextFragment`].
+/// An [`ElidedTextFragment`] can be one of the following two:
+/// 1. It is a fragment for an elided text item.
+/// 2. It is a fragment for the overflow indicator.
+#[derive(MallocSizeOf, Clone)]
+pub(crate) struct ElidedTextFragment {
+    pub text_fragment: TextFragment,
+    pub fully_elided: bool,
+    pub original_advance: Au,
+    pub boundary: Au, // TODO: In the future, make the signature (Au, Au) once two sided `text-overflow: ellipsis` has been supported
 }
 
 #[derive(MallocSizeOf)]
@@ -117,6 +130,9 @@ impl Fragment {
             Fragment::Float(fragment) => {
                 AtomicRef::map(fragment.borrow(), |fragment| &fragment.base)
             },
+            Fragment::ElidedText(fragment) => {
+                AtomicRef::map(fragment.borrow(), |fragment| &fragment.text_fragment.base)
+            },
         })
     }
 
@@ -141,6 +157,11 @@ impl Fragment {
             Fragment::Float(fragment) => {
                 AtomicRefMut::map(fragment.borrow_mut(), |fragment| &mut fragment.base)
             },
+            Fragment::ElidedText(fragment) => {
+                AtomicRefMut::map(fragment.borrow_mut(), |fragment| {
+                    &mut fragment.text_fragment.base
+                })
+            },
         })
     }
 
@@ -163,6 +184,7 @@ impl Fragment {
             Fragment::Text(_) => {},
             Fragment::Image(_) => {},
             Fragment::IFrame(_) => {},
+            Fragment::ElidedText(_) => {},
         }
     }
 
@@ -185,6 +207,7 @@ impl Fragment {
             Fragment::Text(fragment) => fragment.borrow().print(tree),
             Fragment::Image(fragment) => fragment.borrow().print(tree),
             Fragment::IFrame(fragment) => fragment.borrow().print(tree),
+            Fragment::ElidedText(fragment) => fragment.borrow().print(tree),
         }
     }
 
@@ -207,7 +230,8 @@ impl Fragment {
             Fragment::AbsoluteOrFixedPositioned(_) |
             Fragment::Text(..) |
             Fragment::Image(..) |
-            Fragment::IFrame(..) => self.base().map(|base| base.rect).unwrap_or_default(),
+            Fragment::IFrame(..) |
+            Fragment::ElidedText(..) => self.base().map(|base| base.rect).unwrap_or_default(),
         }
     }
 
@@ -242,7 +266,8 @@ impl Fragment {
             Fragment::Text(_) |
             Fragment::AbsoluteOrFixedPositioned(_) |
             Fragment::Image(_) |
-            Fragment::IFrame(_) => None,
+            Fragment::IFrame(_) |
+            Fragment::ElidedText(_) => None,
         }
     }
 
@@ -433,6 +458,12 @@ impl IFrameFragment {
                 \npipeline={:?} rect={:?}",
             self.pipeline_id, self.base.rect
         ));
+    }
+}
+
+impl ElidedTextFragment {
+    pub fn print(&self, tree: &mut PrintTree) {
+        tree.add_item("Elided Text".to_string());
     }
 }
 

--- a/components/layout/query.rs
+++ b/components/layout/query.rs
@@ -412,7 +412,7 @@ fn resolved_size_should_be_used_value(fragment: &Fragment) -> bool {
         Fragment::AbsoluteOrFixedPositioned(_) |
         Fragment::Image(_) |
         Fragment::IFrame(_) => true,
-        Fragment::Text(_) => false,
+        Fragment::Text(_) | Fragment::ElidedText(_) => false,
     }
 }
 
@@ -1308,9 +1308,14 @@ pub fn find_character_offset_in_fragment_descendants(
         point_in_fragment: Point2D<Au, CSSPixel>,
         closest_relative_fragment: &mut ClosestFragment,
     ) {
-        let Fragment::Text(text_fragment) = fragment else {
-            return;
+        let text_fragment = match fragment {
+            Fragment::Text(txt_fragment) => txt_fragment.clone(),
+            Fragment::ElidedText(elided_fragment) => {
+                ArcRefCell::new(elided_fragment.borrow().text_fragment.clone())
+            },
+            _ => return,
         };
+
         let Some(new_distance) = text_fragment
             .borrow()
             .distance_to_point_for_glyph_offset(point_in_fragment)
@@ -1321,7 +1326,7 @@ pub fn find_character_offset_in_fragment_descendants(
         {
             return;
         };
-        *closest_relative_fragment = Some((new_distance, point_in_fragment, text_fragment.clone()))
+        *closest_relative_fragment = Some((new_distance, point_in_fragment, text_fragment))
     }
 
     fn collect_relevant_children(

--- a/deny.toml
+++ b/deny.toml
@@ -231,4 +231,7 @@ github = [
 
     # Temporarily needed by servoshell: see root Cargo.toml
     "emilk",
+
+    # TODO: remove this once stylo PR lands.
+    "RichardTjokroutomo",
 ]

--- a/tests/unit/style/parsing/text_overflow.rs
+++ b/tests/unit/style/parsing/text_overflow.rs
@@ -12,12 +12,13 @@ fn test_text_overflow() {
 
     assert_roundtrip_with_context!(text_overflow::parse, r#"clip"#);
     assert_roundtrip_with_context!(text_overflow::parse, r#"ellipsis"#);
-    assert_roundtrip_with_context!(text_overflow::parse, r#"clip ellipsis"#);
-    assert_roundtrip_with_context!(text_overflow::parse, r#""x""#);
-    assert_roundtrip_with_context!(text_overflow::parse, r#"'x'"#, r#""x""#);
-    assert_roundtrip_with_context!(text_overflow::parse, r#"clip "x""#);
-    assert_roundtrip_with_context!(text_overflow::parse, r#""x" clip"#);
-    assert_roundtrip_with_context!(text_overflow::parse, r#""x" "y""#);
+    // TODO: Uncomment this assertion once two-valued text-overflow is supported.
+    // assert_roundtrip_with_context!(text_overflow::parse, r#"clip ellipsis"#);
+    // assert_roundtrip_with_context!(text_overflow::parse, r#""x""#);
+    // assert_roundtrip_with_context!(text_overflow::parse, r#"'x'"#, r#""x""#);
+    // assert_roundtrip_with_context!(text_overflow::parse, r#"clip "x""#);
+    // assert_roundtrip_with_context!(text_overflow::parse, r#""x" clip"#);
+    // assert_roundtrip_with_context!(text_overflow::parse, r#""x" "y""#);
 }
 
 #[test]
@@ -27,5 +28,6 @@ fn test_text_overflow_parser_exhaustion() {
     assert_parser_exhausted!(text_overflow::parse, r#"clip rubbish"#, false);
     assert_parser_exhausted!(text_overflow::parse, r#"clip"#, true);
     assert_parser_exhausted!(text_overflow::parse, r#"ellipsis"#, true);
-    assert_parser_exhausted!(text_overflow::parse, r#"clip ellipsis"#, true);
+    // TODO: Uncomment this assertion once two-valued text-overflow is supported.
+    // assert_parser_exhausted!(text_overflow::parse, r#"clip ellipsis"#, true);
 }


### PR DESCRIPTION
Layout: add initial support for `text-overflow: ellipsis` property, which is a re-implementation of #40526 .

Companion stylo PR: [#270](https://github.com/servo/stylo/pull/270)

Testing: existing WPT
Fixes: #40444 
