### PR TITLE
canvas: Change canvas to use JSContext instead of CanGc

### DIFF
--- a/components/script/dom/canvas/2d/canvas_state.rs
+++ b/components/script/dom/canvas/2d/canvas_state.rs
@@ -1741,24 +1741,24 @@ impl CanvasState {
     pub(super) fn create_image_data(
         &self,
         global: &GlobalScope,
-        cx: &mut JSContext,
         sw: i32,
         sh: i32,
+        can_gc: CanGc,
     ) -> Fallible<DomRoot<ImageData>> {
         if sw == 0 || sh == 0 {
             return Err(Error::IndexSize(None));
         }
-        ImageData::new(global, cx, sw.unsigned_abs(), sh.unsigned_abs(), None)
+        ImageData::new(global, sw.unsigned_abs(), sh.unsigned_abs(), None, can_gc)
     }
 
     // https://html.spec.whatwg.org/multipage/#dom-context-2d-createimagedata
     pub(super) fn create_image_data_(
         &self,
         global: &GlobalScope,
-        cx: &mut JSContext,
         imagedata: &ImageData,
+        can_gc: CanGc,
     ) -> Fallible<DomRoot<ImageData>> {
-        ImageData::new(global, cx, imagedata.Width(), imagedata.Height(), None)
+        ImageData::new(global, imagedata.Width(), imagedata.Height(), None, can_gc)
     }
 
     // https://html.spec.whatwg.org/multipage/#dom-context-2d-getimagedata
@@ -1767,11 +1767,11 @@ impl CanvasState {
         &self,
         canvas_size: Size2D<u32>,
         global: &GlobalScope,
-        cx: &mut JSContext,
         sx: i32,
         sy: i32,
         sw: i32,
         sh: i32,
+        can_gc: CanGc,
     ) -> Fallible<DomRoot<ImageData>> {
         // FIXME(nox): There are many arithmetic operations here that can
         // overflow or underflow, this should probably be audited.
@@ -1789,7 +1789,7 @@ impl CanvasState {
             Some(rect) => rect,
             None => {
                 // All the pixels are outside the canvas surface.
-                return ImageData::new(global, cx, size.width, size.height, None);
+                return ImageData::new(global, size.width, size.height, None, can_gc);
             },
         };
 
@@ -1809,7 +1809,7 @@ impl CanvasState {
             None
         };
 
-        ImageData::new(global, cx, size.width, size.height, data)
+        ImageData::new(global, size.width, size.height, data, can_gc)
     }
 
     // https://html.spec.whatwg.org/multipage/#dom-context-2d-putimagedata

--- a/components/script/dom/canvas/2d/canvas_state.rs
+++ b/components/script/dom/canvas/2d/canvas_state.rs
@@ -24,6 +24,7 @@ use fonts::{
     FontBaseline, FontContext, FontGroup, FontIdentifier, FontMetrics, FontRef,
     LAST_RESORT_GLYPH_ADVANCE, ShapingFlags, ShapingOptions,
 };
+use js::context::JSContext;
 use net_traits::image_cache::{ImageCache, ImageResponse};
 use net_traits::request::CorsSettings;
 use pixels::{Snapshot, SnapshotAlphaMode, SnapshotPixelFormat};
@@ -1189,16 +1190,16 @@ impl CanvasState {
     pub(super) fn create_linear_gradient(
         &self,
         global: &GlobalScope,
+        cx: &mut JSContext,
         x0: Finite<f64>,
         y0: Finite<f64>,
         x1: Finite<f64>,
         y1: Finite<f64>,
-        can_gc: CanGc,
     ) -> DomRoot<CanvasGradient> {
         CanvasGradient::new(
             global,
+            cx,
             CanvasGradientStyle::Linear(LinearGradientStyle::new(*x0, *y0, *x1, *y1, Vec::new())),
-            can_gc,
         )
     }
 
@@ -1207,13 +1208,13 @@ impl CanvasState {
     pub(super) fn create_radial_gradient(
         &self,
         global: &GlobalScope,
+        cx: &mut JSContext,
         x0: Finite<f64>,
         y0: Finite<f64>,
         r0: Finite<f64>,
         x1: Finite<f64>,
         y1: Finite<f64>,
         r1: Finite<f64>,
-        can_gc: CanGc,
     ) -> Fallible<DomRoot<CanvasGradient>> {
         if *r0 < 0. || *r1 < 0. {
             return Err(Error::IndexSize(None));
@@ -1221,6 +1222,7 @@ impl CanvasState {
 
         Ok(CanvasGradient::new(
             global,
+            cx,
             CanvasGradientStyle::Radial(RadialGradientStyle::new(
                 *x0,
                 *y0,
@@ -1230,7 +1232,6 @@ impl CanvasState {
                 *r1,
                 Vec::new(),
             )),
-            can_gc,
         ))
     }
 
@@ -1238,9 +1239,9 @@ impl CanvasState {
     pub(super) fn create_pattern(
         &self,
         global: &GlobalScope,
+        cx: &mut JSContext,
         image: CanvasImageSource,
         mut repetition: DOMString,
-        can_gc: CanGc,
     ) -> Fallible<Option<DomRoot<CanvasPattern>>> {
         let snapshot = match image {
             CanvasImageSource::HTMLImageElement(ref image) => {
@@ -1304,11 +1305,11 @@ impl CanvasState {
             let size = snapshot.size();
             Ok(Some(CanvasPattern::new(
                 global,
+                cx,
                 snapshot,
                 size.cast(),
                 rep,
                 self.is_origin_clean(image),
-                can_gc,
             )))
         } else {
             Err(Error::Syntax(None))
@@ -1471,7 +1472,7 @@ impl CanvasState {
         global: &GlobalScope,
         canvas: Option<&HTMLCanvasElement>,
         text: DOMString,
-        can_gc: CanGc,
+        cx: &mut JSContext,
     ) -> DomRoot<TextMetrics> {
         // > Step 1: If maxWidth was provided but is less than or equal to zero or equal to NaN, then return an empty array.0
         // Max width is not provided for `measureText()`.
@@ -1487,7 +1488,7 @@ impl CanvasState {
 
         let Some(font_context) = global.font_context() else {
             warn!("Tried to paint to a canvas of GlobalScope without a FontContext.");
-            return TextMetrics::default(global, can_gc);
+            return TextMetrics::default(global, cx);
         };
 
         let font_style = self.font_style();
@@ -1540,6 +1541,7 @@ impl CanvasState {
 
         TextMetrics::new(
             global,
+            cx,
             total_advance as f64,
             anchor_x - bounding_box.min_x(),
             bounding_box.max_x() - anchor_x,
@@ -1552,7 +1554,6 @@ impl CanvasState {
             hanging_baseline - anchor_y,
             alphabetic_baseline - anchor_y,
             ideographic_baseline - anchor_y,
-            can_gc,
         )
     }
 
@@ -1740,24 +1741,24 @@ impl CanvasState {
     pub(super) fn create_image_data(
         &self,
         global: &GlobalScope,
+        cx: &mut JSContext,
         sw: i32,
         sh: i32,
-        can_gc: CanGc,
     ) -> Fallible<DomRoot<ImageData>> {
         if sw == 0 || sh == 0 {
             return Err(Error::IndexSize(None));
         }
-        ImageData::new(global, sw.unsigned_abs(), sh.unsigned_abs(), None, can_gc)
+        ImageData::new(global, cx, sw.unsigned_abs(), sh.unsigned_abs(), None)
     }
 
     // https://html.spec.whatwg.org/multipage/#dom-context-2d-createimagedata
     pub(super) fn create_image_data_(
         &self,
         global: &GlobalScope,
+        cx: &mut JSContext,
         imagedata: &ImageData,
-        can_gc: CanGc,
     ) -> Fallible<DomRoot<ImageData>> {
-        ImageData::new(global, imagedata.Width(), imagedata.Height(), None, can_gc)
+        ImageData::new(global, cx, imagedata.Width(), imagedata.Height(), None)
     }
 
     // https://html.spec.whatwg.org/multipage/#dom-context-2d-getimagedata
@@ -1766,11 +1767,11 @@ impl CanvasState {
         &self,
         canvas_size: Size2D<u32>,
         global: &GlobalScope,
+        cx: &mut JSContext,
         sx: i32,
         sy: i32,
         sw: i32,
         sh: i32,
-        can_gc: CanGc,
     ) -> Fallible<DomRoot<ImageData>> {
         // FIXME(nox): There are many arithmetic operations here that can
         // overflow or underflow, this should probably be audited.
@@ -1788,7 +1789,7 @@ impl CanvasState {
             Some(rect) => rect,
             None => {
                 // All the pixels are outside the canvas surface.
-                return ImageData::new(global, size.width, size.height, None, can_gc);
+                return ImageData::new(global, cx, size.width, size.height, None);
             },
         };
 
@@ -1808,7 +1809,7 @@ impl CanvasState {
             None
         };
 
-        ImageData::new(global, size.width, size.height, data, can_gc)
+        ImageData::new(global, cx, size.width, size.height, data)
     }
 
     // https://html.spec.whatwg.org/multipage/#dom-context-2d-putimagedata
@@ -2106,9 +2107,13 @@ impl CanvasState {
     }
 
     // https://html.spec.whatwg.org/multipage/#dom-context-2d-gettransform
-    pub(super) fn get_transform(&self, global: &GlobalScope, can_gc: CanGc) -> DomRoot<DOMMatrix> {
+    pub(super) fn get_transform(
+        &self,
+        global: &GlobalScope,
+        cx: &mut JSContext,
+    ) -> DomRoot<DOMMatrix> {
         let transform = self.state.borrow_mut().transform;
-        DOMMatrix::new(global, true, transform.to_3d(), can_gc)
+        DOMMatrix::new(global, true, transform.to_3d(), CanGc::from_cx(cx))
     }
 
     /// <https://html.spec.whatwg.org/multipage/#dom-context-2d-settransform>

--- a/components/script/dom/canvas/2d/canvasgradient.rs
+++ b/components/script/dom/canvas/2d/canvasgradient.rs
@@ -6,6 +6,7 @@ use canvas_traits::canvas::{
     CanvasGradientStop, FillOrStrokeStyle, LinearGradientStyle, RadialGradientStyle,
 };
 use dom_struct::dom_struct;
+use js::context::JSContext;
 
 use super::canvas_state::parse_color;
 use crate::dom::bindings::cell::DomRefCell;
@@ -44,13 +45,13 @@ impl CanvasGradient {
 
     pub(crate) fn new(
         global: &GlobalScope,
+        cx: &mut JSContext,
         style: CanvasGradientStyle,
-        can_gc: CanGc,
     ) -> DomRoot<CanvasGradient> {
         reflect_dom_object(
             Box::new(CanvasGradient::new_inherited(style)),
             global,
-            can_gc,
+            CanGc::from_cx(cx),
         )
     }
 }

--- a/components/script/dom/canvas/2d/canvaspattern.rs
+++ b/components/script/dom/canvas/2d/canvaspattern.rs
@@ -5,6 +5,7 @@
 use canvas_traits::canvas::{FillOrStrokeStyle, RepetitionStyle, SurfaceStyle};
 use dom_struct::dom_struct;
 use euclid::default::{Size2D, Transform2D};
+use js::context::JSContext;
 use pixels::{SharedSnapshot, Snapshot};
 
 use crate::dom::bindings::cell::DomRefCell;
@@ -59,11 +60,11 @@ impl CanvasPattern {
     }
     pub(crate) fn new(
         global: &GlobalScope,
+        cx: &mut JSContext,
         surface_data: Snapshot,
         surface_size: Size2D<u32>,
         repeat: RepetitionStyle,
         origin_clean: bool,
-        can_gc: CanGc,
     ) -> DomRoot<CanvasPattern> {
         reflect_dom_object(
             Box::new(CanvasPattern::new_inherited(
@@ -73,7 +74,7 @@ impl CanvasPattern {
                 origin_clean,
             )),
             global,
-            can_gc,
+            CanGc::from_cx(cx),
         )
     }
     pub(crate) fn origin_is_clean(&self) -> bool {

--- a/components/script/dom/canvas/2d/canvasrenderingcontext2d.rs
+++ b/components/script/dom/canvas/2d/canvasrenderingcontext2d.rs
@@ -513,37 +513,32 @@ impl CanvasRenderingContext2DMethods<crate::DomTypeHolder> for CanvasRenderingCo
     }
 
     /// <https://html.spec.whatwg.org/multipage/#dom-context-2d-createimagedata>
-    fn CreateImageData(
-        &self,
-        cx: &mut JSContext,
-        sw: i32,
-        sh: i32,
-    ) -> Fallible<DomRoot<ImageData>> {
+    fn CreateImageData(&self, sw: i32, sh: i32, can_gc: CanGc) -> Fallible<DomRoot<ImageData>> {
         self.canvas_state
-            .create_image_data(&self.global(), cx, sw, sh)
+            .create_image_data(&self.global(), sw, sh, can_gc)
     }
 
     /// <https://html.spec.whatwg.org/multipage/#dom-context-2d-createimagedata>
     fn CreateImageData_(
         &self,
-        cx: &mut JSContext,
         imagedata: &ImageData,
+        can_gc: CanGc,
     ) -> Fallible<DomRoot<ImageData>> {
         self.canvas_state
-            .create_image_data_(&self.global(), cx, imagedata)
+            .create_image_data_(&self.global(), imagedata, can_gc)
     }
 
     /// <https://html.spec.whatwg.org/multipage/#dom-context-2d-getimagedata>
     fn GetImageData(
         &self,
-        cx: &mut JSContext,
         sx: i32,
         sy: i32,
         sw: i32,
         sh: i32,
+        can_gc: CanGc,
     ) -> Fallible<DomRoot<ImageData>> {
         self.canvas_state
-            .get_image_data(self.canvas.size(), &self.global(), cx, sx, sy, sw, sh)
+            .get_image_data(self.canvas.size(), &self.global(), sx, sy, sw, sh, can_gc)
     }
 
     /// <https://html.spec.whatwg.org/multipage/#dom-context-2d-putimagedata>

--- a/components/script/dom/canvas/2d/canvasrenderingcontext2d.rs
+++ b/components/script/dom/canvas/2d/canvasrenderingcontext2d.rs
@@ -6,6 +6,7 @@ use base::{Epoch, generic_channel};
 use canvas_traits::canvas::{Canvas2dMsg, CanvasId};
 use dom_struct::dom_struct;
 use euclid::default::Size2D;
+use js::context::JSContext;
 use pixels::Snapshot;
 use script_bindings::reflector::AssociatedMemory;
 use servo_url::ServoUrl;
@@ -194,8 +195,8 @@ impl CanvasRenderingContext2DMethods<crate::DomTypeHolder> for CanvasRenderingCo
     }
 
     /// <https://html.spec.whatwg.org/multipage/#dom-context-2d-gettransform>
-    fn GetTransform(&self, can_gc: CanGc) -> DomRoot<DOMMatrix> {
-        self.canvas_state.get_transform(&self.global(), can_gc)
+    fn GetTransform(&self, cx: &mut JSContext) -> DomRoot<DOMMatrix> {
+        self.canvas_state.get_transform(&self.global(), cx)
     }
 
     /// <https://html.spec.whatwg.org/multipage/#dom-context-2d-settransform>
@@ -335,13 +336,9 @@ impl CanvasRenderingContext2DMethods<crate::DomTypeHolder> for CanvasRenderingCo
     }
 
     /// <https://html.spec.whatwg.org/multipage/#textmetrics>
-    fn MeasureText(&self, text: DOMString, can_gc: CanGc) -> DomRoot<TextMetrics> {
-        self.canvas_state.measure_text(
-            &self.global(),
-            self.canvas.canvas().as_deref(),
-            text,
-            can_gc,
-        )
+    fn MeasureText(&self, cx: &mut JSContext, text: DOMString) -> DomRoot<TextMetrics> {
+        self.canvas_state
+            .measure_text(&self.global(), self.canvas.canvas().as_deref(), text, cx)
     }
 
     /// <https://html.spec.whatwg.org/multipage/#dom-context-2d-font>
@@ -516,32 +513,37 @@ impl CanvasRenderingContext2DMethods<crate::DomTypeHolder> for CanvasRenderingCo
     }
 
     /// <https://html.spec.whatwg.org/multipage/#dom-context-2d-createimagedata>
-    fn CreateImageData(&self, sw: i32, sh: i32, can_gc: CanGc) -> Fallible<DomRoot<ImageData>> {
+    fn CreateImageData(
+        &self,
+        cx: &mut JSContext,
+        sw: i32,
+        sh: i32,
+    ) -> Fallible<DomRoot<ImageData>> {
         self.canvas_state
-            .create_image_data(&self.global(), sw, sh, can_gc)
+            .create_image_data(&self.global(), cx, sw, sh)
     }
 
     /// <https://html.spec.whatwg.org/multipage/#dom-context-2d-createimagedata>
     fn CreateImageData_(
         &self,
+        cx: &mut JSContext,
         imagedata: &ImageData,
-        can_gc: CanGc,
     ) -> Fallible<DomRoot<ImageData>> {
         self.canvas_state
-            .create_image_data_(&self.global(), imagedata, can_gc)
+            .create_image_data_(&self.global(), cx, imagedata)
     }
 
     /// <https://html.spec.whatwg.org/multipage/#dom-context-2d-getimagedata>
     fn GetImageData(
         &self,
+        cx: &mut JSContext,
         sx: i32,
         sy: i32,
         sw: i32,
         sh: i32,
-        can_gc: CanGc,
     ) -> Fallible<DomRoot<ImageData>> {
         self.canvas_state
-            .get_image_data(self.canvas.size(), &self.global(), sx, sy, sw, sh, can_gc)
+            .get_image_data(self.canvas.size(), &self.global(), cx, sx, sy, sw, sh)
     }
 
     /// <https://html.spec.whatwg.org/multipage/#dom-context-2d-putimagedata>
@@ -577,40 +579,40 @@ impl CanvasRenderingContext2DMethods<crate::DomTypeHolder> for CanvasRenderingCo
     /// <https://html.spec.whatwg.org/multipage/#dom-context-2d-createlineargradient>
     fn CreateLinearGradient(
         &self,
+        cx: &mut JSContext,
         x0: Finite<f64>,
         y0: Finite<f64>,
         x1: Finite<f64>,
         y1: Finite<f64>,
-        can_gc: CanGc,
     ) -> DomRoot<CanvasGradient> {
         self.canvas_state
-            .create_linear_gradient(&self.global(), x0, y0, x1, y1, can_gc)
+            .create_linear_gradient(&self.global(), cx, x0, y0, x1, y1)
     }
 
     /// <https://html.spec.whatwg.org/multipage/#dom-context-2d-createradialgradient>
     fn CreateRadialGradient(
         &self,
+        cx: &mut JSContext,
         x0: Finite<f64>,
         y0: Finite<f64>,
         r0: Finite<f64>,
         x1: Finite<f64>,
         y1: Finite<f64>,
         r1: Finite<f64>,
-        can_gc: CanGc,
     ) -> Fallible<DomRoot<CanvasGradient>> {
         self.canvas_state
-            .create_radial_gradient(&self.global(), x0, y0, r0, x1, y1, r1, can_gc)
+            .create_radial_gradient(&self.global(), cx, x0, y0, r0, x1, y1, r1)
     }
 
     /// <https://html.spec.whatwg.org/multipage/#dom-context-2d-createpattern>
     fn CreatePattern(
         &self,
+        cx: &mut JSContext,
         image: CanvasImageSource,
         repetition: DOMString,
-        can_gc: CanGc,
     ) -> Fallible<Option<DomRoot<CanvasPattern>>> {
         self.canvas_state
-            .create_pattern(&self.global(), image, repetition, can_gc)
+            .create_pattern(&self.global(), cx, image, repetition)
     }
 
     /// <https://html.spec.whatwg.org/multipage/#dom-context-2d-linewidth>

--- a/components/script/dom/canvas/2d/offscreencanvasrenderingcontext2d.rs
+++ b/components/script/dom/canvas/2d/offscreencanvasrenderingcontext2d.rs
@@ -5,6 +5,7 @@
 use canvas_traits::canvas::Canvas2dMsg;
 use dom_struct::dom_struct;
 use euclid::default::Size2D;
+use js::context::JSContext;
 use pixels::Snapshot;
 
 use crate::canvas_context::{CanvasContext, HTMLCanvasElementOrOffscreenCanvas};
@@ -189,38 +190,38 @@ impl OffscreenCanvasRenderingContext2DMethods<crate::DomTypeHolder>
     /// <https://html.spec.whatwg.org/multipage/#dom-context-2d-createlineargradient>
     fn CreateLinearGradient(
         &self,
+        cx: &mut JSContext,
         x0: Finite<f64>,
         y0: Finite<f64>,
         x1: Finite<f64>,
         y1: Finite<f64>,
-        can_gc: CanGc,
     ) -> DomRoot<CanvasGradient> {
-        self.context.CreateLinearGradient(x0, y0, x1, y1, can_gc)
+        self.context.CreateLinearGradient(cx, x0, y0, x1, y1)
     }
 
     /// <https://html.spec.whatwg.org/multipage/#dom-context-2d-createradialgradient>
     fn CreateRadialGradient(
         &self,
+        cx: &mut JSContext,
         x0: Finite<f64>,
         y0: Finite<f64>,
         r0: Finite<f64>,
         x1: Finite<f64>,
         y1: Finite<f64>,
         r1: Finite<f64>,
-        can_gc: CanGc,
     ) -> Fallible<DomRoot<CanvasGradient>> {
         self.context
-            .CreateRadialGradient(x0, y0, r0, x1, y1, r1, can_gc)
+            .CreateRadialGradient(cx, x0, y0, r0, x1, y1, r1)
     }
 
     /// <https://html.spec.whatwg.org/multipage/#dom-context-2d-createpattern>
     fn CreatePattern(
         &self,
+        cx: &mut JSContext,
         image: CanvasImageSource,
         repetition: DOMString,
-        can_gc: CanGc,
     ) -> Fallible<Option<DomRoot<CanvasPattern>>> {
-        self.context.CreatePattern(image, repetition, can_gc)
+        self.context.CreatePattern(cx, image, repetition)
     }
 
     /// <https://html.spec.whatwg.org/multipage/#dom-context-2d-save>
@@ -279,8 +280,8 @@ impl OffscreenCanvasRenderingContext2DMethods<crate::DomTypeHolder>
     }
 
     /// <https://html.spec.whatwg.org/multipage/#textmetrics>
-    fn MeasureText(&self, text: DOMString, can_gc: CanGc) -> DomRoot<TextMetrics> {
-        self.context.MeasureText(text, can_gc)
+    fn MeasureText(&self, cx: &mut JSContext, text: DOMString) -> DomRoot<TextMetrics> {
+        self.context.MeasureText(cx, text)
     }
 
     /// <https://html.spec.whatwg.org/multipage/#dom-context-2d-font>
@@ -384,29 +385,34 @@ impl OffscreenCanvasRenderingContext2DMethods<crate::DomTypeHolder>
     }
 
     /// <https://html.spec.whatwg.org/multipage/#dom-context-2d-createimagedata>
-    fn CreateImageData(&self, sw: i32, sh: i32, can_gc: CanGc) -> Fallible<DomRoot<ImageData>> {
-        self.context.CreateImageData(sw, sh, can_gc)
+    fn CreateImageData(
+        &self,
+        cx: &mut JSContext,
+        sw: i32,
+        sh: i32,
+    ) -> Fallible<DomRoot<ImageData>> {
+        self.context.CreateImageData(cx, sw, sh)
     }
 
     /// <https://html.spec.whatwg.org/multipage/#dom-context-2d-createimagedata>
     fn CreateImageData_(
         &self,
+        cx: &mut JSContext,
         imagedata: &ImageData,
-        can_gc: CanGc,
     ) -> Fallible<DomRoot<ImageData>> {
-        self.context.CreateImageData_(imagedata, can_gc)
+        self.context.CreateImageData_(cx, imagedata)
     }
 
     /// <https://html.spec.whatwg.org/multipage/#dom-context-2d-getimagedata>
     fn GetImageData(
         &self,
+        cx: &mut JSContext,
         sx: i32,
         sy: i32,
         sw: i32,
         sh: i32,
-        can_gc: CanGc,
     ) -> Fallible<DomRoot<ImageData>> {
-        self.context.GetImageData(sx, sy, sw, sh, can_gc)
+        self.context.GetImageData(cx, sx, sy, sw, sh)
     }
 
     /// <https://html.spec.whatwg.org/multipage/#dom-context-2d-putimagedata>
@@ -536,8 +542,8 @@ impl OffscreenCanvasRenderingContext2DMethods<crate::DomTypeHolder>
     }
 
     /// <https://html.spec.whatwg.org/multipage/#dom-context-2d-gettransform>
-    fn GetTransform(&self, can_gc: CanGc) -> DomRoot<DOMMatrix> {
-        self.context.GetTransform(can_gc)
+    fn GetTransform(&self, cx: &mut JSContext) -> DomRoot<DOMMatrix> {
+        self.context.GetTransform(cx)
     }
 
     /// <https://html.spec.whatwg.org/multipage/#dom-context-2d-settransform>

--- a/components/script/dom/canvas/2d/offscreencanvasrenderingcontext2d.rs
+++ b/components/script/dom/canvas/2d/offscreencanvasrenderingcontext2d.rs
@@ -391,7 +391,7 @@ impl OffscreenCanvasRenderingContext2DMethods<crate::DomTypeHolder>
         sw: i32,
         sh: i32,
     ) -> Fallible<DomRoot<ImageData>> {
-        self.context.CreateImageData(cx, sw, sh)
+        self.context.CreateImageData(sw, sh, CanGc::from_cx(cx))
     }
 
     /// <https://html.spec.whatwg.org/multipage/#dom-context-2d-createimagedata>
@@ -400,7 +400,7 @@ impl OffscreenCanvasRenderingContext2DMethods<crate::DomTypeHolder>
         cx: &mut JSContext,
         imagedata: &ImageData,
     ) -> Fallible<DomRoot<ImageData>> {
-        self.context.CreateImageData_(cx, imagedata)
+        self.context.CreateImageData_(imagedata, CanGc::from_cx(cx))
     }
 
     /// <https://html.spec.whatwg.org/multipage/#dom-context-2d-getimagedata>
@@ -412,7 +412,8 @@ impl OffscreenCanvasRenderingContext2DMethods<crate::DomTypeHolder>
         sw: i32,
         sh: i32,
     ) -> Fallible<DomRoot<ImageData>> {
-        self.context.GetImageData(cx, sx, sy, sw, sh)
+        self.context
+            .GetImageData(sx, sy, sw, sh, CanGc::from_cx(cx))
     }
 
     /// <https://html.spec.whatwg.org/multipage/#dom-context-2d-putimagedata>

--- a/components/script/dom/canvas/2d/paintrenderingcontext2d.rs
+++ b/components/script/dom/canvas/2d/paintrenderingcontext2d.rs
@@ -6,6 +6,7 @@ use std::cell::Cell;
 
 use dom_struct::dom_struct;
 use euclid::{Scale, Size2D};
+use js::context::JSContext;
 use script_bindings::reflector::Reflector;
 use servo_url::ServoUrl;
 use style_traits::CSSPixel;
@@ -140,8 +141,8 @@ impl PaintRenderingContext2DMethods<crate::DomTypeHolder> for PaintRenderingCont
     }
 
     /// <https://html.spec.whatwg.org/multipage/#dom-context-2d-gettransform>
-    fn GetTransform(&self, can_gc: CanGc) -> DomRoot<DOMMatrix> {
-        self.canvas_state.get_transform(&self.global(), can_gc)
+    fn GetTransform(&self, cx: &mut JSContext) -> DomRoot<DOMMatrix> {
+        self.canvas_state.get_transform(&self.global(), cx)
     }
 
     /// <https://html.spec.whatwg.org/multipage/#dom-context-2d-settransform>
@@ -370,40 +371,40 @@ impl PaintRenderingContext2DMethods<crate::DomTypeHolder> for PaintRenderingCont
     /// <https://html.spec.whatwg.org/multipage/#dom-context-2d-createlineargradient>
     fn CreateLinearGradient(
         &self,
+        cx: &mut JSContext,
         x0: Finite<f64>,
         y0: Finite<f64>,
         x1: Finite<f64>,
         y1: Finite<f64>,
-        can_gc: CanGc,
     ) -> DomRoot<CanvasGradient> {
         self.canvas_state
-            .create_linear_gradient(&self.global(), x0, y0, x1, y1, can_gc)
+            .create_linear_gradient(&self.global(), cx, x0, y0, x1, y1)
     }
 
     /// <https://html.spec.whatwg.org/multipage/#dom-context-2d-createradialgradient>
     fn CreateRadialGradient(
         &self,
+        cx: &mut JSContext,
         x0: Finite<f64>,
         y0: Finite<f64>,
         r0: Finite<f64>,
         x1: Finite<f64>,
         y1: Finite<f64>,
         r1: Finite<f64>,
-        can_gc: CanGc,
     ) -> Fallible<DomRoot<CanvasGradient>> {
         self.canvas_state
-            .create_radial_gradient(&self.global(), x0, y0, r0, x1, y1, r1, can_gc)
+            .create_radial_gradient(&self.global(), cx, x0, y0, r0, x1, y1, r1)
     }
 
     /// <https://html.spec.whatwg.org/multipage/#dom-context-2d-createpattern>
     fn CreatePattern(
         &self,
+        cx: &mut JSContext,
         image: CanvasImageSource,
         repetition: DOMString,
-        can_gc: CanGc,
     ) -> Fallible<Option<DomRoot<CanvasPattern>>> {
         self.canvas_state
-            .create_pattern(&self.global(), image, repetition, can_gc)
+            .create_pattern(&self.global(), cx, image, repetition)
     }
 
     /// <https://html.spec.whatwg.org/multipage/#dom-context-2d-linewidth>

--- a/components/script/dom/canvas/2d/textmetrics.rs
+++ b/components/script/dom/canvas/2d/textmetrics.rs
@@ -3,6 +3,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 use dom_struct::dom_struct;
+use js::context::JSContext;
 
 use crate::dom::bindings::codegen::Bindings::TextMetricsBinding::TextMetricsMethods;
 use crate::dom::bindings::num::Finite;
@@ -66,6 +67,7 @@ impl TextMetrics {
     #[expect(clippy::too_many_arguments)]
     pub(crate) fn new(
         global: &GlobalScope,
+        cx: &mut JSContext,
         width: f64,
         actualBoundingBoxLeft: f64,
         actualBoundingBoxRight: f64,
@@ -78,7 +80,6 @@ impl TextMetrics {
         hangingBaseline: f64,
         alphabeticBaseline: f64,
         ideographicBaseline: f64,
-        can_gc: CanGc,
     ) -> DomRoot<TextMetrics> {
         reflect_dom_object(
             Box::new(TextMetrics::new_inherited(
@@ -96,11 +97,11 @@ impl TextMetrics {
                 ideographicBaseline,
             )),
             global,
-            can_gc,
+            CanGc::from_cx(cx),
         )
     }
 
-    pub(crate) fn default(global: &GlobalScope, can_gc: CanGc) -> DomRoot<Self> {
+    pub(crate) fn default(global: &GlobalScope, cx: &mut JSContext) -> DomRoot<Self> {
         reflect_dom_object(
             Box::new(Self {
                 reflector_: Reflector::new(),
@@ -118,7 +119,7 @@ impl TextMetrics {
                 ideographicBaseline: Default::default(),
             }),
             global,
-            can_gc,
+            CanGc::from_cx(cx),
         )
     }
 }

--- a/components/script/dom/canvas/imagedata.rs
+++ b/components/script/dom/canvas/imagedata.rs
@@ -10,7 +10,6 @@ use base::id::{ImageDataId, ImageDataIndex};
 use constellation_traits::SerializableImageData;
 use dom_struct::dom_struct;
 use euclid::default::{Rect, Size2D};
-use js::context::JSContext;
 use js::gc::CustomAutoRooterGuard;
 use js::jsapi::JSObject;
 use js::rust::HandleObject;
@@ -48,10 +47,10 @@ pub(crate) struct ImageData {
 impl ImageData {
     pub(crate) fn new(
         global: &GlobalScope,
-        cx: &mut JSContext,
         width: u32,
         height: u32,
         mut data: Option<Vec<u8>>,
+        can_gc: CanGc,
     ) -> Fallible<DomRoot<ImageData>> {
         let len =
             pixels::compute_rgba8_byte_length_if_within_limit(width as usize, height as usize)
@@ -67,27 +66,16 @@ impl ImageData {
         if let Some(ref mut d) = data {
             d.resize(len as usize, 0);
 
-            rooted!(&in(cx) let mut js_object = std::ptr::null_mut::<JSObject>());
-            let _buffer_source = create_buffer_source::<ClampedU8>(
-                cx.into(),
-                &d[..],
-                js_object.handle_mut(),
-                CanGc::from_cx(cx),
-            )
-            .map_err(|_| Error::JSFailed)?;
+            let cx = GlobalScope::get_cx();
+            rooted!(in(*cx) let mut js_object = std::ptr::null_mut::<JSObject>());
+            let _buffer_source =
+                create_buffer_source::<ClampedU8>(cx, &d[..], js_object.handle_mut(), can_gc)
+                    .map_err(|_| Error::JSFailed)?;
             auto_root!(&in(cx) let data = TypedArray::<ClampedU8, *mut JSObject>::from(js_object.get()).map_err(|_| Error::JSFailed)?);
 
-            Self::Constructor_(
-                global,
-                None,
-                CanGc::from_cx(cx),
-                data,
-                width,
-                Some(height),
-                &settings,
-            )
+            Self::Constructor_(global, None, can_gc, data, width, Some(height), &settings)
         } else {
-            Self::Constructor(global, None, CanGc::from_cx(cx), width, height, &settings)
+            Self::Constructor(global, None, can_gc, width, height, &settings)
         }
     }
 
@@ -253,7 +241,11 @@ impl Serializable for ImageData {
     }
 
     /// <https://html.spec.whatwg.org/multipage/#the-imagedata-interface:deserialization-steps>
-    fn deserialize(owner: &GlobalScope, serialized: Self::Data) -> Result<DomRoot<Self>, ()> {
+    fn deserialize(
+        owner: &GlobalScope,
+        serialized: Self::Data,
+        can_gc: CanGc,
+    ) -> Result<DomRoot<Self>, ()> {
         // Step 1 Initialize value's data attribute to the sub-deserialization of serialized.[[Data]].
         // Step 2 Initialize value's width attribute to serialized.[[Width]].
         // Step 3 Initialize value's height attribute to serialized.[[Height]].
@@ -261,10 +253,10 @@ impl Serializable for ImageData {
         // Step 5 Initialize value's pixelFormat attribute to serialized.[[PixelFormat]].
         ImageData::new(
             owner,
-            cx,
             serialized.width,
             serialized.height,
             Some(serialized.data),
+            can_gc,
         )
         .map_err(|_| ())
     }

--- a/components/script/dom/canvas/imagedata.rs
+++ b/components/script/dom/canvas/imagedata.rs
@@ -10,6 +10,7 @@ use base::id::{ImageDataId, ImageDataIndex};
 use constellation_traits::SerializableImageData;
 use dom_struct::dom_struct;
 use euclid::default::{Rect, Size2D};
+use js::context::JSContext;
 use js::gc::CustomAutoRooterGuard;
 use js::jsapi::JSObject;
 use js::rust::HandleObject;
@@ -30,7 +31,7 @@ use crate::dom::bindings::root::DomRoot;
 use crate::dom::bindings::serializable::Serializable;
 use crate::dom::bindings::structuredclone::StructuredData;
 use crate::dom::globalscope::GlobalScope;
-use crate::script_runtime::{CanGc, JSContext};
+use crate::script_runtime::CanGc;
 
 #[dom_struct]
 pub(crate) struct ImageData {
@@ -47,10 +48,10 @@ pub(crate) struct ImageData {
 impl ImageData {
     pub(crate) fn new(
         global: &GlobalScope,
+        cx: &mut JSContext,
         width: u32,
         height: u32,
         mut data: Option<Vec<u8>>,
-        can_gc: CanGc,
     ) -> Fallible<DomRoot<ImageData>> {
         let len =
             pixels::compute_rgba8_byte_length_if_within_limit(width as usize, height as usize)
@@ -66,16 +67,27 @@ impl ImageData {
         if let Some(ref mut d) = data {
             d.resize(len as usize, 0);
 
-            let cx = GlobalScope::get_cx();
-            rooted!(in (*cx) let mut js_object = std::ptr::null_mut::<JSObject>());
-            let _buffer_source =
-                create_buffer_source::<ClampedU8>(cx, &d[..], js_object.handle_mut(), can_gc)
-                    .map_err(|_| Error::JSFailed)?;
-            auto_root!(in(*cx) let data = TypedArray::<ClampedU8, *mut JSObject>::from(js_object.get()).map_err(|_| Error::JSFailed)?);
+            rooted!(&in(cx) let mut js_object = std::ptr::null_mut::<JSObject>());
+            let _buffer_source = create_buffer_source::<ClampedU8>(
+                cx.into(),
+                &d[..],
+                js_object.handle_mut(),
+                CanGc::from_cx(cx),
+            )
+            .map_err(|_| Error::JSFailed)?;
+            auto_root!(&in(cx) let data = TypedArray::<ClampedU8, *mut JSObject>::from(js_object.get()).map_err(|_| Error::JSFailed)?);
 
-            Self::Constructor_(global, None, can_gc, data, width, Some(height), &settings)
+            Self::Constructor_(
+                global,
+                None,
+                CanGc::from_cx(cx),
+                data,
+                width,
+                Some(height),
+                &settings,
+            )
         } else {
-            Self::Constructor(global, None, can_gc, width, height, &settings)
+            Self::Constructor(global, None, CanGc::from_cx(cx), width, height, &settings)
         }
     }
 
@@ -241,11 +253,7 @@ impl Serializable for ImageData {
     }
 
     /// <https://html.spec.whatwg.org/multipage/#the-imagedata-interface:deserialization-steps>
-    fn deserialize(
-        owner: &GlobalScope,
-        serialized: Self::Data,
-        can_gc: CanGc,
-    ) -> Result<DomRoot<Self>, ()> {
+    fn deserialize(owner: &GlobalScope, serialized: Self::Data) -> Result<DomRoot<Self>, ()> {
         // Step 1 Initialize value's data attribute to the sub-deserialization of serialized.[[Data]].
         // Step 2 Initialize value's width attribute to serialized.[[Width]].
         // Step 3 Initialize value's height attribute to serialized.[[Height]].
@@ -253,10 +261,10 @@ impl Serializable for ImageData {
         // Step 5 Initialize value's pixelFormat attribute to serialized.[[PixelFormat]].
         ImageData::new(
             owner,
+            cx,
             serialized.width,
             serialized.height,
             Some(serialized.data),
-            can_gc,
         )
         .map_err(|_| ())
     }
@@ -356,7 +364,10 @@ impl ImageDataMethods<crate::DomTypeHolder> for ImageData {
     }
 
     /// <https://html.spec.whatwg.org/multipage/#dom-imagedata-data>
-    fn GetData(&self, _: JSContext) -> Fallible<RootedTraceableBox<HeapUint8ClampedArray>> {
+    fn GetData(
+        &self,
+        _: script_bindings::script_runtime::JSContext,
+    ) -> Fallible<RootedTraceableBox<HeapUint8ClampedArray>> {
         self.data.get_typed_array().map_err(|_| Error::JSFailed)
     }
 

--- a/components/script_bindings/codegen/Bindings.conf
+++ b/components/script_bindings/codegen/Bindings.conf
@@ -90,7 +90,8 @@ DOMInterfaces = {
 },
 
 'CanvasRenderingContext2D': {
-    'cx': ['GetTransform','GetImageData', 'CreateImageData', 'CreateImageData_', 'MeasureText', 'CreateLinearGradient', 'CreatePattern', 'CreateRadialGradient'],
+    'cx': ['GetTransform', 'MeasureText', 'CreateLinearGradient', 'CreatePattern', 'CreateRadialGradient'],
+    'canGc': ['CreateImageData', 'GetImageData', 'CreateImageData_',],
 },
 
 'CharacterData': {

--- a/components/script_bindings/codegen/Bindings.conf
+++ b/components/script_bindings/codegen/Bindings.conf
@@ -90,7 +90,7 @@ DOMInterfaces = {
 },
 
 'CanvasRenderingContext2D': {
-    'canGc': ['GetTransform','GetImageData', 'CreateImageData', 'CreateImageData_', 'MeasureText', 'CreateLinearGradient', 'CreatePattern', 'CreateRadialGradient'],
+    'cx': ['GetTransform','GetImageData', 'CreateImageData', 'CreateImageData_', 'MeasureText', 'CreateLinearGradient', 'CreatePattern', 'CreateRadialGradient'],
 },
 
 'CharacterData': {
@@ -635,11 +635,11 @@ DOMInterfaces = {
 },
 
 'OffscreenCanvasRenderingContext2D': {
-    'canGc': ['CreateImageData', 'CreateImageData_', 'GetImageData', 'GetTransform', 'MeasureText', 'CreateLinearGradient', 'CreatePattern', 'CreateRadialGradient'],
+    'cx': ['CreateImageData', 'CreateImageData_', 'GetImageData', 'GetTransform', 'MeasureText', 'CreateLinearGradient', 'CreatePattern', 'CreateRadialGradient'],
 },
 
 'PaintRenderingContext2D': {
-    'canGc': ['CreateLinearGradient', 'CreatePattern', 'CreateRadialGradient', 'GetTransform'],
+    'cx': ['CreateLinearGradient', 'CreatePattern', 'CreateRadialGradient', 'GetTransform'],
 },
 
 'PerformanceObserver': {


### PR DESCRIPTION
This changes the methods in dom/canvas to use the new JSContext/&mut JSContext instead of CanGc.

Part of https://github.com/servo/servo/issues/40600

Signed-off-by: Narfinger <Narfinger@users.noreply.github.com>

Testing: This is a refactor, hence, compilation is the test.
