### PR TITLE
tests: fix incorrect dead_code lint expectations

### DIFF
--- a/components/servo/tests/common/mod.rs
+++ b/components/servo/tests/common/mod.rs
@@ -26,7 +26,6 @@ impl ServoTest {
     pub(crate) fn new() -> Self {
         Self::new_with_builder(|builder| builder)
     }
-
     pub(crate) fn new_with_builder<F>(customize: F) -> Self
     where
         F: FnOnce(ServoBuilder) -> ServoBuilder,

--- a/components/servo/tests/multiprocess.rs
+++ b/components/servo/tests/multiprocess.rs
@@ -9,7 +9,7 @@
 //! of `assert!` for test assertions. `ensure!` will produce a `Result::Err` in
 //! place of panicking.
 
-#[expect(dead_code)]
+#[allow(dead_code)]
 mod common;
 
 use std::rc::Rc;

--- a/components/servo/tests/servo.rs
+++ b/components/servo/tests/servo.rs
@@ -9,7 +9,6 @@
 //! of `assert!` for test assertions. `ensure!` will produce a `Result::Err` in
 //! place of panicking.
 
-#[expect(dead_code)]
 mod common;
 
 use common::ServoTest;


### PR DESCRIPTION
I accidentally worked on #42420 while working on #42412. This PR contains the changes for #42420 only. Please assign me to this issue if possible.