### PR TITLE
script: Use `CryptoAlgorithm` in name fields of subtle dictionaries

### DIFF
--- a/components/script/dom/subtlecrypto.rs
+++ b/components/script/dom/subtlecrypto.rs
@@ -72,44 +72,6 @@ use crate::dom::globalscope::GlobalScope;
 use crate::dom::promise::Promise;
 use crate::script_runtime::{CanGc, JSContext};
 
-// Regconized algorithm name from <https://w3c.github.io/webcrypto/>
-const ALG_RSASSA_PKCS1_V1_5: &str = "RSASSA-PKCS1-v1_5";
-const ALG_RSA_PSS: &str = "RSA-PSS";
-const ALG_RSA_OAEP: &str = "RSA-OAEP";
-const ALG_ECDSA: &str = "ECDSA";
-const ALG_ECDH: &str = "ECDH";
-const ALG_ED25519: &str = "Ed25519";
-const ALG_X25519: &str = "X25519";
-const ALG_AES_CTR: &str = "AES-CTR";
-const ALG_AES_CBC: &str = "AES-CBC";
-const ALG_AES_GCM: &str = "AES-GCM";
-const ALG_AES_KW: &str = "AES-KW";
-const ALG_HMAC: &str = "HMAC";
-const ALG_SHA1: &str = "SHA-1";
-const ALG_SHA256: &str = "SHA-256";
-const ALG_SHA384: &str = "SHA-384";
-const ALG_SHA512: &str = "SHA-512";
-const ALG_HKDF: &str = "HKDF";
-const ALG_PBKDF2: &str = "PBKDF2";
-
-// Regconized algorithm name from <https://wicg.github.io/webcrypto-modern-algos/>
-const ALG_ML_KEM_512: &str = "ML-KEM-512";
-const ALG_ML_KEM_768: &str = "ML-KEM-768";
-const ALG_ML_KEM_1024: &str = "ML-KEM-1024";
-const ALG_ML_DSA_44: &str = "ML-DSA-44";
-const ALG_ML_DSA_65: &str = "ML-DSA-65";
-const ALG_ML_DSA_87: &str = "ML-DSA-87";
-const ALG_AES_OCB: &str = "AES-OCB";
-const ALG_CHACHA20_POLY1305: &str = "ChaCha20-Poly1305";
-const ALG_SHA3_256: &str = "SHA3-256";
-const ALG_SHA3_384: &str = "SHA3-384";
-const ALG_SHA3_512: &str = "SHA3-512";
-const ALG_CSHAKE_128: &str = "cSHAKE128";
-const ALG_CSHAKE_256: &str = "cSHAKE256";
-const ALG_ARGON2D: &str = "Argon2d";
-const ALG_ARGON2I: &str = "Argon2i";
-const ALG_ARGON2ID: &str = "Argon2id";
-
 // Named elliptic curves
 const NAMED_CURVE_P256: &str = "P-256";
 const NAMED_CURVE_P384: &str = "P-384";
@@ -117,7 +79,7 @@ const NAMED_CURVE_P521: &str = "P-521";
 
 static SUPPORTED_CURVES: &[&str] = &[NAMED_CURVE_P256, NAMED_CURVE_P384, NAMED_CURVE_P521];
 
-#[derive(EnumString, VariantArray, IntoStaticStr, Clone, Copy)]
+#[derive(EnumString, VariantArray, IntoStaticStr, PartialEq, Clone, Copy, MallocSizeOf)]
 enum CryptoAlgorithm {
     #[strum(serialize = "RSASSA-PKCS1-v1_5")]
     RsassaPkcs1V1_5,
@@ -203,6 +165,10 @@ impl CryptoAlgorithm {
             .ok_or(Error::NotSupported(Some(format!(
                 "Unsupported algorithm: {algorithm_name}"
             ))))
+    }
+
+    fn from_domstring(name: &DOMString) -> Fallible<Self> {
+        CryptoAlgorithm::try_from(&*name.str()).map_err(|_| Error::NotSupported(None))
     }
 }
 
