### PR TITLE
webdriver: Do nothing for `dispatch_pause_action`

### DIFF
--- a/components/webdriver_server/actions.rs
+++ b/components/webdriver_server/actions.rs
@@ -315,11 +315,9 @@ impl Handler {
     }
 
     /// <https://w3c.github.io/webdriver/#dfn-dispatch-a-pause-action>
-    fn dispatch_pause_action(&mut self, input_id: &str) {
-        self.input_state_table_mut()
-            .entry(input_id.to_string())
-            .or_insert(InputSourceState::Null);
-    }
+    /// This is a dummy action. The sole effect of the action is that
+    /// its `duration` parameter may decide "tick duration".
+    fn dispatch_pause_action(&mut self, _input_id: &str) {}
 
     /// <https://w3c.github.io/webdriver/#dfn-dispatch-a-keydown-action>
     fn dispatch_keydown_action(&mut self, input_id: &str, action: &KeyDownAction) {


### PR DESCRIPTION
We should not try to create a input id here: it is already done in 
https://w3c.github.io/webdriver/#dfn-process-an-input-source-action-sequence

The sole effect of the action is that its `duration` parameter may decide "tick duration".