### PR TITLE
script: Remove `Worker` scope from `PerformancePaintTiming`

### DIFF
--- a/components/script_bindings/webidls/PerformancePaintTiming.webidl
+++ b/components/script_bindings/webidls/PerformancePaintTiming.webidl
@@ -6,6 +6,6 @@
  * https://w3c.github.io/paint-timing/#sec-PerformancePaintTiming
  */
 
-[Exposed=(Window,Worker)]
+[Exposed=Window]
 interface PerformancePaintTiming : PerformanceEntry {
 };

--- a/tests/wpt/mozilla/meta/MANIFEST.json
+++ b/tests/wpt/mozilla/meta/MANIFEST.json
@@ -14059,7 +14059,7 @@
      ]
     ],
     "interfaces.worker.js": [
-     "c6cc6b49c4903d1d1b436efcd5426bf682a6b21d",
+     "f528745591b56d96f016bd9402874a22eec80323",
      [
       "mozilla/interfaces.worker.html",
       {}

--- a/tests/wpt/mozilla/tests/mozilla/interfaces.worker.js
+++ b/tests/wpt/mozilla/tests/mozilla/interfaces.worker.js
@@ -97,7 +97,6 @@ test_interfaces([
   "PerformanceMeasure",
   "PerformanceObserver",
   "PerformanceObserverEntryList",
-  "PerformancePaintTiming",
   "PerformanceResourceTiming",
   "PermissionStatus",
   "Permissions",


### PR DESCRIPTION
This will align `PerformancePaintTiming` interface according to `W3C` specifications.

Specifiactions: [PerformancePaintTiming](https://w3c.github.io/paint-timing/#sec-PerformancePaintTiming)

Testing: `_mozilla/mozilla/interfaces.worker.html`
