### PR TITLE
media: enable default controls on top-level media elements

### DIFF
--- a/components/script/dom/servoparser/mod.rs
+++ b/components/script/dom/servoparser/mod.rs
@@ -1160,6 +1160,7 @@ impl ParserContext {
                 CanGc::note(),
             );
             let audio = DomRoot::downcast::<HTMLMediaElement>(audio).unwrap();
+            audio.SetControls(true);
             audio.SetSrc(USVString(self.url.to_string()));
             DomRoot::upcast::<Node>(audio)
         } else {
@@ -1173,6 +1174,7 @@ impl ParserContext {
                 CanGc::note(),
             );
             let video = DomRoot::downcast::<HTMLMediaElement>(video).unwrap();
+            video.SetControls(true);
             video.SetSrc(USVString(self.url.to_string()));
             DomRoot::upcast::<Node>(video)
         };


### PR DESCRIPTION
This makes it possible to actually play media when loaded as top level content and not already in a video or audio element.

Testing: manual testing with `./mach run https://interactive-examples.mdn.mozilla.net/media/cc0-videos/flower.webm`

