### PR TITLE
script: Allow focusing boxes with overflow with the keyboard

### DIFF
--- a/components/script/dom/element.rs
+++ b/components/script/dom/element.rs
@@ -1871,6 +1871,26 @@ impl Element {
             return FocusableAreaKind::Click | FocusableAreaKind::Sequential;
         }
 
+        // > The scrollable regions of elements that are being rendered and are not inert.
+        //
+        // Note that these kind of focusable areas are only focusable via the keyboard.
+        //
+        // TODO: Handle inert.
+        if self
+            .upcast::<Node>()
+            .effective_overflow()
+            .is_some_and(|axes_overflow| {
+                // This is checking whether there is an input event scrollable overflow value in
+                // a given axis and also overflow in that same axis.
+                (matches!(axes_overflow.x, Overflow::Auto | Overflow::Scroll) &&
+                    self.ScrollWidth() > self.ClientWidth()) ||
+                    (matches!(axes_overflow.y, Overflow::Auto | Overflow::Scroll) &&
+                        self.ScrollHeight() > self.ClientHeight())
+            })
+        {
+            return FocusableAreaKind::Sequential;
+        }
+
         Default::default()
     }
 

--- a/tests/wpt/meta/shadow-dom/focus-navigation/tentative/focus-scroller-layout-update.html.ini
+++ b/tests/wpt/meta/shadow-dom/focus-navigation/tentative/focus-scroller-layout-update.html.ini
@@ -1,3 +1,0 @@
-[focus-scroller-layout-update.html]
-  [When checking that element is a scroller, layout information should be up to date.]
-    expected: FAIL


### PR DESCRIPTION
This change makes it possible to focus boxes with overflow via the
keyboard. These boxes should be focusable areas, yet are not focusable
via the mouse. Instead they can be focused via sequential tab
navigation.

Testing: This fixes a WPT test.
