### PR TITLE
script: Add `reflect_dom_object_with_cx`

### DIFF
--- a/components/script/dom/bindings/reflector.rs
+++ b/components/script/dom/bindings/reflector.rs
@@ -45,6 +45,22 @@ where
 
 /// Create the reflector for a new DOM object and yield ownership to the
 /// reflector.
+pub(crate) fn reflect_dom_object_with_cx<D, T, U>(
+    obj: Box<T>,
+    global: &U,
+    cx: &mut js::context::JSContext,
+) -> DomRoot<T>
+where
+    D: DomTypes,
+    T: DomObject + DomObjectWrap<D>,
+    U: DerivedFrom<D::GlobalScope>,
+{
+    let global_scope = global.upcast();
+    unsafe { T::WRAP(cx, global_scope, None, obj) }
+}
+
+/// Create the reflector for a new DOM object and yield ownership to the
+/// reflector.
 pub(crate) fn reflect_dom_object_with_proto_and_cx<D, T, U>(
     obj: Box<T>,
     global: &U,

--- a/components/script/dom/bluetooth/bluetoothremotegattservice.rs
+++ b/components/script/dom/bluetooth/bluetoothremotegattservice.rs
@@ -10,7 +10,7 @@ use dom_struct::dom_struct;
 use crate::dom::bindings::codegen::Bindings::BluetoothRemoteGATTServerBinding::BluetoothRemoteGATTServerMethods;
 use crate::dom::bindings::codegen::Bindings::BluetoothRemoteGATTServiceBinding::BluetoothRemoteGATTServiceMethods;
 use crate::dom::bindings::error::Error;
-use crate::dom::bindings::reflector::reflect_dom_object;
+use crate::dom::bindings::reflector::reflect_dom_object_with_cx;
 use crate::dom::bindings::root::{Dom, DomRoot};
 use crate::dom::bindings::str::DOMString;
 use crate::dom::bluetooth::{AsyncBluetoothListener, get_gatt_children};
@@ -56,12 +56,12 @@ impl BluetoothRemoteGATTService {
         isPrimary: bool,
         instanceID: String,
     ) -> DomRoot<BluetoothRemoteGATTService> {
-        reflect_dom_object(
+        reflect_dom_object_with_cx(
             Box::new(BluetoothRemoteGATTService::new_inherited(
                 device, uuid, isPrimary, instanceID,
             )),
             global,
-            CanGc::from_cx(cx),
+            cx,
         )
     }
 


### PR DESCRIPTION
Just to complement existing with_proto method introduced in #42699.

Justification for arg ordering: reflect_dom_* have arguments reversed, so first one is Box (the most important) then global, proto and lastly cx.