### PR TITLE
servoshell: Add missing format string.

### DIFF
--- a/ports/servoshell/running_app_state.rs
+++ b/ports/servoshell/running_app_state.rs
@@ -456,7 +456,7 @@ impl RunningAppState {
 
     pub(crate) fn window_for_webview_id(&self, webview_id: WebViewId) -> Rc<ServoShellWindow> {
         self.maybe_window_for_webview_id(webview_id)
-            .expect(&format!("Looking for unexpected WebView: {webview_id:?}"))
+            .unwrap_or_else(|| panic!("Looking for unexpected WebView: {webview_id:?}"))
     }
 
     pub(crate) fn platform_window_for_webview_id(

--- a/ports/servoshell/running_app_state.rs
+++ b/ports/servoshell/running_app_state.rs
@@ -456,7 +456,7 @@ impl RunningAppState {
 
     pub(crate) fn window_for_webview_id(&self, webview_id: WebViewId) -> Rc<ServoShellWindow> {
         self.maybe_window_for_webview_id(webview_id)
-            .expect("Looking for unexpected WebView: {webview_id:?}")
+            .expect(format!("Looking for unexpected WebView: {webview_id:?}"))
     }
 
     pub(crate) fn platform_window_for_webview_id(

--- a/ports/servoshell/running_app_state.rs
+++ b/ports/servoshell/running_app_state.rs
@@ -456,7 +456,7 @@ impl RunningAppState {
 
     pub(crate) fn window_for_webview_id(&self, webview_id: WebViewId) -> Rc<ServoShellWindow> {
         self.maybe_window_for_webview_id(webview_id)
-            .expect(format!("Looking for unexpected WebView: {webview_id:?}"))
+            .expect(&format!("Looking for unexpected WebView: {webview_id:?}"))
     }
 
     pub(crate) fn platform_window_for_webview_id(


### PR DESCRIPTION
This message appeared in a backtrace without any format replacement taking place.

Testing: No tests for error messages.