### PR TITLE
constellation: Track top-level pipeline changes in webviews

### DIFF
--- a/components/constellation/constellation.rs
+++ b/components/constellation/constellation.rs
@@ -3123,7 +3123,12 @@ where
         // its focused browsing context to be itself.
         self.webviews.insert(
             webview_id,
-            ConstellationWebView::new(webview_id, browsing_context_id, user_content_manager_id),
+            ConstellationWebView::new(
+                webview_id,
+                pipeline_id,
+                browsing_context_id,
+                user_content_manager_id,
+            ),
         );
 
         // https://html.spec.whatwg.org/multipage/#creating-a-new-browsing-context-group
@@ -3512,6 +3517,7 @@ where
             new_webview_id,
             ConstellationWebView::new(
                 new_webview_id,
+                new_pipeline_id,
                 new_browsing_context_id,
                 user_content_manager_id,
             ),
@@ -5634,6 +5640,12 @@ where
         // with low-resource scenarios.
         let browsing_context_id = BrowsingContextId::from(webview_id);
         if let Some(frame_tree) = self.browsing_context_to_sendable(browsing_context_id) {
+            if let Some(webview) = self.webviews.get_mut(&webview_id) {
+                if frame_tree.pipeline.id != webview.active_top_level_pipeline_id {
+                    webview.active_top_level_pipeline_id = frame_tree.pipeline.id;
+                }
+            }
+
             debug!("{}: Sending frame tree", browsing_context_id);
             self.paint_proxy
                 .send(PaintMessage::SetFrameTreeForWebView(webview_id, frame_tree));

--- a/components/constellation/constellation_webview.rs
+++ b/components/constellation/constellation_webview.rs
@@ -21,6 +21,9 @@ pub(crate) struct ConstellationWebView {
     /// The [`WebViewId`] of this [`ConstellationWebView`].
     webview_id: WebViewId,
 
+    /// The [`PipelineId`] of the currently active pipeline at the top level of this WebView.
+    pub active_top_level_pipeline_id: PipelineId,
+
     /// The currently focused browsing context in this webview for key events.
     /// The focused pipeline is the current entry of the focused browsing
     /// context.
@@ -50,12 +53,14 @@ pub(crate) struct ConstellationWebView {
 impl ConstellationWebView {
     pub(crate) fn new(
         webview_id: WebViewId,
+        active_top_level_pipeline_id: PipelineId,
         focused_browsing_context_id: BrowsingContextId,
         user_content_manager_id: Option<UserContentManagerId>,
     ) -> Self {
         Self {
             webview_id,
             user_content_manager_id,
+            active_top_level_pipeline_id,
             focused_browsing_context_id,
             hovered_browsing_context_id: None,
             last_mouse_move_point: Default::default(),


### PR DESCRIPTION
whenever a browsing context loads a new document or otherwise navigates, the constellation sends a new frame tree to the compositor, giving us a nice, relatively central way to detect when we may need to update the graft node in a webview’s AccessKit subtree. but we only want to update that graft node when the pipeline in its *top-level* browsing context has changed, not just when the pipeline in *any* of its browsing contexts has changed.

this patch adds a field to the ConstellationWebView that tracks the active top-level pipeline for each webview, allowing us to check when a set_frame_tree_for_webview() call actually involves navigation in the top-level browsing context.

Testing: will be covered by accessibility tree tests in a later patch
Fixes: part of #4344, extracted from our work in #42338