### PR TITLE
mach: Remove generic nightly download support

### DIFF
--- a/python/servo/command_base.py
+++ b/python/servo/command_base.py
@@ -20,18 +20,14 @@ import subprocess
 import sys
 import tarfile
 from tarfile import TarInfo
-import urllib
 import zipfile
-import urllib.error
-import urllib.request
 from dataclasses import dataclass
 from enum import Enum
 from glob import glob
 from os import path
-from subprocess import PIPE, CompletedProcess
+from subprocess import CompletedProcess
 from typing import Any, Optional, Union, LiteralString, cast, List
 from collections.abc import Generator, Callable
-from xml.etree.ElementTree import XML
 
 import toml
 from mach.decorators import CommandArgument, CommandArgumentGroup
@@ -39,12 +35,11 @@ from mach.decorators import CommandArgument, CommandArgumentGroup
 import servo.platform
 import servo.util as util
 from servo.platform.build_target import AndroidTarget, BuildTarget, OpenHarmonyTarget
-from servo.util import download_file, get_default_cache_dir
+from servo.util import get_default_cache_dir
 
 from python.servo.platform.build_target import SanitizerKind
 from python.servo.util import get_target_dir
 
-NIGHTLY_REPOSITORY_URL = "https://servo-builds2.s3.amazonaws.com/"
 ASAN_LEAK_SUPPRESSION_FILE = "support/suppressed_leaks_for_asan.txt"
 
 
@@ -358,124 +353,6 @@ class CommandBase(object):
 
         return binary_path
 
