### PR TITLE
script: Use the `Weak<ScriptThread>` reference for tracing instead of thread-local storage

### DIFF
--- a/components/script/script_runtime.rs
+++ b/components/script/script_runtime.rs
@@ -13,7 +13,7 @@ use std::ffi::{CStr, CString};
 use std::io::{Write, stdout};
 use std::ops::{Deref, DerefMut};
 use std::os::raw::c_void;
-use std::rc::Rc;
+use std::rc::{Rc, Weak};
 use std::sync::Mutex;
 use std::time::{Duration, Instant};
 use std::{os, ptr, thread};
@@ -51,7 +51,7 @@ use js::rust::wrappers2::{
 };
 use js::rust::{
     Handle, HandleObject as RustHandleObject, HandleValue, IntoHandle, JSEngine, JSEngineHandle,
-    ParentRuntime, Runtime as RustRuntime,
+    ParentRuntime, Runtime as RustRuntime, Trace,
 };
 use malloc_size_of::MallocSizeOfOps;
 use malloc_size_of_derive::MallocSizeOf;
@@ -62,6 +62,7 @@ use script_bindings::script_runtime::{mark_runtime_dead, runtime_is_alive};
 use servo_config::{opts, pref};
 use style::thread_state::{self, ThreadState};
 
+use crate::ScriptThread;
 use crate::dom::bindings::codegen::Bindings::PromiseBinding::PromiseJobCallback;
 use crate::dom::bindings::codegen::Bindings::ResponseBinding::Response_Binding::ResponseMethods;
 use crate::dom::bindings::codegen::Bindings::ResponseBinding::ResponseType as DOMResponseType;
@@ -91,7 +92,6 @@ use crate::messaging::{CommonScriptMsg, ScriptEventLoopSender};
 use crate::microtask::{EnqueuedPromiseCallback, Microtask, MicrotaskQueue};
 use crate::realms::{AlreadyInRealm, InRealm, enter_realm};
 use crate::script_module::EnsureModuleHooksInitialized;
-use crate::script_thread::trace_thread;
 use crate::task_source::TaskSourceName;
 
 static JOB_QUEUE_TRAPS: JobQueueTraps = JobQueueTraps {
@@ -669,6 +669,16 @@ pub(crate) fn notify_about_rejected_promises(global: &GlobalScope) {
     }
 }
 
