### PR TITLE
Implement loop count for animated image

### DIFF
--- a/components/net/image_cache.rs
+++ b/components/net/image_cache.rs
@@ -1037,6 +1037,7 @@ impl ImageCache for ImageCacheImpl {
                 id: None,
                 cors_status: vector_image.cors_status,
                 is_opaque: false,
+                loop_count: None,
             };
 
             let mut store = store.lock();

--- a/components/pixels/lib.rs
+++ b/components/pixels/lib.rs
@@ -312,8 +312,10 @@ pub struct RasterImage {
     pub frames: Vec<ImageFrame>,
     /// Whether or not all of the frames of this image are opaque.
     pub is_opaque: bool,
-    pub loop_count: Option<Repeat>, // For non-looptable, this would be None,
-                                    // For animated image, there would be default value of Infinite type.
+    /// The loop count for the image animation.
+    /// For non-looptable images, this would be `None`.
+    /// For animated images, there would be a default value of `Repeat::Infinite`.
+    pub loop_count: Option<Repeat>,
 }
 
 fn sensible_delay(delay: Duration) -> Duration {

--- a/components/pixels/lib.rs
+++ b/components/pixels/lib.rs
@@ -16,6 +16,7 @@ use euclid::default::{Point2D, Rect, Size2D};
 use image::codecs::{bmp, gif, ico, jpeg, png, webp};
 use image::error::ImageFormatHint;
 use image::imageops::{self, FilterType};
+use image::metadata::LoopCount;
 use image::{
     AnimationDecoder, DynamicImage, ImageBuffer, ImageDecoder, ImageError, ImageFormat,
     ImageResult, Limits, Rgba,
@@ -814,6 +815,10 @@ where
     let mut frame_data = vec![];
     let mut total_number_of_bytes = 0;
     let mut is_opaque = true;
+    let loop_count = match animated_image_decoder.loop_count() {
+        LoopCount::Finite(repeat_time) => Repeat::Finite(repeat_time),
+        LoopCount::Infinite => Repeat::Infinite,
+    };
     let frames: Vec<ImageFrame> = animated_image_decoder
         .into_frames()
         .map_while(|decoded_frame| {
@@ -871,7 +876,7 @@ where
         format: PixelFormat::RGBA8,
         bytes: Arc::new(bytes),
         is_opaque,
-        loop_count: Some(Repeat::Infinite), // TODO(Ray): wait for image-rs 0.26 release for exposing repeat count, default to Infinite for now.
+        loop_count: Some(loop_count),
     })
 }
 

--- a/components/pixels/lib.rs
+++ b/components/pixels/lib.rs
@@ -6,6 +6,7 @@ mod snapshot;
 
 use std::borrow::Cow;
 use std::io::Cursor;
+use std::num::NonZeroU32;
 use std::ops::Range;
 use std::sync::Arc;
 use std::time::Duration;
@@ -281,6 +282,11 @@ pub enum CorsStatus {
     Unsafe,
 }
 
+#[derive(Clone, MallocSizeOf, PartialEq)]
+pub enum Repeat {
+    Infinite,
+    Finite(NonZeroU32),
+}
 /// A version of [`RasterImage`] that can be sent across IPC channels.
 #[derive(Clone, Debug, Deserialize, MallocSizeOf, Serialize)]
 pub struct SharedRasterImage {
@@ -306,6 +312,8 @@ pub struct RasterImage {
     pub frames: Vec<ImageFrame>,
     /// Whether or not all of the frames of this image are opaque.
     pub is_opaque: bool,
+    pub loop_count: Option<Repeat>, // For non-looptable, this would be None,
+                                    // For animated image, there would be default value of Infinite type.
 }
 
 fn sensible_delay(delay: Duration) -> Duration {
@@ -784,6 +792,7 @@ fn decode_static_image(
         id: None,
         cors_status,
         is_opaque,
+        loop_count: None,
     })
 }
 
@@ -860,6 +869,7 @@ where
         format: PixelFormat::RGBA8,
         bytes: Arc::new(bytes),
         is_opaque,
+        loop_count: Some(Repeat::Infinite), // TODO(Ray): wait for image-rs 0.26 release for exposing repeat count, default to Infinite for now.
     })
 }
 

