### PR TITLE
layout: Clear all node damage during damage traversal

### DIFF
--- a/components/layout/dom.rs
+++ b/components/layout/dom.rs
@@ -9,8 +9,8 @@ use base::id::{BrowsingContextId, PipelineId};
 use html5ever::{local_name, ns};
 use layout_api::wrapper_traits::{LayoutDataTrait, ThreadSafeLayoutElement, ThreadSafeLayoutNode};
 use layout_api::{
-    GenericLayoutDataTrait, LayoutDamage, LayoutElementType,
-    LayoutNodeType as ScriptLayoutNodeType, SVGElementData,
+    GenericLayoutDataTrait, LayoutElementType, LayoutNodeType as ScriptLayoutNodeType,
+    SVGElementData,
 };
 use malloc_size_of_derive::MallocSizeOf;
 use net_traits::image_cache::Image;
@@ -19,7 +19,7 @@ use servo_arc::Arc as ServoArc;
 use smallvec::SmallVec;
 use style::context::SharedStyleContext;
 use style::properties::ComputedValues;
-use style::selector_parser::{PseudoElement, RestyleDamage};
+use style::selector_parser::PseudoElement;
 
 use crate::cell::{ArcRefCell, WeakRefCell};
 use crate::flexbox::FlexLevelBox;
@@ -321,7 +321,6 @@ pub(crate) trait NodeExt<'dom> {
     fn with_layout_box_base_including_pseudos(&self, callback: impl Fn(&LayoutBoxBase));
 
     fn repair_style(&self, context: &SharedStyleContext);
-    fn take_restyle_damage(&self) -> LayoutDamage;
 
     /// Whether or not this node isolates downward flowing box tree rebuild damage. Roughly,
     /// this corresponds to independent formatting context boundaries. The node's boxes
@@ -485,14 +484,6 @@ impl<'dom> NodeExt<'dom> for ServoThreadSafeLayoutNode<'dom> {
         if let Some(layout_data) = self.inner_layout_data() {
             layout_data.repair_style(self, context);
         }
-    }
-
-    fn take_restyle_damage(&self) -> LayoutDamage {
-        let damage = self
-            .style_data()
-            .map(|style_data| std::mem::take(&mut style_data.element_data.borrow_mut().damage))
-            .unwrap_or_else(RestyleDamage::reconstruct);
-        LayoutDamage::from_bits_retain(damage.bits())
     }
 
     fn isolates_box_tree_rebuild_damage(&self) -> bool {


### PR DESCRIPTION
Instead of waiting until the box tree construction phase of layout to
clear node damage, clear it during the damage traversal. This means that
damage is cleared in the same way in all types of situations, which
simplifies the code and will make it easier to implement future
optimizations.

Testing: This should not really change behavior (other than being marginally more
efficient when there is a dirty root), so existing tests should suffice.
