### PR TITLE
deps: Deduplicate `futures`, disable features & improve consistency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2979,15 +2979,9 @@ checksum = "7ab85b9b05e3978cc9a9cf8fea7f01b494e1a09ed3037e16ba39edc7a29eb61a"
 
 [[package]]
 name = "futures"
-version = "0.1.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a471a38ef8ed83cd6e40aa59c1ffe17db6855c18e3604d9c4ed8c08ebc28678"
-
-[[package]]
-name = "futures"
-version = "0.3.31"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "65bc07b1a8bc7c85c5f2e110c476c7389b4554ba72af57d8445ea63a576b0876"
+checksum = "8b147ee9d1f6d097cef9ce628cd2ee62288d963e16fb287bd9286455b241382d"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -3016,9 +3010,9 @@ checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
 
 [[package]]
 name = "futures-executor"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e28d1d997f585e54aebc3f97d39e72338912123a67330d723fdbb564d646c9f"
+checksum = "baf29c38818342a3b26b5b923639e7b1f4a61fc5e76102d4b1981c6dc7a7579d"
 dependencies = [
  "futures-core",
  "futures-task",
@@ -3084,14 +3078,12 @@ version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
 dependencies = [
- "futures 0.1.31",
  "futures-channel",
  "futures-core",
  "futures-io",
  "futures-macro",
  "futures-sink",
  "futures-task",
- "libc",
  "memchr",
  "pin-project-lite",
  "slab",
@@ -5693,7 +5685,7 @@ checksum = "300401a6c16e3a166bfb43d196e3bafe98362332e918377e18c8443bd7318e40"
 dependencies = [
  "bitflags 2.10.0",
  "ctor",
- "futures 0.3.31",
+ "futures",
  "napi-build-ohos",
  "napi-sys-ohos",
  "nohash-hasher",
@@ -5758,7 +5750,7 @@ dependencies = [
  "embedder_traits",
  "flate2",
  "fst",
- "futures 0.3.31",
+ "futures",
  "futures-core",
  "futures-util",
  "generic-array",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -74,7 +74,7 @@ euclid = "0.22"
 flate2 = "1.1"
 fonts_traits = { path = "components/shared/fonts" }
 freetype-sys = "0.20"
-futures = { version = "0.3" }
+futures = { version = "0.3", default-features = false }
 futures-core = { version = "0.3", default-features = false }
 futures-util = { version = "0.3", default-features = false }
 gleam = "0.15"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -74,6 +74,9 @@ euclid = "0.22"
 flate2 = "1.1"
 fonts_traits = { path = "components/shared/fonts" }
 freetype-sys = "0.20"
+futures = { version = "0.3" }
+futures-core = { version = "0.3", default-features = false }
+futures-util = { version = "0.3", default-features = false }
 gleam = "0.15"
 glib = "0.21"
 glib-sys = "0.21"

--- a/components/net/Cargo.toml
+++ b/components/net/Cargo.toml
@@ -32,9 +32,9 @@ data-url = { workspace = true }
 devtools_traits = { workspace = true }
 embedder_traits = { workspace = true }
 fst = "0.4"
-futures = { version = "0.3", package = "futures" }
-futures-core = { version = "0.3.30", default-features = false }
-futures-util = { version = "0.3.30", default-features = false }
+futures = { workspace = true}
+futures-core = { workspace = true }
+futures-util = { workspace = true }
 generic-array = "0.14"
 headers = { workspace = true }
 http = { workspace = true }
@@ -67,7 +67,7 @@ serde = { workspace = true }
 servo_arc = { workspace = true }
 servo_config = { path = "../config" }
 servo_url = { path = "../url" }
-sha2 = "0.10"
+sha2 = { workspace = true}
 time = { workspace = true }
 tokio = { workspace = true, features = ["macros", "rt-multi-thread", "sync"] }
 tokio-rustls = { workspace = true }
@@ -84,7 +84,6 @@ webrender_api = { workspace = true }
 embedder_traits = { workspace = true, features = ["baked-default-resources"] }
 flate2 = { workspace = true }
 fst = "0.4"
-futures = { version = "0.3", features = ["compat"] }
 hyper = { workspace = true, features = ["full"] }
 hyper-util = { workspace = true, features = ["server-graceful"] }
 net = { path = "../net", features = ["test-util"] }

--- a/components/net/Cargo.toml
+++ b/components/net/Cargo.toml
@@ -32,7 +32,7 @@ data-url = { workspace = true }
 devtools_traits = { workspace = true }
 embedder_traits = { workspace = true }
 fst = "0.4"
-futures = { workspace = true}
+futures = { workspace = true }
 futures-core = { workspace = true }
 futures-util = { workspace = true }
 generic-array = "0.14"
@@ -67,7 +67,7 @@ serde = { workspace = true }
 servo_arc = { workspace = true }
 servo_config = { path = "../config" }
 servo_url = { path = "../url" }
-sha2 = { workspace = true}
+sha2 = { workspace = true }
 time = { workspace = true }
 tokio = { workspace = true, features = ["macros", "rt-multi-thread", "sync"] }
 tokio-rustls = { workspace = true }

--- a/deny.toml
+++ b/deny.toml
@@ -214,7 +214,6 @@ skip = [
     # These need to be investigated separately to see if the duplication can be
     # avoided.
     "libloading",
-    "futures",
     "cfg-expr",
     "system-deps",
     "target-lexicon",


### PR DESCRIPTION
- Remove deps on `futures@0.1.31`. Update deny
- Remove `compat` features of futures. This is not used anywhere and introduces duplication.
- Move deps to root. Fix weird field like `futures = { version = "0.3", package = "futures" }`. Use 0.3 instead of patch version as recommended by [README](https://github.com/rust-lang/futures-rs/tree/master/futures-executor#readme)
- Use workspace version for sha2
- Update `futures` & `futures-executor` to 0.3.32
- Disable default features of `futures`: this decreases binary size by 12KB in release.

Testing: Existing UT.