### PR TITLE
layout: Consider image backgrounds as contentful for the `first-contentful-paint` paint metric

### DIFF
--- a/components/layout/display_list/mod.rs
+++ b/components/layout/display_list/mod.rs
@@ -1410,6 +1410,12 @@ impl<'a> BuilderForBoxFragment<'a> {
                             )
                         }
 
+                        // From <https://www.w3.org/TR/paint-timing/#sec-terminology>:
+                        // An element target is contentful when one or more of the following apply:
+                        // > target has a background-image which is a contentful image, and its used
+                        // > background-size has non-zero width and height values.
+                        builder.check_for_contentful_paint(layer.bounds, layer.common.clip_rect);
+
                         let lcp_candidate_id = self
                             .fragment
                             .base

--- a/tests/wpt/meta/paint-timing/fcp-only/fcp-background-size.html.ini
+++ b/tests/wpt/meta/paint-timing/fcp-only/fcp-background-size.html.ini
@@ -1,4 +1,0 @@
-[fcp-background-size.html]
-  expected: TIMEOUT
-  [First contentful paint fires due to background size.]
-    expected: TIMEOUT

--- a/tests/wpt/meta/paint-timing/fcp-only/fcp-bg-image-set.html.ini
+++ b/tests/wpt/meta/paint-timing/fcp-only/fcp-bg-image-set.html.ini
@@ -1,4 +1,0 @@
-[fcp-bg-image-set.html]
-  expected: TIMEOUT
-  [First contentful paint fires due to background image in image-set.]
-    expected: TIMEOUT

--- a/tests/wpt/meta/paint-timing/fcp-only/fcp-bg-image-two-steps.html.ini
+++ b/tests/wpt/meta/paint-timing/fcp-only/fcp-bg-image-two-steps.html.ini
@@ -1,4 +1,0 @@
-[fcp-bg-image-two-steps.html]
-  expected: TIMEOUT
-  [First contentful paint fires for background image only when visible.]
-    expected: TIMEOUT

--- a/tests/wpt/meta/paint-timing/fcp-only/fcp-invisible-scale.html.ini
+++ b/tests/wpt/meta/paint-timing/fcp-only/fcp-invisible-scale.html.ini
@@ -1,4 +1,0 @@
-[fcp-invisible-scale.html]
-  expected: TIMEOUT
-  [First contentful paint fires due to scale becoming positive.]
-    expected: TIMEOUT

--- a/tests/wpt/meta/paint-timing/fcp-only/fcp-opacity.html.ini
+++ b/tests/wpt/meta/paint-timing/fcp-only/fcp-opacity.html.ini
@@ -1,4 +1,3 @@
 [fcp-opacity.html]
-  expected: TIMEOUT
   [First contentful paint fires due to opacity-revealed element.]
-    expected: TIMEOUT
+    expected: FAIL

--- a/tests/wpt/meta/paint-timing/fcp-only/fcp-out-of-bounds-translate.html.ini
+++ b/tests/wpt/meta/paint-timing/fcp-only/fcp-out-of-bounds-translate.html.ini
@@ -1,4 +1,3 @@
 [fcp-out-of-bounds-translate.html]
-  expected: TIMEOUT
   [First contentful paint fires due to transform-based intersection with document.]
-    expected: TIMEOUT
+    expected: FAIL

--- a/tests/wpt/meta/paint-timing/fcp-only/fcp-out-of-bounds.html.ini
+++ b/tests/wpt/meta/paint-timing/fcp-only/fcp-out-of-bounds.html.ini
@@ -1,4 +1,0 @@
-[fcp-out-of-bounds.html]
-  expected: TIMEOUT
-  [First contentful paint fires due to intersection with document.]
-    expected: TIMEOUT

--- a/tests/wpt/meta/paint-timing/fcp-only/fcp-with-rtl.html.ini
+++ b/tests/wpt/meta/paint-timing/fcp-only/fcp-with-rtl.html.ini
@@ -1,0 +1,4 @@
+[fcp-with-rtl.html]
+  expected: TIMEOUT
+  [FCP should fire when coordinates are negative, if within document scrollable area]
+    expected: TIMEOUT

--- a/tests/wpt/meta/paint-timing/first-contentful-bg-image.html.ini
+++ b/tests/wpt/meta/paint-timing/first-contentful-bg-image.html.ini
@@ -1,4 +1,0 @@
-[first-contentful-bg-image.html]
-  expected: TIMEOUT
-  [First contentful paint fires due to background image render.]
-    expected: TIMEOUT


### PR DESCRIPTION
As per W3C [spec](https://www.w3.org/TR/paint-timing/#sec-terminology)

> An [element](https://dom.spec.whatwg.org/#concept-element) target is contentful when one or more of the following apply:
> - target has a [background-image](https://www.w3.org/TR/css-backgrounds-3/#propdef-background-image) which is a [contentful image](https://www.w3.org/TR/paint-timing/#contentful-image), and its [used](https://www.w3.org/TR/css-cascade-5/#used-value) [background-size](https://www.w3.org/TR/css-backgrounds-3/#background-size) has non-zero width and height values.

Testing: Updated WPT Expectations
Fixes: #42568