### PR TITLE
script: Clean up attribute access a little bit in `Element`

### DIFF
--- a/components/script/dom/attr.rs
+++ b/components/script/dom/attr.rs
@@ -201,7 +201,7 @@ impl Attr {
             (Some(old), None) => {
                 // Already gone from the list of attributes of old owner.
                 assert!(
-                    old.get_attribute(ns, &self.identifier.local_name)
+                    old.get_attribute_with_namespace(ns, &self.identifier.local_name)
                         .as_deref() !=
                         Some(self)
                 )

--- a/components/script/dom/domtokenlist.rs
+++ b/components/script/dom/domtokenlist.rs
@@ -3,7 +3,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 use dom_struct::dom_struct;
-use html5ever::{LocalName, ns};
+use html5ever::LocalName;
 use style::str::HTML_SPACE_CHARACTERS;
 use stylo_atoms::Atom;
 
@@ -59,7 +59,7 @@ impl DOMTokenList {
     }
 
     fn attribute(&self) -> Option<DomRoot<Attr>> {
-        self.element.get_attribute(&ns!(), &self.local_name)
+        self.element.get_attribute(&self.local_name)
     }
 
     fn check_token_exceptions(&self, token: &DOMString) -> Fallible<Atom> {

--- a/components/script/dom/element.rs
+++ b/components/script/dom/element.rs
@@ -2067,7 +2067,12 @@ impl Element {
         self.handle_attribute_changes(attr, None, Some(new_value), reason, can_gc);
     }
 
-    pub(crate) fn get_attribute(
+    /// This is the inner logic for:
+    /// <https://dom.spec.whatwg.org/#concept-element-attributes-get-by-namespace>
+    ///
+    /// In addition to taking a namespace argument, this version does not require the attribute
+    /// to be lowercase ASCII, in accordance with the specification.
+    pub(crate) fn get_attribute_with_namespace(
         &self,
         namespace: &Namespace,
         local_name: &LocalName,
@@ -2077,6 +2082,19 @@ impl Element {
             .iter()
             .find(|attr| attr.local_name() == local_name && attr.namespace() == namespace)
             .map(|js| DomRoot::from_ref(&**js))
+    }
+
+    /// This is the inner logic for:
+    /// <https://dom.spec.whatwg.org/#concept-element-attributes-get-by-name>
+    ///
+    /// Callers should convert the `LocalName` to ASCII lowercase before calling.
+    pub(crate) fn get_attribute(&self, local_name: &LocalName) -> Option<DomRoot<Attr>> {
+        debug_assert_eq!(
+            *local_name,
+            local_name.to_ascii_lowercase(),
+            "All namespace-less attribute accesses should use a lowercase ASCII name"
+        );
+        self.get_attribute_with_namespace(&ns!(), local_name)
     }
 
     /// <https://dom.spec.whatwg.org/#concept-element-attributes-get-by-name>
@@ -2139,8 +2157,12 @@ impl Element {
     }
 
     pub(crate) fn set_attribute(&self, name: &LocalName, value: AttrValue, can_gc: CanGc) {
-        assert!(name == &name.to_ascii_lowercase());
-        assert!(!name.contains(':'));
+        debug_assert_eq!(
+            *name,
+            name.to_ascii_lowercase(),
+            "All attribute accesses should use a lowercase ASCII name"
+        );
+        debug_assert!(!name.contains(':'));
 
         self.set_first_matching_attribute(
             name.clone(),
@@ -2276,7 +2298,7 @@ impl Element {
     }
 
     pub(crate) fn has_class(&self, name: &Atom, case_sensitivity: CaseSensitivity) -> bool {
-        self.get_attribute(&ns!(), &local_name!("class"))
+        self.get_attribute(&local_name!("class"))
             .is_some_and(|attr| {
                 attr.value()
                     .as_tokens()
@@ -2286,7 +2308,7 @@ impl Element {
     }
 
     pub(crate) fn is_part(&self, name: &Atom, case_sensitivity: CaseSensitivity) -> bool {
-        self.get_attribute(&ns!(), &LocalName::from("part"))
+        self.get_attribute(&LocalName::from("part"))
             .is_some_and(|attr| {
                 attr.value()
                     .as_tokens()
@@ -2301,13 +2323,16 @@ impl Element {
         value: DOMString,
         can_gc: CanGc,
     ) {
-        assert!(*local_name == local_name.to_ascii_lowercase());
-        let value = AttrValue::from_atomic(value.into());
-        self.set_attribute(local_name, value, can_gc);
+        self.set_attribute(local_name, AttrValue::from_atomic(value.into()), can_gc);
     }
 
     pub(crate) fn has_attribute(&self, local_name: &LocalName) -> bool {
-        assert!(local_name.bytes().all(|b| b.to_ascii_lowercase() == b));
+        debug_assert_eq!(
+            *local_name,
+            local_name.to_ascii_lowercase(),
+            "All attribute accesses should use a lowercase ASCII name"
+        );
+        debug_assert!(!local_name.contains(':'));
         self.attrs
             .borrow()
             .iter()
@@ -2326,12 +2351,10 @@ impl Element {
     }
 
     pub(crate) fn get_url_attribute(&self, local_name: &LocalName) -> USVString {
-        assert!(*local_name == local_name.to_ascii_lowercase());
-        let attr = match self.get_attribute(&ns!(), local_name) {
-            Some(attr) => attr,
-            None => return USVString::default(),
+        let Some(attribute) = self.get_attribute(local_name) else {
+            return Default::default();
         };
-        let value = &**attr.value();
+        let value = &**attribute.value();
         // XXXManishearth this doesn't handle `javascript:` urls properly
         self.owner_document()
             .base_url()
@@ -2346,7 +2369,6 @@ impl Element {
         value: USVString,
         can_gc: CanGc,
     ) {
-        assert!(*local_name == local_name.to_ascii_lowercase());
         self.set_attribute(local_name, AttrValue::String(value.to_string()), can_gc);
     }
 
@@ -2354,12 +2376,10 @@ impl Element {
         &self,
         local_name: &LocalName,
     ) -> TrustedScriptURLOrUSVString {
-        assert_eq!(*local_name, local_name.to_ascii_lowercase());
-        let attr = match self.get_attribute(&ns!(), local_name) {
-            Some(attr) => attr,
-            None => return TrustedScriptURLOrUSVString::USVString(USVString::default()),
+        let Some(attribute) = self.get_attribute(local_name) else {
+            return TrustedScriptURLOrUSVString::USVString(USVString::default());
         };
-        let value = &**attr.value();
+        let value = &**attribute.value();
         // XXXManishearth this doesn't handle `javascript:` urls properly
         self.owner_document()
             .base_url()
@@ -2369,19 +2389,13 @@ impl Element {
     }
 
     pub(crate) fn get_trusted_html_attribute(&self, local_name: &LocalName) -> TrustedHTMLOrString {
-        assert_eq!(*local_name, local_name.to_ascii_lowercase());
-        let value = match self.get_attribute(&ns!(), local_name) {
-            Some(attr) => (&**attr.value()).into(),
-            None => "".into(),
-        };
-        TrustedHTMLOrString::String(value)
+        TrustedHTMLOrString::String(self.get_string_attribute(local_name))
     }
 
     pub(crate) fn get_string_attribute(&self, local_name: &LocalName) -> DOMString {
-        match self.get_attribute(&ns!(), local_name) {
-            Some(x) => x.Value(),
-            None => DOMString::new(),
-        }
+        self.get_attribute(local_name)
+            .map(|attribute| attribute.Value())
+            .unwrap_or_default()
     }
 
     pub(crate) fn set_string_attribute(
@@ -2390,7 +2404,6 @@ impl Element {
         value: DOMString,
         can_gc: CanGc,
     ) {
-        assert!(*local_name == local_name.to_ascii_lowercase());
         self.set_attribute(local_name, AttrValue::String(value.into()), can_gc);
     }
 
@@ -2423,8 +2436,8 @@ impl Element {
     }
 
     pub(crate) fn get_tokenlist_attribute(&self, local_name: &LocalName) -> Vec<Atom> {
-        self.get_attribute(&ns!(), local_name)
-            .map(|attr| attr.value().as_tokens().to_vec())
+        self.get_attribute(local_name)
+            .map(|attribute| attribute.value().as_tokens().to_vec())
             .unwrap_or_default()
     }
 
@@ -2434,7 +2447,6 @@ impl Element {
         value: DOMString,
         can_gc: CanGc,
     ) {
-        assert!(*local_name == local_name.to_ascii_lowercase());
         self.set_attribute(
             local_name,
             AttrValue::from_serialized_tokenlist(value.into()),
@@ -2448,53 +2460,33 @@ impl Element {
         tokens: Vec<Atom>,
         can_gc: CanGc,
     ) {
-        assert!(*local_name == local_name.to_ascii_lowercase());
         self.set_attribute(local_name, AttrValue::from_atomic_tokens(tokens), can_gc);
     }
 
     pub(crate) fn get_int_attribute(&self, local_name: &LocalName, default: i32) -> i32 {
-        // TODO: Is this assert necessary?
-        assert!(
-            local_name
-                .chars()
-                .all(|ch| !ch.is_ascii() || ch.to_ascii_lowercase() == ch)
-        );
-        let attribute = self.get_attribute(&ns!(), local_name);
-
-        match attribute {
+        match self.get_attribute(local_name) {
             Some(ref attribute) => match *attribute.value() {
                 AttrValue::Int(_, value) => value,
-                _ => panic!(
-                    "Expected an AttrValue::Int: \
-                     implement parse_plain_attribute"
-                ),
+                _ => unreachable!("Expected an AttrValue::Int: implement parse_plain_attribute"),
             },
             None => default,
         }
     }
 
     pub(crate) fn set_int_attribute(&self, local_name: &LocalName, value: i32, can_gc: CanGc) {
-        assert!(*local_name == local_name.to_ascii_lowercase());
         self.set_attribute(local_name, AttrValue::Int(value.to_string(), value), can_gc);
     }
 
     pub(crate) fn get_uint_attribute(&self, local_name: &LocalName, default: u32) -> u32 {
-        assert!(
-            local_name
-                .chars()
-                .all(|ch| !ch.is_ascii() || ch.to_ascii_lowercase() == ch)
-        );
-        let attribute = self.get_attribute(&ns!(), local_name);
-        match attribute {
+        match self.get_attribute(local_name) {
             Some(ref attribute) => match *attribute.value() {
                 AttrValue::UInt(_, value) => value,
-                _ => panic!("Expected an AttrValue::UInt: implement parse_plain_attribute"),
+                _ => unreachable!("Expected an AttrValue::UInt: implement parse_plain_attribute"),
             },
             None => default,
         }
     }
     pub(crate) fn set_uint_attribute(&self, local_name: &LocalName, value: u32, can_gc: CanGc) {
-        assert!(*local_name == local_name.to_ascii_lowercase());
         self.set_attribute(
             local_name,
             AttrValue::UInt(value.to_string(), value),
@@ -3113,7 +3105,7 @@ impl ElementMethods<crate::DomTypeHolder> for Element {
         local_name: DOMString,
     ) -> Option<DomRoot<Attr>> {
         let namespace = &namespace_from_domstring(namespace);
-        self.get_attribute(namespace, &LocalName::from(local_name))
+        self.get_attribute_with_namespace(namespace, &LocalName::from(local_name))
     }
 
     /// <https://dom.spec.whatwg.org/#dom-element-toggleattribute>
@@ -4923,7 +4915,7 @@ impl SelectorsElement for SelectorWrapper<'_> {
     ) -> bool {
         match *ns {
             NamespaceConstraint::Specific(ns) => self
-                .get_attribute(ns, local_name)
+                .get_attribute_with_namespace(ns, local_name)
                 .is_some_and(|attr| attr.value().eval_selector(operation)),
             NamespaceConstraint::Any => self.attrs.borrow().iter().any(|attr| {
                 *attr.local_name() == **local_name && attr.value().eval_selector(operation)
@@ -5104,7 +5096,7 @@ impl SelectorsElement for SelectorWrapper<'_> {
             f(id.get_hash());
         }
 
-        if let Some(attr) = self.get_attribute(&ns!(), &local_name!("class")) {
+        if let Some(attr) = self.get_attribute(&local_name!("class")) {
             for class in attr.value().as_tokens() {
                 f(AtomIdent::cast(class).get_hash());
             }
@@ -5708,7 +5700,7 @@ impl TaskOnce for ElementPerformFullscreenExit {
 /// <https://html.spec.whatwg.org/multipage/#cors-settings-attribute>
 pub(crate) fn reflect_cross_origin_attribute(element: &Element) -> Option<DOMString> {
     element
-        .get_attribute(&ns!(), &local_name!("crossorigin"))
+        .get_attribute(&local_name!("crossorigin"))
         .map(|attribute| {
             let value = attribute.value().to_ascii_lowercase();
             if value == "anonymous" || value == "use-credentials" {
@@ -5737,7 +5729,7 @@ pub(crate) fn set_cross_origin_attribute(
 /// <https://html.spec.whatwg.org/multipage/#referrer-policy-attribute>
 pub(crate) fn reflect_referrer_policy_attribute(element: &Element) -> DOMString {
     element
-        .get_attribute(&ns!(), &local_name!("referrerpolicy"))
+        .get_attribute(&local_name!("referrerpolicy"))
         .map(|attribute| {
             let value = attribute.value().to_ascii_lowercase();
             if value == "no-referrer" ||
@@ -5759,14 +5751,14 @@ pub(crate) fn reflect_referrer_policy_attribute(element: &Element) -> DOMString 
 
 pub(crate) fn referrer_policy_for_element(element: &Element) -> ReferrerPolicy {
     element
-        .get_attribute(&ns!(), &local_name!("referrerpolicy"))
+        .get_attribute(&local_name!("referrerpolicy"))
         .map(|attribute| ReferrerPolicy::from(&**attribute.value()))
         .unwrap_or(element.owner_document().get_referrer_policy())
 }
 
 pub(crate) fn cors_setting_for_element(element: &Element) -> Option<CorsSettings> {
     element
-        .get_attribute(&ns!(), &local_name!("crossorigin"))
+        .get_attribute(&local_name!("crossorigin"))
         .map(|attribute| CorsSettings::from_enumerated_attribute(&attribute.value()))
 }
 

--- a/components/script/dom/html/htmlanchorelement.rs
+++ b/components/script/dom/html/htmlanchorelement.rs
@@ -13,7 +13,6 @@ use servo_url::ServoUrl;
 use style::attr::AttrValue;
 use stylo_atoms::Atom;
 use stylo_dom::ElementState;
-use xml5ever::ns;
 
 use crate::dom::activation::Activatable;
 use crate::dom::attr::Attr;
@@ -83,7 +82,7 @@ impl HTMLAnchorElement {
     /// the URL could not be joined with the `Document` URL.
     pub(crate) fn full_href_url_for_user_interface(&self) -> Option<ServoUrl> {
         self.upcast::<Element>()
-            .get_attribute(&ns!(), &local_name!("href"))?;
+            .get_attribute(&local_name!("href"))?;
         self.owner_document().base_url().join(&self.Href()).ok()
     }
 }

--- a/components/script/dom/html/htmlbaseelement.rs
+++ b/components/script/dom/html/htmlbaseelement.rs
@@ -3,7 +3,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 use dom_struct::dom_struct;
-use html5ever::{LocalName, Prefix, local_name, ns};
+use html5ever::{LocalName, Prefix, local_name};
 use js::rust::HandleObject;
 use servo_url::ServoUrl;
 
@@ -68,9 +68,7 @@ impl HTMLBaseElement {
         let document = self.owner_document();
         // Step 2. Let urlRecord be the result of parsing the value of element's href content attribute
         // with document's fallback base URL, and document's character encoding. (Thus, the base element isn't affected by itself.)
-        let attr = self
-            .upcast::<Element>()
-            .get_attribute(&ns!(), &local_name!("href"));
+        let attr = self.upcast::<Element>().get_attribute(&local_name!("href"));
         let Some(href_value) = attr.as_ref().map(|attr| attr.value()) else {
             unreachable!("Must always have a href set when setting frozen base URL");
         };
@@ -117,9 +115,7 @@ impl HTMLBaseElementMethods<crate::DomTypeHolder> for HTMLBaseElement {
         let document = self.owner_document();
 
         // Step 2. Let url be the value of the href attribute of this element, if it has one, and the empty string otherwise.
-        let attr = self
-            .upcast::<Element>()
-            .get_attribute(&ns!(), &local_name!("href"));
+        let attr = self.upcast::<Element>().get_attribute(&local_name!("href"));
         let value = attr.as_ref().map(|attr| attr.value());
         let url = value.as_ref().map_or("", |value| &**value);
 

--- a/components/script/dom/html/htmlbuttonelement.rs
+++ b/components/script/dom/html/htmlbuttonelement.rs
@@ -6,7 +6,7 @@ use std::cell::Cell;
 use std::default::Default;
 
 use dom_struct::dom_struct;
-use html5ever::{LocalName, Prefix, local_name, ns};
+use html5ever::{LocalName, Prefix, local_name};
 use js::context::JSContext;
 use js::rust::HandleObject;
 use script_bindings::codegen::GenericBindings::AttrBinding::AttrMethods;
@@ -290,7 +290,7 @@ impl HTMLButtonElement {
     fn command_for_element(&self) -> Option<DomRoot<Element>> {
         let command_for_value = self
             .upcast::<Element>()
-            .get_attribute(&ns!(), &local_name!("commandfor"))?
+            .get_attribute(&local_name!("commandfor"))?
             .Value();
 
         let root_node = self
@@ -355,7 +355,7 @@ impl HTMLButtonElement {
         // The element's optional value is the value of the element's value attribute,
         // if there is one; otherwise null.
         self.upcast::<Element>()
-            .get_attribute(&ns!(), &local_name!("value"))
+            .get_attribute(&local_name!("value"))
             .map(|attribute| attribute.Value())
     }
 }

--- a/components/script/dom/html/htmlelement.rs
+++ b/components/script/dom/html/htmlelement.rs
@@ -158,7 +158,7 @@ impl HTMLElement {
         // a string consisting of only ASCII whitespace, or is a media query list that
         // matches the user's environment according to the definitions given in Media Queries. [MQ]
         self.upcast::<Element>()
-            .get_attribute(&ns!(), &local_name!("media"))
+            .get_attribute(&local_name!("media"))
             .is_none_or(|media| {
                 MediaList::matches_environment(&self.owner_document(), &media.value())
             })

--- a/components/script/dom/html/htmlformelement.rs
+++ b/components/script/dom/html/htmlformelement.rs
@@ -10,7 +10,7 @@ use content_security_policy::sandboxing_directive::SandboxingFlagSet;
 use dom_struct::dom_struct;
 use encoding_rs::{Encoding, UTF_8};
 use headers::{ContentType, HeaderMapExt};
-use html5ever::{LocalName, Prefix, local_name, ns};
+use html5ever::{LocalName, Prefix, local_name};
 use http::Method;
 use js::context::JSContext;
 use js::rust::HandleObject;
@@ -1043,7 +1043,7 @@ impl HTMLFormElement {
         //    then set referrerPolicy to "no-referrer".
         // Note: both steps done below.
         let elem = self.upcast::<Element>();
-        let referrer = match elem.get_attribute(&ns!(), &local_name!("rel")) {
+        let referrer = match elem.get_attribute(&local_name!("rel")) {
             Some(ref link_types) if link_types.Value().contains("noreferrer") => {
                 Referrer::NoReferrer
             },

--- a/components/script/dom/html/htmlhyperlinkelementutils.rs
+++ b/components/script/dom/html/htmlhyperlinkelementutils.rs
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-use html5ever::{local_name, ns};
+use html5ever::local_name;
 use servo_url::ServoUrl;
 
 use crate::dom::bindings::cell::DomRefCell;
@@ -185,10 +185,7 @@ impl<T: HyperlinkElement + DerivedFrom<Element> + Castable + NodeTraits> Hyperli
         // Step 2. Let url be this's url.
         USVString(match *self.get_url().borrow() {
             None => {
-                match self
-                    .upcast::<Element>()
-                    .get_attribute(&ns!(), &local_name!("href"))
-                {
+                match self.upcast::<Element>().get_attribute(&local_name!("href")) {
                     // Step 3. If url is null and this has no href content attribute, return the
                     // empty string.
                     None => String::new(),
@@ -428,9 +425,7 @@ impl<T: HyperlinkElement + DerivedFrom<Element> + Castable + NodeTraits> Hyperli
         // Step 1. Set this element's url to null.
         *self.get_url().borrow_mut() = None;
 
-        let attribute = self
-            .upcast::<Element>()
-            .get_attribute(&ns!(), &local_name!("href"));
+        let attribute = self.upcast::<Element>().get_attribute(&local_name!("href"));
 
         // Step 2. If this element's href content attribute is absent, then return.
         let Some(attribute) = attribute else {

--- a/components/script/dom/html/htmliframeelement.rs
+++ b/components/script/dom/html/htmliframeelement.rs
@@ -120,7 +120,7 @@ impl HTMLIFrameElement {
         let element = self.upcast::<Element>();
         // Step 2. If element has a src attribute specified, and its value is not the empty string, then:
         let url = element
-            .get_attribute(&ns!(), &local_name!("src"))
+            .get_attribute(&local_name!("src"))
             .and_then(|src| {
                 let url = src.value();
                 if url.is_empty() {
@@ -750,7 +750,7 @@ impl HTMLIFrameElement {
     fn parse_sandbox_attribute(&self) {
         let attribute = self
             .upcast::<Element>()
-            .get_attribute(&ns!(), &local_name!("sandbox"));
+            .get_attribute(&local_name!("sandbox"));
         self.sandboxing_flag_set
             .set(attribute.map(|attribute_value| {
                 let tokens: Vec<_> = attribute_value

--- a/components/script/dom/html/htmlimageelement.rs
+++ b/components/script/dom/html/htmlimageelement.rs
@@ -633,12 +633,12 @@ impl HTMLImageElement {
 
         // Step 2. If srcset is not an empty string, then set source set to the result of parsing
         // srcset.
-        if let Some(srcset) = element.get_attribute(&ns!(), &local_name!("srcset")) {
+        if let Some(srcset) = element.get_attribute(&local_name!("srcset")) {
             source_set.image_sources = parse_a_srcset_attribute(&srcset.value());
         }
 
         // Step 3. Set source set's source size to the result of parsing sizes with img.
-        if let Some(sizes) = element.get_attribute(&ns!(), &local_name!("sizes")) {
+        if let Some(sizes) = element.get_attribute(&local_name!("sizes")) {
             source_set.source_size = parse_a_sizes_attribute(&sizes.value());
         }
 
@@ -718,7 +718,7 @@ impl HTMLImageElement {
             // Step 5.3. If child does not have a srcset attribute, continue to the next child.
             // Step 5.4. Parse child's srcset attribute and let source set be the returned source
             // set.
-            match element.get_attribute(&ns!(), &local_name!("srcset")) {
+            match element.get_attribute(&local_name!("srcset")) {
                 Some(srcset) => {
                     source_set.image_sources = parse_a_srcset_attribute(&srcset.value());
                 },
@@ -732,7 +732,7 @@ impl HTMLImageElement {
 
             // Step 5.6. If child has a media attribute, and its value does not match the
             // environment, continue to the next child.
-            if let Some(media) = element.get_attribute(&ns!(), &local_name!("media")) {
+            if let Some(media) = element.get_attribute(&local_name!("media")) {
                 if !MediaList::matches_environment(&element.owner_document(), &media.value()) {
                     continue;
                 }
@@ -740,13 +740,13 @@ impl HTMLImageElement {
 
             // Step 5.7. Parse child's sizes attribute with img, and let source set's source size be
             // the returned value.
-            if let Some(sizes) = element.get_attribute(&ns!(), &local_name!("sizes")) {
+            if let Some(sizes) = element.get_attribute(&local_name!("sizes")) {
                 source_set.source_size = parse_a_sizes_attribute(&sizes.value());
             }
 
             // Step 5.8. If child has a type attribute, and its value is an unknown or unsupported
             // MIME type, continue to the next child.
-            if let Some(type_) = element.get_attribute(&ns!(), &local_name!("type")) {
+            if let Some(type_) = element.get_attribute(&local_name!("type")) {
                 if !is_supported_image_mime_type(&type_.value()) {
                     continue;
                 }
@@ -754,12 +754,8 @@ impl HTMLImageElement {
 
             // Step 5.9. If child has width or height attributes, set el's dimension attribute
             // source to child. Otherwise, set el's dimension attribute source to el.
-            if element
-                .get_attribute(&ns!(), &local_name!("width"))
-                .is_some() ||
-                element
-                    .get_attribute(&ns!(), &local_name!("height"))
-                    .is_some()
+            if element.get_attribute(&local_name!("width")).is_some() ||
+                element.get_attribute(&local_name!("height")).is_some()
             {
                 self.dimension_attribute_source.set(Some(element));
             } else {
@@ -1555,7 +1551,7 @@ impl HTMLImageElement {
 
     pub(crate) fn areas(&self) -> Option<Vec<DomRoot<HTMLAreaElement>>> {
         let elem = self.upcast::<Element>();
-        let usemap_attr = elem.get_attribute(&ns!(), &local_name!("usemap"))?;
+        let usemap_attr = elem.get_attribute(&local_name!("usemap"))?;
 
         let value = usemap_attr.value();
 

--- a/components/script/dom/html/htmlinputelement.rs
+++ b/components/script/dom/html/htmlinputelement.rs
@@ -870,10 +870,7 @@ impl HTMLInputElement {
 
         // Step 2. Otherwise, if the attribute is absent, then the allowed value step
         // is the default step multiplied by the step scale factor.
-        let Some(attribute) = self
-            .upcast::<Element>()
-            .get_attribute(&ns!(), &local_name!("step"))
-        else {
+        let Some(attribute) = self.upcast::<Element>().get_attribute(&local_name!("step")) else {
             return Some(default_step * self.step_scale_factor());
         };
 
@@ -901,7 +898,7 @@ impl HTMLInputElement {
     /// <https://html.spec.whatwg.org/multipage#concept-input-min>
     fn minimum(&self) -> Option<f64> {
         self.upcast::<Element>()
-            .get_attribute(&ns!(), &local_name!("min"))
+            .get_attribute(&local_name!("min"))
             .and_then(|attribute| self.convert_string_to_number(&attribute.value()))
             .or_else(|| self.default_minimum())
     }
@@ -909,7 +906,7 @@ impl HTMLInputElement {
     /// <https://html.spec.whatwg.org/multipage#concept-input-max>
     fn maximum(&self) -> Option<f64> {
         self.upcast::<Element>()
-            .get_attribute(&ns!(), &local_name!("max"))
+            .get_attribute(&local_name!("max"))
             .and_then(|attribute| self.convert_string_to_number(&attribute.value()))
             .or_else(|| self.default_maximum())
     }
@@ -1006,7 +1003,7 @@ impl HTMLInputElement {
         // is not an error, then return that result.
         if let Some(minimum) = self
             .upcast::<Element>()
-            .get_attribute(&ns!(), &local_name!("min"))
+            .get_attribute(&local_name!("min"))
             .and_then(|attribute| self.convert_string_to_number(&attribute.value()))
         {
             return minimum;
@@ -1017,7 +1014,7 @@ impl HTMLInputElement {
         // is not an error, then return that result.
         if let Some(value) = self
             .upcast::<Element>()
-            .get_attribute(&ns!(), &local_name!("value"))
+            .get_attribute(&local_name!("value"))
             .and_then(|attribute| self.convert_string_to_number(&attribute.value()))
         {
             return value;
@@ -1489,7 +1486,7 @@ impl HTMLInputElement {
             _ => {
                 if let Some(attribute_value) = self
                     .upcast::<Element>()
-                    .get_attribute(&ns!(), &local_name!("value"))
+                    .get_attribute(&local_name!("value"))
                     .map(|attribute| attribute.Value())
                 {
                     return attribute_value;
@@ -1693,13 +1690,13 @@ impl HTMLInputElementMethods<crate::DomTypeHolder> for HTMLInputElement {
             ValueMode::Value => self.textinput.borrow().get_content(),
             ValueMode::Default => self
                 .upcast::<Element>()
-                .get_attribute(&ns!(), &local_name!("value"))
+                .get_attribute(&local_name!("value"))
                 .map_or(DOMString::from(""), |a| {
                     DOMString::from(a.summarize().value)
                 }),
             ValueMode::DefaultOn => self
                 .upcast::<Element>()
-                .get_attribute(&ns!(), &local_name!("value"))
+                .get_attribute(&local_name!("value"))
                 .map_or(DOMString::from("on"), |a| {
                     DOMString::from(a.summarize().value)
                 }),
@@ -3119,7 +3116,7 @@ impl VirtualMethods for HTMLInputElement {
                             (_, _, ValueMode::Value) if old_value_mode != ValueMode::Value => {
                                 self.SetValue(
                                     self.upcast::<Element>()
-                                        .get_attribute(&ns!(), &local_name!("value"))
+                                        .get_attribute(&local_name!("value"))
                                         .map_or(DOMString::from(""), |a| {
                                             DOMString::from(a.summarize().value)
                                         }),

--- a/components/script/dom/html/htmllabelelement.rs
+++ b/components/script/dom/html/htmllabelelement.rs
@@ -3,7 +3,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 use dom_struct::dom_struct;
-use html5ever::{LocalName, Prefix, local_name, ns};
+use html5ever::{LocalName, Prefix, local_name};
 use js::rust::HandleObject;
 use style::attr::AttrValue;
 
@@ -96,10 +96,7 @@ impl HTMLLabelElementMethods<crate::DomTypeHolder> for HTMLLabelElement {
 
     /// <https://html.spec.whatwg.org/multipage/#dom-label-control>
     fn GetControl(&self) -> Option<DomRoot<HTMLElement>> {
-        let for_attr = match self
-            .upcast::<Element>()
-            .get_attribute(&ns!(), &local_name!("for"))
-        {
+        let for_attr = match self.upcast::<Element>().get_attribute(&local_name!("for")) {
             Some(for_attr) => for_attr,
             None => return self.first_labelable_descendant(),
         };

--- a/components/script/dom/html/htmllinkelement.rs
+++ b/components/script/dom/html/htmllinkelement.rs
@@ -8,7 +8,7 @@ use std::default::Default;
 
 use base::generic_channel::GenericSharedMemory;
 use dom_struct::dom_struct;
-use html5ever::{LocalName, Prefix, local_name, ns};
+use html5ever::{LocalName, Prefix, local_name};
 use js::context::JSContext;
 use js::rust::HandleObject;
 use net_traits::image_cache::{
@@ -230,7 +230,7 @@ impl HTMLLinkElement {
 }
 
 fn get_attr(element: &Element, local_name: &LocalName) -> Option<String> {
-    let elem = element.get_attribute(&ns!(), local_name);
+    let elem = element.get_attribute(local_name);
     elem.map(|e| {
         let value = e.value();
         (**value).to_owned()
@@ -472,7 +472,7 @@ impl HTMLLinkElement {
         // representing the state of el's as attribute.
         let element = self.upcast::<Element>();
         element
-            .get_attribute(&ns!(), &local_name!("as"))
+            .get_attribute(&local_name!("as"))
             .and_then(|attr| LinkProcessingOptions::translate_a_preload_destination(&attr.value()))
     }
 
@@ -504,19 +504,18 @@ impl HTMLLinkElement {
         };
 
         // Step 3. If el has an href attribute, then set options's href to the value of el's href attribute.
-        if let Some(href_attribute) = element.get_attribute(&ns!(), &local_name!("href")) {
+        if let Some(href_attribute) = element.get_attribute(&local_name!("href")) {
             options.href = (**href_attribute.value()).to_owned();
         }
 
         // Step 4. If el has an integrity attribute, then set options's integrity
         //         to the value of el's integrity content attribute.
-        if let Some(integrity_attribute) = element.get_attribute(&ns!(), &local_name!("integrity"))
-        {
+        if let Some(integrity_attribute) = element.get_attribute(&local_name!("integrity")) {
             options.integrity = (**integrity_attribute.value()).to_owned();
         }
 
         // Step 5. If el has a type attribute, then set options's type to the value of el's type attribute.
-        if let Some(type_attribute) = element.get_attribute(&ns!(), &local_name!("type")) {
+        if let Some(type_attribute) = element.get_attribute(&local_name!("type")) {
             options.link_type = (**type_attribute.value()).to_owned();
         }
 
@@ -673,7 +672,7 @@ impl HTMLLinkElement {
         // Step 3
         let cors_setting = cors_setting_for_element(element);
 
-        let mq_attribute = element.get_attribute(&ns!(), &local_name!("media"));
+        let mq_attribute = element.get_attribute(&local_name!("media"));
         let value = mq_attribute.as_ref().map(|a| a.value());
         let mq_str = match value {
             Some(ref value) => &***value,
@@ -683,7 +682,7 @@ impl HTMLLinkElement {
         let media = MediaList::parse_media_list(mq_str, document.window());
         let media = Arc::new(document.style_shared_lock().wrap(media));
 
-        let im_attribute = element.get_attribute(&ns!(), &local_name!("integrity"));
+        let im_attribute = element.get_attribute(&local_name!("integrity"));
         let integrity_val = im_attribute.as_ref().map(|a| a.value());
         let integrity_metadata = match integrity_val {
             Some(ref value) => &***value,

--- a/components/script/dom/html/htmlmediaelement.rs
+++ b/components/script/dom/html/htmlmediaelement.rs
@@ -1092,9 +1092,7 @@ impl HTMLMediaElement {
         let mode = if self.src_object.borrow().is_some() {
             // If the media element has an assigned media provider object, then let mode be object.
             Mode::Object
-        } else if let Some(attribute) = self
-            .upcast::<Element>()
-            .get_attribute(&ns!(), &local_name!("src"))
+        } else if let Some(attribute) = self.upcast::<Element>().get_attribute(&local_name!("src"))
         {
             // Otherwise, if the media element has no assigned media provider object but has a src
             // attribute, then let mode be attribute.
@@ -1213,7 +1211,7 @@ impl HTMLMediaElement {
         // its src attribute's value is the empty string, then end the synchronous section, and jump
         // down to the failed with elements step below.
         let Some(src) = element
-            .get_attribute(&ns!(), &local_name!("src"))
+            .get_attribute(&local_name!("src"))
             .filter(|attribute| !attribute.value().is_empty())
         else {
             self.load_from_source_child_failure_steps(source);
@@ -1223,7 +1221,7 @@ impl HTMLMediaElement {
         // Step 9.children.3. If candidate has a media attribute whose value does not match the
         // environment, then end the synchronous section, and jump down to the failed with elements
         // step below.
-        if let Some(media) = element.get_attribute(&ns!(), &local_name!("media")) {
+        if let Some(media) = element.get_attribute(&local_name!("media")) {
             if !MediaList::matches_environment(&element.owner_document(), &media.value()) {
                 self.load_from_source_child_failure_steps(source);
                 return;
@@ -1244,7 +1242,7 @@ impl HTMLMediaElement {
         // type (including any codecs described by the codecs parameter, for types that define that
         // parameter), represents a type that the user agent knows it cannot render, then end the
         // synchronous section, and jump down to the failed with elements step below.
-        if let Some(type_) = element.get_attribute(&ns!(), &local_name!("type")) {
+        if let Some(type_) = element.get_attribute(&local_name!("type")) {
             if ServoMedia::get().can_play_type(&type_.value()) == SupportsMediaType::No {
                 self.load_from_source_child_failure_steps(source);
                 return;

--- a/components/script/dom/html/htmlmetaelement.rs
+++ b/components/script/dom/html/htmlmetaelement.rs
@@ -6,7 +6,7 @@ use std::str::FromStr;
 
 use content_security_policy::{Policy, PolicyDisposition, PolicySource};
 use dom_struct::dom_struct;
-use html5ever::{LocalName, Prefix, local_name, ns};
+use html5ever::{LocalName, Prefix, local_name};
 use js::rust::HandleObject;
 use net_traits::ReferrerPolicy;
 use paint_api::viewport_description::ViewportDescription;
@@ -114,7 +114,7 @@ impl HTMLMetaElement {
         // empty string, then return.
         if let Some(content) = self
             .upcast::<Element>()
-            .get_attribute(&ns!(), &local_name!("content"))
+            .get_attribute(&local_name!("content"))
             .filter(|attr| !attr.value().is_empty())
         {
             // Step 4. Let value be the value of element's content attribute, converted to ASCII
@@ -138,7 +138,7 @@ impl HTMLMetaElement {
             return;
         }
         let element = self.upcast::<Element>();
-        let Some(content) = element.get_attribute(&ns!(), &local_name!("content")) else {
+        let Some(content) = element.get_attribute(&local_name!("content")) else {
             return;
         };
 
@@ -162,7 +162,7 @@ impl HTMLMetaElement {
         // Step 2. If the meta element has no content attribute, or if that attribute's value is the empty string, then return.
         let Some(content) = self
             .upcast::<Element>()
-            .get_attribute(&ns!(), &local_name!("content"))
+            .get_attribute(&local_name!("content"))
         else {
             return;
         };

--- a/components/script/dom/html/htmlobjectelement.rs
+++ b/components/script/dom/html/htmlobjectelement.rs
@@ -5,7 +5,7 @@
 use std::default::Default;
 
 use dom_struct::dom_struct;
-use html5ever::{LocalName, Prefix, local_name, ns};
+use html5ever::{LocalName, Prefix, local_name};
 use js::context::JSContext;
 use js::rust::HandleObject;
 use pixels::RasterImage;
@@ -81,8 +81,8 @@ impl ProcessDataURL for &HTMLObjectElement {
 
         // TODO: support other values
         if let (None, Some(_uri)) = (
-            element.get_attribute(&ns!(), &local_name!("type")),
-            element.get_attribute(&ns!(), &local_name!("data")),
+            element.get_attribute(&local_name!("type")),
+            element.get_attribute(&local_name!("data")),
         ) {
             // TODO(gw): Prefetch the image here.
         }

--- a/components/script/dom/html/htmlscriptelement.rs
+++ b/components/script/dom/html/htmlscriptelement.rs
@@ -12,7 +12,7 @@ use std::rc::Rc;
 use base::id::WebViewId;
 use dom_struct::dom_struct;
 use encoding_rs::Encoding;
-use html5ever::{LocalName, Prefix, local_name, ns};
+use html5ever::{LocalName, Prefix, local_name};
 use js::context::JSContext;
 use js::rust::{HandleObject, Stencil};
 use net_traits::http_status::HttpStatus;
@@ -676,8 +676,8 @@ impl HTMLScriptElement {
 
         // Step 20. If el has an event attribute and a for attribute, and el's type is "classic", then:
         if script_type == ScriptType::Classic {
-            let for_attribute = element.get_attribute(&ns!(), &local_name!("for"));
-            let event_attribute = element.get_attribute(&ns!(), &local_name!("event"));
+            let for_attribute = element.get_attribute(&local_name!("for"));
+            let event_attribute = element.get_attribute(&local_name!("event"));
             if let (Some(ref for_attribute), Some(ref event_attribute)) =
                 (for_attribute, event_attribute)
             {
@@ -700,7 +700,7 @@ impl HTMLScriptElement {
         // If el does not have a charset attribute, or if getting an encoding failed,
         // then let encoding be el's node document's the encoding.
         let encoding = element
-            .get_attribute(&ns!(), &local_name!("charset"))
+            .get_attribute(&local_name!("charset"))
             .and_then(|charset| Encoding::for_label(charset.value().as_bytes()))
             .unwrap_or_else(|| doc.encoding());
 
@@ -734,7 +734,7 @@ impl HTMLScriptElement {
 
         // Step 25. If el has an integrity attribute, then let integrity metadata be that attribute's value.
         // Otherwise, let integrity metadata be the empty string.
-        let im_attribute = element.get_attribute(&ns!(), &local_name!("integrity"));
+        let im_attribute = element.get_attribute(&local_name!("integrity"));
         let integrity_val = im_attribute.as_ref().map(|a| a.value());
         let integrity_metadata = match integrity_val {
             Some(ref value) => &***value,
@@ -769,7 +769,7 @@ impl HTMLScriptElement {
         // What we actually need is global's import map eventually.
 
         let base_url = doc.base_url();
-        if let Some(src) = element.get_attribute(&ns!(), &local_name!("src")) {
+        if let Some(src) = element.get_attribute(&local_name!("src")) {
             // Step 31. If el has a src content attribute, then:
 
             // Step 31.1. If el's type is "importmap".
@@ -1066,8 +1066,8 @@ impl HTMLScriptElement {
     pub(crate) fn get_script_type(&self) -> Option<ScriptType> {
         let element = self.upcast::<Element>();
 
-        let type_attr = element.get_attribute(&ns!(), &local_name!("type"));
-        let language_attr = element.get_attribute(&ns!(), &local_name!("language"));
+        let type_attr = element.get_attribute(&local_name!("type"));
+        let language_attr = element.get_attribute(&local_name!("language"));
 
         match (
             type_attr.as_ref().map(|t| t.value()),

--- a/components/script/dom/macros.rs
+++ b/components/script/dom/macros.rs
@@ -129,7 +129,7 @@ macro_rules! make_form_action_getter(
             use $crate::dom::element::Element;
             let element = self.upcast::<Element>();
             let doc = $crate::dom::node::NodeTraits::owner_document(self);
-            let attr = element.get_attribute(&html5ever::ns!(), &html5ever::local_name!($htmlname));
+            let attr = element.get_attribute(&html5ever::local_name!($htmlname));
             let value = attr.as_ref().map(|attr| attr.value());
             let value = match value {
                 Some(ref value) if !value.is_empty() => &***value,
@@ -175,7 +175,7 @@ macro_rules! make_enumerated_getter(
             use $crate::dom::bindings::codegen::Bindings::AttrBinding::Attr_Binding::AttrMethods;
 
             let attr_or_none = self.upcast::<Element>()
-                .get_attribute(&html5ever::ns!(), &html5ever::local_name!($htmlname));
+                .get_attribute(&html5ever::local_name!($htmlname));
             match attr_or_none  {
                 // Step 1. If the attribute is not specified:
                 None => {
@@ -427,7 +427,7 @@ macro_rules! make_dimension_uint_getter(
             use $crate::dom::values::UNSIGNED_LONG_MAX;
             let element = self.upcast::<Element>();
             element
-                .get_attribute(&html5ever::ns!(), &html5ever::local_name!($htmlname))
+                .get_attribute(&html5ever::local_name!($htmlname))
                 .map_or($default, |attribute| parse_unsigned_integer(attribute.value().chars())
                     .map_or($default, |value| {
                         if value > UNSIGNED_LONG_MAX {

--- a/components/script/dom/namednodemap.rs
+++ b/components/script/dom/namednodemap.rs
@@ -62,7 +62,8 @@ impl NamedNodeMapMethods<crate::DomTypeHolder> for NamedNodeMap {
         local_name: DOMString,
     ) -> Option<DomRoot<Attr>> {
         let ns = namespace_from_domstring(namespace);
-        self.owner.get_attribute(&ns, &LocalName::from(local_name))
+        self.owner
+            .get_attribute_with_namespace(&ns, &LocalName::from(local_name))
     }
 
     /// <https://dom.spec.whatwg.org/#dom-namednodemap-setnameditem>

--- a/components/script/dom/node.rs
+++ b/components/script/dom/node.rs
@@ -1534,8 +1534,8 @@ impl Node {
         self.inclusive_ancestors(ShadowIncluding::Yes)
             .find_map(|node| {
                 node.downcast::<Element>().and_then(|el| {
-                    el.get_attribute(&ns!(xml), &local_name!("lang"))
-                        .or_else(|| el.get_attribute(&ns!(), &local_name!("lang")))
+                    el.get_attribute_with_namespace(&ns!(xml), &local_name!("lang"))
+                        .or_else(|| el.get_attribute(&local_name!("lang")))
                         .map(|attr| String::from(attr.Value()))
                 })
                 // TODO: Check meta tags for a pragma-set default language

--- a/components/script/dom/servoparser/mod.rs
+++ b/components/script/dom/servoparser/mod.rs
@@ -1793,7 +1793,7 @@ impl TreeSink for Sink {
     /// Specifically, the `<annotation-xml>` cases.
     fn is_mathml_annotation_xml_integration_point(&self, handle: &Dom<Node>) -> bool {
         let elem = handle.downcast::<Element>().unwrap();
-        elem.get_attribute(&ns!(), &local_name!("encoding"))
+        elem.get_attribute(&local_name!("encoding"))
             .is_some_and(|attr| {
                 attr.value().eq_ignore_ascii_case("text/html") ||
                     attr.value().eq_ignore_ascii_case("application/xhtml+xml")

--- a/components/script/links.rs
+++ b/components/script/links.rs
@@ -5,7 +5,7 @@
 //! Defines shared hyperlink behaviour for `<link>`, `<a>`, `<area>` and `<form>` elements.
 
 use constellation_traits::{LoadData, LoadOrigin, NavigationHistoryBehavior};
-use html5ever::{local_name, ns};
+use html5ever::local_name;
 use malloc_size_of::malloc_size_of_is_0;
 use net_traits::request::Referrer;
 use style::str::HTML_SPACE_CHARACTERS;
@@ -182,7 +182,7 @@ impl LinkRelations {
     /// [`<area>`]: https://html.spec.whatwg.org/multipage/#the-area-element
     /// [`<form>`]: https://html.spec.whatwg.org/multipage/#the-form-element
     pub(crate) fn for_element(element: &Element) -> Self {
-        let rel = element.get_attribute(&ns!(), &local_name!("rel")).map(|e| {
+        let rel = element.get_attribute(&local_name!("rel")).map(|e| {
             let value = e.value();
             (**value).to_owned()
         });
@@ -198,7 +198,7 @@ impl LinkRelations {
 
         // For historical reasons, "rev=made" is treated as if the "author" relation was specified
         let has_legacy_author_relation = element
-            .get_attribute(&ns!(), &local_name!("rev"))
+            .get_attribute(&local_name!("rev"))
             .is_some_and(|rev| &**rev.value() == "made");
         if has_legacy_author_relation {
             relations |= Self::AUTHOR;
@@ -456,7 +456,7 @@ pub(crate) fn follow_hyperlink(
         // Step 9: Let urlString be the result of applying the URL serializer to urlRecord.
         // TODO: Implement this.
 
-        let attribute = subject.get_attribute(&ns!(), &local_name!("href")).unwrap();
+        let attribute = subject.get_attribute(&local_name!("href")).unwrap();
         let mut href = attribute.Value();
 
         // Step 10: If hyperlinkSuffix is non-null, then append it to urlString.


### PR DESCRIPTION
 - Use modern Rust conveniences such as `unwrap_or_default`
 - Unabbreviate `attr`
 - Unify the lowercase ASCII name assertion and make it a debug assertion
 - Use `unreachable!` instead of panic
 - Expose two attribute getters that follow the behavior of two specification concepts and what we expect internally in Servo:
   - One that takes a namespace, but does not require lowercase attribute names.  ([specification concept](https://dom.spec.whatwg.org/#concept-element-attributes-get-by-namespace>))
   - One that does not take a namespace, but does require lowercase attribute names.  ([specification concept](https://dom.spec.whatwg.org/#concept-element-attributes-get-by-name))
Testing: This should not really change behavior so should be covered by existing tests.
