### PR TITLE
script: Incubent global should always be available when called

### DIFF
--- a/components/script/dom/bindings/settings_stack.rs
+++ b/components/script/dom/bindings/settings_stack.rs
@@ -49,7 +49,7 @@ pub type AutoIncumbentScript = GenericAutoIncumbentScript<crate::DomTypeHolder>;
 /// Returns the ["incumbent"] global object.
 ///
 /// ["incumbent"]: https://html.spec.whatwg.org/multipage/#incumbent
-pub(crate) fn incumbent_global() -> Option<DomRoot<GlobalScope>> {
+pub(crate) fn incumbent_global() -> DomRoot<GlobalScope> {
     // https://html.spec.whatwg.org/multipage/#incumbent-settings-object
 
     // Step 1, 3: See what the JS engine has to say. If we've got a scripted
@@ -57,14 +57,10 @@ pub(crate) fn incumbent_global() -> Option<DomRoot<GlobalScope>> {
     // there's nothing on the JS stack, which will cause us to check the
     // incumbent script stack below.
     unsafe {
-        let Some(cx) = Runtime::get() else {
-            // It's not meaningful to return a global object if the runtime
-            // no longer exists.
-            return None;
-        };
+        let cx = Runtime::get().unwrap();
         let global = GetScriptedCallerGlobal(cx.as_ptr());
         if !global.is_null() {
-            return Some(GlobalScope::from_object(global));
+            return GlobalScope::from_object(global);
         }
     }
 
@@ -74,5 +70,6 @@ pub(crate) fn incumbent_global() -> Option<DomRoot<GlobalScope>> {
             .borrow()
             .last()
             .map(|entry| DomRoot::from_ref(&*entry.global))
+            .unwrap()
     })
 }

--- a/components/script/dom/dissimilaroriginwindow.rs
+++ b/components/script/dom/dissimilaroriginwindow.rs
@@ -223,10 +223,7 @@ impl DissimilarOriginWindow {
         // Step 1.
         let target = self.window_proxy.browsing_context_id();
         // Step 2.
-        let incumbent = match GlobalScope::incumbent() {
-            None => panic!("postMessage called with no incumbent global"),
-            Some(incumbent) => incumbent,
-        };
+        let incumbent = GlobalScope::incumbent();
 
         let source_origin = incumbent.origin().immutable().clone();
 

--- a/components/script/dom/eventtarget.rs
+++ b/components/script/dom/eventtarget.rs
@@ -20,10 +20,12 @@ use js::rust::{CompileOptionsWrapper, HandleObject, transform_u16_to_source_text
 use libc::c_char;
 use rustc_hash::FxBuildHasher;
 use script_bindings::cformat;
+use script_bindings::settings_stack::StackEntryKind;
 use servo_url::ServoUrl;
 use style::str::HTML_SPACE_CHARACTERS;
 use stylo_atoms::Atom;
 
+use crate::DomTypeHolder;
 use crate::conversions::Convert;
 use crate::dom::abortsignal::{AbortAlgorithm, RemovableDomEventListener};
 use crate::dom::beforeunloadevent::BeforeUnloadEvent;
@@ -739,19 +741,29 @@ impl EventTarget {
             .and_then(|e| e.as_maybe_form_control())
             .and_then(|f| f.form_owner());
 
-        // Step 3.6 TODO: settings objects not implemented
+        // Step 3.6 Let settings object be the relevant settings object of document.
+        let global = document.global();
 
         // Step 3.7 is written as though we call the parser separately
         // from the compiler; since we just call CompileFunction with
         // source text, we handle parse errors later
 
-        // Step 3.8 TODO: settings objects not implemented
-        let window = document.window();
-        let _ac = enter_realm(window);
+        // Step 3.8 Push settings object's realm execution context onto the JavaScript execution context stack; it is now the running JavaScript execution context.
+        let realm = enter_realm(&*global);
+        let settings_stack = <DomTypeHolder as script_bindings::interfaces::DomHelpers<
+            DomTypeHolder,
+        >>::settings_stack();
+        settings_stack.with(|stack| {
+            let mut stack = stack.borrow_mut();
+            stack.push(script_bindings::settings_stack::StackEntry {
+                global: Dom::from_ref(&global),
+                kind: script_bindings::settings_stack::StackEntryKind::Entry,
+            });
+        });
 
         // Step 3.9
 
-        let name = CString::new(format!("on{}", &**ty)).unwrap();
+        let name = CString::new(std::format!("on{}", &**ty)).unwrap();
 
         // Step 3.9, subsection ParameterList
         const ARG_NAMES: &[*const c_char] = &[c"event".as_ptr()];
@@ -780,7 +792,7 @@ impl EventTarget {
             scopechain.append(element.reflector().get_jsobject().get());
         }
 
-        rooted!(in(*cx) let mut handler = unsafe {
+        js::rooted!(in(*cx) let mut handler = unsafe {
             CompileFunction(
                 *cx,
                 scopechain.get(),
@@ -799,7 +811,16 @@ impl EventTarget {
             return None;
         }
 
-        // Step 3.10 happens when we drop _ac
+        settings_stack.with(|stack| {
+            let mut stack = stack.borrow_mut();
+            let entry = stack.pop().unwrap();
+            std::assert_eq!(
+                &*entry.global as *const GlobalScope,
+                &*global as *const GlobalScope,
+            );
+            std::assert_eq!(entry.kind, StackEntryKind::Entry);
+        });
+        drop(realm); // Step 3.10 happens when we drop _ac
 
         // TODO Step 3.11
 

--- a/components/script/dom/globalscope.rs
+++ b/components/script/dom/globalscope.rs
@@ -3055,7 +3055,7 @@ impl GlobalScope {
     /// Returns the ["incumbent"] global object.
     ///
     /// ["incumbent"]: https://html.spec.whatwg.org/multipage/#incumbent
-    pub(crate) fn incumbent() -> Option<DomRoot<Self>> {
+    pub(crate) fn incumbent() -> DomRoot<Self> {
         incumbent_global()
     }
 
@@ -3591,7 +3591,7 @@ impl GlobalScopeHelpers<crate::DomTypeHolder> for GlobalScope {
         GlobalScope::origin(self)
     }
 
-    fn incumbent() -> Option<DomRoot<Self>> {
+    fn incumbent() -> DomRoot<Self> {
         GlobalScope::incumbent()
     }
 

--- a/components/script/dom/location.rs
+++ b/components/script/dom/location.rs
@@ -67,7 +67,7 @@ impl Location {
         let navigable = &self.window;
         let navigable_document = navigable.Document();
         // Step 2. Let sourceDocument be the incumbent global object's associated Document.
-        let incumbent_global = GlobalScope::incumbent().expect("no incumbent global object");
+        let incumbent_global = GlobalScope::incumbent();
         let mut load_data = incumbent_global
             .as_window()
             .load_data_for_document(url, navigable.pipeline_id());
@@ -98,7 +98,7 @@ impl Location {
         can_gc: CanGc,
     ) {
         fn incumbent_window() -> DomRoot<Window> {
-            let incumbent_global = GlobalScope::incumbent().expect("no incumbent global object");
+            let incumbent_global = GlobalScope::incumbent();
             DomRoot::downcast(incumbent_global).expect("global object is not a Window")
         }
 

--- a/components/script/dom/messageport.rs
+++ b/components/script/dom/messageport.rs
@@ -157,10 +157,7 @@ impl MessagePort {
 
         // Step 6, done in MessagePortImpl.
 
-        let incumbent = match GlobalScope::incumbent() {
-            None => unreachable!("postMessage called with no incumbent global"),
-            Some(incumbent) => incumbent,
-        };
+        let incumbent = GlobalScope::incumbent();
 
         // Step 7
         let task = PortMessageTask {

--- a/components/script/dom/testing/testbinding.rs
+++ b/components/script/dom/testing/testbinding.rs
@@ -1074,7 +1074,7 @@ impl TestBindingMethods<crate::DomTypeHolder> for TestBinding {
         GlobalScope::entry()
     }
     fn IncumbentGlobal(&self) -> DomRoot<GlobalScope> {
-        GlobalScope::incumbent().unwrap()
+        GlobalScope::incumbent()
     }
 
     fn SemiExposedBoolFromInterface(&self) -> bool {

--- a/components/script/dom/window.rs
+++ b/components/script/dom/window.rs
@@ -1721,7 +1721,7 @@ impl WindowMethods<crate::DomTypeHolder> for Window {
         target_origin: USVString,
         transfer: CustomAutoRooterGuard<Vec<*mut JSObject>>,
     ) -> ErrorResult {
-        let incumbent = GlobalScope::incumbent().expect("no incumbent global?");
+        let incumbent = GlobalScope::incumbent();
         let source = incumbent.as_window();
         let source_origin = source.Document().origin().immutable().clone();
 
@@ -1746,7 +1746,7 @@ impl WindowMethods<crate::DomTypeHolder> for Window {
         #[expect(unsafe_code)]
         let transfer = unsafe { CustomAutoRooterGuard::new(cx.raw_cx(), &mut rooted) };
 
-        let incumbent = GlobalScope::incumbent().expect("no incumbent global?");
+        let incumbent = GlobalScope::incumbent();
         let source = incumbent.as_window();
 
         let source_origin = source.Document().origin().immutable().clone();

--- a/components/script/dom/workers/serviceworker.rs
+++ b/components/script/dom/workers/serviceworker.rs
@@ -105,7 +105,7 @@ impl ServiceWorker {
         }
         // Step 7
         let data = structuredclone::write(cx.into(), message, Some(transfer))?;
-        let incumbent = GlobalScope::incumbent().expect("no incumbent global?");
+        let incumbent = GlobalScope::incumbent();
         let msg_vec = DOMMessage {
             origin: incumbent.origin().immutable().clone(),
             data,

--- a/components/script/script_runtime.rs
+++ b/components/script/script_runtime.rs
@@ -276,10 +276,7 @@ unsafe extern "C" fn get_host_defined_data(
     data: MutableHandleObject,
 ) -> bool {
     wrap_panic(&mut || {
-        let Some(incumbent_global) = GlobalScope::incumbent() else {
-            data.set(ptr::null_mut());
-            return;
-        };
+        let incumbent_global = GlobalScope::incumbent();
 
         let _realm = enter_realm(&*incumbent_global);
 

--- a/components/script_bindings/callback.rs
+++ b/components/script_bindings/callback.rs
@@ -66,15 +66,8 @@ pub struct CallbackObject<D: DomTypes> {
     /// The ["callback context"], that is, the global to use as incumbent
     /// global when calling the callback.
     ///
-    /// Looking at the WebIDL standard, it appears as though there would always
-    /// be a value here, but [sometimes] callback functions are created by
-    /// hand-waving without defining the value of the callback context, and
-    /// without any JavaScript code on the stack to grab an incumbent global
-    /// from.
-    ///
     /// ["callback context"]: https://heycam.github.io/webidl/#dfn-callback-context
-    /// [sometimes]: https://github.com/whatwg/html/issues/2248
-    incumbent: Option<Dom<D::GlobalScope>>,
+    incumbent: Dom<D::GlobalScope>,
 }
 
 impl<D: DomTypes> CallbackObject<D> {
@@ -84,7 +77,7 @@ impl<D: DomTypes> CallbackObject<D> {
         Self {
             callback: Heap::default(),
             permanent_js_root: Heap::default(),
-            incumbent: D::GlobalScope::incumbent().map(|i| Dom::from_ref(&*i)),
+            incumbent: Dom::from_ref(&*D::GlobalScope::incumbent()),
         }
     }
 
@@ -141,8 +134,8 @@ pub trait CallbackContainer<D: DomTypes> {
     /// incumbent global when calling the callback.
     ///
     /// ["callback context"]: https://heycam.github.io/webidl/#dfn-callback-context
-    fn incumbent(&self) -> Option<&D::GlobalScope> {
-        self.callback_holder().incumbent.as_deref()
+    fn incumbent(&self) -> &D::GlobalScope {
+        &self.callback_holder().incumbent
     }
 }
 
@@ -275,9 +268,7 @@ pub fn call_setup<D: DomTypes, T: CallbackContainer<D>, R>(
     // Step 8: Prepare to run script with relevant settings.
     run_a_script::<D, R>(global, move || {
         // Step 9: Prepare to run a callback with stored settings.
-        let ais = callback
-            .incumbent()
-            .map(GenericAutoIncumbentScript::<D>::new);
+        let ais = GenericAutoIncumbentScript::<D>::new(callback.incumbent());
         let old_realm = unsafe { EnterRealm(*cx, callback.callback()) };
         let r = f(cx);
         unsafe {

--- a/components/script_bindings/codegen/codegen.py
+++ b/components/script_bindings/codegen/codegen.py
@@ -3616,7 +3616,7 @@ class CGCollectJSONAttributesMethod(CGAbstractMethod):
         self.toJSONMethod = toJSONMethod
 
     def definition_body(self) -> CGThing:
-        ret = """let incumbent_global = D::GlobalScope::incumbent().expect("no incumbent global");
+        ret = """let incumbent_global = D::GlobalScope::incumbent();
 let global = incumbent_global.reflector().get_jsobject();\n"""
         interface = self.descriptor.interface
         for m in interface.members:

--- a/components/script_bindings/interfaces.rs
+++ b/components/script_bindings/interfaces.rs
@@ -79,7 +79,7 @@ pub trait GlobalScopeHelpers<D: DomTypes> {
 
     fn origin(&self) -> &MutableOrigin;
 
-    fn incumbent() -> Option<DomRoot<D::GlobalScope>>;
+    fn incumbent() -> DomRoot<D::GlobalScope>;
 
     fn perform_a_microtask_checkpoint(&self, cx: &mut js::context::JSContext);
 


### PR DESCRIPTION
This comment in code is stale:

https://github.com/servo/servo/blob/e61ad2775e0932873e27d54b3a649572f89cea25/components/script_bindings/callback.rs#L69-L77

as linked https://github.com/whatwg/html/issues/2248 is now resolved by https://github.com/alice/html/commit/aadbfc8f689079f9ce87e7b4f016c8ebfc3251d9.

Furthermore spec now contains assert in [incumbent settings object](https://html.spec.whatwg.org/multipage/webappapis.html#incumbent-settings-object) in cases browser/spec writter do not properly set settings stack, with this note:

> This assert would fail if you try to obtain the [incumbent settings object](https://html.spec.whatwg.org/multipage/webappapis.html#incumbent-settings-object) from inside an algorithm that was triggered neither by [calling scripts](https://html.spec.whatwg.org/multipage/webappapis.html#calling-scripts) nor by Web IDL [invoking](https://webidl.spec.whatwg.org/#invoke-a-callback-function) a callback. For example, it would trigger if you tried to obtain the [incumbent settings object](https://html.spec.whatwg.org/multipage/webappapis.html#incumbent-settings-object) inside an algorithm that ran periodically as part of the [event loop](https://html.spec.whatwg.org/multipage/webappapis.html#event-loop), with no involvement of author code. In such cases the [incumbent](https://html.spec.whatwg.org/multipage/webappapis.html#concept-incumbent-everything) concept cannot be used.

First commit makes incumbent_global always return something or unwrap (read assert) per spec. In second commit I fixed EventTarget (as this one the original one that got reported in https://github.com/whatwg/html/issues/2248), but apparently that is not enough as we are still missing some cases so this is WIP until I fix them all. 

Testing: Existing WPT tests
Fixes: ???