### PR TITLE
script_bindings: Eliminate `DOMString::from_string`

### DIFF
--- a/components/script/dom/client.rs
+++ b/components/script/dom/client.rs
@@ -73,7 +73,6 @@ impl ClientMethods<crate::DomTypeHolder> for Client {
 
     /// <https://w3c.github.io/ServiceWorker/#client-id>
     fn Id(&self) -> DOMString {
-        let uid_str = format!("{}", self.id);
-        DOMString::from_string(uid_str)
+        format!("{}", self.id).into()
     }
 }

--- a/components/script/dom/console.rs
+++ b/components/script/dom/console.rs
@@ -130,7 +130,7 @@ unsafe fn handle_value_to_string(cx: *mut jsapi::JSContext, value: HandleValue) 
     match std::ptr::NonNull::new(unsafe { JS_ValueToSource(cx, value) }) {
         Some(js_str) => {
             js_string.set(js_str.as_ptr());
-            DOMString::from_string(unsafe { jsstr_to_string(cx, js_str) })
+            unsafe { jsstr_to_string(cx, js_str) }.into()
         },
         None => "<error converting value to string>".into(),
     }
@@ -275,7 +275,7 @@ fn stringify_handle_value(message: HandleValue) -> DOMString {
     unsafe {
         if message.is_string() {
             let jsstr = std::ptr::NonNull::new(message.to_string()).unwrap();
-            return DOMString::from_string(jsstr_to_string(*cx, jsstr));
+            return jsstr_to_string(*cx, jsstr).into();
         }
         unsafe fn stringify_object_from_handle_value(
             cx: *mut jsapi::JSContext,

--- a/components/script/dom/css/cssimportrule.rs
+++ b/components/script/dom/css/cssimportrule.rs
@@ -79,7 +79,7 @@ impl CSSImportRuleMethods<crate::DomTypeHolder> for CSSImportRule {
         match &self.import_rule.borrow().read_with(&guard).layer {
             ImportLayer::None => None,
             ImportLayer::Anonymous => Some(DOMString::new()),
-            ImportLayer::Named(name) => Some(DOMString::from_string(name.to_css_string())),
+            ImportLayer::Named(name) => Some(name.to_css_string().into()),
         }
     }
 }

--- a/components/script/dom/css/csslayerblockrule.rs
+++ b/components/script/dom/css/csslayerblockrule.rs
@@ -84,10 +84,11 @@ impl SpecificCSSRule for CSSLayerBlockRule {
 impl CSSLayerBlockRuleMethods<crate::DomTypeHolder> for CSSLayerBlockRule {
     /// <https://drafts.csswg.org/css-cascade-5/#dom-csslayerblockrule-name>
     fn Name(&self) -> DOMString {
-        if let Some(name) = &self.layer_block_rule.borrow().name {
-            DOMString::from_string(name.to_css_string())
-        } else {
-            DOMString::new()
-        }
+        self.layer_block_rule
+            .borrow()
+            .name
+            .as_ref()
+            .map(|name| name.to_css_cssstring().into())
+            .unwrap_or_default()
     }
 }

--- a/components/script/dom/css/csslayerstatementrule.rs
+++ b/components/script/dom/css/csslayerstatementrule.rs
@@ -83,7 +83,7 @@ impl CSSLayerStatementRuleMethods<crate::DomTypeHolder> for CSSLayerStatementRul
             .borrow()
             .names
             .iter()
-            .map(|name| DOMString::from_string(name.to_css_string()))
+            .map(|name| name.to_css_string().into())
             .collect();
         to_frozen_array(names.as_slice(), cx, retval, can_gc)
     }

--- a/components/script/dom/css/cssstylerule.rs
+++ b/components/script/dom/css/cssstylerule.rs
@@ -123,13 +123,12 @@ impl CSSStyleRuleMethods<crate::DomTypeHolder> for CSSStyleRule {
     /// <https://drafts.csswg.org/cssom/#dom-cssstylerule-selectortext>
     fn SelectorText(&self) -> DOMString {
         let guard = self.css_grouping_rule.shared_lock().read();
-        DOMString::from_string(
-            self.style_rule
-                .borrow()
-                .read_with(&guard)
-                .selectors
-                .to_css_string(),
-        )
+        self.style_rule
+            .borrow()
+            .read_with(&guard)
+            .selectors
+            .to_css_string()
+            .into()
     }
 
     /// <https://drafts.csswg.org/cssom/#dom-cssstylerule-selectortext>

--- a/components/script/dom/domexception.rs
+++ b/components/script/dom/domexception.rs
@@ -272,7 +272,7 @@ impl Serializable for DOMException {
     {
         Ok(Self::new_with_custom_message(
             owner,
-            DOMErrorName::from(&DOMString::from_string(serialized.name)).ok_or(())?,
+            DOMErrorName::from(&DOMString::from(serialized.name)).ok_or(())?,
             serialized.message,
             can_gc,
         ))

--- a/components/script/dom/domstringlist.rs
+++ b/components/script/dom/domstringlist.rs
@@ -49,10 +49,9 @@ impl DOMStringList {
             .map(|dom_string| dom_string.str().encode_utf16().collect::<Vec<u16>>())
             .sorted_unstable()
             .map(|utf16_str| {
-                DOMString::from_string(
-                    String::from_utf16(utf16_str.as_slice())
-                        .expect("can't convert object store name from utf16 back to utf8"),
-                )
+                String::from_utf16(utf16_str.as_slice())
+                    .expect("can't convert object store name from utf16 back to utf8")
+                    .into()
             })
             .collect();
         Self::new(global, sorted, can_gc)

--- a/components/script/dom/globalscope.rs
+++ b/components/script/dom/globalscope.rs
@@ -1315,9 +1315,7 @@ impl GlobalScope {
             }
 
             // - Check for a case-sensitive match for the name of the channel.
-            let channel_name = DOMString::from_string(channel_name);
-
-            if let Some(channels) = channels.get(&channel_name) {
+            if let Some(channels) = channels.get(&channel_name.into()) {
                 channels
                     .iter()
                     .filter(|channel| {

--- a/components/script/dom/html/htmlfieldsetelement.rs
+++ b/components/script/dom/html/htmlfieldsetelement.rs
@@ -149,7 +149,7 @@ impl HTMLFieldSetElementMethods<crate::DomTypeHolder> for HTMLFieldSetElement {
 
     /// <https://html.spec.whatwg.org/multipage/#dom-fieldset-type>
     fn Type(&self) -> DOMString {
-        DOMString::from_string(String::from("fieldset"))
+        "fieldset".into()
     }
 }
 

--- a/components/script/dom/html/htmlhyperlinkelementutils.rs
+++ b/components/script/dom/html/htmlhyperlinkelementutils.rs
@@ -201,11 +201,8 @@ impl<T: HyperlinkElement + DerivedFrom<Element> + Castable + NodeTraits> Hyperli
 
     /// <https://html.spec.whatwg.org/multipage/#dom-hyperlink-href
     fn set_href(&self, value: USVString, can_gc: CanGc) {
-        self.upcast::<Element>().set_string_attribute(
-            &local_name!("href"),
-            DOMString::from_string(value.0),
-            can_gc,
-        );
+        self.upcast::<Element>()
+            .set_string_attribute(&local_name!("href"), value.into(), can_gc);
 
         self.set_url();
     }

--- a/components/script/dom/html/htmlinputelement.rs
+++ b/components/script/dom/html/htmlinputelement.rs
@@ -2469,7 +2469,7 @@ impl HTMLInputElement {
                     .parse_local_date_time_string()
                     .map(|date_time| date_time.to_local_date_time_string());
                 match time {
-                    Some(normalized_string) => *value = DOMString::from_string(normalized_string),
+                    Some(normalized_string) => *value = normalized_string.into(),
                     None => value.clear(),
                 }
             },
@@ -2847,7 +2847,7 @@ impl HTMLInputElement {
     /// This does the safe Rust part of conversion; the unsafe JS Date part
     /// is in SetValueAsDate
     fn convert_datetime_to_dom_string(&self, value: OffsetDateTime) -> DOMString {
-        DOMString::from_string(match self.input_type() {
+        match self.input_type() {
             InputType::Date => value.to_date_string(),
             InputType::Month => value.to_month_string(),
             InputType::Week => value.to_week_string(),
@@ -2856,7 +2856,8 @@ impl HTMLInputElement {
             _ => {
                 unreachable!("Should not have called convert_datetime_to_string for non-Date types")
             },
-        })
+        }
+        .into()
     }
 
     fn update_related_validity_states(&self, can_gc: CanGc) {

--- a/components/script/dom/html/htmlmeterelement.rs
+++ b/components/script/dom/html/htmlmeterelement.rs
@@ -184,10 +184,8 @@ impl HTMLMeterElementMethods<crate::DomTypeHolder> for HTMLMeterElement {
 
     /// <https://html.spec.whatwg.org/multipage/#dom-meter-value>
     fn SetValue(&self, value: Finite<f64>, can_gc: CanGc) {
-        let mut string_value = DOMString::from_string((*value).to_string());
-
+        let mut string_value = DOMString::from((*value).to_string());
         string_value.set_best_representation_of_the_floating_point_number();
-
         self.upcast::<Element>()
             .set_string_attribute(&local_name!("value"), string_value, can_gc);
     }
@@ -204,10 +202,8 @@ impl HTMLMeterElementMethods<crate::DomTypeHolder> for HTMLMeterElement {
 
     /// <https://html.spec.whatwg.org/multipage/#dom-meter-min>
     fn SetMin(&self, value: Finite<f64>, can_gc: CanGc) {
-        let mut string_value = DOMString::from_string((*value).to_string());
-
+        let mut string_value = DOMString::from((*value).to_string());
         string_value.set_best_representation_of_the_floating_point_number();
-
         self.upcast::<Element>()
             .set_string_attribute(&local_name!("min"), string_value, can_gc);
     }
@@ -225,10 +221,8 @@ impl HTMLMeterElementMethods<crate::DomTypeHolder> for HTMLMeterElement {
 
     /// <https://html.spec.whatwg.org/multipage/#concept-meter-maximum>
     fn SetMax(&self, value: Finite<f64>, can_gc: CanGc) {
-        let mut string_value = DOMString::from_string((*value).to_string());
-
+        let mut string_value = DOMString::from((*value).to_string());
         string_value.set_best_representation_of_the_floating_point_number();
-
         self.upcast::<Element>()
             .set_string_attribute(&local_name!("max"), string_value, can_gc);
     }
@@ -250,10 +244,8 @@ impl HTMLMeterElementMethods<crate::DomTypeHolder> for HTMLMeterElement {
 
     /// <https://html.spec.whatwg.org/multipage/#dom-meter-low>
     fn SetLow(&self, value: Finite<f64>, can_gc: CanGc) {
-        let mut string_value = DOMString::from_string((*value).to_string());
-
+        let mut string_value = DOMString::from((*value).to_string());
         string_value.set_best_representation_of_the_floating_point_number();
-
         self.upcast::<Element>()
             .set_string_attribute(&local_name!("low"), string_value, can_gc);
     }
@@ -279,10 +271,8 @@ impl HTMLMeterElementMethods<crate::DomTypeHolder> for HTMLMeterElement {
 
     /// <https://html.spec.whatwg.org/multipage/#dom-meter-high>
     fn SetHigh(&self, value: Finite<f64>, can_gc: CanGc) {
-        let mut string_value = DOMString::from_string((*value).to_string());
-
+        let mut string_value = DOMString::from((*value).to_string());
         string_value.set_best_representation_of_the_floating_point_number();
-
         self.upcast::<Element>()
             .set_string_attribute(&local_name!("high"), string_value, can_gc);
     }
@@ -304,10 +294,8 @@ impl HTMLMeterElementMethods<crate::DomTypeHolder> for HTMLMeterElement {
 
     /// <https://html.spec.whatwg.org/multipage/#dom-meter-optimum>
     fn SetOptimum(&self, value: Finite<f64>, can_gc: CanGc) {
-        let mut string_value = DOMString::from_string((*value).to_string());
-
+        let mut string_value = DOMString::from((*value).to_string());
         string_value.set_best_representation_of_the_floating_point_number();
-
         self.upcast::<Element>().set_string_attribute(
             &local_name!("optimum"),
             string_value,

--- a/components/script/dom/html/htmlprogresselement.rs
+++ b/components/script/dom/html/htmlprogresselement.rs
@@ -145,10 +145,8 @@ impl HTMLProgressElementMethods<crate::DomTypeHolder> for HTMLProgressElement {
     /// <https://html.spec.whatwg.org/multipage/#dom-progress-value>
     fn SetValue(&self, new_val: Finite<f64>, can_gc: CanGc) {
         if *new_val >= 0.0 {
-            let mut string_value = DOMString::from_string((*new_val).to_string());
-
+            let mut string_value = DOMString::from((*new_val).to_string());
             string_value.set_best_representation_of_the_floating_point_number();
-
             self.upcast::<Element>().set_string_attribute(
                 &local_name!("value"),
                 string_value,
@@ -177,10 +175,8 @@ impl HTMLProgressElementMethods<crate::DomTypeHolder> for HTMLProgressElement {
     /// <https://html.spec.whatwg.org/multipage/#dom-progress-max>
     fn SetMax(&self, new_val: Finite<f64>, can_gc: CanGc) {
         if *new_val > 0.0 {
-            let mut string_value = DOMString::from_string((*new_val).to_string());
-
+            let mut string_value = DOMString::from((*new_val).to_string());
             string_value.set_best_representation_of_the_floating_point_number();
-
             self.upcast::<Element>().set_string_attribute(
                 &local_name!("max"),
                 string_value,

--- a/components/script/dom/indexeddb/idbdatabase.rs
+++ b/components/script/dom/indexeddb/idbdatabase.rs
@@ -106,8 +106,7 @@ impl IDBDatabase {
     pub(crate) fn set_object_store_names_from_backend(&self, names: Vec<String>) {
         // https://w3c.github.io/IndexedDB/#abort-upgrade-transaction
         // Step 4. NOTE: This reverts the value of objectStoreNames returned by the IDBDatabase object.
-        *self.object_store_names.borrow_mut() =
-            names.into_iter().map(DOMString::from_string).collect();
+        *self.object_store_names.borrow_mut() = names.into_iter().map(Into::into).collect();
     }
 
     pub(crate) fn restore_object_store_names(&self, names: Vec<DOMString>) {

--- a/components/script/dom/indexeddb/idbobjectstore.rs
+++ b/components/script/dom/indexeddb/idbobjectstore.rs
@@ -65,9 +65,9 @@ impl From<StringOrStringSequence> for KeyPath {
 impl From<indexeddb::KeyPath> for KeyPath {
     fn from(value: indexeddb::KeyPath) -> Self {
         match value {
-            indexeddb::KeyPath::String(s) => KeyPath::String(DOMString::from_string(s)),
+            indexeddb::KeyPath::String(string) => KeyPath::String(string.into()),
             indexeddb::KeyPath::Sequence(ss) => {
-                KeyPath::StringSequence(ss.into_iter().map(DOMString::from_string).collect())
+                KeyPath::StringSequence(ss.into_iter().map(Into::into).collect())
             },
         }
     }

--- a/components/script/dom/indexeddb/idbopendbrequest.rs
+++ b/components/script/dom/indexeddb/idbopendbrequest.rs
@@ -19,7 +19,6 @@ use crate::dom::bindings::inheritance::Castable;
 use crate::dom::bindings::refcounted::Trusted;
 use crate::dom::bindings::reflector::{DomGlobal, reflect_dom_object};
 use crate::dom::bindings::root::{DomRoot, MutNullableDom};
-use crate::dom::bindings::str::DOMString;
 use crate::dom::event::{Event, EventBubbles, EventCancelable};
 use crate::dom::globalscope::GlobalScope;
 use crate::dom::indexeddb::idbdatabase::IDBDatabase;
@@ -141,13 +140,7 @@ impl IDBOpenDBRequest {
     ) -> DomRoot<IDBDatabase> {
         self.pending_connection.or_init(|| {
             debug_assert!(!upgraded, "A connection should exist for the upgraded db.");
-            IDBDatabase::new(
-                global,
-                DOMString::from_string(name.clone()),
-                self.get_id(),
-                version,
-                can_gc,
-            )
+            IDBDatabase::new(global, name.into(), self.get_id(), version, can_gc)
         })
     }
 

--- a/components/script/dom/indexeddb/idbtransaction.rs
+++ b/components/script/dom/indexeddb/idbtransaction.rs
@@ -634,10 +634,10 @@ impl IDBTransaction {
         // First unwrap for ipc
         // Second unwrap will never happen unless this db gets manually deleted somehow
         let key_path = object_store.key_path.map(|key_path| match key_path {
-            KeyPath::String(s) => StringOrStringSequence::String(DOMString::from_string(s)),
-            KeyPath::Sequence(seq) => StringOrStringSequence::StringSequence(
-                seq.into_iter().map(DOMString::from_string).collect(),
-            ),
+            KeyPath::String(string) => StringOrStringSequence::String(string.into()),
+            KeyPath::Sequence(seq) => {
+                StringOrStringSequence::StringSequence(seq.into_iter().map(Into::into).collect())
+            },
         });
         Some((
             IDBObjectStoreParameters {
@@ -697,7 +697,7 @@ impl IDBTransactionMethods<crate::DomTypeHolder> for IDBTransaction {
         if let Some(indexes) = parameters.map(|(_, indexes, _)| indexes) {
             for index in indexes {
                 store.add_index(
-                    DOMString::from_string(index.name),
+                    index.name.into(),
                     &IDBIndexParameters {
                         multiEntry: index.multi_entry,
                         unique: index.unique,

--- a/components/script/dom/intersectionobserver.rs
+++ b/components/script/dom/intersectionobserver.rs
@@ -717,7 +717,7 @@ impl IntersectionObserverMethods<crate::DomTypeHolder> for IntersectionObserver 
     ///
     /// <https://w3c.github.io/IntersectionObserver/#dom-intersectionobserver-rootmargin>
     fn RootMargin(&self) -> DOMString {
-        DOMString::from_string(self.root_margin.borrow().to_css_string())
+        self.root_margin.borrow().to_css_string().into()
     }
 
     /// > Offsets are applied to scrollports on the path from intersection root to target,
@@ -725,7 +725,7 @@ impl IntersectionObserverMethods<crate::DomTypeHolder> for IntersectionObserver 
     ///
     /// <https://w3c.github.io/IntersectionObserver/#dom-intersectionobserver-scrollmargin>
     fn ScrollMargin(&self) -> DOMString {
-        DOMString::from_string(self.scroll_margin.borrow().to_css_string())
+        self.scroll_margin.borrow().to_css_string().into()
     }
 
     /// > A list of thresholds, sorted in increasing numeric order, where each threshold

--- a/components/script/dom/media/mediaquerylist.rs
+++ b/components/script/dom/media/mediaquerylist.rs
@@ -105,7 +105,7 @@ impl MediaQueryListMethods<crate::DomTypeHolder> for MediaQueryList {
     /// <https://drafts.csswg.org/cssom-view/#dom-mediaquerylist-addlistener>
     fn AddListener(&self, listener: Option<Rc<EventListener>>) {
         self.upcast::<EventTarget>().add_event_listener(
-            DOMString::from_string("change".to_owned()),
+            "change".into(),
             listener,
             AddEventListenerOptions {
                 parent: EventListenerOptions { capture: false },
@@ -119,7 +119,7 @@ impl MediaQueryListMethods<crate::DomTypeHolder> for MediaQueryList {
     /// <https://drafts.csswg.org/cssom-view/#dom-mediaquerylist-removelistener>
     fn RemoveListener(&self, listener: Option<Rc<EventListener>>) {
         self.upcast::<EventTarget>().remove_event_listener(
-            DOMString::from_string("change".to_owned()),
+            "change".into(),
             &listener,
             &EventListenerOptions { capture: false },
         );

--- a/components/script/dom/media/mediasession.rs
+++ b/components/script/dom/media/mediasession.rs
@@ -26,7 +26,6 @@ use crate::dom::bindings::codegen::Bindings::MediaSessionBinding::{
 use crate::dom::bindings::error::{Error, Fallible};
 use crate::dom::bindings::reflector::{DomGlobal, Reflector, reflect_dom_object};
 use crate::dom::bindings::root::DomRoot;
-use crate::dom::bindings::str::DOMString;
 use crate::dom::bindings::trace::HashMapTracedValues;
 use crate::dom::bindings::weakref::MutableWeakRef;
 use crate::dom::html::htmlmediaelement::HTMLMediaElement;
@@ -145,9 +144,9 @@ impl MediaSessionMethods<crate::DomTypeHolder> for MediaSession {
     fn GetMetadata(&self, can_gc: CanGc) -> Option<DomRoot<MediaMetadata>> {
         if let Some(ref metadata) = *self.metadata.borrow() {
             let mut init = MediaMetadataInit::empty();
-            init.title = DOMString::from_string(metadata.title.clone());
-            init.artist = DOMString::from_string(metadata.artist.clone());
-            init.album = DOMString::from_string(metadata.album.clone());
+            init.title = metadata.title.clone().into();
+            init.artist = metadata.artist.clone().into();
+            init.album = metadata.album.clone().into();
             let global = self.global();
             Some(MediaMetadata::new(global.as_window(), &init, can_gc))
         } else {

--- a/components/script/dom/quotaexceedederror.rs
+++ b/components/script/dom/quotaexceedederror.rs
@@ -39,10 +39,7 @@ impl QuotaExceededError {
         requested: Option<Finite<f64>>,
     ) -> Self {
         Self {
-            dom_exception: DOMException::new_inherited(
-                message,
-                DOMString::from_string("QuotaExceededError".to_string()),
-            ),
+            dom_exception: DOMException::new_inherited(message, "QuotaExceededError".into()),
             quota,
             requested,
         }

--- a/components/script/dom/request.rs
+++ b/components/script/dom/request.rs
@@ -686,8 +686,7 @@ impl RequestMethods<crate::DomTypeHolder> for Request {
 
     /// <https://fetch.spec.whatwg.org/#dom-request-integrity>
     fn Integrity(&self) -> DOMString {
-        let r = self.request.borrow();
-        DOMString::from_string(r.integrity_metadata.clone())
+        self.request.borrow().integrity_metadata.clone().into()
     }
 
     /// <https://fetch.spec.whatwg.org/#dom-request-keepalive>

--- a/components/script/dom/storageevent.rs
+++ b/components/script/dom/storageevent.rs
@@ -213,7 +213,7 @@ impl StorageEventMethods<crate::DomTypeHolder> for StorageEvent {
         *self.key.borrow_mut() = key;
         *self.old_value.borrow_mut() = oldValue;
         *self.new_value.borrow_mut() = newValue;
-        *self.url.borrow_mut() = DOMString::from_string(url.0);
+        *self.url.borrow_mut() = url.into();
         self.storage_area.set(storageArea);
     }
 }

--- a/components/script/dom/testing/testbinding.rs
+++ b/components/script/dom/testing/testbinding.rs
@@ -895,12 +895,11 @@ impl TestBindingMethods<crate::DomTypeHolder> for TestBinding {
             .unwrap_or(false)
     }
     fn StringMozPreference(&self, pref_name: DOMString) -> DOMString {
-        DOMString::from_string(
-            prefs::get()
-                .get_value(&pref_name.str())
-                .try_into()
-                .unwrap_or_default(),
-        )
+        let string: String = prefs::get()
+            .get_value(&pref_name.str())
+            .try_into()
+            .unwrap_or_default();
+        string.into()
     }
     fn PrefControlledAttributeDisabled(&self) -> bool {
         false

--- a/components/script/dom/webgpu/gpuadapter.rs
+++ b/components/script/dom/webgpu/gpuadapter.rs
@@ -125,7 +125,7 @@ impl GPUAdapter {
         // adapterInfo.vendor to the empty string or a reasonable approximation of the vendor as a
         // normalized identifier string.
         let vendor = if info.vendor != 0 {
-            DOMString::from_string(info.vendor.to_string())
+            info.vendor.to_string().into()
         } else {
             DOMString::new()
         };
@@ -144,7 +144,7 @@ impl GPUAdapter {
         // agent may instead set adapterInfo.device to to the empty string or a reasonable
         // approximation of a vendor-specific identifier as a normalized identifier string.
         let device = if info.device != 0 {
-            DOMString::from_string(info.device.to_string())
+            info.device.to_string().into()
         } else {
             DOMString::new()
         };
@@ -153,7 +153,7 @@ impl GPUAdapter {
         // adapter as reported by the driver. To preserve privacy, the user agent may instead set
         // adapterInfo.description to the empty string or a reasonable approximation of a
         // description.
-        let description = DOMString::from_string(info.name.clone());
+        let description = info.name.clone().into();
 
         // Step 6. If "subgroups" is supported, set subgroupMinSize to the smallest supported
         // subgroup size. Otherwise, set this value to 4.

--- a/components/script/dom/webgpu/gpuerror.rs
+++ b/components/script/dom/webgpu/gpuerror.rs
@@ -53,19 +53,19 @@ impl GPUError {
             Error::Validation(msg) => DomRoot::upcast(GPUValidationError::new_with_proto(
                 global,
                 None,
-                DOMString::from_string(msg),
+                msg.into(),
                 can_gc,
             )),
             Error::OutOfMemory(msg) => DomRoot::upcast(GPUOutOfMemoryError::new_with_proto(
                 global,
                 None,
-                DOMString::from_string(msg),
+                msg.into(),
                 can_gc,
             )),
             Error::Internal(msg) => DomRoot::upcast(GPUInternalError::new_with_proto(
                 global,
                 None,
-                DOMString::from_string(msg),
+                msg.into(),
                 can_gc,
             )),
         }

--- a/components/script/dom/webgpu/gpusupportedfeatures.rs
+++ b/components/script/dom/webgpu/gpusupportedfeatures.rs
@@ -156,7 +156,7 @@ impl Setlike for GPUSupportedFeatures {
     fn get_index(&self, index: u32) -> Option<Self::Key> {
         self.internal
             .get_index(index)
-            .map(|k| DOMString::from_string(k.as_str().to_owned()))
+            .map(|key| key.as_str().into())
     }
     #[inline(always)]
     fn size(&self) -> u32 {

--- a/components/script/dom/workers/dedicatedworkerglobalscope.rs
+++ b/components/script/dom/workers/dedicatedworkerglobalscope.rs
@@ -477,7 +477,7 @@ impl DedicatedWorkerGlobalScope {
                 let global = DedicatedWorkerGlobalScope::new(
                     init,
                     webview_id,
-                    DOMString::from_string(worker_name),
+                    worker_name.into(),
                     worker_type,
                     worker_url,
                     devtools_mpsc_port,

--- a/components/script/module_loading.rs
+++ b/components/script/module_loading.rs
@@ -23,7 +23,6 @@ use js::rust::wrappers2::{
 use js::rust::{HandleValue, IntoHandle};
 use net_traits::request::{Destination, Referrer};
 use script_bindings::settings_stack::run_a_callback;
-use script_bindings::str::DOMString;
 use servo_url::ServoUrl;
 
 use crate::DomTypeHolder;
@@ -463,7 +462,7 @@ pub(crate) fn host_load_imported_module(
     let url = ModuleTree::resolve_module_specifier(
         &global_scope,
         referencing_script,
-        DOMString::from_string(specifier.clone()),
+        specifier.clone().into(),
     );
 
     // Step 9 If the previous step threw an exception, then:

--- a/components/script/script_module.rs
+++ b/components/script/script_module.rs
@@ -1130,7 +1130,7 @@ unsafe extern "C" fn import_meta_resolve(cx: *mut RawJSContext, argc: u32, vp: *
         let value = HandleValue::from_raw(args.get(0));
 
         match NonNull::new(ToString(cx.raw_cx(), value)) {
-            Some(jsstr) => DOMString::from_string(jsstr_to_string(cx.raw_cx(), jsstr)),
+            Some(jsstr) => jsstr_to_string(cx.raw_cx(), jsstr).into(),
             None => return false,
         }
     };

--- a/components/script_bindings/conversions.rs
+++ b/components/script_bindings/conversions.rs
@@ -414,7 +414,7 @@ pub unsafe fn jsid_to_string(cx: *mut JSContext, id: HandleId) -> Option<DOMStri
     let id_raw = *id;
     if id_raw.is_string() {
         let jsstr = std::ptr::NonNull::new(id_raw.to_string()).unwrap();
-        return Some(DOMString::from_string(jsstr_to_string(cx, jsstr)));
+        return Some(jsstr_to_string(cx, jsstr).into());
     }
 
     if id_raw.is_int() {

--- a/components/script_bindings/domstring.rs
+++ b/components/script_bindings/domstring.rs
@@ -301,7 +301,7 @@ impl Clone for DOMString {
     fn clone(&self) -> Self {
         self.make_rust();
         if let DOMStringType::Rust(ref s) = *self.0.borrow() {
-            DOMString::from_string(s.to_owned())
+            DOMString::from(s.to_owned())
         } else {
             unreachable!()
         }
@@ -341,10 +341,6 @@ impl DOMString {
             };
             Ok(DOMString(RefCell::new(inner)))
         }
-    }
-
-    pub fn from_string(s: String) -> DOMString {
-        DOMString(RefCell::new(DOMStringType::Rust(s)))
     }
 
     /// Transforms the string into rust string if not yet a rust string.
@@ -899,8 +895,14 @@ impl std::cmp::PartialEq for DOMString {
 impl std::cmp::Eq for DOMString {}
 
 impl From<std::string::String> for DOMString {
-    fn from(value: String) -> Self {
-        DOMString::from_string(value)
+    fn from(string: String) -> Self {
+        DOMString(RefCell::new(DOMStringType::Rust(string)))
+    }
+}
+
+impl From<&str> for DOMString {
+    fn from(string: &str) -> Self {
+        String::from(string).into()
     }
 }
 
@@ -925,12 +927,6 @@ impl From<DOMString> for Namespace {
 impl From<DOMString> for Atom {
     fn from(dom_string: DOMString) -> Atom {
         dom_string.with_str_reference(|string| Atom::from(string))
-    }
-}
-
-impl From<&str> for DOMString {
-    fn from(contents: &str) -> DOMString {
-        DOMString(RefCell::new(DOMStringType::Rust(String::from(contents))))
     }
 }
 
@@ -978,7 +974,7 @@ macro_rules! match_domstring_ascii_inner {
 /// You are only allowed to match ascii strings otherwise this macro will
 /// lead to wrong results.
 /// ```ignore
-/// let s = DOMString::from_string(String::from("test"));
+/// let s = DOMString::from("test");
 /// let value = match_domstring!(s,
 /// "test1" => 1,
 /// "test2" => 2,
@@ -1120,7 +1116,7 @@ mod tests {
     fn partial_eq() {
         let s = from_latin1(vec![b'a', b'b', b'c', b'%', b'$']);
         let string = String::from("abc%$");
-        let s2 = DOMString::from_string(string.clone());
+        let s2 = DOMString::from(string.clone());
         assert_eq!(s, s2);
         assert_eq!(s, string);
     }
@@ -1161,7 +1157,7 @@ mod tests {
         let s = from_latin1(vec![b'a', b'b', b'c', b'%', b'$', 0xB2]);
         let s_converted = from_latin1(vec![b'a', b'b', b'c', b'%', b'$', 0xB2]);
         s_converted.make_rust();
-        let s2 = DOMString::from_string(String::from("abc%$²"));
+        let s2 = DOMString::from("abc%$²");
 
         let hash_s = hash_value(&s);
         let hash_s_converted = hash_value(&s_converted);
@@ -1203,7 +1199,7 @@ mod tests {
         }
 
         {
-            let s = DOMString::from_string(String::from("abcde"));
+            let s = DOMString::from("abcde");
             match_domstring_ascii!( s,
                 "abc" => assert!(false),
                 "bcd" => assert!(false),
@@ -1211,7 +1207,7 @@ mod tests {
             );
         }
         {
-            let s = DOMString::from_string(String::from("abc%$"));
+            let s = DOMString::from("abc%$");
             match_domstring_ascii!( s,
                 "bcd" => assert!(false),
                 "abc%$" => assert!(true),
@@ -1260,7 +1256,7 @@ mod tests {
         }
 
         {
-            let s = DOMString::from_string(String::from("abcde"));
+            let s = DOMString::from("abcde");
             let res = match_domstring_ascii!( s,
                 "abc" => false,
                 "bcd" => false,
@@ -1269,7 +1265,7 @@ mod tests {
             assert_eq!(res, true);
         }
         {
-            let s = DOMString::from_string(String::from("abc%$"));
+            let s = DOMString::from("abc%$");
             let res = match_domstring_ascii!( s,
                 "bcd" => false,
                 "abc%$" => true,
@@ -1291,7 +1287,7 @@ mod tests {
     #[test]
     #[should_panic]
     fn test_match_panic() {
-        let s = DOMString::from_string(String::from("abcd"));
+        let s = DOMString::from("abcd");
         let _res = match_domstring_ascii!(s,
             "❤" => true,
             _ => false,);
@@ -1300,7 +1296,7 @@ mod tests {
     #[test]
     #[should_panic]
     fn test_match_panic2() {
-        let s = DOMString::from_string(String::from("abcd"));
+        let s = DOMString::from("abcd");
         let _res = match_domstring_ascii!(s,
             "abc" => false,
             "❤" => true,
@@ -1320,7 +1316,7 @@ mod tests {
             assert_eq!(&*s.str(), "abc%$²");
         }
         {
-            let mut s = DOMString::from_string(String::from("   \n  abc%$ "));
+            let mut s = DOMString::from("   \n  abc%$ ");
 
             s.strip_leading_and_trailing_ascii_whitespace();
             s.make_rust();
@@ -1366,7 +1362,7 @@ mod tests {
     fn atom() {
         let s = from_latin1(vec![b'a', b'a', b'a', 0x20, b'a', b'a']);
         let atom1 = Atom::from(s);
-        let s2 = DOMString::from_string(String::from("aaa aa"));
+        let s2 = DOMString::from("aaa aa");
         let atom2 = Atom::from(s2);
         assert_eq!(atom1, atom2);
         let s3 = from_latin1(vec![b'a', b'a', b'a', 0xB2, b'a', b'a']);
@@ -1378,7 +1374,7 @@ mod tests {
     fn namespace() {
         let s = from_latin1(vec![b'a', b'a', b'a', ASCII_SPACE, b'a', b'a']);
         let atom1 = Namespace::from(s);
-        let s2 = DOMString::from_string(String::from("aaa aa"));
+        let s2 = DOMString::from("aaa aa");
         let atom2 = Namespace::from(s2);
         assert_eq!(atom1, atom2);
         let s3 = from_latin1(vec![b'a', b'a', b'a', LATIN1_POWER2, b'a', b'a']);
@@ -1390,7 +1386,7 @@ mod tests {
     fn localname() {
         let s = from_latin1(vec![b'a', b'a', b'a', ASCII_SPACE, b'a', b'a']);
         let atom1 = LocalName::from(s);
-        let s2 = DOMString::from_string(String::from("aaa aa"));
+        let s2 = DOMString::from("aaa aa");
         let atom2 = LocalName::from(s2);
         assert_eq!(atom1, atom2);
         let s3 = from_latin1(vec![b'a', b'a', b'a', LATIN1_POWER2, b'a', b'a']);
@@ -1408,9 +1404,9 @@ mod tests {
         assert!(s.is_ascii_lowercase());
         let s = from_latin1(vec![b'`', b'a', b'a', b'a', b'z']);
         assert!(!s.is_ascii_lowercase());
-        let s = DOMString::from_string(String::from("`aaaz"));
+        let s = DOMString::from("`aaaz");
         assert!(!s.is_ascii_lowercase());
-        let s = DOMString::from_string(String::from("aaaz"));
+        let s = DOMString::from("aaaz");
         assert!(s.is_ascii_lowercase());
     }
 

--- a/components/script_bindings/proxyhandler.rs
+++ b/components/script_bindings/proxyhandler.rs
@@ -230,7 +230,7 @@ pub(crate) fn id_to_source(cx: SafeJSContext, id: RawHandleId) -> Option<DOMStri
                 jsstr.get()
             })
             .and_then(ptr::NonNull::new)
-            .map(|jsstr| DOMString::from_string(jsstr_to_string(*cx, jsstr)))
+            .map(|jsstr| jsstr_to_string(*cx, jsstr).into())
     }
 }
 

--- a/components/script_bindings/str.rs
+++ b/components/script_bindings/str.rs
@@ -128,7 +128,7 @@ impl From<USVString> for String {
 
 impl From<USVString> for DOMString {
     fn from(value: USVString) -> Self {
-        DOMString::from_string(value.0)
+        value.0.into()
     }
 }
 

--- a/components/script_bindings/utils.rs
+++ b/components/script_bindings/utils.rs
@@ -223,7 +223,7 @@ pub(crate) unsafe fn find_enum_value<'a, T>(
 ) -> Result<(Option<&'a T>, DOMString), ()> {
     match ptr::NonNull::new(ToString(cx, v)) {
         Some(jsstr) => {
-            let search = DOMString::from_string(jsstr_to_string(cx, jsstr));
+            let search = jsstr_to_string(cx, jsstr).into();
             Ok((
                 pairs
                     .iter()


### PR DESCRIPTION
This method is the same as `DOMString::from` with a `String` argument
and `From` and `Into` are preferred when writing modern Rust.

Testing: This should not change behavior and is thus covered by existing tests.
