### PR TITLE
script: Fire pointer, `mouseenter`, and `mouseleave`events respecting the flat tree

### DIFF
--- a/components/script/dom/document_event_handler.rs
+++ b/components/script/dom/document_event_handler.rs
@@ -31,7 +31,6 @@ use script_bindings::codegen::GenericBindings::DocumentBinding::DocumentMethods;
 use script_bindings::codegen::GenericBindings::EventBinding::EventMethods;
 use script_bindings::codegen::GenericBindings::HTMLLabelElementBinding::HTMLLabelElementMethods;
 use script_bindings::codegen::GenericBindings::NavigatorBinding::NavigatorMethods;
-use script_bindings::codegen::GenericBindings::NodeBinding::NodeMethods;
 use script_bindings::codegen::GenericBindings::PerformanceBinding::PerformanceMethods;
 use script_bindings::codegen::GenericBindings::TouchBinding::TouchMethods;
 use script_bindings::codegen::GenericBindings::WindowBinding::{ScrollBehavior, WindowMethods};
@@ -405,7 +404,7 @@ impl DocumentEventHandler {
 
         let common_ancestor = match related_target.as_ref() {
             Some(related_target) => event_target
-                .common_ancestor(related_target, ShadowIncluding::Yes)
+                .common_ancestor_in_flat_tree(related_target)
                 .unwrap_or_else(|| DomRoot::from_ref(&*event_target)),
             None => DomRoot::from_ref(&*event_target),
         };
@@ -418,7 +417,7 @@ impl DocumentEventHandler {
             if node == common_ancestor {
                 break;
             }
-            current = node.GetParentNode();
+            current = node.parent_in_flat_tree();
             targets.push(node);
         }
 
@@ -2165,7 +2164,7 @@ impl DocumentEventHandler {
         let mut current: Option<DomRoot<Node>> = Some(DomRoot::from_ref(target_element.upcast()));
         while let Some(node) = current {
             targets.push(DomRoot::from_ref(&*node));
-            current = node.GetParentNode();
+            current = node.parent_in_flat_tree();
         }
 
         // Reverse to dispatch from topmost ancestor to target

--- a/tests/wpt/meta/pointerevents/capturing_boundary_event_handler_at_ua_shadowdom.html.ini
+++ b/tests/wpt/meta/pointerevents/capturing_boundary_event_handler_at_ua_shadowdom.html.ini
@@ -2,9 +2,6 @@
   [Capturing boundary event handler at DIV]
     expected: FAIL
 
-  [Capturing boundary event handler at INPUT]
-    expected: FAIL
-
 
 [capturing_boundary_event_handler_at_ua_shadowdom.html?pen]
   [Capturing boundary event handler at DIV]


### PR DESCRIPTION
The [spec](https://w3c.github.io/pointerevents/#the-pointerenter-event) says that pointer events should be fired for the element hovered by the pointer and all its ancestors. That implies using the flat tree, which we were not doing before.

Testing: This change fixes a web platform test and makes https://github.com/simeydotme/hover-tilt work in servo