### PR TITLE
script_bindings/libservo: Fix build script to use `uv` to build instead of `python3`

### DIFF
--- a/components/script_bindings/build.rs
+++ b/components/script_bindings/build.rs
@@ -5,7 +5,7 @@
 use std::fs::File;
 use std::io::Write;
 use std::path::PathBuf;
-use std::process::Command;
+use std::process::{Command, Stdio};
 use std::time::Instant;
 use std::{env, fmt};
 
@@ -84,6 +84,7 @@ fn try_python_command(program: &str, args: &[&str]) -> Result<(), String> {
     let mut command = Command::new(program);
     command.args(args);
     command.arg("--version");
+    command.stdin(Stdio::null());
 
     let command_result = command.output();
 

--- a/components/script_bindings/build.rs
+++ b/components/script_bindings/build.rs
@@ -118,7 +118,7 @@ fn find_python() -> Command {
         .inspect_err(|e| println!("cargo:warning={e}"));
     if uv_result.is_ok() {
         let mut cmd = Command::new("uv");
-        cmd.args(["run", "python"]);
+        cmd.args(["run", "--frozen", "python"]);
         return cmd;
     }
 

--- a/components/script_bindings/build.rs
+++ b/components/script_bindings/build.rs
@@ -114,8 +114,8 @@ fn try_python_command(program: &str, args: &[&str]) -> Result<(), String> {
 /// Note: This function should be kept in sync with the version in `components/servo/build.rs`
 fn find_python() -> Command {
     // Test uv first - if it works, create a FRESH command to return
-    let uv_result =
-        try_python_command("uv", &["run", "python"]).inspect_err(|e| println!("cargo:warning={e}"));
+    let uv_result = try_python_command("uv", &["run", "--frozen", "python"])
+        .inspect_err(|e| println!("cargo:warning={e}"));
     if uv_result.is_ok() {
         let mut cmd = Command::new("uv");
         cmd.args(["run", "python"]);

--- a/components/servo/build.rs
+++ b/components/servo/build.rs
@@ -59,8 +59,8 @@ fn try_python_command(program: &str, args: &[&str]) -> Result<(), String> {
 /// Note: This function should be kept in sync with the version in `components/script_bindings/build.rs`
 fn find_python() -> Command {
     // Test uv first - if it works, create a FRESH command to return
-    let uv_result =
-        try_python_command("uv", &["run", "python"]).inspect_err(|e| println!("cargo:warning={e}"));
+    let uv_result = try_python_command("uv", &["run", "--frozen", "python"])
+        .inspect_err(|e| println!("cargo:warning={e}"));
     if uv_result.is_ok() {
         let mut cmd = Command::new("uv");
         cmd.args(["run", "python"]);

--- a/components/servo/build.rs
+++ b/components/servo/build.rs
@@ -63,7 +63,7 @@ fn find_python() -> Command {
         .inspect_err(|e| println!("cargo:warning={e}"));
     if uv_result.is_ok() {
         let mut cmd = Command::new("uv");
-        cmd.args(["run", "python"]);
+        cmd.args(["run", "--frozen", "python"]);
         return cmd;
     }
 


### PR DESCRIPTION
- Redirect stdin to null device when testing Python command. This fixes the issue with Windows.
- Use `--frozen` for both test command and actual command used in build. This is what we've been doing for `mach`.

Before this PR, uv fails due to the missing `--frozen` and we fall back to python3 in CI for various platforms.

Fixes: #42527
