### PR TITLE
layout: Mark `Contentful` for Images only if they have `ImageKey`

### DIFF
--- a/components/layout/display_list/mod.rs
+++ b/components/layout/display_list/mod.rs
@@ -630,8 +630,6 @@ impl Fragment {
                 let style = image.base.style();
                 match style.get_inherited_box().visibility {
                     Visibility::Visible => {
-                        builder.mark_is_contentful();
-
                         let image_rendering =
                             style.get_inherited_box().image_rendering.to_webrender();
                         let rect = image
@@ -646,6 +644,8 @@ impl Fragment {
                         let common = builder.common_properties(clip, &style);
 
                         if let Some(image_key) = image.image_key {
+                            builder.mark_is_contentful();
+
                             builder.wr().push_image(
                                 &common,
                                 rect,


### PR DESCRIPTION
This PR checks if `ImageKey` is available, then it marks it as `Contentful`. For Videos, if valid `poster` or `first frame`, it will be stored in `ImageKey`.
Hence, appropriate way to mark `Contentful`.

Testing: 

- `/paint-timing/fcp-only/fcp-video-poster.html`
-  `/paint-timing/fcp-only/fcp-video-frame.html`

Fixes #42359
Fixes #42360
