### PR TITLE
layout: Add testing API for counting restyled and rebuilt fragments

### DIFF
--- a/components/layout/display_list/mod.rs
+++ b/components/layout/display_list/mod.rs
@@ -11,6 +11,7 @@ use clip::{Clip, ClipId};
 use euclid::{Box2D, Point2D, Rect, Scale, SideOffsets2D, Size2D, UnknownUnit, Vector2D};
 use fonts::GlyphStore;
 use gradient::WebRenderGradient;
+use layout_api::ReflowStatistics;
 use net_traits::image_cache::Image as CachedImage;
 use paint_api::display_list::{PaintDisplayListInfo, SpatialTreeNodeInfo};
 use paint_api::largest_contentful_paint_candidate::LCPCandidateID;
@@ -53,8 +54,8 @@ use crate::context::{ImageResolver, ResolvedImage};
 pub(crate) use crate::display_list::conversions::ToWebRender;
 use crate::display_list::stacking_context::StackingContextSection;
 use crate::fragment_tree::{
-    BackgroundMode, BoxFragment, Fragment, FragmentFlags, FragmentTree, SpecificLayoutInfo, Tag,
-    TextFragment,
+    BackgroundMode, BoxFragment, Fragment, FragmentFlags, FragmentStatus, FragmentTree,
+    SpecificLayoutInfo, Tag, TextFragment,
 };
 use crate::geom::{
     LengthPercentageOrAuto, PhysicalPoint, PhysicalRect, PhysicalSides, PhysicalSize,
@@ -124,6 +125,9 @@ pub(crate) struct DisplayListBuilder<'a> {
 
     /// Handler for all Paint Timings
     paint_timing_handler: &'a mut PaintTimingHandler,
+
+    /// Statistics collected about the reflow, in order to write tests for incremental layout.
+    reflow_statistics: &'a mut ReflowStatistics,
 }
 
 struct InspectorHighlight {
@@ -165,6 +169,7 @@ impl InspectorHighlight {
 }
 
 impl DisplayListBuilder<'_> {
+    #[expect(clippy::too_many_arguments)]
     pub(crate) fn build(
         stacking_context_tree: &mut StackingContextTree,
         fragment_tree: &FragmentTree,
@@ -173,6 +178,7 @@ impl DisplayListBuilder<'_> {
         highlighted_dom_node: Option<OpaqueNode>,
         debug: &DiagnosticsLogging,
         paint_timing_handler: &mut PaintTimingHandler,
+        reflow_statistics: &mut ReflowStatistics,
     ) -> BuiltDisplayList {
         // Build the rest of the display list which inclues all of the WebRender primitives.
         let paint_info = &mut stacking_context_tree.paint_info;
@@ -202,6 +208,7 @@ impl DisplayListBuilder<'_> {
             image_resolver,
             device_pixel_ratio,
             paint_timing_handler,
+            reflow_statistics,
         };
 
         builder.add_all_spatial_nodes();
@@ -619,6 +626,20 @@ impl Fragment {
         is_collapsed_table_borders: bool,
         text_decorations: &Arc<Vec<FragmentTextDecoration>>,
     ) {
+        if let Some(mut base) = self.base_mut() {
+            match base.status {
+                FragmentStatus::New => {
+                    builder.reflow_statistics.rebuilt_fragment_count += 1;
+                    base.status = FragmentStatus::Clean;
+                },
+                FragmentStatus::StyleChanged => {
+                    builder.reflow_statistics.restyle_fragment_count += 1;
+                    base.status = FragmentStatus::Clean;
+                },
+                FragmentStatus::Clean => {},
+            }
+        }
+
         let spatial_id = builder.spatial_id(builder.current_scroll_node_id);
         let clip_chain_id = builder.clip_chain_id(builder.current_clip_id);
         if let Some(inspector_highlight) = &mut builder.inspector_highlight {

--- a/components/layout/fragment_tree/base_fragment.rs
+++ b/components/layout/fragment_tree/base_fragment.rs
@@ -67,6 +67,17 @@ impl std::fmt::Debug for BaseFragmentStyle {
     }
 }
 
+#[derive(Clone, Debug, Default, MallocSizeOf)]
+pub(crate) enum FragmentStatus {
+    /// This is a brand new fragment.
+    #[default]
+    New,
+    /// The style of the fragment has changed.
+    StyleChanged,
+    /// The fragment hasn't changed.
+    Clean,
+}
+
 /// This data structure stores fields that are common to all non-base
 /// Fragment types and should generally be the first member of all
 /// concrete fragments.
@@ -89,6 +100,8 @@ pub(crate) struct BaseFragment {
     /// does not include padding, border, or margin -- it only includes content. This is
     /// relative to the parent containing block.
     pub rect: PhysicalRect<Au>,
+
+    pub status: FragmentStatus,
 }
 
 impl BaseFragment {
@@ -102,6 +115,7 @@ impl BaseFragment {
             flags: base_fragment_info.flags,
             style,
             rect,
+            status: Default::default(),
         }
     }
 
@@ -111,6 +125,7 @@ impl BaseFragment {
 
     pub(crate) fn repair_style(&mut self, style: &ServoArc<ComputedValues>) {
         self.style = style.clone().into();
+        self.status = FragmentStatus::StyleChanged;
     }
 
     pub(crate) fn style<'a>(&'a self) -> BaseFragmentStyleRef<'a> {

--- a/components/layout/fragment_tree/base_fragment.rs
+++ b/components/layout/fragment_tree/base_fragment.rs
@@ -101,6 +101,7 @@ pub(crate) struct BaseFragment {
     /// relative to the parent containing block.
     pub rect: PhysicalRect<Au>,
 
+    /// A [`FragmentStatus`] used to track fragment reuse when collecting reflow statistics.
     pub status: FragmentStatus,
 }
 

--- a/components/script/dom/testing/layoutresult.rs
+++ b/components/script/dom/testing/layoutresult.rs
@@ -18,27 +18,53 @@ use crate::script_runtime::CanGc;
 pub(crate) struct LayoutResult {
     reflector_: Reflector,
     phases: Vec<DOMString>,
+    rebuilt_fragment_count: u32,
+    restyle_fragment_count: u32,
 }
 
 impl LayoutResult {
-    pub(crate) fn new_inherited(phases: Vec<DOMString>) -> Self {
+    pub(crate) fn new_inherited(
+        phases: Vec<DOMString>,
+        rebuilt_fragment_count: u32,
+        restyle_fragment_count: u32,
+    ) -> Self {
         Self {
             reflector_: Reflector::new(),
             phases,
+            rebuilt_fragment_count,
+            restyle_fragment_count,
         }
     }
 
     pub(crate) fn new(
         global: &GlobalScope,
         phases: Vec<DOMString>,
+        rebuilt_fragment_count: u32,
+        restyle_fragment_count: u32,
         can_gc: CanGc,
     ) -> DomRoot<Self> {
-        reflect_dom_object(Box::new(Self::new_inherited(phases)), global, can_gc)
+        reflect_dom_object(
+            Box::new(Self::new_inherited(
+                phases,
+                rebuilt_fragment_count,
+                restyle_fragment_count,
+            )),
+            global,
+            can_gc,
+        )
     }
 }
 
 impl LayoutResultMethods<crate::DomTypeHolder> for LayoutResult {
     fn Phases(&self, cx: SafeJSContext, can_gc: CanGc, return_value: MutableHandleValue) {
         to_frozen_array(&self.phases, cx, return_value, can_gc);
+    }
+
+    fn RebuiltFragmentCount(&self) -> u32 {
+        self.rebuilt_fragment_count
+    }
+
+    fn RestyleFragmentCount(&self) -> u32 {
+        self.restyle_fragment_count
     }
 }

--- a/components/script/dom/testing/servotestutils.rs
+++ b/components/script/dom/testing/servotestutils.rs
@@ -33,7 +33,7 @@ impl ServoTestUtilsMethods<crate::DomTypeHolder> for ServoTestUtils {
     }
 
     fn ForceLayout(global: &GlobalScope, can_gc: CanGc) -> DomRoot<LayoutResult> {
-        let phases_run = global.as_window().Document().update_the_rendering();
+        let (phases_run, statistics) = global.as_window().Document().update_the_rendering();
 
         let mut phases = Vec::new();
         if phases_run.contains(ReflowPhasesRun::RanLayout) {
@@ -55,7 +55,13 @@ impl ServoTestUtilsMethods<crate::DomTypeHolder> for ServoTestUtils {
             phases.push(DOMString::from("UpdatedImageData"))
         }
 
-        LayoutResult::new(global, phases, can_gc)
+        LayoutResult::new(
+            global,
+            phases,
+            statistics.rebuilt_fragment_count,
+            statistics.restyle_fragment_count,
+            can_gc,
+        )
     }
 
     fn Js_backtrace(_: &GlobalScope) {

--- a/components/script/dom/window.rs
+++ b/components/script/dom/window.rs
@@ -58,8 +58,8 @@ use layout_api::{
     BoxAreaType, CSSPixelRectIterator, ElementsFromPointFlags, ElementsFromPointResult,
     FragmentType, Layout, LayoutImageDestination, PendingImage, PendingImageState,
     PendingRasterizationImage, PhysicalSides, QueryMsg, ReflowGoal, ReflowPhasesRun, ReflowRequest,
-    ReflowRequestRestyle, RestyleReason, ScrollContainerQueryFlags, ScrollContainerResponse,
-    TrustedNodeAddress, combine_id_with_fragment_type,
+    ReflowRequestRestyle, ReflowStatistics, RestyleReason, ScrollContainerQueryFlags,
+    ScrollContainerResponse, TrustedNodeAddress, combine_id_with_fragment_type,
 };
 use malloc_size_of::MallocSizeOf;
 use media::WindowGLContext;
@@ -2504,7 +2504,7 @@ impl Window {
         // TODO Step 1
         // TODO(mrobinson, #18709): Add smooth scrolling support to WebRender so that we can
         // properly process ScrollBehavior here.
-        let reflow_phases_run =
+        let (reflow_phases_run, _) =
             self.reflow(ReflowGoal::UpdateScrollNode(scroll_id, Vector2D::new(x, y)));
         if reflow_phases_run.needs_frame() {
             self.paint_api()
@@ -2550,12 +2550,12 @@ impl Window {
     ///
     /// NOTE: This method should almost never be called directly! Layout and rendering updates should
     /// happen as part of the HTML event loop via *update the rendering*.
-    pub(crate) fn reflow(&self, reflow_goal: ReflowGoal) -> ReflowPhasesRun {
+    pub(crate) fn reflow(&self, reflow_goal: ReflowGoal) -> (ReflowPhasesRun, ReflowStatistics) {
         let document = self.Document();
 
         // Never reflow inactive Documents.
         if !document.is_fully_active() {
-            return ReflowPhasesRun::empty();
+            return Default::default();
         }
 
         self.Document().ensure_safe_to_run_script_or_layout();
@@ -2568,7 +2568,7 @@ impl Window {
             self.layout_blocker.get().layout_blocked()
         {
             debug!("Suppressing pre-load-event reflow pipeline {pipeline_id}");
-            return ReflowPhasesRun::empty();
+            return Default::default();
         }
 
         debug!("script: performing reflow for goal {reflow_goal:?}");
@@ -2624,7 +2624,7 @@ impl Window {
         };
 
         let Some(reflow_result) = self.layout.borrow_mut().reflow(reflow) else {
-            return ReflowPhasesRun::empty();
+            return Default::default();
         };
 
         debug!("script: layout complete");
@@ -2646,7 +2646,10 @@ impl Window {
 
         document.update_animations_post_reflow();
 
-        reflow_result.reflow_phases_run
+        (
+            reflow_result.reflow_phases_run,
+            reflow_result.reflow_statistics,
+        )
     }
 
     pub(crate) fn request_screenshot_readiness(&self, can_gc: CanGc) {
@@ -2764,7 +2767,7 @@ impl Window {
         // iframe size updates.
         //
         // See <https://github.com/servo/servo/issues/14719>
-        if self.Document().update_the_rendering().needs_frame() {
+        if self.Document().update_the_rendering().0.needs_frame() {
             self.paint_api()
                 .generate_frame(vec![self.webview_id().into()]);
         }

--- a/components/script/script_thread.rs
+++ b/components/script/script_thread.rs
@@ -1261,7 +1261,7 @@ impl ScriptThread {
 
             // > Step 22: For each doc of docs, update the rendering or user interface of
             // > doc and its node navigable to reflect the current state.
-            if document.update_the_rendering().needs_frame() {
+            if document.update_the_rendering().0.needs_frame() {
                 painters_generating_frames.insert(document.webview_id().into());
             }
 

--- a/components/script_bindings/webidls/ServoTestUtils.webidl
+++ b/components/script_bindings/webidls/ServoTestUtils.webidl
@@ -25,4 +25,6 @@ namespace ServoTestUtils {
 [Exposed=Window, Pref="dom_servo_helpers_enabled"]
 interface LayoutResult {
     readonly attribute /* FrozenArray<DOMString> */ any phases;
+    readonly attribute unsigned long rebuiltFragmentCount;
+    readonly attribute unsigned long restyleFragmentCount;
 };

--- a/components/shared/layout/lib.rs
+++ b/components/shared/layout/lib.rs
@@ -561,6 +561,7 @@ impl RestyleReason {
 pub struct ReflowResult {
     /// The phases that were run during this reflow.
     pub reflow_phases_run: ReflowPhasesRun,
+    pub reflow_statistics: ReflowStatistics,
     /// The list of images that were encountered that are in progress.
     pub pending_images: Vec<PendingImage>,
     /// The list of vector images that were encountered that still need to be rasterized.
@@ -599,6 +600,12 @@ impl ReflowPhasesRun {
             Self::BuiltDisplayList | Self::UpdatedScrollNodeOffset | Self::UpdatedImageData,
         )
     }
+}
+
+#[derive(Debug, Default)]
+pub struct ReflowStatistics {
+    pub rebuilt_fragment_count: u32,
+    pub restyle_fragment_count: u32,
 }
 
 /// Information needed for a script-initiated reflow that requires a restyle

--- a/tests/wpt/mozilla/meta/MANIFEST.json
+++ b/tests/wpt/mozilla/meta/MANIFEST.json
@@ -13032,6 +13032,13 @@
     ]
    },
    "incremental-layout": {
+    "basic-fragment-tree-layout.html": [
+     "f249b241dd97d20295efd923d77a12fac873a911",
+     [
+      null,
+      {}
+     ]
+    ],
     "layout-phases-display-list.html": [
      "0f08ae12a4610987d304bdd2431ccde0bec192be",
      [

--- a/tests/wpt/mozilla/tests/incremental-layout/basic-fragment-tree-layout.html
+++ b/tests/wpt/mozilla/tests/incremental-layout/basic-fragment-tree-layout.html
@@ -1,0 +1,127 @@
+<!DOCTYPE html>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<style>
+div, p, section {
+  display: flow-root;
+}
+#section2 {
+  width: 50px;
+}
+</style>
+
+<div id="div1">
+  <p id="p1">Example1</p>
+</div>
+
+<div id="div2">
+  <section id="section2">
+    <p id="p2">Example2</p>
+  </section>
+</div>
+
+<div id="div3">
+  <section id="section3">
+    <p id="p3">Example2</p>
+  </section>
+</div>
+
+<script>
+setup({explicit_done:true});
+window.onload = () => {
+    test((t) => {
+        ServoTestUtils.forceLayout();
+        div1.style.backgroundColor = 'green';
+        t.add_cleanup(() => {
+            div1.style.cssText = '';
+        });
+
+        let result = ServoTestUtils.forceLayout();
+        assert_equals(result.rebuiltFragmentCount, 0, "rebuiltFragmentCount");
+        assert_equals(result.restyleFragmentCount, 1, "restyleFragmentCount");
+    }, "Updating div1's background-color property restyles but doesn't rebuild");
+
+    test((t) => {
+        ServoTestUtils.forceLayout();
+        div1.style.width = '100px';
+        t.add_cleanup(() => {
+            div1.style.cssText = '';
+        });
+
+        let result = ServoTestUtils.forceLayout();
+        // We rebuild these fragments:
+        // - html
+        // - body
+        // - #div1
+        // - #div1 > #p1
+        // - #div1 > #p1::text("Example1")
+        // - #div2
+        // - #div3
+        assert_equals(result.rebuiltFragmentCount, 7, "rebuiltFragmentCount");
+        assert_equals(result.restyleFragmentCount, 0, "restyleFragmentCount");
+    }, "Updating div1's width property rebuilds some fragments");
+
+   test((t) => {
+        ServoTestUtils.forceLayout();
+        div2.style.width = '100px';
+        t.add_cleanup(() => {
+            div2.style.cssText = '';
+        });
+
+        let result = ServoTestUtils.forceLayout();
+        // We rebuild these fragments:
+        // - html
+        // - body
+        // - #div1
+        // - #div2
+        // - #div2 > #section2
+        // - #div2 > #section2 > #p2
+        // - #div3
+        assert_equals(result.rebuiltFragmentCount, 7, "rebuiltFragmentCount");
+        assert_equals(result.restyleFragmentCount, 0, "restyleFragmentCount");
+    }, "Updating div2's width property rebuilds some fragments");
+
+   test((t) => {
+        ServoTestUtils.forceLayout();
+        div3.style.width = '100px';
+        t.add_cleanup(() => {
+            div3.style.cssText = '';
+        });
+
+        let result = ServoTestUtils.forceLayout();
+        // We rebuild these fragments:
+        // - html
+        // - body
+        // - #div1
+        // - #div2
+        // - #div3
+        // - #div3 > #section3
+        // - #div3 > #section3 > #p3
+        // - #div3 > #p3::text("Example3")
+        assert_equals(result.rebuiltFragmentCount, 8, "rebuiltFragmentCount");
+        assert_equals(result.restyleFragmentCount, 0, "restyleFragmentCount");
+    }, "Updating div3's width property rebuilds some fragments");
+
+   test((t) => {
+        ServoTestUtils.forceLayout();
+        div3.style.height = '100px';
+        t.add_cleanup(() => {
+            div3.style.cssText = '';
+        });
+
+        let result = ServoTestUtils.forceLayout();
+        // We rebuild these fragments:
+        // - html
+        // - body
+        // - #div1
+        // - #div2
+        // - #div3
+        // - #div3 > #section3
+        // - #div3 > #section3 > #p3
+        assert_equals(result.rebuiltFragmentCount, 7, "rebuiltFragmentCount");
+        assert_equals(result.restyleFragmentCount, 0, "restyleFragmentCount");
+    }, "Updating div3's height property rebuilds some fragments");
+
+    done();
+}
+</script>


### PR DESCRIPTION
Now `ServoTestUtils.forceLayout()` will provide the number of fragments that have been restyled and rebuilt. This will be useful to test that incremental layout works well.

Testing: Adds a test using this new API
