### PR TITLE
servoshell ohos: Cleanup to use platform windows instead of custom solution and allow deleting

### DIFF
--- a/ports/servoshell/egl/android/mod.rs
+++ b/ports/servoshell/egl/android/mod.rs
@@ -205,6 +205,7 @@ pub extern "C" fn Java_org_servo_servoview_JNIServo_init<'local>(
                 window_handle,
                 init_opts.viewport_rect,
                 hidpi_scale_factor,
+                None,
             );
             *app.borrow_mut() = Some(new_app);
         });

--- a/ports/servoshell/egl/app.rs
+++ b/ports/servoshell/egl/app.rs
@@ -45,6 +45,8 @@ pub(crate) struct EmbeddedPlatformWindow {
     current_can_go_forward: Cell<bool>,
     /// The current load status of the active WebView.
     current_load_status: Cell<Option<LoadStatus>>,
+
+    id: ServoShellWindowId,
 }
 
 impl PlatformWindow for EmbeddedPlatformWindow {
@@ -53,7 +55,7 @@ impl PlatformWindow for EmbeddedPlatformWindow {
     }
 
     fn id(&self) -> ServoShellWindowId {
-        0.into()
+        self.id
     }
 
     fn screen_geometry(&self) -> ScreenGeometry {
@@ -267,7 +269,7 @@ pub(crate) struct AppInitOptions {
 }
 
 pub struct App {
-    state: Rc<RunningAppState>,
+    pub(crate) state: Rc<RunningAppState>,
     // TODO: multi-window support, like desktop version.
     // This is just an intermediate state, to split refactoring into
     // multiple PRs.
@@ -328,7 +330,16 @@ impl App {
             )
             .expect("Could not create RenderingContext"),
         );
+        let id = self
+            .state
+            .windows()
+            .values()
+            .map(|windows| windows.id())
+            .max()
+            .unwrap_or(ServoShellWindowId::default())
+            .inc();
         let platform_window = Rc::new(EmbeddedPlatformWindow {
+            id,
             host: self.host.clone(),
             rendering_context,
             refresh_driver,
@@ -355,10 +366,8 @@ impl App {
 
     pub(crate) fn window(&self) -> Rc<ServoShellWindow> {
         self.state
-            .windows()
-            .values()
-            .nth(0)
-            .expect("Should always have one open window")
+            .focused_window()
+            .expect("There is always an active window")
             .clone()
     }
 

--- a/ports/servoshell/egl/app.rs
+++ b/ports/servoshell/egl/app.rs
@@ -103,7 +103,9 @@ impl PlatformWindow for EmbeddedPlatformWindow {
         if url_changed {
             let new_url_string = new_url.as_ref().map(Url::to_string).unwrap_or_default();
             *self.current_url.borrow_mut() = new_url;
-            self.host.on_url_changed(new_url_string);
+            if self.has_platform_focus() {
+                self.host.on_url_changed(new_url_string);
+            }
         }
 
         let new_back_forward = (
@@ -318,6 +320,7 @@ impl App {
         window_handle: WindowHandle,
         viewport_rect: Rect<i32, DevicePixel>,
         hidpi_scale_factor: Scale<f32, DeviceIndependentPixel, DevicePixel>,
+        window_id: Option<ServoShellWindowId>,
     ) {
         let viewport_size = viewport_rect.size;
         let refresh_driver = Rc::new(VsyncRefreshDriver::default());
@@ -330,7 +333,7 @@ impl App {
             )
             .expect("Could not create RenderingContext"),
         );
-        let id = ServoShellWindowId::next();
+        let id = window_id.unwrap_or(ServoShellWindowId::next());
         let platform_window = Rc::new(EmbeddedPlatformWindow {
             id,
             host: self.host.clone(),

--- a/ports/servoshell/egl/app.rs
+++ b/ports/servoshell/egl/app.rs
@@ -330,14 +330,7 @@ impl App {
             )
             .expect("Could not create RenderingContext"),
         );
-        let id = self
-            .state
-            .windows()
-            .values()
-            .map(|windows| windows.id())
-            .max()
-            .unwrap_or(ServoShellWindowId::default())
-            .inc();
+        let id = ServoShellWindowId::next();
         let platform_window = Rc::new(EmbeddedPlatformWindow {
             id,
             host: self.host.clone(),

--- a/ports/servoshell/egl/ohos/mod.rs
+++ b/ports/servoshell/egl/ohos/mod.rs
@@ -61,9 +61,9 @@ use std::os::raw::c_void;
 use std::path::PathBuf;
 use std::ptr::NonNull;
 use std::rc::Rc;
-use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::mpsc::{Receiver, Sender};
-use std::sync::{LazyLock, Mutex, Once, OnceLock, mpsc};
+use std::sync::{LazyLock, Once, OnceLock, mpsc};
 use std::{fs, thread};
 
 use euclid::{Point2D, Rect, Scale, Size2D};
@@ -101,8 +101,7 @@ use xcomponent_sys::{
 use super::app::{App, AppInitOptions};
 use super::host_trait::HostTrait;
 use crate::prefs::{ArgumentParsingResult, parse_command_line_arguments};
-use crate::running_app_state::RunningAppState;
-use crate::window::{ServoShellWindow, ServoShellWindowId};
+use crate::window::ServoShellWindowId;
 
 /// Queue length for the thread-safe function to submit URL updates to ArkTS
 const UPDATE_URL_QUEUE_SIZE: usize = 1;
@@ -123,6 +122,7 @@ static TERMINATE_CALLBACK: OnceLock<
 static PROMPT_TOAST: OnceLock<
     ThreadsafeFunction<String, (), String, napi_ohos::Status, false, false, PROMPT_QUEUE_SIZE>,
 > = OnceLock::new();
+static NEXT_WINDOW_ID: AtomicU64 = AtomicU64::new(0);
 
 static SERVO_CHANNEL: OnceLock<Sender<ServoAction>> = OnceLock::new();
 
@@ -493,6 +493,9 @@ impl ServoAction {
                     window_handle,
                     viewport_rect,
                     hidpi_factor,
+                    Some(ServoShellWindowId::from(
+                        NEXT_WINDOW_ID.load(std::sync::atomic::Ordering::SeqCst),
+                    )),
                 );
             },
             RemovePlatformWindow(arkts_index, arkts_ids) => {
@@ -972,6 +975,11 @@ fn focus_webview(index: u32, arkts_ids: Vec<u32>) {
 #[napi]
 fn delete_webview(index: u32, arkts_ids: Vec<u32>) {
     call(ServoAction::RemovePlatformWindow(index, arkts_ids)).expect("Could not delete webview");
+}
+
+#[napi]
+fn next_window_id(id: u32) {
+    NEXT_WINDOW_ID.store(id.into(), std::sync::atomic::Ordering::SeqCst);
 }
 
 struct OhosImeOptions {

--- a/ports/servoshell/egl/ohos/mod.rs
+++ b/ports/servoshell/egl/ohos/mod.rs
@@ -64,10 +64,8 @@ use std::rc::Rc;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::mpsc::{Receiver, Sender};
 use std::sync::{LazyLock, Mutex, Once, OnceLock, mpsc};
-use std::time::Duration;
 use std::{fs, thread};
 
-use dpi::PhysicalSize;
 use euclid::{Point2D, Rect, Scale, Size2D};
 use keyboard_types::{Key, NamedKey};
 use log::{LevelFilter, debug, error, info, trace, warn};
@@ -88,7 +86,7 @@ use raw_window_handle::{
 };
 use servo::{
     self, DevicePixel, EventLoopWaker, InputMethodControl, InputMethodType, LoadStatus,
-    MediaSessionPlaybackState, PrefValue, WebViewId, WindowRenderingContext, Zero,
+    MediaSessionPlaybackState, PrefValue, Zero,
 };
 use xcomponent_sys::{
     OH_NativeXComponent, OH_NativeXComponent_Callback, OH_NativeXComponent_GetKeyEvent,
@@ -100,9 +98,11 @@ use xcomponent_sys::{
     OH_NativeXComponent_TouchEvent, OH_NativeXComponent_TouchEventType,
 };
 
-use super::app::{App, AppInitOptions, EmbeddedPlatformWindow, VsyncRefreshDriver};
+use super::app::{App, AppInitOptions};
 use super::host_trait::HostTrait;
 use crate::prefs::{ArgumentParsingResult, parse_command_line_arguments};
+use crate::running_app_state::RunningAppState;
+use crate::window::ServoShellWindow;
 
 /// Queue length for the thread-safe function to submit URL updates to ArkTS
 const UPDATE_URL_QUEUE_SIZE: usize = 1;
@@ -124,9 +124,9 @@ static PROMPT_TOAST: OnceLock<
     ThreadsafeFunction<String, (), String, napi_ohos::Status, false, false, PROMPT_QUEUE_SIZE>,
 > = OnceLock::new();
 
-/// Currently we do not support different contexts for different windows but we might want to change tabs.
-/// For this we store the window context for every tab and change the compositor by hand.
-static NATIVE_WEBVIEWS: Mutex<Vec<NativeWebViewComponents>> = Mutex::new(Vec::new());
+static UI_CALLBACK: OnceLock<
+    ThreadsafeFunction<Vec<i32>, (), Vec<i32>, napi_ohos::Status, false, false, 1>,
+> = OnceLock::new();
 
 static SERVO_CHANNEL: OnceLock<Sender<ServoAction>> = OnceLock::new();
 
@@ -352,19 +352,47 @@ pub(super) enum ServoAction {
         width: i32,
         height: i32,
     },
-    FocusWebview(u32),
+    FocusWindow(u32),
     CreatePlatformWindow(XComponentWrapper, WindowWrapper),
-    NewWebview(XComponentWrapper, WindowWrapper),
 }
 
-/// Storing webview related items
-struct NativeWebViewComponents {
-    /// The id of the related webview
-    id: WebViewId,
-    /// The XComponentWrapper for the above webview
-    xcomponent: XComponentWrapper,
-    /// The WindowWrapper for the above webview
-    window: WindowWrapper,
+impl std::fmt::Debug for ServoAction {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::WakeUp => write!(f, "WakeUp"),
+            Self::LoadUrl(arg0) => f.debug_tuple("LoadUrl").field(arg0).finish(),
+            Self::GoBack => write!(f, "GoBack"),
+            Self::GoForward => write!(f, "GoForward"),
+            Self::TouchEvent {
+                kind,
+                x,
+                y,
+                pointer_id,
+            } => f
+                .debug_struct("TouchEvent")
+                .field("kind", kind)
+                .field("x", x)
+                .field("y", y)
+                .field("pointer_id", pointer_id)
+                .finish(),
+            Self::KeyUp(arg0) => f.debug_tuple("KeyUp").field(arg0).finish(),
+            Self::KeyDown(arg0) => f.debug_tuple("KeyDown").field(arg0).finish(),
+            Self::InsertText(arg0) => f.debug_tuple("InsertText").field(arg0).finish(),
+            Self::ImeDeleteForward(arg0) => f.debug_tuple("ImeDeleteForward").field(arg0).finish(),
+            Self::ImeDeleteBackward(arg0) => {
+                f.debug_tuple("ImeDeleteBackward").field(arg0).finish()
+            },
+            Self::ImeSendEnter => write!(f, "ImeSendEnter"),
+            Self::Vsync => write!(f, "Vsync"),
+            Self::Resize { width, height } => f
+                .debug_struct("Resize")
+                .field("width", width)
+                .field("height", height)
+                .finish(),
+            Self::FocusWindow(arg0) => f.debug_tuple("FocusWindow").field(arg0).finish(),
+            Self::CreatePlatformWindow(..) => f.debug_tuple("CreatePlatformWindow").finish(),
+        }
+    }
 }
 
 impl ServoAction {
@@ -381,6 +409,9 @@ impl ServoAction {
     // todo: consider making this take `self`, so we don't need to needlessly clone.
     fn do_action(&self, servo: &Rc<App>) {
         use ServoAction::*;
+        if !(matches!(self, ServoAction::Vsync) || matches!(self, ServoAction::WakeUp)) {
+            trace!("ACTION {:?}", self);
+        }
         match self {
             WakeUp => {
                 servo.spin_event_loop();
@@ -419,31 +450,27 @@ impl ServoAction {
             Resize { width, height } => {
                 servo.resize(Rect::new(Point2D::origin(), Size2D::new(*width, *height)))
             },
-            FocusWebview(arkts_id) => {
-                if let Some(native_webview_components) =
-                    NATIVE_WEBVIEWS.lock().unwrap().get(*arkts_id as usize)
-                {
-                    let webview = servo
-                        .active_or_newest_webview()
-                        .expect("Should always start with at least one WebView");
-                    if webview.id() != native_webview_components.id {
-                        servo.activate_webview(native_webview_components.id);
-                        servo.pause_painting();
-                        let (window_handle, viewport_rect) = get_raw_window_handle(
-                            native_webview_components.xcomponent.0,
-                            native_webview_components.window.0,
-                        );
-                        servo.resume_painting(window_handle, viewport_rect);
-                        let url = webview
-                            .url()
-                            .map(|u| u.to_string())
-                            .unwrap_or(String::from("about:blank"));
-                        SET_URL_BAR_CB
-                            .get()
-                            .map(|f| f.call(url, ThreadsafeFunctionCallMode::Blocking));
+            FocusWindow(arkts_id) => {
+                let windows = servo.state.windows();
+
+                let mut ids = windows
+                    .values()
+                    .map(|window| window.id())
+                    .collect::<Vec<_>>();
+                ids.sort_unstable();
+
+                if let Some(window) = ids.get(*arkts_id as usize).and_then(|id| windows.get(id)) {
+                    servo.state.focus_window(window.clone());
+                    if let Some(webview) = window.active_webview() {
+                        webview.focus();
+                        if let Some(url) = webview.url() {
+                            SET_URL_BAR_CB.get().map(|f| {
+                                f.call(url.to_string(), ThreadsafeFunctionCallMode::Blocking)
+                            });
+                        }
                     }
                 } else {
-                    error!("Could not find webview to activate");
+                    error!("Could not find window to activate.");
                 }
             },
             CreatePlatformWindow(xcomponent, native_window) => {
@@ -460,41 +487,6 @@ impl ServoAction {
                     viewport_rect,
                     hidpi_factor,
                 );
-                // TODO: creating the window and creating the webview should be separate.
-                let webview = servo.create_and_activate_toplevel_webview(servo.initial_url());
-                let id = webview.id();
-                NATIVE_WEBVIEWS
-                    .lock()
-                    .unwrap()
-                    .push(NativeWebViewComponents {
-                        id,
-                        xcomponent: xcomponent.clone(),
-                        window: native_window.clone(),
-                    });
-            },
-            NewWebview(xcomponent, window) => {
-                servo.pause_painting();
-                let webview =
-                    servo.create_and_activate_toplevel_webview("about:blank".parse().unwrap());
-                let (window_handle, viewport_rect) = get_raw_window_handle(xcomponent.0, window.0);
-
-                servo.resume_painting(window_handle, viewport_rect);
-                let id = webview.id();
-                NATIVE_WEBVIEWS
-                    .lock()
-                    .unwrap()
-                    .push(NativeWebViewComponents {
-                        id,
-                        xcomponent: xcomponent.clone(),
-                        window: window.clone(),
-                    });
-                let url = webview
-                    .url()
-                    .map(|u| u.to_string())
-                    .unwrap_or(String::from("about:blank"));
-                SET_URL_BAR_CB
-                    .get()
-                    .map(|f| f.call(url, ThreadsafeFunctionCallMode::Blocking));
             },
         };
     }
@@ -575,8 +567,11 @@ extern "C" fn on_surface_created_cb(xcomponent: *mut OH_NativeXComponent, window
         }
         info!("Enabled Vsync!");
     } else {
-        call(ServoAction::NewWebview(xc_wrapper, window_wrapper))
-            .expect("Servo main thread channel not initialized");
+        call(ServoAction::CreatePlatformWindow(
+            xc_wrapper,
+            window_wrapper,
+        ))
+        .expect("Servo main thread channel not initialized");
     }
     info!("Returning from on_surface_created_cb");
 }
@@ -944,7 +939,7 @@ pub fn init_servo(init_opts: InitOpts) -> napi_ohos::Result<()> {
 #[napi]
 fn focus_webview(id: u32) {
     debug!("Focusing webview {id} from napi");
-    call(ServoAction::FocusWebview(id)).expect("Could not focus webview");
+    call(ServoAction::FocusWindow(id)).expect("Could not focus webview");
 }
 
 struct OhosImeOptions {

--- a/ports/servoshell/egl/ohos/mod.rs
+++ b/ports/servoshell/egl/ohos/mod.rs
@@ -102,7 +102,7 @@ use super::app::{App, AppInitOptions};
 use super::host_trait::HostTrait;
 use crate::prefs::{ArgumentParsingResult, parse_command_line_arguments};
 use crate::running_app_state::RunningAppState;
-use crate::window::ServoShellWindow;
+use crate::window::{ServoShellWindow, ServoShellWindowId};
 
 /// Queue length for the thread-safe function to submit URL updates to ArkTS
 const UPDATE_URL_QUEUE_SIZE: usize = 1;
@@ -122,10 +122,6 @@ static TERMINATE_CALLBACK: OnceLock<
 > = OnceLock::new();
 static PROMPT_TOAST: OnceLock<
     ThreadsafeFunction<String, (), String, napi_ohos::Status, false, false, PROMPT_QUEUE_SIZE>,
-> = OnceLock::new();
-
-static UI_CALLBACK: OnceLock<
-    ThreadsafeFunction<Vec<i32>, (), Vec<i32>, napi_ohos::Status, false, false, 1>,
 > = OnceLock::new();
 
 static SERVO_CHANNEL: OnceLock<Sender<ServoAction>> = OnceLock::new();
@@ -352,8 +348,9 @@ pub(super) enum ServoAction {
         width: i32,
         height: i32,
     },
-    FocusWindow(u32),
+    FocusWindow(u32, Vec<u32>),
     CreatePlatformWindow(XComponentWrapper, WindowWrapper),
+    RemovePlatformWindow(u32, Vec<u32>),
 }
 
 impl std::fmt::Debug for ServoAction {
@@ -389,8 +386,17 @@ impl std::fmt::Debug for ServoAction {
                 .field("width", width)
                 .field("height", height)
                 .finish(),
-            Self::FocusWindow(arg0) => f.debug_tuple("FocusWindow").field(arg0).finish(),
+            Self::FocusWindow(arg0, arkts_ids) => f
+                .debug_tuple("FocusWindow")
+                .field(arg0)
+                .field(arkts_ids)
+                .finish(),
             Self::CreatePlatformWindow(..) => f.debug_tuple("CreatePlatformWindow").finish(),
+            Self::RemovePlatformWindow(window, arkts_ids) => f
+                .debug_tuple("RemovePlatformWindow")
+                .field(window)
+                .field(arkts_ids)
+                .finish(),
         }
     }
 }
@@ -450,16 +456,12 @@ impl ServoAction {
             Resize { width, height } => {
                 servo.resize(Rect::new(Point2D::origin(), Size2D::new(*width, *height)))
             },
-            FocusWindow(arkts_id) => {
+            FocusWindow(arkts_index, arkts_ids) => {
                 let windows = servo.state.windows();
-
-                let mut ids = windows
-                    .values()
-                    .map(|window| window.id())
-                    .collect::<Vec<_>>();
-                ids.sort_unstable();
-
-                if let Some(window) = ids.get(*arkts_id as usize).and_then(|id| windows.get(id)) {
+                if let Some(window) = arkts_ids
+                    .get(*arkts_index as usize)
+                    .and_then(|value| windows.get(&ServoShellWindowId::from(*value as u64)))
+                {
                     servo.state.focus_window(window.clone());
                     if let Some(webview) = window.active_webview() {
                         webview.focus();
@@ -470,7 +472,12 @@ impl ServoAction {
                         }
                     }
                 } else {
-                    error!("Could not find window to activate.");
+                    error!(
+                        "Could not find window to activate. Arkts_index {}, arkts_ids {:?}, window_ids {:?}",
+                        arkts_index,
+                        arkts_ids,
+                        windows.keys().collect::<Vec<_>>(),
+                    );
                 }
             },
             CreatePlatformWindow(xcomponent, native_window) => {
@@ -487,6 +494,26 @@ impl ServoAction {
                     viewport_rect,
                     hidpi_factor,
                 );
+            },
+            RemovePlatformWindow(arkts_index, arkts_ids) => {
+                let windows = servo.state.windows();
+                if let Some(window_to_remove) = arkts_ids
+                    .get(*arkts_index as usize)
+                    .map(|id| ServoShellWindowId::from(*id as u64))
+                    .and_then(|window_id| windows.get(&window_id))
+                {
+                    if let Some(window_to_focus) =
+                        servo.state.windows().get(&ServoShellWindowId::from(0))
+                    {
+                        servo.state.focus_window(window_to_focus.clone());
+                        if let Some(webview) = window_to_focus.active_webview() {
+                            webview.focus();
+                        }
+                        window_to_remove.schedule_close();
+                    } else {
+                        error!("Window is already closed.");
+                    }
+                }
             },
         };
     }
@@ -937,9 +964,14 @@ pub fn init_servo(init_opts: InitOpts) -> napi_ohos::Result<()> {
 }
 
 #[napi]
-fn focus_webview(id: u32) {
-    debug!("Focusing webview {id} from napi");
-    call(ServoAction::FocusWindow(id)).expect("Could not focus webview");
+fn focus_webview(index: u32, arkts_ids: Vec<u32>) {
+    debug!("Focusing webview {index} from napi");
+    call(ServoAction::FocusWindow(index, arkts_ids)).expect("Could not focus webview");
+}
+
+#[napi]
+fn delete_webview(index: u32, arkts_ids: Vec<u32>) {
+    call(ServoAction::RemovePlatformWindow(index, arkts_ids)).expect("Could not delete webview");
 }
 
 struct OhosImeOptions {

--- a/ports/servoshell/window.rs
+++ b/ports/servoshell/window.rs
@@ -29,12 +29,22 @@ pub(crate) const LINE_WIDTH: f32 = 76.0;
 #[cfg_attr(any(target_os = "android", target_env = "ohos"), expect(dead_code))]
 pub(crate) const MIN_WINDOW_INNER_SIZE: DeviceIntSize = DeviceIntSize::new(100, 100);
 
-#[derive(Copy, Clone, Eq, Hash, PartialEq)]
+#[derive(Copy, Clone, Debug, Eq, Hash, PartialEq, PartialOrd, Ord)]
 pub(crate) struct ServoShellWindowId(u64);
 
 impl From<u64> for ServoShellWindowId {
     fn from(value: u64) -> Self {
         Self(value)
+    }
+}
+
+impl ServoShellWindowId {
+    pub(crate) fn inc(&self) -> ServoShellWindowId {
+        ServoShellWindowId(self.0 + 1)
+    }
+
+    pub(crate) fn default() -> ServoShellWindowId {
+        ServoShellWindowId(0)
     }
 }
 

--- a/ports/servoshell/window.rs
+++ b/ports/servoshell/window.rs
@@ -4,6 +4,7 @@
 
 use std::cell::{Cell, RefCell};
 use std::rc::Rc;
+use std::sync::atomic::AtomicU64;
 
 use euclid::Scale;
 use log::warn;
@@ -29,6 +30,8 @@ pub(crate) const LINE_WIDTH: f32 = 76.0;
 #[cfg_attr(any(target_os = "android", target_env = "ohos"), expect(dead_code))]
 pub(crate) const MIN_WINDOW_INNER_SIZE: DeviceIntSize = DeviceIntSize::new(100, 100);
 
+static SERVOSHELL_WINDOW_ID: AtomicU64 = AtomicU64::new(0);
+
 #[derive(Copy, Clone, Debug, Eq, Hash, PartialEq, PartialOrd, Ord)]
 pub(crate) struct ServoShellWindowId(u64);
 
@@ -39,12 +42,9 @@ impl From<u64> for ServoShellWindowId {
 }
 
 impl ServoShellWindowId {
-    pub(crate) fn inc(&self) -> ServoShellWindowId {
-        ServoShellWindowId(self.0 + 1)
-    }
-
-    pub(crate) fn default() -> ServoShellWindowId {
-        ServoShellWindowId(0)
+    #[cfg_attr(not(any(target_os = "android", target_env = "ohos")), expect(unused))]
+    pub(crate) fn next() -> ServoShellWindowId {
+        ServoShellWindowId(SERVOSHELL_WINDOW_ID.fetch_add(1, std::sync::atomic::Ordering::SeqCst))
     }
 }
 
@@ -160,7 +160,7 @@ impl ServoShellWindow {
         self.needs_repaint.set(true)
     }
 
-    #[cfg_attr(any(target_os = "android", target_env = "ohos"), expect(dead_code))]
+    #[cfg_attr(target_os = "android", expect(dead_code))]
     pub(crate) fn schedule_close(&self) {
         self.close_scheduled.set(true)
     }

--- a/support/openharmony/entry/src/main/cpp/types/libentry/index.d.ts
+++ b/support/openharmony/entry/src/main/cpp/types/libentry/index.d.ts
@@ -10,5 +10,6 @@ export const goForward: () => void;
 export const registerURLcallback: (callback: (url: string) => void) => void;
 export const registerTerminateCallback: (callback: () => void) => void;
 export const registerPromptToastCallback: (callback: (msg: string) => void) => void;
-export const focusWebview:(index: number) => void;
+export const focusWebview:(index: number, arkts_ids:number[]) => void;
+export const deleteWebview:(index: number, arkts_ids:number[]) => void;
 export const initServo:(options: InitOpts) => void;

--- a/support/openharmony/entry/src/main/cpp/types/libentry/index.d.ts
+++ b/support/openharmony/entry/src/main/cpp/types/libentry/index.d.ts
@@ -13,3 +13,4 @@ export const registerPromptToastCallback: (callback: (msg: string) => void) => v
 export const focusWebview:(index: number, arkts_ids:number[]) => void;
 export const deleteWebview:(index: number, arkts_ids:number[]) => void;
 export const initServo:(options: InitOpts) => void;
+export const nextWindowId:(arkts_id: number) => void;

--- a/support/openharmony/entry/src/main/ets/pages/Index.ets
+++ b/support/openharmony/entry/src/main/ets/pages/Index.ets
@@ -41,10 +41,16 @@ struct Index {
         })
     }
     .width(65)
-    .height(50)
+    .height(40)
     .justifyContent(FlexAlign.Center)
     .backgroundColor(this.currentIndex === index ? '#1B8381': Color.White)
     .borderRadius(10)
+    .shadow({
+          radius: 10,
+          color: Color.Gray,
+          offsetX: 10,
+          offsetY: 10
+        })
   }
 
   aboutToAppear(): void {
@@ -116,11 +122,12 @@ struct Index {
               .focusable(true)
           }.tabBar(this.tabBuilder(String(item), index))
         })
-      }.onChange((index: number) => {
+      }.barHeight(40)
+      .onChange((index: number) => {
         this.currentIndex = index;
         servoshell.focusWebview(index, this.tablist);
       })
-      .backgroundColor('#c7c7c7')
+      .backgroundColor('#e1e1e1')
     }
     .width('100%')
   }

--- a/support/openharmony/entry/src/main/ets/pages/Index.ets
+++ b/support/openharmony/entry/src/main/ets/pages/Index.ets
@@ -83,6 +83,8 @@ struct Index {
           .width('12%')
           .onClick((event) => {
             const new_id = this.tablist[this.tablist.length-1]+1;
+            // the order is important as setting the new index will automatically create a new surface.
+            servoshell.nextWindowId(new_id);
             this.currentIndex = this.tablist.push(new_id) - 1;
           })
         Button('⇦')

--- a/support/openharmony/entry/src/main/ets/pages/Index.ets
+++ b/support/openharmony/entry/src/main/ets/pages/Index.ets
@@ -20,9 +20,32 @@ struct Index {
     libraryname: 'servoshell',
   }
 
+  // The state seem to be required to be on the top.
   @State urlToLoad: string = ""
-  @State tablist: Array<number> = [1];
+  @State tablist: Array<number> = [0];
   @State currentIndex: number = 0;
+
+  @Builder tabBuilder(title: string, index: number) {
+    Row() {
+      Text(String(index))
+        .padding('10pt')
+      Button('X')
+      .backgroundColor('#00000000')
+      .visibility(this.tablist.length>1 && index != 0 ? Visibility.Visible: Visibility.Hidden)
+      .fontColor(Color.Black)
+      .fontWeight(FontWeight.Bolder)
+      .onClick((event) => {
+          this.currentIndex = 0;
+          servoshell.deleteWebview(index, this.tablist);
+          this.tablist.splice(index,1);
+        })
+    }
+    .width(65)
+    .height(50)
+    .justifyContent(FlexAlign.Center)
+    .backgroundColor(this.currentIndex === index ? '#1B8381': Color.White)
+    .borderRadius(10)
+  }
 
   aboutToAppear(): void {
     console.info("aboutToAppear - registering callbacks!")
@@ -53,8 +76,8 @@ struct Index {
           .fontSize(22)
           .width('12%')
           .onClick((event) => {
-            this.tablist.push(this.tablist[this.tablist.length-1]+1);
-            this.currentIndex = this.tablist.length - 1;
+            const new_id = this.tablist[this.tablist.length-1]+1;
+            this.currentIndex = this.tablist.push(new_id) - 1;
           })
         Button('⇦')
           .backgroundColor(Color.White)
@@ -87,16 +110,17 @@ struct Index {
       }
 
       Tabs({ barPosition: BarPosition.Start, index: this.currentIndex}) {
-        ForEach(this.tablist, (item: number) => {
+        ForEach(this.tablist, (item: number, index: number) => {
           TabContent() {
             XComponent(this.xComponentAttrs)
               .focusable(true)
-          }.tabBar(String(item))
+          }.tabBar(this.tabBuilder(String(item), index))
         })
       }.onChange((index: number) => {
-        console.info("Focusing Tab number %d", index)
-        servoshell.focusWebview(index);
+        this.currentIndex = index;
+        servoshell.focusWebview(index, this.tablist);
       })
+      .backgroundColor('#c7c7c7')
     }
     .width('100%')
   }


### PR DESCRIPTION
This cleans up the OHOS servoshell port to use the PlatformWindows API instead of
the custom solution of NATIVE_WEBVIEW_INFO. This should bring it more in line with how potential
embedders use this api.

This also fixes that previously only one PlatformWindow was allowed for embedders which can not be the case.
In the OHOS case, we actually have different surfaces we can render to (with how the app is setup currently),
hence, we have more than one platform window.

This also allows us to delete tabs now.

On the brighter side we added some color which makes the selected tab more obvious.

Testing: ScenarioTest and bencher should find if there are any problems with this. Manual tests were also performed.
