### PR TITLE
script: Implement "getPublicKey" operations of ECDSA and ECDH

### DIFF
--- a/components/script/dom/subtlecrypto.rs
+++ b/components/script/dom/subtlecrypto.rs
@@ -11,6 +11,7 @@ mod aes_ocb_operation;
 mod argon2_operation;
 mod chacha20_poly1305_operation;
 mod cshake_operation;
+mod ec_common;
 mod ecdh_operation;
 mod ecdsa_operation;
 mod ed25519_operation;
@@ -5022,6 +5023,8 @@ enum GetPublicKeyAlgorithm {
     RsassaPkcs1v1_5(SubtleAlgorithm),
     RsaPss(SubtleAlgorithm),
     RsaOaep(SubtleAlgorithm),
+    Ecdsa(SubtleAlgorithm),
+    Ecdh(SubtleAlgorithm),
     X25519(SubtleAlgorithm),
 }
 
@@ -5041,6 +5044,8 @@ impl NormalizedAlgorithm for GetPublicKeyAlgorithm {
             CryptoAlgorithm::RsaOaep => {
                 Ok(GetPublicKeyAlgorithm::RsaOaep(value.try_into_with_cx(cx)?))
             },
+            CryptoAlgorithm::Ecdsa => Ok(GetPublicKeyAlgorithm::Ecdsa(value.try_into_with_cx(cx)?)),
+            CryptoAlgorithm::Ecdh => Ok(GetPublicKeyAlgorithm::Ecdh(value.try_into_with_cx(cx)?)),
             CryptoAlgorithm::X25519 => {
                 Ok(GetPublicKeyAlgorithm::X25519(value.try_into_with_cx(cx)?))
             },
@@ -5056,6 +5061,8 @@ impl NormalizedAlgorithm for GetPublicKeyAlgorithm {
             GetPublicKeyAlgorithm::RsassaPkcs1v1_5(algorithm) => algorithm.name,
             GetPublicKeyAlgorithm::RsaPss(algorithm) => algorithm.name,
             GetPublicKeyAlgorithm::RsaOaep(algorithm) => algorithm.name,
+            GetPublicKeyAlgorithm::Ecdsa(algorithm) => algorithm.name,
+            GetPublicKeyAlgorithm::Ecdh(algorithm) => algorithm.name,
             GetPublicKeyAlgorithm::X25519(algorithm) => algorithm.name,
         }
     }
