### PR TITLE
script: Use stylo dom apis for querySelector/querySelectorAll

### DIFF
--- a/components/layout/layout_impl.rs
+++ b/components/layout/layout_impl.rs
@@ -26,6 +26,7 @@ use layout_api::{
     OffsetParentResponse, PhysicalSides, PropertyRegistration, QueryMsg, ReflowGoal,
     ReflowPhasesRun, ReflowRequest, ReflowRequestRestyle, ReflowResult, ReflowStatistics,
     RegisterPropertyError, ScrollContainerQueryFlags, ScrollContainerResponse, TrustedNodeAddress,
+    with_layout_state,
 };
 use log::{debug, error, warn};
 use malloc_size_of::{MallocConditionalSizeOf, MallocSizeOf, MallocSizeOfOps};
@@ -71,7 +72,6 @@ use style::stylesheets::{
     CustomMediaMap, DocumentStyleSheet, Origin, Stylesheet, StylesheetInDocument,
 };
 use style::stylist::Stylist;
-use style::thread_state::{self, ThreadState};
 use style::traversal::DomTraversal;
 use style::traversal_flags::TraversalFlags;
 use style::values::computed::font::GenericFontFamily;
@@ -221,39 +221,6 @@ impl LayoutFactory for LayoutFactoryImpl {
     fn create(&self, config: LayoutConfig) -> Box<dyn Layout> {
         Box::new(LayoutThread::new(config))
     }
-}
-
-struct ThreadStateRestorer;
-
-impl ThreadStateRestorer {
-    fn new() -> Self {
-        #[cfg(debug_assertions)]
-        {
-            thread_state::exit(ThreadState::SCRIPT);
-            thread_state::enter(ThreadState::LAYOUT);
-        }
-        Self
-    }
-}
-
-impl Drop for ThreadStateRestorer {
-    fn drop(&mut self) {
-        #[cfg(debug_assertions)]
-        {
-            thread_state::exit(ThreadState::LAYOUT);
-            thread_state::enter(ThreadState::SCRIPT);
-        }
-    }
-}
-
-/// Set up the thread-local state to reflect that layout code is about to run,
-/// then call the provided function.
-/// This must be used when running code that will interact with the DOM tree
-/// through types like `ServoLayoutNode`, `ServoLayoutElement`, and `LayoutDom`,
-/// which have rules about how they must be used from layout worker threads.
-fn with_layout_state<R>(f: impl FnOnce() -> R) -> R {
-    let _guard = ThreadStateRestorer::new();
-    f()
 }
 
 impl Drop for LayoutThread {

--- a/components/script/dom/bindings/root.rs
+++ b/components/script/dom/bindings/root.rs
@@ -101,6 +101,15 @@ where
         assert_in_layout();
         self.value.is::<U>()
     }
+
+    /// Get a reference to the internal value.
+    ///
+    /// ## SAFETY
+    /// This function effectively circumvents all the safety provided by `LayoutDom` as it allows
+    /// performing arbitrary (potentially mutating) operations on the value. Use with caution!
+    pub(crate) unsafe fn as_ref(self) -> &'dom T {
+        self.value
+    }
 }
 
 impl<T> LayoutDom<'_, T>

--- a/components/script/dom/document.rs
+++ b/components/script/dom/document.rs
@@ -3614,6 +3614,7 @@ pub(crate) trait LayoutDocumentHelpers<'dom> {
     fn shadow_roots(self) -> Vec<LayoutDom<'dom, ShadowRoot>>;
     fn shadow_roots_styles_changed(self) -> bool;
     fn flush_shadow_roots_stylesheets(self);
+    fn elements_with_id(self, id: &Atom) -> &[LayoutDom<'dom, Element>];
 }
 
 #[expect(unsafe_code)]
@@ -3657,6 +3658,12 @@ impl<'dom> LayoutDocumentHelpers<'dom> for LayoutDom<'dom, Document> {
     #[inline]
     fn flush_shadow_roots_stylesheets(self) {
         (*self.unsafe_get()).flush_shadow_roots_stylesheets()
+    }
+
+    fn elements_with_id(self, id: &Atom) -> &[LayoutDom<'dom, Element>] {
+        let id_map = unsafe { self.unsafe_get().id_map.borrow_for_layout() };
+        let matching_elements = id_map.get(id).map(Vec::as_slice).unwrap_or_default();
+        unsafe { LayoutDom::to_layout_slice(matching_elements) }
     }
 }
 
