### PR TITLE
script bindings: Fix warning about unused span.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8053,6 +8053,7 @@ dependencies = [
  "phf",
  "phf_codegen",
  "phf_shared",
+ "profile_traits",
  "regex",
  "serde_json",
  "servo_arc",

--- a/components/script_bindings/Cargo.toml
+++ b/components/script_bindings/Cargo.toml
@@ -34,6 +34,7 @@ malloc_size_of_derive = { workspace = true }
 num-traits = { workspace = true }
 parking_lot = { workspace = true }
 phf = "0.13"
+profile_traits = { workspace = true }
 regex = { workspace = true }
 servo_arc = { workspace = true }
 servo_config = { path = "../config" }


### PR DESCRIPTION
The span needs to be assigned to a variable, so that it drops at the end of scope.
This was introduced in #42715. 
Additionally also switch tho the profile_traits macro to simplify the statement.

Testing: Manually verified the warning is fixed.
