### PR TITLE
media: Propagate errors from `GStreamerMediaStream::encoded`

### DIFF
--- a/components/media/audio/context.rs
+++ b/components/media/audio/context.rs
@@ -219,7 +219,7 @@ impl AudioContext {
         let _ = self
             .sender
             .send(AudioRenderThreadMsg::CreateNode(node_type, tx, ch));
-        rx.recv().ok()
+        rx.recv().ok().flatten()
     }
 
     // Resume audio processing.

--- a/components/media/audio/lib.rs
+++ b/components/media/audio/lib.rs
@@ -56,7 +56,7 @@ pub trait AudioBackend {
     fn make_streamreader(
         id: servo_media_streams::MediaStreamId,
         sample_rate: f32,
-    ) -> Box<dyn AudioStreamReader + Send>;
+    ) -> Result<Box<dyn AudioStreamReader + Send>, sink::AudioSinkError>;
 }
 
 pub trait AudioStreamReader {

--- a/components/media/backends/dummy/lib.rs
+++ b/components/media/backends/dummy/lib.rs
@@ -135,8 +135,8 @@ impl AudioBackend for DummyBackend {
     fn make_streamreader(
         _id: MediaStreamId,
         _sample_rate: f32,
-    ) -> Box<dyn AudioStreamReader + Send> {
-        Box::new(DummyStreamReader)
+    ) -> Result<Box<dyn AudioStreamReader + Send>, AudioSinkError> {
+        Ok(Box::new(DummyStreamReader))
     }
 }
 

--- a/components/media/backends/gstreamer/lib.rs
+++ b/components/media/backends/gstreamer/lib.rs
@@ -311,8 +311,13 @@ impl AudioBackend for GStreamerBackend {
         audio_sink::GStreamerAudioSink::new()
     }
 
-    fn make_streamreader(id: MediaStreamId, sample_rate: f32) -> Box<dyn AudioStreamReader + Send> {
-        Box::new(audio_stream_reader::GStreamerAudioStreamReader::new(id, sample_rate).unwrap())
+    fn make_streamreader(
+        id: MediaStreamId,
+        sample_rate: f32,
+    ) -> Result<Box<dyn AudioStreamReader + Send>, AudioSinkError> {
+        let reader = audio_stream_reader::GStreamerAudioStreamReader::new(id, sample_rate)
+            .map_err(AudioSinkError::Backend)?;
+        Ok(Box::new(reader))
     }
 }
 

--- a/components/media/backends/gstreamer/webrtc.rs
+++ b/components/media/backends/gstreamer/webrtc.rs
@@ -469,7 +469,9 @@ impl GStreamerWebRtcController {
                 self.request_pad_counter = idx + 1;
             }
             stream.attach_to_pipeline(&self.pipeline);
-            let element = stream.encoded();
+            let element = stream.encoded().map_err(|_| {
+                WebRtcError::Backend(String::from("Failed to attach encoding adapters to stream"))
+            })?;
             self.remote_mline_info[idx].is_used = true;
             let caps = stream.caps_with_payload(self.remote_mline_info[idx].payload);
             element.set_property("caps", &caps);
@@ -482,7 +484,9 @@ impl GStreamerWebRtcController {
             self.streams.push(*stream_id);
         } else if request_new_pads {
             stream.attach_to_pipeline(&self.pipeline);
-            let element = stream.encoded();
+            let element = stream.encoded().map_err(|_| {
+                WebRtcError::Backend(String::from("Failed to attach encoding adapters to stream"))
+            })?;
             let caps = stream.caps_with_payload(self.pt_counter);
             self.pt_counter += 1;
             element.set_property("caps", &caps);

--- a/tests/wpt/tests/webaudio/the-audio-api/the-mediaelementaudiosourcenode-interface/mediaElementAudioSource-mediaStreamAudioDestination-stream-crash.html
+++ b/tests/wpt/tests/webaudio/the-audio-api/the-mediaelementaudiosourcenode-interface/mediaElementAudioSource-mediaStreamAudioDestination-stream-crash.html
@@ -1,0 +1,8 @@
+<!doctype html>
+<link rel="help" href="https://github.com/servo/servo/issues/36844">
+<script>
+var context = new AudioContext();
+var stream = (new MediaStreamAudioDestinationNode(context)).stream;
+new MediaStreamAudioSourceNode(context,{mediaStream:stream}) ;
+new MediaStreamAudioSourceNode(context,{mediaStream:stream});
+</script>


### PR DESCRIPTION
Instead of unwrapping in `GStreamerMediaStream::encoded`, properly
propagate errors to callers. This prevents panics when we fail to
build GStreamer pipelines in this code path. This is probably the first
of many changes to avoid `unwrap()`ing in this code.

Testing: This change adds a WPT crash test.
Fixes: #36844.
