### PR TITLE
script: Implement queryCommandSupported

### DIFF
--- a/components/script/dom/document.rs
+++ b/components/script/dom/document.rs
@@ -5113,11 +5113,6 @@ impl DocumentMethods<crate::DomTypeHolder> for Document {
         Ok(document)
     }
 
-    /// <https://w3c.github.io/editing/ActiveDocuments/execCommand.html#querycommandsupported()>
-    fn QueryCommandSupported(&self, _command: DOMString) -> bool {
-        false
-    }
-
     /// <https://drafts.csswg.org/cssom/#dom-document-stylesheets>
     fn StyleSheets(&self, can_gc: CanGc) -> DomRoot<StyleSheetList> {
         self.stylesheet_list.or_init(|| {
@@ -6473,7 +6468,16 @@ impl DocumentMethods<crate::DomTypeHolder> for Document {
 
     /// <https://w3c.github.io/editing/docs/execCommand/#querycommandenabled()>
     fn QueryCommandEnabled(&self, command_id: DOMString, can_gc: CanGc) -> bool {
+        // Step 2. Return true if command is both supported and enabled, false otherwise.
         self.check_support_and_enabled(command_id, can_gc).is_some()
+    }
+
+    /// <https://w3c.github.io/editing/ActiveDocuments/execCommand.html#querycommandsupported()>
+    fn QueryCommandSupported(&self, command_id: DOMString) -> bool {
+        // > When the queryCommandSupported(command) method on the Document interface is invoked,
+        // the user agent must return true if command is supported and available
+        // within the current script on the current site, and false otherwise.
+        self.is_command_supported(command_id)
     }
 
     // https://fullscreen.spec.whatwg.org/#handler-document-onfullscreenerror

--- a/components/script/dom/execcommand/execcommands.rs
+++ b/components/script/dom/execcommand/execcommands.rs
@@ -50,6 +50,7 @@ impl Document {
 }
 
 pub(crate) trait ExecCommandsSupport {
+    fn is_command_supported(&self, command_id: DOMString) -> bool;
     fn check_support_and_enabled(
         &self,
         command_id: DOMString,
@@ -64,6 +65,11 @@ pub(crate) trait ExecCommandsSupport {
 }
 
 impl ExecCommandsSupport for Document {
+    /// <https://w3c.github.io/editing/docs/execCommand/#querycommandsupported()>
+    fn is_command_supported(&self, command_id: DOMString) -> bool {
+        self.command_if_command_is_supported(command_id).is_some()
+    }
+
     /// <https://w3c.github.io/editing/docs/execCommand/#querycommandenabled()>
     fn check_support_and_enabled(
         &self,

--- a/components/script_bindings/webidls/Document.webidl
+++ b/components/script_bindings/webidls/Document.webidl
@@ -146,12 +146,12 @@ partial /*sealed*/ interface Document {
   boolean hasFocus();
   // [CEReactions]
   // attribute DOMString designMode;
-  // [CEReactions]
-  // boolean execCommand(DOMString commandId, optional boolean showUI = false, optional DOMString value = "");
-  // boolean queryCommandEnabled(DOMString commandId);
+  [CEReactions, Throws, Pref="dom_exec_command_enabled"]
+  boolean execCommand(DOMString commandId, optional boolean showUI = false, optional (TrustedHTML or DOMString) value = "");
+  [Pref="dom_exec_command_enabled"] boolean queryCommandEnabled(DOMString commandId);
   // boolean queryCommandIndeterm(DOMString commandId);
   // boolean queryCommandState(DOMString commandId);
-  boolean queryCommandSupported(DOMString commandId);
+  [Pref="dom_exec_command_enabled"] boolean queryCommandSupported(DOMString commandId);
   // DOMString queryCommandValue(DOMString commandId);
   readonly attribute boolean hidden;
   readonly attribute DocumentVisibilityState visibilityState;
@@ -234,9 +234,3 @@ partial interface Document {
 
 // https://html.spec.whatwg.org/multipage/#dom-document-nameditem-filter
 typedef (WindowProxy or Element or HTMLCollection) NamedPropertyValue;
-
-// https://w3c.github.io/editing/docs/execCommand/#methods-to-query-and-execute-commands
-partial interface Document {
-  [CEReactions, Throws, Pref="dom_exec_command_enabled"] boolean execCommand(DOMString commandId, optional boolean showUI = false, optional (TrustedHTML or DOMString) value = "");
-  [CEReactions, Pref="dom_exec_command_enabled"] boolean queryCommandEnabled(DOMString commandId);
-};

--- a/tests/wpt/meta/editing/other/exec-command-with-text-editor.tentative.html.ini
+++ b/tests/wpt/meta/editing/other/exec-command-with-text-editor.tentative.html.ini
@@ -38,13 +38,7 @@
   [In <input type="password">, execCommand("paste", false, null), a[\]c): The command should be enabled]
     expected: FAIL
 
-  [In <input type="password">, execCommand("delete", false, null), ab[\]c): The command should be supported]
-    expected: FAIL
-
   [In <input type="password">, execCommand("delete", false, null), ab[\]c): The command should be enabled]
-    expected: FAIL
-
-  [In <input type="password">, execCommand("delete", false, null), a[b\]c): The command should be supported]
     expected: FAIL
 
   [In <input type="password">, execCommand("delete", false, null), a[b\]c): The command should be enabled]
@@ -218,13 +212,7 @@
   [In <input type="password"> in contenteditable, execCommand("paste", false, null), a[\]c): The command should be enabled]
     expected: FAIL
 
-  [In <input type="password"> in contenteditable, execCommand("delete", false, null), ab[\]c): The command should be supported]
-    expected: FAIL
-
   [In <input type="password"> in contenteditable, execCommand("delete", false, null), ab[\]c): The command should be enabled]
-    expected: FAIL
-
-  [In <input type="password"> in contenteditable, execCommand("delete", false, null), a[b\]c): The command should be supported]
     expected: FAIL
 
   [In <input type="password"> in contenteditable, execCommand("delete", false, null), a[b\]c): The command should be enabled]
