### PR TITLE
etc: Add script to vendor all dependencies, modify the toml and create an archive

### DIFF
--- a/etc/vendor_servo.py
+++ b/etc/vendor_servo.py
@@ -21,6 +21,7 @@ import pathlib
 def vendor():
     parser = argparse.ArgumentParser(prog="vendor_servo")
     parser.add_argument("--force", action="store_true")
+    parser.add_argument("--filename", type=pathlib.Path, help="name of the output archive without the extension, e.g. `servo` for `servo.tar.gz`")
 
     args = parser.parse_args()
     # This script is `etc/vendor_servo.py`, so the grandparent of the filename is the servo root directory.
@@ -55,7 +56,16 @@ def vendor():
         file = tempfile.gettempdir() + "/servo"
         print(f"Making archive in {file}.tar.gz")
         shutil.make_archive(file, format="gztar", base_dir="./")
-        print(f"Moving archive to {servo_root}")
+        if args.filename is not None:
+            name = pathlib.Path(args.filename)
+            if name.is_absolute():
+                out_filepath = name
+            else:
+                name = name.with_name(name.name + ".tar.gz")
+                out_filepath = servo_root.joinpath(name)
+        else:
+            out_filepath = servo_root.joinpath("servo.tar.gz")
+        print(f"Moving archive to {out_filepath}")
         shutil.move(file, servo_root)
     return
 

--- a/etc/vendor_servo.py
+++ b/etc/vendor_servo.py
@@ -61,6 +61,7 @@ def vendor():
         file = tempfile.gettempdir() + "/servo"
         print(f"Making archive in {file}.tar.gz")
         shutil.make_archive(file, format="gztar", base_dir="./")
+        tmp_file_path = file + ".tar.gz"
         if args.filename is not None:
             name = pathlib.Path(args.filename)
             if name.is_absolute():
@@ -71,7 +72,7 @@ def vendor():
         else:
             out_filepath = servo_root.joinpath("servo.tar.gz")
         print(f"Moving archive to {out_filepath}")
-        shutil.move(file, servo_root)
+        shutil.move(tmp_file_path, servo_root)
     return
 
 

--- a/etc/vendor_servo.py
+++ b/etc/vendor_servo.py
@@ -55,6 +55,8 @@ def vendor():
         file = tempfile.gettempdir() + "/servo"
         print(f"Making archive in {file}.tar.gz")
         shutil.make_archive(file, format="gztar", base_dir="./")
+        print(f"Moving archive to {servo_root}")
+        shutil.move(file, servo_root)
     return
 
 

--- a/etc/vendor_servo.py
+++ b/etc/vendor_servo.py
@@ -32,6 +32,8 @@ def vendor():
         print("git working directory is not clean. Check `git status` or run with --force")
         return
 
+    git_revision = subprocess.run(["git", "rev-parse", "HEAD"], capture_output=True, text=True, check=True)
+
     # copying servo into temporary directory
     with tempfile.TemporaryDirectory() as tmpdirname:
         print(f"Copying servo repo to temporary directory {tmpdirname}")
@@ -42,6 +44,9 @@ def vendor():
             dirs_exist_ok=True,
         )
         os.chdir(tmpdirname)
+        # Save the git hash into a file so that the archive can be mapped to a git revision.
+        with open('GIT_REVISION', "w") as revision_file:
+            revision_file.write(git_revision.stdout)
         # vendoring crates
         print("Vendoring Crates")
         vendor_process = subprocess.run(

--- a/etc/vendor_servo.py
+++ b/etc/vendor_servo.py
@@ -53,8 +53,8 @@ def vendor():
             ["cargo", "vendor", "vendor/"], capture_output=True, encoding="utf-8", check=True
         )
         out = vendor_process.stdout
-        print("Modifying cargo")
-        with open("Cargo.toml", "a") as toml:
+        print("Modifying .cargo/config.toml")
+        with open(".cargo/config.toml", "a") as toml:
             toml.write("\n")
             toml.writelines(out)
 

--- a/etc/vendor_servo.py
+++ b/etc/vendor_servo.py
@@ -55,7 +55,7 @@ def vendor():
         # vendoring crates
         print("Vendoring Crates")
         vendor_process = subprocess.run(
-            ["cargo", "vendor", "vendor/"], capture_output=True, encoding="utf-8", check=True
+            ["cargo", "vendor", "--locked", "vendor/"], capture_output=True, encoding="utf-8", check=True
         )
         out = vendor_process.stdout
         print("Modifying .cargo/config.toml")

