### PR TITLE
script: Fix delaying load event blocker for parents

### DIFF
--- a/components/script/document_loader.rs
+++ b/components/script/document_loader.rs
@@ -21,6 +21,7 @@ pub(crate) enum LoadType {
     Image(#[no_trace] ServoUrl),
     Script(#[no_trace] ServoUrl),
     Subframe(#[no_trace] ServoUrl),
+    DelayingLoadEventsMode(#[no_trace] ServoUrl),
     Stylesheet(#[no_trace] ServoUrl),
     PageSource(#[no_trace] ServoUrl),
     Media,
@@ -150,16 +151,12 @@ impl DocumentLoader {
             load,
             self.blocking_loads.len()
         );
-        let idx = self
+        let index = self
             .blocking_loads
             .iter()
-            .position(|unfinished| *unfinished == *load);
-        match idx {
-            Some(i) => {
-                self.blocking_loads.remove(i);
-            },
-            None => warn!("unknown completed load {:?}", load),
-        }
+            .position(|unfinished| *unfinished == *load)
+            .expect(&format!("unknown completed load {:?}", load));
+        self.blocking_loads.remove(index);
     }
 
     pub(crate) fn is_blocked(&self) -> bool {
@@ -168,9 +165,12 @@ impl DocumentLoader {
     }
 
     pub(crate) fn is_only_blocked_by_iframes(&self) -> bool {
-        self.blocking_loads
-            .iter()
-            .all(|load| matches!(*load, LoadType::Subframe(_)))
+        self.blocking_loads.iter().all(|load| {
+            matches!(
+                *load,
+                LoadType::Subframe(_) | LoadType::DelayingLoadEventsMode(_)
+            )
+        })
     }
 
     pub(crate) fn inhibit_events(&mut self) {

--- a/components/script/dom/document.rs
+++ b/components/script/dom/document.rs
@@ -55,7 +55,7 @@ use profile_traits::time::TimerMetadataFrameType;
 use regex::bytes::Regex;
 use rustc_hash::{FxBuildHasher, FxHashMap};
 use script_bindings::interfaces::DocumentHelpers;
-use script_bindings::script_runtime::JSContext;
+use script_bindings::script_runtime::{JSContext, runtime_is_alive};
 use script_traits::{DocumentActivity, ProgressiveWebMetricType};
 use servo_arc::Arc;
 use servo_config::pref;
@@ -259,6 +259,16 @@ pub(crate) enum IsHTMLDocument {
     NonHTMLDocument,
 }
 
+#[derive(Clone, Copy, Default, MallocSizeOf, PartialEq)]
+pub(crate) enum TheEndLoadingPhase {
+    #[default]
+    Initial,
+    ProcessingDeferredScripts,
+    ProcessingAsSoonAsPossibleScripts,
+    WaitingForLoadEventBlockers,
+    Done,
+}
+
 #[derive(JSTraceable, MallocSizeOf)]
 #[cfg_attr(crown, crown::unrooted_must_root_lint::must_root)]
 struct FocusTransaction {
@@ -356,8 +366,6 @@ pub(crate) struct Document {
     stylesheets: DomRefCell<DocumentStylesheetSet<ServoStylesheetInDocument>>,
     stylesheet_list: MutNullableDom<StyleSheetList>,
     ready_state: Cell<DocumentReadyState>,
-    /// Whether the DOMContentLoaded event has already been dispatched.
-    domcontentloaded_dispatched: Cell<bool>,
     /// The state of this document's focus transaction.
     focus_transaction: DomRefCell<Option<FocusTransaction>>,
     /// The element that currently has the document focus context.
@@ -371,6 +379,8 @@ pub(crate) struct Document {
     has_focus: Cell<bool>,
     /// The script element that is currently executing.
     current_script: MutNullableDom<HTMLScriptElement>,
+    #[no_trace]
+    current_the_end_loading_phase: Cell<TheEndLoadingPhase>,
     /// <https://html.spec.whatwg.org/multipage/#pending-parsing-blocking-script>
     pending_parsing_blocking_script: DomRefCell<Option<PendingScript>>,
     /// Number of stylesheets that block executing the next parser-inserted script
@@ -2169,8 +2179,8 @@ impl Document {
         }
     }
 
-    // https://html.spec.whatwg.org/multipage/#the-end
-    // https://html.spec.whatwg.org/multipage/#delay-the-load-event
+    /// Step 8 of <https://html.spec.whatwg.org/multipage/#the-end>
+    /// <https://html.spec.whatwg.org/multipage/#delay-the-load-event>
     pub(crate) fn finish_load(&self, load: LoadType, can_gc: CanGc) {
         // This does not delay the load event anymore.
         debug!("Document got finish_load: {:?}", load);
@@ -2201,25 +2211,20 @@ impl Document {
             _ => {},
         }
 
-        // Step 4 is in another castle, namely at the end of
-        // process_deferred_scripts.
-
-        // Step 5 can be found in asap_script_loaded and
-        // asap_in_order_script_loaded.
-
-        let loader = self.loader.borrow();
-
-        // Servo measures when the top-level content (not iframes) is loaded.
-        if self.top_level_dom_complete.get().is_none() && loader.is_only_blocked_by_iframes() {
-            update_with_current_instant(&self.top_level_dom_complete);
-        }
-
-        if loader.is_blocked() || loader.events_inhibited() {
-            // Step 6.
+        // Note: if a LoadBlocker is dropped since the whole page is dropped, we shouldn't continue
+        // processing this load. Otherwise, any subsequent interaction with the document will panic.
+        if !runtime_is_alive() {
             return;
         }
 
-        ScriptThread::mark_document_with_no_blocked_loads(self);
+        // Step 8. Spin the event loop until there is nothing that delays the load event in the Document.
+        let document = Trusted::new(self);
+        self.owner_global()
+            .task_manager()
+            .dom_manipulation_task_source()
+            .queue(task!(fire_load_event: move || {
+                document.root().wait_until_load_blockers_have_resolved();
+            }));
     }
 
     /// <https://html.spec.whatwg.org/multipage/#checking-if-unloading-is-canceled>
@@ -2400,30 +2405,8 @@ impl Document {
         }
     }
 
-    // https://html.spec.whatwg.org/multipage/#the-end
-    pub(crate) fn maybe_queue_document_completion(&self) {
-        // https://html.spec.whatwg.org/multipage/#delaying-load-events-mode
-        let is_in_delaying_load_events_mode = match self.window.undiscarded_window_proxy() {
-            Some(window_proxy) => window_proxy.is_delaying_load_events_mode(),
-            None => false,
-        };
-
-        // Note: if the document is not fully active, layout will have exited already,
-        // and this method will panic.
-        // The underlying problem might actually be that layout exits while it should be kept alive.
-        // See https://github.com/servo/servo/issues/22507
-        let not_ready_for_load = self.loader.borrow().is_blocked() ||
-            !self.is_fully_active() ||
-            is_in_delaying_load_events_mode ||
-            // In case we have already aborted this document and receive a
-            // a subsequent message to load the document
-            self.loader.borrow().events_inhibited();
-
-        if not_ready_for_load {
-            // Step 6.
-            return;
-        }
-
+    /// Step 9 of <https://html.spec.whatwg.org/multipage/#the-end>
+    fn queue_document_completion(&self) {
         self.loader.borrow_mut().inhibit_events();
 
         // The rest will ever run only once per document.
@@ -2531,6 +2514,11 @@ impl Document {
         self.completely_loaded.get()
     }
 
+    pub(crate) fn start_the_end_loading_phase(&self) {
+        self.current_the_end_loading_phase
+            .set(TheEndLoadingPhase::ProcessingDeferredScripts);
+    }
+
     // https://html.spec.whatwg.org/multipage/#pending-parsing-blocking-script
     pub(crate) fn set_pending_parsing_blocking_script(
         &self,
@@ -2604,6 +2592,7 @@ impl Document {
             scripts.swap_remove(idx);
         }
         element.execute(result, can_gc);
+        self.wait_until_asap_scripts_have_executed();
     }
 
     // https://html.spec.whatwg.org/multipage/#list-of-scripts-that-will-execute-in-order-as-soon-as-possible
@@ -2626,9 +2615,11 @@ impl Document {
         {
             element.execute(result, can_gc);
         }
+
+        self.wait_until_asap_scripts_have_executed();
     }
 
-    // https://html.spec.whatwg.org/multipage/#list-of-scripts-that-will-execute-when-the-document-has-finished-parsing
+    /// <https://html.spec.whatwg.org/multipage/#list-of-scripts-that-will-execute-when-the-document-has-finished-parsing>
     pub(crate) fn add_deferred_script(&self, script: &HTMLScriptElement) {
         self.deferred_scripts.push(script);
     }
@@ -2645,53 +2636,71 @@ impl Document {
         self.process_deferred_scripts(can_gc);
     }
 
-    /// <https://html.spec.whatwg.org/multipage/#the-end> step 3.
+    /// Step 5 of <https://html.spec.whatwg.org/multipage/#the-end>
     fn process_deferred_scripts(&self, can_gc: CanGc) {
-        if self.ready_state.get() != DocumentReadyState::Interactive {
+        if self.current_the_end_loading_phase.get() != TheEndLoadingPhase::ProcessingDeferredScripts
+        {
             return;
         }
-        // Part of substep 1.
+
+        // Step 5.1. Spin the event loop until the first script in the list of scripts that will execute when the
+        // document has finished parsing has its ready to be parser-executed set to true and the parser's Document
+        // has no style sheet that is blocking scripts.
         loop {
             if self.script_blocking_stylesheets_count.get() > 0 {
                 return;
             }
+            // Step 5.3. Remove the first script element from the list of scripts that will execute when the
+            // document has finished parsing (i.e. shift out the first entry in the list).
             if let Some((element, result)) = self.deferred_scripts.take_next_ready_to_be_executed()
             {
+                // Step 5.2. Execute the script element given by the first script in the list of scripts that will execute when the document has finished parsing.
                 element.execute(result, can_gc);
             } else {
                 break;
             }
         }
+        // Step 5. While the list of scripts that will execute when the document has finished parsing is not empty:
         if self.deferred_scripts.is_empty() {
-            // https://html.spec.whatwg.org/multipage/#the-end step 4.
-            self.maybe_dispatch_dom_content_loaded();
+            self.current_the_end_loading_phase
+                .set(TheEndLoadingPhase::ProcessingAsSoonAsPossibleScripts);
+            self.dispatch_dom_content_loaded();
         }
     }
 
-    // https://html.spec.whatwg.org/multipage/#the-end step 4.
-    pub(crate) fn maybe_dispatch_dom_content_loaded(&self) {
-        if self.domcontentloaded_dispatched.get() {
-            return;
-        }
-        self.domcontentloaded_dispatched.set(true);
+    /// Step 6 of <https://html.spec.whatwg.org/multipage/#the-end>
+    fn dispatch_dom_content_loaded(&self) {
         assert_ne!(
             self.ReadyState(),
             DocumentReadyState::Complete,
             "Complete before DOMContentLoaded?"
         );
 
-        update_with_current_instant(&self.dom_content_loaded_event_start);
-
-        // Step 4.1.
+        // Step 6. Queue a global task on the DOM manipulation task source given the Document's
+        // relevant global object to run the following substeps:
         let document = Trusted::new(self);
         self.owner_global()
             .task_manager()
             .dom_manipulation_task_source()
             .queue(
                 task!(fire_dom_content_loaded_event: move || {
-                let document = document.root();
-                document.upcast::<EventTarget>().fire_bubbling_event(atom!("DOMContentLoaded"), CanGc::note());
-                update_with_current_instant(&document.dom_content_loaded_event_end);
+                    // Step 6.1. Set the Document's load timing info's DOM content loaded event start time to
+                    // the current high resolution time given the Document's relevant global object.
+                    let document = document.root();
+                    update_with_current_instant(&document.dom_content_loaded_event_start);
+                    // Step 6.2. Fire an event named DOMContentLoaded at the Document object, with its bubbles attribute initialized to true.
+                    document.upcast::<EventTarget>().fire_bubbling_event(atom!("DOMContentLoaded"), CanGc::note());
+                    // Step 6.3. Set the Document's load timing info's DOM content loaded event end time to
+                    // the current high resolution time given the Document's relevant global object.
+                    update_with_current_instant(&document.dom_content_loaded_event_end);
+                    // Step 6.4. Enable the client message queue of the ServiceWorkerContainer object
+                    // whose associated service worker client is the Document object's relevant settings object.
+                    // TODO
+
+                    // Step 6.5. Invoke WebDriver BiDi DOM content loaded with the Document's browsing context,
+                    // and a new WebDriver BiDi navigation status whose id is the Document object's during-loading
+                    // navigation ID for WebDriver BiDi, status is "pending", and url is the Document object's URL.
+                    // TODO
                 })
             );
 
@@ -2700,8 +2709,72 @@ impl Document {
             .borrow()
             .maybe_set_tti(InteractiveFlag::DOMContentLoaded);
 
-        // Step 4.2.
-        // TODO: client message queue.
+        self.wait_until_asap_scripts_have_executed();
+    }
+
+    fn has_finished_all_asap_scripts(&self) -> bool {
+        self.asap_scripts_set.borrow().is_empty() && self.asap_in_order_scripts_list.is_empty()
+    }
+
+    /// Step 7 of <https://html.spec.whatwg.org/multipage/#the-end>
+    fn wait_until_asap_scripts_have_executed(&self) {
+        if self.current_the_end_loading_phase.get() !=
+            TheEndLoadingPhase::ProcessingAsSoonAsPossibleScripts
+        {
+            return;
+        }
+        // Step 7. Spin the event loop until the set of scripts that will execute as soon as possible
+        // and the list of scripts that will execute in order as soon as possible are empty.
+        if self.has_finished_all_asap_scripts() {
+            let document = Trusted::new(self);
+            self.owner_global()
+                .task_manager()
+                .dom_manipulation_task_source()
+                .queue(task!(fire_load_event: move || {
+                    let document = document.root();
+                    // Ensure that if this task is fired multiple times, we only progress the
+                    // end of loading phase once.
+                    if document.current_the_end_loading_phase.get() !=
+                        TheEndLoadingPhase::ProcessingAsSoonAsPossibleScripts
+                    {
+                        return;
+                    }
+                    // Check again if we still fulfil the goal
+                    if !document.has_finished_all_asap_scripts() {
+                        return;
+                    }
+                    document.current_the_end_loading_phase
+                        .set(TheEndLoadingPhase::WaitingForLoadEventBlockers);
+                    document.wait_until_load_blockers_have_resolved();
+                }));
+        }
+    }
+
+    /// Step 8 of <https://html.spec.whatwg.org/multipage/#the-end>
+    pub(crate) fn wait_until_load_blockers_have_resolved(&self) {
+        if self.current_the_end_loading_phase.get() !=
+            TheEndLoadingPhase::WaitingForLoadEventBlockers
+        {
+            return;
+        }
+        // Step 8. Spin the event loop until there is nothing that delays the load event in the Document.
+        {
+            let loader = self.loader.borrow();
+
+            // Servo measures when the top-level content (not iframes) is loaded.
+            if self.top_level_dom_complete.get().is_none() && loader.is_only_blocked_by_iframes() {
+                update_with_current_instant(&self.top_level_dom_complete);
+            }
+
+            let not_ready_for_load = loader.is_blocked() || loader.events_inhibited();
+            if not_ready_for_load {
+                return;
+            }
+        }
+
+        self.current_the_end_loading_phase
+            .set(TheEndLoadingPhase::Done);
+        self.queue_document_completion();
     }
 
     /// <https://html.spec.whatwg.org/multipage/#destroy-a-document-and-its-descendants>
@@ -3733,10 +3806,10 @@ impl Document {
     ) -> Document {
         let url = url.unwrap_or_else(|| ServoUrl::parse("about:blank").unwrap());
 
-        let (ready_state, domcontentloaded_dispatched) = if source == DocumentSource::FromParser {
-            (DocumentReadyState::Loading, false)
+        let ready_state = if source == DocumentSource::FromParser {
+            DocumentReadyState::Loading
         } else {
-            (DocumentReadyState::Complete, true)
+            DocumentReadyState::Complete
         };
 
         let frame_type = match window.is_top_level() {
@@ -3816,12 +3889,12 @@ impl Document {
             stylesheets: DomRefCell::new(DocumentStylesheetSet::new()),
             stylesheet_list: MutNullableDom::new(None),
             ready_state: Cell::new(ready_state),
-            domcontentloaded_dispatched: Cell::new(domcontentloaded_dispatched),
             focus_transaction: DomRefCell::new(None),
             focused: Default::default(),
             focus_sequence: Cell::new(FocusSequenceNumber::default()),
             has_focus: Cell::new(has_focus),
             current_script: Default::default(),
+            current_the_end_loading_phase: Default::default(),
             pending_parsing_blocking_script: Default::default(),
             script_blocking_stylesheets_count: Default::default(),
             render_blocking_element_count: Default::default(),

--- a/components/script/dom/document.rs
+++ b/components/script/dom/document.rs
@@ -2515,8 +2515,16 @@ impl Document {
     }
 
     pub(crate) fn start_the_end_loading_phase(&self) {
+        assert!(self.current_the_end_loading_phase.get() == TheEndLoadingPhase::Initial);
         self.current_the_end_loading_phase
             .set(TheEndLoadingPhase::ProcessingDeferredScripts);
+        let document = Trusted::new(self);
+        self.owner_global()
+            .task_manager()
+            .dom_manipulation_task_source()
+            .queue(task!(process_deferred_scripts: move || {
+                document.root().process_deferred_scripts(CanGc::note());
+            }));
     }
 
     // https://html.spec.whatwg.org/multipage/#pending-parsing-blocking-script

--- a/components/script/dom/html/htmliframeelement.rs
+++ b/components/script/dom/html/htmliframeelement.rs
@@ -198,11 +198,15 @@ impl HTMLIFrameElement {
         match load_data.js_eval_result {
             Some(JsEvalResult::NoContent) => (),
             _ => {
-                let mut load_blocker = self.load_blocker.borrow_mut();
-                *load_blocker = Some(LoadBlocker::new(
-                    &document,
-                    LoadType::Subframe(load_data.url.clone()),
-                ));
+                // For the initial blank load, we already have the
+                // DelayingLoadEventsMode in the windowproxy
+                if matches!(pipeline_type, PipelineType::Navigation) {
+                    let mut load_blocker = self.load_blocker.borrow_mut();
+                    *load_blocker = Some(LoadBlocker::new(
+                        &document,
+                        LoadType::Subframe(load_data.url.clone()),
+                    ));
+                }
             },
         };
 

--- a/components/script/dom/servoparser/mod.rs
+++ b/components/script/dom/servoparser/mod.rs
@@ -754,15 +754,20 @@ impl ServoParser {
         assert!(self.network_input.is_empty());
         assert!(self.network_decoder.borrow().is_finished());
 
-        // Step 1.
+        // Step 1. If the active speculative HTML parser is not null, then stop the speculative HTML parser and return.
+        // TODO
+
+        // Step 3. Update the current document readiness to "interactive".
         self.document
             .set_ready_state(DocumentReadyState::Interactive, can_gc);
 
-        // Step 2.
+        // Step 2. Set the insertion point to undefined.
         self.tokenizer.end(can_gc);
+        // Step 4. Pop all the nodes off the stack of open elements.
         self.document.set_current_parser(None);
 
-        // Steps 3-12 are in another castle, namely finish_load.
+        // Step 5. While the list of scripts that will execute when the document has finished parsing is not empty:
+        self.document.start_the_end_loading_phase();
         let url = self.tokenizer.url().clone();
         self.document.finish_load(LoadType::PageSource(url), can_gc);
 

--- a/components/script/dom/window.rs
+++ b/components/script/dom/window.rs
@@ -3256,8 +3256,11 @@ impl Window {
 
             // Step 15. If navigable's parent is non-null, then set navigable's is delaying load events to true.
             let window_proxy = self.window_proxy();
-            if window_proxy.parent().is_some() {
-                window_proxy.start_delaying_load_events_mode();
+            if let Some(parent_document) =
+                window_proxy.parent().and_then(|parent| parent.document())
+            {
+                window_proxy
+                    .start_delaying_load_events_mode(&parent_document, load_data.url.clone());
             }
 
             if let Some(sender) = self.webdriver_load_status_sender.borrow().as_ref() {

--- a/components/script/dom/windowproxy.rs
+++ b/components/script/dom/windowproxy.rs
@@ -44,6 +44,7 @@ use servo_url::{ImmutableOrigin, ServoUrl};
 use storage_traits::webstorage_thread::WebStorageThreadMsg;
 use style::attr::parse_integer;
 
+use crate::document_loader::{LoadBlocker, LoadType};
 use crate::dom::bindings::cell::DomRefCell;
 use crate::dom::bindings::conversions::{ToJSValConvertible, root_from_handleobject};
 use crate::dom::bindings::error::{Error, Fallible, throw_dom_exception};
@@ -120,11 +121,7 @@ pub(crate) struct WindowProxy {
     parent: Option<Dom<WindowProxy>>,
 
     /// <https://html.spec.whatwg.org/multipage/#delaying-load-events-mode>
-    delaying_load_events_mode: Cell<bool>,
-
-    /// The creator browsing context's url.
-    #[no_trace]
-    creator_url: Option<ServoUrl>,
+    delaying_load_events_mode_blocker: DomRefCell<Option<LoadBlocker>>,
 
     /// The creator browsing context's origin.
     #[no_trace]
@@ -159,9 +156,8 @@ impl WindowProxy {
             is_closing: Cell::new(false),
             frame_element: frame_element.map(Dom::from_ref),
             parent: parent.map(Dom::from_ref),
-            delaying_load_events_mode: Cell::new(false),
+            delaying_load_events_mode_blocker: Default::default(),
             opener,
-            creator_url: creator.url,
             creator_origin: creator.origin,
             script_window_proxies: ScriptThread::window_proxies(),
         }
@@ -384,23 +380,23 @@ impl WindowProxy {
     }
 
     /// <https://html.spec.whatwg.org/multipage/#delaying-load-events-mode>
-    pub(crate) fn start_delaying_load_events_mode(&self) {
-        self.delaying_load_events_mode.set(true);
+    pub(crate) fn start_delaying_load_events_mode(
+        &self,
+        parent_document: &Document,
+        current_document_url: ServoUrl,
+    ) {
+        if current_document_url.scheme() == "javascript" {
+            return;
+        }
+        *self.delaying_load_events_mode_blocker.borrow_mut() = Some(LoadBlocker::new(
+            parent_document,
+            LoadType::DelayingLoadEventsMode(current_document_url),
+        ));
     }
 
     /// <https://html.spec.whatwg.org/multipage/#delaying-load-events-mode>
-    pub(crate) fn stop_delaying_load_events_mode(&self) {
-        // Make sure we also started delaying the load event, otherwise we might
-        // end up unblocking the parent when we shouldn't have.
-        if !self.delaying_load_events_mode.replace(false) {
-            return;
-        }
-        let Some(parent) = self.parent() else {
-            unreachable!("Can only delay load event for a parent");
-        };
-        if let Some(document) = parent.document() {
-            document.wait_until_load_blockers_have_resolved();
-        }
+    pub(crate) fn stop_delaying_load_events_mode(&self, can_gc: CanGc) {
+        LoadBlocker::terminate(&self.delaying_load_events_mode_blocker, can_gc);
     }
 
     // https://html.spec.whatwg.org/multipage/#disowned-its-opener

--- a/components/script/script_thread.rs
+++ b/components/script/script_thread.rs
@@ -1713,7 +1713,7 @@ impl ScriptThread {
     ) {
         match msg {
             ScriptThreadMessage::StopDelayingLoadEventsMode(pipeline_id) => {
-                self.handle_stop_delaying_load_events_mode(pipeline_id)
+                self.handle_stop_delaying_load_events_mode(pipeline_id, cx)
             },
             ScriptThreadMessage::NavigateIframe(
                 parent_pipeline_id,
@@ -2868,11 +2868,17 @@ impl ScriptThread {
         }
     }
 
-    fn handle_stop_delaying_load_events_mode(&self, pipeline_id: PipelineId) {
+    fn handle_stop_delaying_load_events_mode(
+        &self,
+        pipeline_id: PipelineId,
+        cx: &mut js::context::JSContext,
+    ) {
         let window = self.documents.borrow().find_window(pipeline_id);
         if let Some(window) = window {
             match window.undiscarded_window_proxy() {
-                Some(window_proxy) => window_proxy.stop_delaying_load_events_mode(),
+                Some(window_proxy) => {
+                    window_proxy.stop_delaying_load_events_mode(CanGc::from_cx(cx))
+                },
                 None => warn!(
                     "Attempted to take {} of 'delaying-load-events-mode' after having been discarded.",
                     pipeline_id
@@ -2998,7 +3004,7 @@ impl ScriptThread {
                     // when this navigation algorithm later matures,
                     // or when it terminates (whether due to having run all the steps,
                     // or being canceled, or being aborted), whichever happens first.
-                    window_proxy.stop_delaying_load_events_mode();
+                    window_proxy.stop_delaying_load_events_mode(can_gc);
                 }
             }
             self.senders
@@ -3354,13 +3360,11 @@ impl ScriptThread {
             incomplete.parent_info,
             incomplete.opener,
         );
-        if window_proxy.parent().is_some() {
-            // https://html.spec.whatwg.org/multipage/#navigating-across-documents:delaying-load-events-mode-2
-            // The user agent must take this nested browsing context
-            // out of the delaying load events mode
-            // when this navigation algorithm later matures.
-            window_proxy.stop_delaying_load_events_mode();
-        }
+        // https://html.spec.whatwg.org/multipage/#navigating-across-documents:delaying-load-events-mode-2
+        // The user agent must take this nested browsing context
+        // out of the delaying load events mode
+        // when this navigation algorithm later matures.
+        window_proxy.stop_delaying_load_events_mode(can_gc);
         window.init_window_proxy(&window_proxy);
 
         let last_modified = metadata.headers.as_ref().and_then(|headers| {

--- a/tests/wpt/meta/css/selectors/invalidation/media-loading-pseudo-classes-in-has.html.ini
+++ b/tests/wpt/meta/css/selectors/invalidation/media-loading-pseudo-classes-in-has.html.ini
@@ -1,4 +1,5 @@
 [media-loading-pseudo-classes-in-has.html]
+  expected: ERROR
   [Test :has(:stalled) invalidation]
     expected: FAIL
 

--- a/tests/wpt/meta/html/browsers/browsing-the-web/navigating-across-documents/replace-before-load/form-submit.html.ini
+++ b/tests/wpt/meta/html/browsers/browsing-the-web/navigating-across-documents/replace-before-load/form-submit.html.ini
@@ -1,6 +1,7 @@
 [form-submit.html]
+  expected: TIMEOUT
   [Replace before load, triggered by formElement.submit()]
     expected: FAIL
 
   [Replace before load, triggered by same-document formElement.submit()]
-    expected: FAIL
+    expected: TIMEOUT

--- a/tests/wpt/meta/html/webappapis/dynamic-markup-insertion/opening-the-input-stream/location-set-and-document-open.html.ini
+++ b/tests/wpt/meta/html/webappapis/dynamic-markup-insertion/opening-the-input-stream/location-set-and-document-open.html.ini
@@ -1,0 +1,3 @@
+[location-set-and-document-open.html]
+  [Location sets should cancel current navigation and prevent later document.open() from doing anything]
+    expected: FAIL

--- a/tests/wpt/meta/trusted-types/inheriting-csp-for-local-schemes.html.ini
+++ b/tests/wpt/meta/trusted-types/inheriting-csp-for-local-schemes.html.ini
@@ -1,31 +1,12 @@
 [inheriting-csp-for-local-schemes.html]
-  expected: TIMEOUT
-  [require-trusted-types-for directive should be inherited in local srcdoc frames]
-    expected: TIMEOUT
-
-  [trusted-types directive should be inherited in local srcdoc frames]
-    expected: NOTRUN
-
   [require-trusted-types-for directive should be inherited in local data frames]
-    expected: NOTRUN
+    expected: FAIL
 
   [trusted-types directive should be inherited in local data frames]
-    expected: NOTRUN
+    expected: FAIL
 
   [require-trusted-types-for directive should be inherited in local blob frames]
-    expected: NOTRUN
+    expected: FAIL
 
   [trusted-types directive should be inherited in local blob frames]
-    expected: NOTRUN
-
-  [require-trusted-types-for directive should be inherited in local about:blank frames]
-    expected: NOTRUN
-
-  [trusted-types directive should be inherited in local about:blank frames]
-    expected: NOTRUN
-
-  [require-trusted-types-for directive should not be inherited in local blank.html frames]
-    expected: NOTRUN
-
-  [trusted-types directive should not be inherited in local blank.html frames]
-    expected: NOTRUN
+    expected: FAIL


### PR DESCRIPTION
Use the LoadBlocker infrastructure to mark the iframe
blocking for the owner document (e.g. the parent).

Fixes #41972