### PR TITLE
CI: OHOS Use mitmproxy in record and replay mode

### DIFF
--- a/.github/workflows/ohos.yml
+++ b/.github/workflows/ohos.yml
@@ -278,6 +278,22 @@ jobs:
       - name: Setup complete
         id: setup_complete
         run: echo "Setup complete"
+      - name: Get mitmproxy cache
+        id: mitmproxy-cache
+        uses: actions/cache@v5
+        with:
+          path: /tmp/mitmproxy-dump
+          key: mitmproxy-dump
+      - name: Generate mitmproxy dump
+        if: steps.mitmproxy-cache.outputs.cache-hit != 'true'
+        run: uv run etc/ci/scenario/update_mitmproxy_dump.py /tmp/mitmproxy-dump
+      - name: Save Cache
+        if: steps.mitmproxy-cache.outputs.cache-hit != 'true'
+        id: cache-mitmproxy-save
+        uses: actions/cache/save@v5
+        with:
+          path: /tmp/mitmproxy-dump
+          key: mitmproxy-dump
       - name: "Run benchmark"
         id: hitrace_bench
         run: hitrace-bench -r support/hitrace-bencher/runs.json --bencher -p ${{ inputs.profile }}
@@ -362,6 +378,22 @@ jobs:
         with:
           sparse-checkout: |
             etc/ci/scenario
+      - name: Get mitmproxy cache
+        id: mitmproxy-cache
+        uses: actions/cache@v5
+        with:
+          path: /tmp/mitmproxy-dump
+          key: mitmproxy-dump
+      - name: Generate mitmproxy dump
+        if: steps.mitmproxy-cache.outputs.cache-hit != 'true'
+        run: uv run etc/ci/scenario/update_mitmproxy_dump.py /tmp/mitmproxy-dump
+      - name: Save Cache
+        if: steps.mitmproxy-cache.outputs.cache-hit != 'true'
+        id: cache-mitmproxy-save
+        uses: actions/cache/save@v5
+        with:
+          path: /tmp/mitmproxy-dump
+          key: mitmproxy-dump
       - name: Test loading servo.org
         run: uv run ./etc/ci/scenario/servo_test_open_page_servo.py
       - name: Test loading Mossel homepage

--- a/.github/workflows/ohos.yml
+++ b/.github/workflows/ohos.yml
@@ -40,7 +40,7 @@ env:
   CARGO_INCREMENTAL: 0
   BENCHER_PROJECT: ${{ vars.BENCHER_PROJECT || 'servo' }}
   HITRACE_BENCH_VERSION: 0.10.0
-  MITMDUMP_CACHE_KEY: mitmdump-cache-0.1
+  MITMDUMP_CACHE_KEY: mitmdump-ohos-cache-0.1
 
 jobs:
   build:

--- a/.github/workflows/ohos.yml
+++ b/.github/workflows/ohos.yml
@@ -40,6 +40,7 @@ env:
   CARGO_INCREMENTAL: 0
   BENCHER_PROJECT: ${{ vars.BENCHER_PROJECT || 'servo' }}
   HITRACE_BENCH_VERSION: 0.10.0
+  MITMDUMP_CACHE_KEY: mitmdump-cache-0.1
 
 jobs:
   build:
@@ -283,7 +284,7 @@ jobs:
         uses: actions/cache@v5
         with:
           path: /tmp/mitmproxy-dump
-          key: mitmproxy-dump
+          key: {{ env.MITMDUMP_CACHE_KEY }}
       - name: Generate mitmproxy dump
         if: steps.mitmproxy-cache.outputs.cache-hit != 'true'
         run: uv run etc/ci/scenario/update_mitmproxy_dump.py /tmp/mitmproxy-dump
@@ -293,7 +294,7 @@ jobs:
         uses: actions/cache/save@v5
         with:
           path: /tmp/mitmproxy-dump
-          key: mitmproxy-dump
+          key: {{ env.MITMDUMP_CACHE_KEY }}
       - name: "Run benchmark"
         id: hitrace_bench
         run: hitrace-bench -r support/hitrace-bencher/runs.json --bencher -p ${{ inputs.profile }}
@@ -383,7 +384,7 @@ jobs:
         uses: actions/cache@v5
         with:
           path: /tmp/mitmproxy-dump
-          key: mitmproxy-dump
+          key: {{ env.MITMDUMP_CACHE_KEY }}
       - name: Generate mitmproxy dump
         if: steps.mitmproxy-cache.outputs.cache-hit != 'true'
         run: uv run etc/ci/scenario/update_mitmproxy_dump.py /tmp/mitmproxy-dump
@@ -393,7 +394,7 @@ jobs:
         uses: actions/cache/save@v5
         with:
           path: /tmp/mitmproxy-dump
-          key: mitmproxy-dump
+          key: {{ env.MITMDUMP_CACHE_KEY }}
       - name: Test loading servo.org
         run: uv run ./etc/ci/scenario/servo_test_open_page_servo.py
       - name: Test loading Mossel homepage

--- a/.github/workflows/ohos.yml
+++ b/.github/workflows/ohos.yml
@@ -284,7 +284,7 @@ jobs:
         uses: actions/cache@v5
         with:
           path: /tmp/mitmproxy-dump
