### PR TITLE
layout: Clear dirty box tree nodes during damage traversal

### DIFF
--- a/components/layout/construct_modern.rs
+++ b/components/layout/construct_modern.rs
@@ -120,12 +120,15 @@ impl<'dom> ModernContainerJob<'dom> {
                     info.style.clone_order()
                 };
 
-                if let Some(layout_box) = box_slot
-                    .take_layout_box_if_undamaged(info.damage)
-                    .and_then(|layout_box| match &layout_box {
-                        LayoutBox::FlexLevel(_) | LayoutBox::TaffyItemBox(_) => Some(layout_box),
-                        _ => None,
-                    })
+                if let Some(layout_box) =
+                    box_slot
+                        .take_layout_box()
+                        .and_then(|layout_box| match &layout_box {
+                            LayoutBox::FlexLevel(_) | LayoutBox::TaffyItemBox(_) => {
+                                Some(layout_box)
+                            },
+                            _ => None,
+                        })
                 {
                     return Some(ModernItem {
                         kind: ModernItemKind::ReusedBox(layout_box),

--- a/components/layout/dom.rs
+++ b/components/layout/dom.rs
@@ -287,10 +287,7 @@ impl BoxSlot<'_> {
         *self.slot.borrow_mut() = Some(layout_box);
     }
 
-    pub(crate) fn take_layout_box_if_undamaged(&self, damage: LayoutDamage) -> Option<LayoutBox> {
-        if damage.has_box_damage() {
-            return None;
-        }
+    pub(crate) fn take_layout_box(&self) -> Option<LayoutBox> {
         self.slot.borrow_mut().take()
     }
 }
@@ -319,9 +316,6 @@ pub(crate) trait NodeExt<'dom> {
 
     /// Remove boxes for the element itself, and all of its pseudo-element boxes.
     fn unset_all_boxes(&self);
-
-    /// Remove all pseudo-element boxes for this element.
-    fn unset_all_pseudo_boxes(&self);
 
     fn fragments_for_pseudo(&self, pseudo_element: Option<PseudoElement>) -> Vec<Fragment>;
     fn with_layout_box_base_including_pseudos(&self, callback: impl Fn(&LayoutBoxBase));
@@ -466,10 +460,6 @@ impl<'dom> NodeExt<'dom> for ServoThreadSafeLayoutNode<'dom> {
 
         // Stylo already takes care of removing all layout data
         // for DOM descendants of elements with `display: none`.
-    }
-
-    fn unset_all_pseudo_boxes(&self) {
-        self.ensure_inner_layout_data().pseudo_boxes.clear();
     }
 
     fn with_layout_box_base_including_pseudos(&self, callback: impl Fn(&LayoutBoxBase)) {

--- a/components/layout/dom_traversal.rs
+++ b/components/layout/dom_traversal.rs
@@ -152,10 +152,6 @@ fn traverse_element<'dom>(
     handler: &mut impl TraversalHandler<'dom>,
 ) {
     let damage = element.take_restyle_damage();
-    if damage.has_box_damage() {
-        element.unset_all_pseudo_boxes();
-    }
-
     let style = element.style(&context.style_context);
     let info = NodeAndStyleInfo::new(element, style, damage);
 

--- a/components/layout/table/construct.rs
+++ b/components/layout/table/construct.rs
@@ -807,7 +807,7 @@ impl<'dom> TraversalHandler<'dom> for TableBuilderTraversal<'_, 'dom> {
                     box_slot.set(LayoutBox::TableLevelBox(TableLevelBox::Track(row)));
                 },
                 DisplayLayoutInternal::TableColumn => {
-                    let old_box = box_slot.take_layout_box_if_undamaged(info.damage);
+                    let old_box = box_slot.take_layout_box();
                     let old_column = old_box.and_then(|layout_box| match layout_box {
                         LayoutBox::TableLevelBox(TableLevelBox::Track(column)) => Some(column),
                         _ => None,
@@ -861,7 +861,7 @@ impl<'dom> TraversalHandler<'dom> for TableBuilderTraversal<'_, 'dom> {
                     )));
                 },
                 DisplayLayoutInternal::TableCaption => {
-                    let old_box = box_slot.take_layout_box_if_undamaged(info.damage);
+                    let old_box = box_slot.take_layout_box();
                     let old_caption = old_box.and_then(|layout_box| match layout_box {
                         LayoutBox::TableLevelBox(TableLevelBox::Caption(caption)) => Some(caption),
                         _ => None,
@@ -1017,7 +1017,7 @@ impl<'dom> TraversalHandler<'dom> for TableRowBuilder<'_, '_, 'dom, '_> {
                 DisplayLayoutInternal::TableCell => {
                     self.finish_current_anonymous_cell_if_needed();
 
-                    let old_box = box_slot.take_layout_box_if_undamaged(info.damage);
+                    let old_box = box_slot.take_layout_box();
                     let old_cell = old_box.and_then(|layout_box| match layout_box {
                         LayoutBox::TableLevelBox(TableLevelBox::Cell(cell)) => Some(cell),
                         _ => None,
@@ -1112,7 +1112,7 @@ impl<'dom> TraversalHandler<'dom> for TableColumnGroupBuilder {
             ::std::mem::forget(box_slot);
             return;
         }
-        let old_box = box_slot.take_layout_box_if_undamaged(info.damage);
+        let old_box = box_slot.take_layout_box();
         let old_column = old_box.and_then(|layout_box| match layout_box {
             LayoutBox::TableLevelBox(TableLevelBox::Track(column)) => Some(column),
             _ => None,


### PR DESCRIPTION
Instead of keeping dirty box tree nodes around after the damage
traversal, clear them readily (like `display: none` nodes). This
simplifies the logic during box tree reconstruction and also prepares
the damage traversal for future work.

In addition, restructure the logic of the damage traversal to make it a
bit easier to follow.

Testing: This shouldn't change observable behavior so should be covered by existing
tests.
