### PR TITLE
OHOS: reverse bump HarmonyOS version number

### DIFF
--- a/support/openharmony/build-profile.json5
+++ b/support/openharmony/build-profile.json5
@@ -12,8 +12,8 @@
       {
         "name": "harmonyos",
         "signingConfig": "hos",
-        "compatibleSdkVersion": "6.0.1(21)",
-        "targetSdkVersion": "6.0.1(21)",
+        "compatibleSdkVersion": "6.0.0(20)",
+        "targetSdkVersion": "6.0.0(20)",
         "runtimeOS": "HarmonyOS"
       }
     ],


### PR DESCRIPTION
It turns out the HarmonyOS version numbers can be confusing. This now puts it as the same as the OpenHarmony version numbers.
As the SDKs are backwards compatible everything should still work with newer SDKs.

Testing: CI will test compilation and installation and manually tested by me.
