### PR TITLE
devtools: Use actual class name in `ObjectActor`

### DIFF
--- a/components/devtools/actors/console.rs
+++ b/components/devtools/actors/console.rs
@@ -73,7 +73,7 @@ fn console_argument_to_value(argument: ConsoleArgument, registry: &ActorRegistry
             // Create a new actor for the object.
             // These are currently never cleaned up, and we make no attempt at re-using the same actor
             // if the same object is logged repeatedly.
-            let actor = ObjectActor::register(registry, None);
+            let actor = ObjectActor::register(registry, None, object.class.clone());
 
             #[derive(Serialize)]
             struct PropertyDescriptor {
@@ -380,9 +380,8 @@ impl ConsoleActor {
             },
             StringValue(s) => Value::String(s),
             ActorValue { class, uuid } => {
-                // TODO: Make initial ActorValue message include these properties?
                 let mut m = Map::new();
-                let actor = ObjectActor::register(registry, Some(uuid));
+                let actor = ObjectActor::register(registry, Some(uuid), class.clone());
 
                 m.insert("type".to_owned(), Value::String("object".to_owned()));
                 m.insert("class".to_owned(), Value::String(class));

--- a/components/devtools/actors/frame.rs
+++ b/components/devtools/actors/frame.rs
@@ -104,7 +104,7 @@ impl FrameActor {
         source_actor: String,
         frame_result: FrameInfo,
     ) -> String {
-        let object_actor = ObjectActor::register(registry, None);
+        let object_actor = ObjectActor::register(registry, None, "Object".to_owned());
 
         let name = registry.new_name::<Self>();
         let actor = Self {

--- a/components/devtools/actors/object.rs
+++ b/components/devtools/actors/object.rs
@@ -62,6 +62,7 @@ pub(crate) struct ObjectActorMsg {
 pub(crate) struct ObjectActor {
     name: String,
     _uuid: Option<String>,
+    class: String,
 }
 
 impl Actor for ObjectActor {
@@ -126,12 +127,13 @@ impl Actor for ObjectActor {
 }
 
 impl ObjectActor {
-    pub fn register(registry: &ActorRegistry, uuid: Option<String>) -> String {
+    pub fn register(registry: &ActorRegistry, uuid: Option<String>, class: String) -> String {
         let Some(uuid) = uuid else {
             let name = registry.new_name::<Self>();
             let actor = ObjectActor {
                 name: name.clone(),
                 _uuid: None,
+                class,
             };
             registry.register(actor);
             return name;
@@ -141,6 +143,7 @@ impl ObjectActor {
             let actor = ObjectActor {
                 name: name.clone(),
                 _uuid: Some(uuid.clone()),
+                class,
             };
 
             registry.register_script_actor(uuid, name.clone());
@@ -155,11 +158,10 @@ impl ObjectActor {
 
 impl ActorEncode<ObjectActorMsg> for ObjectActor {
     fn encode(&self, _: &ActorRegistry) -> ObjectActorMsg {
-        // TODO: Review hardcoded values here
         ObjectActorMsg {
             actor: self.name(),
             type_: "object".into(),
-            class: "Window".into(),
+            class: self.class.clone(),
             own_property_length: 0,
             extensible: true,
             frozen: false,


### PR DESCRIPTION
Class name in `ObjectActor` was harcoded to `Window`, which is wrong. This change removes the hardcoded value and replaces it with actual class name.

**Before:**
<img width="320" height="163" alt="image" src="https://github.com/user-attachments/assets/f94df58a-5309-4fd1-bb02-aa06dfeb32c3" />


**After:**
<img width="353" height="138" alt="image" src="https://github.com/user-attachments/assets/ad129676-8c3d-48e2-a543-1447c75c40f0" />

Testing: Existing test passes
Fixes: part of #36027 
Depends on https://github.com/servo/servo/pull/42936