### PR TITLE
script: Fire `select` events for user input selections

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8076,6 +8076,7 @@ dependencies = [
  "encoding_rs",
  "euclid",
  "keyboard-types",
+ "layout_api",
  "script",
  "servo_url",
 ]

--- a/components/script/dom/html/htmlinputelement.rs
+++ b/components/script/dom/html/htmlinputelement.rs
@@ -1565,25 +1565,56 @@ impl TextControlElement for HTMLInputElement {
     }
 
     fn maybe_update_shared_selection(&self) {
-        let offsets = self.textinput.borrow().sorted_selection_offsets_range();
+        let (offsets, direction) = {
+            let textinput = self.textinput.borrow();
+            (
+                textinput.sorted_selection_offsets_range(),
+                textinput.selection_direction(),
+            )
+        };
         let (start, end) = (offsets.start.0, offsets.end.0);
         let range = TextByteRange::new(ByteIndex(start), ByteIndex(end));
         let enabled = self.renders_as_text_input_widget() && self.upcast::<Element>().focus_state();
 
         let mut shared_selection = self.shared_selection.borrow_mut();
-        if range == shared_selection.range && enabled == shared_selection.enabled {
+        if shared_selection.is_equivalent_to(&range, enabled, direction) {
             return;
         }
 
-        *shared_selection = ScriptSelection {
-            range,
-            character_range: self
-                .textinput
-                .borrow()
-                .sorted_selection_character_offsets_range(),
-            enabled,
-        };
-        self.owner_window().layout().set_needs_new_display_list();
+        let old_selection = std::mem::replace(
+            &mut *shared_selection,
+            ScriptSelection {
+                direction,
+                range,
+                character_range: self
+                    .textinput
+                    .borrow()
+                    .sorted_selection_character_offsets_range(),
+                enabled,
+            },
+        );
+
+        // The direction does not currently matter for rendering purposes.
+        if old_selection.range != shared_selection.range ||
+            old_selection.enabled != shared_selection.enabled
+        {
+            self.owner_window().layout().set_needs_new_display_list();
+        }
+
+        // The enabled status does not matter for deciding whether to send `select` events.
+        if old_selection.range != shared_selection.range ||
+            old_selection.direction != shared_selection.direction
+        {
+            self.owner_global()
+                .task_manager()
+                .user_interaction_task_source()
+                .queue_event(
+                    self.upcast(),
+                    atom!("select"),
+                    EventBubbles::Bubbles,
+                    EventCancelable::NotCancelable,
+                );
+        }
     }
 }
 

--- a/components/script/dom/textcontrol.rs
+++ b/components/script/dom/textcontrol.rs
@@ -8,6 +8,7 @@
 //! <https://html.spec.whatwg.org/multipage/#textFieldSelection>
 
 use base::text::Utf16CodeUnitLength;
+use layout_api::wrapper_traits::SelectionDirection;
 
 use crate::clipboard_provider::EmbedderClipboardProvider;
 use crate::dom::bindings::cell::DomRefCell;
@@ -15,10 +16,9 @@ use crate::dom::bindings::codegen::Bindings::HTMLFormElementBinding::SelectionMo
 use crate::dom::bindings::conversions::DerivedFrom;
 use crate::dom::bindings::error::{Error, ErrorResult};
 use crate::dom::bindings::str::DOMString;
-use crate::dom::event::{EventBubbles, EventCancelable};
 use crate::dom::eventtarget::EventTarget;
-use crate::dom::node::{Node, NodeTraits};
-use crate::textinput::{SelectionDirection, SelectionState, TextInput};
+use crate::dom::node::Node;
+use crate::textinput::TextInput;
 
 pub(crate) trait TextControlElement: DerivedFrom<EventTarget> + DerivedFrom<Node> {
     fn selection_api_applies(&self) -> bool;
@@ -55,7 +55,6 @@ impl<'a, E: TextControlElement> TextControlSelection<'a, E> {
             Some(Utf16CodeUnitLength::zero()),
             Some(Utf16CodeUnitLength(usize::MAX)),
             None,
-            None,
         );
     }
 
@@ -89,7 +88,7 @@ impl<'a, E: TextControlElement> TextControlSelection<'a, E> {
 
         // Step 4: Set the selection range with the given value, end, and the value of
         // this element's selectionDirection attribute.
-        self.set_range(start, Some(end), Some(self.direction()), None);
+        self.set_range(start, Some(end), Some(self.direction()));
         Ok(())
     }
 
