### PR TITLE
ohos CI: Ignore certificate errors for hitrace-bencher

### DIFF
--- a/support/hitrace-bencher/runs.json
+++ b/support/hitrace-bencher/runs.json
@@ -6,10 +6,10 @@
         "run_args": {
             "url": "https://www.google.com", // the url to test
             "tries": 5, // How many repeated tries we should have, we show the min,max,avg in the output
-            "mitmproxy": true   // Use mitmproxy in forwarding mode
+            "mitmproxy": true,   // Use mitmproxy in forwarding mode
             //"trace_buffer": 524288,   // trace_buffer size of hitrace
             //"sleep": 10,  // how long should we wait for servo to load the page
-            //"commands": ["--ps=--tracing-filter", "info"] // arbitrary additional arguments
+            "commands": ["--psn=--ignore-certificate-errors"]
         },
         "filters": [
             // Filters are currently given via the simple serialize of `filters::JsonValueFilter`.
@@ -66,7 +66,8 @@
         "run_args": {
             "url": "https://www.servo.org",
             "tries": 5,
-            "mitmproxy": true
+            "mitmproxy": true,
+            "commands": ["--psn=--ignore-certificate-errors"]
         },
         "filters": [
             {


### PR DESCRIPTION
Currently the bencher tests for harmonyos have a suspiciously low ram usage. However, Scenario tests and speedometer work.
The most likely explanation is that we forgot to add the certificate while switching hitrace-bencher to use mitmproxy.
Hence, we add the flag.

Testing: This does not have an automatic test but manually testing shows that we will have the certificate errors otherwise.
