### PR TITLE
script: Pass `&mut JSContext` to more dom methods

### DIFF
--- a/components/script/dom/audio/audiocontext.rs
+++ b/components/script/dom/audio/audiocontext.rs
@@ -254,12 +254,12 @@ impl AudioContextMethods<crate::DomTypeHolder> for AudioContext {
     /// <https://webaudio.github.io/web-audio-api/#dom-audiocontext-createmediaelementsource>
     fn CreateMediaElementSource(
         &self,
+        cx: &mut js::context::JSContext,
         media_element: &HTMLMediaElement,
-        can_gc: CanGc,
     ) -> Fallible<DomRoot<MediaElementAudioSourceNode>> {
         let global = self.global();
         let window = global.as_window();
-        MediaElementAudioSourceNode::new(window, self, media_element, can_gc)
+        MediaElementAudioSourceNode::new(window, self, media_element, cx)
     }
 
     /// <https://webaudio.github.io/web-audio-api/#dom-audiocontext-createmediastreamsource>

--- a/components/script/dom/audio/mediaelementaudiosourcenode.rs
+++ b/components/script/dom/audio/mediaelementaudiosourcenode.rs
@@ -15,7 +15,7 @@ use crate::dom::bindings::codegen::Bindings::MediaElementAudioSourceNodeBinding:
     MediaElementAudioSourceNodeMethods, MediaElementAudioSourceOptions,
 };
 use crate::dom::bindings::error::Fallible;
-use crate::dom::bindings::reflector::reflect_dom_object_with_proto;
+use crate::dom::bindings::reflector::reflect_dom_object_with_proto_and_cx;
 use crate::dom::bindings::root::{Dom, DomRoot};
 use crate::dom::html::htmlmediaelement::HTMLMediaElement;
 use crate::dom::window::Window;
