### PR TITLE
layout: Preserve independent formatting contexts fragment caches when undamaged

### DIFF
--- a/components/layout/dom.rs
+++ b/components/layout/dom.rs
@@ -521,6 +521,15 @@ impl<'dom> NodeExt<'dom> for ServoThreadSafeLayoutNode<'dom> {
     }
 
     fn isolates_damage_for_damage_propagation(&self) -> bool {
+        // Do not run incremental box and fragment tree layout at the `<body>` or root element as
+        // there is some special processing that must happen for these elements and it currently
+        // only happens when doing a full box tree construction traversal.
+        if self.as_element().is_some_and(|element| {
+            element.is_body_element_of_html_element_root() || element.is_root()
+        }) {
+            return false;
+        }
+
         let Some(inner_layout_data) = self.inner_layout_data() else {
             return false;
         };

--- a/components/layout/traversal.rs
+++ b/components/layout/traversal.rs
@@ -191,7 +191,7 @@ pub(crate) fn compute_damage_and_rebuild_box_tree_inner(
         )
     };
 
-    let element_and_parent_damage = element_damage | damage_from_parent;
+    let mut element_and_parent_damage = element_damage | damage_from_parent;
     if is_display_none {
         node.unset_all_boxes();
         return element_and_parent_damage;
@@ -208,7 +208,7 @@ pub(crate) fn compute_damage_and_rebuild_box_tree_inner(
             !node.isolates_damage_for_damage_propagation());
     if rebuild_children {
         damage_for_children.insert(LayoutDamage::box_damage());
-    } else if damage_for_children.contains(RestyleDamage::RELAYOUT) &&
+    } else if element_and_parent_damage.contains(RestyleDamage::RELAYOUT) &&
         !element_damage.contains(RestyleDamage::RELAYOUT) &&
         node.isolates_damage_for_damage_propagation()
     {
@@ -216,6 +216,7 @@ pub(crate) fn compute_damage_and_rebuild_box_tree_inner(
         // only because of an ancestor, fragment layout caches should still be valid when
         // crossing down into new independent formatting contexts.
         damage_for_children.remove(RestyleDamage::RELAYOUT);
+        element_and_parent_damage.remove(RestyleDamage::RELAYOUT);
     }
 
     let mut damage_from_children = RestyleDamage::empty();

--- a/tests/wpt/mozilla/meta/MANIFEST.json
+++ b/tests/wpt/mozilla/meta/MANIFEST.json
@@ -13033,7 +13033,7 @@
    },
    "incremental-layout": {
     "basic-fragment-tree-layout.html": [
-     "f249b241dd97d20295efd923d77a12fac873a911",
+     "9cdf3e36941658512926988e3d9e467cabd3087d",
      [
       null,
       {}

--- a/tests/wpt/mozilla/tests/incremental-layout/basic-fragment-tree-layout.html
+++ b/tests/wpt/mozilla/tests/incremental-layout/basic-fragment-tree-layout.html
@@ -75,9 +75,8 @@ window.onload = () => {
         // - #div1
         // - #div2
         // - #div2 > #section2
-        // - #div2 > #section2 > #p2
         // - #div3
-        assert_equals(result.rebuiltFragmentCount, 7, "rebuiltFragmentCount");
+        assert_equals(result.rebuiltFragmentCount, 6, "rebuiltFragmentCount");
         assert_equals(result.restyleFragmentCount, 0, "restyleFragmentCount");
     }, "Updating div2's width property rebuilds some fragments");
 
@@ -117,8 +116,7 @@ window.onload = () => {
         // - #div2
         // - #div3
         // - #div3 > #section3
-        // - #div3 > #section3 > #p3
-        assert_equals(result.rebuiltFragmentCount, 7, "rebuiltFragmentCount");
+        assert_equals(result.rebuiltFragmentCount, 6, "rebuiltFragmentCount");
         assert_equals(result.restyleFragmentCount, 0, "restyleFragmentCount");
     }, "Updating div3's height property rebuilds some fragments");
 


### PR DESCRIPTION
When fragment tree layout is going to run for a node that starts an
independent formatting context, but only because an ancestor was
damaged, preserve the fragment cache. This means that in the optimistic
case we do not need to re-run fragment tree layout for this independent
formatting context. Previously this was only done for the children of
the independent formatting context, but the fragment cache is robust
enough to detect any layout changes necessary for the IFC fragment
itself as well. This helps to avoid so much fragment reconstruction
during incremental layout.

Testing: `basic-fragment-tree-layout.html` is updated reflecting the decrease
in the number of fragments rebuilt.
