### PR TITLE
script: Encapsulates GPUDevice resource cleanup logic

### DIFF
--- a/components/script_bindings/codegen/Bindings.conf
+++ b/components/script_bindings/codegen/Bindings.conf
@@ -346,7 +346,6 @@ DOMInterfaces = {
         'CreateShaderModule',
         'PopErrorScope'
     ],
-    'allowDropImpl': True,
     'weakReferenceable': True, # for usage in GlobalScope https://github.com/servo/servo/issues/32519
 },
 


### PR DESCRIPTION
Moves the `Drop` implementation for `GPUDevice` into a private `DroppableGPUDevice` struct.

Also updates `Bindings.conf` to prevent the generation of `Drop` implementations for `GPUDevice`.

Testing: WebGpu tests just cover the cases
Fixes: Partially #26488 
