### PR TITLE
libservo: Remove implicit unit tests entries from `Cargo.toml`

### DIFF
--- a/components/servo/Cargo.toml
+++ b/components/servo/Cargo.toml
@@ -156,25 +156,5 @@ tracing = { workspace = true }
 winit = { workspace = true }
 
 [[test]]
-name = "largest_contentful_paint"
-path = "tests/largest_contentful_paint.rs"
-
-[[test]]
-name = "performance_paint_timing"
-path = "tests/performance_paint_timing.rs"
-
-[[test]]
-name = "network_manager"
-
-[[test]]
-name = "webview"
-
-[[test]]
-name = "servo"
-
-[[test]]
-name = "site_data_manager"
-
-[[test]]
 name = "multiprocess"
 harness = false


### PR DESCRIPTION
Tests are implicitly detected by `cargo`. So, it is not required to mention them unless required custom requirments. 

Testing: Existing Unit Tests Passed.
