### PR TITLE
tools: Support tab navigation via navigateTo, goBack, and goForward

### DIFF
--- a/components/devtools/actors/root.rs
+++ b/components/devtools/actors/root.rs
@@ -120,6 +120,7 @@ struct ListProcessesResponse {
 pub(crate) struct DescriptorTraits {
     pub(crate) watcher: bool,
     pub(crate) supports_reload_descriptor: bool,
+    pub(crate) supports_navigation: bool,
 }
 
 #[derive(Serialize)]

--- a/components/devtools/actors/tab.rs
+++ b/components/devtools/actors/tab.rs
@@ -13,6 +13,7 @@ use devtools_traits::DevtoolScriptControlMsg;
 use malloc_size_of_derive::MallocSizeOf;
 use serde::Serialize;
 use serde_json::{Map, Value};
+use servo_url::ServoUrl;
 
 use crate::actor::{Actor, ActorEncode, ActorError, ActorRegistry};
 use crate::actors::browsing_context::{BrowsingContextActor, BrowsingContextActorMsg};
@@ -95,7 +96,7 @@ impl Actor for TabDescriptorActor {
         request: ClientRequest,
         registry: &ActorRegistry,
         msg_type: &str,
-        _msg: &Map<String, Value>,
+        msg: &Map<String, Value>,
         _id: StreamId,
     ) -> Result<(), ActorError> {
         match msg_type {
@@ -116,6 +117,44 @@ impl Actor for TabDescriptorActor {
                     from: self.name(),
                     watcher: registry.encode::<WatcherActor, _>(&ctx_actor.watcher),
                 })?
+            },
+            "goBack" => {
+                let ctx_actor = registry.find::<BrowsingContextActor>(&self.browsing_context_actor);
+                let pipeline = ctx_actor.pipeline_id();
+                ctx_actor
+                    .script_chan
+                    .send(DevtoolScriptControlMsg::GoBack(pipeline))
+                    .map_err(|_| ActorError::Internal)?;
+                request.reply_final(&EmptyReplyMsg { from: self.name() })?
+            },
+            "goForward" => {
+                let ctx_actor = registry.find::<BrowsingContextActor>(&self.browsing_context_actor);
+                let pipeline = ctx_actor.pipeline_id();
+                ctx_actor
+                    .script_chan
+                    .send(DevtoolScriptControlMsg::GoForward(pipeline))
+                    .map_err(|_| ActorError::Internal)?;
+                request.reply_final(&EmptyReplyMsg { from: self.name() })?
+            },
+            "navigateTo" => {
+                if msg.get("waitForLoad").unwrap_or(&Value::Bool(false)) != &Value::Bool(false) {
+                    log::warn!("waitForLoad option for devtools navigation is not supported.");
+                }
+                let url = msg
+                    .get("url")
+                    .and_then(|value| value.as_str())
+                    .map(ServoUrl::parse)
+                    .ok_or(ActorError::Internal)?
+                    .map_err(|_| ActorError::Internal)?;
+
+                let ctx_actor = registry.find::<BrowsingContextActor>(&self.browsing_context_actor);
+                let pipeline = ctx_actor.pipeline_id();
+                ctx_actor
+                    .script_chan
+                    .send(DevtoolScriptControlMsg::NavigateTo(pipeline, url))
+                    .map_err(|_| ActorError::Internal)?;
+
+                request.reply_final(&EmptyReplyMsg { from: self.name() })?
             },
             "reloadDescriptor" => {
                 // There is an extra bypassCache parameter that we don't currently use.
@@ -175,6 +214,7 @@ impl ActorEncode<TabDescriptorActorMsg> for TabDescriptorActor {
             title,
             traits: DescriptorTraits {
                 watcher: true,
+                supports_navigation: true,
                 supports_reload_descriptor: true,
             },
             url,

--- a/components/devtools/actors/tab.rs
+++ b/components/devtools/actors/tab.rs
@@ -99,6 +99,9 @@ impl Actor for TabDescriptorActor {
         msg: &Map<String, Value>,
         _id: StreamId,
     ) -> Result<(), ActorError> {
+        let ctx_actor = registry.find::<BrowsingContextActor>(&self.browsing_context_actor);
+        let pipeline = ctx_actor.pipeline_id();
+
         match msg_type {
             "getTarget" => request.reply_final(&GetTargetReply {
                 from: self.name(),
@@ -111,16 +114,11 @@ impl Actor for TabDescriptorActor {
                     favicon: String::new(),
                 })?
             },
-            "getWatcher" => {
-                let ctx_actor = registry.find::<BrowsingContextActor>(&self.browsing_context_actor);
-                request.reply_final(&GetWatcherReply {
-                    from: self.name(),
-                    watcher: registry.encode::<WatcherActor, _>(&ctx_actor.watcher),
-                })?
-            },
+            "getWatcher" => request.reply_final(&GetWatcherReply {
+                from: self.name(),
+                watcher: registry.encode::<WatcherActor, _>(&ctx_actor.watcher),
+            })?,
             "goBack" => {
-                let ctx_actor = registry.find::<BrowsingContextActor>(&self.browsing_context_actor);
-                let pipeline = ctx_actor.pipeline_id();
                 ctx_actor
                     .script_chan
                     .send(DevtoolScriptControlMsg::GoBack(pipeline))
@@ -128,8 +126,6 @@ impl Actor for TabDescriptorActor {
                 request.reply_final(&EmptyReplyMsg { from: self.name() })?
             },
             "goForward" => {
-                let ctx_actor = registry.find::<BrowsingContextActor>(&self.browsing_context_actor);
-                let pipeline = ctx_actor.pipeline_id();
                 ctx_actor
                     .script_chan
                     .send(DevtoolScriptControlMsg::GoForward(pipeline))
@@ -147,8 +143,6 @@ impl Actor for TabDescriptorActor {
                     .ok_or(ActorError::Internal)?
                     .map_err(|_| ActorError::Internal)?;
 
-                let ctx_actor = registry.find::<BrowsingContextActor>(&self.browsing_context_actor);
-                let pipeline = ctx_actor.pipeline_id();
                 ctx_actor
                     .script_chan
                     .send(DevtoolScriptControlMsg::NavigateTo(pipeline, url))
@@ -158,8 +152,6 @@ impl Actor for TabDescriptorActor {
             },
             "reloadDescriptor" => {
                 // There is an extra bypassCache parameter that we don't currently use.
-                let ctx_actor = registry.find::<BrowsingContextActor>(&self.browsing_context_actor);
-                let pipeline = ctx_actor.pipeline_id();
                 ctx_actor
                     .script_chan
                     .send(DevtoolScriptControlMsg::Reload(pipeline))

--- a/components/script/script_thread.rs
+++ b/components/script/script_thread.rs
@@ -43,7 +43,7 @@ use chrono::{DateTime, Local};
 use constellation_traits::{
     JsEvalResult, LoadData, LoadOrigin, NavigationHistoryBehavior, ScreenshotReadinessResponse,
     ScriptToConstellationChan, ScriptToConstellationMessage, ScrollStateUpdate,
-    StructuredSerializedData, WindowSizeType,
+    StructuredSerializedData, TraversalDirection, WindowSizeType,
 };
 use crossbeam_channel::unbounded;
 use data_url::mime::Mime;
@@ -2229,6 +2229,15 @@ impl ScriptThread {
             DevtoolScriptControlMsg::RequestAnimationFrame(id, name) => {
                 devtools::handle_request_animation_frame(&documents, id, name)
             },
+            DevtoolScriptControlMsg::NavigateTo(pipeline_id, url) => {
+                self.handle_navigate_to(pipeline_id, url)
+            },
+            DevtoolScriptControlMsg::GoBack(pipeline_id) => {
+                self.handle_traverse_history(pipeline_id, TraversalDirection::Back(1))
+            },
+            DevtoolScriptControlMsg::GoForward(pipeline_id) => {
+                self.handle_traverse_history(pipeline_id, TraversalDirection::Forward(1))
+            },
             DevtoolScriptControlMsg::Reload(id) => self.handle_reload(id, CanGc::from_cx(cx)),
             DevtoolScriptControlMsg::GetCssDatabase(reply) => {
                 devtools::handle_get_css_database(reply)
@@ -4094,6 +4103,39 @@ impl ScriptThread {
                 let message = ScriptToDevtoolsControlMsg::ReportCSSError(pipeline_id, css_error);
                 sender.send(message).unwrap();
             }
+        }
+    }
+
+    fn handle_navigate_to(&self, pipeline_id: PipelineId, url: ServoUrl) {
+        // The constellation only needs to know the WebView ID for navigation,
+        // but actors don't keep track of it. Infer WebView ID from pipeline ID instead.
+        if let Some(document) = self.documents.borrow().find_document(pipeline_id) {
+            self.senders
+                .pipeline_to_constellation_sender
+                .send((
+                    document.webview_id(),
+                    pipeline_id,
+                    ScriptToConstellationMessage::LoadUrl(
+                        LoadData::new_for_new_unrelated_webview(url),
+                        NavigationHistoryBehavior::Push,
+                    ),
+                ))
+                .unwrap();
+        }
+    }
+
+    fn handle_traverse_history(&self, pipeline_id: PipelineId, direction: TraversalDirection) {
+        // The constellation only needs to know the WebView ID for navigation,
+        // but actors don't keep track of it. Infer WebView ID from pipeline ID instead.
+        if let Some(document) = self.documents.borrow().find_document(pipeline_id) {
+            self.senders
+                .pipeline_to_constellation_sender
+                .send((
+                    document.webview_id(),
+                    pipeline_id,
+                    ScriptToConstellationMessage::TraverseHistory(direction),
+                ))
+                .unwrap();
         }
     }
 

--- a/components/shared/devtools/lib.rs
+++ b/components/shared/devtools/lib.rs
@@ -333,6 +333,15 @@ pub enum DevtoolScriptControlMsg {
     /// Request a callback directed at the given actor name from the next animation frame
     /// executed in the given pipeline.
     RequestAnimationFrame(PipelineId, String),
+    /// Direct the WebView containing the given pipeline to load a new URL,
+    /// as if it was typed by the user.
+    NavigateTo(PipelineId, ServoUrl),
+    /// Direct the WebView containing the given pipeline to traverse history backward
+    /// up to one step.
+    GoBack(PipelineId),
+    /// Direct the WebView containing the given pipeline to traverse history forward
+    /// up to one step.
+    GoForward(PipelineId),
     /// Direct the given pipeline to reload the current page.
     Reload(PipelineId),
     /// Gets the list of all allowed CSS rules and possible values.

--- a/python/servo/devtools_tests.py
+++ b/python/servo/devtools_tests.py
@@ -47,6 +47,7 @@ class Source:
 @dataclass
 class Devtools:
     client: RDPClient
+    tab: TabActor
     watcher: WatcherActor
     targets: list
     exited: bool = False
@@ -90,7 +91,7 @@ class Devtools:
         if result:
             raise result
 
-        return Devtools(client, watcher, targets)
+        return Devtools(client, tab, watcher, targets)
 
     def __getattribute__(self, name: str) -> Any:
         """
@@ -1036,6 +1037,34 @@ class DevtoolsTests(unittest.IsolatedAsyncioTestCase):
             time.sleep(1)
             self.assertFalse(did_see_new_mutations)
             self.assertEquals(walker.get_mutations(False), [])
+
+    def test_navigation(self):
+        self.run_servoshell(url=f"{self.base_urls[0]}/tab/page1.html")
+        with Devtools.connect() as devtools:
+            for message_data, target_path in [
+                ({"type": "navigateTo", "url": f"{self.base_urls[0]}/tab/page2.html"}, "/tab/page2.html"),
+                ({"type": "goBack"}, "/tab/page1.html"),
+                ({"type": "goForward"}, "/tab/page2.html"),
+            ]:
+                done = Future()
+
+                def on_tab_navigated(data):
+                    if data.get("url").endswith(target_path):
+                        done.set_result(None)
+                        return
+
+                devtools.client.add_event_listener(
+                    devtools.targets[0]["actor"],
+                    "tabNavigated",
+                    on_tab_navigated,
+                )
+                devtools.client.send_receive({"to": devtools.tab.actor_id, **message_data})
+
+                done.result(1)
+                # History may momentarily report stale state when navigating
+                # rapidly. The code under test does not seem to be responsible,
+                # so wait it out.
+                time.sleep(0.1)
 
     # Sets `base_url` and `web_server` and `web_server_thread`.
     @classmethod

--- a/python/servo/devtools_tests/tab/page1.html
+++ b/python/servo/devtools_tests/tab/page1.html
@@ -1,0 +1,6 @@
+<!DOCTYPE html>
+<head>
+    <title>Page 1</title>
+</head>
+<body>
+</body>

--- a/python/servo/devtools_tests/tab/page2.html
+++ b/python/servo/devtools_tests/tab/page2.html
@@ -1,0 +1,6 @@
+<!DOCTYPE html>
+<head>
+    <title>Page 2</title>
+</head>
+<body>
+</body>


### PR DESCRIPTION
Add support for navigation requests ("navigateTo", "goBack", and "goForward") over the Remote Debugging Protocol. These may be sent by a UI client in response to user input (for example the address bar in the Firefox inspector), or they can be used to automate navigation during unit tests.

This currently only supports navigation within the URL domain at which servoshell is initially launched, due to a bug in servo's `BrowsingContextActor` implementation. (Unit tests covering a fix for that issue will depend on this change.)

Testing: The behavior of all 3 new message types is covered by a new test case—`test_navigation`—in the devtools unit test suite.
Fixes: #38668
