### PR TITLE
libservo: Per-webview accessibility activation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7289,6 +7289,7 @@ name = "servo"
 version = "0.0.6"
 dependencies = [
  "accesskit",
+ "accesskit_consumer",
  "arboard",
  "bitflags 2.11.0",
  "crossbeam-channel",

--- a/components/constellation/constellation.rs
+++ b/components/constellation/constellation.rs
@@ -507,9 +507,6 @@ pub struct Constellation<STF, SWF> {
     /// to the `UserContents` need to be forwared to all the `ScriptThread`s that host
     /// the relevant `WebView`.
     pub(crate) user_contents_for_manager_id: FxHashMap<UserContentManagerId, UserContents>,
-
-    /// Whether accessibility trees are being built and sent to the underlying platform.
-    pub(crate) accessibility_active: bool,
 }
 
 /// State needed to construct a constellation.
@@ -728,7 +725,6 @@ where
                     pending_viewport_changes: Default::default(),
                     screenshot_readiness_requests: Vec::new(),
                     user_contents_for_manager_id: Default::default(),
-                    accessibility_active: false,
                 };
 
                 constellation.run();
@@ -1190,14 +1186,6 @@ where
         self.browsing_contexts
             .insert(browsing_context_id, browsing_context);
 
-        if self.accessibility_active {
-            if let Some(pipeline) = self.pipelines.get(&pipeline_id) {
-                let _ = pipeline
-                    .event_loop
-                    .send(ScriptThreadMessage::SetAccessibilityActive(true));
-            }
-        }
-
         // If this context is a nested container, attach it to parent pipeline.
         if let Some(parent_pipeline_id) = parent_pipeline_id {
             if let Some(parent) = self.pipelines.get_mut(&parent_pipeline_id) {
@@ -1562,8 +1550,8 @@ where
             EmbedderToConstellationMessage::UpdatePinchZoomInfos(pipeline_id, pinch_zoom) => {
                 self.handle_update_pinch_zoom_infos(pipeline_id, pinch_zoom);
             },
-            EmbedderToConstellationMessage::SetAccessibilityActive(active) => {
-                self.set_accessibility_active(active);
+            EmbedderToConstellationMessage::SetAccessibilityActive(webview_id, active) => {
+                self.set_accessibility_active(webview_id, active);
             },
         }
     }
@@ -3111,17 +3099,26 @@ where
         }
     }
 
-    fn set_accessibility_active(&mut self, active: bool) {
+    fn set_accessibility_active(&mut self, webview_id: WebViewId, active: bool) {
         if !(pref!(accessibility_enabled)) {
             return;
         }
-        if active == self.accessibility_active {
-            return;
-        }
 
-        self.accessibility_active = active;
-        for event_loop in self.event_loops() {
-            let _ = event_loop.send(ScriptThreadMessage::SetAccessibilityActive(active));
+        let Some(webview) = self.webviews.get_mut(&webview_id) else {
+            return;
+        };
+
+        webview.accessibility_active = active;
+
+        // Forward the activation to the webview’s active pipelines (of those that represent
+        // documents). For inactive pipelines (documents in bfcache), we only need to forward the
+        // activation if and when they become active (see set_frame_tree_for_webview()).
+        for pipeline_id in self.active_pipelines_for_webview(webview_id) {
+            self.send_message_to_pipeline(
+                pipeline_id,
+                ScriptThreadMessage::SetAccessibilityActive(pipeline_id, active),
+                "Set accessibility active after closure",
+            );
         }
     }
 
@@ -5673,7 +5670,7 @@ where
         }
     }
 
-    // Convert a browsing context to a sendable form to pass to `Paint`
+    /// Convert a browsing context to a tree of active pipeline ids, for sending to Paint.
     #[servo_tracing::instrument(skip_all)]
     fn browsing_context_to_sendable(
         &self,
@@ -5703,6 +5700,23 @@ where
             })
     }
 
