### PR TITLE
script: use `&mut JSContext` in `WorkerGloblaScope::StructuredClone` and `Window::StructuredClone`

### DIFF
--- a/components/script/dom/window.rs
+++ b/components/script/dom/window.rs
@@ -2322,14 +2322,18 @@ impl WindowMethods<crate::DomTypeHolder> for Window {
     /// <https://html.spec.whatwg.org/multipage/#dom-structuredclone>
     fn StructuredClone(
         &self,
-        cx: SafeJSContext,
+        cx: &mut JSContext,
         value: HandleValue,
         options: RootedTraceableBox<StructuredSerializeOptions>,
-        can_gc: CanGc,
         retval: MutableHandleValue,
     ) -> Fallible<()> {
-        self.as_global_scope()
-            .structured_clone(cx, value, options, retval, can_gc)
+        self.as_global_scope().structured_clone(
+            cx.into(),
+            value,
+            options,
+            retval,
+            CanGc::from_cx(cx),
+        )
     }
 
     fn TrustedTypes(&self, can_gc: CanGc) -> DomRoot<TrustedTypePolicyFactory> {

--- a/components/script/dom/workers/workerglobalscope.rs
+++ b/components/script/dom/workers/workerglobalscope.rs
@@ -960,14 +960,18 @@ impl WorkerGlobalScopeMethods<crate::DomTypeHolder> for WorkerGlobalScope {
     /// <https://html.spec.whatwg.org/multipage/#dom-structuredclone>
     fn StructuredClone(
         &self,
-        cx: JSContext,
+        cx: &mut js::context::JSContext,
         value: HandleValue,
         options: RootedTraceableBox<StructuredSerializeOptions>,
-        can_gc: CanGc,
         retval: MutableHandleValue,
     ) -> Fallible<()> {
-        self.upcast::<GlobalScope>()
-            .structured_clone(cx, value, options, retval, can_gc)
+        self.upcast::<GlobalScope>().structured_clone(
+            cx.into(),
+            value,
+            options,
+            retval,
+            CanGc::from_cx(cx),
+        )
     }
 
     /// <https://www.w3.org/TR/trusted-types/#dom-windoworworkerglobalscope-trustedtypes>

--- a/components/script_bindings/codegen/Bindings.conf
+++ b/components/script_bindings/codegen/Bindings.conf
@@ -832,11 +832,11 @@ DOMInterfaces = {
 },
 
 'Window': {
-    'canGc': ['CookieStore', 'Fetch', 'FetchLater', 'GetVisualViewport', 'Open', 'ReportError', 'Screen', 'SetInterval', 'SetTimeout', 'StructuredClone', 'TrustedTypes'],
+    'canGc': ['CookieStore', 'Fetch', 'FetchLater', 'GetVisualViewport', 'Open', 'ReportError', 'Screen', 'SetInterval', 'SetTimeout', 'TrustedTypes'],
     'inRealms': ['Fetch'],
     'additionalTraits': ['crate::interfaces::WindowHelpers'],
     'realm': ['CreateImageBitmap', 'CreateImageBitmap_', 'WebdriverCallback', 'GetOpener'],
-    'cx': ['PostMessage', 'PostMessage_', 'Stop', 'WebdriverException']
+    'cx': ['PostMessage', 'PostMessage_', 'Stop', 'WebdriverException', 'StructuredClone']
 },
 
 'WindowProxy' : {
@@ -850,8 +850,8 @@ DOMInterfaces = {
 
 'WorkerGlobalScope': {
     'inRealms': ['Fetch'],
-    'cx': ['ImportScripts'],
-    'canGc': ['Fetch', 'ReportError', 'SetInterval', 'SetTimeout', 'StructuredClone', 'TrustedTypes'],
+    'cx': ['ImportScripts', 'StructuredClone'],
+    'canGc': ['Fetch', 'ReportError', 'SetInterval', 'SetTimeout', 'TrustedTypes'],
     'realm': ['CreateImageBitmap', 'CreateImageBitmap_'],
 },
 


### PR DESCRIPTION
Replace `crate::script_runtime::JSContext` with `js::context::JSContext` in:

- `WorkerGloblaScope::StructuredClone`
- `Window::StructuredClone`

Testing: Builds and runs locally.
Fixes: part of https://github.com/servo/servo/issues/42347
