### PR TITLE
net: Close the control stream of RequestBody to fix resource leak

### DIFF
--- a/components/net/fetch/methods.rs
+++ b/components/net/fetch/methods.rs
@@ -941,11 +941,17 @@ fn handle_allowcert_request(request: &mut Request, context: &FetchContext) -> io
         None => return error("No body found"),
     };
 
-    let stream = body.take_stream();
-    let stream = stream.lock();
+    let stream = body.clone_stream();
+    let mut stream = stream.lock();
     let (body_chan, body_port) = ipc::channel().unwrap();
-    let _ = stream.send(BodyChunkRequest::Connect(body_chan));
-    let _ = stream.send(BodyChunkRequest::Chunk);
+    let Some(chunk_requester) = stream.as_mut() else {
+        log::error!(
+            "Could not send BodyChunkRequest to chunk_requester as stream got already neutered."
+        );
+        return Err(std::io::Error::other("Could not send BodyChunkRequest"));
+    };
+    let _ = chunk_requester.send(BodyChunkRequest::Connect(body_chan));
+    let _ = chunk_requester.send(BodyChunkRequest::Chunk);
     let body_bytes = match body_port.recv().ok() {
         Some(BodyChunkResponse::Chunk(bytes)) => bytes,
         _ => return error("Certificate not sent in a single chunk"),

--- a/components/net/fetch/methods.rs
+++ b/components/net/fetch/methods.rs
@@ -240,6 +240,15 @@ pub async fn fetch_with_cors_cache(
             .retain(|record| record.request_id != request_id);
     }
 
+    if fetch_params.request.mode != RequestMode::Navigate {
+        // Lifecycle: Non-Navigate fetches complete redirect/body replay within this
+        // function, so no later `extract_source()` can occur after this return.
+        // we can close the stream.
+        if let Some(body) = fetch_params.request.body.as_ref() {
+            body.close_stream();
+        }
+    }
+
     // Step 18: Return fetchParams’s controller.
     // TODO: We don't implement fetchParams as defined in the spec
     response

--- a/components/net/fetch/methods.rs
+++ b/components/net/fetch/methods.rs
@@ -27,8 +27,9 @@ use net_traits::http_status::HttpStatus;
 use net_traits::policy_container::{PolicyContainer, RequestPolicyContainer};
 use net_traits::request::{
     BodyChunkRequest, BodyChunkResponse, CredentialsMode, Destination, Initiator,
-    InsecureRequestsPolicy, Origin, ParserMetadata, RedirectMode, Referrer, Request, RequestId,
-    RequestMode, ResponseTainting, is_cors_safelisted_method, is_cors_safelisted_request_header,
+    InsecureRequestsPolicy, Origin, ParserMetadata, RedirectMode, Referrer, Request, RequestBody,
+    RequestId, RequestMode, ResponseTainting, is_cors_safelisted_method,
+    is_cors_safelisted_request_header,
 };
 use net_traits::response::{Response, ResponseBody, ResponseType, TerminationReason};
 use net_traits::{
@@ -126,6 +127,52 @@ impl CancellationListener {
         self.cancelled.store(true, Ordering::Relaxed)
     }
 }
+
+/// Closes the current process request body sender state when the net side fetch invocation ends.
+/// Redirect replay for navigation requests happens in a later fetch invocation with a newly
+/// deserialized "RequestBody", so each invocation owns closing only its local copy.
+pub(crate) struct AutoRequestBodyStreamCloser {
+    body: Option<RequestBody>,
+}
+
+impl AutoRequestBodyStreamCloser {
+    pub(crate) fn new(body: Option<&RequestBody>) -> Self {
+        Self {
+            body: body.cloned(),
+        }
+    }
+
+    pub(crate) fn disarm(&mut self) {
+        self.body = None;
+    }
+}
+
+impl Drop for AutoRequestBodyStreamCloser {
+    fn drop(&mut self) {
+        if let Some(body) = self.body.take() {
+            body.close_stream();
+        }
+    }
+}
+
+/// A manual navigation redirect keeps the same request body alive for a later net side redirect
+/// replay invocation. That later invocation becomes the next lifecycle owner and must close its
+/// local shared sender state once it reaches a terminal response.
+pub(crate) fn transfers_request_body_stream_to_later_manual_redirect(
+    request: &Request,
+    response: &Response,
+) -> bool {
+    request.mode == RequestMode::Navigate &&
+        request.redirect_mode == RedirectMode::Manual &&
+        request.body.is_some() &&
+        !response.is_network_error() &&
+        response
+            .actual_response()
+            .status
+            .try_code()
+            .is_some_and(|status| status.is_redirection())
+}
+
 pub type DoneChannel = Option<(TokioSender<Data>, TokioReceiver<Data>)>;
 
 /// [Fetch](https://fetch.spec.whatwg.org#concept-fetch)
@@ -151,6 +198,11 @@ pub async fn fetch_with_cors_cache(
 ) -> Response {
     // Step 8. Let fetchParams be a new fetch params whose request is request
     let mut fetch_params = FetchParams::new(request);
+    // Each net side fetch invocation owns closing its local deserialized request-body sender state
+    // once this function returns, even if navigation redirect replay later starts a new fetch with
+    // a fresh "RequestBody" copy.
+    let mut request_body_stream_closer =
+        AutoRequestBodyStreamCloser::new(fetch_params.request.body.as_ref());
     let request = &mut fetch_params.request;
 
     // Step 4. Populate request from client given request.
@@ -230,6 +282,10 @@ pub async fn fetch_with_cors_cache(
     // Step 17: Run main fetch given fetchParams.
     let response = main_fetch(&mut fetch_params, cache, false, target, &mut None, context).await;
 
+    if transfers_request_body_stream_to_later_manual_redirect(&fetch_params.request, &response) {
+        request_body_stream_closer.disarm();
+    }
+
     // Mimics <https://fetch.spec.whatwg.org/#done-flag>
     if should_track_in_flight_record {
         context
@@ -238,15 +294,6 @@ pub async fn fetch_with_cors_cache(
             .get_mut(&pipeline_id.expect("Must always set a pipeline ID for keep-alive requests"))
             .expect("Must always have initialized tracked requests before starting fetch")
             .retain(|record| record.request_id != request_id);
-    }
-
-    if fetch_params.request.mode != RequestMode::Navigate {
-        // Lifecycle: Non-Navigate fetches complete redirect/body replay within this
-        // function, so no later `extract_source()` can occur after this return.
-        // we can close the stream.
-        if let Some(body) = fetch_params.request.body.as_ref() {
-            body.close_stream();
-        }
     }
 
     // Step 18: Return fetchParams’s controller.
@@ -955,12 +1002,26 @@ fn handle_allowcert_request(request: &mut Request, context: &FetchContext) -> io
     let (body_chan, body_port) = ipc::channel().unwrap();
     let Some(chunk_requester) = stream.as_mut() else {
         log::error!(
-            "Could not send BodyChunkRequest to chunk_requester as stream got already neutered."
+            "Could not connect to the request body stream because it has already been closed."
         );
         return Err(std::io::Error::other("Could not send BodyChunkRequest"));
     };
-    let _ = chunk_requester.send(BodyChunkRequest::Connect(body_chan));
-    let _ = chunk_requester.send(BodyChunkRequest::Chunk);
+    chunk_requester
+        .send(BodyChunkRequest::Connect(body_chan))
+        .map_err(|error| {
+            log::error!(
+                "Could not connect to the request body stream because it has already been closed: {error}"
+            );
+            std::io::Error::other("Could not connect to request body stream")
+        })?;
+    chunk_requester
+        .send(BodyChunkRequest::Chunk)
+        .map_err(|error| {
+            log::error!(
+                "Could not request the first request body chunk because the body stream has already been closed: {error}"
+            );
+            std::io::Error::other("Could not request request body chunk")
+        })?;
     let body_bytes = match body_port.recv().ok() {
         Some(BodyChunkResponse::Chunk(bytes)) => bytes,
         _ => return error("Certificate not sent in a single chunk"),

--- a/components/net/http_loader.rs
+++ b/components/net/http_loader.rs
@@ -38,6 +38,7 @@ use hyper::body::{Bytes, Frame};
 use hyper::ext::ReasonPhrase;
 use hyper::header::{HeaderName, TRANSFER_ENCODING};
 use hyper_serde::Serde;
+use ipc_channel::IpcError;
 use ipc_channel::ipc::{self, IpcSender};
 use ipc_channel::router::ROUTER;
 use log::{debug, error, info, log_enabled, warn};
@@ -646,6 +647,27 @@ impl BodySink {
     }
 }
 
+fn request_body_stream_closed_error(action: &str) -> NetworkError {
+    NetworkError::Crash(format!(
+        "Request body stream has already been closed while trying to {action}."
+    ))
+}
+
+fn log_request_body_stream_closed(action: &str, error: Option<&IpcError>) {
+    match error {
+        Some(error) => {
+            error!("Request body stream has already been closed while trying to {action}: {error}")
+        },
+        None => error!("Request body stream has already been closed while trying to {action}."),
+    }
+}
+
+fn log_fetch_terminated_send_failure(terminated_with_error: bool, context: &str) {
+    warn!(
+        "Failed to notify request-body stream termination state ({terminated_with_error}) while {context} because the receiver was already dropped."
+    );
+}
+
 #[allow(clippy::too_many_arguments)]
 async fn obtain_response(
     client: &ServoClient,
@@ -700,16 +722,32 @@ async fn obtain_response(
             {
                 let mut lock = chunk_requester.lock();
                 if let Some(chunk_requester) = lock.as_mut() {
-                    let _ = chunk_requester.send(BodyChunkRequest::Connect(body_chan));
+                    if let Err(error) = chunk_requester.send(BodyChunkRequest::Connect(body_chan)) {
+                        log_request_body_stream_closed(
+                            "connect to the request body stream",
+                            Some(&error),
+                        );
+                        return Err(request_body_stream_closed_error(
+                            "connect to the request body stream",
+                        ));
+                    }
 
                     // https://fetch.spec.whatwg.org/#concept-request-transmit-body
                     // Request the first chunk, corresponding to Step 3 and 4.
-                    let _ = chunk_requester.send(BodyChunkRequest::Chunk);
+                    if let Err(error) = chunk_requester.send(BodyChunkRequest::Chunk) {
+                        log_request_body_stream_closed(
+                            "request the first request body chunk",
+                            Some(&error),
+                        );
+                        return Err(request_body_stream_closed_error(
+                            "request the first request body chunk",
+                        ));
+                    }
                 } else {
-                    error!(
-                        "Could not send BodyChunkRequests as chunk requester got already closed."
-                    );
-                    return Err(NetworkError::Crash("Chunk requester wrong".into()));
+                    log_request_body_stream_closed("connect to the request body stream", None);
+                    return Err(request_body_stream_closed_error(
+                        "connect to the request body stream",
+                    ));
                 }
             }
 
@@ -724,7 +762,12 @@ async fn obtain_response(
                         BodyChunkResponse::Chunk(bytes) => bytes,
                         BodyChunkResponse::Done => {
                             // Step 3, abort these parallel steps.
-                            let _ = fetch_terminated.send(false);
+                            if fetch_terminated.send(false).is_err() {
+                                log_fetch_terminated_send_failure(
+                                    false,
+                                    "handling request body completion",
+                                );
+                            }
                             sink.close();
 
                             return;
@@ -733,7 +776,12 @@ async fn obtain_response(
                             // Step 4 and/or 5.
                             // TODO: differentiate between the two steps,
                             // where step 5 requires setting an `aborted` flag on the fetch.
-                            let _ = fetch_terminated.send(true);
+                            if fetch_terminated.send(true).is_err() {
+                                log_fetch_terminated_send_failure(
+                                    true,
+                                    "handling request body stream error",
+                                );
+                            }
                             sink.close();
 
                             return;
@@ -750,9 +798,28 @@ async fn obtain_response(
                     // Request the next chunk.
                     let mut chunk_requester2 = chunk_requester2.lock();
                     if let Some(chunk_requester2) = chunk_requester2.as_mut() {
-                        let _ = chunk_requester2.send(BodyChunkRequest::Chunk);
+                        if let Err(error) = chunk_requester2.send(BodyChunkRequest::Chunk) {
+                            log_request_body_stream_closed(
+                                "request the next request body chunk",
+                                Some(&error),
+                            );
+                            if fetch_terminated.send(true).is_err() {
+                                log_fetch_terminated_send_failure(
+                                    true,
+                                    "handling failure to request the next request body chunk",
+                                );
+                            }
+                            sink.close();
+                        }
                     } else {
-                        error!("Could not send chunk request to closed ChunkRequester.");
+                        log_request_body_stream_closed("request the next request body chunk", None);
+                        if fetch_terminated.send(true).is_err() {
+                            log_fetch_terminated_send_failure(
+                                true,
+                                "handling a closed request body stream while requesting the next chunk",
+                            );
+                        }
+                        sink.close();
                     }
                 }),
             );
@@ -2102,9 +2169,6 @@ async fn http_network_fetch(
             {
                 Ok(response) => response,
                 Err(error) => {
-                    if let Some(body_chunk_request_stream) = request.body.as_ref() {
-                        body_chunk_request_stream.close_stream();
-                    }
                     return Response::network_error(NetworkError::WebsocketConnectionFailure(
                         format!("{error:?}"),
                     ));
@@ -2142,12 +2206,7 @@ async fn http_network_fetch(
             // This will only get the headers, the body is read later
             let (res, msg) = match response_future.await {
                 Ok(wrapped_response) => wrapped_response,
-                Err(error) => {
-                    if let Some(body_chunk_request_stream) = request.body.as_ref() {
-                        body_chunk_request_stream.close_stream();
-                    }
-                    return Response::network_error(error);
-                },
+                Err(error) => return Response::network_error(error),
             };
             (res, msg)
         },
@@ -2163,12 +2222,7 @@ async fn http_network_fetch(
     // Check if there was an error while streaming the request body.
     //
     match fetch_terminated_receiver.recv().await {
-        Some(true) => {
-            if let Some(body_chunk_request_stream) = request.body.as_ref() {
-                body_chunk_request_stream.close_stream();
-            }
-            return Response::network_error(NetworkError::ConnectionFailure);
-        },
+        Some(true) => return Response::network_error(NetworkError::ConnectionFailure),
         Some(false) => {},
         _ => warn!("Failed to receive confirmation request was streamed without error."),
     }
@@ -2241,9 +2295,6 @@ async fn http_network_fetch(
     let devtools_sender = context.devtools_chan.clone();
     let cancellation_listener = context.cancellation_listener.clone();
     if cancellation_listener.cancelled() {
-        if let Some(body_chunk_request_stream) = request.body.as_ref() {
-            body_chunk_request_stream.close_stream();
-        }
         return Response::network_error(NetworkError::LoadCancelled);
     }
 

--- a/components/net/http_loader.rs
+++ b/components/net/http_loader.rs
@@ -707,7 +707,7 @@ async fn obtain_response(
                     let _ = chunk_requester.send(BodyChunkRequest::Chunk);
                 } else {
                     error!(
-                        "Could not send BodyChunkRequests as chunk requester got already neutered."
+                        "Could not send BodyChunkRequests as chunk requester got already closed."
                     );
                     return Err(NetworkError::Crash("Chunk requester wrong".into()));
                 }
@@ -752,7 +752,7 @@ async fn obtain_response(
                     if let Some(chunk_requester2) = chunk_requester2.as_mut() {
                         let _ = chunk_requester2.send(BodyChunkRequest::Chunk);
                     } else {
-                        error!("Could not send chunk request to neutered ChunkRequester.");
+                        error!("Could not send chunk request to closed ChunkRequester.");
                     }
                 }),
             );
@@ -1057,7 +1057,7 @@ pub async fn http_fetch(
     }
 
     if let Some(ref body) = fetch_params.request.body {
-        body.neuter_stream();
+        body.close_stream();
     }
 
     // set back to default
@@ -2107,7 +2107,7 @@ async fn http_network_fetch(
                 Ok(response) => response,
                 Err(error) => {
                     if let Some(body_chunk_request_stream) = request.body.as_ref() {
-                        body_chunk_request_stream.neuter_stream();
+                        body_chunk_request_stream.close_stream();
                     }
                     return Response::network_error(NetworkError::WebsocketConnectionFailure(
                         format!("{error:?}"),
@@ -2148,7 +2148,7 @@ async fn http_network_fetch(
                 Ok(wrapped_response) => wrapped_response,
                 Err(error) => {
                     if let Some(body_chunk_request_stream) = request.body.as_ref() {
-                        body_chunk_request_stream.neuter_stream();
+                        body_chunk_request_stream.close_stream();
                     }
                     return Response::network_error(error);
                 },
@@ -2169,7 +2169,7 @@ async fn http_network_fetch(
     match fetch_terminated_receiver.recv().await {
         Some(true) => {
             if let Some(body_chunk_request_stream) = request.body.as_ref() {
-                body_chunk_request_stream.neuter_stream();
+                body_chunk_request_stream.close_stream();
             }
             return Response::network_error(NetworkError::ConnectionFailure);
         },
@@ -2246,7 +2246,7 @@ async fn http_network_fetch(
     let cancellation_listener = context.cancellation_listener.clone();
     if cancellation_listener.cancelled() {
         if let Some(body_chunk_request_stream) = request.body.as_ref() {
-            body_chunk_request_stream.neuter_stream();
+            body_chunk_request_stream.close_stream();
         }
         return Response::network_error(NetworkError::LoadCancelled);
     }

--- a/components/net/http_loader.rs
+++ b/components/net/http_loader.rs
@@ -652,7 +652,7 @@ async fn obtain_response(
     url: &ServoUrl,
     method: &Method,
     request_headers: &mut HeaderMap,
-    body: Option<StdArc<Mutex<IpcSender<BodyChunkRequest>>>>,
+    body: Option<StdArc<Mutex<Option<IpcSender<BodyChunkRequest>>>>>,
     source_is_null: bool,
     pipeline_id: &Option<PipelineId>,
     request_id: Option<&str>,
@@ -698,12 +698,20 @@ async fn obtain_response(
             let (body_chan, body_port) = ipc::channel().unwrap();
 
             {
-                let requester = chunk_requester.lock();
-                let _ = requester.send(BodyChunkRequest::Connect(body_chan));
+                let mut lock = chunk_requester.lock();
+                if let Some(chunk_requester) = lock.as_mut() {
+                    let _ = chunk_requester.send(BodyChunkRequest::Connect(body_chan));
 
-                // https://fetch.spec.whatwg.org/#concept-request-transmit-body
-                // Request the first chunk, corresponding to Step 3 and 4.
-                let _ = requester.send(BodyChunkRequest::Chunk);
+                    // https://fetch.spec.whatwg.org/#concept-request-transmit-body
+                    // Request the first chunk, corresponding to Step 3 and 4.
+                    let _ = chunk_requester.send(BodyChunkRequest::Chunk);
+                } else {
+                    /*
+                    error!(
+                        "Could not send BodyChunkRequests as chunk requester got already neutered."
+                    )
+                    */
+                }
             }
 
             let devtools_bytes = devtools_bytes.clone();
@@ -741,7 +749,12 @@ async fn obtain_response(
 
                     // Step 5.1.2.3
                     // Request the next chunk.
-                    let _ = chunk_requester2.lock().send(BodyChunkRequest::Chunk);
+                    let mut chunk_requester2 = chunk_requester2.lock();
+                    if let Some(chunk_requester2) = chunk_requester2.as_mut() {
+                        let _ = chunk_requester2.send(BodyChunkRequest::Chunk);
+                    } else {
+                        error!("Could not send chunk request to neutered ChunkRequester.");
+                    }
                 }),
             );
 
@@ -1042,6 +1055,10 @@ pub async fn http_fetch(
                 .await
             },
         };
+    }
+
+    if let Some(ref body) = fetch_params.request.body {
+        body.neuter_stream();
     }
 
     // set back to default
@@ -2044,7 +2061,7 @@ async fn http_network_fetch(
     // The receiver will receive true if there has been an error streaming the request body.
     let (fetch_terminated_sender, mut fetch_terminated_receiver) = unbounded_channel();
 
-    let body = request.body.as_ref().map(|body| body.take_stream());
+    let body = request.body.as_ref().map(|body| body.clone_stream());
 
     if body.is_none() {
         // There cannot be an error streaming a non-existent body.
@@ -2090,6 +2107,9 @@ async fn http_network_fetch(
             {
                 Ok(response) => response,
                 Err(error) => {
+                    if let Some(body_chunk_request_stream) = request.body.as_ref() {
+                        body_chunk_request_stream.neuter_stream();
+                    }
                     return Response::network_error(NetworkError::WebsocketConnectionFailure(
                         format!("{error:?}"),
                     ));
@@ -2127,7 +2147,12 @@ async fn http_network_fetch(
             // This will only get the headers, the body is read later
             let (res, msg) = match response_future.await {
                 Ok(wrapped_response) => wrapped_response,
-                Err(error) => return Response::network_error(error),
+                Err(error) => {
+                    if let Some(body_chunk_request_stream) = request.body.as_ref() {
+                        body_chunk_request_stream.neuter_stream();
+                    }
+                    return Response::network_error(error);
+                },
             };
             (res, msg)
         },
@@ -2144,6 +2169,9 @@ async fn http_network_fetch(
     //
     match fetch_terminated_receiver.recv().await {
         Some(true) => {
+            if let Some(body_chunk_request_stream) = request.body.as_ref() {
+                body_chunk_request_stream.neuter_stream();
+            }
             return Response::network_error(NetworkError::ConnectionFailure);
         },
         Some(false) => {},
@@ -2218,6 +2246,9 @@ async fn http_network_fetch(
     let devtools_sender = context.devtools_chan.clone();
     let cancellation_listener = context.cancellation_listener.clone();
     if cancellation_listener.cancelled() {
+        if let Some(body_chunk_request_stream) = request.body.as_ref() {
+            body_chunk_request_stream.neuter_stream();
+        }
         return Response::network_error(NetworkError::LoadCancelled);
     }
 
@@ -2350,7 +2381,6 @@ async fn http_network_fetch(
 
     // Ensure we don't override "responseEnd" on successful return of this function
     response_end_timer.neuter();
-
     response
 }
 

--- a/components/net/http_loader.rs
+++ b/components/net/http_loader.rs
@@ -706,11 +706,10 @@ async fn obtain_response(
                     // Request the first chunk, corresponding to Step 3 and 4.
                     let _ = chunk_requester.send(BodyChunkRequest::Chunk);
                 } else {
-                    /*
                     error!(
                         "Could not send BodyChunkRequests as chunk requester got already neutered."
-                    )
-                    */
+                    );
+                    return Err(NetworkError::Crash("Chunk requester wrong".into()));
                 }
             }
 

--- a/components/net/http_loader.rs
+++ b/components/net/http_loader.rs
@@ -1056,10 +1056,6 @@ pub async fn http_fetch(
         };
     }
 
-    if let Some(ref body) = fetch_params.request.body {
-        body.close_stream();
-    }
-
     // set back to default
     response.return_internal = true;
     context

--- a/components/net/resource_thread.rs
+++ b/components/net/resource_thread.rs
@@ -60,7 +60,9 @@ use crate::embedder::NetToEmbedderMsg;
 use crate::fetch::cors_cache::CorsCache;
 use crate::fetch::fetch_params::{FetchParams, SharedPreloadedResources};
 use crate::fetch::methods::{
-    CancellationListener, FetchContext, SharedInflightKeepAliveRecords, WebSocketChannel, fetch,
+    AutoRequestBodyStreamCloser, CancellationListener, FetchContext,
+    SharedInflightKeepAliveRecords, WebSocketChannel, fetch,
+    transfers_request_body_stream_to_later_manual_redirect,
 };
 use crate::filemanager_thread::FileManager;
 use crate::hsts::{self, HstsList};
@@ -753,7 +755,9 @@ impl CoreResourceManager {
                     let response = Response::from_init(res_init, timing_type);
 
                     let mut fetch_params = FetchParams::new(request);
-                    http_redirect_fetch(
+                    let mut request_body_stream_closer =
+                        AutoRequestBodyStreamCloser::new(fetch_params.request.body.as_ref());
+                    let response = http_redirect_fetch(
                         &mut fetch_params,
                         &mut CorsCache::default(),
                         response,
@@ -763,6 +767,12 @@ impl CoreResourceManager {
                         &context,
                     )
                     .await;
+                    if transfers_request_body_stream_to_later_manual_redirect(
+                        &fetch_params.request,
+                        &response,
+                    ) {
+                        request_body_stream_closer.disarm();
+                    }
                 },
                 None => {
                     fetch(request, &mut sender, &context).await;

--- a/components/script/script_thread.rs
+++ b/components/script/script_thread.rs
@@ -3111,6 +3111,17 @@ impl ScriptThread {
             unreachable!("Pipeline shouldn't have finished loading.");
         };
 
+        {
+            let loads = self.incomplete_loads.borrow();
+            if let Some(body) = loads[idx].load_data.data.as_ref() {
+                // Lifecycle: Non-Navigate redirects can span multiple net fetch calls.
+                // This hook runs only for terminal (Non-Navigate) navigation responses, so no
+                // later redirect replay can reach `extract_source()`.
+                // we can close the stream.
+                body.close_stream();
+            }
+        }
+
         // https://html.spec.whatwg.org/multipage/#process-a-navigate-response
         // 2. If response's status is 204 or 205, then abort these steps.
         let is_204_205 = match metadata {

--- a/components/script/script_thread.rs
+++ b/components/script/script_thread.rs
@@ -3111,17 +3111,6 @@ impl ScriptThread {
             unreachable!("Pipeline shouldn't have finished loading.");
         };
 
-        {
-            let loads = self.incomplete_loads.borrow();
-            if let Some(body) = loads[idx].load_data.data.as_ref() {
-                // Lifecycle: Non-Navigate redirects can span multiple net fetch calls.
-                // This hook runs only for terminal (Non-Navigate) navigation responses, so no
-                // later redirect replay can reach `extract_source()`.
-                // we can close the stream.
-                body.close_stream();
-            }
-        }
-
         // https://html.spec.whatwg.org/multipage/#process-a-navigate-response
         // 2. If response's status is 204 or 205, then abort these steps.
         let is_204_205 = match metadata {

--- a/components/shared/net/request.rs
+++ b/components/shared/net/request.rs
@@ -359,10 +359,10 @@ impl RequestBody {
         self.body_chunk_request_channel.clone()
     }
 
-    /// This needs to be called the last time the `self.chan` is used to not leak resources.
+    /// This needs to be called the last time the body stream sender is used to not leak resources.
     /// Can be called multiple times.
     pub fn close_stream(&self) {
-        let _ = self.body_chunk_request_channel.lock().take();
+        self.body_chunk_request_channel.lock().take();
     }
 
     pub fn source_is_null(&self) -> bool {

--- a/components/shared/net/request.rs
+++ b/components/shared/net/request.rs
@@ -311,7 +311,7 @@ pub enum BodyChunkRequest {
 }
 
 /// The net component's view into <https://fetch.spec.whatwg.org/#bodies>
-/// After the last call to `extract_source`, `neuter_stream` must be called
+/// After the last call to `extract_source`, `close_stream` must be called
 /// to not leak resources.
 #[derive(Clone, Debug, Deserialize, MallocSizeOf, Serialize)]
 pub struct RequestBody {
@@ -345,7 +345,7 @@ impl RequestBody {
                 let (chan, port) = ipc::channel().unwrap();
                 let mut lock = self.body_chunk_request_channel.lock();
                 let Some(selfchan) = lock.as_mut() else {
-                    error!("Could not extract_source because the stream got already neutered.");
+                    error!("Could not extract_source because the stream already got closed.");
                     return;
                 };
                 let _ = selfchan.send(BodyChunkRequest::Extract(port));
@@ -361,7 +361,7 @@ impl RequestBody {
 
     /// This needs to be called the last time the `self.chan` is used to not leak resources.
     /// Can be called multiple times.
-    pub fn neuter_stream(&self) {
+    pub fn close_stream(&self) {
         let _ = self.body_chunk_request_channel.lock().take();
     }
 

--- a/components/shared/net/request.rs
+++ b/components/shared/net/request.rs
@@ -354,6 +354,7 @@ impl RequestBody {
         }
     }
 
+    /// This is a shared optional sender to request BodyChunks.
     pub fn clone_stream(&self) -> Arc<Mutex<Option<IpcSender<BodyChunkRequest>>>> {
         self.body_chunk_request_channel.clone()
     }

--- a/components/shared/net/request.rs
+++ b/components/shared/net/request.rs
@@ -310,9 +310,11 @@ pub enum BodyChunkRequest {
     Error,
 }
 
-/// The net component's view into <https://fetch.spec.whatwg.org/#bodies>
-/// After the last call to `extract_source`, `close_stream` must be called
-/// to not leak resources.
+/// A process local view into <https://fetch.spec.whatwg.org/#bodies>.
+/// After IPC serialization, each process gets its own shared sender state for the same body
+/// stream. the net side fetch entry points own clearing their local copy once that fetch invocation
+/// reaches its terminal state. Redirect replay can later deserialize a fresh "RequestBody", so
+/// lower level fetch steps cannot always clean up immediately.
 #[derive(Clone, Debug, Deserialize, MallocSizeOf, Serialize)]
 pub struct RequestBody {
     /// Net's channel to communicate with script re this body.
@@ -345,21 +347,30 @@ impl RequestBody {
                 let (chan, port) = ipc::channel().unwrap();
                 let mut lock = self.body_chunk_request_channel.lock();
                 let Some(selfchan) = lock.as_mut() else {
-                    error!("Could not extract_source because the stream already got closed.");
+                    error!(
+                        "Could not re-extract the request body source because the body stream has already been closed."
+                    );
                     return;
                 };
-                let _ = selfchan.send(BodyChunkRequest::Extract(port));
+                if let Err(error) = selfchan.send(BodyChunkRequest::Extract(port)) {
+                    error!(
+                        "Could not re-extract the request body source because the body stream has already been closed: {error}"
+                    );
+                    return;
+                }
                 *selfchan = chan;
             },
         }
     }
 
-    /// This is a shared optional sender to request BodyChunks.
+    /// This is the current process shared optional sender for requesting body chunks.
     pub fn clone_stream(&self) -> Arc<Mutex<Option<IpcSender<BodyChunkRequest>>>> {
         self.body_chunk_request_channel.clone()
     }
 
-    /// This needs to be called the last time the body stream sender is used to not leak resources.
+    /// Clears the current process shared sender state for this "RequestBody" copy.
+    ///
+    /// This does not notify or mutate other deserialized "RequestBody" values in other processes.
     /// Can be called multiple times.
     pub fn close_stream(&self) {
         self.body_chunk_request_channel.lock().take();

--- a/components/shared/net/request.rs
+++ b/components/shared/net/request.rs
@@ -11,6 +11,7 @@ use http::header::{AUTHORIZATION, HeaderName};
 use http::{HeaderMap, Method};
 use ipc_channel::ipc::{self, IpcReceiver, IpcSender};
 use ipc_channel::router::ROUTER;
+use log::error;
 use malloc_size_of_derive::MallocSizeOf;
 use mime::Mime;
 use parking_lot::Mutex;
@@ -310,11 +311,13 @@ pub enum BodyChunkRequest {
 }
 
 /// The net component's view into <https://fetch.spec.whatwg.org/#bodies>
+/// After the last call to `extract_source`, `neuter_stream` must be called
+/// to not leak resources.
 #[derive(Clone, Debug, Deserialize, MallocSizeOf, Serialize)]
 pub struct RequestBody {
     /// Net's channel to communicate with script re this body.
-    #[conditional_malloc_size_of]
-    chan: Arc<Mutex<IpcSender<BodyChunkRequest>>>,
+    #[ignore_malloc_size_of = "Channels are hard"]
+    body_chunk_request_channel: Arc<Mutex<Option<IpcSender<BodyChunkRequest>>>>,
     /// <https://fetch.spec.whatwg.org/#concept-body-source>
     source: BodySource,
     /// <https://fetch.spec.whatwg.org/#concept-body-total-bytes>
@@ -323,12 +326,12 @@ pub struct RequestBody {
 
 impl RequestBody {
     pub fn new(
-        chan: IpcSender<BodyChunkRequest>,
+        body_chunk_request_channel: IpcSender<BodyChunkRequest>,
         source: BodySource,
         total_bytes: Option<usize>,
     ) -> Self {
         RequestBody {
-            chan: Arc::new(Mutex::new(chan)),
+            body_chunk_request_channel: Arc::new(Mutex::new(Some(body_chunk_request_channel))),
             source,
             total_bytes,
         }
@@ -340,15 +343,25 @@ impl RequestBody {
             BodySource::Null => panic!("Null sources should never be re-directed."),
             BodySource::Object => {
                 let (chan, port) = ipc::channel().unwrap();
-                let mut selfchan = self.chan.lock();
+                let mut lock = self.body_chunk_request_channel.lock();
+                let Some(selfchan) = lock.as_mut() else {
+                    error!("Could not extract_source because the stream got already neutered.");
+                    return;
+                };
                 let _ = selfchan.send(BodyChunkRequest::Extract(port));
                 *selfchan = chan;
             },
         }
     }
 
-    pub fn take_stream(&self) -> Arc<Mutex<IpcSender<BodyChunkRequest>>> {
-        self.chan.clone()
+    pub fn clone_stream(&self) -> Arc<Mutex<Option<IpcSender<BodyChunkRequest>>>> {
+        self.body_chunk_request_channel.clone()
+    }
+
+    /// This needs to be called the last time the `self.chan` is used to not leak resources.
+    /// Can be called multiple times.
+    pub fn neuter_stream(&self) {
+        let _ = self.body_chunk_request_channel.lock().take();
     }
 
     pub fn source_is_null(&self) -> bool {


### PR DESCRIPTION
For a network fetch, the body chunk request sender keeps being alive as long as the request is alive. This leads to a big resource leak as this keeps a couple of IpcChannels and SharedMemory around. These would only be cleaned up when the Gc cleans up the Request which can be too long for tight fetch loops.

This gives a method to destroy the channel at the end of the complete fetch (keeping in mind redirects). Currently we have to do this by hand as a simple guard structure did not work correctly.

Additionally, this renames `RequestBody::take_stream` to the correct clone_stream and cleans up some smaller names and documentation.

Testing: WPT should catch anything that is not spec conform.
Fixes: https://github.com/servo/servo/issues/41202
