### PR TITLE
deps-bot: Add futures-rs group

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -28,6 +28,17 @@ updates:
         - "emath"
         - "epaint"
         - "epaint_default_fonts"
+    futures-rs-related:
+      patterns:
+        - "futures"
+        - "futures-channel"
+        - "futures-core"
+        - "futures-executor"
+        - "futures-io"
+        - "futures-macro"
+        - "futures-sink"
+        - "futures-task"
+        - "futures-util"
     gstreamer-related:
       patterns:
         - "gio*"


### PR DESCRIPTION
This is a foundational repo from rust-lang. Things should get bumped together. 
Otherwise you would see #42645, #42646, #42648, #42673 at same time.