### PR TITLE
layout: Do not consider `iframe` fragments as contentful for paint timing

### DIFF
--- a/components/layout/display_list/mod.rs
+++ b/components/layout/display_list/mod.rs
@@ -685,7 +685,10 @@ impl Fragment {
                 let style = iframe.base.style();
                 match style.get_inherited_box().visibility {
                     Visibility::Visible => {
-                        builder.mark_is_contentful();
+                        // From <https://www.w3.org/TR/paint-timing/#mark-paint-timing>:
+                        // > A parent frame should not be aware of the paint events from its child iframes, and
+                        // > vice versa. This means that a frame that contains just iframes will have first paint
+                        // > (due to the enclosing boxes of the iframes) but no first contentful paint.
                         let rect = iframe
                             .base
                             .rect

--- a/tests/wpt/meta/paint-timing/fcp-only/fcp-ignore-from-subframe.html.ini
+++ b/tests/wpt/meta/paint-timing/fcp-only/fcp-ignore-from-subframe.html.ini
@@ -1,3 +1,0 @@
-[fcp-ignore-from-subframe.html]
-  [Parent frame should not fire own paint-timing events for subframes.]
-    expected: FAIL

--- a/tests/wpt/meta/paint-timing/fcp-only/svg-in-iframe.html.ini
+++ b/tests/wpt/meta/paint-timing/fcp-only/svg-in-iframe.html.ini
@@ -1,3 +1,0 @@
-[svg-in-iframe.html]
-  [SVG in an iframe does not trigger FCP in the main frame]
-    expected: FAIL

--- a/tests/wpt/meta/paint-timing/first-paint-only/child-painting-first-image.html.ini
+++ b/tests/wpt/meta/paint-timing/first-paint-only/child-painting-first-image.html.ini
@@ -1,3 +1,0 @@
-[child-painting-first-image.html]
-  [Parent frame ignores paint-timing events fired from child image rendering.]
-    expected: FAIL


### PR DESCRIPTION
This aligns `first-contentful-paint` about `iframe` according to [specs](https://www.w3.org/TR/paint-timing/#mark-paint-timing), Step: 10.2.1.
 
> NOTE: A parent frame should not be aware of the paint events from its child iframes, and vice versa. This means that a frame that contains just iframes will have [first paint](https://www.w3.org/TR/paint-timing/#first-paint) (due to the enclosing boxes of the iframes) but no [first contentful paint](https://www.w3.org/TR/paint-timing/#first-contentful-paint).

Testing: Update WPT tests expectations.
