### PR TITLE
script: Remember which nodes the devtools know about

### DIFF
--- a/components/devtools/actors/inspector/walker.rs
+++ b/components/devtools/actors/inspector/walker.rs
@@ -317,7 +317,6 @@ impl WalkerActor {
             } => old_node != node || old_attribute_name != attribute_name,
         });
 
-        log::warn!("notified of dom mutation: {dom_mutation:?}");
         pending_mutations.push(dom_mutation);
 
         stream.write_json_packet(&NewMutationsNotification {

--- a/components/script/devtools.rs
+++ b/components/script/devtools.rs
@@ -68,11 +68,57 @@ pub(crate) struct DevtoolsState {
 impl PerPipelineState {
     fn register_node(&mut self, node: &Node) {
         let unique_id = node.unique_id(self.pipeline);
-        if self.known_nodes.contains_key(&unique_id) {
-            return;
-        }
+        self.known_nodes
+            .entry(unique_id)
+            .or_insert_with(|| Dom::from_ref(node));
+    }
+}
 
-        self.known_nodes.insert(unique_id, Dom::from_ref(node));
+impl DevtoolsState {
+    pub(crate) fn notify_pipeline_created(&self, pipeline: PipelineId) {
+        self.per_pipeline_state.borrow_mut().insert(
+            NoTrace(pipeline),
+            PerPipelineState {
+                pipeline,
+                known_nodes: Default::default(),
+            },
+        );
+    }
+    pub(crate) fn notify_pipeline_exited(&self, pipeline: PipelineId) {
+        self.per_pipeline_state
+            .borrow_mut()
+            .remove(&NoTrace(pipeline));
+    }
+
+    fn pipeline_state_for(&self, pipeline: PipelineId) -> Option<Ref<'_, PerPipelineState>> {
+        Ref::filter_map(self.per_pipeline_state.borrow(), |state| {
+            state.get(&NoTrace(pipeline))
+        })
+        .ok()
+    }
+
+    fn mut_pipeline_state_for(&self, pipeline: PipelineId) -> Option<RefMut<'_, PerPipelineState>> {
+        RefMut::filter_map(self.per_pipeline_state.borrow_mut(), |state| {
+            state.get_mut(&NoTrace(pipeline))
+        })
+        .ok()
+    }
+
+    pub(crate) fn wants_updates_for_node(&self, pipeline: PipelineId, node: &Node) -> bool {
+        let Some(unique_id) = node.unique_id_if_already_present() else {
+            // This node does not have a unique id, so clearly the devtools inspector
+            // hasn't seen it before.
+            return false;
+        };
+        self.pipeline_state_for(pipeline)
+            .is_some_and(|pipeline_state| pipeline_state.known_nodes.contains_key(&unique_id))
+    }
+
+    fn find_node_by_unique_id(&self, pipeline: PipelineId, node_id: &str) -> Option<DomRoot<Node>> {
+        self.pipeline_state_for(pipeline)?
+            .known_nodes
+            .get(node_id)
+            .map(|node: &Dom<Node>| node.as_rooted())
     }
 }
 
@@ -178,516 +224,469 @@ pub(crate) fn handle_get_css_database(reply: GenericSender<HashMap<String, CssDa
     let _ = reply.send(database);
 }
 
-impl DevtoolsState {
-    pub(crate) fn notify_pipeline_created(&self, pipeline: PipelineId) {
-        self.per_pipeline_state.borrow_mut().insert(
-            NoTrace(pipeline),
-            PerPipelineState {
-                pipeline,
-                known_nodes: Default::default(),
-            },
-        );
-    }
-    pub(crate) fn notify_pipeline_exited(&self, pipeline: PipelineId) {
-        self.per_pipeline_state
-            .borrow_mut()
-            .remove(&NoTrace(pipeline));
-    }
+pub(crate) fn handle_get_event_listener_info(
+    state: &DevtoolsState,
+    pipeline: PipelineId,
+    node_id: &str,
+    reply: GenericSender<Vec<EventListenerInfo>>,
+) {
+    let Some(node) = state.find_node_by_unique_id(pipeline, node_id) else {
+        reply.send(vec![]).unwrap();
+        return;
+    };
 
-    fn pipeline_state_for(&self, pipeline: PipelineId) -> Option<Ref<'_, PerPipelineState>> {
-        Ref::filter_map(self.per_pipeline_state.borrow(), |state| {
-            state.get(&NoTrace(pipeline))
+    let event_listeners = node
+        .upcast::<EventTarget>()
+        .summarize_event_listeners_for_devtools();
+    reply.send(event_listeners).unwrap();
+}
+
+pub(crate) fn handle_get_root_node(
+    state: &DevtoolsState,
+    documents: &DocumentCollection,
+    pipeline: PipelineId,
+    reply: GenericSender<Option<NodeInfo>>,
+    can_gc: CanGc,
+) {
+    let info = documents
+        .find_document(pipeline)
+        .map(DomRoot::upcast::<Node>)
+        .inspect(|node| {
+            state
+                .mut_pipeline_state_for(pipeline)
+                .unwrap()
+                .register_node(node)
         })
-        .ok()
-    }
+        .map(|document| document.upcast::<Node>().summarize(can_gc));
+    reply.send(info).unwrap();
+}
 
-    fn mut_pipeline_state_for(&self, pipeline: PipelineId) -> Option<RefMut<'_, PerPipelineState>> {
-        RefMut::filter_map(self.per_pipeline_state.borrow_mut(), |state| {
-            state.get_mut(&NoTrace(pipeline))
+pub(crate) fn handle_get_document_element(
+    state: &DevtoolsState,
+    documents: &DocumentCollection,
+    pipeline: PipelineId,
+    reply: GenericSender<Option<NodeInfo>>,
+    can_gc: CanGc,
+) {
+    let info = documents
+        .find_document(pipeline)
+        .and_then(|document| document.GetDocumentElement())
+        .inspect(|element| {
+            state
+                .mut_pipeline_state_for(pipeline)
+                .unwrap()
+                .register_node(element.upcast())
         })
-        .ok()
-    }
+        .map(|element| element.upcast::<Node>().summarize(can_gc));
+    reply.send(info).unwrap();
+}
 
-    pub(crate) fn wants_updates_for_node(&self, pipeline: PipelineId, node: &Node) -> bool {
-        let Some(unique_id) = node.unique_id_if_already_present() else {
-            // This node does not have a unique id, so clearly the devtools inspector
-            // hasn't seen it before.
-            return false;
-        };
-        self.pipeline_state_for(pipeline)
-            .is_some_and(|pipeline_state| pipeline_state.known_nodes.contains_key(&unique_id))
-    }
+pub(crate) fn handle_get_children(
+    state: &DevtoolsState,
+    pipeline: PipelineId,
+    node_id: &str,
+    reply: GenericSender<Option<Vec<NodeInfo>>>,
+    can_gc: CanGc,
+) {
+    let Some(parent) = state.find_node_by_unique_id(pipeline, node_id) else {
+        reply.send(None).unwrap();
+        return;
+    };
+    let is_whitespace = |node: &NodeInfo| {
+        node.node_type == NodeConstants::TEXT_NODE &&
+            node.node_value.as_ref().is_none_or(|v| v.trim().is_empty())
+    };
+    let mut pipeline_state = state.mut_pipeline_state_for(pipeline).unwrap();
 
-    pub(crate) fn handle_get_event_listener_info(
-        &self,
-        pipeline: PipelineId,
-        node_id: &str,
-        reply: GenericSender<Vec<EventListenerInfo>>,
-    ) {
-        let Some(node) = self.find_node_by_unique_id(pipeline, node_id) else {
-            reply.send(vec![]).unwrap();
-            return;
-        };
+    let inline: Vec<_> = parent
+        .children()
+        .map(|child| {
+            let window = child.owner_window();
+            let Some(elem) = child.downcast::<Element>() else {
+                return false;
+            };
+            let computed_style = window.GetComputedStyle(elem, None);
+            let display = computed_style.Display();
+            display == "inline"
+        })
+        .collect();
 
-        let event_listeners = node
-            .upcast::<EventTarget>()
-            .summarize_event_listeners_for_devtools();
-        reply.send(event_listeners).unwrap();
-    }
-
-    pub(crate) fn handle_get_root_node(
-        &self,
-        documents: &DocumentCollection,
-        pipeline: PipelineId,
-        reply: GenericSender<Option<NodeInfo>>,
-        can_gc: CanGc,
-    ) {
-        let info = documents
-            .find_document(pipeline)
-            .map(DomRoot::upcast::<Node>)
-            .inspect(|node| {
-                self.mut_pipeline_state_for(pipeline)
-                    .unwrap()
-                    .register_node(node)
-            })
-            .map(|document| document.upcast::<Node>().summarize(can_gc));
-        reply.send(info).unwrap();
-    }
-
-    pub(crate) fn handle_get_document_element(
-        &self,
-        documents: &DocumentCollection,
-        pipeline: PipelineId,
-        reply: GenericSender<Option<NodeInfo>>,
-        can_gc: CanGc,
-    ) {
-        let info = documents
-            .find_document(pipeline)
-            .and_then(|document| document.GetDocumentElement())
-            .inspect(|element| {
-                self.mut_pipeline_state_for(pipeline)
-                    .unwrap()
-                    .register_node(element.upcast())
-            })
-            .map(|element| element.upcast::<Node>().summarize(can_gc));
-        reply.send(info).unwrap();
-    }
-
-    fn find_node_by_unique_id(&self, pipeline: PipelineId, node_id: &str) -> Option<DomRoot<Node>> {
-        self.pipeline_state_for(pipeline)?
-            .known_nodes
-            .get(node_id)
-            .map(|node: &Dom<Node>| node.as_rooted())
-    }
-
-    pub(crate) fn handle_get_children(
-        &self,
-        pipeline: PipelineId,
-        node_id: &str,
-        reply: GenericSender<Option<Vec<NodeInfo>>>,
-        can_gc: CanGc,
-    ) {
-        let Some(parent) = self.find_node_by_unique_id(pipeline, node_id) else {
-            reply.send(None).unwrap();
-            return;
-        };
-        let is_whitespace = |node: &NodeInfo| {
-            node.node_type == NodeConstants::TEXT_NODE &&
-                node.node_value.as_ref().is_none_or(|v| v.trim().is_empty())
-        };
-        let mut pipeline_state = self.mut_pipeline_state_for(pipeline).unwrap();
-
-        let inline: Vec<_> = parent
-            .children()
-            .map(|child| {
-                let window = child.owner_window();
-                let Some(elem) = child.downcast::<Element>() else {
-                    return false;
-                };
-                let computed_style = window.GetComputedStyle(elem, None);
-                let display = computed_style.Display();
-                display == "inline"
-            })
-            .collect();
-
-        let mut children = vec![];
-        if let Some(shadow_root) = parent.downcast::<Element>().and_then(Element::shadow_root) {
-            if !shadow_root.is_user_agent_widget() ||
-                pref!(inspector_show_servo_internal_shadow_roots)
-            {
-                children.push(shadow_root.upcast::<Node>().summarize(can_gc));
-            }
+    let mut children = vec![];
+    if let Some(shadow_root) = parent.downcast::<Element>().and_then(Element::shadow_root) {
+        if !shadow_root.is_user_agent_widget() || pref!(inspector_show_servo_internal_shadow_roots)
+        {
+            children.push(shadow_root.upcast::<Node>().summarize(can_gc));
         }
-        let children_iter = parent.children().enumerate().filter_map(|(i, child)| {
-            // Filter whitespace only text nodes that are not inline level
-            // https://firefox-source-docs.mozilla.org/devtools-user/page_inspector/how_to/examine_and_edit_html/index.html#whitespace-only-text-nodes
-            let prev_inline = i > 0 && inline[i - 1];
-            let next_inline = i < inline.len() - 1 && inline[i + 1];
-            let is_inline_level = prev_inline && next_inline;
+    }
+    let children_iter = parent.children().enumerate().filter_map(|(i, child)| {
+        // Filter whitespace only text nodes that are not inline level
+        // https://firefox-source-docs.mozilla.org/devtools-user/page_inspector/how_to/examine_and_edit_html/index.html#whitespace-only-text-nodes
+        let prev_inline = i > 0 && inline[i - 1];
+        let next_inline = i < inline.len() - 1 && inline[i + 1];
+        let is_inline_level = prev_inline && next_inline;
 
-            let info = child.summarize(can_gc);
-            if is_whitespace(&info) && !is_inline_level {
-                return None;
+        let info = child.summarize(can_gc);
+        if is_whitespace(&info) && !is_inline_level {
+            return None;
+        }
+        pipeline_state.register_node(&child);
+
+        Some(info)
+    });
+    children.extend(children_iter);
+
+    reply.send(Some(children)).unwrap();
+}
+
+pub(crate) fn handle_get_attribute_style(
+    state: &DevtoolsState,
+    pipeline: PipelineId,
+    node_id: &str,
+    reply: GenericSender<Option<Vec<NodeStyle>>>,
+    can_gc: CanGc,
+) {
+    let node = match state.find_node_by_unique_id(pipeline, node_id) {
+        None => return reply.send(None).unwrap(),
+        Some(found_node) => found_node,
+    };
+
+    let Some(elem) = node.downcast::<HTMLElement>() else {
+        // the style attribute only works on html elements
+        reply.send(None).unwrap();
+        return;
+    };
+    let style = elem.Style(can_gc);
+
+    let msg = (0..style.Length())
+        .map(|i| {
+            let name = style.Item(i);
+            NodeStyle {
+                name: name.to_string(),
+                value: style.GetPropertyValue(name.clone()).to_string(),
+                priority: style.GetPropertyPriority(name).to_string(),
             }
-            pipeline_state.register_node(&child);
+        })
+        .collect();
 
-            Some(info)
-        });
-        children.extend(children_iter);
+    reply.send(Some(msg)).unwrap();
+}
 
-        reply.send(Some(children)).unwrap();
-    }
+#[cfg_attr(crown, expect(crown::unrooted_must_root))]
+#[allow(clippy::too_many_arguments)]
+pub(crate) fn handle_get_stylesheet_style(
+    state: &DevtoolsState,
+    documents: &DocumentCollection,
+    pipeline: PipelineId,
+    node_id: &str,
+    selector: String,
+    stylesheet: usize,
+    reply: GenericSender<Option<Vec<NodeStyle>>>,
+    can_gc: CanGc,
+) {
+    let msg = (|| {
+        let node = state.find_node_by_unique_id(pipeline, node_id)?;
 
-    pub(crate) fn handle_get_attribute_style(
-        &self,
-        pipeline: PipelineId,
-        node_id: &str,
-        reply: GenericSender<Option<Vec<NodeStyle>>>,
-        can_gc: CanGc,
-    ) {
-        let node = match self.find_node_by_unique_id(pipeline, node_id) {
-            None => return reply.send(None).unwrap(),
-            Some(found_node) => found_node,
-        };
+        let document = documents.find_document(pipeline)?;
+        let _realm = enter_realm(document.window());
+        let owner = node.stylesheet_list_owner();
 
-        let Some(elem) = node.downcast::<HTMLElement>() else {
-            // the style attribute only works on html elements
-            reply.send(None).unwrap();
-            return;
-        };
-        let style = elem.Style(can_gc);
+        let stylesheet = owner.stylesheet_at(stylesheet)?;
+        let list = stylesheet.GetCssRules(can_gc).ok()?;
 
-        let msg = (0..style.Length())
-            .map(|i| {
-                let name = style.Item(i);
-                NodeStyle {
-                    name: name.to_string(),
-                    value: style.GetPropertyValue(name.clone()).to_string(),
-                    priority: style.GetPropertyPriority(name).to_string(),
-                }
-            })
-            .collect();
-
-        reply.send(Some(msg)).unwrap();
-    }
-
-    #[cfg_attr(crown, expect(crown::unrooted_must_root))]
-    #[allow(clippy::too_many_arguments)]
-    pub(crate) fn handle_get_stylesheet_style(
-        &self,
-        documents: &DocumentCollection,
-        pipeline: PipelineId,
-        node_id: &str,
-        selector: String,
-        stylesheet: usize,
-        reply: GenericSender<Option<Vec<NodeStyle>>>,
-        can_gc: CanGc,
-    ) {
-        let msg = (|| {
-            let node = self.find_node_by_unique_id(pipeline, node_id)?;
-
-            let document = documents.find_document(pipeline)?;
-            let _realm = enter_realm(document.window());
-            let owner = node.stylesheet_list_owner();
-
-            let stylesheet = owner.stylesheet_at(stylesheet)?;
-            let list = stylesheet.GetCssRules(can_gc).ok()?;
-
-            let styles = (0..list.Length())
-                .filter_map(move |i| {
-                    let rule = list.Item(i, can_gc)?;
-                    let style = rule.downcast::<CSSStyleRule>()?;
-                    if selector != style.SelectorText() {
-                        return None;
-                    };
-                    Some(style.Style(can_gc))
-                })
-                .flat_map(|style| {
-                    (0..style.Length()).map(move |i| {
-                        let name = style.Item(i);
-                        NodeStyle {
-                            name: name.to_string(),
-                            value: style.GetPropertyValue(name.clone()).to_string(),
-                            priority: style.GetPropertyPriority(name).to_string(),
-                        }
-                    })
-                })
-                .collect();
-
-            Some(styles)
-        })();
-
-        reply.send(msg).unwrap();
-    }
-
-    #[cfg_attr(crown, expect(crown::unrooted_must_root))]
-    pub(crate) fn handle_get_selectors(
-        &self,
-        documents: &DocumentCollection,
-        pipeline: PipelineId,
-        node_id: &str,
-        reply: GenericSender<Option<Vec<(String, usize)>>>,
-        can_gc: CanGc,
-    ) {
-        let msg = (|| {
-            let node = self.find_node_by_unique_id(pipeline, node_id)?;
-
-            let document = documents.find_document(pipeline)?;
-            let _realm = enter_realm(document.window());
-            let owner = node.stylesheet_list_owner();
-
-            let rules = (0..owner.stylesheet_count())
-                .filter_map(|i| {
-                    let stylesheet = owner.stylesheet_at(i)?;
-                    let list = stylesheet.GetCssRules(can_gc).ok()?;
-                    let elem = node.downcast::<Element>()?;
-
-                    Some((0..list.Length()).filter_map(move |j| {
-                        let rule = list.Item(j, can_gc)?;
-                        let style = rule.downcast::<CSSStyleRule>()?;
-                        let selector = style.SelectorText();
-                        elem.Matches(selector.clone()).ok()?.then_some(())?;
-                        Some((selector.into(), i))
-                    }))
-                })
-                .flatten()
-                .collect();
-
-            Some(rules)
-        })();
-
-        reply.send(msg).unwrap();
-    }
-
-    pub(crate) fn handle_get_computed_style(
-        &self,
-        pipeline: PipelineId,
-        node_id: &str,
-        reply: GenericSender<Option<Vec<NodeStyle>>>,
-    ) {
-        let node = match self.find_node_by_unique_id(pipeline, node_id) {
-            None => return reply.send(None).unwrap(),
-            Some(found_node) => found_node,
-        };
-
-        let window = node.owner_window();
-        let elem = node
-            .downcast::<Element>()
-            .expect("This should be an element");
-        let computed_style = window.GetComputedStyle(elem, None);
-
-        let msg = (0..computed_style.Length())
-            .map(|i| {
-                let name = computed_style.Item(i);
-                NodeStyle {
-                    name: name.to_string(),
-                    value: computed_style.GetPropertyValue(name.clone()).to_string(),
-                    priority: computed_style.GetPropertyPriority(name).to_string(),
-                }
-            })
-            .collect();
-
-        reply.send(Some(msg)).unwrap();
-    }
-
-    pub(crate) fn handle_get_layout(
-        &self,
-        pipeline: PipelineId,
-        node_id: &str,
-        reply: GenericSender<Option<(ComputedNodeLayout, AutoMargins)>>,
-        can_gc: CanGc,
-    ) {
-        let node = match self.find_node_by_unique_id(pipeline, node_id) {
-            None => return reply.send(None).unwrap(),
-            Some(found_node) => found_node,
-        };
-        let auto_margins = determine_auto_margins(&node);
-
-        let elem = node
-            .downcast::<Element>()
-            .expect("should be getting layout of element");
-        let rect = elem.GetBoundingClientRect(can_gc);
-        let width = rect.Width() as f32;
-        let height = rect.Height() as f32;
-
-        let window = node.owner_window();
-        let computed_style = window.GetComputedStyle(elem, None);
-        let computed_layout = ComputedNodeLayout {
-            display: computed_style.Display().into(),
-            position: computed_style.Position().into(),
-            z_index: computed_style.ZIndex().into(),
-            box_sizing: computed_style.BoxSizing().into(),
-            margin_top: computed_style.MarginTop().into(),
-            margin_right: computed_style.MarginRight().into(),
-            margin_bottom: computed_style.MarginBottom().into(),
-            margin_left: computed_style.MarginLeft().into(),
-            border_top_width: computed_style.BorderTopWidth().into(),
-            border_right_width: computed_style.BorderRightWidth().into(),
-            border_bottom_width: computed_style.BorderBottomWidth().into(),
-            border_left_width: computed_style.BorderLeftWidth().into(),
-            padding_top: computed_style.PaddingTop().into(),
-            padding_right: computed_style.PaddingRight().into(),
-            padding_bottom: computed_style.PaddingBottom().into(),
-            padding_left: computed_style.PaddingLeft().into(),
-            width,
-            height,
-        };
-
-        reply.send(Some((computed_layout, auto_margins))).unwrap();
-    }
-
-    pub(crate) fn handle_get_xpath(
-        &self,
-        pipeline: PipelineId,
-        node_id: &str,
-        reply: GenericSender<String>,
-    ) {
-        let Some(node) = self.find_node_by_unique_id(pipeline, node_id) else {
-            return reply.send(Default::default()).unwrap();
-        };
-
-        let selector = node
-            .inclusive_ancestors(ShadowIncluding::Yes)
-            .filter_map(|ancestor| {
-                let Some(element) = ancestor.downcast::<Element>() else {
-                    // TODO: figure out how to handle shadow roots here
+        let styles = (0..list.Length())
+            .filter_map(move |i| {
+                let rule = list.Item(i, can_gc)?;
+                let style = rule.downcast::<CSSStyleRule>()?;
+                if selector != style.SelectorText() {
                     return None;
                 };
-
-                let mut result = "/".to_owned();
-                if *element.namespace() != ns!(html) {
-                    result.push_str(element.namespace());
-                    result.push(':');
-                }
-
-                result.push_str(element.local_name());
-
-                let would_node_also_match_selector = |sibling: &Node| {
-                    let Some(sibling) = sibling.downcast::<Element>() else {
-                        return false;
-                    };
-                    sibling.namespace() == element.namespace() &&
-                        sibling.local_name() == element.local_name()
-                };
-
-                let matching_elements_before = ancestor
-                    .preceding_siblings()
-                    .filter(|node| would_node_also_match_selector(node))
-                    .count();
-                let matching_elements_after = ancestor
-                    .following_siblings()
-                    .filter(|node| would_node_also_match_selector(node))
-                    .count();
-
-                if matching_elements_before + matching_elements_after != 0 {
-                    // Need to add an index (note that XPath uses 1-based indexing)
-                    result.push_str(&format!("[{}]", matching_elements_before + 1));
-                }
-
-                Some(result)
+                Some(style.Style(can_gc))
             })
-            .collect::<Vec<_>>()
-            .into_iter()
-            .rev()
-            .collect::<Vec<_>>()
-            .join("");
+            .flat_map(|style| {
+                (0..style.Length()).map(move |i| {
+                    let name = style.Item(i);
+                    NodeStyle {
+                        name: name.to_string(),
+                        value: style.GetPropertyValue(name.clone()).to_string(),
+                        priority: style.GetPropertyPriority(name).to_string(),
+                    }
+                })
+            })
+            .collect();
 
-        reply.send(selector).unwrap();
-    }
+        Some(styles)
+    })();
 
-    pub(crate) fn handle_modify_attribute(
-        &self,
-        documents: &DocumentCollection,
-        pipeline: PipelineId,
-        node_id: &str,
-        modifications: Vec<AttrModification>,
-        can_gc: CanGc,
-    ) {
-        let Some(document) = documents.find_document(pipeline) else {
-            return warn!("document for pipeline id {} is not found", &pipeline);
-        };
+    reply.send(msg).unwrap();
+}
+
+#[cfg_attr(crown, expect(crown::unrooted_must_root))]
+pub(crate) fn handle_get_selectors(
+    state: &DevtoolsState,
+    documents: &DocumentCollection,
+    pipeline: PipelineId,
+    node_id: &str,
+    reply: GenericSender<Option<Vec<(String, usize)>>>,
+    can_gc: CanGc,
+) {
+    let msg = (|| {
+        let node = state.find_node_by_unique_id(pipeline, node_id)?;
+
+        let document = documents.find_document(pipeline)?;
         let _realm = enter_realm(document.window());
+        let owner = node.stylesheet_list_owner();
 
-        let node = match self.find_node_by_unique_id(pipeline, node_id) {
-            None => {
-                return warn!(
-                    "node id {} for pipeline id {} is not found",
-                    &node_id, &pipeline
-                );
-            },
-            Some(found_node) => found_node,
-        };
+        let rules = (0..owner.stylesheet_count())
+            .filter_map(|i| {
+                let stylesheet = owner.stylesheet_at(i)?;
+                let list = stylesheet.GetCssRules(can_gc).ok()?;
+                let elem = node.downcast::<Element>()?;
 
-        let elem = node
-            .downcast::<Element>()
-            .expect("should be getting layout of element");
+                Some((0..list.Length()).filter_map(move |j| {
+                    let rule = list.Item(j, can_gc)?;
+                    let style = rule.downcast::<CSSStyleRule>()?;
+                    let selector = style.SelectorText();
+                    elem.Matches(selector.clone()).ok()?.then_some(())?;
+                    Some((selector.into(), i))
+                }))
+            })
+            .flatten()
+            .collect();
 
-        for modification in modifications {
-            match modification.new_value {
-                Some(string) => {
-                    elem.set_attribute(
-                        &LocalName::from(modification.attribute_name),
-                        AttrValue::String(string),
-                        can_gc,
-                    );
-                },
-                None => elem.RemoveAttribute(DOMString::from(modification.attribute_name), can_gc),
+        Some(rules)
+    })();
+
+    reply.send(msg).unwrap();
+}
+
+pub(crate) fn handle_get_computed_style(
+    state: &DevtoolsState,
+    pipeline: PipelineId,
+    node_id: &str,
+    reply: GenericSender<Option<Vec<NodeStyle>>>,
+) {
+    let node = match state.find_node_by_unique_id(pipeline, node_id) {
+        None => return reply.send(None).unwrap(),
+        Some(found_node) => found_node,
+    };
+
+    let window = node.owner_window();
+    let elem = node
+        .downcast::<Element>()
+        .expect("This should be an element");
+    let computed_style = window.GetComputedStyle(elem, None);
+
+    let msg = (0..computed_style.Length())
+        .map(|i| {
+            let name = computed_style.Item(i);
+            NodeStyle {
+                name: name.to_string(),
+                value: computed_style.GetPropertyValue(name.clone()).to_string(),
+                priority: computed_style.GetPropertyPriority(name).to_string(),
             }
-        }
-    }
+        })
+        .collect();
 
-    pub(crate) fn handle_modify_rule(
-        &self,
-        documents: &DocumentCollection,
-        pipeline: PipelineId,
-        node_id: &str,
-        modifications: Vec<RuleModification>,
-        can_gc: CanGc,
-    ) {
-        let Some(document) = documents.find_document(pipeline) else {
-            return warn!("Document for pipeline id {} is not found", &pipeline);
-        };
-        let _realm = enter_realm(document.window());
+    reply.send(Some(msg)).unwrap();
+}
 
-        let Some(node) = self.find_node_by_unique_id(pipeline, node_id) else {
+pub(crate) fn handle_get_layout(
+    state: &DevtoolsState,
+    pipeline: PipelineId,
+    node_id: &str,
+    reply: GenericSender<Option<(ComputedNodeLayout, AutoMargins)>>,
+    can_gc: CanGc,
+) {
+    let node = match state.find_node_by_unique_id(pipeline, node_id) {
+        None => return reply.send(None).unwrap(),
+        Some(found_node) => found_node,
+    };
+    let auto_margins = determine_auto_margins(&node);
+
+    let elem = node
+        .downcast::<Element>()
+        .expect("should be getting layout of element");
+    let rect = elem.GetBoundingClientRect(can_gc);
+    let width = rect.Width() as f32;
+    let height = rect.Height() as f32;
+
+    let window = node.owner_window();
+    let computed_style = window.GetComputedStyle(elem, None);
+    let computed_layout = ComputedNodeLayout {
+        display: computed_style.Display().into(),
+        position: computed_style.Position().into(),
+        z_index: computed_style.ZIndex().into(),
+        box_sizing: computed_style.BoxSizing().into(),
+        margin_top: computed_style.MarginTop().into(),
+        margin_right: computed_style.MarginRight().into(),
+        margin_bottom: computed_style.MarginBottom().into(),
+        margin_left: computed_style.MarginLeft().into(),
+        border_top_width: computed_style.BorderTopWidth().into(),
+        border_right_width: computed_style.BorderRightWidth().into(),
+        border_bottom_width: computed_style.BorderBottomWidth().into(),
+        border_left_width: computed_style.BorderLeftWidth().into(),
+        padding_top: computed_style.PaddingTop().into(),
+        padding_right: computed_style.PaddingRight().into(),
+        padding_bottom: computed_style.PaddingBottom().into(),
+        padding_left: computed_style.PaddingLeft().into(),
+        width,
+        height,
+    };
+
+    reply.send(Some((computed_layout, auto_margins))).unwrap();
+}
+
+pub(crate) fn handle_get_xpath(
+    state: &DevtoolsState,
+    pipeline: PipelineId,
+    node_id: &str,
+    reply: GenericSender<String>,
+) {
+    let Some(node) = state.find_node_by_unique_id(pipeline, node_id) else {
+        return reply.send(Default::default()).unwrap();
+    };
+
+    let selector = node
+        .inclusive_ancestors(ShadowIncluding::Yes)
+        .filter_map(|ancestor| {
+            let Some(element) = ancestor.downcast::<Element>() else {
+                // TODO: figure out how to handle shadow roots here
+                return None;
+            };
+
+            let mut result = "/".to_owned();
+            if *element.namespace() != ns!(html) {
+                result.push_str(element.namespace());
+                result.push(':');
+            }
+
+            result.push_str(element.local_name());
+
+            let would_node_also_match_selector = |sibling: &Node| {
+                let Some(sibling) = sibling.downcast::<Element>() else {
+                    return false;
+                };
+                sibling.namespace() == element.namespace() &&
+                    sibling.local_name() == element.local_name()
+            };
+
+            let matching_elements_before = ancestor
+                .preceding_siblings()
+                .filter(|node| would_node_also_match_selector(node))
+                .count();
+            let matching_elements_after = ancestor
+                .following_siblings()
+                .filter(|node| would_node_also_match_selector(node))
+                .count();
+
+            if matching_elements_before + matching_elements_after != 0 {
+                // Need to add an index (note that XPath uses 1-based indexing)
+                result.push_str(&format!("[{}]", matching_elements_before + 1));
+            }
+
+            Some(result)
+        })
+        .collect::<Vec<_>>()
+        .into_iter()
+        .rev()
+        .collect::<Vec<_>>()
+        .join("");
+
+    reply.send(selector).unwrap();
+}
+
+pub(crate) fn handle_modify_attribute(
+    state: &DevtoolsState,
+    documents: &DocumentCollection,
+    pipeline: PipelineId,
+    node_id: &str,
+    modifications: Vec<AttrModification>,
+    can_gc: CanGc,
+) {
+    let Some(document) = documents.find_document(pipeline) else {
+        return warn!("document for pipeline id {} is not found", &pipeline);
+    };
+    let _realm = enter_realm(document.window());
+
+    let node = match state.find_node_by_unique_id(pipeline, node_id) {
+        None => {
             return warn!(
-                "Node id {} for pipeline id {} is not found",
+                "node id {} for pipeline id {} is not found",
                 &node_id, &pipeline
             );
-        };
+        },
+        Some(found_node) => found_node,
+    };
 
-        let elem = node
-            .downcast::<HTMLElement>()
-            .expect("This should be an HTMLElement");
-        let style = elem.Style(can_gc);
+    let elem = node
+        .downcast::<Element>()
+        .expect("should be getting layout of element");
 
-        for modification in modifications {
-            let _ = style.SetProperty(
-                modification.name.into(),
-                modification.value.into(),
-                modification.priority.into(),
-                can_gc,
-            );
+    for modification in modifications {
+        match modification.new_value {
+            Some(string) => {
+                elem.set_attribute(
+                    &LocalName::from(modification.attribute_name),
+                    AttrValue::String(string),
+                    can_gc,
+                );
+            },
+            None => elem.RemoveAttribute(DOMString::from(modification.attribute_name), can_gc),
         }
     }
+}
 
-    pub(crate) fn handle_highlight_dom_node(
-        &self,
-        documents: &DocumentCollection,
-        id: PipelineId,
-        node_id: Option<&str>,
-    ) {
-        let node = node_id.and_then(|node_id| {
-            let node = self.find_node_by_unique_id(id, node_id);
-            if node.is_none() {
-                log::warn!("Node id {node_id} for pipeline id {id} is not found",);
-            }
-            node
-        });
+pub(crate) fn handle_modify_rule(
+    state: &DevtoolsState,
+    documents: &DocumentCollection,
+    pipeline: PipelineId,
+    node_id: &str,
+    modifications: Vec<RuleModification>,
+    can_gc: CanGc,
+) {
+    let Some(document) = documents.find_document(pipeline) else {
+        return warn!("Document for pipeline id {} is not found", &pipeline);
+    };
+    let _realm = enter_realm(document.window());
 
-        if let Some(window) = documents.find_window(id) {
-            window.Document().highlight_dom_node(node.as_deref());
+    let Some(node) = state.find_node_by_unique_id(pipeline, node_id) else {
+        return warn!(
+            "Node id {} for pipeline id {} is not found",
+            &node_id, &pipeline
+        );
+    };
+
+    let elem = node
+        .downcast::<HTMLElement>()
+        .expect("This should be an HTMLElement");
+    let style = elem.Style(can_gc);
+
+    for modification in modifications {
+        let _ = style.SetProperty(
+            modification.name.into(),
+            modification.value.into(),
+            modification.priority.into(),
+            can_gc,
+        );
+    }
+}
+
+pub(crate) fn handle_highlight_dom_node(
+    state: &DevtoolsState,
+    documents: &DocumentCollection,
+    id: PipelineId,
+    node_id: Option<&str>,
+) {
+    let node = node_id.and_then(|node_id| {
+        let node = state.find_node_by_unique_id(id, node_id);
+        if node.is_none() {
+            log::warn!("Node id {node_id} for pipeline id {id} is not found",);
         }
+        node
+    });
+
+    if let Some(window) = documents.find_window(id) {
+        window.Document().highlight_dom_node(node.as_deref());
     }
 }
 

--- a/components/script/devtools.rs
+++ b/components/script/devtools.rs
@@ -2,6 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
+use std::cell::{Ref, RefCell, RefMut};
 use std::collections::HashMap;
 use std::str;
 
@@ -16,6 +17,8 @@ use js::conversions::jsstr_to_string;
 use js::jsval::UndefinedValue;
 use js::rust::ToString;
 use markup5ever::{LocalName, ns};
+use rustc_hash::FxHashMap;
+use script_bindings::root::Dom;
 use servo_config::pref;
 use style::attr::AttrValue;
 use uuid::Uuid;
@@ -35,6 +38,7 @@ use crate::dom::bindings::conversions::{ConversionResult, FromJSValConvertible};
 use crate::dom::bindings::inheritance::Castable;
 use crate::dom::bindings::root::DomRoot;
 use crate::dom::bindings::str::DOMString;
+use crate::dom::bindings::trace::NoTrace;
 use crate::dom::css::cssstyledeclaration::ENABLED_LONGHAND_PROPERTIES;
 use crate::dom::css::cssstylerule::CSSStyleRule;
 use crate::dom::document::AnimationFrameCallback;
@@ -44,6 +48,33 @@ use crate::dom::node::{Node, NodeTraits, ShadowIncluding};
 use crate::dom::types::{EventTarget, HTMLElement};
 use crate::realms::{enter_auto_realm, enter_realm};
 use crate::script_runtime::{CanGc, IntroductionType};
+
+#[cfg_attr(crown, crown::unrooted_must_root_lint::must_root)]
+#[derive(JSTraceable)]
+pub(crate) struct PerPipelineState {
+    #[no_trace]
+    pipeline: PipelineId,
+
+    /// Maps from a node's unique ID to the Node itself
+    known_nodes: FxHashMap<String, Dom<Node>>,
+}
+
+#[cfg_attr(crown, crown::unrooted_must_root_lint::must_root)]
+#[derive(JSTraceable, Default)]
+pub(crate) struct DevtoolsState {
+    per_pipeline_state: RefCell<FxHashMap<NoTrace<PipelineId>, PerPipelineState>>,
+}
+
+impl PerPipelineState {
+    fn register_node(&mut self, node: &Node) {
+        let unique_id = node.unique_id(self.pipeline);
+        if self.known_nodes.contains_key(&unique_id) {
+            return;
+        }
+
+        self.known_nodes.insert(unique_id, Dom::from_ref(node));
+    }
+}
 
 #[expect(unsafe_code)]
 pub(crate) fn handle_evaluate_js(
@@ -97,462 +128,6 @@ pub(crate) fn handle_evaluate_js(
     reply.send(result).unwrap();
 }
 
-pub(crate) fn handle_get_event_listener_info(
-    documents: &DocumentCollection,
-    pipeline: PipelineId,
-    node_id: &str,
-    reply: GenericSender<Vec<EventListenerInfo>>,
-) {
-    let Some(node) = find_node_by_unique_id(documents, pipeline, node_id) else {
-        reply.send(vec![]).unwrap();
-        return;
-    };
-
-    let event_listeners = node
-        .upcast::<EventTarget>()
-        .summarize_event_listeners_for_devtools();
-    reply.send(event_listeners).unwrap();
-}
-
-pub(crate) fn handle_get_root_node(
-    documents: &DocumentCollection,
-    pipeline: PipelineId,
-    reply: GenericSender<Option<NodeInfo>>,
-    can_gc: CanGc,
-) {
-    let info = documents
-        .find_document(pipeline)
-        .map(|document| document.upcast::<Node>().summarize(can_gc));
-    reply.send(info).unwrap();
-}
-
-pub(crate) fn handle_get_document_element(
-    documents: &DocumentCollection,
-    pipeline: PipelineId,
-    reply: GenericSender<Option<NodeInfo>>,
-    can_gc: CanGc,
-) {
-    let info = documents
-        .find_document(pipeline)
-        .and_then(|document| document.GetDocumentElement())
-        .map(|element| element.upcast::<Node>().summarize(can_gc));
-    reply.send(info).unwrap();
-}
-
-fn find_node_by_unique_id(
-    documents: &DocumentCollection,
-    pipeline: PipelineId,
-    node_id: &str,
-) -> Option<DomRoot<Node>> {
-    documents.find_document(pipeline).and_then(|document| {
-        document
-            .upcast::<Node>()
-            .traverse_preorder(ShadowIncluding::Yes)
-            .find(|candidate| candidate.unique_id(pipeline) == node_id)
-    })
-}
-
-pub(crate) fn handle_get_children(
-    documents: &DocumentCollection,
-    pipeline: PipelineId,
-    node_id: String,
-    reply: GenericSender<Option<Vec<NodeInfo>>>,
-    can_gc: CanGc,
-) {
-    match find_node_by_unique_id(documents, pipeline, &node_id) {
-        None => reply.send(None).unwrap(),
-        Some(parent) => {
-            let is_whitespace = |node: &NodeInfo| {
-                node.node_type == NodeConstants::TEXT_NODE &&
-                    node.node_value.as_ref().is_none_or(|v| v.trim().is_empty())
-            };
-
-            let inline: Vec<_> = parent
-                .children()
-                .map(|child| {
-                    let window = child.owner_window();
-                    let Some(elem) = child.downcast::<Element>() else {
-                        return false;
-                    };
-                    let computed_style = window.GetComputedStyle(elem, None);
-                    let display = computed_style.Display();
-                    display == "inline"
-                })
-                .collect();
-
-            let mut children = vec![];
-            if let Some(shadow_root) = parent.downcast::<Element>().and_then(Element::shadow_root) {
-                if !shadow_root.is_user_agent_widget() ||
-                    pref!(inspector_show_servo_internal_shadow_roots)
-                {
-                    children.push(shadow_root.upcast::<Node>().summarize(can_gc));
-                }
-            }
-            let children_iter = parent.children().enumerate().filter_map(|(i, child)| {
-                // Filter whitespace only text nodes that are not inline level
-                // https://firefox-source-docs.mozilla.org/devtools-user/page_inspector/how_to/examine_and_edit_html/index.html#whitespace-only-text-nodes
-                let prev_inline = i > 0 && inline[i - 1];
-                let next_inline = i < inline.len() - 1 && inline[i + 1];
-
-                let info = child.summarize(can_gc);
-                if !is_whitespace(&info) {
-                    return Some(info);
-                }
-
-                (prev_inline && next_inline).then_some(info)
-            });
-            children.extend(children_iter);
-
-            reply.send(Some(children)).unwrap();
-        },
-    };
-}
-
-pub(crate) fn handle_get_attribute_style(
-    documents: &DocumentCollection,
-    pipeline: PipelineId,
-    node_id: String,
-    reply: GenericSender<Option<Vec<NodeStyle>>>,
-    can_gc: CanGc,
-) {
-    let node = match find_node_by_unique_id(documents, pipeline, &node_id) {
-        None => return reply.send(None).unwrap(),
-        Some(found_node) => found_node,
-    };
-
-    let Some(elem) = node.downcast::<HTMLElement>() else {
-        // the style attribute only works on html elements
-        reply.send(None).unwrap();
-        return;
-    };
-    let style = elem.Style(can_gc);
-
-    let msg = (0..style.Length())
-        .map(|i| {
-            let name = style.Item(i);
-            NodeStyle {
-                name: name.to_string(),
-                value: style.GetPropertyValue(name.clone()).to_string(),
-                priority: style.GetPropertyPriority(name).to_string(),
-            }
-        })
-        .collect();
-
-    reply.send(Some(msg)).unwrap();
-}
-
-#[cfg_attr(crown, expect(crown::unrooted_must_root))]
-pub(crate) fn handle_get_stylesheet_style(
-    documents: &DocumentCollection,
-    pipeline: PipelineId,
-    node_id: String,
-    selector: String,
-    stylesheet: usize,
-    reply: GenericSender<Option<Vec<NodeStyle>>>,
-    can_gc: CanGc,
-) {
-    let msg = (|| {
-        let node = find_node_by_unique_id(documents, pipeline, &node_id)?;
-
-        let document = documents.find_document(pipeline)?;
-        let _realm = enter_realm(document.window());
-        let owner = node.stylesheet_list_owner();
-
-        let stylesheet = owner.stylesheet_at(stylesheet)?;
-        let list = stylesheet.GetCssRules(can_gc).ok()?;
-
-        let styles = (0..list.Length())
-            .filter_map(move |i| {
-                let rule = list.Item(i, can_gc)?;
-                let style = rule.downcast::<CSSStyleRule>()?;
-                if selector != style.SelectorText() {
-                    return None;
-                };
-                Some(style.Style(can_gc))
-            })
-            .flat_map(|style| {
-                (0..style.Length()).map(move |i| {
-                    let name = style.Item(i);
-                    NodeStyle {
-                        name: name.to_string(),
-                        value: style.GetPropertyValue(name.clone()).to_string(),
-                        priority: style.GetPropertyPriority(name).to_string(),
-                    }
-                })
-            })
-            .collect();
-
-        Some(styles)
-    })();
-
-    reply.send(msg).unwrap();
-}
-
-#[cfg_attr(crown, expect(crown::unrooted_must_root))]
-pub(crate) fn handle_get_selectors(
-    documents: &DocumentCollection,
-    pipeline: PipelineId,
-    node_id: String,
-    reply: GenericSender<Option<Vec<(String, usize)>>>,
-    can_gc: CanGc,
-) {
-    let msg = (|| {
-        let node = find_node_by_unique_id(documents, pipeline, &node_id)?;
-
-        let document = documents.find_document(pipeline)?;
-        let _realm = enter_realm(document.window());
-        let owner = node.stylesheet_list_owner();
-
-        let rules = (0..owner.stylesheet_count())
-            .filter_map(|i| {
-                let stylesheet = owner.stylesheet_at(i)?;
-                let list = stylesheet.GetCssRules(can_gc).ok()?;
-                let elem = node.downcast::<Element>()?;
-
-                Some((0..list.Length()).filter_map(move |j| {
-                    let rule = list.Item(j, can_gc)?;
-                    let style = rule.downcast::<CSSStyleRule>()?;
-                    let selector = style.SelectorText();
-                    elem.Matches(selector.clone()).ok()?.then_some(())?;
-                    Some((selector.into(), i))
-                }))
-            })
-            .flatten()
-            .collect();
-
-        Some(rules)
-    })();
-
-    reply.send(msg).unwrap();
-}
-
-pub(crate) fn handle_get_computed_style(
-    documents: &DocumentCollection,
-    pipeline: PipelineId,
-    node_id: String,
-    reply: GenericSender<Option<Vec<NodeStyle>>>,
-) {
-    let node = match find_node_by_unique_id(documents, pipeline, &node_id) {
-        None => return reply.send(None).unwrap(),
-        Some(found_node) => found_node,
-    };
-
-    let window = node.owner_window();
-    let elem = node
-        .downcast::<Element>()
-        .expect("This should be an element");
-    let computed_style = window.GetComputedStyle(elem, None);
-
-    let msg = (0..computed_style.Length())
-        .map(|i| {
-            let name = computed_style.Item(i);
-            NodeStyle {
-                name: name.to_string(),
-                value: computed_style.GetPropertyValue(name.clone()).to_string(),
-                priority: computed_style.GetPropertyPriority(name).to_string(),
-            }
-        })
-        .collect();
-
-    reply.send(Some(msg)).unwrap();
-}
-
-pub(crate) fn handle_get_layout(
-    documents: &DocumentCollection,
-    pipeline: PipelineId,
-    node_id: String,
-    reply: GenericSender<Option<(ComputedNodeLayout, AutoMargins)>>,
-    can_gc: CanGc,
-) {
-    let node = match find_node_by_unique_id(documents, pipeline, &node_id) {
-        None => return reply.send(None).unwrap(),
-        Some(found_node) => found_node,
-    };
-    let auto_margins = determine_auto_margins(&node);
-
-    let elem = node
-        .downcast::<Element>()
-        .expect("should be getting layout of element");
-    let rect = elem.GetBoundingClientRect(can_gc);
-    let width = rect.Width() as f32;
-    let height = rect.Height() as f32;
-
-    let window = node.owner_window();
-    let computed_style = window.GetComputedStyle(elem, None);
-    let computed_layout = ComputedNodeLayout {
-        display: computed_style.Display().into(),
-        position: computed_style.Position().into(),
-        z_index: computed_style.ZIndex().into(),
-        box_sizing: computed_style.BoxSizing().into(),
-        margin_top: computed_style.MarginTop().into(),
-        margin_right: computed_style.MarginRight().into(),
-        margin_bottom: computed_style.MarginBottom().into(),
-        margin_left: computed_style.MarginLeft().into(),
-        border_top_width: computed_style.BorderTopWidth().into(),
-        border_right_width: computed_style.BorderRightWidth().into(),
-        border_bottom_width: computed_style.BorderBottomWidth().into(),
-        border_left_width: computed_style.BorderLeftWidth().into(),
-        padding_top: computed_style.PaddingTop().into(),
-        padding_right: computed_style.PaddingRight().into(),
-        padding_bottom: computed_style.PaddingBottom().into(),
-        padding_left: computed_style.PaddingLeft().into(),
-        width,
-        height,
-    };
-
-    reply.send(Some((computed_layout, auto_margins))).unwrap();
-}
-
-pub(crate) fn handle_get_xpath(
-    documents: &DocumentCollection,
-    pipeline: PipelineId,
-    node_id: String,
-    reply: GenericSender<String>,
-) {
-    let Some(node) = find_node_by_unique_id(documents, pipeline, &node_id) else {
-        return reply.send(Default::default()).unwrap();
-    };
-
-    let selector = node
-        .inclusive_ancestors(ShadowIncluding::Yes)
-        .filter_map(|ancestor| {
-            let Some(element) = ancestor.downcast::<Element>() else {
-                // TODO: figure out how to handle shadow roots here
-                return None;
-            };
-
-            let mut result = "/".to_owned();
-            if *element.namespace() != ns!(html) {
-                result.push_str(element.namespace());
-                result.push(':');
-            }
-
-            result.push_str(element.local_name());
-
-            let would_node_also_match_selector = |sibling: &Node| {
-                let Some(sibling) = sibling.downcast::<Element>() else {
-                    return false;
-                };
-                sibling.namespace() == element.namespace() &&
-                    sibling.local_name() == element.local_name()
-            };
-
-            let matching_elements_before = ancestor
-                .preceding_siblings()
-                .filter(|node| would_node_also_match_selector(node))
-                .count();
-            let matching_elements_after = ancestor
-                .following_siblings()
-                .filter(|node| would_node_also_match_selector(node))
-                .count();
-
-            if matching_elements_before + matching_elements_after != 0 {
-                // Need to add an index (note that XPath uses 1-based indexing)
-                result.push_str(&format!("[{}]", matching_elements_before + 1));
-            }
-
-            Some(result)
-        })
-        .collect::<Vec<_>>()
-        .into_iter()
-        .rev()
-        .collect::<Vec<_>>()
-        .join("");
-
-    reply.send(selector).unwrap();
-}
-
-fn determine_auto_margins(node: &Node) -> AutoMargins {
-    let Some(style) = node.style() else {
-        return AutoMargins::default();
-    };
-    let margin = style.get_margin();
-    AutoMargins {
-        top: margin.margin_top.is_auto(),
-        right: margin.margin_right.is_auto(),
-        bottom: margin.margin_bottom.is_auto(),
-        left: margin.margin_left.is_auto(),
-    }
-}
-
-pub(crate) fn handle_modify_attribute(
-    documents: &DocumentCollection,
-    pipeline: PipelineId,
-    node_id: String,
-    modifications: Vec<AttrModification>,
-    can_gc: CanGc,
-) {
-    let Some(document) = documents.find_document(pipeline) else {
-        return warn!("document for pipeline id {} is not found", &pipeline);
-    };
-    let _realm = enter_realm(document.window());
-
-    let node = match find_node_by_unique_id(documents, pipeline, &node_id) {
-        None => {
-            return warn!(
-                "node id {} for pipeline id {} is not found",
-                &node_id, &pipeline
-            );
-        },
-        Some(found_node) => found_node,
-    };
-
-    let elem = node
-        .downcast::<Element>()
-        .expect("should be getting layout of element");
-
-    for modification in modifications {
-        match modification.new_value {
-            Some(string) => {
-                elem.set_attribute(
-                    &LocalName::from(modification.attribute_name),
-                    AttrValue::String(string),
-                    can_gc,
-                );
-            },
-            None => elem.RemoveAttribute(DOMString::from(modification.attribute_name), can_gc),
-        }
-    }
-}
-
-pub(crate) fn handle_modify_rule(
-    documents: &DocumentCollection,
-    pipeline: PipelineId,
-    node_id: String,
-    modifications: Vec<RuleModification>,
-    can_gc: CanGc,
-) {
-    let Some(document) = documents.find_document(pipeline) else {
-        return warn!("Document for pipeline id {} is not found", &pipeline);
-    };
-    let _realm = enter_realm(document.window());
-
-    let Some(node) = find_node_by_unique_id(documents, pipeline, &node_id) else {
-        return warn!(
-            "Node id {} for pipeline id {} is not found",
-            &node_id, &pipeline
-        );
-    };
-
-    let elem = node
-        .downcast::<HTMLElement>()
-        .expect("This should be an HTMLElement");
-    let style = elem.Style(can_gc);
-
-    for modification in modifications {
-        let _ = style.SetProperty(
-            modification.name.into(),
-            modification.value.into(),
-            modification.priority.into(),
-            can_gc,
-        );
-    }
-}
-
-pub(crate) fn handle_wants_live_notifications(global: &GlobalScope, send_notifications: bool) {
-    global.set_devtools_wants_updates(send_notifications);
-}
-
 pub(crate) fn handle_set_timeline_markers(
     documents: &DocumentCollection,
     pipeline: PipelineId,
@@ -603,20 +178,528 @@ pub(crate) fn handle_get_css_database(reply: GenericSender<HashMap<String, CssDa
     let _ = reply.send(database);
 }
 
-pub(crate) fn handle_highlight_dom_node(
-    documents: &DocumentCollection,
-    id: PipelineId,
-    node_id: Option<String>,
-) {
-    let node = node_id.and_then(|node_id| {
-        let node = find_node_by_unique_id(documents, id, &node_id);
-        if node.is_none() {
-            log::warn!("Node id {node_id} for pipeline id {id} is not found",);
-        }
-        node
-    });
+impl DevtoolsState {
+    pub(crate) fn notify_pipeline_created(&self, pipeline: PipelineId) {
+        self.per_pipeline_state.borrow_mut().insert(
+            NoTrace(pipeline),
+            PerPipelineState {
+                pipeline,
+                known_nodes: Default::default(),
+            },
+        );
+    }
+    pub(crate) fn notify_pipeline_exited(&self, pipeline: PipelineId) {
+        self.per_pipeline_state
+            .borrow_mut()
+            .remove(&NoTrace(pipeline));
+    }
 
-    if let Some(window) = documents.find_window(id) {
-        window.Document().highlight_dom_node(node.as_deref());
+    fn pipeline_state_for(&self, pipeline: PipelineId) -> Option<Ref<'_, PerPipelineState>> {
+        Ref::filter_map(self.per_pipeline_state.borrow(), |state| {
+            state.get(&NoTrace(pipeline))
+        })
+        .ok()
+    }
+
+    fn mut_pipeline_state_for(&self, pipeline: PipelineId) -> Option<RefMut<'_, PerPipelineState>> {
+        RefMut::filter_map(self.per_pipeline_state.borrow_mut(), |state| {
+            state.get_mut(&NoTrace(pipeline))
+        })
+        .ok()
+    }
+
+    pub(crate) fn wants_updates_for_node(&self, pipeline: PipelineId, node: &Node) -> bool {
+        let Some(unique_id) = node.unique_id_if_already_present() else {
+            // This node does not have a unique id, so clearly the devtools inspector
+            // hasn't seen it before.
+            return false;
+        };
+        self.pipeline_state_for(pipeline)
+            .is_some_and(|pipeline_state| pipeline_state.known_nodes.contains_key(&unique_id))
+    }
+
+    pub(crate) fn handle_get_event_listener_info(
+        &self,
+        pipeline: PipelineId,
+        node_id: &str,
+        reply: GenericSender<Vec<EventListenerInfo>>,
+    ) {
+        let Some(node) = self.find_node_by_unique_id(pipeline, node_id) else {
+            reply.send(vec![]).unwrap();
+            return;
+        };
+
+        let event_listeners = node
+            .upcast::<EventTarget>()
+            .summarize_event_listeners_for_devtools();
+        reply.send(event_listeners).unwrap();
+    }
+
+    pub(crate) fn handle_get_root_node(
+        &self,
+        documents: &DocumentCollection,
+        pipeline: PipelineId,
+        reply: GenericSender<Option<NodeInfo>>,
+        can_gc: CanGc,
+    ) {
+        let info = documents
+            .find_document(pipeline)
+            .map(DomRoot::upcast::<Node>)
+            .inspect(|node| {
+                self.mut_pipeline_state_for(pipeline)
+                    .unwrap()
+                    .register_node(node)
+            })
+            .map(|document| document.upcast::<Node>().summarize(can_gc));
+        reply.send(info).unwrap();
+    }
+
+    pub(crate) fn handle_get_document_element(
+        &self,
+        documents: &DocumentCollection,
+        pipeline: PipelineId,
+        reply: GenericSender<Option<NodeInfo>>,
+        can_gc: CanGc,
+    ) {
+        let info = documents
+            .find_document(pipeline)
+            .and_then(|document| document.GetDocumentElement())
+            .inspect(|element| {
+                self.mut_pipeline_state_for(pipeline)
+                    .unwrap()
+                    .register_node(element.upcast())
+            })
+            .map(|element| element.upcast::<Node>().summarize(can_gc));
+        reply.send(info).unwrap();
+    }
+
+    fn find_node_by_unique_id(&self, pipeline: PipelineId, node_id: &str) -> Option<DomRoot<Node>> {
+        self.pipeline_state_for(pipeline)?
+            .known_nodes
+            .get(node_id)
+            .map(|node: &Dom<Node>| node.as_rooted())
+    }
+
+    pub(crate) fn handle_get_children(
+        &self,
+        pipeline: PipelineId,
+        node_id: &str,
+        reply: GenericSender<Option<Vec<NodeInfo>>>,
+        can_gc: CanGc,
+    ) {
+        let Some(parent) = self.find_node_by_unique_id(pipeline, node_id) else {
+            reply.send(None).unwrap();
+            return;
+        };
+        let is_whitespace = |node: &NodeInfo| {
+            node.node_type == NodeConstants::TEXT_NODE &&
+                node.node_value.as_ref().is_none_or(|v| v.trim().is_empty())
+        };
+        let mut pipeline_state = self.mut_pipeline_state_for(pipeline).unwrap();
+
+        let inline: Vec<_> = parent
+            .children()
+            .map(|child| {
+                let window = child.owner_window();
+                let Some(elem) = child.downcast::<Element>() else {
+                    return false;
+                };
+                let computed_style = window.GetComputedStyle(elem, None);
+                let display = computed_style.Display();
+                display == "inline"
+            })
+            .collect();
+
+        let mut children = vec![];
+        if let Some(shadow_root) = parent.downcast::<Element>().and_then(Element::shadow_root) {
+            if !shadow_root.is_user_agent_widget() ||
+                pref!(inspector_show_servo_internal_shadow_roots)
+            {
+                children.push(shadow_root.upcast::<Node>().summarize(can_gc));
+            }
+        }
+        let children_iter = parent.children().enumerate().filter_map(|(i, child)| {
+            // Filter whitespace only text nodes that are not inline level
+            // https://firefox-source-docs.mozilla.org/devtools-user/page_inspector/how_to/examine_and_edit_html/index.html#whitespace-only-text-nodes
+            let prev_inline = i > 0 && inline[i - 1];
+            let next_inline = i < inline.len() - 1 && inline[i + 1];
+            let is_inline_level = prev_inline && next_inline;
+
+            let info = child.summarize(can_gc);
+            if is_whitespace(&info) && !is_inline_level {
+                return None;
+            }
+            pipeline_state.register_node(&child);
+
+            Some(info)
+        });
+        children.extend(children_iter);
+
+        reply.send(Some(children)).unwrap();
+    }
+
+    pub(crate) fn handle_get_attribute_style(
+        &self,
+        pipeline: PipelineId,
+        node_id: &str,
+        reply: GenericSender<Option<Vec<NodeStyle>>>,
+        can_gc: CanGc,
+    ) {
+        let node = match self.find_node_by_unique_id(pipeline, node_id) {
+            None => return reply.send(None).unwrap(),
+            Some(found_node) => found_node,
+        };
+
+        let Some(elem) = node.downcast::<HTMLElement>() else {
+            // the style attribute only works on html elements
+            reply.send(None).unwrap();
+            return;
+        };
+        let style = elem.Style(can_gc);
+
+        let msg = (0..style.Length())
+            .map(|i| {
+                let name = style.Item(i);
+                NodeStyle {
+                    name: name.to_string(),
+                    value: style.GetPropertyValue(name.clone()).to_string(),
+                    priority: style.GetPropertyPriority(name).to_string(),
+                }
+            })
+            .collect();
+
+        reply.send(Some(msg)).unwrap();
+    }
+
+    #[cfg_attr(crown, expect(crown::unrooted_must_root))]
+    #[allow(clippy::too_many_arguments)]
+    pub(crate) fn handle_get_stylesheet_style(
+        &self,
+        documents: &DocumentCollection,
+        pipeline: PipelineId,
+        node_id: &str,
+        selector: String,
+        stylesheet: usize,
+        reply: GenericSender<Option<Vec<NodeStyle>>>,
+        can_gc: CanGc,
+    ) {
+        let msg = (|| {
+            let node = self.find_node_by_unique_id(pipeline, node_id)?;
+
+            let document = documents.find_document(pipeline)?;
+            let _realm = enter_realm(document.window());
+            let owner = node.stylesheet_list_owner();
+
+            let stylesheet = owner.stylesheet_at(stylesheet)?;
+            let list = stylesheet.GetCssRules(can_gc).ok()?;
+
+            let styles = (0..list.Length())
+                .filter_map(move |i| {
+                    let rule = list.Item(i, can_gc)?;
+                    let style = rule.downcast::<CSSStyleRule>()?;
+                    if selector != style.SelectorText() {
+                        return None;
+                    };
+                    Some(style.Style(can_gc))
+                })
+                .flat_map(|style| {
+                    (0..style.Length()).map(move |i| {
+                        let name = style.Item(i);
+                        NodeStyle {
+                            name: name.to_string(),
+                            value: style.GetPropertyValue(name.clone()).to_string(),
+                            priority: style.GetPropertyPriority(name).to_string(),
+                        }
+                    })
+                })
+                .collect();
+
+            Some(styles)
+        })();
+
+        reply.send(msg).unwrap();
+    }
+
+    #[cfg_attr(crown, expect(crown::unrooted_must_root))]
+    pub(crate) fn handle_get_selectors(
+        &self,
+        documents: &DocumentCollection,
+        pipeline: PipelineId,
+        node_id: &str,
+        reply: GenericSender<Option<Vec<(String, usize)>>>,
+        can_gc: CanGc,
+    ) {
+        let msg = (|| {
+            let node = self.find_node_by_unique_id(pipeline, node_id)?;
+
+            let document = documents.find_document(pipeline)?;
+            let _realm = enter_realm(document.window());
+            let owner = node.stylesheet_list_owner();
+
+            let rules = (0..owner.stylesheet_count())
+                .filter_map(|i| {
+                    let stylesheet = owner.stylesheet_at(i)?;
+                    let list = stylesheet.GetCssRules(can_gc).ok()?;
+                    let elem = node.downcast::<Element>()?;
+
+                    Some((0..list.Length()).filter_map(move |j| {
+                        let rule = list.Item(j, can_gc)?;
+                        let style = rule.downcast::<CSSStyleRule>()?;
+                        let selector = style.SelectorText();
+                        elem.Matches(selector.clone()).ok()?.then_some(())?;
+                        Some((selector.into(), i))
+                    }))
+                })
+                .flatten()
+                .collect();
+
+            Some(rules)
+        })();
+
+        reply.send(msg).unwrap();
+    }
+
+    pub(crate) fn handle_get_computed_style(
+        &self,
+        pipeline: PipelineId,
+        node_id: &str,
+        reply: GenericSender<Option<Vec<NodeStyle>>>,
+    ) {
+        let node = match self.find_node_by_unique_id(pipeline, node_id) {
+            None => return reply.send(None).unwrap(),
+            Some(found_node) => found_node,
+        };
+
+        let window = node.owner_window();
+        let elem = node
+            .downcast::<Element>()
+            .expect("This should be an element");
+        let computed_style = window.GetComputedStyle(elem, None);
+
+        let msg = (0..computed_style.Length())
+            .map(|i| {
+                let name = computed_style.Item(i);
+                NodeStyle {
+                    name: name.to_string(),
+                    value: computed_style.GetPropertyValue(name.clone()).to_string(),
+                    priority: computed_style.GetPropertyPriority(name).to_string(),
+                }
+            })
+            .collect();
+
+        reply.send(Some(msg)).unwrap();
+    }
+
+    pub(crate) fn handle_get_layout(
+        &self,
+        pipeline: PipelineId,
+        node_id: &str,
+        reply: GenericSender<Option<(ComputedNodeLayout, AutoMargins)>>,
+        can_gc: CanGc,
+    ) {
+        let node = match self.find_node_by_unique_id(pipeline, node_id) {
+            None => return reply.send(None).unwrap(),
+            Some(found_node) => found_node,
+        };
+        let auto_margins = determine_auto_margins(&node);
+
+        let elem = node
+            .downcast::<Element>()
+            .expect("should be getting layout of element");
+        let rect = elem.GetBoundingClientRect(can_gc);
+        let width = rect.Width() as f32;
+        let height = rect.Height() as f32;
+
+        let window = node.owner_window();
+        let computed_style = window.GetComputedStyle(elem, None);
+        let computed_layout = ComputedNodeLayout {
+            display: computed_style.Display().into(),
+            position: computed_style.Position().into(),
+            z_index: computed_style.ZIndex().into(),
+            box_sizing: computed_style.BoxSizing().into(),
+            margin_top: computed_style.MarginTop().into(),
+            margin_right: computed_style.MarginRight().into(),
+            margin_bottom: computed_style.MarginBottom().into(),
+            margin_left: computed_style.MarginLeft().into(),
+            border_top_width: computed_style.BorderTopWidth().into(),
+            border_right_width: computed_style.BorderRightWidth().into(),
+            border_bottom_width: computed_style.BorderBottomWidth().into(),
+            border_left_width: computed_style.BorderLeftWidth().into(),
+            padding_top: computed_style.PaddingTop().into(),
+            padding_right: computed_style.PaddingRight().into(),
+            padding_bottom: computed_style.PaddingBottom().into(),
+            padding_left: computed_style.PaddingLeft().into(),
+            width,
+            height,
+        };
+
+        reply.send(Some((computed_layout, auto_margins))).unwrap();
+    }
+
+    pub(crate) fn handle_get_xpath(
+        &self,
+        pipeline: PipelineId,
+        node_id: &str,
+        reply: GenericSender<String>,
+    ) {
+        let Some(node) = self.find_node_by_unique_id(pipeline, node_id) else {
+            return reply.send(Default::default()).unwrap();
+        };
+
+        let selector = node
+            .inclusive_ancestors(ShadowIncluding::Yes)
+            .filter_map(|ancestor| {
+                let Some(element) = ancestor.downcast::<Element>() else {
+                    // TODO: figure out how to handle shadow roots here
+                    return None;
+                };
+
+                let mut result = "/".to_owned();
+                if *element.namespace() != ns!(html) {
+                    result.push_str(element.namespace());
+                    result.push(':');
+                }
+
+                result.push_str(element.local_name());
+
+                let would_node_also_match_selector = |sibling: &Node| {
+                    let Some(sibling) = sibling.downcast::<Element>() else {
+                        return false;
+                    };
+                    sibling.namespace() == element.namespace() &&
+                        sibling.local_name() == element.local_name()
+                };
+
+                let matching_elements_before = ancestor
+                    .preceding_siblings()
+                    .filter(|node| would_node_also_match_selector(node))
+                    .count();
+                let matching_elements_after = ancestor
+                    .following_siblings()
+                    .filter(|node| would_node_also_match_selector(node))
+                    .count();
+
+                if matching_elements_before + matching_elements_after != 0 {
+                    // Need to add an index (note that XPath uses 1-based indexing)
+                    result.push_str(&format!("[{}]", matching_elements_before + 1));
+                }
+
+                Some(result)
+            })
+            .collect::<Vec<_>>()
+            .into_iter()
+            .rev()
+            .collect::<Vec<_>>()
+            .join("");
+
+        reply.send(selector).unwrap();
+    }
+
+    pub(crate) fn handle_modify_attribute(
+        &self,
+        documents: &DocumentCollection,
+        pipeline: PipelineId,
+        node_id: &str,
+        modifications: Vec<AttrModification>,
+        can_gc: CanGc,
+    ) {
+        let Some(document) = documents.find_document(pipeline) else {
+            return warn!("document for pipeline id {} is not found", &pipeline);
+        };
+        let _realm = enter_realm(document.window());
+
+        let node = match self.find_node_by_unique_id(pipeline, node_id) {
+            None => {
+                return warn!(
+                    "node id {} for pipeline id {} is not found",
+                    &node_id, &pipeline
+                );
+            },
+            Some(found_node) => found_node,
+        };
+
+        let elem = node
+            .downcast::<Element>()
+            .expect("should be getting layout of element");
+
+        for modification in modifications {
+            match modification.new_value {
+                Some(string) => {
+                    elem.set_attribute(
+                        &LocalName::from(modification.attribute_name),
+                        AttrValue::String(string),
+                        can_gc,
+                    );
+                },
+                None => elem.RemoveAttribute(DOMString::from(modification.attribute_name), can_gc),
+            }
+        }
+    }
+
+    pub(crate) fn handle_modify_rule(
+        &self,
+        documents: &DocumentCollection,
+        pipeline: PipelineId,
+        node_id: &str,
+        modifications: Vec<RuleModification>,
+        can_gc: CanGc,
+    ) {
+        let Some(document) = documents.find_document(pipeline) else {
+            return warn!("Document for pipeline id {} is not found", &pipeline);
+        };
+        let _realm = enter_realm(document.window());
+
+        let Some(node) = self.find_node_by_unique_id(pipeline, node_id) else {
+            return warn!(
+                "Node id {} for pipeline id {} is not found",
+                &node_id, &pipeline
+            );
+        };
+
+        let elem = node
+            .downcast::<HTMLElement>()
+            .expect("This should be an HTMLElement");
+        let style = elem.Style(can_gc);
+
+        for modification in modifications {
+            let _ = style.SetProperty(
+                modification.name.into(),
+                modification.value.into(),
+                modification.priority.into(),
+                can_gc,
+            );
+        }
+    }
+
+    pub(crate) fn handle_highlight_dom_node(
+        &self,
+        documents: &DocumentCollection,
+        id: PipelineId,
+        node_id: Option<&str>,
+    ) {
+        let node = node_id.and_then(|node_id| {
+            let node = self.find_node_by_unique_id(id, node_id);
+            if node.is_none() {
+                log::warn!("Node id {node_id} for pipeline id {id} is not found",);
+            }
+            node
+        });
+
+        if let Some(window) = documents.find_window(id) {
+            window.Document().highlight_dom_node(node.as_deref());
+        }
+    }
+}
+
+fn determine_auto_margins(node: &Node) -> AutoMargins {
+    let Some(style) = node.style() else {
+        return AutoMargins::default();
+    };
+    let margin = style.get_margin();
+    AutoMargins {
+        top: margin.margin_top.is_auto(),
+        right: margin.margin_right.is_auto(),
+        bottom: margin.margin_bottom.is_auto(),
+        left: margin.margin_left.is_auto(),
     }
 }

--- a/components/script/dom/element.rs
+++ b/components/script/dom/element.rs
@@ -4584,15 +4584,17 @@ impl VirtualMethods for Element {
         if global.live_devtools_updates() {
             if let Some(sender) = global.devtools_chan() {
                 let pipeline_id = global.pipeline_id();
-                let devtools_message = ScriptToDevtoolsControlMsg::DomMutation(
-                    pipeline_id,
-                    DomMutation::AttributeModified {
-                        node: self.upcast::<Node>().unique_id(pipeline_id),
-                        attribute_name: attr.local_name().to_string(),
-                        new_value: mutation.new_value(attr).map(|value| value.to_string()),
-                    },
-                );
-                sender.send(devtools_message).unwrap();
+                if ScriptThread::devtools_want_updates_for_node(pipeline_id, self.upcast()) {
+                    let devtools_message = ScriptToDevtoolsControlMsg::DomMutation(
+                        pipeline_id,
+                        DomMutation::AttributeModified {
+                            node: self.upcast::<Node>().unique_id(pipeline_id),
+                            attribute_name: attr.local_name().to_string(),
+                            new_value: mutation.new_value(attr).map(|value| value.to_string()),
+                        },
+                    );
+                    sender.send(devtools_message).unwrap();
+                }
             }
         }
     }

--- a/components/script/dom/node.rs
+++ b/components/script/dom/node.rs
@@ -1353,6 +1353,17 @@ impl Node {
         }
     }
 
+    /// Returns the node's `unique_id` if it has been computed before and `None` otherwise.
+    pub(crate) fn unique_id_if_already_present(&self) -> Option<String> {
+        Ref::filter_map(self.rare_data(), |rare_data| {
+            rare_data
+                .as_ref()
+                .and_then(|rare_data| rare_data.unique_id.as_ref())
+        })
+        .ok()
+        .map(|unique_id| unique_id.borrow().simple().to_string())
+    }
+
     pub(crate) fn unique_id(&self, pipeline: PipelineId) -> String {
         let mut rare_data = self.ensure_rare_data();
 

--- a/components/script/dom/workers/dedicatedworkerglobalscope.rs
+++ b/components/script/dom/workers/dedicatedworkerglobalscope.rs
@@ -652,7 +652,8 @@ impl DedicatedWorkerGlobalScope {
                     devtools::handle_evaluate_js(self.upcast(), string, sender, cx)
                 },
                 DevtoolScriptControlMsg::WantsLiveNotifications(_pipe_id, bool_val) => {
-                    devtools::handle_wants_live_notifications(self.upcast(), bool_val)
+                    self.upcast::<GlobalScope>()
+                        .set_devtools_wants_updates(bool_val);
                 },
                 _ => debug!("got an unusable devtools control message inside the worker!"),
             },

--- a/components/script/dom/workers/serviceworkerglobalscope.rs
+++ b/components/script/dom/workers/serviceworkerglobalscope.rs
@@ -461,8 +461,9 @@ impl ServiceWorkerGlobalScope {
                 DevtoolScriptControlMsg::EvaluateJS(_pipe_id, string, sender) => {
                     devtools::handle_evaluate_js(self.upcast(), string, sender, cx)
                 },
-                DevtoolScriptControlMsg::WantsLiveNotifications(_pipe_id, bool_val) => {
-                    devtools::handle_wants_live_notifications(self.upcast(), bool_val)
+                DevtoolScriptControlMsg::WantsLiveNotifications(_pipe_id, wants_updates) => {
+                    self.upcast::<GlobalScope>()
+                        .set_devtools_wants_updates(wants_updates);
                 },
                 _ => debug!("got an unusable devtools control message inside the worker!"),
             },

--- a/components/script/script_thread.rs
+++ b/components/script/script_thread.rs
@@ -110,6 +110,7 @@ use webgpu_traits::{WebGPUDevice, WebGPUMsg};
 use webrender_api::ExternalScrollId;
 use webrender_api::units::LayoutVector2D;
 
+use crate::devtools::DevtoolsState;
 use crate::document_collection::DocumentCollection;
 use crate::document_loader::DocumentLoader;
 use crate::dom::bindings::cell::DomRefCell;
@@ -138,7 +139,7 @@ use crate::dom::document::{
 use crate::dom::element::Element;
 use crate::dom::globalscope::GlobalScope;
 use crate::dom::html::htmliframeelement::{HTMLIFrameElement, IframeContext};
-use crate::dom::node::NodeTraits;
+use crate::dom::node::{Node, NodeTraits};
 use crate::dom::servoparser::{ParserContext, ServoParser};
 use crate::dom::types::DebuggerGlobalScope;
 #[cfg(feature = "webgpu")]
@@ -411,6 +412,7 @@ pub struct ScriptThread {
     /// Whether accessibility is active. If true, each Layout will maintain an accessibility tree
     /// and send accessibility updates to the embedder.
     accessibility_active: Cell<bool>,
+    devtools_state: DevtoolsState,
 }
 
 struct BHMExitSignal {
@@ -1043,6 +1045,7 @@ impl ScriptThread {
                     privileged_urls: state.privileged_urls,
                     this: weak_script_thread.clone(),
                     accessibility_active: Cell::new(state.accessibility_active),
+                    devtools_state: Default::default(),
                 }
             }),
             cx,
@@ -2113,77 +2116,69 @@ impl ScriptThread {
                 },
                 None => warn!("Message sent to closed pipeline {}.", id),
             },
-            DevtoolScriptControlMsg::GetEventListenerInfo(id, node, reply) => {
-                devtools::handle_get_event_listener_info(&documents, id, &node, reply)
-            },
-            DevtoolScriptControlMsg::GetRootNode(id, reply) => {
-                devtools::handle_get_root_node(&documents, id, reply, CanGc::from_cx(cx))
-            },
-            DevtoolScriptControlMsg::GetDocumentElement(id, reply) => {
-                devtools::handle_get_document_element(&documents, id, reply, CanGc::from_cx(cx))
-            },
-            DevtoolScriptControlMsg::GetChildren(id, node_id, reply) => {
-                devtools::handle_get_children(&documents, id, node_id, reply, CanGc::from_cx(cx))
-            },
-            DevtoolScriptControlMsg::GetAttributeStyle(id, node_id, reply) => {
-                devtools::handle_get_attribute_style(
-                    &documents,
-                    id,
-                    node_id,
-                    reply,
-                    CanGc::from_cx(cx),
-                )
-            },
+            DevtoolScriptControlMsg::GetEventListenerInfo(id, node, reply) => self
+                .devtools_state
+                .handle_get_event_listener_info(id, &node, reply),
+            DevtoolScriptControlMsg::GetRootNode(id, reply) => self
+                .devtools_state
+                .handle_get_root_node(&documents, id, reply, CanGc::from_cx(cx)),
+            DevtoolScriptControlMsg::GetDocumentElement(id, reply) => self
+                .devtools_state
+                .handle_get_document_element(&documents, id, reply, CanGc::from_cx(cx)),
+            DevtoolScriptControlMsg::GetChildren(id, node_id, reply) => self
+                .devtools_state
+                .handle_get_children(id, &node_id, reply, CanGc::from_cx(cx)),
+            DevtoolScriptControlMsg::GetAttributeStyle(id, node_id, reply) => self
+                .devtools_state
+                .handle_get_attribute_style(id, &node_id, reply, CanGc::from_cx(cx)),
             DevtoolScriptControlMsg::GetStylesheetStyle(
                 id,
                 node_id,
                 selector,
                 stylesheet,
                 reply,
-            ) => devtools::handle_get_stylesheet_style(
+            ) => self.devtools_state.handle_get_stylesheet_style(
                 &documents,
                 id,
-                node_id,
+                &node_id,
                 selector,
                 stylesheet,
                 reply,
                 CanGc::from_cx(cx),
             ),
-            DevtoolScriptControlMsg::GetSelectors(id, node_id, reply) => {
-                devtools::handle_get_selectors(&documents, id, node_id, reply, CanGc::from_cx(cx))
-            },
-            DevtoolScriptControlMsg::GetComputedStyle(id, node_id, reply) => {
-                devtools::handle_get_computed_style(&documents, id, node_id, reply)
-            },
-            DevtoolScriptControlMsg::GetLayout(id, node_id, reply) => {
-                devtools::handle_get_layout(&documents, id, node_id, reply, CanGc::from_cx(cx))
-            },
+            DevtoolScriptControlMsg::GetSelectors(id, node_id, reply) => self
+                .devtools_state
+                .handle_get_selectors(&documents, id, &node_id, reply, CanGc::from_cx(cx)),
+            DevtoolScriptControlMsg::GetComputedStyle(id, node_id, reply) => self
+                .devtools_state
+                .handle_get_computed_style(id, &node_id, reply),
+            DevtoolScriptControlMsg::GetLayout(id, node_id, reply) => self
+                .devtools_state
+                .handle_get_layout(id, &node_id, reply, CanGc::from_cx(cx)),
             DevtoolScriptControlMsg::GetXPath(id, node_id, reply) => {
-                devtools::handle_get_xpath(&documents, id, node_id, reply)
+                self.devtools_state.handle_get_xpath(id, &node_id, reply)
             },
             DevtoolScriptControlMsg::ModifyAttribute(id, node_id, modifications) => {
-                devtools::handle_modify_attribute(
+                self.devtools_state.handle_modify_attribute(
                     &documents,
                     id,
-                    node_id,
+                    &node_id,
                     modifications,
                     CanGc::from_cx(cx),
                 )
             },
-            DevtoolScriptControlMsg::ModifyRule(id, node_id, modifications) => {
-                devtools::handle_modify_rule(
-                    &documents,
-                    id,
-                    node_id,
-                    modifications,
-                    CanGc::from_cx(cx),
-                )
-            },
-            DevtoolScriptControlMsg::WantsLiveNotifications(id, to_send) => match documents
-                .find_window(id)
-            {
-                Some(window) => devtools::handle_wants_live_notifications(window.upcast(), to_send),
-                None => warn!("Message sent to closed pipeline {}.", id),
+            DevtoolScriptControlMsg::ModifyRule(id, node_id, modifications) => self
+                .devtools_state
+                .handle_modify_rule(&documents, id, &node_id, modifications, CanGc::from_cx(cx)),
+            DevtoolScriptControlMsg::WantsLiveNotifications(id, to_send) => {
+                match documents.find_window(id) {
+                    Some(window) => {
+                        window
+                            .upcast::<GlobalScope>()
+                            .set_devtools_wants_updates(to_send);
+                    },
+                    None => warn!("Message sent to closed pipeline {}.", id),
+                }
             },
             DevtoolScriptControlMsg::SetTimelineMarkers(id, marker_types, reply) => {
                 devtools::handle_set_timeline_markers(&documents, id, marker_types, reply)
@@ -2206,9 +2201,9 @@ impl ScriptThread {
                     None => warn!("Message sent to closed pipeline {}.", id),
                 }
             },
-            DevtoolScriptControlMsg::HighlightDomNode(id, node_id) => {
-                devtools::handle_highlight_dom_node(&documents, id, node_id)
-            },
+            DevtoolScriptControlMsg::HighlightDomNode(id, node_id) => self
+                .devtools_state
+                .handle_highlight_dom_node(&documents, id, node_id.as_deref()),
             DevtoolScriptControlMsg::Eval(code, id, reply) => {
                 self.debugger_global
                     .fire_eval(CanGc::from_cx(cx), code.into(), id, None, reply);
@@ -2698,6 +2693,9 @@ impl ScriptThread {
                     MutableOrigin::new(ImmutableOrigin::new_opaque())
                 };
 
+                self.devtools_state
+                    .notify_pipeline_created(new_pipeline_info.new_pipeline_id);
+
                 // Kick off the fetch for the new resource.
                 self.pre_page_load(cx, InProgressLoad::new(new_pipeline_info, origin));
             },
@@ -3148,6 +3146,8 @@ impl ScriptThread {
 
         self.paint_api
             .pipeline_exited(webview_id, pipeline_id, PipelineExitSource::Script);
+
+        self.devtools_state.notify_pipeline_exited(pipeline_id);
 
         debug!("{pipeline_id}: Finished pipeline exit");
     }
@@ -4199,6 +4199,14 @@ impl ScriptThread {
         };
 
         window.maybe_update_visual_viewport(pinch_zoom_infos, can_gc);
+    }
+
+    pub(crate) fn devtools_want_updates_for_node(pipeline: PipelineId, node: &Node) -> bool {
+        with_script_thread(|script_thread| {
+            script_thread
+                .devtools_state
+                .wants_updates_for_node(pipeline, node)
+        })
     }
 }
 

--- a/components/script/script_thread.rs
+++ b/components/script/script_thread.rs
@@ -2116,28 +2116,51 @@ impl ScriptThread {
                 },
                 None => warn!("Message sent to closed pipeline {}.", id),
             },
-            DevtoolScriptControlMsg::GetEventListenerInfo(id, node, reply) => self
-                .devtools_state
-                .handle_get_event_listener_info(id, &node, reply),
-            DevtoolScriptControlMsg::GetRootNode(id, reply) => self
-                .devtools_state
-                .handle_get_root_node(&documents, id, reply, CanGc::from_cx(cx)),
-            DevtoolScriptControlMsg::GetDocumentElement(id, reply) => self
-                .devtools_state
-                .handle_get_document_element(&documents, id, reply, CanGc::from_cx(cx)),
-            DevtoolScriptControlMsg::GetChildren(id, node_id, reply) => self
-                .devtools_state
-                .handle_get_children(id, &node_id, reply, CanGc::from_cx(cx)),
-            DevtoolScriptControlMsg::GetAttributeStyle(id, node_id, reply) => self
-                .devtools_state
-                .handle_get_attribute_style(id, &node_id, reply, CanGc::from_cx(cx)),
+            DevtoolScriptControlMsg::GetEventListenerInfo(id, node, reply) => {
+                devtools::handle_get_event_listener_info(&self.devtools_state, id, &node, reply)
+            },
+            DevtoolScriptControlMsg::GetRootNode(id, reply) => devtools::handle_get_root_node(
+                &self.devtools_state,
+                &documents,
+                id,
+                reply,
+                CanGc::from_cx(cx),
+            ),
+            DevtoolScriptControlMsg::GetDocumentElement(id, reply) => {
+                devtools::handle_get_document_element(
+                    &self.devtools_state,
+                    &documents,
+                    id,
+                    reply,
+                    CanGc::from_cx(cx),
+                )
+            },
+            DevtoolScriptControlMsg::GetChildren(id, node_id, reply) => {
+                devtools::handle_get_children(
+                    &self.devtools_state,
+                    id,
+                    &node_id,
+                    reply,
+                    CanGc::from_cx(cx),
+                )
+            },
+            DevtoolScriptControlMsg::GetAttributeStyle(id, node_id, reply) => {
+                devtools::handle_get_attribute_style(
+                    &self.devtools_state,
+                    id,
+                    &node_id,
+                    reply,
+                    CanGc::from_cx(cx),
+                )
+            },
             DevtoolScriptControlMsg::GetStylesheetStyle(
                 id,
                 node_id,
                 selector,
                 stylesheet,
                 reply,
-            ) => self.devtools_state.handle_get_stylesheet_style(
+            ) => devtools::handle_get_stylesheet_style(
+                &self.devtools_state,
                 &documents,
                 id,
                 &node_id,
@@ -2146,20 +2169,32 @@ impl ScriptThread {
                 reply,
                 CanGc::from_cx(cx),
             ),
-            DevtoolScriptControlMsg::GetSelectors(id, node_id, reply) => self
-                .devtools_state
-                .handle_get_selectors(&documents, id, &node_id, reply, CanGc::from_cx(cx)),
-            DevtoolScriptControlMsg::GetComputedStyle(id, node_id, reply) => self
-                .devtools_state
-                .handle_get_computed_style(id, &node_id, reply),
-            DevtoolScriptControlMsg::GetLayout(id, node_id, reply) => self
-                .devtools_state
-                .handle_get_layout(id, &node_id, reply, CanGc::from_cx(cx)),
+            DevtoolScriptControlMsg::GetSelectors(id, node_id, reply) => {
+                devtools::handle_get_selectors(
+                    &self.devtools_state,
+                    &documents,
+                    id,
+                    &node_id,
+                    reply,
+                    CanGc::from_cx(cx),
+                )
+            },
+            DevtoolScriptControlMsg::GetComputedStyle(id, node_id, reply) => {
+                devtools::handle_get_computed_style(&self.devtools_state, id, &node_id, reply)
+            },
+            DevtoolScriptControlMsg::GetLayout(id, node_id, reply) => devtools::handle_get_layout(
+                &self.devtools_state,
+                id,
+                &node_id,
+                reply,
+                CanGc::from_cx(cx),
+            ),
             DevtoolScriptControlMsg::GetXPath(id, node_id, reply) => {
-                self.devtools_state.handle_get_xpath(id, &node_id, reply)
+                devtools::handle_get_xpath(&self.devtools_state, id, &node_id, reply)
             },
             DevtoolScriptControlMsg::ModifyAttribute(id, node_id, modifications) => {
-                self.devtools_state.handle_modify_attribute(
+                devtools::handle_modify_attribute(
+                    &self.devtools_state,
                     &documents,
                     id,
                     &node_id,
@@ -2167,9 +2202,16 @@ impl ScriptThread {
                     CanGc::from_cx(cx),
                 )
             },
-            DevtoolScriptControlMsg::ModifyRule(id, node_id, modifications) => self
-                .devtools_state
-                .handle_modify_rule(&documents, id, &node_id, modifications, CanGc::from_cx(cx)),
+            DevtoolScriptControlMsg::ModifyRule(id, node_id, modifications) => {
+                devtools::handle_modify_rule(
+                    &self.devtools_state,
+                    &documents,
+                    id,
+                    &node_id,
+                    modifications,
+                    CanGc::from_cx(cx),
+                )
+            },
             DevtoolScriptControlMsg::WantsLiveNotifications(id, to_send) => {
                 match documents.find_window(id) {
                     Some(window) => {
@@ -2201,9 +2243,14 @@ impl ScriptThread {
                     None => warn!("Message sent to closed pipeline {}.", id),
                 }
             },
-            DevtoolScriptControlMsg::HighlightDomNode(id, node_id) => self
-                .devtools_state
-                .handle_highlight_dom_node(&documents, id, node_id.as_deref()),
+            DevtoolScriptControlMsg::HighlightDomNode(id, node_id) => {
+                devtools::handle_highlight_dom_node(
+                    &self.devtools_state,
+                    &documents,
+                    id,
+                    node_id.as_deref(),
+                )
+            },
             DevtoolScriptControlMsg::Eval(code, id, reply) => {
                 self.debugger_global
                     .fire_eval(CanGc::from_cx(cx), code.into(), id, None, reply);

--- a/python/servo/devtools_tests.py
+++ b/python/servo/devtools_tests.py
@@ -949,6 +949,39 @@ class DevtoolsTests(unittest.IsolatedAsyncioTestCase):
         # properly yet. The important part is that we didn't crash and didn't time out waiting for
         # a console notification (meaning we got *something*).
 
+    def test_inspector_doesnt_crash_when_attribute_on_element_it_doesnt_know_about_is_mutated(self):
+        self.run_servoshell(url=f"{self.base_urls[0]}/inspector/demo_dom.html")
+        with Devtools.connect() as devtools:
+            inspector = InspectorActor(devtools.client, devtools.targets[0]["inspectorActor"])
+            walker = WalkerActor(devtools.client, inspector.get_walker()["actor"])
+            console = WebConsoleActor(devtools.client, devtools.targets[0]["consoleActor"])
+
+            did_see_new_mutations = False
+            evaluation_result = Future()
+
+            async def on_new_mutations(data):
+                global did_see_new_mutations
+                did_see_new_mutations = True
+
+            async def on_evaluation_result(data: dict):
+                evaluation_result.set_result(data)
+
+            devtools.client.add_event_listener(
+                inspector.get_walker()["actor"], Events.Walker.NEW_MUTATIONS, on_new_mutations
+            )
+            devtools.client.add_event_listener(
+                console.actor_id, Events.WebConsole.EVALUATION_RESULT, on_evaluation_result
+            )
+
+            # Modify the nodes attribute
+            console.evaluate_js_async("document.body.firstElementChild.setAttribute('foo', 'baz');")
+            evaluation_result.result(1)
+
+            # Wait for a bit for unwanted notifications to arrive - we should not get any.
+            time.sleep(1)
+            self.assertFalse(did_see_new_mutations)
+            self.assertEquals(walker.get_mutations(False), [])
+
     # Sets `base_url` and `web_server` and `web_server_thread`.
     @classmethod
     def setUpClass(cls):


### PR DESCRIPTION
Currently, `script` and `devtools` use a node's unique id to identify it across requests. The unique ID is part of a node's rare data field and is really only meant for debugging. Instantiating it on a node causes it's memory usage to go up significantly. Now, when the devtools ask for information about a specific `Node` then they send the unique ID to `script`, and the script thread then walks the whole DOM tree searching for that specific ID. This happens here:
https://github.com/servo/servo/blob/6d0b65121852e75ad9aea5cdf3f04ca186cc67f9/components/script/devtools.rs#L142-L153

So, in the worst case, all of the nodes in the tree now have a unique ID. That's not great! 

Also, when `script` notifies `devtools` about changes to a DOM node then `devtools` expects a `NodeActor` to exist for that Node. The actor might not exist if the inspector doesn't know about that node yet - that happens when the user hasn't expanded their parent yet.
 That is an oversight from https://github.com/servo/servo/pull/42601 and causes problems now(https://github.com/servo/servo/issues/42784) because for the longest time, `devtools` was mostly the one sending requests. Of course, we could make `devtools` simply ignore updates for nodes that it doesn't know about, but ideally we shouldn't send these updates in the first place.

This change implements a lookup map on the `ScriptThread` that contains all nodes that have been sent to the devtools inspector. The map allows us to efficiently resolve a unique ID to a `Node` in O(1), without creating unique IDs for the whole tree. It also allows us to only send DOM updates for nodes that the inspector cares about.

For now, entries from the cache are not evicted unless the relevant pipeline is closed. That reflects reality, because the inspector also keeps using them forever. 
In the future we will tell the inspector when nodes are removed from the tree - then it can't interact with them anymore, and we can remove them from the script-side map.

This is change is not all that complicated but it involves moving a lot of code around, so feel free to ask for clarification when something is unclear!





Testing: This change adds a test
Fixes part of https://github.com/servo/servo/issues/42784