### PR TITLE
build(deps): bump Stylo to "Make preference system more robust"

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7229,7 +7229,7 @@ dependencies = [
 [[package]]
 name = "selectors"
 version = "0.35.0"
-source = "git+https://github.com/servo/stylo?rev=b22d59d21f9604ce8afaac1f7420f9ffa79f2898#b22d59d21f9604ce8afaac1f7420f9ffa79f2898"
+source = "git+https://github.com/servo/stylo?rev=9b635629e627a611419745198de1b1ba6c8667c2#9b635629e627a611419745198de1b1ba6c8667c2"
 dependencies = [
  "bitflags 2.11.0",
  "cssparser",
@@ -8797,7 +8797,7 @@ dependencies = [
 [[package]]
 name = "servo_arc"
 version = "0.4.3"
-source = "git+https://github.com/servo/stylo?rev=b22d59d21f9604ce8afaac1f7420f9ffa79f2898#b22d59d21f9604ce8afaac1f7420f9ffa79f2898"
+source = "git+https://github.com/servo/stylo?rev=9b635629e627a611419745198de1b1ba6c8667c2#9b635629e627a611419745198de1b1ba6c8667c2"
 dependencies = [
  "serde",
  "stable_deref_trait",
@@ -9217,7 +9217,7 @@ dependencies = [
 [[package]]
 name = "stylo"
 version = "0.12.0"
-source = "git+https://github.com/servo/stylo?rev=b22d59d21f9604ce8afaac1f7420f9ffa79f2898#b22d59d21f9604ce8afaac1f7420f9ffa79f2898"
+source = "git+https://github.com/servo/stylo?rev=9b635629e627a611419745198de1b1ba6c8667c2#9b635629e627a611419745198de1b1ba6c8667c2"
 dependencies = [
  "app_units",
  "arrayvec",
@@ -9273,7 +9273,7 @@ dependencies = [
 [[package]]
 name = "stylo_atoms"
 version = "0.12.0"
-source = "git+https://github.com/servo/stylo?rev=b22d59d21f9604ce8afaac1f7420f9ffa79f2898#b22d59d21f9604ce8afaac1f7420f9ffa79f2898"
+source = "git+https://github.com/servo/stylo?rev=9b635629e627a611419745198de1b1ba6c8667c2#9b635629e627a611419745198de1b1ba6c8667c2"
 dependencies = [
  "string_cache",
  "string_cache_codegen",
@@ -9282,7 +9282,7 @@ dependencies = [
 [[package]]
 name = "stylo_derive"
 version = "0.12.0"
-source = "git+https://github.com/servo/stylo?rev=b22d59d21f9604ce8afaac1f7420f9ffa79f2898#b22d59d21f9604ce8afaac1f7420f9ffa79f2898"
+source = "git+https://github.com/servo/stylo?rev=9b635629e627a611419745198de1b1ba6c8667c2#9b635629e627a611419745198de1b1ba6c8667c2"
 dependencies = [
  "darling",
  "proc-macro2",
@@ -9294,7 +9294,7 @@ dependencies = [
 [[package]]
 name = "stylo_dom"
 version = "0.12.0"
-source = "git+https://github.com/servo/stylo?rev=b22d59d21f9604ce8afaac1f7420f9ffa79f2898#b22d59d21f9604ce8afaac1f7420f9ffa79f2898"
+source = "git+https://github.com/servo/stylo?rev=9b635629e627a611419745198de1b1ba6c8667c2#9b635629e627a611419745198de1b1ba6c8667c2"
 dependencies = [
  "bitflags 2.11.0",
  "stylo_malloc_size_of",
@@ -9303,7 +9303,7 @@ dependencies = [
 [[package]]
 name = "stylo_malloc_size_of"
 version = "0.12.0"
-source = "git+https://github.com/servo/stylo?rev=b22d59d21f9604ce8afaac1f7420f9ffa79f2898#b22d59d21f9604ce8afaac1f7420f9ffa79f2898"
+source = "git+https://github.com/servo/stylo?rev=9b635629e627a611419745198de1b1ba6c8667c2#9b635629e627a611419745198de1b1ba6c8667c2"
 dependencies = [
  "app_units",
  "cssparser",
@@ -9320,12 +9320,12 @@ dependencies = [
 [[package]]
 name = "stylo_static_prefs"
 version = "0.12.0"
-source = "git+https://github.com/servo/stylo?rev=b22d59d21f9604ce8afaac1f7420f9ffa79f2898#b22d59d21f9604ce8afaac1f7420f9ffa79f2898"
+source = "git+https://github.com/servo/stylo?rev=9b635629e627a611419745198de1b1ba6c8667c2#9b635629e627a611419745198de1b1ba6c8667c2"
 
 [[package]]
 name = "stylo_traits"
 version = "0.12.0"
-source = "git+https://github.com/servo/stylo?rev=b22d59d21f9604ce8afaac1f7420f9ffa79f2898#b22d59d21f9604ce8afaac1f7420f9ffa79f2898"
+source = "git+https://github.com/servo/stylo?rev=9b635629e627a611419745198de1b1ba6c8667c2#9b635629e627a611419745198de1b1ba6c8667c2"
 dependencies = [
  "app_units",
  "bitflags 2.11.0",
@@ -9747,7 +9747,7 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 [[package]]
 name = "to_shmem"
 version = "0.3.0"
-source = "git+https://github.com/servo/stylo?rev=b22d59d21f9604ce8afaac1f7420f9ffa79f2898#b22d59d21f9604ce8afaac1f7420f9ffa79f2898"
+source = "git+https://github.com/servo/stylo?rev=9b635629e627a611419745198de1b1ba6c8667c2#9b635629e627a611419745198de1b1ba6c8667c2"
 dependencies = [
  "cssparser",
  "servo_arc",
@@ -9760,7 +9760,7 @@ dependencies = [
 [[package]]
 name = "to_shmem_derive"
 version = "0.1.0"
-source = "git+https://github.com/servo/stylo?rev=b22d59d21f9604ce8afaac1f7420f9ffa79f2898#b22d59d21f9604ce8afaac1f7420f9ffa79f2898"
+source = "git+https://github.com/servo/stylo?rev=9b635629e627a611419745198de1b1ba6c8667c2#9b635629e627a611419745198de1b1ba6c8667c2"
 dependencies = [
  "darling",
  "proc-macro2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -172,7 +172,7 @@ script_traits = { package = "servo-script-traits", path = "components/shared/scr
 sea-query = { version = "1.0.0-rc.31", default-features = false, features = ["backend-sqlite", "derive"] }
 sea-query-rusqlite = { version = "0.8.0-rc.15" }
 sec1 = "0.7"
-selectors = { git = "https://github.com/servo/stylo", rev = "b22d59d21f9604ce8afaac1f7420f9ffa79f2898" }
+selectors = { git = "https://github.com/servo/stylo", rev = "9b635629e627a611419745198de1b1ba6c8667c2" }
 serde = "1.0.228"
 serde_bytes = "0.11"
 serde_core = "1.0.226"
@@ -181,7 +181,7 @@ servo-media = { path = "components/media/servo-media" }
 servo-media-dummy = { path = "components/media/backends/dummy" }
 servo-media-gstreamer = { path = "components/media/backends/gstreamer" }
 servo-tracing = { path = "components/servo_tracing" }
-servo_arc = { git = "https://github.com/servo/stylo", rev = "b22d59d21f9604ce8afaac1f7420f9ffa79f2898" }
+servo_arc = { git = "https://github.com/servo/stylo", rev = "9b635629e627a611419745198de1b1ba6c8667c2" }
 sha1 = "0.10"
 sha2 = "0.10"
 sha3 = "0.10"
@@ -190,12 +190,12 @@ smallvec = { version = "1.15", features = ["serde", "union"] }
 storage_traits = { package = "servo-storage-traits", path = "components/shared/storage" }
 string_cache = "0.9"
 strum = { version = "0.27", features = ["derive"] }
-stylo = { git = "https://github.com/servo/stylo", rev = "b22d59d21f9604ce8afaac1f7420f9ffa79f2898" }
-stylo_atoms = { git = "https://github.com/servo/stylo", rev = "b22d59d21f9604ce8afaac1f7420f9ffa79f2898" }
-stylo_dom = { git = "https://github.com/servo/stylo", rev = "b22d59d21f9604ce8afaac1f7420f9ffa79f2898" }
-stylo_malloc_size_of = { git = "https://github.com/servo/stylo", rev = "b22d59d21f9604ce8afaac1f7420f9ffa79f2898" }
-stylo_static_prefs = { git = "https://github.com/servo/stylo", rev = "b22d59d21f9604ce8afaac1f7420f9ffa79f2898" }
-stylo_traits = { git = "https://github.com/servo/stylo", rev = "b22d59d21f9604ce8afaac1f7420f9ffa79f2898" }
+stylo = { git = "https://github.com/servo/stylo", rev = "9b635629e627a611419745198de1b1ba6c8667c2" }
+stylo_atoms = { git = "https://github.com/servo/stylo", rev = "9b635629e627a611419745198de1b1ba6c8667c2" }
+stylo_dom = { git = "https://github.com/servo/stylo", rev = "9b635629e627a611419745198de1b1ba6c8667c2" }
+stylo_malloc_size_of = { git = "https://github.com/servo/stylo", rev = "9b635629e627a611419745198de1b1ba6c8667c2" }
+stylo_static_prefs = { git = "https://github.com/servo/stylo", rev = "9b635629e627a611419745198de1b1ba6c8667c2" }
+stylo_traits = { git = "https://github.com/servo/stylo", rev = "9b635629e627a611419745198de1b1ba6c8667c2" }
 surfman = { version = "0.11.0", features = ["chains"] }
 syn = { version = "2", default-features = false, features = ["clone-impls", "derive", "parsing"] }
 synstructure = "0.13"

--- a/components/config/prefs.rs
+++ b/components/config/prefs.rs
@@ -32,30 +32,25 @@ pub fn set(preferences: Preferences) {
     // Map between Stylo preference names and Servo preference names as the This should be
     // kept in sync with components/script/dom/bindings/codegen/run.py which generates the
     // DOM CSS style accessors.
-    stylo_static_prefs::set_bool("layout.unimplemented", preferences.layout_unimplemented);
-    stylo_static_prefs::set_i32("layout.threads", preferences.layout_threads as i32);
-    stylo_static_prefs::set_bool("layout.flexbox.enabled", preferences.layout_flexbox_enabled);
-    stylo_static_prefs::set_bool("layout.columns.enabled", preferences.layout_columns_enabled);
-    stylo_static_prefs::set_bool("layout.grid.enabled", preferences.layout_grid_enabled);
-    stylo_static_prefs::set_bool(
+    stylo_static_prefs::set_pref!("layout.unimplemented", preferences.layout_unimplemented);
+    stylo_static_prefs::set_pref!("layout.threads", preferences.layout_threads as i32);
+    stylo_static_prefs::set_pref!("layout.columns.enabled", preferences.layout_columns_enabled);
+    stylo_static_prefs::set_pref!("layout.grid.enabled", preferences.layout_grid_enabled);
+    stylo_static_prefs::set_pref!(
         "layout.css.attr.enabled",
-        preferences.layout_css_attr_enabled,
+        preferences.layout_css_attr_enabled
     );
-    stylo_static_prefs::set_bool(
-        "layout.css.transition-behavior.enabled",
-        preferences.layout_css_transition_behavior_enabled,
-    );
-    stylo_static_prefs::set_bool(
+    stylo_static_prefs::set_pref!(
         "layout.writing-mode.enabled",
-        preferences.layout_writing_mode_enabled,
+        preferences.layout_writing_mode_enabled
     );
-    stylo_static_prefs::set_bool(
+    stylo_static_prefs::set_pref!(
         "layout.container-queries.enabled",
-        preferences.layout_container_queries_enabled,
+        preferences.layout_container_queries_enabled
     );
-    stylo_static_prefs::set_bool(
+    stylo_static_prefs::set_pref!(
         "layout.variable_fonts.enabled",
-        preferences.layout_variable_fonts_enabled,
+        preferences.layout_variable_fonts_enabled
     );
 
     let changed = preferences.diff(&PREFERENCES.read().unwrap());
@@ -258,9 +253,6 @@ pub struct Preferences {
     pub layout_grid_enabled: bool,
     pub layout_container_queries_enabled: bool,
     pub layout_css_attr_enabled: bool,
-    pub layout_css_transition_behavior_enabled: bool,
-    // feature: CSS Flexbox | #12453 | Web/CSS/Guides/Flexible_box_layout
-    pub layout_flexbox_enabled: bool,
     pub layout_style_sharing_cache_enabled: bool,
     pub layout_threads: i64,
     pub layout_unimplemented: bool,
@@ -457,8 +449,6 @@ impl Preferences {
             layout_columns_enabled: false,
             layout_container_queries_enabled: false,
             layout_css_attr_enabled: false,
-            layout_css_transition_behavior_enabled: true,
-            layout_flexbox_enabled: true,
             layout_grid_enabled: false,
             layout_style_sharing_cache_enabled: true,
             // TODO(mrobinson): This should likely be based on the number of processors.

--- a/components/script_bindings/codegen/run.py
+++ b/components/script_bindings/codegen/run.py
@@ -116,11 +116,9 @@ def add_css_properties_attributes(css_properties_json: str, parser: Parser) -> N
         MAPPING = [
             ["layout.unimplemented", "layout_unimplemented"],
             ["layout.threads", "layout_threads"],
-            ["layout.flexbox.enabled", "layout_flexbox_enabled"],
             ["layout.columns.enabled", "layout_columns_enabled"],
             ["layout.grid.enabled", "layout_grid_enabled"],
             ["layout.css.attr.enabled", "layout_css_attr_enabled"],
-            ["layout.css.transition-behavior.enabled", "layout_css_transition_behavior_enabled"],
             ["layout.writing-mode.enabled", "layout_writing_mode_enabled"],
             ["layout.container-queries.enabled", "layout_container_queries_enabled"],
             ["layout.variable_fonts.enabled", "layout_variable_fonts_enabled"]

--- a/tests/wpt/mozilla/meta/css/flex_align_content_stretch_subpixel.html.ini
+++ b/tests/wpt/mozilla/meta/css/flex_align_content_stretch_subpixel.html.ini
@@ -1,2 +1,0 @@
-[flex_align_content_stretch_subpixel.html]
-  prefs: ["layout_flexbox_enabled:true"]


### PR DESCRIPTION
Bumps Stylo to https://github.com/servo/stylo/pull/314

In particular, we would now get a compile error because we were setting `layout.flexbox.enabled` and `layout.css.transition-behavior.enabled`, even if Stylo removed at some point. So stop setting them.

Testing: Not needed, no behavior change
