### PR TITLE
 script: Pass `&mut JSContext` in `FetchResponseListener::process_response_eof`

### DIFF
--- a/components/script/dom/eventsource.rs
+++ b/components/script/dom/eventsource.rs
@@ -452,18 +452,19 @@ impl FetchResponseListener for EventSourceContext {
 
     fn process_response_eof(
         mut self,
+        cx: &mut js::context::JSContext,
         _: RequestId,
         response: Result<(), NetworkError>,
         timing: ResourceFetchTiming,
     ) {
         if self.incomplete_utf8.take().is_some() {
-            self.parse("\u{FFFD}".chars(), CanGc::note());
+            self.parse("\u{FFFD}".chars(), CanGc::from_cx(cx));
         }
         if response.is_ok() {
             self.reestablish_the_connection();
         }
 
-        network_listener::submit_timing(&self, &response, &timing, CanGc::note());
+        network_listener::submit_timing(&self, &response, &timing, CanGc::from_cx(cx));
     }
 
     fn process_csp_violations(&mut self, _request_id: RequestId, violations: Vec<Violation>) {

--- a/components/script/dom/html/htmlimageelement.rs
+++ b/components/script/dom/html/htmlimageelement.rs
@@ -306,6 +306,7 @@ impl FetchResponseListener for ImageContext {
 
     fn process_response_eof(
         self,
+        cx: &mut js::context::JSContext,
         request_id: RequestId,
         response: Result<(), NetworkError>,
         timing: ResourceFetchTiming,
@@ -314,7 +315,7 @@ impl FetchResponseListener for ImageContext {
             self.id,
             FetchResponseMsg::ProcessResponseEOF(request_id, response.clone(), timing.clone()),
         );
-        network_listener::submit_timing(&self, &response, &timing, CanGc::note());
+        network_listener::submit_timing(&self, &response, &timing, CanGc::from_cx(cx));
     }
 
     fn process_csp_violations(&mut self, _request_id: RequestId, violations: Vec<Violation>) {

--- a/components/script/dom/html/htmllinkelement.rs
+++ b/components/script/dom/html/htmllinkelement.rs
@@ -1124,6 +1124,7 @@ impl FetchResponseListener for FaviconFetchContext {
 
     fn process_response_eof(
         self,
+        cx: &mut js::context::JSContext,
         request_id: RequestId,
         response: Result<(), NetworkError>,
         timing: ResourceFetchTiming,
@@ -1132,7 +1133,7 @@ impl FetchResponseListener for FaviconFetchContext {
             self.id,
             FetchResponseMsg::ProcessResponseEOF(request_id, response.clone(), timing.clone()),
         );
-        submit_timing(&self, &response, &timing, CanGc::note());
+        submit_timing(&self, &response, &timing, CanGc::from_cx(cx));
     }
 
     fn process_csp_violations(&mut self, _request_id: RequestId, violations: Vec<Violation>) {

--- a/components/script/dom/html/htmlmediaelement.rs
+++ b/components/script/dom/html/htmlmediaelement.rs
@@ -3834,6 +3834,7 @@ impl FetchResponseListener for HTMLMediaElementFetchListener {
 
     fn process_response_eof(
         self,
+        cx: &mut js::context::JSContext,
         _: RequestId,
         status: Result<(), NetworkError>,
         timing: ResourceFetchTiming,
@@ -3878,7 +3879,7 @@ impl FetchResponseListener for HTMLMediaElementFetchListener {
             // Step 1. Fire an event named progress at the media element.
             element
                 .upcast::<EventTarget>()
-                .fire_event(atom!("progress"), CanGc::note());
+                .fire_event(atom!("progress"), CanGc::from_cx(cx));
 
             // Step 2. Set the networkState to NETWORK_IDLE and fire an event named suspend at the
             // media element.
@@ -3886,17 +3887,17 @@ impl FetchResponseListener for HTMLMediaElementFetchListener {
 
             element
                 .upcast::<EventTarget>()
-                .fire_event(atom!("suspend"), CanGc::note());
+                .fire_event(atom!("suspend"), CanGc::from_cx(cx));
         } else if status.is_err() && element.ready_state.get() != ReadyState::HaveNothing {
             // => "If the connection is interrupted after some media data has been received..."
-            element.media_data_processing_fatal_steps(MEDIA_ERR_NETWORK, CanGc::note());
+            element.media_data_processing_fatal_steps(MEDIA_ERR_NETWORK, CanGc::from_cx(cx));
         } else {
             // => "If the media data can be fetched but is found by inspection to be in an
             // unsupported format, or can otherwise not be rendered at all"
             element.media_data_processing_failure_steps();
         }
 
-        network_listener::submit_timing(&self, &status, &timing, CanGc::note());
+        network_listener::submit_timing(&self, &status, &timing, CanGc::from_cx(cx));
     }
 
     fn process_csp_violations(&mut self, _request_id: RequestId, violations: Vec<Violation>) {

--- a/components/script/dom/html/htmlscriptelement.rs
+++ b/components/script/dom/html/htmlscriptelement.rs
@@ -375,6 +375,7 @@ impl FetchResponseListener for ClassicContext {
     /// step 4-9
     fn process_response_eof(
         mut self,
+        cx: &mut js::context::JSContext,
         _: RequestId,
         response: Result<(), NetworkError>,
         timing: ResourceFetchTiming,
@@ -388,11 +389,11 @@ impl FetchResponseListener for ClassicContext {
                     self.kind,
                     self.url.clone(),
                     Err(()),
-                    CanGc::note(),
+                    CanGc::from_cx(cx),
                 );
 
                 // Resource timing is expected to be available before "error" or "load" events are fired.
-                network_listener::submit_timing(&self, &response, &timing, CanGc::note());
+                network_listener::submit_timing(&self, &response, &timing, CanGc::from_cx(cx));
                 return;
             },
             _ => {},
@@ -469,11 +470,11 @@ impl FetchResponseListener for ClassicContext {
             self.kind,
             self.url.clone(),
             Ok(load),
-            CanGc::note(),
+            CanGc::from_cx(cx),
         );
         // }
 
-        network_listener::submit_timing(&self, &response, &timing, CanGc::note());
+        network_listener::submit_timing(&self, &response, &timing, CanGc::from_cx(cx));
     }
 
     fn process_csp_violations(&mut self, _request_id: RequestId, violations: Vec<Violation>) {

--- a/components/script/dom/html/htmlvideoelement.rs
+++ b/components/script/dom/html/htmlvideoelement.rs
@@ -446,6 +446,7 @@ impl FetchResponseListener for PosterFrameFetchContext {
 
     fn process_response_eof(
         self,
+        cx: &mut js::context::JSContext,
         request_id: RequestId,
         response: Result<(), NetworkError>,
         timing: ResourceFetchTiming,
@@ -454,7 +455,7 @@ impl FetchResponseListener for PosterFrameFetchContext {
             self.id,
             FetchResponseMsg::ProcessResponseEOF(request_id, response.clone(), timing.clone()),
         );
-        network_listener::submit_timing(&self, &response, &timing, CanGc::note());
+        network_listener::submit_timing(&self, &response, &timing, CanGc::from_cx(cx));
     }
 
     fn process_csp_violations(&mut self, _request_id: RequestId, violations: Vec<Violation>) {

--- a/components/script/dom/navigator.rs
+++ b/components/script/dom/navigator.rs
@@ -630,11 +630,12 @@ impl FetchResponseListener for BeaconFetchListener {
 
     fn process_response_eof(
         self,
+        cx: &mut js::context::JSContext,
         _: RequestId,
         response: Result<(), NetworkError>,
         timing: ResourceFetchTiming,
     ) {
-        submit_timing(&self, &response, &timing, CanGc::note());
+        submit_timing(&self, &response, &timing, CanGc::from_cx(cx));
     }
 
     fn process_csp_violations(&mut self, _request_id: RequestId, violations: Vec<Violation>) {

--- a/components/script/dom/notification.rs
+++ b/components/script/dom/notification.rs
@@ -781,6 +781,7 @@ impl FetchResponseListener for ResourceFetchListener {
 
     fn process_response_eof(
         self,
+        cx: &mut js::context::JSContext,
         request_id: RequestId,
         response: Result<(), NetworkError>,
         timing: ResourceFetchTiming,
@@ -789,7 +790,7 @@ impl FetchResponseListener for ResourceFetchListener {
             self.pending_image_id,
             FetchResponseMsg::ProcessResponseEOF(request_id, response.clone(), timing.clone()),
         );
-        network_listener::submit_timing(&self, &response, &timing, CanGc::note());
+        network_listener::submit_timing(&self, &response, &timing, CanGc::from_cx(cx));
     }
 
     fn process_csp_violations(&mut self, _request_id: RequestId, violations: Vec<Violation>) {

--- a/components/script/dom/processingoptions.rs
+++ b/components/script/dom/processingoptions.rs
@@ -486,6 +486,7 @@ impl FetchResponseListener for LinkFetchContext {
     /// and step 3.1 of <https://html.spec.whatwg.org/multipage/#link-type-preload:fetch-and-process-the-linked-resource-2>
     fn process_response_eof(
         mut self,
+        cx: &mut js::context::JSContext,
         _: RequestId,
         response_result: Result<(), NetworkError>,
         timing: ResourceFetchTiming,
@@ -519,7 +520,7 @@ impl FetchResponseListener for LinkFetchContext {
             );
         }
 
-        submit_timing(&self, &response_result, &timing, CanGc::note());
+        submit_timing(&self, &response_result, &timing, CanGc::from_cx(cx));
 
         // Step 11.6. If processResponse is given, then call processResponse with response.
         //
@@ -530,7 +531,7 @@ impl FetchResponseListener for LinkFetchContext {
         // Part of Prefetch
         if let Some(link) = self.link.as_ref() {
             link.root()
-                .fire_event_after_response(response_result, CanGc::note());
+                .fire_event_after_response(response_result, CanGc::from_cx(cx));
         }
     }
 

--- a/components/script/dom/reportingendpoint.rs
+++ b/components/script/dom/reportingendpoint.rs
@@ -330,11 +330,12 @@ impl FetchResponseListener for CSPReportEndpointFetchListener {
 
     fn process_response_eof(
         self,
+        cx: &mut js::context::JSContext,
         _: RequestId,
         response: Result<(), NetworkError>,
         timing: ResourceFetchTiming,
     ) {
-        submit_timing(&self, &response, &timing, CanGc::note());
+        submit_timing(&self, &response, &timing, CanGc::from_cx(cx));
     }
 
     fn process_csp_violations(&mut self, _request_id: RequestId, _violations: Vec<Violation>) {}

--- a/components/script/dom/servoparser/mod.rs
+++ b/components/script/dom/servoparser/mod.rs
@@ -1405,6 +1405,7 @@ impl FetchResponseListener for ParserContext {
     // Resource listeners are called via net_traits::Action::process, which handles submission for them
     fn process_response_eof(
         mut self,
+        cx: &mut js::context::JSContext,
         _: RequestId,
         status: Result<(), NetworkError>,
         timing: ResourceFetchTiming,
@@ -1426,7 +1427,7 @@ impl FetchResponseListener for ParserContext {
         //
         // the end of the resource is reached.
         if !self.has_loaded_document {
-            self.load_document(CanGc::note());
+            self.load_document(CanGc::from_cx(cx));
         }
 
         let _realm = enter_realm(&*parser);
@@ -1437,7 +1438,7 @@ impl FetchResponseListener for ParserContext {
 
         parser.last_chunk_received.set(true);
         if !parser.suspended.get() {
-            parser.parse_sync(CanGc::note());
+            parser.parse_sync(CanGc::from_cx(cx));
         }
 
         // TODO: Only update if this is the current document resource.
@@ -1448,7 +1449,7 @@ impl FetchResponseListener for ParserContext {
                 &document.global(),
                 CrossProcessInstant::now(),
                 document,
-                CanGc::note(),
+                CanGc::from_cx(cx),
             );
             document
                 .global()

--- a/components/script/dom/workers/workerglobalscope.rs
+++ b/components/script/dom/workers/workerglobalscope.rs
@@ -158,13 +158,11 @@ impl FetchResponseListener for ScriptFetchContext {
 
     fn process_response_eof(
         mut self,
+        cx: &mut js::context::JSContext,
         _request_id: RequestId,
         response: Result<(), NetworkError>,
         timing: ResourceFetchTiming,
     ) {
-        #[expect(unsafe_code)]
-        let mut cx = unsafe { script_bindings::script_runtime::temp_cx() };
-        let cx = &mut cx;
         let scope = self.scope.root();
 
         if response

--- a/components/script/dom/xmlhttprequest.rs
+++ b/components/script/dom/xmlhttprequest.rs
@@ -126,16 +126,17 @@ impl FetchResponseListener for XHRContext {
 
     fn process_response_eof(
         self,
+        cx: &mut js::context::JSContext,
         _: RequestId,
         response: Result<(), NetworkError>,
         timing: ResourceFetchTiming,
     ) {
-        network_listener::submit_timing(&self, &response, &timing, CanGc::note());
+        network_listener::submit_timing(&self, &response, &timing, CanGc::from_cx(cx));
 
         let rv = self.xhr.root().process_response_complete(
             self.gen_id,
             response.map(|_| ()),
-            CanGc::note(),
+            CanGc::from_cx(cx),
         );
         *self.sync_status.borrow_mut() = Some(rv);
     }

--- a/components/script/fetch.rs
+++ b/components/script/fetch.rs
@@ -621,6 +621,7 @@ impl FetchResponseListener for FetchContext {
 
     fn process_response_eof(
         self,
+        cx: &mut js::context::JSContext,
         _: RequestId,
         response: Result<(), NetworkError>,
         timing: ResourceFetchTiming,
@@ -631,16 +632,16 @@ impl FetchResponseListener for FetchContext {
             if *error == NetworkError::DecompressionError {
                 response_object.error_stream(
                     Error::Type(c"Network error occurred".to_owned()),
-                    CanGc::note(),
+                    CanGc::from_cx(cx),
                 );
             }
         }
-        response_object.finish(CanGc::note());
+        response_object.finish(CanGc::from_cx(cx));
         // TODO
         // ... trailerObject is not supported in Servo yet.
 
         // navigation submission is handled in servoparser/mod.rs
-        network_listener::submit_timing(&self, &response, &timing, CanGc::note());
+        network_listener::submit_timing(&self, &response, &timing, CanGc::from_cx(cx));
     }
 
     fn process_csp_violations(&mut self, _request_id: RequestId, violations: Vec<Violation>) {
@@ -685,11 +686,12 @@ impl FetchResponseListener for FetchLaterListener {
 
     fn process_response_eof(
         self,
+        cx: &mut js::context::JSContext,
         _: RequestId,
         response: Result<(), NetworkError>,
         timing: ResourceFetchTiming,
     ) {
-        network_listener::submit_timing(&self, &response, &timing, CanGc::note());
+        network_listener::submit_timing(&self, &response, &timing, CanGc::from_cx(cx));
     }
 
     fn process_csp_violations(&mut self, _request_id: RequestId, violations: Vec<Violation>) {

--- a/components/script/layout_image.rs
+++ b/components/script/layout_image.rs
@@ -55,6 +55,7 @@ impl FetchResponseListener for LayoutImageContext {
 
     fn process_response_eof(
         self,
+        cx: &mut js::context::JSContext,
         request_id: RequestId,
         response: Result<(), NetworkError>,
         timing: ResourceFetchTiming,
@@ -63,7 +64,7 @@ impl FetchResponseListener for LayoutImageContext {
             self.id,
             FetchResponseMsg::ProcessResponseEOF(request_id, response.clone(), timing.clone()),
         );
-        network_listener::submit_timing(&self, &response, &timing, CanGc::note());
+        network_listener::submit_timing(&self, &response, &timing, CanGc::from_cx(cx));
     }
 
     fn process_csp_violations(&mut self, _request_id: RequestId, violations: Vec<Violation>) {

--- a/components/script/script_thread.rs
+++ b/components/script/script_thread.rs
@@ -85,7 +85,7 @@ use profile_traits::mem::{ProcessReports, ReportsChan, perform_memory_report};
 use profile_traits::time::ProfilerCategory;
 use profile_traits::time_profile;
 use rustc_hash::{FxHashMap, FxHashSet};
-use script_bindings::script_runtime::JSContext;
+use script_bindings::script_runtime::{JSContext, temp_cx};
 use script_traits::{
     ConstellationInputEvent, DiscardBrowsingContext, DocumentActivity, InitialScriptState,
     NewPipelineInfo, Painter, ProgressiveWebMetricType, ScriptThreadMessage,
@@ -2668,7 +2668,10 @@ impl ScriptThread {
         }
     }
 
+    #[expect(unsafe_code)]
     pub(crate) fn spawn_pipeline(&self, new_pipeline_info: NewPipelineInfo) {
+        let mut cx = unsafe { temp_cx() };
+        let cx = &mut cx;
         self.profile_event(
             ScriptThreadEventCategory::SpawnPipeline,
             Some(new_pipeline_info.new_pipeline_id),
@@ -2697,7 +2700,7 @@ impl ScriptThread {
                 };
 
                 // Kick off the fetch for the new resource.
-                self.pre_page_load(InProgressLoad::new(new_pipeline_info, origin));
+                self.pre_page_load(cx, InProgressLoad::new(new_pipeline_info, origin));
             },
         );
     }

--- a/components/script/script_thread.rs
+++ b/components/script/script_thread.rs
@@ -2076,7 +2076,7 @@ impl ScriptThread {
                 pipeline_id,
                 message,
             } => {
-                self.handle_navigation_response(pipeline_id, *message);
+                self.handle_navigation_response(cx, pipeline_id, *message);
             },
             MainThreadScriptMsg::WorkletLoaded(pipeline_id) => {
                 self.handle_worklet_loaded(pipeline_id)
@@ -3720,14 +3720,14 @@ impl ScriptThread {
 
     /// Instructs the constellation to fetch the document that will be loaded. Stores the InProgressLoad
     /// argument until a notification is received that the fetch is complete.
-    fn pre_page_load(&self, mut incomplete: InProgressLoad) {
+    fn pre_page_load(&self, cx: &mut js::context::JSContext, mut incomplete: InProgressLoad) {
         let url_str = incomplete.load_data.url.as_str();
         if url_str == "about:blank" {
-            self.start_page_load_about_blank(incomplete);
+            self.start_page_load_about_blank(cx, incomplete);
             return;
         }
         if url_str == "about:srcdoc" {
-            self.page_load_about_srcdoc(incomplete);
+            self.page_load_about_srcdoc(cx, incomplete);
             return;
         }
 
@@ -3753,7 +3753,12 @@ impl ScriptThread {
         self.incomplete_loads.borrow_mut().push(incomplete);
     }
 
-    fn handle_navigation_response(&self, pipeline_id: PipelineId, message: FetchResponseMsg) {
+    fn handle_navigation_response(
+        &self,
+        cx: &mut js::context::JSContext,
+        pipeline_id: PipelineId,
+        message: FetchResponseMsg,
+    ) {
         if let Some(metadata) = NavigationListener::http_redirect_metadata(&message) {
             self.handle_navigation_redirect(pipeline_id, metadata);
             return;
@@ -3767,7 +3772,7 @@ impl ScriptThread {
                 self.handle_fetch_chunk(pipeline_id, request_id, chunk.0)
             },
             FetchResponseMsg::ProcessResponseEOF(request_id, eof, timing) => {
-                self.handle_fetch_eof(pipeline_id, request_id, eof, timing)
+                self.handle_fetch_eof(cx, pipeline_id, request_id, eof, timing)
             },
             FetchResponseMsg::ProcessCspViolations(request_id, violations) => {
                 self.handle_csp_violations(pipeline_id, request_id, violations)
@@ -3812,6 +3817,7 @@ impl ScriptThread {
 
     fn handle_fetch_eof(
         &self,
+        cx: &mut js::context::JSContext,
         id: PipelineId,
         request_id: RequestId,
         eof: Result<(), NetworkError>,
@@ -3842,11 +3848,11 @@ impl ScriptThread {
                     // submit_timing will only accept timing that is of type ResourceTimingType::Resource
                     let mut resource_timing = timing.clone();
                     resource_timing.timing_type = ResourceTimingType::Resource;
-                    submit_timing(&iframe_ctx, &eof, &resource_timing, CanGc::note());
+                    submit_timing(&iframe_ctx, &eof, &resource_timing, CanGc::from_cx(cx));
                 }
             }
 
-            context.process_response_eof(request_id, eof, timing);
+            context.process_response_eof(cx, request_id, eof, timing);
         }
     }
 
@@ -3912,7 +3918,11 @@ impl ScriptThread {
 
     /// Synchronously fetch `about:blank`. Stores the `InProgressLoad`
     /// argument until a notification is received that the fetch is complete.
-    fn start_page_load_about_blank(&self, mut incomplete: InProgressLoad) {
+    fn start_page_load_about_blank(
+        &self,
+        cx: &mut js::context::JSContext,
+        mut incomplete: InProgressLoad,
+    ) {
         let url = ServoUrl::parse("about:blank").unwrap();
         let mut context = ParserContext::new(
             incomplete.webview_id,
@@ -3946,6 +3956,7 @@ impl ScriptThread {
         context.set_about_base_url(about_base_url);
         context.process_response_chunk(dummy_request_id, chunk);
         context.process_response_eof(
+            cx,
             dummy_request_id,
             Ok(()),
             ResourceFetchTiming::new(ResourceTimingType::None),
@@ -3953,7 +3964,11 @@ impl ScriptThread {
     }
 
     /// Synchronously parse a srcdoc document from a giving HTML string.
-    fn page_load_about_srcdoc(&self, mut incomplete: InProgressLoad) {
+    fn page_load_about_srcdoc(
+        &self,
+        cx: &mut js::context::JSContext,
+        mut incomplete: InProgressLoad,
+    ) {
         let url = ServoUrl::parse("about:srcdoc").unwrap();
         let mut meta = Metadata::default(url.clone());
         meta.set_content_type(Some(&mime::TEXT_HTML));
@@ -3979,6 +3994,7 @@ impl ScriptThread {
         context.set_about_base_url(about_base_url);
         context.process_response_chunk(dummy_request_id, chunk);
         context.process_response_eof(
+            cx,
             dummy_request_id,
             Ok(()),
             ResourceFetchTiming::new(ResourceTimingType::None),

--- a/components/script/security_manager.rs
+++ b/components/script/security_manager.rs
@@ -199,11 +199,12 @@ impl FetchResponseListener for CSPReportUriFetchListener {
 
     fn process_response_eof(
         self,
+        cx: &mut js::context::JSContext,
         _: RequestId,
         response: Result<(), NetworkError>,
         timing: ResourceFetchTiming,
     ) {
-        submit_timing(&self, &response, &timing, CanGc::note())
+        submit_timing(&self, &response, &timing, CanGc::from_cx(cx))
     }
 
     fn process_csp_violations(&mut self, _request_id: RequestId, _violations: Vec<Violation>) {}

--- a/components/script/stylesheet_loader.rs
+++ b/components/script/stylesheet_loader.rs
@@ -349,11 +349,12 @@ impl FetchResponseListener for StylesheetContext {
 
     fn process_response_eof(
         mut self,
+        cx: &mut js::context::JSContext,
         _: RequestId,
         status: Result<(), NetworkError>,
         timing: ResourceFetchTiming,
     ) {
-        network_listener::submit_timing(&self, &status, &timing, CanGc::note());
+        network_listener::submit_timing(&self, &status, &timing, CanGc::from_cx(cx));
 
         let document = self.document.root();
         let Some(metadata) = self.metadata.as_ref() else {


### PR DESCRIPTION
`process_response_eof` is the only method that needs cx at least right now. This PR removes one temp_cx and introduces one, removing that one will is hard (needs VirtualMethods and a lot of work)

Testing: Just refactor
Part of #40600