### PR TITLE
script: always `let cx = &mut cx` in codegen and support cx in Constructor

### DIFF
--- a/components/script/dom/testing/testbinding.rs
+++ b/components/script/dom/testing/testbinding.rs
@@ -42,7 +42,7 @@ use crate::dom::bindings::codegen::UnionTypes::{
 use crate::dom::bindings::error::{Error, Fallible};
 use crate::dom::bindings::num::Finite;
 use crate::dom::bindings::refcounted::TrustedPromise;
-use crate::dom::bindings::reflector::{DomGlobal, Reflector, reflect_dom_object_with_proto};
+use crate::dom::bindings::reflector::{DomGlobal, Reflector, reflect_dom_object_with_proto_and_cx};
 use crate::dom::bindings::root::DomRoot;
 use crate::dom::bindings::str::{ByteString, DOMString, USVString};
 use crate::dom::bindings::trace::RootedTraceableBox;
@@ -72,46 +72,46 @@ impl TestBinding {
     }
 
     fn new(
+        cx: &mut js::context::JSContext,
         global: &GlobalScope,
         proto: Option<HandleObject>,
-        can_gc: CanGc,
     ) -> DomRoot<TestBinding> {
-        reflect_dom_object_with_proto(
+        reflect_dom_object_with_proto_and_cx(
             Box::new(TestBinding::new_inherited()),
             global,
             proto,
-            can_gc,
+            cx,
         )
     }
 }
 
 impl TestBindingMethods<crate::DomTypeHolder> for TestBinding {
     fn Constructor(
+        cx: &mut js::context::JSContext,
         global: &GlobalScope,
         proto: Option<HandleObject>,
-        can_gc: CanGc,
     ) -> Fallible<DomRoot<TestBinding>> {
-        Ok(TestBinding::new(global, proto, can_gc))
+        Ok(TestBinding::new(cx, global, proto))
     }
 
     #[expect(unused_variables)]
     fn Constructor_(
+        cx: &mut js::context::JSContext,
         global: &GlobalScope,
         proto: Option<HandleObject>,
-        can_gc: CanGc,
         nums: Vec<f64>,
     ) -> Fallible<DomRoot<TestBinding>> {
-        Ok(TestBinding::new(global, proto, can_gc))
+        Ok(TestBinding::new(cx, global, proto))
     }
 
     #[expect(unused_variables)]
     fn Constructor__(
+        cx: &mut js::context::JSContext,
         global: &GlobalScope,
         proto: Option<HandleObject>,
-        can_gc: CanGc,
         num: f64,
     ) -> Fallible<DomRoot<TestBinding>> {
-        Ok(TestBinding::new(global, proto, can_gc))
+        Ok(TestBinding::new(cx, global, proto))
     }
 
     fn BooleanAttribute(&self) -> bool {

--- a/components/script_bindings/codegen/Bindings.conf
+++ b/components/script_bindings/codegen/Bindings.conf
@@ -720,6 +720,7 @@ DOMInterfaces = {
     'inRealms': ['PromiseAttribute', 'PromiseNativeHandler'],
     'canGc': ['InterfaceAttribute', 'GetInterfaceAttributeNullable', 'ReceiveInterface', 'ReceiveInterfaceSequence', 'ReceiveNullableInterface', 'PromiseAttribute', 'PromiseNativeHandler', 'PromiseResolveNative', 'PromiseRejectNative', 'PromiseRejectWithTypeError'],
     'additionalTraits': ['crate::interfaces::TestBindingHelpers'],
+    'cx': ['Constructor', 'Constructor_', 'Constructor__'],
 },
 
 'TestWorklet': {


### PR DESCRIPTION
#42681 did not actually allowed using cx in Constructor, but it did most heavy lifting. Now we need to pass cx to Constructor call (and skip CanGc) if cx is requested in Bindings.conf. This PR also test this on testbindings.

Also we now always use `let cx = &mut cx`, so we can always use just cx (compiler will automatically deref it into &cx if needed). This is important because codegen stuff is called from many places to it make sense/easier to just unify this.

Testing: It compiles