### PR TITLE
mem: fix camelCase in JSON serialization of memory reports

### DIFF
--- a/components/shared/profile/mem.rs
+++ b/components/shared/profile/mem.rs
@@ -269,6 +269,7 @@ pub struct MemoryReport {
     /// The pid of the report
     pub pid: u32,
     /// Is this the main process
+    #[serde(rename = "isMainProcess")]
     pub is_main_process: bool,
     /// All the reports for this pid
     pub reports: Vec<Report>,


### PR DESCRIPTION
The change in 2d3a7c87c288 dropped the camelCase formatting of is_main_process. As a result the about:memory page claims that all processes are content processes.

Testing: run `./mach run -M` and open `about:memory` . The first process listed will be "Main process" with this change.

