### PR TITLE
Webdriver CI: Use single chunk, default number of processes

### DIFF
--- a/python/servo/try_parser.py
+++ b/python/servo/try_parser.py
@@ -124,12 +124,7 @@ def handle_preset(s: str) -> Optional[JobConfig]:
             "WebDriver",
             Workflow.LINUX,
             wpt=True,
-            wpt_args=" ".join(
-                [
-                    "./tests/wpt/tests/webdriver/tests/classic/",
-                    "--processes 1",
-                ]
-            ),
+            wpt_args="./tests/wpt/tests/webdriver/tests/classic/",
             unit_tests=False,
             number_of_wpt_chunks=1,
         )

--- a/python/servo/try_parser.py
+++ b/python/servo/try_parser.py
@@ -131,7 +131,7 @@ def handle_preset(s: str) -> Optional[JobConfig]:
                 ]
             ),
             unit_tests=False,
-            number_of_wpt_chunks=2,
+            number_of_wpt_chunks=1,
         )
     elif any(word in s for word in ["vello"]):
         return JobConfig(


### PR DESCRIPTION
As said in https://github.com/servo/servo/issues/42803#issuecomment-3957052680, there's been a weird discrepancy between running wdspec tests in:
1. local / Linux WPT workflow
2. WebDriver Try

For 2, it triggers FAIL/ERROR that never happen in 1. It is not intermittent, but always happens.

This PR makes 2 have same behaviour as running locally: default number of processes (CPU count. For self-hosted runner workflow, this is double. Hyperthreading?), single chunk.

This improves the running time by 2 mins as well.

Testing: The test results now work same as Linux WPT and local. https://github.com/servo/servo/actions/runs/22385441028/job/64795317878#step:11:552 
Fixes: #39097
Fixes: #42803
