### PR TITLE
script: Propagate `&mut JSContext` inside `evaluate_js_on_global`

### DIFF
--- a/components/script/devtools.rs
+++ b/components/script/devtools.rs
@@ -131,16 +131,16 @@ pub(crate) fn handle_evaluate_js(
 ) {
     let result = unsafe {
         let mut realm = enter_auto_realm(cx, global);
-        let cx = &mut realm;
+        let cx = &mut realm.current_realm();
         rooted!(&in(cx) let mut rval = UndefinedValue());
         // TODO: run code with SpiderMonkey Debugger API, like Firefox does
         // <https://searchfox.org/mozilla-central/rev/f6a806c38c459e0e0d797d264ca0e8ad46005105/devtools/server/actors/webconsole/eval-with-debugger.js#270>
         _ = global.evaluate_js_on_global(
+            cx,
             eval.into(),
             "<eval>",
             Some(IntroductionType::DEBUGGER_EVAL),
             rval.handle_mut(),
-            CanGc::from_cx(cx),
         );
 
         if rval.is_undefined() {

--- a/components/script/dom/debuggerglobalscope.rs
+++ b/components/script/dom/debuggerglobalscope.rs
@@ -23,7 +23,6 @@ use script_bindings::codegen::GenericBindings::DebuggerGetPossibleBreakpointsEve
 use script_bindings::codegen::GenericBindings::DebuggerGlobalScopeBinding::{
     DebuggerGlobalScopeMethods, NotifyNewSource, PipelineIdInit,
 };
-use script_bindings::realms::InRealm;
 use script_bindings::reflector::DomObject;
 use script_bindings::str::DOMString;
 use servo_url::{ImmutableOrigin, MutableOrigin, ServoUrl};
@@ -33,7 +32,6 @@ use crate::dom::bindings::codegen::Bindings::DebuggerGlobalScopeBinding;
 use crate::dom::bindings::codegen::Bindings::DebuggerInterruptEventBinding::{
     FrameInfo, PauseReason,
 };
-use crate::dom::bindings::error::report_pending_exception;
 use crate::dom::bindings::inheritance::Castable;
 use crate::dom::bindings::root::DomRoot;
 use crate::dom::bindings::utils::define_all_exposed_interfaces;
@@ -130,23 +128,16 @@ impl DebuggerGlobalScope {
 
     pub(crate) fn execute(&self, cx: &mut JSContext) {
         let mut realm = enter_auto_realm(cx, self);
-        let mut realm = realm.current_realm();
-        let in_realm_proof = (&mut realm).into();
-        let in_realm = InRealm::Already(&in_realm_proof);
+        let cx = &mut realm.current_realm();
 
-        let cx = &mut realm;
         rooted!(&in(cx) let mut rval = UndefinedValue());
-        let result = self.global_scope.evaluate_js_on_global(
+        let _ = self.global_scope.evaluate_js_on_global(
             cx,
             resources::read_string(Resource::DebuggerJS).into(),
             "",
             None,
             rval.handle_mut(),
         );
-
-        if result.is_err() {
-            report_pending_exception(cx.into(), true, in_realm, CanGc::from_cx(cx));
-        }
     }
 
     pub(crate) fn fire_add_debuggee(

--- a/components/script/dom/debuggerglobalscope.rs
+++ b/components/script/dom/debuggerglobalscope.rs
@@ -2,7 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-use std::borrow::Cow;
 use std::cell::RefCell;
 
 use base::generic_channel::{GenericCallback, GenericSender, channel};
@@ -12,8 +11,8 @@ use devtools_traits::{
     DevtoolScriptControlMsg, EvaluateJSReply, ScriptToDevtoolsControlMsg, SourceInfo, WorkerId,
 };
 use dom_struct::dom_struct;
+use embedder_traits::ScriptToEmbedderChan;
 use embedder_traits::resources::{self, Resource};
-use embedder_traits::{JavaScriptEvaluationError, ScriptToEmbedderChan};
 use js::context::JSContext;
 use js::jsval::UndefinedValue;
 use js::rust::wrappers2::JS_DefineDebuggerObject;
@@ -129,32 +128,23 @@ impl DebuggerGlobalScope {
         self.upcast::<GlobalScope>()
     }
 
-    fn evaluate_js(
-        &self,
-        script: Cow<'_, str>,
-        cx: &mut JSContext,
-    ) -> Result<(), JavaScriptEvaluationError> {
+    pub(crate) fn execute(&self, cx: &mut JSContext) {
+        let mut realm = enter_auto_realm(cx, self);
+        let mut realm = realm.current_realm();
+        let in_realm_proof = (&mut realm).into();
+        let in_realm = InRealm::Already(&in_realm_proof);
+
+        let cx = &mut realm;
         rooted!(&in(cx) let mut rval = UndefinedValue());
-        self.global_scope.evaluate_js_on_global(
-            script,
+        let result = self.global_scope.evaluate_js_on_global(
+            cx,
+            resources::read_string(Resource::DebuggerJS).into(),
             "",
             None,
             rval.handle_mut(),
-            CanGc::from_cx(cx),
-        )
-    }
+        );
 
-    pub(crate) fn execute(&self, cx: &mut JSContext) {
-        if self
-            .evaluate_js(resources::read_string(Resource::DebuggerJS).into(), cx)
-            .is_err()
-        {
-            let mut realm = enter_auto_realm(cx, self);
-            let mut realm = realm.current_realm();
-            let in_realm_proof = (&mut realm).into();
-            let in_realm = InRealm::Already(&in_realm_proof);
-
-            let cx = &mut realm;
+        if result.is_err() {
             report_pending_exception(cx.into(), true, in_realm, CanGc::from_cx(cx));
         }
     }

--- a/components/script/dom/globalscope.rs
+++ b/components/script/dom/globalscope.rs
@@ -2876,11 +2876,7 @@ impl GlobalScope {
             let script = NonNull::new(*compiled_script).expect("Can't be null");
 
             if !evaluate_script(cx.into(), script, url, fetch_options, rval) {
-                let error_info = take_and_report_pending_exception_for_api(
-                    cx.into(),
-                    in_realm,
-                    CanGc::from_cx(cx),
-                );
+                let error_info = take_and_report_pending_exception_for_api(cx);
                 return Err(JavaScriptEvaluationError::EvaluationFailure(error_info));
             }
 

--- a/components/script/dom/globalscope.rs
+++ b/components/script/dom/globalscope.rs
@@ -2845,32 +2845,42 @@ impl GlobalScope {
     /// Evaluate JS code on this global scope.
     pub(crate) fn evaluate_js_on_global(
         &self,
+        cx: &mut CurrentRealm,
         code: Cow<'_, str>,
         filename: &str,
         introduction_type: Option<&'static CStr>,
         rval: MutableHandleValue,
-        can_gc: CanGc,
     ) -> Result<(), JavaScriptEvaluationError> {
-        let cx = GlobalScope::get_cx();
-        let ar = enter_realm(self);
+        let in_realm_proof = cx.into();
+        let in_realm = InRealm::Already(&in_realm_proof);
+
         run_a_script::<DomTypeHolder, _>(self, || {
             let url = self.api_base_url();
             let fetch_options = ScriptFetchOptions::default_classic_script(self);
 
-            rooted!(in(*cx) let mut compiled_script = std::ptr::null_mut::<JSScript>());
-            compiled_script.set(compile_script(cx, &code, filename, 1, introduction_type));
+            rooted!(&in(cx) let mut compiled_script = std::ptr::null_mut::<JSScript>());
+            compiled_script.set(compile_script(
+                cx.into(),
+                &code,
+                filename,
+                1,
+                introduction_type,
+            ));
 
             if compiled_script.is_null() {
                 debug!("error compiling Dom string");
-                report_pending_exception(cx, true, InRealm::Entered(&ar), can_gc);
+                report_pending_exception(cx.into(), true, in_realm, CanGc::from_cx(cx));
                 return Err(JavaScriptEvaluationError::CompilationFailure);
             }
 
             let script = NonNull::new(*compiled_script).expect("Can't be null");
 
-            if !evaluate_script(cx, script, url, fetch_options, rval) {
-                let error_info =
-                    take_and_report_pending_exception_for_api(cx, InRealm::Entered(&ar), can_gc);
+            if !evaluate_script(cx.into(), script, url, fetch_options, rval) {
+                let error_info = take_and_report_pending_exception_for_api(
+                    cx.into(),
+                    in_realm,
+                    CanGc::from_cx(cx),
+                );
                 return Err(JavaScriptEvaluationError::EvaluationFailure(error_info));
             }
 

--- a/components/script/dom/html/htmliframeelement.rs
+++ b/components/script/dom/html/htmliframeelement.rs
@@ -193,11 +193,11 @@ impl HTMLIFrameElement {
             let window_proxy = self.GetContentWindow();
             if let Some(window_proxy) = window_proxy {
                 if !ScriptThread::navigate_to_javascript_url(
+                    cx,
                     &document.global(),
                     &window_proxy.global(),
                     &mut load_data,
                     Some(self.upcast()),
-                    CanGc::from_cx(cx),
                 ) {
                     return;
                 }

--- a/components/script/dom/workletglobalscope.rs
+++ b/components/script/dom/workletglobalscope.rs
@@ -34,7 +34,7 @@ use crate::dom::webgpu::identityhub::IdentityHub;
 use crate::dom::worklet::WorkletExecutor;
 use crate::messaging::MainThreadScriptMsg;
 use crate::realms::enter_auto_realm;
-use crate::script_runtime::{CanGc, IntroductionType, JSContext};
+use crate::script_runtime::{IntroductionType, JSContext};
 
 #[dom_struct]
 /// <https://drafts.css-houdini.org/worklets/#workletglobalscope>
@@ -142,14 +142,17 @@ impl WorkletGlobalScope {
         script: Cow<'_, str>,
         cx: &mut js::context::JSContext,
     ) -> Result<(), JavaScriptEvaluationError> {
+        let mut realm = enter_auto_realm(cx, self);
+        let cx = &mut realm.current_realm();
+
         debug!("Evaluating Dom in a worklet.");
         rooted!(&in(cx) let mut rval = UndefinedValue());
         self.globalscope.evaluate_js_on_global(
+            cx,
             script,
             "",
             Some(IntroductionType::WORKLET),
             rval.handle_mut(),
-            CanGc::from_cx(cx),
         )
     }
 

--- a/components/script/webdriver_handlers.rs
+++ b/components/script/webdriver_handlers.rs
@@ -641,12 +641,15 @@ pub(crate) fn handle_execute_async_script(
             rooted!(&in(cx) let mut rval = UndefinedValue());
 
             let global_scope = window.as_global_scope();
+
+            let mut realm = enter_auto_realm(cx, global_scope);
+            let mut realm = realm.current_realm();
             if let Err(error) = global_scope.evaluate_js_on_global(
+                &mut realm,
                 eval.into(),
                 "",
                 None, // No known `introductionType` for JS code from WebDriver
                 rval.handle_mut(),
-                CanGc::from_cx(cx),
             ) {
                 reply_sender.send(Err(error)).unwrap_or_else(|error| {
                     error!("ExecuteAsyncScript Failed to send reply: {error}");

--- a/components/script_bindings/codegen/Bindings.conf
+++ b/components/script_bindings/codegen/Bindings.conf
@@ -823,11 +823,11 @@ DOMInterfaces = {
 },
 
 'Window': {
-    'canGc': ['CookieStore', 'Fetch', 'FetchLater', 'GetVisualViewport', 'Open', 'ReportError', 'Screen', 'SetInterval', 'SetTimeout', 'StructuredClone', 'TrustedTypes', 'WebdriverException'],
+    'canGc': ['CookieStore', 'Fetch', 'FetchLater', 'GetVisualViewport', 'Open', 'ReportError', 'Screen', 'SetInterval', 'SetTimeout', 'StructuredClone', 'TrustedTypes'],
     'inRealms': ['Fetch'],
     'additionalTraits': ['crate::interfaces::WindowHelpers'],
     'realm': ['CreateImageBitmap', 'CreateImageBitmap_', 'WebdriverCallback', 'GetOpener'],
-    'cx': ['PostMessage', 'PostMessage_', 'Stop']
+    'cx': ['PostMessage', 'PostMessage_', 'Stop', 'WebdriverException']
 },
 
 'WindowProxy' : {


### PR DESCRIPTION
Since `evaluate_js_on_global` called `enter_realm` and there were already some callee that did it, I've actually passed `&mut CurrentRealm`.
Also converted `Window::WebdriverException` to pass `&mut JSContext` inside `javascript_error_info_from_error_info`.

Testing: A successful build is enough
Part of #40600
