### PR TITLE
script: Defers GPUComputePipeline drop to a helper struct

### DIFF
--- a/components/script_bindings/codegen/Bindings.conf
+++ b/components/script_bindings/codegen/Bindings.conf
@@ -328,10 +328,6 @@ DOMInterfaces = {
     'canGc': ['Messages'],
 },
 
-'GPUComputePipeline': {
-    'allowDropImpl': True,
-},
-
 'GPUDevice': {
     'inRealms': [
         'CreateComputePipelineAsync',


### PR DESCRIPTION
Moves the drop implementation for `GPUComputePipeline` to a separate `DroppableGPUComputePipeline` struct.

Removes `allowDropImpl` from the bindings configuration.

Testing: No tests added because of webgpu tests existent coverage
Fixes: Partially #26488 
