### PR TITLE
ci: Add `jackd2` to dependency of Media Examples

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -393,6 +393,7 @@ jobs:
             gstreamer1.0-plugins-good \
             gstreamer1.0-plugins-ugly \
             gstreamer1.0-tools \
+            jackd2 \
             libasound2-plugins \
             libfaad2 \
             libffi7 \


### PR DESCRIPTION
Testing: Output log is reduced to 910 lines in [try](https://github.com/servo/servo/actions/runs/22567021352/job/65365322261#step:8:910). Previously, it is 1400 lines, and we get error in [when start dummy audio device](https://github.com/servo/servo/actions/runs/22502937019/job/65194401381#step:7:13).
Fixes: Part of #42934?
