### PR TITLE
webxr: Implement MallocSizeOf

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10810,8 +10810,10 @@ dependencies = [
  "euclid",
  "ipc-channel",
  "log",
+ "malloc_size_of_derive",
  "profile_traits",
  "serde",
+ "servo_malloc_size_of",
 ]
 
 [[package]]

--- a/components/malloc_size_of/lib.rs
+++ b/components/malloc_size_of/lib.rs
@@ -764,6 +764,12 @@ impl<T: MallocSizeOf, U> MallocSizeOf for euclid::Box2D<T, U> {
     }
 }
 
+impl<T: MallocSizeOf, U> MallocSizeOf for euclid::Vector3D<T, U> {
+    fn size_of(&self, ops: &mut MallocSizeOfOps) -> usize {
+        self.x.size_of(ops) + self.y.size_of(ops) + self.z.size_of(ops)
+    }
+}
+
 impl<T: MallocSizeOf, U> MallocSizeOf for euclid::Rect<T, U> {
     fn size_of(&self, ops: &mut MallocSizeOfOps) -> usize {
         self.origin.size_of(ops) + self.size.size_of(ops)
@@ -814,6 +820,18 @@ impl<T: MallocSizeOf, Src, Dst> MallocSizeOf for euclid::Transform3D<T, Src, Dst
             self.m42.size_of(ops) +
             self.m43.size_of(ops) +
             self.m44.size_of(ops)
+    }
+}
+
+impl<T: MallocSizeOf, Src, Dst> MallocSizeOf for euclid::RigidTransform3D<T, Src, Dst> {
+    fn size_of(&self, ops: &mut MallocSizeOfOps) -> usize {
+        self.rotation.i.size_of(ops) +
+            self.rotation.j.size_of(ops) +
+            self.rotation.k.size_of(ops) +
+            self.rotation.r.size_of(ops) +
+            self.translation.x.size_of(ops) +
+            self.translation.y.size_of(ops) +
+            self.translation.z.size_of(ops)
     }
 }
 

