### PR TITLE
wdspec: Update ambiguous expectation

### DIFF
--- a/tests/wpt/meta/webdriver/tests/classic/accept_alert/accept.py.ini
+++ b/tests/wpt/meta/webdriver/tests/classic/accept_alert/accept.py.ini
@@ -1,3 +1,0 @@
-[accept.py]
-  [test_accept_in_popup_window]
-    expected: [PASS, FAIL]

--- a/tests/wpt/meta/webdriver/tests/classic/perform_actions/wheel.py.ini
+++ b/tests/wpt/meta/webdriver/tests/classic/perform_actions/wheel.py.ini
@@ -1,2 +1,0 @@
-[wheel.py]
-    expected: [OK, TIMEOUT]

--- a/tests/wpt/meta/webdriver/tests/classic/send_alert_text/send.py.ini
+++ b/tests/wpt/meta/webdriver/tests/classic/send_alert_text/send.py.ini
@@ -1,6 +1,6 @@
 [send.py]
   [test_chained_alert_element_not_interactable[alert\]]
-    expected: [PASS, FAIL]
+    expected: FAIL
 
   [test_chained_alert_element_not_interactable[confirm\]]
-    expected: [PASS, FAIL]
+    expected: FAIL

--- a/tests/wpt/meta/webdriver/tests/classic/send_alert_text/send.py.ini
+++ b/tests/wpt/meta/webdriver/tests/classic/send_alert_text/send.py.ini
@@ -1,6 +1,6 @@
 [send.py]
   [test_chained_alert_element_not_interactable[alert\]]
-    expected: FAIL
+    expected: [PASS, FAIL]
 
   [test_chained_alert_element_not_interactable[confirm\]]
-    expected: FAIL
+    expected: [PASS, FAIL]


### PR DESCRIPTION
These were introduced in #39159, #39644 to close intermittent issues. They are no longer reproducible.
This will prevent potential regression.

Testing: ~I~ Harness ran them for a whole night locally.
