### PR TITLE
script_bindings: Fix warnings about `match_domstring_ascii_inner` macro

### DIFF
--- a/components/script_bindings/domstring.rs
+++ b/components/script_bindings/domstring.rs
@@ -1019,7 +1019,7 @@ macro_rules! match_domstring_ascii_inner {
         } == $input {
           $then
         } else {
-            match_domstring_ascii_inner!($variant, $input, $($rest)*)
+            $crate::match_domstring_ascii_inner!($variant, $input, $($rest)*)
         }
 
     };

--- a/components/script_bindings/domstring.rs
+++ b/components/script_bindings/domstring.rs
@@ -1047,15 +1047,14 @@ macro_rules! match_domstring_ascii_inner {
 macro_rules! match_domstring_ascii {
     ($input:expr, $($tail:tt)*) => {
         {
-            use $crate::match_domstring_ascii_inner;
             use $crate::domstring::EncodedBytes;
 
             let view = $input.view();
             let s = view.encoded_bytes();
             if matches!(s, EncodedBytes::Latin1Bytes(_)) {
-                match_domstring_ascii_inner!(EncodedBytes::Latin1Bytes, s, $($tail)*)
+                $crate::match_domstring_ascii_inner!(EncodedBytes::Latin1Bytes, s, $($tail)*)
             } else {
-                match_domstring_ascii_inner!(EncodedBytes::Utf8Bytes, s, $($tail)*)
+                $crate::match_domstring_ascii_inner!(EncodedBytes::Utf8Bytes, s, $($tail)*)
             }
         }
     };


### PR DESCRIPTION
The warning occurs when compiling the script bindings unit-tests `./mach test-unit -p script_bindings --lib`.
Presumably in some contexts the inner macro is already imported, which triggers the warning.
Directly using `crate::` avoids this.

The fixed warning:
```
warning: unused import: `$crate::match_domstring_ascii_inner`
    --> components/script_bindings/domstring.rs:1050:17
     |
1050 |               use $crate::match_domstring_ascii_inner;
     |                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
...
1352 |           let _res = match_domstring_ascii!(s,
     |  ____________________-
1353 | |             "❤" => true,
1354 | |             _ => false,);
     | |________________________- in this macro invocation
     |
     = note: this warning originates in the macro `match_domstring_ascii` (in Nightly builds, run with -Z macro-backtrace for more info)
```

Testing: Manually tested the warning is fixed by running `./mach test-unit -p script_bindings --lib`.