@@ -5996,14 +6003,12 @@ impl DocumentMethods<crate::DomTypeHolder> for Document {
 
     /// <https://dom.spec.whatwg.org/#dom-parentnode-queryselector>
     fn QuerySelector(&self, selectors: DOMString) -> Fallible<Option<DomRoot<Element>>> {
-        let root = self.upcast::<Node>();
-        root.query_selector(selectors)
+        self.upcast::<Node>().query_selector(selectors)
     }
 
     /// <https://dom.spec.whatwg.org/#dom-parentnode-queryselectorall>
     fn QuerySelectorAll(&self, selectors: DOMString) -> Fallible<DomRoot<NodeList>> {
-        let root = self.upcast::<Node>();
-        root.query_selector_all(selectors)
+        self.upcast::<Node>().query_selector_all(selectors)
     }
 
     /// <https://html.spec.whatwg.org/multipage/#dom-document-readystate>

--- a/components/script/dom/html/htmlinputelement.rs
+++ b/components/script/dom/html/htmlinputelement.rs
@@ -2674,7 +2674,7 @@ impl HTMLInputElement {
         .into();
     }
 
-    // https://html.spec.whatwg.org/multipage/#implicit-submission
+    /// <https://html.spec.whatwg.org/multipage/#implicit-submission>
     fn implicit_submission(&self, can_gc: CanGc) {
         let doc = self.owner_document();
         let node = doc.upcast::<Node>();
@@ -2688,9 +2688,9 @@ impl HTMLInputElement {
             return;
         }
         let submit_button = node
-            .query_selector_iter(DOMString::from("input[type=submit]"))
-            .unwrap()
+            .traverse_preorder(ShadowIncluding::No)
             .filter_map(DomRoot::downcast::<HTMLInputElement>)
+            .filter(|input| input.input_type() == InputType::Submit)
             .find(|r| r.form_owner() == owner);
         match submit_button {
             Some(ref button) => {
@@ -2704,8 +2704,7 @@ impl HTMLInputElement {
             },
             None => {
                 let mut inputs = node
-                    .query_selector_iter(DOMString::from("input"))
-                    .unwrap()
+                    .traverse_preorder(ShadowIncluding::No)
                     .filter_map(DomRoot::downcast::<HTMLInputElement>)
                     .filter(|input| {
                         input.form_owner() == owner &&

--- a/components/script/dom/node.rs
+++ b/components/script/dom/node.rs
@@ -36,12 +36,6 @@ use net_traits::image_cache::Image;
 use pixels::ImageMetadata;
 use script_bindings::codegen::InheritTypes::DocumentFragmentTypeId;
 use script_traits::DocumentActivity;
-use selectors::bloom::BloomFilter;
-use selectors::matching::{
-    MatchingContext, MatchingForInvalidation, MatchingMode, NeedsSelectorFlags,
-    matches_selector_list,
-};
-use selectors::parser::SelectorList;
 use servo_arc::Arc as ServoArc;
 use servo_config::pref;
 use servo_url::ServoUrl;
@@ -49,9 +43,10 @@ use smallvec::SmallVec;
 use style::attr::AttrValue;
 use style::context::QuirksMode;
 use style::dom::OpaqueNode;
+use style::dom_apis::{QueryAll, QueryFirst};
 use style::properties::ComputedValues;
-use style::selector_parser::{PseudoElement, SelectorImpl, SelectorParser};
-use style::stylesheets::{Stylesheet, UrlExtraData};
+use style::selector_parser::PseudoElement;
+use style::stylesheets::Stylesheet;
 use style_traits::CSSPixel;
 use uuid::Uuid;
 use xml5ever::{local_name, serialize as xml_serialize};
@@ -99,7 +94,7 @@ use crate::dom::document::{Document, DocumentSource, HasBrowsingContext, IsHTMLD
 use crate::dom::documentfragment::DocumentFragment;
 use crate::dom::documenttype::DocumentType;
 use crate::dom::element::{
-    AttributeMutationReason, CustomElementCreationMode, Element, ElementCreator, SelectorWrapper,
+    AttributeMutationReason, CustomElementCreationMode, Element, ElementCreator,
 };
 use crate::dom::event::{Event, EventBubbles, EventCancelable};
 use crate::dom::eventtarget::EventTarget;
@@ -131,6 +126,7 @@ use crate::dom::text::Text;
 use crate::dom::types::KeyboardEvent;
 use crate::dom::virtualmethods::{VirtualMethods, vtable_for};
 use crate::dom::window::Window;
+use crate::layout_dom::ServoLayoutNode;
 use crate::script_runtime::CanGc;
 use crate::script_thread::ScriptThread;
 
@@ -593,52 +589,6 @@ impl Node {
                 None => return "ltr".to_owned(),
             }
         }
-    }
-}
-
-pub(crate) struct QuerySelectorIterator {
-    selectors: SelectorList<SelectorImpl>,
-    iterator: TreeIterator,
-}
-
-impl QuerySelectorIterator {
-    fn new(iter: TreeIterator, selectors: SelectorList<SelectorImpl>) -> QuerySelectorIterator {
-        QuerySelectorIterator {
-            selectors,
-            iterator: iter,
-        }
-    }
-}
-
-impl Iterator for QuerySelectorIterator {
-    type Item = DomRoot<Node>;
-
-    fn next(&mut self) -> Option<DomRoot<Node>> {
-        let selectors = &self.selectors;
-
-        let (quirks_mode, filter) = match self.iterator.by_ref().peek() {
-            Some(node) => (node.owner_doc().quirks_mode(), BloomFilter::default()),
-            None => return None,
-        };
-
-        self.iterator.by_ref().find_map(|node| {
-            if let Some(element) = DomRoot::downcast(node) {
-                let mut nth_index_cache = Default::default();
-                let mut ctx = MatchingContext::new(
-                    MatchingMode::Normal,
-                    Some(&filter),
-                    &mut nth_index_cache,
-                    quirks_mode,
-                    NeedsSelectorFlags::No,
-                    MatchingForInvalidation::No,
-                );
-                if matches_selector_list(selectors, &SelectorWrapper::Borrowed(&element), &mut ctx)
-                {
-                    return Some(DomRoot::upcast(element));
-                }
-            }
-            None
-        })
     }
 }
 
@@ -1207,71 +1157,51 @@ impl Node {
     }
 
     /// <https://dom.spec.whatwg.org/#dom-parentnode-queryselector>
+    #[allow(unsafe_code)]
+    #[cfg_attr(crown, allow(crown::unrooted_must_root))]
     pub(crate) fn query_selector(
         &self,
         selectors: DOMString,
     ) -> Fallible<Option<DomRoot<Element>>> {
-        // Step 1.
-        let doc = self.owner_doc();
-        match SelectorParser::parse_author_origin_no_namespace(
-            &selectors.str(),
-            &UrlExtraData(doc.url().get_arc()),
-        ) {
-            // Step 2.
-            Err(_) => Err(Error::Syntax(None)),
-            // Step 3.
-            Ok(selectors) => {
-                let mut nth_index_cache = Default::default();
-                let filter = BloomFilter::default();
-                let mut ctx = MatchingContext::new(
-                    MatchingMode::Normal,
-                    Some(&filter),
-                    &mut nth_index_cache,
-                    doc.quirks_mode(),
-                    NeedsSelectorFlags::No,
-                    MatchingForInvalidation::No,
-                );
-                let mut descendants = self.traverse_preorder(ShadowIncluding::No);
-                // Skip the root of the tree.
-                assert!(&*descendants.next().unwrap() == self);
-                Ok(descendants.filter_map(DomRoot::downcast).find(|element| {
-                    matches_selector_list(&selectors, &SelectorWrapper::Borrowed(element), &mut ctx)
-                }))
-            },
-        }
-    }
+        // > The querySelector(selectors) method steps are to return the first result of running scope-match
+        // > a selectors string selectors against this, if the result is not an empty list; otherwise null.
+        let document_url = self.owner_document().url().get_arc();
 
-    /// <https://dom.spec.whatwg.org/#scope-match-a-selectors-string>
-    /// Get an iterator over all nodes which match a set of selectors
-    /// Be careful not to do anything which may manipulate the DOM tree
-    /// whilst iterating, otherwise the iterator may be invalidated.
-    pub(crate) fn query_selector_iter(
-        &self,
-        selectors: DOMString,
-    ) -> Fallible<QuerySelectorIterator> {
-        // Step 1.
-        let url = self.owner_doc().url();
-        match SelectorParser::parse_author_origin_no_namespace(
-            &selectors.str(),
-            &UrlExtraData(url.get_arc()),
-        ) {
-            // Step 2.
-            Err(_) => Err(Error::Syntax(None)),
-            // Step 3.
-            Ok(selectors) => {
-                let mut descendants = self.traverse_preorder(ShadowIncluding::No);
-                // Skip the root of the tree.
-                assert!(&*descendants.next().unwrap() == self);
-                Ok(QuerySelectorIterator::new(descendants, selectors))
-            },
-        }
+        // SAFETY: traced_node is unrooted, but we have a reference to "self" so it won't be freed.
+        let traced_node = Dom::from_ref(self);
+        let layout_node = unsafe { traced_node.to_layout() };
+        let first_matching_element = ServoLayoutNode::from_layout_js(layout_node)
+            .scope_match_a_selectors_string::<QueryFirst>(document_url, &selectors.str())?;
+
+        Ok(first_matching_element
+            .map(|element| DomRoot::from_ref(unsafe { element.to_layout_js().as_ref() })))
     }
 
     /// <https://dom.spec.whatwg.org/#dom-parentnode-queryselectorall>
+    #[allow(unsafe_code)]
+    #[cfg_attr(crown, allow(crown::unrooted_must_root))]
     pub(crate) fn query_selector_all(&self, selectors: DOMString) -> Fallible<DomRoot<NodeList>> {
-        let window = self.owner_window();
-        let iter = self.query_selector_iter(selectors)?;
-        Ok(NodeList::new_simple_list(&window, iter, CanGc::note()))
+        // > The querySelectorAll(selectors) method steps are to return the static result of running scope-match
+        // > a selectors string selectors against this.
+        let document_url = self.owner_document().url().get_arc();
+
+        // SAFETY: traced_node is unrooted, but we have a reference to "self" so it won't be freed.
+        let traced_node = Dom::from_ref(self);
+        let layout_node = unsafe { traced_node.to_layout() };
+        let matching_elements = ServoLayoutNode::from_layout_js(layout_node)
+            .scope_match_a_selectors_string::<QueryAll>(document_url, &selectors.str())?;
+        let iter = matching_elements
+            .into_iter()
+            .map(|element| DomRoot::from_ref(unsafe { element.to_layout_js().as_ref() }))
+            .map(DomRoot::upcast::<Node>);
+
+        // NodeList::new_simple_list immediately collects the iterator, so we're not leaking LayoutDom
+        // elements here.
+        Ok(NodeList::new_simple_list(
+            &self.owner_window(),
+            iter,
+            CanGc::note(),
+        ))
     }
 
     pub(crate) fn ancestors(&self) -> impl Iterator<Item = DomRoot<Node>> + use<> {

--- a/components/script/dom/node.rs
+++ b/components/script/dom/node.rs
@@ -28,7 +28,7 @@ use layout_api::wrapper_traits::SharedSelection;
 use layout_api::{
     BoxAreaType, CSSPixelRectIterator, GenericLayoutData, HTMLCanvasData, HTMLMediaData,
     LayoutElementType, LayoutNodeType, PhysicalSides, QueryMsg, SVGElementData, StyleData,
-    TrustedNodeAddress,
+    TrustedNodeAddress, with_layout_state,
 };
 use libc::{self, c_void, uintptr_t};
 use malloc_size_of::{MallocSizeOf, MallocSizeOfOps};
@@ -1169,9 +1169,12 @@ impl Node {
 
         // SAFETY: traced_node is unrooted, but we have a reference to "self" so it won't be freed.
         let traced_node = Dom::from_ref(self);
-        let layout_node = unsafe { traced_node.to_layout() };
-        let first_matching_element = ServoLayoutNode::from_layout_js(layout_node)
-            .scope_match_a_selectors_string::<QueryFirst>(document_url, &selectors.str())?;
+
+        let first_matching_element = with_layout_state(|| {
+            let layout_node = unsafe { traced_node.to_layout() };
+            ServoLayoutNode::from_layout_js(layout_node)
+                .scope_match_a_selectors_string::<QueryFirst>(document_url, &selectors.str())
+        })?;
 
         Ok(first_matching_element
             .map(|element| DomRoot::from_ref(unsafe { element.to_layout_js().as_ref() })))
@@ -1187,9 +1190,11 @@ impl Node {
 
         // SAFETY: traced_node is unrooted, but we have a reference to "self" so it won't be freed.
         let traced_node = Dom::from_ref(self);
-        let layout_node = unsafe { traced_node.to_layout() };
-        let matching_elements = ServoLayoutNode::from_layout_js(layout_node)
-            .scope_match_a_selectors_string::<QueryAll>(document_url, &selectors.str())?;
+        let matching_elements = with_layout_state(|| {
+            let layout_node = unsafe { traced_node.to_layout() };
+            ServoLayoutNode::from_layout_js(layout_node)
+                .scope_match_a_selectors_string::<QueryAll>(document_url, &selectors.str())
+        })?;
         let iter = matching_elements
             .into_iter()
             .map(|element| DomRoot::from_ref(unsafe { element.to_layout_js().as_ref() }))

--- a/components/script/layout_dom/document.rs
+++ b/components/script/layout_dom/document.rs
@@ -21,6 +21,7 @@ pub struct ServoLayoutDocument<'dom> {
     document: LayoutDom<'dom, Document>,
 }
 
+use style::values::AtomIdent;
 impl<'ld> ::style::dom::TDocument for ServoLayoutDocument<'ld> {
     type ConcreteNode = ServoLayoutNode<'ld>;
 
@@ -38,6 +39,22 @@ impl<'ld> ::style::dom::TDocument for ServoLayoutDocument<'ld> {
 
     fn shared_lock(&self) -> &StyleSharedRwLock {
         self.document.style_shared_lock()
+    }
+
+    fn elements_with_id<'a>(&self, id: &AtomIdent) -> Result<&'a [ServoLayoutElement<'ld>], ()>
+    where
+        Self: 'a,
+    {
+        let elements_with_id = self.document.elements_with_id(&id.0);
+
+        // SAFETY: ServoLayoutElement is known to have the same layout and alignment as LayoutDom<Element>
+        let result = unsafe {
+            std::slice::from_raw_parts(
+                elements_with_id.as_ptr() as *const ServoLayoutElement<'ld>,
+                elements_with_id.len(),
+            )
+        };
+        Ok(result)
     }
 }
 

--- a/components/script/layout_dom/element.rs
+++ b/components/script/layout_dom/element.rs
@@ -79,6 +79,9 @@ impl<'dom> ServoLayoutElement<'dom> {
     }
 
     /// Returns the interior of this element as a `LayoutDom`.
+    ///
+    /// This method must never be exposed to layout as it returns
+    /// a `LayoutDom`.
     pub(crate) fn to_layout_js(self) -> LayoutDom<'dom, Element> {
         self.element
     }

--- a/components/script/layout_dom/element.rs
+++ b/components/script/layout_dom/element.rs
@@ -57,6 +57,7 @@ use crate::layout_dom::{ServoLayoutNode, ServoShadowRoot, ServoThreadSafeLayoutN
 
 /// A wrapper around elements that ensures layout can only ever access safe properties.
 #[derive(Clone, Copy, Eq, Hash, PartialEq)]
+#[repr(transparent)]
 pub struct ServoLayoutElement<'dom> {
     /// The wrapped private DOM Element.
     element: LayoutDom<'dom, Element>,
@@ -75,6 +76,11 @@ impl fmt::Debug for ServoLayoutElement<'_> {
 impl<'dom> ServoLayoutElement<'dom> {
     pub(super) fn from_layout_js(el: LayoutDom<'dom, Element>) -> Self {
         ServoLayoutElement { element: el }
+    }
+
+    /// Returns the interior of this element as a `LayoutDom`.
+    pub(crate) fn to_layout_js(self) -> LayoutDom<'dom, Element> {
+        self.element
     }
 
     pub(super) fn is_html_element(&self) -> bool {

--- a/components/script/layout_dom/node.rs
+++ b/components/script/layout_dom/node.rs
@@ -107,16 +107,16 @@ impl<'dom> ServoLayoutNode<'dom> {
     }
 
     /// <https://dom.spec.whatwg.org/#scope-match-a-selectors-string>
-    pub(crate) fn scope_match_a_selectors_string<Q>(
+    pub(crate) fn scope_match_a_selectors_string<Query>(
         self,
         document_url: Arc<Url>,
         selector: &str,
-    ) -> Fallible<Q::Output>
+    ) -> Fallible<Query::Output>
     where
-        Q: SelectorQuery<ServoLayoutElement<'dom>>,
-        Q::Output: Default,
+        Query: SelectorQuery<ServoLayoutElement<'dom>>,
+        Query::Output: Default,
     {
-        let mut result = Q::Output::default();
+        let mut result = Query::Output::default();
 
         // Step 1. Let selector be the result of parse a selector selectors.
         let selector_or_error =
@@ -129,7 +129,7 @@ impl<'dom> ServoLayoutNode<'dom> {
 
         // Step 3. Return the result of match a selector against a tree with selector
         // and node’s root using scoping root node.
-        query_selector::<ServoLayoutElement<'dom>, Q>(
+        query_selector::<ServoLayoutElement<'dom>, Query>(
             self,
             &selector_list,
             &mut result,

--- a/components/script/layout_dom/node.rs
+++ b/components/script/layout_dom/node.rs
@@ -19,18 +19,23 @@ use layout_api::{
 };
 use net_traits::image_cache::Image;
 use pixels::ImageMetadata;
+use script_bindings::error::Fallible;
 use selectors::Element as _;
 use servo_arc::Arc;
 use servo_url::ServoUrl;
 use style;
 use style::context::SharedStyleContext;
 use style::dom::{NodeInfo, TElement, TNode, TShadowRoot};
+use style::dom_apis::{MayUseInvalidation, SelectorQuery, query_selector};
 use style::properties::ComputedValues;
-use style::selector_parser::PseudoElement;
+use style::selector_parser::{PseudoElement, SelectorParser};
+use style::stylesheets::UrlExtraData;
+use url::Url;
 
 use super::{
     ServoLayoutDocument, ServoLayoutElement, ServoShadowRoot, ServoThreadSafeLayoutElement,
 };
+use crate::dom::bindings::error::Error;
 use crate::dom::bindings::inheritance::NodeTypeId;
 use crate::dom::bindings::root::LayoutDom;
 use crate::dom::element::{Element, LayoutElementHelpers};
@@ -70,7 +75,7 @@ impl fmt::Debug for ServoLayoutNode<'_> {
 }
 
 impl<'dom> ServoLayoutNode<'dom> {
-    pub(super) fn from_layout_js(n: LayoutDom<'dom, Node>) -> Self {
+    pub(crate) fn from_layout_js(n: LayoutDom<'dom, Node>) -> Self {
         ServoLayoutNode { node: n }
     }
 
@@ -99,6 +104,39 @@ impl<'dom> ServoLayoutNode<'dom> {
             .as_ref()
             .map(LayoutDom::upcast)
             .map(ServoLayoutElement::from_layout_js)
+    }
+
+    /// <https://dom.spec.whatwg.org/#scope-match-a-selectors-string>
+    pub(crate) fn scope_match_a_selectors_string<Q>(
+        self,
+        document_url: Arc<Url>,
+        selector: &str,
+    ) -> Fallible<Q::Output>
+    where
+        Q: SelectorQuery<ServoLayoutElement<'dom>>,
+        Q::Output: Default,
+    {
+        let mut result = Q::Output::default();
+
+        // Step 1. Let selector be the result of parse a selector selectors.
+        let selector_or_error =
+            SelectorParser::parse_author_origin_no_namespace(selector, &UrlExtraData(document_url));
+
+        // Step 2. If selector is failure, then throw a "SyntaxError" DOMException.
+        let Ok(selector_list) = selector_or_error else {
+            return Err(Error::Syntax(None));
+        };
+
+        // Step 3. Return the result of match a selector against a tree with selector
+        // and node’s root using scoping root node.
+        query_selector::<ServoLayoutElement<'dom>, Q>(
+            self,
+            &selector_list,
+            &mut result,
+            MayUseInvalidation::No,
+        );
+
+        Ok(result)
     }
 }
 

--- a/components/shared/layout/lib.rs
+++ b/components/shared/layout/lib.rs
@@ -56,6 +56,7 @@ use style::properties::{ComputedValues, PropertyId};
 use style::selector_parser::{PseudoElement, RestyleDamage, Snapshot};
 use style::str::char_is_whitespace;
 use style::stylesheets::{DocumentStyleSheet, Stylesheet, UrlExtraData};
+use style::thread_state::{self, ThreadState};
 use style::values::computed::Overflow;
 use style_traits::CSSPixel;
 use webrender_api::units::{DeviceIntSize, LayoutPoint, LayoutVector2D};
@@ -868,6 +869,39 @@ impl AnimatingImages {
     pub fn is_empty(&self) -> bool {
         self.node_to_state_map.is_empty()
     }
+}
+
+struct ThreadStateRestorer;
+
+impl ThreadStateRestorer {
+    fn new() -> Self {
+        #[cfg(debug_assertions)]
+        {
+            thread_state::exit(ThreadState::SCRIPT);
+            thread_state::enter(ThreadState::LAYOUT);
+        }
+        Self
+    }
+}
+
+impl Drop for ThreadStateRestorer {
+    fn drop(&mut self) {
+        #[cfg(debug_assertions)]
+        {
+            thread_state::exit(ThreadState::LAYOUT);
+            thread_state::enter(ThreadState::SCRIPT);
+        }
+    }
+}
+
+/// Set up the thread-local state to reflect that layout code is about to run,
+/// then call the provided function.
+/// This must be used when running code that will interact with the DOM tree
+/// through types like `ServoLayoutNode`, `ServoLayoutElement`, and `LayoutDom`,
+/// which have rules about how they must be used from layout worker threads.
+pub fn with_layout_state<R>(f: impl FnOnce() -> R) -> R {
+    let _guard = ThreadStateRestorer::new();
+    f()
 }
 
 #[cfg(test)]

--- a/tests/wpt/meta/css/css-nesting/top-level-is-scope.html.ini
+++ b/tests/wpt/meta/css/css-nesting/top-level-is-scope.html.ini
@@ -1,3 +1,0 @@
-[top-level-is-scope.html]
-  [& matches scoped element only, not everything]
-    expected: FAIL

--- a/tests/wpt/meta/css/css-shadow/host-dom-001.html.ini
+++ b/tests/wpt/meta/css/css-shadow/host-dom-001.html.ini
@@ -1,3 +1,0 @@
-[host-dom-001.html]
-  [CSS Test: :host in DOM APIs]
-    expected: FAIL

--- a/tests/wpt/meta/dom/nodes/ParentNode-querySelector-scope.html.ini
+++ b/tests/wpt/meta/dom/nodes/ParentNode-querySelector-scope.html.ini
@@ -4,9 +4,3 @@
 
   [querySelector]
     expected: FAIL
-
-  [querySelector with :scope]
-    expected: FAIL
-
-  [querySelectorAll with :scope]
-    expected: FAIL


### PR DESCRIPTION
Stylo has ready-to-use apis for `Node::querySelector` and `Node::querySelectorAll`. We currently instead set up our own selector queries, which is neither as correct nor as performant, so this change makes servo use the stylo interfaces instead.

This change contains a fair amount of unsafe code - review with caution!

Notably, this makes the tab component from the astro framework work correctly in servo (https://starlight.astro.build/components/tabs/). I've seen that (broken) component on multiple websites.

Fixes https://github.com/servo/servo/issues/41105
Testing: New tests start to pass