### PR TITLE
layout: Wrap Image related data in `ImageInfo` struct in `NodeExt` impl

### DIFF
--- a/components/layout/dom.rs
+++ b/components/layout/dom.rs
@@ -13,7 +13,6 @@ use layout_api::{
     SVGElementData,
 };
 use malloc_size_of_derive::MallocSizeOf;
-use net_traits::image_cache::Image;
 use script::layout_dom::ServoThreadSafeLayoutNode;
 use servo_arc::Arc as ServoArc;
 use smallvec::SmallVec;
@@ -31,7 +30,7 @@ use crate::flow::{BlockLevelBox, BlockLevelCreator};
 use crate::fragment_tree::{Fragment, FragmentFlags};
 use crate::geom::PhysicalSize;
 use crate::layout_box_base::LayoutBoxBase;
-use crate::replaced::{CanvasInfo, VideoInfo};
+use crate::replaced::{CanvasInfo, ImageInfo, VideoInfo};
 use crate::style_ext::{
     ComputedValuesExt, Display, DisplayGeneratingBox, DisplayLayoutInternal, DisplayOutside,
 };
@@ -307,9 +306,8 @@ impl Drop for BoxSlot<'_> {
 }
 
 pub(crate) trait NodeExt<'dom> {
-    /// Returns the image if it’s loaded, and its size in image pixels
-    /// adjusted for `image_density`.
-    fn as_image(&self) -> Option<(Option<Image>, PhysicalSize<f64>)>;
+    /// Returns the relevant data wrapping into respective struct and its size in pixels.
+    fn as_image(&self) -> Option<(ImageInfo, PhysicalSize<f64>)>;
     fn as_canvas(&self) -> Option<(CanvasInfo, PhysicalSize<f64>)>;
     fn as_iframe(&self) -> Option<(PipelineId, BrowsingContextId)>;
     fn as_video(&self) -> Option<(VideoInfo, Option<PhysicalSize<f64>>)>;
@@ -354,7 +352,7 @@ pub(crate) trait NodeExt<'dom> {
 }
 
 impl<'dom> NodeExt<'dom> for ServoThreadSafeLayoutNode<'dom> {
-    fn as_image(&self) -> Option<(Option<Image>, PhysicalSize<f64>)> {
+    fn as_image(&self) -> Option<(ImageInfo, PhysicalSize<f64>)> {
         let (resource, metadata) = self.image_data()?;
         let width = metadata.map(|metadata| metadata.width).unwrap_or_default();
         let height = metadata.map(|metadata| metadata.height).unwrap_or_default();
@@ -363,7 +361,13 @@ impl<'dom> NodeExt<'dom> for ServoThreadSafeLayoutNode<'dom> {
             width /= density;
             height /= density;
         }
-        Some((resource, PhysicalSize::new(width, height)))
+        Some((
+            ImageInfo {
+                image: resource,
+                showing_broken_image_icon: self.showing_broken_image_icon(),
+            },
+            PhysicalSize::new(width, height),
+        ))
     }
 
     fn as_svg(&self) -> Option<SVGElementData<'dom>> {

--- a/components/layout/replaced.rs
+++ b/components/layout/replaced.rs
@@ -160,15 +160,12 @@ impl ReplacedContents {
         }
 
         let (kind, natural_size) = {
-            if let Some((image, natural_size_in_dots)) = node.as_image() {
+            if let Some((image_info, natural_size_in_dots)) = node.as_image() {
                 if let Some(content_image) = Self::from_content_property(node, context) {
                     return Some(content_image);
                 }
                 (
-                    ReplacedContentKind::Image(ImageInfo {
-                        image,
-                        showing_broken_image_icon: node.showing_broken_image_icon(),
-                    }),
+                    ReplacedContentKind::Image(image_info),
                     NaturalSizes::from_natural_size_in_dots(natural_size_in_dots),
                 )
             } else if let Some((canvas_info, natural_size_in_dots)) = node.as_canvas() {


### PR DESCRIPTION
Encapsulating Image related data in ImageInfo in NodeExt impl.

Testing: This is just a little refactor. No change in behavior expected. Successful compilation is enough to verify.
