### PR TITLE
Upgrade GitHub Actions to latest versions

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -84,7 +84,7 @@ jobs:
         with:
           ndk-version: r28b
       - name: Setup Gradle caches
-        uses: gradle/actions/setup-gradle@v4
+        uses: gradle/actions/setup-gradle@v5
       - name: Trigger initial download of Gradle with retries
         run: |
           for i in {1..4}; do

--- a/.github/workflows/linux-wpt.yml
+++ b/.github/workflows/linux-wpt.yml
@@ -142,14 +142,14 @@ jobs:
     needs: linux-wpt
     steps:
       - name: Merge logs (full)
-        uses: actions/upload-artifact/merge@v4
+        uses: actions/upload-artifact/merge@v7
         with:
           name: wpt-full-logs-linux
           pattern: wpt-full-logs-linux-*
           delete-merged: true
       # This job needs to be last. If no filtered results were uploaded, it will fail, but we want to merge other archives in that case.
       - name: Merge logs (filtered)
-        uses: actions/upload-artifact/merge@v4
+        uses: actions/upload-artifact/merge@v7
         with:
           name: wpt-filtered-logs-linux
           pattern: wpt-filtered-logs-linux-*

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -145,7 +145,7 @@ jobs:
       - name: Change Mirror Priorities
         if: ${{ runner.environment != 'self-hosted' }}
         uses: ./.github/actions/apt-mirrors
-      - uses: taiki-e/install-action@v2
+      - uses: taiki-e/install-action@v2.68.16
         with:
           tool: nextest
       - name: Bootstrap dependencies
@@ -332,7 +332,7 @@ jobs:
         if: ${{ runner.environment != 'self-hosted' }}
         uses: ./.github/actions/apt-mirrors
       - name: Install cargo-llvm-cov
-        uses: taiki-e/install-action@v2
+        uses: taiki-e/install-action@v2.68.16
         with:
           tool: cargo-llvm-cov,cargo-nextest
       - name: Bootstrap dependencies

--- a/.github/workflows/mac-arm64.yml
+++ b/.github/workflows/mac-arm64.yml
@@ -118,7 +118,7 @@ jobs:
       - name: Install crown
         run: cargo install --path support/crown
 
-      - uses: taiki-e/install-action@v2
+      - uses: taiki-e/install-action@v2.68.16
         with:
           tool: nextest
 

--- a/.github/workflows/mac-wpt.yml
+++ b/.github/workflows/mac-wpt.yml
@@ -81,13 +81,13 @@ jobs:
     needs: mac-wpt
     steps:
       - name: Merge logs (filtered)
-        uses: actions/upload-artifact/merge@v4
+        uses: actions/upload-artifact/merge@v7
         with:
           name: wpt-filtered-logs-${{ env.NAME }}
           pattern: wpt-filtered-logs-${{ env.NAME }}-*
           delete-merged: true
       - name: Merge logs (full)
-        uses: actions/upload-artifact/merge@v4
+        uses: actions/upload-artifact/merge@v7
         with:
           name: wpt-full-logs-${{ env.NAME }}
           pattern: wpt-full-logs-${{ env.NAME }}-*

--- a/.github/workflows/mac.yml
+++ b/.github/workflows/mac.yml
@@ -126,7 +126,7 @@ jobs:
       - name: Install crown
         run: cargo install --path support/crown
 
-      - uses: taiki-e/install-action@v2
+      - uses: taiki-e/install-action@v2.68.16
         with:
           tool: nextest
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -71,7 +71,7 @@ jobs:
       - build
     steps:
       - name: Merge build timings
-        uses: actions/upload-artifact/merge@v4
+        uses: actions/upload-artifact/merge@v7
         with:
           name: cargo-timings
           pattern: cargo-timings-*

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -130,7 +130,7 @@ jobs:
         run: |
           python3 etc/vendor_servo.py --filename "${ARTIFACT_BASENAME}"
       - name: Generate artifact attestation
