### PR TITLE
Script: Use `&mut JSContext` in `BroadcastChannel::PostMessage`

### DIFF
--- a/components/script/dom/broadcastchannel.rs
+++ b/components/script/dom/broadcastchannel.rs
@@ -18,7 +18,7 @@ use crate::dom::bindings::str::DOMString;
 use crate::dom::bindings::structuredclone;
 use crate::dom::eventtarget::EventTarget;
 use crate::dom::globalscope::GlobalScope;
-use crate::script_runtime::{CanGc};
+use crate::script_runtime::CanGc;
 
 #[dom_struct]
 pub(crate) struct BroadcastChannel {

--- a/components/script/dom/broadcastchannel.rs
+++ b/components/script/dom/broadcastchannel.rs
@@ -6,6 +6,7 @@ use std::cell::Cell;
 
 use constellation_traits::BroadcastChannelMsg;
 use dom_struct::dom_struct;
+use js::context::JSContext;
 use js::rust::{HandleObject, HandleValue};
 use uuid::Uuid;
 
@@ -17,7 +18,7 @@ use crate::dom::bindings::str::DOMString;
 use crate::dom::bindings::structuredclone;
 use crate::dom::eventtarget::EventTarget;
 use crate::dom::globalscope::GlobalScope;
-use crate::script_runtime::{CanGc, JSContext as SafeJSContext};
+use crate::script_runtime::{CanGc};
 
 #[dom_struct]
 pub(crate) struct BroadcastChannel {
@@ -78,14 +79,14 @@ impl BroadcastChannelMethods<crate::DomTypeHolder> for BroadcastChannel {
     }
 
     /// <https://html.spec.whatwg.org/multipage/#dom-messageport-postmessage>
-    fn PostMessage(&self, cx: SafeJSContext, message: HandleValue) -> ErrorResult {
+    fn PostMessage(&self, cx: &mut JSContext, message: HandleValue) -> ErrorResult {
         // Step 3, if closed.
         if self.closed.get() {
             return Err(Error::InvalidState(None));
         }
 
         // Step 6, StructuredSerialize(message).
-        let data = structuredclone::write(cx, message, None)?;
+        let data = structuredclone::write(cx.into(), message, None)?;
 
         let global = self.global();
 

--- a/components/script_bindings/codegen/Bindings.conf
+++ b/components/script_bindings/codegen/Bindings.conf
@@ -82,6 +82,10 @@ DOMInterfaces = {
     'canGc': ['GetCharacteristic', 'GetCharacteristics', 'GetIncludedService', 'GetIncludedServices'],
 },
 
+'BroadcastChannel': {
+    'cx': ['PostMessage'],
+},
+
 'ByteLengthQueuingStrategy': {
     'canGc': ['GetSize'],
 },


### PR DESCRIPTION
Replace `crate::script_runtime::JSContext` with `js::context::JSContext` in `BroadcastChannel::PostMessage` and update interface binding.

Testing: Builds and runs locally.
Part of: https://github.com/servo/servo/issues/42347