### PR TITLE
Reword our security policy

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,4 +1,3 @@
 # Security Policy
 
-Given that Servo does not yet have customers or products, we are comfortable accepting the security related issues as [GitHub security reports](https://github.com/servo/servo/security/advisories/new) for now.
-
+Please submit security related issues as [GitHub security reports](https://github.com/servo/servo/security/advisories/new).


### PR DESCRIPTION
In ac24cd61395f6a9646efe1da13ba5674eea59e7e we started asking for people to use **private** github security reports, but kept the wording from before, which was related to accepting such reports as **public** issues.
The wording doesn't make sense in the context of asking people for private reports, so update the wording to reflect that.
This is not a policy change, just making the wording more clear.

Testing: Not required, policy description.
