### PR TITLE
libservo: Fix build warnings for unfulfilled `dead_code` lint expectations in tests

### DIFF
--- a/components/servo/tests/common/mod.rs
+++ b/components/servo/tests/common/mod.rs
@@ -22,7 +22,7 @@ pub struct ServoTest {
 }
 
 impl ServoTest {
-    #[expect(dead_code)] // Used by some tests and not others
+    #[allow(dead_code)] // Used by some tests and not others
     pub(crate) fn new() -> Self {
         Self::new_with_builder(|builder| builder)
     }

--- a/components/servo/tests/multiprocess.rs
+++ b/components/servo/tests/multiprocess.rs
@@ -9,7 +9,6 @@
 //! of `assert!` for test assertions. `ensure!` will produce a `Result::Err` in
 //! place of panicking.
 
-#[expect(dead_code)]
 mod common;
 
 use std::rc::Rc;


### PR DESCRIPTION
The `#[expect(dead_code)]` annotations in `components/servo/tests/common/mod.rs` and `components/servo/tests/multiprocess.rs` were no longer valid because the related helpers are currently used by tests. Removed unfulfilled `#[expect(dead_code)]` annotations from the above files.

Testing: Tests compile cleanly after this change.
Fixes: #42412