-          key: {{ env.MITMDUMP_CACHE_KEY }}
+          key: ${{ env.MITMDUMP_CACHE_KEY }}
       - name: Generate mitmproxy dump
         if: steps.mitmproxy-cache.outputs.cache-hit != 'true'
         run: uv run etc/ci/scenario/update_mitmproxy_dump.py /tmp/mitmproxy-dump
@@ -294,7 +294,7 @@ jobs:
         uses: actions/cache/save@v5
         with:
           path: /tmp/mitmproxy-dump
-          key: {{ env.MITMDUMP_CACHE_KEY }}
+          key: ${{ env.MITMDUMP_CACHE_KEY }}
       - name: "Run benchmark"
         id: hitrace_bench
         run: hitrace-bench -r support/hitrace-bencher/runs.json --bencher -p ${{ inputs.profile }}
@@ -384,7 +384,7 @@ jobs:
         uses: actions/cache@v5
         with:
           path: /tmp/mitmproxy-dump
-          key: {{ env.MITMDUMP_CACHE_KEY }}
+          key: ${{ env.MITMDUMP_CACHE_KEY }}
       - name: Generate mitmproxy dump
         if: steps.mitmproxy-cache.outputs.cache-hit != 'true'
         run: uv run etc/ci/scenario/update_mitmproxy_dump.py /tmp/mitmproxy-dump
@@ -394,7 +394,7 @@ jobs:
         uses: actions/cache/save@v5
         with:
           path: /tmp/mitmproxy-dump
-          key: {{ env.MITMDUMP_CACHE_KEY }}
+          key: ${{ env.MITMDUMP_CACHE_KEY }}
       - name: Test loading servo.org
         run: uv run ./etc/ci/scenario/servo_test_open_page_servo.py
       - name: Test loading Mossel homepage

--- a/etc/ci/scenario/common_function_for_servo_test.py
+++ b/etc/ci/scenario/common_function_for_servo_test.py
@@ -331,11 +331,11 @@ def close_usb_popup(hdc: HarmonyDeviceConnector):
 
 # We always load "about:blank" first, and then use
 # WebDriver to load target url so that it is blocked until fully loaded.
-def run_test(test_fn, test_name: str, use_mitmproxy: MitmProxyRunType = MitmProxyRunType.REPLAY):
-    # if os.environ.get("CI") and use_mitmproxy == MitmProxyRunType.NOPROXY:
-    # if we are in CI and nobody overrode our mitmproxy type we want to replay.
-    #    print("Setting mitmproxy replay")
-    #    use_mitmproxy = MitmProxyRunType.REPLAY
+def run_test(test_fn, test_name: str, use_mitmproxy: MitmProxyRunType = MitmProxyRunType.NOPROXY):
+    if os.environ.get("CI") and use_mitmproxy == MitmProxyRunType.NOPROXY:
+        # if we are in CI and nobody overrode our mitmproxy type we want to replay.
+        print("Setting mitmproxy replay")
+        use_mitmproxy = MitmProxyRunType.REPLAY
 
     dump_file = pathlib.Path("/tmp/mitmproxy-dump")
     if use_mitmproxy == MitmProxyRunType.REPLAY and not dump_file.is_file():

--- a/etc/ci/scenario/common_function_for_servo_test.py
+++ b/etc/ci/scenario/common_function_for_servo_test.py
@@ -337,7 +337,7 @@ def run_test(test_fn, test_name: str, use_mitmproxy: MitmProxyRunType = MitmProx
     #    print("Setting mitmproxy replay")
     #    use_mitmproxy = MitmProxyRunType.REPLAY
 
-    dump_file = pathlib.Path("/tmp/mitmdump-current")
+    dump_file = pathlib.Path("/tmp/mitmproxy-dump")
     if use_mitmproxy == MitmProxyRunType.REPLAY and not dump_file.is_file():
         print(f"Dump file {dump_file} did not exist. We will abort")
         return

--- a/etc/ci/scenario/common_function_for_servo_test.py
+++ b/etc/ci/scenario/common_function_for_servo_test.py
@@ -331,7 +331,7 @@ def close_usb_popup(hdc: HarmonyDeviceConnector):
 
 # We always load "about:blank" first, and then use
 # WebDriver to load target url so that it is blocked until fully loaded.
-def run_test(test_fn, test_name: str, use_mitmproxy: MitmProxyRunType = MitmProxyRunType.FORWARD):
+def run_test(test_fn, test_name: str, use_mitmproxy: MitmProxyRunType = MitmProxyRunType.REPLAY):
     # if os.environ.get("CI") and use_mitmproxy == MitmProxyRunType.NOPROXY:
     # if we are in CI and nobody overrode our mitmproxy type we want to replay.
     #    print("Setting mitmproxy replay")


### PR DESCRIPTION
We now use a replay recorded via mitmproxy to run the benchmarks.
1. Check the GitHub cache for a mitmproxy dump.
2. If it does not exists create it with update_mitmproxy_dump and store it in the GitHub cache
3. Run mitmproxy in Replay mode instead of Forward mode with the above given dump.

This should reduce the jitter of tests that depend on network.
This works currently for the scenariotests and speedometer with hitrace-bencher soon to follow.

Testing: Tested with two separate runs. https://github.com/Narfinger/servo/actions/runs/21828840808 has the cache already populated.
The noisy output of mitmdump actually shows that it is answering the queries from replay for all scenario tests.
https://github.com/Narfinger/servo/actions/runs/21831381306/job/62991977638 shows how before the scenario tests the cache is created and stored.

