### PR TITLE
indexeddb: Implement index retrieval

### DIFF
--- a/components/script/dom/domstringlist.rs
+++ b/components/script/dom/domstringlist.rs
@@ -39,13 +39,13 @@ impl DOMStringList {
     }
 
     /// <https://www.w3.org/TR/IndexedDB-2/#sorted-name-list>
-    pub(crate) fn new_sorted(
+    pub(crate) fn new_sorted<'a>(
         global: &GlobalScope,
-        strings: &[DOMString],
+        strings: impl IntoIterator<Item = &'a DOMString>,
         can_gc: CanGc,
     ) -> DomRoot<DOMStringList> {
         let sorted = strings
-            .iter()
+            .into_iter()
             .map(|dom_string| dom_string.str().encode_utf16().collect::<Vec<u16>>())
             .sorted_unstable()
             .map(|utf16_str| {

--- a/components/script/dom/indexeddb/idbdatabase.rs
+++ b/components/script/dom/indexeddb/idbdatabase.rs
@@ -347,7 +347,7 @@ impl IDBDatabaseMethods<crate::DomTypeHolder> for IDBDatabase {
 
     /// <https://www.w3.org/TR/IndexedDB-2/#dom-idbdatabase-objectstorenames>
     fn ObjectStoreNames(&self, can_gc: CanGc) -> DomRoot<DOMStringList> {
-        DOMStringList::new_sorted(&self.global(), &self.object_store_names.borrow(), can_gc)
+        DOMStringList::new_sorted(&self.global(), &*self.object_store_names.borrow(), can_gc)
     }
 
     /// <https://w3c.github.io/IndexedDB/#dom-idbdatabase-close>

--- a/components/script_bindings/webidls/IDBObjectStore.webidl
+++ b/components/script_bindings/webidls/IDBObjectStore.webidl
@@ -33,7 +33,7 @@ interface IDBObjectStore {
   [NewObject, Throws] IDBRequest openKeyCursor(optional any query,
                                        optional IDBCursorDirection direction = "next");
 
-  // IDBIndex index(DOMString name);
+  [Throws] IDBIndex index(DOMString name);
 
   [NewObject, Throws] IDBIndex createIndex(DOMString name,
                                    (DOMString or sequence<DOMString>) keyPath,

--- a/components/storage/indexeddb/engines/mod.rs
+++ b/components/storage/indexeddb/engines/mod.rs
@@ -4,7 +4,9 @@
 
 use std::collections::VecDeque;
 
-use storage_traits::indexeddb::{AsyncOperation, CreateObjectResult, IndexedDBTxnMode, KeyPath};
+use storage_traits::indexeddb::{
+    AsyncOperation, CreateObjectResult, IndexedDBIndex, IndexedDBTxnMode, KeyPath,
+};
 use tokio::sync::oneshot;
 
 pub use self::sqlite::SqliteEngine;
@@ -47,6 +49,7 @@ pub trait KvsEngine {
 
     fn has_key_generator(&self, store_name: &str) -> bool;
     fn key_path(&self, store_name: &str) -> Option<KeyPath>;
+    fn indexes(&self, store_name: &str) -> Result<Vec<IndexedDBIndex>, Self::Error>;
 
     fn create_index(
         &self,

--- a/components/storage/indexeddb/engines/sqlite/object_store_index_model.rs
+++ b/components/storage/indexeddb/engines/sqlite/object_store_index_model.rs
@@ -1,6 +1,7 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+use rusqlite::Row;
 use sea_query::Iden;
 
 #[derive(Iden)]
@@ -15,7 +16,6 @@ pub enum Column {
     MultiEntryIndex,
 }
 
-#[expect(dead_code)]
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct Model {
     pub id: i32,
@@ -24,4 +24,19 @@ pub struct Model {
     pub key_path: Vec<u8>,
     pub unique_index: bool,
     pub multi_entry_index: bool,
+}
+
+impl TryFrom<&Row<'_>> for Model {
+    type Error = rusqlite::Error;
+
+    fn try_from(value: &Row) -> Result<Self, Self::Error> {
+        Ok(Self {
+            id: value.get(0)?,
+            object_store_id: value.get(1)?,
+            name: value.get(2)?,
+            key_path: value.get(3)?,
+            unique_index: value.get(4)?,
+            multi_entry_index: value.get(5)?,
+        })
+    }
 }

--- a/components/storage/indexeddb/mod.rs
+++ b/components/storage/indexeddb/mod.rs
@@ -21,7 +21,8 @@ use servo_config::pref;
 use servo_url::origin::ImmutableOrigin;
 use storage_traits::indexeddb::{
     AsyncOperation, BackendError, BackendResult, ConnectionMsg, CreateObjectResult, DatabaseInfo,
-    DbResult, IndexedDBThreadMsg, IndexedDBTxnMode, KeyPath, SyncOperation,
+    DbResult, IndexedDBIndex, IndexedDBObjectStore, IndexedDBThreadMsg, IndexedDBTxnMode, KeyPath,
+    SyncOperation,
 };
 use uuid::Uuid;
 
@@ -141,6 +142,12 @@ impl<E: KvsEngine> IndexedDBEnvironment<E> {
 
     fn key_path(&self, store_name: &str) -> Option<KeyPath> {
         self.engine.key_path(store_name)
+    }
+
+    fn indexes(&self, store_name: &str) -> DbResult<Vec<IndexedDBIndex>> {
+        self.engine
+            .indexes(store_name)
+            .map_err(|err| format!("{err:?}"))
     }
 
     fn create_index(
@@ -1328,16 +1335,16 @@ impl IndexedDBManager {
                 };
                 self.start_delete_database(idb_description, id, callback);
             },
-            SyncOperation::HasKeyGenerator(sender, origin, db_name, store_name) => {
+            SyncOperation::GetObjectStore(sender, origin, db_name, store_name) => {
+                // FIXME:(arihant2math) Should we error out more aggressively here?
                 let result = self
                     .get_database(origin, db_name)
-                    .map(|db| db.has_key_generator(&store_name));
-                let _ = sender.send(result.ok_or(BackendError::DbNotFound));
-            },
-            SyncOperation::KeyPath(sender, origin, db_name, store_name) => {
-                let result = self
-                    .get_database(origin, db_name)
-                    .map(|db| db.key_path(&store_name));
+                    .map(|db| IndexedDBObjectStore {
+                        key_path: db.key_path(&store_name),
+                        has_key_generator: db.has_key_generator(&store_name),
+                        indexes: db.indexes(&store_name).unwrap_or_default(),
+                        name: store_name,
+                    });
                 let _ = sender.send(result.ok_or(BackendError::DbNotFound));
             },
             SyncOperation::CreateIndex(

--- a/tests/wpt/meta/IndexedDB/idbindex-getAll-enforcerange.any.js.ini
+++ b/tests/wpt/meta/IndexedDB/idbindex-getAll-enforcerange.any.js.ini
@@ -1,15 +1,9 @@
 [idbindex-getAll-enforcerange.any.worker.html]
-  [IDBIndex.getAll() should enforce valid range constraints.]
-    expected: FAIL
-
 
 [idbindex-getAll-enforcerange.any.serviceworker.html]
   expected: ERROR
 
 [idbindex-getAll-enforcerange.any.html]
-  [IDBIndex.getAll() should enforce valid range constraints.]
-    expected: FAIL
-
 
 [idbindex-getAll-enforcerange.any.sharedworker.html]
   expected: ERROR

--- a/tests/wpt/meta/IndexedDB/idbindex-getAllKeys-enforcerange.any.js.ini
+++ b/tests/wpt/meta/IndexedDB/idbindex-getAllKeys-enforcerange.any.js.ini
@@ -1,15 +1,9 @@
 [idbindex-getAllKeys-enforcerange.any.html]
-  [IDBIndex.getAllKeys() should enforce valid range constraints.]
-    expected: FAIL
-
 
 [idbindex-getAllKeys-enforcerange.any.sharedworker.html]
   expected: ERROR
 
 [idbindex-getAllKeys-enforcerange.any.worker.html]
-  [IDBIndex.getAllKeys() should enforce valid range constraints.]
-    expected: FAIL
-
 
 [idbindex-getAllKeys-enforcerange.any.serviceworker.html]
   expected: ERROR

--- a/tests/wpt/meta/IndexedDB/idbindex-objectStore-SameObject.any.js.ini
+++ b/tests/wpt/meta/IndexedDB/idbindex-objectStore-SameObject.any.js.ini
@@ -2,13 +2,8 @@
   expected: ERROR
 
 [idbindex-objectStore-SameObject.any.worker.html]
-  [IDBIndex.objectStore should return same object each time.]
-    expected: FAIL
-
 
 [idbindex-objectStore-SameObject.any.sharedworker.html]
   expected: ERROR
 
 [idbindex-objectStore-SameObject.any.html]
-  [IDBIndex.objectStore should return same object each time.]
-    expected: FAIL

--- a/tests/wpt/meta/IndexedDB/idbindex_indexNames.any.js.ini
+++ b/tests/wpt/meta/IndexedDB/idbindex_indexNames.any.js.ini
@@ -1,7 +1,4 @@
 [idbindex_indexNames.any.worker.html]
-  [Verify IDBObjectStore.indexNames property]
-    expected: FAIL
-
 
 [idbindex_indexNames.any.serviceworker.html]
   expected: ERROR
@@ -10,5 +7,3 @@
   expected: ERROR
 
 [idbindex_indexNames.any.html]
-  [Verify IDBObjectStore.indexNames property]
-    expected: FAIL

--- a/tests/wpt/meta/IndexedDB/idbobjectstore_index.any.js.ini
+++ b/tests/wpt/meta/IndexedDB/idbobjectstore_index.any.js.ini
@@ -2,13 +2,8 @@
   expected: ERROR
 
 [idbobjectstore_index.any.worker.html]
-  [IDBObjectStore.index() - returns an index]
-    expected: FAIL
-
 
 [idbobjectstore_index.any.serviceworker.html]
   expected: ERROR
 
 [idbobjectstore_index.any.html]
-  [IDBObjectStore.index() - returns an index]
-    expected: FAIL

--- a/tests/wpt/meta/IndexedDB/idlharness.any.js.ini
+++ b/tests/wpt/meta/IndexedDB/idlharness.any.js.ini
@@ -2,9 +2,6 @@
   expected: ERROR
 
 [idlharness.any.html]
-  [IDBObjectStore interface: operation index(DOMString)]
-    expected: FAIL
-
   [IDBIndex interface: attribute name]
     expected: FAIL
 
@@ -85,10 +82,6 @@
   expected: ERROR
 
 [idlharness.any.worker.html]
-
-  [IDBObjectStore interface: operation index(DOMString)]
-    expected: FAIL
-
   [IDBIndex interface: attribute name]
     expected: FAIL
 


### PR DESCRIPTION
Retrieve already stored indexes from the backend when querying for other object store data.

Also removes the extraneous blocking IPC call when creating an `IDBObjectStore` object by batching all the info into a single struct.

Testing: WPT
Fixes: #42438