### PR TITLE
script: use `&mut JSContext` in `MessagePort::PostMessage`

### DIFF
--- a/components/script_bindings/codegen/Bindings.conf
+++ b/components/script_bindings/codegen/Bindings.conf
@@ -603,6 +603,7 @@ DOMInterfaces = {
 'MessagePort': {
     'weakReferenceable': True,
     'canGc': ['Close', 'GetOnmessage', 'SetOnmessage', 'Start'],
+    'cx': ['PostMessage', 'PostMessage_']
 },
 
 'MessageEvent': {


### PR DESCRIPTION
Replace crate::script_runtime::JSContext with js::context::JSContext in `MessagePort::PostMessage`

Testing: Builds and runs fine
Fixes: part of https://github.com/servo/servo/issues/42347
