### PR TITLE
testdriver harness: Allow duration 0 for actions/tick

### DIFF
--- a/tests/wpt/tests/resources/testdriver-actions.js
+++ b/tests/wpt/tests/resources/testdriver-actions.js
@@ -252,7 +252,7 @@
      */
     addTick: function(duration) {
       this.tickIdx += 1;
-      if (duration) {
+      if (duration !== undefined && duration !== null) {
         this.pause(duration);
       }
       return this;
@@ -544,7 +544,7 @@
         tick = actions.addTick().tickIdx;
       }
       let moveAction = {type: "pointerMove", x, y, origin};
-      if (duration) {
+      if (duration !== undefined && duration !== null) {
         moveAction.duration = duration;
       }
       let actionProperties = setPointerProperties(moveAction, width, height, pressure,
@@ -589,7 +589,7 @@
         tick = actions.addTick().tickIdx;
       }
       this.actions.set(tick, {type: "scroll", x, y, deltaX, deltaY, origin});
-      if (duration) {
+      if (duration !== undefined && duration !== null) {
         this.actions.get(tick).duration = duration;
       }
     },


### PR DESCRIPTION
Previously, even if you explicitly set duration 0, it still ends up with `None`.
But you can set duration 0 in wdspec python tests.
This complies with [spec](https://w3c.github.io/webdriver/#dfn-process-a-wheel-action:~:text=If%20duration%20is%20not%20undefined%20and%20duration%20is%20not%20an%20Integer%20greater%20than%20or%20equal%20to%200%2C%20return%20error%20with%20error%20code%20invalid%20argument%2E): duration can be greater than or equal to 0.

Testing: There is no existing testdriver tests that use duration 0.
Fixes: https://github.com/web-platform-tests/wpt/issues/57606
Found in: https://github.com/servo/servo/pull/42387#issuecomment-3859501808
