### PR TITLE
script: Merge `ScrollEvent` with `SetScrollStates` messages

### DIFF
--- a/components/constellation/constellation.rs
+++ b/components/constellation/constellation.rs
@@ -119,9 +119,8 @@ use constellation_traits::{
     EmbedderToConstellationMessage, IFrameLoadInfo, IFrameLoadInfoWithData, IFrameSizeMsg, Job,
     LoadData, LogEntry, MessagePortMsg, NavigationHistoryBehavior, PaintMetricEvent,
     PortMessageTask, PortTransferInfo, SWManagerMsg, SWManagerSenders, ScreenshotReadinessResponse,
-    ScriptToConstellationMessage, ScrollStatesUpdate, ServiceWorkerManagerFactory,
-    ServiceWorkerMsg, StructuredSerializedData, TraversalDirection, UserContentManagerAction,
-    WindowSizeType,
+    ScriptToConstellationMessage, ScrollStateUpdate, ServiceWorkerManagerFactory, ServiceWorkerMsg,
+    StructuredSerializedData, TraversalDirection, UserContentManagerAction, WindowSizeType,
 };
 use content_security_policy::sandboxing_directive::SandboxingFlagSet;
 use crossbeam_channel::{Receiver, Select, Sender, unbounded};
@@ -5650,7 +5649,7 @@ where
     }
 
     #[servo_tracing::instrument(skip_all)]
