### PR TITLE
script: Move attribute-related methods to &mut JSContext

### DIFF
--- a/components/script/dom/namednodemap.rs
+++ b/components/script/dom/namednodemap.rs
@@ -66,32 +66,45 @@ impl NamedNodeMapMethods<crate::DomTypeHolder> for NamedNodeMap {
     }
 
     /// <https://dom.spec.whatwg.org/#dom-namednodemap-setnameditem>
-    fn SetNamedItem(&self, attr: &Attr) -> Fallible<Option<DomRoot<Attr>>> {
-        self.owner.SetAttributeNode(attr, CanGc::note())
+    fn SetNamedItem(
+        &self,
+        cx: &mut js::context::JSContext,
+        attr: &Attr,
+    ) -> Fallible<Option<DomRoot<Attr>>> {
+        self.owner.SetAttributeNode(cx, attr)
     }
 
     /// <https://dom.spec.whatwg.org/#dom-namednodemap-setnameditemns>
-    fn SetNamedItemNS(&self, attr: &Attr) -> Fallible<Option<DomRoot<Attr>>> {
-        self.SetNamedItem(attr)
+    fn SetNamedItemNS(
+        &self,
+        cx: &mut js::context::JSContext,
+        attr: &Attr,
+    ) -> Fallible<Option<DomRoot<Attr>>> {
+        self.SetNamedItem(cx, attr)
     }
 
     /// <https://dom.spec.whatwg.org/#dom-namednodemap-removenameditem>
-    fn RemoveNamedItem(&self, name: DOMString) -> Fallible<DomRoot<Attr>> {
+    fn RemoveNamedItem(
+        &self,
+        cx: &mut js::context::JSContext,
+        name: DOMString,
+    ) -> Fallible<DomRoot<Attr>> {
         let name = self.owner.parsed_name(name);
         self.owner
-            .remove_attribute_by_name(&name, CanGc::note())
+            .remove_attribute_by_name(&name, CanGc::from_cx(cx))
             .ok_or(Error::NotFound(None))
     }
 
     /// <https://dom.spec.whatwg.org/#dom-namednodemap-removenameditemns>
     fn RemoveNamedItemNS(
         &self,
+        cx: &mut js::context::JSContext,
         namespace: Option<DOMString>,
         local_name: DOMString,
     ) -> Fallible<DomRoot<Attr>> {
         let ns = namespace_from_domstring(namespace);
         self.owner
-            .remove_attribute(&ns, &LocalName::from(local_name), CanGc::note())
+            .remove_attribute(&ns, &LocalName::from(local_name), CanGc::from_cx(cx))
             .ok_or(Error::NotFound(None))
     }
 

--- a/components/script_bindings/codegen/Bindings.conf
+++ b/components/script_bindings/codegen/Bindings.conf
@@ -250,7 +250,8 @@ DOMInterfaces = {
 },
 
 'Element': {
-    'canGc': ['SetHTMLUnsafe', 'SetInnerHTML', 'SetOuterHTML', 'InsertAdjacentHTML', 'GetClientRects', 'GetBoundingClientRect', 'InsertAdjacentText', 'ToggleAttribute', 'SetAttribute', 'SetAttributeNS', 'SetId','SetClassName','Prepend','Append','ReplaceChildren','Before','After','ReplaceWith', 'SetRole', 'SetAriaAtomic', 'SetAriaAutoComplete', 'SetAriaBrailleLabel', 'SetAriaBrailleRoleDescription', 'SetAriaBusy', 'SetAriaChecked', 'SetAriaColCount', 'SetAriaColIndex', 'SetAriaColIndexText', 'SetAriaColSpan', 'SetAriaCurrent', 'SetAriaDescription', 'SetAriaDisabled', 'SetAriaExpanded', 'SetAriaHasPopup', 'SetAriaHidden', 'SetAriaInvalid', 'SetAriaKeyShortcuts', 'SetAriaLabel', 'SetAriaLevel', 'SetAriaLive', 'SetAriaModal', 'SetAriaMultiLine', 'SetAriaMultiSelectable', 'SetAriaOrientation', 'SetAriaPlaceholder', 'SetAriaPosInSet', 'SetAriaPressed','SetAriaReadOnly', 'SetAriaRelevant', 'SetAriaRequired', 'SetAriaRoleDescription', 'SetAriaRowCount', 'SetAriaRowIndex', 'SetAriaRowIndexText', 'SetAriaRowSpan', 'SetAriaSelected', 'SetAriaSetSize','SetAriaSort', 'SetAriaValueMax', 'SetAriaValueMin', 'SetAriaValueNow', 'SetAriaValueText', 'RequestFullscreen', 'GetHTML', 'GetInnerHTML', 'GetOuterHTML', 'ClassList', 'Attributes', 'SetAttributeNode', 'SetAttributeNodeNS', 'RemoveAttribute', 'RemoveAttributeNS', 'RemoveAttributeNode', 'GetElementsByTagName', 'GetElementsByTagNameNS', 'GetElementsByClassName', 'Children', 'Remove', 'InsertAdjacentElement', 'AttachShadow'],
+    'cx': ['ToggleAttribute', 'SetAttribute', 'SetAttributeNS', 'SetAttributeNode', 'SetAttributeNodeNS', 'RemoveAttributeNS', 'RemoveAttributeNode'],
+    'canGc': ['SetHTMLUnsafe', 'SetInnerHTML', 'SetOuterHTML', 'InsertAdjacentHTML', 'GetClientRects', 'GetBoundingClientRect', 'InsertAdjacentText', 'SetId','SetClassName','Prepend','Append','ReplaceChildren','Before','After','ReplaceWith', 'SetRole', 'SetAriaAtomic', 'SetAriaAutoComplete', 'SetAriaBrailleLabel', 'SetAriaBrailleRoleDescription', 'SetAriaBusy', 'SetAriaChecked', 'SetAriaColCount', 'SetAriaColIndex', 'SetAriaColIndexText', 'SetAriaColSpan', 'SetAriaCurrent', 'SetAriaDescription', 'SetAriaDisabled', 'SetAriaExpanded', 'SetAriaHasPopup', 'SetAriaHidden', 'SetAriaInvalid', 'SetAriaKeyShortcuts', 'SetAriaLabel', 'SetAriaLevel', 'SetAriaLive', 'SetAriaModal', 'SetAriaMultiLine', 'SetAriaMultiSelectable', 'SetAriaOrientation', 'SetAriaPlaceholder', 'SetAriaPosInSet', 'SetAriaPressed','SetAriaReadOnly', 'SetAriaRelevant', 'SetAriaRequired', 'SetAriaRoleDescription', 'SetAriaRowCount', 'SetAriaRowIndex', 'SetAriaRowIndexText', 'SetAriaRowSpan', 'SetAriaSelected', 'SetAriaSetSize','SetAriaSort', 'SetAriaValueMax', 'SetAriaValueMin', 'SetAriaValueNow', 'SetAriaValueText', 'RequestFullscreen', 'GetHTML', 'GetInnerHTML', 'GetOuterHTML', 'ClassList', 'Attributes', 'GetElementsByTagName', 'GetElementsByTagNameNS', 'GetElementsByClassName', 'Children', 'Remove', 'InsertAdjacentElement', 'AttachShadow', 'RemoveAttribute'],
 },
 
 'ElementInternals': {
@@ -596,6 +597,10 @@ DOMInterfaces = {
 
 'MessageEvent': {
     'canGc': ['Ports'],
+},
+
+'NamedNodeMap': {
+    'cx': ['SetNamedItem', 'SetNamedItemNS', 'RemoveNamedItem', 'RemoveNamedItemNS', 'RemoveAttribute'],
 },
 
 'NavigationPreloadManager': {


### PR DESCRIPTION
Part of #42638