### PR TITLE
fonts: Use the system font API to get a fallback on macOS

### DIFF
--- a/components/fonts/platform/macos/font_list.rs
+++ b/components/fonts/platform/macos/font_list.rs
@@ -35,7 +35,7 @@ where
     }
 }
 
-fn font_template_for_local_font_descriptor(
+pub(crate) fn font_template_for_local_font_descriptor(
     family_descriptor: CFRetained<CTFontDescriptor>,
 ) -> Option<FontTemplate> {
     let url = unsafe {


### PR DESCRIPTION
As a last resort, as the system font API to find a suitable fallback
font on macOS. This allows macOS to use the fonts that are found in the
`/System/Library/Fonts/Supplemental` directory, which normally aren't
available. This is currently used as a last resort because these fonts
cannot currently be shared between font groups. A future change will try
to make this possible and prefer this API to the old system font lists.
For now, this allows text to render in exchange for a bit more memory
usage.

This fixes the rendering of Adlam and many other scripts on macOS.

Testing: WPT tests are not currently run for macOS, but I've verified that this
improves rendering of Adlam and, in general, in the `alluni.txt` testcase.
Fixes: #38403. This is part of #41426.

