### PR TITLE
layout: Store a fallback cache in the `FontGroup`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8222,7 +8222,7 @@ dependencies = [
 [[package]]
 name = "selectors"
 version = "0.35.0"
-source = "git+https://github.com/servo/stylo?rev=1f465de23efeb8ad7e981b2d36638263e13f16bb#1f465de23efeb8ad7e981b2d36638263e13f16bb"
+source = "git+https://github.com/servo/stylo?rev=e9f0252a0ac851e8185d825668630d6b627fc5ee#e9f0252a0ac851e8185d825668630d6b627fc5ee"
 dependencies = [
  "bitflags 2.10.0",
  "cssparser",
@@ -8537,7 +8537,7 @@ dependencies = [
 [[package]]
 name = "servo_arc"
 version = "0.4.3"
-source = "git+https://github.com/servo/stylo?rev=1f465de23efeb8ad7e981b2d36638263e13f16bb#1f465de23efeb8ad7e981b2d36638263e13f16bb"
+source = "git+https://github.com/servo/stylo?rev=e9f0252a0ac851e8185d825668630d6b627fc5ee#e9f0252a0ac851e8185d825668630d6b627fc5ee"
 dependencies = [
  "serde",
  "stable_deref_trait",
@@ -9086,7 +9086,7 @@ dependencies = [
 [[package]]
 name = "stylo"
 version = "0.12.0"
-source = "git+https://github.com/servo/stylo?rev=1f465de23efeb8ad7e981b2d36638263e13f16bb#1f465de23efeb8ad7e981b2d36638263e13f16bb"
+source = "git+https://github.com/servo/stylo?rev=e9f0252a0ac851e8185d825668630d6b627fc5ee#e9f0252a0ac851e8185d825668630d6b627fc5ee"
 dependencies = [
  "app_units",
  "arrayvec",
@@ -9143,7 +9143,7 @@ dependencies = [
 [[package]]
 name = "stylo_atoms"
 version = "0.12.0"
-source = "git+https://github.com/servo/stylo?rev=1f465de23efeb8ad7e981b2d36638263e13f16bb#1f465de23efeb8ad7e981b2d36638263e13f16bb"
+source = "git+https://github.com/servo/stylo?rev=e9f0252a0ac851e8185d825668630d6b627fc5ee#e9f0252a0ac851e8185d825668630d6b627fc5ee"
 dependencies = [
  "string_cache",
  "string_cache_codegen",
@@ -9152,12 +9152,12 @@ dependencies = [
 [[package]]
 name = "stylo_config"
 version = "0.12.0"
-source = "git+https://github.com/servo/stylo?rev=1f465de23efeb8ad7e981b2d36638263e13f16bb#1f465de23efeb8ad7e981b2d36638263e13f16bb"
+source = "git+https://github.com/servo/stylo?rev=e9f0252a0ac851e8185d825668630d6b627fc5ee#e9f0252a0ac851e8185d825668630d6b627fc5ee"
 
 [[package]]
 name = "stylo_derive"
 version = "0.12.0"
-source = "git+https://github.com/servo/stylo?rev=1f465de23efeb8ad7e981b2d36638263e13f16bb#1f465de23efeb8ad7e981b2d36638263e13f16bb"
+source = "git+https://github.com/servo/stylo?rev=e9f0252a0ac851e8185d825668630d6b627fc5ee#e9f0252a0ac851e8185d825668630d6b627fc5ee"
 dependencies = [
  "darling",
  "proc-macro2",
@@ -9169,7 +9169,7 @@ dependencies = [
 [[package]]
 name = "stylo_dom"
 version = "0.12.0"
-source = "git+https://github.com/servo/stylo?rev=1f465de23efeb8ad7e981b2d36638263e13f16bb#1f465de23efeb8ad7e981b2d36638263e13f16bb"
+source = "git+https://github.com/servo/stylo?rev=e9f0252a0ac851e8185d825668630d6b627fc5ee#e9f0252a0ac851e8185d825668630d6b627fc5ee"
 dependencies = [
  "bitflags 2.10.0",
  "stylo_malloc_size_of",
@@ -9178,7 +9178,7 @@ dependencies = [
 [[package]]
 name = "stylo_malloc_size_of"
 version = "0.12.0"
-source = "git+https://github.com/servo/stylo?rev=1f465de23efeb8ad7e981b2d36638263e13f16bb#1f465de23efeb8ad7e981b2d36638263e13f16bb"
+source = "git+https://github.com/servo/stylo?rev=e9f0252a0ac851e8185d825668630d6b627fc5ee#e9f0252a0ac851e8185d825668630d6b627fc5ee"
 dependencies = [
  "app_units",
  "cssparser",
@@ -9195,7 +9195,7 @@ dependencies = [
 [[package]]
 name = "stylo_static_prefs"
 version = "0.12.0"
-source = "git+https://github.com/servo/stylo?rev=1f465de23efeb8ad7e981b2d36638263e13f16bb#1f465de23efeb8ad7e981b2d36638263e13f16bb"
+source = "git+https://github.com/servo/stylo?rev=e9f0252a0ac851e8185d825668630d6b627fc5ee#e9f0252a0ac851e8185d825668630d6b627fc5ee"
 dependencies = [
  "stylo_config",
 ]
@@ -9203,7 +9203,7 @@ dependencies = [
 [[package]]
 name = "stylo_traits"
 version = "0.12.0"
-source = "git+https://github.com/servo/stylo?rev=1f465de23efeb8ad7e981b2d36638263e13f16bb#1f465de23efeb8ad7e981b2d36638263e13f16bb"
+source = "git+https://github.com/servo/stylo?rev=e9f0252a0ac851e8185d825668630d6b627fc5ee#e9f0252a0ac851e8185d825668630d6b627fc5ee"
 dependencies = [
  "app_units",
  "bitflags 2.10.0",
@@ -9625,7 +9625,7 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 [[package]]
 name = "to_shmem"
 version = "0.3.0"
-source = "git+https://github.com/servo/stylo?rev=1f465de23efeb8ad7e981b2d36638263e13f16bb#1f465de23efeb8ad7e981b2d36638263e13f16bb"
+source = "git+https://github.com/servo/stylo?rev=e9f0252a0ac851e8185d825668630d6b627fc5ee#e9f0252a0ac851e8185d825668630d6b627fc5ee"
 dependencies = [
  "cssparser",
  "servo_arc",
@@ -9638,7 +9638,7 @@ dependencies = [
 [[package]]
 name = "to_shmem_derive"
 version = "0.1.0"
-source = "git+https://github.com/servo/stylo?rev=1f465de23efeb8ad7e981b2d36638263e13f16bb#1f465de23efeb8ad7e981b2d36638263e13f16bb"
+source = "git+https://github.com/servo/stylo?rev=e9f0252a0ac851e8185d825668630d6b627fc5ee#e9f0252a0ac851e8185d825668630d6b627fc5ee"
 dependencies = [
  "darling",
  "proc-macro2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -168,7 +168,7 @@ script_traits = { path = "components/shared/script" }
 sea-query = { version = "1.0.0-rc.31", default-features = false, features = ["backend-sqlite", "derive"] }
 sea-query-rusqlite = { version = "0.8.0-rc.15" }
 sec1 = "0.7"
-selectors = { git = "https://github.com/servo/stylo", rev = "1f465de23efeb8ad7e981b2d36638263e13f16bb" }
+selectors = { git = "https://github.com/servo/stylo", rev = "e9f0252a0ac851e8185d825668630d6b627fc5ee" }
 serde = "1.0.228"
 serde_bytes = "0.11"
 serde_core = "1.0.226"
@@ -177,7 +177,7 @@ servo-media = { path = "components/media/servo-media" }
 servo-media-dummy = { path = "components/media/backends/dummy" }
 servo-media-gstreamer = { path = "components/media/backends/gstreamer" }
 servo-tracing = { path = "components/servo_tracing" }
-servo_arc = { git = "https://github.com/servo/stylo", rev = "1f465de23efeb8ad7e981b2d36638263e13f16bb" }
+servo_arc = { git = "https://github.com/servo/stylo", rev = "e9f0252a0ac851e8185d825668630d6b627fc5ee" }
 sha1 = "0.10"
 sha2 = "0.10"
 sha3 = "0.10"
@@ -186,12 +186,12 @@ smallvec = { version = "1.15", features = ["serde", "union"] }
 storage_traits = { path = "components/shared/storage" }
 string_cache = "0.9"
 strum = { version = "0.27", features = ["derive"] }
-stylo = { git = "https://github.com/servo/stylo", rev = "1f465de23efeb8ad7e981b2d36638263e13f16bb" }
-stylo_atoms = { git = "https://github.com/servo/stylo", rev = "1f465de23efeb8ad7e981b2d36638263e13f16bb" }
-stylo_config = { git = "https://github.com/servo/stylo", rev = "1f465de23efeb8ad7e981b2d36638263e13f16bb" }
-stylo_dom = { git = "https://github.com/servo/stylo", rev = "1f465de23efeb8ad7e981b2d36638263e13f16bb" }
-stylo_malloc_size_of = { git = "https://github.com/servo/stylo", rev = "1f465de23efeb8ad7e981b2d36638263e13f16bb" }
-stylo_traits = { git = "https://github.com/servo/stylo", rev = "1f465de23efeb8ad7e981b2d36638263e13f16bb" }
+stylo = { git = "https://github.com/servo/stylo", rev = "e9f0252a0ac851e8185d825668630d6b627fc5ee" }
+stylo_atoms = { git = "https://github.com/servo/stylo", rev = "e9f0252a0ac851e8185d825668630d6b627fc5ee" }
+stylo_config = { git = "https://github.com/servo/stylo", rev = "e9f0252a0ac851e8185d825668630d6b627fc5ee" }
+stylo_dom = { git = "https://github.com/servo/stylo", rev = "e9f0252a0ac851e8185d825668630d6b627fc5ee" }
+stylo_malloc_size_of = { git = "https://github.com/servo/stylo", rev = "e9f0252a0ac851e8185d825668630d6b627fc5ee" }
+stylo_traits = { git = "https://github.com/servo/stylo", rev = "e9f0252a0ac851e8185d825668630d6b627fc5ee" }
 surfman = { version = "0.11.0", features = ["chains"] }
 syn = { version = "2", default-features = false, features = ["clone-impls", "derive", "parsing"] }
 synstructure = "0.13"

--- a/components/fonts/lib.rs
+++ b/components/fonts/lib.rs
@@ -30,6 +30,7 @@ pub(crate) use glyph::*;
 pub use glyph::{GlyphInfo, GlyphStore};
 pub use platform::font_list::fallback_font_families;
 pub(crate) use shapers::*;
+use style::values::computed::XLang;
 pub use system_font_service::SystemFontService;
 use unicode_properties::{EmojiStatus, UnicodeEmoji, emoji};
 
@@ -46,8 +47,7 @@ pub(crate) enum EmojiPresentationPreference {
 pub struct FallbackFontSelectionOptions {
     pub(crate) character: char,
     pub(crate) presentation_preference: EmojiPresentationPreference,
-    #[cfg_attr(any(target_os = "android", target_os = "windows"), expect(dead_code))]
-    pub(crate) lang: Option<String>,
+    pub(crate) lang: XLang,
 }
 
 impl Default for FallbackFontSelectionOptions {
@@ -55,13 +55,13 @@ impl Default for FallbackFontSelectionOptions {
         Self {
             character: ' ',
             presentation_preference: EmojiPresentationPreference::None,
-            lang: None,
+            lang: XLang::get_initial_value(),
         }
     }
 }
 
 impl FallbackFontSelectionOptions {
-    pub(crate) fn new(character: char, next_character: Option<char>, lang: Option<String>) -> Self {
+    pub(crate) fn new(character: char, next_character: Option<char>, lang: XLang) -> Self {
         let presentation_preference = match next_character {
             Some(next_character) if emoji::is_emoji_presentation_selector(next_character) => {
                 EmojiPresentationPreference::Emoji

--- a/components/fonts/platform/freetype/font_list.rs
+++ b/components/fonts/platform/freetype/font_list.rs
@@ -24,7 +24,7 @@ use libc::{c_char, c_int};
 use log::debug;
 use style::Atom;
 use style::values::computed::font::GenericFontFamily;
-use style::values::computed::{FontStretch, FontStyle, FontWeight};
+use style::values::computed::{FontStretch, FontStyle, FontWeight, XLang};
 use unicode_script::Script;
 
 use crate::font::map_platform_values_to_style_values;
@@ -188,13 +188,13 @@ pub fn fallback_font_families(options: FallbackFontSelectionOptions) -> Vec<&'st
             // In Japanese typography, it is not common to use different fonts
             // for Kanji(Han), Hiragana, and Katakana within the same document.
             // We uniformly fallback to Japanese fonts when the document language is Japanese.
-            _ if options.lang == Some(String::from("ja")) => {
+            _ if options.lang == XLang(Atom::from("ja")) => {
                 families.push("TakaoPGothic");
             },
             _ if matches!(
                 Script::from(options.character),
                 Script::Bopomofo | Script::Han
-            ) && options.lang != Some(String::from("ja")) =>
+            ) && options.lang != XLang(Atom::from("ja")) =>
             {
                 families.push("WenQuanYi Micro Hei");
             },

--- a/components/fonts/platform/macos/font_list.rs
+++ b/components/fonts/platform/macos/font_list.rs
@@ -13,6 +13,7 @@ use objc2_core_text::{
     kCTFontNameAttribute, kCTFontTraitsAttribute, kCTFontURLAttribute,
 };
 use style::Atom;
+use style::values::computed::XLang;
 use style::values::computed::font::GenericFontFamily;
 use unicode_script::Script;
 
@@ -131,7 +132,7 @@ pub fn fallback_font_families(options: FallbackFontSelectionOptions) -> Vec<&'st
             // In Japanese typography, it is not common to use different fonts
             // for Kanji(Han), Hiragana, and Katakana within the same document. Since Hiragino supports
             // a comprehensive set of Japanese kanji, we uniformly fallback to Hiragino for all Japanese text.
-            _ if options.lang == Some(String::from("ja")) => {
+            _ if options.lang == XLang(Atom::from("ja")) => {
                 families.push("Hiragino Sans");
                 families.push("Hiragino Kaku Gothic ProN");
             },
@@ -140,7 +141,7 @@ pub fn fallback_font_families(options: FallbackFontSelectionOptions) -> Vec<&'st
             // language font to try for fallback is rather arbitrary. Usually, though,
             // we hope that font prefs will have handled this earlier.
             _ if matches!(script, Script::Bopomofo | Script::Han) &&
-                options.lang != Some(String::from("ja")) =>
+                options.lang != XLang(Atom::from("ja")) =>
             {
                 // TODO: Need to differentiate between traditional and simplified Han here!
                 families.push("Songti SC");

--- a/components/fonts/tests/font_context.rs
+++ b/components/fonts/tests/font_context.rs
@@ -30,6 +30,7 @@ mod font_context {
     use style::computed_values::font_optical_sizing::T as FontOpticalSizing;
     use style::properties::longhands::font_variant_caps::computed_value::T as FontVariantCaps;
     use style::properties::style_structs::Font as FontStyleStruct;
+    use style::values::computed::XLang;
     use style::values::computed::font::{
         FamilyName, FontFamily, FontFamilyList, FontFamilyNameSyntax, FontStretch, FontStyle,
         FontSynthesis, FontWeight, SingleFontFamily,
@@ -263,7 +264,7 @@ mod font_context {
         let group = context.context.font_group(ServoArc::new(style));
 
         let font = group
-            .find_by_codepoint(&mut context.context, 'a', None, None, None)
+            .find_by_codepoint(&mut context.context, 'a', None, XLang::get_initial_value())
             .unwrap();
         assert_eq!(&font_face_name(&font.identifier()), "csstest-ascii");
         assert_eq!(
@@ -276,7 +277,7 @@ mod font_context {
         );
 
         let font = group
-            .find_by_codepoint(&mut context.context, 'a', None, None, None)
+            .find_by_codepoint(&mut context.context, 'a', None, XLang::get_initial_value())
             .unwrap();
         assert_eq!(&font_face_name(&font.identifier()), "csstest-ascii");
         assert_eq!(
@@ -289,7 +290,7 @@ mod font_context {
         );
 
         let font = group
-            .find_by_codepoint(&mut context.context, 'á', None, None, None)
+            .find_by_codepoint(&mut context.context, 'á', None, XLang::get_initial_value())
             .unwrap();
         assert_eq!(&font_face_name(&font.identifier()), "csstest-basic-regular");
         assert_eq!(
@@ -312,7 +313,7 @@ mod font_context {
         let group = context.context.font_group(ServoArc::new(style));
 
         let font = group
-            .find_by_codepoint(&mut context.context, 'a', None, None, None)
+            .find_by_codepoint(&mut context.context, 'a', None, XLang::get_initial_value())
             .unwrap();
         assert_eq!(
             &font_face_name(&font.identifier()),
@@ -321,7 +322,7 @@ mod font_context {
         );
 
         let font = group
-            .find_by_codepoint(&mut context.context, 'á', None, None, None)
+            .find_by_codepoint(&mut context.context, 'á', None, XLang::get_initial_value())
             .unwrap();
         assert_eq!(
             &font_face_name(&font.identifier()),

--- a/components/layout/flow/inline/text_run.rs
+++ b/components/layout/flow/inline/text_run.rs
@@ -485,6 +485,7 @@ impl TextRun {
         let mut current: Option<TextRunSegment> = None;
         let mut results = Vec::new();
 
+        let lang = parent_style.get_font()._x_lang.clone();
         let text_run_text = &formatting_context_text[self.text_range.clone()];
         let char_iterator = TwoCharsAtATimeIterator::new(text_run_text.chars());
 
@@ -509,22 +510,12 @@ impl TextRun {
             // at the bottom of the list.
             let script = Script::from(character);
             let bidi_level = bidi_info.levels[current_byte_index];
-            let current_font = current.as_ref().and_then(|text_run_segment| {
-                if text_run_segment.bidi_level == bidi_level && text_run_segment.script == script {
-                    Some(text_run_segment.font.clone())
-                } else {
-                    None
-                }
-            });
-
-            let lang = parent_style.get_font()._x_lang.clone();
 
             let Some(font) = font_group.find_by_codepoint(
                 &layout_context.font_context,
                 character,
                 next_character,
-                current_font,
-                Some(lang.0.as_ref().to_string()),
+                lang.clone(),
             ) else {
                 continue;
             };

--- a/components/layout/layout_impl.rs
+++ b/components/layout/layout_impl.rs
@@ -74,7 +74,7 @@ use style::stylist::Stylist;
 use style::traversal::DomTraversal;
 use style::traversal_flags::TraversalFlags;
 use style::values::computed::font::GenericFontFamily;
-use style::values::computed::{CSSPixelLength, FontSize, Length, NonNegativeLength};
+use style::values::computed::{CSSPixelLength, FontSize, Length, NonNegativeLength, XLang};
 use style::values::specified::font::{KeywordInfo, QueryFontMetricsFlags};
 use style::values::{Parser, SourceLocation};
 use style::{Zero, driver};
@@ -1547,7 +1547,7 @@ impl FontMetricsProvider for LayoutFontMetricsProvider {
             .zero_horizontal_advance
             .or_else(|| {
                 font_group
-                    .find_by_codepoint(font_context, '0', None, None, None)?
+                    .find_by_codepoint(font_context, '0', None, XLang::get_initial_value())?
                     .metrics
                     .zero_horizontal_advance
             })
@@ -1557,7 +1557,7 @@ impl FontMetricsProvider for LayoutFontMetricsProvider {
             .ic_horizontal_advance
             .or_else(|| {
                 font_group
-                    .find_by_codepoint(font_context, '\u{6C34}', None, None, None)?
+                    .find_by_codepoint(font_context, '\u{6C34}', None, XLang::get_initial_value())?
                     .metrics
                     .ic_horizontal_advance
             })

--- a/components/malloc_size_of/lib.rs
+++ b/components/malloc_size_of/lib.rs
@@ -1289,6 +1289,7 @@ malloc_size_of_is_stylo_malloc_size_of!(style::values::computed::font::SingleFon
 malloc_size_of_is_stylo_malloc_size_of!(style::values::specified::align::AlignFlags);
 malloc_size_of_is_stylo_malloc_size_of!(style::values::specified::box_::Overflow);
 malloc_size_of_is_stylo_malloc_size_of!(style::values::specified::font::FontSynthesis);
+malloc_size_of_is_stylo_malloc_size_of!(style::values::specified::font::XLang);
 malloc_size_of_is_stylo_malloc_size_of!(style::values::specified::TextDecorationLine);
 malloc_size_of_is_stylo_malloc_size_of!(stylo_dom::ElementState);
 malloc_size_of_is_stylo_malloc_size_of!(style::computed_values::font_optical_sizing::T);

--- a/components/script/dom/canvas/2d/canvas_state.rs
+++ b/components/script/dom/canvas/2d/canvas_state.rs
@@ -33,6 +33,7 @@ use style::color::{AbsoluteColor, ColorFlags, ColorSpace};
 use style::properties::longhands::font_variant_caps::computed_value::T as FontVariantCaps;
 use style::properties::style_structs::Font;
 use style::stylesheets::CssRuleType;
+use style::values::computed::XLang;
 use style::values::computed::font::FontStyle;
 use style::values::specified::color::Color;
 use style_traits::values::ToCss;
@@ -2344,7 +2345,12 @@ impl CanvasState {
             // TODO: This should ultimately handle emoji variation selectors, but raqote does not yet
             // have support for color glyphs.
             let script = Script::from(character);
-            let font = font_group.find_by_codepoint(font_context, character, None, None, None);
+            let font = font_group.find_by_codepoint(
+                font_context,
+                character,
+                None,
+                XLang::get_initial_value(),
+            );
 
             if !current_text_run.script_and_font_compatible(script, &font) {
                 let previous_text_run = std::mem::replace(

--- a/components/shared/base/unicode_block.rs
+++ b/components/shared/base/unicode_block.rs
@@ -6,7 +6,9 @@
 // Generated via: https://www.unicode.org/Public/UNIDATA/Blocks.txt.
 // $ ./generate-unicode-block.py Blocks.txt > unicode_block.rs
 
-#[derive(Clone, Copy, Debug, PartialEq)]
+use malloc_size_of_derive::MallocSizeOf;
+
+#[derive(Clone, Copy, Debug, Eq, Hash, MallocSizeOf, PartialEq)]
 pub enum UnicodeBlock {
     BasicLatin,
     Latin1Supplement,


### PR DESCRIPTION
Store a list of recently used fallbacks in the `FontGroups`, keyed by
`lang` property and the detected `UnicodeBlock` and `Script` of the
character in question. This should mean that less work is done when
switching between falling back and not falling back. In addition, this
will allow better caching of `FontRef`s that come directly from the
platform font backend -- something necessary for the next generation
font fallback code.

Testing: This should not change rendering output so is covered by existing
tests. It might have a minor affect on performance.
Fixes: This is part of #41426.
