### PR TITLE
ohos: Add script to run blink perf tests on device

### DIFF
--- a/etc/ci/scenario/blink_perf_test.py
+++ b/etc/ci/scenario/blink_perf_test.py
@@ -1,0 +1,301 @@
+import random
+import subprocess
+from enum import Enum
+import os
+import time
+import sys
+import re
+import json
+from pathlib import PurePath
+from http.server import SimpleHTTPRequestHandler, ThreadingHTTPServer
+from hdc_py.hdc import HarmonyDeviceConnector, HarmonyDevicePerfMode
+from selenium import webdriver
+from selenium.webdriver.common.by import By
+from selenium.webdriver.common.options import ArgOptions
+from selenium.webdriver.remote.webelement import WebElement
+from selenium.common.exceptions import NoSuchElementException
+from urllib3.exceptions import ProtocolError
+from dataclasses import dataclass
+from functools import partial
+import threading
+
+class PortMapResult(Enum):
+    SUCCESSFUL = (1,)
+    PORT_EXISTS = (2,)
+    FORWARD_FAILED = (3,)
+
+    def is_success(self) -> bool:
+        return self == PortMapResult.SUCCESSFUL or self == PortMapResult.PORT_EXISTS
+
+
+WEBDRIVER_PORT = 7000
+BLINK_PERF_FILES_SERVE_PORT = random.randrange(7150, 9000)
+SERVO_URL = f"http://127.0.0.1:{WEBDRIVER_PORT}"
+ABOUT_BLANK = "about:blank"
+DIRECTORY = "../../../tests/blink_perf_tests/perf_tests"
+
+class LocalFileServe:
+    def __init__(self, port: int, *args, **kwargs):
+        self.local_server = None
+        self.port = port
+
+    def __enter__(self):
+        print(f">>> Serving local test files on port {self.port}")
+
+        class StaticHandler(SimpleHTTPRequestHandler):
+            def __init__(self, *args, **kwargs):
+                super().__init__(*args, directory=DIRECTORY, **kwargs)
+            
+        # handler = partial(SimpleHTTPRequestHandler, directory = DIRECTORY)
+        self.local_server = ThreadingHTTPServer(
+            ("0.0.0.0", self.port),
+            StaticHandler,
+        )
+
+        # self.local_server.serve_forever()
+        thread = threading.Thread(
+            target=self.local_server.serve_forever,
+            daemon=True
+        )
+        thread.start()
+
+    def __exit__(self, *args):
+        print(f">>> *args: {args}")
+        print(f">>> Closing local test file server on port {self.port}")
+        self.local_server.server_close()
+
+def create_driver(timeout: int = 10) -> webdriver.Remote:
+    print("Trying to create driver")
+    options = ArgOptions()
+    options.set_capability("browserName", "servo")
+    driver = None
+    start_time = time.time()
+    while driver is None and time.time() - start_time < timeout:
+        try:
+            driver = webdriver.Remote(command_executor=SERVO_URL, options=options)
+        except (ConnectionError, ProtocolError):
+            time.sleep(0.2)
+        except Exception as e:
+            print(f"Unexpected exception when creating webdriver: {e}, {type(e)}")
+            time.sleep(1)
+    print(
+        f"Established Webdriver connection in {time.time() - start_time}s",
+    )
+    return driver
+
+
+def port_forward(port: int | str, reverse: bool) -> PortMapResult:
+    cmd = ["hdc", "fport", "ls"]
+    output = subprocess.check_output(cmd, encoding="utf-8")
+    if f"tcp:{port}" in output:
+        return PortMapResult.PORT_EXISTS
+
+    cmd = []
+    if reverse:
+        cmd = ["hdc", "rport", f"tcp:{port}", f"tcp:{port}"]
+    else:
+        cmd = ["hdc", "fport", f"tcp:{port}", f"tcp:{port}"]
+    print(f"Setting up HDC port forwarding: {' '.join(cmd)}")
+    result = subprocess.run(cmd, capture_output=True, text=True, timeout=10)
+    if result.stdout.startswith("[Fail]TCP Port listen failed"):
+        print("Forward failed")
+        return PortMapResult.FORWARD_FAILED
+    elif result.stdout.startswith("[Fail]"):
+        print("Forward failed other way")
+        raise RuntimeError(f"HDC port forwarding failed with: {result.stdout}")
+
+    print("Port forward successful")
+    return PortMapResult.SUCCESSFUL
+
+def setup_hdc_forward(timeout: int = 5):
+    """
+    set hdc forward
+    :return: If successful, return driver; If failed, return False
+    """
+    for v in ("HTTP_PROXY", "http_proxy", "HTTPS_PROXY", "https_proxy"):
+        os.environ.pop(v, None)
+
+    start_time = time.time()
+    while time.time() - start_time < timeout:
+        try:
+            if port_forward(WEBDRIVER_PORT, False).is_success() and port_forward(BLINK_PERF_FILES_SERVE_PORT, True).is_success():
+                return
+            time.sleep(0.2)
+        except FileNotFoundError:
+            print("HDC command not found. Make sure OHOS SDK is installed and hdc is in PATH.")
+            raise
+        except subprocess.TimeoutExpired:
+            print(f"HDC port forwarding timed out on port {WEBDRIVER_PORT}")
+            raise
+        except Exception as e:
+            print(f"failed to setup HDC forwarding: {e}")
+            raise
+    raise TimeoutError("HDC port forwarding timed out")
+
+def stop_servo():
+    """stop servo application"""
+    print("Prepare to stop Test Application...")
+    cmd = ["hdc", "shell", "aa force-stop org.servo.servo"]
+    subprocess.run(cmd, capture_output=True, text=True, timeout=10)
+    print("Stop Test Application successful!")
+
+def close_usb_popup(hdc: HarmonyDeviceConnector):
+    """
+    When connecting an OpenHarmony device, a system pop-up will be opened on the device,
+    asking the user to confirm which USB mode should be used for the connection.
+    This pop-up overlays servo, and will hence disturb some inputs, and affect screenshots.
+    """
+    try:
+        if not is_servo_window_focused(hdc):
+            print("The focused window does not belong to servo. Sending back-event to try and close the window.")
+            # The USB pop-up can be dismissed by simulating the back key-event.
+            hdc.cmd("uitest uiInput keyEvent Back")
+        if not is_servo_window_focused(hdc):
+            print("The focused window still isn't servo. Giving up.")
+    except Exception as e:
+        print(f"Internal error trying to close the USB pop-up overlay: {e}. Ignoring...")
+
+def is_servo_window_focused(hdc: HarmonyDeviceConnector) -> bool:
+    completed_process = hdc.cmd("hidumper -s WindowManagerService -a '-a'", capture_output=True, encoding="utf-8")
+    output = str(completed_process.stdout)
+    lines = output.splitlines()
+    focused_window = None
+    servo_window_id = None
+    for line in lines:
+        if line.lower().startswith("focus window:"):
+            focused_window = int(line.split(":")[1].strip())
+        if line.lower().startswith("servo"):
+            # The table format is as follows:
+            # WindowName DisplayId Pid WinId
+            servo_window_id = int(line.split()[3])
+        if line.lower().startswith("windowname"):
+            table_headers = line.split()
+            assert table_headers[0].lower() == "windowname"
+            assert table_headers[3].lower() == "winid"
+        if focused_window is not None and servo_window_id is not None:
+            break
+    if focused_window is None or servo_window_id is None:
+        raise RuntimeError("Could not find focused window or servo window id.")
+    return focused_window == servo_window_id
+
+@dataclass(frozen=True)
+class TestResult:
+    value: float
+    lower_value: float
+    upper_value: float
+    unit: str
+
+class AbortReason(Enum):
+    NotFound = 1
+    Panic = 2
+
+MAX_WAIT_TIME = 60
+
+_PATTERN = re.compile(
+    r"""
+Time:\s+
+values\s+[0-9.,\s]+(?P<unit>ms|runs\/s)\s+
+avg\s+(?P<avg>[0-9.]+)\s+(?P=unit)\s+
+median\s+[0-9.]+\s+(?P=unit)\s+
+stdev\s+[0-9.]+\s+(?P=unit)\s+
+min\s+(?P<min>[0-9.]+)\s+(?P=unit)\s+
+max\s+(?P<max>[0-9.]+)\s+(?P=unit)
+""",
+    re.VERBOSE,
+)
+
+def get_parent_dir_name_of_test_html(s: str) -> str:
+    return "layout"
+
+def test(s: str, driver: webdriver.Remote, port: int) -> TestResult | AbortReason:
+    """Run a test by loading a website, and returning (avg, min, max).
+    This will run for MAX_WAIT_TIME seconds and return as soon as the avg line exists in the log element"""
+
+    s = f"http://127.0.0.1:{port}/layout/{s}"
+    text = None
+    try:
+        driver.get(s)
+        avg_line, min_line, max_line = None, None, None
+        for i in range(MAX_WAIT_TIME):
+            element = driver.find_element(By.ID, "log")
+            text = element.text
+            m = _PATTERN.search(text)
+            if m:
+                avg_line = float(m.group("avg"))
+                min_line = float(m.group("min"))
+                max_line = float(m.group("max"))
+                unit = m.group("unit")
+            if avg_line is not None and min_line is not None and max_line is not None and unit is not None:
+                return TestResult(value=avg_line, lower_value=min_line, upper_value=max_line, unit=unit)
+            time.sleep(1)
+    except NoSuchElementException:
+        print("Could not find log?")
+        return AbortReason.NotFound
+    except Exception as e:
+        print(f"Some other exception for this test case: {e}")
+        return AbortReason.Panic
+    return AbortReason.NotFound
+
+PREPEND = "PHONE"
+
+def oswalk_error(error: OSError):
+    print(error)
+    sys.exit(1)
+
+def write_file(results):
+    with open("../../../results.json", "w") as f:
+        json.dump(results, f)
+
+def run_tests(webdriver, port):
+    final_result = {}
+    time.sleep(2)
+    for root, dir, files in os.walk("../../../tests/blink_perf_tests/perf_tests/layout", onerror=oswalk_error):
+        for file in files:
+            filePath = file
+
+            result = test(filePath, webdriver, port)
+            print(f">>> result: {result}")
+            if result == AbortReason.NotFound or result == AbortReason.Panic:
+                pass
+            else:
+                combined_result = {}
+                combined_result["value"] = result.value
+                combined_result["lower_value"] = result.lower_value
+                combined_result["upper_value"] = result.upper_value
+                parent_dir = get_parent_dir_name_of_test_html(filePath)
+                if result.unit == "ms":
+                    final_result[f"perf_tests/{parent_dir}/{filePath}"] = {"ms": combined_result}
+                else:
+                    final_result[f"perf_tests/{parent_dir}/{filePath}"] = {"throughput": combined_result}
+    print(f">>> final_result {final_result}")
+    write_file(final_result)
+
+
+    
+
+if __name__ == "__main__":
+    hdc = HarmonyDeviceConnector()
+    try:
+        print("Stopping potential old servo instance ...")
+        stop_servo()
+        setup_hdc_forward()
+        with LocalFileServe(BLINK_PERF_FILES_SERVE_PORT):
+            print("Starting new servo instance...")
+            cmd_str = f"aa start -a EntryAbility -b org.servo.servo -U {ABOUT_BLANK} --psn=--webdriver"
+            hdc.cmd(
+                cmd_str,
+                timeout = 10
+            )
+            with HarmonyDevicePerfMode():
+                close_usb_popup(hdc)
+                print(">>> Creating webdriver")
+                wd = create_driver()
+                print(">>> Running the tests")
+                run_tests(wd, BLINK_PERF_FILES_SERVE_PORT)
+    except Exception as e:
+        print(f"Test failed with error: {e} (exception: {type(e)})")
+        hdc.screenshot(f"Blink_perf_test_error.jpg")
+        stop_servo()
+        sys.exit(1)
+    print("\033[32mTest Succeeded.\033[0m")
+    stop_servo()

