### PR TITLE
script: Implement efficient TreeIterator without rooting when possible

### DIFF
--- a/components/script/dom/bindings/root.rs
+++ b/components/script/dom/bindings/root.rs
@@ -29,7 +29,7 @@ use std::default::Default;
 use std::hash::{Hash, Hasher};
 use std::{mem, ptr};
 
-use js::context::JSContext;
+use js::context::NoGC;
 use js::jsapi::{Heap, JSObject, JSTracer, Value};
 use js::rust::HandleValue;
 use layout_api::TrustedNodeAddress;
@@ -271,7 +271,7 @@ impl<T: DomObject> MutNullableDom<T> {
     }
 
     /// Get the `DomObject` without rooting it. You need to make sure that no Gc takes place.
-    pub(crate) unsafe fn get_unsafe(&self, _cx: &JSContext) -> Option<Dom<T>> {
+    pub(crate) unsafe fn get_unsafe(&self, _no_gc: &NoGC) -> Option<Dom<T>> {
         assert_in_script();
         unsafe { ptr::read(self.ptr.get()).map(|o| Dom::from_ref(&*o)) }
     }

--- a/components/script/dom/bindings/root.rs
+++ b/components/script/dom/bindings/root.rs
@@ -269,6 +269,11 @@ impl<T: DomObject> MutNullableDom<T> {
         unsafe { ptr::read(self.ptr.get()).map(|o| DomRoot::from_ref(&*o)) }
     }
 
+    pub(crate) fn get_unsafe(&self) -> Option<Dom<T>> {
+        assert_in_script();
+        unsafe { ptr::read(self.ptr.get()).map(|o| Dom::from_ref(&*o)) }
+    }
+
     /// Set this `MutNullableDom` to the given value.
     pub(crate) fn set(&self, val: Option<&T>) {
         assert_in_script();

--- a/components/script/dom/bindings/root.rs
+++ b/components/script/dom/bindings/root.rs
@@ -27,6 +27,7 @@
 use std::cell::{OnceCell, UnsafeCell};
 use std::default::Default;
 use std::hash::{Hash, Hasher};
+use std::ops::Deref;
 use std::{mem, ptr};
 
 use js::context::NoGC;
@@ -219,6 +220,33 @@ pub(crate) fn assert_in_layout() {
     debug_assert!(thread_state::get().is_layout());
 }
 
+/// A struct to make Unrooted Dom objects work. By taking a no_gc as reference, we ensure that the lifetime of this object
+/// is bounded by the lifetime of NoGC which enforces no gc happening.
+#[cfg_attr(crown, crown::unrooted_must_root_lint::allow_unrooted_interior)]
+pub(crate) struct UnrootedDom<'a, T: DomObject> {
+    inner: Dom<T>,
+    _no_gc: &'a NoGC,
+}
+
+impl<'a, T: DomObject> UnrootedDom<'a, T> {
+    /// Construct an `UnrootedDom` with the lifetime of `NoGC`. This is safe, as `NoGC` implies no garbage collection will happen
+    #[cfg_attr(crown, expect(crown::unrooted_must_root))]
+    pub(crate) fn from_dom(object: Dom<T>, no_gc: &'a NoGC) -> UnrootedDom<'a, T> {
+        UnrootedDom {
+            inner: object,
+            _no_gc: no_gc,
+        }
+    }
+}
+
+impl<'a, T: DomObject> Deref for UnrootedDom<'a, T> {
+    type Target = Dom<T>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.inner
+    }
+}
+
 /// A holder that provides interior mutability for GC-managed values such as
 /// `Dom<T>`, with nullability represented by an enclosing Option wrapper.
 /// Essentially a `Cell<Option<Dom<T>>>`, but safer.
@@ -270,10 +298,17 @@ impl<T: DomObject> MutNullableDom<T> {
         unsafe { ptr::read(self.ptr.get()).map(|o| DomRoot::from_ref(&*o)) }
     }
 
-    /// Get the `DomObject` without rooting it. You need to make sure that no Gc takes place.
-    pub(crate) unsafe fn get_unsafe(&self, _no_gc: &NoGC) -> Option<Dom<T>> {
+    /// Get the `DomObject` without rooting it. Constructing an UnrootedDom. This is safe
+    /// as we take a reference to NoGC and bound the lifetime by NoGC bound. This implies that
+    /// while the `UnrootedDom` is alive we do not have a GC run.
+    #[cfg_attr(crown, expect(crown::unrooted_must_root))]
+    pub(crate) fn get_unrooted<'a>(&self, no_gc: &'a NoGC) -> Option<UnrootedDom<'a, T>> {
         assert_in_script();
-        unsafe { ptr::read(self.ptr.get()).map(|o| Dom::from_ref(&*o)) }
+        let ptr = unsafe { ptr::read(self.ptr.get()) };
+        ptr.map(|o| Dom::from_ref(&*o)).map(|dom| UnrootedDom {
+            inner: dom,
+            _no_gc: no_gc,
+        })
     }
 
     /// Set this `MutNullableDom` to the given value.

--- a/components/script/dom/bindings/root.rs
+++ b/components/script/dom/bindings/root.rs
@@ -29,6 +29,7 @@ use std::default::Default;
 use std::hash::{Hash, Hasher};
 use std::{mem, ptr};
 
+use js::context::JSContext;
 use js::jsapi::{Heap, JSObject, JSTracer, Value};
 use js::rust::HandleValue;
 use layout_api::TrustedNodeAddress;
@@ -269,7 +270,8 @@ impl<T: DomObject> MutNullableDom<T> {
         unsafe { ptr::read(self.ptr.get()).map(|o| DomRoot::from_ref(&*o)) }
     }
 
