### PR TITLE
ohos CI: Add timeouts

### DIFF
--- a/.github/workflows/ohos.yml
+++ b/.github/workflows/ohos.yml
@@ -43,8 +43,9 @@ env:
   MITMDUMP_CACHE_KEY: mitmdump-ohos-cache-0.1
 
 jobs:
-  build:
+  build-openharmony:
     name: OpenHarmony Build
+    timeout-minutes: 60
     runs-on: ubuntu-22.04
     strategy:
       matrix:
@@ -165,6 +166,7 @@ jobs:
   # if we figure out how to make hvigor build for harmonyos without the HOS commandline-tools installed.
   build-harmonyos-aarch64:
     name: HarmonyOS Build (aarch64)
+    timeout-minutes: 60
     runs-on: hos-builder
     if: github.repository == 'servo/servo'
     outputs:
@@ -196,6 +198,7 @@ jobs:
 
   bench-harmonyos-aarch64:
     name: Benching HarmonyOS aarch64
+    timeout-minutes: 40
     env:
       # This will ensure the scenario pyproject.toml is picked up and the correct venv used.
       UV_PROJECT: "etc/ci/scenario"
@@ -354,6 +357,7 @@ jobs:
   scenario-test-harmonyos:
     name: Mossel Scenario test
     continue-on-error: true
+    timeout-minutes: 20
     runs-on: hos-runner
     if: github.repository == 'servo/servo' && needs.build-harmonyos-aarch64.outputs.job_status == 'success'
     needs: build-harmonyos-aarch64

--- a/.github/workflows/ohos.yml
+++ b/.github/workflows/ohos.yml
@@ -146,7 +146,7 @@ jobs:
           echo "artifact_ids=${{steps.upload-library.outputs.artifact-id}},${{steps.upload-hap-signed.outputs.artifact-id}}" >> $GITHUB_OUTPUT
 
   bencher:
-    needs: ["build"]
+    needs: ["build-openharmony"]
     strategy:
       matrix:
         target: ["aarch64-unknown-linux-ohos", "x86_64-unknown-linux-ohos"]


### PR DESCRIPTION
There's some hanged scenarios with mitmproxy: https://github.com/servo/servo/actions/runs/22539387007/job/65292396178

1. We rename `build` to `build-openharmony`.
2. We add 
- 60 minutes timeout for each Build profile
- 40 minutes for bencher (Normally finish under 10 mins)
- 20 mins for scenario tests. (Normally finish under 4 mins)