### PR TITLE
script: Fix lookup of properties of DOMStringMap

### DIFF
--- a/components/script/dom/domstringmap.rs
+++ b/components/script/dom/domstringmap.rs
@@ -3,12 +3,16 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 use dom_struct::dom_struct;
+use html5ever::{LocalName, ns};
 
 use crate::dom::bindings::codegen::Bindings::DOMStringMapBinding::DOMStringMapMethods;
-use crate::dom::bindings::error::ErrorResult;
+use crate::dom::bindings::error::{Error, ErrorResult};
+use crate::dom::bindings::inheritance::Castable;
 use crate::dom::bindings::reflector::{Reflector, reflect_dom_object};
 use crate::dom::bindings::root::{Dom, DomRoot};
 use crate::dom::bindings::str::DOMString;
+use crate::dom::bindings::xmlname::matches_name_production;
+use crate::dom::element::Element;
 use crate::dom::html::htmlelement::HTMLElement;
 use crate::dom::node::NodeTraits;
 use crate::script_runtime::CanGc;
@@ -17,6 +21,99 @@ use crate::script_runtime::CanGc;
 pub(crate) struct DOMStringMap {
     reflector_: Reflector,
     element: Dom<HTMLElement>,
+}
+
+static DATA_PREFIX: &str = "data-";
+static DATA_HYPHEN_SEPARATOR: char = '\x2d';
+
+/// <https://html.spec.whatwg.org/multipage/#concept-domstringmap-pairs>
+fn to_camel_case(name: &str) -> Option<DOMString> {
+    // Step 2. For each content attribute on the DOMStringMap's associated element whose
+    // first five characters are the string "data-" and whose remaining characters (if any)
+    // do not include any ASCII upper alphas, in the order that those attributes
+    // are listed in the element's attribute list,
+    // add a name-value pair to list whose name is the attribute's name with the first
+    // five characters removed and whose value is the attribute's value.
+    let Some(name) = name.strip_prefix(DATA_PREFIX) else {
+        return None;
+    };
+    let has_uppercase = name.chars().any(|curr_char| curr_char.is_ascii_uppercase());
+    if has_uppercase {
+        return None;
+    }
+    // Step 3. For each name in list, for each U+002D HYPHEN-MINUS character (-)
+    // in the name that is followed by an ASCII lower alpha, remove the
+    // U+002D HYPHEN-MINUS character (-) and replace the character that followed
+    // it by the same character converted to ASCII uppercase.
+    let mut result = String::with_capacity(name.len().saturating_sub(DATA_PREFIX.len()));
+    let mut name_chars = name.chars().peekable();
+    while let Some(curr_char) = name_chars.next() {
+        // Note that we first need to peek, since we shouldn't advance the iterator twice
+        // in case there are two consecutive dashes and then followed by a ASCII lower alpha
+        if curr_char == DATA_HYPHEN_SEPARATOR &&
+            name_chars
+                .peek()
+                .is_some_and(|next_char| next_char.is_ascii_lowercase())
+        {
+            result.push(
+                name_chars
+                    .next()
+                    .expect("Already called peek")
+                    .to_ascii_uppercase(),
+            );
+            continue;
+        }
+        result.push(curr_char);
+    }
+    // Step 1. Let list be an empty list of name-value pairs.
+    // Step 4. Return list.
+    //
+    // We do the iteration in the calling function, to avoid needlessly computing attribute
+    // values when we only need the names. Therefore, we only return the name.
+    Some(DOMString::from(result))
+}
+
+/// <https://html.spec.whatwg.org/multipage/#dom-domstringmap-setitem>
+/// and <https://html.spec.whatwg.org/multipage/#dom-domstringmap-removeitem>
+fn to_snake_case(name: &DOMString, should_throw: bool) -> Option<String> {
+    let name = name.str();
+    let mut result = String::with_capacity(DATA_PREFIX.len() + name.len());
+    // > Insert the string data- at the front of name.
+    result.push_str(DATA_PREFIX);
+    let mut name_chars = name.chars();
+    while let Some(curr_char) = name_chars.next() {
+        if curr_char == DATA_HYPHEN_SEPARATOR {
+            result.push(curr_char);
+
+            if let Some(next_char) = name_chars.next() {
+                // Only relevant for https://html.spec.whatwg.org/multipage/#dom-domstringmap-setitem
+                //
+                // > If name contains a U+002D HYPHEN-MINUS character (-) followed by an ASCII lower alpha,
+                // > then throw a "SyntaxError" DOMException.
+                if next_char.is_ascii_lowercase() {
+                    if should_throw {
+                        return None;
+                    }
+                    result.push(next_char);
+                } else {
+                    // > For each ASCII upper alpha in name, insert a U+002D HYPHEN-MINUS character (-) before the character
+                    // > and replace the character with the same character converted to ASCII lowercase.
+                    result.push(DATA_HYPHEN_SEPARATOR);
+                    result.push(next_char.to_ascii_lowercase());
+                }
+            }
+        } else {
+            // > For each ASCII upper alpha in name, insert a U+002D HYPHEN-MINUS character (-) before the character
+            // > and replace the character with the same character converted to ASCII lowercase.
+            if curr_char.is_ascii_uppercase() {
+                result.push(DATA_HYPHEN_SEPARATOR);
+                result.push(curr_char.to_ascii_lowercase());
+            } else {
+                result.push(curr_char);
+            }
+        }
+    }
+    Some(result)
 }
 
 impl DOMStringMap {
@@ -34,27 +131,73 @@ impl DOMStringMap {
             can_gc,
         )
     }
