### PR TITLE
script: pass down `&mut JSContext` in `post_connection_steps`

### DIFF
--- a/components/script/dom/element.rs
+++ b/components/script/dom/element.rs
@@ -4675,9 +4675,9 @@ impl VirtualMethods for Element {
         }
     }
 
-    fn post_connection_steps(&self, can_gc: CanGc) {
+    fn post_connection_steps(&self, cx: &mut js::context::JSContext) {
         if let Some(s) = self.super_type() {
-            s.post_connection_steps(can_gc);
+            s.post_connection_steps(cx);
         }
 
         self.update_nonce_post_connection();

--- a/components/script/dom/html/htmliframeelement.rs
+++ b/components/script/dom/html/htmliframeelement.rs
@@ -16,6 +16,7 @@ use content_security_policy::sandboxing_directive::{
 use dom_struct::dom_struct;
 use embedder_traits::ViewportDetails;
 use html5ever::{LocalName, Prefix, local_name, ns};
+use js::context::JSContext;
 use js::rust::HandleObject;
 use net_traits::ReferrerPolicy;
 use net_traits::request::Destination;
@@ -999,9 +1000,9 @@ impl VirtualMethods for HTMLIFrameElement {
     }
 
     /// <https://html.spec.whatwg.org/multipage/#the-iframe-element:html-element-post-connection-steps>
-    fn post_connection_steps(&self, can_gc: CanGc) {
+    fn post_connection_steps(&self, cx: &mut JSContext) {
         if let Some(s) = self.super_type() {
-            s.post_connection_steps(can_gc);
+            s.post_connection_steps(cx);
         }
 
         // This isn't mentioned any longer in the specification, but still seems important. This is
@@ -1014,14 +1015,14 @@ impl VirtualMethods for HTMLIFrameElement {
         debug!("<iframe> running post connection steps");
 
         // Step 1. Create a new child navigable for insertedNode.
-        self.create_nested_browsing_context(can_gc);
+        self.create_nested_browsing_context(CanGc::from_cx(cx));
 
         // Step 2: If insertedNode has a sandbox attribute, then parse the sandboxing directive
         // given the attribute's value and insertedNode's iframe sandboxing flag set.
         self.parse_sandbox_attribute();
 
         // Step 3. Process the iframe attributes for insertedNode, with initialInsertion set to true.
-        self.process_the_iframe_attributes(ProcessingMode::FirstTime, can_gc);
+        self.process_the_iframe_attributes(ProcessingMode::FirstTime, CanGc::from_cx(cx));
     }
 
     fn bind_to_tree(&self, context: &BindContext, can_gc: CanGc) {

--- a/components/script/dom/html/htmlscriptelement.rs
+++ b/components/script/dom/html/htmlscriptelement.rs
@@ -13,6 +13,7 @@ use base::id::WebViewId;
 use dom_struct::dom_struct;
 use encoding_rs::Encoding;
 use html5ever::{LocalName, Prefix, local_name, ns};
+use js::context::JSContext;
 use js::jsval::UndefinedValue;
 use js::rust::{HandleObject, Stencil};
 use net_traits::http_status::HttpStatus;
@@ -1232,13 +1233,13 @@ impl VirtualMethods for HTMLScriptElement {
     }
 
     /// <https://html.spec.whatwg.org/multipage/#script-processing-model:the-script-element-20>
-    fn post_connection_steps(&self, can_gc: CanGc) {
+    fn post_connection_steps(&self, cx: &mut JSContext) {
         if let Some(s) = self.super_type() {
-            s.post_connection_steps(can_gc);
+            s.post_connection_steps(cx);
         }
 
         if self.upcast::<Node>().is_connected() && !self.parser_inserted.get() {
-            self.prepare(Some(IntroductionType::INJECTED_SCRIPT), can_gc);
+            self.prepare(Some(IntroductionType::INJECTED_SCRIPT), CanGc::from_cx(cx));
         }
     }
 

--- a/components/script/dom/node.rs
+++ b/components/script/dom/node.rs
@@ -2751,7 +2751,7 @@ impl Node {
                 // Step 12. For each node of staticNodeList, if node is connected, then run the
                 //          post-connection steps with node.
                 for node in static_node_list {
-                    vtable_for(&node).post_connection_steps(CanGc::from_cx(cx));
+                    vtable_for(&node).post_connection_steps(cx);
                 }
             }),
         );

--- a/components/script/dom/virtualmethods.rs
+++ b/components/script/dom/virtualmethods.rs
@@ -3,6 +3,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 use html5ever::LocalName;
+use js::context::JSContext;
 use script_bindings::script_runtime::CanGc;
 use style::attr::AttrValue;
 
@@ -101,9 +102,9 @@ pub(crate) trait VirtualMethods {
     /// Invoked during a DOM tree mutation after a node becomes connected, once all
     /// related DOM tree mutations have been applied.
     /// <https://dom.spec.whatwg.org/#concept-node-post-connection-ext>
-    fn post_connection_steps(&self, can_gc: CanGc) {
+    fn post_connection_steps(&self, cx: &mut JSContext) {
         if let Some(s) = self.super_type() {
-            s.post_connection_steps(can_gc);
+            s.post_connection_steps(cx);
         }
     }
 


### PR DESCRIPTION
Pass down `&mut JSContext` in `post_connection_steps` 

Testing: No functionality change, a successful build is enough
Part of #40600
