### PR TITLE
script: Implement DocumentOrShadowRoot.FullscreenDocument

### DIFF
--- a/components/script/dom/document.rs
+++ b/components/script/dom/document.rs
@@ -4995,6 +4995,10 @@ impl Document {
         *self.favicon.borrow_mut() = Some(favicon);
         self.notify_embedder_favicon();
     }
+
+    pub(crate) fn fullscreen_element(&self) -> Option<DomRoot<Element>> {
+        self.fullscreen_element.get()
+    }
 }
 
 impl DocumentMethods<crate::DomTypeHolder> for Document {
@@ -6442,8 +6446,7 @@ impl DocumentMethods<crate::DomTypeHolder> for Document {
 
     /// <https://fullscreen.spec.whatwg.org/#dom-document-fullscreenelement>
     fn GetFullscreenElement(&self) -> Option<DomRoot<Element>> {
-        // TODO ShadowRoot
-        self.fullscreen_element.get()
+        DocumentOrShadowRoot::get_fullscreen_element(&self.node, self.fullscreen_element.get())
     }
 
     /// <https://fullscreen.spec.whatwg.org/#dom-document-exitfullscreen>

--- a/components/script/dom/documentorshadowroot.rs
+++ b/components/script/dom/documentorshadowroot.rs
@@ -23,6 +23,7 @@ use webrender_api::units::LayoutPoint;
 
 use super::bindings::trace::HashMapTracedValues;
 use crate::dom::bindings::cell::DomRefCell;
+use crate::dom::bindings::codegen::Bindings::NodeBinding::GetRootNodeOptions;
 use crate::dom::bindings::codegen::Bindings::NodeBinding::Node_Binding::NodeMethods;
 use crate::dom::bindings::codegen::Bindings::ShadowRootBinding::ShadowRootMethods;
 use crate::dom::bindings::conversions::{ConversionResult, SafeFromJSValConvertible};
@@ -34,7 +35,7 @@ use crate::dom::element::Element;
 use crate::dom::html::htmlelement::HTMLElement;
 use crate::dom::node::{self, Node, VecPreOrderInsertionHelper};
 use crate::dom::shadowroot::ShadowRoot;
-use crate::dom::types::CSSStyleSheet;
+use crate::dom::types::{CSSStyleSheet, EventTarget};
 use crate::dom::window::Window;
 use crate::stylesheet_set::StylesheetSetRef;
 
@@ -451,5 +452,37 @@ impl DocumentOrShadowRoot {
                 "The provided value is not a sequence of 'CSSStylesheet'.".to_owned(),
             )),
         }
+    }
+
+    /// <https://fullscreen.spec.whatwg.org/#dom-document-fullscreenelement>
+    pub(crate) fn get_fullscreen_element(
+        node: &Node,
+        fullscreen_element: Option<DomRoot<Element>>,
+    ) -> Option<DomRoot<Element>> {
+        // Step 1. If this is a shadow root and its host is not connected, then return null.
+        if let Some(shadow_root) = node.downcast::<ShadowRoot>() {
+            if !shadow_root.Host().is_connected() {
+                return None;
+            }
+        }
+
+        // Step 2. Let candidate be the result of retargeting fullscreen element against this.
+        let retargeted = fullscreen_element?
+            .upcast::<EventTarget>()
+            .retarget(node.upcast());
+        // It's safe to unwrap downcasting to `Element` because `retarget` either returns `fullscreen_element` or a host of `fullscreen_element` and hosts are always elements.
+        let candidate = DomRoot::downcast::<Element>(retargeted).unwrap();
+
+        // Step 3. If candidate and this are in the same tree, then return candidate.
+        if *candidate
+            .upcast::<Node>()
+            .GetRootNode(&GetRootNodeOptions::empty()) ==
+            *node
+        {
+            return Some(candidate);
+        }
+
+        // Step 4. Return null.
+        None
     }
 }

--- a/components/script/dom/element.rs
+++ b/components/script/dom/element.rs
@@ -113,6 +113,7 @@ use crate::dom::domrect::DOMRect;
 use crate::dom::domrectlist::DOMRectList;
 use crate::dom::domtokenlist::DOMTokenList;
 use crate::dom::elementinternals::ElementInternals;
+use crate::dom::event::{EventBubbles, EventCancelable, EventComposed};
 use crate::dom::eventtarget::EventTarget;
 use crate::dom::globalscope::GlobalScope;
 use crate::dom::html::htmlanchorelement::HTMLAnchorElement;
