### PR TITLE
wpt: Move exec_command preference to experimental preferences

### DIFF
--- a/ports/servoshell/prefs.rs
+++ b/ports/servoshell/prefs.rs
@@ -27,6 +27,7 @@ use crate::VERSION;
 
 pub(crate) static EXPERIMENTAL_PREFS: &[&str] = &[
     "dom_async_clipboard_enabled",
+    "dom_exec_command_enabled",
     "dom_fontface_enabled",
     "dom_intersection_observer_enabled",
     "dom_navigator_protocol_handlers_enabled",

--- a/tests/wpt/meta/__dir__.ini
+++ b/tests/wpt/meta/__dir__.ini
@@ -1,7 +1,6 @@
 prefs: [
   "dom_adoptedstylesheet_enabled:true",
   "dom_credential_management_enabled:true",
-  "dom_exec_command_enabled:true",
   "dom_indexeddb_enabled:true",
   "dom_serviceworker_enabled:true",
   "dom_testutils_enabled:true",


### PR DESCRIPTION
That way, we correctly run it whenever we invoke WPT. This is relevant for wpt.fyi, where currently we are not seeing any test coverage in the `/editing` tests. To make tracking of progress possible, it should be defined in prefs, not in the `.ini` configuration.

Part of #25005
