### PR TITLE
layout: Make `::placeholder` public and add property restriction for `::placeholder` and `::marker`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7230,7 +7230,7 @@ dependencies = [
 [[package]]
 name = "selectors"
 version = "0.36.0"
-source = "git+https://github.com/servo/stylo?rev=1d2177035f79863fa42fd09cd18122b3b2322c28#1d2177035f79863fa42fd09cd18122b3b2322c28"
+source = "git+https://github.com/servo/stylo?rev=07364a6c67c08276a9ed0a9bba031ea99f808502#07364a6c67c08276a9ed0a9bba031ea99f808502"
 dependencies = [
  "bitflags 2.11.0",
  "cssparser",
@@ -8799,7 +8799,7 @@ dependencies = [
 [[package]]
 name = "servo_arc"
 version = "0.4.3"
-source = "git+https://github.com/servo/stylo?rev=1d2177035f79863fa42fd09cd18122b3b2322c28#1d2177035f79863fa42fd09cd18122b3b2322c28"
+source = "git+https://github.com/servo/stylo?rev=07364a6c67c08276a9ed0a9bba031ea99f808502#07364a6c67c08276a9ed0a9bba031ea99f808502"
 dependencies = [
  "serde",
  "stable_deref_trait",
@@ -9219,7 +9219,7 @@ dependencies = [
 [[package]]
 name = "stylo"
 version = "0.13.0"
-source = "git+https://github.com/servo/stylo?rev=1d2177035f79863fa42fd09cd18122b3b2322c28#1d2177035f79863fa42fd09cd18122b3b2322c28"
+source = "git+https://github.com/servo/stylo?rev=07364a6c67c08276a9ed0a9bba031ea99f808502#07364a6c67c08276a9ed0a9bba031ea99f808502"
 dependencies = [
  "app_units",
  "arrayvec",
@@ -9275,7 +9275,7 @@ dependencies = [
 [[package]]
 name = "stylo_atoms"
 version = "0.13.0"
-source = "git+https://github.com/servo/stylo?rev=1d2177035f79863fa42fd09cd18122b3b2322c28#1d2177035f79863fa42fd09cd18122b3b2322c28"
+source = "git+https://github.com/servo/stylo?rev=07364a6c67c08276a9ed0a9bba031ea99f808502#07364a6c67c08276a9ed0a9bba031ea99f808502"
 dependencies = [
  "string_cache",
  "string_cache_codegen",
@@ -9284,7 +9284,7 @@ dependencies = [
 [[package]]
 name = "stylo_derive"
 version = "0.13.0"
-source = "git+https://github.com/servo/stylo?rev=1d2177035f79863fa42fd09cd18122b3b2322c28#1d2177035f79863fa42fd09cd18122b3b2322c28"
+source = "git+https://github.com/servo/stylo?rev=07364a6c67c08276a9ed0a9bba031ea99f808502#07364a6c67c08276a9ed0a9bba031ea99f808502"
 dependencies = [
  "darling",
  "proc-macro2",
@@ -9296,7 +9296,7 @@ dependencies = [
 [[package]]
 name = "stylo_dom"
 version = "0.13.0"
-source = "git+https://github.com/servo/stylo?rev=1d2177035f79863fa42fd09cd18122b3b2322c28#1d2177035f79863fa42fd09cd18122b3b2322c28"
+source = "git+https://github.com/servo/stylo?rev=07364a6c67c08276a9ed0a9bba031ea99f808502#07364a6c67c08276a9ed0a9bba031ea99f808502"
 dependencies = [
  "bitflags 2.11.0",
  "stylo_malloc_size_of",
@@ -9305,7 +9305,7 @@ dependencies = [
 [[package]]
 name = "stylo_malloc_size_of"
 version = "0.13.0"
-source = "git+https://github.com/servo/stylo?rev=1d2177035f79863fa42fd09cd18122b3b2322c28#1d2177035f79863fa42fd09cd18122b3b2322c28"
+source = "git+https://github.com/servo/stylo?rev=07364a6c67c08276a9ed0a9bba031ea99f808502#07364a6c67c08276a9ed0a9bba031ea99f808502"
 dependencies = [
  "app_units",
  "cssparser",
@@ -9322,12 +9322,12 @@ dependencies = [
 [[package]]
 name = "stylo_static_prefs"
 version = "0.13.0"
-source = "git+https://github.com/servo/stylo?rev=1d2177035f79863fa42fd09cd18122b3b2322c28#1d2177035f79863fa42fd09cd18122b3b2322c28"
+source = "git+https://github.com/servo/stylo?rev=07364a6c67c08276a9ed0a9bba031ea99f808502#07364a6c67c08276a9ed0a9bba031ea99f808502"
 
 [[package]]
 name = "stylo_traits"
 version = "0.13.0"
-source = "git+https://github.com/servo/stylo?rev=1d2177035f79863fa42fd09cd18122b3b2322c28#1d2177035f79863fa42fd09cd18122b3b2322c28"
+source = "git+https://github.com/servo/stylo?rev=07364a6c67c08276a9ed0a9bba031ea99f808502#07364a6c67c08276a9ed0a9bba031ea99f808502"
 dependencies = [
  "app_units",
  "bitflags 2.11.0",
@@ -9749,7 +9749,7 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 [[package]]
 name = "to_shmem"
 version = "0.3.0"
-source = "git+https://github.com/servo/stylo?rev=1d2177035f79863fa42fd09cd18122b3b2322c28#1d2177035f79863fa42fd09cd18122b3b2322c28"
+source = "git+https://github.com/servo/stylo?rev=07364a6c67c08276a9ed0a9bba031ea99f808502#07364a6c67c08276a9ed0a9bba031ea99f808502"
 dependencies = [
  "cssparser",
  "servo_arc",
@@ -9762,7 +9762,7 @@ dependencies = [
 [[package]]
 name = "to_shmem_derive"
 version = "0.1.0"
-source = "git+https://github.com/servo/stylo?rev=1d2177035f79863fa42fd09cd18122b3b2322c28#1d2177035f79863fa42fd09cd18122b3b2322c28"
+source = "git+https://github.com/servo/stylo?rev=07364a6c67c08276a9ed0a9bba031ea99f808502#07364a6c67c08276a9ed0a9bba031ea99f808502"
 dependencies = [
  "darling",
  "proc-macro2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -172,7 +172,7 @@ script_traits = { package = "servo-script-traits", path = "components/shared/scr
 sea-query = { version = "1.0.0-rc.31", default-features = false, features = ["backend-sqlite", "derive"] }
 sea-query-rusqlite = { version = "0.8.0-rc.15" }
 sec1 = "0.7"
-selectors = { git = "https://github.com/servo/stylo", rev = "1d2177035f79863fa42fd09cd18122b3b2322c28" }
+selectors = { git = "https://github.com/servo/stylo", rev = "07364a6c67c08276a9ed0a9bba031ea99f808502" }
 serde = "1.0.228"
 serde_bytes = "0.11"
 serde_core = "1.0.226"
@@ -181,7 +181,7 @@ servo-media = { path = "components/media/servo-media" }
 servo-media-dummy = { path = "components/media/backends/dummy" }
 servo-media-gstreamer = { path = "components/media/backends/gstreamer" }
 servo-tracing = { path = "components/servo_tracing" }
-servo_arc = { git = "https://github.com/servo/stylo", rev = "1d2177035f79863fa42fd09cd18122b3b2322c28" }
+servo_arc = { git = "https://github.com/servo/stylo", rev = "07364a6c67c08276a9ed0a9bba031ea99f808502" }
 sha1 = "0.10"
 sha2 = "0.10"
 sha3 = "0.10"
@@ -190,12 +190,12 @@ smallvec = { version = "1.15", features = ["serde", "union"] }
 storage_traits = { package = "servo-storage-traits", path = "components/shared/storage" }
 string_cache = "0.9"
 strum = { version = "0.28", features = ["derive"] }
-stylo = { git = "https://github.com/servo/stylo", rev = "1d2177035f79863fa42fd09cd18122b3b2322c28" }
-stylo_atoms = { git = "https://github.com/servo/stylo", rev = "1d2177035f79863fa42fd09cd18122b3b2322c28" }
-stylo_dom = { git = "https://github.com/servo/stylo", rev = "1d2177035f79863fa42fd09cd18122b3b2322c28" }
-stylo_malloc_size_of = { git = "https://github.com/servo/stylo", rev = "1d2177035f79863fa42fd09cd18122b3b2322c28" }
-stylo_static_prefs = { git = "https://github.com/servo/stylo", rev = "1d2177035f79863fa42fd09cd18122b3b2322c28" }
-stylo_traits = { git = "https://github.com/servo/stylo", rev = "1d2177035f79863fa42fd09cd18122b3b2322c28" }
+stylo = { git = "https://github.com/servo/stylo", rev = "07364a6c67c08276a9ed0a9bba031ea99f808502" }
+stylo_atoms = { git = "https://github.com/servo/stylo", rev = "07364a6c67c08276a9ed0a9bba031ea99f808502" }
+stylo_dom = { git = "https://github.com/servo/stylo", rev = "07364a6c67c08276a9ed0a9bba031ea99f808502" }
+stylo_malloc_size_of = { git = "https://github.com/servo/stylo", rev = "07364a6c67c08276a9ed0a9bba031ea99f808502" }
+stylo_static_prefs = { git = "https://github.com/servo/stylo", rev = "07364a6c67c08276a9ed0a9bba031ea99f808502" }
+stylo_traits = { git = "https://github.com/servo/stylo", rev = "07364a6c67c08276a9ed0a9bba031ea99f808502" }
 surfman = { version = "0.11.0", features = ["chains"] }
 syn = { version = "2", default-features = false, features = ["clone-impls", "derive", "parsing"] }
 synstructure = "0.13"

--- a/components/script/dom/window.rs
+++ b/components/script/dom/window.rs
@@ -1841,6 +1841,9 @@ impl WindowMethods<crate::DomTypeHolder> for Window {
 
         // Step 3: If pseudoElt is provided, is not the empty string, and starts with a colon, then:
         // Step 3.1: Parse pseudoElt as a <pseudo-element-selector>, and let type be the result.
+        // TODO(#43095): This is quite hacky and it would be better to have a parsing function that
+        // is integrated with stylo `PseudoElement` itself. Comparing with stylo, we are now currently
+        // missing `::backdrop`, `::color-swatch`, and `::details-content`.
         let pseudo = pseudo.map(|mut s| {
             s.make_ascii_lowercase();
             s
@@ -1854,6 +1857,7 @@ impl WindowMethods<crate::DomTypeHolder> for Window {
             },
             Some(ref pseudo) if pseudo == "::selection" => Some(PseudoElement::Selection),
             Some(ref pseudo) if pseudo == "::marker" => Some(PseudoElement::Marker),
+            Some(ref pseudo) if pseudo == "::placeholder" => Some(PseudoElement::Placeholder),
             Some(ref pseudo) if pseudo.starts_with(':') => {
                 // Step 3.2: If type is failure, or is a ::slotted() or ::part()
                 // pseudo-element, let obj be null.

--- a/tests/wpt/meta/css/css-conditional/at-supports-selector-placeholder.html.ini
+++ b/tests/wpt/meta/css/css-conditional/at-supports-selector-placeholder.html.ini
@@ -1,2 +1,0 @@
-[at-supports-selector-placeholder.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-pseudo/parsing/marker-supported-properties-in-animation.html.ini
+++ b/tests/wpt/meta/css/css-pseudo/parsing/marker-supported-properties-in-animation.html.ini
@@ -209,23 +209,11 @@
   [Transition of text-shadow in ::marker]
     expected: FAIL
 
-  [Transition of display in ::marker]
-    expected: FAIL
-
-  [Transition of position in ::marker]
-    expected: FAIL
-
-  [Transition of float in ::marker]
-    expected: FAIL
-
   [Transition of list-style in ::marker]
     expected: FAIL
 
-  [Transition of list-style-image in ::marker]
+  [Transition of line-break in ::marker]
     expected: FAIL
 
-  [Transition of list-style-position in ::marker]
-    expected: FAIL
-
-  [Transition of list-style-type in ::marker]
+  [Transition of overflow-wrap in ::marker]
     expected: FAIL

--- a/tests/wpt/meta/css/css-pseudo/parsing/marker-supported-properties.html.ini
+++ b/tests/wpt/meta/css/css-pseudo/parsing/marker-supported-properties.html.ini
@@ -59,25 +59,7 @@
   [Property text-emphasis-style value 'dot' in ::marker]
     expected: FAIL
 
-  [Property display value 'none' in ::marker]
-    expected: FAIL
-
-  [Property position value 'absolute' in ::marker]
-    expected: FAIL
-
-  [Property float value 'right' in ::marker]
-    expected: FAIL
-
   [Property list-style value 'inside url('foo') decimal' in ::marker]
-    expected: FAIL
-
-  [Property list-style-image value 'url('foo')' in ::marker]
-    expected: FAIL
-
-  [Property list-style-position value 'inside' in ::marker]
-    expected: FAIL
-
-  [Property list-style-type value 'decimal' in ::marker]
     expected: FAIL
 
   [Property animation-range value 'contain 10px cover 20px' in ::marker]
@@ -90,4 +72,16 @@
     expected: FAIL
 
   [Property animation-timeline value 'scroll()' in ::marker]
+    expected: FAIL
+
+  [Property letter-spacing value '10px' in ::marker]
+    expected: FAIL
+
+  [Property line-break value 'anywhere' in ::marker]
+    expected: FAIL
+
+  [Property overflow-wrap value 'anywhere' in ::marker]
+    expected: FAIL
+
+  [Property word-spacing value '10px' in ::marker]
     expected: FAIL

--- a/tests/wpt/meta/css/css-pseudo/parsing/tree-abiding-pseudo-elements.html.ini
+++ b/tests/wpt/meta/css/css-pseudo/parsing/tree-abiding-pseudo-elements.html.ini
@@ -1,13 +1,4 @@
 [tree-abiding-pseudo-elements.html]
-  ["::placeholder" should be a valid selector]
-    expected: FAIL
-
-  ["*::placeholder" should be a valid selector]
-    expected: FAIL
-
-  ["foo.bar[baz\]::placeholder" should be a valid selector]
-    expected: FAIL
-
   ["::file-selector-button" should be a valid selector]
     expected: FAIL
 

--- a/tests/wpt/meta/css/css-pseudo/placeholder-inherit.html.ini
+++ b/tests/wpt/meta/css/css-pseudo/placeholder-inherit.html.ini
@@ -1,3 +1,0 @@
-[placeholder-inherit.html]
-  [::placeholder should inherit from its originating element]
-    expected: FAIL

--- a/tests/wpt/meta/css/css-pseudo/placeholder-input-number.html.ini
+++ b/tests/wpt/meta/css/css-pseudo/placeholder-input-number.html.ini
@@ -1,2 +1,0 @@
-[placeholder-input-number.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-shadow/part/interaction-with-pseudo-elements.html.ini
+++ b/tests/wpt/meta/css/css-shadow/part/interaction-with-pseudo-elements.html.ini
@@ -1,7 +1,4 @@
 [interaction-with-pseudo-elements.html]
-  [::placeholder in selected host is styled]
-    expected: FAIL
-
   [::first-line in selected host is styled]
     expected: FAIL
 

--- a/tests/wpt/meta/css/css-shadow/part/pseudo-elements-after-part.html.ini
+++ b/tests/wpt/meta/css/css-shadow/part/pseudo-elements-after-part.html.ini
@@ -17,9 +17,6 @@
   ["::part(mypart)::highlight(myhighlight)" should be a valid selector]
     expected: FAIL
 
-  ["::part(mypart)::placeholder" should be a valid selector]
-    expected: FAIL
-
   ["::part(mypart)::search-text" should be a valid selector]
     expected: FAIL
 
@@ -69,9 +66,6 @@
     expected: FAIL
 
   [computed style for ::part()::highlight(myhighlight)]
-    expected: FAIL
-
-  [computed style for ::part()::placeholder]
     expected: FAIL
 
   [computed style for ::part()::search-text]

--- a/tests/wpt/meta/css/css-shadow/slotted-placeholder.html.ini
+++ b/tests/wpt/meta/css/css-shadow/slotted-placeholder.html.ini
@@ -1,0 +1,2 @@
+[slotted-placeholder.html]
+  expected: FAIL

--- a/tests/wpt/meta/css/cssom/getComputedStyle-pseudo.html.ini
+++ b/tests/wpt/meta/css/cssom/getComputedStyle-pseudo.html.ini
@@ -26,9 +26,6 @@
   [Unknown pseudo-element with a known identifier: highlight(name)]
     expected: PRECONDITION_FAILED
 
-  [Unknown pseudo-element with a known identifier: placeholder]
-    expected: PRECONDITION_FAILED
-
   [Unknown pseudo-element with a known identifier: spelling-error]
     expected: PRECONDITION_FAILED
 

--- a/tests/wpt/meta/css/selectors/parsing/parse-part.html.ini
+++ b/tests/wpt/meta/css/selectors/parsing/parse-part.html.ini
@@ -1,7 +1,4 @@
 [parse-part.html]
-  ["::part(foo)::placeholder" should be a valid selector]
-    expected: FAIL
-
   ["::part(foo)::first-line" should be a valid selector]
     expected: FAIL
 

--- a/tests/wpt/meta/html/rendering/non-replaced-elements/form-controls/placeholder-opacity-default.tentative.html.ini
+++ b/tests/wpt/meta/html/rendering/non-replaced-elements/form-controls/placeholder-opacity-default.tentative.html.ini
@@ -1,3 +1,0 @@
-[placeholder-opacity-default.tentative.html]
-  [Default opacity value is '1']
-    expected: FAIL

--- a/tests/wpt/meta/html/rendering/replaced-elements/attributes-for-embedded-content-and-images/number-placeholder-right-aligned.html.ini
+++ b/tests/wpt/meta/html/rendering/replaced-elements/attributes-for-embedded-content-and-images/number-placeholder-right-aligned.html.ini
@@ -1,2 +1,0 @@
-[number-placeholder-right-aligned.html]
-  expected: FAIL

--- a/tests/wpt/meta/html/semantics/forms/the-textarea-element/multiline-placeholder-cr.html.ini
+++ b/tests/wpt/meta/html/semantics/forms/the-textarea-element/multiline-placeholder-cr.html.ini
@@ -1,0 +1,2 @@
+[multiline-placeholder-cr.html]
+  expected: FAIL

--- a/tests/wpt/meta/html/semantics/forms/the-textarea-element/multiline-placeholder-crlf.html.ini
+++ b/tests/wpt/meta/html/semantics/forms/the-textarea-element/multiline-placeholder-crlf.html.ini
@@ -1,0 +1,2 @@
+[multiline-placeholder-crlf.html]
+  expected: FAIL

--- a/tests/wpt/meta/html/semantics/forms/the-textarea-element/multiline-placeholder.html.ini
+++ b/tests/wpt/meta/html/semantics/forms/the-textarea-element/multiline-placeholder.html.ini
@@ -1,0 +1,2 @@
+[multiline-placeholder.html]
+  expected: FAIL


### PR DESCRIPTION
Servo side of https://github.com/servo/stylo/pull/322.

Update the WPT expectation following the changes to make `::placeholder` public and adding property restriction to `::placeholder` and `::marker`. Additionally ensure that `getComputedStyle` works for `::placeholder`. 

Testing: Existing WPTs
Fixes: #43034 
Fixes: #43035 
Fixes: #19808