### PR TITLE
devtools: Implement MallocSizeOf for DevtoolsInstance

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2071,6 +2071,7 @@ dependencies = [
  "headers 0.4.1",
  "http 1.4.0",
  "log",
+ "malloc_size_of_derive",
  "net",
  "net_traits",
  "rand 0.9.2",
@@ -2078,6 +2079,7 @@ dependencies = [
  "serde",
  "serde_json",
  "servo_config",
+ "servo_malloc_size_of",
  "servo_url",
  "uuid",
 ]

--- a/components/devtools/Cargo.toml
+++ b/components/devtools/Cargo.toml
@@ -22,6 +22,8 @@ embedder_traits = { workspace = true }
 headers = { workspace = true }
 http = { workspace = true }
 log = { workspace = true }
+malloc_size_of = { workspace = true }
+malloc_size_of_derive = { workspace = true }
 net = { path = "../net" }
 net_traits = { workspace = true }
 rand = { workspace = true }

--- a/components/devtools/actors/breakpoint.rs
+++ b/components/devtools/actors/breakpoint.rs
@@ -3,6 +3,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 use devtools_traits::DevtoolScriptControlMsg;
+use malloc_size_of_derive::MallocSizeOf;
 use serde::Deserialize;
 use serde_json::Map;
 
@@ -26,6 +27,7 @@ struct BreakpointRequest {
     location: BreakpointRequestLocation,
 }
 
+#[derive(MallocSizeOf)]
 pub(crate) struct BreakpointListActor {
     name: String,
     browsing_context: String,

--- a/components/devtools/actors/browsing_context.rs
+++ b/components/devtools/actors/browsing_context.rs
@@ -17,6 +17,7 @@ use devtools_traits::DevtoolScriptControlMsg::{
 };
 use devtools_traits::{DevtoolsPageInfo, NavigationState};
 use embedder_traits::Theme;
+use malloc_size_of_derive::MallocSizeOf;
 use serde::Serialize;
 use serde_json::{Map, Value};
 
@@ -131,6 +132,7 @@ pub(crate) struct BrowsingContextActorMsg {
 /// The browsing context actor encompasses all of the other supporting actors when debugging a web
 /// view. To this extent, it contains a watcher actor that helps when communicating with the host,
 /// as well as resource actors that each perform one debugging function.
+#[derive(MallocSizeOf)]
 pub(crate) struct BrowsingContextActor {
     name: String,
     pub title: AtomicRefCell<String>,

--- a/components/devtools/actors/console.rs
+++ b/components/devtools/actors/console.rs
@@ -20,6 +20,7 @@ use devtools_traits::{
     ConsoleArgument, ConsoleMessage, ConsoleMessageFields, DevtoolScriptControlMsg, PageError,
     StackFrame, get_time_stamp,
 };
+use malloc_size_of_derive::MallocSizeOf;
 use serde::Serialize;
 use serde_json::{self, Map, Number, Value};
 use uuid::Uuid;
@@ -32,11 +33,12 @@ use crate::protocol::{ClientRequest, JsonPacketStream};
 use crate::resource::{ResourceArrayType, ResourceAvailable};
 use crate::{EmptyReplyMsg, StreamId, UniqueId};
 
-#[derive(Clone, Serialize)]
+#[derive(Clone, Serialize, MallocSizeOf)]
 #[serde(rename_all = "camelCase")]
 pub(crate) struct DevtoolsConsoleMessage {
     #[serde(flatten)]
     fields: ConsoleMessageFields,
+    #[ignore_malloc_size_of = "Currently no way to have serde_json::Value"]
     arguments: Vec<Value>,
     #[serde(skip_serializing_if = "Option::is_none")]
     stacktrace: Option<Vec<StackFrame>>,
@@ -69,7 +71,7 @@ fn console_argument_to_value(argument: ConsoleArgument) -> Value {
     }
 }
 
-#[derive(Clone, Serialize)]
+#[derive(Clone, Serialize, MallocSizeOf)]
 #[serde(rename_all = "camelCase")]
 struct DevtoolsPageError {
     #[serde(flatten)]
@@ -101,7 +103,7 @@ impl From<PageError> for DevtoolsPageError {
         }
     }
 }
-#[derive(Clone, Serialize)]
+#[derive(Clone, Serialize, MallocSizeOf)]
 #[serde(rename_all = "camelCase")]
 pub(crate) struct PageErrorWrapper {
     page_error: DevtoolsPageError,
@@ -115,7 +117,7 @@ impl From<PageError> for PageErrorWrapper {
     }
 }
 
-#[derive(Clone, Serialize)]
+#[derive(Clone, Serialize, MallocSizeOf)]
 #[serde(untagged)]
 pub(crate) enum ConsoleResource {
     ConsoleMessage(DevtoolsConsoleMessage),
@@ -185,11 +187,13 @@ struct SetPreferencesReply {
     updated: Vec<String>,
 }
 
+#[derive(MallocSizeOf)]
 pub(crate) enum Root {
     BrowsingContext(String),
     DedicatedWorker(String),
 }
 
+#[derive(MallocSizeOf)]
 pub(crate) struct ConsoleActor {
     name: String,
     root: Root,

--- a/components/devtools/actors/device.rs
+++ b/components/devtools/actors/device.rs
@@ -2,6 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
+use malloc_size_of_derive::MallocSizeOf;
 use serde::Serialize;
 use serde_json::{Map, Value};
 
@@ -34,6 +35,7 @@ struct SystemInfo {
 
 include!(concat!(env!("OUT_DIR"), "/build_id.rs"));
 
+#[derive(MallocSizeOf)]
 pub(crate) struct DeviceActor {
     name: String,
 }

--- a/components/devtools/actors/environment.rs
+++ b/components/devtools/actors/environment.rs
@@ -2,6 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
+use malloc_size_of_derive::MallocSizeOf;
 use serde::Serialize;
 use serde_json::{Map, Value};
 
@@ -57,6 +58,7 @@ pub(crate) struct EnvironmentActorMsg {
 /// Resposible for listing the bindings in an environment and assigning new values to them.
 /// Referenced by `FrameActor` when replying to `getEnvironment` messages.
 /// <https://searchfox.org/firefox-main/source/devtools/server/actors/environment.js>
+#[derive(MallocSizeOf)]
 pub(crate) struct EnvironmentActor {
     pub name: String,
     pub parent: Option<String>,

--- a/components/devtools/actors/frame.rs
+++ b/components/devtools/actors/frame.rs
@@ -3,6 +3,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 use devtools_traits::PauseFrameResult;
+use malloc_size_of_derive::MallocSizeOf;
 use serde::Serialize;
 use serde_json::{Map, Value};
 
@@ -52,6 +53,7 @@ pub(crate) struct FrameActorMsg {
 
 /// Represents an stack frame. Used by `ThreadActor` when replying to interrupt messages.
 /// <https://searchfox.org/firefox-main/source/devtools/server/actors/frame.js>
+#[derive(MallocSizeOf)]
 pub(crate) struct FrameActor {
     name: String,
     object_actor: String,

--- a/components/devtools/actors/framerate.rs
+++ b/components/devtools/actors/framerate.rs
@@ -8,10 +8,12 @@ use atomic_refcell::AtomicRefCell;
 use base::generic_channel::GenericSender;
 use base::id::PipelineId;
 use devtools_traits::DevtoolScriptControlMsg;
+use malloc_size_of_derive::MallocSizeOf;
 
 use crate::actor::{Actor, ActorRegistry};
 use crate::actors::timeline::HighResolutionStamp;
 
+#[derive(MallocSizeOf)]
 pub(crate) struct FramerateActor {
     name: String,
     pipeline_id: PipelineId,

--- a/components/devtools/actors/inspector.rs
+++ b/components/devtools/actors/inspector.rs
@@ -8,6 +8,7 @@ use atomic_refcell::AtomicRefCell;
 use base::generic_channel::GenericSender;
 use base::id::PipelineId;
 use devtools_traits::DevtoolScriptControlMsg;
+use malloc_size_of_derive::MallocSizeOf;
 use serde::Serialize;
 use serde_json::{self, Map, Value};
 
@@ -52,6 +53,7 @@ struct SupportsHighlightersReply {
     value: bool,
 }
 
+#[derive(MallocSizeOf)]
 pub(crate) struct InspectorActor {
     name: String,
     highlighter: String,

--- a/components/devtools/actors/inspector/accessibility.rs
+++ b/components/devtools/actors/inspector/accessibility.rs
@@ -5,6 +5,7 @@
 //! The Accessibility actor is responsible for the Accessibility tab in the DevTools page. Right
 //! now it is a placeholder for future functionality.
 
+use malloc_size_of_derive::MallocSizeOf;
 use serde::Serialize;
 use serde_json::{Map, Value};
 
@@ -52,6 +53,7 @@ struct GetWalkerReply {
     walker: ActorMsg,
 }
 
+#[derive(MallocSizeOf)]
 pub(crate) struct AccessibilityActor {
     name: String,
 }
@@ -132,6 +134,7 @@ impl AccessibilityActor {
     }
 }
 
+#[derive(MallocSizeOf)]
 pub(crate) struct SimulatorActor {
     name: String,
 }
@@ -142,6 +145,7 @@ impl Actor for SimulatorActor {
     }
 }
 
+#[derive(MallocSizeOf)]
 pub(crate) struct AccessibleWalkerActor {
     name: String,
 }

--- a/components/devtools/actors/inspector/css_properties.rs
+++ b/components/devtools/actors/inspector/css_properties.rs
@@ -8,6 +8,7 @@
 use std::collections::HashMap;
 
 use devtools_traits::CssDatabaseProperty;
+use malloc_size_of_derive::MallocSizeOf;
 use serde::Serialize;
 use serde_json::{Map, Value};
 
@@ -15,6 +16,7 @@ use crate::StreamId;
 use crate::actor::{Actor, ActorError, ActorRegistry};
 use crate::protocol::ClientRequest;
 
+#[derive(MallocSizeOf)]
 pub(crate) struct CssPropertiesActor {
     name: String,
     properties: HashMap<String, CssDatabaseProperty>,

--- a/components/devtools/actors/inspector/highlighter.rs
+++ b/components/devtools/actors/inspector/highlighter.rs
@@ -8,6 +8,7 @@
 use base::generic_channel::GenericSender;
 use base::id::PipelineId;
 use devtools_traits::DevtoolScriptControlMsg;
+use malloc_size_of_derive::MallocSizeOf;
 use serde::Serialize;
 use serde_json::{self, Map, Value};
 
@@ -16,6 +17,7 @@ use crate::actors::inspector::InspectorActor;
 use crate::protocol::ClientRequest;
 use crate::{ActorMsg, EmptyReplyMsg, StreamId};
 
+#[derive(MallocSizeOf)]
 pub(crate) struct HighlighterActor {
     pub name: String,
     pub script_sender: GenericSender<DevtoolScriptControlMsg>,

--- a/components/devtools/actors/inspector/layout.rs
+++ b/components/devtools/actors/inspector/layout.rs
@@ -5,6 +5,7 @@
 //! The layout actor informs the DevTools client of the layout properties of the document, such as
 //! grids or flexboxes. It acts as a placeholder for now.
 
+use malloc_size_of_derive::MallocSizeOf;
 use serde::Serialize;
 use serde_json::{Map, Value};
 
@@ -12,6 +13,7 @@ use crate::actor::{Actor, ActorEncode, ActorError, ActorRegistry};
 use crate::protocol::ClientRequest;
 use crate::{ActorMsg, StreamId};
 
+#[derive(MallocSizeOf)]
 pub(crate) struct LayoutInspectorActor {
     name: String,
 }

--- a/components/devtools/actors/inspector/node.rs
+++ b/components/devtools/actors/inspector/node.rs
@@ -11,6 +11,7 @@ use atomic_refcell::AtomicRefCell;
 use base::generic_channel::{self, GenericSender};
 use base::id::PipelineId;
 use devtools_traits::{DevtoolScriptControlMsg, NodeInfo, ShadowRootMode};
+use malloc_size_of_derive::MallocSizeOf;
 use serde::Serialize;
 use serde_json::{self, Map, Value};
 
@@ -99,6 +100,7 @@ pub(crate) struct NodeActorMsg {
     system_id: Option<String>,
 }
 
+#[derive(MallocSizeOf)]
 pub(crate) struct NodeActor {
     name: String,
     pub script_chan: GenericSender<DevtoolScriptControlMsg>,

--- a/components/devtools/actors/inspector/page_style.rs
+++ b/components/devtools/actors/inspector/page_style.rs
@@ -13,6 +13,7 @@ use base::generic_channel::{self, GenericSender};
 use base::id::PipelineId;
 use devtools_traits::DevtoolScriptControlMsg::{GetLayout, GetSelectors};
 use devtools_traits::{AutoMargins, ComputedNodeLayout, DevtoolScriptControlMsg};
+use malloc_size_of_derive::MallocSizeOf;
 use serde::Serialize;
 use serde_json::{self, Map, Value};
 
@@ -90,6 +91,7 @@ pub(crate) struct PageStyleMsg {
     pub traits: HashMap<String, bool>,
 }
 
+#[derive(MallocSizeOf)]
 pub(crate) struct PageStyleActor {
     pub name: String,
     pub script_chan: GenericSender<DevtoolScriptControlMsg>,

--- a/components/devtools/actors/inspector/style_rule.rs
+++ b/components/devtools/actors/inspector/style_rule.rs
@@ -12,6 +12,7 @@ use base::generic_channel;
 use devtools_traits::DevtoolScriptControlMsg::{
     GetAttributeStyle, GetComputedStyle, GetDocumentElement, GetStylesheetStyle, ModifyRule,
 };
+use malloc_size_of_derive::MallocSizeOf;
 use serde::Serialize;
 use serde_json::{Map, Value};
 
@@ -78,6 +79,7 @@ pub(crate) struct StyleRuleActorMsg {
     rule: Option<AppliedRule>,
 }
 
+#[derive(MallocSizeOf)]
 pub(crate) struct StyleRuleActor {
     name: String,
     node: String,

--- a/components/devtools/actors/inspector/walker.rs
+++ b/components/devtools/actors/inspector/walker.rs
@@ -9,6 +9,7 @@ use base::generic_channel::{self, GenericSender};
 use base::id::PipelineId;
 use devtools_traits::DevtoolScriptControlMsg::{GetChildren, GetDocumentElement, GetRootNode};
 use devtools_traits::{AttrModification, DevtoolScriptControlMsg};
+use malloc_size_of_derive::MallocSizeOf;
 use serde::Serialize;
 use serde_json::{self, Map, Value};
 
@@ -24,6 +25,7 @@ pub(crate) struct WalkerMsg {
     root: NodeActorMsg,
 }
 
+#[derive(MallocSizeOf)]
 pub(crate) struct WalkerActor {
     pub name: String,
     pub mutations: AtomicRefCell<Vec<(AttrModification, String)>>,

--- a/components/devtools/actors/long_string.rs
+++ b/components/devtools/actors/long_string.rs
@@ -1,7 +1,7 @@
-use malloc_size_of_derive::MallocSizeOf;
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+use malloc_size_of_derive::MallocSizeOf;
 use serde::Serialize;
 use serde_json::{Map, Value};
 

--- a/components/devtools/actors/long_string.rs
+++ b/components/devtools/actors/long_string.rs
@@ -1,3 +1,4 @@
+use malloc_size_of_derive::MallocSizeOf;
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
@@ -10,6 +11,7 @@ use crate::protocol::ClientRequest;
 
 const INITIAL_LENGTH: usize = 500;
 
+#[derive(MallocSizeOf)]
 pub(crate) struct LongStringActor {
     name: String,
     full_string: String,

--- a/components/devtools/actors/memory.rs
+++ b/components/devtools/actors/memory.rs
@@ -2,6 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
+use malloc_size_of_derive::MallocSizeOf;
 use serde::Serialize;
 
 use crate::actor::{Actor, ActorRegistry};
@@ -21,6 +22,7 @@ pub(crate) struct TimelineMemoryReply {
     non_js_milliseconds: f64,
 }
 
+#[derive(MallocSizeOf)]
 pub(crate) struct MemoryActor {
     name: String,
 }

--- a/components/devtools/actors/network_event.rs
+++ b/components/devtools/actors/network_event.rs
@@ -14,6 +14,7 @@ use chrono::{Local, LocalResult, TimeZone};
 use devtools_traits::{HttpRequest, HttpResponse};
 use headers::{ContentLength, HeaderMapExt};
 use http::HeaderMap;
+use malloc_size_of_derive::MallocSizeOf;
 use net::cookie::ServoCookie;
 use net_traits::fetch::headers::extract_mime_type_as_dataurl_mime;
 use net_traits::{CookieSource, TlsSecurityInfo};
@@ -29,7 +30,7 @@ use crate::actors::watcher::WatcherActor;
 use crate::network_handler::Cause;
 use crate::protocol::ClientRequest;
 
-#[derive(Default)]
+#[derive(Default, MallocSizeOf)]
 pub(crate) struct NetworkEventActor {
     name: String,
     request: AtomicRefCell<Option<NetworkEventRequest>>,
@@ -188,14 +189,14 @@ struct ResponseContent {
     transferred_size: Option<u64>,
 }
 
-#[derive(Clone, Serialize)]
+#[derive(Clone, Serialize, MallocSizeOf)]
 #[serde(rename_all = "camelCase")]
 pub(crate) struct CacheDetails {
     from_cache: bool,
     from_service_worker: bool,
 }
 
-#[derive(Clone, Default, Serialize)]
+#[derive(Clone, Default, Serialize, MallocSizeOf)]
 pub(crate) struct Timings {
     blocked: usize,
     dns: usize,
@@ -312,6 +313,7 @@ impl From<&TlsSecurityInfo> for SecurityInfo {
     }
 }
 
+#[derive(MallocSizeOf)]
 struct NetworkEventRequest {
     offsets: Timings,
     timings: Timings,
@@ -319,6 +321,7 @@ struct NetworkEventRequest {
     total_time: Duration,
 }
 
+#[derive(MallocSizeOf)]
 struct NetworkEventResponse {
     cache_details: CacheDetails,
     response: HttpResponse,

--- a/components/devtools/actors/object.rs
+++ b/components/devtools/actors/object.rs
@@ -2,6 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
+use malloc_size_of_derive::MallocSizeOf;
 use serde::Serialize;
 use serde_json::{Map, Value};
 
@@ -57,6 +58,7 @@ pub(crate) struct ObjectActorMsg {
     preview: ObjectPreview,
 }
 
+#[derive(MallocSizeOf)]
 pub(crate) struct ObjectActor {
     name: String,
     _uuid: Option<String>,
@@ -172,6 +174,7 @@ impl ActorEncode<ObjectActorMsg> for ObjectActor {
 }
 
 // TODO: Implement functionality of property and symbol iterators
+#[derive(MallocSizeOf)]
 struct PropertyIteratorActor {
     name: String,
 }
@@ -182,6 +185,7 @@ impl Actor for PropertyIteratorActor {
     }
 }
 
+#[derive(MallocSizeOf)]
 struct SymbolIteratorActor {
     name: String,
 }

--- a/components/devtools/actors/pause.rs
+++ b/components/devtools/actors/pause.rs
@@ -2,10 +2,13 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
+use malloc_size_of_derive::MallocSizeOf;
+
 use crate::actor::Actor;
 
 /// Referenced by `ThreadActor` when replying to `interupt` messages.
 /// <https://searchfox.org/firefox-main/source/devtools/server/actors/thread.js#1699>
+#[derive(MallocSizeOf)]
 pub(crate) struct PauseActor {
     pub name: String,
 }

--- a/components/devtools/actors/performance.rs
+++ b/components/devtools/actors/performance.rs
@@ -2,6 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
+use malloc_size_of_derive::MallocSizeOf;
 use serde::Serialize;
 use serde_json::{Map, Value};
 
@@ -9,6 +10,7 @@ use crate::StreamId;
 use crate::actor::{Actor, ActorError, ActorRegistry};
 use crate::protocol::{ActorDescription, ClientRequest, Method};
 
+#[derive(MallocSizeOf)]
 pub(crate) struct PerformanceActor {
     name: String,
 }

--- a/components/devtools/actors/preference.rs
+++ b/components/devtools/actors/preference.rs
@@ -2,6 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
+use malloc_size_of_derive::MallocSizeOf;
 use serde::Serialize;
 use serde_json::{Map, Value};
 use servo_config::pref;
@@ -10,6 +11,7 @@ use crate::StreamId;
 use crate::actor::{Actor, ActorError, ActorRegistry};
 use crate::protocol::ClientRequest;
 
+#[derive(MallocSizeOf)]
 pub(crate) struct PreferenceActor {
     name: String,
 }

--- a/components/devtools/actors/process.rs
+++ b/components/devtools/actors/process.rs
@@ -6,6 +6,7 @@
 //!
 //! [Firefox JS implementation]: https://searchfox.org/mozilla-central/source/devtools/server/actors/descriptors/process.js
 
+use malloc_size_of_derive::MallocSizeOf;
 use serde::Serialize;
 use serde_json::{Map, Value};
 
@@ -30,6 +31,7 @@ pub(crate) struct ProcessActorMsg {
     traits: DescriptorTraits,
 }
 
+#[derive(MallocSizeOf)]
 pub(crate) struct ProcessActor {
     name: String,
 }

--- a/components/devtools/actors/reflow.rs
+++ b/components/devtools/actors/reflow.rs
@@ -4,12 +4,14 @@
 
 //! This actor is used for protocol purposes, it forwards the reflow events to clients.
 
+use malloc_size_of_derive::MallocSizeOf;
 use serde_json::{Map, Value};
 
 use crate::actor::{Actor, ActorError, ActorRegistry};
 use crate::protocol::ClientRequest;
 use crate::{EmptyReplyMsg, StreamId};
 
+#[derive(MallocSizeOf)]
 pub(crate) struct ReflowActor {
     name: String,
 }

--- a/components/devtools/actors/root.rs
+++ b/components/devtools/actors/root.rs
@@ -12,6 +12,7 @@
 use std::collections::HashMap;
 
 use atomic_refcell::AtomicRefCell;
+use malloc_size_of_derive::MallocSizeOf;
 use serde::Serialize;
 use serde_json::{Map, Value, json};
 
@@ -44,7 +45,7 @@ struct ListAddonsReply {
 #[derive(Serialize)]
 enum AddonMsg {}
 
-#[derive(Clone, Default, Serialize)]
+#[derive(Clone, Default, Serialize, MallocSizeOf)]
 #[serde(rename_all = "camelCase")]
 struct GlobalActors {
     device_actor: String,
@@ -128,7 +129,7 @@ struct GetProcessResponse {
     process_descriptor: ProcessActorMsg,
 }
 
-#[derive(Default)]
+#[derive(Default, MallocSizeOf)]
 pub(crate) struct RootActor {
     active_tab: AtomicRefCell<Option<String>>,
     global_actors: GlobalActors,

--- a/components/devtools/actors/source.rs
+++ b/components/devtools/actors/source.rs
@@ -9,6 +9,7 @@ use atomic_refcell::AtomicRefCell;
 use base::generic_channel::{GenericSender, channel};
 use base::id::PipelineId;
 use devtools_traits::DevtoolScriptControlMsg;
+use malloc_size_of_derive::MallocSizeOf;
 use serde::{Deserialize, Serialize};
 use serde_json::{Map, Value};
 use servo_url::ServoUrl;
@@ -41,6 +42,7 @@ pub(crate) struct SourcesReply {
     pub sources: Vec<SourceForm>,
 }
 
+#[derive(MallocSizeOf)]
 pub(crate) struct SourceManager {
     source_actor_names: AtomicRefCell<BTreeSet<String>>,
 }
@@ -81,7 +83,7 @@ impl SourceManager {
     }
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, MallocSizeOf)]
 pub(crate) struct SourceActor {
     /// Actor name.
     name: String,

--- a/components/devtools/actors/stylesheets.rs
+++ b/components/devtools/actors/stylesheets.rs
@@ -2,6 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
+use malloc_size_of_derive::MallocSizeOf;
 use serde::Serialize;
 use serde_json::{Map, Value};
 
@@ -16,6 +17,7 @@ struct GetStyleSheetsReply {
     style_sheets: Vec<u32>, // TODO: real JSON structure.
 }
 
+#[derive(MallocSizeOf)]
 pub(crate) struct StyleSheetsActor {
     name: String,
 }

--- a/components/devtools/actors/tab.rs
+++ b/components/devtools/actors/tab.rs
@@ -10,6 +10,7 @@
 //! [Firefox JS implementation]: https://searchfox.org/mozilla-central/source/devtools/server/actors/descriptors/tab.js
 
 use devtools_traits::DevtoolScriptControlMsg;
+use malloc_size_of_derive::MallocSizeOf;
 use serde::Serialize;
 use serde_json::{Map, Value};
 
@@ -67,6 +68,7 @@ struct GetWatcherReply {
     watcher: WatcherActorMsg,
 }
 
+#[derive(MallocSizeOf)]
 pub(crate) struct TabDescriptorActor {
     name: String,
     browsing_context_actor: String,

--- a/components/devtools/actors/thread.rs
+++ b/components/devtools/actors/thread.rs
@@ -7,6 +7,7 @@ use std::collections::HashSet;
 use atomic_refcell::AtomicRefCell;
 use base::generic_channel::{GenericSender, channel};
 use devtools_traits::DevtoolScriptControlMsg;
+use malloc_size_of_derive::MallocSizeOf;
 use serde::Serialize;
 use serde_json::{Map, Value};
 
@@ -73,6 +74,7 @@ struct FramesReply {
     frames: Vec<FrameActorMsg>,
 }
 
+#[derive(MallocSizeOf)]
 pub(crate) struct ThreadActor {
     name: String,
     pub source_manager: SourceManager,

--- a/components/devtools/actors/timeline.rs
+++ b/components/devtools/actors/timeline.rs
@@ -15,6 +15,7 @@ use base::generic_channel::{self, GenericReceiver, GenericSender};
 use base::id::PipelineId;
 use devtools_traits::DevtoolScriptControlMsg::{DropTimelineMarkers, SetTimelineMarkers};
 use devtools_traits::{DevtoolScriptControlMsg, TimelineMarker, TimelineMarkerType};
+use malloc_size_of_derive::MallocSizeOf;
 use serde::{Serialize, Serializer};
 use serde_json::{Map, Value};
 
@@ -24,15 +25,18 @@ use crate::actors::framerate::FramerateActor;
 use crate::actors::memory::{MemoryActor, TimelineMemoryReply};
 use crate::protocol::{ClientRequest, JsonPacketStream};
 
+#[derive(MallocSizeOf)]
 pub(crate) struct TimelineActor {
     name: String,
     script_sender: GenericSender<DevtoolScriptControlMsg>,
     marker_types: Vec<TimelineMarkerType>,
     pipeline_id: PipelineId,
+    #[conditional_malloc_size_of]
     is_recording: Arc<Mutex<bool>>,
     stream: AtomicRefCell<Option<TcpStream>>,
     framerate_actor: AtomicRefCell<Option<String>>,
     memory_actor: AtomicRefCell<Option<String>>,
+    #[conditional_malloc_size_of]
     registry: Arc<Mutex<ActorRegistry>>,
     start_stamp: CrossProcessInstant,
 }
@@ -107,6 +111,7 @@ struct FramerateEmitterReply {
 /// with accuracy to microsecond that shows how much time has passed since
 /// actor registry inited
 /// analog <https://w3c.github.io/hr-time/#sec-DOMHighResTimeStamp>
+#[derive(MallocSizeOf)]
 pub(crate) struct HighResolutionStamp(f64);
 
 impl HighResolutionStamp {

--- a/components/devtools/actors/watcher.rs
+++ b/components/devtools/actors/watcher.rs
@@ -16,6 +16,7 @@ use std::net::TcpStream;
 use base::id::BrowsingContextId;
 use devtools_traits::get_time_stamp;
 use log::warn;
+use malloc_size_of_derive::MallocSizeOf;
 use serde::Serialize;
 use serde_json::{Map, Value};
 use servo_url::ServoUrl;
@@ -42,7 +43,7 @@ pub mod thread_configuration;
 
 /// Describes the debugged context. It informs the server of which objects can be debugged.
 /// <https://searchfox.org/mozilla-central/source/devtools/server/actors/watcher/session-context.js>
-#[derive(Serialize)]
+#[derive(Serialize, MallocSizeOf)]
 #[serde(rename_all = "camelCase")]
 pub(crate) struct SessionContext {
     is_server_target_switching_enabled: bool,
@@ -97,7 +98,7 @@ impl SessionContext {
     }
 }
 
-#[derive(Serialize)]
+#[derive(Serialize, MallocSizeOf)]
 pub enum SessionContextType {
     BrowserElement,
     _ContextProcess,
@@ -179,6 +180,7 @@ pub(crate) struct WatcherActorMsg {
     traits: WatcherTraits,
 }
 
+#[derive(MallocSizeOf)]
 pub(crate) struct WatcherActor {
     name: String,
     pub browsing_context_actor: String,

--- a/components/devtools/actors/watcher/network_parent.rs
+++ b/components/devtools/actors/watcher/network_parent.rs
@@ -2,12 +2,14 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
+use malloc_size_of_derive::MallocSizeOf;
 use serde_json::{Map, Value};
 
 use crate::actor::{Actor, ActorEncode, ActorError, ActorRegistry};
 use crate::protocol::ClientRequest;
 use crate::{ActorMsg, EmptyReplyMsg, StreamId};
 
+#[derive(MallocSizeOf)]
 pub(crate) struct NetworkParentActor {
     name: String,
 }

--- a/components/devtools/actors/watcher/target_configuration.rs
+++ b/components/devtools/actors/watcher/target_configuration.rs
@@ -9,6 +9,7 @@ use std::collections::HashMap;
 
 use embedder_traits::Theme;
 use log::warn;
+use malloc_size_of_derive::MallocSizeOf;
 use serde::Serialize;
 use serde_json::{Map, Value};
 
@@ -31,6 +32,7 @@ pub(crate) struct TargetConfigurationActorMsg {
     traits: TargetConfigurationTraits,
 }
 
+#[derive(MallocSizeOf)]
 pub(crate) struct TargetConfigurationActor {
     name: String,
     configuration: HashMap<&'static str, bool>,

--- a/components/devtools/actors/watcher/thread_configuration.rs
+++ b/components/devtools/actors/watcher/thread_configuration.rs
@@ -7,12 +7,14 @@
 
 use std::collections::HashMap;
 
+use malloc_size_of_derive::MallocSizeOf;
 use serde_json::{Map, Value};
 
 use crate::actor::{Actor, ActorEncode, ActorError, ActorRegistry};
 use crate::protocol::ClientRequest;
 use crate::{ActorMsg, EmptyReplyMsg, StreamId};
 
+#[derive(MallocSizeOf)]
 pub(crate) struct ThreadConfigurationActor {
     name: String,
     _configuration: HashMap<&'static str, bool>,

--- a/components/devtools/actors/worker.rs
+++ b/components/devtools/actors/worker.rs
@@ -10,6 +10,7 @@ use base::generic_channel::GenericSender;
 use base::id::TEST_PIPELINE_ID;
 use devtools_traits::DevtoolScriptControlMsg::WantsLiveNotifications;
 use devtools_traits::{DevtoolScriptControlMsg, WorkerId};
+use malloc_size_of_derive::MallocSizeOf;
 use serde::Serialize;
 use serde_json::{Map, Value};
 use servo_url::ServoUrl;
@@ -19,7 +20,7 @@ use crate::actor::{Actor, ActorEncode, ActorError, ActorRegistry};
 use crate::protocol::{ClientRequest, JsonPacketStream};
 use crate::resource::ResourceAvailable;
 
-#[derive(Clone, Copy)]
+#[derive(Clone, Copy, MallocSizeOf)]
 #[expect(dead_code)]
 pub enum WorkerType {
     Dedicated = 0,
@@ -27,6 +28,7 @@ pub enum WorkerType {
     Service = 2,
 }
 
+#[derive(MallocSizeOf)]
 pub(crate) struct WorkerActor {
     pub name: String,
     pub console: String,

--- a/components/devtools/id.rs
+++ b/components/devtools/id.rs
@@ -3,9 +3,10 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 use base::id::{BrowsingContextId, PipelineId, WebViewId};
+use malloc_size_of_derive::MallocSizeOf;
 use rustc_hash::FxHashMap;
 
-#[derive(Debug, Default)]
+#[derive(Debug, Default, MallocSizeOf)]
 pub(crate) struct IdMap {
     browser_ids: FxHashMap<WebViewId, u32>,
     browsing_context_ids: FxHashMap<BrowsingContextId, u32>,
@@ -53,13 +54,13 @@ impl IdMap {
     }
 }
 
-#[derive(Clone, Copy, Debug, PartialEq)]
+#[derive(Clone, Copy, Debug, PartialEq, MallocSizeOf)]
 pub(crate) struct DevtoolsBrowserId(u32);
 
-#[derive(Clone, Copy, Debug, PartialEq)]
+#[derive(Clone, Copy, Debug, PartialEq, MallocSizeOf)]
 pub(crate) struct DevtoolsBrowsingContextId(u32);
 
-#[derive(Clone, Copy, Debug, PartialEq)]
+#[derive(Clone, Copy, Debug, PartialEq, MallocSizeOf)]
 pub(crate) struct DevtoolsOuterWindowId(u32);
 
 impl DevtoolsBrowserId {

--- a/components/devtools/lib.rs
+++ b/components/devtools/lib.rs
@@ -28,6 +28,7 @@ use devtools_traits::{
 };
 use embedder_traits::{AllowOrDeny, EmbedderMsg, EmbedderProxy};
 use log::{trace, warn};
+use malloc_size_of_derive::MallocSizeOf;
 use rand::{RngCore, rng};
 use resource::{ResourceArrayType, ResourceAvailable};
 use rustc_hash::FxHashMap;
@@ -81,7 +82,7 @@ mod network_handler;
 mod protocol;
 mod resource;
 
-#[derive(Clone, Debug, Eq, Hash, PartialEq)]
+#[derive(Clone, Debug, Eq, Hash, PartialEq, MallocSizeOf)]
 enum UniqueId {
     Pipeline(PipelineId),
     Worker(WorkerId),
@@ -114,11 +115,14 @@ pub fn start_server(port: u16, embedder: EmbedderProxy) -> Sender<DevtoolsContro
     sender
 }
 
-#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq, MallocSizeOf)]
 pub(crate) struct StreamId(u32);
 
+#[derive(MallocSizeOf)]
 struct DevtoolsInstance {
+    #[conditional_malloc_size_of]
     registry: Arc<ActorRegistry>,
+    #[conditional_malloc_size_of]
     id_map: Arc<Mutex<IdMap>>,
     browsing_contexts: FxHashMap<BrowsingContextId, String>,
     receiver: Receiver<DevtoolsControlMsg>,

--- a/components/malloc_size_of/lib.rs
+++ b/components/malloc_size_of/lib.rs
@@ -432,6 +432,12 @@ impl<T: MallocSizeOf> MallocSizeOf for BinaryHeap<T> {
     }
 }
 
+impl<T: MallocSizeOf> MallocSizeOf for std::collections::BTreeSet<T> {
+    fn size_of(&self, ops: &mut MallocSizeOfOps) -> usize {
+        self.iter().map(|element| element.size_of(ops)).sum()
+    }
+}
+
 impl<T: MallocSizeOf> MallocSizeOf for Range<T> {
     fn size_of(&self, ops: &mut MallocSizeOfOps) -> usize {
         self.start.size_of(ops) + self.end.size_of(ops)
@@ -1098,6 +1104,7 @@ malloc_size_of_is_0!(std::num::NonZeroUsize);
 malloc_size_of_is_0!(std::sync::atomic::AtomicBool);
 malloc_size_of_is_0!(std::sync::atomic::AtomicIsize);
 malloc_size_of_is_0!(std::sync::atomic::AtomicUsize);
+malloc_size_of_is_0!(std::sync::atomic::AtomicU32);
 malloc_size_of_is_0!(std::time::Duration);
 malloc_size_of_is_0!(std::time::Instant);
 malloc_size_of_is_0!(std::time::SystemTime);
@@ -1114,6 +1121,7 @@ malloc_size_of_is_0!(unicode_bidi::Level);
 malloc_size_of_is_0!(unicode_script::Script);
 malloc_size_of_is_0!(urlpattern::UrlPattern);
 malloc_size_of_is_0!(utf8::Incomplete);
+malloc_size_of_is_0!(std::net::TcpStream);
 
 impl<S: tendril::TendrilSink<tendril::fmt::UTF8, A>, A: tendril::Atomicity> MallocSizeOf
     for tendril::stream::LossyDecoder<S, A>

--- a/components/shared/devtools/lib.rs
+++ b/components/shared/devtools/lib.rs
@@ -313,7 +313,7 @@ pub enum DevtoolScriptControlMsg {
     Pause(GenericSender<PauseFrameResult>),
 }
 
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, MallocSizeOf)]
 #[serde(rename_all = "camelCase")]
 pub struct AttrModification {
     pub attribute_name: String,
@@ -331,7 +331,7 @@ pub struct RuleModification {
     pub priority: String,
 }
 
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, MallocSizeOf)]
 #[serde(rename_all = "camelCase")]
 pub struct StackFrame {
     pub filename: String,
@@ -349,7 +349,7 @@ pub fn get_time_stamp() -> u64 {
         .as_millis() as u64
 }
 
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, MallocSizeOf)]
 #[serde(rename_all = "camelCase")]
 pub struct ConsoleMessageFields {
     pub level: ConsoleLogLevel,
@@ -379,7 +379,7 @@ pub struct ConsoleMessage {
     pub stacktrace: Option<Vec<StackFrame>>,
 }
 
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, MallocSizeOf)]
 #[serde(rename_all = "camelCase")]
 pub struct PageError {
     pub error_message: String,
@@ -389,10 +389,12 @@ pub struct PageError {
     pub time_stamp: u64,
 }
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, MallocSizeOf)]
 pub struct HttpRequest {
     pub url: ServoUrl,
+    #[ignore_malloc_size_of = "http type"]
     pub method: Method,
+    #[ignore_malloc_size_of = "http type"]
     pub headers: HeaderMap,
     pub body: Option<DebugVec>,
     pub pipeline_id: PipelineId,
@@ -405,8 +407,9 @@ pub struct HttpRequest {
     pub browsing_context_id: BrowsingContextId,
 }
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, MallocSizeOf)]
 pub struct HttpResponse {
+    #[ignore_malloc_size_of = "Http type"]
     pub headers: Option<HeaderMap>,
     pub status: HttpStatus,
     pub body: Option<DebugVec>,
@@ -476,7 +479,7 @@ impl FromStr for WorkerId {
     }
 }
 
-#[derive(Debug, Deserialize, Serialize)]
+#[derive(Debug, Deserialize, Serialize, MallocSizeOf)]
 #[serde(rename_all = "camelCase")]
 pub struct CssDatabaseProperty {
     pub is_inherited: bool,
@@ -521,7 +524,7 @@ pub struct RecommendedBreakpointLocation {
     pub is_step_start: bool,
 }
 
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, MallocSizeOf)]
 #[serde(rename_all = "camelCase")]
 pub struct PauseFrameResult {
     pub column: u32,

--- a/components/shared/embedder/lib.rs
+++ b/components/shared/embedder/lib.rs
@@ -387,7 +387,7 @@ impl Image {
     }
 }
 
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, MallocSizeOf)]
 #[serde(rename_all = "lowercase")]
 pub enum ConsoleLogLevel {
     Log,

--- a/components/shared/net/lib.rs
+++ b/components/shared/net/lib.rs
@@ -250,7 +250,7 @@ pub enum FetchResponseMsg {
     ProcessCspViolations(RequestId, Vec<csp::Violation>),
 }
 
-#[derive(Deserialize, PartialEq, Serialize)]
+#[derive(Deserialize, PartialEq, Serialize, MallocSizeOf)]
 pub struct DebugVec(pub Vec<u8>);
 
 impl From<Vec<u8>> for DebugVec {


### PR DESCRIPTION
This implements MallocSizeOf for DevtoolsInstance. Major changes:
- Newtype for ActorRegistry because AtomicRefCell<HashMap<String, Arc<dyn Actor>>> did not like mallocsizeof (even with trait bound on Actor)
- Implement MallocSizeOf for BTreeSet.
- Implement MallocSizeOf of 0 for AtomicU32 and TcpStream
- Ignore a couple of MallocSizeof for http::Method, http::HeaderMap and json::Value

Signed-off-by: Narfinger <Narfinger@users.noreply.github.com>

Testing: Compilation is the test.
Fixes: Part of addressing https://github.com/servo/servo/issues/42453
