### PR TITLE
script: cookiestore: implement steps to 'set a cookie'

### DIFF
--- a/components/script/dom/cookiestore.rs
+++ b/components/script/dom/cookiestore.rs
@@ -31,6 +31,7 @@ use crate::dom::bindings::refcounted::Trusted;
 use crate::dom::bindings::reflector::{DomGlobal, reflect_dom_object};
 use crate::dom::bindings::root::DomRoot;
 use crate::dom::bindings::str::USVString;
+use crate::dom::document::get_registrable_domain_suffix_of_or_is_equal_to;
 use crate::dom::eventtarget::EventTarget;
 use crate::dom::globalscope::GlobalScope;
 use crate::dom::promise::Promise;
@@ -445,38 +446,31 @@ impl CookieStoreMethods<crate::DomTypeHolder> for CookieStore {
             return p;
         }
 
-        // From https://cookiestore.spec.whatwg.org/#set-cookie-algorithm
-        // Normalize name and value
-        // We do this here so we don't have to modify the cookie name/value again
-        let name = CookieStore::normalize(&name);
-        let value = CookieStore::normalize(&value);
-
-        if !CookieStore::validate_name_and_value(&name, &value) {
-            p.reject_error(Error::Type("Invalid cookie".to_string()), can_gc);
+        // 6.1 Let r be the result of running set a cookie with url, name, value, null, null, "/", "strict", false, and null.
+        let properties = CookieInit {
+            name,
+            value,
+            expires: None,
+            domain: None,
+            path: USVString(String::from("/")),
+            sameSite: CookieSameSite::Strict,
+            partitioned: false,
+        };
+        let creation_url = global.creation_url();
+        let Some(cookie) = CookieStore::set_a_cookie(&creation_url, &properties) else {
+            // If r is failure, then reject p with a TypeError and abort these steps.
+            p.reject_error(Error::Type(String::from("Invalid cookie")), can_gc);
             return p;
-        }
+        };
 
-        // 4. Let url be settings’s creation URL.
-        // 5. Let domain be null.
-        // 6. Let path be "/".
-        // 7. Let sameSite be strict.
-        // 8. Let partitioned be false.
-        let cookie = Cookie::build((Cow::Owned(name), Cow::Owned(value)))
-            .path("/")
-            .secure(true)
-            .same_site(SameSite::Strict)
-            .partitioned(false);
-        // TODO: This currently doesn't implement all the "set a cookie" steps which involves
-        // additional processing of the name and value
-
-        // 10. Run the following steps in parallel:
+        // 6. Run the following steps in parallel:
         let res = self
             .global()
             .resource_threads()
             .send(CoreResourceMsg::SetCookieForUrlAsync(
                 self.droppable.store_id,
-                self.global().creation_url().clone(),
-                Serde(cookie.build()),
+                creation_url.clone(),
+                Serde(cookie.into_owned()),
                 NonHTTP,
             ));
         if res.is_err() {
@@ -485,7 +479,7 @@ impl CookieStoreMethods<crate::DomTypeHolder> for CookieStore {
             self.in_flight.borrow_mut().push_back(p.clone());
         }
 
-        // 11. Return p.
+        // 7. Return p.
         p
     }
 
