### PR TITLE
wpt: Fix syntax error in `pointerevent_touch-propagates-when-target-is-video_touch.html`

### DIFF
--- a/tests/wpt/meta/pointerevents/pointerevent_touch-propagates-when-target-is-video_touch.html.ini
+++ b/tests/wpt/meta/pointerevents/pointerevent_touch-propagates-when-target-is-video_touch.html.ini
@@ -1,4 +1,0 @@
-[pointerevent_touch-propagates-when-target-is-video_touch.html]
-  expected: TIMEOUT
-  [Touch-generated events should propagate to the parent when a video element is the target]
-    expected: TIMEOUT

--- a/tests/wpt/tests/pointerevents/pointerevent_touch-propagates-when-target-is-video_touch.html
+++ b/tests/wpt/tests/pointerevents/pointerevent_touch-propagates-when-target-is-video_touch.html
@@ -40,7 +40,7 @@ promise_test(async t => {
       .setPointer("touchPointer")
       .pointerMove(xPosition, yPosition)
       .pointerDown()
-      .pointerMove(3, 3, video)
+      .pointerMove(3, 3, { origin: video } )
       .pointerUp()
       .send();
   });


### PR DESCRIPTION
The syntax is wrong. We cannot pass an Element as duration. Only Firefox [was passing this](https://wpt.fyi/results/pointerevents/pointerevent_touch-propagates-when-target-is-video_touch.html?run_id=5098406608633856&run_id=5170937667518464&run_id=4715813002280960&run_id=5136051728547840),
which is a bug of geckodriver: 


Testing: Updated expectation of existing tests.
This blocks https://github.com/servo/servo/pull/42398, https://github.com/servo/servo/pull/42387.
