### PR TITLE
script: Call ElementStylesheetLoader::load_with_element directly

### DIFF
--- a/components/script/dom/html/htmllinkelement.rs
+++ b/components/script/dom/html/htmllinkelement.rs
@@ -662,8 +662,8 @@ impl HTMLLinkElement {
             .set(self.request_generation_id.get().increment());
         self.pending_loads.set(0);
 
-        let loader = ElementStylesheetLoader::new(self.upcast());
-        loader.load(
+        ElementStylesheetLoader::load_with_element(
+            self.upcast(),
             StylesheetContextSource::LinkElement,
             media,
             link_url,

--- a/components/script/stylesheet_loader.rs
+++ b/components/script/stylesheet_loader.rs
@@ -436,30 +436,7 @@ impl<'a> ElementStylesheetLoader<'a> {
 }
 
 impl ElementStylesheetLoader<'_> {
-    pub(crate) fn load(
-        &self,
-        source: StylesheetContextSource,
-        media: Arc<Locked<MediaList>>,
-        url: ServoUrl,
-        cors_setting: Option<CorsSettings>,
-        integrity_metadata: String,
-    ) {
-        match self {
-            ElementStylesheetLoader::Synchronous { element } => Self::load_with_element(
-                element,
-                source,
-                media,
-                url,
-                cors_setting,
-                integrity_metadata,
-            ),
-            ElementStylesheetLoader::Asynchronous { .. } => unreachable!(
-                "Should never call load directly on an asynchronous ElementStylesheetLoader"
-            ),
-        }
-    }
-
-    fn load_with_element(
+    pub(crate) fn load_with_element(
         element: &HTMLElement,
         source: StylesheetContextSource,
         media: Arc<Locked<MediaList>>,
@@ -470,7 +447,7 @@ impl ElementStylesheetLoader<'_> {
         let document = element.owner_document();
         let shadow_root = element
             .containing_shadow_root()
-            .map(|sr| Trusted::new(&*sr));
+            .map(|shadow_root| Trusted::new(&*shadow_root));
         let generation = element
             .downcast::<HTMLLinkElement>()
             .map(HTMLLinkElement::get_request_generation_id);


### PR DESCRIPTION
When a `<link>` element loads a stylesheet then it calls `ElementStylesheetLoader::new`, followed immediately by
calling `load` on the new loader. This is the only place where these functions are used, so we can coalesce them together and avoid an unreachable assertion in the process.

This should have no impact on the end user, it's just a cleanup.

Testing: Regressions should be covered by existing tests