### PR TITLE
webstorage: Improve storage memory size reporting

### DIFF
--- a/components/shared/storage/webstorage_thread.rs
+++ b/components/shared/storage/webstorage_thread.rs
@@ -15,7 +15,7 @@ pub enum WebStorageType {
     Local,
 }
 
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, MallocSizeOf, Serialize)]
 pub struct OriginDescriptor {
     pub name: String,
 }

--- a/components/storage/webstorage/mod.rs
+++ b/components/storage/webstorage/mod.rs
@@ -62,7 +62,7 @@ impl WebStorageThreadFactory for GenericSender<WebStorageThreadMsg> {
     }
 }
 
-#[derive(Deserialize, Serialize)]
+#[derive(Deserialize, MallocSizeOf, Serialize)]
 pub struct StorageOrigins {
     // TODO: Consider grouping by eTLD+1
     // TODO: Consider ImmutableOrigin instead of String for tracking origins
@@ -304,13 +304,13 @@ impl WebStorageManager {
             reports.push(Report {
                 path: path!["storage", "local"],
                 kind: ReportKind::ExplicitJemallocHeapSize,
-                size: self.environments.size_of(ops),
+                size: self.environments.size_of(ops) + self.local_storage_origins.size_of(ops),
             });
 
             reports.push(Report {
                 path: path!["storage", "session"],
                 kind: ReportKind::ExplicitJemallocHeapSize,
-                size: self.session_data.size_of(ops),
+                size: self.session_data.size_of(ops) + self.session_storage_origins.size_of(ops),
             });
         });
         reports


### PR DESCRIPTION
`local_storage_origins` is ~2-3kb of memory, which is probably large enough to be included in the report, given that it likely can grow much more. A much bigger memory user is sqlite3, but I'm still working on finding a way to extract memory usage for it.

Testing: Manual
