### PR TITLE
serviceworker: Stub out window client

### DIFF
--- a/components/script/dom/mod.rs
+++ b/components/script/dom/mod.rs
@@ -450,6 +450,8 @@ pub(crate) use self::webvtt::*;
 pub(crate) mod wheelevent;
 #[expect(dead_code)]
 pub(crate) mod window;
+pub(crate) mod windowclient;
+#[expect(dead_code)]
 pub(crate) mod windowproxy;
 pub(crate) mod workers;
 pub(crate) use self::workers::*;

--- a/components/script/dom/windowclient.rs
+++ b/components/script/dom/windowclient.rs
@@ -1,0 +1,33 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+use std::rc::Rc;
+
+use dom_struct::dom_struct;
+use script_bindings::codegen::GenericBindings::WindowClientBinding::WindowClientMethods;
+use script_bindings::script_runtime::CanGc;
+use script_bindings::str::USVString;
+
+use crate::dom::bindings::reflector::DomGlobal;
+use crate::dom::client::Client;
+use crate::dom::promise::Promise;
+
+#[dom_struct]
+pub(crate) struct WindowClient {
+    client: Client,
+}
+
+impl WindowClientMethods<crate::DomTypeHolder> for WindowClient {
+    /// <https://w3c.github.io/ServiceWorker/#dom-windowclient-focus>
+    fn Focus(&self) -> Rc<Promise> {
+        // TODO: Implement
+        Promise::new(&self.global(), CanGc::note())
+    }
+
+    /// <https://w3c.github.io/ServiceWorker/#dom-windowclient-navigate>
+    fn Navigate(&self, _url: USVString) -> Rc<Promise> {
+        // TODO: Implement
+        Promise::new(&self.global(), CanGc::note())
+    }
+}

--- a/components/script_bindings/webidls/Client.webidl
+++ b/components/script_bindings/webidls/Client.webidl
@@ -9,7 +9,8 @@ interface Client {
   readonly attribute USVString url;
   readonly attribute FrameType frameType;
   readonly attribute DOMString id;
-  //void postMessage(any message, optional sequence<Transferable> transfer);
+  // undefined postMessage(any message, sequence<object> transfer);
+  // undefined postMessage(any message, optional StructuredSerializeOptions options = {});
 };
 
 enum FrameType {

--- a/components/script_bindings/webidls/WindowClient.webidl
+++ b/components/script_bindings/webidls/WindowClient.webidl
@@ -1,0 +1,14 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+// https://w3c.github.io/ServiceWorker/#windowclient
+
+[Pref="dom_serviceworker_enabled", Exposed=ServiceWorker]
+interface WindowClient : Client {
+  // readonly attribute VisibilityState visibilityState;
+  // readonly attribute boolean focused;
+  // [SameObject] readonly attribute FrozenArray<USVString> any ancestorOrigins;
+  [NewObject] Promise<WindowClient> focus();
+  [NewObject] Promise<WindowClient?> navigate(USVString url);
+};


### PR DESCRIPTION
Previously #40889. Since this doesn't cause timeouts it should make sense to upstream this to main.

`WindowClient` is used to represent a globalscope that represents a window as a source in ExtendableMessageEvent. We don't actually need any of the methods other than `postMessage` for WPT to pass/not timeout, so I've commented/stubbed them out for now.

Testing: WPT
Fixes: Partially #40781