### PR TITLE
Bump rust version to 1.92.0

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -19,7 +19,7 @@ ENV RUSTUP_HOME=/usr/local/rustup \
     CARGO_HOME=/usr/local/cargo \
     PATH=/usr/local/cargo/bin:$PATH \
     UV_TOOL_BIN_DIR=/usr/local/bin \
-    RUST_VERSION=1.91.0
+    RUST_VERSION=1.92.0
 
 # Keep the list of components in sync with `rust-toolchain.toml` file.
 RUN curl https://sh.rustup.rs -sSf \

--- a/components/script/dom/bindings/root.rs
+++ b/components/script/dom/bindings/root.rs
@@ -130,9 +130,9 @@ impl<T> Hash for LayoutDom<'_, T> {
     }
 }
 
+#[expect(clippy::non_canonical_clone_impl)]
 impl<T> Clone for LayoutDom<'_, T> {
     #[inline]
-    #[allow(clippy::non_canonical_clone_impl)]
     fn clone(&self) -> Self {
         assert_in_layout();
         *self

--- a/components/script/dom/document.rs
+++ b/components/script/dom/document.rs
@@ -3266,6 +3266,7 @@ impl Document {
     }
 
     /// <https://drafts.csswg.org/resize-observer/#broadcast-active-resize-observations>
+    #[expect(clippy::redundant_iter_cloned)]
     pub(crate) fn broadcast_active_resize_observations(
         &self,
         can_gc: CanGc,

--- a/components/script_bindings/lock.rs
+++ b/components/script_bindings/lock.rs
@@ -13,7 +13,6 @@ use std::sync::OnceLock;
 pub struct ThreadUnsafeOnceLock<T>(OnceLock<T>);
 
 impl<T> ThreadUnsafeOnceLock<T> {
-    #[expect(clippy::new_without_default)]
     pub const fn new() -> Self {
         Self(OnceLock::new())
     }

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -3,8 +3,8 @@
 # - the 'rust-overlay' module's url in shell.nix to point to a
 #   commit which supports the required rustc version
 # - the version in support/crown/rust-toolchain.toml
-# - the version in .github/devcontainer.json
-channel = "1.91.0"
+# - the version in .devcontainer/Dockerfile
+channel = "1.92.0"
 
 components = [
     "clippy",

--- a/shell.nix
+++ b/shell.nix
@@ -13,7 +13,9 @@ with import (builtins.fetchTarball {
   overlays = [
     (import (builtins.fetchTarball {
       # Bumped the channel in rust-toolchain.toml? Bump this commit too!
-      url = "https://github.com/oxalica/rust-overlay/archive/0881bcdf6c34cd3ba558b19d7a74d8ffc9e1fff0.tar.gz";
+      # Use the latest commit hash for the manifest associated with the relevant version number in
+      # https://github.com/oxalica/rust-overlay/tree/master/manifests
+      url = "https://github.com/oxalica/rust-overlay/archive/99cc5667eece98bb35dcf35f7e511031a8b7a125.tar.gz";
     }))
   ];
   config = {

--- a/support/crown/rust-toolchain.toml
+++ b/support/crown/rust-toolchain.toml
@@ -1,5 +1,5 @@
 [toolchain]
-channel = "1.91.0"
+channel = "1.92.0"
 
 components = [
     "clippy",


### PR DESCRIPTION
This is a prerequisite for using the new version of egui introduced in https://github.com/servo/servo/pull/42402.

Testing: No new behaviour.
