### PR TITLE
layout: Properly set parent of dirty root after box tree layout

### DIFF
--- a/components/layout/flow/root.rs
+++ b/components/layout/flow/root.rs
@@ -414,12 +414,25 @@ impl<'dom> IncrementalBoxTreeUpdate<'dom> {
         let info =
             NodeAndStyleInfo::new(node, self.primary_style.clone(), node.take_restyle_damage());
 
-        let out_of_flow_absolutely_positioned_box =
-            AbsolutelyPositionedBox::construct(context, &info, self.display_inside, contents);
+        let build_new_box = |old_parent| {
+            let mut out_of_flow_absolutely_positioned_box =
+                AbsolutelyPositionedBox::construct(context, &info, self.display_inside, contents);
+            if let Some(old_parent) = old_parent {
+                out_of_flow_absolutely_positioned_box
+                    .context
+                    .base
+                    .parent_box
+                    .replace(old_parent);
+            }
+            out_of_flow_absolutely_positioned_box
+        };
+
         match &self.box_tree_node {
             DirtyRootBoxTreeNode::AbsolutelyPositionedBlockLevelBox(block_level_box) => {
-                *block_level_box.borrow_mut() = BlockLevelBox::OutOfFlowAbsolutelyPositionedBox(
-                    ArcRefCell::new(out_of_flow_absolutely_positioned_box),
+                let mut block_level_box = block_level_box.borrow_mut();
+                let old_parent = block_level_box.with_base(|base| base.parent_box.clone());
+                *block_level_box = BlockLevelBox::OutOfFlowAbsolutelyPositionedBox(
+                    ArcRefCell::new(build_new_box(old_parent)),
                 );
             },
             DirtyRootBoxTreeNode::AbsolutelyPositionedInlineLevelBox(
@@ -427,7 +440,9 @@ impl<'dom> IncrementalBoxTreeUpdate<'dom> {
                 text_offset_index,
             ) => match inline_level_box {
                 InlineItem::OutOfFlowAbsolutelyPositionedBox(positioned_box, offset_in_text) => {
-                    *positioned_box.borrow_mut() = out_of_flow_absolutely_positioned_box;
+                    let mut positioned_box = positioned_box.borrow_mut();
+                    let old_parent = positioned_box.context.base.parent_box.clone();
+                    *positioned_box = build_new_box(old_parent);
                     assert_eq!(
                         *offset_in_text, *text_offset_index,
                         "The offset of the dirty root shouldn't have changed"
@@ -436,14 +451,18 @@ impl<'dom> IncrementalBoxTreeUpdate<'dom> {
                 _ => unreachable!("The dirty root should be absolutely positioned"),
             },
             DirtyRootBoxTreeNode::AbsolutelyPositionedFlexLevelBox(flex_level_box) => {
-                *flex_level_box.borrow_mut() = FlexLevelBox::OutOfFlowAbsolutelyPositionedBox(
-                    ArcRefCell::new(out_of_flow_absolutely_positioned_box),
-                );
+                let mut flex_level_box = flex_level_box.borrow_mut();
+                let old_parent = flex_level_box.with_base(|base| base.parent_box.clone());
+                *flex_level_box = FlexLevelBox::OutOfFlowAbsolutelyPositionedBox(ArcRefCell::new(
+                    build_new_box(old_parent),
+                ));
             },
             DirtyRootBoxTreeNode::AbsolutelyPositionedTaffyLevelBox(taffy_level_box) => {
-                taffy_level_box.borrow_mut().taffy_level_box =
+                let mut taffy_level_box = taffy_level_box.borrow_mut();
+                let old_parent = taffy_level_box.with_base(|base| base.parent_box.clone());
+                taffy_level_box.taffy_level_box =
                     TaffyItemBoxInner::OutOfFlowAbsolutelyPositionedBox(ArcRefCell::new(
-                        out_of_flow_absolutely_positioned_box,
+                        build_new_box(old_parent),
                     ));
             },
         }


### PR DESCRIPTION
When laying out the box tree from a dirty root, we were replacing the inner layout
box contents of the dirty root, but not updating its parent. This change fixes
that. This is important because any sort of operation that will need the parent
will subsequently fail unless it is properly set. We do not use the parent now, but
we will in the future.

Testing: The parent is currently unused, but it will be used in the future. This
shouldn't change the functioning of Servo currently.