### PR TITLE
indexeddb: Add `processed` flag, rename `close` to `close_pending` and update spec links to version 3 of the spec

### DIFF
--- a/components/script/dom/domstringlist.rs
+++ b/components/script/dom/domstringlist.rs
@@ -38,7 +38,7 @@ impl DOMStringList {
         )
     }
 
-    /// <https://www.w3.org/TR/IndexedDB-2/#sorted-name-list>
+    /// <https://www.w3.org/TR/IndexedDB-3/#sorted-name-list>
     pub(crate) fn new_sorted<'a>(
         global: &GlobalScope,
         strings: impl IntoIterator<Item = &'a DOMString>,

--- a/components/script/dom/indexeddb/idbcursor.rs
+++ b/components/script/dom/indexeddb/idbcursor.rs
@@ -41,30 +41,30 @@ pub(crate) enum ObjectStoreOrIndex {
 pub(crate) struct IDBCursor {
     reflector_: Reflector,
 
-    /// <https://www.w3.org/TR/IndexedDB-2/#cursor-transaction>
+    /// <https://www.w3.org/TR/IndexedDB-3/#cursor-transaction>
     transaction: Dom<IDBTransaction>,
-    /// <https://www.w3.org/TR/IndexedDB-2/#cursor-range>
+    /// <https://www.w3.org/TR/IndexedDB-3/#cursor-range>
     #[no_trace]
     range: IndexedDBKeyRange,
-    /// <https://www.w3.org/TR/IndexedDB-2/#cursor-source>
+    /// <https://www.w3.org/TR/IndexedDB-3/#cursor-source>
     source: ObjectStoreOrIndex,
-    /// <https://www.w3.org/TR/IndexedDB-2/#cursor-direction>
+    /// <https://www.w3.org/TR/IndexedDB-3/#cursor-direction>
     direction: IDBCursorDirection,
-    /// <https://www.w3.org/TR/IndexedDB-2/#cursor-position>
+    /// <https://www.w3.org/TR/IndexedDB-3/#cursor-position>
     #[no_trace]
     position: DomRefCell<Option<IndexedDBKeyType>>,
-    /// <https://www.w3.org/TR/IndexedDB-2/#cursor-key>
+    /// <https://www.w3.org/TR/IndexedDB-3/#cursor-key>
     #[no_trace]
     key: DomRefCell<Option<IndexedDBKeyType>>,
-    /// <https://www.w3.org/TR/IndexedDB-2/#cursor-value>
+    /// <https://www.w3.org/TR/IndexedDB-3/#cursor-value>
     #[ignore_malloc_size_of = "mozjs"]
     value: Heap<JSVal>,
-    /// <https://www.w3.org/TR/IndexedDB-2/#cursor-got-value-flag>
+    /// <https://www.w3.org/TR/IndexedDB-3/#cursor-got-value-flag>
     got_value: Cell<bool>,
-    /// <https://www.w3.org/TR/IndexedDB-2/#cursor-object-store-position>
+    /// <https://www.w3.org/TR/IndexedDB-3/#cursor-object-store-position>
     #[no_trace]
     object_store_position: DomRefCell<Option<IndexedDBKeyType>>,
-    /// <https://www.w3.org/TR/IndexedDB-2/#cursor-key-only-flag>
+    /// <https://www.w3.org/TR/IndexedDB-3/#cursor-key-only-flag>
     key_only: bool,
 
     /// <https://w3c.github.io/IndexedDB/#cursor-request>
@@ -143,7 +143,7 @@ impl IDBCursor {
         out.set(self.value.get());
     }
 
-    /// <https://www.w3.org/TR/IndexedDB-2/#cursor-effective-key>
+    /// <https://www.w3.org/TR/IndexedDB-3/#cursor-effective-key>
     pub(crate) fn effective_key(&self) -> Option<IndexedDBKeyType> {
         match &self.source {
             ObjectStoreOrIndex::ObjectStore(_) => self.position.borrow().clone(),
@@ -153,7 +153,7 @@ impl IDBCursor {
 }
 
 impl IDBCursorMethods<crate::DomTypeHolder> for IDBCursor {
-    /// <https://www.w3.org/TR/IndexedDB-2/#dom-idbcursor-source>
+    /// <https://www.w3.org/TR/IndexedDB-3/#dom-idbcursor-source>
     fn Source(&self) -> IDBObjectStoreOrIDBIndex {
         match &self.source {
             ObjectStoreOrIndex::ObjectStore(source) => {
@@ -165,12 +165,12 @@ impl IDBCursorMethods<crate::DomTypeHolder> for IDBCursor {
         }
     }
 
-    /// <https://www.w3.org/TR/IndexedDB-2/#dom-idbcursor-direction>
+    /// <https://www.w3.org/TR/IndexedDB-3/#dom-idbcursor-direction>
     fn Direction(&self) -> IDBCursorDirection {
         self.direction
     }
 
-    /// <https://www.w3.org/TR/IndexedDB-2/#dom-idbcursor-key>
+    /// <https://www.w3.org/TR/IndexedDB-3/#dom-idbcursor-key>
     fn Key(&self, cx: &mut JSContext, mut value: MutableHandleValue) {
         match self.key.borrow().as_ref() {
             Some(key) => key_type_to_jsval(cx, key, value),
@@ -178,7 +178,7 @@ impl IDBCursorMethods<crate::DomTypeHolder> for IDBCursor {
         }
     }
 
-    /// <https://www.w3.org/TR/IndexedDB-2/#dom-idbcursor-primarykey>
+    /// <https://www.w3.org/TR/IndexedDB-3/#dom-idbcursor-primarykey>
     fn PrimaryKey(&self, cx: &mut JSContext, mut value: MutableHandleValue) {
         match self.effective_key() {
             Some(effective_key) => key_type_to_jsval(cx, &effective_key, value),
@@ -195,7 +195,7 @@ impl IDBCursorMethods<crate::DomTypeHolder> for IDBCursor {
 }
 
 /// A struct containing parameters for
-/// <https://www.w3.org/TR/IndexedDB-2/#iterate-a-cursor>
+/// <https://www.w3.org/TR/IndexedDB-3/#iterate-a-cursor>
 #[derive(Clone)]
 pub(crate) struct IterationParam {
     pub(crate) cursor: Trusted<IDBCursor>,
@@ -204,7 +204,7 @@ pub(crate) struct IterationParam {
     pub(crate) count: Option<u32>,
 }
 
-/// <https://www.w3.org/TR/IndexedDB-2/#iterate-a-cursor>
+/// <https://www.w3.org/TR/IndexedDB-3/#iterate-a-cursor>
 ///
 /// NOTE: Be cautious: this part of the specification seems to assume the cursor’s source is an
 /// index. Therefore,

--- a/components/script/dom/indexeddb/idbcursorwithvalue.rs
+++ b/components/script/dom/indexeddb/idbcursorwithvalue.rs
@@ -70,7 +70,7 @@ impl IDBCursorWithValue {
 }
 
 impl IDBCursorWithValueMethods<crate::DomTypeHolder> for IDBCursorWithValue {
-    /// <https://www.w3.org/TR/IndexedDB-2/#dom-idbcursorwithvalue-value>
+    /// <https://www.w3.org/TR/IndexedDB-3/#dom-idbcursorwithvalue-value>
     fn Value(&self, _cx: SafeJSContext, value: MutableHandleValue) {
         self.cursor.value(value);
     }

--- a/components/script/dom/indexeddb/idbfactory.rs
+++ b/components/script/dom/indexeddb/idbfactory.rs
@@ -43,7 +43,7 @@ pub(crate) struct DBName(pub(crate) String);
 #[dom_struct]
 pub struct IDBFactory {
     reflector_: Reflector,
-    /// <https://www.w3.org/TR/IndexedDB-2/#connection>
+    /// <https://www.w3.org/TR/IndexedDB-3/#connection>
     /// The connections opened through this factory.
     /// We store the open request, which contains the connection.
     /// TODO: remove when we are sure they are not needed anymore.
@@ -618,7 +618,7 @@ impl IDBFactoryMethods<crate::DomTypeHolder> for IDBFactory {
         p
     }
 
-    /// <https://www.w3.org/TR/IndexedDB-2/#dom-idbfactory-cmp>
+    /// <https://www.w3.org/TR/IndexedDB-3/#dom-idbfactory-cmp>
     fn Cmp(&self, cx: &mut JSContext, first: HandleValue, second: HandleValue) -> Fallible<i16> {
         let first_key = convert_value_to_key(cx, first, None)?.into_result()?;
         let second_key = convert_value_to_key(cx, second, None)?.into_result()?;

--- a/components/script/dom/indexeddb/idbkeyrange.rs
+++ b/components/script/dom/indexeddb/idbkeyrange.rs
@@ -41,31 +41,31 @@ impl IDBKeyRange {
 }
 
 impl IDBKeyRangeMethods<crate::DomTypeHolder> for IDBKeyRange {
-    /// <https://www.w3.org/TR/IndexedDB-2/#dom-idbkeyrange-lower>
+    /// <https://www.w3.org/TR/IndexedDB-3/#dom-idbkeyrange-lower>
     fn Lower(&self, cx: &mut JSContext, answer: MutableHandleValue) {
         if let Some(lower) = self.inner.lower.as_ref() {
             key_type_to_jsval(cx, lower, answer);
         }
     }
 
-    /// <https://www.w3.org/TR/IndexedDB-2/#dom-idbkeyrange-upper>
+    /// <https://www.w3.org/TR/IndexedDB-3/#dom-idbkeyrange-upper>
     fn Upper(&self, cx: &mut JSContext, answer: MutableHandleValue) {
         if let Some(upper) = self.inner.upper.as_ref() {
             key_type_to_jsval(cx, upper, answer);
         }
     }
 
-    /// <https://www.w3.org/TR/IndexedDB-2/#dom-idbkeyrange-loweropen>
+    /// <https://www.w3.org/TR/IndexedDB-3/#dom-idbkeyrange-loweropen>
     fn LowerOpen(&self) -> bool {
         self.inner.lower_open
     }
 
-    /// <https://www.w3.org/TR/IndexedDB-2/#dom-idbkeyrange-upperopen>
+    /// <https://www.w3.org/TR/IndexedDB-3/#dom-idbkeyrange-upperopen>
     fn UpperOpen(&self) -> bool {
         self.inner.upper_open
     }
 
-    /// <https://www.w3.org/TR/IndexedDB-2/#dom-idbkeyrange-only>
+    /// <https://www.w3.org/TR/IndexedDB-3/#dom-idbkeyrange-only>
     fn Only(
         cx: &mut JSContext,
         global: &GlobalScope,
@@ -76,7 +76,7 @@ impl IDBKeyRangeMethods<crate::DomTypeHolder> for IDBKeyRange {
         Ok(IDBKeyRange::new(global, inner, CanGc::from_cx(cx)))
     }
 
-    /// <https://www.w3.org/TR/IndexedDB-2/#dom-idbkeyrange-lowerbound>
+    /// <https://www.w3.org/TR/IndexedDB-3/#dom-idbkeyrange-lowerbound>
     fn LowerBound(
         cx: &mut JSContext,
         global: &GlobalScope,
@@ -88,7 +88,7 @@ impl IDBKeyRangeMethods<crate::DomTypeHolder> for IDBKeyRange {
         Ok(IDBKeyRange::new(global, inner, CanGc::from_cx(cx)))
     }
 
-    /// <https://www.w3.org/TR/IndexedDB-2/#dom-idbkeyrange-upperbound>
+    /// <https://www.w3.org/TR/IndexedDB-3/#dom-idbkeyrange-upperbound>
     fn UpperBound(
         cx: &mut JSContext,
         global: &GlobalScope,
@@ -100,7 +100,7 @@ impl IDBKeyRangeMethods<crate::DomTypeHolder> for IDBKeyRange {
         Ok(IDBKeyRange::new(global, inner, CanGc::from_cx(cx)))
     }
 
-    /// <https://www.w3.org/TR/IndexedDB-2/#dom-idbkeyrange-bound>
+    /// <https://www.w3.org/TR/IndexedDB-3/#dom-idbkeyrange-bound>
     fn Bound(
         cx: &mut JSContext,
         global: &GlobalScope,
@@ -132,7 +132,7 @@ impl IDBKeyRangeMethods<crate::DomTypeHolder> for IDBKeyRange {
         Ok(IDBKeyRange::new(global, inner, CanGc::from_cx(cx)))
     }
 
-    /// <https://www.w3.org/TR/IndexedDB-2/#dom-idbkeyrange-_includes>
+    /// <https://www.w3.org/TR/IndexedDB-3/#dom-idbkeyrange-_includes>
     fn Includes(&self, cx: &mut JSContext, value: HandleValue) -> Fallible<bool> {
         let key = convert_value_to_key(cx, value, None)?.into_result()?;
         if self.inner.contains(&key) {

--- a/components/script/dom/indexeddb/idbobjectstore.rs
+++ b/components/script/dom/indexeddb/idbobjectstore.rs
@@ -175,7 +175,7 @@ impl IDBObjectStore {
         receiver.recv().unwrap().unwrap().has_key_generator
     }
 
-    /// <https://www.w3.org/TR/IndexedDB-2/#object-store-in-line-keys>
+    /// <https://www.w3.org/TR/IndexedDB-3/#object-store-in-line-keys>
     fn uses_inline_keys(&self) -> bool {
         self.key_path.is_some()
     }
@@ -219,7 +219,7 @@ impl IDBObjectStore {
         Ok(())
     }
 
-    /// <https://www.w3.org/TR/IndexedDB-2/#dom-idbobjectstore-put>
+    /// <https://www.w3.org/TR/IndexedDB-3/#dom-idbobjectstore-put>
     fn put(
         &self,
         cx: &mut JSContext,
@@ -310,8 +310,8 @@ impl IDBObjectStore {
         )
     }
 
-    /// <https://www.w3.org/TR/IndexedDB-2/#dom-idbobjectstore-opencursor>
-    /// <https://www.w3.org/TR/IndexedDB-2/#dom-idbobjectstore-openkeycursor>
+    /// <https://www.w3.org/TR/IndexedDB-3/#dom-idbobjectstore-opencursor>
+    /// <https://www.w3.org/TR/IndexedDB-3/#dom-idbobjectstore-openkeycursor>
     fn open_cursor(
         &self,
         cx: &mut JSContext,
@@ -415,7 +415,7 @@ impl IDBObjectStore {
 }
 
 impl IDBObjectStoreMethods<crate::DomTypeHolder> for IDBObjectStore {
-    /// <https://www.w3.org/TR/IndexedDB-2/#dom-idbobjectstore-put>
+    /// <https://www.w3.org/TR/IndexedDB-3/#dom-idbobjectstore-put>
     fn Put(
         &self,
         cx: &mut JSContext,
@@ -425,7 +425,7 @@ impl IDBObjectStoreMethods<crate::DomTypeHolder> for IDBObjectStore {
         self.put(cx, value, key, true)
     }
 
-    /// <https://www.w3.org/TR/IndexedDB-2/#dom-idbobjectstore-add>
+    /// <https://www.w3.org/TR/IndexedDB-3/#dom-idbobjectstore-add>
     fn Add(
         &self,
         cx: &mut JSContext,
@@ -435,7 +435,7 @@ impl IDBObjectStoreMethods<crate::DomTypeHolder> for IDBObjectStore {
         self.put(cx, value, key, false)
     }
 
-    /// <https://www.w3.org/TR/IndexedDB-2/#dom-idbobjectstore-delete>
+    /// <https://www.w3.org/TR/IndexedDB-3/#dom-idbobjectstore-delete>
     fn Delete(&self, cx: &mut JSContext, query: HandleValue) -> Fallible<DomRoot<IDBRequest>> {
         // Step 1. Let transaction be this’s transaction.
         // Step 2. Let store be this's object store.
@@ -466,7 +466,7 @@ impl IDBObjectStoreMethods<crate::DomTypeHolder> for IDBObjectStore {
         })
     }
 
-    /// <https://www.w3.org/TR/IndexedDB-2/#dom-idbobjectstore-clear>
+    /// <https://www.w3.org/TR/IndexedDB-3/#dom-idbobjectstore-clear>
     fn Clear(&self, cx: &mut JSContext) -> Fallible<DomRoot<IDBRequest>> {
         // Step 1. Let transaction be this’s transaction.
         // Step 2. Let store be this's object store.
@@ -488,7 +488,7 @@ impl IDBObjectStoreMethods<crate::DomTypeHolder> for IDBObjectStore {
         )
     }
 
-    /// <https://www.w3.org/TR/IndexedDB-2/#dom-idbobjectstore-get>
+    /// <https://www.w3.org/TR/IndexedDB-3/#dom-idbobjectstore-get>
     fn Get(&self, cx: &mut JSContext, query: HandleValue) -> Fallible<DomRoot<IDBRequest>> {
         // Step 1. Let transaction be this’s transaction.
         // Step 2. Let store be this's object store.
@@ -519,7 +519,7 @@ impl IDBObjectStoreMethods<crate::DomTypeHolder> for IDBObjectStore {
         })
     }
 
-    /// <https://www.w3.org/TR/IndexedDB-2/#dom-idbobjectstore-getkey>
+    /// <https://www.w3.org/TR/IndexedDB-3/#dom-idbobjectstore-getkey>
     fn GetKey(&self, cx: &mut JSContext, query: HandleValue) -> Result<DomRoot<IDBRequest>, Error> {
         // Step 1. Let transaction be this’s transaction.
         // Step 2. Let store be this's object store.
@@ -551,7 +551,7 @@ impl IDBObjectStoreMethods<crate::DomTypeHolder> for IDBObjectStore {
         })
     }
 
-    /// <https://www.w3.org/TR/IndexedDB-2/#dom-idbobjectstore-getall>
+    /// <https://www.w3.org/TR/IndexedDB-3/#dom-idbobjectstore-getall>
     fn GetAll(
         &self,
         cx: &mut JSContext,
@@ -589,7 +589,7 @@ impl IDBObjectStoreMethods<crate::DomTypeHolder> for IDBObjectStore {
         })
     }
 
-    /// <https://www.w3.org/TR/IndexedDB-2/#dom-idbobjectstore-getallkeys>
+    /// <https://www.w3.org/TR/IndexedDB-3/#dom-idbobjectstore-getallkeys>
     fn GetAllKeys(
         &self,
         cx: &mut JSContext,
@@ -627,7 +627,7 @@ impl IDBObjectStoreMethods<crate::DomTypeHolder> for IDBObjectStore {
         })
     }
 
-    /// <https://www.w3.org/TR/IndexedDB-2/#dom-idbobjectstore-count>
+    /// <https://www.w3.org/TR/IndexedDB-3/#dom-idbobjectstore-count>
     fn Count(&self, cx: &mut JSContext, query: HandleValue) -> Fallible<DomRoot<IDBRequest>> {
         // Step 1. Let transaction be this’s transaction.
         // Step 2. Let store be this's object store.
@@ -658,7 +658,7 @@ impl IDBObjectStoreMethods<crate::DomTypeHolder> for IDBObjectStore {
         })
     }
 
-    /// <https://www.w3.org/TR/IndexedDB-2/#dom-idbobjectstore-opencursor>
+    /// <https://www.w3.org/TR/IndexedDB-3/#dom-idbobjectstore-opencursor>
     fn OpenCursor(
         &self,
         cx: &mut JSContext,
@@ -668,7 +668,7 @@ impl IDBObjectStoreMethods<crate::DomTypeHolder> for IDBObjectStore {
         self.open_cursor(cx, query, direction, false)
     }
 
-    /// <https://www.w3.org/TR/IndexedDB-2/#dom-idbobjectstore-openkeycursor>
+    /// <https://www.w3.org/TR/IndexedDB-3/#dom-idbobjectstore-openkeycursor>
     fn OpenKeyCursor(
         &self,
         cx: &mut JSContext,
@@ -678,12 +678,12 @@ impl IDBObjectStoreMethods<crate::DomTypeHolder> for IDBObjectStore {
         self.open_cursor(cx, query, direction, true)
     }
 
-    /// <https://www.w3.org/TR/IndexedDB-2/#dom-idbobjectstore-name>
+    /// <https://www.w3.org/TR/IndexedDB-3/#dom-idbobjectstore-name>
     fn Name(&self) -> DOMString {
         self.name.borrow().clone()
     }
 
-    /// <https://www.w3.org/TR/IndexedDB-2/#dom-idbobjectstore-setname>
+    /// <https://www.w3.org/TR/IndexedDB-3/#dom-idbobjectstore-setname>
     fn SetName(&self, value: DOMString) -> ErrorResult {
         // Step 2. Let transaction be this’s transaction.
         let transaction = &self.transaction;
@@ -703,7 +703,7 @@ impl IDBObjectStoreMethods<crate::DomTypeHolder> for IDBObjectStore {
         Ok(())
     }
 
-    /// <https://www.w3.org/TR/IndexedDB-2/#dom-idbobjectstore-keypath>
+    /// <https://www.w3.org/TR/IndexedDB-3/#dom-idbobjectstore-keypath>
     fn KeyPath(&self, cx: &mut JSContext, mut ret_val: MutableHandleValue) {
         match &self.key_path {
             Some(KeyPath::String(path)) => path.safe_to_jsval(cx, ret_val),
@@ -712,22 +712,22 @@ impl IDBObjectStoreMethods<crate::DomTypeHolder> for IDBObjectStore {
         }
     }
 
-    /// <https://www.w3.org/TR/IndexedDB-2/#dom-idbobjectstore-indexnames>
+    /// <https://www.w3.org/TR/IndexedDB-3/#dom-idbobjectstore-indexnames>
     fn IndexNames(&self, can_gc: CanGc) -> DomRoot<DOMStringList> {
         DOMStringList::new_sorted(&self.global(), self.index_set.borrow().keys(), can_gc)
     }
 
-    /// <https://www.w3.org/TR/IndexedDB-2/#dom-idbobjectstore-transaction>
+    /// <https://www.w3.org/TR/IndexedDB-3/#dom-idbobjectstore-transaction>
     fn Transaction(&self) -> DomRoot<IDBTransaction> {
         self.transaction()
     }
 
-    /// <https://www.w3.org/TR/IndexedDB-2/#dom-idbobjectstore-autoincrement>
+    /// <https://www.w3.org/TR/IndexedDB-3/#dom-idbobjectstore-autoincrement>
     fn AutoIncrement(&self) -> bool {
         self.has_key_generator()
     }
 
-    /// <https://www.w3.org/TR/IndexedDB-2/#dom-idbobjectstore-createindex>
+    /// <https://www.w3.org/TR/IndexedDB-3/#dom-idbobjectstore-createindex>
     fn CreateIndex(
         &self,
         name: DOMString,
@@ -786,7 +786,7 @@ impl IDBObjectStoreMethods<crate::DomTypeHolder> for IDBObjectStore {
         Ok(index)
     }
 
-    /// <https://www.w3.org/TR/IndexedDB-2/#dom-idbobjectstore-deleteindex>
+    /// <https://www.w3.org/TR/IndexedDB-3/#dom-idbobjectstore-deleteindex>
     fn DeleteIndex(&self, name: DOMString) -> Fallible<()> {
         // Step 3. If transaction is not an upgrade transaction, throw an "InvalidStateError" DOMException.
         if self.transaction.Mode() != IDBTransactionMode::Versionchange {

--- a/components/script/dom/indexeddb/idbopendbrequest.rs
+++ b/components/script/dom/indexeddb/idbopendbrequest.rs
@@ -319,9 +319,9 @@ impl IDBOpenDBRequest {
 }
 
 impl IDBOpenDBRequestMethods<crate::DomTypeHolder> for IDBOpenDBRequest {
-    // https://www.w3.org/TR/IndexedDB-2/#dom-idbopendbrequest-onblocked
+    // https://www.w3.org/TR/IndexedDB-3/#dom-idbopendbrequest-onblocked
     event_handler!(blocked, GetOnblocked, SetOnblocked);
 
-    // https://www.w3.org/TR/IndexedDB-2/#dom-idbopendbrequest-onupgradeneeded
+    // https://www.w3.org/TR/IndexedDB-3/#dom-idbopendbrequest-onupgradeneeded
     event_handler!(upgradeneeded, GetOnupgradeneeded, SetOnupgradeneeded);
 }

--- a/components/script/dom/indexeddb/idbrequest.rs
+++ b/components/script/dom/indexeddb/idbrequest.rs
@@ -147,7 +147,7 @@ impl RequestListener {
         transaction.maybe_commit();
     }
 
-    // https://www.w3.org/TR/IndexedDB-2/#async-execute-request
+    // https://www.w3.org/TR/IndexedDB-3/#async-execute-request
     // Implements Step 5.4
     fn handle_async_request_finished(&self, cx: &mut JSContext, result: BackendResult<IdbResult>) {
         let request = self.request.root();
@@ -309,7 +309,7 @@ impl RequestListener {
         }
     }
 
-    // https://www.w3.org/TR/IndexedDB-2/#async-execute-request
+    // https://www.w3.org/TR/IndexedDB-3/#async-execute-request
     // Implements Step 5.4.2
     fn handle_async_request_error(
         global: &GlobalScope,
@@ -429,7 +429,7 @@ impl IDBRequest {
         self.transaction.get()
     }
 
-    // https://www.w3.org/TR/IndexedDB-2/#asynchronously-execute-a-request
+    // https://www.w3.org/TR/IndexedDB-3/#asynchronously-execute-a-request
     pub fn execute_async<T, F>(
         source: &IDBObjectStore,
         operation_fn: F,
@@ -535,34 +535,34 @@ impl IDBRequest {
 }
 
 impl IDBRequestMethods<crate::DomTypeHolder> for IDBRequest {
-    /// <https://www.w3.org/TR/IndexedDB-2/#dom-idbrequest-result>
+    /// <https://www.w3.org/TR/IndexedDB-3/#dom-idbrequest-result>
     fn Result(&self, _cx: SafeJSContext, mut val: js::rust::MutableHandle<'_, js::jsapi::Value>) {
         val.set(self.result.get());
     }
 
-    /// <https://www.w3.org/TR/IndexedDB-2/#dom-idbrequest-error>
+    /// <https://www.w3.org/TR/IndexedDB-3/#dom-idbrequest-error>
     fn GetError(&self) -> Option<DomRoot<DOMException>> {
         self.error.get()
     }
 
-    /// <https://www.w3.org/TR/IndexedDB-2/#dom-idbrequest-source>
+    /// <https://www.w3.org/TR/IndexedDB-3/#dom-idbrequest-source>
     fn GetSource(&self) -> Option<DomRoot<IDBObjectStore>> {
         self.source.get()
     }
 
-    /// <https://www.w3.org/TR/IndexedDB-2/#dom-idbrequest-transaction>
+    /// <https://www.w3.org/TR/IndexedDB-3/#dom-idbrequest-transaction>
     fn GetTransaction(&self) -> Option<DomRoot<IDBTransaction>> {
         self.transaction.get()
     }
 
-    /// <https://www.w3.org/TR/IndexedDB-2/#dom-idbrequest-readystate>
+    /// <https://www.w3.org/TR/IndexedDB-3/#dom-idbrequest-readystate>
     fn ReadyState(&self) -> IDBRequestReadyState {
         self.ready_state.get()
     }
 
-    // https://www.w3.org/TR/IndexedDB-2/#dom-idbrequest-onsuccess
+    // https://www.w3.org/TR/IndexedDB-3/#dom-idbrequest-onsuccess
     event_handler!(success, GetOnsuccess, SetOnsuccess);
 
-    // https://www.w3.org/TR/IndexedDB-2/#dom-idbrequest-onerror
+    // https://www.w3.org/TR/IndexedDB-3/#dom-idbrequest-onerror
     event_handler!(error, GetOnerror, SetOnerror);
 }

--- a/components/script/dom/indexeddb/idbtransaction.rs
+++ b/components/script/dom/indexeddb/idbtransaction.rs
@@ -48,11 +48,11 @@ pub struct IDBTransaction {
     error: MutNullableDom<DOMException>,
 
     store_handles: DomRefCell<HashMap<String, Dom<IDBObjectStore>>>,
-    // https://www.w3.org/TR/IndexedDB-2/#transaction-request-list
+    // https://www.w3.org/TR/IndexedDB-3/#transaction-request-list
     requests: DomRefCell<Vec<Dom<IDBRequest>>>,
-    // https://www.w3.org/TR/IndexedDB-2/#transaction-active-flag
+    // https://www.w3.org/TR/IndexedDB-3/#transaction-active-flag
     active: Cell<bool>,
-    // https://www.w3.org/TR/IndexedDB-2/#transaction-finish
+    // https://www.w3.org/TR/IndexedDB-3/#transaction-finish
     finished: Cell<bool>,
     abort_initiated: Cell<bool>,
     abort_requested: Cell<bool>,
@@ -626,12 +626,12 @@ impl IDBTransaction {
 }
 
 impl IDBTransactionMethods<crate::DomTypeHolder> for IDBTransaction {
-    /// <https://www.w3.org/TR/IndexedDB-2/#dom-idbtransaction-db>
+    /// <https://www.w3.org/TR/IndexedDB-3/#dom-idbtransaction-db>
     fn Db(&self) -> DomRoot<IDBDatabase> {
         DomRoot::from_ref(&*self.db)
     }
 
-    /// <https://www.w3.org/TR/IndexedDB-2/#dom-idbtransaction-objectstore>
+    /// <https://www.w3.org/TR/IndexedDB-3/#dom-idbtransaction-objectstore>
     fn ObjectStore(&self, name: DOMString, can_gc: CanGc) -> Fallible<DomRoot<IDBObjectStore>> {
         // Step 1: If transaction has finished, throw an "InvalidStateError" DOMException.
         if self.finished.get() || self.abort_initiated.get() {
@@ -685,7 +685,7 @@ impl IDBTransactionMethods<crate::DomTypeHolder> for IDBTransaction {
         Ok(store)
     }
 
-    /// <https://www.w3.org/TR/IndexedDB-2/#commit-transaction>
+    /// <https://www.w3.org/TR/IndexedDB-3/#commit-transaction>
     fn Commit(&self) -> Fallible<()> {
         // Step 1
         if self.finished.get() {
@@ -705,7 +705,7 @@ impl IDBTransactionMethods<crate::DomTypeHolder> for IDBTransaction {
         Ok(())
     }
 
-    /// <https://www.w3.org/TR/IndexedDB-2/#dom-idbtransaction-abort>
+    /// <https://www.w3.org/TR/IndexedDB-3/#dom-idbtransaction-abort>
     fn Abort(&self) -> Fallible<()> {
         if self.finished.get() || self.committing.get() {
             return Err(Error::InvalidState(None));
@@ -717,7 +717,7 @@ impl IDBTransactionMethods<crate::DomTypeHolder> for IDBTransaction {
         Ok(())
     }
 
-    /// <https://www.w3.org/TR/IndexedDB-2/#dom-idbtransaction-objectstorenames>
+    /// <https://www.w3.org/TR/IndexedDB-3/#dom-idbtransaction-objectstorenames>
     fn ObjectStoreNames(&self) -> DomRoot<DOMStringList> {
         if self.mode == IDBTransactionMode::Versionchange {
             self.db.object_stores()
@@ -726,28 +726,28 @@ impl IDBTransactionMethods<crate::DomTypeHolder> for IDBTransaction {
         }
     }
 
-    /// <https://www.w3.org/TR/IndexedDB-2/#dom-idbtransaction-mode>
+    /// <https://www.w3.org/TR/IndexedDB-3/#dom-idbtransaction-mode>
     fn Mode(&self) -> IDBTransactionMode {
         self.mode
     }
 
-    // https://www.w3.org/TR/IndexedDB-2/#dom-idbtransaction-mode
+    // https://www.w3.org/TR/IndexedDB-3/#dom-idbtransaction-mode
     // fn Durability(&self) -> IDBTransactionDurability {
     //     // FIXME:(arihant2math) Durability is not implemented at all
     //     unimplemented!();
     // }
 
-    /// <https://www.w3.org/TR/IndexedDB-2/#dom-idbtransaction-error>
+    /// <https://www.w3.org/TR/IndexedDB-3/#dom-idbtransaction-error>
     fn GetError(&self) -> Option<DomRoot<DOMException>> {
         self.error.get()
     }
 
-    // https://www.w3.org/TR/IndexedDB-2/#dom-idbtransaction-onabort
+    // https://www.w3.org/TR/IndexedDB-3/#dom-idbtransaction-onabort
     event_handler!(abort, GetOnabort, SetOnabort);
 
-    // https://www.w3.org/TR/IndexedDB-2/#dom-idbtransaction-oncomplete
+    // https://www.w3.org/TR/IndexedDB-3/#dom-idbtransaction-oncomplete
     event_handler!(complete, GetOncomplete, SetOncomplete);
 
-    // https://www.w3.org/TR/IndexedDB-2/#dom-idbtransaction-onerror
+    // https://www.w3.org/TR/IndexedDB-3/#dom-idbtransaction-onerror
     event_handler!(error, GetOnerror, SetOnerror);
 }

--- a/components/script/dom/indexeddb/idbversionchangeevent.rs
+++ b/components/script/dom/indexeddb/idbversionchangeevent.rs
@@ -145,12 +145,12 @@ impl IDBVersionChangeEventMethods<crate::DomTypeHolder> for IDBVersionChangeEven
         )
     }
 
-    /// <https://www.w3.org/TR/IndexedDB-2/#dom-idbversionchangeevent-oldversion>
+    /// <https://www.w3.org/TR/IndexedDB-3/#dom-idbversionchangeevent-oldversion>
     fn OldVersion(&self) -> u64 {
         self.old_version
     }
 
-    /// <https://www.w3.org/TR/IndexedDB-2/#dom-idbversionchangeevent-newversion>
+    /// <https://www.w3.org/TR/IndexedDB-3/#dom-idbversionchangeevent-newversion>
     fn GetNewVersion(&self) -> Option<u64> {
         self.new_version
     }

--- a/components/script/indexeddb.rs
+++ b/components/script/indexeddb.rs
@@ -35,7 +35,7 @@ use crate::dom::file::File;
 use crate::dom::idbkeyrange::IDBKeyRange;
 use crate::dom::idbobjectstore::KeyPath;
 
-// https://www.w3.org/TR/IndexedDB-2/#convert-key-to-value
+// https://www.w3.org/TR/IndexedDB-3/#convert-key-to-value
 #[expect(unsafe_code)]
 pub fn key_type_to_jsval(
     cx: &mut JSContext,
@@ -61,7 +61,7 @@ pub fn key_type_to_jsval(
     }
 }
 
-/// <https://www.w3.org/TR/IndexedDB-2/#valid-key-path>
+/// <https://www.w3.org/TR/IndexedDB-3/#valid-key-path>
 pub(crate) fn is_valid_key_path(
     cx: &mut JSContext,
     key_path: &StrOrStringSequence,
@@ -135,7 +135,7 @@ impl ConversionResult {
     }
 }
 
-// https://www.w3.org/TR/IndexedDB-2/#convert-value-to-key
+// https://www.w3.org/TR/IndexedDB-3/#convert-value-to-key
 #[expect(unsafe_code)]
 pub fn convert_value_to_key(
     cx: &mut JSContext,
@@ -238,7 +238,7 @@ pub fn convert_value_to_key(
     Ok(ConversionResult::Invalid)
 }
 
-/// <https://www.w3.org/TR/IndexedDB-2/#convert-a-value-to-a-key-range>
+/// <https://www.w3.org/TR/IndexedDB-3/#convert-a-value-to-a-key-range>
 #[expect(unsafe_code)]
 pub fn convert_value_to_key_range(
     cx: &mut JSContext,
@@ -296,13 +296,13 @@ pub(crate) fn map_backend_error_to_dom_error(error: BackendError) -> Error {
 }
 
 /// The result of steps in
-/// <https://www.w3.org/TR/IndexedDB-2/#evaluate-a-key-path-on-a-value>
+/// <https://www.w3.org/TR/IndexedDB-3/#evaluate-a-key-path-on-a-value>
 pub(crate) enum EvaluationResult {
     Success,
     Failure,
 }
 
-/// <https://www.w3.org/TR/IndexedDB-2/#evaluate-a-key-path-on-a-value>
+/// <https://www.w3.org/TR/IndexedDB-3/#evaluate-a-key-path-on-a-value>
 #[expect(unsafe_code)]
 pub(crate) fn evaluate_key_path_on_value(
     cx: &mut JSContext,
@@ -515,14 +515,14 @@ pub(crate) fn evaluate_key_path_on_value(
 }
 
 /// The result of steps in
-/// <https://www.w3.org/TR/IndexedDB-2/#extract-a-key-from-a-value-using-a-key-path>
+/// <https://www.w3.org/TR/IndexedDB-3/#extract-a-key-from-a-value-using-a-key-path>
 pub(crate) enum ExtractionResult {
     Key(IndexedDBKeyType),
     Invalid,
     Failure,
 }
 
-/// <https://www.w3.org/TR/IndexedDB-2/#extract-a-key-from-a-value-using-a-key-path>
+/// <https://www.w3.org/TR/IndexedDB-3/#extract-a-key-from-a-value-using-a-key-path>
 pub(crate) fn extract_key(
     cx: &mut JSContext,
     value: HandleValue,

--- a/components/shared/storage/indexeddb.rs
+++ b/components/shared/storage/indexeddb.rs
@@ -64,7 +64,7 @@ pub enum KeyPath {
     Sequence(Vec<String>),
 }
 
-// https://www.w3.org/TR/IndexedDB-2/#enumdef-idbtransactionmode
+// https://www.w3.org/TR/IndexedDB-3/#enumdef-idbtransactionmode
 #[derive(Clone, Debug, Deserialize, Eq, MallocSizeOf, PartialEq, Serialize)]
 pub enum IndexedDBTxnMode {
     Readonly,
@@ -72,7 +72,7 @@ pub enum IndexedDBTxnMode {
     Versionchange,
 }
 
-/// <https://www.w3.org/TR/IndexedDB-2/#key-type>
+/// <https://www.w3.org/TR/IndexedDB-3/#key-type>
 #[derive(Clone, Debug, Deserialize, MallocSizeOf, Serialize)]
 pub enum IndexedDBKeyType {
     Number(f64),
@@ -83,7 +83,7 @@ pub enum IndexedDBKeyType {
     // FIXME:(arihant2math) implment ArrayBuffer
 }
 
-/// <https://www.w3.org/TR/IndexedDB-2/#compare-two-keys>
+/// <https://www.w3.org/TR/IndexedDB-3/#compare-two-keys>
 impl PartialOrd for IndexedDBKeyType {
     fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
         // 1. Let ta be the type of a.
@@ -163,7 +163,7 @@ impl PartialEq for IndexedDBKeyType {
     }
 }
 
-// <https://www.w3.org/TR/IndexedDB-2/#key-range>
+// <https://www.w3.org/TR/IndexedDB-3/#key-range>
 #[derive(Clone, Debug, Default, Deserialize, MallocSizeOf, Serialize)]
 pub struct IndexedDBKeyRange {
     pub lower: Option<IndexedDBKeyType>,
@@ -219,7 +219,7 @@ impl IndexedDBKeyRange {
         }
     }
 
-    // <https://www.w3.org/TR/IndexedDB-2/#in>
+    // <https://www.w3.org/TR/IndexedDB-3/#in>
     pub fn contains(&self, key: &IndexedDBKeyType) -> bool {
         // A key is in a key range if both of the following conditions are fulfilled:
         // The lower bound is null, or it is less than key,

--- a/components/storage/indexeddb/mod.rs
+++ b/components/storage/indexeddb/mod.rs
@@ -620,7 +620,7 @@ enum OpenRequest {
         /// <https://w3c.github.io/IndexedDB/#request-processed-flag>
         processed: bool,
 
-        /// Optionnaly, a version pending upgrade.
+        /// Optionally, a version pending upgrade.
         pending_upgrade: Option<VersionUpgrade>,
 
         /// This request is pending on these connections to close.

--- a/components/storage/indexeddb/mod.rs
+++ b/components/storage/indexeddb/mod.rs
@@ -617,8 +617,10 @@ enum OpenRequest {
         /// Note: when the open algorithm starts, this will be mutated and set to something as per the algo.
         version: Option<u64>,
 
+        /// <https://w3c.github.io/IndexedDB/#request-processed-flag>
+        processed: bool,
+
         /// Optionnaly, a version pending upgrade.
-        /// Used as <https://w3c.github.io/IndexedDB/#request-processed-flag>
         pending_upgrade: Option<VersionUpgrade>,
 
         /// This request is pending on these connections to close.
@@ -659,6 +661,7 @@ impl OpenRequest {
                 sender: _,
                 db_name: _,
                 version: _,
+                processed: _,
                 pending_upgrade: _,
                 pending_close: _,
                 pending_versionchange: _,
@@ -681,6 +684,7 @@ impl OpenRequest {
                 sender: _,
                 db_name: _,
                 version: _,
+                processed: _,
                 pending_upgrade: _,
                 pending_close: _,
                 pending_versionchange: _,
@@ -696,20 +700,22 @@ impl OpenRequest {
         }
     }
 
-    /// An open request can be pending either an upgrade,
-    /// or the closing of other connections.
+    /// An open request remains pending until it has been processed,
+    /// and while waiting on upgrade completion or other connections.
     fn is_pending(&self) -> bool {
         match self {
             OpenRequest::Open {
                 sender: _,
                 db_name: _,
                 version: _,
+                processed,
                 pending_upgrade,
                 pending_close,
                 pending_versionchange,
                 id: _,
             } => {
-                pending_upgrade.is_some() ||
+                !processed ||
+                    pending_upgrade.is_some() ||
                     !pending_close.is_empty() ||
                     !pending_versionchange.is_empty()
             },
@@ -731,6 +737,7 @@ impl OpenRequest {
                 sender,
                 db_name,
                 version: _,
+                processed: _,
                 pending_close: _,
                 pending_versionchange: _,
                 pending_upgrade,
@@ -1009,6 +1016,7 @@ impl IndexedDBManager {
                 sender,
                 db_name,
                 version: _,
+                processed: _,
                 pending_upgrade: Some(pending_upgrade),
                 pending_close: _,
                 pending_versionchange: _,
@@ -1255,6 +1263,7 @@ impl IndexedDBManager {
             sender,
             db_name,
             version,
+            processed: false,
             pending_close: Default::default(),
             pending_versionchange: Default::default(),
             pending_upgrade: None,
@@ -1316,6 +1325,7 @@ impl IndexedDBManager {
             sender,
             db_name,
             version: _,
+            processed,
             id,
             pending_close: _,
             pending_versionchange: _,
@@ -1358,6 +1368,7 @@ impl IndexedDBManager {
             .expect("Setting the version should not fail");
 
         // Step 9: Set request’s processed flag to true.
+        *processed = true;
         let _ = pending_upgrade.insert(VersionUpgrade {
             old: old_version,
             new: new_version,
@@ -1407,6 +1418,7 @@ impl IndexedDBManager {
                 version,
                 id,
                 pending_upgrade: _,
+                processed: _,
                 pending_versionchange,
                 pending_close,
             } = open_request
@@ -1481,6 +1493,7 @@ impl IndexedDBManager {
             db_name,
             version,
             id,
+            processed,
             pending_upgrade: _pending_upgrade,
             pending_close,
             pending_versionchange,
@@ -1517,6 +1530,7 @@ impl IndexedDBManager {
                         }) {
                             debug!("Script exit during indexeddb database open {:?}", e);
                         }
+                        *processed = true;
                         return;
                     },
                 };
@@ -1533,6 +1547,7 @@ impl IndexedDBManager {
                         }) {
                             debug!("Script exit during indexeddb database open {:?}", e);
                         }
+                        *processed = true;
                         return;
                     },
                 };
@@ -1558,6 +1573,7 @@ impl IndexedDBManager {
                         }) {
                             debug!("Script exit during indexeddb database open {:?}", e);
                         }
+                        *processed = true;
                         return;
                     },
                 };
@@ -1587,6 +1603,7 @@ impl IndexedDBManager {
             {
                 debug!("Script exit during indexeddb database open");
             }
+            *processed = true;
             return;
         }
 
@@ -1636,6 +1653,7 @@ impl IndexedDBManager {
         }
 
         // Step 11:
+        *processed = true;
         if sender
             .send(ConnectionMsg::Connection {
                 name: db_name.clone(),
@@ -1719,6 +1737,7 @@ impl IndexedDBManager {
             // Step 10: Let version be db’s version.
             let res = db.version();
             let Ok(version) = res else {
+                *processed = true;
                 if sender
                     .send(BackendResult::Err(BackendError::DbErr(
                         res.unwrap_err().to_string(),
@@ -1734,6 +1753,7 @@ impl IndexedDBManager {
             // If this fails for any reason,
             // return an appropriate error (e.g. a QuotaExceededError, or an "UnknownError" DOMException).
             if let Err(err) = db.delete_database() {
+                *processed = true;
                 if sender
                     .send(BackendResult::Err(BackendError::DbErr(err.to_string())))
                     .is_err()
@@ -1789,6 +1809,7 @@ impl IndexedDBManager {
                 db_name: _,
                 version,
                 id: _,
+                processed: _,
                 pending_upgrade,
                 pending_versionchange,
                 pending_close,


### PR DESCRIPTION
This changes does three things:
 - Updates all specification links to reflect version 3 of the specification
 - Renames the `IDBDatabase::close` member to `IDBDatabase::close_pending` to better match the specification
 - Adds a `OpenRequest::processed` member, again to better match the specification

Testing: This should not change behavior, so is covered by existing IndexedDB WPT tests.
Fixes: Part of #40983
