### PR TITLE
script: Use `touchstart` element as event target for `touchmove`/`touchend`/`touchcancel`

### DIFF
--- a/components/script/dom/document_event_handler.rs
+++ b/components/script/dom/document_event_handler.rs
@@ -953,7 +953,6 @@ impl DocumentEventHandler {
             Finite::wrap(hit_test_result.point_in_frame.y as f64 + window.PageYOffset() as f64);
 
         // This is used to construct pointerevent and touchdown event.
-        // TODO: Need cleanup later.
         let pointer_touch = Touch::new(
             window,
             identifier,
@@ -1002,24 +1001,23 @@ impl DocumentEventHandler {
                 (current_target, pointer_touch)
             },
             _ => {
-                // https://w3c.github.io/touch-events/#dfn-touchend
-                // For move/up/cancel:
-                // The target of this event must be the same Element on which the touch
-                // point started when it was first placed on the surface,
-                // even if the touch point has since moved outside
-                // the interactive area of the target element.
-                let mut active = self.active_touch_points.borrow_mut();
-                let index = match active.iter().position(|t| t.Identifier() == identifier) {
-                    Some(i) => i,
-                    None => {
-                        warn!("No active touch point for {:?}", event.event_type);
-                        return Default::default();
-                    },
+                // From <https://w3c.github.io/touch-events/#dfn-touchend>:
+                // > For move/up/cancel:
+                // > The target of this event must be the same Element on which the touch
+                // > point started when it was first placed on the surface, even if the touch point
+                // > has since moved outside the interactive area of the target element.
+                let mut active_touch_points = self.active_touch_points.borrow_mut();
+                let Some(index) = active_touch_points
+                    .iter()
+                    .position(|point| point.Identifier() == identifier)
+                else {
+                    warn!("No active touch point for {:?}", event.event_type);
+                    return Default::default();
                 };
-                // original target from touchstart
-                let original_target = active[index].Target();
+                // This is the original target that was selected during `touchstart` event handling.
+                let original_target = active_touch_points[index].Target();
 
-                let changed_touch = Touch::new(
+                let touch_with_touchstart_target = Touch::new(
                     window,
                     identifier,
                     &original_target,
@@ -1035,36 +1033,26 @@ impl DocumentEventHandler {
                 // Update or remove the stored touch
                 match event.event_type {
                     TouchEventType::Move => {
-                        active[index] = Dom::from_ref(&*changed_touch);
+                        active_touch_points[index] = Dom::from_ref(&*touch_with_touchstart_target);
                     },
                     TouchEventType::Up | TouchEventType::Cancel => {
-                        active.swap_remove(index);
+                        active_touch_points.swap_remove(index);
                         self.remove_pointer_id_for_touch(identifier);
                     },
-                    TouchEventType::Down => unreachable!(),
+                    TouchEventType::Down => unreachable!("Should have been handled above"),
                 }
-                (original_target, changed_touch)
+                (original_target, touch_with_touchstart_target)
             },
         };
 
-        let touches = {
-            let active = self.active_touch_points.borrow();
-            TouchList::new(window, active.r(), can_gc)
-        };
-
-        let target_touches = {
-            let active = self.active_touch_points.borrow();
-            rooted_vec!(let mut filtered);
-            filtered.extend(
-                active
-                    .iter()
-                    .filter(|t| t.Target() == touch_dispatch_target)
-                    .cloned(),
-            );
-            TouchList::new(window, filtered.r(), can_gc)
-        };
-
-        let changed_touches = TouchList::new(window, from_ref(&&*changed_touch), can_gc);
+        rooted_vec!(let mut target_touches);
+        target_touches.extend(
+            self.active_touch_points
+                .borrow()
+                .iter()
+                .filter(|t| t.Target() == touch_dispatch_target)
+                .cloned(),
+        );
 
         let event_name = match event.event_type {
             TouchEventType::Down => "touchstart",
@@ -1081,9 +1069,9 @@ impl DocumentEventHandler {
             EventComposed::Composed,
             Some(window),
             0i32,
-            &touches,
-            &changed_touches,
-            &target_touches,
+            &TouchList::new(window, self.active_touch_points.borrow().r(), can_gc),
+            &TouchList::new(window, from_ref(&&*changed_touch), can_gc),
+            &TouchList::new(window, target_touches.r(), can_gc),
             // FIXME: modifier keys
             false,
             false,

--- a/components/script/dom/document_event_handler.rs
+++ b/components/script/dom/document_event_handler.rs
@@ -932,14 +932,8 @@ impl DocumentEventHandler {
         };
 
         let TouchId(identifier) = event.touch_id;
-        let event_name = match event.event_type {
-            TouchEventType::Down => "touchstart",
-            TouchEventType::Move => "touchmove",
-            TouchEventType::Up => "touchend",
-            TouchEventType::Cancel => "touchcancel",
-        };
 
-        let Some(el) = hit_test_result
+        let Some(element) = hit_test_result
             .node
             .inclusive_ancestors(ShadowIncluding::Yes)
             .find_map(DomRoot::downcast::<Element>)
@@ -948,7 +942,7 @@ impl DocumentEventHandler {
             return Default::default();
         };
 
-        let target = DomRoot::upcast::<EventTarget>(el);
+        let current_target = DomRoot::upcast::<EventTarget>(element);
         let window = &*self.window;
 
         let client_x = Finite::wrap(hit_test_result.point_in_frame.x as f64);
@@ -958,10 +952,19 @@ impl DocumentEventHandler {
         let page_y =
             Finite::wrap(hit_test_result.point_in_frame.y as f64 + window.PageYOffset() as f64);
 
-        let touch = Touch::new(
-            window, identifier, &target, client_x,
+        // This is used to construct pointerevent and touchdown event.
+        // TODO: Need cleanup later.
+        let pointer_touch = Touch::new(
+            window,
+            identifier,
+            &current_target,
+            client_x,
             client_y, // TODO: Get real screen coordinates?
-            client_x, client_y, page_x, page_y, can_gc,
+            client_x,
+            client_y,
+            page_x,
+            page_y,
+            can_gc,
         );
 
         // Dispatch pointer event before updating active touch points and before touch event.
@@ -976,7 +979,7 @@ impl DocumentEventHandler {
         let pointer_id = self.get_or_create_pointer_id_for_touch(identifier);
         let is_primary = self.is_primary_pointer(pointer_id);
 
-        let pointer_event = touch.to_pointer_event(
+        let pointer_event = pointer_touch.to_pointer_event(
             window,
             pointer_event_type,
             pointer_id,
@@ -986,48 +989,88 @@ impl DocumentEventHandler {
             Some(hit_test_result.point_in_node),
             can_gc,
         );
-        pointer_event.upcast::<Event>().fire(&target, can_gc);
+        pointer_event
+            .upcast::<Event>()
+            .fire(&current_target, can_gc);
 
-        match event.event_type {
+        let (touch_dispatch_target, changed_touch) = match event.event_type {
             TouchEventType::Down => {
                 // Add a new touch point
                 self.active_touch_points
                     .borrow_mut()
-                    .push(Dom::from_ref(&*touch));
+                    .push(Dom::from_ref(&*pointer_touch));
+                (current_target, pointer_touch)
             },
-            TouchEventType::Move => {
-                // Replace an existing touch point
-                let mut active_touch_points = self.active_touch_points.borrow_mut();
-                match active_touch_points
-                    .iter_mut()
-                    .find(|t| t.Identifier() == identifier)
-                {
-                    Some(t) => *t = Dom::from_ref(&*touch),
-                    None => warn!("Got a touchmove event for a non-active touch point"),
-                }
-            },
-            TouchEventType::Up | TouchEventType::Cancel => {
-                // Remove an existing touch point
-                let mut active_touch_points = self.active_touch_points.borrow_mut();
-                match active_touch_points
-                    .iter()
-                    .position(|t| t.Identifier() == identifier)
-                {
-                    Some(i) => {
-                        active_touch_points.swap_remove(i);
-                        // Remove the pointer ID mapping when touch ends
+            _ => {
+                // https://w3c.github.io/touch-events/#dfn-touchend
+                // For move/up/cancel:
+                // The target of this event must be the same Element on which the touch
+                // point started when it was first placed on the surface,
+                // even if the touch point has since moved outside
+                // the interactive area of the target element.
+                let mut active = self.active_touch_points.borrow_mut();
+                let index = match active.iter().position(|t| t.Identifier() == identifier) {
+                    Some(i) => i,
+                    None => {
+                        warn!("No active touch point for {:?}", event.event_type);
+                        return Default::default();
+                    },
+                };
+                // original target from touchstart
+                let original_target = active[index].Target();
+
+                let changed_touch = Touch::new(
+                    window,
+                    identifier,
+                    &original_target,
+                    client_x,
+                    client_y,
+                    client_x,
+                    client_y,
+                    page_x,
+                    page_y,
+                    can_gc,
+                );
+
+                // Update or remove the stored touch
+                match event.event_type {
+                    TouchEventType::Move => {
+                        active[index] = Dom::from_ref(&*changed_touch);
+                    },
+                    TouchEventType::Up | TouchEventType::Cancel => {
+                        active.swap_remove(index);
                         self.remove_pointer_id_for_touch(identifier);
                     },
-                    None => warn!("Got a touchend event for a non-active touch point"),
+                    TouchEventType::Down => unreachable!(),
                 }
+                (original_target, changed_touch)
             },
-        }
+        };
 
-        rooted_vec!(let mut target_touches);
         let touches = {
-            let touches = self.active_touch_points.borrow();
-            target_touches.extend(touches.iter().filter(|t| t.Target() == target).cloned());
-            TouchList::new(window, touches.r(), can_gc)
+            let active = self.active_touch_points.borrow();
+            TouchList::new(window, active.r(), can_gc)
+        };
+
+        let target_touches = {
+            let active = self.active_touch_points.borrow();
+            rooted_vec!(let mut filtered);
+            filtered.extend(
+                active
+                    .iter()
+                    .filter(|t| t.Target() == touch_dispatch_target)
+                    .cloned(),
+            );
+            TouchList::new(window, filtered.r(), can_gc)
+        };
+
+        let changed_touches = TouchList::new(window, from_ref(&&*changed_touch), can_gc);
+
+        let event_name = match event.event_type {
+            TouchEventType::Down => "touchstart",
+            TouchEventType::Move => "touchmove",
+            TouchEventType::Up => "touchend",
+            TouchEventType::Cancel => "touchcancel",
         };
 
         let touch_event = TouchEvent::new(
@@ -1039,8 +1082,8 @@ impl DocumentEventHandler {
             Some(window),
             0i32,
             &touches,
-            &TouchList::new(window, from_ref(&&*touch), can_gc),
-            &TouchList::new(window, target_touches.r(), can_gc),
+            &changed_touches,
+            &target_touches,
             // FIXME: modifier keys
             false,
             false,
@@ -1048,9 +1091,8 @@ impl DocumentEventHandler {
             false,
             can_gc,
         );
-
         let event = touch_event.upcast::<Event>();
-        event.fire(&target, can_gc);
+        event.fire(&touch_dispatch_target, can_gc);
         event.flags().into()
     }
 

--- a/tests/wpt/meta/pointerevents/compat/pointerevent_touch_target_after_pointerdown_target_removed.tentative.html.ini
+++ b/tests/wpt/meta/pointerevents/compat/pointerevent_touch_target_after_pointerdown_target_removed.tentative.html.ini
@@ -1,11 +1,5 @@
 [pointerevent_touch_target_after_pointerdown_target_removed.tentative.html]
-  [After a pointerdown listener removes its target, touch events should be fired on the touchstart target even though an orphan and pointer events should be fired on the parent]
-    expected: FAIL
-
   [After a pointerdown listener removes its target, click event should be fired on the pointerdown target parent]
-    expected: FAIL
-
-  [After a pointerdown listener removes its target, touchmove event should be fired on the pointerdown target]
     expected: FAIL
 
   [After a pointerdown listener moves the target to different position, touch events should be fired on the pointerdown target, but pointer events should be fired on the pointerdown target parent]

--- a/tests/wpt/meta/touch-events/multi-touch-interfaces.html.ini
+++ b/tests/wpt/meta/touch-events/multi-touch-interfaces.html.ini
@@ -1,3 +1,0 @@
-[multi-touch-interfaces.html]
-  [touchend event received]
-    expected: FAIL

--- a/tests/wpt/tests/webdriver/tests/classic/perform_actions/pointer_touch.py
+++ b/tests/wpt/tests/webdriver/tests/classic/perform_actions/pointer_touch.py
@@ -74,38 +74,6 @@ def test_touch_pointer_cancel_and_up(session, test_actions_pointer_page, touch_c
 
     assert results['touchstart']
     assert results["touchcancel"]
-    assert results["touchend"]
-    assert not results["click"]
-
-
-def test_touch_pointer_cancel_without_up(session, test_actions_pointer_page, touch_chain):
-    pointerArea = session.find.css("#pointerArea", all=False)
-
-    session.execute_script("""
-        window.events = {
-            touchstart: false,
-            touchcancel: false,
-            touchend: false,
-            click: false
-        };
-        const area = document.getElementById("pointerArea");
-        ['touchstart', 'touchcancel', 'touchend', 'click'].forEach(type => {
-            area.addEventListener(type, () => { window.events[type] = true; });
-        });
-    """)
-
-    touch_chain.pointer_move(0, 0, origin=pointerArea) \
-        .pointer_down() \
-        .pointer_cancel() \
-        .perform()
-
-    # Use delay to allow potential
-    # simulated click to spin (which should not if pointerCancel works)
-    time.sleep(1)
-    results = session.execute_script("return window.events;")
-
-    assert results['touchstart']
-    assert results["touchcancel"]
     assert not results["touchend"]
     assert not results["click"]
 


### PR DESCRIPTION
[Spec](https://w3c.github.io/touch-events/#dfn-touchend:~:text=screen%2E-,The,element,-%2E) for touchmove/touchend/touchcancel:
> The target of this event must be the same Element on which the [touch point](https://w3c.github.io/touch-events/#dfn-touch-point) started when it was first placed on the surface, even if the [touch point](https://w3c.github.io/touch-events/#dfn-touch-point) has since moved outside the interactive area of the target element.

Also, previously `touchend` can be fired after `touchcancel`, which was wrong and fixed in this PR.

Testing: Fully passes `/touch-events/multi-touch-interfaces.html` (511 subtests) and new passes in `pointerevents\compat\pointerevent_touch_target_after_pointerdown_target_removed.tentative.html`.

We also take the chance to update `pointercancel` related tests introduced in https://github.com/servo/servo/pull/41937: `touchcancel` should not be followed by `touchend` according to [spec](https://w3c.github.io/touch-events/#dfn-touchcancel).

