### PR TITLE
Fix nightly release

### DIFF
--- a/.github/workflows/ohos.yml
+++ b/.github/workflows/ohos.yml
@@ -16,7 +16,7 @@ on:
         type: boolean
     outputs:
       artifact_ids:
-        value: ${{ jobs.build.outputs.artifact_ids }}
+        value: ${{ jobs.build-openharmony.outputs.artifact_ids }}
         description: Comma-separated list of artifact IDs for the release artifacts
       optional_job_status:
         description: "Status of optional jobs (as an object)"

--- a/.github/workflows/upload_release.yml
+++ b/.github/workflows/upload_release.yml
@@ -43,7 +43,7 @@ jobs:
         run: |
           if [[ -z "${{ inputs.artifact_ids }}" ]]; then
             echo "Error: No artifact IDs provided."
-            echo "Help: Check the calling workflow's inputs.artifact_ids parameter, usually created by a build workflow."
+            echo "Help: Check the calling workflow's output.artifact_ids parameter, usually created by a build workflow."
             echo "If you recently renamed the build job for the artifacts, without updating the `outputs.artifact_ids` "
             echo "parameter then this might be the cause of the error."
             exit 1

--- a/.github/workflows/upload_release.yml
+++ b/.github/workflows/upload_release.yml
@@ -39,6 +39,15 @@ jobs:
           fetch-depth: '1'
       - name: Setup Python
         uses: ./.github/actions/setup-python
+      - name: Validate artifact IDs
+        run: |
+          if [[ -z "${{ inputs.artifact_ids }}" ]]; then
+            echo "Error: No artifact IDs provided."
+            echo "Help: Check the calling workflow's inputs.artifact_ids parameter, usually created by a build workflow."
+            echo "If you recently renamed the build job for the artifacts, without updating the `outputs.artifact_ids` "
+            echo "parameter then this might be the cause of the error."
+            exit 1
+          fi
       - uses: actions/download-artifact@v7
         with:
           artifact-ids: ${{ inputs.artifact_ids }}


### PR DESCRIPTION
Renaming the openharmony build job in #42929 caused artifact_ids to be empty, which caused release failures.
Additionally, we add a validation step to the upload workflow, to quickly pinpoint the issue of a missing input parameter, 
since apparently github won't throw an error if a required input parameter is empty. 
This should make it easier to pinpoint the issue if it happens again. 

Testing: Not tested.
