### PR TITLE
mach: use --no-verify for mach try push command

### DIFF
--- a/python/servo/testing_commands.py
+++ b/python/servo/testing_commands.py
@@ -869,7 +869,7 @@ class MachCommands(CommandBase):
 
         # From here on out, we need to always clean up the commit we added to the branch.
         try:
-            result = call(["git", "push", "--quiet", remote, "--force", "HEAD:try"])
+            result = call(["git", "push", "--no-verify", "--quiet", remote, "--force", "HEAD:try"])
             if result != 0:
                 return result
 


### PR DESCRIPTION
Skip push hooks for try command. This speeds up try for me, which normally means waiting for clippy a second time. The commit step is already using `--no-verify`.

Testing: tested this change locally and it works

