### PR TITLE
Upgrade GitHub Actions for Node 24 compatibility

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -49,13 +49,13 @@ jobs:
           tool-cache: true
           android: false
           swap-storage: false
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
         if: github.event_name != 'pull_request_target'
         with:
           fetch-depth: 2
       # This is necessary to checkout the pull request if this run was triggered via a
       # `pull_request_target` event.
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
         if: github.event_name == 'pull_request_target'
         with:
           ref: ${{ github.event.pull_request.head.sha }}
@@ -70,7 +70,7 @@ jobs:
         timeout-minutes: 30
         run: sudo apt update && ./mach bootstrap --yes --skip-lints --skip-nextest
       - name: Set up JDK 17
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           java-version: '17'
           distribution: 'temurin'
@@ -113,19 +113,19 @@ jobs:
       # - name: Script tests
       #   run: ./mach test-android-startup
       - name: Archive build timing
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@v7
         with:
           name: cargo-timings-android-${{ matrix.target }}-${{ inputs.profile }}
           # Using a wildcard here ensures that the archive includes the path.
           path: target/cargo-timings-*
       - name: Upload APK artifact
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@v7
         id: upload-apk
         with:
           name: ${{ inputs.profile }}-binary-android-${{ matrix.target }}
           path: target/android/${{ matrix.target }}/${{ inputs.profile }}/servoapp.apk
       - name: Upload AAR artifact
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@v7
         id: upload-aar
         with:
           name: ${{ inputs.profile }}-library-android-${{ matrix.target }}

--- a/.github/workflows/bencher.yml
+++ b/.github/workflows/bencher.yml
@@ -78,7 +78,7 @@ jobs:
     runs-on: ${{ needs.runner-select.outputs.selected-runner-label }}
     steps:
       - uses: servo/ci-runners/actions/checkout@6d88b19dda997f1ce2a11e4c1c34717c2bbcafba
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v8
         with:
           name: ${{ inputs.profile }}-binary-${{ inputs.target }}
           path: ${{ inputs.profile }}-binary-${{ inputs.target }}

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -12,7 +12,7 @@ jobs:
     name: Upload docs to GitHub Pages
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
       - name: Free Disk Space (Ubuntu)
         uses: jlumbroso/free-disk-space@main
         with:

--- a/.github/workflows/linux-wpt.yml
+++ b/.github/workflows/linux-wpt.yml
@@ -72,15 +72,15 @@ jobs:
       matrix:
         chunk_id: ${{ fromJSON(needs.runner-select.outputs.selected-runner-indices) }}
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
         if: github.event_name != 'pull_request_target'
       # This is necessary to checkout the pull request if this run was triggered via a
       # `pull_request_target` event.
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
         if: github.event_name == 'pull_request_target'
         with:
           ref: refs/pull/${{ github.event.number }}/head
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v8
         with:
           name: ${{ inputs.profile }}-binary-linux
           path: ${{ inputs.profile }}-binary-linux