@@ -4600,7 +4601,7 @@ impl VirtualMethods for Element {
 
         let doc = self.owner_document();
 
-        let fullscreen = doc.GetFullscreenElement();
+        let fullscreen = doc.fullscreen_element();
         if fullscreen.as_deref() == Some(self) {
             doc.exit_fullscreen(can_gc);
         }
@@ -5509,9 +5510,13 @@ impl TaskOnce for ElementPerformFullscreenEnter {
         // The following operations is based on the old version of the specs.
         element.set_fullscreen_state(true);
         document.set_fullscreen_element(Some(&element));
-        document
-            .upcast::<EventTarget>()
-            .fire_event(atom!("fullscreenchange"), CanGc::from_cx(cx));
+        document.upcast::<EventTarget>().fire_event_with_params(
+            atom!("fullscreenchange"),
+            EventBubbles::Bubbles,
+            EventCancelable::NotCancelable,
+            EventComposed::Composed,
+            CanGc::from_cx(cx),
+        );
 
         // Step 14.
         // > Resolve promise with undefined.
@@ -5546,9 +5551,13 @@ impl TaskOnce for ElementPerformFullscreenExit {
         // The following operations is based on the old version of the specs.
         element.set_fullscreen_state(false);
         document.set_fullscreen_element(None);
-        document
-            .upcast::<EventTarget>()
-            .fire_event(atom!("fullscreenchange"), CanGc::from_cx(cx));
+        document.upcast::<EventTarget>().fire_event_with_params(
+            atom!("fullscreenchange"),
+            EventBubbles::Bubbles,
+            EventCancelable::NotCancelable,
+            EventComposed::Composed,
+            CanGc::from_cx(cx),
+        );
 
         // Step 16
         // > Resolve promise with undefined.

--- a/components/script/dom/shadowroot.rs
+++ b/components/script/dom/shadowroot.rs
@@ -579,6 +579,14 @@ impl ShadowRootMethods<crate::DomTypeHolder> for ShadowRoot {
 
         result
     }
+
+    /// <https://fullscreen.spec.whatwg.org/#dom-document-fullscreenelement>
+    fn GetFullscreenElement(&self) -> Option<DomRoot<Element>> {
+        DocumentOrShadowRoot::get_fullscreen_element(
+            self.upcast::<Node>(),
+            self.document.fullscreen_element(),
+        )
+    }
 }
 
 impl VirtualMethods for ShadowRoot {

--- a/components/script_bindings/webidls/Document.webidl
+++ b/components/script_bindings/webidls/Document.webidl
@@ -200,7 +200,6 @@ partial interface Document {
 // https://fullscreen.spec.whatwg.org/#api
 partial interface Document {
   [LegacyLenientSetter] readonly attribute boolean fullscreenEnabled;
-  [LegacyLenientSetter] readonly attribute Element? fullscreenElement;
   [LegacyLenientSetter] readonly attribute boolean fullscreen; // historical
 
   Promise<undefined> exitFullscreen();

--- a/components/script_bindings/webidls/DocumentOrShadowRoot.webidl
+++ b/components/script_bindings/webidls/DocumentOrShadowRoot.webidl
@@ -5,6 +5,7 @@
  * The origin of this IDL file is
  * https://dom.spec.whatwg.org/#documentorshadowroot
  * https://w3c.github.io/webcomponents/spec/shadow/#extensions-to-the-documentorshadowroot-mixin
+ * https://fullscreen.spec.whatwg.org/#api
  */
 
 interface mixin DocumentOrShadowRoot {
@@ -20,4 +21,9 @@ partial interface mixin DocumentOrShadowRoot {
   // TODO(37902): Use ObservableArray Array when available
   [Pref="dom_adoptedstylesheet_enabled", SetterThrows]
   attribute /* ObservableArray<CSSStyleSheet> */ any adoptedStyleSheets;
+};
+
+// https://fullscreen.spec.whatwg.org/#api
+partial interface mixin DocumentOrShadowRoot {
+  [LegacyLenientSetter] readonly attribute Element? fullscreenElement;
 };

--- a/tests/wpt/meta/fullscreen/api/shadowroot-fullscreen-element.html.ini
+++ b/tests/wpt/meta/fullscreen/api/shadowroot-fullscreen-element.html.ini
@@ -1,4 +1,0 @@
-[shadowroot-fullscreen-element.html]
-  expected: TIMEOUT
-  [shadowRoot.fullscreenElement works correctly]
-    expected: TIMEOUT


### PR DESCRIPTION
Implement [DocumentOrShadowRoot.FullscreenDocument](https://fullscreen.spec.whatwg.org/#dom-document-fullscreenelement).

## Changes
- Update IDL definition by removing `Document.fullscreenElement` and declaring it in `DocumentOrShadowRoot` mixin as per the [spec](https://fullscreen.spec.whatwg.org/#api)
- Implement [fullscreenElement getter](https://fullscreen.spec.whatwg.org/#dom-document-fullscreenelement) as a method in `DocumentOrShadowroot.get_fullscreen_element` which is used by `Document` and `ShadowRoot`.
- Changedbubble and composed flags for fullscreen enter and exit events to true.
- Delete `shadowroot-fullscreen-element.html.ini` since the test now passes.

## Testing
Enable `shadowroot-fullscreen-element.html` WPT test.

Passing WPT run: https://github.com/onsah/servo/actions/runs/21872882492

## Fixes
https://github.com/servo/servo/issues/42234
