### PR TITLE
layout: Properly count characters when segmenting IFC text

### DIFF
--- a/components/layout/flow/inline/text_run.rs
+++ b/components/layout/flow/inline/text_run.rs
@@ -487,13 +487,15 @@ impl TextRun {
 
         let text_run_text = &formatting_context_text[self.text_range.clone()];
         let char_iterator = TwoCharsAtATimeIterator::new(text_run_text.chars());
+
+        // The next current character index within the entire inline formatting context's text.
+        let mut next_character_index = self.character_range.start;
+        // The next bytes index of the charcter within the entire inline formatting context's text.
         let mut next_byte_index = self.text_range.start;
 
-        // This represents the current character index as we iterate relative to the entire inline formatting
-        // context.
-        let mut current_character_index = self.character_range.start;
         for (character, next_character) in char_iterator {
-            current_character_index += 1;
+            let current_character_index = next_character_index;
+            next_character_index += 1;
 
             let current_byte_index = next_byte_index;
             next_byte_index += character.len_utf8();

--- a/tests/wpt/mozilla/meta/MANIFEST.json
+++ b/tests/wpt/mozilla/meta/MANIFEST.json
@@ -136,6 +136,19 @@
   },
   "reftest": {
    "appearance": {
+    "input-text-caret-mixed-language.html": [
+     "9fd52d39a076d9d03876efd93af30402e17e5ee0",
+     [
+      null,
+      [
+       [
+        "/_mozilla/appearance/input-text-caret-mixed-language-ref.html",
+        "!="
+       ]
+      ],
+      {}
+     ]
+    ],
     "input-textual-definite-width.html": [
      "59f1797fab3d1889bbcb7863178c6c5ef9e54f19",
      [
@@ -8269,6 +8282,10 @@
     []
    ],
    "appearance": {
+    "input-text-caret-mixed-language-ref.html": [
+     "ff0b91f2a8857fdefa4a8a3d7d75e06e53e699cf",
+     []
+    ],
     "input-textual-definite-width-ref.html": [
      "7a256be23b3c084bb8477d7380a8b1801ec07f05",
      []

--- a/tests/wpt/mozilla/tests/appearance/input-text-caret-mixed-language-ref.html
+++ b/tests/wpt/mozilla/tests/appearance/input-text-caret-mixed-language-ref.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>Text caret should be properly positioned in &lt;input&gt; with multiple fonts</title>
+    <link rel="help" href="https://github.com/servo/servo/issues/42354">
+</head>
+
+<input id="input" value="A床">
+
+<script>
+    input.focus();
+    input.setSelectionRange(1, 1);
+</script>

--- a/tests/wpt/mozilla/tests/appearance/input-text-caret-mixed-language.html
+++ b/tests/wpt/mozilla/tests/appearance/input-text-caret-mixed-language.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>Text caret should be properly positioned in &lt;input&gt; with multiple fonts</title>
+    <link rel="mismatch" href="input-text-caret-mixed-language-ref.html">
+    <link rel="help" href="https://github.com/servo/servo/issues/42354">
+</head>
+
+<input id="input" value="A床">
+
+<script>
+    input.focus();
+    input.setSelectionRange(2, 2);
+</script>


### PR DESCRIPTION
There was a bug where characters were not properly counted when
segmeting IFC text. Immediately incrementing the
`current_character_index` meant that the count was always one character
off. This character count is mainly used for drawing selections and
really matters when multiple text segments are in a single IFC. This
change fixes that by counting characters in the same way we were
counting byte indices for the text.

Testing: This change adds a Servo-specific WPT-style test. As it is quite
difficult to reproduce the correct display in a different way, a mismatch test
is used. Since this is mainly about appearance and is very specific to our
implementation the test is Servo-specific.
Fixes: #42354.
