### PR TITLE
layout: Ensure layout damage clears inline content size cache of parent

### DIFF
--- a/components/shared/layout/layout_damage.rs
+++ b/components/shared/layout/layout_damage.rs
@@ -45,6 +45,12 @@ impl From<RestyleDamage> for LayoutDamage {
     }
 }
 
+impl From<LayoutDamage> for RestyleDamage {
+    fn from(layout_damage: LayoutDamage) -> Self {
+        RestyleDamage::from_bits_retain(layout_damage.bits())
+    }
+}
+
 impl std::fmt::Debug for LayoutDamage {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         if self.contains(Self::REBUILD_BOX) {

--- a/tests/wpt/tests/css/css-sizing/dynamic-change-inline-size-004.html
+++ b/tests/wpt/tests/css/css-sizing/dynamic-change-inline-size-004.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html class="reftest-wait">
+    <title>Dynamic change to inline size is reflected in intrinsic size of width: max-content parent</title>
+    <link rel="author" title="Martin Robinson" href="mrobinson@igalia.com">
+    <link rel="match" href="/css/reference/ref-filled-green-100px-square.xht">
+    <link rel="help" href="https://www.w3.org/TR/css-sizing-3/#intrinsic-sizes">
+
+    <p>Test passes if there is a filled green square and <strong>no red</strong>.</p>
+    <div style="width: 100px; height: 100px; background: red;">
+        <div style="background: green; width: max-content; height: 100px;">
+            <div id=inner style="width: 10px; height: 100px;"></div>
+        </div>
+    </div>
+
+    <script>
+        addEventListener("load", () => {
+            inner.style.width = "100px";
+            document.documentElement.classList.remove("reftest-wait");
+        });
+    </script>
+</html>


### PR DESCRIPTION
This change fixes an issue where layout damage to a node was not
clearing the inline content size cache of the parent node. In addition
it starts to clean up the damage traversal logic in preparation for
changes to the way that damage is processed and box tree layout is done.

Testing: This change adds a new WPT test.
