### PR TITLE
mach: Remove ensure_clobber

### DIFF
--- a/python/servo/build_commands.py
+++ b/python/servo/build_commands.py
@@ -122,7 +122,6 @@ class MachCommands(CommandBase):
 
         env = self.build_env()
         self.ensure_bootstrapped()
-        self.ensure_clobbered()
 
         host = servo.platform.host_triple()
         target_triple = self.target.triple()

--- a/python/servo/command_base.py
+++ b/python/servo/command_base.py
@@ -35,7 +35,6 @@ from xml.etree.ElementTree import XML
 
 import toml
 from mach.decorators import CommandArgument, CommandArgumentGroup
-from mach.registrar import Registrar
 
 import servo.platform
 import servo.util as util
@@ -960,30 +959,3 @@ class CommandBase(object):
             installed_targets = installed_targets.decode("utf-8")
         if self.target.triple() not in installed_targets:
             check_call(["rustup", "target", "add", self.target.triple()], cwd=self.context.topdir)
-
-    def ensure_clobbered(self, target_dir: str | None = None) -> None:
-        if target_dir is None:
-            target_dir = util.get_target_dir()
-        auto = True if os.environ.get("AUTOCLOBBER", False) else False
-        src_clobber = os.path.join(self.context.topdir, "CLOBBER")
-        target_clobber = os.path.join(target_dir, "CLOBBER")
-
-        if not os.path.exists(target_dir):
-            os.makedirs(target_dir)
-
-        if not os.path.exists(target_clobber):
-            # Simply touch the file.
-            with open(target_clobber, "a"):
-                pass
-
-        if auto:
-            if os.path.getmtime(src_clobber) > os.path.getmtime(target_clobber):
-                print("Automatically clobbering target directory: {}".format(target_dir))
-
-                try:
-                    Registrar.dispatch("clean", context=self.context, verbose=True)
-                    print("Successfully completed auto clobber.")
-                except subprocess.CalledProcessError as error:
-                    sys.exit(error.returncode)
-            else:
-                print("Clobber not needed.")

--- a/python/servo/devenv_commands.py
+++ b/python/servo/devenv_commands.py
@@ -33,7 +33,6 @@ class MachCommands(CommandBase):
             params = []
 
         self.ensure_bootstrapped()
-        self.ensure_clobbered()
         status = self.run_cargo_build_like_command("check", params, **kwargs)
         assert isinstance(status, int)
         if status == 0:
@@ -60,7 +59,6 @@ class MachCommands(CommandBase):
             params = []
 
         self.ensure_bootstrapped()
-        self.ensure_clobbered()
         status = self.run_cargo_build_like_command("fix", params, **kwargs)
         assert isinstance(status, int)
         return status
@@ -87,7 +85,6 @@ class MachCommands(CommandBase):
             return 1
 
         self.ensure_bootstrapped()
-        self.ensure_clobbered()
         env = self.build_env()
         env["RUSTC"] = "rustc"
 


### PR DESCRIPTION
We don't use the CLOBBER file anywhere. The CLOBBER was introduced in d03e52d2405a1b9149e9fc6c86f056525cd7c18d, but without any commit message. Judging by the CLOBBER file in that commit, this was related to the CI machines at the time. Should be safe to remove.

Testing: Well, this probably should be reviewed by someone who is familiar with the background. Not covered by any tests.