@@ -32,7 +32,7 @@ impl MediaElementAudioSourceNode {
     fn new_inherited(
         context: &AudioContext,
         media_element: &HTMLMediaElement,
-        can_gc: CanGc,
+        cx: &mut js::context::JSContext,
     ) -> Fallible<MediaElementAudioSourceNode> {
         let node = AudioNode::new_inherited(
             AudioNodeInit::MediaElementSourceNode,
@@ -46,7 +46,7 @@ impl MediaElementAudioSourceNode {
             MediaElementSourceNodeMessage::GetAudioRenderer(sender),
         ));
         let audio_renderer = receiver.recv();
-        media_element.set_audio_renderer(audio_renderer.ok(), can_gc);
+        media_element.set_audio_renderer(audio_renderer.ok(), CanGc::from_cx(cx));
         let media_element = Dom::from_ref(media_element);
         Ok(MediaElementAudioSourceNode {
             node,
@@ -58,9 +58,9 @@ impl MediaElementAudioSourceNode {
         window: &Window,
         context: &AudioContext,
         media_element: &HTMLMediaElement,
-        can_gc: CanGc,
+        cx: &mut js::context::JSContext,
     ) -> Fallible<DomRoot<MediaElementAudioSourceNode>> {
-        Self::new_with_proto(window, None, context, media_element, can_gc)
+        Self::new_with_proto(window, None, context, media_element, cx)
     }
 
     #[cfg_attr(crown, expect(crown::unrooted_must_root))]
@@ -69,14 +69,14 @@ impl MediaElementAudioSourceNode {
         proto: Option<HandleObject>,
         context: &AudioContext,
         media_element: &HTMLMediaElement,
-        can_gc: CanGc,
+        cx: &mut js::context::JSContext,
     ) -> Fallible<DomRoot<MediaElementAudioSourceNode>> {
-        let node = MediaElementAudioSourceNode::new_inherited(context, media_element, can_gc)?;
-        Ok(reflect_dom_object_with_proto(
+        let node = MediaElementAudioSourceNode::new_inherited(context, media_element, cx)?;
+        Ok(reflect_dom_object_with_proto_and_cx(
             Box::new(node),
             window,
             proto,
-            can_gc,
+            cx,
         ))
     }
 }
@@ -84,9 +84,9 @@ impl MediaElementAudioSourceNode {
 impl MediaElementAudioSourceNodeMethods<crate::DomTypeHolder> for MediaElementAudioSourceNode {
     /// <https://webaudio.github.io/web-audio-api/#dom-mediaelementaudiosourcenode-mediaelementaudiosourcenode>
     fn Constructor(
+        cx: &mut js::context::JSContext,
         window: &Window,
         proto: Option<HandleObject>,
-        can_gc: CanGc,
         context: &AudioContext,
         options: &MediaElementAudioSourceOptions,
     ) -> Fallible<DomRoot<MediaElementAudioSourceNode>> {
@@ -95,7 +95,7 @@ impl MediaElementAudioSourceNodeMethods<crate::DomTypeHolder> for MediaElementAu
             proto,
             context,
             &options.mediaElement,
-            can_gc,
+            cx,
         )
     }
 

--- a/components/script/dom/document.rs
+++ b/components/script/dom/document.rs
@@ -3497,11 +3497,11 @@ impl Document {
     /// <https://html.spec.whatwg.org/multipage/#document-write-steps>
     fn write(
         &self,
+        cx: &mut js::context::JSContext,
         text: Vec<TrustedHTMLOrString>,
         line_feed: bool,
         containing_class: &str,
         field: &str,
-        can_gc: CanGc,
     ) -> ErrorResult {
         // Step 1: Let string be the empty string.
         let mut strings: Vec<String> = Vec::with_capacity(text.len());
@@ -3531,7 +3531,7 @@ impl Document {
                 &self.global(),
                 TrustedHTMLOrString::String(string.into()),
                 &format!("{} {}", containing_class, field),
-                can_gc,
+                CanGc::from_cx(cx),
             )?
             .str()
             .to_owned();
@@ -3568,13 +3568,13 @@ impl Document {
                     return Ok(());
                 }
                 // Step 9.2: Run the document open steps with document.
-                self.Open(None, None, can_gc)?;
+                self.Open(cx, None, None)?;
                 self.get_current_parser().unwrap()
             },
         };
 
         // Steps 10-11.
-        parser.write(string.into(), can_gc);
+        parser.write(string.into(), CanGc::from_cx(cx));
 
         Ok(())
     }
@@ -5060,9 +5060,9 @@ impl DocumentMethods<crate::DomTypeHolder> for Document {
 
     /// <https://html.spec.whatwg.org/multipage/#dom-parsehtmlunsafe>
     fn ParseHTMLUnsafe(
+        cx: &mut js::context::JSContext,
         window: &Window,
         s: TrustedHTMLOrString,
-        can_gc: CanGc,
     ) -> Fallible<DomRoot<Self>> {
         // Step 1. Let compliantHTML be the result of invoking the
         // Get Trusted Type compliant string algorithm with TrustedHTML, the current global object,
@@ -5071,7 +5071,7 @@ impl DocumentMethods<crate::DomTypeHolder> for Document {
             window.as_global_scope(),
             s,
             "Document parseHTMLUnsafe",
-            can_gc,
+            CanGc::from_cx(cx),
         )?;
 
         let url = window.get_url();
@@ -5104,12 +5104,19 @@ impl DocumentMethods<crate::DomTypeHolder> for Document {
             doc.has_trustworthy_ancestor_or_current_origin(),
             doc.custom_element_reaction_stack(),
             doc.creation_sandboxing_flag_set(),
-            can_gc,
+            CanGc::from_cx(cx),
         );
         // Step 4. Parse HTML from string given document and compliantHTML.
-        ServoParser::parse_html_document(&document, Some(compliant_html), url, None, None, can_gc);
+        ServoParser::parse_html_document(
+            &document,
+            Some(compliant_html),
+            url,
+            None,
+            None,
+            CanGc::from_cx(cx),
+        );
         // Step 5. Return document.
-        document.set_ready_state(DocumentReadyState::Complete, can_gc);
+        document.set_ready_state(DocumentReadyState::Complete, CanGc::from_cx(cx));
         Ok(document)
     }
 
@@ -6273,9 +6280,9 @@ impl DocumentMethods<crate::DomTypeHolder> for Document {
     /// <https://html.spec.whatwg.org/multipage/#dom-document-open>
     fn Open(
         &self,
+        cx: &mut js::context::JSContext,
         _unused1: Option<DOMString>,
         _unused2: Option<DOMString>,
-        can_gc: CanGc,
     ) -> Fallible<DomRoot<Document>> {
         // Step 1
         if !self.is_html_document() {
@@ -6323,7 +6330,7 @@ impl DocumentMethods<crate::DomTypeHolder> for Document {
         if self.has_browsing_context() {
             // spec says "stop document loading",
             // which is a process that does more than just abort
-            self.abort(can_gc);
+            self.abort(CanGc::from_cx(cx));
         }
 
         // Step 9
@@ -6340,7 +6347,7 @@ impl DocumentMethods<crate::DomTypeHolder> for Document {
         }
 
         // Step 11. Replace all with null within document.
-        Node::replace_all(None, self.upcast::<Node>(), can_gc);
+        Node::replace_all(None, self.upcast::<Node>(), CanGc::from_cx(cx));
 
         // Specs and tests are in a state of flux about whether
         // we want to clear the selection when we remove the contents;
@@ -6396,32 +6403,40 @@ impl DocumentMethods<crate::DomTypeHolder> for Document {
     /// <https://html.spec.whatwg.org/multipage/#dom-document-open-window>
     fn Open_(
         &self,
+        cx: &mut js::context::JSContext,
         url: USVString,
         target: DOMString,
         features: DOMString,
-        can_gc: CanGc,
     ) -> Fallible<Option<DomRoot<WindowProxy>>> {
         self.browsing_context()
             .ok_or(Error::InvalidAccess(None))?
-            .open(url, target, features, can_gc)
+            .open(url, target, features, CanGc::from_cx(cx))
     }
 
     /// <https://html.spec.whatwg.org/multipage/#dom-document-write>
-    fn Write(&self, text: Vec<TrustedHTMLOrString>, can_gc: CanGc) -> ErrorResult {
+    fn Write(
+        &self,
+        cx: &mut js::context::JSContext,
+        text: Vec<TrustedHTMLOrString>,
+    ) -> ErrorResult {
         // The document.write(...text) method steps are to run the document write steps
         // with this, text, false, and "Document write".
-        self.write(text, false, "Document", "write", can_gc)
+        self.write(cx, text, false, "Document", "write")
     }
 
     /// <https://html.spec.whatwg.org/multipage/#dom-document-writeln>
-    fn Writeln(&self, text: Vec<TrustedHTMLOrString>, can_gc: CanGc) -> ErrorResult {
+    fn Writeln(
+        &self,
+        cx: &mut js::context::JSContext,
+        text: Vec<TrustedHTMLOrString>,
+    ) -> ErrorResult {
         // The document.writeln(...text) method steps are to run the document write steps
         // with this, text, true, and "Document writeln".
-        self.write(text, true, "Document", "writeln", can_gc)
+        self.write(cx, text, true, "Document", "writeln")
     }
 
     /// <https://html.spec.whatwg.org/multipage/#dom-document-close>
-    fn Close(&self, can_gc: CanGc) -> ErrorResult {
+    fn Close(&self, cx: &mut js::context::JSContext) -> ErrorResult {
         if !self.is_html_document() {
             // Step 1.
             return Err(Error::InvalidState(None));
@@ -6441,7 +6456,7 @@ impl DocumentMethods<crate::DomTypeHolder> for Document {
         };
 
         // Step 4-6.
-        parser.close(can_gc);
+        parser.close(CanGc::from_cx(cx));
 
         Ok(())
     }

--- a/components/script/dom/domparser.rs
+++ b/components/script/dom/domparser.rs
@@ -61,9 +61,9 @@ impl DOMParserMethods<crate::DomTypeHolder> for DOMParser {
     /// <https://html.spec.whatwg.org/multipage/#dom-domparser-parsefromstring>
     fn ParseFromString(
         &self,
+        cx: &mut js::context::JSContext,
         s: TrustedHTMLOrString,
         ty: DOMParserBinding::SupportedType,
-        can_gc: CanGc,
     ) -> Fallible<DomRoot<Document>> {
         // Step 1. Let compliantString be the result of invoking the
         // Get Trusted Type compliant string algorithm with TrustedHTML,
@@ -72,7 +72,7 @@ impl DOMParserMethods<crate::DomTypeHolder> for DOMParser {
             self.window.as_global_scope(),
             s,
             "DOMParser parseFromString",
-            can_gc,
+            CanGc::from_cx(cx),
         )?;
         let url = self.window.get_url();
         let content_type = ty
@@ -107,7 +107,7 @@ impl DOMParserMethods<crate::DomTypeHolder> for DOMParser {
                     doc.has_trustworthy_ancestor_or_current_origin(),
                     doc.custom_element_reaction_stack(),
                     doc.creation_sandboxing_flag_set(),
-                    can_gc,
+                    CanGc::from_cx(cx),
                 );
                 // Step switch-1. Parse HTML from a string given document and compliantString.
                 ServoParser::parse_html_document(
@@ -116,7 +116,7 @@ impl DOMParserMethods<crate::DomTypeHolder> for DOMParser {
                     url,
                     None,
                     None,
-                    can_gc,
+                    CanGc::from_cx(cx),
                 );
                 document
             },
@@ -144,7 +144,7 @@ impl DOMParserMethods<crate::DomTypeHolder> for DOMParser {
                     doc.has_trustworthy_ancestor_or_current_origin(),
                     doc.custom_element_reaction_stack(),
                     doc.creation_sandboxing_flag_set(),
-                    can_gc,
+                    CanGc::from_cx(cx),
                 );
                 // Step switch-1. Create an XML parser parser, associated with document,
                 // and with XML scripting support disabled.
@@ -153,13 +153,13 @@ impl DOMParserMethods<crate::DomTypeHolder> for DOMParser {
                     Some(compliant_string),
                     url,
                     None,
-                    can_gc,
+                    CanGc::from_cx(cx),
                 );
                 document
             },
         };
         // Step 4. Return document.
-        document.set_ready_state(DocumentReadyState::Complete, can_gc);
+        document.set_ready_state(DocumentReadyState::Complete, CanGc::from_cx(cx));
         Ok(document)
     }
 }

--- a/components/script/dom/element.rs
+++ b/components/script/dom/element.rs
@@ -3587,7 +3587,11 @@ impl ElementMethods<crate::DomTypeHolder> for Element {
     }
 
     /// <https://html.spec.whatwg.org/multipage/#dom-element-sethtmlunsafe>
-    fn SetHTMLUnsafe(&self, html: TrustedHTMLOrString, can_gc: CanGc) -> ErrorResult {
+    fn SetHTMLUnsafe(
+        &self,
+        cx: &mut js::context::JSContext,
+        html: TrustedHTMLOrString,
+    ) -> ErrorResult {
         // Step 1. Let compliantHTML be the result of invoking the
         // Get Trusted Type compliant string algorithm with TrustedHTML,
         // this's relevant global object, html, "Element setHTMLUnsafe", and "script".
@@ -3595,17 +3599,17 @@ impl ElementMethods<crate::DomTypeHolder> for Element {
             &self.owner_global(),
             html,
             "Element setHTMLUnsafe",
-            can_gc,
+            CanGc::from_cx(cx),
         )?;
         // Step 2. Let target be this's template contents if this is a template element; otherwise this.
         let target = if let Some(template) = self.downcast::<HTMLTemplateElement>() {
-            DomRoot::upcast(template.Content(can_gc))
+            DomRoot::upcast(template.Content(CanGc::from_cx(cx)))
         } else {
             DomRoot::from_ref(self.upcast())
         };
 
         // Step 3. Unsafely set HTML given target, this, and compliantHTML
-        Node::unsafely_set_html(&target, self, html, can_gc);
+        Node::unsafely_set_html(&target, self, html, CanGc::from_cx(cx));
         Ok(())
     }
 
@@ -3643,7 +3647,11 @@ impl ElementMethods<crate::DomTypeHolder> for Element {
     }
 
     /// <https://html.spec.whatwg.org/multipage/#dom-element-innerhtml>
-    fn SetInnerHTML(&self, value: TrustedHTMLOrNullIsEmptyString, can_gc: CanGc) -> ErrorResult {
+    fn SetInnerHTML(
+        &self,
+        cx: &mut js::context::JSContext,
+        value: TrustedHTMLOrNullIsEmptyString,
+    ) -> ErrorResult {
         // Step 1: Let compliantString be the result of invoking the
         // Get Trusted Type compliant string algorithm with TrustedHTML,
         // this's relevant global object, the given value, "Element innerHTML", and "script".
@@ -3651,13 +3659,13 @@ impl ElementMethods<crate::DomTypeHolder> for Element {
             &self.owner_global(),
             value.convert(),
             "Element innerHTML",
-            can_gc,
+            CanGc::from_cx(cx),
         )?;
         // https://github.com/w3c/DOM-Parsing/issues/1
         let target = if let Some(template) = self.downcast::<HTMLTemplateElement>() {
             // Step 4: If context is a template element, then set context to
             // the template element's template contents (a DocumentFragment).
-            DomRoot::upcast(template.Content(can_gc))
+            DomRoot::upcast(template.Content(CanGc::from_cx(cx)))
         } else {
             // Step 2: Let context be this.
             DomRoot::from_ref(self.upcast())
@@ -3672,15 +3680,15 @@ impl ElementMethods<crate::DomTypeHolder> for Element {
                 .iter()
                 .any(|c| matches!(*c, b'&' | b'\0' | b'<' | b'\r'))
         {
-            return Node::SetTextContent(&target, Some(value), can_gc);
+            return Node::SetTextContent(&target, Some(value), CanGc::from_cx(cx));
         }
 
         // Step 3: Let fragment be the result of invoking the fragment parsing algorithm steps
         // with context and compliantString.
-        let frag = self.parse_fragment(value, can_gc)?;
+        let frag = self.parse_fragment(value, CanGc::from_cx(cx))?;
 
         // Step 5: Replace all with fragment within context.
-        Node::replace_all(Some(frag.upcast()), &target, can_gc);
+        Node::replace_all(Some(frag.upcast()), &target, CanGc::from_cx(cx));
         Ok(())
     }
 
@@ -3699,7 +3707,11 @@ impl ElementMethods<crate::DomTypeHolder> for Element {
     }
 
     /// <https://html.spec.whatwg.org/multipage/#dom-element-outerhtml>
-    fn SetOuterHTML(&self, value: TrustedHTMLOrNullIsEmptyString, can_gc: CanGc) -> ErrorResult {
+    fn SetOuterHTML(
+        &self,
+        cx: &mut js::context::JSContext,
+        value: TrustedHTMLOrNullIsEmptyString,
+    ) -> ErrorResult {
         // Step 1: Let compliantString be the result of invoking the
         // Get Trusted Type compliant string algorithm with TrustedHTML,
         // this's relevant global object, the given value, "Element outerHTML", and "script".
@@ -3707,7 +3719,7 @@ impl ElementMethods<crate::DomTypeHolder> for Element {
             &self.owner_global(),
             value.convert(),
             "Element outerHTML",
-            can_gc,
+            CanGc::from_cx(cx),
         )?;
         let context_document = self.owner_document();
         let context_node = self.upcast::<Node>();
@@ -3735,7 +3747,7 @@ impl ElementMethods<crate::DomTypeHolder> for Element {
                     ElementCreator::ScriptCreated,
                     CustomElementCreationMode::Synchronous,
                     None,
-                    can_gc,
+                    CanGc::from_cx(cx),
                 );
                 DomRoot::upcast(body_elem)
             },
@@ -3744,9 +3756,9 @@ impl ElementMethods<crate::DomTypeHolder> for Element {
 
         // Step 6: Let fragment be the result of invoking the
         // fragment parsing algorithm steps given parent and compliantString.
-        let frag = parent.parse_fragment(value, can_gc)?;
+        let frag = parent.parse_fragment(value, CanGc::from_cx(cx))?;
         // Step 7: Replace this with fragment within this's parent.
-        context_parent.ReplaceChild(frag.upcast(), context_node, can_gc)?;
+        context_parent.ReplaceChild(frag.upcast(), context_node, CanGc::from_cx(cx))?;
         Ok(())
     }
 
@@ -3908,9 +3920,9 @@ impl ElementMethods<crate::DomTypeHolder> for Element {
     /// <https://w3c.github.io/DOM-Parsing/#dom-element-insertadjacenthtml>
     fn InsertAdjacentHTML(
         &self,
+        cx: &mut js::context::JSContext,
         position: DOMString,
         text: TrustedHTMLOrString,
-        can_gc: CanGc,
     ) -> ErrorResult {
         // Step 1: Let compliantString be the result of invoking the
         // Get Trusted Type compliant string algorithm with TrustedHTML,
@@ -3919,7 +3931,7 @@ impl ElementMethods<crate::DomTypeHolder> for Element {
             &self.owner_global(),
             text,
             "Element insertAdjacentHTML",
-            can_gc,
+            CanGc::from_cx(cx),
         )?;
         let position = position.parse::<AdjacentPosition>()?;
 
@@ -3951,15 +3963,15 @@ impl ElementMethods<crate::DomTypeHolder> for Element {
         let context = Element::fragment_parsing_context(
             &context.owner_doc(),
             context.downcast::<Element>(),
-            can_gc,
+            CanGc::from_cx(cx),
         );
 
         // Step 5: Let fragment be the result of invoking the
         // fragment parsing algorithm steps with context and compliantString.
-        let fragment = context.parse_fragment(text, can_gc)?;
+        let fragment = context.parse_fragment(text, CanGc::from_cx(cx))?;
 
         // Step 6.
-        self.insert_adjacent(position, fragment.upcast(), can_gc)
+        self.insert_adjacent(position, fragment.upcast(), CanGc::from_cx(cx))
             .map(|_| ())
     }
 

--- a/components/script/dom/range.rs
+++ b/components/script/dom/range.rs
@@ -1113,8 +1113,8 @@ impl RangeMethods<crate::DomTypeHolder> for Range {
     /// <https://html.spec.whatwg.org/multipage/#dom-range-createcontextualfragment>
     fn CreateContextualFragment(
         &self,
+        cx: &mut js::context::JSContext,
         fragment: TrustedHTMLOrString,
-        can_gc: CanGc,
     ) -> Fallible<DomRoot<DocumentFragment>> {
         // Step 2. Let node be this's start node.
         //
@@ -1129,7 +1129,7 @@ impl RangeMethods<crate::DomTypeHolder> for Range {
             node.owner_window().upcast(),
             fragment,
             "Range createContextualFragment",
-            can_gc,
+            CanGc::from_cx(cx),
         )?;
 
         let owner_doc = node.owner_doc();
@@ -1145,10 +1145,11 @@ impl RangeMethods<crate::DomTypeHolder> for Range {
         };
 
         // Step 6. If element is null or all of the following are true:
-        let element = Element::fragment_parsing_context(&owner_doc, element.as_deref(), can_gc);
+        let element =
+            Element::fragment_parsing_context(&owner_doc, element.as_deref(), CanGc::from_cx(cx));
 
         // Step 7. Let fragment node be the result of invoking the fragment parsing algorithm steps with element and compliantString.
-        let fragment_node = element.parse_fragment(fragment, can_gc)?;
+        let fragment_node = element.parse_fragment(fragment, CanGc::from_cx(cx))?;
 
         // Step 8. For each script of fragment node's script element descendants:
         for node in fragment_node

--- a/components/script/dom/shadowroot.rs
+++ b/components/script/dom/shadowroot.rs
@@ -487,14 +487,18 @@ impl ShadowRootMethods<crate::DomTypeHolder> for ShadowRoot {
     }
 
     /// <https://html.spec.whatwg.org/multipage/#dom-shadowroot-innerhtml>
-    fn SetInnerHTML(&self, value: TrustedHTMLOrNullIsEmptyString, can_gc: CanGc) -> ErrorResult {
+    fn SetInnerHTML(
+        &self,
+        cx: &mut js::context::JSContext,
+        value: TrustedHTMLOrNullIsEmptyString,
+    ) -> ErrorResult {
         // Step 1. Let compliantString be the result of invoking the Get Trusted Type compliant string algorithm
         // with TrustedHTML, this's relevant global object, the given value, "ShadowRoot innerHTML", and "script".
         let value = TrustedHTML::get_trusted_script_compliant_string(
             &self.owner_global(),
             value.convert(),
             "ShadowRoot innerHTML",
-            can_gc,
+            CanGc::from_cx(cx),
         )?;
 
         // Step 2. Let context be this's host.
@@ -505,10 +509,10 @@ impl ShadowRootMethods<crate::DomTypeHolder> for ShadowRoot {
         //
         // NOTE: The spec doesn't strictly tell us to bail out here, but
         // we can't continue if parsing failed
-        let frag = context.parse_fragment(value, can_gc)?;
+        let frag = context.parse_fragment(value, CanGc::from_cx(cx))?;
 
         // Step 4. Replace all with fragment within this.
-        Node::replace_all(Some(frag.upcast()), self.upcast(), can_gc);
+        Node::replace_all(Some(frag.upcast()), self.upcast(), CanGc::from_cx(cx));
         Ok(())
     }
 
@@ -518,7 +522,11 @@ impl ShadowRootMethods<crate::DomTypeHolder> for ShadowRoot {
     }
 
     /// <https://html.spec.whatwg.org/multipage/#dom-shadowroot-sethtmlunsafe>
-    fn SetHTMLUnsafe(&self, value: TrustedHTMLOrString, can_gc: CanGc) -> ErrorResult {
+    fn SetHTMLUnsafe(
+        &self,
+        cx: &mut js::context::JSContext,
+        value: TrustedHTMLOrString,
+    ) -> ErrorResult {
         // Step 1. Let compliantHTML be the result of invoking the
         // Get Trusted Type compliant string algorithm with TrustedHTML,
         // this's relevant global object, html, "ShadowRoot setHTMLUnsafe", and "script".
@@ -526,13 +534,13 @@ impl ShadowRootMethods<crate::DomTypeHolder> for ShadowRoot {
             &self.owner_global(),
             value,
             "ShadowRoot setHTMLUnsafe",
-            can_gc,
+            CanGc::from_cx(cx),
         )?;
         // Step 2. Unsafely set HTMl given this, this's shadow host, and complaintHTML
         let target = self.upcast::<Node>();
         let context_element = self.Host();
 
-        Node::unsafely_set_html(target, &context_element, value, can_gc);
+        Node::unsafely_set_html(target, &context_element, value, CanGc::from_cx(cx));
         Ok(())
     }
 

--- a/components/script/script_thread.rs
+++ b/components/script/script_thread.rs
@@ -1883,7 +1883,7 @@ impl ScriptThread {
                 CanGc::from_cx(cx),
             ),
             ScriptThreadMessage::MediaSessionAction(pipeline_id, action) => {
-                self.handle_media_session_action(pipeline_id, action, CanGc::from_cx(cx))
+                self.handle_media_session_action(cx, pipeline_id, action)
             },
             ScriptThreadMessage::SendInputEvent(webview_id, id, event) => {
                 self.handle_input_event(webview_id, id, event)
@@ -4057,13 +4057,13 @@ impl ScriptThread {
 
     fn handle_media_session_action(
         &self,
+        cx: &mut js::context::JSContext,
         pipeline_id: PipelineId,
         action: MediaSessionActionType,
-        can_gc: CanGc,
     ) {
         if let Some(window) = self.documents.borrow().find_window(pipeline_id) {
             let media_session = window.Navigator().MediaSession();
-            media_session.handle_action(action, can_gc);
+            media_session.handle_action(cx, action);
         } else {
             warn!("No MediaSession for this pipeline ID");
         };

--- a/components/script_bindings/codegen/Bindings.conf
+++ b/components/script_bindings/codegen/Bindings.conf
@@ -38,7 +38,8 @@ DOMInterfaces = {
 
 'AudioContext': {
     'inRealms': ['Close', 'Suspend'],
-    'canGc':['CreateMediaStreamDestination', 'CreateMediaElementSource', 'CreateMediaStreamSource', 'CreateMediaStreamTrackSource', 'Suspend', 'Close'],
+    'cx': ['CreateMediaElementSource'],
+    'canGc':['CreateMediaStreamDestination', 'CreateMediaStreamSource', 'CreateMediaStreamTrackSource', 'Suspend', 'Close'],
 },
 
 'BaseAudioContext': {
@@ -192,7 +193,8 @@ DOMInterfaces = {
 
 'Document': {
     'additionalTraits': ["crate::interfaces::DocumentHelpers"],
-    'canGc': ['Close', 'CreateElement', 'CreateElementNS', 'ImportNode', 'ParseHTMLUnsafe', 'SetTitle', 'Write', 'Writeln', 'CreateEvent', 'CreateRange', 'Open', 'Open_', 'CreateComment', 'CreateAttribute', 'CreateAttributeNS', 'CreateDocumentFragment', 'CreateTextNode', 'CreateCDATASection', 'CreateProcessingInstruction', 'Prepend', 'Append', 'ReplaceChildren', 'SetBgColor', 'SetFgColor', 'Fonts', 'ExitFullscreen', 'CreateExpression', 'CreateNSResolver', 'Evaluate', 'StyleSheets', 'Implementation', 'GetElementsByTagName', 'GetElementsByTagNameNS', 'GetElementsByClassName', 'AdoptNode', 'CreateNodeIterator', 'SetBody', 'GetElementsByName', 'Images', 'Embeds', 'Plugins', 'Links', 'Forms', 'Scripts', 'Anchors', 'Applets', 'Children', 'GetSelection', 'NamedGetter', 'AdoptedStyleSheets', 'SetAdoptedStyleSheets', 'ExecCommand', 'QueryCommandEnabled'],
+    'canGc': ['CreateElement', 'CreateElementNS', 'ImportNode', 'SetTitle', 'CreateEvent', 'CreateRange', 'CreateComment', 'CreateAttribute', 'CreateAttributeNS', 'CreateDocumentFragment', 'CreateTextNode', 'CreateCDATASection', 'CreateProcessingInstruction', 'Prepend', 'Append', 'ReplaceChildren', 'SetBgColor', 'SetFgColor', 'Fonts', 'ExitFullscreen', 'CreateExpression', 'CreateNSResolver', 'Evaluate', 'StyleSheets', 'Implementation', 'GetElementsByTagName', 'GetElementsByTagNameNS', 'GetElementsByClassName', 'AdoptNode', 'CreateNodeIterator', 'SetBody', 'GetElementsByName', 'Images', 'Embeds', 'Plugins', 'Links', 'Forms', 'Scripts', 'Anchors', 'Applets', 'Children', 'GetSelection', 'NamedGetter', 'AdoptedStyleSheets', 'SetAdoptedStyleSheets', 'ExecCommand', 'QueryCommandEnabled'],
+    'cx': ['Close', 'Open', 'Open_', 'ParseHTMLUnsafe', 'Write', 'Writeln'],
 },
 
 'DissimilarOriginWindow': {
@@ -220,7 +222,7 @@ DOMInterfaces = {
 },
 
 'DOMParser': {
-    'canGc': ['ParseFromString'],
+    'cx': ['ParseFromString'],
 },
 
 'DOMPoint': {
@@ -252,8 +254,8 @@ DOMInterfaces = {
 },
 
 'Element': {
-    'cx': ['ToggleAttribute', 'SetAttribute', 'SetAttributeNS', 'SetAttributeNode', 'SetAttributeNodeNS', 'RemoveAttributeNS', 'RemoveAttributeNode'],
-    'canGc': ['SetHTMLUnsafe', 'SetInnerHTML', 'SetOuterHTML', 'InsertAdjacentHTML', 'GetClientRects', 'GetBoundingClientRect', 'InsertAdjacentText', 'SetId','SetClassName','Prepend','Append','ReplaceChildren','Before','After','ReplaceWith', 'SetRole', 'SetAriaAtomic', 'SetAriaAutoComplete', 'SetAriaBrailleLabel', 'SetAriaBrailleRoleDescription', 'SetAriaBusy', 'SetAriaChecked', 'SetAriaColCount', 'SetAriaColIndex', 'SetAriaColIndexText', 'SetAriaColSpan', 'SetAriaCurrent', 'SetAriaDescription', 'SetAriaDisabled', 'SetAriaExpanded', 'SetAriaHasPopup', 'SetAriaHidden', 'SetAriaInvalid', 'SetAriaKeyShortcuts', 'SetAriaLabel', 'SetAriaLevel', 'SetAriaLive', 'SetAriaModal', 'SetAriaMultiLine', 'SetAriaMultiSelectable', 'SetAriaOrientation', 'SetAriaPlaceholder', 'SetAriaPosInSet', 'SetAriaPressed','SetAriaReadOnly', 'SetAriaRelevant', 'SetAriaRequired', 'SetAriaRoleDescription', 'SetAriaRowCount', 'SetAriaRowIndex', 'SetAriaRowIndexText', 'SetAriaRowSpan', 'SetAriaSelected', 'SetAriaSetSize','SetAriaSort', 'SetAriaValueMax', 'SetAriaValueMin', 'SetAriaValueNow', 'SetAriaValueText', 'RequestFullscreen', 'GetHTML', 'GetInnerHTML', 'GetOuterHTML', 'ClassList', 'Attributes', 'GetElementsByTagName', 'GetElementsByTagNameNS', 'GetElementsByClassName', 'Children', 'Remove', 'InsertAdjacentElement', 'AttachShadow', 'RemoveAttribute'],
+    'cx': ['SetHTMLUnsafe', 'SetInnerHTML', 'SetOuterHTML', 'InsertAdjacentHTML', 'ToggleAttribute', 'SetAttribute', 'SetAttributeNS', 'SetAttributeNode', 'SetAttributeNodeNS', 'RemoveAttributeNS', 'RemoveAttributeNode'],
+    'canGc': ['GetClientRects', 'GetBoundingClientRect', 'InsertAdjacentText', 'SetId','SetClassName','Prepend','Append','ReplaceChildren','Before','After','ReplaceWith', 'SetRole', 'SetAriaAtomic', 'SetAriaAutoComplete', 'SetAriaBrailleLabel', 'SetAriaBrailleRoleDescription', 'SetAriaBusy', 'SetAriaChecked', 'SetAriaColCount', 'SetAriaColIndex', 'SetAriaColIndexText', 'SetAriaColSpan', 'SetAriaCurrent', 'SetAriaDescription', 'SetAriaDisabled', 'SetAriaExpanded', 'SetAriaHasPopup', 'SetAriaHidden', 'SetAriaInvalid', 'SetAriaKeyShortcuts', 'SetAriaLabel', 'SetAriaLevel', 'SetAriaLive', 'SetAriaModal', 'SetAriaMultiLine', 'SetAriaMultiSelectable', 'SetAriaOrientation', 'SetAriaPlaceholder', 'SetAriaPosInSet', 'SetAriaPressed','SetAriaReadOnly', 'SetAriaRelevant', 'SetAriaRequired', 'SetAriaRoleDescription', 'SetAriaRowCount', 'SetAriaRowIndex', 'SetAriaRowIndexText', 'SetAriaRowSpan', 'SetAriaSelected', 'SetAriaSetSize','SetAriaSort', 'SetAriaValueMax', 'SetAriaValueMin', 'SetAriaValueNow', 'SetAriaValueText', 'RequestFullscreen', 'GetHTML', 'GetInnerHTML', 'GetOuterHTML', 'ClassList', 'Attributes', 'GetElementsByTagName', 'GetElementsByTagNameNS', 'GetElementsByClassName', 'Children', 'Remove', 'InsertAdjacentElement', 'AttachShadow', 'RemoveAttribute'],
 },
 
 'ElementInternals': {
@@ -464,9 +466,10 @@ DOMInterfaces = {
 },
 
 'HTMLMediaElement': {
-    'canGc': ['AddTextTrack', 'AudioTracks', 'Buffered', 'Load', 'Pause', 'Play', 'Played', 'Seekable', 'SetSrcObject', 'SetCrossOrigin', 'TextTracks', 'VideoTracks'],
-    'inRealms': ['Play'],
+    'canGc': ['AddTextTrack', 'AudioTracks', 'Buffered', 'Played', 'Seekable', 'SetCrossOrigin', 'TextTracks', 'VideoTracks'],
+    'realm': ['Play'],
     'weakReferenceable': True,
+    'cx': ['SetSrcObject', 'Load', 'Pause'],
 },
 
 'HTMLMeterElement': {
@@ -580,6 +583,10 @@ DOMInterfaces = {
     'inRealms': ['GetUserMedia', 'GetClientRects', 'GetBoundingClientRect'],
 },
 
+'MediaElementAudioSourceNode': {
+    'cx': ['Constructor'],
+},
+
 'MediaQueryList': {
     'weakReferenceable': True,
 },
@@ -664,8 +671,9 @@ DOMInterfaces = {
 },
 
 'Range': {
-    'canGc': ['CloneContents', 'CloneRange', 'CreateContextualFragment', 'ExtractContents', 'SurroundContents', 'InsertNode', 'GetClientRects', 'GetBoundingClientRect'],
+    'canGc': ['CloneContents', 'CloneRange', 'ExtractContents', 'SurroundContents', 'InsertNode', 'GetClientRects', 'GetBoundingClientRect'],
     'weakReferenceable': True,
+    'cx': ['CreateContextualFragment'],
 },
 
 'Request': {
@@ -709,7 +717,8 @@ DOMInterfaces = {
 },
 
 'ShadowRoot': {
-    'canGc': ['SetHTMLUnsafe', 'SetInnerHTML', 'GetHTML', 'GetInnerHTML', 'AdoptedStyleSheets', 'SetAdoptedStyleSheets'],
+    'canGc': ['GetHTML', 'GetInnerHTML', 'AdoptedStyleSheets', 'SetAdoptedStyleSheets'],
+    'cx': ['SetHTMLUnsafe', 'SetInnerHTML'],
 },
 
 'StaticRange': {
@@ -835,8 +844,8 @@ DOMInterfaces = {
 },
 
 'XMLHttpRequest': {
-    'canGc': ['Abort', 'GetResponseXML', 'Response'],
-    'cx': ['Send'],
+    'canGc': ['Abort'],
+    'cx': ['Send', 'GetResponseXML', 'Response'],
 },
 
 'XPathEvaluator': {


### PR DESCRIPTION
split from https://github.com/servo/servo/pull/42635, some dom methods are also called from other function, which require passing down cx from many more places :(

Testing: Just refactor, but should be covered by WPT.
Part of #42638