-    def detach_volume(self, mounted_volume: str | bytes) -> None:
-        print("Detaching volume {}".format(mounted_volume))
-        try:
-            subprocess.check_call(["hdiutil", "detach", mounted_volume])
-        except subprocess.CalledProcessError as e:
-            print("Could not detach volume {} : {}".format(mounted_volume, e.returncode))
-            sys.exit(1)
-
-    def detach_volume_if_attached(self, mounted_volume: str | bytes) -> None:
-        if os.path.exists(mounted_volume):
-            self.detach_volume(mounted_volume)
-
-    def mount_dmg(self, dmg_path: str) -> None:
-        print("Mounting dmg {}".format(dmg_path))
-        try:
-            subprocess.check_call(["hdiutil", "attach", dmg_path])
-        except subprocess.CalledProcessError as e:
-            print("Could not mount Servo dmg : {}".format(e.returncode))
-            sys.exit(1)
-
-    def extract_nightly(self, nightlies_folder: LiteralString, destination_folder: str, destination_file: str) -> None:
-        print("Extracting to {} ...".format(destination_folder))
-        if is_macosx():
-            mounted_volume = path.join(path.sep, "Volumes", "Servo")
-            self.detach_volume_if_attached(mounted_volume)
-            self.mount_dmg(destination_file)
-            # Servo folder is always this one
-            servo_directory = path.join(path.sep, "Volumes", "Servo", "Servo.app", "Contents", "MacOS")
-            print("Copying files from {} to {}".format(servo_directory, destination_folder))
-            shutil.copytree(servo_directory, destination_folder)
-            self.detach_volume(mounted_volume)
-        else:
-            if is_windows():
-                command = "msiexec /a {} /qn TARGETDIR={}".format(
-                    os.path.join(nightlies_folder, destination_file), destination_folder
-                )
-                if subprocess.call(command, stdout=PIPE, stderr=PIPE) != 0:
-                    print("Could not extract the nightly executable from the msi package.")
-                    sys.exit(1)
-            else:
-                with tarfile.open(os.path.join(nightlies_folder, destination_file), "r") as tar:
-                    tar.extractall(destination_folder)
-
-    def get_executable(self, destination_folder: str) -> str:
-        if is_windows():
-            return path.join(destination_folder, "PFiles", "Mozilla research", "Servo Tech Demo")
-        if is_linux:
-            return path.join(destination_folder, "servo", "servo")
-        return path.join(destination_folder, "servo")
-
-    def get_nightly_binary_path(self, nightly_date: str | None) -> str | None:
-        if nightly_date is None:
-            return
-        if not nightly_date:
-            print("No nightly date has been provided although the --nightly or -n flag has been passed.")
-            sys.exit(1)
-        # Will alow us to fetch the relevant builds from the nightly repository
-        os_prefix = "linux"
-        if is_windows():
-            os_prefix = "windows-msvc"
-        if is_macosx():
-            os_prefix = "mac"
-        nightly_date = nightly_date.strip()
-        # Fetch the filename to download from the build list
-        repository_index = NIGHTLY_REPOSITORY_URL + "?list-type=2&prefix=nightly"
-        req = urllib.request.Request("{}/{}/{}".format(repository_index, os_prefix, nightly_date))
-        try:
-            response = urllib.request.urlopen(req).read()
-            tree = XML(response)
-            namespaces = {"ns": tree.tag[1 : tree.tag.index("}")]}
-            # pyrefly: ignore  # missing-attribute
-            file_to_download = tree.find("ns:Contents", namespaces).find("ns:Key", namespaces).text
-        except urllib.error.URLError as e:
-            print("Could not fetch the available nightly versions from the repository : {}".format(e.reason))
-            sys.exit(1)
-        except ValueError as e:
-            print(
-                "Could not fetch a nightly version for date {} and platform {} cause of {}".format(
-                    nightly_date, os_prefix, e
-                )
-            )
-            sys.exit(1)
-        except AttributeError:
-            print("Could not fetch a nightly version for date {} and platform {}".format(nightly_date, os_prefix))
-            sys.exit(1)
-
-        nightly_target_directory = path.join(self.context.topdir, "target")
-        # ':' is not an authorized character for a file name on Windows
-        # make sure the OS specific separator is used
-        # pyrefly: ignore  # missing-attribute
-        target_file_path = file_to_download.replace(":", "-").split("/")
-        destination_file = os.path.join(nightly_target_directory, os.path.join(*target_file_path))
-        # Once extracted, the nightly folder name is the tar name without the extension
-        # (eg /foo/bar/baz.tar.gz extracts to /foo/bar/baz)
-        destination_folder = os.path.splitext(destination_file)[0]
-        nightlies_folder = path.join(nightly_target_directory, "nightly", os_prefix)
-
-        # Make sure the target directory exists
-        if not os.path.isdir(nightlies_folder):
-            print("The nightly folder for the target does not exist yet. Creating {}".format(nightlies_folder))
-            os.makedirs(nightlies_folder)
-
-        # Download the nightly version
-        if os.path.isfile(path.join(nightlies_folder, destination_file)):
-            print("The nightly file {} has already been downloaded.".format(destination_file))
-        else:
-            print("The nightly {} does not exist yet, downloading it.".format(destination_file))
-            # pyrefly: ignore  # no-matching-overload
-            download_file(destination_file, NIGHTLY_REPOSITORY_URL + file_to_download, destination_file)
-
-        # Extract the downloaded nightly version
-        if os.path.isdir(destination_folder):
-            print("The nightly folder {} has already been extracted.".format(destination_folder))
-        else:
-            self.extract_nightly(nightlies_folder, destination_folder, destination_file)
-
-        return self.get_executable(destination_folder)
-
     def msvc_package_dir(self, package: str) -> str:
         return servo.platform.windows.get_dependency_dir(package)
 
@@ -715,13 +592,9 @@ class CommandBase(object):
 
                 if binary_selection:
                     if "servo_binary" not in kwargs:
-                        kwargs["servo_binary"] = (
-                            kwargs.get("bin")
-                            or self.get_nightly_binary_path(kwargs.get("nightly"))
-                            or self.get_binary_path(
-                                cast(BuildType, kwargs.get("build_type")),
-                                sanitizer=cast(SanitizerKind, kwargs.get("sanitizer")),
-                            )
+                        kwargs["servo_binary"] = kwargs.get("bin") or self.get_binary_path(
+                            cast(BuildType, kwargs.get("build_type")),
+                            sanitizer=cast(SanitizerKind, kwargs.get("sanitizer")),
                         )
                     kwargs.pop("bin")
                     kwargs.pop("nightly")


### PR DESCRIPTION
See #42956. It's quite likely that this code has bitrotted and if this
feature is desired, should probably download the nightlies from GitHub
and also be updated to support our current packaging output.

Testing: This is just removing unused code from our build scripts.
Fixes: #42956.
