### PR TITLE
script: Fire scroll event on visual viewport scroll

### DIFF
--- a/components/paint/webview_renderer.rs
+++ b/components/paint/webview_renderer.rs
@@ -919,7 +919,7 @@ impl WebViewRenderer {
 
         self.send_scroll_positions_to_layout_for_pipeline(root_pipeline_id, external_scroll_id);
 
-        if pinch_zoom_result == PinchZoomResult::DidNotPinchZoom {
+        if pinch_zoom_result == PinchZoomResult::DidPinchZoom {
             self.send_pinch_zoom_infos_to_script();
         }
 

--- a/components/script/dom/document.rs
+++ b/components/script/dom/document.rs
@@ -185,7 +185,9 @@ use crate::dom::touchevent::TouchEvent as DomTouchEvent;
 use crate::dom::touchlist::TouchList;
 use crate::dom::treewalker::TreeWalker;
 use crate::dom::trustedtypes::trustedhtml::TrustedHTML;
-use crate::dom::types::{HTMLCanvasElement, HTMLDialogElement, VisibilityStateEntry};
+use crate::dom::types::{
+    HTMLCanvasElement, HTMLDialogElement, VisibilityStateEntry, VisualViewport,
+};
 use crate::dom::uievent::UIEvent;
 use crate::dom::virtualmethods::vtable_for;
 use crate::dom::websocket::WebSocket;
@@ -582,7 +584,10 @@ pub(crate) struct Document {
     /// Cached frozen array of [`Self::adopted_stylesheets`]
     #[ignore_malloc_size_of = "mozjs"]
     adopted_stylesheets_frozen_types: CachedFrozenArray,
-    /// <https://drafts.csswg.org/cssom-view/#document-pending-scroll-event-targets>
+    /// <https://drafts.csswg.org/cssom-view/#document-pending-scroll-events>
+    // TODO(31665): Instead of having separate list for `scroll` and `scrollend` event, the updated spec
+    //              make it store both the event target and the event type. Need to update this along with
+    //              the implementation of `scrollend`.
     pending_scroll_event_targets: DomRefCell<Vec<Dom<EventTarget>>>,
     /// Other reasons that a rendering update might be required for this [`Document`].
     rendering_update_reasons: Cell<RenderingUpdateReason>,
@@ -1734,7 +1739,7 @@ impl Document {
                 // Step 2.1
                 // > If target is a Document, fire an event named scroll that bubbles at target.
                 target.fire_bubbling_event(Atom::from("scroll"), can_gc);
-            } else if target.downcast::<Element>().is_some() {
+            } else {
                 // Step 2.2
                 // > Otherwise, fire an event named scroll at target.
                 target.fire_event(Atom::from("scroll"), can_gc);
@@ -1800,6 +1805,29 @@ impl Document {
 
         // Step 4.
         // > Append the element to doc’s pending scroll event targets.
+        self.pending_scroll_event_targets
+            .borrow_mut()
+            .push(Dom::from_ref(target));
+    }
+
+    /// From <https://drafts.csswg.org/cssom-view/#scrolling-events>:
+    /// > Whenever a visual viewport gets scrolled (whether in response to user interaction or by an
+    /// > API), the user agent must run these steps:
+    pub(crate) fn handle_visual_viewport_scroll_event(&self, visual_viewport: &VisualViewport) {
+        // Step 3.
+        // > If (vv, "scroll") is already in doc’s pending scroll events, abort these steps.
+        let target = visual_viewport.upcast::<EventTarget>();
+        if self
+            .pending_scroll_event_targets
+            .borrow()
+            .iter()
+            .any(|other_target| *other_target == target)
+        {
+            return;
+        }
+
+        // Step 4.
+        // > Append (vv, "scroll") to doc’s pending scroll events.
         self.pending_scroll_event_targets
             .borrow_mut()
             .push(Dom::from_ref(target));

--- a/components/script/dom/document.rs
+++ b/components/script/dom/document.rs
@@ -586,8 +586,8 @@ pub(crate) struct Document {
     adopted_stylesheets_frozen_types: CachedFrozenArray,
     /// <https://drafts.csswg.org/cssom-view/#document-pending-scroll-events>
     // TODO(31665): Instead of having separate list for `scroll` and `scrollend` event, the updated spec
-    //              make it store both the event target and the event type. Need to update this along with
-    //              the implementation of `scrollend`.
+    // make it store both the event target and the event type. Need to update this along with
+    // the implementation of `scrollend`.
     pending_scroll_event_targets: DomRefCell<Vec<Dom<EventTarget>>>,
     /// Other reasons that a rendering update might be required for this [`Document`].
     rendering_update_reasons: Cell<RenderingUpdateReason>,
@@ -1814,6 +1814,12 @@ impl Document {
     /// > Whenever a visual viewport gets scrolled (whether in response to user interaction or by an
     /// > API), the user agent must run these steps:
     pub(crate) fn handle_visual_viewport_scroll_event(&self, visual_viewport: &VisualViewport) {
+        // Step 1.
+        // > Let vv be the VisualViewport object that was scrolled.
+        // Step 2.
+        // > Let doc be vv’s associated document.
+        // Both of the variables are being passed as parameters.
+
         // Step 3.
         // > If (vv, "scroll") is already in doc’s pending scroll events, abort these steps.
         let target = visual_viewport.upcast::<EventTarget>();

--- a/components/script/dom/window.rs
+++ b/components/script/dom/window.rs
@@ -3303,7 +3303,10 @@ impl Window {
         if changes.intersects(VisualViewportChanges::DimensionChanged) {
             self.has_changed_visual_viewport_dimension.set(true);
         }
-        // TODO(stevennovaryo): additionally handle the visual viewport scroll event here
+        if changes.intersects(VisualViewportChanges::OffsetChanged) {
+            self.Document()
+                .handle_visual_viewport_scroll_event(&visual_viewport);
+        }
     }
 
     /// Get the theme of this [`Window`].

--- a/components/servo/tests/webview.rs
+++ b/components/servo/tests/webview.rs
@@ -19,13 +19,13 @@ use servo::{
     ContextMenuAction, ContextMenuElementInformation, ContextMenuElementInformationFlags,
     ContextMenuItem, CreateNewWebViewRequest, Cursor, EmbedderControl, InputEvent, InputMethodType,
     JSValue, LoadStatus, MouseButton, MouseButtonAction, MouseButtonEvent, MouseLeftViewportEvent,
-    MouseMoveEvent, RenderingContext, SimpleDialog, Theme, WebView, WebViewBuilder,
-    WebViewDelegate,
+    MouseMoveEvent, RenderingContext, Scroll, SimpleDialog, Theme, WebView, WebViewBuilder,
+    WebViewDelegate, WebViewPoint, WebViewVector,
 };
 use servo_config::prefs::Preferences;
 use servo_url::ServoUrl;
 use url::Url;
-use webrender_api::units::{DeviceIntSize, DevicePoint};
+use webrender_api::units::{DeviceIntSize, DevicePoint, DeviceVector2D};
 
 use crate::common::{
     ServoTest, WebViewDelegateImpl, click_at_point, evaluate_javascript,
@@ -846,28 +846,43 @@ fn test_pinch_zoom_update_dom_visual_viewport() {
         .build();
 
     show_webview_and_wait_for_rendering_to_be_ready(&servo_test, &webview, &delegate);
-    let eval_visual_viewport = |attr: &str| {
-        evaluate_javascript(
-            &servo_test,
-            webview.clone(),
-            format!("window.visualViewport.{}", attr),
-        )
+    let eval_visual_viewport = |attr: &str| match evaluate_javascript(
+        &servo_test,
+        webview.clone(),
+        format!("window.visualViewport.{}", attr),
+    ) {
+        Ok(JSValue::Number(num)) => Some(num),
+        _ => None,
     };
 
     // Default value of the DOM visual viewport is initialized correctly.
-    assert_eq!(eval_visual_viewport("scale"), Ok(JSValue::Number(1.)));
-    assert_eq!(eval_visual_viewport("width"), Ok(JSValue::Number(500.)));
-    assert_eq!(eval_visual_viewport("height"), Ok(JSValue::Number(500.)));
-    assert_eq!(eval_visual_viewport("offsetLeft"), Ok(JSValue::Number(0.)));
-    assert_eq!(eval_visual_viewport("offsetTop"), Ok(JSValue::Number(0.)));
+    assert_eq!(eval_visual_viewport("scale"), Some(1.));
+    assert_eq!(eval_visual_viewport("width"), Some(500.));
+    assert_eq!(eval_visual_viewport("height"), Some(500.));
+    assert_eq!(eval_visual_viewport("offsetLeft"), Some(0.));
+    assert_eq!(eval_visual_viewport("offsetTop"), Some(0.));
 
     webview.pinch_zoom(5., DevicePoint::new(100., 100.));
     wait_for_webview_scene_to_be_up_to_date(&servo_test, &webview);
 
-    // The visual viewport dimension is correct after a pinch zoom.
-    assert_eq!(eval_visual_viewport("scale"), Ok(JSValue::Number(5.)));
-    assert_eq!(eval_visual_viewport("width"), Ok(JSValue::Number(100.)));
-    assert_eq!(eval_visual_viewport("height"), Ok(JSValue::Number(100.)));
-    assert_eq!(eval_visual_viewport("offsetLeft"), Ok(JSValue::Number(80.)));
-    assert_eq!(eval_visual_viewport("offsetTop"), Ok(JSValue::Number(80.)));
+    // The visual viewport size and offset is correct after a pinch zoom.
+    assert_eq!(eval_visual_viewport("scale"), Some(5.));
+    assert_eq!(eval_visual_viewport("width"), Some(100.));
+    assert_eq!(eval_visual_viewport("height"), Some(100.));
+    assert_eq!(eval_visual_viewport("offsetLeft"), Some(80.));
+    assert_eq!(eval_visual_viewport("offsetTop"), Some(80.));
+
+    // Note that the scroll vector will be affected by the pinch zoom scale.
+    webview.notify_scroll_event(
+        Scroll::Delta(WebViewVector::Device(DeviceVector2D::new(100., 100.))),
+        WebViewPoint::Device(DevicePoint::zero()),
+    );
+    wait_for_webview_scene_to_be_up_to_date(&servo_test, &webview);
+
+    // The visual viewport size and offset is correct after the scroll event.
+    assert_eq!(eval_visual_viewport("scale"), Some(5.));
+    assert_eq!(eval_visual_viewport("width"), Some(100.));
+    assert_eq!(eval_visual_viewport("height"), Some(100.));
+    assert_eq!(eval_visual_viewport("offsetLeft"), Some(100.));
+    assert_eq!(eval_visual_viewport("offsetTop"), Some(100.));
 }

--- a/components/servo/tests/webview.rs
+++ b/components/servo/tests/webview.rs
@@ -846,12 +846,12 @@ fn test_pinch_zoom_update_dom_visual_viewport() {
         .build();
 
     show_webview_and_wait_for_rendering_to_be_ready(&servo_test, &webview, &delegate);
-    let eval_visual_viewport = |attr: &str| match evaluate_javascript(
+    let eval_visual_viewport = |attribute: &str| match evaluate_javascript(
         &servo_test,
         webview.clone(),
-        format!("window.visualViewport.{}", attr),
+        format!("window.visualViewport.{}", attribute),
     ) {
-        Ok(JSValue::Number(num)) => Some(num),
+        Ok(JSValue::Number(number)) => Some(number),
         _ => None,
     };
 


### PR DESCRIPTION
On visual viewport scroll, fire the scroll event to the `VisualViewport` instances. Incidentaly, fix a bug where the pinch zoom update should be propagated to the script.

Testing: New unit test and manual WPT.
