### PR TITLE
layout: Always treat SVG elements as replaced content.

### DIFF
--- a/components/layout/replaced.rs
+++ b/components/layout/replaced.rs
@@ -182,7 +182,7 @@ impl ReplacedContents {
                         .map_or_else(NaturalSizes::empty, NaturalSizes::from_natural_size_in_dots),
                 )
             } else if let Some(svg_data) = node.as_svg() {
-                Self::svg_kind_size(svg_data, context, node)?
+                Self::svg_kind_size(svg_data, context, node)
             } else if node
                 .as_html_element()
                 .is_some_and(|element| element.has_local_name(&local_name!("audio")))
@@ -217,7 +217,7 @@ impl ReplacedContents {
         svg_data: SVGElementData,
         context: &LayoutContext,
         node: ServoThreadSafeLayoutNode<'_>,
-    ) -> Option<(ReplacedContentKind, NaturalSizes)> {
+    ) -> (ReplacedContentKind, NaturalSizes) {
         let rule_cache_conditions = &mut RuleCacheConditions::default();
 
         let parent_style = node.style(&context.style_context);
@@ -267,25 +267,27 @@ impl ReplacedContents {
                 context
                     .image_resolver
                     .queue_svg_element_for_serialization(node);
-                return None;
+                None
             },
             Some(Err(_)) => {
                 // Don't attempt to serialize if previous attempt had errored.
-                return None;
+                None
             },
-            Some(Ok(svg_source)) => svg_source,
+            Some(Ok(svg_source)) => Some(svg_source),
         };
 
-        let result = context
-            .image_resolver
-            .get_cached_image_for_url(
-                node.opaque(),
-                svg_source,
-                LayoutImageDestination::BoxTreeConstruction,
-            )
-            .ok();
+        let cached_image = svg_source.and_then(|svg_source| {
+            context
+                .image_resolver
+                .get_cached_image_for_url(
+                    node.opaque(),
+                    svg_source,
+                    LayoutImageDestination::BoxTreeConstruction,
+                )
+                .ok()
+        });
 
