### PR TITLE
base: Replace calls to servo_opts in generic channel with OnceLock

### DIFF
--- a/components/shared/base/generic_channel.rs
+++ b/components/shared/base/generic_channel.rs
@@ -7,6 +7,7 @@
 use std::fmt;
 use std::fmt::Display;
 use std::marker::PhantomData;
+use std::sync::OnceLock;
 use std::time::Duration;
 
 use crossbeam_channel::RecvTimeoutError;
@@ -27,6 +28,16 @@ pub use ipc_channel::ipc::IpcSharedMemory as GenericSharedMemory;
 pub use oneshot::{GenericOneshotReceiver, GenericOneshotSender, oneshot};
 mod generic_channelset;
 pub use generic_channelset::{GenericReceiverSet, GenericSelectionResult};
+
+/// Cache for being in Ipc Mode
+static USE_IPC: OnceLock<bool> = OnceLock::new();
+
+/// Return if we should be in IPC Mode
+fn use_ipc() -> bool {
+    *USE_IPC.get_or_init(|| {
+        servo_config::opts::get().multiprocess || servo_config::opts::get().force_ipc
+    })
+}
 
 /// Abstraction of the ability to send a particular type of message cross-process.
 /// This can be used to ease the use of GenericSender sub-fields.
@@ -481,7 +492,7 @@ where
                 .newtype_variant::<ipc_channel::ipc::IpcReceiver<T>>()
                 .map(|receiver| GenericReceiver(GenericReceiverVariants::Ipc(receiver))),
             GenericReceiverVariantNames::Crossbeam => {
-                if opts::get().multiprocess {
+                if use_ipc() {
                     return Err(serde::de::Error::custom(
                         "Crossbeam channel found in multiprocess mode!",
                     ));
@@ -551,7 +562,7 @@ pub fn channel<T>() -> Option<(GenericSender<T>, GenericReceiver<T>)>
 where
     T: for<'de> Deserialize<'de> + Serialize,
 {
-    if servo_config::opts::get().multiprocess || servo_config::opts::get().force_ipc {
+    if use_ipc() {
         new_generic_channel_ipc().ok()
     } else {
         Some(new_generic_channel_crossbeam())

--- a/components/shared/base/generic_channel/generic_channelset.rs
+++ b/components/shared/base/generic_channel/generic_channelset.rs
@@ -4,7 +4,7 @@
 use ipc_channel::ipc::{IpcReceiverSet, IpcSelectionResult};
 use serde::{Deserialize, Serialize};
 
-use crate::generic_channel::{GenericReceiver, GenericReceiverVariants};
+use crate::generic_channel::{GenericReceiver, GenericReceiverVariants, use_ipc};
 
 /// A GenericReceiverSet. Allows you to wait on multiple GenericReceivers.
 /// Automatically selects either Ipc or crossbeam depending on multiprocess mode.
@@ -86,7 +86,7 @@ impl<T: Serialize + for<'de> serde::Deserialize<'de>> From<IpcSelectionResult>
 impl<T: Serialize + for<'de> Deserialize<'de>> GenericReceiverSet<T> {
     /// Create a new ReceiverSet.
     pub fn new() -> GenericReceiverSet<T> {
-        if servo_config::opts::get().multiprocess || servo_config::opts::get().force_ipc {
+        if use_ipc() {
             GenericReceiverSet(GenericReceiverSetVariants::Ipc(
                 IpcReceiverSet::new().expect("Could not create ipc receiver"),
             ))

--- a/components/shared/base/generic_channel/oneshot.rs
+++ b/components/shared/base/generic_channel/oneshot.rs
@@ -9,7 +9,7 @@ use serde::{Deserialize, Deserializer, Serialize, Serializer};
 
 use crate::generic_channel::{
     GenericReceiverVariants, GenericSenderVariants, GenericSenderVisitor, ReceiveResult, SendError,
-    SendResult, serialize_generic_sender_variants,
+    SendResult, serialize_generic_sender_variants, use_ipc,
 };
 
 /// The oneshot sender struct
@@ -62,7 +62,7 @@ pub fn oneshot<T>() -> Option<(GenericOneshotSender<T>, GenericOneshotReceiver<T
 where
     T: for<'de> Deserialize<'de> + Serialize,
 {
-    if servo_config::opts::get().multiprocess || servo_config::opts::get().force_ipc {
+    if use_ipc() {
         ipc_channel::ipc::channel()
             .map(|(tx, rx)| {
                 (


### PR DESCRIPTION
Previous we had multiple calls to `servo_config::opts::get().multiprocess || servo_config::opts::get().force_ipc` scattered
throughout the code base for GenericChannel etc. This replaces it with a simple function and a LazyLock to get more consistency.

Testing: Compilation is the test.
