### PR TITLE
Revert "CI: OHOS: Better test for hdc device connected (#42365)"

### DIFF
--- a/.github/workflows/ohos.yml
+++ b/.github/workflows/ohos.yml
@@ -280,7 +280,7 @@ jobs:
           name: servoshell-hos-${{ inputs.profile }}.hap
       - name: Test hdc device
         # First we ensure a device is actually connected and working.
-        run: ! hdc list targets | grep -q Empty
+        run: hdc list targets && hdc shell echo hello world
       - name: Sign the hap
         run: |
           ls -la
@@ -415,7 +415,7 @@ jobs:
           name: servoshell-hos-${{ inputs.profile }}.hap
       - name: Test hdc device
         # First we ensure a device is actually connected and working.
-        run: ! hdc list targets | grep -q Empty
+        run: hdc list targets && hdc shell echo hello world
       - name: Sign the hap
         run: |
           ls -la


### PR DESCRIPTION
This reverts commit 071f064e2e97b4b4c41e2683db1298c75fe7291f.

Seems the devices are more finicky in CI.