--- a/components/script/dom/webgpu/gpubuffer.rs
+++ b/components/script/dom/webgpu/gpubuffer.rs
@@ -67,7 +67,6 @@ impl ActiveBufferMapping {
 #[dom_struct]
 pub(crate) struct GPUBuffer {
     reflector_: Reflector,
-    #[ignore_malloc_size_of = "defined in webgpu"]
     #[no_trace]
     channel: WebGPU,
     label: DomRefCell<USVString>,

--- a/components/script/dom/webgpu/gpucommandbuffer.rs
+++ b/components/script/dom/webgpu/gpucommandbuffer.rs
@@ -14,7 +14,6 @@ use crate::dom::globalscope::GlobalScope;
 use crate::script_runtime::CanGc;
 #[derive(JSTraceable, MallocSizeOf)]
 struct DroppableGPUCommandBuffer {
-    #[ignore_malloc_size_of = "defined in webgpu"]
     #[no_trace]
     channel: WebGPU,
     #[no_trace]

--- a/components/script/dom/webgpu/gpucommandencoder.rs
+++ b/components/script/dom/webgpu/gpucommandencoder.rs
@@ -32,7 +32,6 @@ use crate::script_runtime::CanGc;
 #[dom_struct]
 pub(crate) struct GPUCommandEncoder {
     reflector_: Reflector,
-    #[ignore_malloc_size_of = "defined in webgpu"]
     #[no_trace]
     channel: WebGPU,
     label: DomRefCell<USVString>,

--- a/components/script/dom/webgpu/gpucompilationmessage.rs
+++ b/components/script/dom/webgpu/gpucompilationmessage.rs
@@ -17,7 +17,6 @@ use crate::script_runtime::CanGc;
 #[dom_struct]
 pub(crate) struct GPUCompilationMessage {
     reflector_: Reflector,
-    // #[ignore_malloc_size_of = "defined in wgpu-types"]
     message: DOMString,
     mtype: GPUCompilationMessageType,
     line_num: u64,

--- a/components/script/dom/webgpu/gpucomputepassencoder.rs
+++ b/components/script/dom/webgpu/gpucomputepassencoder.rs
@@ -20,7 +20,6 @@ use crate::script_runtime::CanGc;
 #[dom_struct]
 pub(crate) struct GPUComputePassEncoder {
     reflector_: Reflector,
-    #[ignore_malloc_size_of = "defined in webgpu"]
     #[no_trace]
     channel: WebGPU,
     label: DomRefCell<USVString>,

--- a/components/script/dom/webgpu/gpudevice.rs
+++ b/components/script/dom/webgpu/gpudevice.rs
@@ -69,7 +69,6 @@ use crate::script_runtime::CanGc;
 #[dom_struct]
 pub(crate) struct GPUDevice {
     eventtarget: EventTarget,
-    #[ignore_malloc_size_of = "channels are hard"]
     #[no_trace]
     channel: WebGPU,
     adapter: Dom<GPUAdapter>,

--- a/components/script/dom/webgpu/gpupipelinelayout.rs
+++ b/components/script/dom/webgpu/gpupipelinelayout.rs
@@ -23,7 +23,6 @@ use crate::script_runtime::CanGc;
 #[dom_struct]
 pub(crate) struct GPUPipelineLayout {
     reflector_: Reflector,
-    #[ignore_malloc_size_of = "defined in webgpu"]
     #[no_trace]
     channel: WebGPU,
     label: DomRefCell<USVString>,

--- a/components/script/dom/webgpu/gpuqueryset.rs
+++ b/components/script/dom/webgpu/gpuqueryset.rs
@@ -11,7 +11,6 @@ use crate::dom::bindings::str::USVString;
 #[dom_struct]
 pub(crate) struct GPUQuerySet {
     reflector_: Reflector,
-    // #[ignore_malloc_size_of = "defined in wgpu-types"]
 }
 
 // TODO: wgpu does not expose right fields right now

--- a/components/script/dom/webgpu/gpurenderbundleencoder.rs
+++ b/components/script/dom/webgpu/gpurenderbundleencoder.rs
@@ -31,7 +31,6 @@ use crate::script_runtime::CanGc;
 #[dom_struct]
 pub(crate) struct GPURenderBundleEncoder {
     reflector_: Reflector,
-    #[ignore_malloc_size_of = "channels are hard"]
     #[no_trace]
     channel: WebGPU,
     device: Dom<GPUDevice>,

--- a/components/script/dom/webgpu/gpurenderpassencoder.rs
+++ b/components/script/dom/webgpu/gpurenderpassencoder.rs
@@ -26,7 +26,6 @@ use crate::script_runtime::CanGc;
 #[dom_struct]
 pub(crate) struct GPURenderPassEncoder {
     reflector_: Reflector,
-    #[ignore_malloc_size_of = "defined in webgpu"]
     #[no_trace]
     channel: WebGPU,
     label: DomRefCell<USVString>,

--- a/components/script/dom/webgpu/gpusampler.rs
+++ b/components/script/dom/webgpu/gpusampler.rs
@@ -21,7 +21,6 @@ use crate::script_runtime::CanGc;
 #[dom_struct]
 pub(crate) struct GPUSampler {
     reflector_: Reflector,
-    #[ignore_malloc_size_of = "defined in webgpu"]
     #[no_trace]
     channel: WebGPU,
     label: DomRefCell<USVString>,

--- a/components/script/dom/webgpu/gpushadermodule.rs
+++ b/components/script/dom/webgpu/gpushadermodule.rs
@@ -26,7 +26,6 @@ use crate::script_runtime::CanGc;
 #[dom_struct]
 pub(crate) struct GPUShaderModule {
     reflector_: Reflector,
-    #[ignore_malloc_size_of = "defined in webgpu"]
     #[no_trace]
     channel: WebGPU,
     label: DomRefCell<USVString>,

--- a/components/script/dom/webgpu/gputexture.rs
+++ b/components/script/dom/webgpu/gputexture.rs
@@ -33,8 +33,8 @@ pub(crate) struct GPUTexture {
     device: Dom<GPUDevice>,
     #[no_trace]
     channel: WebGPU,
-    #[ignore_malloc_size_of = "defined in wgpu"]
     #[no_trace]
+    #[ignore_malloc_size_of = "External type"]
     texture_size: wgpu_types::Extent3d,
     mip_level_count: u32,
     sample_count: u32,

--- a/components/script/dom/webxr/fakexrdevice.rs
+++ b/components/script/dom/webxr/fakexrdevice.rs
@@ -40,7 +40,6 @@ pub(crate) struct FakeXRDevice {
     reflector: Reflector,
     #[no_trace]
     sender: GenericSender<MockDeviceMsg>,
-    #[ignore_malloc_size_of = "defined in webxr-api"]
     #[no_trace]
     next_input_id: Cell<InputId>,
 }

--- a/components/script/dom/webxr/fakexrinputcontroller.rs
+++ b/components/script/dom/webxr/fakexrinputcontroller.rs
@@ -30,7 +30,6 @@ pub(crate) struct FakeXRInputController {
     reflector: Reflector,
     #[no_trace]
     sender: GenericSender<MockDeviceMsg>,
-    #[ignore_malloc_size_of = "defined in webxr-api"]
     #[no_trace]
     id: InputId,
 }

--- a/components/script/dom/webxr/xrframe.rs
+++ b/components/script/dom/webxr/xrframe.rs
@@ -31,7 +31,6 @@ use crate::script_runtime::CanGc;
 pub(crate) struct XRFrame {
     reflector_: Reflector,
     session: Dom<XRSession>,
-    #[ignore_malloc_size_of = "defined in webxr_api"]
     #[no_trace]
     data: Frame,
     active: Cell<bool>,

--- a/components/script/dom/webxr/xrhand.rs
+++ b/components/script/dom/webxr/xrhand.rs
@@ -107,9 +107,7 @@ const JOINT_SPACE_MAP: [(XRHandJoint, Joint); 25] = [
 #[dom_struct]
 pub(crate) struct XRHand {
     reflector_: Reflector,
-    #[ignore_malloc_size_of = "defined in webxr"]
     source: Dom<XRInputSource>,
-    #[ignore_malloc_size_of = "partially defind in webxr"]
     #[custom_trace]
     spaces: Hand<Dom<XRJointSpace>>,
 }

--- a/components/script/dom/webxr/xrhittestresult.rs
+++ b/components/script/dom/webxr/xrhittestresult.rs
@@ -17,7 +17,6 @@ use crate::script_runtime::CanGc;
 #[dom_struct]
 pub(crate) struct XRHitTestResult {
     reflector_: Reflector,
-    #[ignore_malloc_size_of = "defined in webxr"]
     #[no_trace]
     result: HitTestResult,
     frame: Dom<XRFrame>,

--- a/components/script/dom/webxr/xrhittestsource.rs
+++ b/components/script/dom/webxr/xrhittestsource.rs
@@ -15,7 +15,6 @@ use crate::script_runtime::CanGc;
 #[dom_struct]
 pub(crate) struct XRHitTestSource {
     reflector_: Reflector,
-    #[ignore_malloc_size_of = "defined in webxr"]
     #[no_trace]
     id: HitTestId,
     session: Dom<XRSession>,

--- a/components/script/dom/webxr/xrinputsource.rs
+++ b/components/script/dom/webxr/xrinputsource.rs
@@ -28,7 +28,6 @@ use crate::script_runtime::{CanGc, JSContext};
 pub(crate) struct XRInputSource {
     reflector: Reflector,
     session: Dom<XRSession>,
-    #[ignore_malloc_size_of = "Defined in rust-webxr"]
     #[no_trace]
     info: InputSource,
     target_ray_space: MutNullableDom<XRSpace>,

--- a/components/script/dom/webxr/xrjointspace.rs
+++ b/components/script/dom/webxr/xrjointspace.rs
@@ -18,11 +18,10 @@ use crate::script_runtime::CanGc;
 #[dom_struct]
 pub(crate) struct XRJointSpace {
     xrspace: XRSpace,
-    #[ignore_malloc_size_of = "defined in rust-webxr"]
     #[no_trace]
     input: InputId,
-    #[ignore_malloc_size_of = "defined in rust-webxr"]
     #[no_trace]
+    #[ignore_malloc_size_of = "Complicated"]
     joint: Joint,
     hand_joint: XRHandJoint,
 }

--- a/components/script/dom/webxr/xrlayer.rs
+++ b/components/script/dom/webxr/xrlayer.rs
@@ -22,7 +22,6 @@ pub(crate) struct XRLayer {
     context: Dom<WebGLRenderingContext>,
     /// If none, the session is inline (the composition disabled flag is true)
     /// and this is a XRWebGLLayer.
-    #[ignore_malloc_size_of = "Layer ids don't heap-allocate"]
     #[no_trace]
     layer_id: Option<LayerId>,
 }

--- a/components/script/dom/webxr/xrray.rs
+++ b/components/script/dom/webxr/xrray.rs
@@ -23,7 +23,6 @@ use crate::script_runtime::{CanGc, JSContext};
 #[dom_struct]
 pub(crate) struct XRRay {
     reflector_: Reflector,
-    #[ignore_malloc_size_of = "defined in webxr"]
     #[no_trace]
     ray: Ray<ApiSpace>,
     #[ignore_malloc_size_of = "defined in mozjs"]

--- a/components/script/dom/webxr/xrrigidtransform.rs
+++ b/components/script/dom/webxr/xrrigidtransform.rs
@@ -24,7 +24,6 @@ pub(crate) struct XRRigidTransform {
     reflector_: Reflector,
     position: MutNullableDom<DOMPointReadOnly>,
     orientation: MutNullableDom<DOMPointReadOnly>,
-    #[ignore_malloc_size_of = "defined in euclid"]
     #[no_trace]
     transform: ApiRigidTransform,
     inverse: MutNullableDom<XRRigidTransform>,

--- a/components/script/dom/webxr/xrsession.rs
+++ b/components/script/dom/webxr/xrsession.rs
@@ -80,7 +80,6 @@ pub(crate) struct XRSession {
     mode: XRSessionMode,
     visibility_state: Cell<XRVisibilityState>,
     viewer_space: MutNullableDom<XRSpace>,
-    #[ignore_malloc_size_of = "defined in webxr"]
     #[no_trace]
     session: DomRefCell<Session>,
     frame_requested: Cell<bool>,
@@ -101,16 +100,14 @@ pub(crate) struct XRSession {
     end_promises: DomRefCell<Vec<Rc<Promise>>>,
     /// <https://immersive-web.github.io/webxr/#ended>
     ended: Cell<bool>,
-    #[ignore_malloc_size_of = "defined in webxr"]
     #[no_trace]
     next_hit_test_id: Cell<HitTestId>,
-    #[ignore_malloc_size_of = "defined in webxr"]
+    #[ignore_malloc_size_of = "Promise"]
     pending_hit_test_promises:
         DomRefCell<HashMapTracedValues<HitTestId, Rc<Promise>, FxBuildHasher>>,
     /// Opaque framebuffers need to know the session is "outside of a requestAnimationFrame"
     /// <https://immersive-web.github.io/webxr/#opaque-framebuffer>
     outside_raf: Cell<bool>,
-    #[ignore_malloc_size_of = "defined in webxr"]
     #[no_trace]
     input_frames: DomRefCell<HashMap<InputId, InputFrame>>,
     framerate: Cell<f32>,

--- a/components/script/dom/webxr/xrview.rs
+++ b/components/script/dom/webxr/xrview.rs
@@ -29,7 +29,6 @@ pub(crate) struct XRView {
     viewport_index: usize,
     #[ignore_malloc_size_of = "mozjs"]
     proj: HeapBufferSource<Float32>,
-    #[ignore_malloc_size_of = "defined in rust-webxr"]
     #[no_trace]
     view: View<ApiSpace>,
     transform: Dom<XRRigidTransform>,

--- a/components/shared/canvas/webgl.rs
+++ b/components/shared/canvas/webgl.rs
@@ -730,7 +730,7 @@ impl From<WebGLContextId> for WebXRContextId {
     }
 }
 
-#[derive(Clone, Copy, Debug, Deserialize, PartialEq, Serialize)]
+#[derive(Clone, Copy, Debug, Deserialize, PartialEq, Serialize, MallocSizeOf)]
 pub enum WebGLError {
     InvalidEnum,
     InvalidFramebufferOperation,

--- a/components/shared/webxr/Cargo.toml
+++ b/components/shared/webxr/Cargo.toml
@@ -23,3 +23,5 @@ profile_traits = { workspace = true }
 euclid = { workspace = true }
 serde = { workspace = true }
 log = { workspace = true }
+malloc_size_of = { workspace = true }
+malloc_size_of_derive = { workspace = true }

--- a/components/shared/webxr/frame.rs
+++ b/components/shared/webxr/frame.rs
@@ -3,6 +3,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 use euclid::RigidTransform3D;
+use malloc_size_of_derive::MallocSizeOf;
 use serde::{Deserialize, Serialize};
 
 use crate::{
@@ -12,7 +13,7 @@ use crate::{
 /// The per-frame data that is provided by the device.
 /// <https://www.w3.org/TR/webxr/#xrframe>
 // TODO: other fields?
-#[derive(Clone, Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize, MallocSizeOf)]
 pub struct Frame {
     /// The pose information of the viewer
     pub pose: Option<ViewerPose>,
@@ -32,14 +33,14 @@ pub struct Frame {
     pub predicted_display_time: f64,
 }
 
-#[derive(Clone, Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize, MallocSizeOf)]
 pub enum FrameUpdateEvent {
     UpdateFloorTransform(Option<RigidTransform3D<f32, Native, Floor>>),
     UpdateViewports(Viewports),
     HitTestSourceAdded(HitTestId),
 }
 
-#[derive(Clone, Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize, MallocSizeOf)]
 pub struct ViewerPose {
     /// The transform from the viewer to native coordinates
     ///

--- a/components/shared/webxr/hand.rs
+++ b/components/shared/webxr/hand.rs
@@ -3,6 +3,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 use euclid::RigidTransform3D;
+use malloc_size_of_derive::MallocSizeOf;
 use serde::{Deserialize, Serialize};
 
 use crate::Native;
@@ -10,7 +11,7 @@ use crate::Native;
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq, Serialize, Deserialize)]
 pub struct HandSpace;
 
-#[derive(Clone, Debug, Default, Serialize, Deserialize)]
+#[derive(Clone, Debug, Default, Serialize, Deserialize, MallocSizeOf)]
 pub struct Hand<J> {
     pub wrist: Option<J>,
     pub thumb_metacarpal: Option<J>,
@@ -23,7 +24,7 @@ pub struct Hand<J> {
     pub little: Finger<J>,
 }
 
-#[derive(Clone, Debug, Default, Serialize, Deserialize)]
+#[derive(Clone, Debug, Default, Serialize, Deserialize, MallocSizeOf)]
 pub struct Finger<J> {
     pub metacarpal: Option<J>,
     pub phalanx_proximal: Option<J>,
@@ -32,7 +33,7 @@ pub struct Finger<J> {
     pub phalanx_tip: Option<J>,
 }
 
-#[derive(Clone, Copy, Debug, Serialize, Deserialize)]
+#[derive(Clone, Copy, Debug, Serialize, Deserialize, MallocSizeOf)]
 pub struct JointFrame {
     pub pose: RigidTransform3D<f32, HandSpace, Native>,
     pub radius: f32,

--- a/components/shared/webxr/hittest.rs
+++ b/components/shared/webxr/hittest.rs
@@ -5,11 +5,12 @@
 use std::iter::FromIterator;
 
 use euclid::{Point3D, RigidTransform3D, Rotation3D, Vector3D};
+use malloc_size_of_derive::MallocSizeOf;
 use serde::{Deserialize, Serialize};
 
 use crate::{ApiSpace, Native, Space};
 
-#[derive(Clone, Copy, Debug, Serialize, Deserialize)]
+#[derive(Clone, Copy, Debug, Serialize, Deserialize, MallocSizeOf)]
 /// <https://immersive-web.github.io/hit-test/#xrray>
 pub struct Ray<Space> {
     /// The origin of the ray
@@ -35,7 +36,7 @@ pub struct HitTestSource {
     pub types: EntityTypes,
 }
 
-#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq, Serialize, Deserialize)]
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq, Serialize, Deserialize, MallocSizeOf)]
 pub struct HitTestId(pub u32);
 
 #[derive(Clone, Copy, Debug, Default, Serialize, Deserialize)]
@@ -46,7 +47,7 @@ pub struct EntityTypes {
     pub mesh: bool,
 }
 
-#[derive(Clone, Copy, Debug, Serialize, Deserialize)]
+#[derive(Clone, Copy, Debug, Serialize, Deserialize, MallocSizeOf)]
 pub struct HitTestResult {
     pub id: HitTestId,
     pub space: RigidTransform3D<f32, HitTestSpace, Native>,

--- a/components/shared/webxr/input.rs
+++ b/components/shared/webxr/input.rs
@@ -3,21 +3,22 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 use euclid::RigidTransform3D;
+use malloc_size_of_derive::MallocSizeOf;
 use serde::{Deserialize, Serialize};
 
 use crate::{Hand, Input, JointFrame, Native};
 
-#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq, Serialize, Deserialize)]
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq, Serialize, Deserialize, MallocSizeOf)]
 pub struct InputId(pub u32);
 
-#[derive(Clone, Copy, Debug, Serialize, Deserialize)]
+#[derive(Clone, Copy, Debug, Serialize, Deserialize, MallocSizeOf)]
 pub enum Handedness {
     None,
     Left,
     Right,
 }
 
-#[derive(Clone, Copy, Debug, Serialize, Deserialize)]
+#[derive(Clone, Copy, Debug, Serialize, Deserialize, MallocSizeOf)]
 pub enum TargetRayMode {
     Gaze,
     TrackedPointer,
@@ -25,7 +26,7 @@ pub enum TargetRayMode {
     TransientPointer,
 }
 
-#[derive(Clone, Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize, MallocSizeOf)]
 pub struct InputSource {
     pub handedness: Handedness,
     pub target_ray_mode: TargetRayMode,
@@ -35,7 +36,7 @@ pub struct InputSource {
     pub profiles: Vec<String>,
 }
 
-#[derive(Clone, Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize, MallocSizeOf)]
 pub struct InputFrame {
     pub id: InputId,
     pub target_ray_origin: Option<RigidTransform3D<f32, Input, Native>>,

--- a/components/shared/webxr/layer.rs
+++ b/components/shared/webxr/layer.rs
@@ -7,6 +7,7 @@ use std::num::NonZeroU32;
 use std::sync::atomic::{AtomicUsize, Ordering};
 
 use euclid::{Rect, Size2D};
+use malloc_size_of_derive::MallocSizeOf;
 use serde::{Deserialize, Serialize};
 
 use crate::{Error, Viewport, Viewports};
@@ -195,7 +196,7 @@ impl<GL: GLTypes> LayerManagerFactory<GL> {
     }
 }
 
-#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq, Deserialize, Serialize)]
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq, Deserialize, Serialize, MallocSizeOf)]
 pub struct LayerId(usize);
 
 static NEXT_LAYER_ID: AtomicUsize = AtomicUsize::new(0);
@@ -261,7 +262,7 @@ pub enum LayerLayout {
     StereoTopBottom,
 }
 
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, MallocSizeOf)]
 pub struct SubImages {
     pub layer_id: LayerId,
     pub sub_image: Option<SubImage>,
@@ -269,7 +270,7 @@ pub struct SubImages {
 }
 
 /// <https://immersive-web.github.io/layers/#xrsubimagetype>
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, MallocSizeOf)]
 pub struct SubImage {
     pub color_texture: Option<NonZeroU32>,
     pub depth_stencil_texture: Option<NonZeroU32>,

--- a/components/shared/webxr/session.rs
+++ b/components/shared/webxr/session.rs
@@ -9,6 +9,7 @@ use base::generic_channel::{self, GenericReceiver, GenericSender};
 use euclid::{Point2D, Rect, RigidTransform3D, Size2D};
 use ipc_channel::ipc::IpcSender;
 use log::warn;
+use malloc_size_of_derive::MallocSizeOf;
 use profile_traits::generic_callback::GenericCallback as ProfileGenericCallback;
 use serde::{Deserialize, Serialize};
 
@@ -76,7 +77,7 @@ impl SessionInit {
 }
 
 /// <https://immersive-web.github.io/webxr-ar-module/#xrenvironmentblendmode-enum>
-#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize, Deserialize, MallocSizeOf)]
 pub enum EnvironmentBlendMode {
     Opaque,
     AlphaBlend,
@@ -114,7 +115,7 @@ impl Quitter {
 /// An object that represents an XR session.
 /// This is owned by the content thread.
 /// <https://www.w3.org/TR/webxr/#xrsession-interface>
-#[derive(Serialize, Deserialize)]
+#[derive(Serialize, Deserialize, MallocSizeOf)]
 pub struct Session {
     floor_transform: Option<RigidTransform3D<f32, Native, Floor>>,
     viewports: Viewports,
@@ -126,7 +127,7 @@ pub struct Session {
     supported_frame_rates: Vec<f32>,
 }
 
-#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq, Deserialize, Serialize)]
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq, Deserialize, Serialize, MallocSizeOf)]
 pub struct SessionId(pub(crate) u32);
 
 impl Session {

--- a/components/shared/webxr/space.rs
+++ b/components/shared/webxr/space.rs
@@ -3,11 +3,12 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 use euclid::RigidTransform3D;
+use malloc_size_of_derive::MallocSizeOf;
 use serde::{Deserialize, Serialize};
 
 use crate::{InputId, Joint};
 
-#[derive(Clone, Copy, Debug, Serialize, Deserialize)]
+#[derive(Clone, Copy, Debug, Serialize, Deserialize, MallocSizeOf)]
 /// A stand-in type for "the space isn't statically known since
 /// it comes from client side code"
 pub struct ApiSpace;

--- a/components/shared/webxr/view.rs
+++ b/components/shared/webxr/view.rs
@@ -7,50 +7,51 @@
 use std::marker::PhantomData;
 
 use euclid::{Rect, RigidTransform3D, Transform3D};
+use malloc_size_of_derive::MallocSizeOf;
 use serde::{Deserialize, Serialize};
 
 /// The coordinate space of the viewer
 /// <https://immersive-web.github.io/webxr/#dom-xrreferencespacetype-viewer>
-#[derive(Clone, Copy, Debug, Serialize, Deserialize)]
+#[derive(Clone, Copy, Debug, Serialize, Deserialize, MallocSizeOf)]
 pub enum Viewer {}
 
 /// The coordinate space of the floor
 /// <https://immersive-web.github.io/webxr/#dom-xrreferencespacetype-local-floor>
-#[derive(Clone, Copy, Debug, Serialize, Deserialize)]
+#[derive(Clone, Copy, Debug, Serialize, Deserialize, MallocSizeOf)]
 pub enum Floor {}
 
 /// The coordinate space of the left eye
 /// <https://immersive-web.github.io/webxr/#dom-xreye-left>
-#[derive(Clone, Copy, Debug, Serialize, Deserialize)]
+#[derive(Clone, Copy, Debug, Serialize, Deserialize, MallocSizeOf)]
 pub enum LeftEye {}
 
 /// The coordinate space of the right eye
 /// <https://immersive-web.github.io/webxr/#dom-xreye-right>
-#[derive(Clone, Copy, Debug, Serialize, Deserialize)]
+#[derive(Clone, Copy, Debug, Serialize, Deserialize, MallocSizeOf)]
 pub enum RightEye {}
 
 /// The coordinate space of the left frustrum of a cubemap
-#[derive(Clone, Copy, Debug, Serialize, Deserialize)]
+#[derive(Clone, Copy, Debug, Serialize, Deserialize, MallocSizeOf)]
 pub enum CubeLeft {}
 
 /// The coordinate space of the right frustrum of a cubemap
-#[derive(Clone, Copy, Debug, Serialize, Deserialize)]
+#[derive(Clone, Copy, Debug, Serialize, Deserialize, MallocSizeOf)]
 pub enum CubeRight {}
 
 /// The coordinate space of the top frustrum of a cubemap
-#[derive(Clone, Copy, Debug, Serialize, Deserialize)]
+#[derive(Clone, Copy, Debug, Serialize, Deserialize, MallocSizeOf)]
 pub enum CubeTop {}
 
 /// The coordinate space of the bottom frustrum of a cubemap
-#[derive(Clone, Copy, Debug, Serialize, Deserialize)]
+#[derive(Clone, Copy, Debug, Serialize, Deserialize, MallocSizeOf)]
 pub enum CubeBottom {}
 
 /// The coordinate space of the back frustrum of a cubemap
-#[derive(Clone, Copy, Debug, Serialize, Deserialize)]
+#[derive(Clone, Copy, Debug, Serialize, Deserialize, MallocSizeOf)]
 pub enum CubeBack {}
 
 /// Pattern-match on eyes
-#[derive(Clone, Copy, Debug, Serialize, Deserialize)]
+#[derive(Clone, Copy, Debug, Serialize, Deserialize, MallocSizeOf)]
 pub struct SomeEye<Eye>(u8, PhantomData<Eye>);
 pub const LEFT_EYE: SomeEye<LeftEye> = SomeEye(0, PhantomData);
 pub const RIGHT_EYE: SomeEye<RightEye> = SomeEye(1, PhantomData);
@@ -89,7 +90,7 @@ pub enum Viewport {}
 pub enum Input {}
 
 /// The coordinate space of a secondary capture view
-#[derive(Clone, Copy, Debug, Serialize, Deserialize)]
+#[derive(Clone, Copy, Debug, Serialize, Deserialize, MallocSizeOf)]
 pub enum Capture {}
 
 /// For each eye, the pose of that eye,
@@ -97,7 +98,7 @@ pub enum Capture {}
 /// For stereo displays, we have a `View<LeftEye>` and a `View<RightEye>`.
 /// For mono displays, we hagve a `View<Viewer>`
 /// <https://immersive-web.github.io/webxr/#xrview>
-#[derive(Clone, Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize, MallocSizeOf)]
 pub struct View<Eye> {
     pub transform: RigidTransform3D<f32, Eye, Native>,
     pub projection: Transform3D<f32, Eye, Display>,
@@ -122,7 +123,7 @@ impl<Eye> View<Eye> {
 }
 
 /// Whether a device is mono or stereo, and the views it supports.
-#[derive(Clone, Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize, MallocSizeOf)]
 #[expect(clippy::large_enum_variant)]
 pub enum Views {
     /// Mono view for inline VR, viewport and projection matrices are calculated by client
@@ -143,7 +144,7 @@ pub enum Views {
 /// A list of viewports per-eye in the order of fields in Views.
 ///
 /// Not all must be in active use.
-#[derive(Clone, Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize, MallocSizeOf)]
 pub struct Viewports {
     pub viewports: Vec<Rect<i32, Viewport>>,
 }


### PR DESCRIPTION
Implement MallocSizeOf for most of WebXr. Mostly uncontroversal changes.
Of note:
- Implementation of size_of for euclid::RigidTransform
- Implementation of size_of for euclid::Vector3D
- Join is currently ignored as the type is very complicated.

Signed-off-by: Narfinger <Narfinger@users.noreply.github.com>

*Describe the changes that this pull request makes here. This will be the commit message.*

Testing: Compilation is the test.