@@ -119,7 +118,7 @@ impl<'a, E: TextControlElement> TextControlSelection<'a, E> {
         // Step 2: Set the selection range with the value of this element's selectionStart
         // attribute, the given value, and the value of this element's selectionDirection
         // attribute.
-        self.set_range(Some(self.start()), end, Some(self.direction()), None);
+        self.set_range(Some(self.start()), end, Some(self.direction()));
         Ok(())
     }
 
@@ -130,7 +129,11 @@ impl<'a, E: TextControlElement> TextControlSelection<'a, E> {
             return None;
         }
 
-        Some(DOMString::from(self.direction()))
+        Some(DOMString::from(match self.direction() {
+            SelectionDirection::Forward => "forward",
+            SelectionDirection::Backward => "backward",
+            SelectionDirection::None => "none",
+        }))
     }
 
     // https://html.spec.whatwg.org/multipage/#dom-textarea/input-selectiondirection
@@ -144,8 +147,7 @@ impl<'a, E: TextControlElement> TextControlSelection<'a, E> {
         self.set_range(
             Some(self.start()),
             Some(self.end()),
-            direction.map(SelectionDirection::from),
-            None,
+            direction.map(|direction| direction.str().as_ref().into()),
         );
         Ok(())
     }
@@ -166,8 +168,7 @@ impl<'a, E: TextControlElement> TextControlSelection<'a, E> {
         self.set_range(
             Some(start),
             Some(end),
-            direction.map(SelectionDirection::from),
-            None,
+            direction.map(|direction| direction.str().as_ref().into()),
         );
         Ok(())
     }
@@ -205,10 +206,6 @@ impl<'a, E: TextControlElement> TextControlSelection<'a, E> {
         if start > end {
             return Err(Error::IndexSize(None));
         }
-
-        // Save the original selection state to later pass to set_selection_range, because we will
-        // change the selection state in order to replace the text in the range.
-        let original_selection_state = self.textinput.borrow().selection_state();
 
         // Step 5: If start is greater than the length of the relevant value of the text
         // control, then set it to the length of the relevant value of the text control.
@@ -313,12 +310,7 @@ impl<'a, E: TextControlElement> TextControlSelection<'a, E> {
         }
 
         // Step 14: Set the selection range with selection start and selection end.
-        self.set_range(
-            Some(selection_start),
-            Some(selection_end),
-            None,
-            Some(original_selection_state),
-        );
+        self.set_range(Some(selection_start), Some(selection_end), None);
         Ok(())
     }
 
@@ -340,11 +332,7 @@ impl<'a, E: TextControlElement> TextControlSelection<'a, E> {
         start: Option<Utf16CodeUnitLength>,
         end: Option<Utf16CodeUnitLength>,
         direction: Option<SelectionDirection>,
-        original_selection_state: Option<SelectionState>,
     ) {
-        let original_selection_state =
-            original_selection_state.unwrap_or_else(|| self.textinput.borrow().selection_state());
-
         // To set the selection range with an integer or null start, an integer or null or
         // the special value infinity end, and optionally a string direction, run the
         // following steps:
@@ -380,20 +368,8 @@ impl<'a, E: TextControlElement> TextControlSelection<'a, E> {
         // modified (in either extent or direction), then queue an element task on the
         // user interaction task source given the element to fire an event named select at
         // the element, with the bubbles attribute initialized to true.
-        if self.textinput.borrow().selection_state() == original_selection_state {
-            return;
-        }
-
-        self.element
-            .owner_global()
-            .task_manager()
-            .user_interaction_task_source()
-            .queue_event(
-                self.element.upcast::<EventTarget>(),
-                atom!("select"),
-                EventBubbles::Bubbles,
-                EventCancelable::NotCancelable,
-            );
+        //
+        // Note: This is handled inside this method call.
         self.element.maybe_update_shared_selection();
     }
 }

