### PR TITLE
paint: Clamp `initial-scale` while processing `ViewportDescription`

### DIFF
--- a/components/paint/webview_renderer.rs
+++ b/components/paint/webview_renderer.rs
@@ -1048,9 +1048,7 @@ impl WebViewRenderer {
     }
 
     pub fn set_viewport_description(&mut self, viewport_description: ViewportDescription) {
-        self.set_page_zoom(Scale::new(
-            viewport_description.clamp_page_zoom(viewport_description.initial_scale.get()),
-        ));
+        self.set_page_zoom(viewport_description.initial_scale);
         self.viewport_description = Some(viewport_description);
     }
 

--- a/components/shared/paint/viewport_description.rs
+++ b/components/shared/paint/viewport_description.rs
@@ -124,6 +124,8 @@ impl ViewportDescription {
                 _ => (),
             }
         }
+        description.initial_scale =
+            Scale::new(description.clamp_zoom(description.initial_scale.get()));
         description
     }
 
@@ -141,7 +143,7 @@ impl ViewportDescription {
     }
 
     /// Constrains a zoom value within the allowed scale range
-    pub fn clamp_page_zoom(&self, zoom: f32) -> f32 {
+    pub fn clamp_zoom(&self, zoom: f32) -> f32 {
         zoom.clamp(self.minimum_scale.get(), self.maximum_scale.get())
     }
 }


### PR DESCRIPTION
We can clamp the `initial-scale` while processing `ViewportDescription`. No need to have a long route to clamp it and removes circular dependency.

Testing: This is just a minor refactoring. No change in behavior expected.
