### PR TITLE
script: Replace RAII of CallSetup and AutoEntryScript with a function wrapper

### DIFF
--- a/components/script/dom/bindings/settings_stack.rs
+++ b/components/script/dom/bindings/settings_stack.rs
@@ -28,8 +28,6 @@ pub(crate) fn is_execution_stack_empty() -> bool {
     STACK.with(|stack| stack.borrow().is_empty())
 }
 
-pub(crate) type AutoEntryScript = GenericAutoEntryScript<crate::DomTypeHolder>;
-
 /// Returns the ["entry"] global object.
 ///
 /// ["entry"]: https://html.spec.whatwg.org/multipage/#entry

--- a/components/script/dom/global_scope_script_execution.rs
+++ b/components/script/dom/global_scope_script_execution.rs
@@ -18,12 +18,13 @@ use js::rust::wrappers::{
 };
 use js::rust::{CompileOptionsWrapper, MutableHandleValue, transform_str_to_source_text};
 use script_bindings::cformat;
+use script_bindings::settings_stack::run_a_script;
 use servo_url::ServoUrl;
 
+use crate::DomTypeHolder;
 use crate::dom::bindings::codegen::Bindings::WindowBinding::WindowMethods;
 use crate::dom::bindings::error::{Error, ErrorResult};
 use crate::dom::bindings::inheritance::Castable;
-use crate::dom::bindings::settings_stack::AutoEntryScript;
 use crate::dom::bindings::str::DOMString;
 use crate::dom::globalscope::GlobalScope;
 use crate::dom::window::Window;
