### PR TITLE
layout: Get rid of `LargestContentfulPaintType` struct

### DIFF
--- a/components/constellation/constellation.rs
+++ b/components/constellation/constellation.rs
@@ -5658,8 +5658,8 @@ where
                 metric_value,
                 first_reflow,
             ),
-            PaintMetricEvent::LargestContentfulPaint(metric_value, area, lcp_type) => (
-                ProgressiveWebMetricType::LargestContentfulPaint { area, lcp_type },
+            PaintMetricEvent::LargestContentfulPaint(metric_value, area) => (
+                ProgressiveWebMetricType::LargestContentfulPaint { area },
                 metric_value,
                 false, // LCP doesn't care about first reflow
             ),

--- a/components/layout/display_list/largest_contenful_paint_candidate_collector.rs
+++ b/components/layout/display_list/largest_contenful_paint_candidate_collector.rs
@@ -3,9 +3,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 use euclid::Rect;
-use paint_api::largest_contentful_paint_candidate::{
-    LCPCandidate, LCPCandidateID, LargestContentfulPaintType,
-};
+use paint_api::largest_contentful_paint_candidate::{LCPCandidate, LCPCandidateID};
 use servo_geometry::{FastLayoutTransform, au_rect_to_f32_rect, f32_rect_to_au_rect};
 use webrender_api::units::{LayoutRect, LayoutSize};
 
@@ -32,7 +30,6 @@ impl LargestContentfulPaintCandidateCollector {
 
     pub fn add_or_update_candidate(
         &mut self,
-        lcp_type: LargestContentfulPaintType,
         lcp_candidate_id: LCPCandidateID,
         clip_rect: LayoutRect,
         bounds: LayoutRect,
@@ -55,7 +52,7 @@ impl LargestContentfulPaintCandidateCollector {
             return;
         }
 
-        self.update_candidate(LCPCandidate::new(lcp_candidate_id, lcp_type, area as usize));
+        self.update_candidate(LCPCandidate::new(lcp_candidate_id, area as usize));
     }
 
     fn update_candidate(&mut self, candidate: LCPCandidate) {

--- a/components/layout/display_list/mod.rs
+++ b/components/layout/display_list/mod.rs
@@ -13,7 +13,7 @@ use fonts::GlyphStore;
 use gradient::WebRenderGradient;
 use net_traits::image_cache::Image as CachedImage;
 use paint_api::display_list::{PaintDisplayListInfo, SpatialTreeNodeInfo};
-use paint_api::largest_contentful_paint_candidate::{LCPCandidateID, LargestContentfulPaintType};
+use paint_api::largest_contentful_paint_candidate::LCPCandidateID;
 use servo_arc::Arc as ServoArc;
 use servo_config::opts::DiagnosticsLogging;
 use servo_geometry::MaxRect;
@@ -523,7 +523,6 @@ impl DisplayListBuilder<'_> {
     #[inline]
     fn collect_lcp_candidate(
         &mut self,
-        lcp_type: LargestContentfulPaintType,
         lcp_candidate_id: LCPCandidateID,
         clip_rect: LayoutRect,
         bounds: LayoutRect,
@@ -533,13 +532,7 @@ impl DisplayListBuilder<'_> {
                 .paint_info
                 .scroll_tree
                 .cumulative_node_to_root_transform(self.current_scroll_node_id);
-            lcp_collector.add_or_update_candidate(
-                lcp_type,
-                lcp_candidate_id,
-                clip_rect,
-                bounds,
-                transform,
-            );
+            lcp_collector.add_or_update_candidate(lcp_candidate_id, clip_rect, bounds, transform);
         }
     }
 }
@@ -669,12 +662,7 @@ impl Fragment {
                             .tag
                             .map(|tag| LCPCandidateID(tag.node.id()))
                             .unwrap_or(LCPCandidateID(0));
-                        builder.collect_lcp_candidate(
-                            LargestContentfulPaintType::Image,
-                            lcp_candidate_id,
-                            common.clip_rect,
-                            rect,
-                        );
+                        builder.collect_lcp_candidate(lcp_candidate_id, common.clip_rect, rect);
                     },
                     Visibility::Hidden => (),
                     Visibility::Collapse => (),
@@ -1406,7 +1394,6 @@ impl<'a> BuilderForBoxFragment<'a> {
                             .map(|tag| LCPCandidateID(tag.node.id()))
                             .unwrap_or(LCPCandidateID(0));
                         builder.collect_lcp_candidate(
-                            LargestContentfulPaintType::BackgroundImage,
                             lcp_candidate_id,
                             layer.common.clip_rect,
                             layer.bounds,

--- a/components/metrics/lib.rs
+++ b/components/metrics/lib.rs
@@ -8,7 +8,6 @@ use std::time::Duration;
 
 use base::cross_process_instant::CrossProcessInstant;
 use malloc_size_of_derive::MallocSizeOf;
-use paint_api::largest_contentful_paint_candidate::LargestContentfulPaintType;
 use profile_traits::time::{
     ProfilerCategory, ProfilerChan, TimerMetadata, TimerMetadataFrameType, TimerMetadataReflowType,
     send_profile_data,
@@ -246,16 +245,11 @@ impl ProgressiveWebMetrics {
         );
     }
 
-    pub fn set_largest_contentful_paint(
-        &self,
-        paint_time: CrossProcessInstant,
-        area: usize,
-        lcp_type: LargestContentfulPaintType,
-    ) {
+    pub fn set_largest_contentful_paint(&self, paint_time: CrossProcessInstant, area: usize) {
         set_metric(
             self,
             Some(self.make_metadata(false)),
-            ProgressiveWebMetricType::LargestContentfulPaint { area, lcp_type },
+            ProgressiveWebMetricType::LargestContentfulPaint { area },
             ProfilerCategory::TimeToLargestContentfulPaint,
             &self.largest_contentful_paint,
             paint_time,

--- a/components/paint/painter.rs
+++ b/components/paint/painter.rs
@@ -508,7 +508,6 @@ impl Painter {
                                 servo_profiling = true,
                                 paint_time = ?paint_time,
                                 area = ?lcp.area,
-                                lcp_type = ?lcp.lcp_type,
                                 pipeline_id = ?pipeline_id,
                             );
                             self.send_to_constellation(
@@ -517,7 +516,6 @@ impl Painter {
                                     PaintMetricEvent::LargestContentfulPaint(
                                         lcp.paint_time,
                                         lcp.area,
-                                        lcp.lcp_type,
                                     ),
                                 ),
                             );

--- a/components/script/dom/document.rs
+++ b/components/script/dom/document.rs
@@ -3475,14 +3475,14 @@ impl Document {
                 let entry = binding.upcast::<PerformanceEntry>();
                 self.window.Performance().queue_entry(entry);
             },
-            ProgressiveWebMetricType::LargestContentfulPaint { area, lcp_type } => {
+            ProgressiveWebMetricType::LargestContentfulPaint { area } => {
                 let binding = LargestContentfulPaint::new(
                     self.window.as_global_scope(),
                     metric_type,
                     metric_value,
                     can_gc,
                 );
-                metrics.set_largest_contentful_paint(metric_value, area, lcp_type);
+                metrics.set_largest_contentful_paint(metric_value, area);
                 let entry = binding.upcast::<PerformanceEntry>();
                 self.window.Performance().queue_entry(entry);
             },

--- a/components/shared/constellation/lib.rs
+++ b/components/shared/constellation/lib.rs
@@ -29,7 +29,6 @@ use embedder_traits::{
 pub use from_script_message::*;
 use malloc_size_of_derive::MallocSizeOf;
 use paint_api::PinchZoomInfos;
-use paint_api::largest_contentful_paint_candidate::LargestContentfulPaintType;
 use profile_traits::mem::MemoryReportResult;
 use rustc_hash::FxHashMap;
 use serde::{Deserialize, Serialize};
@@ -132,11 +131,7 @@ pub enum UserContentManagerAction {
 pub enum PaintMetricEvent {
     FirstPaint(CrossProcessInstant, bool /* first_reflow */),
     FirstContentfulPaint(CrossProcessInstant, bool /* first_reflow */),
-    LargestContentfulPaint(
-        CrossProcessInstant,
-        usize, /* area */
-        LargestContentfulPaintType,
-    ),
+    LargestContentfulPaint(CrossProcessInstant, usize /* area */),
 }
 
 impl fmt::Debug for EmbedderToConstellationMessage {

--- a/components/shared/paint/largest_contentful_paint_candidate.rs
+++ b/components/shared/paint/largest_contentful_paint_candidate.rs
@@ -7,12 +7,6 @@
 use base::cross_process_instant::CrossProcessInstant;
 use serde::{Deserialize, Serialize};
 
-#[derive(Clone, Copy, Debug, Deserialize, Serialize)]
-pub enum LargestContentfulPaintType {
-    BackgroundImage,
-    Image,
-}
-
 /// Largest Contentful Paint Candidate, include image and block-level element containing text
 #[derive(Clone, Copy, Debug, Deserialize, Serialize)]
 pub struct LCPCandidate {
@@ -20,13 +14,11 @@ pub struct LCPCandidate {
     pub id: LCPCandidateID,
     /// The size of the visual area
     pub area: usize,
-    /// The type of LCP candidate
-    pub lcp_type: LargestContentfulPaintType,
 }
 
 impl LCPCandidate {
-    pub fn new(id: LCPCandidateID, lcp_type: LargestContentfulPaintType, area: usize) -> Self {
-        Self { id, lcp_type, area }
+    pub fn new(id: LCPCandidateID, area: usize) -> Self {
+        Self { id, area }
     }
 }
 
@@ -37,7 +29,6 @@ pub struct LCPCandidateID(pub usize);
 pub struct LargestContentfulPaint {
     pub id: LCPCandidateID,
     pub area: usize,
-    pub lcp_type: LargestContentfulPaintType,
     pub paint_time: CrossProcessInstant,
 }
 
@@ -45,7 +36,6 @@ impl LargestContentfulPaint {
     pub fn from(lcp_candidate: LCPCandidate, paint_time: CrossProcessInstant) -> Self {
         Self {
             id: lcp_candidate.id,
-            lcp_type: lcp_candidate.lcp_type,
             area: lcp_candidate.area,
             paint_time,
         }

--- a/components/shared/script/lib.rs
+++ b/components/shared/script/lib.rs
@@ -38,7 +38,6 @@ use keyboard_types::Modifiers;
 use malloc_size_of_derive::MallocSizeOf;
 use media::WindowGLContext;
 use net_traits::ResourceThreads;
-use paint_api::largest_contentful_paint_candidate::LargestContentfulPaintType;
 use paint_api::{CrossProcessPaintApi, PinchZoomInfos};
 use pixels::PixelFormat;
 use profile_traits::mem;
@@ -117,8 +116,6 @@ pub enum ProgressiveWebMetricType {
     LargestContentfulPaint {
         /// The pixel area of the largest contentful element.
         area: usize,
-        /// The type of the largest contentful paint element.
-        lcp_type: LargestContentfulPaintType,
     },
     /// Time to interactive
     TimeToInteractive,


### PR DESCRIPTION
LargestContentfulPaintType is not useful.

Testing: No behaviour change expected
