### PR TITLE
base: Deterministic AccessKit tree UUID format for pipelines

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7389,6 +7389,7 @@ dependencies = [
 name = "servo-base"
 version = "0.0.1"
 dependencies = [
+ "accesskit",
  "crossbeam-channel",
  "ipc-channel",
  "libc",

--- a/components/shared/base/Cargo.toml
+++ b/components/shared/base/Cargo.toml
@@ -14,6 +14,7 @@ test = true
 doctest = false
 
 [dependencies]
+accesskit = { workspace = true }
 crossbeam-channel = { workspace = true }
 ipc-channel = { workspace = true }
 malloc_size_of = { workspace = true }

--- a/components/shared/base/id.rs
+++ b/components/shared/base/id.rs
@@ -13,6 +13,7 @@ use std::num::NonZeroU32;
 use std::sync::atomic::{AtomicU32, Ordering};
 use std::sync::{Arc, LazyLock};
 
+use accesskit::{TreeId, Uuid};
 use malloc_size_of::MallocSizeOfOps;
 use malloc_size_of_derive::MallocSizeOf;
 use parking_lot::Mutex;
@@ -259,6 +260,38 @@ impl PipelineId {
     pub fn root_scroll_id(&self) -> webrender_api::ExternalScrollId {
         ExternalScrollId(0, self.into())
     }
+}
+
+impl From<PipelineId> for TreeId {
+    /// Return the AccessKit [`TreeId`] for this [`PipelineId`], assuming it represents a document.
+    ///
+    /// This is a pure function of the namespace id and index values, allowing us to graft pipelines
+    /// into `WebView`s (or other pipelines) without IPC, but it also means you can’t have multiple
+    /// instances of [`Servo`] in a single application, because the tree ids would conflict.
+    ///
+    /// [`Servo`]: https://doc.servo.org/servo/struct.Servo.html
+    fn from(pipeline_id: PipelineId) -> TreeId {
+        const PIPELINE_IDS: Uuid = Uuid::from_u128(0x429419c0_3277_47eb_8d31_7573b97621ee);
+        let with_namespace_id =
+            Uuid::new_v5(&PIPELINE_IDS, &pipeline_id.namespace_id.0.to_be_bytes());
+        let with_index = Uuid::new_v5(&with_namespace_id, &pipeline_id.index.0.get().to_be_bytes());
+        TreeId(with_index)
+    }
+}
+
+#[cfg(test)]
+#[test]
+fn test_pipeline_id_to_accesskit_tree_id() {
+    let namespace_id = PipelineNamespaceId(1);
+    let index = Index::new(1).expect("Guaranteed by argument");
+    let pipeline_id = PipelineId {
+        namespace_id,
+        index,
+    };
+    assert_eq!(
+        TreeId::from(pipeline_id),
+        TreeId(Uuid::from_u128(0x879211fb_8799_5492_9a31_95a35c05a192))
+    );
 }
 
 impl From<WebRenderPipelineId> for PipelineId {


### PR DESCRIPTION
each webview will have an AccessKit subtree, and each pipeline representing a document will have an AccessKit subtree for its layout. but to graft the subtree of a pipeline into that of a webview (for top-level documents) or another pipeline (for documents in iframes etc), the parent tree needs to know the [TreeId](https://docs.rs/accesskit/0.24.0/accesskit/struct.TreeId.html) of the child tree.

this is annoying for pipelines, because they run in a separate thread (or process) to the constellation, and they may run in a separate script thread (or web content process) to other pipelines. if the pipeline generates a random (UUIDv4) TreeId as internal state, it has to communicate that to the constellation (or parent pipeline) over IPC, which takes time and makes it harder for us to obey AccessKit’s subtree invariants (notably, the subtree must not send updates before a graft node is created for it in some other subtree).

this patch defines a deterministic and pure conversion from PipelineId to a UUIDv5-based TreeId, allowing anyone that knows a PipelineId to derive its TreeId. one consequence of this approach is that it precludes having multiple instances of [Servo](https://doc.servo.org/servo/struct.Servo.html) in a single application, but i’m not sure that was an intended use case (or even possible).

Testing: this patch includes a unit test
Fixes: part of #4344, extracted from our work in #42338

<img width="521" height="400" alt="grafts drawio" src="https://github.com/user-attachments/assets/39efa426-ba21-41dc-874b-c3e4fcb17593" />