@@ -156,76 +157,76 @@ impl GlobalScope {
 
         // Step 4. Prepare to run script given settings.
         // Once dropped this will run "Step 9. Clean up after running script" steps
-        let _aes = AutoEntryScript::new(self);
+        run_a_script::<DomTypeHolder, _>(self, || {
+            // Step 5. Let evaluationStatus be null.
+            rooted!(in(*cx) let mut evaluation_status = UndefinedValue());
+            let mut result = false;
 
-        // Step 5. Let evaluationStatus be null.
-        rooted!(in(*cx) let mut evaluation_status = UndefinedValue());
-        let mut result = false;
-
-        match script.record {
-            // Step 6. If script's error to rethrow is not null, then set evaluationStatus to ThrowCompletion(script's error to rethrow).
-            Err(error_to_rethrow) => unsafe {
-                JS_SetPendingException(
-                    *cx,
-                    error_to_rethrow.handle(),
-                    ExceptionStackBehavior::Capture,
-                )
-            },
-            // Step 7. Otherwise, set evaluationStatus to ScriptEvaluation(script's record).
-            Ok(compiled_script) => {
-                rooted!(in(*cx) let mut rval = UndefinedValue());
-                result = evaluate_script(
-                    cx,
-                    compiled_script,
-                    script.url,
-                    script.fetch_options,
-                    rval.handle_mut(),
-                );
-            },
-        }
-
-        unsafe { JS_GetPendingException(*cx, evaluation_status.handle_mut()) };
-
-        // Step 8. If evaluationStatus is an abrupt completion, then:
-        if !evaluation_status.is_undefined() {
-            warn!("Error evaluating script");
-
-            match (rethrow_errors, script.muted_errors) {
-                // Step 8.1. If rethrow errors is true and script's muted errors is false, then:
-                (RethrowErrors::Yes, ErrorReporting::Unmuted) => {
-                    // Rethrow evaluationStatus.[[Value]].
-                    return Err(Error::JSFailed);
+            match script.record {
+                // Step 6. If script's error to rethrow is not null, then set evaluationStatus to ThrowCompletion(script's error to rethrow).
+                Err(error_to_rethrow) => unsafe {
+                    JS_SetPendingException(
+                        *cx,
+                        error_to_rethrow.handle(),
+                        ExceptionStackBehavior::Capture,
+                    )
                 },
-                // Step 8.2. If rethrow errors is true and script's muted errors is true, then:
-                (RethrowErrors::Yes, ErrorReporting::Muted) => {
-                    unsafe { JS_ClearPendingException(*cx) };
-                    // Throw a "NetworkError" DOMException.
-                    return Err(Error::Network(None));
-                },
-                // Step 8.3. Otherwise, rethrow errors is false. Perform the following steps:
-                _ => {
-                    unsafe { JS_ClearPendingException(*cx) };
-                    // Report an exception given by evaluationStatus.[[Value]] for script's settings object's global object.
-                    self.report_an_exception(cx, evaluation_status.handle(), can_gc);
-
-                    // Return evaluationStatus.
-                    return Err(Error::JSFailed);
+                // Step 7. Otherwise, set evaluationStatus to ScriptEvaluation(script's record).
+                Ok(compiled_script) => {
+                    rooted!(in(*cx) let mut rval = UndefinedValue());
+                    result = evaluate_script(
+                        cx,
+                        compiled_script,
+                        script.url,
+                        script.fetch_options,
+                        rval.handle_mut(),
+                    );
                 },
             }
-        }
 
-        maybe_resume_unwind();
+            unsafe { JS_GetPendingException(*cx, evaluation_status.handle_mut()) };
 
-        // Step 10. If evaluationStatus is a normal completion, then return evaluationStatus.
-        if result {
-            return Ok(());
-        }
+            // Step 8. If evaluationStatus is an abrupt completion, then:
+            if !evaluation_status.is_undefined() {
+                warn!("Error evaluating script");
 
-        // Step 11. If we've reached this point, evaluationStatus was left as null because the script
-        // was aborted prematurely during evaluation. Return ThrowCompletion(a new QuotaExceededError).
-        Err(Error::QuotaExceeded {
-            quota: None,
-            requested: None,
+                match (rethrow_errors, script.muted_errors) {
+                    // Step 8.1. If rethrow errors is true and script's muted errors is false, then:
+                    (RethrowErrors::Yes, ErrorReporting::Unmuted) => {
+                        // Rethrow evaluationStatus.[[Value]].
+                        return Err(Error::JSFailed);
+                    },
+                    // Step 8.2. If rethrow errors is true and script's muted errors is true, then:
+                    (RethrowErrors::Yes, ErrorReporting::Muted) => {
+                        unsafe { JS_ClearPendingException(*cx) };
+                        // Throw a "NetworkError" DOMException.
+                        return Err(Error::Network(None));
+                    },
+                    // Step 8.3. Otherwise, rethrow errors is false. Perform the following steps:
+                    _ => {
+                        unsafe { JS_ClearPendingException(*cx) };
+                        // Report an exception given by evaluationStatus.[[Value]] for script's settings object's global object.
+                        self.report_an_exception(cx, evaluation_status.handle(), can_gc);
+
+                        // Return evaluationStatus.
+                        return Err(Error::JSFailed);
+                    },
+                }
+            }
+
+            maybe_resume_unwind();
+
+            // Step 10. If evaluationStatus is a normal completion, then return evaluationStatus.
+            if result {
+                return Ok(());
+            }
+
+            // Step 11. If we've reached this point, evaluationStatus was left as null because the script
+            // was aborted prematurely during evaluation. Return ThrowCompletion(a new QuotaExceededError).
+            Err(Error::QuotaExceeded {
+                quota: None,
+                requested: None,
+            })
         })
     }
 

--- a/components/script/dom/global_scope_script_execution.rs
+++ b/components/script/dom/global_scope_script_execution.rs
@@ -250,34 +250,34 @@ impl GlobalScope {
         // TODO
 
         // Step 4. Prepare to run script given settings.
-        let _aes = AutoEntryScript::new(self);
-
-        // Step 6. If script's error to rethrow is not null, then set evaluationPromise to a
-        // promise rejected with script's error to rethrow.
-        {
-            let module_error = module_tree.get_rethrow_error().borrow();
-            if module_error.is_some() {
-                module_tree.report_error(self, can_gc);
-                return;
+        run_a_script::<DomTypeHolder, _>(self, || {
+            // Step 6. If script's error to rethrow is not null, then set evaluationPromise to a
+            // promise rejected with script's error to rethrow.
+            {
+                let module_error = module_tree.get_rethrow_error().borrow();
+                if module_error.is_some() {
+                    module_tree.report_error(self, can_gc);
+                    return;
+                }
             }
-        }
 
-        // Step 7.1. Otherwise: Let record be script's record.
-        let record = module_tree.get_record().map(|record| record.handle());
+            // Step 7.1. Otherwise: Let record be script's record.
+            let record = module_tree.get_record().map(|record| record.handle());
 
-        if let Some(record) = record {
-            // Step 7.2. Set evaluationPromise to record.Evaluate().
-            rooted!(in(*GlobalScope::get_cx()) let mut rval = UndefinedValue());
-            let evaluated = module_tree.execute_module(self, record, rval.handle_mut(), can_gc);
+            if let Some(record) = record {
+                // Step 7.2. Set evaluationPromise to record.Evaluate().
+                rooted!(in(*GlobalScope::get_cx()) let mut rval = UndefinedValue());
+                let evaluated = module_tree.execute_module(self, record, rval.handle_mut(), can_gc);
 
-            // Step 8. If preventErrorReporting is false, then upon rejection of evaluationPromise
-            // with reason, report an exception given by reason for script's settings object's
-            // global object.
-            if let Err(exception) = evaluated {
-                module_tree.set_rethrow_error(exception);
-                module_tree.report_error(self, can_gc);
+                // Step 8. If preventErrorReporting is false, then upon rejection of evaluationPromise
+                // with reason, report an exception given by reason for script's settings object's
+                // global object.
+                if let Err(exception) = evaluated {
+                    module_tree.set_rethrow_error(exception);
+                    module_tree.report_error(self, can_gc);
+                }
             }
-        }
+        });
     }
 
     /// <https://html.spec.whatwg.org/multipage/#check-if-we-can-run-script>

--- a/components/script/dom/html/htmlscriptelement.rs
+++ b/components/script/dom/html/htmlscriptelement.rs
@@ -20,12 +20,14 @@ use net_traits::request::{
     CorsSettings, CredentialsMode, Destination, ParserMetadata, RequestBuilder, RequestId,
 };
 use net_traits::{FetchMetadata, Metadata, NetworkError, ResourceFetchTiming};
+use script_bindings::settings_stack::run_a_script;
 use servo_url::ServoUrl;
 use style::attr::AttrValue;
 use style::str::{HTML_SPACE_CHARACTERS, StaticStringVec};
 use stylo_atoms::Atom;
 use uuid::Uuid;
 
+use crate::DomTypeHolder;
 use crate::document_loader::LoadType;
 use crate::dom::attr::Attr;
 use crate::dom::bindings::cell::DomRefCell;

--- a/components/script/dom/html/htmlscriptelement.rs
+++ b/components/script/dom/html/htmlscriptelement.rs
@@ -20,14 +20,12 @@ use net_traits::request::{
     CorsSettings, CredentialsMode, Destination, ParserMetadata, RequestBuilder, RequestId,
 };
 use net_traits::{FetchMetadata, Metadata, NetworkError, ResourceFetchTiming};
-use script_bindings::settings_stack::run_a_script;
 use servo_url::ServoUrl;
 use style::attr::AttrValue;
 use style::str::{HTML_SPACE_CHARACTERS, StaticStringVec};
 use stylo_atoms::Atom;
 use uuid::Uuid;
 
-use crate::DomTypeHolder;
 use crate::document_loader::LoadType;
 use crate::dom::attr::Attr;
 use crate::dom::bindings::cell::DomRefCell;

--- a/components/script_bindings/callback.rs
+++ b/components/script_bindings/callback.rs
@@ -24,7 +24,7 @@ use crate::realms::{InRealm, enter_realm};
 use crate::reflector::DomObject;
 use crate::root::Dom;
 use crate::script_runtime::{CanGc, JSContext};
-use crate::settings_stack::{GenericAutoEntryScript, GenericAutoIncumbentScript};
+use crate::settings_stack::{GenericAutoIncumbentScript, run_a_script};
 use crate::{DomTypes, cformat};
 
 pub trait ThisReflector {
@@ -270,29 +270,30 @@ pub fn call_setup<D: DomTypes, T: CallbackContainer<D>, R>(
     }
     let cx = D::GlobalScope::get_cx();
 
+    let global = &global;
+
     // Step 8: Prepare to run script with relevant settings.
-    let aes = GenericAutoEntryScript::<D>::new(&global);
-    // Step 9: Prepare to run a callback with stored settings.
-    let ais = callback
-        .incumbent()
-        .map(GenericAutoIncumbentScript::<D>::new);
-    let old_realm = unsafe { EnterRealm(*cx, callback.callback()) };
-    let r = f(cx);
-    unsafe {
-        LeaveRealm(*cx, old_realm);
-    }
-    if handling == ExceptionHandling::Report {
-        let ar = enter_realm::<D>(&*global);
-        <D as DomHelpers<D>>::report_pending_exception(
-            cx,
-            true,
-            InRealm::Entered(&ar),
-            CanGc::note(),
-        );
-    }
-    // Step 14.1: Clean up after running a callback with stored settings.
-    drop(ais);
-    // Step 14.2: Clean up after running script with relevant settings.
-    drop(aes);
-    r
+    run_a_script::<D, R>(global, move || {
+        // Step 9: Prepare to run a callback with stored settings.
+        let ais = callback
+            .incumbent()
+            .map(GenericAutoIncumbentScript::<D>::new);
+        let old_realm = unsafe { EnterRealm(*cx, callback.callback()) };
+        let r = f(cx);
+        unsafe {
+            LeaveRealm(*cx, old_realm);
+        }
+        if handling == ExceptionHandling::Report {
+            let ar = enter_realm::<D>(&**global);
+            <D as DomHelpers<D>>::report_pending_exception(
+                cx,
+                true,
+                InRealm::Entered(&ar),
+                CanGc::note(),
+            );
+        }
+        // Step 14.1: Clean up after running a callback with stored settings.
+        drop(ais);
+        r
+    }) // Step 14.2: Clean up after running script with relevant settings.
 }

--- a/components/script_bindings/callback.rs
+++ b/components/script_bindings/callback.rs
@@ -10,7 +10,7 @@ use std::mem::drop;
 use std::rc::Rc;
 
 use js::jsapi::{
-    AddRawValueRoot, EnterRealm, Heap, IsCallable, JSObject, LeaveRealm, Realm, RemoveRawValueRoot,
+    AddRawValueRoot, EnterRealm, Heap, IsCallable, JSObject, LeaveRealm, RemoveRawValueRoot,
 };
 use js::jsval::{JSVal, NullValue, ObjectValue, UndefinedValue};
 use js::rust::wrappers::{JS_GetProperty, JS_WrapObject};
@@ -22,7 +22,7 @@ use crate::inheritance::Castable;
 use crate::interfaces::{DocumentHelpers, DomHelpers, GlobalScopeHelpers};
 use crate::realms::{InRealm, enter_realm};
 use crate::reflector::DomObject;
-use crate::root::{Dom, DomRoot};
+use crate::root::Dom;
 use crate::script_runtime::{CanGc, JSContext};
 use crate::settings_stack::{GenericAutoEntryScript, GenericAutoIncumbentScript};
 use crate::{DomTypes, cformat};
@@ -254,68 +254,45 @@ pub(crate) fn wrap_call_this_value<T: ThisReflector>(
     true
 }
 
-/// A class that performs whatever setup we need to safely make a call while
-/// this class is on the stack. After `new` returns, the call is safe to make.
-pub struct CallSetup<D: DomTypes> {
-    /// The global for reporting exceptions. This is the global object of the
-    /// (possibly wrapped) callback object.
-    exception_global: DomRoot<D::GlobalScope>,
-    /// The `JSContext` used for the call.
-    cx: JSContext,
-    /// The realm we were in before the call.
-    old_realm: *mut Realm,
-    /// The exception handling used for the call.
+/// A function wrapper that performs whatever setup we need to safely make a call.
+///
+/// <https://webidl.spec.whatwg.org/#es-invoking-callback-functions>
+pub fn call_setup<D: DomTypes, T: CallbackContainer<D>, R>(
+    callback: &T,
     handling: ExceptionHandling,
-    /// <https://heycam.github.io/webidl/#es-invoking-callback-functions>
-    /// steps 8 and 18.2.
-    entry_script: Option<GenericAutoEntryScript<D>>,
-    /// <https://heycam.github.io/webidl/#es-invoking-callback-functions>
-    /// steps 9 and 18.1.
-    incumbent_script: Option<GenericAutoIncumbentScript<D>>,
-}
+    f: impl FnOnce(JSContext) -> R,
+) -> R {
+    // The global for reporting exceptions. This is the global object of the
+    // (possibly wrapped) callback object.
+    let global = unsafe { D::GlobalScope::from_object(callback.callback()) };
+    if let Some(window) = global.downcast::<D::Window>() {
+        window.Document().ensure_safe_to_run_script_or_layout();
+    }
+    let cx = D::GlobalScope::get_cx();
 
-impl<D: DomTypes> CallSetup<D> {
-    /// Performs the setup needed to make a call.
-    pub fn new<T: CallbackContainer<D>>(callback: &T, handling: ExceptionHandling) -> Self {
-        let global = unsafe { D::GlobalScope::from_object(callback.callback()) };
-        if let Some(window) = global.downcast::<D::Window>() {
-            window.Document().ensure_safe_to_run_script_or_layout();
-        }
-        let cx = D::GlobalScope::get_cx();
-
-        let aes = GenericAutoEntryScript::<D>::new(&global);
-        let ais = callback.incumbent().map(GenericAutoIncumbentScript::new);
-        CallSetup {
-            exception_global: global,
+    // Step 8: Prepare to run script with relevant settings.
+    let aes = GenericAutoEntryScript::<D>::new(&global);
+    // Step 9: Prepare to run a callback with stored settings.
+    let ais = callback
+        .incumbent()
+        .map(GenericAutoIncumbentScript::<D>::new);
+    let old_realm = unsafe { EnterRealm(*cx, callback.callback()) };
+    let r = f(cx);
+    unsafe {
+        LeaveRealm(*cx, old_realm);
+    }
+    if handling == ExceptionHandling::Report {
+        let ar = enter_realm::<D>(&*global);
+        <D as DomHelpers<D>>::report_pending_exception(
             cx,
-            old_realm: unsafe { EnterRealm(*cx, callback.callback()) },
-            handling,
-            entry_script: Some(aes),
-            incumbent_script: ais,
-        }
+            true,
+            InRealm::Entered(&ar),
+            CanGc::note(),
+        );
     }
-
-    /// Returns the `JSContext` used for the call.
-    pub fn get_context(&self) -> JSContext {
-        self.cx
-    }
-}
-
-impl<D: DomTypes> Drop for CallSetup<D> {
-    fn drop(&mut self) {
-        unsafe {
-            LeaveRealm(*self.cx, self.old_realm);
-        }
-        if self.handling == ExceptionHandling::Report {
-            let ar = enter_realm::<D>(&*self.exception_global);
-            <D as DomHelpers<D>>::report_pending_exception(
-                self.cx,
-                true,
-                InRealm::Entered(&ar),
-                CanGc::note(),
-            );
-        }
-        drop(self.incumbent_script.take());
-        drop(self.entry_script.take().unwrap());
-    }
+    // Step 14.1: Clean up after running a callback with stored settings.
+    drop(ais);
+    // Step 14.2: Clean up after running script with relevant settings.
+    drop(aes);
+    r
 }

--- a/components/script_bindings/import.rs
+++ b/components/script_bindings/import.rs
@@ -28,8 +28,8 @@ pub(crate) mod base {
     };
 
     pub(crate) use crate::callback::{
-        CallSetup, CallbackContainer, CallbackFunction, CallbackInterface, CallbackObject,
-        ExceptionHandling, ThisReflector, wrap_call_this_value,
+        CallbackContainer, CallbackFunction, CallbackInterface, CallbackObject, ExceptionHandling,
+        ThisReflector, call_setup, wrap_call_this_value,
     };
     pub(crate) use crate::codegen::DomTypes::DomTypes;
     pub(crate) use crate::codegen::GenericUnionTypes;

--- a/components/script_bindings/settings_stack.rs
+++ b/components/script_bindings/settings_stack.rs
@@ -10,10 +10,8 @@ use js::rust::Runtime;
 
 use crate::DomTypes;
 use crate::interfaces::{DomHelpers, GlobalScopeHelpers};
-use crate::root::{Dom, DomRoot};
-use crate::script_runtime::temp_cx;
 use crate::root::Dom;
-use crate::script_runtime::CanGc;
+use crate::script_runtime::temp_cx;
 
 #[derive(Debug, Eq, JSTraceable, PartialEq)]
 pub enum StackEntryKind {
@@ -65,7 +63,7 @@ pub fn run_a_script<D: DomTypes, R>(global: &D::GlobalScope, f: impl FnOnce() ->
     // Step 5
     if !thread::panicking() && stack_is_empty {
         let mut cx = unsafe { temp_cx() };
-        self.global.perform_a_microtask_checkpoint(&mut cx);
+        global.perform_a_microtask_checkpoint(&mut cx);
     }
     r
 }

--- a/components/script_bindings/settings_stack.rs
+++ b/components/script_bindings/settings_stack.rs
@@ -12,6 +12,8 @@ use crate::DomTypes;
 use crate::interfaces::{DomHelpers, GlobalScopeHelpers};
 use crate::root::{Dom, DomRoot};
 use crate::script_runtime::temp_cx;
+use crate::root::Dom;
+use crate::script_runtime::CanGc;
 
 #[derive(Debug, Eq, JSTraceable, PartialEq)]
 pub enum StackEntryKind {
@@ -26,64 +28,46 @@ pub struct StackEntry<D: DomTypes> {
     pub kind: StackEntryKind,
 }
 
-/// RAII struct that pushes and pops entries from the script settings stack.
-pub struct GenericAutoEntryScript<D: DomTypes> {
-    global: DomRoot<D::GlobalScope>,
-    #[cfg(feature = "tracing")]
-    #[expect(dead_code)]
-    span: tracing::span::EnteredSpan,
-}
-
-impl<D: DomTypes> GenericAutoEntryScript<D> {
-    /// <https://html.spec.whatwg.org/multipage/#prepare-to-run-script>
-    pub fn new(global: &D::GlobalScope) -> Self {
-        let settings_stack = <D as DomHelpers<D>>::settings_stack();
-        settings_stack.with(|stack| {
-            trace!("Prepare to run script with {:p}", global);
-            let mut stack = stack.borrow_mut();
-            stack.push(StackEntry {
-                global: Dom::from_ref(global),
-                kind: StackEntryKind::Entry,
-            });
-            Self {
-                global: DomRoot::from_ref(global),
-                #[cfg(feature = "tracing")]
-                span: tracing::info_span!(
-                    "ScriptEvaluate",
-                    servo_profiling = true,
-                    url = global.get_url().to_string(),
-                )
-                .entered(),
-            }
-        })
-    }
-}
-
-impl<D: DomTypes> Drop for GenericAutoEntryScript<D> {
-    /// <https://html.spec.whatwg.org/multipage/#clean-up-after-running-script>
-    fn drop(&mut self) {
-        let settings_stack = <D as DomHelpers<D>>::settings_stack();
-        let mut stack_is_empty = false;
-        settings_stack.with(|stack| {
-            let mut stack = stack.borrow_mut();
-            let entry = stack.pop().unwrap();
-            assert_eq!(
-                &*entry.global as *const D::GlobalScope, &*self.global as *const D::GlobalScope,
-                "Dropped AutoEntryScript out of order."
-            );
-            assert_eq!(entry.kind, StackEntryKind::Entry);
-            trace!("Clean up after running script with {:p}", &*entry.global);
-            stack_is_empty = stack.is_empty();
+/// Wrapper that pushes and pops entries from the script settings stack.
+///
+/// <https://html.spec.whatwg.org/multipage/#prepare-to-run-script>
+/// <https://html.spec.whatwg.org/multipage/#clean-up-after-running-script>
+pub fn run_a_script<D: DomTypes, R>(global: &D::GlobalScope, f: impl FnOnce() -> R) -> R {
+    let settings_stack = <D as DomHelpers<D>>::settings_stack();
+    settings_stack.with(|stack| {
+        trace!("Prepare to run script with {:p}", global);
+        let mut stack = stack.borrow_mut();
+        stack.push(StackEntry {
+            global: Dom::from_ref(global),
+            kind: StackEntryKind::Entry,
         });
+        #[cfg(feature = "tracing")]
+        tracing::info_span!(
+            "ScriptEvaluate",
+            servo_profiling = true,
+            url = global.get_url().to_string(),
+        )
+        .entered()
+    });
+    let r = f();
+    let stack_is_empty = settings_stack.with(|stack| {
+        let mut stack = stack.borrow_mut();
+        let entry = stack.pop().unwrap();
+        assert_eq!(
+            &*entry.global as *const D::GlobalScope, global as *const D::GlobalScope,
+            "Dropped AutoEntryScript out of order."
+        );
+        assert_eq!(entry.kind, StackEntryKind::Entry);
+        trace!("Clean up after running script with {:p}", &*entry.global);
+        stack.is_empty()
+    });
 
-        // Step 5
-        if !thread::panicking() && stack_is_empty {
-            // To remove this we would need to refactor this whole type.
-            // Instead of RAII we should have use callback pattern.
-            let mut cx = unsafe { temp_cx() };
-            self.global.perform_a_microtask_checkpoint(&mut cx);
-        }
+    // Step 5
+    if !thread::panicking() && stack_is_empty {
+        let mut cx = unsafe { temp_cx() };
+        self.global.perform_a_microtask_checkpoint(&mut cx);
     }
+    r
 }
 
 /// RAII struct that pushes and pops entries from the script settings stack.


### PR DESCRIPTION
As mentioned in #40600 we will need this to properly handle &mut JSContext (we cannot pass it to drop) and I think this wrappers are preferred ways of doing this in rust as it is safe to forget (not call drop) which is unsound in this case (due to realm stack at least).

Revieable per commits.

Testing: Just a refactor, but should be covered by WPT
