### PR TITLE
layout: SVG with zero size should get natural ratio from viewBox

### DIFF
--- a/components/layout/replaced.rs
+++ b/components/layout/replaced.rs
@@ -247,14 +247,11 @@ impl ReplacedContents {
         let width = svg_data.width.and_then(attr_to_computed);
         let height = svg_data.height.and_then(attr_to_computed);
 
-        let ratio = if let (Some(width), Some(height)) = (width, height) {
-            if !width.is_zero() && !height.is_zero() {
+        let ratio = match (width, height) {
+            (Some(width), Some(height)) if !width.is_zero() && !height.is_zero() => {
                 Some(width.px() / height.px())
-            } else {
-                None
-            }
-        } else {
-            svg_data.ratio_from_view_box()
+            },
+            _ => svg_data.ratio_from_view_box(),
         };
 
         let natural_size = NaturalSizes {

--- a/tests/wpt/tests/css/css-sizing/svg-intrinsic-size-007.tentative.html
+++ b/tests/wpt/tests/css/css-sizing/svg-intrinsic-size-007.tentative.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<title>Natural aspect ratio of SVG</title>
+<link rel="help" href="https://github.com/w3c/csswg-drafts/issues/6286">
+<link rel="author" title="Oriol Brufau" href="obrufau@igalia.com">
+<link rel="author" title="Ian Kilpatrick" href="ikilpatrick@chromium.org">
+<link rel="match" href="../reference/ref-filled-green-100px-square-only.html">
+<meta name="assert" content="The SVG has width and height attributes,
+  so they would normally set the natural aspect ratio. However, here
+  the height attribute is zero, which would produce a degenerate ratio.
+  Therefore, the natural aspect ratio is instead determined from viewBox.
+">
+<style>
+svg {
+  background: green;
+  width: auto;
+  height: auto;
+}
+</style>
+<p>Test passes if there is a filled green square.</p>
+<svg viewBox="0 0 1 1" width="100" height="0"></svg>


### PR DESCRIPTION
This logic was (accidentally?) changed in #40761. Revert it back to the original one, which is simpler, and matches Blink and WebKit.

Testing: Adding new test