@@ -383,6 +371,54 @@
   [In <input type="password"> in contenteditable, execCommand("defaultParagraphSeparator", false, div), a[b\]c): The command should be enabled]
     expected: FAIL
 
+  [In <input type="password">, execCommand("delete", false, null), ab[\]c): execCommand() should return true]
+    expected: FAIL
+
+  [In <input type="password">, execCommand("delete", false, null), ab[\]c): <input>.value should be "a[\]c"]
+    expected: FAIL
+
+  [In <input type="password">, execCommand("delete", false, null), ab[\]c): input.inputType should be deleteContentBackward]
+    expected: FAIL
+
+  [In <input type="password">, execCommand("delete", false, null), ab[\]c): input.target should be [object HTMLInputElement\]]
+    expected: FAIL
+
+  [In <input type="password">, execCommand("delete", false, null), a[b\]c): execCommand() should return true]
+    expected: FAIL
+
+  [In <input type="password">, execCommand("delete", false, null), a[b\]c): <input>.value should be "a[\]c"]
+    expected: FAIL
+
+  [In <input type="password">, execCommand("delete", false, null), a[b\]c): input.inputType should be deleteContentBackward]
+    expected: FAIL
+
+  [In <input type="password">, execCommand("delete", false, null), a[b\]c): input.target should be [object HTMLInputElement\]]
+    expected: FAIL
+
+  [In <input type="password"> in contenteditable, execCommand("delete", false, null), ab[\]c): execCommand() should return true]
+    expected: FAIL
+
+  [In <input type="password"> in contenteditable, execCommand("delete", false, null), ab[\]c): <input>.value should be "a[\]c"]
+    expected: FAIL
+
+  [In <input type="password"> in contenteditable, execCommand("delete", false, null), ab[\]c): input.inputType should be deleteContentBackward]
+    expected: FAIL
+
+  [In <input type="password"> in contenteditable, execCommand("delete", false, null), ab[\]c): input.target should be [object HTMLInputElement\]]
+    expected: FAIL
+
+  [In <input type="password"> in contenteditable, execCommand("delete", false, null), a[b\]c): execCommand() should return true]
+    expected: FAIL
+
+  [In <input type="password"> in contenteditable, execCommand("delete", false, null), a[b\]c): <input>.value should be "a[\]c"]
+    expected: FAIL
+
+  [In <input type="password"> in contenteditable, execCommand("delete", false, null), a[b\]c): input.inputType should be deleteContentBackward]
+    expected: FAIL
+
+  [In <input type="password"> in contenteditable, execCommand("delete", false, null), a[b\]c): input.target should be [object HTMLInputElement\]]
+    expected: FAIL
+
 
 [exec-command-with-text-editor.tentative.html?type=text]
   [In <input type="text">, execCommand("bold", false, bold), a[b\]c): The command should be supported]
@@ -424,13 +460,7 @@
   [In <input type="text">, execCommand("paste", false, null), a[\]c): The command should be enabled]
     expected: FAIL
 
