### PR TITLE
devtools: implement pause and resume in debugger

### DIFF
--- a/components/devtools/actors/thread.rs
+++ b/components/devtools/actors/thread.rs
@@ -38,11 +38,11 @@ enum PoppedFrameMsg {}
 
 #[derive(Serialize)]
 #[serde(rename_all = "camelCase")]
-struct WhyMsg {
+pub(crate) struct WhyMsg {
     #[serde(rename = "type")]
-    type_: String,
+    pub type_: String,
     #[serde(skip_serializing_if = "Option::is_none")]
-    on_next: Option<bool>,
+    pub on_next: Option<bool>,
 }
 
 #[derive(Serialize)]
@@ -53,13 +53,13 @@ struct ThreadResumedReply {
 }
 
 #[derive(Serialize)]
-struct ThreadInterruptedReply {
-    from: String,
+pub(crate) struct ThreadInterruptedReply {
+    pub from: String,
     #[serde(rename = "type")]
-    type_: String,
-    actor: String,
-    frame: FrameActorMsg,
-    why: WhyMsg,
+    pub type_: String,
+    pub actor: String,
+    pub frame: FrameActorMsg,
+    pub why: WhyMsg,
 }
 
 #[derive(Serialize)]
@@ -79,7 +79,7 @@ pub(crate) struct ThreadActor {
     name: String,
     pub source_manager: SourceManager,
     script_sender: GenericSender<DevtoolScriptControlMsg>,
-    frames: AtomicRefCell<HashSet<String>>,
+    pub frames: AtomicRefCell<HashSet<String>>,
 }
 
 impl ThreadActor {
@@ -131,6 +131,8 @@ impl Actor for ThreadActor {
             },
 
             "resume" => {
+                let _ = self.script_sender.send(DevtoolScriptControlMsg::Resume);
+
                 let msg = ThreadResumedReply {
                     from: self.name(),
                     type_: "resumed".to_owned(),

--- a/components/script_bindings/webidls/DebuggerPauseEvent.webidl
+++ b/components/script_bindings/webidls/DebuggerPauseEvent.webidl
@@ -11,6 +11,8 @@ partial interface DebuggerGlobalScope {
     undefined getFrameResult(
         DebuggerPauseEvent event,
         PauseFrameResult result);
+
+    undefined notifyBreakpointHit(PipelineIdInit pipelineId, PauseFrameResult result);
 };
 
 dictionary PauseFrameResult {

--- a/components/shared/devtools/lib.rs
+++ b/components/shared/devtools/lib.rs
@@ -131,6 +131,9 @@ pub enum ScriptToDevtoolsControlMsg {
     UpdateSourceContent(PipelineId, String),
 
     DomMutation(PipelineId, DomMutation),
+
+    /// A breakpoint was hit in script, sending frame information.
+    BreakpointHit(PipelineId, PauseFrameResult),
 }
 
 #[derive(Clone, Debug, Deserialize, MallocSizeOf, Serialize)]
@@ -332,6 +335,7 @@ pub enum DevtoolScriptControlMsg {
     SetBreakpoint(u32, u32, u32),
     ClearBreakpoint(u32, u32, u32),
     Pause(GenericSender<PauseFrameResult>),
+    Resume,
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize, MallocSizeOf)]
@@ -563,7 +567,7 @@ pub struct RecommendedBreakpointLocation {
     pub is_step_start: bool,
 }
 
-#[derive(Clone, Debug, Deserialize, Serialize, MallocSizeOf)]
+#[derive(Clone, Debug, Deserialize, MallocSizeOf, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct PauseFrameResult {
     pub column: u32,

--- a/python/servo/devtools_tests/breakpoint/breakpoint_hit.html
+++ b/python/servo/devtools_tests/breakpoint/breakpoint_hit.html
@@ -1,0 +1,11 @@
+<!doctype html><meta charset=utf-8>
+<script>
+    function testBreakpointHit() {
+        let x = 1;
+        let y = 2;
+        let z = x + y;
+        console.log("z =", z);
+        return z;
+    }
+</script>
+


### PR DESCRIPTION
When a breakpoint is hit, the script thread now pauses execution and
notifies devtools clients with a "paused" event. The script
thread enters a loop that processes devtools messages until
a Resume command is received.

This change does not implement manual pause

Testing: Added new test
Fixes: part of https://github.com/servo/servo/issues/36027



https://github.com/user-attachments/assets/c619db20-4579-4f77-aa60-0e43e6e7e575


