### PR TITLE
layout: Support `svg` in `border-image-source`

### DIFF
--- a/components/layout/display_list/mod.rs
+++ b/components/layout/display_list/mod.rs
@@ -1584,11 +1584,24 @@ impl<'a> BuilderForBoxFragment<'a> {
         {
             Err(_) => return false,
             Ok(ResolvedImage::Image { image, size }) => {
-                let Some(image) = image.as_raster_image() else {
-                    return false;
+                let image_key = match image {
+                    CachedImage::Raster(raster_image) => raster_image.id,
+                    CachedImage::Vector(vector_image) => {
+                        let scale = builder.device_pixel_ratio.get();
+                        let size = Size2D::new(size.width * scale, size.height * scale).to_i32();
+                        node.and_then(|node| {
+                            builder.image_resolver.rasterize_vector_image(
+                                vector_image.id,
+                                size,
+                                node,
+                                vector_image.svg_id,
+                            )
+                        })
+                        .and_then(|rasterized_image| rasterized_image.id)
+                    },
                 };
 
-                let Some(key) = image.id else {
+                let Some(key) = image_key else {
                     return false;
                 };
 

--- a/tests/wpt/meta/css/css-backgrounds/border-image-image-type-002.htm.ini
+++ b/tests/wpt/meta/css/css-backgrounds/border-image-image-type-002.htm.ini
@@ -1,2 +1,0 @@
-[border-image-image-type-002.htm]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-backgrounds/border-image-image-type-004.htm.ini
+++ b/tests/wpt/meta/css/css-backgrounds/border-image-image-type-004.htm.ini
@@ -1,2 +1,0 @@
-[border-image-image-type-004.htm]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-backgrounds/border-image-image-type-005.htm.ini
+++ b/tests/wpt/meta/css/css-backgrounds/border-image-image-type-005.htm.ini
@@ -1,2 +1,0 @@
-[border-image-image-type-005.htm]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-backgrounds/border-image-repeat-1.html.ini
+++ b/tests/wpt/meta/css/css-backgrounds/border-image-repeat-1.html.ini
@@ -1,2 +1,0 @@
-[border-image-repeat-1.html]
-  expected: FAIL

--- a/tests/wpt/meta/paint-timing/fcp-only/fcp-border-image-with-svg.html.ini
+++ b/tests/wpt/meta/paint-timing/fcp-only/fcp-border-image-with-svg.html.ini
@@ -1,4 +1,0 @@
-[fcp-border-image-with-svg.html]
-  expected: TIMEOUT
-  [Border image triggers First Contentful Paint.]
-    expected: TIMEOUT


### PR DESCRIPTION
Extends the SVG support for `border-image-source`

> The logic is almost identical to `build_background_image`

Testing: Following WPT Tests Passed
- `tests/wpt/tests/css/css-backgrounds/border-image-image-type-002.htm`
- `tests/wpt/tests/css/css-backgrounds/border-image-image-type-004.htm` 
- `tests/wpt/tests/css/css-backgrounds/border-image-image-type-005.htm`
- `tests/wpt/tests/css/css-backgrounds/border-image-repeat-1.html`
- `tests/wpt/tests/paint-timing/fcp-only/fcp-border-image-with-svg.html`

Fixes: #42098
