### PR TITLE
script: Append CSP policies from meta elements

### DIFF
--- a/components/script/dom/document.rs
+++ b/components/script/dom/document.rs
@@ -21,7 +21,7 @@ use bitflags::bitflags;
 use chrono::Local;
 use constellation_traits::{NavigationHistoryBehavior, ScriptToConstellationMessage};
 use content_security_policy::sandboxing_directive::SandboxingFlagSet;
-use content_security_policy::{CspList, PolicyDisposition};
+use content_security_policy::{CspList, Policy as CspPolicy, PolicyDisposition};
 use cookie::Cookie;
 use data_url::mime::Mime;
 use devtools_traits::ScriptToDevtoolsControlMsg;
@@ -1971,6 +1971,16 @@ impl Document {
 
     pub(crate) fn set_csp_list(&self, csp_list: Option<CspList>) {
         self.policy_container.borrow_mut().set_csp_list(csp_list);
+    }
+
+    /// <https://www.w3.org/TR/CSP/#enforced>
+    pub(crate) fn enforce_csp_policy(&self, policy: CspPolicy) {
+        // > A policy is enforced or monitored for a global object by inserting it into the global object’s CSP list.
+        let mut csp_list = self.get_csp_list().clone().unwrap_or(CspList(vec![]));
+        csp_list.push(policy);
+        self.policy_container
+            .borrow_mut()
+            .set_csp_list(Some(csp_list));
     }
 
     pub(crate) fn get_csp_list(&self) -> Ref<'_, Option<CspList>> {

--- a/components/script/dom/html/htmlheadelement.rs
+++ b/components/script/dom/html/htmlheadelement.rs
@@ -2,19 +2,15 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-use content_security_policy::{CspList, PolicyDisposition, PolicySource};
 use dom_struct::dom_struct;
-use html5ever::{LocalName, Prefix, local_name, ns};
+use html5ever::{LocalName, Prefix};
 use js::rust::HandleObject;
 
-use crate::dom::bindings::codegen::Bindings::DocumentBinding::DocumentMethods;
 use crate::dom::bindings::inheritance::Castable;
 use crate::dom::bindings::root::DomRoot;
 use crate::dom::document::Document;
-use crate::dom::element::Element;
 use crate::dom::html::htmlelement::HTMLElement;
-use crate::dom::html::htmlmetaelement::HTMLMetaElement;
-use crate::dom::node::{BindContext, Node, NodeTraits, ShadowIncluding};
+use crate::dom::node::{BindContext, Node};
 use crate::dom::userscripts::load_script;
 use crate::dom::virtualmethods::VirtualMethods;
 use crate::script_runtime::CanGc;
@@ -51,48 +47,6 @@ impl HTMLHeadElement {
 
         n.upcast::<Node>().set_weird_parser_insertion_mode();
         n
-    }
-
-    /// <https://html.spec.whatwg.org/multipage/#attr-meta-http-equiv-content-security-policy>
-    pub(crate) fn set_content_security_policy(&self) {
-        let doc = self.owner_document();
-
-        if doc.GetHead().as_deref() != Some(self) {
-            return;
-        }
-
-        let mut csp_list: Option<CspList> = None;
-        let node = self.upcast::<Node>();
-        let candidates = node
-            .traverse_preorder(ShadowIncluding::No)
-            .filter_map(DomRoot::downcast::<Element>)
-            .filter(|elem| elem.is::<HTMLMetaElement>())
-            .filter(|elem| {
-                elem.get_string_attribute(&local_name!("http-equiv"))
-                    .to_ascii_lowercase() ==
-                    *"content-security-policy"
-            })
-            .filter(|elem| {
-                elem.get_attribute(&ns!(), &local_name!("content"))
-                    .is_some()
-            });
-
-        for meta in candidates {
-            if let Some(ref content) = meta.get_attribute(&ns!(), &local_name!("content")) {
-                let content = content.value();
-                let content_val = content.trim();
-                if !content_val.is_empty() {
-                    let policies =
-                        CspList::parse(content_val, PolicySource::Meta, PolicyDisposition::Enforce);
-                    match csp_list {
-                        Some(ref mut csp_list) => csp_list.append(policies),
-                        None => csp_list = Some(policies),
-                    }
-                }
-            }
-        }
-
-        doc.set_csp_list(csp_list);
     }
 }
 

--- a/components/script/dom/html/htmlmetaelement.rs
+++ b/components/script/dom/html/htmlmetaelement.rs
@@ -4,6 +4,7 @@
 
 use std::str::FromStr;
 
+use content_security_policy::{Policy, PolicyDisposition, PolicySource};
 use dom_struct::dom_struct;
 use html5ever::{LocalName, Prefix, local_name, ns};
 use js::rust::HandleObject;
@@ -150,11 +151,40 @@ impl HTMLMetaElement {
 
     /// <https://html.spec.whatwg.org/multipage/#attr-meta-http-equiv-content-security-policy>
     fn apply_csp_list(&self) {
-        if let Some(parent) = self.upcast::<Node>().GetParentElement() {
-            if let Some(head) = parent.downcast::<HTMLHeadElement>() {
-                head.set_content_security_policy();
-            }
+        // Step 1. If the meta element is not a child of a head element, return.
+        if self
+            .upcast::<Node>()
+            .GetParentElement()
+            .is_none_or(|parent| !parent.is::<HTMLHeadElement>())
+        {
+            return;
+        };
+        // Step 2. If the meta element has no content attribute, or if that attribute's value is the empty string, then return.
+        let Some(content) = self
+            .upcast::<Element>()
+            .get_attribute(&ns!(), &local_name!("content"))
+        else {
+            return;
+        };
+        let content = content.value();
+        if content.is_empty() {
+            return;
         }
+        // Step 3. Let policy be the result of executing Content Security Policy's
+        // parse a serialized Content Security Policy algorithm
+        // on the meta element's content attribute's value,
+        // with a source of "meta", and a disposition of "enforce".
+        let mut policy = Policy::parse(&content, PolicySource::Meta, PolicyDisposition::Enforce);
+        // Step 4. Remove all occurrences of the report-uri, frame-ancestors,
+        // and sandbox directives from policy.
+        policy.directive_set.retain(|directive| {
+            !matches!(
+                directive.name.as_str(),
+                "report-uri" | "frame-ancestors" | "sandbox"
+            )
+        });
+        // Step 5. Enforce the policy policy.
+        self.owner_document().enforce_csp_policy(policy);
     }
 
     /// <https://html.spec.whatwg.org/multipage/#shared-declarative-refresh-steps>

--- a/tests/wpt/meta/content-security-policy/meta/combine-header-and-meta-policies.sub.html.ini
+++ b/tests/wpt/meta/content-security-policy/meta/combine-header-and-meta-policies.sub.html.ini
@@ -1,3 +1,0 @@
-[combine-header-and-meta-policies.sub.html]
-  [Expecting logs: ["TEST COMPLETE", "violated-directive=img-src", "violated-directive=style-src-elem"\]]
-    expected: FAIL


### PR DESCRIPTION
Rather than overwriting the CSP list from a fetch header response, we should add a policy from a meta element to the global CSP list (if it exists).

Fixes #36822
Supersedes and closes #36828