### PR TITLE
Enable `layout.css.attr.enabled` pref for `css-values` tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8181,7 +8181,7 @@ dependencies = [
 [[package]]
 name = "selectors"
 version = "0.35.0"
-source = "git+https://github.com/servo/stylo?rev=3b46f3ef27eb14ca276b4bf3ff041a6c43d93827#3b46f3ef27eb14ca276b4bf3ff041a6c43d93827"
+source = "git+https://github.com/servo/stylo?rev=d99b4a52f71b423363626d58506a731f3d06ccf6#d99b4a52f71b423363626d58506a731f3d06ccf6"
 dependencies = [
  "bitflags 2.10.0",
  "cssparser",
@@ -8486,7 +8486,7 @@ dependencies = [
 [[package]]
 name = "servo_arc"
 version = "0.4.3"
-source = "git+https://github.com/servo/stylo?rev=3b46f3ef27eb14ca276b4bf3ff041a6c43d93827#3b46f3ef27eb14ca276b4bf3ff041a6c43d93827"
+source = "git+https://github.com/servo/stylo?rev=d99b4a52f71b423363626d58506a731f3d06ccf6#d99b4a52f71b423363626d58506a731f3d06ccf6"
 dependencies = [
  "serde",
  "stable_deref_trait",
@@ -9035,7 +9035,7 @@ dependencies = [
 [[package]]
 name = "stylo"
 version = "0.11.0"
-source = "git+https://github.com/servo/stylo?rev=3b46f3ef27eb14ca276b4bf3ff041a6c43d93827#3b46f3ef27eb14ca276b4bf3ff041a6c43d93827"
+source = "git+https://github.com/servo/stylo?rev=d99b4a52f71b423363626d58506a731f3d06ccf6#d99b4a52f71b423363626d58506a731f3d06ccf6"
 dependencies = [
  "app_units",
  "arrayvec",
@@ -9090,7 +9090,7 @@ dependencies = [
 [[package]]
 name = "stylo_atoms"
 version = "0.11.0"
-source = "git+https://github.com/servo/stylo?rev=3b46f3ef27eb14ca276b4bf3ff041a6c43d93827#3b46f3ef27eb14ca276b4bf3ff041a6c43d93827"
+source = "git+https://github.com/servo/stylo?rev=d99b4a52f71b423363626d58506a731f3d06ccf6#d99b4a52f71b423363626d58506a731f3d06ccf6"
 dependencies = [
  "string_cache",
  "string_cache_codegen",
@@ -9099,12 +9099,12 @@ dependencies = [
 [[package]]
 name = "stylo_config"
 version = "0.11.0"
-source = "git+https://github.com/servo/stylo?rev=3b46f3ef27eb14ca276b4bf3ff041a6c43d93827#3b46f3ef27eb14ca276b4bf3ff041a6c43d93827"
+source = "git+https://github.com/servo/stylo?rev=d99b4a52f71b423363626d58506a731f3d06ccf6#d99b4a52f71b423363626d58506a731f3d06ccf6"
 
 [[package]]
 name = "stylo_derive"
 version = "0.11.0"
-source = "git+https://github.com/servo/stylo?rev=3b46f3ef27eb14ca276b4bf3ff041a6c43d93827#3b46f3ef27eb14ca276b4bf3ff041a6c43d93827"
+source = "git+https://github.com/servo/stylo?rev=d99b4a52f71b423363626d58506a731f3d06ccf6#d99b4a52f71b423363626d58506a731f3d06ccf6"
 dependencies = [
  "darling",
  "proc-macro2",
@@ -9116,7 +9116,7 @@ dependencies = [
 [[package]]
 name = "stylo_dom"
 version = "0.11.0"
-source = "git+https://github.com/servo/stylo?rev=3b46f3ef27eb14ca276b4bf3ff041a6c43d93827#3b46f3ef27eb14ca276b4bf3ff041a6c43d93827"
+source = "git+https://github.com/servo/stylo?rev=d99b4a52f71b423363626d58506a731f3d06ccf6#d99b4a52f71b423363626d58506a731f3d06ccf6"
 dependencies = [
  "bitflags 2.10.0",
  "stylo_malloc_size_of",
@@ -9125,7 +9125,7 @@ dependencies = [
 [[package]]
 name = "stylo_malloc_size_of"
 version = "0.11.0"
-source = "git+https://github.com/servo/stylo?rev=3b46f3ef27eb14ca276b4bf3ff041a6c43d93827#3b46f3ef27eb14ca276b4bf3ff041a6c43d93827"
+source = "git+https://github.com/servo/stylo?rev=d99b4a52f71b423363626d58506a731f3d06ccf6#d99b4a52f71b423363626d58506a731f3d06ccf6"
 dependencies = [
  "app_units",
  "cssparser",
@@ -9142,12 +9142,15 @@ dependencies = [
 [[package]]
 name = "stylo_static_prefs"
 version = "0.11.0"
-source = "git+https://github.com/servo/stylo?rev=3b46f3ef27eb14ca276b4bf3ff041a6c43d93827#3b46f3ef27eb14ca276b4bf3ff041a6c43d93827"
+source = "git+https://github.com/servo/stylo?rev=d99b4a52f71b423363626d58506a731f3d06ccf6#d99b4a52f71b423363626d58506a731f3d06ccf6"
+dependencies = [
+ "stylo_config",
+]
 
 [[package]]
 name = "stylo_traits"
 version = "0.11.0"
-source = "git+https://github.com/servo/stylo?rev=3b46f3ef27eb14ca276b4bf3ff041a6c43d93827#3b46f3ef27eb14ca276b4bf3ff041a6c43d93827"
+source = "git+https://github.com/servo/stylo?rev=d99b4a52f71b423363626d58506a731f3d06ccf6#d99b4a52f71b423363626d58506a731f3d06ccf6"
 dependencies = [
  "app_units",
  "bitflags 2.10.0",
@@ -9569,7 +9572,7 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 [[package]]
 name = "to_shmem"
 version = "0.3.0"
-source = "git+https://github.com/servo/stylo?rev=3b46f3ef27eb14ca276b4bf3ff041a6c43d93827#3b46f3ef27eb14ca276b4bf3ff041a6c43d93827"
+source = "git+https://github.com/servo/stylo?rev=d99b4a52f71b423363626d58506a731f3d06ccf6#d99b4a52f71b423363626d58506a731f3d06ccf6"
 dependencies = [
  "cssparser",
  "servo_arc",
@@ -9582,7 +9585,7 @@ dependencies = [
 [[package]]
 name = "to_shmem_derive"
 version = "0.1.0"
-source = "git+https://github.com/servo/stylo?rev=3b46f3ef27eb14ca276b4bf3ff041a6c43d93827#3b46f3ef27eb14ca276b4bf3ff041a6c43d93827"
+source = "git+https://github.com/servo/stylo?rev=d99b4a52f71b423363626d58506a731f3d06ccf6#d99b4a52f71b423363626d58506a731f3d06ccf6"
 dependencies = [
  "darling",
  "proc-macro2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -168,7 +168,7 @@ script_traits = { path = "components/shared/script" }
 sea-query = { version = "1.0.0-rc.30", default-features = false, features = ["backend-sqlite", "derive"] }
 sea-query-rusqlite = { version = "0.8.0-rc.15" }
 sec1 = "0.7"
-selectors = { git = "https://github.com/servo/stylo", rev = "3b46f3ef27eb14ca276b4bf3ff041a6c43d93827" }
+selectors = { git = "https://github.com/servo/stylo", rev = "d99b4a52f71b423363626d58506a731f3d06ccf6" }
 serde = "1.0.228"
 serde_bytes = "0.11"
 serde_core = "1.0.226"
@@ -177,7 +177,7 @@ servo-media = { path = "components/media/servo-media" }
 servo-media-dummy = { path = "components/media/backends/dummy" }
 servo-media-gstreamer = { path = "components/media/backends/gstreamer" }
 servo-tracing = { path = "components/servo_tracing" }
-servo_arc = { git = "https://github.com/servo/stylo", rev = "3b46f3ef27eb14ca276b4bf3ff041a6c43d93827" }
+servo_arc = { git = "https://github.com/servo/stylo", rev = "d99b4a52f71b423363626d58506a731f3d06ccf6" }
 sha1 = "0.10"
 sha2 = "0.10"
 sha3 = "0.10"
@@ -186,12 +186,12 @@ smallvec = { version = "1.15", features = ["serde", "union"] }
 storage_traits = { path = "components/shared/storage" }
 string_cache = "0.9"
 strum = { version = "0.27", features = ["derive"] }
-stylo = { git = "https://github.com/servo/stylo", rev = "3b46f3ef27eb14ca276b4bf3ff041a6c43d93827" }
-stylo_atoms = { git = "https://github.com/servo/stylo", rev = "3b46f3ef27eb14ca276b4bf3ff041a6c43d93827" }
-stylo_config = { git = "https://github.com/servo/stylo", rev = "3b46f3ef27eb14ca276b4bf3ff041a6c43d93827" }
-stylo_dom = { git = "https://github.com/servo/stylo", rev = "3b46f3ef27eb14ca276b4bf3ff041a6c43d93827" }
-stylo_malloc_size_of = { git = "https://github.com/servo/stylo", rev = "3b46f3ef27eb14ca276b4bf3ff041a6c43d93827" }
-stylo_traits = { git = "https://github.com/servo/stylo", rev = "3b46f3ef27eb14ca276b4bf3ff041a6c43d93827" }
+stylo = { git = "https://github.com/servo/stylo", rev = "d99b4a52f71b423363626d58506a731f3d06ccf6" }
+stylo_atoms = { git = "https://github.com/servo/stylo", rev = "d99b4a52f71b423363626d58506a731f3d06ccf6" }
+stylo_config = { git = "https://github.com/servo/stylo", rev = "d99b4a52f71b423363626d58506a731f3d06ccf6" }
+stylo_dom = { git = "https://github.com/servo/stylo", rev = "d99b4a52f71b423363626d58506a731f3d06ccf6" }
+stylo_malloc_size_of = { git = "https://github.com/servo/stylo", rev = "d99b4a52f71b423363626d58506a731f3d06ccf6" }
+stylo_traits = { git = "https://github.com/servo/stylo", rev = "d99b4a52f71b423363626d58506a731f3d06ccf6" }
 surfman = { version = "0.11.0", features = ["chains"] }
 syn = { version = "2", default-features = false, features = ["clone-impls", "derive", "parsing"] }
 synstructure = "0.13"

--- a/components/config/prefs.rs
+++ b/components/config/prefs.rs
@@ -38,6 +38,10 @@ pub fn set(preferences: Preferences) {
     stylo_config::set_bool("layout.columns.enabled", preferences.layout_columns_enabled);
     stylo_config::set_bool("layout.grid.enabled", preferences.layout_grid_enabled);
     stylo_config::set_bool(
+        "layout.css.attr.enabled",
+        preferences.layout_css_attr_enabled,
+    );
+    stylo_config::set_bool(
         "layout.css.transition-behavior.enabled",
         preferences.layout_css_transition_behavior_enabled,
     );
@@ -263,6 +267,7 @@ pub struct Preferences {
     // feature: CSS Grid | #34479 | Web/CSS/Guides/Grid_layout
     pub layout_grid_enabled: bool,
     pub layout_container_queries_enabled: bool,
+    pub layout_css_attr_enabled: bool,
     pub layout_css_transition_behavior_enabled: bool,
     // feature: CSS Flexbox | #12453 | Web/CSS/Guides/Flexible_box_layout
     pub layout_flexbox_enabled: bool,
@@ -468,6 +473,7 @@ impl Preferences {
             layout_animations_test_enabled: false,
             layout_columns_enabled: false,
             layout_container_queries_enabled: false,
+            layout_css_attr_enabled: false,
             layout_css_transition_behavior_enabled: true,
             layout_flexbox_enabled: true,
             layout_grid_enabled: false,

--- a/components/script_bindings/codegen/run.py
+++ b/components/script_bindings/codegen/run.py
@@ -119,6 +119,7 @@ def add_css_properties_attributes(css_properties_json: str, parser: Parser) -> N
             ["layout.flexbox.enabled", "layout_flexbox_enabled"],
             ["layout.columns.enabled", "layout_columns_enabled"],
             ["layout.grid.enabled", "layout_grid_enabled"],
+            ["layout.css.attr.enabled", "layout_css_attr_enabled"],
             ["layout.css.transition-behavior.enabled", "layout_css_transition_behavior_enabled"],
             ["layout.writing-mode.enabled", "layout_writing_mode_enabled"],
             ["layout.container-queries.enabled", "layout_container_queries_enabled"],

--- a/tests/wpt/meta/css/css-values/__dir__.ini
+++ b/tests/wpt/meta/css/css-values/__dir__.ini
@@ -1,0 +1,1 @@
+prefs: [layout_css_attr_enabled: true]

--- a/tests/wpt/meta/css/css-values/attr-IACVT.html.ini
+++ b/tests/wpt/meta/css/css-values/attr-IACVT.html.ini
@@ -1,3 +1,0 @@
-[attr-IACVT.html]
-  [CSS Values Test: attr() IACVT]
-    expected: FAIL

--- a/tests/wpt/meta/css/css-values/attr-all-types.html.ini
+++ b/tests/wpt/meta/css/css-values/attr-all-types.html.ini
@@ -8,12 +8,6 @@
   [CSS Values and Units Test: attr 3]
     expected: FAIL
 
-  [CSS Values and Units Test: attr 4]
-    expected: FAIL
-
-  [CSS Values and Units Test: attr 5]
-    expected: FAIL
-
   [CSS Values and Units Test: attr 6]
     expected: FAIL
 
@@ -21,39 +15,6 @@
     expected: FAIL
 
   [CSS Values and Units Test: attr 11]
-    expected: FAIL
-
-  [CSS Values and Units Test: attr 24]
-    expected: FAIL
-
-  [CSS Values and Units Test: attr 25]
-    expected: FAIL
-
-  [CSS Values and Units Test: attr 26]
-    expected: FAIL
-
-  [CSS Values and Units Test: attr 27]
-    expected: FAIL
-
-  [CSS Values and Units Test: attr 28]
-    expected: FAIL
-
-  [CSS Values and Units Test: attr 43]
-    expected: FAIL
-
-  [CSS Values and Units Test: attr 45]
-    expected: FAIL
-
-  [CSS Values and Units Test: attr 51]
-    expected: FAIL
-
-  [CSS Values and Units Test: attr 55]
-    expected: FAIL
-
-  [CSS Values and Units Test: attr 56]
-    expected: FAIL
-
-  [CSS Values and Units Test: attr 58]
     expected: FAIL
 
   [CSS Values and Units Test: attr 61]
@@ -71,18 +32,6 @@
   [CSS Values and Units Test: attr 70]
     expected: FAIL
 
-  [CSS Values and Units Test: attr 29]
-    expected: FAIL
-
-  [CSS Values and Units Test: attr 71]
-    expected: FAIL
-
-  [CSS Values and Units Test: attr 72]
-    expected: FAIL
-
-  [CSS Values and Units Test: attr 73]
-    expected: FAIL
-
   [CSS Values and Units Test: attr 74]
     expected: FAIL
 
@@ -95,100 +44,37 @@
   [CSS Values and Units Test: attr 77]
     expected: FAIL
 
-  [CSS Values and Units Test: attr 33]
-    expected: FAIL
-
   [CSS Values and Units Test: attr 79]
     expected: FAIL
 
   [CSS Values and Units Test: attr 81]
     expected: FAIL
 
-  [CSS Values and Units Test: attr 82]
-    expected: FAIL
-
-  [CSS Values and Units Test: attr 8]
-    expected: FAIL
-
-  [CSS Values and Units Test: attr 53]
-    expected: FAIL
-
   [CSS Values and Units Test: attr 83]
-    expected: FAIL
-
-  [CSS Values and Units Test: attr 54]
-    expected: FAIL
-
-  [CSS Values and Units Test: attr 84]
     expected: FAIL
 
   [CSS Values and Units Test: attr 85]
     expected: FAIL
 
-  [CSS Values and Units Test: attr 86]
-    expected: FAIL
-
   [CSS Values and Units Test: attr 87]
-    expected: FAIL
-
-  [CSS Values and Units Test: attr 88]
     expected: FAIL
 
   [CSS Values and Units Test: attr 89]
     expected: FAIL
 
-  [CSS Values and Units Test: attr 9]
-    expected: FAIL
-
-  [CSS Values and Units Test: attr 10]
-    expected: FAIL
-
-  [CSS Values and Units Test: attr 30]
-    expected: FAIL
-
-  [CSS Values and Units Test: attr 31]
-    expected: FAIL
-
-  [CSS Values and Units Test: attr 32]
-    expected: FAIL
-
-  [CSS Values and Units Test: attr 41]
-    expected: FAIL
-
-  [CSS Values and Units Test: attr 42]
-    expected: FAIL
-
-  [CSS Values and Units Test: attr 44]
-    expected: FAIL
-
   [CSS Values and Units Test: attr 60]
-    expected: FAIL
-
-  [CSS Values and Units Test: attr 90]
     expected: FAIL
 
   [CSS Values and Units Test: attr 91]
     expected: FAIL
 
-  [CSS Values and Units Test: attr 92]
-    expected: FAIL
-
   [CSS Values and Units Test: attr 93]
-    expected: FAIL
-
-  [CSS Values and Units Test: attr 94]
     expected: FAIL
 
   [CSS Values and Units Test: attr 95]
     expected: FAIL
 
-  [CSS Values and Units Test: attr 96]
-    expected: FAIL
-
   [CSS Values and Units Test: attr 107]
-    expected: FAIL
-
-  [CSS Values and Units Test: attr 108]
     expected: FAIL
 
   [CSS Values and Units Test: attr 1]
@@ -197,49 +83,13 @@
   [CSS Values and Units Test: attr 12]
     expected: FAIL
 
-  [CSS Values and Units Test: attr 17]
-    expected: FAIL
-
-  [CSS Values and Units Test: attr 19]
-    expected: FAIL
-
-  [CSS Values and Units Test: attr 34]
-    expected: FAIL
-
-  [CSS Values and Units Test: attr 36]
-    expected: FAIL
-
-  [CSS Values and Units Test: attr 46]
-    expected: FAIL
-
   [CSS Values and Units Test: attr 65]
     expected: FAIL
 
   [CSS Values and Units Test: attr 97]
     expected: FAIL
 
-  [CSS Values and Units Test: attr 98]
-    expected: FAIL
-
   [CSS Values and Units Test: attr 109]
-    expected: FAIL
-
-  [CSS Values and Units Test: attr 18]
-    expected: FAIL
-
-  [CSS Values and Units Test: attr 21]
-    expected: FAIL
-
-  [CSS Values and Units Test: attr 35]
-    expected: FAIL
-
-  [CSS Values and Units Test: attr 38]
-    expected: FAIL
-
-  [CSS Values and Units Test: attr 47]
-    expected: FAIL
-
-  [CSS Values and Units Test: attr 48]
     expected: FAIL
 
   [CSS Values and Units Test: attr 67]
@@ -251,35 +101,20 @@
   [CSS Values and Units Test: attr 99]
     expected: FAIL
 
-  [CSS Values and Units Test: attr 100]
-    expected: FAIL
-
   [CSS Values and Units Test: attr 101]
-    expected: FAIL
-
-  [CSS Values and Units Test: attr 102]
     expected: FAIL
 
   [CSS Values and Units Test: attr 103]
     expected: FAIL
 
-  [CSS Values and Units Test: attr 104]
-    expected: FAIL
-
   [CSS Values and Units Test: attr 105]
-    expected: FAIL
-
-  [CSS Values and Units Test: attr 106]
-    expected: FAIL
-
-  [CSS Values and Units Test: attr 118]
     expected: FAIL
 
   [CSS Values and Units Test: attr 119]
     expected: FAIL
 
-  [CSS Values and Units Test: attr 120]
+  [CSS Values and Units Test: attr 121]
     expected: FAIL
 
-  [CSS Values and Units Test: attr 121]
+  [CSS Values and Units Test: attr 80]
     expected: FAIL

--- a/tests/wpt/meta/css/css-values/attr-color-invalid-cast.html.ini
+++ b/tests/wpt/meta/css/css-values/attr-color-invalid-cast.html.ini
@@ -1,2 +1,0 @@
-[attr-color-invalid-cast.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-values/attr-color-valid.html.ini
+++ b/tests/wpt/meta/css/css-values/attr-color-valid.html.ini
@@ -1,2 +1,0 @@
-[attr-color-valid.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-values/attr-cycle.html.ini
+++ b/tests/wpt/meta/css/css-values/attr-cycle.html.ini
@@ -2,9 +2,6 @@
   [CSS Values and Units Test: attr]
     expected: FAIL
 
-  [CSS Values and Units Test: attr 1]
-    expected: FAIL
-
   [CSS Values and Units Test: attr 2]
     expected: FAIL
 
@@ -14,28 +11,16 @@
   [CSS Values and Units Test: attr 4]
     expected: FAIL
 
-  [CSS Values and Units Test: attr 5]
-    expected: FAIL
-
   [CSS Values and Units Test: attr 6]
     expected: FAIL
 
   [CSS Values and Units Test: attr 7]
     expected: FAIL
 
-  [CSS Values and Units Test: attr 8]
-    expected: FAIL
-
   [CSS Values and Units Test: attr 9]
     expected: FAIL
 
   [CSS Values and Units Test: attr 10]
-    expected: FAIL
-
-  [CSS Values and Units Test: attr 11]
-    expected: FAIL
-
-  [CSS Values and Units Test: attr 12]
     expected: FAIL
 
   [CSS Values and Units Test: attr 14]
@@ -47,16 +32,10 @@
   [CSS Values and Units Test: attr 20]
     expected: FAIL
 
-  [CSS Values and Units Test: attr 15]
-    expected: FAIL
-
   [CSS Values and Units Test: attr 17]
     expected: FAIL
 
   [CSS Values and Units Test: attr 21]
-    expected: FAIL
-
-  [CSS Values and Units Test: attr 13]
     expected: FAIL
 
   [CSS Values and Units Test: attr 19]
@@ -66,9 +45,6 @@
     expected: FAIL
 
   [CSS Values and Units Test: attr 23]
-    expected: FAIL
-
-  [CSS Values and Units Test: attr 25]
     expected: FAIL
 
   [CSS Values and Units Test: attr 26]

--- a/tests/wpt/meta/css/css-values/attr-in-max.html.ini
+++ b/tests/wpt/meta/css/css-values/attr-in-max.html.ini
@@ -1,2 +1,0 @@
-[attr-in-max.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-values/attr-in-slotted.html.ini
+++ b/tests/wpt/meta/css/css-values/attr-in-slotted.html.ini
@@ -1,2 +1,0 @@
-[attr-in-slotted.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-values/attr-length-invalid-cast.html.ini
+++ b/tests/wpt/meta/css/css-values/attr-length-invalid-cast.html.ini
@@ -1,2 +1,0 @@
-[attr-length-invalid-cast.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-values/attr-length-valid-zero-nofallback.html.ini
+++ b/tests/wpt/meta/css/css-values/attr-length-valid-zero-nofallback.html.ini
@@ -1,2 +1,0 @@
-[attr-length-valid-zero-nofallback.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-values/attr-length-valid-zero.html.ini
+++ b/tests/wpt/meta/css/css-values/attr-length-valid-zero.html.ini
@@ -1,2 +1,0 @@
-[attr-length-valid-zero.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-values/attr-length-valid.html.ini
+++ b/tests/wpt/meta/css/css-values/attr-length-valid.html.ini
@@ -1,2 +1,0 @@
-[attr-length-valid.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-values/attr-null-namespace.xhtml.ini
+++ b/tests/wpt/meta/css/css-values/attr-null-namespace.xhtml.ini
@@ -5,11 +5,5 @@
   [Attribute in null-namespace is substituted]
     expected: FAIL
 
-  [Fallback is taken when attribute does not exist in null-namespace]
-    expected: FAIL
-
   [Attribute in null-namespace is substituted (JS)]
-    expected: FAIL
-
-  [Fallback is taken when attribute does not does exist in null-namespace (JS)]
     expected: FAIL

--- a/tests/wpt/meta/css/css-values/attr-security.html.ini
+++ b/tests/wpt/meta/css/css-values/attr-security.html.ini
@@ -38,46 +38,13 @@
   [CSS Values and Units Test: attr() security limitations 14]
     expected: FAIL
 
-  ['--x: image-set(attr(data-foo))' with data-foo="https://does-not-exist.test/404.png"]
-    expected: FAIL
-
-  ['--x: src(attr(data-foo))' with data-foo="https://does-not-exist.test/404.png"]
-    expected: FAIL
-
   ['background-image: src("https://does-not-exist.test/404.png")' with data-foo="https://does-not-exist.test/404.png"]
-    expected: FAIL
-
-  ['--x: src(string("https://does-not-exist.test" attr(data-foo)))' with data-foo="/404.png"]
     expected: FAIL
 
   ['background-image: src(string("https://does-not-exist.test/""404.png"))' with data-foo="/404.png"]
     expected: FAIL
 
-  ['--x: attr(data-foo type(<url>))' with data-foo="url(https://does-not-exist.test/404.png)"]
-    expected: FAIL
-
-  ['--x: image(attr(data-foo))' with data-foo="https://does-not-exist.test/404.png"]
-    expected: FAIL
-
   ['background-image: image("https://does-not-exist.test/404.png")' with data-foo="https://does-not-exist.test/404.png"]
-    expected: FAIL
-
-  ['background-image: url(https://does-not-exist.test/404.png), attr(data-foo type(<image>))' with data-foo="linear-gradient(#000000, #ffffff)"]
-    expected: FAIL
-
-  ['--x: image-set(var(--y, attr(data-foo)))' with data-foo="https://does-not-exist.test/404.png"]
-    expected: FAIL
-
-  ['--x: image-set(var(--some-string))' with data-foo="https://does-not-exist.test/404.png"]
-    expected: FAIL
-
-  ['--x: image-set(var(--some-string-list))' with data-foo="https://does-not-exist.test/404.png"]
-    expected: FAIL
-
-  ['--registered-color: attr(data-foo type(<color>))' with data-foo="blue"]
-    expected: FAIL
-
-  ['--x: image-set(var(--some-other-url))' with data-foo="https://does-not-exist.test/404.png"]
     expected: FAIL
 
   ['--x: image-set(if(style(--true): attr(data-foo);))' with data-foo="https://does-not-exist.test/404.png"]
@@ -98,5 +65,17 @@
   ['background-image: image-set(var(--some-string))' with data-foo="https://does-not-exist.test/404.png"]
     expected: FAIL
 
-  ['background-image: image-set(var(--some-string-list))' with data-foo="https://does-not-exist.test/404.png"]
+  ['background-image: image-set(attr(data-foo))' with data-foo="https://does-not-exist.test/404.png"]
+    expected: FAIL
+
+  ['background-image: attr(data-foo type(<url>))' with data-foo="url(https://does-not-exist.test/404.png)"]
+    expected: FAIL
+
+  ['background-image: image-set(var(--y, attr(data-foo)))' with data-foo="https://does-not-exist.test/404.png"]
+    expected: FAIL
+
+  ['background-image: image-set(var(--some-other-url))' with data-foo="https://does-not-exist.test/404.png"]
+    expected: FAIL
+
+  ['background-image: image-set(var(--image-set-valid))' with data-foo="image/jpeg"]
     expected: FAIL

--- a/tests/wpt/meta/css/css-values/attr-style-sharing-3.html.ini
+++ b/tests/wpt/meta/css/css-values/attr-style-sharing-3.html.ini
@@ -1,2 +1,0 @@
-[attr-style-sharing-3.html]
-  expected: FAIL


### PR DESCRIPTION
The implementation of `attr()` in Stylo is not complete, but this way we can start testing for it.

Bumps Stylo to https://github.com/servo/stylo/pull/306

Testing: Various tests pass, also a few failures. No impact on users, even with experimental features enabled.
