### PR TITLE
layout: Cache `SameFormattingContextBlock` layout results

### DIFF
--- a/components/layout/display_list/mod.rs
+++ b/components/layout/display_list/mod.rs
@@ -640,6 +640,10 @@ impl Fragment {
                     builder.reflow_statistics.restyle_fragment_count += 1;
                     base.status = FragmentStatus::Clean;
                 },
+                FragmentStatus::PositionMaybeChanged => {
+                    builder.reflow_statistics.possibly_moved_fragment_count += 1;
+                    base.status = FragmentStatus::Clean;
+                },
                 FragmentStatus::Clean => {},
             }
         }

--- a/components/layout/flexbox/layout.rs
+++ b/components/layout/flexbox/layout.rs
@@ -33,7 +33,7 @@ use crate::fragment_tree::{
     BoxFragment, CollapsedBlockMargins, Fragment, FragmentFlags, SpecificLayoutInfo,
 };
 use crate::geom::{AuOrAuto, LogicalRect, LogicalSides, LogicalVec2};
-use crate::layout_box_base::CacheableLayoutResult;
+use crate::layout_box_base::IndependentFormattingContextLayoutResult;
 use crate::positioned::{
     AbsolutelyPositionedBox, PositioningContext, PositioningContextLength, relative_adjustement,
 };