+    /// Convert a webview to a flat list of active pipeline ids, for activating accessibility.
+    fn active_pipelines_for_webview(&self, webview_id: WebViewId) -> Vec<PipelineId> {
+        let mut result = vec![];
+        let mut browsing_context_ids = vec![BrowsingContextId::from(webview_id)];
+        while let Some(browsing_context_id) = browsing_context_ids.pop() {
+            let Some(browsing_context) = self.browsing_contexts.get(&browsing_context_id) else {
+                continue;
+            };
+            let Some(pipeline) = self.pipelines.get(&browsing_context.pipeline_id) else {
+                continue;
+            };
+            result.push(browsing_context.pipeline_id);
+            browsing_context_ids.extend(pipeline.children.iter().copied());
+        }
+        result
+    }
+
     /// Send the frame tree for the given webview to `Paint`.
     #[servo_tracing::instrument(skip_all)]
     fn set_frame_tree_for_webview(&mut self, webview_id: WebViewId) {
@@ -5720,6 +5734,18 @@ where
             debug!("{}: Sending frame tree", browsing_context_id);
             self.paint_proxy
                 .send(PaintMessage::SetFrameTreeForWebView(webview_id, frame_tree));
+        }
+
+        let Some(webview) = self.webviews.get(&webview_id) else {
+            return;
+        };
+        let active = webview.accessibility_active;
+        for pipeline_id in self.active_pipelines_for_webview(webview_id) {
+            self.send_message_to_pipeline(
+                pipeline_id,
+                ScriptThreadMessage::SetAccessibilityActive(pipeline_id, active),
+                "Set accessibility active after closure",
+            );
         }
     }
 

--- a/components/constellation/constellation.rs
+++ b/components/constellation/constellation.rs
@@ -5670,7 +5670,7 @@ where
         }
     }
 
-    /// Convert a browsing context to a tree of active pipeline ids, for sending to Paint.
+    /// Convert a browsing context to a tree of active pipeline ids, for sending to `Paint`.
     #[servo_tracing::instrument(skip_all)]
     fn browsing_context_to_sendable(
         &self,

--- a/components/constellation/constellation_webview.rs
+++ b/components/constellation/constellation_webview.rs
@@ -48,6 +48,14 @@ pub(crate) struct ConstellationWebView {
     /// The [`Theme`] that this [`ConstellationWebView`] uses. This is communicated to all
     /// `ScriptThread`s so that they know how to render the contents of a particular `WebView.
     theme: Theme,
+
+    /// Whether accessibility is active for this webview.
+    ///
+    /// Set by [`crate::Constellation::set_accessibility_active()`], and forwarded to the
+    /// webview’s *active* pipelines (of those that represent documents) at any given moment
+    /// via [`ScriptThreadMessage::SetAccessibilityActive`] in `set_accessibility_active()`
+    /// and [`crate::Constellation::set_frame_tree_for_webview()`].
+    pub accessibility_active: bool,
 }
 
 impl ConstellationWebView {
@@ -66,6 +74,7 @@ impl ConstellationWebView {
             last_mouse_move_point: Default::default(),
             session_history: JointSessionHistory::new(),
             theme: Theme::Light,
+            accessibility_active: false,
         }
     }
 

--- a/components/constellation/event_loop.rs
+++ b/components/constellation/event_loop.rs
@@ -111,7 +111,6 @@ impl EventLoop {
             player_context: WindowGLContext::get(),
             privileged_urls: constellation.privileged_urls.clone(),
             user_contents_for_manager_id: constellation.user_contents_for_manager_id.clone(),
-            accessibility_active: constellation.accessibility_active,
         };
 
         let event_loop = if opts::get().multiprocess {

--- a/components/layout/layout_impl.rs
+++ b/components/layout/layout_impl.rs
@@ -728,7 +728,7 @@ impl LayoutThread {
             previously_highlighted_dom_node: Cell::new(None),
             paint_timing_handler: Default::default(),
             user_stylesheets: config.user_stylesheets,
-            accessibility_active: Cell::new(config.accessibility_active),
+            accessibility_active: Cell::new(false),
         }
     }
 

--- a/components/script/script_thread.rs
+++ b/components/script/script_thread.rs
@@ -403,9 +403,6 @@ pub struct ScriptThread {
     #[no_trace]
     privileged_urls: Vec<ServoUrl>,
 
-    /// Whether accessibility is active. If true, each Layout will maintain an accessibility tree
-    /// and send accessibility updates to the embedder.
-    accessibility_active: Cell<bool>,
     devtools_state: DevtoolsState,
 }
 
@@ -1037,7 +1034,6 @@ impl ScriptThread {
                     debugger_paused: Cell::new(false),
                     privileged_urls: state.privileged_urls,
                     this: weak_script_thread.clone(),
-                    accessibility_active: Cell::new(state.accessibility_active),
                     devtools_state: Default::default(),
                 }
             }),
