### PR TITLE
wpt: Unskip most `css-inline` tests

### DIFF
--- a/tests/wpt/include.ini
+++ b/tests/wpt/include.ini
@@ -62,9 +62,11 @@ skip: true
   [css-highlight-api]
     skip: true
   [css-inline]
-    skip: true
-    [baseline-source]
-      skip: false
+    skip: false
+    [initial-letter]
+      skip: true
+    [text-box-trim]
+      skip: true
   [css-layout-api]
     skip: true
   [css-masking]

--- a/tests/wpt/meta/css/css-inline/animation/alignment-baseline-no-interpolation.html.ini
+++ b/tests/wpt/meta/css/css-inline/animation/alignment-baseline-no-interpolation.html.ini
@@ -1,0 +1,126 @@
+[alignment-baseline-no-interpolation.html]
+  [CSS Transitions with transition-behavior:allow-discrete: property <alignment-baseline> from [initial\] to [central\] at (-0.3) should be [initial\]]
+    expected: FAIL
+
+  [CSS Transitions with transition-behavior:allow-discrete: property <alignment-baseline> from [initial\] to [central\] at (0) should be [initial\]]
+    expected: FAIL
+
+  [CSS Transitions with transition-behavior:allow-discrete: property <alignment-baseline> from [initial\] to [central\] at (0.3) should be [initial\]]
+    expected: FAIL
+
+  [CSS Transitions with transition-behavior:allow-discrete: property <alignment-baseline> from [initial\] to [central\] at (0.5) should be [central\]]
+    expected: FAIL
+
+  [CSS Transitions with transition-behavior:allow-discrete: property <alignment-baseline> from [initial\] to [central\] at (0.6) should be [central\]]
+    expected: FAIL
+
+  [CSS Transitions with transition-behavior:allow-discrete: property <alignment-baseline> from [initial\] to [central\] at (1) should be [central\]]
+    expected: FAIL
+
+  [CSS Transitions with transition-behavior:allow-discrete: property <alignment-baseline> from [initial\] to [central\] at (1.5) should be [central\]]
+    expected: FAIL
+
+  [CSS Transitions with transition-property:all and transition-behavor:allow-discrete: property <alignment-baseline> from [initial\] to [central\] at (-0.3) should be [initial\]]
+    expected: FAIL
+
+  [CSS Transitions with transition-property:all and transition-behavor:allow-discrete: property <alignment-baseline> from [initial\] to [central\] at (0) should be [initial\]]
+    expected: FAIL
+
+  [CSS Transitions with transition-property:all and transition-behavor:allow-discrete: property <alignment-baseline> from [initial\] to [central\] at (0.3) should be [initial\]]
+    expected: FAIL
+
+  [CSS Transitions with transition-property:all and transition-behavor:allow-discrete: property <alignment-baseline> from [initial\] to [central\] at (0.5) should be [central\]]
+    expected: FAIL
+
+  [CSS Transitions with transition-property:all and transition-behavor:allow-discrete: property <alignment-baseline> from [initial\] to [central\] at (0.6) should be [central\]]
+    expected: FAIL
+
+  [CSS Transitions with transition-property:all and transition-behavor:allow-discrete: property <alignment-baseline> from [initial\] to [central\] at (1) should be [central\]]
+    expected: FAIL
+
+  [CSS Transitions with transition-property:all and transition-behavor:allow-discrete: property <alignment-baseline> from [initial\] to [central\] at (1.5) should be [central\]]
+    expected: FAIL
+
+  [CSS Transitions: property <alignment-baseline> from [initial\] to [central\] at (-0.3) should be [central\]]
+    expected: FAIL
+
+  [CSS Transitions: property <alignment-baseline> from [initial\] to [central\] at (0) should be [central\]]
+    expected: FAIL
+
+  [CSS Transitions: property <alignment-baseline> from [initial\] to [central\] at (0.3) should be [central\]]
+    expected: FAIL
+
+  [CSS Transitions: property <alignment-baseline> from [initial\] to [central\] at (0.5) should be [central\]]
+    expected: FAIL
+
+  [CSS Transitions: property <alignment-baseline> from [initial\] to [central\] at (0.6) should be [central\]]
+    expected: FAIL
+
+  [CSS Transitions: property <alignment-baseline> from [initial\] to [central\] at (1) should be [central\]]
+    expected: FAIL
+
+  [CSS Transitions: property <alignment-baseline> from [initial\] to [central\] at (1.5) should be [central\]]
+    expected: FAIL
+
+  [CSS Transitions with transition: all: property <alignment-baseline> from [initial\] to [central\] at (-0.3) should be [central\]]
+    expected: FAIL
+
+  [CSS Transitions with transition: all: property <alignment-baseline> from [initial\] to [central\] at (0) should be [central\]]
+    expected: FAIL
+
+  [CSS Transitions with transition: all: property <alignment-baseline> from [initial\] to [central\] at (0.3) should be [central\]]
+    expected: FAIL
+
+  [CSS Transitions with transition: all: property <alignment-baseline> from [initial\] to [central\] at (0.5) should be [central\]]
+    expected: FAIL
+
+  [CSS Transitions with transition: all: property <alignment-baseline> from [initial\] to [central\] at (0.6) should be [central\]]
+    expected: FAIL
+
+  [CSS Transitions with transition: all: property <alignment-baseline> from [initial\] to [central\] at (1) should be [central\]]
+    expected: FAIL
+
+  [CSS Transitions with transition: all: property <alignment-baseline> from [initial\] to [central\] at (1.5) should be [central\]]
+    expected: FAIL
+
+  [CSS Animations: property <alignment-baseline> from [initial\] to [central\] at (-0.3) should be [initial\]]
+    expected: FAIL
+
+  [CSS Animations: property <alignment-baseline> from [initial\] to [central\] at (0) should be [initial\]]
+    expected: FAIL
+
+  [CSS Animations: property <alignment-baseline> from [initial\] to [central\] at (0.3) should be [initial\]]
+    expected: FAIL
+
+  [CSS Animations: property <alignment-baseline> from [initial\] to [central\] at (0.5) should be [central\]]
+    expected: FAIL
+
+  [CSS Animations: property <alignment-baseline> from [initial\] to [central\] at (0.6) should be [central\]]
+    expected: FAIL
+
+  [CSS Animations: property <alignment-baseline> from [initial\] to [central\] at (1) should be [central\]]
+    expected: FAIL
+
+  [CSS Animations: property <alignment-baseline> from [initial\] to [central\] at (1.5) should be [central\]]
+    expected: FAIL
+
+  [Web Animations: property <alignment-baseline> from [initial\] to [central\] at (-0.3) should be [initial\]]
+    expected: FAIL
+
+  [Web Animations: property <alignment-baseline> from [initial\] to [central\] at (0) should be [initial\]]
+    expected: FAIL
+
+  [Web Animations: property <alignment-baseline> from [initial\] to [central\] at (0.3) should be [initial\]]
+    expected: FAIL
+
+  [Web Animations: property <alignment-baseline> from [initial\] to [central\] at (0.5) should be [central\]]
+    expected: FAIL
+
+  [Web Animations: property <alignment-baseline> from [initial\] to [central\] at (0.6) should be [central\]]
+    expected: FAIL
+
+  [Web Animations: property <alignment-baseline> from [initial\] to [central\] at (1) should be [central\]]
+    expected: FAIL
+
+  [Web Animations: property <alignment-baseline> from [initial\] to [central\] at (1.5) should be [central\]]
+    expected: FAIL

