### PR TITLE
IndexedDB: Throw InvalidStateError if object store is deleted in createIndex/deleteIndex

### DIFF
--- a/components/script/dom/indexeddb/idbobjectstore.rs
+++ b/components/script/dom/indexeddb/idbobjectstore.rs
@@ -714,7 +714,8 @@ impl IDBObjectStoreMethods<crate::DomTypeHolder> for IDBObjectStore {
             return Err(Error::InvalidState(None));
         }
 
-        // TODO: Step 4. If store has been deleted, throw an "InvalidStateError" DOMException.
+        // Step 4. If store has been deleted, throw an "InvalidStateError" DOMException.
+        self.verify_not_deleted()?;
         // Step 5. If transaction is not active, throw a "TransactionInactiveError" DOMException.
         self.check_transaction_active()?;
 
@@ -771,7 +772,8 @@ impl IDBObjectStoreMethods<crate::DomTypeHolder> for IDBObjectStore {
         if self.transaction.Mode() != IDBTransactionMode::Versionchange {
             return Err(Error::InvalidState(None));
         }
-        // TODO: Step 4. If store has been deleted, throw an "InvalidStateError" DOMException.
+        // Step 4. If store has been deleted, throw an "InvalidStateError" DOMException.
+        self.verify_not_deleted()?;
         // Step 5. If transaction is not active, throw a "TransactionInactiveError" DOMException.
         self.check_transaction_active()?;
         // Step 6. Let index be the index named name in store if one exists,

--- a/tests/wpt/meta/IndexedDB/idbobjectstore_createIndex.any.js.ini
+++ b/tests/wpt/meta/IndexedDB/idbobjectstore_createIndex.any.js.ini
@@ -31,13 +31,13 @@
     expected: FAIL
 
   [If the object store has been deleted, the implementation must throw a DOMException of type InvalidStateError]
-    expected: FAIL
+
 
   [InvalidStateError(Incorrect mode) vs. TransactionInactiveError. Mode check should precede state check of the transaction.]
     expected: TIMEOUT
 
   [InvalidStateError(Deleted ObjectStore) vs. TransactionInactiveError. Deletion check should precede transaction-state check.]
-    expected: TIMEOUT
+
 
   [SyntaxError vs. InvalidAccessError. Syntax check should precede multiEntry check of the key path.]
     expected: FAIL
@@ -91,13 +91,13 @@
     expected: FAIL
 
   [If the object store has been deleted, the implementation must throw a DOMException of type InvalidStateError]
-    expected: FAIL
+
 
   [InvalidStateError(Incorrect mode) vs. TransactionInactiveError. Mode check should precede state check of the transaction.]
     expected: TIMEOUT
 
   [InvalidStateError(Deleted ObjectStore) vs. TransactionInactiveError. Deletion check should precede transaction-state check.]
-    expected: TIMEOUT
+
 
   [SyntaxError vs. InvalidAccessError. Syntax check should precede multiEntry check of the key path.]
     expected: FAIL


### PR DESCRIPTION
 This PR adds a check to ensure that createIndex and deleteIndex throw an InvalidStateError if the object store has been deleted, aligning with the W3C spec.

I checked the spec to make sure the error check happens in the right order (checking the transaction mode before the deleted state). I've verified this with the Web Platform Tests, and the createIndex test is now passing.

Fixes #42436

