### PR TITLE
layout: Let `OutsideMarker` store an `IndependentFormattingContext`

### DIFF
--- a/components/layout/flow/construct.rs
+++ b/components/layout/flow/construct.rs
@@ -25,7 +25,9 @@ use crate::dom_traversal::{
 };
 use crate::flow::float::FloatBox;
 use crate::flow::{BlockContainer, BlockFormattingContext, BlockLevelBox};
-use crate::formatting_contexts::IndependentFormattingContext;
+use crate::formatting_contexts::{
+    IndependentFormattingContext, IndependentFormattingContextContents,
+};
 use crate::fragment_tree::FragmentFlags;
 use crate::layout_box_base::LayoutBoxBase;
 use crate::positioned::AbsolutelyPositionedBox;
@@ -772,8 +774,11 @@ impl BlockLevelJob<'_> {
                     contains_floats: false,
                 };
                 ArcRefCell::new(BlockLevelBox::OutsideMarker(OutsideMarker {
-                    base: LayoutBoxBase::new(info.into(), info.style.clone()),
-                    block_formatting_context,
+                    context: IndependentFormattingContext::new(
+                        LayoutBoxBase::new(info.into(), info.style.clone()),
+                        IndependentFormattingContextContents::Flow(block_formatting_context),
+                        self.propagated_data,
+                    ),
                     list_item_style,
                 }))
             },

--- a/components/layout/lib.rs
+++ b/components/layout/lib.rs
@@ -76,13 +76,6 @@ impl<'a> ConstraintSpace<'a> {
             preferred_aspect_ratio,
         }
     }
-
-    fn new_for_style_and_ratio(
-        style: &'a ComputedValues,
-        preferred_aspect_ratio: Option<AspectRatio>,
-    ) -> Self {
-        Self::new(SizeConstraint::default(), style, preferred_aspect_ratio)
-    }
 }
 
 /// A variant of [`ContainingBlock`] that allows an indefinite inline size.

--- a/tests/wpt/tests/css/CSS2/lists/list-item-dynamic-color-ref.html
+++ b/tests/wpt/tests/css/CSS2/lists/list-item-dynamic-color-ref.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<title>CSS Reference: list item with dynamically changing `color`</title>
+<link rel="author" title="Oriol Brufau" href="mailto:obrufau@igalia.com">
+
+<link rel="stylesheet" type="text/css" href="/fonts/ahem.css">
+<style>
+ol {
+  padding-left: 160px;
+}
+li {
+  font: 64px/1 Ahem;
+  list-style-type: square;
+  color: green;
+}
+</style>
+
+<p>Test passes if there are 2 filled green squares and <strong>no red</strong>.</p>
+<ol>
+  <li>X</li>
+</ol>

--- a/tests/wpt/tests/css/CSS2/lists/list-item-dynamic-color.html
+++ b/tests/wpt/tests/css/CSS2/lists/list-item-dynamic-color.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<html class="reftest-wait">
+<title>CSS Test: list item with dynamically changing `color`</title>
+<link rel="author" title="Oriol Brufau" href="mailto:obrufau@igalia.com">
+<link rel="help" href="http://www.w3.org/TR/CSS21/generate.html#lists">
+<link rel="match" href="list-item-dynamic-color-ref.html">
+
+<link rel="stylesheet" type="text/css" href="/fonts/ahem.css">
+<style>
+ol {
+  padding-left: 160px;
+}
+li {
+  font: 64px/1 Ahem;
+  list-style-type: square;
+  color: red;
+}
+</style>
+
+<p>Test passes if there are 2 filled green squares and <strong>no red</strong>.</p>
+<ol>
+  <li id="target">X</li>
+</ol>
+
+<script src="/common/reftest-wait.js"></script>
+<script>
+requestAnimationFrame(() => requestAnimationFrame(() => {
+  document.getElementById("target").style.color = "green";
+  takeScreenshot();
+}));
+</script>
+</html>


### PR DESCRIPTION
`OutsideMarker` was storing the `BlockFormattingContext` and the `LayoutBoxBase` in separate fields. Now it will store an entire `IndependentFormattingContext` in a single field.

In particular, this fixes the issue that `OutsideMarker::repair_style()` wasn't calling `BlockFormattingContext::repair_style()`. Now we can just rely on `IndependentFormattingContext::repair_style()`, which correctly repairs the style of both the `BlockFormattingContext` and the `LayoutBoxBase`.

Also, the `BlockLevelBox::repair_style()` was repairing the style of the `LayoutBoxBase` twice, for all kinds of block-level boxes. This removes the duplication.

Testing: Adding a new test
Fixes: #42779