--- a/tests/wpt/meta/css/css-inline/animation/baseline-shift-composition.html.ini
+++ b/tests/wpt/meta/css/css-inline/animation/baseline-shift-composition.html.ini
@@ -1,0 +1,90 @@
+[baseline-shift-composition.html]
+  [Compositing CSS Animations: property <baseline-shift> underlying [50px\] from add [100px\] to add [200px\] at (-0.3) should be [120px\]]
+    expected: FAIL
+
+  [Compositing CSS Animations: property <baseline-shift> underlying [50px\] from add [100px\] to add [200px\] at (0) should be [150px\]]
+    expected: FAIL
+
+  [Compositing CSS Animations: property <baseline-shift> underlying [50px\] from add [100px\] to add [200px\] at (0.5) should be [200px\]]
+    expected: FAIL
+
+  [Compositing CSS Animations: property <baseline-shift> underlying [50px\] from add [100px\] to add [200px\] at (1) should be [250px\]]
+    expected: FAIL
+
+  [Compositing CSS Animations: property <baseline-shift> underlying [50px\] from add [100px\] to add [200px\] at (1.5) should be [300px\]]
+    expected: FAIL
+
+  [Compositing Web Animations: property <baseline-shift> underlying [50px\] from add [100px\] to add [200px\] at (-0.3) should be [120px\]]
+    expected: FAIL
+
+  [Compositing Web Animations: property <baseline-shift> underlying [50px\] from add [100px\] to add [200px\] at (0) should be [150px\]]
+    expected: FAIL
+
+  [Compositing Web Animations: property <baseline-shift> underlying [50px\] from add [100px\] to add [200px\] at (0.5) should be [200px\]]
+    expected: FAIL
+
+  [Compositing Web Animations: property <baseline-shift> underlying [50px\] from add [100px\] to add [200px\] at (1) should be [250px\]]
+    expected: FAIL
+
+  [Compositing Web Animations: property <baseline-shift> underlying [50px\] from add [100px\] to add [200px\] at (1.5) should be [300px\]]
+    expected: FAIL
+
+  [Compositing CSS Animations: property <baseline-shift> underlying [100px\] from add [10px\] to add [2px\] at (-0.5) should be [114px\]]
+    expected: FAIL
+
+  [Compositing CSS Animations: property <baseline-shift> underlying [100px\] from add [10px\] to add [2px\] at (0) should be [110px\]]
+    expected: FAIL
+
+  [Compositing CSS Animations: property <baseline-shift> underlying [100px\] from add [10px\] to add [2px\] at (0.5) should be [106px\]]
+    expected: FAIL
+
+  [Compositing CSS Animations: property <baseline-shift> underlying [100px\] from add [10px\] to add [2px\] at (1) should be [102px\]]
+    expected: FAIL
+
+  [Compositing CSS Animations: property <baseline-shift> underlying [100px\] from add [10px\] to add [2px\] at (1.5) should be [98px\]]
+    expected: FAIL
+
+  [Compositing Web Animations: property <baseline-shift> underlying [100px\] from add [10px\] to add [2px\] at (-0.5) should be [114px\]]
+    expected: FAIL
+
+  [Compositing Web Animations: property <baseline-shift> underlying [100px\] from add [10px\] to add [2px\] at (0) should be [110px\]]
+    expected: FAIL
+
+  [Compositing Web Animations: property <baseline-shift> underlying [100px\] from add [10px\] to add [2px\] at (0.5) should be [106px\]]
+    expected: FAIL
+
+  [Compositing Web Animations: property <baseline-shift> underlying [100px\] from add [10px\] to add [2px\] at (1) should be [102px\]]
+    expected: FAIL
+
+  [Compositing Web Animations: property <baseline-shift> underlying [100px\] from add [10px\] to add [2px\] at (1.5) should be [98px\]]
+    expected: FAIL
+
+  [Compositing CSS Animations: property <baseline-shift> underlying [50px\] from add [100px\] to replace [200px\] at (-0.3) should be [135px\]]
+    expected: FAIL
+
+  [Compositing CSS Animations: property <baseline-shift> underlying [50px\] from add [100px\] to replace [200px\] at (0) should be [150px\]]
+    expected: FAIL
+
+  [Compositing CSS Animations: property <baseline-shift> underlying [50px\] from add [100px\] to replace [200px\] at (0.5) should be [175px\]]
+    expected: FAIL
+
+  [Compositing CSS Animations: property <baseline-shift> underlying [50px\] from add [100px\] to replace [200px\] at (1) should be [200px\]]
+    expected: FAIL
+
+  [Compositing CSS Animations: property <baseline-shift> underlying [50px\] from add [100px\] to replace [200px\] at (1.5) should be [225px\]]
+    expected: FAIL
+
+  [Compositing Web Animations: property <baseline-shift> underlying [50px\] from add [100px\] to replace [200px\] at (-0.3) should be [135px\]]
+    expected: FAIL
+
+  [Compositing Web Animations: property <baseline-shift> underlying [50px\] from add [100px\] to replace [200px\] at (0) should be [150px\]]
+    expected: FAIL
+
+  [Compositing Web Animations: property <baseline-shift> underlying [50px\] from add [100px\] to replace [200px\] at (0.5) should be [175px\]]
+    expected: FAIL
+
+  [Compositing Web Animations: property <baseline-shift> underlying [50px\] from add [100px\] to replace [200px\] at (1) should be [200px\]]
+    expected: FAIL
+
+  [Compositing Web Animations: property <baseline-shift> underlying [50px\] from add [100px\] to replace [200px\] at (1.5) should be [225px\]]
+    expected: FAIL

