### PR TITLE
libservo: Add `allow_virtual_keyboard` flag for `InputMethodControl`

### DIFF
--- a/components/script/dom/html/htmlinputelement.rs
+++ b/components/script/dom/html/htmlinputelement.rs
@@ -3003,6 +3003,7 @@ impl HTMLInputElement {
                         text: self.Value().to_string(),
                         insertion_point: self.GetSelectionEnd(),
                         multiline: false,
+                        has_sticky_activation: self.owner_window().has_sticky_activation(),
                     }),
                     None,
                 );

--- a/components/script/dom/html/htmlinputelement.rs
+++ b/components/script/dom/html/htmlinputelement.rs
@@ -3003,7 +3003,8 @@ impl HTMLInputElement {
                         text: self.Value().to_string(),
                         insertion_point: self.GetSelectionEnd(),
                         multiline: false,
-                        has_sticky_activation: self.owner_window().has_sticky_activation(),
+                        // We follow chromium's heuristic to show the virtual keyboard only if user had interacted before.
+                        allow_virtual_keyboard: self.owner_window().has_sticky_activation(),
                     }),
                     None,
                 );

--- a/components/script/dom/html/htmltextareaelement.rs
+++ b/components/script/dom/html/htmltextareaelement.rs
@@ -187,7 +187,8 @@ impl HTMLTextAreaElement {
                         text: self.Value().to_string(),
                         insertion_point: self.GetSelectionEnd(),
                         multiline: false,
-                        has_sticky_activation: self.owner_window().has_sticky_activation(),
+                        // We follow chromium's heuristic to show the virtual keyboard only if user had interacted before.
+                        allow_virtual_keyboard: self.owner_window().has_sticky_activation(),
                     }),
                     None,
                 );

--- a/components/script/dom/html/htmltextareaelement.rs
+++ b/components/script/dom/html/htmltextareaelement.rs
@@ -187,6 +187,7 @@ impl HTMLTextAreaElement {
                         text: self.Value().to_string(),
                         insertion_point: self.GetSelectionEnd(),
                         multiline: false,
+                        has_sticky_activation: self.owner_window().has_sticky_activation(),
                     }),
                     None,
                 );

