### PR TITLE
layout: Account `opacity` for marking `first-contentful-paint`

### DIFF
--- a/tests/wpt/meta/paint-timing/fcp-only/fcp-opacity-descendant.html.ini
+++ b/tests/wpt/meta/paint-timing/fcp-only/fcp-opacity-descendant.html.ini
@@ -1,3 +1,0 @@
-[fcp-opacity-descendant.html]
-  [First contentful paint fires due to its ancestor getting positive opacity.]
-    expected: FAIL

--- a/tests/wpt/meta/paint-timing/fcp-only/fcp-opacity.html.ini
+++ b/tests/wpt/meta/paint-timing/fcp-only/fcp-opacity.html.ini
@@ -1,3 +1,0 @@
-[fcp-opacity.html]
-  [First contentful paint fires due to opacity-revealed element.]
-    expected: FAIL

--- a/tests/wpt/meta/paint-timing/fcp-only/fcp-pseudo-element-opacity.html.ini
+++ b/tests/wpt/meta/paint-timing/fcp-only/fcp-pseudo-element-opacity.html.ini
@@ -1,3 +1,0 @@
-[fcp-pseudo-element-opacity.html]
-  [First contentful paint fires due to pseudo-element getting positive opacity.]
-    expected: FAIL


### PR DESCRIPTION
As per the spec opacity should be considered for `first-contentful-paint`

> An [element](https://dom.spec.whatwg.org/#concept-element) el is paintable when all of the following apply:
> 
>  - el and all of its ancestors' [used](https://www.w3.org/TR/css-cascade-5/#used-value) [opacity](https://www.w3.org/TR/css-color-3/#opacity) is greater than zero.

Testing: WPT Tests Passed