-  [In <input type="text">, execCommand("delete", false, null), ab[\]c): The command should be supported]
-    expected: FAIL
-
   [In <input type="text">, execCommand("delete", false, null), ab[\]c): The command should be enabled]
-    expected: FAIL
-
-  [In <input type="text">, execCommand("delete", false, null), a[b\]c): The command should be supported]
     expected: FAIL
 
   [In <input type="text">, execCommand("delete", false, null), a[b\]c): The command should be enabled]
@@ -604,13 +634,7 @@
   [In <input type="text"> in contenteditable, execCommand("paste", false, null), a[\]c): The command should be enabled]
     expected: FAIL
 
-  [In <input type="text"> in contenteditable, execCommand("delete", false, null), ab[\]c): The command should be supported]
-    expected: FAIL
-
   [In <input type="text"> in contenteditable, execCommand("delete", false, null), ab[\]c): The command should be enabled]
-    expected: FAIL
-
-  [In <input type="text"> in contenteditable, execCommand("delete", false, null), a[b\]c): The command should be supported]
     expected: FAIL
 
   [In <input type="text"> in contenteditable, execCommand("delete", false, null), a[b\]c): The command should be enabled]
@@ -769,6 +793,54 @@
   [In <input type="text"> in contenteditable, execCommand("defaultParagraphSeparator", false, div), a[b\]c): The command should be enabled]
     expected: FAIL
 
+  [In <input type="text">, execCommand("delete", false, null), ab[\]c): execCommand() should return true]
+    expected: FAIL
+
+  [In <input type="text">, execCommand("delete", false, null), ab[\]c): <input>.value should be "a[\]c"]
+    expected: FAIL
+
+  [In <input type="text">, execCommand("delete", false, null), ab[\]c): input.inputType should be deleteContentBackward]
+    expected: FAIL
+
+  [In <input type="text">, execCommand("delete", false, null), ab[\]c): input.target should be [object HTMLInputElement\]]
+    expected: FAIL
+
+  [In <input type="text">, execCommand("delete", false, null), a[b\]c): execCommand() should return true]
+    expected: FAIL
+
+  [In <input type="text">, execCommand("delete", false, null), a[b\]c): <input>.value should be "a[\]c"]
+    expected: FAIL
+
+  [In <input type="text">, execCommand("delete", false, null), a[b\]c): input.inputType should be deleteContentBackward]
+    expected: FAIL
+
+  [In <input type="text">, execCommand("delete", false, null), a[b\]c): input.target should be [object HTMLInputElement\]]
+    expected: FAIL
+
+  [In <input type="text"> in contenteditable, execCommand("delete", false, null), ab[\]c): execCommand() should return true]
+    expected: FAIL
+
+  [In <input type="text"> in contenteditable, execCommand("delete", false, null), ab[\]c): <input>.value should be "a[\]c"]
+    expected: FAIL
+
+  [In <input type="text"> in contenteditable, execCommand("delete", false, null), ab[\]c): input.inputType should be deleteContentBackward]
+    expected: FAIL
+
+  [In <input type="text"> in contenteditable, execCommand("delete", false, null), ab[\]c): input.target should be [object HTMLInputElement\]]
+    expected: FAIL
+
+  [In <input type="text"> in contenteditable, execCommand("delete", false, null), a[b\]c): execCommand() should return true]
+    expected: FAIL
+
+  [In <input type="text"> in contenteditable, execCommand("delete", false, null), a[b\]c): <input>.value should be "a[\]c"]
+    expected: FAIL
+
+  [In <input type="text"> in contenteditable, execCommand("delete", false, null), a[b\]c): input.inputType should be deleteContentBackward]
+    expected: FAIL
+
+  [In <input type="text"> in contenteditable, execCommand("delete", false, null), a[b\]c): input.target should be [object HTMLInputElement\]]
+    expected: FAIL
+
 
 [exec-command-with-text-editor.tentative.html?type=textarea]
   [In <textarea>, execCommand("bold", false, bold), a[b\]c): The command should be supported]
@@ -810,13 +882,7 @@
   [In <textarea>, execCommand("paste", false, null), a[\]c): The command should be enabled]
     expected: FAIL
 
-  [In <textarea>, execCommand("delete", false, null), ab[\]c): The command should be supported]
-    expected: FAIL
-
   [In <textarea>, execCommand("delete", false, null), ab[\]c): The command should be enabled]
-    expected: FAIL
-
-  [In <textarea>, execCommand("delete", false, null), a[b\]c): The command should be supported]
     expected: FAIL
 
   [In <textarea>, execCommand("delete", false, null), a[b\]c): The command should be enabled]