--- a/tests/wpt/meta/css/css-inline/animation/dominant-baseline-no-interpolation.html.ini
+++ b/tests/wpt/meta/css/css-inline/animation/dominant-baseline-no-interpolation.html.ini
@@ -1,0 +1,126 @@
+[dominant-baseline-no-interpolation.html]
+  [CSS Transitions with transition-behavior:allow-discrete: property <dominant-baseline> from [initial\] to [middle\] at (-0.3) should be [initial\]]
+    expected: FAIL
+
+  [CSS Transitions with transition-behavior:allow-discrete: property <dominant-baseline> from [initial\] to [middle\] at (0) should be [initial\]]
+    expected: FAIL
+
+  [CSS Transitions with transition-behavior:allow-discrete: property <dominant-baseline> from [initial\] to [middle\] at (0.3) should be [initial\]]
+    expected: FAIL
+
+  [CSS Transitions with transition-behavior:allow-discrete: property <dominant-baseline> from [initial\] to [middle\] at (0.5) should be [middle\]]
+    expected: FAIL
+
+  [CSS Transitions with transition-behavior:allow-discrete: property <dominant-baseline> from [initial\] to [middle\] at (0.6) should be [middle\]]
+    expected: FAIL
+
+  [CSS Transitions with transition-behavior:allow-discrete: property <dominant-baseline> from [initial\] to [middle\] at (1) should be [middle\]]
+    expected: FAIL
+
+  [CSS Transitions with transition-behavior:allow-discrete: property <dominant-baseline> from [initial\] to [middle\] at (1.5) should be [middle\]]
+    expected: FAIL
+
+  [CSS Transitions with transition-property:all and transition-behavor:allow-discrete: property <dominant-baseline> from [initial\] to [middle\] at (-0.3) should be [initial\]]
+    expected: FAIL
+
+  [CSS Transitions with transition-property:all and transition-behavor:allow-discrete: property <dominant-baseline> from [initial\] to [middle\] at (0) should be [initial\]]
+    expected: FAIL
+
+  [CSS Transitions with transition-property:all and transition-behavor:allow-discrete: property <dominant-baseline> from [initial\] to [middle\] at (0.3) should be [initial\]]
+    expected: FAIL
+
+  [CSS Transitions with transition-property:all and transition-behavor:allow-discrete: property <dominant-baseline> from [initial\] to [middle\] at (0.5) should be [middle\]]
+    expected: FAIL
+
+  [CSS Transitions with transition-property:all and transition-behavor:allow-discrete: property <dominant-baseline> from [initial\] to [middle\] at (0.6) should be [middle\]]
+    expected: FAIL
+
+  [CSS Transitions with transition-property:all and transition-behavor:allow-discrete: property <dominant-baseline> from [initial\] to [middle\] at (1) should be [middle\]]
+    expected: FAIL
+
+  [CSS Transitions with transition-property:all and transition-behavor:allow-discrete: property <dominant-baseline> from [initial\] to [middle\] at (1.5) should be [middle\]]
+    expected: FAIL
+
+  [CSS Transitions: property <dominant-baseline> from [initial\] to [middle\] at (-0.3) should be [middle\]]
+    expected: FAIL
+
+  [CSS Transitions: property <dominant-baseline> from [initial\] to [middle\] at (0) should be [middle\]]
+    expected: FAIL
+
+  [CSS Transitions: property <dominant-baseline> from [initial\] to [middle\] at (0.3) should be [middle\]]
+    expected: FAIL
+
+  [CSS Transitions: property <dominant-baseline> from [initial\] to [middle\] at (0.5) should be [middle\]]
+    expected: FAIL
+
+  [CSS Transitions: property <dominant-baseline> from [initial\] to [middle\] at (0.6) should be [middle\]]
+    expected: FAIL
+
+  [CSS Transitions: property <dominant-baseline> from [initial\] to [middle\] at (1) should be [middle\]]
+    expected: FAIL
+
+  [CSS Transitions: property <dominant-baseline> from [initial\] to [middle\] at (1.5) should be [middle\]]
+    expected: FAIL
+
+  [CSS Transitions with transition: all: property <dominant-baseline> from [initial\] to [middle\] at (-0.3) should be [middle\]]
+    expected: FAIL
+
+  [CSS Transitions with transition: all: property <dominant-baseline> from [initial\] to [middle\] at (0) should be [middle\]]
+    expected: FAIL
+
+  [CSS Transitions with transition: all: property <dominant-baseline> from [initial\] to [middle\] at (0.3) should be [middle\]]
+    expected: FAIL
+
+  [CSS Transitions with transition: all: property <dominant-baseline> from [initial\] to [middle\] at (0.5) should be [middle\]]
+    expected: FAIL
+
+  [CSS Transitions with transition: all: property <dominant-baseline> from [initial\] to [middle\] at (0.6) should be [middle\]]
+    expected: FAIL
+
+  [CSS Transitions with transition: all: property <dominant-baseline> from [initial\] to [middle\] at (1) should be [middle\]]
+    expected: FAIL
+
+  [CSS Transitions with transition: all: property <dominant-baseline> from [initial\] to [middle\] at (1.5) should be [middle\]]
+    expected: FAIL
+
+  [CSS Animations: property <dominant-baseline> from [initial\] to [middle\] at (-0.3) should be [initial\]]
+    expected: FAIL
+
+  [CSS Animations: property <dominant-baseline> from [initial\] to [middle\] at (0) should be [initial\]]
+    expected: FAIL
+
+  [CSS Animations: property <dominant-baseline> from [initial\] to [middle\] at (0.3) should be [initial\]]
+    expected: FAIL
+
+  [CSS Animations: property <dominant-baseline> from [initial\] to [middle\] at (0.5) should be [middle\]]
+    expected: FAIL
+
+  [CSS Animations: property <dominant-baseline> from [initial\] to [middle\] at (0.6) should be [middle\]]
+    expected: FAIL
+
+  [CSS Animations: property <dominant-baseline> from [initial\] to [middle\] at (1) should be [middle\]]
+    expected: FAIL
+
+  [CSS Animations: property <dominant-baseline> from [initial\] to [middle\] at (1.5) should be [middle\]]
+    expected: FAIL
+
+  [Web Animations: property <dominant-baseline> from [initial\] to [middle\] at (-0.3) should be [initial\]]
+    expected: FAIL
+
+  [Web Animations: property <dominant-baseline> from [initial\] to [middle\] at (0) should be [initial\]]
+    expected: FAIL
+
+  [Web Animations: property <dominant-baseline> from [initial\] to [middle\] at (0.3) should be [initial\]]
+    expected: FAIL
+
+  [Web Animations: property <dominant-baseline> from [initial\] to [middle\] at (0.5) should be [middle\]]
+    expected: FAIL
+
+  [Web Animations: property <dominant-baseline> from [initial\] to [middle\] at (0.6) should be [middle\]]
+    expected: FAIL
+
+  [Web Animations: property <dominant-baseline> from [initial\] to [middle\] at (1) should be [middle\]]
+    expected: FAIL
+
+  [Web Animations: property <dominant-baseline> from [initial\] to [middle\] at (1.5) should be [middle\]]
+    expected: FAIL

