### PR TITLE
devtools: Make `why` attribute use `PauseReasons`

### DIFF
--- a/components/devtools/actors/thread.rs
+++ b/components/devtools/actors/thread.rs
@@ -6,7 +6,7 @@ use std::collections::HashSet;
 
 use atomic_refcell::AtomicRefCell;
 use base::generic_channel::GenericSender;
-use devtools_traits::DevtoolScriptControlMsg;
+use devtools_traits::{DevtoolScriptControlMsg, PauseReason};
 use malloc_size_of_derive::MallocSizeOf;
 use serde::Serialize;
 use serde_json::{Map, Value};
@@ -30,20 +30,11 @@ struct ThreadAttached {
     recording_endpoint: u32,
     execution_point: u32,
     popped_frames: Vec<PoppedFrameMsg>,
-    why: WhyMsg,
+    why: PauseReason,
 }
 
 #[derive(Serialize)]
 enum PoppedFrameMsg {}
-
-#[derive(Serialize)]
-#[serde(rename_all = "camelCase")]
-pub(crate) struct WhyMsg {
-    #[serde(rename = "type")]
-    pub type_: String,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub on_next: Option<bool>,
-}
 
 #[derive(Serialize)]
 struct ThreadResumedReply {
@@ -59,7 +50,7 @@ pub(crate) struct ThreadInterruptedReply {
     pub type_: String,
     pub actor: String,
     pub frame: FrameActorMsg,
-    pub why: WhyMsg,
+    pub why: PauseReason,
 }
 
 #[derive(Serialize)]
@@ -121,7 +112,7 @@ impl Actor for ThreadActor {
                     recording_endpoint: 0,
                     execution_point: 0,
                     popped_frames: vec![],
-                    why: WhyMsg {
+                    why: PauseReason {
                         type_: "attached".to_owned(),
                         on_next: None,
                     },

--- a/components/script_bindings/webidls/DebuggerInterruptEvent.webidl
+++ b/components/script_bindings/webidls/DebuggerInterruptEvent.webidl
@@ -11,11 +11,16 @@ partial interface DebuggerGlobalScope {
     undefined pauseAndRespond(
         PipelineIdInit pipelineId,
         DOMString frameActorId,
-        boolean isBreakpoint);
+        PauseReason pauseReason);
 
     DOMString? registerFrameActor(
         PipelineIdInit pipelineId,
         FrameInfo result);
+};
+
+dictionary PauseReason {
+    required DOMString type_;
+    boolean onNext;
 };
 
 dictionary FrameInfo {

--- a/components/shared/devtools/lib.rs
+++ b/components/shared/devtools/lib.rs
@@ -133,7 +133,7 @@ pub enum ScriptToDevtoolsControlMsg {
     DomMutation(PipelineId, DomMutation),
 
     /// The debugger is paused, sending frame information.
-    DebuggerPause(PipelineId, String, bool),
+    DebuggerPause(PipelineId, String, PauseReason),
 
     /// Get frame information from script
     CreateFrameActor(GenericSender<String>, PipelineId, FrameInfo),
@@ -588,4 +588,12 @@ pub struct FrameInfo {
 pub struct EventListenerInfo {
     pub event_type: String,
     pub capturing: bool,
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct PauseReason {
+    #[serde(rename = "type")]
+    pub type_: String,
+    pub on_next: Option<bool>,
 }


### PR DESCRIPTION
devtools: Make `why` attribute use `PauseReasons`

Currently we have why attribute hardcoded as per the event. In this PR we introduce `PAUSE_REASON` and make sure `why` attribute is using `PAUSE_REASONS`.

This is in order to support the upcoming work on `onStep`, `onPop`, and `onEnterFrame` hook.

Testing: all existing tests are passing
Fixes: Part of #36027