### PR TITLE
ohos ci: Do not use action that does not exist

### DIFF
--- a/.github/workflows/ohos.yml
+++ b/.github/workflows/ohos.yml
@@ -393,7 +393,7 @@ jobs:
             etc/ci/scenario
       - name: Get mitmproxy cache
         id: mitmproxy-cache
-        uses: actions/cache@v6
+        uses: actions/cache@v5
         with:
           path: /tmp/mitmproxy-dump
           key: ${{ env.MITMDUMP_CACHE_KEY }}


### PR DESCRIPTION
Testing: https://github.com/servo/servo/actions/runs/22749912784
Fixes: The consistent CI failure after #42990