@@ -1322,7 +1288,7 @@ impl SubtleCryptoMethods<crate::DomTypeHolder> for SubtleCrypto {
                 // the export key operation.
                 let export_key_algorithm = match normalize_algorithm::<ExportKeyOperation>(
                     cx,
-                    &AlgorithmIdentifier::String(DOMString::from(key.algorithm().name())),
+                    &AlgorithmIdentifier::String(DOMString::from(key.algorithm().name().as_str())),
                 ) {
                     Ok(normalized_algorithm) => normalized_algorithm,
                     Err(error) => {
@@ -1461,7 +1427,7 @@ impl SubtleCryptoMethods<crate::DomTypeHolder> for SubtleCrypto {
                 // the export key operation.
                 let export_key_algorithm = match normalize_algorithm::<ExportKeyOperation>(
                     cx,
-                    &AlgorithmIdentifier::String(DOMString::from(key.algorithm().name())),
+                    &AlgorithmIdentifier::String(DOMString::from(key.algorithm().name().as_str())),
                 ) {
                     Ok(normalized_algorithm) => normalized_algorithm,
                     Err(error) => {
@@ -2238,10 +2204,10 @@ where
 // so they can be sent safely when running steps in parallel.
 
 /// <https://w3c.github.io/webcrypto/#dfn-Algorithm>
-#[derive(Clone, Debug, MallocSizeOf)]
+#[derive(Clone, MallocSizeOf)]
 struct SubtleAlgorithm {
     /// <https://w3c.github.io/webcrypto/#dom-algorithm-name>
-    name: String,
+    name: CryptoAlgorithm,
 }
 
 impl<'a> TryFromWithCx<HandleValue<'a>> for SubtleAlgorithm {
@@ -2254,22 +2220,22 @@ impl<'a> TryFromWithCx<HandleValue<'a>> for SubtleAlgorithm {
         let dictionary = dictionary_from_jsval::<Algorithm>(cx, value)?;
 
         Ok(SubtleAlgorithm {
-            name: dictionary.name.to_string(),
+            name: CryptoAlgorithm::from_domstring(&dictionary.name)?,
         })
     }
 }
 
 /// <https://w3c.github.io/webcrypto/#dfn-KeyAlgorithm>
-#[derive(Clone, Debug, MallocSizeOf)]
+#[derive(Clone, MallocSizeOf)]
 pub(crate) struct SubtleKeyAlgorithm {
     /// <https://w3c.github.io/webcrypto/#dom-keyalgorithm-name>
-    name: String,
+    name: CryptoAlgorithm,
 }
 
 impl SafeToJSValConvertible for SubtleKeyAlgorithm {
     fn safe_to_jsval(&self, cx: JSContext, rval: MutableHandleValue, can_gc: CanGc) {
         let dictionary = KeyAlgorithm {
-            name: self.name.clone().into(),
+            name: self.name.as_str().into(),
         };
         dictionary.safe_to_jsval(cx, rval, can_gc);
     }
@@ -2279,7 +2245,7 @@ impl SafeToJSValConvertible for SubtleKeyAlgorithm {
 #[derive(Clone, MallocSizeOf)]
 pub(crate) struct SubtleRsaHashedKeyGenParams {
     /// <https://w3c.github.io/webcrypto/#dom-algorithm-name>
-    name: String,
+    name: CryptoAlgorithm,
 
     /// <https://w3c.github.io/webcrypto/#dfn-RsaKeyGenParams-modulusLength>
     modulus_length: u32,
@@ -2302,7 +2268,7 @@ impl<'a> TryFromWithCx<HandleValue<'a>> for SubtleRsaHashedKeyGenParams {
             dictionary_from_jsval::<RootedTraceableBox<RsaHashedKeyGenParams>>(cx, value)?;
 
         Ok(SubtleRsaHashedKeyGenParams {
-            name: dictionary.parent.parent.name.to_string(),
+            name: CryptoAlgorithm::from_domstring(&dictionary.parent.parent.name)?,
             modulus_length: dictionary.parent.modulusLength,
             public_exponent: dictionary.parent.publicExponent.to_vec(),
             hash: normalize_algorithm::<DigestOperation>(cx, &dictionary.hash)?,
@@ -2314,7 +2280,7 @@ impl<'a> TryFromWithCx<HandleValue<'a>> for SubtleRsaHashedKeyGenParams {
 #[derive(Clone, MallocSizeOf)]
 pub(crate) struct SubtleRsaHashedKeyAlgorithm {
     /// <https://w3c.github.io/webcrypto/#dom-keyalgorithm-name>
-    name: String,
+    name: CryptoAlgorithm,
 
     /// <https://w3c.github.io/webcrypto/#dfn-RsaKeyAlgorithm-modulusLength>
     modulus_length: u32,
@@ -2333,7 +2299,7 @@ impl SafeToJSValConvertible for SubtleRsaHashedKeyAlgorithm {
             create_buffer_source(cx, &self.public_exponent, js_object.handle_mut(), can_gc)
                 .expect("Fail to convert publicExponent to Uint8Array");
         let key_algorithm = KeyAlgorithm {
-            name: self.name.clone().into(),
+            name: self.name.as_str().into(),
         };
         let rsa_key_algorithm = RootedTraceableBox::new(RsaKeyAlgorithm {
             parent: key_algorithm,
@@ -2343,7 +2309,7 @@ impl SafeToJSValConvertible for SubtleRsaHashedKeyAlgorithm {
         let rsa_hashed_key_algorithm = RootedTraceableBox::new(RsaHashedKeyAlgorithm {
             parent: rsa_key_algorithm,
             hash: KeyAlgorithm {
-                name: self.hash.name().into(),
+                name: self.hash.name().as_str().into(),
             },
         });
         rsa_hashed_key_algorithm.safe_to_jsval(cx, rval, can_gc);
@@ -2354,7 +2320,7 @@ impl SafeToJSValConvertible for SubtleRsaHashedKeyAlgorithm {
 #[derive(Clone, MallocSizeOf)]
 struct SubtleRsaHashedImportParams {
     /// <https://w3c.github.io/webcrypto/#dom-algorithm-name>
-    name: String,
+    name: CryptoAlgorithm,
 
     /// <https://w3c.github.io/webcrypto/#dfn-RsaHashedImportParams-hash>
     hash: DigestAlgorithm,
@@ -2371,17 +2337,17 @@ impl<'a> TryFromWithCx<HandleValue<'a>> for SubtleRsaHashedImportParams {
             dictionary_from_jsval::<RootedTraceableBox<RsaHashedImportParams>>(cx, value)?;
 
         Ok(SubtleRsaHashedImportParams {
-            name: dictionary.parent.name.to_string(),
+            name: CryptoAlgorithm::from_domstring(&dictionary.parent.name)?,
             hash: normalize_algorithm::<DigestOperation>(cx, &dictionary.hash)?,
         })
     }
 }
 
 /// <https://w3c.github.io/webcrypto/#dfn-RsaPssParams>
-#[derive(Clone, Debug, MallocSizeOf)]
+#[derive(Clone, MallocSizeOf)]
 struct SubtleRsaPssParams {
     /// <https://w3c.github.io/webcrypto/#dom-algorithm-name>
-    name: String,
+    name: CryptoAlgorithm,
 
     /// <https://w3c.github.io/webcrypto/#dfn-RsaPssParams-saltLength>
     salt_length: u32,
@@ -2397,17 +2363,18 @@ impl<'a> TryFromWithCx<HandleValue<'a>> for SubtleRsaPssParams {
         let dictionary = dictionary_from_jsval::<RsaPssParams>(cx, value)?;
 
         Ok(SubtleRsaPssParams {
-            name: dictionary.parent.name.to_string(),
+            name: CryptoAlgorithm::from_domstring(&dictionary.parent.name)?,
             salt_length: dictionary.saltLength,
         })
     }
 }
 
 /// <https://w3c.github.io/webcrypto/#dfn-RsaOaepParams>
-#[derive(Clone, Debug, MallocSizeOf)]
+#[derive(Clone, MallocSizeOf)]
 struct SubtleRsaOaepParams {
     /// <https://w3c.github.io/webcrypto/#dom-algorithm-name>
-    name: String,
+    name: CryptoAlgorithm,
+
     /// <https://w3c.github.io/webcrypto/#dfn-RsaOaepParams-label>
     label: Option<Vec<u8>>,
 }
@@ -2427,7 +2394,7 @@ impl<'a> TryFromWithCx<HandleValue<'a>> for SubtleRsaOaepParams {
         });
 
         Ok(SubtleRsaOaepParams {
-            name: dictionary.parent.name.to_string(),
+            name: CryptoAlgorithm::from_domstring(&dictionary.parent.name)?,
             label,
         })
     }
@@ -2437,7 +2404,7 @@ impl<'a> TryFromWithCx<HandleValue<'a>> for SubtleRsaOaepParams {
 #[derive(Clone, MallocSizeOf)]
 struct SubtleEcdsaParams {
     /// <https://w3c.github.io/webcrypto/#dom-algorithm-name>
-    name: String,
+    name: CryptoAlgorithm,
 
     /// <https://w3c.github.io/webcrypto/#dfn-EcdsaParams-hash>
     hash: DigestAlgorithm,
@@ -2453,17 +2420,17 @@ impl<'a> TryFromWithCx<HandleValue<'a>> for SubtleEcdsaParams {
         let dictionary = dictionary_from_jsval::<RootedTraceableBox<EcdsaParams>>(cx, value)?;
 
         Ok(SubtleEcdsaParams {
-            name: dictionary.parent.name.to_string(),
+            name: CryptoAlgorithm::from_domstring(&dictionary.parent.name)?,
             hash: normalize_algorithm::<DigestOperation>(cx, &dictionary.hash)?,
         })
     }
 }
 
 /// <https://w3c.github.io/webcrypto/#dfn-EcKeyGenParams>
-#[derive(Clone, Debug, MallocSizeOf)]
+#[derive(Clone, MallocSizeOf)]
 struct SubtleEcKeyGenParams {
     /// <https://w3c.github.io/webcrypto/#dom-algorithm-name>
-    name: String,
+    name: CryptoAlgorithm,
 
     /// <https://w3c.github.io/webcrypto/#dfn-EcKeyGenParams-namedCurve>
     named_curve: String,
@@ -2479,17 +2446,17 @@ impl<'a> TryFromWithCx<HandleValue<'a>> for SubtleEcKeyGenParams {
         let dictionary = dictionary_from_jsval::<EcKeyGenParams>(cx, value)?;
 
         Ok(SubtleEcKeyGenParams {
-            name: dictionary.parent.name.to_string(),
+            name: CryptoAlgorithm::from_domstring(&dictionary.parent.name)?,
             named_curve: dictionary.namedCurve.to_string(),
         })
     }
 }
 
 /// <https://w3c.github.io/webcrypto/#dfn-EcKeyAlgorithm>
-#[derive(Clone, Debug, MallocSizeOf)]
+#[derive(Clone, MallocSizeOf)]
 pub(crate) struct SubtleEcKeyAlgorithm {
     /// <https://w3c.github.io/webcrypto/#dom-keyalgorithm-name>
-    name: String,
+    name: CryptoAlgorithm,
 
     /// <https://w3c.github.io/webcrypto/#dfn-EcKeyAlgorithm-namedCurve>
     named_curve: String,
@@ -2498,7 +2465,7 @@ pub(crate) struct SubtleEcKeyAlgorithm {
 impl SafeToJSValConvertible for SubtleEcKeyAlgorithm {
     fn safe_to_jsval(&self, cx: JSContext, rval: MutableHandleValue, can_gc: CanGc) {
         let parent = KeyAlgorithm {
-            name: self.name.clone().into(),
+            name: self.name.as_str().into(),
         };
         let dictionary = EcKeyAlgorithm {
             parent,
@@ -2509,10 +2476,10 @@ impl SafeToJSValConvertible for SubtleEcKeyAlgorithm {
 }
 
 /// <https://w3c.github.io/webcrypto/#dfn-EcKeyImportParams>
-#[derive(Clone, Debug, MallocSizeOf)]
+#[derive(Clone, MallocSizeOf)]
 struct SubtleEcKeyImportParams {
     /// <https://w3c.github.io/webcrypto/#dom-algorithm-name>
-    name: String,
+    name: CryptoAlgorithm,
 
     /// <https://w3c.github.io/webcrypto/#dfn-EcKeyImportParams-namedCurve>
     named_curve: String,
@@ -2528,7 +2495,7 @@ impl<'a> TryFromWithCx<HandleValue<'a>> for SubtleEcKeyImportParams {
         let dictionary = dictionary_from_jsval::<EcKeyImportParams>(cx, value)?;
 
         Ok(SubtleEcKeyImportParams {
-            name: dictionary.parent.name.to_string(),
+            name: CryptoAlgorithm::from_domstring(&dictionary.parent.name)?,
             named_curve: dictionary.namedCurve.to_string(),
         })
     }
@@ -2538,7 +2505,7 @@ impl<'a> TryFromWithCx<HandleValue<'a>> for SubtleEcKeyImportParams {
 #[derive(Clone, MallocSizeOf)]
 struct SubtleEcdhKeyDeriveParams {
     /// <https://w3c.github.io/webcrypto/#dom-algorithm-name>
-    name: String,
+    name: CryptoAlgorithm,
 
     /// <https://w3c.github.io/webcrypto/#dfn-EcdhKeyDeriveParams-public>
     public: Trusted<CryptoKey>,
@@ -2554,17 +2521,17 @@ impl<'a> TryFromWithCx<HandleValue<'a>> for SubtleEcdhKeyDeriveParams {
         let dictionary = dictionary_from_jsval::<EcdhKeyDeriveParams>(cx, value)?;
 
         Ok(SubtleEcdhKeyDeriveParams {
-            name: dictionary.parent.name.to_string(),
+            name: CryptoAlgorithm::from_domstring(&dictionary.parent.name)?,
             public: Trusted::new(&dictionary.public),
         })
     }
 }
 
 /// <https://w3c.github.io/webcrypto/#dfn-AesCtrParams>
-#[derive(Clone, Debug, MallocSizeOf)]
+#[derive(Clone, MallocSizeOf)]
 struct SubtleAesCtrParams {
     /// <https://w3c.github.io/webcrypto/#dom-algorithm-name>
-    name: String,
+    name: CryptoAlgorithm,
 
     /// <https://w3c.github.io/webcrypto/#dfn-AesCtrParams-counter>
     counter: Vec<u8>,
@@ -2588,7 +2555,7 @@ impl<'a> TryFromWithCx<HandleValue<'a>> for SubtleAesCtrParams {
         };
 
         Ok(SubtleAesCtrParams {
-            name: dictionary.parent.name.to_string(),
+            name: CryptoAlgorithm::from_domstring(&dictionary.parent.name)?,
             counter,
             length: dictionary.length,
         })
@@ -2596,10 +2563,10 @@ impl<'a> TryFromWithCx<HandleValue<'a>> for SubtleAesCtrParams {
 }
 
 /// <https://w3c.github.io/webcrypto/#dfn-AesKeyAlgorithm>
-#[derive(Clone, Debug, MallocSizeOf)]
+#[derive(Clone, MallocSizeOf)]
 pub(crate) struct SubtleAesKeyAlgorithm {
     /// <https://w3c.github.io/webcrypto/#dom-keyalgorithm-name>
-    name: String,
+    name: CryptoAlgorithm,
 
     /// <https://w3c.github.io/webcrypto/#dfn-AesKeyAlgorithm-length>
     length: u16,
@@ -2608,7 +2575,7 @@ pub(crate) struct SubtleAesKeyAlgorithm {
 impl SafeToJSValConvertible for SubtleAesKeyAlgorithm {
     fn safe_to_jsval(&self, cx: JSContext, rval: MutableHandleValue, can_gc: CanGc) {
         let parent = KeyAlgorithm {
-            name: self.name.clone().into(),
+            name: self.name.as_str().into(),
         };
         let dictionary = AesKeyAlgorithm {
             parent,
@@ -2619,10 +2586,10 @@ impl SafeToJSValConvertible for SubtleAesKeyAlgorithm {
 }
 
 /// <https://w3c.github.io/webcrypto/#dfn-AesKeyGenParams>
-#[derive(Clone, Debug, MallocSizeOf)]
+#[derive(Clone, MallocSizeOf)]
 struct SubtleAesKeyGenParams {
     /// <https://w3c.github.io/webcrypto/#dom-algorithm-name>
-    name: String,
+    name: CryptoAlgorithm,
 
     /// <https://w3c.github.io/webcrypto/#dfn-AesKeyGenParams-length>
     length: u16,
@@ -2638,17 +2605,17 @@ impl<'a> TryFromWithCx<HandleValue<'a>> for SubtleAesKeyGenParams {
         let dictionary = dictionary_from_jsval::<AesKeyGenParams>(cx, value)?;
 
         Ok(SubtleAesKeyGenParams {
-            name: dictionary.parent.name.to_string(),
+            name: CryptoAlgorithm::from_domstring(&dictionary.parent.name)?,
             length: dictionary.length,
         })
     }
 }
 
 /// <https://w3c.github.io/webcrypto/#dfn-AesDerivedKeyParams>
-#[derive(Clone, Debug, MallocSizeOf)]
+#[derive(Clone, MallocSizeOf)]
 struct SubtleAesDerivedKeyParams {
     /// <https://w3c.github.io/webcrypto/#dom-algorithm-name>
-    name: String,
+    name: CryptoAlgorithm,
 
     /// <https://w3c.github.io/webcrypto/#dfn-AesDerivedKeyParams-length>
     length: u16,
@@ -2664,17 +2631,17 @@ impl<'a> TryFromWithCx<HandleValue<'a>> for SubtleAesDerivedKeyParams {
         let dictionary = dictionary_from_jsval::<AesDerivedKeyParams>(cx, value)?;
 
         Ok(SubtleAesDerivedKeyParams {
-            name: dictionary.parent.name.to_string(),
+            name: CryptoAlgorithm::from_domstring(&dictionary.parent.name)?,
             length: dictionary.length,
         })
     }
 }
 
 /// <https://w3c.github.io/webcrypto/#dfn-AesCbcParams>
-#[derive(Clone, Debug, MallocSizeOf)]
+#[derive(Clone, MallocSizeOf)]
 struct SubtleAesCbcParams {
     /// <https://w3c.github.io/webcrypto/#dom-algorithm-name>
-    name: String,
+    name: CryptoAlgorithm,
 
     /// <https://w3c.github.io/webcrypto/#dfn-AesCbcParams-iv>
     iv: Vec<u8>,
@@ -2695,17 +2662,17 @@ impl<'a> TryFromWithCx<HandleValue<'a>> for SubtleAesCbcParams {
         };
 
         Ok(SubtleAesCbcParams {
-            name: dictionary.parent.name.to_string(),
+            name: CryptoAlgorithm::from_domstring(&dictionary.parent.name)?,
             iv,
         })
     }
 }
 
 /// <https://w3c.github.io/webcrypto/#dfn-AesGcmParams>
-#[derive(Clone, Debug, MallocSizeOf)]
+#[derive(Clone, MallocSizeOf)]
 struct SubtleAesGcmParams {
     /// <https://w3c.github.io/webcrypto/#dom-algorithm-name>
-    name: String,
+    name: CryptoAlgorithm,
 
     /// <https://w3c.github.io/webcrypto/#dfn-AesGcmParams-iv>
     iv: Vec<u8>,
@@ -2736,7 +2703,7 @@ impl<'a> TryFromWithCx<HandleValue<'a>> for SubtleAesGcmParams {
         });
 
         Ok(SubtleAesGcmParams {
-            name: dictionary.parent.name.to_string(),
+            name: CryptoAlgorithm::from_domstring(&dictionary.parent.name)?,
             iv,
             additional_data,
             tag_length: dictionary.tagLength,
@@ -2748,7 +2715,7 @@ impl<'a> TryFromWithCx<HandleValue<'a>> for SubtleAesGcmParams {
 #[derive(Clone, MallocSizeOf)]
 struct SubtleHmacImportParams {
     /// <https://w3c.github.io/webcrypto/#dom-algorithm-name>
-    name: String,
+    name: CryptoAlgorithm,
 
     /// <https://w3c.github.io/webcrypto/#dfn-HmacImportParams-hash>
     hash: DigestAlgorithm,
@@ -2767,7 +2734,7 @@ impl<'a> TryFromWithCx<HandleValue<'a>> for SubtleHmacImportParams {
         let dictionary = dictionary_from_jsval::<RootedTraceableBox<HmacImportParams>>(cx, value)?;
 
         Ok(SubtleHmacImportParams {
-            name: dictionary.parent.name.to_string(),
+            name: CryptoAlgorithm::from_domstring(&dictionary.parent.name)?,
             hash: normalize_algorithm::<DigestOperation>(cx, &dictionary.hash)?,
             length: dictionary.length,
         })
@@ -2775,10 +2742,10 @@ impl<'a> TryFromWithCx<HandleValue<'a>> for SubtleHmacImportParams {
 }
 
 /// <https://w3c.github.io/webcrypto/#dfn-HmacKeyAlgorithm>
-#[derive(Clone, Debug, MallocSizeOf)]
+#[derive(Clone, MallocSizeOf)]
 pub(crate) struct SubtleHmacKeyAlgorithm {
     /// <https://w3c.github.io/webcrypto/#dom-keyalgorithm-name>
-    name: String,
+    name: CryptoAlgorithm,
 
     /// <https://w3c.github.io/webcrypto/#dfn-HmacKeyAlgorithm-hash>
     hash: SubtleKeyAlgorithm,
@@ -2790,10 +2757,10 @@ pub(crate) struct SubtleHmacKeyAlgorithm {
 impl SafeToJSValConvertible for SubtleHmacKeyAlgorithm {
     fn safe_to_jsval(&self, cx: JSContext, rval: MutableHandleValue, can_gc: CanGc) {
         let parent = KeyAlgorithm {
-            name: self.name.clone().into(),
+            name: self.name.as_str().into(),
         };
         let hash = KeyAlgorithm {
-            name: self.hash.name.clone().into(),
+            name: self.hash.name.as_str().into(),
         };
         let dictionary = HmacKeyAlgorithm {
             parent,
@@ -2808,7 +2775,7 @@ impl SafeToJSValConvertible for SubtleHmacKeyAlgorithm {
 #[derive(Clone, MallocSizeOf)]
 struct SubtleHmacKeyGenParams {
     /// <https://w3c.github.io/webcrypto/#dom-algorithm-name>
-    name: String,
+    name: CryptoAlgorithm,
 
     /// <https://w3c.github.io/webcrypto/#dfn-HmacKeyGenParams-hash>
     hash: DigestAlgorithm,
@@ -2827,7 +2794,7 @@ impl<'a> TryFromWithCx<HandleValue<'a>> for SubtleHmacKeyGenParams {
         let dictionary = dictionary_from_jsval::<RootedTraceableBox<HmacKeyGenParams>>(cx, value)?;
 
         Ok(SubtleHmacKeyGenParams {
-            name: dictionary.parent.name.to_string(),
+            name: CryptoAlgorithm::from_domstring(&dictionary.parent.name)?,
             hash: normalize_algorithm::<DigestOperation>(cx, &dictionary.hash)?,
             length: dictionary.length,
         })
@@ -2838,7 +2805,7 @@ impl<'a> TryFromWithCx<HandleValue<'a>> for SubtleHmacKeyGenParams {
 #[derive(Clone, MallocSizeOf)]
 pub(crate) struct SubtleHkdfParams {
     /// <https://w3c.github.io/webcrypto/#dom-algorithm-name>
-    name: String,
+    name: CryptoAlgorithm,
 
     /// <https://w3c.github.io/webcrypto/#dfn-HkdfParams-hash>
     hash: DigestAlgorithm,
@@ -2869,7 +2836,7 @@ impl<'a> TryFromWithCx<HandleValue<'a>> for SubtleHkdfParams {
         };
 
         Ok(SubtleHkdfParams {
-            name: dictionary.parent.name.to_string(),
+            name: CryptoAlgorithm::from_domstring(&dictionary.parent.name)?,
             hash: normalize_algorithm::<DigestOperation>(cx, &dictionary.hash)?,
             salt,
             info,
@@ -2881,7 +2848,7 @@ impl<'a> TryFromWithCx<HandleValue<'a>> for SubtleHkdfParams {
 #[derive(Clone, MallocSizeOf)]
 pub(crate) struct SubtlePbkdf2Params {
     /// <https://w3c.github.io/webcrypto/#dom-algorithm-name>
-    name: String,
+    name: CryptoAlgorithm,
 
     /// <https://w3c.github.io/webcrypto/#dfn-Pbkdf2Params-salt>
     salt: Vec<u8>,
@@ -2908,7 +2875,7 @@ impl<'a> TryFromWithCx<HandleValue<'a>> for SubtlePbkdf2Params {
         };
 
         Ok(SubtlePbkdf2Params {
-            name: dictionary.parent.name.to_string(),
+            name: CryptoAlgorithm::from_domstring(&dictionary.parent.name)?,
             salt,
             iterations: dictionary.iterations,
             hash: normalize_algorithm::<DigestOperation>(cx, &dictionary.hash)?,
@@ -2917,10 +2884,10 @@ impl<'a> TryFromWithCx<HandleValue<'a>> for SubtlePbkdf2Params {
 }
 
 /// <https://wicg.github.io/webcrypto-modern-algos/#dfn-ContextParams>
-#[derive(Clone, Debug, MallocSizeOf)]
+#[derive(Clone, MallocSizeOf)]
 struct SubtleContextParams {
     /// <https://w3c.github.io/webcrypto/#dom-algorithm-name>
-    name: String,
+    name: CryptoAlgorithm,
 
     /// <https://wicg.github.io/webcrypto-modern-algos/#dfn-ContextParams-context>
     context: Option<Vec<u8>>,
@@ -2941,17 +2908,17 @@ impl<'a> TryFromWithCx<HandleValue<'a>> for SubtleContextParams {
         });
 
         Ok(SubtleContextParams {
-            name: dictionary.parent.name.to_string(),
+            name: CryptoAlgorithm::from_domstring(&dictionary.parent.name)?,
             context,
         })
     }
 }
 
 /// <https://wicg.github.io/webcrypto-modern-algos/#dfn-AeadParams>
-#[derive(Clone, Debug, MallocSizeOf)]
+#[derive(Clone, MallocSizeOf)]
 struct SubtleAeadParams {
     /// <https://w3c.github.io/webcrypto/#dom-algorithm-name>
-    name: String,
+    name: CryptoAlgorithm,
 
     /// <https://wicg.github.io/webcrypto-modern-algos/#dfn-AeadParams-iv>
     iv: Vec<u8>,
@@ -2982,7 +2949,7 @@ impl<'a> TryFromWithCx<HandleValue<'a>> for SubtleAeadParams {
         });
 
         Ok(SubtleAeadParams {
-            name: dictionary.parent.name.to_string(),
+            name: CryptoAlgorithm::from_domstring(&dictionary.parent.name)?,
             iv,
             additional_data,
             tag_length: dictionary.tagLength,
@@ -2991,10 +2958,10 @@ impl<'a> TryFromWithCx<HandleValue<'a>> for SubtleAeadParams {
 }
 
 /// <https://wicg.github.io/webcrypto-modern-algos/#dfn-CShakeParams>
-#[derive(Clone, Debug, MallocSizeOf)]
+#[derive(Clone, MallocSizeOf)]
 struct SubtleCShakeParams {
     /// <https://w3c.github.io/webcrypto/#dom-algorithm-name>
-    name: String,
+    name: CryptoAlgorithm,
 
     /// <https://wicg.github.io/webcrypto-modern-algos/#dfn-CShakeParams-length>
     length: u32,
@@ -3033,7 +3000,7 @@ impl<'a> TryFromWithCx<HandleValue<'a>> for SubtleCShakeParams {
                 });
 
         Ok(SubtleCShakeParams {
-            name: dictionary.parent.name.to_string(),
+            name: CryptoAlgorithm::from_domstring(&dictionary.parent.name)?,
             length: dictionary.length,
             function_name,
             customization,
@@ -3042,10 +3009,10 @@ impl<'a> TryFromWithCx<HandleValue<'a>> for SubtleCShakeParams {
 }
 
 /// <https://wicg.github.io/webcrypto-modern-algos/#dfn-Argon2Params>
-#[derive(Clone, Debug, MallocSizeOf)]
+#[derive(Clone, MallocSizeOf)]
 struct SubtleArgon2Params {
     /// <https://w3c.github.io/webcrypto/#dom-algorithm-name>
-    name: String,
+    name: CryptoAlgorithm,
 
     /// <https://wicg.github.io/webcrypto-modern-algos/#dfn-Argon2Params-nonce>
     nonce: Vec<u8>,
@@ -3099,7 +3066,7 @@ impl<'a> TryFromWithCx<HandleValue<'a>> for SubtleArgon2Params {
                 });
 
         Ok(SubtleArgon2Params {
-            name: dictionary.parent.name.to_string(),
+            name: CryptoAlgorithm::from_domstring(&dictionary.parent.name)?,
             nonce,
             parallelism: dictionary.parallelism,
             memory: dictionary.memory,
@@ -3200,13 +3167,13 @@ pub(crate) enum KeyAlgorithmAndDerivatives {
 }
 
 impl KeyAlgorithmAndDerivatives {
-    fn name(&self) -> &str {
+    fn name(&self) -> CryptoAlgorithm {
         match self {
-            KeyAlgorithmAndDerivatives::KeyAlgorithm(algo) => &algo.name,
-            KeyAlgorithmAndDerivatives::RsaHashedKeyAlgorithm(algo) => &algo.name,
-            KeyAlgorithmAndDerivatives::EcKeyAlgorithm(algo) => &algo.name,
-            KeyAlgorithmAndDerivatives::AesKeyAlgorithm(algo) => &algo.name,
-            KeyAlgorithmAndDerivatives::HmacKeyAlgorithm(algo) => &algo.name,
+            KeyAlgorithmAndDerivatives::KeyAlgorithm(algorithm) => algorithm.name,
+            KeyAlgorithmAndDerivatives::RsaHashedKeyAlgorithm(algorithm) => algorithm.name,
+            KeyAlgorithmAndDerivatives::EcKeyAlgorithm(algorithm) => algorithm.name,
+            KeyAlgorithmAndDerivatives::AesKeyAlgorithm(algorithm) => algorithm.name,
+            KeyAlgorithmAndDerivatives::HmacKeyAlgorithm(algorithm) => algorithm.name,
         }
     }
 }
@@ -3687,7 +3654,7 @@ trait NormalizedAlgorithm: Sized {
         algorithm_name: CryptoAlgorithm,
         value: HandleValue,
     ) -> Fallible<Self>;
-    fn name(&self) -> &str;
+    fn name(&self) -> CryptoAlgorithm;
 }
 
 /// The value of the key "encrypt" in the internal object supportedAlgorithms
@@ -3730,14 +3697,14 @@ impl NormalizedAlgorithm for EncryptAlgorithm {
         }
     }
 
-    fn name(&self) -> &str {
+    fn name(&self) -> CryptoAlgorithm {
         match self {
-            EncryptAlgorithm::RsaOaep(algorithm) => &algorithm.name,
-            EncryptAlgorithm::AesCtr(algorithm) => &algorithm.name,
-            EncryptAlgorithm::AesCbc(algorithm) => &algorithm.name,
-            EncryptAlgorithm::AesGcm(algorithm) => &algorithm.name,
-            EncryptAlgorithm::AesOcb(algorithm) => &algorithm.name,
-            EncryptAlgorithm::ChaCha20Poly1305(algorithm) => &algorithm.name,
+            EncryptAlgorithm::RsaOaep(algorithm) => algorithm.name,
+            EncryptAlgorithm::AesCtr(algorithm) => algorithm.name,
+            EncryptAlgorithm::AesCbc(algorithm) => algorithm.name,
+            EncryptAlgorithm::AesGcm(algorithm) => algorithm.name,
+            EncryptAlgorithm::AesOcb(algorithm) => algorithm.name,
+            EncryptAlgorithm::ChaCha20Poly1305(algorithm) => algorithm.name,
         }
     }
 }
@@ -3807,14 +3774,14 @@ impl NormalizedAlgorithm for DecryptAlgorithm {
         }
     }
 
-    fn name(&self) -> &str {
+    fn name(&self) -> CryptoAlgorithm {
         match self {
-            DecryptAlgorithm::RsaOaep(algorithm) => &algorithm.name,
-            DecryptAlgorithm::AesCtr(algorithm) => &algorithm.name,
-            DecryptAlgorithm::AesCbc(algorithm) => &algorithm.name,
-            DecryptAlgorithm::AesGcm(algorithm) => &algorithm.name,
-            DecryptAlgorithm::AesOcb(algorithm) => &algorithm.name,
-            DecryptAlgorithm::ChaCha20Poly1305(algorithm) => &algorithm.name,
+            DecryptAlgorithm::RsaOaep(algorithm) => algorithm.name,
+            DecryptAlgorithm::AesCtr(algorithm) => algorithm.name,
+            DecryptAlgorithm::AesCbc(algorithm) => algorithm.name,
+            DecryptAlgorithm::AesGcm(algorithm) => algorithm.name,
+            DecryptAlgorithm::AesOcb(algorithm) => algorithm.name,
+            DecryptAlgorithm::ChaCha20Poly1305(algorithm) => algorithm.name,
         }
     }
 }
@@ -3886,14 +3853,14 @@ impl NormalizedAlgorithm for SignAlgorithm {
         }
     }
 
-    fn name(&self) -> &str {
+    fn name(&self) -> CryptoAlgorithm {
         match self {
-            SignAlgorithm::RsassaPkcs1V1_5(algorithm) => &algorithm.name,
-            SignAlgorithm::RsaPss(algorithm) => &algorithm.name,
-            SignAlgorithm::Ecdsa(algorithm) => &algorithm.name,
-            SignAlgorithm::Ed25519(algorithm) => &algorithm.name,
-            SignAlgorithm::Hmac(algorithm) => &algorithm.name,
-            SignAlgorithm::MlDsa(algorithm) => &algorithm.name,
+            SignAlgorithm::RsassaPkcs1V1_5(algorithm) => algorithm.name,
+            SignAlgorithm::RsaPss(algorithm) => algorithm.name,
+            SignAlgorithm::Ecdsa(algorithm) => algorithm.name,
+            SignAlgorithm::Ed25519(algorithm) => algorithm.name,
+            SignAlgorithm::Hmac(algorithm) => algorithm.name,
+            SignAlgorithm::MlDsa(algorithm) => algorithm.name,
         }
     }
 }
@@ -3955,14 +3922,14 @@ impl NormalizedAlgorithm for VerifyAlgorithm {
         }
     }
 
-    fn name(&self) -> &str {
+    fn name(&self) -> CryptoAlgorithm {
         match self {
-            VerifyAlgorithm::RsassaPkcs1V1_5(algorithm) => &algorithm.name,
-            VerifyAlgorithm::RsaPss(algorithm) => &algorithm.name,
-            VerifyAlgorithm::Ecdsa(algorithm) => &algorithm.name,
-            VerifyAlgorithm::Ed25519(algorithm) => &algorithm.name,
-            VerifyAlgorithm::Hmac(algorithm) => &algorithm.name,
-            VerifyAlgorithm::MlDsa(algorithm) => &algorithm.name,
+            VerifyAlgorithm::RsassaPkcs1V1_5(algorithm) => algorithm.name,
+            VerifyAlgorithm::RsaPss(algorithm) => algorithm.name,
+            VerifyAlgorithm::Ecdsa(algorithm) => algorithm.name,
+            VerifyAlgorithm::Ed25519(algorithm) => algorithm.name,
+            VerifyAlgorithm::Hmac(algorithm) => algorithm.name,
+            VerifyAlgorithm::MlDsa(algorithm) => algorithm.name,
         }
     }
 }
@@ -4030,11 +3997,11 @@ impl NormalizedAlgorithm for DigestAlgorithm {
         }
     }
 
-    fn name(&self) -> &str {
+    fn name(&self) -> CryptoAlgorithm {
         match self {
-            DigestAlgorithm::Sha(algorithm) => &algorithm.name,
-            DigestAlgorithm::Sha3(algorithm) => &algorithm.name,
-            DigestAlgorithm::CShake(algorithm) => &algorithm.name,
+            DigestAlgorithm::Sha(algorithm) => algorithm.name,
+            DigestAlgorithm::Sha3(algorithm) => algorithm.name,
+            DigestAlgorithm::CShake(algorithm) => algorithm.name,
         }
     }
 }
@@ -4087,13 +4054,13 @@ impl NormalizedAlgorithm for DeriveBitsAlgorithm {
         }
     }
 
-    fn name(&self) -> &str {
+    fn name(&self) -> CryptoAlgorithm {
         match self {
-            DeriveBitsAlgorithm::Ecdh(algorithm) => &algorithm.name,
-            DeriveBitsAlgorithm::X25519(algorithm) => &algorithm.name,
-            DeriveBitsAlgorithm::Hkdf(algorithm) => &algorithm.name,
-            DeriveBitsAlgorithm::Pbkdf2(algorithm) => &algorithm.name,
-            DeriveBitsAlgorithm::Argon2(algorithm) => &algorithm.name,
+            DeriveBitsAlgorithm::Ecdh(algorithm) => algorithm.name,
+            DeriveBitsAlgorithm::X25519(algorithm) => algorithm.name,
+            DeriveBitsAlgorithm::Hkdf(algorithm) => algorithm.name,
+            DeriveBitsAlgorithm::Pbkdf2(algorithm) => algorithm.name,
+            DeriveBitsAlgorithm::Argon2(algorithm) => algorithm.name,
         }
     }
 }
@@ -4148,9 +4115,9 @@ impl NormalizedAlgorithm for WrapKeyAlgorithm {
         }
     }
 
-    fn name(&self) -> &str {
+    fn name(&self) -> CryptoAlgorithm {
         match self {
-            WrapKeyAlgorithm::AesKw(algorithm) => &algorithm.name,
+            WrapKeyAlgorithm::AesKw(algorithm) => algorithm.name,
         }
     }
 }
@@ -4191,9 +4158,9 @@ impl NormalizedAlgorithm for UnwrapKeyAlgorithm {
         }
     }
 
-    fn name(&self) -> &str {
+    fn name(&self) -> CryptoAlgorithm {
         match self {
-            UnwrapKeyAlgorithm::AesKw(algorithm) => &algorithm.name,
+            UnwrapKeyAlgorithm::AesKw(algorithm) => algorithm.name,
         }
     }
 }
@@ -4288,24 +4255,24 @@ impl NormalizedAlgorithm for GenerateKeyAlgorithm {
         }
     }
 
-    fn name(&self) -> &str {
+    fn name(&self) -> CryptoAlgorithm {
         match self {
-            GenerateKeyAlgorithm::RsassaPkcs1V1_5(algorithm) => &algorithm.name,
-            GenerateKeyAlgorithm::RsaPss(algorithm) => &algorithm.name,
-            GenerateKeyAlgorithm::RsaOaep(algorithm) => &algorithm.name,
-            GenerateKeyAlgorithm::Ecdsa(algorithm) => &algorithm.name,
-            GenerateKeyAlgorithm::Ecdh(algorithm) => &algorithm.name,
-            GenerateKeyAlgorithm::Ed25519(algorithm) => &algorithm.name,
-            GenerateKeyAlgorithm::X25519(algorithm) => &algorithm.name,
-            GenerateKeyAlgorithm::AesCtr(algorithm) => &algorithm.name,
-            GenerateKeyAlgorithm::AesCbc(algorithm) => &algorithm.name,
-            GenerateKeyAlgorithm::AesGcm(algorithm) => &algorithm.name,
-            GenerateKeyAlgorithm::AesKw(algorithm) => &algorithm.name,
-            GenerateKeyAlgorithm::Hmac(algorithm) => &algorithm.name,
-            GenerateKeyAlgorithm::MlKem(algorithm) => &algorithm.name,
-            GenerateKeyAlgorithm::MlDsa(algorithm) => &algorithm.name,
-            GenerateKeyAlgorithm::AesOcb(algorithm) => &algorithm.name,
-            GenerateKeyAlgorithm::ChaCha20Poly1305(algorithm) => &algorithm.name,
+            GenerateKeyAlgorithm::RsassaPkcs1V1_5(algorithm) => algorithm.name,
+            GenerateKeyAlgorithm::RsaPss(algorithm) => algorithm.name,
+            GenerateKeyAlgorithm::RsaOaep(algorithm) => algorithm.name,
+            GenerateKeyAlgorithm::Ecdsa(algorithm) => algorithm.name,
+            GenerateKeyAlgorithm::Ecdh(algorithm) => algorithm.name,
+            GenerateKeyAlgorithm::Ed25519(algorithm) => algorithm.name,
+            GenerateKeyAlgorithm::X25519(algorithm) => algorithm.name,
+            GenerateKeyAlgorithm::AesCtr(algorithm) => algorithm.name,
+            GenerateKeyAlgorithm::AesCbc(algorithm) => algorithm.name,
+            GenerateKeyAlgorithm::AesGcm(algorithm) => algorithm.name,
+            GenerateKeyAlgorithm::AesKw(algorithm) => algorithm.name,
+            GenerateKeyAlgorithm::Hmac(algorithm) => algorithm.name,
+            GenerateKeyAlgorithm::MlKem(algorithm) => algorithm.name,
+            GenerateKeyAlgorithm::MlDsa(algorithm) => algorithm.name,
+            GenerateKeyAlgorithm::AesOcb(algorithm) => algorithm.name,
+            GenerateKeyAlgorithm::ChaCha20Poly1305(algorithm) => algorithm.name,
         }
     }
 }
@@ -4471,27 +4438,27 @@ impl NormalizedAlgorithm for ImportKeyAlgorithm {
         }
     }
 
-    fn name(&self) -> &str {
+    fn name(&self) -> CryptoAlgorithm {
         match self {
-            ImportKeyAlgorithm::RsassaPkcs1V1_5(algorithm) => &algorithm.name,
-            ImportKeyAlgorithm::RsaPss(algorithm) => &algorithm.name,
-            ImportKeyAlgorithm::RsaOaep(algorithm) => &algorithm.name,
-            ImportKeyAlgorithm::Ecdsa(algorithm) => &algorithm.name,
-            ImportKeyAlgorithm::Ecdh(algorithm) => &algorithm.name,
-            ImportKeyAlgorithm::Ed25519(algorithm) => &algorithm.name,
-            ImportKeyAlgorithm::X25519(algorithm) => &algorithm.name,
-            ImportKeyAlgorithm::AesCtr(algorithm) => &algorithm.name,
-            ImportKeyAlgorithm::AesCbc(algorithm) => &algorithm.name,
-            ImportKeyAlgorithm::AesGcm(algorithm) => &algorithm.name,
-            ImportKeyAlgorithm::AesKw(algorithm) => &algorithm.name,
-            ImportKeyAlgorithm::Hmac(algorithm) => &algorithm.name,
-            ImportKeyAlgorithm::Hkdf(algorithm) => &algorithm.name,
-            ImportKeyAlgorithm::Pbkdf2(algorithm) => &algorithm.name,
-            ImportKeyAlgorithm::MlKem(algorithm) => &algorithm.name,
-            ImportKeyAlgorithm::MlDsa(algorithm) => &algorithm.name,
-            ImportKeyAlgorithm::AesOcb(algorithm) => &algorithm.name,
-            ImportKeyAlgorithm::ChaCha20Poly1305(algorithm) => &algorithm.name,
-            ImportKeyAlgorithm::Argon2(algorithm) => &algorithm.name,
+            ImportKeyAlgorithm::RsassaPkcs1V1_5(algorithm) => algorithm.name,
+            ImportKeyAlgorithm::RsaPss(algorithm) => algorithm.name,
+            ImportKeyAlgorithm::RsaOaep(algorithm) => algorithm.name,
+            ImportKeyAlgorithm::Ecdsa(algorithm) => algorithm.name,
+            ImportKeyAlgorithm::Ecdh(algorithm) => algorithm.name,
+            ImportKeyAlgorithm::Ed25519(algorithm) => algorithm.name,
+            ImportKeyAlgorithm::X25519(algorithm) => algorithm.name,
+            ImportKeyAlgorithm::AesCtr(algorithm) => algorithm.name,
+            ImportKeyAlgorithm::AesCbc(algorithm) => algorithm.name,
+            ImportKeyAlgorithm::AesGcm(algorithm) => algorithm.name,
+            ImportKeyAlgorithm::AesKw(algorithm) => algorithm.name,
+            ImportKeyAlgorithm::Hmac(algorithm) => algorithm.name,
+            ImportKeyAlgorithm::Hkdf(algorithm) => algorithm.name,
+            ImportKeyAlgorithm::Pbkdf2(algorithm) => algorithm.name,
+            ImportKeyAlgorithm::MlKem(algorithm) => algorithm.name,
+            ImportKeyAlgorithm::MlDsa(algorithm) => algorithm.name,
+            ImportKeyAlgorithm::AesOcb(algorithm) => algorithm.name,
+            ImportKeyAlgorithm::ChaCha20Poly1305(algorithm) => algorithm.name,
+            ImportKeyAlgorithm::Argon2(algorithm) => algorithm.name,
         }
     }
 }
@@ -4701,24 +4668,24 @@ impl NormalizedAlgorithm for ExportKeyAlgorithm {
         }
     }
 
-    fn name(&self) -> &str {
+    fn name(&self) -> CryptoAlgorithm {
         match self {
-            ExportKeyAlgorithm::RsassaPkcs1V1_5(algorithm) => &algorithm.name,
-            ExportKeyAlgorithm::RsaPss(algorithm) => &algorithm.name,
-            ExportKeyAlgorithm::RsaOaep(algorithm) => &algorithm.name,
-            ExportKeyAlgorithm::Ecdsa(algorithm) => &algorithm.name,
-            ExportKeyAlgorithm::Ecdh(algorithm) => &algorithm.name,
-            ExportKeyAlgorithm::Ed25519(algorithm) => &algorithm.name,
-            ExportKeyAlgorithm::X25519(algorithm) => &algorithm.name,
-            ExportKeyAlgorithm::AesCtr(algorithm) => &algorithm.name,
-            ExportKeyAlgorithm::AesCbc(algorithm) => &algorithm.name,
-            ExportKeyAlgorithm::AesGcm(algorithm) => &algorithm.name,
-            ExportKeyAlgorithm::AesKw(algorithm) => &algorithm.name,
-            ExportKeyAlgorithm::Hmac(algorithm) => &algorithm.name,
-            ExportKeyAlgorithm::MlKem(algorithm) => &algorithm.name,
-            ExportKeyAlgorithm::MlDsa(algorithm) => &algorithm.name,
-            ExportKeyAlgorithm::AesOcb(algorithm) => &algorithm.name,
-            ExportKeyAlgorithm::ChaCha20Poly1305(algorithm) => &algorithm.name,
+            ExportKeyAlgorithm::RsassaPkcs1V1_5(algorithm) => algorithm.name,
+            ExportKeyAlgorithm::RsaPss(algorithm) => algorithm.name,
+            ExportKeyAlgorithm::RsaOaep(algorithm) => algorithm.name,
+            ExportKeyAlgorithm::Ecdsa(algorithm) => algorithm.name,
+            ExportKeyAlgorithm::Ecdh(algorithm) => algorithm.name,
+            ExportKeyAlgorithm::Ed25519(algorithm) => algorithm.name,
+            ExportKeyAlgorithm::X25519(algorithm) => algorithm.name,
+            ExportKeyAlgorithm::AesCtr(algorithm) => algorithm.name,
+            ExportKeyAlgorithm::AesCbc(algorithm) => algorithm.name,
+            ExportKeyAlgorithm::AesGcm(algorithm) => algorithm.name,
+            ExportKeyAlgorithm::AesKw(algorithm) => algorithm.name,
+            ExportKeyAlgorithm::Hmac(algorithm) => algorithm.name,
+            ExportKeyAlgorithm::MlKem(algorithm) => algorithm.name,
+            ExportKeyAlgorithm::MlDsa(algorithm) => algorithm.name,
+            ExportKeyAlgorithm::AesOcb(algorithm) => algorithm.name,
+            ExportKeyAlgorithm::ChaCha20Poly1305(algorithm) => algorithm.name,
         }
     }
 }
@@ -4810,18 +4777,18 @@ impl NormalizedAlgorithm for GetKeyLengthAlgorithm {
         }
     }
 
-    fn name(&self) -> &str {
+    fn name(&self) -> CryptoAlgorithm {
         match self {
-            GetKeyLengthAlgorithm::AesCtr(algorithm) => &algorithm.name,
-            GetKeyLengthAlgorithm::AesCbc(algorithm) => &algorithm.name,
-            GetKeyLengthAlgorithm::AesGcm(algorithm) => &algorithm.name,
-            GetKeyLengthAlgorithm::AesKw(algorithm) => &algorithm.name,
-            GetKeyLengthAlgorithm::Hmac(algorithm) => &algorithm.name,
-            GetKeyLengthAlgorithm::Hkdf(algorithm) => &algorithm.name,
-            GetKeyLengthAlgorithm::Pbkdf2(algorithm) => &algorithm.name,
-            GetKeyLengthAlgorithm::AesOcb(algorithm) => &algorithm.name,
-            GetKeyLengthAlgorithm::ChaCha20Poly1305(algorithm) => &algorithm.name,
-            GetKeyLengthAlgorithm::Argon2(algorithm) => &algorithm.name,
+            GetKeyLengthAlgorithm::AesCtr(algorithm) => algorithm.name,
+            GetKeyLengthAlgorithm::AesCbc(algorithm) => algorithm.name,
+            GetKeyLengthAlgorithm::AesGcm(algorithm) => algorithm.name,
+            GetKeyLengthAlgorithm::AesKw(algorithm) => algorithm.name,
+            GetKeyLengthAlgorithm::Hmac(algorithm) => algorithm.name,
+            GetKeyLengthAlgorithm::Hkdf(algorithm) => algorithm.name,
+            GetKeyLengthAlgorithm::Pbkdf2(algorithm) => algorithm.name,
+            GetKeyLengthAlgorithm::AesOcb(algorithm) => algorithm.name,
+            GetKeyLengthAlgorithm::ChaCha20Poly1305(algorithm) => algorithm.name,
+            GetKeyLengthAlgorithm::Argon2(algorithm) => algorithm.name,
         }
     }
 }
@@ -4883,9 +4850,9 @@ impl NormalizedAlgorithm for EncapsulateAlgorithm {
         }
     }
 
-    fn name(&self) -> &str {
+    fn name(&self) -> CryptoAlgorithm {
         match self {
-            EncapsulateAlgorithm::MlKem(algorithm) => &algorithm.name,
+            EncapsulateAlgorithm::MlKem(algorithm) => algorithm.name,
         }
     }
 }
@@ -4928,9 +4895,9 @@ impl NormalizedAlgorithm for DecapsulateAlgorithm {
         }
     }
 
-    fn name(&self) -> &str {
+    fn name(&self) -> CryptoAlgorithm {
         match self {
-            DecapsulateAlgorithm::MlKem(algorithm) => &algorithm.name,
+            DecapsulateAlgorithm::MlKem(algorithm) => algorithm.name,
         }
     }
 }

--- a/components/script/dom/subtlecrypto/aes_common.rs
+++ b/components/script/dom/subtlecrypto/aes_common.rs
@@ -17,9 +17,8 @@ use crate::dom::bindings::str::DOMString;
 use crate::dom::cryptokey::{CryptoKey, Handle};
 use crate::dom::globalscope::GlobalScope;
 use crate::dom::subtlecrypto::{
-    ALG_AES_CBC, ALG_AES_CTR, ALG_AES_GCM, ALG_AES_KW, ALG_AES_OCB, ExportedKey, JsonWebKeyExt,
-    JwkStringField, KeyAlgorithmAndDerivatives, SubtleAesDerivedKeyParams, SubtleAesKeyAlgorithm,
-    SubtleAesKeyGenParams,
+    CryptoAlgorithm, ExportedKey, JsonWebKeyExt, JwkStringField, KeyAlgorithmAndDerivatives,
+    SubtleAesDerivedKeyParams, SubtleAesKeyAlgorithm, SubtleAesKeyGenParams,
 };
 
 #[expect(clippy::enum_variant_names)]
@@ -120,27 +119,27 @@ pub(crate) fn generate_key(
     let algorithm_name = match aes_algorithm {
         AesAlgorithm::AesCtr => {
             // Step 7. Set the name attribute of algorithm to "AES-CTR".
-            "AES-CTR"
+            CryptoAlgorithm::AesCtr
         },
         AesAlgorithm::AesCbc => {
             // Step 7. Set the name attribute of algorithm to "AES-CBC".
-            "AES-CBC"
+            CryptoAlgorithm::AesCbc
         },
         AesAlgorithm::AesGcm => {
             // Step 7. Set the name attribute of algorithm to "AES-GCM".
-            "AES-GCM"
+            CryptoAlgorithm::AesGcm
         },
         AesAlgorithm::AesKw => {
             // Step 7. Set the name attribute of algorithm to "AES-KW".
-            "AES-KW"
+            CryptoAlgorithm::AesKw
         },
         AesAlgorithm::AesOcb => {
             // Step 7. Set the name attribute of algorithm to "AES-OCB".
-            "AES-OCB"
+            CryptoAlgorithm::AesOcb
         },
     };
     let algorithm = SubtleAesKeyAlgorithm {
-        name: algorithm_name.to_string(),
+        name: algorithm_name,
         length: normalized_algorithm.length,
     };
     let key = CryptoKey::new(
@@ -476,23 +475,23 @@ pub(crate) fn import_key(
         name: match &aes_algorithm {
             AesAlgorithm::AesCtr => {
                 // Step 6. Set the name attribute of algorithm to "AES-CTR".
-                ALG_AES_CTR.to_string()
+                CryptoAlgorithm::AesCtr
             },
             AesAlgorithm::AesCbc => {
                 // Step 6. Set the name attribute of algorithm to "AES-CBC".
-                ALG_AES_CBC.to_string()
+                CryptoAlgorithm::AesCbc
             },
             AesAlgorithm::AesGcm => {
                 // Step 6. Set the name attribute of algorithm to "AES-GCM".
-                ALG_AES_GCM.to_string()
+                CryptoAlgorithm::AesGcm
             },
             AesAlgorithm::AesKw => {
                 // Step 6. Set the name attribute of algorithm to "AES-KW".
-                ALG_AES_KW.to_string()
+                CryptoAlgorithm::AesKw
             },
             AesAlgorithm::AesOcb => {
                 // Step 6. Set the name attribute of algorithm to "AES-OCB".
-                ALG_AES_OCB.to_string()
+                CryptoAlgorithm::AesOcb
             },
         },
         length: data.len() as u16 * 8,

--- a/components/script/dom/subtlecrypto/argon2_operation.rs
+++ b/components/script/dom/subtlecrypto/argon2_operation.rs
@@ -12,8 +12,8 @@ use crate::dom::bindings::root::DomRoot;
 use crate::dom::cryptokey::{CryptoKey, Handle};
 use crate::dom::globalscope::GlobalScope;
 use crate::dom::subtlecrypto::{
-    ALG_ARGON2D, ALG_ARGON2I, ALG_ARGON2ID, KeyAlgorithmAndDerivatives, SubtleAlgorithm,
-    SubtleArgon2Params, SubtleKeyAlgorithm,
+    CryptoAlgorithm, KeyAlgorithmAndDerivatives, SubtleAlgorithm, SubtleArgon2Params,
+    SubtleKeyAlgorithm,
 };
 
 /// <https://wicg.github.io/webcrypto-modern-algos/#argon2-operations-derive-bits>
@@ -71,14 +71,14 @@ pub(crate) fn derive_bits(
     //     Let type be 1.
     // If the name member of normalizedAlgorithm is a case-sensitive string match for "Argon2id":
     //     Let type be 2.
-    let type_ = match normalized_algorithm.name.as_str() {
-        ALG_ARGON2D => argon2::Algorithm::Argon2d,
-        ALG_ARGON2I => argon2::Algorithm::Argon2i,
-        ALG_ARGON2ID => argon2::Algorithm::Argon2id,
+    let type_ = match normalized_algorithm.name {
+        CryptoAlgorithm::Argon2D => argon2::Algorithm::Argon2d,
+        CryptoAlgorithm::Argon2I => argon2::Algorithm::Argon2i,
+        CryptoAlgorithm::Argon2ID => argon2::Algorithm::Argon2id,
         _ => {
             return Err(Error::NotSupported(Some(format!(
                 "Unknown Argon2 algorithm name: {}",
-                normalized_algorithm.name
+                normalized_algorithm.name.as_str()
             ))));
         },
     };
@@ -168,7 +168,7 @@ pub(crate) fn import_key(
     // Step 8. Set the name attribute of algorithm to the name member of normalizedAlgorithm.
     // Step 9. Set the [[algorithm]] internal slot of key to algorithm.
     let algorithm = SubtleKeyAlgorithm {
-        name: normalized_algorithm.name.clone(),
+        name: normalized_algorithm.name,
     };
     let key = CryptoKey::new(
         cx,

--- a/components/script/dom/subtlecrypto/chacha20_poly1305_operation.rs
+++ b/components/script/dom/subtlecrypto/chacha20_poly1305_operation.rs
@@ -16,7 +16,7 @@ use crate::dom::bindings::str::DOMString;
 use crate::dom::cryptokey::{CryptoKey, Handle};
 use crate::dom::globalscope::GlobalScope;
 use crate::dom::subtlecrypto::{
-    ALG_CHACHA20_POLY1305, ExportedKey, JsonWebKeyExt, JwkStringField, KeyAlgorithmAndDerivatives,
+    CryptoAlgorithm, ExportedKey, JsonWebKeyExt, JwkStringField, KeyAlgorithmAndDerivatives,
     SubtleAeadParams, SubtleKeyAlgorithm,
 };
 
@@ -180,7 +180,7 @@ pub(crate) fn generate_key(
     // Step 9. Set the [[extractable]] internal slot of key to be extractable.
     // Step 10. Set the [[usages]] internal slot of key to be usages.
     let algorithm = SubtleKeyAlgorithm {
-        name: ALG_CHACHA20_POLY1305.to_string(),
+        name: CryptoAlgorithm::ChaCha20Poly1305,
     };
     let key = CryptoKey::new(
         cx,
@@ -308,7 +308,7 @@ pub(crate) fn import_key(
         Some("ChaCha20-Poly1305 fails to create key from data".to_string()),
     ))?);
     let algorithm = SubtleKeyAlgorithm {
-        name: ALG_CHACHA20_POLY1305.to_string(),
+        name: CryptoAlgorithm::ChaCha20Poly1305,
     };
     let key = CryptoKey::new(
         cx,

--- a/components/script/dom/subtlecrypto/cshake_operation.rs
+++ b/components/script/dom/subtlecrypto/cshake_operation.rs
@@ -6,7 +6,7 @@ use digest::{ExtendableOutput, Update};
 use sha3::{CShake128, CShake128Core, CShake256, CShake256Core};
 
 use crate::dom::bindings::error::Error;
-use crate::dom::subtlecrypto::{ALG_CSHAKE_128, ALG_CSHAKE_256, SubtleCShakeParams};
+use crate::dom::subtlecrypto::{CryptoAlgorithm, SubtleCShakeParams};
 
 /// <https://wicg.github.io/webcrypto-modern-algos/#cshake-operations-digest>
 pub(crate) fn digest(
@@ -36,14 +36,14 @@ pub(crate) fn digest(
     //     parameter, functionName as the N input parameter, and customization as the S input
     //     parameter.
     // Step 5. If performing the operation results in an error, then throw an OperationError.
-    let result = match normalized_algorithm.name.as_str() {
-        ALG_CSHAKE_128 => {
+    let result = match normalized_algorithm.name {
+        CryptoAlgorithm::CShake128 => {
             let core = CShake128Core::new_with_function_name(function_name, customization);
             let mut hasher = CShake128::from_core(core);
             hasher.update(message);
             hasher.finalize_boxed(length / 8).to_vec()
         },
-        ALG_CSHAKE_256 => {
+        CryptoAlgorithm::CShake256 => {
             let core = CShake256Core::new_with_function_name(function_name, customization);
             let mut hasher = CShake256::from_core(core);
             hasher.update(message);
@@ -51,7 +51,8 @@ pub(crate) fn digest(
         },
         algorithm_name => {
             return Err(Error::NotSupported(Some(format!(
-                "{algorithm_name} is not supported"
+                "{} is not supported",
+                algorithm_name.as_str()
             ))));
         },
     };

--- a/components/script/dom/subtlecrypto/ecdh_operation.rs
+++ b/components/script/dom/subtlecrypto/ecdh_operation.rs
@@ -25,7 +25,7 @@ use crate::dom::bindings::str::DOMString;
 use crate::dom::cryptokey::{CryptoKey, Handle};
 use crate::dom::globalscope::GlobalScope;
 use crate::dom::subtlecrypto::{
-    ALG_ECDH, ExportedKey, JsonWebKeyExt, JwkStringField, KeyAlgorithmAndDerivatives,
+    CryptoAlgorithm, ExportedKey, JsonWebKeyExt, JwkStringField, KeyAlgorithmAndDerivatives,
     NAMED_CURVE_P256, NAMED_CURVE_P384, NAMED_CURVE_P521, SUPPORTED_CURVES, SubtleEcKeyAlgorithm,
     SubtleEcKeyGenParams, SubtleEcKeyImportParams, SubtleEcdhKeyDeriveParams,
 };
@@ -98,7 +98,7 @@ pub(crate) fn generate_key(
     // Step 6. Set the namedCurve attribute of algorithm to equal the namedCurve member of
     // normalizedAlgorithm.
     let algorithm = SubtleEcKeyAlgorithm {
-        name: ALG_ECDH.to_string(),
+        name: CryptoAlgorithm::Ecdh,
         named_curve: normalized_algorithm.named_curve.clone(),
     };
 
@@ -444,7 +444,7 @@ pub(crate) fn import_key(
             // Step 2.16. Set the namedCurve attribute of algorithm to namedCurve.
             // Step 2.17. Set the [[algorithm]] internal slot of key to algorithm.
             let algorithm = SubtleEcKeyAlgorithm {
-                name: ALG_ECDH.to_string(),
+                name: CryptoAlgorithm::Ecdh,
                 named_curve: named_curve
                     .expect("named_curve must exist here")
                     .to_string(),
@@ -612,7 +612,7 @@ pub(crate) fn import_key(
             // Step 2.16. Set the namedCurve attribute of algorithm to namedCurve.
             // Step 2.17. Set the [[algorithm]] internal slot of key to algorithm.
             let algorithm = SubtleEcKeyAlgorithm {
-                name: ALG_ECDH.to_string(),
+                name: CryptoAlgorithm::Ecdh,
                 named_curve: named_curve
                     .expect("named_curve must exist here")
                     .to_string(),
@@ -870,7 +870,7 @@ pub(crate) fn import_key(
             // Step 2.14. Set the namedCurve attribute of algorithm to namedCurve.
             // Step 2.15. Set the [[algorithm]] internal slot of key to algorithm.
             let algorithm = SubtleEcKeyAlgorithm {
-                name: ALG_ECDH.to_string(),
+                name: CryptoAlgorithm::Ecdh,
                 named_curve,
             };
             CryptoKey::new(
@@ -954,7 +954,7 @@ pub(crate) fn import_key(
             // Step 2.6. Set the namedCurve attribute of algorithm to equal the namedCurve member
             // of normalizedAlgorithm.
             let algorithm = SubtleEcKeyAlgorithm {
-                name: ALG_ECDH.to_string(),
+                name: CryptoAlgorithm::Ecdh,
                 named_curve: normalized_algorithm.named_curve.clone(),
             };
 

--- a/components/script/dom/subtlecrypto/ecdsa_operation.rs
+++ b/components/script/dom/subtlecrypto/ecdsa_operation.rs
@@ -30,10 +30,9 @@ use crate::dom::bindings::str::DOMString;
 use crate::dom::cryptokey::{CryptoKey, Handle};
 use crate::dom::globalscope::GlobalScope;
 use crate::dom::subtlecrypto::{
-    ALG_ECDSA, ALG_SHA1, ALG_SHA256, ALG_SHA384, ALG_SHA512, ExportedKey, JsonWebKeyExt,
-    JwkStringField, KeyAlgorithmAndDerivatives, NAMED_CURVE_P256, NAMED_CURVE_P384,
-    NAMED_CURVE_P521, NormalizedAlgorithm, SUPPORTED_CURVES, SubtleEcKeyAlgorithm,
-    SubtleEcKeyGenParams, SubtleEcKeyImportParams, SubtleEcdsaParams,
+    CryptoAlgorithm, ExportedKey, JsonWebKeyExt, JwkStringField, KeyAlgorithmAndDerivatives,
+    NAMED_CURVE_P256, NAMED_CURVE_P384, NAMED_CURVE_P521, NormalizedAlgorithm, SUPPORTED_CURVES,
+    SubtleEcKeyAlgorithm, SubtleEcKeyGenParams, SubtleEcKeyImportParams, SubtleEcdsaParams,
 };
 
 const P256_PREHASH_LENGTH: usize = 32;
@@ -58,10 +57,10 @@ pub(crate) fn sign(
     // Step 3. Let M be the result of performing the digest operation specified by hashAlgorithm
     // using message.
     let m = match hash_algorithm.name() {
-        ALG_SHA1 => Sha1::new_with_prefix(message).finalize().to_vec(),
-        ALG_SHA256 => Sha256::new_with_prefix(message).finalize().to_vec(),
-        ALG_SHA384 => Sha384::new_with_prefix(message).finalize().to_vec(),
-        ALG_SHA512 => Sha512::new_with_prefix(message).finalize().to_vec(),
+        CryptoAlgorithm::Sha1 => Sha1::new_with_prefix(message).finalize().to_vec(),
+        CryptoAlgorithm::Sha256 => Sha256::new_with_prefix(message).finalize().to_vec(),
+        CryptoAlgorithm::Sha384 => Sha384::new_with_prefix(message).finalize().to_vec(),
+        CryptoAlgorithm::Sha512 => Sha512::new_with_prefix(message).finalize().to_vec(),
         _ => return Err(Error::NotSupported(None)),
     };
 
@@ -158,10 +157,10 @@ pub(crate) fn verify(
     // Step 3. Let M be the result of performing the digest operation specified by hashAlgorithm
     // using message.
     let m = match hash_algorithm.name() {
-        ALG_SHA1 => Sha1::new_with_prefix(message).finalize().to_vec(),
-        ALG_SHA256 => Sha256::new_with_prefix(message).finalize().to_vec(),
-        ALG_SHA384 => Sha384::new_with_prefix(message).finalize().to_vec(),
-        ALG_SHA512 => Sha512::new_with_prefix(message).finalize().to_vec(),
+        CryptoAlgorithm::Sha1 => Sha1::new_with_prefix(message).finalize().to_vec(),
+        CryptoAlgorithm::Sha256 => Sha256::new_with_prefix(message).finalize().to_vec(),
+        CryptoAlgorithm::Sha384 => Sha384::new_with_prefix(message).finalize().to_vec(),
+        CryptoAlgorithm::Sha512 => Sha512::new_with_prefix(message).finalize().to_vec(),
         _ => return Err(Error::NotSupported(None)),
     };
 
@@ -310,7 +309,7 @@ pub(crate) fn generate_key(
     // Step 6. Set the namedCurve attribute of algorithm to equal the namedCurve member of
     // normalizedAlgorithm.
     let algorithm = SubtleEcKeyAlgorithm {
-        name: ALG_ECDSA.to_string(),
+        name: CryptoAlgorithm::Ecdsa,
         named_curve: normalized_algorithm.named_curve.clone(),
     };
 
@@ -490,7 +489,7 @@ pub(crate) fn import_key(
             // Step 2.16. Set the namedCurve attribute of algorithm to namedCurve.
             // Step 2.17. Set the [[algorithm]] internal slot of key to algorithm.
             let algorithm = SubtleEcKeyAlgorithm {
-                name: ALG_ECDSA.to_string(),
+                name: CryptoAlgorithm::Ecdsa,
                 named_curve: named_curve
                     .expect("named_curve must exist here")
                     .to_string(),
@@ -628,7 +627,7 @@ pub(crate) fn import_key(
             // Step 2.16. Set the namedCurve attribute of algorithm to namedCurve.
             // Step 2.17. Set the [[algorithm]] internal slot of key to algorithm.
             let algorithm = SubtleEcKeyAlgorithm {
-                name: ALG_ECDSA.to_string(),
+                name: CryptoAlgorithm::Ecdsa,
                 named_curve: named_curve
                     .expect("named_curve must exist here")
                     .to_string(),
@@ -863,7 +862,7 @@ pub(crate) fn import_key(
             // Step 2.13. Set the namedCurve attribute of algorithm to namedCurve.
             // Step 2.14. Set the [[algorithm]] internal slot of key to algorithm.
             let algorithm = SubtleEcKeyAlgorithm {
-                name: ALG_ECDSA.to_string(),
+                name: CryptoAlgorithm::Ecdsa,
                 named_curve,
             };
             CryptoKey::new(
@@ -943,7 +942,7 @@ pub(crate) fn import_key(
             // Step 2.6. Set the namedCurve attribute of algorithm to equal the namedCurve member
             // of normalizedAlgorithm.
             let algorithm = SubtleEcKeyAlgorithm {
-                name: ALG_ECDSA.to_string(),
+                name: CryptoAlgorithm::Ecdsa,
                 named_curve: normalized_algorithm.named_curve.clone(),
             };
 

--- a/components/script/dom/subtlecrypto/ed25519_operation.rs
+++ b/components/script/dom/subtlecrypto/ed25519_operation.rs
@@ -18,7 +18,7 @@ use crate::dom::bindings::str::DOMString;
 use crate::dom::cryptokey::{CryptoKey, Handle};
 use crate::dom::globalscope::GlobalScope;
 use crate::dom::subtlecrypto::{
-    ALG_ED25519, ExportedKey, JsonWebKeyExt, JwkStringField, KeyAlgorithmAndDerivatives,
+    CryptoAlgorithm, ExportedKey, JsonWebKeyExt, JwkStringField, KeyAlgorithmAndDerivatives,
     SubtleKeyAlgorithm,
 };
 
@@ -114,7 +114,7 @@ pub(crate) fn generate_key(
     // Step 3. Let algorithm be a new KeyAlgorithm object.
     // Step 4. Set the name attribute of algorithm to "Ed25519".
     let algorithm = SubtleKeyAlgorithm {
-        name: ALG_ED25519.to_string(),
+        name: CryptoAlgorithm::Ed25519,
     };
 
     // Step 5. Let publicKey be a new CryptoKey representing the public key of the generated key pair.
@@ -211,7 +211,7 @@ pub(crate) fn import_key(
             // Step 2.9. Let algorithm be a new KeyAlgorithm.
             // Step 2.10. Set the name attribute of algorithm to "Ed25519".
             let algorithm = SubtleKeyAlgorithm {
-                name: ALG_ED25519.to_string(),
+                name: CryptoAlgorithm::Ed25519,
             };
 
             // Step 2.7. Let key be a new CryptoKey that represents publicKey.
@@ -273,7 +273,7 @@ pub(crate) fn import_key(
             // Step 2.10. Let algorithm be a new KeyAlgorithm.
             // Step 2.11. Set the name attribute of algorithm to "Ed25519".
             let algorithm = SubtleKeyAlgorithm {
-                name: ALG_ED25519.to_string(),
+                name: CryptoAlgorithm::Ed25519,
             };
 
             // Step 2.8. Let key be a new CryptoKey that represents the Ed25519 private key
@@ -319,7 +319,7 @@ pub(crate) fn import_key(
             }
 
             // Step 2.4 If the crv field of jwk is not "Ed25519", then throw a DataError.
-            if jwk.crv.as_ref().is_none_or(|crv| crv != ALG_ED25519) {
+            if jwk.crv.as_ref().is_none_or(|crv| crv != "Ed25519") {
                 return Err(Error::Data(Some(
                     "The 'crv' field of the key is different from 'Ed25519'".into(),
                 )));
@@ -330,7 +330,7 @@ pub(crate) fn import_key(
             if jwk
                 .alg
                 .as_ref()
-                .is_some_and(|alg| !matches!(alg.str().as_ref(), ALG_ED25519 | "EdDSA"))
+                .is_some_and(|alg| !matches!(alg.str().as_ref(), "Ed25519" | "EdDSA"))
             {
                 return Err(Error::Data(Some(
                     "The 'alg' field is different from 'Ed25519' and 'EdDSA'".into(),
@@ -361,7 +361,7 @@ pub(crate) fn import_key(
             // Step 2.10. Let algorithm be a new instance of a KeyAlgorithm object.
             // Step 2.11. Set the name attribute of algorithm to "Ed25519".
             let algorithm = SubtleKeyAlgorithm {
-                name: ALG_ED25519.to_string(),
+                name: CryptoAlgorithm::Ed25519,
             };
 
             // Step 2.9
@@ -431,7 +431,7 @@ pub(crate) fn import_key(
             // Step 2.3. Let algorithm be a new KeyAlgorithm object.
             // Step 2.4. Set the name attribute of algorithm to "Ed25519".
             let algorithm = SubtleKeyAlgorithm {
-                name: ALG_ED25519.to_string(),
+                name: CryptoAlgorithm::Ed25519,
             };
 
             // Step 2.5. Let key be a new CryptoKey representing the key data provided in keyData.
@@ -551,8 +551,8 @@ pub(crate) fn export_key(format: KeyFormat, key: &CryptoKey) -> Result<ExportedK
             // Step 3.4. Set the crv attribute of jwk to "Ed25519".
             let mut jwk = JsonWebKey {
                 kty: Some(DOMString::from("OKP")),
-                alg: Some(DOMString::from(ALG_ED25519)),
-                crv: Some(DOMString::from(ALG_ED25519)),
+                alg: Some(DOMString::from("Ed25519")),
+                crv: Some(DOMString::from("Ed25519")),
                 ..Default::default()
             };
 

--- a/components/script/dom/subtlecrypto/hkdf_operation.rs
+++ b/components/script/dom/subtlecrypto/hkdf_operation.rs
@@ -14,8 +14,8 @@ use crate::dom::bindings::root::DomRoot;
 use crate::dom::cryptokey::{CryptoKey, Handle};
 use crate::dom::globalscope::GlobalScope;
 use crate::dom::subtlecrypto::{
-    ALG_HKDF, ALG_SHA1, ALG_SHA256, ALG_SHA384, ALG_SHA512, KeyAlgorithmAndDerivatives,
-    NormalizedAlgorithm, SubtleHkdfParams, SubtleKeyAlgorithm,
+    CryptoAlgorithm, KeyAlgorithmAndDerivatives, NormalizedAlgorithm, SubtleHkdfParams,
+    SubtleKeyAlgorithm,
 };
 
 /// <https://w3c.github.io/webcrypto/#hkdf-operations-derive-bits>
@@ -51,21 +51,30 @@ pub(crate) fn derive_bits(
     // Step 4. If the key derivation operation fails, then throw an OperationError.
     let mut result = vec![0u8; length as usize / 8];
     match normalized_algorithm.hash.name() {
-        ALG_SHA1 => Hkdf::<Sha1>::new(Some(&normalized_algorithm.salt), key_derivation_key)
-            .expand(&normalized_algorithm.info, &mut result)
-            .map_err(|error| Error::Operation(Some(error.to_string())))?,
-        ALG_SHA256 => Hkdf::<Sha256>::new(Some(&normalized_algorithm.salt), key_derivation_key)
-            .expand(&normalized_algorithm.info, &mut result)
-            .map_err(|error| Error::Operation(Some(error.to_string())))?,
-        ALG_SHA384 => Hkdf::<Sha384>::new(Some(&normalized_algorithm.salt), key_derivation_key)
-            .expand(&normalized_algorithm.info, &mut result)
-            .map_err(|error| Error::Operation(Some(error.to_string())))?,
-        ALG_SHA512 => Hkdf::<Sha512>::new(Some(&normalized_algorithm.salt), key_derivation_key)
-            .expand(&normalized_algorithm.info, &mut result)
-            .map_err(|error| Error::Operation(Some(error.to_string())))?,
+        CryptoAlgorithm::Sha1 => {
+            Hkdf::<Sha1>::new(Some(&normalized_algorithm.salt), key_derivation_key)
+                .expand(&normalized_algorithm.info, &mut result)
+                .map_err(|error| Error::Operation(Some(error.to_string())))?
+        },
+        CryptoAlgorithm::Sha256 => {
+            Hkdf::<Sha256>::new(Some(&normalized_algorithm.salt), key_derivation_key)
+                .expand(&normalized_algorithm.info, &mut result)
+                .map_err(|error| Error::Operation(Some(error.to_string())))?
+        },
+        CryptoAlgorithm::Sha384 => {
+            Hkdf::<Sha384>::new(Some(&normalized_algorithm.salt), key_derivation_key)
+                .expand(&normalized_algorithm.info, &mut result)
+                .map_err(|error| Error::Operation(Some(error.to_string())))?
+        },
+        CryptoAlgorithm::Sha512 => {
+            Hkdf::<Sha512>::new(Some(&normalized_algorithm.salt), key_derivation_key)
+                .expand(&normalized_algorithm.info, &mut result)
+                .map_err(|error| Error::Operation(Some(error.to_string())))?
+        },
         algorithm_name => {
             return Err(Error::Operation(Some(format!(
-                "Invalid hash algorithm: {algorithm_name}"
+                "Invalid hash algorithm: {}",
+                algorithm_name.as_str()
             ))));
         },
     }
@@ -110,7 +119,7 @@ pub(crate) fn import_key(
         // Step 2.6. Set the name attribute of algorithm to "HKDF".
         // Step 2.7. Set the [[algorithm]] internal slot of key to algorithm.
         let algorithm = SubtleKeyAlgorithm {
-            name: ALG_HKDF.to_string(),
+            name: CryptoAlgorithm::Hkdf,
         };
         let key = CryptoKey::new(
             cx,

--- a/components/script/dom/subtlecrypto/hmac_operation.rs
+++ b/components/script/dom/subtlecrypto/hmac_operation.rs
@@ -16,9 +16,9 @@ use crate::dom::bindings::root::DomRoot;
 use crate::dom::cryptokey::{CryptoKey, Handle};
 use crate::dom::globalscope::GlobalScope;
 use crate::dom::subtlecrypto::{
-    ALG_HMAC, ALG_SHA1, ALG_SHA256, ALG_SHA384, ALG_SHA512, ExportedKey, JsonWebKeyExt,
-    JwkStringField, KeyAlgorithmAndDerivatives, NormalizedAlgorithm, SubtleHmacImportParams,
-    SubtleHmacKeyAlgorithm, SubtleHmacKeyGenParams, SubtleKeyAlgorithm,
+    CryptoAlgorithm, ExportedKey, JsonWebKeyExt, JwkStringField, KeyAlgorithmAndDerivatives,
+    NormalizedAlgorithm, SubtleHmacImportParams, SubtleHmacKeyAlgorithm, SubtleHmacKeyGenParams,
+    SubtleKeyAlgorithm,
 };
 
 /// <https://w3c.github.io/webcrypto/#hmac-operations-sign>
@@ -28,11 +28,11 @@ pub(crate) fn sign(key: &CryptoKey, message: &[u8]) -> Result<Vec<u8>, Error> {
     // the hash function identified by the hash attribute of the [[algorithm]] internal slot of key
     // and message as the input data text.
     let hash_function = match key.algorithm() {
-        KeyAlgorithmAndDerivatives::HmacKeyAlgorithm(algo) => match algo.hash.name.as_str() {
-            ALG_SHA1 => hmac::HMAC_SHA1_FOR_LEGACY_USE_ONLY,
-            ALG_SHA256 => hmac::HMAC_SHA256,
-            ALG_SHA384 => hmac::HMAC_SHA384,
-            ALG_SHA512 => hmac::HMAC_SHA512,
+        KeyAlgorithmAndDerivatives::HmacKeyAlgorithm(algo) => match algo.hash.name {
+            CryptoAlgorithm::Sha1 => hmac::HMAC_SHA1_FOR_LEGACY_USE_ONLY,
+            CryptoAlgorithm::Sha256 => hmac::HMAC_SHA256,
+            CryptoAlgorithm::Sha384 => hmac::HMAC_SHA384,
+            CryptoAlgorithm::Sha512 => hmac::HMAC_SHA512,
             _ => return Err(Error::NotSupported(None)),
         },
         _ => return Err(Error::NotSupported(None)),
@@ -51,11 +51,11 @@ pub(crate) fn verify(key: &CryptoKey, message: &[u8], signature: &[u8]) -> Resul
     // the hash function identified by the hash attribute of the [[algorithm]] internal slot of key
     // and message as the input data text.
     let hash_function = match key.algorithm() {
-        KeyAlgorithmAndDerivatives::HmacKeyAlgorithm(algo) => match algo.hash.name.as_str() {
-            ALG_SHA1 => hmac::HMAC_SHA1_FOR_LEGACY_USE_ONLY,
-            ALG_SHA256 => hmac::HMAC_SHA256,
-            ALG_SHA384 => hmac::HMAC_SHA384,
-            ALG_SHA512 => hmac::HMAC_SHA512,
+        KeyAlgorithmAndDerivatives::HmacKeyAlgorithm(algo) => match algo.hash.name {
+            CryptoAlgorithm::Sha1 => hmac::HMAC_SHA1_FOR_LEGACY_USE_ONLY,
+            CryptoAlgorithm::Sha256 => hmac::HMAC_SHA256,
+            CryptoAlgorithm::Sha384 => hmac::HMAC_SHA384,
+            CryptoAlgorithm::Sha512 => hmac::HMAC_SHA512,
             _ => return Err(Error::NotSupported(None)),
         },
         _ => return Err(Error::NotSupported(None)),
@@ -118,10 +118,10 @@ pub(crate) fn generate_key(
     // normalizedAlgorithm.
     // Step 11. Set the hash attribute of algorithm to hash.
     let hash = SubtleKeyAlgorithm {
-        name: normalized_algorithm.hash.name().to_string(),
+        name: normalized_algorithm.hash.name(),
     };
     let algorithm = SubtleHmacKeyAlgorithm {
-        name: ALG_HMAC.to_string(),
+        name: CryptoAlgorithm::Hmac,
         hash,
         length,
     };
@@ -206,28 +206,28 @@ pub(crate) fn import_key(
             // Step 2.6.
             match hash.name() {
                 // If the name attribute of hash is "SHA-1":
-                ALG_SHA1 => {
+                CryptoAlgorithm::Sha1 => {
                     // If the alg field of jwk is present and is not "HS1", then throw a DataError.
                     if jwk.alg.as_ref().is_some_and(|alg| alg != "HS1") {
                         return Err(Error::Data(None));
                     }
                 },
                 // If the name attribute of hash is "SHA-256":
-                ALG_SHA256 => {
+                CryptoAlgorithm::Sha256 => {
                     // If the alg field of jwk is present and is not "HS256", then throw a DataError.
                     if jwk.alg.as_ref().is_some_and(|alg| alg != "HS256") {
                         return Err(Error::Data(None));
                     }
                 },
                 // If the name attribute of hash is "SHA-384":
-                ALG_SHA384 => {
+                CryptoAlgorithm::Sha384 => {
                     // If the alg field of jwk is present and is not "HS384", then throw a DataError.
                     if jwk.alg.as_ref().is_some_and(|alg| alg != "HS384") {
                         return Err(Error::Data(None));
                     }
                 },
                 // If the name attribute of hash is "SHA-512":
-                ALG_SHA512 => {
+                CryptoAlgorithm::Sha512 => {
                     // If the alg field of jwk is present and is not "HS512", then throw a DataError.
                     if jwk.alg.as_ref().is_some_and(|alg| alg != "HS512") {
                         return Err(Error::Data(None));
@@ -294,10 +294,8 @@ pub(crate) fn import_key(
     // Step 12. Set the length attribute of algorithm to length.
     // Step 13. Set the hash attribute of algorithm to hash.
     let algorithm = SubtleHmacKeyAlgorithm {
-        name: ALG_HMAC.to_string(),
-        hash: SubtleKeyAlgorithm {
-            name: hash.name().to_string(),
-        },
+        name: CryptoAlgorithm::Hmac,
+        hash: SubtleKeyAlgorithm { name: hash.name() },
         length,
     };
 
@@ -357,12 +355,14 @@ pub(crate) fn export_key(format: KeyFormat, key: &CryptoKey) -> Result<ExportedK
             //     format and key and obtaining alg.
             //     Set the alg attribute of jwk to alg.
             let hash_algorithm = match key.algorithm() {
-                KeyAlgorithmAndDerivatives::HmacKeyAlgorithm(alg) => match &*alg.hash.name {
-                    ALG_SHA1 => "HS1",
-                    ALG_SHA256 => "HS256",
-                    ALG_SHA384 => "HS384",
-                    ALG_SHA512 => "HS512",
-                    _ => return Err(Error::NotSupported(None)),
+                KeyAlgorithmAndDerivatives::HmacKeyAlgorithm(algorithm) => {
+                    match algorithm.hash.name {
+                        CryptoAlgorithm::Sha1 => "HS1",
+                        CryptoAlgorithm::Sha256 => "HS256",
+                        CryptoAlgorithm::Sha384 => "HS384",
+                        CryptoAlgorithm::Sha512 => "HS512",
+                        _ => return Err(Error::NotSupported(None)),
+                    }
                 },
                 _ => return Err(Error::NotSupported(None)),
             };
@@ -415,12 +415,12 @@ pub(crate) fn get_key_length(
 
 /// Return the block size in bits of a hash function, according to Figure 1 of
 /// <https://nvlpubs.nist.gov/nistpubs/FIPS/NIST.FIPS.180-4.pdf>.
-fn hash_function_block_size_in_bits(hash: &str) -> Result<u32, Error> {
+fn hash_function_block_size_in_bits(hash: CryptoAlgorithm) -> Result<u32, Error> {
     match hash {
-        ALG_SHA1 => Ok(512),
-        ALG_SHA256 => Ok(512),
-        ALG_SHA384 => Ok(1024),
-        ALG_SHA512 => Ok(1024),
+        CryptoAlgorithm::Sha1 => Ok(512),
+        CryptoAlgorithm::Sha256 => Ok(512),
+        CryptoAlgorithm::Sha384 => Ok(1024),
+        CryptoAlgorithm::Sha512 => Ok(1024),
         _ => Err(Error::NotSupported(Some(
             "Unidentified hash member".to_string(),
         ))),

--- a/components/script/dom/subtlecrypto/ml_dsa_operation.rs
+++ b/components/script/dom/subtlecrypto/ml_dsa_operation.rs
@@ -22,8 +22,8 @@ use crate::dom::bindings::str::DOMString;
 use crate::dom::cryptokey::{CryptoKey, Handle};
 use crate::dom::globalscope::GlobalScope;
 use crate::dom::subtlecrypto::{
-    ALG_ML_DSA_44, ALG_ML_DSA_65, ALG_ML_DSA_87, ExportedKey, JsonWebKeyExt, JwkStringField,
-    KeyAlgorithmAndDerivatives, SubtleAlgorithm, SubtleContextParams, SubtleKeyAlgorithm,
+    CryptoAlgorithm, ExportedKey, JsonWebKeyExt, JwkStringField, KeyAlgorithmAndDerivatives,
+    SubtleAlgorithm, SubtleContextParams, SubtleKeyAlgorithm,
 };
 
 /// Object Identifier (OID) of ML-DSA-44
@@ -145,8 +145,8 @@ pub(crate) fn sign(
     // of normalizedAlgorithm, using the ML-DSA private key associated with key as sk, message as M
     // and context as ctx.
     // Step 4. If the ML-DSA.Sign algorithm returned an error, return an OperationError.
-    let result = match normalized_algorithm.name.as_str() {
-        ALG_ML_DSA_44 => {
+    let result = match normalized_algorithm.name {
+        CryptoAlgorithm::MlDsa44 => {
             let Handle::MlDsa44PrivateKey(seed) = key.handle() else {
                 return Err(Error::Operation(Some(
                     "The key handle is not representing an ML-DSA-44 private key".to_string(),
@@ -161,7 +161,7 @@ pub(crate) fn sign(
                 .encode()
                 .to_vec()
         },
-        ALG_ML_DSA_65 => {
+        CryptoAlgorithm::MlDsa65 => {
             let Handle::MlDsa65PrivateKey(seed) = key.handle() else {
                 return Err(Error::Operation(Some(
                     "The key handle is not representing an ML-DSA-65 private key".to_string(),
@@ -176,7 +176,7 @@ pub(crate) fn sign(
                 .encode()
                 .to_vec()
         },
-        ALG_ML_DSA_87 => {
+        CryptoAlgorithm::MlDsa87 => {
             let Handle::MlDsa87PrivateKey(seed) = key.handle() else {
                 return Err(Error::Operation(Some(
                     "The key handle is not representing an ML-DSA-87 private key".to_string(),
@@ -227,8 +227,8 @@ pub(crate) fn verify(
     // of normalizedAlgorithm, using the ML-DSA public key associated with key as pk, message as M,
     // signature as σ and context as ctx.
     // Step 4. If the ML-DSA.Verify algorithm returned an error, return an OperationError.
-    let result = match normalized_algorithm.name.as_str() {
-        ALG_ML_DSA_44 => {
+    let result = match normalized_algorithm.name {
+        CryptoAlgorithm::MlDsa44 => {
             let Handle::MlDsa44PublicKey(public_key) = key.handle() else {
                 return Err(Error::Operation(Some(
                     "The key handle is not representing an ML-DSA-44 public key".to_string(),
@@ -242,7 +242,7 @@ pub(crate) fn verify(
                 Err(_) => false,
             }
         },
-        ALG_ML_DSA_65 => {
+        CryptoAlgorithm::MlDsa65 => {
             let Handle::MlDsa65PublicKey(public_key) = key.handle() else {
                 return Err(Error::Operation(Some(
                     "The key handle is not representing an ML-DSA-65 public key".to_string(),
@@ -256,7 +256,7 @@ pub(crate) fn verify(
                 Err(_) => false,
             }
         },
-        ALG_ML_DSA_87 => {
+        CryptoAlgorithm::MlDsa87 => {
             let Handle::MlDsa87PublicKey(public_key) = key.handle() else {
                 return Err(Error::Operation(Some(
                     "The key handle is not representing an ML-DSA-87 public key".to_string(),
@@ -307,12 +307,12 @@ pub(crate) fn generate_key(
     let mut seed_bytes = vec![0u8; 32];
     OsRng.fill_bytes(&mut seed_bytes);
     let (private_key_handle, public_key_handle) =
-        convert_seed_to_handles(&normalized_algorithm.name, &seed_bytes, None, None)?;
+        convert_seed_to_handles(normalized_algorithm.name, &seed_bytes, None, None)?;
 
     // Step 4. Let algorithm be a new KeyAlgorithm object.
     // Step 5. Set the name attribute of algorithm to the name attribute of normalizedAlgorithm.
     let algorithm = SubtleKeyAlgorithm {
-        name: normalized_algorithm.name.clone(),
+        name: normalized_algorithm.name,
     };
 
     // Step 6. Let publicKey be a new CryptoKey representing the public key of the generated key
@@ -411,10 +411,10 @@ pub(crate) fn import_key(
             //     Let expectedOid be id-ml-dsa-87 (2.16.840.1.101.3.4.3.19).
             // Otherwise:
             //     throw a NotSupportedError.
-            let expected_oid = match normalized_algorithm.name.as_str() {
-                ALG_ML_DSA_44 => ObjectIdentifier::new_unwrap(ID_ALG_ML_DSA_44),
-                ALG_ML_DSA_65 => ObjectIdentifier::new_unwrap(ID_ALG_ML_DSA_65),
-                ALG_ML_DSA_87 => ObjectIdentifier::new_unwrap(ID_ALG_ML_DSA_87),
+            let expected_oid = match normalized_algorithm.name {
+                CryptoAlgorithm::MlDsa44 => ObjectIdentifier::new_unwrap(ID_ALG_ML_DSA_44),
+                CryptoAlgorithm::MlDsa65 => ObjectIdentifier::new_unwrap(ID_ALG_ML_DSA_65),
+                CryptoAlgorithm::MlDsa87 => ObjectIdentifier::new_unwrap(ID_ALG_ML_DSA_87),
                 _ => {
                     return Err(Error::NotSupported(Some(format!(
                         "{} is not an ML-DSA algorithm",
@@ -445,7 +445,7 @@ pub(crate) fn import_key(
             let key_bytes = spki.subject_public_key.as_bytes().ok_or(Error::Data(Some(
                 "Failed to parse byte sequence over SubjectPublicKey field of spki".to_string(),
             )))?;
-            let public_key = convert_public_key_to_handle(&normalized_algorithm.name, key_bytes)?;
+            let public_key = convert_public_key_to_handle(normalized_algorithm.name, key_bytes)?;
 
             // Step 2.8. Let key be a new CryptoKey that represents publicKey.
             // Step 2.9. Set the [[type]] internal slot of key to "public"
@@ -454,7 +454,7 @@ pub(crate) fn import_key(
             // normalizedAlgorithm.
             // Step 2.12. Set the [[algorithm]] internal slot of key to algorithm.
             let algorithm = SubtleKeyAlgorithm {
-                name: normalized_algorithm.name.clone(),
+                name: normalized_algorithm.name,
             };
             CryptoKey::new(
                 cx,
@@ -496,10 +496,10 @@ pub(crate) fn import_key(
             //     Let asn1Structure be the ASN.1 ML-DSA-87-PrivateKey structure.
             // Otherwise:
             //     throw a NotSupportedError.
-            let expected_oid = match normalized_algorithm.name.as_str() {
-                ALG_ML_DSA_44 => ObjectIdentifier::new_unwrap(ID_ALG_ML_DSA_44),
-                ALG_ML_DSA_65 => ObjectIdentifier::new_unwrap(ID_ALG_ML_DSA_65),
-                ALG_ML_DSA_87 => ObjectIdentifier::new_unwrap(ID_ALG_ML_DSA_87),
+            let expected_oid = match normalized_algorithm.name {
+                CryptoAlgorithm::MlDsa44 => ObjectIdentifier::new_unwrap(ID_ALG_ML_DSA_44),
+                CryptoAlgorithm::MlDsa65 => ObjectIdentifier::new_unwrap(ID_ALG_ML_DSA_65),
+                CryptoAlgorithm::MlDsa87 => ObjectIdentifier::new_unwrap(ID_ALG_ML_DSA_87),
                 _ => {
                     return Err(Error::NotSupported(Some(format!(
                         "{} is not an ML-DSA algorithm",
@@ -548,7 +548,7 @@ pub(crate) fn import_key(
             let ml_dsa_private_key = match private_key_structure {
                 MlDsaPrivateKeyStructure::Seed(seed) => {
                     let (private_key_handle, _public_key_handle) = convert_seed_to_handles(
-                        &normalized_algorithm.name,
+                        normalized_algorithm.name,
                         seed.as_bytes(),
                         None,
                         None,
@@ -563,7 +563,7 @@ pub(crate) fn import_key(
                 },
                 MlDsaPrivateKeyStructure::Both(both) => {
                     let (private_key_handle, _public_key_handle) = convert_seed_to_handles(
-                        &normalized_algorithm.name,
+                        normalized_algorithm.name,
                         both.seed.as_bytes(),
                         Some(both.expanded_key.as_bytes()),
                         None,
@@ -580,7 +580,7 @@ pub(crate) fn import_key(
             // normalizedAlgorithm.
             // Step 2.13. Set the [[algorithm]] internal slot of key to algorithm.
             let algorithm = SubtleKeyAlgorithm {
-                name: normalized_algorithm.name.clone(),
+                name: normalized_algorithm.name,
             };
             CryptoKey::new(
                 cx,
@@ -608,9 +608,9 @@ pub(crate) fn import_key(
             // Step 2.5. Set the [[type]] internal slot of key to "public"
             // Step 2.6. Set the [[algorithm]] internal slot of key to algorithm.
             let public_key_handle =
-                convert_public_key_to_handle(&normalized_algorithm.name, key_data)?;
+                convert_public_key_to_handle(normalized_algorithm.name, key_data)?;
             let algorithm = SubtleKeyAlgorithm {
-                name: normalized_algorithm.name.clone(),
+                name: normalized_algorithm.name,
             };
             CryptoKey::new(
                 cx,
@@ -639,7 +639,7 @@ pub(crate) fn import_key(
             // function described in Section 6.1 of [FIPS-204] with the parameter set indicated by
             // the name member of normalizedAlgorithm, using data as ξ.
             let (private_key_handle, _public_key_handle) =
-                convert_seed_to_handles(&normalized_algorithm.name, data, None, None)?;
+                convert_seed_to_handles(normalized_algorithm.name, data, None, None)?;
 
             // Step 2.5. Let key be a new CryptoKey that represents the ML-DSA private key
             // identified by privateKey.
@@ -649,7 +649,7 @@ pub(crate) fn import_key(
             // normalizedAlgorithm.
             // Step 2.9. Set the [[algorithm]] internal slot of key to algorithm.
             let algorithm = SubtleKeyAlgorithm {
-                name: normalized_algorithm.name.clone(),
+                name: normalized_algorithm.name,
             };
             CryptoKey::new(
                 cx,
@@ -748,13 +748,13 @@ pub(crate) fn import_key(
                 // DataError.
                 let pub_bytes = jwk.decode_required_string_field(JwkStringField::Pub)?;
                 let (private_key_handle, _public_key_handle) = convert_seed_to_handles(
-                    &normalized_algorithm.name,
+                    normalized_algorithm.name,
                     &priv_bytes,
                     None,
                     Some(&pub_bytes),
                 )?;
                 let algorithm = SubtleKeyAlgorithm {
-                    name: normalized_algorithm.name.clone(),
+                    name: normalized_algorithm.name,
                 };
                 CryptoKey::new(
                     cx,
@@ -777,9 +777,9 @@ pub(crate) fn import_key(
                 // public key.
                 // Step 2.8.3. Set the [[type]] internal slot of key to "public".
                 let public_key_handle =
-                    convert_public_key_to_handle(&normalized_algorithm.name, &pub_bytes)?;
+                    convert_public_key_to_handle(normalized_algorithm.name, &pub_bytes)?;
                 let algorithm = SubtleKeyAlgorithm {
-                    name: normalized_algorithm.name.clone(),
+                    name: normalized_algorithm.name,
                 };
                 CryptoKey::new(
                     cx,
@@ -853,10 +853,10 @@ pub(crate) fn export_key(format: KeyFormat, key: &CryptoKey) -> Result<ExportedK
             //             throw a NotSupportedError.
             //
             //     Set the subjectPublicKey field to keyData.
-            let oid = match key_algorithm.name.as_str() {
-                ALG_ML_DSA_44 => ID_ALG_ML_DSA_44,
-                ALG_ML_DSA_65 => ID_ALG_ML_DSA_65,
-                ALG_ML_DSA_87 => ID_ALG_ML_DSA_87,
+            let oid = match key_algorithm.name {
+                CryptoAlgorithm::MlDsa44 => ID_ALG_ML_DSA_44,
+                CryptoAlgorithm::MlDsa65 => ID_ALG_ML_DSA_65,
+                CryptoAlgorithm::MlDsa87 => ID_ALG_ML_DSA_87,
                 _ => {
                     return Err(Error::Operation(Some(format!(
                         "{} is not an ML-DSA algorithm",
@@ -951,10 +951,10 @@ pub(crate) fn export_key(format: KeyFormat, key: &CryptoKey) -> Result<ExportedK
             //
             //         Otherwise:
             //             throw a NotSupportedError.
-            let oid = match key_algorithm.name.as_str() {
-                ALG_ML_DSA_44 => ID_ALG_ML_DSA_44,
-                ALG_ML_DSA_65 => ID_ALG_ML_DSA_65,
-                ALG_ML_DSA_87 => ID_ALG_ML_DSA_87,
+            let oid = match key_algorithm.name {
+                CryptoAlgorithm::MlDsa44 => ID_ALG_ML_DSA_44,
+                CryptoAlgorithm::MlDsa65 => ID_ALG_ML_DSA_65,
+                CryptoAlgorithm::MlDsa87 => ID_ALG_ML_DSA_87,
                 _ => {
                     return Err(Error::Operation(Some(format!(
                         "{} is not an ML-DSA algorithm",
@@ -1088,7 +1088,7 @@ pub(crate) fn export_key(format: KeyFormat, key: &CryptoKey) -> Result<ExportedK
 /// If the length in bits of seed bytes is not 256, the conversion fails, or the consistency check
 /// fails, throw a DataError.
 fn convert_seed_to_handles(
-    algo_name: &str,
+    algorithm_name: CryptoAlgorithm,
     seed_bytes: &[u8],
     private_key_bytes: Option<&[u8]>,
     public_key_bytes: Option<&[u8]>,
@@ -1102,8 +1102,8 @@ fn convert_seed_to_handles(
     let seed: B32 = seed_bytes
         .try_into()
         .map_err(|_| Error::Data(Some("Failed to parse the seed bytes".to_string())))?;
-    let handles = match algo_name {
-        ALG_ML_DSA_44 => {
+    let handles = match algorithm_name {
+        CryptoAlgorithm::MlDsa44 => {
             let key_pair = MlDsa44::key_gen_internal(&seed);
             if let Some(private_key_bytes) = private_key_bytes {
                 if private_key_bytes != key_pair.signing_key().encode().as_slice() {
@@ -1125,7 +1125,7 @@ fn convert_seed_to_handles(
                 Handle::MlDsa44PublicKey(Box::new(key_pair.verifying_key().encode())),
             )
         },
-        ALG_ML_DSA_65 => {
+        CryptoAlgorithm::MlDsa65 => {
             let key_pair = MlDsa65::key_gen_internal(&seed);
             if let Some(private_key_bytes) = private_key_bytes {
                 if private_key_bytes != key_pair.signing_key().encode().as_slice() {
@@ -1147,7 +1147,7 @@ fn convert_seed_to_handles(
                 Handle::MlDsa65PublicKey(Box::new(key_pair.verifying_key().encode())),
             )
         },
-        ALG_ML_DSA_87 => {
+        CryptoAlgorithm::MlDsa87 => {
             let key_pair = MlDsa87::key_gen_internal(&seed);
             if let Some(private_key_bytes) = private_key_bytes {
                 if private_key_bytes != key_pair.signing_key().encode().as_slice() {
@@ -1172,7 +1172,7 @@ fn convert_seed_to_handles(
         _ => {
             return Err(Error::NotSupported(Some(format!(
                 "{} is not an ML-DSA algorithm",
-                algo_name
+                algorithm_name.as_str()
             ))));
         },
     };
@@ -1182,19 +1182,22 @@ fn convert_seed_to_handles(
 
 /// Convert public key bytes to an ML-DSA public key handle. If the conversion fails, throw a
 /// DataError.
-fn convert_public_key_to_handle(algo_name: &str, public_key_bytes: &[u8]) -> Result<Handle, Error> {
-    let public_key_handle = match algo_name {
-        ALG_ML_DSA_44 => {
+fn convert_public_key_to_handle(
+    algorithm_name: CryptoAlgorithm,
+    public_key_bytes: &[u8],
+) -> Result<Handle, Error> {
+    let public_key_handle = match algorithm_name {
+        CryptoAlgorithm::MlDsa44 => {
             let encoded_verifying_key = EncodedVerifyingKey::<MlDsa44>::try_from(public_key_bytes)
                 .map_err(|_| Error::Data(Some("Failed to parse ML-DSA public key".to_string())))?;
             Handle::MlDsa44PublicKey(Box::new(encoded_verifying_key))
         },
-        ALG_ML_DSA_65 => {
+        CryptoAlgorithm::MlDsa65 => {
             let encoded_verifying_key = EncodedVerifyingKey::<MlDsa65>::try_from(public_key_bytes)
                 .map_err(|_| Error::Data(Some("Failed to parse ML-DSA public key".to_string())))?;
             Handle::MlDsa65PublicKey(Box::new(encoded_verifying_key))
         },
-        ALG_ML_DSA_87 => {
+        CryptoAlgorithm::MlDsa87 => {
             let encoded_verifying_key = EncodedVerifyingKey::<MlDsa87>::try_from(public_key_bytes)
                 .map_err(|_| Error::Data(Some("Failed to parse ML-DSA public key".to_string())))?;
             Handle::MlDsa87PublicKey(Box::new(encoded_verifying_key))
@@ -1202,7 +1205,7 @@ fn convert_public_key_to_handle(algo_name: &str, public_key_bytes: &[u8]) -> Res
         _ => {
             return Err(Error::NotSupported(Some(format!(
                 "{} is not an ML-DSA algorithm",
-                algo_name
+                algorithm_name.as_str()
             ))));
         },
     };

--- a/components/script/dom/subtlecrypto/ml_kem_operation.rs
+++ b/components/script/dom/subtlecrypto/ml_kem_operation.rs
@@ -24,8 +24,8 @@ use crate::dom::bindings::str::DOMString;
 use crate::dom::cryptokey::{CryptoKey, Handle};
 use crate::dom::globalscope::GlobalScope;
 use crate::dom::subtlecrypto::{
-    ALG_ML_KEM_512, ALG_ML_KEM_768, ALG_ML_KEM_1024, ExportedKey, JsonWebKeyExt, JwkStringField,
-    KeyAlgorithmAndDerivatives, SubtleAlgorithm, SubtleEncapsulatedBits, SubtleKeyAlgorithm,
+    CryptoAlgorithm, ExportedKey, JsonWebKeyExt, JwkStringField, KeyAlgorithmAndDerivatives,
+    SubtleAlgorithm, SubtleEncapsulatedBits, SubtleKeyAlgorithm,
 };
 
 /// Object Identifier (OID) of MK-KEM-512
@@ -146,8 +146,8 @@ pub(crate) fn encapsulate(
     // indicated by the name member of algorithm, using the key represented by the [[handle]]
     // internal slot of key as the ek input parameter.
     // Step 5. If the ML-KEM.Encaps function returned an error, return an OperationError.
-    let (shared_key, ciphertext) = match normalized_algorithm.name.as_str() {
-        ALG_ML_KEM_512 => {
+    let (shared_key, ciphertext) = match normalized_algorithm.name {
+        CryptoAlgorithm::MlKem512 => {
             let Handle::MlKem512PublicKey(encoded_ek) = key.handle() else {
                 return Err(Error::Operation(Some(
                     "The key handle is not representing an ML-KEM-512 public key".to_string(),
@@ -159,7 +159,7 @@ pub(crate) fn encapsulate(
             })?;
             (shared_key.to_vec(), encoded_ciphertext.to_vec())
         },
-        ALG_ML_KEM_768 => {
+        CryptoAlgorithm::MlKem768 => {
             let Handle::MlKem768PublicKey(encoded_ek) = key.handle() else {
                 return Err(Error::Operation(Some(
                     "The key handle is not representing an ML-KEM-768 public key".to_string(),
@@ -171,7 +171,7 @@ pub(crate) fn encapsulate(
             })?;
             (shared_key.to_vec(), encoded_ciphertext.to_vec())
         },
-        ALG_ML_KEM_1024 => {
+        CryptoAlgorithm::MlKem1024 => {
             let Handle::MlKem1024PublicKey(encoded_ek) = key.handle() else {
                 return Err(Error::Operation(Some(
                     "The key handle is not representing an ML-KEM-1024 public key".to_string(),
@@ -228,8 +228,8 @@ pub(crate) fn decapsulate(
     // described in Section 7.3 of [FIPS-203] with the parameter set indicated by the name member
     // of algorithm, using the key represented by the [[handle]] internal slot of key as the dk
     // input parameter, and ciphertext as the c input parameter.
-    let shared_key = match normalized_algorithm.name.as_str() {
-        ALG_ML_KEM_512 => {
+    let shared_key = match normalized_algorithm.name {
+        CryptoAlgorithm::MlKem512 => {
             let Handle::MlKem512PrivateKey(seed) = key.handle() else {
                 return Err(Error::Operation(Some(
                     "The key handle is not representing an ML-KEM-512 private key".to_string(),
@@ -245,7 +245,7 @@ pub(crate) fn decapsulate(
                 })?
                 .to_vec()
         },
-        ALG_ML_KEM_768 => {
+        CryptoAlgorithm::MlKem768 => {
             let Handle::MlKem768PrivateKey(seed) = key.handle() else {
                 return Err(Error::Operation(Some(
                     "The key handle is not representing an ML-KEM-768 private key".to_string(),
@@ -261,7 +261,7 @@ pub(crate) fn decapsulate(
                 })?
                 .to_vec()
         },
-        ALG_ML_KEM_1024 => {
+        CryptoAlgorithm::MlKem1024 => {
             let Handle::MlKem1024PrivateKey(seed) = key.handle() else {
                 return Err(Error::Operation(Some(
                     "The key handle is not representing an ML-KEM-1024 private key".to_string(),
@@ -321,12 +321,12 @@ pub(crate) fn generate_key(
     let mut seed_bytes = vec![0u8; 64];
     OsRng.fill_bytes(&mut seed_bytes);
     let (private_key_handle, public_key_handle) =
-        convert_seed_to_handles(&normalized_algorithm.name, &seed_bytes, None, None)?;
+        convert_seed_to_handles(normalized_algorithm.name, &seed_bytes, None, None)?;
 
     // Step 4. Let algorithm be a new KeyAlgorithm object.
     // Step 5. Set the name attribute of algorithm to the name attribute of normalizedAlgorithm.
     let algorithm = SubtleKeyAlgorithm {
-        name: normalized_algorithm.name.clone(),
+        name: normalized_algorithm.name,
     };
 
     // Step 6. Let publicKey be a new CryptoKey representing the encapsulation key of the generated
@@ -362,7 +362,7 @@ pub(crate) fn generate_key(
         global,
         KeyType::Private,
         extractable,
-        KeyAlgorithmAndDerivatives::KeyAlgorithm(algorithm.clone()),
+        KeyAlgorithmAndDerivatives::KeyAlgorithm(algorithm),
         usages
             .iter()
             .filter(|usage| matches!(usage, KeyUsage::DecapsulateKey | KeyUsage::DecapsulateBits))
@@ -431,10 +431,10 @@ pub(crate) fn import_key(
             //     Let expectedOid be id-alg-ml-kem-1024 (2.16.840.1.101.3.4.4.3).
             // Otherwise:
             //     throw a NotSupportedError.
-            let expected_oid = match normalized_algorithm.name.as_str() {
-                ALG_ML_KEM_512 => ObjectIdentifier::new_unwrap(ID_ALG_ML_KEM_512),
-                ALG_ML_KEM_768 => ObjectIdentifier::new_unwrap(ID_ALG_ML_KEM_768),
-                ALG_ML_KEM_1024 => ObjectIdentifier::new_unwrap(ID_ALG_ML_KEM_1024),
+            let expected_oid = match normalized_algorithm.name {
+                CryptoAlgorithm::MlKem512 => ObjectIdentifier::new_unwrap(ID_ALG_ML_KEM_512),
+                CryptoAlgorithm::MlKem768 => ObjectIdentifier::new_unwrap(ID_ALG_ML_KEM_768),
+                CryptoAlgorithm::MlKem1024 => ObjectIdentifier::new_unwrap(ID_ALG_ML_KEM_1024),
                 _ => {
                     return Err(Error::NotSupported(Some(format!(
                         "{} is not an ML-KEM algorithm",
@@ -465,7 +465,7 @@ pub(crate) fn import_key(
             let key_bytes = spki.subject_public_key.as_bytes().ok_or(Error::Data(Some(
                 "Fail to parse byte sequence over SubjectPublicKey field of spki".to_string(),
             )))?;
-            let public_key = convert_public_key_to_handle(&normalized_algorithm.name, key_bytes)?;
+            let public_key = convert_public_key_to_handle(normalized_algorithm.name, key_bytes)?;
 
             // Step 2.8. Let key be a new CryptoKey that represents publicKey.
             // Step 2.9. Set the [[type]] internal slot of key to "public"
@@ -474,7 +474,7 @@ pub(crate) fn import_key(
             // normalizedAlgorithm.
             // Step 2.12. Set the [[algorithm]] internal slot of key to algorithm.
             let algorithm = SubtleKeyAlgorithm {
-                name: normalized_algorithm.name.clone(),
+                name: normalized_algorithm.name,
             };
             CryptoKey::new(
                 cx,
@@ -522,10 +522,10 @@ pub(crate) fn import_key(
             //     Let asn1Structure be the ASN.1 ML-KEM-1024-PrivateKey structure.
             // Otherwise:
             //     throw a NotSupportedError.
-            let expected_oid = match normalized_algorithm.name.as_str() {
-                ALG_ML_KEM_512 => ObjectIdentifier::new_unwrap(ID_ALG_ML_KEM_512),
-                ALG_ML_KEM_768 => ObjectIdentifier::new_unwrap(ID_ALG_ML_KEM_768),
-                ALG_ML_KEM_1024 => ObjectIdentifier::new_unwrap(ID_ALG_ML_KEM_1024),
+            let expected_oid = match normalized_algorithm.name {
+                CryptoAlgorithm::MlKem512 => ObjectIdentifier::new_unwrap(ID_ALG_ML_KEM_512),
+                CryptoAlgorithm::MlKem768 => ObjectIdentifier::new_unwrap(ID_ALG_ML_KEM_768),
+                CryptoAlgorithm::MlKem1024 => ObjectIdentifier::new_unwrap(ID_ALG_ML_KEM_1024),
                 _ => {
                     return Err(Error::NotSupported(Some(format!(
                         "{} is not an ML-KEM algorithm",
@@ -574,7 +574,7 @@ pub(crate) fn import_key(
             let ml_kem_private_key = match private_key_structure {
                 MlKemPrivateKeyStructure::Seed(seed) => {
                     let (private_key_handle, _) = convert_seed_to_handles(
-                        &normalized_algorithm.name,
+                        normalized_algorithm.name,
                         seed.as_bytes(),
                         None,
                         None,
@@ -589,7 +589,7 @@ pub(crate) fn import_key(
                 },
                 MlKemPrivateKeyStructure::Both(both) => {
                     let (private_key_handle, _) = convert_seed_to_handles(
-                        &normalized_algorithm.name,
+                        normalized_algorithm.name,
                         both.seed.as_bytes(),
                         Some(both.expanded_key.as_bytes()),
                         None,
@@ -606,7 +606,7 @@ pub(crate) fn import_key(
             // normalizedAlgorithm.
             // Step 2.13. Set the [[algorithm]] internal slot of key to algorithm.
             let algorithm = SubtleKeyAlgorithm {
-                name: normalized_algorithm.name.clone(),
+                name: normalized_algorithm.name,
             };
             CryptoKey::new(
                 cx,
@@ -642,9 +642,9 @@ pub(crate) fn import_key(
             // normalizedAlgorithm.
             // Step 2.7. Set the [[algorithm]] internal slot of key to algorithm.
             let public_key_handle =
-                convert_public_key_to_handle(&normalized_algorithm.name, key_data)?;
+                convert_public_key_to_handle(normalized_algorithm.name, key_data)?;
             let algorithm = SubtleKeyAlgorithm {
-                name: normalized_algorithm.name.clone(),
+                name: normalized_algorithm.name,
             };
             CryptoKey::new(
                 cx,
@@ -680,7 +680,7 @@ pub(crate) fn import_key(
             // the name member of normalizedAlgorithm, using the first 256 bits of data as d and
             // the last 256 bits of data as z.
             let (private_key_handle, _) =
-                convert_seed_to_handles(&normalized_algorithm.name, data, None, None)?;
+                convert_seed_to_handles(normalized_algorithm.name, data, None, None)?;
 
             // Step 2.5. Let key be a new CryptoKey that represents the ML-KEM private key
             // identified by privateKey.
@@ -690,7 +690,7 @@ pub(crate) fn import_key(
             // normalizedAlgorithm.
             // Step 2.9. Set the [[algorithm]] internal slot of key to algorithm.
             let algorithm = SubtleKeyAlgorithm {
-                name: normalized_algorithm.name.clone(),
+                name: normalized_algorithm.name,
             };
             CryptoKey::new(
                 cx,
@@ -749,8 +749,8 @@ pub(crate) fn import_key(
             // Step 2.5. If the alg field of jwk is not one of the alg values corresponding to the
             // name member of normalizedAlgorithm indicated in Section 8 of
             // [draft-ietf-jose-pqc-kem-01] (Figure 1 or 2), then throw a DataError.
-            match normalized_algorithm.name.as_str() {
-                ALG_ML_KEM_512 => {
+            match normalized_algorithm.name {
+                CryptoAlgorithm::MlKem512 => {
                     if jwk
                         .alg
                         .as_ref()
@@ -761,7 +761,7 @@ pub(crate) fn import_key(
                         )));
                     }
                 },
-                ALG_ML_KEM_768 => {
+                CryptoAlgorithm::MlKem768 => {
                     if jwk
                         .alg
                         .as_ref()
@@ -772,7 +772,7 @@ pub(crate) fn import_key(
                         )));
                     }
                 },
-                ALG_ML_KEM_1024 => {
+                CryptoAlgorithm::MlKem1024 => {
                     if jwk
                         .alg
                         .as_ref()
@@ -833,7 +833,7 @@ pub(crate) fn import_key(
                 // NOTE: Completed in Step 2.10 - 2.12.
                 let pub_bytes = jwk.decode_required_string_field(JwkStringField::Pub)?;
                 let (private_key_handle, _) = convert_seed_to_handles(
-                    &normalized_algorithm.name,
+                    normalized_algorithm.name,
                     &priv_bytes,
                     None,
                     Some(&pub_bytes),
@@ -853,7 +853,7 @@ pub(crate) fn import_key(
                 // Step 2.9.3. Set the [[type]] internal slot of Key to "public".
                 // NOTE: Completed in Step 2.10 - 2.12.
                 let public_key_handle =
-                    convert_public_key_to_handle(&normalized_algorithm.name, &pub_bytes)?;
+                    convert_public_key_to_handle(normalized_algorithm.name, &pub_bytes)?;
 
                 (KeyType::Public, public_key_handle)
             };
@@ -863,7 +863,7 @@ pub(crate) fn import_key(
             // normalizedAlgorithm.
             // Step 2.12. Set the [[algorithm]] internal slot of key to algorithm.
             let algorithm = SubtleKeyAlgorithm {
-                name: normalized_algorithm.name.clone(),
+                name: normalized_algorithm.name,
             };
             CryptoKey::new(
                 cx,
@@ -935,10 +935,10 @@ pub(crate) fn export_key(format: KeyFormat, key: &CryptoKey) -> Result<ExportedK
             //             throw a NotSupportedError.
             //
             //     Set the subjectPublicKey field to keyData.
-            let oid = match key_algorithm.name.as_str() {
-                ALG_ML_KEM_512 => ID_ALG_ML_KEM_512,
-                ALG_ML_KEM_768 => ID_ALG_ML_KEM_768,
-                ALG_ML_KEM_1024 => ID_ALG_ML_KEM_1024,
+            let oid = match key_algorithm.name {
+                CryptoAlgorithm::MlKem512 => ID_ALG_ML_KEM_512,
+                CryptoAlgorithm::MlKem768 => ID_ALG_ML_KEM_768,
+                CryptoAlgorithm::MlKem1024 => ID_ALG_ML_KEM_1024,
                 _ => {
                     return Err(Error::Operation(Some(format!(
                         "{} is not an ML-KEM algorithm",
@@ -1034,10 +1034,10 @@ pub(crate) fn export_key(format: KeyFormat, key: &CryptoKey) -> Result<ExportedK
             //
             //         Otherwise:
             //             throw a NotSupportedError.
-            let oid = match key_algorithm.name.as_str() {
-                ALG_ML_KEM_512 => ID_ALG_ML_KEM_512,
-                ALG_ML_KEM_768 => ID_ALG_ML_KEM_768,
-                ALG_ML_KEM_1024 => ID_ALG_ML_KEM_1024,
+            let oid = match key_algorithm.name {
+                CryptoAlgorithm::MlKem512 => ID_ALG_ML_KEM_512,
+                CryptoAlgorithm::MlKem768 => ID_ALG_ML_KEM_768,
+                CryptoAlgorithm::MlKem1024 => ID_ALG_ML_KEM_1024,
                 _ => {
                     return Err(Error::Operation(Some(format!(
                         "{} is not an ML-KEM algorithm",
@@ -1131,10 +1131,10 @@ pub(crate) fn export_key(format: KeyFormat, key: &CryptoKey) -> Result<ExportedK
             // (Figure 1).
             //
             // <https://www.ietf.org/archive/id/draft-ietf-jose-pqc-kem-01.html#direct-table>
-            let alg = match key_algorithm.name.as_str() {
-                ALG_ML_KEM_512 => "MLKEM512",
-                ALG_ML_KEM_768 => "MLKEM768",
-                ALG_ML_KEM_1024 => "MLKEM1024",
+            let alg = match key_algorithm.name {
+                CryptoAlgorithm::MlKem512 => "MLKEM512",
+                CryptoAlgorithm::MlKem768 => "MLKEM768",
+                CryptoAlgorithm::MlKem1024 => "MLKEM1024",
                 _ => {
                     return Err(Error::Operation(Some(format!(
                         "{} is not an ML-KEM algorithm",
@@ -1187,7 +1187,7 @@ pub(crate) fn export_key(format: KeyFormat, key: &CryptoKey) -> Result<ExportedK
 /// If the length in bits of seed bytes is not 512, the conversion fails, or the consistency check
 /// fails, throw a DataError.
 fn convert_seed_to_handles(
-    algo_name: &str,
+    algorithm_name: CryptoAlgorithm,
     seed_bytes: &[u8],
     private_key_bytes: Option<&[u8]>,
     public_key_bytes: Option<&[u8]>,
@@ -1208,8 +1208,8 @@ fn convert_seed_to_handles(
             "Failed to parse last 256 bits of seed bytes".to_string(),
         ))
     })?;
-    let handles = match algo_name {
-        ALG_ML_KEM_512 => {
+    let handles = match algorithm_name {
+        CryptoAlgorithm::MlKem512 => {
             let (decapsulation_key, encapsulation_key) = MlKem512::generate_deterministic(&d, &z);
             if let Some(private_key_bytes) = private_key_bytes {
                 if private_key_bytes != decapsulation_key.as_bytes().as_slice() {
@@ -1231,7 +1231,7 @@ fn convert_seed_to_handles(
                 Handle::MlKem512PublicKey(Box::new(encapsulation_key.as_bytes())),
             )
         },
-        ALG_ML_KEM_768 => {
+        CryptoAlgorithm::MlKem768 => {
             let (decapsulation_key, encapsulation_key) = MlKem768::generate_deterministic(&d, &z);
             if let Some(private_key_bytes) = private_key_bytes {
                 if private_key_bytes != decapsulation_key.as_bytes().as_slice() {
@@ -1253,7 +1253,7 @@ fn convert_seed_to_handles(
                 Handle::MlKem768PublicKey(Box::new(encapsulation_key.as_bytes())),
             )
         },
-        ALG_ML_KEM_1024 => {
+        CryptoAlgorithm::MlKem1024 => {
             let (decapsulation_key, encapsulation_key) = MlKem1024::generate_deterministic(&d, &z);
             if let Some(private_key_bytes) = private_key_bytes {
                 if private_key_bytes != decapsulation_key.as_bytes().as_slice() {
@@ -1278,7 +1278,7 @@ fn convert_seed_to_handles(
         _ => {
             return Err(Error::NotSupported(Some(format!(
                 "{} is not an ML-KEM algorithm",
-                algo_name
+                algorithm_name.as_str()
             ))));
         },
     };
@@ -1288,23 +1288,26 @@ fn convert_seed_to_handles(
 
 /// Convert public key bytes to an ML-KEM public key handle. If the conversion fails, throw a
 /// DataError.
-fn convert_public_key_to_handle(algo_name: &str, public_key_bytes: &[u8]) -> Result<Handle, Error> {
-    let public_key_handle = match algo_name {
-        ALG_ML_KEM_512 => {
+fn convert_public_key_to_handle(
+    algorithm_name: CryptoAlgorithm,
+    public_key_bytes: &[u8],
+) -> Result<Handle, Error> {
+    let public_key_handle = match algorithm_name {
+        CryptoAlgorithm::MlKem512 => {
             let encoded_encapsulation_key = Encoded::<EncapsulationKey<MlKem512Params>>::try_from(
                 public_key_bytes,
             )
             .map_err(|_| Error::Data(Some("Failed to parse ML-KEM public key".to_string())))?;
             Handle::MlKem512PublicKey(Box::new(encoded_encapsulation_key))
         },
-        ALG_ML_KEM_768 => {
+        CryptoAlgorithm::MlKem768 => {
             let encoded_encapsulation_key = Encoded::<EncapsulationKey<MlKem768Params>>::try_from(
                 public_key_bytes,
             )
             .map_err(|_| Error::Data(Some("Failed to parse ML-KEM public key".to_string())))?;
             Handle::MlKem768PublicKey(Box::new(encoded_encapsulation_key))
         },
-        ALG_ML_KEM_1024 => {
+        CryptoAlgorithm::MlKem1024 => {
             let encoded_encapsulation_key = Encoded::<EncapsulationKey<MlKem1024Params>>::try_from(
                 public_key_bytes,
             )
@@ -1314,7 +1317,7 @@ fn convert_public_key_to_handle(algo_name: &str, public_key_bytes: &[u8]) -> Res
         _ => {
             return Err(Error::NotSupported(Some(format!(
                 "{} is not an ML-KEM algorithm",
-                algo_name
+                algorithm_name.as_str()
             ))));
         },
     };

--- a/components/script/dom/subtlecrypto/pbkdf2_operation.rs
+++ b/components/script/dom/subtlecrypto/pbkdf2_operation.rs
@@ -14,8 +14,8 @@ use crate::dom::bindings::root::DomRoot;
 use crate::dom::cryptokey::{CryptoKey, Handle};
 use crate::dom::globalscope::GlobalScope;
 use crate::dom::subtlecrypto::{
-    ALG_PBKDF2, ALG_SHA1, ALG_SHA256, ALG_SHA384, ALG_SHA512, KeyAlgorithmAndDerivatives,
-    NormalizedAlgorithm, SubtleKeyAlgorithm, SubtlePbkdf2Params,
+    CryptoAlgorithm, KeyAlgorithmAndDerivatives, NormalizedAlgorithm, SubtleKeyAlgorithm,
+    SubtlePbkdf2Params,
 };
 
 /// <https://w3c.github.io/webcrypto/#pbkdf2-operations-derive-bits>
@@ -45,10 +45,10 @@ pub(crate) fn derive_bits(
     // Step 4. Let prf be the MAC Generation function described in Section 4 of [FIPS-198-1] using
     // the hash function described by the hash member of normalizedAlgorithm.
     let prf = match normalized_algorithm.hash.name() {
-        ALG_SHA1 => pbkdf2::PBKDF2_HMAC_SHA1,
-        ALG_SHA256 => pbkdf2::PBKDF2_HMAC_SHA256,
-        ALG_SHA384 => pbkdf2::PBKDF2_HMAC_SHA384,
-        ALG_SHA512 => pbkdf2::PBKDF2_HMAC_SHA512,
+        CryptoAlgorithm::Sha1 => pbkdf2::PBKDF2_HMAC_SHA1,
+        CryptoAlgorithm::Sha256 => pbkdf2::PBKDF2_HMAC_SHA256,
+        CryptoAlgorithm::Sha384 => pbkdf2::PBKDF2_HMAC_SHA384,
+        CryptoAlgorithm::Sha512 => pbkdf2::PBKDF2_HMAC_SHA512,
         _ => {
             return Err(Error::NotSupported(None));
         },
@@ -111,7 +111,7 @@ pub(crate) fn import_key(
     // Step 7. Set the name attribute of algorithm to "PBKDF2".
     // Step 8. Set the [[algorithm]] internal slot of key to algorithm.
     let algorithm = SubtleKeyAlgorithm {
-        name: ALG_PBKDF2.to_string(),
+        name: CryptoAlgorithm::Pbkdf2,
     };
     let key = CryptoKey::new(
         cx,

--- a/components/script/dom/subtlecrypto/rsa_common.rs
+++ b/components/script/dom/subtlecrypto/rsa_common.rs
@@ -30,10 +30,9 @@ use crate::dom::bindings::str::DOMString;
 use crate::dom::cryptokey::{CryptoKey, Handle};
 use crate::dom::globalscope::GlobalScope;
 use crate::dom::subtlecrypto::{
-    ALG_RSA_OAEP, ALG_RSA_PSS, ALG_RSASSA_PKCS1_V1_5, ALG_SHA1, ALG_SHA256, ALG_SHA384, ALG_SHA512,
-    DigestOperation, ExportedKey, JsonWebKeyExt, JwkStringField, KeyAlgorithmAndDerivatives,
-    NormalizedAlgorithm, SubtleRsaHashedImportParams, SubtleRsaHashedKeyAlgorithm,
-    SubtleRsaHashedKeyGenParams, normalize_algorithm,
+    CryptoAlgorithm, DigestOperation, ExportedKey, JsonWebKeyExt, JwkStringField,
+    KeyAlgorithmAndDerivatives, NormalizedAlgorithm, SubtleRsaHashedImportParams,
+    SubtleRsaHashedKeyAlgorithm, SubtleRsaHashedKeyGenParams, normalize_algorithm,
 };
 
 pub(crate) enum RsaAlgorithm {
@@ -117,13 +116,12 @@ pub(crate) fn generate_key(
     let algorithm = SubtleRsaHashedKeyAlgorithm {
         name: match rsa_algorithm {
             // Step 5. Set the name attribute of algorithm to "RSASSA-PKCS1-v1_5".
-            RsaAlgorithm::RsassaPkcs1v1_5 => ALG_RSASSA_PKCS1_V1_5,
+            RsaAlgorithm::RsassaPkcs1v1_5 => CryptoAlgorithm::RsassaPkcs1V1_5,
             // Step 5. Set the name attribute of algorithm to "RSA-PSS".
-            RsaAlgorithm::RsaPss => ALG_RSA_PSS,
+            RsaAlgorithm::RsaPss => CryptoAlgorithm::RsaPss,
             // Step 5. Set the name attribute of algorithm to "RSA-OAEP".
-            RsaAlgorithm::RsaOaep => ALG_RSA_OAEP,
-        }
-        .to_string(),
+            RsaAlgorithm::RsaOaep => CryptoAlgorithm::RsaOaep,
+        },
         modulus_length: normalized_algorithm.modulus_length,
         public_exponent: normalized_algorithm.public_exponent.clone(),
         hash: normalized_algorithm.hash.clone(),
@@ -509,10 +507,10 @@ pub(crate) fn import_key(
                     match &jwk.alg {
                         None => None,
                         Some(alg) => match &*alg.str() {
-                            "RS1" => Some(ALG_SHA1),
-                            "RS256" => Some(ALG_SHA256),
-                            "RS384" => Some(ALG_SHA384),
-                            "RS512" => Some(ALG_SHA512),
+                            "RS1" => Some("SHA-1"),
+                            "RS256" => Some("SHA-256"),
+                            "RS384" => Some("SHA-384"),
+                            "RS512" => Some("SHA-512"),
                             _ => None,
                         },
                     }
@@ -537,10 +535,10 @@ pub(crate) fn import_key(
                     match &jwk.alg {
                         None => None,
                         Some(alg) => match &*alg.str() {
-                            "PS1" => Some(ALG_SHA1),
-                            "PS256" => Some(ALG_SHA256),
-                            "PS384" => Some(ALG_SHA384),
-                            "PS512" => Some(ALG_SHA512),
+                            "PS1" => Some("SHA-1"),
+                            "PS256" => Some("SHA-256"),
+                            "PS384" => Some("SHA-384"),
+                            "PS512" => Some("SHA-512"),
                             _ => None,
                         },
                     }
@@ -565,10 +563,10 @@ pub(crate) fn import_key(
                     match &jwk.alg {
                         None => None,
                         Some(alg) => match &*alg.str() {
-                            "RSA-OAEP" => Some(ALG_SHA1),
-                            "RSA-OAEP-256" => Some(ALG_SHA256),
-                            "RSA-OAEP-384" => Some(ALG_SHA384),
-                            "RSA-OAEP-512" => Some(ALG_SHA512),
+                            "RSA-OAEP" => Some("SHA-1"),
+                            "RSA-OAEP-256" => Some("SHA-256"),
+                            "RSA-OAEP-384" => Some("SHA-384"),
+                            "RSA-OAEP-512" => Some("SHA-512"),
                             _ => None,
                         },
                     }
@@ -699,15 +697,15 @@ pub(crate) fn import_key(
         name: match &rsa_algorithm {
             RsaAlgorithm::RsassaPkcs1v1_5 => {
                 // Step 4. Set the name attribute of algorithm to "RSASSA-PKCS1-v1_5"
-                ALG_RSASSA_PKCS1_V1_5.to_string()
+                CryptoAlgorithm::RsassaPkcs1V1_5
             },
             RsaAlgorithm::RsaPss => {
                 // Step 4. Set the name attribute of algorithm to "RSA-PSS"
-                ALG_RSA_PSS.to_string()
+                CryptoAlgorithm::RsaPss
             },
             RsaAlgorithm::RsaOaep => {
                 // Step 4. Set the name attribute of algorithm to "RSA-OAEP"
-                ALG_RSA_OAEP.to_string()
+                CryptoAlgorithm::RsaOaep
             },
         },
         modulus_length,
@@ -863,14 +861,14 @@ pub(crate) fn export_key(
                     //     of key and obtaining alg.
                     //     Set the alg attribute of jwk to alg.
                     let alg = match hash {
-                        ALG_SHA1 => "RS1",
-                        ALG_SHA256 => "RS256",
-                        ALG_SHA384 => "RS384",
-                        ALG_SHA512 => "RS512",
+                        CryptoAlgorithm::Sha1 => "RS1",
+                        CryptoAlgorithm::Sha256 => "RS256",
+                        CryptoAlgorithm::Sha384 => "RS384",
+                        CryptoAlgorithm::Sha512 => "RS512",
                         _ => {
                             return Err(Error::NotSupported(Some(format!(
                                 "Unsupported \"{}\" hash for RSASSA-PKCS1-v1_5",
-                                hash
+                                hash.as_str()
                             ))));
                         },
                     };
@@ -892,14 +890,14 @@ pub(crate) fn export_key(
                     //     of key and obtaining alg.
                     //     Set the alg attribute of jwk to alg.
                     let alg = match hash {
-                        ALG_SHA1 => "PS1",
-                        ALG_SHA256 => "PS256",
-                        ALG_SHA384 => "PS384",
-                        ALG_SHA512 => "PS512",
+                        CryptoAlgorithm::Sha1 => "PS1",
+                        CryptoAlgorithm::Sha256 => "PS256",
+                        CryptoAlgorithm::Sha384 => "PS384",
+                        CryptoAlgorithm::Sha512 => "PS512",
                         _ => {
                             return Err(Error::NotSupported(Some(format!(
                                 "Unsupported \"{}\" hash for RSA-PSS",
-                                hash
+                                hash.as_str()
                             ))));
                         },
                     };
@@ -921,14 +919,14 @@ pub(crate) fn export_key(
                     //     of key and obtaining alg.
                     //     Set the alg attribute of jwk to alg.
                     let alg = match hash {
-                        ALG_SHA1 => "RSA-OAEP",
-                        ALG_SHA256 => "RSA-OAEP-256",
-                        ALG_SHA384 => "RSA-OAEP-384",
-                        ALG_SHA512 => "RSA-OAEP-512",
+                        CryptoAlgorithm::Sha1 => "RSA-OAEP",
+                        CryptoAlgorithm::Sha256 => "RSA-OAEP-256",
+                        CryptoAlgorithm::Sha384 => "RSA-OAEP-384",
+                        CryptoAlgorithm::Sha512 => "RSA-OAEP-512",
                         _ => {
                             return Err(Error::NotSupported(Some(format!(
                                 "Unsupported \"{}\" hash for RSA-OAEP",
-                                hash
+                                hash.as_str()
                             ))));
                         },
                     };

--- a/components/script/dom/subtlecrypto/rsa_oaep_operation.rs
+++ b/components/script/dom/subtlecrypto/rsa_oaep_operation.rs
@@ -18,9 +18,8 @@ use crate::dom::cryptokey::{CryptoKey, Handle};
 use crate::dom::globalscope::GlobalScope;
 use crate::dom::subtlecrypto::rsa_common::{self, RsaAlgorithm};
 use crate::dom::subtlecrypto::{
-    ALG_SHA1, ALG_SHA256, ALG_SHA384, ALG_SHA512, ExportedKey, KeyAlgorithmAndDerivatives,
-    NormalizedAlgorithm, SubtleRsaHashedImportParams, SubtleRsaHashedKeyGenParams,
-    SubtleRsaOaepParams,
+    CryptoAlgorithm, ExportedKey, KeyAlgorithmAndDerivatives, NormalizedAlgorithm,
+    SubtleRsaHashedImportParams, SubtleRsaHashedKeyGenParams, SubtleRsaOaepParams,
 };
 
 /// <https://w3c.github.io/webcrypto/#rsa-oaep-operations-encrypt>
@@ -63,14 +62,14 @@ pub(crate) fn encrypt(
         )));
     };
     let padding = match algorithm.hash.name() {
-        ALG_SHA1 => Oaep::new_with_label::<Sha1, _>(label),
-        ALG_SHA256 => Oaep::new_with_label::<Sha256, _>(label),
-        ALG_SHA384 => Oaep::new_with_label::<Sha384, _>(label),
-        ALG_SHA512 => Oaep::new_with_label::<Sha512, _>(label),
+        CryptoAlgorithm::Sha1 => Oaep::new_with_label::<Sha1, _>(label),
+        CryptoAlgorithm::Sha256 => Oaep::new_with_label::<Sha256, _>(label),
+        CryptoAlgorithm::Sha384 => Oaep::new_with_label::<Sha384, _>(label),
+        CryptoAlgorithm::Sha512 => Oaep::new_with_label::<Sha512, _>(label),
         _ => {
             return Err(Error::Operation(Some(format!(
                 "Unsupported \"{}\" hash for RSASSA-PKCS1-v1_5",
-                algorithm.hash.name()
+                algorithm.hash.name().as_str()
             ))));
         },
     };
@@ -122,14 +121,14 @@ pub(crate) fn decrypt(
         )));
     };
     let padding = match algorithm.hash.name() {
-        ALG_SHA1 => Oaep::new_with_label::<Sha1, _>(label),
-        ALG_SHA256 => Oaep::new_with_label::<Sha256, _>(label),
-        ALG_SHA384 => Oaep::new_with_label::<Sha384, _>(label),
-        ALG_SHA512 => Oaep::new_with_label::<Sha512, _>(label),
+        CryptoAlgorithm::Sha1 => Oaep::new_with_label::<Sha1, _>(label),
+        CryptoAlgorithm::Sha256 => Oaep::new_with_label::<Sha256, _>(label),
+        CryptoAlgorithm::Sha384 => Oaep::new_with_label::<Sha384, _>(label),
+        CryptoAlgorithm::Sha512 => Oaep::new_with_label::<Sha512, _>(label),
         _ => {
             return Err(Error::Operation(Some(format!(
-                "Unsupported \"{}\" hash for RSA-OAEP",
-                algorithm.hash.name()
+                "Unsupported \"{}\" hash for RSASSA-PKCS1-v1_5",
+                algorithm.hash.name().as_str()
             ))));
         },
     };

--- a/components/script/dom/subtlecrypto/rsa_pss_operation.rs
+++ b/components/script/dom/subtlecrypto/rsa_pss_operation.rs
@@ -19,9 +19,8 @@ use crate::dom::cryptokey::{CryptoKey, Handle};
 use crate::dom::globalscope::GlobalScope;
 use crate::dom::subtlecrypto::rsa_common::{self, RsaAlgorithm};
 use crate::dom::subtlecrypto::{
-    ALG_SHA1, ALG_SHA256, ALG_SHA384, ALG_SHA512, ExportedKey, KeyAlgorithmAndDerivatives,
-    NormalizedAlgorithm, SubtleRsaHashedImportParams, SubtleRsaHashedKeyGenParams,
-    SubtleRsaPssParams,
+    CryptoAlgorithm, ExportedKey, KeyAlgorithmAndDerivatives, NormalizedAlgorithm,
+    SubtleRsaHashedImportParams, SubtleRsaHashedKeyGenParams, SubtleRsaPssParams,
 };
 
 /// <https://w3c.github.io/webcrypto/#rsa-pss-operations-sign>
@@ -58,28 +57,28 @@ pub(crate) fn sign(
     };
     let mut rng = OsRng;
     let signature = match algorithm.hash.name() {
-        ALG_SHA1 => {
+        CryptoAlgorithm::Sha1 => {
             let signing_key = SigningKey::<Sha1>::new_with_salt_len(
                 private_key.clone(),
                 normalized_algorithm.salt_length as usize,
             );
             signing_key.try_sign_with_rng(&mut rng, message)
         },
-        ALG_SHA256 => {
+        CryptoAlgorithm::Sha256 => {
             let signing_key = SigningKey::<Sha256>::new_with_salt_len(
                 private_key.clone(),
                 normalized_algorithm.salt_length as usize,
             );
             signing_key.try_sign_with_rng(&mut rng, message)
         },
-        ALG_SHA384 => {
+        CryptoAlgorithm::Sha384 => {
             let signing_key = SigningKey::<Sha384>::new_with_salt_len(
                 private_key.clone(),
                 normalized_algorithm.salt_length as usize,
             );
             signing_key.try_sign_with_rng(&mut rng, message)
         },
-        ALG_SHA512 => {
+        CryptoAlgorithm::Sha512 => {
             let signing_key = SigningKey::<Sha512>::new_with_salt_len(
                 private_key.clone(),
                 normalized_algorithm.salt_length as usize,
@@ -89,7 +88,7 @@ pub(crate) fn sign(
         _ => {
             return Err(Error::Operation(Some(format!(
                 "Unsupported \"{}\" hash for RSA-PSS",
-                algorithm.hash.name()
+                algorithm.hash.name().as_str()
             ))));
         },
     }
@@ -135,28 +134,28 @@ pub(crate) fn verify(
     let signature = Signature::try_from(signature)
         .map_err(|_| Error::Operation(Some("Failed to parse RSA signature".to_string())))?;
     let result = match algorithm.hash.name() {
-        ALG_SHA1 => {
+        CryptoAlgorithm::Sha1 => {
             let verifying_key = VerifyingKey::<Sha1>::new_with_salt_len(
                 public_key.clone(),
                 normalized_algorithm.salt_length as usize,
             );
             verifying_key.verify(message, &signature)
         },
-        ALG_SHA256 => {
+        CryptoAlgorithm::Sha256 => {
             let verifying_key = VerifyingKey::<Sha256>::new_with_salt_len(
                 public_key.clone(),
                 normalized_algorithm.salt_length as usize,
             );
             verifying_key.verify(message, &signature)
         },
-        ALG_SHA384 => {
+        CryptoAlgorithm::Sha384 => {
             let verifying_key = VerifyingKey::<Sha384>::new_with_salt_len(
                 public_key.clone(),
                 normalized_algorithm.salt_length as usize,
             );
             verifying_key.verify(message, &signature)
         },
-        ALG_SHA512 => {
+        CryptoAlgorithm::Sha512 => {
             let verifying_key = VerifyingKey::<Sha512>::new_with_salt_len(
                 public_key.clone(),
                 normalized_algorithm.salt_length as usize,
@@ -166,7 +165,7 @@ pub(crate) fn verify(
         _ => {
             return Err(Error::Operation(Some(format!(
                 "Unsupported \"{}\" hash for RSASSA-PKCS1-v1_5",
-                algorithm.hash.name()
+                algorithm.hash.name().as_str()
             ))));
         },
     }

--- a/components/script/dom/subtlecrypto/rsassa_pkcs1_v1_5_operation.rs
+++ b/components/script/dom/subtlecrypto/rsassa_pkcs1_v1_5_operation.rs
@@ -18,8 +18,8 @@ use crate::dom::cryptokey::{CryptoKey, Handle};
 use crate::dom::globalscope::GlobalScope;
 use crate::dom::subtlecrypto::rsa_common::{self, RsaAlgorithm};
 use crate::dom::subtlecrypto::{
-    ALG_SHA1, ALG_SHA256, ALG_SHA384, ALG_SHA512, ExportedKey, KeyAlgorithmAndDerivatives,
-    NormalizedAlgorithm, SubtleRsaHashedImportParams, SubtleRsaHashedKeyGenParams,
+    CryptoAlgorithm, ExportedKey, KeyAlgorithmAndDerivatives, NormalizedAlgorithm,
+    SubtleRsaHashedImportParams, SubtleRsaHashedKeyGenParams,
 };
 
 /// <https://w3c.github.io/webcrypto/#rsassa-pkcs1-operations-sign>
@@ -50,26 +50,26 @@ pub(crate) fn sign(key: &CryptoKey, message: &[u8]) -> Result<Vec<u8>, Error> {
         )));
     };
     let signature = match algorithm.hash.name() {
-        ALG_SHA1 => {
+        CryptoAlgorithm::Sha1 => {
             let signing_key = SigningKey::<Sha1>::new(private_key.clone());
             signing_key.try_sign(message)
         },
-        ALG_SHA256 => {
+        CryptoAlgorithm::Sha256 => {
             let signing_key = SigningKey::<Sha256>::new(private_key.clone());
             signing_key.try_sign(message)
         },
-        ALG_SHA384 => {
+        CryptoAlgorithm::Sha384 => {
             let signing_key = SigningKey::<Sha384>::new(private_key.clone());
             signing_key.try_sign(message)
         },
-        ALG_SHA512 => {
+        CryptoAlgorithm::Sha512 => {
             let signing_key = SigningKey::<Sha512>::new(private_key.clone());
             signing_key.try_sign(message)
         },
         _ => {
             return Err(Error::Operation(Some(format!(
                 "Unsupported \"{}\" hash for RSASSA-PKCS1-v1_5",
-                algorithm.hash.name()
+                algorithm.hash.name().as_str()
             ))));
         },
     }
@@ -109,26 +109,26 @@ pub(crate) fn verify(key: &CryptoKey, message: &[u8], signature: &[u8]) -> Resul
     let signature = Signature::try_from(signature)
         .map_err(|_| Error::Operation(Some("Failed to parse RSA signature".to_string())))?;
     let result = match algorithm.hash.name() {
-        ALG_SHA1 => {
+        CryptoAlgorithm::Sha1 => {
             let verifying_key = VerifyingKey::<Sha1>::new(public_key.clone());
             verifying_key.verify(message, &signature)
         },
-        ALG_SHA256 => {
+        CryptoAlgorithm::Sha256 => {
             let verifying_key = VerifyingKey::<Sha256>::new(public_key.clone());
             verifying_key.verify(message, &signature)
         },
-        ALG_SHA384 => {
+        CryptoAlgorithm::Sha384 => {
             let verifying_key = VerifyingKey::<Sha384>::new(public_key.clone());
             verifying_key.verify(message, &signature)
         },
-        ALG_SHA512 => {
+        CryptoAlgorithm::Sha512 => {
             let verifying_key = VerifyingKey::<Sha512>::new(public_key.clone());
             verifying_key.verify(message, &signature)
         },
         _ => {
             return Err(Error::Operation(Some(format!(
                 "Unsupported \"{}\" hash for RSASSA-PKCS1-v1_5",
-                algorithm.hash.name()
+                algorithm.hash.name().as_str()
             ))));
         },
     }

--- a/components/script/dom/subtlecrypto/sha3_operation.rs
+++ b/components/script/dom/subtlecrypto/sha3_operation.rs
@@ -5,7 +5,7 @@
 use sha3::{Digest, Sha3_256, Sha3_384, Sha3_512};
 
 use crate::dom::bindings::error::Error;
-use crate::dom::subtlecrypto::{ALG_SHA3_256, ALG_SHA3_384, ALG_SHA3_512, SubtleAlgorithm};
+use crate::dom::subtlecrypto::{CryptoAlgorithm, SubtleAlgorithm};
 
 /// <https://wicg.github.io/webcrypto-modern-algos/#sha3-operations-digest>
 pub(crate) fn digest(
@@ -23,10 +23,10 @@ pub(crate) fn digest(
     //     Let result be the result of performing the SHA3-512 hash function defined in Section 6.1
     //     of [FIPS-202] using message as the input message, M.
     // Step 2. If performing the operation results in an error, then throw an OperationError.
-    let result = match normalized_algorithm.name.as_str() {
-        ALG_SHA3_256 => Sha3_256::new_with_prefix(message).finalize().to_vec(),
-        ALG_SHA3_384 => Sha3_384::new_with_prefix(message).finalize().to_vec(),
-        ALG_SHA3_512 => Sha3_512::new_with_prefix(message).finalize().to_vec(),
+    let result = match normalized_algorithm.name {
+        CryptoAlgorithm::Sha3_256 => Sha3_256::new_with_prefix(message).finalize().to_vec(),
+        CryptoAlgorithm::Sha3_384 => Sha3_384::new_with_prefix(message).finalize().to_vec(),
+        CryptoAlgorithm::Sha3_512 => Sha3_512::new_with_prefix(message).finalize().to_vec(),
         _ => return Err(Error::NotSupported(None)),
     };
 

--- a/components/script/dom/subtlecrypto/sha_operation.rs
+++ b/components/script/dom/subtlecrypto/sha_operation.rs
@@ -5,7 +5,7 @@
 use aws_lc_rs::digest;
 
 use crate::dom::bindings::error::Error;
-use crate::dom::subtlecrypto::{ALG_SHA1, ALG_SHA256, ALG_SHA384, ALG_SHA512, SubtleAlgorithm};
+use crate::dom::subtlecrypto::{CryptoAlgorithm, SubtleAlgorithm};
 
 /// <https://w3c.github.io/webcrypto/#sha-operations-digest>
 pub(crate) fn digest(
@@ -26,13 +26,13 @@ pub(crate) fn digest(
     //     Let result be the result of performing the SHA-512 hash function defined in Section 6.4
     //     of [FIPS-180-4] using message as the input message, M.
     // Step 2. If performing the operation results in an error, then throw an OperationError.
-    let result = match nomrmalized_algorithm.name.as_str() {
-        ALG_SHA1 => digest::digest(&digest::SHA1_FOR_LEGACY_USE_ONLY, message)
+    let result = match nomrmalized_algorithm.name {
+        CryptoAlgorithm::Sha1 => digest::digest(&digest::SHA1_FOR_LEGACY_USE_ONLY, message)
             .as_ref()
             .to_vec(),
-        ALG_SHA256 => digest::digest(&digest::SHA256, message).as_ref().to_vec(),
-        ALG_SHA384 => digest::digest(&digest::SHA384, message).as_ref().to_vec(),
-        ALG_SHA512 => digest::digest(&digest::SHA512, message).as_ref().to_vec(),
+        CryptoAlgorithm::Sha256 => digest::digest(&digest::SHA256, message).as_ref().to_vec(),
+        CryptoAlgorithm::Sha384 => digest::digest(&digest::SHA384, message).as_ref().to_vec(),
+        CryptoAlgorithm::Sha512 => digest::digest(&digest::SHA512, message).as_ref().to_vec(),
         _ => {
             return Err(Error::NotSupported(None));
         },

--- a/components/script/dom/subtlecrypto/x25519_operation.rs
+++ b/components/script/dom/subtlecrypto/x25519_operation.rs
@@ -20,7 +20,7 @@ use crate::dom::bindings::str::DOMString;
 use crate::dom::cryptokey::{CryptoKey, Handle};
 use crate::dom::globalscope::GlobalScope;
 use crate::dom::subtlecrypto::{
-    ALG_X25519, ExportedKey, JsonWebKeyExt, JwkStringField, KeyAlgorithmAndDerivatives,
+    CryptoAlgorithm, ExportedKey, JsonWebKeyExt, JwkStringField, KeyAlgorithmAndDerivatives,
     SubtleEcdhKeyDeriveParams, SubtleKeyAlgorithm,
 };
 
@@ -132,7 +132,7 @@ pub(crate) fn generate_key(
     // Step 3. Let algorithm be a new KeyAlgorithm object.
     // Step 4. Set the name attribute of algorithm to "X25519".
     let algorithm = SubtleKeyAlgorithm {
-        name: ALG_X25519.to_string(),
+        name: CryptoAlgorithm::X25519,
     };
 
     // Step 5. Let publicKey be a new CryptoKey representing the public key of the generated key pair.
@@ -237,7 +237,7 @@ pub(crate) fn import_key(
             // Step 2.10. Set the name attribute of algorithm to "X25519".
             // Step 2.11. Set the [[algorithm]] internal slot of key to algorithm.
             let algorithm = SubtleKeyAlgorithm {
-                name: ALG_X25519.to_string(),
+                name: CryptoAlgorithm::X25519,
             };
             CryptoKey::new(
                 cx,
@@ -300,7 +300,7 @@ pub(crate) fn import_key(
             // Step 2.11. Set the name attribute of algorithm to "X25519".
             // Step 2.12. Set the [[algorithm]] internal slot of key to algorithm.
             let algorithm = SubtleKeyAlgorithm {
-                name: ALG_X25519.to_string(),
+                name: CryptoAlgorithm::X25519,
             };
             CryptoKey::new(
                 cx,
@@ -343,7 +343,7 @@ pub(crate) fn import_key(
             }
 
             // Step 2.2. If the crv field of jwk is not "X25519", then throw a DataError.
-            if jwk.crv.as_ref().is_none_or(|crv| crv != ALG_X25519) {
+            if jwk.crv.as_ref().is_none_or(|crv| crv != "X25519") {
                 return Err(Error::Data(None));
             }
 
@@ -415,7 +415,7 @@ pub(crate) fn import_key(
             // Step 2.11. Set the name attribute of algorithm to "X25519".
             // Step 2.12. Set the [[algorithm]] internal slot of key to algorithm.
             let algorithm = SubtleKeyAlgorithm {
-                name: ALG_X25519.to_string(),
+                name: CryptoAlgorithm::X25519,
             };
             CryptoKey::new(
                 cx,
@@ -448,7 +448,7 @@ pub(crate) fn import_key(
                 key_data.try_into().map_err(|_| Error::Data(None))?;
             let public_key = PublicKey::from(key_bytes);
             let algorithm = SubtleKeyAlgorithm {
-                name: ALG_X25519.to_string(),
+                name: CryptoAlgorithm::X25519,
             };
             CryptoKey::new(
                 cx,
@@ -555,7 +555,7 @@ pub(crate) fn export_key(format: KeyFormat, key: &CryptoKey) -> Result<ExportedK
             // Step 3.3. Set the crv attribute of jwk to "X25519".
             let mut jwk = JsonWebKey {
                 kty: Some(DOMString::from("OKP")),
-                crv: Some(DOMString::from(ALG_X25519)),
+                crv: Some(DOMString::from("X25519")),
                 ..Default::default()
             };
 


### PR DESCRIPTION
We currently use `String` to store cryptographic algorithm name in subtle dictionaries in WebCrypto code. The algorithm normalization guarantees that there are only a limited number of possible strings that can be assigned to the name fields.

We switch to use the `CryptoAlgorithm` enum, which contains all possible algorithm names, to represent these values. This reduces string comparison and saves a small amount of memory.

The constant string `ALG_*` in `subtlecrypto.rs`, which are the recognized algorithm name for the algorithms, are also removed since they are already embedded in the `CryptoAlgorithm` enum.

Testing: Refactoring. Existing tests suffice.
Fixes: Part of #42579