### PR TITLE
script: Add UnrootedSimpleNodeIterator

### DIFF
--- a/components/script/dom/node.rs
+++ b/components/script/dom/node.rs
@@ -865,12 +865,36 @@ impl Node {
         }
     }
 
+    pub(crate) fn inclusively_following_siblings_unrooted<'a, 'b>(
+        &'a self,
+        no_gc: &'b NoGC,
+    ) -> impl Iterator<Item = UnrootedDom<'b, Node>> + use<'b> {
+        UnrootedSimpleNodeIterator {
+            current: Some(UnrootedDom::from_dom(Dom::from_ref(self), no_gc)),
+            next_node: |n, no_gc| n.get_next_sibling_unrooted(no_gc),
+            no_gc,
+            phantom: PhantomData,
+        }
+    }
+
     pub(crate) fn inclusively_preceding_siblings(
         &self,
     ) -> impl Iterator<Item = DomRoot<Node>> + use<> {
         SimpleNodeIterator {
             current: Some(DomRoot::from_ref(self)),
             next_node: |n| n.GetPreviousSibling(),
+        }
+    }
+
+    pub(crate) fn inclusively_preceding_siblings_unrooted<'a, 'b>(
+        &'a self,
+        no_gc: &'b NoGC,
+    ) -> impl Iterator<Item = UnrootedDom<'b, Node>> + use<'b> {
+        UnrootedSimpleNodeIterator {
+            current: Some(UnrootedDom::from_dom(Dom::from_ref(self), no_gc)),
+            next_node: |n, no_gc| n.get_previous_sibling_unrooted(no_gc),
+            no_gc,
+            phantom: PhantomData,
         }
     }
 
@@ -2200,9 +2224,9 @@ where
 /// This does not root the required children. Taking a `&NoGC` enforces that there is no `&mut JSContext`
 /// while this iterator is alive.
 #[cfg_attr(crown, crown::unrooted_must_root_lint::allow_unrooted_interior)]
-pub(crate) struct EfficientSimpleNodeIterator<'a, 'b, I>
+pub(crate) struct UnrootedSimpleNodeIterator<'a, 'b, I>
 where
-    I: Fn(&Node) -> Option<UnrootedDom<'b, Node>>,
+    I: Fn(&Node, &'b NoGC) -> Option<UnrootedDom<'b, Node>>,
 {
     current: Option<UnrootedDom<'b, Node>>,
     next_node: I,
@@ -2211,16 +2235,18 @@ where
     phantom: PhantomData<&'a Node>,
 }
 
-impl<'a, 'b, I> Iterator for EfficientSimpleNodeIterator<'a, 'b, I>
+impl<'a, 'b, I> Iterator for UnrootedSimpleNodeIterator<'a, 'b, I>
 where
     'b: 'a,
-    I: Fn(&Node) -> Option<UnrootedDom<'b, Node>>,
+    I: Fn(&Node, &'b NoGC) -> Option<UnrootedDom<'b, Node>>,
 {
     type Item = UnrootedDom<'b, Node>;
 
     fn next(&mut self) -> Option<Self::Item> {
         let current = self.current.take();
-        self.current = current.as_ref().and_then(|c| (self.next_node)(c));
+        self.current = current
+            .as_ref()
+            .and_then(|c| (self.next_node)(c, self.no_gc));
         current
     }
 }
@@ -3519,6 +3545,10 @@ impl Node {
 
     fn get_next_sibling_unrooted<'a>(&self, no_gc: &'a NoGC) -> Option<UnrootedDom<'a, Node>> {
         self.next_sibling.get_unrooted(no_gc)
+    }
+
+    fn get_previous_sibling_unrooted<'a>(&self, no_gc: &'a NoGC) -> Option<UnrootedDom<'a, Node>> {
+        self.prev_sibling.get_unrooted(no_gc)
     }
 
     fn get_first_child_unrooted<'a>(&self, no_gc: &'a NoGC) -> Option<UnrootedDom<'a, Node>> {

--- a/components/script/dom/node.rs
+++ b/components/script/dom/node.rs
@@ -2192,6 +2192,39 @@ where
     }
 }
 
+/// An efficient SimpleNodeIterator because it skips rooting if there are no GC pauses.
+///
+/// Use this if you have a `&JSContext` or `NoGC`.
+///
+/// Normally we need to root every `Node` we come across as we do not know if we will have a GC pause.
+/// This does not root the required children. Taking a `&NoGC` enforces that there is no `&mut JSContext`
+/// while this iterator is alive.
+#[cfg_attr(crown, crown::unrooted_must_root_lint::allow_unrooted_interior)]
+pub(crate) struct EfficientSimpleNodeIterator<'a, 'b, I>
+where
+    I: Fn(&Node) -> Option<UnrootedDom<'b, Node>>,
+{
+    current: Option<UnrootedDom<'b, Node>>,
+    next_node: I,
+    /// This is unused and only used for lifetime guarantee of NoGC
+    no_gc: &'b NoGC,
+    phantom: PhantomData<&'a Node>,
+}
+
+impl<'a, 'b, I> Iterator for EfficientSimpleNodeIterator<'a, 'b, I>
+where
+    'b: 'a,
+    I: Fn(&Node) -> Option<UnrootedDom<'b, Node>>,
+{
+    type Item = UnrootedDom<'b, Node>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        let current = self.current.take();
+        self.current = current.as_ref().and_then(|c| (self.next_node)(c));
+        current
+    }
+}
+
 /// Whether a tree traversal should pass shadow tree boundaries.
 #[derive(Clone, Copy, PartialEq)]
 pub(crate) enum ShadowIncluding {

--- a/components/script/dom/node.rs
+++ b/components/script/dom/node.rs
@@ -865,8 +865,8 @@ impl Node {
         }
     }
 
