### PR TITLE
deps: Upgrade to `strum` 0.28

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7230,7 +7230,7 @@ dependencies = [
 [[package]]
 name = "selectors"
 version = "0.35.0"
-source = "git+https://github.com/servo/stylo?rev=9b635629e627a611419745198de1b1ba6c8667c2#9b635629e627a611419745198de1b1ba6c8667c2"
+source = "git+https://github.com/servo/stylo?rev=ab75cec2f1fdb1c6d5731b4c685a3bfc798f9619#ab75cec2f1fdb1c6d5731b4c685a3bfc798f9619"
 dependencies = [
  "bitflags 2.11.0",
  "cssparser",
@@ -8798,7 +8798,7 @@ dependencies = [
 [[package]]
 name = "servo_arc"
 version = "0.4.3"
-source = "git+https://github.com/servo/stylo?rev=9b635629e627a611419745198de1b1ba6c8667c2#9b635629e627a611419745198de1b1ba6c8667c2"
+source = "git+https://github.com/servo/stylo?rev=ab75cec2f1fdb1c6d5731b4c685a3bfc798f9619#ab75cec2f1fdb1c6d5731b4c685a3bfc798f9619"
 dependencies = [
  "serde",
  "stable_deref_trait",
@@ -9178,18 +9178,18 @@ dependencies = [
 
 [[package]]
 name = "strum"
-version = "0.27.2"
+version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af23d6f6c1a224baef9d3f61e287d2761385a5b88fdab4eb4c6f11aeb54c4bcf"
+checksum = "9628de9b8791db39ceda2b119bbe13134770b56c138ec1d3af810d045c04f9bd"
 dependencies = [
  "strum_macros",
 ]
 
 [[package]]
 name = "strum_macros"
-version = "0.27.2"
+version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7695ce3845ea4b33927c055a39dc438a45b059f7c1b3d91d38d10355fb8cbca7"
+checksum = "ab85eea0270ee17587ed4156089e10b9e6880ee688791d45a905f5b1ca36f664"
 dependencies = [
  "heck 0.5.0",
  "proc-macro2",
@@ -9218,7 +9218,7 @@ dependencies = [
 [[package]]
 name = "stylo"
 version = "0.12.0"
-source = "git+https://github.com/servo/stylo?rev=9b635629e627a611419745198de1b1ba6c8667c2#9b635629e627a611419745198de1b1ba6c8667c2"
+source = "git+https://github.com/servo/stylo?rev=ab75cec2f1fdb1c6d5731b4c685a3bfc798f9619#ab75cec2f1fdb1c6d5731b4c685a3bfc798f9619"
 dependencies = [
  "app_units",
  "arrayvec",
@@ -9274,7 +9274,7 @@ dependencies = [
 [[package]]
 name = "stylo_atoms"
 version = "0.12.0"
-source = "git+https://github.com/servo/stylo?rev=9b635629e627a611419745198de1b1ba6c8667c2#9b635629e627a611419745198de1b1ba6c8667c2"
+source = "git+https://github.com/servo/stylo?rev=ab75cec2f1fdb1c6d5731b4c685a3bfc798f9619#ab75cec2f1fdb1c6d5731b4c685a3bfc798f9619"
 dependencies = [
  "string_cache",
  "string_cache_codegen",
@@ -9283,7 +9283,7 @@ dependencies = [
 [[package]]
 name = "stylo_derive"
 version = "0.12.0"
-source = "git+https://github.com/servo/stylo?rev=9b635629e627a611419745198de1b1ba6c8667c2#9b635629e627a611419745198de1b1ba6c8667c2"
+source = "git+https://github.com/servo/stylo?rev=ab75cec2f1fdb1c6d5731b4c685a3bfc798f9619#ab75cec2f1fdb1c6d5731b4c685a3bfc798f9619"
 dependencies = [
  "darling",
  "proc-macro2",
@@ -9295,7 +9295,7 @@ dependencies = [
 [[package]]
 name = "stylo_dom"
 version = "0.12.0"
-source = "git+https://github.com/servo/stylo?rev=9b635629e627a611419745198de1b1ba6c8667c2#9b635629e627a611419745198de1b1ba6c8667c2"
+source = "git+https://github.com/servo/stylo?rev=ab75cec2f1fdb1c6d5731b4c685a3bfc798f9619#ab75cec2f1fdb1c6d5731b4c685a3bfc798f9619"
 dependencies = [
  "bitflags 2.11.0",
  "stylo_malloc_size_of",
@@ -9304,7 +9304,7 @@ dependencies = [
 [[package]]
 name = "stylo_malloc_size_of"
 version = "0.12.0"
-source = "git+https://github.com/servo/stylo?rev=9b635629e627a611419745198de1b1ba6c8667c2#9b635629e627a611419745198de1b1ba6c8667c2"
+source = "git+https://github.com/servo/stylo?rev=ab75cec2f1fdb1c6d5731b4c685a3bfc798f9619#ab75cec2f1fdb1c6d5731b4c685a3bfc798f9619"
 dependencies = [
  "app_units",
  "cssparser",
@@ -9321,12 +9321,12 @@ dependencies = [
 [[package]]
 name = "stylo_static_prefs"
 version = "0.12.0"
-source = "git+https://github.com/servo/stylo?rev=9b635629e627a611419745198de1b1ba6c8667c2#9b635629e627a611419745198de1b1ba6c8667c2"
+source = "git+https://github.com/servo/stylo?rev=ab75cec2f1fdb1c6d5731b4c685a3bfc798f9619#ab75cec2f1fdb1c6d5731b4c685a3bfc798f9619"
 
 [[package]]
 name = "stylo_traits"
 version = "0.12.0"
-source = "git+https://github.com/servo/stylo?rev=9b635629e627a611419745198de1b1ba6c8667c2#9b635629e627a611419745198de1b1ba6c8667c2"
+source = "git+https://github.com/servo/stylo?rev=ab75cec2f1fdb1c6d5731b4c685a3bfc798f9619#ab75cec2f1fdb1c6d5731b4c685a3bfc798f9619"
 dependencies = [
  "app_units",
  "bitflags 2.11.0",
@@ -9748,7 +9748,7 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 [[package]]
 name = "to_shmem"
 version = "0.3.0"
-source = "git+https://github.com/servo/stylo?rev=9b635629e627a611419745198de1b1ba6c8667c2#9b635629e627a611419745198de1b1ba6c8667c2"
+source = "git+https://github.com/servo/stylo?rev=ab75cec2f1fdb1c6d5731b4c685a3bfc798f9619#ab75cec2f1fdb1c6d5731b4c685a3bfc798f9619"
 dependencies = [
  "cssparser",
  "servo_arc",
@@ -9761,7 +9761,7 @@ dependencies = [
 [[package]]
 name = "to_shmem_derive"
 version = "0.1.0"
-source = "git+https://github.com/servo/stylo?rev=9b635629e627a611419745198de1b1ba6c8667c2#9b635629e627a611419745198de1b1ba6c8667c2"
+source = "git+https://github.com/servo/stylo?rev=ab75cec2f1fdb1c6d5731b4c685a3bfc798f9619#ab75cec2f1fdb1c6d5731b4c685a3bfc798f9619"
 dependencies = [
  "darling",
  "proc-macro2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -172,7 +172,7 @@ script_traits = { package = "servo-script-traits", path = "components/shared/scr
 sea-query = { version = "1.0.0-rc.31", default-features = false, features = ["backend-sqlite", "derive"] }
 sea-query-rusqlite = { version = "0.8.0-rc.15" }
 sec1 = "0.7"
-selectors = { git = "https://github.com/servo/stylo", rev = "9b635629e627a611419745198de1b1ba6c8667c2" }
+selectors = { git = "https://github.com/servo/stylo", rev = "ab75cec2f1fdb1c6d5731b4c685a3bfc798f9619" }
 serde = "1.0.228"
 serde_bytes = "0.11"
 serde_core = "1.0.226"
@@ -181,7 +181,7 @@ servo-media = { path = "components/media/servo-media" }
 servo-media-dummy = { path = "components/media/backends/dummy" }
 servo-media-gstreamer = { path = "components/media/backends/gstreamer" }
 servo-tracing = { path = "components/servo_tracing" }
-servo_arc = { git = "https://github.com/servo/stylo", rev = "9b635629e627a611419745198de1b1ba6c8667c2" }
+servo_arc = { git = "https://github.com/servo/stylo", rev = "ab75cec2f1fdb1c6d5731b4c685a3bfc798f9619" }
 sha1 = "0.10"
 sha2 = "0.10"
 sha3 = "0.10"
@@ -189,13 +189,13 @@ skrifa = "0.37.0"
 smallvec = { version = "1.15", features = ["serde", "union"] }
 storage_traits = { package = "servo-storage-traits", path = "components/shared/storage" }
 string_cache = "0.9"
-strum = { version = "0.27", features = ["derive"] }
-stylo = { git = "https://github.com/servo/stylo", rev = "9b635629e627a611419745198de1b1ba6c8667c2" }
-stylo_atoms = { git = "https://github.com/servo/stylo", rev = "9b635629e627a611419745198de1b1ba6c8667c2" }
-stylo_dom = { git = "https://github.com/servo/stylo", rev = "9b635629e627a611419745198de1b1ba6c8667c2" }
-stylo_malloc_size_of = { git = "https://github.com/servo/stylo", rev = "9b635629e627a611419745198de1b1ba6c8667c2" }
-stylo_static_prefs = { git = "https://github.com/servo/stylo", rev = "9b635629e627a611419745198de1b1ba6c8667c2" }
-stylo_traits = { git = "https://github.com/servo/stylo", rev = "9b635629e627a611419745198de1b1ba6c8667c2" }
+strum = { version = "0.28", features = ["derive"] }
+stylo = { git = "https://github.com/servo/stylo", rev = "ab75cec2f1fdb1c6d5731b4c685a3bfc798f9619" }
+stylo_atoms = { git = "https://github.com/servo/stylo", rev = "ab75cec2f1fdb1c6d5731b4c685a3bfc798f9619" }
+stylo_dom = { git = "https://github.com/servo/stylo", rev = "ab75cec2f1fdb1c6d5731b4c685a3bfc798f9619" }
+stylo_malloc_size_of = { git = "https://github.com/servo/stylo", rev = "ab75cec2f1fdb1c6d5731b4c685a3bfc798f9619" }
+stylo_static_prefs = { git = "https://github.com/servo/stylo", rev = "ab75cec2f1fdb1c6d5731b4c685a3bfc798f9619" }
+stylo_traits = { git = "https://github.com/servo/stylo", rev = "ab75cec2f1fdb1c6d5731b4c685a3bfc798f9619" }
 surfman = { version = "0.11.0", features = ["chains"] }
 syn = { version = "2", default-features = false, features = ["clone-impls", "derive", "parsing"] }
 synstructure = "0.13"


### PR DESCRIPTION
This requires updating to a new version of Stylo. 

Corresponding Stylo PR: servo/stylo#319
Testing: This just upgrades a dependency so existing tests should suffice.
