### PR TITLE
script: Use `reflect_dom_object_with_cx` in `CryptoKey::new`

### DIFF
--- a/components/script/dom/subtlecrypto.rs
+++ b/components/script/dom/subtlecrypto.rs
@@ -1243,7 +1243,7 @@ impl SubtleCryptoMethods<crate::DomTypeHolder> for SubtleCrypto {
                 result.set_extractable(extractable);
 
                 // Step 12. Set the [[usages]] internal slot of result to the normalized value of usages.
-                result.set_usages(&key_usages);
+                result.set_usages(cx, &key_usages);
 
                 // Step 13. Queue a global task on the crypto task source, given realm's global
                 // object, to perform the remaining steps.

--- a/components/script/dom/subtlecrypto/aes_common.rs
+++ b/components/script/dom/subtlecrypto/aes_common.rs
@@ -21,7 +21,6 @@ use crate::dom::subtlecrypto::{
     JwkStringField, KeyAlgorithmAndDerivatives, SubtleAesDerivedKeyParams, SubtleAesKeyAlgorithm,
     SubtleAesKeyGenParams,
 };
-use crate::script_runtime::CanGc;
 
 #[expect(clippy::enum_variant_names)]
 pub(crate) enum AesAlgorithm {
@@ -145,13 +144,13 @@ pub(crate) fn generate_key(
         length: normalized_algorithm.length,
     };
     let key = CryptoKey::new(
+        cx,
         global,
         KeyType::Secret,
         extractable,
         KeyAlgorithmAndDerivatives::AesKeyAlgorithm(algorithm),
         usages,
         handle,
-        CanGc::from_cx(cx),
     );
 
     // Step 13. Return key.
@@ -499,13 +498,13 @@ pub(crate) fn import_key(
         length: data.len() as u16 * 8,
     };
     let key = CryptoKey::new(
+        cx,
         global,
         KeyType::Secret,
         extractable,
         KeyAlgorithmAndDerivatives::AesKeyAlgorithm(algorithm),
         usages,
         handle,
-        CanGc::from_cx(cx),
     );
 
     // Step 9. Return key.

--- a/components/script/dom/subtlecrypto/argon2_operation.rs
+++ b/components/script/dom/subtlecrypto/argon2_operation.rs
@@ -15,7 +15,6 @@ use crate::dom::subtlecrypto::{
     ALG_ARGON2D, ALG_ARGON2I, ALG_ARGON2ID, KeyAlgorithmAndDerivatives, SubtleAlgorithm,
     SubtleArgon2Params, SubtleKeyAlgorithm,
 };
-use crate::script_runtime::CanGc;
 
 /// <https://wicg.github.io/webcrypto-modern-algos/#argon2-operations-derive-bits>
 pub(crate) fn derive_bits(
@@ -172,13 +171,13 @@ pub(crate) fn import_key(
         name: normalized_algorithm.name.clone(),
     };
     let key = CryptoKey::new(
+        cx,
         global,
         KeyType::Secret,
         extractable,
         KeyAlgorithmAndDerivatives::KeyAlgorithm(algorithm),
         usages,
         Handle::Argon2Password(key_data.to_vec()),
-        CanGc::from_cx(cx),
     );
 
     // Step 10. Return key.

--- a/components/script/dom/subtlecrypto/chacha20_poly1305_operation.rs
+++ b/components/script/dom/subtlecrypto/chacha20_poly1305_operation.rs
@@ -19,7 +19,6 @@ use crate::dom::subtlecrypto::{
     ALG_CHACHA20_POLY1305, ExportedKey, JsonWebKeyExt, JwkStringField, KeyAlgorithmAndDerivatives,
     SubtleAeadParams, SubtleKeyAlgorithm,
 };
-use crate::script_runtime::CanGc;
 
 /// <https://wicg.github.io/webcrypto-modern-algos/#chacha20-poly1305-operations-encrypt>
 pub(crate) fn encrypt(
@@ -184,13 +183,13 @@ pub(crate) fn generate_key(
         name: ALG_CHACHA20_POLY1305.to_string(),
     };
     let key = CryptoKey::new(
+        cx,
         global,
         KeyType::Secret,
         extractable,
         KeyAlgorithmAndDerivatives::KeyAlgorithm(algorithm),
         usages,
         Handle::ChaCha20Poly1305Key(generated_key),
-        CanGc::from_cx(cx),
     );
 
     // Step 11. Return key.
@@ -312,13 +311,13 @@ pub(crate) fn import_key(
         name: ALG_CHACHA20_POLY1305.to_string(),
     };
     let key = CryptoKey::new(
+        cx,
         global,
         KeyType::Secret,
         extractable,
         KeyAlgorithmAndDerivatives::KeyAlgorithm(algorithm),
         usages,
         handle,
-        CanGc::from_cx(cx),
     );
 
     // Step 9. Return key.

--- a/components/script/dom/subtlecrypto/ecdh_operation.rs
+++ b/components/script/dom/subtlecrypto/ecdh_operation.rs
@@ -29,7 +29,6 @@ use crate::dom::subtlecrypto::{
     NAMED_CURVE_P256, NAMED_CURVE_P384, NAMED_CURVE_P521, SUPPORTED_CURVES, SubtleEcKeyAlgorithm,
     SubtleEcKeyGenParams, SubtleEcKeyImportParams, SubtleEcdhKeyDeriveParams,
 };
-use crate::script_runtime::CanGc;
 
 /// <https://w3c.github.io/webcrypto/#ecdh-operations-generate-key>
 pub(crate) fn generate_key(
@@ -109,13 +108,13 @@ pub(crate) fn generate_key(
     // Step 10. Set the [[extractable]] internal slot of publicKey to true.
     // Step 11. Set the [[usages]] internal slot of publicKey to be the empty list.
     let public_key = CryptoKey::new(
+        cx,
         global,
         KeyType::Public,
         true,
         KeyAlgorithmAndDerivatives::EcKeyAlgorithm(algorithm.clone()),
         Vec::new(),
         public_key_handle,
-        CanGc::from_cx(cx),
     );
 
     // Step 12. Let privateKey be a new CryptoKey representing the private key of the generated key pair.
@@ -125,6 +124,7 @@ pub(crate) fn generate_key(
     // Step 16. Set the [[usages]] internal slot of privateKey to be the usage intersection of
     // usages and [ "deriveKey", "deriveBits" ].
     let private_key = CryptoKey::new(
+        cx,
         global,
         KeyType::Private,
         extractable,
@@ -135,7 +135,6 @@ pub(crate) fn generate_key(
             .cloned()
             .collect(),
         private_key_handle,
-        CanGc::from_cx(cx),
     );
 
     // Step 17. Let result be a new CryptoKeyPair dictionary.
@@ -451,13 +450,13 @@ pub(crate) fn import_key(
                     .to_string(),
             };
             CryptoKey::new(
+                cx,
                 global,
                 KeyType::Public,
                 extractable,
                 KeyAlgorithmAndDerivatives::EcKeyAlgorithm(algorithm),
                 usages,
                 handle,
-                CanGc::from_cx(cx),
             )
         },
         KeyFormat::Pkcs8 => {
@@ -619,13 +618,13 @@ pub(crate) fn import_key(
                     .to_string(),
             };
             CryptoKey::new(
+                cx,
                 global,
                 KeyType::Private,
                 extractable,
                 KeyAlgorithmAndDerivatives::EcKeyAlgorithm(algorithm),
                 usages,
                 handle,
-                CanGc::from_cx(cx),
             )
         },
         KeyFormat::Jwk => {
@@ -875,13 +874,13 @@ pub(crate) fn import_key(
                 named_curve,
             };
             CryptoKey::new(
+                cx,
                 global,
                 key_type,
                 extractable,
                 KeyAlgorithmAndDerivatives::EcKeyAlgorithm(algorithm),
                 usages,
                 handle,
-                CanGc::from_cx(cx),
             )
         },
         KeyFormat::Raw | KeyFormat::Raw_public => {
@@ -962,13 +961,13 @@ pub(crate) fn import_key(
             // Step 2.7. Set the [[type]] internal slot of key to "public"
             // Step 2.8. Set the [[algorithm]] internal slot of key to algorithm.
             CryptoKey::new(
+                cx,
                 global,
                 KeyType::Public,
                 extractable,
                 KeyAlgorithmAndDerivatives::EcKeyAlgorithm(algorithm),
                 usages,
                 handle,
-                CanGc::from_cx(cx),
             )
         },
         // Otherwise:

--- a/components/script/dom/subtlecrypto/ecdsa_operation.rs
+++ b/components/script/dom/subtlecrypto/ecdsa_operation.rs
@@ -35,7 +35,6 @@ use crate::dom::subtlecrypto::{
     NAMED_CURVE_P521, SUPPORTED_CURVES, SubtleEcKeyAlgorithm, SubtleEcKeyGenParams,
     SubtleEcKeyImportParams, SubtleEcdsaParams,
 };
-use crate::script_runtime::CanGc;
 
 const P256_PREHASH_LENGTH: usize = 32;
 const P384_PREHASH_LENGTH: usize = 48;
@@ -322,6 +321,7 @@ pub(crate) fn generate_key(
     // Step 11. Set the [[usages]] internal slot of publicKey to be the usage intersection of
     // usages and [ "verify" ].
     let public_key = CryptoKey::new(
+        cx,
         global,
         KeyType::Public,
         true,
@@ -332,7 +332,6 @@ pub(crate) fn generate_key(
             .cloned()
             .collect(),
         public_key_handle,
-        CanGc::from_cx(cx),
     );
 
     // Step 12. Let privateKey be a new CryptoKey representing the private key of the generated key pair.
@@ -342,6 +341,7 @@ pub(crate) fn generate_key(
     // Step 16. Set the [[usages]] internal slot of privateKey to be the usage intersection of
     // usages and [ "sign" ].
     let private_key = CryptoKey::new(
+        cx,
         global,
         KeyType::Private,
         extractable,
@@ -352,7 +352,6 @@ pub(crate) fn generate_key(
             .cloned()
             .collect(),
         private_key_handle,
-        CanGc::from_cx(cx),
     );
 
     // Step 17. Let result be a new CryptoKeyPair dictionary.
@@ -497,13 +496,13 @@ pub(crate) fn import_key(
                     .to_string(),
             };
             CryptoKey::new(
+                cx,
                 global,
                 KeyType::Public,
                 extractable,
                 KeyAlgorithmAndDerivatives::EcKeyAlgorithm(algorithm),
                 usages,
                 handle,
-                CanGc::from_cx(cx),
             )
         },
         // If format is "pkcs8":
@@ -635,13 +634,13 @@ pub(crate) fn import_key(
                     .to_string(),
             };
             CryptoKey::new(
+                cx,
                 global,
                 KeyType::Private,
                 extractable,
                 KeyAlgorithmAndDerivatives::EcKeyAlgorithm(algorithm),
                 usages,
                 handle,
-                CanGc::from_cx(cx),
             )
         },
         // If format is "jwk":
@@ -868,13 +867,13 @@ pub(crate) fn import_key(
                 named_curve,
             };
             CryptoKey::new(
+                cx,
                 global,
                 key_type,
                 extractable,
                 KeyAlgorithmAndDerivatives::EcKeyAlgorithm(algorithm),
                 usages,
                 handle,
-                CanGc::from_cx(cx),
             )
         },
         // If format is "raw":
@@ -951,13 +950,13 @@ pub(crate) fn import_key(
             // Step 2.7. Set the [[type]] internal slot of key to "public"
             // Step 2.8. Set the [[algorithm]] internal slot of key to algorithm.
             CryptoKey::new(
+                cx,
                 global,
                 KeyType::Public,
                 extractable,
                 KeyAlgorithmAndDerivatives::EcKeyAlgorithm(algorithm),
                 usages,
                 handle,
-                CanGc::from_cx(cx),
             )
         },
         // Otherwise:

--- a/components/script/dom/subtlecrypto/ed25519_operation.rs
+++ b/components/script/dom/subtlecrypto/ed25519_operation.rs
@@ -21,7 +21,6 @@ use crate::dom::subtlecrypto::{
     ALG_ED25519, ExportedKey, JsonWebKeyExt, JwkStringField, KeyAlgorithmAndDerivatives,
     SubtleKeyAlgorithm,
 };
-use crate::script_runtime::CanGc;
 
 const ED25519_SEED_LENGTH: usize = 32;
 
@@ -125,6 +124,7 @@ pub(crate) fn generate_key(
     // Step 9. Set the [[usages]] internal slot of publicKey to be the usage intersection of usages
     // and [ "verify" ].
     let public_key = CryptoKey::new(
+        cx,
         global,
         KeyType::Public,
         true,
@@ -135,7 +135,6 @@ pub(crate) fn generate_key(
             .cloned()
             .collect(),
         Handle::Ed25519(key_pair.public_key().as_ref().to_vec()),
-        CanGc::from_cx(cx),
     );
 
     // Step 10. Let privateKey be a new CryptoKey representing the private key of the generated key pair.
@@ -145,6 +144,7 @@ pub(crate) fn generate_key(
     // Step 14. Set the [[usages]] internal slot of privateKey to be the usage intersection of
     // usages and [ "sign" ].
     let private_key = CryptoKey::new(
+        cx,
         global,
         KeyType::Private,
         extractable,
@@ -155,7 +155,6 @@ pub(crate) fn generate_key(
             .cloned()
             .collect(),
         Handle::Ed25519(seed),
-        CanGc::from_cx(cx),
     );
 
     // Step 16. Let result be a new CryptoKeyPair dictionary.
@@ -219,13 +218,13 @@ pub(crate) fn import_key(
             // Step 2.8. Set the [[type]] internal slot of key to "public"
             // Step 2.11. Set the [[algorithm]] internal slot of key to algorithm.
             CryptoKey::new(
+                cx,
                 global,
                 KeyType::Public,
                 extractable,
                 KeyAlgorithmAndDerivatives::KeyAlgorithm(algorithm),
                 usages,
                 Handle::Ed25519(public_key.as_ref().to_vec()),
-                CanGc::from_cx(cx),
             )
         },
         // If format is "pkcs8":
@@ -282,13 +281,13 @@ pub(crate) fn import_key(
             // Step 2.9. Set the [[type]] internal slot of key to "private"
             // Step 2.12. Set the [[algorithm]] internal slot of key to algorithm.
             CryptoKey::new(
+                cx,
                 global,
                 KeyType::Private,
                 extractable,
                 KeyAlgorithmAndDerivatives::KeyAlgorithm(algorithm),
                 usages,
                 Handle::Ed25519(curve_private_key),
-                CanGc::from_cx(cx),
             )
         },
         // If format is "jwk":
@@ -383,13 +382,13 @@ pub(crate) fn import_key(
                 // 2 of [RFC8037]
                 // Step 2.9.3. Set the [[type]] internal slot of Key to "private".
                 CryptoKey::new(
+                    cx,
                     global,
                     KeyType::Private,
                     extractable,
                     KeyAlgorithmAndDerivatives::KeyAlgorithm(algorithm),
                     usages,
                     Handle::Ed25519(d),
-                    CanGc::from_cx(cx),
                 )
             }
             // Otherwise:
@@ -402,13 +401,13 @@ pub(crate) fn import_key(
                 // key identified by interpreting jwk according to Section 2 of [RFC8037].
                 // Step 2.9.3. Set the [[type]] internal slot of Key to "public".
                 CryptoKey::new(
+                    cx,
                     global,
                     KeyType::Public,
                     extractable,
                     KeyAlgorithmAndDerivatives::KeyAlgorithm(algorithm),
                     usages,
                     Handle::Ed25519(x),
-                    CanGc::from_cx(cx),
                 )
             }
 
@@ -439,13 +438,13 @@ pub(crate) fn import_key(
             // Step 2.6. Set the [[type]] internal slot of key to "public"
             // Step 2.7. Set the [[algorithm]] internal slot of key to algorithm.
             CryptoKey::new(
+                cx,
                 global,
                 KeyType::Public,
                 extractable,
                 KeyAlgorithmAndDerivatives::KeyAlgorithm(algorithm),
                 usages,
                 Handle::Ed25519(key_data.to_vec()),
-                CanGc::from_cx(cx),
             )
         },
         // Otherwise:

--- a/components/script/dom/subtlecrypto/hkdf_operation.rs
+++ b/components/script/dom/subtlecrypto/hkdf_operation.rs
@@ -17,7 +17,6 @@ use crate::dom::subtlecrypto::{
     ALG_HKDF, ALG_SHA1, ALG_SHA256, ALG_SHA384, ALG_SHA512, KeyAlgorithmAndDerivatives,
     SubtleHkdfParams, SubtleKeyAlgorithm,
 };
-use crate::script_runtime::CanGc;
 
 /// <https://w3c.github.io/webcrypto/#hkdf-operations-derive-bits>
 pub(crate) fn derive_bits(
@@ -114,13 +113,13 @@ pub(crate) fn import_key(
             name: ALG_HKDF.to_string(),
         };
         let key = CryptoKey::new(
+            cx,
             global,
             KeyType::Secret,
             extractable,
             KeyAlgorithmAndDerivatives::KeyAlgorithm(algorithm),
             usages,
             Handle::HkdfSecret(key_data.to_vec()),
-            CanGc::from_cx(cx),
         );
 
         // Step 2.8. Return key.

--- a/components/script/dom/subtlecrypto/hmac_operation.rs
+++ b/components/script/dom/subtlecrypto/hmac_operation.rs
@@ -20,7 +20,6 @@ use crate::dom::subtlecrypto::{
     JwkStringField, KeyAlgorithmAndDerivatives, SubtleHmacImportParams, SubtleHmacKeyAlgorithm,
     SubtleHmacKeyGenParams, SubtleKeyAlgorithm,
 };
-use crate::script_runtime::CanGc;
 
 /// <https://w3c.github.io/webcrypto/#hmac-operations-sign>
 pub(crate) fn sign(key: &CryptoKey, message: &[u8]) -> Result<Vec<u8>, Error> {
@@ -133,13 +132,13 @@ pub(crate) fn generate_key(
     // Step 14. Set the [[extractable]] internal slot of key to be extractable.
     // Step 15. Set the [[usages]] internal slot of key to be usages.
     let key = CryptoKey::new(
+        cx,
         global,
         KeyType::Secret,
         extractable,
         KeyAlgorithmAndDerivatives::HmacKeyAlgorithm(algorithm),
         usages,
         Handle::Hmac(key_data),
-        CanGc::from_cx(cx),
     );
 
     // Step 16. Return key.
@@ -308,13 +307,13 @@ pub(crate) fn import_key(
     // Step 14. Set the [[algorithm]] internal slot of key to algorithm.
     let truncated_data = data[..length as usize / 8].to_vec();
     let key = CryptoKey::new(
+        cx,
         global,
         KeyType::Secret,
         extractable,
         KeyAlgorithmAndDerivatives::HmacKeyAlgorithm(algorithm),
         usages,
         Handle::Hmac(truncated_data),
-        CanGc::from_cx(cx),
     );
 
     // Step 15. Return key.

--- a/components/script/dom/subtlecrypto/ml_dsa_operation.rs
+++ b/components/script/dom/subtlecrypto/ml_dsa_operation.rs
@@ -25,7 +25,6 @@ use crate::dom::subtlecrypto::{
     ALG_ML_DSA_44, ALG_ML_DSA_65, ALG_ML_DSA_87, ExportedKey, JsonWebKeyExt, JwkStringField,
     KeyAlgorithmAndDerivatives, SubtleAlgorithm, SubtleContextParams, SubtleKeyAlgorithm,
 };
-use crate::script_runtime::CanGc;
 
 /// Object Identifier (OID) of ML-DSA-44
 /// Section 2 of <https://datatracker.ietf.org/doc/html/rfc9881>
@@ -324,6 +323,7 @@ pub(crate) fn generate_key(
     // Step 10. Set the [[usages]] internal slot of publicKey to be the usage intersection of
     // usages and [ "verify" ].
     let public_key = CryptoKey::new(
+        cx,
         global,
         KeyType::Public,
         true,
@@ -334,7 +334,6 @@ pub(crate) fn generate_key(
             .cloned()
             .collect(),
         public_key_handle,
-        CanGc::from_cx(cx),
     );
 
     // Step 11. Let privateKey be a new CryptoKey representing the private key of the generated key
@@ -345,6 +344,7 @@ pub(crate) fn generate_key(
     // Step 15. Set the [[usages]] internal slot of privateKey to be the usage intersection of
     // usages and [ "sign" ].
     let private_key = CryptoKey::new(
+        cx,
         global,
         KeyType::Private,
         extractable,
@@ -355,7 +355,6 @@ pub(crate) fn generate_key(
             .cloned()
             .collect(),
         private_key_handle,
-        CanGc::from_cx(cx),
     );
 
     // Step 16. Let result be a new CryptoKeyPair dictionary.
@@ -458,13 +457,13 @@ pub(crate) fn import_key(
                 name: normalized_algorithm.name.clone(),
             };
             CryptoKey::new(
+                cx,
                 global,
                 KeyType::Public,
                 extractable,
                 KeyAlgorithmAndDerivatives::KeyAlgorithm(algorithm),
                 usages,
                 public_key,
-                CanGc::from_cx(cx),
             )
         },
         // If format is "pkcs8":
@@ -584,13 +583,13 @@ pub(crate) fn import_key(
                 name: normalized_algorithm.name.clone(),
             };
             CryptoKey::new(
+                cx,
                 global,
                 KeyType::Private,
                 extractable,
                 KeyAlgorithmAndDerivatives::KeyAlgorithm(algorithm),
                 usages,
                 ml_dsa_private_key,
-                CanGc::from_cx(cx),
             )
         },
         // If format is "raw-public":
@@ -614,13 +613,13 @@ pub(crate) fn import_key(
                 name: normalized_algorithm.name.clone(),
             };
             CryptoKey::new(
+                cx,
                 global,
                 KeyType::Public,
                 extractable,
                 KeyAlgorithmAndDerivatives::KeyAlgorithm(algorithm),
                 usages,
                 public_key_handle,
-                CanGc::from_cx(cx),
             )
         },
         // If format is "raw-seed":
@@ -653,13 +652,13 @@ pub(crate) fn import_key(
                 name: normalized_algorithm.name.clone(),
             };
             CryptoKey::new(
+                cx,
                 global,
                 KeyType::Private,
                 extractable,
                 KeyAlgorithmAndDerivatives::KeyAlgorithm(algorithm),
                 usages,
                 private_key_handle,
-                CanGc::from_cx(cx),
             )
         },
         // If format is "jwk":
@@ -758,13 +757,13 @@ pub(crate) fn import_key(
                     name: normalized_algorithm.name.clone(),
                 };
                 CryptoKey::new(
+                    cx,
                     global,
                     KeyType::Private,
                     extractable,
                     KeyAlgorithmAndDerivatives::KeyAlgorithm(algorithm),
                     usages,
                     private_key_handle,
-                    CanGc::from_cx(cx),
                 )
             }
             // Otherwise:
@@ -783,13 +782,13 @@ pub(crate) fn import_key(
                     name: normalized_algorithm.name.clone(),
                 };
                 CryptoKey::new(
+                    cx,
                     global,
                     KeyType::Public,
                     extractable,
                     KeyAlgorithmAndDerivatives::KeyAlgorithm(algorithm),
                     usages,
                     public_key_handle,
-                    CanGc::from_cx(cx),
                 )
             }
         },

--- a/components/script/dom/subtlecrypto/ml_kem_operation.rs
+++ b/components/script/dom/subtlecrypto/ml_kem_operation.rs
@@ -27,7 +27,6 @@ use crate::dom::subtlecrypto::{
     ALG_ML_KEM_512, ALG_ML_KEM_768, ALG_ML_KEM_1024, ExportedKey, JsonWebKeyExt, JwkStringField,
     KeyAlgorithmAndDerivatives, SubtleAlgorithm, SubtleEncapsulatedBits, SubtleKeyAlgorithm,
 };
-use crate::script_runtime::CanGc;
 
 /// Object Identifier (OID) of MK-KEM-512
 /// Section 3 of <https://datatracker.ietf.org/doc/draft-ietf-lamps-kyber-certificates/>
@@ -338,6 +337,7 @@ pub(crate) fn generate_key(
     // Step 10. Set the [[usages]] internal slot of publicKey to be the usage intersection of
     // usages and [ "encapsulateKey", "encapsulateBits" ].
     let public_key = CryptoKey::new(
+        cx,
         global,
         KeyType::Public,
         true,
@@ -348,7 +348,6 @@ pub(crate) fn generate_key(
             .cloned()
             .collect(),
         public_key_handle,
-        CanGc::from_cx(cx),
     );
 
     // Step 11. Let privateKey be a new CryptoKey representing the decapsulation key of the
@@ -359,6 +358,7 @@ pub(crate) fn generate_key(
     // Step 15. Set the [[usages]] internal slot of privateKey to be the usage intersection of
     // usages and [ "decapsulateKey", "decapsulateBits" ].
     let private_key = CryptoKey::new(
+        cx,
         global,
         KeyType::Private,
         extractable,
@@ -369,7 +369,6 @@ pub(crate) fn generate_key(
             .cloned()
             .collect(),
         private_key_handle,
-        CanGc::from_cx(cx),
     );
 
     // Step 16. Let result be a new CryptoKeyPair dictionary.
@@ -478,13 +477,13 @@ pub(crate) fn import_key(
                 name: normalized_algorithm.name.clone(),
             };
             CryptoKey::new(
+                cx,
                 global,
                 KeyType::Public,
                 extractable,
                 KeyAlgorithmAndDerivatives::KeyAlgorithm(algorithm),
                 usages,
                 public_key,
-                CanGc::from_cx(cx),
             )
         },
         // If format is "pkcs8":
@@ -610,13 +609,13 @@ pub(crate) fn import_key(
                 name: normalized_algorithm.name.clone(),
             };
             CryptoKey::new(
+                cx,
                 global,
                 KeyType::Private,
                 extractable,
                 KeyAlgorithmAndDerivatives::KeyAlgorithm(algorithm),
                 usages,
                 ml_kem_private_key,
-                CanGc::from_cx(cx),
             )
         },
         // If format is "raw-public":
@@ -648,13 +647,13 @@ pub(crate) fn import_key(
                 name: normalized_algorithm.name.clone(),
             };
             CryptoKey::new(
+                cx,
                 global,
                 KeyType::Public,
                 extractable,
                 KeyAlgorithmAndDerivatives::KeyAlgorithm(algorithm),
                 usages,
                 public_key_handle,
-                CanGc::from_cx(cx),
             )
         },
         // If format is "raw-seed":
@@ -694,13 +693,13 @@ pub(crate) fn import_key(
                 name: normalized_algorithm.name.clone(),
             };
             CryptoKey::new(
+                cx,
                 global,
                 KeyType::Private,
                 extractable,
                 KeyAlgorithmAndDerivatives::KeyAlgorithm(algorithm),
                 usages,
                 private_key_handle,
-                CanGc::from_cx(cx),
             )
         },
         // If format is "jwk":
@@ -867,13 +866,13 @@ pub(crate) fn import_key(
                 name: normalized_algorithm.name.clone(),
             };
             CryptoKey::new(
+                cx,
                 global,
                 key_type,
                 extractable,
                 KeyAlgorithmAndDerivatives::KeyAlgorithm(algorithm),
                 usages,
                 key_handle,
-                CanGc::from_cx(cx),
             )
         },
         // Otherwise:

--- a/components/script/dom/subtlecrypto/pbkdf2_operation.rs
+++ b/components/script/dom/subtlecrypto/pbkdf2_operation.rs
@@ -17,7 +17,6 @@ use crate::dom::subtlecrypto::{
     ALG_PBKDF2, ALG_SHA1, ALG_SHA256, ALG_SHA384, ALG_SHA512, KeyAlgorithmAndDerivatives,
     SubtleKeyAlgorithm, SubtlePbkdf2Params,
 };
-use crate::script_runtime::CanGc;
 
 /// <https://w3c.github.io/webcrypto/#pbkdf2-operations-derive-bits>
 pub(crate) fn derive_bits(
@@ -115,13 +114,13 @@ pub(crate) fn import_key(
         name: ALG_PBKDF2.to_string(),
     };
     let key = CryptoKey::new(
+        cx,
         global,
         KeyType::Secret,
         extractable,
         KeyAlgorithmAndDerivatives::KeyAlgorithm(algorithm),
         usages,
         Handle::Pbkdf2(key_data.to_vec()),
-        CanGc::from_cx(cx),
     );
 
     // Step 9. Return key.

--- a/components/script/dom/subtlecrypto/rsa_common.rs
+++ b/components/script/dom/subtlecrypto/rsa_common.rs
@@ -35,7 +35,6 @@ use crate::dom::subtlecrypto::{
     SubtleRsaHashedImportParams, SubtleRsaHashedKeyAlgorithm, SubtleRsaHashedKeyGenParams,
     normalize_algorithm,
 };
-use crate::script_runtime::CanGc;
 
 pub(crate) enum RsaAlgorithm {
     RsassaPkcs1v1_5,
@@ -156,13 +155,13 @@ pub(crate) fn generate_key(
         },
     };
     let public_key = CryptoKey::new(
+        cx,
         global,
         KeyType::Public,
         true,
         KeyAlgorithmAndDerivatives::RsaHashedKeyAlgorithm(algorithm.clone()),
         intersected_usages,
         Handle::RsaPublicKey(public_key),
-        CanGc::from_cx(cx),
     );
 
     // Step 14. Let privateKey be a new CryptoKey representing the private key of the generated key
@@ -191,13 +190,13 @@ pub(crate) fn generate_key(
         },
     };
     let private_key = CryptoKey::new(
+        cx,
         global,
         KeyType::Private,
         extractable,
         KeyAlgorithmAndDerivatives::RsaHashedKeyAlgorithm(algorithm),
         intersected_usages,
         Handle::RsaPrivateKey(private_key),
-        CanGc::from_cx(cx),
     );
 
     // Step 19. Let result be a new CryptoKeyPair dictionary.
@@ -717,13 +716,13 @@ pub(crate) fn import_key(
         hash: normalized_algorithm.hash.clone(),
     };
     let key = CryptoKey::new(
+        cx,
         global,
         key_type,
         extractable,
         KeyAlgorithmAndDerivatives::RsaHashedKeyAlgorithm(algorithm),
         usages,
         key_handle,
-        CanGc::from_cx(cx),
     );
 
     // Step 9. Return key.

--- a/components/script/dom/subtlecrypto/x25519_operation.rs
+++ b/components/script/dom/subtlecrypto/x25519_operation.rs
@@ -23,7 +23,6 @@ use crate::dom::subtlecrypto::{
     ALG_X25519, ExportedKey, JsonWebKeyExt, JwkStringField, KeyAlgorithmAndDerivatives,
     SubtleEcdhKeyDeriveParams, SubtleKeyAlgorithm,
 };
-use crate::script_runtime::CanGc;
 
 /// `id-X25519` object identifier defined in [RFC8410]
 const X25519_OID_STRING: &str = "1.3.101.110";
@@ -142,13 +141,13 @@ pub(crate) fn generate_key(
     // Step 8. Set the [[extractable]] internal slot of publicKey to true.
     // Step 9. Set the [[usages]] internal slot of publicKey to be the empty list.
     let public_key = CryptoKey::new(
+        cx,
         global,
         KeyType::Public,
         true,
         KeyAlgorithmAndDerivatives::KeyAlgorithm(algorithm.clone()),
         Vec::new(),
         Handle::X25519PublicKey(public_key),
-        CanGc::from_cx(cx),
     );
 
     // Step 10. Let privateKey be a new CryptoKey representing the private key of the generated key pair.
@@ -158,6 +157,7 @@ pub(crate) fn generate_key(
     // Step 14. Set the [[usages]] internal slot of privateKey to be the usage intersection of
     // usages and [ "deriveKey", "deriveBits" ].
     let private_key = CryptoKey::new(
+        cx,
         global,
         KeyType::Private,
         extractable,
@@ -168,7 +168,6 @@ pub(crate) fn generate_key(
             .cloned()
             .collect(),
         Handle::X25519PrivateKey(private_key),
-        CanGc::from_cx(cx),
     );
 
     // Step 15. Let result be a new CryptoKeyPair dictionary.
@@ -241,13 +240,13 @@ pub(crate) fn import_key(
                 name: ALG_X25519.to_string(),
             };
             CryptoKey::new(
+                cx,
                 global,
                 KeyType::Public,
                 extractable,
                 KeyAlgorithmAndDerivatives::KeyAlgorithm(algorithm),
                 usages,
                 Handle::X25519PublicKey(public_key),
-                CanGc::from_cx(cx),
             )
         },
         // If format is "pkcs8":
@@ -304,13 +303,13 @@ pub(crate) fn import_key(
                 name: ALG_X25519.to_string(),
             };
             CryptoKey::new(
+                cx,
                 global,
                 KeyType::Private,
                 extractable,
                 KeyAlgorithmAndDerivatives::KeyAlgorithm(algorithm),
                 usages,
                 Handle::X25519PrivateKey(private_key),
-                CanGc::from_cx(cx),
             )
         },
         // If format is "jwk":
@@ -419,13 +418,13 @@ pub(crate) fn import_key(
                 name: ALG_X25519.to_string(),
             };
             CryptoKey::new(
+                cx,
                 global,
                 key_type,
                 extractable,
                 KeyAlgorithmAndDerivatives::KeyAlgorithm(algorithm),
                 usages,
                 handle,
-                CanGc::from_cx(cx),
             )
         },
         // If format is "raw":
@@ -452,13 +451,13 @@ pub(crate) fn import_key(
                 name: ALG_X25519.to_string(),
             };
             CryptoKey::new(
+                cx,
                 global,
                 KeyType::Public,
                 extractable,
                 KeyAlgorithmAndDerivatives::KeyAlgorithm(algorithm),
                 usages,
                 Handle::X25519PublicKey(public_key),
-                CanGc::from_cx(cx),
             )
         },
         // Otherwise:


### PR DESCRIPTION
Use the new `reflect_dom_object_with_cx` introduced in #42725 in `CryptoKey::new`.

Testing: Refactoring. Existing tests suffice.
