### PR TITLE
script: Pass down `&mut JSContext` in servoparser and event loop.

### DIFF
--- a/components/script/dom/audio/mediaelementaudiosourcenode.rs
+++ b/components/script/dom/audio/mediaelementaudiosourcenode.rs
@@ -19,7 +19,6 @@ use crate::dom::bindings::reflector::reflect_dom_object_with_proto_and_cx;
 use crate::dom::bindings::root::{Dom, DomRoot};
 use crate::dom::html::htmlmediaelement::HTMLMediaElement;
 use crate::dom::window::Window;
-use crate::script_runtime::CanGc;
 
 #[dom_struct]
 pub(crate) struct MediaElementAudioSourceNode {
@@ -46,7 +45,7 @@ impl MediaElementAudioSourceNode {
             MediaElementSourceNodeMessage::GetAudioRenderer(sender),
         ));
         let audio_renderer = receiver.recv();
-        media_element.set_audio_renderer(audio_renderer.ok(), CanGc::from_cx(cx));
+        media_element.set_audio_renderer(audio_renderer.ok(), cx);
         let media_element = Dom::from_ref(media_element);
         Ok(MediaElementAudioSourceNode {
             node,

--- a/components/script/dom/dissimilaroriginwindow.rs
+++ b/components/script/dom/dissimilaroriginwindow.rs
@@ -9,7 +9,6 @@ use js::context::JSContext;
 use js::jsapi::{Heap, JSObject};
 use js::jsval::UndefinedValue;
 use js::rust::{CustomAutoRooter, CustomAutoRooterGuard, HandleValue, MutableHandleValue};
-use script_bindings::script_runtime::temp_cx;
 use servo_url::ServoUrl;
 
 use crate::dom::bindings::codegen::Bindings::DissimilarOriginWindowBinding;
@@ -47,12 +46,11 @@ pub(crate) struct DissimilarOriginWindow {
 }
 
 impl DissimilarOriginWindow {
-    #[expect(unsafe_code)]
     pub(crate) fn new(
+        cx: &mut js::context::JSContext,
         global_to_clone_from: &GlobalScope,
         window_proxy: &WindowProxy,
     ) -> DomRoot<Self> {
-        let mut cx = unsafe { temp_cx() };
         let win = Box::new(Self {
             globalscope: GlobalScope::new_inherited(
                 PipelineId::new(),
@@ -75,7 +73,7 @@ impl DissimilarOriginWindow {
             window_proxy: Dom::from_ref(window_proxy),
             location: Default::default(),
         });
-        DissimilarOriginWindowBinding::Wrap::<crate::DomTypeHolder>(&mut cx, win)
+        DissimilarOriginWindowBinding::Wrap::<crate::DomTypeHolder>(cx, win)
     }
 
     pub(crate) fn window_proxy(&self) -> DomRoot<WindowProxy> {

--- a/components/script/dom/document.rs
+++ b/components/script/dom/document.rs
@@ -2183,7 +2183,7 @@ impl Document {
 
     // https://html.spec.whatwg.org/multipage/#the-end
     // https://html.spec.whatwg.org/multipage/#delay-the-load-event
-    pub(crate) fn finish_load(&self, load: LoadType, can_gc: CanGc) {
+    pub(crate) fn finish_load(&self, load: LoadType, cx: &mut js::context::JSContext) {
         // This does not delay the load event anymore.
         debug!("Document got finish_load: {:?}", load);
         self.loader.borrow_mut().finish_load(&load);
@@ -2192,10 +2192,10 @@ impl Document {
             LoadType::Stylesheet(_) => {
                 // A stylesheet finishing to load may unblock any pending
                 // parsing-blocking script or deferred script.
-                self.process_pending_parsing_blocking_script(can_gc);
+                self.process_pending_parsing_blocking_script(cx);
 
                 // Step 3.
-                self.process_deferred_scripts(can_gc);
+                self.process_deferred_scripts(CanGc::from_cx(cx));
             },
             LoadType::PageSource(_) => {
                 // We finished loading the page, so if the `Window` is still waiting for
@@ -2208,7 +2208,7 @@ impl Document {
                 // this is the first opportunity to process them.
 
                 // Step 3.
-                self.process_deferred_scripts(can_gc);
+                self.process_deferred_scripts(CanGc::from_cx(cx));
             },
             _ => {},
         }
@@ -2564,7 +2564,7 @@ impl Document {
         &self,
         element: &HTMLScriptElement,
         result: ScriptResult,
-        can_gc: CanGc,
+        cx: &mut js::context::JSContext,
     ) {
         {
             let mut blocking_script = self.pending_parsing_blocking_script.borrow_mut();
@@ -2572,10 +2572,10 @@ impl Document {
             assert!(&*entry.element == element);
             entry.loaded(result);
         }
-        self.process_pending_parsing_blocking_script(can_gc);
+        self.process_pending_parsing_blocking_script(cx);
     }
 
-    fn process_pending_parsing_blocking_script(&self, can_gc: CanGc) {
+    fn process_pending_parsing_blocking_script(&self, cx: &mut js::context::JSContext) {
         if self.script_blocking_stylesheets_count.get() > 0 {
             return;
         }
@@ -2588,7 +2588,7 @@ impl Document {
             *self.pending_parsing_blocking_script.borrow_mut() = None;
             self.get_current_parser()
                 .unwrap()
-                .resume_with_pending_parsing_blocking_script(&element, result, can_gc);
+                .resume_with_pending_parsing_blocking_script(&element, result, cx);
         }
     }
 
@@ -2717,7 +2717,7 @@ impl Document {
     }
 
     /// <https://html.spec.whatwg.org/multipage/#destroy-a-document-and-its-descendants>
-    pub(crate) fn destroy_document_and_its_descendants(&self, can_gc: CanGc) {
+    pub(crate) fn destroy_document_and_its_descendants(&self, cx: &mut js::context::JSContext) {
         // Step 1. If document is not fully active, then:
         if !self.is_fully_active() {
             // Step 1.1. Let reason be a string from user-agent specific blocking reasons.
@@ -2743,22 +2743,22 @@ impl Document {
         // Step 5. Wait until numberDestroyed equals childNavigable's size.
         for exited_iframe in self.iframes().iter() {
             debug!("Destroying nested iframe document");
-            exited_iframe.destroy_document_and_its_descendants(can_gc);
+            exited_iframe.destroy_document_and_its_descendants(cx);
         }
         // Step 6. Queue a global task on the navigation and traversal task source
         // given document's relevant global object to perform the following steps:
         // TODO
         // Step 6.1. Destroy document.
-        self.destroy(can_gc);
+        self.destroy(cx);
         // Step 6.2. If afterAllDestruction was given, then run it.
         // TODO
     }
 
     /// <https://html.spec.whatwg.org/multipage/#destroy-a-document>
-    pub(crate) fn destroy(&self, can_gc: CanGc) {
+    pub(crate) fn destroy(&self, cx: &mut js::context::JSContext) {
         let exited_window = self.window();
         // Step 2. Abort document.
-        self.abort(can_gc);
+        self.abort(cx);
         // Step 3. Set document's salvageable state to false.
         self.salvageable.set(false);
         // Step 4. Let ports be the list of MessagePorts whose relevant
@@ -2814,14 +2814,14 @@ impl Document {
     }
 
     /// <https://html.spec.whatwg.org/multipage/#abort-a-document>
-    pub(crate) fn abort(&self, can_gc: CanGc) {
+    pub(crate) fn abort(&self, cx: &mut js::context::JSContext) {
         // We need to inhibit the loader before anything else.
         self.loader.borrow_mut().inhibit_events();
 
         // Step 1.
         for iframe in self.iframes().iter() {
             if let Some(document) = iframe.GetContentDocument() {
-                document.abort(can_gc);
+                document.abort(cx);
             }
         }
 
@@ -2858,7 +2858,7 @@ impl Document {
             // Step 4.1. Set document's active parser was aborted to true.
             self.active_parser_was_aborted.set(true);
             // Step 4.2. Abort that parser.
-            parser.abort(can_gc);
+            parser.abort(cx);
             // Step 4.3. Make document unsalvageable given document and "parser-aborted".
             self.salvageable.set(false);
         }
@@ -3586,7 +3586,7 @@ impl Document {
         };
 
         // Steps 10-11.
-        parser.write(string.into(), CanGc::from_cx(cx));
+        parser.write(string.into(), cx);
 
         Ok(())
     }
@@ -4784,7 +4784,7 @@ impl Document {
     }
 
     /// An implementation of <https://drafts.csswg.org/web-animations-1/#update-animations-and-send-events>.
-    pub(crate) fn update_animations_and_send_events(&self, can_gc: CanGc) {
+    pub(crate) fn update_animations_and_send_events(&self, cx: &mut js::context::JSContext) {
         // Only update the time if it isn't being managed by a test.
         if !self.layout_animations_test_enabled {
             self.animation_timeline.borrow_mut().update();
@@ -4802,11 +4802,12 @@ impl Document {
         self.maybe_mark_animating_nodes_as_dirty();
 
         // > 3. Perform a microtask checkpoint.
-        self.window().perform_a_microtask_checkpoint(can_gc);
+        self.window().perform_a_microtask_checkpoint(cx);
 
         // Steps 4 through 7 occur inside `send_pending_events().`
         let _realm = enter_realm(self);
-        self.animations().send_pending_events(self.window(), can_gc);
+        self.animations()
+            .send_pending_events(self.window(), CanGc::from_cx(cx));
     }
 
     pub(crate) fn image_animation_manager(&self) -> Ref<'_, ImageAnimationManager> {
@@ -5131,14 +5132,7 @@ impl DocumentMethods<crate::DomTypeHolder> for Document {
             CanGc::from_cx(cx),
         );
         // Step 4. Parse HTML from string given document and compliantHTML.
-        ServoParser::parse_html_document(
-            &document,
-            Some(compliant_html),
-            url,
-            None,
-            None,
-            CanGc::from_cx(cx),
-        );
+        ServoParser::parse_html_document(&document, Some(compliant_html), url, None, None, cx);
         // Step 5. Return document.
         document.set_ready_state(DocumentReadyState::Complete, CanGc::from_cx(cx));
         Ok(document)
@@ -6349,7 +6343,7 @@ impl DocumentMethods<crate::DomTypeHolder> for Document {
         if self.has_browsing_context() {
             // spec says "stop document loading",
             // which is a process that does more than just abort
-            self.abort(CanGc::from_cx(cx));
+            self.abort(cx);
         }
 
         // Step 9
@@ -6475,7 +6469,7 @@ impl DocumentMethods<crate::DomTypeHolder> for Document {
         };
 
         // Step 4-6.
-        parser.close(CanGc::from_cx(cx));
+        parser.close(cx);
 
         Ok(())
     }

--- a/components/script/dom/document.rs
+++ b/components/script/dom/document.rs
@@ -843,7 +843,7 @@ impl Document {
         self.current_rendering_epoch.get()
     }
 
-    pub(crate) fn set_activity(&self, activity: DocumentActivity, can_gc: CanGc) {
+    pub(crate) fn set_activity(&self, cx: &mut js::context::JSContext, activity: DocumentActivity) {
         // This function should only be called on documents with a browsing context
         assert!(self.has_browsing_context);
         if activity == self.activity.get() {
@@ -858,7 +858,7 @@ impl Document {
             ClientContextId::build(pipeline_id.namespace_id.0, pipeline_id.index.0.get());
 
         if activity != DocumentActivity::FullyActive {
-            self.window().suspend(can_gc);
+            self.window().suspend(cx);
             media.suspend(&client_context_id);
             return;
         }
@@ -866,7 +866,7 @@ impl Document {
         self.title_changed();
         self.notify_embedder_favicon();
         self.dirty_all_nodes();
-        self.window().resume(can_gc);
+        self.window().resume(CanGc::from_cx(cx));
         media.resume(&client_context_id);
 
         if self.ready_state.get() != DocumentReadyState::Complete {

--- a/components/script/dom/domparser.rs
+++ b/components/script/dom/domparser.rs
@@ -116,7 +116,7 @@ impl DOMParserMethods<crate::DomTypeHolder> for DOMParser {
                     url,
                     None,
                     None,
-                    CanGc::from_cx(cx),
+                    cx,
                 );
                 document
             },
@@ -148,13 +148,7 @@ impl DOMParserMethods<crate::DomTypeHolder> for DOMParser {
                 );
                 // Step switch-1. Create an XML parser parser, associated with document,
                 // and with XML scripting support disabled.
-                ServoParser::parse_xml_document(
-                    &document,
-                    Some(compliant_string),
-                    url,
-                    None,
-                    CanGc::from_cx(cx),
-                );
+                ServoParser::parse_xml_document(&document, Some(compliant_string), url, None, cx);
                 document
             },
         };

--- a/components/script/dom/globalscope.rs
+++ b/components/script/dom/globalscope.rs
@@ -2963,11 +2963,11 @@ impl GlobalScope {
     }
 
     /// Perform a microtask checkpoint.
-    pub(crate) fn perform_a_microtask_checkpoint(&self, can_gc: CanGc) {
+    pub(crate) fn perform_a_microtask_checkpoint(&self, cx: &mut js::context::JSContext) {
         if let Some(window) = self.downcast::<Window>() {
-            window.perform_a_microtask_checkpoint(can_gc);
+            window.perform_a_microtask_checkpoint(cx);
         } else if let Some(worker) = self.downcast::<WorkerGlobalScope>() {
-            worker.perform_a_microtask_checkpoint(can_gc);
+            worker.perform_a_microtask_checkpoint(cx);
         }
     }
 
@@ -3586,8 +3586,8 @@ impl GlobalScopeHelpers<crate::DomTypeHolder> for GlobalScope {
         GlobalScope::incumbent()
     }
 
-    fn perform_a_microtask_checkpoint(&self, can_gc: CanGc) {
-        GlobalScope::perform_a_microtask_checkpoint(self, can_gc)
+    fn perform_a_microtask_checkpoint(&self, cx: &mut js::context::JSContext) {
+        GlobalScope::perform_a_microtask_checkpoint(self, cx)
     }
 
     fn get_url(&self) -> ServoUrl {

--- a/components/script/dom/html/htmliframeelement.rs
+++ b/components/script/dom/html/htmliframeelement.rs
@@ -21,6 +21,7 @@ use js::rust::HandleObject;
 use net_traits::ReferrerPolicy;
 use net_traits::request::Destination;
 use profile_traits::ipc as ProfiledIpc;
+use script_bindings::script_runtime::temp_cx;
 use script_traits::{NewPipelineInfo, UpdatePipelineIdReason};
 use servo_url::ServoUrl;
 use style::attr::{AttrValue, LengthOrPercentageOrAuto};
@@ -136,7 +137,7 @@ impl HTMLIFrameElement {
         &self,
         load_data: LoadData,
         history_handling: NavigationHistoryBehavior,
-        can_gc: CanGc,
+        cx: &mut js::context::JSContext,
     ) {
         // In case we fired a synchronous load event, but navigate away
         // in the event listener of that event, then we should still
@@ -146,12 +147,7 @@ impl HTMLIFrameElement {
         // of whether we synchronously fired a load in the same microtask.
         self.already_fired_synchronous_load_event.set(false);
 
-        self.start_new_pipeline(
-            load_data,
-            PipelineType::Navigation,
-            history_handling,
-            can_gc,
-        );
+        self.start_new_pipeline(load_data, PipelineType::Navigation, history_handling, cx);
     }
 
     fn start_new_pipeline(
@@ -159,7 +155,7 @@ impl HTMLIFrameElement {
         mut load_data: LoadData,
         pipeline_type: PipelineType,
         history_handling: NavigationHistoryBehavior,
-        can_gc: CanGc,
+        cx: &mut js::context::JSContext,
     ) {
         let browsing_context_id = match self.browsing_context_id() {
             None => return warn!("Attempted to start a new pipeline on an unattached iframe."),
@@ -177,7 +173,7 @@ impl HTMLIFrameElement {
             let load_blocker = &self.load_blocker;
             // Any oustanding load is finished from the point of view of the blocked
             // document; the new navigation will continue blocking it.
-            LoadBlocker::terminate(load_blocker, can_gc);
+            LoadBlocker::terminate(load_blocker, cx);
         }
 
         if load_data.url.scheme() == "javascript" {
@@ -188,7 +184,7 @@ impl HTMLIFrameElement {
                     &window_proxy.global(),
                     &mut load_data,
                     Some(self.upcast()),
-                    can_gc,
+                    CanGc::from_cx(cx),
                 ) {
                     return;
                 }
@@ -292,7 +288,7 @@ impl HTMLIFrameElement {
     }
 
     /// <https://html.spec.whatwg.org/multipage/#process-the-iframe-attributes>
-    fn process_the_iframe_attributes(&self, mode: ProcessingMode, can_gc: CanGc) {
+    fn process_the_iframe_attributes(&self, mode: ProcessingMode, cx: &mut js::context::JSContext) {
         let element = self.upcast::<Element>();
         // Step 1. If `element`'s `srcdoc` attribute is specified, then:
         //
@@ -320,7 +316,7 @@ impl HTMLIFrameElement {
             self.navigate_or_reload_child_browsing_context(
                 load_data,
                 NavigationHistoryBehavior::Push,
-                can_gc,
+                cx,
             );
             return;
         }
@@ -361,7 +357,7 @@ impl HTMLIFrameElement {
             // so we can fire that. Following https://github.com/servo/servo/issues/31973
             // we should call `iframe_load_event_steps` once it is spec-compliant.
             self.upcast::<EventTarget>()
-                .fire_event(atom!("load"), can_gc);
+                .fire_event(atom!("load"), CanGc::from_cx(cx));
             // Step 2.3.2. Return.
             return;
         }
@@ -441,7 +437,7 @@ impl HTMLIFrameElement {
             NavigationHistoryBehavior::Push
         };
 
-        self.navigate_or_reload_child_browsing_context(load_data, history_handling, can_gc);
+        self.navigate_or_reload_child_browsing_context(load_data, history_handling, cx);
     }
 
     /// <https://html.spec.whatwg.org/multipage/#create-a-new-child-navigable>
@@ -451,7 +447,7 @@ impl HTMLIFrameElement {
     /// For now only the iframe load event steps are skipped in some cases for this initial document,
     /// and we still fire load and pageshow events as part of `maybe_queue_document_completion`.
     /// Also, some controversy spec-wise remains: <https://github.com/whatwg/html/issues/4965>
-    fn create_nested_browsing_context(&self, can_gc: CanGc) {
+    fn create_nested_browsing_context(&self, cx: &mut js::context::JSContext) {
         let url = ServoUrl::parse("about:blank").unwrap();
         let document = self.owner_document();
         let window = self.owner_window();
@@ -481,7 +477,7 @@ impl HTMLIFrameElement {
             load_data,
             PipelineType::InitialAboutBlank,
             NavigationHistoryBehavior::Push,
-            can_gc,
+            cx,
         );
     }
 
@@ -499,7 +495,7 @@ impl HTMLIFrameElement {
         &self,
         new_pipeline_id: PipelineId,
         reason: UpdatePipelineIdReason,
-        can_gc: CanGc,
+        cx: &mut js::context::JSContext,
     ) {
         // For all updates except the one for the initial blank document,
         // we need to set the flag back to false because the navigation is complete,
@@ -520,7 +516,7 @@ impl HTMLIFrameElement {
         // The load blocker will be terminated for a navigation in iframe_load_event_steps.
         if reason == UpdatePipelineIdReason::Traversal {
             let blocker = &self.load_blocker;
-            LoadBlocker::terminate(blocker, can_gc);
+            LoadBlocker::terminate(blocker, cx);
         }
 
         self.upcast::<Node>().dirty(NodeDamage::Other);
@@ -601,7 +597,11 @@ impl HTMLIFrameElement {
     }
 
     /// <https://html.spec.whatwg.org/multipage/#iframe-load-event-steps>
-    pub(crate) fn iframe_load_event_steps(&self, loaded_pipeline: PipelineId, can_gc: CanGc) {
+    pub(crate) fn iframe_load_event_steps(
+        &self,
+        loaded_pipeline: PipelineId,
+        cx: &mut js::context::JSContext,
+    ) {
         // TODO(#9592): assert that the load blocker is present at all times when we
         //              can guarantee that it's created for the case of iframe.reload().
         if Some(loaded_pipeline) != self.pending_pipeline_id.get() {
@@ -654,11 +654,11 @@ impl HTMLIFrameElement {
         if should_fire_event {
             // Step 6. Fire an event named load at element.
             self.upcast::<EventTarget>()
-                .fire_event(atom!("load"), can_gc);
+                .fire_event(atom!("load"), CanGc::from_cx(cx));
         }
 
         let blocker = &self.load_blocker;
-        LoadBlocker::terminate(blocker, can_gc);
+        LoadBlocker::terminate(blocker, cx);
 
         // TODO Step 7 - unset child document `mute iframe load` flag
     }
@@ -683,21 +683,21 @@ impl HTMLIFrameElement {
     }
 
     /// Step 4.2. of <https://html.spec.whatwg.org/multipage/#destroy-a-document-and-its-descendants>
-    pub(crate) fn destroy_document_and_its_descendants(&self, can_gc: CanGc) {
+    pub(crate) fn destroy_document_and_its_descendants(&self, cx: &mut js::context::JSContext) {
         let Some(pipeline_id) = self.pipeline_id.get() else {
             return;
         };
         // Step 4.2. Destroy a document and its descendants given childNavigable's active document and incrementDestroyed.
         if let Some(exited_document) = ScriptThread::find_document(pipeline_id) {
-            exited_document.destroy_document_and_its_descendants(can_gc);
+            exited_document.destroy_document_and_its_descendants(cx);
         }
         self.destroy_nested_browsing_context();
     }
 
     /// <https://html.spec.whatwg.org/multipage/#destroy-a-child-navigable>
-    fn destroy_child_navigable(&self, can_gc: CanGc) {
+    fn destroy_child_navigable(&self, cx: &mut js::context::JSContext) {
         let blocker = &self.load_blocker;
-        LoadBlocker::terminate(blocker, CanGc::note());
+        LoadBlocker::terminate(blocker, cx);
 
         // Step 1. Let navigable be container's content navigable.
         let Some(browsing_context_id) = self.browsing_context_id() else {
@@ -734,7 +734,7 @@ impl HTMLIFrameElement {
             return;
         };
         if let Some(exited_document) = ScriptThread::find_document(pipeline_id) {
-            exited_document.destroy_document_and_its_descendants(can_gc);
+            exited_document.destroy_document_and_its_descendants(cx);
         }
 
         // Step 6. Let parentDocState be container's node navigable's active session history entry's document state.
@@ -925,10 +925,13 @@ impl VirtualMethods for HTMLIFrameElement {
         Some(self.upcast::<HTMLElement>() as &dyn VirtualMethods)
     }
 
-    fn attribute_mutated(&self, attr: &Attr, mutation: AttributeMutation, can_gc: CanGc) {
+    #[expect(unsafe_code)]
+    fn attribute_mutated(&self, attr: &Attr, mutation: AttributeMutation, _can_gc: CanGc) {
+        let mut cx = unsafe { temp_cx() };
+        let cx = &mut cx;
         self.super_type()
             .unwrap()
-            .attribute_mutated(attr, mutation, can_gc);
+            .attribute_mutated(attr, mutation, CanGc::from_cx(cx));
         match *attr.local_name() {
             // From <https://html.spec.whatwg.org/multipage/#attr-iframe-sandbox>:
             //
@@ -956,7 +959,7 @@ impl VirtualMethods for HTMLIFrameElement {
                 // trigger the processing of iframe attributes whenever "srcdoc" attribute is set, changed or removed
                 if self.upcast::<Node>().is_connected_with_browsing_context() {
                     debug!("iframe srcdoc modified while in browsing context.");
-                    self.process_the_iframe_attributes(ProcessingMode::NotFirstTime, can_gc);
+                    self.process_the_iframe_attributes(ProcessingMode::NotFirstTime, cx);
                 }
             },
             local_name!("src") => {
@@ -970,7 +973,7 @@ impl VirtualMethods for HTMLIFrameElement {
                 // the child browsing context to be created.
                 if self.upcast::<Node>().is_connected_with_browsing_context() {
                     debug!("iframe src set while in browsing context.");
-                    self.process_the_iframe_attributes(ProcessingMode::NotFirstTime, can_gc);
+                    self.process_the_iframe_attributes(ProcessingMode::NotFirstTime, cx);
                 }
             },
             _ => {},
@@ -1015,14 +1018,14 @@ impl VirtualMethods for HTMLIFrameElement {
         debug!("<iframe> running post connection steps");
 
         // Step 1. Create a new child navigable for insertedNode.
-        self.create_nested_browsing_context(CanGc::from_cx(cx));
+        self.create_nested_browsing_context(cx);
 
         // Step 2: If insertedNode has a sandbox attribute, then parse the sandboxing directive
         // given the attribute's value and insertedNode's iframe sandboxing flag set.
         self.parse_sandbox_attribute();
 
         // Step 3. Process the iframe attributes for insertedNode, with initialInsertion set to true.
-        self.process_the_iframe_attributes(ProcessingMode::FirstTime, CanGc::from_cx(cx));
+        self.process_the_iframe_attributes(ProcessingMode::FirstTime, cx);
     }
 
     fn bind_to_tree(&self, context: &BindContext, can_gc: CanGc) {
@@ -1033,11 +1036,14 @@ impl VirtualMethods for HTMLIFrameElement {
     }
 
     /// <https://html.spec.whatwg.org/multipage/#the-iframe-element:html-element-removing-steps>
+    #[expect(unsafe_code)]
     fn unbind_from_tree(&self, context: &UnbindContext, can_gc: CanGc) {
         self.super_type().unwrap().unbind_from_tree(context, can_gc);
 
+        let mut cx = unsafe { temp_cx() };
+
         // The iframe HTML element removing steps, given removedNode, are to destroy a child navigable given removedNode
-        self.destroy_child_navigable(can_gc);
+        self.destroy_child_navigable(&mut cx);
 
         self.owner_document().invalidate_iframes_collection();
     }

--- a/components/script/dom/html/htmliframeelement.rs
+++ b/components/script/dom/html/htmliframeelement.rs
@@ -927,6 +927,7 @@ impl VirtualMethods for HTMLIFrameElement {
 
     #[expect(unsafe_code)]
     fn attribute_mutated(&self, attr: &Attr, mutation: AttributeMutation, _can_gc: CanGc) {
+        // TODO: https://github.com/servo/servo/issues/42812
         let mut cx = unsafe { temp_cx() };
         let cx = &mut cx;
         self.super_type()
@@ -1040,6 +1041,7 @@ impl VirtualMethods for HTMLIFrameElement {
     fn unbind_from_tree(&self, context: &UnbindContext, can_gc: CanGc) {
         self.super_type().unwrap().unbind_from_tree(context, can_gc);
 
+        // TODO: https://github.com/servo/servo/issues/42837
         let mut cx = unsafe { temp_cx() };
 
         // The iframe HTML element removing steps, given removedNode, are to destroy a child navigable given removedNode

--- a/components/script/dom/html/htmlimageelement.rs
+++ b/components/script/dom/html/htmlimageelement.rs
@@ -13,7 +13,7 @@ use cssparser::{Parser, ParserInput};
 use dom_struct::dom_struct;
 use euclid::default::Point2D;
 use html5ever::{LocalName, Prefix, QualName, local_name, ns};
-use js::jsapi::JSAutoRealm;
+use js::realm::AutoRealm;
 use js::rust::HandleObject;
 use mime::{self, Mime};
 use net_traits::http_status::HttpStatus;
@@ -29,6 +29,7 @@ use num_traits::ToPrimitive;
 use pixels::{CorsStatus, ImageMetadata, Snapshot};
 use regex::Regex;
 use rustc_hash::FxHashSet;
+use script_bindings::script_runtime::temp_cx;
 use servo_url::ServoUrl;
 use servo_url::origin::MutableOrigin;
 use style::attr::{AttrValue, LengthOrPercentageOrAuto, parse_unsigned_integer};
@@ -80,7 +81,7 @@ use crate::dom::window::Window;
 use crate::fetch::{RequestWithGlobalScope, create_a_potential_cors_request};
 use crate::microtask::{Microtask, MicrotaskRunnable};
 use crate::network_listener::{self, FetchResponseListener, ResourceTimingListener};
-use crate::realms::enter_realm;
+use crate::realms::enter_auto_realm;
 use crate::script_runtime::CanGc;
 use crate::script_thread::ScriptThread;
 
@@ -344,7 +345,7 @@ impl ResourceTimingListener for ImageContext {
 #[expect(non_snake_case)]
 impl HTMLImageElement {
     /// Update the current image with a valid URL.
-    fn fetch_image(&self, img_url: &ServoUrl, can_gc: CanGc) {
+    fn fetch_image(&self, img_url: &ServoUrl, cx: &mut js::context::JSContext) {
         let window = self.owner_window();
 
         let cache_result = window.image_cache().get_cached_image_status(
@@ -357,12 +358,12 @@ impl HTMLImageElement {
             ImageCacheResult::Available(ImageOrMetadataAvailable::ImageAvailable {
                 image,
                 url,
-            }) => self.process_image_response(ImageResponse::Loaded(image, url), can_gc),
+            }) => self.process_image_response(ImageResponse::Loaded(image, url), cx),
             ImageCacheResult::Available(ImageOrMetadataAvailable::MetadataAvailable(
                 metadata,
                 id,
             )) => {
-                self.process_image_response(ImageResponse::MetadataLoaded(metadata), can_gc);
+                self.process_image_response(ImageResponse::MetadataLoaded(metadata), cx);
                 self.register_image_cache_callback(id, ChangeType::Element);
             },
             ImageCacheResult::Pending(id) => {
@@ -373,7 +374,7 @@ impl HTMLImageElement {
                 self.register_image_cache_callback(id, ChangeType::Element);
             },
             ImageCacheResult::FailedToLoadOrDecode => {
-                self.process_image_response(ImageResponse::FailedToLoadOrDecode, can_gc)
+                self.process_image_response(ImageResponse::FailedToLoadOrDecode, cx)
             },
         };
     }
@@ -382,7 +383,7 @@ impl HTMLImageElement {
         let trusted_node = Trusted::new(self);
         let generation = self.generation_id();
         let window = self.owner_window();
-        let callback = window.register_image_cache_listener(id, move |response| {
+        let callback = window.register_image_cache_listener(id, move |response, _| {
             let trusted_node = trusted_node.clone();
             let window = trusted_node.root().owner_window();
             let callback_type = change_type.clone();
@@ -391,7 +392,7 @@ impl HTMLImageElement {
                 .as_global_scope()
                 .task_manager()
                 .networking_task_source()
-                .queue(task!(process_image_response: move || {
+                .queue(task!(process_image_response: move |cx| {
                 let element = trusted_node.root();
 
                 // Ignore any image response for a previous request that has been discarded.
@@ -401,11 +402,11 @@ impl HTMLImageElement {
 
                 match callback_type {
                     ChangeType::Element => {
-                        element.process_image_response(response.response, CanGc::note());
+                        element.process_image_response(response.response, cx);
                     }
                     ChangeType::Environment { selected_source, selected_pixel_density } => {
                         element.process_image_response_for_environment_change(
-                            response.response, selected_source, generation, selected_pixel_density, CanGc::note()
+                            response.response, selected_source, generation, selected_pixel_density, cx
                         );
                     }
                 }
@@ -457,19 +458,19 @@ impl HTMLImageElement {
     }
 
     // Steps common to when an image has been loaded.
-    fn handle_loaded_image(&self, image: Image, url: ServoUrl, can_gc: CanGc) {
+    fn handle_loaded_image(&self, image: Image, url: ServoUrl, cx: &mut js::context::JSContext) {
         self.current_request.borrow_mut().metadata = Some(image.metadata());
         self.current_request.borrow_mut().final_url = Some(url);
         self.current_request.borrow_mut().image = Some(image);
         self.current_request.borrow_mut().state = State::CompletelyAvailable;
-        LoadBlocker::terminate(&self.current_request.borrow().blocker, can_gc);
+        LoadBlocker::terminate(&self.current_request.borrow().blocker, cx);
         // Mark the node dirty
         self.upcast::<Node>().dirty(NodeDamage::Other);
         self.resolve_image_decode_promises();
     }
 
     /// <https://html.spec.whatwg.org/multipage/#update-the-image-data>
-    fn process_image_response(&self, image: ImageResponse, can_gc: CanGc) {
+    fn process_image_response(&self, image: ImageResponse, cx: &mut js::context::JSContext) {
         // Step 27. As soon as possible, jump to the first applicable entry from the following list:
 
         // TODO => "If the resource type is multipart/x-mixed-replace"
@@ -477,13 +478,13 @@ impl HTMLImageElement {
         // => "If the resource type and data corresponds to a supported image format ...""
         let (trigger_image_load, trigger_image_error) = match (image, self.image_request.get()) {
             (ImageResponse::Loaded(image, url), ImageRequestPhase::Current) => {
-                self.handle_loaded_image(image, url, can_gc);
+                self.handle_loaded_image(image, url, cx);
                 (true, false)
             },
             (ImageResponse::Loaded(image, url), ImageRequestPhase::Pending) => {
-                self.abort_request(State::Unavailable, ImageRequestPhase::Pending, can_gc);
+                self.abort_request(State::Unavailable, ImageRequestPhase::Pending, cx);
                 self.image_request.set(ImageRequestPhase::Current);
-                self.handle_loaded_image(image, url, can_gc);
+                self.handle_loaded_image(image, url, cx);
                 (true, false)
             },
             (ImageResponse::MetadataLoaded(meta), ImageRequestPhase::Current) => {
@@ -508,7 +509,7 @@ impl HTMLImageElement {
                 // and image request is the current request:
 
                 // Step 1. Abort the image request for image request.
-                self.abort_request(State::Broken, ImageRequestPhase::Current, can_gc);
+                self.abort_request(State::Broken, ImageRequestPhase::Current, cx);
 
                 self.load_broken_image_icon();
 
@@ -523,8 +524,8 @@ impl HTMLImageElement {
                 // and image request is the pending request:
 
                 // Step 1. Abort the image request for the current request and the pending request.
-                self.abort_request(State::Broken, ImageRequestPhase::Current, can_gc);
-                self.abort_request(State::Unavailable, ImageRequestPhase::Pending, can_gc);
+                self.abort_request(State::Broken, ImageRequestPhase::Current, cx);
+                self.abort_request(State::Unavailable, ImageRequestPhase::Pending, cx);
 
                 // Step 2. Upgrade the pending request to the current request.
                 mem::swap(
@@ -547,17 +548,17 @@ impl HTMLImageElement {
         if trigger_image_load {
             // TODO: https://html.spec.whatwg.org/multipage/#fire-a-progress-event-or-event
             self.upcast::<EventTarget>()
-                .fire_event(atom!("load"), can_gc);
+                .fire_event(atom!("load"), CanGc::from_cx(cx));
             self.upcast::<EventTarget>()
-                .fire_event(atom!("loadend"), can_gc);
+                .fire_event(atom!("loadend"), CanGc::from_cx(cx));
         }
 
         // Fire image.onerror
         if trigger_image_error {
             self.upcast::<EventTarget>()
-                .fire_event(atom!("error"), can_gc);
+                .fire_event(atom!("error"), CanGc::from_cx(cx));
             self.upcast::<EventTarget>()
-                .fire_event(atom!("loadend"), can_gc);
+                .fire_event(atom!("loadend"), CanGc::from_cx(cx));
         }
     }
 
@@ -569,7 +570,7 @@ impl HTMLImageElement {
         selected_source: USVString,
         generation: u32,
         selected_pixel_density: f64,
-        can_gc: CanGc,
+        cx: &mut js::context::JSContext,
     ) {
         match image {
             ImageResponse::Loaded(image, url) => {
@@ -590,7 +591,7 @@ impl HTMLImageElement {
                 // > way such that the image dimensions cannot be obtained, or if the
                 // > resource type is multipart/x-mixed-replace, then set the pending
                 // > request to null and abort these steps.
-                self.abort_request(State::Unavailable, ImageRequestPhase::Pending, can_gc);
+                self.abort_request(State::Unavailable, ImageRequestPhase::Pending, cx);
             },
             ImageResponse::MetadataLoaded(meta) => {
                 self.pending_request.borrow_mut().metadata = Some(meta);
@@ -599,12 +600,17 @@ impl HTMLImageElement {
     }
 
     /// <https://html.spec.whatwg.org/multipage/#abort-the-image-request>
-    fn abort_request(&self, state: State, request: ImageRequestPhase, can_gc: CanGc) {
+    fn abort_request(
+        &self,
+        state: State,
+        request: ImageRequestPhase,
+        cx: &mut js::context::JSContext,
+    ) {
         let mut request = match request {
             ImageRequestPhase::Current => self.current_request.borrow_mut(),
             ImageRequestPhase::Pending => self.pending_request.borrow_mut(),
         };
-        LoadBlocker::terminate(&request.blocker, can_gc);
+        LoadBlocker::terminate(&request.blocker, cx);
         request.state = state;
         request.image = None;
         request.metadata = None;
@@ -884,14 +890,14 @@ impl HTMLImageElement {
         request: &mut RefMut<'_, ImageRequest>,
         url: &ServoUrl,
         src: &USVString,
-        can_gc: CanGc,
+        cx: &mut js::context::JSContext,
     ) {
         request.parsed_url = Some(url.clone());
         request.source_url = Some(src.clone());
         request.image = None;
         request.metadata = None;
         let document = self.owner_document();
-        LoadBlocker::terminate(&request.blocker, can_gc);
+        LoadBlocker::terminate(&request.blocker, cx);
         *request.blocker.borrow_mut() =
             Some(LoadBlocker::new(&document, LoadType::Image(url.clone())));
     }
@@ -902,7 +908,7 @@ impl HTMLImageElement {
         selected_source: &USVString,
         selected_pixel_density: f64,
         image_url: &ServoUrl,
-        can_gc: CanGc,
+        cx: &mut js::context::JSContext,
     ) {
         match self.image_request.get() {
             ImageRequestPhase::Pending => {
@@ -920,7 +926,7 @@ impl HTMLImageElement {
             },
             ImageRequestPhase::Current => {
                 // Step 16. Abort the image request for the pending request.
-                self.abort_request(State::Unavailable, ImageRequestPhase::Pending, can_gc);
+                self.abort_request(State::Unavailable, ImageRequestPhase::Pending, cx);
 
                 // Step 17. Set image request to a new image request whose current URL is urlString.
 
@@ -947,7 +953,7 @@ impl HTMLImageElement {
                             &mut pending_request,
                             image_url,
                             selected_source,
-                            can_gc,
+                            cx,
                         );
                         pending_request.current_pixel_density = Some(selected_pixel_density);
                     },
@@ -959,7 +965,7 @@ impl HTMLImageElement {
                             &mut current_request,
                             image_url,
                             selected_source,
-                            can_gc,
+                            cx,
                         );
                         current_request.current_pixel_density = Some(selected_pixel_density);
                         self.reject_image_decode_promises();
@@ -973,7 +979,7 @@ impl HTMLImageElement {
                             &mut pending_request,
                             image_url,
                             selected_source,
-                            can_gc,
+                            cx,
                         );
                         pending_request.current_pixel_density = Some(selected_pixel_density);
                     },
@@ -981,11 +987,11 @@ impl HTMLImageElement {
             },
         }
 
-        self.fetch_image(image_url, can_gc);
+        self.fetch_image(image_url, cx);
     }
 
     /// <https://html.spec.whatwg.org/multipage/#update-the-image-data>
-    fn update_the_image_data_sync_steps(&self, can_gc: CanGc) {
+    fn update_the_image_data_sync_steps(&self, cx: &mut js::context::JSContext) {
         // Step 10. Let selected source and selected pixel density be the URL and pixel density that
         // results from selecting an image source, respectively.
         let Some((selected_source, selected_pixel_density)) = self.select_image_source() else {
@@ -993,8 +999,8 @@ impl HTMLImageElement {
 
             // Step 11.1. Set the current request's state to broken, abort the image request for the
             // current request and the pending request, and set the pending request to null.
-            self.abort_request(State::Broken, ImageRequestPhase::Current, can_gc);
-            self.abort_request(State::Unavailable, ImageRequestPhase::Pending, can_gc);
+            self.abort_request(State::Broken, ImageRequestPhase::Current, cx);
+            self.abort_request(State::Unavailable, ImageRequestPhase::Pending, cx);
             self.image_request.set(ImageRequestPhase::Current);
 
             // Step 11.2. Queue an element task on the DOM manipulation task source given the img
@@ -1002,7 +1008,7 @@ impl HTMLImageElement {
             let this = Trusted::new(self);
 
             self.owner_global().task_manager().dom_manipulation_task_source().queue(
-                task!(image_null_source_error: move || {
+                task!(image_null_source_error: move |cx| {
                     let this = this.root();
 
                     // Step 11.2.1. Change the current request's current URL to the empty string.
@@ -1021,7 +1027,7 @@ impl HTMLImageElement {
                     let has_src_attribute = this.upcast::<Element>().has_attribute(&local_name!("src"));
 
                     if has_src_attribute || this.uses_srcset_or_picture() {
-                        this.upcast::<EventTarget>().fire_event(atom!("error"), CanGc::note());
+                        this.upcast::<EventTarget>().fire_event(atom!("error"), CanGc::from_cx(cx));
                     }
                 }));
 
@@ -1036,8 +1042,8 @@ impl HTMLImageElement {
 
             // Step 13.1. Abort the image request for the current request and the pending request.
             // Step 13.2. Set the current request's state to broken.
-            self.abort_request(State::Broken, ImageRequestPhase::Current, can_gc);
-            self.abort_request(State::Unavailable, ImageRequestPhase::Pending, can_gc);
+            self.abort_request(State::Broken, ImageRequestPhase::Current, cx);
+            self.abort_request(State::Unavailable, ImageRequestPhase::Pending, cx);
 
             // Step 13.3. Set the pending request to null.
             self.image_request.set(ImageRequestPhase::Current);
@@ -1049,7 +1055,7 @@ impl HTMLImageElement {
             self.owner_global()
                 .task_manager()
                 .dom_manipulation_task_source()
-                .queue(task!(image_selected_source_error: move || {
+                .queue(task!(image_selected_source_error: move |cx| {
                     let this = this.root();
 
                     // Step 13.4.1. Change the current request's current URL to selected source.
@@ -1063,18 +1069,18 @@ impl HTMLImageElement {
                     // Step 13.4.2. If maybe omit events is not set or previousURL is not equal to
                     // selected source, then fire an event named error at the img element.
                     // TODO: Add missing `maybe omit events` flag and previousURL.
-                    this.upcast::<EventTarget>().fire_event(atom!("error"), CanGc::note());
+                    this.upcast::<EventTarget>().fire_event(atom!("error"), CanGc::from_cx(cx));
                 }));
 
             // Step 13.5. Return.
             return;
         };
 
-        self.prepare_image_request(&selected_source, selected_pixel_density, &image_url, can_gc);
+        self.prepare_image_request(&selected_source, selected_pixel_density, &image_url, cx);
     }
 
     /// <https://html.spec.whatwg.org/multipage/#update-the-image-data>
-    pub(crate) fn update_the_image_data(&self, can_gc: CanGc) {
+    pub(crate) fn update_the_image_data(&self, cx: &mut js::context::JSContext) {
         // Cancel any outstanding tasks that were queued before.
         self.generation.set(self.generation.get() + 1);
 
@@ -1142,12 +1148,8 @@ impl HTMLImageElement {
 
                     // Step 7.4.2. Abort the image request for the current request and the pending
                     // request.
-                    self.abort_request(
-                        State::CompletelyAvailable,
-                        ImageRequestPhase::Current,
-                        can_gc,
-                    );
-                    self.abort_request(State::Unavailable, ImageRequestPhase::Pending, can_gc);
+                    self.abort_request(State::CompletelyAvailable, ImageRequestPhase::Current, cx);
+                    self.abort_request(State::Unavailable, ImageRequestPhase::Pending, cx);
 
                     // Step 7.4.3. Set the pending request to null.
                     self.image_request.set(ImageRequestPhase::Current);
@@ -1174,7 +1176,7 @@ impl HTMLImageElement {
                     self.owner_global()
                         .task_manager()
                         .dom_manipulation_task_source()
-                        .queue(task!(image_load_event: move || {
+                        .queue(task!(image_load_event: move |cx| {
                             let this = this.root();
 
                             // TODO Step 7.4.7.1. If restart animation is set, then restart the
@@ -1191,7 +1193,7 @@ impl HTMLImageElement {
                             // Step 7.4.7.3. If maybe omit events is not set or previousURL is not
                             // equal to urlString, then fire an event named load at the img element.
                             // TODO: Add missing `maybe omit events` flag and previousURL.
-                            this.upcast::<EventTarget>().fire_event(atom!("load"), CanGc::note());
+                            this.upcast::<EventTarget>().fire_event(atom!("load"), CanGc::from_cx(cx));
                         }));
 
                     // Step 7.4.8. Abort the update the image data algorithm.
@@ -1222,7 +1224,11 @@ impl HTMLImageElement {
     }
 
     /// <https://html.spec.whatwg.org/multipage/#img-environment-changes>
-    fn react_to_environment_changes_sync_steps(&self, generation: u32, can_gc: CanGc) {
+    fn react_to_environment_changes_sync_steps(
+        &self,
+        generation: u32,
+        cx: &mut js::context::JSContext,
+    ) {
         let document = self.owner_document();
         let has_pending_request = matches!(self.image_request.get(), ImageRequestPhase::Pending);
 
@@ -1281,7 +1287,7 @@ impl HTMLImageElement {
             &mut self.pending_request.borrow_mut(),
             &image_url,
             &selected_source,
-            can_gc,
+            cx,
         );
 
         // Step 15. If the list of available images contains an entry for key, then set image
@@ -1312,7 +1318,7 @@ impl HTMLImageElement {
                     selected_source,
                     generation,
                     selected_pixel_density,
-                    can_gc,
+                    cx,
                 );
                 self.register_image_cache_callback(id, change_type);
             },
@@ -1322,7 +1328,7 @@ impl HTMLImageElement {
                     selected_source,
                     generation,
                     selected_pixel_density,
-                    can_gc,
+                    cx,
                 );
             },
             ImageCacheResult::ReadyForRequest(id) => {
@@ -1428,14 +1434,16 @@ impl HTMLImageElement {
         // and the following steps:
         let this = Trusted::new(self);
 
-        self.owner_global().task_manager().dom_manipulation_task_source().queue(
-            task!(image_load_event: move || {
+        self.owner_global()
+            .task_manager()
+            .dom_manipulation_task_source()
+            .queue(task!(image_load_event: move |cx| {
                 let this = this.root();
 
                 // Step 16.1. If the img element has experienced relevant mutations since this
                 // algorithm started, then set the pending request to null and abort these steps.
                 if this.generation.get() != generation {
-                    this.abort_request(State::Unavailable, ImageRequestPhase::Pending, CanGc::note());
+                    this.abort_request(State::Unavailable, ImageRequestPhase::Pending, cx);
                     this.image_request.set(ImageRequestPhase::Current);
                     return;
                 }
@@ -1460,16 +1468,15 @@ impl HTMLImageElement {
                     mem::swap(&mut *this.current_request.borrow_mut(), &mut *pending_request);
                 }
 
-                this.abort_request(State::Unavailable, ImageRequestPhase::Pending, CanGc::note());
+                this.abort_request(State::Unavailable, ImageRequestPhase::Pending, cx);
                 this.image_request.set(ImageRequestPhase::Current);
 
                 // TODO Step 16.6. Prepare image request for presentation given the img element.
                 this.upcast::<Node>().dirty(NodeDamage::Other);
 
                 // Step 16.7. Fire an event named load at the img element.
-                this.upcast::<EventTarget>().fire_event(atom!("load"), CanGc::note());
-            })
-        );
+                this.upcast::<EventTarget>().fire_event(atom!("load"), CanGc::from_cx(cx));
+            }));
     }
 
     /// <https://html.spec.whatwg.org/multipage/#use-srcset-or-picture>
@@ -1630,7 +1637,7 @@ pub(crate) enum ImageElementMicrotask {
 }
 
 impl MicrotaskRunnable for ImageElementMicrotask {
-    fn handler(&self, can_gc: CanGc) {
+    fn handler(&self, cx: &mut js::context::JSContext) {
         match *self {
             ImageElementMicrotask::UpdateImageData {
                 ref elem,
@@ -1640,29 +1647,29 @@ impl MicrotaskRunnable for ImageElementMicrotask {
                 // Step 9. If another instance of this algorithm for this img element was started
                 // after this instance (even if it aborted and is no longer running), then return.
                 if elem.generation.get() == *generation {
-                    elem.update_the_image_data_sync_steps(can_gc);
+                    elem.update_the_image_data_sync_steps(cx);
                 }
             },
             ImageElementMicrotask::EnvironmentChanges {
                 ref elem,
                 ref generation,
             } => {
-                elem.react_to_environment_changes_sync_steps(*generation, can_gc);
+                elem.react_to_environment_changes_sync_steps(*generation, cx);
             },
             ImageElementMicrotask::Decode {
                 ref elem,
                 ref promise,
             } => {
-                elem.react_to_decode_image_sync_steps(promise.clone(), can_gc);
+                elem.react_to_decode_image_sync_steps(promise.clone(), CanGc::from_cx(cx));
             },
         }
     }
 
-    fn enter_realm(&self) -> JSAutoRealm {
+    fn enter_realm<'cx>(&self, cx: &'cx mut js::context::JSContext) -> AutoRealm<'cx> {
         match self {
             &ImageElementMicrotask::UpdateImageData { ref elem, .. } |
             &ImageElementMicrotask::EnvironmentChanges { ref elem, .. } |
-            &ImageElementMicrotask::Decode { ref elem, .. } => enter_realm(&**elem),
+            &ImageElementMicrotask::Decode { ref elem, .. } => enter_auto_realm(cx, &**elem),
         }
     }
 }
@@ -1989,15 +1996,23 @@ impl VirtualMethods for HTMLImageElement {
         Some(self.upcast::<HTMLElement>() as &dyn VirtualMethods)
     }
 
-    fn adopting_steps(&self, old_doc: &Document, can_gc: CanGc) {
-        self.super_type().unwrap().adopting_steps(old_doc, can_gc);
-        self.update_the_image_data(can_gc);
-    }
-
-    fn attribute_mutated(&self, attr: &Attr, mutation: AttributeMutation, can_gc: CanGc) {
+    #[expect(unsafe_code)]
+    fn adopting_steps(&self, old_doc: &Document, _can_gc: CanGc) {
+        let mut cx = unsafe { temp_cx() };
+        let cx = &mut cx;
         self.super_type()
             .unwrap()
-            .attribute_mutated(attr, mutation, can_gc);
+            .adopting_steps(old_doc, CanGc::from_cx(cx));
+        self.update_the_image_data(cx);
+    }
+
+    #[expect(unsafe_code)]
+    fn attribute_mutated(&self, attr: &Attr, mutation: AttributeMutation, _can_gc: CanGc) {
+        let mut cx = unsafe { temp_cx() };
+        let cx = &mut cx;
+        self.super_type()
+            .unwrap()
+            .attribute_mutated(attr, mutation, CanGc::from_cx(cx));
         match attr.local_name() {
             &local_name!("src") |
             &local_name!("srcset") |
@@ -2006,7 +2021,7 @@ impl VirtualMethods for HTMLImageElement {
                 // <https://html.spec.whatwg.org/multipage/#reacting-to-dom-mutations>
                 // The element's src, srcset, width, or sizes attributes are set, changed, or
                 // removed.
-                self.update_the_image_data(can_gc);
+                self.update_the_image_data(cx);
             },
             &local_name!("crossorigin") => {
                 // <https://html.spec.whatwg.org/multipage/#reacting-to-dom-mutations>
@@ -2023,7 +2038,7 @@ impl VirtualMethods for HTMLImageElement {
                 };
 
                 if cross_origin_state_changed {
-                    self.update_the_image_data(can_gc);
+                    self.update_the_image_data(cx);
                 }
             },
             &local_name!("referrerpolicy") => {
@@ -2039,7 +2054,7 @@ impl VirtualMethods for HTMLImageElement {
                 };
 
                 if referrer_policy_state_changed {
-                    self.update_the_image_data(can_gc);
+                    self.update_the_image_data(cx);
                 }
             },
             _ => {},
@@ -2107,10 +2122,13 @@ impl VirtualMethods for HTMLImageElement {
         }
     }
 
+    #[expect(unsafe_code)]
     /// <https://html.spec.whatwg.org/multipage/#the-img-element:html-element-insertion-steps>
-    fn bind_to_tree(&self, context: &BindContext, can_gc: CanGc) {
+    fn bind_to_tree(&self, context: &BindContext, _can_gc: CanGc) {
+        let mut cx = unsafe { temp_cx() };
+        let cx = &mut cx;
         if let Some(s) = self.super_type() {
-            s.bind_to_tree(context, can_gc);
+            s.bind_to_tree(context, CanGc::from_cx(cx));
         }
         let document = self.owner_document();
         if context.tree_connected {
@@ -2122,20 +2140,25 @@ impl VirtualMethods for HTMLImageElement {
         // Step 1. If insertedNode's parent is a picture element, then, count this as a relevant
         // mutation for insertedNode.
         if parent.is::<HTMLPictureElement>() && std::ptr::eq(&*parent, context.parent) {
-            self.update_the_image_data(can_gc);
+            self.update_the_image_data(cx);
         }
     }
 
+    #[expect(unsafe_code)]
     /// <https://html.spec.whatwg.org/multipage/#the-img-element:html-element-removing-steps>
-    fn unbind_from_tree(&self, context: &UnbindContext, can_gc: CanGc) {
-        self.super_type().unwrap().unbind_from_tree(context, can_gc);
+    fn unbind_from_tree(&self, context: &UnbindContext, _can_gc: CanGc) {
+        let mut cx = unsafe { temp_cx() };
+        let cx = &mut cx;
+        self.super_type()
+            .unwrap()
+            .unbind_from_tree(context, CanGc::from_cx(cx));
         let document = self.owner_document();
         document.unregister_responsive_image(self);
 
         // Step 1. If oldParent is a picture element, then, count this as a relevant mutation for
         // removedNode.
         if context.parent.is::<HTMLPictureElement>() && !self.upcast::<Node>().has_parent() {
-            self.update_the_image_data(can_gc);
+            self.update_the_image_data(cx);
         }
     }
 }

--- a/components/script/dom/html/htmlimageelement.rs
+++ b/components/script/dom/html/htmlimageelement.rs
@@ -2008,6 +2008,7 @@ impl VirtualMethods for HTMLImageElement {
 
     #[expect(unsafe_code)]
     fn attribute_mutated(&self, attr: &Attr, mutation: AttributeMutation, _can_gc: CanGc) {
+        // TODO: https://github.com/servo/servo/issues/42812
         let mut cx = unsafe { temp_cx() };
         let cx = &mut cx;
         self.super_type()
@@ -2125,6 +2126,7 @@ impl VirtualMethods for HTMLImageElement {
     #[expect(unsafe_code)]
     /// <https://html.spec.whatwg.org/multipage/#the-img-element:html-element-insertion-steps>
     fn bind_to_tree(&self, context: &BindContext, _can_gc: CanGc) {
+        // TODO: https://github.com/servo/servo/issues/42838
         let mut cx = unsafe { temp_cx() };
         let cx = &mut cx;
         if let Some(s) = self.super_type() {
@@ -2147,6 +2149,7 @@ impl VirtualMethods for HTMLImageElement {
     #[expect(unsafe_code)]
     /// <https://html.spec.whatwg.org/multipage/#the-img-element:html-element-removing-steps>
     fn unbind_from_tree(&self, context: &UnbindContext, _can_gc: CanGc) {
+        // TODO: https://github.com/servo/servo/issues/42837
         let mut cx = unsafe { temp_cx() };
         let cx = &mut cx;
         self.super_type()

--- a/components/script/dom/html/htmllinkelement.rs
+++ b/components/script/dom/html/htmllinkelement.rs
@@ -755,7 +755,7 @@ impl HTMLLinkElement {
         let trusted_node = Trusted::new(self);
         let window = self.owner_window();
         let request_generation_id = self.get_request_generation_id();
-        window.register_image_cache_listener(id, move |response| {
+        window.register_image_cache_listener(id, move |response, _| {
             let trusted_node = trusted_node.clone();
             let link_element = trusted_node.root();
             let window = link_element.owner_window();

--- a/components/script/dom/html/htmlmediaelement.rs
+++ b/components/script/dom/html/htmlmediaelement.rs
@@ -3374,6 +3374,7 @@ impl VirtualMethods for HTMLMediaElement {
 
     #[expect(unsafe_code)]
     fn attribute_mutated(&self, attr: &Attr, mutation: AttributeMutation, _can_gc: CanGc) {
+        // TODO: https://github.com/servo/servo/issues/42812
         let mut cx = unsafe { temp_cx() };
         let cx = &mut cx;
         self.super_type()
@@ -3716,6 +3717,7 @@ impl FetchResponseListener for HTMLMediaElementFetchListener {
 
     #[expect(unsafe_code)]
     fn process_response(&mut self, _: RequestId, metadata: Result<FetchMetadata, NetworkError>) {
+        // TODO: https://github.com/servo/servo/issues/42840
         let mut cx = unsafe { temp_cx() };
         let cx = &mut cx;
         let element = self.element.root();

--- a/components/script/dom/html/htmlmediaelement.rs
+++ b/components/script/dom/html/htmlmediaelement.rs
@@ -21,8 +21,7 @@ use http::StatusCode;
 use http::header::{self, HeaderMap, HeaderValue};
 use ipc_channel::ipc::{self};
 use ipc_channel::router::ROUTER;
-use js::jsapi::JSAutoRealm;
-use js::realm::CurrentRealm;
+use js::realm::{AutoRealm, CurrentRealm};
 use layout_api::MediaFrame;
 use media::{GLPlayerMsg, GLPlayerMsgForward, WindowGLContext};
 use net_traits::request::{Destination, RequestId};
@@ -35,6 +34,7 @@ use script_bindings::codegen::InheritTypes::{
     ElementTypeId, HTMLElementTypeId, HTMLMediaElementTypeId, NodeTypeId,
 };
 use script_bindings::root::assert_in_script;
+use script_bindings::script_runtime::temp_cx;
 use script_bindings::weakref::WeakRef;
 use servo_config::pref;
 use servo_media::player::audio::AudioRenderer;
@@ -105,7 +105,7 @@ use crate::dom::virtualmethods::VirtualMethods;
 use crate::fetch::{FetchCanceller, RequestWithGlobalScope, create_a_potential_cors_request};
 use crate::microtask::{Microtask, MicrotaskRunnable};
 use crate::network_listener::{self, FetchResponseListener, ResourceTimingListener};
-use crate::realms::enter_realm;
+use crate::realms::enter_auto_realm;
 use crate::script_runtime::CanGc;
 use crate::script_thread::ScriptThread;
 use crate::task_source::SendableTaskSource;
@@ -735,12 +735,12 @@ impl HTMLMediaElement {
     /// we pass true to that method again.
     ///
     /// <https://html.spec.whatwg.org/multipage/#delaying-the-load-event-flag>
-    pub(crate) fn delay_load_event(&self, delay: bool, can_gc: CanGc) {
+    pub(crate) fn delay_load_event(&self, delay: bool, cx: &mut js::context::JSContext) {
         let blocker = &self.delaying_the_load_event_flag;
         if delay && blocker.borrow().is_none() {
             *blocker.borrow_mut() = Some(LoadBlocker::new(&self.owner_document(), LoadType::Media));
         } else if !delay && blocker.borrow().is_some() {
-            LoadBlocker::terminate(blocker, can_gc);
+            LoadBlocker::terminate(blocker, cx);
         }
     }
 
@@ -759,11 +759,11 @@ impl HTMLMediaElement {
     }
 
     /// <https://html.spec.whatwg.org/multipage/#internal-play-steps>
-    fn internal_play_steps(&self, can_gc: CanGc) {
+    fn internal_play_steps(&self, cx: &mut js::context::JSContext) {
         // Step 1. If the media element's networkState attribute has the value NETWORK_EMPTY, invoke
         // the media element's resource selection algorithm.
         if self.network_state.get() == NetworkState::Empty {
-            self.invoke_resource_selection_algorithm(can_gc);
+            self.invoke_resource_selection_algorithm(cx);
         }
 
         // Step 2. If the playback has ended and the direction of playback is forwards, seek to the
@@ -962,17 +962,17 @@ impl HTMLMediaElement {
                     self.owner_global()
                         .task_manager()
                         .media_element_task_source()
-                        .queue(task!(media_reached_current_data: move || {
+                        .queue(task!(media_reached_current_data: move |cx| {
                             let this = this.root();
                             if generation_id != this.generation_id.get() {
                                 return;
                             }
 
-                            this.upcast::<EventTarget>().fire_event(atom!("loadeddata"), CanGc::note());
+                            this.upcast::<EventTarget>().fire_event(atom!("loadeddata"), CanGc::from_cx(cx));
                             // Once the readyState attribute reaches HAVE_CURRENT_DATA, after the
                             // loadeddata event has been fired, set the element's
                             // delaying-the-load-event flag to false.
-                            this.delay_load_event(false, CanGc::note());
+                            this.delay_load_event(false, cx);
                         }));
                 }
 
@@ -1039,7 +1039,7 @@ impl HTMLMediaElement {
     }
 
     /// <https://html.spec.whatwg.org/multipage/#concept-media-load-algorithm>
-    fn invoke_resource_selection_algorithm(&self, can_gc: CanGc) {
+    fn invoke_resource_selection_algorithm(&self, cx: &mut js::context::JSContext) {
         // Step 1. Set the element's networkState attribute to the NETWORK_NO_SOURCE value.
         self.network_state.set(NetworkState::NoSource);
 
@@ -1048,7 +1048,7 @@ impl HTMLMediaElement {
 
         // Step 3. Set the media element's delaying-the-load-event flag to true (this delays the
         // load event).
-        self.delay_load_event(true, can_gc);
+        self.delay_load_event(true, cx);
 
         // Step 4. Await a stable state, allowing the task that invoked this algorithm to continue.
         // If the resource selection mode in the synchronous section is
@@ -1070,7 +1070,11 @@ impl HTMLMediaElement {
     }
 
     /// <https://html.spec.whatwg.org/multipage/#concept-media-load-algorithm>
-    fn resource_selection_algorithm_sync(&self, base_url: ServoUrl, can_gc: CanGc) {
+    fn resource_selection_algorithm_sync(
+        &self,
+        base_url: ServoUrl,
+        cx: &mut js::context::JSContext,
+    ) {
         // TODO Step 5. If the media element's blocked-on-parser flag is false, then populate the
         // list of pending text tracks.
         // FIXME(ferjm): Implement blocked_on_parser logic
@@ -1113,7 +1117,7 @@ impl HTMLMediaElement {
 
             // Step 6.none.2. Set the element's delaying-the-load-event flag to false. This stops
             // delaying the load event.
-            self.delay_load_event(false, can_gc);
+            self.delay_load_event(false, cx);
 
             // Step 6.none.3. End the synchronous section and return.
             return;
@@ -1273,14 +1277,14 @@ impl HTMLMediaElement {
         self.owner_global()
             .task_manager()
             .media_element_task_source()
-            .queue(task!(queue_error_event: move || {
+            .queue(task!(queue_error_event: move |cx| {
                 let this = trusted_this.root();
                 if generation_id != this.generation_id.get() {
                     return;
                 }
 
                 let source = trusted_source.root();
-                source.upcast::<EventTarget>().fire_event(atom!("error"), CanGc::note());
+                source.upcast::<EventTarget>().fire_event(atom!("error"), CanGc::from_cx(cx));
             }));
 
         // Step 9.children.11. Await a stable state.
@@ -1365,13 +1369,13 @@ impl HTMLMediaElement {
         self.owner_global()
             .task_manager()
             .media_element_task_source()
-            .queue(task!(queue_delay_load_event: move || {
+            .queue(task!(queue_delay_load_event: move |cx| {
                 let this = this.root();
                 if generation_id != this.generation_id.get() {
                     return;
                 }
 
-                this.delay_load_event(false, CanGc::note());
+                this.delay_load_event(false, cx);
             }));
 
         // Step 9.children.22. Wait until the node after pointer is a node other than the end of the
@@ -1533,13 +1537,13 @@ impl HTMLMediaElement {
                     self.owner_global()
                         .task_manager()
                         .media_element_task_source()
-                        .queue(task!(queue_delay_load_event: move || {
+                        .queue(task!(queue_delay_load_event: move |cx| {
                             let this = this.root();
                             if generation_id != this.generation_id.get() {
                                 return;
                             }
 
-                            this.delay_load_event(false, CanGc::note());
+                            this.delay_load_event(false, cx);
                         }));
 
                     // TODO Steps 5.remote.1.4. Wait for the task to be run.
@@ -1600,7 +1604,7 @@ impl HTMLMediaElement {
         self.owner_global()
             .task_manager()
             .media_element_task_source()
-            .queue(task!(dedicated_media_source_failure_steps: move || {
+            .queue(task!(dedicated_media_source_failure_steps: move |cx| {
                 let this = this.root();
                 if generation_id != this.generation_id.get() {
                     return;
@@ -1611,11 +1615,11 @@ impl HTMLMediaElement {
                     // MEDIA_ERR_SRC_NOT_SUPPORTED.
                     this.error.set(Some(&*MediaError::new(
                         &this.owner_window(),
-                        MEDIA_ERR_SRC_NOT_SUPPORTED, CanGc::note())));
+                        MEDIA_ERR_SRC_NOT_SUPPORTED, CanGc::from_cx(cx))));
 
                     // Step 2. Forget the media element's media-resource-specific tracks.
-                    this.AudioTracks(CanGc::note()).clear();
-                    this.VideoTracks(CanGc::note()).clear();
+                    this.AudioTracks(CanGc::from_cx(cx)).clear();
+                    this.VideoTracks(CanGc::from_cx(cx)).clear();
 
                     // Step 3. Set the element's networkState attribute to the NETWORK_NO_SOURCE
                     // value.
@@ -1625,7 +1629,7 @@ impl HTMLMediaElement {
                     this.show_poster.set(true);
 
                     // Step 5. Fire an event named error at the media element.
-                    this.upcast::<EventTarget>().fire_event(atom!("error"), CanGc::note());
+                    this.upcast::<EventTarget>().fire_event(atom!("error"), CanGc::from_cx(cx));
 
                     if let Some(ref player) = *this.player.borrow() {
                         if let Err(error) = player.lock().unwrap().stop() {
@@ -1640,7 +1644,7 @@ impl HTMLMediaElement {
 
                 // Step 7. Set the element's delaying-the-load-event flag to false. This stops
                 // delaying the load event.
-                this.delay_load_event(false, CanGc::note());
+                this.delay_load_event(false, cx);
             }));
     }
 
@@ -1678,7 +1682,7 @@ impl HTMLMediaElement {
     }
 
     /// <https://html.spec.whatwg.org/multipage/#media-element-load-algorithm>
-    fn media_element_load_algorithm(&self, can_gc: CanGc) {
+    fn media_element_load_algorithm(&self, cx: &mut js::context::JSContext) {
         // Reset the flag that signals whether loadeddata was ever fired for
         // this invokation of the load algorithm.
         self.fired_loadeddata_event.set(false);
@@ -1735,8 +1739,8 @@ impl HTMLMediaElement {
             // object, then detach it.
 
             // Step 7.4. Forget the media element's media-resource-specific tracks.
-            self.AudioTracks(can_gc).clear();
-            self.VideoTracks(can_gc).clear();
+            self.AudioTracks(CanGc::from_cx(cx)).clear();
+            self.VideoTracks(CanGc::from_cx(cx)).clear();
 
             // Step 7.5. If readyState is not set to HAVE_NOTHING, then set it to that state.
             if self.ready_state.get() != ReadyState::HaveNothing {
@@ -1783,7 +1787,7 @@ impl HTMLMediaElement {
         self.autoplaying.set(true);
 
         // Step 10. Invoke the media element's resource selection algorithm.
-        self.invoke_resource_selection_algorithm(can_gc);
+        self.invoke_resource_selection_algorithm(cx);
 
         // Step 11. Note: Playback of any previously playing media resource for this element stops.
     }
@@ -1797,13 +1801,13 @@ impl HTMLMediaElement {
         self.owner_global()
             .task_manager()
             .media_element_task_source()
-            .queue(task!(queue_event: move || {
+            .queue(task!(queue_event: move |cx| {
                 let this = this.root();
                 if generation_id != this.generation_id.get() {
                     return;
                 }
 
-                this.upcast::<EventTarget>().fire_event(name, CanGc::note());
+                this.upcast::<EventTarget>().fire_event(name, CanGc::from_cx(cx));
             }));
     }
 
@@ -1857,7 +1861,11 @@ impl HTMLMediaElement {
         }
     }
 
-    pub(crate) fn handle_source_child_insertion(&self, source: &HTMLSourceElement, can_gc: CanGc) {
+    pub(crate) fn handle_source_child_insertion(
+        &self,
+        source: &HTMLSourceElement,
+        cx: &mut js::context::JSContext,
+    ) {
         // <https://html.spec.whatwg.org/multipage/#the-source-element:html-element-insertion-steps>
         // Step 2. If parent is a media element that has no src attribute and whose networkState has
         // the value NETWORK_EMPTY, then invoke that media element's resource selection algorithm.
@@ -1866,7 +1874,7 @@ impl HTMLMediaElement {
         }
 
         if self.network_state.get() == NetworkState::Empty {
-            self.invoke_resource_selection_algorithm(can_gc);
+            self.invoke_resource_selection_algorithm(cx);
             return;
         }
 
@@ -1892,16 +1900,16 @@ impl HTMLMediaElement {
     }
 
     /// <https://html.spec.whatwg.org/multipage/#concept-media-load-algorithm>
-    fn select_next_source_child_after_wait(&self, can_gc: CanGc) {
+    fn select_next_source_child_after_wait(&self, cx: &mut js::context::JSContext) {
         // Step 9.children.24. Set the element's delaying-the-load-event flag back to true (this
         // delays the load event again, in case it hasn't been fired yet).
-        self.delay_load_event(true, can_gc);
+        self.delay_load_event(true, cx);
 
         // Step 9.children.25. Set the networkState back to NETWORK_LOADING.
         self.network_state.set(NetworkState::Loading);
 
         // Step 9.children.26. Jump back to the find next candidate step above.
-        self.select_next_source_child(can_gc);
+        self.select_next_source_child(CanGc::from_cx(cx));
     }
 
     /// <https://html.spec.whatwg.org/multipage/#media-data-processing-steps-list>
@@ -1921,7 +1929,7 @@ impl HTMLMediaElement {
     /// <https://html.spec.whatwg.org/multipage/#media-data-processing-steps-list>
     /// => "If the connection is interrupted after some media data has been received..."
     /// => "If the media data is corrupted"
-    fn media_data_processing_fatal_steps(&self, error: u16, can_gc: CanGc) {
+    fn media_data_processing_fatal_steps(&self, error: u16, cx: &mut js::context::JSContext) {
         *self.source_children_pointer.borrow_mut() = None;
         self.current_source_child.set(None);
 
@@ -1932,19 +1940,22 @@ impl HTMLMediaElement {
 
         // Step 2. Set the error attribute to the result of creating a MediaError with
         // MEDIA_ERR_NETWORK/MEDIA_ERR_DECODE.
-        self.error
-            .set(Some(&*MediaError::new(&self.owner_window(), error, can_gc)));
+        self.error.set(Some(&*MediaError::new(
+            &self.owner_window(),
+            error,
+            CanGc::from_cx(cx),
+        )));
 
         // Step 3. Set the element's networkState attribute to the NETWORK_IDLE value.
         self.network_state.set(NetworkState::Idle);
 
         // Step 4. Set the element's delaying-the-load-event flag to false. This stops delaying
         // the load event.
-        self.delay_load_event(false, can_gc);
+        self.delay_load_event(false, cx);
 
         // Step 5. Fire an event named error at the media element.
         self.upcast::<EventTarget>()
-            .fire_event(atom!("error"), can_gc);
+            .fire_event(atom!("error"), CanGc::from_cx(cx));
 
         // Step 6. Abort the overall resource selection algorithm.
     }
@@ -2155,14 +2166,14 @@ impl HTMLMediaElement {
                 let event = message.unwrap();
                 let weak_event_handler = weak_event_handler.clone();
 
-                task_source.queue(task!(handle_player_event: move || {
+                task_source.queue(task!(handle_player_event: move |cx| {
                     trace!("HTMLMediaElement event: {event:?}");
 
                     let Some(event_handler) = weak_event_handler.upgrade() else {
                         return;
                     };
 
-                    event_handler.lock().unwrap().handle_player_event(player_id, event, CanGc::note());
+                    event_handler.lock().unwrap().handle_player_event(player_id, event, cx);
                 }));
             }),
         );
@@ -2336,7 +2347,7 @@ impl HTMLMediaElement {
         }
     }
 
-    fn playback_error(&self, error: &str, can_gc: CanGc) {
+    fn playback_error(&self, error: &str, cx: &mut js::context::JSContext) {
         error!("Player error: {:?}", error);
 
         // If we have already flagged an error condition while processing
@@ -2353,7 +2364,7 @@ impl HTMLMediaElement {
             self.media_data_processing_failure_steps();
         } else {
             // => "If the media data is corrupted"
-            self.media_data_processing_fatal_steps(MEDIA_ERR_DECODE, can_gc);
+            self.media_data_processing_fatal_steps(MEDIA_ERR_DECODE, cx);
         }
     }
 
@@ -2897,7 +2908,7 @@ impl HTMLMediaElement {
     pub(crate) fn set_audio_renderer(
         &self,
         audio_renderer: Option<Arc<Mutex<dyn AudioRenderer>>>,
-        can_gc: CanGc,
+        cx: &mut js::context::JSContext,
     ) {
         *self.audio_renderer.borrow_mut() = audio_renderer;
 
@@ -2913,7 +2924,7 @@ impl HTMLMediaElement {
         };
 
         if had_player {
-            self.media_element_load_algorithm(can_gc);
+            self.media_element_load_algorithm(cx);
         }
     }
 
@@ -3040,7 +3051,7 @@ impl HTMLMediaElementMethods<crate::DomTypeHolder> for HTMLMediaElement {
     /// <https://html.spec.whatwg.org/multipage/#dom-media-srcobject>
     fn SetSrcObject(&self, cx: &mut js::context::JSContext, value: Option<MediaStreamOrBlob>) {
         *self.src_object.borrow_mut() = value.map(|value| value.into());
-        self.media_element_load_algorithm(CanGc::from_cx(cx));
+        self.media_element_load_algorithm(cx);
     }
 
     // https://html.spec.whatwg.org/multipage/#attr-media-preload
@@ -3063,7 +3074,7 @@ impl HTMLMediaElementMethods<crate::DomTypeHolder> for HTMLMediaElement {
 
     /// <https://html.spec.whatwg.org/multipage/#dom-media-load>
     fn Load(&self, cx: &mut js::context::JSContext) {
-        self.media_element_load_algorithm(CanGc::from_cx(cx));
+        self.media_element_load_algorithm(cx);
     }
 
     /// <https://html.spec.whatwg.org/multipage/#dom-navigator-canplaytype>
@@ -3104,7 +3115,7 @@ impl HTMLMediaElementMethods<crate::DomTypeHolder> for HTMLMediaElement {
         self.push_pending_play_promise(&promise);
 
         // Step 4. Run the internal play steps for the media element.
-        self.internal_play_steps(CanGc::from_cx(cx));
+        self.internal_play_steps(cx);
 
         // Step 5. Return promise.
         promise
@@ -3115,7 +3126,7 @@ impl HTMLMediaElementMethods<crate::DomTypeHolder> for HTMLMediaElement {
         // Step 1. If the media element's networkState attribute has the value NETWORK_EMPTY, invoke
         // the media element's resource selection algorithm.
         if self.network_state.get() == NetworkState::Empty {
-            self.invoke_resource_selection_algorithm(CanGc::from_cx(cx));
+            self.invoke_resource_selection_algorithm(cx);
         }
 
         // Step 2. Run the internal pause steps for the media element.
@@ -3361,10 +3372,13 @@ impl VirtualMethods for HTMLMediaElement {
         Some(self.upcast::<HTMLElement>() as &dyn VirtualMethods)
     }
 
-    fn attribute_mutated(&self, attr: &Attr, mutation: AttributeMutation, can_gc: CanGc) {
+    #[expect(unsafe_code)]
+    fn attribute_mutated(&self, attr: &Attr, mutation: AttributeMutation, _can_gc: CanGc) {
+        let mut cx = unsafe { temp_cx() };
+        let cx = &mut cx;
         self.super_type()
             .unwrap()
-            .attribute_mutated(attr, mutation, can_gc);
+            .attribute_mutated(attr, mutation, CanGc::from_cx(cx));
 
         match *attr.local_name() {
             local_name!("muted") => {
@@ -3385,12 +3399,12 @@ impl VirtualMethods for HTMLMediaElement {
                 // the media element's media element load algorithm (Removing the src attribute does
                 // not do this, even if there are source elements present).
                 if !mutation.is_removal() {
-                    self.media_element_load_algorithm(can_gc);
+                    self.media_element_load_algorithm(cx);
                 }
             },
             local_name!("controls") => {
                 if mutation.new_value(attr).is_some() {
-                    self.render_controls(can_gc);
+                    self.render_controls(CanGc::from_cx(cx));
                 } else {
                     self.remove_controls();
                 }
@@ -3458,7 +3472,7 @@ pub(crate) enum MediaElementMicrotask {
 }
 
 impl MicrotaskRunnable for MediaElementMicrotask {
-    fn handler(&self, can_gc: CanGc) {
+    fn handler(&self, cx: &mut js::context::JSContext) {
         match self {
             &MediaElementMicrotask::ResourceSelection {
                 ref elem,
@@ -3466,7 +3480,7 @@ impl MicrotaskRunnable for MediaElementMicrotask {
                 ref base_url,
             } => {
                 if generation_id == elem.generation_id.get() {
-                    elem.resource_selection_algorithm_sync(base_url.clone(), can_gc);
+                    elem.resource_selection_algorithm_sync(base_url.clone(), cx);
                 }
             },
             MediaElementMicrotask::PauseIfNotInDocument { elem } => {
@@ -3487,7 +3501,7 @@ impl MicrotaskRunnable for MediaElementMicrotask {
                 generation_id,
             } => {
                 if generation_id == elem.generation_id.get() {
-                    elem.select_next_source_child(can_gc);
+                    elem.select_next_source_child(CanGc::from_cx(cx));
                 }
             },
             &MediaElementMicrotask::SelectNextSourceChildAfterWait {
@@ -3495,20 +3509,20 @@ impl MicrotaskRunnable for MediaElementMicrotask {
                 generation_id,
             } => {
                 if generation_id == elem.generation_id.get() {
-                    elem.select_next_source_child_after_wait(can_gc);
+                    elem.select_next_source_child_after_wait(cx);
                 }
             },
         }
     }
 
-    fn enter_realm(&self) -> JSAutoRealm {
+    fn enter_realm<'cx>(&self, cx: &'cx mut js::context::JSContext) -> AutoRealm<'cx> {
         match self {
             &MediaElementMicrotask::ResourceSelection { ref elem, .. } |
             &MediaElementMicrotask::PauseIfNotInDocument { ref elem } |
             &MediaElementMicrotask::Seeked { ref elem, .. } |
             &MediaElementMicrotask::SelectNextSourceChild { ref elem, .. } |
             &MediaElementMicrotask::SelectNextSourceChildAfterWait { ref elem, .. } => {
-                enter_realm(&**elem)
+                enter_auto_realm(cx, &**elem)
             },
         }
     }
@@ -3700,7 +3714,10 @@ impl FetchResponseListener for HTMLMediaElementFetchListener {
 
     fn process_request_eof(&mut self, _: RequestId) {}
 
+    #[expect(unsafe_code)]
     fn process_response(&mut self, _: RequestId, metadata: Result<FetchMetadata, NetworkError>) {
+        let mut cx = unsafe { temp_cx() };
+        let cx = &mut cx;
         let element = self.element.root();
 
         let (metadata, origin_clean) = match metadata {
@@ -3730,7 +3747,7 @@ impl FetchResponseListener for HTMLMediaElementFetchListener {
                 element.media_data_processing_failure_steps();
             } else {
                 // => "If the connection is interrupted after some media data has been received..."
-                element.media_data_processing_fatal_steps(MEDIA_ERR_NETWORK, CanGc::note());
+                element.media_data_processing_fatal_steps(MEDIA_ERR_NETWORK, cx);
             }
             return;
         }
@@ -3891,7 +3908,7 @@ impl FetchResponseListener for HTMLMediaElementFetchListener {
                 .fire_event(atom!("suspend"), CanGc::from_cx(cx));
         } else if status.is_err() && element.ready_state.get() != ReadyState::HaveNothing {
             // => "If the connection is interrupted after some media data has been received..."
-            element.media_data_processing_fatal_steps(MEDIA_ERR_NETWORK, CanGc::from_cx(cx));
+            element.media_data_processing_fatal_steps(MEDIA_ERR_NETWORK, cx);
         } else {
             // => "If the media data can be fetched but is found by inspection to be in an
             // unsupported format, or can otherwise not be rendered at all"
@@ -3984,7 +4001,12 @@ impl HTMLMediaElementEventHandler {
         }
     }
 
-    fn handle_player_event(&self, player_id: usize, event: PlayerEvent, can_gc: CanGc) {
+    fn handle_player_event(
+        &self,
+        player_id: usize,
+        event: PlayerEvent,
+        cx: &mut js::context::JSContext,
+    ) {
         let Some(element) = self.element.root() else {
             return;
         };
@@ -3998,9 +4020,9 @@ impl HTMLMediaElementEventHandler {
             PlayerEvent::DurationChanged(duration) => element.playback_duration_changed(duration),
             PlayerEvent::EndOfStream => element.playback_end(),
             PlayerEvent::EnoughData => element.playback_enough_data(),
-            PlayerEvent::Error(ref error) => element.playback_error(error, can_gc),
+            PlayerEvent::Error(ref error) => element.playback_error(error, cx),
             PlayerEvent::MetadataUpdated(ref metadata) => {
-                element.playback_metadata_updated(metadata, can_gc)
+                element.playback_metadata_updated(metadata, CanGc::from_cx(cx))
             },
             PlayerEvent::NeedData => element.playback_need_data(),
             PlayerEvent::PositionChanged(position) => element.playback_position_changed(position),

--- a/components/script/dom/html/htmlsourceelement.rs
+++ b/components/script/dom/html/htmlsourceelement.rs
@@ -5,6 +5,7 @@
 use dom_struct::dom_struct;
 use html5ever::{LocalName, Prefix, local_name};
 use js::rust::HandleObject;
+use script_bindings::script_runtime::temp_cx;
 use style::attr::AttrValue;
 
 use crate::dom::attr::Attr;
@@ -66,6 +67,18 @@ impl HTMLSourceElement {
             }
         }
     }
+
+    fn iterate_next_html_image_element_siblings_with_cx(
+        cx: &mut js::context::JSContext,
+        next_siblings_iterator: impl Iterator<Item = Root<Dom<Node>>>,
+        callback: impl Fn(&mut js::context::JSContext, &HTMLImageElement),
+    ) {
+        for next_sibling in next_siblings_iterator {
+            if let Some(html_image_element_sibling) = next_sibling.downcast::<HTMLImageElement>() {
+                callback(cx, html_image_element_sibling);
+            }
+        }
+    }
 }
 
 impl VirtualMethods for HTMLSourceElement {
@@ -73,10 +86,13 @@ impl VirtualMethods for HTMLSourceElement {
         Some(self.upcast::<HTMLElement>() as &dyn VirtualMethods)
     }
 
-    fn attribute_mutated(&self, attr: &Attr, mutation: AttributeMutation, can_gc: CanGc) {
+    #[expect(unsafe_code)]
+    fn attribute_mutated(&self, attr: &Attr, mutation: AttributeMutation, _can_gc: CanGc) {
+        let mut cx = unsafe { temp_cx() };
+        let cx = &mut cx;
         self.super_type()
             .unwrap()
-            .attribute_mutated(attr, mutation, can_gc);
+            .attribute_mutated(attr, mutation, CanGc::from_cx(cx));
 
         match attr.local_name() {
             &local_name!("srcset") |
@@ -89,9 +105,10 @@ impl VirtualMethods for HTMLSourceElement {
                 if let Some(parent) = self.upcast::<Node>().GetParentElement() {
                     if parent.is::<HTMLPictureElement>() {
                         let next_sibling_iterator = self.upcast::<Node>().following_siblings();
-                        HTMLSourceElement::iterate_next_html_image_element_siblings(
+                        HTMLSourceElement::iterate_next_html_image_element_siblings_with_cx(
+                            cx,
                             next_sibling_iterator,
-                            |image| image.update_the_image_data(can_gc),
+                            |cx, image| image.update_the_image_data(cx),
                         );
                     }
                 }
@@ -127,9 +144,14 @@ impl VirtualMethods for HTMLSourceElement {
         }
     }
 
+    #[expect(unsafe_code)]
     /// <https://html.spec.whatwg.org/multipage/#the-source-element:html-element-insertion-steps>
-    fn bind_to_tree(&self, context: &BindContext, can_gc: CanGc) {
-        self.super_type().unwrap().bind_to_tree(context, can_gc);
+    fn bind_to_tree(&self, context: &BindContext, _can_gc: CanGc) {
+        let mut cx = unsafe { temp_cx() };
+        let cx = &mut cx;
+        self.super_type()
+            .unwrap()
+            .bind_to_tree(context, CanGc::from_cx(cx));
 
         // Step 1. Let parent be insertedNode's parent.
         let parent = self.upcast::<Node>().GetParentNode().unwrap();
@@ -140,32 +162,39 @@ impl VirtualMethods for HTMLSourceElement {
             parent
                 .downcast::<HTMLMediaElement>()
                 .unwrap()
-                .handle_source_child_insertion(self, can_gc);
+                .handle_source_child_insertion(self, cx);
         }
 
         // Step 3. If parent is a picture element, then for each child of parent's children, if
         // child is an img element, then count this as a relevant mutation for child.
         if parent.is::<HTMLPictureElement>() && std::ptr::eq(&*parent, context.parent) {
             let next_sibling_iterator = self.upcast::<Node>().following_siblings();
-            HTMLSourceElement::iterate_next_html_image_element_siblings(
+            HTMLSourceElement::iterate_next_html_image_element_siblings_with_cx(
+                cx,
                 next_sibling_iterator,
-                |image| image.update_the_image_data(can_gc),
+                |cx, image| image.update_the_image_data(cx),
             );
         }
     }
 
+    #[expect(unsafe_code)]
     /// <https://html.spec.whatwg.org/multipage/#the-source-element:html-element-removing-steps>
-    fn unbind_from_tree(&self, context: &UnbindContext, can_gc: CanGc) {
-        self.super_type().unwrap().unbind_from_tree(context, can_gc);
+    fn unbind_from_tree(&self, context: &UnbindContext, _can_gc: CanGc) {
+        let mut cx = unsafe { temp_cx() };
+        let cx = &mut cx;
+        self.super_type()
+            .unwrap()
+            .unbind_from_tree(context, CanGc::from_cx(cx));
 
         // Step 1. If oldParent is a picture element, then for each child of oldParent's children,
         // if child is an img element, then count this as a relevant mutation for child.
         if context.parent.is::<HTMLPictureElement>() && !self.upcast::<Node>().has_parent() {
             if let Some(next_sibling) = context.next_sibling {
                 let next_sibling_iterator = next_sibling.inclusively_following_siblings();
-                HTMLSourceElement::iterate_next_html_image_element_siblings(
+                HTMLSourceElement::iterate_next_html_image_element_siblings_with_cx(
+                    cx,
                     next_sibling_iterator,
-                    |image| image.update_the_image_data(can_gc),
+                    |cx, image| image.update_the_image_data(cx),
                 );
             }
         }

--- a/components/script/dom/html/htmlsourceelement.rs
+++ b/components/script/dom/html/htmlsourceelement.rs
@@ -88,6 +88,7 @@ impl VirtualMethods for HTMLSourceElement {
 
     #[expect(unsafe_code)]
     fn attribute_mutated(&self, attr: &Attr, mutation: AttributeMutation, _can_gc: CanGc) {
+        // TODO: https://github.com/servo/servo/issues/42812
         let mut cx = unsafe { temp_cx() };
         let cx = &mut cx;
         self.super_type()
@@ -147,6 +148,7 @@ impl VirtualMethods for HTMLSourceElement {
     #[expect(unsafe_code)]
     /// <https://html.spec.whatwg.org/multipage/#the-source-element:html-element-insertion-steps>
     fn bind_to_tree(&self, context: &BindContext, _can_gc: CanGc) {
+        // TODO: https://github.com/servo/servo/issues/42838
         let mut cx = unsafe { temp_cx() };
         let cx = &mut cx;
         self.super_type()
@@ -180,6 +182,7 @@ impl VirtualMethods for HTMLSourceElement {
     #[expect(unsafe_code)]
     /// <https://html.spec.whatwg.org/multipage/#the-source-element:html-element-removing-steps>
     fn unbind_from_tree(&self, context: &UnbindContext, _can_gc: CanGc) {
+        // TODO: https://github.com/servo/servo/issues/42837
         let mut cx = unsafe { temp_cx() };
         let cx = &mut cx;
         self.super_type()

--- a/components/script/dom/html/htmlvideoelement.rs
+++ b/components/script/dom/html/htmlvideoelement.rs
@@ -19,6 +19,7 @@ use net_traits::{
     CoreResourceThread, FetchMetadata, FetchResponseMsg, NetworkError, ResourceFetchTiming,
 };
 use pixels::{Snapshot, SnapshotAlphaMode, SnapshotPixelFormat};
+use script_bindings::script_runtime::temp_cx;
 use servo_media::player::video::VideoFrame;
 use servo_url::ServoUrl;
 use style::attr::{AttrValue, LengthOrPercentageOrAuto};
@@ -148,7 +149,7 @@ impl HTMLVideoElement {
     }
 
     /// <https://html.spec.whatwg.org/multipage/#poster-frame>
-    fn update_poster_frame(&self, poster_url: Option<&str>, can_gc: CanGc) {
+    fn update_poster_frame(&self, poster_url: Option<&str>, cx: &mut js::context::JSContext) {
         // Step 1. If there is an existing instance of this algorithm running
         // for this video element, abort that instance of this algorithm without
         // changing the poster frame.
@@ -189,16 +190,16 @@ impl HTMLVideoElement {
                 url,
                 ..
             }) => {
-                self.process_image_response(ImageResponse::Loaded(image, url), can_gc);
+                self.process_image_response(ImageResponse::Loaded(image, url), cx);
                 return;
             },
             ImageCacheResult::Available(ImageOrMetadataAvailable::MetadataAvailable(_, id)) => id,
             ImageCacheResult::ReadyForRequest(id) => {
-                self.do_fetch_poster_frame(poster_url, id, can_gc);
+                self.do_fetch_poster_frame(poster_url, id, cx);
                 id
             },
             ImageCacheResult::FailedToLoadOrDecode => {
-                self.process_image_response(ImageResponse::FailedToLoadOrDecode, can_gc);
+                self.process_image_response(ImageResponse::FailedToLoadOrDecode, cx);
                 return;
             },
             ImageCacheResult::Pending(id) => id,
@@ -206,21 +207,26 @@ impl HTMLVideoElement {
 
         let trusted_node = Trusted::new(self);
         let generation = self.generation_id();
-        let callback = window.register_image_cache_listener(id, move |response| {
+        let callback = window.register_image_cache_listener(id, move |response, cx| {
             let element = trusted_node.root();
 
             // Ignore any image response for a previous request that has been discarded.
             if generation != element.generation_id() {
                 return;
             }
-            element.process_image_response(response.response, CanGc::note());
+            element.process_image_response(response.response, cx);
         });
 
         image_cache.add_listener(ImageLoadListener::new(callback, window.pipeline_id(), id));
     }
 
     /// <https://html.spec.whatwg.org/multipage/#poster-frame>
-    fn do_fetch_poster_frame(&self, poster_url: ServoUrl, id: PendingImageId, can_gc: CanGc) {
+    fn do_fetch_poster_frame(
+        &self,
+        poster_url: ServoUrl,
+        id: PendingImageId,
+        cx: &mut js::context::JSContext,
+    ) {
         // Step 5. Let request be a new request whose URL is url, client is the element's node
         // document's relevant settings object, destination is "image", initiator type is "video",
         // credentials mode is "include", and whose use-URL-credentials flag is set.
@@ -243,7 +249,7 @@ impl HTMLVideoElement {
         // (which triggers no media load algorithm unless a explicit call to .load() is done)
         // will block the document's load event forever.
         let blocker = &self.load_blocker;
-        LoadBlocker::terminate(blocker, can_gc);
+        LoadBlocker::terminate(blocker, cx);
         *blocker.borrow_mut() = Some(LoadBlocker::new(
             &self.owner_document(),
             LoadType::Image(poster_url.clone()),
@@ -264,7 +270,7 @@ impl HTMLVideoElement {
     }
 
     /// <https://html.spec.whatwg.org/multipage/#poster-frame>
-    fn process_image_response(&self, response: ImageResponse, can_gc: CanGc) {
+    fn process_image_response(&self, response: ImageResponse, cx: &mut js::context::JSContext) {
         // Step 7. If an image is thus obtained, the poster frame is that image.
         // Otherwise, there is no poster frame.
         match response {
@@ -274,14 +280,14 @@ impl HTMLVideoElement {
                     Some(image) => self.htmlmediaelement.set_poster_frame(Some(image)),
                     None => warn!("Vector images are not yet supported in video poster"),
                 }
-                LoadBlocker::terminate(&self.load_blocker, can_gc);
+                LoadBlocker::terminate(&self.load_blocker, cx);
             },
             ImageResponse::MetadataLoaded(..) => {},
             // The image cache may have loaded a placeholder for an invalid poster url
             ImageResponse::FailedToLoadOrDecode => {
                 self.htmlmediaelement.set_poster_frame(None);
                 // A failed load should unblock the document load.
-                LoadBlocker::terminate(&self.load_blocker, can_gc);
+                LoadBlocker::terminate(&self.load_blocker, cx);
             },
         }
     }
@@ -348,16 +354,19 @@ impl VirtualMethods for HTMLVideoElement {
         Some(self.upcast::<HTMLMediaElement>() as &dyn VirtualMethods)
     }
 
-    fn attribute_mutated(&self, attr: &Attr, mutation: AttributeMutation, can_gc: CanGc) {
+    #[expect(unsafe_code)]
+    fn attribute_mutated(&self, attr: &Attr, mutation: AttributeMutation, _can_gc: CanGc) {
+        let mut cx = unsafe { temp_cx() };
+        let cx = &mut cx;
         self.super_type()
             .unwrap()
-            .attribute_mutated(attr, mutation, can_gc);
+            .attribute_mutated(attr, mutation, CanGc::from_cx(cx));
 
         if attr.local_name() == &local_name!("poster") {
             if let Some(new_value) = mutation.new_value(attr) {
-                self.update_poster_frame(Some(&new_value), CanGc::note())
+                self.update_poster_frame(Some(&new_value), cx)
             } else {
-                self.update_poster_frame(None, CanGc::note())
+                self.update_poster_frame(None, cx)
             }
         };
     }

--- a/components/script/dom/html/htmlvideoelement.rs
+++ b/components/script/dom/html/htmlvideoelement.rs
@@ -356,6 +356,7 @@ impl VirtualMethods for HTMLVideoElement {
 
     #[expect(unsafe_code)]
     fn attribute_mutated(&self, attr: &Attr, mutation: AttributeMutation, _can_gc: CanGc) {
+        // TODO: https://github.com/servo/servo/issues/42812
         let mut cx = unsafe { temp_cx() };
         let cx = &mut cx;
         self.super_type()

--- a/components/script/dom/node.rs
+++ b/components/script/dom/node.rs
@@ -345,26 +345,26 @@ impl Node {
         target: &Node,
         context_element: &Element,
         html: DOMString,
-        can_gc: CanGc,
+        cx: &mut js::context::JSContext,
     ) {
         // Step 1. Let newChildren be the result of the HTML fragment parsing algorithm.
-        let new_children = ServoParser::parse_html_fragment(context_element, html, true, can_gc);
+        let new_children = ServoParser::parse_html_fragment(context_element, html, true, cx);
 
         // Step 2. Let fragment be a new DocumentFragment whose node document is contextElement's node document.
 
         let context_document = context_element.owner_document();
-        let fragment = DocumentFragment::new(&context_document, can_gc);
+        let fragment = DocumentFragment::new(&context_document, CanGc::from_cx(cx));
 
         // Step 3. For each node in newChildren, append node to fragment.
         for child in new_children {
             fragment
                 .upcast::<Node>()
-                .AppendChild(&child, can_gc)
+                .AppendChild(&child, CanGc::from_cx(cx))
                 .unwrap();
         }
 
         // Step 4. Replace all with fragment within target.
-        Node::replace_all(Some(fragment.upcast()), target, can_gc);
+        Node::replace_all(Some(fragment.upcast()), target, CanGc::from_cx(cx));
     }
 
     /// Clear this [`Node`]'s layout data and also clear the layout data of all children.

--- a/components/script/dom/promise.rs
+++ b/components/script/dom/promise.rs
@@ -43,7 +43,7 @@ use crate::dom::bindings::settings_stack::AutoEntryScript;
 use crate::dom::globalscope::GlobalScope;
 use crate::dom::promisenativehandler::{Callback, PromiseNativeHandler};
 use crate::microtask::{Microtask, MicrotaskRunnable};
-use crate::realms::{AlreadyInRealm, InRealm, enter_realm};
+use crate::realms::{AlreadyInRealm, InRealm, enter_auto_realm, enter_realm};
 use crate::script_runtime::{CanGc, JSContext as SafeJSContext};
 use crate::script_thread::ScriptThread;
 
@@ -525,12 +525,12 @@ pub(crate) struct WaitForAllSuccessStepsMicrotask {
 }
 
 impl MicrotaskRunnable for WaitForAllSuccessStepsMicrotask {
-    fn handler(&self, _can_gc: CanGc) {
+    fn handler(&self, _cx: &mut JSContext) {
         (self.success_steps)(vec![]);
     }
 
-    fn enter_realm(&self) -> JSAutoRealm {
-        enter_realm(&*self.global)
+    fn enter_realm<'cx>(&self, cx: &'cx mut JSContext) -> AutoRealm<'cx> {
+        enter_auto_realm(cx, &*self.global)
     }
 }
 

--- a/components/script/dom/range.rs
+++ b/components/script/dom/range.rs
@@ -1149,7 +1149,7 @@ impl RangeMethods<crate::DomTypeHolder> for Range {
             Element::fragment_parsing_context(&owner_doc, element.as_deref(), CanGc::from_cx(cx));
 
         // Step 7. Let fragment node be the result of invoking the fragment parsing algorithm steps with element and compliantString.
-        let fragment_node = element.parse_fragment(fragment, CanGc::from_cx(cx))?;
+        let fragment_node = element.parse_fragment(fragment, cx)?;
 
         // Step 8. For each script of fragment node's script element descendants:
         for node in fragment_node

--- a/components/script/dom/servoparser/mod.rs
+++ b/components/script/dom/servoparser/mod.rs
@@ -1231,6 +1231,7 @@ impl FetchResponseListener for ParserContext {
 
     #[expect(unsafe_code)]
     fn process_response(&mut self, _: RequestId, meta_result: Result<FetchMetadata, NetworkError>) {
+        // TODO: https://github.com/servo/servo/issues/42840
         let mut cx = unsafe { temp_cx() };
         let cx = &mut cx;
         let (metadata, error) = match meta_result {
@@ -1385,6 +1386,7 @@ impl FetchResponseListener for ParserContext {
 
     #[expect(unsafe_code)]
     fn process_response_chunk(&mut self, _: RequestId, payload: Vec<u8>) {
+        // TODO: https://github.com/servo/servo/issues/42841
         let mut cx = unsafe { temp_cx() };
         let cx = &mut cx;
         if self.is_synthesized_document {
@@ -1604,7 +1606,7 @@ impl TreeSink for Sink {
         attrs: Vec<Attribute>,
         flags: ElementFlags,
     ) -> Dom<Node> {
-        // We need to add ability to pass custom data to trait calls.
+        // TODO: https://github.com/servo/servo/issues/42839
         let mut cx = unsafe { temp_cx() };
         let cx = &mut cx;
         let attrs = attrs

--- a/components/script/dom/servoparser/mod.rs
+++ b/components/script/dom/servoparser/mod.rs
@@ -33,6 +33,7 @@ use profile_traits::time::{
     ProfilerCategory, ProfilerChan, TimerMetadata, TimerMetadataFrameType, TimerMetadataReflowType,
 };
 use profile_traits::time_profile;
+use script_bindings::script_runtime::temp_cx;
 use script_traits::DocumentActivity;
 use servo_config::pref;
 use servo_url::ServoUrl;
@@ -84,7 +85,7 @@ use crate::dom::text::Text;
 use crate::dom::types::{HTMLElement, HTMLMediaElement, HTMLOptionElement};
 use crate::dom::virtualmethods::vtable_for;
 use crate::network_listener::FetchResponseListener;
-use crate::realms::enter_realm;
+use crate::realms::{enter_auto_realm, enter_realm};
 use crate::script_runtime::{CanGc, IntroductionType};
 use crate::script_thread::ScriptThread;
 
@@ -183,7 +184,7 @@ impl ServoParser {
         url: ServoUrl,
         encoding_hint_from_content_type: Option<&'static Encoding>,
         encoding_of_container_document: Option<&'static Encoding>,
-        can_gc: CanGc,
+        cx: &mut js::context::JSContext,
     ) {
         // Step 1. Set document's type to "html".
         //
@@ -198,7 +199,7 @@ impl ServoParser {
                 ParserKind::Normal,
                 encoding_hint_from_content_type,
                 encoding_of_container_document,
-                can_gc,
+                CanGc::from_cx(cx),
             )
         } else {
             ServoParser::new(
@@ -212,7 +213,7 @@ impl ServoParser {
                 ParserKind::Normal,
                 encoding_hint_from_content_type,
                 encoding_of_container_document,
-                can_gc,
+                CanGc::from_cx(cx),
             )
         };
         // Step 3. Place html into the input stream for parser. The encoding confidence is irrelevant.
@@ -221,19 +222,19 @@ impl ServoParser {
         //
         // Set as the document's current parser and initialize with `input`, if given.
         if let Some(input) = input {
-            parser.parse_complete_string_chunk(String::from(input), can_gc);
+            parser.parse_complete_string_chunk(String::from(input), cx);
         } else {
             parser.document.set_current_parser(Some(&parser));
         }
     }
 
     /// <https://html.spec.whatwg.org/multipage/#parsing-html-fragments>
-    pub(crate) fn parse_html_fragment(
-        context: &Element,
+    pub(crate) fn parse_html_fragment<'el>(
+        context: &'el Element,
         input: DOMString,
         allow_declarative_shadow_roots: bool,
-        can_gc: CanGc,
-    ) -> impl Iterator<Item = DomRoot<Node>> + use<'_> {
+        cx: &mut js::context::JSContext,
+    ) -> impl Iterator<Item = DomRoot<Node>> + use<'el> {
         let context_node = context.upcast::<Node>();
         let context_document = context_node.owner_doc();
         let window = context_document.window();
@@ -265,7 +266,7 @@ impl ServoParser {
             context_document.has_trustworthy_ancestor_or_current_origin(),
             context_document.custom_element_reaction_stack(),
             context_document.creation_sandboxing_flag_set(),
-            can_gc,
+            CanGc::from_cx(cx),
         );
 
         // Step 2. If context's node document is in quirks mode, then set document's mode to "quirks".
@@ -300,9 +301,9 @@ impl ServoParser {
             ParserKind::Normal,
             None,
             None,
-            can_gc,
+            CanGc::from_cx(cx),
         );
-        parser.parse_complete_string_chunk(String::from(input), can_gc);
+        parser.parse_complete_string_chunk(String::from(input), cx);
 
         // Step 14.
         let root_element = document.GetDocumentElement().expect("no document element");
@@ -333,7 +334,7 @@ impl ServoParser {
         input: Option<DOMString>,
         url: ServoUrl,
         encoding_hint_from_content_type: Option<&'static Encoding>,
-        can_gc: CanGc,
+        cx: &mut js::context::JSContext,
     ) {
         let parser = ServoParser::new(
             document,
@@ -341,12 +342,12 @@ impl ServoParser {
             ParserKind::Normal,
             encoding_hint_from_content_type,
             None,
-            can_gc,
+            CanGc::from_cx(cx),
         );
 
         // Set as the document's current parser and initialize with `input`, if given.
         if let Some(input) = input {
-            parser.parse_complete_string_chunk(String::from(input), can_gc);
+            parser.parse_complete_string_chunk(String::from(input), cx);
         } else {
             parser.document.set_current_parser(Some(&parser));
         }
@@ -378,7 +379,7 @@ impl ServoParser {
         &self,
         script: &HTMLScriptElement,
         result: ScriptResult,
-        can_gc: CanGc,
+        cx: &mut js::context::JSContext,
     ) {
         assert!(self.suspended.get());
         self.suspended.set(false);
@@ -392,11 +393,11 @@ impl ServoParser {
         assert_eq!(script_nesting_level, 0);
 
         self.script_nesting_level.set(script_nesting_level + 1);
-        script.execute(result, can_gc);
+        script.execute(result, CanGc::from_cx(cx));
         self.script_nesting_level.set(script_nesting_level);
 
         if !self.suspended.get() && !self.aborted.get() {
-            self.parse_sync(can_gc);
+            self.parse_sync(cx);
         }
     }
 
@@ -405,7 +406,7 @@ impl ServoParser {
     }
 
     /// Steps 6-8 of <https://html.spec.whatwg.org/multipage/#document.write()>
-    pub(crate) fn write(&self, text: DOMString, can_gc: CanGc) {
+    pub(crate) fn write(&self, text: DOMString, cx: &mut js::context::JSContext) {
         assert!(self.can_write());
 
         if self.document.has_pending_parsing_blocking_script() {
@@ -436,15 +437,10 @@ impl ServoParser {
             incremental: TimerMetadataReflowType::FirstReflow,
         };
         self.tokenize(
-            |tokenizer| {
-                tokenizer.feed(
-                    &input,
-                    can_gc,
-                    profiler_chan.clone(),
-                    profiler_metadata.clone(),
-                )
+            |cx, tokenizer| {
+                tokenizer.feed(&input, cx, profiler_chan.clone(), profiler_metadata.clone())
             },
-            can_gc,
+            cx,
         );
 
         if self.suspended.get() {
@@ -461,7 +457,7 @@ impl ServoParser {
     }
 
     // Steps 4-6 of https://html.spec.whatwg.org/multipage/#dom-document-close
-    pub(crate) fn close(&self, can_gc: CanGc) {
+    pub(crate) fn close(&self, cx: &mut js::context::JSContext) {
         assert!(self.script_created_parser);
 
         // Step 4.
@@ -473,11 +469,11 @@ impl ServoParser {
         }
 
         // Step 6.
-        self.parse_sync(can_gc);
+        self.parse_sync(cx);
     }
 
     // https://html.spec.whatwg.org/multipage/#abort-a-parser
-    pub(crate) fn abort(&self, can_gc: CanGc) {
+    pub(crate) fn abort(&self, cx: &mut js::context::JSContext) {
         assert!(!self.aborted.get());
         self.aborted.set(true);
 
@@ -487,15 +483,15 @@ impl ServoParser {
 
         // Step 2.
         self.document
-            .set_ready_state(DocumentReadyState::Interactive, can_gc);
+            .set_ready_state(DocumentReadyState::Interactive, CanGc::from_cx(cx));
 
         // Step 3.
-        self.tokenizer.end(can_gc);
+        self.tokenizer.end(cx);
         self.document.set_current_parser(None);
 
         // Step 4.
         self.document
-            .set_ready_state(DocumentReadyState::Complete, can_gc);
+            .set_ready_state(DocumentReadyState::Complete, CanGc::from_cx(cx));
     }
 
     // https://html.spec.whatwg.org/multipage/#active-parser
@@ -631,7 +627,7 @@ impl ServoParser {
         self.push_tendril_input_chunk(chunk);
     }
 
-    fn parse_sync(&self, can_gc: CanGc) {
+    fn parse_sync(&self, cx: &mut js::context::JSContext) {
         assert!(self.script_input.is_empty());
 
         // This parser will continue to parse while there is either pending input or
@@ -660,15 +656,15 @@ impl ServoParser {
             incremental: TimerMetadataReflowType::FirstReflow,
         };
         self.tokenize(
-            |tokenizer| {
+            |cx, tokenizer| {
                 tokenizer.feed(
                     &self.network_input,
-                    can_gc,
+                    cx,
                     profiler_chan.clone(),
                     profiler_metadata.clone(),
                 )
             },
-            can_gc,
+            cx,
         );
 
         if self.suspended.get() {
@@ -678,38 +674,41 @@ impl ServoParser {
         assert!(self.network_input.is_empty());
 
         if self.last_chunk_received.get() {
-            self.finish(can_gc);
+            self.finish(cx);
         }
     }
 
-    fn parse_complete_string_chunk(&self, input: String, can_gc: CanGc) {
+    fn parse_complete_string_chunk(&self, input: String, cx: &mut js::context::JSContext) {
         self.document.set_current_parser(Some(self));
         self.push_string_input_chunk(input);
         self.last_chunk_received.set(true);
         if !self.suspended.get() {
-            self.parse_sync(can_gc);
+            self.parse_sync(cx);
         }
     }
 
-    fn parse_bytes_chunk(&self, input: Vec<u8>, can_gc: CanGc) {
+    fn parse_bytes_chunk(&self, input: Vec<u8>, cx: &mut js::context::JSContext) {
         let _realm = enter_realm(&*self.document);
         self.document.set_current_parser(Some(self));
         self.push_bytes_input_chunk(input);
         if !self.suspended.get() {
-            self.parse_sync(can_gc);
+            self.parse_sync(cx);
         }
     }
 
-    fn tokenize<F>(&self, feed: F, can_gc: CanGc)
+    fn tokenize<F>(&self, feed: F, cx: &mut js::context::JSContext)
     where
-        F: Fn(&Tokenizer) -> TokenizerResult<DomRoot<HTMLScriptElement>>,
+        F: Fn(
+            &mut js::context::JSContext,
+            &Tokenizer,
+        ) -> TokenizerResult<DomRoot<HTMLScriptElement>>,
     {
         loop {
             assert!(!self.suspended.get());
             assert!(!self.aborted.get());
 
             self.document.window().reflow_if_reflow_timer_expired();
-            let script = match feed(&self.tokenizer) {
+            let script = match feed(cx, &self.tokenizer) {
                 TokenizerResult::Done => return,
                 TokenizerResult::EncodingIndicator(_) => continue,
                 TokenizerResult::Script(script) => script,
@@ -722,9 +721,7 @@ impl ServoParser {
             // possible with the way servo and html5ever currently
             // relate to each other, and hopefully it is not observable.
             if is_execution_stack_empty() {
-                self.document
-                    .window()
-                    .perform_a_microtask_checkpoint(can_gc);
+                self.document.window().perform_a_microtask_checkpoint(cx);
             }
 
             let script_nesting_level = self.script_nesting_level.get();
@@ -733,7 +730,7 @@ impl ServoParser {
             script.set_initial_script_text();
             let introduction_type_override =
                 (script_nesting_level > 0).then_some(IntroductionType::INJECTED_SCRIPT);
-            script.prepare(introduction_type_override, can_gc);
+            script.prepare(introduction_type_override, CanGc::from_cx(cx));
             self.script_nesting_level.set(script_nesting_level);
 
             if self.document.has_pending_parsing_blocking_script() {
@@ -747,7 +744,7 @@ impl ServoParser {
     }
 
     /// <https://html.spec.whatwg.org/multipage/#the-end>
-    fn finish(&self, can_gc: CanGc) {
+    fn finish(&self, cx: &mut js::context::JSContext) {
         assert!(!self.suspended.get());
         assert!(self.last_chunk_received.get());
         assert!(self.script_input.is_empty());
@@ -756,15 +753,15 @@ impl ServoParser {
 
         // Step 1.
         self.document
-            .set_ready_state(DocumentReadyState::Interactive, can_gc);
+            .set_ready_state(DocumentReadyState::Interactive, CanGc::from_cx(cx));
 
         // Step 2.
-        self.tokenizer.end(can_gc);
+        self.tokenizer.end(cx);
         self.document.set_current_parser(None);
 
         // Steps 3-12 are in another castle, namely finish_load.
         let url = self.tokenizer.url().clone();
-        self.document.finish_load(LoadType::PageSource(url), can_gc);
+        self.document.finish_load(LoadType::PageSource(url), cx);
 
         // Send the source contents to devtools, if needed.
         if let Some(content_for_devtools) = self
@@ -825,7 +822,7 @@ impl Tokenizer {
     fn feed(
         &self,
         input: &BufferQueue,
-        can_gc: CanGc,
+        cx: &mut js::context::JSContext,
         profiler_chan: ProfilerChan,
         profiler_metadata: TimerMetadata,
     ) -> TokenizerResult<DomRoot<HTMLScriptElement>> {
@@ -840,7 +837,7 @@ impl Tokenizer {
                 ProfilerCategory::ScriptParseHTML,
                 Some(profiler_metadata),
                 profiler_chan,
-                || tokenizer.feed(input, can_gc),
+                || tokenizer.feed(input, cx),
             ),
             Tokenizer::Xml(ref tokenizer) => time_profile!(
                 ProfilerCategory::ScriptParseXML,
@@ -851,10 +848,10 @@ impl Tokenizer {
         }
     }
 
-    fn end(&self, can_gc: CanGc) {
+    fn end(&self, cx: &mut js::context::JSContext) {
         match *self {
             Tokenizer::Html(ref tokenizer) => tokenizer.end(),
-            Tokenizer::AsyncHtml(ref tokenizer) => tokenizer.end(can_gc),
+            Tokenizer::AsyncHtml(ref tokenizer) => tokenizer.end(cx),
             Tokenizer::Xml(ref tokenizer) => tokenizer.end(),
         }
     }
@@ -1014,7 +1011,7 @@ impl ParserContext {
     }
 
     /// <https://html.spec.whatwg.org/multipage/#loading-a-document>
-    fn load_document(&mut self, can_gc: CanGc) {
+    fn load_document(&mut self, cx: &mut js::context::JSContext) {
         assert!(!self.has_loaded_document);
         self.has_loaded_document = true;
         let Some(ref parser) = self.parser.as_ref().map(|p| p.root()) else {
@@ -1037,7 +1034,7 @@ impl ParserContext {
                 "<html><body><p>Unknown content type ({}).</p></body></html>",
                 &mime_type,
             );
-            self.load_inline_unknown_content(parser, page);
+            self.load_inline_unknown_content(parser, page, cx);
             return;
         };
         match media_type {
@@ -1047,11 +1044,11 @@ impl ParserContext {
             MediaType::Xml => self.load_xml_document(parser),
             // Return the result of loading a text document given navigationParams and type.
             MediaType::JavaScript | MediaType::Json | MediaType::Text | MediaType::Css => {
-                self.load_text_document(parser)
+                self.load_text_document(parser, cx)
             },
             // Return the result of loading a media document given navigationParams and type.
             MediaType::Image | MediaType::AudioVideo => {
-                self.load_media_document(parser, media_type, &mime_type);
+                self.load_media_document(parser, media_type, &mime_type, cx);
                 return;
             },
             MediaType::Font => {
@@ -1059,14 +1056,14 @@ impl ParserContext {
                     "<html><body><p>Unable to load font with content type ({}).</p></body></html>",
                     &mime_type,
                 );
-                self.load_inline_unknown_content(parser, page);
+                self.load_inline_unknown_content(parser, page, cx);
                 return;
             },
         };
 
         parser.parse_bytes_chunk(
             std::mem::take(&mut self.navigation_params.resource_header),
-            can_gc,
+            cx,
         );
     }
 
@@ -1096,7 +1093,7 @@ impl ParserContext {
     }
 
     /// <https://html.spec.whatwg.org/multipage/#navigate-text>
-    fn load_text_document(&mut self, parser: &ServoParser) {
+    fn load_text_document(&mut self, parser: &ServoParser, cx: &mut js::context::JSContext) {
         // Step 1. Let document be the result of creating and initializing a Document
         // object given "html", type, and navigationParams.
         self.initialize_document_object(&parser.document);
@@ -1108,7 +1105,7 @@ impl ParserContext {
         // the appropriate processing of the input stream.
         let page = "<pre>\n".into();
         parser.push_string_input_chunk(page);
-        parser.parse_sync(CanGc::note());
+        parser.parse_sync(cx);
         parser.tokenizer.set_plaintext_state();
         // The first task that the networking task source places on the task queue while fetching
         // runs must process link headers given document, navigationParams's response, and "media",
@@ -1122,6 +1119,7 @@ impl ParserContext {
         parser: &ServoParser,
         media_type: MediaType,
         mime_type: &Mime,
+        cx: &mut js::context::JSContext,
     ) {
         // Step 1. Let document be the result of creating and initializing a Document
         // object given "html", type, and navigationParams.
@@ -1131,7 +1129,7 @@ impl ParserContext {
         // Step 3. Populate with html/head/body given document.
         let page = "<html><body></body></html>".into();
         parser.push_string_input_chunk(page);
-        parser.parse_sync(CanGc::note());
+        parser.parse_sync(cx);
 
         let doc = &parser.document;
         // Step 5. Set the appropriate attribute of the element host element, as described below,
@@ -1144,7 +1142,7 @@ impl ParserContext {
                 ElementCreator::ParserCreated(1),
                 CustomElementCreationMode::Asynchronous,
                 None,
-                CanGc::note(),
+                CanGc::from_cx(cx),
             );
             let img = DomRoot::downcast::<HTMLImageElement>(img).unwrap();
             img.SetSrc(USVString(self.url.to_string()));
@@ -1157,7 +1155,7 @@ impl ParserContext {
                 ElementCreator::ParserCreated(1),
                 CustomElementCreationMode::Asynchronous,
                 None,
-                CanGc::note(),
+                CanGc::from_cx(cx),
             );
             let audio = DomRoot::downcast::<HTMLMediaElement>(audio).unwrap();
             audio.SetControls(true);
@@ -1171,7 +1169,7 @@ impl ParserContext {
                 ElementCreator::ParserCreated(1),
                 CustomElementCreationMode::Asynchronous,
                 None,
-                CanGc::note(),
+                CanGc::from_cx(cx),
             );
             let video = DomRoot::downcast::<HTMLMediaElement>(video).unwrap();
             video.SetControls(true);
@@ -1181,7 +1179,7 @@ impl ParserContext {
         // Step 4. Append an element host element for the media, as described below, to the body element.
         let doc_body = DomRoot::upcast::<Node>(doc.GetBody().unwrap());
         doc_body
-            .AppendChild(&node, CanGc::note())
+            .AppendChild(&node, CanGc::from_cx(cx))
             .expect("Appending failed");
         // Step 7. Process link headers given document, navigationParams's response, and "media".
         let link_headers = std::mem::take(&mut self.navigation_params.link_headers);
@@ -1189,10 +1187,15 @@ impl ParserContext {
     }
 
     /// <https://html.spec.whatwg.org/multipage/#read-ua-inline>
-    fn load_inline_unknown_content(&mut self, parser: &ServoParser, page: String) {
+    fn load_inline_unknown_content(
+        &mut self,
+        parser: &ServoParser,
+        page: String,
+        cx: &mut js::context::JSContext,
+    ) {
         self.is_synthesized_document = true;
         parser.push_string_input_chunk(page);
-        parser.parse_sync(CanGc::note());
+        parser.parse_sync(cx);
     }
 
     /// Store a PerformanceNavigationTiming entry in the globalscope's Performance buffer
@@ -1226,7 +1229,10 @@ impl FetchResponseListener for ParserContext {
 
     fn process_request_eof(&mut self, _: RequestId) {}
 
+    #[expect(unsafe_code)]
     fn process_response(&mut self, _: RequestId, meta_result: Result<FetchMetadata, NetworkError>) {
+        let mut cx = unsafe { temp_cx() };
+        let cx = &mut cx;
         let (metadata, error) = match meta_result {
             Ok(meta) => (
                 Some(match meta {
@@ -1273,7 +1279,7 @@ impl FetchResponseListener for ParserContext {
             self.webview_id,
             self.pipeline_id,
             metadata,
-            CanGc::note(),
+            cx,
         ) {
             Some(parser) => parser,
             None => return,
@@ -1282,7 +1288,8 @@ impl FetchResponseListener for ParserContext {
             return;
         }
 
-        let _realm = enter_realm(&*parser.document);
+        let mut realm = enter_auto_realm(cx, &*parser.document);
+        let cx = &mut realm;
         let window = parser.document.window();
 
         // From Step 23.8.3 of https://html.spec.whatwg.org/multipage/#navigate
@@ -1372,11 +1379,14 @@ impl FetchResponseListener for ParserContext {
                     return;
                 },
             };
-            self.load_inline_unknown_content(&parser, page);
+            self.load_inline_unknown_content(&parser, page, cx);
         }
     }
 
+    #[expect(unsafe_code)]
     fn process_response_chunk(&mut self, _: RequestId, payload: Vec<u8>) {
+        let mut cx = unsafe { temp_cx() };
+        let cx = &mut cx;
         if self.is_synthesized_document {
             return;
         }
@@ -1393,10 +1403,10 @@ impl FetchResponseListener for ParserContext {
                 .extend_from_slice(&payload);
             // the number of bytes in buffer is greater than or equal to 1445.
             if self.navigation_params.resource_header.len() >= 1445 {
-                self.load_document(CanGc::note());
+                self.load_document(cx);
             }
         } else {
-            parser.parse_bytes_chunk(payload, CanGc::note());
+            parser.parse_bytes_chunk(payload, cx);
         }
     }
 
@@ -1427,10 +1437,11 @@ impl FetchResponseListener for ParserContext {
         //
         // the end of the resource is reached.
         if !self.has_loaded_document {
-            self.load_document(CanGc::from_cx(cx));
+            self.load_document(cx);
         }
 
-        let _realm = enter_realm(&*parser);
+        let mut realm = enter_auto_realm(cx, &*parser);
+        let cx = &mut realm;
 
         if status.is_ok() {
             parser.document.set_redirect_count(timing.redirect_count);
@@ -1438,7 +1449,7 @@ impl FetchResponseListener for ParserContext {
 
         parser.last_chunk_received.set(true);
         if !parser.suspended.get() {
-            parser.parse_sync(CanGc::from_cx(cx));
+            parser.parse_sync(cx);
         }
 
         // TODO: Only update if this is the current document resource.
@@ -1585,6 +1596,7 @@ impl TreeSink for Sink {
         }
     }
 
+    #[expect(unsafe_code)]
     #[cfg_attr(crown, expect(crown::unrooted_must_root))]
     fn create_element(
         &self,
@@ -1592,6 +1604,9 @@ impl TreeSink for Sink {
         attrs: Vec<Attribute>,
         flags: ElementFlags,
     ) -> Dom<Node> {
+        // We need to add ability to pass custom data to trait calls.
+        let mut cx = unsafe { temp_cx() };
+        let cx = &mut cx;
         let attrs = attrs
             .into_iter()
             .map(|attr| ElementAttribute::new(attr.name, DOMString::from(String::from(attr.value))))
@@ -1608,7 +1623,7 @@ impl TreeSink for Sink {
             ElementCreator::ParserCreated(self.current_line.get()),
             parsing_algorithm,
             &self.custom_element_reaction_stack,
-            CanGc::note(),
+            cx,
         );
         Dom::from_ref(element.upcast())
     }
@@ -1832,7 +1847,7 @@ fn create_element_for_token(
     creator: ElementCreator,
     parsing_algorithm: ParsingAlgorithm,
     custom_element_reaction_stack: &CustomElementReactionStack,
-    can_gc: CanGc,
+    cx: &mut js::context::JSContext,
 ) -> DomRoot<Element> {
     // Step 1. If the active speculative HTML parser is not null, then return the result
     // of creating a speculative mock element given namespace, token's tag name, and
@@ -1875,7 +1890,7 @@ fn create_element_for_token(
         // Step 6.2. If the JavaScript execution context stack is empty, then perform a
         // microtask checkpoint.
         if is_execution_stack_empty() {
-            document.window().perform_a_microtask_checkpoint(can_gc);
+            document.window().perform_a_microtask_checkpoint(cx);
         }
         // Step 9.3. Push a new element queue onto document's relevant agent's custom
         // element reactions stack.
@@ -1889,11 +1904,19 @@ fn create_element_for_token(
     } else {
         CustomElementCreationMode::Asynchronous
     };
-    let element = Element::create(name, is, document, creator, creation_mode, None, can_gc);
+    let element = Element::create(
+        name,
+        is,
+        document,
+        creator,
+        creation_mode,
+        None,
+        CanGc::from_cx(cx),
+    );
 
     // Step 11. Append each attribute in the given token to element.
     for attr in attrs {
-        element.set_attribute_from_parser(attr.name, attr.value, None, can_gc);
+        element.set_attribute_from_parser(attr.name, attr.value, None, CanGc::from_cx(cx));
     }
 
     // Step 12. If willExecuteScript is true:
@@ -1902,7 +1925,7 @@ fn create_element_for_token(
         // custom element reactions stack. (This will be the same element queue as was
         // pushed above.)
         // Step 12.2 Invoke custom element reactions in queue.
-        custom_element_reaction_stack.pop_current_element_queue(can_gc);
+        custom_element_reaction_stack.pop_current_element_queue(CanGc::from_cx(cx));
         // Step 12.3. Decrement document's throw-on-dynamic-markup-insertion counter.
         document.decrement_throw_on_dynamic_markup_insertion_counter();
     }
@@ -1918,7 +1941,7 @@ fn create_element_for_token(
     // checkedness based on the element's attributes.)
     if let Some(html_element) = element.downcast::<HTMLElement>() {
         if element.is_resettable() && !html_element.is_form_associated_custom_element() {
-            element.reset(can_gc);
+            element.reset(CanGc::from_cx(cx));
         }
     }
 

--- a/components/script/dom/shadowroot.rs
+++ b/components/script/dom/shadowroot.rs
@@ -509,7 +509,7 @@ impl ShadowRootMethods<crate::DomTypeHolder> for ShadowRoot {
         //
         // NOTE: The spec doesn't strictly tell us to bail out here, but
         // we can't continue if parsing failed
-        let frag = context.parse_fragment(value, CanGc::from_cx(cx))?;
+        let frag = context.parse_fragment(value, cx)?;
 
         // Step 4. Replace all with fragment within this.
         Node::replace_all(Some(frag.upcast()), self.upcast(), CanGc::from_cx(cx));
@@ -540,7 +540,7 @@ impl ShadowRootMethods<crate::DomTypeHolder> for ShadowRoot {
         let target = self.upcast::<Node>();
         let context_element = self.Host();
 
-        Node::unsafely_set_html(target, &context_element, value, CanGc::from_cx(cx));
+        Node::unsafely_set_html(target, &context_element, value, cx);
         Ok(())
     }
 

--- a/components/script/dom/window.rs
+++ b/components/script/dom/window.rs
@@ -79,7 +79,6 @@ use script_bindings::codegen::GenericBindings::WindowBinding::ScrollToOptions;
 use script_bindings::conversions::SafeToJSValConvertible;
 use script_bindings::interfaces::WindowHelpers;
 use script_bindings::root::Root;
-use script_bindings::script_runtime::temp_cx;
 use script_traits::{ConstellationInputEvent, ScriptThreadMessage};
 use selectors::attr::CaseSensitivity;
 use servo_arc::Arc as ServoArc;
@@ -208,7 +207,8 @@ use crate::{fetch, window_named_properties};
 #[derive(MallocSizeOf)]
 pub struct PendingImageCallback(
     #[ignore_malloc_size_of = "dyn Fn is currently impossible to measure"]
-    Box<dyn Fn(PendingImageResponse) + 'static>,
+    #[expect(clippy::type_complexity)]
+    Box<dyn Fn(PendingImageResponse, &mut js::context::JSContext) + 'static>,
 );
 
 /// Current state of the window object
@@ -696,7 +696,7 @@ impl Window {
     pub(crate) fn register_image_cache_listener(
         &self,
         id: PendingImageId,
-        callback: impl Fn(PendingImageResponse) + 'static,
+        callback: impl Fn(PendingImageResponse, &mut js::context::JSContext) + 'static,
     ) -> ImageCacheResponseCallback {
         self.pending_image_callbacks
             .borrow_mut()
@@ -757,7 +757,11 @@ impl Window {
         nodes.remove();
     }
 
-    pub(crate) fn pending_image_notification(&self, response: PendingImageResponse) {
+    pub(crate) fn pending_image_notification(
+        &self,
+        response: PendingImageResponse,
+        cx: &mut js::context::JSContext,
+    ) {
         // We take the images here, in order to prevent maintaining a mutable borrow when
         // image callbacks are called. These, in turn, can trigger garbage collection.
         // Normally this shouldn't trigger more pending image notifications, but just in
@@ -769,7 +773,7 @@ impl Window {
         };
 
         for callback in callbacks.get() {
-            callback.0(response.clone());
+            callback.0(response.clone(), cx);
         }
 
         match response.response {
@@ -829,7 +833,7 @@ impl Window {
     }
 
     /// <https://html.spec.whatwg.org/multipage/#nav-stop>
-    fn stop_loading(&self, can_gc: CanGc) {
+    fn stop_loading(&self, cx: &mut js::context::JSContext) {
         // 1. Let document be navigable's active document.
         let doc = self.Document();
 
@@ -845,11 +849,11 @@ impl Window {
         self.set_ongoing_navigation();
 
         // 3. Abort a document and its descendants given document.
-        doc.abort(can_gc);
+        doc.abort(cx);
     }
 
     /// <https://html.spec.whatwg.org/multipage/#destroy-a-top-level-traversable>
-    fn destroy_top_level_traversable(&self, can_gc: CanGc) {
+    fn destroy_top_level_traversable(&self, cx: &mut js::context::JSContext) {
         // Step 1. Let browsingContext be traversable's active browsing context.
         // TODO
         // Step 2. For each historyEntry in traversable's session history entries:
@@ -857,27 +861,27 @@ impl Window {
         // Step 2.1. Let document be historyEntry's document.
         let document = self.Document();
         // Step 2.2. If document is not null, then destroy a document and its descendants given document.
-        document.destroy_document_and_its_descendants(can_gc);
+        document.destroy_document_and_its_descendants(cx);
         // Step 3-6.
         self.send_to_constellation(ScriptToConstellationMessage::DiscardTopLevelBrowsingContext);
     }
 
     /// <https://html.spec.whatwg.org/multipage/#definitely-close-a-top-level-traversable>
-    fn definitely_close(&self, can_gc: CanGc) {
+    fn definitely_close(&self, cx: &mut js::context::JSContext) {
         let document = self.Document();
         // Step 1. Let toUnload be traversable's active document's inclusive descendant navigables.
         //
         // Implemented by passing `false` into the method below
         // Step 2. If the result of checking if unloading is canceled for toUnload is not "continue", then return.
-        if !document.check_if_unloading_is_cancelled(false, can_gc) {
+        if !document.check_if_unloading_is_cancelled(false, CanGc::from_cx(cx)) {
             return;
         }
         // Step 3. Append the following session history traversal steps to traversable:
         // TODO
         // Step 3.2. Unload a document and its descendants given traversable's active document, null, and afterAllUnloads.
-        document.unload(false, can_gc);
+        document.unload(false, CanGc::from_cx(cx));
         // Step 3.1. Let afterAllUnloads be an algorithm step which destroys traversable.
-        self.destroy_top_level_traversable(can_gc);
+        self.destroy_top_level_traversable(cx);
     }
 
     /// <https://html.spec.whatwg.org/multipage/#cannot-show-simple-dialogs>
@@ -912,8 +916,8 @@ impl Window {
         false
     }
 
-    pub(crate) fn perform_a_microtask_checkpoint(&self, can_gc: CanGc) {
-        self.script_thread().perform_a_microtask_checkpoint(can_gc);
+    pub(crate) fn perform_a_microtask_checkpoint(&self, cx: &mut js::context::JSContext) {
+        self.script_thread().perform_a_microtask_checkpoint(cx);
     }
 
     pub(crate) fn web_font_context(&self) -> WebFontDocumentContext {
@@ -1265,12 +1269,12 @@ impl WindowMethods<crate::DomTypeHolder> for Window {
     }
 
     /// <https://html.spec.whatwg.org/multipage/#dom-window-stop>
-    fn Stop(&self, can_gc: CanGc) {
+    fn Stop(&self, cx: &mut js::context::JSContext) {
         // 1. If this's navigable is null, then return.
         // Note: Servo doesn't have a concept of navigable yet.
 
         // 2. Stop loading this's navigable.
-        self.stop_loading(can_gc);
+        self.stop_loading(cx);
     }
 
     /// <https://html.spec.whatwg.org/multipage/#dom-window-focus>
@@ -1398,9 +1402,9 @@ impl WindowMethods<crate::DomTypeHolder> for Window {
 
                 // Step 6.2. Queue a task on the DOM manipulation task source to definitely close thisTraversable.
                 let this = Trusted::new(self);
-                let task = task!(window_close_browsing_context: move || {
+                let task = task!(window_close_browsing_context: move |cx| {
                     let window = this.root();
-                    window.definitely_close(CanGc::note());
+                    window.definitely_close(cx);
                 });
                 self.as_global_scope()
                     .task_manager()
@@ -3591,7 +3595,7 @@ impl Window {
             let mut images = self.pending_layout_images.borrow_mut();
             if !images.contains_key(&id) {
                 let trusted_node = Trusted::new(&*node);
-                let sender = self.register_image_cache_listener(id, move |response| {
+                let sender = self.register_image_cache_listener(id, move |response, _| {
                     trusted_node
                         .root()
                         .owner_window()
@@ -3696,8 +3700,8 @@ impl Window {
     }
 
     #[allow(clippy::too_many_arguments)]
-    #[expect(unsafe_code)]
     pub(crate) fn new(
+        cx: &mut js::context::JSContext,
         webview_id: WebViewId,
         runtime: Rc<Runtime>,
         script_chan: Sender<MainThreadScriptMsg>,
@@ -3734,7 +3738,6 @@ impl Window {
         theme: Theme,
         weak_script_thread: Weak<ScriptThread>,
     ) -> DomRoot<Self> {
-        let mut cx = unsafe { temp_cx() };
         let error_reporter = CSSErrorReporter {
             pipelineid: pipeline_id,
             script_chan: control_chan,
@@ -3828,7 +3831,7 @@ impl Window {
             last_activation_timestamp: Cell::new(UserActivationTimestamp::PositiveInfinity),
         });
 
-        WindowBinding::Wrap::<crate::DomTypeHolder>(&mut cx, win)
+        WindowBinding::Wrap::<crate::DomTypeHolder>(cx, win)
     }
 
     pub(crate) fn pipeline_id(&self) -> PipelineId {

--- a/components/script/dom/window.rs
+++ b/components/script/dom/window.rs
@@ -1315,12 +1315,7 @@ impl WindowMethods<crate::DomTypeHolder> for Window {
     }
 
     /// <https://html.spec.whatwg.org/multipage/#dom-opener>
-    fn GetOpener(
-        &self,
-        cx: SafeJSContext,
-        in_realm_proof: InRealm,
-        mut retval: MutableHandleValue,
-    ) -> Fallible<()> {
+    fn GetOpener(&self, cx: &mut CurrentRealm, mut retval: MutableHandleValue) -> Fallible<()> {
         // Step 1, Let current be this Window object's browsing context.
         let current = match self.window_proxy.get() {
             Some(proxy) => proxy,
@@ -1339,7 +1334,7 @@ impl WindowMethods<crate::DomTypeHolder> for Window {
             return Ok(());
         }
         // Step 3 to 5.
-        current.opener(*cx, in_realm_proof, retval);
+        current.opener(cx, retval);
         Ok(())
     }
 
@@ -3330,13 +3325,13 @@ impl Window {
         self.unhandled_resize_event.borrow().is_some()
     }
 
-    pub(crate) fn suspend(&self, can_gc: CanGc) {
+    pub(crate) fn suspend(&self, cx: &mut js::context::JSContext) {
         // Suspend timer events.
         self.as_global_scope().suspend();
 
         // Set the window proxy to be a cross-origin window.
         if self.window_proxy().currently_active() == Some(self.global().pipeline_id()) {
-            self.window_proxy().unset_currently_active(can_gc);
+            self.window_proxy().unset_currently_active(cx);
         }
 
         // A hint to the JS runtime that now would be a good time to

--- a/components/script/dom/workers/abstractworkerglobalscope.rs
+++ b/components/script/dom/workers/abstractworkerglobalscope.rs
@@ -13,7 +13,6 @@ use crate::dom::globalscope::GlobalScope;
 use crate::dom::worker::TrustedWorkerAddress;
 use crate::dom::workerglobalscope::WorkerGlobalScope;
 use crate::realms::enter_realm;
-use crate::script_runtime::CanGc;
 use crate::task_queue::{QueuedTaskConversion, TaskQueue};
 
 pub(crate) trait WorkerEventLoopMethods {
@@ -95,7 +94,7 @@ pub(crate) fn run_worker_event_loop<T, WorkerMsg, Event>(
             Some(worker) => worker_scope.handle_worker_post_event(worker),
             None => None,
         };
-        scope.perform_a_microtask_checkpoint(CanGc::from_cx(cx));
+        scope.perform_a_microtask_checkpoint(cx);
     }
     worker_scope
         .upcast::<GlobalScope>()

--- a/components/script/dom/workers/workerglobalscope.rs
+++ b/components/script/dom/workers/workerglobalscope.rs
@@ -399,14 +399,13 @@ impl WorkerGlobalScope {
     }
 
     /// Perform a microtask checkpoint.
-    pub(crate) fn perform_a_microtask_checkpoint(&self, can_gc: CanGc) {
+    pub(crate) fn perform_a_microtask_checkpoint(&self, cx: &mut js::context::JSContext) {
         // Only perform the checkpoint if we're not shutting down.
         if !self.is_closing() {
             self.microtask_queue.checkpoint(
-                GlobalScope::get_cx(),
+                cx,
                 |_| Some(DomRoot::from_ref(&self.globalscope)),
                 vec![DomRoot::from_ref(&self.globalscope)],
-                can_gc,
             );
         }
     }

--- a/components/script/script_module.rs
+++ b/components/script/script_module.rs
@@ -748,7 +748,7 @@ impl FetchResponseListener for ModuleContext {
         if let Some(window) = global.downcast::<Window>() {
             window
                 .Document()
-                .finish_load(LoadType::Script(url.clone()), CanGc::from_cx(cx));
+                .finish_load(LoadType::Script(url.clone()), cx);
         }
 
         network_listener::submit_timing(&self, &response, &timing, CanGc::from_cx(cx));

--- a/components/script/script_thread.rs
+++ b/components/script/script_thread.rs
@@ -1762,7 +1762,7 @@ impl ScriptThread {
             },
             ScriptThreadMessage::GetTitle(pipeline_id) => self.handle_get_title_msg(pipeline_id),
             ScriptThreadMessage::SetDocumentActivity(pipeline_id, activity) => {
-                self.handle_set_document_activity_msg(pipeline_id, activity, CanGc::from_cx(cx))
+                self.handle_set_document_activity_msg(cx, pipeline_id, activity)
             },
             ScriptThreadMessage::SetThrottled(webview_id, pipeline_id, throttled) => {
                 self.handle_set_throttled_msg(webview_id, pipeline_id, throttled)
@@ -1785,6 +1785,7 @@ impl ScriptThread {
                 source_origin,
                 data,
             } => self.handle_post_message_msg(
+                cx,
                 target_pipeline_id,
                 source_webview,
                 source_with_ancestry,
@@ -2779,9 +2780,9 @@ impl ScriptThread {
     /// Handles activity change message
     fn handle_set_document_activity_msg(
         &self,
+        cx: &mut js::context::JSContext,
         id: PipelineId,
         activity: DocumentActivity,
-        can_gc: CanGc,
     ) {
         debug!(
             "Setting activity of {} to be {:?} in {:?}.",
@@ -2791,7 +2792,7 @@ impl ScriptThread {
         );
         let document = self.documents.borrow().find_document(id);
         if let Some(document) = document {
-            document.set_activity(activity, can_gc);
+            document.set_activity(cx, activity);
             return;
         }
         let mut loads = self.incomplete_loads.borrow_mut();
@@ -2887,9 +2888,11 @@ impl ScriptThread {
         }
     }
 
+    #[expect(clippy::too_many_arguments)]
     /// <https://html.spec.whatwg.org/multipage/#window-post-message-steps>
     fn handle_post_message_msg(
         &self,
+        cx: &mut js::context::JSContext,
         pipeline_id: PipelineId,
         source_webview: WebViewId,
         source_with_ancestry: Vec<BrowsingContextId>,
@@ -2908,6 +2911,7 @@ impl ScriptThread {
                         continue;
                     }
                     let window_proxy = WindowProxy::new_dissimilar_origin(
+                        cx,
                         window.upcast::<GlobalScope>(),
                         browsing_context_id,
                         source_webview,
@@ -2971,6 +2975,7 @@ impl ScriptThread {
             // Ensure that the state of any local window proxies accurately reflects
             // the new pipeline.
             let _ = self.window_proxies.local_window_proxy(
+                cx,
                 &self.senders,
                 &self.documents,
                 &window,
@@ -3406,6 +3411,7 @@ impl ScriptThread {
 
         // Initialize the browsing context for the window.
         let window_proxy = self.window_proxies.local_window_proxy(
+            cx,
             &self.senders,
             &self.documents,
             &window,
@@ -3574,7 +3580,7 @@ impl ScriptThread {
         if incomplete.activity == DocumentActivity::FullyActive {
             window.resume(CanGc::from_cx(cx));
         } else {
-            window.suspend(CanGc::from_cx(cx));
+            window.suspend(cx);
         }
 
         if incomplete.throttled {

--- a/components/script/script_thread.rs
+++ b/components/script/script_thread.rs
@@ -545,10 +545,10 @@ impl ScriptThread {
         webview_id: WebViewId,
         pipeline_id: PipelineId,
         metadata: Option<Metadata>,
-        can_gc: CanGc,
+        cx: &mut js::context::JSContext,
     ) -> Option<DomRoot<ServoParser>> {
         with_script_thread(|script_thread| {
-            script_thread.handle_page_headers_available(webview_id, pipeline_id, metadata, can_gc)
+            script_thread.handle_page_headers_available(webview_id, pipeline_id, metadata, cx)
         })
     }
 
@@ -1129,7 +1129,7 @@ impl ScriptThread {
     /// actually updated.
     ///
     /// Returns true if any reflows produced a new display list.
-    pub(crate) fn update_the_rendering(&self, can_gc: CanGc) -> bool {
+    pub(crate) fn update_the_rendering(&self, cx: &mut js::context::JSContext) -> bool {
         self.last_render_opportunity_time.set(Some(Instant::now()));
         self.cancel_scheduled_update_the_rendering();
         self.needs_rendering_update.store(false, Ordering::Relaxed);
@@ -1192,20 +1192,20 @@ impl ScriptThread {
 
             // TODO: Should this be broken and to match the specification more closely? For instance see
             // https://html.spec.whatwg.org/multipage/#flush-autofocus-candidates.
-            self.process_pending_input_events(*pipeline_id, can_gc);
+            self.process_pending_input_events(*pipeline_id, CanGc::from_cx(cx));
 
             // > 8. For each doc of docs, run the resize steps for doc. [CSSOMVIEW]
-            let resized = document.window().run_the_resize_steps(can_gc);
+            let resized = document.window().run_the_resize_steps(CanGc::from_cx(cx));
 
             // > 9. For each doc of docs, run the scroll steps for doc.
-            document.run_the_scroll_steps(can_gc);
+            document.run_the_scroll_steps(CanGc::from_cx(cx));
 
             // Media queries is only relevant when there are resizing.
             if resized {
                 // 10. For each doc of docs, evaluate media queries and report changes for doc.
                 document
                     .window()
-                    .evaluate_media_queries_and_report_changes(can_gc);
+                    .evaluate_media_queries_and_report_changes(CanGc::from_cx(cx));
 
                 // https://html.spec.whatwg.org/multipage/#img-environment-changes
                 // As per the spec, this can be run at any time.
@@ -1215,7 +1215,7 @@ impl ScriptThread {
             // > 11. For each doc of docs, update animations and send events for doc, passing
             // > in relative high resolution time given frameTimestamp and doc's relevant
             // > global object as the timestamp [WEBANIMATIONS]
-            document.update_animations_and_send_events(can_gc);
+            document.update_animations_and_send_events(cx);
 
             // TODO(#31866): Implement "run the fullscreen steps" from
             // https://fullscreen.spec.whatwg.org/multipage/#run-the-fullscreen-steps.
@@ -1226,18 +1226,18 @@ impl ScriptThread {
             // > 14. For each doc of docs, run the animation frame callbacks for doc, passing
             // > in the relative high resolution time given frameTimestamp and doc's
             // > relevant global object as the timestamp.
-            document.run_the_animation_frame_callbacks(can_gc);
+            document.run_the_animation_frame_callbacks(CanGc::from_cx(cx));
 
             // Run the resize observer steps.
             let _realm = enter_realm(&*document);
             let mut depth = Default::default();
             while document.gather_active_resize_observations_at_depth(&depth) {
                 // Note: this will reflow the doc.
-                depth = document.broadcast_active_resize_observations(can_gc);
+                depth = document.broadcast_active_resize_observations(CanGc::from_cx(cx));
             }
 
             if document.has_skipped_resize_observations() {
-                document.deliver_resize_loop_error_notification(can_gc);
+                document.deliver_resize_loop_error_notification(CanGc::from_cx(cx));
                 // Ensure that another turn of the event loop occurs to process
                 // the skipped observations.
                 document.add_rendering_update_reason(
@@ -1255,7 +1255,8 @@ impl ScriptThread {
             // > passing in the relative high resolution time given now and
             // > doc's relevant global object as the timestamp. [INTERSECTIONOBSERVER]
             // TODO(stevennovaryo): The time attribute should be relative to the time origin of the global object
-            document.update_intersection_observer_steps(CrossProcessInstant::now(), can_gc);
+            document
+                .update_intersection_observer_steps(CrossProcessInstant::now(), CanGc::from_cx(cx));
 
             // TODO: Mark paint timing from https://w3c.github.io/paint-timing.
 
@@ -1277,7 +1278,7 @@ impl ScriptThread {
 
         // Perform a microtask checkpoint as the specifications says that *update the rendering*
         // should be run in a task and a microtask checkpoint is always done when running tasks.
-        self.perform_a_microtask_checkpoint(can_gc);
+        self.perform_a_microtask_checkpoint(cx);
         should_generate_frame
     }
 
@@ -1348,14 +1349,15 @@ impl ScriptThread {
 
     /// Fulfill the possibly-pending pending `document.fonts.ready` promise if
     /// all web fonts have loaded.
-    fn maybe_fulfill_font_ready_promises(&self, can_gc: CanGc) {
+    fn maybe_fulfill_font_ready_promises(&self, cx: &mut js::context::JSContext) {
         let mut sent_message = false;
         for (_, document) in self.documents.borrow().iter() {
-            sent_message = document.maybe_fulfill_font_ready_promise(can_gc) || sent_message;
+            sent_message =
+                document.maybe_fulfill_font_ready_promise(CanGc::from_cx(cx)) || sent_message;
         }
 
         if sent_message {
-            self.perform_a_microtask_checkpoint(can_gc);
+            self.perform_a_microtask_checkpoint(cx);
         }
     }
 
@@ -1442,7 +1444,7 @@ impl ScriptThread {
                 // If we've received the closed signal from the BHM, only handle exit messages.
                 match msg {
                     MixedMessage::FromConstellation(ScriptThreadMessage::ExitScriptThread) => {
-                        self.handle_exit_script_thread_msg(CanGc::from_cx(cx));
+                        self.handle_exit_script_thread_msg(cx);
                         return false;
                     },
                     MixedMessage::FromConstellation(ScriptThreadMessage::ExitPipeline(
@@ -1454,7 +1456,7 @@ impl ScriptThread {
                             webview_id,
                             pipeline_id,
                             discard_browsing_context,
-                            CanGc::from_cx(cx),
+                            cx,
                         );
                     },
                     _ => {},
@@ -1465,7 +1467,7 @@ impl ScriptThread {
             let exiting = self.profile_event(category, pipeline_id, || {
                 match msg {
                     MixedMessage::FromConstellation(ScriptThreadMessage::ExitScriptThread) => {
-                        self.handle_exit_script_thread_msg(CanGc::from_cx(cx));
+                        self.handle_exit_script_thread_msg(cx);
                         return true;
                     },
                     MixedMessage::FromConstellation(inner_msg) => {
@@ -1478,7 +1480,7 @@ impl ScriptThread {
                         self.handle_msg_from_devtools(inner_msg, cx)
                     },
                     MixedMessage::FromImageCache(inner_msg) => {
-                        self.handle_msg_from_image_cache(inner_msg)
+                        self.handle_msg_from_image_cache(inner_msg, cx)
                     },
                     #[cfg(feature = "webgpu")]
                     MixedMessage::FromWebGPUServer(inner_msg) => {
@@ -1497,7 +1499,7 @@ impl ScriptThread {
 
             // https://html.spec.whatwg.org/multipage/#event-loop-processing-model step 6
             // TODO(#32003): A microtask checkpoint is only supposed to be performed after running a task.
-            self.perform_a_microtask_checkpoint(CanGc::from_cx(cx));
+            self.perform_a_microtask_checkpoint(cx);
         }
 
         for (_, doc) in self.documents.borrow().iter() {
@@ -1517,10 +1519,10 @@ impl ScriptThread {
             docs.clear();
         }
 
-        let built_any_display_lists = self.needs_rendering_update.load(Ordering::Relaxed) &&
-            self.update_the_rendering(CanGc::from_cx(cx));
+        let built_any_display_lists =
+            self.needs_rendering_update.load(Ordering::Relaxed) && self.update_the_rendering(cx);
 
-        self.maybe_fulfill_font_ready_promises(CanGc::from_cx(cx));
+        self.maybe_fulfill_font_ready_promises(cx);
         self.maybe_resolve_pending_screenshot_readiness_requests(CanGc::from_cx(cx));
 
         // This must happen last to detect if any change above makes a rendering update necessary.
@@ -1747,7 +1749,7 @@ impl ScriptThread {
                 browsing_context_id,
                 load_data,
                 history_handling,
-                CanGc::from_cx(cx),
+                cx,
             ),
             ScriptThreadMessage::UnloadDocument(pipeline_id) => {
                 self.handle_unload_document(pipeline_id, CanGc::from_cx(cx))
@@ -1802,7 +1804,7 @@ impl ScriptThread {
                 webview_id,
                 new_pipeline_id,
                 reason,
-                CanGc::from_cx(cx),
+                cx,
             ),
             ScriptThreadMessage::UpdateHistoryState(pipeline_id, history_state_id, url) => self
                 .handle_update_history_state_msg(
@@ -1837,12 +1839,7 @@ impl ScriptThread {
                 target: browsing_context_id,
                 parent: parent_id,
                 child: child_id,
-            } => self.handle_iframe_load_event(
-                parent_id,
-                browsing_context_id,
-                child_id,
-                CanGc::from_cx(cx),
-            ),
+            } => self.handle_iframe_load_event(parent_id, browsing_context_id, child_id, cx),
             ScriptThreadMessage::DispatchStorageEvent(
                 pipeline_id,
                 storage,
@@ -1864,12 +1861,9 @@ impl ScriptThread {
                 webview_id,
                 pipeline_id,
                 discard_browsing_context,
-            ) => self.handle_exit_pipeline_msg(
-                webview_id,
-                pipeline_id,
-                discard_browsing_context,
-                CanGc::from_cx(cx),
-            ),
+            ) => {
+                self.handle_exit_pipeline_msg(webview_id, pipeline_id, discard_browsing_context, cx)
+            },
             ScriptThreadMessage::PaintMetric(
                 pipeline_id,
                 metric_type,
@@ -2264,7 +2258,11 @@ impl ScriptThread {
         }
     }
 
-    fn handle_msg_from_image_cache(&self, response: ImageCacheResponseMessage) {
+    fn handle_msg_from_image_cache(
+        &self,
+        response: ImageCacheResponseMessage,
+        cx: &mut js::context::JSContext,
+    ) {
         match response {
             ImageCacheResponseMessage::NotifyPendingImageLoadStatus(pending_image_response) => {
                 let window = self
@@ -2272,7 +2270,7 @@ impl ScriptThread {
                     .borrow()
                     .find_window(pending_image_response.pipeline_id);
                 if let Some(ref window) = window {
-                    window.pending_image_notification(pending_image_response);
+                    window.pending_image_notification(pending_image_response, cx);
                 }
             },
             ImageCacheResponseMessage::VectorImageRasterizationComplete(response) => {
@@ -2959,14 +2957,14 @@ impl ScriptThread {
         webview_id: WebViewId,
         new_pipeline_id: PipelineId,
         reason: UpdatePipelineIdReason,
-        can_gc: CanGc,
+        cx: &mut js::context::JSContext,
     ) {
         let frame_element = self
             .documents
             .borrow()
             .find_iframe(parent_pipeline_id, browsing_context_id);
         if let Some(frame_element) = frame_element {
-            frame_element.update_pipeline_id(new_pipeline_id, reason, can_gc);
+            frame_element.update_pipeline_id(new_pipeline_id, reason, cx);
         }
 
         if let Some(window) = self.documents.borrow().find_window(new_pipeline_id) {
@@ -3027,7 +3025,7 @@ impl ScriptThread {
         webview_id: WebViewId,
         pipeline_id: PipelineId,
         metadata: Option<Metadata>,
-        can_gc: CanGc,
+        cx: &mut js::context::JSContext,
     ) -> Option<DomRoot<ServoParser>> {
         if self.closed_pipelines.borrow().contains(&pipeline_id) {
             // If the pipeline closed, do not process the headers.
@@ -3077,7 +3075,7 @@ impl ScriptThread {
         };
 
         let load = self.incomplete_loads.borrow_mut().remove(idx);
-        metadata.map(|meta| self.load(meta, load, can_gc))
+        metadata.map(|meta| self.load(meta, load, cx))
     }
 
     /// Handles a request for the window title.
@@ -3094,7 +3092,7 @@ impl ScriptThread {
         webview_id: WebViewId,
         pipeline_id: PipelineId,
         discard_bc: DiscardBrowsingContext,
-        can_gc: CanGc,
+        cx: &mut js::context::JSContext,
     ) {
         debug!("{pipeline_id}: Starting pipeline exit.");
 
@@ -3112,7 +3110,7 @@ impl ScriptThread {
             );
 
             if let Some(parser) = document.get_current_parser() {
-                parser.abort(can_gc);
+                parser.abort(cx);
             }
 
             debug!("{pipeline_id}: Shutting down layout");
@@ -3153,7 +3151,7 @@ impl ScriptThread {
     }
 
     /// Handles a request to exit the script thread and shut down layout.
-    fn handle_exit_script_thread_msg(&self, can_gc: CanGc) {
+    fn handle_exit_script_thread_msg(&self, cx: &mut js::context::JSContext) {
         debug!("Exiting script thread.");
 
         let mut webview_and_pipeline_ids = Vec::new();
@@ -3173,12 +3171,7 @@ impl ScriptThread {
         );
 
         for (webview_id, pipeline_id) in webview_and_pipeline_ids {
-            self.handle_exit_pipeline_msg(
-                webview_id,
-                pipeline_id,
-                DiscardBrowsingContext::Yes,
-                can_gc,
-            );
+            self.handle_exit_pipeline_msg(webview_id, pipeline_id, DiscardBrowsingContext::Yes, cx);
         }
 
         self.background_hang_monitor.unregister();
@@ -3250,14 +3243,14 @@ impl ScriptThread {
         parent_id: PipelineId,
         browsing_context_id: BrowsingContextId,
         child_id: PipelineId,
-        can_gc: CanGc,
+        cx: &mut js::context::JSContext,
     ) {
         let iframe = self
             .documents
             .borrow()
             .find_iframe(parent_id, browsing_context_id);
         match iframe {
-            Some(iframe) => iframe.iframe_load_event_steps(child_id, can_gc),
+            Some(iframe) => iframe.iframe_load_event_steps(child_id, cx),
             None => warn!("Message sent to closed pipeline {}.", parent_id),
         }
     }
@@ -3288,7 +3281,7 @@ impl ScriptThread {
         &self,
         metadata: Metadata,
         incomplete: InProgressLoad,
-        can_gc: CanGc,
+        cx: &mut js::context::JSContext,
     ) -> DomRoot<ServoParser> {
         let script_to_constellation_chan = ScriptToConstellationChan {
             sender: self.senders.pipeline_to_constellation_sender.clone(),
@@ -3357,6 +3350,7 @@ impl ScriptThread {
 
         // Create the window and document objects.
         let window = Window::new(
+            cx,
             incomplete.webview_id,
             self.js_runtime.clone(),
             self.senders.self_sender.clone(),
@@ -3401,13 +3395,14 @@ impl ScriptThread {
             self.this.clone(),
         );
         self.debugger_global.fire_add_debuggee(
-            can_gc,
+            CanGc::from_cx(cx),
             window.upcast(),
             incomplete.pipeline_id,
             None,
         );
 
-        let _realm = enter_realm(&*window);
+        let mut realm = enter_auto_realm(cx, &*window);
+        let cx = &mut realm;
 
         // Initialize the browsing context for the window.
         let window_proxy = self.window_proxies.local_window_proxy(
@@ -3489,7 +3484,7 @@ impl ScriptThread {
             incomplete.load_data.has_trustworthy_ancestor_origin,
             self.custom_element_reaction_stack.clone(),
             incomplete.load_data.creation_sandboxing_flag_set,
-            can_gc,
+            CanGc::from_cx(cx),
         );
 
         let referrer_policy = metadata
@@ -3505,7 +3500,7 @@ impl ScriptThread {
             document.shared_declarative_refresh_steps(refresh_val.as_bytes());
         }
 
-        document.set_ready_state(DocumentReadyState::Loading, can_gc);
+        document.set_ready_state(DocumentReadyState::Loading, CanGc::from_cx(cx));
 
         self.documents
             .borrow_mut()
@@ -3526,7 +3521,7 @@ impl ScriptThread {
                 window_proxy.webview_id(),
                 incomplete.pipeline_id,
                 UpdatePipelineIdReason::Navigation,
-                can_gc,
+                cx,
             );
         }
 
@@ -3563,7 +3558,7 @@ impl ScriptThread {
                 None,
                 final_url,
                 encoding_hint_from_content_type,
-                can_gc,
+                cx,
             );
         } else {
             ServoParser::parse_html_document(
@@ -3572,14 +3567,14 @@ impl ScriptThread {
                 final_url,
                 encoding_hint_from_content_type,
                 incomplete.load_data.container_document_encoding,
-                can_gc,
+                cx,
             );
         }
 
         if incomplete.activity == DocumentActivity::FullyActive {
-            window.resume(can_gc);
+            window.resume(CanGc::from_cx(cx));
         } else {
-            window.suspend(can_gc);
+            window.suspend(CanGc::from_cx(cx));
         }
 
         if incomplete.throttled {
@@ -3666,14 +3661,14 @@ impl ScriptThread {
         browsing_context_id: BrowsingContextId,
         load_data: LoadData,
         history_handling: NavigationHistoryBehavior,
-        can_gc: CanGc,
+        cx: &mut js::context::JSContext,
     ) {
         let iframe = self
             .documents
             .borrow()
             .find_iframe(parent_pipeline_id, browsing_context_id);
         if let Some(iframe) = iframe {
-            iframe.navigate_or_reload_child_browsing_context(load_data, history_handling, can_gc);
+            iframe.navigate_or_reload_child_browsing_context(load_data, history_handling, cx);
         }
     }
 
@@ -4076,7 +4071,7 @@ impl ScriptThread {
         });
     }
 
-    pub(crate) fn perform_a_microtask_checkpoint(&self, can_gc: CanGc) {
+    pub(crate) fn perform_a_microtask_checkpoint(&self, cx: &mut js::context::JSContext) {
         // Only perform the checkpoint if we're not shutting down.
         if self.can_continue_running_inner() {
             let globals = self
@@ -4087,10 +4082,9 @@ impl ScriptThread {
                 .collect();
 
             self.microtask_queue.checkpoint(
-                self.get_cx(),
+                cx,
                 |id| self.documents.borrow().find_global(id),
                 globals,
-                can_gc,
             )
         }
     }

--- a/components/script_bindings/codegen/Bindings.conf
+++ b/components/script_bindings/codegen/Bindings.conf
@@ -812,11 +812,11 @@ DOMInterfaces = {
 },
 
 'Window': {
-    'canGc': ['CookieStore', 'Fetch', 'FetchLater', 'GetVisualViewport', 'Open', 'ReportError', 'Screen', 'SetInterval', 'SetTimeout', 'Stop', 'StructuredClone', 'TrustedTypes', 'WebdriverException'],
+    'canGc': ['CookieStore', 'Fetch', 'FetchLater', 'GetVisualViewport', 'Open', 'ReportError', 'Screen', 'SetInterval', 'SetTimeout', 'StructuredClone', 'TrustedTypes', 'WebdriverException'],
     'inRealms': ['Fetch', 'GetOpener'],
     'additionalTraits': ['crate::interfaces::WindowHelpers'],
     'realm': ['CreateImageBitmap', 'CreateImageBitmap_', 'WebdriverCallback'],
-    'cx': ['PostMessage', 'PostMessage_']
+    'cx': ['PostMessage', 'PostMessage_', 'Stop']
 },
 
 'WindowProxy' : {

--- a/components/script_bindings/codegen/Bindings.conf
+++ b/components/script_bindings/codegen/Bindings.conf
@@ -813,9 +813,9 @@ DOMInterfaces = {
 
 'Window': {
     'canGc': ['CookieStore', 'Fetch', 'FetchLater', 'GetVisualViewport', 'Open', 'ReportError', 'Screen', 'SetInterval', 'SetTimeout', 'StructuredClone', 'TrustedTypes', 'WebdriverException'],
-    'inRealms': ['Fetch', 'GetOpener'],
+    'inRealms': ['Fetch'],
     'additionalTraits': ['crate::interfaces::WindowHelpers'],
-    'realm': ['CreateImageBitmap', 'CreateImageBitmap_', 'WebdriverCallback'],
+    'realm': ['CreateImageBitmap', 'CreateImageBitmap_', 'WebdriverCallback', 'GetOpener'],
     'cx': ['PostMessage', 'PostMessage_', 'Stop']
 },
 

--- a/components/script_bindings/interfaces.rs
+++ b/components/script_bindings/interfaces.rs
@@ -81,7 +81,7 @@ pub trait GlobalScopeHelpers<D: DomTypes> {
 
     fn incumbent() -> Option<DomRoot<D::GlobalScope>>;
 
-    fn perform_a_microtask_checkpoint(&self, can_gc: CanGc);
+    fn perform_a_microtask_checkpoint(&self, cx: &mut js::context::JSContext);
 
     fn get_url(&self) -> ServoUrl;
 

--- a/components/script_bindings/settings_stack.rs
+++ b/components/script_bindings/settings_stack.rs
@@ -11,7 +11,7 @@ use js::rust::Runtime;
 use crate::DomTypes;
 use crate::interfaces::{DomHelpers, GlobalScopeHelpers};
 use crate::root::{Dom, DomRoot};
-use crate::script_runtime::CanGc;
+use crate::script_runtime::temp_cx;
 
 #[derive(Debug, Eq, JSTraceable, PartialEq)]
 pub enum StackEntryKind {
@@ -78,7 +78,10 @@ impl<D: DomTypes> Drop for GenericAutoEntryScript<D> {
 
         // Step 5
         if !thread::panicking() && stack_is_empty {
-            self.global.perform_a_microtask_checkpoint(CanGc::note());
+            // To remove this we would need to refactor this whole type.
+            // Instead of RAII we should have use callback pattern.
+            let mut cx = unsafe { temp_cx() };
+            self.global.perform_a_microtask_checkpoint(&mut cx);
         }
     }
 }


### PR DESCRIPTION
I only wanted to get `&mut JSContext` in microtask chunk and checkpoint, but this in turn needed `&mut JSContext` in servoparser, which then caused need for even more changes in script.

I tried to limit the size by putting some `temp_cx` in:
- drops of `LoadBlocker`, `GenericAutoEntryScript`
- methods of `VirtualMethods`
- methods of `FetchResponseListener`

Testing: Just refactor, but should be covered by WPT tests.
Part of #40600
