### PR TITLE
OHOS: Update openharmony versions to api lvl 21

### DIFF
--- a/.github/workflows/ohos.yml
+++ b/.github/workflows/ohos.yml
@@ -72,9 +72,9 @@ jobs:
         run: sudo apt update && ./mach bootstrap --yes --skip-lints --skip-nextest
       - name: Setup OpenHarmony SDK
         id: setup_sdk
-        uses: openharmony-rs/setup-ohos-sdk@v0.2.3
+        uses: openharmony-rs/setup-ohos-sdk@v0.2.4
         with:
-          version: "5.0.2"
+          version: "6.0.0.1" # api 20 in openharmony
           fixup-path: true
       - name: Install node for hvigor
         uses: actions/setup-node@v4

--- a/support/openharmony/build-profile.json5
+++ b/support/openharmony/build-profile.json5
@@ -4,16 +4,16 @@
       {
         "name": "default",
         "signingConfig": "default",
-        "compileSdkVersion": 14,
-        "compatibleSdkVersion": 14,
-        "targetSdkVersion": 14,
+        "compileSdkVersion": 20,
+        "compatibleSdkVersion": 20,
+        "targetSdkVersion": 20,
         "runtimeOS": "OpenHarmony"
       },
       {
         "name": "harmonyos",
         "signingConfig": "hos",
-        "compatibleSdkVersion": "5.0.2(14)",
-        "targetSdkVersion": "5.0.2(14)",
+        "compatibleSdkVersion": "6.0.1(21)",
+        "targetSdkVersion": "6.0.1(21)",
         "runtimeOS": "HarmonyOS"
       }
     ],


### PR DESCRIPTION
This updates the Openharmony required version to API lvl 21 (6.0.0.1 OpenHarmony and 6.0.1 HarmonyOS).
We need API level 19+ for https://github.com/servo/servo/pull/41738, however an API level 19 SDK was never released for OpenHarmony. API-20 seems to be the same as the the 6.0-beta release, so we are playing it safe and directly going for the API-21 release, which is also the 6.0.1 release that the actual HarmonyOS 6 update was, so it should be the most polished. 
This also has the update for the version used in CI.

The HarmonyOS runners are already updated.

Testing: Successful openharmony run here: https://github.com/Narfinger/servo/actions/runs/21755920480
