### PR TITLE
Update expected results for paint-timing tests

### DIFF
--- a/tests/wpt/meta/paint-timing/fcp-only/fcp-video-frame.html.ini
+++ b/tests/wpt/meta/paint-timing/fcp-only/fcp-video-frame.html.ini
@@ -1,3 +1,0 @@
-[fcp-video-frame.html]
-  [Video should become contentful when first frame is loaded]
-    expected: FAIL

--- a/tests/wpt/meta/paint-timing/fcp-only/fcp-video-poster.html.ini
+++ b/tests/wpt/meta/paint-timing/fcp-only/fcp-video-poster.html.ini
@@ -1,3 +1,0 @@
-[fcp-video-poster.html]
-  [Video should become contentful when poster is loaded]
-    expected: FAIL


### PR DESCRIPTION
Updates the WPT expectations for #42411. 

#42433 changed the expectations recently.

Testing: WPT Tests Passed
Fixes #42359
Fixes #42360