-        let vector_image = result.map(|result| match result {
+        let vector_image = cached_image.map(|image| match image {
             Image::Vector(mut vector_image) => {
                 vector_image.svg_id = Some(svg_data.svg_id);
                 vector_image
@@ -293,7 +295,7 @@ impl ReplacedContents {
             _ => unreachable!("SVG element can't contain a raster image."),
         });
 
-        Some((ReplacedContentKind::SVGElement(vector_image), natural_size))
+        (ReplacedContentKind::SVGElement(vector_image), natural_size)
     }
 
     fn from_content_property(

--- a/components/layout/replaced.rs
+++ b/components/layout/replaced.rs
@@ -269,11 +269,9 @@ impl ReplacedContents {
                     .queue_svg_element_for_serialization(node);
                 None
             },
-            Some(Err(_)) => {
-                // Don't attempt to serialize if previous attempt had errored.
-                None
-            },
-            Some(Ok(svg_source)) => Some(svg_source),
+            // If `svg_source_result` is `Err()`, it means that the previous attempt
+            // had errored, then don't attempt to serialize again.
+            Some(svg_source_result) => svg_source_result.ok(),
         };
 
         let cached_image = svg_source.and_then(|svg_source| {

--- a/tests/wpt/meta/css/cssom-view/outer-svg.html.ini
+++ b/tests/wpt/meta/css/cssom-view/outer-svg.html.ini
@@ -1,3 +1,0 @@
-[outer-svg.html]
-  [clientWidth, clientHeight, clientTop and clientLeft work on outer svg element]
-    expected: FAIL

--- a/tests/wpt/meta/html/rendering/replaced-elements/svg-inline-sizing/svg-inline.html.ini
+++ b/tests/wpt/meta/html/rendering/replaced-elements/svg-inline-sizing/svg-inline.html.ini
@@ -1,16 +1,4 @@
 [svg-inline.html]
-  [(initial values)]
-    expected: FAIL
-
-  [containerWidthStyle: '400px', ]
-    expected: FAIL
-
-  [containerHeightStyle: '400px', ]
-    expected: FAIL
-
-  [containerWidthStyle: '400px', containerHeightStyle: '400px', ]
-    expected: FAIL
-
   [svgViewBoxAttr: '0 0 100 200', ]
     expected: FAIL
 
@@ -23,280 +11,10 @@
   [containerWidthStyle: '400px', containerHeightStyle: '400px', svgViewBoxAttr: '0 0 100 200', ]
     expected: FAIL
 
-  [svgWidthStyle: '100px', ]
-    expected: FAIL
-
-  [containerWidthStyle: '400px', svgWidthStyle: '100px', ]
-    expected: FAIL
-
-  [containerHeightStyle: '400px', svgWidthStyle: '100px', ]
-    expected: FAIL
-
-  [containerWidthStyle: '400px', containerHeightStyle: '400px', svgWidthStyle: '100px', ]
-    expected: FAIL
-
-  [svgViewBoxAttr: '0 0 100 200', svgWidthStyle: '100px', ]
-    expected: FAIL
-
-  [containerWidthStyle: '400px', svgViewBoxAttr: '0 0 100 200', svgWidthStyle: '100px', ]
-    expected: FAIL
-
-  [containerHeightStyle: '400px', svgViewBoxAttr: '0 0 100 200', svgWidthStyle: '100px', ]
-    expected: FAIL
-
-  [containerWidthStyle: '400px', containerHeightStyle: '400px', svgViewBoxAttr: '0 0 100 200', svgWidthStyle: '100px', ]
-    expected: FAIL
-
-  [svgWidthStyle: '50%', ]
-    expected: FAIL
-
-  [containerWidthStyle: '400px', svgWidthStyle: '50%', ]
-    expected: FAIL
-
-  [containerHeightStyle: '400px', svgWidthStyle: '50%', ]
-    expected: FAIL
-
-  [containerWidthStyle: '400px', containerHeightStyle: '400px', svgWidthStyle: '50%', ]
-    expected: FAIL
-
-  [svgViewBoxAttr: '0 0 100 200', svgWidthStyle: '50%', ]
-    expected: FAIL
-
-  [containerWidthStyle: '400px', svgViewBoxAttr: '0 0 100 200', svgWidthStyle: '50%', ]
-    expected: FAIL
-
-  [containerHeightStyle: '400px', svgViewBoxAttr: '0 0 100 200', svgWidthStyle: '50%', ]
-    expected: FAIL
-
-  [containerWidthStyle: '400px', containerHeightStyle: '400px', svgViewBoxAttr: '0 0 100 200', svgWidthStyle: '50%', ]
-    expected: FAIL
-
-  [svgHeightStyle: '100px', ]
-    expected: FAIL
-
-  [containerWidthStyle: '400px', svgHeightStyle: '100px', ]
-    expected: FAIL
-
-  [containerHeightStyle: '400px', svgHeightStyle: '100px', ]
-    expected: FAIL
-
-  [containerWidthStyle: '400px', containerHeightStyle: '400px', svgHeightStyle: '100px', ]
-    expected: FAIL
-
-  [svgViewBoxAttr: '0 0 100 200', svgHeightStyle: '100px', ]
-    expected: FAIL
-
-  [containerWidthStyle: '400px', svgViewBoxAttr: '0 0 100 200', svgHeightStyle: '100px', ]
-    expected: FAIL
-
-  [containerHeightStyle: '400px', svgViewBoxAttr: '0 0 100 200', svgHeightStyle: '100px', ]
-    expected: FAIL
-
-  [containerWidthStyle: '400px', containerHeightStyle: '400px', svgViewBoxAttr: '0 0 100 200', svgHeightStyle: '100px', ]
-    expected: FAIL
-
-  [svgWidthStyle: '100px', svgHeightStyle: '100px', ]
-    expected: FAIL
-
-  [containerWidthStyle: '400px', svgWidthStyle: '100px', svgHeightStyle: '100px', ]
-    expected: FAIL
-
-  [containerHeightStyle: '400px', svgWidthStyle: '100px', svgHeightStyle: '100px', ]
-    expected: FAIL
-
-  [containerWidthStyle: '400px', containerHeightStyle: '400px', svgWidthStyle: '100px', svgHeightStyle: '100px', ]
-    expected: FAIL
-
-  [svgViewBoxAttr: '0 0 100 200', svgWidthStyle: '100px', svgHeightStyle: '100px', ]
-    expected: FAIL
-
-  [containerWidthStyle: '400px', svgViewBoxAttr: '0 0 100 200', svgWidthStyle: '100px', svgHeightStyle: '100px', ]
-    expected: FAIL
-
-  [containerHeightStyle: '400px', svgViewBoxAttr: '0 0 100 200', svgWidthStyle: '100px', svgHeightStyle: '100px', ]
-    expected: FAIL
-
-  [containerWidthStyle: '400px', containerHeightStyle: '400px', svgViewBoxAttr: '0 0 100 200', svgWidthStyle: '100px', svgHeightStyle: '100px', ]
-    expected: FAIL
-
-  [svgWidthStyle: '50%', svgHeightStyle: '100px', ]
-    expected: FAIL
-
-  [containerWidthStyle: '400px', svgWidthStyle: '50%', svgHeightStyle: '100px', ]
-    expected: FAIL
-
-  [containerHeightStyle: '400px', svgWidthStyle: '50%', svgHeightStyle: '100px', ]
-    expected: FAIL
-
-  [containerWidthStyle: '400px', containerHeightStyle: '400px', svgWidthStyle: '50%', svgHeightStyle: '100px', ]
-    expected: FAIL
-
-  [svgViewBoxAttr: '0 0 100 200', svgWidthStyle: '50%', svgHeightStyle: '100px', ]
-    expected: FAIL
-
-  [containerWidthStyle: '400px', svgViewBoxAttr: '0 0 100 200', svgWidthStyle: '50%', svgHeightStyle: '100px', ]
-    expected: FAIL
-
-  [containerHeightStyle: '400px', svgViewBoxAttr: '0 0 100 200', svgWidthStyle: '50%', svgHeightStyle: '100px', ]
-    expected: FAIL
-
-  [containerWidthStyle: '400px', containerHeightStyle: '400px', svgViewBoxAttr: '0 0 100 200', svgWidthStyle: '50%', svgHeightStyle: '100px', ]
-    expected: FAIL
-
-  [svgHeightStyle: '50%', ]
-    expected: FAIL
-
-  [containerWidthStyle: '400px', svgHeightStyle: '50%', ]
-    expected: FAIL
-
-  [containerHeightStyle: '400px', svgHeightStyle: '50%', ]
-    expected: FAIL
-
-  [containerWidthStyle: '400px', containerHeightStyle: '400px', svgHeightStyle: '50%', ]
-    expected: FAIL
-
   [svgViewBoxAttr: '0 0 100 200', svgHeightStyle: '50%', ]
     expected: FAIL
 
   [containerWidthStyle: '400px', svgViewBoxAttr: '0 0 100 200', svgHeightStyle: '50%', ]
-    expected: FAIL
-
-  [containerHeightStyle: '400px', svgViewBoxAttr: '0 0 100 200', svgHeightStyle: '50%', ]
-    expected: FAIL
-
-  [containerWidthStyle: '400px', containerHeightStyle: '400px', svgViewBoxAttr: '0 0 100 200', svgHeightStyle: '50%', ]
-    expected: FAIL
-
-  [svgWidthStyle: '100px', svgHeightStyle: '50%', ]
-    expected: FAIL
-
-  [containerWidthStyle: '400px', svgWidthStyle: '100px', svgHeightStyle: '50%', ]
-    expected: FAIL
-
-  [containerHeightStyle: '400px', svgWidthStyle: '100px', svgHeightStyle: '50%', ]
-    expected: FAIL
-
-  [containerWidthStyle: '400px', containerHeightStyle: '400px', svgWidthStyle: '100px', svgHeightStyle: '50%', ]
-    expected: FAIL
-
-  [svgViewBoxAttr: '0 0 100 200', svgWidthStyle: '100px', svgHeightStyle: '50%', ]
-    expected: FAIL
-
-  [containerWidthStyle: '400px', svgViewBoxAttr: '0 0 100 200', svgWidthStyle: '100px', svgHeightStyle: '50%', ]
-    expected: FAIL
-
-  [containerHeightStyle: '400px', svgViewBoxAttr: '0 0 100 200', svgWidthStyle: '100px', svgHeightStyle: '50%', ]
-    expected: FAIL
-
-  [containerWidthStyle: '400px', containerHeightStyle: '400px', svgViewBoxAttr: '0 0 100 200', svgWidthStyle: '100px', svgHeightStyle: '50%', ]
-    expected: FAIL
-
-  [svgWidthStyle: '50%', svgHeightStyle: '50%', ]
-    expected: FAIL
-
-  [containerWidthStyle: '400px', svgWidthStyle: '50%', svgHeightStyle: '50%', ]
-    expected: FAIL
-
-  [containerHeightStyle: '400px', svgWidthStyle: '50%', svgHeightStyle: '50%', ]
-    expected: FAIL
-
-  [containerWidthStyle: '400px', containerHeightStyle: '400px', svgWidthStyle: '50%', svgHeightStyle: '50%', ]
-    expected: FAIL
-
-  [svgViewBoxAttr: '0 0 100 200', svgWidthStyle: '50%', svgHeightStyle: '50%', ]
-    expected: FAIL
-
-  [containerWidthStyle: '400px', svgViewBoxAttr: '0 0 100 200', svgWidthStyle: '50%', svgHeightStyle: '50%', ]
-    expected: FAIL
-
-  [containerHeightStyle: '400px', svgViewBoxAttr: '0 0 100 200', svgWidthStyle: '50%', svgHeightStyle: '50%', ]
-    expected: FAIL
-
-  [containerWidthStyle: '400px', containerHeightStyle: '400px', svgViewBoxAttr: '0 0 100 200', svgWidthStyle: '50%', svgHeightStyle: '50%', ]
-    expected: FAIL
-
-  [svgWidthAttr: '200', ]
-    expected: FAIL
-
-  [containerWidthStyle: '400px', svgWidthAttr: '200', ]
-    expected: FAIL
-
-  [containerHeightStyle: '400px', svgWidthAttr: '200', ]
-    expected: FAIL
-
-  [containerWidthStyle: '400px', containerHeightStyle: '400px', svgWidthAttr: '200', ]
-    expected: FAIL
-
-  [svgViewBoxAttr: '0 0 100 200', svgWidthAttr: '200', ]
-    expected: FAIL
-
-  [containerWidthStyle: '400px', svgViewBoxAttr: '0 0 100 200', svgWidthAttr: '200', ]
-    expected: FAIL
-
-  [containerHeightStyle: '400px', svgViewBoxAttr: '0 0 100 200', svgWidthAttr: '200', ]
-    expected: FAIL
-
-  [containerWidthStyle: '400px', containerHeightStyle: '400px', svgViewBoxAttr: '0 0 100 200', svgWidthAttr: '200', ]
-    expected: FAIL
-
-  [svgWidthStyle: '100px', svgWidthAttr: '200', ]
-    expected: FAIL
-
-  [containerWidthStyle: '400px', svgWidthStyle: '100px', svgWidthAttr: '200', ]
-    expected: FAIL
-
-  [containerHeightStyle: '400px', svgWidthStyle: '100px', svgWidthAttr: '200', ]
-    expected: FAIL
-
-  [containerWidthStyle: '400px', containerHeightStyle: '400px', svgWidthStyle: '100px', svgWidthAttr: '200', ]
-    expected: FAIL
-
-  [svgViewBoxAttr: '0 0 100 200', svgWidthStyle: '100px', svgWidthAttr: '200', ]
-    expected: FAIL
-
-  [containerWidthStyle: '400px', svgViewBoxAttr: '0 0 100 200', svgWidthStyle: '100px', svgWidthAttr: '200', ]
-    expected: FAIL
-
-  [containerHeightStyle: '400px', svgViewBoxAttr: '0 0 100 200', svgWidthStyle: '100px', svgWidthAttr: '200', ]
-    expected: FAIL
-
-  [containerWidthStyle: '400px', containerHeightStyle: '400px', svgViewBoxAttr: '0 0 100 200', svgWidthStyle: '100px', svgWidthAttr: '200', ]
-    expected: FAIL
-
-  [svgWidthStyle: '50%', svgWidthAttr: '200', ]
-    expected: FAIL
-
-  [containerWidthStyle: '400px', svgWidthStyle: '50%', svgWidthAttr: '200', ]
-    expected: FAIL
-
-  [containerHeightStyle: '400px', svgWidthStyle: '50%', svgWidthAttr: '200', ]
-    expected: FAIL
-
-  [containerWidthStyle: '400px', containerHeightStyle: '400px', svgWidthStyle: '50%', svgWidthAttr: '200', ]
-    expected: FAIL
-
-  [svgViewBoxAttr: '0 0 100 200', svgWidthStyle: '50%', svgWidthAttr: '200', ]
-    expected: FAIL
-
-  [containerWidthStyle: '400px', svgViewBoxAttr: '0 0 100 200', svgWidthStyle: '50%', svgWidthAttr: '200', ]
-    expected: FAIL
-
-  [containerHeightStyle: '400px', svgViewBoxAttr: '0 0 100 200', svgWidthStyle: '50%', svgWidthAttr: '200', ]
-    expected: FAIL
-
-  [containerWidthStyle: '400px', containerHeightStyle: '400px', svgViewBoxAttr: '0 0 100 200', svgWidthStyle: '50%', svgWidthAttr: '200', ]
-    expected: FAIL
-
-  [svgHeightStyle: '100px', svgWidthAttr: '200', ]
-    expected: FAIL
-
-  [containerWidthStyle: '400px', svgHeightStyle: '100px', svgWidthAttr: '200', ]
-    expected: FAIL
-
-  [containerHeightStyle: '400px', svgHeightStyle: '100px', svgWidthAttr: '200', ]
-    expected: FAIL
-
-  [containerWidthStyle: '400px', containerHeightStyle: '400px', svgHeightStyle: '100px', svgWidthAttr: '200', ]
     expected: FAIL
 
   [svgViewBoxAttr: '0 0 100 200', svgHeightStyle: '100px', svgWidthAttr: '200', ]
@@ -311,124 +29,10 @@
   [containerWidthStyle: '400px', containerHeightStyle: '400px', svgViewBoxAttr: '0 0 100 200', svgHeightStyle: '100px', svgWidthAttr: '200', ]
     expected: FAIL
 
-  [svgWidthStyle: '100px', svgHeightStyle: '100px', svgWidthAttr: '200', ]
-    expected: FAIL
-
-  [containerWidthStyle: '400px', svgWidthStyle: '100px', svgHeightStyle: '100px', svgWidthAttr: '200', ]
-    expected: FAIL
-
-  [containerHeightStyle: '400px', svgWidthStyle: '100px', svgHeightStyle: '100px', svgWidthAttr: '200', ]
-    expected: FAIL
-
-  [containerWidthStyle: '400px', containerHeightStyle: '400px', svgWidthStyle: '100px', svgHeightStyle: '100px', svgWidthAttr: '200', ]
-    expected: FAIL
-
-  [svgViewBoxAttr: '0 0 100 200', svgWidthStyle: '100px', svgHeightStyle: '100px', svgWidthAttr: '200', ]
-    expected: FAIL
-
-  [containerWidthStyle: '400px', svgViewBoxAttr: '0 0 100 200', svgWidthStyle: '100px', svgHeightStyle: '100px', svgWidthAttr: '200', ]
-    expected: FAIL
-
-  [containerHeightStyle: '400px', svgViewBoxAttr: '0 0 100 200', svgWidthStyle: '100px', svgHeightStyle: '100px', svgWidthAttr: '200', ]
-    expected: FAIL
-
-  [containerWidthStyle: '400px', containerHeightStyle: '400px', svgViewBoxAttr: '0 0 100 200', svgWidthStyle: '100px', svgHeightStyle: '100px', svgWidthAttr: '200', ]
-    expected: FAIL
-
-  [svgWidthStyle: '50%', svgHeightStyle: '100px', svgWidthAttr: '200', ]
-    expected: FAIL
-
-  [containerWidthStyle: '400px', svgWidthStyle: '50%', svgHeightStyle: '100px', svgWidthAttr: '200', ]
-    expected: FAIL
-
-  [containerHeightStyle: '400px', svgWidthStyle: '50%', svgHeightStyle: '100px', svgWidthAttr: '200', ]
-    expected: FAIL
-
-  [containerWidthStyle: '400px', containerHeightStyle: '400px', svgWidthStyle: '50%', svgHeightStyle: '100px', svgWidthAttr: '200', ]
-    expected: FAIL
-
-  [svgViewBoxAttr: '0 0 100 200', svgWidthStyle: '50%', svgHeightStyle: '100px', svgWidthAttr: '200', ]
-    expected: FAIL
-
-  [containerWidthStyle: '400px', svgViewBoxAttr: '0 0 100 200', svgWidthStyle: '50%', svgHeightStyle: '100px', svgWidthAttr: '200', ]
-    expected: FAIL
-
-  [containerHeightStyle: '400px', svgViewBoxAttr: '0 0 100 200', svgWidthStyle: '50%', svgHeightStyle: '100px', svgWidthAttr: '200', ]
-    expected: FAIL
-
-  [containerWidthStyle: '400px', containerHeightStyle: '400px', svgViewBoxAttr: '0 0 100 200', svgWidthStyle: '50%', svgHeightStyle: '100px', svgWidthAttr: '200', ]
-    expected: FAIL
-
-  [svgHeightStyle: '50%', svgWidthAttr: '200', ]
-    expected: FAIL
-
-  [containerWidthStyle: '400px', svgHeightStyle: '50%', svgWidthAttr: '200', ]
-    expected: FAIL
-
-  [containerHeightStyle: '400px', svgHeightStyle: '50%', svgWidthAttr: '200', ]
-    expected: FAIL
-
-  [containerWidthStyle: '400px', containerHeightStyle: '400px', svgHeightStyle: '50%', svgWidthAttr: '200', ]
-    expected: FAIL
-
-  [svgViewBoxAttr: '0 0 100 200', svgHeightStyle: '50%', svgWidthAttr: '200', ]
-    expected: FAIL
-
-  [containerWidthStyle: '400px', svgViewBoxAttr: '0 0 100 200', svgHeightStyle: '50%', svgWidthAttr: '200', ]
-    expected: FAIL
-
   [containerHeightStyle: '400px', svgViewBoxAttr: '0 0 100 200', svgHeightStyle: '50%', svgWidthAttr: '200', ]
     expected: FAIL
 
   [containerWidthStyle: '400px', containerHeightStyle: '400px', svgViewBoxAttr: '0 0 100 200', svgHeightStyle: '50%', svgWidthAttr: '200', ]
-    expected: FAIL
-
-  [svgWidthStyle: '100px', svgHeightStyle: '50%', svgWidthAttr: '200', ]
-    expected: FAIL
-
-  [containerWidthStyle: '400px', svgWidthStyle: '100px', svgHeightStyle: '50%', svgWidthAttr: '200', ]
-    expected: FAIL
-
-  [containerHeightStyle: '400px', svgWidthStyle: '100px', svgHeightStyle: '50%', svgWidthAttr: '200', ]
-    expected: FAIL
-
-  [containerWidthStyle: '400px', containerHeightStyle: '400px', svgWidthStyle: '100px', svgHeightStyle: '50%', svgWidthAttr: '200', ]
-    expected: FAIL
-
-  [svgViewBoxAttr: '0 0 100 200', svgWidthStyle: '100px', svgHeightStyle: '50%', svgWidthAttr: '200', ]
-    expected: FAIL
-
-  [containerWidthStyle: '400px', svgViewBoxAttr: '0 0 100 200', svgWidthStyle: '100px', svgHeightStyle: '50%', svgWidthAttr: '200', ]
-    expected: FAIL
-
-  [containerHeightStyle: '400px', svgViewBoxAttr: '0 0 100 200', svgWidthStyle: '100px', svgHeightStyle: '50%', svgWidthAttr: '200', ]
-    expected: FAIL
-
-  [containerWidthStyle: '400px', containerHeightStyle: '400px', svgViewBoxAttr: '0 0 100 200', svgWidthStyle: '100px', svgHeightStyle: '50%', svgWidthAttr: '200', ]
-    expected: FAIL
-
-  [svgWidthStyle: '50%', svgHeightStyle: '50%', svgWidthAttr: '200', ]
-    expected: FAIL
-
-  [containerWidthStyle: '400px', svgWidthStyle: '50%', svgHeightStyle: '50%', svgWidthAttr: '200', ]
-    expected: FAIL
-
-  [containerHeightStyle: '400px', svgWidthStyle: '50%', svgHeightStyle: '50%', svgWidthAttr: '200', ]
-    expected: FAIL
-
-  [containerWidthStyle: '400px', containerHeightStyle: '400px', svgWidthStyle: '50%', svgHeightStyle: '50%', svgWidthAttr: '200', ]
-    expected: FAIL
-
-  [svgViewBoxAttr: '0 0 100 200', svgWidthStyle: '50%', svgHeightStyle: '50%', svgWidthAttr: '200', ]
-    expected: FAIL
-
-  [containerWidthStyle: '400px', svgViewBoxAttr: '0 0 100 200', svgWidthStyle: '50%', svgHeightStyle: '50%', svgWidthAttr: '200', ]
-    expected: FAIL
-
-  [containerHeightStyle: '400px', svgViewBoxAttr: '0 0 100 200', svgWidthStyle: '50%', svgHeightStyle: '50%', svgWidthAttr: '200', ]
-    expected: FAIL
-
-  [containerWidthStyle: '400px', containerHeightStyle: '400px', svgViewBoxAttr: '0 0 100 200', svgWidthStyle: '50%', svgHeightStyle: '50%', svgWidthAttr: '200', ]
     expected: FAIL
 
   [svgWidthAttr: '25%', ]
@@ -455,54 +59,6 @@
   [containerWidthStyle: '400px', containerHeightStyle: '400px', svgViewBoxAttr: '0 0 100 200', svgWidthAttr: '25%', ]
     expected: FAIL
 
-  [svgWidthStyle: '100px', svgWidthAttr: '25%', ]
-    expected: FAIL
-
-  [containerWidthStyle: '400px', svgWidthStyle: '100px', svgWidthAttr: '25%', ]
-    expected: FAIL
-
-  [containerHeightStyle: '400px', svgWidthStyle: '100px', svgWidthAttr: '25%', ]
-    expected: FAIL
-
-  [containerWidthStyle: '400px', containerHeightStyle: '400px', svgWidthStyle: '100px', svgWidthAttr: '25%', ]
-    expected: FAIL
-
-  [svgViewBoxAttr: '0 0 100 200', svgWidthStyle: '100px', svgWidthAttr: '25%', ]
-    expected: FAIL
-
-  [containerWidthStyle: '400px', svgViewBoxAttr: '0 0 100 200', svgWidthStyle: '100px', svgWidthAttr: '25%', ]
-    expected: FAIL
-
-  [containerHeightStyle: '400px', svgViewBoxAttr: '0 0 100 200', svgWidthStyle: '100px', svgWidthAttr: '25%', ]
-    expected: FAIL
-
-  [containerWidthStyle: '400px', containerHeightStyle: '400px', svgViewBoxAttr: '0 0 100 200', svgWidthStyle: '100px', svgWidthAttr: '25%', ]
-    expected: FAIL
-
-  [svgWidthStyle: '50%', svgWidthAttr: '25%', ]
-    expected: FAIL
-
-  [containerWidthStyle: '400px', svgWidthStyle: '50%', svgWidthAttr: '25%', ]
-    expected: FAIL
-
-  [containerHeightStyle: '400px', svgWidthStyle: '50%', svgWidthAttr: '25%', ]
-    expected: FAIL
-
-  [containerWidthStyle: '400px', containerHeightStyle: '400px', svgWidthStyle: '50%', svgWidthAttr: '25%', ]
-    expected: FAIL
-
-  [svgViewBoxAttr: '0 0 100 200', svgWidthStyle: '50%', svgWidthAttr: '25%', ]
-    expected: FAIL
-
-  [containerWidthStyle: '400px', svgViewBoxAttr: '0 0 100 200', svgWidthStyle: '50%', svgWidthAttr: '25%', ]
-    expected: FAIL
-
-  [containerHeightStyle: '400px', svgViewBoxAttr: '0 0 100 200', svgWidthStyle: '50%', svgWidthAttr: '25%', ]
-    expected: FAIL
-
-  [containerWidthStyle: '400px', containerHeightStyle: '400px', svgViewBoxAttr: '0 0 100 200', svgWidthStyle: '50%', svgWidthAttr: '25%', ]
-    expected: FAIL
-
   [svgHeightStyle: '100px', svgWidthAttr: '25%', ]
     expected: FAIL
 
@@ -527,54 +83,6 @@
   [containerWidthStyle: '400px', containerHeightStyle: '400px', svgViewBoxAttr: '0 0 100 200', svgHeightStyle: '100px', svgWidthAttr: '25%', ]
     expected: FAIL
 
-  [svgWidthStyle: '100px', svgHeightStyle: '100px', svgWidthAttr: '25%', ]
-    expected: FAIL
-
-  [containerWidthStyle: '400px', svgWidthStyle: '100px', svgHeightStyle: '100px', svgWidthAttr: '25%', ]
-    expected: FAIL
-
-  [containerHeightStyle: '400px', svgWidthStyle: '100px', svgHeightStyle: '100px', svgWidthAttr: '25%', ]
-    expected: FAIL
-
-  [containerWidthStyle: '400px', containerHeightStyle: '400px', svgWidthStyle: '100px', svgHeightStyle: '100px', svgWidthAttr: '25%', ]
-    expected: FAIL
-
-  [svgViewBoxAttr: '0 0 100 200', svgWidthStyle: '100px', svgHeightStyle: '100px', svgWidthAttr: '25%', ]
-    expected: FAIL
-
-  [containerWidthStyle: '400px', svgViewBoxAttr: '0 0 100 200', svgWidthStyle: '100px', svgHeightStyle: '100px', svgWidthAttr: '25%', ]
-    expected: FAIL
-
-  [containerHeightStyle: '400px', svgViewBoxAttr: '0 0 100 200', svgWidthStyle: '100px', svgHeightStyle: '100px', svgWidthAttr: '25%', ]
-    expected: FAIL
-
-  [containerWidthStyle: '400px', containerHeightStyle: '400px', svgViewBoxAttr: '0 0 100 200', svgWidthStyle: '100px', svgHeightStyle: '100px', svgWidthAttr: '25%', ]
-    expected: FAIL
-
-  [svgWidthStyle: '50%', svgHeightStyle: '100px', svgWidthAttr: '25%', ]
-    expected: FAIL
-
-  [containerWidthStyle: '400px', svgWidthStyle: '50%', svgHeightStyle: '100px', svgWidthAttr: '25%', ]
-    expected: FAIL
-
-  [containerHeightStyle: '400px', svgWidthStyle: '50%', svgHeightStyle: '100px', svgWidthAttr: '25%', ]
-    expected: FAIL
-
-  [containerWidthStyle: '400px', containerHeightStyle: '400px', svgWidthStyle: '50%', svgHeightStyle: '100px', svgWidthAttr: '25%', ]
-    expected: FAIL
-
-  [svgViewBoxAttr: '0 0 100 200', svgWidthStyle: '50%', svgHeightStyle: '100px', svgWidthAttr: '25%', ]
-    expected: FAIL
-
-  [containerWidthStyle: '400px', svgViewBoxAttr: '0 0 100 200', svgWidthStyle: '50%', svgHeightStyle: '100px', svgWidthAttr: '25%', ]
-    expected: FAIL
-
-  [containerHeightStyle: '400px', svgViewBoxAttr: '0 0 100 200', svgWidthStyle: '50%', svgHeightStyle: '100px', svgWidthAttr: '25%', ]
-    expected: FAIL
-
-  [containerWidthStyle: '400px', containerHeightStyle: '400px', svgViewBoxAttr: '0 0 100 200', svgWidthStyle: '50%', svgHeightStyle: '100px', svgWidthAttr: '25%', ]
-    expected: FAIL
-
   [svgHeightStyle: '50%', svgWidthAttr: '25%', ]
     expected: FAIL
 
@@ -596,117 +104,6 @@
   [containerHeightStyle: '400px', svgViewBoxAttr: '0 0 100 200', svgHeightStyle: '50%', svgWidthAttr: '25%', ]
     expected: FAIL
 
-  [containerWidthStyle: '400px', containerHeightStyle: '400px', svgViewBoxAttr: '0 0 100 200', svgHeightStyle: '50%', svgWidthAttr: '25%', ]
-    expected: FAIL
-
-  [svgWidthStyle: '100px', svgHeightStyle: '50%', svgWidthAttr: '25%', ]
-    expected: FAIL
-
-  [containerWidthStyle: '400px', svgWidthStyle: '100px', svgHeightStyle: '50%', svgWidthAttr: '25%', ]
-    expected: FAIL
-
-  [containerHeightStyle: '400px', svgWidthStyle: '100px', svgHeightStyle: '50%', svgWidthAttr: '25%', ]
-    expected: FAIL
-
-  [containerWidthStyle: '400px', containerHeightStyle: '400px', svgWidthStyle: '100px', svgHeightStyle: '50%', svgWidthAttr: '25%', ]
-    expected: FAIL
-
-  [svgViewBoxAttr: '0 0 100 200', svgWidthStyle: '100px', svgHeightStyle: '50%', svgWidthAttr: '25%', ]
-    expected: FAIL
-
-  [containerWidthStyle: '400px', svgViewBoxAttr: '0 0 100 200', svgWidthStyle: '100px', svgHeightStyle: '50%', svgWidthAttr: '25%', ]
-    expected: FAIL
-
-  [containerHeightStyle: '400px', svgViewBoxAttr: '0 0 100 200', svgWidthStyle: '100px', svgHeightStyle: '50%', svgWidthAttr: '25%', ]
-    expected: FAIL
-
-  [containerWidthStyle: '400px', containerHeightStyle: '400px', svgViewBoxAttr: '0 0 100 200', svgWidthStyle: '100px', svgHeightStyle: '50%', svgWidthAttr: '25%', ]
-    expected: FAIL
-
-  [svgWidthStyle: '50%', svgHeightStyle: '50%', svgWidthAttr: '25%', ]
-    expected: FAIL
-
-  [containerWidthStyle: '400px', svgWidthStyle: '50%', svgHeightStyle: '50%', svgWidthAttr: '25%', ]
-    expected: FAIL
-
-  [containerHeightStyle: '400px', svgWidthStyle: '50%', svgHeightStyle: '50%', svgWidthAttr: '25%', ]
-    expected: FAIL
-
-  [containerWidthStyle: '400px', containerHeightStyle: '400px', svgWidthStyle: '50%', svgHeightStyle: '50%', svgWidthAttr: '25%', ]
-    expected: FAIL
-
-  [svgViewBoxAttr: '0 0 100 200', svgWidthStyle: '50%', svgHeightStyle: '50%', svgWidthAttr: '25%', ]
-    expected: FAIL
-
-  [containerWidthStyle: '400px', svgViewBoxAttr: '0 0 100 200', svgWidthStyle: '50%', svgHeightStyle: '50%', svgWidthAttr: '25%', ]
-    expected: FAIL
-
-  [containerHeightStyle: '400px', svgViewBoxAttr: '0 0 100 200', svgWidthStyle: '50%', svgHeightStyle: '50%', svgWidthAttr: '25%', ]
-    expected: FAIL
-
-  [containerWidthStyle: '400px', containerHeightStyle: '400px', svgViewBoxAttr: '0 0 100 200', svgWidthStyle: '50%', svgHeightStyle: '50%', svgWidthAttr: '25%', ]
-    expected: FAIL
-
-  [svgHeightAttr: '200', ]
-    expected: FAIL
-
-  [containerWidthStyle: '400px', svgHeightAttr: '200', ]
-    expected: FAIL
-
-  [containerHeightStyle: '400px', svgHeightAttr: '200', ]
-    expected: FAIL
-
-  [containerWidthStyle: '400px', containerHeightStyle: '400px', svgHeightAttr: '200', ]
-    expected: FAIL
-
-  [svgViewBoxAttr: '0 0 100 200', svgHeightAttr: '200', ]
-    expected: FAIL
-
-  [containerWidthStyle: '400px', svgViewBoxAttr: '0 0 100 200', svgHeightAttr: '200', ]
-    expected: FAIL
-
-  [containerHeightStyle: '400px', svgViewBoxAttr: '0 0 100 200', svgHeightAttr: '200', ]
-    expected: FAIL
-
-  [containerWidthStyle: '400px', containerHeightStyle: '400px', svgViewBoxAttr: '0 0 100 200', svgHeightAttr: '200', ]
-    expected: FAIL
-
-  [svgWidthStyle: '100px', svgHeightAttr: '200', ]
-    expected: FAIL
-
-  [containerWidthStyle: '400px', svgWidthStyle: '100px', svgHeightAttr: '200', ]
-    expected: FAIL
-
-  [containerHeightStyle: '400px', svgWidthStyle: '100px', svgHeightAttr: '200', ]
-    expected: FAIL
-
-  [containerWidthStyle: '400px', containerHeightStyle: '400px', svgWidthStyle: '100px', svgHeightAttr: '200', ]
-    expected: FAIL
-
-  [svgViewBoxAttr: '0 0 100 200', svgWidthStyle: '100px', svgHeightAttr: '200', ]
-    expected: FAIL
-
-  [containerWidthStyle: '400px', svgViewBoxAttr: '0 0 100 200', svgWidthStyle: '100px', svgHeightAttr: '200', ]
-    expected: FAIL
-
-  [containerHeightStyle: '400px', svgViewBoxAttr: '0 0 100 200', svgWidthStyle: '100px', svgHeightAttr: '200', ]
-    expected: FAIL
-
-  [containerWidthStyle: '400px', containerHeightStyle: '400px', svgViewBoxAttr: '0 0 100 200', svgWidthStyle: '100px', svgHeightAttr: '200', ]
-    expected: FAIL
-
-  [svgWidthStyle: '50%', svgHeightAttr: '200', ]
-    expected: FAIL
-
-  [containerWidthStyle: '400px', svgWidthStyle: '50%', svgHeightAttr: '200', ]
-    expected: FAIL
-
-  [containerHeightStyle: '400px', svgWidthStyle: '50%', svgHeightAttr: '200', ]
-    expected: FAIL
-
-  [containerWidthStyle: '400px', containerHeightStyle: '400px', svgWidthStyle: '50%', svgHeightAttr: '200', ]
-    expected: FAIL
-
   [svgViewBoxAttr: '0 0 100 200', svgWidthStyle: '50%', svgHeightAttr: '200', ]
     expected: FAIL
 
@@ -717,174 +114,6 @@
     expected: FAIL
 
   [containerWidthStyle: '400px', containerHeightStyle: '400px', svgViewBoxAttr: '0 0 100 200', svgWidthStyle: '50%', svgHeightAttr: '200', ]
-    expected: FAIL
-
-  [svgHeightStyle: '100px', svgHeightAttr: '200', ]
-    expected: FAIL
-
-  [containerWidthStyle: '400px', svgHeightStyle: '100px', svgHeightAttr: '200', ]
-    expected: FAIL
-
-  [containerHeightStyle: '400px', svgHeightStyle: '100px', svgHeightAttr: '200', ]
-    expected: FAIL
-
-  [containerWidthStyle: '400px', containerHeightStyle: '400px', svgHeightStyle: '100px', svgHeightAttr: '200', ]
-    expected: FAIL
-
-  [svgViewBoxAttr: '0 0 100 200', svgHeightStyle: '100px', svgHeightAttr: '200', ]
-    expected: FAIL
-
-  [containerWidthStyle: '400px', svgViewBoxAttr: '0 0 100 200', svgHeightStyle: '100px', svgHeightAttr: '200', ]
-    expected: FAIL
-
-  [containerHeightStyle: '400px', svgViewBoxAttr: '0 0 100 200', svgHeightStyle: '100px', svgHeightAttr: '200', ]
-    expected: FAIL
-
-  [containerWidthStyle: '400px', containerHeightStyle: '400px', svgViewBoxAttr: '0 0 100 200', svgHeightStyle: '100px', svgHeightAttr: '200', ]
-    expected: FAIL
-
-  [svgWidthStyle: '100px', svgHeightStyle: '100px', svgHeightAttr: '200', ]
-    expected: FAIL
-
-  [containerWidthStyle: '400px', svgWidthStyle: '100px', svgHeightStyle: '100px', svgHeightAttr: '200', ]
-    expected: FAIL
-
-  [containerHeightStyle: '400px', svgWidthStyle: '100px', svgHeightStyle: '100px', svgHeightAttr: '200', ]
-    expected: FAIL
-
-  [containerWidthStyle: '400px', containerHeightStyle: '400px', svgWidthStyle: '100px', svgHeightStyle: '100px', svgHeightAttr: '200', ]
-    expected: FAIL
-
-  [svgViewBoxAttr: '0 0 100 200', svgWidthStyle: '100px', svgHeightStyle: '100px', svgHeightAttr: '200', ]
-    expected: FAIL
-
-  [containerWidthStyle: '400px', svgViewBoxAttr: '0 0 100 200', svgWidthStyle: '100px', svgHeightStyle: '100px', svgHeightAttr: '200', ]
-    expected: FAIL
-
-  [containerHeightStyle: '400px', svgViewBoxAttr: '0 0 100 200', svgWidthStyle: '100px', svgHeightStyle: '100px', svgHeightAttr: '200', ]
-    expected: FAIL
-
-  [containerWidthStyle: '400px', containerHeightStyle: '400px', svgViewBoxAttr: '0 0 100 200', svgWidthStyle: '100px', svgHeightStyle: '100px', svgHeightAttr: '200', ]
-    expected: FAIL
-
-  [svgWidthStyle: '50%', svgHeightStyle: '100px', svgHeightAttr: '200', ]
-    expected: FAIL
-
-  [containerWidthStyle: '400px', svgWidthStyle: '50%', svgHeightStyle: '100px', svgHeightAttr: '200', ]
-    expected: FAIL
-
-  [containerHeightStyle: '400px', svgWidthStyle: '50%', svgHeightStyle: '100px', svgHeightAttr: '200', ]
-    expected: FAIL
-
-  [containerWidthStyle: '400px', containerHeightStyle: '400px', svgWidthStyle: '50%', svgHeightStyle: '100px', svgHeightAttr: '200', ]
-    expected: FAIL
-
-  [svgViewBoxAttr: '0 0 100 200', svgWidthStyle: '50%', svgHeightStyle: '100px', svgHeightAttr: '200', ]
-    expected: FAIL
-
-  [containerWidthStyle: '400px', svgViewBoxAttr: '0 0 100 200', svgWidthStyle: '50%', svgHeightStyle: '100px', svgHeightAttr: '200', ]
-    expected: FAIL
-
-  [containerHeightStyle: '400px', svgViewBoxAttr: '0 0 100 200', svgWidthStyle: '50%', svgHeightStyle: '100px', svgHeightAttr: '200', ]
-    expected: FAIL
-
-  [containerWidthStyle: '400px', containerHeightStyle: '400px', svgViewBoxAttr: '0 0 100 200', svgWidthStyle: '50%', svgHeightStyle: '100px', svgHeightAttr: '200', ]
-    expected: FAIL
-
-  [svgHeightStyle: '50%', svgHeightAttr: '200', ]
-    expected: FAIL
-
-  [containerWidthStyle: '400px', svgHeightStyle: '50%', svgHeightAttr: '200', ]
-    expected: FAIL
-
-  [containerHeightStyle: '400px', svgHeightStyle: '50%', svgHeightAttr: '200', ]
-    expected: FAIL
-
-  [containerWidthStyle: '400px', containerHeightStyle: '400px', svgHeightStyle: '50%', svgHeightAttr: '200', ]
-    expected: FAIL
-
-  [svgViewBoxAttr: '0 0 100 200', svgHeightStyle: '50%', svgHeightAttr: '200', ]
-    expected: FAIL
-
-  [containerWidthStyle: '400px', svgViewBoxAttr: '0 0 100 200', svgHeightStyle: '50%', svgHeightAttr: '200', ]
-    expected: FAIL
-
-  [containerHeightStyle: '400px', svgViewBoxAttr: '0 0 100 200', svgHeightStyle: '50%', svgHeightAttr: '200', ]
-    expected: FAIL
-
-  [containerWidthStyle: '400px', containerHeightStyle: '400px', svgViewBoxAttr: '0 0 100 200', svgHeightStyle: '50%', svgHeightAttr: '200', ]
-    expected: FAIL
-
-  [svgWidthStyle: '100px', svgHeightStyle: '50%', svgHeightAttr: '200', ]
-    expected: FAIL
-
-  [containerWidthStyle: '400px', svgWidthStyle: '100px', svgHeightStyle: '50%', svgHeightAttr: '200', ]
-    expected: FAIL
-
-  [containerHeightStyle: '400px', svgWidthStyle: '100px', svgHeightStyle: '50%', svgHeightAttr: '200', ]
-    expected: FAIL
-
-  [containerWidthStyle: '400px', containerHeightStyle: '400px', svgWidthStyle: '100px', svgHeightStyle: '50%', svgHeightAttr: '200', ]
-    expected: FAIL
-
-  [svgViewBoxAttr: '0 0 100 200', svgWidthStyle: '100px', svgHeightStyle: '50%', svgHeightAttr: '200', ]
-    expected: FAIL
-
-  [containerWidthStyle: '400px', svgViewBoxAttr: '0 0 100 200', svgWidthStyle: '100px', svgHeightStyle: '50%', svgHeightAttr: '200', ]
-    expected: FAIL
-
-  [containerHeightStyle: '400px', svgViewBoxAttr: '0 0 100 200', svgWidthStyle: '100px', svgHeightStyle: '50%', svgHeightAttr: '200', ]
-    expected: FAIL
-
-  [containerWidthStyle: '400px', containerHeightStyle: '400px', svgViewBoxAttr: '0 0 100 200', svgWidthStyle: '100px', svgHeightStyle: '50%', svgHeightAttr: '200', ]
-    expected: FAIL
-
-  [svgWidthStyle: '50%', svgHeightStyle: '50%', svgHeightAttr: '200', ]
-    expected: FAIL
-
-  [containerWidthStyle: '400px', svgWidthStyle: '50%', svgHeightStyle: '50%', svgHeightAttr: '200', ]
-    expected: FAIL
-
-  [containerHeightStyle: '400px', svgWidthStyle: '50%', svgHeightStyle: '50%', svgHeightAttr: '200', ]
-    expected: FAIL
-
-  [containerWidthStyle: '400px', containerHeightStyle: '400px', svgWidthStyle: '50%', svgHeightStyle: '50%', svgHeightAttr: '200', ]
-    expected: FAIL
-
-  [svgViewBoxAttr: '0 0 100 200', svgWidthStyle: '50%', svgHeightStyle: '50%', svgHeightAttr: '200', ]
-    expected: FAIL
-
-  [containerWidthStyle: '400px', svgViewBoxAttr: '0 0 100 200', svgWidthStyle: '50%', svgHeightStyle: '50%', svgHeightAttr: '200', ]
-    expected: FAIL
-
-  [containerHeightStyle: '400px', svgViewBoxAttr: '0 0 100 200', svgWidthStyle: '50%', svgHeightStyle: '50%', svgHeightAttr: '200', ]
-    expected: FAIL
-
-  [containerWidthStyle: '400px', containerHeightStyle: '400px', svgViewBoxAttr: '0 0 100 200', svgWidthStyle: '50%', svgHeightStyle: '50%', svgHeightAttr: '200', ]
-    expected: FAIL
-
-  [svgWidthAttr: '200', svgHeightAttr: '200', ]
-    expected: FAIL
-
-  [containerWidthStyle: '400px', svgWidthAttr: '200', svgHeightAttr: '200', ]
-    expected: FAIL
-
-  [containerHeightStyle: '400px', svgWidthAttr: '200', svgHeightAttr: '200', ]
-    expected: FAIL
-
-  [containerWidthStyle: '400px', containerHeightStyle: '400px', svgWidthAttr: '200', svgHeightAttr: '200', ]
-    expected: FAIL
-
-  [svgViewBoxAttr: '0 0 100 200', svgWidthAttr: '200', svgHeightAttr: '200', ]
-    expected: FAIL
-
-  [containerWidthStyle: '400px', svgViewBoxAttr: '0 0 100 200', svgWidthAttr: '200', svgHeightAttr: '200', ]
-    expected: FAIL
-
-  [containerHeightStyle: '400px', svgViewBoxAttr: '0 0 100 200', svgWidthAttr: '200', svgHeightAttr: '200', ]
-    expected: FAIL
-
-  [containerWidthStyle: '400px', containerHeightStyle: '400px', svgViewBoxAttr: '0 0 100 200', svgWidthAttr: '200', svgHeightAttr: '200', ]
     expected: FAIL
 
   [svgWidthStyle: '100px', svgWidthAttr: '200', svgHeightAttr: '200', ]
@@ -914,25 +143,13 @@
   [svgWidthStyle: '50%', svgWidthAttr: '200', svgHeightAttr: '200', ]
     expected: FAIL
 
-  [containerWidthStyle: '400px', svgWidthStyle: '50%', svgWidthAttr: '200', svgHeightAttr: '200', ]
-    expected: FAIL
-
   [containerHeightStyle: '400px', svgWidthStyle: '50%', svgWidthAttr: '200', svgHeightAttr: '200', ]
-    expected: FAIL
-
-  [containerWidthStyle: '400px', containerHeightStyle: '400px', svgWidthStyle: '50%', svgWidthAttr: '200', svgHeightAttr: '200', ]
     expected: FAIL
 
   [svgViewBoxAttr: '0 0 100 200', svgWidthStyle: '50%', svgWidthAttr: '200', svgHeightAttr: '200', ]
     expected: FAIL
 
-  [containerWidthStyle: '400px', svgViewBoxAttr: '0 0 100 200', svgWidthStyle: '50%', svgWidthAttr: '200', svgHeightAttr: '200', ]
-    expected: FAIL
-
   [containerHeightStyle: '400px', svgViewBoxAttr: '0 0 100 200', svgWidthStyle: '50%', svgWidthAttr: '200', svgHeightAttr: '200', ]
-    expected: FAIL
-
-  [containerWidthStyle: '400px', containerHeightStyle: '400px', svgViewBoxAttr: '0 0 100 200', svgWidthStyle: '50%', svgWidthAttr: '200', svgHeightAttr: '200', ]
     expected: FAIL
 
   [svgHeightStyle: '100px', svgWidthAttr: '200', svgHeightAttr: '200', ]
@@ -959,126 +176,6 @@
   [containerWidthStyle: '400px', containerHeightStyle: '400px', svgViewBoxAttr: '0 0 100 200', svgHeightStyle: '100px', svgWidthAttr: '200', svgHeightAttr: '200', ]
     expected: FAIL
 
-  [svgWidthStyle: '100px', svgHeightStyle: '100px', svgWidthAttr: '200', svgHeightAttr: '200', ]
-    expected: FAIL
-
-  [containerWidthStyle: '400px', svgWidthStyle: '100px', svgHeightStyle: '100px', svgWidthAttr: '200', svgHeightAttr: '200', ]
-    expected: FAIL
-
-  [containerHeightStyle: '400px', svgWidthStyle: '100px', svgHeightStyle: '100px', svgWidthAttr: '200', svgHeightAttr: '200', ]
-    expected: FAIL
-
-  [containerWidthStyle: '400px', containerHeightStyle: '400px', svgWidthStyle: '100px', svgHeightStyle: '100px', svgWidthAttr: '200', svgHeightAttr: '200', ]
-    expected: FAIL
-
-  [svgViewBoxAttr: '0 0 100 200', svgWidthStyle: '100px', svgHeightStyle: '100px', svgWidthAttr: '200', svgHeightAttr: '200', ]
-    expected: FAIL
-
-  [containerWidthStyle: '400px', svgViewBoxAttr: '0 0 100 200', svgWidthStyle: '100px', svgHeightStyle: '100px', svgWidthAttr: '200', svgHeightAttr: '200', ]
-    expected: FAIL
-
-  [containerHeightStyle: '400px', svgViewBoxAttr: '0 0 100 200', svgWidthStyle: '100px', svgHeightStyle: '100px', svgWidthAttr: '200', svgHeightAttr: '200', ]
-    expected: FAIL
-
-  [containerWidthStyle: '400px', containerHeightStyle: '400px', svgViewBoxAttr: '0 0 100 200', svgWidthStyle: '100px', svgHeightStyle: '100px', svgWidthAttr: '200', svgHeightAttr: '200', ]
-    expected: FAIL
-
-  [svgWidthStyle: '50%', svgHeightStyle: '100px', svgWidthAttr: '200', svgHeightAttr: '200', ]
-    expected: FAIL
-
-  [containerWidthStyle: '400px', svgWidthStyle: '50%', svgHeightStyle: '100px', svgWidthAttr: '200', svgHeightAttr: '200', ]
-    expected: FAIL
-
-  [containerHeightStyle: '400px', svgWidthStyle: '50%', svgHeightStyle: '100px', svgWidthAttr: '200', svgHeightAttr: '200', ]
-    expected: FAIL
-
-  [containerWidthStyle: '400px', containerHeightStyle: '400px', svgWidthStyle: '50%', svgHeightStyle: '100px', svgWidthAttr: '200', svgHeightAttr: '200', ]
-    expected: FAIL
-
-  [svgViewBoxAttr: '0 0 100 200', svgWidthStyle: '50%', svgHeightStyle: '100px', svgWidthAttr: '200', svgHeightAttr: '200', ]
-    expected: FAIL
-
-  [containerWidthStyle: '400px', svgViewBoxAttr: '0 0 100 200', svgWidthStyle: '50%', svgHeightStyle: '100px', svgWidthAttr: '200', svgHeightAttr: '200', ]
-    expected: FAIL
-
-  [containerHeightStyle: '400px', svgViewBoxAttr: '0 0 100 200', svgWidthStyle: '50%', svgHeightStyle: '100px', svgWidthAttr: '200', svgHeightAttr: '200', ]
-    expected: FAIL
-
-  [containerWidthStyle: '400px', containerHeightStyle: '400px', svgViewBoxAttr: '0 0 100 200', svgWidthStyle: '50%', svgHeightStyle: '100px', svgWidthAttr: '200', svgHeightAttr: '200', ]
-    expected: FAIL
-
-  [svgHeightStyle: '50%', svgWidthAttr: '200', svgHeightAttr: '200', ]
-    expected: FAIL
-
-  [containerWidthStyle: '400px', svgHeightStyle: '50%', svgWidthAttr: '200', svgHeightAttr: '200', ]
-    expected: FAIL
-
-  [containerHeightStyle: '400px', svgHeightStyle: '50%', svgWidthAttr: '200', svgHeightAttr: '200', ]
-    expected: FAIL
-
-  [containerWidthStyle: '400px', containerHeightStyle: '400px', svgHeightStyle: '50%', svgWidthAttr: '200', svgHeightAttr: '200', ]
-    expected: FAIL
-
-  [svgViewBoxAttr: '0 0 100 200', svgHeightStyle: '50%', svgWidthAttr: '200', svgHeightAttr: '200', ]
-    expected: FAIL
-
-  [containerWidthStyle: '400px', svgViewBoxAttr: '0 0 100 200', svgHeightStyle: '50%', svgWidthAttr: '200', svgHeightAttr: '200', ]
-    expected: FAIL
-
-  [containerHeightStyle: '400px', svgViewBoxAttr: '0 0 100 200', svgHeightStyle: '50%', svgWidthAttr: '200', svgHeightAttr: '200', ]
-    expected: FAIL
-
-  [containerWidthStyle: '400px', containerHeightStyle: '400px', svgViewBoxAttr: '0 0 100 200', svgHeightStyle: '50%', svgWidthAttr: '200', svgHeightAttr: '200', ]
-    expected: FAIL
-
-  [svgWidthStyle: '100px', svgHeightStyle: '50%', svgWidthAttr: '200', svgHeightAttr: '200', ]
-    expected: FAIL
-
-  [containerWidthStyle: '400px', svgWidthStyle: '100px', svgHeightStyle: '50%', svgWidthAttr: '200', svgHeightAttr: '200', ]
-    expected: FAIL
-
-  [containerHeightStyle: '400px', svgWidthStyle: '100px', svgHeightStyle: '50%', svgWidthAttr: '200', svgHeightAttr: '200', ]
-    expected: FAIL
-
-  [containerWidthStyle: '400px', containerHeightStyle: '400px', svgWidthStyle: '100px', svgHeightStyle: '50%', svgWidthAttr: '200', svgHeightAttr: '200', ]
-    expected: FAIL
-
-  [svgViewBoxAttr: '0 0 100 200', svgWidthStyle: '100px', svgHeightStyle: '50%', svgWidthAttr: '200', svgHeightAttr: '200', ]
-    expected: FAIL
-
-  [containerWidthStyle: '400px', svgViewBoxAttr: '0 0 100 200', svgWidthStyle: '100px', svgHeightStyle: '50%', svgWidthAttr: '200', svgHeightAttr: '200', ]
-    expected: FAIL
-
-  [containerHeightStyle: '400px', svgViewBoxAttr: '0 0 100 200', svgWidthStyle: '100px', svgHeightStyle: '50%', svgWidthAttr: '200', svgHeightAttr: '200', ]
-    expected: FAIL
-
-  [containerWidthStyle: '400px', containerHeightStyle: '400px', svgViewBoxAttr: '0 0 100 200', svgWidthStyle: '100px', svgHeightStyle: '50%', svgWidthAttr: '200', svgHeightAttr: '200', ]
-    expected: FAIL
-
-  [svgWidthStyle: '50%', svgHeightStyle: '50%', svgWidthAttr: '200', svgHeightAttr: '200', ]
-    expected: FAIL
-
-  [containerWidthStyle: '400px', svgWidthStyle: '50%', svgHeightStyle: '50%', svgWidthAttr: '200', svgHeightAttr: '200', ]
-    expected: FAIL
-
-  [containerHeightStyle: '400px', svgWidthStyle: '50%', svgHeightStyle: '50%', svgWidthAttr: '200', svgHeightAttr: '200', ]
-    expected: FAIL
-
-  [containerWidthStyle: '400px', containerHeightStyle: '400px', svgWidthStyle: '50%', svgHeightStyle: '50%', svgWidthAttr: '200', svgHeightAttr: '200', ]
-    expected: FAIL
-
-  [svgViewBoxAttr: '0 0 100 200', svgWidthStyle: '50%', svgHeightStyle: '50%', svgWidthAttr: '200', svgHeightAttr: '200', ]
-    expected: FAIL
-
-  [containerWidthStyle: '400px', svgViewBoxAttr: '0 0 100 200', svgWidthStyle: '50%', svgHeightStyle: '50%', svgWidthAttr: '200', svgHeightAttr: '200', ]
-    expected: FAIL
-
-  [containerHeightStyle: '400px', svgViewBoxAttr: '0 0 100 200', svgWidthStyle: '50%', svgHeightStyle: '50%', svgWidthAttr: '200', svgHeightAttr: '200', ]
-    expected: FAIL
-
-  [containerWidthStyle: '400px', containerHeightStyle: '400px', svgViewBoxAttr: '0 0 100 200', svgWidthStyle: '50%', svgHeightStyle: '50%', svgWidthAttr: '200', svgHeightAttr: '200', ]
-    expected: FAIL
-
   [svgWidthAttr: '25%', svgHeightAttr: '200', ]
     expected: FAIL
 
@@ -1094,49 +191,7 @@
   [svgViewBoxAttr: '0 0 100 200', svgWidthAttr: '25%', svgHeightAttr: '200', ]
     expected: FAIL
 
-  [containerWidthStyle: '400px', svgViewBoxAttr: '0 0 100 200', svgWidthAttr: '25%', svgHeightAttr: '200', ]
-    expected: FAIL
-
   [containerHeightStyle: '400px', svgViewBoxAttr: '0 0 100 200', svgWidthAttr: '25%', svgHeightAttr: '200', ]
-    expected: FAIL
-
-  [containerWidthStyle: '400px', containerHeightStyle: '400px', svgViewBoxAttr: '0 0 100 200', svgWidthAttr: '25%', svgHeightAttr: '200', ]
-    expected: FAIL
-
-  [svgWidthStyle: '100px', svgWidthAttr: '25%', svgHeightAttr: '200', ]
-    expected: FAIL
-
-  [containerWidthStyle: '400px', svgWidthStyle: '100px', svgWidthAttr: '25%', svgHeightAttr: '200', ]
-    expected: FAIL
-
-  [containerHeightStyle: '400px', svgWidthStyle: '100px', svgWidthAttr: '25%', svgHeightAttr: '200', ]
-    expected: FAIL
-
-  [containerWidthStyle: '400px', containerHeightStyle: '400px', svgWidthStyle: '100px', svgWidthAttr: '25%', svgHeightAttr: '200', ]
-    expected: FAIL
-
-  [svgViewBoxAttr: '0 0 100 200', svgWidthStyle: '100px', svgWidthAttr: '25%', svgHeightAttr: '200', ]
-    expected: FAIL
-
-  [containerWidthStyle: '400px', svgViewBoxAttr: '0 0 100 200', svgWidthStyle: '100px', svgWidthAttr: '25%', svgHeightAttr: '200', ]
-    expected: FAIL
-
-  [containerHeightStyle: '400px', svgViewBoxAttr: '0 0 100 200', svgWidthStyle: '100px', svgWidthAttr: '25%', svgHeightAttr: '200', ]
-    expected: FAIL
-
-  [containerWidthStyle: '400px', containerHeightStyle: '400px', svgViewBoxAttr: '0 0 100 200', svgWidthStyle: '100px', svgWidthAttr: '25%', svgHeightAttr: '200', ]
-    expected: FAIL
-
-  [svgWidthStyle: '50%', svgWidthAttr: '25%', svgHeightAttr: '200', ]
-    expected: FAIL
-
-  [containerWidthStyle: '400px', svgWidthStyle: '50%', svgWidthAttr: '25%', svgHeightAttr: '200', ]
-    expected: FAIL
-
-  [containerHeightStyle: '400px', svgWidthStyle: '50%', svgWidthAttr: '25%', svgHeightAttr: '200', ]
-    expected: FAIL
-
-  [containerWidthStyle: '400px', containerHeightStyle: '400px', svgWidthStyle: '50%', svgWidthAttr: '25%', svgHeightAttr: '200', ]
     expected: FAIL
 
   [svgViewBoxAttr: '0 0 100 200', svgWidthStyle: '50%', svgWidthAttr: '25%', svgHeightAttr: '200', ]
@@ -1175,54 +230,6 @@
   [containerWidthStyle: '400px', containerHeightStyle: '400px', svgViewBoxAttr: '0 0 100 200', svgHeightStyle: '100px', svgWidthAttr: '25%', svgHeightAttr: '200', ]
     expected: FAIL
 
-  [svgWidthStyle: '100px', svgHeightStyle: '100px', svgWidthAttr: '25%', svgHeightAttr: '200', ]
-    expected: FAIL
-
-  [containerWidthStyle: '400px', svgWidthStyle: '100px', svgHeightStyle: '100px', svgWidthAttr: '25%', svgHeightAttr: '200', ]
-    expected: FAIL
-
-  [containerHeightStyle: '400px', svgWidthStyle: '100px', svgHeightStyle: '100px', svgWidthAttr: '25%', svgHeightAttr: '200', ]
-    expected: FAIL
-
-  [containerWidthStyle: '400px', containerHeightStyle: '400px', svgWidthStyle: '100px', svgHeightStyle: '100px', svgWidthAttr: '25%', svgHeightAttr: '200', ]
-    expected: FAIL
-
-  [svgViewBoxAttr: '0 0 100 200', svgWidthStyle: '100px', svgHeightStyle: '100px', svgWidthAttr: '25%', svgHeightAttr: '200', ]
-    expected: FAIL
-
-  [containerWidthStyle: '400px', svgViewBoxAttr: '0 0 100 200', svgWidthStyle: '100px', svgHeightStyle: '100px', svgWidthAttr: '25%', svgHeightAttr: '200', ]
-    expected: FAIL
-
-  [containerHeightStyle: '400px', svgViewBoxAttr: '0 0 100 200', svgWidthStyle: '100px', svgHeightStyle: '100px', svgWidthAttr: '25%', svgHeightAttr: '200', ]
-    expected: FAIL
-
-  [containerWidthStyle: '400px', containerHeightStyle: '400px', svgViewBoxAttr: '0 0 100 200', svgWidthStyle: '100px', svgHeightStyle: '100px', svgWidthAttr: '25%', svgHeightAttr: '200', ]
-    expected: FAIL
-
-  [svgWidthStyle: '50%', svgHeightStyle: '100px', svgWidthAttr: '25%', svgHeightAttr: '200', ]
-    expected: FAIL
-
-  [containerWidthStyle: '400px', svgWidthStyle: '50%', svgHeightStyle: '100px', svgWidthAttr: '25%', svgHeightAttr: '200', ]
-    expected: FAIL
-
-  [containerHeightStyle: '400px', svgWidthStyle: '50%', svgHeightStyle: '100px', svgWidthAttr: '25%', svgHeightAttr: '200', ]
-    expected: FAIL
-
-  [containerWidthStyle: '400px', containerHeightStyle: '400px', svgWidthStyle: '50%', svgHeightStyle: '100px', svgWidthAttr: '25%', svgHeightAttr: '200', ]
-    expected: FAIL
-
-  [svgViewBoxAttr: '0 0 100 200', svgWidthStyle: '50%', svgHeightStyle: '100px', svgWidthAttr: '25%', svgHeightAttr: '200', ]
-    expected: FAIL
-
-  [containerWidthStyle: '400px', svgViewBoxAttr: '0 0 100 200', svgWidthStyle: '50%', svgHeightStyle: '100px', svgWidthAttr: '25%', svgHeightAttr: '200', ]
-    expected: FAIL
-
-  [containerHeightStyle: '400px', svgViewBoxAttr: '0 0 100 200', svgWidthStyle: '50%', svgHeightStyle: '100px', svgWidthAttr: '25%', svgHeightAttr: '200', ]
-    expected: FAIL
-
-  [containerWidthStyle: '400px', containerHeightStyle: '400px', svgViewBoxAttr: '0 0 100 200', svgWidthStyle: '50%', svgHeightStyle: '100px', svgWidthAttr: '25%', svgHeightAttr: '200', ]
-    expected: FAIL
-
   [svgHeightStyle: '50%', svgWidthAttr: '25%', svgHeightAttr: '200', ]
     expected: FAIL
 
@@ -1238,67 +245,7 @@
   [svgViewBoxAttr: '0 0 100 200', svgHeightStyle: '50%', svgWidthAttr: '25%', svgHeightAttr: '200', ]
     expected: FAIL
 
-  [containerWidthStyle: '400px', svgViewBoxAttr: '0 0 100 200', svgHeightStyle: '50%', svgWidthAttr: '25%', svgHeightAttr: '200', ]
-    expected: FAIL
-
   [containerHeightStyle: '400px', svgViewBoxAttr: '0 0 100 200', svgHeightStyle: '50%', svgWidthAttr: '25%', svgHeightAttr: '200', ]
-    expected: FAIL
-
-  [containerWidthStyle: '400px', containerHeightStyle: '400px', svgViewBoxAttr: '0 0 100 200', svgHeightStyle: '50%', svgWidthAttr: '25%', svgHeightAttr: '200', ]
-    expected: FAIL
-
-  [svgWidthStyle: '100px', svgHeightStyle: '50%', svgWidthAttr: '25%', svgHeightAttr: '200', ]
-    expected: FAIL
-
-  [containerWidthStyle: '400px', svgWidthStyle: '100px', svgHeightStyle: '50%', svgWidthAttr: '25%', svgHeightAttr: '200', ]
-    expected: FAIL
-
-  [containerHeightStyle: '400px', svgWidthStyle: '100px', svgHeightStyle: '50%', svgWidthAttr: '25%', svgHeightAttr: '200', ]
-    expected: FAIL
-
-  [containerWidthStyle: '400px', containerHeightStyle: '400px', svgWidthStyle: '100px', svgHeightStyle: '50%', svgWidthAttr: '25%', svgHeightAttr: '200', ]
-    expected: FAIL
-
-  [svgViewBoxAttr: '0 0 100 200', svgWidthStyle: '100px', svgHeightStyle: '50%', svgWidthAttr: '25%', svgHeightAttr: '200', ]
-    expected: FAIL
-
-  [containerWidthStyle: '400px', svgViewBoxAttr: '0 0 100 200', svgWidthStyle: '100px', svgHeightStyle: '50%', svgWidthAttr: '25%', svgHeightAttr: '200', ]
-    expected: FAIL
-
-  [containerHeightStyle: '400px', svgViewBoxAttr: '0 0 100 200', svgWidthStyle: '100px', svgHeightStyle: '50%', svgWidthAttr: '25%', svgHeightAttr: '200', ]
-    expected: FAIL
-
-  [containerWidthStyle: '400px', containerHeightStyle: '400px', svgViewBoxAttr: '0 0 100 200', svgWidthStyle: '100px', svgHeightStyle: '50%', svgWidthAttr: '25%', svgHeightAttr: '200', ]
-    expected: FAIL
-
-  [svgWidthStyle: '50%', svgHeightStyle: '50%', svgWidthAttr: '25%', svgHeightAttr: '200', ]
-    expected: FAIL
-
-  [containerWidthStyle: '400px', svgWidthStyle: '50%', svgHeightStyle: '50%', svgWidthAttr: '25%', svgHeightAttr: '200', ]
-    expected: FAIL
-
-  [containerHeightStyle: '400px', svgWidthStyle: '50%', svgHeightStyle: '50%', svgWidthAttr: '25%', svgHeightAttr: '200', ]
-    expected: FAIL
-
-  [containerWidthStyle: '400px', containerHeightStyle: '400px', svgWidthStyle: '50%', svgHeightStyle: '50%', svgWidthAttr: '25%', svgHeightAttr: '200', ]
-    expected: FAIL
-
-  [svgViewBoxAttr: '0 0 100 200', svgWidthStyle: '50%', svgHeightStyle: '50%', svgWidthAttr: '25%', svgHeightAttr: '200', ]
-    expected: FAIL
-
-  [containerWidthStyle: '400px', svgViewBoxAttr: '0 0 100 200', svgWidthStyle: '50%', svgHeightStyle: '50%', svgWidthAttr: '25%', svgHeightAttr: '200', ]
-    expected: FAIL
-
-  [containerHeightStyle: '400px', svgViewBoxAttr: '0 0 100 200', svgWidthStyle: '50%', svgHeightStyle: '50%', svgWidthAttr: '25%', svgHeightAttr: '200', ]
-    expected: FAIL
-
-  [containerWidthStyle: '400px', containerHeightStyle: '400px', svgViewBoxAttr: '0 0 100 200', svgWidthStyle: '50%', svgHeightStyle: '50%', svgWidthAttr: '25%', svgHeightAttr: '200', ]
-    expected: FAIL
-
-  [svgHeightAttr: '25%', ]
-    expected: FAIL
-
-  [containerWidthStyle: '400px', svgHeightAttr: '25%', ]
     expected: FAIL
 
   [containerHeightStyle: '400px', svgHeightAttr: '25%', ]
@@ -1319,22 +266,10 @@
   [containerWidthStyle: '400px', containerHeightStyle: '400px', svgViewBoxAttr: '0 0 100 200', svgHeightAttr: '25%', ]
     expected: FAIL
 
-  [svgWidthStyle: '100px', svgHeightAttr: '25%', ]
-    expected: FAIL
-
-  [containerWidthStyle: '400px', svgWidthStyle: '100px', svgHeightAttr: '25%', ]
-    expected: FAIL
-
   [containerHeightStyle: '400px', svgWidthStyle: '100px', svgHeightAttr: '25%', ]
     expected: FAIL
 
   [containerWidthStyle: '400px', containerHeightStyle: '400px', svgWidthStyle: '100px', svgHeightAttr: '25%', ]
-    expected: FAIL
-
-  [svgViewBoxAttr: '0 0 100 200', svgWidthStyle: '100px', svgHeightAttr: '25%', ]
-    expected: FAIL
-
-  [containerWidthStyle: '400px', svgViewBoxAttr: '0 0 100 200', svgWidthStyle: '100px', svgHeightAttr: '25%', ]
     expected: FAIL
 
   [containerHeightStyle: '400px', svgViewBoxAttr: '0 0 100 200', svgWidthStyle: '100px', svgHeightAttr: '25%', ]
@@ -1343,22 +278,10 @@
   [containerWidthStyle: '400px', containerHeightStyle: '400px', svgViewBoxAttr: '0 0 100 200', svgWidthStyle: '100px', svgHeightAttr: '25%', ]
     expected: FAIL
 
-  [svgWidthStyle: '50%', svgHeightAttr: '25%', ]
-    expected: FAIL
-
-  [containerWidthStyle: '400px', svgWidthStyle: '50%', svgHeightAttr: '25%', ]
-    expected: FAIL
-
   [containerHeightStyle: '400px', svgWidthStyle: '50%', svgHeightAttr: '25%', ]
     expected: FAIL
 
   [containerWidthStyle: '400px', containerHeightStyle: '400px', svgWidthStyle: '50%', svgHeightAttr: '25%', ]
-    expected: FAIL
-
-  [svgViewBoxAttr: '0 0 100 200', svgWidthStyle: '50%', svgHeightAttr: '25%', ]
-    expected: FAIL
-
-  [containerWidthStyle: '400px', svgViewBoxAttr: '0 0 100 200', svgWidthStyle: '50%', svgHeightAttr: '25%', ]
     expected: FAIL
 
   [containerHeightStyle: '400px', svgViewBoxAttr: '0 0 100 200', svgWidthStyle: '50%', svgHeightAttr: '25%', ]
@@ -1367,154 +290,10 @@
   [containerWidthStyle: '400px', containerHeightStyle: '400px', svgViewBoxAttr: '0 0 100 200', svgWidthStyle: '50%', svgHeightAttr: '25%', ]
     expected: FAIL
 
-  [svgHeightStyle: '100px', svgHeightAttr: '25%', ]
-    expected: FAIL
-
-  [containerWidthStyle: '400px', svgHeightStyle: '100px', svgHeightAttr: '25%', ]
-    expected: FAIL
-
-  [containerHeightStyle: '400px', svgHeightStyle: '100px', svgHeightAttr: '25%', ]
-    expected: FAIL
-
-  [containerWidthStyle: '400px', containerHeightStyle: '400px', svgHeightStyle: '100px', svgHeightAttr: '25%', ]
-    expected: FAIL
-
-  [svgViewBoxAttr: '0 0 100 200', svgHeightStyle: '100px', svgHeightAttr: '25%', ]
-    expected: FAIL
-
-  [containerWidthStyle: '400px', svgViewBoxAttr: '0 0 100 200', svgHeightStyle: '100px', svgHeightAttr: '25%', ]
-    expected: FAIL
-
-  [containerHeightStyle: '400px', svgViewBoxAttr: '0 0 100 200', svgHeightStyle: '100px', svgHeightAttr: '25%', ]
-    expected: FAIL
-
-  [containerWidthStyle: '400px', containerHeightStyle: '400px', svgViewBoxAttr: '0 0 100 200', svgHeightStyle: '100px', svgHeightAttr: '25%', ]
-    expected: FAIL
-
-  [svgWidthStyle: '100px', svgHeightStyle: '100px', svgHeightAttr: '25%', ]
-    expected: FAIL
-
-  [containerWidthStyle: '400px', svgWidthStyle: '100px', svgHeightStyle: '100px', svgHeightAttr: '25%', ]
-    expected: FAIL
-
-  [containerHeightStyle: '400px', svgWidthStyle: '100px', svgHeightStyle: '100px', svgHeightAttr: '25%', ]
-    expected: FAIL
-
-  [containerWidthStyle: '400px', containerHeightStyle: '400px', svgWidthStyle: '100px', svgHeightStyle: '100px', svgHeightAttr: '25%', ]
-    expected: FAIL
-
-  [svgViewBoxAttr: '0 0 100 200', svgWidthStyle: '100px', svgHeightStyle: '100px', svgHeightAttr: '25%', ]
-    expected: FAIL
-
-  [containerWidthStyle: '400px', svgViewBoxAttr: '0 0 100 200', svgWidthStyle: '100px', svgHeightStyle: '100px', svgHeightAttr: '25%', ]
-    expected: FAIL
-
-  [containerHeightStyle: '400px', svgViewBoxAttr: '0 0 100 200', svgWidthStyle: '100px', svgHeightStyle: '100px', svgHeightAttr: '25%', ]
-    expected: FAIL
-
-  [containerWidthStyle: '400px', containerHeightStyle: '400px', svgViewBoxAttr: '0 0 100 200', svgWidthStyle: '100px', svgHeightStyle: '100px', svgHeightAttr: '25%', ]
-    expected: FAIL
-
-  [svgWidthStyle: '50%', svgHeightStyle: '100px', svgHeightAttr: '25%', ]
-    expected: FAIL
-
-  [containerWidthStyle: '400px', svgWidthStyle: '50%', svgHeightStyle: '100px', svgHeightAttr: '25%', ]
-    expected: FAIL
-
-  [containerHeightStyle: '400px', svgWidthStyle: '50%', svgHeightStyle: '100px', svgHeightAttr: '25%', ]
-    expected: FAIL
-
-  [containerWidthStyle: '400px', containerHeightStyle: '400px', svgWidthStyle: '50%', svgHeightStyle: '100px', svgHeightAttr: '25%', ]
-    expected: FAIL
-
-  [svgViewBoxAttr: '0 0 100 200', svgWidthStyle: '50%', svgHeightStyle: '100px', svgHeightAttr: '25%', ]
-    expected: FAIL
-
-  [containerWidthStyle: '400px', svgViewBoxAttr: '0 0 100 200', svgWidthStyle: '50%', svgHeightStyle: '100px', svgHeightAttr: '25%', ]
-    expected: FAIL
-
-  [containerHeightStyle: '400px', svgViewBoxAttr: '0 0 100 200', svgWidthStyle: '50%', svgHeightStyle: '100px', svgHeightAttr: '25%', ]
-    expected: FAIL
-
-  [containerWidthStyle: '400px', containerHeightStyle: '400px', svgViewBoxAttr: '0 0 100 200', svgWidthStyle: '50%', svgHeightStyle: '100px', svgHeightAttr: '25%', ]
-    expected: FAIL
-
-  [svgHeightStyle: '50%', svgHeightAttr: '25%', ]
-    expected: FAIL
-
-  [containerWidthStyle: '400px', svgHeightStyle: '50%', svgHeightAttr: '25%', ]
-    expected: FAIL
-
-  [containerHeightStyle: '400px', svgHeightStyle: '50%', svgHeightAttr: '25%', ]
-    expected: FAIL
-
-  [containerWidthStyle: '400px', containerHeightStyle: '400px', svgHeightStyle: '50%', svgHeightAttr: '25%', ]
-    expected: FAIL
-
   [svgViewBoxAttr: '0 0 100 200', svgHeightStyle: '50%', svgHeightAttr: '25%', ]
     expected: FAIL
 
   [containerWidthStyle: '400px', svgViewBoxAttr: '0 0 100 200', svgHeightStyle: '50%', svgHeightAttr: '25%', ]
-    expected: FAIL
-
-  [containerHeightStyle: '400px', svgViewBoxAttr: '0 0 100 200', svgHeightStyle: '50%', svgHeightAttr: '25%', ]
-    expected: FAIL
-
-  [containerWidthStyle: '400px', containerHeightStyle: '400px', svgViewBoxAttr: '0 0 100 200', svgHeightStyle: '50%', svgHeightAttr: '25%', ]
-    expected: FAIL
-
-  [svgWidthStyle: '100px', svgHeightStyle: '50%', svgHeightAttr: '25%', ]
-    expected: FAIL
-
-  [containerWidthStyle: '400px', svgWidthStyle: '100px', svgHeightStyle: '50%', svgHeightAttr: '25%', ]
-    expected: FAIL
-
-  [containerHeightStyle: '400px', svgWidthStyle: '100px', svgHeightStyle: '50%', svgHeightAttr: '25%', ]
-    expected: FAIL
-
-  [containerWidthStyle: '400px', containerHeightStyle: '400px', svgWidthStyle: '100px', svgHeightStyle: '50%', svgHeightAttr: '25%', ]
-    expected: FAIL
-
-  [svgViewBoxAttr: '0 0 100 200', svgWidthStyle: '100px', svgHeightStyle: '50%', svgHeightAttr: '25%', ]
-    expected: FAIL
-
-  [containerWidthStyle: '400px', svgViewBoxAttr: '0 0 100 200', svgWidthStyle: '100px', svgHeightStyle: '50%', svgHeightAttr: '25%', ]
-    expected: FAIL
-
-  [containerHeightStyle: '400px', svgViewBoxAttr: '0 0 100 200', svgWidthStyle: '100px', svgHeightStyle: '50%', svgHeightAttr: '25%', ]
-    expected: FAIL
-
-  [containerWidthStyle: '400px', containerHeightStyle: '400px', svgViewBoxAttr: '0 0 100 200', svgWidthStyle: '100px', svgHeightStyle: '50%', svgHeightAttr: '25%', ]
-    expected: FAIL
-
-  [svgWidthStyle: '50%', svgHeightStyle: '50%', svgHeightAttr: '25%', ]
-    expected: FAIL
-
-  [containerWidthStyle: '400px', svgWidthStyle: '50%', svgHeightStyle: '50%', svgHeightAttr: '25%', ]
-    expected: FAIL
-
-  [containerHeightStyle: '400px', svgWidthStyle: '50%', svgHeightStyle: '50%', svgHeightAttr: '25%', ]
-    expected: FAIL
-
-  [containerWidthStyle: '400px', containerHeightStyle: '400px', svgWidthStyle: '50%', svgHeightStyle: '50%', svgHeightAttr: '25%', ]
-    expected: FAIL
-
-  [svgViewBoxAttr: '0 0 100 200', svgWidthStyle: '50%', svgHeightStyle: '50%', svgHeightAttr: '25%', ]
-    expected: FAIL
-
-  [containerWidthStyle: '400px', svgViewBoxAttr: '0 0 100 200', svgWidthStyle: '50%', svgHeightStyle: '50%', svgHeightAttr: '25%', ]
-    expected: FAIL
-
-  [containerHeightStyle: '400px', svgViewBoxAttr: '0 0 100 200', svgWidthStyle: '50%', svgHeightStyle: '50%', svgHeightAttr: '25%', ]
-    expected: FAIL
-
-  [containerWidthStyle: '400px', containerHeightStyle: '400px', svgViewBoxAttr: '0 0 100 200', svgWidthStyle: '50%', svgHeightStyle: '50%', svgHeightAttr: '25%', ]
-    expected: FAIL
-
-  [svgWidthAttr: '200', svgHeightAttr: '25%', ]
-    expected: FAIL
-
-  [containerWidthStyle: '400px', svgWidthAttr: '200', svgHeightAttr: '25%', ]
     expected: FAIL
 
   [containerHeightStyle: '400px', svgWidthAttr: '200', svgHeightAttr: '25%', ]
@@ -1523,22 +302,10 @@
   [containerWidthStyle: '400px', containerHeightStyle: '400px', svgWidthAttr: '200', svgHeightAttr: '25%', ]
     expected: FAIL
 
-  [svgViewBoxAttr: '0 0 100 200', svgWidthAttr: '200', svgHeightAttr: '25%', ]
-    expected: FAIL
-
-  [containerWidthStyle: '400px', svgViewBoxAttr: '0 0 100 200', svgWidthAttr: '200', svgHeightAttr: '25%', ]
-    expected: FAIL
-
   [containerHeightStyle: '400px', svgViewBoxAttr: '0 0 100 200', svgWidthAttr: '200', svgHeightAttr: '25%', ]
     expected: FAIL
 
   [containerWidthStyle: '400px', containerHeightStyle: '400px', svgViewBoxAttr: '0 0 100 200', svgWidthAttr: '200', svgHeightAttr: '25%', ]
-    expected: FAIL
-
-  [svgWidthStyle: '100px', svgWidthAttr: '200', svgHeightAttr: '25%', ]
-    expected: FAIL
-
-  [containerWidthStyle: '400px', svgWidthStyle: '100px', svgWidthAttr: '200', svgHeightAttr: '25%', ]
     expected: FAIL
 
   [containerHeightStyle: '400px', svgWidthStyle: '100px', svgWidthAttr: '200', svgHeightAttr: '25%', ]
@@ -1547,22 +314,10 @@
   [containerWidthStyle: '400px', containerHeightStyle: '400px', svgWidthStyle: '100px', svgWidthAttr: '200', svgHeightAttr: '25%', ]
     expected: FAIL
 
-  [svgViewBoxAttr: '0 0 100 200', svgWidthStyle: '100px', svgWidthAttr: '200', svgHeightAttr: '25%', ]
-    expected: FAIL
-
-  [containerWidthStyle: '400px', svgViewBoxAttr: '0 0 100 200', svgWidthStyle: '100px', svgWidthAttr: '200', svgHeightAttr: '25%', ]
-    expected: FAIL
-
   [containerHeightStyle: '400px', svgViewBoxAttr: '0 0 100 200', svgWidthStyle: '100px', svgWidthAttr: '200', svgHeightAttr: '25%', ]
     expected: FAIL
 
   [containerWidthStyle: '400px', containerHeightStyle: '400px', svgViewBoxAttr: '0 0 100 200', svgWidthStyle: '100px', svgWidthAttr: '200', svgHeightAttr: '25%', ]
-    expected: FAIL
-
-  [svgWidthStyle: '50%', svgWidthAttr: '200', svgHeightAttr: '25%', ]
-    expected: FAIL
-
-  [containerWidthStyle: '400px', svgWidthStyle: '50%', svgWidthAttr: '200', svgHeightAttr: '25%', ]
     expected: FAIL
 
   [containerHeightStyle: '400px', svgWidthStyle: '50%', svgWidthAttr: '200', svgHeightAttr: '25%', ]
@@ -1571,28 +326,10 @@
   [containerWidthStyle: '400px', containerHeightStyle: '400px', svgWidthStyle: '50%', svgWidthAttr: '200', svgHeightAttr: '25%', ]
     expected: FAIL
 
-  [svgViewBoxAttr: '0 0 100 200', svgWidthStyle: '50%', svgWidthAttr: '200', svgHeightAttr: '25%', ]
-    expected: FAIL
-
-  [containerWidthStyle: '400px', svgViewBoxAttr: '0 0 100 200', svgWidthStyle: '50%', svgWidthAttr: '200', svgHeightAttr: '25%', ]
-    expected: FAIL
-
   [containerHeightStyle: '400px', svgViewBoxAttr: '0 0 100 200', svgWidthStyle: '50%', svgWidthAttr: '200', svgHeightAttr: '25%', ]
     expected: FAIL
 
   [containerWidthStyle: '400px', containerHeightStyle: '400px', svgViewBoxAttr: '0 0 100 200', svgWidthStyle: '50%', svgWidthAttr: '200', svgHeightAttr: '25%', ]
-    expected: FAIL
-
-  [svgHeightStyle: '100px', svgWidthAttr: '200', svgHeightAttr: '25%', ]
-    expected: FAIL
-
-  [containerWidthStyle: '400px', svgHeightStyle: '100px', svgWidthAttr: '200', svgHeightAttr: '25%', ]
-    expected: FAIL
-
-  [containerHeightStyle: '400px', svgHeightStyle: '100px', svgWidthAttr: '200', svgHeightAttr: '25%', ]
-    expected: FAIL
-
-  [containerWidthStyle: '400px', containerHeightStyle: '400px', svgHeightStyle: '100px', svgWidthAttr: '200', svgHeightAttr: '25%', ]
     expected: FAIL
 
   [svgViewBoxAttr: '0 0 100 200', svgHeightStyle: '100px', svgWidthAttr: '200', svgHeightAttr: '25%', ]
@@ -1607,124 +344,10 @@
   [containerWidthStyle: '400px', containerHeightStyle: '400px', svgViewBoxAttr: '0 0 100 200', svgHeightStyle: '100px', svgWidthAttr: '200', svgHeightAttr: '25%', ]
     expected: FAIL
 
-  [svgWidthStyle: '100px', svgHeightStyle: '100px', svgWidthAttr: '200', svgHeightAttr: '25%', ]
-    expected: FAIL
-
-  [containerWidthStyle: '400px', svgWidthStyle: '100px', svgHeightStyle: '100px', svgWidthAttr: '200', svgHeightAttr: '25%', ]
-    expected: FAIL
-
-  [containerHeightStyle: '400px', svgWidthStyle: '100px', svgHeightStyle: '100px', svgWidthAttr: '200', svgHeightAttr: '25%', ]
-    expected: FAIL
-
-  [containerWidthStyle: '400px', containerHeightStyle: '400px', svgWidthStyle: '100px', svgHeightStyle: '100px', svgWidthAttr: '200', svgHeightAttr: '25%', ]
-    expected: FAIL
-
-  [svgViewBoxAttr: '0 0 100 200', svgWidthStyle: '100px', svgHeightStyle: '100px', svgWidthAttr: '200', svgHeightAttr: '25%', ]
-    expected: FAIL
-
-  [containerWidthStyle: '400px', svgViewBoxAttr: '0 0 100 200', svgWidthStyle: '100px', svgHeightStyle: '100px', svgWidthAttr: '200', svgHeightAttr: '25%', ]
-    expected: FAIL
-
-  [containerHeightStyle: '400px', svgViewBoxAttr: '0 0 100 200', svgWidthStyle: '100px', svgHeightStyle: '100px', svgWidthAttr: '200', svgHeightAttr: '25%', ]
-    expected: FAIL
-
-  [containerWidthStyle: '400px', containerHeightStyle: '400px', svgViewBoxAttr: '0 0 100 200', svgWidthStyle: '100px', svgHeightStyle: '100px', svgWidthAttr: '200', svgHeightAttr: '25%', ]
-    expected: FAIL
-
-  [svgWidthStyle: '50%', svgHeightStyle: '100px', svgWidthAttr: '200', svgHeightAttr: '25%', ]
-    expected: FAIL
-
-  [containerWidthStyle: '400px', svgWidthStyle: '50%', svgHeightStyle: '100px', svgWidthAttr: '200', svgHeightAttr: '25%', ]
-    expected: FAIL
-
-  [containerHeightStyle: '400px', svgWidthStyle: '50%', svgHeightStyle: '100px', svgWidthAttr: '200', svgHeightAttr: '25%', ]
-    expected: FAIL
-
-  [containerWidthStyle: '400px', containerHeightStyle: '400px', svgWidthStyle: '50%', svgHeightStyle: '100px', svgWidthAttr: '200', svgHeightAttr: '25%', ]
-    expected: FAIL
-
-  [svgViewBoxAttr: '0 0 100 200', svgWidthStyle: '50%', svgHeightStyle: '100px', svgWidthAttr: '200', svgHeightAttr: '25%', ]
-    expected: FAIL
-
-  [containerWidthStyle: '400px', svgViewBoxAttr: '0 0 100 200', svgWidthStyle: '50%', svgHeightStyle: '100px', svgWidthAttr: '200', svgHeightAttr: '25%', ]
-    expected: FAIL
-
-  [containerHeightStyle: '400px', svgViewBoxAttr: '0 0 100 200', svgWidthStyle: '50%', svgHeightStyle: '100px', svgWidthAttr: '200', svgHeightAttr: '25%', ]
-    expected: FAIL
-
-  [containerWidthStyle: '400px', containerHeightStyle: '400px', svgViewBoxAttr: '0 0 100 200', svgWidthStyle: '50%', svgHeightStyle: '100px', svgWidthAttr: '200', svgHeightAttr: '25%', ]
-    expected: FAIL
-
-  [svgHeightStyle: '50%', svgWidthAttr: '200', svgHeightAttr: '25%', ]
-    expected: FAIL
-
-  [containerWidthStyle: '400px', svgHeightStyle: '50%', svgWidthAttr: '200', svgHeightAttr: '25%', ]
-    expected: FAIL
-
-  [containerHeightStyle: '400px', svgHeightStyle: '50%', svgWidthAttr: '200', svgHeightAttr: '25%', ]
-    expected: FAIL
-
-  [containerWidthStyle: '400px', containerHeightStyle: '400px', svgHeightStyle: '50%', svgWidthAttr: '200', svgHeightAttr: '25%', ]
-    expected: FAIL
-
-  [svgViewBoxAttr: '0 0 100 200', svgHeightStyle: '50%', svgWidthAttr: '200', svgHeightAttr: '25%', ]
-    expected: FAIL
-
-  [containerWidthStyle: '400px', svgViewBoxAttr: '0 0 100 200', svgHeightStyle: '50%', svgWidthAttr: '200', svgHeightAttr: '25%', ]
-    expected: FAIL
-
   [containerHeightStyle: '400px', svgViewBoxAttr: '0 0 100 200', svgHeightStyle: '50%', svgWidthAttr: '200', svgHeightAttr: '25%', ]
     expected: FAIL
 
   [containerWidthStyle: '400px', containerHeightStyle: '400px', svgViewBoxAttr: '0 0 100 200', svgHeightStyle: '50%', svgWidthAttr: '200', svgHeightAttr: '25%', ]
-    expected: FAIL
-
-  [svgWidthStyle: '100px', svgHeightStyle: '50%', svgWidthAttr: '200', svgHeightAttr: '25%', ]
-    expected: FAIL
-
-  [containerWidthStyle: '400px', svgWidthStyle: '100px', svgHeightStyle: '50%', svgWidthAttr: '200', svgHeightAttr: '25%', ]
-    expected: FAIL
-
-  [containerHeightStyle: '400px', svgWidthStyle: '100px', svgHeightStyle: '50%', svgWidthAttr: '200', svgHeightAttr: '25%', ]
-    expected: FAIL
-
-  [containerWidthStyle: '400px', containerHeightStyle: '400px', svgWidthStyle: '100px', svgHeightStyle: '50%', svgWidthAttr: '200', svgHeightAttr: '25%', ]
-    expected: FAIL
-
-  [svgViewBoxAttr: '0 0 100 200', svgWidthStyle: '100px', svgHeightStyle: '50%', svgWidthAttr: '200', svgHeightAttr: '25%', ]
-    expected: FAIL
-
-  [containerWidthStyle: '400px', svgViewBoxAttr: '0 0 100 200', svgWidthStyle: '100px', svgHeightStyle: '50%', svgWidthAttr: '200', svgHeightAttr: '25%', ]
-    expected: FAIL
-
-  [containerHeightStyle: '400px', svgViewBoxAttr: '0 0 100 200', svgWidthStyle: '100px', svgHeightStyle: '50%', svgWidthAttr: '200', svgHeightAttr: '25%', ]
-    expected: FAIL
-
-  [containerWidthStyle: '400px', containerHeightStyle: '400px', svgViewBoxAttr: '0 0 100 200', svgWidthStyle: '100px', svgHeightStyle: '50%', svgWidthAttr: '200', svgHeightAttr: '25%', ]
-    expected: FAIL
-
-  [svgWidthStyle: '50%', svgHeightStyle: '50%', svgWidthAttr: '200', svgHeightAttr: '25%', ]
-    expected: FAIL
-
-  [containerWidthStyle: '400px', svgWidthStyle: '50%', svgHeightStyle: '50%', svgWidthAttr: '200', svgHeightAttr: '25%', ]
-    expected: FAIL
-
-  [containerHeightStyle: '400px', svgWidthStyle: '50%', svgHeightStyle: '50%', svgWidthAttr: '200', svgHeightAttr: '25%', ]
-    expected: FAIL
-
-  [containerWidthStyle: '400px', containerHeightStyle: '400px', svgWidthStyle: '50%', svgHeightStyle: '50%', svgWidthAttr: '200', svgHeightAttr: '25%', ]
-    expected: FAIL
-
-  [svgViewBoxAttr: '0 0 100 200', svgWidthStyle: '50%', svgHeightStyle: '50%', svgWidthAttr: '200', svgHeightAttr: '25%', ]
-    expected: FAIL
-
-  [containerWidthStyle: '400px', svgViewBoxAttr: '0 0 100 200', svgWidthStyle: '50%', svgHeightStyle: '50%', svgWidthAttr: '200', svgHeightAttr: '25%', ]
-    expected: FAIL
-
-  [containerHeightStyle: '400px', svgViewBoxAttr: '0 0 100 200', svgWidthStyle: '50%', svgHeightStyle: '50%', svgWidthAttr: '200', svgHeightAttr: '25%', ]
-    expected: FAIL
-
-  [containerWidthStyle: '400px', containerHeightStyle: '400px', svgViewBoxAttr: '0 0 100 200', svgWidthStyle: '50%', svgHeightStyle: '50%', svgWidthAttr: '200', svgHeightAttr: '25%', ]
     expected: FAIL
 
   [svgWidthAttr: '25%', svgHeightAttr: '25%', ]
@@ -1751,22 +374,10 @@
   [containerWidthStyle: '400px', containerHeightStyle: '400px', svgViewBoxAttr: '0 0 100 200', svgWidthAttr: '25%', svgHeightAttr: '25%', ]
     expected: FAIL
 
-  [svgWidthStyle: '100px', svgWidthAttr: '25%', svgHeightAttr: '25%', ]
-    expected: FAIL
-
-  [containerWidthStyle: '400px', svgWidthStyle: '100px', svgWidthAttr: '25%', svgHeightAttr: '25%', ]
-    expected: FAIL
-
   [containerHeightStyle: '400px', svgWidthStyle: '100px', svgWidthAttr: '25%', svgHeightAttr: '25%', ]
     expected: FAIL
 
   [containerWidthStyle: '400px', containerHeightStyle: '400px', svgWidthStyle: '100px', svgWidthAttr: '25%', svgHeightAttr: '25%', ]
-    expected: FAIL
-
-  [svgViewBoxAttr: '0 0 100 200', svgWidthStyle: '100px', svgWidthAttr: '25%', svgHeightAttr: '25%', ]
-    expected: FAIL
-
-  [containerWidthStyle: '400px', svgViewBoxAttr: '0 0 100 200', svgWidthStyle: '100px', svgWidthAttr: '25%', svgHeightAttr: '25%', ]
     expected: FAIL
 
   [containerHeightStyle: '400px', svgViewBoxAttr: '0 0 100 200', svgWidthStyle: '100px', svgWidthAttr: '25%', svgHeightAttr: '25%', ]
@@ -1775,22 +386,10 @@
   [containerWidthStyle: '400px', containerHeightStyle: '400px', svgViewBoxAttr: '0 0 100 200', svgWidthStyle: '100px', svgWidthAttr: '25%', svgHeightAttr: '25%', ]
     expected: FAIL
 
-  [svgWidthStyle: '50%', svgWidthAttr: '25%', svgHeightAttr: '25%', ]
-    expected: FAIL
-
-  [containerWidthStyle: '400px', svgWidthStyle: '50%', svgWidthAttr: '25%', svgHeightAttr: '25%', ]
-    expected: FAIL
-
   [containerHeightStyle: '400px', svgWidthStyle: '50%', svgWidthAttr: '25%', svgHeightAttr: '25%', ]
     expected: FAIL
 
   [containerWidthStyle: '400px', containerHeightStyle: '400px', svgWidthStyle: '50%', svgWidthAttr: '25%', svgHeightAttr: '25%', ]
-    expected: FAIL
-
-  [svgViewBoxAttr: '0 0 100 200', svgWidthStyle: '50%', svgWidthAttr: '25%', svgHeightAttr: '25%', ]
-    expected: FAIL
-
-  [containerWidthStyle: '400px', svgViewBoxAttr: '0 0 100 200', svgWidthStyle: '50%', svgWidthAttr: '25%', svgHeightAttr: '25%', ]
     expected: FAIL
 
   [containerHeightStyle: '400px', svgViewBoxAttr: '0 0 100 200', svgWidthStyle: '50%', svgWidthAttr: '25%', svgHeightAttr: '25%', ]
@@ -1823,54 +422,6 @@
   [containerWidthStyle: '400px', containerHeightStyle: '400px', svgViewBoxAttr: '0 0 100 200', svgHeightStyle: '100px', svgWidthAttr: '25%', svgHeightAttr: '25%', ]
     expected: FAIL
 
-  [svgWidthStyle: '100px', svgHeightStyle: '100px', svgWidthAttr: '25%', svgHeightAttr: '25%', ]
-    expected: FAIL
-
-  [containerWidthStyle: '400px', svgWidthStyle: '100px', svgHeightStyle: '100px', svgWidthAttr: '25%', svgHeightAttr: '25%', ]
-    expected: FAIL
-
-  [containerHeightStyle: '400px', svgWidthStyle: '100px', svgHeightStyle: '100px', svgWidthAttr: '25%', svgHeightAttr: '25%', ]
-    expected: FAIL
-
-  [containerWidthStyle: '400px', containerHeightStyle: '400px', svgWidthStyle: '100px', svgHeightStyle: '100px', svgWidthAttr: '25%', svgHeightAttr: '25%', ]
-    expected: FAIL
-
-  [svgViewBoxAttr: '0 0 100 200', svgWidthStyle: '100px', svgHeightStyle: '100px', svgWidthAttr: '25%', svgHeightAttr: '25%', ]
-    expected: FAIL
-
-  [containerWidthStyle: '400px', svgViewBoxAttr: '0 0 100 200', svgWidthStyle: '100px', svgHeightStyle: '100px', svgWidthAttr: '25%', svgHeightAttr: '25%', ]
-    expected: FAIL
-
-  [containerHeightStyle: '400px', svgViewBoxAttr: '0 0 100 200', svgWidthStyle: '100px', svgHeightStyle: '100px', svgWidthAttr: '25%', svgHeightAttr: '25%', ]
-    expected: FAIL
-
-  [containerWidthStyle: '400px', containerHeightStyle: '400px', svgViewBoxAttr: '0 0 100 200', svgWidthStyle: '100px', svgHeightStyle: '100px', svgWidthAttr: '25%', svgHeightAttr: '25%', ]
-    expected: FAIL
-
-  [svgWidthStyle: '50%', svgHeightStyle: '100px', svgWidthAttr: '25%', svgHeightAttr: '25%', ]
-    expected: FAIL
-
-  [containerWidthStyle: '400px', svgWidthStyle: '50%', svgHeightStyle: '100px', svgWidthAttr: '25%', svgHeightAttr: '25%', ]
-    expected: FAIL
-
-  [containerHeightStyle: '400px', svgWidthStyle: '50%', svgHeightStyle: '100px', svgWidthAttr: '25%', svgHeightAttr: '25%', ]
-    expected: FAIL
-
-  [containerWidthStyle: '400px', containerHeightStyle: '400px', svgWidthStyle: '50%', svgHeightStyle: '100px', svgWidthAttr: '25%', svgHeightAttr: '25%', ]
-    expected: FAIL
-
-  [svgViewBoxAttr: '0 0 100 200', svgWidthStyle: '50%', svgHeightStyle: '100px', svgWidthAttr: '25%', svgHeightAttr: '25%', ]
-    expected: FAIL
-
-  [containerWidthStyle: '400px', svgViewBoxAttr: '0 0 100 200', svgWidthStyle: '50%', svgHeightStyle: '100px', svgWidthAttr: '25%', svgHeightAttr: '25%', ]
-    expected: FAIL
-
-  [containerHeightStyle: '400px', svgViewBoxAttr: '0 0 100 200', svgWidthStyle: '50%', svgHeightStyle: '100px', svgWidthAttr: '25%', svgHeightAttr: '25%', ]
-    expected: FAIL
-
-  [containerWidthStyle: '400px', containerHeightStyle: '400px', svgViewBoxAttr: '0 0 100 200', svgWidthStyle: '50%', svgHeightStyle: '100px', svgWidthAttr: '25%', svgHeightAttr: '25%', ]
-    expected: FAIL
-
   [svgHeightStyle: '50%', svgWidthAttr: '25%', svgHeightAttr: '25%', ]
     expected: FAIL
 
@@ -1890,55 +441,4 @@
     expected: FAIL
 
   [containerHeightStyle: '400px', svgViewBoxAttr: '0 0 100 200', svgHeightStyle: '50%', svgWidthAttr: '25%', svgHeightAttr: '25%', ]
-    expected: FAIL
-
-  [containerWidthStyle: '400px', containerHeightStyle: '400px', svgViewBoxAttr: '0 0 100 200', svgHeightStyle: '50%', svgWidthAttr: '25%', svgHeightAttr: '25%', ]
-    expected: FAIL
-
-  [svgWidthStyle: '100px', svgHeightStyle: '50%', svgWidthAttr: '25%', svgHeightAttr: '25%', ]
-    expected: FAIL
-
-  [containerWidthStyle: '400px', svgWidthStyle: '100px', svgHeightStyle: '50%', svgWidthAttr: '25%', svgHeightAttr: '25%', ]
-    expected: FAIL
-
-  [containerHeightStyle: '400px', svgWidthStyle: '100px', svgHeightStyle: '50%', svgWidthAttr: '25%', svgHeightAttr: '25%', ]
-    expected: FAIL
-
-  [containerWidthStyle: '400px', containerHeightStyle: '400px', svgWidthStyle: '100px', svgHeightStyle: '50%', svgWidthAttr: '25%', svgHeightAttr: '25%', ]
-    expected: FAIL
-
-  [svgViewBoxAttr: '0 0 100 200', svgWidthStyle: '100px', svgHeightStyle: '50%', svgWidthAttr: '25%', svgHeightAttr: '25%', ]
-    expected: FAIL
-
-  [containerWidthStyle: '400px', svgViewBoxAttr: '0 0 100 200', svgWidthStyle: '100px', svgHeightStyle: '50%', svgWidthAttr: '25%', svgHeightAttr: '25%', ]
-    expected: FAIL
-
-  [containerHeightStyle: '400px', svgViewBoxAttr: '0 0 100 200', svgWidthStyle: '100px', svgHeightStyle: '50%', svgWidthAttr: '25%', svgHeightAttr: '25%', ]
-    expected: FAIL
-
-  [containerWidthStyle: '400px', containerHeightStyle: '400px', svgViewBoxAttr: '0 0 100 200', svgWidthStyle: '100px', svgHeightStyle: '50%', svgWidthAttr: '25%', svgHeightAttr: '25%', ]
-    expected: FAIL
-
-  [svgWidthStyle: '50%', svgHeightStyle: '50%', svgWidthAttr: '25%', svgHeightAttr: '25%', ]
-    expected: FAIL
-
-  [containerWidthStyle: '400px', svgWidthStyle: '50%', svgHeightStyle: '50%', svgWidthAttr: '25%', svgHeightAttr: '25%', ]
-    expected: FAIL
-
-  [containerHeightStyle: '400px', svgWidthStyle: '50%', svgHeightStyle: '50%', svgWidthAttr: '25%', svgHeightAttr: '25%', ]
-    expected: FAIL
-
-  [containerWidthStyle: '400px', containerHeightStyle: '400px', svgWidthStyle: '50%', svgHeightStyle: '50%', svgWidthAttr: '25%', svgHeightAttr: '25%', ]
-    expected: FAIL
-
-  [svgViewBoxAttr: '0 0 100 200', svgWidthStyle: '50%', svgHeightStyle: '50%', svgWidthAttr: '25%', svgHeightAttr: '25%', ]
-    expected: FAIL
-
-  [containerWidthStyle: '400px', svgViewBoxAttr: '0 0 100 200', svgWidthStyle: '50%', svgHeightStyle: '50%', svgWidthAttr: '25%', svgHeightAttr: '25%', ]
-    expected: FAIL
-
-  [containerHeightStyle: '400px', svgViewBoxAttr: '0 0 100 200', svgWidthStyle: '50%', svgHeightStyle: '50%', svgWidthAttr: '25%', svgHeightAttr: '25%', ]
-    expected: FAIL
-
-  [containerWidthStyle: '400px', containerHeightStyle: '400px', svgViewBoxAttr: '0 0 100 200', svgWidthStyle: '50%', svgHeightStyle: '50%', svgWidthAttr: '25%', svgHeightAttr: '25%', ]
     expected: FAIL

--- a/tests/wpt/meta/svg/coordinate-systems/outer-svg-intrinsic-size-001.html.ini
+++ b/tests/wpt/meta/svg/coordinate-systems/outer-svg-intrinsic-size-001.html.ini
@@ -1,45 +1,9 @@
 [outer-svg-intrinsic-size-001.html]
-  [no sizing attributes set]
-    expected: FAIL
-
-  [specified width]
-    expected: FAIL
-
-  [modified specified width]
-    expected: FAIL
-
-  [specified width and height]
-    expected: FAIL
-
-  [specified width and modified specified height]
-    expected: FAIL
-
-  [specified height]
-    expected: FAIL
-
-  [modified specified height]
-    expected: FAIL
-
-  [no specified sizing attrs (after setting & removing them)]
-    expected: FAIL
-
   [set a 10x8 viewBox]
     expected: FAIL
 
   [modified viewBox to 50x20]
     expected: FAIL
 
-  [adding specified width, in presence of specified viewBox]
-    expected: FAIL
-
-  [modifiying specified viewBox, in presence of specified width]
-    expected: FAIL
-
   [removing specified width, in presence of specified viewBox]
-    expected: FAIL
-
-  [adding specified height, in presence of specified viewBox]
-    expected: FAIL
-
-  [modifiying specified viewBox, in presence of specified height]
     expected: FAIL

--- a/tests/wpt/meta/svg/interact/scripted/svg-root-border-radius.html.ini
+++ b/tests/wpt/meta/svg/interact/scripted/svg-root-border-radius.html.ini
@@ -1,3 +1,0 @@
-[svg-root-border-radius.html]
-  [SVG root with border-radius hit test]
-    expected: FAIL

--- a/tests/wpt/mozilla/meta/MANIFEST.json
+++ b/tests/wpt/mozilla/meta/MANIFEST.json
@@ -102,6 +102,15 @@
       {}
      ]
     ],
+    "svg": {
+     "svg-replaced-crash.html": [
+      "f1764e4a1bc5e15dedb6a4f2154ff86ae884a5d2",
+      [
+       null,
+       {}
+      ]
+     ]
+    },
     "test-wait-crash.html": [
      "2419da6af0c278a17b9ff974d4418f9e386ef3e0",
      [

--- a/tests/wpt/mozilla/tests/mozilla/svg/svg-replaced-crash.html
+++ b/tests/wpt/mozilla/tests/mozilla/svg/svg-replaced-crash.html
@@ -1,0 +1,8 @@
+<!DOCTYPE html>
+<style>
+  clipPath {display: block; perspective: 1em;}
+</style>
+<svg><clipPath id="clipPath"></svg>
+<script>
+onload = _ => document.getElementById("clipPath").getBoundingClientRect();
+</script>


### PR DESCRIPTION
The current implementation treats an SVG element that needs a new serialized tree as non-replaced content, so we attempt to lay out all of the children. If serialization is successful, subsequent layouts treat the SVG as replaced content and ignore the children, but the children's layout data is never cleaned up. This means that layout queries against those children can return stale data, which can lead to unexpected results. By always treating SVG elements as replaced content, we remove this footgun and improve consistency.

Testing: New crashtest added. It doesn't make sense to upstream this because our SVG implementation is very nonstandard.
Fixes: #42291
Fixes: #40900
