### PR TITLE
indexeddb: remove blocking GenerateKey sync IPC

### DIFF
--- a/components/script/dom/indexeddb/idbdatabase.rs
+++ b/components/script/dom/indexeddb/idbdatabase.rs
@@ -268,6 +268,7 @@ impl IDBDatabaseMethods<crate::DomTypeHolder> for IDBDatabase {
             self.name.clone(),
             name.clone(),
             Some(options),
+            if auto_increment { Some(1) } else { None },
             CanGc::from_cx(cx),
             &upgrade_transaction,
         );

--- a/components/script/dom/indexeddb/idbobjectstore.rs
+++ b/components/script/dom/indexeddb/idbobjectstore.rs
@@ -173,17 +173,54 @@ impl IDBObjectStore {
         self.has_key_generator
     }
 
-    fn reserve_generated_key_for_put(&self) -> Fallible<(IndexedDBKeyType, i32)> {
+    /// <https://w3c.github.io/IndexedDB/#generate-a-key>
+    fn generate_key_for_put(&self) -> Fallible<(IndexedDBKeyType, i32)> {
+        // Step 1. Let generator be store's key generator.
         let Some(current_number) = self.key_generator_current_number.get() else {
             return Err(Error::Data(None));
         };
+        // Step 2. Let key be generator's current number.
+        let key = current_number as f64;
+        // Step 3. If key is greater than 2^53 (9007199254740992), then return failure.
+        if key > 9_007_199_254_740_992.0 {
+            return Err(Error::Constraint(None));
+        }
+        // Step 4. Increase generator's current number by 1.
         let next_current_number = current_number
             .checked_add(1)
             .ok_or(Error::Constraint(None))?;
-        Ok((
-            IndexedDBKeyType::Number(current_number as f64),
-            next_current_number,
-        ))
+        // Step 5. Return key.
+        Ok((IndexedDBKeyType::Number(key), next_current_number))
+    }
+
+    /// <https://w3c.github.io/IndexedDB/#possibly-update-the-key-generator>
+    fn possibly_update_the_key_generator(&self, key: &IndexedDBKeyType) -> Option<i32> {
+        // Step 1. If the type of key is not number, abort these steps.
+        let IndexedDBKeyType::Number(number) = key else {
+            return None;
+        };
+
+        // Step 2. Let value be the value of key.
+        let mut value = *number;
+        // Step 3. Set value to the minimum of value and 2^53 (9007199254740992).
+        value = value.min(9_007_199_254_740_992.0);
+        // Step 4. Set value to the largest integer not greater than value.
+        value = value.floor();
+        // Step 5. Let generator be store's key generator.
+        let current_number = self.key_generator_current_number.get()?;
+        // Step 6. If value is greater than or equal to generator's current number,
+        // then set generator's current number to value + 1.
+        if value < current_number as f64 {
+            return None;
+        }
+
+        let next = value + 1.0;
+        // Servo currently stores the key generator current number as i32.
+        // Saturate to keep "no more generated keys" behavior when this overflows.
+        if next >= i32::MAX as f64 {
+            return Some(i32::MAX);
+        }
+        Some(next as i32)
     }
 
     /// <https://www.w3.org/TR/IndexedDB-3/#object-store-in-line-keys>
@@ -265,9 +302,10 @@ impl IDBObjectStore {
         let key_generator_current_number_for_put: Option<i32>;
 
         if !key.is_undefined() {
-            serialized_key = Some(convert_value_to_key(cx, key, None)?.into_result()?);
+            let key = convert_value_to_key(cx, key, None)?.into_result()?;
+            key_generator_current_number_for_put = self.possibly_update_the_key_generator(&key);
+            serialized_key = Some(key);
             maybe_modified_cloned_value = None;
-            key_generator_current_number_for_put = None;
         } else {
             match self.key_path.as_ref() {
                 Some(key_path) => {
@@ -294,8 +332,9 @@ impl IDBObjectStore {
                         ExtractionResult::Invalid => return Err(Error::Data(None)),
                         // Step 11.3. If kpk is not failure, let key be kpk.
                         ExtractionResult::Key(kpk) => {
+                            key_generator_current_number_for_put =
+                                self.possibly_update_the_key_generator(&kpk);
                             serialized_key = Some(kpk);
-                            key_generator_current_number_for_put = None;
                         },
                         ExtractionResult::Failure => {
                             // Step 11.4. Otherwise:
@@ -315,7 +354,7 @@ impl IDBObjectStore {
                             }
                             // Step 11.4.3. Let key be the result of generating a key for store.
                             let (generated_key, next_current_number) =
-                                self.reserve_generated_key_for_put()?;
+                                self.generate_key_for_put()?;
                             // Step 11.4.4. Inject key into value.
                             if !inject_key_into_value(
                                 cx,

--- a/components/script/dom/indexeddb/idbobjectstore.rs
+++ b/components/script/dom/indexeddb/idbobjectstore.rs
@@ -1,6 +1,7 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+use std::cell::Cell;
 use std::collections::HashMap;
 
 use base::generic_channel::{GenericSend, GenericSender};
@@ -10,7 +11,6 @@ use js::conversions::ToJSValConvertible;
 use js::gc::MutableHandleValue;
 use js::jsval::NullValue;
 use js::rust::HandleValue;
-use profile_traits::generic_channel::channel;
 use script_bindings::codegen::GenericBindings::IDBObjectStoreBinding::IDBIndexParameters;
 use script_bindings::codegen::GenericUnionTypes::StringOrStringSequence;
 use script_bindings::error::ErrorResult;
@@ -43,7 +43,7 @@ use crate::dom::indexeddb::idbrequest::IDBRequest;
 use crate::dom::indexeddb::idbtransaction::IDBTransaction;
 use crate::indexeddb::{
     ExtractionResult, can_inject_key_into_value, convert_value_to_key, convert_value_to_key_range,
-    extract_key, inject_key_into_value, map_backend_error_to_dom_error,
+    extract_key, inject_key_into_value,
 };
 use crate::script_runtime::CanGc;
 
@@ -91,9 +91,11 @@ pub struct IDBObjectStore {
     key_path: Option<KeyPath>,
     index_set: DomRefCell<HashMap<DOMString, Dom<IDBIndex>>>,
     transaction: Dom<IDBTransaction>,
+    has_key_generator: bool,
+    key_generator_current_number: Cell<Option<i32>>,
 
-    // We store the db name in the object store to be able to find the correct
-    // store in the idb thread when checking if we have a key generator
+    // We store the db name in the object store to address backend operations
+    // that are keyed by (origin, database name, object store name).
     db_name: DOMString,
 }
 
@@ -102,6 +104,7 @@ impl IDBObjectStore {
         db_name: DOMString,
         name: DOMString,
         options: Option<&IDBObjectStoreParameters>,
+        key_generator_current_number: Option<i32>,
         transaction: &IDBTransaction,
     ) -> IDBObjectStore {
         let key_path: Option<KeyPath> = match options {
@@ -113,6 +116,12 @@ impl IDBObjectStore {
             }),
             None => None,
         };
+        let has_key_generator = options.is_some_and(|options| options.autoIncrement);
+        let key_generator_current_number = if has_key_generator {
+            Some(key_generator_current_number.unwrap_or(1))
+        } else {
+            None
+        };
 
         IDBObjectStore {
             reflector_: Reflector::new(),
@@ -120,6 +129,8 @@ impl IDBObjectStore {
             key_path,
             index_set: DomRefCell::new(HashMap::new()),
             transaction: Dom::from_ref(transaction),
+            has_key_generator,
+            key_generator_current_number: Cell::new(key_generator_current_number),
             db_name,
         }
     }
@@ -129,6 +140,7 @@ impl IDBObjectStore {
         db_name: DOMString,
         name: DOMString,
         options: Option<&IDBObjectStoreParameters>,
+        key_generator_current_number: Option<i32>,
         can_gc: CanGc,
         transaction: &IDBTransaction,
     ) -> DomRoot<IDBObjectStore> {
@@ -137,6 +149,7 @@ impl IDBObjectStore {
                 db_name,
                 name,
                 options,
+                key_generator_current_number,
                 transaction,
             )),
             global,
@@ -157,43 +170,20 @@ impl IDBObjectStore {
     }
 
     fn has_key_generator(&self) -> bool {
-        // FIXME: blocking IPC call
-        let (sender, receiver) = channel(self.global().time_profiler_chan().clone()).unwrap();
-
-        let operation = SyncOperation::GetObjectStore(
-            sender,
-            self.global().origin().immutable().clone(),
-            self.db_name.to_string(),
-            self.name.borrow().to_string(),
-        );
-
-        self.get_idb_thread()
-            .send(IndexedDBThreadMsg::Sync(operation))
-            .unwrap();
-
-        // First unwrap for ipc
-        // Second unwrap will never happen unless this db gets manually deleted somehow
-        receiver.recv().unwrap().unwrap().has_key_generator
+        self.has_key_generator
     }
 
-    fn generate_key(&self) -> Fallible<IndexedDBKeyType> {
-        // FIXME: blocking IPC call ? how ?
-        let (sender, receiver) = channel(self.global().time_profiler_chan().clone()).unwrap();
-        let operation = SyncOperation::GenerateKey(
-            sender,
-            self.global().origin().immutable().clone(),
-            self.db_name.to_string(),
-            self.name.borrow().to_string(),
-        );
-
-        self.get_idb_thread()
-            .send(IndexedDBThreadMsg::Sync(operation))
-            .unwrap();
-
-        receiver
-            .recv()
-            .unwrap()
-            .map_err(map_backend_error_to_dom_error)
+    fn reserve_generated_key_for_put(&self) -> Fallible<(IndexedDBKeyType, i32)> {
+        let Some(current_number) = self.key_generator_current_number.get() else {
+            return Err(Error::Data(None));
+        };
+        let next_current_number = current_number
+            .checked_add(1)
+            .ok_or(Error::Constraint(None))?;
+        Ok((
+            IndexedDBKeyType::Number(current_number as f64),
+            next_current_number,
+        ))
     }
 
     /// <https://www.w3.org/TR/IndexedDB-3/#object-store-in-line-keys>
@@ -272,10 +262,12 @@ impl IDBObjectStore {
         // Step 8. If key was given, then: convert a value to a key with key.
         let serialized_key: Option<IndexedDBKeyType>;
         let maybe_modified_cloned_value;
+        let key_generator_current_number_for_put: Option<i32>;
 
         if !key.is_undefined() {
             serialized_key = Some(convert_value_to_key(cx, key, None)?.into_result()?);
             maybe_modified_cloned_value = None;
+            key_generator_current_number_for_put = None;
         } else {
             match self.key_path.as_ref() {
                 Some(key_path) => {
@@ -301,7 +293,10 @@ impl IDBObjectStore {
                         // Step 11.2. If kpk is invalid, throw a "DataError" DOMException.
                         ExtractionResult::Invalid => return Err(Error::Data(None)),
                         // Step 11.3. If kpk is not failure, let key be kpk.
-                        ExtractionResult::Key(kpk) => serialized_key = Some(kpk),
+                        ExtractionResult::Key(kpk) => {
+                            serialized_key = Some(kpk);
+                            key_generator_current_number_for_put = None;
+                        },
                         ExtractionResult::Failure => {
                             // Step 11.4. Otherwise:
                             // Step 11.4.1. If store does not have a key generator, throw
@@ -319,7 +314,8 @@ impl IDBObjectStore {
                                 return Err(Error::Data(None));
                             }
                             // Step 11.4.3. Let key be the result of generating a key for store.
-                            let generated_key = self.generate_key()?;
+                            let (generated_key, next_current_number) =
+                                self.reserve_generated_key_for_put()?;
                             // Step 11.4.4. Inject key into value.
                             if !inject_key_into_value(
                                 cx,
@@ -330,6 +326,7 @@ impl IDBObjectStore {
                                 return Err(Error::Data(None));
                             }
                             serialized_key = Some(generated_key);
+                            key_generator_current_number_for_put = Some(next_current_number);
                         },
                     }
 
@@ -345,8 +342,11 @@ impl IDBObjectStore {
                     if !self.has_key_generator() {
                         return Err(Error::Data(None));
                     }
+                    // Out-of-line key generation happens in the backend as part of executing
+                    // the put request, so script does not reserve a key here.
                     serialized_key = None;
                     maybe_modified_cloned_value = None;
+                    key_generator_current_number_for_put = None;
                 },
             }
         }
@@ -360,7 +360,7 @@ impl IDBObjectStore {
         };
         // Step 12. Let operation be an algorithm to run store a record into an object store with store, clone, key, and no-overwrite flag.
         // Step 13. Return the result (an IDBRequest) of running asynchronously execute a request with handle and operation.
-        IDBRequest::execute_async(
+        let request = IDBRequest::execute_async(
             self,
             |callback| {
                 AsyncOperation::ReadWrite(AsyncReadWriteOperation::PutItem {
@@ -368,12 +368,18 @@ impl IDBObjectStore {
                     key: serialized_key,
                     value: serialized_value,
                     should_overwrite: overwrite,
+                    key_generator_current_number: key_generator_current_number_for_put,
                 })
             },
             None,
             None,
             CanGc::from_cx(cx),
-        )
+        )?;
+        if let Some(next_key_generator_current_number) = key_generator_current_number_for_put {
+            self.key_generator_current_number
+                .set(Some(next_key_generator_current_number));
+        }
+        Ok(request)
     }
 
     /// <https://www.w3.org/TR/IndexedDB-3/#dom-idbobjectstore-opencursor>

--- a/components/script/dom/indexeddb/idbtransaction.rs
+++ b/components/script/dom/indexeddb/idbtransaction.rs
@@ -584,7 +584,7 @@ impl IDBTransaction {
     fn object_store_parameters(
         &self,
         object_store_name: &DOMString,
-    ) -> Option<(IDBObjectStoreParameters, Vec<IndexedDBIndex>)> {
+    ) -> Option<(IDBObjectStoreParameters, Vec<IndexedDBIndex>, Option<i32>)> {
         let global = self.global();
         let idb_sender = global.storage_threads().sender();
         let (sender, receiver) =
@@ -621,6 +621,7 @@ impl IDBTransaction {
                 keyPath: key_path,
             },
             object_store.indexes,
+            object_store.key_generator_current_number,
         ))
     }
 }
@@ -662,11 +663,14 @@ impl IDBTransactionMethods<crate::DomTypeHolder> for IDBTransaction {
             &self.global(),
             self.db.get_name(),
             name.clone(),
-            parameters.as_ref().map(|(params, _)| params),
+            parameters.as_ref().map(|(params, _, _)| params),
+            parameters
+                .as_ref()
+                .and_then(|(_, _, key_generator_current_number)| *key_generator_current_number),
             can_gc,
             self,
         );
-        if let Some(indexes) = parameters.map(|(_, indexes)| indexes) {
+        if let Some(indexes) = parameters.map(|(_, indexes, _)| indexes) {
             for index in indexes {
                 store.add_index(
                     DOMString::from_string(index.name),

--- a/components/shared/storage/indexeddb.rs
+++ b/components/shared/storage/indexeddb.rs
@@ -270,6 +270,7 @@ pub struct IndexedDBObjectStore {
     pub name: String,
     pub key_path: Option<KeyPath>,
     pub has_key_generator: bool,
+    pub key_generator_current_number: Option<i32>,
     pub indexes: Vec<IndexedDBIndex>,
 }
 
@@ -333,6 +334,8 @@ pub enum AsyncReadWriteOperation {
         key: Option<IndexedDBKeyType>,
         value: Vec<u8>,
         should_overwrite: bool,
+        /// New object store key generator current number to persist if the put succeeds.
+        key_generator_current_number: Option<i32>,
     },
 
     /// Removes the key/value pair for the given key in the associated idb data
@@ -463,14 +466,6 @@ pub enum SyncOperation {
         String, // Database
         String, // Store
     ),
-    /// Generate and reserve a key from an object store key generator.
-    GenerateKey(
-        GenericSender<BackendResult<IndexedDBKeyType>>,
-        ImmutableOrigin,
-        String, // Database
-        String, // Store
-    ),
-
     /// Commits changes of a transaction to the database
     Commit(
         GenericCallback<TxnCompleteMsg>,

--- a/components/storage/indexeddb/engines/mod.rs
+++ b/components/storage/indexeddb/engines/mod.rs
@@ -7,7 +7,7 @@ use std::collections::VecDeque;
 use malloc_size_of::MallocSizeOf;
 use malloc_size_of_derive::MallocSizeOf;
 use storage_traits::indexeddb::{
-    AsyncOperation, CreateObjectResult, IndexedDBIndex, IndexedDBKeyType, IndexedDBTxnMode, KeyPath,
+    AsyncOperation, CreateObjectResult, IndexedDBIndex, IndexedDBTxnMode, KeyPath,
 };
 
 pub use self::sqlite::SqliteEngine;
@@ -51,8 +51,7 @@ pub trait KvsEngine: MallocSizeOf {
         on_complete: Box<dyn FnOnce() + Send + 'static>,
     );
 
-    fn has_key_generator(&self, store_name: &str) -> bool;
-    fn generate_key(&self, store_name: &str) -> Result<IndexedDBKeyType, Self::Error>;
+    fn key_generator_current_number(&self, store_name: &str) -> Option<i32>;
     fn key_path(&self, store_name: &str) -> Option<KeyPath>;
     fn object_store_names(&self) -> Result<Vec<String>, Self::Error>;
     fn indexes(&self, store_name: &str) -> Result<Vec<IndexedDBIndex>, Self::Error>;

--- a/components/storage/indexeddb/engines/sqlite.rs
+++ b/components/storage/indexeddb/engines/sqlite.rs
@@ -5,7 +5,7 @@ use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
 use base::threadpool::ThreadPool;
-use log::{error, info};
+use log::{error, info, warn};
 use malloc_size_of::{MallocSizeOf, MallocSizeOfOps};
 use rusqlite::{Connection, Error, OptionalExtension, params};
 use sea_query::{Condition, Expr, ExprTrait, IntoCondition, SqliteQueryBuilder};
@@ -425,17 +425,23 @@ impl KvsEngine for SqliteEngine {
                             Some(key) => (key, key_generator_current_number),
                             None => {
                                 if object_store.auto_increment == 0 {
-                                    let _ = callback.send(Err(BackendError::DbErr(
+                                    if let Err(error) = callback.send(Err(BackendError::DbErr(
                                         "Missing key for PutItem request".to_string(),
-                                    )));
+                                    ))) {
+                                        warn!("Failed to send PutItem missing key error: {error:?}");
+                                    }
                                     continue;
                                 }
                                 let Some(next_key_generator_current_number) =
                                     object_store.auto_increment.checked_add(1)
                                 else {
-                                    let _ = callback.send(Err(BackendError::DbErr(
+                                    if let Err(error) = callback.send(Err(BackendError::DbErr(
                                         "Key generator overflow".to_string(),
-                                    )));
+                                    ))) {
+                                        warn!(
+                                            "Failed to send PutItem key generator overflow error: {error:?}"
+                                        );
+                                    }
                                     continue;
                                 };
                                 (

--- a/components/storage/indexeddb/engines/sqlite.rs
+++ b/components/storage/indexeddb/engines/sqlite.rs
@@ -240,6 +240,7 @@ impl SqliteEngine {
         key: IndexedDBKeyType,
         value: Vec<u8>,
         should_overwrite: bool,
+        key_generator_current_number: Option<i32>,
     ) -> Result<PutItemResult, Error> {
         let serialized_key: Vec<u8> = postcard::to_stdvec(&key).unwrap();
         let existing_item = connection
@@ -255,6 +256,12 @@ impl SqliteEngine {
                 "INSERT INTO object_data (object_store_id, key, data) VALUES (?, ?, ?)",
                 params![store.id, serialized_key, value],
             )?;
+            if let Some(next_key_generator_current_number) = key_generator_current_number {
+                connection.execute(
+                    "UPDATE object_store SET auto_increment = ? WHERE id = ?",
+                    params![next_key_generator_current_number, store.id],
+                )?;
+            }
             Ok(PutItemResult::Key(key))
         } else {
             Ok(PutItemResult::CannotOverwrite)
@@ -298,23 +305,6 @@ impl SqliteEngine {
             .prepare(&sql)?
             .query_row(&*values.as_params(), |row| row.get(0))
             .map(|count: i64| count as usize)
-    }
-
-    fn generate_key(
-        connection: &Connection,
-        store: &object_store_model::Model,
-    ) -> Result<IndexedDBKeyType, Error> {
-        if store.auto_increment == 0 {
-            unreachable!("Should be caught in the script thread");
-        }
-        // TODO: handle overflows, this also needs to be able to handle 2^53 as per spec
-        let generated_key = store.auto_increment as f64;
-        let next_key = store.auto_increment + 1;
-        connection.execute(
-            "UPDATE object_store SET auto_increment = ? WHERE id = ?",
-            params![next_key, store.id],
-        )?;
-        Ok(IndexedDBKeyType::Number(generated_key))
     }
 }
 
@@ -429,20 +419,41 @@ impl KvsEngine for SqliteEngine {
                         key,
                         value,
                         should_overwrite,
+                        key_generator_current_number,
                     }) => {
-                        let key = match key
-                            .map(Ok)
-                            .unwrap_or_else(|| Self::generate_key(&connection, &object_store))
-                        {
-                            Ok(key) => key,
-                            Err(e) => {
-                                let _ = callback.send(Err(BackendError::DbErr(format!("{:?}", e))));
-                                continue;
+                        let (key, key_generator_current_number) = match key {
+                            Some(key) => (key, key_generator_current_number),
+                            None => {
+                                if object_store.auto_increment == 0 {
+                                    let _ = callback.send(Err(BackendError::DbErr(
+                                        "Missing key for PutItem request".to_string(),
+                                    )));
+                                    continue;
+                                }
+                                let Some(next_key_generator_current_number) =
+                                    object_store.auto_increment.checked_add(1)
+                                else {
+                                    let _ = callback.send(Err(BackendError::DbErr(
+                                        "Key generator overflow".to_string(),
+                                    )));
+                                    continue;
+                                };
+                                (
+                                    IndexedDBKeyType::Number(object_store.auto_increment as f64),
+                                    Some(next_key_generator_current_number),
+                                )
                             },
                         };
                         let _ = callback.send(
-                            Self::put_item(&connection, object_store, key, value, should_overwrite)
-                                .map_err(|e| BackendError::DbErr(format!("{:?}", e))),
+                            Self::put_item(
+                                &connection,
+                                object_store,
+                                key,
+                                value,
+                                should_overwrite,
+                                key_generator_current_number,
+                            )
+                            .map_err(|e| BackendError::DbErr(format!("{:?}", e))),
                         );
                     },
                     AsyncOperation::ReadOnly(AsyncReadOnlyOperation::GetItem {
@@ -539,8 +550,7 @@ impl KvsEngine for SqliteEngine {
         });
     }
 
-    // TODO: we should be able to error out here, maybe change the trait definition?
-    fn has_key_generator(&self, store_name: &str) -> bool {
+    fn key_generator_current_number(&self, store_name: &str) -> Option<i32> {
         self.connection
             .prepare("SELECT * FROM object_store WHERE name = ?")
             .and_then(|mut stmt| {
@@ -551,18 +561,7 @@ impl KvsEngine for SqliteEngine {
             })
             .optional()
             .unwrap()
-            // TODO: Wrong (change trait definition for this function)
-            .unwrap_or_default() !=
-            0
-    }
-
-    fn generate_key(&self, store_name: &str) -> Result<IndexedDBKeyType, Self::Error> {
-        let store = self.connection.query_row(
-            "SELECT * FROM object_store WHERE name = ?",
-            params![store_name.to_string()],
-            |row| object_store_model::Model::try_from(row),
-        )?;
-        Self::generate_key(&self.connection, &store)
+            .and_then(|current_number| (current_number != 0).then_some(current_number))
     }
 
     fn key_path(&self, store_name: &str) -> Option<KeyPath> {
@@ -798,7 +797,7 @@ mod tests {
         let create_result = result.unwrap();
         assert_eq!(create_result, CreateObjectResult::AlreadyExists);
         // Ensure store was not overwritten
-        assert!(db.has_key_generator(store_name));
+        assert!(db.key_generator_current_number(store_name).is_some());
     }
 
     #[test]
@@ -952,6 +951,7 @@ mod tests {
                             key: Some(IndexedDBKeyType::Number(1.0)),
                             value: vec![1, 2, 3],
                             should_overwrite: false,
+                            key_generator_current_number: None,
                         }),
                     },
                     KvsOperation {
@@ -961,6 +961,7 @@ mod tests {
                             key: Some(IndexedDBKeyType::String("2.0".to_string())),
                             value: vec![4, 5, 6],
                             should_overwrite: false,
+                            key_generator_current_number: None,
                         }),
                     },
                     KvsOperation {
@@ -973,6 +974,7 @@ mod tests {
                             ])),
                             value: vec![7, 8, 9],
                             should_overwrite: false,
+                            key_generator_current_number: None,
                         }),
                     },
                     // Try to put a duplicate key without overwrite
@@ -983,6 +985,7 @@ mod tests {
                             key: Some(IndexedDBKeyType::Number(1.0)),
                             value: vec![10, 11, 12],
                             should_overwrite: false,
+                            key_generator_current_number: None,
                         }),
                     },
                     KvsOperation {

--- a/components/storage/indexeddb/mod.rs
+++ b/components/storage/indexeddb/mod.rs
@@ -27,8 +27,8 @@ use servo_config::pref;
 use servo_url::origin::ImmutableOrigin;
 use storage_traits::indexeddb::{
     AsyncOperation, BackendError, BackendResult, ConnectionMsg, CreateObjectResult, DatabaseInfo,
-    DbResult, IndexedDBIndex, IndexedDBKeyType, IndexedDBObjectStore, IndexedDBThreadMsg,
-    IndexedDBTxnMode, KeyPath, SyncOperation, TxnCompleteMsg,
+    DbResult, IndexedDBIndex, IndexedDBObjectStore, IndexedDBThreadMsg, IndexedDBTxnMode, KeyPath,
+    SyncOperation, TxnCompleteMsg,
 };
 use uuid::Uuid;
 
@@ -520,14 +520,8 @@ impl<E: KvsEngine> IndexedDBEnvironment<E> {
         self.pending_commit_callbacks.remove(&txn);
     }
 
-    fn has_key_generator(&self, store_name: &str) -> bool {
-        self.engine.has_key_generator(store_name)
-    }
-
-    fn generate_key(&self, store_name: &str) -> DbResult<IndexedDBKeyType> {
-        self.engine
-            .generate_key(store_name)
-            .map_err(|err| format!("{err:?}"))
+    fn key_generator_current_number(&self, store_name: &str) -> Option<i32> {
+        self.engine.key_generator_current_number(store_name)
     }
 
     fn key_path(&self, store_name: &str) -> Option<KeyPath> {
@@ -1932,22 +1926,17 @@ impl IndexedDBManager {
             },
             SyncOperation::GetObjectStore(sender, origin, db_name, store_name) => {
                 // FIXME:(arihant2math) Should we error out more aggressively here?
-                let result = self
-                    .get_database(origin, db_name)
-                    .map(|db| IndexedDBObjectStore {
+                let result = self.get_database(origin, db_name).map(|db| {
+                    let key_generator_current_number = db.key_generator_current_number(&store_name);
+                    IndexedDBObjectStore {
                         key_path: db.key_path(&store_name),
-                        has_key_generator: db.has_key_generator(&store_name),
+                        has_key_generator: key_generator_current_number.is_some(),
+                        key_generator_current_number,
                         indexes: db.indexes(&store_name).unwrap_or_default(),
                         name: store_name,
-                    });
+                    }
+                });
                 let _ = sender.send(result.ok_or(BackendError::DbNotFound));
-            },
-            SyncOperation::GenerateKey(sender, origin, db_name, store_name) => {
-                if let Some(db) = self.get_database(origin, db_name) {
-                    let _ = sender.send(db.generate_key(&store_name).map_err(BackendError::from));
-                } else {
-                    let _ = sender.send(Err(BackendError::DbNotFound));
-                }
             },
             SyncOperation::CreateIndex(
                 origin,

--- a/tests/wpt/meta/IndexedDB/keygenerator.any.js.ini
+++ b/tests/wpt/meta/IndexedDB/keygenerator.any.js.ini
@@ -17,31 +17,16 @@
   [Key generator vs. explicit key greater than 53 bits, less than 64 bits]
     expected: FAIL
 
-  [Key generator vs. explicit key greater than 53 bits, less than 64 bits (negative)]
-    expected: FAIL
-
   [Key generator vs. explicit key 63 bits]
-    expected: FAIL
-
-  [Key generator vs. explicit key 63 bits (negative)]
     expected: FAIL
 
   [Key generator vs. explicit key 64 bits]
     expected: FAIL
 
-  [Key generator vs. explicit key 64 bits (negative)]
-    expected: FAIL
-
   [Key generator vs. explicit key greater than 64 bits, but still finite]
     expected: FAIL
 
-  [Key generator vs. explicit key greater than 64 bits, but still finite (negative)]
-    expected: FAIL
-
   [Key generator vs. explicit key equal to Infinity]
-    expected: FAIL
-
-  [Key generator vs. explicit key equal to -Infinity]
     expected: FAIL
 
   [Keygenerator overflow]
@@ -73,31 +58,16 @@
   [Key generator vs. explicit key greater than 53 bits, less than 64 bits]
     expected: FAIL
 
-  [Key generator vs. explicit key greater than 53 bits, less than 64 bits (negative)]
-    expected: FAIL
-
   [Key generator vs. explicit key 63 bits]
-    expected: FAIL
-
-  [Key generator vs. explicit key 63 bits (negative)]
     expected: FAIL
 
   [Key generator vs. explicit key 64 bits]
     expected: FAIL
 
-  [Key generator vs. explicit key 64 bits (negative)]
-    expected: FAIL
-
   [Key generator vs. explicit key greater than 64 bits, but still finite]
     expected: FAIL
 
-  [Key generator vs. explicit key greater than 64 bits, but still finite (negative)]
-    expected: FAIL
-
   [Key generator vs. explicit key equal to Infinity]
-    expected: FAIL
-
-  [Key generator vs. explicit key equal to -Infinity]
     expected: FAIL
 
   [Keygenerator overflow]

--- a/tests/wpt/meta/IndexedDB/reading-autoincrement-store.any.js.ini
+++ b/tests/wpt/meta/IndexedDB/reading-autoincrement-store.any.js.ini
@@ -11,16 +11,10 @@
   [IDBObjectStore.getAllKeys() for an autoincrement store]
     expected: FAIL
 
-  [IDBObjectStore.get() for an autoincrement store]
-    expected: FAIL
-
 
 [reading-autoincrement-store.any.html]
   [IDBObjectStore.getAll() for an autoincrement store]
     expected: FAIL
 
   [IDBObjectStore.getAllKeys() for an autoincrement store]
-    expected: FAIL
-
-  [IDBObjectStore.get() for an autoincrement store]
     expected: FAIL


### PR DESCRIPTION
indexeddb: remove blocking GenerateKey sync IPC

Testing: covered by indexeddb WPT tests. 
part of https://github.com/servo/servo/issues/40983