--- a/etc/ci/scenario/blink_perf_test.py
+++ b/etc/ci/scenario/blink_perf_test.py
@@ -16,6 +16,7 @@ import time
 import sys
 import re
 import json
+import argparse
 from http.server import SimpleHTTPRequestHandler, ThreadingHTTPServer
 from hdc_py.hdc import HarmonyDeviceConnector, HarmonyDevicePerfMode
 from selenium import webdriver
@@ -25,7 +26,10 @@ from selenium.webdriver.support.ui import WebDriverWait
 from selenium.webdriver.support import expected_conditions as EC
 from dataclasses import dataclass
 import threading
+import csv
+from typing import Dict
 from common_function_for_servo_test import create_driver, setup_hdc_forward, stop_servo, close_usb_popup
+
 
 class PortMapResult(Enum):
     SUCCESSFUL = (1,)
@@ -43,12 +47,25 @@ ABOUT_BLANK = "about:blank"
 DIRECTORY = "tests/blink_perf_tests/perf_tests"
 
 skipped_tests = [
-    "large-table-with-collapsed-borders-and-no-colspans.html", # RAM
-    "large-table-with-collapsed-borders-and-colspans-wider-than-table.html", # RAM
-    "tall-content-short-columns-realistic.html", # JS Fatal
-    "tall-content-short-columns.html", # JS Fatal
-    "floats_10_1000.html" # timeout
+    "large-table-with-collapsed-borders-and-no-colspans.html",  # RAM
+    "large-table-with-collapsed-borders-and-colspans-wider-than-table.html",  # RAM
+    "tall-content-short-columns-realistic.html",  # JS Fatal
+    "tall-content-short-columns.html",  # JS Fatal
+    "floats_10_1000.html",  # timeout
+    "nested-percent-height-tables.html",
+    "large-table-with-collapsed-borders-and-colspans.html",  # causes next test to fail
 ]
+
+tests_that_hang_memory_report = [
+    "contain-content-style-change.html",
+    "large-grid.html",
+    "layer-overhead.html",
+]
+
+### Failed tests
+# abspos.html,error
+# flexbox-row-stretch-height-definite.html,error
+
 
 class LocalFileServe:
     def __init__(self, port: int, *args, **kwargs):
@@ -56,7 +73,7 @@ class LocalFileServe:
         self.port = port
 
     def __enter__(self):
-        print(f">>> Serving local test files on port {self.port}")
+        print(f"Serving local test files on port {self.port}")
 
         class StaticHandler(SimpleHTTPRequestHandler):
             def __init__(self, *args, **kwargs):
@@ -73,6 +90,7 @@ class LocalFileServe:
     def __exit__(self, *args):
         self.local_server.server_close()
 
+
 @dataclass(frozen=True)
 class TestResult:
     value: float
@@ -88,7 +106,7 @@ class AbortReason(Enum):
 
 MAX_WAIT_TIME = 60
 
