### PR TITLE
devtools: implement listing all frames

### DIFF
--- a/components/devtools/actors/browsing_context.rs
+++ b/components/devtools/actors/browsing_context.rs
@@ -228,7 +228,11 @@ impl BrowsingContextActor {
 
         let tabdesc = TabDescriptorActor::new(actors, name.clone(), is_top_level_global);
 
-        let thread = ThreadActor::new(actors.new_name::<ThreadActor>(), script_sender.clone());
+        let thread = ThreadActor::new(
+            actors.new_name::<ThreadActor>(),
+            script_sender.clone(),
+            Some(name.clone()),
+        );
 
         let watcher = WatcherActor::new(
             actors,

--- a/components/devtools/actors/thread.rs
+++ b/components/devtools/actors/thread.rs
@@ -16,7 +16,7 @@ use crate::actor::{Actor, ActorError, ActorRegistry};
 use crate::actors::frame::{FrameActor, FrameActorMsg};
 use crate::actors::pause::PauseActor;
 use crate::protocol::{ClientRequest, JsonPacketStream};
-use crate::{EmptyReplyMsg, StreamId};
+use crate::{BrowsingContextActor, EmptyReplyMsg, StreamId};
 
 #[derive(Serialize)]
 #[serde(rename_all = "camelCase")]
@@ -90,6 +90,12 @@ struct ResumeRequest {
     frame_actor_id: Option<String>,
 }
 
+#[derive(Deserialize, Debug)]
+struct FramesRequest {
+    start: u32,
+    count: u32,
+}
+
 impl ResumeRequest {
     fn get_type(&self) -> Option<String> {
         let resume_limit = self.resume_limit.as_ref()?;
@@ -105,15 +111,21 @@ pub(crate) struct ThreadActor {
     pub source_manager: SourceManager,
     script_sender: GenericSender<DevtoolScriptControlMsg>,
     pub frames: AtomicRefCell<HashSet<String>>,
+    browsing_context: Option<String>,
 }
 
 impl ThreadActor {
-    pub fn new(name: String, script_sender: GenericSender<DevtoolScriptControlMsg>) -> ThreadActor {
+    pub fn new(
+        name: String,
+        script_sender: GenericSender<DevtoolScriptControlMsg>,
+        browsing_context: Option<String>,
+    ) -> ThreadActor {
         ThreadActor {
             name: name.clone(),
             source_manager: SourceManager::new(),
             script_sender,
             frames: Default::default(),
+            browsing_context,
         }
     }
 }
@@ -202,6 +214,21 @@ impl Actor for ThreadActor {
             },
 
             "frames" => {
+                let Some(ref browsing_context) = self.browsing_context else {
+                    return Err(ActorError::Internal);
+                };
+                let browsing_context = registry.find::<BrowsingContextActor>(browsing_context);
+
+                let frames: FramesRequest =
+                    serde_json::from_value(msg.clone().into()).map_err(|_| ActorError::Internal)?;
+
+                self.script_sender
+                    .send(DevtoolScriptControlMsg::ListFrames(
+                        browsing_context.pipeline_id(),
+                        frames.start,
+                        frames.count,
+                    ))
+                    .map_err(|_| ActorError::Internal)?;
                 // TODO: This should get the youngest frame and its parents from debugger.js
                 // self.frames is not needed
                 // Frame actors should be registered here

--- a/components/devtools/lib.rs
+++ b/components/devtools/lib.rs
@@ -471,7 +471,11 @@ impl DevtoolsInstance {
             assert!(self.pipelines.contains_key(&pipeline_id));
             assert!(self.browsing_contexts.contains_key(&browsing_context_id));
 
-            let thread = ThreadActor::new(actors.new_name::<ThreadActor>(), script_sender.clone());
+            let thread = ThreadActor::new(
+                actors.new_name::<ThreadActor>(),
+                script_sender.clone(),
+                None,
+            );
             let thread_name = thread.name();
             actors.register(thread);
 

--- a/components/script/dom/debuggerframeevent.rs
+++ b/components/script/dom/debuggerframeevent.rs
@@ -1,0 +1,72 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+use std::fmt::Debug;
+
+use dom_struct::dom_struct;
+
+use crate::dom::bindings::codegen::Bindings::DebuggerFrameEventBinding::DebuggerFrameEventMethods;
+use crate::dom::bindings::codegen::Bindings::EventBinding::Event_Binding::EventMethods;
+use crate::dom::bindings::reflector::reflect_dom_object;
+use crate::dom::bindings::root::{Dom, DomRoot};
+use crate::dom::event::Event;
+use crate::dom::types::{GlobalScope, PipelineId};
+use crate::script_runtime::CanGc;
+
+#[dom_struct]
+/// Event for Rust → JS calls in [`crate::dom::DebuggerGlobalScope`].
+pub(crate) struct DebuggerFrameEvent {
+    event: Event,
+    pipeline_id: Dom<PipelineId>,
+    start: u32,
+    count: u32,
+}
+
+impl DebuggerFrameEvent {
+    pub(crate) fn new(
+        debugger_global: &GlobalScope,
+        pipeline_id: &PipelineId,
+        start: u32,
+        count: u32,
+        can_gc: CanGc,
+    ) -> DomRoot<Self> {
+        let result = Box::new(Self {
+            event: Event::new_inherited(),
+            pipeline_id: Dom::from_ref(pipeline_id),
+            start,
+            count,
+        });
+        let result = reflect_dom_object(result, debugger_global, can_gc);
+        result.event.init_event("frames".into(), false, false);
+
+        result
+    }
+}
+
+impl DebuggerFrameEventMethods<crate::DomTypeHolder> for DebuggerFrameEvent {
+    // check-tidy: no specs after this line
+    fn PipelineId(
+        &self,
+    ) -> DomRoot<<crate::DomTypeHolder as script_bindings::DomTypes>::PipelineId> {
+        DomRoot::from_ref(&self.pipeline_id)
+    }
+
+    fn Start(&self) -> u32 {
+        self.start
+    }
+
+    fn Count(&self) -> u32 {
+        self.count
+    }
+
+    fn IsTrusted(&self) -> bool {
+        self.event.IsTrusted()
+    }
+}
+
+impl Debug for DebuggerFrameEvent {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("DebuggerFrameEvent").finish()
+    }
+}

--- a/components/script/dom/debuggerglobalscope.rs
+++ b/components/script/dom/debuggerglobalscope.rs
@@ -37,6 +37,7 @@ use crate::dom::bindings::inheritance::Castable;
 use crate::dom::bindings::root::DomRoot;
 use crate::dom::bindings::utils::define_all_exposed_interfaces;
 use crate::dom::debuggerclearbreakpointevent::DebuggerClearBreakpointEvent;
+use crate::dom::debuggerframeevent::DebuggerFrameEvent;
 use crate::dom::debuggerinterruptevent::DebuggerInterruptEvent;
 use crate::dom::debuggerresumeevent::DebuggerResumeEvent;
 use crate::dom::debuggersetbreakpointevent::DebuggerSetBreakpointEvent;
@@ -244,6 +245,29 @@ impl DebuggerGlobalScope {
         assert!(
             event.fire(self.upcast(), can_gc),
             "Guaranteed by DebuggerInterruptEvent::new"
+        );
+    }
+
+    pub(crate) fn fire_list_frames(
+        &self,
+        pipeline_id: PipelineId,
+        start: u32,
+        count: u32,
+        can_gc: CanGc,
+    ) {
+        let _realm = enter_realm(self);
+        let pipeline_id =
+            crate::dom::pipelineid::PipelineId::new(self.upcast(), pipeline_id, can_gc);
+        let event = DomRoot::upcast::<Event>(DebuggerFrameEvent::new(
+            self.upcast(),
+            &pipeline_id,
+            start,
+            count,
+            can_gc,
+        ));
+        assert!(
+            event.fire(self.upcast(), can_gc),
+            "Guaranteed by DebuggerFrameEvent::new"
         );
     }
 
@@ -517,5 +541,9 @@ impl DebuggerGlobalScopeMethods<crate::DomTypeHolder> for DebuggerGlobalScope {
         let _ = chan.send(msg);
 
         rx.recv().ok().map(DOMString::from)
+    }
+
+    fn ListFramesResult(&self, _frame_actor_ids: Vec<DOMString>) {
+        log::debug!("Not implemented yet")
     }
 }

--- a/components/script/dom/mod.rs
+++ b/components/script/dom/mod.rs
@@ -257,6 +257,7 @@ pub(crate) mod datatransferitemlist;
 pub(crate) mod debuggeradddebuggeeevent;
 pub(crate) mod debuggerclearbreakpointevent;
 pub(crate) mod debuggerevalevent;
+pub(crate) mod debuggerframeevent;
 pub(crate) mod debuggergetpossiblebreakpointsevent;
 pub(crate) mod debuggerglobalscope;
 pub(crate) mod debuggerinterruptevent;

--- a/components/script/script_thread.rs
+++ b/components/script/script_thread.rs
@@ -2285,6 +2285,14 @@ impl ScriptThread {
             DevtoolScriptControlMsg::Interrupt => {
                 self.debugger_global.fire_interrupt(CanGc::from_cx(cx));
             },
+            DevtoolScriptControlMsg::ListFrames(pipeline_id, start, count) => {
+                self.debugger_global.fire_list_frames(
+                    pipeline_id,
+                    start,
+                    count,
+                    CanGc::from_cx(cx),
+                );
+            },
             DevtoolScriptControlMsg::Resume(resume_limit_type, frame_actor_id) => {
                 self.debugger_global.fire_resume(
                     resume_limit_type,

--- a/components/script_bindings/webidls/DebuggerFrameEvent.webidl
+++ b/components/script_bindings/webidls/DebuggerFrameEvent.webidl
@@ -1,0 +1,20 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+// This interface is entirely internal to Servo, and should not be accessible to
+// web pages.
+[Exposed=DebuggerGlobalScope]
+interface DebuggerFrameEvent : Event {
+    readonly attribute PipelineId pipelineId;
+    readonly attribute unsigned long start;
+    readonly attribute unsigned long count;
+};
+
+partial interface DebuggerGlobalScope {
+    undefined listFramesResult(
+        sequence<DOMString> frameActorId
+    );
+};
+
+

--- a/components/shared/devtools/lib.rs
+++ b/components/shared/devtools/lib.rs
@@ -349,6 +349,7 @@ pub enum DevtoolScriptControlMsg {
     ClearBreakpoint(u32, u32, u32),
     Interrupt,
     Resume(Option<String>, Option<String>),
+    ListFrames(PipelineId, u32, u32),
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize, MallocSizeOf)]

--- a/resources/debugger.js
+++ b/resources/debugger.js
@@ -148,17 +148,7 @@ addEventListener("getPossibleBreakpoints", event => {
     getPossibleBreakpointsResult(event, result);
 });
 
-function handlePauseAndRespond(frame, pauseReason) {
-    dbg.onEnterFrame = undefined;
-    clearSteppingHooks();
-
-    // Get the pipeline ID for this debuggee
-    const pipelineId = debuggeesToPipelineIds.get(frame.script.global);
-    if (!pipelineId) {
-        console.error("[debugger] No pipeline ID for frame's global");
-        return undefined;
-    }
-
+function createFrameActor(frame, pipelineId) {
     let frameActorId = findKeyByValue(frameActorsToFrames, frame);
     if (!frameActorId) {
         // TODO: Check if we already have an actor for this frame
@@ -180,6 +170,22 @@ function handlePauseAndRespond(frame, pauseReason) {
         frameActorsToFrames.set(frameActorId, frame);
     }
 
+    return frameActorId;
+}
+
+function handlePauseAndRespond(frame, pauseReason) {
+    dbg.onEnterFrame = undefined;
+    clearSteppingHooks();
+
+    // Get the pipeline ID for this debuggee
+    const pipelineId = debuggeesToPipelineIds.get(frame.script.global);
+    if (!pipelineId) {
+        console.error("[debugger] No pipeline ID for frame's global");
+        return undefined;
+    }
+
+    let frameActorId = createFrameActor(frame, pipelineId);
+
     // <https://firefox-source-docs.mozilla.org/js/Debugger/Debugger.Script.html#getoffsetmetadata-offset>
     const offset = frame.offset;
     const offsetMetadata = frame.script.getOffsetMetadata(offset);
@@ -199,6 +205,46 @@ function handlePauseAndRespond(frame, pauseReason) {
     // <https://firefox-source-docs.mozilla.org/js/Debugger/Conventions.html#resumption-values>
     // Return undefined to continue execution normally after resume.
     return undefined;
+}
+
+addEventListener("frames", event => {
+    const {pipelineId, start, count} = event;
+    let frameList = handleListFrames(pipelineId, start, count);
+
+    listFramesResult(frameList);
+})
+
+// <https://searchfox.org/firefox-main/source/devtools/server/actors/thread.js#1425>
+function handleListFrames(pipelineId, start, count) {
+    let frame = dbg.getNewestFrame()
+
+    const walkToParentFrame = () => {
+        if (!frame) {
+            return;
+        }
+
+        const currentFrame = frame;
+        frame = null;
+
+        if (currentFrame.older) {
+            frame = currentFrame.older;
+        }
+    }
+
+    let i = 0;
+    while (frame && i < start) {
+      walkToParentFrame();
+      i++;
+    }
+
+    // Return count frames, or all remaining frames if count is not defined.
+    const frames = [];
+    for (; frame && (!count || i < start + count); i++, walkToParentFrame()) {
+      const frameActorId = createFrameActor(frame, pipelineId);
+      frames.push(frameActorId);
+    }
+
+    return frames;
 }
 
 addEventListener("setBreakpoint", event => {


### PR DESCRIPTION
This change implements listing all frames from youngest to oldest. This is in order to send correct frame message from thread actor

This is needed for our upcoming work!

Testing: Current tests are passing + manual test
Fixes: part of #36027 
