### PR TITLE
script: Preserve the order of entries when parsing an import map

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8273,6 +8273,7 @@ version = "1.0.149"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
 dependencies = [
+ "indexmap",
  "itoa",
  "memchr",
  "serde",

--- a/components/script/Cargo.toml
+++ b/components/script/Cargo.toml
@@ -128,7 +128,7 @@ script_traits = { workspace = true }
 sec1 = { workspace = true }
 selectors = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
-serde_json = { workspace = true }
+serde_json = { workspace = true, features = ["preserve_order"] }
 servo-media = { workspace = true }
 servo_arc = { workspace = true }
 servo_config = { path = "../config" }

--- a/components/script/dom/html/htmlscriptelement.rs
+++ b/components/script/dom/html/htmlscriptelement.rs
@@ -934,7 +934,6 @@ impl HTMLScriptElement {
                         ModuleOwner::Window(Trusted::new(self)),
                         Rc::clone(&text_rc),
                         base_url.clone(),
-                        can_gc,
                     );
                     let script = Script::ImportMap(ScriptOrigin::internal(
                         text_rc,

--- a/components/script/script_module.rs
+++ b/components/script/script_module.rs
@@ -1707,7 +1707,6 @@ pub(crate) fn parse_an_import_map_string(
     module_owner: ModuleOwner,
     input: Rc<DOMString>,
     base_url: ServoUrl,
-    can_gc: CanGc,
 ) -> Fallible<ImportMap> {
     // Step 1. Let parsed be the result of parsing a JSON string to an Infra value given input.
     let parsed: JsonValue = serde_json::from_str(&input.str())
@@ -1733,12 +1732,8 @@ pub(crate) fn parse_an_import_map_string(
         };
         // Step 4.2 Set sortedAndNormalizedImports to the result of sorting and
         // normalizing a module specifier map given parsed["imports"] and baseURL.
-        sorted_and_normalized_imports = sort_and_normalize_module_specifier_map(
-            &module_owner.global(),
-            imports,
-            &base_url,
-            can_gc,
-        );
+        sorted_and_normalized_imports =
+            sort_and_normalize_module_specifier_map(&module_owner.global(), imports, &base_url);
     }
 
     // Step 5. Let sortedAndNormalizedScopes be an empty ordered map.
@@ -1755,7 +1750,7 @@ pub(crate) fn parse_an_import_map_string(
         // Step 6.2 Set sortedAndNormalizedScopes to the result of sorting and
         // normalizing scopes given parsed["scopes"] and baseURL.
         sorted_and_normalized_scopes =
-            sort_and_normalize_scopes(&module_owner.global(), scopes, &base_url, can_gc)?;
+            sort_and_normalize_scopes(&module_owner.global(), scopes, &base_url)?;
     }
 
     // Step 7. Let normalizedIntegrity be an empty ordered map.
@@ -1772,7 +1767,7 @@ pub(crate) fn parse_an_import_map_string(
         // Step 8.2 Set normalizedIntegrity to the result of normalizing
         // a module integrity map given parsed["integrity"] and baseURL.
         normalized_integrity =
-            normalize_module_integrity_map(&module_owner.global(), integrity, &base_url, can_gc);
+            normalize_module_integrity_map(&module_owner.global(), integrity, &base_url);
     }
 
     // Step 9. If parsed's keys contains any items besides "imports", "scopes", or "integrity",
@@ -1802,7 +1797,6 @@ fn sort_and_normalize_module_specifier_map(
     global: &GlobalScope,
     original_map: &JsonMap<String, JsonValue>,
     base_url: &ServoUrl,
-    can_gc: CanGc,
 ) -> ModuleSpecifierMap {
     // Step 1. Let normalized be an empty ordered map.
     let mut normalized = ModuleSpecifierMap::new();
@@ -1812,7 +1806,7 @@ fn sort_and_normalize_module_specifier_map(
         // Step 2.1 Let normalized_specifier_key be the result of
         // normalizing a specifier key given specifier_key and base_url.
         let Some(normalized_specifier_key) =
-            normalize_specifier_key(global, specifier_key, base_url, can_gc)
+            normalize_specifier_key(global, specifier_key, base_url)
         else {
             // Step 2.2 If normalized_specifier_key is null, then continue.
             continue;
@@ -1885,7 +1879,6 @@ fn sort_and_normalize_scopes(
     global: &GlobalScope,
     original_map: &JsonMap<String, JsonValue>,
     base_url: &ServoUrl,
-    can_gc: CanGc,
 ) -> Fallible<IndexMap<ServoUrl, ModuleSpecifierMap>> {
     // Step 1. Let normalized be an empty ordered map.
     let mut normalized: IndexMap<ServoUrl, ModuleSpecifierMap> = IndexMap::new();
@@ -1921,12 +1914,8 @@ fn sort_and_normalize_scopes(
 
         // Step 2.5 Set normalized[normalizedScopePrefix] to the result of sorting and
         // normalizing a module specifier map given potentialSpecifierMap and baseURL.
-        let normalized_specifier_map = sort_and_normalize_module_specifier_map(
-            global,
-            potential_specifier_map,
-            base_url,
-            can_gc,
-        );
+        let normalized_specifier_map =
+            sort_and_normalize_module_specifier_map(global, potential_specifier_map, base_url);
         normalized.insert(normalized_scope_prefix, normalized_specifier_map);
     }
 
@@ -1941,7 +1930,6 @@ fn normalize_module_integrity_map(
     global: &GlobalScope,
     original_map: &JsonMap<String, JsonValue>,
     base_url: &ServoUrl,
-    _can_gc: CanGc,
 ) -> ModuleIntegrityMap {
     // Step 1. Let normalized be an empty ordered map.
     let mut normalized = ModuleIntegrityMap::new();
@@ -1989,7 +1977,6 @@ fn normalize_specifier_key(
     global: &GlobalScope,
     specifier_key: &str,
     base_url: &ServoUrl,
-    _can_gc: CanGc,
 ) -> Option<String> {
     // step 1. If specifierKey is the empty string, then:
     if specifier_key.is_empty() {

--- a/tests/wpt/meta/import-maps/data-driven/resolving.html.ini
+++ b/tests/wpt/meta/import-maps/data-driven/resolving.html.ini
@@ -3,9 +3,6 @@
 [resolving.html?resolving-null.json]
 
 [resolving.html?url-specifiers.json]
-  [URL-like specifiers: should use the last entry's address when URL-like specifiers parse to the same absolute URL: /test]
-    expected: FAIL
-
 
 [resolving.html?url-specifiers-schemes.json]
 


### PR DESCRIPTION
Unless the feature `preserve_order` is enabled, serde_json will sort the map's entries in an alphanumerical order.
The specification instead expect the entries to be visited by the order they are listed, a latter entry should replace a previous one when they are resolved to the same url.

I've also removed a couple of `CanGc` introduced in #37405, unless I've missed something there is not code that can trigger a GC.

Testing: A subtest now pass
Part of #37553 
