### PR TITLE
Remove many unecessary `ignore_malloc_sizes_of` annotations

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10592,6 +10592,7 @@ version = "0.0.1"
 dependencies = [
  "arrayvec",
  "base",
+ "malloc_size_of_derive",
  "pixels",
  "serde",
  "servo_malloc_size_of",

--- a/components/metrics/lib.rs
+++ b/components/metrics/lib.rs
@@ -101,7 +101,6 @@ pub struct ProgressiveWebMetrics {
     ///
     /// See <https://www.w3.org/TR/largest-contentful-paint/>
     largest_contentful_paint: Cell<Option<CrossProcessInstant>>,
-    #[ignore_malloc_size_of = "can't measure channels"]
     time_profiler_chan: ProfilerChan,
     url: ServoUrl,
 }

--- a/components/net/image_cache.rs
+++ b/components/net/image_cache.rs
@@ -466,7 +466,6 @@ struct ImageCacheStore {
     broken_image_icon_image: OnceCell<Option<Arc<RasterImage>>>,
 
     /// Cross-process `Paint` API instance.
-    #[ignore_malloc_size_of = "Channel from another crate"]
     paint_api: CrossProcessPaintApi,
 
     /// The [`WebView`] of the `Webview` associated with this [`ImageCache`].

--- a/components/script/body.rs
+++ b/components/script/body.rs
@@ -307,11 +307,9 @@ impl TransmitBodyConnectHandler {
 #[derive(Clone, JSTraceable, MallocSizeOf)]
 #[cfg_attr(crown, crown::unrooted_must_root_lint::must_root)]
 struct TransmitBodyPromiseHandler {
-    #[ignore_malloc_size_of = "Channels are hard"]
     #[no_trace]
     bytes_sender: IpcSender<BodyChunkResponse>,
     stream: Dom<ReadableStream>,
-    #[ignore_malloc_size_of = "Channels are hard"]
     #[no_trace]
     control_sender: IpcSender<BodyChunkRequest>,
 }
@@ -366,11 +364,9 @@ impl Callback for TransmitBodyPromiseHandler {
 #[derive(Clone, JSTraceable, MallocSizeOf)]
 #[cfg_attr(crown, crown::unrooted_must_root_lint::must_root)]
 struct TransmitBodyPromiseRejectionHandler {
-    #[ignore_malloc_size_of = "Channels are hard"]
     #[no_trace]
     bytes_sender: IpcSender<BodyChunkResponse>,
     stream: Dom<ReadableStream>,
-    #[ignore_malloc_size_of = "Channels are hard"]
     #[no_trace]
     control_sender: IpcSender<BodyChunkRequest>,
 }

--- a/components/script/dom/client.rs
+++ b/components/script/dom/client.rs
@@ -23,7 +23,6 @@ pub(crate) struct Client {
     #[no_trace]
     url: ServoUrl,
     frame_type: FrameType,
-    #[ignore_malloc_size_of = "Defined in uuid"]
     #[no_trace]
     id: Uuid,
 }

--- a/components/script/dom/cookiestore.rs
+++ b/components/script/dom/cookiestore.rs
@@ -42,7 +42,6 @@ struct DroppableCookieStore {
     // Store an id so that we can send it with requests and the resource thread knows who to respond to
     #[no_trace]
     store_id: CookieStoreId,
-    #[ignore_malloc_size_of = "Channels are hard"]
     #[no_trace]
     unregister_channel: GenericSender<CoreResourceMsg>,
 }

--- a/components/script/dom/document.rs
+++ b/components/script/dom/document.rs
@@ -610,7 +610,6 @@ pub(crate) struct Document {
     creation_sandboxing_flag_set: Cell<SandboxingFlagSet>,
     /// The cached favicon for that document.
     #[no_trace]
-    #[ignore_malloc_size_of = "TODO: unimplemented on Image"]
     favicon: RefCell<Option<Image>>,
 
     /// All websockets created that are associated with this document.

--- a/components/script/dom/globalscope.rs
+++ b/components/script/dom/globalscope.rs
@@ -254,22 +254,18 @@ pub(crate) struct GlobalScope {
     devtools_chan: Option<GenericCallback<ScriptToDevtoolsControlMsg>>,
 
     /// For sending messages to the memory profiler.
-    #[ignore_malloc_size_of = "channels are hard"]
     #[no_trace]
     mem_profiler_chan: profile_mem::ProfilerChan,
 
     /// For sending messages to the time profiler.
-    #[ignore_malloc_size_of = "channels are hard"]
     #[no_trace]
     time_profiler_chan: profile_time::ProfilerChan,
 
     /// A handle for communicating messages to the constellation thread.
-    #[ignore_malloc_size_of = "channels are hard"]
     #[no_trace]
     script_to_constellation_chan: ScriptToConstellationChan,
 
     /// A handle for communicating messages to the Embedder.
-    #[ignore_malloc_size_of = "channels are hard"]
     #[no_trace]
     script_to_embedder_chan: ScriptToEmbedderChan,
 

--- a/components/script/dom/mutationobserver.rs
+++ b/components/script/dom/mutationobserver.rs
@@ -28,7 +28,7 @@ use crate::script_thread::ScriptThread;
 #[dom_struct]
 pub(crate) struct MutationObserver {
     reflector_: Reflector,
-    #[ignore_malloc_size_of = "can't measure Rc values"]
+    #[conditional_malloc_size_of]
     callback: Rc<MutationCallback>,
     record_queue: DomRefCell<Vec<Dom<MutationRecord>>>,
     node_list: DomRefCell<Vec<Dom<Node>>>,

--- a/components/script/dom/performance/performanceobserver.rs
+++ b/components/script/dom/performance/performanceobserver.rs
@@ -35,7 +35,7 @@ enum ObserverType {
 #[dom_struct]
 pub(crate) struct PerformanceObserver {
     reflector_: Reflector,
-    #[ignore_malloc_size_of = "can't measure Rc values"]
+    #[conditional_malloc_size_of]
     callback: Rc<PerformanceObserverCallback>,
     entries: DomRefCell<DOMPerformanceEntryList>,
     observer_type: Cell<ObserverType>,

--- a/components/script/dom/stream/byteteereadintorequest.rs
+++ b/components/script/dom/stream/byteteereadintorequest.rs
@@ -44,17 +44,17 @@ pub(crate) struct ByteTeeReadIntoRequest {
     byob_branch: Dom<ReadableStream>,
     other_branch: Dom<ReadableStream>,
     stream: Dom<ReadableStream>,
-    #[ignore_malloc_size_of = "Rc"]
+    #[conditional_malloc_size_of]
     read_again_for_branch_1: Rc<Cell<bool>>,
-    #[ignore_malloc_size_of = "Rc"]
+    #[conditional_malloc_size_of]
     read_again_for_branch_2: Rc<Cell<bool>>,
-    #[ignore_malloc_size_of = "Rc"]
+    #[conditional_malloc_size_of]
     reading: Rc<Cell<bool>>,
-    #[ignore_malloc_size_of = "Rc"]
+    #[conditional_malloc_size_of]
     canceled_1: Rc<Cell<bool>>,
-    #[ignore_malloc_size_of = "Rc"]
+    #[conditional_malloc_size_of]
     canceled_2: Rc<Cell<bool>>,
-    #[ignore_malloc_size_of = "Rc"]
+    #[conditional_malloc_size_of]
     cancel_promise: Rc<Promise>,
     tee_underlying_source: Dom<ByteTeeUnderlyingSource>,
 }

--- a/components/script/dom/stream/byteteereadrequest.rs
+++ b/components/script/dom/stream/byteteereadrequest.rs
@@ -47,17 +47,17 @@ pub(crate) struct ByteTeeReadRequest {
     branch_1: Dom<ReadableStream>,
     branch_2: Dom<ReadableStream>,
     stream: Dom<ReadableStream>,
-    #[ignore_malloc_size_of = "Rc"]
+    #[conditional_malloc_size_of]
     read_again_for_branch_1: Rc<Cell<bool>>,
-    #[ignore_malloc_size_of = "Rc"]
+    #[conditional_malloc_size_of]
     read_again_for_branch_2: Rc<Cell<bool>>,
-    #[ignore_malloc_size_of = "Rc"]
+    #[conditional_malloc_size_of]
     reading: Rc<Cell<bool>>,
-    #[ignore_malloc_size_of = "Rc"]
+    #[conditional_malloc_size_of]
     canceled_1: Rc<Cell<bool>>,
-    #[ignore_malloc_size_of = "Rc"]
+    #[conditional_malloc_size_of]
     canceled_2: Rc<Cell<bool>>,
-    #[ignore_malloc_size_of = "Rc"]
+    #[conditional_malloc_size_of]
     cancel_promise: Rc<Promise>,
     tee_underlying_source: Dom<ByteTeeUnderlyingSource>,
 }

--- a/components/script/dom/stream/byteteeunderlyingsource.rs
+++ b/components/script/dom/stream/byteteeunderlyingsource.rs
@@ -41,30 +41,30 @@ pub(crate) enum ByteTeePullAlgorithm {
 /// <https://streams.spec.whatwg.org/#abstract-opdef-readablestreamdefaulttee>
 pub(crate) struct ByteTeeUnderlyingSource {
     reflector_: Reflector,
-    #[ignore_malloc_size_of = "Rc"]
+    #[conditional_malloc_size_of]
     reader: Rc<RefCell<ReaderType>>,
     stream: Dom<ReadableStream>,
     branch_1: MutNullableDom<ReadableStream>,
     branch_2: MutNullableDom<ReadableStream>,
-    #[ignore_malloc_size_of = "Rc"]
+    #[conditional_malloc_size_of]
     read_again_for_branch_1: Rc<Cell<bool>>,
-    #[ignore_malloc_size_of = "Rc"]
+    #[conditional_malloc_size_of]
     read_again_for_branch_2: Rc<Cell<bool>>,
-    #[ignore_malloc_size_of = "Rc"]
+    #[conditional_malloc_size_of]
     reading: Rc<Cell<bool>>,
-    #[ignore_malloc_size_of = "Rc"]
+    #[conditional_malloc_size_of]
     canceled_1: Rc<Cell<bool>>,
-    #[ignore_malloc_size_of = "Rc"]
+    #[conditional_malloc_size_of]
     canceled_2: Rc<Cell<bool>>,
-    #[ignore_malloc_size_of = "Rc"]
+    #[ignore_malloc_size_of = "Mozjs"]
     #[allow(clippy::redundant_allocation)]
     reason_1: Rc<Box<Heap<Value>>>,
-    #[ignore_malloc_size_of = "Rc"]
+    #[ignore_malloc_size_of = "Mozjs"]
     #[allow(clippy::redundant_allocation)]
     reason_2: Rc<Box<Heap<Value>>>,
-    #[ignore_malloc_size_of = "Rc"]
+    #[conditional_malloc_size_of]
     cancel_promise: Rc<Promise>,
-    #[ignore_malloc_size_of = "Rc"]
+    #[conditional_malloc_size_of]
     reader_version: Rc<Cell<u64>>,
     tee_cancel_algorithm: ByteTeeCancelAlgorithm,
     byte_tee_pull_algorithm: ByteTeePullAlgorithm,

--- a/components/script/dom/stream/readablestreambyobreader.rs
+++ b/components/script/dom/stream/readablestreambyobreader.rs
@@ -144,13 +144,13 @@ impl ReadIntoRequest {
 struct ByteTeeClosedPromiseRejectionHandler {
     branch_1_controller: Dom<ReadableByteStreamController>,
     branch_2_controller: Dom<ReadableByteStreamController>,
-    #[ignore_malloc_size_of = "Rc"]
+    #[conditional_malloc_size_of]
     canceled_1: Rc<Cell<bool>>,
-    #[ignore_malloc_size_of = "Rc"]
+    #[conditional_malloc_size_of]
     canceled_2: Rc<Cell<bool>>,
-    #[ignore_malloc_size_of = "Rc"]
+    #[conditional_malloc_size_of]
     cancel_promise: Rc<Promise>,
-    #[ignore_malloc_size_of = "Rc"]
+    #[conditional_malloc_size_of]
     reader_version: Rc<Cell<u64>>,
     expected_version: u64,
 }

--- a/components/script/dom/stream/readablestreamdefaultreader.rs
+++ b/components/script/dom/stream/readablestreamdefaultreader.rs
@@ -95,10 +95,10 @@ pub(crate) enum ReadRequest {
     /// Spec read loop variant, driven by read-request steps (no Promise).
     /// <https://streams.spec.whatwg.org/#read-loop>
     ReadLoop {
-        #[ignore_malloc_size_of = "Rc is hard"]
+        #[ignore_malloc_size_of = "dyn Fn"]
         #[no_trace]
         success_steps: Rc<ReadAllBytesSuccessSteps>,
-        #[ignore_malloc_size_of = "Rc is hard"]
+        #[ignore_malloc_size_of = "dyn Fn"]
         #[no_trace]
         failure_steps: Rc<ReadAllBytesFailureSteps>,
         reader: Dom<ReadableStreamDefaultReader>,

--- a/components/script/dom/webgpu/gpuadapter.rs
+++ b/components/script/dom/webgpu/gpuadapter.rs
@@ -32,7 +32,6 @@ use crate::script_runtime::CanGc;
 
 #[derive(JSTraceable, MallocSizeOf)]
 struct DroppableGPUAdapter {
-    #[ignore_malloc_size_of = "channels are hard"]
     #[no_trace]
     channel: WebGPU,
     #[no_trace]

--- a/components/script/dom/webgpu/gpubindgroup.rs
+++ b/components/script/dom/webgpu/gpubindgroup.rs
@@ -22,7 +22,6 @@ use crate::dom::webgpu::gpudevice::GPUDevice;
 use crate::script_runtime::CanGc;
 #[derive(JSTraceable, MallocSizeOf)]
 struct DroppableGPUBindGroup {
-    #[ignore_malloc_size_of = "channels are hard"]
     #[no_trace]
     channel: WebGPU,
     #[no_trace]

--- a/components/script/dom/webgpu/gpubindgrouplayout.rs
+++ b/components/script/dom/webgpu/gpubindgrouplayout.rs
@@ -24,7 +24,6 @@ use crate::script_runtime::CanGc;
 
 #[derive(JSTraceable, MallocSizeOf)]
 struct DroppableGPUBindGroupLayout {
-    #[ignore_malloc_size_of = "channels are hard"]
     #[no_trace]
     channel: WebGPU,
     #[no_trace]

--- a/components/script/dom/webgpu/gpucanvascontext.rs
+++ b/components/script/dom/webgpu/gpucanvascontext.rs
@@ -48,7 +48,6 @@ fn supported_context_format(format: GPUTextureFormat) -> bool {
 struct DroppableGPUCanvasContext {
     #[no_trace]
     context_id: WebGPUContextId,
-    #[ignore_malloc_size_of = "channels are hard"]
     #[no_trace]
     channel: WebGPU,
 }

--- a/components/script/dom/webgpu/gpucomputepipeline.rs
+++ b/components/script/dom/webgpu/gpucomputepipeline.rs
@@ -27,7 +27,6 @@ use crate::script_runtime::CanGc;
 #[dom_struct]
 pub(crate) struct GPUComputePipeline {
     reflector_: Reflector,
-    #[ignore_malloc_size_of = "channels are hard"]
     #[no_trace]
     channel: WebGPU,
     label: DomRefCell<USVString>,

--- a/components/script/dom/webgpu/gpurenderbundle.rs
+++ b/components/script/dom/webgpu/gpurenderbundle.rs
@@ -16,7 +16,6 @@ use crate::script_runtime::CanGc;
 #[dom_struct]
 pub(crate) struct GPURenderBundle {
     reflector_: Reflector,
-    #[ignore_malloc_size_of = "channels are hard"]
     #[no_trace]
     channel: WebGPU,
     #[no_trace]

--- a/components/script/dom/webgpu/gpurenderpipeline.rs
+++ b/components/script/dom/webgpu/gpurenderpipeline.rs
@@ -24,7 +24,6 @@ use crate::script_runtime::CanGc;
 #[dom_struct]
 pub(crate) struct GPURenderPipeline {
     reflector_: Reflector,
-    #[ignore_malloc_size_of = "channels are hard"]
     #[no_trace]
     channel: WebGPU,
     label: DomRefCell<USVString>,

--- a/components/script/dom/webgpu/gputexture.rs
+++ b/components/script/dom/webgpu/gputexture.rs
@@ -31,7 +31,6 @@ pub(crate) struct GPUTexture {
     texture: WebGPUTexture,
     label: DomRefCell<USVString>,
     device: Dom<GPUDevice>,
-    #[ignore_malloc_size_of = "channels are hard"]
     #[no_trace]
     channel: WebGPU,
     #[ignore_malloc_size_of = "defined in wgpu"]

--- a/components/script/dom/websocket.rs
+++ b/components/script/dom/websocket.rs
@@ -107,7 +107,6 @@ pub(crate) struct WebSocket {
     ready_state: Cell<WebSocketRequestState>,
     buffered_amount: Cell<u64>,
     clearing_buffer: Cell<bool>, // Flag to tell if there is a running thread to clear buffered_amount
-    #[ignore_malloc_size_of = "Defined in std"]
     #[no_trace]
     sender: IpcSender<WebSocketDomAction>,
     binary_type: Cell<BinaryType>,

--- a/components/script/dom/window.rs
+++ b/components/script/dom/window.rs
@@ -423,7 +423,6 @@ pub(crate) struct Window {
     exists_mut_observer: Cell<bool>,
 
     /// Cross-process access to `Paint`.
-    #[ignore_malloc_size_of = "Wraps an IpcSender"]
     #[no_trace]
     paint_api: CrossProcessPaintApi,
 

--- a/components/script/dom/workers/dedicatedworkerglobalscope.rs
+++ b/components/script/dom/workers/dedicatedworkerglobalscope.rs
@@ -195,7 +195,6 @@ pub(crate) struct DedicatedWorkerGlobalScope {
     browsing_context: Option<BrowsingContextId>,
     /// A receiver of control messages,
     /// currently only used to signal shutdown.
-    #[ignore_malloc_size_of = "Channels are hard"]
     #[no_trace]
     control_receiver: Receiver<DedicatedWorkerControlMsg>,
     #[no_trace]

--- a/components/script/dom/workers/serviceworkerglobalscope.rs
+++ b/components/script/dom/workers/serviceworkerglobalscope.rs
@@ -171,7 +171,6 @@ pub(crate) struct ServiceWorkerGlobalScope {
 
     /// A receiver of control messages,
     /// currently only used to signal shutdown.
-    #[ignore_malloc_size_of = "Channels are hard"]
     #[no_trace]
     control_receiver: Receiver<ServiceWorkerControlMsg>,
 }

--- a/components/shared/canvas/webgl.rs
+++ b/components/shared/canvas/webgl.rs
@@ -39,7 +39,7 @@ where
 }
 
 /// Entry point channel type used for sending WebGLMsg messages to the WebGL renderer.
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, MallocSizeOf)]
 pub struct WebGLChan(pub GenericSender<WebGLMsg>);
 
 impl WebGLChan {
@@ -176,7 +176,6 @@ pub struct WebGLSLVersion {
 #[derive(Clone, Debug, Deserialize, MallocSizeOf, Serialize)]
 pub struct WebGLMsgSender {
     ctx_id: WebGLContextId,
-    #[ignore_malloc_size_of = "channels are hard"]
     sender: WebGLChan,
 }
 

--- a/components/shared/embedder/lib.rs
+++ b/components/shared/embedder/lib.rs
@@ -339,7 +339,7 @@ impl TraversalId {
     }
 }
 
-#[derive(Clone, Copy, Deserialize, Eq, Hash, PartialEq, Serialize)]
+#[derive(Clone, Copy, Deserialize, Eq, Hash, PartialEq, Serialize, MallocSizeOf)]
 pub enum PixelFormat {
     /// Luminance channel only
     K8,
@@ -354,12 +354,13 @@ pub enum PixelFormat {
 }
 
 /// A raster image buffer.
-#[derive(Clone, Deserialize, Serialize)]
+#[derive(Clone, Deserialize, Serialize, MallocSizeOf)]
 pub struct Image {
     pub width: u32,
     pub height: u32,
     pub format: PixelFormat,
     /// A shared memory block containing the data of one or more image frames.
+    #[conditional_malloc_size_of]
     data: Arc<GenericSharedMemory>,
     range: Range<usize>,
 }

--- a/components/shared/net/request.rs
+++ b/components/shared/net/request.rs
@@ -173,7 +173,7 @@ pub struct PreloadEntry {
     /// <https://html.spec.whatwg.org/multipage/#preload-response>
     pub response: Option<Response>,
     /// <https://html.spec.whatwg.org/multipage/#preload-on-response-available>
-    #[ignore_malloc_size_of = "channels are hard"]
+    #[ignore_malloc_size_of = "Channels are hard"]
     pub on_response_available: Option<TokioSender<Response>>,
 }
 
@@ -313,7 +313,7 @@ pub enum BodyChunkRequest {
 #[derive(Clone, Debug, Deserialize, MallocSizeOf, Serialize)]
 pub struct RequestBody {
     /// Net's channel to communicate with script re this body.
-    #[ignore_malloc_size_of = "Channels are hard"]
+    #[conditional_malloc_size_of]
     chan: Arc<Mutex<IpcSender<BodyChunkRequest>>>,
     /// <https://fetch.spec.whatwg.org/#concept-body-source>
     source: BodySource,

--- a/components/shared/net/response.rs
+++ b/components/shared/net/response.rs
@@ -112,7 +112,7 @@ pub struct Response {
     )]
     #[ignore_malloc_size_of = "Defined in hyper"]
     pub headers: HeaderMap,
-    #[ignore_malloc_size_of = "Mutex heap size undefined"]
+    #[conditional_malloc_size_of]
     pub body: Arc<Mutex<ResponseBody>>,
     pub cache_state: CacheState,
     pub https_state: HttpsState,
@@ -131,10 +131,10 @@ pub struct Response {
     /// whether or not to try to return the internal_response when asked for actual_response
     pub return_internal: bool,
     /// <https://fetch.spec.whatwg.org/#concept-response-aborted>
-    #[ignore_malloc_size_of = "AtomicBool heap size undefined"]
+    #[conditional_malloc_size_of]
     pub aborted: Arc<AtomicBool>,
     /// track network metrics
-    #[ignore_malloc_size_of = "Mutex heap size undefined"]
+    #[conditional_malloc_size_of]
     pub resource_timing: Arc<Mutex<ResourceFetchTiming>>,
 
     /// <https://fetch.spec.whatwg.org/#concept-response-range-requested-flag>

--- a/components/shared/profile/mem.rs
+++ b/components/shared/profile/mem.rs
@@ -66,7 +66,7 @@ where
 
 /// Front-end representation of the profiler used to communicate with the
 /// profiler.
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, MallocSizeOf)]
 pub struct ProfilerChan(pub GenericSender<ProfilerMsg>);
 
 /// A handle that encompasses a registration with the memory profiler.

--- a/components/shared/webgpu/Cargo.toml
+++ b/components/shared/webgpu/Cargo.toml
@@ -15,6 +15,7 @@ path = "lib.rs"
 arrayvec = { workspace = true }
 base = { workspace = true }
 malloc_size_of = { workspace = true }
+malloc_size_of_derive = { workspace = true }
 pixels = { path = "../../pixels" }
 serde = { workspace = true }
 webrender_api = { workspace = true }

--- a/components/shared/webgpu/lib.rs
+++ b/components/shared/webgpu/lib.rs
@@ -10,6 +10,7 @@ pub mod render_commands;
 use std::ops::Range;
 
 use base::generic_channel::{GenericOneshotSender, GenericSender, GenericSharedMemory};
+use malloc_size_of_derive::MallocSizeOf;
 use serde::{Deserialize, Serialize};
 use webrender_api::euclid::default::Size2D;
 use webrender_api::{ImageDescriptor, ImageDescriptorFlags, ImageFormat};
@@ -37,7 +38,7 @@ pub type WebGPUComputePipelineResponse = Result<Pipeline<ComputePipelineId>, Err
 pub type WebGPUPoppedErrorScopeResponse = Result<Option<Error>, PopError>;
 pub type WebGPURenderPipelineResponse = Result<Pipeline<RenderPipelineId>, Error>;
 
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, MallocSizeOf)]
 pub struct WebGPU(pub GenericSender<WebGPURequest>);
 
 impl WebGPU {


### PR DESCRIPTION
We implemented many more MallocSizeOf tests (even if some such as channels are zero).
Meaning we can not ignore more of it making the code cleaner.

Testing: Compilation is the test.
