### PR TITLE
deps: Update Stylo to include "Restore Servo's original form control theme colors"

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7230,7 +7230,7 @@ dependencies = [
 [[package]]
 name = "selectors"
 version = "0.36.0"
-source = "git+https://github.com/servo/stylo?rev=51593b0258309bfbbee767b3c116bc7ce6bc1b80#51593b0258309bfbbee767b3c116bc7ce6bc1b80"
+source = "git+https://github.com/servo/stylo?rev=2373b812bbfdf0d01168fd613a0e772e94d32012#2373b812bbfdf0d01168fd613a0e772e94d32012"
 dependencies = [
  "bitflags 2.11.0",
  "cssparser",
@@ -8799,7 +8799,7 @@ dependencies = [
 [[package]]
 name = "servo_arc"
 version = "0.4.3"
-source = "git+https://github.com/servo/stylo?rev=51593b0258309bfbbee767b3c116bc7ce6bc1b80#51593b0258309bfbbee767b3c116bc7ce6bc1b80"
+source = "git+https://github.com/servo/stylo?rev=2373b812bbfdf0d01168fd613a0e772e94d32012#2373b812bbfdf0d01168fd613a0e772e94d32012"
 dependencies = [
  "serde",
  "stable_deref_trait",
@@ -9219,7 +9219,7 @@ dependencies = [
 [[package]]
 name = "stylo"
 version = "0.13.0"
-source = "git+https://github.com/servo/stylo?rev=51593b0258309bfbbee767b3c116bc7ce6bc1b80#51593b0258309bfbbee767b3c116bc7ce6bc1b80"
+source = "git+https://github.com/servo/stylo?rev=2373b812bbfdf0d01168fd613a0e772e94d32012#2373b812bbfdf0d01168fd613a0e772e94d32012"
 dependencies = [
  "app_units",
  "arrayvec",
@@ -9275,7 +9275,7 @@ dependencies = [
 [[package]]
 name = "stylo_atoms"
 version = "0.13.0"
-source = "git+https://github.com/servo/stylo?rev=51593b0258309bfbbee767b3c116bc7ce6bc1b80#51593b0258309bfbbee767b3c116bc7ce6bc1b80"
+source = "git+https://github.com/servo/stylo?rev=2373b812bbfdf0d01168fd613a0e772e94d32012#2373b812bbfdf0d01168fd613a0e772e94d32012"
 dependencies = [
  "string_cache",
  "string_cache_codegen",
@@ -9284,7 +9284,7 @@ dependencies = [
 [[package]]
 name = "stylo_derive"
 version = "0.13.0"
-source = "git+https://github.com/servo/stylo?rev=51593b0258309bfbbee767b3c116bc7ce6bc1b80#51593b0258309bfbbee767b3c116bc7ce6bc1b80"
+source = "git+https://github.com/servo/stylo?rev=2373b812bbfdf0d01168fd613a0e772e94d32012#2373b812bbfdf0d01168fd613a0e772e94d32012"
 dependencies = [
  "darling",
  "proc-macro2",
@@ -9296,7 +9296,7 @@ dependencies = [
 [[package]]
 name = "stylo_dom"
 version = "0.13.0"
-source = "git+https://github.com/servo/stylo?rev=51593b0258309bfbbee767b3c116bc7ce6bc1b80#51593b0258309bfbbee767b3c116bc7ce6bc1b80"
+source = "git+https://github.com/servo/stylo?rev=2373b812bbfdf0d01168fd613a0e772e94d32012#2373b812bbfdf0d01168fd613a0e772e94d32012"
 dependencies = [
  "bitflags 2.11.0",
  "stylo_malloc_size_of",
@@ -9305,7 +9305,7 @@ dependencies = [
 [[package]]
 name = "stylo_malloc_size_of"
 version = "0.13.0"
-source = "git+https://github.com/servo/stylo?rev=51593b0258309bfbbee767b3c116bc7ce6bc1b80#51593b0258309bfbbee767b3c116bc7ce6bc1b80"
+source = "git+https://github.com/servo/stylo?rev=2373b812bbfdf0d01168fd613a0e772e94d32012#2373b812bbfdf0d01168fd613a0e772e94d32012"
 dependencies = [
  "app_units",
  "cssparser",
@@ -9322,12 +9322,12 @@ dependencies = [
 [[package]]
 name = "stylo_static_prefs"
 version = "0.13.0"
-source = "git+https://github.com/servo/stylo?rev=51593b0258309bfbbee767b3c116bc7ce6bc1b80#51593b0258309bfbbee767b3c116bc7ce6bc1b80"
+source = "git+https://github.com/servo/stylo?rev=2373b812bbfdf0d01168fd613a0e772e94d32012#2373b812bbfdf0d01168fd613a0e772e94d32012"
 
 [[package]]
 name = "stylo_traits"
 version = "0.13.0"
-source = "git+https://github.com/servo/stylo?rev=51593b0258309bfbbee767b3c116bc7ce6bc1b80#51593b0258309bfbbee767b3c116bc7ce6bc1b80"
+source = "git+https://github.com/servo/stylo?rev=2373b812bbfdf0d01168fd613a0e772e94d32012#2373b812bbfdf0d01168fd613a0e772e94d32012"
 dependencies = [
  "app_units",
  "bitflags 2.11.0",
@@ -9749,7 +9749,7 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 [[package]]
 name = "to_shmem"
 version = "0.3.0"
-source = "git+https://github.com/servo/stylo?rev=51593b0258309bfbbee767b3c116bc7ce6bc1b80#51593b0258309bfbbee767b3c116bc7ce6bc1b80"
+source = "git+https://github.com/servo/stylo?rev=2373b812bbfdf0d01168fd613a0e772e94d32012#2373b812bbfdf0d01168fd613a0e772e94d32012"
 dependencies = [
  "cssparser",
  "servo_arc",
@@ -9762,7 +9762,7 @@ dependencies = [
 [[package]]
 name = "to_shmem_derive"
 version = "0.1.0"
-source = "git+https://github.com/servo/stylo?rev=51593b0258309bfbbee767b3c116bc7ce6bc1b80#51593b0258309bfbbee767b3c116bc7ce6bc1b80"
+source = "git+https://github.com/servo/stylo?rev=2373b812bbfdf0d01168fd613a0e772e94d32012#2373b812bbfdf0d01168fd613a0e772e94d32012"
 dependencies = [
  "darling",
  "proc-macro2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -172,7 +172,7 @@ script_traits = { package = "servo-script-traits", path = "components/shared/scr
 sea-query = { version = "1.0.0-rc.31", default-features = false, features = ["backend-sqlite", "derive"] }
 sea-query-rusqlite = { version = "0.8.0-rc.15" }
 sec1 = "0.7"
-selectors = { git = "https://github.com/servo/stylo", rev = "51593b0258309bfbbee767b3c116bc7ce6bc1b80" }
+selectors = { git = "https://github.com/servo/stylo", rev = "2373b812bbfdf0d01168fd613a0e772e94d32012" }
 serde = "1.0.228"
 serde_bytes = "0.11"
 serde_core = "1.0.226"
@@ -181,7 +181,7 @@ servo-media = { path = "components/media/servo-media" }
 servo-media-dummy = { path = "components/media/backends/dummy" }
 servo-media-gstreamer = { path = "components/media/backends/gstreamer" }
 servo-tracing = { path = "components/servo_tracing" }
-servo_arc = { git = "https://github.com/servo/stylo", rev = "51593b0258309bfbbee767b3c116bc7ce6bc1b80" }
+servo_arc = { git = "https://github.com/servo/stylo", rev = "2373b812bbfdf0d01168fd613a0e772e94d32012" }
 sha1 = "0.10"
 sha2 = "0.10"
 sha3 = "0.10"
@@ -190,12 +190,12 @@ smallvec = { version = "1.15", features = ["serde", "union"] }
 storage_traits = { package = "servo-storage-traits", path = "components/shared/storage" }
 string_cache = "0.9"
 strum = { version = "0.28", features = ["derive"] }
-stylo = { git = "https://github.com/servo/stylo", rev = "51593b0258309bfbbee767b3c116bc7ce6bc1b80" }
-stylo_atoms = { git = "https://github.com/servo/stylo", rev = "51593b0258309bfbbee767b3c116bc7ce6bc1b80" }
-stylo_dom = { git = "https://github.com/servo/stylo", rev = "51593b0258309bfbbee767b3c116bc7ce6bc1b80" }
-stylo_malloc_size_of = { git = "https://github.com/servo/stylo", rev = "51593b0258309bfbbee767b3c116bc7ce6bc1b80" }
-stylo_static_prefs = { git = "https://github.com/servo/stylo", rev = "51593b0258309bfbbee767b3c116bc7ce6bc1b80" }
-stylo_traits = { git = "https://github.com/servo/stylo", rev = "51593b0258309bfbbee767b3c116bc7ce6bc1b80" }
+stylo = { git = "https://github.com/servo/stylo", rev = "2373b812bbfdf0d01168fd613a0e772e94d32012" }
+stylo_atoms = { git = "https://github.com/servo/stylo", rev = "2373b812bbfdf0d01168fd613a0e772e94d32012" }
+stylo_dom = { git = "https://github.com/servo/stylo", rev = "2373b812bbfdf0d01168fd613a0e772e94d32012" }
+stylo_malloc_size_of = { git = "https://github.com/servo/stylo", rev = "2373b812bbfdf0d01168fd613a0e772e94d32012" }
+stylo_static_prefs = { git = "https://github.com/servo/stylo", rev = "2373b812bbfdf0d01168fd613a0e772e94d32012" }
+stylo_traits = { git = "https://github.com/servo/stylo", rev = "2373b812bbfdf0d01168fd613a0e772e94d32012" }
 surfman = { version = "0.11.0", features = ["chains"] }
 syn = { version = "2", default-features = false, features = ["clone-impls", "derive", "parsing"] }
 synstructure = "0.13"

--- a/tests/wpt/meta/css/css-transforms/transform-input-016.html.ini
+++ b/tests/wpt/meta/css/css-transforms/transform-input-016.html.ini
@@ -1,0 +1,2 @@
+[transform-input-016.html]
+  expected: FAIL


### PR DESCRIPTION
This change just updates the version of Stylo to a version which restores the original Servo theme colors.

Stylo PR: servo/stylo#327
Testing: This just restore the original form control theme colors, so should
not change test results. Manual testing was performed with the
`form-controls-visual.html` test. One form tests starts to fail due to
subpixel differences. This test was failing originally (before form
control style was inadvertently changed). This likely happens due to
the rounded grey borders of buttons. This PR changes them back to
gray from black.