### PR TITLE
layout: Only run damage traversal under dirty root

### DIFF
--- a/components/layout/flow/root.rs
+++ b/components/layout/flow/root.rs
@@ -147,9 +147,9 @@ impl BoxTree {
     ///   made an incremental update.
     pub(crate) fn update(
         context: &LayoutContext,
-        dirty_root_from_script: ServoLayoutNode<'_>,
+        dirty_root_from_style: ServoLayoutNode<'_>,
     ) -> bool {
-        let Some(box_tree_update) = IncrementalBoxTreeUpdate::find(dirty_root_from_script) else {
+        let Some(box_tree_update) = IncrementalBoxTreeUpdate::find(dirty_root_from_style) else {
             return false;
         };
         box_tree_update.update_from_dirty_root(context);
@@ -285,11 +285,15 @@ struct IncrementalBoxTreeUpdate<'dom> {
 
 impl<'dom> IncrementalBoxTreeUpdate<'dom> {
     fn find(dirty_root_from_script: ServoLayoutNode<'dom>) -> Option<Self> {
-        let mut maybe_dirty_root_node = Some(dirty_root_from_script);
+        let mut maybe_dirty_root_node = dirty_root_from_script.parent_node();
         while let Some(dirty_root_node) = maybe_dirty_root_node {
             if let Some(dirty_root) = Self::new_if_valid(dirty_root_node) {
                 return Some(dirty_root);
             }
+
+            // A node above this one will be the root for box tree reconstruction, so we
+            // must force this node's boxes to be rebuilt.
+            dirty_root_node.to_threadsafe().unset_all_boxes();
 
             maybe_dirty_root_node = dirty_root_node.parent_node();
         }
@@ -457,6 +461,16 @@ impl<'dom> IncrementalBoxTreeUpdate<'dom> {
                         build_new_box(old_parent),
                     ));
             },
+        }
+
+        let mut invalidate_start_point = self.node;
+        while let Some(parent_node) = invalidate_start_point.parent_node() {
+            parent_node
+                .to_threadsafe()
+                .with_layout_box_base_including_pseudos(|base| {
+                    base.clear_fragments_and_fragment_cache();
+                });
+            invalidate_start_point = parent_node;
         }
     }
 }

--- a/components/layout/layout_box_base.rs
+++ b/components/layout/layout_box_base.rs
@@ -92,6 +92,11 @@ impl LayoutBoxBase {
         self.fragments.borrow_mut().clear();
     }
 
+    pub(crate) fn clear_fragments_and_fragment_cache(&self) {
+        self.clear_fragments();
+        *self.cached_layout_result.borrow_mut() = None;
+    }
+
     pub(crate) fn repair_style(&mut self, new_style: &Arc<ComputedValues>) {
         self.style = new_style.clone();
         for fragment in self.fragments.borrow_mut().iter_mut() {
@@ -111,8 +116,7 @@ impl LayoutBoxBase {
         element_damage: LayoutDamage,
         damage_from_children: LayoutDamage,
     ) -> LayoutDamage {
-        self.clear_fragments();
-        *self.cached_layout_result.borrow_mut() = None;
+        self.clear_fragments_and_fragment_cache();
 
         if !element_damage.is_empty() ||
             damage_from_children.contains(LayoutDamage::RECOMPUTE_INLINE_CONTENT_SIZES)

--- a/components/layout/layout_impl.rs
+++ b/components/layout/layout_impl.rs
@@ -1108,7 +1108,7 @@ impl LayoutThread {
 
         let damage = compute_damage_and_repair_style(
             &layout_context.style_context,
-            root_node.to_threadsafe(),
+            dirty_root.to_threadsafe(),
             damage_from_environment,
         );
         if damage.contains(RestyleDamage::RECALCULATE_OVERFLOW) {


### PR DESCRIPTION
Instead of running the damage traversal on the entire tree, only run it
under the dirty root. This change also allows box tree
reconstruction from the dirty root to operate properly again. A previous
change had cleared boxes (when there was box tree damage) to the root of
the DOM.

Testing: This should not change behavior in a testable way, but should
do less work, particularly in large DOM trees.
