### PR TITLE
layout: align/justify-self last baseline should be treated as safe end in absolute position box.

### DIFF
--- a/components/layout/positioned.rs
+++ b/components/layout/positioned.rs
@@ -863,11 +863,11 @@ impl AbsoluteAxisSolver {
             AlignFlags::RIGHT => AlignFlags::START,
             // https://drafts.csswg.org/css-align/#valdef-self-position-end
             // https://drafts.csswg.org/css-align/#valdef-self-position-flex-end
-            AlignFlags::END | AlignFlags::FLEX_END => AlignFlags::END,
-            // https://drafts.csswg.org/css-align-3/#baseline-values
-            AlignFlags::LAST_BASELINE => AlignFlags::END,
+            // https://drafts.csswg.org/css-align/#valdef-justify-self-last-baseline
+            AlignFlags::END | AlignFlags::FLEX_END | AlignFlags::LAST_BASELINE => AlignFlags::END,
             // https://drafts.csswg.org/css-align/#valdef-self-position-start
             // https://drafts.csswg.org/css-align/#valdef-self-position-flex-start
+            // https://drafts.csswg.org/css-align/#valdef-justify-self-first-baseline
             _ => AlignFlags::START,
         };
 

--- a/components/layout/positioned.rs
+++ b/components/layout/positioned.rs
@@ -864,6 +864,8 @@ impl AbsoluteAxisSolver {
             // https://drafts.csswg.org/css-align/#valdef-self-position-end
             // https://drafts.csswg.org/css-align/#valdef-self-position-flex-end
             AlignFlags::END | AlignFlags::FLEX_END => AlignFlags::END,
+            // https://drafts.csswg.org/css-align-3/#baseline-values
+            AlignFlags::LAST_BASELINE => AlignFlags::END,
             // https://drafts.csswg.org/css-align/#valdef-self-position-start
             // https://drafts.csswg.org/css-align/#valdef-self-position-flex-start
             _ => AlignFlags::START,

--- a/tests/wpt/meta/css/css-align/abspos/align-self-htb-ltr-htb.html.ini
+++ b/tests/wpt/meta/css/css-align/abspos/align-self-htb-ltr-htb.html.ini
@@ -1,6 +1,0 @@
-[align-self-htb-ltr-htb.html]
-  [.item 5]
-    expected: FAIL
-
-  [.item 13]
-    expected: FAIL

--- a/tests/wpt/meta/css/css-align/abspos/align-self-htb-ltr-vlr.html.ini
+++ b/tests/wpt/meta/css/css-align/abspos/align-self-htb-ltr-vlr.html.ini
@@ -1,10 +1,4 @@
 [align-self-htb-ltr-vlr.html]
-  [.item 5]
-    expected: FAIL
-
-  [.item 13]
-    expected: FAIL
-
   [.item 14]
     expected: FAIL
 

--- a/tests/wpt/meta/css/css-align/abspos/align-self-htb-ltr-vrl.html.ini
+++ b/tests/wpt/meta/css/css-align/abspos/align-self-htb-ltr-vrl.html.ini
@@ -1,10 +1,4 @@
 [align-self-htb-ltr-vrl.html]
-  [.item 5]
-    expected: FAIL
-
-  [.item 13]
-    expected: FAIL
-
   [.item 14]
     expected: FAIL
 

--- a/tests/wpt/meta/css/css-align/abspos/align-self-htb-rtl-htb.html.ini
+++ b/tests/wpt/meta/css/css-align/abspos/align-self-htb-rtl-htb.html.ini
@@ -1,6 +1,0 @@
-[align-self-htb-rtl-htb.html]
-  [.item 5]
-    expected: FAIL
-
-  [.item 13]
-    expected: FAIL

--- a/tests/wpt/meta/css/css-align/abspos/align-self-htb-rtl-vlr.html.ini
+++ b/tests/wpt/meta/css/css-align/abspos/align-self-htb-rtl-vlr.html.ini
@@ -1,10 +1,4 @@
 [align-self-htb-rtl-vlr.html]
-  [.item 5]
-    expected: FAIL
-
-  [.item 13]
-    expected: FAIL
-
   [.item 14]
     expected: FAIL
 

--- a/tests/wpt/meta/css/css-align/abspos/align-self-htb-rtl-vrl.html.ini
+++ b/tests/wpt/meta/css/css-align/abspos/align-self-htb-rtl-vrl.html.ini
@@ -1,10 +1,4 @@
 [align-self-htb-rtl-vrl.html]
-  [.item 5]
-    expected: FAIL
-
-  [.item 13]
-    expected: FAIL
-
   [.item 14]
     expected: FAIL
 

--- a/tests/wpt/meta/css/css-align/abspos/justify-self-htb-ltr-htb.html.ini
+++ b/tests/wpt/meta/css/css-align/abspos/justify-self-htb-ltr-htb.html.ini
@@ -1,6 +1,0 @@
-[justify-self-htb-ltr-htb.html]
-  [.item 5]
-    expected: FAIL
-
-  [.item 15]
-    expected: FAIL

--- a/tests/wpt/meta/css/css-align/abspos/justify-self-htb-ltr-vlr.html.ini
+++ b/tests/wpt/meta/css/css-align/abspos/justify-self-htb-ltr-vlr.html.ini
@@ -1,10 +1,4 @@
 [justify-self-htb-ltr-vlr.html]
-  [.item 5]
-    expected: FAIL
-
-  [.item 15]
-    expected: FAIL
-
   [.item 17]
     expected: FAIL
 

--- a/tests/wpt/meta/css/css-align/abspos/justify-self-htb-ltr-vrl.html.ini
+++ b/tests/wpt/meta/css/css-align/abspos/justify-self-htb-ltr-vrl.html.ini
@@ -1,11 +1,5 @@
 [justify-self-htb-ltr-vrl.html]
-  [.item 5]
-    expected: FAIL
-
   [.item 6]
-    expected: FAIL
-
-  [.item 15]
     expected: FAIL
 
   [.item 7]

--- a/tests/wpt/meta/css/css-align/abspos/justify-self-htb-rtl-htb.html.ini
+++ b/tests/wpt/meta/css/css-align/abspos/justify-self-htb-rtl-htb.html.ini
@@ -1,6 +1,0 @@
-[justify-self-htb-rtl-htb.html]
-  [.item 5]
-    expected: FAIL
-
-  [.item 15]
-    expected: FAIL

--- a/tests/wpt/meta/css/css-align/abspos/justify-self-htb-rtl-vlr.html.ini
+++ b/tests/wpt/meta/css/css-align/abspos/justify-self-htb-rtl-vlr.html.ini
@@ -1,10 +1,4 @@
 [justify-self-htb-rtl-vlr.html]
-  [.item 5]
-    expected: FAIL
-
-  [.item 15]
-    expected: FAIL
-
   [.item 16]
     expected: FAIL
 

--- a/tests/wpt/meta/css/css-align/abspos/justify-self-htb-rtl-vrl.html.ini
+++ b/tests/wpt/meta/css/css-align/abspos/justify-self-htb-rtl-vrl.html.ini
@@ -1,11 +1,5 @@
 [justify-self-htb-rtl-vrl.html]
-  [.item 5]
-    expected: FAIL
-
   [.item 7]
-    expected: FAIL
-
-  [.item 15]
     expected: FAIL
 
   [.item 6]

--- a/tests/wpt/meta/css/css-flexbox/abspos/flex-abspos-staticpos-align-self-rtl-003.html.ini
+++ b/tests/wpt/meta/css/css-flexbox/abspos/flex-abspos-staticpos-align-self-rtl-003.html.ini
@@ -47,8 +47,3 @@
   [.container > div 23]
     expected: FAIL
 
-  [.container > div 5]
-    expected: FAIL
-
-  [.container > div 17]
-    expected: FAIL

--- a/tests/wpt/meta/css/css-flexbox/abspos/flex-abspos-staticpos-align-self-rtl-004.html.ini
+++ b/tests/wpt/meta/css/css-flexbox/abspos/flex-abspos-staticpos-align-self-rtl-004.html.ini
@@ -46,9 +46,3 @@
 
   [.container > div 23]
     expected: FAIL
-
-  [.container > div 5]
-    expected: FAIL
-
-  [.container > div 17]
-    expected: FAIL

--- a/tests/wpt/meta/css/css-flexbox/abspos/flex-abspos-staticpos-align-self-vertWM-001.html.ini
+++ b/tests/wpt/meta/css/css-flexbox/abspos/flex-abspos-staticpos-align-self-vertWM-001.html.ini
@@ -11,6 +11,9 @@
   [.container > div 4]
     expected: FAIL
 
+  [.container > div 5]
+    expected: FAIL
+
   [.container > div 6]
     expected: FAIL
 
@@ -39,6 +42,9 @@
     expected: FAIL
 
   [.container > div 18]
+    expected: FAIL
+  
+  [.container > div 19]
     expected: FAIL
 
   [.container > div 20]

--- a/tests/wpt/meta/css/css-flexbox/abspos/flex-abspos-staticpos-align-self-vertWM-002.html.ini
+++ b/tests/wpt/meta/css/css-flexbox/abspos/flex-abspos-staticpos-align-self-vertWM-002.html.ini
@@ -11,6 +11,9 @@
   [.container > div 4]
     expected: FAIL
 
+  [.container > div 5]
+    expected: FAIL
+
   [.container > div 6]
     expected: FAIL
 
@@ -39,6 +42,9 @@
     expected: FAIL
 
   [.container > div 18]
+    expected: FAIL
+
+  [.container > div 19]
     expected: FAIL
 
   [.container > div 20]

--- a/tests/wpt/meta/css/css-grid/abspos/grid-abspos-staticpos-align-self-vertWM-last-baseline-003.html.ini
+++ b/tests/wpt/meta/css/css-grid/abspos/grid-abspos-staticpos-align-self-vertWM-last-baseline-003.html.ini
@@ -1,0 +1,2 @@
+[grid-abspos-staticpos-align-self-vertWM-last-baseline-003.html]
+  expected: FAIL

--- a/tests/wpt/meta/css/css-grid/abspos/grid-abspos-staticpos-align-self-vertWM-last-baseline-004.html.ini
+++ b/tests/wpt/meta/css/css-grid/abspos/grid-abspos-staticpos-align-self-vertWM-last-baseline-004.html.ini
@@ -1,0 +1,2 @@
+[grid-abspos-staticpos-align-self-vertWM-last-baseline-004.html]
+  expected: FAIL


### PR DESCRIPTION
`align-self: last baseline` should be treated as `safe end` in absolute position box. Given the `baseline` require a group of box, and in the context of absolute position box, there always would be only one box, we can follow the [spec of baseline fallback spec](https://drafts.csswg.org/css-align-3/#ref-for-fallback-alignment), make `last baseline` fallback to `end`.

Testing: More WPT test is passing.
Fixes: N/A
