### PR TITLE
script: Start using `&mut JSContext` in devtools and webdriver code

### DIFF
--- a/components/script/devtools.rs
+++ b/components/script/devtools.rs
@@ -54,7 +54,7 @@ pub(crate) fn handle_evaluate_js(
 ) {
     let result = unsafe {
         let mut realm = enter_auto_realm(cx, global);
-        let cx = &mut realm.current_realm();
+        let cx = &mut realm;
         rooted!(&in(cx) let mut rval = UndefinedValue());
         // TODO: run code with SpiderMonkey Debugger API, like Firefox does
         // <https://searchfox.org/mozilla-central/rev/f6a806c38c459e0e0d797d264ca0e8ad46005105/devtools/server/actors/webconsole/eval-with-debugger.js#270>

--- a/components/script/devtools.rs
+++ b/components/script/devtools.rs
@@ -11,6 +11,7 @@ use devtools_traits::{
     AttrModification, AutoMargins, ComputedNodeLayout, CssDatabaseProperty, EvaluateJSReply,
     EventListenerInfo, NodeInfo, NodeStyle, RuleModification, TimelineMarker, TimelineMarkerType,
 };
+use js::context::JSContext;
 use js::conversions::jsstr_to_string;
 use js::jsval::UndefinedValue;
 use js::rust::ToString;
@@ -41,7 +42,7 @@ use crate::dom::element::Element;
 use crate::dom::globalscope::GlobalScope;
 use crate::dom::node::{Node, NodeTraits, ShadowIncluding};
 use crate::dom::types::{EventTarget, HTMLElement};
-use crate::realms::enter_realm;
+use crate::realms::{enter_auto_realm, enter_realm};
 use crate::script_runtime::{CanGc, IntroductionType};
 
 #[expect(unsafe_code)]
@@ -49,13 +50,12 @@ pub(crate) fn handle_evaluate_js(
     global: &GlobalScope,
     eval: String,
     reply: GenericSender<EvaluateJSReply>,
-    can_gc: CanGc,
+    cx: &mut JSContext,
 ) {
-    // global.get_cx() returns a valid `JSContext` pointer, so this is safe.
     let result = unsafe {
-        let cx = GlobalScope::get_cx();
-        let _ac = enter_realm(global);
-        rooted!(in(*cx) let mut rval = UndefinedValue());
+        let mut realm = enter_auto_realm(cx, global);
+        let cx = &mut realm.current_realm();
+        rooted!(&in(cx) let mut rval = UndefinedValue());
         // TODO: run code with SpiderMonkey Debugger API, like Firefox does
         // <https://searchfox.org/mozilla-central/rev/f6a806c38c459e0e0d797d264ca0e8ad46005105/devtools/server/actors/webconsole/eval-with-debugger.js#270>
         _ = global.evaluate_js_on_global(
@@ -63,7 +63,7 @@ pub(crate) fn handle_evaluate_js(
             "<eval>",
             Some(IntroductionType::DEBUGGER_EVAL),
             rval.handle_mut(),
-            can_gc,
+            CanGc::from_cx(cx),
         );
 
         if rval.is_undefined() {
@@ -72,21 +72,21 @@ pub(crate) fn handle_evaluate_js(
             EvaluateJSReply::BooleanValue(rval.to_boolean())
         } else if rval.is_double() || rval.is_int32() {
             EvaluateJSReply::NumberValue(
-                match FromJSValConvertible::from_jsval(*cx, rval.handle(), ()) {
+                match FromJSValConvertible::from_jsval(cx.raw_cx(), rval.handle(), ()) {
                     Ok(ConversionResult::Success(v)) => v,
                     _ => unreachable!(),
                 },
             )
         } else if rval.is_string() {
             let jsstr = std::ptr::NonNull::new(rval.to_string()).unwrap();
-            EvaluateJSReply::StringValue(jsstr_to_string(*cx, jsstr))
+            EvaluateJSReply::StringValue(jsstr_to_string(cx.raw_cx(), jsstr))
         } else if rval.is_null() {
             EvaluateJSReply::NullValue
         } else {
             assert!(rval.is_object());
 
-            let jsstr = std::ptr::NonNull::new(ToString(*cx, rval.handle())).unwrap();
-            let class_name = jsstr_to_string(*cx, jsstr);
+            let jsstr = std::ptr::NonNull::new(ToString(cx.raw_cx(), rval.handle())).unwrap();
+            let class_name = jsstr_to_string(cx.raw_cx(), jsstr);
 
             EvaluateJSReply::ActorValue {
                 class: class_name,

--- a/components/script/dom/userscripts.rs
+++ b/components/script/dom/userscripts.rs
@@ -17,9 +17,8 @@ pub(crate) fn load_script(head: &HTMLHeadElement) {
         return;
     }
     let win = DomRoot::from_ref(doc.window());
-    doc.add_delayed_task(task!(UserScriptExecute: |win: DomRoot<Window>| {
-        let cx = win.get_cx();
-        rooted!(in(*cx) let mut rval = UndefinedValue());
+    doc.add_delayed_task(task!(UserScriptExecute: |cx, win: DomRoot<Window>| {
+        rooted!(&in(cx) let mut rval = UndefinedValue());
 
         let global_scope = win.as_global_scope();
         for user_script in userscripts {
@@ -28,7 +27,7 @@ pub(crate) fn load_script(head: &HTMLHeadElement) {
                 &user_script.source_file().map(|path| path.to_string_lossy().to_string()).unwrap_or_default(),
                 None,
                 rval.handle_mut(),
-                CanGc::note(),
+                CanGc::from_cx(cx),
             );
         }
     }));

--- a/components/script/dom/window.rs
+++ b/components/script/dom/window.rs
@@ -1791,16 +1791,10 @@ impl WindowMethods<crate::DomTypeHolder> for Window {
         }
     }
 
-    fn WebdriverCallback(
-        &self,
-        cx: SafeJSContext,
-        value: HandleValue,
-        realm: InRealm,
-        can_gc: CanGc,
-    ) {
+    fn WebdriverCallback(&self, realm: &mut CurrentRealm, value: HandleValue) {
         let webdriver_script_sender = self.webdriver_script_chan.borrow_mut().take();
         if let Some(webdriver_script_sender) = webdriver_script_sender {
-            let result = jsval_to_webdriver(cx, &self.globalscope, value, realm, can_gc);
+            let result = jsval_to_webdriver(realm, &self.globalscope, value);
             let _ = webdriver_script_sender.send(result);
         }
     }

--- a/components/script/dom/workers/dedicatedworkerglobalscope.rs
+++ b/components/script/dom/workers/dedicatedworkerglobalscope.rs
@@ -452,7 +452,7 @@ impl DedicatedWorkerGlobalScope {
                     gpu_id_hub.clone(),
                     cx,
                 );
-                debugger_global.execute(CanGc::from_cx(cx));
+                debugger_global.execute(cx);
 
                 let context_for_interrupt = runtime.thread_safe_js_context();
                 let _ = context_sender.send(context_for_interrupt);

--- a/components/script/dom/workers/dedicatedworkerglobalscope.rs
+++ b/components/script/dom/workers/dedicatedworkerglobalscope.rs
@@ -650,7 +650,7 @@ impl DedicatedWorkerGlobalScope {
         match msg {
             MixedMessage::Devtools(msg) => match msg {
                 DevtoolScriptControlMsg::EvaluateJS(_pipe_id, string, sender) => {
-                    devtools::handle_evaluate_js(self.upcast(), string, sender, CanGc::from_cx(cx))
+                    devtools::handle_evaluate_js(self.upcast(), string, sender, cx)
                 },
                 DevtoolScriptControlMsg::WantsLiveNotifications(_pipe_id, bool_val) => {
                     devtools::handle_wants_live_notifications(self.upcast(), bool_val)

--- a/components/script/dom/workers/serviceworkerglobalscope.rs
+++ b/components/script/dom/workers/serviceworkerglobalscope.rs
@@ -457,7 +457,7 @@ impl ServiceWorkerGlobalScope {
         match msg {
             MixedMessage::Devtools(msg) => match msg {
                 DevtoolScriptControlMsg::EvaluateJS(_pipe_id, string, sender) => {
-                    devtools::handle_evaluate_js(self.upcast(), string, sender, CanGc::from_cx(cx))
+                    devtools::handle_evaluate_js(self.upcast(), string, sender, cx)
                 },
                 DevtoolScriptControlMsg::WantsLiveNotifications(_pipe_id, bool_val) => {
                     devtools::handle_wants_live_notifications(self.upcast(), bool_val)

--- a/components/script/dom/worklet.rs
+++ b/components/script/dom/worklet.rs
@@ -711,11 +711,7 @@ impl WorkletThread {
         // Also, the spec currently doesn't allow exceptions to be propagated
         // to the main script thread.
         // https://github.com/w3c/css-houdini-drafts/issues/407
-        let ok = script.is_some_and(|s| {
-            global_scope
-                .evaluate_js(s.into(), CanGc::from_cx(cx))
-                .is_ok()
-        });
+        let ok = script.is_some_and(|s| global_scope.evaluate_js(s.into(), cx).is_ok());
 
         if !ok {
             // Step 3.

--- a/components/script/dom/workletglobalscope.rs
+++ b/components/script/dom/workletglobalscope.rs
@@ -138,16 +138,16 @@ impl WorkletGlobalScope {
     pub(crate) fn evaluate_js(
         &self,
         script: Cow<'_, str>,
-        can_gc: CanGc,
+        cx: &mut js::context::JSContext,
     ) -> Result<(), JavaScriptEvaluationError> {
         debug!("Evaluating Dom in a worklet.");
-        rooted!(in (*GlobalScope::get_cx()) let mut rval = UndefinedValue());
+        rooted!(&in(cx) let mut rval = UndefinedValue());
         self.globalscope.evaluate_js_on_global(
             script,
             "",
             Some(IntroductionType::WORKLET),
             rval.handle_mut(),
-            can_gc,
+            CanGc::from_cx(cx),
         )
     }
 

--- a/components/script/script_thread.rs
+++ b/components/script/script_thread.rs
@@ -992,7 +992,7 @@ impl ScriptThread {
             &mut cx,
         );
 
-        debugger_global.execute(CanGc::from_cx(&mut cx));
+        debugger_global.execute(&mut cx);
 
         let user_contents_for_manager_id =
             FxHashMap::from_iter(state.user_contents_for_manager_id.into_iter().map(

--- a/components/script/script_thread.rs
+++ b/components/script/script_thread.rs
@@ -2108,7 +2108,7 @@ impl ScriptThread {
                 Some(window) => {
                     let global = window.as_global_scope();
                     let _aes = AutoEntryScript::new(global);
-                    devtools::handle_evaluate_js(global, s, reply, CanGc::from_cx(cx))
+                    devtools::handle_evaluate_js(global, s, reply, cx)
                 },
                 None => warn!("Message sent to closed pipeline {}.", id),
             },

--- a/components/script/script_thread.rs
+++ b/components/script/script_thread.rs
@@ -1830,7 +1830,7 @@ impl ScriptThread {
                 self.handle_unfocus_msg(pipeline_id, sequence, CanGc::from_cx(cx))
             },
             ScriptThreadMessage::WebDriverScriptCommand(pipeline_id, msg) => {
-                self.handle_webdriver_msg(pipeline_id, msg, CanGc::from_cx(cx))
+                self.handle_webdriver_msg(pipeline_id, msg, cx)
             },
             ScriptThreadMessage::WebFontLoaded(pipeline_id, success) => {
                 self.handle_web_font_loaded(pipeline_id, success)
@@ -1916,13 +1916,7 @@ impl ScriptThread {
                 evaluation_id,
                 script,
             ) => {
-                self.handle_evaluate_javascript(
-                    webview_id,
-                    pipeline_id,
-                    evaluation_id,
-                    script,
-                    CanGc::from_cx(cx),
-                );
+                self.handle_evaluate_javascript(webview_id, pipeline_id, evaluation_id, script, cx);
             },
             ScriptThreadMessage::SendImageKeysBatch(pipeline_id, image_keys) => {
                 if let Some(window) = self.documents.borrow().find_window(pipeline_id) {
@@ -2272,7 +2266,7 @@ impl ScriptThread {
         &self,
         pipeline_id: PipelineId,
         msg: WebDriverScriptCommand,
-        can_gc: CanGc,
+        cx: &mut js::context::JSContext,
     ) {
         let documents = self.documents.borrow();
         match msg {
@@ -2291,7 +2285,7 @@ impl ScriptThread {
                     pipeline_id,
                     element_id,
                     reply,
-                    can_gc,
+                    CanGc::from_cx(cx),
                 )
             },
             WebDriverScriptCommand::FindElementsCSSSelector(selector, reply) => {
@@ -2317,7 +2311,7 @@ impl ScriptThread {
                     pipeline_id,
                     selector,
                     reply,
-                    can_gc,
+                    CanGc::from_cx(cx),
                 )
             },
             WebDriverScriptCommand::FindElementsXpathSelector(selector, reply) => {
@@ -2326,7 +2320,7 @@ impl ScriptThread {
                     pipeline_id,
                     selector,
                     reply,
-                    can_gc,
+                    CanGc::from_cx(cx),
                 )
             },
             WebDriverScriptCommand::FindElementElementsCSSSelector(selector, element_id, reply) => {
@@ -2358,7 +2352,7 @@ impl ScriptThread {
                     element_id,
                     selector,
                     reply,
-                    can_gc,
+                    CanGc::from_cx(cx),
                 )
             },
             WebDriverScriptCommand::FindElementElementsXPathSelector(
@@ -2371,7 +2365,7 @@ impl ScriptThread {
                 element_id,
                 selector,
                 reply,
-                can_gc,
+                CanGc::from_cx(cx),
             ),
             WebDriverScriptCommand::FindShadowElementsCSSSelector(
                 selector,
@@ -2416,7 +2410,7 @@ impl ScriptThread {
                 shadow_root_id,
                 selector,
                 reply,
-                can_gc,
+                CanGc::from_cx(cx),
             ),
             WebDriverScriptCommand::GetElementShadowRoot(element_id, reply) => {
                 webdriver_handlers::handle_get_element_shadow_root(
@@ -2432,7 +2426,7 @@ impl ScriptThread {
                     pipeline_id,
                     element_id,
                     reply,
-                    can_gc,
+                    CanGc::from_cx(cx),
                 )
             },
             WebDriverScriptCommand::GetKnownElement(element_id, reply) => {
@@ -2471,7 +2465,12 @@ impl ScriptThread {
                 )
             },
             WebDriverScriptCommand::GetPageSource(reply) => {
-                webdriver_handlers::handle_get_page_source(&documents, pipeline_id, reply, can_gc)
+                webdriver_handlers::handle_get_page_source(
+                    &documents,
+                    pipeline_id,
+                    reply,
+                    CanGc::from_cx(cx),
+                )
             },
             WebDriverScriptCommand::GetCookies(reply) => {
                 webdriver_handlers::handle_get_cookies(&documents, pipeline_id, reply)
@@ -2498,14 +2497,20 @@ impl ScriptThread {
                     node_id,
                     name,
                     reply,
-                    can_gc,
+                    cx,
                 )
             },
             WebDriverScriptCommand::GetElementCSS(node_id, name, reply) => {
                 webdriver_handlers::handle_get_css(&documents, pipeline_id, node_id, name, reply)
             },
             WebDriverScriptCommand::GetElementRect(node_id, reply) => {
-                webdriver_handlers::handle_get_rect(&documents, pipeline_id, node_id, reply, can_gc)
+                webdriver_handlers::handle_get_rect(
+                    &documents,
+                    pipeline_id,
+                    node_id,
+                    reply,
+                    CanGc::from_cx(cx),
+                )
             },
             WebDriverScriptCommand::ScrollAndGetBoundingClientRect(node_id, reply) => {
                 webdriver_handlers::handle_scroll_and_get_bounding_client_rect(
@@ -2513,7 +2518,7 @@ impl ScriptThread {
                     pipeline_id,
                     node_id,
                     reply,
-                    can_gc,
+                    CanGc::from_cx(cx),
                 )
             },
             WebDriverScriptCommand::GetElementText(node_id, reply) => {
@@ -2525,7 +2530,7 @@ impl ScriptThread {
                     pipeline_id,
                     node_id,
                     reply,
-                    can_gc,
+                    CanGc::from_cx(cx),
                 )
             },
             WebDriverScriptCommand::GetParentFrameId(reply) => {
@@ -2539,9 +2544,12 @@ impl ScriptThread {
                     reply,
                 )
             },
-            WebDriverScriptCommand::GetUrl(reply) => {
-                webdriver_handlers::handle_get_url(&documents, pipeline_id, reply, can_gc)
-            },
+            WebDriverScriptCommand::GetUrl(reply) => webdriver_handlers::handle_get_url(
+                &documents,
+                pipeline_id,
+                reply,
+                CanGc::from_cx(cx),
+            ),
             WebDriverScriptCommand::IsEnabled(element_id, reply) => {
                 webdriver_handlers::handle_is_enabled(&documents, pipeline_id, element_id, reply)
             },
@@ -2563,7 +2571,7 @@ impl ScriptThread {
                 text,
                 strict_file_interactability,
                 reply,
-                can_gc,
+                CanGc::from_cx(cx),
             ),
             WebDriverScriptCommand::AddLoadStatusSender(_, response_sender) => {
                 webdriver_handlers::handle_add_load_status_sender(
@@ -2584,7 +2592,7 @@ impl ScriptThread {
             WebDriverScriptCommand::ExecuteScriptWithCallback(script, reply) => {
                 let window = documents.find_window(pipeline_id);
                 drop(documents);
-                webdriver_handlers::handle_execute_async_script(window, script, reply, can_gc);
+                webdriver_handlers::handle_execute_async_script(window, script, reply, cx);
             },
             WebDriverScriptCommand::SetProtocolHandlerAutomationMode(mode) => {
                 webdriver_handlers::set_protocol_handler_automation_mode(
@@ -4036,7 +4044,7 @@ impl ScriptThread {
         pipeline_id: PipelineId,
         evaluation_id: JavaScriptEvaluationId,
         script: String,
-        can_gc: CanGc,
+        cx: &mut js::context::JSContext,
     ) {
         let Some(window) = self.documents.borrow().find_window(pipeline_id) else {
             let _ = self.senders.pipeline_to_constellation_sender.send((
@@ -4051,16 +4059,16 @@ impl ScriptThread {
         };
 
         let global_scope = window.as_global_scope();
-        let realm = enter_realm(global_scope);
-        let context = window.get_cx();
+        let mut realm = enter_auto_realm(cx, global_scope);
+        let cx = &mut realm.current_realm();
 
-        rooted!(in(*context) let mut return_value = UndefinedValue());
+        rooted!(&in(cx) let mut return_value = UndefinedValue());
         if let Err(err) = global_scope.evaluate_js_on_global(
             script.into(),
             "",
             None, // No known `introductionType` for JS code from embedder
             return_value.handle_mut(),
-            can_gc,
+            CanGc::from_cx(cx),
         ) {
             _ = self.senders.pipeline_to_constellation_sender.send((
                 webview_id,
@@ -4070,13 +4078,7 @@ impl ScriptThread {
             return;
         };
 
-        let result = jsval_to_webdriver(
-            context,
-            global_scope,
-            return_value.handle(),
-            (&realm).into(),
-            can_gc,
-        );
+        let result = jsval_to_webdriver(cx, global_scope, return_value.handle());
         let _ = self.senders.pipeline_to_constellation_sender.send((
             webview_id,
             pipeline_id,

--- a/components/script/webdriver_handlers.rs
+++ b/components/script/webdriver_handlers.rs
@@ -17,12 +17,14 @@ use embedder_traits::{
 use euclid::default::{Point2D, Rect, Size2D};
 use hyper_serde::Serde;
 use ipc_channel::ipc::{self};
+use js::context::JSContext;
 use js::conversions::jsstr_to_string;
 use js::jsapi::{
     self, GetPropertyKeys, HandleValueArray, JS_GetOwnPropertyDescriptorById, JS_GetPropertyById,
     JS_IsExceptionPending, JSAutoRealm, JSObject, JSType, PropertyDescriptor,
 };
 use js::jsval::UndefinedValue;
+use js::realm::CurrentRealm;
 use js::rust::wrappers::{JS_CallFunctionName, JS_GetProperty, JS_HasOwnProperty, JS_TypeOfValue};
 use js::rust::{Handle, HandleObject, HandleValue, IdVector, ToString};
 use net_traits::CookieSource::{HTTP, NonHTTP};
@@ -88,7 +90,7 @@ use crate::dom::types::ShadowRoot;
 use crate::dom::validitystate::ValidationFlags;
 use crate::dom::window::Window;
 use crate::dom::xmlserializer::XMLSerializer;
-use crate::realms::{InRealm, enter_realm};
+use crate::realms::{InRealm, enter_auto_realm, enter_realm};
 use crate::script_runtime::{CanGc, JSContext as SafeJSContext};
 use crate::script_thread::ScriptThread;
 
@@ -366,17 +368,20 @@ impl From<HandleValue<'_>> for HashableJSVal {
 
 /// <https://w3c.github.io/webdriver/#dfn-json-clone>
 pub(crate) fn jsval_to_webdriver(
-    cx: SafeJSContext,
+    cx: &mut CurrentRealm,
     global_scope: &GlobalScope,
     val: HandleValue,
-    realm: InRealm,
-    can_gc: CanGc,
 ) -> WebDriverJSResult {
     let _aes = AutoEntryScript::new(global_scope);
     let mut seen = HashSet::new();
-    let result = jsval_to_webdriver_inner(cx, global_scope, val, &mut seen);
+    let result = jsval_to_webdriver_inner(cx.into(), global_scope, val, &mut seen);
+
+    let mut realm = CurrentRealm::assert(cx);
+    let in_realm_proof = (&mut realm).into();
+    let in_realm = InRealm::Already(&in_realm_proof);
+
     if result.is_err() {
-        report_pending_exception(cx, true, realm, can_gc);
+        report_pending_exception(cx.into(), true, in_realm, CanGc::from_cx(cx));
     }
     result
 }
@@ -626,14 +631,13 @@ pub(crate) fn handle_execute_async_script(
     window: Option<DomRoot<Window>>,
     eval: String,
     reply: GenericSender<WebDriverJSResult>,
-    can_gc: CanGc,
+    cx: &mut JSContext,
 ) {
     match window {
         Some(window) => {
-            let cx = window.get_cx();
             let reply_sender = reply.clone();
             window.set_webdriver_script_chan(Some(reply));
-            rooted!(in(*cx) let mut rval = UndefinedValue());
+            rooted!(&in(cx) let mut rval = UndefinedValue());
 
             let global_scope = window.as_global_scope();
             if let Err(error) = global_scope.evaluate_js_on_global(
@@ -641,7 +645,7 @@ pub(crate) fn handle_execute_async_script(
                 "",
                 None, // No known `introductionType` for JS code from WebDriver
                 rval.handle_mut(),
-                can_gc,
+                CanGc::from_cx(cx),
             ) {
                 reply_sender.send(Err(error)).unwrap_or_else(|error| {
                     error!("ExecuteAsyncScript Failed to send reply: {error}");
@@ -1693,39 +1697,38 @@ pub(crate) fn handle_get_property(
     node_id: String,
     name: String,
     reply: GenericSender<Result<JSValue, ErrorStatus>>,
-    can_gc: CanGc,
+    cx: &mut JSContext,
 ) {
     reply
         .send(
             get_known_element(documents, pipeline, node_id).map(|element| {
                 let document = documents.find_document(pipeline).unwrap();
-                let realm = enter_realm(&*document);
-                let cx = document.window().get_cx();
+
                 let Ok(cname) = CString::new(name) else {
                     return JSValue::Undefined;
                 };
 
-                rooted!(in(*cx) let mut property = UndefinedValue());
+                let mut realm = enter_auto_realm(cx, &*document);
+                let cx = &mut realm.current_realm();
+
+                rooted!(&in(cx) let mut property = UndefinedValue());
                 match get_property_jsval(
-                    cx,
+                    cx.into(),
                     element.reflector().get_jsobject(),
                     &cname,
                     property.handle_mut(),
                 ) {
-                    Ok(_) => {
-                        match jsval_to_webdriver(
-                            cx,
-                            &element.global(),
-                            property.handle(),
-                            InRealm::entered(&realm),
-                            can_gc,
-                        ) {
-                            Ok(property) => property,
-                            Err(_) => JSValue::Undefined,
-                        }
+                    Ok(_) => match jsval_to_webdriver(cx, &element.global(), property.handle()) {
+                        Ok(property) => property,
+                        Err(_) => JSValue::Undefined,
                     },
                     Err(error) => {
-                        throw_dom_exception(cx, &element.global(), error, can_gc);
+                        throw_dom_exception(
+                            cx.into(),
+                            &element.global(),
+                            error,
+                            CanGc::from_cx(cx),
+                        );
                         JSValue::Undefined
                     },
                 }

--- a/components/script/webdriver_handlers.rs
+++ b/components/script/webdriver_handlers.rs
@@ -376,8 +376,7 @@ pub(crate) fn jsval_to_webdriver(
     let mut seen = HashSet::new();
     let result = jsval_to_webdriver_inner(cx.into(), global_scope, val, &mut seen);
 
-    let mut realm = CurrentRealm::assert(cx);
-    let in_realm_proof = (&mut realm).into();
+    let in_realm_proof = cx.into();
     let in_realm = InRealm::Already(&in_realm_proof);
 
     if result.is_err() {

--- a/components/script_bindings/codegen/Bindings.conf
+++ b/components/script_bindings/codegen/Bindings.conf
@@ -793,10 +793,10 @@ DOMInterfaces = {
 },
 
 'Window': {
-    'canGc': ['CookieStore', 'Fetch', 'FetchLater', 'GetVisualViewport', 'Open', 'ReportError', 'Screen', 'SetInterval', 'SetTimeout', 'Stop', 'StructuredClone', 'TrustedTypes', 'WebdriverCallback', 'WebdriverException'],
-    'inRealms': ['Fetch', 'GetOpener', 'WebdriverCallback'],
+    'canGc': ['CookieStore', 'Fetch', 'FetchLater', 'GetVisualViewport', 'Open', 'ReportError', 'Screen', 'SetInterval', 'SetTimeout', 'Stop', 'StructuredClone', 'TrustedTypes', 'WebdriverException'],
+    'inRealms': ['Fetch', 'GetOpener'],
     'additionalTraits': ['crate::interfaces::WindowHelpers'],
-    'realm': ['CreateImageBitmap', 'CreateImageBitmap_'],
+    'realm': ['CreateImageBitmap', 'CreateImageBitmap_', 'WebdriverCallback'],
     'cx': ['PostMessage', 'PostMessage_']
 },
 


### PR DESCRIPTION
This is a first step to compile scripts using `&mut JSContext`.

Testing: Refactor, covered by existing WPT tests.
Part of #40600