@@ -611,7 +611,7 @@ impl FlexContainer {
         positioning_context: &mut PositioningContext,
         containing_block: &ContainingBlock,
         lazy_block_size: &LazySize,
-    ) -> CacheableLayoutResult {
+    ) -> IndependentFormattingContextLayoutResult {
         let mut flex_context = FlexContext {
             config: self.config.clone(),
             layout_context,
@@ -949,7 +949,7 @@ impl FlexContainer {
         //   This is unlikely because `align-content` defaults to `stretch`.
         let depends_on_block_constraints = true;
 
-        CacheableLayoutResult {
+        IndependentFormattingContextLayoutResult {
             fragments,
             content_block_size,
             content_inline_size_for_table: None,
@@ -1870,7 +1870,7 @@ impl FlexItem<'_> {
             self.preferred_aspect_ratio,
             &lazy_block_size,
         );
-        let CacheableLayoutResult {
+        let IndependentFormattingContextLayoutResult {
             fragments,
             content_block_size,
             baselines: content_box_baselines,

--- a/components/layout/flow/inline/mod.rs
+++ b/components/layout/flow/inline/mod.rs
@@ -118,7 +118,7 @@ use unicode_bidi::{BidiInfo, Level};
 use xi_unicode::linebreak_property;
 
 use super::float::{Clear, PlacementAmongFloats};
-use super::{CacheableLayoutResult, IndependentFloatOrAtomicLayoutResult};
+use super::{IndependentFloatOrAtomicLayoutResult, IndependentFormattingContextLayoutResult};
 use crate::cell::{ArcRefCell, WeakRefCell};
 use crate::context::LayoutContext;
 use crate::dom::WeakLayoutBox;
@@ -1932,7 +1932,7 @@ impl InlineFormattingContext {
         containing_block: &ContainingBlock,
         sequential_layout_state: Option<&mut SequentialLayoutState>,
         collapsible_with_parent_start_margin: CollapsibleWithParentStartMargin,
-    ) -> CacheableLayoutResult {
+    ) -> IndependentFormattingContextLayoutResult {
         // Clear any cached inline fragments from previous layouts.
         for inline_box in self.inline_boxes.iter() {
             inline_box.borrow().base.clear_fragments();
@@ -2030,7 +2030,7 @@ impl InlineFormattingContext {
         let (content_block_size, collapsible_margins_in_children, baselines) =
             layout.placement_state.finish();
 
-        CacheableLayoutResult {
+        IndependentFormattingContextLayoutResult {
             fragments: layout.fragments,
             content_block_size,
             collapsible_margins_in_children,

--- a/components/layout/flow/mod.rs
+++ b/components/layout/flow/mod.rs
@@ -37,7 +37,7 @@ use crate::geom::{
     AuOrAuto, LogicalRect, LogicalSides, LogicalSides1D, LogicalVec2, PhysicalPoint, PhysicalRect,
     PhysicalSides, ToLogical, ToLogicalWithContainingBlock,
 };
-use crate::layout_box_base::{CacheableLayoutResult, LayoutBoxBase};
+use crate::layout_box_base::{IndependentFormattingContextLayoutResult, LayoutBoxBase};
 use crate::positioned::{AbsolutelyPositionedBox, PositioningContext, PositioningContextLength};
 use crate::sizing::{
     self, ComputeInlineContentSizes, ContentSizes, InlineContentSizesResult, LazySize, Size,
@@ -290,7 +290,7 @@ impl BlockLevelBox {
     }
 }
 
-#[derive(Clone, Copy)]
+#[derive(Clone, Copy, MallocSizeOf, PartialEq)]
 pub(crate) struct CollapsibleWithParentStartMargin(bool);
 
 /// The contentes of a BlockContainer created to render a list marker
@@ -402,7 +402,7 @@ impl BlockFormattingContext {
         layout_context: &LayoutContext,
         positioning_context: &mut PositioningContext,
         containing_block: &ContainingBlock,
-    ) -> CacheableLayoutResult {
+    ) -> IndependentFormattingContextLayoutResult {
         let mut sequential_layout_state = if self.contains_floats || !layout_context.use_rayon {
             Some(SequentialLayoutState::new(containing_block.size.inline))
         } else {
@@ -435,7 +435,7 @@ impl BlockFormattingContext {
             sequential_layout_state.calculate_clearance(Clear::Both, &CollapsedMargin::zero())
         });
 
-        CacheableLayoutResult {
+        IndependentFormattingContextLayoutResult {
             fragments: flow_layout.fragments,
             content_block_size: flow_layout.content_block_size +
                 flow_layout.collapsible_margins_in_children.end.solve() +
@@ -630,7 +630,7 @@ impl BlockContainer {
         sequential_layout_state: Option<&mut SequentialLayoutState>,
         collapsible_with_parent_start_margin: CollapsibleWithParentStartMargin,
         ignore_block_margins_for_stretch: LogicalSides1D<bool>,
-    ) -> CacheableLayoutResult {
+    ) -> IndependentFormattingContextLayoutResult {
         match self {
             BlockContainer::BlockLevelBoxes(child_boxes) => layout_block_level_children(
                 layout_context,
@@ -722,7 +722,7 @@ fn layout_block_level_children(
     mut sequential_layout_state: Option<&mut SequentialLayoutState>,
     collapsible_with_parent_start_margin: CollapsibleWithParentStartMargin,
     ignore_block_margins_for_stretch: LogicalSides1D<bool>,
-) -> CacheableLayoutResult {
+) -> IndependentFormattingContextLayoutResult {
     let mut placement_state =
         PlacementState::new(collapsible_with_parent_start_margin, containing_block);
 
@@ -753,7 +753,7 @@ fn layout_block_level_children(
     });
 
     let (content_block_size, collapsible_margins_in_children, baselines) = placement_state.finish();
-    CacheableLayoutResult {
+    IndependentFormattingContextLayoutResult {
         fragments,
         content_block_size,
         collapsible_margins_in_children,
@@ -877,24 +877,17 @@ impl BlockLevelBox {
     ) -> Fragment {
         let fragment = match self {
             BlockLevelBox::SameFormattingContextBlock { base, contents, .. } => Fragment::Box(
-                ArcRefCell::new(positioning_context.layout_maybe_position_relative_fragment(
+                layout_in_flow_non_replaced_block_level_same_formatting_context_cached(
                     layout_context,
+                    positioning_context,
                     containing_block,
+                    sequential_layout_state,
+                    collapsible_with_parent_start_margin,
+                    ignore_block_margins_for_stretch,
+                    has_inline_parent,
                     base,
-                    |positioning_context| {
-                        layout_in_flow_non_replaced_block_level_same_formatting_context(
-                            layout_context,
-                            positioning_context,
-                            containing_block,
-                            base,
-                            contents,
-                            sequential_layout_state,
-                            collapsible_with_parent_start_margin,
-                            ignore_block_margins_for_stretch,
-                            has_inline_parent,
-                        )
-                    },
-                )),
+                    contents,
+                ),
             ),
             BlockLevelBox::Independent(independent) => Fragment::Box(ArcRefCell::new(
                 positioning_context.layout_maybe_position_relative_fragment(
@@ -962,6 +955,79 @@ impl BlockLevelBox {
         };
         independent_formatting_context.inline_content_sizes(layout_context, constraint_space)
     }
+}
+
+/// Lay out a normal flow non-replaced block that does not establish a new formatting
+/// context, properly taking into account relative positioning. This version also handles
+/// caching the layout results and fetching the results from the cache, if they are still valid.
+///
+/// - <https://drafts.csswg.org/css2/visudet.html#blockwidth>
+/// - <https://drafts.csswg.org/css2/visudet.html#normal-block>
+#[allow(clippy::too_many_arguments)]
+fn layout_in_flow_non_replaced_block_level_same_formatting_context_cached(
+    layout_context: &LayoutContext<'_>,
+    positioning_context: &mut PositioningContext,
+    containing_block: &ContainingBlock<'_>,
+    sequential_layout_state: Option<&mut SequentialLayoutState>,
+    collapsible_with_parent_start_margin: Option<CollapsibleWithParentStartMargin>,
+    ignore_block_margins_for_stretch: LogicalSides1D<bool>,
+    has_inline_parent: bool,
+    base: &LayoutBoxBase,
+    contents: &BlockContainer,
+) -> ArcRefCell<BoxFragment> {
+    let mut allows_caching = sequential_layout_state.is_none();
+
+    if allows_caching {
+        if let Some(cached_result) = base.cached_same_formatting_context_block_if_applicable(
+            containing_block,
+            collapsible_with_parent_start_margin,
+            ignore_block_margins_for_stretch,
+            has_inline_parent,
+        ) {
+            return cached_result;
+        };
+    }
+
+    let positioning_context_length = positioning_context.len();
+    let fragment = ArcRefCell::new(positioning_context.layout_maybe_position_relative_fragment(
+        layout_context,
+        containing_block,
+        base,
+        |positioning_context| {
+            layout_in_flow_non_replaced_block_level_same_formatting_context(
+                layout_context,
+                positioning_context,
+                containing_block,
+                base,
+                contents,
+                sequential_layout_state,
+                collapsible_with_parent_start_margin,
+                ignore_block_margins_for_stretch,
+                has_inline_parent,
+            )
+        },
+    ));
+
+    // We currently do not allow caching `SameFormattingContextBlock` box layout results if they
+    // contain absolutely positioned children.
+    //
+    // TODO: It would be good to find a way to allow this, without having to create and store a
+    // PositioningContext for every single SameFormattingContextBlock.
+    allows_caching = allows_caching && positioning_context_length == positioning_context.len();
+
+    if !allows_caching {
+        base.clear_fragments_and_fragment_cache();
+    } else {
+        base.cache_same_formatting_context_block_layout(
+            containing_block,
+            collapsible_with_parent_start_margin,
+            ignore_block_margins_for_stretch,
+            has_inline_parent,
+            fragment.clone(),
+        );
+    }
+
+    fragment
 }
 
 /// Lay out a normal flow non-replaced block that does not establish a new formatting
@@ -2413,7 +2479,7 @@ impl IndependentFormattingContext {
             is_table,
         );
 
-        let CacheableLayoutResult {
+        let IndependentFormattingContextLayoutResult {
             content_inline_size_for_table,
             content_block_size,
             fragments,

--- a/components/layout/formatting_contexts.rs
+++ b/components/layout/formatting_contexts.rs
@@ -19,7 +19,8 @@ use crate::flexbox::FlexContainer;
 use crate::flow::BlockFormattingContext;
 use crate::fragment_tree::{BaseFragmentInfo, FragmentFlags};
 use crate::layout_box_base::{
-    CacheableLayoutResult, CacheableLayoutResultAndInputs, LayoutBoxBase,
+    IndependentFormattingContextLayoutResult, IndependentFormattingContextLayoutResultAndInputs,
+    LayoutBoxBase, LayoutResultAndInputs,
 };
 use crate::positioned::PositioningContext;
 use crate::replaced::ReplacedContents;
@@ -395,7 +396,7 @@ impl IndependentFormattingContext {
         containing_block: &ContainingBlock,
         preferred_aspect_ratio: Option<AspectRatio>,
         lazy_block_size: &LazySize,
-    ) -> CacheableLayoutResult {
+    ) -> IndependentFormattingContextLayoutResult {
         match &self.contents {
             IndependentFormattingContextContents::Replaced(replaced, widget) => {
                 let mut replaced_layout = replaced.layout(
@@ -454,8 +455,10 @@ impl IndependentFormattingContext {
         containing_block: &ContainingBlock,
         preferred_aspect_ratio: Option<AspectRatio>,
         lazy_block_size: &LazySize,
-    ) -> (CacheableLayoutResult, bool) {
-        if let Some(cache) = self.base.cached_layout_result.borrow().as_ref() {
+    ) -> (IndependentFormattingContextLayoutResult, bool) {
+        if let Some(LayoutResultAndInputs::IndependentFormattingContext(cache)) =
+            self.base.cached_layout_result.borrow().as_ref()
+        {
             let cache = &**cache;
             if cache.containing_block_for_children_size.inline ==
                 containing_block_for_children.size.inline &&
@@ -485,11 +488,13 @@ impl IndependentFormattingContext {
         );
 
         *self.base.cached_layout_result.borrow_mut() =
-            Some(Box::new(CacheableLayoutResultAndInputs {
-                result: result.clone(),
-                positioning_context: child_positioning_context.clone(),
-                containing_block_for_children_size: containing_block_for_children.size.clone(),
-            }));
+            Some(LayoutResultAndInputs::IndependentFormattingContext(
+                Box::new(IndependentFormattingContextLayoutResultAndInputs {
+                    result: result.clone(),
+                    positioning_context: child_positioning_context.clone(),
+                    containing_block_for_children_size: containing_block_for_children.size.clone(),
+                }),
+            ));
         positioning_context.append(child_positioning_context);
 
         (result, false)
@@ -503,7 +508,7 @@ impl IndependentFormattingContext {
         containing_block: &ContainingBlock,
         preferred_aspect_ratio: Option<AspectRatio>,
         lazy_block_size: &LazySize,
-    ) -> CacheableLayoutResult {
+    ) -> IndependentFormattingContextLayoutResult {
         self.layout_and_is_cached(
             layout_context,
             positioning_context,

--- a/components/layout/fragment_tree/base_fragment.rs
+++ b/components/layout/fragment_tree/base_fragment.rs
@@ -71,6 +71,9 @@ pub(crate) enum FragmentStatus {
     New,
     /// The style of the fragment has changed.
     StyleChanged,
+    /// The fragment was reused between layouts, but its final layout
+    /// position may have changed.
+    PositionMaybeChanged,
     /// The fragment hasn't changed.
     Clean,
 }

--- a/components/layout/geom.rs
+++ b/components/layout/geom.rs
@@ -45,7 +45,7 @@ pub struct LogicalSides<T> {
     pub block_end: T,
 }
 
-#[derive(Clone, Copy, Debug, Default)]
+#[derive(Clone, Copy, Debug, Default, MallocSizeOf, PartialEq)]
 pub(crate) struct LogicalSides1D<T> {
     pub start: T,
     pub end: T,

--- a/components/layout/layout_box_base.rs
+++ b/components/layout/layout_box_base.rs
@@ -7,18 +7,28 @@ use std::sync::atomic::{AtomicBool, Ordering};
 
 use app_units::Au;
 use atomic_refcell::AtomicRefCell;
+use euclid::Point2D;
 use layout_api::LayoutDamage;
 use malloc_size_of_derive::MallocSizeOf;
 use servo_arc::Arc;
+use style::computed_values::position::T as Position;
+use style::logical_geometry::WritingMode;
 use style::properties::ComputedValues;
+use style::values::specified::align::AlignFlags;
+use style_traits::CSSPixel;
 
 use crate::context::LayoutContext;
 use crate::dom::{LayoutBox, WeakLayoutBox};
+use crate::flow::CollapsibleWithParentStartMargin;
 use crate::formatting_contexts::Baselines;
-use crate::fragment_tree::{BaseFragmentInfo, CollapsedBlockMargins, Fragment, SpecificLayoutInfo};
-use crate::positioned::PositioningContext;
+use crate::fragment_tree::{
+    BaseFragmentInfo, BoxFragment, CollapsedBlockMargins, Fragment, FragmentStatus,
+    SpecificLayoutInfo,
+};
+use crate::geom::LogicalSides1D;
+use crate::positioned::{PositioningContext, relative_adjustement};
 use crate::sizing::{ComputeInlineContentSizes, InlineContentSizesResult, SizeConstraint};
-use crate::{ConstraintSpace, ContainingBlockSize};
+use crate::{ArcRefCell, ConstraintSpace, ContainingBlock, ContainingBlockSize};
 
 /// A box tree node that handles containing information about style and the original DOM
 /// node or pseudo-element that it is based on. This also handles caching of layout values
@@ -33,7 +43,7 @@ pub(crate) struct LayoutBoxBase {
     pub cached_inline_content_size:
         AtomicRefCell<Option<Box<(SizeConstraint, InlineContentSizesResult)>>>,
     pub outer_inline_content_sizes_depend_on_content: AtomicBool,
-    pub cached_layout_result: AtomicRefCell<Option<Box<CacheableLayoutResultAndInputs>>>,
+    pub cached_layout_result: AtomicRefCell<Option<LayoutResultAndInputs>>,
     pub fragments: AtomicRefCell<Vec<Fragment>>,
     pub parent_box: Option<WeakLayoutBox>,
 }
@@ -146,6 +156,92 @@ impl LayoutBoxBase {
 
         damage_for_parent
     }
+
+    pub(crate) fn cached_same_formatting_context_block_if_applicable(
+        &self,
+        containing_block: &ContainingBlock,
+        collapsible_with_parent_start_margin: Option<CollapsibleWithParentStartMargin>,
+        ignore_block_margins_for_stretch: LogicalSides1D<bool>,
+        has_inline_parent: bool,
+    ) -> Option<ArcRefCell<BoxFragment>> {
+        let mut cached_layout_result = self.cached_layout_result.borrow_mut();
+        let Some(LayoutResultAndInputs::SameFormattingContextBlock(result)) =
+            &mut *cached_layout_result
+        else {
+            return None;
+        };
+
+        if result.containing_block_size != containing_block.size ||
+            result.containing_block_writing_mode != containing_block.style.writing_mode ||
+            result.containing_block_justify_items !=
+                containing_block.style.clone_justify_items().computed.0.0 ||
+            result.collapsible_with_parent_start_margin != collapsible_with_parent_start_margin ||
+            result.ignore_block_margins_for_stretch != ignore_block_margins_for_stretch ||
+            result.has_inline_parent != has_inline_parent
+        {
+            return None;
+        }
+
+        let fragment = result.result.fragment.clone();
+        {
+            let mut borrowed_fragment = fragment.borrow_mut();
+
+            // Ideally when the final position doesn't change, this wouldn't be set, but we have
+            // no way currently to track whether the final position wil differ from the one set in
+            // the cached fragment. Final positioning is done in the containing block and depends
+            // on things like margins and the size of siblings.
+            borrowed_fragment.base.status = FragmentStatus::PositionMaybeChanged;
+
+            borrowed_fragment.base.rect.origin = result.result.original_offset;
+            if self.style.clone_position() == Position::Relative {
+                borrowed_fragment.base.rect.origin +=
+                    relative_adjustement(&self.style, containing_block)
+                        .to_physical_vector(containing_block.style.writing_mode)
+            }
+        }
+
+        Some(fragment)
+    }
+
+    pub(crate) fn cache_same_formatting_context_block_layout(
+        &self,
+        containing_block: &ContainingBlock,
+        collapsible_with_parent_start_margin: Option<CollapsibleWithParentStartMargin>,
+        ignore_block_margins_for_stretch: LogicalSides1D<bool>,
+        has_inline_parent: bool,
+        fragment: ArcRefCell<BoxFragment>,
+    ) {
+        let mut original_offset;
+        {
+            let borrowed_fragment = fragment.borrow();
+            original_offset = borrowed_fragment.content_rect().origin;
+            if self.style.clone_position() == Position::Relative {
+                original_offset -= relative_adjustement(&self.style, containing_block)
+                    .to_physical_vector(containing_block.style.writing_mode)
+            }
+        }
+
+        *self.cached_layout_result.borrow_mut() =
+            Some(LayoutResultAndInputs::SameFormattingContextBlock(Box::new(
+                SameFormattingContextBlockLayoutResultAndInputs {
+                    result: SameFormattingContextBlockLayoutResult {
+                        fragment,
+                        original_offset,
+                    },
+                    containing_block_size: containing_block.size.clone(),
+                    containing_block_writing_mode: containing_block.style.writing_mode,
+                    containing_block_justify_items: containing_block
+                        .style
+                        .clone_justify_items()
+                        .computed
+                        .0
+                        .0,
+                    collapsible_with_parent_start_margin,
+                    ignore_block_margins_for_stretch,
+                    has_inline_parent,
+                },
+            )));
+    }
 }
 
 impl Debug for LayoutBoxBase {
@@ -154,8 +250,14 @@ impl Debug for LayoutBoxBase {
     }
 }
 
+#[derive(MallocSizeOf)]
+pub(crate) enum LayoutResultAndInputs {
+    IndependentFormattingContext(Box<IndependentFormattingContextLayoutResultAndInputs>),
+    SameFormattingContextBlock(Box<SameFormattingContextBlockLayoutResultAndInputs>),
+}
+
 #[derive(Clone, MallocSizeOf)]
-pub(crate) struct CacheableLayoutResult {
+pub(crate) struct IndependentFormattingContextLayoutResult {
     pub fragments: Vec<Fragment>,
 
     /// <https://drafts.csswg.org/css2/visudet.html#root-height>
@@ -182,11 +284,12 @@ pub(crate) struct CacheableLayoutResult {
     pub specific_layout_info: Option<SpecificLayoutInfo>,
 }
 
-/// A collection of layout inputs and a cached layout result for a [`LayoutBoxBase`].
+/// A collection of layout inputs and a cached layout result for an IndependentFormattingContext for
+/// use in [`LayoutBoxBase`].
 #[derive(MallocSizeOf)]
-pub(crate) struct CacheableLayoutResultAndInputs {
-    /// The [`CacheableLayoutResult`] for this layout.
-    pub result: CacheableLayoutResult,
+pub(crate) struct IndependentFormattingContextLayoutResultAndInputs {
+    /// The [`IndependentFormattingContextLayoutResult`] for this layout.
+    pub result: IndependentFormattingContextLayoutResult,
 
     /// The [`ContainingBlockSize`] to use for this box's contents, but not
     /// for the box itself.
@@ -195,4 +298,30 @@ pub(crate) struct CacheableLayoutResultAndInputs {
     /// A [`PositioningContext`] holding absolutely-positioned descendants
     /// collected during the layout of this box.
     pub positioning_context: PositioningContext,
+}
+
+#[derive(Clone, MallocSizeOf)]
+pub(crate) struct SameFormattingContextBlockLayoutResult {
+    pub fragment: ArcRefCell<BoxFragment>,
+    original_offset: Point2D<Au, CSSPixel>,
+}
+
+/// A collection of layout inputs and a cached layout result for a SameFormattingContextBlock for
+/// use in [`LayoutBoxBase`].
+#[derive(MallocSizeOf)]
+pub(crate) struct SameFormattingContextBlockLayoutResultAndInputs {
+    pub result: SameFormattingContextBlockLayoutResult,
+    /// The [`ContainingBlockSize`] used when this block was laid out.
+    pub containing_block_size: ContainingBlockSize,
+    /// The containing block's [`WritingMode`]  used when this block was laid out.
+    pub containing_block_writing_mode: WritingMode,
+    /// The containing block's `justify-items` [`AlignFlags`] used when this block was laid out.
+    pub containing_block_justify_items: AlignFlags,
+    /// Whether or not the margin in this block was collapsible with the parent's start margin
+    /// when this block was laid out.
+    collapsible_with_parent_start_margin: Option<CollapsibleWithParentStartMargin>,
+    /// Whether or not block margins were ignored for stretch when this block was laid out.
+    ignore_block_margins_for_stretch: LogicalSides1D<bool>,
+    /// Whether or not this block had an inline parent.
+    has_inline_parent: bool,
 }

--- a/components/layout/lib.rs
+++ b/components/layout/lib.rs
@@ -120,7 +120,7 @@ impl<'a> From<&'_ DefiniteContainingBlock<'a>> for IndefiniteContainingBlock<'a>
     }
 }
 
-#[derive(Clone, Debug, MallocSizeOf)]
+#[derive(Clone, Debug, MallocSizeOf, PartialEq)]
 pub(crate) struct ContainingBlockSize {
     inline: Au,
     block: SizeConstraint,

--- a/components/layout/positioned.rs
+++ b/components/layout/positioned.rs
@@ -23,7 +23,7 @@ use crate::geom::{
     AuOrAuto, LogicalRect, LogicalSides, LogicalSides1D, LogicalVec2, PhysicalPoint, PhysicalRect,
     PhysicalSides, PhysicalSize, PhysicalVec, ToLogical, ToLogicalWithContainingBlock,
 };
-use crate::layout_box_base::{CacheableLayoutResult, LayoutBoxBase};
+use crate::layout_box_base::{IndependentFormattingContextLayoutResult, LayoutBoxBase};
 use crate::sizing::{LazySize, Size, SizeConstraint, Sizes};
 use crate::style_ext::{Clamp, ComputedValuesExt, ContentBoxSizesAndPBM, DisplayInside};
 use crate::{
@@ -592,7 +592,7 @@ impl HoistedAbsolutelyPositionedBox {
             preferred_aspect_ratio,
             &lazy_block_size,
         );
-        let CacheableLayoutResult {
+        let IndependentFormattingContextLayoutResult {
             content_inline_size_for_table,
             content_block_size,
             fragments,

--- a/components/layout/replaced.rs
+++ b/components/layout/replaced.rs
@@ -37,7 +37,7 @@ use crate::fragment_tree::{
     BaseFragment, BaseFragmentInfo, CollapsedBlockMargins, Fragment, IFrameFragment, ImageFragment,
 };
 use crate::geom::{LogicalVec2, PhysicalPoint, PhysicalRect, PhysicalSize};
-use crate::layout_box_base::{CacheableLayoutResult, LayoutBoxBase};
+use crate::layout_box_base::{IndependentFormattingContextLayoutResult, LayoutBoxBase};
 use crate::sizing::{
     ComputeInlineContentSizes, InlineContentSizesResult, LazySize, SizeConstraint,
 };
@@ -692,7 +692,7 @@ impl ReplacedContents {
         preferred_aspect_ratio: Option<AspectRatio>,
         base: &LayoutBoxBase,
         lazy_block_size: &LazySize,
-    ) -> CacheableLayoutResult {
+    ) -> IndependentFormattingContextLayoutResult {
         let writing_mode = base.style.writing_mode;
         let inline_size = containing_block_for_children.size.inline;
         let content_block_size = self.content_size(
@@ -706,7 +706,7 @@ impl ReplacedContents {
             block: lazy_block_size.resolve(|| content_block_size),
         }
         .to_physical_size(writing_mode);
-        CacheableLayoutResult {
+        IndependentFormattingContextLayoutResult {
             baselines: Default::default(),
             collapsible_margins_in_children: CollapsedBlockMargins::zero(),
             content_block_size,

--- a/components/layout/table/layout.rs
+++ b/components/layout/table/layout.rs
@@ -42,7 +42,7 @@ use crate::geom::{
     LogicalRect, LogicalSides, LogicalSides1D, LogicalVec2, PhysicalPoint, PhysicalRect,
     PhysicalSides, PhysicalVec, ToLogical, ToLogicalWithContainingBlock,
 };
-use crate::layout_box_base::CacheableLayoutResult;
+use crate::layout_box_base::IndependentFormattingContextLayoutResult;
 use crate::positioned::{PositioningContext, PositioningContextLength, relative_adjustement};
 use crate::sizing::{
     ComputeInlineContentSizes, ContentSizes, InlineContentSizesResult, LazySize, Size,
@@ -68,7 +68,7 @@ enum CellContentAlignment {
 /// the table. Note that this is only done for slots that are not
 /// covered by spans or empty.
 struct CellLayout {
-    layout: CacheableLayoutResult,
+    layout: IndependentFormattingContextLayoutResult,
     padding: LogicalSides<Au>,
     border: LogicalSides<Au>,
     positioning_context: PositioningContext,
@@ -1560,7 +1560,7 @@ impl<'a> TableLayout<'a> {
         positioning_context: &mut PositioningContext,
         containing_block_for_children: &ContainingBlock,
         containing_block_for_table: &ContainingBlock,
-    ) -> CacheableLayoutResult {
+    ) -> IndependentFormattingContextLayoutResult {
         let table_writing_mode = containing_block_for_children.style.writing_mode;
         self.compute_border_collapse(table_writing_mode);
         let layout_style = self.table.layout_style(Some(&self));
@@ -1597,7 +1597,7 @@ impl<'a> TableLayout<'a> {
         let offset_from_wrapper = -self.pbm.padding - self.pbm.border;
         let mut current_block_offset = offset_from_wrapper.block_start;
 
-        let mut table_layout = CacheableLayoutResult {
+        let mut table_layout = IndependentFormattingContextLayoutResult {
             fragments: Vec::new(),
             content_block_size: Zero::zero(),
             content_inline_size_for_table: None,
@@ -2677,7 +2677,7 @@ impl Table {
         positioning_context: &mut PositioningContext,
         containing_block_for_children: &ContainingBlock,
         containing_block_for_table: &ContainingBlock,
-    ) -> CacheableLayoutResult {
+    ) -> IndependentFormattingContextLayoutResult {
         TableLayout::new(self).layout(
             layout_context,
             positioning_context,

--- a/components/layout/taffy/layout.rs
+++ b/components/layout/taffy/layout.rs
@@ -24,7 +24,7 @@ use crate::fragment_tree::{
     BoxFragment, CollapsedBlockMargins, Fragment, FragmentFlags, SpecificLayoutInfo,
 };
 use crate::geom::{LogicalVec2, PhysicalPoint, PhysicalRect, PhysicalSides, PhysicalSize};
-use crate::layout_box_base::CacheableLayoutResult;
+use crate::layout_box_base::IndependentFormattingContextLayoutResult;
 use crate::positioned::{AbsolutelyPositionedBox, PositioningContext, PositioningContextLength};
 use crate::sizing::{
     ComputeInlineContentSizes, ContentSizes, InlineContentSizesResult, LazySize, SizeConstraint,
@@ -380,7 +380,7 @@ impl TaffyContainer {
         positioning_context: &mut PositioningContext,
         content_box_size_override: &ContainingBlock,
         containing_block: &ContainingBlock,
-    ) -> CacheableLayoutResult {
+    ) -> IndependentFormattingContextLayoutResult {
         let mut container_ctx = TaffyContainerContext {
             layout_context,
             positioning_context,
@@ -574,7 +574,7 @@ impl TaffyContainer {
             })
             .collect();
 
-        CacheableLayoutResult {
+        IndependentFormattingContextLayoutResult {
             fragments,
             content_block_size: Au::from_f32_px(output.size.height) - pbm.padding_border_sums.block,
             content_inline_size_for_table: None,

--- a/components/script/dom/testing/layoutresult.rs
+++ b/components/script/dom/testing/layoutresult.rs
@@ -20,6 +20,7 @@ pub(crate) struct LayoutResult {
     phases: Vec<DOMString>,
     rebuilt_fragment_count: u32,
     restyle_fragment_count: u32,
+    possibly_moved_fragment_count: u32,
 }
 
 impl LayoutResult {
@@ -27,12 +28,14 @@ impl LayoutResult {
         phases: Vec<DOMString>,
         rebuilt_fragment_count: u32,
         restyle_fragment_count: u32,
+        possibly_moved_fragment_count: u32,
     ) -> Self {
         Self {
             reflector_: Reflector::new(),
             phases,
             rebuilt_fragment_count,
             restyle_fragment_count,
+            possibly_moved_fragment_count,
         }
     }
 
@@ -41,6 +44,7 @@ impl LayoutResult {
         phases: Vec<DOMString>,
         rebuilt_fragment_count: u32,
         restyle_fragment_count: u32,
+        possibly_moved_fragment_count: u32,
         can_gc: CanGc,
     ) -> DomRoot<Self> {
         reflect_dom_object(
@@ -48,6 +52,7 @@ impl LayoutResult {
                 phases,
                 rebuilt_fragment_count,
                 restyle_fragment_count,
+                possibly_moved_fragment_count,
             )),
             global,
             can_gc,
@@ -66,5 +71,9 @@ impl LayoutResultMethods<crate::DomTypeHolder> for LayoutResult {
 
     fn RestyleFragmentCount(&self) -> u32 {
         self.restyle_fragment_count
+    }
+
+    fn PossiblyMovedFragmentCount(&self) -> u32 {
+        self.possibly_moved_fragment_count
     }
 }

--- a/components/script/dom/testing/servotestutils.rs
+++ b/components/script/dom/testing/servotestutils.rs
@@ -63,6 +63,7 @@ impl ServoTestUtilsMethods<crate::DomTypeHolder> for ServoTestUtils {
             phases,
             statistics.rebuilt_fragment_count,
             statistics.restyle_fragment_count,
+            statistics.possibly_moved_fragment_count,
             can_gc,
         )
     }

--- a/components/script_bindings/webidls/ServoTestUtils.webidl
+++ b/components/script_bindings/webidls/ServoTestUtils.webidl
@@ -27,4 +27,5 @@ interface LayoutResult {
     readonly attribute /* FrozenArray<DOMString> */ any phases;
     readonly attribute unsigned long rebuiltFragmentCount;
     readonly attribute unsigned long restyleFragmentCount;
+    readonly attribute unsigned long possiblyMovedFragmentCount;
 };

--- a/components/shared/layout/lib.rs
+++ b/components/shared/layout/lib.rs
@@ -626,8 +626,13 @@ impl ReflowPhasesRun {
 
 #[derive(Debug, Default)]
 pub struct ReflowStatistics {
+    /// A count of the number of fragments that have been completely rebuilt.
     pub rebuilt_fragment_count: u32,
+    /// A count of the number of fragments that are reused, but have had their style change.
     pub restyle_fragment_count: u32,
+    /// A count of the number of fragments that are reused, but may have had their final
+    /// position change.
+    pub possibly_moved_fragment_count: u32,
 }
 
 /// Information needed for a script-initiated reflow that requires a restyle

--- a/tests/wpt/mozilla/meta/MANIFEST.json
+++ b/tests/wpt/mozilla/meta/MANIFEST.json
@@ -13159,6 +13159,13 @@
       null,
       {}
      ]
+    ],
+    "preserved-same-formatting-context-block-layout.html": [
+     "068936574cedc2ad55a98f8a24ea419fab3535cf",
+     [
+      null,
+      {}
+     ]
     ]
    },
    "input-events": {

--- a/tests/wpt/mozilla/tests/incremental-layout/preserved-same-formatting-context-block-layout.html
+++ b/tests/wpt/mozilla/tests/incremental-layout/preserved-same-formatting-context-block-layout.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+
+<div>
+  <p id="p1">Example1</p>
+  <p id="p2">Example2</p>
+  <p id="p3">Example3</p>
+  <p id="p4">Example4</p>
+  <p id="p5">Example5</p>
+</div>
+
+<script>
+setup({explicit_done:true});
+
+window.onload = () => {
+    test((t) => {
+        ServoTestUtils.forceLayout();
+        p1.innerText = "Changed";
+
+        let result = ServoTestUtils.forceLayout();
+
+        // text fragment + p1 + div + body + root
+        assert_equals(result.rebuiltFragmentCount, 5, "rebuiltFragmentCount");
+        assert_equals(result.restyleFragmentCount, 0, "restyleFragmentCount");
+        // p2 + p3 + p4 + p5
+        assert_equals(result.possiblyMovedFragmentCount, 4, "possiblyMovedFragmentCount");
+
+    }, "Updating a sibling should not cause fragments to be rebuilt");
+
+    done();
+}
+</script>


### PR DESCRIPTION
Add a cache for `SameFormattingContextBlock`s: A new kind of cache
is added which allows reusing fragments for
`SameFormattingContextBlock` (the majority of block level elements).
This can reduce the amount of fragment tree construction during
incremental layout (although with a 40 byte overhead per
`SameFormattingContextBlock`).

Testing: This change adds a new Servo-specific WPT test that verifies that
the minimal number of `Fragment`s are rebuilt after an incremental layout.
Previously, when running `flexbox-deeply-nested-column-flow.html` from
`tests/blink_perf_tests/perf_tests/layout/`, performance would degrade
with successive test runs. This is due to how slow inline layout is. This change
removes that progressive degradation, though we may be able to remove
this cache with improvements to inline layout. 
