### PR TITLE
paint: Track `TouchId` in `PendingTouchInputEvent`

### DIFF
--- a/components/paint/touch.rs
+++ b/components/paint/touch.rs
@@ -157,13 +157,13 @@ impl TouchSequenceInfo {
 #[derive(Clone, Copy, Debug, PartialEq)]
 
 pub struct TouchPoint {
-    pub id: TouchId,
+    pub touch_id: TouchId,
     pub point: Point2D<f32, DevicePixel>,
 }
 
 impl TouchPoint {
-    fn new(id: TouchId, point: Point2D<f32, DevicePixel>) -> Self {
-        TouchPoint { id, point }
+    fn new(touch_id: TouchId, point: Point2D<f32, DevicePixel>) -> Self {
+        TouchPoint { touch_id, point }
     }
 }
 
@@ -322,7 +322,7 @@ impl TouchHandler {
         self.touch_sequence_map.get_mut(&sequence_id)
     }
 
-    pub(crate) fn on_touch_down(&mut self, id: TouchId, point: Point2D<f32, DevicePixel>) {
+    pub(crate) fn on_touch_down(&mut self, touch_id: TouchId, point: Point2D<f32, DevicePixel>) {
         // if the current sequence ID does not exist in the map, then it was already handled
         if !self
             .touch_sequence_map
@@ -332,7 +332,7 @@ impl TouchHandler {
         {
             self.current_sequence_id.next();
             debug!("Entered new touch sequence: {:?}", self.current_sequence_id);
-            let active_touch_points = vec![TouchPoint::new(id, point)];
+            let active_touch_points = vec![TouchPoint::new(touch_id, point)];
             self.touch_sequence_map.insert(
                 self.current_sequence_id,
                 TouchSequenceInfo {
@@ -350,7 +350,7 @@ impl TouchHandler {
             let touch_sequence = self.get_current_touch_sequence_mut();
             touch_sequence
                 .active_touch_points
-                .push(TouchPoint::new(id, point));
+                .push(TouchPoint::new(touch_id, point));
             match touch_sequence.active_touch_points.len() {
                 2.. => {
                     touch_sequence.state = MultiTouch;
@@ -418,7 +418,7 @@ impl TouchHandler {
 
     pub(crate) fn on_touch_move(
         &mut self,
-        id: TouchId,
+        touch_id: TouchId,
         point: Point2D<f32, DevicePixel>,
         scale: f32,
     ) -> Option<ScrollZoomEvent> {
@@ -429,7 +429,7 @@ impl TouchHandler {
         let idx = match touch_sequence
             .active_touch_points
             .iter_mut()
-            .position(|t| t.id == id)
+            .position(|t| t.touch_id == touch_id)
         {
             Some(i) => i,
             None => {
@@ -520,7 +520,7 @@ impl TouchHandler {
         action
     }
 
-    pub(crate) fn on_touch_up(&mut self, id: TouchId, point: Point2D<f32, DevicePixel>) {
+    pub(crate) fn on_touch_up(&mut self, touch_id: TouchId, point: Point2D<f32, DevicePixel>) {
         let Some(touch_sequence) = self.try_get_current_touch_sequence_mut() else {
             warn!("Current touch sequence not found");
             return;
@@ -528,7 +528,7 @@ impl TouchHandler {
         let old = match touch_sequence
             .active_touch_points
             .iter()
-            .position(|t| t.id == id)
+            .position(|t| t.touch_id == touch_id)
         {
             Some(i) => Some(touch_sequence.active_touch_points.swap_remove(i).point),
             None => {
@@ -604,7 +604,7 @@ impl TouchHandler {
         );
     }
 
-    pub(crate) fn on_touch_cancel(&mut self, id: TouchId, _point: Point2D<f32, DevicePixel>) {
+    pub(crate) fn on_touch_cancel(&mut self, touch_id: TouchId, _point: Point2D<f32, DevicePixel>) {
         // A similar thing with touch move can happen here where the event is coming from a different webview.
         let Some(touch_sequence) = self.try_get_current_touch_sequence_mut() else {
             return;
@@ -612,7 +612,7 @@ impl TouchHandler {
         match touch_sequence
             .active_touch_points
             .iter()
-            .position(|t| t.id == id)
+            .position(|t| t.touch_id == touch_id)
         {
             Some(i) => {
                 touch_sequence.active_touch_points.swap_remove(i);

--- a/components/paint/touch.rs
+++ b/components/paint/touch.rs
@@ -656,6 +656,7 @@ impl TouchHandler {
     pub(crate) fn add_pending_touch_input_event(
         &self,
         id: InputEventId,
+        touch_id: TouchId,
         event_type: TouchEventType,
     ) {
         self.pending_touch_input_events.borrow_mut().insert(
@@ -663,6 +664,7 @@ impl TouchHandler {
             PendingTouchInputEvent {
                 event_type,
                 sequence_id: self.current_sequence_id,
+                touch_id,
             },
         );
     }
@@ -708,6 +710,8 @@ impl TouchHandler {
 pub(crate) struct PendingTouchInputEvent {
     pub event_type: TouchEventType,
     pub sequence_id: TouchSequenceId,
+    #[expect(unused)]
+    pub touch_id: TouchId,
 }
 
 pub(crate) struct FlingRefreshDriverObserver {

--- a/components/paint/webview_renderer.rs
+++ b/components/paint/webview_renderer.rs
@@ -412,7 +412,7 @@ impl WebViewRenderer {
         // Constellation.
         if cancelable && result {
             self.touch_handler
-                .add_pending_touch_input_event(id, event_type);
+                .add_pending_touch_input_event(id, event.touch_id, event_type);
         }
 
         result
@@ -505,9 +505,11 @@ impl WebViewRenderer {
         pending_touch_input_event: PendingTouchInputEvent,
         result: InputEventResult,
     ) {
+        // TODO: This is gonna be used very soon, for tracking move per touch_id.
         let PendingTouchInputEvent {
             sequence_id,
             event_type,
+            touch_id: _,
         } = pending_touch_input_event;
 
         if result.contains(InputEventResult::DefaultPrevented) {

--- a/components/paint/webview_renderer.rs
+++ b/components/paint/webview_renderer.rs
@@ -443,7 +443,7 @@ impl WebViewRenderer {
         let point = event
             .point
             .as_device_point(self.device_pixels_per_page_pixel());
-        self.touch_handler.on_touch_down(event.id, point);
+        self.touch_handler.on_touch_down(event.touch_id, point);
         self.send_touch_event(render_api, event, id);
     }
 
@@ -452,7 +452,7 @@ impl WebViewRenderer {
             .point
             .as_device_point(self.device_pixels_per_page_pixel());
         let action = self.touch_handler.on_touch_move(
-            event.id,
+            event.touch_id,
             point,
             self.device_pixels_per_page_pixel_not_including_pinch_zoom()
                 .get(),
@@ -487,7 +487,7 @@ impl WebViewRenderer {
         let point = event
             .point
             .as_device_point(self.device_pixels_per_page_pixel());
-        self.touch_handler.on_touch_up(event.id, point);
+        self.touch_handler.on_touch_up(event.touch_id, point);
         self.send_touch_event(render_api, event, id);
     }
 
@@ -495,7 +495,7 @@ impl WebViewRenderer {
         let point = event
             .point
             .as_device_point(self.device_pixels_per_page_pixel());
-        self.touch_handler.on_touch_cancel(event.id, point);
+        self.touch_handler.on_touch_cancel(event.touch_id, point);
         self.send_touch_event(render_api, event, id);
     }
 

--- a/components/script/dom/document_event_handler.rs
+++ b/components/script/dom/document_event_handler.rs
@@ -879,7 +879,7 @@ impl DocumentEventHandler {
             return Default::default();
         };
 
-        let TouchId(identifier) = event.id;
+        let TouchId(identifier) = event.touch_id;
         let event_name = match event.event_type {
             TouchEventType::Down => "touchstart",
             TouchEventType::Move => "touchmove",
@@ -993,7 +993,7 @@ impl DocumentEventHandler {
                 let mut active_touch_points = self.active_touch_points.borrow_mut();
                 match active_touch_points
                     .iter()
-                    .position(|t| t.Identifier() == event.id.0)
+                    .position(|t| t.Identifier() == event.touch_id.0)
                 {
                     Some(i) => {
                         active_touch_points.swap_remove(i);

--- a/components/shared/embedder/input_events.rs
+++ b/components/shared/embedder/input_events.rs
@@ -247,17 +247,17 @@ pub struct TouchId(pub i32);
 #[derive(Clone, Copy, Debug, Deserialize, Serialize)]
 pub struct TouchEvent {
     pub event_type: TouchEventType,
-    pub id: TouchId,
+    pub touch_id: TouchId,
     pub point: WebViewPoint,
     /// cancelable default value is true, once the first move has been processed by script disable it.
     cancelable: bool,
 }
 
 impl TouchEvent {
-    pub fn new(event_type: TouchEventType, id: TouchId, point: WebViewPoint) -> Self {
+    pub fn new(event_type: TouchEventType, touch_id: TouchId, point: WebViewPoint) -> Self {
         TouchEvent {
             event_type,
-            id,
+            touch_id,
             point,
             cancelable: true,
         }


### PR DESCRIPTION
As you can tell from branch name, the initial goal is to add multi-touch support for touchmove.
But things get too messy, so I decide to split into two PRs.

This PR
- Track `TouchId` in `PendingTouchInputEvent`
- Rename `id` to `touch_id` for `TouchId`. This is to make distinction from `id: InputEventId`, 
which became very confusing while implementing the initial goal.

Testing: No behaviour change.
Part of #41923
