### PR TITLE
mach: enable type checking for etc/ci python files

### DIFF
--- a/etc/ci/chaos_monkey_test.py
+++ b/etc/ci/chaos_monkey_test.py
@@ -31,11 +31,14 @@ TEST_CMD = [
 # by random pipeline closure, so we ignore the status code
 # returned by the test command (which is why we can't use check_output).
 
-test_results = Popen(TEST_CMD, stdout=PIPE)
+test_results = Popen(TEST_CMD, stdout=PIPE, text=True)
 any_crashes = False
 
+if test_results.stdout is None:
+    sys.exit(1)
+
 for line in test_results.stdout:
-    report = json.loads(line.decode("utf-8"))
+    report = json.loads(line)
     if report.get("action") == "process_output":
         print("{} - {}".format(report.get("thread"), report.get("data")))
     status = report.get("status")

--- a/etc/ci/report_aggregated_expected_results.py
+++ b/etc/ci/report_aggregated_expected_results.py
@@ -272,8 +272,12 @@ def main():
 
         pr_number = get_pr_number()
         if pr_number:
-            process = subprocess.Popen(["gh", "pr", "comment", pr_number, "-F", "-"], stdin=subprocess.PIPE)
-            print(process.communicate(input=html_string.encode("utf-8"))[0])
+            process = subprocess.Popen(
+                ["gh", "pr", "comment", pr_number, "-F", "-"],
+                stdin=subprocess.PIPE,
+                text=True,
+            )
+            print(process.communicate(input=html_string)[0])
         else:
             print("Could not find PR number in environment. Not making GitHub comment.")
 

--- a/etc/ci/upload_nightly.py
+++ b/etc/ci/upload_nightly.py
@@ -19,9 +19,8 @@ from datetime import datetime
 from typing import List, Optional
 
 import sys
-from github import Github, Auth
-
-import boto3
+from github import Github, Auth  # pyrefly: ignore
+import boto3  # pyrefly: ignore
 
 
 def get_s3_secret(secret_from_environment: bool) -> tuple:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,6 +64,7 @@ search-path = [
 project-includes = [
     "python/**/*.py",
     "components/script_bindings",
+    "etc/ci/*.py",
 ]
 project-excludes = [
     "**/venv/**",


### PR DESCRIPTION
This enables type checking for Python files under etc/ci by adding
etc/ci/*.py to pyrefly's project-includes in pyproject.toml.

Enabling these checks surfaced a few type issues, which are addressed here :

a) Use text=True in subprocess usage to avoid bytes/str mismatches
b) Remove unnecessary encode/decode calls
c) Guard against None stdout in chaos_monkey_test.py
d) Suppress unresolved optional imports in upload_nightly.py
    (runtime dependencies declared via uv script metadata)

After these changes, ./mach test-tidy passes successfully locally.

Fixes: #42653