### PR TITLE
script: Refactors GPURenderPassEncoder's drop implementation.

### DIFF
--- a/components/script/dom/webgpu/gpurenderpassencoder.rs
+++ b/components/script/dom/webgpu/gpurenderpassencoder.rs
@@ -23,15 +23,31 @@ use crate::dom::webgpu::gpurenderbundle::GPURenderBundle;
 use crate::dom::webgpu::gpurenderpipeline::GPURenderPipeline;
 use crate::script_runtime::CanGc;
 
+#[derive(JSTraceable, MallocSizeOf)]
+struct DroppableGPURenderPassEncoder {
+    #[no_trace]
+    channel: WebGPU,
+    #[no_trace]
+    render_pass: WebGPURenderPass,
+}
+
+impl Drop for DroppableGPURenderPassEncoder {
+    fn drop(&mut self) {
+        if let Err(e) = self
+            .channel
+            .0
+            .send(WebGPURequest::DropRenderPass(self.render_pass.0))
+        {
+            warn!("Failed to send WebGPURequest::DropRenderPass with {e:?}");
+        }
+    }
+}
 #[dom_struct]
 pub(crate) struct GPURenderPassEncoder {
     reflector_: Reflector,
-    #[no_trace]
-    channel: WebGPU,
     label: DomRefCell<USVString>,
-    #[no_trace]
-    render_pass: WebGPURenderPass,
     command_encoder: Dom<GPUCommandEncoder>,
+    droppable: DroppableGPURenderPassEncoder,
 }
 
 impl GPURenderPassEncoder {
@@ -42,11 +58,13 @@ impl GPURenderPassEncoder {
         label: USVString,
     ) -> Self {
         Self {
-            channel,
             reflector_: Reflector::new(),
             label: DomRefCell::new(label),
-            render_pass,
             command_encoder: Dom::from_ref(parent),
+            droppable: DroppableGPURenderPassEncoder {
+                channel,
+                render_pass,
+            },
         }
     }
 
@@ -71,13 +89,24 @@ impl GPURenderPassEncoder {
     }
 
     fn send_render_command(&self, render_command: RenderCommand) {
-        if let Err(e) = self.channel.0.send(WebGPURequest::RenderPassCommand {
-            render_pass_id: self.render_pass.0,
-            render_command,
-            device_id: self.command_encoder.device_id().0,
-        }) {
+        if let Err(e) = self
+            .droppable
+            .channel
+            .0
+            .send(WebGPURequest::RenderPassCommand {
+                render_pass_id: self.id().0,
+                render_command,
+                device_id: self.command_encoder.device_id().0,
+            })
+        {
             warn!("Error sending WebGPURequest::RenderPassCommand: {e:?}")
         }
+    }
+}
+
+impl GPURenderPassEncoder {
+    pub(crate) fn id(&self) -> WebGPURenderPass {
+        self.droppable.render_pass
     }
 }
 
@@ -144,8 +173,8 @@ impl GPURenderPassEncoderMethods<crate::DomTypeHolder> for GPURenderPassEncoder 
 
     /// <https://gpuweb.github.io/gpuweb/#dom-gpurenderpassencoder-end>
     fn End(&self) {
-        if let Err(e) = self.channel.0.send(WebGPURequest::EndRenderPass {
-            render_pass_id: self.render_pass.0,
+        if let Err(e) = self.droppable.channel.0.send(WebGPURequest::EndRenderPass {
+            render_pass_id: self.id().0,
             device_id: self.command_encoder.device_id().0,
             command_encoder_id: self.command_encoder.id().0,
         }) {
@@ -235,17 +264,5 @@ impl GPURenderPassEncoderMethods<crate::DomTypeHolder> for GPURenderPassEncoder 
     fn ExecuteBundles(&self, bundles: Vec<DomRoot<GPURenderBundle>>) {
         let bundle_ids: Vec<_> = bundles.iter().map(|b| b.id().0).collect();
         self.send_render_command(RenderCommand::ExecuteBundles(bundle_ids))
-    }
-}
-
-impl Drop for GPURenderPassEncoder {
-    fn drop(&mut self) {
-        if let Err(e) = self
-            .channel
-            .0
-            .send(WebGPURequest::DropRenderPass(self.render_pass.0))
-        {
-            warn!("Failed to send WebGPURequest::DropRenderPass with {e:?}");
-        }
     }
 }

--- a/components/script_bindings/codegen/Bindings.conf
+++ b/components/script_bindings/codegen/Bindings.conf
@@ -353,10 +353,6 @@ DOMInterfaces = {
     'canGc': ['OnSubmittedWorkDone'],
 },
 
-'GPURenderPassEncoder': {
-    'allowDropImpl': True,
-},
-
 'GPURenderPipeline': {
     'allowDropImpl': True,
 },


### PR DESCRIPTION
Moves the `Drop` logic for `GPURenderPassEncoder` into a dedicated helper struct, `DroppableGPURenderPassEncoder`. This ensures that DOM types do not directly implement `Drop`, aligning with the policy for resource management in the DOM. The associated `Bindings.conf` entry is removed as direct `Drop` is no longer needed for this type.

Testing: WebGPU tests just cover its cases
Fixes: Partially #26488 
