### PR TITLE
net/fetch: Don't write Response::termination_reason in closure

### DIFF
--- a/components/net/http_loader.rs
+++ b/components/net/http_loader.rs
@@ -55,7 +55,7 @@ use net_traits::request::{
     is_cors_safelisted_request_header,
 };
 use net_traits::response::{
-    CacheState, HttpsState, RedirectTaint, Response, ResponseBody, ResponseType, TerminationReason,
+    CacheState, HttpsState, RedirectTaint, Response, ResponseBody, ResponseType,
 };
 use net_traits::{
     CookieSource, DOCUMENT_ACCEPT_HEADER_VALUE, DebugVec, FetchMetadata, NetworkError,
@@ -2288,7 +2288,6 @@ async fn http_network_fetch(
                     debug!("Content decompression error for {:?}", url2);
                     let _ = done_sender3.send(Data::Error(NetworkError::DecompressionError));
                     let mut body = res_body2.lock();
-                    response.termination_reason = Some(TerminationReason::Fatal);
 
                     *body = ResponseBody::Done(vec![]);
                 }


### PR DESCRIPTION
Writing `termination_reason` in the closure in `http_network_fetch()` had no effect, as the response is captured by value, and cannot be captured by mutable reference as it is needed later in the outer function.

This is flagged as a warning with Rust 1.92:

https://github.com/servo/servo/actions/runs/21750902723/job/62748597306?pr=42402

Note: I don't understand this code deeply, I was just trying my best to fix the warning. I'm more than happy to close this PR or change the code if someone more familiar has a better idea of how to fix it.

Testing: Existing tests, no behaviour change.
