### PR TITLE
prefs: Fix typo "arugment" -> "argument"

### DIFF
--- a/ports/servoshell/prefs.rs
+++ b/ports/servoshell/prefs.rs
@@ -288,7 +288,7 @@ fn parse_user_stylesheets(string: String) -> Result<Vec<(Vec<u8>, ServoUrl)>, st
 /// check for long/short cmd. If there is the flag with this
 /// If the flag is not there, parse `None``
 /// If the flag is there but no argument, parse `Some(default)`
-/// If the flag is there and an argument parse the arugment
+/// If the flag is there and an argument parse the argument
 fn flag_with_default_parser<S, T>(
     short_cmd: Option<char>,
     long_cmd: &'static str,


### PR DESCRIPTION
Fixed a typo in the comment documentation in `ports/servoshell/prefs.rs`. Changed "arugment" to "argument" on line 291.

Testing: This change does not need testing because it just fixes a typo in a rustdoc comment.