@@ -996,13 +1062,7 @@
   [In <textarea> in contenteditable, execCommand("paste", false, null), a[\]c): The command should be enabled]
     expected: FAIL
 
-  [In <textarea> in contenteditable, execCommand("delete", false, null), ab[\]c): The command should be supported]
-    expected: FAIL
-
   [In <textarea> in contenteditable, execCommand("delete", false, null), ab[\]c): The command should be enabled]
-    expected: FAIL
-
-  [In <textarea> in contenteditable, execCommand("delete", false, null), a[b\]c): The command should be supported]
     expected: FAIL
 
   [In <textarea> in contenteditable, execCommand("delete", false, null), a[b\]c): The command should be enabled]
@@ -1165,4 +1225,52 @@
     expected: FAIL
 
   [In <textarea> in contenteditable, execCommand("defaultParagraphSeparator", false, div), a[b\]c): The command should be enabled]
+    expected: FAIL
+
+  [In <textarea>, execCommand("delete", false, null), ab[\]c): execCommand() should return true]
+    expected: FAIL
+
+  [In <textarea>, execCommand("delete", false, null), ab[\]c): <textarea>.value should be "a[\]c"]
+    expected: FAIL
+
+  [In <textarea>, execCommand("delete", false, null), ab[\]c): input.inputType should be deleteContentBackward]
+    expected: FAIL
+
+  [In <textarea>, execCommand("delete", false, null), ab[\]c): input.target should be [object HTMLTextAreaElement\]]
+    expected: FAIL
+
+  [In <textarea>, execCommand("delete", false, null), a[b\]c): execCommand() should return true]
+    expected: FAIL
+
+  [In <textarea>, execCommand("delete", false, null), a[b\]c): <textarea>.value should be "a[\]c"]
+    expected: FAIL
+
+  [In <textarea>, execCommand("delete", false, null), a[b\]c): input.inputType should be deleteContentBackward]
+    expected: FAIL
+
+  [In <textarea>, execCommand("delete", false, null), a[b\]c): input.target should be [object HTMLTextAreaElement\]]
+    expected: FAIL
+
+  [In <textarea> in contenteditable, execCommand("delete", false, null), ab[\]c): execCommand() should return true]
+    expected: FAIL
+
+  [In <textarea> in contenteditable, execCommand("delete", false, null), ab[\]c): <textarea>.value should be "a[\]c"]
+    expected: FAIL
+
+  [In <textarea> in contenteditable, execCommand("delete", false, null), ab[\]c): input.inputType should be deleteContentBackward]
+    expected: FAIL
+
+  [In <textarea> in contenteditable, execCommand("delete", false, null), ab[\]c): input.target should be [object HTMLTextAreaElement\]]
+    expected: FAIL
+
+  [In <textarea> in contenteditable, execCommand("delete", false, null), a[b\]c): execCommand() should return true]
+    expected: FAIL
+
+  [In <textarea> in contenteditable, execCommand("delete", false, null), a[b\]c): <textarea>.value should be "a[\]c"]
+    expected: FAIL
+
+  [In <textarea> in contenteditable, execCommand("delete", false, null), a[b\]c): input.inputType should be deleteContentBackward]
+    expected: FAIL
+
+  [In <textarea> in contenteditable, execCommand("delete", false, null), a[b\]c): input.target should be [object HTMLTextAreaElement\]]
     expected: FAIL

--- a/tests/wpt/meta/editing/other/exec-command-without-editable-element.tentative.html.ini
+++ b/tests/wpt/meta/editing/other/exec-command-without-editable-element.tentative.html.ini
@@ -1,2 +1,0 @@
-[exec-command-without-editable-element.tentative.html]
-  expected: ERROR

--- a/tests/wpt/meta/html/editing/editing-0/making-entire-documents-editable-the-designmode-idl-attribute/user-interaction-editing-designMode.html.ini
+++ b/tests/wpt/meta/html/editing/editing-0/making-entire-documents-editable-the-designmode-idl-attribute/user-interaction-editing-designMode.html.ini
@@ -4,6 +4,3 @@
 
   [set designMode = "on"]
     expected: FAIL
-
-  [set designMode = "off"]
-    expected: FAIL


### PR DESCRIPTION
This method was already present on the document, but
wasn't implemented yet. Note that now more tests are
failing, since before they weren't running. The tests
check if a command is enabled before they started
running.

The selection API doesn't yet take into account
contenteditable containers, which is why these
tests don't consider a command enabled, since the
range of the selection is empty.

Part of #25005