### PR TITLE
script: Pass `&mut JSContext` to method of `Crypto` interface

### DIFF
--- a/components/script/dom/crypto.rs
+++ b/components/script/dom/crypto.rs
@@ -42,9 +42,9 @@ impl Crypto {
 
 impl CryptoMethods<crate::DomTypeHolder> for Crypto {
     /// <https://w3c.github.io/webcrypto/#dfn-Crypto-attribute-subtle>
-    fn Subtle(&self, can_gc: CanGc) -> DomRoot<SubtleCrypto> {
+    fn Subtle(&self, cx: &mut js::context::JSContext) -> DomRoot<SubtleCrypto> {
         self.subtle
-            .or_init(|| SubtleCrypto::new(&self.global(), can_gc))
+            .or_init(|| SubtleCrypto::new(cx, &self.global()))
     }
 
     #[expect(unsafe_code)]

--- a/components/script/dom/subtlecrypto.rs
+++ b/components/script/dom/subtlecrypto.rs
@@ -61,7 +61,7 @@ use crate::dom::bindings::codegen::UnionTypes::{
 use crate::dom::bindings::conversions::{SafeFromJSValConvertible, SafeToJSValConvertible};
 use crate::dom::bindings::error::{Error, Fallible};
 use crate::dom::bindings::refcounted::{Trusted, TrustedPromise};
-use crate::dom::bindings::reflector::{DomGlobal, Reflector, reflect_dom_object};
+use crate::dom::bindings::reflector::{DomGlobal, Reflector, reflect_dom_object_with_cx};
 use crate::dom::bindings::root::DomRoot;
 use crate::dom::bindings::str::{DOMString, serialize_jsval_to_json_utf8};
 use crate::dom::bindings::trace::RootedTraceableBox;
@@ -204,8 +204,11 @@ impl SubtleCrypto {
         }
     }
 
-    pub(crate) fn new(global: &GlobalScope, can_gc: CanGc) -> DomRoot<SubtleCrypto> {
-        reflect_dom_object(Box::new(SubtleCrypto::new_inherited()), global, can_gc)
+    pub(crate) fn new(
+        cx: &mut js::context::JSContext,
+        global: &GlobalScope,
+    ) -> DomRoot<SubtleCrypto> {
+        reflect_dom_object_with_cx(Box::new(SubtleCrypto::new_inherited()), global, cx)
     }
 
     /// Queue a global task on the crypto task source, given realm's global object, to resolve

--- a/components/script_bindings/codegen/Bindings.conf
+++ b/components/script_bindings/codegen/Bindings.conf
@@ -159,7 +159,7 @@ DOMInterfaces = {
 },
 
 'Crypto': {
-    'canGc': ['Subtle'],
+    'cx': ['Subtle'],
 },
 
 'CSSStyleDeclaration': {


### PR DESCRIPTION
This patch changes the method of `Crypto` interface to use the new `&mut JSContext`.

The method `crypto.subtle` calls `SubtleCrypto::new` to create an instance of `SubtleCrypto` and the new `&mut JSContext` is passed to `SubtleCrypto::new`. Therefore, the new `reflect_dom_object_with_cx` method is also used in `SubtleCrypto::new`.

Testing: Refactoring. Existing tests suffice.
Fixes: Part of #42638