### PR TITLE
deps: Include glsl-optimizer patch for building with glibc 2.43

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2935,8 +2935,7 @@ dependencies = [
 [[package]]
 name = "glslopt"
 version = "0.1.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ba4741358604ca0848c27ecc069d68e62e11cde81e38aac1da3c54b79ab5adf"
+source = "git+https://github.com/kkoyung/glslopt-rs?rev=e32e57d8c260f7e3c51a41e8c5399ca928260dce#e32e57d8c260f7e3c51a41e8c5399ca928260dce"
 dependencies = [
  "cc",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -318,6 +318,13 @@ codegen-units = 1
 egui = { git = "https://github.com/emilk/egui.git", rev = "5d8f393335e051785b4fd3af9ef92eda5b61177f" }
 egui-winit = { git = "https://github.com/emilk/egui.git", rev = "5d8f393335e051785b4fd3af9ef92eda5b61177f" }
 #
+# Pending glslopt-rs bumping the version to include a patch at glsl-optimizer:
+# https://github.com/jamienicol/glsl-optimizer/pull/18
+# Servo issue for tracking: https://github.com/servo/servo/issues/42695
+# This is required for building servo with glibc 2.43.
+# TODO: When this is no longer needed remove the exception in deny.toml as well.
+glslopt = { git = "https://github.com/kkoyung/glslopt-rs", rev = "e32e57d8c260f7e3c51a41e8c5399ca928260dce" }
+#
 # Or for Stylo:
 #
 # [patch."https://github.com/servo/stylo"]

--- a/deny.toml
+++ b/deny.toml
@@ -231,4 +231,7 @@ github = [
 
     # Temporarily needed by servoshell: see root Cargo.toml
     "emilk",
+
+    # Temporarily needed for building with glibc 2.43: see root Cargo.toml
+    "kkoyung",
 ]


### PR DESCRIPTION
The `glslopt` dependency fails to build with Glibc 2.43, which blocks Servo builds on some Linux distributions that already ship glibc 2.43 (e.g. Arch Linux, Gentoo).

A fix has been merged upstream, but the upstream version has not been bumped yet.

Until then, we point `glslopt` to a forked repository that containing the fix (in its submodule) so the build works without manual changes like this: https://github.com/servo/servo/issues/42695#issuecomment-3948856031

Fixes: Temporary fix for #42695