@@ -1982,8 +1978,8 @@ impl ScriptThread {
             ScriptThreadMessage::UpdatePinchZoomInfos(id, pinch_zoom_infos) => {
                 self.handle_update_pinch_zoom_infos(id, pinch_zoom_infos, CanGc::from_cx(cx));
             },
-            ScriptThreadMessage::SetAccessibilityActive(active) => {
-                self.set_accessibility_active(active);
+            ScriptThreadMessage::SetAccessibilityActive(pipeline_id, active) => {
+                self.set_accessibility_active(pipeline_id, active);
             },
             ScriptThreadMessage::TriggerGarbageCollection => unsafe {
                 JS_GC(*GlobalScope::get_cx(), GCReason::API);
@@ -3444,7 +3440,6 @@ impl ScriptThread {
             viewport_details: incomplete.viewport_details,
             user_stylesheets,
             theme: incomplete.theme,
-            accessibility_active: self.accessibility_active.get(),
         };
 
         // Create the window and document objects.
@@ -3741,19 +3736,18 @@ impl ScriptThread {
         document.event_handler().note_pending_input_event(event);
     }
 
-    fn set_accessibility_active(&self, active: bool) {
+    /// See the docs for [`ScriptThreadMessage::SetAccessibilityActive`].
+    fn set_accessibility_active(&self, pipeline_id: PipelineId, active: bool) {
         if !(pref!(accessibility_enabled)) {
             return;
         }
 
-        let old_value = self.accessibility_active.replace(active);
-        if active == old_value {
-            return;
-        }
-
-        for (_, document) in self.documents.borrow().iter() {
-            document.window().layout().set_accessibility_active(active);
-        }
+        let document = self
+            .documents
+            .borrow()
+            .find_document(pipeline_id)
+            .expect("Got pipeline_id from self.documents");
+        document.window().layout().set_accessibility_active(active);
     }
 
     /// Handle a "navigate an iframe" message from the constellation.

--- a/components/servo/Cargo.toml
+++ b/components/servo/Cargo.toml
@@ -145,6 +145,7 @@ gaol = "0.2.1"
 webxr = { workspace = true, features = ["glwindow", "headless", "openxr-api"] }
 
 [dev-dependencies]
+accesskit_consumer = "0.35.0"
 http = { workspace = true }
 http-body-util = { workspace = true }
 hyper = { workspace = true }

--- a/components/servo/servo.rs
+++ b/components/servo/servo.rs
@@ -927,14 +927,6 @@ impl Servo {
         self.0.site_data_manager.borrow()
     }
 
-    pub fn set_accessibility_active(&self, active: bool) {
-        self.0
-            .constellation_proxy
-            .send(EmbedderToConstellationMessage::SetAccessibilityActive(
-                active,
-            ));
-    }
-
     pub(crate) fn paint<'a>(&'a self) -> Ref<'a, Paint> {
         self.0.paint.borrow()
     }

--- a/components/servo/tests/accessibility.rs
+++ b/components/servo/tests/accessibility.rs
@@ -1,0 +1,126 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+//! WebView API unit tests.
+mod common;
+
+use std::collections::VecDeque;
+use std::rc::Rc;
+
+use servo::{LoadStatus, Preferences, WebViewBuilder};
+use url::Url;
+
+use crate::common::{ServoTest, WebViewDelegateImpl};
+
+struct NoOpChangeHandler;
+
+impl accesskit_consumer::TreeChangeHandler for NoOpChangeHandler {
+    fn node_added(&mut self, _: &accesskit_consumer::Node) {}
+    fn node_updated(&mut self, _: &accesskit_consumer::Node, _: &accesskit_consumer::Node) {}
+    fn focus_moved(
+        &mut self,
+        _: Option<&accesskit_consumer::Node>,
+        _: Option<&accesskit_consumer::Node>,
+    ) {
+    }
+    fn node_removed(&mut self, _: &accesskit_consumer::Node) {}
+}
+
+#[test]
+fn test_basic_accessibility_update() {
+    let servo_test = ServoTest::new_with_builder(|builder| {
+        let mut preferences = Preferences::default();
+        preferences.accessibility_enabled = true;
+        builder.preferences(preferences)
+    });
+
+    let delegate = Rc::new(WebViewDelegateImpl::default());
+    let webview = WebViewBuilder::new(servo_test.servo(), servo_test.rendering_context.clone())
+        .delegate(delegate.clone())
+        .url(Url::parse("data:text/html,<!DOCTYPE html>").unwrap())
+        .build();
+
+    webview.set_accessibility_active(true);
+
+    let load_webview = webview.clone();
+    servo_test.spin(move || load_webview.load_status() != LoadStatus::Complete);
+
+    let updates = wait_for_min_updates(&servo_test, delegate.clone(), 1);
+    let tree = build_tree(updates);
+    let root_node = tree.state().root();
+    find_first_matching_node(root_node, |node| node.role() == accesskit::Role::ScrollView)
+        .expect("Tree should include a scroll view corresponding to the WebView.");
+}
+
+fn wait_for_min_updates(
+    servo_test: &ServoTest,
+    delegate: Rc<WebViewDelegateImpl>,
+    min_num_updates: usize,
+) -> Vec<accesskit::TreeUpdate> {
+    let captured_delegate = delegate.clone();
+    servo_test.spin(move || {
+        captured_delegate.last_accesskit_tree_updates.borrow().len() < min_num_updates
+    });
+
+    delegate
+        .last_accesskit_tree_updates
+        .borrow_mut()
+        .drain(..)
+        .collect()
+}
+
+fn build_tree(tree_updates: Vec<accesskit::TreeUpdate>) -> accesskit_consumer::Tree {
+    let first_update = tree_updates[0].clone();
+    let tree_id = first_update.tree_id;
+
+    // We need to make a TreeUpdate with a TreeId of ROOT, which can have the subtrees grafted in
+    let root_node_id = accesskit::NodeId(0x0);
+    let mut root_node = accesskit::Node::new(accesskit::Role::GenericContainer);
+
+    // We need to make a graft node so that we have a non-graft node to set as the initial focused
+    // node for the tree.
+    let graft_node_id = accesskit::NodeId(0x1);
+    let mut graft_node = accesskit::Node::new(accesskit::Role::GenericContainer);
+    graft_node.set_tree_id(tree_id);
+
+    root_node.set_children(vec![graft_node_id]);
+
+    let root_tree = accesskit::Tree {
+        root: root_node_id,
+        toolkit_name: None,
+        toolkit_version: None,
+    };
+
+    let root_update = accesskit::TreeUpdate {
+        nodes: vec![(root_node_id, root_node), (graft_node_id, graft_node)],
+        tree: Some(root_tree),
+        tree_id: accesskit::TreeId::ROOT,
+        focus: root_node_id,
+    };
+
+    let mut tree = accesskit_consumer::Tree::new(root_update, true /* is_host_focused */);
+
+    for tree_update in tree_updates {
+        tree.update_and_process_changes(tree_update, &mut NoOpChangeHandler);
+    }
+    tree
+}
+
+fn find_first_matching_node(
+    root_node: accesskit_consumer::Node<'_>,
+    mut pred: impl FnMut(&accesskit_consumer::Node) -> bool,
+) -> Option<accesskit_consumer::Node<'_>> {
+    let mut children = root_node.children().collect::<VecDeque<_>>();
+    let mut result: Option<accesskit_consumer::Node> = None;
+    while let Some(candidate) = children.pop_front() {
+        if pred(&candidate) {
+            result = Some(candidate);
+            break;
+        }
+        for child in candidate.children() {
+            children.push_back(child);
+        }
+    }
+    result
+}

--- a/components/servo/tests/common/mod.rs
+++ b/components/servo/tests/common/mod.rs
@@ -95,6 +95,7 @@ pub(crate) struct WebViewDelegateImpl {
     pub(crate) active_dialog: RefCell<Option<SimpleDialog>>,
     pub(crate) number_of_controls_shown: Cell<usize>,
     pub(crate) number_of_controls_hidden: Cell<usize>,
+    pub(crate) last_accesskit_tree_updates: RefCell<Vec<accesskit::TreeUpdate>>,
 }
 
 #[allow(dead_code)] // Used by some tests and not others
@@ -106,6 +107,7 @@ impl WebViewDelegateImpl {
         self.controls_shown.borrow_mut().clear();
         self.number_of_controls_shown.set(0);
         self.number_of_controls_hidden.set(0);
+        self.last_accesskit_tree_updates.borrow_mut().clear();
     }
 }
 
