### PR TITLE
webgl: correctly handle corner case of active texture (the one at MAX_COMBINED_TEXTURE_IMAGE_UNITS)

### DIFF
--- a/components/script/dom/webgl/webglrenderingcontext.rs
+++ b/components/script/dom/webgl/webglrenderingcontext.rs
@@ -5089,12 +5089,12 @@ impl Textures {
     }
 
     fn set_active_unit_enum(&self, index: u32) -> WebGLResult<()> {
-        if index < constants::TEXTURE0 || (index - constants::TEXTURE0) as usize > self.units.len()
-        {
-            return Err(InvalidEnum);
+        if (constants::TEXTURE0..constants::TEXTURE0 + self.units.len() as u32).contains(&index) {
+            self.active_unit.set(index - constants::TEXTURE0);
+            Ok(())
+        } else {
+            Err(InvalidEnum)
         }
-        self.active_unit.set(index - constants::TEXTURE0);
-        Ok(())
     }
 
     pub(crate) fn active_texture_slot(


### PR DESCRIPTION
#42639 was actually the real issue, just solved less ideally. Instead of doing negative checks, which are easy to go wrong like before, we know do positive check which is more clear IMO. Because counting of units is 0-based, we need to not include upper limit.

WebGL spec is a mess, so I will rather link this MDN: https://developer.mozilla.org/en-US/docs/Web/API/WebGLRenderingContext/activeTexture#exceptions

Testing: Added test to WebGL CTS: https://github.com/KhronosGroup/WebGL/pull/3757, live at: https://sagudev.github.io/WebGL/sdk/tests/conformance/textures/misc/texture-active-bind.html
Fixes: #42639

Co-authored-by: Weixie Cui <cuiweixie@gmail.com>