### PR TITLE
script: Implement "getPublicKey" operations of RSA algorithms

### DIFF
--- a/components/script/dom/subtlecrypto.rs
+++ b/components/script/dom/subtlecrypto.rs
@@ -5019,6 +5019,9 @@ impl Operation for GetPublicKeyOperation {
 /// Normalized algorithm for the "getPublicKey" operation, used as output of
 /// <https://w3c.github.io/webcrypto/#dfn-normalize-an-algorithm>
 enum GetPublicKeyAlgorithm {
+    RsassaPkcs1v1_5(SubtleAlgorithm),
+    RsaPss(SubtleAlgorithm),
+    RsaOaep(SubtleAlgorithm),
     X25519(SubtleAlgorithm),
 }
 
@@ -5029,6 +5032,15 @@ impl NormalizedAlgorithm for GetPublicKeyAlgorithm {
         value: HandleValue,
     ) -> Fallible<Self> {
         match algorithm_name {
+            CryptoAlgorithm::RsassaPkcs1V1_5 => Ok(GetPublicKeyAlgorithm::RsassaPkcs1v1_5(
+                value.try_into_with_cx(cx)?,
+            )),
+            CryptoAlgorithm::RsaPss => {
+                Ok(GetPublicKeyAlgorithm::RsaPss(value.try_into_with_cx(cx)?))
+            },
+            CryptoAlgorithm::RsaOaep => {
+                Ok(GetPublicKeyAlgorithm::RsaOaep(value.try_into_with_cx(cx)?))
+            },
             CryptoAlgorithm::X25519 => {
                 Ok(GetPublicKeyAlgorithm::X25519(value.try_into_with_cx(cx)?))
             },
@@ -5041,6 +5053,9 @@ impl NormalizedAlgorithm for GetPublicKeyAlgorithm {
 
     fn name(&self) -> CryptoAlgorithm {
         match self {
+            GetPublicKeyAlgorithm::RsassaPkcs1v1_5(algorithm) => algorithm.name,
+            GetPublicKeyAlgorithm::RsaPss(algorithm) => algorithm.name,
+            GetPublicKeyAlgorithm::RsaOaep(algorithm) => algorithm.name,
             GetPublicKeyAlgorithm::X25519(algorithm) => algorithm.name,
         }
     }
@@ -5056,6 +5071,15 @@ impl GetPublicKeyAlgorithm {
         usages: Vec<KeyUsage>,
     ) -> Result<DomRoot<CryptoKey>, Error> {
         match self {
+            GetPublicKeyAlgorithm::RsassaPkcs1v1_5(_algorithm) => {
+                rsassa_pkcs1_v1_5_operation::get_public_key(cx, global, key, algorithm, usages)
+            },
+            GetPublicKeyAlgorithm::RsaPss(_algorithm) => {
+                rsa_pss_operation::get_public_key(cx, global, key, algorithm, usages)
+            },
+            GetPublicKeyAlgorithm::RsaOaep(_algorithm) => {
+                rsa_oaep_operation::get_public_key(cx, global, key, algorithm, usages)
+            },
             GetPublicKeyAlgorithm::X25519(_algorithm) => {
                 x25519_operation::get_public_key(cx, global, key, algorithm, usages)
             },

--- a/components/script/dom/subtlecrypto/rsa_common.rs
+++ b/components/script/dom/subtlecrypto/rsa_common.rs
@@ -1057,3 +1057,62 @@ pub(crate) fn export_key(
     // Step 4. Return result.
     Ok(result)
 }
+
+/// <https://wicg.github.io/webcrypto-modern-algos/#SubtleCrypto-method-getPublicKey>
+/// Step 9 - 15, for RSA algorithms
+pub(crate) fn get_public_key(
+    rsa_algorithm: RsaAlgorithm,
+    cx: &mut JSContext,
+    global: &GlobalScope,
+    key: &CryptoKey,
+    algorithm: &KeyAlgorithmAndDerivatives,
+    usages: Vec<KeyUsage>,
+) -> Result<DomRoot<CryptoKey>, Error> {
+    // Step 9. If usages contains an entry which is not supported for a public key by the algorithm
+    // identified by algorithm, then throw a SyntaxError.
+    //
+    // NOTE: See "importKey" operation for supported usages
+    match rsa_algorithm {
+        RsaAlgorithm::RsassaPkcs1v1_5 | RsaAlgorithm::RsaPss => {
+            if usages.iter().any(|usage| *usage != KeyUsage::Verify) {
+                return Err(Error::Syntax(Some(
+                    "Usages contains an entry which is not \"verify\"".to_string(),
+                )));
+            }
+        },
+        RsaAlgorithm::RsaOaep => {
+            if usages
+                .iter()
+                .any(|usage| !matches!(usage, KeyUsage::Encrypt | KeyUsage::WrapKey))
+            {
+                return Err(Error::Syntax(Some(
+                    "Usages contains an entry which is not \"encrypt\" or \"wrapKey\"".to_string(),
+                )));
+            }
+        },
+    }
+
+    // Step 10. Let publicKey be a new CryptoKey representing the public key corresponding to the
+    // private key represented by the [[handle]] internal slot of key.
+    // Step 11. If an error occurred, then throw a OperationError.
+    // Step 12. Set the [[type]] internal slot of publicKey to "public".
+    // Step 13. Set the [[algorithm]] internal slot of publicKey to algorithm.
+    // Step 14. Set the [[extractable]] internal slot of publicKey to true.
+    // Step 15. Set the [[usages]] internal slot of publicKey to usages.
+    let Handle::RsaPrivateKey(private_key) = key.handle() else {
+        return Err(Error::Operation(Some(
+            "[[handle]] internal slot of key is not an RSA private key".to_string(),
+        )));
+    };
+    let public_key = CryptoKey::new(
+        cx,
+        global,
+        KeyType::Public,
+        true,
+        algorithm.clone(),
+        usages,
+        Handle::RsaPublicKey(private_key.into()),
+    );
+
+    Ok(public_key)
+}

--- a/components/script/dom/subtlecrypto/rsa_oaep_operation.rs
+++ b/components/script/dom/subtlecrypto/rsa_oaep_operation.rs
@@ -184,3 +184,15 @@ pub(crate) fn import_key(
 pub(crate) fn export_key(format: KeyFormat, key: &CryptoKey) -> Result<ExportedKey, Error> {
     rsa_common::export_key(RsaAlgorithm::RsaOaep, format, key)
 }
+
+/// <https://wicg.github.io/webcrypto-modern-algos/#SubtleCrypto-method-getPublicKey>
+/// Step 9 - 15, for RSA-OAEP
+pub(crate) fn get_public_key(
+    cx: &mut JSContext,
+    global: &GlobalScope,
+    key: &CryptoKey,
+    algorithm: &KeyAlgorithmAndDerivatives,
+    usages: Vec<KeyUsage>,
+) -> Result<DomRoot<CryptoKey>, Error> {
+    rsa_common::get_public_key(RsaAlgorithm::RsaOaep, cx, global, key, algorithm, usages)
+}

--- a/components/script/dom/subtlecrypto/rsa_pss_operation.rs
+++ b/components/script/dom/subtlecrypto/rsa_pss_operation.rs
@@ -219,3 +219,15 @@ pub(crate) fn import_key(
 pub(crate) fn export_key(format: KeyFormat, key: &CryptoKey) -> Result<ExportedKey, Error> {
     rsa_common::export_key(RsaAlgorithm::RsaPss, format, key)
 }
+
+/// <https://wicg.github.io/webcrypto-modern-algos/#SubtleCrypto-method-getPublicKey>
+/// Step 9 - 15, for RSA-PSS
+pub(crate) fn get_public_key(
+    cx: &mut JSContext,
+    global: &GlobalScope,
+    key: &CryptoKey,
+    algorithm: &KeyAlgorithmAndDerivatives,
+    usages: Vec<KeyUsage>,
+) -> Result<DomRoot<CryptoKey>, Error> {
+    rsa_common::get_public_key(RsaAlgorithm::RsaPss, cx, global, key, algorithm, usages)
+}

--- a/components/script/dom/subtlecrypto/rsassa_pkcs1_v1_5_operation.rs
+++ b/components/script/dom/subtlecrypto/rsassa_pkcs1_v1_5_operation.rs
@@ -182,3 +182,22 @@ pub(crate) fn import_key(
 pub(crate) fn export_key(format: KeyFormat, key: &CryptoKey) -> Result<ExportedKey, Error> {
     rsa_common::export_key(RsaAlgorithm::RsassaPkcs1v1_5, format, key)
 }
+
+/// <https://wicg.github.io/webcrypto-modern-algos/#SubtleCrypto-method-getPublicKey>
+/// Step 9 - 15, for RSASSA-PKCS1-v1_5
+pub(crate) fn get_public_key(
+    cx: &mut JSContext,
+    global: &GlobalScope,
+    key: &CryptoKey,
+    algorithm: &KeyAlgorithmAndDerivatives,
+    usages: Vec<KeyUsage>,
+) -> Result<DomRoot<CryptoKey>, Error> {
+    rsa_common::get_public_key(
+        RsaAlgorithm::RsassaPkcs1v1_5,
+        cx,
+        global,
+        key,
+        algorithm,
+        usages,
+    )
+}

--- a/tests/wpt/meta/WebCryptoAPI/getPublicKey.tentative.https.any.js.ini
+++ b/tests/wpt/meta/WebCryptoAPI/getPublicKey.tentative.https.any.js.ini
@@ -8,15 +8,6 @@
   [getPublicKey works for Ed25519]
     expected: FAIL
 
-  [getPublicKey works for RSA-OAEP]
-    expected: FAIL
-
-  [getPublicKey works for RSA-PSS]
-    expected: FAIL
-
-  [getPublicKey works for RSASSA-PKCS1-v1_5]
-    expected: FAIL
-
   [Derived public key is functionally equivalent to original public key]
     expected: FAIL
 
@@ -27,15 +18,6 @@
     expected: FAIL
 
   [getPublicKey works with empty usages for Ed25519]
-    expected: FAIL
-
-  [getPublicKey works with empty usages for RSA-OAEP]
-    expected: FAIL
-
-  [getPublicKey works with empty usages for RSA-PSS]
-    expected: FAIL
-
-  [getPublicKey works with empty usages for RSASSA-PKCS1-v1_5]
     expected: FAIL
 
   [getPublicKey rejects with InvalidAccessError when given a public key]
@@ -58,15 +40,6 @@
   [getPublicKey works for Ed25519]
     expected: FAIL
 
-  [getPublicKey works for RSA-OAEP]
-    expected: FAIL
-
-  [getPublicKey works for RSA-PSS]
-    expected: FAIL
-
-  [getPublicKey works for RSASSA-PKCS1-v1_5]
-    expected: FAIL
-
   [Derived public key is functionally equivalent to original public key]
     expected: FAIL
 
@@ -77,15 +50,6 @@
     expected: FAIL
 
   [getPublicKey works with empty usages for Ed25519]
-    expected: FAIL
-
-  [getPublicKey works with empty usages for RSA-OAEP]
-    expected: FAIL
-
-  [getPublicKey works with empty usages for RSA-PSS]
-    expected: FAIL
-
-  [getPublicKey works with empty usages for RSASSA-PKCS1-v1_5]
     expected: FAIL
 
   [getPublicKey rejects with InvalidAccessError when given a public key]


### PR DESCRIPTION
Implement "getPublicKey" operations of RSASSA-PKCS1-v1_5, RSA-PSS and RSA-OAEP. The steps are implemented at `rsa_common.rs` shared by the three RSA algorithms.

To make the operations functioning, they are also registered at `GetPublicKeyAlgorithm`.

Specification: https://wicg.github.io/webcrypto-modern-algos/#SubtleCrypto-method-getPublicKey
Testing: Pass WPT tests that were expected to fail.
Fixes: Part of #43072