+/// Data that is sent to SpiderMonkey runtime callbacks as a pointer, which allows access
+/// to the `Runtime` state.
+#[derive(Default, JSTraceable, MallocSizeOf)]
+struct RuntimeCallbackData {
+    script_event_loop_sender: Option<ScriptEventLoopSender>,
+    #[no_trace]
+    #[ignore_malloc_size_of = "ScriptThread measures its own memory itself."]
+    script_thread: Option<Weak<ScriptThread>>,
+}
+
 #[derive(JSTraceable, MallocSizeOf)]
 pub(crate) struct Runtime {
     #[ignore_malloc_size_of = "Type from mozjs"]
@@ -678,7 +688,8 @@ pub(crate) struct Runtime {
     pub(crate) microtask_queue: Rc<MicrotaskQueue>,
     #[ignore_malloc_size_of = "Type from mozjs"]
     job_queue: *mut JobQueue,
-    script_event_loop_sender: Option<Box<ScriptEventLoopSender>>,
+    /// The data that is set on the SpiderMonkey runtime callbacks as a pointer.
+    runtime_callback_data: Box<RuntimeCallbackData>,
 }
 
 impl Runtime {
@@ -719,7 +730,7 @@ impl Runtime {
     #[expect(unsafe_code)]
     pub(crate) unsafe fn new_with_parent(
         parent: Option<ParentRuntime>,
-        script_event_looper_sender: Option<ScriptEventLoopSender>,
+        script_event_loop_sender: Option<ScriptEventLoopSender>,
     ) -> Runtime {
         let mut runtime = if let Some(parent) = parent {
             unsafe { RustRuntime::create_with_parent(parent) }
@@ -728,8 +739,19 @@ impl Runtime {
         };
         let cx = runtime.cx();
 
+        let have_event_loop_sender = script_event_loop_sender.is_some();
+        let runtime_callback_data = Box::new(RuntimeCallbackData {
+            script_event_loop_sender,
+            script_thread: None,
+        });
+        let runtime_callback_data = Box::into_raw(runtime_callback_data);
+
         unsafe {
-            JS_AddExtraGCRootsTracer(cx, Some(trace_rust_roots), ptr::null_mut());
+            JS_AddExtraGCRootsTracer(
+                cx,
+                Some(trace_rust_roots),
+                runtime_callback_data as *mut c_void,
+            );
 
             JS_SetSecurityCallbacks(cx, &SECURITY_CALLBACKS);
 
@@ -769,8 +791,14 @@ impl Runtime {
             data: *mut c_void,
             dispatchable: *mut DispatchablePointer,
         ) -> bool {
-            let script_event_loop_sender: &ScriptEventLoopSender =
-                unsafe { &*(data as *mut ScriptEventLoopSender) };
+            let runtime_callback_data: &RuntimeCallbackData =
+                unsafe { &*(data as *mut RuntimeCallbackData) };
+            let Some(script_event_loop_sender) =
+                runtime_callback_data.script_event_loop_sender.as_ref()
+            else {
+                return false;
+            };
+
             let runnable = Runnable(dispatchable);
             let task = task!(dispatch_to_event_loop_message: move || {
                 if let Some(cx) = RustRuntime::get() {
@@ -788,14 +816,12 @@ impl Runtime {
                 .is_ok()
         }
 
-        let mut script_event_loop_sender_pointer = std::ptr::null_mut();
-        if let Some(script_event_loop_sender) = script_event_looper_sender {
-            script_event_loop_sender_pointer = Box::into_raw(Box::new(script_event_loop_sender));
+        if have_event_loop_sender {
             unsafe {
                 SetUpEventLoopDispatch(
                     cx,
                     Some(dispatch_to_event_loop),
-                    script_event_loop_sender_pointer as *mut c_void,
+                    runtime_callback_data as *mut c_void,
                 );
             }
         }
@@ -973,9 +999,14 @@ impl Runtime {
             rt: runtime,
             microtask_queue,
             job_queue,
-            script_event_loop_sender: (!script_event_loop_sender_pointer.is_null())
-                .then(|| unsafe { Box::from_raw(script_event_loop_sender_pointer) }),
+            runtime_callback_data: unsafe { Box::from_raw(runtime_callback_data) },
         }
+    }
+
+    pub(crate) fn set_script_thread(&mut self, script_thread: Weak<ScriptThread>) {
+        self.runtime_callback_data
+            .script_thread
+            .replace(script_thread);
     }
 
     pub(crate) fn thread_safe_js_context(&self) -> ThreadSafeJSContext {
@@ -1114,13 +1145,23 @@ unsafe extern "C" fn debug_gc_callback(
 }
 
 #[expect(unsafe_code)]
-unsafe extern "C" fn trace_rust_roots(tr: *mut JSTracer, _data: *mut os::raw::c_void) {
+unsafe extern "C" fn trace_rust_roots(tr: *mut JSTracer, data: *mut os::raw::c_void) {
     if !runtime_is_alive() {
         return;
     }
     trace!("starting custom root handler");
+
+    let runtime_callback_data = unsafe { &*(data as *const RuntimeCallbackData) };
+    if let Some(script_thread) = runtime_callback_data
+        .script_thread
+        .as_ref()
+        .and_then(Weak::upgrade)
+    {
+        trace!("tracing fields of ScriptThread");
+        unsafe { script_thread.trace(tr) };
+    };
+
     unsafe {
-        trace_thread(tr);
         trace_roots(tr);
         trace_refcounted_objects(tr);
         settings_stack::trace(tr);


### PR DESCRIPTION
This changes makes it so that tracing accesses the `ScriptThread` via a
weak reference set on the `Runtime` rather than thread local storage.
The idea is to use TLS less and less as time goes on. This is done by
creating a new data structure that holds all the data that is necessary
for SpiderMonkey callbacks in the `ScriptThread`.

Testing: This should not change behavior in a way that is observable
via testing.