--- a/tests/wpt/meta/css/css-inline/animation/initial-letter-no-interpolation.html.ini
+++ b/tests/wpt/meta/css/css-inline/animation/initial-letter-no-interpolation.html.ini
@@ -1,0 +1,126 @@
+[initial-letter-no-interpolation.html]
+  [CSS Transitions with transition-behavior:allow-discrete: property <initial-letter> from [initial\] to [123\] at (-0.3) should be [initial\]]
+    expected: FAIL
+
+  [CSS Transitions with transition-behavior:allow-discrete: property <initial-letter> from [initial\] to [123\] at (0) should be [initial\]]
+    expected: FAIL
+
+  [CSS Transitions with transition-behavior:allow-discrete: property <initial-letter> from [initial\] to [123\] at (0.3) should be [initial\]]
+    expected: FAIL
+
+  [CSS Transitions with transition-behavior:allow-discrete: property <initial-letter> from [initial\] to [123\] at (0.5) should be [123\]]
+    expected: FAIL
+
+  [CSS Transitions with transition-behavior:allow-discrete: property <initial-letter> from [initial\] to [123\] at (0.6) should be [123\]]
+    expected: FAIL
+
+  [CSS Transitions with transition-behavior:allow-discrete: property <initial-letter> from [initial\] to [123\] at (1) should be [123\]]
+    expected: FAIL
+
+  [CSS Transitions with transition-behavior:allow-discrete: property <initial-letter> from [initial\] to [123\] at (1.5) should be [123\]]
+    expected: FAIL
+
+  [CSS Transitions with transition-property:all and transition-behavor:allow-discrete: property <initial-letter> from [initial\] to [123\] at (-0.3) should be [initial\]]
+    expected: FAIL
+
+  [CSS Transitions with transition-property:all and transition-behavor:allow-discrete: property <initial-letter> from [initial\] to [123\] at (0) should be [initial\]]
+    expected: FAIL
+
+  [CSS Transitions with transition-property:all and transition-behavor:allow-discrete: property <initial-letter> from [initial\] to [123\] at (0.3) should be [initial\]]
+    expected: FAIL
+
+  [CSS Transitions with transition-property:all and transition-behavor:allow-discrete: property <initial-letter> from [initial\] to [123\] at (0.5) should be [123\]]
+    expected: FAIL
+
+  [CSS Transitions with transition-property:all and transition-behavor:allow-discrete: property <initial-letter> from [initial\] to [123\] at (0.6) should be [123\]]
+    expected: FAIL
+
+  [CSS Transitions with transition-property:all and transition-behavor:allow-discrete: property <initial-letter> from [initial\] to [123\] at (1) should be [123\]]
+    expected: FAIL
+
+  [CSS Transitions with transition-property:all and transition-behavor:allow-discrete: property <initial-letter> from [initial\] to [123\] at (1.5) should be [123\]]
+    expected: FAIL
+
+  [CSS Transitions: property <initial-letter> from [initial\] to [123\] at (-0.3) should be [123\]]
+    expected: FAIL
+
+  [CSS Transitions: property <initial-letter> from [initial\] to [123\] at (0) should be [123\]]
+    expected: FAIL
+
+  [CSS Transitions: property <initial-letter> from [initial\] to [123\] at (0.3) should be [123\]]
+    expected: FAIL
+
+  [CSS Transitions: property <initial-letter> from [initial\] to [123\] at (0.5) should be [123\]]
+    expected: FAIL
+
+  [CSS Transitions: property <initial-letter> from [initial\] to [123\] at (0.6) should be [123\]]
+    expected: FAIL
+
+  [CSS Transitions: property <initial-letter> from [initial\] to [123\] at (1) should be [123\]]
+    expected: FAIL
+
+  [CSS Transitions: property <initial-letter> from [initial\] to [123\] at (1.5) should be [123\]]
+    expected: FAIL
+
+  [CSS Transitions with transition: all: property <initial-letter> from [initial\] to [123\] at (-0.3) should be [123\]]
+    expected: FAIL
+
+  [CSS Transitions with transition: all: property <initial-letter> from [initial\] to [123\] at (0) should be [123\]]
+    expected: FAIL
+
+  [CSS Transitions with transition: all: property <initial-letter> from [initial\] to [123\] at (0.3) should be [123\]]
+    expected: FAIL
+
+  [CSS Transitions with transition: all: property <initial-letter> from [initial\] to [123\] at (0.5) should be [123\]]
+    expected: FAIL
+
+  [CSS Transitions with transition: all: property <initial-letter> from [initial\] to [123\] at (0.6) should be [123\]]
+    expected: FAIL
+
+  [CSS Transitions with transition: all: property <initial-letter> from [initial\] to [123\] at (1) should be [123\]]
+    expected: FAIL
+
+  [CSS Transitions with transition: all: property <initial-letter> from [initial\] to [123\] at (1.5) should be [123\]]
+    expected: FAIL
+
+  [CSS Animations: property <initial-letter> from [initial\] to [123\] at (-0.3) should be [initial\]]
+    expected: FAIL
+
+  [CSS Animations: property <initial-letter> from [initial\] to [123\] at (0) should be [initial\]]
+    expected: FAIL
+
+  [CSS Animations: property <initial-letter> from [initial\] to [123\] at (0.3) should be [initial\]]
+    expected: FAIL
+
+  [CSS Animations: property <initial-letter> from [initial\] to [123\] at (0.5) should be [123\]]
+    expected: FAIL
+
+  [CSS Animations: property <initial-letter> from [initial\] to [123\] at (0.6) should be [123\]]
+    expected: FAIL
+
+  [CSS Animations: property <initial-letter> from [initial\] to [123\] at (1) should be [123\]]
+    expected: FAIL
+
+  [CSS Animations: property <initial-letter> from [initial\] to [123\] at (1.5) should be [123\]]
+    expected: FAIL
+
+  [Web Animations: property <initial-letter> from [initial\] to [123\] at (-0.3) should be [initial\]]
+    expected: FAIL
+
+  [Web Animations: property <initial-letter> from [initial\] to [123\] at (0) should be [initial\]]
+    expected: FAIL
+
+  [Web Animations: property <initial-letter> from [initial\] to [123\] at (0.3) should be [initial\]]
+    expected: FAIL
+
+  [Web Animations: property <initial-letter> from [initial\] to [123\] at (0.5) should be [123\]]
+    expected: FAIL
+
+  [Web Animations: property <initial-letter> from [initial\] to [123\] at (0.6) should be [123\]]
+    expected: FAIL
+
+  [Web Animations: property <initial-letter> from [initial\] to [123\] at (1) should be [123\]]
+    expected: FAIL
+
+  [Web Animations: property <initial-letter> from [initial\] to [123\] at (1.5) should be [123\]]
+    expected: FAIL

