### PR TITLE
Indexeddb: Move IDBFactory to global scope(away from specific globals like window and worker)

### DIFF
--- a/components/script/dom/window.rs
+++ b/components/script/dom/window.rs
@@ -298,7 +298,6 @@ pub(crate) struct Window {
     document: MutNullableDom<Document>,
     location: MutNullableDom<Location>,
     history: MutNullableDom<History>,
-    indexeddb: MutNullableDom<IDBFactory>,
     custom_element_registry: MutNullableDom<CustomElementRegistry>,
     performance: MutNullableDom<Performance>,
     #[no_trace]
@@ -1425,10 +1424,7 @@ impl WindowMethods<crate::DomTypeHolder> for Window {
 
     /// <https://w3c.github.io/IndexedDB/#factory-interface>
     fn IndexedDB(&self) -> DomRoot<IDBFactory> {
-        self.indexeddb.or_init(|| {
-            let global_scope = self.upcast::<GlobalScope>();
-            IDBFactory::new(global_scope, CanGc::note())
-        })
+        self.upcast::<GlobalScope>().get_indexeddb()
     }
 
     /// <https://html.spec.whatwg.org/multipage/#dom-window-customelements>
@@ -3772,7 +3768,6 @@ impl Window {
             navigator: Default::default(),
             location: Default::default(),
             history: Default::default(),
-            indexeddb: Default::default(),
             custom_element_registry: Default::default(),
             window_proxy: Default::default(),
             document: Default::default(),


### PR DESCRIPTION
Move IDBFactory to global scope(away from specific globals like window and worker)


Testing: no effect on WPT test.
part of https://github.com/servo/servo/issues/40983