@@ -123,13 +123,13 @@ jobs:
         env:
           GITHUB_CONTEXT: ${{ toJson(github) }}
       - name: Archive results (filtered)
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@v7
         if: ${{ always() }}
         with:
           name: wpt-filtered-logs-linux-${{ matrix.chunk_id }}
           path: wpt-filtered-logs/*/
       - name: Archive results (full)
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@v7
         if: ${{ always() }}
         with:
           name: wpt-full-logs-linux-${{ matrix.chunk_id }}
@@ -154,15 +154,15 @@ jobs:
           name: wpt-filtered-logs-linux
           pattern: wpt-filtered-logs-linux-*
           delete-merged: true
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
         if: ${{ !cancelled() && !inputs.wpt-sync-from-upstream && github.event_name != 'pull_request_target' }}
       # This is necessary to checkout the pull request if this run was triggered via a
       # `pull_request_target` event.
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
         if: ${{ !cancelled() && !inputs.wpt-sync-from-upstream && github.event_name == 'pull_request_target' }}
         with:
           ref: refs/pull/${{ github.event.number }}/head
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v8
         if: ${{ !cancelled() && !inputs.wpt-sync-from-upstream }}
         with:
           name: wpt-filtered-logs-linux
@@ -174,7 +174,7 @@ jobs:
           cat results/linux/*.log > stable-unexpected-results.log || true
       - name: Upload aggregated results
         if: ${{ !cancelled() && !inputs.wpt-sync-from-upstream }}
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@v7
         with:
           name: stable-unexpected-results-linux
           path: stable-unexpected-results.log

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -195,7 +195,7 @@ jobs:
         if: ${{ false && inputs.unit-tests }} # FIXME #39273
         run: ./mach test-devtools --profile ${{ inputs.profile }}
       - name: Archive build timing
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@v7
         with:
           name: cargo-timings-linux-${{ inputs.profile }}
           # Using a wildcard here ensures that the archive includes the path.
@@ -203,7 +203,7 @@ jobs:
       - name: Build mach package
         run: ./mach package --profile ${{ inputs.profile }}
       - name: Upload artifact for mach package
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@v7
         id: upload-tarball
         with:
           name: ${{ inputs.profile }}-binary-linux
@@ -247,13 +247,13 @@ jobs:
     name: Build libservo and MSRV check
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
         if: github.event_name != 'pull_request_target'
         with:
           fetch-depth: 1
       # This is necessary to checkout the pull request if this run was triggered via a
       # `pull_request_target` event.
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
         if: github.event_name == 'pull_request_target'
         with:
           ref: ${{ github.event.pull_request.head.sha }}
@@ -376,7 +376,7 @@ jobs:
     if: ${{ inputs.unit-tests }}
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
         if: github.event_name != 'pull_request_target'
         with:
           fetch-depth: 1

--- a/.github/workflows/mac-arm64.yml
+++ b/.github/workflows/mac-arm64.yml
@@ -88,11 +88,11 @@ jobs:
       - name: Kill XProtectBehaviorService
         run: |
           echo Killing XProtect.; sudo pkill -9 XProtect >/dev/null || true;
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
         if: runner.environment != 'self-hosted' && github.event_name != 'pull_request_target'
       # This is necessary to checkout the pull request if this run was triggered via a
       # `pull_request_target` event.
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
         if: runner.environment != 'self-hosted' && github.event_name == 'pull_request_target'
         with:
           ref: ${{ github.event.pull_request.head.sha }}
@@ -170,13 +170,13 @@ jobs:
           max_attempts: 2
           command: ./etc/ci/macos_package_smoketest.sh target/${{ inputs.profile }}/servo-tech-demo.dmg
       - name: Archive build timing
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@v7
         with:
           name: cargo-timings-macos-arm64-${{ inputs.profile }}
           # Using a wildcard here ensures that the archive includes the path.
           path: target/cargo-timings-*
       - name: Upload artifact for mach package
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@v7
         id: upload-dmg
         with:
           name: ${{ inputs.profile }}-binary-mac-arm64
@@ -189,7 +189,7 @@ jobs:
       - name: Build package for target
         run: gtar -czf target.tar.gz target/${{ inputs.profile }}/servo target/${{ inputs.profile }}/lib/*.dylib resources
       - name: Upload package for target
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@v7
         with:
           name: ${{ inputs.profile }}-binary-macos-arm64
           path: target.tar.gz
@@ -224,13 +224,13 @@ jobs:
     name: Build libservo and MSRV check
     runs-on: macos-15
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
         if: github.event_name != 'pull_request_target'
         with:
           fetch-depth: 1
       # This is necessary to checkout the pull request if this run was triggered via a
       # `pull_request_target` event.
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
         if: github.event_name == 'pull_request_target'
         with:
           ref: ${{ github.event.pull_request.head.sha }}

--- a/.github/workflows/mac-wpt.yml
+++ b/.github/workflows/mac-wpt.yml
@@ -30,15 +30,15 @@ jobs:
       matrix:
         chunk_id: [1, 2, 3, 4, 5]
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
         if: github.event_name != 'pull_request_target'
       # This is necessary to checkout the pull request if this run was triggered via a
       # `pull_request_target` event.
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
         if: github.event_name == 'pull_request_target'
         with:
           ref: refs/pull/${{ github.event.number }}/head
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v8
         with:
           name: ${{ inputs.profile }}-binary-${{ env.NAME }}
       - name: Setup Python
@@ -62,13 +62,13 @@ jobs:
             --filter-intermittents wpt-filtered-logs/${{ env.NAME }}/${{ matrix.chunk_id }}.json
             ${{ inputs.wpt-args }}
       - name: Archive results (filtered)
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@v7
         if: ${{ always() }}
         with:
           name: wpt-filtered-logs-${{ env.NAME }}-${{ matrix.chunk_id }}
           path: wpt-filtered-logs/*/
       - name: Archive results (full)
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@v7
         if: ${{ always() }}
         with:
           name: wpt-full-logs-${{ env.NAME }}-${{ matrix.chunk_id }}