--- a/tests/wpt/meta/css/css-inline/baseline-shift/baseline-shift-bottom.html.ini
+++ b/tests/wpt/meta/css/css-inline/baseline-shift/baseline-shift-bottom.html.ini
@@ -1,0 +1,2 @@
+[baseline-shift-bottom.html]
+  expected: FAIL

--- a/tests/wpt/meta/css/css-inline/baseline-shift/baseline-shift-center.html.ini
+++ b/tests/wpt/meta/css/css-inline/baseline-shift/baseline-shift-center.html.ini
@@ -1,0 +1,2 @@
+[baseline-shift-center.html]
+  expected: FAIL

--- a/tests/wpt/meta/css/css-inline/baseline-shift/baseline-shift-length-percentage.html.ini
+++ b/tests/wpt/meta/css/css-inline/baseline-shift/baseline-shift-length-percentage.html.ini
@@ -1,0 +1,2 @@
+[baseline-shift-length-percentage.html]
+  expected: FAIL

--- a/tests/wpt/meta/css/css-inline/baseline-shift/baseline-shift-sub-super.html.ini
+++ b/tests/wpt/meta/css/css-inline/baseline-shift/baseline-shift-sub-super.html.ini
@@ -1,0 +1,6 @@
+[baseline-shift-sub-super.html]
+  [baseline-shift: sub is below baseline]
+    expected: FAIL
+
+  [baseline-shift: super is above baseline]
+    expected: FAIL

