### PR TITLE
script: Do not unconditionally expect a parent element in `DocumentOrShadowRoot::element_from_point`

### DIFF
--- a/tests/wpt/meta/css/cssom-view/elementFromPoint.html.ini
+++ b/tests/wpt/meta/css/cssom-view/elementFromPoint.html.ini
@@ -1,8 +1,4 @@
 [elementFromPoint.html]
-  expected: CRASH
-  [SVG element at x,y]
-    expected: FAIL
-
   [no hit target at x,y]
     expected: FAIL
 


### PR DESCRIPTION
When processing `elementFromPoint` on a `Document` or a `ShadowRoot`,
better handle the situation where the result of the hit test is the root
element, fixing a crash.

Testing: This fixes a crash in the WPT tests.
