### PR TITLE
script: Report associated memory for webgl objects

### DIFF
--- a/components/script/dom/webgl/webgl2renderingcontext.rs
+++ b/components/script/dom/webgl/webgl2renderingcontext.rs
@@ -94,7 +94,7 @@ impl IndexedBinding {
     }
 }
 
-#[dom_struct]
+#[dom_struct] // no need to report size here as it is reported as part of WebGLRenderingContext
 pub(crate) struct WebGL2RenderingContext {
     reflector_: Reflector,
     base: Dom<WebGLRenderingContext>,

--- a/components/script/dom/webgl/webglbuffer.rs
+++ b/components/script/dom/webgl/webglbuffer.rs
@@ -8,6 +8,7 @@ use std::cell::Cell;
 use base::generic_channel;
 use canvas_traits::webgl::{WebGLBufferId, WebGLCommand, WebGLError, WebGLResult, webgl_channel};
 use dom_struct::dom_struct;
+use script_bindings::reflector::DomObject;
 use script_bindings::weakref::WeakRef;
 
 use crate::dom::bindings::codegen::Bindings::WebGL2RenderingContextBinding::WebGL2RenderingContextConstants;
@@ -106,7 +107,7 @@ impl Drop for DroppableWebGLBuffer {
     }
 }
 
-#[dom_struct]
+#[dom_struct(associated_memory)]
 pub(crate) struct WebGLBuffer {
     webgl_object: WebGLObject,
     /// The target to which this buffer was bound the first time
@@ -178,6 +179,8 @@ impl WebGLBuffer {
         }
 
         self.capacity.set(data.len());
+        self.reflector()
+            .update_memory_size(self, self.capacity.get());
         self.usage.set(usage);
         let (sender, receiver) = generic_channel::channel().unwrap();
         self.upcast()

--- a/components/script/dom/webgl/webglframebuffer.rs
+++ b/components/script/dom/webgl/webglframebuffer.rs
@@ -143,7 +143,7 @@ impl Drop for DroppableWebGLFramebuffer {
     }
 }
 
