### PR TITLE
devtools: Register frame actor before pause

### DIFF
--- a/components/devtools/actors/frame.rs
+++ b/components/devtools/actors/frame.rs
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-use devtools_traits::PausedFrame;
+use devtools_traits::FrameInfo;
 use malloc_size_of_derive::MallocSizeOf;
 use serde::Serialize;
 use serde_json::{Map, Value};
@@ -58,7 +58,7 @@ pub(crate) struct FrameActor {
     name: String,
     object_actor: String,
     source_actor: String,
-    frame_result: PausedFrame,
+    frame_result: FrameInfo,
 }
 
 impl Actor for FrameActor {
@@ -100,7 +100,7 @@ impl FrameActor {
     pub fn register(
         registry: &ActorRegistry,
         source_actor: String,
-        frame_result: PausedFrame,
+        frame_result: FrameInfo,
     ) -> String {
         let object_actor = ObjectActor::register(registry, None);
 

--- a/components/script_bindings/webidls/DebuggerInterruptEvent.webidl
+++ b/components/script_bindings/webidls/DebuggerInterruptEvent.webidl
@@ -10,11 +10,15 @@ interface DebuggerInterruptEvent : Event {};
 partial interface DebuggerGlobalScope {
     undefined pauseAndRespond(
         PipelineIdInit pipelineId,
-        PausedFrame result,
-        boolean is_breakpoint);
+        DOMString frameActorId,
+        boolean isBreakpoint);
+
+    DOMString? registerFrameActor(
+        PipelineIdInit pipelineId,
+        FrameInfo result);
 };
 
-dictionary PausedFrame {
+dictionary FrameInfo {
     required unsigned long column;
     required DOMString displayName;
     required unsigned long line;

--- a/components/shared/devtools/lib.rs
+++ b/components/shared/devtools/lib.rs
@@ -133,7 +133,10 @@ pub enum ScriptToDevtoolsControlMsg {
     DomMutation(PipelineId, DomMutation),
 
     /// The debugger is paused, sending frame information.
-    DebuggerPause(PipelineId, PausedFrame, bool),
+    DebuggerPause(PipelineId, String, bool),
+
+    /// Get frame information from script
+    CreateFrameActor(GenericSender<String>, PipelineId, FrameInfo),
 }
 
 #[derive(Clone, Debug, Deserialize, MallocSizeOf, Serialize)]
@@ -569,7 +572,7 @@ pub struct RecommendedBreakpointLocation {
 
 #[derive(Clone, Debug, Deserialize, MallocSizeOf, Serialize)]
 #[serde(rename_all = "camelCase")]
-pub struct PausedFrame {
+pub struct FrameInfo {
     pub column: u32,
     pub display_name: String,
     pub line: u32,


### PR DESCRIPTION
We need a map between frame actor ids (from devtools) and frame objects (from debugger.js) to implement stepping hooks in the future.

To achieve this, we register the frame actor with a call to the devtools before entering the event loop when the debugger is paused. Instead of creating the frame actor in `handle_debugger_pause`, we create it before.

Testing: It passes existing devtools tests
Part of: #36027