### PR TITLE
devtools: Avoid creating unnecessary new frame actors

### DIFF
--- a/components/script_bindings/webidls/DebuggerInterruptEvent.webidl
+++ b/components/script_bindings/webidls/DebuggerInterruptEvent.webidl
@@ -10,7 +10,7 @@ interface DebuggerInterruptEvent : Event {};
 partial interface DebuggerGlobalScope {
     undefined pauseAndRespond(
         PipelineIdInit pipelineId,
-        DOMString frameActorId,
+        FrameOffset frameOffset,
         PauseReason pauseReason);
 
     DOMString? registerFrameActor(
@@ -24,12 +24,16 @@ dictionary PauseReason {
 };
 
 dictionary FrameInfo {
-    required unsigned long column;
     required DOMString displayName;
-    required unsigned long line;
     required boolean onStack;
     required boolean oldest;
     required boolean terminated;
     required DOMString type_;
     required DOMString url;
+};
+
+dictionary FrameOffset {
+    required DOMString frameActorId;
+    required unsigned long column;
+    required unsigned long line;
 };

--- a/components/shared/devtools/lib.rs
+++ b/components/shared/devtools/lib.rs
@@ -133,7 +133,7 @@ pub enum ScriptToDevtoolsControlMsg {
     DomMutation(PipelineId, DomMutation),
 
     /// The debugger is paused, sending frame information.
-    DebuggerPause(PipelineId, String, PauseReason),
+    DebuggerPause(PipelineId, FrameOffset, PauseReason),
 
     /// Get frame information from script
     CreateFrameActor(GenericSender<String>, PipelineId, FrameInfo),
@@ -573,9 +573,7 @@ pub struct RecommendedBreakpointLocation {
 #[derive(Clone, Debug, Deserialize, MallocSizeOf, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct FrameInfo {
-    pub column: u32,
     pub display_name: String,
-    pub line: u32,
     pub on_stack: bool,
     pub oldest: bool,
     pub terminated: bool,
@@ -596,4 +594,11 @@ pub struct PauseReason {
     #[serde(rename = "type")]
     pub type_: String,
     pub on_next: Option<bool>,
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+pub struct FrameOffset {
+    pub actor: String,
+    pub column: u32,
+    pub line: u32,
 }


### PR DESCRIPTION
Before we were creating a new frame actor each time we paused, even if the frame object in debugger.js was the same. Now we avoid this by reusing the same frame actor id.

This helps our upcoming work on onStep, onPop, and onEnterFrame hooks.

Testing: Ran `mach test-devtools` and manually check that it works
Part of: #36027