--- a/components/script/test.rs
+++ b/components/script/test.rs
@@ -71,7 +71,7 @@ pub mod timeranges {
 
 pub mod textinput {
     pub use crate::clipboard_provider::ClipboardProvider;
-    pub use crate::textinput::{Direction, SelectionDirection, TextInput};
+    pub use crate::textinput::{Direction, TextInput};
 }
 
 pub mod encoding_detection {

--- a/components/script/textinput.rs
+++ b/components/script/textinput.rs
@@ -11,6 +11,7 @@ use base::text::{Utf8CodeUnitLength, Utf16CodeUnitLength};
 use base::{Rope, RopeIndex, RopeMovement, RopeSlice};
 use bitflags::bitflags;
 use keyboard_types::{Key, KeyState, Modifiers, NamedKey, ShortcutMatcher};
+use layout_api::wrapper_traits::SelectionDirection;
 use script_bindings::codegen::GenericBindings::MouseEventBinding::MouseEventMethods;
 use script_bindings::codegen::GenericBindings::UIEventBinding::UIEventMethods;
 use script_bindings::match_domstring_ascii;
@@ -39,33 +40,6 @@ pub enum Selection {
     NotSelected,
 }
 
-#[derive(Clone, Copy, Debug, JSTraceable, MallocSizeOf, PartialEq)]
-pub enum SelectionDirection {
-    Forward,
-    Backward,
-    None,
-}
-
-impl From<DOMString> for SelectionDirection {
-    fn from(direction: DOMString) -> SelectionDirection {
-        match_domstring_ascii!(direction,
-            "forward" => SelectionDirection::Forward,
-            "backward" => SelectionDirection::Backward,
-            _ => SelectionDirection::None,
-        )
-    }
-}
-
-impl From<SelectionDirection> for DOMString {
-    fn from(direction: SelectionDirection) -> DOMString {
-        match direction {
-            SelectionDirection::Forward => DOMString::from("forward"),
-            SelectionDirection::Backward => DOMString::from("backward"),
-            SelectionDirection::None => DOMString::from("none"),
-        }
-    }
-}
-
 #[derive(Clone, Copy, JSTraceable, MallocSizeOf)]
 pub enum Lines {
     Single,
@@ -88,13 +62,6 @@ impl Lines {
     }
 }
 
-#[derive(Clone, Copy, PartialEq)]
-pub(crate) struct SelectionState {
-    start: RopeIndex,
-    end: RopeIndex,
-    direction: SelectionDirection,
-}
-
 /// Encapsulated state for handling keyboard input in a single or multiline text input control.
 #[derive(JSTraceable, MallocSizeOf)]
 pub struct TextInput<T: ClipboardProvider> {
@@ -115,6 +82,10 @@ pub struct TextInput<T: ClipboardProvider> {
     /// selection_origin may be after the edit_point, in the case of a backward selection.
     #[no_trace]
     selection_origin: Option<RopeIndex>,
+
+    /// The direction that the selection goes in this [`TextInput`]. DOM APIs track this as
+    /// a separate field.
+    #[no_trace]
     selection_direction: SelectionDirection,
 
     #[ignore_malloc_size_of = "Can't easily measure this generic type"]
@@ -389,15 +360,6 @@ impl<T: ClipboardProvider> TextInput<T> {
     pub(crate) fn sorted_selection_character_offsets_range(&self) -> Range<usize> {
         self.rope.index_to_character_offset(self.selection_start())..
             self.rope.index_to_character_offset(self.selection_end())
-    }
-
-    /// The state of the current selection. Can be used to compare whether selection state has changed.
-    pub(crate) fn selection_state(&self) -> SelectionState {
-        SelectionState {
-            start: self.selection_start(),
-            end: self.selection_end(),
-            direction: self.selection_direction,
-        }
     }
 
     // Check that the selection is valid.

--- a/components/shared/layout/wrapper_traits.rs
+++ b/components/shared/layout/wrapper_traits.rs
@@ -434,11 +434,31 @@ impl PseudoElementChain {
     }
 }
 
+#[derive(Clone, Copy, Debug, Default, MallocSizeOf, PartialEq)]
+pub enum SelectionDirection {
+    Forward,
+    Backward,
+    #[default]
+    None,
+}
+
+impl From<&str> for SelectionDirection {
+    fn from(direction: &str) -> SelectionDirection {
+        match direction {
+            "forward" => SelectionDirection::Forward,
+            "backward" => SelectionDirection::Backward,
+            _ => SelectionDirection::None,
+        }
+    }
+}
+
 /// A selection shared between script and layout. This selection is managed by the DOM
 /// node that maintains it, and can be modified from script. Once modified, layout is
 /// expected to reflect the new selection visual on the next display list update.
 #[derive(Clone, Debug, Default, MallocSizeOf, PartialEq)]
 pub struct ScriptSelection {
+    /// The direction of this text selection.
+    pub direction: SelectionDirection,
     /// The range of this selection in the DOM node that manages it.
     pub range: TextByteRange,
     /// The character range of this selection in the DOM node that manages it.
@@ -449,3 +469,14 @@ pub struct ScriptSelection {
 }
 
 pub type SharedSelection = std::sync::Arc<AtomicRefCell<ScriptSelection>>;
+
+impl ScriptSelection {
+    pub fn is_equivalent_to(
+        &self,
+        range: &TextByteRange,
+        enabled: bool,
+        direction: SelectionDirection,
+    ) -> bool {
+        self.range == *range && self.enabled == enabled && self.direction == direction
+    }
+}

--- a/tests/unit/script/Cargo.toml
+++ b/tests/unit/script/Cargo.toml
@@ -16,5 +16,6 @@ base = { workspace = true }
 encoding_rs = { workspace = true }
 euclid = { workspace = true }
 keyboard-types = { workspace = true }
-script = {path = "../../../components/script"}
-servo_url = {path = "../../../components/url"}
+layout_api = { workspace = true }
+script = { path = "../../../components/script" }
+servo_url = { path = "../../../components/url" }

--- a/tests/unit/script/textinput.rs
+++ b/tests/unit/script/textinput.rs
@@ -10,8 +10,9 @@
 use base::text::{Utf8CodeUnitLength, Utf16CodeUnitLength};
 use base::{RopeIndex, RopeMovement};
 use keyboard_types::{Key, Modifiers, NamedKey};
+use layout_api::wrapper_traits::SelectionDirection;
 use script::test::DOMString;
-use script::test::textinput::{ClipboardProvider, Direction, SelectionDirection, TextInput};
+use script::test::textinput::{ClipboardProvider, Direction, TextInput};
 use script::textinput::Lines;
 
 pub struct DummyClipboardContext {

--- a/tests/wpt/mozilla/meta/MANIFEST.json
+++ b/tests/wpt/mozilla/meta/MANIFEST.json
@@ -13123,6 +13123,15 @@
       }
      ]
     ],
+    "mouse-text-selection-input-text-selection-event.html": [
+     "f23bddeaa2a5eedd7c2aa5a8f8cc017a68390e5b",
+     [
+      null,
+      {
+       "testdriver": true
+      }
+     ]
+    ],
     "mouse-text-selection-input-text.html": [
      "c140004ae89fb8a73fb2a4d3c78382dde6134a07",
      [

--- a/tests/wpt/mozilla/tests/input-events/mouse-text-selection-input-text-selection-event.html
+++ b/tests/wpt/mozilla/tests/input-events/mouse-text-selection-input-text-selection-event.html
@@ -1,0 +1,42 @@
+<!DOCTYPE html>
+<title>Basic selection of text via the mouse in &lt;input type=text&gt; triggers select event</title>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/resources/testdriver.js"></script>
+<script src="/resources/testdriver-actions.js"></script>
+<script src="/resources/testdriver-vendor.js"></script>
+<link rel="stylesheet" type="text/css" href="/fonts/ahem.css" />
+
+<input id="target" style="font: 50px/1 Ahem;" value="123456">
+
+<script>
+promise_test(async test => {
+    let targetRect = target.getBoundingClientRect();
+    let verticalCenterOfLine = targetRect.top + (targetRect.height / 2);
+
+    // Click somewhere else to avoid double-clicking.
+    await new test_driver.Actions()
+      .pointerMove(500, 500)
+      .pointerDown()
+      .pointerUp()
+      .send();
+
+    // We should only receive a single "mousemove" event if the cursor does not move.
+    const eventWatcher = new EventWatcher(test, target, ["mousedown", "mousemove", "mouseup", "select"]);
+    const eventPromise = eventWatcher.wait_for(["mousemove", "mousedown", "select", "mousemove", "select", "mouseup"]);
+
+    await new test_driver.Actions()
+      .pointerMove(targetRect.left + 1, verticalCenterOfLine)
+      .pointerDown()
+      .pointerMove(targetRect.left + (50 * 5), verticalCenterOfLine)
+      .pointerUp()
+      .send();
+
+    await eventPromise;
+
+    assert_equals(target.selectionStart, 0);
+    assert_equals(target.selectionEnd, 5);
+    assert_equals(target.selectionDirection, "forward");
+    target.setSelectionRange(0, 0);
+});
+</script>


### PR DESCRIPTION
This change makes it so that selection changes driven by user input
events also fire the `select` event and not just selection changes from
script. In addition the change eliminate the `SelectionState` data
structure instead opting to store the `SelectionDirection` in the
`SharedSelection`. That way there is a centralized place that selection
changes are handled.

Testing: This change adds a Servo-specific WPT test. This is Servo-specific as
it relies on engine-specific text selection behavior.
Fixes: #41308.
