### PR TITLE
NixOS: fix missing library errors when running libservo tests

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -146,7 +146,7 @@ stdenv.mkDerivation (androidEnvironment // {
   # Provide libraries that aren’t linked against but somehow required
   LD_LIBRARY_PATH = lib.makeLibraryPath [
     # Fixes missing library errors
-    xorg.libXcursor xorg.libXrandr xorg.libXi libxkbcommon
+    wayland xorg.libXcursor xorg.libXrandr xorg.libXi libxkbcommon
 
     # [WARN  script::dom::gpu] Could not get GPUAdapter ("NotFound")
     # TLA Err: Error: Couldn't request WebGPU adapter.


### PR DESCRIPTION
on NixOS, under X11 at least, many libservo tests panic:

```
$ ./mach test-unit -p libservo test_create_webview
[...]
    thread 'test_create_webview' (3589026) panicked at /home/delan/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/wayland-sys-0.31.8/src/client.rs:110:103:
    Library libwayland-client.so could not be loaded.
    note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```

this patch fixes that by adding `wayland` to the LD_LIBRARY_PATH in shell.nix.

Testing: tested manually as above