-    fn handle_set_scroll_states(&self, pipeline_id: PipelineId, scroll_states: ScrollStatesUpdate) {
+    fn handle_set_scroll_states(&self, pipeline_id: PipelineId, scroll_states: ScrollStateUpdate) {
         let Some(pipeline) = self.pipelines.get(&pipeline_id) else {
             warn!("Discarding scroll offset update for unknown pipeline");
             return;

--- a/components/constellation/constellation.rs
+++ b/components/constellation/constellation.rs
@@ -119,8 +119,9 @@ use constellation_traits::{
     EmbedderToConstellationMessage, IFrameLoadInfo, IFrameLoadInfoWithData, IFrameSizeMsg, Job,
     LoadData, LogEntry, MessagePortMsg, NavigationHistoryBehavior, PaintMetricEvent,
     PortMessageTask, PortTransferInfo, SWManagerMsg, SWManagerSenders, ScreenshotReadinessResponse,
-    ScriptToConstellationMessage, ServiceWorkerManagerFactory, ServiceWorkerMsg,
-    StructuredSerializedData, TraversalDirection, UserContentManagerAction, WindowSizeType,
+    ScriptToConstellationMessage, ScrollStatesUpdate, ServiceWorkerManagerFactory,
+    ServiceWorkerMsg, StructuredSerializedData, TraversalDirection, UserContentManagerAction,
+    WindowSizeType,
 };
 use content_security_policy::sandboxing_directive::SandboxingFlagSet;
 use crossbeam_channel::{Receiver, Select, Sender, unbounded};
@@ -175,8 +176,6 @@ use style::global_style_data::StyleThreadPool;
 use webgpu::canvas_context::WebGpuExternalImageMap;
 #[cfg(feature = "webgpu")]
 use webgpu_traits::{WebGPU, WebGPURequest};
-use webrender_api::ExternalScrollId;
-use webrender_api::units::LayoutVector2D;
 
 use crate::broadcastchannel::BroadcastChannels;
 use crate::browsingcontext::{
@@ -5651,11 +5650,7 @@ where
     }
 
     #[servo_tracing::instrument(skip_all)]
-    fn handle_set_scroll_states(
-        &self,
-        pipeline_id: PipelineId,
-        scroll_states: FxHashMap<ExternalScrollId, LayoutVector2D>,
-    ) {
+    fn handle_set_scroll_states(&self, pipeline_id: PipelineId, scroll_states: ScrollStatesUpdate) {
         let Some(pipeline) = self.pipelines.get(&pipeline_id) else {
             warn!("Discarding scroll offset update for unknown pipeline");
             return;

--- a/components/constellation/tracing.rs
+++ b/components/constellation/tracing.rs
@@ -106,7 +106,6 @@ mod from_embedder {
                 InputEvent::MouseLeftViewport(..) => target_variant!("MouseLeftViewport"),
                 InputEvent::Touch(..) => target_variant!("Touch"),
                 InputEvent::Wheel(..) => target_variant!("Wheel"),
-                InputEvent::Scroll(..) => target_variant!("Scroll"),
             }
         }
     }

--- a/components/paint/webview_renderer.rs
+++ b/components/paint/webview_renderer.rs
@@ -7,13 +7,12 @@ use std::collections::hash_map::Entry;
 use std::rc::Rc;
 
 use base::id::{PipelineId, WebViewId};
-use constellation_traits::{EmbedderToConstellationMessage, WindowSizeType};
+use constellation_traits::{EmbedderToConstellationMessage, ScrollStatesUpdate, WindowSizeType};
 use crossbeam_channel::Sender;
 use embedder_traits::{
     AnimationState, InputEvent, InputEventAndId, InputEventId, InputEventResult, MouseButton,
-    MouseButtonAction, MouseButtonEvent, MouseMoveEvent, PaintHitTestResult, Scroll,
-    ScrollEvent as EmbedderScrollEvent, TouchEvent, TouchEventType, ViewportDetails, WebViewPoint,
-    WheelEvent,
+    MouseButtonAction, MouseButtonEvent, MouseMoveEvent, PaintHitTestResult, Scroll, TouchEvent,
+    TouchEventType, ViewportDetails, WebViewPoint, WheelEvent,
 };
 use euclid::{Scale, Vector2D};
 use log::{debug, warn};
@@ -230,23 +229,35 @@ impl WebViewRenderer {
         self.set_frame_tree_on_pipeline_details(frame_tree, None);
     }
 
-    pub(crate) fn send_scroll_positions_to_layout_for_pipeline(&self, pipeline_id: PipelineId) {
+    // FIXME: For now, we are sending the whole scroll offsets, but ideally we should consider the one that is
+    //        actually scrolled. This is quite tricky due to the possibility of race.
+    pub(crate) fn send_scroll_positions_to_layout_for_pipeline(
+        &self,
+        pipeline_id: PipelineId,
+        scrolled_node: ExternalScrollId,
+    ) {
         let Some(details) = self.pipelines.get(&pipeline_id) else {
             return;
         };
 
-        let scroll_offsets = details.scroll_tree.scroll_offsets();
+        let offsets = details.scroll_tree.scroll_offsets();
 
         // This might be true if we have not received a display list from the layout
         // associated with this pipeline yet. In that case, the layout is not ready to
         // receive scroll offsets anyway, so just save time and prevent other issues by
         // not sending them.
-        if scroll_offsets.is_empty() {
+        if offsets.is_empty() {
             return;
         }
 
         let _ = self.embedder_to_constellation_sender.send(
-            EmbedderToConstellationMessage::SetScrollStates(pipeline_id, scroll_offsets),
+            EmbedderToConstellationMessage::SetScrollStates(
+                pipeline_id,
+                ScrollStatesUpdate {
+                    scrolled_node,
+                    offsets,
+                },
+            ),
         );
     }
 
@@ -774,10 +785,7 @@ impl WebViewRenderer {
         if let Some(ref scroll_result) = scroll_result {
             self.send_scroll_positions_to_layout_for_pipeline(
                 scroll_result.hit_test_result.pipeline_id,
-            );
-            self.dispatch_scroll_event(
                 scroll_result.external_scroll_id,
-                scroll_result.hit_test_result.clone(),
             );
         } else {
             self.touch_handler.stop_fling_if_needed();
@@ -901,8 +909,7 @@ impl WebViewRenderer {
             external_scroll_id,
         };
 
-        self.send_scroll_positions_to_layout_for_pipeline(root_pipeline_id);
-        self.dispatch_scroll_event(external_scroll_id, hit_test_result.clone());
+        self.send_scroll_positions_to_layout_for_pipeline(root_pipeline_id, external_scroll_id);
 
         if pinch_zoom_result == PinchZoomResult::DidNotPinchZoom {
             self.send_pinch_zoom_infos_to_script();
@@ -930,22 +937,6 @@ impl WebViewRenderer {
         let _ = self.embedder_to_constellation_sender.send(
             EmbedderToConstellationMessage::UpdatePinchZoomInfos(pipeline_id, pinch_zoom_infos),
         );
-    }
-
-    fn dispatch_scroll_event(
-        &self,
-        external_id: ExternalScrollId,
-        hit_test_result: PaintHitTestResult,
-    ) {
-        let event = InputEvent::Scroll(EmbedderScrollEvent { external_id }).into();
-        let msg = EmbedderToConstellationMessage::ForwardInputEvent(
-            self.id,
-            event,
-            Some(hit_test_result),
-        );
-        if let Err(e) = self.embedder_to_constellation_sender.send(msg) {
-            warn!("Sending scroll event to constellation failed ({:?}).", e);
-        }
     }
 
     pub(crate) fn pinch_zoom(&self) -> PinchZoom {

--- a/components/paint/webview_renderer.rs
+++ b/components/paint/webview_renderer.rs
@@ -7,7 +7,7 @@ use std::collections::hash_map::Entry;
 use std::rc::Rc;
 
 use base::id::{PipelineId, WebViewId};
-use constellation_traits::{EmbedderToConstellationMessage, ScrollStatesUpdate, WindowSizeType};
+use constellation_traits::{EmbedderToConstellationMessage, ScrollStateUpdate, WindowSizeType};
 use crossbeam_channel::Sender;
 use embedder_traits::{
     AnimationState, InputEvent, InputEventAndId, InputEventId, InputEventResult, MouseButton,
@@ -229,8 +229,6 @@ impl WebViewRenderer {
         self.set_frame_tree_on_pipeline_details(frame_tree, None);
     }
 
-    // FIXME: For now, we are sending the whole scroll offsets, but ideally we should consider the one that is
-    //        actually scrolled. This is quite tricky due to the possibility of race.
     pub(crate) fn send_scroll_positions_to_layout_for_pipeline(
         &self,
         pipeline_id: PipelineId,
@@ -253,7 +251,7 @@ impl WebViewRenderer {
         let _ = self.embedder_to_constellation_sender.send(
             EmbedderToConstellationMessage::SetScrollStates(
                 pipeline_id,
-                ScrollStatesUpdate {
+                ScrollStateUpdate {
                     scrolled_node,
                     offsets,
                 },

--- a/components/script/dom/document_event_handler.rs
+++ b/components/script/dom/document_event_handler.rs
@@ -1658,7 +1658,7 @@ impl DocumentEventHandler {
         }
     }
 
-    /// Handle scroll events triggered by user interactions from embedder-side.
+    /// Handle a scroll event triggered by user interactions from the embedder.
     /// <https://drafts.csswg.org/cssom-view/#scrolling-events>
     #[expect(unsafe_code)]
     pub(crate) fn handle_embedder_scroll_event(&self, scrolled_node: ExternalScrollId) {

--- a/components/script/dom/document_event_handler.rs
+++ b/components/script/dom/document_event_handler.rs
@@ -1658,10 +1658,10 @@ impl DocumentEventHandler {
         }
     }
 
-    /// Handle scroll triggered by user interactions from embedder side.
+    /// Handle scroll events triggered by user interactions from embedder-side.
     /// <https://drafts.csswg.org/cssom-view/#scrolling-events>
     #[expect(unsafe_code)]
-    pub(crate) fn handle_embedder_scroll(&self, scrolled_node: ExternalScrollId) {
+    pub(crate) fn handle_embedder_scroll_event(&self, scrolled_node: ExternalScrollId) {
         // If it is a viewport scroll.
         let document = self.window.Document();
         if scrolled_node.is_root() {

--- a/components/script/dom/document_event_handler.rs
+++ b/components/script/dom/document_event_handler.rs
@@ -14,8 +14,8 @@ use constellation_traits::{KeyboardScroll, ScriptToConstellationMessage};
 use embedder_traits::{
     Cursor, EditingActionEvent, EmbedderMsg, ImeEvent, InputEvent, InputEventAndId,
     InputEventResult, KeyboardEvent as EmbedderKeyboardEvent, MouseButton, MouseButtonAction,
-    MouseButtonEvent, MouseLeftViewportEvent, ScrollEvent, TouchEvent as EmbedderTouchEvent,
-    TouchEventType, TouchId, UntrustedNodeAddress, WheelEvent as EmbedderWheelEvent,
+    MouseButtonEvent, MouseLeftViewportEvent, TouchEvent as EmbedderTouchEvent, TouchEventType,
+    TouchId, UntrustedNodeAddress, WheelEvent as EmbedderWheelEvent,
 };
 #[cfg(feature = "gamepad")]
 use embedder_traits::{
@@ -43,6 +43,7 @@ use script_bindings::str::DOMString;
 use script_traits::ConstellationInputEvent;
 use servo_config::pref;
 use style_traits::CSSPixel;
+use webrender_api::ExternalScrollId;
 
 use crate::dom::bindings::cell::DomRefCell;
 use crate::dom::bindings::refcounted::Trusted;
@@ -277,10 +278,6 @@ impl DocumentEventHandler {
                 },
                 InputEvent::EditingAction(editing_action_event) => {
                     self.handle_editing_action(None, editing_action_event, can_gc)
-                },
-                InputEvent::Scroll(scroll_event) => {
-                    self.handle_embedder_scroll_event(scroll_event);
-                    InputEventResult::default()
                 },
             };
 
@@ -1661,17 +1658,17 @@ impl DocumentEventHandler {
         }
     }
 
-    /// Handle scroll event triggered by user interactions from embedder side.
+    /// Handle scroll triggered by user interactions from embedder side.
     /// <https://drafts.csswg.org/cssom-view/#scrolling-events>
     #[expect(unsafe_code)]
-    fn handle_embedder_scroll_event(&self, event: ScrollEvent) {
+    pub(crate) fn handle_embedder_scroll(&self, scrolled_node: ExternalScrollId) {
         // If it is a viewport scroll.
         let document = self.window.Document();
-        if event.external_id.is_root() {
+        if scrolled_node.is_root() {
             document.handle_viewport_scroll_event();
         } else {
             // Otherwise, check whether it is for a relevant element within the document.
-            let Some(node_id) = node_id_from_scroll_id(event.external_id.0 as usize) else {
+            let Some(node_id) = node_id_from_scroll_id(scrolled_node.0 as usize) else {
                 return;
             };
             let node = unsafe {

--- a/components/script/script_thread.rs
+++ b/components/script/script_thread.rs
@@ -42,7 +42,7 @@ use canvas_traits::webgl::WebGLPipeline;
 use chrono::{DateTime, Local};
 use constellation_traits::{
     JsEvalResult, LoadData, LoadOrigin, NavigationHistoryBehavior, ScreenshotReadinessResponse,
-    ScriptToConstellationChan, ScriptToConstellationMessage, ScrollStatesUpdate,
+    ScriptToConstellationChan, ScriptToConstellationMessage, ScrollStateUpdate,
     StructuredSerializedData, WindowSizeType,
 };
 use crossbeam_channel::unbounded;
@@ -1975,16 +1975,11 @@ impl ScriptThread {
         }
     }
 
-    fn handle_set_scroll_states(&self, pipeline_id: PipelineId, scroll_states: ScrollStatesUpdate) {
+    fn handle_set_scroll_states(&self, pipeline_id: PipelineId, scroll_states: ScrollStateUpdate) {
         let Some(window) = self.documents.borrow().find_window(pipeline_id) else {
             warn!("Received scroll states for closed pipeline {pipeline_id}");
             return;
         };
-
-        window
-            .Document()
-            .event_handler()
-            .handle_embedder_scroll(scroll_states.scrolled_node);
 
         self.profile_event(
             ScriptThreadEventCategory::SetScrollState,
@@ -1994,7 +1989,12 @@ impl ScriptThread {
                     .layout_mut()
                     .set_scroll_offsets_from_renderer(&scroll_states.offsets);
             },
-        )
+        );
+
+        window
+            .Document()
+            .event_handler()
+            .handle_embedder_scroll_event(scroll_states.scrolled_node);
     }
 
     #[cfg(feature = "webgpu")]

--- a/components/script/script_thread.rs
+++ b/components/script/script_thread.rs
@@ -42,8 +42,8 @@ use canvas_traits::webgl::WebGLPipeline;
 use chrono::{DateTime, Local};
 use constellation_traits::{
     JsEvalResult, LoadData, LoadOrigin, NavigationHistoryBehavior, ScreenshotReadinessResponse,
-    ScriptToConstellationChan, ScriptToConstellationMessage, StructuredSerializedData,
-    WindowSizeType,
+    ScriptToConstellationChan, ScriptToConstellationMessage, ScrollStatesUpdate,
+    StructuredSerializedData, WindowSizeType,
 };
 use crossbeam_channel::unbounded;
 use data_url::mime::Mime;
@@ -107,8 +107,6 @@ use timers::{TimerEventRequest, TimerId, TimerScheduler};
 use url::Position;
 #[cfg(feature = "webgpu")]
 use webgpu_traits::{WebGPUDevice, WebGPUMsg};
-use webrender_api::ExternalScrollId;
-use webrender_api::units::LayoutVector2D;
 
 use crate::document_collection::DocumentCollection;
 use crate::document_loader::DocumentLoader;
@@ -1977,15 +1975,16 @@ impl ScriptThread {
         }
     }
 
-    fn handle_set_scroll_states(
-        &self,
-        pipeline_id: PipelineId,
-        scroll_states: FxHashMap<ExternalScrollId, LayoutVector2D>,
-    ) {
+    fn handle_set_scroll_states(&self, pipeline_id: PipelineId, scroll_states: ScrollStatesUpdate) {
         let Some(window) = self.documents.borrow().find_window(pipeline_id) else {
             warn!("Received scroll states for closed pipeline {pipeline_id}");
             return;
         };
+
+        window
+            .Document()
+            .event_handler()
+            .handle_embedder_scroll(scroll_states.scrolled_node);
 
         self.profile_event(
             ScriptThreadEventCategory::SetScrollState,
@@ -1993,7 +1992,7 @@ impl ScriptThread {
             || {
                 window
                     .layout_mut()
-                    .set_scroll_offsets_from_renderer(&scroll_states);
+                    .set_scroll_offsets_from_renderer(&scroll_states.offsets);
             },
         )
     }

--- a/components/shared/constellation/lib.rs
+++ b/components/shared/constellation/lib.rs
@@ -211,7 +211,7 @@ pub enum MessagePortMsg {
 }
 
 /// A data structure which contains information for the pipeline after a scroll happens in the
-/// embedder-side of a `WebView`.
+/// embedder-side `WebView`.
 #[derive(Debug, Deserialize, Serialize)]
 pub struct ScrollStateUpdate {
     /// The [`ExternalScrollId`] of the node that that was scrolled.

--- a/components/shared/constellation/lib.rs
+++ b/components/shared/constellation/lib.rs
@@ -95,7 +95,7 @@ pub enum EmbedderToConstellationMessage {
     SetWebViewThrottled(WebViewId, bool),
     /// The Servo renderer scrolled and is updating the scroll states of the nodes in the
     /// given pipeline via the constellation.
-    SetScrollStates(PipelineId, FxHashMap<ExternalScrollId, LayoutVector2D>),
+    SetScrollStates(PipelineId, ScrollStatesUpdate),
     /// Notify the constellation that a particular paint metric event has happened for the given pipeline.
     PaintMetric(PipelineId, PaintMetricEvent),
     /// Evaluate a JavaScript string in the context of a `WebView`. When execution is complete or an
@@ -208,4 +208,13 @@ pub enum MessagePortMsg {
     CompleteDisentanglement(MessagePortId),
     /// Handle a new port-message-task.
     NewTask(MessagePortId, PortMessageTask),
+}
+
+/// If renderer is scrolled, we need to send these states to update the scroll tree in the constellation.
+#[derive(Debug, Deserialize, Serialize)]
+pub struct ScrollStatesUpdate {
+    /// Which node that is scrolled. This is required for JS scroll event.
+    pub scrolled_node: ExternalScrollId,
+    /// The whole scroll offsets from the renderer's scroll tree.
+    pub offsets: FxHashMap<ExternalScrollId, LayoutVector2D>,
 }

--- a/components/shared/constellation/lib.rs
+++ b/components/shared/constellation/lib.rs
@@ -95,7 +95,7 @@ pub enum EmbedderToConstellationMessage {
     SetWebViewThrottled(WebViewId, bool),
     /// The Servo renderer scrolled and is updating the scroll states of the nodes in the
     /// given pipeline via the constellation.
-    SetScrollStates(PipelineId, ScrollStatesUpdate),
+    SetScrollStates(PipelineId, ScrollStateUpdate),
     /// Notify the constellation that a particular paint metric event has happened for the given pipeline.
     PaintMetric(PipelineId, PaintMetricEvent),
     /// Evaluate a JavaScript string in the context of a `WebView`. When execution is complete or an
@@ -210,11 +210,13 @@ pub enum MessagePortMsg {
     NewTask(MessagePortId, PortMessageTask),
 }
 
-/// If renderer is scrolled, we need to send these states to update the scroll tree in the constellation.
+/// A data structure which contains information for the pipeline after a scroll happens in the
+/// embedder-side of a `WebView`.
 #[derive(Debug, Deserialize, Serialize)]
-pub struct ScrollStatesUpdate {
-    /// Which node that is scrolled. This is required for JS scroll event.
+pub struct ScrollStateUpdate {
+    /// The [`ExternalScrollId`] of the node that that was scrolled.
     pub scrolled_node: ExternalScrollId,
-    /// The whole scroll offsets from the renderer's scroll tree.
+    /// A map containing the scroll offsets of the entire scroll tree. This is necessary,
+    /// because scroll events can cause other nodes to scroll due to sticky positioning.
     pub offsets: FxHashMap<ExternalScrollId, LayoutVector2D>,
 }

--- a/components/shared/embedder/input_events.rs
+++ b/components/shared/embedder/input_events.rs
@@ -8,7 +8,6 @@ use bitflags::bitflags;
 use keyboard_types::{Code, CompositionEvent, Key, KeyState, Location, Modifiers};
 use malloc_size_of_derive::MallocSizeOf;
 use serde::{Deserialize, Serialize};
-use webrender_api::ExternalScrollId;
 
 use crate::WebViewPoint;
 
@@ -48,7 +47,6 @@ pub enum InputEvent {
     MouseButton(MouseButtonEvent),
     MouseLeftViewport(MouseLeftViewportEvent),
     MouseMove(MouseMoveEvent),
-    Scroll(ScrollEvent),
     Touch(TouchEvent),
     Wheel(WheelEvent),
 }
@@ -89,7 +87,6 @@ impl InputEvent {
             InputEvent::MouseLeftViewport(_) => None,
             InputEvent::Touch(event) => Some(event.point),
             InputEvent::Wheel(event) => Some(event.point),
-            InputEvent::Scroll(..) => None,
         }
     }
 }
@@ -308,11 +305,6 @@ impl WheelEvent {
     pub fn new(delta: WheelDelta, point: WebViewPoint) -> Self {
         WheelEvent { delta, point }
     }
-}
-
-#[derive(Clone, Copy, Debug, Deserialize, Serialize)]
-pub struct ScrollEvent {
-    pub external_id: ExternalScrollId,
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize)]

--- a/components/shared/script/lib.rs
+++ b/components/shared/script/lib.rs
@@ -22,7 +22,7 @@ use bluetooth_traits::BluetoothRequest;
 use canvas_traits::webgl::WebGLPipeline;
 use constellation_traits::{
     KeyboardScroll, LoadData, NavigationHistoryBehavior, ScriptToConstellationSender,
-    ScrollStatesUpdate, StructuredSerializedData, WindowSizeType,
+    ScrollStateUpdate, StructuredSerializedData, WindowSizeType,
 };
 use crossbeam_channel::RecvTimeoutError;
 use devtools_traits::ScriptToDevtoolsControlMsg;
@@ -273,7 +273,7 @@ pub enum ScriptThreadMessage {
     SetWebGPUPort(GenericReceiver<WebGPUMsg>),
     /// `Paint` scrolled and is updating the scroll states of the nodes in the given
     /// pipeline via the Constellation.
-    SetScrollStates(PipelineId, ScrollStatesUpdate),
+    SetScrollStates(PipelineId, ScrollStateUpdate),
     /// Evaluate the given JavaScript and return a result via a corresponding message
     /// to the Constellation.
     EvaluateJavaScript(WebViewId, PipelineId, JavaScriptEvaluationId, String),

--- a/components/shared/script/lib.rs
+++ b/components/shared/script/lib.rs
@@ -22,7 +22,7 @@ use bluetooth_traits::BluetoothRequest;
 use canvas_traits::webgl::WebGLPipeline;
 use constellation_traits::{
     KeyboardScroll, LoadData, NavigationHistoryBehavior, ScriptToConstellationSender,
-    StructuredSerializedData, WindowSizeType,
+    ScrollStatesUpdate, StructuredSerializedData, WindowSizeType,
 };
 use crossbeam_channel::RecvTimeoutError;
 use devtools_traits::ScriptToDevtoolsControlMsg;
@@ -52,8 +52,8 @@ use style_traits::{CSSPixel, SpeculativePainter};
 use stylo_atoms::Atom;
 #[cfg(feature = "webgpu")]
 use webgpu_traits::WebGPUMsg;
-use webrender_api::units::{DevicePixel, LayoutVector2D};
-use webrender_api::{ExternalScrollId, ImageKey};
+use webrender_api::ImageKey;
+use webrender_api::units::DevicePixel;
 
 /// The initial data required to create a new `Pipeline` attached to an existing `ScriptThread`.
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -273,7 +273,7 @@ pub enum ScriptThreadMessage {
     SetWebGPUPort(GenericReceiver<WebGPUMsg>),
     /// `Paint` scrolled and is updating the scroll states of the nodes in the given
     /// pipeline via the Constellation.
-    SetScrollStates(PipelineId, FxHashMap<ExternalScrollId, LayoutVector2D>),
+    SetScrollStates(PipelineId, ScrollStatesUpdate),
     /// Evaluate the given JavaScript and return a result via a corresponding message
     /// to the Constellation.
     EvaluateJavaScript(WebViewId, PipelineId, JavaScriptEvaluationId, String),


### PR DESCRIPTION
Remove embedder defined `ScrollEvent` and merge the payload of it to the `SetScrollStates` message which tell the `ScriptThread` to update the scroll state. 

In the past, `ScrollEvent` is defined as a embedder's `InputEvent` and being used only to forward the external scroll node id for a node that is considered scrolled. This make us sends an additional message to constellation and additionally, `ScrollEvent` went through lengthy pipelines as it was deemed as an embedder input event, albeit being a synthetic input fired by `WebviewRenderer`.

Subsequently, we could introduce a flag to detect whether the scrolling is still ongoing or not (like whether it is still flinging) for `scrollend` event.

Testing: No WPT changes
