### PR TITLE
layout: Cache `transform` for `LCP` while layout thread is created.

### DIFF
--- a/components/layout/display_list/mod.rs
+++ b/components/layout/display_list/mod.rs
@@ -16,7 +16,6 @@ use paint_api::display_list::{PaintDisplayListInfo, SpatialTreeNodeInfo};
 use paint_api::largest_contentful_paint_candidate::LCPCandidateID;
 use servo_arc::Arc as ServoArc;
 use servo_config::opts::DiagnosticsLogging;
-use servo_config::pref;
 use servo_geometry::MaxRect;
 use style::Zero;
 use style::color::{AbsoluteColor, ColorSpace};
@@ -536,21 +535,8 @@ impl DisplayListBuilder<'_> {
         clip_rect: LayoutRect,
         bounds: LayoutRect,
     ) {
-        if !pref!(largest_contentful_paint_enabled) {
-            return;
-        }
-
-        let transform = self
-            .paint_info
-            .scroll_tree
-            .cumulative_node_to_root_transform(self.current_scroll_node_id);
-
-        self.paint_timing_handler.update_lcp_candidate(
-            lcp_candidate_id,
-            bounds,
-            clip_rect,
-            transform,
-        );
+        self.paint_timing_handler
+            .update_lcp_candidate(lcp_candidate_id, bounds, clip_rect);
     }
 }
 

--- a/components/layout/display_list/paint_timing_handler.rs
+++ b/components/layout/display_list/paint_timing_handler.rs
@@ -11,24 +11,27 @@ use webrender_api::units::{LayoutRect, LayoutSize};
 use crate::query::transform_au_rectangle;
 
 pub(crate) struct PaintTimingHandler {
+    /// The rect of viewport.
+    viewport_rect: LayoutRect,
+    /// Initial Transform of display list
+    transform: Option<FastLayoutTransform>,
     /// The document’s largest contentful paint size
     lcp_size: f32,
     /// The LCP candidate, it may be a image or text.
     lcp_candidate: Option<LCPCandidate>,
-    /// The rect of viewport.
-    viewport_rect: LayoutRect,
     /// Flag to indicate if there is an update to LCP candidate.
     /// This is used to avoid sending duplicate LCP candidates to `Paint`.
     lcp_candidate_updated: bool,
 }
 
 impl PaintTimingHandler {
-    pub(crate) fn new(viewport_size: LayoutSize) -> Self {
+    pub(crate) fn new(viewport_size: LayoutSize, transform: Option<FastLayoutTransform>) -> Self {
         Self {
             lcp_size: 0.0,
             lcp_candidate: None,
-            viewport_rect: LayoutRect::from_size(viewport_size),
             lcp_candidate_updated: false,
+            viewport_rect: LayoutRect::from_size(viewport_size),
+            transform: transform,
         }
     }
 
@@ -50,15 +53,15 @@ impl PaintTimingHandler {
         &self,
         bounds: LayoutRect,
         clip_rect: LayoutRect,
-        transform: FastLayoutTransform,
     ) -> Rect<f32, CSSPixel> {
         let clipped_rect = bounds
             .intersection(&clip_rect)
             .unwrap_or(LayoutRect::zero());
 
+        // If transform if not cached, lcp works in minimal mode without considering transform in calculations
         let transformed_rect = transform_au_rectangle(
             f32_rect_to_au_rect(clipped_rect.to_rect().cast_unit()),
-            transform,
+            self.transform.unwrap_or_default(),
         )
         .unwrap_or_default();
 
@@ -75,11 +78,10 @@ impl PaintTimingHandler {
         lcp_candidate_id: LCPCandidateID,
         bounds: LayoutRect,
         clip_rect: LayoutRect,
-        transform: FastLayoutTransform,
     ) {
         // From <https://www.w3.org/TR/largest-contentful-paint/#sec-report-largest-contentful-paint>:
         //  Let intersectionRect be the value returned by the intersection rect algorithm using imageElement as the target and viewport as the root.
-        let intersection_rect = self.calculate_intersection_rect(bounds, clip_rect, transform);
+        let intersection_rect = self.calculate_intersection_rect(bounds, clip_rect);
 
         // Let size be the effective visual size of candidate’s element given intersectionRect.
         let size = intersection_rect.size.width * intersection_rect.size.height;

--- a/components/layout/layout_impl.rs
+++ b/components/layout/layout_impl.rs
@@ -1303,12 +1303,25 @@ impl LayoutThread {
         let paint_timing_handler = match paint_timing_handler.as_mut() {
             Some(paint_timing_handler) => paint_timing_handler,
             None => {
-                *paint_timing_handler = Some(PaintTimingHandler::new(
-                    stacking_context_tree
-                        .paint_info
-                        .viewport_details
-                        .layout_size(),
-                ));
+                let viewport = stacking_context_tree
+                    .paint_info
+                    .viewport_details
+                    .layout_size();
+
+                let mut transform = None;
+                // Only calculate and cache transform when feature is enabled.
+                if pref!(largest_contentful_paint_enabled) {
+                    transform = Some(
+                        stacking_context_tree
+                            .paint_info
+                            .scroll_tree
+                            .cumulative_node_to_root_transform(
+                                stacking_context_tree.paint_info.root_reference_frame_id,
+                            ),
+                    )
+                }
+
+                *paint_timing_handler = Some(PaintTimingHandler::new(viewport, transform));
                 paint_timing_handler.as_mut().unwrap()
             },
         };


### PR DESCRIPTION
If we cache the Initial transform and use it for LCP, in this way we don't need to heavy calculations.

And transform will change with scroll events and LCP makes no sense after scroll.

Testing: (TBU)
