### PR TITLE
script: bump mozjs to use SpiderMonkey 140.8 and set more compile options

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5040,9 +5040,9 @@ dependencies = [
 
 [[package]]
 name = "mozjs"
-version = "0.15.1"
+version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "074cf37bcac620b5c7e56ed0830a4a5288e08a266cbe7e9737d29035e3ab4e64"
+checksum = "6efb4331060c22cc64e136c11c810eec22c063dd7cdeffdee394cb4e7f4d2880"
 dependencies = [
  "bindgen",
  "cc",
@@ -5055,9 +5055,9 @@ dependencies = [
 
 [[package]]
 name = "mozjs_sys"
-version = "0.140.5-11"
+version = "0.140.8-0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e57169b7c9e59053c26d76ecb499f5227fbcadbd1eadbb60009f3f745d21fce1"
+checksum = "2d84f9f721dd87b500958f5815c118adb8adcd8e310e30b0188647c179ea7bcb"
 dependencies = [
  "bindgen",
  "cc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -114,7 +114,7 @@ imsz = "0.4"
 indexmap = { version = "2.11.4", features = ["std"] }
 ipc-channel = "0.21"
 itertools = "0.14"
-js = { package = "mozjs", version = "=0.15.1", default-features = false, features = ["libz-sys", "intl"] }
+js = { package = "mozjs", version = "=0.15.5", default-features = false, features = ["libz-sys", "intl"] }
 keyboard-types = { version = "0.8.3", features = ["serde", "webdriver"] }
 kurbo = { version = "0.12", features = ["euclid"] }
 layout_api = { package = "servo-layout-api", path = "components/shared/layout" }

--- a/components/script/devtools.rs
+++ b/components/script/devtools.rs
@@ -141,7 +141,7 @@ pub(crate) fn handle_evaluate_js(
             eval.into(),
             "<eval>",
             Some(IntroductionType::DEBUGGER_EVAL),
-            rval.handle_mut(),
+            Some(rval.handle_mut()),
         );
 
         if rval.is_undefined() {

--- a/components/script/dom/debuggerglobalscope.rs
+++ b/components/script/dom/debuggerglobalscope.rs
@@ -15,7 +15,6 @@ use dom_struct::dom_struct;
 use embedder_traits::ScriptToEmbedderChan;
 use embedder_traits::resources::{self, Resource};
 use js::context::JSContext;
-use js::jsval::UndefinedValue;
 use js::rust::wrappers2::JS_DefineDebuggerObject;
 use net_traits::ResourceThreads;
 use profile_traits::{mem, time};
@@ -136,13 +135,12 @@ impl DebuggerGlobalScope {
         let mut realm = enter_auto_realm(cx, self);
         let cx = &mut realm.current_realm();
 
-        rooted!(&in(cx) let mut rval = UndefinedValue());
         let _ = self.global_scope.evaluate_js_on_global(
             cx,
             resources::read_string(Resource::DebuggerJS).into(),
             "",
             None,
-            rval.handle_mut(),
+            None,
         );
     }
 

--- a/components/script/dom/global_scope_script_execution.rs
+++ b/components/script/dom/global_scope_script_execution.rs
@@ -51,7 +51,7 @@ pub(crate) struct ClassicScript {
     muted_errors: ErrorReporting,
 }
 
-#[derive(JSTraceable, MallocSizeOf)]
+#[derive(Clone, Copy, JSTraceable, MallocSizeOf)]
 pub(crate) enum ErrorReporting {
     Muted,
     Unmuted,
@@ -112,6 +112,8 @@ impl GlobalScope {
             url.as_str(),
             line_number,
             introduction_type,
+            muted_errors,
+            true,
         ));
 
         // Step 11. If result is a list of errors, then:
@@ -311,7 +313,14 @@ pub(crate) fn compile_script(
     filename: &str,
     line_number: u32,
     introduction_type: Option<&'static CStr>,
+    muted_errors: ErrorReporting,
+    no_script_rval: bool,
 ) -> *mut JSScript {
+    let muted_errors = match muted_errors {
+        ErrorReporting::Muted => true,
+        ErrorReporting::Unmuted => false,
+    };
+
     // TODO: pass filename as CString to avoid allocation
     // See https://github.com/servo/servo/issues/42126
     let filename = cformat!("{filename}");
@@ -319,6 +328,10 @@ pub(crate) fn compile_script(
     if let Some(introduction_type) = introduction_type {
         options.set_introduction_type(introduction_type);
     }
+
+    options.set_muted_errors(muted_errors);
+    options.set_is_run_once(true);
+    options.set_no_script_rval(no_script_rval);
 
     debug!("Compiling script");
     unsafe { Compile1(*cx, options.ptr, &mut transform_str_to_source_text(text)) }

--- a/components/script/dom/global_scope_script_execution.rs
+++ b/components/script/dom/global_scope_script_execution.rs
@@ -329,7 +329,10 @@ pub(crate) fn compile_script(
         options.set_introduction_type(introduction_type);
     }
 
+    // https://searchfox.org/firefox-main/rev/46fa95cd7f10222996ec267947ab94c5107b1475/js/public/CompileOptions.h#284
     options.set_muted_errors(muted_errors);
+
+    // https://searchfox.org/firefox-main/rev/46fa95cd7f10222996ec267947ab94c5107b1475/js/public/CompileOptions.h#518
     options.set_is_run_once(true);
     options.set_no_script_rval(no_script_rval);
 

--- a/components/script/dom/globalscope.rs
+++ b/components/script/dom/globalscope.rs
@@ -114,7 +114,7 @@ use crate::dom::event::{Event, EventBubbles, EventCancelable};
 use crate::dom::eventsource::EventSource;
 use crate::dom::eventtarget::EventTarget;
 use crate::dom::file::File;
-use crate::dom::global_scope_script_execution::{compile_script, evaluate_script};
+use crate::dom::global_scope_script_execution::{ErrorReporting, compile_script, evaluate_script};
 use crate::dom::idbfactory::IDBFactory;
 use crate::dom::messageport::MessagePort;
 use crate::dom::paintworkletglobalscope::PaintWorkletGlobalScope;
@@ -2863,6 +2863,8 @@ impl GlobalScope {
                 filename,
                 1,
                 introduction_type,
+                ErrorReporting::Unmuted,
+                false,
             ));
 
             if compiled_script.is_null() {

--- a/components/script/dom/globalscope.rs
+++ b/components/script/dom/globalscope.rs
@@ -2847,7 +2847,7 @@ impl GlobalScope {
         code: Cow<'_, str>,
         filename: &str,
         introduction_type: Option<&'static CStr>,
-        rval: MutableHandleValue,
+        rval: Option<MutableHandleValue>,
     ) -> Result<(), JavaScriptEvaluationError> {
         let in_realm_proof = cx.into();
         let in_realm = InRealm::Already(&in_realm_proof);
@@ -2855,6 +2855,8 @@ impl GlobalScope {
         run_a_script::<DomTypeHolder, _>(self, || {
             let url = self.api_base_url();
             let fetch_options = ScriptFetchOptions::default_classic_script(self);
+
+            let no_script_rval = rval.is_none();
 
             rooted!(&in(cx) let mut compiled_script = std::ptr::null_mut::<JSScript>());
             compiled_script.set(compile_script(
@@ -2864,7 +2866,7 @@ impl GlobalScope {
                 1,
                 introduction_type,
                 ErrorReporting::Unmuted,
-                false,
+                no_script_rval,
             ));
 
             if compiled_script.is_null() {
@@ -2874,6 +2876,12 @@ impl GlobalScope {
             }
 
             let script = NonNull::new(*compiled_script).expect("Can't be null");
+
+            rooted!(&in(cx) let mut value = UndefinedValue());
+            let rval = match rval {
+                Some(rval) => rval,
+                None => value.handle_mut(),
+            };
 
             if !evaluate_script(cx.into(), script, url, fetch_options, rval) {
                 let error_info = take_and_report_pending_exception_for_api(cx);

--- a/components/script/dom/globalscope.rs
+++ b/components/script/dom/globalscope.rs
@@ -2878,10 +2878,7 @@ impl GlobalScope {
             let script = NonNull::new(*compiled_script).expect("Can't be null");
 
             rooted!(&in(cx) let mut value = UndefinedValue());
-            let rval = match rval {
-                Some(rval) => rval,
-                None => value.handle_mut(),
-            };
+            let rval = rval.unwrap_or_else(|| value.handle_mut());
 
             if !evaluate_script(cx.into(), script, url, fetch_options, rval) {
                 let error_info = take_and_report_pending_exception_for_api(cx);

--- a/components/script/dom/userscripts.rs
+++ b/components/script/dom/userscripts.rs
@@ -2,7 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-use js::jsval::UndefinedValue;
 use script_bindings::root::DomRoot;
 
 use crate::dom::html::htmlheadelement::HTMLHeadElement;
@@ -22,14 +21,13 @@ pub(crate) fn load_script(head: &HTMLHeadElement) {
         let mut realm = enter_auto_realm(cx, global_scope);
         let cx = &mut realm.current_realm();
 
-        rooted!(&in(cx) let mut rval = UndefinedValue());
         for user_script in userscripts {
             _ = global_scope.evaluate_js_on_global(
                 cx,
                 user_script.script().into(),
                 &user_script.source_file().map(|path| path.to_string_lossy().to_string()).unwrap_or_default(),
                 None,
-                rval.handle_mut(),
+                None,
             );
         }
     }));

--- a/components/script/dom/workletglobalscope.rs
+++ b/components/script/dom/workletglobalscope.rs
@@ -12,7 +12,6 @@ use crossbeam_channel::Sender;
 use devtools_traits::ScriptToDevtoolsControlMsg;
 use dom_struct::dom_struct;
 use embedder_traits::{JavaScriptEvaluationError, ScriptToEmbedderChan};
-use js::jsval::UndefinedValue;
 use net_traits::ResourceThreads;
 use net_traits::image_cache::ImageCache;
 use profile_traits::{mem, time};
@@ -146,13 +145,12 @@ impl WorkletGlobalScope {
         let cx = &mut realm.current_realm();
 
         debug!("Evaluating Dom in a worklet.");
-        rooted!(&in(cx) let mut rval = UndefinedValue());
         self.globalscope.evaluate_js_on_global(
             cx,
             script,
             "",
             Some(IntroductionType::WORKLET),
-            rval.handle_mut(),
+            None,
         )
     }
 

--- a/components/script/script_module.rs
+++ b/components/script/script_module.rs
@@ -320,6 +320,10 @@ impl ModuleTree {
         if let Some(introduction_type) = introduction_type {
             compile_options.set_introduction_type(introduction_type);
         }
+        compile_options.set_muted_errors(false);
+        compile_options.set_is_run_once(true);
+        compile_options.set_no_script_rval(true);
+
         let mut module_source = ModuleSource {
             source,
             unminified_dir: global.unminified_js_dir(),
@@ -372,7 +376,7 @@ impl ModuleTree {
     /// <https://html.spec.whatwg.org/multipage/#creating-a-json-module-script>
     /// Although the CanGc argument appears unused, it represents the GC operations that
     /// can occur as part of compiling a script.
-    fn crate_a_json_module_script(
+    fn create_a_json_module_script(
         source: &str,
         global: &GlobalScope,
         url: &ServoUrl,
@@ -401,6 +405,9 @@ impl ModuleTree {
         if let Some(introduction_type) = introduction_type {
             compile_options.set_introduction_type(introduction_type);
         }
+        compile_options.set_muted_errors(false);
+        compile_options.set_is_run_once(true);
+        compile_options.set_no_script_rval(true);
 
         rooted!(in(*cx) let mut module_script: *mut JSObject = std::ptr::null_mut());
 
@@ -826,7 +833,7 @@ impl FetchResponseListener for ModuleContext {
             // Step 7.4 If mimeType is a JSON MIME type and moduleType is "json",
             // then set moduleScript to the result of creating a JSON module script given sourceText and settingsObject.
             if MimeClassifier::is_json(&mime) && matches!(module_type, ModuleType::JSON) {
-                let module_tree = Rc::new(ModuleTree::crate_a_json_module_script(
+                let module_tree = Rc::new(ModuleTree::create_a_json_module_script(
                     &source_text,
                     &global,
                     &final_url,

--- a/components/script/script_module.rs
+++ b/components/script/script_module.rs
@@ -314,15 +314,7 @@ impl ModuleTree {
             loaded_modules: DomRefCell::new(IndexMap::new()),
         };
 
-        let c_url = cformat!("{url}");
-        let mut compile_options =
-            unsafe { CompileOptionsWrapper::new_raw(*cx, c_url, line_number) };
-        if let Some(introduction_type) = introduction_type {
-            compile_options.set_introduction_type(introduction_type);
-        }
-        compile_options.set_muted_errors(false);
-        compile_options.set_is_run_once(true);
-        compile_options.set_no_script_rval(true);
+        let compile_options = fill_module_compile_options(cx, url, introduction_type, line_number);
 
         let mut module_source = ModuleSource {
             source,
@@ -400,14 +392,7 @@ impl ModuleTree {
         // Step 3. Set script's base URL and fetch options to null.
         // Note: We don't need to call `SetModulePrivate` for json scripts
 
-        let c_url = cformat!("{url}");
-        let mut compile_options = unsafe { CompileOptionsWrapper::new_raw(*cx, c_url, 1) };
-        if let Some(introduction_type) = introduction_type {
-            compile_options.set_introduction_type(introduction_type);
-        }
-        compile_options.set_muted_errors(false);
-        compile_options.set_is_run_once(true);
-        compile_options.set_no_script_rval(true);
+        let compile_options = fill_module_compile_options(cx, url, introduction_type, 1);
 
         rooted!(in(*cx) let mut module_script: *mut JSObject = std::ptr::null_mut());
 
@@ -1461,6 +1446,29 @@ pub(crate) fn fetch_a_single_module_script(
             None => global.fetch_with_network_listener(request, network_listener),
         };
     })
+}
+
+#[expect(unsafe_code)]
+fn fill_module_compile_options(
+    cx: SafeJSContext,
+    url: &ServoUrl,
+    introduction_type: Option<&'static CStr>,
+    line_number: u32,
+) -> CompileOptionsWrapper {
+    let mut options =
+        unsafe { CompileOptionsWrapper::new_raw(*cx, cformat!("{url}"), line_number) };
+    if let Some(introduction_type) = introduction_type {
+        options.set_introduction_type(introduction_type);
+    }
+
+    // https://searchfox.org/firefox-main/rev/46fa95cd7f10222996ec267947ab94c5107b1475/js/public/CompileOptions.h#284
+    options.set_muted_errors(false);
+
+    // https://searchfox.org/firefox-main/rev/46fa95cd7f10222996ec267947ab94c5107b1475/js/public/CompileOptions.h#518
+    options.set_is_run_once(true);
+    options.set_no_script_rval(true);
+
+    options
 }
 
 pub(crate) type ModuleSpecifierMap = IndexMap<String, Option<ServoUrl>>;

--- a/components/script/script_runtime.rs
+++ b/components/script/script_runtime.rs
@@ -418,12 +418,16 @@ unsafe extern "C" fn enqueue_promise_job(
 /// <https://html.spec.whatwg.org/multipage/#the-hostpromiserejectiontracker-implementation>
 unsafe extern "C" fn promise_rejection_tracker(
     cx: *mut RawJSContext,
-    _muted_errors: bool,
+    muted_errors: bool,
     promise: HandleObject,
     state: PromiseRejectionHandlingState,
     _data: *mut c_void,
 ) {
-    // TODO: Step 2 - If script's muted errors is true, terminate these steps.
+    // Step 1. Let script be the running script.
+    // Step 2. If script is a classic script and script's muted errors is true, then return.
+    if muted_errors {
+        return;
+    }
 
     // Step 3.
     let cx = unsafe { JSContext::from_ptr(cx) };

--- a/components/script/script_thread.rs
+++ b/components/script/script_thread.rs
@@ -3786,7 +3786,7 @@ impl ScriptThread {
             script_source,
             "",
             Some(IntroductionType::JAVASCRIPT_URL),
-            jsval.handle_mut(),
+            Some(jsval.handle_mut()),
         );
 
         load_data.js_eval_result = if jsval.get().is_string() {
@@ -4246,7 +4246,7 @@ impl ScriptThread {
             script.into(),
             "",
             None, // No known `introductionType` for JS code from embedder
-            return_value.handle_mut(),
+            Some(return_value.handle_mut()),
         ) {
             _ = self.senders.pipeline_to_constellation_sender.send((
                 webview_id,

--- a/components/script/webdriver_handlers.rs
+++ b/components/script/webdriver_handlers.rs
@@ -638,7 +638,6 @@ pub(crate) fn handle_execute_async_script(
         Some(window) => {
             let reply_sender = reply.clone();
             window.set_webdriver_script_chan(Some(reply));
-            rooted!(&in(cx) let mut rval = UndefinedValue());
 
             let global_scope = window.as_global_scope();
 
@@ -649,7 +648,7 @@ pub(crate) fn handle_execute_async_script(
                 eval.into(),
                 "",
                 None, // No known `introductionType` for JS code from WebDriver
-                rval.handle_mut(),
+                None,
             ) {
                 reply_sender.send(Err(error)).unwrap_or_else(|error| {
                     error!("ExecuteAsyncScript Failed to send reply: {error}");

--- a/tests/wpt/meta/html/webappapis/scripting/processing-model-2/unhandled-promise-rejections/disallow-crossorigin.html.ini
+++ b/tests/wpt/meta/html/webappapis/scripting/processing-model-2/unhandled-promise-rejections/disallow-crossorigin.html.ini
@@ -1,3 +1,0 @@
-[disallow-crossorigin.html]
-  [Promise rejection event should be muted for cross-origin non-CORS script]
-    expected: FAIL


### PR DESCRIPTION
Set `mutedErrors_`, `noScriptRval`, `isRunOnce` compile options.

Testing: A test now passes
Part of #38378
