### PR TITLE
script: Fix handling of attributes for link elements

### DIFF
--- a/components/script/dom/html/htmllinkelement.rs
+++ b/components/script/dom/html/htmllinkelement.rs
@@ -24,6 +24,7 @@ use script_bindings::root::Dom;
 use servo_arc::Arc;
 use servo_url::ServoUrl;
 use style::attr::AttrValue;
+use style::media_queries::MediaList as StyleMediaList;
 use style::stylesheets::Stylesheet;
 use stylo_atoms::Atom;
 use webrender_api::units::DeviceIntSize;
@@ -252,10 +253,22 @@ impl VirtualMethods for HTMLLinkElement {
             self.handle_disabled_attribute_change(is_removal);
             return;
         }
+        let node = self.upcast::<Node>();
 
-        if !self.upcast::<Node>().is_connected() {
+        if !node.is_connected() {
             return;
         }
+
+        // For stylesheets, we should only refetch when the actual attribute value
+        // has been changed.
+        if self.relations.get().contains(LinkRelations::STYLESHEET) {
+            if let AttributeMutation::Set(Some(previous_value), _) = mutation {
+                if **previous_value == **attr.value() {
+                    return;
+                }
+            }
+        }
+
         match *local_name {
             local_name!("rel") | local_name!("rev") => {
                 let previous_relations = self.relations.get();
@@ -374,6 +387,21 @@ impl VirtualMethods for HTMLLinkElement {
                         },
                         _ => {},
                     };
+                } else if self.relations.get().contains(LinkRelations::STYLESHEET) {
+                    if let Some(ref stylesheet) = *self.stylesheet.borrow_mut() {
+                        let document = self.owner_document();
+                        let shared_lock = document.style_shared_lock().clone();
+                        let mut guard = shared_lock.write();
+                        let media = stylesheet.media.write_with(&mut guard);
+                        match mutation {
+                            AttributeMutation::Set(..) => {
+                                *media =
+                                    MediaList::parse_media_list(&attr.value(), document.window())
+                            },
+                            AttributeMutation::Removed => *media = StyleMediaList::empty(),
+                        };
+                        self.owner_document().invalidate_stylesheets();
+                    }
                 }
 
                 let matches_media_environment =
@@ -616,6 +644,17 @@ impl HTMLLinkElement {
 
         let element = self.upcast::<Element>();
 
+        // https://html.spec.whatwg.org/multipage/#processing-the-type-attribute
+        // > If the UA does not support the given MIME type for the given link relationship,
+        // > then the UA should not fetch and process the linked resource
+        //
+        // https://html.spec.whatwg.org/multipage/#link-type-stylesheet
+        // > The default type for resources given by the stylesheet keyword is text/css.
+        let type_ = element.get_string_attribute(&local_name!("type"));
+        if !type_.is_empty() && type_ != "text/css" {
+            return;
+        }
+
         // Step 1.
         let href = element.get_string_attribute(&local_name!("href"));
         if href.is_empty() {
@@ -640,10 +679,6 @@ impl HTMLLinkElement {
             Some(ref value) => &***value,
             None => "",
         };
-
-        if !MediaList::matches_environment(&document, mq_str) {
-            return;
-        }
 
         let media = MediaList::parse_media_list(mq_str, document.window());
         let media = Arc::new(document.style_shared_lock().wrap(media));

--- a/tests/wpt/meta/html/semantics/document-metadata/interactions-of-styling-and-scripting/conditionally-block-rendering-on-link-media-attr.html.ini
+++ b/tests/wpt/meta/html/semantics/document-metadata/interactions-of-styling-and-scripting/conditionally-block-rendering-on-link-media-attr.html.ini
@@ -1,3 +1,0 @@
-[conditionally-block-rendering-on-link-media-attr.html]
-  [Both style sheets loaded via the link elements should be registered as style sheets for the document after 2 seconds]
-    expected: FAIL

--- a/tests/wpt/meta/html/semantics/document-metadata/the-link-element/link-multiple-load-events.html.ini
+++ b/tests/wpt/meta/html/semantics/document-metadata/the-link-element/link-multiple-load-events.html.ini
@@ -1,6 +1,0 @@
-[link-multiple-load-events.html]
-  [<link> cannot request the same resource twice by touching the 'href' attribute, if its value never changes]
-    expected: FAIL
-
-  [<link> cannot request the same resource twice by touching the 'type' attribute, if its value never changes]
-    expected: FAIL

--- a/tests/wpt/meta/html/semantics/document-metadata/the-link-element/link-type-attribute.html.ini
+++ b/tests/wpt/meta/html/semantics/document-metadata/the-link-element/link-type-attribute.html.ini
@@ -1,2 +1,0 @@
-[link-type-attribute.html]
-  expected: FAIL

--- a/tests/wpt/meta/html/semantics/document-metadata/the-link-element/stylesheet-media-change-no-fetch.html.ini
+++ b/tests/wpt/meta/html/semantics/document-metadata/the-link-element/stylesheet-media-change-no-fetch.html.ini
@@ -1,4 +1,0 @@
-[stylesheet-media-change-no-fetch.html]
-  expected: TIMEOUT
-  [stylesheet should not re-fetch when media changes. The media change should apply immediately]
-    expected: TIMEOUT

--- a/tests/wpt/meta/html/syntax/speculative-parsing/generated/document-write/link-rel-stylesheet-nomatch-media.tentative.sub.html.ini
+++ b/tests/wpt/meta/html/syntax/speculative-parsing/generated/document-write/link-rel-stylesheet-nomatch-media.tentative.sub.html.ini
@@ -1,0 +1,3 @@
+[link-rel-stylesheet-nomatch-media.tentative.sub.html]
+  [Speculative parsing, document.write(): link-rel-stylesheet-nomatch-media]
+    expected: FAIL

--- a/tests/wpt/meta/html/syntax/speculative-parsing/generated/document-write/link-rel-stylesheet-unsupported-type.tentative.sub.html.ini
+++ b/tests/wpt/meta/html/syntax/speculative-parsing/generated/document-write/link-rel-stylesheet-unsupported-type.tentative.sub.html.ini
@@ -1,3 +1,0 @@
-[link-rel-stylesheet-unsupported-type.tentative.sub.html]
-  [Speculative parsing, document.write(): link-rel-stylesheet-unsupported-type]
-    expected: FAIL

--- a/tests/wpt/meta/html/syntax/speculative-parsing/generated/document-write/meta-viewport-link-stylesheet-media.tentative.sub.html.ini
+++ b/tests/wpt/meta/html/syntax/speculative-parsing/generated/document-write/meta-viewport-link-stylesheet-media.tentative.sub.html.ini
@@ -1,0 +1,3 @@
+[meta-viewport-link-stylesheet-media.tentative.sub.html]
+  [Speculative parsing, document.write(): meta-viewport-link-stylesheet-media]
+    expected: FAIL


### PR DESCRIPTION
These were some of the remaining failures for link elements. They concern attribute handling and when to run fetches.

1. We shouldn't refetch on media changes, but immediately apply the effect. This is already the case for style elements
2. We shouldn't refetch when attribute values are the same
3. We shouldn't fetch when the type attribute doesn't match
4. We should fetch, even if the media doesn't match. Only when the media is then changed, we should re-evaluate.