### PR TITLE
layout: Reuse boxes for independent formatting contexts with self damage if compatible

### DIFF
--- a/components/layout/flow/mod.rs
+++ b/components/layout/flow/mod.rs
@@ -51,7 +51,7 @@ pub mod float;
 pub mod inline;
 mod root;
 
-pub(crate) use construct::BlockContainerBuilder;
+pub(crate) use construct::{BlockContainerBuilder, BlockLevelCreator};
 pub(crate) use root::BoxTree;
 
 #[derive(Debug, MallocSizeOf)]

--- a/components/layout/formatting_contexts.rs
+++ b/components/layout/formatting_contexts.rs
@@ -43,7 +43,7 @@ pub(crate) struct IndependentFormattingContext {
     contents: IndependentFormattingContextContents,
     /// Data that was originally propagated down to this [`IndependentFormattingContext`]
     /// during creation. This is used during incremental layout.
-    propagated_data: PropagatedBoxTreeData,
+    pub propagated_data: PropagatedBoxTreeData,
 }
 
 #[derive(Debug, MallocSizeOf)]

--- a/components/layout/fragment_tree/box_fragment.rs
+++ b/components/layout/fragment_tree/box_fragment.rs
@@ -16,7 +16,6 @@ use style::computed_values::overflow_x::T as ComputedOverflow;
 use style::computed_values::position::T as ComputedPosition;
 use style::logical_geometry::WritingMode;
 use style::properties::ComputedValues;
-use style::values::specified::box_::DisplayOutside;
 
 use super::{BaseFragment, BaseFragmentInfo, CollapsedBlockMargins, Fragment, FragmentFlags};
 use crate::SharedStyle;
@@ -548,7 +547,7 @@ impl BoxFragment {
     /// Whether this is an atomic inline-level box.
     /// <https://drafts.csswg.org/css-display-3/#atomic-inline>
     pub(crate) fn is_atomic_inline_level(&self) -> bool {
-        self.style().get_box().display.outside() == DisplayOutside::Inline && !self.is_inline_box()
+        self.style().is_atomic_inline_level(self.base.flags)
     }
 
     /// Whether this is a table wrapper box.

--- a/components/layout/traversal.rs
+++ b/components/layout/traversal.rs
@@ -239,13 +239,13 @@ pub(crate) fn compute_damage_and_rebuild_box_tree_inner(
     let descendant_needs_rebuild =
         damage_from_children.contains(LayoutDamage::descendant_has_box_damage());
     if element_or_ancestors_need_rebuild || descendant_needs_rebuild {
-        if element_or_ancestors_need_rebuild ||
+        if damage_from_parent.contains(LayoutDamage::descendant_has_box_damage()) ||
             !node.rebuild_box_tree_from_independent_formatting_context(layout_context)
         {
             // In this case:
-            //  - this node or an ancestor needs to be completely rebuilt.
+            //  - an ancestor needs to be completely rebuilt, or
             //  - a descendant needs to be rebuilt, but we are still propagating the rebuild
-            //    damage to an independent formatting context.
+            //    damage to an independent formatting context with a compatible box level.
             //
             // This means that this box is no longer valid and also needs to be rebuilt
             // (perhaps some of its descendants do not though). In this case, unset all existing


### PR DESCRIPTION
Previously, when a formatting context root had rebuild damage from its own (not from ancestors), we weren't reusing it. Now we check if the level of the box (i.e. whether it's inline-level, block-level, a table cell, a table caption, or absolutely positioned) that will be generated by the new style is compatible with the old box. And if so, we reuse it.

Testing: Not needed, there should be no behavior change
