### PR TITLE
media: Implement MallocSizeOf for most of the types used

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5392,11 +5392,13 @@ dependencies = [
  "euclid",
  "ipc-channel",
  "log",
+ "malloc_size_of_derive",
  "paint_api",
  "rustc-hash 2.1.1",
  "serde",
  "servo-media",
  "servo_config",
+ "servo_malloc_size_of",
  "webrender_api",
 ]
 
@@ -8318,6 +8320,7 @@ dependencies = [
  "byte-slice-cast",
  "euclid",
  "log",
+ "malloc_size_of_derive",
  "num-complex",
  "num-traits",
  "petgraph",
@@ -8327,6 +8330,7 @@ dependencies = [
  "servo-media-player",
  "servo-media-streams",
  "servo-media-traits",
+ "servo_malloc_size_of",
  "smallvec",
  "speexdsp-resampler",
 ]
@@ -8435,22 +8439,30 @@ name = "servo-media-player"
 version = "0.0.1"
 dependencies = [
  "ipc-channel",
+ "malloc_size_of_derive",
  "serde",
  "serde_derive",
  "servo-media-streams",
  "servo-media-traits",
+ "servo_malloc_size_of",
 ]
 
 [[package]]
 name = "servo-media-streams"
 version = "0.0.1"
 dependencies = [
+ "malloc_size_of_derive",
+ "servo_malloc_size_of",
  "uuid",
 ]
 
 [[package]]
 name = "servo-media-traits"
 version = "0.0.1"
+dependencies = [
+ "malloc_size_of_derive",
+ "servo_malloc_size_of",
+]
 
 [[package]]
 name = "servo-media-webrtc"

--- a/components/malloc_size_of/lib.rs
+++ b/components/malloc_size_of/lib.rs
@@ -1060,6 +1060,12 @@ impl MallocSizeOf for ipc_channel::ipc::IpcSharedMemory {
     }
 }
 
