### PR TITLE
script: use `&mut JSContext` inside `History`

### DIFF
--- a/components/script_bindings/codegen/Bindings.conf
+++ b/components/script_bindings/codegen/Bindings.conf
@@ -385,7 +385,7 @@ DOMInterfaces = {
 },
 
 'History': {
-    'canGc': ['Go', 'PushState', 'ReplaceState'],
+    'cx': ['PushState', 'ReplaceState', 'GetState', 'Go']
 },
 
 "HTMLAnchorElement": {


### PR DESCRIPTION
Replace `crate::script_runtime::JSContext` with `js::context::JSContext` in:
- `History::PostMessage`
- `History::ReplaceState`
- `History::GetState`

Testing: Builds and runs locally. [WPT passed](https://github.com/onsah/servo/actions/runs/22341528931)

Fixes: part of https://github.com/servo/servo/issues/42347