### PR TITLE
pixels: Avoid unnecessary clone

### DIFF
--- a/components/shared/paint/lib.rs
+++ b/components/shared/paint/lib.rs
@@ -779,8 +779,7 @@ impl Debug for ImageUpdate {
 }
 
 #[derive(Debug, Deserialize, Serialize)]
-/// Serialized `ImageData`. It contains IPC byte channel receiver to prevent from loading bytes too
-/// slow.
+/// Serialized `ImageData`.
 pub enum SerializableImageData {
     /// A simple series of bytes, provided by the embedding and owned by WebRender.
     /// The format is stored out-of-band, currently in ImageDescriptor.


### PR DESCRIPTION
We do not need to clone the vector just to clone it again for an GenericSharedMemory to take it.

In real life tests this copy can take up to 30% of the `webrender_image_descriptor_and_data_for_frame` function.


Testing: This does not change functionality and just reorders the allocation.
