### PR TITLE
script: use `&mut JSContext` in `DissimilarOriginWindowMethods`

### DIFF
--- a/components/script_bindings/codegen/Bindings.conf
+++ b/components/script_bindings/codegen/Bindings.conf
@@ -198,7 +198,8 @@ DOMInterfaces = {
 },
 
 'DissimilarOriginWindow': {
-    'canGc': ['Location']
+    'canGc': ['Location'],
+    'cx': ['PostMessage', 'PostMessage_', 'SetOpener', 'Opener']
 },
 
 'DocumentFragment': {


### PR DESCRIPTION
Replace `crate::script_runtime::JSContext` with `js::context::JSContext` in:
- `DissimilarOriginWindowMethods::PostMessage`
- `DissimilarOriginWindowMethods::SetOpener`
- `DissimilarOriginWindowMethods::Opener`

Testing: Builds and runs locally. WPT [test passed](https://github.com/onsah/servo/actions/runs/22342635066)

Fixes: part of https://github.com/servo/servo/issues/42347