### PR TITLE
tests: Add back .ini file for parser reentrancy test

### DIFF
--- a/tests/wpt/mozilla/meta/mozilla/parser-reentrancy-customelement.window.js.ini
+++ b/tests/wpt/mozilla/meta/mozilla/parser-reentrancy-customelement.window.js.ini
@@ -1,0 +1,5 @@
+[parser-reentrancy-customelement.window.html?default]
+  prefs: ["dom_servoparser_async_html_tokenizer_enabled:false"]
+
+[parser-reentrancy-customelement.window.html?async]
+  prefs: ["dom_servoparser_async_html_tokenizer_enabled:true"]


### PR DESCRIPTION
The file was removed in https://github.com/servo/servo/commit/bb5547a5d05b1f002d9cce3197cfb9cdcb71d33c but we still need it. Note that we don't crash on the async variant anymore since https://github.com/servo/servo/pull/42910.

Fixes https://github.com/servo/servo/issues/42933
Testing: The tests run as expected.
