### PR TITLE
layout: Stretch replaced elements with aspect ratio but no natural sizes

### DIFF
--- a/components/layout/flexbox/layout.rs
+++ b/components/layout/flexbox/layout.rs
@@ -1773,19 +1773,24 @@ impl FlexItem<'_> {
             let cross_size = match used_cross_size_override {
                 Some(s) => SizeConstraint::Definite(s),
                 None => {
-                    let stretch_size = containing_block
+                    let inline_stretch_size =
+                        Au::zero().max(containing_block.size.inline - self.pbm_auto_is_zero.main);
+                    let block_stretch_size = containing_block
                         .size
                         .block
                         .to_definite()
                         .map(|size| Au::zero().max(size - self.pbm_auto_is_zero.cross));
                     let tentative_block_content_size = independent_formatting_context
-                        .tentative_block_content_size(self.preferred_aspect_ratio);
+                        .tentative_block_content_size(
+                            self.preferred_aspect_ratio,
+                            inline_stretch_size,
+                        );
                     if let Some(block_content_size) = tentative_block_content_size {
                         SizeConstraint::Definite(self.content_cross_sizes.resolve(
                             Direction::Block,
                             Size::FitContent,
                             Au::zero,
-                            stretch_size,
+                            block_stretch_size,
                             || block_content_size,
                             is_table,
                         ))
@@ -1793,7 +1798,7 @@ impl FlexItem<'_> {
                         self.content_cross_sizes.resolve_extrinsic(
                             Size::FitContent,
                             Au::zero(),
-                            stretch_size,
+                            block_stretch_size,
                         )
                     }
                 },
@@ -2140,7 +2145,10 @@ impl FlexItemBox {
         let is_table = self.independent_formatting_context.is_table();
         let tentative_cross_content_size = if cross_axis_is_item_block_axis {
             self.independent_formatting_context
-                .tentative_block_content_size(preferred_aspect_ratio)
+                .tentative_block_content_size(
+                    preferred_aspect_ratio,
+                    stretch_size.main.unwrap_or_default(),
+                )
         } else {
             None
         };

--- a/components/layout/flow/mod.rs
+++ b/components/layout/flow/mod.rs
@@ -1393,45 +1393,68 @@ impl IndependentFormattingContext {
             .map(|block_size| Au::zero().max(block_size - pbm_sums.block));
         let is_table = self.is_table();
         let preferred_aspect_ratio = self.preferred_aspect_ratio(&pbm.padding_border_sums);
-        let tentative_block_content_size =
-            self.tentative_block_content_size(preferred_aspect_ratio);
-        let (preferred_block_size, min_block_size, max_block_size) =
-            if let Some(block_content_size) = tentative_block_content_size {
-                let (preferred, min, max) = content_box_sizes.block.resolve_each(
-                    Size::FitContent,
-                    Au::zero,
-                    available_block_size,
-                    || block_content_size,
-                    is_table,
-                );
-                (Some(preferred), min, max)
-            } else {
-                content_box_sizes.block.resolve_each_extrinsic(
-                    Size::FitContent,
-                    Au::zero(),
-                    available_block_size,
-                )
-            };
-        let tentative_block_size =
-            SizeConstraint::new(preferred_block_size, min_block_size, max_block_size);
+
+        #[derive(Default)]
+        struct Cache {
+            min_block_size: Au,
+            max_block_size: Option<Au>,
+            tentative_block_size: SizeConstraint,
+            depends_on_stretch_size: bool,
+        }
+        let mut cache = Cache {
+            depends_on_stretch_size: true,
+            ..Default::default()
+        };
+
+        let update_cache = |cache: &mut Cache, stretch_size| {
+            let tentative_block_content_size = self
+                .tentative_block_content_size_with_dependency(preferred_aspect_ratio, stretch_size);
+            let (preferred_block_size, min_block_size, max_block_size, depends_on_stretch_size) =
+                if let Some(result) = tentative_block_content_size {
+                    let (block_content_size, depends_on_stretch_size) = result;
+                    let (preferred, min, max) = content_box_sizes.block.resolve_each(
+                        Size::FitContent,
+                        Au::zero,
+                        available_block_size,
+                        || block_content_size,
+                        is_table,
+                    );
+                    (Some(preferred), min, max, depends_on_stretch_size)
+                } else {
+                    let (preferred, min, max) = content_box_sizes.block.resolve_each_extrinsic(
+                        Size::FitContent,
+                        Au::zero(),
+                        available_block_size,
+                    );
+                    (preferred, min, max, false)
+                };
+            cache.min_block_size = min_block_size;
+            cache.max_block_size = max_block_size;
+            cache.tentative_block_size =
+                SizeConstraint::new(preferred_block_size, min_block_size, max_block_size);
+            cache.depends_on_stretch_size = depends_on_stretch_size;
+        };
 
         // With the tentative block size we can compute the inline min/max-content sizes.
-        let get_inline_content_sizes = || {
+        let get_inline_content_sizes = |cache: &Cache| {
             let constraint_space =
-                ConstraintSpace::new(tentative_block_size, style, preferred_aspect_ratio);
+                ConstraintSpace::new(cache.tentative_block_size, style, preferred_aspect_ratio);
             self.inline_content_sizes(layout_context, &constraint_space)
                 .sizes
         };
 
         let justify_self = resolve_justify_self(style, containing_block.style);
         let automatic_inline_size = automatic_inline_size(justify_self, Some(self));
-        let compute_inline_size = |stretch_size| {
+        let compute_inline_size = |cache: &mut Cache, stretch_size| {
+            if cache.depends_on_stretch_size {
+                update_cache(cache, stretch_size);
+            }
             content_box_sizes.inline.resolve(
                 Direction::Inline,
                 automatic_inline_size,
                 Au::zero,
                 Some(stretch_size),
-                get_inline_content_sizes,
+                || get_inline_content_sizes(cache),
                 is_table,
             )
         };
@@ -1455,8 +1478,9 @@ impl IndependentFormattingContext {
         // TODO: `compute_inline_size()` may not be monotonic with `calc-size()`. For example,
         // `calc-size(stretch, (1px / (size + 1px) + sign(size)) * 1px)` would result in 1px
         // both when the available space is zero and infinity, but it's not constant.
-        let inline_size_with_no_available_space = compute_inline_size(Au::zero());
-        if inline_size_with_no_available_space == compute_inline_size(MAX_AU) {
+        let inline_size_with_max_available_space = compute_inline_size(&mut cache, MAX_AU);
+        let inline_size_with_no_available_space = compute_inline_size(&mut cache, Au::zero());
+        if inline_size_with_no_available_space == inline_size_with_max_available_space {
             // If the inline size doesn't depend on the available inline space, we can just
             // compute it with an available inline space of zero. Then, after layout we can
             // compute the block size, and finally place among floats.
@@ -1468,7 +1492,10 @@ impl IndependentFormattingContext {
                 &ContainingBlock {
                     size: ContainingBlockSize {
                         inline: inline_size,
-                        block: tentative_block_size,
+                        // `cache.tentative_block_size` can only depend on the inline stretch size
+                        // for replaced elements, whose layout doesn't use the block size of the
+                        // containing block for children.
+                        block: cache.tentative_block_size,
                     },
                     style,
                 },
@@ -1500,13 +1527,20 @@ impl IndependentFormattingContext {
                 // TODO: this won't work for things like `calc-size(stretch, 100px - size)`,
                 // which should result in a bigger size when the available space gets smaller.
                 inline: inline_size_with_no_available_space,
-                block: match tentative_block_size {
+                // For the lower bound of the block size, also use the cached data that was
+                // computed with no inline available space. If there is a dependency, it will
+                // be monotonically increasing.
+                // TODO: won't work e.g. for `block-size: calc-size(max-content, 100px - size)`
+                // on a stretchable replaced element with an aspect ratio of 1/1: when the
+                // inline available space is 0, it will resolve to 100px, but for 100px it
+                // will resolve to 0.
+                block: match cache.tentative_block_size {
                     // If we were able to resolve the preferred and maximum block sizes,
                     // use the tentative block size (it takes the 3 sizes into account).
-                    SizeConstraint::Definite(size) if max_block_size.is_some() => size,
+                    SizeConstraint::Definite(size) if cache.max_block_size.is_some() => size,
                     // Oherwise the preferred or maximum block size might end up being zero,
                     // so can only rely on the minimum block size.
-                    _ => min_block_size,
+                    _ => cache.min_block_size,
                 },
             } + pbm.padding_border_sums;
             let mut placement = PlacementAmongFloats::new(
@@ -1521,7 +1555,7 @@ impl IndependentFormattingContext {
                 placement_rect = placement.place();
                 let available_inline_size =
                     placement_rect.size.inline - pbm.padding_border_sums.inline;
-                let proposed_inline_size = compute_inline_size(available_inline_size);
+                let proposed_inline_size = compute_inline_size(&mut cache, available_inline_size);
 
                 // Now lay out the block using the inline size we calculated from the placement.
                 // Later we'll check to see if the resulting block size is compatible with the
@@ -1534,7 +1568,7 @@ impl IndependentFormattingContext {
                     &ContainingBlock {
                         size: ContainingBlockSize {
                             inline: proposed_inline_size,
-                            block: tentative_block_size,
+                            block: cache.tentative_block_size,
                         },
                         style,
                     },
@@ -1737,8 +1771,9 @@ fn solve_containing_block_padding_and_border_for_in_flow_box<'a>(
 
     // https://drafts.csswg.org/css2/#the-height-property
     // https://drafts.csswg.org/css2/visudet.html#min-max-heights
-    let tentative_block_content_size =
-        context.and_then(|context| context.tentative_block_content_size(preferred_aspect_ratio));
+    let tentative_block_content_size = context.and_then(|context| {
+        context.tentative_block_content_size(preferred_aspect_ratio, available_inline_size)
+    });
     let tentative_block_size = if let Some(block_content_size) = tentative_block_content_size {
         SizeConstraint::Definite(content_box_sizes.block.resolve(
             Direction::Block,
@@ -2283,7 +2318,7 @@ impl IndependentFormattingContext {
             .map(|block_size| Au::zero().max(block_size - pbm_sums.block_sum()));
 
         let tentative_block_content_size =
-            self.tentative_block_content_size(preferred_aspect_ratio);
+            self.tentative_block_content_size(preferred_aspect_ratio, available_inline_size);
         let tentative_block_size = if let Some(block_content_size) = tentative_block_content_size {
             SizeConstraint::Definite(content_box_sizes_and_pbm.content_box_sizes.block.resolve(
                 Direction::Block,

--- a/components/layout/formatting_contexts.rs
+++ b/components/layout/formatting_contexts.rs
@@ -266,7 +266,23 @@ impl IndependentFormattingContext {
     pub(crate) fn tentative_block_content_size(
         &self,
         preferred_aspect_ratio: Option<AspectRatio>,
+        inline_stretch_size: Au,
     ) -> Option<ContentSizes> {
+        let result = self.tentative_block_content_size_with_dependency(
+            preferred_aspect_ratio,
+            inline_stretch_size,
+        );
+        Some(result?.0)
+    }
+
+    /// Same as [`Self::tentative_block_content_size()`], but if there is a tentative intrinsic
+    /// block size, it also includes a bool which will be true if the former depends on
+    /// the provided `inline_stretch_size`.
+    pub(crate) fn tentative_block_content_size_with_dependency(
+        &self,
+        preferred_aspect_ratio: Option<AspectRatio>,
+        inline_stretch_size: Au,
+    ) -> Option<(ContentSizes, bool)> {
         // See <https://github.com/w3c/csswg-drafts/issues/12333> regarding the difference
         // in behavior for the replaced and non-replaced cases.
         match &self.contents {
@@ -275,14 +291,19 @@ impl IndependentFormattingContext {
                 let ratio = preferred_aspect_ratio?;
                 let writing_mode = self.style().writing_mode;
                 let natural_sizes = contents.logical_natural_sizes(writing_mode);
-                let block_size = match (natural_sizes.block, natural_sizes.inline) {
-                    (Some(block_size), None) => block_size,
-                    _ => {
-                        let inline_size = contents.fallback_inline_size(writing_mode);
-                        ratio.compute_dependent_size(Direction::Block, inline_size)
-                    },
-                };
-                Some(block_size.into())
+                let (block_size, depends_on_inline_stretch_size) =
+                    match (natural_sizes.block, natural_sizes.inline) {
+                        (Some(block_size), None) => (block_size, false),
+                        (_, Some(inline_size)) => (
+                            ratio.compute_dependent_size(Direction::Block, inline_size),
+                            false,
+                        ),
+                        (None, None) => (
+                            ratio.compute_dependent_size(Direction::Block, inline_stretch_size),
+                            true,
+                        ),
+                    };
+                Some((block_size.into(), depends_on_inline_stretch_size))
             },
             _ => None,
         }
@@ -305,7 +326,9 @@ impl IndependentFormattingContext {
             true, /* establishes_containing_block */
             |padding_border_sums| self.preferred_aspect_ratio(padding_border_sums),
             |constraint_space| self.inline_content_sizes(layout_context, constraint_space),
-            |preferred_aspect_ratio| self.tentative_block_content_size(preferred_aspect_ratio),
+            |preferred_aspect_ratio| {
+                self.tentative_block_content_size(preferred_aspect_ratio, Au(0))
+            },
         )
     }
 

--- a/components/layout/positioned.rs
+++ b/components/layout/positioned.rs
@@ -510,8 +510,9 @@ impl HoistedAbsolutelyPositionedBox {
         // we may have to resolve it properly later on.
         let block_automatic_size = block_axis_solver.automatic_size();
         let block_stretch_size = Some(block_axis_solver.stretch_size());
+        let inline_stretch_size = inline_axis_solver.stretch_size();
         let tentative_block_content_size =
-            context.tentative_block_content_size(preferred_aspect_ratio);
+            context.tentative_block_content_size(preferred_aspect_ratio, inline_stretch_size);
         let tentative_block_size = if let Some(block_content_size) = tentative_block_content_size {
             SizeConstraint::Definite(block_axis_solver.computed_sizes.resolve(
                 Direction::Block,
@@ -542,7 +543,7 @@ impl HoistedAbsolutelyPositionedBox {
             Direction::Inline,
             inline_axis_solver.automatic_size(),
             Au::zero,
-            Some(inline_axis_solver.stretch_size()),
+            Some(inline_stretch_size),
             get_inline_content_size,
             is_table,
         );

--- a/tests/wpt/meta/css/css-flexbox/aspect-ratio-intrinsic-size-007.html.ini
+++ b/tests/wpt/meta/css/css-flexbox/aspect-ratio-intrinsic-size-007.html.ini
@@ -1,2 +1,0 @@
-[aspect-ratio-intrinsic-size-007.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-flexbox/svg-root-as-flex-item-002.html.ini
+++ b/tests/wpt/meta/css/css-flexbox/svg-root-as-flex-item-002.html.ini
@@ -1,2 +1,0 @@
-[svg-root-as-flex-item-002.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-flexbox/svg-root-as-flex-item-003.html.ini
+++ b/tests/wpt/meta/css/css-flexbox/svg-root-as-flex-item-003.html.ini
@@ -1,2 +1,0 @@
-[svg-root-as-flex-item-003.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-sizing/replaced-aspect-ratio-stretch-fit-002.html.ini
+++ b/tests/wpt/meta/css/css-sizing/replaced-aspect-ratio-stretch-fit-002.html.ini
@@ -1,2 +1,0 @@
-[replaced-aspect-ratio-stretch-fit-002.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-sizing/svg-intrinsic-size-001.html.ini
+++ b/tests/wpt/meta/css/css-sizing/svg-intrinsic-size-001.html.ini
@@ -1,3 +1,0 @@
-[svg-intrinsic-size-001.html]
-  [svg 5]
-    expected: FAIL

--- a/tests/wpt/meta/css/css-sizing/svg-intrinsic-size-002.html.ini
+++ b/tests/wpt/meta/css/css-sizing/svg-intrinsic-size-002.html.ini
@@ -1,3 +1,0 @@
-[svg-intrinsic-size-002.html]
-  [svg 5]
-    expected: FAIL

--- a/tests/wpt/meta/css/css-sizing/svg-intrinsic-size-003.html.ini
+++ b/tests/wpt/meta/css/css-sizing/svg-intrinsic-size-003.html.ini
@@ -1,3 +1,0 @@
-[svg-intrinsic-size-003.html]
-  [svg 5]
-    expected: FAIL

--- a/tests/wpt/meta/css/css-sizing/svg-intrinsic-size-004.html.ini
+++ b/tests/wpt/meta/css/css-sizing/svg-intrinsic-size-004.html.ini
@@ -1,3 +1,0 @@
-[svg-intrinsic-size-004.html]
-  [svg 5]
-    expected: FAIL

--- a/tests/wpt/meta/html/rendering/replaced-elements/attributes-for-embedded-content-and-images/video-intrinsic-width-height.html.ini
+++ b/tests/wpt/meta/html/rendering/replaced-elements/attributes-for-embedded-content-and-images/video-intrinsic-width-height.html.ini
@@ -1,3 +1,0 @@
-[video-intrinsic-width-height.html]
-  [both width/height attributes and style keeping aspect-ratio]
-    expected: FAIL

--- a/tests/wpt/meta/html/rendering/replaced-elements/svg-inline-sizing/svg-inline.html.ini
+++ b/tests/wpt/meta/html/rendering/replaced-elements/svg-inline-sizing/svg-inline.html.ini
@@ -1,22 +1,4 @@
 [svg-inline.html]
-  [svgViewBoxAttr: '0 0 100 200', ]
-    expected: FAIL
-
-  [containerWidthStyle: '400px', svgViewBoxAttr: '0 0 100 200', ]
-    expected: FAIL
-
-  [containerHeightStyle: '400px', svgViewBoxAttr: '0 0 100 200', ]
-    expected: FAIL
-
-  [containerWidthStyle: '400px', containerHeightStyle: '400px', svgViewBoxAttr: '0 0 100 200', ]
-    expected: FAIL
-
-  [svgViewBoxAttr: '0 0 100 200', svgHeightStyle: '50%', ]
-    expected: FAIL
-
-  [containerWidthStyle: '400px', svgViewBoxAttr: '0 0 100 200', svgHeightStyle: '50%', ]
-    expected: FAIL
-
   [svgViewBoxAttr: '0 0 100 200', svgHeightStyle: '100px', svgWidthAttr: '200', ]
     expected: FAIL
 
@@ -254,12 +236,6 @@
   [containerWidthStyle: '400px', containerHeightStyle: '400px', svgHeightAttr: '25%', ]
     expected: FAIL
 
-  [svgViewBoxAttr: '0 0 100 200', svgHeightAttr: '25%', ]
-    expected: FAIL
-
-  [containerWidthStyle: '400px', svgViewBoxAttr: '0 0 100 200', svgHeightAttr: '25%', ]
-    expected: FAIL
-
   [containerHeightStyle: '400px', svgViewBoxAttr: '0 0 100 200', svgHeightAttr: '25%', ]
     expected: FAIL
 
@@ -288,12 +264,6 @@
     expected: FAIL
 
   [containerWidthStyle: '400px', containerHeightStyle: '400px', svgViewBoxAttr: '0 0 100 200', svgWidthStyle: '50%', svgHeightAttr: '25%', ]
-    expected: FAIL
-
-  [svgViewBoxAttr: '0 0 100 200', svgHeightStyle: '50%', svgHeightAttr: '25%', ]
-    expected: FAIL
-
-  [containerWidthStyle: '400px', svgViewBoxAttr: '0 0 100 200', svgHeightStyle: '50%', svgHeightAttr: '25%', ]
     expected: FAIL
 
   [containerHeightStyle: '400px', svgWidthAttr: '200', svgHeightAttr: '25%', ]

--- a/tests/wpt/meta/html/semantics/interestfor/interestfor-svg-a-event-dispatch.tentative.html.ini
+++ b/tests/wpt/meta/html/semantics/interestfor/interestfor-svg-a-event-dispatch.tentative.html.ini
@@ -1,6 +1,7 @@
 [interestfor-svg-a-event-dispatch.tentative.html]
+  expected: ERROR
   [InterestEvent is not dispatched unless the svg <a> has an href]
     expected: FAIL
 
   [InterestEvent dispatches on svg <a> hover]
-    expected: FAIL
+    expected: NOTRUN

--- a/tests/wpt/meta/svg/coordinate-systems/out-of-flow-svg-root.html.ini
+++ b/tests/wpt/meta/svg/coordinate-systems/out-of-flow-svg-root.html.ini
@@ -1,2 +1,0 @@
-[out-of-flow-svg-root.html]
-  expected: FAIL

--- a/tests/wpt/meta/svg/coordinate-systems/outer-svg-intrinsic-size-001.html.ini
+++ b/tests/wpt/meta/svg/coordinate-systems/outer-svg-intrinsic-size-001.html.ini
@@ -1,9 +1,0 @@
-[outer-svg-intrinsic-size-001.html]
-  [set a 10x8 viewBox]
-    expected: FAIL
-
-  [modified viewBox to 50x20]
-    expected: FAIL
-
-  [removing specified width, in presence of specified viewBox]
-    expected: FAIL


### PR DESCRIPTION
Instead of using the default object width of 300px, use the inline-axis stretch size, or zero when computing the intrinsic contribution.

Note browsers don't completely agree in the details of how to do this. This implements a behavior very similar to Blink, but without having different behaviors for min/max-content depending on which property they are used (which doesn't make much sense to me).

The biggest part of the patch is for block-level boxes that establish an independent formatting context and need to avoid overlapping floats. In that case we may need to try laying out multiple times, varying the stretch size. Previously the code assumed that this wouldn't affect the intrinsic inline sizes, but now we have this dependency, so the logic had to be refactored.

Testing: Some tests pass. One test results in an error, but that happens in all browsers.
Fixes: #38653