--- a/etc/vendor_servo.py
+++ b/etc/vendor_servo.py
@@ -18,10 +18,15 @@ import subprocess
 import tempfile
 import pathlib
 
+
 def vendor():
     parser = argparse.ArgumentParser(prog="vendor_servo")
     parser.add_argument("--force", action="store_true")
-    parser.add_argument("--filename", type=pathlib.Path, help="name of the output archive without the extension, e.g. `servo` for `servo.tar.gz`")
+    parser.add_argument(
+        "--filename",
+        type=pathlib.Path,
+        help="name of the output archive without the extension, e.g. `servo` for `servo.tar.gz`",
+    )
 
     args = parser.parse_args()
     # This script is `etc/vendor_servo.py`, so the grandparent of the filename is the servo root directory.
@@ -45,7 +50,7 @@ def vendor():
         )
         os.chdir(tmpdirname)
         # Save the git hash into a file so that the archive can be mapped to a git revision.
-        with open('GIT_REVISION', "w") as revision_file:
+        with open("GIT_REVISION", "w") as revision_file:
             revision_file.write(git_revision.stdout)
         # vendoring crates
         print("Vendoring Crates")

--- a/etc/vendor_servo.py
+++ b/etc/vendor_servo.py
@@ -27,14 +27,12 @@ def vendor():
         print("Please call from top level servo directory")
         return
 
-    git_clean = subprocess.run(["git", "clean", "--dry-run", "-x"], capture_output=True)
-    if git_clean is not None and not args.force:
-        print("git clean -x would have removed some files. These would end up in the archive. Aborting")
-        print("run git clean --dry-run -x")
-        print("Or run with --force")
+    git_status = subprocess.run(["git", "status", "--porcelain"], capture_output=True, check=True)
+    if len(git_status.stdout) > 0 and not args.force:
+        print("git working directory is not clean. Check `git status` or run with --force")
         return
 
-    # coying servo into directory
+    # copying servo into temporary directory
     with tempfile.TemporaryDirectory() as tmpdirname:
         print(f"Copying servo repo to temporary directory {tmpdirname}")
         shutil.copytree(
@@ -47,7 +45,7 @@ def vendor():
         # vendoring crates
         print("Vendoring Crates")
         vendor_process = subprocess.run(
-            ["cargo", "vendor", "vendor/"], capture_output=True, encoding="Utf8", check=True
+            ["cargo", "vendor", "vendor/"], capture_output=True, encoding="utf-8", check=True
         )
         out = vendor_process.stdout
         print("Modifying cargo")
@@ -58,7 +56,7 @@ def vendor():
         file = tempfile.gettempdir() + "/servo"
         print(f"Making archive in {file}.tar.gz")
         shutil.make_archive(file, format="gztar", base_dir="./")
-    return 0
+    return
 
 
 if __name__ == "__main__":

--- a/etc/vendor_servo.py
+++ b/etc/vendor_servo.py
@@ -1,0 +1,62 @@
+#!/usr/bin/env python3
+
+# Copyright 2026 The Servo Project Developers. See the COPYRIGHT
+# file at the top-level directory of this distribution.
+#
+# Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+# http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+# <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+# option. This file may not be copied, modified, or distributed
+# except according to those terms.
+
+
+# A simple script to use cargo vendor to vendor the dependencies and then create an archive.
+import argparse
+import os
+import shutil
+import subprocess
+import tempfile
+
+
+def vendor():
+    parser = argparse.ArgumentParser(prog="vendor_servo")
+    parser.add_argument("--force", action="store_true")
+
+    args = parser.parse_args()
+    if os.path.basename(os.getcwd()) != "servo":
+        print("Please call from top level servo directory")
+        return
+
+    git_clean = subprocess.run(["git", "clean", "--dry-run", "-x"], capture_output=True)
+    if git_clean is not None and not args.force:
+        print("git clean -x would have removed some files. These would end up in the archive. Aborting")
+        print("run git clean --dry-run -x")
+        print("Or run with --force")
+        return
+
+    # coying servo into directory
+    with tempfile.TemporaryDirectory() as tmpdirname:
+        print(f"Copying servo repo to temporary directory {tmpdirname}")
+        shutil.copytree(
+            ".",
+            tmpdirname + "/",
+            ignore=shutil.ignore_patterns("*.git", "target", "etc", ".venv"),
+            dirs_exist_ok=True,
+        )
+        os.chdir(tmpdirname)
+        # shutil.rmtree('.git/')
+        # vendoring crates
+        print("Vendoring Crates")
+        vendor_process = subprocess.run(["cargo", "vendor", "vendor/"], capture_output=True, encoding="Utf8")
+        out = vendor_process.stdout
+        print("Modifying cargo")
+        with open("Cargo.toml", "a") as toml:
+            toml.write("\n")
+            toml.writelines(out)
+        print("Making archive in /tmp/servo.tar.gz. This might take a while.")
+        shutil.make_archive("/tmp/servo", format="gztar", base_dir="./")
+    return 0
+
+
+if __name__ == "__main__":
+    vendor()

--- a/etc/vendor_servo.py
+++ b/etc/vendor_servo.py
@@ -44,17 +44,20 @@ def vendor():
             dirs_exist_ok=True,
         )
         os.chdir(tmpdirname)
