### PR TITLE
script: ensure `resolve_module_specifier` picks the most specific scope

### DIFF
--- a/components/script/script_module.rs
+++ b/components/script/script_module.rs
@@ -1664,6 +1664,12 @@ fn merge_existing_and_new_import_maps(
         can_gc,
     );
     old_import_map.imports = merged_module_specifier_map;
+
+    // https://html.spec.whatwg.org/multipage/#the-resolution-algorithm
+    // Sort scopes to ensure entries are visited from most-specific to least-specific.
+    old_import_map
+        .scopes
+        .sort_by(|a_key, _, b_key, _| b_key.cmp(a_key));
 }
 
 /// <https://html.spec.whatwg.org/multipage/#merge-module-specifier-maps>

--- a/tests/wpt/meta/import-maps/multiple-import-maps/scope-ordering.html.ini
+++ b/tests/wpt/meta/import-maps/multiple-import-maps/scope-ordering.html.ini
@@ -1,3 +1,0 @@
-[scope-ordering.html]
-  [More specific scope from second import map should be checked first]
-    expected: FAIL


### PR DESCRIPTION
According to [specification](https://html.spec.whatwg.org/multipage/#the-resolution-algorithm) when resolving a module specifier we should prioritize more specific scopes, we achieve it by sorting the scopes in descending order.

Testing: A test is now passing
Part of #37553 
