### PR TITLE
devtools: Implement frame scoped evaluation

### DIFF
--- a/components/devtools/actors/console.rs
+++ b/components/devtools/actors/console.rs
@@ -13,7 +13,7 @@ use std::sync::atomic::{AtomicBool, Ordering};
 use atomic_refcell::AtomicRefCell;
 use base::generic_channel::{self, GenericSender};
 use base::id::TEST_PIPELINE_ID;
-use devtools_traits::EvaluateJSReply::{
+use devtools_traits::EvaluateJSReplyValue::{
     ActorValue, BooleanValue, NullValue, NumberValue, StringValue, VoidValue,
 };
 use devtools_traits::{
@@ -227,6 +227,7 @@ struct EvaluateJSReply {
     timestamp: u64,
     exception: Value,
     exception_message: Value,
+    has_exception: bool,
     helper_result: Value,
 }
 
@@ -243,6 +244,7 @@ struct EvaluateJSEvent {
     result_id: String,
     exception: Value,
     exception_message: Value,
+    has_exception: bool,
     helper_result: Value,
 }
 
@@ -319,6 +321,10 @@ impl ConsoleActor {
         msg: &Map<String, Value>,
     ) -> Result<EvaluateJSReply, ()> {
         let input = msg.get("text").unwrap().as_str().unwrap().to_owned();
+        let frame_actor_id = msg
+            .get("frameActor")
+            .and_then(|v| v.as_str())
+            .map(String::from);
         let (chan, port) = generic_channel::channel().unwrap();
         // FIXME: Redesign messages so we don't have to fake pipeline ids when
         //        communicating with workers.
@@ -327,11 +333,19 @@ impl ConsoleActor {
             UniqueId::Worker(_) => TEST_PIPELINE_ID,
         };
         self.script_chan(registry)
-            .send(DevtoolScriptControlMsg::Eval(input.clone(), pipeline, chan))
+            .send(DevtoolScriptControlMsg::Eval(
+                input.clone(),
+                pipeline,
+                frame_actor_id,
+                chan,
+            ))
             .unwrap();
 
         // TODO: Extract conversion into protocol module or some other useful place
-        let result = match port.recv().map_err(|_| ())? {
+        let eval_result = port.recv().map_err(|_| ())?;
+        let has_exception = eval_result.has_exception;
+
+        let result = match eval_result.value {
             VoidValue => {
                 let mut m = Map::new();
                 m.insert("type".to_owned(), Value::String("undefined".to_owned()));
@@ -380,8 +394,6 @@ impl ConsoleActor {
             },
         };
 
-        // TODO: Catch and return exception values from JS evaluation
-        // TODO: This should have a has_exception field
         let reply = EvaluateJSReply {
             from: self.name(),
             input,
@@ -389,9 +401,10 @@ impl ConsoleActor {
             timestamp: get_time_stamp(),
             exception: Value::Null,
             exception_message: Value::Null,
+            has_exception,
             helper_result: Value::Null,
         };
-        std::result::Result::Ok(reply)
+        Ok(reply)
     }
 
     pub(crate) fn handle_console_resource(
@@ -532,6 +545,7 @@ impl Actor for ConsoleActor {
                     result_id,
                     exception: reply.exception,
                     exception_message: reply.exception_message,
+                    has_exception: reply.has_exception,
                     helper_result: reply.helper_result,
                 };
                 // Send the data from evaluateJS along with a resultID

--- a/components/script/devtools.rs
+++ b/components/script/devtools.rs
@@ -10,7 +10,8 @@ use base::generic_channel::GenericSender;
 use base::id::PipelineId;
 use devtools_traits::{
     AttrModification, AutoMargins, ComputedNodeLayout, CssDatabaseProperty, EvaluateJSReply,
-    EventListenerInfo, NodeInfo, NodeStyle, RuleModification, TimelineMarker, TimelineMarkerType,
+    EvaluateJSReplyValue, EventListenerInfo, NodeInfo, NodeStyle, RuleModification, TimelineMarker,
+    TimelineMarkerType,
 };
 use js::context::JSContext;
 use js::conversions::jsstr_to_string;
@@ -129,7 +130,7 @@ pub(crate) fn handle_evaluate_js(
     reply: GenericSender<EvaluateJSReply>,
     cx: &mut JSContext,
 ) {
-    let result = unsafe {
+    let value = unsafe {
         let mut realm = enter_auto_realm(cx, global);
         let cx = &mut realm.current_realm();
         rooted!(&in(cx) let mut rval = UndefinedValue());
@@ -144,11 +145,11 @@ pub(crate) fn handle_evaluate_js(
         );
 
         if rval.is_undefined() {
-            EvaluateJSReply::VoidValue
+            EvaluateJSReplyValue::VoidValue
         } else if rval.is_boolean() {
-            EvaluateJSReply::BooleanValue(rval.to_boolean())
+            EvaluateJSReplyValue::BooleanValue(rval.to_boolean())
         } else if rval.is_double() || rval.is_int32() {
-            EvaluateJSReply::NumberValue(
+            EvaluateJSReplyValue::NumberValue(
                 match FromJSValConvertible::from_jsval(cx.raw_cx(), rval.handle(), ()) {
                     Ok(ConversionResult::Success(v)) => v,
                     _ => unreachable!(),
@@ -156,20 +157,25 @@ pub(crate) fn handle_evaluate_js(
             )
         } else if rval.is_string() {
             let jsstr = std::ptr::NonNull::new(rval.to_string()).unwrap();
-            EvaluateJSReply::StringValue(jsstr_to_string(cx.raw_cx(), jsstr))
+            EvaluateJSReplyValue::StringValue(jsstr_to_string(cx.raw_cx(), jsstr))
         } else if rval.is_null() {
-            EvaluateJSReply::NullValue
+            EvaluateJSReplyValue::NullValue
         } else {
             assert!(rval.is_object());
 
             let jsstr = std::ptr::NonNull::new(ToString(cx.raw_cx(), rval.handle())).unwrap();
             let class_name = jsstr_to_string(cx.raw_cx(), jsstr);
 
-            EvaluateJSReply::ActorValue {
+            EvaluateJSReplyValue::ActorValue {
                 class: class_name,
                 uuid: Uuid::new_v4().to_string(),
             }
         }
+    };
+
+    let result = EvaluateJSReply {
+        value,
+        has_exception: false,
     };
     reply.send(result).unwrap();
 }

--- a/components/script/dom/debuggerevalevent.rs
+++ b/components/script/dom/debuggerevalevent.rs
@@ -20,6 +20,7 @@ pub(crate) struct DebuggerEvalEvent {
     code: DOMString,
     pipeline_id: Dom<PipelineId>,
     worker_id: Option<DOMString>,
+    frame_actor_id: Option<DOMString>,
 }
 
 impl DebuggerEvalEvent {
@@ -28,6 +29,7 @@ impl DebuggerEvalEvent {
         code: DOMString,
         pipeline_id: &PipelineId,
         worker_id: Option<DOMString>,
+        frame_actor_id: Option<DOMString>,
         can_gc: CanGc,
     ) -> DomRoot<Self> {
         let result = Box::new(Self {
@@ -35,6 +37,7 @@ impl DebuggerEvalEvent {
             code,
             pipeline_id: Dom::from_ref(pipeline_id),
             worker_id,
+            frame_actor_id,
         });
         let result = reflect_dom_object(result, debugger_global, can_gc);
         result.event.init_event("eval".into(), false, false);
@@ -57,6 +60,10 @@ impl DebuggerEvalEventMethods<crate::DomTypeHolder> for DebuggerEvalEvent {
 
     fn GetWorkerId(&self) -> Option<DOMString> {
         self.worker_id.clone()
+    }
+
+    fn GetFrameActorId(&self) -> Option<DOMString> {
+        self.frame_actor_id.clone()
     }
 
     fn IsTrusted(&self) -> bool {

--- a/components/script/dom/debuggerglobalscope.rs
+++ b/components/script/dom/debuggerglobalscope.rs
@@ -8,7 +8,8 @@ use base::generic_channel::{GenericCallback, GenericSender, channel};
 use base::id::{Index, PipelineId, PipelineNamespaceId};
 use constellation_traits::ScriptToConstellationChan;
 use devtools_traits::{
-    DevtoolScriptControlMsg, EvaluateJSReply, ScriptToDevtoolsControlMsg, SourceInfo, WorkerId,
+    DevtoolScriptControlMsg, EvaluateJSReply, EvaluateJSReplyValue, ScriptToDevtoolsControlMsg,
+    SourceInfo, WorkerId,
 };
 use dom_struct::dom_struct;
 use embedder_traits::ScriptToEmbedderChan;
@@ -170,6 +171,7 @@ impl DebuggerGlobalScope {
         code: DOMString,
         debuggee_pipeline_id: PipelineId,
         debuggee_worker_id: Option<WorkerId>,
+        frame_actor_id: Option<String>,
         result_sender: GenericSender<EvaluateJSReply>,
     ) {
         assert!(
@@ -185,6 +187,7 @@ impl DebuggerGlobalScope {
             code,
             &debuggee_pipeline_id,
             debuggee_worker_id.map(|id| id.to_string().into()),
+            frame_actor_id.map(|id| id.into()),
             can_gc,
         ));
         assert!(
@@ -413,41 +416,44 @@ impl DebuggerGlobalScopeMethods<crate::DomTypeHolder> for DebuggerGlobalScope {
             .take()
             .expect("Guaranteed by Self::fire_eval()");
 
-        let reply = if result.completionType.str() == "terminated" {
-            EvaluateJSReply::VoidValue
-        } else {
-            match &*result.valueType.str() {
-                "undefined" => EvaluateJSReply::VoidValue,
-                "null" => EvaluateJSReply::NullValue,
-                "boolean" => {
-                    EvaluateJSReply::BooleanValue(result.booleanValue.flatten().unwrap_or(false))
-                },
-                "number" => {
-                    let num = result.numberValue.flatten().map(|f| *f).unwrap_or(0.0);
-                    EvaluateJSReply::NumberValue(num)
-                },
-                "string" => EvaluateJSReply::StringValue(
-                    result
-                        .stringValue
-                        .as_ref()
-                        .and_then(|opt| opt.as_ref())
-                        .map(|s| s.to_string())
-                        .unwrap_or_default(),
-                ),
-                "object" => {
-                    let class = result
-                        .objectClass
-                        .as_ref()
-                        .and_then(|opt| opt.as_ref())
-                        .map(|s| s.to_string())
-                        .unwrap_or_else(|| "Object".to_string());
-                    EvaluateJSReply::ActorValue {
-                        class,
-                        uuid: uuid::Uuid::new_v4().to_string(),
-                    }
-                },
-                _ => unreachable!(),
-            }
+        let has_exception = result.hasException.flatten().unwrap_or(false);
+
+        let value = match &*result.valueType.str() {
+            "undefined" => EvaluateJSReplyValue::VoidValue,
+            "null" => EvaluateJSReplyValue::NullValue,
+            "boolean" => {
+                EvaluateJSReplyValue::BooleanValue(result.booleanValue.flatten().unwrap_or(false))
+            },
+            "number" => {
+                let num = result.numberValue.flatten().map(|f| *f).unwrap_or(0.0);
+                EvaluateJSReplyValue::NumberValue(num)
+            },
+            "string" => EvaluateJSReplyValue::StringValue(
+                result
+                    .stringValue
+                    .as_ref()
+                    .and_then(|opt| opt.as_ref())
+                    .map(|s| s.to_string())
+                    .unwrap_or_default(),
+            ),
+            "object" => {
+                let class = result
+                    .objectClass
+                    .as_ref()
+                    .and_then(|opt| opt.as_ref())
+                    .map(|s| s.to_string())
+                    .unwrap_or_else(|| "Object".to_string());
+                EvaluateJSReplyValue::ActorValue {
+                    class,
+                    uuid: uuid::Uuid::new_v4().to_string(),
+                }
+            },
+            _ => unreachable!(),
+        };
+
+        let reply = EvaluateJSReply {
+            value,
+            has_exception,
         };
 
         let _ = sender.send(reply);

--- a/components/script/script_thread.rs
+++ b/components/script/script_thread.rs
@@ -2249,9 +2249,15 @@ impl ScriptThread {
                     node_id.as_deref(),
                 )
             },
-            DevtoolScriptControlMsg::Eval(code, id, reply) => {
-                self.debugger_global
-                    .fire_eval(CanGc::from_cx(cx), code.into(), id, None, reply);
+            DevtoolScriptControlMsg::Eval(code, id, frame_actor_id, reply) => {
+                self.debugger_global.fire_eval(
+                    CanGc::from_cx(cx),
+                    code.into(),
+                    id,
+                    None,
+                    frame_actor_id,
+                    reply,
+                );
             },
             DevtoolScriptControlMsg::GetPossibleBreakpoints(spidermonkey_id, result_sender) => {
                 self.debugger_global.fire_get_possible_breakpoints(

--- a/components/script_bindings/webidls/DebuggerEvalEvent.webidl
+++ b/components/script_bindings/webidls/DebuggerEvalEvent.webidl
@@ -9,6 +9,7 @@ interface DebuggerEvalEvent : Event {
     readonly attribute DOMString code;
     readonly attribute PipelineId pipelineId;
     readonly attribute DOMString? workerId;
+    readonly attribute DOMString? frameActorId;
 };
 
 partial interface DebuggerGlobalScope {
@@ -36,4 +37,5 @@ dictionary EvalResultValue {
     // A string naming the ECMAScript [[Class]] of the referent.
     // <https://firefox-source-docs.mozilla.org/js/Debugger/Debugger.Object.html#accessor-properties-of-the-debugger-object-prototype>
     DOMString? objectClass;
+    boolean? hasException;
 };

--- a/components/shared/devtools/lib.rs
+++ b/components/shared/devtools/lib.rs
@@ -149,15 +149,20 @@ pub enum DomMutation {
 }
 
 /// Serialized JS return values
-/// TODO: generalize this beyond the EvaluateJS message?
 #[derive(Debug, Deserialize, Serialize)]
-pub enum EvaluateJSReply {
+pub enum EvaluateJSReplyValue {
     VoidValue,
     NullValue,
     BooleanValue(bool),
     NumberValue(f64),
     StringValue(String),
     ActorValue { class: String, uuid: String },
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+pub struct EvaluateJSReply {
+    pub value: EvaluateJSReplyValue,
+    pub has_exception: bool,
 }
 
 #[derive(Debug, Deserialize, Serialize)]
@@ -333,7 +338,12 @@ pub enum DevtoolScriptControlMsg {
     /// Highlight the given DOM node
     HighlightDomNode(PipelineId, Option<String>),
 
-    Eval(String, PipelineId, GenericSender<EvaluateJSReply>),
+    Eval(
+        String,
+        PipelineId,
+        Option<String>,
+        GenericSender<EvaluateJSReply>,
+    ),
     GetPossibleBreakpoints(u32, GenericSender<Vec<RecommendedBreakpointLocation>>),
     SetBreakpoint(u32, u32, u32),
     ClearBreakpoint(u32, u32, u32),

--- a/python/servo/devtools_tests.py
+++ b/python/servo/devtools_tests.py
@@ -218,6 +218,44 @@ class DevtoolsTests(unittest.IsolatedAsyncioTestCase):
             self.assertEqual(paused_data.get("type"), "paused")
             self.assertEqual(paused_data.get("why", {}).get("type"), "breakpoint")
 
+    def test_frame_scoped_eval(self):
+        self.run_servoshell(url=f"{self.base_urls[0]}/debugger/frame_scoped.html")
+        with Devtools.connect() as devtools:
+            thread_actor = devtools.targets[0]["threadActor"]
+            console_actor = devtools.targets[0]["consoleActor"]
+            devtools.client.send_receive({"to": thread_actor, "type": "attach"})
+
+            paused_future = Future()
+
+            def on_paused(data):
+                paused_future.set_result(data)
+
+            devtools.client.add_event_listener(thread_actor, "paused", on_paused)
+            devtools.client.send_receive({"to": thread_actor, "type": "interrupt", "when": "onNext"})
+
+            paused_data = paused_future.result(3)
+            frame_actor = paused_data.get("frame", {}).get("actor")
+            self.assertIsNotNone(frame_actor)
+
+            eval_future = Future()
+
+            def on_eval_result(data):
+                eval_future.set_result(data)
+
+            devtools.client.add_event_listener(console_actor, Events.WebConsole.EVALUATION_RESULT, on_eval_result)
+            devtools.client.send_receive(
+                {
+                    "to": console_actor,
+                    "type": "evaluateJSAsync",
+                    "text": "i",
+                    "frameActor": frame_actor,
+                }
+            )
+
+            eval_result = eval_future.result(2)
+            self.assertFalse(eval_result.get("hasException", True))
+            self.assertEqual(eval_result.get("result"), 42)
+
     def test_breakpoint_at_invalid_entry_point_does_not_crash(self):
         self.run_servoshell(url=f"{self.base_urls[0]}/debugger/loop.html")
         with Devtools.connect() as devtools:

--- a/python/servo/devtools_tests/debugger/frame_scoped.html
+++ b/python/servo/devtools_tests/debugger/frame_scoped.html
@@ -1,0 +1,7 @@
+<!doctype html><meta charset=utf-8>
+<script>
+    function testFunc(i) {
+        setTimeout(testFunc, 200, 42);
+    }
+    testFunc(42);
+</script>

--- a/resources/debugger.js
+++ b/resources/debugger.js
@@ -100,27 +100,36 @@ function createValueResult(value) {
 // Evaluate some javascript code in the global context of the debuggee
 // <https://firefox-source-docs.mozilla.org/js/Debugger/Debugger.Object.html#executeinglobal-code-options>
 addEventListener("eval", event => {
-    const {code, pipelineId, workerId} = event;
-    const object = workerId !== undefined ?
-        findKeyByValue(debuggeesToWorkerIds, workerId) :
-        findKeyByValue(debuggeesToPipelineIds, pipelineId);
+    const {code, pipelineId, workerId, frameActorId} = event;
+
+    let completionValue;
+    if (frameActorId) {
+        const frame = frameActorsToFrames.get(frameActorId);
+        // <https://searchfox.org/firefox-main/source/js/src/doc/Debugger/Debugger.Frame.md#223>
+        if (frame?.onStack) {
+            completionValue = frame.eval(code);
+        } else {
+            completionValue = { throw: "Frame not available" };
+        }
+    } else {
+        const object = workerId !== undefined ?
+            findKeyByValue(debuggeesToWorkerIds, workerId) :
+            findKeyByValue(debuggeesToPipelineIds, pipelineId);
+        completionValue = object.executeInGlobal(code);
+    }
 
     // Completion values: <https://firefox-source-docs.mozilla.org/js/Debugger/Conventions.html#completion-values>
-    const completionValue = object.executeInGlobal(code);
     let resultValue;
-
     if (completionValue === null) {
-        resultValue = { completionType: "terminated", valueType: "undefined" };
+        resultValue = { completionType: "terminated", valueType: "undefined", hasException: false };
     } else if ("throw" in completionValue) {
-        // Adopt the value to ensure proper Debugger ownership
         // <https://firefox-source-docs.mozilla.org/js/Debugger/Debugger.html#adoptdebuggeevalue-value>
         // <https://searchfox.org/firefox-main/source/devtools/server/actors/webconsole/eval-with-debugger.js#312>
         // we probably don't need adoptDebuggeeValue, as we only have one debugger instance for now
         // let value = dbg.adoptDebuggeeValue(completionValue.throw);
-        resultValue = { completionType: "throw", ...createValueResult(completionValue.throw) };
+        resultValue = { completionType: "throw", ...createValueResult(completionValue.throw), hasException: true };
     } else if ("return" in completionValue) {
-        // let value = dbg.adoptDebuggeeValue(completionValue.return);
-        resultValue = { completionType: "return", ...createValueResult(completionValue.return) };
+        resultValue = { completionType: "return", ...createValueResult(completionValue.return), hasException: false };
     }
 
     evalResult(event, resultValue);


### PR DESCRIPTION
When paused at a breakpoint, hovering over local variables now shows their value. Previously `eval` used `executeInGlobal()` which could not access local scope, so hovering showed `ReferenceError` instead of the actual value.

https://github.com/user-attachments/assets/05247b82-4e4d-422d-a428-63e46b55d55f

Testing: Added a new test
Fixes: Part #36027 