@@ -509,38 +503,12 @@ impl CookieStoreMethods<crate::DomTypeHolder> for CookieStore {
         // 4. Let url be settings’s creation URL.
         let creation_url = global.creation_url();
 
-        // From https://cookiestore.spec.whatwg.org/#set-cookie-algorithm
-        // Normalize name and value
-        // We do this here so we don't have to modify the cookie name/value again
-        let name = CookieStore::normalize(&options.name);
-        let value = CookieStore::normalize(&options.value);
-
-        if !CookieStore::validate_name_and_value(&name, &value) {
-            p.reject_error(Error::Type("Invalid cookie".to_string()), can_gc);
-            return p;
-        }
-
         // 6.1. Let r be the result of running set a cookie with url, options["name"], options["value"],
         // options["expires"], options["domain"], options["path"], options["sameSite"], and options["partitioned"].
-        let mut cookie = Cookie::build((Cow::Owned(name), Cow::Owned(value)))
-            .path(options.path.0.clone())
-            .secure(true)
-            .http_only(false)
-            .same_site(match options.sameSite {
-                CookieSameSite::Lax => SameSite::Lax,
-                CookieSameSite::Strict => SameSite::Strict,
-                CookieSameSite::None => SameSite::None,
-            });
-        if let Some(domain) = &options.domain {
-            cookie.inner_mut().set_domain(domain.0.clone());
-        }
-        if let Some(expiry) = options.expires {
-            cookie.inner_mut().set_expires(
-                OffsetDateTime::from_unix_timestamp((*expiry / 1000.0) as i64).unwrap(),
-            );
-        }
-        // TODO: This currently doesn't implement all the "set a cookie" steps which involves
-        // additional processing of the name and value
+        let Some(cookie) = CookieStore::set_a_cookie(&creation_url, options) else {
+            p.reject_error(Error::Type(String::from("Invalid cookie")), can_gc);
+            return p;
+        };
 
         // 6. Run the following steps in parallel:
         let res = self
@@ -549,7 +517,7 @@ impl CookieStoreMethods<crate::DomTypeHolder> for CookieStore {
             .send(CoreResourceMsg::SetCookieForUrlAsync(
                 self.droppable.store_id,
                 creation_url.clone(),
-                Serde(cookie.build()),
+                Serde(cookie.into_owned()),
                 NonHTTP,
             ));
         if res.is_err() {
@@ -642,47 +610,150 @@ impl CookieStore {
     }
 
     /// <https://cookiestore.spec.whatwg.org/#set-cookie-algorithm>
-    fn validate_name_and_value(name: &str, value: &str) -> bool {
-        // If name or value contain U+003B (;), any C0 control character except U+0009 TAB, or U+007F DELETE, then return failure.
-        if CookieStore::contains_control_characters(name) ||
-            CookieStore::contains_control_characters(value)
+    fn set_a_cookie<'a>(url: &'a ServoUrl, properties: &'a CookieInit) -> Option<Cookie<'a>> {
+        // 1. Normalize name.
+        let name = CookieStore::normalize(&properties.name);
+        // 2. Normalize value.
+        let value = CookieStore::normalize(&properties.value);
+
+        // 3. If name or value contain U+003B (;), any C0 control character except U+0009 TAB, or U+007F DELETE, then return failure.
+        if CookieStore::contains_control_characters(&name) ||
+            CookieStore::contains_control_characters(&value)
         {
-            return false;
+            return None;
         }
 
-        // If name contains U+003D (=), then return failure.
+        // 4. If name contains U+003D (=), then return failure.
         if name.contains('=') {
-            return false;
+            return None;
         }
 
-        // If name’s length is 0:
+        // 5. If name’s length is 0:
         if name.is_empty() {
-            // If value contains U+003D (=), then return failure.
-            // If value’s length is 0, then return failure.
+            // 5.1 If value contains U+003D (=), then return failure.
+            // 5.2 If value’s length is 0, then return failure.
             if value.contains('=') || value.is_empty() {
-                return false;
+                return None;
             }
-            // If value, byte-lowercased, starts with `__host-`, `__host-http-`, `__http-`, or `__secure-`, then return failure.
+            // 5.3 If value, byte-lowercased, starts with `__host-`, `__host-http-`, `__http-`, or `__secure-`, then return failure.
             let lowercased_value = value.to_ascii_lowercase();
             if ["__host-", "__host-http-", "__http-", "__secure-"]
                 .iter()
                 .any(|prefix| lowercased_value.starts_with(prefix))
             {
-                return false;
+                return None;
             }
         }
 
-        // If name, byte-lowercased, starts with `__host-http-` or `__http-`, then return failure.
+        // 6. If name, byte-lowercased, starts with `__host-http-` or `__http-`, then return failure.
         let lowercased_name = name.to_ascii_lowercase();
         if lowercased_name.starts_with("__host-http-") || lowercased_name.starts_with("__http-") {
-            return false;
+            return None;
         }
 
-        true
+        // 9. If the byte sequence length of encodedName plus the byte sequence length of encodedValue is greater than the maximum name/value pair size, then return failure.
+        if name.len() + value.len() > 4096 {
+            return None;
+        }
+
+        let mut cookie = Cookie::build((Cow::Owned(name), Cow::Owned(value)))
+            // 21. Append ('Secure', '') to attributes
+            .secure(true)
+            // 23. If partitioned is true, Append (`Partitioned`, ``) to attributes.
+            .partitioned(properties.partitioned)
+            // 21. Switch on sameSite:
+            .same_site(match properties.sameSite {
+                CookieSameSite::Lax => SameSite::Lax,
+                CookieSameSite::Strict => SameSite::Strict,
+                CookieSameSite::None => SameSite::None,
+            });
+
+        // 12. If domain is non-null
+        if let Some(domain) = &properties.domain {
+            // 10. Let host be url's host.
+            let host = match url.host() {
+                Some(host) => host.to_owned(),
+                None => return None,
+            };
+            // 12.1 If domain starts with U+002E (.), then return failure
+            if domain.starts_with('.') {
+                return None;
+            }
+            // 12.2 If name, byte-lowercased, starts with `__host-`, then return failure.
+            if lowercased_name.starts_with("__host-") {
+                return None;
+            }
+
+            // 12.3 If domain is not a registrable domain suffix of and is not equal to host, then return failure.
+            // 12.4 Let parsedDomain be the result of host parsing domain.
+            // 12.5 Assert: parsedDomain is not failure.
+            // Note: this function parses the host and returns the parsed host on success
+            let domain = get_registrable_domain_suffix_of_or_is_equal_to(domain, host)?;
+
+            // 12.6 Let encodedDomain be the result of UTF-8 encoding parsedDomain.
+            let domain = domain.to_string();
+            // 12.7 If the byte sequence length of encodedDomain is greater than the maximum attribute value size, then return failure.
+            if domain.len() > 1024 {
+                return None;
+            }
+            // 12.8 Append (`Domain`, encodedDomain) to attributes.
+            cookie.inner_mut().set_domain(domain);
+        }
+
+        // 13. If expires is non-null:
+        if let Some(expiry) = properties.expires {
+            // TODO: update cookiestore to take new maxAge parameter
+            // 13.2 Append (`Expires`, expires (date serialized)) to attributes.
+            cookie.inner_mut().set_expires(
+                OffsetDateTime::from_unix_timestamp((*expiry / 1000.0) as i64)
+                    .expect("cookie expiry out of range"),
+            );
+        }
+
+        // 15. If path is the empty string, then set path to the serialized cookie default path of url.
+        let path = if properties.path.is_empty() {
+            // 15.1 Let cloneURL be a clone of url.
+            let mut cloned_url = url.clone();
+            {
+                // 15.2 Set cloneURL’s path to the cookie default path of cloneURL’s path.
+                // <https://datatracker.ietf.org/doc/html/draft-ietf-httpbis-layered-cookies#name-cookie-default-path>
+                let mut path_segments = cloned_url
+                    .as_mut_url()
+                    .path_segments_mut()
+                    .expect("document creation url cannot be a base");
+                // 2. If path's size is greater than 1, then remove path's last item
+                if url.path_segments().is_some_and(|ps| ps.count() > 1) {
+                    path_segments.pop();
+                } else {
+                    // 3. Otherwise, set path[0] to the empty string.
+                    path_segments.clear();
+                }
+            }
+            cloned_url.path().to_owned()
+        } else {
+            properties.path.to_string()
+        };
+        // 16. If path does not start with U+002F (/), then return failure.
+        if !path.starts_with('/') {
+            return None;
+        }
+        // 17. If path is not U+002F (/), and name, byte-lowercased, starts with `__host-`, then return failure.
+        if path != "/" && lowercased_name.starts_with("__host-") {
+            return None;
+        }
+        // 19. If the byte sequence length of encodedPath is greater than the maximum attribute value size, then return failure.
+        if path.len() > 1024 {
+            return None;
+        }
+        // 20. Append (`Path`, encodedPath) to attributes.
+        cookie.inner_mut().set_path(path);
+
+        Some(cookie.build())
     }
 
-    /// If name or value contain U+003B (;), any C0 control character except U+0009 TAB, or U+007F DELETE, then return failure.
+    /// <https://cookiestore.spec.whatwg.org/#set-cookie-algorithm>
     fn contains_control_characters(val: &str) -> bool {
+        // If name or value contain U+003B (;), any C0 control character except U+0009 TAB, or U+007F DELETE, then return failure.
         val.contains(
             |v| matches!(v, '\u{0000}'..='\u{0008}' | '\u{000a}'..='\u{001f}' | '\u{007f}' | ';'),
         )

--- a/components/script/dom/document.rs
+++ b/components/script/dom/document.rs
@@ -3648,8 +3648,8 @@ impl<'dom> LayoutDocumentHelpers<'dom> for LayoutDom<'dom, Document> {
 // https://html.spec.whatwg.org/multipage/#is-a-registrable-domain-suffix-of-or-is-equal-to
 // The spec says to return a bool, we actually return an Option<Host> containing
 // the parsed host in the successful case, to avoid having to re-parse the host.
-fn get_registrable_domain_suffix_of_or_is_equal_to(
-    host_suffix_string: &DOMString,
+pub(crate) fn get_registrable_domain_suffix_of_or_is_equal_to(
+    host_suffix_string: &str,
     original_host: Host,
 ) -> Option<Host> {
     // Step 1
@@ -3658,7 +3658,7 @@ fn get_registrable_domain_suffix_of_or_is_equal_to(
     }
 
     // Step 2-3.
-    let host = match Host::parse(&host_suffix_string.str()) {
+    let host = match Host::parse(host_suffix_string) {
         Ok(host) => host,
         Err(_) => return None,
     };
@@ -5211,10 +5211,11 @@ impl DocumentMethods<crate::DomTypeHolder> for Document {
         };
 
         // Step 5. If the given value is not a registrable domain suffix of and is not equal to effectiveDomain, then throw a "SecurityError" DOMException.
-        let host = match get_registrable_domain_suffix_of_or_is_equal_to(&value, effective_domain) {
-            None => return Err(Error::Security(None)),
-            Some(host) => host,
-        };
+        let host =
+            match get_registrable_domain_suffix_of_or_is_equal_to(&value.str(), effective_domain) {
+                None => return Err(Error::Security(None)),
+                Some(host) => host,
+            };
 
         // Step 6. If the surrounding agent's agent cluster's is origin-keyed is true, then return.
         // TODO

--- a/tests/wpt/meta/cookiestore/cookieStore_delete_arguments.https.any.js.ini
+++ b/tests/wpt/meta/cookiestore/cookieStore_delete_arguments.https.any.js.ini
@@ -1,10 +1,4 @@
 [cookieStore_delete_arguments.https.any.html]
-  [cookieStore.delete domain starts with "."]
-    expected: FAIL
-
-  [cookieStore.delete with domain that is not equal current host]
-    expected: FAIL
-
   [cookieStore.delete with domain set to a subdomain of the current hostname]
     expected: FAIL
 

--- a/tests/wpt/meta/cookiestore/cookieStore_set_arguments.https.any.js.ini
+++ b/tests/wpt/meta/cookiestore/cookieStore_set_arguments.https.any.js.ini
@@ -2,159 +2,32 @@
   expected: ERROR
 
 [cookieStore_set_arguments.https.any.html]
-  expected: CRASH
-  [cookieStore.set fails with empty name and empty value]
-    expected: TIMEOUT
-
-  [cookieStore.set with empty name and an '=' in value]
-    expected: NOTRUN
-
-  [cookieStore.set with normal name and an '=' in value]
-    expected: NOTRUN
-
-  [cookieStore.set checks if name or value contain invalid character U+0000]
-    expected: NOTRUN
-
-  [cookieStore.set checks if name or value contain invalid character U+0001]
-    expected: NOTRUN
-
-  [cookieStore.set checks if name or value contain invalid character U+0002]
-    expected: NOTRUN
-
-  [cookieStore.set checks if name or value contain invalid character U+0003]
-    expected: NOTRUN
-
-  [cookieStore.set checks if name or value contain invalid character U+0004]
-    expected: NOTRUN
-
-  [cookieStore.set checks if name or value contain invalid character U+0005]
-    expected: NOTRUN
-
-  [cookieStore.set checks if name or value contain invalid character U+0006]
-    expected: NOTRUN
-
-  [cookieStore.set checks if name or value contain invalid character U+0007]
-    expected: NOTRUN
-
-  [cookieStore.set checks if name or value contain invalid character U+0008]
-    expected: NOTRUN
-
-  [cookieStore.set checks if name or value contain invalid character U+0010]
-    expected: NOTRUN
-
-  [cookieStore.set checks if name or value contain invalid character U+0011]
-    expected: NOTRUN
-
-  [cookieStore.set checks if name or value contain invalid character U+0012]
-    expected: NOTRUN
-
-  [cookieStore.set checks if name or value contain invalid character U+0013]
-    expected: NOTRUN
-
-  [cookieStore.set checks if name or value contain invalid character U+0014]
-    expected: NOTRUN
-
-  [cookieStore.set checks if name or value contain invalid character U+0015]
-    expected: NOTRUN
-
-  [cookieStore.set checks if name or value contain invalid character U+0016]
-    expected: NOTRUN
-
-  [cookieStore.set checks if name or value contain invalid character U+0017]
-    expected: NOTRUN
-
-  [cookieStore.set checks if name or value contain invalid character U+0018]
-    expected: NOTRUN
-
-  [cookieStore.set checks if name or value contain invalid character U+0019]
-    expected: NOTRUN
-
-  [cookieStore.set checks if name or value contain invalid character U+001A]
-    expected: NOTRUN
-
-  [cookieStore.set checks if name or value contain invalid character U+001B]
-    expected: NOTRUN
-
-  [cookieStore.set checks if name or value contain invalid character U+001C]
-    expected: NOTRUN
-
-  [cookieStore.set checks if name or value contain invalid character U+001D]
-    expected: NOTRUN
-
-  [cookieStore.set checks if name or value contain invalid character U+001E]
-    expected: NOTRUN
-
-  [cookieStore.set checks if name or value contain invalid character U+001F]
-    expected: NOTRUN
-
-  [cookieStore.set checks if name or value contain invalid character U+003B]
-    expected: NOTRUN
-
-  [cookieStore.set checks if name or value contain invalid character U+007F]
-    expected: NOTRUN
-
-  [cookieStore.set with expires set to a future Date]
-    expected: NOTRUN
-
-  [cookieStore.set with expires set to a past Date]
-    expected: NOTRUN
-
-  [cookieStore.set with expires set to a future timestamp]
-    expected: NOTRUN
-
-  [cookieStore.set with expires set to a past timestamp]
-    expected: NOTRUN
-
   [cookieStore.set domain starts with "."]
-    expected: NOTRUN
+    expected: FAIL
 
   [cookieStore.set with domain that is not equal current host]
-    expected: NOTRUN
-
-  [cookieStore.set with domain set to the current hostname]
-    expected: NOTRUN
+    expected: FAIL
 
   [cookieStore.set with domain set to a subdomain of the current hostname]
-    expected: NOTRUN
+    expected: FAIL
 
   [cookieStore.set with domain set to a non-domain-matching suffix of the current hostname]
-    expected: NOTRUN
+    expected: FAIL
 
   [cookieStore.set default domain is null and differs from current hostname]
-    expected: NOTRUN
-
-  [cookieStore.set with path set to the current directory]
-    expected: NOTRUN
-
-  [cookieStore.set with path set to a subdirectory of the current directory]
-    expected: NOTRUN
-
-  [cookieStore.set default path is /]
-    expected: NOTRUN
-
-  [cookieStore.set does not add / to path that does not end with /]
-    expected: NOTRUN
-
-  [cookieStore.set can modify a cookie set by document.cookie if document is defined]
-    expected: NOTRUN
+    expected: FAIL
 
   [cookieStore.set with path that does not start with /]
-    expected: NOTRUN
+    expected: FAIL
 
   [cookieStore.set with get result]
-    expected: NOTRUN
+    expected: FAIL
 
   [cookieStore.set checks if the path is too long]
-    expected: NOTRUN
+    expected: FAIL
 
   [cookieStore.set checks if the domain is too long]
-    expected: NOTRUN
+    expected: FAIL
 
   [cookieStore.set with a __Host- prefix should not have a domain]
-    expected: NOTRUN
-
-  [cookieStore.set with whitespace only name and value]
-    expected: NOTRUN
-
-  [cookieStore.set with whitespace at begining or end]
-    expected: NOTRUN
+    expected: FAIL

--- a/tests/wpt/meta/cookiestore/cookieStore_set_arguments.https.any.js.ini
+++ b/tests/wpt/meta/cookiestore/cookieStore_set_arguments.https.any.js.ini
@@ -2,32 +2,5 @@
   expected: ERROR
 
 [cookieStore_set_arguments.https.any.html]
-  [cookieStore.set domain starts with "."]
-    expected: FAIL
-
-  [cookieStore.set with domain that is not equal current host]
-    expected: FAIL
-
-  [cookieStore.set with domain set to a subdomain of the current hostname]
-    expected: FAIL
-
-  [cookieStore.set with domain set to a non-domain-matching suffix of the current hostname]
-    expected: FAIL
-
   [cookieStore.set default domain is null and differs from current hostname]
-    expected: FAIL
-
-  [cookieStore.set with path that does not start with /]
-    expected: FAIL
-
-  [cookieStore.set with get result]
-    expected: FAIL
-
-  [cookieStore.set checks if the path is too long]
-    expected: FAIL
-
-  [cookieStore.set checks if the domain is too long]
-    expected: FAIL
-
-  [cookieStore.set with a __Host- prefix should not have a domain]
     expected: FAIL

--- a/tests/wpt/meta/cookiestore/cookieStore_set_path.https.window.js.ini
+++ b/tests/wpt/meta/cookiestore/cookieStore_set_path.https.window.js.ini
@@ -1,3 +1,0 @@
-[cookieStore_set_path.https.window.html]
-  [CookieListItem - cookieStore.set with empty string path defaults to current URL with __host- prefix]
-    expected: FAIL

--- a/tests/wpt/meta/cookiestore/cookieStore_special_names.https.any.js.ini
+++ b/tests/wpt/meta/cookiestore/cookieStore_special_names.https.any.js.ini
@@ -17,82 +17,19 @@
   [cookieStore.set with __hosthttp- prefix rejects]
     expected: FAIL
 
-  [cookieStore.set with __Http- prefix rejects]
-    expected: FAIL
-
-  [cookieStore.set with __http- prefix rejects]
-    expected: FAIL
-
-  [cookieStore.set with   __Http- prefix rejects]
-    expected: FAIL
-
-  [cookieStore.set with \t__Http- prefix rejects]
-    expected: FAIL
-
   [cookieStore.set with   __HostHttp- prefix rejects]
     expected: FAIL
 
   [cookieStore.set with \t__HostHttp- prefix rejects]
     expected: FAIL
 
-  [cookieStore.set with malformed name.]
-    expected: FAIL
-
-  [cookieStore.set a nameless cookie cannot have __Host- prefix]
-    expected: FAIL
-
-  [cookieStore.set a nameless cookie cannot have __Secure- prefix]
-    expected: FAIL
-
-  [cookieStore.set a nameless cookie cannot have __Http- prefix]
-    expected: FAIL
-
   [cookieStore.set a nameless cookie cannot have __HostHttp- prefix]
-    expected: FAIL
-
-  [cookieStore.set a nameless cookie cannot have  __Host- prefix]
-    expected: FAIL
-
-  [cookieStore.set a nameless cookie cannot have \t__Host- prefix]
-    expected: FAIL
-
-  [cookieStore.set a nameless cookie cannot have  __Secure- prefix]
-    expected: FAIL
-
-  [cookieStore.set a nameless cookie cannot have \t__Secure- prefix]
-    expected: FAIL
-
-  [cookieStore.set a nameless cookie cannot have  __Http- prefix]
-    expected: FAIL
-
-  [cookieStore.set a nameless cookie cannot have \t__Http- prefix]
     expected: FAIL
 
   [cookieStore.set a nameless cookie cannot have  __HostHttp- prefix]
     expected: FAIL
 
   [cookieStore.set a nameless cookie cannot have \t__HostHttp- prefix]
-    expected: FAIL
-
-  [cookieStore.set with __Host-Http- prefix rejects]
-    expected: FAIL
-
-  [cookieStore.set with __host-http- prefix rejects]
-    expected: FAIL
-
-  [cookieStore.set with   __Host-Http- prefix rejects]
-    expected: FAIL
-
-  [cookieStore.set with \t__Host-Http- prefix rejects]
-    expected: FAIL
-
-  [cookieStore.set a nameless cookie cannot have __Host-Http- prefix]
-    expected: FAIL
-
-  [cookieStore.set a nameless cookie cannot have  __Host-Http- prefix]
-    expected: FAIL
-
-  [cookieStore.set a nameless cookie cannot have \t__Host-Http- prefix]
     expected: FAIL
 
 

--- a/tests/wpt/meta/cookiestore/cookieStore_special_names.https.any.js.ini
+++ b/tests/wpt/meta/cookiestore/cookieStore_special_names.https.any.js.ini
@@ -1,16 +1,4 @@
 [cookieStore_special_names.https.any.html]
-  [cookieStore.set with __Host- prefix and a domain option]
-    expected: FAIL
-
-  [cookieStore.set with __Host- prefix a path option]
-    expected: FAIL
-
-  [cookieStore.set with __host- prefix and a domain option]
-    expected: FAIL
-
-  [cookieStore.set with __host- prefix a path option]
-    expected: FAIL
-
   [cookieStore.set with __HostHttp- prefix rejects]
     expected: FAIL
 


### PR DESCRIPTION
Implements the `set_a_cookie` behavior from the cookiestore spec.

Testing: cookiestore WPT tests cover this
