### PR TITLE
Script: Use &mut JSContext in CheckValidity and ReportValidity Methods

### DIFF
--- a/components/script/dom/elementinternals.rs
+++ b/components/script/dom/elementinternals.rs
@@ -6,6 +6,7 @@ use std::cell::Cell;
 
 use dom_struct::dom_struct;
 use html5ever::local_name;
+use js::context::JSContext;
 
 use crate::dom::bindings::cell::DomRefCell;
 use crate::dom::bindings::codegen::Bindings::ElementInternalsBinding::{
@@ -362,19 +363,19 @@ impl ElementInternalsMethods<crate::DomTypeHolder> for ElementInternals {
     }
 
     /// <https://html.spec.whatwg.org/multipage#dom-elementinternals-checkvalidity>
-    fn CheckValidity(&self, can_gc: CanGc) -> Fallible<bool> {
+    fn CheckValidity(&self, cx: &mut JSContext) -> Fallible<bool> {
         if !self.is_target_form_associated() {
             return Err(Error::NotSupported(None));
         }
-        Ok(self.check_validity(can_gc))
+        Ok(self.check_validity(cx))
     }
 
     /// <https://html.spec.whatwg.org/multipage#dom-elementinternals-reportvalidity>
-    fn ReportValidity(&self, can_gc: CanGc) -> Fallible<bool> {
+    fn ReportValidity(&self, cx: &mut JSContext) -> Fallible<bool> {
         if !self.is_target_form_associated() {
             return Err(Error::NotSupported(None));
         }
-        Ok(self.report_validity(can_gc))
+        Ok(self.report_validity(cx))
     }
 
     /// <https://html.spec.whatwg.org/multipage/#dom-elementinternals-states>

--- a/components/script/dom/html/htmlbuttonelement.rs
+++ b/components/script/dom/html/htmlbuttonelement.rs
@@ -7,6 +7,7 @@ use std::default::Default;
 
 use dom_struct::dom_struct;
 use html5ever::{LocalName, Prefix, local_name};
+use js::context::JSContext;
 use js::rust::HandleObject;
 use stylo_dom::ElementState;
 
@@ -182,13 +183,13 @@ impl HTMLButtonElementMethods<crate::DomTypeHolder> for HTMLButtonElement {
     }
 
     /// <https://html.spec.whatwg.org/multipage/#dom-cva-checkvalidity>
-    fn CheckValidity(&self, can_gc: CanGc) -> bool {
-        self.check_validity(can_gc)
+    fn CheckValidity(&self, cx: &mut JSContext) -> bool {
+        self.check_validity(cx)
     }
 
     /// <https://html.spec.whatwg.org/multipage/#dom-cva-reportvalidity>
-    fn ReportValidity(&self, can_gc: CanGc) -> bool {
-        self.report_validity(can_gc)
+    fn ReportValidity(&self, cx: &mut JSContext) -> bool {
+        self.report_validity(cx)
     }
 
     /// <https://html.spec.whatwg.org/multipage/#dom-cva-validationmessage>

--- a/components/script/dom/html/htmlfieldsetelement.rs
+++ b/components/script/dom/html/htmlfieldsetelement.rs
@@ -6,6 +6,7 @@ use std::default::Default;
 
 use dom_struct::dom_struct;
 use html5ever::{LocalName, Prefix, local_name};
+use js::context::JSContext;
 use js::rust::HandleObject;
 use stylo_dom::ElementState;
 
@@ -127,13 +128,13 @@ impl HTMLFieldSetElementMethods<crate::DomTypeHolder> for HTMLFieldSetElement {
     }
 
     /// <https://html.spec.whatwg.org/multipage/#dom-cva-checkvalidity>
-    fn CheckValidity(&self, can_gc: CanGc) -> bool {
-        self.check_validity(can_gc)
+    fn CheckValidity(&self, cx: &mut JSContext) -> bool {
+        self.check_validity(cx)
     }
 
     /// <https://html.spec.whatwg.org/multipage/#dom-cva-reportvalidity>
-    fn ReportValidity(&self, can_gc: CanGc) -> bool {
-        self.report_validity(can_gc)
+    fn ReportValidity(&self, cx: &mut JSContext) -> bool {
+        self.report_validity(cx)
     }
 
     /// <https://html.spec.whatwg.org/multipage/#dom-cva-validationmessage>

--- a/components/script/dom/html/htmlformelement.rs
+++ b/components/script/dom/html/htmlformelement.rs
@@ -12,6 +12,7 @@ use encoding_rs::{Encoding, UTF_8};
 use headers::{ContentType, HeaderMapExt};
 use html5ever::{LocalName, Prefix, local_name, ns};
 use http::Method;
+use js::context::JSContext;
 use js::rust::HandleObject;
 use mime::{self, Mime};
 use net_traits::http_percent_encode;
@@ -649,13 +650,13 @@ impl HTMLFormElementMethods<crate::DomTypeHolder> for HTMLFormElement {
     }
 
     /// <https://html.spec.whatwg.org/multipage/#dom-form-checkvalidity>
-    fn CheckValidity(&self, can_gc: CanGc) -> bool {
-        self.static_validation(can_gc).is_ok()
+    fn CheckValidity(&self, cx: &mut JSContext) -> bool {
+        self.static_validation(CanGc::from_cx(cx)).is_ok()
     }
 
     /// <https://html.spec.whatwg.org/multipage/#dom-form-reportvalidity>
-    fn ReportValidity(&self, can_gc: CanGc) -> bool {
-        self.interactive_validation(can_gc).is_ok()
+    fn ReportValidity(&self, cx: &mut JSContext) -> bool {
+        self.interactive_validation(CanGc::from_cx(cx)).is_ok()
     }
 }
 

--- a/components/script/dom/html/htmlinputelement.rs
+++ b/components/script/dom/html/htmlinputelement.rs
@@ -21,6 +21,7 @@ use encoding_rs::Encoding;
 use fonts::{ByteIndex, TextByteRange};
 use html5ever::{LocalName, Prefix, QualName, local_name, ns};
 use itertools::Itertools;
+use js::context::JSContext;
 use js::jsapi::{
     ClippedTime, DateGetMsecSinceEpoch, Handle, JS_ClearPendingException, JSObject, NewDateObject,
     NewUCRegExpObject, ObjectIsDate, RegExpFlag_UnicodeSets, RegExpFlags,
@@ -2094,13 +2095,13 @@ impl HTMLInputElementMethods<crate::DomTypeHolder> for HTMLInputElement {
     }
 
     /// <https://html.spec.whatwg.org/multipage/#dom-cva-checkvalidity>
-    fn CheckValidity(&self, can_gc: CanGc) -> bool {
-        self.check_validity(can_gc)
+    fn CheckValidity(&self, cx: &mut JSContext) -> bool {
+        self.check_validity(cx)
     }
 
     /// <https://html.spec.whatwg.org/multipage/#dom-cva-reportvalidity>
-    fn ReportValidity(&self, can_gc: CanGc) -> bool {
-        self.report_validity(can_gc)
+    fn ReportValidity(&self, cx: &mut JSContext) -> bool {
+        self.report_validity(cx)
     }
 
     /// <https://html.spec.whatwg.org/multipage/#dom-cva-validationmessage>

--- a/components/script/dom/html/htmlobjectelement.rs
+++ b/components/script/dom/html/htmlobjectelement.rs
@@ -6,6 +6,7 @@ use std::default::Default;
 
 use dom_struct::dom_struct;
 use html5ever::{LocalName, Prefix, local_name, ns};
+use js::context::JSContext;
 use js::rust::HandleObject;
 use pixels::RasterImage;
 use servo_arc::Arc;
@@ -111,13 +112,13 @@ impl HTMLObjectElementMethods<crate::DomTypeHolder> for HTMLObjectElement {
     }
 
     /// <https://html.spec.whatwg.org/multipage/#dom-cva-checkvalidity>
-    fn CheckValidity(&self, can_gc: CanGc) -> bool {
-        self.check_validity(can_gc)
+    fn CheckValidity(&self, cx: &mut JSContext) -> bool {
+        self.check_validity(cx)
     }
 
     /// <https://html.spec.whatwg.org/multipage/#dom-cva-reportvalidity>
-    fn ReportValidity(&self, can_gc: CanGc) -> bool {
-        self.report_validity(can_gc)
+    fn ReportValidity(&self, cx: &mut JSContext) -> bool {
+        self.report_validity(cx)
     }
 
     /// <https://html.spec.whatwg.org/multipage/#dom-cva-validationmessage>

--- a/components/script/dom/html/htmloutputelement.rs
+++ b/components/script/dom/html/htmloutputelement.rs
@@ -4,6 +4,7 @@
 
 use dom_struct::dom_struct;
 use html5ever::{LocalName, Prefix, local_name};
+use js::context::JSContext;
 use js::rust::HandleObject;
 
 use crate::dom::attr::Attr;
@@ -133,13 +134,13 @@ impl HTMLOutputElementMethods<crate::DomTypeHolder> for HTMLOutputElement {
     }
 
     /// <https://html.spec.whatwg.org/multipage/#dom-cva-checkvalidity>
-    fn CheckValidity(&self, can_gc: CanGc) -> bool {
-        self.check_validity(can_gc)
+    fn CheckValidity(&self, cx: &mut JSContext) -> bool {
+        self.check_validity(cx)
     }
 
     /// <https://html.spec.whatwg.org/multipage/#dom-cva-reportvalidity>
-    fn ReportValidity(&self, can_gc: CanGc) -> bool {
-        self.report_validity(can_gc)
+    fn ReportValidity(&self, cx: &mut JSContext) -> bool {
+        self.report_validity(cx)
     }
 
     /// <https://html.spec.whatwg.org/multipage/#dom-cva-validationmessage>

--- a/components/script/dom/html/htmlselectelement.rs
+++ b/components/script/dom/html/htmlselectelement.rs
@@ -9,6 +9,7 @@ use dom_struct::dom_struct;
 use embedder_traits::EmbedderControlRequest;
 use embedder_traits::{SelectElementOption, SelectElementOptionOrOptgroup};
 use html5ever::{LocalName, Prefix, QualName, local_name, ns};
+use js::context::JSContext;
 use js::rust::HandleObject;
 use style::attr::AttrValue;
 use stylo_dom::ElementState;
@@ -656,13 +657,13 @@ impl HTMLSelectElementMethods<crate::DomTypeHolder> for HTMLSelectElement {
     }
 
     /// <https://html.spec.whatwg.org/multipage/#dom-cva-checkvalidity>
-    fn CheckValidity(&self, can_gc: CanGc) -> bool {
-        self.check_validity(can_gc)
+    fn CheckValidity(&self, cx: &mut JSContext) -> bool {
+        self.check_validity(cx)
     }
 
     /// <https://html.spec.whatwg.org/multipage/#dom-cva-reportvalidity>
-    fn ReportValidity(&self, can_gc: CanGc) -> bool {
-        self.report_validity(can_gc)
+    fn ReportValidity(&self, cx: &mut JSContext) -> bool {
+        self.report_validity(cx)
     }
 
     /// <https://html.spec.whatwg.org/multipage/#dom-cva-validationmessage>

--- a/components/script/dom/html/htmltextareaelement.rs
+++ b/components/script/dom/html/htmltextareaelement.rs
@@ -10,6 +10,7 @@ use dom_struct::dom_struct;
 use embedder_traits::{EmbedderControlRequest, InputMethodRequest, InputMethodType};
 use fonts::{ByteIndex, TextByteRange};
 use html5ever::{LocalName, Prefix, local_name, ns};
+use js::context::JSContext;
 use js::rust::HandleObject;
 use layout_api::wrapper_traits::{ScriptSelection, SharedSelection};
 use script_bindings::codegen::GenericBindings::CharacterDataBinding::CharacterDataMethods;
@@ -525,13 +526,13 @@ impl HTMLTextAreaElementMethods<crate::DomTypeHolder> for HTMLTextAreaElement {
     }
 
     /// <https://html.spec.whatwg.org/multipage/#dom-cva-checkvalidity>
-    fn CheckValidity(&self, can_gc: CanGc) -> bool {
-        self.check_validity(can_gc)
+    fn CheckValidity(&self, cx: &mut JSContext) -> bool {
+        self.check_validity(cx)
     }
 
     /// <https://html.spec.whatwg.org/multipage/#dom-cva-reportvalidity>
-    fn ReportValidity(&self, can_gc: CanGc) -> bool {
-        self.report_validity(can_gc)
+    fn ReportValidity(&self, cx: &mut JSContext) -> bool {
+        self.report_validity(cx)
     }
 
     /// <https://html.spec.whatwg.org/multipage/#dom-cva-validationmessage>

--- a/components/script/dom/validation.rs
+++ b/components/script/dom/validation.rs
@@ -1,3 +1,5 @@
+use js::context::JSContext;
+
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
@@ -39,11 +41,11 @@ pub(crate) trait Validatable {
     }
 
     /// <https://html.spec.whatwg.org/multipage/#check-validity-steps>
-    fn check_validity(&self, can_gc: CanGc) -> bool {
-        if self.is_instance_validatable() && !self.satisfies_constraints(can_gc) {
+    fn check_validity(&self, cx: &mut JSContext) -> bool {
+        if self.is_instance_validatable() && !self.satisfies_constraints(CanGc::from_cx(cx)) {
             self.as_element()
                 .upcast::<EventTarget>()
-                .fire_cancelable_event(atom!("invalid"), can_gc);
+                .fire_cancelable_event(atom!("invalid"), CanGc::from_cx(cx));
             false
         } else {
             true
@@ -51,13 +53,13 @@ pub(crate) trait Validatable {
     }
 
     /// <https://html.spec.whatwg.org/multipage/#report-validity-steps>
-    fn report_validity(&self, can_gc: CanGc) -> bool {
+    fn report_validity(&self, cx: &mut JSContext) -> bool {
         // Step 1.
         if !self.is_instance_validatable() {
             return true;
         }
 
-        if self.satisfies_constraints(can_gc) {
+        if self.satisfies_constraints(CanGc::from_cx(cx)) {
             return true;
         }
 
@@ -66,19 +68,19 @@ pub(crate) trait Validatable {
         let report = self
             .as_element()
             .upcast::<EventTarget>()
-            .fire_cancelable_event(atom!("invalid"), can_gc);
+            .fire_cancelable_event(atom!("invalid"), CanGc::from_cx(cx));
 
         // Step 1.2. If `report` is true, for the element,
         // report the problem, run focusing steps, scroll into view.
         if report {
-            let flags = self.validity_state(can_gc).invalid_flags();
+            let flags = self.validity_state(CanGc::from_cx(cx)).invalid_flags();
             println!(
                 "Validation error: {}",
-                validation_message_for_flags(&self.validity_state(can_gc), flags)
+                validation_message_for_flags(&self.validity_state(CanGc::from_cx(cx)), flags)
             );
             if let Some(html_elem) = self.as_element().downcast::<HTMLElement>() {
                 // Run focusing steps and scroll into view.
-                html_elem.Focus(&FocusOptions::default(), can_gc);
+                html_elem.Focus(&FocusOptions::default(), CanGc::from_cx(cx));
             }
         }
 

--- a/components/script/dom/validation.rs
+++ b/components/script/dom/validation.rs
@@ -1,8 +1,8 @@
-use js::context::JSContext;
-
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+use js::context::JSContext;
+
 use crate::dom::bindings::codegen::Bindings::HTMLElementBinding::HTMLElementMethods;
 use crate::dom::bindings::codegen::Bindings::HTMLOrSVGElementBinding::FocusOptions;
 use crate::dom::bindings::inheritance::Castable;

--- a/components/script_bindings/codegen/Bindings.conf
+++ b/components/script_bindings/codegen/Bindings.conf
@@ -259,7 +259,8 @@ DOMInterfaces = {
 },
 
 'ElementInternals': {
-    'canGc': ['CheckValidity', 'GetLabels', 'GetValidity', 'SetValidity', 'ReportValidity', 'States'],
+    'canGc': ['GetLabels', 'GetValidity', 'SetValidity', 'States'],
+    'cx': ['CheckValidity', 'ReportValidity'],
 },
 
 'EventSource': {
@@ -405,7 +406,8 @@ DOMInterfaces = {
 },
 
 'HTMLButtonElement': {
-    'canGc': ['CheckValidity', 'ReportValidity', 'SetBackground', 'SetCustomValidity', 'Validity'],
+    'canGc': ['SetBackground', 'SetCustomValidity', 'Validity'],
+    'cx': ['CheckValidity', 'ReportValidity'],
 },
 
 'HTMLCanvasElement': {
@@ -430,7 +432,8 @@ DOMInterfaces = {
 },
 
 'HTMLFieldSetElement': {
-    'canGc': ['CheckValidity', 'Elements', 'ReportValidity', 'SetCustomValidity', 'Validity'],
+    'canGc': ['Elements', 'SetCustomValidity', 'Validity'],
+    'cx': ['CheckValidity', 'ReportValidity'],
 },
 
 'HTMLFontElement': {
@@ -442,7 +445,8 @@ DOMInterfaces = {
 },
 
 'HTMLFormElement': {
-    'canGc': ['CheckValidity', 'Elements', 'IndexedGetter', 'NamedGetter', 'RequestSubmit', 'ReportValidity', 'Submit', 'Reset', 'SetRel', 'RelList'],
+    'canGc': ['Elements', 'IndexedGetter', 'NamedGetter', 'RequestSubmit', 'Submit', 'Reset', 'SetRel', 'RelList'],
+    'cx': ['CheckValidity', 'ReportValidity'],
 },
 
 'HTMLIFrameElement': {
@@ -450,11 +454,13 @@ DOMInterfaces = {
 },
 
 'HTMLImageElement': {
-    'canGc': ['RequestSubmit', 'ReportValidity', 'Reset','SetRel', 'Decode', 'SetCrossOrigin'],
+    'canGc': ['RequestSubmit', 'Reset','SetRel', 'Decode', 'SetCrossOrigin'],
+    'cx': ['ReportValidity'],
 },
 
 'HTMLInputElement': {
-    'canGc': ['ReportValidity', 'SetValue', 'SetValueAsNumber', 'SetValueAsDate', 'StepUp', 'StepDown', 'CheckValidity', 'ReportValidity', 'GetLabels', 'SetCustomValidity', 'Validity', 'SetChecked'],
+    'canGc': ['SetValue', 'SetValueAsNumber', 'SetValueAsDate', 'StepUp', 'StepDown','GetLabels', 'SetCustomValidity', 'Validity', 'SetChecked'],
+    'cx': ['CheckValidity', 'ReportValidity'],
 },
 
 'HTMLLinkElement': {
@@ -473,11 +479,13 @@ DOMInterfaces = {
 },
 
 'HTMLMeterElement': {
-    'canGc': ['SetValue', 'SetMin', 'SetMax', 'SetLow', 'SetHigh', 'SetOptimum', 'CheckValidity', 'ReportValidity']
+    'canGc': ['SetValue', 'SetMin', 'SetMax', 'SetLow', 'SetHigh', 'SetOptimum'],
+    'cx': ['CheckValidity', 'ReportValidity'],
 },
 
 'HTMLObjectElement': {
-    'canGc': ['CheckValidity', 'ReportValidity', 'SetCustomValidity', 'Validity'],
+    'canGc': ['SetCustomValidity', 'Validity'],
+    'cx': ['CheckValidity', 'ReportValidity'],
 },
 
 'HTMLOptionElement': {
@@ -489,7 +497,8 @@ DOMInterfaces = {
 },
 
 'HTMLOutputElement': {
-    'canGc': ['ReportValidity', 'SetDefaultValue', 'SetValue', 'CheckValidity', 'SetCustomValidity', 'Validity'],
+    'canGc': ['SetDefaultValue', 'SetValue', 'SetCustomValidity', 'Validity'],
+    'cx': ['CheckValidity', 'ReportValidity'],
 },
 
 'HTMLProgressElement': {
@@ -501,7 +510,8 @@ DOMInterfaces = {
 },
 
 'HTMLSelectElement': {
-    'canGc': ['ReportValidity', 'SetLength', 'IndexedSetter', 'CheckValidity', 'SetSelectedIndex', 'SetCustomValidity', 'SetValue', 'Validity'],
+    'canGc': ['SetLength', 'IndexedSetter', 'SetSelectedIndex', 'SetCustomValidity', 'SetValue', 'Validity'],
+    'cx': ['CheckValidity', 'ReportValidity'],
 },
 
 'HTMLStyleElement': {
@@ -525,7 +535,8 @@ DOMInterfaces = {
 },
 
 'HTMLTextAreaElement': {
-    'canGc': ['ReportValidity', 'SetDefaultValue', 'CheckValidity', 'SetCustomValidity', 'SetValue', 'Validity'],
+    'canGc': ['SetDefaultValue', 'SetCustomValidity', 'SetValue', 'Validity'],
+    'cx': ['CheckValidity', 'ReportValidity'],
 },
 
 'HTMLTitleElement': {


### PR DESCRIPTION
This is part of replacing can_gc with the new &JSContext/&mut JSContext method.
We modify CheckValidity and ReportValidity in various HTML Elements to use the context instead of CanGc.

Testing: Compilation is the test as this is mostly mechanical.
