### PR TITLE
Explicitly set publish = false for test crates

### DIFF
--- a/tests/unit/deny_public_fields/Cargo.toml
+++ b/tests/unit/deny_public_fields/Cargo.toml
@@ -4,8 +4,8 @@ version.workspace = true
 authors.workspace = true
 license.workspace = true
 edition.workspace = true
-publish.workspace = true
 rust-version.workspace = true
+publish = false
 
 [lib]
 path = "lib.rs"

--- a/tests/unit/malloc_size_of/Cargo.toml
+++ b/tests/unit/malloc_size_of/Cargo.toml
@@ -4,8 +4,8 @@ version.workspace = true
 authors.workspace = true
 license.workspace = true
 edition.workspace = true
-publish.workspace = true
 rust-version.workspace = true
+publish = false
 
 [lib]
 path = "lib.rs"

--- a/tests/unit/profile/Cargo.toml
+++ b/tests/unit/profile/Cargo.toml
@@ -4,8 +4,8 @@ version.workspace = true
 authors.workspace = true
 license.workspace = true
 edition.workspace = true
-publish.workspace = true
 rust-version.workspace = true
+publish = false
 
 [lib]
 name = "profile_tests"

--- a/tests/unit/script/Cargo.toml
+++ b/tests/unit/script/Cargo.toml
@@ -4,8 +4,8 @@ version.workspace = true
 authors.workspace = true
 license.workspace = true
 edition.workspace = true
-publish.workspace = true
 rust-version.workspace = true
+publish = false
 
 [lib]
 name = "script_tests"

--- a/tests/unit/style/Cargo.toml
+++ b/tests/unit/style/Cargo.toml
@@ -4,8 +4,8 @@ version.workspace = true
 authors.workspace = true
 license.workspace = true
 edition.workspace = true
-publish.workspace = true
 rust-version.workspace = true
+publish = false
 
 [lib]
 name = "style_tests"


### PR DESCRIPTION
The workspace `publish` key is currently also set to false, but we will probably start publishing in the future. To prepare for that we explicitly prevent publishing in these crates, instead of following the workspace setting.

Testing: No functional changes, covered by cargo build still working.

