### PR TITLE
python: Run flake8 on WPT tooling to match upstream.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,8 +5,8 @@ version = "0.0.1"
 requires-python = ">=3.11"
 dynamic = ["dependencies"]
 
-[tool.setuptools.dynamic]
-dependencies = { file = ["python/requirements.txt", "tests/wpt/tests/tools/requirements_tests.txt", "tests/wpt/tests/tools/wptrunner/requirements.txt"] }
+[tool.setuptools.dynamic.dependencies]
+file = ["python/requirements.txt", "tests/wpt/tests/tools/requirements_tests.txt", "tests/wpt/tests/tools/wptrunner/requirements.txt", "tests/wpt/tests/tools/requirements_flake8.txt"]
 
 [tool.setuptools.packages.find]
 exclude = ["config*"]

--- a/python/tidy/tidy.py
+++ b/python/tidy/tidy.py
@@ -432,6 +432,17 @@ def check_ruff_lints() -> Iterator[tuple[str, int, str]]:
             )
 
 
+def check_flake8_lints() -> Iterator[tuple[str, int, str]]:
+    try:
+        args = ["uv", "run", "flake8", "--append-config=flake8.ini"]
+        subprocess.check_output(args, universal_newlines=True, cwd="tests/wpt/tests/tools")
+    except subprocess.CalledProcessError as e:
+        output = e.output
+        for error in output.splitlines():
+            filename, line_num, _, message = error.split(":", 3)
+            yield filename, line_num, message.strip()
+
+
 @dataclass
 class PyreflyDiagnostic:
     """
@@ -731,6 +742,7 @@ def run_wpt_lints(only_changed_files: bool) -> Iterator[tuple[str, int, str]]:
 
     yield from check_that_manifests_are_clean()
     yield from lint_wpt_test_files()
+    yield from check_flake8_lints()
 
 
 def check_spec(file_name: str, lines: list[bytes]) -> Iterator[tuple[int, str]]:

--- a/tests/wpt/tests/tools/wptrunner/wptrunner/browsers/servo.py
+++ b/tests/wpt/tests/tools/wptrunner/wptrunner/browsers/servo.py
@@ -138,7 +138,7 @@ class ServoBrowser(WebDriverBrowser):
         try:
             requests.get(f"http://{self.host}:{self.port}/status", timeout=3)
         except requests.exceptions.Timeout:
-            # FIXME: This indicates a hanged browser. 
+            # FIXME: This indicates a hanged browser.
             # Server is waiting for response of the previous command.
             # It happens with ~0.1% probability in our CI runs.
             self.logger.debug("Servo webdriver status request timed out.")
@@ -173,7 +173,7 @@ class ServoBrowser(WebDriverBrowser):
                 )
                 self.logger.warning("Hanged server. Killing instead.")
                 break
- 
+
             time.sleep(1)
         else:
             self.logger.warning("Max retry exceeded to normally shut down. Killing instead.")


### PR DESCRIPTION
This should prevent recurring issues with exported WPT changes being prevented from merging due to failing linting checks upstream.

Testing: Can't test WPT linting integration at this point in time.
Fixes: #40662
