### PR TITLE
Build nightly releases earlier for WPT

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,8 +2,8 @@ name: Release
 
 on:
   schedule:
-    # Run at 5:15 am, daily.
-    - cron: '15 5 * * *'
+    # Run at 1:15 am, daily.
+    - cron: '15 1 * * *'
   workflow_dispatch:
     inputs:
       # Note: On scheduled runs `inputs.regular_release` will be `null`, which allows us to create

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,8 +2,9 @@ name: Release
 
 on:
   schedule:
-    # Run at 1:15 am, daily.
-    - cron: '15 1 * * *'
+    # Run at 22:15 pm, daily.
+    # To make sure it finishes in time before next WPT daily epoch run
+    - cron: '15 22 * * *'
   workflow_dispatch:
     inputs:
       # Note: On scheduled runs `inputs.regular_release` will be `null`, which allows us to create


### PR DESCRIPTION
WPT creates `epochs/daily` either at 2 or 3AM. This means that if a fix land on day 1, then WPT is tagged earlier than the nightly release, so it can take 24-48 hours before a change is reflected on wpt.fyi

If instead we create the nightly release in time before epoch, we can see those results within 24 hours.

Testing: GitHub workflow change
