### PR TITLE
layout: Extend damage propagation isolation to table cells and captions

### DIFF
--- a/components/layout/dom.rs
+++ b/components/layout/dom.rs
@@ -537,7 +537,10 @@ impl<'dom> NodeExt<'dom> for ServoThreadSafeLayoutNode<'dom> {
                 InlineItem::OutOfFlowAbsolutelyPositionedBox(..) | InlineItem::Atomic(..)
             ),
             LayoutBox::FlexLevel(..) => true,
-            LayoutBox::TableLevelBox(..) => false,
+            LayoutBox::TableLevelBox(table_level_box) => matches!(
+                table_level_box,
+                TableLevelBox::Cell(..) | TableLevelBox::Caption(..),
+            ),
             LayoutBox::TaffyItemBox(..) => true,
         }
     }
@@ -617,7 +620,17 @@ impl<'dom> NodeExt<'dom> for ServoThreadSafeLayoutNode<'dom> {
                 }
                 true
             },
-            LayoutBox::TableLevelBox(..) => false,
+            LayoutBox::TableLevelBox(table_level_box) => match table_level_box {
+                TableLevelBox::Caption(caption) => {
+                    caption.borrow_mut().context.rebuild(layout_context, &info);
+                    true
+                },
+                TableLevelBox::Cell(table_cell) => {
+                    table_cell.borrow_mut().rebuild(layout_context, &info);
+                    true
+                },
+                _ => false,
+            },
             LayoutBox::TaffyItemBox(..) => false,
         }
     }

--- a/components/layout/table/construct.rs
+++ b/components/layout/table/construct.rs
@@ -1172,3 +1172,26 @@ fn add_column(
     collection.extend(repeat_n(column.clone(), span as usize));
     column
 }
+
+impl TableSlotCell {
+    pub(crate) fn rebuild(
+        &mut self,
+        layout_context: &LayoutContext,
+        node_and_style_info: &NodeAndStyleInfo,
+    ) {
+        self.contents = BlockFormattingContext::construct(
+            layout_context,
+            node_and_style_info,
+            NonReplacedContents::OfElement,
+            // TODO: This only works because currently PropagatedBoxTreeData only stores
+            // this single bit of information. If we ever add more information to
+            // PropagatedBoxTreeData, this will need to be stored on the table cell
+            // and reused.
+            PropagatedBoxTreeData::default().disallowing_percentage_table_columns(),
+            false, /* is_list_item */
+        );
+        self.base.clear_fragments_and_fragment_cache();
+        *self.base.cached_inline_content_size.borrow_mut() = None;
+        self.base.repair_style(&node_and_style_info.style);
+    }
+}

--- a/components/layout/table/mod.rs
+++ b/components/layout/table/mod.rs
@@ -360,7 +360,7 @@ impl TableTrackGroup {
 #[derive(Debug, MallocSizeOf)]
 pub struct TableCaption {
     /// The contents of this cell, with its own layout.
-    context: IndependentFormattingContext,
+    pub(crate) context: IndependentFormattingContext,
 }
 
 /// A calculated collapsed border.


### PR DESCRIPTION
These two types of boxes should also be able to isolate damage during
propagation and serve as roots for box tree reconstruction, as their
contents are independent of their containing box.

Testing: This should not change testable behavior so is covered by existing WPT tests.