--- a/tests/wpt/meta/css/css-inline/baseline-shift/baseline-shift-top.html.ini
+++ b/tests/wpt/meta/css/css-inline/baseline-shift/baseline-shift-top.html.ini
@@ -1,0 +1,2 @@
+[baseline-shift-top.html]
+  expected: FAIL

--- a/tests/wpt/meta/css/css-inline/empty-span-size-001.html.ini
+++ b/tests/wpt/meta/css/css-inline/empty-span-size-001.html.ini
@@ -1,0 +1,2 @@
+[empty-span-size-001.html]
+  expected: FAIL

--- a/tests/wpt/meta/css/css-inline/inheritance.html.ini
+++ b/tests/wpt/meta/css/css-inline/inheritance.html.ini
@@ -1,0 +1,42 @@
+[inheritance.html]
+  [Property alignment-baseline has initial value baseline]
+    expected: FAIL
+
+  [Property alignment-baseline does not inherit]
+    expected: FAIL
+
+  [Property baseline-shift has initial value 0px]
+    expected: FAIL
+
+  [Property baseline-shift does not inherit]
+    expected: FAIL
+
+  [Property dominant-baseline has initial value auto]
+    expected: FAIL
+
+  [Property dominant-baseline inherits]
+    expected: FAIL
+
+  [Property initial-letters has initial value normal]
+    expected: FAIL
+
+  [Property initial-letters does not inherit]
+    expected: FAIL
+
+  [Property initial-letters-align has initial value alphabetic]
+    expected: FAIL
+
+  [Property initial-letters-align inherits]
+    expected: FAIL
+
+  [Property initial-letters-wrap has initial value none]
+    expected: FAIL
+
+  [Property initial-letters-wrap inherits]
+    expected: FAIL
+
+  [Property initial-sizing has initial value normal]
+    expected: FAIL
+
+  [Property initial-sizing does not inherit]
+    expected: FAIL

