### PR TITLE
layout: Replace dirty root approach with flexible box tree layout

### DIFF
--- a/components/layout/construct_modern.rs
+++ b/components/layout/construct_modern.rs
@@ -99,6 +99,8 @@ impl<'dom> ModernContainerJob<'dom> {
                 let formatting_context = IndependentFormattingContext::new(
                     LayoutBoxBase::new(info.into(), info.style.clone()),
                     IndependentFormattingContextContents::Flow(block_formatting_context),
+                    // This is just a series of anonymous text runs, so we don't need to worry
+                    // about what kind of PropagatedBoxTreeData is used here.
                     Default::default(),
                 );
 

--- a/components/layout/construct_modern.rs
+++ b/components/layout/construct_modern.rs
@@ -99,6 +99,7 @@ impl<'dom> ModernContainerJob<'dom> {
                 let formatting_context = IndependentFormattingContext::new(
                     LayoutBoxBase::new(info.into(), info.style.clone()),
                     IndependentFormattingContextContents::Flow(block_formatting_context),
+                    Default::default(),
                 );
 
                 Some(ModernItem {

--- a/components/layout/dom.rs
+++ b/components/layout/dom.rs
@@ -546,6 +546,15 @@ impl<'dom> NodeExt<'dom> for ServoThreadSafeLayoutNode<'dom> {
         &self,
         layout_context: &LayoutContext,
     ) -> bool {
+        // Do not run incremental box tree layout at the `<body>` or root element as there
+        // is some special processing that must happen for these elements and it currently
+        // only happens when doing a full box tree construction traversal.
+        if self.as_element().is_some_and(|element| {
+            element.is_body_element_of_html_element_root() || element.is_root()
+        }) {
+            return false;
+        }
+
         let layout_box = {
             let Some(mut inner_layout_data) = self.inner_layout_data_mut() else {
                 return false;

--- a/components/layout/dom.rs
+++ b/components/layout/dom.rs
@@ -22,6 +22,8 @@ use style::properties::ComputedValues;
 use style::selector_parser::PseudoElement;
 
 use crate::cell::{ArcRefCell, WeakRefCell};
+use crate::context::LayoutContext;
+use crate::dom_traversal::NodeAndStyleInfo;
 use crate::flexbox::FlexLevelBox;
 use crate::flow::BlockLevelBox;
 use crate::flow::inline::{InlineItem, SharedInlineStyles, WeakInlineItem};
@@ -312,6 +314,7 @@ pub(crate) trait NodeExt<'dom> {
 
     fn ensure_inner_layout_data(&self) -> AtomicRefMut<'dom, InnerDOMLayoutData>;
     fn inner_layout_data(&self) -> Option<AtomicRef<'dom, InnerDOMLayoutData>>;
+    fn inner_layout_data_mut(&self) -> Option<AtomicRefMut<'dom, InnerDOMLayoutData>>;
     fn box_slot(&self) -> BoxSlot<'dom>;
 
     /// Remove boxes for the element itself, and all of its pseudo-element boxes.
@@ -333,6 +336,17 @@ pub(crate) trait NodeExt<'dom> {
     ///
     /// When this node has no box yet, `false` is returned.
     fn isolates_damage_for_damage_propagation(&self) -> bool;
+
+    /// Try to re-run box tree reconstruction from this point. This can succeed if the
+    /// node itself is still valid and isolates box tree damage from ancestors (for
+    /// instance, if it starts an independent formatting context). **Note:** This assumes
+    /// that no ancestors have box damage.
+    ///
+    /// Returns `true` if box tree reconstruction was sucessful and `false` otherwise.
+    fn rebuild_box_tree_from_independent_formatting_context(
+        &self,
+        layout_context: &LayoutContext,
+    ) -> bool;
 }
 
 impl<'dom> NodeExt<'dom> for ServoThreadSafeLayoutNode<'dom> {
@@ -428,6 +442,16 @@ impl<'dom> NodeExt<'dom> for ServoThreadSafeLayoutNode<'dom> {
         })
     }
 
+    fn inner_layout_data_mut(&self) -> Option<AtomicRefMut<'dom, InnerDOMLayoutData>> {
+        self.layout_data().map(|data| {
+            data.as_any()
+                .downcast_ref::<DOMLayoutData>()
+                .unwrap()
+                .0
+                .borrow_mut()
+        })
+    }
+
     fn box_slot(&self) -> BoxSlot<'dom> {
         let pseudo_element_chain = self.pseudo_element_chain();
         let Some(primary) = pseudo_element_chain.primary else {
@@ -515,6 +539,77 @@ impl<'dom> NodeExt<'dom> for ServoThreadSafeLayoutNode<'dom> {
             LayoutBox::FlexLevel(..) => true,
             LayoutBox::TableLevelBox(..) => false,
             LayoutBox::TaffyItemBox(..) => true,
+        }
+    }
+
+    fn rebuild_box_tree_from_independent_formatting_context(
+        &self,
+        layout_context: &LayoutContext,
+    ) -> bool {
+        let layout_box = {
+            let Some(mut inner_layout_data) = self.inner_layout_data_mut() else {
+                return false;
+            };
+            inner_layout_data.pseudo_boxes.clear();
+            inner_layout_data.self_box.clone()
+        };
+
+        let layout_box = layout_box.borrow();
+        let Some(layout_box) = &*layout_box else {
+            return false;
+        };
+
+        let info = NodeAndStyleInfo::new(*self, self.style(&layout_context.style_context));
+        match layout_box {
+            LayoutBox::DisplayContents(..) => false,
+            LayoutBox::BlockLevel(block_level) => {
+                let mut block_level = block_level.borrow_mut();
+                match &mut *block_level {
+                    BlockLevelBox::Independent(independent_formatting_context) => {
+                        independent_formatting_context.rebuild(layout_context, &info);
+                        true
+                    },
+                    BlockLevelBox::OutOfFlowAbsolutelyPositionedBox(positioned_box) => {
+                        positioned_box
+                            .borrow_mut()
+                            .context
+                            .rebuild(layout_context, &info);
+                        true
+                    },
+                    _ => false,
+                }
+            },
+            LayoutBox::InlineLevel(inline_level) => match inline_level {
+                InlineItem::OutOfFlowAbsolutelyPositionedBox(positioned_box, ..) => {
+                    positioned_box
+                        .borrow_mut()
+                        .context
+                        .rebuild(layout_context, &info);
+                    true
+                },
+                InlineItem::Atomic(atomic_box, _, _) => {
+                    atomic_box.borrow_mut().rebuild(layout_context, &info);
+                    true
+                },
+                _ => false,
+            },
+            LayoutBox::FlexLevel(flex_level_box) => {
+                let mut flex_level_box = flex_level_box.borrow_mut();
+                match &mut *flex_level_box {
+                    FlexLevelBox::FlexItem(flex_item_box) => flex_item_box
+                        .independent_formatting_context
+                        .rebuild(layout_context, &info),
+                    FlexLevelBox::OutOfFlowAbsolutelyPositionedBox(positioned_box) => {
+                        positioned_box
+                            .borrow_mut()
+                            .context
+                            .rebuild(layout_context, &info);
+                    },
+                }
+                true
+            },
+            LayoutBox::TableLevelBox(..) => false,
+            LayoutBox::TaffyItemBox(..) => false,
         }
     }
 }

