### PR TITLE
layout: Fix `first-paint` detection

### DIFF
--- a/components/layout/display_list/mod.rs
+++ b/components/layout/display_list/mod.rs
@@ -253,6 +253,10 @@ impl DisplayListBuilder<'_> {
         self.paint_info.pipeline_id
     }
 
+    fn mark_is_paintable(&mut self) {
+        self.paint_info.is_paintable = true;
+    }
+
     fn mark_is_contentful(&mut self) {
         self.paint_info.is_contentful = true;
     }
@@ -531,14 +535,13 @@ impl DisplayListBuilder<'_> {
         }
     }
 
-    fn check_for_contentful_paint(
-        &mut self,
-        bounds: LayoutRect,
-        clip_rect: LayoutRect,
-        opacity: f32,
-    ) {
-        // From <https://www.w3.org/TR/paint-timing/#sec-terminology>:
+    fn check_if_paintable(&mut self, bounds: LayoutRect, clip_rect: LayoutRect, opacity: f32) {
+        // From <https://www.w3.org/TR/paint-timing/#paintable>:
         // An element el is paintable when all of the following apply:
+        // > el is being rendered.
+        // > el’s used visibility is visible.
+        // Above conditions are met, as we selectively call this API.
+
         // > el and all of its ancestors' used opacity is greater than zero.
         if opacity <= 0.0 {
             return;
@@ -549,7 +552,7 @@ impl DisplayListBuilder<'_> {
             .paint_timing_handler
             .check_bounding_rect(bounds, clip_rect)
         {
-            self.mark_is_contentful();
+            self.mark_is_paintable();
         }
     }
 
@@ -697,14 +700,16 @@ impl Fragment {
                                 wr::ColorF::WHITE,
                             );
 
-                            // From <https://www.w3.org/TR/paint-timing/#sec-terminology>:
-                            // An element target is contentful when one or more of the following apply:
-                            // > target is a replaced element representing an available image.
-                            builder.check_for_contentful_paint(
+                            builder.check_if_paintable(
                                 rect,
                                 common.clip_rect,
                                 style.clone_opacity(),
                             );
+
+                            // From <https://www.w3.org/TR/paint-timing/#contentful>:
+                            // An element target is contentful when one or more of the following apply:
+                            // > target is a replaced element representing an available image.
+                            builder.mark_is_contentful();
 
                             // Skip Broken Images for LCP
                             if !image.showing_broken_image_icon {
@@ -887,14 +892,12 @@ impl Fragment {
             None,
         );
 
-        // From <https://www.w3.org/TR/paint-timing/#sec-terminology>:
+        builder.check_if_paintable(glyph_bounds, common.clip_rect, parent_style.clone_opacity());
+
+        // From <https://www.w3.org/TR/paint-timing/#contentful>:
         // An element target is contentful when one or more of the following apply:
         // > target has a text node child, representing non-empty text, and the node’s used opacity is greater than zero.
-        builder.check_for_contentful_paint(
-            glyph_bounds,
-            common.clip_rect,
-            parent_style.clone_opacity(),
-        );
+        builder.mark_is_contentful();
 
         for text_decoration in text_decorations.iter() {
             if text_decoration
@@ -1319,7 +1322,23 @@ impl<'a> BuilderForBoxFragment<'a> {
             let common = painter.common_properties(self, builder, layer_index, bounds);
             builder
                 .wr()
-                .push_rect(&common, bounds, rgba(background_color))
+                .push_rect(&common, bounds, rgba(background_color));
+
+            // From <https://www.w3.org/TR/paint-timing/#sec-terminology>:
+            // First paint ... includes non-default background paint and the enclosing box of an iframe.
+            // The spec is vague. See also: https://github.com/w3c/paint-timing/issues/122
+            let default_background_color = servo_config::pref!(shell_background_color_rgba);
+            let default_background_color = AbsoluteColor::new(
+                ColorSpace::Srgb,
+                default_background_color[0] as f32,
+                default_background_color[1] as f32,
+                default_background_color[2] as f32,
+                default_background_color[3] as f32,
+            )
+            .into_srgb_legacy();
+            if background_color != default_background_color {
+                builder.mark_is_paintable();
+            }
         }
 
         self.build_background_image(builder, painter);
@@ -1419,6 +1438,12 @@ impl<'a> BuilderForBoxFragment<'a> {
                             )
                         },
                     }
+
+                    builder.check_if_paintable(
+                        layer.bounds,
+                        layer.common.clip_rect,
+                        style.clone_opacity(),
+                    );
                 },
                 Ok(ResolvedImage::Image { image, size }) => {
                     // FIXME: https://drafts.csswg.org/css-images-4/#the-image-resolution
@@ -1480,15 +1505,17 @@ impl<'a> BuilderForBoxFragment<'a> {
                             )
                         }
 
-                        // From <https://www.w3.org/TR/paint-timing/#sec-terminology>:
-                        // An element target is contentful when one or more of the following apply:
-                        // > target has a background-image which is a contentful image, and its used
-                        // > background-size has non-zero width and height values.
-                        builder.check_for_contentful_paint(
+                        builder.check_if_paintable(
                             layer.bounds,
                             layer.common.clip_rect,
                             style.clone_opacity(),
                         );
+
+                        // From <https://www.w3.org/TR/paint-timing/#sec-terminology>:
+                        // An element target is contentful when one or more of the following apply:
+                        // > target has a background-image which is a contentful image, and its used
+                        // > background-size has non-zero width and height values.
+                        builder.mark_is_contentful();
 
                         builder.check_for_lcp_candidate(
                             layer.common.clip_rect,
@@ -1674,15 +1701,18 @@ impl<'a> BuilderForBoxFragment<'a> {
                     return false;
                 };
 
-                // From <https://www.w3.org/TR/paint-timing/#sec-terminology>:
-                // An element target is contentful when one or more of the following apply:
-                // > target has a background-image which is a contentful image,
-                // > and its used background-size has non-zero width and height values.
-                builder.check_for_contentful_paint(
+                builder.check_if_paintable(
                     Box2D::from_size(size.cast_unit()),
                     common.clip_rect,
                     style.clone_opacity(),
                 );
+
+                // From <https://www.w3.org/TR/paint-timing/#contentful>:
+                // An element target is contentful when one or more of the following apply:
+                // > target has a background-image which is a contentful image,
+                // > and its used background-size has non-zero width and height values.
+                builder.mark_is_contentful();
+
                 width = size.width;
                 height = size.height;
                 let image_rendering = style.clone_image_rendering().to_webrender();

--- a/components/layout/display_list/stacking_context.rs
+++ b/components/layout/display_list/stacking_context.rs
@@ -20,7 +20,7 @@ use paint_api::display_list::{
 };
 use servo_config::opts::DiagnosticsLogging;
 use style::Zero;
-use style::color::AbsoluteColor;
+use style::color::{AbsoluteColor, ColorSpace};
 use style::computed_values::float::T as ComputedFloat;
 use style::computed_values::mix_blend_mode::T as ComputedMixBlendMode;
 use style::computed_values::overflow_x::T as ComputedOverflow;
@@ -707,7 +707,23 @@ impl StackingContext {
         if background_color.alpha > 0.0 {
             let common = builder.common_properties(painting_area, &source_style);
             let color = super::rgba(background_color);
-            builder.wr().push_rect(&common, painting_area, color)
+            builder.wr().push_rect(&common, painting_area, color);
+
+            // From <https://www.w3.org/TR/paint-timing/#sec-terminology>:
+            // First paint ... includes non-default background paint and the enclosing box of an iframe.
+            // The spec is vague. See also: https://github.com/w3c/paint-timing/issues/122
+            let default_background_color = servo_config::pref!(shell_background_color_rgba);
+            let default_background_color = AbsoluteColor::new(
+                ColorSpace::Srgb,
+                default_background_color[0] as f32,
+                default_background_color[1] as f32,
+                default_background_color[2] as f32,
+                default_background_color[3] as f32,
+            )
+            .into_srgb_legacy();
+            if background_color != default_background_color {
+                builder.mark_is_paintable();
+            }
         }
 
         let mut fragment_builder = BuilderForBoxFragment::new(

--- a/components/paint/painter.rs
+++ b/components/paint/painter.rs
@@ -979,13 +979,16 @@ impl Painter {
 
         let epoch = display_list_info.epoch.into();
         let first_reflow = display_list_info.first_reflow;
-        if details.first_paint_metric.get() == PaintMetricState::Waiting {
+        if details.first_paint_metric.get() == PaintMetricState::Waiting &&
+            display_list_info.is_paintable
+        {
             details
                 .first_paint_metric
                 .set(PaintMetricState::Seen(epoch, first_reflow));
         }
 
         if details.first_contentful_paint_metric.get() == PaintMetricState::Waiting &&
+            display_list_info.is_paintable &&
             display_list_info.is_contentful
         {
             details

--- a/components/servo/tests/performance_paint_timing.rs
+++ b/components/servo/tests/performance_paint_timing.rs
@@ -8,6 +8,7 @@ mod common;
 use std::rc::Rc;
 
 use servo::{JSValue, WebViewBuilder};
+use servo_config::prefs::Preferences;
 use url::Url;
 
 use crate::common::{
@@ -83,4 +84,124 @@ fn test_paint_timing_js_api() {
     } else {
         panic!("first-contentful-paint entry is not an object");
     }
+}
+
+#[allow(dead_code)]
+fn verify_first_paint(servo_test: &ServoTest, data_url: &str, expected_fp: i32) {
+    let delegate = Rc::new(WebViewDelegateImpl::default());
+    let webview = WebViewBuilder::new(servo_test.servo(), servo_test.rendering_context.clone())
+        .delegate(delegate.clone())
+        .url(Url::parse(data_url).unwrap())
+        .build();
+
+    show_webview_and_wait_for_rendering_to_be_ready(&servo_test, &webview, &delegate);
+
+    let paint_entries = evaluate_javascript(
+        &servo_test,
+        webview.clone(),
+        "performance.getEntriesByType('paint').length;",
+    );
+    assert_eq!(paint_entries, Ok(JSValue::Number(expected_fp as f64)));
+
+    if expected_fp > 0 {
+        let first_paint = evaluate_javascript(
+            &servo_test,
+            webview.clone(),
+            "performance.getEntriesByName('first-paint')[0].toJSON();",
+        );
+
+        if let Ok(JSValue::Object(obj)) = first_paint {
+            assert_eq!(
+                obj.get("name"),
+                Some(JSValue::String("first-paint".to_string())).as_ref()
+            );
+        } else {
+            panic!("first-paint entry is not an object");
+        }
+    }
+}
+
+#[test]
+fn test_default_pref_with_unset_background() {
+    let servo_test = ServoTest::new();
+
+    verify_first_paint(&servo_test, "data:text/html, <html>", 0);
+}
+
+#[test]
+fn test_non_default_pref_with_unset_background() {
+    let servo_test = ServoTest::new_with_builder(|builder| {
+        let mut preferences = Preferences::default();
+        preferences.shell_background_color_rgba = [0.5, 0.5, 0.5, 1.0]; // Gray
+        builder.preferences(preferences)
+    });
+
+    verify_first_paint(&servo_test, "data:text/html, <html>", 0);
+}
+
+#[test]
+fn test_default_pref_with_transparent_background() {
+    let servo_test = ServoTest::new();
+
+    verify_first_paint(
+        &servo_test,
+        "data:text/html, <html style='background: transparent;'>",
+        0,
+    );
+}
+
+#[test]
+fn test_non_default_pref_with_transparent_background() {
+    let servo_test = ServoTest::new_with_builder(|builder| {
+        let mut preferences = Preferences::default();
+        preferences.shell_background_color_rgba = [0.5, 0.5, 0.5, 1.0]; // Gray
+        builder.preferences(preferences)
+    });
+
+    verify_first_paint(
+        &servo_test,
+        "data:text/html, <html style='background: transparent;'>",
+        0,
+    );
+}
+
+#[test]
+fn test_default_pref_with_background() {
+    let servo_test = ServoTest::new();
+
+    verify_first_paint(
+        &servo_test,
+        "data:text/html, <html style='background: red;'>",
+        1,
+    );
+}
+
+#[test]
+fn test_non_default_pref_with_background() {
+    let servo_test = ServoTest::new_with_builder(|builder| {
+        let mut preferences = Preferences::default();
+        preferences.shell_background_color_rgba = [0.5, 0.5, 0.5, 1.0]; // Gray
+        builder.preferences(preferences)
+    });
+
+    verify_first_paint(
+        &servo_test,
+        "data:text/html, <html style='background: green;'>",
+        1,
+    );
+}
+
+#[test]
+fn test_non_default_pref_with_same_background() {
+    let servo_test = ServoTest::new_with_builder(|builder| {
+        let mut preferences = Preferences::default();
+        preferences.shell_background_color_rgba = [0.0, 0.0, 1.0, 1.0]; // Blue
+        builder.preferences(preferences)
+    });
+
+    verify_first_paint(
+        &servo_test,
+        "data:text/html, <html style='background: blue;'>",
+        0,
+    );
 }

--- a/components/shared/paint/display_list.rs
+++ b/components/shared/paint/display_list.rs
@@ -842,9 +842,13 @@ pub struct PaintDisplayListInfo {
     /// tree.
     pub root_scroll_node_id: ScrollTreeNodeId,
 
+    /// From <https://www.w3.org/TR/paint-timing/#paintable>:
+    /// Whether the display list contains paintable items.
+    pub is_paintable: bool,
+
+    /// From <https://www.w3.org/TR/paint-timing/#contentful>:
     /// Contentful paint i.e. whether the display list contains items of type
     /// text, image, non-white canvas or SVG). Used by metrics.
-    /// See <https://w3c.github.io/paint-timing/#first-contentful-paint>.
     pub is_contentful: bool,
 
     /// Whether the first layout or a subsequent (incremental) layout triggered this
@@ -901,6 +905,7 @@ impl PaintDisplayListInfo {
             scroll_tree,
             root_reference_frame_id,
             root_scroll_node_id,
+            is_paintable: false,
             is_contentful: false,
             first_reflow,
             caret_property_binding: Default::default(),

--- a/tests/wpt/meta/paint-timing/first-image-child.html.ini
+++ b/tests/wpt/meta/paint-timing/first-image-child.html.ini
@@ -1,3 +1,0 @@
-[first-image-child.html]
-  [Child iframe ignores paint-timing events fired from parent image rendering.]
-    expected: FAIL

--- a/tests/wpt/meta/paint-timing/first-paint-only/sibling-painting-first-image.html.ini
+++ b/tests/wpt/meta/paint-timing/first-paint-only/sibling-painting-first-image.html.ini
@@ -1,3 +1,0 @@
-[sibling-painting-first-image.html]
-  [Frame ignores paint-timing events fired from sibling frame.]
-    expected: FAIL

--- a/tests/wpt/tests/paint-timing/first-paint-only/first-paint-bg-color.html
+++ b/tests/wpt/tests/paint-timing/first-paint-only/first-paint-bg-color.html
@@ -14,6 +14,9 @@
 setup({"hide_test_state": true});
 async_test(function (t) {
     assert_implements(window.PerformancePaintTiming, "Paint Timing isn't supported.");
+    assert_equals(performance.getEntriesByType('paint').length, 0, "There should be no Paint Entry");
+
+    // Changing background color should fire FP.
     document.body.style.backgroundColor = "#AA0000";
 
     assertFirstPaint(t, 20);


### PR DESCRIPTION
This PR comprises
1. Segregate `paintable` and `contentful`.
2. Adds Checking of non-default background for eligibility to mark `first-paint`.
3. Adds a bool `is_paintable` to `display_list` and use same for marking `first-paint`.

TODO: This doesn't consider `iframes`. Will add PR after fixing WPT tests.

Raised an issue for some incomplete definitions: https://github.com/w3c/paint-timing/issues/122




Testing: 
- `wpt/tests/paint-timing/first-paint-only/first-paint-bg-color.html`
- Updated WPT tests expectations.
  - `wpt/paint-timing/first-image-child.html`
  - `wpt/paint-timing/first-paint-only/sibling-painting-first-image.html`
- Unit Test: `servo/tests/performance_paint_timings.rs`. Following Tests Cases are covered: 

Background Pref |Root Background|FP|TC
--|--|--|--
|Default|Unset|:x: | `test_default_pref_with_unset_background`
|Non-Default|Unset|:x: | `test_non_default_pref_with_unset_background`
|Default|Transparent|:x:|`test_default_pref_with_transparent_background`
|Non-Default|Unset|:x:|`test_non_default_pref_with_transparent_background`
|Default|Set|:white_check_mark:|`test_default_pref_with_background`
|Non-Default|Set|:white_check_mark:|`test_non_default_pref_with_background`
|Non-Default|Set (same as pref)|:x:|`test_non_default_pref_with_same_background`

Fixes: #42148
