### PR TITLE
IndexedDB: correct the expected result for a test set

### DIFF
--- a/tests/wpt/meta/IndexedDB/idbobjectstore_createIndex.any.js.ini
+++ b/tests/wpt/meta/IndexedDB/idbobjectstore_createIndex.any.js.ini
@@ -1,5 +1,5 @@
 [idbobjectstore_createIndex.any.worker.html]
-  expected: ERROR
+  expected: TIMEOUT
   [Returns an IDBIndex and the properties are set correctly]
     expected: FAIL
 
@@ -30,14 +30,8 @@
   [If keyPath is not a valid key path, the implementation must throw a DOMException of type SyntaxError]
     expected: FAIL
 
-  [If the object store has been deleted, the implementation must throw a DOMException of type InvalidStateError]
-
-
   [InvalidStateError(Incorrect mode) vs. TransactionInactiveError. Mode check should precede state check of the transaction.]
     expected: TIMEOUT
-
-  [InvalidStateError(Deleted ObjectStore) vs. TransactionInactiveError. Deletion check should precede transaction-state check.]
-
 
   [SyntaxError vs. InvalidAccessError. Syntax check should precede multiEntry check of the key path.]
     expected: FAIL
@@ -90,14 +84,8 @@
   [If keyPath is not a valid key path, the implementation must throw a DOMException of type SyntaxError]
     expected: FAIL
 
-  [If the object store has been deleted, the implementation must throw a DOMException of type InvalidStateError]
-
-
   [InvalidStateError(Incorrect mode) vs. TransactionInactiveError. Mode check should precede state check of the transaction.]
     expected: TIMEOUT
-
-  [InvalidStateError(Deleted ObjectStore) vs. TransactionInactiveError. Deletion check should precede transaction-state check.]
-
 
   [SyntaxError vs. InvalidAccessError. Syntax check should precede multiEntry check of the key path.]
     expected: FAIL


### PR DESCRIPTION
After the changes from #42443, there are no longer any unhandled errors in the`idbobjectstore_createIndex.any.worker.html` tests, so the result is `TIMEOUT` rather than `ERROR`.

Also remove the now-passing test labels for consistency with other `.ini` files.

Testing: No unexpected results in `idbobjectstore_createIndex.any.worker.html`, the tests now run as expected.
Fixes: #42445
