### PR TITLE
script: Close existing context menus when a new one opens

### DIFF
--- a/components/script/dom/document_embedder_controls.rs
+++ b/components/script/dom/document_embedder_controls.rs
@@ -236,6 +236,24 @@ impl DocumentEmbedderControls {
     }
 
     pub(crate) fn show_context_menu(&self, hit_test_result: &HitTestResult) {
+        {
+            let mut visible_elements = self.visible_elements.borrow_mut();
+            visible_elements.retain(|index, control_element| {
+                if matches!(control_element, ControlElement::ContextMenu(..)) {
+                    let id = EmbedderControlId {
+                        webview_id: self.window.webview_id(),
+                        pipeline_id: self.window.pipeline_id(),
+                        index: index.0,
+                    };
+                    self.window
+                        .send_to_embedder(EmbedderMsg::HideEmbedderControl(id));
+                    false
+                } else {
+                    true
+                }
+            });
+        }
+
         let mut anchor_element = None;
         let mut image_element = None;
         let mut text_input_element = None;

--- a/components/servo/tests/webview.rs
+++ b/components/servo/tests/webview.rs
@@ -747,6 +747,33 @@ fn test_simple_context_menu() {
 }
 
 #[test]
+fn test_open_context_menu_closes_existing() {
+    let servo_test = ServoTest::new();
+
+    let delegate = Rc::new(WebViewDelegateImpl::default());
+    let webview = WebViewBuilder::new(servo_test.servo(), servo_test.rendering_context.clone())
+        .delegate(delegate.clone())
+        .url(Url::parse("data:text/html,<!DOCTYPE html>").unwrap())
+        .build();
+
+    show_webview_and_wait_for_rendering_to_be_ready(&servo_test, &webview, &delegate);
+    open_context_menu_at_point(&webview, DevicePoint::new(50.0, 50.0));
+
+    let captured_delegate = delegate.clone();
+    servo_test.spin(move || captured_delegate.number_of_controls_shown.get() == 0);
+
+    assert_eq!(delegate.number_of_controls_hidden.get(), 0);
+
+    open_context_menu_at_point(&webview, DevicePoint::new(25.0, 25.0));
+
+    let captured_delegate = delegate.clone();
+    servo_test.spin(move || captured_delegate.number_of_controls_hidden.get() != 1);
+
+    let captured_delegate = delegate.clone();
+    servo_test.spin(move || captured_delegate.number_of_controls_shown.get() != 2);
+}
+
+#[test]
 fn test_contextual_context_menu_items() {
     let servo_test = ServoTest::new();
 

--- a/ports/servoshell/desktop/dialog.rs
+++ b/ports/servoshell/desktop/dialog.rs
@@ -704,6 +704,7 @@ impl Dialog {
             Dialog::ColorPicker { maybe_prompt, .. } => {
                 maybe_prompt.as_ref().map(|element| element.id())
             },
+            Dialog::ContextMenu { menu, .. } => menu.as_ref().map(|menu| menu.id()),
             _ => None,
         }
     }


### PR DESCRIPTION
No longer allow showing two context menus as once. Instead only allow a
single context menu at a time. Multiple context menus cause issues with
egui, so it's quite likely that this will cause issues with even more
embedders. This fixes an issue where egui draws scary runtime errors all
over servoshell when opening multiple context menus.

Testing: This changes adds a new WebView API test.
