### PR TITLE
OHOS CI: Fix cache version

### DIFF
--- a/.github/workflows/ohos.yml
+++ b/.github/workflows/ohos.yml
@@ -393,7 +393,7 @@ jobs:
             etc/ci/scenario
       - name: Get mitmproxy cache
         id: mitmproxy-cache
-        uses: actions/cache@v6
+        uses: actions/cache@v5
         with:
           path: /tmp/mitmproxy-dump
           key: ${{ env.MITMDUMP_CACHE_KEY }}


### PR DESCRIPTION
Mistakenly I set the cache version to the wrong version. This fixes this mistake.