-#[dom_struct]
+#[dom_struct(associated_memory)] // actual memory usage is reported in WebGLFramebufferAttachment
 pub(crate) struct WebGLFramebuffer {
     webgl_object: WebGLObject,
     #[no_trace]

--- a/components/script/dom/webgl/webglobject.rs
+++ b/components/script/dom/webgl/webglobject.rs
@@ -5,6 +5,7 @@
 use canvas_traits::webgl::{WebGLCommand, WebGLContextId, WebGLMsgSender};
 // https://www.khronos.org/registry/webgl/specs/latest/1.0/webgl.idl
 use dom_struct::dom_struct;
+use script_bindings::reflector::AssociatedMemory;
 use script_bindings::root::DomRoot;
 use script_bindings::weakref::WeakRef;
 
@@ -15,9 +16,9 @@ use crate::dom::bindings::str::USVString;
 use crate::dom::webgl::webglrenderingcontext::WebGLRenderingContext;
 use crate::dom::webglrenderingcontext::{Operation, capture_webgl_backtrace};
 
-#[dom_struct]
+#[dom_struct(associated_memory)]
 pub(crate) struct WebGLObject {
-    reflector_: Reflector,
+    reflector_: Reflector<AssociatedMemory>,
     #[no_trace]
     webgl_sender: WebGLMsgSender,
     context: WeakRef<WebGLRenderingContext>,

--- a/components/script/dom/webgl/webglprogram.rs
+++ b/components/script/dom/webgl/webglprogram.rs
@@ -171,7 +171,7 @@ impl Drop for DroppableWebGLProgram {
     }
 }
 
-#[dom_struct]
+#[dom_struct(associated_memory)]
 pub(crate) struct WebGLProgram {
     webgl_object: WebGLObject,
     link_called: Cell<bool>,

--- a/components/script/dom/webgl/webglquery.rs
+++ b/components/script/dom/webgl/webglquery.rs
@@ -17,7 +17,7 @@ use crate::dom::webgl::webglobject::WebGLObject;
 use crate::dom::webgl::webglrenderingcontext::{Operation, WebGLRenderingContext};
 use crate::script_runtime::CanGc;
 
-#[dom_struct]
+#[dom_struct(associated_memory)]
 pub(crate) struct WebGLQuery {
     webgl_object: WebGLObject,
     #[no_trace]

--- a/components/script/dom/webgl/webglrenderbuffer.rs
+++ b/components/script/dom/webgl/webglrenderbuffer.rs
@@ -22,7 +22,7 @@ use crate::dom::webgl::webglobject::WebGLObject;
 use crate::dom::webgl::webglrenderingcontext::{Operation, WebGLRenderingContext};
 use crate::script_runtime::CanGc;
 
-#[dom_struct]
+#[dom_struct(associated_memory)]
 pub(crate) struct WebGLRenderbuffer {
     webgl_object: WebGLObject,
     #[no_trace]

--- a/components/script/dom/webgl/webglrenderingcontext.rs
+++ b/components/script/dom/webgl/webglrenderingcontext.rs
@@ -31,6 +31,7 @@ use js::typedarray::{
 };
 use pixels::{self, Alpha, PixelFormat, Snapshot, SnapshotPixelFormat};
 use script_bindings::conversions::SafeToJSValConvertible;
+use script_bindings::reflector::AssociatedMemory;
 use serde::{Deserialize, Serialize};
 use servo_config::pref;
 use webrender_api::ImageKey;
@@ -183,9 +184,9 @@ impl Drop for DroppableWebGLRenderingContext {
     }
 }
 
-#[dom_struct]
+#[dom_struct(associated_memory)]
 pub(crate) struct WebGLRenderingContext {
-    reflector_: Reflector,
+    reflector_: Reflector<AssociatedMemory>,
     #[no_trace]
     webgl_version: WebGLVersion,
     #[no_trace]
@@ -2007,6 +2008,8 @@ impl CanvasContext for WebGLRenderingContext {
         // FIXME(#21718) The backend is allowed to choose a size smaller than
         // what was requested
         self.size.set(size);
+        self.reflector_
+            .update_memory_size(self, size.cast::<usize>().area() * 4);
 
         if let Err(msg) = receiver.recv().unwrap() {
             error!("Error resizing WebGLContext: {}", msg);

--- a/components/script/dom/webgl/webglsampler.rs
+++ b/components/script/dom/webgl/webglsampler.rs
@@ -16,7 +16,7 @@ use crate::dom::webgl::webglobject::WebGLObject;
 use crate::dom::webgl::webglrenderingcontext::{Operation, WebGLRenderingContext};
 use crate::script_runtime::CanGc;
 
-#[dom_struct]
+#[dom_struct(associated_memory)]
 pub(crate) struct WebGLSampler {
     webgl_object: WebGLObject,
     #[no_trace]

--- a/components/script/dom/webgl/webglshader.rs
+++ b/components/script/dom/webgl/webglshader.rs
@@ -34,7 +34,7 @@ pub(crate) enum ShaderCompilationStatus {
     Failed,
 }
 
-#[dom_struct]
+#[dom_struct(associated_memory)]
 pub(crate) struct WebGLShader {
     webgl_object: WebGLObject,
     #[no_trace]

--- a/components/script/dom/webgl/webglsync.rs
+++ b/components/script/dom/webgl/webglsync.rs
@@ -16,7 +16,7 @@ use crate::dom::webgl::webglobject::WebGLObject;
 use crate::dom::webgl::webglrenderingcontext::{Operation, WebGLRenderingContext};
 use crate::script_runtime::CanGc;
 
-#[dom_struct]
+#[dom_struct(associated_memory)]
 pub(crate) struct WebGLSync {
     webgl_object: WebGLObject,
     #[no_trace]

--- a/components/script/dom/webgl/webgltransformfeedback.rs
+++ b/components/script/dom/webgl/webgltransformfeedback.rs
@@ -14,7 +14,7 @@ use crate::dom::webgl::webglobject::WebGLObject;
 use crate::dom::webgl::webglrenderingcontext::{Operation, WebGLRenderingContext};
 use crate::script_runtime::CanGc;
 
-#[dom_struct]
+#[dom_struct(associated_memory)]
 pub(crate) struct WebGLTransformFeedback {
     webgl_object: WebGLObject,
     id: u32,

--- a/components/script/dom/webgl/webglvertexarrayobject.rs
+++ b/components/script/dom/webgl/webglvertexarrayobject.rs
@@ -14,7 +14,7 @@ use crate::dom::webgl::webglobject::WebGLObject;
 use crate::dom::webgl::webglrenderingcontext::{Operation, WebGLRenderingContext};
 use crate::script_runtime::CanGc;
 
-#[dom_struct]
+#[dom_struct(associated_memory)]
 pub(crate) struct WebGLVertexArrayObject {
     webgl_object_: WebGLObject,
     array_object: VertexArrayObject,

--- a/components/script/dom/webgl/webglvertexarrayobjectoes.rs
+++ b/components/script/dom/webgl/webglvertexarrayobjectoes.rs
@@ -14,7 +14,7 @@ use crate::dom::webgl::webglobject::WebGLObject;
 use crate::dom::webgl::webglrenderingcontext::{Operation, WebGLRenderingContext};
 use crate::script_runtime::CanGc;
 
-#[dom_struct]
+#[dom_struct(associated_memory)]
 pub(crate) struct WebGLVertexArrayObjectOES {
     webgl_object_: WebGLObject,
     array_object: VertexArrayObject,


### PR DESCRIPTION
As started in https://github.com/servo/servo/issues/42168 let's report memory pressure for webgl objects. CanvasContexts report memory twice: once because of underlying texture object and once by themself, but that's okay as we also need to account for swapchain textures.

Computing exact size would be to much work and code so we report rough estimations.

Testing: None
