### PR TITLE
servoshell: Trigger reload when the F5 key is pressed

### DIFF
--- a/ports/servoshell/desktop/headed_window.rs
+++ b/ports/servoshell/desktop/headed_window.rs
@@ -339,7 +339,9 @@ impl HeadedWindow {
         let mut handled = true;
         ShortcutMatcher::from_event(key_event.event.clone())
             .shortcut(CMD_OR_CONTROL, 'R', || active_webview.reload())
-            .shortcut(Modifiers::empty(), Key::Named(NamedKey::F5), || active_webview.reload())
+            .shortcut(Modifiers::empty(), Key::Named(NamedKey::F5), || {
+                active_webview.reload()
+            })
             .shortcut(CMD_OR_CONTROL, 'W', || {
                 window.close_webview(active_webview.id());
             })

--- a/ports/servoshell/desktop/headed_window.rs
+++ b/ports/servoshell/desktop/headed_window.rs
@@ -339,9 +339,6 @@ impl HeadedWindow {
         let mut handled = true;
         ShortcutMatcher::from_event(key_event.event.clone())
             .shortcut(CMD_OR_CONTROL, 'R', || active_webview.reload())
-            .shortcut(Modifiers::empty(), Key::Named(NamedKey::F5), || {
-                active_webview.reload()
-            })
             .shortcut(CMD_OR_CONTROL, 'W', || {
                 window.close_webview(active_webview.id());
             })
@@ -1041,6 +1038,9 @@ impl PlatformWindow for HeadedWindow {
             })
             .shortcut(CMD_OR_CONTROL, '0', || {
                 webview.set_page_zoom(1.0);
+            })
+            .shortcut(Modifiers::empty(), Key::Named(NamedKey::F5), || {
+                webview.reload()
             });
     }
 

--- a/ports/servoshell/desktop/headed_window.rs
+++ b/ports/servoshell/desktop/headed_window.rs
@@ -338,7 +338,6 @@ impl HeadedWindow {
 
         let mut handled = true;
         ShortcutMatcher::from_event(key_event.event.clone())
-            .shortcut(CMD_OR_CONTROL, 'R', || active_webview.reload())
             .shortcut(CMD_OR_CONTROL, 'W', || {
                 window.close_webview(active_webview.id());
             })
@@ -1039,6 +1038,7 @@ impl PlatformWindow for HeadedWindow {
             .shortcut(CMD_OR_CONTROL, '0', || {
                 webview.set_page_zoom(1.0);
             })
+            .shortcut(CMD_OR_CONTROL, 'R', || webview.reload())
             .shortcut(Modifiers::empty(), Key::Named(NamedKey::F5), || {
                 webview.reload()
             });

--- a/ports/servoshell/desktop/headed_window.rs
+++ b/ports/servoshell/desktop/headed_window.rs
@@ -339,6 +339,7 @@ impl HeadedWindow {
         let mut handled = true;
         ShortcutMatcher::from_event(key_event.event.clone())
             .shortcut(CMD_OR_CONTROL, 'R', || active_webview.reload())
+            .shortcut(Modifiers::empty(), Key::Named(NamedKey::F5), || active_webview.reload())
             .shortcut(CMD_OR_CONTROL, 'W', || {
                 window.close_webview(active_webview.id());
             })


### PR DESCRIPTION
Whenever I open Servoshell and reload, I want to hit F5. Alas it does nothing.
Now it will.

Testing: This level of functionality in servoshell is not tested at the moment.