--- a/components/pixels/lib.rs
+++ b/components/pixels/lib.rs
@@ -313,9 +313,9 @@ pub struct RasterImage {
     pub frames: Vec<ImageFrame>,
     /// Whether or not all of the frames of this image are opaque.
     pub is_opaque: bool,
-    /// The loop count for the image animation.
-    /// For non-looptable images, this would be `None`.
-    /// For animated images, there would be a default value of `Repeat::Infinite`.
+    /// The loop count for this image's animation. For animated images, this
+    /// has a default value of `Repeat::Infinite` (if no loop count is specified in
+    /// the image).  For images that do not animate, this will be `None`.
     pub loop_count: Option<Repeat>,
 }
 

--- a/components/script/image_animation.rs
+++ b/components/script/image_animation.rs
@@ -52,7 +52,7 @@ impl ImageAnimationManager {
             .read()
             .node_to_state_map
             .values()
-            .map(|state| state.duration_to_next_frame(now))
+            .filter_map(|state| state.duration_to_next_frame(now))
             .min()
     }
 

--- a/components/shared/layout/lib.rs
+++ b/components/shared/layout/lib.rs
@@ -810,13 +810,11 @@ impl ImageAnimationState {
             return false;
         }
         if let Some(repeat) = &self.image.loop_count &&
-            let Repeat::Finite(loop_times) = repeat
+            let Repeat::Finite(loop_times) = repeat &&
+            let Some(current_loop_count) = self.current_loop_count &&
+            current_loop_count >= loop_times.get()
         {
-            if let Some(current_loop_count) = self.current_loop_count {
-                if current_loop_count >= loop_times.get() {
-                    return false;
-                }
-            }
+            return false;
         }
         let image = &self.image;
         let time_interval_since_last_update = now - self.frame_start_time;
@@ -843,15 +841,15 @@ impl ImageAnimationState {
                 .unwrap()
                 .as_secs_f64();
         }
