### PR TITLE
devtools: Implement initial support for `Step in`, `Step out` and `Step over`

### DIFF
--- a/components/devtools/actors/thread.rs
+++ b/components/devtools/actors/thread.rs
@@ -8,7 +8,7 @@ use atomic_refcell::AtomicRefCell;
 use base::generic_channel::GenericSender;
 use devtools_traits::{DevtoolScriptControlMsg, PauseReason};
 use malloc_size_of_derive::MallocSizeOf;
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 use serde_json::{Map, Value};
 
 use super::source::{SourceManager, SourcesReply};
@@ -65,6 +65,40 @@ struct FramesReply {
     frames: Vec<FrameActorMsg>,
 }
 
+#[derive(Debug, Deserialize, Serialize)]
+#[serde(rename_all = "lowercase")]
+enum ResumeLimitType {
+    Break,
+    Finish,
+    Next,
+    Restart,
+    Step,
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+struct ResumeLimit {
+    #[serde(rename = "type")]
+    type_: ResumeLimitType,
+}
+
+#[derive(Deserialize, Debug)]
+#[serde(rename_all = "camelCase")]
+struct ResumeRequest {
+    resume_limit: Option<ResumeLimit>,
+    #[serde(rename = "frameActorID")]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    frame_actor_id: Option<String>,
+}
+
+impl ResumeRequest {
+    fn get_type(&self) -> Option<String> {
+        let resume_limit = self.resume_limit.as_ref()?;
+        serde_json::to_string(&resume_limit.type_)
+            .ok()
+            .map(|s| s.trim_matches('"').into())
+    }
+}
+
 #[derive(MallocSizeOf)]
 pub(crate) struct ThreadActor {
     name: String,
@@ -94,7 +128,7 @@ impl Actor for ThreadActor {
         mut request: ClientRequest,
         registry: &ActorRegistry,
         msg_type: &str,
-        _msg: &Map<String, Value>,
+        msg: &Map<String, Value>,
         _id: StreamId,
     ) -> Result<(), ActorError> {
         match msg_type {
@@ -122,7 +156,13 @@ impl Actor for ThreadActor {
             },
 
             "resume" => {
-                let _ = self.script_sender.send(DevtoolScriptControlMsg::Resume);
+                let resume: ResumeRequest =
+                    serde_json::from_value(msg.clone().into()).map_err(|_| ActorError::Internal)?;
+
+                let _ = self.script_sender.send(DevtoolScriptControlMsg::Resume(
+                    resume.get_type(),
+                    resume.frame_actor_id,
+                ));
 
                 let msg = ThreadResumedReply {
                     from: self.name(),
@@ -162,6 +202,10 @@ impl Actor for ThreadActor {
             },
 
             "frames" => {
+                // TODO: This should get the youngest frame and its parents from debugger.js
+                // self.frames is not needed
+                // Frame actors should be registered here
+                // https://searchfox.org/firefox-main/source/devtools/server/actors/thread.js#1425
                 let msg = FramesReply {
                     from: self.name(),
                     frames: self

--- a/components/script/dom/debuggerglobalscope.rs
+++ b/components/script/dom/debuggerglobalscope.rs
@@ -37,6 +37,7 @@ use crate::dom::bindings::root::DomRoot;
 use crate::dom::bindings::utils::define_all_exposed_interfaces;
 use crate::dom::debuggerclearbreakpointevent::DebuggerClearBreakpointEvent;
 use crate::dom::debuggerinterruptevent::DebuggerInterruptEvent;
+use crate::dom::debuggerresumeevent::DebuggerResumeEvent;
 use crate::dom::debuggersetbreakpointevent::DebuggerSetBreakpointEvent;
 use crate::dom::globalscope::GlobalScope;
 use crate::dom::types::{
@@ -240,6 +241,24 @@ impl DebuggerGlobalScope {
         assert!(
             event.fire(self.upcast(), can_gc),
             "Guaranteed by DebuggerInterruptEvent::new"
+        );
+    }
+
+    pub(crate) fn fire_resume(
+        &self,
+        resume_limit_type: Option<String>,
+        frame_actor_id: Option<String>,
+        can_gc: CanGc,
+    ) {
+        let event = DomRoot::upcast::<Event>(DebuggerResumeEvent::new(
+            self.upcast(),
+            resume_limit_type.map(DOMString::from),
+            frame_actor_id.map(DOMString::from),
+            can_gc,
+        ));
+        assert!(
+            event.fire(self.upcast(), can_gc),
+            "Guaranteed by DebuggerResumeEvent::new"
         );
     }
 

--- a/components/script/dom/debuggerresumeevent.rs
+++ b/components/script/dom/debuggerresumeevent.rs
@@ -1,0 +1,64 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+use std::fmt::Debug;
+
+use dom_struct::dom_struct;
+use script_bindings::str::DOMString;
+
+use crate::dom::bindings::codegen::Bindings::DebuggerResumeEventBinding::DebuggerResumeEventMethods;
+use crate::dom::bindings::codegen::Bindings::EventBinding::Event_Binding::EventMethods;
+use crate::dom::bindings::reflector::reflect_dom_object;
+use crate::dom::bindings::root::DomRoot;
+use crate::dom::event::Event;
+use crate::dom::types::GlobalScope;
+use crate::script_runtime::CanGc;
+
+#[dom_struct]
+/// Event for Rust → JS calls in [`crate::dom::DebuggerGlobalScope`].
+pub(crate) struct DebuggerResumeEvent {
+    event: Event,
+    resume_limit_type: Option<DOMString>,
+    frame_actor_id: Option<DOMString>,
+}
+
+impl DebuggerResumeEvent {
+    pub(crate) fn new(
+        debugger_global: &GlobalScope,
+        resume_limit_type: Option<DOMString>,
+        frame_actor_id: Option<DOMString>,
+        can_gc: CanGc,
+    ) -> DomRoot<Self> {
+        let result = Box::new(Self {
+            event: Event::new_inherited(),
+            resume_limit_type,
+            frame_actor_id,
+        });
+        let result = reflect_dom_object(result, debugger_global, can_gc);
+        result.event.init_event("resume".into(), false, false);
+
+        result
+    }
+}
+
+impl DebuggerResumeEventMethods<crate::DomTypeHolder> for DebuggerResumeEvent {
+    // check-tidy: no specs after this line
+    fn IsTrusted(&self) -> bool {
+        self.event.IsTrusted()
+    }
+
+    fn GetResumeLimitType(&self) -> Option<DOMString> {
+        self.resume_limit_type.clone()
+    }
+
+    fn GetFrameActorID(&self) -> Option<DOMString> {
+        self.frame_actor_id.clone()
+    }
+}
+
+impl Debug for DebuggerResumeEvent {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("DebuggerResumeEvent").finish()
+    }
+}

--- a/components/script/dom/mod.rs
+++ b/components/script/dom/mod.rs
@@ -260,6 +260,7 @@ pub(crate) mod debuggerevalevent;
 pub(crate) mod debuggergetpossiblebreakpointsevent;
 pub(crate) mod debuggerglobalscope;
 pub(crate) mod debuggerinterruptevent;
+pub(crate) mod debuggerresumeevent;
 pub(crate) mod debuggersetbreakpointevent;
 pub(crate) mod dissimilaroriginlocation;
 pub(crate) mod dissimilaroriginwindow;

--- a/components/script/script_thread.rs
+++ b/components/script/script_thread.rs
@@ -2279,7 +2279,12 @@ impl ScriptThread {
             DevtoolScriptControlMsg::Interrupt => {
                 self.debugger_global.fire_interrupt(CanGc::from_cx(cx));
             },
-            DevtoolScriptControlMsg::Resume => {
+            DevtoolScriptControlMsg::Resume(resume_limit_type, frame_actor_id) => {
+                self.debugger_global.fire_resume(
+                    resume_limit_type,
+                    frame_actor_id,
+                    CanGc::from_cx(cx),
+                );
                 self.debugger_paused.set(false);
             },
         }

--- a/components/script_bindings/webidls/DebuggerResumeEvent.webidl
+++ b/components/script_bindings/webidls/DebuggerResumeEvent.webidl
@@ -1,0 +1,11 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+// This interface is entirely internal to Servo, and should not be accessible to
+// web pages.
+[Exposed=DebuggerGlobalScope]
+interface DebuggerResumeEvent : Event {
+    readonly attribute DOMString? resumeLimitType;
+    readonly attribute DOMString? frameActorID;
+};

--- a/components/shared/devtools/lib.rs
+++ b/components/shared/devtools/lib.rs
@@ -338,7 +338,7 @@ pub enum DevtoolScriptControlMsg {
     SetBreakpoint(u32, u32, u32),
     ClearBreakpoint(u32, u32, u32),
     Interrupt,
-    Resume,
+    Resume(Option<String>, Option<String>),
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize, MallocSizeOf)]

--- a/resources/debugger.js
+++ b/resources/debugger.js
@@ -140,6 +140,9 @@ addEventListener("getPossibleBreakpoints", event => {
 });
 
 function handlePauseAndRespond(frame, pauseReason) {
+    dbg.onEnterFrame = undefined;
+    clearSteppingHooks();
+
     // Get the pipeline ID for this debuggee
     const pipelineId = debuggeesToPipelineIds.get(frame.script.global);
     if (!pipelineId) {
@@ -204,10 +207,90 @@ addEventListener("setBreakpoint", event => {
 
 // <https://firefox-source-docs.mozilla.org/js/Debugger/Debugger.Frame.html>
 addEventListener("interrupt", event => {
-    dbg.onEnterFrame = function(frame) {
-        dbg.onEnterFrame = undefined;
-        handlePauseAndRespond(frame, { type_:PAUSE_REASONS.INTERRUPTED, onNext: true});
-    };
+    dbg.onEnterFrame = (frame) => handlePauseAndRespond(
+        frame,
+        { type_: PAUSE_REASONS.INTERRUPTED, onNext: true }
+    );
+});
+
+function makeSteppingHooks(steppingType, startFrame) {
+    return {
+        onEnterFrame: (frame) => {
+            const { onStep, onPop } = makeSteppingHooks("next", frame);
+            frame.onStep = onStep;
+            frame.onPop = onPop;
+        },
+        onStep: () => {
+            const meta = startFrame.script.getOffsetMetadata(startFrame.offset);
+            if (meta.isBreakpoint && meta.isStepStart) {
+                return handlePauseAndRespond(startFrame, { type_: PAUSE_REASONS.RESUME_LIMIT });
+            }
+        },
+        onPop: () => {},
+    }
+}
+
+function getNextStepFrame(frame) {
+    const endOfFrame = frame.reportedPop;
+    const stepFrame = endOfFrame ? frame.older : frame;
+    if (!stepFrame || !stepFrame.script) {
+      return null;
+    }
+    return stepFrame;
+}
+
+// <https://searchfox.org/firefox-main/source/devtools/server/actors/thread.js#1235>
+function attachSteppingHooks(steppingType, frame) {
+    if (steppingType === "finish" && frame.reportedPop) {
+      steppingType = "next";
+    }
+
+    const stepFrame = getNextStepFrame(frame);
+    if (!stepFrame) {
+        steppingType = "step";
+    }
+
+    const { onEnterFrame, onPop, onStep } = makeSteppingHooks(
+        steppingType,
+        frame,
+    );
+
+    if (steppingType === "step") {
+        dbg.onEnterFrame = onEnterFrame;
+    }
+
+    if (stepFrame) {
+        switch (steppingType) {
+            case "step":
+            case "next":
+                if (stepFrame.script) {
+                    stepFrame.onStep = onStep;
+                }
+        }
+    }
+}
+
+function clearSteppingHooks() {
+    let frame = this.youngestFrame;
+    if (frame?.onStack) {
+        while (frame) {
+            frame.onStep = undefined;
+            frame.onPop = undefined;
+            frame = frame.older;
+        }
+    }
+}
+
+// <https://firefox-source-docs.mozilla.org/devtools/backend/protocol.html#resuming-a-thread>
+addEventListener("resume", event => {
+    const {resumeLimitType: steppingType, frameActorID} = event;
+    console.log("\n\n\n---------", steppingType);
+    if (steppingType) {
+        const frame = frameActorsToFrames.get(frameActorID);
+        attachSteppingHooks(steppingType, frame);
+    } else {
+        clearSteppingHooks();
+    }
 });
 
 // <https://firefox-source-docs.mozilla.org/js/Debugger/Debugger.Script.html#clearbreakpoint-handler-offset>


### PR DESCRIPTION
We are adding initial support for stepping in the debugger. Step over mostly works, but Step in and Step out have some quirks that we are working on.

![2026-02-27 12-32-05](https://github.com/user-attachments/assets/0b73b32c-efa3-444c-80a4-f863a64b6fdc)

Testing: DevTools tests and manual checks.
Part of: #36027