### PR TITLE
layout: Expand text clipping boundaries based on the largest advance in run

### DIFF
--- a/tests/wpt/meta/css/CSS2/css1/c542-letter-sp-001.xht.ini
+++ b/tests/wpt/meta/css/CSS2/css1/c542-letter-sp-001.xht.ini
@@ -1,2 +1,0 @@
-[c542-letter-sp-001.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/normal-flow/blocks-018.xht.ini
+++ b/tests/wpt/meta/css/CSS2/normal-flow/blocks-018.xht.ini
@@ -1,2 +1,0 @@
-[blocks-018.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/normal-flow/blocks-019.xht.ini
+++ b/tests/wpt/meta/css/CSS2/normal-flow/blocks-019.xht.ini
@@ -1,2 +1,0 @@
-[blocks-019.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/normal-flow/replaced-intrinsic-002.xht.ini
+++ b/tests/wpt/meta/css/CSS2/normal-flow/replaced-intrinsic-002.xht.ini
@@ -1,2 +1,0 @@
-[replaced-intrinsic-002.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/text/text-transform-bicameral-003.xht.ini
+++ b/tests/wpt/meta/css/CSS2/text/text-transform-bicameral-003.xht.ini
@@ -1,2 +1,0 @@
-[text-transform-bicameral-003.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/text/text-transform-bicameral-004.xht.ini
+++ b/tests/wpt/meta/css/CSS2/text/text-transform-bicameral-004.xht.ini
@@ -1,2 +1,0 @@
-[text-transform-bicameral-004.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/text/text-transform-bicameral-011.xht.ini
+++ b/tests/wpt/meta/css/CSS2/text/text-transform-bicameral-011.xht.ini
@@ -1,2 +1,0 @@
-[text-transform-bicameral-011.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/text/text-transform-bicameral-014.xht.ini
+++ b/tests/wpt/meta/css/CSS2/text/text-transform-bicameral-014.xht.ini
@@ -1,2 +1,0 @@
-[text-transform-bicameral-014.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/text/text-transform-bicameral-016.xht.ini
+++ b/tests/wpt/meta/css/CSS2/text/text-transform-bicameral-016.xht.ini
@@ -1,2 +1,0 @@
-[text-transform-bicameral-016.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/WOFF2/datatypes-alt-255uint16-001.xht.ini
+++ b/tests/wpt/meta/css/WOFF2/datatypes-alt-255uint16-001.xht.ini
@@ -1,2 +1,0 @@
-[datatypes-alt-255uint16-001.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/WOFF2/tabledata-transform-hmtx-001.xht.ini
+++ b/tests/wpt/meta/css/WOFF2/tabledata-transform-hmtx-001.xht.ini
@@ -1,2 +1,0 @@
-[tabledata-transform-hmtx-001.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/WOFF2/tabledata-transform-hmtx-002.xht.ini
+++ b/tests/wpt/meta/css/WOFF2/tabledata-transform-hmtx-002.xht.ini
@@ -1,2 +1,0 @@
-[tabledata-transform-hmtx-002.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/WOFF2/valid-005.xht.ini
+++ b/tests/wpt/meta/css/WOFF2/valid-005.xht.ini
@@ -1,2 +1,0 @@
-[valid-005.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/WOFF2/valid-006.xht.ini
+++ b/tests/wpt/meta/css/WOFF2/valid-006.xht.ini
@@ -1,2 +1,0 @@
-[valid-006.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/WOFF2/valid-007.xht.ini
+++ b/tests/wpt/meta/css/WOFF2/valid-007.xht.ini
@@ -1,2 +1,0 @@
-[valid-007.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/WOFF2/valid-008.xht.ini
+++ b/tests/wpt/meta/css/WOFF2/valid-008.xht.ini
@@ -1,2 +1,0 @@
-[valid-008.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-content/quotes-034.html.ini
+++ b/tests/wpt/meta/css/css-content/quotes-034.html.ini
@@ -1,2 +1,0 @@
-[quotes-034.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-text/shaping/shaping-012.html.ini
+++ b/tests/wpt/meta/css/css-text/shaping/shaping-012.html.ini
@@ -1,2 +1,0 @@
-[shaping-012.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-text/shaping/shaping-013.html.ini
+++ b/tests/wpt/meta/css/css-text/shaping/shaping-013.html.ini
@@ -1,2 +1,0 @@
-[shaping-013.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-text/shaping/shaping-arabic-diacritics-002.html.ini
+++ b/tests/wpt/meta/css/css-text/shaping/shaping-arabic-diacritics-002.html.ini
@@ -1,0 +1,2 @@
+[shaping-arabic-diacritics-002.html]
+  expected: FAIL

--- a/tests/wpt/mozilla/meta/MANIFEST.json
+++ b/tests/wpt/mozilla/meta/MANIFEST.json
@@ -253,6 +253,19 @@
       {}
      ]
     ],
+    "text-advance-less-than-ink-clipping.html": [
+     "a726bd2881ff7cb29a9e68f8e7f1fae728b9382e",
+     [
+      null,
+      [
+       [
+        "/_mozilla/appearance/text-advance-less-than-ink-clipping-ref.html",
+        "=="
+       ]
+      ],
+      {}
+     ]
+    ],
     "textarea-caret-following-linebreak.html": [
      "55bc06e372e9ce8ad4d62d368a644c1f1cd3ffd9",
      [
@@ -8324,6 +8337,10 @@
       []
      ]
     },
+    "text-advance-less-than-ink-clipping-ref.html": [
+     "af9ec609b175040a66756fb6ce00d81a2e5707ec",
+     []
+    ],
     "textarea-caret-following-linebreak-ref.html": [
      "f424853f243ff0fe4c43506db800b51afc294113",
      []

--- a/tests/wpt/mozilla/meta/css/pseudo_inherit.html.ini
+++ b/tests/wpt/mozilla/meta/css/pseudo_inherit.html.ini
@@ -1,2 +1,0 @@
-[pseudo_inherit.html]
-  expected: FAIL

--- a/tests/wpt/mozilla/tests/appearance/text-advance-less-than-ink-clipping-ref.html
+++ b/tests/wpt/mozilla/tests/appearance/text-advance-less-than-ink-clipping-ref.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>When glyph ink extends past advance, it should still be painted</title>
+    <link rel="help" href="https://github.com/servo/servo/issues/41413">
+</head>
+<style>
+    div { font-size: 130px; font-style: italic; background: grey; }
+</style>
+<div>f&nbsp;&nbsp;&nbsp;&nbsp;</div>

--- a/tests/wpt/mozilla/tests/appearance/text-advance-less-than-ink-clipping.html
+++ b/tests/wpt/mozilla/tests/appearance/text-advance-less-than-ink-clipping.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>When glyph ink extends past advance, it should still be painted</title>
+    <link rel="match" href="text-advance-less-than-ink-clipping-ref.html">
+    <link rel="help" href="https://github.com/servo/servo/issues/41413">
+</head>
+<style>
+    div { font-size: 130px; font-style: italic; background: grey; }
+</style>
+<div>f</div>


### PR DESCRIPTION
Servo does not yet calculate the ink overflow area, as this sort of
thing is usually a result of `contain: paint` which Servo does not
support yet. We just need to ensure that text clipping is large
enough to contain the ink of all of the glyphs in the run. This change
just expands the rectangle based on glyph advances by 2 times the
largest advance, which should be big enough for most glyphs.

This is a big of a workaround until we have support for `contain:
paint`.

Testing:
- This change adds a Servo-specific test to ensure glyphs are fully
inked. While this test would run just fine in other browsers, it isn't very
useful to them as this is test is very specific to the way that Servo draws
glyphs.
- This also fixes a variety of existing WPT tests.

Fixes: #41413.
