### PR TITLE
layout: Correctly repair `OutsideMarker::list_item_style`

### DIFF
--- a/components/layout/construct_modern.rs
+++ b/components/layout/construct_modern.rs
@@ -57,7 +57,7 @@ impl<'dom> ModernContainerJob<'dom> {
         match self {
             ModernContainerJob::TextRuns(runs, box_slot) => {
                 let mut inline_formatting_context_builder =
-                    InlineFormattingContextBuilder::new(builder.info);
+                    InlineFormattingContextBuilder::new(builder.info, builder.context);
                 let mut last_style_from_display_contents: Option<SharedInlineStyles> = None;
                 for flex_text_run in runs.into_iter() {
                     match (

--- a/components/layout/dom.rs
+++ b/components/layout/dom.rs
@@ -167,7 +167,7 @@ impl LayoutBox {
         match self {
             LayoutBox::DisplayContents(inline_shared_styles) => {
                 *inline_shared_styles.style.borrow_mut() = new_style.clone();
-                *inline_shared_styles.selected.borrow_mut() = node.selected_style();
+                *inline_shared_styles.selected.borrow_mut() = node.selected_style(context);
             },
             LayoutBox::BlockLevel(block_level_box) => {
                 block_level_box

--- a/components/layout/dom_traversal.rs
+++ b/components/layout/dom_traversal.rs
@@ -151,7 +151,8 @@ fn traverse_element<'dom>(
                 // <https://drafts.csswg.org/css-display-3/#valdef-display-contents>
                 element.unset_all_boxes()
             } else {
-                let shared_inline_styles: SharedInlineStyles = (&info).into();
+                let shared_inline_styles =
+                    SharedInlineStyles::from_info_and_context(&info, context);
                 element
                     .box_slot()
                     .set(LayoutBox::DisplayContents(shared_inline_styles.clone()));
@@ -193,7 +194,8 @@ fn traverse_eager_pseudo_element<'dom>(
         Display::Contents => {
             let items = generate_pseudo_element_content(&pseudo_element_info, context);
             let box_slot = pseudo_element_info.node.box_slot();
-            let shared_inline_styles: SharedInlineStyles = (&pseudo_element_info).into();
+            let shared_inline_styles =
+                SharedInlineStyles::from_info_and_context(&pseudo_element_info, context);
             box_slot.set(LayoutBox::DisplayContents(shared_inline_styles.clone()));
 
             handler.enter_display_contents(shared_inline_styles);

--- a/components/layout/flow/inline/construct.rs
+++ b/components/layout/flow/inline/construct.rs
@@ -96,12 +96,14 @@ pub(crate) struct InlineFormattingContextBuilder {
 }
 
 impl InlineFormattingContextBuilder {
-    pub(crate) fn new(info: &NodeAndStyleInfo) -> Self {
+    pub(crate) fn new(info: &NodeAndStyleInfo, context: &LayoutContext) -> Self {
         Self {
             // For the purposes of `text-transform: capitalize` the start of the IFC is a word boundary.
             on_word_boundary: true,
             is_empty: true,
-            shared_inline_styles_stack: vec![info.into()],
+            shared_inline_styles_stack: vec![SharedInlineStyles::from_info_and_context(
+                info, context,
+            )],
             shared_selection: info.node.selection(),
             ..Default::default()
         }

--- a/components/layout/flow/mod.rs
+++ b/components/layout/flow/mod.rs
@@ -78,13 +78,14 @@ impl BlockContainer {
 
     pub(crate) fn repair_style(
         &mut self,
+        context: &SharedStyleContext,
         node: &ServoThreadSafeLayoutNode,
         new_style: &Arc<ComputedValues>,
     ) {
         match self {
             BlockContainer::BlockLevelBoxes(..) => {},
             BlockContainer::InlineFormattingContext(inline_formatting_context) => {
-                inline_formatting_context.repair_style(node, new_style)
+                inline_formatting_context.repair_style(context, node, new_style)
             },
         }
     }
@@ -130,7 +131,7 @@ impl BlockLevelBox {
             },
             BlockLevelBox::SameFormattingContextBlock { base, contents, .. } => {
                 base.repair_style(new_style);
-                contents.repair_style(node, new_style);
+                contents.repair_style(context, node, new_style);
             },
         }
     }
@@ -401,8 +402,9 @@ impl OutsideMarker {
         node: &ServoThreadSafeLayoutNode,
         new_style: &Arc<ComputedValues>,
     ) {
-        self.list_item_style = node.style(context);
+        self.list_item_style = node.parent_style(context);
         self.base.repair_style(new_style);
+        // FIXME(#42779): repair the style of the block formatting context.
     }
 }
 
@@ -465,10 +467,11 @@ impl BlockFormattingContext {
 
     pub(crate) fn repair_style(
         &mut self,
+        context: &SharedStyleContext,
         node: &ServoThreadSafeLayoutNode,
         new_style: &Arc<ComputedValues>,
     ) {
-        self.contents.repair_style(node, new_style);
+        self.contents.repair_style(context, node, new_style);
     }
 
     pub(crate) fn attached_to_tree(&self, layout_box: WeakLayoutBox) {

--- a/components/layout/formatting_contexts.rs
+++ b/components/layout/formatting_contexts.rs
@@ -326,7 +326,7 @@ impl IndependentFormattingContext {
                 }
             },
             IndependentFormattingContextContents::Flow(block_formatting_context) => {
-                block_formatting_context.repair_style(node, new_style);
+                block_formatting_context.repair_style(context, node, new_style);
             },
             IndependentFormattingContextContents::Flex(flex_container) => {
                 flex_container.repair_style(new_style)

--- a/tests/wpt/tests/css/css-lists/list-item-dynamic-padding-ref.html
+++ b/tests/wpt/tests/css/css-lists/list-item-dynamic-padding-ref.html
@@ -1,0 +1,7 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Reference: List item with dynamic padding</title>
+<link rel="author" title="Oriol Brufau" href="mailto:obrufau@igalia.com">
+<ul>
+  <li style="padding-left: 100px">text</li>
+</ul>

--- a/tests/wpt/tests/css/css-lists/list-item-dynamic-padding.html
+++ b/tests/wpt/tests/css/css-lists/list-item-dynamic-padding.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html class="reftest-wait">
+<meta charset="utf-8">
+<title>CSS Test: List item with dynamic padding</title>
+<link rel="author" title="Oriol Brufau" href="mailto:obrufau@igalia.com">
+<link rel="help" href="https://drafts.csswg.org/css-display-4/#valdef-display-list-item">
+<link rel="help" href="https://drafts.csswg.org/css-box-4/#paddings">
+<link rel="match" href="list-item-dynamic-padding-ref.html">
+<ul>
+  <li id="target">text</li>
+</ul>
+<script src="/common/reftest-wait.js"></script>
+<script>
+requestAnimationFrame(() => requestAnimationFrame(() => {
+  document.getElementById("target").style.paddingLeft = "100px";
+  takeScreenshot();
+}));
+</script>
+</html>


### PR DESCRIPTION
`OutsideMarker::repair_style()` was setting `list_item_style` to the style of the marker, not the style of the list item.

This patch sets it to `node.parent_style(context)` instead, and it fixes `ServoThreadSafeLayoutNode::parent_style()` to take the pseudo-element chain into account. This requires modifying a bunch of logic to pass the `SharedStyleContext` around.

Testing: Adding a new test
