### PR TITLE
script: add safe structured clone write wrapper

### DIFF
--- a/components/script/dom/bindings/structuredclone.rs
+++ b/components/script/dom/bindings/structuredclone.rs
@@ -659,13 +659,24 @@ pub(crate) struct StructuredDataWriter {
     // A map of serialized image data.
     pub(crate) image_data: Option<FxHashMap<ImageDataId, SerializableImageData>>,
 }
-
-/// Writes a structured clone. Returns a `DataClone` error if that fails.
+/// Writes a structured clone using the current JS context.
+///
+/// This is the safe entry point that callers should use.
 pub(crate) fn write(
+    global: &GlobalScope,
+    message: HandleValue,
+    transfer: Option<CustomAutoRooterGuard<Vec<*mut JSObject>>>,
+) -> Fallible<StructuredSerializedData> {
+   let cx = GlobalScope::get_cx();
+
+   write_inner(cx, message, transfer)
+}
+fn write_inner(
     cx: SafeJSContext,
     message: HandleValue,
     transfer: Option<CustomAutoRooterGuard<Vec<*mut JSObject>>>,
 ) -> Fallible<StructuredSerializedData> {
+
     unsafe {
         rooted!(in(*cx) let mut val = UndefinedValue());
         if let Some(transfer) = transfer {

--- a/components/script/dom/broadcastchannel.rs
+++ b/components/script/dom/broadcastchannel.rs
@@ -85,7 +85,7 @@ impl BroadcastChannelMethods<crate::DomTypeHolder> for BroadcastChannel {
         }
 
         // Step 6, StructuredSerialize(message).
-        let data = structuredclone::write(cx, message, None)?;
+        let data = structuredclone::write(self.global(), message, None)?;
 
         let global = self.global();
 

--- a/components/script/dom/dissimilaroriginwindow.rs
+++ b/components/script/dom/dissimilaroriginwindow.rs
@@ -207,7 +207,7 @@ impl DissimilarOriginWindow {
         transfer: CustomAutoRooterGuard<Vec<*mut JSObject>>,
     ) -> ErrorResult {
         // Step 6-7.
-        let data = structuredclone::write(cx, message, Some(transfer))?;
+        let data = structuredclone::write(self.window.global(), message, Some(transfer))?;
 
         self.post_message(target_origin, data)
     }

--- a/components/script/dom/globalscope.rs
+++ b/components/script/dom/globalscope.rs
@@ -3281,7 +3281,7 @@ impl GlobalScope {
         );
         let guard = CustomAutoRooterGuard::new(*cx, &mut rooted);
 
-        let data = structuredclone::write(cx, value, Some(guard))?;
+        let data = structuredclone::write(self, value, Some(guard))?;
 
         structuredclone::read(self, data, retval, can_gc)?;
 

--- a/components/script/dom/history.rs
+++ b/components/script/dom/history.rs
@@ -202,8 +202,8 @@ impl History {
         // https://github.com/servo/servo/issues/19159
 
         // Step 4. Let serializedData be StructuredSerializeForStorage(data). Rethrow any exceptions.
-        let serialized_data = structuredclone::write(cx, data, None)?;
-
+        let serialized_data = structuredclone::write(self.window.global(), data, None)?;
+        
         // Step 5. Let newURL be document's URL.
         let new_url: ServoUrl = match url {
             // Step 6. If url is not null or the empty string, then:

--- a/components/script/dom/indexeddb/idbobjectstore.rs
+++ b/components/script/dom/indexeddb/idbobjectstore.rs
@@ -251,7 +251,7 @@ impl IDBObjectStore {
         }
 
         // Step 10. Let clone be a clone of value in targetRealm during transaction. Rethrow any exceptions.
-        let cloned_value = structuredclone::write(cx.into(), value, None)?;
+        let cloned_value = structuredclone::write(self.global(), value, None)?;
         let Ok(serialized_value) = postcard::to_stdvec(&cloned_value) else {
             return Err(Error::InvalidState(None));
         };

--- a/components/script/dom/messageport.rs
+++ b/components/script/dom/messageport.rs
@@ -148,7 +148,7 @@ impl MessagePort {
         }
 
         // Step 5
-        let data = structuredclone::write(cx, message, Some(transfer))?;
+        let data = structuredclone::write(self.global(), message, Some(transfer))?;
 
         if doomed {
             // TODO: The spec says to optionally report such a case to a dev console.

--- a/components/script/dom/stream/defaultteereadrequest.rs
+++ b/components/script/dom/stream/defaultteereadrequest.rs
@@ -136,7 +136,7 @@ impl DefaultTeeReadRequest {
         if !self.canceled_2.get() && self.clone_for_branch_2.get() {
             // Let cloneResult be StructuredClone(chunk2).
             rooted!(in(*cx) let mut clone_result = UndefinedValue());
-            let data = structuredclone::write(cx, chunk2_value.handle(), None).unwrap();
+            let data = structuredclone::write(global, chunk2_value.handle(), None).unwrap();
             // If cloneResult is an abrupt completion,
             if structuredclone::read(global, data, clone_result.handle_mut(), can_gc).is_err() {
                 // Perform ! ReadableStreamDefaultControllerError(branch_1.[[controller]], cloneResult.[[Value]]).

--- a/components/script/dom/window.rs
+++ b/components/script/dom/window.rs
@@ -2389,7 +2389,7 @@ impl Window {
         transfer: CustomAutoRooterGuard<Vec<*mut JSObject>>,
     ) -> ErrorResult {
         // Step 1-2, 6-8.
-        let data = structuredclone::write(cx, message, Some(transfer))?;
+        let data = structuredclone::write(self.global(), message, Some(transfer))?;
 
         // Step 3-5.
         let target_origin = match target_origin.0[..].as_ref() {

--- a/components/script/dom/workers/dedicatedworkerglobalscope.rs
+++ b/components/script/dom/workers/dedicatedworkerglobalscope.rs
@@ -704,7 +704,7 @@ impl DedicatedWorkerGlobalScope {
         message: HandleValue,
         transfer: CustomAutoRooterGuard<Vec<*mut JSObject>>,
     ) -> ErrorResult {
-        let data = structuredclone::write(cx.into(), message, Some(transfer))?;
+        let data = structuredclone::write(self.global(), message, Some(transfer))?;
         let worker = self.worker.borrow().as_ref().unwrap().clone();
         let global_scope = self.upcast::<GlobalScope>();
         let pipeline_id = global_scope.pipeline_id();

--- a/components/script/dom/workers/serviceworker.rs
+++ b/components/script/dom/workers/serviceworker.rs
@@ -104,7 +104,7 @@ impl ServiceWorker {
             return Err(Error::InvalidState(None));
         }
         // Step 7
-        let data = structuredclone::write(cx.into(), message, Some(transfer))?;
+        let data = structuredclone::write(self.global(), message, Some(transfer))?;
         let incumbent = GlobalScope::incumbent().expect("no incumbent global?");
         let msg_vec = DOMMessage {
             origin: incumbent.origin().immutable().clone(),

--- a/components/script/dom/workers/worker.rs
+++ b/components/script/dom/workers/worker.rs
@@ -144,7 +144,7 @@ impl Worker {
         message: HandleValue,
         transfer: CustomAutoRooterGuard<Vec<*mut JSObject>>,
     ) -> ErrorResult {
-        let data = structuredclone::write(cx.into(), message, Some(transfer))?;
+        let data = structuredclone::write(self.global(), message, Some(transfer))?;
         let address = Trusted::new(self);
 
         // NOTE: step 9 of https://html.spec.whatwg.org/multipage/#dom-messageport-postmessage

--- a/components/script/indexeddb.rs
+++ b/components/script/indexeddb.rs
@@ -190,7 +190,7 @@ pub fn convert_value_to_key(
 
             if IsArrayBufferObject(*object) || JS_IsArrayBufferViewObject(*object) {
                 // FIXME:(arihant2math) implement it the correct way (is this correct?)
-                let key = structuredclone::write(cx.into(), input, None)?;
+                let key = structuredclone::write(self.global(), input, None)?;
                 return Ok(ConversionResult::Valid(IndexedDBKeyType::Binary(
                     key.serialized.clone(),
                 )));


### PR DESCRIPTION
This adds a safe wrapper for structured clone writing that obtains the
JSContext internally instead of requiring callers to pass it.

The existing write_DO_NOT_MERGE function is left unchanged.
