### PR TITLE
CI: Free more disk space in android workflow

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -46,9 +46,8 @@ jobs:
       - name: Free Disk Space (Ubuntu)
         uses: jlumbroso/free-disk-space@main
         with:
-          tool-cache: false
+          tool-cache: true
           android: false
-          large-packages: false
           swap-storage: false
       - uses: actions/checkout@v5
         if: github.event_name != 'pull_request_target'


### PR DESCRIPTION
Before we freed 6GB now we free 19GB.

Fixes: #42857 (hopefully)