-    pub(crate) fn get_unsafe(&self) -> Option<Dom<T>> {
+    /// Get the `DomObject` without rooting it. You need to make sure that no Gc takes place.
+    pub(crate) unsafe fn get_unsafe(&self, _cx: &JSContext) -> Option<Dom<T>> {
         assert_in_script();
         unsafe { ptr::read(self.ptr.get()).map(|o| Dom::from_ref(&*o)) }
     }

--- a/components/script/dom/document.rs
+++ b/components/script/dom/document.rs
@@ -6351,7 +6351,7 @@ impl DocumentMethods<crate::DomTypeHolder> for Document {
         // Step 9
         for node in self
             .upcast::<Node>()
-            .traverse_preorder_efficient_gc(ShadowIncluding::Yes, cx)
+            .traverse_preorder(ShadowIncluding::Yes)
         {
             node.upcast::<EventTarget>().remove_all_listeners();
         }

--- a/components/script/dom/document.rs
+++ b/components/script/dom/document.rs
@@ -6351,7 +6351,7 @@ impl DocumentMethods<crate::DomTypeHolder> for Document {
         // Step 9
         for node in self
             .upcast::<Node>()
-            .traverse_preorder(ShadowIncluding::Yes)
+            .traverse_preorder_non_rooting(cx.no_gc(), ShadowIncluding::Yes)
         {
             node.upcast::<EventTarget>().remove_all_listeners();
         }

--- a/components/script/dom/document.rs
+++ b/components/script/dom/document.rs
@@ -6351,7 +6351,7 @@ impl DocumentMethods<crate::DomTypeHolder> for Document {
         // Step 9
         for node in self
             .upcast::<Node>()
-            .traverse_preorder(ShadowIncluding::Yes)
+            .traverse_preorder_efficient_gc(ShadowIncluding::Yes, cx)
         {
             node.upcast::<EventTarget>().remove_all_listeners();
         }

--- a/components/script/dom/node.rs
+++ b/components/script/dom/node.rs
@@ -9,7 +9,6 @@ use std::cell::{Cell, LazyCell, UnsafeCell};
 use std::default::Default;
 use std::f64::consts::PI;
 use std::marker::PhantomData;
-use std::ops::Deref;
 use std::slice::from_ref;
 use std::{cmp, fmt, iter};
 
@@ -2282,67 +2281,15 @@ impl Iterator for TreeIterator {
     }
 }
 
-#[derive(Clone)]
-#[cfg_attr(crown, crown::unrooted_must_root_lint::allow_unrooted_interior)]
-/// Either a DomRoot or a Dom. This type should only be constructed while extreme care is taken.
-/// We allow unrooted interior because we will make sure in `EfficientTreeIterator` that only methods that
-/// do not use Gc will be used by capturing a `&JSContext`.
-pub(crate) enum DomNodeVariant {
-    Gc(DomRoot<Node>),
-    NonGc(Dom<Node>),
-}
-
-impl DomNodeVariant {
-    /// Returns the rooted version of the interior.
-    pub(crate) fn rooted(self) -> DomRoot<Node> {
-        match self {
-            DomNodeVariant::Gc(root) => root,
-            DomNodeVariant::NonGc(dom) => DomRoot::from_ref(&dom),
-        }
-    }
-}
-
-impl Deref for DomNodeVariant {
-    type Target = Node;
-
-    fn deref(&self) -> &Self::Target {
-        match self {
-            DomNodeVariant::Gc(root) => root,
-            DomNodeVariant::NonGc(dom) => dom,
-        }
-    }
-}
-
-impl AsRef<Node> for DomNodeVariant {
-    fn as_ref(&self) -> &Node {
-        match self {
-            DomNodeVariant::Gc(root) => root,
-            DomNodeVariant::NonGc(dom) => dom,
-        }
-    }
-}
-
-impl From<DomRoot<Node>> for DomNodeVariant {
-    fn from(value: DomRoot<Node>) -> Self {
-        DomNodeVariant::Gc(value)
-    }
-}
-
-impl From<Dom<Node>> for DomNodeVariant {
-    fn from(value: Dom<Node>) -> Self {
-        DomNodeVariant::NonGc(value)
-    }
-}
-
 /// An efficient TreeIterator.
 /// Normally we need to root every `Node` we come across as we do not know if we will have a Gc pause.
 /// via a `&JSContext` to not root the required children. Taking a &JSContext ensures that we will never have
 /// a method needing `&mut JSContext`, hence, no Gc is happening while this is alive.
+#[cfg_attr(crown, crown::unrooted_must_root_lint::allow_unrooted_interior)]
 pub(crate) struct EfficientTreeIterator<'a, 'b> {
-    current: Option<DomNodeVariant>,
+    current: Option<Dom<Node>>,
     depth: usize,
     shadow_including: bool,
-    use_gc_methods: bool,
     /// This is unused and only used to make sure you give us the right JSContext.
     js_context: &'a JSContext,
     phantom: PhantomData<&'b Node>,
@@ -2358,17 +2305,16 @@ where
         cx: &'b JSContext,
     ) -> EfficientTreeIterator<'a, 'b> {
         EfficientTreeIterator {
-            current: Some(Dom::from_ref(root).into()),
+            current: Some(Dom::from_ref(root)),
             depth: 0,
             shadow_including: shadow_including == ShadowIncluding::Yes,
-            use_gc_methods: true,
             js_context: cx,
             phantom: PhantomData,
         }
     }
 
     #[expect(unsafe_code)]
-    pub(crate) fn next_skipping_children(&mut self) -> Option<DomNodeVariant> {
+    pub(crate) fn next_skipping_children(&mut self) -> Option<Dom<Node>> {
         let current = self.current.take()?;
 
         let iter = current.inclusive_ancestors(if self.shadow_including {
@@ -2382,43 +2328,28 @@ where
                 break;
             }
 
-            if self.use_gc_methods {
-                if let Some(next_sibling) = ancestor.GetNextSibling() {
-                    self.current = Some(next_sibling.into());
-                    return Some(current);
-                }
-            } else {
-                /// SAFETY: Using unsafe methods is ok, as we have a reference to a JSContext, hence, disallowing any mutable reference which would imply Gc happening.
-                let next_sibling_option =
-                    unsafe { ancestor.get_next_sibling_unsafe(self.js_context) };
+            // SAFETY: Using unsafe methods is ok, as we have a reference to a JSContext, hence, disallowing any mutable reference which would imply Gc happening.
+            let next_sibling_option = unsafe { ancestor.get_next_sibling_unsafe(self.js_context) };
 
-                if let Some(next_sibling) = next_sibling_option {
-                    self.current = Some(next_sibling.into());
-                    return Some(current);
-                }
+            if let Some(next_sibling) = next_sibling_option {
+                self.current = Some(next_sibling.into());
+                return Some(current);
             }
 
             if let Some(shadow_root) = ancestor.downcast::<ShadowRoot>() {
                 // Shadow roots don't have sibling, so after we're done traversing
                 // one we jump to the first child of the host
-                if self.use_gc_methods {
-                    if let Some(child) = shadow_root.Host().upcast::<Node>().GetFirstChild() {
-                        self.current = Some(child.into());
-                        return Some(current);
-                    }
-                } else {
-                    /// SAFETY: Using unsafe methods is ok, as we have a reference to a JSContext, hence, disallowing any mutable reference which would imply Gc happening.
-                    let child_option = unsafe {
-                        shadow_root
-                            .Host()
-                            .upcast::<Node>()
-                            .get_first_child_unsafe(&self.js_context)
-                    };
+                // SAFETY: Using unsafe methods is ok, as we have a reference to a JSContext, hence, disallowing any mutable reference which would imply Gc happening.
+                let child_option = unsafe {
+                    shadow_root
+                        .Host()
+                        .upcast::<Node>()
+                        .get_first_child_unsafe(&self.js_context)
+                };
 
-                    if let Some(child) = child_option {
-                        self.current = Some(child.into());
-                        return Some(current);
-                    }
+                if let Some(child) = child_option {
+                    self.current = Some(child.into());
+                    return Some(current);
                 }
             }
             self.depth -= 1;
@@ -2433,40 +2364,32 @@ impl<'a, 'b> Iterator for EfficientTreeIterator<'a, 'b>
 where
     'b: 'a,
 {
-    type Item = DomNodeVariant;
+    type Item = Dom<Node>;
 
     /// <https://dom.spec.whatwg.org/#concept-tree-order>
     /// <https://dom.spec.whatwg.org/#concept-shadow-including-tree-order>
     #[expect(unsafe_code)]
-    fn next(&mut self) -> Option<DomNodeVariant> {
+    fn next(&mut self) -> Option<Dom<Node>> {
         let current = self.current.take()?;
 
         // Handle a potential shadow root on the element
         if let Some(element) = current.downcast::<Element>() {
             if let Some(shadow_root) = element.shadow_root() {
                 if self.shadow_including {
-                    self.current = Some(DomRoot::from_ref(shadow_root.upcast::<Node>()).into());
+                    self.current = Some(Dom::from_ref(shadow_root.upcast::<Node>()));
                     self.depth += 1;
                     return Some(current);
                 }
             }
         }
 
-        if self.use_gc_methods {
-            if let Some(first_child) = current.GetFirstChild() {
-                self.current = Some(first_child.into());
-                self.depth += 1;
-                return Some(current);
-            };
-        } else {
-            /// SAFETY: Using unsafe methods is ok, as we have a reference to a JSContext, hence, disallowing any mutable reference which would imply Gc happening.
-            let first_child_option = unsafe { current.get_first_child_unsafe(self.js_context) };
-            if let Some(first_child) = first_child_option {
-                self.current = Some(first_child.into());
-                self.depth += 1;
-                return Some(current);
-            };
-        }
+        // SAFETY: Using unsafe methods is ok, as we have a reference to a JSContext, hence, disallowing any mutable reference which would imply Gc happening.
+        let first_child_option = unsafe { current.get_first_child_unsafe(self.js_context) };
+        if let Some(first_child) = first_child_option {
+            self.current = Some(first_child.into());
+            self.depth += 1;
+            return Some(current);
+        };
 
         self.next_skipping_children()
     }

--- a/components/script/dom/node.rs
+++ b/components/script/dom/node.rs
@@ -2332,7 +2332,7 @@ where
             let next_sibling_option = unsafe { ancestor.get_next_sibling_unsafe(self.js_context) };
 
             if let Some(next_sibling) = next_sibling_option {
-                self.current = Some(next_sibling.into());
+                self.current = Some(next_sibling);
                 return Some(current);
             }
 
@@ -2344,11 +2344,11 @@ where
                     shadow_root
                         .Host()
                         .upcast::<Node>()
-                        .get_first_child_unsafe(&self.js_context)
+                        .get_first_child_unsafe(self.js_context)
                 };
 
                 if let Some(child) = child_option {
-                    self.current = Some(child.into());
+                    self.current = Some(child);
                     return Some(current);
                 }
             }
@@ -2386,7 +2386,7 @@ where
         // SAFETY: Using unsafe methods is ok, as we have a reference to a JSContext, hence, disallowing any mutable reference which would imply Gc happening.
         let first_child_option = unsafe { current.get_first_child_unsafe(self.js_context) };
         if let Some(first_child) = first_child_option {
-            self.current = Some(first_child.into());
+            self.current = Some(first_child);
             self.depth += 1;
             return Some(current);
         };

--- a/components/script/dom/node.rs
+++ b/components/script/dom/node.rs
@@ -843,16 +843,16 @@ impl Node {
         TreeIterator::new(self, shadow_including)
     }
 
-    /// Iterates over this node and all its descendants, in preorder. Does not root.
+    /// Iterates over this node and all its descendants, in preorder. We take &NoGC to prevent GC which allows us to avoid rooting.
     pub(crate) fn traverse_preorder_non_rooting<'a, 'b>(
         &'a self,
         no_gc: &'b NoGC,
         shadow_including: ShadowIncluding,
-    ) -> EfficientTreeIterator<'a, 'b>
+    ) -> UnrootedTreeIterator<'a, 'b>
     where
         'b: 'a,
     {
-        EfficientTreeIterator::new(self, shadow_including, no_gc)
+        UnrootedTreeIterator::new(self, shadow_including, no_gc)
     }
 
     pub(crate) fn inclusively_following_siblings(
@@ -2201,7 +2201,7 @@ pub(crate) enum ShadowIncluding {
 pub(crate) struct TreeIterator {
     current: Option<DomRoot<Node>>,
     depth: usize,
-    shadow_including: bool,
+    shadow_including: ShadowIncluding,
 }
 
 impl TreeIterator {
@@ -2209,7 +2209,7 @@ impl TreeIterator {
         TreeIterator {
             current: Some(DomRoot::from_ref(root)),
             depth: 0,
-            shadow_including: shadow_including == ShadowIncluding::Yes,
+            shadow_including,
         }
     }
 
@@ -2220,11 +2220,7 @@ impl TreeIterator {
     }
 
     fn next_skipping_children_impl(&mut self, current: DomRoot<Node>) -> Option<DomRoot<Node>> {
-        let iter = current.inclusive_ancestors(if self.shadow_including {
-            ShadowIncluding::Yes
-        } else {
-            ShadowIncluding::No
-        });
+        let iter = current.inclusive_ancestors(self.shadow_including);
 
         for ancestor in iter {
             if self.depth == 0 {
@@ -2265,7 +2261,7 @@ impl Iterator for TreeIterator {
         // Handle a potential shadow root on the element
         if let Some(element) = current.downcast::<Element>() {
             if let Some(shadow_root) = element.shadow_root() {
-                if self.shadow_including {
+                if self.shadow_including == ShadowIncluding::Yes {
                     self.current = Some(DomRoot::from_ref(shadow_root.upcast::<Node>()));
                     self.depth += 1;
                     return Some(current);
@@ -2291,16 +2287,16 @@ impl Iterator for TreeIterator {
 /// This does not root the required children. Taking a `&NoGC` enforces that there is no `&mut JSContext`
 /// while this iterator is alive.
 #[cfg_attr(crown, crown::unrooted_must_root_lint::allow_unrooted_interior)]
-pub(crate) struct EfficientTreeIterator<'a, 'b> {
+pub(crate) struct UnrootedTreeIterator<'a, 'b> {
     current: Option<UnrootedDom<'b, Node>>,
     depth: usize,
-    shadow_including: bool,
+    shadow_including: ShadowIncluding,
     /// This is unused and only used for lifetime guarantee of NoGC
     no_gc: &'b NoGC,
     phantom: PhantomData<&'a Node>,
 }
 
-impl<'a, 'b> EfficientTreeIterator<'a, 'b>
+impl<'a, 'b> UnrootedTreeIterator<'a, 'b>
 where
     'b: 'a,
 {
@@ -2308,11 +2304,11 @@ where
         root: &'a Node,
         shadow_including: ShadowIncluding,
         no_gc: &'b NoGC,
-    ) -> EfficientTreeIterator<'a, 'b> {
-        EfficientTreeIterator {
+    ) -> UnrootedTreeIterator<'a, 'b> {
+        UnrootedTreeIterator {
             current: Some(UnrootedDom::from_dom(Dom::from_ref(root), no_gc)),
             depth: 0,
-            shadow_including: shadow_including == ShadowIncluding::Yes,
+            shadow_including,
             no_gc,
             phantom: PhantomData,
         }
@@ -2321,11 +2317,7 @@ where
     pub(crate) fn next_skipping_children(&mut self) -> Option<UnrootedDom<'b, Node>> {
         let current = self.current.take()?;
 
-        let iter = current.inclusive_ancestors(if self.shadow_including {
-            ShadowIncluding::Yes
-        } else {
-            ShadowIncluding::No
-        });
+        let iter = current.inclusive_ancestors(self.shadow_including);
 
         for ancestor in iter {
             if self.depth == 0 {
@@ -2360,7 +2352,7 @@ where
     }
 }
 
-impl<'a, 'b> Iterator for EfficientTreeIterator<'a, 'b>
+impl<'a, 'b> Iterator for UnrootedTreeIterator<'a, 'b>
 where
     'b: 'a,
 {
@@ -2374,7 +2366,7 @@ where
         // Handle a potential shadow root on the element
         if let Some(element) = current.downcast::<Element>() {
             if let Some(shadow_root) = element.shadow_root() {
-                if self.shadow_including {
+                if self.shadow_including == ShadowIncluding::Yes {
                     self.current = Some(UnrootedDom::from_dom(
                         Dom::from_ref(shadow_root.upcast::<Node>()),
                         self.no_gc,

--- a/components/script/dom/node.rs
+++ b/components/script/dom/node.rs
@@ -2332,7 +2332,6 @@ where
                 break;
             }
 
-            // SAFETY: Using unsafe methods is ok, as we have a reference to a NoGC, hence, disallowing any mutable reference which would imply Gc happening.
             let next_sibling_option = ancestor.get_next_sibling_unrooted(self.no_gc);
 
             if let Some(next_sibling) = next_sibling_option {
@@ -2343,7 +2342,6 @@ where
             if let Some(shadow_root) = ancestor.downcast::<ShadowRoot>() {
                 // Shadow roots don't have sibling, so after we're done traversing
                 // one we jump to the first child of the host
-                // SAFETY: Using unsafe methods is ok, as we have a reference to NoGC, hence, disallowing any mutable reference which would imply Gc happening.
                 let child_option = shadow_root
                     .Host()
                     .upcast::<Node>()
@@ -2387,7 +2385,6 @@ where
             }
         }
 
-        // SAFETY: Using unsafe methods is ok, as we have a reference to a JSContext, hence, disallowing any mutable reference which would imply Gc happening.
         let first_child_option = current.get_first_child_unrooted(self.no_gc);
         if let Some(first_child) = first_child_option {
             self.current = Some(first_child);

--- a/components/script/dom/node.rs
+++ b/components/script/dom/node.rs
@@ -843,7 +843,7 @@ impl Node {
     }
 
     /// Iterates over this node and all its descendants, in preorder.
-    pub(crate) fn traverse_preorder_efficient<'a, 'b>(
+    pub(crate) fn traverse_preorder_non_rooting<'a, 'b>(
         &'a self,
         cx: &'b JSContext,
         shadow_including: ShadowIncluding,
@@ -852,18 +852,6 @@ impl Node {
         'b: 'a,
     {
         EfficientTreeIterator::new(self, shadow_including, cx)
-    }
-
-    /// Iterates over this node and all its descendants, in preorder.
-    pub(crate) fn traverse_preorder_efficient_gc<'a, 'b>(
-        &'a self,
-        shadow_including: ShadowIncluding,
-        cx: &'b mut JSContext,
-    ) -> EfficientTreeIterator<'a, 'b>
-    where
-        'b: 'a,
-    {
-        EfficientTreeIterator::new_can_gc(self, shadow_including, cx)
     }
 
     pub(crate) fn inclusively_following_siblings(
@@ -2295,13 +2283,17 @@ impl Iterator for TreeIterator {
 }
 
 #[derive(Clone)]
-/// Either a DomRoot or a Dom. Do not construct this type. See more on `EfficientTreeIterator`.
+#[cfg_attr(crown, crown::unrooted_must_root_lint::allow_unrooted_interior)]
+/// Either a DomRoot or a Dom. This type should only be constructed while extreme care is taken.
+/// We allow unrooted interior because we will make sure in `EfficientTreeIterator` that only methods that
+/// do not use Gc will be used by capturing a `&JSContext`.
 pub(crate) enum DomNodeVariant {
     Gc(DomRoot<Node>),
     NonGc(Dom<Node>),
 }
 
 impl DomNodeVariant {
+    /// Returns the rooted version of the interior.
     pub(crate) fn rooted(self) -> DomRoot<Node> {
         match self {
             DomNodeVariant::Gc(root) => root,
@@ -2342,23 +2334,17 @@ impl From<Dom<Node>> for DomNodeVariant {
     }
 }
 
-enum JSContextType<'a> {
-    Gc(&'a mut JSContext),
-    NonGc(&'a JSContext),
-}
-
 /// An efficient TreeIterator.
 /// Normally we need to root every `Node` we come across as we do not know if we will have a Gc pause.
-/// This can be constructed in two ways, either via a `&mut JSContext` to be the normal `TreeIterator` or
-/// via a `&JSContext` to not root the required children.
-/// This is safe as a `&JSContext` ensures that Gc will not run while used.
+/// via a `&JSContext` to not root the required children. Taking a &JSContext ensures that we will never have
+/// a method needing `&mut JSContext`, hence, no Gc is happening while this is alive.
 pub(crate) struct EfficientTreeIterator<'a, 'b> {
     current: Option<DomNodeVariant>,
     depth: usize,
     shadow_including: bool,
     use_gc_methods: bool,
     /// This is unused and only used to make sure you give us the right JSContext.
-    js_context: JSContextType<'a>,
+    js_context: &'a JSContext,
     phantom: PhantomData<&'b Node>,
 }
 
@@ -2376,36 +2362,12 @@ where
             depth: 0,
             shadow_including: shadow_including == ShadowIncluding::Yes,
             use_gc_methods: true,
-            js_context: JSContextType::NonGc(cx),
+            js_context: cx,
             phantom: PhantomData,
         }
     }
 
-    pub(crate) fn new_can_gc(
-        root: &'a Node,
-        shadow_including: ShadowIncluding,
-        cx: &'b mut JSContext,
-    ) -> EfficientTreeIterator<'a, 'b> {
-        EfficientTreeIterator {
-            current: Some(DomRoot::from_ref(root).into()),
-            depth: 0,
-            shadow_including: shadow_including == ShadowIncluding::Yes,
-            use_gc_methods: false,
-            js_context: JSContextType::Gc(cx),
-            phantom: PhantomData,
-        }
-    }
-
-    /*
-    pub(crate) fn new_non_gc(root: &Node, shadow_including: ShadowIncluding, cx: &JSContext) -> TreeIterator {
-        TreeIterator {
-            current: Some(Dom::new(root)),
-            depth: 0,
-            shadow_including: shadow_including == ShadowIncluding::Yes,
-        }
-    }
-    */
-
+    #[expect(unsafe_code)]
     pub(crate) fn next_skipping_children(&mut self) -> Option<DomNodeVariant> {
         let current = self.current.take()?;
 
@@ -2426,7 +2388,11 @@ where
                     return Some(current);
                 }
             } else {
-                if let Some(next_sibling) = ancestor.get_next_sibling_unsafe() {
+                /// SAFETY: Using unsafe methods is ok, as we have a reference to a JSContext, hence, disallowing any mutable reference which would imply Gc happening.
+                let next_sibling_option =
+                    unsafe { ancestor.get_next_sibling_unsafe(self.js_context) };
+
+                if let Some(next_sibling) = next_sibling_option {
                     self.current = Some(next_sibling.into());
                     return Some(current);
                 }
@@ -2441,9 +2407,15 @@ where
                         return Some(current);
                     }
                 } else {
-                    if let Some(child) =
-                        shadow_root.Host().upcast::<Node>().get_first_child_unsafe()
-                    {
+                    /// SAFETY: Using unsafe methods is ok, as we have a reference to a JSContext, hence, disallowing any mutable reference which would imply Gc happening.
+                    let child_option = unsafe {
+                        shadow_root
+                            .Host()
+                            .upcast::<Node>()
+                            .get_first_child_unsafe(&self.js_context)
+                    };
+
+                    if let Some(child) = child_option {
                         self.current = Some(child.into());
                         return Some(current);
                     }
@@ -2465,6 +2437,7 @@ where
 
     /// <https://dom.spec.whatwg.org/#concept-tree-order>
     /// <https://dom.spec.whatwg.org/#concept-shadow-including-tree-order>
+    #[expect(unsafe_code)]
     fn next(&mut self) -> Option<DomNodeVariant> {
         let current = self.current.take()?;
 
@@ -2486,7 +2459,9 @@ where
                 return Some(current);
             };
         } else {
-            if let Some(first_child) = current.get_first_child_unsafe() {
+            /// SAFETY: Using unsafe methods is ok, as we have a reference to a JSContext, hence, disallowing any mutable reference which would imply Gc happening.
+            let first_child_option = unsafe { current.get_first_child_unsafe(self.js_context) };
+            if let Some(first_child) = first_child_option {
                 self.current = Some(first_child.into());
                 self.depth += 1;
                 return Some(current);
@@ -3590,13 +3565,16 @@ impl Node {
         self.xml_serialize(xml_serialize::TraversalScope::ChildrenOnly(None))
     }
 
-    /// Do not call this unless you know that we will not have a gc or you root this value immediately.
-    fn get_next_sibling_unsafe(&self) -> Option<Dom<Node>> {
-        self.next_sibling.get_unsafe()
+    /// SAFETY: Only call this if you know that there will be no Gc ffor the lifetime of this reference.
+    #[expect(unsafe_code)]
+    unsafe fn get_next_sibling_unsafe(&self, cx: &JSContext) -> Option<Dom<Node>> {
+        unsafe { self.next_sibling.get_unsafe(cx) }
     }
 
-    fn get_first_child_unsafe(&self) -> Option<Dom<Node>> {
-        self.first_child.get_unsafe()
+    /// SAFETY: Only call this if you know that there will be no Gc ffor the lifetime of this reference.
+    #[expect(unsafe_code)]
+    unsafe fn get_first_child_unsafe(&self, cx: &JSContext) -> Option<Dom<Node>> {
+        unsafe { self.first_child.get_unsafe(cx) }
     }
 }
 

--- a/components/script/dom/node.rs
+++ b/components/script/dom/node.rs
@@ -8,6 +8,8 @@ use std::borrow::Cow;
 use std::cell::{Cell, LazyCell, UnsafeCell};
 use std::default::Default;
 use std::f64::consts::PI;
+use std::marker::PhantomData;
+use std::ops::Deref;
 use std::slice::from_ref;
 use std::{cmp, fmt, iter};
 
@@ -21,6 +23,7 @@ use euclid::default::Size2D;
 use euclid::{Point2D, Rect};
 use html5ever::serialize::HtmlSerializer;
 use html5ever::{Namespace, Prefix, QualName, ns, serialize as html_serialize};
+use js::context::JSContext;
 use js::jsapi::JSObject;
 use js::rust::HandleObject;
 use keyboard_types::Modifiers;
@@ -837,6 +840,30 @@ impl Node {
     /// Iterates over this node and all its descendants, in preorder.
     pub(crate) fn traverse_preorder(&self, shadow_including: ShadowIncluding) -> TreeIterator {
         TreeIterator::new(self, shadow_including)
+    }
+
+    /// Iterates over this node and all its descendants, in preorder.
+    pub(crate) fn traverse_preorder_efficient<'a, 'b>(
+        &'a self,
+        cx: &'b JSContext,
+        shadow_including: ShadowIncluding,
+    ) -> EfficientTreeIterator<'a, 'b>
+    where
+        'b: 'a,
+    {
+        EfficientTreeIterator::new(self, shadow_including, cx)
+    }
+
+    /// Iterates over this node and all its descendants, in preorder.
+    pub(crate) fn traverse_preorder_efficient_gc<'a, 'b>(
+        &'a self,
+        shadow_including: ShadowIncluding,
+        cx: &'b mut JSContext,
+    ) -> EfficientTreeIterator<'a, 'b>
+    where
+        'b: 'a,
+    {
+        EfficientTreeIterator::new_can_gc(self, shadow_including, cx)
     }
 
     pub(crate) fn inclusively_following_siblings(
@@ -2267,6 +2294,209 @@ impl Iterator for TreeIterator {
     }
 }
 
+#[derive(Clone)]
+/// Either a DomRoot or a Dom. Do not construct this type. See more on `EfficientTreeIterator`.
+pub(crate) enum DomNodeVariant {
+    Gc(DomRoot<Node>),
+    NonGc(Dom<Node>),
+}
+
+impl DomNodeVariant {
+    pub(crate) fn rooted(self) -> DomRoot<Node> {
+        match self {
+            DomNodeVariant::Gc(root) => root,
+            DomNodeVariant::NonGc(dom) => DomRoot::from_ref(&dom),
+        }
+    }
+}
+
+impl Deref for DomNodeVariant {
+    type Target = Node;
+
+    fn deref(&self) -> &Self::Target {
+        match self {
+            DomNodeVariant::Gc(root) => root,
+            DomNodeVariant::NonGc(dom) => dom,
+        }
+    }
+}
+
+impl AsRef<Node> for DomNodeVariant {
+    fn as_ref(&self) -> &Node {
+        match self {
+            DomNodeVariant::Gc(root) => root,
+            DomNodeVariant::NonGc(dom) => dom,
+        }
+    }
+}
+
+impl From<DomRoot<Node>> for DomNodeVariant {
+    fn from(value: DomRoot<Node>) -> Self {
+        DomNodeVariant::Gc(value)
+    }
+}
+
+impl From<Dom<Node>> for DomNodeVariant {
+    fn from(value: Dom<Node>) -> Self {
+        DomNodeVariant::NonGc(value)
+    }
+}
+
+enum JSContextType<'a> {
+    Gc(&'a mut JSContext),
+    NonGc(&'a JSContext),
+}
+
+/// An efficient TreeIterator.
+/// Normally we need to root every `Node` we come across as we do not know if we will have a Gc pause.
+/// This can be constructed in two ways, either via a `&mut JSContext` to be the normal `TreeIterator` or
+/// via a `&JSContext` to not root the required children.
+/// This is safe as a `&JSContext` ensures that Gc will not run while used.
+pub(crate) struct EfficientTreeIterator<'a, 'b> {
+    current: Option<DomNodeVariant>,
+    depth: usize,
+    shadow_including: bool,
+    use_gc_methods: bool,
+    /// This is unused and only used to make sure you give us the right JSContext.
+    js_context: JSContextType<'a>,
+    phantom: PhantomData<&'b Node>,
+}
+
+impl<'a, 'b> EfficientTreeIterator<'a, 'b>
+where
+    'b: 'a,
+{
+    pub(crate) fn new(
+        root: &'a Node,
+        shadow_including: ShadowIncluding,
+        cx: &'b JSContext,
+    ) -> EfficientTreeIterator<'a, 'b> {
+        EfficientTreeIterator {
+            current: Some(Dom::from_ref(root).into()),
+            depth: 0,
+            shadow_including: shadow_including == ShadowIncluding::Yes,
+            use_gc_methods: true,
+            js_context: JSContextType::NonGc(cx),
+            phantom: PhantomData,
+        }
+    }
+
+    pub(crate) fn new_can_gc(
+        root: &'a Node,
+        shadow_including: ShadowIncluding,
+        cx: &'b mut JSContext,
+    ) -> EfficientTreeIterator<'a, 'b> {
+        EfficientTreeIterator {
+            current: Some(DomRoot::from_ref(root).into()),
+            depth: 0,
+            shadow_including: shadow_including == ShadowIncluding::Yes,
+            use_gc_methods: false,
+            js_context: JSContextType::Gc(cx),
+            phantom: PhantomData,
+        }
+    }
+
+    /*
+    pub(crate) fn new_non_gc(root: &Node, shadow_including: ShadowIncluding, cx: &JSContext) -> TreeIterator {
+        TreeIterator {
+            current: Some(Dom::new(root)),
+            depth: 0,
+            shadow_including: shadow_including == ShadowIncluding::Yes,
+        }
+    }
+    */
+
+    pub(crate) fn next_skipping_children(&mut self) -> Option<DomNodeVariant> {
+        let current = self.current.take()?;
+
+        let iter = current.inclusive_ancestors(if self.shadow_including {
+            ShadowIncluding::Yes
+        } else {
+            ShadowIncluding::No
+        });
+
+        for ancestor in iter {
+            if self.depth == 0 {
+                break;
+            }
+
+            if self.use_gc_methods {
+                if let Some(next_sibling) = ancestor.GetNextSibling() {
+                    self.current = Some(next_sibling.into());
+                    return Some(current);
+                }
+            } else {
+                if let Some(next_sibling) = ancestor.get_next_sibling_unsafe() {
+                    self.current = Some(next_sibling.into());
+                    return Some(current);
+                }
+            }
+
+            if let Some(shadow_root) = ancestor.downcast::<ShadowRoot>() {
+                // Shadow roots don't have sibling, so after we're done traversing
+                // one we jump to the first child of the host
+                if self.use_gc_methods {
+                    if let Some(child) = shadow_root.Host().upcast::<Node>().GetFirstChild() {
+                        self.current = Some(child.into());
+                        return Some(current);
+                    }
+                } else {
+                    if let Some(child) =
+                        shadow_root.Host().upcast::<Node>().get_first_child_unsafe()
+                    {
+                        self.current = Some(child.into());
+                        return Some(current);
+                    }
+                }
+            }
+            self.depth -= 1;
+        }
+        debug_assert_eq!(self.depth, 0);
+        self.current = None;
+        Some(current)
+    }
+}
+
+impl<'a, 'b> Iterator for EfficientTreeIterator<'a, 'b>
+where
+    'b: 'a,
+{
+    type Item = DomNodeVariant;
+
+    /// <https://dom.spec.whatwg.org/#concept-tree-order>
+    /// <https://dom.spec.whatwg.org/#concept-shadow-including-tree-order>
+    fn next(&mut self) -> Option<DomNodeVariant> {
+        let current = self.current.take()?;
+
+        // Handle a potential shadow root on the element
+        if let Some(element) = current.downcast::<Element>() {
+            if let Some(shadow_root) = element.shadow_root() {
+                if self.shadow_including {
+                    self.current = Some(DomRoot::from_ref(shadow_root.upcast::<Node>()).into());
+                    self.depth += 1;
+                    return Some(current);
+                }
+            }
+        }
+
+        if self.use_gc_methods {
+            if let Some(first_child) = current.GetFirstChild() {
+                self.current = Some(first_child.into());
+                self.depth += 1;
+                return Some(current);
+            };
+        } else {
+            if let Some(first_child) = current.get_first_child_unsafe() {
+                self.current = Some(first_child.into());
+                self.depth += 1;
+                return Some(current);
+            };
+        }
+
+        self.next_skipping_children()
+    }
+}
+
 /// Specifies whether children must be recursively cloned or not.
 #[derive(Clone, Copy, MallocSizeOf, PartialEq)]
 pub(crate) enum CloneChildrenFlag {
@@ -3358,6 +3588,15 @@ impl Node {
         // TODO: xml5ever doesn't seem to want require_well_formed
         let _ = require_well_formed;
         self.xml_serialize(xml_serialize::TraversalScope::ChildrenOnly(None))
+    }
+
+    /// Do not call this unless you know that we will not have a gc or you root this value immediately.
+    fn get_next_sibling_unsafe(&self) -> Option<Dom<Node>> {
+        self.next_sibling.get_unsafe()
+    }
+
+    fn get_first_child_unsafe(&self) -> Option<Dom<Node>> {
+        self.first_child.get_unsafe()
     }
 }
 

--- a/components/script/dom/node.rs
+++ b/components/script/dom/node.rs
@@ -2395,6 +2395,8 @@ where
             return Some(current);
         };
 
+        // current is empty.
+        let _ = self.current.insert(current);
         self.next_skipping_children()
     }
 }

--- a/components/script/dom/node.rs
+++ b/components/script/dom/node.rs
@@ -22,7 +22,7 @@ use euclid::default::Size2D;
 use euclid::{Point2D, Rect};
 use html5ever::serialize::HtmlSerializer;
 use html5ever::{Namespace, Prefix, QualName, ns, serialize as html_serialize};
-use js::context::JSContext;
+use js::context::NoGC;
 use js::jsapi::JSObject;
 use js::rust::HandleObject;
 use keyboard_types::Modifiers;
@@ -841,16 +841,16 @@ impl Node {
         TreeIterator::new(self, shadow_including)
     }
 
-    /// Iterates over this node and all its descendants, in preorder.
+    /// Iterates over this node and all its descendants, in preorder. Does not root.
     pub(crate) fn traverse_preorder_non_rooting<'a, 'b>(
         &'a self,
-        cx: &'b JSContext,
+        no_gc: &'b NoGC,
         shadow_including: ShadowIncluding,
     ) -> EfficientTreeIterator<'a, 'b>
     where
         'b: 'a,
     {
-        EfficientTreeIterator::new(self, shadow_including, cx)
+        EfficientTreeIterator::new(self, shadow_including, no_gc)
     }
 
     pub(crate) fn inclusively_following_siblings(
@@ -2281,18 +2281,21 @@ impl Iterator for TreeIterator {
     }
 }
 
-/// An efficient TreeIterator.
-/// Normally we need to root every `Node` we come across as we do not know if we will have a Gc pause.
-/// via a `&JSContext` to not root the required children. Taking a &JSContext ensures that we will never have
-/// a method needing `&mut JSContext`, hence, no Gc is happening while this is alive.
+/// An efficient TreeIterator because it skips rooting if there are no GC pauses.
+///
+/// Use this if you have a `&JSContext` or `NoGC`.
+///
+/// Normally we need to root every `Node` we come across as we do not know if we will have a GC pause.
+/// This does not root the required children. Taking a `&NoGC` enforces that there is no `&mut JSContext`
+/// while this iterator is alive.
 #[cfg_attr(crown, crown::unrooted_must_root_lint::allow_unrooted_interior)]
 pub(crate) struct EfficientTreeIterator<'a, 'b> {
     current: Option<Dom<Node>>,
     depth: usize,
     shadow_including: bool,
-    /// This is unused and only used to make sure you give us the right JSContext.
-    js_context: &'a JSContext,
-    phantom: PhantomData<&'b Node>,
+    /// This is unused and only used for lifetime guarantee of NoGC
+    no_gc: &'b NoGC,
+    phantom: PhantomData<&'a Node>,
 }
 
 impl<'a, 'b> EfficientTreeIterator<'a, 'b>
@@ -2302,13 +2305,13 @@ where
     pub(crate) fn new(
         root: &'a Node,
         shadow_including: ShadowIncluding,
-        cx: &'b JSContext,
+        no_gc: &'b NoGC,
     ) -> EfficientTreeIterator<'a, 'b> {
         EfficientTreeIterator {
             current: Some(Dom::from_ref(root)),
             depth: 0,
             shadow_including: shadow_including == ShadowIncluding::Yes,
-            js_context: cx,
+            no_gc,
             phantom: PhantomData,
         }
     }
@@ -2328,8 +2331,8 @@ where
                 break;
             }
 
-            // SAFETY: Using unsafe methods is ok, as we have a reference to a JSContext, hence, disallowing any mutable reference which would imply Gc happening.
-            let next_sibling_option = unsafe { ancestor.get_next_sibling_unsafe(self.js_context) };
+            // SAFETY: Using unsafe methods is ok, as we have a reference to a NoGC, hence, disallowing any mutable reference which would imply Gc happening.
+            let next_sibling_option = unsafe { ancestor.get_next_sibling_unsafe(self.no_gc) };
 
             if let Some(next_sibling) = next_sibling_option {
                 self.current = Some(next_sibling);
@@ -2339,12 +2342,12 @@ where
             if let Some(shadow_root) = ancestor.downcast::<ShadowRoot>() {
                 // Shadow roots don't have sibling, so after we're done traversing
                 // one we jump to the first child of the host
-                // SAFETY: Using unsafe methods is ok, as we have a reference to a JSContext, hence, disallowing any mutable reference which would imply Gc happening.
+                // SAFETY: Using unsafe methods is ok, as we have a reference to NoGC, hence, disallowing any mutable reference which would imply Gc happening.
                 let child_option = unsafe {
                     shadow_root
                         .Host()
                         .upcast::<Node>()
-                        .get_first_child_unsafe(self.js_context)
+                        .get_first_child_unsafe(self.no_gc)
                 };
 
                 if let Some(child) = child_option {
@@ -2384,7 +2387,7 @@ where
         }
 
         // SAFETY: Using unsafe methods is ok, as we have a reference to a JSContext, hence, disallowing any mutable reference which would imply Gc happening.
-        let first_child_option = unsafe { current.get_first_child_unsafe(self.js_context) };
+        let first_child_option = unsafe { current.get_first_child_unsafe(self.no_gc) };
         if let Some(first_child) = first_child_option {
             self.current = Some(first_child);
             self.depth += 1;
@@ -3490,14 +3493,14 @@ impl Node {
 
     /// SAFETY: Only call this if you know that there will be no Gc ffor the lifetime of this reference.
     #[expect(unsafe_code)]
-    unsafe fn get_next_sibling_unsafe(&self, cx: &JSContext) -> Option<Dom<Node>> {
-        unsafe { self.next_sibling.get_unsafe(cx) }
+    unsafe fn get_next_sibling_unsafe(&self, no_gc: &NoGC) -> Option<Dom<Node>> {
+        unsafe { self.next_sibling.get_unsafe(no_gc) }
     }
 
     /// SAFETY: Only call this if you know that there will be no Gc ffor the lifetime of this reference.
     #[expect(unsafe_code)]
-    unsafe fn get_first_child_unsafe(&self, cx: &JSContext) -> Option<Dom<Node>> {
-        unsafe { self.first_child.get_unsafe(cx) }
+    unsafe fn get_first_child_unsafe(&self, no_gc: &NoGC) -> Option<Dom<Node>> {
+        unsafe { self.first_child.get_unsafe(no_gc) }
     }
 }
 

--- a/components/script/dom/node.rs
+++ b/components/script/dom/node.rs
@@ -84,7 +84,9 @@ use crate::dom::bindings::inheritance::{
     SVGElementTypeId, SVGGraphicsElementTypeId, TextTypeId,
 };
 use crate::dom::bindings::reflector::{DomObject, DomObjectWrap, reflect_dom_object_with_proto};
-use crate::dom::bindings::root::{Dom, DomRoot, DomSlice, LayoutDom, MutNullableDom, ToLayout};
+use crate::dom::bindings::root::{
+    Dom, DomRoot, DomSlice, LayoutDom, MutNullableDom, ToLayout, UnrootedDom,
+};
 use crate::dom::bindings::str::{DOMString, USVString};
 use crate::dom::characterdata::{CharacterData, LayoutCharacterDataHelpers};
 use crate::dom::css::cssstylesheet::CSSStyleSheet;
@@ -2290,7 +2292,7 @@ impl Iterator for TreeIterator {
 /// while this iterator is alive.
 #[cfg_attr(crown, crown::unrooted_must_root_lint::allow_unrooted_interior)]
 pub(crate) struct EfficientTreeIterator<'a, 'b> {
-    current: Option<Dom<Node>>,
+    current: Option<UnrootedDom<'b, Node>>,
     depth: usize,
     shadow_including: bool,
     /// This is unused and only used for lifetime guarantee of NoGC
@@ -2308,7 +2310,7 @@ where
         no_gc: &'b NoGC,
     ) -> EfficientTreeIterator<'a, 'b> {
         EfficientTreeIterator {
-            current: Some(Dom::from_ref(root)),
+            current: Some(UnrootedDom::from_dom(Dom::from_ref(root), no_gc)),
             depth: 0,
             shadow_including: shadow_including == ShadowIncluding::Yes,
             no_gc,
@@ -2316,8 +2318,7 @@ where
         }
     }
 
-    #[expect(unsafe_code)]
-    pub(crate) fn next_skipping_children(&mut self) -> Option<Dom<Node>> {
+    pub(crate) fn next_skipping_children(&mut self) -> Option<UnrootedDom<'b, Node>> {
         let current = self.current.take()?;
 
         let iter = current.inclusive_ancestors(if self.shadow_including {
@@ -2332,7 +2333,7 @@ where
             }
 
             // SAFETY: Using unsafe methods is ok, as we have a reference to a NoGC, hence, disallowing any mutable reference which would imply Gc happening.
-            let next_sibling_option = unsafe { ancestor.get_next_sibling_unsafe(self.no_gc) };
+            let next_sibling_option = ancestor.get_next_sibling_unrooted(self.no_gc);
 
             if let Some(next_sibling) = next_sibling_option {
                 self.current = Some(next_sibling);
@@ -2343,12 +2344,10 @@ where
                 // Shadow roots don't have sibling, so after we're done traversing
                 // one we jump to the first child of the host
                 // SAFETY: Using unsafe methods is ok, as we have a reference to NoGC, hence, disallowing any mutable reference which would imply Gc happening.
-                let child_option = unsafe {
-                    shadow_root
-                        .Host()
-                        .upcast::<Node>()
-                        .get_first_child_unsafe(self.no_gc)
-                };
+                let child_option = shadow_root
+                    .Host()
+                    .upcast::<Node>()
+                    .get_first_child_unrooted(self.no_gc);
 
                 if let Some(child) = child_option {
                     self.current = Some(child);
@@ -2367,19 +2366,21 @@ impl<'a, 'b> Iterator for EfficientTreeIterator<'a, 'b>
 where
     'b: 'a,
 {
-    type Item = Dom<Node>;
+    type Item = UnrootedDom<'b, Node>;
 
     /// <https://dom.spec.whatwg.org/#concept-tree-order>
     /// <https://dom.spec.whatwg.org/#concept-shadow-including-tree-order>
-    #[expect(unsafe_code)]
-    fn next(&mut self) -> Option<Dom<Node>> {
+    fn next(&mut self) -> Option<UnrootedDom<'b, Node>> {
         let current = self.current.take()?;
 
         // Handle a potential shadow root on the element
         if let Some(element) = current.downcast::<Element>() {
             if let Some(shadow_root) = element.shadow_root() {
                 if self.shadow_including {
-                    self.current = Some(Dom::from_ref(shadow_root.upcast::<Node>()));
+                    self.current = Some(UnrootedDom::from_dom(
+                        Dom::from_ref(shadow_root.upcast::<Node>()),
+                        self.no_gc,
+                    ));
                     self.depth += 1;
                     return Some(current);
                 }
@@ -2387,7 +2388,7 @@ where
         }
 
         // SAFETY: Using unsafe methods is ok, as we have a reference to a JSContext, hence, disallowing any mutable reference which would imply Gc happening.
-        let first_child_option = unsafe { current.get_first_child_unsafe(self.no_gc) };
+        let first_child_option = current.get_first_child_unrooted(self.no_gc);
         if let Some(first_child) = first_child_option {
             self.current = Some(first_child);
             self.depth += 1;
@@ -3491,16 +3492,12 @@ impl Node {
         self.xml_serialize(xml_serialize::TraversalScope::ChildrenOnly(None))
     }
 
-    /// SAFETY: Only call this if you know that there will be no Gc ffor the lifetime of this reference.
-    #[expect(unsafe_code)]
-    unsafe fn get_next_sibling_unsafe(&self, no_gc: &NoGC) -> Option<Dom<Node>> {
-        unsafe { self.next_sibling.get_unsafe(no_gc) }
+    fn get_next_sibling_unrooted<'a>(&self, no_gc: &'a NoGC) -> Option<UnrootedDom<'a, Node>> {
+        self.next_sibling.get_unrooted(no_gc)
     }
 
-    /// SAFETY: Only call this if you know that there will be no Gc ffor the lifetime of this reference.
-    #[expect(unsafe_code)]
-    unsafe fn get_first_child_unsafe(&self, no_gc: &NoGC) -> Option<Dom<Node>> {
-        unsafe { self.first_child.get_unsafe(no_gc) }
+    fn get_first_child_unrooted<'a>(&self, no_gc: &'a NoGC) -> Option<UnrootedDom<'a, Node>> {
+        self.first_child.get_unrooted(no_gc)
     }
 }
 

--- a/components/script/dom/range.rs
+++ b/components/script/dom/range.rs
@@ -1154,7 +1154,7 @@ impl RangeMethods<crate::DomTypeHolder> for Range {
         // Step 8. For each script of fragment node's script element descendants:
         for node in fragment_node
             .upcast::<Node>()
-            .traverse_preorder(ShadowIncluding::No)
+            .traverse_preorder_efficient_gc(ShadowIncluding::No, cx)
         {
             if let Some(script) = node.downcast::<HTMLScriptElement>() {
                 // Step 8.1. Set script's already started to false.

--- a/components/script/dom/range.rs
+++ b/components/script/dom/range.rs
@@ -1154,7 +1154,7 @@ impl RangeMethods<crate::DomTypeHolder> for Range {
         // Step 8. For each script of fragment node's script element descendants:
         for node in fragment_node
             .upcast::<Node>()
-            .traverse_preorder_efficient_gc(ShadowIncluding::No, cx)
+            .traverse_preorder(ShadowIncluding::No)
         {
             if let Some(script) = node.downcast::<HTMLScriptElement>() {
                 // Step 8.1. Set script's already started to false.


### PR DESCRIPTION
This implements an two types:
- Efficient Tree Iterator that can be used without rooting when possible.
- UnrootedDom that can be used while not rooting while capturing a NoGC.

We:
- introduce new methods in 'script/dom/node.rs' to get the correct iterator.
- introduce methods in 'script/dom/node.rs' to get the unrooted children in an 'UnrootedDom' container.

We use the new TreeIterator in 'script/dom/document.rs' Open.

Testing: WPT tests should catch this but careful review is required.
