### PR TITLE
Fix ohos.yml bencher file size on main

### DIFF
--- a/.github/workflows/ohos.yml
+++ b/.github/workflows/ohos.yml
@@ -155,7 +155,7 @@ jobs:
     with:
       target: ohos-${{ matrix.target }}
       profile: ${{ inputs.profile }}
-      compressed-file-path: ${{ inputs.profile }}-binary-ohos-${{ matrix.target }}/servoshell-default-${{ needs.build.outputs.signed && 'signed' || 'unsigned' }}.hap
+      compressed-file-path: ${{ inputs.profile }}-binary-ohos-${{ matrix.target }}/servoshell-default-${{ needs.build-openharmony.outputs.signed && 'signed' || 'unsigned' }}.hap
       binary-path: libs/${{ matrix.target == 'aarch64-unknown-linux-ohos' && 'arm64-v8a' || matrix.target == 'x86_64-unknown-linux-ohos' && 'x86_64' }}/libservoshell.so
       file-size: true
       speedometer: false


### PR DESCRIPTION
Renaming the job in #42929 silently broke the evaluation here.

Testing: Can only be tested on main / in priviledge contexts / otherwise the unsigned binary is anyway built.
Fixes: ohos bencher failing on main (since the wrong binary name is chosen)
