### PR TITLE
fonts: Don't apply `letter-spacing` to formatting characters

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7697,6 +7697,7 @@ dependencies = [
  "fontsan",
  "freetype-sys",
  "harfbuzz-sys",
+ "icu_properties",
  "itertools 0.14.0",
  "libc",
  "log",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -107,8 +107,8 @@ hyper-rustls = { version = "0.27", default-features = false, features = ["http1"
 hyper-util = { version = "0.1", features = ["client-legacy", "http2", "tokio", "client-proxy"] }
 hyper_serde = { package = "servo-hyper-serde", path = "components/hyper_serde" }
 icu_locid = "1.5.0"
-icu_segmenter = "1.5.0"
 icu_properties = "1.5.0"
+icu_segmenter = "1.5.0"
 image = { version = "0.25", default-features = false, features = ["avif", "rayon", "bmp", "gif", "ico", "jpeg", "png", "webp"] }
 imsz = "0.4"
 indexmap = { version = "2.11.4", features = ["std"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -108,6 +108,7 @@ hyper-util = { version = "0.1", features = ["client-legacy", "http2", "tokio", "
 hyper_serde = { package = "servo-hyper-serde", path = "components/hyper_serde" }
 icu_locid = "1.5.0"
 icu_segmenter = "1.5.0"
+icu_properties = "1.5.0"
 image = { version = "0.25", default-features = false, features = ["avif", "rayon", "bmp", "gif", "ico", "jpeg", "png", "webp"] }
 imsz = "0.4"
 indexmap = { version = "2.11.4", features = ["std"] }

--- a/components/fonts/Cargo.toml
+++ b/components/fonts/Cargo.toml
@@ -27,6 +27,7 @@ fontsan = { version = "0.6.1" }
 # FIXME (#34517): macOS only needs this when building libservo without `--features media-gstreamer`
 harfbuzz-sys = { workspace = true, features = ["bundled"] }
 itertools = { workspace = true }
+icu_properties = { workspace = true, features = ["compiled_data"] }
 libc = { workspace = true }
 log = { workspace = true }
 malloc_size_of = { workspace = true }

--- a/components/fonts/Cargo.toml
+++ b/components/fonts/Cargo.toml
@@ -26,8 +26,8 @@ fonts_traits = { workspace = true }
 fontsan = { version = "0.6.1" }
 # FIXME (#34517): macOS only needs this when building libservo without `--features media-gstreamer`
 harfbuzz-sys = { workspace = true, features = ["bundled"] }
-itertools = { workspace = true }
 icu_properties = { workspace = true, features = ["compiled_data"] }
+itertools = { workspace = true }
 libc = { workspace = true }
 log = { workspace = true }
 malloc_size_of = { workspace = true }

--- a/components/fonts/font.rs
+++ b/components/fonts/font.rs
@@ -375,6 +375,9 @@ bitflags! {
 pub struct ShapingOptions {
     /// Spacing to add between each letter. Corresponds to the CSS 2.1 `letter-spacing` property.
     /// NB: You will probably want to set the `IGNORE_LIGATURES_SHAPING_FLAG` if this is non-null.
+    ///
+    /// Letter spacing is not applied to all characters. Use [Self::letter_spacing_for_character] to
+    /// determine the amount of spacing to apply.
     pub letter_spacing: Option<Au>,
     /// Spacing to add between each word. Corresponds to the CSS 2.1 `word-spacing` property.
     pub word_spacing: Au,
@@ -382,6 +385,18 @@ pub struct ShapingOptions {
     pub script: Script,
     /// Various flags.
     pub flags: ShapingFlags,
+}
+
+impl ShapingOptions {
+    pub(crate) fn letter_spacing_for_character(&self, character: char) -> Option<Au> {
+        // https://drafts.csswg.org/css-text/#letter-spacing-property
+        // Letter spacing ignores invisible zero-width formatting characters (such as those from the Unicode Cf category).
+        // Spacing must be added as if those characters did not exist in the document.
+        self.letter_spacing.filter(|_| {
+            icu_properties::maps::general_category().get(character) !=
+                icu_properties::GeneralCategory::Format
+        })
+    }
 }
 
 /// An entry in the shape cache.
@@ -963,7 +978,7 @@ pub(super) fn advance_for_shaped_glyph(
     character: char,
     options: &ShapingOptions,
 ) -> Au {
-    if let Some(letter_spacing) = options.letter_spacing {
+    if let Some(letter_spacing) = options.letter_spacing_for_character(character) {
         advance += letter_spacing;
     };
 

--- a/components/fonts/glyph.rs
+++ b/components/fonts/glyph.rs
@@ -553,7 +553,7 @@ impl ShapedGlyph {
             self.advance = font.metrics.space_advance * 8;
         }
 
-        if let Some(letter_spacing) = shaping_options.letter_spacing {
+        if let Some(letter_spacing) = shaping_options.letter_spacing_for_character(character) {
             self.advance += letter_spacing;
         };
 

--- a/tests/wpt/meta/css/CSS2/bidi-text/bidi-005b.xht.ini
+++ b/tests/wpt/meta/css/CSS2/bidi-text/bidi-005b.xht.ini
@@ -1,2 +1,0 @@
-[bidi-005b.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/bidi-text/bidi-006b.xht.ini
+++ b/tests/wpt/meta/css/CSS2/bidi-text/bidi-006b.xht.ini
@@ -1,2 +1,0 @@
-[bidi-006b.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/bidi-text/bidi-007b.xht.ini
+++ b/tests/wpt/meta/css/CSS2/bidi-text/bidi-007b.xht.ini
@@ -1,2 +1,0 @@
-[bidi-007b.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/bidi-text/bidi-008b.xht.ini
+++ b/tests/wpt/meta/css/CSS2/bidi-text/bidi-008b.xht.ini
@@ -1,2 +1,0 @@
-[bidi-008b.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/bidi-text/bidi-009b.xht.ini
+++ b/tests/wpt/meta/css/CSS2/bidi-text/bidi-009b.xht.ini
@@ -1,2 +1,0 @@
-[bidi-009b.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/bidi-text/bidi-010b.xht.ini
+++ b/tests/wpt/meta/css/CSS2/bidi-text/bidi-010b.xht.ini
@@ -1,2 +1,0 @@
-[bidi-010b.xht]
-  expected: FAIL


### PR DESCRIPTION
This change checks whether a character belongs to the `Cf` category of unicode characters before applying `letter-spacing`. The `fonts` crate now depends on `icu_properties`, but that crate is already in our dependency tree (with the same features enabled).

Testing: New tests start to pass
Fixes https://github.com/servo/servo/issues/38781