-        if let Some(Repeat::Finite(repeat_times)) = self.image.loop_count {
-            if let Some(current_loop_cnt) = self.current_loop_count {
-                let new_loop_cnt = current_loop_cnt + advance_loop;
-                self.current_loop_count = Some(new_loop_cnt);
-                // the "now" time value exceed the time value after iterating through loop_cnt times.
-                if new_loop_cnt >= repeat_times.get() {
-                    // should freeze at last frame
-                    return self.active_frame != (self.image.frames.len() - 1);
-                }
+        if let Some(Repeat::Finite(repeat_times)) = self.image.loop_count &&
+            let Some(current_loop_count) = self.current_loop_count 
+        {
+            let new_loop_cnt = current_loop_count + advance_loop;
+            self.current_loop_count = Some(new_loop_cnt);
+            // the "now" time value exceed the time value after iterating through loop_cnt times.
+            if new_loop_cnt >= repeat_times.get() {
+                // should freeze at last frame
+                return self.active_frame != (self.image.frames.len() - 1);
             }
         }
         if self.active_frame == next_active_frame_id {

--- a/components/shared/layout/lib.rs
+++ b/components/shared/layout/lib.rs
@@ -788,7 +788,10 @@ impl ImageAnimationState {
         self.image.id
     }
 
-    pub fn duration_to_next_frame(&self, now: f64) -> Duration {
+    pub fn duration_to_next_frame(&self, now: f64) -> Option<Duration> {
+        if self.is_finished() {
+            return None;
+        }
         let frame_delay = self
             .image
             .frames
@@ -799,21 +802,14 @@ impl ImageAnimationState {
 
         let time_since_frame_start = (now - self.frame_start_time).max(0.0) * 1000.0;
         let time_since_frame_start = Duration::from_secs_f64(time_since_frame_start);
-        frame_delay - time_since_frame_start.min(frame_delay)
+        Some(frame_delay - time_since_frame_start.min(frame_delay))
     }
 
     /// check whether image active frame need to be updated given current time,
     /// return true if there are image that need to be updated.
     /// false otherwise.
     pub fn update_frame_for_animation_timeline_value(&mut self, now: f64) -> bool {
-        if self.image.frames.len() <= 1 {
-            return false;
-        }
-        if let Some(repeat) = &self.image.loop_count &&
-            let Repeat::Finite(loop_times) = repeat &&
-            let Some(current_loop_count) = self.current_loop_count &&
-            current_loop_count >= loop_times.get()
-        {
+        if self.image.frames.len() <= 1 || self.is_finished() {
             return false;
         }
         let image = &self.image;
@@ -849,7 +845,12 @@ impl ImageAnimationState {
             // the "now" time value exceed the time value after iterating through loop_cnt times.
             if new_loop_cnt >= repeat_times.get() {
                 // should freeze at last frame
-                return self.active_frame != (self.image.frames.len() - 1);
+                if self.active_frame != (self.image.frames.len() - 1) {
+                    self.active_frame = self.image.frames.len() - 1;
+                    self.frame_start_time = now;
+                    return true;
+                } // at this point, we can know the animation has finished, and potentially can set the flag here.
+                return false;
             }
         }
         if self.active_frame == next_active_frame_id {
@@ -858,6 +859,17 @@ impl ImageAnimationState {
         self.active_frame = next_active_frame_id;
         self.frame_start_time = now;
         true
+    }
+
+    fn is_finished(&self) -> bool {
+        let Some(Repeat::Finite(loop_times)) = self.image.loop_count.as_ref() else {
+            return false;
+        };
+        let Some(current_loop_count) = self.current_loop_count else {
+            return false;
+        };
+        current_loop_count >= loop_times.get() &&
+            self.active_frame == self.image.frames.len().saturating_sub(1)
     }
 }
 

--- a/components/shared/layout/lib.rs
+++ b/components/shared/layout/lib.rs
@@ -765,22 +765,28 @@ pub struct ImageAnimationState {
     #[conditional_malloc_size_of]
     pub image: Arc<RasterImage>,
     pub active_frame: usize,
-    pub current_loop_count: Option<u32>,
     frame_start_time: f64,
+
+    /// The number of loops that have fully completed in this [`ImageAnimationState`].
+    /// If this is greater than or equal to the maximum number of loops in the
+    /// [`RasterImage`], then the animation has ended. If it is `None`, then the image
+    /// will loop infinitely.
+    pub completed_loops: Option<u32>,
 }
 
 impl ImageAnimationState {
     pub fn new(image: Arc<RasterImage>, last_update_time: f64) -> Self {
-        let current_loop_count = match &image.loop_count {
+        let completd_loops = match &image.loop_count {
             None => unreachable!("Loop count of an animated Image should never be None"),
             Some(repeat) if Repeat::Infinite == *repeat => None,
             _ => Some(0),
         };
+
         Self {
             image,
             active_frame: 0,
-            current_loop_count,
             frame_start_time: last_update_time,
+            completed_loops: completd_loops,
         }
     }
 
@@ -812,10 +818,9 @@ impl ImageAnimationState {
         if self.image.frames.len() <= 1 || self.is_finished() {
             return false;
         }
-        let image = &self.image;
         let time_interval_since_last_update = now - self.frame_start_time;
         let mut remain_time_interval = time_interval_since_last_update -
-            image
+            self.image
                 .frames
                 .get(self.active_frame)
                 .unwrap()
@@ -823,32 +828,29 @@ impl ImageAnimationState {
                 .unwrap()
                 .as_secs_f64();
         let mut next_active_frame_id = self.active_frame;
-        let mut will_loop_animation = false;
-        while remain_time_interval > 0.0 {
-            next_active_frame_id = (next_active_frame_id + 1) % image.frames.len();
-            if next_active_frame_id == 0 {
-                will_loop_animation = true;
-            }
 
-            // only check once on start of new loop.
-            if let Some(Repeat::Finite(repeat_times)) = image.loop_count &&
-                let Some(current_loop_count) = self.current_loop_count &&
-                will_loop_animation
-            {
-                will_loop_animation = false;
-                let new_loop_count = current_loop_count + 1;
-                self.current_loop_count = Some(new_loop_count);
-                if new_loop_count >= repeat_times.get() {
-                    if self.active_frame != image.frames.len() - 1 {
-                        self.active_frame = image.frames.len() - 1;
-                        self.frame_start_time = now;
-                        return true;
+        let frame_count = self.image.frames.len();
+        while remain_time_interval > 0.0 {
+            next_active_frame_id = (next_active_frame_id + 1) % frame_count;
+
+            // If the next active frame is 0, this means the animation is about to loop.
+            if next_active_frame_id == 0 {
+                self.advance_completed_loops();
+
+                // If we have just finished the animation, advance to the final frame if
+                // necessary and stop walking through frames.
+                if self.is_finished() {
+                    if self.active_frame == frame_count - 1 {
+                        return false;
                     }
-                    return false;
+                    self.active_frame = frame_count - 1;
+                    self.frame_start_time = now;
+                    return true;
                 }
             }
 
-            remain_time_interval -= image
+            remain_time_interval -= self
+                .image
                 .frames
                 .get(next_active_frame_id)
                 .unwrap()
@@ -864,15 +866,20 @@ impl ImageAnimationState {
         true
     }
 
+    /// Whether or not this animation has finished looping and has reached its final frame.
     fn is_finished(&self) -> bool {
-        let Some(Repeat::Finite(loop_times)) = self.image.loop_count.as_ref() else {
+        let Some(Repeat::Finite(maximum_loops)) = self.image.loop_count.as_ref() else {
             return false;
         };
-        let Some(current_loop_count) = self.current_loop_count else {
-            return false;
-        };
-        current_loop_count >= loop_times.get() &&
-            self.active_frame == self.image.frames.len().saturating_sub(1)
+        self.completed_loops
+            .is_some_and(|completed_loops| completed_loops >= maximum_loops.get())
+    }
+
+    /// If this animation has a finite number of loops, advance the count of completed loops.
+    fn advance_completed_loops(&mut self) {
+        if let Some(completed_loops) = self.completed_loops.as_mut() {
+            *completed_loops += 1;
+        }
     }
 }
 

--- a/components/shared/layout/lib.rs
+++ b/components/shared/layout/lib.rs
@@ -823,12 +823,30 @@ impl ImageAnimationState {
                 .unwrap()
                 .as_secs_f64();
         let mut next_active_frame_id = self.active_frame;
-        let mut advance_loop = 0;
+        let mut will_loop_animation = false;
         while remain_time_interval > 0.0 {
             next_active_frame_id = (next_active_frame_id + 1) % image.frames.len();
             if next_active_frame_id == 0 {
-                advance_loop += 1;
+                will_loop_animation = true;
             }
+
+            // only check once on start of new loop.
+            if let Some(Repeat::Finite(repeat_times)) = image.loop_count &&
+                let Some(current_loop_count) = self.current_loop_count && will_loop_animation
+            {
+                will_loop_animation = false;
+                let new_loop_count = current_loop_count + 1;
+                self.current_loop_count = Some(new_loop_count);
+                if new_loop_count >= repeat_times.get() {
+                    if self.active_frame != image.frames.len() - 1 {
+                        self.active_frame = image.frames.len() - 1;
+                        self.frame_start_time = now;
+                        return true;
+                    }
+                    return false;
+                }
+            }
+
             remain_time_interval -= image
                 .frames
                 .get(next_active_frame_id)
@@ -836,22 +854,6 @@ impl ImageAnimationState {
                 .delay()
                 .unwrap()
                 .as_secs_f64();
-        }
-        if let Some(Repeat::Finite(repeat_times)) = self.image.loop_count &&
-            let Some(current_loop_count) = self.current_loop_count
-        {
-            let new_loop_cnt = current_loop_count + advance_loop;
-            self.current_loop_count = Some(new_loop_cnt);
-            // the "now" time value exceed the time value after iterating through loop_cnt times.
-            if new_loop_cnt >= repeat_times.get() {
-                // should freeze at last frame
-                if self.active_frame != (self.image.frames.len() - 1) {
-                    self.active_frame = self.image.frames.len() - 1;
-                    self.frame_start_time = now;
-                    return true;
-                } // at this point, we can know the animation has finished, and potentially can set the flag here.
-                return false;
-            }
         }
         if self.active_frame == next_active_frame_id {
             return false;
@@ -976,7 +978,7 @@ pub fn with_layout_state<R>(f: impl FnOnce() -> R) -> R {
 
 #[cfg(test)]
 mod test {
-    use std::num::{NonZero, NonZeroU32};
+    use std::num::NonZeroU32;
     use std::sync::Arc;
     use std::time::Duration;
 

--- a/components/shared/layout/lib.rs
+++ b/components/shared/layout/lib.rs
@@ -43,7 +43,7 @@ use net_traits::image_cache::{ImageCache, ImageCacheFactory, PendingImageId};
 use net_traits::request::InternalRequest;
 use paint_api::CrossProcessPaintApi;
 use parking_lot::RwLock;
-use pixels::RasterImage;
+use pixels::{RasterImage, Repeat};
 use profile_traits::mem::Report;
 use profile_traits::time;
 pub use pseudo_element_chain::PseudoElementChain;
@@ -765,14 +765,21 @@ pub struct ImageAnimationState {
     #[conditional_malloc_size_of]
     pub image: Arc<RasterImage>,
     pub active_frame: usize,
+    pub current_loop_count: Option<u32>,
     frame_start_time: f64,
 }
 
 impl ImageAnimationState {
     pub fn new(image: Arc<RasterImage>, last_update_time: f64) -> Self {
+        let current_loop_count = match &image.loop_count {
+            None => unreachable!("Loop_count of Animated Image should not be None"),
+            Some(repeat) if Repeat::Infinite == *repeat => None,
+            _ => Some(0),
+        };
         Self {
             image,
             active_frame: 0,
+            current_loop_count,
             frame_start_time: last_update_time,
         }
     }
@@ -802,6 +809,15 @@ impl ImageAnimationState {
         if self.image.frames.len() <= 1 {
             return false;
         }
+        if let Some(repeat) = &self.image.loop_count &&
+            let Repeat::Finite(loop_times) = repeat
+        {
+            if let Some(current_loop_count) = self.current_loop_count {
+                if current_loop_count >= loop_times.get() {
+                    return false;
+                }
+            }
+        }
         let image = &self.image;
         let time_interval_since_last_update = now - self.frame_start_time;
         let mut remain_time_interval = time_interval_since_last_update -
@@ -813,8 +829,12 @@ impl ImageAnimationState {
                 .unwrap()
                 .as_secs_f64();
         let mut next_active_frame_id = self.active_frame;
+        let mut advance_loop = 0;
         while remain_time_interval > 0.0 {
             next_active_frame_id = (next_active_frame_id + 1) % image.frames.len();
+            if next_active_frame_id == image.frames.len() - 1 {
+                advance_loop += 1;
+            }
             remain_time_interval -= image
                 .frames
                 .get(next_active_frame_id)
@@ -825,6 +845,9 @@ impl ImageAnimationState {
         }
         if self.active_frame == next_active_frame_id {
             return false;
+        }
+        if let Some(current_loop_cnt) = self.current_loop_count {
+            self.current_loop_count = Some(current_loop_cnt + advance_loop);
         }
         self.active_frame = next_active_frame_id;
         self.frame_start_time = now;
@@ -882,6 +905,7 @@ impl AnimatingImages {
             self.dirty = true;
             *entry = ImageAnimationState::new(image.clone(), current_timeline_value);
         }
+        // Todo: We may not want to re-insert the node when animating image loop cnt reached.
     }
 
     pub fn remove(&mut self, node: OpaqueNode) {

--- a/components/shared/layout/lib.rs
+++ b/components/shared/layout/lib.rs
@@ -832,7 +832,7 @@ impl ImageAnimationState {
         let mut advance_loop = 0;
         while remain_time_interval > 0.0 {
             next_active_frame_id = (next_active_frame_id + 1) % image.frames.len();
-            if next_active_frame_id == image.frames.len() - 1 {
+            if next_active_frame_id == 0 {
                 advance_loop += 1;
             }
             remain_time_interval -= image
@@ -843,11 +843,19 @@ impl ImageAnimationState {
                 .unwrap()
                 .as_secs_f64();
         }
+        if let Some(Repeat::Finite(repeat_times)) = self.image.loop_count {
+            if let Some(current_loop_cnt) = self.current_loop_count {
+                let new_loop_cnt = current_loop_cnt + advance_loop;
+                self.current_loop_count = Some(new_loop_cnt);
+                // the "now" time value exceed the time value after iterating through loop_cnt times.
+                if new_loop_cnt >= repeat_times.get() {
+                    // should freeze at last frame
+                    return self.active_frame != (self.image.frames.len() - 1);
+                }
+            }
+        }
         if self.active_frame == next_active_frame_id {
             return false;
-        }
-        if let Some(current_loop_cnt) = self.current_loop_count {
-            self.current_loop_count = Some(current_loop_cnt + advance_loop);
         }
         self.active_frame = next_active_frame_id;
         self.frame_start_time = now;
@@ -905,7 +913,6 @@ impl AnimatingImages {
             self.dirty = true;
             *entry = ImageAnimationState::new(image.clone(), current_timeline_value);
         }
-        // Todo: We may not want to re-insert the node when animating image loop cnt reached.
     }
 
     pub fn remove(&mut self, node: OpaqueNode) {
@@ -959,15 +966,16 @@ pub fn with_layout_state<R>(f: impl FnOnce() -> R) -> R {
 
 #[cfg(test)]
 mod test {
+    use std::num::{NonZero, NonZeroU32};
     use std::sync::Arc;
     use std::time::Duration;
 
-    use pixels::{CorsStatus, ImageFrame, ImageMetadata, PixelFormat, RasterImage};
+    use pixels::{CorsStatus, ImageFrame, ImageMetadata, PixelFormat, RasterImage, Repeat};
 
     use crate::ImageAnimationState;
 
     #[test]
-    fn test() {
+    fn test_animated_image_update() {
         let image_frames: Vec<ImageFrame> = std::iter::repeat_with(|| ImageFrame {
             delay: Some(Duration::from_millis(100)),
             byte_range: 0..1,
@@ -986,6 +994,7 @@ mod test {
             bytes: Arc::new(vec![1]),
             frames: image_frames,
             cors_status: CorsStatus::Unsafe,
+            loop_count: Some(Repeat::Infinite),
             is_opaque: false,
         };
         let mut image_animation_state = ImageAnimationState::new(Arc::new(image), 0.0);
@@ -1004,5 +1013,50 @@ mod test {
         );
         assert_eq!(image_animation_state.active_frame, 1);
         assert_eq!(image_animation_state.frame_start_time, 0.101);
+    }
+
+    #[test]
+    fn test_finite_image_repeat() {
+        let image_frames: Vec<ImageFrame> = std::iter::repeat_with(|| ImageFrame {
+            delay: Some(Duration::from_millis(100)),
+            byte_range: 0..1,
+            width: 100,
+            height: 100,
+        })
+        .take(2)
+        .collect();
+        let image = RasterImage {
+            metadata: ImageMetadata {
+                width: 100,
+                height: 100,
+            },
+            format: PixelFormat::BGRA8,
+            id: None,
+            bytes: Arc::new(vec![1]),
+            frames: image_frames,
+            cors_status: CorsStatus::Unsafe,
+            loop_count: Some(Repeat::Finite(NonZeroU32::new(1).unwrap())),
+            is_opaque: false,
+        };
+        let mut image_animation_state = ImageAnimationState::new(Arc::new(image), 0.0);
+
+        assert_eq!(image_animation_state.active_frame, 0);
+        assert_eq!(image_animation_state.frame_start_time, 0.0);
+        assert_eq!(
+            image_animation_state.update_frame_for_animation_timeline_value(0.101),
+            true
+        );
+        assert_eq!(image_animation_state.active_frame, 1);
+        assert_eq!(image_animation_state.frame_start_time, 0.101);
+        assert_eq!(
+            image_animation_state.update_frame_for_animation_timeline_value(0.202),
+            false
+        );
+        assert_eq!(
+            image_animation_state.update_frame_for_animation_timeline_value(0.303),
+            false
+        );
+
+        assert_eq!(image_animation_state.active_frame, 1);
     }
 }

--- a/components/shared/layout/lib.rs
+++ b/components/shared/layout/lib.rs
@@ -772,7 +772,7 @@ pub struct ImageAnimationState {
 impl ImageAnimationState {
     pub fn new(image: Arc<RasterImage>, last_update_time: f64) -> Self {
         let current_loop_count = match &image.loop_count {
-            None => unreachable!("Loop_count of Animated Image should not be None"),
+            None => unreachable!("Loop count of an animated Image should never be None"),
             Some(repeat) if Repeat::Infinite == *repeat => None,
             _ => Some(0),
         };

--- a/components/shared/layout/lib.rs
+++ b/components/shared/layout/lib.rs
@@ -842,7 +842,7 @@ impl ImageAnimationState {
                 .as_secs_f64();
         }
         if let Some(Repeat::Finite(repeat_times)) = self.image.loop_count &&
-            let Some(current_loop_count) = self.current_loop_count 
+            let Some(current_loop_count) = self.current_loop_count
         {
             let new_loop_cnt = current_loop_count + advance_loop;
             self.current_loop_count = Some(new_loop_cnt);

--- a/components/shared/layout/lib.rs
+++ b/components/shared/layout/lib.rs
@@ -832,7 +832,8 @@ impl ImageAnimationState {
 
             // only check once on start of new loop.
             if let Some(Repeat::Finite(repeat_times)) = image.loop_count &&
-                let Some(current_loop_count) = self.current_loop_count && will_loop_animation
+                let Some(current_loop_count) = self.current_loop_count &&
+                will_loop_animation
             {
                 will_loop_animation = false;
                 let new_loop_count = current_loop_count + 1;

--- a/tests/wpt/meta/png/apng/fcTL-dispose-background.html.ini
+++ b/tests/wpt/meta/png/apng/fcTL-dispose-background.html.ini
@@ -1,2 +1,0 @@
-[fcTL-dispose-background.html]
-  expected: FAIL

--- a/tests/wpt/meta/png/apng/fcTL-dispose-in-region-background.html.ini
+++ b/tests/wpt/meta/png/apng/fcTL-dispose-in-region-background.html.ini
@@ -1,2 +1,0 @@
-[fcTL-dispose-in-region-background.html]
-  expected: FAIL

--- a/tests/wpt/meta/png/apng/fcTL-dispose-in-region-none.html.ini
+++ b/tests/wpt/meta/png/apng/fcTL-dispose-in-region-none.html.ini
@@ -1,2 +1,0 @@
-[fcTL-dispose-in-region-none.html]
-  expected: FAIL


### PR DESCRIPTION
This PR add servo side animated image loop count control, animated image should stop looping once they hit the loop count.

Testing: added a Unit test under `components/shared/layout/lib.rs`. This also causes some WPT tests to start passing.
Fixes: #41581.
Fixes: #37493.
