### PR TITLE
layout: Fix intrinsic size of replaced with ratio and natural height only

### DIFF
--- a/components/layout/formatting_contexts.rs
+++ b/components/layout/formatting_contexts.rs
@@ -220,8 +220,14 @@ impl IndependentFormattingContext {
                 // For replaced elements with no ratio, the returned value doesn't matter.
                 let ratio = preferred_aspect_ratio?;
                 let writing_mode = self.style().writing_mode;
-                let inline_size = contents.fallback_inline_size(writing_mode);
-                let block_size = ratio.compute_dependent_size(Direction::Block, inline_size);
+                let natural_sizes = contents.logical_natural_sizes(writing_mode);
+                let block_size = match (natural_sizes.block, natural_sizes.inline) {
+                    (Some(block_size), None) => block_size,
+                    _ => {
+                        let inline_size = contents.fallback_inline_size(writing_mode);
+                        ratio.compute_dependent_size(Direction::Block, inline_size)
+                    },
+                };
                 Some(block_size.into())
             },
             _ => None,

--- a/components/layout/replaced.rs
+++ b/components/layout/replaced.rs
@@ -645,6 +645,23 @@ impl ReplacedContents {
         }
     }
 
+    pub(crate) fn logical_natural_sizes(
+        &self,
+        writing_mode: WritingMode,
+    ) -> LogicalVec2<Option<Au>> {
+        if writing_mode.is_horizontal() {
+            LogicalVec2 {
+                inline: self.natural_size.width,
+                block: self.natural_size.height,
+            }
+        } else {
+            LogicalVec2 {
+                inline: self.natural_size.height,
+                block: self.natural_size.width,
+            }
+        }
+    }
+
     #[inline]
     pub(crate) fn layout_style<'a>(&self, base: &'a LayoutBoxBase) -> LayoutStyle<'a> {
         LayoutStyle::Default(&base.style)

--- a/tests/wpt/meta/css/css-sizing/svg-intrinsic-size-001.html.ini
+++ b/tests/wpt/meta/css/css-sizing/svg-intrinsic-size-001.html.ini
@@ -1,6 +1,3 @@
 [svg-intrinsic-size-001.html]
-  [svg 2]
-    expected: FAIL
-
   [svg 5]
     expected: FAIL

--- a/tests/wpt/meta/css/css-sizing/svg-intrinsic-size-002.html.ini
+++ b/tests/wpt/meta/css/css-sizing/svg-intrinsic-size-002.html.ini
@@ -1,6 +1,3 @@
 [svg-intrinsic-size-002.html]
-  [svg 2]
-    expected: FAIL
-
   [svg 5]
     expected: FAIL

--- a/tests/wpt/meta/css/css-sizing/svg-intrinsic-size-003.html.ini
+++ b/tests/wpt/meta/css/css-sizing/svg-intrinsic-size-003.html.ini
@@ -1,6 +1,3 @@
 [svg-intrinsic-size-003.html]
-  [svg 2]
-    expected: FAIL
-
   [svg 5]
     expected: FAIL

--- a/tests/wpt/meta/css/css-sizing/svg-intrinsic-size-004.html.ini
+++ b/tests/wpt/meta/css/css-sizing/svg-intrinsic-size-004.html.ini
@@ -1,6 +1,3 @@
 [svg-intrinsic-size-004.html]
-  [svg 2]
-    expected: FAIL
-
   [svg 5]
     expected: FAIL


### PR DESCRIPTION
If a replaced element has a natural width and a natural height, then the natural width wins, and the intrinsic height is computed thru the preferred aspect ratio.

If it has no natural width and no natural height, then the width falls back to 300px, and again compute the intrinsic height thru the ratio.

However, if it has a natural height but no natural width, then we should compute the intrinsic width from the natural height thru the ratio. We were still letting the 300px fallback width win.

Testing: Some tests pass
Fixes: #42573