--- a/components/servo/webview.rs
+++ b/components/servo/webview.rs
@@ -723,6 +723,7 @@ impl WebView {
                     insertion_point: input_method_request.insertion_point,
                     position,
                     multiline: input_method_request.multiline,
+                    allow_virtual_keyboard: input_method_request.has_sticky_activation,
                 })
             },
             EmbedderControlRequest::ContextMenu(mut context_menu_request) => {

--- a/components/servo/webview.rs
+++ b/components/servo/webview.rs
@@ -723,7 +723,7 @@ impl WebView {
                     insertion_point: input_method_request.insertion_point,
                     position,
                     multiline: input_method_request.multiline,
-                    allow_virtual_keyboard: input_method_request.has_sticky_activation,
+                    allow_virtual_keyboard: input_method_request.allow_virtual_keyboard,
                 })
             },
             EmbedderControlRequest::ContextMenu(mut context_menu_request) => {

--- a/components/servo/webview_delegate.rs
+++ b/components/servo/webview_delegate.rs
@@ -594,7 +594,7 @@ impl InputMethodControl {
     }
 
     /// Whether the UAs allows virtual keyboard to be shown, we currently allow keyboard to be shown
-    /// onlu if user has interacted with the document.
+    /// only if user has interacted with the document to cause this input method event.
     pub fn allow_virtual_keyboard(&self) -> bool {
         self.allow_virtual_keyboard
     }

--- a/components/servo/webview_delegate.rs
+++ b/components/servo/webview_delegate.rs
@@ -560,6 +560,7 @@ pub struct InputMethodControl {
     pub(crate) insertion_point: Option<u32>,
     pub(crate) position: DeviceIntRect,
     pub(crate) multiline: bool,
+    pub(crate) allow_virtual_keyboard: bool,
 }
 
 impl InputMethodControl {
@@ -590,6 +591,12 @@ impl InputMethodControl {
     /// Whether or not this field is a multiline field.
     pub fn multiline(&self) -> bool {
         self.multiline
+    }
+
+    /// Whether the UAs allows virtual keyboard to be shown, we currently allow keyboard to be shown
+    /// onlu if user has interacted with the document.
+    pub fn allow_virtual_keyboard(&self) -> bool {
+        self.allow_virtual_keyboard
     }
 }
 

--- a/components/servo/webview_delegate.rs
+++ b/components/servo/webview_delegate.rs
@@ -593,8 +593,9 @@ impl InputMethodControl {
         self.multiline
     }
 
-    /// Whether the UAs allows virtual keyboard to be shown, we currently allow keyboard to be shown
-    /// only if user has interacted with the document to cause this input method event.
+    /// Whether the virtual keyboard should be shown for this input method event.
+    /// This is currently true for input method events that happen after the user has
+    /// interacted with page contents via an input event.
     pub fn allow_virtual_keyboard(&self) -> bool {
         self.allow_virtual_keyboard
     }

--- a/components/shared/embedder/embedder_controls.rs
+++ b/components/shared/embedder/embedder_controls.rs
@@ -136,7 +136,7 @@ pub struct InputMethodRequest {
     pub text: String,
     pub insertion_point: Option<u32>,
     pub multiline: bool,
-    pub has_sticky_activation: bool,
+    pub allow_virtual_keyboard: bool,
 }
 
 /// Filter for file selection;

--- a/components/shared/embedder/embedder_controls.rs
+++ b/components/shared/embedder/embedder_controls.rs
@@ -136,6 +136,7 @@ pub struct InputMethodRequest {
     pub text: String,
     pub insertion_point: Option<u32>,
     pub multiline: bool,
+    pub has_sticky_activation: bool,
 }
 
 /// Filter for file selection;

--- a/ports/servoshell/egl/android/mod.rs
+++ b/ports/servoshell/egl/android/mod.rs
@@ -666,7 +666,7 @@ impl HostTrait for HostCallbacks {
         .unwrap();
     }
 
-    fn on_ime_show(&self, control: InputMethodControl) {
+    fn on_ime_show(&self, _: InputMethodControl) {
         let mut env = self.jvm.get_env().unwrap();
         env.call_method(self.callbacks.as_obj(), "onImeShow", "()V", &[])
             .unwrap();

--- a/ports/servoshell/egl/android/mod.rs
+++ b/ports/servoshell/egl/android/mod.rs
@@ -666,7 +666,7 @@ impl HostTrait for HostCallbacks {
         .unwrap();
     }
 
-    fn on_ime_show(&self, _: InputMethodControl) {
+    fn on_ime_show(&self, control: InputMethodControl) {
         let mut env = self.jvm.get_env().unwrap();
         env.call_method(self.callbacks.as_obj(), "onImeShow", "()V", &[])
             .unwrap();

--- a/ports/servoshell/egl/app.rs
+++ b/ports/servoshell/egl/app.rs
@@ -170,8 +170,10 @@ impl PlatformWindow for EmbeddedPlatformWindow {
         let control_id = embedder_control.id();
         match embedder_control {
             EmbedderControl::InputMethod(input_method_control) => {
-                self.visible_input_methods.borrow_mut().push(control_id);
-                self.host.on_ime_show(input_method_control);
+                if input_method_control.allow_virtual_keyboard() {
+                    self.visible_input_methods.borrow_mut().push(control_id);
+                    self.host.on_ime_show(input_method_control);
+                }
             },
             EmbedderControl::SimpleDialog(simple_dialog) => match simple_dialog {
                 SimpleDialog::Alert(alert_dialog) => {


### PR DESCRIPTION
Following the convention of other major UAs of gating the virtual keyboard by certain user activation, adding a flags to let the embedder knows about the user activation. This would be used to determine whether the virtual keyboard needs to be shown or not in android and ohos. 

Testing: Manual testing.
