### PR TITLE
devtools: Implement function name preview in debugger popup

### DIFF
--- a/components/devtools/actors/console.rs
+++ b/components/devtools/actors/console.rs
@@ -379,7 +379,7 @@ impl ConsoleActor {
                 }
             },
             StringValue(s) => Value::String(s),
-            ActorValue { class, uuid } => {
+            ActorValue { class, uuid, name } => {
                 let mut m = Map::new();
                 let actor = ObjectActor::register(registry, Some(uuid), class.clone());
 
@@ -389,6 +389,9 @@ impl ConsoleActor {
                 m.insert("extensible".to_owned(), Value::Bool(true));
                 m.insert("frozen".to_owned(), Value::Bool(false));
                 m.insert("sealed".to_owned(), Value::Bool(false));
+                if let Some(name) = name {
+                    m.insert("name".to_owned(), Value::String(name));
+                }
                 Value::Object(m)
             },
         };

--- a/components/script/devtools.rs
+++ b/components/script/devtools.rs
@@ -169,6 +169,7 @@ pub(crate) fn handle_evaluate_js(
             EvaluateJSReplyValue::ActorValue {
                 class: class_name,
                 uuid: Uuid::new_v4().to_string(),
+                name: None,
             }
         }
     };

--- a/components/script/dom/debuggerglobalscope.rs
+++ b/components/script/dom/debuggerglobalscope.rs
@@ -443,9 +443,15 @@ impl DebuggerGlobalScopeMethods<crate::DomTypeHolder> for DebuggerGlobalScope {
                     .and_then(|opt| opt.as_ref())
                     .map(|s| s.to_string())
                     .unwrap_or_else(|| "Object".to_string());
+                let name = result
+                    .name
+                    .as_ref()
+                    .and_then(|opt| opt.as_ref())
+                    .map(|s| s.to_string());
                 EvaluateJSReplyValue::ActorValue {
                     class,
                     uuid: uuid::Uuid::new_v4().to_string(),
+                    name,
                 }
             },
             _ => unreachable!(),

--- a/components/script_bindings/webidls/DebuggerEvalEvent.webidl
+++ b/components/script_bindings/webidls/DebuggerEvalEvent.webidl
@@ -37,5 +37,6 @@ dictionary EvalResultValue {
     // A string naming the ECMAScript [[Class]] of the referent.
     // <https://firefox-source-docs.mozilla.org/js/Debugger/Debugger.Object.html#accessor-properties-of-the-debugger-object-prototype>
     DOMString? objectClass;
+    DOMString? name;
     boolean? hasException;
 };

--- a/components/shared/devtools/lib.rs
+++ b/components/shared/devtools/lib.rs
@@ -156,7 +156,11 @@ pub enum EvaluateJSReplyValue {
     BooleanValue(bool),
     NumberValue(f64),
     StringValue(String),
-    ActorValue { class: String, uuid: String },
+    ActorValue {
+        class: String,
+        uuid: String,
+        name: Option<String>,
+    },
 }
 
 #[derive(Debug, Deserialize, Serialize)]

--- a/resources/debugger.js
+++ b/resources/debugger.js
@@ -91,6 +91,13 @@ function createValueResult(value) {
             }
             // Debugger.Object - use the `class` accessor property
             // <https://firefox-source-docs.mozilla.org/js/Debugger/Debugger.Object.html>
+            if (value.callable) {
+                return {
+                    valueType: "object",
+                    objectClass: value.class,
+                    name: value.name
+                };
+            }
             return { valueType: "object", objectClass: value.class };
         default:
             return { valueType: "string", stringValue: String(value) };


### PR DESCRIPTION
The debugger preview popup was showing `function ()` for all functions. This change implements support to show function name in the debugger preview popup.

This is initial work towards showing other values in debugger preview popup!

**Before:**
<img width="306" height="118" alt="image" src="https://github.com/user-attachments/assets/5c090820-4862-4234-a6ea-50666f83c192" />


**After:**
<img width="282" height="128" alt="image" src="https://github.com/user-attachments/assets/869a0122-c9da-4098-bb77-8a1110c29d48" />

<img width="286" height="137" alt="image" src="https://github.com/user-attachments/assets/8655a8cb-bbd3-4b80-a297-daac58a6337f" />


Testing: Existing test passes
Fixes: Part of #36027 