### PR TITLE
script: Add a `ServoInternals.garbageCollectAllContexts()`

### DIFF
--- a/components/constellation/constellation.rs
+++ b/components/constellation/constellation.rs
@@ -2054,6 +2054,11 @@ where
             ScriptToConstellationMessage::RespondToScreenshotReadinessRequest(response) => {
                 self.handle_screenshot_readiness_response(source_pipeline_id, response);
             },
+            ScriptToConstellationMessage::TriggerGarbageCollection => {
+                for event_loop in self.event_loops() {
+                    let _ = event_loop.send(ScriptThreadMessage::TriggerGarbageCollection);
+                }
+            },
         }
     }
 

--- a/components/constellation/tracing.rs
+++ b/components/constellation/tracing.rs
@@ -186,6 +186,7 @@ mod from_script {
                 Self::RespondToScreenshotReadinessRequest(..) => {
                     target!("RespondToScreenshotReadinessRequest")
                 },
+                Self::TriggerGarbageCollection => target!("TriggerGarbageCollection"),
             }
         }
     }

--- a/components/script/dom/servointernals.rs
+++ b/components/script/dom/servointernals.rs
@@ -84,6 +84,15 @@ impl ServoInternalsMethods<crate::DomTypeHolder> for ServoInternals {
     }
 
     /// <https://servo.org/internal-no-spec>
+    fn GarbageCollectAllContexts(&self) {
+        let global = &self.global();
+
+        let script_to_constellation_chan = global.script_to_constellation_chan();
+        let _ = script_to_constellation_chan
+            .send(ScriptToConstellationMessage::TriggerGarbageCollection);
+    }
+
+    /// <https://servo.org/internal-no-spec>
     fn PreferenceList(&self) -> Vec<USVString> {
         Preferences::all_fields()
             .into_iter()

--- a/components/script/messaging.rs
+++ b/components/script/messaging.rs
@@ -107,6 +107,7 @@ impl MixedMessage {
                 ScriptThreadMessage::AccessibilityTreeUpdate(..) => None,
                 ScriptThreadMessage::UpdatePinchZoomInfos(id, _) => Some(*id),
                 ScriptThreadMessage::SetAccessibilityActive(..) => None,
+                ScriptThreadMessage::TriggerGarbageCollection => None,
             },
             MixedMessage::FromScript(inner_msg) => match inner_msg {
                 MainThreadScriptMsg::Common(CommonScriptMsg::Task(_, _, pipeline_id, _)) => {
@@ -358,7 +359,7 @@ pub(crate) struct ScriptThreadSenders {
     #[cfg(feature = "bluetooth")]
     pub(crate) bluetooth_sender: GenericSender<BluetoothRequest>,
 
-    /// A [`Sender`] that sends messages to the `Constellation`.
+    /// A [`Sender`] that sends messages to the `ScriptThread`.
     #[no_trace]
     pub(crate) constellation_sender: GenericSender<ScriptThreadMessage>,
 

--- a/components/script/script_thread.rs
+++ b/components/script/script_thread.rs
@@ -65,7 +65,7 @@ use hyper_serde::Serde;
 use ipc_channel::ipc;
 use ipc_channel::router::ROUTER;
 use js::glue::GetWindowProxyClass;
-use js::jsapi::JSContext as UnsafeJSContext;
+use js::jsapi::{GCReason, JS_GC, JSContext as UnsafeJSContext};
 use js::jsval::UndefinedValue;
 use js::rust::ParentRuntime;
 use js::rust::wrappers2::{JS_AddInterruptCallback, SetWindowProxyClass};
@@ -1971,6 +1971,9 @@ impl ScriptThread {
             },
             ScriptThreadMessage::SetAccessibilityActive(active) => {
                 self.set_accessibility_active(active);
+            },
+            ScriptThreadMessage::TriggerGarbageCollection => unsafe {
+                JS_GC(*GlobalScope::get_cx(), GCReason::API);
             },
         }
     }

--- a/components/script_bindings/webidls/ServoInternals.webidl
+++ b/components/script_bindings/webidls/ServoInternals.webidl
@@ -11,6 +11,7 @@
 Func="ServoInternals::is_servo_internal"]
 interface ServoInternals {
     Promise<object> reportMemory();
+    undefined garbageCollectAllContexts();
 
     sequence<USVString> preferenceList();
     [Throws] USVString preferenceType(USVString name);

--- a/components/shared/constellation/from_script_message.rs
+++ b/components/shared/constellation/from_script_message.rs
@@ -724,6 +724,8 @@ pub enum ScriptToConstellationMessage {
     ForwardKeyboardScroll(PipelineId, KeyboardScroll),
     /// Notify the Constellation of the screenshot readiness of a given pipeline.
     RespondToScreenshotReadinessRequest(ScreenshotReadinessResponse),
+    /// Request the constellation to force garbage collection in all `ScriptThread`'s.
+    TriggerGarbageCollection,
 }
 
 impl fmt::Debug for ScriptToConstellationMessage {

--- a/components/shared/script/lib.rs
+++ b/components/shared/script/lib.rs
@@ -308,6 +308,8 @@ pub enum ScriptThreadMessage {
     UpdatePinchZoomInfos(PipelineId, PinchZoomInfos),
     /// Activate or deactivate accessibility features.
     SetAccessibilityActive(bool),
+    /// Force a garbage collection in this script thread.
+    TriggerGarbageCollection,
 }
 
 impl fmt::Debug for ScriptThreadMessage {

--- a/resources/about-memory.html
+++ b/resources/about-memory.html
@@ -154,6 +154,12 @@
       }
 
       function start() {
+        window.gcButton.onclick = async () => {
+          window.gcButton.disabled = true;
+          navigator.servo.garbageCollectAllContexts();
+          window.gcButton.disabled = false;
+        };
+
         window.startButton.onclick = async () => {
           let content = await navigator.servo.reportMemory();
           let reports = JSON.parse(content);
@@ -211,6 +217,7 @@
   <body>
     <h2>Memory Reports</h2>
     <button id="startButton">Measure</button>
+    <button id="gcButton">Force GC</button>
     <div id="reports" class="hidden"></div>
   </body>
 </html>


### PR DESCRIPTION
This is useful in about:memory to measure memory usage after running the GC.

The calling page sends a callback to the constellation that in turn wait for all script threads to run the GC and report back.

Testing: Manual testing in `about:memory`

Before running GC:

<img width="2048" height="1480" alt="Screenshot from 2026-02-23 18-50-46" src="https://github.com/user-attachments/assets/fd8399c1-fbc7-4f4c-886d-f29629ef8369" />

After running GC:

<img width="2048" height="1480" alt="Screenshot from 2026-02-23 18-51-00" src="https://github.com/user-attachments/assets/82c793f7-8229-4de4-9cb5-47c94383b410" />
