### PR TITLE
layout: Preserve fragment tree layout caches in clean subtrees

### DIFF
--- a/components/layout/dom.rs
+++ b/components/layout/dom.rs
@@ -322,11 +322,17 @@ pub(crate) trait NodeExt<'dom> {
 
     fn repair_style(&self, context: &SharedStyleContext);
 
-    /// Whether or not this node isolates downward flowing box tree rebuild damage. Roughly,
-    /// this corresponds to independent formatting context boundaries. The node's boxes
-    /// themselves will be rebuilt, but not the descendant node's boxes. When this node
-    /// has no box yet, `false` is returned.
-    fn isolates_box_tree_rebuild_damage(&self) -> bool;
+    /// Whether or not this node isolates downward flowing box tree rebuild damage and
+    /// fragment tree layout cache damage. Roughly, this corresponds to independent
+    /// formatting context boundaries.
+    ///
+    /// - The node's boxes themselves will be rebuilt, but not the descendant node's
+    ///   boxes.
+    /// - The node's fragment tree layout will be rebuilt, not the descendent node's
+    ///   fragment tree layout cache.
+    ///
+    /// When this node has no box yet, `false` is returned.
+    fn isolates_damage_for_damage_propagation(&self) -> bool;
 }
 
 impl<'dom> NodeExt<'dom> for ServoThreadSafeLayoutNode<'dom> {
@@ -486,7 +492,7 @@ impl<'dom> NodeExt<'dom> for ServoThreadSafeLayoutNode<'dom> {
         }
     }
 
-    fn isolates_box_tree_rebuild_damage(&self) -> bool {
+    fn isolates_damage_for_damage_propagation(&self) -> bool {
         let Some(inner_layout_data) = self.inner_layout_data() else {
             return false;
         };


### PR DESCRIPTION
Instead of clearing the fragment tree layout cache in a clean subtree of
a node that needs a new fragment, preserve caches when crossing
(roughly) independent formatting context boundaries [^1]. This should
allow layout to preserve more fragments when, for instance, a node
changes size, but its children do not.

[^1]: Currently things like table cells and captions do not do this.
Support for these will be added gradually.

Testing: This should not change behavior in a testable way, but should result in less work done during layout.
