### PR TITLE
indexeddb: Update index data in backend

### DIFF
--- a/components/script/dom/indexeddb/idbindex.rs
+++ b/components/script/dom/indexeddb/idbindex.rs
@@ -2,17 +2,22 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 use dom_struct::dom_struct;
-use js::gc::MutableHandleValue;
+use js::context::JSContext;
+use js::gc::{HandleValue, MutableHandleValue};
 use script_bindings::codegen::GenericBindings::IDBIndexBinding::IDBIndexMethods;
 use script_bindings::conversions::SafeToJSValConvertible;
+use script_bindings::error::{Error, ErrorResult, Fallible};
 use script_bindings::str::DOMString;
+use storage_traits::indexeddb::{AsyncOperation, AsyncReadOnlyOperation};
 
 use crate::dom::bindings::import::base::SafeJSContext;
 use crate::dom::bindings::reflector::{Reflector, reflect_dom_object};
 use crate::dom::bindings::root::DomRoot;
 use crate::dom::globalscope::GlobalScope;
 use crate::dom::idbobjectstore::KeyPath;
+use crate::dom::idbrequest::IDBRequest;
 use crate::dom::indexeddb::idbobjectstore::IDBObjectStore;
+use crate::indexeddb::convert_value_to_key_range;
 use crate::script_runtime::CanGc;
 
 #[dom_struct]
@@ -64,6 +69,34 @@ impl IDBIndex {
             can_gc,
         )
     }
+
+    pub(crate) fn name(&self) -> String {
+        self.name.to_string()
+    }
+
+    pub(crate) fn key_path(&self) -> &KeyPath {
+        &self.key_path
+    }
+
+    pub(crate) fn multi_entry(&self) -> bool {
+        self.multi_entry
+    }
+
+    pub(crate) fn unique(&self) -> bool {
+        self.unique
+    }
+
+    pub(crate) fn object_store(&self) -> &DomRoot<IDBObjectStore> {
+        &self.object_store
+    }
+
+    fn verify_not_deleted(&self) -> ErrorResult {
+        if !self.object_store.index_exists(&self.name) {
+            return Err(Error::InvalidState(None));
+        }
+        self.object_store.verify_not_deleted()?;
+        Ok(())
+    }
 }
 
 impl IDBIndexMethods<crate::DomTypeHolder> for IDBIndex {
@@ -92,5 +125,93 @@ impl IDBIndexMethods<crate::DomTypeHolder> for IDBIndex {
                 sequence.safe_to_jsval(cx, retval, can_gc);
             },
         }
+    }
+
+    /// <https://www.w3.org/TR/IndexedDB/#dom-idbindex-get>
+    fn Get(&self, cx: &mut JSContext, query: HandleValue) -> Fallible<DomRoot<IDBRequest>> {
+        // Step 3. If index or index’s object store has been deleted, throw an "InvalidStateError" DOMException.
+        self.verify_not_deleted()?;
+
+        // Step 4. If transaction’s state is not active, then throw a "TransactionInactiveError" DOMException.
+        self.object_store.check_transaction_active()?;
+
+        // Step 5. Let range be the result of converting a value to a key range with query and true. Rethrow any exceptions.
+        let range = convert_value_to_key_range(cx, query, None);
+
+        // Step 6. Let operation be an algorithm to run retrieve a referenced value from an index with the current Realm record, index, and range.
+        // Step 7. Return the result (an IDBRequest) of running asynchronously execute a request with this and operation.
+        range.and_then(|q| {
+            IDBRequest::execute_async(
+                self,
+                |callback| {
+                    AsyncOperation::ReadOnly(AsyncReadOnlyOperation::IndexGetItem {
+                        callback,
+                        index_name: self.name.to_string(),
+                        key_range: q,
+                    })
+                },
+                None,
+                None,
+                CanGc::from_cx(cx),
+            )
+        })
+    }
+
+    /// <https://www.w3.org/TR/IndexedDB/#dom-idbindex-getkey>
+    fn GetKey(
+        &self,
+        cx: &mut JSContext,
+        query_or_options: HandleValue,
+    ) -> Fallible<DomRoot<IDBRequest>> {
+        // Step 3. If index or index’s object store has been deleted, throw an "InvalidStateError" DOMException.
+        self.verify_not_deleted()?;
+
+        // Step 4. If transaction’s state is not active, then throw a "TransactionInactiveError" DOMException.
+        self.object_store.check_transaction_active()?;
+
+        // Step 5. Let range be the result of converting a value to a key range with query and true. Rethrow any exceptions.
+        let range = convert_value_to_key_range(cx, query_or_options, None);
+        range.and_then(|q| {
+            IDBRequest::execute_async(
+                self,
+                |callback| {
+                    AsyncOperation::ReadOnly(AsyncReadOnlyOperation::IndexGetKey {
+                        callback,
+                        index_name: self.name.to_string(),
+                        key_range: q,
+                    })
+                },
+                None,
+                None,
+                CanGc::from_cx(cx),
+            )
+        })
+    }
+
+    /// <https://www.w3.org/TR/IndexedDB/#dom-idbindex-count>
+    fn Count(&self, cx: &mut JSContext, query: HandleValue) -> Fallible<DomRoot<IDBRequest>> {
+        // Step 3. If index or index’s object store has been deleted, throw an "InvalidStateError" DOMException.
+        self.verify_not_deleted()?;
+
+        // Step 4. If transaction’s state is not active, then throw a "TransactionInactiveError" DOMException.
+        self.object_store.check_transaction_active()?;
+
+        // Step 5. Let range be the result of converting a value to a key range with query. Rethrow any exceptions.
+        let range = convert_value_to_key_range(cx, query, None);
+        range.and_then(|q| {
+            IDBRequest::execute_async(
+                self,
+                |callback| {
+                    AsyncOperation::ReadOnly(AsyncReadOnlyOperation::IndexCount {
+                        callback,
+                        index_name: self.name.to_string(),
+                        key_range: q,
+                    })
+                },
+                None,
+                None,
+                CanGc::from_cx(cx),
+            )
+        })
     }
 }