+impl<T> MallocSizeOf for std::sync::mpsc::Sender<T> {
+    fn size_of(&self, _ops: &mut MallocSizeOfOps) -> usize {
+        0
+    }
+}
+
 impl<T: MallocSizeOf> MallocSizeOf for accountable_refcell::RefCell<T> {
     fn size_of(&self, ops: &mut MallocSizeOfOps) -> usize {
         self.borrow().size_of(ops)
@@ -1093,6 +1099,7 @@ malloc_size_of_is_0!(resvg::usvg::fontdb::Weight);
 malloc_size_of_is_0!(resvg::usvg::fontdb::Stretch);
 malloc_size_of_is_0!(resvg::usvg::fontdb::Language);
 malloc_size_of_is_0!(std::num::NonZeroU16);
+malloc_size_of_is_0!(std::num::NonZeroU32);
 malloc_size_of_is_0!(std::num::NonZeroU64);
 malloc_size_of_is_0!(std::num::NonZeroUsize);
 malloc_size_of_is_0!(std::sync::atomic::AtomicBool);

--- a/components/media/audio/Cargo.toml
+++ b/components/media/audio/Cargo.toml
@@ -22,6 +22,8 @@ servo-media-traits = { path = "../traits" }
 servo-media-streams = { path = "../streams" }
 smallvec = "1"
 speexdsp-resampler = "0.1.0"
+malloc_size_of = { workspace = true }
+malloc_size_of_derive = { workspace = true }
 num-complex = "0.2.4"
 
 [dependencies.petgraph]

--- a/components/media/audio/analyser_node.rs
+++ b/components/media/audio/analyser_node.rs
@@ -5,6 +5,8 @@
 use std::cmp;
 use std::f32::consts::PI;
 
+use malloc_size_of_derive::MallocSizeOf;
+
 use crate::block::{Block, Chunk, FRAMES_PER_BLOCK_USIZE};
 use crate::node::{AudioNodeEngine, AudioNodeType, BlockInfo, ChannelInfo, ChannelInterpretation};
 
@@ -48,6 +50,7 @@ pub const MAX_BLOCK_COUNT: usize = MAX_FFT_SIZE / FRAMES_PER_BLOCK_USIZE;
 /// The actual analysis is done on the DOM side. We provide
 /// the actual base functionality in this struct, so the DOM
 /// just has to do basic shimming
+#[derive(MallocSizeOf)]
 pub struct AnalysisEngine {
     /// The number of past sample-frames to consider in the FFT
     fft_size: usize,
@@ -56,6 +59,7 @@ pub struct AnalysisEngine {
     max_decibels: f64,
     /// This is a ring buffer containing the last MAX_FFT_SIZE
     /// sample-frames
+    #[ignore_malloc_size_of = "Do not know how"]
     data: Box<[f32; MAX_FFT_SIZE]>,
     /// The index of the current block
     current_block: usize,

--- a/components/media/audio/biquad_filter_node.rs
+++ b/components/media/audio/biquad_filter_node.rs
@@ -4,13 +4,14 @@
 
 use std::f64::consts::{PI, SQRT_2};
 
+use malloc_size_of_derive::MallocSizeOf;
 use smallvec::SmallVec;
 
 use crate::block::{Chunk, Tick};
 use crate::node::{AudioNodeEngine, AudioNodeMessage, AudioNodeType, BlockInfo, ChannelInfo};
 use crate::param::{Param, ParamType};
 
-#[derive(Copy, Clone, Debug)]
+#[derive(Copy, Clone, Debug, MallocSizeOf)]
 pub struct BiquadFilterNodeOptions {
     pub filter: FilterType,
     pub frequency: f32,
@@ -19,7 +20,7 @@ pub struct BiquadFilterNodeOptions {
     pub gain: f32,
 }
 
-#[derive(Copy, Clone, Debug)]
+#[derive(Copy, Clone, Debug, MallocSizeOf)]
 pub enum FilterType {
     LowPass,
     HighPass,
@@ -43,7 +44,7 @@ impl Default for BiquadFilterNodeOptions {
     }
 }
 
-#[derive(Copy, Clone, Debug)]
+#[derive(Copy, Clone, Debug, MallocSizeOf)]
 pub enum BiquadFilterNodeMessage {
     SetFilterType(FilterType),
 }

--- a/components/media/audio/buffer_source_node.rs
+++ b/components/media/audio/buffer_source_node.rs
@@ -2,6 +2,8 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
+use malloc_size_of_derive::MallocSizeOf;
+
 use crate::block::{Block, Chunk, FRAMES_PER_BLOCK, Tick};
 use crate::node::{
     AudioNodeEngine, AudioNodeType, AudioScheduledSourceNodeMessage, BlockInfo, ChannelInfo,
@@ -10,7 +12,7 @@ use crate::node::{
 use crate::param::{Param, ParamType};
 
 /// Control messages directed to AudioBufferSourceNodes.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, MallocSizeOf)]
 pub enum AudioBufferSourceNodeMessage {
     /// Set the data block holding the audio sample data to be played.
     SetBuffer(Option<AudioBuffer>),
@@ -25,7 +27,7 @@ pub enum AudioBufferSourceNodeMessage {
 }
 
 /// This specifies options for constructing an AudioBufferSourceNode.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, MallocSizeOf)]
 pub struct AudioBufferSourceNodeOptions {
     /// The audio asset to be played.
     pub buffer: Option<AudioBuffer>,
@@ -360,7 +362,7 @@ impl AudioNodeEngine for AudioBufferSourceNode {
     );
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, MallocSizeOf)]
 pub struct AudioBuffer {
     /// Invariant: all buffers must be of the same length
     pub buffers: Vec<Vec<f32>>,

--- a/components/media/audio/channel_node.rs
+++ b/components/media/audio/channel_node.rs
@@ -2,12 +2,14 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
+use malloc_size_of_derive::MallocSizeOf;
+
 use crate::block::{Block, Chunk, FRAMES_PER_BLOCK_USIZE};
 use crate::node::{
     AudioNodeEngine, AudioNodeType, BlockInfo, ChannelCountMode, ChannelInfo, ChannelInterpretation,
 };
 
-#[derive(Copy, Clone, Debug)]
+#[derive(Copy, Clone, Debug, MallocSizeOf)]
 pub struct ChannelNodeOptions {
     pub channels: u8,
 }

--- a/components/media/audio/constant_source_node.rs
+++ b/components/media/audio/constant_source_node.rs
@@ -2,6 +2,8 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
+use malloc_size_of_derive::MallocSizeOf;
+
 use crate::block::{Chunk, Tick};
 use crate::node::{
     AudioNodeEngine, AudioNodeType, AudioScheduledSourceNodeMessage, BlockInfo, ChannelInfo,
@@ -9,7 +11,7 @@ use crate::node::{
 };
 use crate::param::{Param, ParamType};
 
-#[derive(Copy, Clone, Debug)]
+#[derive(Copy, Clone, Debug, MallocSizeOf)]
 pub struct ConstantSourceNodeOptions {
     pub offset: f32,
 }

--- a/components/media/audio/gain_node.rs
+++ b/components/media/audio/gain_node.rs
@@ -2,11 +2,13 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
+use malloc_size_of_derive::MallocSizeOf;
+
 use crate::block::{Chunk, Tick};
 use crate::node::{AudioNodeEngine, AudioNodeType, BlockInfo, ChannelInfo};
 use crate::param::{Param, ParamType};
 
-#[derive(Copy, Clone, Debug)]
+#[derive(Copy, Clone, Debug, MallocSizeOf)]
 pub struct GainNodeOptions {
     pub gain: f32,
 }

--- a/components/media/audio/graph.rs
+++ b/components/media/audio/graph.rs
@@ -5,6 +5,8 @@
 use std::cell::{RefCell, RefMut};
 use std::{cmp, fmt, hash};
 
+use malloc_size_of::MallocSizeOf as MallocSizeOfTrait;
+use malloc_size_of_derive::MallocSizeOf;
 use petgraph::Direction;
 use petgraph::graph::DefaultIx;
 use petgraph::stable_graph::{NodeIndex, StableGraph};
@@ -17,10 +19,10 @@ use crate::listener::AudioListenerNode;
 use crate::node::{AudioNodeEngine, BlockInfo, ChannelCountMode, ChannelInterpretation};
 use crate::param::ParamType;
 
-#[derive(Clone, Copy, PartialEq, Eq, Ord, PartialOrd, Hash, Debug)]
+#[derive(Clone, Copy, PartialEq, Eq, Ord, PartialOrd, Hash, Debug, MallocSizeOf)]
 /// A unique identifier for nodes in the graph. Stable
 /// under graph mutation.
-pub struct NodeId(NodeIndex<DefaultIx>);
+pub struct NodeId(#[ignore_malloc_size_of = "External Type"] NodeIndex<DefaultIx>);
 
 impl NodeId {
     pub fn input(self, port: u32) -> PortId<InputPort> {
@@ -46,7 +48,7 @@ impl NodeId {
 ///
 /// Kind is a zero sized type and is useful for distinguishing
 /// between input and output ports (which may otherwise share indices)
-#[derive(Clone, Copy, PartialEq, Eq, Ord, PartialOrd, Hash, Debug)]
+#[derive(Clone, Copy, PartialEq, Eq, Ord, PartialOrd, Hash, Debug, MallocSizeOf)]
 pub enum PortIndex<Kind: PortKind> {
     Port(u32),
     Param(Kind::ParamId),
@@ -62,19 +64,33 @@ impl<Kind: PortKind> PortId<Kind> {
 }
 
 pub trait PortKind {
-    type ParamId: Copy + Eq + PartialEq + Ord + PartialOrd + hash::Hash + fmt::Debug;
-    type Listener: Copy + Eq + PartialEq + Ord + PartialOrd + hash::Hash + fmt::Debug;
+    type ParamId: Copy
+        + Eq
+        + PartialEq
+        + Ord
+        + PartialOrd
+        + hash::Hash
+        + fmt::Debug
+        + MallocSizeOfTrait;
+    type Listener: Copy
+        + Eq
+        + PartialEq
+        + Ord
+        + PartialOrd
+        + hash::Hash
+        + fmt::Debug
+        + MallocSizeOfTrait;
 }
 
 /// An identifier for a port.
-#[derive(Clone, Copy, PartialEq, Eq, Ord, PartialOrd, Hash, Debug)]
+#[derive(Clone, Copy, PartialEq, Eq, Ord, PartialOrd, Hash, Debug, MallocSizeOf)]
 pub struct PortId<Kind: PortKind>(NodeId, PortIndex<Kind>);
 
-#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Debug)]
+#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Debug, MallocSizeOf)]
 /// Marker type for denoting that the port is an input port
 /// of the node it is connected to
 pub struct InputPort;
-#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Debug)]
+#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Debug, MallocSizeOf)]
 /// Marker type for denoting that the port is an output port
 /// of the node it is connected to
 pub struct OutputPort;
@@ -84,7 +100,7 @@ impl PortKind for InputPort {
     type Listener = ();
 }
 
-#[derive(Debug, Hash, PartialOrd, Ord, PartialEq, Eq, Copy, Clone)]
+#[derive(Debug, Hash, PartialOrd, Ord, PartialEq, Eq, Copy, Clone, MallocSizeOf)]
 pub enum Void {}
 
 impl PortKind for OutputPort {

--- a/components/media/audio/iir_filter_node.rs
+++ b/components/media/audio/iir_filter_node.rs
@@ -6,6 +6,7 @@ use std::collections::VecDeque;
 use std::sync::Arc;
 
 use log::warn;
+use malloc_size_of_derive::MallocSizeOf;
 use num_complex::Complex64;
 
 use crate::block::Chunk;
@@ -13,9 +14,11 @@ use crate::node::{AudioNodeEngine, AudioNodeType, BlockInfo, ChannelInfo};
 
 const MAX_COEFFS: usize = 20;
 
-#[derive(Debug)]
+#[derive(Debug, MallocSizeOf)]
 pub struct IIRFilterNodeOptions {
+    #[conditional_malloc_size_of]
     pub feedforward: Arc<Vec<f64>>,
+    #[conditional_malloc_size_of]
     pub feedback: Arc<Vec<f64>>,
 }
 

--- a/components/media/audio/media_element_source_node.rs
+++ b/components/media/audio/media_element_source_node.rs
@@ -7,12 +7,13 @@ use std::collections::hash_map::Entry;
 use std::sync::mpsc::Sender;
 use std::sync::{Arc, Mutex};
 
+use malloc_size_of_derive::MallocSizeOf;
 use player::audio::AudioRenderer;
 
 use crate::block::{Block, Chunk, FRAMES_PER_BLOCK};
 use crate::node::{AudioNodeEngine, AudioNodeType, BlockInfo, ChannelInfo};
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, MallocSizeOf)]
 pub enum MediaElementSourceNodeMessage {
     GetAudioRenderer(Sender<Arc<Mutex<dyn AudioRenderer>>>),
 }

--- a/components/media/audio/node.rs
+++ b/components/media/audio/node.rs
@@ -5,6 +5,7 @@
 use std::cmp::min;
 use std::sync::mpsc::Sender;
 
+use malloc_size_of_derive::MallocSizeOf;
 use servo_media_streams::{MediaSocket, MediaStreamId};
 
 use crate::biquad_filter_node::{BiquadFilterNodeMessage, BiquadFilterNodeOptions};
@@ -22,8 +23,9 @@ use crate::stereo_panner::StereoPannerOptions;
 use crate::wave_shaper_node::{WaveShaperNodeMessage, WaveShaperNodeOptions};
 
 /// Information required to construct an audio node
+#[derive(MallocSizeOf)]
 pub enum AudioNodeInit {
-    AnalyserNode(Box<dyn FnMut(Block) + Send>),
+    AnalyserNode(#[ignore_malloc_size_of = "Fn"] Box<dyn FnMut(Block) + Send>),
     BiquadFilterNode(BiquadFilterNodeOptions),
     AudioBuffer,
     AudioBufferSourceNode(AudioBufferSourceNodeOptions),
@@ -36,7 +38,7 @@ pub enum AudioNodeInit {
     GainNode(GainNodeOptions),
     IIRFilterNode(IIRFilterNodeOptions),
     MediaElementSourceNode,
-    MediaStreamDestinationNode(Box<dyn MediaSocket>),
+    MediaStreamDestinationNode(#[ignore_malloc_size_of = "Fn"] Box<dyn MediaSocket>),
     MediaStreamSourceNode(MediaStreamId),
     OscillatorNode(OscillatorNodeOptions),
     PannerNode(PannerNodeOptions),
@@ -47,7 +49,7 @@ pub enum AudioNodeInit {
 }
 
 /// Type of AudioNodeEngine.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, MallocSizeOf)]
 pub enum AudioNodeType {
     /// Not a constructable node
     AudioListenerNode,
@@ -75,14 +77,14 @@ pub enum AudioNodeType {
     WaveShaperNode,
 }
 
-#[derive(Copy, Clone, PartialEq, Eq, Debug)]
+#[derive(Copy, Clone, PartialEq, Eq, Debug, MallocSizeOf)]
 pub enum ChannelCountMode {
     Max,
     ClampedMax,
     Explicit,
 }
 
-#[derive(Copy, Clone, PartialEq, Eq, Debug)]
+#[derive(Copy, Clone, PartialEq, Eq, Debug, MallocSizeOf)]
 pub enum ChannelInterpretation {
     Discrete,
     Speakers,
@@ -103,6 +105,7 @@ impl BlockInfo {
     }
 }
 
+#[derive(MallocSizeOf)]
 pub struct ChannelInfo {
     pub count: u8,
     pub mode: ChannelCountMode,
@@ -207,6 +210,7 @@ pub(crate) trait AudioNodeEngine: Send + AudioNodeCommon {
     }
 }
 
+#[derive(MallocSizeOf)]
 pub enum AudioNodeMessage {
     AudioBufferSourceNode(AudioBufferSourceNodeMessage),
     AudioScheduledSourceNode(AudioScheduledSourceNodeMessage),
@@ -232,13 +236,14 @@ impl OnEndedCallback {
 }
 
 /// Type of message directed to AudioScheduledSourceNodes.
+#[derive(MallocSizeOf)]
 pub enum AudioScheduledSourceNodeMessage {
     /// Schedules a sound to playback at an exact time.
     Start(f64),
     /// Schedules a sound to stop playback at an exact time.
     Stop(f64),
     /// Register onended event callback.
-    RegisterOnEndedCallback(OnEndedCallback),
+    RegisterOnEndedCallback(#[ignore_malloc_size_of = "Fn"] OnEndedCallback),
 }
 
 #[derive(Clone, Copy, PartialEq, Eq)]

--- a/components/media/audio/oscillator_node.rs
+++ b/components/media/audio/oscillator_node.rs
@@ -2,6 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
+use malloc_size_of_derive::MallocSizeOf;
 use num_traits::cast::NumCast;
 
 use crate::block::{Chunk, Tick};
@@ -11,11 +12,11 @@ use crate::node::{
 };
 use crate::param::{Param, ParamType};
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, MallocSizeOf)]
 pub struct PeriodicWaveOptions {
     // XXX https://webaudio.github.io/web-audio-api/#dictdef-periodicwaveoptions
 }
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, MallocSizeOf)]
 pub enum OscillatorType {
     Sine,
     Square,
@@ -24,7 +25,7 @@ pub enum OscillatorType {
     Custom,
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, MallocSizeOf)]
 pub struct OscillatorNodeOptions {
     pub oscillator_type: OscillatorType,
     pub freq: f32,
@@ -43,7 +44,7 @@ impl Default for OscillatorNodeOptions {
     }
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, MallocSizeOf)]
 pub enum OscillatorNodeMessage {
     SetOscillatorType(OscillatorType),
 }

--- a/components/media/audio/panner_node.rs
+++ b/components/media/audio/panner_node.rs
@@ -5,6 +5,7 @@
 use std::f32::consts::PI;
 
 use euclid::default::Vector3D;
+use malloc_size_of_derive::MallocSizeOf;
 
 use crate::block::{Block, Chunk, FRAMES_PER_BLOCK, Tick};
 use crate::node::{AudioNodeEngine, AudioNodeMessage, AudioNodeType, BlockInfo, ChannelInfo};
@@ -16,20 +17,20 @@ pub fn normalize_zero(v: Vector3D<f32>) -> Vector3D<f32> {
     if len == 0. { v } else { v / len }
 }
 
-#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq, MallocSizeOf)]
 pub enum PanningModel {
     EqualPower,
     HRTF,
 }
 
-#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq, MallocSizeOf)]
 pub enum DistanceModel {
     Linear,
     Inverse,
     Exponential,
 }
 
-#[derive(Copy, Clone, Debug)]
+#[derive(Copy, Clone, Debug, MallocSizeOf)]
 pub struct PannerNodeOptions {
     pub panning_model: PanningModel,
     pub distance_model: DistanceModel,
@@ -47,6 +48,7 @@ pub struct PannerNodeOptions {
     pub cone_outer_gain: f64,
 }
 
+#[derive(MallocSizeOf)]
 pub enum PannerNodeMessage {
     SetPanningModel(PanningModel),
     SetDistanceModel(DistanceModel),

--- a/components/media/audio/param.rs
+++ b/components/media/audio/param.rs
@@ -2,10 +2,12 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
+use malloc_size_of_derive::MallocSizeOf;
+
 use crate::block::{Block, FRAMES_PER_BLOCK_USIZE, Tick};
 use crate::node::BlockInfo;
 
-#[derive(Clone, Copy, Debug, Hash, Eq, PartialEq, Ord, PartialOrd)]
+#[derive(Clone, Copy, Debug, Hash, Eq, PartialEq, Ord, PartialOrd, MallocSizeOf)]
 pub enum ParamType {
     Frequency,
     Detune,
@@ -20,7 +22,7 @@ pub enum ParamType {
     Offset,
 }
 
-#[derive(Clone, Copy, Debug, Hash, Eq, PartialEq, Ord, PartialOrd)]
+#[derive(Clone, Copy, Debug, Hash, Eq, PartialEq, Ord, PartialOrd, MallocSizeOf)]
 pub enum ParamDir {
     X,
     Y,
@@ -46,7 +48,7 @@ pub struct Param {
     dirty: bool,
 }
 
-#[derive(Copy, Clone, Eq, PartialEq, Debug)]
+#[derive(Copy, Clone, Eq, PartialEq, Debug, MallocSizeOf)]
 pub enum ParamRate {
     /// Value is held for entire block
     KRate,
@@ -268,7 +270,7 @@ impl Param {
     }
 }
 
-#[derive(Clone, Copy, Eq, PartialEq, Debug)]
+#[derive(Clone, Copy, Eq, PartialEq, Debug, MallocSizeOf)]
 pub enum RampKind {
     Linear,
     Exponential,
@@ -290,7 +292,7 @@ pub(crate) enum AutomationEvent {
     CancelScheduledValues(Tick),
 }
 
-#[derive(Clone, PartialEq, Debug)]
+#[derive(Clone, PartialEq, Debug, MallocSizeOf)]
 /// An AutomationEvent that uses times in s instead of Ticks
 pub enum UserAutomationEvent {
     SetValue(f32),

--- a/components/media/audio/render_thread.rs
+++ b/components/media/audio/render_thread.rs
@@ -4,6 +4,7 @@
 
 use std::sync::mpsc::{Receiver, Sender};
 
+use malloc_size_of_derive::MallocSizeOf;
 use servo_media_streams::{MediaSocket, MediaStreamId};
 
 use crate::analyser_node::AnalyserNode;
@@ -30,6 +31,7 @@ use crate::{AudioBackend, AudioStreamReader};
 
 pub type SinkEosCallback = Box<dyn Fn(Box<dyn AsRef<[f32]>>) + Send + Sync + 'static>;
 
+#[derive(MallocSizeOf)]
 pub enum AudioRenderThreadMsg {
     CreateNode(AudioNodeInit, Sender<NodeId>, ChannelInfo),
     ConnectPorts(PortId<OutputPort>, PortId<InputPort>),
@@ -47,7 +49,7 @@ pub enum AudioRenderThreadMsg {
     DisconnectOutputBetween(PortId<OutputPort>, NodeId),
     DisconnectOutputBetweenTo(PortId<OutputPort>, PortId<InputPort>),
 
-    SetSinkEosCallback(SinkEosCallback),
+    SetSinkEosCallback(#[ignore_malloc_size_of = "Fn"] SinkEosCallback),
 
     SetMute(bool),
 }

--- a/components/media/audio/stereo_panner.rs
+++ b/components/media/audio/stereo_panner.rs
@@ -4,11 +4,13 @@
 
 use std::f32::consts::PI;
 
+use malloc_size_of_derive::MallocSizeOf;
+
 use crate::block::{Chunk, FRAMES_PER_BLOCK, Tick};
 use crate::node::{AudioNodeEngine, AudioNodeType, BlockInfo, ChannelInfo};
 use crate::param::{Param, ParamType};
 
-#[derive(Copy, Clone, Debug)]
+#[derive(Copy, Clone, Debug, MallocSizeOf)]
 pub struct StereoPannerOptions {
     pub pan: f32,
 }

--- a/components/media/audio/wave_shaper_node.rs
+++ b/components/media/audio/wave_shaper_node.rs
@@ -2,19 +2,20 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
+use malloc_size_of_derive::MallocSizeOf;
 use speexdsp_resampler::State as SpeexResamplerState;
 
 use crate::block::{Chunk, FRAMES_PER_BLOCK_USIZE};
 use crate::node::{AudioNodeEngine, AudioNodeType, BlockInfo, ChannelInfo};
 
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq, MallocSizeOf)]
 pub enum OverSampleType {
     None,
     Double,
     Quadruple,
 }
 
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq, MallocSizeOf)]
 enum TailtimeBlocks {
     Zero,
     One,
@@ -35,7 +36,7 @@ impl OverSampleType {
 
 type WaveShaperCurve = Option<Vec<f32>>;
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, MallocSizeOf)]
 pub struct WaveShaperNodeOptions {
     pub curve: WaveShaperCurve,
     pub oversample: OverSampleType,
@@ -50,19 +51,21 @@ impl Default for WaveShaperNodeOptions {
     }
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, MallocSizeOf)]
 pub enum WaveShaperNodeMessage {
     SetCurve(WaveShaperCurve),
 }
 
-#[derive(AudioNodeCommon)]
+#[derive(AudioNodeCommon, MallocSizeOf)]
 pub(crate) struct WaveShaperNode {
     curve_set: bool,
     curve: WaveShaperCurve,
     #[allow(dead_code)]
     oversample: OverSampleType,
     channel_info: ChannelInfo,
+    #[ignore_malloc_size_of = "External Type"]
     upsampler: Option<SpeexResamplerState>,
+    #[ignore_malloc_size_of = "External Type"]
     downsampler: Option<SpeexResamplerState>,
     tailtime_blocks_left: TailtimeBlocks,
 }

--- a/components/media/media-thread/Cargo.toml
+++ b/components/media/media-thread/Cargo.toml
@@ -20,4 +20,6 @@ rustc-hash = { workspace = true }
 serde = { workspace = true }
 servo-media = { workspace = true }
 servo_config = { path = "../../config" }
+malloc_size_of = { workspace = true }
+malloc_size_of_derive = { workspace = true }
 webrender_api = { workspace = true }

--- a/components/media/media-thread/lib.rs
+++ b/components/media/media-thread/lib.rs
@@ -12,6 +12,7 @@ use std::sync::Mutex;
 use euclid::default::Size2D;
 use ipc_channel::ipc::{IpcReceiver, IpcSender, channel};
 use log::warn;
+use malloc_size_of_derive::MallocSizeOf;
 use paint_api::{
     ExternalImageSource, WebRenderExternalImageApi, WebRenderExternalImageHandlers,
     WebRenderImageHandlerType,
@@ -78,7 +79,7 @@ pub enum GLPlayerMsg {
 /// A [`PlayerGLContext`] that renders to a window. Note that if the background
 /// thread is not started for this context, then it is inactive (returning
 /// `Unknown` values in the trait implementation).
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, MallocSizeOf)]
 pub struct WindowGLContext {
     /// Application's GL Context
     pub context: GlContext,

--- a/components/media/player/Cargo.toml
+++ b/components/media/player/Cargo.toml
@@ -15,6 +15,8 @@ path = "lib.rs"
 serde = "1.0.66"
 serde_derive = "1.0.66"
 ipc-channel = { workspace = true }
+malloc_size_of = { workspace = true }
+malloc_size_of_derive = { workspace = true }
 
 [dependencies.servo-media-streams]
 path = "../streams"

--- a/components/media/player/context.rs
+++ b/components/media/player/context.rs
@@ -11,7 +11,9 @@
 //! The client application should implement this trait and pass the
 //! trait object to its `player` instance.
 
-#[derive(Clone, Debug, Deserialize, Serialize)]
+use malloc_size_of_derive::MallocSizeOf;
+
+#[derive(Clone, Debug, Deserialize, Serialize, MallocSizeOf)]
 pub enum GlContext {
     /// The EGL platform used primarily with the X11, Wayland and
     /// Android window systems as well as on embedded Linux.
@@ -21,7 +23,7 @@ pub enum GlContext {
     Unknown,
 }
 
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, MallocSizeOf)]
 pub enum NativeDisplay {
     /// The EGLDisplay memory address
     Egl(usize),
@@ -33,7 +35,7 @@ pub enum NativeDisplay {
     Unknown,
 }
 
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, MallocSizeOf)]
 pub enum GlApi {
     OpenGL,
     OpenGL3,

--- a/components/media/player/video.rs
+++ b/components/media/player/video.rs
@@ -4,9 +4,11 @@
 
 use std::sync::Arc;
 
-#[derive(Clone)]
+use malloc_size_of_derive::MallocSizeOf;
+
+#[derive(Clone, MallocSizeOf)]
 pub enum VideoFrameData {
-    Raw(Arc<Vec<u8>>),
+    Raw(#[conditional_malloc_size_of] Arc<Vec<u8>>),
     Texture(u32),
     OESTexture(u32),
 }
@@ -15,11 +17,12 @@ pub trait Buffer: Send + Sync {
     fn to_vec(&self) -> Option<VideoFrameData>;
 }
 
-#[derive(Clone)]
+#[derive(Clone, MallocSizeOf)]
 pub struct VideoFrame {
     width: i32,
     height: i32,
     data: VideoFrameData,
+    #[ignore_malloc_size_of = "Difficult"]
     _buffer: Arc<dyn Buffer>,
 }
 

--- a/components/media/streams/Cargo.toml
+++ b/components/media/streams/Cargo.toml
@@ -12,4 +12,6 @@ name = "servo_media_streams"
 path = "lib.rs"
 
 [dependencies]
+malloc_size_of = { workspace = true }
+malloc_size_of_derive = { workspace = true }
 uuid = { version = "1.4", features = ["v4"] }

--- a/components/media/streams/registry.rs
+++ b/components/media/streams/registry.rs
@@ -5,6 +5,7 @@
 use std::collections::HashMap;
 use std::sync::{Arc, LazyLock, Mutex};
 
+use malloc_size_of_derive::MallocSizeOf;
 use uuid::Uuid;
 
 use super::MediaStream;
@@ -14,7 +15,7 @@ type RegisteredMediaStream = Arc<Mutex<dyn MediaStream>>;
 static MEDIA_STREAMS_REGISTRY: LazyLock<Mutex<HashMap<MediaStreamId, RegisteredMediaStream>>> =
     LazyLock::new(|| Mutex::new(HashMap::new()));
 
-#[derive(Clone, Copy, Default, Hash, Eq, PartialEq)]
+#[derive(Clone, Copy, Default, Hash, Eq, PartialEq, MallocSizeOf)]
 pub struct MediaStreamId(Uuid);
 impl MediaStreamId {
     pub fn new() -> MediaStreamId {

--- a/components/media/traits/Cargo.toml
+++ b/components/media/traits/Cargo.toml
@@ -10,3 +10,7 @@ rust-version.workspace = true
 [lib]
 name = "servo_media_traits"
 path = "lib.rs"
+
+[dependencies]
+malloc_size_of = { workspace = true }
+malloc_size_of_derive = { workspace = true }

--- a/components/media/traits/lib.rs
+++ b/components/media/traits/lib.rs
@@ -4,9 +4,11 @@
 
 use std::num::NonZeroU32;
 use std::sync::mpsc::Sender;
+
+use malloc_size_of_derive::MallocSizeOf;
 /// An ID for clients to track instances of Players and AudioContexts belonging to the same tab and mute them simultaneously.
 /// Current tuple implementation matches one of Servo's BrowsingContextId.
-#[derive(PartialEq, Eq, Hash, Debug, Clone, Copy)]
+#[derive(PartialEq, Eq, Hash, Debug, Clone, Copy, MallocSizeOf)]
 pub struct ClientContextId(u32, NonZeroU32);
 
 impl ClientContextId {
@@ -35,6 +37,7 @@ pub trait MediaInstance: Send {
     fn resume(&self) -> Result<(), MediaInstanceError>;
 }
 
+#[derive(MallocSizeOf)]
 pub enum BackendMsg {
     /// Message to notify about a media instance shutdown.
     /// The given `usize` is the media instance ID.


### PR DESCRIPTION
Implement MallocSizeOf for most of former servo media crate.
Most of this should be uncontroversal as it is just adding derives.

Of note are implementation of std::sync::mpsc::Sender<T> with currently size_of=0 and an ignored Box<[f32, MAX_FFT_SIZE]>.


Signed-off-by: Narfinger <Narfinger@users.noreply.github.com>

Testing: Compilation is the test.