+
+    fn as_element(&self) -> &Element {
+        self.element.upcast::<Element>()
+    }
 }
 
 // https://html.spec.whatwg.org/multipage/#domstringmap
 impl DOMStringMapMethods<crate::DomTypeHolder> for DOMStringMap {
     /// <https://html.spec.whatwg.org/multipage/#dom-domstringmap-removeitem>
-    fn NamedDeleter(&self, name: DOMString, can_gc: CanGc) {
-        self.element.delete_custom_attr(name, can_gc)
+    fn NamedDeleter(&self, cx: &mut js::context::JSContext, name: DOMString) {
+        // Step 1. For each ASCII upper alpha in name, insert a U+002D HYPHEN-MINUS character (-) before the character
+        // and replace the character with the same character converted to ASCII lowercase.
+        // Step 2. Insert the string data- at the front of name.
+        let name = to_snake_case(&name, false).expect("Must always succeed");
+        // Step 3. Remove an attribute by name given name and the DOMStringMap's associated element.
+        self.as_element()
+            .remove_attribute(&ns!(), &LocalName::from(name), CanGc::from_cx(cx));
     }
 
     /// <https://html.spec.whatwg.org/multipage/#dom-domstringmap-setitem>
-    fn NamedSetter(&self, name: DOMString, value: DOMString, can_gc: CanGc) -> ErrorResult {
-        self.element.set_custom_attr(name, value, can_gc)
+    fn NamedSetter(
+        &self,
+        cx: &mut js::context::JSContext,
+        name: DOMString,
+        value: DOMString,
+    ) -> ErrorResult {
+        // Step 2. For each ASCII upper alpha in name, insert a U+002D HYPHEN-MINUS character (-)
+        // before the character and replace the character with the same character converted to ASCII lowercase.
+        // Step 3. Insert the string data- at the front of name.
+        let Some(name) = to_snake_case(&name, true) else {
+            // Step 1. If name contains a U+002D HYPHEN-MINUS character (-) followed by an ASCII lower alpha,
+            // then throw a "SyntaxError" DOMException.
+            return Err(Error::Syntax(None));
+        };
+        // Step 4. If name is not a valid attribute local name, then throw an "InvalidCharacterError" DOMException.
+        if !matches_name_production(&name) {
+            return Err(Error::InvalidCharacter(None));
+        }
+        // Step 5. Set an attribute value for the DOMStringMap's associated element using name and value.
+        let name = LocalName::from(name);
+        let element = self.as_element();
+        let value = element.parse_attribute(&ns!(), &name, value);
+        element.set_attribute_with_namespace(cx, name.clone(), value, name, ns!(), None);
+        Ok(())
     }
 
     /// <https://html.spec.whatwg.org/multipage/#dom-domstringmap-nameditem>
     fn NamedGetter(&self, name: DOMString) -> Option<DOMString> {
-        self.element.get_custom_attr(name)
+        // > To determine the value of a named property name for a DOMStringMap,
+        // > return the value component of the name-value pair whose name component is
+        // > name in the list returned from getting the DOMStringMap's name-value pairs.
+        self.as_element()
+            .attrs()
+            .iter()
+            .find(|attr| to_camel_case(attr.local_name()).as_ref() == Some(&name))
+            .map(|attr| DOMString::from(&**attr.value()))
     }
 
     /// <https://html.spec.whatwg.org/multipage/#the-domstringmap-interface:supported-property-names>
     fn SupportedPropertyNames(&self) -> Vec<DOMString> {
-        self.element.supported_prop_names_custom_attr().to_vec()
+        // > The supported property names on a DOMStringMap object at any instant are
+        // > the names of each pair returned from getting the DOMStringMap's name-value
+        // > pairs at that instant, in the order returned.
+        self.as_element()
+            .attrs()
+            .iter()
+            .filter_map(|attr| to_camel_case(attr.local_name()))
+            .collect()
     }
 }

--- a/components/script/dom/domstringmap.rs
+++ b/components/script/dom/domstringmap.rs
@@ -34,9 +34,7 @@ fn to_camel_case(name: &str) -> Option<DOMString> {
     // are listed in the element's attribute list,
     // add a name-value pair to list whose name is the attribute's name with the first
     // five characters removed and whose value is the attribute's value.
-    let Some(name) = name.strip_prefix(DATA_PREFIX) else {
-        return None;
-    };
+    let name = name.strip_prefix(DATA_PREFIX)?;
     let has_uppercase = name.chars().any(|curr_char| curr_char.is_ascii_uppercase());
     if has_uppercase {
         return None;

--- a/components/script/dom/element.rs
+++ b/components/script/dom/element.rs
@@ -102,7 +102,6 @@ use crate::dom::bindings::refcounted::{Trusted, TrustedPromise};
 use crate::dom::bindings::reflector::DomObject;
 use crate::dom::bindings::root::{Dom, DomRoot, LayoutDom, MutNullableDom, ToLayout};
 use crate::dom::bindings::str::{DOMString, USVString};
-use crate::dom::bindings::xmlname::matches_name_production;
 use crate::dom::characterdata::CharacterData;
 use crate::dom::create::create_element;
 use crate::dom::csp::{CspReporting, InlineCheckType, SourcePosition};
@@ -2133,31 +2132,24 @@ impl Element {
         );
     }
 
-    // https://html.spec.whatwg.org/multipage/#attr-data-*
-    pub(crate) fn set_custom_attribute(
+    pub(crate) fn set_attribute_with_namespace(
         &self,
-        name: DOMString,
-        value: DOMString,
-        can_gc: CanGc,
-    ) -> ErrorResult {
-        // Step 1.
-        if !matches_name_production(&name.str()) {
-            return Err(Error::InvalidCharacter(None));
-        }
-
-        // Steps 2-5.
-        let name = LocalName::from(name);
-        let value = self.parse_attribute(&ns!(), &name, value);
+        cx: &mut js::context::JSContext,
+        local_name: LocalName,
+        value: AttrValue,
+        name: LocalName,
+        namespace: Namespace,
+        prefix: Option<Prefix>,
+    ) {
         self.set_first_matching_attribute(
-            name.clone(),
+            local_name.clone(),
             value,
-            name.clone(),
-            ns!(),
-            None,
-            |attr| *attr.name() == name && *attr.namespace() == ns!(),
-            can_gc,
+            name,
+            namespace.clone(),
+            prefix,
+            |attr| *attr.local_name() == local_name && *attr.namespace() == namespace,
+            CanGc::from_cx(cx),
         );
-        Ok(())
     }
 
     /// <https://dom.spec.whatwg.org/#concept-element-attributes-set-value>
@@ -3223,14 +3215,13 @@ impl ElementMethods<crate::DomTypeHolder> for Element {
         )?;
         // Step 3. Set an attribute value for this using localName, verifiedValue, and also prefix and namespace.
         let value = self.parse_attribute(&namespace, &local_name, value);
-        self.set_first_matching_attribute(
-            local_name.clone(),
+        self.set_attribute_with_namespace(
+            cx,
+            local_name,
             value,
             LocalName::from(qualified_name),
-            namespace.clone(),
+            namespace,
             prefix,
-            |attr| *attr.local_name() == local_name && *attr.namespace() == namespace,
-            CanGc::from_cx(cx),
         );
         Ok(())
     }

--- a/components/script/dom/html/htmlelement.rs
+++ b/components/script/dom/html/htmlelement.rs
@@ -765,98 +765,7 @@ fn append_text_node_to_fragment(
         .unwrap();
 }
 
-// https://html.spec.whatwg.org/multipage/#attr-data-*
-
-static DATA_PREFIX: &str = "data-";
-static DATA_HYPHEN_SEPARATOR: char = '\x2d';
-
-fn to_snake_case(name: DOMString) -> DOMString {
-    let mut attr_name = String::with_capacity(name.len() + DATA_PREFIX.len());
-    attr_name.push_str(DATA_PREFIX);
-    for ch in name.str().chars() {
-        if ch.is_ascii_uppercase() {
-            attr_name.push(DATA_HYPHEN_SEPARATOR);
-            attr_name.push(ch.to_ascii_lowercase());
-        } else {
-            attr_name.push(ch);
-        }
-    }
-    DOMString::from(attr_name)
-}
-
-// https://html.spec.whatwg.org/multipage/#attr-data-*
-// if this attribute is in snake case with a data- prefix,
-// this function returns a name converted to camel case
-// without the data prefix.
-
-fn to_camel_case(name: &str) -> Option<DOMString> {
-    if !name.starts_with(DATA_PREFIX) {
-        return None;
-    }
-    let name = &name[5..];
-    let has_uppercase = name.chars().any(|curr_char| curr_char.is_ascii_uppercase());
-    if has_uppercase {
-        return None;
-    }
-    let mut result = String::with_capacity(name.len().saturating_sub(DATA_PREFIX.len()));
-    let mut name_chars = name.chars();
-    while let Some(curr_char) = name_chars.next() {
-        // check for hyphen followed by character
-        if curr_char == DATA_HYPHEN_SEPARATOR {
-            if let Some(next_char) = name_chars.next() {
-                if next_char.is_ascii_lowercase() {
-                    result.push(next_char.to_ascii_uppercase());
-                } else {
-                    result.push(curr_char);
-                    result.push(next_char);
-                }
-            } else {
-                result.push(curr_char);
-            }
-        } else {
-            result.push(curr_char);
-        }
-    }
-    Some(DOMString::from(result))
-}
-
 impl HTMLElement {
-    pub(crate) fn set_custom_attr(
-        &self,
-        name: DOMString,
-        value: DOMString,
-        can_gc: CanGc,
-    ) -> ErrorResult {
-        if name
-            .str()
-            .chars()
-            .skip_while(|&ch| ch != '\u{2d}')
-            .nth(1)
-            .is_some_and(|ch| ch.is_ascii_lowercase())
-        {
-            return Err(Error::Syntax(None));
-        }
-        self.as_element()
-            .set_custom_attribute(to_snake_case(name), value, can_gc)
-    }
-
-    pub(crate) fn get_custom_attr(&self, local_name: DOMString) -> Option<DOMString> {
-        // FIXME(ajeffrey): Convert directly from DOMString to LocalName
-        let local_name = LocalName::from(to_snake_case(local_name));
-        self.as_element()
-            .get_attribute(&ns!(), &local_name)
-            .map(|attr| {
-                DOMString::from(&**attr.value()) // FIXME(ajeffrey): Convert directly from AttrValue to DOMString
-            })
-    }
-
-    pub(crate) fn delete_custom_attr(&self, local_name: DOMString, can_gc: CanGc) {
-        // FIXME(ajeffrey): Convert directly from DOMString to LocalName
-        let local_name = LocalName::from(to_snake_case(local_name));
-        self.as_element()
-            .remove_attribute(&ns!(), &local_name, can_gc);
-    }
-
     /// <https://html.spec.whatwg.org/multipage/#category-label>
     pub(crate) fn is_labelable_element(&self) -> bool {
         match self.upcast::<Node>().type_id() {
@@ -927,18 +836,6 @@ impl HTMLElement {
             },
             _ => false,
         }
-    }
-
-    pub(crate) fn supported_prop_names_custom_attr(&self) -> Vec<DOMString> {
-        let element = self.as_element();
-        element
-            .attrs()
-            .iter()
-            .filter_map(|attr| {
-                let raw_name = attr.local_name();
-                to_camel_case(raw_name)
-            })
-            .collect()
     }
 
     // https://html.spec.whatwg.org/multipage/#dom-lfe-labels

--- a/components/script_bindings/codegen/Bindings.conf
+++ b/components/script_bindings/codegen/Bindings.conf
@@ -247,7 +247,7 @@ DOMInterfaces = {
 },
 
 'DOMStringMap': {
-    'canGc': ['NamedDeleter', 'NamedSetter']
+    'cx': ['NamedDeleter', 'NamedSetter']
 },
 
 "DOMTokenList": {

--- a/components/script_bindings/webidls/DOMStringMap.webidl
+++ b/components/script_bindings/webidls/DOMStringMap.webidl
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-// https://html.spec.whatwg.org/multipage/#the-domstringmap-interface
+// https://html.spec.whatwg.org/multipage/#domstringmap
 [Exposed=Window, LegacyOverrideBuiltIns]
 interface DOMStringMap {
   getter DOMString (DOMString name);


### PR DESCRIPTION
The conversion of strings was wrong for `--foo` where it should become `-Foo`. Instead, it was consuming both the `--` and then would encounter a `f`.

This moves the relevant algorithms to DOMStringMap and adds corresponding spec comments to explain what's going on.

This does make us closer to passing
`html/dom/elements/global-attributes/dataset-delete.html` but unfortunately it still fails because of #12978

Prior to this fix, the value of `d.dataset['-foo']` wasn't undefined. However, we now fail the assertion where the attribute should remain, despite the call to delete.

That's because per `LegacyOverrideBuiltIns` we should be checking the existence of which properties it can delete, before it actually deletes the attribute. Right now, we do it regardless if it is a valid property and thus we incorrectly delete the attribute.

Testing: No change in tests, since the test in question has more assertions that require more fixes
