### PR TITLE
layout: Revert changes from #42529 to button control style

### DIFF
--- a/components/layout/stylesheets/servo.css
+++ b/components/layout/stylesheets/servo.css
@@ -81,12 +81,11 @@ input[type="reset"],
 input[type="color"],
 input[type="file"]::before {
   cursor: default;
-  background: gainsboro;
-  border: 2px outset ButtonBorder;
+  background: ButtonFace;
   border-radius: 2px;
+  border: 1px solid ButtonBorder;
   padding: 4px;
   color: black;
-  background-color: ButtonFace;
 }
 
 button,


### PR DESCRIPTION
I believe that these changes (part of #42529) were likely made in error. Servo
button controls do not follow the system theme, so system colors should not be
used. These changes degraded the look of the buttons, so this change
reverts to the previous state.

### Before (with unintended change):

<img width="520" height="115" alt="Screenshot 2026-03-09 at 08 47 15" src="https://github.com/user-attachments/assets/cff5fc1a-bfd0-4785-8326-91e735390176" />

### After (restored style):

<img width="499" height="113" alt="Screenshot 2026-03-09 at 08 46 02" src="https://github.com/user-attachments/assets/99660c7f-9eb6-4ee8-905e-f7a594bd363d" />


Testing: These changes are really only testable via the manual test `tests/html/form-control-visuals.html`.
