### PR TITLE
libservo: Fix `test_largest_contentful_paint_js_api_with_mouse_click_and_reload` intermittency

### DIFF
--- a/components/servo/tests/largest_contentful_paint.rs
+++ b/components/servo/tests/largest_contentful_paint.rs
@@ -128,19 +128,13 @@ fn test_largest_contentful_paint_js_api_with_mouse_click_and_reload() {
     let delegate = Rc::new(WebViewDelegateImpl::default());
     let webview = WebViewBuilder::new(servo_test.servo(), servo_test.rendering_context.clone())
         .delegate(delegate.clone())
-        .url(
-            Url::parse(
-                "data:text/html,<!DOCTYPE html>\
-                <a href=\"https://servo.org\"><div style=\"width: 50px; height: 50px;\">Link</div></a> \
-                <div><img src=\"data:image/svg+xml,<svg width='50' height='50'><circle cx='25' cy='25' r='20' fill='green'/></svg>\"\
-                style=\"width: 50px; height: 50px;\"></div>"
-            )
-            .unwrap(),
-        )
+        .url(Url::parse(DATA_URL_FOR_PAGE_WITH_SINGLE_RED_SQUARE).unwrap())
         .build();
 
-    // Simulate a user interaction to disable LCP calculation for the WebView.
+    // Simulate a user interaction before loading i.e before spinning event loop to disable LCP calculation for the WebView.
     click_at_point(&webview, Point2D::new(1., 1.));
+
+    show_webview_and_wait_for_rendering_to_be_ready(&servo_test, &webview, &delegate);
 
     let lcp_script = "(async () => {
         window.lcp = await new Promise(resolve => {
@@ -154,7 +148,6 @@ fn test_largest_contentful_paint_js_api_with_mouse_click_and_reload() {
     if let Err(err) = evaluate_javascript(&servo_test, webview.clone(), lcp_script) {
         panic!("Failed to evaluate LCP setup script: {:?}", err);
     }
-    show_webview_and_wait_for_rendering_to_be_ready(&servo_test, &webview, &delegate);
 
     // Read from a global variable used to store the result since evaluate_javascript doesn't handle Promises
     let lcp = evaluate_javascript(&servo_test, webview.clone(), "window.lcp;");
@@ -162,11 +155,11 @@ fn test_largest_contentful_paint_js_api_with_mouse_click_and_reload() {
 
     // Reloading the WebView should re-enable LCP calculation.
     webview.reload();
+    show_webview_and_wait_for_rendering_to_be_ready(&servo_test, &webview, &delegate);
 
     if let Err(err) = evaluate_javascript(&servo_test, webview.clone(), lcp_script) {
         panic!("Failed to evaluate LCP setup script: {:?}", err);
     }
-    show_webview_and_wait_for_rendering_to_be_ready(&servo_test, &webview, &delegate);
 
     // Read from a global variable used to store the result since evaluate_javascript doesn't handle Promises
     let lcp = evaluate_javascript(&servo_test, webview.clone(), "window.lcp;");


### PR DESCRIPTION
> This was overlooked earlier in #41169

Simulate a mouse click before loading the page so that it should trigger input events before populating any LCP entries for this `webview`.
- When mouse click event is received before/while loading, it should not report LCP for webview.

When Page is reloaded, LCp should be reinstated for webview.
- Verify the Successful reporting of LCP entry after the reload.

Testing: `tests/largest_contentful_paint.rs`
Fixes: #42759 