--- a/tests/wpt/meta/css/css-inline/parsing/alignment-baseline-computed.html.ini
+++ b/tests/wpt/meta/css/css-inline/parsing/alignment-baseline-computed.html.ini
@@ -1,0 +1,24 @@
+[alignment-baseline-computed.html]
+  [Property alignment-baseline value 'baseline']
+    expected: FAIL
+
+  [Property alignment-baseline value 'text-bottom']
+    expected: FAIL
+
+  [Property alignment-baseline value 'alphabetic']
+    expected: FAIL
+
+  [Property alignment-baseline value 'ideographic']
+    expected: FAIL
+
+  [Property alignment-baseline value 'middle']
+    expected: FAIL
+
+  [Property alignment-baseline value 'central']
+    expected: FAIL
+
+  [Property alignment-baseline value 'mathematical']
+    expected: FAIL
+
+  [Property alignment-baseline value 'text-top']
+    expected: FAIL

--- a/tests/wpt/meta/css/css-inline/parsing/alignment-baseline-valid.html.ini
+++ b/tests/wpt/meta/css/css-inline/parsing/alignment-baseline-valid.html.ini
@@ -1,0 +1,24 @@
+[alignment-baseline-valid.html]
+  [e.style['alignment-baseline'\] = "baseline" should set the property value]
+    expected: FAIL
+
+  [e.style['alignment-baseline'\] = "text-bottom" should set the property value]
+    expected: FAIL
+
+  [e.style['alignment-baseline'\] = "alphabetic" should set the property value]
+    expected: FAIL
+
+  [e.style['alignment-baseline'\] = "ideographic" should set the property value]
+    expected: FAIL
+
+  [e.style['alignment-baseline'\] = "middle" should set the property value]
+    expected: FAIL
+
+  [e.style['alignment-baseline'\] = "central" should set the property value]
+    expected: FAIL
+
+  [e.style['alignment-baseline'\] = "mathematical" should set the property value]
+    expected: FAIL
+
+  [e.style['alignment-baseline'\] = "text-top" should set the property value]
+    expected: FAIL

--- a/tests/wpt/meta/css/css-inline/parsing/baseline-shift-computed.html.ini
+++ b/tests/wpt/meta/css/css-inline/parsing/baseline-shift-computed.html.ini
@@ -1,0 +1,24 @@
+[baseline-shift-computed.html]
+  [Property baseline-shift value '-10px']
+    expected: FAIL
+
+  [Property baseline-shift value '20%']
+    expected: FAIL
+
+  [Property baseline-shift value 'calc(10px - 0.5em)']
+    expected: FAIL
+
+  [Property baseline-shift value 'sub']
+    expected: FAIL
+
+  [Property baseline-shift value 'super']
+    expected: FAIL
+
+  [Property baseline-shift value 'bottom']
+    expected: FAIL
+
+  [Property baseline-shift value 'center']
+    expected: FAIL
+
+  [Property baseline-shift value 'top']
+    expected: FAIL

--- a/tests/wpt/meta/css/css-inline/parsing/baseline-shift-valid.html.ini
+++ b/tests/wpt/meta/css/css-inline/parsing/baseline-shift-valid.html.ini
@@ -1,0 +1,27 @@
+[baseline-shift-valid.html]
+  [e.style['baseline-shift'\] = "-10px" should set the property value]
+    expected: FAIL
+
+  [e.style['baseline-shift'\] = "20%" should set the property value]
+    expected: FAIL
+
+  [e.style['baseline-shift'\] = "calc(2em + 3ex)" should set the property value]
+    expected: FAIL
+
+  [e.style['baseline-shift'\] = "0" should set the property value]
+    expected: FAIL
+
+  [e.style['baseline-shift'\] = "sub" should set the property value]
+    expected: FAIL
+
+  [e.style['baseline-shift'\] = "super" should set the property value]
+    expected: FAIL
+
+  [e.style['baseline-shift'\] = "bottom" should set the property value]
+    expected: FAIL
+
+  [e.style['baseline-shift'\] = "center" should set the property value]
+    expected: FAIL
+
+  [e.style['baseline-shift'\] = "top" should set the property value]
+    expected: FAIL

--- a/tests/wpt/meta/css/css-inline/parsing/dominant-baseline-computed.html.ini
+++ b/tests/wpt/meta/css/css-inline/parsing/dominant-baseline-computed.html.ini
@@ -1,0 +1,27 @@
+[dominant-baseline-computed.html]
+  [Property dominant-baseline value 'auto']
+    expected: FAIL
+
+  [Property dominant-baseline value 'text-bottom']
+    expected: FAIL
+
+  [Property dominant-baseline value 'alphabetic']
+    expected: FAIL
+
+  [Property dominant-baseline value 'ideographic']
+    expected: FAIL
+
+  [Property dominant-baseline value 'middle']
+    expected: FAIL
+
+  [Property dominant-baseline value 'central']
+    expected: FAIL
+
+  [Property dominant-baseline value 'mathematical']
+    expected: FAIL
+
+  [Property dominant-baseline value 'hanging']
+    expected: FAIL
+
+  [Property dominant-baseline value 'text-top']
+    expected: FAIL