@@ -5079,6 +5086,12 @@ impl GetPublicKeyAlgorithm {
             },
             GetPublicKeyAlgorithm::RsaOaep(_algorithm) => {
                 rsa_oaep_operation::get_public_key(cx, global, key, algorithm, usages)
+            },
+            GetPublicKeyAlgorithm::Ecdsa(_algorithm) => {
+                ecdsa_operation::get_public_key(cx, global, key, algorithm, usages)
+            },
+            GetPublicKeyAlgorithm::Ecdh(_algorithm) => {
+                ecdh_operation::get_public_key(cx, global, key, algorithm, usages)
             },
             GetPublicKeyAlgorithm::X25519(_algorithm) => {
                 x25519_operation::get_public_key(cx, global, key, algorithm, usages)

--- a/components/script/dom/subtlecrypto/ec_common.rs
+++ b/components/script/dom/subtlecrypto/ec_common.rs
@@ -1,0 +1,61 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+use js::context::JSContext;
+
+use crate::dom::bindings::codegen::Bindings::CryptoKeyBinding::{KeyType, KeyUsage};
+use crate::dom::bindings::error::Error;
+use crate::dom::bindings::root::DomRoot;
+use crate::dom::cryptokey::{CryptoKey, Handle};
+use crate::dom::globalscope::GlobalScope;
+use crate::dom::subtlecrypto::KeyAlgorithmAndDerivatives;
+
+/// <https://wicg.github.io/webcrypto-modern-algos/#SubtleCrypto-method-getPublicKey>
+/// Step 9 - 15, for elliptic curve cryptography
+pub(crate) fn get_public_key(
+    cx: &mut JSContext,
+    global: &GlobalScope,
+    key: &CryptoKey,
+    algorithm: &KeyAlgorithmAndDerivatives,
+    usages: Vec<KeyUsage>,
+) -> Result<DomRoot<CryptoKey>, Error> {
+    // Step 9. If usages contains an entry which is not supported for a public key by the algorithm
+    // identified by algorithm, then throw a SyntaxError.
+    //
+    // NOTE: See "importKey" operation for supported usages
+    if usages.iter().any(|usage| *usage != KeyUsage::Verify) {
+        return Err(Error::Syntax(Some(
+            "Usages contains an entry which is not \"verify\"".to_string(),
+        )));
+    }
+
+    // Step 10. Let publicKey be a new CryptoKey representing the public key corresponding to the
+    // private key represented by the [[handle]] internal slot of key.
+    // Step 11. If an error occurred, then throw a OperationError.
+    // Step 12. Set the [[type]] internal slot of publicKey to "public".
+    // Step 13. Set the [[algorithm]] internal slot of publicKey to algorithm.
+    // Step 14. Set the [[extractable]] internal slot of publicKey to true.
+    // Step 15. Set the [[usages]] internal slot of publicKey to usages.
+    let public_key_handle = match key.handle() {
+        Handle::P256PrivateKey(private_key) => Handle::P256PublicKey(private_key.public_key()),
+        Handle::P384PrivateKey(private_key) => Handle::P384PublicKey(private_key.public_key()),
+        Handle::P521PrivateKey(private_key) => Handle::P521PublicKey(private_key.public_key()),
+        _ => {
+            return Err(Error::Operation(Some(
+                "[[handle]] internal slot of key is not an elliptic curve private key".to_string(),
+            )));
+        },
+    };
+    let public_key = CryptoKey::new(
+        cx,
+        global,
+        KeyType::Public,
+        true,
+        algorithm.clone(),
+        usages,
+        public_key_handle,
+    );
+
+    Ok(public_key)
+}

--- a/components/script/dom/subtlecrypto/ecdh_operation.rs
+++ b/components/script/dom/subtlecrypto/ecdh_operation.rs
@@ -27,7 +27,7 @@ use crate::dom::globalscope::GlobalScope;
 use crate::dom::subtlecrypto::{
     CryptoAlgorithm, ExportedKey, JsonWebKeyExt, JwkStringField, KeyAlgorithmAndDerivatives,
     NAMED_CURVE_P256, NAMED_CURVE_P384, NAMED_CURVE_P521, SUPPORTED_CURVES, SubtleEcKeyAlgorithm,
-    SubtleEcKeyGenParams, SubtleEcKeyImportParams, SubtleEcdhKeyDeriveParams,
+    SubtleEcKeyGenParams, SubtleEcKeyImportParams, SubtleEcdhKeyDeriveParams, ec_common,
 };
 
 /// <https://w3c.github.io/webcrypto/#ecdh-operations-generate-key>
@@ -1338,4 +1338,16 @@ pub(crate) fn export_key(format: KeyFormat, key: &CryptoKey) -> Result<ExportedK
 
     // Step 4. Return result.
     Ok(result)
+}
+
+/// <https://wicg.github.io/webcrypto-modern-algos/#SubtleCrypto-method-getPublicKey>
+/// Step 9 - 15, for ECDH
+pub(crate) fn get_public_key(
+    cx: &mut JSContext,
+    global: &GlobalScope,
+    key: &CryptoKey,
+    algorithm: &KeyAlgorithmAndDerivatives,
+    usages: Vec<KeyUsage>,
+) -> Result<DomRoot<CryptoKey>, Error> {
+    ec_common::get_public_key(cx, global, key, algorithm, usages)
 }