--- a/components/script/dom/indexeddb/idbobjectstore.rs
+++ b/components/script/dom/indexeddb/idbobjectstore.rs
@@ -89,7 +89,7 @@ pub struct IDBObjectStore {
     reflector_: Reflector,
     name: DomRefCell<DOMString>,
     key_path: Option<KeyPath>,
-    index_set: DomRefCell<HashMap<DOMString, Dom<IDBIndex>>>,
+    index_set: DomRefCell<HashMap<DOMString, DomRoot<IDBIndex>>>,
     transaction: Dom<IDBTransaction>,
     has_key_generator: bool,
     key_generator_current_number: Cell<Option<i32>>,
@@ -261,7 +261,11 @@ impl IDBObjectStore {
         self.key_path.is_some()
     }
 
-    fn verify_not_deleted(&self) -> ErrorResult {
+    pub(crate) fn index_exists(&self, name: &DOMString) -> bool {
+        self.index_set.borrow().contains_key(name)
+    }
+
+    pub(crate) fn verify_not_deleted(&self) -> ErrorResult {
         let db = self.transaction.Db();
         if !db.object_store_exists(&self.name.borrow()) {
             return Err(Error::InvalidState(None));
@@ -270,7 +274,7 @@ impl IDBObjectStore {
     }
 
     /// Checks if the transaction is active, throwing a "TransactionInactiveError" DOMException if not.
-    fn check_transaction_active(&self) -> Fallible<()> {
+    pub(crate) fn check_transaction_active(&self) -> Fallible<()> {
         // Let transaction be this object store handle's transaction.
         let transaction = &self.transaction;
 
@@ -287,7 +291,7 @@ impl IDBObjectStore {
 
     /// Checks if the transaction is active, throwing a "TransactionInactiveError" DOMException if not.
     /// it then checks if the transaction is a read-only transaction, throwing a "ReadOnlyError" DOMException if so.
-    fn check_readwrite_transaction_active(&self) -> Fallible<()> {
+    pub(crate) fn check_readwrite_transaction_active(&self) -> Fallible<()> {
         // Let transaction be this object store handle's transaction.
         let transaction = &self.transaction;
 
@@ -407,6 +411,19 @@ impl IDBObjectStore {
         };
         // Step 12. Let operation be an algorithm to run store a record into an object store with
         // store, clone, key, and no-overwrite flag.
+        let mut index_keys = Vec::new();
+        let index_set = self.index_set.borrow();
+        for index in index_set.values() {
+            // https://www.w3.org/TR/IndexedDB/#store-a-record-into-an-object-store: Step 5.1
+            // Let index key be the result of extracting a key from a value using a key path with value, index’s key path, and index’s multiEntry flag.
+            let index_key = extract_key(cx, value, index.key_path(), Some(index.multi_entry()))?;
+
+            // https://www.w3.org/TR/IndexedDB/#store-a-record-into-an-object-store: Step 5.2
+            // If index key is an exception, or invalid, or failure, take no further actions for index, and continue these steps for the next index.
+            if let ExtractionResult::Key(key) = index_key {
+                index_keys.push((index.name(), index.unique(), key));
+            }
+        }
         let request = IDBRequest::execute_async(
             self,
             |callback| {
@@ -416,6 +433,7 @@ impl IDBObjectStore {
                     value: serialized_value,
                     should_overwrite: !no_overwrite,
                     key_generator_current_number: key_generator_current_number_for_put,
+                    index_keys,
                 })
             },
             None,
@@ -531,7 +549,7 @@ impl IDBObjectStore {
         );
         self.index_set
             .borrow_mut()
-            .insert(name, Dom::from_ref(&index));
+            .insert(name, DomRoot::from_ref(&index));
         index
     }
 }
@@ -981,6 +999,6 @@ impl IDBObjectStoreMethods<crate::DomTypeHolder> for IDBObjectStore {
         let index = index_set.get(&name).ok_or(Error::NotFound(None))?;
 
         // Step 6. Return an index handle associated with index and this.
-        Ok(index.as_rooted())
+        Ok(index.clone())
     }
 }

--- a/components/script/dom/indexeddb/idbrequest.rs
+++ b/components/script/dom/indexeddb/idbrequest.rs
@@ -19,10 +19,12 @@ use storage_traits::indexeddb::{
 };
 use stylo_atoms::Atom;
 
+use crate::dom::bindings::cell::DomRefCell;
 use crate::dom::bindings::codegen::Bindings::IDBRequestBinding::{
     IDBRequestMethods, IDBRequestReadyState,
 };
 use crate::dom::bindings::codegen::Bindings::IDBTransactionBinding::IDBTransactionMode;
+use crate::dom::bindings::codegen::UnionTypes::IDBObjectStoreOrIDBIndexOrIDBCursor;
 use crate::dom::bindings::error::{Error, Fallible, create_dom_exception};
 use crate::dom::bindings::inheritance::Castable;
 use crate::dom::bindings::refcounted::Trusted;
@@ -35,9 +37,8 @@ use crate::dom::eventtarget::EventTarget;
 use crate::dom::globalscope::GlobalScope;
 use crate::dom::indexeddb::idbcursor::{IterationParam, iterate_cursor};
 use crate::dom::indexeddb::idbcursorwithvalue::IDBCursorWithValue;
-use crate::dom::indexeddb::idbobjectstore::IDBObjectStore;
 use crate::dom::indexeddb::idbtransaction::IDBTransaction;
-use crate::indexeddb::key_type_to_jsval;
+use crate::indexeddb::{IDBSource, key_type_to_jsval};
 use crate::realms::enter_auto_realm;
 use crate::script_runtime::{CanGc, JSContext as SafeJSContext};
 
@@ -406,7 +407,8 @@ pub struct IDBRequest {
     #[ignore_malloc_size_of = "mozjs"]
     result: Heap<JSVal>,
     error: MutNullableDom<DOMException>,
-    source: MutNullableDom<IDBObjectStore>,
+    #[ignore_malloc_size_of = "refcell"]
+    source: DomRefCell<Option<IDBObjectStoreOrIDBIndexOrIDBCursor>>,
     transaction: MutNullableDom<IDBTransaction>,
     ready_state: Cell<IDBRequestReadyState>,
 }
@@ -428,8 +430,8 @@ impl IDBRequest {
         reflect_dom_object(Box::new(IDBRequest::new_inherited()), global, can_gc)
     }
 
-    pub fn set_source(&self, source: Option<&IDBObjectStore>) {
-        self.source.set(source);
+    pub fn set_source(&self, source: Option<IDBObjectStoreOrIDBIndexOrIDBCursor>) {
+        *self.source.borrow_mut() = source;
     }
 
     pub fn set_ready_state_done(&self) {
@@ -463,16 +465,17 @@ impl IDBRequest {
     }
 
     // https://www.w3.org/TR/IndexedDB-3/#asynchronously-execute-a-request
-    pub fn execute_async<T, F>(
-        source: &IDBObjectStore,
+    pub fn execute_async<S, F, T>(
+        source: &S,
         operation_fn: F,
         request: Option<DomRoot<IDBRequest>>,
         iteration_param: Option<IterationParam>,
         can_gc: CanGc,
     ) -> Fallible<DomRoot<IDBRequest>>
     where
-        T: Into<IdbResult> + for<'a> Deserialize<'a> + Serialize + Send + Sync + 'static,
+        S: IDBSource,
         F: FnOnce(GenericCallback<BackendResult<T>>) -> AsyncOperation,
+        T: Into<IdbResult> + for<'a> Deserialize<'a> + Serialize + Send + Sync + 'static,
     {
         // Step 1: Let transaction be the transaction associated with source.
         let transaction = source.transaction();
@@ -487,7 +490,7 @@ impl IDBRequest {
         // Step 3: If request was not given, let request be a new request with source as source.
         let request = request.unwrap_or_else(|| {
             let new_request = IDBRequest::new(&global, can_gc);
-            new_request.set_source(Some(source));
+            new_request.set_source(Some(source.as_source()));
             new_request.set_transaction(&transaction);
             new_request
         });
@@ -554,7 +557,7 @@ impl IDBRequest {
             .send(IndexedDBThreadMsg::Async(
                 global.origin().immutable().clone(),
                 transaction.get_db_name().to_string(),
-                source.get_name().to_string(),
+                source.object_store_name().to_string(),
                 transaction.get_serial_number(),
                 request_id,
                 transaction_mode,
@@ -579,8 +582,20 @@ impl IDBRequestMethods<crate::DomTypeHolder> for IDBRequest {
     }
 
     /// <https://www.w3.org/TR/IndexedDB-3/#dom-idbrequest-source>
-    fn GetSource(&self) -> Option<DomRoot<IDBObjectStore>> {
-        self.source.get()
+    fn GetSource(&self) -> Option<IDBObjectStoreOrIDBIndexOrIDBCursor> {
+        // IDBObjectStoreOrIDBIndexOrIDBCursor doesn't implement Copy
+        match &*self.source.borrow() {
+            Some(IDBObjectStoreOrIDBIndexOrIDBCursor::IDBObjectStore(store)) => Some(
+                IDBObjectStoreOrIDBIndexOrIDBCursor::IDBObjectStore(DomRoot::from_ref(store)),
+            ),
+            Some(IDBObjectStoreOrIDBIndexOrIDBCursor::IDBIndex(index)) => Some(
+                IDBObjectStoreOrIDBIndexOrIDBCursor::IDBIndex(DomRoot::from_ref(index)),
+            ),
+            Some(IDBObjectStoreOrIDBIndexOrIDBCursor::IDBCursor(cursor)) => Some(
+                IDBObjectStoreOrIDBIndexOrIDBCursor::IDBCursor(DomRoot::from_ref(cursor)),
+            ),
+            None => None,
+        }
     }
 
     /// <https://www.w3.org/TR/IndexedDB-3/#dom-idbrequest-transaction>

--- a/components/script/indexeddb.rs
+++ b/components/script/indexeddb.rs
@@ -21,11 +21,14 @@ use js::rust::wrappers2::{
 };
 use js::rust::{HandleValue, MutableHandleValue};
 use js::typedarray::{ArrayBuffer, ArrayBufferView, CreateWith};
+use script_bindings::root::DomRoot;
 use storage_traits::indexeddb::{BackendError, IndexedDBKeyRange, IndexedDBKeyType};
 
 use crate::dom::bindings::codegen::Bindings::BlobBinding::BlobMethods;
 use crate::dom::bindings::codegen::Bindings::FileBinding::FileMethods;
-use crate::dom::bindings::codegen::UnionTypes::StringOrStringSequence as StrOrStringSequence;
+use crate::dom::bindings::codegen::UnionTypes::{
+    IDBObjectStoreOrIDBIndexOrIDBCursor, StringOrStringSequence as StrOrStringSequence,
+};
 use crate::dom::bindings::conversions::{
     get_property_jsval, root_from_handlevalue, root_from_object,
 };
@@ -36,8 +39,44 @@ use crate::dom::bindings::utils::{
 };
 use crate::dom::blob::Blob;
 use crate::dom::file::File;
+use crate::dom::idbindex::IDBIndex;
 use crate::dom::idbkeyrange::IDBKeyRange;
-use crate::dom::idbobjectstore::KeyPath;
+use crate::dom::idbobjectstore::{IDBObjectStore, KeyPath};
+use crate::dom::idbtransaction::IDBTransaction;
+
+pub(crate) trait IDBSource {
+    fn transaction(&self) -> DomRoot<IDBTransaction>;
+    fn object_store_name(&self) -> DOMString;
+    fn as_source(&self) -> IDBObjectStoreOrIDBIndexOrIDBCursor;
+}
+
+impl IDBSource for IDBObjectStore {
+    fn transaction(&self) -> DomRoot<IDBTransaction> {
+        self.transaction()
+    }
+
+    fn object_store_name(&self) -> DOMString {
+        self.get_name()
+    }
+
+    fn as_source(&self) -> IDBObjectStoreOrIDBIndexOrIDBCursor {
+        IDBObjectStoreOrIDBIndexOrIDBCursor::IDBObjectStore(DomRoot::from_ref(self))
+    }
+}
+
+impl IDBSource for IDBIndex {
+    fn transaction(&self) -> DomRoot<IDBTransaction> {
+        self.object_store().transaction()
+    }
+
+    fn object_store_name(&self) -> DOMString {
+        self.object_store().get_name()
+    }
+
+    fn as_source(&self) -> IDBObjectStoreOrIDBIndexOrIDBCursor {
+        IDBObjectStoreOrIDBIndexOrIDBCursor::IDBIndex(DomRoot::from_ref(self))
+    }
+}
 use crate::script_runtime::CanGc;
 
 // https://www.w3.org/TR/IndexedDB-3/#convert-key-to-value
@@ -874,9 +913,11 @@ pub(crate) fn extract_key(
     // multiEntry flag is unset, and the result of running the steps to convert a value to a
     // multiEntry key with r otherwise. Rethrow any exceptions.
     let key = match multi_entry {
-        Some(true) => {
-            // TODO: implement convert_value_to_multientry_key
-            unimplemented!("multiEntry keys are not yet supported");
+        // TODO(arihant2math): implement multiEntry key conversion
+        Some(true) => match convert_value_to_key(cx, r.handle(), None)? {
+            ConversionResult::Valid(key) => key,
+            // Step 4. If key is invalid, return invalid.
+            ConversionResult::Invalid => return Ok(ExtractionResult::Invalid),
         },
         _ => match convert_value_to_key(cx, r.handle(), None)? {
             ConversionResult::Valid(key) => key,

--- a/components/script_bindings/codegen/Bindings.conf
+++ b/components/script_bindings/codegen/Bindings.conf
@@ -613,6 +613,7 @@ DOMInterfaces = {
 
 'IDBIndex': {
     'canGc': ['KeyPath'],
+    'cx': ['Get', 'GetKey', 'GetAll', 'GetAllKeys', 'Count'],
 },
 
 'IDBKeyRange': {

--- a/components/script_bindings/webidls/IDBIndex.webidl
+++ b/components/script_bindings/webidls/IDBIndex.webidl
@@ -15,14 +15,14 @@ interface IDBIndex {
   readonly attribute boolean multiEntry;
   readonly attribute boolean unique;
 
-  // [NewObject] IDBRequest get(any query);
-  // [NewObject] IDBRequest getKey(any query);
+  [Throws, NewObject] IDBRequest get(any query);
+  [Throws, NewObject] IDBRequest getKey(any query);
   // [NewObject] IDBRequest getAll(optional any queryOrOptions,
   //                               optional [EnforceRange] unsigned long count);
   // [NewObject] IDBRequest getAllKeys(optional any queryOrOptions,
   //                                   optional [EnforceRange] unsigned long count);
   // [NewObject] IDBRequest getAllRecords(optional IDBGetAllOptions options = {});
-  // [NewObject] IDBRequest count(optional any query);
+  [Throws, NewObject] IDBRequest count(optional any query);
 
   // [NewObject] IDBRequest openCursor(optional any query,
   //                                   optional IDBCursorDirection direction = "next");

--- a/components/script_bindings/webidls/IDBRequest.webidl
+++ b/components/script_bindings/webidls/IDBRequest.webidl
@@ -12,8 +12,7 @@
 interface IDBRequest : EventTarget {
   readonly attribute any result;
   readonly attribute DOMException? error;
-  // readonly attribute (IDBObjectStore or IDBIndex or IDBCursor)? source;
-  readonly attribute IDBObjectStore? source;
+  readonly attribute (IDBObjectStore or IDBIndex or IDBCursor)? source;
   readonly attribute IDBTransaction? transaction;
   readonly attribute IDBRequestReadyState readyState;
 

--- a/components/shared/storage/indexeddb.rs
+++ b/components/shared/storage/indexeddb.rs
@@ -311,6 +311,36 @@ pub enum AsyncReadOnlyOperation {
         callback: GenericCallback<BackendResult<Vec<IndexedDBRecord>>>,
         key_range: IndexedDBKeyRange,
     },
+
+    IndexGetKey {
+        callback: GenericCallback<BackendResult<Option<IndexedDBKeyType>>>,
+        index_name: String,
+        key_range: IndexedDBKeyRange,
+    },
+    IndexGetItem {
+        callback: GenericCallback<BackendResult<Option<Vec<u8>>>>,
+        index_name: String,
+        key_range: IndexedDBKeyRange,
+    },
+
+    IndexGetAllKeys {
+        callback: GenericCallback<BackendResult<Vec<IndexedDBKeyType>>>,
+        index_name: String,
+        key_range: IndexedDBKeyRange,
+        count: Option<u32>,
+    },
+    IndexGetAllItems {
+        callback: GenericCallback<BackendResult<Vec<Vec<u8>>>>,
+        index_name: String,
+        key_range: IndexedDBKeyRange,
+        count: Option<u32>,
+    },
+
+    IndexCount {
+        callback: GenericCallback<BackendResult<u64>>,
+        index_name: String,
+        key_range: IndexedDBKeyRange,
+    },
 }
 
 impl AsyncReadOnlyOperation {
@@ -322,6 +352,11 @@ impl AsyncReadOnlyOperation {
             Self::GetAllItems { callback, .. } => callback.send(Err(error)),
             Self::Count { callback, .. } => callback.send(Err(error)),
             Self::Iterate { callback, .. } => callback.send(Err(error)),
+            Self::IndexGetKey { callback, .. } => callback.send(Err(error)),
+            Self::IndexGetItem { callback, .. } => callback.send(Err(error)),
+            Self::IndexGetAllKeys { callback, .. } => callback.send(Err(error)),
+            Self::IndexGetAllItems { callback, .. } => callback.send(Err(error)),
+            Self::IndexCount { callback, .. } => callback.send(Err(error)),
         };
     }
 }
@@ -333,6 +368,8 @@ pub enum AsyncReadWriteOperation {
         callback: GenericCallback<BackendResult<PutItemResult>>,
         key: Option<IndexedDBKeyType>,
         value: Vec<u8>,
+        /// (index_name, is_unique, key)
+        index_keys: Vec<(String, bool, IndexedDBKeyType)>,
         should_overwrite: bool,
         /// New object store key generator current number to persist if the put succeeds.
         key_generator_current_number: Option<i32>,

--- a/components/storage/indexeddb/engines/sqlite.rs
+++ b/components/storage/indexeddb/engines/sqlite.rs
@@ -7,7 +7,7 @@ use std::sync::Arc;
 use log::{error, info, warn};
 use malloc_size_of::{MallocSizeOf, MallocSizeOfOps};
 use rusqlite::{Connection, Error, OptionalExtension, params};
-use sea_query::{Condition, Expr, ExprTrait, IntoCondition, SqliteQueryBuilder};
+use sea_query::{Condition, Expr, ExprTrait, IntoColumnRef, IntoCondition, SqliteQueryBuilder};
 use sea_query_rusqlite::RusqliteBinder;
 use servo_base::threadpool::ThreadPool;
 use storage_traits::indexeddb::{
@@ -23,34 +23,34 @@ use crate::shared::{DB_INIT_PRAGMAS, DB_PRAGMAS};
 mod create;
 mod database_model;
 mod encoding;
+mod index_data_model;
 mod object_data_model;
 mod object_store_index_model;
 mod object_store_model;
+mod unique_index_data_model;
 
-fn range_to_query(range: IndexedDBKeyRange) -> Condition {
+fn range_to_query<T: Copy + IntoColumnRef>(range: &IndexedDBKeyRange, column: T) -> Condition {
     // Special case for optimization
     if let Some(singleton) = range.as_singleton() {
         let encoded = encoding::serialize(singleton);
-        return Expr::column(object_data_model::Column::Key)
-            .eq(encoded)
-            .into_condition();
+        return Expr::column(column).eq(encoded).into_condition();
     }
     let mut parts = vec![];
     if let Some(upper) = range.upper.as_ref() {
         let upper_bytes = encoding::serialize(upper);
         let query = if range.upper_open {
-            Expr::column(object_data_model::Column::Key).lt(upper_bytes)
+            Expr::column(column).clone().lt(upper_bytes)
         } else {
-            Expr::column(object_data_model::Column::Key).lte(upper_bytes)
+            Expr::column(column).clone().lte(upper_bytes)
         };
         parts.push(query);
     }
     if let Some(lower) = range.lower.as_ref() {
         let lower_bytes = encoding::serialize(lower);
         let query = if range.lower_open {
-            Expr::column(object_data_model::Column::Key).gt(lower_bytes)
+            Expr::column(column).gt(lower_bytes)
         } else {
-            Expr::column(object_data_model::Column::Key).gte(lower_bytes)
+            Expr::column(column).gte(lower_bytes)
         };
         parts.push(query);
     }
@@ -147,12 +147,24 @@ impl SqliteEngine {
         Ok(connection)
     }
 
+    fn get_index(
+        connection: &Connection,
+        store: &object_store_model::Model,
+        index_name: String,
+    ) -> Result<object_store_index_model::Model, Error> {
+        connection
+            .prepare("SELECT * FROM object_store_index WHERE name = ? AND object_store_id = ?")?
+            .query_row(params![index_name.to_string(), store.id], |row| {
+                object_store_index_model::Model::try_from(row)
+            })
+    }
+
     fn get(
         connection: &Connection,
         store: object_store_model::Model,
         key_range: IndexedDBKeyRange,
     ) -> Result<Option<object_data_model::Model>, Error> {
-        let query = range_to_query(key_range);
+        let query = range_to_query(&key_range, object_data_model::Column::Key);
         let (sql, values) = sea_query::Query::select()
             .from(object_data_model::Column::Table)
             .columns(vec![
@@ -171,12 +183,67 @@ impl SqliteEngine {
             .optional()
     }
 
+    fn index_get(
+        connection: &Connection,
+        store: object_store_model::Model,
+        index: String,
+        key_range: IndexedDBKeyRange,
+    ) -> Result<Option<index_data_model::Model>, Error> {
+        let index = Self::get_index(connection, &store, index)?;
+        let (sql, values) = if index.unique_index {
+            let query = range_to_query(&key_range, unique_index_data_model::Column::ObjectDataKey);
+            sea_query::Query::select()
+                .from(unique_index_data_model::Column::Table)
+                .columns(vec![
+                    unique_index_data_model::Column::IndexId,
+                    unique_index_data_model::Column::Value,
+                    unique_index_data_model::Column::ObjectDataKey,
+                    unique_index_data_model::Column::ObjectStoreId,
+                    unique_index_data_model::Column::ValueLocale,
+                ])
+                .and_where(
+                    query.and(Expr::col(unique_index_data_model::Column::IndexId).is(index.id)),
+                )
+                .limit(1)
+                .build_rusqlite(SqliteQueryBuilder)
+        } else {
+            let query = range_to_query(&key_range, index_data_model::Column::Value);
+            sea_query::Query::select()
+                .from(index_data_model::Column::Table)
+                .columns(vec![
+                    index_data_model::Column::IndexId,
+                    index_data_model::Column::Value,
+                    index_data_model::Column::ObjectDataKey,
+                    index_data_model::Column::ObjectStoreId,
+                    index_data_model::Column::ValueLocale,
+                ])
+                .and_where(query.and(Expr::col(index_data_model::Column::IndexId).is(index.id)))
+                .limit(1)
+                .build_rusqlite(SqliteQueryBuilder)
+        };
+        connection
+            .prepare(&sql)?
+            .query_one(&*values.as_params(), |row| {
+                index_data_model::Model::try_from(row)
+            })
+            .optional()
+    }
+
     fn get_key(
         connection: &Connection,
         store: object_store_model::Model,
         key_range: IndexedDBKeyRange,
     ) -> Result<Option<Vec<u8>>, Error> {
         Self::get(connection, store, key_range).map(|opt| opt.map(|model| model.key))
+    }
+
+    fn get_index_key(
+        connection: &Connection,
+        store: object_store_model::Model,
+        index: String,
+        key_range: IndexedDBKeyRange,
+    ) -> Result<Option<Vec<u8>>, Error> {
+        Self::index_get(connection, store, index, key_range).map(|opt| opt.map(|model| model.value))
     }
 
     fn get_item(
@@ -187,13 +254,23 @@ impl SqliteEngine {
         Self::get(connection, store, key_range).map(|opt| opt.map(|model| model.data))
     }
 
+    fn get_index_item(
+        connection: &Connection,
+        store: object_store_model::Model,
+        index: String,
+        key_range: IndexedDBKeyRange,
+    ) -> Result<Option<Vec<u8>>, Error> {
+        Self::index_get(connection, store, index, key_range)
+            .map(|opt| opt.map(|model| model.object_data_key))
+    }
+
     fn get_all(
         connection: &Connection,
         store: object_store_model::Model,
         key_range: IndexedDBKeyRange,
         count: Option<u32>,
     ) -> Result<Vec<object_data_model::Model>, Error> {
-        let query = range_to_query(key_range);
+        let query = range_to_query(&key_range, object_data_model::Column::Key);
         let mut sql_query = sea_query::Query::select();
         sql_query
             .from(object_data_model::Column::Table)
@@ -216,6 +293,55 @@ impl SqliteEngine {
         Ok(models)
     }
 
+    fn index_get_all(
+        connection: &Connection,
+        store: object_store_model::Model,
+        index: String,
+        key_range: IndexedDBKeyRange,
+        count: Option<u32>,
+    ) -> Result<Vec<index_data_model::Model>, Error> {
+        let index = Self::get_index(connection, &store, index)?;
+        let mut select = sea_query::Query::select();
+        if index.unique_index {
+            let query = range_to_query(&key_range, unique_index_data_model::Column::ObjectDataKey);
+            select
+                .from(unique_index_data_model::Column::Table)
+                .columns(vec![
+                    unique_index_data_model::Column::IndexId,
+                    unique_index_data_model::Column::Value,
+                    unique_index_data_model::Column::ObjectDataKey,
+                    unique_index_data_model::Column::ObjectStoreId,
+                    unique_index_data_model::Column::ValueLocale,
+                ])
+                .and_where(
+                    query.and(Expr::col(unique_index_data_model::Column::IndexId).is(index.id)),
+                )
+        } else {
+            let query = range_to_query(&key_range, index_data_model::Column::Value);
+            select
+                .from(index_data_model::Column::Table)
+                .columns(vec![
+                    index_data_model::Column::IndexId,
+                    index_data_model::Column::Value,
+                    index_data_model::Column::ObjectDataKey,
+                    index_data_model::Column::ObjectStoreId,
+                    index_data_model::Column::ValueLocale,
+                ])
+                .and_where(query.and(Expr::col(index_data_model::Column::IndexId).is(index.id)))
+        };
+        if let Some(count) = count {
+            select.limit(count as u64);
+        }
+        let (sql, values) = select.build_rusqlite(SqliteQueryBuilder);
+        let mut stmt = connection.prepare(&sql)?;
+        let models = stmt
+            .query_and_then(&*values.as_params(), |row| {
+                index_data_model::Model::try_from(row)
+            })?
+            .collect::<Result<Vec<_>, _>>()?;
+        Ok(models)
+    }
+
     fn get_all_keys(
         connection: &Connection,
         store: object_store_model::Model,
@@ -224,6 +350,17 @@ impl SqliteEngine {
     ) -> Result<Vec<Vec<u8>>, Error> {
         Self::get_all(connection, store, key_range, count)
             .map(|models| models.into_iter().map(|m| m.key).collect())
+    }
+
+    fn index_get_all_keys(
+        connection: &Connection,
+        store: object_store_model::Model,
+        index: String,
+        key_range: IndexedDBKeyRange,
+        count: Option<u32>,
+    ) -> Result<Vec<Vec<u8>>, Error> {
+        Self::index_get_all(connection, store, index, key_range, count)
+            .map(|models| models.into_iter().map(|m| m.value).collect())
     }
 
     fn get_all_items(
@@ -236,6 +373,17 @@ impl SqliteEngine {
             .map(|models| models.into_iter().map(|m| m.data).collect())
     }
 
+    fn index_get_all_items(
+        connection: &Connection,
+        store: object_store_model::Model,
+        index: String,
+        key_range: IndexedDBKeyRange,
+        count: Option<u32>,
+    ) -> Result<Vec<Vec<u8>>, Error> {
+        Self::index_get_all(connection, store, index, key_range, count)
+            .map(|models| models.into_iter().map(|m| m.object_data_key).collect())
+    }
+
     #[expect(clippy::type_complexity)]
     fn get_all_records(
         connection: &Connection,
@@ -246,11 +394,28 @@ impl SqliteEngine {
             .map(|models| models.into_iter().map(|m| (m.key, m.data)).collect())
     }
 
+    #[expect(unused, clippy::type_complexity)]
+    fn index_get_all_records(
+        connection: &Connection,
+        store: object_store_model::Model,
+        index: String,
+        key_range: IndexedDBKeyRange,
+    ) -> Result<Vec<(Vec<u8>, Vec<u8>)>, Error> {
+        Self::index_get_all(connection, store, index, key_range, None).map(|models| {
+            models
+                .into_iter()
+                .map(|m| (m.value, m.object_data_key))
+                .collect()
+        })
+    }
+
+    /// <https://www.w3.org/TR/IndexedDB/#store-a-record-into-an-object-store>
     fn put_item(
         connection: &Connection,
         store: object_store_model::Model,
         key: IndexedDBKeyType,
         value: Vec<u8>,
+        index_keys: Vec<(String, bool, IndexedDBKeyType)>,
         should_overwrite: bool,
         key_generator_current_number: Option<i32>,
     ) -> Result<PutItemResult, Error> {
@@ -280,6 +445,43 @@ impl SqliteEngine {
                 params![store.id, serialized_key, value],
             )?;
         }
+        // Step 5. For each index which references store:
+        for (index_name, unique, key_type) in index_keys {
+            // Step 1, 2 already done.
+            // Get index id
+            let index_id: i64 = connection.query_row(
+                "SELECT id FROM object_store_index WHERE name = ? AND object_store_id = ?",
+                params![index_name.to_string(), store.id],
+                |row| row.get(0),
+            )?;
+            if unique {
+                // TODO: Step 3.
+                // Step 5.
+                let serialized_index_key: Vec<u8> = postcard::to_stdvec(&key).unwrap();
+                connection.execute(
+                    "INSERT INTO unique_index_data (index_id, object_data_key, value, object_store_id) VALUES (?, ?, ?, ?)",
+                    params![index_id, serialized_index_key, serialized_key, store.id],
+                )?;
+            } else if let IndexedDBKeyType::Array(array) = key_type {
+                // TODO: Step 4.
+                // Step 6.
+                for key in array {
+                    let serialized_index_key: Vec<u8> = postcard::to_stdvec(&key).unwrap();
+                    connection.execute(
+                        "INSERT INTO index_data (index_id, object_data_key, value, object_store_id) VALUES (?, ?, ?, ?)",
+                        params![index_id, serialized_index_key, serialized_key, store.id],
+                    )?;
+                }
+            } else {
+                // TODO: Step 3.
+                // Step 5.
+                let serialized_index_key: Vec<u8> = postcard::to_stdvec(&key).unwrap();
+                connection.execute(
+                    "INSERT INTO index_data (index_id, object_data_key, value, object_store_id) VALUES (?, ?, ?, ?)",
+                    params![index_id, serialized_index_key, serialized_key, store.id],
+                )?;
+            }
+        }
         if let Some(next_key_generator_current_number) = key_generator_current_number {
             connection.execute(
                 "UPDATE object_store SET auto_increment = ? WHERE id = ?",
@@ -294,20 +496,54 @@ impl SqliteEngine {
         store: object_store_model::Model,
         key_range: IndexedDBKeyRange,
     ) -> Result<(), Error> {
-        let query = range_to_query(key_range);
+        // Object Store
+        let query = range_to_query(&key_range, object_data_model::Column::Key);
         let (sql, values) = sea_query::Query::delete()
             .from_table(object_data_model::Column::Table)
             .and_where(query.and(Expr::col(object_data_model::Column::ObjectStoreId).is(store.id)))
             .build_rusqlite(SqliteQueryBuilder);
         connection.prepare(&sql)?.execute(&*values.as_params())?;
+
+        // Index
+        let query = range_to_query(&key_range, index_data_model::Column::Value);
+        let (sql, values) = sea_query::Query::delete()
+            .from_table(index_data_model::Column::Table)
+            .and_where(query.and(Expr::col(index_data_model::Column::ObjectStoreId).is(store.id)))
+            .build_rusqlite(SqliteQueryBuilder);
+        connection.prepare(&sql)?.execute(&*values.as_params())?;
+
+        // Unique Index
+        let query = range_to_query(&key_range, unique_index_data_model::Column::Value);
+        let (sql, values) = sea_query::Query::delete()
+            .from_table(unique_index_data_model::Column::Table)
+            .and_where(
+                query.and(Expr::col(unique_index_data_model::Column::ObjectStoreId).is(store.id)),
+            )
+            .build_rusqlite(SqliteQueryBuilder);
+        connection.prepare(&sql)?.execute(&*values.as_params())?;
+
         Ok(())
     }
 
     fn clear(connection: &Connection, store: object_store_model::Model) -> Result<(), Error> {
+        // Object Store
         connection.execute(
             "DELETE FROM object_data WHERE object_store_id = ?",
             params![store.id],
         )?;
+
+        // Index
+        connection.execute(
+            "DELETE FROM index_data WHERE object_store_id = ?",
+            params![store.id],
+        )?;
+
+        // Unique Index
+        connection.execute(
+            "DELETE FROM unique_index_data WHERE object_store_id = ?",
+            params![store.id],
+        )?;
+
         Ok(())
     }
 
@@ -316,7 +552,7 @@ impl SqliteEngine {
         store: object_store_model::Model,
         key_range: IndexedDBKeyRange,
     ) -> Result<usize, Error> {
-        let query = range_to_query(key_range);
+        let query = range_to_query(&key_range, object_data_model::Column::Key);
         let (sql, values) = sea_query::Query::select()
             .expr(Expr::col(object_data_model::Column::Key).count())
             .from(object_data_model::Column::Table)
@@ -326,6 +562,52 @@ impl SqliteEngine {
             .prepare(&sql)?
             .query_row(&*values.as_params(), |row| row.get(0))
             .map(|count: i64| count as usize)
+    }
+
+    fn index_count(
+        connection: &Connection,
+        store: object_store_model::Model,
+        index: String,
+        key_range: IndexedDBKeyRange,
+    ) -> Result<usize, Error> {
+        let index = Self::get_index(connection, &store, index)?;
+        let (sql, values) = if index.unique_index {
+            let query = range_to_query(&key_range, unique_index_data_model::Column::ObjectDataKey);
+            sea_query::Query::select()
+                .expr(Expr::col(unique_index_data_model::Column::ObjectDataKey).count())
+                .from(unique_index_data_model::Column::Table)
+                .and_where(
+                    query.and(Expr::col(unique_index_data_model::Column::IndexId).is(index.id)),
+                )
+                .build_rusqlite(SqliteQueryBuilder)
+        } else {
+            let query = range_to_query(&key_range, index_data_model::Column::Value);
+            sea_query::Query::select()
+                .expr(Expr::col(index_data_model::Column::Value).count())
+                .from(index_data_model::Column::Table)
+                .and_where(query.and(Expr::col(index_data_model::Column::IndexId).is(index.id)))
+                .build_rusqlite(SqliteQueryBuilder)
+        };
+        connection
+            .prepare(&sql)?
+            .query_row(&*values.as_params(), |row| row.get(0))
+            .map(|count: i64| count as usize)
+    }
+
+    fn generate_key(
+        connection: &Connection,
+        store: &object_store_model::Model,
+    ) -> Result<IndexedDBKeyType, Error> {
+        if store.auto_increment == 0 {
+            unreachable!("Should be caught in the script thread");
+        }
+        // TODO: handle overflows, this also needs to be able to handle 2^53 as per spec
+        let new_key = store.auto_increment + 1;
+        connection.execute(
+            "UPDATE object_store SET auto_increment = ? WHERE id = ?",
+            params![new_key, store.id],
+        )?;
+        Ok(IndexedDBKeyType::Number(new_key as f64))
     }
 }
 
@@ -459,6 +741,7 @@ impl KvsEngine for SqliteEngine {
                         callback,
                         key,
                         value,
+                        index_keys,
                         should_overwrite,
                         key_generator_current_number,
                     }) => {
@@ -497,6 +780,7 @@ impl KvsEngine for SqliteEngine {
                                 object_store,
                                 key,
                                 value,
+                                index_keys,
                                 should_overwrite,
                                 key_generator_current_number,
                             )
@@ -591,6 +875,77 @@ impl KvsEngine for SqliteEngine {
                                 .map_err(|e| BackendError::DbErr(format!("{:?}", e))),
                         );
                     },
+                    AsyncOperation::ReadOnly(AsyncReadOnlyOperation::IndexGetKey {
+                        callback,
+                        index_name,
+                        key_range,
+                    }) => {
+                        let _ = callback.send(
+                            Self::get_index_key(&connection, object_store, index_name, key_range)
+                                .map(|key| key.map(|k| postcard::from_bytes(&k).unwrap()))
+                                .map_err(|e| BackendError::DbErr(format!("{:?}", e))),
+                        );
+                    },
+                    AsyncOperation::ReadOnly(AsyncReadOnlyOperation::IndexGetItem {
+                        callback,
+                        index_name,
+                        key_range,
+                    }) => {
+                        let _ = callback.send(
+                            Self::get_index_item(&connection, object_store, index_name, key_range)
+                                .map_err(|e| BackendError::DbErr(format!("{:?}", e))),
+                        );
+                    },
+                    AsyncOperation::ReadOnly(AsyncReadOnlyOperation::IndexGetAllKeys {
+                        callback,
+                        index_name,
+                        key_range,
+                        count,
+                    }) => {
+                        let _ = callback.send(
+                            Self::index_get_all_keys(
+                                &connection,
+                                object_store,
+                                index_name,
+                                key_range,
+                                count,
+                            )
+                            .map(|keys| {
+                                keys.into_iter()
+                                    .map(|k| postcard::from_bytes(&k).unwrap())
+                                    .collect()
+                            })
+                            .map_err(|e| BackendError::DbErr(format!("{:?}", e))),
+                        );
+                    },
+                    AsyncOperation::ReadOnly(AsyncReadOnlyOperation::IndexGetAllItems {
+                        callback,
+                        index_name,
+                        key_range,
+                        count,
+                    }) => {
+                        let _ = callback.send(
+                            Self::index_get_all_items(
+                                &connection,
+                                object_store,
+                                index_name,
+                                key_range,
+                                count,
+                            )
+                            .map_err(|e| BackendError::DbErr(format!("{:?}", e))),
+                        );
+                    },
+                    AsyncOperation::ReadOnly(AsyncReadOnlyOperation::IndexCount {
+                        callback,
+                        index_name,
+                        key_range,
+                    }) => {
+                        let _ = callback.send(
+                            Self::index_count(&connection, object_store, index_name, key_range)
+                                .map(|r| r as u64)
+                                .map_err(|e| BackendError::DbErr(format!("{:?}", e))),
+                        );
+                    },
                 }
             }
             on_complete();
@@ -673,25 +1028,25 @@ impl KvsEngine for SqliteEngine {
         )?;
 
         let index_exists: bool = self.connection.query_row(
-            "SELECT EXISTS(SELECT * FROM object_store_index WHERE name = ? AND object_store_id = ?)",
-            params![index_name, object_store.id],
-            |row| row.get(0),
-        )?;
+                "SELECT EXISTS(SELECT * FROM object_store_index WHERE name = ? AND object_store_id = ?)",
+                params![index_name, object_store.id],
+                |row| row.get(0),
+            )?;
         if index_exists {
             return Ok(CreateObjectResult::AlreadyExists);
         }
 
         self.connection.execute(
-            "INSERT INTO object_store_index (object_store_id, name, key_path, unique_index, multi_entry_index)\
-            VALUES (?, ?, ?, ?, ?)",
-            params![
-                object_store.id,
-                index_name,
-                postcard::to_stdvec(&key_path).unwrap(),
-                unique,
-                multi_entry,
-            ],
-        )?;
+                "INSERT INTO object_store_index (object_store_id, name, key_path, unique_index, multi_entry_index)\
+                VALUES (?, ?, ?, ?, ?)",
+                params![
+                    object_store.id,
+                    index_name,
+                    postcard::to_stdvec(&key_path).unwrap(),
+                    unique,
+                    multi_entry,
+                ],
+            )?;
         Ok(CreateObjectResult::Created)
     }
 
@@ -1051,6 +1406,7 @@ mod tests {
                             callback: get_callback(put.0),
                             key: Some(IndexedDBKeyType::Number(1.0)),
                             value: vec![1, 2, 3],
+                            index_keys: vec![],
                             should_overwrite: false,
                             key_generator_current_number: None,
                         }),
@@ -1061,6 +1417,7 @@ mod tests {
                             callback: get_callback(put2.0),
                             key: Some(IndexedDBKeyType::String("2.0".to_string())),
                             value: vec![4, 5, 6],
+                            index_keys: vec![],
                             should_overwrite: false,
                             key_generator_current_number: None,
                         }),
@@ -1074,6 +1431,7 @@ mod tests {
                                 IndexedDBKeyType::Number(0.0),
                             ])),
                             value: vec![7, 8, 9],
+                            index_keys: vec![],
                             should_overwrite: false,
                             key_generator_current_number: None,
                         }),
@@ -1085,6 +1443,7 @@ mod tests {
                             callback: get_callback(put_dup.0),
                             key: Some(IndexedDBKeyType::Number(1.0)),
                             value: vec![10, 11, 12],
+                            index_keys: vec![],
                             should_overwrite: false,
                             key_generator_current_number: None,
                         }),

--- a/components/storage/indexeddb/engines/sqlite/index_data_model.rs
+++ b/components/storage/indexeddb/engines/sqlite/index_data_model.rs
@@ -6,18 +6,22 @@ use sea_query::Iden;
 
 #[derive(Clone, Copy, Iden)]
 pub enum Column {
-    #[iden = "object_data"]
+    #[iden = "index_data"]
     Table,
+    IndexId,
+    Value,
+    ObjectDataKey,
     ObjectStoreId,
-    Key,
-    Data,
+    ValueLocale,
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct Model {
-    pub object_store_id: i32,
-    pub key: Vec<u8>,
-    pub data: Vec<u8>,
+    pub index_id: i64,
+    pub value: Vec<u8>,
+    pub object_data_key: Vec<u8>,
+    pub object_store_id: i64,
+    pub value_locale: Vec<u8>,
 }
 
 impl TryFrom<&Row<'_>> for Model {
@@ -25,9 +29,11 @@ impl TryFrom<&Row<'_>> for Model {
 
     fn try_from(value: &Row) -> Result<Self, Self::Error> {
         Ok(Self {
-            object_store_id: value.get(0)?,
-            key: value.get(1)?,
-            data: value.get(2)?,
+            index_id: value.get(0)?,
+            value: value.get(1)?,
+            object_data_key: value.get(2)?,
+            object_store_id: value.get(3)?,
+            value_locale: value.get(4)?,
         })
     }
 }

--- a/components/storage/indexeddb/engines/sqlite/unique_index_data_model.rs
+++ b/components/storage/indexeddb/engines/sqlite/unique_index_data_model.rs
@@ -1,0 +1,16 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+use sea_query::Iden;
+
+#[derive(Clone, Copy, Iden)]
+pub enum Column {
+    #[iden = "unique_index_data"]
+    Table,
+    IndexId,
+    Value,
+    ObjectDataKey,
+    ObjectStoreId,
+    ValueLocale,
+}

--- a/tests/wpt/meta/IndexedDB/idbindex-multientry.any.js.ini
+++ b/tests/wpt/meta/IndexedDB/idbindex-multientry.any.js.ini
@@ -2,16 +2,18 @@
   expected: ERROR
 
 [idbindex-multientry.any.worker.html]
+  expected: TIMEOUT
   [A 1000 entry multiEntry array]
-    expected: FAIL
+    expected: TIMEOUT
 
   [Adding keys]
     expected: FAIL
 
 
 [idbindex-multientry.any.html]
+  expected: TIMEOUT
   [A 1000 entry multiEntry array]
-    expected: FAIL
+    expected: TIMEOUT
 
   [Adding keys]
     expected: FAIL

--- a/tests/wpt/meta/IndexedDB/idbindex-query-exception-order.any.js.ini
+++ b/tests/wpt/meta/IndexedDB/idbindex-query-exception-order.any.js.ini
@@ -5,12 +5,6 @@
   expected: ERROR
 
 [idbindex-query-exception-order.any.html]
-  [IDBIndex.get exception order: InvalidStateError vs. TransactionInactiveError]
-    expected: FAIL
-
-  [IDBIndex.get exception order: TransactionInactiveError vs. DataError]
-    expected: FAIL
-
   [IDBIndex.getAll exception order: InvalidStateError vs. TransactionInactiveError]
     expected: FAIL
 
@@ -21,12 +15,6 @@
     expected: FAIL
 
   [IDBIndex.getAllKeys exception order: TransactionInactiveError vs. DataError]
-    expected: FAIL
-
-  [IDBIndex.count exception order: InvalidStateError vs. TransactionInactiveError]
-    expected: FAIL
-
-  [IDBIndex.count exception order: TransactionInactiveError vs. DataError]
     expected: FAIL
 
   [IDBIndex.openCursor exception order: InvalidStateError vs. TransactionInactiveError]
@@ -43,12 +31,6 @@
 
 
 [idbindex-query-exception-order.any.worker.html]
-  [IDBIndex.get exception order: InvalidStateError vs. TransactionInactiveError]
-    expected: FAIL
-
-  [IDBIndex.get exception order: TransactionInactiveError vs. DataError]
-    expected: FAIL
-
   [IDBIndex.getAll exception order: InvalidStateError vs. TransactionInactiveError]
     expected: FAIL
 
@@ -59,12 +41,6 @@
     expected: FAIL
 
   [IDBIndex.getAllKeys exception order: TransactionInactiveError vs. DataError]
-    expected: FAIL
-
-  [IDBIndex.count exception order: InvalidStateError vs. TransactionInactiveError]
-    expected: FAIL
-
-  [IDBIndex.count exception order: TransactionInactiveError vs. DataError]
     expected: FAIL
 
   [IDBIndex.openCursor exception order: InvalidStateError vs. TransactionInactiveError]

--- a/tests/wpt/meta/IndexedDB/idbindex-request-source.any.js.ini
+++ b/tests/wpt/meta/IndexedDB/idbindex-request-source.any.js.ini
@@ -1,17 +1,8 @@
 [idbindex-request-source.any.html]
-  [The source of the request from index => index.get(0) is the index itself]
-    expected: FAIL
-
-  [The source of the request from index => index.getKey(0) is the index itself]
-    expected: FAIL
-
   [The source of the request from index => index.getAll() is the index itself]
     expected: FAIL
 
   [The source of the request from index => index.getAllKeys() is the index itself]
-    expected: FAIL
-
-  [The source of the request from index => index.count() is the index itself]
     expected: FAIL
 
   [The source of the request from index => index.openCursor() is the index itself]
@@ -22,19 +13,10 @@
 
 
 [idbindex-request-source.any.worker.html]
-  [The source of the request from index => index.get(0) is the index itself]
-    expected: FAIL
-
-  [The source of the request from index => index.getKey(0) is the index itself]
-    expected: FAIL
-
   [The source of the request from index => index.getAll() is the index itself]
     expected: FAIL
 
   [The source of the request from index => index.getAllKeys() is the index itself]
-    expected: FAIL
-
-  [The source of the request from index => index.count() is the index itself]
     expected: FAIL
 
   [The source of the request from index => index.openCursor() is the index itself]

--- a/tests/wpt/meta/IndexedDB/idbindex_count.any.js.ini
+++ b/tests/wpt/meta/IndexedDB/idbindex_count.any.js.ini
@@ -14,9 +14,6 @@
   [count() returns the number of records that have keys with the key]
     expected: FAIL
 
-  [count() throws DataError when using invalid key]
-    expected: FAIL
-
 
 [idbindex_count.any.html]
   [count() returns the number of records in the index]
@@ -26,7 +23,4 @@
     expected: FAIL
 
   [count() returns the number of records that have keys with the key]
-    expected: FAIL
-
-  [count() throws DataError when using invalid key]
     expected: FAIL

--- a/tests/wpt/meta/IndexedDB/idbindex_get.any.js.ini
+++ b/tests/wpt/meta/IndexedDB/idbindex_get.any.js.ini
@@ -5,19 +5,7 @@
   [get() returns the record where the index contains duplicate values]
     expected: FAIL
 
-  [get() attempts to retrieve a record that does not exist]
-    expected: FAIL
-
   [get() returns the record with the first key in the range]
-    expected: FAIL
-
-  [get() throws DataError when using invalid key]
-    expected: FAIL
-
-  [get() throws InvalidStateError when the index is deleted]
-    expected: FAIL
-
-  [get() throws TransactionInactiveError on aborted transaction]
     expected: FAIL
 
   [get() throws InvalidStateError on index deleted by aborted upgrade]
@@ -31,19 +19,7 @@
   [get() returns the record where the index contains duplicate values]
     expected: FAIL
 
-  [get() attempts to retrieve a record that does not exist]
-    expected: FAIL
-
   [get() returns the record with the first key in the range]
-    expected: FAIL
-
-  [get() throws DataError when using invalid key]
-    expected: FAIL
-
-  [get() throws InvalidStateError when the index is deleted]
-    expected: FAIL
-
-  [get() throws TransactionInactiveError on aborted transaction]
     expected: FAIL
 
   [get() throws InvalidStateError on index deleted by aborted upgrade]

--- a/tests/wpt/meta/IndexedDB/idbindex_getKey.any.js.ini
+++ b/tests/wpt/meta/IndexedDB/idbindex_getKey.any.js.ini
@@ -8,19 +8,7 @@
   [getKey() returns the record's primary key where the index contains duplicate values]
     expected: FAIL
 
-  [getKey() attempt to retrieve the primary key of a record that doesn't exist]
-    expected: FAIL
-
   [getKey() returns the key of the first record within the range]
-    expected: FAIL
-
-  [getKey() throws DataError when using invalid key]
-    expected: FAIL
-
-  [getKey() throws InvalidStateError when the index is deleted]
-    expected: FAIL
-
-  [getKey() throws TransactionInactiveError on aborted transaction]
     expected: FAIL
 
   [getKey() throws InvalidStateError on index deleted by aborted upgrade]
@@ -37,19 +25,7 @@
   [getKey() returns the record's primary key where the index contains duplicate values]
     expected: FAIL
 
-  [getKey() attempt to retrieve the primary key of a record that doesn't exist]
-    expected: FAIL
-
   [getKey() returns the key of the first record within the range]
-    expected: FAIL
-
-  [getKey() throws DataError when using invalid key]
-    expected: FAIL
-
-  [getKey() throws InvalidStateError when the index is deleted]
-    expected: FAIL
-
-  [getKey() throws TransactionInactiveError on aborted transaction]
     expected: FAIL
 
   [getKey() throws InvalidStateError on index deleted by aborted upgrade]

--- a/tests/wpt/meta/IndexedDB/idlharness.any.js.ini
+++ b/tests/wpt/meta/IndexedDB/idlharness.any.js.ini
@@ -5,19 +5,10 @@
   [IDBIndex interface: attribute name]
     expected: FAIL
 
-  [IDBIndex interface: operation get(any)]
-    expected: FAIL
-
-  [IDBIndex interface: operation getKey(any)]
-    expected: FAIL
-
   [IDBIndex interface: operation getAll(optional any, optional unsigned long)]
     expected: FAIL
 
   [IDBIndex interface: operation getAllKeys(optional any, optional unsigned long)]
-    expected: FAIL
-
-  [IDBIndex interface: operation count(optional any)]
     expected: FAIL
 
   [IDBIndex interface: operation openCursor(optional any, optional IDBCursorDirection)]
@@ -82,19 +73,10 @@
   [IDBIndex interface: attribute name]
     expected: FAIL
 
-  [IDBIndex interface: operation get(any)]
-    expected: FAIL
-
-  [IDBIndex interface: operation getKey(any)]
-    expected: FAIL
-
   [IDBIndex interface: operation getAll(optional any, optional unsigned long)]
     expected: FAIL
 
   [IDBIndex interface: operation getAllKeys(optional any, optional unsigned long)]
-    expected: FAIL
-
-  [IDBIndex interface: operation count(optional any)]
     expected: FAIL
 
   [IDBIndex interface: operation openCursor(optional any, optional IDBCursorDirection)]

--- a/tests/wpt/meta/IndexedDB/key-conversion-exceptions.any.js.ini
+++ b/tests/wpt/meta/IndexedDB/key-conversion-exceptions.any.js.ini
@@ -5,15 +5,6 @@
   [IndexedDB: Exceptions thrown during key conversion]
     expected: FAIL
 
-  [IDBIndex get() method with throwing/invalid keys]
-    expected: FAIL
-
-  [IDBIndex getKey() method with throwing/invalid keys]
-    expected: FAIL
-
-  [IDBIndex count() method with throwing/invalid keys]
-    expected: FAIL
-
   [IDBIndex openCursor() method with throwing/invalid keys]
     expected: FAIL
 
@@ -29,15 +20,6 @@
 
 [key-conversion-exceptions.any.html]
   [IndexedDB: Exceptions thrown during key conversion]
-    expected: FAIL
-
-  [IDBIndex get() method with throwing/invalid keys]
-    expected: FAIL
-
-  [IDBIndex getKey() method with throwing/invalid keys]
-    expected: FAIL
-
-  [IDBIndex count() method with throwing/invalid keys]
     expected: FAIL
 
   [IDBIndex openCursor() method with throwing/invalid keys]


### PR DESCRIPTION
Updates indices in the course of regular object store operations. Also allows for querying of indices.

Followups:

- https://www.w3.org/TR/IndexedDB/#store-a-record-into-an-object-store has a few missing pieces
- Handling of index population if there are pre-existing items in the database. We would likely need coordination with the script thread in order to deserialize the stored values and extract the key paths. It would be nice if we could manage values without having to rely on the script thread.
- Proper multi-entry key conversion
- Store index id on frontend to avoid name change issues and to reduce nessicary DB queries for index operations.

Testing: More WPT tests
Fixes: Partially #38100 
