### PR TITLE
Revert "script: Introduce end of loading phases"

### DIFF
--- a/components/script/dom/document.rs
+++ b/components/script/dom/document.rs
@@ -55,7 +55,7 @@ use profile_traits::time::TimerMetadataFrameType;
 use regex::bytes::Regex;
 use rustc_hash::{FxBuildHasher, FxHashMap};
 use script_bindings::interfaces::DocumentHelpers;
-use script_bindings::script_runtime::{JSContext, runtime_is_alive};
+use script_bindings::script_runtime::JSContext;
 use script_traits::{DocumentActivity, ProgressiveWebMetricType};
 use servo_arc::Arc;
 use servo_config::pref;
@@ -259,16 +259,6 @@ pub(crate) enum IsHTMLDocument {
     NonHTMLDocument,
 }
 
-#[derive(Clone, Copy, Default, MallocSizeOf, PartialEq)]
-pub(crate) enum TheEndLoadingPhase {
-    #[default]
-    Initial,
-    ProcessingDeferredScripts,
-    ProcessingAsSoonAsPossibleScripts,
-    WaitingForLoadEventBlockers,
-    Done,
-}
-
 #[derive(JSTraceable, MallocSizeOf)]
 #[cfg_attr(crown, crown::unrooted_must_root_lint::must_root)]
 struct FocusTransaction {
@@ -366,6 +356,8 @@ pub(crate) struct Document {
     stylesheets: DomRefCell<DocumentStylesheetSet<ServoStylesheetInDocument>>,
     stylesheet_list: MutNullableDom<StyleSheetList>,
     ready_state: Cell<DocumentReadyState>,
+    /// Whether the DOMContentLoaded event has already been dispatched.
+    domcontentloaded_dispatched: Cell<bool>,
     /// The state of this document's focus transaction.
     focus_transaction: DomRefCell<Option<FocusTransaction>>,
     /// The element that currently has the document focus context.
@@ -379,8 +371,6 @@ pub(crate) struct Document {
     has_focus: Cell<bool>,
     /// The script element that is currently executing.
     current_script: MutNullableDom<HTMLScriptElement>,
-    #[no_trace]
-    current_the_end_loading_phase: Cell<TheEndLoadingPhase>,
     /// <https://html.spec.whatwg.org/multipage/#pending-parsing-blocking-script>
     pending_parsing_blocking_script: DomRefCell<Option<PendingScript>>,
     /// Number of stylesheets that block executing the next parser-inserted script
@@ -2178,8 +2168,8 @@ impl Document {
         }
     }
 
-    /// Step 8 of <https://html.spec.whatwg.org/multipage/#the-end>
-    /// <https://html.spec.whatwg.org/multipage/#delay-the-load-event>
+    // https://html.spec.whatwg.org/multipage/#the-end
+    // https://html.spec.whatwg.org/multipage/#delay-the-load-event
     pub(crate) fn finish_load(&self, load: LoadType, can_gc: CanGc) {
         // This does not delay the load event anymore.
         debug!("Document got finish_load: {:?}", load);
@@ -2210,20 +2200,25 @@ impl Document {
             _ => {},
         }
 
-        // Note: if a LoadBlocker is dropped since the whole page is dropped, we shouldn't continue
-        // processing this load. Otherwise, any subsequent interaction with the document will panic.
-        if !runtime_is_alive() {
+        // Step 4 is in another castle, namely at the end of
+        // process_deferred_scripts.
+
+        // Step 5 can be found in asap_script_loaded and
+        // asap_in_order_script_loaded.
+
+        let loader = self.loader.borrow();
+
+        // Servo measures when the top-level content (not iframes) is loaded.
+        if self.top_level_dom_complete.get().is_none() && loader.is_only_blocked_by_iframes() {
+            update_with_current_instant(&self.top_level_dom_complete);
+        }
+
+        if loader.is_blocked() || loader.events_inhibited() {
+            // Step 6.
             return;
         }
 
-        // Step 8. Spin the event loop until there is nothing that delays the load event in the Document.
-        let document = Trusted::new(self);
-        self.owner_global()
-            .task_manager()
-            .dom_manipulation_task_source()
-            .queue(task!(check_load_blockers: move || {
-                document.root().wait_until_load_blockers_have_resolved();
-            }));
+        ScriptThread::mark_document_with_no_blocked_loads(self);
     }
 
     /// <https://html.spec.whatwg.org/multipage/#checking-if-unloading-is-canceled>
@@ -2404,8 +2399,30 @@ impl Document {
         }
     }
 
-    /// Step 9 of <https://html.spec.whatwg.org/multipage/#the-end>
-    fn queue_document_completion(&self) {
+    // https://html.spec.whatwg.org/multipage/#the-end
+    pub(crate) fn maybe_queue_document_completion(&self) {
+        // https://html.spec.whatwg.org/multipage/#delaying-load-events-mode
+        let is_in_delaying_load_events_mode = match self.window.undiscarded_window_proxy() {
+            Some(window_proxy) => window_proxy.is_delaying_load_events_mode(),
+            None => false,
+        };
+
+        // Note: if the document is not fully active, layout will have exited already,
+        // and this method will panic.
+        // The underlying problem might actually be that layout exits while it should be kept alive.
+        // See https://github.com/servo/servo/issues/22507
+        let not_ready_for_load = self.loader.borrow().is_blocked() ||
+            !self.is_fully_active() ||
+            is_in_delaying_load_events_mode ||
+            // In case we have already aborted this document and receive a
+            // a subsequent message to load the document
+            self.loader.borrow().events_inhibited();
+
+        if not_ready_for_load {
+            // Step 6.
+            return;
+        }
+
         self.loader.borrow_mut().inhibit_events();
 
         // The rest will ever run only once per document.
@@ -2513,11 +2530,6 @@ impl Document {
         self.completely_loaded.get()
     }
 
-    pub(crate) fn start_the_end_loading_phase(&self) {
-        self.current_the_end_loading_phase
-            .set(TheEndLoadingPhase::ProcessingDeferredScripts);
-    }
-
     // https://html.spec.whatwg.org/multipage/#pending-parsing-blocking-script
     pub(crate) fn set_pending_parsing_blocking_script(
         &self,
@@ -2591,7 +2603,6 @@ impl Document {
             scripts.swap_remove(idx);
         }
         element.execute(result, can_gc);
-        self.wait_until_asap_scripts_have_executed();
     }
 
     // https://html.spec.whatwg.org/multipage/#list-of-scripts-that-will-execute-in-order-as-soon-as-possible
@@ -2614,11 +2625,9 @@ impl Document {
         {
             element.execute(result, can_gc);
         }
-
-        self.wait_until_asap_scripts_have_executed();
     }
 
-    /// <https://html.spec.whatwg.org/multipage/#list-of-scripts-that-will-execute-when-the-document-has-finished-parsing>
+    // https://html.spec.whatwg.org/multipage/#list-of-scripts-that-will-execute-when-the-document-has-finished-parsing
     pub(crate) fn add_deferred_script(&self, script: &HTMLScriptElement) {
         self.deferred_scripts.push(script);
     }
@@ -2635,71 +2644,53 @@ impl Document {
         self.process_deferred_scripts(can_gc);
     }
 
-    /// Step 5 of <https://html.spec.whatwg.org/multipage/#the-end>
+    /// <https://html.spec.whatwg.org/multipage/#the-end> step 3.
     fn process_deferred_scripts(&self, can_gc: CanGc) {
-        if self.current_the_end_loading_phase.get() != TheEndLoadingPhase::ProcessingDeferredScripts
-        {
+        if self.ready_state.get() != DocumentReadyState::Interactive {
             return;
         }
-
-        // Step 5.1. Spin the event loop until the first script in the list of scripts that will execute when the
-        // document has finished parsing has its ready to be parser-executed set to true and the parser's Document
-        // has no style sheet that is blocking scripts.
+        // Part of substep 1.
         loop {
             if self.script_blocking_stylesheets_count.get() > 0 {
                 return;
             }
-            // Step 5.3. Remove the first script element from the list of scripts that will execute when the
-            // document has finished parsing (i.e. shift out the first entry in the list).
             if let Some((element, result)) = self.deferred_scripts.take_next_ready_to_be_executed()
             {
-                // Step 5.2. Execute the script element given by the first script in the list of scripts that will execute when the document has finished parsing.
                 element.execute(result, can_gc);
             } else {
                 break;
             }
         }
-        // Step 5. While the list of scripts that will execute when the document has finished parsing is not empty:
         if self.deferred_scripts.is_empty() {
-            self.current_the_end_loading_phase
-                .set(TheEndLoadingPhase::ProcessingAsSoonAsPossibleScripts);
-            self.dispatch_dom_content_loaded();
+            // https://html.spec.whatwg.org/multipage/#the-end step 4.
+            self.maybe_dispatch_dom_content_loaded();
         }
     }
 
-    /// Step 6 of <https://html.spec.whatwg.org/multipage/#the-end>
-    fn dispatch_dom_content_loaded(&self) {
+    // https://html.spec.whatwg.org/multipage/#the-end step 4.
+    pub(crate) fn maybe_dispatch_dom_content_loaded(&self) {
+        if self.domcontentloaded_dispatched.get() {
+            return;
+        }
+        self.domcontentloaded_dispatched.set(true);
         assert_ne!(
             self.ReadyState(),
             DocumentReadyState::Complete,
             "Complete before DOMContentLoaded?"
         );
 
-        // Step 6. Queue a global task on the DOM manipulation task source given the Document's
-        // relevant global object to run the following substeps:
+        update_with_current_instant(&self.dom_content_loaded_event_start);
+
+        // Step 4.1.
         let document = Trusted::new(self);
         self.owner_global()
             .task_manager()
             .dom_manipulation_task_source()
             .queue(
                 task!(fire_dom_content_loaded_event: move || {
-                    // Step 6.1. Set the Document's load timing info's DOM content loaded event start time to
-                    // the current high resolution time given the Document's relevant global object.
-                    let document = document.root();
-                    update_with_current_instant(&document.dom_content_loaded_event_start);
-                    // Step 6.2. Fire an event named DOMContentLoaded at the Document object, with its bubbles attribute initialized to true.
-                    document.upcast::<EventTarget>().fire_bubbling_event(atom!("DOMContentLoaded"), CanGc::note());
-                    // Step 6.3. Set the Document's load timing info's DOM content loaded event end time to
-                    // the current high resolution time given the Document's relevant global object.
-                    update_with_current_instant(&document.dom_content_loaded_event_end);
-                    // Step 6.4. Enable the client message queue of the ServiceWorkerContainer object
-                    // whose associated service worker client is the Document object's relevant settings object.
-                    // TODO
-
-                    // Step 6.5. Invoke WebDriver BiDi DOM content loaded with the Document's browsing context,
-                    // and a new WebDriver BiDi navigation status whose id is the Document object's during-loading
-                    // navigation ID for WebDriver BiDi, status is "pending", and url is the Document object's URL.
-                    // TODO
+                let document = document.root();
+                document.upcast::<EventTarget>().fire_bubbling_event(atom!("DOMContentLoaded"), CanGc::note());
+                update_with_current_instant(&document.dom_content_loaded_event_end);
                 })
             );
 
@@ -2708,72 +2699,8 @@ impl Document {
             .borrow()
             .maybe_set_tti(InteractiveFlag::DOMContentLoaded);
 
-        self.wait_until_asap_scripts_have_executed();
-    }
-
-    fn has_finished_all_asap_scripts(&self) -> bool {
-        self.asap_scripts_set.borrow().is_empty() && self.asap_in_order_scripts_list.is_empty()
-    }
-
-    /// Step 7 of <https://html.spec.whatwg.org/multipage/#the-end>
-    fn wait_until_asap_scripts_have_executed(&self) {
-        if self.current_the_end_loading_phase.get() !=
-            TheEndLoadingPhase::ProcessingAsSoonAsPossibleScripts
-        {
-            return;
-        }
-        // Step 7. Spin the event loop until the set of scripts that will execute as soon as possible
-        // and the list of scripts that will execute in order as soon as possible are empty.
-        if self.has_finished_all_asap_scripts() {
-            let document = Trusted::new(self);
-            self.owner_global()
-                .task_manager()
-                .dom_manipulation_task_source()
-                .queue(task!(progress_to_load_blocking_phase: move || {
-                    let document = document.root();
-                    // Ensure that if this task is fired multiple times, we only progress the
-                    // end of loading phase once.
-                    if document.current_the_end_loading_phase.get() !=
-                        TheEndLoadingPhase::ProcessingAsSoonAsPossibleScripts
-                    {
-                        return;
-                    }
-                    // Check again if we still fulfil the goal
-                    if !document.has_finished_all_asap_scripts() {
-                        return;
-                    }
-                    document.current_the_end_loading_phase
-                        .set(TheEndLoadingPhase::WaitingForLoadEventBlockers);
-                    document.wait_until_load_blockers_have_resolved();
-                }));
-        }
-    }
-
-    /// Step 8 of <https://html.spec.whatwg.org/multipage/#the-end>
-    pub(crate) fn wait_until_load_blockers_have_resolved(&self) {
-        if self.current_the_end_loading_phase.get() !=
-            TheEndLoadingPhase::WaitingForLoadEventBlockers
-        {
-            return;
-        }
-        // Step 8. Spin the event loop until there is nothing that delays the load event in the Document.
-        {
-            let loader = self.loader.borrow();
-
-            // Servo measures when the top-level content (not iframes) is loaded.
-            if self.top_level_dom_complete.get().is_none() && loader.is_only_blocked_by_iframes() {
-                update_with_current_instant(&self.top_level_dom_complete);
-            }
-
-            let not_ready_for_load = loader.is_blocked() || loader.events_inhibited();
-            if not_ready_for_load {
-                return;
-            }
-        }
-
-        self.current_the_end_loading_phase
-            .set(TheEndLoadingPhase::Done);
-        self.queue_document_completion();
+        // Step 4.2.
+        // TODO: client message queue.
     }
 
     /// <https://html.spec.whatwg.org/multipage/#destroy-a-document-and-its-descendants>
@@ -3805,10 +3732,10 @@ impl Document {
     ) -> Document {
         let url = url.unwrap_or_else(|| ServoUrl::parse("about:blank").unwrap());
 
-        let ready_state = if source == DocumentSource::FromParser {
-            DocumentReadyState::Loading
+        let (ready_state, domcontentloaded_dispatched) = if source == DocumentSource::FromParser {
+            (DocumentReadyState::Loading, false)
         } else {
-            DocumentReadyState::Complete
+            (DocumentReadyState::Complete, true)
         };
 
         let frame_type = match window.is_top_level() {
@@ -3888,12 +3815,12 @@ impl Document {
             stylesheets: DomRefCell::new(DocumentStylesheetSet::new()),
             stylesheet_list: MutNullableDom::new(None),
             ready_state: Cell::new(ready_state),
+            domcontentloaded_dispatched: Cell::new(domcontentloaded_dispatched),
             focus_transaction: DomRefCell::new(None),
             focused: Default::default(),
             focus_sequence: Cell::new(FocusSequenceNumber::default()),
             has_focus: Cell::new(has_focus),
             current_script: Default::default(),
-            current_the_end_loading_phase: Default::default(),
             pending_parsing_blocking_script: Default::default(),
             script_blocking_stylesheets_count: Default::default(),
             render_blocking_element_count: Default::default(),

--- a/components/script/dom/servoparser/mod.rs
+++ b/components/script/dom/servoparser/mod.rs
@@ -754,20 +754,15 @@ impl ServoParser {
         assert!(self.network_input.is_empty());
         assert!(self.network_decoder.borrow().is_finished());
 
-        // Step 1. If the active speculative HTML parser is not null, then stop the speculative HTML parser and return.
-        // TODO
-
-        // Step 3. Update the current document readiness to "interactive".
+        // Step 1.
         self.document
             .set_ready_state(DocumentReadyState::Interactive, can_gc);
 
-        // Step 2. Set the insertion point to undefined.
+        // Step 2.
         self.tokenizer.end(can_gc);
-        // Step 4. Pop all the nodes off the stack of open elements.
         self.document.set_current_parser(None);
 
-        // Step 5. While the list of scripts that will execute when the document has finished parsing is not empty:
-        self.document.start_the_end_loading_phase();
+        // Steps 3-12 are in another castle, namely finish_load.
         let url = self.tokenizer.url().clone();
         self.document.finish_load(LoadType::PageSource(url), can_gc);
 

--- a/components/script/dom/windowproxy.rs
+++ b/components/script/dom/windowproxy.rs
@@ -384,22 +384,22 @@ impl WindowProxy {
     }
 
     /// <https://html.spec.whatwg.org/multipage/#delaying-load-events-mode>
+    pub(crate) fn is_delaying_load_events_mode(&self) -> bool {
+        self.delaying_load_events_mode.get()
+    }
+
+    /// <https://html.spec.whatwg.org/multipage/#delaying-load-events-mode>
     pub(crate) fn start_delaying_load_events_mode(&self) {
         self.delaying_load_events_mode.set(true);
     }
 
     /// <https://html.spec.whatwg.org/multipage/#delaying-load-events-mode>
     pub(crate) fn stop_delaying_load_events_mode(&self) {
-        // Make sure we also started delaying the load event, otherwise we might
-        // end up unblocking the parent when we shouldn't have.
-        if !self.delaying_load_events_mode.replace(false) {
-            return;
-        }
-        let Some(parent) = self.parent() else {
-            unreachable!("Can only delay load event for a parent");
-        };
-        if let Some(document) = parent.document() {
-            document.wait_until_load_blockers_have_resolved();
+        self.delaying_load_events_mode.set(false);
+        if let Some(document) = self.document() {
+            if !document.loader().events_inhibited() {
+                ScriptThread::mark_document_with_no_blocked_loads(&document);
+            }
         }
     }
 

--- a/components/script/script_thread.rs
+++ b/components/script/script_thread.rs
@@ -346,6 +346,10 @@ pub struct ScriptThread {
     /// The worklet thread pool
     worklet_thread_pool: DomRefCell<Option<Rc<WorkletThreadPool>>>,
 
+    /// A list of pipelines containing documents that finished loading all their blocking
+    /// resources during a turn of the event loop.
+    docs_with_no_blocking_loads: DomRefCell<FxHashSet<Dom<Document>>>,
+
     /// <https://html.spec.whatwg.org/multipage/#custom-element-reactions-stack>
     custom_element_reaction_stack: Rc<CustomElementReactionStack>,
 
@@ -533,6 +537,15 @@ impl ScriptThread {
 
     pub(crate) fn microtask_queue() -> Rc<MicrotaskQueue> {
         with_script_thread(|script_thread| script_thread.microtask_queue.clone())
+    }
+
+    pub(crate) fn mark_document_with_no_blocked_loads(doc: &Document) {
+        with_script_thread(|script_thread| {
+            script_thread
+                .docs_with_no_blocking_loads
+                .borrow_mut()
+                .insert(Dom::from_ref(doc));
+        })
     }
 
     pub(crate) fn page_headers_available(
@@ -1013,6 +1026,7 @@ impl ScriptThread {
                 #[cfg(feature = "webxr")]
                 webxr_registry: state.webxr_registry,
                 worklet_thread_pool: Default::default(),
+                docs_with_no_blocking_loads: Default::default(),
                 custom_element_reaction_stack: Rc::new(CustomElementReactionStack::new()),
                 paint_api: state.cross_process_paint_api,
                 profile_script_events: opts.debug.profile_script_events,
@@ -1493,6 +1507,16 @@ impl ScriptThread {
             window
                 .upcast::<GlobalScope>()
                 .perform_a_dom_garbage_collection_checkpoint();
+        }
+
+        {
+            // https://html.spec.whatwg.org/multipage/#the-end step 6
+            let mut docs = self.docs_with_no_blocking_loads.borrow_mut();
+            for document in docs.iter() {
+                let _realm = enter_auto_realm(cx, &**document);
+                document.maybe_queue_document_completion();
+            }
+            docs.clear();
         }
 
         let built_any_display_lists = self.needs_rendering_update.load(Ordering::Relaxed) &&

--- a/tests/wpt/meta/css/selectors/invalidation/media-loading-pseudo-classes-in-has.html.ini
+++ b/tests/wpt/meta/css/selectors/invalidation/media-loading-pseudo-classes-in-has.html.ini
@@ -1,5 +1,4 @@
 [media-loading-pseudo-classes-in-has.html]
-  expected: ERROR
   [Test :has(:stalled) invalidation]
     expected: FAIL
 

--- a/tests/wpt/meta/html/browsers/browsing-the-web/navigating-across-documents/replace-before-load/form-submit.html.ini
+++ b/tests/wpt/meta/html/browsers/browsing-the-web/navigating-across-documents/replace-before-load/form-submit.html.ini
@@ -1,7 +1,6 @@
 [form-submit.html]
-  expected: TIMEOUT
   [Replace before load, triggered by formElement.submit()]
     expected: FAIL
 
   [Replace before load, triggered by same-document formElement.submit()]
-    expected: TIMEOUT
+    expected: FAIL

--- a/tests/wpt/meta/html/webappapis/dynamic-markup-insertion/opening-the-input-stream/location-set-and-document-open.html.ini
+++ b/tests/wpt/meta/html/webappapis/dynamic-markup-insertion/opening-the-input-stream/location-set-and-document-open.html.ini
@@ -1,3 +1,0 @@
-[location-set-and-document-open.html]
-  [Location sets should cancel current navigation and prevent later document.open() from doing anything]
-    expected: FAIL

--- a/tests/wpt/meta/trusted-types/inheriting-csp-for-local-schemes.html.ini
+++ b/tests/wpt/meta/trusted-types/inheriting-csp-for-local-schemes.html.ini
@@ -1,12 +1,31 @@
 [inheriting-csp-for-local-schemes.html]
+  expected: TIMEOUT
+  [require-trusted-types-for directive should be inherited in local srcdoc frames]
+    expected: TIMEOUT
+
+  [trusted-types directive should be inherited in local srcdoc frames]
+    expected: NOTRUN
+
   [require-trusted-types-for directive should be inherited in local data frames]
-    expected: FAIL
+    expected: NOTRUN
 
   [trusted-types directive should be inherited in local data frames]
-    expected: FAIL
+    expected: NOTRUN
 
   [require-trusted-types-for directive should be inherited in local blob frames]
-    expected: FAIL
+    expected: NOTRUN
 
   [trusted-types directive should be inherited in local blob frames]
-    expected: FAIL
+    expected: NOTRUN
+
+  [require-trusted-types-for directive should be inherited in local about:blank frames]
+    expected: NOTRUN
+
+  [trusted-types directive should be inherited in local about:blank frames]
+    expected: NOTRUN
+
+  [require-trusted-types-for directive should not be inherited in local blank.html frames]
+    expected: NOTRUN
+
+  [trusted-types directive should not be inherited in local blank.html frames]
+    expected: NOTRUN


### PR DESCRIPTION
Reverts servo/servo#42446 . Too many new intermittent timeouts caused by missing document load events.

Fixes: #42555
Fixes: #42556
Fixes: #42560
Fixes: #42557
Fixes: #42561 
Fixes: #42559 
Fixes: #42554 