### PR TITLE
script: Fully implement delete_the_selection

### DIFF
--- a/components/script/dom/document.rs
+++ b/components/script/dom/document.rs
@@ -6480,17 +6480,17 @@ impl DocumentMethods<crate::DomTypeHolder> for Document {
     /// <https://w3c.github.io/editing/docs/execCommand/#execcommand()>
     fn ExecCommand(
         &self,
+        cx: &mut js::context::JSContext,
         command_id: DOMString,
         _show_ui: bool,
         value: TrustedHTMLOrString,
-        can_gc: CanGc,
     ) -> Fallible<bool> {
         let value = if command_id == "insertHTML" {
             TrustedHTML::get_trusted_script_compliant_string(
                 self.window.as_global_scope(),
                 value,
                 "Document execCommand",
-                can_gc,
+                CanGc::from_cx(cx),
             )?
         } else {
             match value {
@@ -6499,13 +6499,13 @@ impl DocumentMethods<crate::DomTypeHolder> for Document {
             }
         };
 
-        Ok(self.exec_command_for_command_id(command_id, value, can_gc))
+        Ok(self.exec_command_for_command_id(cx, command_id, value))
     }
 
     /// <https://w3c.github.io/editing/docs/execCommand/#querycommandenabled()>
-    fn QueryCommandEnabled(&self, command_id: DOMString, can_gc: CanGc) -> bool {
+    fn QueryCommandEnabled(&self, cx: &mut js::context::JSContext, command_id: DOMString) -> bool {
         // Step 2. Return true if command is both supported and enabled, false otherwise.
-        self.check_support_and_enabled(command_id, can_gc).is_some()
+        self.check_support_and_enabled(cx, command_id).is_some()
     }
 
     /// <https://w3c.github.io/editing/docs/execCommand/#querycommandsupported()>

--- a/components/script/dom/execcommand/basecommand.rs
+++ b/components/script/dom/execcommand/basecommand.rs
@@ -22,5 +22,10 @@ pub(crate) trait BaseCommand {
     }
 
     /// <https://w3c.github.io/editing/docs/execCommand/#action>
-    fn execute(&self, selection: &Selection, value: DOMString) -> bool;
+    fn execute(
+        &self,
+        cx: &mut js::context::JSContext,
+        selection: &Selection,
+        value: DOMString,
+    ) -> bool;
 }

--- a/components/script/dom/execcommand/commands/delete.rs
+++ b/components/script/dom/execcommand/commands/delete.rs
@@ -2,39 +2,160 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
+use script_bindings::inheritance::Castable;
+
+use crate::dom::bindings::codegen::Bindings::NodeBinding::NodeMethods;
+use crate::dom::bindings::codegen::Bindings::SelectionBinding::SelectionMethods;
 use crate::dom::bindings::str::DOMString;
 use crate::dom::execcommand::basecommand::BaseCommand;
-use crate::dom::execcommand::contenteditable::SelectionExecCommandSupport;
+use crate::dom::execcommand::contenteditable::{
+    NodeExecCommandSupport, SelectionExecCommandSupport,
+};
+use crate::dom::html::htmlanchorelement::HTMLAnchorElement;
+use crate::dom::html::htmlbrelement::HTMLBRElement;
+use crate::dom::html::htmlhrelement::HTMLHRElement;
+use crate::dom::html::htmlimageelement::HTMLImageElement;
 use crate::dom::selection::Selection;
+use crate::dom::text::Text;
+use crate::script_runtime::CanGc;
 
 pub(crate) struct DeleteCommand {}
 
 impl BaseCommand for DeleteCommand {
     /// <https://w3c.github.io/editing/docs/execCommand/#the-delete-command>
-    fn execute(&self, selection: &Selection, _value: DOMString) -> bool {
+    fn execute(
+        &self,
+        cx: &mut js::context::JSContext,
+        selection: &Selection,
+        _value: DOMString,
+    ) -> bool {
         let active_range = selection
             .active_range()
             .expect("Must always have an active range");
         // Step 1. If the active range is not collapsed, delete the selection and return true.
         if !active_range.collapsed() {
-            selection.delete_the_selection(&active_range);
+            selection.delete_the_selection(
+                cx,
+                Default::default(),
+                Default::default(),
+                Default::default(),
+            );
             return true;
         }
         // Step 2. Canonicalize whitespace at the active range's start.
-        // TODO
+        active_range
+            .start_container()
+            .canonicalize_whitespace(active_range.start_offset(), true);
 
         // Step 3. Let node and offset be the active range's start node and offset.
-        // TODO
+        let mut node = active_range.start_container();
+        let mut offset = active_range.start_offset();
 
         // Step 4. Repeat the following steps:
-        // TODO
+        loop {
+            // Step 4.1. If offset is zero and node's previousSibling is an editable invisible node,
+            // remove node's previousSibling from its parent.
+            if offset == 0 {
+                if let Some(sibling) = node.GetPreviousSibling() {
+                    if sibling.is_editable() && sibling.is_invisible() {
+                        if let Some(parent) = node.GetParentNode() {
+                            if parent.RemoveChild(&sibling, CanGc::from_cx(cx)).is_err() {
+                                unreachable!("Must always have a parent to be able to remove from");
+                            }
+                            continue;
+                        }
+                    }
+                }
+            }
+            // Step 4.2. Otherwise, if node has a child with index offset − 1 and that child is an editable invisible node,
+            // remove that child from node, then subtract one from offset.
+            if offset > 0 {
+                if let Some(child) = node.children().nth(offset as usize - 1) {
+                    if child.is_editable() && child.is_invisible() {
+                        if node.RemoveChild(&child, CanGc::from_cx(cx)).is_err() {
+                            unreachable!("Must always have a parent to be able to remove from");
+                        }
+                        offset -= 1;
+                        continue;
+                    }
+                }
+            }
+            // Step 4.3. Otherwise, if offset is zero and node is an inline node, or if node is an invisible node,
+            // set offset to the index of node, then set node to its parent.
+            if (offset == 0 && node.is_inline_node()) || node.is_invisible() {
+                offset = node.index();
+                node = match node.GetParentNode() {
+                    None => break,
+                    Some(node) => node,
+                };
+                continue;
+            }
+            if offset > 0 {
+                if let Some(child) = node.children().nth(offset as usize - 1) {
+                    // Step 4.4. Otherwise, if node has a child with index offset − 1 and that child is an editable a,
+                    // remove that child from node, preserving its descendants. Then return true.
+                    if child.is_editable() && child.is::<HTMLAnchorElement>() {
+                        child.remove_preserving_its_descendants(cx, &node);
+                        return true;
+                    }
+                    // Step 4.5. Otherwise, if node has a child with index offset − 1 and that child is not a block node or a br or an img,
+                    // set node to that child, then set offset to the length of node.
+                    if !(child.is_block_node() ||
+                        child.is::<HTMLBRElement>() ||
+                        child.is::<HTMLImageElement>())
+                    {
+                        node = child;
+                        offset = node.len();
+                        continue;
+                    }
+                }
+            }
+            // Step 4.6. Otherwise, break from this loop.
+            break;
+        }
 
         // Step 5. If node is a Text node and offset is not zero, or if node is
         // a block node that has a child with index offset − 1 and that child is a br or hr or img:
-        // TODO
+        if (node.is::<Text>() && offset != 0) ||
+            (offset > 0 &&
+                node.is_block_node() &&
+                node.children()
+                    .nth(offset as usize - 1)
+                    .is_some_and(|child| {
+                        child.is::<HTMLBRElement>() ||
+                            child.is::<HTMLHRElement>() ||
+                            child.is::<HTMLImageElement>()
+                    }))
+        {
+            // Step 5.1. Call collapse(node, offset) on the context object's selection.
+            if selection
+                .Collapse(Some(&node), offset, CanGc::from_cx(cx))
+                .is_err()
+            {
+                unreachable!("Must not fail to collapse");
+            }
+            // Step 5.2. Call extend(node, offset − 1) on the context object's selection.
+            if selection
+                .Extend(&node, offset - 1, CanGc::from_cx(cx))
+                .is_err()
+            {
+                unreachable!("Must not fail to extend");
+            }
+            // Step 5.3. Delete the selection.
+            selection.delete_the_selection(
+                cx,
+                Default::default(),
+                Default::default(),
+                Default::default(),
+            );
+            // Step 5.4. Return true.
+            return true;
+        }
 
         // Step 6. If node is an inline node, return true.
-        // TODO
+        if node.is_inline_node() {
+            return true;
+        }
 
         // Step 7. If node is an li or dt or dd and is the first child of its parent, and offset is zero:
         // TODO

--- a/components/script/dom/execcommand/contenteditable.rs
+++ b/components/script/dom/execcommand/contenteditable.rs
@@ -3,7 +3,9 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 use std::cmp::Ordering;
+use std::ops::Deref;
 
+use html5ever::local_name;
 use script_bindings::inheritance::Castable;
 use style::computed_values::white_space_collapse::T as WhiteSpaceCollapse;
 use style::values::specified::box_::DisplayOutside;
@@ -11,21 +13,27 @@ use style::values::specified::box_::DisplayOutside;
 use crate::dom::abstractrange::bp_position;
 use crate::dom::bindings::cell::Ref;
 use crate::dom::bindings::codegen::Bindings::CharacterDataBinding::CharacterDataMethods;
-use crate::dom::bindings::codegen::Bindings::DocumentBinding::DocumentMethods;
+use crate::dom::bindings::codegen::Bindings::DocumentBinding::{
+    DocumentMethods, ElementCreationOptions,
+};
 use crate::dom::bindings::codegen::Bindings::HTMLElementBinding::HTMLElementMethods;
 use crate::dom::bindings::codegen::Bindings::NodeBinding::NodeMethods;
-use crate::dom::bindings::codegen::Bindings::RangeBinding::RangeMethods;
 use crate::dom::bindings::codegen::Bindings::SelectionBinding::SelectionMethods;
+use crate::dom::bindings::codegen::UnionTypes::StringOrElementCreationOptions;
 use crate::dom::bindings::inheritance::{ElementTypeId, HTMLElementTypeId, NodeTypeId};
-use crate::dom::bindings::root::DomRoot;
+use crate::dom::bindings::root::{DomRoot, DomSlice};
 use crate::dom::characterdata::CharacterData;
+use crate::dom::document::Document;
 use crate::dom::element::Element;
+use crate::dom::html::htmlanchorelement::HTMLAnchorElement;
 use crate::dom::html::htmlbrelement::HTMLBRElement;
 use crate::dom::html::htmlelement::HTMLElement;
 use crate::dom::html::htmlimageelement::HTMLImageElement;
 use crate::dom::html::htmllielement::HTMLLIElement;
+use crate::dom::html::htmltablecellelement::HTMLTableCellElement;
+use crate::dom::html::htmltablerowelement::HTMLTableRowElement;
+use crate::dom::html::htmltablesectionelement::HTMLTableSectionElement;
 use crate::dom::node::{Node, NodeTraits, ShadowIncluding};
-use crate::dom::range::Range;
 use crate::dom::selection::Selection;
 use crate::dom::text::Text;
 use crate::script_runtime::CanGc;
@@ -187,7 +195,514 @@ impl HTMLBRElement {
     }
 }
 
-impl Node {
+impl Document {
+    fn create_br_element(&self, cx: &mut js::context::JSContext) -> DomRoot<Element> {
+        let element_options =
+            StringOrElementCreationOptions::ElementCreationOptions(ElementCreationOptions {
+                is: None,
+            });
+        match self.CreateElement("br".into(), element_options, CanGc::from_cx(cx)) {
+            Err(_) => unreachable!("Must always be able to create br"),
+            Ok(br) => br,
+        }
+    }
+}
+
+impl HTMLElement {
+    fn local_name(&self) -> &str {
+        self.upcast::<Element>().local_name()
+    }
+}
+
+pub(crate) enum NodeOrString {
+    String(String),
+    Node(DomRoot<Node>),
+}
+
+impl NodeOrString {
+    fn name(&self) -> &str {
+        match self {
+            NodeOrString::String(str_) => str_,
+            NodeOrString::Node(node) => node
+                .downcast::<Element>()
+                .map(|element| element.local_name().as_ref())
+                .unwrap_or_default(),
+        }
+    }
+
+    fn as_node(&self) -> Option<DomRoot<Node>> {
+        match self {
+            NodeOrString::String(_) => None,
+            NodeOrString::Node(node) => Some(node.clone()),
+        }
+    }
+}
+
+/// <https://w3c.github.io/editing/docs/execCommand/#prohibited-paragraph-child-name>
+const PROHIBITED_PARAGRAPH_CHILD_NAMES: [&str; 47] = [
+    "address",
+    "article",
+    "aside",
+    "blockquote",
+    "caption",
+    "center",
+    "col",
+    "colgroup",
+    "dd",
+    "details",
+    "dir",
+    "div",
+    "dl",
+    "dt",
+    "fieldset",
+    "figcaption",
+    "figure",
+    "footer",
+    "form",
+    "h1",
+    "h2",
+    "h3",
+    "h4",
+    "h5",
+    "h6",
+    "header",
+    "hgroup",
+    "hr",
+    "li",
+    "listing",
+    "menu",
+    "nav",
+    "ol",
+    "p",
+    "plaintext",
+    "pre",
+    "section",
+    "summary",
+    "table",
+    "tbody",
+    "td",
+    "tfoot",
+    "th",
+    "thead",
+    "tr",
+    "ul",
+    "xmp",
+];
+/// <https://w3c.github.io/editing/docs/execCommand/#name-of-an-element-with-inline-contents>
+const NAME_OF_AN_ELEMENT_WITH_INLINE_CONTENTS: [&str; 43] = [
+    "a", "abbr", "b", "bdi", "bdo", "cite", "code", "dfn", "em", "h1", "h2", "h3", "h4", "h5",
+    "h6", "i", "kbd", "mark", "p", "pre", "q", "rp", "rt", "ruby", "s", "samp", "small", "span",
+    "strong", "sub", "sup", "u", "var", "acronym", "listing", "strike", "xmp", "big", "blink",
+    "font", "marquee", "nobr", "tt",
+];
+
+/// <https://w3c.github.io/editing/docs/execCommand/#element-with-inline-contents>
+fn is_element_with_inline_contents(element: &Node) -> bool {
+    // > An element with inline contents is an HTML element whose local name is a name of an element with inline contents.
+    let Some(html_element) = element.downcast::<HTMLElement>() else {
+        return false;
+    };
+    NAME_OF_AN_ELEMENT_WITH_INLINE_CONTENTS.contains(&html_element.local_name())
+}
+
+/// <https://w3c.github.io/editing/docs/execCommand/#allowed-child>
+fn is_allowed_child(child: NodeOrString, parent: NodeOrString) -> bool {
+    // Step 1. If parent is "colgroup", "table", "tbody", "tfoot", "thead", "tr",
+    // or an HTML element with local name equal to one of those,
+    // and child is a Text node whose data does not consist solely of space characters, return false.
+    if matches!(
+        parent.name(),
+        "colgroup" | "table" | "tbody" | "tfoot" | "thead" | "tr"
+    ) && child.as_node().is_some_and(|node| {
+        // Note: cannot use `.and_then` here, since `downcast` would outlive its reference
+        node.downcast::<Text>()
+            .is_some_and(|text| !text.data().bytes().all(|byte| byte == b' '))
+    }) {
+        return false;
+    }
+    // Step 2. If parent is "script", "style", "plaintext", or "xmp",
+    // or an HTML element with local name equal to one of those, and child is not a Text node, return false.
+    if matches!(parent.name(), "script" | "style" | "plaintext" | "xmp") &&
+        child.as_node().is_none_or(|node| !node.is::<Text>())
+    {
+        return false;
+    }
+    // Step 3. If child is a document, DocumentFragment, or DocumentType, return false.
+    if let NodeOrString::Node(ref node) = child {
+        if matches!(
+            node.type_id(),
+            NodeTypeId::Document(_) | NodeTypeId::DocumentFragment(_) | NodeTypeId::DocumentType
+        ) {
+            return false;
+        }
+    }
+    // Step 4. If child is an HTML element, set child to the local name of child.
+    let child_name = match child {
+        NodeOrString::String(str_) => str_,
+        NodeOrString::Node(node) => match node.downcast::<HTMLElement>() {
+            // Step 5. If child is not a string, return true.
+            None => return true,
+            Some(html_element) => html_element.local_name().to_owned(),
+        },
+    };
+    let child = child_name.as_str();
+    let parent_name = match parent {
+        NodeOrString::String(str_) => str_,
+        NodeOrString::Node(parent) => {
+            // Step 6. If parent is an HTML element:
+            if let Some(parent_element) = parent.downcast::<HTMLElement>() {
+                // Step 6.1. If child is "a", and parent or some ancestor of parent is an a, return false.
+                if child == "a" &&
+                    parent
+                        .inclusive_ancestors(ShadowIncluding::No)
+                        .any(|node| node.is::<HTMLAnchorElement>())
+                {
+                    return false;
+                }
+                // Step 6.2. If child is a prohibited paragraph child name and parent or some ancestor of parent
+                // is an element with inline contents, return false.
+                if PROHIBITED_PARAGRAPH_CHILD_NAMES.contains(&child) &&
+                    parent
+                        .inclusive_ancestors(ShadowIncluding::No)
+                        .any(|node| is_element_with_inline_contents(&node))
+                {
+                    return false;
+                }
+                // Step 6.3. If child is "h1", "h2", "h3", "h4", "h5", or "h6",
+                // and parent or some ancestor of parent is an HTML element with local name
+                // "h1", "h2", "h3", "h4", "h5", or "h6", return false.
+                if matches!(child, "h1" | "h2" | "h3" | "h4" | "h5" | "h6") &&
+                    parent.inclusive_ancestors(ShadowIncluding::No).any(|node| {
+                        node.downcast::<HTMLElement>().is_some_and(|html_element| {
+                            matches!(
+                                html_element.local_name(),
+                                "h1" | "h2" | "h3" | "h4" | "h5" | "h6"
+                            )
+                        })
+                    })
+                {
+                    return false;
+                }
+                // Step 6.4. Let parent be the local name of parent.
+                parent_element.local_name().to_owned()
+            } else {
+                // Step 7. If parent is an Element or DocumentFragment, return true.
+                // Step 8. If parent is not a string, return false.
+                return matches!(
+                    parent.type_id(),
+                    NodeTypeId::DocumentFragment(_) | NodeTypeId::Element(_)
+                );
+            }
+        },
+    };
+    let parent = parent_name.as_str();
+    // Step 9. If parent is on the left-hand side of an entry on the following list,
+    // then return true if child is listed on the right-hand side of that entry, and false otherwise.
+    match parent {
+        "colgroup" => return child == "col",
+        "table" => {
+            return matches!(
+                child,
+                "caption" | "col" | "colgroup" | "tbody" | "td" | "tfoot" | "th" | "thead" | "tr"
+            );
+        },
+        "tbody" | "tfoot" | "thead" => return matches!(child, "td" | "th" | "tr"),
+        "tr" => return matches!(child, "td" | "th"),
+        "dl" => return matches!(child, "dt" | "dd"),
+        "dir" | "ol" | "ul" => return matches!(child, "dir" | "li" | "ol" | "ul"),
+        "hgroup" => return matches!(child, "h1" | "h2" | "h3" | "h4" | "h5" | "h6"),
+        _ => {},
+    };
+    // Step 10. If child is "body", "caption", "col", "colgroup", "frame", "frameset", "head",
+    // "html", "tbody", "td", "tfoot", "th", "thead", or "tr", return false.
+    if matches!(
+        child,
+        "body" |
+            "caption" |
+            "col" |
+            "colgroup" |
+            "frame" |
+            "frameset" |
+            "head" |
+            "html" |
+            "tbody" |
+            "td" |
+            "tfoot" |
+            "th" |
+            "thead" |
+            "tr"
+    ) {
+        return false;
+    }
+    // Step 11. If child is "dd" or "dt" and parent is not "dl", return false.
+    if matches!(child, "dd" | "dt") && parent != "dl" {
+        return false;
+    }
+    // Step 12. If child is "li" and parent is not "ol" or "ul", return false.
+    if child == "li" && !matches!(parent, "ol" | "ul") {
+        return false;
+    }
+    // Step 13. If parent is on the left-hand side of an entry on the following list
+    // and child is listed on the right-hand side of that entry, return false.
+    if match parent {
+        "a" => child == "a",
+        "dd" | "dt" => matches!(child, "dd" | "dt"),
+        "h1" | "h2" | "h3" | "h4" | "h5" | "h6" => {
+            matches!(child, "h1" | "h2" | "h3" | "h4" | "h5" | "h6")
+        },
+        "li" => child == "li",
+        "nobr" => child == "nobr",
+        "td" | "th" => {
+            matches!(
+                child,
+                "caption" | "col" | "colgroup" | "tbody" | "td" | "tfoot" | "th" | "thead" | "tr"
+            )
+        },
+        _ if NAME_OF_AN_ELEMENT_WITH_INLINE_CONTENTS.contains(&parent) => {
+            PROHIBITED_PARAGRAPH_CHILD_NAMES.contains(&child)
+        },
+        _ => false,
+    } {
+        return false;
+    }
+    // Step 14. Return true.
+    true
+}
+
+/// <https://w3c.github.io/editing/docs/execCommand/#split-the-parent>
+fn split_the_parent<'a>(cx: &mut js::context::JSContext, node_list: &'a [&'a Node]) {
+    assert!(!node_list.is_empty());
+    // Step 1. Let original parent be the parent of the first member of node list.
+    let Some(original_parent) = node_list.first().and_then(|first| first.GetParentNode()) else {
+        return;
+    };
+    let context_object = original_parent.owner_document();
+    // Step 2. If original parent is not editable or its parent is null, do nothing and abort these steps.
+    if !original_parent.is_editable() {
+        return;
+    }
+    let Some(parent_of_original_parent) = original_parent.GetParentNode() else {
+        return;
+    };
+    // Step 3. If the first child of original parent is in node list, remove extraneous line breaks before original parent.
+    if original_parent
+        .children()
+        .next()
+        .is_some_and(|first_child| node_list.contains(&first_child.deref()))
+    {
+        original_parent.remove_extraneous_line_breaks_before(cx);
+    }
+    // Step 4. If the first child of original parent is in node list, and original parent follows a line break,
+    // set follows line break to true. Otherwise, set follows line break to false.
+    let first_child_is_in_node_list = original_parent
+        .children()
+        .next()
+        .is_some_and(|first_child| node_list.contains(&first_child.deref()));
+    let follows_line_break = first_child_is_in_node_list && original_parent.follows_a_line_break();
+    // Step 5. If the last child of original parent is in node list, and original parent precedes a line break,
+    // set precedes line break to true. Otherwise, set precedes line break to false.
+    let last_child_is_in_node_list = original_parent
+        .children()
+        .last()
+        .is_some_and(|last_child| node_list.contains(&last_child.deref()));
+    let precedes_line_break = last_child_is_in_node_list && original_parent.precedes_a_line_break();
+    // Step 6. If the first child of original parent is not in node list, but its last child is:
+    if !first_child_is_in_node_list && last_child_is_in_node_list {
+        // Step 6.1. For each node in node list, in reverse order,
+        // insert node into the parent of original parent immediately after original parent, preserving ranges.
+        for node in node_list.iter().rev() {
+            // TODO: Preserving ranges
+            if parent_of_original_parent
+                .InsertBefore(
+                    node,
+                    original_parent.GetNextSibling().as_deref(),
+                    CanGc::from_cx(cx),
+                )
+                .is_err()
+            {
+                unreachable!("Must always have a parent");
+            }
+        }
+        // Step 6.2. If precedes line break is true, and the last member of node list does not precede a line break,
+        // call createElement("br") on the context object and insert the result immediately after the last member of node list.
+        if precedes_line_break {
+            if let Some(last) = node_list.last() {
+                if !last.precedes_a_line_break() {
+                    let br = context_object.create_br_element(cx);
+                    if last
+                        .GetParentNode()
+                        .expect("Must always have a parent")
+                        .InsertBefore(
+                            br.upcast(),
+                            last.GetNextSibling().as_deref(),
+                            CanGc::from_cx(cx),
+                        )
+                        .is_err()
+                    {
+                        unreachable!("Must always be able to append");
+                    }
+                }
+            }
+        }
+        // Step 6.3. Remove extraneous line breaks at the end of original parent.
+        original_parent.remove_extraneous_line_breaks_at_the_end_of(cx);
+        // Step 6.4. Abort these steps.
+        return;
+    }
+    // Step 7. If the first child of original parent is not in node list:
+    if first_child_is_in_node_list {
+        // Step 7.1. Let cloned parent be the result of calling cloneNode(false) on original parent.
+        let Ok(cloned_parent) = original_parent.CloneNode(false, CanGc::from_cx(cx)) else {
+            unreachable!("Must always be able to clone node");
+        };
+        // Step 7.2. If original parent has an id attribute, unset it.
+        if let Some(element) = original_parent.downcast::<Element>() {
+            element.remove_attribute_by_name(&local_name!("id"), CanGc::from_cx(cx));
+        }
+        // Step 7.3. Insert cloned parent into the parent of original parent immediately before original parent.
+        if parent_of_original_parent
+            .InsertBefore(&cloned_parent, Some(&original_parent), CanGc::from_cx(cx))
+            .is_err()
+        {
+            unreachable!("Must always have a parent");
+        }
+        // Step 7.4. While the previousSibling of the first member of node list is not null,
+        // append the first child of original parent as the last child of cloned parent, preserving ranges.
+        loop {
+            if node_list
+                .first()
+                .and_then(|first| first.GetPreviousSibling())
+                .is_some()
+            {
+                if let Some(first_of_original) = original_parent.children().next() {
+                    // TODO: Preserving ranges
+                    if cloned_parent
+                        .AppendChild(&first_of_original, CanGc::from_cx(cx))
+                        .is_err()
+                    {
+                        unreachable!("Must always have a parent");
+                    }
+                    continue;
+                }
+            }
+            break;
+        }
+    }
+    // Step 8. For each node in node list, insert node into the parent of original parent immediately before original parent, preserving ranges.
+    for node in node_list.iter() {
+        // TODO: Preserving ranges
+        if parent_of_original_parent
+            .InsertBefore(node, Some(&original_parent), CanGc::from_cx(cx))
+            .is_err()
+        {
+            unreachable!("Must always have a parent");
+        }
+    }
+    // Step 9. If follows line break is true, and the first member of node list does not follow a line break,
+    // call createElement("br") on the context object and insert the result immediately before the first member of node list.
+    if follows_line_break {
+        if let Some(first) = node_list.first() {
+            if !first.follows_a_line_break() {
+                let br = context_object.create_br_element(cx);
+                if first
+                    .GetParentNode()
+                    .expect("Must always have a parent")
+                    .InsertBefore(br.upcast(), Some(first), CanGc::from_cx(cx))
+                    .is_err()
+                {
+                    unreachable!("Must always be able to insert");
+                }
+            }
+        }
+    }
+    // Step 10. If the last member of node list is an inline node other than a br,
+    // and the first child of original parent is a br, and original parent is not an inline node,
+    // remove the first child of original parent from original parent.
+    if node_list
+        .last()
+        .is_some_and(|last| last.is_inline_node() && !last.is::<HTMLBRElement>()) &&
+        !original_parent.is_inline_node()
+    {
+        if let Some(first_of_original) = original_parent.children().next() {
+            if first_of_original.is::<HTMLBRElement>() &&
+                original_parent
+                    .RemoveChild(&first_of_original, CanGc::from_cx(cx))
+                    .is_err()
+            {
+                unreachable!("Must always have a parent");
+            }
+        }
+    }
+    // Step 11. If original parent has no children:
+    if original_parent.children_count() == 0 {
+        // Step 11.1. Remove original parent from its parent.
+        if parent_of_original_parent
+            .RemoveChild(&original_parent, CanGc::from_cx(cx))
+            .is_err()
+        {
+            unreachable!("Must always have a parent");
+        }
+        // Step 11.2. If precedes line break is true, and the last member of node list does not precede a line break,
+        // call createElement("br") on the context object and insert the result immediately after the last member of node list.
+        if precedes_line_break {
+            if let Some(last) = node_list.last() {
+                if !last.precedes_a_line_break() {
+                    let br = context_object.create_br_element(cx);
+                    if last
+                        .GetParentNode()
+                        .expect("Must always have a parent")
+                        .InsertBefore(
+                            br.upcast(),
+                            last.GetNextSibling().as_deref(),
+                            CanGc::from_cx(cx),
+                        )
+                        .is_err()
+                    {
+                        unreachable!("Must always be able to insert");
+                    }
+                }
+            }
+        }
+    } else {
+        // Step 12. Otherwise, remove extraneous line breaks before original parent.
+        original_parent.remove_extraneous_line_breaks_before(cx);
+    }
+    // Step 13. If node list's last member's nextSibling is null, but its parent is not null,
+    // remove extraneous line breaks at the end of node list's last member's parent.
+    if let Some(last) = node_list.last() {
+        if last.GetNextSibling().is_none() {
+            if let Some(parent_of_last) = last.GetParentNode() {
+                parent_of_last.remove_extraneous_line_breaks_at_the_end_of(cx);
+            }
+        }
+    }
+}
+
+pub(crate) trait NodeExecCommandSupport {
+    fn same_editing_host(&self, other: &Node) -> bool;
+    fn is_block_node(&self) -> bool;
+    fn is_inline_node(&self) -> bool;
+    fn block_node_of(&self) -> Option<DomRoot<Node>>;
+    fn is_visible(&self) -> bool;
+    fn is_invisible(&self) -> bool;
+    fn is_block_start_point(&self, offset: usize) -> bool;
+    fn is_block_end_point(&self, offset: u32) -> bool;
+    fn is_block_boundary_point(&self, offset: u32) -> bool;
+    fn is_collapsed_block_prop(&self) -> bool;
+    fn follows_a_line_break(&self) -> bool;
+    fn precedes_a_line_break(&self) -> bool;
+    fn canonical_space_sequence(
+        n: usize,
+        non_breaking_start: bool,
+        non_breaking_end: bool,
+    ) -> String;
+    fn canonicalize_whitespace(&self, offset: u32, fix_collapsed_space: bool);
+    fn remove_extraneous_line_breaks_before(&self, cx: &mut js::context::JSContext);
+    fn remove_extraneous_line_breaks_at_the_end_of(&self, cx: &mut js::context::JSContext);
+    fn remove_preserving_its_descendants(&self, cx: &mut js::context::JSContext, parent: &Node);
+}
+
+impl NodeExecCommandSupport for Node {
     /// <https://w3c.github.io/editing/docs/execCommand/#in-the-same-editing-host>
     fn same_editing_host(&self, other: &Node) -> bool {
         // > Two nodes are in the same editing host if the editing host of the first is non-null and the same as the editing host of the second.
@@ -209,6 +724,27 @@ impl Node {
             self.type_id(),
             NodeTypeId::Document(_) | NodeTypeId::DocumentFragment(_)
         )
+    }
+
+    /// <https://w3c.github.io/editing/docs/execCommand/#inline-node>
+    fn is_inline_node(&self) -> bool {
+        // > An inline node is a node that is not a block node.
+        !self.is_block_node()
+    }
+
+    /// <https://w3c.github.io/editing/docs/execCommand/#block-node-of>
+    fn block_node_of(&self) -> Option<DomRoot<Node>> {
+        let mut node = DomRoot::from_ref(self);
+
+        loop {
+            // Step 1. While node is an inline node, set node to its parent.
+            if node.is_inline_node() {
+                node = node.GetParentNode()?;
+                continue;
+            }
+            // Step 2. Return node.
+            return Some(node);
+        }
     }
 
     /// <https://w3c.github.io/editing/docs/execCommand/#visible>
@@ -248,6 +784,12 @@ impl Node {
         false
     }
 
+    /// <https://w3c.github.io/editing/docs/execCommand/#invisible>
+    fn is_invisible(&self) -> bool {
+        // > Something is invisible if it is a node that is not visible.
+        !self.is_visible()
+    }
+
     /// <https://w3c.github.io/editing/docs/execCommand/#block-start-point>
     fn is_block_start_point(&self, offset: usize) -> bool {
         // > A boundary point (node, offset) is a block start point if either node's parent is null and offset is zero;
@@ -276,6 +818,40 @@ impl Node {
     fn is_block_boundary_point(&self, offset: u32) -> bool {
         // > A boundary point is a block boundary point if it is either a block start point or a block end point.
         self.is_block_start_point(offset as usize) || self.is_block_end_point(offset)
+    }
+
+    /// <https://w3c.github.io/editing/docs/execCommand/#collapsed-block-prop>
+    fn is_collapsed_block_prop(&self) -> bool {
+        // > A collapsed block prop is either a collapsed line break that is not an extraneous line break,
+
+        // TODO: Check for collapsed line break
+        if self
+            .downcast::<HTMLBRElement>()
+            .is_some_and(|br| !br.is_extraneous_line_break())
+        {
+            return true;
+        }
+        // > or an Element that is an inline node and whose children are all either invisible or collapsed block props
+        if !self.is::<Element>() {
+            return false;
+        };
+        if !self.is_inline_node() {
+            return false;
+        }
+        let mut at_least_one_collapsed_block_prop = false;
+        for child in self.children() {
+            if child.is_collapsed_block_prop() {
+                at_least_one_collapsed_block_prop = true;
+                continue;
+            }
+            if child.is_invisible() {
+                continue;
+            }
+
+            return false;
+        }
+        // > and that has at least one child that is a collapsed block prop.
+        at_least_one_collapsed_block_prop
     }
 
     /// <https://w3c.github.io/editing/docs/execCommand/#follows-a-line-break>
@@ -629,6 +1205,114 @@ impl Node {
             start_offset += 1;
         }
     }
+
+    /// <https://w3c.github.io/editing/docs/execCommand/#remove-extraneous-line-breaks-before>
+    fn remove_extraneous_line_breaks_before(&self, cx: &mut js::context::JSContext) {
+        let parent = self.GetParentNode();
+        // Step 1. Let ref be the previousSibling of node.
+        let Some(mut ref_) = self.GetPreviousSibling() else {
+            // Step 2. If ref is null, abort these steps.
+            return;
+        };
+        // Step 3. While ref has children, set ref to its lastChild.
+        while let Some(last_child) = ref_.children().last() {
+            ref_ = last_child;
+        }
+        // Step 4. While ref is invisible but not an extraneous line break,
+        // and ref does not equal node's parent, set ref to the node before it in tree order.
+        loop {
+            if ref_.is_invisible() &&
+                ref_.downcast::<HTMLBRElement>()
+                    .is_none_or(|br| !br.is_extraneous_line_break())
+            {
+                if let Some(parent) = parent.as_ref() {
+                    if ref_ != *parent {
+                        ref_ = match ref_.preceding_nodes(parent).nth(0) {
+                            None => break,
+                            Some(node) => node,
+                        };
+                        continue;
+                    }
+                }
+            }
+            break;
+        }
+        // Step 5. If ref is an editable extraneous line break, remove it from its parent.
+        if ref_.is_editable() &&
+            ref_.downcast::<HTMLBRElement>()
+                .is_some_and(|br| br.is_extraneous_line_break())
+        {
+            ref_.remove_self(CanGc::from_cx(cx));
+        }
+    }
+
+    /// <https://w3c.github.io/editing/docs/execCommand/#remove-extraneous-line-breaks-at-the-end-of>
+    fn remove_extraneous_line_breaks_at_the_end_of(&self, cx: &mut js::context::JSContext) {
+        // Step 1. Let ref be node.
+        let mut ref_ = DomRoot::from_ref(self);
+        // Step 2. While ref has children, set ref to its lastChild.
+        while let Some(last_child) = ref_.children().last() {
+            ref_ = last_child;
+        }
+        // Step 3. While ref is invisible but not an extraneous line break, and ref does not equal node,
+        // set ref to the node before it in tree order.
+        loop {
+            if ref_.is_invisible() &&
+                *ref_ != *self &&
+                ref_.downcast::<HTMLBRElement>()
+                    .is_none_or(|br| !br.is_extraneous_line_break())
+            {
+                if let Some(parent_of_ref) = ref_.GetParentNode() {
+                    ref_ = match ref_.preceding_nodes(&parent_of_ref).nth(0) {
+                        None => break,
+                        Some(node) => node,
+                    };
+                    continue;
+                }
+            }
+            break;
+        }
+        // Step 4. If ref is an editable extraneous line break:
+        if ref_.is_editable() &&
+            ref_.downcast::<HTMLBRElement>()
+                .is_some_and(|br| br.is_extraneous_line_break())
+        {
+            // Step 4.1. While ref's parent is editable and invisible, set ref to its parent.
+            loop {
+                if let Some(parent) = ref_.GetParentNode() {
+                    if parent.is_editable() && parent.is_invisible() {
+                        ref_ = parent;
+                        continue;
+                    }
+                }
+                break;
+            }
+            // Step 4.2. Remove ref from its parent.
+            if ref_
+                .GetParentNode()
+                .expect("Must always have a parent")
+                .RemoveChild(&ref_, CanGc::from_cx(cx))
+                .is_err()
+            {
+                unreachable!("Must always have a parent");
+            }
+        }
+    }
+
+    /// <https://w3c.github.io/editing/docs/execCommand/#preserving-its-descendants>
+    fn remove_preserving_its_descendants(&self, cx: &mut js::context::JSContext, parent: &Node) {
+        // > To remove a node node while preserving its descendants,
+        // > split the parent of node's children if it has any.
+        // > If it has no children, instead remove it from its parent.
+        if self.children_count() == 0 {
+            if parent.RemoveChild(self, CanGc::from_cx(cx)).is_err() {
+                unreachable!("Must always have a parent to be able to remove from");
+            }
+        } else {
+            rooted_vec!(let children <- self.children().map(|child| DomRoot::as_traced(&child)));
+            split_the_parent(cx, children.r());
+        }
+    }
 }
 
 pub(crate) trait ContentEditableRange {
@@ -733,16 +1417,158 @@ impl ContentEditableRange for HTMLElement {
     }
 }
 
+trait EquivalentPoint {
+    fn previous_equivalent_point(&self) -> Option<(DomRoot<Node>, u32)>;
+    fn next_equivalent_point(&self) -> Option<(DomRoot<Node>, u32)>;
+    fn first_equivalent_point(self) -> (DomRoot<Node>, u32);
+    fn last_equivalent_point(self) -> (DomRoot<Node>, u32);
+}
+
+impl EquivalentPoint for (DomRoot<Node>, u32) {
+    /// <https://w3c.github.io/editing/docs/execCommand/#previous-equivalent-point>
+    fn previous_equivalent_point(&self) -> Option<(DomRoot<Node>, u32)> {
+        let (node, offset) = self;
+        // Step 1. If node's length is zero, return null.
+        let len = node.len();
+        if len == 0 {
+            return None;
+        }
+        // Step 2. If offset is 0, and node's parent is not null, and node is an inline node,
+        // return (node's parent, node's index).
+        if *offset == 0 && node.is_inline_node() {
+            if let Some(parent) = node.GetParentNode() {
+                return Some((parent, node.index()));
+            }
+        }
+        // Step 3. If node has a child with index offset − 1, and that child's length is not zero,
+        // and that child is an inline node, return (that child, that child's length).
+        if *offset > 0 {
+            if let Some(child) = node.children().nth(*offset as usize - 1) {
+                if !child.is_empty() && child.is_inline_node() {
+                    let len = child.len();
+                    return Some((child, len));
+                }
+            }
+        }
+
+        // Step 4. Return null.
+        None
+    }
+
+    /// <https://w3c.github.io/editing/docs/execCommand/#next-equivalent-point>
+    fn next_equivalent_point(&self) -> Option<(DomRoot<Node>, u32)> {
+        let (node, offset) = self;
+        // Step 1. If node's length is zero, return null.
+        let len = node.len();
+        if len == 0 {
+            return None;
+        }
+
+        // Step 2.
+        //
+        // This step does not exist in the spec
+
+        // Step 3. If offset is node's length, and node's parent is not null, and node is an inline node,
+        // return (node's parent, 1 + node's index).
+        if *offset == len && node.is_inline_node() {
+            if let Some(parent) = node.GetParentNode() {
+                return Some((parent, node.index() + 1));
+            }
+        }
+
+        // Step 4.
+        //
+        // This step does not exist in the spec
+
+        // Step 5. If node has a child with index offset, and that child's length is not zero,
+        // and that child is an inline node, return (that child, 0).
+        if let Some(child) = node.children().nth(*offset as usize) {
+            if !child.is_empty() && child.is_inline_node() {
+                return Some((child, 0));
+            }
+        }
+
+        // Step 6.
+        //
+        // This step does not exist in the spec
+
+        // Step 7. Return null.
+        None
+    }
+
+    /// <https://w3c.github.io/editing/docs/execCommand/#first-equivalent-point>
+    fn first_equivalent_point(self) -> (DomRoot<Node>, u32) {
+        let mut previous_equivalent_point = self;
+        // Step 1. While (node, offset)'s previous equivalent point is not null, set (node, offset) to its previous equivalent point.
+        loop {
+            if let Some(next) = previous_equivalent_point.previous_equivalent_point() {
+                previous_equivalent_point = next;
+            } else {
+                // Step 2. Return (node, offset).
+                return previous_equivalent_point;
+            }
+        }
+    }
+
+    /// <https://w3c.github.io/editing/docs/execCommand/#last-equivalent-point>
+    fn last_equivalent_point(self) -> (DomRoot<Node>, u32) {
+        let mut next_equivalent_point = self;
+        // Step 1. While (node, offset)'s next equivalent point is not null, set (node, offset) to its next equivalent point.
+        loop {
+            if let Some(next) = next_equivalent_point.next_equivalent_point() {
+                next_equivalent_point = next;
+            } else {
+                // Step 2. Return (node, offset).
+                return next_equivalent_point;
+            }
+        }
+    }
+}
+
+#[derive(Default, PartialEq)]
+pub(crate) enum SelectionDeletionBlockMerging {
+    #[default]
+    Merge,
+    Skip,
+}
+
+#[derive(Default, PartialEq)]
+pub(crate) enum SelectionDeletionStripWrappers {
+    #[default]
+    Strip,
+}
+
+#[derive(Default, PartialEq)]
+pub(crate) enum SelectionDeleteDirection {
+    #[default]
+    Forward,
+}
+
 pub(crate) trait SelectionExecCommandSupport {
-    fn delete_the_selection(&self, active_range: &Range);
+    fn delete_the_selection(
+        &self,
+        cx: &mut js::context::JSContext,
+        block_merging: SelectionDeletionBlockMerging,
+        strip_wrappers: SelectionDeletionStripWrappers,
+        direction: SelectionDeleteDirection,
+    );
 }
 
 impl SelectionExecCommandSupport for Selection {
     /// <https://w3c.github.io/editing/docs/execCommand/#delete-the-selection>
-    fn delete_the_selection(&self, active_range: &Range) {
+    fn delete_the_selection(
+        &self,
+        cx: &mut js::context::JSContext,
+        block_merging: SelectionDeletionBlockMerging,
+        strip_wrappers: SelectionDeletionStripWrappers,
+        direction: SelectionDeleteDirection,
+    ) {
         // Step 1. If the active range is null, abort these steps and do nothing.
-        //
-        // Always passed in as argument
+        let Some(active_range) = self.active_range() else {
+            return;
+        };
+
+        let context_object = self.owner_document();
 
         // Step 2. Canonicalize whitespace at the active range's start.
         active_range
@@ -755,51 +1581,135 @@ impl SelectionExecCommandSupport for Selection {
             .canonicalize_whitespace(active_range.end_offset(), true);
 
         // Step 4. Let (start node, start offset) be the last equivalent point for the active range's start.
-        // TODO
+        let (mut start_node, mut start_offset) =
+            (active_range.start_container(), active_range.start_offset()).last_equivalent_point();
 
         // Step 5. Let (end node, end offset) be the first equivalent point for the active range's end.
-        // TODO
+        let (mut end_node, mut end_offset) =
+            (active_range.end_container(), active_range.end_offset()).first_equivalent_point();
 
         // Step 6. If (end node, end offset) is not after (start node, start offset):
-        // TODO
+        if bp_position(&end_node, end_offset, &start_node, start_offset) != Some(Ordering::Greater)
+        {
+            // Step 6.1. If direction is "forward", call collapseToStart() on the context object's selection.
+            if direction == SelectionDeleteDirection::Forward {
+                if self.CollapseToStart(CanGc::from_cx(cx)).is_err() {
+                    unreachable!("Should be able to collapse to start");
+                }
+            } else {
+                // Step 6.2. Otherwise, call collapseToEnd() on the context object's selection.
+                if self.CollapseToEnd(CanGc::from_cx(cx)).is_err() {
+                    unreachable!("Should be able to collapse to end");
+                }
+            }
+            // Step 6.3. Abort these steps.
+            return;
+        }
 
         // Step 7. If start node is a Text node and start offset is 0, set start offset to the index of start node,
         // then set start node to its parent.
-        // TODO
+        if start_node.is::<Text>() && start_offset == 0 {
+            start_offset = start_node.index();
+            start_node = match start_node.GetParentNode() {
+                None => return,
+                Some(node) => node,
+            };
+        }
 
         // Step 8. If end node is a Text node and end offset is its length, set end offset to one plus the index of end node,
         // then set end node to its parent.
-        // TODO
+        if end_node.is::<Text>() && end_offset == end_node.len() {
+            end_offset = end_node.index() + 1;
+            end_node = match end_node.GetParentNode() {
+                None => return,
+                Some(node) => node,
+            };
+        }
 
         // Step 9. Call collapse(start node, start offset) on the context object's selection.
-        // TODO
+        if self
+            .Collapse(Some(&start_node), start_offset, CanGc::from_cx(cx))
+            .is_err()
+        {
+            unreachable!("Must always be able to collapse");
+        }
 
         // Step 10. Call extend(end node, end offset) on the context object's selection.
-        // TODO
+        if self
+            .Extend(&end_node, end_offset, CanGc::from_cx(cx))
+            .is_err()
+        {
+            unreachable!("Must always be able to extend");
+        }
 
         // Step 11.
         //
         // This step does not exist in the spec
 
         // Step 12. Let start block be the active range's start node.
-        // TODO
+        let Some(active_range) = self.active_range() else {
+            return;
+        };
+        let mut start_block = active_range.start_container();
 
-        // Step 13. While start block's parent is in the same editing host and start block is an inline node, set start block to its parent.
-        // TODO
+        // Step 13. While start block's parent is in the same editing host and start block is an inline node,
+        // set start block to its parent.
+        loop {
+            if start_block.is_inline_node() {
+                if let Some(parent) = start_block.GetParentNode() {
+                    if parent.same_editing_host(&start_node) {
+                        start_block = parent;
+                        continue;
+                    }
+                }
+            }
+            break;
+        }
 
-        // Step 14. If start block is neither a block node nor an editing host, or "span" is not an allowed child of start block,
+        // Step 14. If start block is neither a block node nor an editing host,
+        // or "span" is not an allowed child of start block,
         // or start block is a td or th, set start block to null.
-        // TODO
+        let start_block = if (!start_block.is_block_node() && !start_block.is_editing_host()) ||
+            !is_allowed_child(
+                NodeOrString::String("span".to_owned()),
+                NodeOrString::Node(start_block.clone()),
+            ) ||
+            start_block.is::<HTMLTableCellElement>()
+        {
+            None
+        } else {
+            Some(start_block)
+        };
 
         // Step 15. Let end block be the active range's end node.
-        // TODO
+        let mut end_block = active_range.end_container();
 
         // Step 16. While end block's parent is in the same editing host and end block is an inline node, set end block to its parent.
-        // TODO
+        loop {
+            if end_block.is_inline_node() {
+                if let Some(parent) = end_block.GetParentNode() {
+                    if parent.same_editing_host(&end_block) {
+                        end_block = parent;
+                        continue;
+                    }
+                }
+            }
+            break;
+        }
 
         // Step 17. If end block is neither a block node nor an editing host, or "span" is not an allowed child of end block,
         // or end block is a td or th, set end block to null.
-        // TODO
+        let end_block = if (!end_block.is_block_node() && !end_block.is_editing_host()) ||
+            !is_allowed_child(
+                NodeOrString::String("span".to_owned()),
+                NodeOrString::Node(end_block.clone()),
+            ) ||
+            end_block.is::<HTMLTableCellElement>()
+        {
+            None
+        } else {
+            Some(end_block)
+        };
 
         // Step 18.
         //
@@ -813,34 +1723,155 @@ impl SelectionExecCommandSupport for Selection {
         // This step does not exist in the spec
 
         // Step 21. If start node and end node are the same, and start node is an editable Text node:
-        //
-        // As per the spec:
-        // > NOTE: This whole piece of the algorithm is based on deleteContents() in DOM Range, copy-pasted and then adjusted to fit.
-        let _ = active_range.DeleteContents();
+        if start_node == end_node && start_node.is_editable() {
+            if let Some(start_text) = start_node.downcast::<Text>() {
+                // Step 21.1. Call deleteData(start offset, end offset − start offset) on start node.
+                if start_text
+                    .upcast::<CharacterData>()
+                    .DeleteData(start_offset, end_offset - start_offset)
+                    .is_err()
+                {
+                    unreachable!("Must always be able to delete");
+                }
+                // Step 21.2. Canonicalize whitespace at (start node, start offset), with fix collapsed space false.
+                start_node.canonicalize_whitespace(start_offset, false);
+                // Step 21.3. If direction is "forward", call collapseToStart() on the context object's selection.
+                if direction == SelectionDeleteDirection::Forward {
+                    if self.CollapseToStart(CanGc::from_cx(cx)).is_err() {
+                        unreachable!("Should be able to collapse to start");
+                    }
+                } else {
+                    // Step 21.4. Otherwise, call collapseToEnd() on the context object's selection.
+                    if self.CollapseToEnd(CanGc::from_cx(cx)).is_err() {
+                        unreachable!("Should be able to collapse to end");
+                    }
+                }
+                // Step 21.5. Restore states and values from overrides.
+                //
+                // TODO
+
+                // Step 21.6. Abort these steps.
+                return;
+            }
+        }
 
         // Step 22. If start node is an editable Text node, call deleteData() on it, with start offset as
         // the first argument and (length of start node − start offset) as the second argument.
-        // TODO
+        if start_node.is_editable() {
+            if let Some(start_text) = start_node.downcast::<Text>() {
+                if start_text
+                    .upcast::<CharacterData>()
+                    .DeleteData(start_offset, start_node.len() - start_offset)
+                    .is_err()
+                {
+                    unreachable!("Must always be able to delete");
+                }
+            }
+        }
 
         // Step 23. Let node list be a list of nodes, initially empty.
-        // TODO
+        rooted_vec!(let mut node_list);
 
         // Step 24. For each node contained in the active range, append node to node list if the
         // last member of node list (if any) is not an ancestor of node; node is editable;
         // and node is not a thead, tbody, tfoot, tr, th, or td.
-        // TODO
+        let Ok(contained_children) = active_range.contained_children() else {
+            unreachable!("Must always have contained children");
+        };
+        for node in contained_children.contained_children {
+            // This type is only used to tell the compiler how to handle the type of `node_list.last()`.
+            // It is not allowed to add a `& DomRoot<Node>` annotation, as test-tidy disallows that.
+            // However, if we omit the type, the compiler doesn't know what it is, since we also
+            // aren't allowed to add a type annotation to `node_list` itself, as that is handled
+            // by the `rooted_vec` macro. Lastly, we also can't make it `&Node`, since then the compiler
+            // thinks that the contents of the `RootedVec` is `Node`, whereas it is should be
+            // `RootedVec<DomRoot<Node>>`. The type alias here doesn't upset test-tidy,
+            // while also providing the necessary information to the compiler to work.
+            type DomRootNode = DomRoot<Node>;
+            if node.is_editable() &&
+                !(node.is::<HTMLTableSectionElement>() ||
+                    node.is::<HTMLTableRowElement>() ||
+                    node.is::<HTMLTableCellElement>()) &&
+                node_list
+                    .last()
+                    .is_none_or(|last: &DomRootNode| !last.is_ancestor_of(&node))
+            {
+                node_list.push(node);
+            }
+        }
 
         // Step 25. For each node in node list:
-        // TODO
+        for node in node_list.iter() {
+            // Step 25.1. Let parent be the parent of node.
+            let parent = match node.GetParentNode() {
+                None => continue,
+                Some(node) => node,
+            };
+            // Step 25.2. Remove node from parent.
+            if parent.RemoveChild(node, CanGc::from_cx(cx)).is_err() {
+                unreachable!("Must always have a parent");
+            }
+            // Step 25.3. If the block node of parent has no visible children, and parent is editable or an editing host,
+            // call createElement("br") on the context object and append the result as the last child of parent.
+            if parent
+                .block_node_of()
+                .is_some_and(|block_node| block_node.children().all(|child| child.is_invisible())) &&
+                parent.is_editable_or_editing_host()
+            {
+                let br = context_object.create_br_element(cx);
+                if parent.AppendChild(br.upcast(), CanGc::from_cx(cx)).is_err() {
+                    unreachable!("Must always be able to append");
+                }
+            }
+            // Step 25.4. If strip wrappers is true or parent is not an inclusive ancestor of start node,
+            // while parent is an editable inline node with length 0, let grandparent be the parent of parent,
+            // then remove parent from grandparent, then set parent to grandparent.
+            if strip_wrappers == SelectionDeletionStripWrappers::Strip ||
+                !parent.is_inclusive_ancestor_of(&start_node)
+            {
+                let mut parent = parent;
+                loop {
+                    if parent.is_editable() && parent.is_inline_node() && parent.is_empty() {
+                        let grand_parent = match parent.GetParentNode() {
+                            None => break,
+                            Some(node) => node,
+                        };
+                        if grand_parent
+                            .RemoveChild(&parent, CanGc::from_cx(cx))
+                            .is_err()
+                        {
+                            unreachable!("Must always have a grand parent");
+                        }
+                        parent = grand_parent;
+                        continue;
+                    }
+                    break;
+                }
+            }
+        }
 
         // Step 26. If end node is an editable Text node, call deleteData(0, end offset) on it.
-        // TODO
+        if end_node.is_editable() {
+            if let Some(end_text) = end_node.downcast::<Text>() {
+                if end_text
+                    .upcast::<CharacterData>()
+                    .DeleteData(0, end_offset)
+                    .is_err()
+                {
+                    unreachable!("Must always be able to delete");
+                }
+            }
+        }
 
         // Step 27. Canonicalize whitespace at the active range's start, with fix collapsed space false.
-        // TODO
+        active_range
+            .start_container()
+            .canonicalize_whitespace(active_range.start_offset(), false);
 
         // Step 28. Canonicalize whitespace at the active range's end, with fix collapsed space false.
-        // TODO
+        active_range
+            .end_container()
+            .canonicalize_whitespace(active_range.end_offset(), false);
 
         // Step 29.
         //
@@ -848,19 +1879,335 @@ impl SelectionExecCommandSupport for Selection {
 
         // Step 30. If block merging is false, or start block or end block is null, or start block is not
         // in the same editing host as end block, or start block and end block are the same:
-        // TODO
+        if block_merging == SelectionDeletionBlockMerging::Skip ||
+            start_block.as_ref().zip(end_block.as_ref()).is_none_or(
+                |(start_block, end_block)| {
+                    start_block == end_block || !start_block.same_editing_host(end_block)
+                },
+            )
+        {
+            // Step 30.1. If direction is "forward", call collapseToStart() on the context object's selection.
+            if direction == SelectionDeleteDirection::Forward {
+                if self.CollapseToStart(CanGc::from_cx(cx)).is_err() {
+                    unreachable!("Should be able to collapse to start");
+                }
+            } else {
+                // Step 30.2. Otherwise, call collapseToEnd() on the context object's selection.
+                if self.CollapseToEnd(CanGc::from_cx(cx)).is_err() {
+                    unreachable!("Should be able to collapse to end");
+                }
+            }
+            // Step 30.3. Restore states and values from overrides.
+            //
+            // TODO
+
+            // Step 30.4. Abort these steps.
+            return;
+        }
+        let start_block = start_block.expect("Already checked for None in previous statement");
+        let end_block = end_block.expect("Already checked for None in previous statement");
 
         // Step 31. If start block has one child, which is a collapsed block prop, remove its child from it.
-        // TODO
+        if start_block.children_count() == 1 {
+            let Some(child) = start_block.children().nth(0) else {
+                unreachable!("Must always have a single child");
+            };
+            if child.is_collapsed_block_prop() &&
+                start_block.RemoveChild(&child, CanGc::from_cx(cx)).is_err()
+            {
+                unreachable!("Must always be able to remove child");
+            }
+        }
 
         // Step 32. If start block is an ancestor of end block:
-        // TODO
+        if start_block.is_ancestor_of(&end_block) {
+            // Step 32.1. Let reference node be end block.
+            let mut reference_node = end_block.clone();
+            // Step 32.2. While reference node is not a child of start block, set reference node to its parent.
+            loop {
+                if start_block.children().all(|child| child != reference_node) {
+                    reference_node = reference_node
+                        .GetParentNode()
+                        .expect("Must always have a parent, at least start_block");
+                    continue;
+                }
+                break;
+            }
+            // Step 32.3. Call collapse() on the context object's selection,
+            // with first argument start block and second argument the index of reference node.
+            if self
+                .Collapse(
+                    Some(&start_block),
+                    reference_node.index(),
+                    CanGc::from_cx(cx),
+                )
+                .is_err()
+            {
+                unreachable!("Must always be able to collapse");
+            }
+            // Step 32.4. If end block has no children:
+            if end_block.children_count() == 0 {
+                let mut end_block = end_block;
+                // Step 32.4.1. While end block is editable and is the only child of its parent and is not a child of start block,
+                // let parent equal end block, then remove end block from parent, then set end block to parent.
+                loop {
+                    if end_block.is_editable() &&
+                        start_block.children().all(|child| child != end_block)
+                    {
+                        if let Some(parent) = end_block.GetParentNode() {
+                            if parent.children_count() == 1 {
+                                if parent.RemoveChild(&end_block, CanGc::from_cx(cx)).is_err() {
+                                    unreachable!("Must always have a parent");
+                                }
+                                end_block = parent;
+                                continue;
+                            }
+                        }
+                    }
+                    break;
+                }
+                // Step 32.4.2. If end block is editable and is not an inline node,
+                // and its previousSibling and nextSibling are both inline nodes,
+                // call createElement("br") on the context object and insert it into end block's parent immediately after end block.
+                if end_block.is_editable() &&
+                    !end_block.is_inline_node() &&
+                    end_block
+                        .GetPreviousSibling()
+                        .is_some_and(|previous| previous.is_inline_node())
+                {
+                    if let Some(next_of_end_block) = end_block.GetNextSibling() {
+                        if next_of_end_block.is_inline_node() {
+                            let br = context_object.create_br_element(cx);
+                            let parent = end_block
+                                .GetParentNode()
+                                .expect("Must always have a parent");
+                            if parent
+                                .InsertBefore(
+                                    br.upcast(),
+                                    Some(&next_of_end_block),
+                                    CanGc::from_cx(cx),
+                                )
+                                .is_err()
+                            {
+                                unreachable!("Must always be able to insert into parent");
+                            }
+                        }
+                    }
+                }
+                // Step 32.4.3. If end block is editable, remove it from its parent.
+                if end_block.is_editable() &&
+                    end_block
+                        .GetParentNode()
+                        .expect("Must always have a parent")
+                        .RemoveChild(&end_block, CanGc::from_cx(cx))
+                        .is_err()
+                {
+                    unreachable!("Must always have a parent to remove child");
+                }
+                // Step 32.4.4. Restore states and values from overrides.
+                //
+                // TODO
 
+                // Step 32.4.5. Abort these steps.
+                return;
+            }
+            let first_child = end_block
+                .children()
+                .nth(0)
+                .expect("Already checked at least 1 child in previous statement");
+            // Step 32.5. If end block's firstChild is not an inline node,
+            // restore states and values from record, then abort these steps.
+            if !first_child.is_inline_node() {
+                // TODO: Restore state
+                return;
+            }
+            // Step 32.6. Let children be a list of nodes, initially empty.
+            rooted_vec!(let mut children);
+            // Step 32.7. Append the first child of end block to children.
+            children.push(first_child.as_traced());
+            // Step 32.8. While children's last member is not a br,
+            // and children's last member's nextSibling is an inline node,
+            // append children's last member's nextSibling to children.
+            loop {
+                let Some(last) = children.last() else {
+                    break;
+                };
+                if last.is::<HTMLBRElement>() {
+                    break;
+                }
+                let Some(next) = last.GetNextSibling() else {
+                    break;
+                };
+                if next.is_inline_node() {
+                    children.push(next.as_traced());
+                    continue;
+                }
+                break;
+            }
+            // Step 32.9. Record the values of children, and let values be the result.
+            // TODO
+
+            // Step 32.10. While children's first member's parent is not start block,
+            // split the parent of children.
+            loop {
+                if children
+                    .first()
+                    .and_then(|child| child.GetParentNode())
+                    .is_some_and(|parent_of_child| parent_of_child != start_block)
+                {
+                    split_the_parent(cx, children.r());
+                    continue;
+                }
+                break;
+            }
+            // Step 32.11. If children's first member's previousSibling is an editable br,
+            // remove that br from its parent.
+            if let Some(first) = children.first() {
+                if let Some(previous_of_first) = first.GetPreviousSibling() {
+                    if previous_of_first.is_editable() && previous_of_first.is::<HTMLBRElement>() {
+                        if let Some(parent) = previous_of_first.GetParentNode() {
+                            if parent
+                                .RemoveChild(&previous_of_first, CanGc::from_cx(cx))
+                                .is_err()
+                            {
+                                unreachable!("Must always have a parent");
+                            }
+                        }
+                    }
+                }
+            }
         // Step 33. Otherwise, if start block is a descendant of end block:
-        // TODO
+        } else if end_block.is_ancestor_of(&start_block) {
+            // Step 33.1. Call collapse() on the context object's selection,
+            // with first argument start block and second argument start block's length.
+            if self
+                .Collapse(Some(&start_block), start_block.len(), CanGc::from_cx(cx))
+                .is_err()
+            {
+                unreachable!("Must always be able to collapse");
+            }
+            // Step 33.2. Let reference node be start block.
+            let mut reference_node = start_block.clone();
+            // Step 33.3. While reference node is not a child of end block, set reference node to its parent.
+            loop {
+                if end_block.children().all(|child| child != reference_node) {
+                    if let Some(parent) = reference_node.GetParentNode() {
+                        reference_node = parent;
+                        continue;
+                    }
+                }
+                break;
+            }
+            // Step 33.4. If reference node's nextSibling is an inline node and start block's lastChild is a br,
+            // remove start block's lastChild from it.
+            if reference_node
+                .GetNextSibling()
+                .is_some_and(|next| next.is_inline_node())
+            {
+                if let Some(last) = start_block.children().last() {
+                    if last.is::<HTMLBRElement>() &&
+                        start_block.RemoveChild(&last, CanGc::from_cx(cx)).is_err()
+                    {
+                        unreachable!("Must always have a parent");
+                    }
+                }
+            }
+            // Step 33.5. Let nodes to move be a list of nodes, initially empty.
+            rooted_vec!(let mut nodes_to_move);
+            // Step 33.6. If reference node's nextSibling is neither null nor a block node,
+            // append it to nodes to move.
+            if let Some(next) = reference_node.GetNextSibling() {
+                if !next.is_block_node() {
+                    nodes_to_move.push(next);
+                }
+            }
+            // Step 33.7. While nodes to move is nonempty and its last member isn't a br
+            // and its last member's nextSibling is neither null nor a block node,
+            // append its last member's nextSibling to nodes to move.
+            loop {
+                if let Some(last) = nodes_to_move.last() {
+                    if !last.is::<HTMLBRElement>() {
+                        if let Some(next_of_last) = last.GetNextSibling() {
+                            if !next_of_last.is_block_node() {
+                                nodes_to_move.push(next_of_last);
+                                continue;
+                            }
+                        }
+                    }
+                }
+                break;
+            }
+            // Step 33.8. Record the values of nodes to move, and let values be the result.
+            // TODO
 
+            // Step 33.9. For each node in nodes to move,
+            // append node as the last child of start block, preserving ranges.
+            for node in nodes_to_move.iter() {
+                // TODO: Preserve ranges
+                if start_block.AppendChild(node, CanGc::from_cx(cx)).is_err() {
+                    unreachable!("Must always be able to append");
+                }
+            }
         // Step 34. Otherwise:
-        // TODO
+        } else {
+            // Step 34.1. Call collapse() on the context object's selection,
+            // with first argument start block and second argument start block's length.
+            if self
+                .Collapse(Some(&start_block), start_block.len(), CanGc::from_cx(cx))
+                .is_err()
+            {
+                unreachable!("Must always be able to collapse");
+            }
+            // Step 34.2. If end block's firstChild is an inline node and start block's lastChild is a br,
+            // remove start block's lastChild from it.
+            if end_block
+                .children()
+                .nth(0)
+                .is_some_and(|next| next.is_inline_node())
+            {
+                if let Some(last) = start_block.children().last() {
+                    if last.is::<HTMLBRElement>() &&
+                        start_block.RemoveChild(&last, CanGc::from_cx(cx)).is_err()
+                    {
+                        unreachable!("Must always have a parent");
+                    }
+                }
+            }
+            // Step 34.3. Record the values of end block's children, and let values be the result.
+            // TODO
+
+            // Step 34.4. While end block has children,
+            // append the first child of end block to start block, preserving ranges.
+            loop {
+                if let Some(first_child) = end_block.children().nth(0) {
+                    // TODO: Preserve ranges
+                    if start_block
+                        .AppendChild(&first_child, CanGc::from_cx(cx))
+                        .is_err()
+                    {
+                        unreachable!("Must always be able to append");
+                    }
+                    continue;
+                }
+                break;
+            }
+            // Step 34.5. While end block has no children,
+            // let parent be the parent of end block, then remove end block from parent,
+            // then set end block to parent.
+            let mut end_block = end_block;
+            loop {
+                if end_block.children_count() == 0 {
+                    if let Some(parent) = end_block.GetParentNode() {
+                        if parent.RemoveChild(&end_block, CanGc::from_cx(cx)).is_err() {
+                            unreachable!("Must always have a parent");
+                        }
+                        end_block = parent;
+                        continue;
+                    }
+                }
+                break;
+            }
+        }
 
         // Step 35.
         //
@@ -879,10 +2226,18 @@ impl SelectionExecCommandSupport for Selection {
 
         // Step 39. If start block has no children, call createElement("br") on the context object and
         // append the result as the last child of start block.
-        // TODO
+        if start_block.children_count() == 0 {
+            let br = context_object.create_br_element(cx);
+            if start_block
+                .AppendChild(br.upcast(), CanGc::from_cx(cx))
+                .is_err()
+            {
+                unreachable!("Must always be able to append");
+            }
+        }
 
         // Step 40. Remove extraneous line breaks at the end of start block.
-        // TODO
+        start_block.remove_extraneous_line_breaks_at_the_end_of(cx);
 
         // Step 41. Restore states and values from overrides.
         // TODO

--- a/components/script/dom/execcommand/execcommands.rs
+++ b/components/script/dom/execcommand/execcommands.rs
@@ -13,12 +13,15 @@ use crate::script_runtime::CanGc;
 
 impl Document {
     /// <https://w3c.github.io/editing/docs/execCommand/#enabled>
-    fn selection_if_command_is_enabled(&self, can_gc: CanGc) -> Option<DomRoot<Selection>> {
+    fn selection_if_command_is_enabled(
+        &self,
+        cx: &mut js::context::JSContext,
+    ) -> Option<DomRoot<Selection>> {
         // > Among commands defined in this specification, those listed in Miscellaneous commands are always enabled,
         // > except for the cut command and the paste command.
         // TODO
         // > The other commands defined here are enabled if the active range is not null,
-        let selection = self.GetSelection(can_gc)?;
+        let selection = self.GetSelection(CanGc::from_cx(cx))?;
         let range = selection.active_range()?;
         // > its start node is either editable or an editing host,
         if !range.start_container().is_editable_or_editing_host() {
@@ -58,14 +61,14 @@ pub(crate) trait DocumentExecCommandSupport {
     fn command_value_for_command(&self, command_id: DOMString) -> DOMString;
     fn check_support_and_enabled(
         &self,
+        cx: &mut js::context::JSContext,
         command_id: DOMString,
-        can_gc: CanGc,
     ) -> Option<(Box<dyn BaseCommand>, DomRoot<Selection>)>;
     fn exec_command_for_command_id(
         &self,
+        cx: &mut js::context::JSContext,
         command_id: DOMString,
         value: DOMString,
-        can_gc: CanGc,
     ) -> bool;
 }
 
@@ -124,23 +127,23 @@ impl DocumentExecCommandSupport for Document {
     /// <https://w3c.github.io/editing/docs/execCommand/#querycommandenabled()>
     fn check_support_and_enabled(
         &self,
+        cx: &mut js::context::JSContext,
         command_id: DOMString,
-        can_gc: CanGc,
     ) -> Option<(Box<dyn BaseCommand>, DomRoot<Selection>)> {
         // Step 2. Return true if command is both supported and enabled, false otherwise.
         self.command_if_command_is_supported(command_id)
-            .zip(self.selection_if_command_is_enabled(can_gc))
+            .zip(self.selection_if_command_is_enabled(cx))
     }
 
     /// <https://w3c.github.io/editing/docs/execCommand/#execcommand()>
     fn exec_command_for_command_id(
         &self,
+        cx: &mut js::context::JSContext,
         command_id: DOMString,
         value: DOMString,
-        can_gc: CanGc,
     ) -> bool {
         // Step 3. If command is not supported or not enabled, return false.
-        let Some((command, selection)) = self.check_support_and_enabled(command_id, can_gc) else {
+        let Some((command, selection)) = self.check_support_and_enabled(cx, command_id) else {
             return false;
         };
         // Step 4. If command is not in the Miscellaneous commands section:
@@ -167,7 +170,7 @@ impl DocumentExecCommandSupport for Document {
         // TODO
 
         // Step 5. Take the action for command, passing value to the instructions as an argument.
-        let result = command.execute(&selection, value);
+        let result = command.execute(cx, &selection, value);
         // Step 6. If the previous step returned false, return false.
         if !result {
             return false;

--- a/components/script/dom/range.rs
+++ b/components/script/dom/range.rs
@@ -59,10 +59,10 @@ pub(crate) struct Range {
     associated_selections: DomRefCell<Vec<Dom<Selection>>>,
 }
 
-struct ContainedChildren {
+pub(crate) struct ContainedChildren {
     first_partially_contained_child: Option<DomRoot<Node>>,
     last_partially_contained_child: Option<DomRoot<Node>>,
-    contained_children: Vec<DomRoot<Node>>,
+    pub(crate) contained_children: Vec<DomRoot<Node>>,
 }
 
 impl Range {
@@ -162,7 +162,7 @@ impl Range {
     }
 
     /// <https://dom.spec.whatwg.org/#concept-range-clone>
-    fn contained_children(&self) -> Fallible<ContainedChildren> {
+    pub(crate) fn contained_children(&self) -> Fallible<ContainedChildren> {
         let start_node = self.start_container();
         let end_node = self.end_container();
         // Steps 5-6.

--- a/components/script/dom/selection.rs
+++ b/components/script/dom/selection.rs
@@ -111,6 +111,10 @@ impl Selection {
         // > The active range is the range of the selection given by calling getSelection() on the context object. (Thus the active range may be null.)
         self.range.get()
     }
+
+    pub(crate) fn owner_document(&self) -> DomRoot<Document> {
+        self.document.as_rooted()
+    }
 }
 
 impl SelectionMethods<crate::DomTypeHolder> for Selection {

--- a/components/script_bindings/codegen/Bindings.conf
+++ b/components/script_bindings/codegen/Bindings.conf
@@ -193,8 +193,8 @@ DOMInterfaces = {
 
 'Document': {
     'additionalTraits': ["crate::interfaces::DocumentHelpers"],
-    'canGc': ['CreateElement', 'CreateElementNS', 'ImportNode', 'SetTitle', 'CreateEvent', 'CreateRange', 'CreateComment', 'CreateAttribute', 'CreateAttributeNS', 'CreateDocumentFragment', 'CreateTextNode', 'CreateCDATASection', 'CreateProcessingInstruction', 'Prepend', 'Append', 'ReplaceChildren', 'SetBgColor', 'SetFgColor', 'Fonts', 'ExitFullscreen', 'CreateExpression', 'CreateNSResolver', 'Evaluate', 'StyleSheets', 'Implementation', 'GetElementsByTagName', 'GetElementsByTagNameNS', 'GetElementsByClassName', 'AdoptNode', 'CreateNodeIterator', 'SetBody', 'GetElementsByName', 'Images', 'Embeds', 'Plugins', 'Links', 'Forms', 'Scripts', 'Anchors', 'Applets', 'Children', 'GetSelection', 'NamedGetter', 'AdoptedStyleSheets', 'SetAdoptedStyleSheets', 'ExecCommand', 'QueryCommandEnabled'],
-    'cx': ['Close', 'Open', 'Open_', 'ParseHTMLUnsafe', 'Write', 'Writeln'],
+    'canGc': ['CreateElement', 'CreateElementNS', 'ImportNode', 'SetTitle', 'CreateEvent', 'CreateRange', 'CreateComment', 'CreateAttribute', 'CreateAttributeNS', 'CreateDocumentFragment', 'CreateTextNode', 'CreateCDATASection', 'CreateProcessingInstruction', 'Prepend', 'Append', 'ReplaceChildren', 'SetBgColor', 'SetFgColor', 'Fonts', 'ExitFullscreen', 'CreateExpression', 'CreateNSResolver', 'Evaluate', 'StyleSheets', 'Implementation', 'GetElementsByTagName', 'GetElementsByTagNameNS', 'GetElementsByClassName', 'AdoptNode', 'CreateNodeIterator', 'SetBody', 'GetElementsByName', 'Images', 'Embeds', 'Plugins', 'Links', 'Forms', 'Scripts', 'Anchors', 'Applets', 'Children', 'GetSelection', 'NamedGetter', 'AdoptedStyleSheets', 'SetAdoptedStyleSheets'],
+    'cx': ['Close', 'Open', 'Open_', 'ParseHTMLUnsafe', 'Write', 'Writeln', 'ExecCommand', 'QueryCommandEnabled'],
 },
 
 'DissimilarOriginWindow': {

--- a/tests/wpt/meta/custom-elements/reactions/Document.html.ini
+++ b/tests/wpt/meta/custom-elements/reactions/Document.html.ini
@@ -1,6 +1,3 @@
 [Document.html]
-  [execCommand on Document must enqueue a disconnected reaction when deleting a custom element from a contenteditable element]
-    expected: FAIL
-
   [importNode on Document must construct a new custom element when importing a custom element into a window-less document]
     expected: FAIL

--- a/tests/wpt/meta/editing/other/br-tag-not-added-with-inline-root-editable-element.html.ini
+++ b/tests/wpt/meta/editing/other/br-tag-not-added-with-inline-root-editable-element.html.ini
@@ -1,3 +1,0 @@
-[br-tag-not-added-with-inline-root-editable-element.html]
-  [BR tag is not inserted after deleting the text node content since root editable element is inline]
-    expected: FAIL

--- a/tests/wpt/meta/editing/other/delete.html.ini
+++ b/tests/wpt/meta/editing/other/delete.html.ini
@@ -1,7 +1,4 @@
 [delete.html]
-  [0: "<p><br></p><p><br></p>" 1,0 delete]
-    expected: FAIL
-
   [1: "<p><br></p><p><br></p>" 0,0 forwarddelete]
     expected: FAIL
 
@@ -36,9 +33,6 @@
     expected: FAIL
 
   [12: "<p><br></p><br>" 1 delete]
-    expected: FAIL
-
-  [13: "<p><br></p><p><br></p>\\n" 1,0 delete]
     expected: FAIL
 
   [14: "<p><br></p><p><br></p>\\n" 0,0 forwarddelete]

--- a/tests/wpt/meta/editing/other/editing-around-select-element.tentative.html.ini
+++ b/tests/wpt/meta/editing/other/editing-around-select-element.tentative.html.ini
@@ -22,28 +22,13 @@
   [execCommand(delete, false, "") in <div contenteditable><p>abc</p><select><option>{def}</option></select><p>ghi</p></div>: shouldn't modify in <option>]
     expected: FAIL
 
-  [execCommand(delete, false, "") in <div contenteditable><p>abc</p><select><option>{def</option><option>ghi}</option></select><p>jkl</p></div>: shouldn't join <option>s]
-    expected: FAIL
-
   [execCommand(delete, false, "") in <div contenteditable><p>abc</p><select>{<option>def</option>}<option>ghi</option></select><p>jkl</p></div>: shouldn't delete <option>]
     expected: FAIL
 
   [execCommand(delete, false, "") in <div contenteditable><p>abc</p><select><option>def</option>{<option>ghi</option>}</select><p>jkl</p></div>: shouldn't delete <option>]
     expected: FAIL
 
-  [execCommand(delete, false, "") in <div contenteditable><p>abc</p><select>{<option>def</option><option>ghi</option>}</select><p>jkl</p></div>: shouldn't delete <option>s nor <select>]
-    expected: FAIL
-
-  [execCommand(delete, false, "") in <div contenteditable><p>abc</p><select><optgroup>{<option>def</option><option>ghi</option>}</optgroup></select><p>jkl</p></div>: shouldn't delete <option>, <optgroup> nor <select>]
-    expected: FAIL
-
-  [execCommand(delete, false, "") in <select contenteditable>{<option>abc</option><option>def</option>}</select>: shouldn't delete <option>s]
-    expected: FAIL
-
   [execCommand(delete, false, "") in <select><option contenteditable>{abc}</option><option>def</option></select>: shouldn't modify <option>]
-    expected: FAIL
-
-  [execCommand(delete, false, "") in <select><optgroup contenteditable>{<option>abc</option><option>def</option>}</optgroup></select>: shouldn't delete <option>s]
     expected: FAIL
 
   [execCommand(delete, false, "") in <select><optgroup contenteditable><option>{abc}</option><option>def</option></optgroup></select>: shouldn't delete <option>s nor optgroup]
@@ -58,28 +43,13 @@
   [execCommand(delete, false, "") in <div contenteditable><p>abc</p><select multiple><option>{def}</option></select><p>ghi</p></div>: shouldn't modify in <option>]
     expected: FAIL
 
-  [execCommand(delete, false, "") in <div contenteditable><p>abc</p><select multiple><option>{def</option><option>ghi}</option></select><p>jkl</p></div>: shouldn't join <option>s]
-    expected: FAIL
-
   [execCommand(delete, false, "") in <div contenteditable><p>abc</p><select multiple>{<option>def</option>}<option>ghi</option></select><p>jkl</p></div>: shouldn't delete <option>]
     expected: FAIL
 
   [execCommand(delete, false, "") in <div contenteditable><p>abc</p><select multiple><option>def</option>{<option>ghi</option>}</select><p>jkl</p></div>: shouldn't delete <option>]
     expected: FAIL
 
-  [execCommand(delete, false, "") in <div contenteditable><p>abc</p><select multiple>{<option>def</option><option>ghi</option>}</select><p>jkl</p></div>: shouldn't delete <option>s nor <select multiple>]
-    expected: FAIL
-
-  [execCommand(delete, false, "") in <div contenteditable><p>abc</p><select multiple><optgroup>{<option>def</option><option>ghi</option>}</optgroup></select><p>jkl</p></div>: shouldn't delete <option>, <optgroup> nor <select multiple>]
-    expected: FAIL
-
-  [execCommand(delete, false, "") in <select multiple contenteditable>{<option>abc</option><option>def</option>}</select>: shouldn't delete <option>s]
-    expected: FAIL
-
   [execCommand(delete, false, "") in <select multiple><option contenteditable>{abc}</option><option>def</option></select>: shouldn't modify <option>]
-    expected: FAIL
-
-  [execCommand(delete, false, "") in <select multiple><optgroup contenteditable>{<option>abc</option><option>def</option>}</optgroup></select>: shouldn't delete <option>s]
     expected: FAIL
 
   [execCommand(delete, false, "") in <select multiple><optgroup contenteditable><option>{abc}</option><option>def</option></optgroup></select>: shouldn't delete <option>s nor optgroup]
@@ -89,6 +59,36 @@
     expected: FAIL
 
   [execCommand(delete, false, "") in <option contenteditable>{abc}</option>: shouldn't modify <option>]
+    expected: FAIL
+
+  [execCommand(delete, false, "") in <div contenteditable><p>abc</p><select><option>d[\]ef</option></select></div>: shouldn't modify in <option>]
+    expected: FAIL
+
+  [execCommand(delete, false, "") in <div contenteditable><p>abc</p><select><option>{}def</option></select><p>ghi</p></div>: shouldn't modify in <option>]
+    expected: FAIL
+
+  [execCommand(delete, false, "") in <div contenteditable><p>abc</p><select><option>def{}</option></select><p>ghi</p></div>: shouldn't modify in <option>]
+    expected: FAIL
+
+  [execCommand(delete, false, "") in <div contenteditable><p>abc</p>{<select><option>def</option><option>ghi</option></select>}<p>jkl</p></div>: <select> element itself should be removable]
+    expected: FAIL
+
+  [execCommand(delete, false, "") in <div contenteditable><p>abc</p>{<select><optgroup><option>def</option><option>ghi</option></optgroup></select>}<p>jkl</p></div>: <select> element itself should be removable]
+    expected: FAIL
+
+  [execCommand(delete, false, "") in <div contenteditable><p>abc</p><select multiple><option>d[\]ef</option></select></div>: shouldn't modify in <option>]
+    expected: FAIL
+
+  [execCommand(delete, false, "") in <div contenteditable><p>abc</p><select multiple><option>{}def</option></select><p>ghi</p></div>: shouldn't modify in <option>]
+    expected: FAIL
+
+  [execCommand(delete, false, "") in <div contenteditable><p>abc</p><select multiple><option>def{}</option></select><p>ghi</p></div>: shouldn't modify in <option>]
+    expected: FAIL
+
+  [execCommand(delete, false, "") in <div contenteditable><p>abc</p>{<select multiple><option>def</option><option>ghi</option></select>}<p>jkl</p></div>: <select multiple> element itself should be removable]
+    expected: FAIL
+
+  [execCommand(delete, false, "") in <div contenteditable><p>abc</p>{<select multiple><optgroup><option>def</option><option>ghi</option></optgroup></select>}<p>jkl</p></div>: <select multiple> element itself should be removable]
     expected: FAIL
 
 

--- a/tests/wpt/meta/editing/run/delete.html.ini
+++ b/tests/wpt/meta/editing/run/delete.html.ini
@@ -2,9 +2,6 @@
   [[["defaultparagraphseparator","p"\],["delete",""\]\] "<p>foo<ol><li>bar<li>ba[z</ol><p>q\]uz": execCommand("defaultparagraphseparator", false, "p") return value]
     expected: FAIL
 
-  [[["defaultparagraphseparator","p"\],["delete",""\]\] "<p>foo<ol><li>bar<li>ba[z</ol><p>q\]uz" compare innerHTML]
-    expected: FAIL
-
   [[["defaultparagraphseparator","p"\],["delete",""\]\] "<p>foo<ol><li>bar<li>ba[z</ol><p>q\]uz" queryCommandValue("defaultparagraphseparator") before]
     expected: FAIL
 
@@ -17,9 +14,6 @@
   [[["defaultparagraphseparator","div"\],["delete",""\]\] "<p>fo[o<ol><li>bar<li>baz</ol><p>q\]uz": execCommand("defaultparagraphseparator", false, "div") return value]
     expected: FAIL
 
-  [[["defaultparagraphseparator","div"\],["delete",""\]\] "<p>fo[o<ol><li>bar<li>baz</ol><p>q\]uz" compare innerHTML]
-    expected: FAIL
-
   [[["defaultparagraphseparator","div"\],["delete",""\]\] "<p>fo[o<ol><li>bar<li>baz</ol><p>q\]uz" queryCommandValue("defaultparagraphseparator") before]
     expected: FAIL
 
@@ -29,40 +23,10 @@
   [[["defaultparagraphseparator","p"\],["delete",""\]\] "<p>fo[o<ol><li>bar<li>baz</ol><p>q\]uz": execCommand("defaultparagraphseparator", false, "p") return value]
     expected: FAIL
 
-  [[["defaultparagraphseparator","p"\],["delete",""\]\] "<p>fo[o<ol><li>bar<li>baz</ol><p>q\]uz" compare innerHTML]
-    expected: FAIL
-
   [[["defaultparagraphseparator","p"\],["delete",""\]\] "<p>fo[o<ol><li>bar<li>baz</ol><p>q\]uz" queryCommandValue("defaultparagraphseparator") before]
     expected: FAIL
 
   [[["defaultparagraphseparator","p"\],["delete",""\]\] "<p>fo[o<ol><li>bar<li>baz</ol><p>q\]uz" queryCommandValue("defaultparagraphseparator") after]
-    expected: FAIL
-
-  [[["delete",""\]\] "<ol><li>fo[o</ol><ol><li>b\]ar</ol>" compare innerHTML]
-    expected: FAIL
-
-  [[["delete",""\]\] "<ol><li>fo[o</ol><ul><li>b\]ar</ul>" compare innerHTML]
-    expected: FAIL
-
-  [[["delete",""\]\] "foo[<ol><li>\]bar</ol>" compare innerHTML]
-    expected: FAIL
-
-  [[["delete",""\]\] "<ol><li>foo[<li>\]bar</ol>" compare innerHTML]
-    expected: FAIL
-
-  [[["delete",""\]\] "foo[<dl><dt>\]bar<dd>baz</dl>" compare innerHTML]
-    expected: FAIL
-
-  [[["delete",""\]\] "foo[<dl><dd>\]bar</dl>" compare innerHTML]
-    expected: FAIL
-
-  [[["delete",""\]\] "<dl><dt>foo[<dd>\]bar</dl>" compare innerHTML]
-    expected: FAIL
-
-  [[["delete",""\]\] "<dl><dt>foo[<dt>\]bar<dd>baz</dl>" compare innerHTML]
-    expected: FAIL
-
-  [[["delete",""\]\] "<dl><dt>foo<dd>bar[<dd>\]baz</dl>" compare innerHTML]
     expected: FAIL
 
   [[["delete",""\]\] "<b>foo [&nbsp;</b>bar\]" compare innerHTML]
@@ -71,13 +35,7 @@
   [[["delete",""\]\] "foo<b> [&nbsp;bar\]</b>" compare innerHTML]
     expected: FAIL
 
-  [[["delete",""\]\] "[foo<b>&nbsp;\] bar</b>" compare innerHTML]
-    expected: FAIL
-
   [[["stylewithcss","true"\],["delete",""\]\] "<span style=display:block>fo[o</span><span style=display:block>b\]ar</span>": execCommand("stylewithcss", false, "true") return value]
-    expected: FAIL
-
-  [[["stylewithcss","true"\],["delete",""\]\] "<span style=display:block>fo[o</span><span style=display:block>b\]ar</span>" compare innerHTML]
     expected: FAIL
 
   [[["stylewithcss","true"\],["delete",""\]\] "<span style=display:block>fo[o</span><span style=display:block>b\]ar</span>" queryCommandState("stylewithcss") after]
@@ -86,25 +44,16 @@
   [[["stylewithcss","false"\],["delete",""\]\] "<span style=display:block>fo[o</span><span style=display:block>b\]ar</span>": execCommand("stylewithcss", false, "false") return value]
     expected: FAIL
 
-  [[["stylewithcss","false"\],["delete",""\]\] "<span style=display:block>fo[o</span><span style=display:block>b\]ar</span>" compare innerHTML]
-    expected: FAIL
-
   [[["stylewithcss","false"\],["delete",""\]\] "<span style=display:block>fo[o</span><span style=display:block>b\]ar</span>" queryCommandState("stylewithcss") before]
     expected: FAIL
 
   [[["stylewithcss","true"\],["delete",""\]\] "<quasit style=display:block>fo[o</quasit><quasit style=display:block>b\]ar</quasit>": execCommand("stylewithcss", false, "true") return value]
     expected: FAIL
 
-  [[["stylewithcss","true"\],["delete",""\]\] "<quasit style=display:block>fo[o</quasit><quasit style=display:block>b\]ar</quasit>" compare innerHTML]
-    expected: FAIL
-
   [[["stylewithcss","true"\],["delete",""\]\] "<quasit style=display:block>fo[o</quasit><quasit style=display:block>b\]ar</quasit>" queryCommandState("stylewithcss") after]
     expected: FAIL
 
   [[["stylewithcss","false"\],["delete",""\]\] "<quasit style=display:block>fo[o</quasit><quasit style=display:block>b\]ar</quasit>": execCommand("stylewithcss", false, "false") return value]
-    expected: FAIL
-
-  [[["stylewithcss","false"\],["delete",""\]\] "<quasit style=display:block>fo[o</quasit><quasit style=display:block>b\]ar</quasit>" compare innerHTML]
     expected: FAIL
 
   [[["stylewithcss","false"\],["delete",""\]\] "<quasit style=display:block>fo[o</quasit><quasit style=display:block>b\]ar</quasit>" queryCommandState("stylewithcss") before]
@@ -437,13 +386,46 @@
   [[["delete",""\]\] "<span>[abc\]</span>" compare innerHTML]
     expected: FAIL
 
-  [[["delete",""\]\] "<span>[abc\]</span><br>" compare innerHTML]
-    expected: FAIL
-
   [[["delete",""\]\] "<p><span>[abc\]</span></p>" compare innerHTML]
     expected: FAIL
 
+  [[["delete",""\]\] "<span style=display:none>fo[o</span><span style=display:none>b\]ar</span>" compare innerHTML]
+    expected: FAIL
+
+  [[["delete",""\]\] "<ol><li>foo</ol>[bar<ol><li>\]baz</ol>" compare innerHTML]
+    expected: FAIL
+
+  [[["delete",""\]\] "<div> [\]abc</div>" compare innerHTML]
+    expected: FAIL
+
+  [[["delete",""\]\] "<div> [\] abc</div>" compare innerHTML]
+    expected: FAIL
+
+  [[["defaultparagraphseparator","div"\],["delete",""\]\] "<p>fo[o<ol><li>bar<li>baz</ol><p>q\]uz" compare innerHTML]
+    expected: FAIL
+
+  [[["defaultparagraphseparator","p"\],["delete",""\]\] "<p>fo[o<ol><li>bar<li>baz</ol><p>q\]uz" compare innerHTML]
+    expected: FAIL
+
+  [[["delete",""\]\] "foo[<ol><li>\]bar</ol>" compare innerHTML]
+    expected: FAIL
+
+  [[["delete",""\]\] "foo[<dl><dt>\]bar<dd>baz</dl>" compare innerHTML]
+    expected: FAIL
+
+  [[["delete",""\]\] "foo[<dl><dd>\]bar</dl>" compare innerHTML]
+    expected: FAIL
+
+  [[["delete",""\]\] "[foo<b>&nbsp;\] bar</b>" compare innerHTML]
+    expected: FAIL
+
+  [[["delete",""\]\] "<span>[abc\]</span><br>" compare innerHTML]
+    expected: FAIL
+
   [[["delete",""\]\] "<p><span>[abc\]</span><br></p>" compare innerHTML]
+    expected: FAIL
+
+  [[["delete",""\]\] "<p contenteditable=false><span contenteditable=true>[abc\]</span></p>" compare innerHTML]
     expected: FAIL
 
 
@@ -784,16 +766,10 @@
   [[["stylewithcss","true"\],["delete",""\]\] "<p>foo<span style=color:#aBcDeF>[bar\]</span>baz": execCommand("stylewithcss", false, "true") return value]
     expected: FAIL
 
-  [[["stylewithcss","true"\],["delete",""\]\] "<p>foo<span style=color:#aBcDeF>[bar\]</span>baz" compare innerHTML]
-    expected: FAIL
-
   [[["stylewithcss","true"\],["delete",""\]\] "<p>foo<span style=color:#aBcDeF>[bar\]</span>baz" queryCommandState("stylewithcss") after]
     expected: FAIL
 
   [[["stylewithcss","false"\],["delete",""\]\] "<p>foo<span style=color:#aBcDeF>[bar\]</span>baz": execCommand("stylewithcss", false, "false") return value]
-    expected: FAIL
-
-  [[["stylewithcss","false"\],["delete",""\]\] "<p>foo<span style=color:#aBcDeF>[bar\]</span>baz" compare innerHTML]
     expected: FAIL
 
   [[["stylewithcss","false"\],["delete",""\]\] "<p>foo<span style=color:#aBcDeF>[bar\]</span>baz" queryCommandState("stylewithcss") before]
@@ -802,16 +778,10 @@
   [[["stylewithcss","true"\],["delete",""\]\] "<p>foo<span style=color:#aBcDeF>{bar}</span>baz": execCommand("stylewithcss", false, "true") return value]
     expected: FAIL
 
-  [[["stylewithcss","true"\],["delete",""\]\] "<p>foo<span style=color:#aBcDeF>{bar}</span>baz" compare innerHTML]
-    expected: FAIL
-
   [[["stylewithcss","true"\],["delete",""\]\] "<p>foo<span style=color:#aBcDeF>{bar}</span>baz" queryCommandState("stylewithcss") after]
     expected: FAIL
 
   [[["stylewithcss","false"\],["delete",""\]\] "<p>foo<span style=color:#aBcDeF>{bar}</span>baz": execCommand("stylewithcss", false, "false") return value]
-    expected: FAIL
-
-  [[["stylewithcss","false"\],["delete",""\]\] "<p>foo<span style=color:#aBcDeF>{bar}</span>baz" compare innerHTML]
     expected: FAIL
 
   [[["stylewithcss","false"\],["delete",""\]\] "<p>foo<span style=color:#aBcDeF>{bar}</span>baz" queryCommandState("stylewithcss") before]
@@ -922,16 +892,10 @@
   [[["stylewithcss","true"\],["delete",""\]\] "foo<b>[bar\]</b>baz": execCommand("stylewithcss", false, "true") return value]
     expected: FAIL
 
-  [[["stylewithcss","true"\],["delete",""\]\] "foo<b>[bar\]</b>baz" compare innerHTML]
-    expected: FAIL
-
   [[["stylewithcss","true"\],["delete",""\]\] "foo<b>[bar\]</b>baz" queryCommandState("stylewithcss") after]
     expected: FAIL
 
   [[["stylewithcss","false"\],["delete",""\]\] "foo<b>[bar\]</b>baz": execCommand("stylewithcss", false, "false") return value]
-    expected: FAIL
-
-  [[["stylewithcss","false"\],["delete",""\]\] "foo<b>[bar\]</b>baz" compare innerHTML]
     expected: FAIL
 
   [[["stylewithcss","false"\],["delete",""\]\] "foo<b>[bar\]</b>baz" queryCommandState("stylewithcss") before]
@@ -940,16 +904,10 @@
   [[["stylewithcss","true"\],["delete",""\]\] "foo<b>{bar}</b>baz": execCommand("stylewithcss", false, "true") return value]
     expected: FAIL
 
-  [[["stylewithcss","true"\],["delete",""\]\] "foo<b>{bar}</b>baz" compare innerHTML]
-    expected: FAIL
-
   [[["stylewithcss","true"\],["delete",""\]\] "foo<b>{bar}</b>baz" queryCommandState("stylewithcss") after]
     expected: FAIL
 
   [[["stylewithcss","false"\],["delete",""\]\] "foo<b>{bar}</b>baz": execCommand("stylewithcss", false, "false") return value]
-    expected: FAIL
-
-  [[["stylewithcss","false"\],["delete",""\]\] "foo<b>{bar}</b>baz" compare innerHTML]
     expected: FAIL
 
   [[["stylewithcss","false"\],["delete",""\]\] "foo<b>{bar}</b>baz" queryCommandState("stylewithcss") before]
@@ -965,18 +923,6 @@
     expected: FAIL
 
   [[["stylewithcss","false"\],["delete",""\]\] "foo{<b>bar</b>}baz" queryCommandState("stylewithcss") before]
-    expected: FAIL
-
-  [[["delete",""\]\] "foo<span>[bar\]</span>baz" compare innerHTML]
-    expected: FAIL
-
-  [[["delete",""\]\] "foo<span>{bar}</span>baz" compare innerHTML]
-    expected: FAIL
-
-  [[["delete",""\]\] "<p>foo</p><p>[bar\]</p><p>baz</p>" compare innerHTML]
-    expected: FAIL
-
-  [[["delete",""\]\] "<p>foo</p><p>{bar}</p><p>baz</p>" compare innerHTML]
     expected: FAIL
 
   [[["delete",""\]\] "<p>foo</p><p>{bar</p>}<p>baz</p>" compare innerHTML]
@@ -1027,9 +973,6 @@
   [[["defaultparagraphseparator","div"\],["delete",""\]\] "<p>foo[bar<p>baz\]quz": execCommand("defaultparagraphseparator", false, "div") return value]
     expected: FAIL
 
-  [[["defaultparagraphseparator","div"\],["delete",""\]\] "<p>foo[bar<p>baz\]quz" compare innerHTML]
-    expected: FAIL
-
   [[["defaultparagraphseparator","div"\],["delete",""\]\] "<p>foo[bar<p>baz\]quz" queryCommandValue("defaultparagraphseparator") before]
     expected: FAIL
 
@@ -1037,9 +980,6 @@
     expected: FAIL
 
   [[["defaultparagraphseparator","p"\],["delete",""\]\] "<p>foo[bar<p>baz\]quz": execCommand("defaultparagraphseparator", false, "p") return value]
-    expected: FAIL
-
-  [[["defaultparagraphseparator","p"\],["delete",""\]\] "<p>foo[bar<p>baz\]quz" compare innerHTML]
     expected: FAIL
 
   [[["defaultparagraphseparator","p"\],["delete",""\]\] "<p>foo[bar<p>baz\]quz" queryCommandValue("defaultparagraphseparator") before]
@@ -1051,9 +991,6 @@
   [[["defaultparagraphseparator","div"\],["delete",""\]\] "<p>foo[bar<div>baz\]quz</div>": execCommand("defaultparagraphseparator", false, "div") return value]
     expected: FAIL
 
-  [[["defaultparagraphseparator","div"\],["delete",""\]\] "<p>foo[bar<div>baz\]quz</div>" compare innerHTML]
-    expected: FAIL
-
   [[["defaultparagraphseparator","div"\],["delete",""\]\] "<p>foo[bar<div>baz\]quz</div>" queryCommandValue("defaultparagraphseparator") before]
     expected: FAIL
 
@@ -1063,24 +1000,66 @@
   [[["defaultparagraphseparator","p"\],["delete",""\]\] "<p>foo[bar<div>baz\]quz</div>": execCommand("defaultparagraphseparator", false, "p") return value]
     expected: FAIL
 
-  [[["defaultparagraphseparator","p"\],["delete",""\]\] "<p>foo[bar<div>baz\]quz</div>" compare innerHTML]
-    expected: FAIL
-
   [[["defaultparagraphseparator","p"\],["delete",""\]\] "<p>foo[bar<div>baz\]quz</div>" queryCommandValue("defaultparagraphseparator") before]
     expected: FAIL
 
   [[["defaultparagraphseparator","p"\],["delete",""\]\] "<p>foo[bar<div>baz\]quz</div>" queryCommandValue("defaultparagraphseparator") after]
     expected: FAIL
 
+  [[["stylewithcss","true"\],["delete",""\]\] "<p>foo<span style=color:#aBcDeF>[bar\]</span>baz" compare innerHTML]
+    expected: FAIL
+
+  [[["stylewithcss","false"\],["delete",""\]\] "<p>foo<span style=color:#aBcDeF>[bar\]</span>baz" compare innerHTML]
+    expected: FAIL
+
+  [[["stylewithcss","true"\],["delete",""\]\] "<p>foo<span style=color:#aBcDeF>{bar}</span>baz" compare innerHTML]
+    expected: FAIL
+
+  [[["stylewithcss","false"\],["delete",""\]\] "<p>foo<span style=color:#aBcDeF>{bar}</span>baz" compare innerHTML]
+    expected: FAIL
+
+  [[["stylewithcss","true"\],["delete",""\]\] "<p>foo{<span style=color:#aBcDeF>bar</span>}baz" compare innerHTML]
+    expected: FAIL
+
+  [[["stylewithcss","false"\],["delete",""\]\] "<p>foo{<span style=color:#aBcDeF>bar</span>}baz" compare innerHTML]
+    expected: FAIL
+
+  [[["stylewithcss","true"\],["delete",""\]\] "foo<b>[bar\]</b>baz" compare innerHTML]
+    expected: FAIL
+
+  [[["stylewithcss","false"\],["delete",""\]\] "foo<b>[bar\]</b>baz" compare innerHTML]
+    expected: FAIL
+
+  [[["stylewithcss","true"\],["delete",""\]\] "foo<b>{bar}</b>baz" compare innerHTML]
+    expected: FAIL
+
+  [[["stylewithcss","false"\],["delete",""\]\] "foo<b>{bar}</b>baz" compare innerHTML]
+    expected: FAIL
+
+  [[["stylewithcss","true"\],["delete",""\]\] "foo{<b>bar</b>}baz" compare innerHTML]
+    expected: FAIL
+
+  [[["stylewithcss","false"\],["delete",""\]\] "foo{<b>bar</b>}baz" compare innerHTML]
+    expected: FAIL
+
+  [[["delete",""\]\] "foo<span>[bar\]</span>baz" compare innerHTML]
+    expected: FAIL
+
+  [[["delete",""\]\] "foo<span>{bar}</span>baz" compare innerHTML]
+    expected: FAIL
+
+  [[["delete",""\]\] "foo{<span>bar</span>}baz" compare innerHTML]
+    expected: FAIL
+
+  [[["defaultparagraphseparator","div"\],["delete",""\]\] "<p>foo</p>{<p>bar</p>}<p>baz</p>" compare innerHTML]
+    expected: FAIL
+
+  [[["defaultparagraphseparator","p"\],["delete",""\]\] "<p>foo</p>{<p>bar</p>}<p>baz</p>" compare innerHTML]
+    expected: FAIL
+
 
 [delete.html?5001-6000]
-  [[["delete",""\]\] "<p>foo[bar<h1>baz\]quz</h1>" compare innerHTML]
-    expected: FAIL
-
   [[["defaultparagraphseparator","div"\],["delete",""\]\] "<div>foo[bar</div><p>baz\]quz": execCommand("defaultparagraphseparator", false, "div") return value]
-    expected: FAIL
-
-  [[["defaultparagraphseparator","div"\],["delete",""\]\] "<div>foo[bar</div><p>baz\]quz" compare innerHTML]
     expected: FAIL
 
   [[["defaultparagraphseparator","div"\],["delete",""\]\] "<div>foo[bar</div><p>baz\]quz" queryCommandValue("defaultparagraphseparator") before]
@@ -1092,22 +1071,13 @@
   [[["defaultparagraphseparator","p"\],["delete",""\]\] "<div>foo[bar</div><p>baz\]quz": execCommand("defaultparagraphseparator", false, "p") return value]
     expected: FAIL
 
-  [[["defaultparagraphseparator","p"\],["delete",""\]\] "<div>foo[bar</div><p>baz\]quz" compare innerHTML]
-    expected: FAIL
-
   [[["defaultparagraphseparator","p"\],["delete",""\]\] "<div>foo[bar</div><p>baz\]quz" queryCommandValue("defaultparagraphseparator") before]
     expected: FAIL
 
   [[["defaultparagraphseparator","p"\],["delete",""\]\] "<div>foo[bar</div><p>baz\]quz" queryCommandValue("defaultparagraphseparator") after]
     expected: FAIL
 
-  [[["delete",""\]\] "<blockquote>foo[bar</blockquote><pre>baz\]quz</pre>" compare innerHTML]
-    expected: FAIL
-
   [[["defaultparagraphseparator","div"\],["delete",""\]\] "<p><b>foo[bar</b><p>baz\]quz": execCommand("defaultparagraphseparator", false, "div") return value]
-    expected: FAIL
-
-  [[["defaultparagraphseparator","div"\],["delete",""\]\] "<p><b>foo[bar</b><p>baz\]quz" compare innerHTML]
     expected: FAIL
 
   [[["defaultparagraphseparator","div"\],["delete",""\]\] "<p><b>foo[bar</b><p>baz\]quz" queryCommandValue("defaultparagraphseparator") before]
@@ -1119,9 +1089,6 @@
   [[["defaultparagraphseparator","p"\],["delete",""\]\] "<p><b>foo[bar</b><p>baz\]quz": execCommand("defaultparagraphseparator", false, "p") return value]
     expected: FAIL
 
-  [[["defaultparagraphseparator","p"\],["delete",""\]\] "<p><b>foo[bar</b><p>baz\]quz" compare innerHTML]
-    expected: FAIL
-
   [[["defaultparagraphseparator","p"\],["delete",""\]\] "<p><b>foo[bar</b><p>baz\]quz" queryCommandValue("defaultparagraphseparator") before]
     expected: FAIL
 
@@ -1129,9 +1096,6 @@
     expected: FAIL
 
   [[["defaultparagraphseparator","div"\],["delete",""\]\] "<div><p>foo[bar</div><p>baz\]quz": execCommand("defaultparagraphseparator", false, "div") return value]
-    expected: FAIL
-
-  [[["defaultparagraphseparator","div"\],["delete",""\]\] "<div><p>foo[bar</div><p>baz\]quz" compare innerHTML]
     expected: FAIL
 
   [[["defaultparagraphseparator","div"\],["delete",""\]\] "<div><p>foo[bar</div><p>baz\]quz" queryCommandValue("defaultparagraphseparator") before]
@@ -1143,9 +1107,6 @@
   [[["defaultparagraphseparator","p"\],["delete",""\]\] "<div><p>foo[bar</div><p>baz\]quz": execCommand("defaultparagraphseparator", false, "p") return value]
     expected: FAIL
 
-  [[["defaultparagraphseparator","p"\],["delete",""\]\] "<div><p>foo[bar</div><p>baz\]quz" compare innerHTML]
-    expected: FAIL
-
   [[["defaultparagraphseparator","p"\],["delete",""\]\] "<div><p>foo[bar</div><p>baz\]quz" queryCommandValue("defaultparagraphseparator") before]
     expected: FAIL
 
@@ -1155,9 +1116,6 @@
   [[["defaultparagraphseparator","div"\],["delete",""\]\] "<p>foo[bar<blockquote><p>baz\]quz<p>qoz</blockquote": execCommand("defaultparagraphseparator", false, "div") return value]
     expected: FAIL
 
-  [[["defaultparagraphseparator","div"\],["delete",""\]\] "<p>foo[bar<blockquote><p>baz\]quz<p>qoz</blockquote" compare innerHTML]
-    expected: FAIL
-
   [[["defaultparagraphseparator","div"\],["delete",""\]\] "<p>foo[bar<blockquote><p>baz\]quz<p>qoz</blockquote" queryCommandValue("defaultparagraphseparator") before]
     expected: FAIL
 
@@ -1165,9 +1123,6 @@
     expected: FAIL
 
   [[["defaultparagraphseparator","p"\],["delete",""\]\] "<p>foo[bar<blockquote><p>baz\]quz<p>qoz</blockquote": execCommand("defaultparagraphseparator", false, "p") return value]
-    expected: FAIL
-
-  [[["defaultparagraphseparator","p"\],["delete",""\]\] "<p>foo[bar<blockquote><p>baz\]quz<p>qoz</blockquote" compare innerHTML]
     expected: FAIL
 
   [[["defaultparagraphseparator","p"\],["delete",""\]\] "<p>foo[bar<blockquote><p>baz\]quz<p>qoz</blockquote" queryCommandValue("defaultparagraphseparator") before]
@@ -1251,9 +1206,6 @@
   [[["defaultparagraphseparator","div"\],["delete",""\]\] "<p>foo[bar<p><b>baz\]quz</b>": execCommand("defaultparagraphseparator", false, "div") return value]
     expected: FAIL
 
-  [[["defaultparagraphseparator","div"\],["delete",""\]\] "<p>foo[bar<p><b>baz\]quz</b>" compare innerHTML]
-    expected: FAIL
-
   [[["defaultparagraphseparator","div"\],["delete",""\]\] "<p>foo[bar<p><b>baz\]quz</b>" queryCommandValue("defaultparagraphseparator") before]
     expected: FAIL
 
@@ -1261,9 +1213,6 @@
     expected: FAIL
 
   [[["defaultparagraphseparator","p"\],["delete",""\]\] "<p>foo[bar<p><b>baz\]quz</b>": execCommand("defaultparagraphseparator", false, "p") return value]
-    expected: FAIL
-
-  [[["defaultparagraphseparator","p"\],["delete",""\]\] "<p>foo[bar<p><b>baz\]quz</b>" compare innerHTML]
     expected: FAIL
 
   [[["defaultparagraphseparator","p"\],["delete",""\]\] "<p>foo[bar<p><b>baz\]quz</b>" queryCommandValue("defaultparagraphseparator") before]
@@ -1299,9 +1248,6 @@
   [[["defaultparagraphseparator","div"\],["delete",""\]\] "<p>foo[</p><p>\]bar</p>": execCommand("defaultparagraphseparator", false, "div") return value]
     expected: FAIL
 
-  [[["defaultparagraphseparator","div"\],["delete",""\]\] "<p>foo[</p><p>\]bar</p>" compare innerHTML]
-    expected: FAIL
-
   [[["defaultparagraphseparator","div"\],["delete",""\]\] "<p>foo[</p><p>\]bar</p>" queryCommandValue("defaultparagraphseparator") before]
     expected: FAIL
 
@@ -1309,9 +1255,6 @@
     expected: FAIL
 
   [[["defaultparagraphseparator","p"\],["delete",""\]\] "<p>foo[</p><p>\]bar</p>": execCommand("defaultparagraphseparator", false, "p") return value]
-    expected: FAIL
-
-  [[["defaultparagraphseparator","p"\],["delete",""\]\] "<p>foo[</p><p>\]bar</p>" compare innerHTML]
     expected: FAIL
 
   [[["defaultparagraphseparator","p"\],["delete",""\]\] "<p>foo[</p><p>\]bar</p>" queryCommandValue("defaultparagraphseparator") before]
@@ -1347,9 +1290,6 @@
   [[["defaultparagraphseparator","div"\],["delete",""\]\] "foo[<p>\]bar</p>": execCommand("defaultparagraphseparator", false, "div") return value]
     expected: FAIL
 
-  [[["defaultparagraphseparator","div"\],["delete",""\]\] "foo[<p>\]bar</p>" compare innerHTML]
-    expected: FAIL
-
   [[["defaultparagraphseparator","div"\],["delete",""\]\] "foo[<p>\]bar</p>" queryCommandValue("defaultparagraphseparator") before]
     expected: FAIL
 
@@ -1357,9 +1297,6 @@
     expected: FAIL
 
   [[["defaultparagraphseparator","p"\],["delete",""\]\] "foo[<p>\]bar</p>": execCommand("defaultparagraphseparator", false, "p") return value]
-    expected: FAIL
-
-  [[["defaultparagraphseparator","p"\],["delete",""\]\] "foo[<p>\]bar</p>" compare innerHTML]
     expected: FAIL
 
   [[["defaultparagraphseparator","p"\],["delete",""\]\] "foo[<p>\]bar</p>" queryCommandValue("defaultparagraphseparator") before]
@@ -1371,9 +1308,6 @@
   [[["defaultparagraphseparator","div"\],["delete",""\]\] "foo{<p>}bar</p>": execCommand("defaultparagraphseparator", false, "div") return value]
     expected: FAIL
 
-  [[["defaultparagraphseparator","div"\],["delete",""\]\] "foo{<p>}bar</p>" compare innerHTML]
-    expected: FAIL
-
   [[["defaultparagraphseparator","div"\],["delete",""\]\] "foo{<p>}bar</p>" queryCommandValue("defaultparagraphseparator") before]
     expected: FAIL
 
@@ -1383,16 +1317,10 @@
   [[["defaultparagraphseparator","p"\],["delete",""\]\] "foo{<p>}bar</p>": execCommand("defaultparagraphseparator", false, "p") return value]
     expected: FAIL
 
-  [[["defaultparagraphseparator","p"\],["delete",""\]\] "foo{<p>}bar</p>" compare innerHTML]
-    expected: FAIL
-
   [[["defaultparagraphseparator","p"\],["delete",""\]\] "foo{<p>}bar</p>" queryCommandValue("defaultparagraphseparator") before]
     expected: FAIL
 
   [[["defaultparagraphseparator","p"\],["delete",""\]\] "foo{<p>}bar</p>" queryCommandValue("defaultparagraphseparator") after]
-    expected: FAIL
-
-  [[["delete",""\]\] "foo[<p>\]bar<br>baz</p>" compare innerHTML]
     expected: FAIL
 
   [[["defaultparagraphseparator","div"\],["delete",""\]\] "foo[<p>\]bar</p>baz": execCommand("defaultparagraphseparator", false, "div") return value]
@@ -1479,9 +1407,6 @@
   [[["defaultparagraphseparator","div"\],["delete",""\]\] "foo[<div><p>\]bar</div>": execCommand("defaultparagraphseparator", false, "div") return value]
     expected: FAIL
 
-  [[["defaultparagraphseparator","div"\],["delete",""\]\] "foo[<div><p>\]bar</div>" compare innerHTML]
-    expected: FAIL
-
   [[["defaultparagraphseparator","div"\],["delete",""\]\] "foo[<div><p>\]bar</div>" queryCommandValue("defaultparagraphseparator") before]
     expected: FAIL
 
@@ -1489,9 +1414,6 @@
     expected: FAIL
 
   [[["defaultparagraphseparator","p"\],["delete",""\]\] "foo[<div><p>\]bar</div>": execCommand("defaultparagraphseparator", false, "p") return value]
-    expected: FAIL
-
-  [[["defaultparagraphseparator","p"\],["delete",""\]\] "foo[<div><p>\]bar</div>" compare innerHTML]
     expected: FAIL
 
   [[["defaultparagraphseparator","p"\],["delete",""\]\] "foo[<div><p>\]bar</div>" queryCommandValue("defaultparagraphseparator") before]
@@ -1506,9 +1428,6 @@
   [[["defaultparagraphseparator","div"\],["delete",""\]\] "foo[<div><p>\]bar</p>baz</div>": execCommand("defaultparagraphseparator", false, "div") return value]
     expected: FAIL
 
-  [[["defaultparagraphseparator","div"\],["delete",""\]\] "foo[<div><p>\]bar</p>baz</div>" compare innerHTML]
-    expected: FAIL
-
   [[["defaultparagraphseparator","div"\],["delete",""\]\] "foo[<div><p>\]bar</p>baz</div>" queryCommandValue("defaultparagraphseparator") before]
     expected: FAIL
 
@@ -1518,16 +1437,10 @@
   [[["defaultparagraphseparator","p"\],["delete",""\]\] "foo[<div><p>\]bar</p>baz</div>": execCommand("defaultparagraphseparator", false, "p") return value]
     expected: FAIL
 
-  [[["defaultparagraphseparator","p"\],["delete",""\]\] "foo[<div><p>\]bar</p>baz</div>" compare innerHTML]
-    expected: FAIL
-
   [[["defaultparagraphseparator","p"\],["delete",""\]\] "foo[<div><p>\]bar</p>baz</div>" queryCommandValue("defaultparagraphseparator") before]
     expected: FAIL
 
   [[["defaultparagraphseparator","p"\],["delete",""\]\] "foo[<div><p>\]bar</p>baz</div>" queryCommandValue("defaultparagraphseparator") after]
-    expected: FAIL
-
-  [[["delete",""\]\] "foo[<div>\]bar<p>baz</p></div>" compare innerHTML]
     expected: FAIL
 
   [[["delete",""\]\] "<div><p>foo</p>bar[</div>\]baz" compare innerHTML]
@@ -1545,9 +1458,6 @@
   [[["defaultparagraphseparator","div"\],["delete",""\]\] "foo<br>{<p>\]bar</p>": execCommand("defaultparagraphseparator", false, "div") return value]
     expected: FAIL
 
-  [[["defaultparagraphseparator","div"\],["delete",""\]\] "foo<br>{<p>\]bar</p>" compare innerHTML]
-    expected: FAIL
-
   [[["defaultparagraphseparator","div"\],["delete",""\]\] "foo<br>{<p>\]bar</p>" queryCommandValue("defaultparagraphseparator") before]
     expected: FAIL
 
@@ -1555,9 +1465,6 @@
     expected: FAIL
 
   [[["defaultparagraphseparator","p"\],["delete",""\]\] "foo<br>{<p>\]bar</p>": execCommand("defaultparagraphseparator", false, "p") return value]
-    expected: FAIL
-
-  [[["defaultparagraphseparator","p"\],["delete",""\]\] "foo<br>{<p>\]bar</p>" compare innerHTML]
     expected: FAIL
 
   [[["defaultparagraphseparator","p"\],["delete",""\]\] "foo<br>{<p>\]bar</p>" queryCommandValue("defaultparagraphseparator") before]
@@ -1593,9 +1500,6 @@
   [[["defaultparagraphseparator","div"\],["delete",""\]\] "<p>foo<br>{</p><p>}bar</p>": execCommand("defaultparagraphseparator", false, "div") return value]
     expected: FAIL
 
-  [[["defaultparagraphseparator","div"\],["delete",""\]\] "<p>foo<br>{</p><p>}bar</p>" compare innerHTML]
-    expected: FAIL
-
   [[["defaultparagraphseparator","div"\],["delete",""\]\] "<p>foo<br>{</p><p>}bar</p>" queryCommandValue("defaultparagraphseparator") before]
     expected: FAIL
 
@@ -1603,9 +1507,6 @@
     expected: FAIL
 
   [[["defaultparagraphseparator","p"\],["delete",""\]\] "<p>foo<br>{</p><p>}bar</p>": execCommand("defaultparagraphseparator", false, "p") return value]
-    expected: FAIL
-
-  [[["defaultparagraphseparator","p"\],["delete",""\]\] "<p>foo<br>{</p><p>}bar</p>" compare innerHTML]
     expected: FAIL
 
   [[["defaultparagraphseparator","p"\],["delete",""\]\] "<p>foo<br>{</p><p>}bar</p>" queryCommandValue("defaultparagraphseparator") before]
@@ -1638,9 +1539,6 @@
   [[["defaultparagraphseparator","p"\],["delete",""\]\] "<p>foo<br><br>{</p><p>}bar</p>" queryCommandValue("defaultparagraphseparator") after]
     expected: FAIL
 
-  [[["delete",""\]\] "<table><tbody><tr><th>foo<th>[bar\]<th>baz<tr><td>quz<td>qoz<td>qiz</table>" compare innerHTML]
-    expected: FAIL
-
   [[["delete",""\]\] "<table><tbody><tr><th>fo[o<th>bar<th>b\]az<tr><td>quz<td>qoz<td>qiz</table>" compare innerHTML]
     expected: FAIL
 
@@ -1650,16 +1548,10 @@
   [[["delete",""\]\] "<table><tbody><tr><th>[foo<th>bar<th>baz<tr><td>quz<td>qoz<td>qiz\]</table>" compare innerHTML]
     expected: FAIL
 
-  [[["delete",""\]\] "{<table><tbody><tr><th>foo<th>bar<th>baz<tr><td>quz<td>qoz<td>qiz</table>}" compare innerHTML]
-    expected: FAIL
-
   [[["delete",""\]\] "<table><tbody><tr><td>foo<td>ba[r<tr><td>baz<td>quz<tr><td>q\]oz<td>qiz</table>" compare innerHTML]
     expected: FAIL
 
   [[["defaultparagraphseparator","div"\],["delete",""\]\] "<p>fo[o<table><tr><td>bar</table><p>b\]az": execCommand("defaultparagraphseparator", false, "div") return value]
-    expected: FAIL
-
-  [[["defaultparagraphseparator","div"\],["delete",""\]\] "<p>fo[o<table><tr><td>bar</table><p>b\]az" compare innerHTML]
     expected: FAIL
 
   [[["defaultparagraphseparator","div"\],["delete",""\]\] "<p>fo[o<table><tr><td>bar</table><p>b\]az" queryCommandValue("defaultparagraphseparator") before]
@@ -1671,34 +1563,70 @@
   [[["defaultparagraphseparator","p"\],["delete",""\]\] "<p>fo[o<table><tr><td>bar</table><p>b\]az": execCommand("defaultparagraphseparator", false, "p") return value]
     expected: FAIL
 
-  [[["defaultparagraphseparator","p"\],["delete",""\]\] "<p>fo[o<table><tr><td>bar</table><p>b\]az" compare innerHTML]
-    expected: FAIL
-
   [[["defaultparagraphseparator","p"\],["delete",""\]\] "<p>fo[o<table><tr><td>bar</table><p>b\]az" queryCommandValue("defaultparagraphseparator") before]
     expected: FAIL
 
   [[["defaultparagraphseparator","p"\],["delete",""\]\] "<p>fo[o<table><tr><td>bar</table><p>b\]az" queryCommandValue("defaultparagraphseparator") after]
     expected: FAIL
 
-  [[["delete",""\]\] "<p>foo<ol><li>ba[r<li>b\]az</ol><p>quz" compare innerHTML]
-    expected: FAIL
-
-  [[["delete",""\]\] "<p>foo<ol><li>bar<li>[baz\]</ol><p>quz" compare innerHTML]
-    expected: FAIL
-
-  [[["delete",""\]\] "<p>fo[o<ol><li>b\]ar<li>baz</ol><p>quz" compare innerHTML]
-    expected: FAIL
-
   [[["defaultparagraphseparator","div"\],["delete",""\]\] "<p>foo<ol><li>bar<li>ba[z</ol><p>q\]uz": execCommand("defaultparagraphseparator", false, "div") return value]
-    expected: FAIL
-
-  [[["defaultparagraphseparator","div"\],["delete",""\]\] "<p>foo<ol><li>bar<li>ba[z</ol><p>q\]uz" compare innerHTML]
     expected: FAIL
 
   [[["defaultparagraphseparator","div"\],["delete",""\]\] "<p>foo<ol><li>bar<li>ba[z</ol><p>q\]uz" queryCommandValue("defaultparagraphseparator") before]
     expected: FAIL
 
   [[["defaultparagraphseparator","div"\],["delete",""\]\] "<p>foo<ol><li>bar<li>ba[z</ol><p>q\]uz" queryCommandValue("defaultparagraphseparator") after]
+    expected: FAIL
+
+  [[["delete",""\]\] "foo[<br>\]bar" compare innerHTML]
+    expected: FAIL
+
+  [[["defaultparagraphseparator","div"\],["delete",""\]\] "foo[<p>\]bar</p>" compare innerHTML]
+    expected: FAIL
+
+  [[["defaultparagraphseparator","p"\],["delete",""\]\] "foo[<p>\]bar</p>" compare innerHTML]
+    expected: FAIL
+
+  [[["defaultparagraphseparator","div"\],["delete",""\]\] "foo{<p>}bar</p>" compare innerHTML]
+    expected: FAIL
+
+  [[["defaultparagraphseparator","p"\],["delete",""\]\] "foo{<p>}bar</p>" compare innerHTML]
+    expected: FAIL
+
+  [[["delete",""\]\] "foo[<p>\]bar<br>baz</p>" compare innerHTML]
+    expected: FAIL
+
+  [[["defaultparagraphseparator","div"\],["delete",""\]\] "foo{<p>bar</p>}baz" compare innerHTML]
+    expected: FAIL
+
+  [[["defaultparagraphseparator","p"\],["delete",""\]\] "foo{<p>bar</p>}baz" compare innerHTML]
+    expected: FAIL
+
+  [[["defaultparagraphseparator","div"\],["delete",""\]\] "foo[<div><p>\]bar</div>" compare innerHTML]
+    expected: FAIL
+
+  [[["defaultparagraphseparator","p"\],["delete",""\]\] "foo[<div><p>\]bar</div>" compare innerHTML]
+    expected: FAIL
+
+  [[["defaultparagraphseparator","div"\],["delete",""\]\] "foo[<div><p>\]bar</p>baz</div>" compare innerHTML]
+    expected: FAIL
+
+  [[["defaultparagraphseparator","p"\],["delete",""\]\] "foo[<div><p>\]bar</p>baz</div>" compare innerHTML]
+    expected: FAIL
+
+  [[["delete",""\]\] "foo[<div>\]bar<p>baz</p></div>" compare innerHTML]
+    expected: FAIL
+
+  [[["defaultparagraphseparator","div"\],["delete",""\]\] "foo<br>{<p>\]bar</p>" compare innerHTML]
+    expected: FAIL
+
+  [[["defaultparagraphseparator","p"\],["delete",""\]\] "foo<br>{<p>\]bar</p>" compare innerHTML]
+    expected: FAIL
+
+  [[["defaultparagraphseparator","div"\],["delete",""\]\] "<p>fo[o<table><tr><td>bar</table><p>b\]az" compare innerHTML]
+    expected: FAIL
+
+  [[["defaultparagraphseparator","p"\],["delete",""\]\] "<p>fo[o<table><tr><td>bar</table><p>b\]az" compare innerHTML]
     expected: FAIL
 
 
@@ -3357,6 +3285,63 @@
   [[["defaultparagraphseparator","div"\],["delete",""\]\] "<ol><li><br></ol><p>{}<br>" queryCommandValue("defaultparagraphseparator") after]
     expected: FAIL
 
+  [[["delete",""\]\] "foo<table><tr><td>[\]bar</table>baz" compare innerHTML]
+    expected: FAIL
+
+  [[["delete",""\]\] "foo<table><tr><td>bar</table>[\]baz" compare innerHTML]
+    expected: FAIL
+
+  [[["delete",""\]\] "<p>foo<table><tr><td>[\]bar</table><p>baz" compare innerHTML]
+    expected: FAIL
+
+  [[["delete",""\]\] "<p>foo<table><tr><td>bar</table><p>[\]baz" compare innerHTML]
+    expected: FAIL
+
+  [[["delete",""\]\] "<table><tr><td>foo<td>[\]bar</table>" compare innerHTML]
+    expected: FAIL
+
+  [[["delete",""\]\] "<table><tr><td>foo<tr><td>[\]bar</table>" compare innerHTML]
+    expected: FAIL
+
+  [[["delete",""\]\] "foo<table><tr><td>bar<br></table>[\]baz" compare innerHTML]
+    expected: FAIL
+
+  [[["delete",""\]\] "<p>foo<br><table><tr><td>[\]bar</table><p>baz" compare innerHTML]
+    expected: FAIL
+
+  [[["delete",""\]\] "<p>foo<table><tr><td>bar<br></table><p>[\]baz" compare innerHTML]
+    expected: FAIL
+
+  [[["delete",""\]\] "foo<br><br><table><tr><td>[\]bar</table>baz" compare innerHTML]
+    expected: FAIL
+
+  [[["delete",""\]\] "foo<table><tr><td>bar<br><br></table>[\]baz" compare innerHTML]
+    expected: FAIL
+
+  [[["delete",""\]\] "<p>foo<br><br><table><tr><td>[\]bar</table><p>baz" compare innerHTML]
+    expected: FAIL
+
+  [[["delete",""\]\] "<p>foo<table><tr><td>bar<br><br></table><p>[\]baz" compare innerHTML]
+    expected: FAIL
+
+  [[["delete",""\]\] "<table><tr><td>foo<br><br><td>[\]bar</table>" compare innerHTML]
+    expected: FAIL
+
+  [[["delete",""\]\] "<table><tr><td>foo<br><br><tr><td>[\]bar</table>" compare innerHTML]
+    expected: FAIL
+
+  [[["delete",""\]\] "foo<hr><table><tr><td>[\]bar</table>baz" compare innerHTML]
+    expected: FAIL
+
+  [[["delete",""\]\] "foo<table><tr><td>bar<hr></table>[\]baz" compare innerHTML]
+    expected: FAIL
+
+  [[["delete",""\]\] "<table><tr><td>foo<hr><td>[\]bar</table>" compare innerHTML]
+    expected: FAIL
+
+  [[["delete",""\]\] "<table><tr><td>foo<hr><tr><td>[\]bar</table>" compare innerHTML]
+    expected: FAIL
+
 
 [delete.html?7001-last]
   [[["delete",""\]\] "<div><div>{}<br></div></div>" compare innerHTML]
@@ -4019,16 +4004,16 @@
   [[["delete",""\]\] " <div><span contenteditable=\\"false\\">A</span></div><div>[\]&nbsp;; <span contenteditable=\\"false\\">B</span> ; <span contenteditable=\\"false\\">C</span></div> " compare innerHTML]
     expected: FAIL
 
-  [[["delete",""\]\] " <span contenteditable=\\"false\\">A</span><div><br></div><div>[\]&nbsp;; <span contenteditable=\\"false\\">B</span> ; <span contenteditable=\\"false\\">C</span></div> " compare innerHTML]
-    expected: FAIL
-
   [[["delete",""\]\] " <span contenteditable=\\"false\\">A</span><div>[\]&nbsp;; <span contenteditable=\\"false\\">B</span> ; <span contenteditable=\\"false\\">C</span></div> " compare innerHTML]
     expected: FAIL
 
   [[["delete",""\]\] " <span contenteditable=\\"false\\">A</span><br><br>[\]&nbsp;; <span contenteditable=\\"false\\">B</span> ; <span contenteditable=\\"false\\">C</span> " compare innerHTML]
     expected: FAIL
 
-  [[["delete",""\]\] " <span contenteditable=\\"false\\">A</span><br>[\]&nbsp;; <span contenteditable=\\"false\\">B</span> ; <span contenteditable=\\"false\\">C</span> " compare innerHTML]
+  [[["delete",""\]\] "<p contenteditable=\\"false\\"><span contenteditable>[abc\]</span></p>" compare innerHTML]
+    expected: FAIL
+
+  [[["delete",""\]\] "<p contenteditable=\\"false\\"><unknown-element contenteditable>[abc\]</unknown-element></p>" compare innerHTML]
     expected: FAIL
 
 

--- a/tests/wpt/meta/editing/whitespaces/chrome-compat/delete-img.tentative.html.ini
+++ b/tests/wpt/meta/editing/whitespaces/chrome-compat/delete-img.tentative.html.ini
@@ -1,7 +1,4 @@
 [delete-img.tentative.html]
-  [document.execCommand("delete") when "<img src="${src}">[\]&nbsp;&nbsp;&nbsp;"]
-    expected: FAIL
-
   [document.execCommand("delete") when "<img src="${src}">[\]&nbsp;&nbsp;&nbsp;b"]
     expected: FAIL
 

--- a/tests/wpt/meta/editing/whitespaces/chrome-compat/delete-to-join-blocks.tentative.html.ini
+++ b/tests/wpt/meta/editing/whitespaces/chrome-compat/delete-to-join-blocks.tentative.html.ini
@@ -5,9 +5,6 @@
   [document.execCommand("delete") when "<div>a&nbsp;&nbsp;&nbsp;</div><div>{}<br></div>"]
     expected: FAIL
 
-  [document.execCommand("delete") when "<div><br></div><div>[\]&nbsp;&nbsp;&nbsp;</div>"]
-    expected: FAIL
-
   [document.execCommand("delete") when "<div><br></div><div>[\]&nbsp;&nbsp;&nbsp;b</div>"]
     expected: FAIL
 
@@ -23,9 +20,6 @@
   [document.execCommand("delete") when "<div>a&nbsp;&nbsp;&nbsp;<div>{}<br></div></div>"]
     expected: FAIL
 
-  [document.execCommand("delete") when "<div><br><div>[\]&nbsp;&nbsp;&nbsp;</div></div>"]
-    expected: FAIL
-
   [document.execCommand("delete") when "<div><br><div>[\]&nbsp;&nbsp;&nbsp;b</div></div>"]
     expected: FAIL
 
@@ -39,9 +33,6 @@
     expected: FAIL
 
   [document.execCommand("delete") when "<div><div>a&nbsp;&nbsp;&nbsp;</div>{}<br></div>"]
-    expected: FAIL
-
-  [document.execCommand("delete") when "<div><div><br></div>[\]&nbsp;&nbsp;&nbsp;</div>"]
     expected: FAIL
 
   [document.execCommand("delete") when "<div><div><br></div>[\]&nbsp;&nbsp;&nbsp;b</div>"]


### PR DESCRIPTION
This continues implementation of the delete command for document.execCommand. Unfortunately, since these algorithms are vast (30+ steps) and partial implementation leads to lots of issues, this PR is "draw the rest of the owl".

I have tried to keep things manageable, by only implementing a couple of extra steps in the delete command, so that we can focus on the "Delete the selection" part.

To do that, several algorithms had to be implemented. Most of these algorithms are required both by commands and by algorithms themselves, which is why they are now exposed on a trait.

Additionally, all code now uses `cx`, to make sure it is up-to-date with the ongoing migration and since some of the DOM API's it needs to call already require `cx`.

Part of #25005