-    pub(crate) fn inclusively_following_siblings_unrooted<'a, 'b>(
-        &'a self,
+    pub(crate) fn inclusively_following_siblings_unrooted<'b>(
+        &self,
         no_gc: &'b NoGC,
     ) -> impl Iterator<Item = UnrootedDom<'b, Node>> + use<'b> {
         UnrootedSimpleNodeIterator {
@@ -886,8 +886,8 @@ impl Node {
         }
     }
 
-    pub(crate) fn inclusively_preceding_siblings_unrooted<'a, 'b>(
-        &'a self,
+    pub(crate) fn inclusively_preceding_siblings_unrooted<'b>(
+        &self,
         no_gc: &'b NoGC,
     ) -> impl Iterator<Item = UnrootedDom<'b, Node>> + use<'b> {
         UnrootedSimpleNodeIterator {

--- a/components/script/dom/text.rs
+++ b/components/script/dom/text.rs
@@ -105,7 +105,7 @@ impl TextMethods<crate::DomTypeHolder> for Text {
     }
 
     /// <https://dom.spec.whatwg.org/#dom-text-wholetext>
-    fn WholeText(&self, cx: &mut JSContext) -> DOMString {
+    fn WholeText(&self, cx: &JSContext) -> DOMString {
         let first = self
             .upcast::<Node>()
             .inclusively_preceding_siblings_unrooted(cx.no_gc())

--- a/components/script/dom/text.rs
+++ b/components/script/dom/text.rs
@@ -3,8 +3,8 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 use dom_struct::dom_struct;
+use js::context::JSContext;
 use js::rust::HandleObject;
-use script_bindings::script_runtime::temp_cx;
 
 use crate::dom::bindings::codegen::Bindings::CharacterDataBinding::CharacterDataMethods;
 use crate::dom::bindings::codegen::Bindings::DocumentBinding::DocumentMethods;
@@ -105,15 +105,15 @@ impl TextMethods<crate::DomTypeHolder> for Text {
     }
 
     /// <https://dom.spec.whatwg.org/#dom-text-wholetext>
-    fn WholeText(&self) -> DOMString {
+    fn WholeText(&self, cx: &mut JSContext) -> DOMString {
         let first = self
             .upcast::<Node>()
-            .inclusively_preceding_siblings_unrooted()
+            .inclusively_preceding_siblings_unrooted(cx.no_gc())
             .take_while(|node| node.is::<Text>())
             .last()
             .unwrap();
         let nodes = first
-            .inclusively_following_siblings_unrooted()
+            .inclusively_following_siblings_unrooted(cx.no_gc())
             .take_while(|node| node.is::<Text>());
         let mut text = String::new();
         for ref node in nodes {

--- a/components/script/dom/text.rs
+++ b/components/script/dom/text.rs
@@ -4,6 +4,7 @@
 
 use dom_struct::dom_struct;
 use js::rust::HandleObject;
+use script_bindings::script_runtime::temp_cx;
 
 use crate::dom::bindings::codegen::Bindings::CharacterDataBinding::CharacterDataMethods;
 use crate::dom::bindings::codegen::Bindings::DocumentBinding::DocumentMethods;
@@ -107,12 +108,12 @@ impl TextMethods<crate::DomTypeHolder> for Text {
     fn WholeText(&self) -> DOMString {
         let first = self
             .upcast::<Node>()
-            .inclusively_preceding_siblings()
+            .inclusively_preceding_siblings_unrooted()
             .take_while(|node| node.is::<Text>())
             .last()
             .unwrap();
         let nodes = first
-            .inclusively_following_siblings()
+            .inclusively_following_siblings_unrooted()
             .take_while(|node| node.is::<Text>());
         let mut text = String::new();
         for ref node in nodes {

--- a/components/script_bindings/codegen/Bindings.conf
+++ b/components/script_bindings/codegen/Bindings.conf
@@ -765,7 +765,7 @@ DOMInterfaces = {
 
 'Text': {
     'canGc': ['SplitText'],
-    'cx': ['WholeText']
+    'cx_no_gc': ['WholeText']
 },
 
 'TextEncoder': {

--- a/components/script_bindings/codegen/Bindings.conf
+++ b/components/script_bindings/codegen/Bindings.conf
@@ -764,7 +764,8 @@ DOMInterfaces = {
 },
 
 'Text': {
-    'canGc': ['SplitText']
+    'canGc': ['SplitText'],
+    'cx': ['WholeText']
 },
 
 'TextEncoder': {


### PR DESCRIPTION
In the same vein as https://github.com/servo/servo/pull/42781 we implement a UnrootedSimpleNodeIterator that takes a no_gc and does not root the required nodes.

We include an example usage in 'dom/text.rs' WholeText.

This requires https://github.com/servo/servo/pull/42781 to be merged first.
