### PR TITLE
paint: Bound screenshot to the viewport

### DIFF
--- a/components/paint/screenshot.rs
+++ b/components/paint/screenshot.rs
@@ -192,8 +192,8 @@ impl ScreenshotTaker {
                     let y = 0.max(
                         (viewport_size.height as f32 - rect.min.y - rect.size().height) as i32,
                     );
-                    let w = rect.size().width as i32;
-                    let h = rect.size().height as i32;
+                    let w = (rect.size().width as i32).min(viewport_size.width - x);
+                    let h = (rect.size().height as i32).min(viewport_size.height - y);
 
                     DeviceIntRect::from_origin_and_size(Point2D::new(x, y), Size2D::new(w, h))
                 });

--- a/components/webdriver_server/lib.rs
+++ b/components/webdriver_server/lib.rs
@@ -2476,10 +2476,11 @@ impl Handler {
 
         let rect = wait_for_ipc_response_flatten(receiver)?;
 
+        // TODO: Consider writing mode. Convert `rect` before requesting screenshot.
         // Step 5
         let encoded = self.take_screenshot(Some(Rect::from_untyped(&rect)))?;
 
-        // Step 6 return success with data encoded string.
+        // Step 6. return success with data encoded string.
         Ok(WebDriverResponse::Generic(ValueResponse(
             serde_json::to_value(encoded)?,
         )))

--- a/tests/wpt/meta/webdriver/tests/classic/take_element_screenshot/screenshot.py.ini
+++ b/tests/wpt/meta/webdriver/tests/classic/take_element_screenshot/screenshot.py.ini
@@ -1,3 +1,0 @@
-[screenshot.py]
-  [test_clip_huge_element_to_viewport]
-    expected: ERROR

--- a/tests/wpt/tests/webdriver/tests/classic/take_element_screenshot/screenshot.py
+++ b/tests/wpt/tests/webdriver/tests/classic/take_element_screenshot/screenshot.py
@@ -94,7 +94,7 @@ def test_clip_huge_element_to_viewport(session, inline):
     width = "32768px"
     height = "32768px"
 
-    session.url = inline(f"<div style='width: {width}; height: {height}; background-color: black;'></div>")
+    session.url = inline(f"<style>body{{margin:0;}}</style><div style='width: {width}; height: {height}; background-color: black;'></div>")
     element = session.find.css("div", all=False)
 
     response = take_element_screenshot(session, element.id)

--- a/tests/wpt/tests/webdriver/tests/classic/take_element_screenshot/screenshot.py
+++ b/tests/wpt/tests/webdriver/tests/classic/take_element_screenshot/screenshot.py
@@ -94,7 +94,12 @@ def test_clip_huge_element_to_viewport(session, inline):
     width = "32768px"
     height = "32768px"
 
-    session.url = inline(f"<style>body{{margin:0;}}</style><div style='width: {width}; height: {height}; background-color: black;'></div>")
+    session.url = inline(f"""
+        <style>
+            body {{ margin: 0; }}
+        </style>
+        <div style='width: {width}; height: {height}; background-color: black;'></div>
+    """)
     element = session.find.css("div", all=False)
 
     response = take_element_screenshot(session, element.id)


### PR DESCRIPTION
Ensure that the screenshot rectangle is bounded by the width and height of the viewport.

Testing: The WPT test `test_clip_huge_element_to_viewport` now passes instead of crashing. It is also fixed so that the returned screenshot size is the expected 800x600; it would otherwise be 792x600 due to the body margin.

Fixes: #42530
