### PR TITLE
servoshell: Foward `WindowEvent::Focused` events to egui

### DIFF
--- a/ports/servoshell/desktop/headed_window.rs
+++ b/ports/servoshell/desktop/headed_window.rs
@@ -572,7 +572,6 @@ impl HeadedWindow {
         // Handle the event
         let mut consumed = false;
         match event {
-            WindowEvent::Focused(true) => state.handle_focused(window.clone()),
             WindowEvent::ScaleFactorChanged { scale_factor, .. } => {
                 // Intercept any ScaleFactorChanged events away from EguiGlow::on_window_event, so
                 // we can use our own logic for calculating the scale factor and set egui’s
@@ -630,6 +629,10 @@ impl HeadedWindow {
 
                 if let WindowEvent::Resized(_) = event {
                     self.rebuild_user_interface(&state, &window);
+                }
+
+                if let WindowEvent::Focused(true) = event {
+                    state.handle_focused(window.clone());
                 }
 
                 if response.repaint && *event != WindowEvent::RedrawRequested {


### PR DESCRIPTION
When doing event handling on desktop servoshell, ensure that
`WindowEvent::Focused(true)` is forwarded to egui. This makes it so that
egui knows to show the text cursor in the URL bar input field.

Testing: We currently do not have a way to test visual behavior at this level of servoshell.
Fixes: #42091.
