### PR TITLE
constellation(storage): validate storage event source and scope session fanout by webview

### DIFF
--- a/components/constellation/constellation.rs
+++ b/components/constellation/constellation.rs
@@ -2570,22 +2570,48 @@ where
         new_value: Option<String>,
     ) {
         let origin = url.origin();
+        let Some(source_pipeline) = self.pipelines.get(&pipeline_id) else {
+            warn!("Received storage event broadcast request from closed pipeline.");
+            return;
+        };
+
+        if source_pipeline.url.origin() != origin {
+            return warn!(
+                "Attempt to broadcast storage event from an origin not matching the source pipeline origin."
+            );
+        }
+
         for pipeline in self.pipelines.values() {
-            if (pipeline.id != pipeline_id) && (pipeline.url.origin() == origin) {
-                let msg = ScriptThreadMessage::DispatchStorageEvent(
-                    pipeline.id,
-                    storage,
-                    url.clone(),
-                    key.clone(),
-                    old_value.clone(),
-                    new_value.clone(),
+            if pipeline.id == pipeline_id || pipeline.url.origin() != origin {
+                continue;
+            }
+
+            // https://html.spec.whatwg.org/multipage/#concept-storage-broadcast
+            // "Step 3. Let remoteStorages be all Storage objects excluding storage whose:
+            // type is storage's type
+            // relevant settings object's origin is same origin with storage's relevant settings object's origin
+            // and, if type is "session", whose relevant settings object's associated Document's
+            // node navigable's traversable navigable is thisDocument's node navigable's
+            // traversable navigable."
+            if storage == WebStorageType::Session &&
+                pipeline.webview_id != source_pipeline.webview_id
+            {
+                continue;
+            }
+
+            let msg = ScriptThreadMessage::DispatchStorageEvent(
+                pipeline.id,
+                storage,
+                url.clone(),
+                key.clone(),
+                old_value.clone(),
+                new_value.clone(),
+            );
+            if let Err(err) = pipeline.event_loop.send(msg) {
+                warn!(
+                    "{}: Failed to broadcast storage event to pipeline ({:?}).",
+                    pipeline.id, err
                 );
-                if let Err(err) = pipeline.event_loop.send(msg) {
-                    warn!(
-                        "{}: Failed to broadcast storage event to pipeline ({:?}).",
-                        pipeline.id, err
-                    );
-                }
             }
         }
     }

--- a/tests/wpt/tests/webstorage/event_local_window_open_oldvalue.html
+++ b/tests/wpt/tests/webstorage/event_local_window_open_oldvalue.html
@@ -1,0 +1,31 @@
+<!DOCTYPE HTML>
+<html>
+ <head>
+  <title>WebStorage Test: localStorage event - window open oldValue</title>
+  <script src="/resources/testharness.js"></script>
+  <script src="/resources/testharnessreport.js"></script>
+ </head>
+ <body>
+    <h1>event_local_window_open_oldValue</h1>
+    <div id="log"></div>
+    <script>
+        async_test(function(t) {
+            localStorage.clear();
+            t.add_cleanup(function() { localStorage.clear(); });
+
+            var expected = [null, 'user1', null];
+            function onStorageEvent(event) {
+                assert_equals(event.oldValue, expected.shift());
+                if (!expected.length) {
+                    t.done();
+                }
+            }
+
+            window.addEventListener('storage', t.step_func(onStorageEvent), false);
+
+            var win = window.open("resources/local_change_item_window.html");
+            t.add_cleanup(function() { win.close(); });
+        }, "oldValue property test of local event from window.open() - Local event is fired due to an invocation of the setItem(), clear() methods.");
+    </script>
+ </body>
+</html>

--- a/tests/wpt/tests/webstorage/event_local_window_open_oldvalue.html
+++ b/tests/wpt/tests/webstorage/event_local_window_open_oldvalue.html
@@ -13,6 +13,9 @@
             localStorage.clear();
             t.add_cleanup(function() { localStorage.clear(); });
 
+            // The opened window does setItem("name", "user1"), then
+            // setItem("name", "user2"), then clear(). The clear() event has
+            // oldValue == null, so the expected sequence is null -> user1 -> null.
             var expected = [null, 'user1', null];
             function onStorageEvent(event) {
                 assert_equals(event.oldValue, expected.shift());

--- a/tests/wpt/tests/webstorage/event_session_window_open_scope.html
+++ b/tests/wpt/tests/webstorage/event_session_window_open_scope.html
@@ -1,0 +1,40 @@
+<!DOCTYPE HTML>
+<html>
+ <head>
+  <title>WebStorage Test: sessionStorage event - window scope</title>
+  <script src="/resources/testharness.js"></script>
+  <script src="/resources/testharnessreport.js"></script>
+ </head>
+ <body>
+    <h1>event_session_window_open_scope</h1>
+    <div id="log"></div>
+    <script>
+        async_test(function(t) {
+            sessionStorage.clear();
+            t.add_cleanup(function() { sessionStorage.clear(); });
+
+            var events = [];
+            window.addEventListener('storage', t.step_func(function(event) {
+                events.push(event);
+            }), false);
+
+            var win = window.open("resources/session_change_item_window.html");
+            t.add_cleanup(function() { win.close(); });
+
+            window.addEventListener('message', t.step_func(function(e) {
+                if (e.data && e.data.error) {
+                    assert_unreached(e.data.error);
+                    return;
+                }
+                if (e.data && e.data.done) {
+                    t.step_timeout(function() {
+                        assert_equals(events.length, 0,
+                            "sessionStorage events from a new window should not fire in the opener (different session scope)");
+                        t.done();
+                    }, 500);
+                }
+            }));
+        }, "sessionStorage events from a new window opened via window.open() should not fire in the opener");
+    </script>
+ </body>
+</html>

--- a/tests/wpt/tests/webstorage/resources/local_change_item_window.html
+++ b/tests/wpt/tests/webstorage/resources/local_change_item_window.html
@@ -1,0 +1,18 @@
+<!DOCTYPE HTML>
+<html>
+<body>
+<script>
+if (('localStorage' in window) && window.localStorage !== null) {
+    try {
+        localStorage.setItem("name", "user1");
+        localStorage.setItem("name", "user2");
+    } catch (e) {
+        window.opener.postMessage({error: "setItem method is failed."}, '*');
+    }
+    localStorage.clear();
+} else {
+    window.opener.postMessage({error: "localStorage is not supported."}, '*');
+}
+</script>
+</body>
+</html>

--- a/tests/wpt/tests/webstorage/resources/session_change_item_window.html
+++ b/tests/wpt/tests/webstorage/resources/session_change_item_window.html
@@ -1,0 +1,19 @@
+<!DOCTYPE HTML>
+<html>
+<body>
+<script>
+if (('sessionStorage' in window) && window.sessionStorage !== null) {
+    try {
+        sessionStorage.setItem("name", "user1");
+        sessionStorage.setItem("name", "user2");
+    } catch (e) {
+        window.opener.postMessage({error: "setItem method is failed."}, '*');
+    }
+    sessionStorage.clear();
+} else {
+    window.opener.postMessage({error: "sessionStorage is not supported."}, '*');
+}
+window.opener.postMessage({done: true}, '*');
+</script>
+</body>
+</html>


### PR DESCRIPTION
Follow the spec and tightenings storage event routing in Constellation by validating that a BroadcastStorageEvent comes from the same origin as its source pipeline, while preserving existing localStorage fanout behavior.


Fixes: part of #40983
