### PR TITLE
script: Handle async parser being aborted while still running

### DIFF
--- a/components/script/dom/document.rs
+++ b/components/script/dom/document.rs
@@ -6452,24 +6452,25 @@ impl DocumentMethods<crate::DomTypeHolder> for Document {
     /// <https://html.spec.whatwg.org/multipage/#dom-document-close>
     fn Close(&self, cx: &mut js::context::JSContext) -> ErrorResult {
         if !self.is_html_document() {
-            // Step 1.
+            // Step 1. If this is an XML document, then throw an "InvalidStateError" DOMException.
             return Err(Error::InvalidState(None));
         }
 
-        // Step 2.
+        // Step 2. If this's throw-on-dynamic-markup-insertion counter is greater than zero,
+        // then throw an "InvalidStateError" DOMException.
         if self.throw_on_dynamic_markup_insertion_counter.get() > 0 {
             return Err(Error::InvalidState(None));
         }
 
+        // Step 3. If there is no script-created parser associated with this, then return.
         let parser = match self.get_current_parser() {
             Some(ref parser) if parser.is_script_created() => DomRoot::from_ref(&**parser),
             _ => {
-                // Step 3.
                 return Ok(());
             },
         };
 
-        // Step 4-6.
+        // parser.close implements the remainder of this algorithm
         parser.close(cx);
 
         Ok(())

--- a/components/script/dom/servoparser/mod.rs
+++ b/components/script/dom/servoparser/mod.rs
@@ -454,19 +454,20 @@ impl ServoParser {
         assert!(input.is_empty());
     }
 
-    // Steps 4-6 of https://html.spec.whatwg.org/multipage/#dom-document-close
+    /// Steps 4-6 of <https://html.spec.whatwg.org/multipage/#dom-document-close>
     pub(crate) fn close(&self, cx: &mut js::context::JSContext) {
         assert!(self.script_created_parser);
 
-        // Step 4.
+        // Step 4. Insert an explicit "EOF" character at the end of the parser's input stream.
         self.last_chunk_received.set(true);
 
+        // Step 5. If this's pending parsing-blocking script is not null, then return.
         if self.suspended.get() {
-            // Step 5.
             return;
         }
 
-        // Step 6.
+        // Step 6. Run the tokenizer, processing resulting tokens as they are emitted,
+        // and stopping when the tokenizer reaches the explicit "EOF" character or spins the event loop.
         self.parse_sync(cx);
     }
 


### PR DESCRIPTION
This fixes a crash on the attached testcase when running with the async html parser enabled. The crash also triggers on wpt. When executing parse ops received from the async parser, we were not considering the case where one of these operations causes the parser to abort (in the case above, said operation is the `<popup-info></popup-info>`). 

```html
<body>
<script>
class PopupInfo extends HTMLElement {
  connectedCallback() {
    document.open();
  }
}

customElements.define('popup-info', PopupInfo);
</script>
<popup-info></popup-info>
</body>
```
 The bug is very obscure and only triggers if `document.open` is called while there is no parser-blocking script **and** the document parser is still active.


Testing: We don't run tests on the async parser yet
Fixes: Part of https://github.com/servo/servo/issues/37418