### PR TITLE
devtools: Properly handle opening and closing client connections 

### DIFF
--- a/components/devtools/actors/watcher.rs
+++ b/components/devtools/actors/watcher.rs
@@ -441,11 +441,11 @@ impl WatcherActor {
         watcher
     }
 
-    pub fn emit_will_navigate(
+    pub fn emit_will_navigate<'a>(
         &self,
         browsing_context_id: BrowsingContextId,
         url: ServoUrl,
-        connections: &mut Vec<TcpStream>,
+        connections: impl Iterator<Item = &'a mut TcpStream>,
         id_map: &mut IdMap,
     ) {
         let msg = WillNavigateMessage {

--- a/components/devtools/lib.rs
+++ b/components/devtools/lib.rs
@@ -18,7 +18,6 @@ use std::net::{Shutdown, TcpListener, TcpStream};
 use std::sync::{Arc, Mutex};
 use std::thread;
 
-use atomic_refcell::AtomicRefCell;
 use base::generic_channel::{self, GenericSender};
 use base::id::{BrowsingContextId, PipelineId, WebViewId};
 use crossbeam_channel::{Receiver, Sender, unbounded};
@@ -160,7 +159,7 @@ struct DevtoolsInstance {
     ///
     /// Client threads remove their connection from here once they exit.
     #[conditional_malloc_size_of]
-    connections: Arc<AtomicRefCell<FxHashMap<StreamId, TcpStream>>>,
+    connections: Arc<Mutex<FxHashMap<StreamId, TcpStream>>>,
     next_resource_id: u64,
 }
 
@@ -238,9 +237,18 @@ impl DevtoolsInstance {
                     let actors = self.registry.clone();
                     let id = next_id;
                     next_id = StreamId(id.0 + 1);
-                    self.connections
-                        .borrow_mut()
-                        .insert(id, stream.try_clone().unwrap());
+
+                    let mut connections = self.connections.lock().unwrap();
+                    if connections.is_empty() {
+                        // We used to have no connection, now we have one.
+                        // Therefore, we need updates from script threads.
+                        for browsing_context in self.browsing_contexts.values() {
+                            let actor =
+                                self.registry.find::<BrowsingContextActor>(browsing_context);
+                            actor.instruct_script_to_send_live_updates(true);
+                        }
+                    }
+                    connections.insert(id, stream.try_clone().unwrap());
 
                     let connections_clone = self.connections.clone();
                     let sender_clone = self.sender.clone();
@@ -335,17 +343,14 @@ impl DevtoolsInstance {
                     request_id,
                     network_event,
                 )) => {
-                    let connections_map = self.connections.borrow_mut();
-
                     // copy the connections vector
                     // FIXME: Why do we need to do this? Cloning the connections here is
                     // almost certainly wrong and means that they might shut down without
                     // us noticing.
                     let mut connections = Vec::<TcpStream>::new();
-                    for stream in connections_map.values() {
+                    for stream in self.connections.lock().unwrap().values() {
                         connections.push(stream.try_clone().unwrap());
                     }
-                    drop(connections_map);
                     self.handle_network_event(connections, request_id, network_event);
                 },
                 DevtoolsControlMsg::FromChrome(ChromeToDevtoolsControlMsg::ServerExitMsg) => break,
@@ -362,7 +367,7 @@ impl DevtoolsInstance {
                     });
                 },
                 DevtoolsControlMsg::ClientExited => {
-                    if self.connections.borrow().is_empty() {
+                    if self.connections.lock().unwrap().is_empty() {
                         // Tell every browsing context to stop sending us updates, because we have nowhere to
                         // send them to.
                         for browsing_context in self.browsing_contexts.values() {
@@ -376,7 +381,7 @@ impl DevtoolsInstance {
         }
 
         // Shut down all active connections
-        let mut connections = self.connections.borrow_mut();
+        let mut connections = self.connections.lock().unwrap();
         for connection in connections.values_mut() {
             let _ = connection.shutdown(Shutdown::Both);
         }
@@ -394,7 +399,7 @@ impl DevtoolsInstance {
         let actors = &self.registry;
         let actor = actors.find::<BrowsingContextActor>(actor_name);
         let mut id_map = self.id_map.lock().expect("Mutex poisoned");
-        let mut connections = self.connections.borrow_mut();
+        let mut connections = self.connections.lock().unwrap();
         if let NavigationState::Start(url) = &state {
             let watcher_actor = actors.find::<WatcherActor>(&actor.watcher);
             watcher_actor.emit_will_navigate(
@@ -510,8 +515,7 @@ impl DevtoolsInstance {
         let console_actor = actors.find::<ConsoleActor>(&console_actor_name);
         let id = worker_id.map_or(UniqueId::Pipeline(pipeline_id), UniqueId::Worker);
 
-        let mut connections = self.connections.borrow_mut();
-        for stream in connections.values_mut() {
+        for stream in self.connections.lock().unwrap().values_mut() {
             console_actor.handle_console_resource(resource.clone(), id.clone(), actors, stream);
         }
     }
@@ -525,8 +529,7 @@ impl DevtoolsInstance {
         let console_actor = actors.find::<ConsoleActor>(&console_actor_name);
         let id = worker_id.map_or(UniqueId::Pipeline(pipeline_id), UniqueId::Worker);
 
-        let mut connections = self.connections.borrow_mut();
-        for stream in connections.values_mut() {
+        for stream in self.connections.lock().unwrap().values_mut() {
             console_actor.send_clear_message(id.clone(), actors, stream);
         }
     }
@@ -638,8 +641,7 @@ impl DevtoolsInstance {
 
             let worker_actor = actors.find::<WorkerActor>(worker_actor_name);
 
-            let mut connections = self.connections.borrow_mut();
-            for stream in connections.values_mut() {
+            for stream in self.connections.lock().unwrap().values_mut() {
                 worker_actor.resource_array(
                     &source_form,
                     "source".into(),
@@ -666,8 +668,7 @@ impl DevtoolsInstance {
             // Notify browsing context about the new source
             let browsing_context = actors.find::<BrowsingContextActor>(actor_name);
 
-            let mut connections = self.connections.borrow_mut();
-            for stream in connections.values_mut() {
+            for stream in self.connections.lock().unwrap().values_mut() {
                 browsing_context.resource_array(
                     &source_form,
                     "source".into(),
@@ -728,7 +729,7 @@ fn handle_client(
     actors: Arc<ActorRegistry>,
     mut stream: TcpStream,
     stream_id: StreamId,
-    connections: Arc<AtomicRefCell<FxHashMap<StreamId, TcpStream>>>,
+    connections: Arc<Mutex<FxHashMap<StreamId, TcpStream>>>,
     sender: Sender<DevtoolsControlMsg>,
 ) {
     log::info!("Connection established to {}", stream.peer_addr().unwrap());
@@ -760,7 +761,7 @@ fn handle_client(
         }
     }
 
-    connections.borrow_mut().remove(&stream_id);
+    connections.lock().unwrap().remove(&stream_id);
     let _ = sender.send(DevtoolsControlMsg::ClientExited);
 
     actors.cleanup(stream_id);

--- a/components/devtools/lib.rs
+++ b/components/devtools/lib.rs
@@ -18,6 +18,7 @@ use std::net::{Shutdown, TcpListener, TcpStream};
 use std::sync::{Arc, Mutex};
 use std::thread;
 
+use atomic_refcell::AtomicRefCell;
 use base::generic_channel::{self, GenericSender};
 use base::id::{BrowsingContextId, PipelineId, WebViewId};
 use crossbeam_channel::{Receiver, Sender, unbounded};
@@ -148,11 +149,18 @@ struct DevtoolsInstance {
     #[conditional_malloc_size_of]
     id_map: Arc<Mutex<IdMap>>,
     browsing_contexts: FxHashMap<BrowsingContextId, String>,
+    /// This is handed to clients so they can notify the devtools instance when
+    /// their connection closes.
+    sender: Sender<DevtoolsControlMsg>,
     receiver: Receiver<DevtoolsControlMsg>,
     pipelines: FxHashMap<PipelineId, BrowsingContextId>,
     actor_workers: FxHashMap<WorkerId, String>,
     actor_requests: HashMap<String, String>,
-    connections: FxHashMap<StreamId, TcpStream>,
+    /// A map of active TCP connections to devtools clients.
+    ///
+    /// Client threads remove their connection from here once they exit.
+    #[conditional_malloc_size_of]
+    connections: Arc<AtomicRefCell<FxHashMap<StreamId, TcpStream>>>,
     next_resource_id: u64,
 }
 
@@ -191,10 +199,11 @@ impl DevtoolsInstance {
             id_map: Arc::new(Mutex::new(IdMap::default())),
             browsing_contexts: FxHashMap::default(),
             pipelines: FxHashMap::default(),
+            sender: sender.clone(),
             receiver,
             actor_requests: HashMap::new(),
             actor_workers: FxHashMap::default(),
-            connections: FxHashMap::default(),
+            connections: Default::default(),
             next_resource_id: 1,
         };
 
@@ -229,18 +238,23 @@ impl DevtoolsInstance {
                     let actors = self.registry.clone();
                     let id = next_id;
                     next_id = StreamId(id.0 + 1);
-                    self.connections.insert(id, stream.try_clone().unwrap());
+                    self.connections
+                        .borrow_mut()
+                        .insert(id, stream.try_clone().unwrap());
 
-                    // Inform every browsing context of the new stream
-                    for name in self.browsing_contexts.values() {
-                        let browsing_context = actors.find::<BrowsingContextActor>(name);
-                        let mut streams = browsing_context.streams.borrow_mut();
-                        streams.insert(id, stream.try_clone().unwrap());
-                    }
-
+                    let connections_clone = self.connections.clone();
+                    let sender_clone = self.sender.clone();
                     thread::Builder::new()
                         .name("DevtoolsClientHandler".to_owned())
-                        .spawn(move || handle_client(actors, stream.try_clone().unwrap(), id))
+                        .spawn(move || {
+                            handle_client(
+                                actors,
+                                stream.try_clone().unwrap(),
+                                id,
+                                connections_clone,
+                                sender_clone,
+                            )
+                        })
                         .expect("Thread spawning failed");
                 },
                 DevtoolsControlMsg::FromScript(ScriptToDevtoolsControlMsg::FramerateTick(
@@ -321,12 +335,17 @@ impl DevtoolsInstance {
                     request_id,
                     network_event,
                 )) => {
+                    let connections_map = self.connections.borrow_mut();
+
                     // copy the connections vector
+                    // FIXME: Why do we need to do this? Cloning the connections here is
+                    // almost certainly wrong and means that they might shut down without
+                    // us noticing.
                     let mut connections = Vec::<TcpStream>::new();
-                    for stream in self.connections.values() {
+                    for stream in connections_map.values() {
                         connections.push(stream.try_clone().unwrap());
                     }
-
+                    drop(connections_map);
                     self.handle_network_event(connections, request_id, network_event);
                 },
                 DevtoolsControlMsg::FromChrome(ChromeToDevtoolsControlMsg::ServerExitMsg) => break,
@@ -342,13 +361,26 @@ impl DevtoolsInstance {
                         chan.send(ProcessReports::new(reports));
                     });
                 },
+                DevtoolsControlMsg::ClientExited => {
+                    if self.connections.borrow().is_empty() {
+                        // Tell every browsing context to stop sending us updates, because we have nowhere to
+                        // send them to.
+                        for browsing_context in self.browsing_contexts.values() {
+                            let actor =
+                                self.registry.find::<BrowsingContextActor>(browsing_context);
+                            actor.instruct_script_to_send_live_updates(false);
+                        }
+                    }
+                },
             }
         }
 
         // Shut down all active connections
-        for connection in self.connections.values_mut() {
+        let mut connections = self.connections.borrow_mut();
+        for connection in connections.values_mut() {
             let _ = connection.shutdown(Shutdown::Both);
         }
+        connections.clear();
     }
 
     fn handle_framerate_tick(&self, actor_name: String, tick: f64) {
@@ -362,20 +394,18 @@ impl DevtoolsInstance {
         let actors = &self.registry;
         let actor = actors.find::<BrowsingContextActor>(actor_name);
         let mut id_map = self.id_map.lock().expect("Mutex poisoned");
+        let mut connections = self.connections.borrow_mut();
         if let NavigationState::Start(url) = &state {
-            let mut connections = Vec::<TcpStream>::new();
-            for stream in self.connections.values() {
-                connections.push(stream.try_clone().unwrap());
-            }
             let watcher_actor = actors.find::<WatcherActor>(&actor.watcher);
             watcher_actor.emit_will_navigate(
                 browsing_context_id,
                 url.clone(),
-                &mut connections,
+                &mut connections.values_mut(),
                 &mut id_map,
             );
         };
-        actor.navigate(state, &mut id_map);
+
+        actor.navigate(state, &mut id_map, connections.values_mut());
     }
 
     // We need separate actor representations for each script global that exists;
@@ -444,13 +474,6 @@ impl DevtoolsInstance {
                     name
                 });
 
-            // Add existing streams to the new browsing context
-            let browsing_context = actors.find::<BrowsingContextActor>(name);
-            let mut streams = browsing_context.streams.borrow_mut();
-            for (id, stream) in &self.connections {
-                streams.insert(*id, stream.try_clone().unwrap());
-            }
-
             Root::BrowsingContext(name.clone())
         };
 
@@ -486,7 +509,9 @@ impl DevtoolsInstance {
         let actors = &self.registry;
         let console_actor = actors.find::<ConsoleActor>(&console_actor_name);
         let id = worker_id.map_or(UniqueId::Pipeline(pipeline_id), UniqueId::Worker);
-        for stream in self.connections.values_mut() {
+
+        let mut connections = self.connections.borrow_mut();
+        for stream in connections.values_mut() {
             console_actor.handle_console_resource(resource.clone(), id.clone(), actors, stream);
         }
     }
@@ -499,7 +524,9 @@ impl DevtoolsInstance {
         let actors = &self.registry;
         let console_actor = actors.find::<ConsoleActor>(&console_actor_name);
         let id = worker_id.map_or(UniqueId::Pipeline(pipeline_id), UniqueId::Worker);
-        for stream in self.connections.values_mut() {
+
+        let mut connections = self.connections.borrow_mut();
+        for stream in connections.values_mut() {
             console_actor.send_clear_message(id.clone(), actors, stream);
         }
     }
@@ -611,7 +638,8 @@ impl DevtoolsInstance {
 
             let worker_actor = actors.find::<WorkerActor>(worker_actor_name);
 
-            for stream in self.connections.values_mut() {
+            let mut connections = self.connections.borrow_mut();
+            for stream in connections.values_mut() {
                 worker_actor.resource_array(
                     &source_form,
                     "source".into(),
@@ -638,7 +666,8 @@ impl DevtoolsInstance {
             // Notify browsing context about the new source
             let browsing_context = actors.find::<BrowsingContextActor>(actor_name);
 
-            for stream in self.connections.values_mut() {
+            let mut connections = self.connections.borrow_mut();
+            for stream in connections.values_mut() {
                 browsing_context.resource_array(
                     &source_form,
                     "source".into(),
@@ -695,7 +724,13 @@ fn allow_devtools_client(stream: &mut TcpStream, embedder: &EmbedderProxy, token
 }
 
 /// Process the input from a single devtools client until EOF.
-fn handle_client(actors: Arc<ActorRegistry>, mut stream: TcpStream, stream_id: StreamId) {
+fn handle_client(
+    actors: Arc<ActorRegistry>,
+    mut stream: TcpStream,
+    stream_id: StreamId,
+    connections: Arc<AtomicRefCell<FxHashMap<StreamId, TcpStream>>>,
+    sender: Sender<DevtoolsControlMsg>,
+) {
     log::info!("Connection established to {}", stream.peer_addr().unwrap());
     let msg = actors.encode::<RootActor, _>("root");
     if let Err(error) = stream.write_json_packet(&msg) {
@@ -724,6 +759,9 @@ fn handle_client(actors: Arc<ActorRegistry>, mut stream: TcpStream, stream_id: S
             },
         }
     }
+
+    connections.borrow_mut().remove(&stream_id);
+    let _ = sender.send(DevtoolsControlMsg::ClientExited);
 
     actors.cleanup(stream_id);
 }

--- a/components/shared/devtools/lib.rs
+++ b/components/shared/devtools/lib.rs
@@ -63,6 +63,9 @@ pub enum DevtoolsControlMsg {
     FromChrome(ChromeToDevtoolsControlMsg),
     /// Messages from script threads
     FromScript(ScriptToDevtoolsControlMsg),
+
+    /// Sent when a devtools client thread terminates.
+    ClientExited,
 }
 
 /// Events that the devtools server must act upon.

--- a/components/shared/devtools/lib.rs
+++ b/components/shared/devtools/lib.rs
@@ -63,7 +63,6 @@ pub enum DevtoolsControlMsg {
     FromChrome(ChromeToDevtoolsControlMsg),
     /// Messages from script threads
     FromScript(ScriptToDevtoolsControlMsg),
-
     /// Sent when a devtools client thread terminates.
     ClientExited,
 }


### PR DESCRIPTION
Both the `DevtoolsInstance` and the `BrowsingContextActor` maintain a list of live connections. When a new global is created, its `BrowsingContextActor` copies the list of active connections from the `DevtoolsInstance`. When a client handler thread exits, the `BrowsingContextActor`s remove the connection from their list of connections.

This has two implications:
* `BrowsingContextActor`s don't know about connections that are created after they were constructed, causing them to possibly incorrectly tell script that it doesn't need to send devtools updates anymore
* the `DevtoolsInstance` never notices when connections are closed and panics when writing to them.

To fix this, I've removed the list of connections from the `BrowsingContextActor` and adjusted the logic to notify script when updates aren't needed anymore accordingly.

For some reason, our tests always open two connections and close the first one immediately, which is how I found this bug in the first place.

Part of https://github.com/servo/servo/issues/42454 - previously https://github.com/servo/servo/blob/d5d400c7d696d583c1353dff03d8e3230722f9a2/components/script/dom/globalscope.rs#L240-L242 was always false during our tests.