### PR TITLE
servoshell: Align console behavior for shell and double‑click launches

### DIFF
--- a/ports/servoshell/main.rs
+++ b/ports/servoshell/main.rs
@@ -14,24 +14,21 @@
 //!
 //! [winit]: https://github.com/rust-windowing/winit
 
-// Normally, rust uses the "Console" Windows subsystem, which pops up a console
-// when running an application. Switching to the "Windows" subsystem prevents
-// this, but also hides debugging output. We mitigate this by attempting to
-// attach to the console of the parent process.
-#![windows_subsystem = "windows"]
-
 #[cfg(target_os = "windows")]
 use windows_sys::Win32::System::Console;
 
 fn main() {
     #[cfg(target_os = "windows")]
     // SAFETY: No safety related side effects or requirements.
+    // See <https://learn.microsoft.com/en-au/windows/console/freeconsole#remarks>
     unsafe {
-        // When servo is started from the commandline, we still want output
-        // to be printed. Due to us using the `windows` subsystem, this doesn't
-        // work out-of-the-box, and we need to manually attempt to attach to
-        // the console of the parent process. If servo was not started from
-        // the commandline, then the call will fail, which we can ignore.
+        // Free the console pop-up when started by double clicking.
+        // If started from the command line, nothing would happen.
+        let _ = Console::FreeConsole();
+        // Try to attach to the console of the parent process.
+        // If servo was started from the command line,
+        // this would allow continous stdout/stderr output to be seen in the console.
+        // Otherwise, the call will fail, which we can ignore.
         let _result = Console::AttachConsole(Console::ATTACH_PARENT_PROCESS);
     }
     cfg_if::cfg_if! {


### PR DESCRIPTION
In addition to issues fixed, this also allows: seeing the follow-up stdout/stderr, if started executable from console.

Testing: Manually tested, started both from GUI double-click and console. We still maintain the no-popup behaviour when started from GUI.
Fixes: #40996
