### PR TITLE
Bump version to 0.0.6 in preparation for release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8615,7 +8615,7 @@ dependencies = [
 
 [[package]]
 name = "servoshell"
-version = "0.0.5"
+version = "0.0.6"
 dependencies = [
  "accesskit",
  "android_logger",

--- a/Info.plist
+++ b/Info.plist
@@ -17,7 +17,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.0.5</string>
+	<string>0.0.6</string>
 	<key>NSHighResolutionCapable</key>
 	<true/>
 	<key>NSPrincipalClass</key>

--- a/ports/servoshell/Cargo.toml
+++ b/ports/servoshell/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "servoshell"
 build = "build.rs"
-version = "0.0.5"
+version = "0.0.6"
 authors.workspace = true
 license.workspace = true
 edition.workspace = true

--- a/ports/servoshell/platform/windows/servo.exe.manifest
+++ b/ports/servoshell/platform/windows/servo.exe.manifest
@@ -4,7 +4,7 @@
           xmlns:asmv3="urn:schemas-microsoft-com:asm.v3">
   <assemblyIdentity type="win32"
                     name="servo.Servo"
-                    version="0.0.5.0"/>
+                    version="0.0.6.0"/>
 
   <compatibility xmlns="urn:schemas-microsoft-com:compatibility.v1">
     <application>

--- a/resources/resource_protocol/license.html
+++ b/resources/resource_protocol/license.html
@@ -55,9 +55,9 @@
             <li><a href="#BSD-3-Clause">BSD 3-Clause &quot;New&quot; or &quot;Revised&quot; License</a></li>
             <li><a href="#ISC">ISC License</a></li>
             <li><a href="#BSD-2-Clause">BSD 2-Clause &quot;Simplified&quot; License</a></li>
+            <li><a href="#Zlib">zlib License</a></li>
             <li><a href="#BSL-1.0">Boost Software License 1.0</a></li>
             <li><a href="#CDLA-Permissive-2.0">Community Data License Agreement Permissive 2.0</a></li>
-            <li><a href="#Zlib">zlib License</a></li>
             <li><a href="#CC0-1.0">Creative Commons Zero v1.0 Universal</a></li>
             <li><a href="#NCSA">University of Illinois/NCSA Open Source License</a></li>
             <li><a href="#OFL-1.1">SIL Open Font License 1.1</a></li>
@@ -1121,7 +1121,7 @@
                 <h3 id="Apache-2.0">Apache License 2.0</h3>
                     <p>
                         Used by
-                            <a href=" https://github.com/jhpratt/deranged ">deranged 0.5.5</a>
+                            <a href=" https://github.com/jhpratt/deranged ">deranged 0.5.8</a>
                     </p>
                 <pre class="license-text">
                                  Apache License
@@ -1556,10 +1556,11 @@
             </li>
             <li class="license">
                 <h3 id="Apache-2.0">Apache License 2.0</h3>
-                    <p>
-                        Used by
-                            <a href=" https://github.com/bytecodealliance/target-lexicon ">target-lexicon 0.12.16</a>
-                    </p>
+                    <h4>Used by:</h4>
+                    <ul class="license-used-by">
+                        <li><a href=" https://github.com/bytecodealliance/target-lexicon ">target-lexicon 0.12.16</a></li>
+                        <li><a href=" https://github.com/bytecodealliance/target-lexicon ">target-lexicon 0.13.2</a></li>
+                    </ul>
                 <pre class="license-text">
                                  Apache License
                            Version 2.0, January 2004
@@ -2207,9 +2208,12 @@ Software.
                     <h4>Used by:</h4>
                     <ul class="license-used-by">
                         <li><a href=" https://github.com/microsoft/windows-rs ">windows-collections 0.2.0</a></li>
+                        <li><a href=" https://github.com/microsoft/windows-rs ">windows-collections 0.3.2</a></li>
                         <li><a href=" https://github.com/microsoft/windows-rs ">windows-core 0.58.0</a></li>
                         <li><a href=" https://github.com/microsoft/windows-rs ">windows-core 0.61.2</a></li>
+                        <li><a href=" https://github.com/microsoft/windows-rs ">windows-core 0.62.2</a></li>
                         <li><a href=" https://github.com/microsoft/windows-rs ">windows-future 0.2.1</a></li>
+                        <li><a href=" https://github.com/microsoft/windows-rs ">windows-future 0.3.2</a></li>
                         <li><a href=" https://github.com/microsoft/windows-rs ">windows-implement 0.58.0</a></li>
                         <li><a href=" https://github.com/microsoft/windows-rs ">windows-implement 0.60.2</a></li>
                         <li><a href=" https://github.com/microsoft/windows-rs ">windows-interface 0.58.0</a></li>
@@ -2217,10 +2221,13 @@ Software.
                         <li><a href=" https://github.com/microsoft/windows-rs ">windows-link 0.1.3</a></li>
                         <li><a href=" https://github.com/microsoft/windows-rs ">windows-link 0.2.1</a></li>
                         <li><a href=" https://github.com/microsoft/windows-rs ">windows-numerics 0.2.0</a></li>
+                        <li><a href=" https://github.com/microsoft/windows-rs ">windows-numerics 0.3.1</a></li>
                         <li><a href=" https://github.com/microsoft/windows-rs ">windows-result 0.2.0</a></li>
                         <li><a href=" https://github.com/microsoft/windows-rs ">windows-result 0.3.4</a></li>
+                        <li><a href=" https://github.com/microsoft/windows-rs ">windows-result 0.4.1</a></li>
                         <li><a href=" https://github.com/microsoft/windows-rs ">windows-strings 0.1.0</a></li>
                         <li><a href=" https://github.com/microsoft/windows-rs ">windows-strings 0.4.2</a></li>
+                        <li><a href=" https://github.com/microsoft/windows-rs ">windows-strings 0.5.1</a></li>
                         <li><a href=" https://github.com/microsoft/windows-rs ">windows-sys 0.45.0</a></li>
                         <li><a href=" https://github.com/microsoft/windows-rs ">windows-sys 0.52.0</a></li>
                         <li><a href=" https://github.com/microsoft/windows-rs ">windows-sys 0.60.2</a></li>
@@ -2229,8 +2236,10 @@ Software.
                         <li><a href=" https://github.com/microsoft/windows-rs ">windows-targets 0.52.6</a></li>
                         <li><a href=" https://github.com/microsoft/windows-rs ">windows-targets 0.53.5</a></li>
                         <li><a href=" https://github.com/microsoft/windows-rs ">windows-threading 0.1.0</a></li>
+                        <li><a href=" https://github.com/microsoft/windows-rs ">windows-threading 0.2.1</a></li>
                         <li><a href=" https://github.com/microsoft/windows-rs ">windows 0.58.0</a></li>
                         <li><a href=" https://github.com/microsoft/windows-rs ">windows 0.61.3</a></li>
+                        <li><a href=" https://github.com/microsoft/windows-rs ">windows 0.62.2</a></li>
                         <li><a href=" https://github.com/microsoft/windows-rs ">windows_aarch64_gnullvm 0.42.2</a></li>
                         <li><a href=" https://github.com/microsoft/windows-rs ">windows_aarch64_gnullvm 0.52.6</a></li>
                         <li><a href=" https://github.com/microsoft/windows-rs ">windows_aarch64_gnullvm 0.53.1</a></li>
@@ -2672,8 +2681,8 @@ Software.
                 <h3 id="Apache-2.0">Apache License 2.0</h3>
                     <h4>Used by:</h4>
                     <ul class="license-used-by">
-                        <li><a href=" https://github.com/google/zerocopy ">zerocopy-derive 0.8.37</a></li>
-                        <li><a href=" https://github.com/google/zerocopy ">zerocopy 0.8.37</a></li>
+                        <li><a href=" https://github.com/google/zerocopy ">zerocopy-derive 0.8.40</a></li>
+                        <li><a href=" https://github.com/google/zerocopy ">zerocopy 0.8.40</a></li>
                     </ul>
                 <pre class="license-text">                                 Apache License
                            Version 2.0, January 2004
@@ -3307,6 +3316,7 @@ Software.
                         <li><a href=" https://github.com/brendanzab/codespan ">codespan-reporting 0.12.0</a></li>
                         <li><a href=" https://github.com/kornelski/imgref ">imgref 1.12.0</a></li>
                         <li><a href=" https://github.com/rustls/rustls-platform-verifier ">rustls-platform-verifier 0.6.2</a></li>
+                        <li><a href=" https://github.com/1Password/sys-locale ">sys-locale 0.3.2</a></li>
                     </ul>
                 <pre class="license-text">                                 Apache License
                            Version 2.0, January 2004
@@ -3940,9 +3950,9 @@ Software.
                         <li><a href=" https://github.com/rust-cli/anstyle.git ">anstyle-query 1.1.5</a></li>
                         <li><a href=" https://github.com/rust-cli/anstyle.git ">anstyle-wincon 3.0.11</a></li>
                         <li><a href=" https://github.com/rust-cli/anstyle.git ">anstyle 1.0.13</a></li>
-                        <li><a href=" https://github.com/clap-rs/clap ">clap 4.5.56</a></li>
-                        <li><a href=" https://github.com/clap-rs/clap ">clap_builder 4.5.56</a></li>
-                        <li><a href=" https://github.com/clap-rs/clap ">clap_lex 0.7.7</a></li>
+                        <li><a href=" https://github.com/clap-rs/clap ">clap 4.5.60</a></li>
+                        <li><a href=" https://github.com/clap-rs/clap ">clap_builder 4.5.60</a></li>
+                        <li><a href=" https://github.com/clap-rs/clap ">clap_lex 1.0.0</a></li>
                         <li><a href=" https://github.com/jamesmunns/cobs.rs ">cobs 0.3.0</a></li>
                         <li><a href=" https://github.com/rust-cli/anstyle.git ">colorchoice 1.0.4</a></li>
                         <li><a href=" https://github.com/rust-ammonia/rust-content-security-policy ">content-security-policy 0.6.0</a></li>
@@ -3958,6 +3968,7 @@ Software.
                         <li><a href=" https://github.com/KokaKiwi/rust-hex ">hex 0.4.3</a></li>
                         <li><a href=" https://github.com/polyfill-rs/is_terminal_polyfill ">is_terminal_polyfill 1.70.2</a></li>
                         <li><a href=" https://github.com/sfackler/rust-jni-sys ">jni-sys 0.3.0</a></li>
+                        <li><a href=" https://github.com/cobalt-org/kstring ">kstring 2.0.2</a></li>
                         <li><a href=" https://github.com/polyfill-rs/once_cell_polyfill ">once_cell_polyfill 1.70.2</a></li>
                         <li><a href=" http://github.com/tailhook/quick-error ">quick-error 2.0.1</a></li>
                         <li><a href=" https://github.com/toml-rs/toml ">serde_spanned 0.6.9</a></li>
@@ -3966,7 +3977,7 @@ Software.
                         <li><a href=" https://github.com/toml-rs/toml ">toml_datetime 0.7.3</a></li>
                         <li><a href=" https://github.com/toml-rs/toml ">toml_edit 0.22.27</a></li>
                         <li><a href=" https://github.com/toml-rs/toml ">toml_edit 0.23.7</a></li>
-                        <li><a href=" https://github.com/toml-rs/toml ">toml_parser 1.0.6+spec-1.1.0</a></li>
+                        <li><a href=" https://github.com/toml-rs/toml ">toml_parser 1.0.9+spec-1.1.0</a></li>
                         <li><a href=" https://github.com/toml-rs/toml ">toml_write 0.1.2</a></li>
                         <li><a href=" https://github.com/gifnksm/topological-sort-rs ">topological-sort 0.1.0</a></li>
                     </ul>
@@ -4376,15 +4387,15 @@ Software.
                 <h3 id="Apache-2.0">Apache License 2.0</h3>
                     <h4>Used by:</h4>
                     <ul class="license-used-by">
-                        <li><a href=" https://github.com/rust-lang/futures-rs ">futures-channel 0.3.31</a></li>
-                        <li><a href=" https://github.com/rust-lang/futures-rs ">futures-core 0.3.31</a></li>
-                        <li><a href=" https://github.com/rust-lang/futures-rs ">futures-executor 0.3.31</a></li>
-                        <li><a href=" https://github.com/rust-lang/futures-rs ">futures-io 0.3.31</a></li>
-                        <li><a href=" https://github.com/rust-lang/futures-rs ">futures-macro 0.3.31</a></li>
-                        <li><a href=" https://github.com/rust-lang/futures-rs ">futures-sink 0.3.31</a></li>
-                        <li><a href=" https://github.com/rust-lang/futures-rs ">futures-task 0.3.31</a></li>
-                        <li><a href=" https://github.com/rust-lang/futures-rs ">futures-util 0.3.31</a></li>
-                        <li><a href=" https://github.com/rust-lang/futures-rs ">futures 0.3.31</a></li>
+                        <li><a href=" https://github.com/rust-lang/futures-rs ">futures-channel 0.3.32</a></li>
+                        <li><a href=" https://github.com/rust-lang/futures-rs ">futures-core 0.3.32</a></li>
+                        <li><a href=" https://github.com/rust-lang/futures-rs ">futures-executor 0.3.32</a></li>
+                        <li><a href=" https://github.com/rust-lang/futures-rs ">futures-io 0.3.32</a></li>
+                        <li><a href=" https://github.com/rust-lang/futures-rs ">futures-macro 0.3.32</a></li>
+                        <li><a href=" https://github.com/rust-lang/futures-rs ">futures-sink 0.3.32</a></li>
+                        <li><a href=" https://github.com/rust-lang/futures-rs ">futures-task 0.3.32</a></li>
+                        <li><a href=" https://github.com/rust-lang/futures-rs ">futures-util 0.3.32</a></li>
+                        <li><a href=" https://github.com/rust-lang/futures-rs ">futures 0.3.32</a></li>
                     </ul>
                 <pre class="license-text">                              Apache License
                         Version 2.0, January 2004
@@ -7107,7 +7118,7 @@ limitations under the License.</pre>
                 <h3 id="Apache-2.0">Apache License 2.0</h3>
                     <p>
                         Used by
-                            <a href=" https://github.com/RazrFalcon/memmap2-rs ">memmap2 0.9.9</a>
+                            <a href=" https://github.com/RazrFalcon/memmap2-rs ">memmap2 0.9.10</a>
                     </p>
                 <pre class="license-text">                              Apache License
                         Version 2.0, January 2004
@@ -7320,7 +7331,7 @@ limitations under the License.
                         <li><a href=" https://github.com/image-rs/image-gif ">gif 0.13.3</a></li>
                         <li><a href=" https://github.com/rust-windowing/keyboard-types ">keyboard-types 0.8.3</a></li>
                         <li><a href=" https://github.com/RustCrypto/RSA ">rsa 0.9.10</a></li>
-                        <li><a href=" https://github.com/SeaQL/sea-query ">sea-query 1.0.0-rc.30</a></li>
+                        <li><a href=" https://github.com/SeaQL/sea-query ">sea-query 1.0.0-rc.31</a></li>
                         <li><a href=" https://github.com/image-rs/weezl ">weezl 0.1.12</a></li>
                     </ul>
                 <pre class="license-text">                              Apache License
@@ -7530,15 +7541,15 @@ limitations under the License.</pre>
                     <h4>Used by:</h4>
                     <ul class="license-used-by">
                         <li><a href=" https://github.com/servo/stylo ">servo_arc 0.4.3</a></li>
-                        <li><a href=" https://github.com/servo/stylo ">stylo_malloc_size_of 0.11.0</a></li>
+                        <li><a href=" https://github.com/servo/stylo ">stylo_malloc_size_of 0.12.0</a></li>
                         <li><a href=" https://crates.io/crates/servo_malloc_size_of ">servo_malloc_size_of 0.0.1</a></li>
                         <li><a href=" https://github.com/gimli-rs/addr2line ">addr2line 0.25.1</a></li>
                         <li><a href=" https://github.com/tkaitchuck/ahash ">ahash 0.8.12</a></li>
                         <li><a href=" https://github.com/rust-fuzz/arbitrary/ ">arbitrary 1.4.2</a></li>
-                        <li><a href=" https://github.com/vorner/arc-swap ">arc-swap 1.8.1</a></li>
+                        <li><a href=" https://github.com/vorner/arc-swap ">arc-swap 1.8.2</a></li>
                         <li><a href=" https://github.com/bluss/arrayvec ">arrayvec 0.7.6</a></li>
                         <li><a href=" https://github.com/smol-rs/async-channel ">async-channel 2.5.0</a></li>
-                        <li><a href=" https://github.com/smol-rs/async-executor ">async-executor 1.13.3</a></li>
+                        <li><a href=" https://github.com/smol-rs/async-executor ">async-executor 1.14.0</a></li>
                         <li><a href=" https://github.com/smol-rs/async-io ">async-io 2.6.0</a></li>
                         <li><a href=" https://github.com/smol-rs/async-lock ">async-lock 3.4.2</a></li>
                         <li><a href=" https://github.com/smol-rs/async-process ">async-process 2.5.0</a></li>
@@ -7547,17 +7558,19 @@ limitations under the License.</pre>
                         <li><a href=" https://github.com/smol-rs/atomic-waker ">atomic-waker 1.1.2</a></li>
                         <li><a href=" https://github.com/cuviper/autocfg ">autocfg 1.5.0</a></li>
                         <li><a href=" https://github.com/rust-lang/backtrace-rs ">backtrace 0.3.76</a></li>
+                        <li><a href=" https://github.com/marshallpierce/rust-base64 ">base64 0.12.3</a></li>
                         <li><a href=" https://github.com/marshallpierce/rust-base64 ">base64 0.21.7</a></li>
                         <li><a href=" https://github.com/marshallpierce/rust-base64 ">base64 0.22.1</a></li>
                         <li><a href=" https://github.com/bitflags/bitflags ">bitflags 1.3.2</a></li>
-                        <li><a href=" https://github.com/bitflags/bitflags ">bitflags 2.10.0</a></li>
+                        <li><a href=" https://github.com/bitflags/bitflags ">bitflags 2.11.0</a></li>
                         <li><a href=" https://github.com/tuffy/bitstream-io ">bitstream-io 2.6.0</a></li>
                         <li><a href=" https://github.com/smol-rs/blocking ">blocking 1.6.2</a></li>
-                        <li><a href=" https://github.com/pacak/bpaf ">bpaf 0.9.22</a></li>
-                        <li><a href=" https://github.com/pacak/bpaf ">bpaf_derive 0.5.21</a></li>
-                        <li><a href=" https://github.com/fitzgen/bumpalo ">bumpalo 3.19.1</a></li>
+                        <li><a href=" https://github.com/pacak/bpaf ">bpaf 0.9.23</a></li>
+                        <li><a href=" https://github.com/pacak/bpaf ">bpaf_derive 0.5.23</a></li>
+                        <li><a href=" https://github.com/mikedilger/buf-read-ext ">buf-read-ext 0.4.0</a></li>
+                        <li><a href=" https://github.com/fitzgen/bumpalo ">bumpalo 3.20.2</a></li>
                         <li><a href=" https://github.com/japaric/cast.rs ">cast 0.3.0</a></li>
-                        <li><a href=" https://github.com/rust-lang/cc-rs ">cc 1.2.55</a></li>
+                        <li><a href=" https://github.com/rust-lang/cc-rs ">cc 1.2.56</a></li>
                         <li><a href=" https://github.com/jethrogb/rust-cexpr ">cexpr 0.6.0</a></li>
                         <li><a href=" https://github.com/rust-lang/cfg-if ">cfg-if 1.0.4</a></li>
                         <li><a href=" https://github.com/servo/cgl-rs ">cgl 0.3.2</a></li>
@@ -7580,7 +7593,6 @@ limitations under the License.</pre>
                         <li><a href=" https://github.com/servo/rust-url ">data-url 0.3.2</a></li>
                         <li><a href=" https://github.com/yaahc/displaydoc ">displaydoc 0.2.5</a></li>
                         <li><a href=" https://github.com/rayon-rs/either ">either 1.15.0</a></li>
-                        <li><a href=" https://github.com/env-logger-rs/env_logger/ ">env_logger 0.8.4</a></li>
                         <li><a href=" https://github.com/indexmap-rs/equivalent ">equivalent 1.0.2</a></li>
                         <li><a href=" https://github.com/lambda-fairy/rust-errno ">errno 0.3.14</a></li>
                         <li><a href=" https://github.com/servo/euclid ">euclid 0.22.13</a></li>
@@ -7590,18 +7602,26 @@ limitations under the License.</pre>
                         <li><a href=" https://github.com/alexcrichton/filetime ">filetime 0.2.27</a></li>
                         <li><a href=" https://github.com/rust-lang/cc-rs ">find-msvc-tools 0.1.9</a></li>
                         <li><a href=" https://github.com/bluss/fixedbitset ">fixedbitset 0.1.9</a></li>
-                        <li><a href=" https://github.com/rust-lang/flate2-rs ">flate2 1.1.8</a></li>
+                        <li><a href=" https://github.com/rust-lang/flate2-rs ">flate2 1.1.9</a></li>
                         <li><a href=" https://github.com/servo/rust-fnv ">fnv 1.0.7</a></li>
                         <li><a href=" https://github.com/servo/rust-url ">form_urlencoded 1.2.2</a></li>
                         <li><a href=" https://github.com/servo/rust-freetype ">freetype 0.7.2</a></li>
                         <li><a href=" https://github.com/smol-rs/futures-lite ">futures-lite 2.6.1</a></li>
-                        <li><a href=" https://github.com/rust-lang-nursery/futures-rs ">futures 0.1.31</a></li>
                         <li><a href=" https://github.com/servo/gaol ">gaol 0.2.1</a></li>
                         <li><a href=" https://codeberg.org/swsnr/gethostname.rs.git ">gethostname 1.1.0</a></li>
                         <li><a href=" https://github.com/gimli-rs/gimli ">gimli 0.32.3</a></li>
                         <li><a href=" https://github.com/servo/gleam ">gleam 0.15.1</a></li>
                         <li><a href=" https://github.com/rust-lang/glob ">glob 0.3.3</a></li>
                         <li><a href=" https://github.com/zkcrypto/group ">group 0.13.0</a></li>
+                        <li><a href=" https://gitlab.freedesktop.org/gstreamer/gstreamer-rs ">gstreamer-app 0.25.0</a></li>
+                        <li><a href=" https://gitlab.freedesktop.org/gstreamer/gstreamer-rs ">gstreamer-audio 0.25.0</a></li>
+                        <li><a href=" https://gitlab.freedesktop.org/gstreamer/gstreamer-rs ">gstreamer-base 0.25.0</a></li>
+                        <li><a href=" https://gitlab.freedesktop.org/gstreamer/gstreamer-rs ">gstreamer-gl-egl 0.25.0</a></li>
+                        <li><a href=" https://gitlab.freedesktop.org/gstreamer/gstreamer-rs ">gstreamer-gl 0.25.0</a></li>
+                        <li><a href=" https://gitlab.freedesktop.org/gstreamer/gstreamer-rs ">gstreamer-sdp 0.25.0</a></li>
+                        <li><a href=" https://gitlab.freedesktop.org/gstreamer/gstreamer-rs ">gstreamer-video 0.25.0</a></li>
+                        <li><a href=" https://gitlab.freedesktop.org/gstreamer/gstreamer-rs ">gstreamer-webrtc 0.25.0</a></li>
+                        <li><a href=" https://gitlab.freedesktop.org/gstreamer/gstreamer-rs ">gstreamer 0.25.0</a></li>
                         <li><a href=" https://github.com/servo/rust-harfbuzz ">harfbuzz-sys 0.6.1</a></li>
                         <li><a href=" https://github.com/rust-lang/hashbrown ">hashbrown 0.15.5</a></li>
                         <li><a href=" https://github.com/rust-lang/hashbrown ">hashbrown 0.16.0</a></li>
@@ -7614,7 +7634,7 @@ limitations under the License.</pre>
                         <li><a href=" https://github.com/servo/rust-url/ ">idna 1.1.0</a></li>
                         <li><a href=" https://github.com/hsivonen/idna_adapter ">idna_adapter 1.2.0</a></li>
                         <li><a href=" https://github.com/indexmap-rs/indexmap ">indexmap 2.11.4</a></li>
-                        <li><a href=" https://github.com/servo/ipc-channel ">ipc-channel 0.20.2</a></li>
+                        <li><a href=" https://github.com/servo/ipc-channel ">ipc-channel 0.21.0</a></li>
                         <li><a href=" https://github.com/rust-itertools/itertools ">itertools 0.10.5</a></li>
                         <li><a href=" https://github.com/rust-itertools/itertools ">itertools 0.12.1</a></li>
                         <li><a href=" https://github.com/rust-itertools/itertools ">itertools 0.14.0</a></li>
@@ -7624,8 +7644,8 @@ limitations under the License.</pre>
                         <li><a href=" https://github.com/wasm-bindgen/wasm-bindgen/tree/master/crates/js-sys ">js-sys 0.3.82</a></li>
                         <li><a href=" https://github.com/timothee-haudebourg/khronos-egl ">khronos-egl 6.0.0</a></li>
                         <li><a href=" https://github.com/rust-lang-nursery/lazy-static.rs ">lazy_static 1.5.0</a></li>
-                        <li><a href=" https://github.com/rust-fuzz/libfuzzer ">libfuzzer-sys 0.4.10</a></li>
-                        <li><a href=" https://github.com/rust-lang/libz-sys ">libz-sys 1.1.23</a></li>
+                        <li><a href=" https://github.com/rust-fuzz/libfuzzer ">libfuzzer-sys 0.4.12</a></li>
+                        <li><a href=" https://github.com/rust-lang/libz-sys ">libz-sys 1.1.24</a></li>
                         <li><a href=" https://github.com/sunfishcode/linux-raw-sys ">linux-raw-sys 0.11.0</a></li>
                         <li><a href=" https://github.com/sunfishcode/linux-raw-sys ">linux-raw-sys 0.4.15</a></li>
                         <li><a href=" https://github.com/Amanieu/parking_lot ">lock_api 0.4.14</a></li>
@@ -7633,6 +7653,7 @@ limitations under the License.</pre>
                         <li><a href=" https://github.com/bholley/malloc_size_of_derive ">malloc_size_of_derive 0.1.3</a></li>
                         <li><a href=" https://github.com/servo/html5ever ">markup5ever 0.38.0</a></li>
                         <li><a href=" https://github.com/gfx-rs/metal-rs ">metal 0.32.0</a></li>
+                        <li><a href=" https://github.com/gw-de/mime-multipart-hyper1 ">mime-multipart-hyper1 0.10.0</a></li>
                         <li><a href=" https://github.com/hyperium/mime ">mime 0.3.17</a></li>
                         <li><a href=" https://github.com/dignifiedquire/num-bigint ">num-bigint-dig 0.8.6</a></li>
                         <li><a href=" https://github.com/rust-num/num-bigint ">num-bigint 0.4.6</a></li>
@@ -7646,6 +7667,7 @@ limitations under the License.</pre>
                         <li><a href=" https://github.com/gimli-rs/object ">object 0.37.3</a></li>
                         <li><a href=" https://github.com/matklad/once_cell ">once_cell 1.21.3</a></li>
                         <li><a href=" https://github.com/rustls/openssl-probe ">openssl-probe 0.2.1</a></li>
+                        <li><a href=" https://github.com/fengalin/option-operations ">option-operations 0.6.1</a></li>
                         <li><a href=" https://github.com/danieldg/ordered-stream ">ordered-stream 0.2.0</a></li>
                         <li><a href=" https://github.com/bluss/ordermap ">ordermap 0.3.5</a></li>
                         <li><a href=" https://github.com/smol-rs/parking ">parking 2.2.1</a></li>
@@ -7663,8 +7685,8 @@ limitations under the License.</pre>
                         <li><a href=" https://github.com/rayon-rs/rayon ">rayon-core 1.13.0</a></li>
                         <li><a href=" https://github.com/rayon-rs/rayon ">rayon 1.11.0</a></li>
                         <li><a href=" https://github.com/rust-lang/regex ">regex-automata 0.4.13</a></li>
-                        <li><a href=" https://github.com/rust-lang/regex ">regex-syntax 0.8.8</a></li>
-                        <li><a href=" https://github.com/rust-lang/regex ">regex 1.12.2</a></li>
+                        <li><a href=" https://github.com/rust-lang/regex ">regex-syntax 0.8.10</a></li>
+                        <li><a href=" https://github.com/rust-lang/regex ">regex 1.12.3</a></li>
                         <li><a href=" https://github.com/ron-rs/ron ">ron 0.10.1</a></li>
                         <li><a href=" https://github.com/RazrFalcon/roxmltree ">roxmltree 0.20.0</a></li>
                         <li><a href=" https://github.com/rust-lang/rustc-demangle ">rustc-demangle 0.1.27</a></li>
@@ -7673,11 +7695,11 @@ limitations under the License.</pre>
                         <li><a href=" https://github.com/bytecodealliance/rustix ">rustix 0.38.44</a></li>
                         <li><a href=" https://github.com/bytecodealliance/rustix ">rustix 1.1.2</a></li>
                         <li><a href=" https://github.com/rustls/rustls-native-certs ">rustls-native-certs 0.8.3</a></li>
-                        <li><a href=" https://github.com/rustls/rustls ">rustls 0.23.36</a></li>
+                        <li><a href=" https://github.com/rustls/rustls ">rustls 0.23.37</a></li>
                         <li><a href=" https://github.com/alexcrichton/scoped-tls ">scoped-tls 1.0.1</a></li>
                         <li><a href=" https://github.com/bluss/scopeguard ">scopeguard 1.2.0</a></li>
-                        <li><a href=" https://github.com/kornelski/rust-security-framework ">security-framework-sys 2.15.0</a></li>
-                        <li><a href=" https://github.com/kornelski/rust-security-framework ">security-framework 3.5.1</a></li>
+                        <li><a href=" https://github.com/kornelski/rust-security-framework ">security-framework-sys 2.17.0</a></li>
+                        <li><a href=" https://github.com/kornelski/rust-security-framework ">security-framework 3.7.0</a></li>
                         <li><a href=" https://github.com/adjivas/sig ">sig 1.0.0</a></li>
                         <li><a href=" https://github.com/vorner/signal-hook ">signal-hook-registry 1.4.8</a></li>
                         <li><a href=" https://github.com/linebender/simplecss ">simplecss 0.2.2</a></li>
@@ -7692,9 +7714,11 @@ limitations under the License.</pre>
                         <li><a href=" https://github.com/servo/surfman ">surfman 0.11.0</a></li>
                         <li><a href=" https://github.com/linebender/svgtypes ">svgtypes 0.15.3</a></li>
                         <li><a href=" https://github.com/gdesmott/system-deps ">system-deps 6.2.2</a></li>
+                        <li><a href=" https://github.com/gdesmott/system-deps ">system-deps 7.0.5</a></li>
                         <li><a href=" https://github.com/alexcrichton/tar-rs ">tar 0.4.44</a></li>
                         <li><a href=" https://github.com/Stebalien/tempfile ">tempfile 3.23.0</a></li>
                         <li><a href=" https://github.com/servo/html5ever ">tendril 0.5.0</a></li>
+                        <li><a href=" https://github.com/mikedilger/textnonce ">textnonce 1.0.0</a></li>
                         <li><a href=" https://github.com/tikv/jemallocator ">tikv-jemalloc-sys 0.6.1+5.3.0-1-ge13ca993e8ccb9ba9847cc330696e02839f328f7</a></li>
                         <li><a href=" https://github.com/tikv/jemallocator ">tikv-jemallocator 0.6.1</a></li>
                         <li><a href=" https://github.com/bheisler/TinyTemplate ">tinytemplate 1.2.1</a></li>
@@ -7709,9 +7733,10 @@ limitations under the License.</pre>
                         <li><a href=" https://github.com/RazrFalcon/unicode-vo ">unicode-vo 0.1.0</a></li>
                         <li><a href=" https://github.com/unicode-rs/unicode-width ">unicode-width 0.2.2</a></li>
                         <li><a href=" https://github.com/servo/rust-url ">url 2.5.8</a></li>
-                        <li><a href=" https://github.com/uuid-rs/uuid ">uuid 1.20.0</a></li>
+                        <li><a href=" https://github.com/uuid-rs/uuid ">uuid 1.21.0</a></li>
                         <li><a href=" https://github.com/SergioBenitez/version_check ">version_check 0.9.5</a></li>
                         <li><a href=" https://github.com/bytecodealliance/wasi ">wasi 0.11.1+wasi-snapshot-preview1</a></li>
+                        <li><a href=" https://github.com/bytecodealliance/wasi ">wasi 0.9.0+wasi-snapshot-preview1</a></li>
                         <li><a href=" https://github.com/wasm-bindgen/wasm-bindgen/tree/master/crates/futures ">wasm-bindgen-futures 0.4.55</a></li>
                         <li><a href=" https://github.com/wasm-bindgen/wasm-bindgen/tree/master/crates/macro-support ">wasm-bindgen-macro-support 0.2.105</a></li>
                         <li><a href=" https://github.com/wasm-bindgen/wasm-bindgen/tree/master/crates/macro ">wasm-bindgen-macro 0.2.105</a></li>
@@ -8352,6 +8377,7 @@ limitations under the License.</pre>
                         <li><a href=" https://github.com/contain-rs/bit-set ">bit-set 0.8.0</a></li>
                         <li><a href=" https://github.com/contain-rs/bit-vec ">bit-vec 0.8.0</a></li>
                         <li><a href=" https://github.com/EmbarkStudios/cfg-expr ">cfg-expr 0.15.8</a></li>
+                        <li><a href=" https://github.com/EmbarkStudios/cfg-expr ">cfg-expr 0.20.3</a></li>
                         <li><a href=" https://github.com/marcianx/downcast-rs ">downcast-rs 1.2.1</a></li>
                         <li><a href=" https://github.com/Alexhuszagh/minimal-lexical ">minimal-lexical 0.2.1</a></li>
                         <li><a href=" https://github.com/EmbarkStudios/presser ">presser 0.3.1</a></li>
@@ -8799,8 +8825,8 @@ limitations under the License.</pre>
                         <li><a href=" https://github.com/RustCrypto/hybrid-array ">hybrid-array 0.2.3</a></li>
                         <li><a href=" https://github.com/RustCrypto/hybrid-array ">hybrid-array 0.3.1</a></li>
                         <li><a href=" https://github.com/RustCrypto/utils ">inout 0.1.4</a></li>
-                        <li><a href=" https://github.com/RustCrypto/sponges/tree/master/keccak ">keccak 0.1.5</a></li>
-                        <li><a href=" https://github.com/RustCrypto/KEMs ">ml-kem 0.2.2</a></li>
+                        <li><a href=" https://github.com/RustCrypto/sponges/tree/master/keccak ">keccak 0.1.6</a></li>
+                        <li><a href=" https://github.com/RustCrypto/KEMs ">ml-kem 0.2.3</a></li>
                         <li><a href=" https://github.com/RustCrypto/AEADs ">ocb3 0.1.0</a></li>
                         <li><a href=" https://github.com/RustCrypto/utils ">opaque-debug 0.3.1</a></li>
                         <li><a href=" https://github.com/RustCrypto/elliptic-curves/tree/master/p256 ">p256 0.13.2</a></li>
@@ -9238,6 +9264,7 @@ limitations under the License.
                 <h3 id="Apache-2.0">Apache License 2.0</h3>
                     <h4>Used by:</h4>
                     <ul class="license-used-by">
+                        <li><a href=" https://github.com/rust-random/rand_core ">rand_core 0.10.0</a></li>
                         <li><a href=" https://github.com/rust-random/rand ">rand_core 0.6.4</a></li>
                         <li><a href=" https://github.com/rust-random/rand ">rand_core 0.9.3</a></li>
                     </ul>
@@ -9434,9 +9461,15 @@ APPENDIX: How to apply the Apache License to your work.
                 <h3 id="Apache-2.0">Apache License 2.0</h3>
                     <h4>Used by:</h4>
                     <ul class="license-used-by">
+                        <li><a href=" https://github.com/rust-random/getrandom ">getrandom 0.1.16</a></li>
                         <li><a href=" https://github.com/rust-random/getrandom ">getrandom 0.2.17</a></li>
                         <li><a href=" https://github.com/rust-random/getrandom ">getrandom 0.3.4</a></li>
+                        <li><a href=" https://github.com/rust-random/getrandom ">getrandom 0.4.1</a></li>
+                        <li><a href=" https://github.com/rust-random/rand ">rand 0.7.3</a></li>
+                        <li><a href=" https://github.com/rust-random/rand ">rand_chacha 0.2.2</a></li>
                         <li><a href=" https://github.com/rust-random/rand ">rand_chacha 0.3.1</a></li>
+                        <li><a href=" https://github.com/rust-random/rand ">rand_core 0.5.1</a></li>
+                        <li><a href=" https://github.com/rust-random/rand ">rand_hc 0.2.0</a></li>
                     </ul>
                 <pre class="license-text">                              Apache License
                         Version 2.0, January 2004
@@ -10786,9 +10819,9 @@ limitations under the License.
                 <h3 id="Apache-2.0">Apache License 2.0</h3>
                     <h4>Used by:</h4>
                     <ul class="license-used-by">
-                        <li><a href=" https://github.com/odilia-app/atspi ">atspi-common 0.9.0</a></li>
-                        <li><a href=" https://github.com/odilia-app/atspi/ ">atspi-connection 0.9.0</a></li>
-                        <li><a href=" https://github.com/odilia-app/atspi ">atspi 0.25.0</a></li>
+                        <li><a href=" https://github.com/odilia-app/atspi ">atspi-common 0.13.0</a></li>
+                        <li><a href=" https://github.com/odilia-app/atspi ">atspi-proxies 0.13.0</a></li>
+                        <li><a href=" https://github.com/odilia-app/atspi ">atspi 0.29.0</a></li>
                     </ul>
                 <pre class="license-text">Apache License
                            Version 2.0, January 2004
@@ -12324,44 +12357,44 @@ limitations under the License.
                 <h3 id="Apache-2.0">Apache License 2.0</h3>
                     <h4>Used by:</h4>
                     <ul class="license-used-by">
+                        <li><a href=" https://github.com/emilk/egui ">ecolor 0.33.3</a></li>
+                        <li><a href=" https://github.com/emilk/egui/tree/main/crates/egui-winit ">egui-winit 0.33.3</a></li>
+                        <li><a href=" https://github.com/emilk/egui ">egui 0.33.3</a></li>
+                        <li><a href=" https://github.com/emilk/egui/tree/main/crates/emath ">emath 0.33.3</a></li>
+                        <li><a href=" https://github.com/emilk/egui/tree/main/crates/epaint ">epaint 0.33.3</a></li>
+                        <li><a href=" https://github.com/emilk/egui/tree/main/crates/epaint_default_fonts ">epaint_default_fonts 0.33.3</a></li>
                         <li><a href=" https://github.com/servo/servo ">hyper_serde 0.13.2</a></li>
                         <li><a href=" https://github.com/alexheretic/ab-glyph ">ab_glyph 0.2.32</a></li>
                         <li><a href=" https://github.com/alexheretic/ab-glyph ">ab_glyph_rasterizer 0.1.10</a></li>
-                        <li><a href=" https://github.com/AccessKit/accesskit ">accesskit 0.21.1</a></li>
-                        <li><a href=" https://github.com/AccessKit/accesskit ">accesskit_atspi_common 0.14.2</a></li>
-                        <li><a href=" https://github.com/AccessKit/accesskit ">accesskit_consumer 0.31.0</a></li>
-                        <li><a href=" https://github.com/AccessKit/accesskit ">accesskit_macos 0.22.2</a></li>
-                        <li><a href=" https://github.com/AccessKit/accesskit ">accesskit_unix 0.17.2</a></li>
-                        <li><a href=" https://github.com/AccessKit/accesskit ">accesskit_windows 0.29.2</a></li>
-                        <li><a href=" https://github.com/AccessKit/accesskit ">accesskit_winit 0.29.2</a></li>
+                        <li><a href=" https://github.com/AccessKit/accesskit ">accesskit 0.24.0</a></li>
+                        <li><a href=" https://github.com/AccessKit/accesskit ">accesskit_atspi_common 0.17.0</a></li>
+                        <li><a href=" https://github.com/AccessKit/accesskit ">accesskit_consumer 0.34.0</a></li>
+                        <li><a href=" https://github.com/AccessKit/accesskit ">accesskit_macos 0.25.0</a></li>
+                        <li><a href=" https://github.com/AccessKit/accesskit ">accesskit_unix 0.20.0</a></li>
+                        <li><a href=" https://github.com/AccessKit/accesskit ">accesskit_windows 0.32.0</a></li>
+                        <li><a href=" https://github.com/AccessKit/accesskit ">accesskit_winit 0.32.1</a></li>
                         <li><a href=" https://github.com/zakarumych/allocator-api2 ">allocator-api2 0.2.21</a></li>
                         <li><a href=" https://github.com/rust-mobile/android-activity ">android-activity 0.6.0</a></li>
                         <li><a href=" https://github.com/nical/android_system_properties ">android_system_properties 0.1.5</a></li>
                         <li><a href=" https://github.com/zrzka/anes-rs ">anes 0.1.6</a></li>
-                        <li><a href=" https://github.com/dtolnay/anyhow ">anyhow 1.0.100</a></li>
+                        <li><a href=" https://github.com/dtolnay/anyhow ">anyhow 1.0.102</a></li>
                         <li><a href=" https://github.com/1Password/arboard ">arboard 3.6.1</a></li>
-                        <li><a href=" https://github.com/Nullus157/async-compression ">async-compression 0.4.37</a></li>
+                        <li><a href=" https://github.com/Nullus157/async-compression ">async-compression 0.4.40</a></li>
                         <li><a href=" https://github.com/dtolnay/async-trait ">async-trait 0.1.89</a></li>
-                        <li><a href=" https://github.com/odilia-app/atspi ">atspi-proxies 0.9.0</a></li>
                         <li><a href=" https://github.com/jrmuizel/build-parallel ">build-parallel 0.1.2</a></li>
                         <li><a href=" https://github.com/emk/cesu8-rs ">cesu8 1.1.0</a></li>
                         <li><a href=" https://github.com/linebender/color ">color 0.3.2</a></li>
-                        <li><a href=" https://github.com/Nullus157/async-compression ">compression-codecs 0.4.36</a></li>
+                        <li><a href=" https://github.com/Nullus157/async-compression ">compression-codecs 0.4.37</a></li>
                         <li><a href=" https://github.com/Nullus157/async-compression ">compression-core 0.4.31</a></li>
                         <li><a href=" https://github.com/soc/directories-rs ">directories 6.0.0</a></li>
                         <li><a href=" https://github.com/dirs-dev/dirs-sys-rs ">dirs-sys 0.5.0</a></li>
                         <li><a href=" https://github.com/soc/dirs-rs ">dirs 6.0.0</a></li>
+                        <li><a href=" https://github.com/madsmtm/objc2 ">dispatch2 0.3.1</a></li>
                         <li><a href=" https://github.com/slint-ui/document-features ">document-features 0.2.12</a></li>
                         <li><a href=" https://github.com/dtolnay/dtoa ">dtoa 1.0.11</a></li>
                         <li><a href=" https://gitlab.com/kornelski/dunce ">dunce 1.0.5</a></li>
-                        <li><a href=" https://github.com/emilk/egui ">ecolor 0.33.3</a></li>
-                        <li><a href=" https://github.com/emilk/egui/tree/main/crates/egui-winit ">egui-winit 0.33.3</a></li>
-                        <li><a href=" https://github.com/emilk/egui ">egui 0.33.3</a></li>
                         <li><a href=" https://github.com/emilk/egui/tree/main/crates/egui_glow ">egui_glow 0.33.3</a></li>
-                        <li><a href=" https://github.com/emilk/egui/tree/main/crates/emath ">emath 0.33.3</a></li>
                         <li><a href=" https://github.com/dtolnay/enumn ">enumn 0.1.14</a></li>
-                        <li><a href=" https://github.com/emilk/egui/tree/main/crates/epaint ">epaint 0.33.3</a></li>
-                        <li><a href=" https://github.com/emilk/egui/tree/main/crates/epaint_default_fonts ">epaint_default_fonts 0.33.3</a></li>
                         <li><a href=" https://github.com/nical/etagere ">etagere 0.2.15</a></li>
                         <li><a href=" https://github.com/image-rs/fdeflate ">fdeflate 0.3.7</a></li>
                         <li><a href=" https://github.com/linebender/fearless_simd ">fearless_simd 0.3.0</a></li>
@@ -12373,6 +12406,7 @@ limitations under the License.
                         <li><a href=" https://github.com/zakarumych/gpu-alloc ">gpu-alloc 0.6.0</a></li>
                         <li><a href=" https://github.com/zakarumych/gpu-descriptor ">gpu-descriptor-types 0.2.0</a></li>
                         <li><a href=" https://github.com/zakarumych/gpu-descriptor ">gpu-descriptor 0.3.2</a></li>
+                        <li><a href=" https://gitlab.freedesktop.org/gstreamer/gstreamer-rs ">gstreamer-play 0.25.0</a></li>
                         <li><a href=" https://github.com/VoidStarKat/half-rs ">half 2.7.1</a></li>
                         <li><a href=" https://github.com/openharmony-rs/ohos-sys ">hilog-sys 0.1.7</a></li>
                         <li><a href=" https://github.com/TedDriggs/ident_case ">ident_case 1.0.1</a></li>
@@ -12382,7 +12416,7 @@ limitations under the License.
                         <li><a href=" https://github.com/dtolnay/itoa ">itoa 1.0.17</a></li>
                         <li><a href=" https://github.com/RustCrypto/traits/tree/master/kem ">kem 0.3.0-pre.0</a></li>
                         <li><a href=" https://github.com/brendanzab/gl-rs/ ">khronos_api 3.1.0</a></li>
-                        <li><a href=" https://github.com/rust-lang/libc ">libc 0.2.180</a></li>
+                        <li><a href=" https://github.com/rust-lang/libc ">libc 0.2.182</a></li>
                         <li><a href=" https://github.com/linebender/raw_resource_handle ">linebender_resource_handle 0.1.1</a></li>
                         <li><a href=" https://github.com/LukasKalbertodt/litrs ">litrs 1.0.0</a></li>
                         <li><a href=" https://github.com/JohnTitor/mach2 ">mach2 0.6.0</a></li>
@@ -12397,23 +12431,25 @@ limitations under the License.
                         <li><a href=" https://github.com/madsmtm/objc2 ">objc2-app-kit 0.3.2</a></li>
                         <li><a href=" https://github.com/madsmtm/objc2 ">objc2-core-foundation 0.3.2</a></li>
                         <li><a href=" https://github.com/madsmtm/objc2 ">objc2-core-graphics 0.3.2</a></li>
+                        <li><a href=" https://github.com/madsmtm/objc2 ">objc2-core-text 0.3.2</a></li>
                         <li><a href=" https://github.com/madsmtm/objc2 ">objc2-core-video 0.3.2</a></li>
                         <li><a href=" https://github.com/madsmtm/objc2 ">objc2-io-kit 0.3.2</a></li>
                         <li><a href=" https://github.com/madsmtm/objc2 ">objc2-io-surface 0.3.2</a></li>
                         <li><a href=" https://github.com/madsmtm/objc2 ">objc2-metal 0.3.2</a></li>
                         <li><a href=" https://github.com/madsmtm/objc2 ">objc2-quartz-core 0.3.2</a></li>
-                        <li><a href=" https://github.com/openharmony-rs/ohos-sys ">ohos-abilitykit-sys 0.1.4</a></li>
+                        <li><a href=" https://github.com/openharmony-rs/ohos-sys ">ohos-abilitykit-sys 0.1.5</a></li>
                         <li><a href=" https://github.com/openharmony-rs/ohos-sys ">ohos-deviceinfo-sys 0.1.6</a></li>
                         <li><a href=" https://github.com/openharmony-rs/ohos-deviceinfo ">ohos-deviceinfo 0.1.0</a></li>
                         <li><a href=" https://github.com/openharmony-rs/ohos-sys ">ohos-ime-sys 0.2.3</a></li>
                         <li><a href=" https://github.com/openharmony-rs/ohos-ime ">ohos-ime 0.4.2</a></li>
-                        <li><a href=" https://github.com/openharmony-rs/ohos-sys ">ohos-sys-opaque-types 0.1.8</a></li>
+                        <li><a href=" https://github.com/openharmony-rs/ohos-sys ">ohos-sys-opaque-types 0.1.9</a></li>
                         <li><a href=" https://github.com/openharmony-rs/ohos-sys ">ohos-vsync-sys 0.1.5</a></li>
                         <li><a href=" https://github.com/openharmony-rs/ohos-vsync ">ohos-vsync 0.1.3</a></li>
                         <li><a href=" https://github.com/openharmony-rs/ohos-sys ">ohos-window-manager-sys 0.1.3</a></li>
                         <li><a href=" https://github.com/Ralith/openxrs ">openxr 0.20.0</a></li>
                         <li><a href=" https://github.com/alexheretic/owned-ttf-parser ">owned_ttf_parser 0.25.1</a></li>
                         <li><a href=" https://github.com/dtolnay/paste ">paste 1.0.15</a></li>
+                        <li><a href=" https://github.com/as1100k/pastey ">pastey 0.2.1</a></li>
                         <li><a href=" https://github.com/taiki-e/pin-project ">pin-project-internal 1.1.10</a></li>
                         <li><a href=" https://github.com/taiki-e/pin-project-lite ">pin-project-lite 0.2.16</a></li>
                         <li><a href=" https://github.com/taiki-e/pin-project ">pin-project 1.1.10</a></li>
@@ -12425,6 +12461,7 @@ limitations under the License.
                         <li><a href=" https://github.com/aclysma/profiling ">profiling 1.0.17</a></li>
                         <li><a href=" https://github.com/dtolnay/quote ">quote 1.0.44</a></li>
                         <li><a href=" https://github.com/r-efi/r-efi ">r-efi 5.3.0</a></li>
+                        <li><a href=" https://github.com/rust-random/rand ">rand 0.10.0</a></li>
                         <li><a href=" https://github.com/rust-random/rand ">rand 0.8.5</a></li>
                         <li><a href=" https://github.com/rust-random/rand ">rand 0.9.2</a></li>
                         <li><a href=" https://github.com/rust-random/rand ">rand_chacha 0.9.0</a></li>
@@ -12434,7 +12471,7 @@ limitations under the License.
                         <li><a href=" https://github.com/rust-lang/rustc-hash ">rustc-hash 2.1.1</a></li>
                         <li><a href=" https://github.com/rustls/rustls-platform-verifier ">rustls-platform-verifier-android 0.1.1</a></li>
                         <li><a href=" https://github.com/dtolnay/rustversion ">rustversion 1.0.22</a></li>
-                        <li><a href=" https://github.com/dtolnay/ryu ">ryu 1.0.22</a></li>
+                        <li><a href=" https://github.com/dtolnay/ryu ">ryu 1.0.23</a></li>
                         <li><a href=" https://github.com/SeaQL/sea-query ">sea-query-derive 1.0.0-rc.12</a></li>
                         <li><a href=" https://github.com/SeaQL/sea-query ">sea-query-rusqlite 0.8.0-rc.15</a></li>
                         <li><a href=" https://github.com/dtolnay/semver ">semver 1.0.27</a></li>
@@ -12450,7 +12487,7 @@ limitations under the License.
                         <li><a href=" https://github.com/jedisct1/rust-siphash ">siphasher 1.0.2</a></li>
                         <li><a href=" https://github.com/gfx-rs/rspirv ">spirv 0.3.0+sdk-1.3.268.0</a></li>
                         <li><a href=" https://github.com/nical/rust_debug ">svg_fmt 0.4.5</a></li>
-                        <li><a href=" https://github.com/dtolnay/syn ">syn 2.0.114</a></li>
+                        <li><a href=" https://github.com/dtolnay/syn ">syn 2.0.117</a></li>
                         <li><a href=" https://github.com/Actyx/sync_wrapper ">sync_wrapper 1.0.2</a></li>
                         <li><a href=" https://github.com/gankra/thin-vec ">thin-vec 0.2.14</a></li>
                         <li><a href=" https://github.com/dtolnay/thiserror ">thiserror-impl 1.0.69</a></li>
@@ -12465,13 +12502,14 @@ limitations under the License.
                         <li><a href=" https://github.com/open-i18n/rust-unic/ ">unic-common 0.9.0</a></li>
                         <li><a href=" https://github.com/open-i18n/rust-unic/ ">unic-ucd-ident 0.9.0</a></li>
                         <li><a href=" https://github.com/open-i18n/rust-unic/ ">unic-ucd-version 0.9.0</a></li>
-                        <li><a href=" https://github.com/dtolnay/unicode-ident ">unicode-ident 1.0.22</a></li>
+                        <li><a href=" https://github.com/dtolnay/unicode-ident ">unicode-ident 1.0.24</a></li>
                         <li><a href=" https://github.com/linebender/resvg ">usvg 0.45.1</a></li>
                         <li><a href=" https://github.com/SimonSapin/rust-utf8 ">utf-8 0.7.6</a></li>
                         <li><a href=" https://github.com/alacritty/vte ">utf8parse 0.2.2</a></li>
                         <li><a href=" https://github.com/linebender/vello ">vello_common 0.0.4</a></li>
                         <li><a href=" https://github.com/linebender/vello ">vello_cpu 0.0.4</a></li>
                         <li><a href=" https://github.com/bytecodealliance/wasi-rs ">wasip2 1.0.2+wasi-0.2.9</a></li>
+                        <li><a href=" https://github.com/bytecodealliance/wasi-rs ">wasip3 0.4.0+wasi-0.3.0-rc-2026-01-06</a></li>
                         <li><a href=" https://github.com/gfx-rs/wgpu ">wgpu-core-deps-apple 26.0.0</a></li>
                         <li><a href=" https://github.com/gfx-rs/wgpu ">wgpu-core-deps-emscripten 26.0.0</a></li>
                         <li><a href=" https://github.com/gfx-rs/wgpu ">wgpu-core-deps-windows-linux-android 26.0.0</a></li>
@@ -12566,7 +12604,7 @@ limitations under the License.
                 <h3 id="Apache-2.0">Apache License 2.0</h3>
                     <p>
                         Used by
-                            <a href=" https://github.com/chronotope/chrono ">chrono 0.4.43</a>
+                            <a href=" https://github.com/chronotope/chrono ">chrono 0.4.44</a>
                     </p>
                 <pre class="license-text">Rust-chrono is dual-licensed under The MIT License [1] and
 Apache 2.0 License [2]. Copyright (c) 2014--2026, Kang Seonghoon and
@@ -13058,7 +13096,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
                 <h3 id="BSD-3-Clause">BSD 3-Clause &quot;New&quot; or &quot;Revised&quot; License</h3>
                     <p>
                         Used by
-                            <a href=" https://github.com/kornelski/avif-serialize ">avif-serialize 0.8.6</a>
+                            <a href=" https://github.com/kornelski/avif-serialize ">avif-serialize 0.8.8</a>
                     </p>
                 <pre class="license-text">BSD 3-Clause License
 
@@ -13610,8 +13648,8 @@ express Statement of Purpose.
                 <h3 id="CDLA-Permissive-2.0">Community Data License Agreement Permissive 2.0</h3>
                     <h4>Used by:</h4>
                     <ul class="license-used-by">
-                        <li><a href=" https://github.com/rustls/webpki-roots ">webpki-root-certs 1.0.5</a></li>
-                        <li><a href=" https://github.com/rustls/webpki-roots ">webpki-roots 1.0.5</a></li>
+                        <li><a href=" https://github.com/rustls/webpki-roots ">webpki-root-certs 1.0.6</a></li>
+                        <li><a href=" https://github.com/rustls/webpki-roots ">webpki-roots 1.0.6</a></li>
                     </ul>
                 <pre class="license-text"># Community Data License Agreement - Permissive - Version 2.0
 
@@ -13680,7 +13718,7 @@ insights.
                 <h3 id="ISC">ISC License</h3>
                     <p>
                         Used by
-                            <a href=" https://github.com/aws/aws-lc-rs ">aws-lc-sys 0.37.0</a>
+                            <a href=" https://github.com/aws/aws-lc-rs ">aws-lc-sys 0.37.1</a>
                     </p>
                 <pre class="license-text">/* Copyright (c) 2018, Google Inc.
  *
@@ -13822,7 +13860,7 @@ third-party/chromium/LICENSE.
                 <h3 id="ISC">ISC License</h3>
                     <p>
                         Used by
-                            <a href=" https://github.com/aws/aws-lc-rs ">aws-lc-rs 1.15.4</a>
+                            <a href=" https://github.com/aws/aws-lc-rs ">aws-lc-rs 1.16.0</a>
                     </p>
                 <pre class="license-text">ISC License:
 
@@ -14337,7 +14375,7 @@ THE SOFTWARE IS PROVIDED &quot;AS IS&quot;, WITHOUT WARRANTY OF ANY KIND, EXPRES
                 <h3 id="MIT">MIT License</h3>
                     <p>
                         Used by
-                            <a href=" https://github.com/sdroege/async-tungstenite ">async-tungstenite 0.32.1</a>
+                            <a href=" https://github.com/sdroege/async-tungstenite ">async-tungstenite 0.33.0</a>
                     </p>
                 <pre class="license-text">Copyright (c) 2017 Daniel Abramov
 Copyright (c) 2017 Alexey Galakhov
@@ -14485,7 +14523,7 @@ DEALINGS IN THE SOFTWARE.
                 <h3 id="MIT">MIT License</h3>
                     <p>
                         Used by
-                            <a href=" https://github.com/tokio-rs/bytes ">bytes 1.11.0</a>
+                            <a href=" https://github.com/tokio-rs/bytes ">bytes 1.11.1</a>
                     </p>
                 <pre class="license-text">Copyright (c) 2018 Carl Lerche
 
@@ -14993,7 +15031,7 @@ SOFTWARE.
                 <h3 id="MIT">MIT License</h3>
                     <p>
                         Used by
-                            <a href=" https://github.com/hyperium/hyper-util ">hyper-util 0.1.19</a>
+                            <a href=" https://github.com/hyperium/hyper-util ">hyper-util 0.1.20</a>
                     </p>
                 <pre class="license-text">Copyright (c) 2023-2025 Sean McArthur
 
@@ -15020,12 +15058,12 @@ THE SOFTWARE.
                 <h3 id="MIT">MIT License</h3>
                     <h4>Used by:</h4>
                     <ul class="license-used-by">
-                        <li><a href=" https://github.com/z-galaxy/zbus/ ">zbus 5.13.2</a></li>
-                        <li><a href=" https://github.com/z-galaxy/zbus/ ">zbus_macros 5.13.2</a></li>
+                        <li><a href=" https://github.com/z-galaxy/zbus/ ">zbus 5.14.0</a></li>
+                        <li><a href=" https://github.com/z-galaxy/zbus/ ">zbus_macros 5.14.0</a></li>
                         <li><a href=" https://github.com/z-galaxy/zbus/ ">zbus_names 4.3.1</a></li>
                         <li><a href=" https://github.com/z-galaxy/zbus/ ">zbus_xml 5.1.0</a></li>
-                        <li><a href=" https://github.com/z-galaxy/zbus/ ">zvariant 5.9.2</a></li>
-                        <li><a href=" https://github.com/z-galaxy/zbus/ ">zvariant_derive 5.9.2</a></li>
+                        <li><a href=" https://github.com/z-galaxy/zbus/ ">zvariant 5.10.0</a></li>
+                        <li><a href=" https://github.com/z-galaxy/zbus/ ">zvariant_derive 5.10.0</a></li>
                     </ul>
                 <pre class="license-text">Copyright (c) 2024 Zeeshan Ali Khan &amp; zbus contributors
 
@@ -15344,7 +15382,7 @@ SOFTWARE.
                 <h3 id="MIT">MIT License</h3>
                     <p>
                         Used by
-                            <a href=" https://github.com/kornelski/rust-rgb ">rgb 0.8.52</a>
+                            <a href=" https://github.com/kornelski/rust-rgb ">rgb 0.8.53</a>
                     </p>
                 <pre class="license-text">MIT License
 
@@ -15828,9 +15866,11 @@ SOFTWARE.</pre>
                     <h4>Used by:</h4>
                     <ul class="license-used-by">
                         <li><a href=" https://github.com/madsmtm/objc2 ">block2 0.5.1</a></li>
+                        <li><a href=" https://github.com/madsmtm/objc2 ">block2 0.6.2</a></li>
                         <li><a href=" http://github.com/SSheldon/rust-block ">block 0.1.6</a></li>
                         <li><a href=" http://github.com/SSheldon/rust-dispatch ">dispatch 0.2.0</a></li>
                         <li><a href=" https://github.com/rust-windowing/winit ">dpi 0.1.2</a></li>
+                        <li><a href=" https://gitlab.freedesktop.org/gstreamer/gstreamer-rs ">gstreamer-play-sys 0.25.0</a></li>
                         <li><a href=" https://github.com/rust-lang/compiler-builtins ">libm 0.2.16</a></li>
                         <li><a href=" https://github.com/SSheldon/malloc_buf ">malloc_buf 0.0.6</a></li>
                         <li><a href=" https://github.com/ohos-rs/ohos-rs ">napi-build-ohos 1.1.6</a></li>
@@ -15846,7 +15886,7 @@ SOFTWARE.</pre>
                         <li><a href=" https://github.com/madsmtm/objc2 ">objc2-foundation 0.3.2</a></li>
                         <li><a href=" https://github.com/madsmtm/objc2 ">objc2-ui-kit 0.2.2</a></li>
                         <li><a href=" https://github.com/madsmtm/objc2 ">objc2 0.5.2</a></li>
-                        <li><a href=" https://github.com/madsmtm/objc2 ">objc2 0.6.3</a></li>
+                        <li><a href=" https://github.com/madsmtm/objc2 ">objc2 0.6.4</a></li>
                         <li><a href=" https://github.com/plotters-rs/plotters ">plotters-backend 0.3.7</a></li>
                         <li><a href=" https://github.com/plotters-rs/plotters.git ">plotters-svg 0.3.7</a></li>
                         <li><a href=" https://github.com/plotters-rs/plotters ">plotters 0.3.7</a></li>
@@ -16056,11 +16096,20 @@ SOFTWARE.
                     <h4>Used by:</h4>
                     <ul class="license-used-by">
                         <li><a href=" https://github.com/zeenix/endi ">endi 1.1.1</a></li>
+                        <li><a href=" https://gitlab.freedesktop.org/gstreamer/gstreamer-rs ">gstreamer-app-sys 0.25.0</a></li>
+                        <li><a href=" https://gitlab.freedesktop.org/gstreamer/gstreamer-rs ">gstreamer-audio-sys 0.25.0</a></li>
+                        <li><a href=" https://gitlab.freedesktop.org/gstreamer/gstreamer-rs ">gstreamer-base-sys 0.25.0</a></li>
+                        <li><a href=" https://gitlab.freedesktop.org/gstreamer/gstreamer-rs ">gstreamer-gl-egl-sys 0.25.0</a></li>
+                        <li><a href=" https://gitlab.freedesktop.org/gstreamer/gstreamer-rs ">gstreamer-gl-sys 0.25.0</a></li>
+                        <li><a href=" https://gitlab.freedesktop.org/gstreamer/gstreamer-rs ">gstreamer-sdp-sys 0.25.0</a></li>
+                        <li><a href=" https://gitlab.freedesktop.org/gstreamer/gstreamer-rs ">gstreamer-sys 0.25.0</a></li>
+                        <li><a href=" https://gitlab.freedesktop.org/gstreamer/gstreamer-rs ">gstreamer-video-sys 0.25.0</a></li>
+                        <li><a href=" https://gitlab.freedesktop.org/gstreamer/gstreamer-rs ">gstreamer-webrtc-sys 0.25.0</a></li>
                         <li><a href=" https://github.com/sunfishcode/is-terminal ">is-terminal 0.4.17</a></li>
                         <li><a href=" https://github.com/AltF02/x11-rs.git ">x11-dl 2.21.0</a></li>
                         <li><a href=" https://github.com/luukvanderduim/zbus-lockstep ">zbus-lockstep-macros 0.5.2</a></li>
                         <li><a href=" https://github.com/luukvanderduim/zbus-lockstep ">zbus-lockstep 0.5.2</a></li>
-                        <li><a href=" https://github.com/dtolnay/zmij ">zmij 1.0.19</a></li>
+                        <li><a href=" https://github.com/dtolnay/zmij ">zmij 1.0.21</a></li>
                         <li><a href=" https://github.com/z-galaxy/zbus/ ">zvariant_utils 3.3.0</a></li>
                     </ul>
                 <pre class="license-text">Permission is hereby granted, free of charge, to any
@@ -16112,6 +16161,36 @@ NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
 LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+</pre>
+            </li>
+            <li class="license">
+                <h3 id="MIT">MIT License</h3>
+                    <h4>Used by:</h4>
+                    <ul class="license-used-by">
+                        <li><a href=" https://github.com/gtk-rs/gtk-rs-core ">gio-sys 0.22.0</a></li>
+                        <li><a href=" https://github.com/gtk-rs/gtk-rs-core ">glib-macros 0.22.0</a></li>
+                        <li><a href=" https://github.com/gtk-rs/gtk-rs-core ">glib-sys 0.22.0</a></li>
+                        <li><a href=" https://github.com/gtk-rs/gtk-rs-core ">glib 0.22.0</a></li>
+                        <li><a href=" https://github.com/gtk-rs/gtk-rs-core ">gobject-sys 0.22.0</a></li>
+                    </ul>
+                <pre class="license-text">Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the &quot;Software&quot;), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED &quot;AS IS&quot;, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
 </pre>
             </li>
             <li class="license">
@@ -16242,9 +16321,9 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
                         <li><a href=" https://github.com/image-rs/byteorder-lite ">byteorder-lite 0.1.0</a></li>
                         <li><a href=" https://github.com/BurntSushi/byteorder ">byteorder 1.5.0</a></li>
                         <li><a href=" https://github.com/BurntSushi/fst ">fst 0.4.7</a></li>
-                        <li><a href=" https://github.com/BurntSushi/jiff ">jiff 0.2.18</a></li>
-                        <li><a href=" https://github.com/BurntSushi/memchr ">memchr 2.7.6</a></li>
-                        <li><a href=" https://github.com/BurntSushi/quickcheck ">quickcheck 1.0.3</a></li>
+                        <li><a href=" https://github.com/BurntSushi/jiff ">jiff 0.2.21</a></li>
+                        <li><a href=" https://github.com/BurntSushi/memchr ">memchr 2.8.0</a></li>
+                        <li><a href=" https://github.com/BurntSushi/quickcheck ">quickcheck 1.1.0</a></li>
                         <li><a href=" https://github.com/BurntSushi/walkdir ">walkdir 2.5.0</a></li>
                     </ul>
                 <pre class="license-text">The MIT License (MIT)
@@ -16539,10 +16618,11 @@ SOFTWARE.
             </li>
             <li class="license">
                 <h3 id="MIT">MIT License</h3>
-                    <p>
-                        Used by
-                            <a href=" https://github.com/sdroege/bytes-num-slice-cast ">byte-slice-cast 1.2.3</a>
-                    </p>
+                    <h4>Used by:</h4>
+                    <ul class="license-used-by">
+                        <li><a href=" https://github.com/sdroege/bytes-num-slice-cast ">byte-slice-cast 1.2.3</a></li>
+                        <li><a href=" https://github.com/sdroege/rust-muldiv ">muldiv 1.0.1</a></li>
+                    </ul>
                 <pre class="license-text">The MIT License (MIT)
 
 Copyright (c) 2017 Sebastian Dröge &lt;sebastian@centricular.com&gt;.
@@ -18810,21 +18890,13 @@ Exhibit B - &quot;Incompatible With Secondary Licenses&quot; Notice
                 <h3 id="MPL-2.0">Mozilla Public License 2.0</h3>
                     <h4>Used by:</h4>
                     <ul class="license-used-by">
-                        <li><a href=" https://crates.io/crates/servo-media-audio ">servo-media-audio 0.2.0</a></li>
-                        <li><a href=" https://crates.io/crates/servo-media-derive ">servo-media-derive 0.1.0</a></li>
-                        <li><a href=" https://crates.io/crates/servo-media-dummy ">servo-media-dummy 0.1.0</a></li>
-                        <li><a href=" https://crates.io/crates/servo-media-player ">servo-media-player 0.1.0</a></li>
-                        <li><a href=" https://crates.io/crates/servo-media-streams ">servo-media-streams 0.1.0</a></li>
-                        <li><a href=" https://crates.io/crates/servo-media-traits ">servo-media-traits 0.1.0</a></li>
-                        <li><a href=" https://crates.io/crates/servo-media-webrtc ">servo-media-webrtc 0.1.0</a></li>
-                        <li><a href=" https://crates.io/crates/servo-media ">servo-media 0.1.0</a></li>
-                        <li><a href=" https://github.com/servo/stylo ">stylo 0.11.0</a></li>
+                        <li><a href=" https://github.com/servo/stylo ">stylo 0.12.0</a></li>
                         <li><a href=" https://github.com/servo/stylo ">selectors 0.35.0</a></li>
-                        <li><a href=" https://github.com/servo/stylo ">stylo_atoms 0.11.0</a></li>
-                        <li><a href=" https://github.com/servo/stylo ">stylo_derive 0.11.0</a></li>
-                        <li><a href=" https://github.com/servo/stylo ">stylo_dom 0.11.0</a></li>
-                        <li><a href=" https://github.com/servo/stylo ">stylo_static_prefs 0.11.0</a></li>
-                        <li><a href=" https://github.com/servo/stylo ">stylo_traits 0.11.0</a></li>
+                        <li><a href=" https://github.com/servo/stylo ">stylo_atoms 0.12.0</a></li>
+                        <li><a href=" https://github.com/servo/stylo ">stylo_derive 0.12.0</a></li>
+                        <li><a href=" https://github.com/servo/stylo ">stylo_dom 0.12.0</a></li>
+                        <li><a href=" https://github.com/servo/stylo ">stylo_static_prefs 0.12.0</a></li>
+                        <li><a href=" https://github.com/servo/stylo ">stylo_traits 0.12.0</a></li>
                         <li><a href=" https://github.com/servo/stylo ">to_shmem 0.3.0</a></li>
                         <li><a href=" https://github.com/servo/stylo ">to_shmem_derive 0.1.0</a></li>
                         <li><a href=" https://crates.io/crates/servo_allocator ">servo_allocator 0.0.1</a></li>
@@ -18841,7 +18913,21 @@ Exhibit B - &quot;Incompatible With Secondary Licenses&quot; Notice
                         <li><a href=" https://crates.io/crates/servo_geometry ">servo_geometry 0.0.1</a></li>
                         <li><a href=" https://crates.io/crates/jstraceable_derive ">jstraceable_derive 0.0.1</a></li>
                         <li><a href=" https://crates.io/crates/layout ">layout 0.0.1</a></li>
+                        <li><a href=" https://crates.io/crates/servo-media-audio ">servo-media-audio 0.0.1</a></li>
+                        <li><a href=" https://crates.io/crates/servo-media-auto ">servo-media-auto 0.0.1</a></li>
+                        <li><a href=" https://crates.io/crates/servo-media-dummy ">servo-media-dummy 0.0.1</a></li>
+                        <li><a href=" https://crates.io/crates/servo-media-gstreamer ">servo-media-gstreamer 0.0.1</a></li>
+                        <li><a href=" https://crates.io/crates/servo-media-gstreamer-render ">servo-media-gstreamer-render 0.0.1</a></li>
+                        <li><a href=" https://crates.io/crates/servo-media-gstreamer-render-android ">servo-media-gstreamer-render-android 0.0.1</a></li>
+                        <li><a href=" https://crates.io/crates/servo-media-gstreamer-render-unix ">servo-media-gstreamer-render-unix 0.0.1</a></li>
+                        <li><a href=" https://crates.io/crates/media-examples ">media-examples 0.0.1</a></li>
                         <li><a href=" https://crates.io/crates/media ">media 0.0.1</a></li>
+                        <li><a href=" https://crates.io/crates/servo-media-player ">servo-media-player 0.0.1</a></li>
+                        <li><a href=" https://crates.io/crates/servo-media ">servo-media 0.0.1</a></li>
+                        <li><a href=" https://crates.io/crates/servo-media-derive ">servo-media-derive 0.0.1</a></li>
+                        <li><a href=" https://crates.io/crates/servo-media-streams ">servo-media-streams 0.0.1</a></li>
+                        <li><a href=" https://crates.io/crates/servo-media-traits ">servo-media-traits 0.0.1</a></li>
+                        <li><a href=" https://crates.io/crates/servo-media-webrtc ">servo-media-webrtc 0.0.1</a></li>
                         <li><a href=" https://crates.io/crates/metrics ">metrics 0.0.1</a></li>
                         <li><a href=" https://crates.io/crates/net ">net 0.0.1</a></li>
                         <li><a href=" https://crates.io/crates/paint ">paint 0.0.1</a></li>
@@ -18875,7 +18961,7 @@ Exhibit B - &quot;Incompatible With Secondary Licenses&quot; Notice
                         <li><a href=" https://crates.io/crates/webgpu ">webgpu 0.0.1</a></li>
                         <li><a href=" https://crates.io/crates/webxr ">webxr 0.0.1</a></li>
                         <li><a href=" https://crates.io/crates/xpath ">xpath 0.0.1</a></li>
-                        <li><a href=" https://crates.io/crates/servoshell ">servoshell 0.0.5</a></li>
+                        <li><a href=" https://crates.io/crates/servoshell ">servoshell 0.0.6</a></li>
                         <li><a href=" https://crates.io/crates/deny_public_fields_tests ">deny_public_fields_tests 0.0.1</a></li>
                         <li><a href=" https://crates.io/crates/malloc_size_of_tests ">malloc_size_of_tests 0.0.1</a></li>
                         <li><a href=" https://crates.io/crates/profile_tests ">profile_tests 0.0.1</a></li>
@@ -18883,7 +18969,7 @@ Exhibit B - &quot;Incompatible With Secondary Licenses&quot; Notice
                         <li><a href=" https://crates.io/crates/style_tests ">style_tests 0.0.1</a></li>
                         <li><a href=" https://github.com/servo/app_units ">app_units 0.7.8</a></li>
                         <li><a href=" https://github.com/servo/dwrote-rs ">dwrote 0.11.5</a></li>
-                        <li><a href=" https://github.com/servo/mozjs/ ">mozjs_sys 0.140.5-10</a></li>
+                        <li><a href=" https://github.com/servo/mozjs/ ">mozjs_sys 0.140.5-11</a></li>
                         <li><a href=" https://github.com/soc/option-ext.git ">option-ext 0.2.0</a></li>
                         <li><a href=" https://hg.mozilla.org/mozilla-central/file/tip/testing/webdriver ">webdriver 0.53.0</a></li>
                         <li><a href=" https://github.com/servo/webrender ">webrender 0.68.0</a></li>
@@ -19270,7 +19356,7 @@ Exhibit B - &quot;Incompatible With Secondary Licenses&quot; Notice
                 <h3 id="MPL-2.0">Mozilla Public License 2.0</h3>
                     <p>
                         Used by
-                            <a href=" https://github.com/servo/mozjs/ ">mozjs 0.14.8</a>
+                            <a href=" https://github.com/servo/mozjs/ ">mozjs 0.15.1</a>
                     </p>
                 <pre class="license-text">Mozilla Public License Version 2.0
 &#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;
@@ -19652,7 +19738,7 @@ defined by the Mozilla Public License, v. 2.0.
                 <h3 id="NCSA">University of Illinois/NCSA Open Source License</h3>
                     <p>
                         Used by
-                            <a href=" https://github.com/rust-fuzz/libfuzzer ">libfuzzer-sys 0.4.10</a>
+                            <a href=" https://github.com/rust-fuzz/libfuzzer ">libfuzzer-sys 0.4.12</a>
                     </p>
                 <pre class="license-text">University of Illinois/NCSA Open Source License
 
@@ -19775,7 +19861,7 @@ OTHER DEALINGS IN THE FONT SOFTWARE.
                 <h3 id="OpenSSL">OpenSSL License</h3>
                     <p>
                         Used by
-                            <a href=" https://github.com/aws/aws-lc-rs ">aws-lc-sys 0.37.0</a>
+                            <a href=" https://github.com/aws/aws-lc-rs ">aws-lc-sys 0.37.1</a>
                     </p>
                 <pre class="license-text">/* Copyright (C) 1995-1998 Eric Young (eay@cryptsoft.com)
  * All rights reserved.
@@ -20053,7 +20139,7 @@ DEALINGS IN THE FONT SOFTWARE.
                 <h3 id="Unicode-3.0">Unicode License v3</h3>
                     <p>
                         Used by
-                            <a href=" https://github.com/dtolnay/unicode-ident ">unicode-ident 1.0.22</a>
+                            <a href=" https://github.com/dtolnay/unicode-ident ">unicode-ident 1.0.24</a>
                     </p>
                 <pre class="license-text">UNICODE LICENSE V3
 
@@ -20203,10 +20289,11 @@ the following restrictions:
             </li>
             <li class="license">
                 <h3 id="Zlib">zlib License</h3>
-                    <p>
-                        Used by
-                            <a href=" https://github.com/orlp/foldhash ">foldhash 0.1.5</a>
-                    </p>
+                    <h4>Used by:</h4>
+                    <ul class="license-used-by">
+                        <li><a href=" https://github.com/orlp/foldhash ">foldhash 0.1.5</a></li>
+                        <li><a href=" https://github.com/orlp/foldhash ">foldhash 0.2.0</a></li>
+                    </ul>
                 <pre class="license-text">Copyright (c) 2024 Orson Peters
 
 This software is provided &#x27;as-is&#x27;, without any express or implied warranty. In

--- a/support/android/apk/servoapp/build.gradle.kts
+++ b/support/android/apk/servoapp/build.gradle.kts
@@ -17,7 +17,7 @@ android {
         minSdk = 30
         targetSdk = 33
         versionCode = generatedVersionCode
-        versionName = "0.0.5"
+        versionName = "0.0.6"
     }
 
     compileOptions {

--- a/support/openharmony/entry/oh-package.json5
+++ b/support/openharmony/entry/oh-package.json5
@@ -5,7 +5,7 @@
   "name": "servoshell",
   "description": "Please describe the basic information.",
   "main": "",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "dependencies": {
     "libservoshell.so": "file:./src/main/cpp/types/libentry"
   }

--- a/support/openharmony/oh-package.json5
+++ b/support/openharmony/oh-package.json5
@@ -8,6 +8,6 @@
   "name": "servoshell",
   "description": "Servo browser shell",
   "main": "",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "dependencies": {}
 }

--- a/support/windows/Servo.wxs.mako
+++ b/support/windows/Servo.wxs.mako
@@ -6,7 +6,7 @@
            UpgradeCode="060cd15d-eab1-4614-b438-3988e3efdcf1"
            Language="1033"
            Codepage="1252"
-           Version="0.0.5">
+           Version="0.0.6">
     <Package Id="*"
              Keywords="Installer"
              Description="Servo Tech Demo Installer"


### PR DESCRIPTION
Same procedure as every month. `./mach release 0.0.6`

Testing: Not tested.

