### PR TITLE
layout/fonts: Mitigate races related to quirks mode and fallback fonts

### DIFF
--- a/components/fonts/font.rs
+++ b/components/fonts/font.rs
@@ -184,6 +184,14 @@ impl FontMetrics {
         static EMPTY: OnceLock<Arc<FontMetrics>> = OnceLock::new();
         EMPTY.get_or_init(Default::default).clone()
     }
+
+    /// Whether or not the block metrics of the two `FontMetrics` instances differ in a way
+    /// that requires the resulting block size of a containing inline box to change.
+    pub fn block_metrics_meaningfully_differ(&self, other: &Self) -> bool {
+        self.ascent != other.ascent ||
+            self.descent != other.descent ||
+            self.line_gap != other.line_gap
+    }
 }
 
 #[derive(Debug, Default)]

--- a/components/fonts/font_context.rs
+++ b/components/fonts/font_context.rs
@@ -264,6 +264,15 @@ impl FontContext {
             font_template, font_descriptor
         );
 
+        // Check one more time whether the font is cached or not. There's a potential race
+        // condition, where between the time we took the read lock above and now, another thread
+        // added the font to the cache. This check makes sense, because loading a font has memory
+        // implications and is much slower than checking the map again.
+        let mut fonts = self.fonts.write();
+        if let Some(font) = fonts.get(&cache_key).cloned() {
+            return font;
+        }
+
         // TODO: Inserting `None` into the cache here is a bit bogus. Instead we should somehow
         // mark this template as invalid so it isn't tried again.
         let font = self
@@ -273,7 +282,7 @@ impl FontContext {
                 synthesized_small_caps_font,
             )
             .ok();
-        self.fonts.write().insert(cache_key, font.clone());
+        fonts.insert(cache_key, font.clone());
         font
     }
 

--- a/components/layout/flow/inline/mod.rs
+++ b/components/layout/flow/inline/mod.rs
@@ -1580,46 +1580,46 @@ impl InlineFormattingContextLayout<'_> {
             SegmentContentFlags::empty()
         };
 
-        // If the metrics of this font don't match the default font, we are likely using a fallback
-        // font and need to adjust the line size to account for a potentially different font.
-        // If somehow the metrics match, the line size won't change.
         let font_metrics = &font.metrics;
         let font_key = font.key(
             self.layout_context.painter_id,
             &self.layout_context.font_context,
         );
-        let using_fallback_font = !Arc::ptr_eq(
-            &self.current_inline_container_state().font_metrics,
-            font_metrics,
-        );
 
+        let mut block_contribution = LineBlockSizes::zero();
         let quirks_mode = self.layout_context.style_context.quirks_mode() != QuirksMode::NoQuirks;
-        let strut_size = if using_fallback_font {
+        if quirks_mode && !flags.is_collapsible_whitespace() {
+            // Normally, the strut is incorporated into the nested block size. In quirks mode though
+            // if we find any text that isn't collapsed whitespace, we need to incorporate the strut.
+            // TODO(mrobinson): This isn't quite right for situations where collapsible white space
+            // ultimately does not collapse because it is between two other pieces of content.
+            block_contribution.max_assign(&self.current_inline_container_state().strut_block_sizes);
+        }
+
+        // If the metrics of this font don't match the default font, we are likely using another
+        // font from the font list or a fallback and should incorporate its block size into the block
+        // size of the container.
+        if self
+            .current_inline_container_state()
+            .font_metrics
+            .block_metrics_meaningfully_differ(&font.metrics)
+        {
             // TODO(mrobinson): This value should probably be cached somewhere.
             let container_state = self.current_inline_container_state();
             let baseline_shift = effective_baseline_shift(
                 &container_state.style,
                 self.inline_box_state_stack.last().map(|c| &c.base),
             );
-            let mut block_size = container_state.get_block_size_contribution(
+            let mut font_block_conribution = container_state.get_block_size_contribution(
                 baseline_shift,
                 font_metrics,
                 &container_state.font_metrics,
             );
-            block_size.adjust_for_baseline_offset(container_state.baseline_offset);
-            block_size
-        } else if quirks_mode && !flags.is_collapsible_whitespace() {
-            // Normally, the strut is incorporated into the nested block size. In quirks mode though
-            // if we find any text that isn't collapsed whitespace, we need to incorporate the strut.
-            // TODO(mrobinson): This isn't quite right for situations where collapsible white space
-            // ultimately does not collapse because it is between two other pieces of content.
-            self.current_inline_container_state()
-                .strut_block_sizes
-                .clone()
-        } else {
-            LineBlockSizes::zero()
-        };
-        self.update_unbreakable_segment_for_new_content(&strut_size, inline_advance, flags);
+            font_block_conribution.adjust_for_baseline_offset(container_state.baseline_offset);
+            block_contribution.max_assign(&font_block_conribution);
+        }
+
+        self.update_unbreakable_segment_for_new_content(&block_contribution, inline_advance, flags);
 
         let current_inline_box_identifier = self.current_inline_box_identifier();
         if let Some(LineItem::TextRun(inline_box_identifier, line_item)) =


### PR DESCRIPTION
This change includes two related fixes for flakiness revealed by #42847.

1. When caching fonts, try harder to not re-cache a font. This could
   happen due to a race condition with the read-write lock on the font
   cache. This change improves memory usage in some cases as it prevents
   a font from being loaded twice.
2. Incorporate both the strut size and the block size contribution of a
   previously unused font in an inline container. Before the code was
   incorporating one or the other. In addition, *only* incorporate the
   block contribution of a previously unused font if its metrics
   meaningfully differ from the container's default font. This was the
   case triggered by failing to have the fix in part one of the change.

Testing: This fixes flakiness in an internal WPT-style test.
Fixes: #42908.
