### PR TITLE
script: Unify naming of LayoutDom conversion functions to `{to, from}_layout_dom`

### DIFF
--- a/components/script/dom/node.rs
+++ b/components/script/dom/node.rs
@@ -1168,12 +1168,12 @@ impl Node {
 
         let first_matching_element = with_layout_state(|| {
             let layout_node = unsafe { traced_node.to_layout() };
-            ServoLayoutNode::from_layout_js(layout_node)
+            ServoLayoutNode::from_layout_dom(layout_node)
                 .scope_match_a_selectors_string::<QueryFirst>(document_url, &selectors.str())
         })?;
 
         Ok(first_matching_element
-            .map(|element| DomRoot::from_ref(unsafe { element.to_layout_js().as_ref() })))
+            .map(|element| DomRoot::from_ref(unsafe { element.to_layout_dom().as_ref() })))
     }
 
     /// <https://dom.spec.whatwg.org/#dom-parentnode-queryselectorall>
@@ -1188,12 +1188,12 @@ impl Node {
         let traced_node = Dom::from_ref(self);
         let matching_elements = with_layout_state(|| {
             let layout_node = unsafe { traced_node.to_layout() };
-            ServoLayoutNode::from_layout_js(layout_node)
+            ServoLayoutNode::from_layout_dom(layout_node)
                 .scope_match_a_selectors_string::<QueryAll>(document_url, &selectors.str())
         })?;
         let iter = matching_elements
             .into_iter()
-            .map(|element| DomRoot::from_ref(unsafe { element.to_layout_js().as_ref() }))
+            .map(|element| DomRoot::from_ref(unsafe { element.to_layout_dom().as_ref() }))
             .map(DomRoot::upcast::<Node>);
 
         // NodeList::new_simple_list immediately collects the iterator, so we're not leaking LayoutDom

--- a/components/script/layout_dom/document.rs
+++ b/components/script/layout_dom/document.rs
@@ -26,7 +26,7 @@ impl<'ld> ::style::dom::TDocument for ServoLayoutDocument<'ld> {
     type ConcreteNode = ServoLayoutNode<'ld>;
 
     fn as_node(&self) -> Self::ConcreteNode {
-        ServoLayoutNode::from_layout_js(self.document.upcast())
+        ServoLayoutNode::from_layout_dom(self.document.upcast())
     }
 
     fn quirks_mode(&self) -> QuirksMode {
@@ -77,7 +77,7 @@ impl<'ld> ServoLayoutDocument<'ld> {
                 .iter()
                 .map(|sr| {
                     debug_assert!(sr.upcast::<Node>().get_flag(NodeFlags::IS_CONNECTED));
-                    ServoShadowRoot::from_layout_js(*sr)
+                    ServoShadowRoot::from_layout_dom(*sr)
                 })
                 .collect()
         }
@@ -99,7 +99,7 @@ impl<'ld> ServoLayoutDocument<'ld> {
         }
     }
 
-    pub(crate) fn from_layout_js(document: LayoutDom<'ld, Document>) -> Self {
+    pub(crate) fn from_layout_dom(document: LayoutDom<'ld, Document>) -> Self {
         ServoLayoutDocument { document }
     }
 }

--- a/components/script/layout_dom/element.rs
+++ b/components/script/layout_dom/element.rs
@@ -74,15 +74,15 @@ impl fmt::Debug for ServoLayoutElement<'_> {
 }
 
 impl<'dom> ServoLayoutElement<'dom> {
-    pub(super) fn from_layout_js(el: LayoutDom<'dom, Element>) -> Self {
-        ServoLayoutElement { element: el }
+    pub(super) fn from_layout_dom(element: LayoutDom<'dom, Element>) -> Self {
+        ServoLayoutElement { element }
     }
 
     /// Returns the interior of this element as a `LayoutDom`.
     ///
     /// This method must never be exposed to layout as it returns
     /// a `LayoutDom`.
-    pub(crate) fn to_layout_js(self) -> LayoutDom<'dom, Element> {
+    pub(crate) fn to_layout_dom(self) -> LayoutDom<'dom, Element> {
         self.element
     }
 
@@ -197,7 +197,7 @@ impl<'dom> style::dom::TElement for ServoLayoutElement<'dom> {
     type TraversalChildrenIterator = DOMDescendantIterator<Self>;
 
     fn as_node(&self) -> ServoLayoutNode<'dom> {
-        ServoLayoutNode::from_layout_js(self.element.upcast())
+        ServoLayoutNode::from_layout_dom(self.element.upcast())
     }
 
     fn traversal_children(&self) -> LayoutIterator<Self::TraversalChildrenIterator> {
@@ -429,12 +429,12 @@ impl<'dom> style::dom::TElement for ServoLayoutElement<'dom> {
     }
 
     unsafe fn clear_data(&self) {
-        unsafe { self.as_node().get_jsmanaged().clear_style_and_layout_data() }
+        unsafe { self.as_node().to_layout_dom().clear_style_and_layout_data() }
     }
 
     unsafe fn ensure_data(&self) -> AtomicRefMut<'_, ElementData> {
         unsafe {
-            self.as_node().get_jsmanaged().initialize_style_data();
+            self.as_node().to_layout_dom().initialize_style_data();
         };
         self.mutate_data().unwrap()
     }
@@ -535,7 +535,7 @@ impl<'dom> style::dom::TElement for ServoLayoutElement<'dom> {
     fn shadow_root(&self) -> Option<ServoShadowRoot<'dom>> {
         self.element
             .get_shadow_root_for_layout()
-            .map(ServoShadowRoot::from_layout_js)
+            .map(ServoShadowRoot::from_layout_dom)
     }
 
     /// The shadow root which roots the subtree this element is contained in.
@@ -543,7 +543,7 @@ impl<'dom> style::dom::TElement for ServoLayoutElement<'dom> {
         self.element
             .upcast()
             .containing_shadow_root_for_layout()
-            .map(ServoShadowRoot::from_layout_js)
+            .map(ServoShadowRoot::from_layout_dom)
     }
 
     fn local_name(&self) -> &LocalName {
@@ -1041,7 +1041,7 @@ impl<'dom> ServoThreadSafeLayoutElement<'dom> {
         self.element
             .element
             .get_shadow_root_for_layout()
-            .map(ServoShadowRoot::from_layout_js)
+            .map(ServoShadowRoot::from_layout_dom)
     }
 
     pub fn slotted_nodes(&self) -> &[ServoLayoutNode<'dom>] {

--- a/components/script/layout_dom/node.rs
+++ b/components/script/layout_dom/node.rs
@@ -75,8 +75,8 @@ impl fmt::Debug for ServoLayoutNode<'_> {
 }
 
 impl<'dom> ServoLayoutNode<'dom> {
-    pub(crate) fn from_layout_js(n: LayoutDom<'dom, Node>) -> Self {
-        ServoLayoutNode { node: n }
+    pub(crate) fn from_layout_dom(node: LayoutDom<'dom, Node>) -> Self {
+        ServoLayoutNode { node }
     }
 
     /// Create a new [`ServoLayoutNode`] for this given [`TrustedNodeAddress`].
@@ -86,7 +86,7 @@ impl<'dom> ServoLayoutNode<'dom> {
     /// The address pointed to by `address` should point to a valid node in memory.
     pub unsafe fn new(address: &TrustedNodeAddress) -> Self {
         let node = unsafe { LayoutDom::from_trusted_node_address(*address) };
-        ServoLayoutNode::from_layout_js(node)
+        ServoLayoutNode::from_layout_dom(node)
     }
 
     pub(super) fn script_type_id(&self) -> NodeTypeId {
@@ -94,7 +94,10 @@ impl<'dom> ServoLayoutNode<'dom> {
     }
 
     /// Returns the interior of this node as a `LayoutDom`.
-    pub(crate) fn get_jsmanaged(self) -> LayoutDom<'dom, Node> {
+    ///
+    /// This method must never be exposed to layout as it returns
+    /// a `LayoutDom`.
+    pub(crate) fn to_layout_dom(self) -> LayoutDom<'dom, Node> {
         self.node
     }
 
@@ -103,7 +106,7 @@ impl<'dom> ServoLayoutNode<'dom> {
             .assigned_slot_for_layout()
             .as_ref()
             .map(LayoutDom::upcast)
-            .map(ServoLayoutElement::from_layout_js)
+            .map(ServoLayoutElement::from_layout_dom)
     }
 
     /// <https://dom.spec.whatwg.org/#scope-match-a-selectors-string>
@@ -156,27 +159,27 @@ impl<'dom> style::dom::TNode for ServoLayoutNode<'dom> {
     type ConcreteShadowRoot = ServoShadowRoot<'dom>;
 
     fn parent_node(&self) -> Option<Self> {
-        self.node.parent_node_ref().map(Self::from_layout_js)
+        self.node.parent_node_ref().map(Self::from_layout_dom)
     }
 
     fn first_child(&self) -> Option<Self> {
-        self.node.first_child_ref().map(Self::from_layout_js)
+        self.node.first_child_ref().map(Self::from_layout_dom)
     }
 
     fn last_child(&self) -> Option<Self> {
-        self.node.last_child_ref().map(Self::from_layout_js)
+        self.node.last_child_ref().map(Self::from_layout_dom)
     }
 
     fn prev_sibling(&self) -> Option<Self> {
-        self.node.prev_sibling_ref().map(Self::from_layout_js)
+        self.node.prev_sibling_ref().map(Self::from_layout_dom)
     }
 
     fn next_sibling(&self) -> Option<Self> {
-        self.node.next_sibling_ref().map(Self::from_layout_js)
+        self.node.next_sibling_ref().map(Self::from_layout_dom)
     }
 
     fn owner_doc(&self) -> Self::ConcreteDocument {
-        ServoLayoutDocument::from_layout_js(self.node.owner_doc_for_layout())
+        ServoLayoutDocument::from_layout_dom(self.node.owner_doc_for_layout())
     }
 
     fn traversal_parent(&self) -> Option<ServoLayoutElement<'dom>> {
@@ -191,7 +194,7 @@ impl<'dom> style::dom::TNode for ServoLayoutNode<'dom> {
     }
 
     fn opaque(&self) -> style::dom::OpaqueNode {
-        self.get_jsmanaged().opaque()
+        self.to_layout_dom().opaque()
     }
 
     fn debug_id(self) -> usize {
@@ -199,17 +202,19 @@ impl<'dom> style::dom::TNode for ServoLayoutNode<'dom> {
     }
 
     fn as_element(&self) -> Option<ServoLayoutElement<'dom>> {
-        self.node.downcast().map(ServoLayoutElement::from_layout_js)
+        self.node
+            .downcast()
+            .map(ServoLayoutElement::from_layout_dom)
     }
 
     fn as_document(&self) -> Option<ServoLayoutDocument<'dom>> {
         self.node
             .downcast()
-            .map(ServoLayoutDocument::from_layout_js)
+            .map(ServoLayoutDocument::from_layout_dom)
     }
 
     fn as_shadow_root(&self) -> Option<ServoShadowRoot<'dom>> {
-        self.node.downcast().map(ServoShadowRoot::from_layout_js)
+        self.node.downcast().map(ServoShadowRoot::from_layout_dom)
     }
 
     fn is_in_document(&self) -> bool {
@@ -229,7 +234,7 @@ impl<'dom> LayoutNode<'dom> for ServoLayoutNode<'dom> {
     }
 
     unsafe fn initialize_style_and_layout_data<RequestedLayoutDataType: LayoutDataTrait>(&self) {
-        let inner = self.get_jsmanaged();
+        let inner = self.to_layout_dom();
         if inner.style_data().is_none() {
             unsafe { inner.initialize_style_data() };
         }
@@ -243,11 +248,11 @@ impl<'dom> LayoutNode<'dom> for ServoLayoutNode<'dom> {
     }
 
     fn style_data(&self) -> Option<&'dom StyleData> {
-        self.get_jsmanaged().style_data()
+        self.to_layout_dom().style_data()
     }
 
     fn layout_data(&self) -> Option<&'dom GenericLayoutData> {
-        self.get_jsmanaged().layout_data()
+        self.to_layout_dom().layout_data()
     }
 }
 
@@ -275,7 +280,7 @@ impl<'dom> ServoThreadSafeLayoutNode<'dom> {
     /// Returns the interior of this node as a `LayoutDom`. This is highly unsafe for layout to
     /// call and as such is marked `unsafe`.
     unsafe fn get_jsmanaged(&self) -> LayoutDom<'dom, Node> {
-        self.node.get_jsmanaged()
+        self.node.to_layout_dom()
     }
 
     /// Get the first child of this node. Important: this is not safe for
@@ -284,7 +289,7 @@ impl<'dom> ServoThreadSafeLayoutNode<'dom> {
         let js_managed = unsafe { self.get_jsmanaged() };
         js_managed
             .first_child_ref()
-            .map(ServoLayoutNode::from_layout_js)
+            .map(ServoLayoutNode::from_layout_dom)
             .map(Self::new)
     }
 
@@ -294,7 +299,7 @@ impl<'dom> ServoThreadSafeLayoutNode<'dom> {
         let js_managed = unsafe { self.get_jsmanaged() };
         js_managed
             .next_sibling_ref()
-            .map(ServoLayoutNode::from_layout_js)
+            .map(ServoLayoutNode::from_layout_dom)
             .map(Self::new)
     }
 
@@ -382,7 +387,7 @@ impl<'dom> ThreadSafeLayoutNode<'dom> for ServoThreadSafeLayoutNode<'dom> {
     }
 
     fn initialize_layout_data<RequestedLayoutDataType: LayoutDataTrait>(&self) {
-        let inner = self.node.get_jsmanaged();
+        let inner = self.node.to_layout_dom();
         if inner.layout_data().is_none() {
             unsafe {
                 inner.initialize_layout_data(Box::<RequestedLayoutDataType>::default());

--- a/components/script/layout_dom/shadow_root.rs
+++ b/components/script/layout_dom/shadow_root.rs
@@ -28,11 +28,11 @@ impl<'dom> TShadowRoot for ServoShadowRoot<'dom> {
     type ConcreteNode = ServoLayoutNode<'dom>;
 
     fn as_node(&self) -> Self::ConcreteNode {
-        ServoLayoutNode::from_layout_js(self.shadow_root.upcast())
+        ServoLayoutNode::from_layout_dom(self.shadow_root.upcast())
     }
 
     fn host(&self) -> ServoLayoutElement<'dom> {
-        ServoLayoutElement::from_layout_js(self.shadow_root.get_host_for_layout())
+        ServoLayoutElement::from_layout_dom(self.shadow_root.get_host_for_layout())
     }
 
     fn style_data<'a>(&self) -> Option<&'a CascadeData>
@@ -44,7 +44,7 @@ impl<'dom> TShadowRoot for ServoShadowRoot<'dom> {
 }
 
 impl<'dom> ServoShadowRoot<'dom> {
-    pub(super) fn from_layout_js(shadow_root: LayoutDom<'dom, ShadowRoot>) -> Self {
+    pub(super) fn from_layout_dom(shadow_root: LayoutDom<'dom, ShadowRoot>) -> Self {
         ServoShadowRoot { shadow_root }
     }
 


### PR DESCRIPTION
As requested during the review of https://github.com/servo/servo/pull/42991. These functions are currently called `{to, from}_layout_js` or sometimes `get_jsmanaged` - this change unifies them as `{to, from}_layout_dom` for clarity.

Testing: Covered by existing tests