### PR TITLE
script:  Rectify `update_active_touch_points_when_early_return`

### DIFF
--- a/components/config/prefs.rs
+++ b/components/config/prefs.rs
@@ -87,7 +87,7 @@ pub struct Preferences {
     pub css_animations_testing_enabled: bool,
     /// Start the devtools server at startup
     pub devtools_server_enabled: bool,
-    /// The address +port the devtools server listens to, default to 127.0.0.1:7000.
+    /// The address:port the devtools server listens to, default to 127.0.0.1:7000.
     pub devtools_server_listen_address: String,
     // feature: WebGPU | #24706 | Web/API/WebGPU_API
     pub dom_webgpu_enabled: bool,

--- a/components/paint/touch.rs
+++ b/components/paint/touch.rs
@@ -532,7 +532,7 @@ impl TouchHandler {
         {
             Some(i) => Some(touch_sequence.active_touch_points.swap_remove(i).point),
             None => {
-                warn!("Got a touch up event for a non-active touch point");
+                warn!("Got a touchup event for a non-active touch point");
                 None
             },
         };


### PR DESCRIPTION
- Use `FxHashMap` for `active_pointer_ids`
- Refactor and fix logging message for touch, especially `update_active_touch_points_when_early_return`
- Randomly fix some typos

Testing: This changes logging message but no other observable behaviours. The logging should be more accurate, but I didn't test.