-        uses: actions/attest-build-provenance@v3
+        uses: actions/attest-build-provenance@v4
         with:
           subject-path: ${{ env.ARTIFACT_FILENAME }}
       - name: Upload vendored archive to release

--- a/.github/workflows/try.yml
+++ b/.github/workflows/try.yml
@@ -128,7 +128,7 @@ jobs:
     steps:
       - name: Merge build timings
         continue-on-error: true
-        uses: actions/upload-artifact/merge@v4
+        uses: actions/upload-artifact/merge@v7
         with:
           name: cargo-timings
           pattern: cargo-timings-*

--- a/.github/workflows/upload_release.yml
+++ b/.github/workflows/upload_release.yml
@@ -45,7 +45,7 @@ jobs:
           merge-multiple: true
           path: release-artifacts
       - name: Generate artifact attestation
-        uses: actions/attest-build-provenance@v3
+        uses: actions/attest-build-provenance@v4
         with:
           subject-path: 'release-artifacts/*'
       - name: Upload release artifacts

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -158,7 +158,7 @@ jobs:
         run: .\mach smoketest --profile ${{ inputs.profile }}
       - name: Install cargo nextest
         if: ${{ runner.environment != 'self-hosted' }}
-        uses: taiki-e/install-action@v2
+        uses: taiki-e/install-action@v2.68.16
         with:
           tool: nextest
       # On self-hosted windows runners the install-action fails


### PR DESCRIPTION
## Summary

Upgrade GitHub Actions to their latest versions for improved features, bug fixes, and security updates.

## Changes

| Action | Old Version(s) | New Version | Release | Files |
|--------|---------------|-------------|---------|-------|
| `actions/attest-build-provenance` | [`v3`](https://github.com/actions/attest-build-provenance/releases/tag/v3) | [`v4`](https://github.com/actions/attest-build-provenance/releases/tag/v4) | [Release](https://github.com/actions/attest-build-provenance/releases/tag/v4) | release.yml, upload_release.yml |
| `actions/upload-artifact/merge` | [`v4`](https://github.com/actions/upload-artifact/merge/releases/tag/v4) | [`v7`](https://github.com/actions/upload-artifact/merge/releases/tag/v7) | [Release](https://github.com/actions/upload-artifact/merge/releases/tag/v7) | linux-wpt.yml, mac-wpt.yml, main.yml, try.yml |
| `gradle/actions/setup-gradle` | [`v4`](https://github.com/gradle/actions/setup-gradle/releases/tag/v4) | [`v5`](https://github.com/gradle/actions/setup-gradle/releases/tag/v5) | [Release](https://github.com/gradle/actions/setup-gradle/releases/tag/v5) | android.yml |
| `taiki-e/install-action` | [`v2`](https://github.com/taiki-e/install-action/releases/tag/v2) | [`v2.68.16`](https://github.com/taiki-e/install-action/releases/tag/v2.68.16) | [Release](https://github.com/taiki-e/install-action/releases/tag/v2.68.16) | linux.yml, mac-arm64.yml, mac.yml, windows.yml |

## Why upgrade?

Keeping GitHub Actions up to date ensures:
- **Security**: Latest security patches and fixes
- **Features**: Access to new functionality and improvements
- **Compatibility**: Better support for current GitHub features
- **Performance**: Optimizations and efficiency improvements

### ⚠️ Breaking Changes

- **gradle/actions/setup-gradle** (v4 → v5): Major version upgrade — review the [release notes](https://github.com/gradle/actions/releases) for breaking changes
- **actions/upload-artifact/merge** (v4 → v7): Major version upgrade — review the [release notes](https://github.com/actions/upload-artifact/releases) for breaking changes
- **actions/attest-build-provenance** (v3 → v4): Major version upgrade — review the [release notes](https://github.com/actions/attest-build-provenance/releases) for breaking changes

### Security Note

Actions that were previously pinned to commit SHAs remain pinned to SHAs (updated to the latest release SHA) to maintain the security benefits of immutable references.

### Testing

These changes only affect CI/CD workflow configurations and should not impact application functionality. The workflows should be tested by running them on a branch before merging.
