### PR TITLE
layout: Do not consider broken images as LCP candidates

### DIFF
--- a/components/layout/display_list/mod.rs
+++ b/components/layout/display_list/mod.rs
@@ -705,6 +705,16 @@ impl Fragment {
                                 common.clip_rect,
                                 style.clone_opacity(),
                             );
+
+                            // Skip Broken Images for LCP
+                            if !image.showing_broken_image_icon {
+                                builder.check_for_lcp_candidate(
+                                    common.clip_rect,
+                                    rect,
+                                    image.base.tag,
+                                    image.url.clone(),
+                                );
+                            }
                         }
 
                         if image.showing_broken_image_icon {
@@ -714,13 +724,6 @@ impl Fragment {
                                 &common,
                             );
                         }
-
-                        builder.check_for_lcp_candidate(
-                            common.clip_rect,
-                            rect,
-                            image.base.tag,
-                            image.url.clone(),
-                        );
                     },
                     Visibility::Hidden => (),
                     Visibility::Collapse => (),

--- a/tests/wpt/meta/largest-contentful-paint/broken-image-icon.html.ini
+++ b/tests/wpt/meta/largest-contentful-paint/broken-image-icon.html.ini
@@ -1,4 +1,0 @@
-[broken-image-icon.html]
-  expected: ERROR
-  [The broken image icon should not emit an LCP entry.]
-    expected: TIMEOUT


### PR DESCRIPTION
Broken Image Icons are not worthy for LCP candidates.

Waiting for WPT Sync to update test from upstream and expectations as well.

Testing: `tests/wpt/tests/largest-contentful-paint/broken-image-icon.html`
Fixes: #42832
Fixes: #43030
