### PR TITLE
layout: Clear `display: none` boxes during damage traversal

### DIFF
--- a/components/layout/dom_traversal.rs
+++ b/components/layout/dom_traversal.rs
@@ -160,7 +160,7 @@ fn traverse_element<'dom>(
     let info = NodeAndStyleInfo::new(element, style, damage);
 
     match Display::from(info.style.get_box().display) {
-        Display::None => element.unset_all_boxes(),
+        Display::None => {},
         Display::Contents => {
             if ReplacedContents::for_element(element, context).is_some() {
                 // `display: content` on a replaced element computes to `display: none`

--- a/components/layout/flow/root.rs
+++ b/components/layout/flow/root.rs
@@ -169,10 +169,7 @@ fn construct_for_root_element(
     let box_style = info.style.get_box();
 
     let display_inside = match Display::from(box_style.display) {
-        Display::None => {
-            root_element.unset_all_boxes();
-            return Vec::new();
-        },
+        Display::None => return Vec::new(),
         Display::Contents => {
             // Unreachable because the style crate adjusts the computed values:
             // https://drafts.csswg.org/css-display-3/#transformations

--- a/components/layout/traversal.rs
+++ b/components/layout/traversal.rs
@@ -13,7 +13,6 @@ use style::data::ElementData;
 use style::dom::{NodeInfo, TElement, TNode};
 use style::selector_parser::RestyleDamage;
 use style::traversal::{DomTraversal, PerLevelTraversalData, recalc_style_at};
-use style::values::computed::Display;
 
 use crate::context::LayoutContext;
 use crate::dom::{DOMLayoutData, NodeExt};
@@ -116,17 +115,16 @@ pub(crate) fn compute_damage_and_repair_style_inner(
         .expect("Should not run `compute_damage` before styling.")
         .element_data;
 
-    {
-        let mut element_data = element_data.borrow_mut();
+    let is_display_none = {
+        let element_data = element_data.borrow_mut();
         element_damage = element_data.damage;
         element_and_parent_damage = element_damage | damage_from_parent;
+        element_data.styles.is_display_none()
+    };
 
-        if let Some(ref style) = element_data.styles.primary {
-            if style.get_box().display == Display::None {
-                element_data.damage = element_and_parent_damage;
-                return element_and_parent_damage;
-            }
-        }
+    if is_display_none {
+        node.unset_all_boxes();
+        return element_and_parent_damage;
     }
 
     // If we are reconstructing this node, then all of the children should be reconstructed as well.


### PR DESCRIPTION
There is no need to wait until box tree layout to do this and we want to
make clearing boxes a thing that happens in the damage traversal.

Testing: This should not change behavior in an observable way, so should
be covered by existing tests.