-_PATTERN = re.compile(
+REGEX_RESULTS_LOG_ELEMENT = re.compile(
     r"""
 Time:\s+
 values\s+[0-9.,\s]+(?P<unit>ms|runs\/s)\s+
@@ -105,18 +123,20 @@ max\s+(?P<max>[0-9.]+)\s+(?P=unit)
 def get_serve_path_for_file(root: str, file: str) -> str:
     return root.split("tests/blink_perf_tests/perf_tests/")[1]
 
+
 def reset_tab_ram(driver: webdriver.Remote):
     original_tab = driver.current_window_handle
-    driver.switch_to.new_window('tab')
+    driver.switch_to.new_window("tab")
     driver.get("about:blank")
     driver.switch_to.window(original_tab)
     driver.close()
-    print(">>> windows has been resets")
+    print("The tab has been reset")
     remaining_tab = driver.window_handles[0]
     driver.switch_to.window(remaining_tab)
     # time.sleep(.1)
 
-def test(s: str, driver: webdriver.Remote, port: int, serve_path) -> TestResult | AbortReason:
+
+def test(s: str, driver: webdriver.Remote, port: int, serve_path, cli_args=None) -> TestResult | AbortReason:
     """Run a test by loading a website, and returning (avg, min, max).
     This will run for MAX_WAIT_TIME seconds and return as soon as the avg line exists in the log element"""
 
@@ -126,16 +146,14 @@ def test(s: str, driver: webdriver.Remote, port: int, serve_path) -> TestResult 
     text = None
     try:
         before_get = time.perf_counter()
-        # print(f">>> entered try at {before_get}")
         driver.get(s)
         after_get = time.perf_counter()
-        # print(f">>> exited try at {after_get}, diff {after_get- before_get}")
-        if after_get - before_get > 2:
+        if after_get - before_get > cli_args.page_loading_timeout:
             raise TimeoutError(f"Page loading took {(after_get - before_get):.2f}s (> 2s limit)")
-        
+
         avg_line, min_line, max_line = None, None, None
         start_time, latest_time = time.perf_counter(), 0
-        while (latest_time - start_time < 60):
+        while latest_time - start_time < 60:
             try:
                 element = driver.find_element(By.ID, "log")
                 latest_time = time.perf_counter()
@@ -144,12 +162,12 @@ def test(s: str, driver: webdriver.Remote, port: int, serve_path) -> TestResult 
             except NoSuchElementException:
                 time.sleep(1)
                 continue
-            m = _PATTERN.search(text)
-            if m:
-                avg_line = float(m.group("avg"))
-                min_line = float(m.group("min"))
-                max_line = float(m.group("max"))
-                unit = m.group("unit")
+            results_log_groups = REGEX_RESULTS_LOG_ELEMENT.search(text)
+            if results_log_groups:
+                avg_line = float(results_log_groups.group("avg"))
+                min_line = float(results_log_groups.group("min"))
+                max_line = float(results_log_groups.group("max"))
+                unit = results_log_groups.group("unit")
             if avg_line is not None and min_line is not None and max_line is not None and unit is not None:
                 return TestResult(value=avg_line, lower_value=min_line, upper_value=max_line, unit=unit)
             time.sleep(1)
@@ -162,9 +180,6 @@ def test(s: str, driver: webdriver.Remote, port: int, serve_path) -> TestResult 
     return AbortReason.NotFound
 
 
-PREPEND = "PHONE"
-
-
 def oswalk_error(error: OSError):
     print(error)
     sys.exit(1)
@@ -174,83 +189,285 @@ def write_file(results):
     with open("results.json", "w") as f:
         json.dump(results, f)
 
-import csv
-def run_tests(webdriver, port):
-    skip_until = None
-    # skip_until = "editing_append_single_line.html"
+
+REGEX_MEMORY_REPORT = re.compile(
+    r"""
+    ^\s*(?P<explicit_value>\d+(?:\.\d+)?)\s+
+    (?P<explicit_unit>MiB|GiB|KiB)\s+--\s+explicit\s*$
+
+    (?:.*\n)*?
+
+    ^\s*(?P<resident_value>\d+(?:\.\d+)?)\s+
+    (?P<resident_unit>MiB|GiB|KiB)\s+--\s+resident\s*$
+
+    (?:.*\n)*?
+
+    ^\s*(?P<smaps_value>\d+(?:\.\d+)?)\s+
+    (?P<smaps_unit>MiB|GiB|KiB)\s+--\s+resident-according-to-smaps\s*$
+    """,
+    re.MULTILINE | re.VERBOSE,
+)
+
+
+@dataclass(frozen=True)
+class MemoryMetric:
+    value: float
+    unit: str
+
+
+@dataclass(frozen=True)
+class MemoryReport:
+    explicit: MemoryMetric
+    resident: MemoryMetric
+    smaps: MemoryMetric
+
+
+@dataclass(frozen=True)
+class ParseError:
+    message: str
+
+
+def parse_memory_report(
+    text: str,
+) -> MemoryReport | ParseError:
+    match = REGEX_MEMORY_REPORT.search(text)
+    if not match:
+        return ParseError("Could not parse memory report (explicit/resident/smaps)")
+
+    try:
+        explicit = MemoryMetric(
+            value=float(match.group("explicit_value")),
+            unit=match.group("explicit_unit"),
+        )
+        resident = MemoryMetric(
+            value=float(match.group("resident_value")),
+            unit=match.group("resident_unit"),
+        )
+        smaps = MemoryMetric(
+            value=float(match.group("smaps_value")),
+            unit=match.group("smaps_unit"),
+        )
+    except (ValueError, KeyError) as exc:
+        return ParseError(f"Invalid numeric value: {exc}")
+
+    return MemoryReport(
+        explicit=explicit,
+        resident=resident,
+        smaps=smaps,
+    )
+
+
+_UNIT_TO_MIB = {
+    "KiB": 1.0 / 1024.0,
+    "MiB": 1.0,
+    "GiB": 1024.0,
+}
+
+
+def _to_mib(value: float, unit: str) -> float:
+    if unit not in _UNIT_TO_MIB:
+        raise ValueError(f"Unsupported unit: {unit}")
+    return value * _UNIT_TO_MIB[unit]
+
+
+def memory_report_to_bencher_metrics(
+    report: MemoryReport,
+) -> Dict[str, Dict[str, float]]:
+    """
+    Convert MemoryReport into Bencher-compatible metric dict.
+
+    Output shape:
+    {
+        "memory_explicit_mib": {"value": float},
+        "memory_resident_mib": {"value": float},
+        "memory_resident_smaps_mib": {"value": float},
+    }
+    """
+
+    explicit_mib = _to_mib(
+        report.explicit.value,
+        report.explicit.unit,
+    )
+    resident_mib = _to_mib(
+        report.resident.value,
+        report.resident.unit,
+    )
+    smaps_mib = _to_mib(
+        report.smaps.value,
+        report.smaps.unit,
+    )
+
+    return {
+        "memory_explicit_mib": {
+            "value": explicit_mib,
+        },
+        "memory_resident_mib": {
+            "value": resident_mib,
+        },
+        "memory_resident_smaps_mib": {
+            "value": smaps_mib,
+        },
+    }
+
+
+def verbose_print(str_to_print: str, is_verbose: bool = False):
+    if is_verbose:
+        print(str_to_print)
+
+
+def run_tests(port, cli_args=None):
+    skip_until = cli_args.skip_until
 
     final_result = {}
-    with open("output.csv", "w", newline="", encoding="utf-8") as f:
-        writer = csv.writer(f)
-        writer.writerow(["name", "return"])
+    csv_file, csv_writer = None, None
+    if cli_args and cli_args.extra_csv:
+        csv_file = open("blink_perf_test_logs.csv", "w", newline="", encoding="utf-8")
+        csv_writer = csv.writer(csv_file)
+        csv_writer.writerow(["name", "return"])
 
+    try:
         for root, dir, files in os.walk("tests/blink_perf_tests/perf_tests/layout", onerror=oswalk_error):
             for file in files:
                 dir[:] = [d for d in dir if d != "resources"]
                 filePath = file
                 if skip_until is None or skip_until in filePath:
-                    skip_until = None
+                    if not cli_args.single_test:
+                        skip_until = None
                     if filePath in skipped_tests:
                         continue
                     # reset_tab_ram(webdriver)
-                    result = test(filePath, webdriver, port, get_serve_path_for_file(root, filePath))
-                    print(f">>> result: {result}")
-                    # get_memory_report(webdriver)
-                    
-                    if result == AbortReason.NotFound or result == AbortReason.Panic:
-                        writer.writerow([filePath, "error"])
-                        pass
-                    else:
-                        combined_result = {}
-                        combined_result["value"] = result.value
-                        combined_result["lower_value"] = result.lower_value
-                        combined_result["upper_value"] = result.upper_value
-                        parent_dir = get_serve_path_for_file(root, filePath)
-                        if result.unit == "ms":
-                            final_result[f"perf_tests/{parent_dir}/{filePath}"] = {"ms": combined_result}
-                        else:
-                            final_result[f"perf_tests/{parent_dir}/{filePath}"] = {"throughput": combined_result}
-                        writer.writerow([filePath, result.value])
-                    f.flush()
-        print(f">>> final_result {final_result}")
+                    print("Starting new servo instance...")
+                    cmd_str = f"aa start -a EntryAbility -b org.servo.servo -U {ABOUT_BLANK} --psn=--webdriver --psn=--pref=session_history_max_length=1"
+                    hdc.cmd(cmd_str, timeout=10)
+                    with HarmonyDevicePerfMode(screen_timeout_seconds=2 * 60 * 60):
+                        close_usb_popup(hdc)
+                        webdriver = create_driver()
+                        if webdriver is None:
+                            continue
+
+                        try:
+                            result = test(
+                                filePath, webdriver, port, get_serve_path_for_file(root, filePath), cli_args=cli_args
+                            )
+
+                            verbose_print(f"result: {result}", cli_args.verbose)
+
+                            if result == AbortReason.NotFound or result == AbortReason.Panic:
+                                if csv_writer:
+                                    csv_writer.writerow([filePath, "error"])
+                            else:
+                                combined_result = {
+                                    "value": result.value,
+                                    "lower_value": result.lower_value,
+                                    "upper_value": result.upper_value,
+                                }
+                                parent_dir = get_serve_path_for_file(root, filePath)
+
+                                bencher_unit = None
+                                if result.unit == "ms":
+                                    bencher_unit = "ms"
+                                elif result.unit == "runs/s":
+                                    bencher_unit = "throughput"
+                                else:
+                                    bencher_unit = "other"
+
+                                if cli_args.memory_report and filePath not in tests_that_hang_memory_report:
+                                    memory_report = get_memory_report_str(webdriver)
+
+                                    if isinstance(memory_report, ParseError):
+                                        print(f"Test memory parsing failed: {memory_report.message}")
+                                    else:
+                                        verbose_print(
+                                            f"memory after test {memory_report}",
+                                            cli_args.verbose,
+                                        )
+                                        metrics = memory_report_to_bencher_metrics(memory_report)
+                                    final_result[f"perf_tests/{parent_dir}/{filePath}"] = {
+                                        bencher_unit: combined_result,
+                                        **metrics,
+                                    }
+                                else:
+                                    final_result[f"perf_tests/{parent_dir}/{filePath}"] = {
+                                        bencher_unit: combined_result
+                                    }
+                                if csv_writer:
+                                    csv_writer.writerow([filePath, result.value])
+                        finally:
+                            webdriver.quit()
+                        if csv_writer:
+                            csv_file.flush()
+                    stop_servo()
+        print(f"final_result {final_result}")
+    finally:
+        if csv_file:
+            csv_file.close()
+
     write_file(final_result)
 
-def get_memory_report(driver: webdriver.Remote) -> str:
-    original_tab = driver.current_window_handle
-    driver.switch_to.new_window("tab")
-    driver.get("about:memory")
-    wait = WebDriverWait(driver, 200)
-    measure_button = wait.until(
-        EC.element_to_be_clickable((By.ID, "startButton"))
-    )
-    measure_button.click()
-    reports = wait.until(
-        lambda d: d.find_element(By.ID, "reports")
-    )
-    wait.until(
-        lambda d: d.find_element(By.ID, "reports").text.strip() != ""
-    )
-    report_text =  reports.text
-    driver.close()
-    driver.switch_to.window(original_tab)
-    return report_text
+
+def get_memory_report_str(driver: webdriver.Remote) -> MemoryReport | ParseError:
+    report_text = None
+    try:
+        # original_tab = driver.current_window_handle
+        # driver.switch_to.new_window("tab")
+        driver.get("about:memory")
+        wait = WebDriverWait(driver, 5)
+        measure_button = wait.until(EC.element_to_be_clickable((By.ID, "startButton")))
+        measure_button.click()
+        reports = wait.until(lambda d: d.find_element(By.ID, "reports"))
+        wait.until(lambda d: d.find_element(By.ID, "reports").text.strip() != "")
+        report_text = reports.text
+        # driver.close()
+        # driver.switch_to.window(original_tab)
+    except Exception as e:
+        return ParseError(message=str(e))
+
+    return parse_memory_report(report_text)
+
 
 if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "-m",
+        "--memory_report",
+        action="store_true",
+        help="Include memory report in results.json",
+    )
+    parser.add_argument(
+        "-v",
+        "--verbose",
+        action="store_true",
+        help="Add more prints",
+    )
+    parser.add_argument(
+        "-e", "--extra_csv", action="store_true", help="Creates output.csv that contains skipper and failed tests"
+    )
+    parser.add_argument(
+        "-s",
+        "--single_test",
+        action="store_true",
+        help="Executes only first test. Can be used with --skip-until to run only one specific test",
+    )
+    parser.add_argument(
+        "--skip_until",
+        type=str,
+        default=None,
+        help="Skips all test until specified one, and if --single_test is not set, continues until the end.",
+    )
+    parser.add_argument(
+        "--page_loading_timeout",
+        type=int,
+        default=2,
+        help="Pages should load very fast, but if takes longer (than default 2s or specified), the result parsing is skipped",
+    )
+    args = parser.parse_args()
     hdc = HarmonyDeviceConnector()
     try:
         print("Stopping potential old servo instance ...")
         stop_servo()
         setup_hdc_forward(webdriver_port=WEBDRIVER_PORT, host_service_port=BLINK_PERF_FILES_SERVE_PORT)
         with LocalFileServe(BLINK_PERF_FILES_SERVE_PORT):
-            print("Starting new servo instance...")
-            cmd_str = f"aa start -a EntryAbility -b org.servo.servo -U {ABOUT_BLANK} --psn=--webdriver"
-            hdc.cmd(cmd_str, timeout=10)
-            with HarmonyDevicePerfMode(screen_timeout_seconds = 2 * 60 * 60):
-                close_usb_popup(hdc)
-                print(">>> Creating webdriver")
-                wd = create_driver()
-                print(">>> Running the tests")
-                run_tests(wd, BLINK_PERF_FILES_SERVE_PORT)
+            run_tests(BLINK_PERF_FILES_SERVE_PORT, cli_args=args)
     except Exception as e:
         print(f"Test failed with error: {e} (exception: {type(e)})")
         hdc.screenshot("Blink_perf_test_error.jpg")

--- a/etc/ci/scenario/blink_perf_test.py
+++ b/etc/ci/scenario/blink_perf_test.py
@@ -42,7 +42,7 @@ WEBDRIVER_PORT = 7000
 BLINK_PERF_FILES_SERVE_PORT = random.randrange(7150, 9000)
 SERVO_URL = f"http://127.0.0.1:{WEBDRIVER_PORT}"
 ABOUT_BLANK = "about:blank"
-DIRECTORY = "../../../tests/blink_perf_tests/perf_tests"
+DIRECTORY = "tests/blink_perf_tests/perf_tests"
 
 skipped_tests = [
     "large-table-with-collapsed-borders-and-no-colspans.html", # RAM
@@ -161,7 +161,7 @@ def oswalk_error(error: OSError):
 
 
 def write_file(results):
-    with open("../../../results.json", "w") as f:
+    with open("results.json", "w") as f:
         json.dump(results, f)
 
 import csv
@@ -169,11 +169,11 @@ def run_tests(webdriver, port):
     skip_until = "animate-abspos-deep.html"
 
     final_result = {}
-    with open("../../../output.csv", "w", newline="", encoding="utf-8") as f:
+    with open("output.csv", "w", newline="", encoding="utf-8") as f:
         writer = csv.writer(f)
         writer.writerow(["name", "return"])
 
-        for root, dir, files in os.walk("../../../tests/blink_perf_tests/perf_tests/layout", onerror=oswalk_error):
+        for root, dir, files in os.walk("tests/blink_perf_tests/perf_tests/layout", onerror=oswalk_error):
             for file in files:
                 dir[:] = [d for d in dir if d != "resources"]
                 filePath = file

--- a/etc/ci/scenario/blink_perf_test.py
+++ b/etc/ci/scenario/blink_perf_test.py
@@ -23,6 +23,8 @@ from selenium import webdriver
 from selenium.webdriver.common.by import By
 from selenium.webdriver.common.options import ArgOptions
 from selenium.common.exceptions import NoSuchElementException
+from selenium.webdriver.common.action_chains import ActionChains
+from selenium.webdriver.common.keys import Keys
 from urllib3.exceptions import ProtocolError
 from dataclasses import dataclass
 import threading
@@ -44,8 +46,10 @@ ABOUT_BLANK = "about:blank"
 DIRECTORY = "../../../tests/blink_perf_tests/perf_tests"
 
 skipped_tests = [
-    "large-table-with-collapsed-borders-and-no-colspans.html",
-    "large-table-with-collapsed-borders-and-colspans-wider-than-table.html"
+    "large-table-with-collapsed-borders-and-no-colspans.html", # RAM
+    "large-table-with-collapsed-borders-and-colspans-wider-than-table.html", # RAM
+    "tall-content-short-columns-realistic.html", # JS Fatal
+    "tall-content-short-columns.html" # JS Fatal
 ]
 
 class LocalFileServe:
@@ -228,6 +232,39 @@ max\s+(?P<max>[0-9.]+)\s+(?P=unit)
 def get_serve_path_for_file(root: str, file: str) -> str:
     return root.split("tests/blink_perf_tests/perf_tests/")[1]
 
+def reset_tab_ram(driver: webdriver.Remote):
+    original_tab = driver.current_window_handle
+    # driver.switch_to.new_window("tab")
+    # driver.get("about:blank")
+    # driver.switch_to.window(original_tab)
+    # driver.close()
+    
+    # driver.get("https://www.w3schools.com/w3css/tryw3css_examples_newspaper.htm")
+    # time.sleep(2)
+    # actions = ActionChains(driver)
+    # actions.key_down(Keys.CONTROL).send_keys("t").key_up(Keys.CONTROL).perform()
+    # driver.switch_to.new_window("tab")
+    # print(">>> new tab")
+    # driver.newWindow()
+    # driver.execute_script("window.open();")
+    # original_tab = driver.current_window_handle
+    # driver.switch_to.window(original_tab)
+
+    # driver.send_keys(Keys.CONTROL + 't')
+    # driver.execute_script("window.open('about:blank')")
+    driver.switch_to.new_window('tab')
+    driver.get("about:blank")
+
+    # driver.execute_script("window.open('about:blank','secondtab');")
+    # time.sleep(2)
+    # print(">>> go back")
+    driver.switch_to.window(original_tab)
+    # time.sleep(2)
+    driver.close()
+    print(">>> windows has been resets")
+    # time.sleep(60)
+    remaining_tab = driver.window_handles[0]
+    driver.switch_to.window(remaining_tab)
 
 def test(s: str, driver: webdriver.Remote, port: int, serve_path) -> TestResult | AbortReason:
     """Run a test by loading a website, and returning (avg, min, max).
@@ -279,7 +316,7 @@ def write_file(results):
 
 import csv
 def run_tests(webdriver, port):
-    skip_until = "word-break-break-all.html"
+    skip_until = "nested-blocks-with-percent-height-and-max-height.html"
 
     final_result = {}
     with open("../../../output.csv", "w", newline="", encoding="utf-8") as f:
@@ -288,12 +325,14 @@ def run_tests(webdriver, port):
 
         for root, dir, files in os.walk("../../../tests/blink_perf_tests/perf_tests/layout", onerror=oswalk_error):
             for file in files:
+                dir[:] = [d for d in dir if d != "resources"]
                 filePath = file
                 if skip_until is None or skip_until in filePath:
-                    # skip_until = None
+                    skip_until = None
                     if filePath in skipped_tests:
                         continue
                     # print(f">>> ROOT: {root}\n>>> dir: {dir}\n>>> files: {files}\n<<<")
+                    reset_tab_ram(webdriver)
                     result = test(filePath, webdriver, port, get_serve_path_for_file(root, filePath))
                     print(f">>> result: {result}")
                     if result == AbortReason.NotFound or result == AbortReason.Panic:
@@ -325,7 +364,7 @@ if __name__ == "__main__":
             print("Starting new servo instance...")
             cmd_str = f"aa start -a EntryAbility -b org.servo.servo -U {ABOUT_BLANK} --psn=--webdriver"
             hdc.cmd(cmd_str, timeout=10)
-            with HarmonyDevicePerfMode(screen_timeout_seconds = 1 * 60 * 60):
+            with HarmonyDevicePerfMode(screen_timeout_seconds = 2 * 60 * 60):
                 close_usb_popup(hdc)
                 print(">>> Creating webdriver")
                 wd = create_driver()

--- a/etc/ci/scenario/blink_perf_test.py
+++ b/etc/ci/scenario/blink_perf_test.py
@@ -20,11 +20,9 @@ from http.server import SimpleHTTPRequestHandler, ThreadingHTTPServer
 from hdc_py.hdc import HarmonyDeviceConnector, HarmonyDevicePerfMode
 from selenium import webdriver
 from selenium.webdriver.common.by import By
-from selenium.webdriver.common.options import ArgOptions
 from selenium.common.exceptions import NoSuchElementException
-from selenium.webdriver.common.action_chains import ActionChains
-from selenium.webdriver.common.keys import Keys
-from urllib3.exceptions import ProtocolError
+from selenium.webdriver.support.ui import WebDriverWait
+from selenium.webdriver.support import expected_conditions as EC
 from dataclasses import dataclass
 import threading
 from common_function_for_servo_test import create_driver, setup_hdc_forward, stop_servo, close_usb_popup
@@ -48,7 +46,8 @@ skipped_tests = [
     "large-table-with-collapsed-borders-and-no-colspans.html", # RAM
     "large-table-with-collapsed-borders-and-colspans-wider-than-table.html", # RAM
     "tall-content-short-columns-realistic.html", # JS Fatal
-    "tall-content-short-columns.html" # JS Fatal
+    "tall-content-short-columns.html", # JS Fatal
+    "floats_10_1000.html" # timeout
 ]
 
 class LocalFileServe:
@@ -115,6 +114,7 @@ def reset_tab_ram(driver: webdriver.Remote):
     print(">>> windows has been resets")
     remaining_tab = driver.window_handles[0]
     driver.switch_to.window(remaining_tab)
+    # time.sleep(.1)
 
 def test(s: str, driver: webdriver.Remote, port: int, serve_path) -> TestResult | AbortReason:
     """Run a test by loading a website, and returning (avg, min, max).
@@ -125,12 +125,22 @@ def test(s: str, driver: webdriver.Remote, port: int, serve_path) -> TestResult 
     print(f">>> testing url: {s}")
     text = None
     try:
+        before_get = time.perf_counter()
+        # print(f">>> entered try at {before_get}")
         driver.get(s)
+        after_get = time.perf_counter()
+        # print(f">>> exited try at {after_get}, diff {after_get- before_get}")
+        if after_get - before_get > 2:
+            raise TimeoutError(f"Page loading took {(after_get - before_get):.2f}s (> 2s limit)")
+        
         avg_line, min_line, max_line = None, None, None
-        for i in range(MAX_WAIT_TIME):
+        start_time, latest_time = time.perf_counter(), 0
+        while (latest_time - start_time < 60):
             try:
                 element = driver.find_element(By.ID, "log")
+                latest_time = time.perf_counter()
                 text = element.text
+                # print(f">>> text:\n{text}\n<<<")
             except NoSuchElementException:
                 time.sleep(1)
                 continue
@@ -166,7 +176,8 @@ def write_file(results):
 
 import csv
 def run_tests(webdriver, port):
-    skip_until = "animate-abspos-deep.html"
+    skip_until = None
+    # skip_until = "editing_append_single_line.html"
 
     final_result = {}
     with open("output.csv", "w", newline="", encoding="utf-8") as f:
@@ -178,13 +189,14 @@ def run_tests(webdriver, port):
                 dir[:] = [d for d in dir if d != "resources"]
                 filePath = file
                 if skip_until is None or skip_until in filePath:
-                    # skip_until = None
+                    skip_until = None
                     if filePath in skipped_tests:
                         continue
-                    # print(f">>> ROOT: {root}\n>>> dir: {dir}\n>>> files: {files}\n<<<")
-                    reset_tab_ram(webdriver)
+                    # reset_tab_ram(webdriver)
                     result = test(filePath, webdriver, port, get_serve_path_for_file(root, filePath))
                     print(f">>> result: {result}")
+                    # get_memory_report(webdriver)
+                    
                     if result == AbortReason.NotFound or result == AbortReason.Panic:
                         writer.writerow([filePath, "error"])
                         pass
@@ -203,6 +215,25 @@ def run_tests(webdriver, port):
         print(f">>> final_result {final_result}")
     write_file(final_result)
 
+def get_memory_report(driver: webdriver.Remote) -> str:
+    original_tab = driver.current_window_handle
+    driver.switch_to.new_window("tab")
+    driver.get("about:memory")
+    wait = WebDriverWait(driver, 200)
+    measure_button = wait.until(
+        EC.element_to_be_clickable((By.ID, "startButton"))
+    )
+    measure_button.click()
+    reports = wait.until(
+        lambda d: d.find_element(By.ID, "reports")
+    )
+    wait.until(
+        lambda d: d.find_element(By.ID, "reports").text.strip() != ""
+    )
+    report_text =  reports.text
+    driver.close()
+    driver.switch_to.window(original_tab)
+    return report_text
 
 if __name__ == "__main__":
     hdc = HarmonyDeviceConnector()

--- a/etc/ci/scenario/blink_perf_test.py
+++ b/etc/ci/scenario/blink_perf_test.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env -S uv run --script
 
-# Copyright 2025 The Servo Project Developers. See the COPYRIGHT
+# Copyright 2026 The Servo Project Developers. See the COPYRIGHT
 # file at the top-level directory of this distribution.
 #
 # Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or

--- a/etc/ci/scenario/blink_perf_test.py
+++ b/etc/ci/scenario/blink_perf_test.py
@@ -58,6 +58,10 @@ skipped_tests = [
     "contain-content-style-change.html",
 ]
 
+# Theses tests do pass and contribute "ms" or "runs/s" to `results`
+# but they also freeze the phone when trying to fetch memory report
+# So, the tests in this list are not skipped in general, but the
+# memory report for them is not included in the `results.json`
 tests_that_hang_memory_report = [
     "large-grid.html",
     "layer-overhead.html",
@@ -66,48 +70,10 @@ tests_that_hang_memory_report = [
     "css-contain-change-text-without-subtree-root.html",
 ]
 
-### Failed tests
-# subtree-detaching.html,error
-# abspos.html,error
-# flexbox-row-stretch-height-definite.html,error
-
-
-class LocalFileServe:
-    def __init__(self, port: int, *args, **kwargs):
-        self.local_server = None
-        self.port = port
-
-    def __enter__(self):
-        print(f"Serving local test files on port {self.port}")
-
-        class StaticHandler(SimpleHTTPRequestHandler):
-            def __init__(self, *args, **kwargs):
-                super().__init__(*args, directory=DIRECTORY, **kwargs)
-
-        self.local_server = ThreadingHTTPServer(
-            ("0.0.0.0", self.port),
-            StaticHandler,
-        )
-
-        thread = threading.Thread(target=self.local_server.serve_forever, daemon=True)
-        thread.start()
-
-    def __exit__(self, *args):
-        self.local_server.server_close()
-
-
-@dataclass(frozen=True)
-class TestResult:
-    value: float
-    lower_value: float
-    upper_value: float
-    unit: str
-
-
-class AbortReason(Enum):
-    NotFound = 1
-    Panic = 2
-
+### Failing tests (They do run, but produce no results)
+# subtree-detaching.html
+# abspos.html
+# flexbox-row-stretch-height-definite.html
 
 MAX_WAIT_TIME = 60
 
@@ -125,17 +91,54 @@ max\s+(?P<max>[0-9.]+)\s+(?P=unit)
 )
 
 
+@dataclass(frozen=True)
+class TestResult:
+    value: float
+    lower_value: float
+    upper_value: float
+    unit: str
+
+
+class AbortReason(Enum):
+    NotFound = 1
+    Panic = 2
+
+
+class LocalFileServe:
+    def __init__(self, port: int, *args, **kwargs):
+        self.local_server = None
+        self.port = port
+
+    def __enter__(self):
+        print(f"Serving local test files on port {self.port}")
+
+        class StaticHandler(SimpleHTTPRequestHandler):
+            def __init__(self, *args, **kwargs):
+                super().__init__(*args, directory=DIRECTORY, **kwargs)
+
+        self.local_server = ThreadingHTTPServer(
+            ("127.0.0.1", self.port),
+            StaticHandler,
+        )
+
+        thread = threading.Thread(target=self.local_server.serve_forever, daemon=True)
+        thread.start()
+
+    def __exit__(self, *args):
+        if self.local_server is not None:
+            self.local_server.server_close()
+
+
 def get_serve_path_for_file(root: str, file: str) -> str:
     return root.split("tests/blink_perf_tests/perf_tests/")[1]
 
 
-def test(s: str, driver: webdriver.Remote, port: int, serve_path, cli_args=None) -> TestResult | AbortReason:
+def run_single_test(s: str, driver: webdriver.Remote, port: int, serve_path, cli_args) -> TestResult | AbortReason:
     """Run a test by loading a website, and returning (avg, min, max).
     This will run for MAX_WAIT_TIME seconds and return as soon as the avg line exists in the log element"""
 
-    # s = f"http://127.0.0.1:{port}/layout/{s}"
     s = f"http://127.0.0.1:{port}/{serve_path}/{s}"
-    print(f">>> testing url: {s}")
+    print(f"Testing url: {s}")
     text = None
     try:
         before_get = time.perf_counter()
@@ -151,7 +154,6 @@ def test(s: str, driver: webdriver.Remote, port: int, serve_path, cli_args=None)
                 element = driver.find_element(By.ID, "log")
                 latest_time = time.perf_counter()
                 text = element.text
-                # print(f">>> text:\n{text}\n<<<")
             except NoSuchElementException:
                 time.sleep(1)
                 continue
@@ -308,7 +310,7 @@ def verbose_print(str_to_print: str, is_verbose: bool = False):
         print(str_to_print)
 
 
-def run_tests(port, cli_args=None):
+def run_tests(port, cli_args):
     skip_until = cli_args.skip_until
 
     final_result = {}
@@ -338,7 +340,7 @@ def run_tests(port, cli_args=None):
                             continue
 
                         try:
-                            result = test(
+                            result = run_single_test(
                                 filePath, webdriver, port, get_serve_path_for_file(root, filePath), cli_args=cli_args
                             )
 

--- a/etc/ci/scenario/blink_perf_test.py
+++ b/etc/ci/scenario/blink_perf_test.py
@@ -58,7 +58,7 @@ skipped_tests = [
     "contain-content-style-change.html",
 ]
 
-# Theses tests do pass and contribute "ms" or "runs/s" to `results`
+# `tests_that_hang_memory_report` do pass and contribute "ms" or "runs/s" to `results`
 # but they also freeze the phone when trying to fetch memory report
 # So, the tests in this list are not skipped in general, but the
 # memory report for them is not included in the `results.json`
@@ -70,10 +70,13 @@ tests_that_hang_memory_report = [
     "css-contain-change-text-without-subtree-root.html",
 ]
 
-### Failing tests (They do run, but produce no results)
-# subtree-detaching.html
-# abspos.html
-# flexbox-row-stretch-height-definite.html
+### `tests_that_take_extra_time_to_load` tests take several seconds to load instead of default 0.05s - 2s
+# can be overriden using `--page_loading_timeout` (in seconds)
+tests_that_take_extra_time_to_load = [
+    ("subtree-detaching.html", 20),
+    ("abspos.html", 5),
+    ("flexbox-row-stretch-height-definite.html", 18),
+]
 
 MAX_WAIT_TIME = 60
 
@@ -133,19 +136,32 @@ def get_serve_path_for_file(root: str, file: str) -> str:
     return root.split("tests/blink_perf_tests/perf_tests/")[1]
 
 
-def run_single_test(s: str, driver: webdriver.Remote, port: int, serve_path, cli_args) -> TestResult | AbortReason:
+def run_single_test(
+    test_file_name: str, driver: webdriver.Remote, port: int, serve_path, cli_args
+) -> TestResult | AbortReason:
     """Run a test by loading a website, and returning (avg, min, max).
     This will run for MAX_WAIT_TIME seconds and return as soon as the avg line exists in the log element"""
 
-    s = f"http://127.0.0.1:{port}/{serve_path}/{s}"
-    print(f"Testing url: {s}")
+    url = f"http://127.0.0.1:{port}/{serve_path}/{test_file_name}"
+    print(f"Testing url: {url}")
     text = None
     try:
         before_get = time.perf_counter()
-        driver.get(s)
+        driver.get(url)
         after_get = time.perf_counter()
+        if cli_args.page_loading_timeout is None:
+            special_case_time = next(
+                (value for s, value in tests_that_take_extra_time_to_load if test_file_name in s), None
+            )
+            if special_case_time is not None:
+                cli_args.page_loading_timeout = special_case_time
+            else:
+                cli_args.page_loading_timeout = 2
         if after_get - before_get > cli_args.page_loading_timeout:
-            raise TimeoutError(f"Page loading took {(after_get - before_get):.2f}s (> 2s limit)")
+            raise TimeoutError(
+                f"Page loading took {(after_get - before_get):.2f}s (> {cli_args.page_loading_timeout}s limit)"
+            )
+        print(f">>> Page loading took {(after_get - before_get):.2f}s")
 
         avg_line, min_line, max_line = None, None, None
         start_time, latest_time = time.perf_counter(), 0
@@ -154,6 +170,7 @@ def run_single_test(s: str, driver: webdriver.Remote, port: int, serve_path, cli
                 element = driver.find_element(By.ID, "log")
                 latest_time = time.perf_counter()
                 text = element.text
+                # print(f">>> Text: \n{text}\n<<<\n")
             except NoSuchElementException:
                 time.sleep(1)
                 continue
@@ -447,7 +464,7 @@ if __name__ == "__main__":
     parser.add_argument(
         "--page_loading_timeout",
         type=int,
-        default=2,
+        default=None,
         help="Pages should load very fast, but if takes longer (than default 2s or specified), the result parsing is skipped",
     )
     args = parser.parse_args()

--- a/etc/ci/scenario/blink_perf_test.py
+++ b/etc/ci/scenario/blink_perf_test.py
@@ -8,9 +8,6 @@
 # <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
 # option. This file may not be copied, modified, or distributed
 # except according to those terms.
-# /// script
-# requires-python = ">=3.12"
-# dependencies = ["selenium"]
 
 import random
 import subprocess
@@ -46,6 +43,10 @@ SERVO_URL = f"http://127.0.0.1:{WEBDRIVER_PORT}"
 ABOUT_BLANK = "about:blank"
 DIRECTORY = "../../../tests/blink_perf_tests/perf_tests"
 
+skipped_tests = [
+    "large-table-with-collapsed-borders-and-no-colspans.html",
+    "large-table-with-collapsed-borders-and-colspans-wider-than-table.html"
+]
 
 class LocalFileServe:
     def __init__(self, port: int, *args, **kwargs):
@@ -226,15 +227,17 @@ max\s+(?P<max>[0-9.]+)\s+(?P=unit)
 )
 
 
-def get_parent_dir_name_of_test_html(s: str) -> str:
-    return "layout"
+def get_serve_path_for_file(root: str, file: str) -> str:
+    return root.split("tests/blink_perf_tests/perf_tests/")[1]
 
 
-def test(s: str, driver: webdriver.Remote, port: int) -> TestResult | AbortReason:
+def test(s: str, driver: webdriver.Remote, port: int, serve_path) -> TestResult | AbortReason:
     """Run a test by loading a website, and returning (avg, min, max).
     This will run for MAX_WAIT_TIME seconds and return as soon as the avg line exists in the log element"""
 
-    s = f"http://127.0.0.1:{port}/layout/{s}"
+    # s = f"http://127.0.0.1:{port}/layout/{s}"
+    s = f"http://127.0.0.1:{port}/{serve_path}/{s}"
+    print(f">>> testing url: {s}")
     text = None
     try:
         driver.get(s)
@@ -272,29 +275,41 @@ def write_file(results):
     with open("../../../results.json", "w") as f:
         json.dump(results, f)
 
-
+import csv
 def run_tests(webdriver, port):
-    final_result = {}
-    time.sleep(2)
-    for root, dir, files in os.walk("../../../tests/blink_perf_tests/perf_tests/layout", onerror=oswalk_error):
-        for file in files:
-            filePath = file
+    skip_until = "nested-percent-height-tables.html"
 
-            result = test(filePath, webdriver, port)
-            print(f">>> result: {result}")
-            if result == AbortReason.NotFound or result == AbortReason.Panic:
-                pass
-            else:
-                combined_result = {}
-                combined_result["value"] = result.value
-                combined_result["lower_value"] = result.lower_value
-                combined_result["upper_value"] = result.upper_value
-                parent_dir = get_parent_dir_name_of_test_html(filePath)
-                if result.unit == "ms":
-                    final_result[f"perf_tests/{parent_dir}/{filePath}"] = {"ms": combined_result}
-                else:
-                    final_result[f"perf_tests/{parent_dir}/{filePath}"] = {"throughput": combined_result}
-    print(f">>> final_result {final_result}")
+    final_result = {}
+    with open("../../../output.csv", "w", newline="", encoding="utf-8") as f:
+        writer = csv.writer(f)
+        writer.writerow(["name", "return"])
+
+        for root, dir, files in os.walk("../../../tests/blink_perf_tests/perf_tests/layout", onerror=oswalk_error):
+            for file in files:
+                filePath = file
+                if skip_until is None or skip_until in filePath:
+                    skip_until = None
+                    if filePath in skipped_tests:
+                        continue
+                    # print(f">>> ROOT: {root}\n>>> dir: {dir}\n>>> files: {files}\n<<<")
+                    result = test(filePath, webdriver, port, get_serve_path_for_file(root, filePath))
+                    print(f">>> result: {result}")
+                    if result == AbortReason.NotFound or result == AbortReason.Panic:
+                        writer.writerow([filePath, "error"])
+                        pass
+                    else:
+                        combined_result = {}
+                        combined_result["value"] = result.value
+                        combined_result["lower_value"] = result.lower_value
+                        combined_result["upper_value"] = result.upper_value
+                        parent_dir = get_serve_path_for_file(root, filePath)
+                        if result.unit == "ms":
+                            final_result[f"perf_tests/{parent_dir}/{filePath}"] = {"ms": combined_result}
+                        else:
+                            final_result[f"perf_tests/{parent_dir}/{filePath}"] = {"throughput": combined_result}
+                        writer.writerow([filePath, result.value])
+                    f.flush()
+        print(f">>> final_result {final_result}")
     write_file(final_result)
 
 
@@ -308,7 +323,7 @@ if __name__ == "__main__":
             print("Starting new servo instance...")
             cmd_str = f"aa start -a EntryAbility -b org.servo.servo -U {ABOUT_BLANK} --psn=--webdriver"
             hdc.cmd(cmd_str, timeout=10)
-            with HarmonyDevicePerfMode():
+            with HarmonyDevicePerfMode(screen_timeout_seconds = 1 * 60 * 60):
                 close_usb_popup(hdc)
                 print(">>> Creating webdriver")
                 wd = create_driver()

--- a/etc/ci/scenario/blink_perf_test.py
+++ b/etc/ci/scenario/blink_perf_test.py
@@ -46,6 +46,7 @@ SERVO_URL = f"http://127.0.0.1:{WEBDRIVER_PORT}"
 ABOUT_BLANK = "about:blank"
 DIRECTORY = "tests/blink_perf_tests/perf_tests"
 
+# Tests we will skip because they are currently broken.
 skipped_tests = [
     "large-table-with-collapsed-borders-and-no-colspans.html",  # RAM
     "large-table-with-collapsed-borders-and-colspans-wider-than-table.html",  # RAM

--- a/etc/ci/scenario/blink_perf_test.py
+++ b/etc/ci/scenario/blink_perf_test.py
@@ -10,7 +10,6 @@
 # except according to those terms.
 
 import random
-import subprocess
 from enum import Enum
 import os
 import time
@@ -28,7 +27,7 @@ from selenium.webdriver.common.keys import Keys
 from urllib3.exceptions import ProtocolError
 from dataclasses import dataclass
 import threading
-
+from common_function_for_servo_test import create_driver, setup_hdc_forward, stop_servo, close_usb_popup
 
 class PortMapResult(Enum):
     SUCCESSFUL = (1,)
@@ -64,141 +63,16 @@ class LocalFileServe:
             def __init__(self, *args, **kwargs):
                 super().__init__(*args, directory=DIRECTORY, **kwargs)
 
-        # handler = partial(SimpleHTTPRequestHandler, directory = DIRECTORY)
         self.local_server = ThreadingHTTPServer(
             ("0.0.0.0", self.port),
             StaticHandler,
         )
 
-        # self.local_server.serve_forever()
         thread = threading.Thread(target=self.local_server.serve_forever, daemon=True)
         thread.start()
 
     def __exit__(self, *args):
         self.local_server.server_close()
-
-
-def create_driver(timeout: int = 10) -> webdriver.Remote:
-    print("Trying to create driver")
-    options = ArgOptions()
-    options.set_capability("browserName", "servo")
-    driver = None
-    start_time = time.time()
-    while driver is None and time.time() - start_time < timeout:
-        try:
-            driver = webdriver.Remote(command_executor=SERVO_URL, options=options)
-        except (ConnectionError, ProtocolError):
-            time.sleep(0.2)
-        except Exception as e:
-            print(f"Unexpected exception when creating webdriver: {e}, {type(e)}")
-            time.sleep(1)
-    print(
-        f"Established Webdriver connection in {time.time() - start_time}s",
-    )
-    return driver
-
-
-def port_forward(port: int | str, reverse: bool) -> PortMapResult:
-    cmd = ["hdc", "fport", "ls"]
-    output = subprocess.check_output(cmd, encoding="utf-8")
-    if f"tcp:{port}" in output:
-        return PortMapResult.PORT_EXISTS
-
-    cmd = []
-    if reverse:
-        cmd = ["hdc", "rport", f"tcp:{port}", f"tcp:{port}"]
-    else:
-        cmd = ["hdc", "fport", f"tcp:{port}", f"tcp:{port}"]
-    print(f"Setting up HDC port forwarding: {' '.join(cmd)}")
-    result = subprocess.run(cmd, capture_output=True, text=True, timeout=10)
-    if result.stdout.startswith("[Fail]TCP Port listen failed"):
-        print("Forward failed")
-        return PortMapResult.FORWARD_FAILED
-    elif result.stdout.startswith("[Fail]"):
-        print("Forward failed other way")
-        raise RuntimeError(f"HDC port forwarding failed with: {result.stdout}")
-
-    print("Port forward successful")
-    return PortMapResult.SUCCESSFUL
-
-
-def setup_hdc_forward(timeout: int = 5):
-    """
-    set hdc forward
-    :return: If successful, return driver; If failed, return False
-    """
-    for v in ("HTTP_PROXY", "http_proxy", "HTTPS_PROXY", "https_proxy"):
-        os.environ.pop(v, None)
-
-    start_time = time.time()
-    while time.time() - start_time < timeout:
-        try:
-            if (
-                port_forward(WEBDRIVER_PORT, False).is_success()
-                and port_forward(BLINK_PERF_FILES_SERVE_PORT, True).is_success()
-            ):
-                return
-            time.sleep(0.2)
-        except FileNotFoundError:
-            print("HDC command not found. Make sure OHOS SDK is installed and hdc is in PATH.")
-            raise
-        except subprocess.TimeoutExpired:
-            print(f"HDC port forwarding timed out on port {WEBDRIVER_PORT}")
-            raise
-        except Exception as e:
-            print(f"failed to setup HDC forwarding: {e}")
-            raise
-    raise TimeoutError("HDC port forwarding timed out")
-
-
-def stop_servo():
-    """stop servo application"""
-    print("Prepare to stop Test Application...")
-    cmd = ["hdc", "shell", "aa force-stop org.servo.servo"]
-    subprocess.run(cmd, capture_output=True, text=True, timeout=10)
-    print("Stop Test Application successful!")
-
-
-def close_usb_popup(hdc: HarmonyDeviceConnector):
-    """
-    When connecting an OpenHarmony device, a system pop-up will be opened on the device,
-    asking the user to confirm which USB mode should be used for the connection.
-    This pop-up overlays servo, and will hence disturb some inputs, and affect screenshots.
-    """
-    try:
-        if not is_servo_window_focused(hdc):
-            print("The focused window does not belong to servo. Sending back-event to try and close the window.")
-            # The USB pop-up can be dismissed by simulating the back key-event.
-            hdc.cmd("uitest uiInput keyEvent Back")
-        if not is_servo_window_focused(hdc):
-            print("The focused window still isn't servo. Giving up.")
-    except Exception as e:
-        print(f"Internal error trying to close the USB pop-up overlay: {e}. Ignoring...")
-
-
-def is_servo_window_focused(hdc: HarmonyDeviceConnector) -> bool:
-    completed_process = hdc.cmd("hidumper -s WindowManagerService -a '-a'", capture_output=True, encoding="utf-8")
-    output = str(completed_process.stdout)
-    lines = output.splitlines()
-    focused_window = None
-    servo_window_id = None
-    for line in lines:
-        if line.lower().startswith("focus window:"):
-            focused_window = int(line.split(":")[1].strip())
-        if line.lower().startswith("servo"):
-            # The table format is as follows:
-            # WindowName DisplayId Pid WinId
-            servo_window_id = int(line.split()[3])
-        if line.lower().startswith("windowname"):
-            table_headers = line.split()
-            assert table_headers[0].lower() == "windowname"
-            assert table_headers[3].lower() == "winid"
-        if focused_window is not None and servo_window_id is not None:
-            break
-    if focused_window is None or servo_window_id is None:
-        raise RuntimeError("Could not find focused window or servo window id.")
-    return focused_window == servo_window_id
-
 
 @dataclass(frozen=True)
 class TestResult:
@@ -234,35 +108,11 @@ def get_serve_path_for_file(root: str, file: str) -> str:
 
 def reset_tab_ram(driver: webdriver.Remote):
     original_tab = driver.current_window_handle
-    # driver.switch_to.new_window("tab")
-    # driver.get("about:blank")
-    # driver.switch_to.window(original_tab)
-    # driver.close()
-    
-    # driver.get("https://www.w3schools.com/w3css/tryw3css_examples_newspaper.htm")
-    # time.sleep(2)
-    # actions = ActionChains(driver)
-    # actions.key_down(Keys.CONTROL).send_keys("t").key_up(Keys.CONTROL).perform()
-    # driver.switch_to.new_window("tab")
-    # print(">>> new tab")
-    # driver.newWindow()
-    # driver.execute_script("window.open();")
-    # original_tab = driver.current_window_handle
-    # driver.switch_to.window(original_tab)
-
-    # driver.send_keys(Keys.CONTROL + 't')
-    # driver.execute_script("window.open('about:blank')")
     driver.switch_to.new_window('tab')
     driver.get("about:blank")
-
-    # driver.execute_script("window.open('about:blank','secondtab');")
-    # time.sleep(2)
-    # print(">>> go back")
     driver.switch_to.window(original_tab)
-    # time.sleep(2)
     driver.close()
     print(">>> windows has been resets")
-    # time.sleep(60)
     remaining_tab = driver.window_handles[0]
     driver.switch_to.window(remaining_tab)
 
@@ -316,7 +166,7 @@ def write_file(results):
 
 import csv
 def run_tests(webdriver, port):
-    skip_until = "nested-blocks-with-percent-height-and-max-height.html"
+    skip_until = "animate-abspos-deep.html"
 
     final_result = {}
     with open("../../../output.csv", "w", newline="", encoding="utf-8") as f:
@@ -328,7 +178,7 @@ def run_tests(webdriver, port):
                 dir[:] = [d for d in dir if d != "resources"]
                 filePath = file
                 if skip_until is None or skip_until in filePath:
-                    skip_until = None
+                    # skip_until = None
                     if filePath in skipped_tests:
                         continue
                     # print(f">>> ROOT: {root}\n>>> dir: {dir}\n>>> files: {files}\n<<<")
@@ -359,7 +209,7 @@ if __name__ == "__main__":
     try:
         print("Stopping potential old servo instance ...")
         stop_servo()
-        setup_hdc_forward()
+        setup_hdc_forward(webdriver_port=WEBDRIVER_PORT, host_service_port=BLINK_PERF_FILES_SERVE_PORT)
         with LocalFileServe(BLINK_PERF_FILES_SERVE_PORT):
             print("Starting new servo instance...")
             cmd_str = f"aa start -a EntryAbility -b org.servo.servo -U {ABOUT_BLANK} --psn=--webdriver"

--- a/etc/ci/scenario/blink_perf_test.py
+++ b/etc/ci/scenario/blink_perf_test.py
@@ -1,3 +1,17 @@
+#!/usr/bin/env -S uv run --script
+
+# Copyright 2025 The Servo Project Developers. See the COPYRIGHT
+# file at the top-level directory of this distribution.
+#
+# Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+# http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+# <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+# option. This file may not be copied, modified, or distributed
+# except according to those terms.
+# /// script
+# requires-python = ">=3.12"
+# dependencies = ["selenium"]
+
 import random
 import subprocess
 from enum import Enum
@@ -6,18 +20,16 @@ import time
 import sys
 import re
 import json
-from pathlib import PurePath
 from http.server import SimpleHTTPRequestHandler, ThreadingHTTPServer
 from hdc_py.hdc import HarmonyDeviceConnector, HarmonyDevicePerfMode
 from selenium import webdriver
 from selenium.webdriver.common.by import By
 from selenium.webdriver.common.options import ArgOptions
-from selenium.webdriver.remote.webelement import WebElement
 from selenium.common.exceptions import NoSuchElementException
 from urllib3.exceptions import ProtocolError
 from dataclasses import dataclass
-from functools import partial
 import threading
+
 
 class PortMapResult(Enum):
     SUCCESSFUL = (1,)
@@ -34,6 +46,7 @@ SERVO_URL = f"http://127.0.0.1:{WEBDRIVER_PORT}"
 ABOUT_BLANK = "about:blank"
 DIRECTORY = "../../../tests/blink_perf_tests/perf_tests"
 
+
 class LocalFileServe:
     def __init__(self, port: int, *args, **kwargs):
         self.local_server = None
@@ -45,7 +58,7 @@ class LocalFileServe:
         class StaticHandler(SimpleHTTPRequestHandler):
             def __init__(self, *args, **kwargs):
                 super().__init__(*args, directory=DIRECTORY, **kwargs)
-            
+
         # handler = partial(SimpleHTTPRequestHandler, directory = DIRECTORY)
         self.local_server = ThreadingHTTPServer(
             ("0.0.0.0", self.port),
@@ -53,16 +66,14 @@ class LocalFileServe:
         )
 
         # self.local_server.serve_forever()
-        thread = threading.Thread(
-            target=self.local_server.serve_forever,
-            daemon=True
-        )
+        thread = threading.Thread(target=self.local_server.serve_forever, daemon=True)
         thread.start()
 
     def __exit__(self, *args):
         print(f">>> *args: {args}")
         print(f">>> Closing local test file server on port {self.port}")
         self.local_server.server_close()
+
 
 def create_driver(timeout: int = 10) -> webdriver.Remote:
     print("Trying to create driver")
@@ -107,6 +118,7 @@ def port_forward(port: int | str, reverse: bool) -> PortMapResult:
     print("Port forward successful")
     return PortMapResult.SUCCESSFUL
 
+
 def setup_hdc_forward(timeout: int = 5):
     """
     set hdc forward
@@ -118,7 +130,10 @@ def setup_hdc_forward(timeout: int = 5):
     start_time = time.time()
     while time.time() - start_time < timeout:
         try:
-            if port_forward(WEBDRIVER_PORT, False).is_success() and port_forward(BLINK_PERF_FILES_SERVE_PORT, True).is_success():
+            if (
+                port_forward(WEBDRIVER_PORT, False).is_success()
+                and port_forward(BLINK_PERF_FILES_SERVE_PORT, True).is_success()
+            ):
                 return
             time.sleep(0.2)
         except FileNotFoundError:
@@ -132,12 +147,14 @@ def setup_hdc_forward(timeout: int = 5):
             raise
     raise TimeoutError("HDC port forwarding timed out")
 
+
 def stop_servo():
     """stop servo application"""
     print("Prepare to stop Test Application...")
     cmd = ["hdc", "shell", "aa force-stop org.servo.servo"]
     subprocess.run(cmd, capture_output=True, text=True, timeout=10)
     print("Stop Test Application successful!")
+
 
 def close_usb_popup(hdc: HarmonyDeviceConnector):
     """
@@ -154,6 +171,7 @@ def close_usb_popup(hdc: HarmonyDeviceConnector):
             print("The focused window still isn't servo. Giving up.")
     except Exception as e:
         print(f"Internal error trying to close the USB pop-up overlay: {e}. Ignoring...")
+
 
 def is_servo_window_focused(hdc: HarmonyDeviceConnector) -> bool:
     completed_process = hdc.cmd("hidumper -s WindowManagerService -a '-a'", capture_output=True, encoding="utf-8")
@@ -178,6 +196,7 @@ def is_servo_window_focused(hdc: HarmonyDeviceConnector) -> bool:
         raise RuntimeError("Could not find focused window or servo window id.")
     return focused_window == servo_window_id
 
+
 @dataclass(frozen=True)
 class TestResult:
     value: float
@@ -185,9 +204,11 @@ class TestResult:
     upper_value: float
     unit: str
 
+
 class AbortReason(Enum):
     NotFound = 1
     Panic = 2
+
 
 MAX_WAIT_TIME = 60
 
@@ -204,8 +225,10 @@ max\s+(?P<max>[0-9.]+)\s+(?P=unit)
     re.VERBOSE,
 )
 
+
 def get_parent_dir_name_of_test_html(s: str) -> str:
     return "layout"
+
 
 def test(s: str, driver: webdriver.Remote, port: int) -> TestResult | AbortReason:
     """Run a test by loading a website, and returning (avg, min, max).
@@ -236,15 +259,19 @@ def test(s: str, driver: webdriver.Remote, port: int) -> TestResult | AbortReaso
         return AbortReason.Panic
     return AbortReason.NotFound
 
+
 PREPEND = "PHONE"
+
 
 def oswalk_error(error: OSError):
     print(error)
     sys.exit(1)
 
+
 def write_file(results):
     with open("../../../results.json", "w") as f:
         json.dump(results, f)
+
 
 def run_tests(webdriver, port):
     final_result = {}
@@ -271,8 +298,6 @@ def run_tests(webdriver, port):
     write_file(final_result)
 
 
-    
-
 if __name__ == "__main__":
     hdc = HarmonyDeviceConnector()
     try:
@@ -282,10 +307,7 @@ if __name__ == "__main__":
         with LocalFileServe(BLINK_PERF_FILES_SERVE_PORT):
             print("Starting new servo instance...")
             cmd_str = f"aa start -a EntryAbility -b org.servo.servo -U {ABOUT_BLANK} --psn=--webdriver"
-            hdc.cmd(
-                cmd_str,
-                timeout = 10
-            )
+            hdc.cmd(cmd_str, timeout=10)
             with HarmonyDevicePerfMode():
                 close_usb_popup(hdc)
                 print(">>> Creating webdriver")
@@ -294,7 +316,7 @@ if __name__ == "__main__":
                 run_tests(wd, BLINK_PERF_FILES_SERVE_PORT)
     except Exception as e:
         print(f"Test failed with error: {e} (exception: {type(e)})")
-        hdc.screenshot(f"Blink_perf_test_error.jpg")
+        hdc.screenshot("Blink_perf_test_error.jpg")
         stop_servo()
         sys.exit(1)
     print("\033[32mTest Succeeded.\033[0m")

--- a/etc/ci/scenario/blink_perf_test.py
+++ b/etc/ci/scenario/blink_perf_test.py
@@ -62,7 +62,7 @@ tests_that_hang_memory_report = [
     "layer-overhead.html",
     "css-contain-change-text.html",
     "fit-content-change-available-size-text.html",
-    "css-contain-change-text-without-subtree-root.html"
+    "css-contain-change-text-without-subtree-root.html",
 ]
 
 ### Failed tests

--- a/etc/ci/scenario/blink_perf_test.py
+++ b/etc/ci/scenario/blink_perf_test.py
@@ -54,15 +54,18 @@ skipped_tests = [
     "floats_10_1000.html",  # timeout
     "nested-percent-height-tables.html",
     "large-table-with-collapsed-borders-and-colspans.html",  # causes next test to fail
+    "contain-content-style-change.html",
 ]
 
 tests_that_hang_memory_report = [
-    "contain-content-style-change.html",
     "large-grid.html",
     "layer-overhead.html",
+    "css-contain-change-text.html",
+    "fit-content-change-available-size-text.html",
 ]
 
 ### Failed tests
+# subtree-detaching.html,error
 # abspos.html,error
 # flexbox-row-stretch-height-definite.html,error
 
@@ -122,18 +125,6 @@ max\s+(?P<max>[0-9.]+)\s+(?P=unit)
 
 def get_serve_path_for_file(root: str, file: str) -> str:
     return root.split("tests/blink_perf_tests/perf_tests/")[1]
-
-
-def reset_tab_ram(driver: webdriver.Remote):
-    original_tab = driver.current_window_handle
-    driver.switch_to.new_window("tab")
-    driver.get("about:blank")
-    driver.switch_to.window(original_tab)
-    driver.close()
-    print("The tab has been reset")
-    remaining_tab = driver.window_handles[0]
-    driver.switch_to.window(remaining_tab)
-    # time.sleep(.1)
 
 
 def test(s: str, driver: webdriver.Remote, port: int, serve_path, cli_args=None) -> TestResult | AbortReason:
@@ -335,13 +326,12 @@ def run_tests(port, cli_args=None):
                         skip_until = None
                     if filePath in skipped_tests:
                         continue
-                    # reset_tab_ram(webdriver)
                     print("Starting new servo instance...")
                     cmd_str = f"aa start -a EntryAbility -b org.servo.servo -U {ABOUT_BLANK} --psn=--webdriver --psn=--pref=session_history_max_length=1"
                     hdc.cmd(cmd_str, timeout=10)
                     with HarmonyDevicePerfMode(screen_timeout_seconds=2 * 60 * 60):
                         close_usb_popup(hdc)
-                        webdriver = create_driver()
+                        webdriver = create_driver(timeout=1)
                         if webdriver is None:
                             continue
 
@@ -408,8 +398,6 @@ def run_tests(port, cli_args=None):
 def get_memory_report_str(driver: webdriver.Remote) -> MemoryReport | ParseError:
     report_text = None
     try:
-        # original_tab = driver.current_window_handle
-        # driver.switch_to.new_window("tab")
         driver.get("about:memory")
         wait = WebDriverWait(driver, 5)
         measure_button = wait.until(EC.element_to_be_clickable((By.ID, "startButton")))
@@ -417,8 +405,6 @@ def get_memory_report_str(driver: webdriver.Remote) -> MemoryReport | ParseError
         reports = wait.until(lambda d: d.find_element(By.ID, "reports"))
         wait.until(lambda d: d.find_element(By.ID, "reports").text.strip() != "")
         report_text = reports.text
-        # driver.close()
-        # driver.switch_to.window(original_tab)
     except Exception as e:
         return ParseError(message=str(e))
 

--- a/etc/ci/scenario/blink_perf_test.py
+++ b/etc/ci/scenario/blink_perf_test.py
@@ -62,6 +62,7 @@ tests_that_hang_memory_report = [
     "layer-overhead.html",
     "css-contain-change-text.html",
     "fit-content-change-available-size-text.html",
+    "css-contain-change-text-without-subtree-root.html"
 ]
 
 ### Failed tests

--- a/etc/ci/scenario/blink_perf_test.py
+++ b/etc/ci/scenario/blink_perf_test.py
@@ -71,8 +71,6 @@ class LocalFileServe:
         thread.start()
 
     def __exit__(self, *args):
-        print(f">>> *args: {args}")
-        print(f">>> Closing local test file server on port {self.port}")
         self.local_server.server_close()
 
 
@@ -243,8 +241,12 @@ def test(s: str, driver: webdriver.Remote, port: int, serve_path) -> TestResult 
         driver.get(s)
         avg_line, min_line, max_line = None, None, None
         for i in range(MAX_WAIT_TIME):
-            element = driver.find_element(By.ID, "log")
-            text = element.text
+            try:
+                element = driver.find_element(By.ID, "log")
+                text = element.text
+            except NoSuchElementException:
+                time.sleep(1)
+                continue
             m = _PATTERN.search(text)
             if m:
                 avg_line = float(m.group("avg"))
@@ -277,7 +279,7 @@ def write_file(results):
 
 import csv
 def run_tests(webdriver, port):
-    skip_until = "nested-percent-height-tables.html"
+    skip_until = "word-break-break-all.html"
 
     final_result = {}
     with open("../../../output.csv", "w", newline="", encoding="utf-8") as f:
@@ -288,7 +290,7 @@ def run_tests(webdriver, port):
             for file in files:
                 filePath = file
                 if skip_until is None or skip_until in filePath:
-                    skip_until = None
+                    # skip_until = None
                     if filePath in skipped_tests:
                         continue
                     # print(f">>> ROOT: {root}\n>>> dir: {dir}\n>>> files: {files}\n<<<")

--- a/etc/ci/scenario/common_function_for_servo_test.py
+++ b/etc/ci/scenario/common_function_for_servo_test.py
@@ -28,7 +28,7 @@ from selenium.webdriver.remote.webelement import WebElement
 from urllib3.exceptions import ProtocolError
 
 WEBDRIVER_PORT = 7000
-MITMPROXY_PORT = str(random.randrange(7150, 9000))
+MITMPROXY_PORT = random.randrange(7150, 9000)
 SERVO_URL = f"http://127.0.0.1:{WEBDRIVER_PORT}"
 ABOUT_BLANK = "about:blank"
 MITMPROXY_VERSION = "12.2.1"
@@ -49,7 +49,7 @@ class MitmProxyRunType(enum.Enum):
 
 
 class MitmProxy:
-    def __init__(self, use_proxy: MitmProxyRunType, dump_file, port: str):
+    def __init__(self, use_proxy: MitmProxyRunType, dump_file, port: int):
         self.mitmproxy = None
         self.use_proxy = use_proxy
         self.dump_file = dump_file
@@ -64,7 +64,7 @@ class MitmProxy:
                 [
                     "mitmdump",
                     "-p",
-                    self.port,
+                    str(self.port),
                     "--server-replay",
                     self.dump_file,
                     # reply with 404 if request is not in dump_file
@@ -84,7 +84,7 @@ class MitmProxy:
                     self.dump_file,
                     # "--mode", "upstream:http://127.0.0.1:3128",
                     "-p",
-                    self.port,
+                    str(self.port),
                     "--set",
                     "ssl_insecure=true",
                 ]
@@ -355,7 +355,7 @@ def run_test(test_fn, test_name: str, use_mitmproxy: MitmProxyRunType = MitmProx
             time.sleep(5)
             cmd_str = f"aa start -a EntryAbility -b org.servo.servo -U {ABOUT_BLANK} --psn=--webdriver"
             if use_mitmproxy.should_servo_proxy():
-                cmd_str += f" --psn=--pref=network_https_proxy_uri=http://127.0.0.1:{MITMPROXY_PORT} --psn=--pref=network_http_proxy_uri=http://127.0.0.1:{MITMPROXY_PORT} --psn=--ignore-certificate-errors"
+                cmd_str += f" --psn=--pref=network_https_proxy_uri=http://127.0.0.1:{str(MITMPROXY_PORT)} --psn=--pref=network_http_proxy_uri=http://127.0.0.1:{MITMPROXY_PORT} --psn=--ignore-certificate-errors"
             hdc.cmd(
                 cmd_str,
                 timeout=10,

--- a/etc/ci/scenario/common_function_for_servo_test.py
+++ b/etc/ci/scenario/common_function_for_servo_test.py
@@ -203,7 +203,7 @@ def port_forward(port: int | str, reverse: bool) -> PortMapResult:
     return PortMapResult.SUCCESSFUL
 
 
-def setup_hdc_forward(timeout: int = 5):
+def setup_hdc_forward(timeout: int = 5, webdriver_port: int = WEBDRIVER_PORT, host_service_port: int = MITMPROXY_PORT):
     """
     set hdc forward
     :return: If successful, return driver; If failed, return False
@@ -214,14 +214,14 @@ def setup_hdc_forward(timeout: int = 5):
     start_time = time.time()
     while time.time() - start_time < timeout:
         try:
-            if port_forward(WEBDRIVER_PORT, False).is_success() and port_forward(MITMPROXY_PORT, True).is_success():
+            if port_forward(webdriver_port, False).is_success() and port_forward(host_service_port, True).is_success():
                 return
             time.sleep(0.2)
         except FileNotFoundError:
             print("HDC command not found. Make sure OHOS SDK is installed and hdc is in PATH.")
             raise
         except subprocess.TimeoutExpired:
-            print(f"HDC port forwarding timed out on port {WEBDRIVER_PORT}")
+            print(f"HDC port forwarding timed out on port {webdriver_port}")
             raise
         except Exception as e:
             print(f"failed to setup HDC forwarding: {e}")

--- a/etc/ci/scenario/common_function_for_servo_test.py
+++ b/etc/ci/scenario/common_function_for_servo_test.py
@@ -163,9 +163,12 @@ def create_driver(timeout: int = 10) -> webdriver.Remote:
         except Exception as e:
             print(f"Unexpected exception when creating webdriver: {e}, {type(e)}")
             time.sleep(1)
-    print(
-        f"Established Webdriver connection in {time.time() - start_time}s",
-    )
+    if driver is None:
+        print(f"The driver is not created due to {timeout}s timeout (took: {time.time() - start_time}s)")
+    else:
+        print(
+            f"Established Webdriver connection in {time.time() - start_time}s",
+        )
     return driver
 
 


### PR DESCRIPTION
CI: ohos blink_perf_test scenario

Background:
There are so called blink_perf_tests in the `tests/blink_perf_tests/` that can be used to bench servo. Those are 100+ unitary test .html pages that result in either "ms" or "runs/s". 
There is also a python script that is currently used to run those tests `etc/blink-perf-test-runner/main.py`, but it runs the tests on the host (tested on linux).

Goal of this PR:
I want to also be able to run the tests on ohos. So I created a .py script in etc/ci/scenario/ that is very similar to the script that is already on servo. The script produces `results.json` and it can be included into the bencher.dev ci and run on the ci ohos devices.

~~Testing: within `etc/ci/scenatio` directory do `uv run blink_perf_test.py`~~
Testing: within servo project root do `UV_PROJECT=etc/ci/scenario uv run etc/ci/scenario/blink_perf_test.py -vem`
For `help` use `-h`