--- a/components/layout/flexbox/mod.rs
+++ b/components/layout/flexbox/mod.rs
@@ -212,7 +212,7 @@ impl FlexLevelBox {
 
 #[derive(MallocSizeOf)]
 pub(crate) struct FlexItemBox {
-    independent_formatting_context: IndependentFormattingContext,
+    pub(crate) independent_formatting_context: IndependentFormattingContext,
 }
 
 impl std::fmt::Debug for FlexItemBox {

--- a/components/layout/formatting_contexts.rs
+++ b/components/layout/formatting_contexts.rs
@@ -26,7 +26,7 @@ use crate::replaced::ReplacedContents;
 use crate::sizing::{
     self, ComputeInlineContentSizes, ContentSizes, InlineContentSizesResult, LazySize,
 };
-use crate::style_ext::{AspectRatio, DisplayInside, LayoutStyle};
+use crate::style_ext::{AspectRatio, Display, DisplayInside, LayoutStyle};
 use crate::table::Table;
 use crate::taffy::TaffyContainer;
 use crate::{
@@ -41,6 +41,9 @@ pub(crate) struct IndependentFormattingContext {
     // Private so that code outside of this module cannot match variants.
     // It should go through methods instead.
     contents: IndependentFormattingContextContents,
+    /// Data that was originally propagated down to this [`IndependentFormattingContext`]
+    /// during creation. This is used during incremental layout.
+    propagated_data: PropagatedBoxTreeData,
 }
 
 #[derive(Debug, MallocSizeOf)]
@@ -75,11 +78,43 @@ impl Baselines {
 }
 
 impl IndependentFormattingContext {
-    pub(crate) fn new(base: LayoutBoxBase, contents: IndependentFormattingContextContents) -> Self {
-        Self { base, contents }
+    pub(crate) fn new(
+        base: LayoutBoxBase,
+        contents: IndependentFormattingContextContents,
+        propagated_data: PropagatedBoxTreeData,
+    ) -> Self {
+        Self {
+            base,
+            contents,
+            propagated_data,
+        }
     }
 
-    pub fn construct(
+    pub(crate) fn rebuild(
+        &mut self,
+        layout_context: &LayoutContext,
+        node_and_style_info: &NodeAndStyleInfo,
+    ) {
+        let contents = Contents::for_element(node_and_style_info.node, layout_context);
+        let display = match Display::from(node_and_style_info.style.get_box().display) {
+            Display::None | Display::Contents => {
+                unreachable!("Should never try to rebuild IndependentFormattingContext with no box")
+            },
+            Display::GeneratingBox(display) => display.used_value_for_contents(&contents),
+        };
+        self.contents = Self::construct_contents(
+            layout_context,
+            node_and_style_info,
+            &mut self.base.base_fragment_info,
+            display.display_inside(),
+            contents,
+            self.propagated_data,
+        );
+        self.base.clear_fragments_and_fragment_cache();
+        self.base.repair_style(&node_and_style_info.style);
+    }
+
+    pub(crate) fn construct(
         context: &LayoutContext,
         node_and_style_info: &NodeAndStyleInfo,
         display_inside: DisplayInside,
@@ -87,7 +122,29 @@ impl IndependentFormattingContext {
         propagated_data: PropagatedBoxTreeData,
     ) -> Self {
         let mut base_fragment_info: BaseFragmentInfo = node_and_style_info.into();
+        let contents = Self::construct_contents(
+            context,
+            node_and_style_info,
+            &mut base_fragment_info,
+            display_inside,
+            contents,
+            propagated_data,
+        );
+        Self {
+            base: LayoutBoxBase::new(base_fragment_info, node_and_style_info.style.clone()),
+            contents,
+            propagated_data,
+        }
+    }
 
+    fn construct_contents(
+        context: &LayoutContext,
+        node_and_style_info: &NodeAndStyleInfo,
+        base_fragment_info: &mut BaseFragmentInfo,
+        display_inside: DisplayInside,
+        contents: Contents,
+        propagated_data: PropagatedBoxTreeData,
+    ) -> IndependentFormattingContextContents {
         let non_replaced_contents = match contents {
             Contents::Replaced(contents) => {
                 base_fragment_info.flags.insert(FragmentFlags::IS_REPLACED);
@@ -116,12 +173,10 @@ impl IndependentFormattingContext {
                         ArcRefCell::new(IndependentFormattingContext::new(
                             widget_base,
                             widget_contents,
+                            propagated_data,
                         ))
                     });
-                return Self {
-                    base: LayoutBoxBase::new(base_fragment_info, node_and_style_info.style.clone()),
-                    contents: IndependentFormattingContextContents::Replaced(contents, widget),
-                };
+                return IndependentFormattingContextContents::Replaced(contents, widget);
             },
             Contents::Widget(non_replaced_contents) => {
                 base_fragment_info.flags.insert(FragmentFlags::IS_WIDGET);
@@ -129,7 +184,8 @@ impl IndependentFormattingContext {
             },
             Contents::NonReplaced(non_replaced_contents) => non_replaced_contents,
         };
-        let contents = match display_inside {
+
+        match display_inside {
             DisplayInside::Flow { is_list_item } | DisplayInside::FlowRoot { is_list_item } => {
                 IndependentFormattingContextContents::Flow(BlockFormattingContext::construct(
                     context,
@@ -173,10 +229,6 @@ impl IndependentFormattingContext {
                     propagated_data,
                 ))
             },
-        };
-        Self {
-            base: LayoutBoxBase::new(base_fragment_info, node_and_style_info.style.clone()),
-            contents,
         }
     }
 

--- a/components/layout/formatting_contexts.rs
+++ b/components/layout/formatting_contexts.rs
@@ -110,7 +110,9 @@ impl IndependentFormattingContext {
             contents,
             self.propagated_data,
         );
+
         self.base.clear_fragments_and_fragment_cache();
+        *self.base.cached_inline_content_size.borrow_mut() = None;
         self.base.repair_style(&node_and_style_info.style);
     }
 

--- a/components/layout/layout_box_base.rs
+++ b/components/layout/layout_box_base.rs
@@ -92,6 +92,11 @@ impl LayoutBoxBase {
         self.fragments.borrow_mut().clear();
     }
 
+    pub(crate) fn clear_fragments_and_fragment_cache(&self) {
+        self.fragments.borrow_mut().clear();
+        *self.cached_layout_result.borrow_mut() = None;
+    }
+
     pub(crate) fn repair_style(&mut self, new_style: &Arc<ComputedValues>) {
         self.style = new_style.clone();
         for fragment in self.fragments.borrow_mut().iter_mut() {
@@ -111,8 +116,7 @@ impl LayoutBoxBase {
         element_damage: LayoutDamage,
         damage_from_children: LayoutDamage,
     ) -> LayoutDamage {
-        self.clear_fragments();
-        *self.cached_layout_result.borrow_mut() = None;
+        self.clear_fragments_and_fragment_cache();
 
         if !element_damage.is_empty() ||
             damage_from_children.contains(LayoutDamage::RECOMPUTE_INLINE_CONTENT_SIZES)

--- a/components/layout/lib.rs
+++ b/components/layout/lib.rs
@@ -157,7 +157,7 @@ impl<'a> From<&'_ DefiniteContainingBlock<'a>> for ContainingBlock<'a> {
 /// Data that is propagated from ancestors to descendants during [`crate::flow::BoxTree`]
 /// construction.  This allows data to flow in the reverse direction of the typical layout
 /// propoagation, but only during `BoxTree` construction.
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone, Copy, Debug, MallocSizeOf)]
 struct PropagatedBoxTreeData {
     allow_percentage_column_in_tables: bool,
 }

--- a/components/layout/table/construct.rs
+++ b/components/layout/table/construct.rs
@@ -121,6 +121,7 @@ impl Table {
         let ifc = IndependentFormattingContext::new(
             LayoutBoxBase::new((&table_info).into(), table_style),
             IndependentFormattingContextContents::Table(table),
+            propagated_data,
         );
 
         (table_info, ifc)
@@ -882,7 +883,11 @@ impl<'dom> TraversalHandler<'dom> for TableBuilderTraversal<'_, 'dom> {
                         );
                         let base = LayoutBoxBase::new(info.into(), info.style.clone());
                         ArcRefCell::new(TableCaption {
-                            context: IndependentFormattingContext::new(base, contents),
+                            context: IndependentFormattingContext::new(
+                                base,
+                                contents,
+                                self.current_propagated_data,
+                            ),
                         })
                     });
 

--- a/components/layout/traversal.rs
+++ b/components/layout/traversal.rs
@@ -3,17 +3,19 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 use std::cell::Cell;
+use std::sync::Arc;
 
 use bitflags::Flags;
 use layout_api::LayoutDamage;
 use layout_api::wrapper_traits::{LayoutNode, ThreadSafeLayoutNode};
-use script::layout_dom::ServoThreadSafeLayoutNode;
+use script::layout_dom::{ServoLayoutNode, ServoThreadSafeLayoutNode};
 use style::context::{SharedStyleContext, StyleContext};
 use style::data::ElementData;
 use style::dom::{NodeInfo, TElement, TNode};
 use style::selector_parser::RestyleDamage;
 use style::traversal::{DomTraversal, PerLevelTraversalData, recalc_style_at};
 
+use crate::BoxTree;
 use crate::context::LayoutContext;
 use crate::dom::{DOMLayoutData, NodeExt};
 
@@ -95,16 +97,79 @@ where
 }
 
 #[servo_tracing::instrument(skip_all)]
-pub(crate) fn compute_damage_and_repair_style(
-    context: &SharedStyleContext,
-    node: ServoThreadSafeLayoutNode<'_>,
+pub(crate) fn compute_damage_and_rebuild_box_tree(
+    box_tree: &mut Option<Arc<BoxTree>>,
+    layout_context: &LayoutContext,
+    dirty_root: ServoLayoutNode<'_>,
+    root_node: ServoLayoutNode<'_>,
     damage_from_environment: RestyleDamage,
 ) -> RestyleDamage {
-    compute_damage_and_repair_style_inner(context, node, damage_from_environment)
+    let restyle_damage = compute_damage_and_rebuild_box_tree_inner(
+        layout_context,
+        dirty_root.to_threadsafe(),
+        damage_from_environment,
+    );
+
+    let layout_damage: LayoutDamage = restyle_damage.into();
+    if box_tree.is_none() {
+        *box_tree = Some(Arc::new(BoxTree::construct(layout_context, root_node)));
+        return restyle_damage;
+    }
+
+    // There are two cases where we need to do more work:
+    //
+    // 1. Fragment tree layout needs to run again, in which case we should invalidate all
+    //    fragments to the root of the DOM.
+    // 2. Box tree reconstruction needs to run at the dirty root, in which case we need to
+    //    find an appropriate place to run box tree reconstruction and *also* invlidate all
+    //    fragments to the root of the DOM.
+    if !restyle_damage.contains(RestyleDamage::RELAYOUT) {
+        return restyle_damage;
+    }
+
+    // If the damage traversal indicated that the dirty root needs a new box, walk up the
+    // tree to find an appropriate place to run box tree reconstruction.
+    let mut needs_box_tree_rebuild = layout_damage.needs_new_box();
+
+    let mut maybe_parent_node = dirty_root.parent_node();
+    while let Some(parent_node) = maybe_parent_node {
+        let threadsafe_parent_node = parent_node.to_threadsafe();
+
+        // If we need box tree reconstruction, try it here.
+        if needs_box_tree_rebuild &&
+            threadsafe_parent_node
+                .rebuild_box_tree_from_independent_formatting_context(layout_context)
+        {
+            needs_box_tree_rebuild = false;
+        }
+
+        if needs_box_tree_rebuild {
+            // We have not yet found a place to run box tree reconstruction, so clear this
+            // node's boxes to ensure that they are invalidated for the reconstruction we
+            // will run later.
+            threadsafe_parent_node.unset_all_boxes();
+        } else {
+            // Reconstruction has already run or was not necessary, so we just need to
+            // ensure that fragment tree layout does not reuse any cached fragments.
+            threadsafe_parent_node.with_layout_box_base_including_pseudos(|base| {
+                base.clear_fragments_and_fragment_cache()
+            });
+        }
+
+        maybe_parent_node = parent_node.parent_node();
+    }
+
+    // We could not find a place in the middle of the tree to run box tree reconstruction,
+    // so just rebuild the whole tree.
+    if needs_box_tree_rebuild {
+        *box_tree = Some(Arc::new(BoxTree::construct(layout_context, root_node)));
+    }
+
+    restyle_damage
 }
 
-pub(crate) fn compute_damage_and_repair_style_inner(
-    context: &SharedStyleContext,
+pub(crate) fn compute_damage_and_rebuild_box_tree_inner(
+    layout_context: &LayoutContext,
     node: ServoThreadSafeLayoutNode<'_>,
     damage_from_parent: RestyleDamage,
 ) -> RestyleDamage {
@@ -132,11 +197,11 @@ pub(crate) fn compute_damage_and_repair_style_inner(
     // box damage.
     let mut damage_for_children = element_and_parent_damage;
     damage_for_children.truncate();
-    let rebuild_children = element_damage.contains(LayoutDamage::rebuild_box_tree()) ||
-        (damage_from_parent.contains(LayoutDamage::rebuild_box_tree()) &&
+    let rebuild_children = element_damage.contains(LayoutDamage::box_damage()) ||
+        (damage_from_parent.contains(LayoutDamage::box_damage()) &&
             !node.isolates_damage_for_damage_propagation());
     if rebuild_children {
-        damage_for_children.insert(LayoutDamage::rebuild_box_tree());
+        damage_for_children.insert(LayoutDamage::box_damage());
     } else if damage_for_children.contains(RestyleDamage::RELAYOUT) &&
         !element_damage.contains(RestyleDamage::RELAYOUT) &&
         node.isolates_damage_for_damage_propagation()
@@ -150,8 +215,11 @@ pub(crate) fn compute_damage_and_repair_style_inner(
     let mut damage_from_children = RestyleDamage::empty();
     for child in node.children() {
         if child.is_element() {
-            damage_from_children |=
-                compute_damage_and_repair_style_inner(context, child, damage_for_children);
+            damage_from_children |= compute_damage_and_rebuild_box_tree_inner(
+                layout_context,
+                child,
+                damage_for_children,
+            );
         }
     }
 
@@ -160,17 +228,31 @@ pub(crate) fn compute_damage_and_repair_style_inner(
     let mut layout_damage_for_parent =
         element_and_parent_damage | (damage_from_children & RestyleDamage::RELAYOUT);
 
-    if damage_from_children.contains(LayoutDamage::recollect_box_tree_children()) ||
-        element_and_parent_damage.contains(LayoutDamage::recollect_box_tree_children())
-    {
-        // In this case, this node, an ancestor, or a descendant needs to be completely
-        // rebuilt. That means that this box is no longer valid and also needs to be rebuilt
-        // (perhaps some of its children do not though). In this case, unset all existing
-        // boxes for the node and ensure that the appropriate rebuild-type damage propagates
-        // up the tree.
-        node.unset_all_boxes();
-        layout_damage_for_parent
-            .insert(LayoutDamage::recollect_box_tree_children() | RestyleDamage::RELAYOUT);
+    let element_or_ancestors_need_rebuild =
+        element_and_parent_damage.contains(LayoutDamage::descendant_has_box_damage());
+    let descendant_needs_rebuild =
+        damage_from_children.contains(LayoutDamage::descendant_has_box_damage());
+    if element_or_ancestors_need_rebuild || descendant_needs_rebuild {
+        if element_or_ancestors_need_rebuild ||
+            !node.rebuild_box_tree_from_independent_formatting_context(layout_context)
+        {
+            // In this case:
+            //  - this node or an ancestor needs to be completely rebuilt.
+            //  - a descendant needs to be rebuilt, but we are still propagating the rebuild
+            //    damage to an independent formatting context.
+            //
+            // This means that this box is no longer valid and also needs to be rebuilt
+            // (perhaps some of its descendants do not though). In this case, unset all existing
+            // boxes for the node and ensure that the appropriate rebuild-type damage
+            // propagates up the tree.
+            node.unset_all_boxes();
+            layout_damage_for_parent
+                .insert(LayoutDamage::descendant_has_box_damage() | RestyleDamage::RELAYOUT);
+        } else {
+            // In this case, we have rebuilt the box tree from this point and we do not
+            // have to propagate rebuild box tree damage up the tree any further.
+            layout_damage_for_parent.insert(RestyleDamage::RELAYOUT);
+        }
     } else {
         // In this case, this node's boxes are preserved! It's possible that we still need
         // to run fragment tree layout in this subtree due to an ancestor, this node, or a
@@ -191,7 +273,7 @@ pub(crate) fn compute_damage_and_repair_style_inner(
         // update any preserved layout data structures' style references, if *this*
         // element's style has changed.
         if !element_damage.is_empty() {
-            node.repair_style(context);
+            node.repair_style(&layout_context.style_context);
         }
     }
 

--- a/components/layout/traversal.rs
+++ b/components/layout/traversal.rs
@@ -121,7 +121,7 @@ pub(crate) fn compute_damage_and_rebuild_box_tree(
     // 1. Fragment tree layout needs to run again, in which case we should invalidate all
     //    fragments to the root of the DOM.
     // 2. Box tree reconstruction needs to run at the dirty root, in which case we need to
-    //    find an appropriate place to run box tree reconstruction and *also* invlidate all
+    //    find an appropriate place to run box tree reconstruction and *also* invalidate all
     //    fragments to the root of the DOM.
     if !restyle_damage.contains(RestyleDamage::RELAYOUT) {
         return restyle_damage;
@@ -131,9 +131,10 @@ pub(crate) fn compute_damage_and_rebuild_box_tree(
     // tree to find an appropriate place to run box tree reconstruction.
     let mut needs_box_tree_rebuild = layout_damage.needs_new_box();
 
-    let mut maybe_parent_node = dirty_root.parent_node();
+    let mut damage_for_ancestors = LayoutDamage::RECOMPUTE_INLINE_CONTENT_SIZES;
+    let mut maybe_parent_node = dirty_root.traversal_parent();
     while let Some(parent_node) = maybe_parent_node {
-        let threadsafe_parent_node = parent_node.to_threadsafe();
+        let threadsafe_parent_node = parent_node.as_node().to_threadsafe();
 
         // If we need box tree reconstruction, try it here.
         if needs_box_tree_rebuild &&
@@ -151,12 +152,17 @@ pub(crate) fn compute_damage_and_rebuild_box_tree(
         } else {
             // Reconstruction has already run or was not necessary, so we just need to
             // ensure that fragment tree layout does not reuse any cached fragments.
+            let new_damage_for_ancestors = Cell::new(LayoutDamage::empty());
             threadsafe_parent_node.with_layout_box_base_including_pseudos(|base| {
-                base.clear_fragments_and_fragment_cache()
+                new_damage_for_ancestors.set(
+                    new_damage_for_ancestors.get() |
+                        base.add_damage(Default::default(), damage_for_ancestors),
+                );
             });
+            damage_for_ancestors = new_damage_for_ancestors.get();
         }
 
-        maybe_parent_node = parent_node.parent_node();
+        maybe_parent_node = parent_node.traversal_parent();
     }
 
     // We could not find a place in the middle of the tree to run box tree reconstruction,
@@ -251,7 +257,8 @@ pub(crate) fn compute_damage_and_rebuild_box_tree_inner(
         } else {
             // In this case, we have rebuilt the box tree from this point and we do not
             // have to propagate rebuild box tree damage up the tree any further.
-            layout_damage_for_parent.insert(RestyleDamage::RELAYOUT);
+            layout_damage_for_parent
+                .insert(RestyleDamage::RELAYOUT | LayoutDamage::recompute_inline_content_sizes());
         }
     } else {
         // In this case, this node's boxes are preserved! It's possible that we still need

--- a/components/script/dom/element.rs
+++ b/components/script/dom/element.rs
@@ -379,7 +379,7 @@ impl Element {
                 doc.note_node_with_dirty_descendants(self.upcast());
                 restyle
                     .damage
-                    .insert(LayoutDamage::recollect_box_tree_children());
+                    .insert(LayoutDamage::descendant_has_box_damage());
             },
             NodeDamage::Other => {
                 doc.note_node_with_dirty_descendants(self.upcast());

--- a/components/script/layout_dom/element.rs
+++ b/components/script/layout_dom/element.rs
@@ -731,9 +731,9 @@ impl<'dom> style::dom::TElement for ServoLayoutElement<'dom> {
         };
 
         if box_tree_needs_rebuild() {
-            RestyleDamage::from_bits_retain(LayoutDamage::REBUILD_BOX.bits())
+            RestyleDamage::from_bits_retain(LayoutDamage::BOX_DAMAGE.bits())
         } else if text_shaping_needs_recollect() {
-            RestyleDamage::from_bits_retain(LayoutDamage::RECOLLECT_BOX_TREE_CHILDREN.bits())
+            RestyleDamage::from_bits_retain(LayoutDamage::DESCENDANT_HAS_BOX_DAMAGE.bits())
         } else {
             // This element needs to be laid out again, but does not have any damage to
             // its box. In the future, we will distinguish between types of damage to the


### PR DESCRIPTION
Replace the old dirty root box tree layout approach with one that works
based on independent formatting contexts. Instead of just allowing a
single dirty root to be the source of box tree reconstruction, allow box
tree reconstruction to happen anywhere in the tree that can isolate box
tree damage from ancestors. This essentially combines damage propagation
and box tree construction into a single step.

There is currently one downside to this approach compared to the dirty
root approach which is that we currently cannot detect and start box
tree layout when the dirty has a compatible `display` and `position`
value. This can mean the scope of box tree layout extends further up the
tree. We will address this in a followup -- but have not noticed any
major performance implications (currently fragment tree layout is much
more expensive than box tree layout).

Benefits:
 1. Damage propagation now only happens under the dirty root.
 2. Future changes can limit the scope of damage up the tree and perhaps
    preserve the inline content size cache between box tree rebuilds.

Testing: This should not change behavior in a testable way (we currently do
not have robust performance tests), so WPT test results should not change.
