### PR TITLE
CI: Always switch apt mirrors before apt

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -63,6 +63,8 @@ jobs:
           fetch-depth: 2
       - name: Install crown
         run: cargo install --path support/crown
+      - name: Change Mirror Priorities
+        uses: ./.github/actions/apt-mirrors
       - name: Setup Python
         uses: ./.github/actions/setup-python
       - name: Bootstrap dependencies

--- a/.github/workflows/bencher.yml
+++ b/.github/workflows/bencher.yml
@@ -92,6 +92,9 @@ jobs:
       - name: Setup Python
         if: ${{ runner.environment != 'self-hosted' }}
         uses: ./.github/actions/setup-python
+      - name: Change Mirror Priorities
+        if: ${{ runner.environment != 'self-hosted' }}
+        uses: ./.github/actions/apt-mirrors
       - name: Bootstrap dependencies
         if: ${{ runner.environment != 'self-hosted' && (inputs.speedometer || inputs.dromaeo) }}
         timeout-minutes: 30

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -21,6 +21,8 @@ jobs:
           swap-storage: false
       - name: Setup Python
         uses: ./.github/actions/setup-python
+      - name: Change Mirror Priorities
+        uses: ./.github/actions/apt-mirrors
       - name: Bootstrap
         run: |
           sudo apt update

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -65,6 +65,8 @@ jobs:
           crate: cargo-deny
           version: 0.19.0
           locked: true
+      - name: Change Mirror Priorities
+        uses: ./.github/actions/apt-mirrors
       - name: Bootstrap dependencies
         if: ${{ runner.environment != 'self-hosted' }}
         timeout-minutes: 30

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -66,6 +66,7 @@ jobs:
           version: 0.19.0
           locked: true
       - name: Change Mirror Priorities
+        if: ${{ runner.environment != 'self-hosted' }}
         uses: ./.github/actions/apt-mirrors
       - name: Bootstrap dependencies
         if: ${{ runner.environment != 'self-hosted' }}

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -380,6 +380,8 @@ jobs:
         if: github.event_name != 'pull_request_target'
         with:
           fetch-depth: 1
+      - name: Change Mirror Priorities
+        uses: ./.github/actions/apt-mirrors
       - name: Install Dependencies
         run: |
           sudo bash -c 'apt-add-repository -y https://mirrors.kernel.org/ubuntu'

--- a/.github/workflows/ohos.yml
+++ b/.github/workflows/ohos.yml
@@ -68,6 +68,8 @@ jobs:
         run: cargo install --path support/crown
       - name: Setup Python
         uses: ./.github/actions/setup-python
+      - name: Change Mirror Priorities
+        uses: ./.github/actions/apt-mirrors
       - name: Bootstrap dependencies
         timeout-minutes: 30
         run: sudo apt update && ./mach bootstrap --yes --skip-lints --skip-nextest

--- a/.github/workflows/scheduled-wpt-import.yml
+++ b/.github/workflows/scheduled-wpt-import.yml
@@ -34,6 +34,8 @@ jobs:
           name: wpt-full-logs-linux
       - name: Setup Python
         uses: ./.github/actions/setup-python
+      - name: Change Mirror Priorities
+        uses: ./.github/actions/apt-mirrors
       - name: Prep environment
         run: |
           sudo apt update


### PR DESCRIPTION
Default azure mirror suck and we already used this in linux/linux-wpt workflows.