--- a/tests/wpt/meta/css/css-inline/parsing/dominant-baseline-valid.html.ini
+++ b/tests/wpt/meta/css/css-inline/parsing/dominant-baseline-valid.html.ini
@@ -1,0 +1,27 @@
+[dominant-baseline-valid.html]
+  [e.style['dominant-baseline'\] = "auto" should set the property value]
+    expected: FAIL
+
+  [e.style['dominant-baseline'\] = "text-bottom" should set the property value]
+    expected: FAIL
+
+  [e.style['dominant-baseline'\] = "alphabetic" should set the property value]
+    expected: FAIL
+
+  [e.style['dominant-baseline'\] = "ideographic" should set the property value]
+    expected: FAIL
+
+  [e.style['dominant-baseline'\] = "middle" should set the property value]
+    expected: FAIL
+
+  [e.style['dominant-baseline'\] = "central" should set the property value]
+    expected: FAIL
+
+  [e.style['dominant-baseline'\] = "mathematical" should set the property value]
+    expected: FAIL
+
+  [e.style['dominant-baseline'\] = "hanging" should set the property value]
+    expected: FAIL
+
+  [e.style['dominant-baseline'\] = "text-top" should set the property value]
+    expected: FAIL

--- a/tests/wpt/meta/css/css-inline/parsing/line-height-computed.html.ini
+++ b/tests/wpt/meta/css/css-inline/parsing/line-height-computed.html.ini
@@ -1,0 +1,9 @@
+[line-height-computed.html]
+  [Property line-height value 'calc(10 + (sign(2cqw - 10px) * 5))']
+    expected: FAIL
+
+  [Property line-height value 'calc(10% + (sign(2cqw - 10px) * 5%))']
+    expected: FAIL
+
+  [Property line-height value 'calc(10px + (sign(2cqw - 10px) * 5px))']
+    expected: FAIL

--- a/tests/wpt/meta/css/css-inline/parsing/vertical-align-computed.html.ini
+++ b/tests/wpt/meta/css/css-inline/parsing/vertical-align-computed.html.ini
@@ -1,0 +1,33 @@
+[vertical-align-computed.html]
+  [Property vertical-align value '0']
+    expected: FAIL
+
+  [Property vertical-align value '0px']
+    expected: FAIL
+
+  [Property vertical-align value 'baseline 0']
+    expected: FAIL
+
+  [Property vertical-align value '0px baseline']
+    expected: FAIL
+
+  [Property vertical-align value 'first']
+    expected: FAIL
+
+  [Property vertical-align value 'last']
+    expected: FAIL
+
+  [Property vertical-align value 'alphabetic']
+    expected: FAIL
+
+  [Property vertical-align value 'ideographic']
+    expected: FAIL
+
+  [Property vertical-align value 'central']
+    expected: FAIL
+
+  [Property vertical-align value 'mathematical']
+    expected: FAIL
+
+  [Property vertical-align value 'center']
+    expected: FAIL

--- a/tests/wpt/meta/css/css-inline/parsing/vertical-align-valid.html.ini
+++ b/tests/wpt/meta/css/css-inline/parsing/vertical-align-valid.html.ini
@@ -1,0 +1,54 @@
+[vertical-align-valid.html]
+  [e.style['vertical-align'\] = "0" should set the property value]
+    expected: FAIL
+
+  [e.style['vertical-align'\] = "0px" should set the property value]
+    expected: FAIL
+
+  [e.style['vertical-align'\] = "baseline 0" should set the property value]
+    expected: FAIL
+
+  [e.style['vertical-align'\] = "0px baseline" should set the property value]
+    expected: FAIL
+
+  [e.style['vertical-align'\] = "first" should set the property value]
+    expected: FAIL
+
+  [e.style['vertical-align'\] = "last" should set the property value]
+    expected: FAIL
+
+  [e.style['vertical-align'\] = "alphabetic" should set the property value]
+    expected: FAIL
+
+  [e.style['vertical-align'\] = "ideographic" should set the property value]
+    expected: FAIL
+
+  [e.style['vertical-align'\] = "central" should set the property value]
+    expected: FAIL
+
+  [e.style['vertical-align'\] = "mathematical" should set the property value]
+    expected: FAIL
+
+  [e.style['vertical-align'\] = "center" should set the property value]
+    expected: FAIL
+
+  [e.style['vertical-align'\] = "first baseline" should set the property value]
+    expected: FAIL
+
+  [e.style['vertical-align'\] = "middle 0" should set the property value]
+    expected: FAIL
+
+  [e.style['vertical-align'\] = "baseline super" should set the property value]
+    expected: FAIL
+
+  [e.style['vertical-align'\] = "last baseline sub" should set the property value]
+    expected: FAIL
+
+  [e.style['vertical-align'\] = "super middle first" should set the property value]
+    expected: FAIL
+
+  [e.style['vertical-align'\] = "1em last" should set the property value]
+    expected: FAIL
+
+  [e.style['vertical-align'\] = "text-top first 10%" should set the property value]
+    expected: FAIL


### PR DESCRIPTION
This is in preparation of #42361, which will add support for `baseline-shift`, so we shouldn't skip these tests.

The `animation` and `model` and `parsing` subdirectories also seem relevant.

Thus this only skips `initial-letter` and `text-box-trim`.

Testing: Just enabling more tests