@@ -92,7 +92,7 @@ jobs:
           name: wpt-full-logs-${{ env.NAME }}
           pattern: wpt-full-logs-${{ env.NAME }}-*
           delete-merged: true
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
         if: ${{ !cancelled() }}
         with:
           fetch-depth: 2
@@ -103,11 +103,11 @@ jobs:
           cat results/${{ env.NAME }}/*.log > stable-unexpected-results.log || true
       - name: Upload aggregated results
         if: ${{ !cancelled() && !inputs.wpt-sync-from-upstream }}
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@v7
         with:
           name: stable-unexpected-results-${{ env.NAME }}
           path: stable-unexpected-results.log
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v8
         if: ${{ !cancelled() }}
         with:
           name: wpt-filtered-logs-${{ env.NAME }}

--- a/.github/workflows/mac.yml
+++ b/.github/workflows/mac.yml
@@ -178,13 +178,13 @@ jobs:
           max_attempts: 2
           command: ./etc/ci/macos_package_smoketest.sh target/${{ inputs.profile }}/servo-tech-demo.dmg
       - name: Archive build timing
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@v7
         with:
           name: cargo-timings-macos-${{ inputs.profile }}
           # Using a wildcard here ensures that the archive includes the path.
           path: target/cargo-timings-*
       - name: Upload artifact for mach package
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@v7
         id: upload-dmg
         with:
           name: ${{ inputs.profile }}-binary-mac
@@ -197,7 +197,7 @@ jobs:
       - name: Build package for target
         run: gtar -czf target.tar.gz target/${{ inputs.profile }}/servo target/${{ inputs.profile }}/lib/*.dylib resources
       - name: Upload package for target
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@v7
         with:
           name: ${{ inputs.profile }}-binary-macos
           path: target.tar.gz
@@ -232,13 +232,13 @@ jobs:
     name: Build libservo and MSRV check
     runs-on: macos-15-intel
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
         if: github.event_name != 'pull_request_target'
         with:
           fetch-depth: 1
       # This is necessary to checkout the pull request if this run was triggered via a
       # `pull_request_target` event.
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
         if: github.event_name == 'pull_request_target'
         with:
           ref: ${{ github.event.pull_request.head.sha }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -20,7 +20,7 @@ jobs:
     outputs:
       configuration: ${{ steps.configuration.outputs.result }}
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 1
           sparse-checkout: |

--- a/.github/workflows/ohos.yml
+++ b/.github/workflows/ohos.yml
@@ -54,13 +54,13 @@ jobs:
       artifact_ids: ${{ steps.artifact_ids.outputs.artifact_ids }}
       signed: ${{ steps.signing_config.outputs.signed }}
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
         if: github.event_name != 'pull_request_target'
         with:
           fetch-depth: 2
       # This is necessary to checkout the pull request if this run was triggered via a
       # `pull_request_target` event.
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
         if: github.event_name == 'pull_request_target'
         with:
           ref: ${{ github.event.pull_request.head.sha }}
@@ -81,7 +81,7 @@ jobs:
           version: "6.0.0.1" # api 20 in openharmony
           fixup-path: true
       - name: Install node for hvigor
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: 18
       - name: Install hvigor modules
@@ -110,28 +110,28 @@ jobs:
           ./mach build --locked --target ${{ matrix.target }} --profile ${{ inputs.profile }}
           cp -r target/cargo-timings target/cargo-timings-ohos-${{ matrix.target }}
       - name: Archive build timing
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@v7
         with:
           name: cargo-timings-ohos-${{ matrix.target }}-${{ inputs.profile }}
           # Using a wildcard here ensures that the archive includes the path.
           path: target/cargo-timings-*
       - name: Upload shared library
         if: ${{ inputs.upload_library }}
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@v7
         id: upload-library
         with:
           name: ${{ inputs.profile }}-library-ohos-${{ matrix.target }}
           path: target/aarch64-unknown-linux-ohos/production/libservoshell.so
       - name: Upload signed HAP artifact
         if: ${{ env.SERVO_OHOS_SIGNING_CONFIG != '' }} # Build output has different name if not signed.
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@v7
         id: upload-hap-signed
         with:
           name: ${{ inputs.profile }}-binary-ohos-${{ matrix.target }}
           path: target/openharmony/${{ matrix.target }}/${{ inputs.profile }}/entry/build/default/outputs/default/servoshell-default-signed.hap
       - name: Upload unsigned HAP artifact
         if: ${{ env.SERVO_OHOS_SIGNING_CONFIG == '' }} # Build output has different name if not signed.
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@v7
         id: upload-hap-unsigned
         with:
           name: ${{ inputs.profile }}-binary-ohos-${{ matrix.target }}
@@ -186,7 +186,7 @@ jobs:
       - name: Build for aarch64 HarmonyOS
         run: |
           ./mach build --locked --target aarch64-unknown-linux-ohos --profile=${{ inputs.profile }} --flavor=harmonyos --no-default-features --features tracing,tracing-hitrace
-      - uses: actions/upload-artifact@v6
+      - uses: actions/upload-artifact@v7
         with:
           # Upload the **unsigned** artifact - We don't have the signing materials in pull request workflows
           name: servoshell-hos-${{ inputs.profile }}.hap
@@ -209,7 +209,7 @@ jobs:
       job_status: ${{ steps.result.outputs.JOB_STATUS }}
     if: github.repository == 'servo/servo' && needs.build-harmonyos-aarch64.outputs.job_status == 'success'
     steps:
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v8
         with:
           # Name of the artifact to download.
           # If unspecified, all artifacts for the run are downloaded.
@@ -228,13 +228,13 @@ jobs:
           # to make sure we don't use a previous version if installation failed for some reason.
           hdc uninstall org.servo.servo
           hdc install -r servoshell-hos-signed.hap
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
         if: github.event_name != 'pull_request_target'
         with:
           fetch-depth: 0
       # This is necessary to checkout the pull request if this run was triggered via a
       # `pull_request_target` event.
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
         if: github.event_name == 'pull_request_target'
         with:
           ref: ${{ github.event.pull_request.head.sha }}
@@ -305,7 +305,7 @@ jobs:
         run: hitrace-bench -r support/hitrace-bencher/runs.json --bencher -p ${{ inputs.profile }}
       - name: Upload failure screenshots
         if: ${{ steps.hitrace_bench.success == 'failure' }}
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@v7
         with:
           name: bencher-${{ inputs.profile }}-failure-screenshot
           path: "/tmp/servo.jpeg"
@@ -323,7 +323,7 @@ jobs:
           hdc file recv /data/local/tmp/servo.jpeg speedometer_error_logs/servo_hos_screenshot.jpeg
           # Todo: Upload logs. This is currently not possible since the test-speedometer-ohos command
           # sets a log filter, which filters everything except JS console output.
-      - uses: actions/upload-artifact@v6
+      - uses: actions/upload-artifact@v7
         if: ${{ !cancelled() && steps.speedometer.outcome == 'failure' }}
         with:
           name: ohos-speedometer-failure-${{ matrix.target }}-${{ inputs.profile }}
@@ -367,7 +367,7 @@ jobs:
       # This will ensure the scenario pyproject.toml is picked up and the correct venv used.
       UV_PROJECT: "etc/ci/scenario"
     steps:
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v8
         with:
           # Name of the artifact to download.
           # If unspecified, all artifacts for the run are downloaded.
@@ -387,7 +387,7 @@ jobs:
           hdc uninstall org.servo.servo
           hdc install -r servoshell-hos-signed.hap
       - name: Checkout scenario scripts
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
         with:
           sparse-checkout: |
             etc/ci/scenario
@@ -420,7 +420,7 @@ jobs:
         run: uv run ./etc/ci/scenario/servo_test_slide.py
       - name: Upload failure screenshots
         if: ${{ steps.install_hap.outcome == 'success' && failure() }}
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@v7
         with:
           name: hos-${{ inputs.profile }}-scenario-failures-screenshots
           path: "servo_scenario_*_error.jpg"

--- a/.github/workflows/pull-request-wpt-export.yml
+++ b/.github/workflows/pull-request-wpt-export.yml
@@ -22,7 +22,7 @@ jobs:
           cd servo
           git fetch origin pull/${{ github.event.pull_request.number}}/head:pr --depth ${{ env.PR_FETCH_DEPTH }}
       - name: Check out wpt
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
         with:
           path: wpt
           repository: 'web-platform-tests/wpt'

--- a/.github/workflows/scheduled-wpt-import.yml
+++ b/.github/workflows/scheduled-wpt-import.yml
@@ -28,8 +28,8 @@ jobs:
       - "linux"
     steps:
       - name: Checkout code
-        uses: actions/checkout@v5
-      - uses: actions/download-artifact@v4
+        uses: actions/checkout@v6
+      - uses: actions/download-artifact@v8
         with:
           name: wpt-full-logs-linux
       - name: Setup Python

--- a/.github/workflows/try-label.yml
+++ b/.github/workflows/try-label.yml
@@ -15,7 +15,7 @@ jobs:
       try_string: ${{ steps.try_string.outputs.result }}
     steps:
       - name: Collect Labels
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         id: try_string
         with:
           result-encoding: string
@@ -66,7 +66,7 @@ jobs:
             }
 
             return try_string;
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
         with:
           sparse-checkout: |
             python/servo/try_parser.py
@@ -87,7 +87,7 @@ jobs:
            } >> $GITHUB_OUTPUT
       - name: Comment Run Start
         if: ${{ steps.try_string.outputs.result }}
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           result-encoding: string
           script: |

--- a/.github/workflows/try.yml
+++ b/.github/workflows/try.yml
@@ -35,7 +35,7 @@ jobs:
     outputs:
       configuration: ${{ steps.configuration.outputs.result }}
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 1
           sparse-checkout: |
@@ -56,7 +56,7 @@ jobs:
            } >> $GITHUB_OUTPUT
       - name: Configuration
         id: configuration
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: |
             // When triggered via a push try the `try` branch, search the last commit for a configuration object.

--- a/.github/workflows/upload_release.yml
+++ b/.github/workflows/upload_release.yml
@@ -39,7 +39,7 @@ jobs:
           fetch-depth: '1'
       - name: Setup Python
         uses: ./.github/actions/setup-python
-      - uses: actions/download-artifact@v7
+      - uses: actions/download-artifact@v8
         with:
           artifact-ids: ${{ inputs.artifact_ids }}
           merge-multiple: true

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -188,7 +188,7 @@ jobs:
         if: ${{ false && inputs.unit-tests }}  # FIXME #39273
         run: .\mach test-devtools --profile ${{ inputs.profile }}
       - name: Archive build timing
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@v7
         with:
           name: cargo-timings-windows-${{ inputs.profile }}
           # Using a wildcard here ensures that the archive includes the path.
@@ -200,13 +200,13 @@ jobs:
       # Bundle: C:\a\servo\servo\target\${{ inputs.profile }}\msi\Servo.exe
       # Zip: C:\a\servo\servo\target\${{ inputs.profile }}\msi\Servo.zip
       - name: Upload artifact for mach package
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@v7
         id: upload-exe
         with:
           name: ${{ inputs.profile }}-binary-windows
           path: C:\\a\\servo\\servo\\target\\${{ inputs.profile }}\\msi\\Servo.exe
       - name: Upload artifact for mach package (zip)
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@v7
         id: upload-zip
         if: ${{ inputs.upload_zip }}
         with:
@@ -241,13 +241,13 @@ jobs:
     name: Build libservo and MSRV check
     runs-on: windows-2022
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
         if: github.event_name != 'pull_request_target'
         with:
           fetch-depth: 1
       # This is necessary to checkout the pull request if this run was triggered via a
       # `pull_request_target` event.
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
         if: github.event_name == 'pull_request_target'
         with:
           ref: ${{ github.event.pull_request.head.sha }}


### PR DESCRIPTION
## Summary

Upgrade GitHub Actions to their latest versions to ensure compatibility with Node 24, as Node 20 will reach end-of-life in April 2026.

## Changes

| Action | Old Version(s) | New Version | Release | Files |
|--------|---------------|-------------|---------|-------|
| `actions/checkout` | [`v5`](https://github.com/actions/checkout/releases/tag/v5) | [`v6`](https://github.com/actions/checkout/releases/tag/v6) | [Release](https://github.com/actions/checkout/releases/tag/v6) | android.yml, docs.yml, linux-wpt.yml, linux.yml, mac-arm64.yml, mac-wpt.yml, mac.yml, main.yml, ohos.yml, pull-request-wpt-export.yml, scheduled-wpt-import.yml, try-label.yml, try.yml, windows.yml |
| `actions/download-artifact` | [`v4`](https://github.com/actions/download-artifact/releases/tag/v4), [`v7`](https://github.com/actions/download-artifact/releases/tag/v7) | [`v8`](https://github.com/actions/download-artifact/releases/tag/v8) | [Release](https://github.com/actions/download-artifact/releases/tag/v8) | bencher.yml, linux-wpt.yml, mac-wpt.yml, ohos.yml, scheduled-wpt-import.yml, upload_release.yml |
| `actions/github-script` | [`v7`](https://github.com/actions/github-script/releases/tag/v7) | [`v8`](https://github.com/actions/github-script/releases/tag/v8) | [Release](https://github.com/actions/github-script/releases/tag/v8) | try-label.yml, try.yml |
| `actions/setup-java` | [`v4`](https://github.com/actions/setup-java/releases/tag/v4) | [`v5`](https://github.com/actions/setup-java/releases/tag/v5) | [Release](https://github.com/actions/setup-java/releases/tag/v5) | android.yml |
| `actions/setup-node` | [`v4`](https://github.com/actions/setup-node/releases/tag/v4) | [`v6`](https://github.com/actions/setup-node/releases/tag/v6) | [Release](https://github.com/actions/setup-node/releases/tag/v6) | ohos.yml |
| `actions/upload-artifact` | [`v6`](https://github.com/actions/upload-artifact/releases/tag/v6) | [`v7`](https://github.com/actions/upload-artifact/releases/tag/v7) | [Release](https://github.com/actions/upload-artifact/releases/tag/v7) | android.yml, linux-wpt.yml, linux.yml, mac-arm64.yml, mac-wpt.yml, mac.yml, ohos.yml, windows.yml |

## Context

Per [GitHub's announcement](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/), Node 20 is being deprecated and runners will begin using Node 24 by default starting June 2nd, 2026.

### Why this matters

- **Node 20 EOL**: April 2026
- **Node 24 default**: June 2nd, 2026
- **Action**: Update to latest action versions that support Node 24

### ⚠️ Breaking Changes

- **actions/checkout** (v5 → v6): Major version upgrade — review the [release notes](https://github.com/actions/checkout/releases) for breaking changes
- **actions/setup-java** (v4 → v5): Major version upgrade — review the [release notes](https://github.com/actions/setup-java/releases) for breaking changes
- **actions/upload-artifact** (v6 → v7): Major version upgrade — review the [release notes](https://github.com/actions/upload-artifact/releases) for breaking changes
- **actions/download-artifact** (v4 → v8): Major version upgrade — review the [release notes](https://github.com/actions/download-artifact/releases) for breaking changes
- **actions/setup-node** (v4 → v6): Major version upgrade — review the [release notes](https://github.com/actions/setup-node/releases) for breaking changes
  - ⚠️ Input `always-auth` was **removed** — if your workflow uses it, the step may fail
- **actions/github-script** (v7 → v8): Major version upgrade — review the [release notes](https://github.com/actions/github-script/releases) for breaking changes

### Security Note

Actions that were previously pinned to commit SHAs remain pinned to SHAs (updated to the latest release SHA) to maintain the security benefits of immutable references.

### Testing

These changes only affect CI/CD workflow configurations and should not impact application functionality. The workflows should be tested by running them on a branch before merging.
