### PR TITLE
script: Refactors GPUComputePassEncoder to manage drop logic

### DIFF
--- a/components/script_bindings/codegen/Bindings.conf
+++ b/components/script_bindings/codegen/Bindings.conf
@@ -326,10 +326,6 @@ DOMInterfaces = {
     'canGc': ['Messages'],
 },
 
-'GPUComputePassEncoder': {
-    'allowDropImpl': True,
-},
-
 'GPUComputePipeline': {
     'allowDropImpl': True,
 },


### PR DESCRIPTION
Moves the drop logic for `GPUComputePassEncoder` to a separate `DroppableGPUComputePassEncoder` struct.

Testing: Tests that coverages webgpu just exist
Fixes: Partially #26488 