-        # shutil.rmtree('.git/')
         # vendoring crates
         print("Vendoring Crates")
-        vendor_process = subprocess.run(["cargo", "vendor", "vendor/"], capture_output=True, encoding="Utf8")
+        vendor_process = subprocess.run(
+            ["cargo", "vendor", "vendor/"], capture_output=True, encoding="Utf8", check=True
+        )
         out = vendor_process.stdout
         print("Modifying cargo")
         with open("Cargo.toml", "a") as toml:
             toml.write("\n")
             toml.writelines(out)
-        print("Making archive in /tmp/servo.tar.gz. This might take a while.")
-        shutil.make_archive("/tmp/servo", format="gztar", base_dir="./")
+
+        file = tempfile.gettempdir() + "/servo"
+        print(f"Making archive in {file}.tar.gz")
+        shutil.make_archive(file, format="gztar", base_dir="./")
     return 0
 
 

--- a/etc/vendor_servo.py
+++ b/etc/vendor_servo.py
@@ -55,7 +55,10 @@ def vendor():
         # vendoring crates
         print("Vendoring Crates")
         vendor_process = subprocess.run(
-            ["cargo", "vendor", "--locked", "vendor/"], capture_output=True, encoding="utf-8", check=True
+            ["cargo", "vendor", "--locked", "vendor/", "--versioned-dirs"],
+            capture_output=True,
+            encoding="utf-8",
+            check=True,
         )
         out = vendor_process.stdout
         print("Modifying .cargo/config.toml")

--- a/etc/vendor_servo.py
+++ b/etc/vendor_servo.py
@@ -16,16 +16,15 @@ import os
 import shutil
 import subprocess
 import tempfile
-
+import pathlib
 
 def vendor():
     parser = argparse.ArgumentParser(prog="vendor_servo")
     parser.add_argument("--force", action="store_true")
 
     args = parser.parse_args()
-    if os.path.basename(os.getcwd()) != "servo":
-        print("Please call from top level servo directory")
-        return
+    # This script is `etc/vendor_servo.py`, so the grandparent of the filename is the servo root directory.
+    servo_root = pathlib.Path(os.path.realpath(__file__)).parent.parent
 
     git_status = subprocess.run(["git", "status", "--porcelain"], capture_output=True, check=True)
     if len(git_status.stdout) > 0 and not args.force:
@@ -36,7 +35,7 @@ def vendor():
     with tempfile.TemporaryDirectory() as tmpdirname:
         print(f"Copying servo repo to temporary directory {tmpdirname}")
         shutil.copytree(
-            ".",
+            servo_root,
             tmpdirname + "/",
             ignore=shutil.ignore_patterns("*.git", "target", "etc", ".venv"),
             dirs_exist_ok=True,


### PR DESCRIPTION
This adds a simple script to vendor all the dependencies and creating a servo.tar.gz archive that should build without downloading.
Note: `./mach bootstrap` is still assumed to have been run to setup the build environment. 

Signed-off-by: Narfinger <Narfinger@users.noreply.github.com>

Testing: I tested the creation of the archive.
This is the first part of #40189