--- a/components/script/dom/subtlecrypto/ecdsa_operation.rs
+++ b/components/script/dom/subtlecrypto/ecdsa_operation.rs
@@ -33,6 +33,7 @@ use crate::dom::subtlecrypto::{
     CryptoAlgorithm, ExportedKey, JsonWebKeyExt, JwkStringField, KeyAlgorithmAndDerivatives,
     NAMED_CURVE_P256, NAMED_CURVE_P384, NAMED_CURVE_P521, NormalizedAlgorithm, SUPPORTED_CURVES,
     SubtleEcKeyAlgorithm, SubtleEcKeyGenParams, SubtleEcKeyImportParams, SubtleEcdsaParams,
+    ec_common,
 };
 
 const P256_PREHASH_LENGTH: usize = 32;
@@ -1264,6 +1265,18 @@ pub(crate) fn export_key(format: KeyFormat, key: &CryptoKey) -> Result<ExportedK
 
     // Step 4. Return result.
     Ok(result)
+}
+
+/// <https://wicg.github.io/webcrypto-modern-algos/#SubtleCrypto-method-getPublicKey>
+/// Step 9 - 15, for ECDSA
+pub(crate) fn get_public_key(
+    cx: &mut JSContext,
+    global: &GlobalScope,
+    key: &CryptoKey,
+    algorithm: &KeyAlgorithmAndDerivatives,
+    usages: Vec<KeyUsage>,
+) -> Result<DomRoot<CryptoKey>, Error> {
+    ec_common::get_public_key(cx, global, key, algorithm, usages)
 }
 
 /// A helper function that expand a prehash to a specified length if the prehash is shorter than

--- a/tests/wpt/meta/WebCryptoAPI/getPublicKey.tentative.https.any.js.ini
+++ b/tests/wpt/meta/WebCryptoAPI/getPublicKey.tentative.https.any.js.ini
@@ -1,62 +1,14 @@
 [getPublicKey.tentative.https.any.worker.html]
-  [getPublicKey works for ECDH]
-    expected: FAIL
-
-  [getPublicKey works for ECDSA]
-    expected: FAIL
-
   [getPublicKey works for Ed25519]
     expected: FAIL
 
-  [Derived public key is functionally equivalent to original public key]
-    expected: FAIL
-
-  [getPublicKey works with empty usages for ECDH]
-    expected: FAIL
-
-  [getPublicKey works with empty usages for ECDSA]
-    expected: FAIL
-
   [getPublicKey works with empty usages for Ed25519]
-    expected: FAIL
-
-  [getPublicKey rejects with InvalidAccessError when given a public key]
-    expected: FAIL
-
-  [getPublicKey rejects with SyntaxError for invalid usages]
-    expected: FAIL
-
-  [getPublicKey rejects with SyntaxError when any usage is invalid for the algorithm]
     expected: FAIL
 
 
 [getPublicKey.tentative.https.any.html]
-  [getPublicKey works for ECDH]
-    expected: FAIL
-
-  [getPublicKey works for ECDSA]
-    expected: FAIL
-
   [getPublicKey works for Ed25519]
     expected: FAIL
 
-  [Derived public key is functionally equivalent to original public key]
-    expected: FAIL
-
-  [getPublicKey works with empty usages for ECDH]
-    expected: FAIL
-
-  [getPublicKey works with empty usages for ECDSA]
-    expected: FAIL
-
   [getPublicKey works with empty usages for Ed25519]
-    expected: FAIL
-
-  [getPublicKey rejects with InvalidAccessError when given a public key]
-    expected: FAIL
-
-  [getPublicKey rejects with SyntaxError for invalid usages]
-    expected: FAIL
-
-  [getPublicKey rejects with SyntaxError when any usage is invalid for the algorithm]
     expected: FAIL


### PR DESCRIPTION
Implement "getPublicKey" operations of ECDSA and ECDH. The steps are implemented at the new submodule `ec_common` shared by ECDSA and ECDH.

To make the operations functioning, they are also registered at `GetPublicKeyAlgorithm`.

Specification: https://wicg.github.io/webcrypto-modern-algos/#SubtleCrypto-method-getPublicKey
Testing: Pass WPT tests that were expected to fail.
Fixes: Part of #43072