### PR TITLE
layout: Remove box damage for parent when we can reuse the box

### DIFF
--- a/components/layout/flexbox/mod.rs
+++ b/components/layout/flexbox/mod.rs
@@ -228,7 +228,7 @@ impl FlexItemBox {
         }
     }
 
-    fn style(&self) -> &ServoArc<ComputedValues> {
+    pub(crate) fn style(&self) -> &ServoArc<ComputedValues> {
         self.independent_formatting_context.style()
     }
 

--- a/components/layout/traversal.rs
+++ b/components/layout/traversal.rs
@@ -258,6 +258,7 @@ pub(crate) fn compute_damage_and_rebuild_box_tree_inner(
         } else {
             // In this case, we have rebuilt the box tree from this point and we do not
             // have to propagate rebuild box tree damage up the tree any further.
+            layout_damage_for_parent.remove(LayoutDamage::box_damage());
             layout_damage_for_parent
                 .insert(RestyleDamage::RELAYOUT | LayoutDamage::recompute_inline_content_sizes());
         }

--- a/tests/wpt/tests/css/css-display/display-flow-root-dynamic-ref.html
+++ b/tests/wpt/tests/css/css-display/display-flow-root-dynamic-ref.html
@@ -1,0 +1,4 @@
+<!DOCTYPE html>
+<title>CSS Reference: dynamically changing the outer display type while keeping a flow-root inner display type</title>
+
+A B C

--- a/tests/wpt/tests/css/css-display/display-flow-root-dynamic.html
+++ b/tests/wpt/tests/css/css-display/display-flow-root-dynamic.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html class="reftest-wait">
+<title>CSS Test: dynamically changing the outer display type while keeping a flow-root inner display type</title>
+<link rel="author" title="Oriol Brufau" href="obrufau@igalia.com">
+<link rel="help" href="https://drafts.csswg.org/css-display-3/#outer-role">
+<link rel="help" href="https://drafts.csswg.org/css-display-3/#valdef-display-flow-root">
+<link rel="match" href="display-flow-root-dynamic-ref.html">
+<meta name="assert" content="The text 'A B C' should appear on a single line.">
+
+A
+<div id="target" style="display: block flow-root">B</div>
+C
+
+<script src="/common/reftest-wait.js"></script>
+<script src="/common/rendering-utils.js"></script>
+<script>
+waitForAtLeastOneFrame().then(() => {
+  target.style.display = "inline flow-root";
+  takeScreenshot();
+});
+</script>
+</html>


### PR DESCRIPTION
This fixes an oversight from #42783: when detecting that a box can be reused, we weren't clearing the box damage propagated to ancestors, so ancestors were still recollecting children.

This exposed some problems in `rebuild_box_tree_from_independent_formatting_context()`:
1. When reusing a block-level box that established an independent formatting context, we weren't checking that the new style was still block-level.
2. When reusing a block-level abspos box, we weren't checking if the new original display was inline-level, preventing it from being handled as a block-level because of the static position.
3. When reusing a flex item, we weren't checking if the `order` had changed.

Testing: we have test coverage for the 3 problems above:
1. Covered by `/html/rendering/non-replaced-elements/the-fieldset-and-legend-elements/legend-display.html`, and also adding a new `/css/css-display/display-flow-root-dynamic.html`.
2. Covered by `/css/CSS2/abspos/hypothetical-box-dynamic.html`
3. Covered by `/css/css-display/order-dynamic.html`.