### PR TITLE
ci: Remove dummy audio device related steps for linux-wpt

### DIFF
--- a/.github/workflows/linux-wpt.yml
+++ b/.github/workflows/linux-wpt.yml
@@ -101,9 +101,6 @@ jobs:
           sudo apt install -qy --no-install-recommends mesa-vulkan-drivers fonts-noto-cjk fonts-dejavu-extra
           # FIXME #35029
           sudo apt purge -y fonts-droid-fallback
-          sudo apt install -y jackd2 libjack-jackd2-0
-      - name: Start Dummy Audio Device
-        run: jackd -d dummy &
       - name: Sync from upstream WPT
         if: ${{ inputs.wpt-sync-from-upstream }}
         run: |


### PR DESCRIPTION
This doesn't seem to have any impact.

[Try](https://github.com/servo/servo/actions/runs/22546956503)

Testing: This is a change to the testing CI configuration.