### PR TITLE
OHOS CI: Fix resident-smaps recording

### DIFF
--- a/ports/servoshell/egl/app.rs
+++ b/ports/servoshell/egl/app.rs
@@ -136,10 +136,17 @@ impl PlatformWindow for EmbeddedPlatformWindow {
                         .results
                         .first()
                         .expect("We should have some memory report");
-                    for report in &reports.reports {
-                        let path = String::from("servo_memory_profiling:") + &report.path.join("/");
-                        hitrace::trace_metric_str(&path, report.size as i64);
-                    }
+                    let search_string = String::from("resident-according-to-smaps");
+                    let sum = reports
+                        .reports
+                        .iter()
+                        .filter(|report| report.path.contains(&search_string))
+                        .map(|report| report.size)
+                        .sum::<usize>();
+                    hitrace::trace_metric_str(
+                        "servo_memory_profiling:resident-according-to-smaps/sum",
+                        sum as i64,
+                    );
                 });
             }
         }

--- a/support/hitrace-bencher/runs.json
+++ b/support/hitrace-bencher/runs.json
@@ -49,7 +49,7 @@
             {
                 "name": "resident-smaps",
                 "match_str": "resident-according-to-smaps",
-                "point_filter_type": "Combined"
+                "point_filter_type": "Largest"
             },
             {
                 "name": "LargestContentfulPaint",
@@ -100,7 +100,7 @@
             {
                 "name": "resident-smaps",
                 "match_str": "resident-according-to-smaps",
-                "point_filter_type": "Combined"
+                "point_filter_type": "Largest"
             },
             {
                 "name": "LargestContentfulPaint",


### PR DESCRIPTION
Because of the move of the reporting function to update_user_interface_state and the multiple events of LoadStatus::Complete, the previous reporting did not work correctly anymore.

This fixes it by manually summing up the reports for 'resident-according-to-smaps' and using the hitrace-bencher point_filter_type Largest.

This should restore the bencher graph.

Signed-off-by: Narfinger <Narfinger@users.noreply.github.com>

Testing: No automatic test but manual test here: https://github.com/Narfinger/servo/actions/runs/22617931816
