### PR TITLE
webdriver: make pen inputs behave like mouse

### DIFF
--- a/components/webdriver_server/actions.rs
+++ b/components/webdriver_server/actions.rs
@@ -390,15 +390,15 @@ impl Handler {
             ..
         } = *self.get_pointer_input_state(source_id);
         match subtype {
-            PointerType::Pen | PointerType::Touch => {
+            PointerType::Touch => {
                 self.send_blocking_input_event_to_embedder(InputEvent::Touch(TouchEvent::new(
                     TouchEventType::Cancel,
                     TouchId(pointer_id as i32),
                     WebViewPoint::Page(Point2D::new(x as f32, y as f32)),
                 )));
             },
-            PointerType::Mouse => {
-                info!("WebDriver pointerCancel is not implemented for mouse yet");
+            PointerType::Pen | PointerType::Mouse => {
+                info!("WebDriver pointerCancel is not implemented for mouse and pen yet");
             },
         }
     }
@@ -420,12 +420,10 @@ impl Handler {
         // TODO: We have not considered pen pointer type
         let point = WebViewPoint::Page(Point2D::new(x as f32, y as f32));
         let input_event = match subtype {
-            PointerType::Mouse => InputEvent::MouseButton(MouseButtonEvent::new(
-                MouseButtonAction::Down,
-                action.button.into(),
-                point,
-            )),
-            PointerType::Pen | PointerType::Touch => InputEvent::Touch(TouchEvent::new(
+            PointerType::Pen | PointerType::Mouse => InputEvent::MouseButton(
+                MouseButtonEvent::new(MouseButtonAction::Down, action.button.into(), point),
+            ),
+            PointerType::Touch => InputEvent::Touch(TouchEvent::new(
                 TouchEventType::Down,
                 TouchId(pointer_input_state.pointer_id as i32),
                 point,
@@ -471,12 +469,10 @@ impl Handler {
         // Step 7. Perform implementation-specific action dispatch steps
         let point = WebViewPoint::Page(Point2D::new(x as f32, y as f32));
         let input_event = match subtype {
-            PointerType::Mouse => InputEvent::MouseButton(MouseButtonEvent::new(
-                MouseButtonAction::Up,
-                action.button.into(),
-                point,
-            )),
-            PointerType::Pen | PointerType::Touch => InputEvent::Touch(TouchEvent::new(
+            PointerType::Pen | PointerType::Mouse => InputEvent::MouseButton(
+                MouseButtonEvent::new(MouseButtonAction::Up, action.button.into(), point),
+            ),
+            PointerType::Touch => InputEvent::Touch(TouchEvent::new(
                 TouchEventType::Up,
                 TouchId(pointer_id as i32),
                 point,
@@ -602,10 +598,10 @@ impl Handler {
             // Step 7.2. Perform implementation-specific action dispatch steps
             let point = WebViewPoint::Page(Point2D::new(x as f32, y as f32));
 
-            // For a pointer of type "mouse"
+            // For a pointer of type "mouse" or pen
             // this will always produce events including at least a pointerMove event.
             match subtype {
-                PointerType::Mouse => {
+                PointerType::Pen | PointerType::Mouse => {
                     let input_event = InputEvent::MouseMove(MouseMoveEvent::new(point));
                     if last {
                         self.send_blocking_input_event_to_embedder(input_event);
@@ -613,9 +609,9 @@ impl Handler {
                         self.send_input_event_to_embedder(input_event);
                     }
                 },
-                // In the case where the pointerType is "pen" or "touch", and buttons is empty,
+                // In the case where the pointerType "touch", and buttons is empty,
                 // this may be a no-op.
-                PointerType::Touch | PointerType::Pen => {
+                PointerType::Touch => {
                     if pressed.contains(&ELEMENT_CLICK_BUTTON) {
                         let input_event = InputEvent::Touch(TouchEvent::new(
                             TouchEventType::Move,


### PR DESCRIPTION
This aligns with the expectations in tests/wpt/tests/pointerevents/pointerevent_attributes.html that classifies pen and mouse as 'hover' pointers, and touch as 'non hover'.

Testing: Green try run at https://github.com/webbeef/servo/actions/runs/21832655621


