### PR TITLE
script: Readily accept all event names as `Atom`s

### DIFF
--- a/components/script/dom/clipboardevent.rs
+++ b/components/script/dom/clipboardevent.rs
@@ -4,6 +4,8 @@
 
 use dom_struct::dom_struct;
 use js::rust::HandleObject;
+use script_bindings::str::DOMString;
+use style::Atom;
 
 use crate::dom::bindings::codegen::Bindings::ClipboardEventBinding::{
     ClipboardEventInit, ClipboardEventMethods,
@@ -12,7 +14,6 @@ use crate::dom::bindings::codegen::Bindings::EventBinding::EventMethods;
 use crate::dom::bindings::inheritance::Castable;
 use crate::dom::bindings::reflector::reflect_dom_object_with_proto;
 use crate::dom::bindings::root::{DomRoot, MutNullableDom};
-use crate::dom::bindings::str::DOMString;
 use crate::dom::datatransfer::DataTransfer;
 use crate::dom::event::{Event, EventBubbles, EventCancelable};
 use crate::dom::window::Window;
@@ -57,7 +58,7 @@ impl ClipboardEvent {
     pub(crate) fn new(
         window: &Window,
         proto: Option<HandleObject>,
-        type_: DOMString,
+        event_type: Atom,
         can_bubble: EventBubbles,
         cancelable: EventCancelable,
         clipboard_data: Option<&DataTransfer>,
@@ -70,7 +71,7 @@ impl ClipboardEvent {
             can_gc,
         );
         ev.upcast::<Event>()
-            .InitEvent(type_, bool::from(can_bubble), bool::from(cancelable));
+            .init_event(event_type, bool::from(can_bubble), bool::from(cancelable));
         ev.clipboard_data.set(clipboard_data);
         ev
     }
@@ -90,7 +91,7 @@ impl ClipboardEventMethods<crate::DomTypeHolder> for ClipboardEvent {
         window: &Window,
         proto: Option<HandleObject>,
         can_gc: CanGc,
-        type_: DOMString,
+        event_type: DOMString,
         init: &ClipboardEventInit,
     ) -> DomRoot<ClipboardEvent> {
         let bubbles = EventBubbles::from(init.parent.bubbles);
@@ -98,7 +99,7 @@ impl ClipboardEventMethods<crate::DomTypeHolder> for ClipboardEvent {
         let event = ClipboardEvent::new(
             window,
             proto,
-            type_,
+            event_type.into(),
             bubbles,
             cancelable,
             init.clipboardData.as_deref(),

--- a/components/script/dom/compositionevent.rs
+++ b/components/script/dom/compositionevent.rs
@@ -4,6 +4,7 @@
 
 use dom_struct::dom_struct;
 use js::rust::HandleObject;
+use style::Atom;
 
 use crate::dom::bindings::codegen::Bindings::CompositionEventBinding::{
     self, CompositionEventMethods,
@@ -38,7 +39,7 @@ impl CompositionEvent {
     #[expect(clippy::too_many_arguments)]
     pub(crate) fn new(
         window: &Window,
-        type_: DOMString,
+        event_type: Atom,
         can_bubble: bool,
         cancelable: bool,
         view: Option<&Window>,
@@ -47,7 +48,7 @@ impl CompositionEvent {
         can_gc: CanGc,
     ) -> DomRoot<CompositionEvent> {
         Self::new_with_proto(
-            window, None, type_, can_bubble, cancelable, view, detail, data, can_gc,
+            window, None, event_type, can_bubble, cancelable, view, detail, data, can_gc,
         )
     }
 
@@ -55,7 +56,7 @@ impl CompositionEvent {
     fn new_with_proto(
         window: &Window,
         proto: Option<HandleObject>,
-        type_: DOMString,
+        event_type: Atom,
         can_bubble: bool,
         cancelable: bool,
         view: Option<&Window>,
@@ -73,7 +74,7 @@ impl CompositionEvent {
             can_gc,
         );
         ev.uievent
-            .InitUIEvent(type_, can_bubble, cancelable, view, detail);
+            .init_event(event_type, can_bubble, cancelable, view, detail);
         ev
     }
 
@@ -88,13 +89,13 @@ impl CompositionEventMethods<crate::DomTypeHolder> for CompositionEvent {
         window: &Window,
         proto: Option<HandleObject>,
         can_gc: CanGc,
-        type_: DOMString,
+        event_type: DOMString,
         init: &CompositionEventBinding::CompositionEventInit,
     ) -> Fallible<DomRoot<CompositionEvent>> {
         let event = CompositionEvent::new_with_proto(
             window,
             proto,
-            type_,
+            event_type.into(),
             init.parent.parent.bubbles,
             init.parent.parent.cancelable,
             init.parent.view.as_deref(),

--- a/components/script/dom/document.rs
+++ b/components/script/dom/document.rs
@@ -2976,8 +2976,8 @@ impl Document {
         can_gc: CanGc,
     ) {
         let (event_name, does_bubble) = match focus_event_type {
-            FocusEventType::Focus => (DOMString::from("focus"), EventBubbles::DoesNotBubble),
-            FocusEventType::Blur => (DOMString::from("blur"), EventBubbles::DoesNotBubble),
+            FocusEventType::Focus => ("focus".into(), EventBubbles::DoesNotBubble),
+            FocusEventType::Blur => ("blur".into(), EventBubbles::DoesNotBubble),
         };
         let event = FocusEvent::new(
             &self.window,

--- a/components/script/dom/document_event_handler.rs
+++ b/components/script/dom/document_event_handler.rs
@@ -45,6 +45,7 @@ use script_bindings::script_runtime::CanGc;
 use script_bindings::str::DOMString;
 use script_traits::ConstellationInputEvent;
 use servo_config::pref;
+use style::Atom;
 use style_traits::CSSPixel;
 use webrender_api::ExternalScrollId;
 
@@ -603,7 +604,7 @@ impl DocumentEventHandler {
         );
 
         // Send pointermove event before mousemove.
-        let pointer_event = mouse_event.to_pointer_event("pointermove", can_gc);
+        let pointer_event = mouse_event.to_pointer_event(Atom::from("pointermove"), can_gc);
         pointer_event
             .upcast::<Event>()
             .fire(new_target.upcast(), can_gc);
@@ -736,9 +737,9 @@ impl DocumentEventHandler {
             return;
         }
 
-        let mouse_event_type_string = match event.action {
-            embedder_traits::MouseButtonAction::Up => "mouseup",
-            embedder_traits::MouseButtonAction::Down => "mousedown",
+        let mouse_event_type = match event.action {
+            embedder_traits::MouseButtonAction::Up => atom!("mouseup"),
+            embedder_traits::MouseButtonAction::Down => atom!("mousedown"),
         };
 
         // From <https://w3c.github.io/uievents/#event-type-mousedown>
@@ -754,7 +755,7 @@ impl DocumentEventHandler {
         }
 
         let dom_event = DomRoot::upcast::<Event>(MouseEvent::for_platform_button_event(
-            mouse_event_type_string,
+            mouse_event_type,
             event,
             input_event.pressed_mouse_buttons,
             &self.window,
@@ -780,7 +781,7 @@ impl DocumentEventHandler {
                 let pointer_event = dom_event
                     .downcast::<MouseEvent>()
                     .unwrap()
-                    .to_pointer_event(event_type, can_gc);
+                    .to_pointer_event(event_type.into(), can_gc);
 
                 pointer_event.upcast::<Event>().fire(node.upcast(), can_gc);
 
@@ -836,7 +837,7 @@ impl DocumentEventHandler {
                 let pointer_event = dom_event
                     .downcast::<MouseEvent>()
                     .unwrap()
-                    .to_pointer_event(event_type, can_gc);
+                    .to_pointer_event(event_type.into(), can_gc);
 
                 pointer_event.upcast::<Event>().fire(node.upcast(), can_gc);
 
@@ -896,7 +897,7 @@ impl DocumentEventHandler {
         let click_count = self.click_counting_info.borrow().count;
         element.set_click_in_progress(true);
         MouseEvent::for_platform_button_event(
-            "click",
+            atom!("click"),
             event,
             input_event.pressed_mouse_buttons,
             &self.window,
@@ -919,7 +920,7 @@ impl DocumentEventHandler {
         // even numbered clicks is a series of double clicks.
         if click_count % 2 == 0 {
             MouseEvent::for_platform_button_event(
-                "dblclick",
+                Atom::from("dblclick"),
                 event,
                 input_event.pressed_mouse_buttons,
                 &self.window,
@@ -943,12 +944,12 @@ impl DocumentEventHandler {
     ) {
         // <https://w3c.github.io/uievents/#contextmenu>
         let menu_event = PointerEvent::new(
-            &self.window,                   // window
-            DOMString::from("contextmenu"), // type
-            EventBubbles::Bubbles,          // can_bubble
-            EventCancelable::Cancelable,    // cancelable
-            Some(&self.window),             // view
-            0,                              // detail
+            &self.window,                // window
+            "contextmenu".into(),        // type
+            EventBubbles::Bubbles,       // can_bubble
+            EventCancelable::Cancelable, // cancelable
+            Some(&self.window),          // view
+            0,                           // detail
             hit_test_result.point_in_frame.to_i32(),
             hit_test_result.point_in_frame.to_i32(),
             hit_test_result
@@ -1199,7 +1200,7 @@ impl DocumentEventHandler {
 
         let touch_event = TouchEvent::new(
             window,
-            DOMString::from(event_name),
+            event_name.into(),
             EventBubbles::Bubbles,
             EventCancelable::from(event.is_cancelable()),
             EventComposed::Composed,
@@ -1267,7 +1268,7 @@ impl DocumentEventHandler {
 
         let keyevent = KeyboardEvent::new(
             &self.window,
-            DOMString::from(keyboard_event.event.state.event_type()),
+            keyboard_event.event.state.event_type().into(),
             true,
             true,
             Some(&self.window),
@@ -1307,7 +1308,7 @@ impl DocumentEventHandler {
             // https://w3c.github.io/uievents/#keypress-event-order
             let keypress_event = KeyboardEvent::new(
                 &self.window,
-                DOMString::from("keypress"),
+                atom!("keypress"),
                 true,
                 true,
                 Some(&self.window),
@@ -1342,7 +1343,7 @@ impl DocumentEventHandler {
         {
             if let Some(elem) = target.downcast::<Element>() {
                 elem.upcast::<Node>()
-                    .fire_synthetic_pointer_event_not_trusted(DOMString::from("click"), can_gc);
+                    .fire_synthetic_pointer_event_not_trusted(atom!("click"), can_gc);
             }
         }
 
@@ -1378,7 +1379,7 @@ impl DocumentEventHandler {
         let cancelable = composition_event.state == keyboard_types::CompositionState::Start;
         let event = CompositionEvent::new(
             &self.window,
-            DOMString::from(composition_event.state.event_type()),
+            composition_event.state.event_type().into(),
             true,
             cancelable,
             Some(&self.window),
@@ -1412,10 +1413,8 @@ impl DocumentEventHandler {
         };
 
         let node = el.upcast::<Node>();
-        let wheel_event_type_string = "wheel".to_owned();
         debug!(
-            "{}: on {:?} at {:?}",
-            wheel_event_type_string,
+            "wheel: on {:?} at {:?}",
             node.debug_str(),
             hit_test_result.point_in_frame
         );
@@ -1423,7 +1422,7 @@ impl DocumentEventHandler {
         // https://w3c.github.io/uievents/#event-wheelevents
         let dom_event = WheelEvent::new(
             &self.window,
-            DOMString::from(wheel_event_type_string),
+            "wheel".into(),
             EventBubbles::Bubbles,
             EventCancelable::Cancelable,
             Some(&self.window),
@@ -1668,7 +1667,7 @@ impl DocumentEventHandler {
         let clipboard_event = ClipboardEvent::new(
             &self.window,
             None,
-            DOMString::from(clipboard_event_type.as_str()),
+            clipboard_event_type.as_str().into(),
             EventBubbles::Bubbles,
             EventCancelable::Cancelable,
             None,

--- a/components/script/dom/focusevent.rs
+++ b/components/script/dom/focusevent.rs
@@ -4,6 +4,7 @@
 
 use dom_struct::dom_struct;
 use js::rust::HandleObject;
+use style::Atom;
 
 use crate::dom::bindings::codegen::Bindings::FocusEventBinding;
 use crate::dom::bindings::codegen::Bindings::FocusEventBinding::FocusEventMethods;
@@ -46,7 +47,7 @@ impl FocusEvent {
     #[expect(clippy::too_many_arguments)]
     pub(crate) fn new(
         window: &Window,
-        type_: DOMString,
+        event_type: Atom,
         can_bubble: EventBubbles,
         cancelable: EventCancelable,
         view: Option<&Window>,
@@ -57,7 +58,7 @@ impl FocusEvent {
         Self::new_with_proto(
             window,
             None,
-            type_,
+            event_type,
             can_bubble,
             cancelable,
             view,
@@ -71,7 +72,7 @@ impl FocusEvent {
     fn new_with_proto(
         window: &Window,
         proto: Option<HandleObject>,
-        type_: DOMString,
+        event_type: Atom,
         can_bubble: EventBubbles,
         cancelable: EventCancelable,
         view: Option<&Window>,
@@ -80,8 +81,8 @@ impl FocusEvent {
         can_gc: CanGc,
     ) -> DomRoot<FocusEvent> {
         let ev = FocusEvent::new_uninitialized_with_proto(window, proto, can_gc);
-        ev.upcast::<UIEvent>().InitUIEvent(
-            type_,
+        ev.upcast::<UIEvent>().init_event(
+            event_type,
             bool::from(can_bubble),
             bool::from(cancelable),
             view,
@@ -98,7 +99,7 @@ impl FocusEventMethods<crate::DomTypeHolder> for FocusEvent {
         window: &Window,
         proto: Option<HandleObject>,
         can_gc: CanGc,
-        type_: DOMString,
+        event_type: DOMString,
         init: &FocusEventBinding::FocusEventInit,
     ) -> Fallible<DomRoot<FocusEvent>> {
         let bubbles = EventBubbles::from(init.parent.parent.bubbles);
@@ -106,7 +107,7 @@ impl FocusEventMethods<crate::DomTypeHolder> for FocusEvent {
         let event = FocusEvent::new_with_proto(
             window,
             proto,
-            type_,
+            event_type.into(),
             bubbles,
             cancelable,
             init.parent.view.as_deref(),

--- a/components/script/dom/html/htmlelement.rs
+++ b/components/script/dom/html/htmlelement.rs
@@ -444,7 +444,7 @@ impl HTMLElementMethods<crate::DomTypeHolder> for HTMLElement {
         element.set_click_in_progress(true);
 
         self.upcast::<Node>()
-            .fire_synthetic_pointer_event_not_trusted(DOMString::from("click"), can_gc);
+            .fire_synthetic_pointer_event_not_trusted(atom!("click"), can_gc);
         element.set_click_in_progress(false);
     }
 

--- a/components/script/dom/html/htmlinputelement.rs
+++ b/components/script/dom/html/htmlinputelement.rs
@@ -2699,7 +2699,7 @@ impl HTMLInputElement {
                     // but we can get here from synthetic keydown events
                     button
                         .upcast::<Node>()
-                        .fire_synthetic_pointer_event_not_trusted(DOMString::from("click"), can_gc);
+                        .fire_synthetic_pointer_event_not_trusted(atom!("click"), can_gc);
                 }
             },
             None => {

--- a/components/script/dom/html/interactive_element_command.rs
+++ b/components/script/dom/html/interactive_element_command.rs
@@ -11,7 +11,6 @@ use script_bindings::codegen::GenericBindings::NodeBinding::NodeMethods;
 use script_bindings::inheritance::Castable;
 use script_bindings::root::DomRoot;
 use script_bindings::script_runtime::CanGc;
-use script_bindings::str::DOMString;
 
 use crate::dom::document::FocusInitiator;
 use crate::dom::node::{Node, NodeTraits, ShadowIncluding};
@@ -163,18 +162,18 @@ impl InteractiveElementCommand {
             // > Firing a click event at target means firing a synthetic pointer event named click at target.
             InteractiveElementCommand::Anchor(anchor_element) => anchor_element
                 .upcast::<Node>()
-                .fire_synthetic_pointer_event_not_trusted(DOMString::from("click"), can_gc),
+                .fire_synthetic_pointer_event_not_trusted(atom!("click"), can_gc),
             // <https://html.spec.whatwg.org/multipage/#using-the-button-element-to-define-a-command>
             // > The Label, Access Key, Hidden State, and Action facets of the command are
             // > determined as for a elements (see the previous section).
             InteractiveElementCommand::Button(button_element) => button_element
                 .upcast::<Node>()
-                .fire_synthetic_pointer_event_not_trusted(DOMString::from("click"), can_gc),
+                .fire_synthetic_pointer_event_not_trusted(atom!("click"), can_gc),
             // <https://html.spec.whatwg.org/multipage/#using-the-input-element-to-define-a-command>
             // > The Action of the command is to fire a click event at the element.
             InteractiveElementCommand::Input(input_element) => input_element
                 .upcast::<Node>()
-                .fire_synthetic_pointer_event_not_trusted(DOMString::from("click"), can_gc),
+                .fire_synthetic_pointer_event_not_trusted(atom!("click"), can_gc),
             // <https://html.spec.whatwg.org/multipage/#using-the-option-element-to-define-a-command>
             // > If the option's nearest ancestor select element has a multiple attribute, the
             // > Action of the command is to toggle the option element. Otherwise, the Action is to
@@ -194,7 +193,7 @@ impl InteractiveElementCommand {
                 );
                 html_element
                     .upcast::<Node>()
-                    .fire_synthetic_pointer_event_not_trusted(DOMString::from("click"), can_gc);
+                    .fire_synthetic_pointer_event_not_trusted(atom!("click"), can_gc);
             },
         }
     }

--- a/components/script/dom/inputevent.rs
+++ b/components/script/dom/inputevent.rs
@@ -6,6 +6,7 @@ use dom_struct::dom_struct;
 use embedder_traits::Cursor;
 use euclid::Point2D;
 use js::rust::HandleObject;
+use style::Atom;
 use style_traits::CSSPixel;
 
 use crate::dom::bindings::codegen::Bindings::InputEventBinding::{self, InputEventMethods};
@@ -34,7 +35,7 @@ impl InputEvent {
     pub(crate) fn new(
         window: &Window,
         proto: Option<HandleObject>,
-        type_: DOMString,
+        event_type: Atom,
         can_bubble: bool,
         cancelable: bool,
         view: Option<&Window>,
@@ -44,7 +45,7 @@ impl InputEvent {
         input_type: DOMString,
         can_gc: CanGc,
     ) -> DomRoot<InputEvent> {
-        let ev = reflect_dom_object_with_proto(
+        let event = reflect_dom_object_with_proto(
             Box::new(InputEvent {
                 uievent: UIEvent::new_inherited(),
                 data,
@@ -55,9 +56,10 @@ impl InputEvent {
             proto,
             can_gc,
         );
-        ev.uievent
-            .InitUIEvent(type_, can_bubble, cancelable, view, detail);
-        ev
+        event
+            .uievent
+            .init_event(event_type, can_bubble, cancelable, view, detail);
+        event
     }
 }
 
@@ -67,13 +69,13 @@ impl InputEventMethods<crate::DomTypeHolder> for InputEvent {
         window: &Window,
         proto: Option<HandleObject>,
         can_gc: CanGc,
-        type_: DOMString,
+        event_type: DOMString,
         init: &InputEventBinding::InputEventInit,
     ) -> Fallible<DomRoot<InputEvent>> {
         let event = InputEvent::new(
             window,
             proto,
-            type_,
+            event_type.into(),
             init.parent.parent.bubbles,
             init.parent.parent.cancelable,
             init.parent.view.as_deref(),

--- a/components/script/dom/keyboardevent.rs
+++ b/components/script/dom/keyboardevent.rs
@@ -7,6 +7,7 @@ use std::cell::Cell;
 use dom_struct::dom_struct;
 use js::rust::HandleObject;
 use keyboard_types::{Key, Modifiers, NamedKey};
+use style::Atom;
 
 use crate::dom::bindings::cell::DomRefCell;
 use crate::dom::bindings::codegen::Bindings::KeyboardEventBinding;
@@ -74,7 +75,7 @@ impl KeyboardEvent {
     #[expect(clippy::too_many_arguments)]
     pub(crate) fn new(
         window: &Window,
-        type_: DOMString,
+        event_type: Atom,
         can_bubble: bool,
         cancelable: bool,
         view: Option<&Window>,
@@ -92,7 +93,7 @@ impl KeyboardEvent {
         Self::new_with_proto(
             window,
             None,
-            type_,
+            event_type,
             can_bubble,
             cancelable,
             view,
@@ -113,7 +114,7 @@ impl KeyboardEvent {
     fn new_with_proto(
         window: &Window,
         proto: Option<HandleObject>,
-        type_: DOMString,
+        event_type: Atom,
         can_bubble: bool,
         cancelable: bool,
         view: Option<&Window>,
@@ -129,16 +130,14 @@ impl KeyboardEvent {
         can_gc: CanGc,
     ) -> DomRoot<KeyboardEvent> {
         let ev = KeyboardEvent::new_uninitialized_with_proto(window, proto, can_gc);
-        ev.InitKeyboardEvent(
-            type_,
+        ev.init_event(
+            event_type,
             can_bubble,
             cancelable,
             view,
             DOMString::from(key.to_string()),
             location,
-            DOMString::new(),
             repeat,
-            DOMString::new(),
         );
         *ev.typed_key.borrow_mut() = key;
         *ev.code.borrow_mut() = code;
@@ -157,6 +156,34 @@ impl KeyboardEvent {
     pub(crate) fn modifiers(&self) -> Modifiers {
         self.modifiers.get()
     }
+
+    /// <https://w3c.github.io/uievents/#widl-KeyboardEvent-initKeyboardEvent>
+    #[expect(clippy::too_many_arguments)]
+    pub fn init_event(
+        &self,
+        event_type: Atom,
+        can_bubble_arg: bool,
+        cancelable_arg: bool,
+        view_arg: Option<&Window>,
+        key_arg: DOMString,
+        location_arg: u32,
+        repeat: bool,
+    ) {
+        if self.upcast::<Event>().dispatching() {
+            return;
+        }
+
+        self.upcast::<UIEvent>().init_event(
+            event_type,
+            can_bubble_arg,
+            cancelable_arg,
+            view_arg,
+            0,
+        );
+        *self.key.borrow_mut() = key_arg;
+        self.location.set(location_arg);
+        self.repeat.set(repeat);
+    }
 }
 
 impl KeyboardEventMethods<crate::DomTypeHolder> for KeyboardEvent {
@@ -165,7 +192,7 @@ impl KeyboardEventMethods<crate::DomTypeHolder> for KeyboardEvent {
         window: &Window,
         proto: Option<HandleObject>,
         can_gc: CanGc,
-        type_: DOMString,
+        event_type: DOMString,
         init: &KeyboardEventBinding::KeyboardEventInit,
     ) -> Fallible<DomRoot<KeyboardEvent>> {
         let mut modifiers = Modifiers::empty();
@@ -176,7 +203,7 @@ impl KeyboardEventMethods<crate::DomTypeHolder> for KeyboardEvent {
         let event = KeyboardEvent::new_with_proto(
             window,
             proto,
-            type_,
+            event_type.into(),
             init.parent.parent.parent.bubbles,
             init.parent.parent.parent.cancelable,
             init.parent.parent.view.as_deref(),
@@ -198,7 +225,7 @@ impl KeyboardEventMethods<crate::DomTypeHolder> for KeyboardEvent {
     /// <https://w3c.github.io/uievents/#widl-KeyboardEvent-initKeyboardEvent>
     fn InitKeyboardEvent(
         &self,
-        type_arg: DOMString,
+        event_type: DOMString,
         can_bubble_arg: bool,
         cancelable_arg: bool,
         view_arg: Option<&Window>,
@@ -208,15 +235,15 @@ impl KeyboardEventMethods<crate::DomTypeHolder> for KeyboardEvent {
         repeat: bool,
         _locale: DOMString,
     ) {
-        if self.upcast::<Event>().dispatching() {
-            return;
-        }
-
-        self.upcast::<UIEvent>()
-            .InitUIEvent(type_arg, can_bubble_arg, cancelable_arg, view_arg, 0);
-        *self.key.borrow_mut() = key_arg;
-        self.location.set(location_arg);
-        self.repeat.set(repeat);
+        self.init_event(
+            event_type.into(),
+            can_bubble_arg,
+            cancelable_arg,
+            view_arg,
+            key_arg,
+            location_arg,
+            repeat,
+        );
     }
 
     /// <https://w3c.github.io/uievents/#dom-keyboardevent-initkeyboardevent>

--- a/components/script/dom/mouseevent.rs
+++ b/components/script/dom/mouseevent.rs
@@ -13,6 +13,7 @@ use keyboard_types::Modifiers;
 use script_bindings::codegen::GenericBindings::WindowBinding::WindowMethods;
 use script_bindings::match_domstring_ascii;
 use script_traits::ConstellationInputEvent;
+use style::Atom;
 use style_traits::CSSPixel;
 
 use crate::dom::bindings::codegen::Bindings::EventBinding::Event_Binding::EventMethods;
@@ -109,7 +110,7 @@ impl MouseEvent {
     #[allow(clippy::too_many_arguments)]
     pub(crate) fn new(
         window: &Window,
-        type_: DOMString,
+        event_type: Atom,
         can_bubble: EventBubbles,
         cancelable: EventCancelable,
         view: Option<&Window>,
@@ -127,7 +128,7 @@ impl MouseEvent {
         Self::new_with_proto(
             window,
             None,
-            type_,
+            event_type,
             can_bubble,
             cancelable,
             view,
@@ -148,7 +149,7 @@ impl MouseEvent {
     fn new_with_proto(
         window: &Window,
         proto: Option<HandleObject>,
-        type_: DOMString,
+        event_type: Atom,
         can_bubble: EventBubbles,
         cancelable: EventCancelable,
         view: Option<&Window>,
@@ -165,7 +166,7 @@ impl MouseEvent {
     ) -> DomRoot<MouseEvent> {
         let ev = MouseEvent::new_uninitialized_with_proto(window, proto, can_gc);
         ev.initialize_mouse_event(
-            type_,
+            event_type,
             can_bubble,
             cancelable,
             view,
@@ -186,7 +187,7 @@ impl MouseEvent {
     #[expect(clippy::too_many_arguments)]
     pub(crate) fn initialize_mouse_event(
         &self,
-        type_: DOMString,
+        event_type: Atom,
         can_bubble: EventBubbles,
         cancelable: EventCancelable,
         view: Option<&Window>,
@@ -201,7 +202,7 @@ impl MouseEvent {
         point_in_target: Option<Point2D<f32, CSSPixel>>,
     ) {
         self.uievent.initialize_ui_event(
-            type_,
+            event_type,
             view.map(|window| window.upcast::<EventTarget>()),
             can_bubble,
             cancelable,
@@ -243,7 +244,7 @@ impl MouseEvent {
 
         let mouse_event = Self::new(
             window,
-            DOMString::from(event_name.as_str()),
+            Atom::from(event_name.as_str()),
             bubbles,
             cancelable,
             Some(window),
@@ -272,7 +273,7 @@ impl MouseEvent {
     /// <https://w3c.github.io/uievents/#create-a-cancelable-mouseevent-id>
     #[expect(clippy::too_many_arguments)]
     pub(crate) fn for_platform_button_event(
-        event_type_string: &'static str,
+        event_type: Atom,
         event: embedder_traits::MouseButtonEvent,
         pressed_mouse_buttons: u16,
         window: &Window,
@@ -288,7 +289,7 @@ impl MouseEvent {
 
         let mouse_event = Self::new(
             window,
-            event_type_string.into(),
+            event_type,
             EventBubbles::Bubbles,
             EventCancelable::Cancelable,
             Some(window),
@@ -319,19 +320,22 @@ impl MouseEvent {
     /// For mouse, the pointer ID is always -1, and is_primary is always true.
     pub(crate) fn to_pointer_event(
         &self,
-        event_type: &str,
+        event_type: Atom,
         can_gc: CanGc,
     ) -> DomRoot<crate::dom::pointerevent::PointerEvent> {
+        // TODO: This function should almost certainly accept an enumn for the event type.
+        let is_pointer_down = &*event_type == "pointerdown";
+        let is_pointer_move = &*event_type == "pointermove";
+        let is_pointer_up = &*event_type == "pointerup";
+
         // Pressure is 0.5 when button is down, 0.0 when up
-        let pressure = if event_type == "pointerdown" ||
-            (event_type == "pointermove" && self.Buttons() != 0)
-        {
+        let pressure = if is_pointer_down || (is_pointer_move && self.Buttons() != 0) {
             0.5
         } else {
             0.0
         };
 
-        let button = if event_type == "pointerdown" || event_type == "pointerup" {
+        let button = if is_pointer_down || is_pointer_up {
             self.Button()
         } else {
             -1
@@ -342,7 +346,7 @@ impl MouseEvent {
 
         PointerEvent::new(
             window,
-            DOMString::from(event_type),
+            event_type,
             EventBubbles::from(self.upcast::<Event>().Bubbles()),
             EventCancelable::from(self.upcast::<Event>().Cancelable()),
             self.uievent.GetView().as_deref(),
@@ -397,7 +401,7 @@ impl MouseEvent {
 
         let pointer_event = PointerEvent::new(
             window,
-            DOMString::from(event_type),
+            event_type.into(),
             bubbles,
             cancelable,
             self.uievent.GetView().as_deref(),
@@ -442,7 +446,7 @@ impl MouseEventMethods<crate::DomTypeHolder> for MouseEvent {
         window: &Window,
         proto: Option<HandleObject>,
         can_gc: CanGc,
-        type_: DOMString,
+        event_type: DOMString,
         init: &MouseEventBinding::MouseEventInit,
     ) -> Fallible<DomRoot<MouseEvent>> {
         let bubbles = EventBubbles::from(init.parent.parent.parent.bubbles);
@@ -455,7 +459,7 @@ impl MouseEventMethods<crate::DomTypeHolder> for MouseEvent {
         let event = MouseEvent::new_with_proto(
             window,
             proto,
-            type_,
+            event_type.into(),
             bubbles,
             cancelable,
             init.parent.parent.view.as_deref(),

--- a/components/script/dom/node.rs
+++ b/components/script/dom/node.rs
@@ -42,6 +42,7 @@ use servo_arc::Arc as ServoArc;
 use servo_config::pref;
 use servo_url::ServoUrl;
 use smallvec::SmallVec;
+use style::Atom;
 use style::attr::AttrValue;
 use style::context::QuirksMode;
 use style::dom::OpaqueNode;
@@ -519,7 +520,7 @@ impl Node {
     }
 
     /// <https://html.spec.whatwg.org/multipage/#fire-a-synthetic-pointer-event>
-    pub(crate) fn fire_synthetic_pointer_event_not_trusted(&self, name: DOMString, can_gc: CanGc) {
+    pub(crate) fn fire_synthetic_pointer_event_not_trusted(&self, event_type: Atom, can_gc: CanGc) {
         // Spec says the choice of which global to create the pointer event
         // on is not well-defined,
         // and refers to heycam/webidl#135
@@ -528,7 +529,7 @@ impl Node {
         // <https://w3c.github.io/pointerevents/#the-click-auxclick-and-contextmenu-events>
         let pointer_event = PointerEvent::new(
             &window, // ambiguous in spec
-            name,
+            event_type,
             EventBubbles::Bubbles,              // Step 3: bubbles
             EventCancelable::Cancelable,        // Step 3: cancelable
             Some(&window),                      // Step 7: view

--- a/components/script/dom/pointerevent.rs
+++ b/components/script/dom/pointerevent.rs
@@ -9,6 +9,7 @@ use euclid::Point2D;
 use js::rust::HandleObject;
 use keyboard_types::Modifiers;
 use script_bindings::inheritance::Castable;
+use style::Atom;
 use style_traits::CSSPixel;
 
 use super::bindings::codegen::Bindings::MouseEventBinding::MouseEventMethods;
@@ -93,7 +94,7 @@ impl PointerEvent {
     #[expect(clippy::too_many_arguments)]
     pub(crate) fn new(
         window: &Window,
-        type_: DOMString,
+        event_type: Atom,
         can_bubble: EventBubbles,
         cancelable: EventCancelable,
         view: Option<&Window>,
@@ -125,7 +126,7 @@ impl PointerEvent {
         Self::new_with_proto(
             window,
             None,
-            type_,
+            event_type,
             can_bubble,
             cancelable,
             view,
@@ -160,7 +161,7 @@ impl PointerEvent {
     fn new_with_proto(
         window: &Window,
         proto: Option<HandleObject>,
-        type_: DOMString,
+        event_type: Atom,
         can_bubble: EventBubbles,
         cancelable: EventCancelable,
         view: Option<&Window>,
@@ -191,9 +192,9 @@ impl PointerEvent {
     ) -> DomRoot<PointerEvent> {
         let ev = PointerEvent::new_uninitialized_with_proto(window, proto, can_gc);
         // See <https://w3c.github.io/pointerevents/#attributes-and-default-actions>
-        let composed = type_ != "pointerenter" && type_ != "pointerleave";
+        let composed = &*event_type != "pointerenter" && &*event_type != "pointerleave";
         ev.mouseevent.initialize_mouse_event(
-            type_,
+            event_type,
             can_bubble,
             cancelable,
             view,
@@ -232,7 +233,7 @@ impl PointerEventMethods<crate::DomTypeHolder> for PointerEvent {
         window: &Window,
         proto: Option<HandleObject>,
         can_gc: CanGc,
-        type_: DOMString,
+        event_type: DOMString,
         init: &PointerEventInit,
     ) -> DomRoot<PointerEvent> {
         let bubbles = EventBubbles::from(init.parent.parent.parent.parent.bubbles);
@@ -245,7 +246,7 @@ impl PointerEventMethods<crate::DomTypeHolder> for PointerEvent {
         PointerEvent::new_with_proto(
             window,
             proto,
-            type_,
+            event_type.into(),
             bubbles,
             cancelable,
             init.parent.parent.parent.view.as_deref(),

--- a/components/script/dom/touch.rs
+++ b/components/script/dom/touch.rs
@@ -11,7 +11,6 @@ use crate::dom::bindings::codegen::Bindings::TouchBinding::TouchMethods;
 use crate::dom::bindings::num::Finite;
 use crate::dom::bindings::reflector::{Reflector, reflect_dom_object};
 use crate::dom::bindings::root::{DomRoot, MutDom};
-use crate::dom::bindings::str::DOMString;
 use crate::dom::event::{EventBubbles, EventCancelable};
 use crate::dom::eventtarget::EventTarget;
 use crate::dom::pointerevent::PointerEvent;
@@ -141,7 +140,7 @@ impl Touch {
 
         PointerEvent::new(
             window,
-            DOMString::from(event_type),
+            event_type.into(),
             bubbles,
             cancelable,
             Some(window),
@@ -164,7 +163,7 @@ impl Touch {
             0,        // twist
             PI / 2.0, // altitude_angle (perpendicular to surface)
             0.0,      // azimuth_angle
-            DOMString::from("touch"),
+            "touch".into(),
             is_primary,
             vec![], // coalesced_events
             vec![], // predicted_events

--- a/components/script/dom/touchevent.rs
+++ b/components/script/dom/touchevent.rs
@@ -5,13 +5,13 @@
 use std::cell::Cell;
 
 use dom_struct::dom_struct;
+use style::Atom;
 
 use crate::dom::bindings::codegen::Bindings::TouchEventBinding::TouchEventMethods;
 use crate::dom::bindings::codegen::Bindings::UIEventBinding::UIEventMethods;
 use crate::dom::bindings::inheritance::Castable;
 use crate::dom::bindings::reflector::reflect_dom_object;
 use crate::dom::bindings::root::{DomRoot, MutDom};
-use crate::dom::bindings::str::DOMString;
 use crate::dom::event::{Event, EventBubbles, EventCancelable, EventComposed};
 use crate::dom::touchlist::TouchList;
 use crate::dom::uievent::UIEvent;
@@ -84,7 +84,7 @@ impl TouchEvent {
     #[allow(clippy::too_many_arguments)]
     pub(crate) fn new(
         window: &Window,
-        type_: DOMString,
+        event_type: Atom,
         can_bubble: EventBubbles,
         cancelable: EventCancelable,
         composed: EventComposed,
@@ -101,8 +101,8 @@ impl TouchEvent {
     ) -> DomRoot<TouchEvent> {
         let ev =
             TouchEvent::new_uninitialized(window, touches, changed_touches, target_touches, can_gc);
-        ev.upcast::<UIEvent>().InitUIEvent(
-            type_,
+        ev.upcast::<UIEvent>().init_event(
+            event_type,
             bool::from(can_bubble),
             bool::from(cancelable),
             view,

--- a/components/script/dom/uievent.rs
+++ b/components/script/dom/uievent.rs
@@ -64,7 +64,7 @@ impl UIEvent {
     #[allow(clippy::too_many_arguments)]
     pub(crate) fn new(
         window: &Window,
-        type_: DOMString,
+        event_type: Atom,
         can_bubble: EventBubbles,
         cancelable: EventCancelable,
         view: Option<&Window>,
@@ -73,7 +73,7 @@ impl UIEvent {
         can_gc: CanGc,
     ) -> DomRoot<UIEvent> {
         Self::new_with_proto(
-            window, None, type_, can_bubble, cancelable, view, detail, which, can_gc,
+            window, None, event_type, can_bubble, cancelable, view, detail, which, can_gc,
         )
     }
 
@@ -81,7 +81,7 @@ impl UIEvent {
     fn new_with_proto(
         window: &Window,
         proto: Option<HandleObject>,
-        type_: DOMString,
+        event_type: Atom,
         can_bubble: EventBubbles,
         cancelable: EventCancelable,
         view: Option<&Window>,
@@ -91,7 +91,7 @@ impl UIEvent {
     ) -> DomRoot<UIEvent> {
         let ev = UIEvent::new_uninitialized_with_proto(window, proto, can_gc);
         ev.initialize_ui_event(
-            type_,
+            event_type,
             view.map(|window| window.upcast::<EventTarget>()),
             can_bubble,
             cancelable,
@@ -104,14 +104,14 @@ impl UIEvent {
     /// <https://w3c.github.io/uievents/#initialize-a-uievent>
     pub(crate) fn initialize_ui_event(
         &self,
-        type_: DOMString,
+        event_type: Atom,
         target_: Option<&EventTarget>,
         bubbles: EventBubbles,
         cancelable: EventCancelable,
     ) {
         // 1. Initialize the base Event attributes:
         self.event
-            .init_event(type_.into(), bool::from(bubbles), bool::from(cancelable));
+            .init_event(event_type, bool::from(bubbles), bool::from(cancelable));
         self.event.set_target(target_);
         // 2. Initialize view/detail:
         if let Some(target_) = target_ {
@@ -128,6 +128,25 @@ impl UIEvent {
     pub(crate) fn set_detail(&self, detail_: i32) {
         self.detail.set(detail_);
     }
+
+    /// <https://w3c.github.io/uievents/#widl-UIEvent-initUIEvent>
+    pub(crate) fn init_event(
+        &self,
+        event_type: Atom,
+        can_bubble: bool,
+        cancelable: bool,
+        view: Option<&Window>,
+        detail: i32,
+    ) {
+        let event = self.upcast::<Event>();
+        if event.dispatching() {
+            return;
+        }
+
+        event.init_event(event_type, can_bubble, cancelable);
+        self.view.set(view);
+        self.detail.set(detail);
+    }
 }
 
 impl UIEventMethods<crate::DomTypeHolder> for UIEvent {
@@ -136,7 +155,7 @@ impl UIEventMethods<crate::DomTypeHolder> for UIEvent {
         window: &Window,
         proto: Option<HandleObject>,
         can_gc: CanGc,
-        type_: DOMString,
+        event_type: DOMString,
         init: &UIEventBinding::UIEventInit,
     ) -> Fallible<DomRoot<UIEvent>> {
         let bubbles = EventBubbles::from(init.parent.bubbles);
@@ -144,7 +163,7 @@ impl UIEventMethods<crate::DomTypeHolder> for UIEvent {
         let event = UIEvent::new_with_proto(
             window,
             proto,
-            type_,
+            event_type.into(),
             bubbles,
             cancelable,
             init.view.as_deref(),
@@ -168,20 +187,13 @@ impl UIEventMethods<crate::DomTypeHolder> for UIEvent {
     /// <https://w3c.github.io/uievents/#widl-UIEvent-initUIEvent>
     fn InitUIEvent(
         &self,
-        type_: DOMString,
+        event_type: DOMString,
         can_bubble: bool,
         cancelable: bool,
         view: Option<&Window>,
         detail: i32,
     ) {
-        let event = self.upcast::<Event>();
-        if event.dispatching() {
-            return;
-        }
-
-        event.init_event(Atom::from(type_), can_bubble, cancelable);
-        self.view.set(view);
-        self.detail.set(detail);
+        self.init_event(event_type.into(), can_bubble, cancelable, view, detail);
     }
 
     /// <https://dom.spec.whatwg.org/#dom-event-istrusted>

--- a/components/script/dom/webgpu/gpudevice.rs
+++ b/components/script/dom/webgpu/gpudevice.rs
@@ -40,7 +40,7 @@ use crate::dom::bindings::inheritance::Castable;
 use crate::dom::bindings::refcounted::Trusted;
 use crate::dom::bindings::reflector::{DomGlobal, reflect_dom_object};
 use crate::dom::bindings::root::{Dom, DomRoot};
-use crate::dom::bindings::str::{DOMString, USVString};
+use crate::dom::bindings::str::USVString;
 use crate::dom::bindings::trace::RootedTraceableBox;
 use crate::dom::event::Event;
 use crate::dom::eventtarget::EventTarget;
@@ -230,7 +230,7 @@ impl GPUDevice {
 
                 let event = GPUUncapturedErrorEvent::new(
                     &this.global(),
-                    DOMString::from("uncapturederror"),
+                    atom!("uncapturederror"),
                     &GPUUncapturedErrorEventInit {
                         error,
                         parent: EventInit::empty(),

--- a/components/script/dom/webgpu/gpuuncapturederrorevent.rs
+++ b/components/script/dom/webgpu/gpuuncapturederrorevent.rs
@@ -35,32 +35,30 @@ impl GPUUncapturedErrorEvent {
 
     pub(crate) fn new(
         global: &GlobalScope,
-        type_: DOMString,
+        event_type: Atom,
         init: &GPUUncapturedErrorEventInit,
         can_gc: CanGc,
     ) -> DomRoot<Self> {
-        Self::new_with_proto(global, None, type_, init, can_gc)
+        Self::new_with_proto(global, None, event_type, init, can_gc)
     }
 
     fn new_with_proto(
         global: &GlobalScope,
         proto: Option<HandleObject>,
-        type_: DOMString,
+        event_type: Atom,
         init: &GPUUncapturedErrorEventInit,
         can_gc: CanGc,
     ) -> DomRoot<Self> {
-        let ev = reflect_dom_object_with_proto(
+        let event = reflect_dom_object_with_proto(
             Box::new(GPUUncapturedErrorEvent::new_inherited(init)),
             global,
             proto,
             can_gc,
         );
-        ev.event.init_event(
-            Atom::from(type_),
-            init.parent.bubbles,
-            init.parent.cancelable,
-        );
-        ev
+        event
+            .event
+            .init_event(event_type, init.parent.bubbles, init.parent.cancelable);
+        event
     }
 }
 
@@ -70,10 +68,10 @@ impl GPUUncapturedErrorEventMethods<crate::DomTypeHolder> for GPUUncapturedError
         global: &GlobalScope,
         proto: Option<HandleObject>,
         can_gc: CanGc,
-        type_: DOMString,
+        event_type: DOMString,
         init: &GPUUncapturedErrorEventInit,
     ) -> DomRoot<Self> {
-        GPUUncapturedErrorEvent::new_with_proto(global, proto, type_, init, can_gc)
+        GPUUncapturedErrorEvent::new_with_proto(global, proto, event_type.into(), init, can_gc)
     }
 
     /// <https://gpuweb.github.io/gpuweb/#dom-gpuuncapturederrorevent-error>

--- a/components/script/dom/wheelevent.rs
+++ b/components/script/dom/wheelevent.rs
@@ -8,6 +8,7 @@ use dom_struct::dom_struct;
 use euclid::Point2D;
 use js::rust::HandleObject;
 use keyboard_types::Modifiers;
+use style::Atom;
 use style_traits::CSSPixel;
 
 use crate::dom::bindings::codegen::Bindings::MouseEventBinding::MouseEventMethods;
@@ -56,7 +57,7 @@ impl WheelEvent {
     #[allow(clippy::too_many_arguments)]
     pub(crate) fn new(
         window: &Window,
-        type_: DOMString,
+        event_type: Atom,
         can_bubble: EventBubbles,
         cancelable: EventCancelable,
         view: Option<&Window>,
@@ -78,7 +79,7 @@ impl WheelEvent {
         Self::new_with_proto(
             window,
             None,
-            type_,
+            event_type,
             can_bubble,
             cancelable,
             view,
@@ -103,7 +104,7 @@ impl WheelEvent {
     fn new_with_proto(
         window: &Window,
         proto: Option<HandleObject>,
-        type_: DOMString,
+        event_type: Atom,
         can_bubble: EventBubbles,
         cancelable: EventCancelable,
         view: Option<&Window>,
@@ -124,7 +125,7 @@ impl WheelEvent {
     ) -> DomRoot<WheelEvent> {
         let ev = WheelEvent::new_unintialized(window, proto, can_gc);
         ev.intitialize_wheel_event(
-            type_,
+            event_type,
             can_bubble,
             cancelable,
             view,
@@ -149,7 +150,7 @@ impl WheelEvent {
     #[allow(clippy::too_many_arguments)]
     pub(crate) fn intitialize_wheel_event(
         &self,
-        type_: DOMString,
+        event_type: Atom,
         can_bubble: EventBubbles,
         cancelable: EventCancelable,
         view: Option<&Window>,
@@ -172,7 +173,7 @@ impl WheelEvent {
         }
 
         self.upcast::<MouseEvent>().initialize_mouse_event(
-            type_,
+            event_type,
             can_bubble,
             cancelable,
             view,
@@ -199,7 +200,7 @@ impl WheelEventMethods<crate::DomTypeHolder> for WheelEvent {
         window: &Window,
         proto: Option<HandleObject>,
         can_gc: CanGc,
-        type_: DOMString,
+        event_type: DOMString,
         init: &WheelEventBinding::WheelEventInit,
     ) -> Fallible<DomRoot<WheelEvent>> {
         let bubbles = EventBubbles::from(init.parent.parent.parent.parent.bubbles);
@@ -214,7 +215,7 @@ impl WheelEventMethods<crate::DomTypeHolder> for WheelEvent {
         let event = WheelEvent::new_with_proto(
             window,
             proto,
-            type_,
+            event_type.into(),
             bubbles,
             cancelable,
             init.parent.parent.parent.view.as_deref(),

--- a/components/script/dom/window.rs
+++ b/components/script/dom/window.rs
@@ -3455,7 +3455,7 @@ impl Window {
         if size_type == WindowSizeType::Resize {
             let uievent = UIEvent::new(
                 self,
-                DOMString::from("resize"),
+                atom!("resize"),
                 EventBubbles::DoesNotBubble,
                 EventCancelable::NotCancelable,
                 Some(self),
@@ -3481,7 +3481,7 @@ impl Window {
 
             let uievent = UIEvent::new(
                 self,
-                DOMString::from("resize"),
+                atom!("resize"),
                 EventBubbles::DoesNotBubble,
                 EventCancelable::NotCancelable,
                 Some(self),

--- a/components/script/textinput.rs
+++ b/components/script/textinput.rs
@@ -1125,7 +1125,7 @@ impl<T: ClipboardProvider> TextInput<T> {
                 let event = InputEvent::new(
                     window,
                     None,
-                    DOMString::from("input"),
+                    atom!("input"),
                     true,
                     false,
                     Some(window),


### PR DESCRIPTION
Accepting the name of the event as a `DOMString` means that when events
are constructed from within Servo (for instance via input event
handling), the static strings are converted to an owned `String`
wrapped in a `DOMString` and then finally converted to an `Atom` in
`Event`. This makes it so that all non-generated `Event` constructors
accept `Atom`, which can avoid a conversion entirely when the atom
already exists on the Stylo atoms list and eliminate one in-memory copy
in the case that it isn't on the atom list.

Eventually, all event names can be on the atom list and we can eliminate
all copies. This is a tiny optimization, but also makes the code much
friendlier everywhere.

Testing: This should not change behavior so should be covered by existing test.
