### PR TITLE
script: Pass `&mut JSContext` to timers, abort controller, some transfers and some streams

### DIFF
--- a/components/script/dom/abortcontroller.rs
+++ b/components/script/dom/abortcontroller.rs
@@ -3,6 +3,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 use dom_struct::dom_struct;
+use js::realm::CurrentRealm;
 use js::rust::{HandleObject, HandleValue};
 
 use crate::dom::abortsignal::AbortSignal;
@@ -10,8 +11,7 @@ use crate::dom::bindings::codegen::Bindings::AbortControllerBinding::AbortContro
 use crate::dom::bindings::reflector::{Reflector, reflect_dom_object_with_proto};
 use crate::dom::bindings::root::{Dom, DomRoot};
 use crate::dom::globalscope::GlobalScope;
-use crate::realms::InRealm;
-use crate::script_runtime::{CanGc, JSContext};
+use crate::script_runtime::CanGc;
 
 /// <https://dom.spec.whatwg.org/#abortcontroller>
 #[dom_struct]
@@ -52,16 +52,10 @@ impl AbortController {
     }
 
     /// <https://dom.spec.whatwg.org/#abortcontroller-signal-abort>
-    pub(crate) fn signal_abort(
-        &self,
-        cx: JSContext,
-        reason: HandleValue,
-        realm: InRealm,
-        can_gc: CanGc,
-    ) {
+    pub(crate) fn signal_abort(&self, cx: &mut CurrentRealm, reason: HandleValue) {
         // To signal abort on an AbortController controller with an optional reason,
         // signal abort on controller’s signal with reason if it is given.
-        self.signal.signal_abort(cx, reason, realm, can_gc);
+        self.signal.signal_abort(cx, reason);
     }
 
     /// <https://dom.spec.whatwg.org/#abortcontroller-signal>
@@ -82,10 +76,10 @@ impl AbortControllerMethods<crate::DomTypeHolder> for AbortController {
     }
 
     /// <https://dom.spec.whatwg.org/#dom-abortcontroller-abort>
-    fn Abort(&self, cx: JSContext, reason: HandleValue, realm: InRealm, can_gc: CanGc) {
+    fn Abort(&self, cx: &mut CurrentRealm, reason: HandleValue) {
         // The abort(reason) method steps are
         // to signal abort on this with reason if it is given.
-        self.signal_abort(cx, reason, realm, can_gc);
+        self.signal_abort(cx, reason);
     }
 
     /// <https://dom.spec.whatwg.org/#dom-abortcontroller-signal>

--- a/components/script/dom/bindings/transferable.rs
+++ b/components/script/dom/bindings/transferable.rs
@@ -29,10 +29,14 @@ where
     }
 
     /// <https://html.spec.whatwg.org/multipage/#transfer-steps>
-    fn transfer(&self) -> Fallible<(NamespaceIndex<Self::Index>, Self::Data)>;
+    fn transfer(
+        &self,
+        cx: &mut js::context::JSContext,
+    ) -> Fallible<(NamespaceIndex<Self::Index>, Self::Data)>;
 
     /// <https://html.spec.whatwg.org/multipage/#transfer-receiving-steps>
     fn transfer_receive(
+        cx: &mut js::context::JSContext,
         owner: &GlobalScope,
         id: NamespaceIndex<Self::Index>,
         serialized: Self::Data,

--- a/components/script/dom/canvas/imagebitmap.rs
+++ b/components/script/dom/canvas/imagebitmap.rs
@@ -665,7 +665,10 @@ impl Transferable for ImageBitmap {
     type Data = SerializableImageBitmap;
 
     /// <https://html.spec.whatwg.org/multipage/#the-imagebitmap-interface:transfer-steps>
-    fn transfer(&self) -> Fallible<(ImageBitmapId, SerializableImageBitmap)> {
+    fn transfer(
+        &self,
+        _cx: &mut js::context::JSContext,
+    ) -> Fallible<(ImageBitmapId, SerializableImageBitmap)> {
         // <https://html.spec.whatwg.org/multipage/#structuredserializewithtransfer>
         // Step 5.2. If transferable has a [[Detached]] internal slot and
         // transferable.[[Detached]] is true, then throw a "DataCloneError"
@@ -695,6 +698,7 @@ impl Transferable for ImageBitmap {
 
     /// <https://html.spec.whatwg.org/multipage/#the-imagebitmap-interface:transfer-receiving-steps>
     fn transfer_receive(
+        cx: &mut js::context::JSContext,
         owner: &GlobalScope,
         _: ImageBitmapId,
         transferred: SerializableImageBitmap,
@@ -703,7 +707,7 @@ impl Transferable for ImageBitmap {
         Ok(ImageBitmap::new(
             owner,
             transferred.bitmap_data.to_owned(),
-            CanGc::note(),
+            CanGc::from_cx(cx),
         ))
     }
 

--- a/components/script/dom/canvas/offscreencanvas.rs
+++ b/components/script/dom/canvas/offscreencanvas.rs
@@ -187,7 +187,10 @@ impl Transferable for OffscreenCanvas {
     type Data = TransferableOffscreenCanvas;
 
     /// <https://html.spec.whatwg.org/multipage/#the-offscreencanvas-interface:transfer-steps>
-    fn transfer(&self) -> Fallible<(OffscreenCanvasId, TransferableOffscreenCanvas)> {
+    fn transfer(
+        &self,
+        _cx: &mut js::context::JSContext,
+    ) -> Fallible<(OffscreenCanvasId, TransferableOffscreenCanvas)> {
         // <https://html.spec.whatwg.org/multipage/#structuredserializewithtransfer>
         // Step 5.2. If transferable has a [[Detached]] internal slot and
         // transferable.[[Detached]] is true, then throw a "DataCloneError"
@@ -234,6 +237,7 @@ impl Transferable for OffscreenCanvas {
 
     /// <https://html.spec.whatwg.org/multipage/#the-offscreencanvas-interface:transfer-receiving-steps>
     fn transfer_receive(
+        cx: &mut js::context::JSContext,
         owner: &GlobalScope,
         _: OffscreenCanvasId,
         transferred: TransferableOffscreenCanvas,
@@ -256,7 +260,7 @@ impl Transferable for OffscreenCanvas {
             transferred.width,
             transferred.height,
             None,
-            CanGc::note(),
+            CanGc::from_cx(cx),
         ))
     }
 

--- a/components/script/dom/globalscope.rs
+++ b/components/script/dom/globalscope.rs
@@ -2927,8 +2927,8 @@ impl GlobalScope {
         self.timers().clear_timeout_or_interval(self, handle);
     }
 
-    pub(crate) fn fire_timer(&self, handle: TimerEventId, can_gc: CanGc) {
-        self.timers().fire_timer(handle, self, can_gc);
+    pub(crate) fn fire_timer(&self, handle: TimerEventId, cx: &mut js::context::JSContext) {
+        self.timers().fire_timer(handle, self, cx);
     }
 
     pub(crate) fn resume(&self) {
@@ -3512,7 +3512,7 @@ impl GlobalScope {
         completion_steps: F,
     ) -> i32
     where
-        F: 'static + FnOnce(&GlobalScope, CanGc),
+        F: 'static + FnOnce(&mut js::context::JSContext, &GlobalScope),
     {
         let timers = self.timers();
 

--- a/components/script/dom/messageport.rs
+++ b/components/script/dom/messageport.rs
@@ -247,7 +247,10 @@ impl Transferable for MessagePort {
     type Data = MessagePortImpl;
 
     /// <https://html.spec.whatwg.org/multipage/#message-ports:transfer-steps>
-    fn transfer(&self) -> Fallible<(MessagePortId, MessagePortImpl)> {
+    fn transfer(
+        &self,
+        _cx: &mut js::context::JSContext,
+    ) -> Fallible<(MessagePortId, MessagePortImpl)> {
         // <https://html.spec.whatwg.org/multipage/#structuredserializewithtransfer>
         // Step 5.2. If transferable has a [[Detached]] internal slot and
         // transferable.[[Detached]] is true, then throw a "DataCloneError"
@@ -267,12 +270,17 @@ impl Transferable for MessagePort {
 
     /// <https://html.spec.whatwg.org/multipage/#message-ports:transfer-receiving-steps>
     fn transfer_receive(
+        cx: &mut js::context::JSContext,
         owner: &GlobalScope,
         id: MessagePortId,
         port_impl: MessagePortImpl,
     ) -> Result<DomRoot<Self>, ()> {
-        let transferred_port =
-            MessagePort::new_transferred(owner, id, port_impl.entangled_port_id(), CanGc::note());
+        let transferred_port = MessagePort::new_transferred(
+            owner,
+            id,
+            port_impl.entangled_port_id(),
+            CanGc::from_cx(cx),
+        );
         owner.track_message_port(&transferred_port, Some(port_impl));
         Ok(transferred_port)
     }

--- a/components/script/dom/stream/writablestreamdefaultcontroller.rs
+++ b/components/script/dom/stream/writablestreamdefaultcontroller.rs
@@ -402,15 +402,8 @@ impl WritableStreamDefaultController {
     }
 
     /// "Signal abort" call from <https://streams.spec.whatwg.org/#writable-stream-abort>
-    pub(crate) fn signal_abort(
-        &self,
-        cx: SafeJSContext,
-        reason: SafeHandleValue,
-        realm: InRealm,
-        can_gc: CanGc,
-    ) {
-        self.abort_controller
-            .signal_abort(cx, reason, realm, can_gc);
+    pub(crate) fn signal_abort(&self, cx: &mut CurrentRealm, reason: SafeHandleValue) {
+        self.abort_controller.signal_abort(cx, reason);
     }
 
     /// <https://streams.spec.whatwg.org/#writable-stream-default-controller-clear-algorithms>

--- a/components/script_bindings/codegen/Bindings.conf
+++ b/components/script_bindings/codegen/Bindings.conf
@@ -15,8 +15,7 @@
 DOMInterfaces = {
 
 'AbortController': {
-    'canGc':['Abort'],
-    'inRealms': ['Abort'],
+    'realm':['Abort'],
 },
 
 'AbortSignal': {
@@ -885,8 +884,8 @@ DOMInterfaces = {
 },
 
 'ReadableStream': {
-    'canGc': ['GetReader', 'Cancel', 'PipeTo', 'PipeThrough', 'Tee'],
-    'inRealms': ['PipeTo', 'PipeThrough'],
+    'canGc': ['GetReader', 'Cancel', 'Tee'],
+    'realm': ['PipeTo', 'PipeThrough']
 },
 
 "ReadableStreamDefaultController": {
@@ -918,8 +917,9 @@ DOMInterfaces = {
 },
 
 'WritableStream': {
-    'canGc': ['Abort', 'Close', 'GetWriter'],
-    'inRealms': ['Abort', 'Close', 'GetWriter'],
+    'canGc': ['Close', 'GetWriter'],
+    'inRealms': ['Close', 'GetWriter'],
+    'realm': ['Abort']
 },
 
 'WritableStreamDefaultController': {
@@ -928,8 +928,9 @@ DOMInterfaces = {
 },
 
 'WritableStreamDefaultWriter': {
-    'canGc': ['Abort', 'Close', 'Write', 'ReleaseLock'],
-    'inRealms': ['Abort', 'Close', 'Write'],
+    'canGc': ['Write', 'ReleaseLock', 'Close'],
+    'inRealms': ['Write', 'Close'],
+    'realm': ['Abort',],
 },
 
 'TransformStreamDefaultController': {


### PR DESCRIPTION
I just wanted to do abort signal, but then this happend.

Testing: Just refactor, should be covered by WPT tests
Part of #40600
