### PR TITLE
release: Upload vendored source archive

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -114,6 +114,8 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+      id-token: write
+      attestations: write
     env:
       ARTIFACT_BASENAME: "servo-${{ needs.create-draft-release.outputs.release-tag }}-src-vendor"
       ARTIFACT_FILENAME: "servo-${{ needs.create-draft-release.outputs.release-tag }}-src-vendor.tar.gz"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -136,8 +136,7 @@ jobs:
         run: |
           gh release upload "${{ needs.create-draft-release.outputs.release-tag }}" \
             "${ARTIFACT_FILENAME}" \
-            --repo "${RELEASE_REPO}" \
-            --clobber
+            --repo "${RELEASE_REPO}"
         env:
           GITHUB_TOKEN: ${{ inputs.regular_release && github.token || secrets.NIGHTLY_REPO_TOKEN }}
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,10 +50,12 @@ jobs:
             | jq '.id' \
           )
           echo "RELEASE_ID=${RELEASE_ID}" >> ${GITHUB_OUTPUT}
+          echo "RELEASE_TAG=${RELEASE_TAG}" >> ${GITHUB_OUTPUT}
         env:
           GITHUB_TOKEN: ${{ inputs.regular_release && github.token || secrets.NIGHTLY_REPO_TOKEN }}
     outputs:
       release-id: ${{ steps.create-release.outputs.RELEASE_ID }}
+      release-tag: ${{ steps.create-release.outputs.RELEASE_TAG }}
 
   publish-nightly-release:
     # We only auto-publish nightly releases, so we do not use this job for regular releases.
@@ -87,6 +89,7 @@ jobs:
       RELEASE_ID: ${{ needs.create-draft-release.outputs.release-id }}
     needs:
       - create-draft-release
+      - upload-vendored-source
       - upload-linux-nightly
       - upload-win-nightly
       - upload-mac-nightly
@@ -103,6 +106,38 @@ jobs:
       profile: "production"
       upload_zip: true
       force-github-hosted-runner: true  # <https://github.com/servo/servo/issues/33296>
+
+  upload-vendored-source:
+    # This job is only useful when run on upstream servo.
+    if: github.repository == 'servo/servo' || github.event_name == 'workflow_dispatch'
+    name: Upload vendored source archive
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    env:
+      ARTIFACT_BASENAME: "servo-${{ needs.create-draft-release.outputs.release-tag }}-src-vendor"
+      ARTIFACT_FILENAME: "servo-${{ needs.create-draft-release.outputs.release-tag }}-src-vendor.tar.gz"
+    needs:
+      - create-draft-release
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 1
+      - name: Generate vendored archive
+        run: |
+          python3 etc/vendor_servo.py --filename "${ARTIFACT_BASENAME}"
+      - name: Generate artifact attestation
+        uses: actions/attest-build-provenance@v3
+        with:
+          subject-path: ${{ env.ARTIFACT_FILENAME }}
+      - name: Upload vendored archive to release
+        run: |
+          gh release upload "${{ needs.create-draft-release.outputs.release-tag }}" \
+            "${ARTIFACT_FILENAME}" \
+            --repo "${RELEASE_REPO}" \
+            --clobber
+        env:
+          GITHUB_TOKEN: ${{ inputs.regular_release && github.token || secrets.NIGHTLY_REPO_TOKEN }}
 
   upload-win-nightly:
     # Only run scheduled nightly builds on upstream servo.

--- a/etc/vendor_servo.py
+++ b/etc/vendor_servo.py
@@ -72,15 +72,15 @@ def vendor():
         tmp_file_path = file + ".tar.gz"
         if args.filename is not None:
             name = pathlib.Path(args.filename)
+            name = name.with_name(name.name + ".tar.gz")
             if name.is_absolute():
                 out_filepath = name
             else:
-                name = name.with_name(name.name + ".tar.gz")
                 out_filepath = servo_root.joinpath(name)
         else:
             out_filepath = servo_root.joinpath("servo.tar.gz")
         print(f"Moving archive to {out_filepath}")
-        shutil.move(tmp_file_path, servo_root)
+        shutil.move(tmp_file_path, out_filepath)
     return
 
 


### PR DESCRIPTION
Add a job to the release workflow which uploads a source code archive including our vendored rust dependencies. This allows offline builds after downloading the archive and will also be documented in the book (see https://github.com/servo/book/pull/206).

Testing: Manually tested by triggering a release on the nightly repo: https://github.com/servo/servo/actions/runs/22405488357/job/64863992613

