### PR TITLE
webdriver: Retrieve viewport size in CSS pixel

### DIFF
--- a/components/shared/embedder/webdriver.rs
+++ b/components/shared/embedder/webdriver.rs
@@ -17,11 +17,10 @@ use image::RgbaImage;
 use malloc_size_of_derive::MallocSizeOf;
 use rustc_hash::FxHashMap;
 use serde::{Deserialize, Serialize};
-use servo_geometry::DeviceIndependentIntRect;
+use servo_geometry::{DeviceIndependentIntRect, DeviceIndependentPixel};
 use style_traits::CSSPixel;
 use url::Url;
 use webdriver::error::ErrorStatus;
-use webrender_api::units::DevicePixel;
 
 use crate::{InputEvent, JSValue, JavaScriptEvaluationError, ScreenshotCaptureError, TraversalId};
 
@@ -92,7 +91,10 @@ pub enum WebDriverCommandMsg {
     /// Get the window rectangle.
     GetWindowRect(WebViewId, GenericOneshotSender<DeviceIndependentIntRect>),
     /// Get the viewport size.
-    GetViewportSize(WebViewId, GenericOneshotSender<Size2D<u32, DevicePixel>>),
+    GetViewportSize(
+        WebViewId,
+        GenericOneshotSender<Size2D<f32, DeviceIndependentPixel>>,
+    ),
     /// Load a URL in the top-level browsing context with the given ID.
     LoadUrl(WebViewId, Url, GenericSender<WebDriverLoadStatus>),
     /// Refresh the top-level browsing context with the given ID.

--- a/ports/servoshell/webdriver.rs
+++ b/ports/servoshell/webdriver.rs
@@ -247,7 +247,8 @@ impl RunningAppState {
                 },
                 WebDriverCommandMsg::GetViewportSize(webview_id, response_sender) => {
                     let platform_window = self.platform_window_for_webview_id(webview_id);
-                    let size = platform_window.rendering_context().size2d();
+                    let size = platform_window.rendering_context().size2d().to_f32() /
+                        platform_window.hidpi_scale_factor();
                     if let Err(error) = response_sender.send(size) {
                         warn!("Failed to send response of GetViewportSize: {error}");
                     }


### PR DESCRIPTION
According to [spec](https://w3c.github.io/webdriver/#ref-for-dfn-move-target-out-of-bounds-2:~:text=the%20viewport%20in%20CSS%20pixels), we are supposed to retrieve viewport size in CSS pixel.

This is a critical step when performing scroll/pointermove, to stop invalid actions that happen outside viewport.

Testing: Tested with tests in headed mode manually, narrowing discrepancy between headed/headless mode. Should not have effect on automated tests in CI.