### PR TITLE
script: Use CString for `Error::Type` and `Error::Range`

### DIFF
--- a/components/malloc_size_of/lib.rs
+++ b/components/malloc_size_of/lib.rs
@@ -48,6 +48,7 @@
 
 use std::cell::OnceCell;
 use std::collections::BinaryHeap;
+use std::ffi::CString;
 use std::hash::{BuildHasher, Hash};
 use std::ops::Range;
 use std::rc::Rc;
@@ -169,6 +170,12 @@ impl MallocSizeOf for markup5ever::QualName {
 }
 
 impl MallocSizeOf for String {
+    fn size_of(&self, ops: &mut MallocSizeOfOps) -> usize {
+        unsafe { ops.malloc_size_of(self.as_ptr()) }
+    }
+}
+
+impl MallocSizeOf for CString {
     fn size_of(&self, ops: &mut MallocSizeOfOps) -> usize {
         unsafe { ops.malloc_size_of(self.as_ptr()) }
     }

--- a/components/script/body.rs
+++ b/components/script/body.rs
@@ -527,13 +527,13 @@ impl Extractable for BodyInit {
                 // If keepalive is true, then throw a TypeError.
                 if keep_alive {
                     return Err(Error::Type(
-                        "The body's stream is for a keepalive request".to_string(),
+                        c"The body's stream is for a keepalive request".to_owned(),
                     ));
                 }
                 // If object is disturbed or locked, then throw a TypeError.
                 if stream.is_locked() || stream.is_disturbed() {
                     return Err(Error::Type(
-                        "The body's stream is disturbed or locked".to_string(),
+                        c"The body's stream is disturbed or locked".to_owned(),
                     ));
                 }
 
@@ -702,7 +702,7 @@ pub(crate) fn consume_body<T: BodyMixin + DomObject>(
     // If object is unusable, then return a promise rejected with a TypeError.
     if object.is_unusable() {
         promise.reject_error(
-            Error::Type("The body's stream is disturbed or locked".to_string()),
+            Error::Type(c"The body's stream is disturbed or locked".to_owned()),
             can_gc,
         );
         return promise;
@@ -947,7 +947,7 @@ fn content_type_from_headers(headers: &HeaderMap) -> Result<String, Error> {
     match headers.get(CONTENT_TYPE) {
         Some(value) => Ok(value
             .to_str()
-            .map_err(|_| Error::Type("Inappropriate MIME-type for Body".to_string()))?
+            .map_err(|_| Error::Type(c"Inappropriate MIME-type for Body".to_owned()))?
             .to_string()),
         None => Ok("text/plain".to_string()),
     }
@@ -1003,7 +1003,7 @@ fn append_multipart_nodes(
             },
             Node::File(file_part) => {
                 let body = fs::read(&file_part.path)
-                    .map_err(|_| Error::Type("file part could not be read".to_string()))?;
+                    .map_err(|_| Error::Type(c"file part could not be read".to_owned()))?;
                 append_form_data_entry_from_part(root, formdata, &file_part.headers, body, can_gc)?;
             },
             Node::Multipart((_, inner)) => {
@@ -1026,7 +1026,7 @@ fn run_form_data_algorithm(
     let mime_str = str::from_utf8(mime).unwrap_or_default();
     let mime: Mime = mime_str
         .parse()
-        .map_err(|_| Error::Type("Inappropriate MIME-type for Body".to_string()))?;
+        .map_err(|_| Error::Type(c"Inappropriate MIME-type for Body".to_owned()))?;
 
     // Let mimeType be the result of get the MIME type with this.
     //
@@ -1040,7 +1040,7 @@ fn run_form_data_algorithm(
             CONTENT_TYPE,
             mime_str
                 .parse()
-                .map_err(|_| Error::Type("Inappropriate MIME-type for Body".to_string()))?,
+                .map_err(|_| Error::Type(c"Inappropriate MIME-type for Body".to_owned()))?,
         );
 
         if let Some(boundary) = mime.get_param(mime::BOUNDARY) {
@@ -1055,7 +1055,7 @@ fn run_form_data_algorithm(
         let mut cursor = Cursor::new(bytes);
         // If that fails for some reason, then throw a TypeError.
         let nodes = read_multipart_body(&mut cursor, &headers, false)
-            .map_err(|_| Error::Type("Inappropriate MIME-type for Body".to_string()))?;
+            .map_err(|_| Error::Type(c"Inappropriate MIME-type for Body".to_owned()))?;
         // The above is a rough approximation of what is needed for `multipart/form-data`,
         // a more detailed parsing specification is to be written. Volunteers welcome.
 
@@ -1081,7 +1081,7 @@ fn run_form_data_algorithm(
     }
 
     // Throw a TypeError.
-    Err(Error::Type("Inappropriate MIME-type for Body".to_string()))
+    Err(Error::Type(c"Inappropriate MIME-type for Body".to_owned()))
 }
 
 /// <https://fetch.spec.whatwg.org/#ref-for-concept-body-consume-body%E2%91%A1>

--- a/components/script/dom/audio/audiobuffer.rs
+++ b/components/script/dom/audio/audiobuffer.rs
@@ -265,7 +265,7 @@ impl AudioBufferMethods<crate::DomTypeHolder> for AudioBuffer {
         start_in_channel: u32,
     ) -> Fallible<()> {
         if destination.is_shared() {
-            return Err(Error::Type("Cannot copy to shared buffer".to_owned()));
+            return Err(Error::Type(c"Cannot copy to shared buffer".to_owned()));
         }
 
         if channel_number >= self.number_of_channels || start_in_channel >= self.length {
@@ -307,7 +307,7 @@ impl AudioBufferMethods<crate::DomTypeHolder> for AudioBuffer {
         can_gc: CanGc,
     ) -> Fallible<()> {
         if source.is_shared() {
-            return Err(Error::Type("Cannot copy from shared buffer".to_owned()));
+            return Err(Error::Type(c"Cannot copy from shared buffer".to_owned()));
         }
 
         if channel_number >= self.number_of_channels || start_in_channel > (source.len() as u32) {

--- a/components/script/dom/audio/audiobuffersourcenode.rs
+++ b/components/script/dom/audio/audiobuffersourcenode.rs
@@ -236,14 +236,16 @@ impl AudioBufferSourceNodeMethods<crate::DomTypeHolder> for AudioBufferSourceNod
     ) -> Fallible<()> {
         if let Some(offset) = offset {
             if *offset < 0. {
-                return Err(Error::Range("'offset' must be a positive value".to_owned()));
+                return Err(Error::Range(
+                    c"'offset' must be a positive value".to_owned(),
+                ));
             }
         }
 
         if let Some(duration) = duration {
             if *duration < 0. {
                 return Err(Error::Range(
-                    "'duration' must be a positive value".to_owned(),
+                    c"'duration' must be a positive value".to_owned(),
                 ));
             }
         }

--- a/components/script/dom/audio/audiocontext.rs
+++ b/components/script/dom/audio/audiocontext.rs
@@ -186,7 +186,7 @@ impl AudioContextMethods<crate::DomTypeHolder> for AudioContext {
                     .dom_manipulation_task_source()
                     .queue(task!(suspend_error: move || {
                         let promise = trusted_promise.root();
-                        promise.reject_error(Error::Type("Something went wrong".to_owned()), CanGc::note());
+                        promise.reject_error(Error::Type(c"Something went wrong".to_owned()), CanGc::note());
                     }));
             },
         };
@@ -242,7 +242,7 @@ impl AudioContextMethods<crate::DomTypeHolder> for AudioContext {
                     .dom_manipulation_task_source()
                     .queue(task!(suspend_error: move || {
                         let promise = trusted_promise.root();
-                        promise.reject_error(Error::Type("Something went wrong".to_owned()), CanGc::note());
+                        promise.reject_error(Error::Type(c"Something went wrong".to_owned()), CanGc::note());
                     }));
             },
         };

--- a/components/script/dom/audio/audioparam.rs
+++ b/components/script/dom/audio/audioparam.rs
@@ -6,6 +6,7 @@ use std::cell::Cell;
 use std::sync::mpsc;
 
 use dom_struct::dom_struct;
+use script_bindings::cformat;
 use servo_media::audio::graph::NodeId;
 use servo_media::audio::node::{AudioNodeMessage, AudioNodeType};
 use servo_media::audio::param::{ParamRate, ParamType, RampKind, UserAutomationEvent};
@@ -183,7 +184,7 @@ impl AudioParamMethods<crate::DomTypeHolder> for AudioParam {
         start_time: Finite<f64>,
     ) -> Fallible<DomRoot<AudioParam>> {
         if *start_time < 0. {
-            return Err(Error::Range(format!(
+            return Err(Error::Range(cformat!(
                 "start time {} should not be negative",
                 *start_time
             )));
@@ -202,7 +203,7 @@ impl AudioParamMethods<crate::DomTypeHolder> for AudioParam {
         end_time: Finite<f64>,
     ) -> Fallible<DomRoot<AudioParam>> {
         if *end_time < 0. {
-            return Err(Error::Range(format!(
+            return Err(Error::Range(cformat!(
                 "end time {} should not be negative",
                 *end_time
             )));
@@ -221,13 +222,13 @@ impl AudioParamMethods<crate::DomTypeHolder> for AudioParam {
         end_time: Finite<f64>,
     ) -> Fallible<DomRoot<AudioParam>> {
         if *end_time < 0. {
-            return Err(Error::Range(format!(
+            return Err(Error::Range(cformat!(
                 "end time {} should not be negative",
                 *end_time
             )));
         }
         if *value == 0. {
-            return Err(Error::Range(format!(
+            return Err(Error::Range(cformat!(
                 "target value {} should not be 0",
                 *value
             )));
@@ -247,13 +248,13 @@ impl AudioParamMethods<crate::DomTypeHolder> for AudioParam {
         time_constant: Finite<f32>,
     ) -> Fallible<DomRoot<AudioParam>> {
         if *start_time < 0. {
-            return Err(Error::Range(format!(
+            return Err(Error::Range(cformat!(
                 "start time {} should not be negative",
                 *start_time
             )));
         }
         if *time_constant < 0. {
-            return Err(Error::Range(format!(
+            return Err(Error::Range(cformat!(
                 "time constant {} should not be negative",
                 *time_constant
             )));
@@ -273,7 +274,7 @@ impl AudioParamMethods<crate::DomTypeHolder> for AudioParam {
         end_time: Finite<f64>,
     ) -> Fallible<DomRoot<AudioParam>> {
         if *start_time < 0. {
-            return Err(Error::Range(format!(
+            return Err(Error::Range(cformat!(
                 "start time {} should not be negative",
                 *start_time
             )));
@@ -283,7 +284,7 @@ impl AudioParamMethods<crate::DomTypeHolder> for AudioParam {
         }
 
         if *end_time < 0. {
-            return Err(Error::Range(format!(
+            return Err(Error::Range(cformat!(
                 "end time {} should not be negative",
                 *end_time
             )));
@@ -302,7 +303,7 @@ impl AudioParamMethods<crate::DomTypeHolder> for AudioParam {
     /// <https://webaudio.github.io/web-audio-api/#dom-audioparam-cancelscheduledvalues>
     fn CancelScheduledValues(&self, cancel_time: Finite<f64>) -> Fallible<DomRoot<AudioParam>> {
         if *cancel_time < 0. {
-            return Err(Error::Range(format!(
+            return Err(Error::Range(cformat!(
                 "cancel time {} should not be negative",
                 *cancel_time
             )));
@@ -317,7 +318,7 @@ impl AudioParamMethods<crate::DomTypeHolder> for AudioParam {
     /// <https://webaudio.github.io/web-audio-api/#dom-audioparam-cancelandholdattime>
     fn CancelAndHoldAtTime(&self, cancel_time: Finite<f64>) -> Fallible<DomRoot<AudioParam>> {
         if *cancel_time < 0. {
-            return Err(Error::Range(format!(
+            return Err(Error::Range(cformat!(
                 "cancel time {} should not be negative",
                 *cancel_time
             )));

--- a/components/script/dom/audio/audioscheduledsourcenode.rs
+++ b/components/script/dom/audio/audioscheduledsourcenode.rs
@@ -63,7 +63,7 @@ impl AudioScheduledSourceNodeMethods<crate::DomTypeHolder> for AudioScheduledSou
     /// <https://webaudio.github.io/web-audio-api/#dom-audioscheduledsourcenode-start>
     fn Start(&self, when: Finite<f64>) -> Fallible<()> {
         if *when < 0. {
-            return Err(Error::Range("'when' must be a positive value".to_owned()));
+            return Err(Error::Range(c"'when' must be a positive value".to_owned()));
         }
 
         if self.has_start.get() || self.has_stop.get() {
@@ -102,7 +102,7 @@ impl AudioScheduledSourceNodeMethods<crate::DomTypeHolder> for AudioScheduledSou
     /// <https://webaudio.github.io/web-audio-api/#dom-audioscheduledsourcenode-stop>
     fn Stop(&self, when: Finite<f64>) -> Fallible<()> {
         if *when < 0. {
-            return Err(Error::Range("'when' must be a positive value".to_owned()));
+            return Err(Error::Range(c"'when' must be a positive value".to_owned()));
         }
 
         if !self.has_start.get() {

--- a/components/script/dom/audio/baseaudiocontext.rs
+++ b/components/script/dom/audio/baseaudiocontext.rs
@@ -12,6 +12,7 @@ use base::id::PipelineId;
 use dom_struct::dom_struct;
 use js::rust::CustomAutoRooterGuard;
 use js::typedarray::ArrayBuffer;
+use script_bindings::cformat;
 use servo_media::audio::context::{
     AudioContext, AudioContextOptions, OfflineAudioContextOptions, ProcessingState,
     RealTimeAudioContextOptions,
@@ -250,7 +251,7 @@ impl BaseAudioContext {
             },
             None => {
                 self.take_pending_resume_promises(Err(Error::Type(
-                    "Something went wrong".to_owned(),
+                    c"Something went wrong".to_owned(),
                 )));
                 self.global()
                     .task_manager()
@@ -562,7 +563,7 @@ impl BaseAudioContextMethods<crate::DomTypeHolder> for BaseAudioContext {
                                 &DOMException::new(&this.global(), DOMErrorName::DataCloneError, CanGc::note()),
                                 ExceptionHandling::Report, CanGc::note());
                         }
-                        let error = format!("Audio decode error {:?}", error);
+                        let error = cformat!("Audio decode error {:?}", error);
                         resolver.promise.reject_error(Error::Type(error), CanGc::note());
                     }));
                 })

--- a/components/script/dom/audio/offlineaudiocontext.rs
+++ b/components/script/dom/audio/offlineaudiocontext.rs
@@ -222,7 +222,7 @@ impl OfflineAudioContextMethods<crate::DomTypeHolder> for OfflineAudioContext {
             .is_none()
         {
             promise.reject_error(
-                Error::Type("Could not start offline rendering".to_owned()),
+                Error::Type(c"Could not start offline rendering".to_owned()),
                 can_gc,
             );
         }

--- a/components/script/dom/audio/pannernode.rs
+++ b/components/script/dom/audio/pannernode.rs
@@ -77,13 +77,13 @@ impl PannerNode {
             return Err(Error::NotSupported(None));
         }
         if *options.maxDistance <= 0. {
-            return Err(Error::Range("maxDistance should be positive".into()));
+            return Err(Error::Range(c"maxDistance should be positive".into()));
         }
         if *options.refDistance < 0. {
-            return Err(Error::Range("refDistance should be non-negative".into()));
+            return Err(Error::Range(c"refDistance should be non-negative".into()));
         }
         if *options.rolloffFactor < 0. {
-            return Err(Error::Range("rolloffFactor should be non-negative".into()));
+            return Err(Error::Range(c"rolloffFactor should be non-negative".into()));
         }
         if *options.coneOuterGain < 0. || *options.coneOuterGain > 1. {
             return Err(Error::InvalidState(None));
@@ -289,7 +289,7 @@ impl PannerNodeMethods<crate::DomTypeHolder> for PannerNode {
     /// <https://webaudio.github.io/web-audio-api/#dom-pannernode-refdistance>
     fn SetRefDistance(&self, val: Finite<f64>) -> Fallible<()> {
         if *val < 0. {
-            return Err(Error::Range("value should be non-negative".into()));
+            return Err(Error::Range(c"value should be non-negative".into()));
         }
         self.ref_distance.set(*val);
         let msg = PannerNodeMessage::SetRefDistance(self.ref_distance.get());
@@ -304,7 +304,7 @@ impl PannerNodeMethods<crate::DomTypeHolder> for PannerNode {
     /// <https://webaudio.github.io/web-audio-api/#dom-pannernode-maxdistance>
     fn SetMaxDistance(&self, val: Finite<f64>) -> Fallible<()> {
         if *val <= 0. {
-            return Err(Error::Range("value should be positive".into()));
+            return Err(Error::Range(c"value should be positive".into()));
         }
         self.max_distance.set(*val);
         let msg = PannerNodeMessage::SetMaxDistance(self.max_distance.get());
@@ -319,7 +319,7 @@ impl PannerNodeMethods<crate::DomTypeHolder> for PannerNode {
     /// <https://webaudio.github.io/web-audio-api/#dom-pannernode-rollofffactor>
     fn SetRolloffFactor(&self, val: Finite<f64>) -> Fallible<()> {
         if *val < 0. {
-            return Err(Error::Range("value should be non-negative".into()));
+            return Err(Error::Range(c"value should be non-negative".into()));
         }
         self.rolloff_factor.set(*val);
         let msg = PannerNodeMessage::SetRolloff(self.rolloff_factor.get());

--- a/components/script/dom/bindings/buffer_source.rs
+++ b/components/script/dom/bindings/buffer_source.rs
@@ -380,7 +380,7 @@ where
                 }
             }
 
-            Err(Error::Type("can't clone array buffer".to_owned()))
+            Err(Error::Type(c"can't clone array buffer".to_owned()))
         } else {
             Ok(HeapBufferSource::<ArrayBufferU8>::new(
                 BufferSource::ArrayBuffer(RootedTraceableBox::from_box(Heap::boxed(result))),
@@ -668,7 +668,7 @@ where
                 JS_ClearPendingException(*cx)
             };
 
-            Err(Error::Type("can't transfer array buffer".to_owned()))
+            Err(Error::Type(c"can't transfer array buffer".to_owned()))
         } else {
             // Return a new ArrayBuffer object, created in the current Realm,
             // whose [[ArrayBufferData]] internal slot value is arrayBufferData and
@@ -895,7 +895,7 @@ pub(crate) fn create_array_buffer_with_size(
             JS_ClearPendingException(*cx)
         };
 
-        Err(Error::Type("can't create array buffer".to_owned()))
+        Err(Error::Type(c"can't create array buffer".to_owned()))
     } else {
         Ok(HeapBufferSource::<ArrayBufferU8>::new(
             BufferSource::ArrayBuffer(RootedTraceableBox::from_box(Heap::boxed(result))),

--- a/components/script/dom/bindings/constructor.rs
+++ b/components/script/dom/bindings/constructor.rs
@@ -81,7 +81,7 @@ fn html_constructor(
         throw_dom_exception(
             cx.into(),
             global,
-            Error::Type("new.target is null".to_owned()),
+            Error::Type(c"new.target is null".to_owned()),
             CanGc::from_cx(cx),
         );
         return Err(());
@@ -90,7 +90,7 @@ fn html_constructor(
         throw_dom_exception(
             cx.into(),
             global,
-            Error::Type("new.target must not be the active function object".to_owned()),
+            Error::Type(c"new.target must not be the active function object".to_owned()),
             CanGc::from_cx(cx),
         );
         return Err(());
@@ -105,7 +105,7 @@ fn html_constructor(
             throw_dom_exception(
                 cx.into(),
                 global,
-                Error::Type("No custom element definition found for new.target".to_owned()),
+                Error::Type(c"No custom element definition found for new.target".to_owned()),
                 CanGc::from_cx(cx),
             );
             return Err(());
@@ -154,7 +154,7 @@ fn html_constructor(
             throw_dom_exception(
                 cx.into(),
                 global,
-                Error::Type("Custom element does not extend the proper interface".to_owned()),
+                Error::Type(c"Custom element does not extend the proper interface".to_owned()),
                 CanGc::from_cx(cx),
             );
             return Err(());
@@ -247,9 +247,9 @@ fn html_constructor(
         },
         // Step 10
         Some(ConstructionStackEntry::AlreadyConstructedMarker) => {
-            let s = "Top of construction stack marked AlreadyConstructed due to \
+            let s = c"Top of construction stack marked AlreadyConstructed due to \
                      a custom element constructor constructing itself after super()"
-                .to_string();
+                .to_owned();
             throw_dom_exception(cx.into(), global, Error::Type(s), CanGc::from_cx(cx));
             return Err(());
         },

--- a/components/script/dom/bluetooth/bluetooth.rs
+++ b/components/script/dom/bluetooth/bluetooth.rs
@@ -8,6 +8,7 @@ use bluetooth_traits::{BluetoothResponse, BluetoothResponseResult};
 use bluetooth_traits::blocklist::{Blocklist, uuid_is_blocklisted};
 use bluetooth_traits::scanfilter::{BluetoothScanfilter, BluetoothScanfilterSequence};
 use bluetooth_traits::scanfilter::{RequestDeviceoptions, ServiceUUIDSequence};
+use script_bindings::cformat;
 use crate::realms::{AlreadyInRealm, InRealm};
 use crate::conversions::Convert;
 use crate::dom::bindings::cell::{DomRefCell, Ref};
@@ -40,27 +41,29 @@ use js::jsapi::JSObject;
 use js::jsval::{ObjectValue, UndefinedValue};
 use profile_traits::{generic_channel};
 use std::collections::HashMap;
+use std::ffi::CStr;
 use std::rc::Rc;
 use std::sync::{Arc, Mutex};
 
 const KEY_CONVERSION_ERROR: &str =
     "This `manufacturerData` key can not be parsed as unsigned short:";
-const FILTER_EMPTY_ERROR: &str =
-    "'filters' member, if present, must be nonempty to find any devices.";
-const FILTER_ERROR: &str = "A filter must restrict the devices in some way.";
-const MANUFACTURER_DATA_ERROR: &str =
-    "'manufacturerData', if present, must be non-empty to filter devices.";
-const MASK_LENGTH_ERROR: &str = "`mask`, if present, must have the same length as `dataPrefix`.";
+const FILTER_EMPTY_ERROR: &CStr =
+    c"'filters' member, if present, must be nonempty to find any devices.";
+const FILTER_ERROR: &CStr = c"A filter must restrict the devices in some way.";
+const MANUFACTURER_DATA_ERROR: &CStr =
+    c"'manufacturerData', if present, must be non-empty to filter devices.";
+const MASK_LENGTH_ERROR: &CStr = c"`mask`, if present, must have the same length as `dataPrefix`.";
 // 248 is the maximum number of UTF-8 code units in a Bluetooth Device Name.
 const MAX_DEVICE_NAME_LENGTH: usize = 248;
-const NAME_PREFIX_ERROR: &str = "'namePrefix', if present, must be nonempty.";
-const NAME_TOO_LONG_ERROR: &str = "A device name can't be longer than 248 bytes.";
-const SERVICE_DATA_ERROR: &str = "'serviceData', if present, must be non-empty to filter devices.";
-const SERVICE_ERROR: &str = "'services', if present, must contain at least one service.";
-const OPTIONS_ERROR: &str = "Fields of 'options' conflict with each other.
+const NAME_PREFIX_ERROR: &CStr = c"'namePrefix', if present, must be nonempty.";
+const NAME_TOO_LONG_ERROR: &CStr = c"A device name can't be longer than 248 bytes.";
+const SERVICE_DATA_ERROR: &CStr =
+    c"'serviceData', if present, must be non-empty to filter devices.";
+const SERVICE_ERROR: &CStr = c"'services', if present, must contain at least one service.";
+const OPTIONS_ERROR: &CStr = c"Fields of 'options' conflict with each other.
  Either 'acceptAllDevices' member must be true, or 'filters' member must be set to a value.";
-const BT_DESC_CONVERSION_ERROR: &str =
-    "Can't convert to an IDL value of type BluetoothPermissionDescriptor";
+const BT_DESC_CONVERSION_ERROR: &CStr =
+    c"Can't convert to an IDL value of type BluetoothPermissionDescriptor";
 
 #[derive(JSTraceable, MallocSizeOf)]
 #[expect(non_snake_case)]
@@ -428,7 +431,7 @@ fn canonicalize_filter(filter: &BluetoothLEScanFilterInit) -> Fallible<Bluetooth
                 let manufacturer_id = match key.str().parse::<u16>() {
                     Ok(id) => id,
                     Err(err) => {
-                        return Err(Type(format!("{} {} {}", KEY_CONVERSION_ERROR, key, err)));
+                        return Err(Type(cformat!("{} {} {}", KEY_CONVERSION_ERROR, key, err)));
                     },
                 };
 
@@ -521,7 +524,7 @@ fn canonicalize_bluetooth_data_filter_init(
 impl Convert<Error> for BluetoothError {
     fn convert(self) -> Error {
         match self {
-            BluetoothError::Type(message) => Error::Type(message),
+            BluetoothError::Type(message) => Error::Type(cformat!("{message}")),
             BluetoothError::Network => Error::Network(None),
             BluetoothError::NotFound => Error::NotFound(None),
             BluetoothError::NotSupported => Error::NotSupported(None),
@@ -616,7 +619,7 @@ impl AsyncBluetoothListener for Bluetooth {
             BluetoothResponse::GetAvailability(is_available) => {
                 promise.resolve_native(&is_available, can_gc);
             },
-            _ => promise.reject_error(Error::Type("Something went wrong...".to_owned()), can_gc),
+            _ => promise.reject_error(Error::Type(c"Something went wrong...".to_owned()), can_gc),
         }
     }
 }
@@ -636,10 +639,8 @@ impl PermissionAlgorithm for Bluetooth {
             .set(ObjectValue(permission_descriptor_obj));
         match BluetoothPermissionDescriptor::new(cx, property.handle(), can_gc) {
             Ok(ConversionResult::Success(descriptor)) => Ok(descriptor),
-            Ok(ConversionResult::Failure(error)) => Err(Error::Type(
-                String::from_utf8_lossy(error.as_ref().to_bytes()).into_owned(),
-            )),
-            Err(_) => Err(Error::Type(String::from(BT_DESC_CONVERSION_ERROR))),
+            Ok(ConversionResult::Failure(error)) => Err(Error::Type(error.into_owned())),
+            Err(_) => Err(Error::Type(BT_DESC_CONVERSION_ERROR.into())),
         }
     }
 

--- a/components/script/dom/bluetooth/bluetoothdevice.rs
+++ b/components/script/dom/bluetooth/bluetoothdevice.rs
@@ -336,7 +336,7 @@ impl AsyncBluetoothListener for BluetoothDevice {
                 // Step 3.2.
                 promise.resolve_native(&(), can_gc);
             },
-            _ => promise.reject_error(Error::Type("Something went wrong...".to_owned()), can_gc),
+            _ => promise.reject_error(Error::Type(c"Something went wrong...".to_owned()), can_gc),
         }
     }
 }

--- a/components/script/dom/bluetooth/bluetoothpermissionresult.rs
+++ b/components/script/dom/bluetooth/bluetoothpermissionresult.rs
@@ -137,7 +137,7 @@ impl AsyncBluetoothListener for BluetoothPermissionResult {
                 // Step 8.
                 promise.resolve_native(self, can_gc);
             },
-            _ => promise.reject_error(Error::Type("Something went wrong...".to_owned()), can_gc),
+            _ => promise.reject_error(Error::Type(c"Something went wrong...".to_owned()), can_gc),
         }
     }
 }

--- a/components/script/dom/bluetooth/bluetoothremotegattcharacteristic.rs
+++ b/components/script/dom/bluetooth/bluetoothremotegattcharacteristic.rs
@@ -359,7 +359,7 @@ impl AsyncBluetoothListener for BluetoothRemoteGATTCharacteristic {
                 // (StopNotification)  Step 5.
                 promise.resolve_native(self, can_gc);
             },
-            _ => promise.reject_error(Error::Type("Something went wrong...".to_owned()), can_gc),
+            _ => promise.reject_error(Error::Type(c"Something went wrong...".to_owned()), can_gc),
         }
     }
 }

--- a/components/script/dom/bluetooth/bluetoothremotegattdescriptor.rs
+++ b/components/script/dom/bluetooth/bluetoothremotegattdescriptor.rs
@@ -207,7 +207,7 @@ impl AsyncBluetoothListener for BluetoothRemoteGATTDescriptor {
                 // TODO: Resolve promise with undefined instead of a value.
                 promise.resolve_native(&(), can_gc);
             },
-            _ => promise.reject_error(Error::Type("Something went wrong...".to_owned()), can_gc),
+            _ => promise.reject_error(Error::Type(c"Something went wrong...".to_owned()), can_gc),
         }
     }
 }

--- a/components/script/dom/bluetooth/bluetoothremotegattserver.rs
+++ b/components/script/dom/bluetooth/bluetoothremotegattserver.rs
@@ -183,7 +183,7 @@ impl AsyncBluetoothListener for BluetoothRemoteGATTServer {
                 }
                 promise.resolve_native(&services, can_gc);
             },
-            _ => promise.reject_error(Error::Type("Something went wrong...".to_owned()), can_gc),
+            _ => promise.reject_error(Error::Type(c"Something went wrong...".to_owned()), can_gc),
         }
     }
 }

--- a/components/script/dom/bluetooth/bluetoothremotegattservice.rs
+++ b/components/script/dom/bluetooth/bluetoothremotegattservice.rs
@@ -207,7 +207,7 @@ impl AsyncBluetoothListener for BluetoothRemoteGATTService {
                 }
                 promise.resolve_native(&services, can_gc);
             },
-            _ => promise.reject_error(Error::Type("Something went wrong...".to_owned()), can_gc),
+            _ => promise.reject_error(Error::Type(c"Something went wrong...".to_owned()), can_gc),
         }
     }
 }

--- a/components/script/dom/bluetooth/bluetoothuuid.rs
+++ b/components/script/dom/bluetooth/bluetoothuuid.rs
@@ -4,6 +4,7 @@
 
 use dom_struct::dom_struct;
 use regex::Regex;
+use script_bindings::cformat;
 
 use crate::dom::bindings::codegen::Bindings::BluetoothUUIDBinding::BluetoothUUIDMethods;
 use crate::dom::bindings::codegen::UnionTypes::StringOrUnsignedLong;
@@ -656,9 +657,12 @@ fn resolve_uuid_name(
                             _ => unreachable!(),
                         };
                         // Step 4.
-                        Err(Type(format!(
+                        Err(Type(cformat!(
                             "Invalid {} name : '{}'.\n{} {}",
-                            attribute_type, dstring, UUID_ERROR_MESSAGE, error_url_message
+                            attribute_type,
+                            dstring,
+                            UUID_ERROR_MESSAGE,
+                            error_url_message
                         )))
                     },
                 }

--- a/components/script/dom/canvas/imagebitmap.rs
+++ b/components/script/dom/canvas/imagebitmap.rs
@@ -292,7 +292,7 @@ impl ImageBitmap {
         // Step 1. If either sw or sh is given and is 0, then return a promise rejected with a RangeError.
         if sw.is_some_and(|w| w == 0) {
             p.reject_error(
-                Error::Range("'sw' must be a non-zero value".to_owned()),
+                Error::Range(c"'sw' must be a non-zero value".to_owned()),
                 can_gc,
             );
             return p;
@@ -300,7 +300,7 @@ impl ImageBitmap {
 
         if sh.is_some_and(|h| h == 0) {
             p.reject_error(
-                Error::Range("'sh' must be a non-zero value".to_owned()),
+                Error::Range(c"'sh' must be a non-zero value".to_owned()),
                 can_gc,
             );
             return p;

--- a/components/script/dom/canvas/imagedata.rs
+++ b/components/script/dom/canvas/imagedata.rs
@@ -55,7 +55,7 @@ impl ImageData {
         let len =
             pixels::compute_rgba8_byte_length_if_within_limit(width as usize, height as usize)
                 .ok_or(Error::Range(
-                    "The requested image size exceeds the supported range".to_owned(),
+                    c"The requested image size exceeds the supported range".to_owned(),
                 ))?;
 
         let settings = ImageDataSettings {

--- a/components/script/dom/canvas/offscreencanvas.rs
+++ b/components/script/dom/canvas/offscreencanvas.rs
@@ -311,9 +311,7 @@ impl OffscreenCanvasMethods<crate::DomTypeHolder> for OffscreenCanvas {
         "webgl2" | "experimental-webgl2" => self
             .get_or_init_webgl2_context(cx, options)
             .map(OffscreenRenderingContext::WebGL2RenderingContext),*/
-            _ => Err(Error::Type(String::from(
-                "Unrecognized OffscreenCanvas context type",
-            ))),
+            _ => Err(Error::Type(c"Unrecognized OffscreenCanvas context type".to_owned())),
         )
     }
 

--- a/components/script/dom/clipboarditem.rs
+++ b/components/script/dom/clipboarditem.rs
@@ -149,7 +149,7 @@ impl ClipboardItemMethods<crate::DomTypeHolder> for ClipboardItem {
     ) -> Fallible<DomRoot<ClipboardItem>> {
         // Step 1 If items is empty, then throw a TypeError.
         if items.is_empty() {
-            return Err(Error::Type(String::from("No item provided")));
+            return Err(Error::Type(c"No item provided".to_owned()));
         }
 
         // Step 2 If options is empty, then set options["presentationStyle"] = "unspecified".
@@ -177,7 +177,7 @@ impl ClipboardItemMethods<crate::DomTypeHolder> for ClipboardItem {
             // Step 6.5 Let mimeType be the result of parsing a MIME type given key.
             // Step 6.6 If mimeType is failure, then throw a TypeError.
             let mime_type =
-                Mime::from_str(key).map_err(|_| Error::Type(String::from("Invalid mime type")))?;
+                Mime::from_str(key).map_err(|_| Error::Type(c"Invalid mime type".to_owned()))?;
 
             // Step 6.7 If this's clipboard item's list of representations contains a representation
             // whose MIME type is mimeType and whose [representation/isCustom] is isCustom, then throw a TypeError.
@@ -189,7 +189,7 @@ impl ClipboardItemMethods<crate::DomTypeHolder> for ClipboardItem {
                     representation.mime_type == mime_type && representation.is_custom == is_custom
                 })
             {
-                return Err(Error::Type(String::from("Tried to add a duplicate mime")));
+                return Err(Error::Type(c"Tried to add a duplicate mime".to_owned()));
             }
 
             // Step 6.1 Let representation be a new representation.
@@ -270,7 +270,7 @@ impl ClipboardItemMethods<crate::DomTypeHolder> for ClipboardItem {
         // Step 4 Let mimeType be the result of parsing a MIME type given type.
         // Step 5 If mimeType is failure, then throw a TypeError.
         let mime_type =
-            Mime::from_str(type_).map_err(|_| Error::Type(String::from("Invalid mime type")))?;
+            Mime::from_str(type_).map_err(|_| Error::Type(c"Invalid mime type".to_owned()))?;
 
         // Step 6 Let itemTypeList be this’s clipboard item’s list of representations.
         let item_type_list = self.representations.borrow();

--- a/components/script/dom/cookiestore.rs
+++ b/components/script/dom/cookiestore.rs
@@ -250,7 +250,7 @@ impl CookieStoreMethods<crate::DomTypeHolder> for CookieStore {
         // 5. If options is empty, then return a promise rejected with a TypeError.
         // "is empty" is not strictly defined anywhere in the spec but the only value we require here is "url"
         if options.url.is_none() && options.name.is_none() {
-            p.reject_error(Error::Type("Options cannot be empty".to_string()), can_gc);
+            p.reject_error(Error::Type(c"Options cannot be empty".to_owned()), can_gc);
             return p;
         }
 
@@ -269,7 +269,7 @@ impl CookieStoreMethods<crate::DomTypeHolder> for CookieStore {
                     .is_ok_and(|parsed| !parsed.is_equal_excluding_fragments(&creation_url))
                 {
                     p.reject_error(
-                        Error::Type("URL does not match context".to_string()),
+                        Error::Type(c"URL does not match context".to_owned()),
                         can_gc,
                     );
                     return p;
@@ -282,7 +282,7 @@ impl CookieStoreMethods<crate::DomTypeHolder> for CookieStore {
                 .as_ref()
                 .is_ok_and(|parsed| creation_url.origin() != parsed.origin())
             {
-                p.reject_error(Error::Type("Not same origin".to_string()), can_gc);
+                p.reject_error(Error::Type(c"Not same origin".to_owned()), can_gc);
                 return p;
             }
 
@@ -386,7 +386,7 @@ impl CookieStoreMethods<crate::DomTypeHolder> for CookieStore {
                     .is_ok_and(|parsed| !parsed.is_equal_excluding_fragments(&creation_url))
                 {
                     p.reject_error(
-                        Error::Type("URL does not match context".to_string()),
+                        Error::Type(c"URL does not match context".to_owned()),
                         can_gc,
                     );
                     return p;
@@ -399,7 +399,7 @@ impl CookieStoreMethods<crate::DomTypeHolder> for CookieStore {
                 .as_ref()
                 .is_ok_and(|parsed| creation_url.origin() != parsed.origin())
             {
-                p.reject_error(Error::Type("Not same origin".to_string()), can_gc);
+                p.reject_error(Error::Type(c"Not same origin".to_owned()), can_gc);
                 return p;
             }
 
@@ -458,7 +458,7 @@ impl CookieStoreMethods<crate::DomTypeHolder> for CookieStore {
         let creation_url = global.creation_url();
         let Some(cookie) = CookieStore::set_a_cookie(&creation_url, &properties) else {
             // If r is failure, then reject p with a TypeError and abort these steps.
-            p.reject_error(Error::Type(String::from("Invalid cookie")), can_gc);
+            p.reject_error(Error::Type(c"Invalid cookie".to_owned()), can_gc);
             return p;
         };
 
@@ -505,7 +505,7 @@ impl CookieStoreMethods<crate::DomTypeHolder> for CookieStore {
         // 6.1. Let r be the result of running set a cookie with url, options["name"], options["value"],
         // options["expires"], options["domain"], options["path"], options["sameSite"], and options["partitioned"].
         let Some(cookie) = CookieStore::set_a_cookie(&creation_url, options) else {
-            p.reject_error(Error::Type(String::from("Invalid cookie")), can_gc);
+            p.reject_error(Error::Type(c"Invalid cookie".to_owned()), can_gc);
             return p;
         };
 

--- a/components/script/dom/customelementregistry.rs
+++ b/components/script/dom/customelementregistry.rs
@@ -188,7 +188,7 @@ impl CustomElementRegistry {
             // Step 10.2
             if !prototype.is_object() {
                 return Err(Error::Type(
-                    "constructor.prototype is not an object".to_owned(),
+                    c"constructor.prototype is not an object".to_owned(),
                 ));
             }
         }
@@ -267,9 +267,7 @@ impl CustomElementRegistry {
         );
         match conversion {
             Ok(ConversionResult::Success(attributes)) => Ok(attributes),
-            Ok(ConversionResult::Failure(error)) => Err(Error::Type(
-                String::from_utf8_lossy(error.as_ref().to_bytes()).into_owned(),
-            )),
+            Ok(ConversionResult::Failure(error)) => Err(Error::Type(error.into_owned())),
             _ => Err(Error::JSFailed),
         }
     }
@@ -307,9 +305,7 @@ impl CustomElementRegistry {
         );
         match conversion {
             Ok(ConversionResult::Success(flag)) => Ok(flag),
-            Ok(ConversionResult::Failure(error)) => Err(Error::Type(
-                String::from_utf8_lossy(error.as_ref().to_bytes()).into_owned(),
-            )),
+            Ok(ConversionResult::Failure(error)) => Err(Error::Type(error.into_owned())),
             _ => Err(Error::JSFailed),
         }
     }
@@ -347,9 +343,7 @@ impl CustomElementRegistry {
         );
         match conversion {
             Ok(ConversionResult::Success(attributes)) => Ok(attributes),
-            Ok(ConversionResult::Failure(error)) => Err(Error::Type(
-                String::from_utf8_lossy(error.as_ref().to_bytes()).into_owned(),
-            )),
+            Ok(ConversionResult::Failure(error)) => Err(Error::Type(error.into_owned())),
             _ => Err(Error::JSFailed),
         }
     }
@@ -378,7 +372,9 @@ fn get_callback(
         // Step 10.4.2
         if !callback.is_undefined() {
             if !callback.is_object() || !IsCallable(callback.to_object()) {
-                return Err(Error::Type("Lifecycle callback is not callable".to_owned()));
+                return Err(Error::Type(
+                    c"Lifecycle callback is not callable".to_owned(),
+                ));
             }
             Ok(Some(Function::new(cx, callback.to_object())))
         } else {
@@ -412,7 +408,7 @@ impl CustomElementRegistryMethods<crate::DomTypeHolder> for CustomElementRegistr
 
         if unsafe { !IsConstructor(unwrapped_constructor.get()) } {
             return Err(Error::Type(
-                "Second argument of CustomElementRegistry.define is not a constructor".to_owned(),
+                c"Second argument of CustomElementRegistry.define is not a constructor".to_owned(),
             ));
         }
 
@@ -810,7 +806,7 @@ impl CustomElementDefinition {
                 Ok(ConversionResult::Success(element)) => element,
                 Ok(ConversionResult::Failure(..)) => {
                     return Err(Error::Type(
-                        "Constructor did not return a DOM node".to_owned(),
+                        c"Constructor did not return a DOM node".to_owned(),
                     ));
                 },
                 _ => return Err(Error::JSFailed),
@@ -1028,7 +1024,7 @@ fn run_upgrade_constructor(
         }
         if !same {
             return Err(Error::Type(
-                "Returned element is not SameValue as the upgraded element".to_string(),
+                c"Returned element is not SameValue as the upgraded element".to_owned(),
             ));
         }
     }

--- a/components/script/dom/document.rs
+++ b/components/script/dom/document.rs
@@ -4369,7 +4369,7 @@ impl Document {
         // > If pendingDoc is not fully active, then reject promise with a TypeError exception and return promise.
         if !self.is_fully_active() {
             promise.reject_error(
-                Error::Type("Document is not fully active".to_owned()),
+                Error::Type(c"Document is not fully active".to_owned()),
                 can_gc,
             );
             return promise;
@@ -4485,7 +4485,7 @@ impl Document {
         if !self.is_fully_active() || self.fullscreen_element.get().is_none() {
             promise.reject_error(
                 Error::Type(
-                    "No fullscreen element to exit or document is not fully active".to_owned(),
+                    c"No fullscreen element to exit or document is not fully active".to_owned(),
                 ),
                 can_gc,
             );

--- a/components/script/dom/documentorshadowroot.rs
+++ b/components/script/dom/documentorshadowroot.rs
@@ -446,11 +446,9 @@ impl DocumentOrShadowRoot {
                     owner,
                 )
             },
-            Ok(ConversionResult::Failure(msg)) => Err(Error::Type(
-                String::from_utf8_lossy(msg.as_ref().to_bytes()).into_owned(),
-            )),
+            Ok(ConversionResult::Failure(msg)) => Err(Error::Type(msg.into_owned())),
             Err(_) => Err(Error::Type(
-                "The provided value is not a sequence of 'CSSStylesheet'.".to_owned(),
+                c"The provided value is not a sequence of 'CSSStylesheet'.".to_owned(),
             )),
         }
     }

--- a/components/script/dom/dommatrix.rs
+++ b/components/script/dom/dommatrix.rs
@@ -93,7 +93,7 @@ impl DOMMatrixMethods<crate::DomTypeHolder> for DOMMatrix {
             StringOrUnrestrictedDoubleSequence::String(ref s) => {
                 if !global.is::<Window>() {
                     return Err(error::Error::Type(
-                        "String constructor is only supported in the main thread.".to_owned(),
+                        c"String constructor is only supported in the main thread.".to_owned(),
                     ));
                 }
                 if s.is_empty() {

--- a/components/script/dom/dommatrixreadonly.rs
+++ b/components/script/dom/dommatrixreadonly.rs
@@ -17,6 +17,7 @@ use js::jsval;
 use js::rust::{CustomAutoRooterGuard, HandleObject, ToString};
 use js::typedarray::{Float32Array, Float64Array, HeapFloat32Array, HeapFloat64Array};
 use rustc_hash::FxHashMap;
+use script_bindings::cformat;
 use script_bindings::trace::RootedTraceableBox;
 use style::stylesheets::CssRuleType;
 use style_traits::ParsingMode;
@@ -493,7 +494,7 @@ impl DOMMatrixReadOnlyMethods<crate::DomTypeHolder> for DOMMatrixReadOnly {
             StringOrUnrestrictedDoubleSequence::String(ref s) => {
                 if !global.is::<Window>() {
                     return Err(error::Error::Type(
-                        "String constructor is only supported in the main thread.".to_owned(),
+                        c"String constructor is only supported in the main thread.".to_owned(),
                     ));
                 }
                 if s.is_empty() {
@@ -1051,8 +1052,8 @@ pub(crate) fn entries_to_matrix(entries: &[f64]) -> Fallible<(bool, Transform3D<
     } else if let Ok(array) = entries.try_into() {
         Ok((false, Transform3D::from_array(array)))
     } else {
-        let err_msg = format!("Expected 6 or 16 entries, but found {}.", entries.len());
-        Err(error::Error::Type(err_msg.to_owned()))
+        let err_msg = cformat!("Expected 6 or 16 entries, but found {}.", entries.len());
+        Err(error::Error::Type(err_msg))
     }
 }
 
@@ -1083,7 +1084,7 @@ fn validate_and_fixup_2d(dict: &DOMMatrix2DInit) -> Fallible<Transform2D<f64>> {
             !same_value_zero(dict.f.unwrap(), dict.m42.unwrap())
     {
         return Err(error::Error::Type(
-            "Property mismatch on matrix initialization.".to_owned(),
+            c"Property mismatch on matrix initialization.".to_owned(),
         ));
     }
 
@@ -1136,7 +1137,7 @@ fn validate_and_fixup(dict: &DOMMatrixInit) -> Fallible<(bool, Transform3D<f64>)
             dict.m44 != 1.0)
     {
         return Err(error::Error::Type(
-            "The is2D member is set to true but the input matrix is a 3d matrix.".to_owned(),
+            c"The is2D member is set to true but the input matrix is a 3d matrix.".to_owned(),
         ));
     }
 

--- a/components/script/dom/domtokenlist.rs
+++ b/components/script/dom/domtokenlist.rs
@@ -88,7 +88,7 @@ impl DOMTokenList {
     fn validation_steps(&self, token: &str) -> Fallible<bool> {
         match &self.supported_tokens {
             None => Err(Error::Type(
-                "This attribute has no supported tokens".to_owned(),
+                c"This attribute has no supported tokens".to_owned(),
             )),
             Some(supported_tokens) => {
                 let token = Atom::from(token).to_ascii_lowercase();

--- a/components/script/dom/element.rs
+++ b/components/script/dom/element.rs
@@ -5502,7 +5502,7 @@ impl TaskOnce for ElementPerformFullscreenEnter {
                 .upcast::<EventTarget>()
                 .fire_event(atom!("fullscreenerror"), CanGc::from_cx(cx));
             promise.reject_error(
-                Error::Type(String::from("fullscreen is not connected")),
+                Error::Type(c"fullscreen is not connected".to_owned()),
                 CanGc::from_cx(cx),
             );
             return;

--- a/components/script/dom/elementinternals.rs
+++ b/components/script/dom/elementinternals.rs
@@ -263,8 +263,8 @@ impl ElementInternalsMethods<crate::DomTypeHolder> for ElementInternals {
         let bits: ValidationFlags = flags.into();
         if !bits.is_empty() && !message.as_ref().map_or_else(|| false, |m| !m.is_empty()) {
             return Err(Error::Type(
-                "Setting an element to invalid requires a message string as the second argument."
-                    .to_string(),
+                c"Setting an element to invalid requires a message string as the second argument."
+                    .to_owned(),
             ));
         }
 

--- a/components/script/dom/formdata.rs
+++ b/components/script/dom/formdata.rs
@@ -96,12 +96,12 @@ impl FormDataMethods<crate::DomTypeHolder> for FormData {
                         .map(FormSubmitterElement::Input)
                 })
                 .ok_or(Error::Type(
-                    "submitter is not a form submitter element".to_string(),
+                    c"submitter is not a form submitter element".to_owned(),
                 ))?;
 
             // Step 1.1.1. If submitter is not a submit button, then throw a TypeError.
             if !submit_button.is_submit_button() {
-                return Err(Error::Type("submitter is not a submit button".to_string()));
+                return Err(Error::Type(c"submitter is not a submit button".to_owned()));
             }
 
             // Step 1.1.2. If submitter’s form owner is not form, then throw a "NotFoundError"

--- a/components/script/dom/gamepad/gamepadhapticactuator.rs
+++ b/components/script/dom/gamepad/gamepadhapticactuator.rs
@@ -136,7 +136,7 @@ impl GamepadHapticActuatorMethods<crate::DomTypeHolder> for GamepadHapticActuato
                 if *params.strongMagnitude < 0.0 || *params.strongMagnitude > 1.0 {
                     playing_effect_promise.reject_error(
                         Error::Type(
-                            "Strong magnitude value is not within range of 0.0 to 1.0.".to_string(),
+                            c"Strong magnitude value is not within range of 0.0 to 1.0.".to_owned(),
                         ),
                         can_gc,
                     );
@@ -144,7 +144,7 @@ impl GamepadHapticActuatorMethods<crate::DomTypeHolder> for GamepadHapticActuato
                 } else if *params.weakMagnitude < 0.0 || *params.weakMagnitude > 1.0 {
                     playing_effect_promise.reject_error(
                         Error::Type(
-                            "Weak magnitude value is not within range of 0.0 to 1.0.".to_string(),
+                            c"Weak magnitude value is not within range of 0.0 to 1.0.".to_owned(),
                         ),
                         can_gc,
                     );
@@ -156,7 +156,7 @@ impl GamepadHapticActuatorMethods<crate::DomTypeHolder> for GamepadHapticActuato
                 if *params.strongMagnitude < 0.0 || *params.strongMagnitude > 1.0 {
                     playing_effect_promise.reject_error(
                         Error::Type(
-                            "Strong magnitude value is not within range of 0.0 to 1.0.".to_string(),
+                            c"Strong magnitude value is not within range of 0.0 to 1.0.".to_owned(),
                         ),
                         can_gc,
                     );
@@ -164,7 +164,7 @@ impl GamepadHapticActuatorMethods<crate::DomTypeHolder> for GamepadHapticActuato
                 } else if *params.weakMagnitude < 0.0 || *params.weakMagnitude > 1.0 {
                     playing_effect_promise.reject_error(
                         Error::Type(
-                            "Weak magnitude value is not within range of 0.0 to 1.0.".to_string(),
+                            c"Weak magnitude value is not within range of 0.0 to 1.0.".to_owned(),
                         ),
                         can_gc,
                     );
@@ -172,7 +172,7 @@ impl GamepadHapticActuatorMethods<crate::DomTypeHolder> for GamepadHapticActuato
                 } else if *params.leftTrigger < 0.0 || *params.leftTrigger > 1.0 {
                     playing_effect_promise.reject_error(
                         Error::Type(
-                            "Left trigger value is not within range of 0.0 to 1.0.".to_string(),
+                            c"Left trigger value is not within range of 0.0 to 1.0.".to_owned(),
                         ),
                         can_gc,
                     );
@@ -180,7 +180,7 @@ impl GamepadHapticActuatorMethods<crate::DomTypeHolder> for GamepadHapticActuato
                 } else if *params.rightTrigger < 0.0 || *params.rightTrigger > 1.0 {
                     playing_effect_promise.reject_error(
                         Error::Type(
-                            "Right trigger value is not within range of 0.0 to 1.0.".to_string(),
+                            c"Right trigger value is not within range of 0.0 to 1.0.".to_owned(),
                         ),
                         can_gc,
                     );

--- a/components/script/dom/geolocation/geolocation.rs
+++ b/components/script/dom/geolocation/geolocation.rs
@@ -41,13 +41,13 @@ fn cast_error_callback(
                     error_callback,
                 )))
             } else {
-                Err(Error::Type("Value is not callable.".to_string()))
+                Err(Error::Type(c"Value is not callable.".to_owned()))
             }
         }
     } else if error_callback.get().is_null_or_undefined() {
         Ok(None)
     } else {
-        Err(Error::Type("Value is not an object.".to_string()))
+        Err(Error::Type(c"Value is not an object.".to_owned()))
     }
 }
 

--- a/components/script/dom/headers.rs
+++ b/components/script/dom/headers.rs
@@ -14,6 +14,7 @@ use net_traits::fetch::headers::{
 };
 use net_traits::request::is_cors_safelisted_request_header;
 use net_traits::trim_http_whitespace;
+use script_bindings::cformat;
 
 use crate::dom::bindings::cell::DomRefCell;
 use crate::dom::bindings::codegen::Bindings::HeadersBinding::{HeadersInit, HeadersMethods};
@@ -268,7 +269,7 @@ impl Headers {
                         let name = seq.pop().unwrap();
                         self.Append(name, val)?;
                     } else {
-                        return Err(Error::Type(format!(
+                        return Err(Error::Type(cformat!(
                             "Each header object must be a sequence of length 2 - found one with length {}",
                             seq.len()
                         )));
@@ -354,11 +355,11 @@ impl Headers {
         // 1. If name is not a header name or value is not a header value, then throw a TypeError.
         let valid_name = validate_name(name)?;
         if !is_legal_header_value(&value) {
-            return Err(Error::Type("Header value is not valid".to_string()));
+            return Err(Error::Type(c"Header value is not valid".to_owned()));
         }
         // 2. If headers’s guard is "immutable", then throw a TypeError.
         if self.guard.get() == Guard::Immutable {
-            return Err(Error::Type("Guard is immutable".to_string()));
+            return Err(Error::Type(c"Guard is immutable".to_owned()));
         }
         // 3. If headers’s guard is "request" and (name, value) is a forbidden request-header, then return false.
         if self.guard.get() == Guard::Request && is_forbidden_request_header(&valid_name, &value) {
@@ -480,11 +481,11 @@ fn is_forbidden_response_header(name: &str) -> bool {
 
 fn validate_name(name: ByteString) -> Fallible<String> {
     if !is_field_name(&name) {
-        return Err(Error::Type("Name is not valid".to_string()));
+        return Err(Error::Type(c"Name is not valid".to_owned()));
     }
     match String::from_utf8(name.into()) {
         Ok(ns) => Ok(ns),
-        _ => Err(Error::Type("Non-UTF8 header name found".to_string())),
+        _ => Err(Error::Type(c"Non-UTF8 header name found".to_owned())),
     }
 }
 

--- a/components/script/dom/html/htmlformelement.rs
+++ b/components/script/dom/html/htmlformelement.rs
@@ -303,7 +303,7 @@ impl HTMLFormElementMethods<crate::DomTypeHolder> for HTMLFormElement {
             Some(submitter_element) => {
                 // Step 1.1
                 let error_not_a_submit_button =
-                    Err(Error::Type("submitter must be a submit button".to_string()));
+                    Err(Error::Type(c"submitter must be a submit button".to_owned()));
 
                 let element = match submitter_element.upcast::<Node>().type_id() {
                     NodeTypeId::Element(ElementTypeId::HTMLElement(element)) => element,

--- a/components/script/dom/html/htmlinputelement.rs
+++ b/components/script/dom/html/htmlinputelement.rs
@@ -1826,7 +1826,7 @@ impl HTMLInputElementMethods<crate::DomTypeHolder> for HTMLInputElement {
                 return Err(Error::JSFailed);
             }
             if !isDate {
-                return Err(Error::Type("Value was not a date".to_string()));
+                return Err(Error::Type(c"Value was not a date".to_owned()));
             }
             if !DateGetMsecSinceEpoch(*cx, Handle::from(value.handle()), &mut msecs) {
                 return Err(Error::JSFailed);
@@ -1851,7 +1851,7 @@ impl HTMLInputElementMethods<crate::DomTypeHolder> for HTMLInputElement {
     /// <https://html.spec.whatwg.org/multipage/#dom-input-valueasnumber>
     fn SetValueAsNumber(&self, value: f64, can_gc: CanGc) -> ErrorResult {
         if value.is_infinite() {
-            Err(Error::Type("value is not finite".to_string()))
+            Err(Error::Type(c"value is not finite".to_owned()))
         } else if !self.does_value_as_number_apply() {
             Err(Error::InvalidState(None))
         } else if value.is_nan() {

--- a/components/script/dom/indexeddb/idbfactory.rs
+++ b/components/script/dom/indexeddb/idbfactory.rs
@@ -339,7 +339,7 @@ impl IDBFactoryMethods<crate::DomTypeHolder> for IDBFactory {
         // Step 1: If version is 0 (zero), throw a TypeError.
         if version == Some(0) {
             return Err(Error::Type(
-                "The version must be an integer >= 1".to_owned(),
+                c"The version must be an integer >= 1".to_owned(),
             ));
         };
 

--- a/components/script/dom/intersectionobserver.rs
+++ b/components/script/dom/intersectionobserver.rs
@@ -196,7 +196,7 @@ impl IntersectionObserver {
         for num in &thresholds {
             if **num < 0.0 || **num > 1.0 {
                 return Err(Error::Range(
-                    "Value in thresholds should not be less than 0.0 or greater than 1.0"
+                    c"Value in thresholds should not be less than 0.0 or greater than 1.0"
                         .to_owned(),
                 ));
             }

--- a/components/script/dom/media/mediasession.rs
+++ b/components/script/dom/media/mediasession.rs
@@ -214,19 +214,19 @@ impl MediaSessionMethods<crate::DomTypeHolder> for MediaSession {
         let duration = if let Some(state_duration) = state.duration {
             // If state’s duration is negative or NaN, throw a TypeError.
             if state_duration < 0.0 || state_duration.is_nan() {
-                return Err(Error::Type("Duration is negative or NaN".to_owned()));
+                return Err(Error::Type(c"Duration is negative or NaN".to_owned()));
             }
             state_duration
         } else {
             // If state’s duration is not present, throw a TypeError.
-            return Err(Error::Type("Duration is not present".to_owned()));
+            return Err(Error::Type(c"Duration is not present".to_owned()));
         };
 
         let position = if let Some(state_position) = state.position {
             // If state’s position is negative or greater than duration, throw a TypeError.
             if *state_position < 0.0 || *state_position > duration {
                 return Err(Error::Type(
-                    "Position is negative or greater than duration".to_owned(),
+                    c"Position is negative or greater than duration".to_owned(),
                 ));
             }
             *state_position
@@ -238,7 +238,7 @@ impl MediaSessionMethods<crate::DomTypeHolder> for MediaSession {
         let playback_rate = if let Some(state_playback_rate) = state.playbackRate {
             // If state’s playbackRate is zero, throw a TypeError.
             if *state_playback_rate == 0.0 {
-                return Err(Error::Type("Playback rate is zero".to_owned()));
+                return Err(Error::Type(c"Playback rate is zero".to_owned()));
             }
             *state_playback_rate
         } else {

--- a/components/script/dom/mutationobserver.rs
+++ b/components/script/dom/mutationobserver.rs
@@ -288,28 +288,28 @@ impl MutationObserverMethods<crate::DomTypeHolder> for MutationObserver {
         // Step 3
         if !child_list && !attributes && !character_data {
             return Err(Error::Type(
-                "One of childList, attributes, or characterData must be true".into(),
+                c"One of childList, attributes, or characterData must be true".into(),
             ));
         }
 
         // Step 4
         if attribute_old_value && !attributes {
             return Err(Error::Type(
-                "attributeOldValue is true but attributes is false".into(),
+                c"attributeOldValue is true but attributes is false".into(),
             ));
         }
 
         // Step 5
         if options.attributeFilter.is_some() && !attributes {
             return Err(Error::Type(
-                "attributeFilter is present but attributes is false".into(),
+                c"attributeFilter is present but attributes is false".into(),
             ));
         }
 
         // Step 6
         if character_data_old_value && !character_data {
             return Err(Error::Type(
-                "characterDataOldValue is true but characterData is false".into(),
+                c"characterDataOldValue is true but characterData is false".into(),
             ));
         }
 

--- a/components/script/dom/navigator.rs
+++ b/components/script/dom/navigator.rs
@@ -484,10 +484,10 @@ impl NavigatorMethods<crate::DomTypeHolder> for Navigator {
         // If the algorithm returns an error, or if parsedUrl's scheme is not "http" or "https",
         // throw a "TypeError" exception and terminate these steps.
         let Ok(url) = ServoUrl::parse_with_base(Some(&base), &url) else {
-            return Err(Error::Type("Cannot parse URL".to_owned()));
+            return Err(Error::Type(c"Cannot parse URL".to_owned()));
         };
         if !matches!(url.scheme(), "http" | "https") {
-            return Err(Error::Type("URL is not http(s)".to_owned()));
+            return Err(Error::Type(c"URL is not http(s)".to_owned()));
         }
         let mut request_body = None;
         // Step 4. Let headerList be an empty list.

--- a/components/script/dom/notification.rs
+++ b/components/script/dom/notification.rs
@@ -358,14 +358,14 @@ impl NotificationMethods<crate::DomTypeHolder> for Notification {
         // step 1: Check global is a ServiceWorkerGlobalScope
         if global.is::<ServiceWorkerGlobalScope>() {
             return Err(Error::Type(
-                "Notification constructor cannot be used in service worker.".to_string(),
+                c"Notification constructor cannot be used in service worker.".to_owned(),
             ));
         }
 
         // step 2: Check options.actions must be empty
         if !options.actions.is_empty() {
             return Err(Error::Type(
-                "Actions are only supported for persistent notifications.".to_string(),
+                c"Actions are only supported for persistent notifications.".to_owned(),
             ));
         }
 
@@ -617,13 +617,13 @@ fn create_notification(
     // If options["silent"] is true and options["vibrate"] exists, then throw a TypeError.
     if options.silent.is_some() && options.vibrate.is_some() {
         return Err(Error::Type(
-            "Can't specify vibration patterns when setting notification to silent.".to_string(),
+            c"Can't specify vibration patterns when setting notification to silent.".to_owned(),
         ));
     }
     // If options["renotify"] is true and options["tag"] is the empty string, then throw a TypeError.
     if options.renotify && options.tag.is_empty() {
         return Err(Error::Type(
-            "tag must be set to renotify as an existing notification.".to_string(),
+            c"tag must be set to renotify as an existing notification.".to_owned(),
         ));
     }
 

--- a/components/script/dom/origin.rs
+++ b/components/script/dom/origin.rs
@@ -130,7 +130,7 @@ impl OriginMethods<crate::DomTypeHolder> for Origin {
                 can_gc,
             ) {
                 Ok(ConversionResult::Success(s)) => s,
-                _ => return Err(Error::Type("Failed to convert value to string".to_string())),
+                _ => return Err(Error::Type(c"Failed to convert value to string".to_owned())),
             };
 
             // Step 2.1. Let parsedURL be the result of basic URL parsing value.
@@ -138,13 +138,13 @@ impl OriginMethods<crate::DomTypeHolder> for Origin {
             //           origin is set to parsedURL's origin.
             match ServoUrl::parse(&s.to_string()) {
                 Ok(url) => return Ok(Origin::new(global, None, url.origin(), can_gc)),
-                Err(_) => return Err(Error::Type("Failed to parse URL".to_string())),
+                Err(_) => return Err(Error::Type(c"Failed to parse URL".to_owned())),
             }
         }
 
         // Step 3. Throw a TypeError.
         Err(Error::Type(
-            "Value must be a string or a platform object with an origin".to_string(),
+            c"Value must be a string or a platform object with an origin".to_owned(),
         ))
     }
 

--- a/components/script/dom/paintworkletglobalscope.rs
+++ b/components/script/dom/paintworkletglobalscope.rs
@@ -506,7 +506,7 @@ impl PaintWorkletGlobalScopeMethods<crate::DomTypeHolder> for PaintWorkletGlobal
 
         // Step 1.
         if name.is_empty() {
-            return Err(Error::Type(String::from("Empty paint name.")));
+            return Err(Error::Type(c"Empty paint name.".to_owned()));
         }
 
         // Step 2-3.
@@ -530,14 +530,14 @@ impl PaintWorkletGlobalScopeMethods<crate::DomTypeHolder> for PaintWorkletGlobal
 
         // Step 14
         if unsafe { !IsConstructor(paint_obj.get()) } {
-            return Err(Error::Type(String::from("Not a constructor.")));
+            return Err(Error::Type(c"Not a constructor.".to_owned()));
         }
 
         // Steps 15-16
         rooted!(in(*cx) let mut prototype = UndefinedValue());
         get_property_jsval(cx, paint_obj.handle(), c"prototype", prototype.handle_mut())?;
         if !prototype.is_object() {
-            return Err(Error::Type(String::from("Prototype is not an object.")));
+            return Err(Error::Type(c"Prototype is not an object.".to_owned()));
         }
         rooted!(in(*cx) let prototype = prototype.to_object());
 
@@ -550,7 +550,7 @@ impl PaintWorkletGlobalScopeMethods<crate::DomTypeHolder> for PaintWorkletGlobal
             paint_function.handle_mut(),
         )?;
         if !paint_function.is_object() || unsafe { !IsCallable(paint_function.to_object()) } {
-            return Err(Error::Type(String::from("Paint function is not callable.")));
+            return Err(Error::Type(c"Paint function is not callable.".to_owned()));
         }
 
         // Step 19.

--- a/components/script/dom/permissions.rs
+++ b/components/script/dom/permissions.rs
@@ -231,9 +231,7 @@ impl PermissionAlgorithm for Permissions {
             .set(ObjectValue(permission_descriptor_obj));
         match PermissionDescriptor::new(cx, property.handle(), can_gc) {
             Ok(ConversionResult::Success(descriptor)) => Ok(descriptor),
-            Ok(ConversionResult::Failure(error)) => Err(Error::Type(
-                String::from_utf8_lossy(error.as_ref().to_bytes()).into_owned(),
-            )),
+            Ok(ConversionResult::Failure(error)) => Err(Error::Type(error.into_owned())),
             Err(_) => Err(Error::JSFailed),
         }
     }

--- a/components/script/dom/quotaexceedederror.rs
+++ b/components/script/dom/quotaexceedederror.rs
@@ -77,7 +77,7 @@ impl QuotaExceededErrorMethods<crate::DomTypeHolder> for QuotaExceededError {
             // If options["quota"] is less than 0, then throw a RangeError.
             if *quota < 0.0 {
                 return Err(Error::Range(
-                    "quota must be at least zero if present".to_string(),
+                    c"quota must be at least zero if present".to_owned(),
                 ));
             }
         }
@@ -86,7 +86,7 @@ impl QuotaExceededErrorMethods<crate::DomTypeHolder> for QuotaExceededError {
             // If options["requested"] is less than 0, then throw a RangeError.
             if *requested < 0.0 {
                 return Err(Error::Range(
-                    "requested must be at least zero if present".to_string(),
+                    c"requested must be at least zero if present".to_owned(),
                 ));
             }
         }
@@ -94,7 +94,7 @@ impl QuotaExceededErrorMethods<crate::DomTypeHolder> for QuotaExceededError {
         // is less than this’s quota, then throw a RangeError.
         if let (Some(quota), Some(requested)) = (options.quota, options.requested) {
             if *requested < *quota {
-                return Err(Error::Range("requested is less than quota".to_string()));
+                return Err(Error::Range(c"requested is less than quota".to_owned()));
             }
         }
         Ok(reflect_dom_object_with_proto(

--- a/components/script/dom/response.rs
+++ b/components/script/dom/response.rs
@@ -11,6 +11,7 @@ use http::header::HeaderMap as HyperHeaders;
 use hyper_serde::Serde;
 use js::rust::{HandleObject, HandleValue};
 use net_traits::http_status::HttpStatus;
+use script_bindings::cformat;
 use servo_url::ServoUrl;
 use url::Position;
 
@@ -215,12 +216,12 @@ impl ResponseMethods<crate::DomTypeHolder> for Response {
         // Step 2
         let url = match parsed_url {
             Ok(url) => url,
-            Err(_) => return Err(Error::Type("ServoUrl could not be parsed".to_string())),
+            Err(_) => return Err(Error::Type(c"ServoUrl could not be parsed".to_owned())),
         };
 
         // Step 3
         if !is_redirect_status(status) {
-            return Err(Error::Range("status is not a redirect status".to_string()));
+            return Err(Error::Range(c"status is not a redirect status".to_owned()));
         }
 
         // Step 4
@@ -317,7 +318,7 @@ impl ResponseMethods<crate::DomTypeHolder> for Response {
     fn Clone(&self, can_gc: CanGc) -> Fallible<DomRoot<Response>> {
         // Step 1. If this is unusable, then throw a TypeError.
         if self.is_unusable() {
-            return Err(Error::Type("cannot clone a disturbed response".to_string()));
+            return Err(Error::Type(c"cannot clone a disturbed response".to_owned()));
         }
 
         // Step 2. Let clonedResponse be the result of cloning this’s response.
@@ -401,7 +402,7 @@ fn initialize_response(
 ) -> Result<DomRoot<Response>, Error> {
     // 1. If init["status"] is not in the range 200 to 599, inclusive, then throw a RangeError.
     if init.status < 200 || init.status > 599 {
-        return Err(Error::Range(format!(
+        return Err(Error::Range(cformat!(
             "init's status member should be in the range 200 to 599, inclusive, but is {}",
             init.status
         )));
@@ -411,8 +412,8 @@ fn initialize_response(
     // then throw a TypeError.
     if !is_valid_status_text(&init.statusText) {
         return Err(Error::Type(
-            "init's statusText member does not match the reason-phrase token production"
-                .to_string(),
+            c"init's statusText member does not match the reason-phrase token production"
+                .to_owned(),
         ));
     }
 
@@ -433,7 +434,7 @@ fn initialize_response(
         // 6.1 If response’s status is a null body status, then throw a TypeError.
         if is_null_body_status(init.status) {
             return Err(Error::Type(
-                "Body is non-null but init's status member is a null body status".to_string(),
+                c"Body is non-null but init's status member is a null body status".to_owned(),
             ));
         };
 

--- a/components/script/dom/stream/compressionstream.rs
+++ b/components/script/dom/stream/compressionstream.rs
@@ -223,10 +223,10 @@ pub(crate) fn compress_and_enqueue_a_chunk(
     let offset = compressor.get_ref().len();
     compressor
         .write_all(&chunk)
-        .map_err(|_| Error::Type("CompressionStream: write_all() failed".to_string()))?;
+        .map_err(|_| Error::Type(c"CompressionStream: write_all() failed".to_owned()))?;
     compressor
         .flush()
-        .map_err(|_| Error::Type("CompressionStream: flush() failed".to_string()))?;
+        .map_err(|_| Error::Type(c"CompressionStream: flush() failed".to_owned()))?;
     let buffer = &compressor.get_ref()[offset..];
 
     // Step 3. If buffer is empty, return.
@@ -241,7 +241,7 @@ pub(crate) fn compress_and_enqueue_a_chunk(
     rooted!(in(*cx) let mut js_object = ptr::null_mut::<JSObject>());
     let buffer_source =
         create_buffer_source::<Uint8>(cx, buffer, js_object.handle_mut(), can_gc)
-            .map_err(|_| Error::Type("Cannot convert byte sequence to Uint8Array".to_owned()))?;
+            .map_err(|_| Error::Type(c"Cannot convert byte sequence to Uint8Array".to_owned()))?;
     rooted!(in(*cx) let mut rval = UndefinedValue());
     buffer_source.safe_to_jsval(cx, rval.handle_mut(), can_gc);
     controller.enqueue(cx, global, rval.handle(), can_gc)?;
@@ -268,7 +268,7 @@ pub(crate) fn compress_flush_and_enqueue(
     let offset = compressor.get_ref().len();
     compressor
         .try_finish()
-        .map_err(|_| Error::Type("CompressionStream: try_finish() failed".to_string()))?;
+        .map_err(|_| Error::Type(c"CompressionStream: try_finish() failed".to_owned()))?;
     let buffer = &compressor.get_ref()[offset..];
 
     // Step 2. If buffer is empty, return.
@@ -283,7 +283,7 @@ pub(crate) fn compress_flush_and_enqueue(
     rooted!(in(*cx) let mut js_object = ptr::null_mut::<JSObject>());
     let buffer_source =
         create_buffer_source::<Uint8>(cx, buffer, js_object.handle_mut(), can_gc)
-            .map_err(|_| Error::Type("Cannot convert byte sequence to Uint8Array".to_owned()))?;
+            .map_err(|_| Error::Type(c"Cannot convert byte sequence to Uint8Array".to_owned()))?;
     rooted!(in(*cx) let mut rval = UndefinedValue());
     buffer_source.safe_to_jsval(cx, rval.handle_mut(), can_gc);
     controller.enqueue(cx, global, rval.handle(), can_gc)?;
@@ -302,10 +302,10 @@ pub(crate) fn convert_chunk_to_vec(
 ) -> Result<Vec<u8>, Error> {
     let conversion_result = ArrayBufferViewOrArrayBuffer::safe_from_jsval(cx, chunk, (), can_gc)
         .map_err(|_| {
-            Error::Type("Unable to convert chunk into ArrayBuffer or ArrayBufferView".to_string())
+            Error::Type(c"Unable to convert chunk into ArrayBuffer or ArrayBufferView".to_owned())
         })?;
     let buffer_source = conversion_result.get_success_value().ok_or_else(|| {
-        Error::Type("Unable to convert chunk into ArrayBuffer or ArrayBufferView".to_string())
+        Error::Type(c"Unable to convert chunk into ArrayBuffer or ArrayBufferView".to_owned())
     })?;
     match buffer_source {
         ArrayBufferViewOrArrayBuffer::ArrayBufferView(view) => Ok(view.to_vec()),

--- a/components/script/dom/stream/countqueuingstrategy.rs
+++ b/components/script/dom/stream/countqueuingstrategy.rs
@@ -111,7 +111,7 @@ pub(crate) fn extract_high_water_mark(
     let high_water_mark = strategy.highWaterMark.unwrap();
     if high_water_mark.is_nan() || high_water_mark < 0.0 {
         return Err(Error::Range(
-            "High water mark must be a non-negative number.".to_string(),
+            c"High water mark must be a non-negative number.".to_owned(),
         ));
     }
 

--- a/components/script/dom/stream/decompressionstream.rs
+++ b/components/script/dom/stream/decompressionstream.rs
@@ -223,12 +223,12 @@ pub(crate) fn decompress_and_enqueue_a_chunk(
     while offset < chunk.len() && written > 0 {
         written = decompressor
             .write(&chunk[offset..])
-            .map_err(|_| Error::Type("DecompressionStream: write() failed".to_string()))?;
+            .map_err(|_| Error::Type(c"DecompressionStream: write() failed".to_owned()))?;
         offset += written;
     }
     decompressor
         .flush()
-        .map_err(|_| Error::Type("DecompressionStream: flush() failed".to_string()))?;
+        .map_err(|_| Error::Type(c"DecompressionStream: flush() failed".to_owned()))?;
     let buffer = decompressor.get_ref();
 
     // Step 3. If buffer is empty, return.
@@ -242,7 +242,7 @@ pub(crate) fn decompress_and_enqueue_a_chunk(
     // NOTE: We process the result in a single Uint8Array.
     rooted!(in(*cx) let mut js_object = ptr::null_mut::<JSObject>());
     let array = create_buffer_source::<Uint8>(cx, buffer, js_object.handle_mut(), can_gc)
-        .map_err(|_| Error::Type("Cannot convert byte sequence to Uint8Array".to_owned()))?;
+        .map_err(|_| Error::Type(c"Cannot convert byte sequence to Uint8Array".to_owned()))?;
     rooted!(in(*cx) let mut rval = UndefinedValue());
     array.safe_to_jsval(cx, rval.handle_mut(), can_gc);
     controller.enqueue(cx, global, rval.handle(), can_gc)?;
@@ -255,7 +255,7 @@ pub(crate) fn decompress_and_enqueue_a_chunk(
     // consumed chunk, then throw a TypeError.
     if offset < chunk.len() {
         return Err(Error::Type(
-            "The end of the compressed input has been reached".to_string(),
+            c"The end of the compressed input has been reached".to_owned(),
         ));
     }
 
@@ -277,11 +277,11 @@ pub(crate) fn decompress_flush_and_enqueue(
     let offset = decompressor.get_ref().len();
     let is_ended = decompressor
         .write(&[0])
-        .map_err(|_| Error::Type("DecompressionStream: write() failed".to_string()))? ==
+        .map_err(|_| Error::Type(c"DecompressionStream: write() failed".to_owned()))? ==
         0;
     decompressor
         .try_finish()
-        .map_err(|_| Error::Type("DecompressionStream: try_finish() failed".to_string()))?;
+        .map_err(|_| Error::Type(c"DecompressionStream: try_finish() failed".to_owned()))?;
     let buffer = &decompressor.get_ref()[offset..];
 
     // Step 2. If buffer is empty, return.
@@ -292,7 +292,7 @@ pub(crate) fn decompress_flush_and_enqueue(
         // NOTE: We process the result in a single Uint8Array.
         rooted!(in(*cx) let mut js_object = ptr::null_mut::<JSObject>());
         let array = create_buffer_source::<Uint8>(cx, buffer, js_object.handle_mut(), can_gc)
-            .map_err(|_| Error::Type("Cannot convert byte sequence to Uint8Array".to_owned()))?;
+            .map_err(|_| Error::Type(c"Cannot convert byte sequence to Uint8Array".to_owned()))?;
         rooted!(in(*cx) let mut rval = UndefinedValue());
         array.safe_to_jsval(cx, rval.handle_mut(), can_gc);
         controller.enqueue(cx, global, rval.handle(), can_gc)?;
@@ -314,7 +314,7 @@ pub(crate) fn decompress_flush_and_enqueue(
     // in `is_ended`.
     if !is_ended {
         return Err(Error::Type(
-            "The end of the compressed input has not been reached".to_string(),
+            c"The end of the compressed input has not been reached".to_owned(),
         ));
     }
 

--- a/components/script/dom/stream/readablebytestreamcontroller.rs
+++ b/components/script/dom/stream/readablebytestreamcontroller.rs
@@ -416,7 +416,7 @@ impl ReadableByteStreamController {
                     if self.close_requested.get() {
                         // Let e be a new TypeError exception.
                         rooted!(in(*cx) let mut error = UndefinedValue());
-                        Error::Type("close requested".to_owned()).to_jsval(
+                        Error::Type(c"close requested".to_owned()).to_jsval(
                             cx,
                             &self.global(),
                             error.handle_mut(),
@@ -484,7 +484,7 @@ impl ReadableByteStreamController {
                 // If bytesWritten is not 0, throw a TypeError exception.
                 if bytes_written != 0 {
                     return Err(Error::Type(
-                        "bytesWritten not zero on closed stream".to_owned(),
+                        c"bytesWritten not zero on closed stream".to_owned(),
                     ));
                 }
             } else {
@@ -493,7 +493,7 @@ impl ReadableByteStreamController {
 
                 // If bytesWritten is 0, throw a TypeError exception.
                 if bytes_written == 0 {
-                    return Err(Error::Type("bytesWritten is 0".to_owned()));
+                    return Err(Error::Type(c"bytesWritten is 0".to_owned()));
                 }
 
                 // If firstDescriptor’s bytes filled + bytesWritten > firstDescriptor’s byte length,
@@ -502,7 +502,7 @@ impl ReadableByteStreamController {
                     first_descriptor.byte_length
                 {
                     return Err(Error::Range(
-                        "bytes filled + bytesWritten > byte length".to_owned(),
+                        c"bytes filled + bytesWritten > byte length".to_owned(),
                     ));
                 }
             }
@@ -740,7 +740,7 @@ impl ReadableByteStreamController {
             if stream.is_closed() {
                 // If view.[[ByteLength]] is not 0, throw a TypeError exception.
                 if view.byte_length() != 0 {
-                    return Err(Error::Type("view byte length is not 0".to_owned()));
+                    return Err(Error::Type(c"view byte length is not 0".to_owned()));
                 }
             } else {
                 // Assert: state is "readable".
@@ -748,7 +748,7 @@ impl ReadableByteStreamController {
 
                 // If view.[[ByteLength]] is 0, throw a TypeError exception.
                 if view.byte_length() == 0 {
-                    return Err(Error::Type("view byte length is 0".to_owned()));
+                    return Err(Error::Type(c"view byte length is 0".to_owned()));
                 }
             }
 
@@ -758,7 +758,7 @@ impl ReadableByteStreamController {
                 (view.get_byte_offset() as u64)
             {
                 return Err(Error::Range(
-                    "firstDescriptor's byte offset + bytes filled is not view byte offset"
+                    c"firstDescriptor's byte offset + bytes filled is not view byte offset"
                         .to_owned(),
                 ));
             }
@@ -769,7 +769,7 @@ impl ReadableByteStreamController {
                 (view.viewed_buffer_array_byte_length(cx) as u64)
             {
                 return Err(Error::Range(
-                "firstDescriptor's buffer byte length is not view viewed buffer array byte length"
+                c"firstDescriptor's buffer byte length is not view viewed buffer array byte length"
                     .to_owned(),
             ));
             }
@@ -780,7 +780,7 @@ impl ReadableByteStreamController {
                 first_descriptor.byte_length
             {
                 return Err(Error::Range(
-                    "bytes filled + view byte length > byte length".to_owned(),
+                    c"bytes filled + view byte length > byte length".to_owned(),
                 ));
             }
 
@@ -894,7 +894,7 @@ impl ReadableByteStreamController {
 
                 // Let e be a new TypeError exception.
                 let e = Error::Type(
-                    "remainder after dividing firstPendingPullInto's bytes
+                    c"remainder after dividing firstPendingPullInto's bytes
                     filled by firstPendingPullInto's element size is not 0"
                         .to_owned(),
                 );
@@ -1009,7 +1009,7 @@ impl ReadableByteStreamController {
 
         // If ! IsDetachedBuffer(buffer) is true, throw a TypeError exception.
         if buffer.is_detached_buffer(cx) {
-            return Err(Error::Type("buffer is detached".to_owned()));
+            return Err(Error::Type(c"buffer is detached".to_owned()));
         }
 
         // Let transferredBuffer be ? TransferArrayBuffer(buffer).
@@ -1023,7 +1023,7 @@ impl ReadableByteStreamController {
                 let first_descriptor = pending_pull_intos.first_mut().unwrap();
                 // If ! IsDetachedBuffer(firstPendingPullInto’s buffer) is true, throw a TypeError exception.
                 if first_descriptor.buffer.is_detached_buffer(cx) {
-                    return Err(Error::Type("buffer is detached".to_owned()));
+                    return Err(Error::Type(c"buffer is detached".to_owned()));
                 }
 
                 // Perform ! ReadableByteStreamControllerInvalidateBYOBRequest(controller).
@@ -1474,7 +1474,7 @@ impl ReadableByteStreamController {
 
             // Perform ! ReadableByteStreamControllerError(controller, cloneResult.[[Value]]).
             rooted!(in(*cx) let mut rval = UndefinedValue());
-            let error = Error::Type("can not clone array buffer".to_owned());
+            let error = Error::Type(c"can not clone array buffer".to_owned());
             error
                 .clone()
                 .to_jsval(cx, &self.global(), rval.handle_mut(), can_gc);
@@ -1976,12 +1976,12 @@ impl ReadableByteStreamControllerMethods<crate::DomTypeHolder> for ReadableByteS
         let cx = GlobalScope::get_cx();
         // If this.[[closeRequested]] is true, throw a TypeError exception.
         if self.close_requested.get() {
-            return Err(Error::Type("closeRequested is true".to_owned()));
+            return Err(Error::Type(c"closeRequested is true".to_owned()));
         }
 
         // If this.[[stream]].[[state]] is not "readable", throw a TypeError exception.
         if !self.stream.get().unwrap().is_readable() {
-            return Err(Error::Type("stream is not readable".to_owned()));
+            return Err(Error::Type(c"stream is not readable".to_owned()));
         }
 
         // Perform ? ReadableByteStreamControllerClose(this).
@@ -2000,24 +2000,24 @@ impl ReadableByteStreamControllerMethods<crate::DomTypeHolder> for ReadableByteS
 
         // If chunk.[[ByteLength]] is 0, throw a TypeError exception.
         if chunk.byte_length() == 0 {
-            return Err(Error::Type("chunk.ByteLength is 0".to_owned()));
+            return Err(Error::Type(c"chunk.ByteLength is 0".to_owned()));
         }
 
         // If chunk.[[ViewedArrayBuffer]].[[ByteLength]] is 0, throw a TypeError exception.
         if chunk.viewed_buffer_array_byte_length(cx) == 0 {
             return Err(Error::Type(
-                "chunk.ViewedArrayBuffer.ByteLength is 0".to_owned(),
+                c"chunk.ViewedArrayBuffer.ByteLength is 0".to_owned(),
             ));
         }
 
         // If this.[[closeRequested]] is true, throw a TypeError exception.
         if self.close_requested.get() {
-            return Err(Error::Type("closeRequested is true".to_owned()));
+            return Err(Error::Type(c"closeRequested is true".to_owned()));
         }
 
         // If this.[[stream]].[[state]] is not "readable", throw a TypeError exception.
         if !self.stream.get().unwrap().is_readable() {
-            return Err(Error::Type("stream is not readable".to_owned()));
+            return Err(Error::Type(c"stream is not readable".to_owned()));
         }
 
         // Return ? ReadableByteStreamControllerEnqueue(this, chunk).

--- a/components/script/dom/stream/readablestreambyobreader.rs
+++ b/components/script/dom/stream/readablestreambyobreader.rs
@@ -233,13 +233,13 @@ impl ReadableStreamBYOBReader {
     ) -> Fallible<()> {
         // If ! IsReadableStreamLocked(stream) is true, throw a TypeError exception.
         if stream.is_locked() {
-            return Err(Error::Type("stream is locked".to_owned()));
+            return Err(Error::Type(c"stream is locked".to_owned()));
         }
 
         // If stream.[[controller]] does not implement ReadableByteStreamController, throw a TypeError exception.
         if !stream.has_byte_controller() {
             return Err(Error::Type(
-                "stream controller is not a byte stream controller".to_owned(),
+                c"stream controller is not a byte stream controller".to_owned(),
             ));
         }
 
@@ -260,7 +260,7 @@ impl ReadableStreamBYOBReader {
         // Let e be a new TypeError exception.
         let cx = GlobalScope::get_cx();
         rooted!(in(*cx) let mut error = UndefinedValue());
-        Error::Type("Reader is released".to_owned()).to_jsval(
+        Error::Type(c"Reader is released".to_owned()).to_jsval(
             cx,
             &self.global(),
             error.handle_mut(),
@@ -434,14 +434,14 @@ impl ReadableStreamBYOBReaderMethods<crate::DomTypeHolder> for ReadableStreamBYO
         let cx = GlobalScope::get_cx();
         // If view.[[ByteLength]] is 0, return a promise rejected with a TypeError exception.
         if view.byte_length() == 0 {
-            promise.reject_error(Error::Type("view byte length is 0".to_owned()), can_gc);
+            promise.reject_error(Error::Type(c"view byte length is 0".to_owned()), can_gc);
             return promise;
         }
         // If view.[[ViewedArrayBuffer]].[[ArrayBufferByteLength]] is 0,
         // return a promise rejected with a TypeError exception.
         if view.viewed_buffer_array_byte_length(cx) == 0 {
             promise.reject_error(
-                Error::Type("viewed buffer byte length is 0".to_owned()),
+                Error::Type(c"viewed buffer byte length is 0".to_owned()),
                 can_gc,
             );
             return promise;
@@ -450,13 +450,13 @@ impl ReadableStreamBYOBReaderMethods<crate::DomTypeHolder> for ReadableStreamBYO
         // If ! IsDetachedBuffer(view.[[ViewedArrayBuffer]]) is true,
         // return a promise rejected with a TypeError exception.
         if view.is_detached_buffer(cx) {
-            promise.reject_error(Error::Type("view is detached".to_owned()), can_gc);
+            promise.reject_error(Error::Type(c"view is detached".to_owned()), can_gc);
             return promise;
         }
 
         // If options["min"] is 0, return a promise rejected with a TypeError exception.
         if min == 0 {
-            promise.reject_error(Error::Type("min is 0".to_owned()), can_gc);
+            promise.reject_error(Error::Type(c"min is 0".to_owned()), can_gc);
             return promise;
         }
 
@@ -465,7 +465,7 @@ impl ReadableStreamBYOBReaderMethods<crate::DomTypeHolder> for ReadableStreamBYO
             // If options["min"] > view.[[ArrayLength]], return a promise rejected with a RangeError exception.
             if min > (view.get_typed_array_length() as u64) {
                 promise.reject_error(
-                    Error::Range("min is greater than array length".to_owned()),
+                    Error::Range(c"min is greater than array length".to_owned()),
                     can_gc,
                 );
                 return promise;
@@ -475,7 +475,7 @@ impl ReadableStreamBYOBReaderMethods<crate::DomTypeHolder> for ReadableStreamBYO
             // If options["min"] > view.[[ByteLength]], return a promise rejected with a RangeError exception.
             if min > (view.byte_length() as u64) {
                 promise.reject_error(
-                    Error::Range("min is greater than byte length".to_owned()),
+                    Error::Range(c"min is greater than byte length".to_owned()),
                     can_gc,
                 );
                 return promise;
@@ -485,7 +485,7 @@ impl ReadableStreamBYOBReaderMethods<crate::DomTypeHolder> for ReadableStreamBYO
         // If this.[[stream]] is undefined, return a promise rejected with a TypeError exception.
         if self.stream.get().is_none() {
             promise.reject_error(
-                Error::Type("min is greater than byte length".to_owned()),
+                Error::Type(c"min is greater than byte length".to_owned()),
                 can_gc,
             );
             return promise;

--- a/components/script/dom/stream/readablestreambyobrequest.rs
+++ b/components/script/dom/stream/readablestreambyobrequest.rs
@@ -77,14 +77,14 @@ impl ReadableStreamBYOBRequestMethods<crate::DomTypeHolder> for ReadableStreamBY
         let controller = if let Some(controller) = self.controller.get() {
             controller
         } else {
-            return Err(Error::Type("controller is undefined".to_owned()));
+            return Err(Error::Type(c"controller is undefined".to_owned()));
         };
 
         {
             let view = self.view.borrow();
             // If ! IsDetachedBuffer(this.[[view]].[[ArrayBuffer]]) is true, throw a TypeError exception.
             if view.get_array_buffer_view_buffer(cx).is_detached_buffer(cx) {
-                return Err(Error::Type("buffer is detached".to_owned()));
+                return Err(Error::Type(c"buffer is detached".to_owned()));
             }
 
             // Assert: this.[[view]].[[ByteLength]] > 0.
@@ -111,12 +111,12 @@ impl ReadableStreamBYOBRequestMethods<crate::DomTypeHolder> for ReadableStreamBY
         let controller = if let Some(controller) = self.controller.get() {
             controller
         } else {
-            return Err(Error::Type("controller is undefined".to_owned()));
+            return Err(Error::Type(c"controller is undefined".to_owned()));
         };
 
         // If ! IsDetachedBuffer(view.[[ViewedArrayBuffer]]) is true, throw a TypeError exception.
         if view.is_detached_buffer(cx) {
-            return Err(Error::Type("buffer is detached".to_owned()));
+            return Err(Error::Type(c"buffer is detached".to_owned()));
         }
 
         // Return ? ReadableByteStreamControllerRespondWithNewView(this.[[controller]], view).

--- a/components/script/dom/stream/readablestreamdefaultcontroller.rs
+++ b/components/script/dom/stream/readablestreamdefaultcontroller.rs
@@ -236,14 +236,14 @@ impl QueueWithSizes {
         // If ! IsNonNegativeNumber(size) is false, throw a RangeError exception.
         if !is_non_negative_number(&value) {
             return Err(Error::Range(
-                "The size of the enqueued chunk is not a non-negative number.".to_string(),
+                c"The size of the enqueued chunk is not a non-negative number.".to_owned(),
             ));
         }
 
         // If size is +∞, throw a RangeError exception.
         if value.size().is_infinite() {
             return Err(Error::Range(
-                "The size of the enqueued chunk is infinite.".to_string(),
+                c"The size of the enqueued chunk is infinite.".to_owned(),
             ));
         }
 
@@ -891,7 +891,7 @@ impl ReadableStreamDefaultControllerMethods<crate::DomTypeHolder>
         if !self.can_close_or_enqueue() {
             // If ! ReadableStreamDefaultControllerCanCloseOrEnqueue(this) is false,
             // throw a TypeError exception.
-            return Err(Error::Type("Stream cannot be closed.".to_string()));
+            return Err(Error::Type(c"Stream cannot be closed.".to_owned()));
         }
 
         // Perform ! ReadableStreamDefaultControllerClose(this).
@@ -904,7 +904,7 @@ impl ReadableStreamDefaultControllerMethods<crate::DomTypeHolder>
     fn Enqueue(&self, cx: SafeJSContext, chunk: SafeHandleValue, can_gc: CanGc) -> Fallible<()> {
         // If ! ReadableStreamDefaultControllerCanCloseOrEnqueue(this) is false, throw a TypeError exception.
         if !self.can_close_or_enqueue() {
-            return Err(Error::Type("Stream cannot be enqueued to.".to_string()));
+            return Err(Error::Type(c"Stream cannot be enqueued to.".to_owned()));
         }
 
         // Perform ? ReadableStreamDefaultControllerEnqueue(this, chunk).

--- a/components/script/dom/stream/readablestreamdefaultreader.rs
+++ b/components/script/dom/stream/readablestreamdefaultreader.rs
@@ -387,7 +387,7 @@ impl ReadableStreamDefaultReader {
     ) -> Fallible<()> {
         // If ! IsReadableStreamLocked(stream) is true, throw a TypeError exception.
         if stream.is_locked() {
-            return Err(Error::Type("stream is locked".to_owned()));
+            return Err(Error::Type(c"stream is locked".to_owned()));
         }
         // Perform ! ReadableStreamReaderGenericInitialize(reader, stream).
 
@@ -454,7 +454,7 @@ impl ReadableStreamDefaultReader {
         // Let e be a new TypeError exception.
         let cx = GlobalScope::get_cx();
         rooted!(in(*cx) let mut error = UndefinedValue());
-        Error::Type("Reader is released".to_owned()).to_jsval(
+        Error::Type(c"Reader is released".to_owned()).to_jsval(
             cx,
             &self.global(),
             error.handle_mut(),
@@ -653,7 +653,7 @@ impl ReadableStreamDefaultReaderMethods<crate::DomTypeHolder> for ReadableStream
         // If this.[[stream]] is undefined, return a promise rejected with a TypeError exception.
         if self.stream.get().is_none() {
             rooted!(in(*cx) let mut error = UndefinedValue());
-            Error::Type("stream is undefined".to_owned()).to_jsval(
+            Error::Type(c"stream is undefined".to_owned()).to_jsval(
                 cx,
                 &self.global(),
                 error.handle_mut(),

--- a/components/script/dom/stream/readablestreamgenericreader.rs
+++ b/components/script/dom/stream/readablestreamgenericreader.rs
@@ -97,14 +97,14 @@ pub(crate) trait ReadableStreamGenericReader {
             if stream.is_readable() {
                 // If stream.[[state]] is "readable", reject reader.[[closedPromise]] with a TypeError exception.
                 self.get_closed_promise().reject_error(
-                    Error::Type("stream state is not readable".to_owned()),
+                    Error::Type(c"stream state is not readable".to_owned()),
                     can_gc,
                 );
             } else {
                 // Otherwise, set reader.[[closedPromise]] to a promise rejected with a TypeError exception.
                 let cx = GlobalScope::get_cx();
                 rooted!(in(*cx) let mut error = UndefinedValue());
-                Error::Type("Cannot release lock due to stream state.".to_owned()).to_jsval(
+                Error::Type(c"Cannot release lock due to stream state.".to_owned()).to_jsval(
                     cx,
                     &stream.global(),
                     error.handle_mut(),
@@ -151,7 +151,7 @@ pub(crate) trait ReadableStreamGenericReader {
             // If this.[[stream]] is undefined,
             // return a promise rejected with a TypeError exception.
             let promise = Promise::new(global, can_gc);
-            promise.reject_error(Error::Type("stream is undefined".to_owned()), can_gc);
+            promise.reject_error(Error::Type(c"stream is undefined".to_owned()), can_gc);
             promise
         } else {
             // Return ! ReadableStreamReaderGenericCancel(this, reason).

--- a/components/script/dom/stream/transformstream.rs
+++ b/components/script/dom/stream/transformstream.rs
@@ -789,7 +789,7 @@ impl TransformStream {
         let controller = self
             .controller
             .get()
-            .ok_or(Error::Type("controller is not set".to_string()))?;
+            .ok_or(Error::Type(c"controller is not set".to_owned()))?;
 
         // If controller.[[finishPromise]] is not undefined, return controller.[[finishPromise]].
         if let Some(finish_promise) = controller.get_finish_promise() {
@@ -800,7 +800,7 @@ impl TransformStream {
         let readable = self
             .readable
             .get()
-            .ok_or(Error::Type("readable stream is not set".to_string()))?;
+            .ok_or(Error::Type(c"readable stream is not set".to_owned()))?;
 
         // Let controller.[[finishPromise]] be a new promise.
         controller.set_finish_promise(Promise::new(global, can_gc));
@@ -847,7 +847,7 @@ impl TransformStream {
         let controller = self
             .controller
             .get()
-            .ok_or(Error::Type("controller is not set".to_string()))?;
+            .ok_or(Error::Type(c"controller is not set".to_owned()))?;
 
         // If controller.[[finishPromise]] is not undefined, return controller.[[finishPromise]].
         if let Some(finish_promise) = controller.get_finish_promise() {
@@ -858,7 +858,7 @@ impl TransformStream {
         let writable = self
             .writable
             .get()
-            .ok_or(Error::Type("writable stream is not set".to_string()))?;
+            .ok_or(Error::Type(c"writable stream is not set".to_owned()))?;
 
         // Let controller.[[finishPromise]] be a new promise.
         controller.set_finish_promise(Promise::new(global, can_gc));
@@ -987,9 +987,7 @@ impl TransformStreamMethods<crate::DomTypeHolder> for TransformStream {
             match Transformer::new(cx, obj_val.handle(), can_gc) {
                 Ok(ConversionResult::Success(val)) => val,
                 Ok(ConversionResult::Failure(error)) => {
-                    return Err(Error::Type(
-                        String::from_utf8_lossy(error.as_ref().to_bytes()).into_owned(),
-                    ));
+                    return Err(Error::Type(error.into_owned()));
                 },
                 _ => {
                     return Err(Error::JSFailed);
@@ -1001,12 +999,12 @@ impl TransformStreamMethods<crate::DomTypeHolder> for TransformStream {
 
         // If transformerDict["readableType"] exists, throw a RangeError exception.
         if !transformer_dict.readableType.handle().is_undefined() {
-            return Err(Error::Range("readableType is set".to_string()));
+            return Err(Error::Range(c"readableType is set".to_owned()));
         }
 
         // If transformerDict["writableType"] exists, throw a RangeError exception.
         if !transformer_dict.writableType.handle().is_undefined() {
-            return Err(Error::Range("writableType is set".to_string()));
+            return Err(Error::Range(c"writableType is set".to_owned()));
         }
 
         // Let readableHighWaterMark be ? ExtractHighWaterMark(readableStrategy, 0).

--- a/components/script/dom/stream/transformstreamdefaultcontroller.rs
+++ b/components/script/dom/stream/transformstreamdefaultcontroller.rs
@@ -590,7 +590,7 @@ impl TransformStreamDefaultController {
         // is false, throw a TypeError exception.
         if !readable_controller.can_close_or_enqueue() {
             return Err(Error::Type(
-                "ReadableStreamDefaultControllerCanCloseOrEnqueue is false".to_owned(),
+                c"ReadableStreamDefaultControllerCanCloseOrEnqueue is false".to_owned(),
             ));
         }
 
@@ -682,7 +682,7 @@ impl TransformStreamDefaultController {
         readable_controller.close(can_gc);
 
         // Let error be a TypeError exception indicating that the stream has been terminated.
-        let error = Error::Type("stream has been terminated".to_owned());
+        let error = Error::Type(c"stream has been terminated".to_owned());
 
         // Perform ! TransformStreamErrorWritableAndUnblockWrite(stream, error).
         rooted!(in(*cx) let mut rooted_error = UndefinedValue());

--- a/components/script/dom/stream/writablestream.rs
+++ b/components/script/dom/stream/writablestream.rs
@@ -752,7 +752,7 @@ impl WritableStream {
             // return a promise rejected with a TypeError exception.
             let promise = Promise::new(global, can_gc);
             promise.reject_error(
-                Error::Type("Stream is closed or errored.".to_string()),
+                Error::Type(c"Stream is closed or errored.".to_owned()),
                 can_gc,
             );
             return promise;
@@ -1033,9 +1033,7 @@ impl WritableStreamMethods<crate::DomTypeHolder> for WritableStream {
             match UnderlyingSink::new(cx, obj_val.handle(), can_gc) {
                 Ok(ConversionResult::Success(val)) => val,
                 Ok(ConversionResult::Failure(error)) => {
-                    return Err(Error::Type(
-                        String::from_utf8_lossy(error.as_ref().to_bytes()).into_owned(),
-                    ));
+                    return Err(Error::Type(error.into_owned()));
                 },
                 _ => {
                     return Err(Error::JSFailed);
@@ -1047,7 +1045,7 @@ impl WritableStreamMethods<crate::DomTypeHolder> for WritableStream {
 
         if !underlying_sink_dict.type_.handle().is_undefined() {
             // If underlyingSinkDict["type"] exists, throw a RangeError exception.
-            return Err(Error::Range("type is set".to_string()));
+            return Err(Error::Range(c"type is set".to_owned()));
         }
 
         // Perform ! InitializeWritableStream(this).
@@ -1095,7 +1093,7 @@ impl WritableStreamMethods<crate::DomTypeHolder> for WritableStream {
         if self.is_locked() {
             // return a promise rejected with a TypeError exception.
             let promise = Promise::new(&global, can_gc);
-            promise.reject_error(Error::Type("Stream is locked.".to_string()), can_gc);
+            promise.reject_error(Error::Type(c"Stream is locked.".to_owned()), can_gc);
             return promise;
         }
 
@@ -1112,7 +1110,7 @@ impl WritableStreamMethods<crate::DomTypeHolder> for WritableStream {
         if self.is_locked() {
             // return a promise rejected with a TypeError exception.
             let promise = Promise::new(&global, can_gc);
-            promise.reject_error(Error::Type("Stream is locked.".to_string()), can_gc);
+            promise.reject_error(Error::Type(c"Stream is locked.".to_owned()), can_gc);
             return promise;
         }
 
@@ -1121,7 +1119,7 @@ impl WritableStreamMethods<crate::DomTypeHolder> for WritableStream {
             // return a promise rejected with a TypeError exception.
             let promise = Promise::new(&global, can_gc);
             promise.reject_error(
-                Error::Type("Stream has closed queued or in-flight".to_string()),
+                Error::Type(c"Stream has closed queued or in-flight".to_owned()),
                 can_gc,
             );
             return promise;

--- a/components/script/dom/stream/writablestreamdefaultwriter.rs
+++ b/components/script/dom/stream/writablestreamdefaultwriter.rs
@@ -70,7 +70,7 @@ impl WritableStreamDefaultWriter {
     ) -> Result<(), Error> {
         // If ! IsWritableStreamLocked(stream) is true, throw a TypeError exception.
         if stream.is_locked() {
-            return Err(Error::Type("Stream is locked".to_string()));
+            return Err(Error::Type(c"Stream is locked".to_owned()));
         }
 
         // Set writer.[[stream]] to stream.
@@ -294,7 +294,7 @@ impl WritableStreamDefaultWriter {
         {
             let promise = Promise::new(global, can_gc);
             promise.reject_error(
-                Error::Type("Stream is not equal to writer stream".to_string()),
+                Error::Type(c"Stream is not equal to writer stream".to_owned()),
                 can_gc,
             );
             return promise;
@@ -318,7 +318,7 @@ impl WritableStreamDefaultWriter {
             // indicating that the stream is closing or closed
             let promise = Promise::new(global, can_gc);
             promise.reject_error(
-                Error::Type("Stream has been closed, or has close queued or in-flight".to_string()),
+                Error::Type(c"Stream has been closed, or has close queued or in-flight".to_owned()),
                 can_gc,
             );
             return promise;
@@ -359,7 +359,7 @@ impl WritableStreamDefaultWriter {
         assert!(stream.get_writer().is_some_and(|writer| &*writer == self));
 
         // Let releasedError be a new TypeError.
-        let released_error = Error::Type("Writer has been released".to_string());
+        let released_error = Error::Type(c"Writer has been released".to_owned());
 
         // Root the js val of the error.
         rooted!(in(*cx) let mut error = UndefinedValue());
@@ -436,7 +436,7 @@ impl WritableStreamDefaultWriterMethods<crate::DomTypeHolder> for WritableStream
     fn GetDesiredSize(&self) -> Result<Option<f64>, Error> {
         // If this.[[stream]] is undefined, throw a TypeError exception.
         let Some(stream) = self.stream.get() else {
-            return Err(Error::Type("Stream is undefined".to_string()));
+            return Err(Error::Type(c"Stream is undefined".to_owned()));
         };
 
         // Return ! WritableStreamDefaultWriterGetDesiredSize(this).
@@ -463,7 +463,7 @@ impl WritableStreamDefaultWriterMethods<crate::DomTypeHolder> for WritableStream
         if self.stream.get().is_none() {
             // return a promise rejected with a TypeError exception.
             let promise = Promise::new(&global, can_gc);
-            promise.reject_error(Error::Type("Stream is undefined".to_string()), can_gc);
+            promise.reject_error(Error::Type(c"Stream is undefined".to_owned()), can_gc);
             return promise;
         }
 
@@ -481,7 +481,7 @@ impl WritableStreamDefaultWriterMethods<crate::DomTypeHolder> for WritableStream
         let Some(stream) = self.stream.get() else {
             // If stream is undefined,
             // return a promise rejected with a TypeError exception.
-            promise.reject_error(Error::Type("Stream is undefined".to_string()), can_gc);
+            promise.reject_error(Error::Type(c"Stream is undefined".to_owned()), can_gc);
             return promise;
         };
 
@@ -489,7 +489,7 @@ impl WritableStreamDefaultWriterMethods<crate::DomTypeHolder> for WritableStream
         if stream.close_queued_or_in_flight() {
             // return a promise rejected with a TypeError exception.
             promise.reject_error(
-                Error::Type("Stream has closed queued or in-flight".to_string()),
+                Error::Type(c"Stream has closed queued or in-flight".to_owned()),
                 can_gc,
             );
             return promise;
@@ -531,7 +531,7 @@ impl WritableStreamDefaultWriterMethods<crate::DomTypeHolder> for WritableStream
             // return a promise rejected with a TypeError exception.
             let global = GlobalScope::from_safe_context(cx, realm);
             let promise = Promise::new(&global, can_gc);
-            promise.reject_error(Error::Type("Stream is undefined".to_string()), can_gc);
+            promise.reject_error(Error::Type(c"Stream is undefined".to_owned()), can_gc);
             return promise;
         }
 

--- a/components/script/dom/subtlecrypto.rs
+++ b/components/script/dom/subtlecrypto.rs
@@ -1162,7 +1162,7 @@ impl SubtleCryptoMethods<crate::DomTypeHolder> for SubtleCrypto {
                         // Step 2.1. If the keyData parameter passed to the importKey() method is
                         // not a JsonWebKey dictionary, throw a TypeError.
                         promise.reject_error(
-                            Error::Type("The keyData type does not match the format".to_string()),
+                            Error::Type(c"The keyData type does not match the format".to_owned()),
                             can_gc,
                         );
                         return promise;
@@ -1192,7 +1192,7 @@ impl SubtleCryptoMethods<crate::DomTypeHolder> for SubtleCrypto {
                     // JsonWebKey dictionary, throw a TypeError.
                     ArrayBufferViewOrArrayBufferOrJsonWebKey::JsonWebKey(_) => {
                         promise.reject_error(
-                            Error::Type("The keyData type does not match the format".to_string()),
+                            Error::Type(c"The keyData type does not match the format".to_owned()),
                             can_gc,
                         );
                         return promise;
@@ -3004,9 +3004,7 @@ where
     let conversion = T::safe_from_jsval(cx, value, (), can_gc).map_err(|_| Error::JSFailed)?;
     match conversion {
         ConversionResult::Success(dictionary) => Ok(dictionary),
-        ConversionResult::Failure(error) => Err(Error::Type(
-            String::from_utf8_lossy(error.as_ref().to_bytes()).into_owned(),
-        )),
+        ConversionResult::Failure(error) => Err(Error::Type(error.into_owned())),
     }
 }
 
@@ -3149,9 +3147,7 @@ impl JsonWebKeyExt for JsonWebKey {
         let key = match JsonWebKey::new(cx, result.handle(), CanGc::note()) {
             Ok(ConversionResult::Success(key)) => key,
             Ok(ConversionResult::Failure(error)) => {
-                return Err(Error::Type(
-                    String::from_utf8_lossy(error.as_ref().to_bytes()).into_owned(),
-                ));
+                return Err(Error::Type(error.into_owned()));
             },
             Err(()) => {
                 return Err(Error::JSFailed);

--- a/components/script/dom/subtlecrypto/hmac_operation.rs
+++ b/components/script/dom/subtlecrypto/hmac_operation.rs
@@ -405,7 +405,7 @@ pub(crate) fn get_key_length(
         // Otherwise:
         _ => {
             // throw a TypeError.
-            return Err(Error::Type("[[length]] must not be zero".to_string()));
+            return Err(Error::Type(c"[[length]] must not be zero".to_owned()));
         },
     };
 

--- a/components/script/dom/testing/testbinding.rs
+++ b/components/script/dom/testing/testbinding.rs
@@ -16,6 +16,7 @@ use js::jsval::JSVal;
 use js::realm::CurrentRealm;
 use js::rust::{CustomAutoRooterGuard, HandleObject, HandleValue, MutableHandleValue};
 use js::typedarray::{self, HeapUint8ClampedArray};
+use script_bindings::cformat;
 use script_bindings::codegen::GenericBindings::WindowBinding::WindowMethods;
 use script_bindings::interfaces::TestBindingHelpers;
 use script_bindings::record::Record;
@@ -997,7 +998,7 @@ impl TestBindingMethods<crate::DomTypeHolder> for TestBinding {
     }
 
     fn PromiseRejectWithTypeError(&self, p: &Promise, s: USVString, can_gc: CanGc) {
-        p.reject_error(Error::Type(s.0), can_gc);
+        p.reject_error(Error::Type(cformat!("{}", s.0)), can_gc);
     }
 
     fn ResolvePromiseDelayed(&self, p: &Promise, value: DOMString, delay: u64) {
@@ -1112,11 +1113,11 @@ impl TestBindingMethods<crate::DomTypeHolder> for TestBinding {
     }
 
     fn MethodThrowToRejectPromise(&self) -> Fallible<Rc<Promise>> {
-        Err(Error::Type("test".to_string()))
+        Err(Error::Type(c"test".to_owned()))
     }
 
     fn GetGetterThrowToRejectPromise(&self) -> Fallible<Rc<Promise>> {
-        Err(Error::Type("test".to_string()))
+        Err(Error::Type(c"test".to_owned()))
     }
 
     fn MethodInternalThrowToRejectPromise(&self, _arg: u64) -> Rc<Promise> {
@@ -1124,7 +1125,7 @@ impl TestBindingMethods<crate::DomTypeHolder> for TestBinding {
     }
 
     fn StaticThrowToRejectPromise(_: &GlobalScope) -> Fallible<Rc<Promise>> {
-        Err(Error::Type("test".to_string()))
+        Err(Error::Type(c"test".to_owned()))
     }
 
     fn StaticInternalThrowToRejectPromise(_: &GlobalScope, _arg: u64) -> Rc<Promise> {

--- a/components/script/dom/testing/testbindingmaplikewithinterface.rs
+++ b/components/script/dom/testing/testbindingmaplikewithinterface.rs
@@ -7,6 +7,7 @@
 use dom_struct::dom_struct;
 use indexmap::IndexMap;
 use js::rust::HandleObject;
+use script_bindings::cformat;
 
 use crate::dom::bindings::cell::DomRefCell;
 use crate::dom::bindings::codegen::Bindings::TestBindingMaplikeWithInterfaceBinding::TestBindingMaplikeWithInterfaceMethods;
@@ -79,7 +80,7 @@ impl TestBindingMaplikeWithInterfaceMethods<crate::DomTypeHolder>
         self.internal
             .borrow()
             .get(&key)
-            .ok_or_else(|| Error::Type(format!("No entry for key {key}")))
+            .ok_or_else(|| Error::Type(cformat!("No entry for key {key}")))
             .cloned()
     }
 

--- a/components/script/dom/testing/testbindingmaplikewithprimitive.rs
+++ b/components/script/dom/testing/testbindingmaplikewithprimitive.rs
@@ -7,6 +7,7 @@
 use dom_struct::dom_struct;
 use indexmap::IndexMap;
 use js::rust::HandleObject;
+use script_bindings::cformat;
 
 use crate::dom::bindings::cell::DomRefCell;
 use crate::dom::bindings::codegen::Bindings::TestBindingMaplikeWithPrimitiveBinding::TestBindingMaplikeWithPrimitiveMethods;
@@ -77,7 +78,7 @@ impl TestBindingMaplikeWithPrimitiveMethods<crate::DomTypeHolder>
         self.internal
             .borrow()
             .get(&key)
-            .ok_or_else(|| Error::Type(format!("No entry for key {key}")))
+            .ok_or_else(|| Error::Type(cformat!("No entry for key {key}")))
             .copied()
     }
 

--- a/components/script/dom/textdecoder.rs
+++ b/components/script/dom/textdecoder.rs
@@ -47,7 +47,7 @@ impl TextDecoder {
 
     fn make_range_error() -> Fallible<DomRoot<TextDecoder>> {
         Err(Error::Range(
-            "The given encoding is not supported.".to_owned(),
+            c"The given encoding is not supported.".to_owned(),
         ))
     }
 

--- a/components/script/dom/textdecodercommon.rs
+++ b/components/script/dom/textdecodercommon.rs
@@ -135,7 +135,7 @@ impl TextDecoderCommon {
                 decoder
                     .max_utf8_buffer_length_without_replacement(input.len())
                     .ok_or_else(|| {
-                        Error::Type("Expected UTF8 buffer length would overflow".to_owned())
+                        Error::Type(c"Expected UTF8 buffer length would overflow".to_owned())
                     })?,
             );
 
@@ -171,7 +171,7 @@ impl TextDecoderCommon {
                 // <https://encoding.spec.whatwg.org/#dom-textdecoder-decode>
                 // Step 5.3.3 Otherwise, if result is error, throw a TypeError.
                 DecoderResult::Malformed(_, _) => {
-                    return Err(Error::Type("Decoding failed".to_owned()));
+                    return Err(Error::Type(c"Decoding failed".to_owned()));
                 },
                 DecoderResult::OutputFull => {
                     unreachable!("output is allocated with sufficient capacity")
@@ -182,7 +182,7 @@ impl TextDecoderCommon {
             // Step 4. Let output be the I/O queue of scalar values « end-of-queue ».
             let mut output =
                 String::with_capacity(decoder.max_utf8_buffer_length(input.len()).ok_or_else(
-                    || Error::Type("Expected UTF8 buffer length would overflow".to_owned()),
+                    || Error::Type(c"Expected UTF8 buffer length would overflow".to_owned()),
                 )?);
 
             // Note: The two algorithms below are implemented in

--- a/components/script/dom/textdecoderstream.rs
+++ b/components/script/dom/textdecoderstream.rs
@@ -37,11 +37,11 @@ pub(crate) fn decode_and_enqueue_a_chunk(
     // Step 1. Let bufferSource be the result of converting chunk to an AllowSharedBufferSource.
     let conversion_result = unsafe {
         ArrayBufferViewOrArrayBuffer::from_jsval(*cx, chunk, ()).map_err(|_| {
-            Error::Type("Unable to convert chunk into ArrayBuffer or ArrayBufferView".to_string())
+            Error::Type(c"Unable to convert chunk into ArrayBuffer or ArrayBufferView".to_owned())
         })?
     };
     let buffer_source = conversion_result.get_success_value().ok_or_else(|| {
-        Error::Type("Unable to convert chunk into ArrayBuffer or ArrayBufferView".to_string())
+        Error::Type(c"Unable to convert chunk into ArrayBuffer or ArrayBufferView".to_owned())
     })?;
 
     // Step 2. Push a copy of bufferSource to decoder’s I/O queue.
@@ -160,7 +160,7 @@ impl TextDecoderStreamMethods<crate::DomTypeHolder> for TextDecoderStream {
             Some(enc) => enc,
             None => {
                 return Err(Error::Range(
-                    "The given encoding is not supported".to_owned(),
+                    c"The given encoding is not supported".to_owned(),
                 ));
             },
         };

--- a/components/script/dom/textencoderstream.rs
+++ b/components/script/dom/textencoderstream.rs
@@ -83,7 +83,7 @@ fn jsval_to_primitive(
                 throw_dom_exception(
                     cx,
                     global,
-                    Error::Type("Cannot convert JSObject to primitive".to_owned()),
+                    Error::Type(c"Cannot convert JSObject to primitive".to_owned()),
                     can_gc,
                 );
             }
@@ -232,7 +232,7 @@ pub(crate) fn encode_and_enqueue_a_chunk(
                 throw_dom_exception(
                     cx,
                     global,
-                    Error::Type("Cannot convert JS primitive to string".to_owned()),
+                    Error::Type(c"Cannot convert JS primitive to string".to_owned()),
                     can_gc,
                 );
             }
@@ -275,7 +275,7 @@ pub(crate) fn encode_and_enqueue_a_chunk(
     //      given output and encoder’s relevant realm.
     rooted!(in(*cx) let mut js_object = ptr::null_mut::<JSObject>());
     let chunk = create_buffer_source::<Uint8>(cx, output, js_object.handle_mut(), can_gc)
-        .map_err(|_| Error::Type("Cannot convert byte sequence to Uint8Array".to_owned()))?;
+        .map_err(|_| Error::Type(c"Cannot convert byte sequence to Uint8Array".to_owned()))?;
     rooted!(in(*cx) let mut rval = UndefinedValue());
     chunk.safe_to_jsval(cx, rval.handle_mut(), can_gc);
     // Step 4.2.2.2 Enqueue chunk into encoder’s transform.
@@ -302,7 +302,7 @@ pub(crate) fn encode_and_flush(
             js_object.handle_mut(),
             can_gc,
         )
-        .map_err(|_| Error::Type("Cannot convert byte sequence to Uint8Array".to_owned()))?;
+        .map_err(|_| Error::Type(c"Cannot convert byte sequence to Uint8Array".to_owned()))?;
         rooted!(in(*cx) let mut rval = UndefinedValue());
         chunk.safe_to_jsval(cx, rval.handle_mut(), can_gc);
         // Step 1.2 Enqueue chunk into encoder’s transform.

--- a/components/script/dom/trustedtypepolicy.rs
+++ b/components/script/dom/trustedtypepolicy.rs
@@ -86,7 +86,7 @@ impl TrustedTypePolicy {
     fn check_callback_if_missing(throw_if_missing: bool) -> Fallible<Option<DOMString>> {
         // Step 3.1: If throwIfMissing throw a TypeError.
         if throw_if_missing {
-            Err(Type("Cannot find type".to_owned()))
+            Err(Type(c"Cannot find type".to_owned()))
         } else {
             // Step 3.2: Else return null.
             Ok(None)

--- a/components/script/dom/trustedtypepolicyfactory.rs
+++ b/components/script/dom/trustedtypepolicyfactory.rs
@@ -86,7 +86,7 @@ impl TrustedTypePolicyFactory {
 
             // Step 2: If allowedByCSP is "Blocked", throw a TypeError and abort further steps.
             if !allowed_by_csp {
-                return Err(Error::Type("Not allowed by CSP".to_string()));
+                return Err(Error::Type(c"Not allowed by CSP".to_owned()));
             }
         }
 
@@ -94,7 +94,7 @@ impl TrustedTypePolicyFactory {
         // and abort further steps.
         if policy_name == "default" && self.default_policy.get().is_some() {
             return Err(Error::Type(
-                "Already set default policy for factory".to_string(),
+                c"Already set default policy for factory".to_owned(),
             ));
         }
 
@@ -332,7 +332,7 @@ impl TrustedTypePolicyFactory {
                 } else {
                     // Step 6.3: Throw a TypeError and abort further steps.
                     Err(Error::Type(
-                        "Cannot set value, expected trusted type".to_owned(),
+                        c"Cannot set value, expected trusted type".to_owned(),
                     ))
                 }
             },

--- a/components/script/dom/url.rs
+++ b/components/script/dom/url.rs
@@ -11,6 +11,7 @@ use net_traits::CoreResourceMsg;
 use net_traits::blob_url_store::parse_blob_url;
 use net_traits::filemanager_thread::FileManagerThreadMsg;
 use profile_traits::ipc;
+use script_bindings::cformat;
 use servo_url::{ImmutableOrigin, ServoUrl};
 use uuid::Uuid;
 
@@ -126,7 +127,7 @@ impl URLMethods<crate::DomTypeHolder> for URL {
                     Ok(base) => Some(base),
                     Err(error) => {
                         // Step 2. Throw a TypeError if URL parsing fails.
-                        return Err(Error::Type(format!("could not parse base: {}", error)));
+                        return Err(Error::Type(cformat!("could not parse base: {}", error)));
                     },
                 }
             },
@@ -135,7 +136,7 @@ impl URLMethods<crate::DomTypeHolder> for URL {
             Ok(url) => url,
             Err(error) => {
                 // Step 2. Throw a TypeError if URL parsing fails.
-                return Err(Error::Type(format!("could not parse URL: {}", error)));
+                return Err(Error::Type(cformat!("could not parse URL: {}", error)));
             },
         };
 
@@ -267,7 +268,7 @@ impl URLMethods<crate::DomTypeHolder> for URL {
                 self.search_params.set(None); // To be re-initialized in the SearchParams getter.
                 Ok(())
             },
-            Err(error) => Err(Error::Type(format!("could not parse URL: {}", error))),
+            Err(error) => Err(Error::Type(cformat!("could not parse URL: {}", error))),
         }
     }
 

--- a/components/script/dom/urlpattern.rs
+++ b/components/script/dom/urlpattern.rs
@@ -4,6 +4,7 @@
 
 use dom_struct::dom_struct;
 use js::rust::HandleObject;
+use script_bindings::cformat;
 use script_bindings::codegen::GenericBindings::URLPatternBinding::URLPatternResult;
 use script_bindings::codegen::GenericUnionTypes::USVStringOrURLPatternInit;
 use script_bindings::error::{Error, Fallible};
@@ -54,10 +55,10 @@ impl URLPattern {
         // Parse and initialize the URL pattern.
         let pattern_init =
             urlpattern::quirks::process_construct_pattern_input(input, base_url.as_deref())
-                .map_err(|error| Error::Type(format!("{error}")))?;
+                .map_err(|error| Error::Type(cformat!("{error}")))?;
 
         let pattern = urlpattern::UrlPattern::parse(pattern_init, options)
-            .map_err(|error| Error::Type(format!("{error}")))?;
+            .map_err(|error| Error::Type(cformat!("{error}")))?;
 
         let url_pattern = reflect_dom_object_with_proto(
             Box::new(URLPattern::new_inherited(pattern)),
@@ -102,14 +103,14 @@ impl URLPatternMethods<crate::DomTypeHolder> for URLPattern {
     ) -> Fallible<bool> {
         let input = bindings_to_third_party::map_urlpattern_input(input);
         let inputs = urlpattern::quirks::process_match_input(input, base_url.as_deref())
-            .map_err(|error| Error::Type(format!("{error}")))?;
+            .map_err(|error| Error::Type(cformat!("{error}")))?;
         let Some((match_input, _)) = inputs else {
             return Ok(false);
         };
 
         self.associated_url_pattern
             .test(match_input)
-            .map_err(|error| Error::Type(format!("{error}")))
+            .map_err(|error| Error::Type(cformat!("{error}")))
     }
 
     /// <https://urlpattern.spec.whatwg.org/#dom-urlpattern-exec>
@@ -120,7 +121,7 @@ impl URLPatternMethods<crate::DomTypeHolder> for URLPattern {
     ) -> Fallible<Option<URLPatternResult>> {
         let input = bindings_to_third_party::map_urlpattern_input(input);
         let inputs = urlpattern::quirks::process_match_input(input, base_url.as_deref())
-            .map_err(|error| Error::Type(format!("{error}")))?;
+            .map_err(|error| Error::Type(cformat!("{error}")))?;
         let Some((match_input, inputs)) = inputs else {
             return Ok(None);
         };
@@ -128,7 +129,7 @@ impl URLPatternMethods<crate::DomTypeHolder> for URLPattern {
         let result = self
             .associated_url_pattern
             .exec(match_input)
-            .map_err(|error| Error::Type(format!("{error}")))?;
+            .map_err(|error| Error::Type(cformat!("{error}")))?;
         let Some(result) = result else {
             return Ok(None);
         };

--- a/components/script/dom/urlsearchparams.rs
+++ b/components/script/dom/urlsearchparams.rs
@@ -81,7 +81,7 @@ impl URLSearchParamsMethods<crate::DomTypeHolder> for URLSearchParams {
 
                 // Step 2-1.
                 if init.iter().any(|pair| pair.len() != 2) {
-                    return Err(Error::Type("Sequence initializer must only contain pair elements.".to_string()));
+                    return Err(Error::Type(c"Sequence initializer must only contain pair elements.".to_owned()));
                 }
 
                 // Step 2-2.

--- a/components/script/dom/webgpu/gpuadapter.rs
+++ b/components/script/dom/webgpu/gpuadapter.rs
@@ -6,6 +6,7 @@ use std::rc::Rc;
 
 use dom_struct::dom_struct;
 use js::jsapi::{HandleObject, Heap, JSObject};
+use script_bindings::cformat;
 use webgpu_traits::{
     RequestDeviceError, WebGPU, WebGPUAdapter, WebGPUDeviceResponse, WebGPURequest,
 };
@@ -206,7 +207,7 @@ impl GPUAdapterMethods<crate::DomTypeHolder> for GPUAdapter {
                 required_features.insert(feature);
             } else {
                 promise.reject_error(
-                    Error::Type(format!("{} is not supported feature", ext.as_str())),
+                    Error::Type(cformat!("{} is not supported feature", ext.as_str())),
                     can_gc,
                 );
                 return promise;
@@ -298,9 +299,10 @@ impl RoutedPromiseListener<WebGPUDeviceResponse> for GPUAdapter {
             },
             // 1. If features are not supported reject promise with a TypeError.
             (_, _, Err(RequestDeviceError::UnsupportedFeature(f))) => promise.reject_error(
-                Error::Type(
-                    wgpu_core::instance::RequestDeviceError::UnsupportedFeature(f).to_string(),
-                ),
+                Error::Type(cformat!(
+                    "{}",
+                    wgpu_core::instance::RequestDeviceError::UnsupportedFeature(f)
+                )),
                 can_gc,
             ),
             // 2. If limits are not supported reject promise with an OperationError.

--- a/components/script/dom/webgpu/gpubuffer.rs
+++ b/components/script/dom/webgpu/gpubuffer.rs
@@ -51,11 +51,11 @@ impl ActiveBufferMapping {
         let size = range.end - range.start;
         // Step 2
         if size > (1 << 53) - 1 {
-            return Err(Error::Range("Over MAX_SAFE_INTEGER".to_string()));
+            return Err(Error::Range(c"Over MAX_SAFE_INTEGER".to_owned()));
         }
         let size: usize = size
             .try_into()
-            .map_err(|_| Error::Range("Over usize".to_string()))?;
+            .map_err(|_| Error::Range(c"Over usize".to_owned()))?;
         Ok(Self {
             data: DataBlock::new_zeroed(size),
             mode,

--- a/components/script/dom/webgpu/gpucanvascontext.rs
+++ b/components/script/dom/webgpu/gpucanvascontext.rs
@@ -9,6 +9,7 @@ use arrayvec::ArrayVec;
 use base::{Epoch, generic_channel};
 use dom_struct::dom_struct;
 use pixels::Snapshot;
+use script_bindings::cformat;
 use script_bindings::codegen::GenericBindings::WebGPUBinding::GPUTextureFormat;
 use webgpu_traits::{
     ContextConfiguration, PRESENTATION_BUFFER_COUNT, PendingTexture, WebGPU, WebGPUContextId,
@@ -343,7 +344,7 @@ impl GPUCanvasContextMethods<crate::DomTypeHolder> for GPUCanvasContext {
 
         // 4. If Supported context formats does not contain configuration.format, throw a TypeError
         if !supported_context_format(configuration.format) {
-            return Err(Error::Type(format!(
+            return Err(Error::Type(cformat!(
                 "Unsupported context format: {:?}",
                 configuration.format
             )));

--- a/components/script/dom/webgpu/gpuconvert.rs
+++ b/components/script/dom/webgpu/gpuconvert.rs
@@ -231,7 +231,7 @@ impl TryConvert<wgpu_types::Extent3d> for &GPUExtent3D {
                 // https://gpuweb.github.io/gpuweb/#abstract-opdef-validate-gpuextent3d-shape
                 if v.is_empty() || v.len() > 3 {
                     Err(Error::Type(
-                        "GPUExtent3D size must be between 1 and 3 (inclusive)".to_string(),
+                        c"GPUExtent3D size must be between 1 and 3 (inclusive)".to_owned(),
                     ))
                 } else {
                     Ok(wgpu_types::Extent3d {
@@ -461,7 +461,7 @@ impl TryConvert<wgpu_types::Origin3d> for &GPUOrigin3D {
                 // https://gpuweb.github.io/gpuweb/#abstract-opdef-validate-gpuorigin3d-shape
                 if v.len() > 3 {
                     Err(Error::Type(
-                        "sequence is too long for GPUOrigin3D".to_string(),
+                        c"sequence is too long for GPUOrigin3D".to_owned(),
                     ))
                 } else {
                     Ok(wgpu_types::Origin3d {
@@ -619,7 +619,7 @@ impl TryConvert<wgpu_types::Color> for &GPUColor {
             GPUColor::DoubleSequence(s) => {
                 // https://gpuweb.github.io/gpuweb/#abstract-opdef-validate-gpucolor-shape
                 if s.len() != 4 {
-                    Err(Error::Type("GPUColor sequence must be len 4".to_string()))
+                    Err(Error::Type(c"GPUColor sequence must be len 4".to_owned()))
                 } else {
                     Ok(wgpu_types::Color {
                         r: *s[0],

--- a/components/script/dom/webgpu/gpudevice.rs
+++ b/components/script/dom/webgpu/gpudevice.rs
@@ -8,6 +8,7 @@ use std::rc::Rc;
 
 use dom_struct::dom_struct;
 use js::jsapi::{HandleObject, Heap, JSObject};
+use script_bindings::cformat;
 use webgpu_traits::{
     PopError, WebGPU, WebGPUComputePipeline, WebGPUComputePipelineResponse, WebGPUDevice,
     WebGPUPoppedErrorScopeResponse, WebGPUQueue, WebGPURenderPipeline,
@@ -242,7 +243,7 @@ impl GPUDevice {
         {
             Ok(texture_format)
         } else {
-            Err(Error::Type(format!(
+            Err(Error::Type(cformat!(
                 "{texture_format:?} is not supported by this GPUDevice"
             )))
         }

--- a/components/script/dom/webrtc/rtcicecandidate.rs
+++ b/components/script/dom/webrtc/rtcicecandidate.rs
@@ -92,7 +92,7 @@ impl RTCIceCandidateMethods<crate::DomTypeHolder> for RTCIceCandidate {
     ) -> Fallible<DomRoot<RTCIceCandidate>> {
         if config.sdpMid.is_none() && config.sdpMLineIndex.is_none() {
             return Err(Error::Type(
-                "one of sdpMid and sdpMLineIndex must be set".to_string(),
+                c"one of sdpMid and sdpMLineIndex must be set".to_owned(),
             ));
         }
         Ok(RTCIceCandidate::new_with_proto(

--- a/components/script/dom/webrtc/rtcpeerconnection.rs
+++ b/components/script/dom/webrtc/rtcpeerconnection.rs
@@ -558,7 +558,7 @@ impl RTCPeerConnectionMethods<crate::DomTypeHolder> for RTCPeerConnection {
         let p = Promise::new_in_current_realm(comp, can_gc);
         if candidate.sdpMid.is_none() && candidate.sdpMLineIndex.is_none() {
             p.reject_error(
-                Error::Type("one of sdpMid and sdpMLineIndex must be set".to_string()),
+                Error::Type(c"one of sdpMid and sdpMLineIndex must be set".to_owned()),
                 can_gc,
             );
             return p;
@@ -567,7 +567,7 @@ impl RTCPeerConnectionMethods<crate::DomTypeHolder> for RTCPeerConnection {
         // XXXManishearth add support for sdpMid
         if candidate.sdpMLineIndex.is_none() {
             p.reject_error(
-                Error::Type("servo only supports sdpMLineIndex right now".to_string()),
+                Error::Type(c"servo only supports sdpMLineIndex right now".to_owned()),
                 can_gc,
             );
             return p;

--- a/components/script/dom/webxr/fakexrdevice.rs
+++ b/components/script/dom/webxr/fakexrdevice.rs
@@ -72,7 +72,7 @@ impl FakeXRDevice {
 
 pub(crate) fn view<Eye>(view: &FakeXRViewInit) -> Fallible<MockViewInit<Eye>> {
     if view.projectionMatrix.len() != 16 || view.viewOffset.position.len() != 3 {
-        return Err(Error::Type("Incorrectly sized array".into()));
+        return Err(Error::Type(c"Incorrectly sized array".into()));
     }
 
     let mut proj = [0.; 16];
@@ -126,7 +126,7 @@ pub(crate) fn get_origin<T, U>(
     origin: &FakeXRRigidTransformInit,
 ) -> Fallible<RigidTransform3D<f32, T, U>> {
     if origin.position.len() != 3 || origin.orientation.len() != 4 {
-        return Err(Error::Type("Incorrectly sized array".into()));
+        return Err(Error::Type(c"Incorrectly sized array".into()));
     }
     let p = Vector3D::new(
         *origin.position[0],
@@ -159,7 +159,7 @@ pub(crate) fn get_world(world: &FakeXRWorldInit) -> Fallible<MockWorld> {
                 .map(|face| {
                     if face.vertices.len() != 3 {
                         return Err(Error::Type(
-                            "Incorrectly sized array for triangle list".into(),
+                            c"Incorrectly sized array for triangle list".into(),
                         ));
                     }
 
@@ -329,7 +329,7 @@ impl FakeXRDeviceMethods<crate::DomTypeHolder> for FakeXRDevice {
     fn SetBoundsGeometry(&self, bounds_coodinates: Vec<FakeXRBoundsPoint>) -> Fallible<()> {
         if bounds_coodinates.len() < 3 {
             return Err(Error::Type(
-                "Bounds geometry must contain at least 3 points".into(),
+                c"Bounds geometry must contain at least 3 points".into(),
             ));
         }
         let coords = bounds_coodinates

--- a/components/script/dom/webxr/fakexrinputcontroller.rs
+++ b/components/script/dom/webxr/fakexrinputcontroller.rs
@@ -155,10 +155,10 @@ impl FakeXRInputControllerMethods<crate::DomTypeHolder> for FakeXRInputControlle
     fn UpdateButtonState(&self, button_state: &FakeXRButtonStateInit) -> Fallible<()> {
         // https://immersive-web.github.io/webxr-test-api/#validate-a-button-state
         if (button_state.pressed || *button_state.pressedValue > 0.0) && !button_state.touched {
-            return Err(Error::Type("Pressed button must also be touched".into()));
+            return Err(Error::Type(c"Pressed button must also be touched".into()));
         }
         if *button_state.pressedValue < 0.0 {
-            return Err(Error::Type("Pressed value must be non-negative".into()));
+            return Err(Error::Type(c"Pressed value must be non-negative".into()));
         }
 
         // TODO: Steps 3-5 of updateButtonState

--- a/components/script/dom/webxr/xrframe.rs
+++ b/components/script/dom/webxr/xrframe.rs
@@ -219,7 +219,7 @@ impl XRFrameMethods<crate::DomTypeHolder> for XRFrame {
 
         if joint_spaces.len() > radii.len() {
             return Err(Error::Type(
-                "Length of radii does not match length of joint spaces".to_string(),
+                c"Length of radii does not match length of joint spaces".to_owned(),
             ));
         }
 
@@ -268,7 +268,7 @@ impl XRFrameMethods<crate::DomTypeHolder> for XRFrame {
 
         if spaces.len() * 16 > transforms.len() {
             return Err(Error::Type(
-                "Transforms array length does not match 16 * spaces length".to_string(),
+                c"Transforms array length does not match 16 * spaces length".to_owned(),
             ));
         }
 

--- a/components/script/dom/webxr/xrray.rs
+++ b/components/script/dom/webxr/xrray.rs
@@ -62,14 +62,14 @@ impl XRRayMethods<crate::DomTypeHolder> for XRRay {
         direction: &XRRayDirectionInit,
     ) -> Fallible<DomRoot<Self>> {
         if origin.w != 1.0 {
-            return Err(Error::Type("Origin w coordinate must be 1".into()));
+            return Err(Error::Type(c"Origin w coordinate must be 1".into()));
         }
         if *direction.w != 0.0 {
-            return Err(Error::Type("Direction w coordinate must be 0".into()));
+            return Err(Error::Type(c"Direction w coordinate must be 0".into()));
         }
         if *direction.x == 0.0 && *direction.y == 0.0 && *direction.z == 0.0 {
             return Err(Error::Type(
-                "Direction vector cannot have zero length".into(),
+                c"Direction vector cannot have zero length".into(),
             ));
         }
 

--- a/components/script/dom/webxr/xrrigidtransform.rs
+++ b/components/script/dom/webxr/xrrigidtransform.rs
@@ -6,6 +6,7 @@ use dom_struct::dom_struct;
 use euclid::{RigidTransform3D, Rotation3D, Vector3D};
 use js::rust::HandleObject;
 use js::typedarray::{Float32, HeapFloat32Array};
+use script_bindings::cformat;
 use script_bindings::trace::RootedTraceableBox;
 
 use crate::dom::bindings::buffer_source::HeapBufferSource;
@@ -81,7 +82,7 @@ impl XRRigidTransformMethods<crate::DomTypeHolder> for XRRigidTransform {
         orientation: &DOMPointInit,
     ) -> Fallible<DomRoot<Self>> {
         if position.w != 1.0 {
-            return Err(Error::Type(format!(
+            return Err(Error::Type(cformat!(
                 "XRRigidTransform must be constructed with a position that has a w value of of 1.0, not {}",
                 position.w
             )));
@@ -93,7 +94,7 @@ impl XRRigidTransformMethods<crate::DomTypeHolder> for XRRigidTransform {
             !position.w.is_finite()
         {
             return Err(Error::Type(
-                "Position must not contain non-finite values".into(),
+                c"Position must not contain non-finite values".into(),
             ));
         }
 
@@ -103,7 +104,7 @@ impl XRRigidTransformMethods<crate::DomTypeHolder> for XRRigidTransform {
             !orientation.w.is_finite()
         {
             return Err(Error::Type(
-                "Orientation must not contain non-finite values".into(),
+                c"Orientation must not contain non-finite values".into(),
             ));
         }
 

--- a/components/script/dom/webxr/xrsession.rs
+++ b/components/script/dom/webxr/xrsession.rs
@@ -694,16 +694,16 @@ impl XRSessionMethods<crate::DomTypeHolder> for XRSession {
                     .filter(|other| other.layer_id() == layer.layer_id())
                     .count();
                 if count > 1 {
-                    return Err(Error::Type(String::from("Duplicate entry in WebXR layers")));
+                    return Err(Error::Type(c"Duplicate entry in WebXR layers".to_owned()));
                 }
             }
 
             // Step 3
             for layer in layers {
                 if layer.session() != self {
-                    return Err(Error::Type(String::from(
-                        "Layer from different session in WebXR layers",
-                    )));
+                    return Err(Error::Type(
+                        c"Layer from different session in WebXR layers".to_owned(),
+                    ));
                 }
             }
         }
@@ -1050,7 +1050,7 @@ impl XRSessionMethods<crate::DomTypeHolder> for XRSession {
 
             if !supported_frame_rates.contains(&*rate) {
                 promise.reject_error(
-                    Error::Type("Provided framerate not supported".into()),
+                    Error::Type(c"Provided framerate not supported".into()),
                     can_gc,
                 );
                 return promise;

--- a/components/script/dom/workers/serviceworkercontainer.rs
+++ b/components/script/dom/workers/serviceworkercontainer.rs
@@ -82,7 +82,7 @@ impl ServiceWorkerContainerMethods<crate::DomTypeHolder> for ServiceWorkerContai
             Ok(url) => url,
             Err(_) => {
                 // B: Step 1
-                promise.reject_error(Error::Type("Invalid script URL".to_owned()), can_gc);
+                promise.reject_error(Error::Type(c"Invalid script URL".to_owned()), can_gc);
                 return promise;
             },
         };
@@ -94,7 +94,7 @@ impl ServiceWorkerContainerMethods<crate::DomTypeHolder> for ServiceWorkerContai
                 match api_base_url.join(inner_scope) {
                     Ok(url) => url,
                     Err(_) => {
-                        promise.reject_error(Error::Type("Invalid scope URL".to_owned()), can_gc);
+                        promise.reject_error(Error::Type(c"Invalid scope URL".to_owned()), can_gc);
                         return promise;
                     },
                 }
@@ -109,7 +109,7 @@ impl ServiceWorkerContainerMethods<crate::DomTypeHolder> for ServiceWorkerContai
             "https" | "http" => {},
             _ => {
                 promise.reject_error(
-                    Error::Type("Only secure origins are allowed".to_owned()),
+                    Error::Type(c"Only secure origins are allowed".to_owned()),
                     can_gc,
                 );
                 return promise;
@@ -120,7 +120,7 @@ impl ServiceWorkerContainerMethods<crate::DomTypeHolder> for ServiceWorkerContai
             script_url.path().to_ascii_lowercase().contains("%5c")
         {
             promise.reject_error(
-                Error::Type("Script URL contains forbidden characters".to_owned()),
+                Error::Type(c"Script URL contains forbidden characters".to_owned()),
                 can_gc,
             );
             return promise;
@@ -131,7 +131,7 @@ impl ServiceWorkerContainerMethods<crate::DomTypeHolder> for ServiceWorkerContai
             "https" | "http" => {},
             _ => {
                 promise.reject_error(
-                    Error::Type("Only secure origins are allowed".to_owned()),
+                    Error::Type(c"Only secure origins are allowed".to_owned()),
                     can_gc,
                 );
                 return promise;
@@ -142,7 +142,7 @@ impl ServiceWorkerContainerMethods<crate::DomTypeHolder> for ServiceWorkerContai
             scope.path().to_ascii_lowercase().contains("%5c")
         {
             promise.reject_error(
-                Error::Type("Scope URL contains forbidden characters".to_owned()),
+                Error::Type(c"Scope URL contains forbidden characters".to_owned()),
                 can_gc,
             );
             return promise;
@@ -211,7 +211,7 @@ impl RegisterJobResultHandler {
                         match error {
                             JobError::TypeError => {
                                 promise.reject_error(
-                                    Error::Type("Failed to register a ServiceWorker".to_string()),
+                                    Error::Type(c"Failed to register a ServiceWorker".to_owned()),
                                     CanGc::note(),
                                 );
                             },

--- a/components/script/dom/workers/workerglobalscope.rs
+++ b/components/script/dom/workers/workerglobalscope.rs
@@ -663,7 +663,7 @@ impl WorkerGlobalScopeMethods<crate::DomTypeHolder> for WorkerGlobalScope {
         // Step 1: If worker global scope's type is "module", throw a TypeError exception.
         if self.worker_type == WorkerType::Module {
             return Err(Error::Type(
-                "importScripts() is not allowed in module workers".to_string(),
+                c"importScripts() is not allowed in module workers".to_owned(),
             ));
         }
 

--- a/components/script/dom/xmlserializer.rs
+++ b/components/script/dom/xmlserializer.rs
@@ -65,9 +65,9 @@ impl XMLSerializerMethods<crate::DomTypeHolder> for XMLSerializer {
             },
         ) {
             Ok(_) => Ok(DOMString::from(String::from_utf8(writer).unwrap())),
-            Err(_) => Err(Error::Type(String::from(
-                "root must be a Node or an Attr object",
-            ))),
+            Err(_) => Err(Error::Type(
+                c"root must be a Node or an Attr object".to_owned(),
+            )),
         }
     }
 }

--- a/components/script/dom/xpathexpression.rs
+++ b/components/script/dom/xpathexpression.rs
@@ -71,7 +71,7 @@ impl XPathExpression {
         }
 
         let result_type = XPathResultType::try_from(result_type_num)
-            .map_err(|()| Error::Type("Invalid XPath result type".to_string()))?;
+            .map_err(|()| Error::Type(c"Invalid XPath result type".to_owned()))?;
 
         let global = self.global();
         let window = global.as_window();

--- a/components/script/dom/xpathresult.rs
+++ b/components/script/dom/xpathresult.rs
@@ -163,7 +163,7 @@ impl XPathResultMethods<crate::DomTypeHolder> for XPathResult {
         match (&*self.value.borrow(), self.result_type.get()) {
             (XPathResultValue::Number(n), XPathResultType::Number) => Ok(*n),
             _ => Err(Error::Type(
-                "Can't get number value for non-number XPathResult".to_string(),
+                c"Can't get number value for non-number XPathResult".to_owned(),
             )),
         }
     }
@@ -173,7 +173,7 @@ impl XPathResultMethods<crate::DomTypeHolder> for XPathResult {
         match (&*self.value.borrow(), self.result_type.get()) {
             (XPathResultValue::String(s), XPathResultType::String) => Ok(s.clone()),
             _ => Err(Error::Type(
-                "Can't get string value for non-string XPathResult".to_string(),
+                c"Can't get string value for non-string XPathResult".to_owned(),
             )),
         }
     }
@@ -183,7 +183,7 @@ impl XPathResultMethods<crate::DomTypeHolder> for XPathResult {
         match (&*self.value.borrow(), self.result_type.get()) {
             (XPathResultValue::Boolean(b), XPathResultType::Boolean) => Ok(*b),
             _ => Err(Error::Type(
-                "Can't get boolean value for non-boolean XPathResult".to_string(),
+                c"Can't get boolean value for non-boolean XPathResult".to_owned(),
             )),
         }
     }
@@ -194,7 +194,7 @@ impl XPathResultMethods<crate::DomTypeHolder> for XPathResult {
             self.result_type.get(),
             XPathResultType::OrderedNodeIterator | XPathResultType::UnorderedNodeIterator
         ) {
-            return Err(Error::Type("Result is not an iterator".into()));
+            return Err(Error::Type(c"Result is not an iterator".into()));
         }
 
         if self.document_changed_since_creation() {
@@ -203,7 +203,7 @@ impl XPathResultMethods<crate::DomTypeHolder> for XPathResult {
 
         let XPathResultValue::Nodeset(nodes) = &*self.value.borrow() else {
             return Err(Error::Type(
-                "Can't iterate on XPathResult that is not a node-set".to_string(),
+                c"Can't iterate on XPathResult that is not a node-set".to_owned(),
             ));
         };
 
@@ -235,7 +235,7 @@ impl XPathResultMethods<crate::DomTypeHolder> for XPathResult {
                 XPathResultType::OrderedNodeSnapshot | XPathResultType::UnorderedNodeSnapshot,
             ) => Ok(nodes.len() as u32),
             _ => Err(Error::Type(
-                "Can't get snapshot length of XPathResult that is not a snapshot".to_string(),
+                c"Can't get snapshot length of XPathResult that is not a snapshot".to_owned(),
             )),
         }
     }
@@ -248,7 +248,7 @@ impl XPathResultMethods<crate::DomTypeHolder> for XPathResult {
                 XPathResultType::OrderedNodeSnapshot | XPathResultType::UnorderedNodeSnapshot,
             ) => Ok(nodes.get(index as usize).cloned()),
             _ => Err(Error::Type(
-                "Can't get snapshot item of XPathResult that is not a snapshot".to_string(),
+                c"Can't get snapshot item of XPathResult that is not a snapshot".to_owned(),
             )),
         }
     }
@@ -261,7 +261,7 @@ impl XPathResultMethods<crate::DomTypeHolder> for XPathResult {
                 XPathResultType::AnyUnorderedNode | XPathResultType::FirstOrderedNode,
             ) => Ok(nodes.first().cloned()),
             _ => Err(Error::Type(
-                "Getting single value requires result type 'any unordered node' or 'first ordered node'".to_string(),
+                c"Getting single value requires result type 'any unordered node' or 'first ordered node'".to_owned(),
             )),
         }
     }

--- a/components/script/module_loading.rs
+++ b/components/script/module_loading.rs
@@ -521,7 +521,7 @@ pub(crate) fn host_load_imported_module(
             // Step 2. If moduleScript is null, then set completion to ThrowCompletion(a new TypeError).
             None => Err(gen_type_error(
                 &global_scope,
-                Error::Type("Module fetching failed".to_string()),
+                Error::Type(c"Module fetching failed".to_owned()),
                 CanGc::from_cx(cx),
             )),
             Some(module_tree) => {

--- a/components/script/script_module.rs
+++ b/components/script/script_module.rs
@@ -592,7 +592,7 @@ impl ModuleTree {
             // Step 14. Throw a TypeError indicating that specifier was a bare specifier,
             // but was not remapped to anything by importMap.
             None => Err(Error::Type(
-                "Specifier was a bare specifier, but was not remapped to anything by importMap."
+                c"Specifier was a bare specifier, but was not remapped to anything by importMap."
                     .to_owned(),
             )),
         }
@@ -1686,12 +1686,12 @@ pub(crate) fn parse_an_import_map_string(
 ) -> Fallible<ImportMap> {
     // Step 1. Let parsed be the result of parsing a JSON string to an Infra value given input.
     let parsed: JsonValue = serde_json::from_str(&input.str())
-        .map_err(|_| Error::Type("The value needs to be a JSON object.".to_owned()))?;
+        .map_err(|_| Error::Type(c"The value needs to be a JSON object.".to_owned()))?;
     // Step 2. If parsed is not an ordered map, then throw a TypeError indicating that the
     // top-level value needs to be a JSON object.
     let JsonValue::Object(mut parsed) = parsed else {
         return Err(Error::Type(
-            "The top-level value needs to be a JSON object.".to_owned(),
+            c"The top-level value needs to be a JSON object.".to_owned(),
         ));
     };
 
@@ -1703,7 +1703,7 @@ pub(crate) fn parse_an_import_map_string(
         // indicating that the value for the "imports" top-level key needs to be a JSON object.
         let JsonValue::Object(imports) = imports else {
             return Err(Error::Type(
-                "The \"imports\" top-level value needs to be a JSON object.".to_owned(),
+                c"The \"imports\" top-level value needs to be a JSON object.".to_owned(),
             ));
         };
         // Step 4.2 Set sortedAndNormalizedImports to the result of sorting and
@@ -1724,7 +1724,7 @@ pub(crate) fn parse_an_import_map_string(
         // indicating that the value for the "scopes" top-level key needs to be a JSON object.
         let JsonValue::Object(scopes) = scopes else {
             return Err(Error::Type(
-                "The \"scopes\" top-level value needs to be a JSON object.".to_owned(),
+                c"The \"scopes\" top-level value needs to be a JSON object.".to_owned(),
             ));
         };
         // Step 6.2 Set sortedAndNormalizedScopes to the result of sorting and
@@ -1741,7 +1741,7 @@ pub(crate) fn parse_an_import_map_string(
         // indicating that the value for the "integrity" top-level key needs to be a JSON object.
         let JsonValue::Object(integrity) = integrity else {
             return Err(Error::Type(
-                "The \"integrity\" top-level value needs to be a JSON object.".to_owned(),
+                c"The \"integrity\" top-level value needs to be a JSON object.".to_owned(),
             ));
         };
         // Step 8.2 Set normalizedIntegrity to the result of normalizing
@@ -1871,7 +1871,7 @@ fn sort_and_normalize_scopes(
         // that the value of the scope with prefix scopePrefix needs to be a JSON object.
         let JsonValue::Object(potential_specifier_map) = potential_specifier_map else {
             return Err(Error::Type(
-                "The value of the scope with prefix scopePrefix needs to be a JSON object."
+                c"The value of the scope with prefix scopePrefix needs to be a JSON object."
                     .to_owned(),
             ));
         };
@@ -2012,7 +2012,7 @@ pub(crate) fn resolve_imports_match(
             } else {
                 // Step 1.1.1 If resolutionResult is null, then throw a TypeError.
                 return Err(Error::Type(
-                    "Resolution of specifierKey was blocked by a null entry.".to_owned(),
+                    c"Resolution of specifierKey was blocked by a null entry.".to_owned(),
                 ));
             }
         }
@@ -2029,7 +2029,7 @@ pub(crate) fn resolve_imports_match(
             // Step 1.2.2 Assert: resolutionResult is a URL.
             let Some(resolution_result) = resolution_result else {
                 return Err(Error::Type(
-                    "Resolution of specifierKey was blocked by a null entry.".to_owned(),
+                    c"Resolution of specifierKey was blocked by a null entry.".to_owned(),
                 ));
             };
 
@@ -2048,7 +2048,7 @@ pub(crate) fn resolve_imports_match(
             // Step 1.2.7 Assert: url is a URL.
             let Ok(url) = url else {
                 return Err(Error::Type(
-                    "Resolution of normalizedSpecifier was blocked since
+                    c"Resolution of normalizedSpecifier was blocked since
                     the afterPrefix portion could not be URL-parsed relative to
                     the resolutionResult mapped to by the specifierKey prefix."
                         .to_owned(),
@@ -2059,7 +2059,7 @@ pub(crate) fn resolve_imports_match(
             // a code unit prefix of the serialization of url, then throw a TypeError
             if !url.as_str().starts_with(resolution_result.as_str()) {
                 return Err(Error::Type(
-                    "Resolution of normalizedSpecifier was blocked due to
+                    c"Resolution of normalizedSpecifier was blocked due to
                     it backtracking above its prefix specifierKey."
                         .to_owned(),
                 ));

--- a/components/script/script_runtime.rs
+++ b/components/script/script_runtime.rs
@@ -1299,7 +1299,7 @@ unsafe extern "C" fn consume_stream(
             throw_dom_exception(
                 cx,
                 &global,
-                Error::Type("Response has unsupported MIME type".to_string()),
+                Error::Type(c"Response has unsupported MIME type".to_owned()),
                 CanGc::note(),
             );
             return false;
@@ -1312,7 +1312,7 @@ unsafe extern "C" fn consume_stream(
                 throw_dom_exception(
                     cx,
                     &global,
-                    Error::Type("Response.type must be 'basic', 'cors' or 'default'".to_string()),
+                    Error::Type(c"Response.type must be 'basic', 'cors' or 'default'".to_owned()),
                     CanGc::note(),
                 );
                 return false;
@@ -1324,7 +1324,7 @@ unsafe extern "C" fn consume_stream(
             throw_dom_exception(
                 cx,
                 &global,
-                Error::Type("Response does not have ok status".to_string()),
+                Error::Type(c"Response does not have ok status".to_owned()),
                 CanGc::note(),
             );
             return false;
@@ -1335,7 +1335,7 @@ unsafe extern "C" fn consume_stream(
             throw_dom_exception(
                 cx,
                 &global,
-                Error::Type("There was an error consuming the Response".to_string()),
+                Error::Type(c"There was an error consuming the Response".to_owned()),
                 CanGc::note(),
             );
             return false;
@@ -1346,7 +1346,7 @@ unsafe extern "C" fn consume_stream(
             throw_dom_exception(
                 cx,
                 &global,
-                Error::Type("Response already consumed".to_string()),
+                Error::Type(c"Response already consumed".to_owned()),
                 CanGc::note(),
             );
             return false;
@@ -1357,7 +1357,7 @@ unsafe extern "C" fn consume_stream(
         throw_dom_exception(
             cx,
             &global,
-            Error::Type("expected Response or Promise resolving to Response".to_string()),
+            Error::Type(c"expected Response or Promise resolving to Response".to_owned()),
             CanGc::note(),
         );
         return false;

--- a/components/script_bindings/callback.rs
+++ b/components/script_bindings/callback.rs
@@ -16,7 +16,6 @@ use js::jsval::{JSVal, NullValue, ObjectValue, UndefinedValue};
 use js::rust::wrappers::{JS_GetProperty, JS_WrapObject};
 use js::rust::{HandleObject, MutableHandleValue, Runtime};
 
-use crate::DomTypes;
 use crate::codegen::GenericBindings::WindowBinding::Window_Binding::WindowMethods;
 use crate::error::{Error, Fallible};
 use crate::inheritance::Castable;
@@ -26,6 +25,7 @@ use crate::reflector::DomObject;
 use crate::root::{Dom, DomRoot};
 use crate::script_runtime::{CanGc, JSContext};
 use crate::settings_stack::{GenericAutoEntryScript, GenericAutoIncumbentScript};
+use crate::{DomTypes, cformat};
 
 pub trait ThisReflector {
     fn jsobject(&self) -> *mut JSObject;
@@ -221,7 +221,7 @@ impl<D: DomTypes> CallbackInterface<D> {
             }
 
             if !callable.is_object() || !IsCallable(callable.to_object()) {
-                return Err(Error::Type(format!(
+                return Err(Error::Type(cformat!(
                     "The value of the {} property is not callable",
                     name
                 )));

--- a/components/script_bindings/error.rs
+++ b/components/script_bindings/error.rs
@@ -80,9 +80,9 @@ pub enum Error {
     Constraint(Option<String>),
 
     /// TypeError JavaScript Error
-    Type(String),
+    Type(CString),
     /// RangeError JavaScript Error
-    Range(String),
+    Range(CString),
 
     /// A JavaScript exception is already pending.
     JSFailed,

--- a/components/script_bindings/str.rs
+++ b/components/script_bindings/str.rs
@@ -202,5 +202,5 @@ pub fn serialize_jsval_to_json_utf8(cx: JSContext, data: HandleValue) -> Result<
     out_str
         .string
         .map(Into::into)
-        .ok_or_else(|| Error::Type("unable to serialize JSON".to_owned()))
+        .ok_or_else(|| Error::Type(c"unable to serialize JSON".to_owned()))
 }


### PR DESCRIPTION
Continuation of https://github.com/servo/servo/pull/42135, switch Error::Type and Error::Range to also use CStrings internally, as they are converted to CString for throwing JS exceptions (other get thrown as DomException object, which uses rust string internally).

Changes in script crate are mechanical.

Testing: Should be covered by WPT tests.
Part of #42126
