### PR TITLE
layout: Move `resolved_sticky_offset` to `BoxFragmentRareData`

### DIFF
--- a/components/layout/display_list/mod.rs
+++ b/components/layout/display_list/mod.rs
@@ -1489,8 +1489,9 @@ impl<'a> BuilderForBoxFragment<'a> {
     }
 
     fn build_collapsed_table_borders(&mut self, builder: &mut DisplayListBuilder) {
+        let layout_info = self.fragment.specific_layout_info();
         let Some(SpecificLayoutInfo::TableGridWithCollapsedBorders(table_info)) =
-            self.fragment.specific_layout_info()
+            layout_info.as_deref()
         else {
             return;
         };

--- a/components/layout/display_list/stacking_context.rs
+++ b/components/layout/display_list/stacking_context.rs
@@ -1422,7 +1422,7 @@ impl BoxFragment {
         }
 
         if matches!(
-            self.specific_layout_info(),
+            self.specific_layout_info().as_deref(),
             Some(SpecificLayoutInfo::TableGridWithCollapsedBorders(_))
         ) {
             stacking_context
@@ -1619,7 +1619,7 @@ impl BoxFragment {
             offsets.bottom.map(|v| v.to_used_value(scroll_frame_height)),
             offsets.left.map(|v| v.to_used_value(scroll_frame_width)),
         );
-        *self.resolved_sticky_insets.borrow_mut() = Some(offsets);
+        self.ensure_rare_data().resolved_sticky_insets = Some(Box::new(offsets));
 
         if scroll_frame_size.is_none() {
             return None;

--- a/components/layout/fragment_tree/box_fragment.rs
+++ b/components/layout/fragment_tree/box_fragment.rs
@@ -3,7 +3,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 use app_units::{Au, MAX_AU, MIN_AU};
-use atomic_refcell::AtomicRefCell;
+use atomic_refcell::{AtomicRef, AtomicRefCell, AtomicRefMut};
 use base::id::ScrollTreeNodeId;
 use base::print_tree::PrintTree;
 use euclid::Rect;
@@ -69,8 +69,13 @@ pub(crate) struct BlockLevelLayoutInfo {
     pub block_margins_collapsed_with_children: CollapsedBlockMargins,
 }
 
-#[derive(MallocSizeOf)]
+#[derive(Default, MallocSizeOf)]
 pub(crate) struct BoxFragmentRareData {
+    /// The resolved box insets if this box is `position: sticky`. These are calculated
+    /// during `StackingContextTree` construction because they rely on the size of the
+    /// scroll container.
+    pub(crate) resolved_sticky_insets: Option<Box<PhysicalSides<AuOrAuto>>>,
+
     /// Information that is specific to a layout system (e.g., grid, table, etc.).
     pub specific_layout_info: Option<SpecificLayoutInfo>,
 }
@@ -78,12 +83,15 @@ pub(crate) struct BoxFragmentRareData {
 impl BoxFragmentRareData {
     /// Create a new rare data based on information given to the fragment. Ideally, We should
     /// avoid creating rare data as much as possible to reduce the memory cost.
-    fn try_boxed_from(specific_layout_info: Option<SpecificLayoutInfo>) -> Option<Box<Self>> {
-        specific_layout_info.map(|info| {
+    fn try_boxed_from(
+        specific_layout_info: Option<SpecificLayoutInfo>,
+    ) -> AtomicRefCell<Option<Box<Self>>> {
+        AtomicRefCell::new(specific_layout_info.map(|info| {
             Box::new(BoxFragmentRareData {
+                resolved_sticky_insets: None,
                 specific_layout_info: Some(info),
             })
-        })
+        }))
     }
 }
 
@@ -112,15 +120,10 @@ pub(crate) struct BoxFragment {
     /// This is handled when calling [`Self::scrollable_overflow_for_parent`].
     scrollable_overflow: Option<PhysicalRect<Au>>,
 
-    /// The resolved box insets if this box is `position: sticky`. These are calculated
-    /// during `StackingContextTree` construction because they rely on the size of the
-    /// scroll container.
-    pub(crate) resolved_sticky_insets: AtomicRefCell<Option<PhysicalSides<AuOrAuto>>>,
-
     pub background_mode: BackgroundMode,
 
     /// Rare data that not all kinds of [`BoxFragment`] would have.
-    pub rare_data: Option<Box<BoxFragmentRareData>>,
+    pub rare_data: AtomicRefCell<Option<Box<BoxFragmentRareData>>>,
 
     /// Additional information for block-level boxes.
     pub block_level_layout_info: Option<Box<BlockLevelLayoutInfo>>,
@@ -155,7 +158,6 @@ impl BoxFragment {
             margin,
             baselines: Baselines::default(),
             scrollable_overflow: None,
-            resolved_sticky_insets: AtomicRefCell::default(),
             background_mode: BackgroundMode::Normal,
             rare_data,
             block_level_layout_info: None,
@@ -216,8 +218,39 @@ impl BoxFragment {
         self.background_mode = BackgroundMode::None;
     }
 
-    pub fn specific_layout_info(&self) -> Option<&SpecificLayoutInfo> {
-        self.rare_data.as_ref()?.specific_layout_info.as_ref()
+    pub fn ensure_rare_data(&self) -> AtomicRefMut<'_, Box<BoxFragmentRareData>> {
+        let mut rare_data = self.rare_data.borrow_mut();
+        if rare_data.is_none() {
+            *rare_data = Some(Default::default());
+        }
+
+        AtomicRefMut::map(rare_data, |rare_data| {
+            rare_data
+                .as_mut()
+                .expect("This data should have just been set")
+        })
+    }
+
+    pub fn specific_layout_info(&self) -> Option<AtomicRef<'_, SpecificLayoutInfo>> {
+        let rare_data = self.rare_data.borrow();
+        if rare_data.is_none() {
+            return None;
+        }
+
+        AtomicRef::filter_map(rare_data, |rare_data| {
+            rare_data.as_ref()?.specific_layout_info.as_ref()
+        })
+    }
+
+    pub fn resolved_sticky_insets(&self) -> Option<AtomicRef<'_, Box<PhysicalSides<AuOrAuto>>>> {
+        let rare_data = self.rare_data.borrow();
+        if rare_data.is_none() {
+            return None;
+        }
+
+        AtomicRef::filter_map(rare_data, |rare_data| {
+            rare_data.as_ref()?.resolved_sticky_insets.as_ref()
+        })
     }
 
     pub fn with_block_level_layout_info(
@@ -470,8 +503,8 @@ impl BoxFragment {
             "Should not call this method on statically positioned box."
         );
 
-        if let Some(resolved_sticky_insets) = *self.resolved_sticky_insets.borrow() {
-            return resolved_sticky_insets;
+        if let Some(resolved_sticky_insets) = self.resolved_sticky_insets() {
+            return **resolved_sticky_insets;
         }
 
         let convert_to_au_or_auto = |sides: PhysicalSides<Au>| {
@@ -554,13 +587,13 @@ impl BoxFragment {
     /// <https://www.w3.org/TR/css-tables-3/#table-wrapper-box>
     pub(crate) fn is_table_wrapper(&self) -> bool {
         matches!(
-            self.specific_layout_info(),
+            self.specific_layout_info().as_deref(),
             Some(SpecificLayoutInfo::TableWrapper)
         )
     }
 
     pub(crate) fn has_collapsed_borders(&self) -> bool {
-        match self.specific_layout_info() {
+        match self.specific_layout_info().as_deref() {
             Some(SpecificLayoutInfo::TableCellWithCollapsedBorders) => true,
             Some(SpecificLayoutInfo::TableGridWithCollapsedBorders(_)) => true,
             Some(SpecificLayoutInfo::TableWrapper) => {

--- a/components/layout/fragment_tree/box_fragment.rs
+++ b/components/layout/fragment_tree/box_fragment.rs
@@ -233,9 +233,6 @@ impl BoxFragment {
 
     pub fn specific_layout_info(&self) -> Option<AtomicRef<'_, SpecificLayoutInfo>> {
         let rare_data = self.rare_data.borrow();
-        if rare_data.is_none() {
-            return None;
-        }
 
         AtomicRef::filter_map(rare_data, |rare_data| {
             rare_data.as_ref()?.specific_layout_info.as_ref()
@@ -244,9 +241,6 @@ impl BoxFragment {
 
     pub fn resolved_sticky_insets(&self) -> Option<AtomicRef<'_, Box<PhysicalSides<AuOrAuto>>>> {
         let rare_data = self.rare_data.borrow();
-        if rare_data.is_none() {
-            return None;
-        }
 
         AtomicRef::filter_map(rare_data, |rare_data| {
             rare_data.as_ref()?.resolved_sticky_insets.as_ref()

--- a/components/layout/query.rs
+++ b/components/layout/query.rs
@@ -343,7 +343,7 @@ pub fn process_resolved_style_request(
                 let content_rect = box_fragment.base.rect;
                 let margins = box_fragment.margin;
                 let padding = box_fragment.padding;
-                let specific_layout_info = box_fragment.specific_layout_info().cloned();
+                let specific_layout_info = box_fragment.specific_layout_info().as_deref().cloned();
                 (content_rect, margins, padding, specific_layout_info)
             },
             Fragment::Positioning(positioning_fragment) => (


### PR DESCRIPTION
Wrap `BoxFragment` rare data with `AtomicRefCell` and move `resolved_sticky_offset` to the `BoxFragmentRareData` since it is relevant only for `position: sticky`. It reduce the size of `BoxFragment` from 296 to 264. This allow us to add more rare data to `BoxFragment` after the reflow, such as the calculation of scrollbar that requires scrollable overflow to be calculated beforehand.

Testing: No WPT change.