### PR TITLE
layout: Simply check of `non-zero` bounding rect for contentful_paint

### DIFF
--- a/components/layout/display_list/paint_timing_handler.rs
+++ b/components/layout/display_list/paint_timing_handler.rs
@@ -43,7 +43,7 @@ impl PaintTimingHandler {
             .intersection(&self.viewport_rect.to_rect().cast_unit())
             .unwrap_or(Rect::zero());
 
-        bounding_rect.size.width > 0.0 && bounding_rect.size.height > 0.0
+        !bounding_rect.is_empty()
     }
 
     fn calculate_intersection_rect(


### PR DESCRIPTION
Use helper function to evaluate non-zero bounding rect size 

Testing: Existing WPT Tests Passed. No change in behaviour.
