### PR TITLE
paint: Consider opportunity to send `touchmove` to `ScriptThread` regardless of existence of `ScrollZoomEvent`

### DIFF
--- a/components/paint/webview_renderer.rs
+++ b/components/paint/webview_renderer.rs
@@ -468,18 +468,18 @@ impl WebViewRenderer {
                 event.disable_cancelable();
                 self.pending_scroll_zoom_events.push(action);
             }
-            // When the event is touchmove, if the script thread is processing the touch
-            // move event, we skip sending the event to the script thread.
-            // This prevents the script thread from stacking up for a large amount of time.
-            if !self
-                .touch_handler
-                .is_handling_touch_move(self.touch_handler.current_sequence_id) &&
-                self.send_touch_event(render_api, event, id) &&
-                event.is_cancelable()
-            {
-                self.touch_handler
-                    .set_handling_touch_move(self.touch_handler.current_sequence_id, true);
-            }
+        }
+        // When the event is touchmove, if the script thread is processing the touch
+        // move event, we skip sending the event to the script thread.
+        // This prevents the script thread from stacking up for a large amount of time.
+        if !self
+            .touch_handler
+            .is_handling_touch_move(self.touch_handler.current_sequence_id) &&
+            self.send_touch_event(render_api, event, id) &&
+            event.is_cancelable()
+        {
+            self.touch_handler
+                .set_handling_touch_move(self.touch_handler.current_sequence_id, true);
         }
     }
 

--- a/tests/wpt/meta/pointerevents/pointerevent_pointerleave_after_pointercancel_touch.html.ini
+++ b/tests/wpt/meta/pointerevents/pointerevent_pointerleave_after_pointercancel_touch.html.ini
@@ -1,4 +1,4 @@
 [pointerevent_pointerleave_after_pointercancel_touch.html]
-  expected: TIMEOUT
+  expected: ERROR
   [pointerleave event received]
     expected: NOTRUN

--- a/tests/wpt/meta/pointerevents/pointerevent_pointerout_after_pointercancel_touch.html.ini
+++ b/tests/wpt/meta/pointerevents/pointerevent_pointerout_after_pointercancel_touch.html.ini
@@ -1,4 +1,4 @@
 [pointerevent_pointerout_after_pointercancel_touch.html]
-  expected: TIMEOUT
+  expected: ERROR
   [pointerout event received]
     expected: NOTRUN

--- a/tests/wpt/meta/touch-events/multi-touch-interfaces.html.ini
+++ b/tests/wpt/meta/touch-events/multi-touch-interfaces.html.ini
@@ -1,7 +1,3 @@
 [multi-touch-interfaces.html]
-  expected: TIMEOUT
-  [touchmove event received]
-    expected: NOTRUN
-
   [touchend event received]
     expected: FAIL


### PR DESCRIPTION
We still keep the key performance optimization. But it is important to send the event to script, if other conditions are still satisfied.

Testing: 
- `multi-touch-interfaces.html` no longer TIMEOUT, which contains 494 subtests.
- `pointerevent_pointerout_after_pointercancel_touch.html`/`pointerevent_pointerleave_after_pointercancel_touch.html` no longer scroll **indefinitely**. These two tests will work once we have `pointerout` and `pointerleave`.

Part of #41923.