### PR TITLE
script: Do not unnecessary clone CSP list in `Document::get_csp_list`

### DIFF
--- a/components/script/dom/document.rs
+++ b/components/script/dom/document.rs
@@ -3920,7 +3920,7 @@ impl Document {
 
     /// Returns a policy value that should be used for fetches initiated by this document.
     pub(crate) fn insecure_requests_policy(&self) -> InsecureRequestsPolicy {
-        if let Some(csp_list) = &*self.get_csp_list() {
+        if let Some(csp_list) = self.get_csp_list().as_ref() {
             for policy in &csp_list.0 {
                 if policy.contains_a_directive_whose_name_is("upgrade-insecure-requests") &&
                     policy.disposition == PolicyDisposition::Enforce

--- a/components/script/dom/document.rs
+++ b/components/script/dom/document.rs
@@ -1968,8 +1968,10 @@ impl Document {
         self.policy_container.borrow_mut().set_csp_list(csp_list);
     }
 
-    pub(crate) fn get_csp_list(&self) -> Option<CspList> {
-        self.policy_container.borrow().csp_list.clone()
+    pub(crate) fn get_csp_list(&self) -> Ref<'_, Option<CspList>> {
+        Ref::map(self.policy_container.borrow(), |policy_container| {
+            &policy_container.csp_list
+        })
     }
 
     pub(crate) fn preloaded_resources(&self) -> std::cell::Ref<'_, PreloadedResources> {
@@ -3918,7 +3920,7 @@ impl Document {
 
     /// Returns a policy value that should be used for fetches initiated by this document.
     pub(crate) fn insecure_requests_policy(&self) -> InsecureRequestsPolicy {
-        if let Some(csp_list) = self.get_csp_list() {
+        if let Some(csp_list) = &*self.get_csp_list() {
             for policy in &csp_list.0 {
                 if policy.contains_a_directive_whose_name_is("upgrade-insecure-requests") &&
                     policy.disposition == PolicyDisposition::Enforce

--- a/components/script/dom/globalscope.rs
+++ b/components/script/dom/globalscope.rs
@@ -2621,9 +2621,7 @@ impl GlobalScope {
             return document.get_referrer_policy();
         }
         if let Some(worker) = self.downcast::<WorkerGlobalScope>() {
-            let policy_container = worker.policy_container().to_owned();
-
-            return policy_container.get_referrer_policy();
+            return worker.policy_container().get_referrer_policy();
         }
         unreachable!();
     }

--- a/components/script/dom/windowproxy.rs
+++ b/components/script/dom/windowproxy.rs
@@ -547,7 +547,7 @@ impl WindowProxy {
                 target_window.as_global_scope().get_referrer()
             };
             // Propagate CSP list and about-base-url from opener to new document
-            let csp_list = existing_document.get_csp_list();
+            let csp_list = existing_document.get_csp_list().clone();
             target_document.set_csp_list(csp_list);
 
             // Step 15.5 Otherwise, navigate targetNavigable to urlRecord using sourceDocument,


### PR DESCRIPTION
We previously clonsed the CSP list unnecessarily which consisted of roughly 2.7%. 1.2% spend in Document::get_csp_list.
We can easily avoid it with Ref and cloning it deliberately when needed.

Testing: This is functionally identical to the previous code as it is a change from clone to a Ref<>.
