### PR TITLE
script: Use snakecase for variables in CSS implementation files

### DIFF
--- a/components/script/dom/css/cssconditionrule.rs
+++ b/components/script/dom/css/cssconditionrule.rs
@@ -19,7 +19,7 @@ use crate::dom::bindings::str::DOMString;
 
 #[dom_struct]
 pub(crate) struct CSSConditionRule {
-    cssgroupingrule: CSSGroupingRule,
+    css_grouping_rule: CSSGroupingRule,
     #[ignore_malloc_size_of = "Stylo"]
     #[no_trace]
     rules: RefCell<Arc<Locked<StyleCssRules>>>,
@@ -31,17 +31,17 @@ impl CSSConditionRule {
         rules: Arc<Locked<StyleCssRules>>,
     ) -> CSSConditionRule {
         CSSConditionRule {
-            cssgroupingrule: CSSGroupingRule::new_inherited(parent_stylesheet),
+            css_grouping_rule: CSSGroupingRule::new_inherited(parent_stylesheet),
             rules: RefCell::new(rules),
         }
     }
 
     pub(crate) fn parent_stylesheet(&self) -> &CSSStyleSheet {
-        self.cssgroupingrule.parent_stylesheet()
+        self.css_grouping_rule.parent_stylesheet()
     }
 
     pub(crate) fn shared_lock(&self) -> &SharedRwLock {
-        self.cssgroupingrule.shared_lock()
+        self.css_grouping_rule.shared_lock()
     }
 
     pub(crate) fn clone_rules(&self) -> Arc<Locked<StyleCssRules>> {
@@ -53,7 +53,7 @@ impl CSSConditionRule {
         rules: Arc<Locked<StyleCssRules>>,
         guard: &SharedRwLockReadGuard,
     ) {
-        self.cssgroupingrule.update_rules(&rules, guard);
+        self.css_grouping_rule.update_rules(&rules, guard);
         *self.rules.borrow_mut() = rules;
     }
 }

--- a/components/script/dom/css/cssfontfacerule.rs
+++ b/components/script/dom/css/cssfontfacerule.rs
@@ -19,10 +19,10 @@ use crate::script_runtime::CanGc;
 
 #[dom_struct]
 pub(crate) struct CSSFontFaceRule {
-    cssrule: CSSRule,
+    css_rule: CSSRule,
     #[ignore_malloc_size_of = "Stylo"]
     #[no_trace]
-    fontfacerule: RefCell<Arc<Locked<FontFaceRule>>>,
+    font_face_rule: RefCell<Arc<Locked<FontFaceRule>>>,
 }
 
 impl CSSFontFaceRule {
@@ -31,8 +31,8 @@ impl CSSFontFaceRule {
         fontfacerule: Arc<Locked<FontFaceRule>>,
     ) -> CSSFontFaceRule {
         CSSFontFaceRule {
-            cssrule: CSSRule::new_inherited(parent_stylesheet),
-            fontfacerule: RefCell::new(fontfacerule),
+            css_rule: CSSRule::new_inherited(parent_stylesheet),
+            font_face_rule: RefCell::new(fontfacerule),
         }
     }
 
@@ -53,7 +53,7 @@ impl CSSFontFaceRule {
     }
 
     pub(crate) fn update_rule(&self, fontfacerule: Arc<Locked<FontFaceRule>>) {
-        *self.fontfacerule.borrow_mut() = fontfacerule;
+        *self.font_face_rule.borrow_mut() = fontfacerule;
     }
 }
 
@@ -63,8 +63,8 @@ impl SpecificCSSRule for CSSFontFaceRule {
     }
 
     fn get_css(&self) -> DOMString {
-        let guard = self.cssrule.shared_lock().read();
-        self.fontfacerule
+        let guard = self.css_rule.shared_lock().read();
+        self.font_face_rule
             .borrow()
             .read_with(&guard)
             .to_css_string(&guard)

--- a/components/script/dom/css/cssgroupingrule.rs
+++ b/components/script/dom/css/cssgroupingrule.rs
@@ -23,21 +23,21 @@ use crate::script_runtime::CanGc;
 
 #[dom_struct]
 pub(crate) struct CSSGroupingRule {
-    cssrule: CSSRule,
-    rulelist: MutNullableDom<CSSRuleList>,
+    css_rule: CSSRule,
+    rule_list: MutNullableDom<CSSRuleList>,
 }
 
 impl CSSGroupingRule {
     pub(crate) fn new_inherited(parent_stylesheet: &CSSStyleSheet) -> CSSGroupingRule {
         CSSGroupingRule {
-            cssrule: CSSRule::new_inherited(parent_stylesheet),
-            rulelist: MutNullableDom::new(None),
+            css_rule: CSSRule::new_inherited(parent_stylesheet),
+            rule_list: MutNullableDom::new(None),
         }
     }
 
     fn rulelist(&self, can_gc: CanGc) -> DomRoot<CSSRuleList> {
         let parent_stylesheet = self.upcast::<CSSRule>().parent_stylesheet();
-        self.rulelist.or_init(|| {
+        self.rule_list.or_init(|| {
             let rules = if let Some(rule) = self.downcast::<CSSConditionRule>() {
                 rule.clone_rules()
             } else if let Some(rule) = self.downcast::<CSSLayerBlockRule>() {
@@ -57,11 +57,11 @@ impl CSSGroupingRule {
     }
 
     pub(crate) fn parent_stylesheet(&self) -> &CSSStyleSheet {
-        self.cssrule.parent_stylesheet()
+        self.css_rule.parent_stylesheet()
     }
 
     pub(crate) fn shared_lock(&self) -> &SharedRwLock {
-        self.cssrule.shared_lock()
+        self.css_rule.shared_lock()
     }
 
     pub(crate) fn update_rules(
@@ -69,7 +69,7 @@ impl CSSGroupingRule {
         rules: &Arc<Locked<CssRules>>,
         guard: &SharedRwLockReadGuard,
     ) {
-        if let Some(rulelist) = self.rulelist.get() {
+        if let Some(rulelist) = self.rule_list.get() {
             rulelist.update_rules(RulesSource::Rules(rules.clone()), guard);
         }
     }
@@ -85,7 +85,7 @@ impl CSSGroupingRuleMethods<crate::DomTypeHolder> for CSSGroupingRule {
     /// <https://drafts.csswg.org/cssom/#dom-cssgroupingrule-insertrule>
     fn InsertRule(&self, rule: DOMString, index: u32, can_gc: CanGc) -> Fallible<u32> {
         // TODO: this should accumulate the rule types of all ancestors.
-        let rule_type = self.cssrule.as_specific().ty();
+        let rule_type = self.css_rule.as_specific().ty();
         let containing_rule_types = CssRuleTypes::from(rule_type);
         let parse_relative_rule_type = match rule_type {
             CssRuleType::Style | CssRuleType::Scope => Some(rule_type),

--- a/components/script/dom/css/cssimportrule.rs
+++ b/components/script/dom/css/cssimportrule.rs
@@ -22,7 +22,7 @@ use crate::script_runtime::CanGc;
 
 #[dom_struct]
 pub(crate) struct CSSImportRule {
-    cssrule: CSSRule,
+    css_rule: CSSRule,
     #[ignore_malloc_size_of = "Stylo"]
     #[no_trace]
     import_rule: RefCell<Arc<Locked<ImportRule>>>,
@@ -34,7 +34,7 @@ impl CSSImportRule {
         import_rule: Arc<Locked<ImportRule>>,
     ) -> Self {
         CSSImportRule {
-            cssrule: CSSRule::new_inherited(parent_stylesheet),
+            css_rule: CSSRule::new_inherited(parent_stylesheet),
             import_rule: RefCell::new(import_rule),
         }
     }
@@ -63,7 +63,7 @@ impl SpecificCSSRule for CSSImportRule {
     }
 
     fn get_css(&self) -> DOMString {
-        let guard = self.cssrule.shared_lock().read();
+        let guard = self.css_rule.shared_lock().read();
         self.import_rule
             .borrow()
             .read_with(&guard)
@@ -75,7 +75,7 @@ impl SpecificCSSRule for CSSImportRule {
 impl CSSImportRuleMethods<crate::DomTypeHolder> for CSSImportRule {
     /// <https://drafts.csswg.org/cssom-1/#dom-cssimportrule-layername>
     fn GetLayerName(&self) -> Option<DOMString> {
-        let guard = self.cssrule.shared_lock().read();
+        let guard = self.css_rule.shared_lock().read();
         match &self.import_rule.borrow().read_with(&guard).layer {
             ImportLayer::None => None,
             ImportLayer::Anonymous => Some(DOMString::new()),

--- a/components/script/dom/css/csskeyframesrule.rs
+++ b/components/script/dom/css/csskeyframesrule.rs
@@ -27,11 +27,11 @@ use crate::script_runtime::CanGc;
 
 #[dom_struct]
 pub(crate) struct CSSKeyframesRule {
-    cssrule: CSSRule,
+    css_rule: CSSRule,
     #[ignore_malloc_size_of = "Stylo"]
     #[no_trace]
-    keyframesrule: RefCell<Arc<Locked<KeyframesRule>>>,
-    rulelist: MutNullableDom<CSSRuleList>,
+    keyframes_rule: RefCell<Arc<Locked<KeyframesRule>>>,
+    rule_list: MutNullableDom<CSSRuleList>,
 }
 
 impl CSSKeyframesRule {
@@ -40,9 +40,9 @@ impl CSSKeyframesRule {
         keyframesrule: Arc<Locked<KeyframesRule>>,
     ) -> CSSKeyframesRule {
         CSSKeyframesRule {
-            cssrule: CSSRule::new_inherited(parent_stylesheet),
-            keyframesrule: RefCell::new(keyframesrule),
-            rulelist: MutNullableDom::new(None),
+            css_rule: CSSRule::new_inherited(parent_stylesheet),
+            keyframes_rule: RefCell::new(keyframesrule),
+            rule_list: MutNullableDom::new(None),
         }
     }
 
@@ -63,12 +63,12 @@ impl CSSKeyframesRule {
     }
 
     fn rulelist(&self, can_gc: CanGc) -> DomRoot<CSSRuleList> {
-        self.rulelist.or_init(|| {
+        self.rule_list.or_init(|| {
             let parent_stylesheet = &self.upcast::<CSSRule>().parent_stylesheet();
             CSSRuleList::new(
                 self.global().as_window(),
                 parent_stylesheet,
-                RulesSource::Keyframes(self.keyframesrule.borrow().clone()),
+                RulesSource::Keyframes(self.keyframes_rule.borrow().clone()),
                 can_gc,
             )
         })
@@ -80,10 +80,10 @@ impl CSSKeyframesRule {
         let mut input = ParserInput::new(&selector);
         let mut input = Parser::new(&mut input);
         if let Ok(sel) = KeyframeSelector::parse(&mut input) {
-            let guard = self.cssrule.shared_lock().read();
+            let guard = self.css_rule.shared_lock().read();
             // This finds the *last* element matching a selector
             // because that's the rule that applies. Thus, rposition
-            self.keyframesrule
+            self.keyframes_rule
                 .borrow()
                 .read_with(&guard)
                 .keyframes
@@ -99,11 +99,11 @@ impl CSSKeyframesRule {
         keyframesrule: Arc<Locked<KeyframesRule>>,
         guard: &SharedRwLockReadGuard,
     ) {
-        if let Some(rulelist) = self.rulelist.get() {
+        if let Some(rulelist) = self.rule_list.get() {
             rulelist.update_rules(RulesSource::Keyframes(keyframesrule.clone()), guard);
         }
 
-        *self.keyframesrule.borrow_mut() = keyframesrule;
+        *self.keyframes_rule.borrow_mut() = keyframesrule;
     }
 }
 
@@ -115,7 +115,7 @@ impl CSSKeyframesRuleMethods<crate::DomTypeHolder> for CSSKeyframesRule {
 
     /// <https://drafts.csswg.org/css-animations/#dom-csskeyframesrule-appendrule>
     fn AppendRule(&self, rule: DOMString, can_gc: CanGc) {
-        let style_stylesheet = self.cssrule.parent_stylesheet().style_stylesheet();
+        let style_stylesheet = self.css_rule.parent_stylesheet().style_stylesheet();
         let rule = rule.str();
         let rule = {
             let guard = style_stylesheet.shared_lock.read();
@@ -127,15 +127,15 @@ impl CSSKeyframesRuleMethods<crate::DomTypeHolder> for CSSKeyframesRule {
         };
 
         if let Ok(rule) = rule {
-            self.cssrule.parent_stylesheet().will_modify();
-            let mut guard = self.cssrule.shared_lock().write();
-            self.keyframesrule
+            self.css_rule.parent_stylesheet().will_modify();
+            let mut guard = self.css_rule.shared_lock().write();
+            self.keyframes_rule
                 .borrow()
                 .write_with(&mut guard)
                 .keyframes
                 .push(rule);
             self.rulelist(can_gc).append_lazy_dom_rule();
-            self.cssrule.parent_stylesheet().notify_invalidations();
+            self.css_rule.parent_stylesheet().notify_invalidations();
         }
     }
 
@@ -155,8 +155,8 @@ impl CSSKeyframesRuleMethods<crate::DomTypeHolder> for CSSKeyframesRule {
 
     /// <https://drafts.csswg.org/css-animations/#dom-csskeyframesrule-name>
     fn Name(&self) -> DOMString {
-        let guard = self.cssrule.shared_lock().read();
-        DOMString::from(&**self.keyframesrule.borrow().read_with(&guard).name.as_atom())
+        let guard = self.css_rule.shared_lock().read();
+        DOMString::from(&**self.keyframes_rule.borrow().read_with(&guard).name.as_atom())
     }
 
     /// <https://drafts.csswg.org/css-animations/#dom-csskeyframesrule-name>
@@ -164,11 +164,11 @@ impl CSSKeyframesRuleMethods<crate::DomTypeHolder> for CSSKeyframesRule {
         // Spec deviation: https://github.com/w3c/csswg-drafts/issues/801
         // Setting this property to a CSS-wide keyword or `none` does not throw,
         // it stores a value that serializes as a quoted string.
-        self.cssrule.parent_stylesheet().will_modify();
+        self.css_rule.parent_stylesheet().will_modify();
         let name = KeyframesName::from_ident(&value.str());
-        let mut guard = self.cssrule.shared_lock().write();
-        self.keyframesrule.borrow().write_with(&mut guard).name = name;
-        self.cssrule.parent_stylesheet().notify_invalidations();
+        let mut guard = self.css_rule.shared_lock().write();
+        self.keyframes_rule.borrow().write_with(&mut guard).name = name;
+        self.css_rule.parent_stylesheet().notify_invalidations();
         Ok(())
     }
 }
@@ -179,8 +179,8 @@ impl SpecificCSSRule for CSSKeyframesRule {
     }
 
     fn get_css(&self) -> DOMString {
-        let guard = self.cssrule.shared_lock().read();
-        self.keyframesrule
+        let guard = self.css_rule.shared_lock().read();
+        self.keyframes_rule
             .borrow()
             .read_with(&guard)
             .to_css_string(&guard)
@@ -188,7 +188,7 @@ impl SpecificCSSRule for CSSKeyframesRule {
     }
 
     fn deparent_children(&self) {
-        if let Some(list) = self.rulelist.get() {
+        if let Some(list) = self.rule_list.get() {
             list.deparent_all()
         }
     }

--- a/components/script/dom/css/csskeyframesrule.rs
+++ b/components/script/dom/css/csskeyframesrule.rs
@@ -156,7 +156,14 @@ impl CSSKeyframesRuleMethods<crate::DomTypeHolder> for CSSKeyframesRule {
     /// <https://drafts.csswg.org/css-animations/#dom-csskeyframesrule-name>
     fn Name(&self) -> DOMString {
         let guard = self.css_rule.shared_lock().read();
-        DOMString::from(&**self.keyframes_rule.borrow().read_with(&guard).name.as_atom())
+        DOMString::from(
+            &**self
+                .keyframes_rule
+                .borrow()
+                .read_with(&guard)
+                .name
+                .as_atom(),
+        )
     }
 
     /// <https://drafts.csswg.org/css-animations/#dom-csskeyframesrule-name>

--- a/components/script/dom/css/csslayerblockrule.rs
+++ b/components/script/dom/css/csslayerblockrule.rs
@@ -22,10 +22,10 @@ use crate::script_runtime::CanGc;
 
 #[dom_struct]
 pub(crate) struct CSSLayerBlockRule {
-    cssgroupingrule: CSSGroupingRule,
+    css_grouping_rule: CSSGroupingRule,
     #[ignore_malloc_size_of = "Stylo"]
     #[no_trace]
-    layerblockrule: RefCell<Arc<LayerBlockRule>>,
+    layer_block_rule: RefCell<Arc<LayerBlockRule>>,
 }
 
 impl CSSLayerBlockRule {
@@ -34,8 +34,8 @@ impl CSSLayerBlockRule {
         layerblockrule: Arc<LayerBlockRule>,
     ) -> CSSLayerBlockRule {
         CSSLayerBlockRule {
-            cssgroupingrule: CSSGroupingRule::new_inherited(parent_stylesheet),
-            layerblockrule: RefCell::new(layerblockrule),
+            css_grouping_rule: CSSGroupingRule::new_inherited(parent_stylesheet),
+            layer_block_rule: RefCell::new(layerblockrule),
         }
     }
 
@@ -56,7 +56,7 @@ impl CSSLayerBlockRule {
     }
 
     pub(crate) fn clone_rules(&self) -> Arc<Locked<CssRules>> {
-        self.layerblockrule.borrow().rules.clone()
+        self.layer_block_rule.borrow().rules.clone()
     }
 
     pub(crate) fn update_rule(
@@ -64,9 +64,9 @@ impl CSSLayerBlockRule {
         layerblockrule: Arc<LayerBlockRule>,
         guard: &SharedRwLockReadGuard,
     ) {
-        self.cssgroupingrule
+        self.css_grouping_rule
             .update_rules(&layerblockrule.rules, guard);
-        *self.layerblockrule.borrow_mut() = layerblockrule;
+        *self.layer_block_rule.borrow_mut() = layerblockrule;
     }
 }
 
@@ -76,15 +76,15 @@ impl SpecificCSSRule for CSSLayerBlockRule {
     }
 
     fn get_css(&self) -> DOMString {
-        let guard = self.cssgroupingrule.shared_lock().read();
-        self.layerblockrule.borrow().to_css_string(&guard).into()
+        let guard = self.css_grouping_rule.shared_lock().read();
+        self.layer_block_rule.borrow().to_css_string(&guard).into()
     }
 }
 
 impl CSSLayerBlockRuleMethods<crate::DomTypeHolder> for CSSLayerBlockRule {
     /// <https://drafts.csswg.org/css-cascade-5/#dom-csslayerblockrule-name>
     fn Name(&self) -> DOMString {
-        if let Some(name) = &self.layerblockrule.borrow().name {
+        if let Some(name) = &self.layer_block_rule.borrow().name {
             DOMString::from_string(name.to_css_string())
         } else {
             DOMString::new()

--- a/components/script/dom/css/csslayerstatementrule.rs
+++ b/components/script/dom/css/csslayerstatementrule.rs
@@ -23,10 +23,10 @@ use crate::script_runtime::{CanGc, JSContext as SafeJSContext};
 
 #[dom_struct]
 pub(crate) struct CSSLayerStatementRule {
-    cssrule: CSSRule,
+    css_rule: CSSRule,
     #[ignore_malloc_size_of = "Stylo"]
     #[no_trace]
-    layerstatementrule: RefCell<Arc<LayerStatementRule>>,
+    layer_statement_rule: RefCell<Arc<LayerStatementRule>>,
 }
 
 impl CSSLayerStatementRule {
@@ -35,8 +35,8 @@ impl CSSLayerStatementRule {
         layerstatementrule: Arc<LayerStatementRule>,
     ) -> CSSLayerStatementRule {
         CSSLayerStatementRule {
-            cssrule: CSSRule::new_inherited(parent_stylesheet),
-            layerstatementrule: RefCell::new(layerstatementrule),
+            css_rule: CSSRule::new_inherited(parent_stylesheet),
+            layer_statement_rule: RefCell::new(layerstatementrule),
         }
     }
 
@@ -57,7 +57,7 @@ impl CSSLayerStatementRule {
     }
 
     pub(crate) fn update_rule(&self, layerstatementrule: Arc<LayerStatementRule>) {
-        *self.layerstatementrule.borrow_mut() = layerstatementrule;
+        *self.layer_statement_rule.borrow_mut() = layerstatementrule;
     }
 }
 
@@ -67,8 +67,8 @@ impl SpecificCSSRule for CSSLayerStatementRule {
     }
 
     fn get_css(&self) -> DOMString {
-        let guard = self.cssrule.shared_lock().read();
-        self.layerstatementrule
+        let guard = self.css_rule.shared_lock().read();
+        self.layer_statement_rule
             .borrow()
             .to_css_string(&guard)
             .into()
@@ -79,7 +79,7 @@ impl CSSLayerStatementRuleMethods<crate::DomTypeHolder> for CSSLayerStatementRul
     /// <https://drafts.csswg.org/css-cascade-5/#dom-csslayerstatementrule-namelist>
     fn NameList(&self, cx: SafeJSContext, can_gc: CanGc, retval: MutableHandleValue) {
         let names: Vec<DOMString> = self
-            .layerstatementrule
+            .layer_statement_rule
             .borrow()
             .names
             .iter()

--- a/components/script/dom/css/cssmediarule.rs
+++ b/components/script/dom/css/cssmediarule.rs
@@ -23,7 +23,7 @@ use crate::script_runtime::CanGc;
 
 #[dom_struct]
 pub(crate) struct CSSMediaRule {
-    cssconditionrule: CSSConditionRule,
+    css_condition_rule: CSSConditionRule,
     #[ignore_malloc_size_of = "Stylo"]
     #[no_trace]
     mediarule: RefCell<Arc<MediaRule>>,
@@ -34,7 +34,7 @@ impl CSSMediaRule {
     fn new_inherited(parent_stylesheet: &CSSStyleSheet, mediarule: Arc<MediaRule>) -> CSSMediaRule {
         let list = mediarule.rules.clone();
         CSSMediaRule {
-            cssconditionrule: CSSConditionRule::new_inherited(parent_stylesheet, list),
+            css_condition_rule: CSSConditionRule::new_inherited(parent_stylesheet, list),
             mediarule: RefCell::new(mediarule),
             medialist: MutNullableDom::new(None),
         }
@@ -57,7 +57,7 @@ impl CSSMediaRule {
         self.medialist.or_init(|| {
             MediaList::new(
                 self.global().as_window(),
-                self.cssconditionrule.parent_stylesheet(),
+                self.css_condition_rule.parent_stylesheet(),
                 self.mediarule.borrow().media_queries.clone(),
                 can_gc,
             )
@@ -66,7 +66,7 @@ impl CSSMediaRule {
 
     /// <https://drafts.csswg.org/css-conditional-3/#the-cssmediarule-interface>
     pub(crate) fn get_condition_text(&self) -> DOMString {
-        let guard = self.cssconditionrule.shared_lock().read();
+        let guard = self.css_condition_rule.shared_lock().read();
         self.mediarule
             .borrow()
             .media_queries
@@ -76,7 +76,7 @@ impl CSSMediaRule {
     }
 
     pub(crate) fn update_rule(&self, mediarule: Arc<MediaRule>, guard: &SharedRwLockReadGuard) {
-        self.cssconditionrule
+        self.css_condition_rule
             .update_rules(mediarule.rules.clone(), guard);
         if let Some(medialist) = self.medialist.get() {
             medialist.update_media_list(mediarule.media_queries.clone());
@@ -91,7 +91,7 @@ impl SpecificCSSRule for CSSMediaRule {
     }
 
     fn get_css(&self) -> DOMString {
-        let guard = self.cssconditionrule.shared_lock().read();
+        let guard = self.css_condition_rule.shared_lock().read();
         self.mediarule.borrow().to_css_string(&guard).into()
     }
 }

--- a/components/script/dom/css/cssmediarule.rs
+++ b/components/script/dom/css/cssmediarule.rs
@@ -26,8 +26,8 @@ pub(crate) struct CSSMediaRule {
     css_condition_rule: CSSConditionRule,
     #[ignore_malloc_size_of = "Stylo"]
     #[no_trace]
-    mediarule: RefCell<Arc<MediaRule>>,
-    medialist: MutNullableDom<MediaList>,
+    media_rule: RefCell<Arc<MediaRule>>,
+    media_list: MutNullableDom<MediaList>,
 }
 
 impl CSSMediaRule {
@@ -35,8 +35,8 @@ impl CSSMediaRule {
         let list = mediarule.rules.clone();
         CSSMediaRule {
             css_condition_rule: CSSConditionRule::new_inherited(parent_stylesheet, list),
-            mediarule: RefCell::new(mediarule),
-            medialist: MutNullableDom::new(None),
+            media_rule: RefCell::new(mediarule),
+            media_list: MutNullableDom::new(None),
         }
     }
 
@@ -54,11 +54,11 @@ impl CSSMediaRule {
     }
 
     fn medialist(&self, can_gc: CanGc) -> DomRoot<MediaList> {
-        self.medialist.or_init(|| {
+        self.media_list.or_init(|| {
             MediaList::new(
                 self.global().as_window(),
                 self.css_condition_rule.parent_stylesheet(),
-                self.mediarule.borrow().media_queries.clone(),
+                self.media_rule.borrow().media_queries.clone(),
                 can_gc,
             )
         })
@@ -67,7 +67,7 @@ impl CSSMediaRule {
     /// <https://drafts.csswg.org/css-conditional-3/#the-cssmediarule-interface>
     pub(crate) fn get_condition_text(&self) -> DOMString {
         let guard = self.css_condition_rule.shared_lock().read();
-        self.mediarule
+        self.media_rule
             .borrow()
             .media_queries
             .read_with(&guard)
@@ -78,10 +78,10 @@ impl CSSMediaRule {
     pub(crate) fn update_rule(&self, mediarule: Arc<MediaRule>, guard: &SharedRwLockReadGuard) {
         self.css_condition_rule
             .update_rules(mediarule.rules.clone(), guard);
-        if let Some(medialist) = self.medialist.get() {
+        if let Some(medialist) = self.media_list.get() {
             medialist.update_media_list(mediarule.media_queries.clone());
         }
-        *self.mediarule.borrow_mut() = mediarule;
+        *self.media_rule.borrow_mut() = mediarule;
     }
 }
 
@@ -92,7 +92,7 @@ impl SpecificCSSRule for CSSMediaRule {
 
     fn get_css(&self) -> DOMString {
         let guard = self.css_condition_rule.shared_lock().read();
-        self.mediarule.borrow().to_css_string(&guard).into()
+        self.media_rule.borrow().to_css_string(&guard).into()
     }
 }
 

--- a/components/script/dom/css/cssnamespacerule.rs
+++ b/components/script/dom/css/cssnamespacerule.rs
@@ -23,7 +23,7 @@ pub(crate) struct CSSNamespaceRule {
     css_rule: CSSRule,
     #[ignore_malloc_size_of = "Stylo"]
     #[no_trace]
-    namespacerule: RefCell<Arc<NamespaceRule>>,
+    namespace_rule: RefCell<Arc<NamespaceRule>>,
 }
 
 impl CSSNamespaceRule {
@@ -33,7 +33,7 @@ impl CSSNamespaceRule {
     ) -> CSSNamespaceRule {
         CSSNamespaceRule {
             css_rule: CSSRule::new_inherited(parent_stylesheet),
-            namespacerule: RefCell::new(namespacerule),
+            namespace_rule: RefCell::new(namespacerule),
         }
     }
 
@@ -54,14 +54,14 @@ impl CSSNamespaceRule {
     }
 
     pub(crate) fn update_rule(&self, namespacerule: Arc<NamespaceRule>) {
-        *self.namespacerule.borrow_mut() = namespacerule;
+        *self.namespace_rule.borrow_mut() = namespacerule;
     }
 }
 
 impl CSSNamespaceRuleMethods<crate::DomTypeHolder> for CSSNamespaceRule {
     /// <https://drafts.csswg.org/cssom/#dom-cssnamespacerule-prefix>
     fn Prefix(&self) -> DOMString {
-        self.namespacerule
+        self.namespace_rule
             .borrow()
             .prefix
             .as_ref()
@@ -71,7 +71,7 @@ impl CSSNamespaceRuleMethods<crate::DomTypeHolder> for CSSNamespaceRule {
 
     /// <https://drafts.csswg.org/cssom/#dom-cssnamespacerule-namespaceuri>
     fn NamespaceURI(&self) -> DOMString {
-        (**self.namespacerule.borrow().url).into()
+        (**self.namespace_rule.borrow().url).into()
     }
 }
 
@@ -82,6 +82,6 @@ impl SpecificCSSRule for CSSNamespaceRule {
 
     fn get_css(&self) -> DOMString {
         let guard = self.css_rule.shared_lock().read();
-        self.namespacerule.borrow().to_css_string(&guard).into()
+        self.namespace_rule.borrow().to_css_string(&guard).into()
     }
 }

--- a/components/script/dom/css/cssnamespacerule.rs
+++ b/components/script/dom/css/cssnamespacerule.rs
@@ -20,7 +20,7 @@ use crate::script_runtime::CanGc;
 
 #[dom_struct]
 pub(crate) struct CSSNamespaceRule {
-    cssrule: CSSRule,
+    css_rule: CSSRule,
     #[ignore_malloc_size_of = "Stylo"]
     #[no_trace]
     namespacerule: RefCell<Arc<NamespaceRule>>,
@@ -32,7 +32,7 @@ impl CSSNamespaceRule {
         namespacerule: Arc<NamespaceRule>,
     ) -> CSSNamespaceRule {
         CSSNamespaceRule {
-            cssrule: CSSRule::new_inherited(parent_stylesheet),
+            css_rule: CSSRule::new_inherited(parent_stylesheet),
             namespacerule: RefCell::new(namespacerule),
         }
     }
@@ -81,7 +81,7 @@ impl SpecificCSSRule for CSSNamespaceRule {
     }
 
     fn get_css(&self) -> DOMString {
-        let guard = self.cssrule.shared_lock().read();
+        let guard = self.css_rule.shared_lock().read();
         self.namespacerule.borrow().to_css_string(&guard).into()
     }
 }

--- a/components/script/dom/css/cssnesteddeclarations.rs
+++ b/components/script/dom/css/cssnesteddeclarations.rs
@@ -22,7 +22,7 @@ use crate::script_runtime::CanGc;
 
 #[dom_struct]
 pub(crate) struct CSSNestedDeclarations {
-    cssrule: CSSRule,
+    css_rule: CSSRule,
     #[ignore_malloc_size_of = "Stylo"]
     #[no_trace]
     nesteddeclarationsrule: RefCell<Arc<Locked<NestedDeclarationsRule>>>,
@@ -35,7 +35,7 @@ impl CSSNestedDeclarations {
         nesteddeclarationsrule: Arc<Locked<NestedDeclarationsRule>>,
     ) -> Self {
         Self {
-            cssrule: CSSRule::new_inherited(parent_stylesheet),
+            css_rule: CSSRule::new_inherited(parent_stylesheet),
             nesteddeclarationsrule: RefCell::new(nesteddeclarationsrule),
             style_declaration: Default::default(),
         }
@@ -76,7 +76,7 @@ impl SpecificCSSRule for CSSNestedDeclarations {
     }
 
     fn get_css(&self) -> DOMString {
-        let guard = self.cssrule.shared_lock().read();
+        let guard = self.css_rule.shared_lock().read();
         self.nesteddeclarationsrule
             .borrow()
             .read_with(&guard)
@@ -89,7 +89,7 @@ impl CSSNestedDeclarationsMethods<crate::DomTypeHolder> for CSSNestedDeclaration
     /// <https://drafts.csswg.org/css-nesting/#dom-cssnesteddeclarations-style>
     fn Style(&self, can_gc: CanGc) -> DomRoot<CSSStyleDeclaration> {
         self.style_declaration.or_init(|| {
-            let guard = self.cssrule.shared_lock().read();
+            let guard = self.css_rule.shared_lock().read();
             CSSStyleDeclaration::new(
                 self.global().as_window(),
                 CSSStyleOwner::CSSRule(

--- a/components/script/dom/css/cssnesteddeclarations.rs
+++ b/components/script/dom/css/cssnesteddeclarations.rs
@@ -26,7 +26,7 @@ pub(crate) struct CSSNestedDeclarations {
     #[ignore_malloc_size_of = "Stylo"]
     #[no_trace]
     nesteddeclarationsrule: RefCell<Arc<Locked<NestedDeclarationsRule>>>,
-    style_decl: MutNullableDom<CSSStyleDeclaration>,
+    style_declaration: MutNullableDom<CSSStyleDeclaration>,
 }
 
 impl CSSNestedDeclarations {
@@ -37,7 +37,7 @@ impl CSSNestedDeclarations {
         Self {
             cssrule: CSSRule::new_inherited(parent_stylesheet),
             nesteddeclarationsrule: RefCell::new(nesteddeclarationsrule),
-            style_decl: Default::default(),
+            style_declaration: Default::default(),
         }
     }
 
@@ -62,7 +62,7 @@ impl CSSNestedDeclarations {
         nesteddeclarationsrule: Arc<Locked<NestedDeclarationsRule>>,
         guard: &SharedRwLockReadGuard,
     ) {
-        if let Some(ref style_decl) = self.style_decl.get() {
+        if let Some(ref style_decl) = self.style_declaration.get() {
             style_decl
                 .update_property_declaration_block(&nesteddeclarationsrule.read_with(guard).block);
         }
@@ -88,7 +88,7 @@ impl SpecificCSSRule for CSSNestedDeclarations {
 impl CSSNestedDeclarationsMethods<crate::DomTypeHolder> for CSSNestedDeclarations {
     /// <https://drafts.csswg.org/css-nesting/#dom-cssnesteddeclarations-style>
     fn Style(&self, can_gc: CanGc) -> DomRoot<CSSStyleDeclaration> {
-        self.style_decl.or_init(|| {
+        self.style_declaration.or_init(|| {
             let guard = self.cssrule.shared_lock().read();
             CSSStyleDeclaration::new(
                 self.global().as_window(),

--- a/components/script/dom/css/csspropertyrule.rs
+++ b/components/script/dom/css/csspropertyrule.rs
@@ -21,7 +21,7 @@ use crate::script_runtime::CanGc;
 
 #[dom_struct]
 pub(crate) struct CSSPropertyRule {
-    cssrule: CSSRule,
+    css_rule: CSSRule,
     #[ignore_malloc_size_of = "Stylo"]
     #[no_trace]
     property_rule: RefCell<Arc<PropertyRule>>,
@@ -30,7 +30,7 @@ pub(crate) struct CSSPropertyRule {
 impl CSSPropertyRule {
     fn new_inherited(parent_stylesheet: &CSSStyleSheet, property_rule: Arc<PropertyRule>) -> Self {
         CSSPropertyRule {
-            cssrule: CSSRule::new_inherited(parent_stylesheet),
+            css_rule: CSSRule::new_inherited(parent_stylesheet),
             property_rule: RefCell::new(property_rule),
         }
     }
@@ -59,7 +59,7 @@ impl SpecificCSSRule for CSSPropertyRule {
     }
 
     fn get_css(&self) -> DOMString {
-        let guard = self.cssrule.shared_lock().read();
+        let guard = self.css_rule.shared_lock().read();
         self.property_rule.borrow().to_css_string(&guard).into()
     }
 }

--- a/components/script/dom/css/cssstylerule.rs
+++ b/components/script/dom/css/cssstylerule.rs
@@ -137,7 +137,10 @@ impl CSSStyleRuleMethods<crate::DomTypeHolder> for CSSStyleRule {
         let value = value.str();
         let Ok(mut selector) = ({
             let guard = self.css_grouping_rule.shared_lock().read();
-            let sheet = self.css_grouping_rule.parent_stylesheet().style_stylesheet();
+            let sheet = self
+                .css_grouping_rule
+                .parent_stylesheet()
+                .style_stylesheet();
             let contents = sheet.contents(&guard);
             // It's not clear from the spec if we should use the stylesheet's namespaces.
             // https://github.com/w3c/csswg-drafts/issues/1511

--- a/components/script/dom/css/cssstylerule.rs
+++ b/components/script/dom/css/cssstylerule.rs
@@ -27,11 +27,11 @@ use crate::script_runtime::CanGc;
 
 #[dom_struct]
 pub(crate) struct CSSStyleRule {
-    cssgroupingrule: CSSGroupingRule,
+    css_grouping_rule: CSSGroupingRule,
     #[ignore_malloc_size_of = "Stylo"]
     #[no_trace]
-    stylerule: RefCell<Arc<Locked<StyleRule>>>,
-    style_decl: MutNullableDom<CSSStyleDeclaration>,
+    style_rule: RefCell<Arc<Locked<StyleRule>>>,
+    style_declaration: MutNullableDom<CSSStyleDeclaration>,
 }
 
 impl CSSStyleRule {
@@ -40,9 +40,9 @@ impl CSSStyleRule {
         stylerule: Arc<Locked<StyleRule>>,
     ) -> CSSStyleRule {
         CSSStyleRule {
-            cssgroupingrule: CSSGroupingRule::new_inherited(parent_stylesheet),
-            stylerule: RefCell::new(stylerule),
-            style_decl: Default::default(),
+            css_grouping_rule: CSSGroupingRule::new_inherited(parent_stylesheet),
+            style_rule: RefCell::new(stylerule),
+            style_declaration: Default::default(),
         }
     }
 
@@ -60,9 +60,9 @@ impl CSSStyleRule {
     }
 
     pub(crate) fn ensure_rules(&self) -> Arc<Locked<CssRules>> {
-        let lock = self.cssgroupingrule.shared_lock();
+        let lock = self.css_grouping_rule.shared_lock();
         let mut guard = lock.write();
-        self.stylerule
+        self.style_rule
             .borrow()
             .write_with(&mut guard)
             .rules
@@ -76,14 +76,14 @@ impl CSSStyleRule {
         guard: &SharedRwLockReadGuard,
     ) {
         if let Some(ref rules) = stylerule.read_with(guard).rules {
-            self.cssgroupingrule.update_rules(rules, guard);
+            self.css_grouping_rule.update_rules(rules, guard);
         }
 
-        if let Some(ref style_decl) = self.style_decl.get() {
+        if let Some(ref style_decl) = self.style_declaration.get() {
             style_decl.update_property_declaration_block(&stylerule.read_with(guard).block);
         }
 
-        *self.stylerule.borrow_mut() = stylerule;
+        *self.style_rule.borrow_mut() = stylerule;
     }
 }
 
@@ -93,8 +93,8 @@ impl SpecificCSSRule for CSSStyleRule {
     }
 
     fn get_css(&self) -> DOMString {
-        let guard = self.cssgroupingrule.shared_lock().read();
-        self.stylerule
+        let guard = self.css_grouping_rule.shared_lock().read();
+        self.style_rule
             .borrow()
             .read_with(&guard)
             .to_css_string(&guard)
@@ -105,13 +105,13 @@ impl SpecificCSSRule for CSSStyleRule {
 impl CSSStyleRuleMethods<crate::DomTypeHolder> for CSSStyleRule {
     /// <https://drafts.csswg.org/cssom/#dom-cssstylerule-style>
     fn Style(&self, can_gc: CanGc) -> DomRoot<CSSStyleDeclaration> {
-        self.style_decl.or_init(|| {
-            let guard = self.cssgroupingrule.shared_lock().read();
+        self.style_declaration.or_init(|| {
+            let guard = self.css_grouping_rule.shared_lock().read();
             CSSStyleDeclaration::new(
                 self.global().as_window(),
                 CSSStyleOwner::CSSRule(
                     Dom::from_ref(self.upcast()),
-                    RefCell::new(self.stylerule.borrow().read_with(&guard).block.clone()),
+                    RefCell::new(self.style_rule.borrow().read_with(&guard).block.clone()),
                 ),
                 None,
                 CSSModificationAccess::ReadWrite,
@@ -122,9 +122,9 @@ impl CSSStyleRuleMethods<crate::DomTypeHolder> for CSSStyleRule {
 
     /// <https://drafts.csswg.org/cssom/#dom-cssstylerule-selectortext>
     fn SelectorText(&self) -> DOMString {
-        let guard = self.cssgroupingrule.shared_lock().read();
+        let guard = self.css_grouping_rule.shared_lock().read();
         DOMString::from_string(
-            self.stylerule
+            self.style_rule
                 .borrow()
                 .read_with(&guard)
                 .selectors
@@ -136,8 +136,8 @@ impl CSSStyleRuleMethods<crate::DomTypeHolder> for CSSStyleRule {
     fn SetSelectorText(&self, value: DOMString) {
         let value = value.str();
         let Ok(mut selector) = ({
-            let guard = self.cssgroupingrule.shared_lock().read();
-            let sheet = self.cssgroupingrule.parent_stylesheet().style_stylesheet();
+            let guard = self.css_grouping_rule.shared_lock().read();
+            let sheet = self.css_grouping_rule.parent_stylesheet().style_stylesheet();
             let contents = sheet.contents(&guard);
             // It's not clear from the spec if we should use the stylesheet's namespaces.
             // https://github.com/w3c/csswg-drafts/issues/1511
@@ -155,14 +155,14 @@ impl CSSStyleRuleMethods<crate::DomTypeHolder> for CSSStyleRule {
         }) else {
             return;
         };
-        self.cssgroupingrule.parent_stylesheet().will_modify();
+        self.css_grouping_rule.parent_stylesheet().will_modify();
         // This mirrors what we do in CSSStyleOwner::mutate_associated_block.
-        let mut guard = self.cssgroupingrule.shared_lock().write();
+        let mut guard = self.css_grouping_rule.shared_lock().write();
         mem::swap(
-            &mut self.stylerule.borrow().write_with(&mut guard).selectors,
+            &mut self.style_rule.borrow().write_with(&mut guard).selectors,
             &mut selector,
         );
-        self.cssgroupingrule
+        self.css_grouping_rule
             .parent_stylesheet()
             .notify_invalidations();
     }

--- a/components/script/dom/css/cssstylesheet.rs
+++ b/components/script/dom/css/cssstylesheet.rs
@@ -53,7 +53,7 @@ pub(crate) struct CSSStyleSheet {
     owner_node: MutNullableDom<Element>,
 
     /// <https://drafts.csswg.org/cssom/#ref-for-concept-css-style-sheet-css-rules>
-    rulelist: MutNullableDom<CSSRuleList>,
+    rule_list: MutNullableDom<CSSRuleList>,
 
     /// The inner Stylo's [Stylesheet].
     #[ignore_malloc_size_of = "Stylo"]
@@ -93,7 +93,7 @@ impl CSSStyleSheet {
         CSSStyleSheet {
             stylesheet: StyleSheet::new_inherited(type_, href, title),
             owner_node: MutNullableDom::new(owner),
-            rulelist: MutNullableDom::new(None),
+            rule_list: MutNullableDom::new(None),
             style_shared_lock: stylesheet.shared_lock.clone(),
             style_stylesheet: DomRefCell::new(stylesheet),
             origin_clean: Cell::new(true),
@@ -156,7 +156,7 @@ impl CSSStyleSheet {
     }
 
     fn rulelist(&self, can_gc: CanGc) -> DomRoot<CSSRuleList> {
-        self.rulelist.or_init(|| {
+        self.rule_list.or_init(|| {
             let sheet = self.style_stylesheet.borrow();
             let guard = sheet.shared_lock.read();
             let rules = sheet.contents(&guard).rules.clone();
@@ -260,7 +260,7 @@ impl CSSStyleSheet {
         // stored in the CSSOMs to ensure that modifications are made only
         // on the new copy.
         *self.style_stylesheet.borrow_mut() = style_stylesheet.clone();
-        if let Some(rulelist) = self.rulelist.get() {
+        if let Some(rulelist) = self.rule_list.get() {
             let rules = style_stylesheet.contents(guard).rules.clone();
             rulelist.update_rules(RulesSource::Rules(rules), guard);
         }
@@ -311,7 +311,7 @@ impl CSSStyleSheet {
         // Step 4. Set sheet’s CSS rules to rules.
         // We reset our rule list, which will be initialized properly
         // at the next getter access.
-        self.rulelist.set(None);
+        self.rule_list.set(None);
 
         // Notify invalidation to update the styles immediately.
         self.notify_invalidations();

--- a/components/script/dom/css/csssupportsrule.rs
+++ b/components/script/dom/css/csssupportsrule.rs
@@ -21,10 +21,10 @@ use crate::script_runtime::CanGc;
 
 #[dom_struct]
 pub(crate) struct CSSSupportsRule {
-    cssconditionrule: CSSConditionRule,
+    css_condition_rule: CSSConditionRule,
     #[ignore_malloc_size_of = "Stylo"]
     #[no_trace]
-    supportsrule: RefCell<Arc<SupportsRule>>,
+    supports_rule: RefCell<Arc<SupportsRule>>,
 }
 
 impl CSSSupportsRule {
@@ -34,8 +34,8 @@ impl CSSSupportsRule {
     ) -> CSSSupportsRule {
         let list = supportsrule.rules.clone();
         CSSSupportsRule {
-            cssconditionrule: CSSConditionRule::new_inherited(parent_stylesheet, list),
-            supportsrule: RefCell::new(supportsrule),
+            css_condition_rule: CSSConditionRule::new_inherited(parent_stylesheet, list),
+            supports_rule: RefCell::new(supportsrule),
         }
     }
 
@@ -57,7 +57,7 @@ impl CSSSupportsRule {
 
     /// <https://drafts.csswg.org/css-conditional-3/#the-csssupportsrule-interface>
     pub(crate) fn get_condition_text(&self) -> DOMString {
-        self.supportsrule.borrow().condition.to_css_string().into()
+        self.supports_rule.borrow().condition.to_css_string().into()
     }
 
     pub(crate) fn update_rule(
@@ -65,9 +65,9 @@ impl CSSSupportsRule {
         supportsrule: Arc<SupportsRule>,
         guard: &SharedRwLockReadGuard,
     ) {
-        self.cssconditionrule
+        self.css_condition_rule
             .update_rules(supportsrule.rules.clone(), guard);
-        *self.supportsrule.borrow_mut() = supportsrule;
+        *self.supports_rule.borrow_mut() = supportsrule;
     }
 }
 
@@ -77,7 +77,7 @@ impl SpecificCSSRule for CSSSupportsRule {
     }
 
     fn get_css(&self) -> DOMString {
-        let guard = self.cssconditionrule.shared_lock().read();
-        self.supportsrule.borrow().to_css_string(&guard).into()
+        let guard = self.css_condition_rule.shared_lock().read();
+        self.supports_rule.borrow().to_css_string(&guard).into()
     }
 }


### PR DESCRIPTION
Use snakecase to be consistent. Also these names are normally quite long already.

Testing: Just renaming.