### PR TITLE
script: avoid stylesheet blocker underflow after window.stop()

### DIFF
--- a/components/script/stylesheet_loader.rs
+++ b/components/script/stylesheet_loader.rs
@@ -232,7 +232,16 @@ impl StylesheetContext {
         cx: &mut js::context::JSContext,
     ) {
         if self.is_script_blocking {
-            document.decrement_script_blocking_stylesheet_count();
+            if document.get_script_blocking_stylesheets_count() > 0 {
+                document.decrement_script_blocking_stylesheet_count();
+            } else {
+                // `window.stop()` can abortt the document from an error handler that we
+                // dispatch just before this call, resetting the blocker count
+                assert!(
+                    document.loader().events_inhibited(),
+                    "script-blocking stylesheet finished without a pending blocker"
+                );
+            }
         }
 
         if self.is_render_blocking {

--- a/tests/wpt/tests/html/semantics/document-metadata/the-link-element/link-href-attribute-crash.html
+++ b/tests/wpt/tests/html/semantics/document-metadata/the-link-element/link-href-attribute-crash.html
@@ -1,0 +1,8 @@
+<!DOCTYPE html>
+<link rel=help href="https://github.com/servo/servo/issues/42854">
+<link id="link" rel="stylesheet" onerror="window.stop()">
+<script>
+  addEventListener("load", () => {
+    link.href = "about:blank";
+  });
+</script>


### PR DESCRIPTION
Avoid stylesheet blocker underflow after window.stop()

Testing: added crash test
Fixes: #42854
