### PR TITLE
bluetooth: move BluetoothToEmbedderMsg to bluetooth crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -966,6 +966,7 @@ dependencies = [
  "blurmock",
  "blurz",
  "embedder_traits",
+ "ipc-channel",
  "log",
  "rand 0.9.2",
  "servo_config",

--- a/components/bluetooth/Cargo.toml
+++ b/components/bluetooth/Cargo.toml
@@ -17,6 +17,7 @@ bitflags = { workspace = true }
 bluetooth_traits = { workspace = true }
 blurmock = { version = "0.1.2", optional = true }
 embedder_traits = { workspace = true }
+ipc-channel = { workspace = true }
 log = { workspace = true }
 rand = { workspace = true }
 servo_config = { path = "../config" }

--- a/components/bluetooth/embedder.rs
+++ b/components/bluetooth/embedder.rs
@@ -1,0 +1,12 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+use base::id::WebViewId;
+use ipc_channel::ipc::IpcSender;
+
+/// Messages sent from the bluetooth threads to the embedder.
+pub enum BluetoothToEmbedderMsg {
+    /// Open dialog to select bluetooth device.
+    GetSelectedBluetoothDevice(WebViewId, Vec<String>, IpcSender<Option<String>>),
+}

--- a/components/bluetooth/lib.rs
+++ b/components/bluetooth/lib.rs
@@ -4,6 +4,7 @@
 
 pub mod adapter;
 pub mod bluetooth;
+pub mod embedder;
 #[cfg(not(any(
     all(target_os = "linux", feature = "native-bluetooth"),
     all(target_os = "android", feature = "native-bluetooth"),
@@ -31,7 +32,8 @@ use bluetooth_traits::{
     BluetoothRequest, BluetoothResponse, BluetoothResponseResult, BluetoothResult,
     BluetoothServiceMsg, GATTType,
 };
-use embedder_traits::{EmbedderMsg, EmbedderProxy};
+use embedder_traits::GenericEmbedderProxy;
+use ipc_channel::ipc;
 use log::warn;
 use rand::{self, Rng};
 use servo_config::pref;
@@ -40,6 +42,7 @@ use crate::bluetooth::{
     BluetoothAdapter, BluetoothDevice, BluetoothGATTCharacteristic, BluetoothGATTDescriptor,
     BluetoothGATTService,
 };
+use crate::embedder::BluetoothToEmbedderMsg;
 
 // A transaction not completed within 30 seconds shall time out. Such a transaction shall be considered to have failed.
 // https://www.bluetooth.org/DocMan/handlers/DownloadDoc.ashx?doc_id=286439 (Vol. 3, page 480)
@@ -71,11 +74,13 @@ macro_rules! return_if_cached(
 );
 
 pub trait BluetoothThreadFactory {
-    fn new(embedder_proxy: EmbedderProxy) -> Self;
+    fn new(embedder_proxy: GenericEmbedderProxy<BluetoothToEmbedderMsg>) -> Self;
 }
 
 impl BluetoothThreadFactory for GenericSender<BluetoothRequest> {
-    fn new(embedder_proxy: EmbedderProxy) -> GenericSender<BluetoothRequest> {
+    fn new(
+        embedder_proxy: GenericEmbedderProxy<BluetoothToEmbedderMsg>,
+    ) -> GenericSender<BluetoothRequest> {
         let (sender, receiver) = generic_channel::channel().unwrap();
         let adapter = if pref!(dom_bluetooth_enabled) {
             BluetoothAdapter::new()
@@ -209,14 +214,14 @@ pub struct BluetoothManager {
     cached_characteristics: HashMap<String, BluetoothGATTCharacteristic>,
     cached_descriptors: HashMap<String, BluetoothGATTDescriptor>,
     allowed_services: HashMap<String, HashSet<String>>,
-    embedder_proxy: EmbedderProxy,
+    embedder_proxy: GenericEmbedderProxy<BluetoothToEmbedderMsg>,
 }
 
 impl BluetoothManager {
     pub fn new(
         receiver: GenericReceiver<BluetoothRequest>,
         adapter: Option<BluetoothAdapter>,
-        embedder_proxy: EmbedderProxy,
+        embedder_proxy: GenericEmbedderProxy<BluetoothToEmbedderMsg>,
     ) -> BluetoothManager {
         BluetoothManager {
             receiver,
@@ -409,10 +414,9 @@ impl BluetoothManager {
             ]);
         }
 
-        let (ipc_sender, ipc_receiver) =
-            generic_channel::channel().expect("Failed to create IPC channel!");
+        let (ipc_sender, ipc_receiver) = ipc::channel().expect("Failed to create IPC channel!");
         self.embedder_proxy
-            .send(EmbedderMsg::GetSelectedBluetoothDevice(
+            .send(BluetoothToEmbedderMsg::GetSelectedBluetoothDevice(
                 webview_id,
                 dialog_rows,
                 ipc_sender,

--- a/components/servo/servo.rs
+++ b/components/servo/servo.rs
@@ -14,6 +14,7 @@ pub use base::id::WebViewId;
 use base::id::{PipelineNamespace, PipelineNamespaceId};
 #[cfg(feature = "bluetooth")]
 use bluetooth::BluetoothThreadFactory;
+use bluetooth::embedder::BluetoothToEmbedderMsg;
 #[cfg(feature = "bluetooth")]
 use bluetooth_traits::BluetoothRequest;
 #[cfg(all(
@@ -137,8 +138,9 @@ mod media_platform {
 }
 
 enum Message {
-    FromNet(NetToEmbedderMsg),
-    FromUnknown(EmbedderMsg),
+    Net(NetToEmbedderMsg),
+    Bluetooth(BluetoothToEmbedderMsg),
+    Unknown(EmbedderMsg),
 }
 
 struct ServoInner {
@@ -147,6 +149,7 @@ struct ServoInner {
     constellation_proxy: ConstellationProxy,
     embedder_receiver: Receiver<EmbedderMsg>,
     net_embedder_receiver: Receiver<NetToEmbedderMsg>,
+    bluetooth_embedder_receiver: Receiver<BluetoothToEmbedderMsg>,
     network_manager: Rc<RefCell<NetworkManager>>,
     site_data_manager: Rc<RefCell<SiteDataManager>>,
     /// A struct that tracks ongoing JavaScript evaluations and is responsible for
@@ -197,8 +200,9 @@ impl ServoInner {
         // Only handle incoming embedder messages if `Paint` hasn't already started shutting down.
         while let Some(message) = self.receive_one_message() {
             match message {
-                Message::FromUnknown(message) => self.handle_embedder_message(message),
-                Message::FromNet(message) => self.handle_net_embedder_message(message),
+                Message::Unknown(message) => self.handle_embedder_message(message),
+                Message::Net(message) => self.handle_net_embedder_message(message),
+                Message::Bluetooth(message) => self.handle_bluetooth_embedder_message(message),
             }
             if self.shutdown_state.get() == ShutdownState::FinishedShuttingDown {
                 break;
@@ -227,6 +231,7 @@ impl ServoInner {
         let mut select = crossbeam_channel::Select::new();
         let embedder_receiver_index = select.recv(&self.embedder_receiver);
         let net_embedder_receiver_index = select.recv(&self.net_embedder_receiver);
+        let bluetooth_embedder_receiver_index = select.recv(&self.bluetooth_embedder_receiver);
         let Ok(operation) = select.try_select() else {
             return None;
         };
@@ -235,12 +240,17 @@ impl ServoInner {
             let Ok(message) = operation.recv(&self.embedder_receiver) else {
                 return None;
             };
-            Some(Message::FromUnknown(message))
+            Some(Message::Unknown(message))
         } else if index == net_embedder_receiver_index {
             let Ok(message) = operation.recv(&self.net_embedder_receiver) else {
                 return None;
             };
-            Some(Message::FromNet(message))
+            Some(Message::Net(message))
+        } else if index == bluetooth_embedder_receiver_index {
+            let Ok(message) = operation.recv(&self.bluetooth_embedder_receiver) else {
+                return None;
+            };
+            Some(Message::Bluetooth(message))
         } else {
             log::error!("No select operation registered for {index:?}");
             None
@@ -339,6 +349,24 @@ impl ServoInner {
                     webview
                         .delegate()
                         .request_authentication(webview, authentication_request);
+                }
+            },
+        }
+    }
+
+    fn handle_bluetooth_embedder_message(&self, message: BluetoothToEmbedderMsg) {
+        match message {
+            BluetoothToEmbedderMsg::GetSelectedBluetoothDevice(
+                webview_id,
+                items,
+                response_sender,
+            ) => {
+                if let Some(webview) = self.get_webview_handle(webview_id) {
+                    webview.delegate().show_bluetooth_device_dialog(
+                        webview,
+                        items,
+                        response_sender,
+                    );
                 }
             },
         }
@@ -527,15 +555,6 @@ impl ServoInner {
                     webview
                         .delegate()
                         .notify_crashed(webview, reason, backtrace);
-                }
-            },
-            EmbedderMsg::GetSelectedBluetoothDevice(webview_id, items, response_sender) => {
-                if let Some(webview) = self.get_webview_handle(webview_id) {
-                    webview.delegate().show_bluetooth_device_dialog(
-                        webview,
-                        items,
-                        response_sender,
-                    );
                 }
             },
             EmbedderMsg::PromptPermission(webview_id, requested_feature, response_sender) => {
@@ -761,6 +780,8 @@ impl Servo {
         let (embedder_proxy, embedder_receiver) = create_embedder_channel(event_loop_waker.clone());
         let (net_embedder_proxy, net_embedder_receiver) =
             create_generic_embedder_channel::<NetToEmbedderMsg>(event_loop_waker.clone());
+        let (bluetooth_embedder_proxy, bluetooth_embedder_receiver) =
+            create_generic_embedder_channel::<BluetoothToEmbedderMsg>(event_loop_waker.clone());
         let time_profiler_chan = profile_time::Profiler::create(
             &opts.time_profiling,
             opts.time_profiler_trace_path.clone(),
@@ -825,6 +846,7 @@ impl Servo {
             embedder_to_constellation_receiver,
             &paint.borrow(),
             embedder_proxy,
+            bluetooth_embedder_proxy,
             paint_proxy.clone(),
             time_profiler_chan,
             mem_profiler_chan,
@@ -860,6 +882,7 @@ impl Servo {
             constellation_proxy,
             embedder_receiver,
             net_embedder_receiver,
+            bluetooth_embedder_receiver,
             shutdown_state,
             webviews: Default::default(),
             servo_errors: ServoErrorChannel::default(),
@@ -1009,6 +1032,7 @@ fn create_constellation(
     embedder_to_constellation_receiver: Receiver<EmbedderToConstellationMessage>,
     paint: &Paint,
     embedder_proxy: EmbedderProxy,
+    bluetooth_embedder_proxy: GenericEmbedderProxy<BluetoothToEmbedderMsg>,
     paint_proxy: PaintProxy,
     time_profiler_chan: time::ProfilerChan,
     mem_profiler_chan: mem::ProfilerChan,
@@ -1025,7 +1049,7 @@ fn create_constellation(
 
     #[cfg(feature = "bluetooth")]
     let bluetooth_thread: GenericSender<BluetoothRequest> =
-        BluetoothThreadFactory::new(embedder_proxy.clone());
+        BluetoothThreadFactory::new(bluetooth_embedder_proxy);
 
     let privileged_urls = protocols.privileged_urls();
 

--- a/components/servo/webview_delegate.rs
+++ b/components/servo/webview_delegate.rs
@@ -19,6 +19,7 @@ use embedder_traits::{
     SimpleDialogRequest, TraversalId, WebResourceRequest, WebResourceResponse,
     WebResourceResponseMsg,
 };
+use ipc_channel::ipc::IpcSender;
 use paint_api::rendering_context::RenderingContext;
 use tokio::sync::mpsc::UnboundedSender as TokioSender;
 use tokio::sync::oneshot::Sender;
@@ -935,7 +936,7 @@ pub trait WebViewDelegate {
         &self,
         _webview: WebView,
         _: Vec<String>,
-        response_sender: GenericSender<Option<String>>,
+        response_sender: IpcSender<Option<String>>,
     ) {
         let _ = response_sender.send(None);
     }

--- a/components/shared/embedder/lib.rs
+++ b/components/shared/embedder/lib.rs
@@ -470,8 +470,6 @@ pub enum EmbedderMsg {
     NotifyLoadStatusChanged(WebViewId, LoadStatus),
     /// A pipeline panicked. First string is the reason, second one is the backtrace.
     Panic(WebViewId, String, Option<String>),
-    /// Open dialog to select bluetooth device.
-    GetSelectedBluetoothDevice(WebViewId, Vec<String>, GenericSender<Option<String>>),
     /// Open interface to request permission specified by prompt.
     PromptPermission(WebViewId, PermissionFeature, GenericSender<AllowOrDeny>),
     /// Report a complete sampled profile

--- a/ports/servoshell/Cargo.toml
+++ b/ports/servoshell/Cargo.toml
@@ -68,6 +68,7 @@ dpi = { workspace = true }
 euclid = { workspace = true }
 hitrace = { workspace = true, optional = true }
 image = { workspace = true }
+ipc-channel = { workspace = true }
 keyboard-types = { workspace = true }
 libc = { workspace = true }
 libservo = { path = "../../components/servo", features = ["background_hang_monitor", "bluetooth", "testbinding"], default-features = false }

--- a/ports/servoshell/desktop/dialog.rs
+++ b/ports/servoshell/desktop/dialog.rs
@@ -10,12 +10,12 @@ use egui::{
 };
 use egui_file_dialog::{DialogState, FileDialog as EguiFileDialog};
 use euclid::Length;
+use ipc_channel::ipc::IpcSender;
 use log::warn;
 use servo::{
     AlertDialog, AuthenticationRequest, ColorPicker, ConfirmDialog, ContextMenu, ContextMenuItem,
-    DeviceIndependentPixel, EmbedderControlId, FilePicker, GenericSender, PermissionRequest,
-    PromptDialog, RgbColor, SelectElement, SelectElementOption, SelectElementOptionOrOptgroup,
-    SimpleDialog,
+    DeviceIndependentPixel, EmbedderControlId, FilePicker, PermissionRequest, PromptDialog,
+    RgbColor, SelectElement, SelectElementOption, SelectElementOptionOrOptgroup, SimpleDialog,
 };
 
 /// The minimum width of many UI elements including dialog boxes and menus,
@@ -43,7 +43,7 @@ pub enum Dialog {
     SelectDevice {
         devices: Vec<String>,
         selected_device_index: usize,
-        response_sender: GenericSender<Option<String>>,
+        response_sender: IpcSender<Option<String>>,
     },
     SelectElement {
         maybe_prompt: Option<SelectElement>,
@@ -115,7 +115,7 @@ impl Dialog {
 
     pub fn new_device_selection_dialog(
         devices: Vec<String>,
-        response_sender: GenericSender<Option<String>>,
+        response_sender: IpcSender<Option<String>>,
     ) -> Self {
         Dialog::SelectDevice {
             devices,

--- a/ports/servoshell/desktop/headed_window.rs
+++ b/ports/servoshell/desktop/headed_window.rs
@@ -14,18 +14,19 @@ use std::rc::Rc;
 use std::time::Duration;
 
 use euclid::{Angle, Length, Point2D, Rect, Rotation3D, Scale, Size2D, UnknownUnit, Vector3D};
+use ipc_channel::ipc::IpcSender;
 use keyboard_types::ShortcutMatcher;
 use log::{debug, info};
 use raw_window_handle::{HasDisplayHandle, HasWindowHandle, RawWindowHandle};
 use servo::{
     AuthenticationRequest, Cursor, DeviceIndependentIntRect, DeviceIndependentPixel,
     DeviceIntPoint, DeviceIntRect, DeviceIntSize, DevicePixel, DevicePoint, EmbedderControl,
-    EmbedderControlId, GenericSender, ImeEvent, InputEvent, InputEventId, InputEventResult,
-    InputMethodControl, Key, KeyState, KeyboardEvent, Modifiers, MouseButton as ServoMouseButton,
-    MouseButtonAction, MouseButtonEvent, MouseLeftViewportEvent, MouseMoveEvent, NamedKey,
-    OffscreenRenderingContext, PermissionRequest, RenderingContext, ScreenGeometry, Theme,
-    TouchEvent, TouchEventType, TouchId, WebRenderDebugOption, WebView, WebViewId, WheelDelta,
-    WheelEvent, WheelMode, WindowRenderingContext, convert_rect_to_css_pixel,
+    EmbedderControlId, ImeEvent, InputEvent, InputEventId, InputEventResult, InputMethodControl,
+    Key, KeyState, KeyboardEvent, Modifiers, MouseButton as ServoMouseButton, MouseButtonAction,
+    MouseButtonEvent, MouseLeftViewportEvent, MouseMoveEvent, NamedKey, OffscreenRenderingContext,
+    PermissionRequest, RenderingContext, ScreenGeometry, Theme, TouchEvent, TouchEventType,
+    TouchId, WebRenderDebugOption, WebView, WebViewId, WheelDelta, WheelEvent, WheelMode,
+    WindowRenderingContext, convert_rect_to_css_pixel,
 };
 use url::Url;
 use winit::dpi::{LogicalPosition, LogicalSize, PhysicalPosition, PhysicalSize};
@@ -1108,7 +1109,7 @@ impl PlatformWindow for HeadedWindow {
         &self,
         webview_id: WebViewId,
         devices: Vec<String>,
-        response_sender: GenericSender<Option<String>>,
+        response_sender: IpcSender<Option<String>>,
     ) {
         self.add_dialog(
             webview_id,

--- a/ports/servoshell/running_app_state.rs
+++ b/ports/servoshell/running_app_state.rs
@@ -12,6 +12,7 @@ use std::rc::Rc;
 use crossbeam_channel::{Receiver, Sender, unbounded};
 use euclid::Rect;
 use image::{DynamicImage, ImageFormat, RgbaImage};
+use ipc_channel::ipc::IpcSender;
 #[cfg(all(
     any(coverage, llvm_pgo),
     any(target_os = "android", target_env = "ohos")
@@ -780,7 +781,7 @@ impl WebViewDelegate for RunningAppState {
         &self,
         webview: WebView,
         devices: Vec<String>,
-        response_sender: GenericSender<Option<String>>,
+        response_sender: IpcSender<Option<String>>,
     ) {
         self.platform_window_for_webview_id(webview.id())
             .show_bluetooth_device_dialog(webview.id(), devices, response_sender);

--- a/ports/servoshell/window.rs
+++ b/ports/servoshell/window.rs
@@ -6,12 +6,13 @@ use std::cell::{Cell, RefCell};
 use std::rc::Rc;
 
 use euclid::Scale;
+use ipc_channel::ipc::IpcSender;
 use log::warn;
 use servo::{
     AuthenticationRequest, ConsoleLogLevel, Cursor, DeviceIndependentIntRect,
     DeviceIndependentPixel, DeviceIntPoint, DeviceIntSize, DevicePixel, EmbedderControl,
-    EmbedderControlId, GenericSender, InputEventId, InputEventResult, MediaSessionEvent,
-    PermissionRequest, RenderingContext, ScreenGeometry, WebView, WebViewBuilder, WebViewId,
+    EmbedderControlId, InputEventId, InputEventResult, MediaSessionEvent, PermissionRequest,
+    RenderingContext, ScreenGeometry, WebView, WebViewBuilder, WebViewId,
 };
 use url::Url;
 
@@ -412,7 +413,7 @@ pub(crate) trait PlatformWindow {
         &self,
         _: WebViewId,
         _devices: Vec<String>,
-        _: GenericSender<Option<String>>,
+        _: IpcSender<Option<String>>,
     ) {
     }
     fn show_permission_dialog(&self, _: WebViewId, _: PermissionRequest) {}


### PR DESCRIPTION
bluetooth: move `BluetoothToEmbedderMsg` to bluetooth crate

Testing: Strictly refactoring; existing test coverage is sufficient.
Fixes: partially addresses #42097
