### PR TITLE
mach (Android): Remove `CC_` & `CXX_` for build environment

### DIFF
--- a/python/servo/platform/build_target.py
+++ b/python/servo/platform/build_target.py
@@ -230,17 +230,6 @@ class AndroidTarget(CrossBuildTarget):
         env["TARGET_CPP"] = to_ndk_bin("clang") + " -E"
         env["TARGET_CXX"] = to_ndk_bin("clang++")
 
-        target_triple = self.triple()
-        rust_target_triple = str(target_triple).replace("-", "_")
-
-        # These are required by `aws-lc-sys` due to a bug:
-        # https://github.com/aws/aws-lc-rs/issues/1025
-        ndk_clang = to_ndk_bin("clang")
-        ndk_clangxx = to_ndk_bin("clang++")
-
-        env[f"CC_{rust_target_triple}"] = ndk_clang
-        env[f"CXX_{rust_target_triple}"] = ndk_clangxx
-
         env["TARGET_AR"] = to_ndk_bin("llvm-ar")
         env["TARGET_RANLIB"] = to_ndk_bin("llvm-ranlib")
         env["TARGET_OBJCOPY"] = to_ndk_bin("llvm-objcopy")


### PR DESCRIPTION
This reverts the workaround introduced in https://github.com/servo/servo/pull/42232#discussion_r2740827196 which enabled CC builder, given https://github.com/aws/aws-lc-rs/pull/1026 in the new release.

Depends on: #42551
Testing: Android build: https://github.com/servo/servo/actions/runs/21931411344
Fixes: #42242
