### PR TITLE
paint: Track whether script is handling touchmove per `TouchId`

### DIFF
--- a/components/paint/touch.rs
+++ b/components/paint/touch.rs
@@ -73,6 +73,11 @@ pub enum TouchMoveAllowed {
     Pending,
 }
 
+pub(crate) enum TouchIdMoveTracking {
+    Track,
+    Remove,
+}
+
 /// A cached [`PaintHitTestResult`] to use during a touch sequence. This
 /// is kept so that the renderer doesn't have to constantly keep making hit tests
 /// while during panning and flinging actions.
@@ -233,13 +238,16 @@ impl TouchHandler {
         &mut self,
         sequence_id: TouchSequenceId,
         touch_id: TouchId,
-        flag: bool,
+        flag: TouchIdMoveTracking,
     ) {
         if let Some(sequence) = self.touch_sequence_map.get_mut(&sequence_id) {
-            if flag {
-                sequence.touch_ids_in_move.insert(touch_id);
-            } else {
-                sequence.touch_ids_in_move.remove(&touch_id);
+            match flag {
+                TouchIdMoveTracking::Track => {
+                    sequence.touch_ids_in_move.insert(touch_id);
+                },
+                TouchIdMoveTracking::Remove => {
+                    sequence.touch_ids_in_move.remove(&touch_id);
+                },
             }
         }
     }

--- a/components/paint/touch.rs
+++ b/components/paint/touch.rs
@@ -9,7 +9,7 @@ use base::id::WebViewId;
 use embedder_traits::{InputEventId, PaintHitTestResult, Scroll, TouchEventType, TouchId};
 use euclid::{Point2D, Scale, Vector2D};
 use log::{debug, error, warn};
-use rustc_hash::FxHashMap;
+use rustc_hash::{FxHashMap, FxHashSet};
 use style_traits::CSSPixel;
 use webrender_api::units::{DevicePixel, DevicePoint, DeviceVector2D};
 
@@ -90,7 +90,7 @@ pub struct TouchSequenceInfo {
     ///
     /// We use this to skip sending the event to the script thread,
     /// to prevent overloading script.
-    handling_touch_move: bool,
+    touch_ids_in_move: FxHashSet<TouchId>,
     /// Do not perform a click action.
     ///
     /// This happens when
@@ -209,7 +209,7 @@ impl TouchHandler {
         let finished_info = TouchSequenceInfo {
             state: TouchSequenceState::Finished,
             active_touch_points: vec![],
-            handling_touch_move: false,
+            touch_ids_in_move: FxHashSet::default(),
             prevent_click: false,
             prevent_move: TouchMoveAllowed::Pending,
             pending_touch_move_actions: vec![],
@@ -229,16 +229,29 @@ impl TouchHandler {
         }
     }
 
-    pub(crate) fn set_handling_touch_move(&mut self, sequence_id: TouchSequenceId, flag: bool) {
+    pub(crate) fn set_handling_touch_move_for_touch_id(
+        &mut self,
+        sequence_id: TouchSequenceId,
+        touch_id: TouchId,
+        flag: bool,
+    ) {
         if let Some(sequence) = self.touch_sequence_map.get_mut(&sequence_id) {
-            sequence.handling_touch_move = flag;
+            if flag {
+                sequence.touch_ids_in_move.insert(touch_id);
+            } else {
+                sequence.touch_ids_in_move.remove(&touch_id);
+            }
         }
     }
 
-    pub(crate) fn is_handling_touch_move(&self, sequence_id: TouchSequenceId) -> bool {
+    pub(crate) fn is_handling_touch_move_for_touch_id(
+        &self,
+        sequence_id: TouchSequenceId,
+        touch_id: TouchId,
+    ) -> bool {
         self.touch_sequence_map
             .get(&sequence_id)
-            .is_some_and(|seq| seq.handling_touch_move)
+            .is_some_and(|seq| seq.touch_ids_in_move.contains(&touch_id))
     }
 
     pub(crate) fn prevent_click(&mut self, sequence_id: TouchSequenceId) {
@@ -338,7 +351,7 @@ impl TouchHandler {
                 TouchSequenceInfo {
                     state: Touching,
                     active_touch_points,
-                    handling_touch_move: false,
+                    touch_ids_in_move: FxHashSet::default(),
                     prevent_click: false,
                     prevent_move: TouchMoveAllowed::Pending,
                     pending_touch_move_actions: vec![],
@@ -710,7 +723,6 @@ impl TouchHandler {
 pub(crate) struct PendingTouchInputEvent {
     pub event_type: TouchEventType,
     pub sequence_id: TouchSequenceId,
-    #[expect(unused)]
     pub touch_id: TouchId,
 }
 

--- a/components/paint/touch.rs
+++ b/components/paint/touch.rs
@@ -91,7 +91,7 @@ pub struct TouchSequenceInfo {
     pub(crate) state: TouchSequenceState,
     /// touch sequence active touch points
     active_touch_points: Vec<TouchPoint>,
-    /// The script thread is already processing a touchmove operation.
+    /// Whether the script thread is already processing a touchmove operation for the TouchId.
     ///
     /// We use this to skip sending the event to the script thread,
     /// to prevent overloading script.

--- a/components/paint/webview_renderer.rs
+++ b/components/paint/webview_renderer.rs
@@ -34,7 +34,9 @@ use crate::painter::Painter;
 use crate::pinch_zoom::PinchZoom;
 use crate::pipeline_details::PipelineDetails;
 use crate::refresh_driver::BaseRefreshDriver;
-use crate::touch::{PendingTouchInputEvent, TouchHandler, TouchMoveAllowed, TouchSequenceState};
+use crate::touch::{
+    PendingTouchInputEvent, TouchHandler, TouchIdMoveTracking, TouchMoveAllowed, TouchSequenceState,
+};
 
 #[derive(Clone, Copy)]
 pub(crate) struct ScrollEvent {
@@ -490,7 +492,7 @@ impl WebViewRenderer {
             self.touch_handler.set_handling_touch_move_for_touch_id(
                 self.touch_handler.current_sequence_id,
                 event.touch_id,
-                true,
+                TouchIdMoveTracking::Track,
             );
         }
     }
@@ -546,7 +548,7 @@ impl WebViewRenderer {
                         self.touch_handler.set_handling_touch_move_for_touch_id(
                             self.touch_handler.current_sequence_id,
                             touch_id,
-                            false,
+                            TouchIdMoveTracking::Remove,
                         );
                         self.touch_handler
                             .remove_pending_touch_move_actions(sequence_id);
@@ -610,7 +612,7 @@ impl WebViewRenderer {
                     self.touch_handler.set_handling_touch_move_for_touch_id(
                         self.touch_handler.current_sequence_id,
                         touch_id,
-                        false,
+                        TouchIdMoveTracking::Remove,
                     );
                     if let Some(info) = self.touch_handler.get_touch_sequence_mut(sequence_id) {
                         if info.prevent_move == TouchMoveAllowed::Pending {

--- a/components/paint/webview_renderer.rs
+++ b/components/paint/webview_renderer.rs
@@ -481,14 +481,17 @@ impl WebViewRenderer {
         // When the event is touchmove, if the script thread is processing the touch
         // move event, we skip sending the event to the script thread.
         // This prevents the script thread from stacking up for a large amount of time.
-        if !self
-            .touch_handler
-            .is_handling_touch_move(self.touch_handler.current_sequence_id) &&
-            self.send_touch_event(render_api, event, id) &&
+        if !self.touch_handler.is_handling_touch_move_for_touch_id(
+            self.touch_handler.current_sequence_id,
+            event.touch_id,
+        ) && self.send_touch_event(render_api, event, id) &&
             event.is_cancelable()
         {
-            self.touch_handler
-                .set_handling_touch_move(self.touch_handler.current_sequence_id, true);
+            self.touch_handler.set_handling_touch_move_for_touch_id(
+                self.touch_handler.current_sequence_id,
+                event.touch_id,
+                true,
+            );
         }
     }
 
@@ -514,11 +517,10 @@ impl WebViewRenderer {
         pending_touch_input_event: PendingTouchInputEvent,
         result: InputEventResult,
     ) {
-        // TODO: This is gonna be used very soon, for tracking move per touch_id.
         let PendingTouchInputEvent {
             sequence_id,
             event_type,
-            touch_id: _,
+            touch_id,
         } = pending_touch_input_event;
 
         if result.contains(InputEventResult::DefaultPrevented) {
@@ -541,8 +543,11 @@ impl WebViewRenderer {
                         if let TouchSequenceState::PendingFling { .. } = info.state {
                             info.state = TouchSequenceState::Finished;
                         }
-                        self.touch_handler
-                            .set_handling_touch_move(self.touch_handler.current_sequence_id, false);
+                        self.touch_handler.set_handling_touch_move_for_touch_id(
+                            self.touch_handler.current_sequence_id,
+                            touch_id,
+                            false,
+                        );
                         self.touch_handler
                             .remove_pending_touch_move_actions(sequence_id);
                     }
@@ -602,8 +607,11 @@ impl WebViewRenderer {
                         self.touch_handler
                             .take_pending_touch_move_actions(sequence_id),
                     );
-                    self.touch_handler
-                        .set_handling_touch_move(self.touch_handler.current_sequence_id, false);
+                    self.touch_handler.set_handling_touch_move_for_touch_id(
+                        self.touch_handler.current_sequence_id,
+                        touch_id,
+                        false,
+                    );
                     if let Some(info) = self.touch_handler.get_touch_sequence_mut(sequence_id) {
                         if info.prevent_move == TouchMoveAllowed::Pending {
                             info.prevent_move = TouchMoveAllowed::Allowed;

--- a/components/shared/embedder/input_events.rs
+++ b/components/shared/embedder/input_events.rs
@@ -238,7 +238,7 @@ pub enum TouchEventType {
 /// An opaque identifier for a touch point.
 ///
 /// <http://w3c.github.io/touch-events/#widl-Touch-identifier>
-#[derive(Clone, Copy, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
 pub struct TouchId(pub i32);
 
 #[derive(Clone, Copy, Debug, Deserialize, Serialize)]

--- a/tests/wpt/tests/touch-events/multi-touch-touchmove.html
+++ b/tests/wpt/tests/touch-events/multi-touch-touchmove.html
@@ -1,0 +1,41 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8">
+    <title>Simultaneous Touch Moves from multiple pointers</title>
+    <link rel=help href="https://github.com/servo/servo/issues/42921">
+    <link rel="author" title="Euclid Ye" href="mailto:yezhizhenjiakang@gmail.com">
+    <script src="/resources/testharness.js"></script>
+    <script src="/resources/testharnessreport.js"></script>
+    <script src="/resources/testdriver.js"></script>
+    <script src="/resources/testdriver-actions.js"></script>
+    <script src="/resources/testdriver-vendor.js"></script>
+</head>
+<body>
+    <script>
+        promise_test(async () => {
+            const seenPointers = new Set();
+            document.addEventListener("touchmove", (e) => {
+                for (let touch of e.changedTouches) {
+                    seenPointers.add(touch.identifier);
+                }
+            });
+
+            await new test_driver.Actions()
+                .addPointer("f1", "touch")
+                .addPointer("f2", "touch")
+                .pointerMove(10, 10, { origin: "viewport", sourceName: "f1" })
+                .pointerMove(15, 15, { origin: "viewport", sourceName: "f2" })
+                .pointerDown({ sourceName: "f1" })
+                .pointerDown({ sourceName: "f2" })
+                .pointerMove(30, 30, { origin: "viewport", duration: 0, sourceName: "f1" })
+                .pointerMove(40, 40, { origin: "viewport", duration: 0, sourceName: "f2" })
+                .pointerUp({ sourceName: "f1" })
+                .pointerUp({ sourceName: "f2" })
+                .send();
+
+            assert_equals(seenPointers.size, 2, "Should have captured 2 distinct touch identifiers");
+        }, "Touchmove events should track multiple pointers");
+    </script>
+</body>
+</html>


### PR DESCRIPTION
As titled. The change is prepared a while ago to eliminate dead code, 
but the test case added requires change from `testdriver-actions.js`: 
https://github.com/web-platform-tests/wpt/pull/57607 just landed by latest wpt-sync: https://github.com/servo/servo/pull/42925.

Part of https://github.com/servo/servo/issues/41923

Testing: Added a WPT test.
Fixes: https://github.com/servo/servo/issues/42921
