### PR TITLE
OHOS CI: Fix parsefromstring

### DIFF
--- a/support/hitrace-bencher/runs.json
+++ b/support/hitrace-bencher/runs.json
@@ -124,7 +124,8 @@
             {
                 "name": "",
                 "match_str": "parsefromstring",
-                "no_unit_conversion": true
+                "no_unit_conversion": true,
+                "point_filter_type": "Largest"
             }
         ]
     }


### PR DESCRIPTION
ParseFromString currently complains that it matches multiple trace lines. The reason for that is a bit unclear as it should only produce one alert. Local testing shows that it produces multiple (even for one run). This should at least give us the metric back.

Testing: This is currently untested. As it is a small CI change that can't break a broken test it should be fine.
Fixes: https://github.com/servo/servo/issues/42992
