### PR TITLE
layout: Create a webrender stacking context for fragments with `transform-style: preserve-3d`

### DIFF
--- a/components/layout/display_list/stacking_context.rs
+++ b/components/layout/display_list/stacking_context.rs
@@ -594,12 +594,13 @@ impl StackingContext {
         // actually need to create a stacking context, just avoid creating one.
         let style = fragment.style();
         let effects = style.get_effects();
+        let transform_style = style.get_used_transform_style();
         if effects.filter.0.is_empty() &&
             effects.opacity == 1.0 &&
             effects.mix_blend_mode == ComputedMixBlendMode::Normal &&
             !style.has_effective_transform_or_perspective(FragmentFlags::empty()) &&
             style.clone_clip_path() == ClipPath::None &&
-            style.get_used_transform_style() == TransformStyle::Flat
+            transform_style == TransformStyle::Flat
         {
             return false;
         }
@@ -632,7 +633,7 @@ impl StackingContext {
             spatial_id,
             style.get_webrender_primitive_flags(),
             clip_chain_id,
-            style.get_used_transform_style().to_webrender(),
+            transform_style.to_webrender(),
             effects.mix_blend_mode.to_webrender(),
             &filters,
             &[], // filter_datas

--- a/components/layout/display_list/stacking_context.rs
+++ b/components/layout/display_list/stacking_context.rs
@@ -31,6 +31,7 @@ use style::values::computed::basic_shape::ClipPath;
 use style::values::computed::{ClipRectOrAuto, Length, TextDecorationLine};
 use style::values::generics::box_::{OverflowClipMarginBox, Perspective};
 use style::values::generics::transform::{self, GenericRotate, GenericScale, GenericTranslate};
+use style::values::specified::TransformStyle;
 use style::values::specified::box_::DisplayOutside;
 use style_traits::CSSPixel;
 use webrender_api::units::{LayoutPoint, LayoutRect, LayoutTransform, LayoutVector2D};
@@ -597,7 +598,8 @@ impl StackingContext {
             effects.opacity == 1.0 &&
             effects.mix_blend_mode == ComputedMixBlendMode::Normal &&
             !style.has_effective_transform_or_perspective(FragmentFlags::empty()) &&
-            style.clone_clip_path() == ClipPath::None
+            style.clone_clip_path() == ClipPath::None &&
+            style.get_used_transform_style() == TransformStyle::Flat
         {
             return false;
         }

--- a/tests/wpt/meta/css/css-transforms/3d-rendering-context-and-abspos.html.ini
+++ b/tests/wpt/meta/css/css-transforms/3d-rendering-context-and-abspos.html.ini
@@ -1,0 +1,2 @@
+[3d-rendering-context-and-abspos.html]
+  expected: FAIL

--- a/tests/wpt/meta/css/css-transforms/preserve3d-and-flattening-002.html.ini
+++ b/tests/wpt/meta/css/css-transforms/preserve3d-and-flattening-002.html.ini
@@ -1,2 +1,0 @@
-[preserve3d-and-flattening-002.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-transforms/preserve3d-and-flattening-003.html.ini
+++ b/tests/wpt/meta/css/css-transforms/preserve3d-and-flattening-003.html.ini
@@ -1,2 +1,0 @@
-[preserve3d-and-flattening-003.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-transforms/preserve3d-and-flattening-z-order-005.html.ini
+++ b/tests/wpt/meta/css/css-transforms/preserve3d-and-flattening-z-order-005.html.ini
@@ -1,2 +1,0 @@
-[preserve3d-and-flattening-z-order-005.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-transforms/preserve3d-and-flattening-z-order-006.html.ini
+++ b/tests/wpt/meta/css/css-transforms/preserve3d-and-flattening-z-order-006.html.ini
@@ -1,2 +1,0 @@
-[preserve3d-and-flattening-z-order-006.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-transforms/preserve3d-and-flattening-z-order-007.html.ini
+++ b/tests/wpt/meta/css/css-transforms/preserve3d-and-flattening-z-order-007.html.ini
@@ -1,2 +1,0 @@
-[preserve3d-and-flattening-z-order-007.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-transforms/preserve3d-and-flattening-z-order-008.html.ini
+++ b/tests/wpt/meta/css/css-transforms/preserve3d-and-flattening-z-order-008.html.ini
@@ -1,2 +1,0 @@
-[preserve3d-and-flattening-z-order-008.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-transforms/scrollable-hidden-3d-transform-z.html.ini
+++ b/tests/wpt/meta/css/css-transforms/scrollable-hidden-3d-transform-z.html.ini
@@ -1,2 +1,0 @@
-[scrollable-hidden-3d-transform-z.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-transforms/scrollable-scroll-3d-transform-z.html.ini
+++ b/tests/wpt/meta/css/css-transforms/scrollable-scroll-3d-transform-z.html.ini
@@ -1,2 +1,0 @@
-[scrollable-scroll-3d-transform-z.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-transforms/transform3d-sorting-001.html.ini
+++ b/tests/wpt/meta/css/css-transforms/transform3d-sorting-001.html.ini
@@ -1,2 +1,0 @@
-[transform3d-sorting-001.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-transforms/transform3d-sorting-004.html.ini
+++ b/tests/wpt/meta/css/css-transforms/transform3d-sorting-004.html.ini
@@ -1,0 +1,2 @@
+[transform3d-sorting-004.html]
+  expected: FAIL

--- a/tests/wpt/meta/css/css-transforms/transform3d-sorting-006.html.ini
+++ b/tests/wpt/meta/css/css-transforms/transform3d-sorting-006.html.ini
@@ -1,2 +1,0 @@
-[transform3d-sorting-006.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-transforms/ttwf-css-3d-polygon-cycle.html.ini
+++ b/tests/wpt/meta/css/css-transforms/ttwf-css-3d-polygon-cycle.html.ini
@@ -1,2 +1,0 @@
-[ttwf-css-3d-polygon-cycle.html]
-  expected: FAIL


### PR DESCRIPTION
Such elements already establish stacking contexts, but we don't tell webrender about them.

Two new failures appear, which I believe incorrectly passed before. We fail because we don't support the concept of a [3D rendering context](https://drafts.csswg.org/css-transforms-2/#3d-rendering-context). 

If I understand correctly then we act as if a 3D rendering context was the same as a stacking context, but elements in the same stacking context may use different 3D coordinate systems, see https://github.com/web-platform-tests/wpt/blob/1903a5a80470223d7117b91b3e4cda3d7c037f40/css/css-transforms/transform3d-sorting-004.html#L9-L14 for example.

Fixes https://github.com/servo/servo/issues/30474
Testing: New tests start to pass. 