### PR TITLE
script: Implement <input type=range> widget's layout

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8206,7 +8206,7 @@ dependencies = [
 [[package]]
 name = "selectors"
 version = "0.35.0"
-source = "git+https://github.com/servo/stylo?rev=9a413b4d05d899c3baedd7b648dbf2c23dc9b879#9a413b4d05d899c3baedd7b648dbf2c23dc9b879"
+source = "git+https://github.com/BudiArb/stylo?branch=slide-bar#06077f109ae13c74ef03bafb53053ed88aa96ebd"
 dependencies = [
  "bitflags 2.11.0",
  "cssparser",
@@ -8522,7 +8522,7 @@ dependencies = [
 [[package]]
 name = "servo_arc"
 version = "0.4.3"
-source = "git+https://github.com/servo/stylo?rev=9a413b4d05d899c3baedd7b648dbf2c23dc9b879#9a413b4d05d899c3baedd7b648dbf2c23dc9b879"
+source = "git+https://github.com/BudiArb/stylo?branch=slide-bar#06077f109ae13c74ef03bafb53053ed88aa96ebd"
 dependencies = [
  "serde",
  "stable_deref_trait",
@@ -9071,7 +9071,7 @@ dependencies = [
 [[package]]
 name = "stylo"
 version = "0.12.0"
-source = "git+https://github.com/servo/stylo?rev=9a413b4d05d899c3baedd7b648dbf2c23dc9b879#9a413b4d05d899c3baedd7b648dbf2c23dc9b879"
+source = "git+https://github.com/BudiArb/stylo?branch=slide-bar#06077f109ae13c74ef03bafb53053ed88aa96ebd"
 dependencies = [
  "app_units",
  "arrayvec",
@@ -9127,7 +9127,7 @@ dependencies = [
 [[package]]
 name = "stylo_atoms"
 version = "0.12.0"
-source = "git+https://github.com/servo/stylo?rev=9a413b4d05d899c3baedd7b648dbf2c23dc9b879#9a413b4d05d899c3baedd7b648dbf2c23dc9b879"
+source = "git+https://github.com/BudiArb/stylo?branch=slide-bar#06077f109ae13c74ef03bafb53053ed88aa96ebd"
 dependencies = [
  "string_cache",
  "string_cache_codegen",
@@ -9136,7 +9136,7 @@ dependencies = [
 [[package]]
 name = "stylo_derive"
 version = "0.12.0"
-source = "git+https://github.com/servo/stylo?rev=9a413b4d05d899c3baedd7b648dbf2c23dc9b879#9a413b4d05d899c3baedd7b648dbf2c23dc9b879"
+source = "git+https://github.com/BudiArb/stylo?branch=slide-bar#06077f109ae13c74ef03bafb53053ed88aa96ebd"
 dependencies = [
  "darling",
  "proc-macro2",
@@ -9148,7 +9148,7 @@ dependencies = [
 [[package]]
 name = "stylo_dom"
 version = "0.12.0"
-source = "git+https://github.com/servo/stylo?rev=9a413b4d05d899c3baedd7b648dbf2c23dc9b879#9a413b4d05d899c3baedd7b648dbf2c23dc9b879"
+source = "git+https://github.com/BudiArb/stylo?branch=slide-bar#06077f109ae13c74ef03bafb53053ed88aa96ebd"
 dependencies = [
  "bitflags 2.11.0",
  "stylo_malloc_size_of",
@@ -9157,7 +9157,7 @@ dependencies = [
 [[package]]
 name = "stylo_malloc_size_of"
 version = "0.12.0"
-source = "git+https://github.com/servo/stylo?rev=9a413b4d05d899c3baedd7b648dbf2c23dc9b879#9a413b4d05d899c3baedd7b648dbf2c23dc9b879"
+source = "git+https://github.com/BudiArb/stylo?branch=slide-bar#06077f109ae13c74ef03bafb53053ed88aa96ebd"
 dependencies = [
  "app_units",
  "cssparser",
@@ -9174,12 +9174,12 @@ dependencies = [
 [[package]]
 name = "stylo_static_prefs"
 version = "0.12.0"
-source = "git+https://github.com/servo/stylo?rev=9a413b4d05d899c3baedd7b648dbf2c23dc9b879#9a413b4d05d899c3baedd7b648dbf2c23dc9b879"
+source = "git+https://github.com/BudiArb/stylo?branch=slide-bar#06077f109ae13c74ef03bafb53053ed88aa96ebd"
 
 [[package]]
 name = "stylo_traits"
 version = "0.12.0"
-source = "git+https://github.com/servo/stylo?rev=9a413b4d05d899c3baedd7b648dbf2c23dc9b879#9a413b4d05d899c3baedd7b648dbf2c23dc9b879"
+source = "git+https://github.com/BudiArb/stylo?branch=slide-bar#06077f109ae13c74ef03bafb53053ed88aa96ebd"
 dependencies = [
  "app_units",
  "bitflags 2.11.0",
@@ -9610,7 +9610,7 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 [[package]]
 name = "to_shmem"
 version = "0.3.0"
-source = "git+https://github.com/servo/stylo?rev=9a413b4d05d899c3baedd7b648dbf2c23dc9b879#9a413b4d05d899c3baedd7b648dbf2c23dc9b879"
+source = "git+https://github.com/BudiArb/stylo?branch=slide-bar#06077f109ae13c74ef03bafb53053ed88aa96ebd"
 dependencies = [
  "cssparser",
  "servo_arc",
@@ -9623,7 +9623,7 @@ dependencies = [
 [[package]]
 name = "to_shmem_derive"
 version = "0.1.0"
-source = "git+https://github.com/servo/stylo?rev=9a413b4d05d899c3baedd7b648dbf2c23dc9b879#9a413b4d05d899c3baedd7b648dbf2c23dc9b879"
+source = "git+https://github.com/BudiArb/stylo?branch=slide-bar#06077f109ae13c74ef03bafb53053ed88aa96ebd"
 dependencies = [
  "darling",
  "proc-macro2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -319,15 +319,15 @@ egui-winit = { git = "https://github.com/emilk/egui.git", rev = "5d8f393335e0517
 #
 # Or for Stylo:
 #
-# [patch."https://github.com/servo/stylo"]
-# selectors = { path = "../stylo/selectors" }
-# servo_arc = { path = "../stylo/servo_arc" }
-# stylo = { path = "../stylo/style" }
-# stylo_atoms = { path = "../stylo/stylo_atoms" }
-# stylo_dom = { path = "../stylo/stylo_dom" }
-# stylo_malloc_size_of = { path = "../stylo/malloc_size_of" }
-# stylo_static_prefs = { path = "../stylo/stylo_static_prefs" }
-# stylo_traits = { path = "../stylo/style_traits" }
+[patch."https://github.com/servo/stylo"]
+selectors = { git = "https://github.com/BudiArb/stylo", branch = "slide-bar" }
+servo_arc = { git = "https://github.com/BudiArb/stylo", branch = "slide-bar" }
+stylo = { git = "https://github.com/BudiArb/stylo", branch = "slide-bar" }
+stylo_atoms = { git = "https://github.com/BudiArb/stylo", branch = "slide-bar" }
+stylo_dom = { git = "https://github.com/BudiArb/stylo", branch = "slide-bar" }
+stylo_malloc_size_of = { git = "https://github.com/BudiArb/stylo", branch = "slide-bar" }
+stylo_static_prefs = { git = "https://github.com/BudiArb/stylo", branch = "slide-bar" }
+stylo_traits = { git = "https://github.com/BudiArb/stylo", branch = "slide-bar" }
 #
 # Or for WebRender:
 #

--- a/components/layout/stylesheets/servo.css
+++ b/components/layout/stylesheets/servo.css
@@ -167,6 +167,51 @@ input::color-swatch {
   width: 100%;
 }
 
+input[type="range"] {
+  width: 100px;
+  min-height: 16px;
+  position: relative;
+  cursor: pointer;
+  background: none;
+  border: none;
+}
+
+input[type="range"]::-servo-slider-track {
+  width: 100%;
+  height: 8px;
+  top: 50%;
+  transform: translateY(-50%);
+  background-color: #ddd;
+  border-radius: 5px;
+  position: absolute;
+  cursor: pointer;
+  z-index: 1;
+}
+
+input[type="range"]::-servo-slider-fill {
+  height: 8px;
+  background-color: #7a3;
+  border-radius: 5px;
+  position: absolute;
+  cursor: pointer;
+  top: 50%;
+  z-index: 2;
+  transform: translateY(-50%);
+}
+
+input[type="range"]::-servo-slider-thumb {
+  width: 12px;
+  height: 12px;
+  border-radius: 50%;
+  background-color: gray;
+  border: 2px solid white;
+  position: absolute;
+  top: 50%;
+  transform: translateY(-50%);
+  cursor: pointer;
+  z-index: 3;
+}
+
 /* Checkbox and radio button inputs */
 input[type="checkbox"],
 input[type="radio"] {
@@ -276,7 +321,7 @@ canvas, embed, iframe, img, video {
   overflow-clip-margin: 0 !important;
 }
 
-input:not([type=radio i], [type=checkbox i], [type=reset i], [type=button i], [type=submit i], [type=file i]) {
+input:not([type=radio i], [type=checkbox i], [type=reset i], [type=button i], [type=submit i], [type=file i], [type=range i]) {
   cursor: text;
   overflow: hidden !important;
   white-space: pre;

--- a/components/script/dom/document.rs
+++ b/components/script/dom/document.rs
@@ -4003,6 +4003,10 @@ impl Document {
         }
     }
 
+    pub(crate) fn has_script_or_layout_blocker(&self) -> bool {
+        self.script_and_layout_blockers.get() > 0
+    }
+
     /// Enqueue a task to run as soon as any JS and layout blockers are removed.
     pub(crate) fn add_delayed_task<T: 'static + NonSendTaskBox>(&self, task: T) {
         self.delayed_tasks.borrow_mut().push(Box::new(task));

--- a/components/script/dom/html/htmlinputelement.rs
+++ b/components/script/dom/html/htmlinputelement.rs
@@ -316,12 +316,138 @@ impl ColorInputShadowTree {
 
 #[derive(Clone, JSTraceable, MallocSizeOf)]
 #[cfg_attr(crown, crown::unrooted_must_root_lint::must_root)]
+struct RangeInputShadowTree {
+    slider_fill: Dom<Element>,
+    slider_thumb: Dom<Element>,
+    slider_track: Dom<Element>,
+}
+
+impl RangeInputShadowTree {
+    fn new(shadow_root: &Node, can_gc: CanGc) -> Self {
+        Node::replace_all(None, shadow_root.upcast::<Node>(), can_gc); //TODO: what isi this
+
+        let slider_fill = Element::create(
+            QualName::new(None, ns!(html), local_name!("div")),
+            None,
+            &shadow_root.owner_document(),
+            ElementCreator::ScriptCreated,
+            CustomElementCreationMode::Asynchronous,
+            None,
+            can_gc,
+        );
+
+        let slider_thumb = Element::create(
+            QualName::new(None, ns!(html), local_name!("div")),
+            None,
+            &shadow_root.owner_document(),
+            ElementCreator::ScriptCreated,
+            CustomElementCreationMode::Asynchronous,
+            None,
+            can_gc,
+        );
+
+        let slider_track = Element::create(
+            QualName::new(None, ns!(html), local_name!("div")),
+            None,
+            &shadow_root.owner_document(),
+            ElementCreator::ScriptCreated,
+            CustomElementCreationMode::Asynchronous,
+            None,
+            can_gc,
+        );
+
+        shadow_root
+            .upcast::<Node>()
+            .AppendChild(slider_track.upcast::<Node>(), can_gc)
+            .unwrap();
+        shadow_root
+            .upcast::<Node>()
+            .AppendChild(slider_fill.upcast::<Node>(), can_gc)
+            .unwrap();
+        shadow_root
+            .upcast::<Node>()
+            .AppendChild(slider_thumb.upcast::<Node>(), can_gc)
+            .unwrap();
+
+        slider_fill
+            .upcast::<Node>()
+            .set_implemented_pseudo_element(PseudoElement::ServoSliderFill);
+        slider_thumb
+            .upcast::<Node>()
+            .set_implemented_pseudo_element(PseudoElement::ServoSliderThumb);
+        slider_track
+            .upcast::<Node>()
+            .set_implemented_pseudo_element(PseudoElement::ServoSliderTrack);
+
+        Self {
+            slider_fill: slider_fill.as_traced(),
+            slider_thumb: slider_thumb.as_traced(),
+            slider_track: slider_track.as_traced(),
+        }
+    }
+
+    fn update(&self, input_element: &HTMLInputElement, can_gc: CanGc) {
+        if input_element.owner_document().has_script_or_layout_blocker() {
+            let range_input_element = DomRoot::from_ref(input_element);
+            input_element.owner_document().add_delayed_task(task!(
+                ThumbPositionUpdate: |range_input_element: DomRoot<HTMLInputElement>| {
+                    range_input_element.get_or_create_shadow_tree(CanGc::note()).update(&range_input_element, CanGc::note());
+                }
+            ));
+            return;
+        }
+        self.update_range_position(input_element, can_gc);
+    }
+
+    fn update_range_position(&self, input_element: &HTMLInputElement, can_gc: CanGc) {
+        let value = input_element.Value();
+        let min = input_element.minimum().unwrap_or(0.0);
+        let max = input_element.maximum().unwrap_or(100.0);
+        let value_num = input_element.convert_string_to_number(&value.str()).unwrap_or(0.0);
+        let percent = if (max - min) < f64::EPSILON {
+            0.0
+        } else {
+            let clamped_value = value_num.clamp(min, max);
+            (clamped_value - min) / (max - min) * 100.0
+        };
+
+        let thumb_rect_width: f64 = self
+            .slider_thumb
+            .upcast::<Node>()
+            .border_box()
+            .unwrap_or_default()
+            .width()
+            .to_f64_px();
+
+        let thumb_style = format!(
+            "inset-inline-start: calc({}% - {}px)",
+            percent,
+            thumb_rect_width * percent / 100.0
+        );
+        let progress_style = format!("width: {percent}%;");
+
+        self.slider_thumb.set_string_attribute(
+            &local_name!("style"),
+            thumb_style.into(),
+            can_gc,
+        );
+        self.slider_fill.set_string_attribute(
+            &local_name!("style"),
+            progress_style.into(),
+            can_gc,
+        );
+    }
+}
+
+#[derive(Clone, JSTraceable, MallocSizeOf)]
+#[cfg_attr(crown, crown::unrooted_must_root_lint::must_root)]
 #[non_exhaustive]
 enum InputElementShadowTree {
     ColorInput(ColorInputShadowTree),
+    RangeInput(RangeInputShadowTree),
     TextInput(TextInputWidgetShadowTree),
     TextValue(TextValueShadowTree),
-    // TODO: Add shadow trees for other input types (range etc) here
+    // TODO: Add shadow trees for other input types here
 }
 
 impl InputElementShadowTree {
@@ -335,6 +461,9 @@ impl InputElementShadowTree {
         if input_element.input_type() == InputType::Color {
             return Self::ColorInput(ColorInputShadowTree::new(shadow_root, can_gc));
         }
+        if input_element.input_type() == InputType::Range {
+            return Self::RangeInput(RangeInputShadowTree::new(shadow_root, can_gc));
+        }
         if input_element.renders_as_text_input_widget() {
             return Self::TextInput(TextInputWidgetShadowTree::new(shadow_root, can_gc));
         }
@@ -344,6 +473,9 @@ impl InputElementShadowTree {
     fn is_valid_for_element(&self, input_element: &HTMLInputElement) -> bool {
         if input_element.input_type() == InputType::Color {
             return matches!(self, InputElementShadowTree::ColorInput(_));
+        }
+        if input_element.input_type() == InputType::Range {
+            return matches!(self, InputElementShadowTree::RangeInput(_));
         }
         if input_element.renders_as_text_input_widget() {
             return matches!(self, InputElementShadowTree::TextInput(_));
@@ -360,6 +492,9 @@ impl InputElementShadowTree {
     fn update(&self, input_element: &HTMLInputElement, can_gc: CanGc) {
         match self {
             InputElementShadowTree::ColorInput(shadow_tree) => {
+                shadow_tree.update(input_element, can_gc)
+            },
+            InputElementShadowTree::RangeInput(shadow_tree) => {
                 shadow_tree.update(input_element, can_gc)
             },
             InputElementShadowTree::TextInput(shadow_tree) => shadow_tree.update(input_element),
@@ -496,7 +631,6 @@ impl InputType {
                 InputType::Hidden |
                 InputType::Month |
                 InputType::Number |
-                InputType::Range |
                 InputType::Search |
                 InputType::Tel |
                 InputType::Text |
@@ -1420,7 +1554,6 @@ impl HTMLInputElement {
                 InputType::Month |
                 InputType::Number |
                 InputType::Password |
-                InputType::Range |
                 InputType::Search |
                 InputType::Tel |
                 InputType::Text |

--- a/tests/wpt/meta/css/css-grid/alignment/grid-self-alignment-stretch-input-range.html.ini
+++ b/tests/wpt/meta/css/css-grid/alignment/grid-self-alignment-stretch-input-range.html.ini
@@ -1,0 +1,2 @@
+[grid-self-alignment-stretch-input-range.html]
+  expected: FAIL

--- a/tests/wpt/meta/css/css-sizing/range-percent-intrinsic-size-2.html.ini
+++ b/tests/wpt/meta/css/css-sizing/range-percent-intrinsic-size-2.html.ini
@@ -1,0 +1,2 @@
+[range-percent-intrinsic-size-2.html]
+  expected: FAIL

--- a/tests/wpt/meta/css/css-sizing/range-percent-intrinsic-size-2a.html.ini
+++ b/tests/wpt/meta/css/css-sizing/range-percent-intrinsic-size-2a.html.ini
@@ -1,0 +1,2 @@
+[range-percent-intrinsic-size-2a.html]
+  expected: FAIL


### PR DESCRIPTION
Implement the layout of <input type="range">. Support automatically calculating the position of thumb based on the current input value, and the size of range-track and range-thumb. Added a document.has_script_or_layout_blocker function to detect whether it is possible to run box_area_query during bind_to_tree, add delay_task if there are blocker.

Testing: Since the layout of the widget is up to the implementation, there has no WPT test testing the layout, and it should not affect any WPT test.
Fixes: https://github.com/servo/servo/issues/22728

Parallel Stylo PR: https://github.com/servo/stylo/pull/276
New Parallel Stylo PR: https://github.com/servo/stylo/pull/310

This PR is based on https://github.com/servo/servo/pull/41024
cc @rayguo17
Due to big changes in the servo script, this PR is modified from https://github.com/servo/servo/pull/41562

Issues: The original PR is failing on a couple wpt tests.
Here are some of the fixes made in this PR:

Fixed the stacking for input type range's track, thumb, and progress.
Fixed the positioning of input type range's thumb based on current value, width, and direction.
Allow input type range to stretch vertically in a bigger container.