@@ -146,6 +148,16 @@ impl WebViewDelegate for WebViewDelegateImpl {
     fn hide_embedder_control(&self, _webview: WebView, _control_id: servo::EmbedderControlId) {
         self.number_of_controls_hidden
             .set(self.number_of_controls_hidden.get() + 1);
+    }
+
+    fn notify_accessibility_tree_update(
+        &self,
+        _webview: WebView,
+        tree_update: accesskit::TreeUpdate,
+    ) {
+        self.last_accesskit_tree_updates
+            .borrow_mut()
+            .push(tree_update);
     }
 }
 

--- a/components/servo/webview.rs
+++ b/components/servo/webview.rs
@@ -21,6 +21,7 @@ use euclid::{Scale, Size2D};
 use image::RgbaImage;
 use paint_api::WebViewTrait;
 use paint_api::rendering_context::RenderingContext;
+use servo_config::pref;
 use servo_geometry::DeviceIndependentPixel;
 use servo_url::ServoUrl;
 use style_traits::CSSPixel;
@@ -89,6 +90,12 @@ pub(crate) struct WebViewInner {
     #[cfg(feature = "gamepad")]
     pub(crate) gamepad_delegate: Rc<dyn GamepadDelegate>,
 
+    /// AccessKit subtree id for this [`WebView`], if accessibility is active.
+    ///
+    /// Set by [`WebView::set_accessibility_active()`], and forwarded to the constellation via
+    /// [`EmbedderToConstellationMessage::SetAccessibilityActive`].
+    pub(crate) accesskit_tree_id: Option<accesskit::TreeId>,
+
     rendering_context: Rc<dyn RenderingContext>,
     user_content_manager: Option<Rc<UserContentManager>>,
     hidpi_scale_factor: Scale<f32, DeviceIndependentPixel, DevicePixel>,
@@ -136,6 +143,7 @@ impl WebView {
             gamepad_delegate: builder
                 .gamepad_delegate
                 .unwrap_or_else(|| Rc::new(DefaultGamepadDelegate)),
+            accesskit_tree_id: None,
             hidpi_scale_factor: builder.hidpi_scale_factor,
             load_status: LoadStatus::Started,
             status_text: None,
@@ -754,6 +762,60 @@ impl WebView {
 
         self.delegate()
             .show_embedder_control(self.clone(), embedder_control);
+    }
+
+    /// AccessKit subtree id for this [`WebView`], if accessibility is active.
+    pub fn accesskit_tree_id(&self) -> Option<accesskit::TreeId> {
+        self.inner().accesskit_tree_id
+    }
+
+    /// Activate or deactivate accessibility features for this [`WebView`], returning the
+    /// AccessKit subtree id if accessibility is now active.
+    ///
+    /// After accessibility is activated, you must [graft] the returned [`accesskit::TreeId`] into
+    /// your application’s main AccessKit tree as soon as possible, before processing any further
+    /// tree updates from the webview’s [`WebViewDelegate::notify_accessibility_tree_update()`].
+    /// Otherwise you may violate AccessKit’s subtree invariants and **panic**.
+    ///
+    /// [graft]: https://docs.rs/accesskit/0.24.0/accesskit/struct.Node.html#method.tree_id
+    pub fn set_accessibility_active(&self, active: bool) -> Option<accesskit::TreeId> {
+        if !pref!(accessibility_enabled) {
+            return None;
+        }
+
+        if active == self.inner().accesskit_tree_id.is_some() {
+            return self.accesskit_tree_id();
+        }
+
+        if active {
+            let accesskit_tree_id = accesskit::TreeId(accesskit::Uuid::new_v4());
+            self.inner_mut().accesskit_tree_id = Some(accesskit_tree_id);
+
+            // Synchronously emit a TreeUpdate containing just a ScrollView, but no graft node yet.
+            let root_node_id = accesskit::NodeId(0);
+            let root_node = accesskit::Node::new(accesskit::Role::ScrollView);
+            self.delegate().notify_accessibility_tree_update(
+                self.clone(),
+                accesskit::TreeUpdate {
+                    nodes: vec![(root_node_id, root_node)],
+                    tree: Some(accesskit::Tree {
+                        root: root_node_id,
+                        toolkit_name: None,
+                        toolkit_version: None,
+                    }),
+                    tree_id: accesskit_tree_id,
+                    focus: root_node_id,
+                },
+            );
+        } else {
+            self.inner_mut().accesskit_tree_id = None;
+        }
+
+        self.inner().servo.constellation_proxy().send(
+            EmbedderToConstellationMessage::SetAccessibilityActive(self.id(), active),
+        );
+
+        self.accesskit_tree_id()
     }
 }
 

--- a/components/servo/webview.rs
+++ b/components/servo/webview.rs
@@ -772,12 +772,18 @@ impl WebView {
     /// Activate or deactivate accessibility features for this [`WebView`], returning the
     /// AccessKit subtree id if accessibility is now active.
     ///
-    /// After accessibility is activated, you must [graft] the returned [`accesskit::TreeId`] into
-    /// your application’s main AccessKit tree as soon as possible, before processing any further
-    /// tree updates from the webview’s [`WebViewDelegate::notify_accessibility_tree_update()`].
-    /// Otherwise you may violate AccessKit’s subtree invariants and **panic**.
+    /// After accessibility is activated, you must [graft] (with [`set_tree_id()`]) the returned
+    /// [`accesskit::TreeId`] into your application’s main AccessKit tree as soon as possible,
+    /// *before* sending any tree updates from the webview to your AccessKit adapter. Otherwise you
+    /// may violate AccessKit’s subtree invariants and **panic**.
+    ///
+    /// This method may call [`WebViewDelegate::notify_accessibility_tree_update()`] synchronously
+    /// with an initial tree update, so if your impl for that method can’t create the graft node
+    /// (and send *that* update to AccessKit) before sending this update to AccessKit, then it must
+    /// queue the update for later.
     ///
     /// [graft]: https://docs.rs/accesskit/0.24.0/accesskit/struct.Node.html#method.tree_id
+    /// [`set_tree_id()`]: https://docs.rs/accesskit/0.24.0/accesskit/struct.Node.html#method.set_tree_id
     pub fn set_accessibility_active(&self, active: bool) -> Option<accesskit::TreeId> {
         if !pref!(accessibility_enabled) {
             return None;

--- a/components/servo/webview_delegate.rs
+++ b/components/servo/webview_delegate.rs
@@ -997,7 +997,12 @@ pub trait WebViewDelegate {
     /// <https://developer.mozilla.org/en-US/docs/Web/API/Console_API>
     fn show_console_message(&self, _webview: WebView, _level: ConsoleLogLevel, _message: String) {}
 
-    /// There are new accessibility tree updates from this [`WebView`].
+    /// There is a new accessibility tree update from this [`WebView`].
+    ///
+    /// Generally the impl should send this update to an AccessKit adapter, but it may need to queue
+    /// the update for later, if the [graft node] for this [`WebView`] has not yet been created
+    /// *and* your impl is unable to create it (and send that update to AccessKit) before sending
+    /// this update to AccessKit. For more details, see [`WebView::set_accessibility_active`].
     fn notify_accessibility_tree_update(
         &self,
         _webview: WebView,

--- a/components/shared/constellation/lib.rs
+++ b/components/shared/constellation/lib.rs
@@ -116,8 +116,8 @@ pub enum EmbedderToConstellationMessage {
     UserContentManagerAction(UserContentManagerId, UserContentManagerAction),
     /// Update pinch zoom details stored in the top level window
     UpdatePinchZoomInfos(PipelineId, PinchZoomInfos),
-    /// Activate or deactivate accessibility features.
-    SetAccessibilityActive(bool),
+    /// Activate or deactivate accessibility features for the given WebView.
+    SetAccessibilityActive(WebViewId, bool),
 }
 
 pub enum UserContentManagerAction {

--- a/components/shared/constellation/lib.rs
+++ b/components/shared/constellation/lib.rs
@@ -116,7 +116,7 @@ pub enum EmbedderToConstellationMessage {
     UserContentManagerAction(UserContentManagerId, UserContentManagerAction),
     /// Update pinch zoom details stored in the top level window
     UpdatePinchZoomInfos(PipelineId, PinchZoomInfos),
-    /// Activate or deactivate accessibility features for the given WebView.
+    /// Activate or deactivate accessibility features for the given `WebView`.
     SetAccessibilityActive(WebViewId, bool),
 }
 

--- a/components/shared/layout/lib.rs
+++ b/components/shared/layout/lib.rs
@@ -229,7 +229,6 @@ pub struct LayoutConfig {
     pub viewport_details: ViewportDetails,
     pub user_stylesheets: Rc<Vec<DocumentStyleSheet>>,
     pub theme: Theme,
-    pub accessibility_active: bool,
 }
 
 pub trait LayoutFactory: Send + Sync {

--- a/components/shared/script/lib.rs
+++ b/components/shared/script/lib.rs
@@ -308,8 +308,15 @@ pub enum ScriptThreadMessage {
     /// Update the pinch zoom details of a pipeline. Each `Window` stores a `VisualViewport` DOM
     /// instance that gets updated according to the changes from the `Compositor``.
     UpdatePinchZoomInfos(PipelineId, PinchZoomInfos),
-    /// Activate or deactivate accessibility features.
-    SetAccessibilityActive(bool),
+    /// Activate or deactivate accessibility features for the given pipeline, assuming it represents
+    /// a document.
+    ///
+    /// Why only one pipeline? In the Servo API, accessibility is activated on a per-webview basis,
+    /// and webviews have a simple one-to-many mapping to pipelines that represent documents. But
+    /// those pipelines run in script threads, which complicates things: the pipelines in a webview
+    /// may be split across multiple script threads, and the pipelines in a script thread may belong
+    /// to multiple webviews. So the simplest approach is to activate it for one pipeline at a time.
+    SetAccessibilityActive(PipelineId, bool),
     /// Force a garbage collection in this script thread.
     TriggerGarbageCollection,
 }
@@ -393,8 +400,6 @@ pub struct InitialScriptState {
     pub privileged_urls: Vec<ServoUrl>,
     /// A copy of constellation's `UserContentManagerId` to `UserContents` map.
     pub user_contents_for_manager_id: FxHashMap<UserContentManagerId, UserContents>,
-    /// Whether this script should be initialized with accessibility already active.
-    pub accessibility_active: bool,
 }
 
 /// Errors from executing a paint worklet


### PR DESCRIPTION
in #42336, we added a [Servo](https://doc.servo.org/servo/struct.Servo.html)-global API for controlling whether accessibility is active. the idea was that when the embedder activates accessibility, all webviews and documents activate accessibility and start sending AccessKit tree updates, and vice versa when they deactivate.

we found a problem with this approach in #42338. global activation of accessibility makes it too easy to accidentally cause a panic in AccessKit, and harder than it needs to be for embedders to learn that they are responsible for grafting each webview’s subtree into their main AccessKit tree as soon as accessibility is activated. this is due to an invariant of the AccessKit subtree API: if a subtree starts sending updates before the graft node is created, the program panics.

this patch reworks accessibility activation to make it per-webview. by requiring embedders to explicitly activate accessibility for a webview, we can communicate the AccessKit invariant via our API docs.

Testing: this patch includes an initial accessibility test in libservo
Fixes: part of #4344, extracted from our work in #42338