### PR TITLE
script: Refactors GPUPipelineLayout to disallow direct Drop.

### DIFF
--- a/components/script/dom/webgpu/gpupipelinelayout.rs
+++ b/components/script/dom/webgpu/gpupipelinelayout.rs
@@ -20,16 +20,36 @@ use crate::dom::globalscope::GlobalScope;
 use crate::dom::webgpu::gpudevice::GPUDevice;
 use crate::script_runtime::CanGc;
 
+#[derive(JSTraceable, MallocSizeOf)]
+struct DroppableGPUPipelineLayout {
+    #[no_trace]
+    channel: WebGPU,
+    #[no_trace]
+    pipeline_layout: WebGPUPipelineLayout,
+}
+
+impl Drop for DroppableGPUPipelineLayout {
+    fn drop(&mut self) {
+        if let Err(e) = self
+            .channel
+            .0
+            .send(WebGPURequest::DropPipelineLayout(self.pipeline_layout.0))
+        {
+            warn!(
+                "Failed to send DropPipelineLayout ({:?}) ({})",
+                self.pipeline_layout.0, e
+            );
+        }
+    }
+}
+
 #[dom_struct]
 pub(crate) struct GPUPipelineLayout {
     reflector_: Reflector,
-    #[no_trace]
-    channel: WebGPU,
     label: DomRefCell<USVString>,
     #[no_trace]
-    pipeline_layout: WebGPUPipelineLayout,
-    #[no_trace]
     bind_group_layouts: Vec<WebGPUBindGroupLayout>,
+    droppable: DroppableGPUPipelineLayout,
 }
 
 impl GPUPipelineLayout {
@@ -41,10 +61,12 @@ impl GPUPipelineLayout {
     ) -> Self {
         Self {
             reflector_: Reflector::new(),
-            channel,
             label: DomRefCell::new(label),
-            pipeline_layout,
             bind_group_layouts: bgls,
+            droppable: DroppableGPUPipelineLayout {
+                channel,
+                pipeline_layout,
+            },
         }
     }
 
@@ -71,7 +93,7 @@ impl GPUPipelineLayout {
 
 impl GPUPipelineLayout {
     pub(crate) fn id(&self) -> WebGPUPipelineLayout {
-        self.pipeline_layout
+        self.droppable.pipeline_layout
     }
 
     pub(crate) fn bind_group_layouts(&self) -> Vec<WebGPUBindGroupLayout> {
@@ -128,20 +150,5 @@ impl GPUPipelineLayoutMethods<crate::DomTypeHolder> for GPUPipelineLayout {
     /// <https://gpuweb.github.io/gpuweb/#dom-gpuobjectbase-label>
     fn SetLabel(&self, value: USVString) {
         *self.label.borrow_mut() = value;
-    }
-}
-
-impl Drop for GPUPipelineLayout {
-    fn drop(&mut self) {
-        if let Err(e) = self
-            .channel
-            .0
-            .send(WebGPURequest::DropPipelineLayout(self.pipeline_layout.0))
-        {
-            warn!(
-                "Failed to send DropPipelineLayout ({:?}) ({})",
-                self.pipeline_layout.0, e
-            );
-        }
     }
 }

--- a/components/script_bindings/codegen/Bindings.conf
+++ b/components/script_bindings/codegen/Bindings.conf
@@ -349,10 +349,6 @@ DOMInterfaces = {
     'weakReferenceable': True, # for usage in GlobalScope https://github.com/servo/servo/issues/32519
 },
 
-'GPUPipelineLayout': {
-    'allowDropImpl': True,
-},
-
 'GPUQueue': {
     'canGc': ['OnSubmittedWorkDone'],
 },


### PR DESCRIPTION
Moves the `Drop` implementation for `GPUPipelineLayout` to a dedicated private helper struct, `DroppableGPUPipelineLayout`. This ensures that DOM types do not directly implement `Drop`, aligning with best practices for resource management in the DOM. The associated `Bindings.conf` entry is removed as direct `Drop` is no longer needed for this type.

Testing: WebGpu just coverages cases with  proper tests
Fixes: Partially #26488 
