### PR TITLE
script: Pass `&mut JSContext` to DOM apis that call `Element::create`

### DIFF
--- a/components/script/dom/document.rs
+++ b/components/script/dom/document.rs
@@ -5420,9 +5420,9 @@ impl DocumentMethods<crate::DomTypeHolder> for Document {
     /// <https://dom.spec.whatwg.org/#dom-document-createelement>
     fn CreateElement(
         &self,
+        cx: &mut js::context::JSContext,
         mut local_name: DOMString,
         options: StringOrElementCreationOptions,
-        can_gc: CanGc,
     ) -> Fallible<DomRoot<Element>> {
         // Step 1. If localName is not a valid element local name,
         //      then throw an "InvalidCharacterError" DOMException.
@@ -5455,17 +5455,17 @@ impl DocumentMethods<crate::DomTypeHolder> for Document {
             ElementCreator::ScriptCreated,
             CustomElementCreationMode::Synchronous,
             None,
-            can_gc,
+            CanGc::from_cx(cx),
         ))
     }
 
     /// <https://dom.spec.whatwg.org/#dom-document-createelementns>
     fn CreateElementNS(
         &self,
+        cx: &mut js::context::JSContext,
         namespace: Option<DOMString>,
         qualified_name: DOMString,
         options: StringOrElementCreationOptions,
-        can_gc: CanGc,
     ) -> Fallible<DomRoot<Element>> {
         // Step 1. Let (namespace, prefix, localName) be the result of
         //      validating and extracting namespace and qualifiedName given "element".
@@ -5491,7 +5491,7 @@ impl DocumentMethods<crate::DomTypeHolder> for Document {
             ElementCreator::ScriptCreated,
             CustomElementCreationMode::Synchronous,
             None,
-            can_gc,
+            CanGc::from_cx(cx),
         ))
     }
 
@@ -5764,7 +5764,7 @@ impl DocumentMethods<crate::DomTypeHolder> for Document {
     }
 
     /// <https://html.spec.whatwg.org/multipage/#document.title>
-    fn SetTitle(&self, title: DOMString, can_gc: CanGc) {
+    fn SetTitle(&self, cx: &mut js::context::JSContext, title: DOMString) {
         let root = match self.GetDocumentElement() {
             Some(root) => root,
             None => return,
@@ -5785,12 +5785,12 @@ impl DocumentMethods<crate::DomTypeHolder> for Document {
                         ElementCreator::ScriptCreated,
                         CustomElementCreationMode::Synchronous,
                         None,
-                        can_gc,
+                        CanGc::from_cx(cx),
                     );
                     let parent = root.upcast::<Node>();
                     let child = elem.upcast::<Node>();
                     parent
-                        .InsertBefore(child, parent.GetFirstChild().as_deref(), can_gc)
+                        .InsertBefore(child, parent.GetFirstChild().as_deref(), CanGc::from_cx(cx))
                         .unwrap()
                 },
             }
@@ -5811,10 +5811,10 @@ impl DocumentMethods<crate::DomTypeHolder> for Document {
                             ElementCreator::ScriptCreated,
                             CustomElementCreationMode::Synchronous,
                             None,
-                            can_gc,
+                            CanGc::from_cx(cx),
                         );
                         head.upcast::<Node>()
-                            .AppendChild(elem.upcast(), can_gc)
+                            .AppendChild(elem.upcast(), CanGc::from_cx(cx))
                             .unwrap()
                     },
                     None => return,
@@ -5824,7 +5824,7 @@ impl DocumentMethods<crate::DomTypeHolder> for Document {
             return;
         };
 
-        node.set_text_content_for_element(Some(title), can_gc);
+        node.set_text_content_for_element(Some(title), CanGc::from_cx(cx));
     }
 
     /// <https://html.spec.whatwg.org/multipage/#dom-document-head>

--- a/components/script/dom/domimplementation.rs
+++ b/components/script/dom/domimplementation.rs
@@ -4,6 +4,7 @@
 
 use dom_struct::dom_struct;
 use html5ever::{QualName, local_name, ns};
+use js::context::JSContext;
 use script_bindings::error::Error;
 use script_traits::DocumentActivity;
 
@@ -83,10 +84,10 @@ impl DOMImplementationMethods<crate::DomTypeHolder> for DOMImplementation {
     /// <https://dom.spec.whatwg.org/#dom-domimplementation-createdocument>
     fn CreateDocument(
         &self,
+        cx: &mut JSContext,
         maybe_namespace: Option<DOMString>,
         qname: DOMString,
         maybe_doctype: Option<&DocumentType>,
-        can_gc: CanGc,
     ) -> Fallible<DomRoot<XMLDocument>> {
         let win = self.document.window();
         let loader = DocumentLoader::new(&self.document.loader());
@@ -115,7 +116,7 @@ impl DOMImplementationMethods<crate::DomTypeHolder> for DOMImplementation {
             Some(self.document.insecure_requests_policy()),
             self.document.has_trustworthy_ancestor_or_current_origin(),
             self.document.custom_element_reaction_stack(),
-            can_gc,
+            CanGc::from_cx(cx),
         );
 
         // Step 2. Let element be null.
@@ -130,7 +131,7 @@ impl DOMImplementationMethods<crate::DomTypeHolder> for DOMImplementation {
                 });
             match doc
                 .upcast::<Document>()
-                .CreateElementNS(maybe_namespace, qname, options, can_gc)
+                .CreateElementNS(cx, maybe_namespace, qname, options)
             {
                 Err(error) => return Err(error),
                 Ok(elem) => Some(elem),
@@ -142,12 +143,16 @@ impl DOMImplementationMethods<crate::DomTypeHolder> for DOMImplementation {
 
             // Step 4.
             if let Some(doc_type) = maybe_doctype {
-                doc_node.AppendChild(doc_type.upcast(), can_gc).unwrap();
+                doc_node
+                    .AppendChild(doc_type.upcast(), CanGc::from_cx(cx))
+                    .unwrap();
             }
 
             // Step 5.
             if let Some(ref elem) = maybe_elem {
-                doc_node.AppendChild(elem.upcast(), can_gc).unwrap();
+                doc_node
+                    .AppendChild(elem.upcast(), CanGc::from_cx(cx))
+                    .unwrap();
             }
         }
 
@@ -159,7 +164,11 @@ impl DOMImplementationMethods<crate::DomTypeHolder> for DOMImplementation {
     }
 
     /// <https://dom.spec.whatwg.org/#dom-domimplementation-createhtmldocument>
-    fn CreateHTMLDocument(&self, title: Option<DOMString>, can_gc: CanGc) -> DomRoot<Document> {
+    fn CreateHTMLDocument(
+        &self,
+        cx: &mut JSContext,
+        title: Option<DOMString>,
+    ) -> DomRoot<Document> {
         let win = self.document.window();
         let loader = DocumentLoader::new(&self.document.loader());
 
@@ -187,14 +196,22 @@ impl DOMImplementationMethods<crate::DomTypeHolder> for DOMImplementation {
             self.document.has_trustworthy_ancestor_or_current_origin(),
             self.document.custom_element_reaction_stack(),
             self.document.creation_sandboxing_flag_set(),
-            can_gc,
+            CanGc::from_cx(cx),
         );
 
         {
             // Step 3. Append a new doctype, with "html" as its name and with its node document set to doc, to doc.
             let doc_node = doc.upcast::<Node>();
-            let doc_type = DocumentType::new(DOMString::from("html"), None, None, &doc, can_gc);
-            doc_node.AppendChild(doc_type.upcast(), can_gc).unwrap();
+            let doc_type = DocumentType::new(
+                DOMString::from("html"),
+                None,
+                None,
+                &doc,
+                CanGc::from_cx(cx),
+            );
+            doc_node
+                .AppendChild(doc_type.upcast(), CanGc::from_cx(cx))
+                .unwrap();
         }
 
         {
@@ -208,10 +225,10 @@ impl DOMImplementationMethods<crate::DomTypeHolder> for DOMImplementation {
                 ElementCreator::ScriptCreated,
                 CustomElementCreationMode::Asynchronous,
                 None,
-                can_gc,
+                CanGc::from_cx(cx),
             ));
             doc_node
-                .AppendChild(&doc_html, can_gc)
+                .AppendChild(&doc_html, CanGc::from_cx(cx))
                 .expect("Appending failed");
 
             {
@@ -224,9 +241,9 @@ impl DOMImplementationMethods<crate::DomTypeHolder> for DOMImplementation {
                     ElementCreator::ScriptCreated,
                     CustomElementCreationMode::Asynchronous,
                     None,
-                    can_gc,
+                    CanGc::from_cx(cx),
                 ));
-                doc_html.AppendChild(&doc_head, can_gc).unwrap();
+                doc_html.AppendChild(&doc_head, CanGc::from_cx(cx)).unwrap();
 
                 // Step 6. If title is given:
                 if let Some(title_str) = title {
@@ -239,14 +256,18 @@ impl DOMImplementationMethods<crate::DomTypeHolder> for DOMImplementation {
                         ElementCreator::ScriptCreated,
                         CustomElementCreationMode::Asynchronous,
                         None,
-                        can_gc,
+                        CanGc::from_cx(cx),
                     ));
-                    doc_head.AppendChild(&doc_title, can_gc).unwrap();
+                    doc_head
+                        .AppendChild(&doc_title, CanGc::from_cx(cx))
+                        .unwrap();
 
                     // Step 6.2. Append a new Text node, with its data set to title (which could be the empty string)
                     // and its node document set to doc, to the title element created earlier.
-                    let title_text = Text::new(title_str, &doc, can_gc);
-                    doc_title.AppendChild(title_text.upcast(), can_gc).unwrap();
+                    let title_text = Text::new(title_str, &doc, CanGc::from_cx(cx));
+                    doc_title
+                        .AppendChild(title_text.upcast(), CanGc::from_cx(cx))
+                        .unwrap();
                 }
             }
 
@@ -259,9 +280,11 @@ impl DOMImplementationMethods<crate::DomTypeHolder> for DOMImplementation {
                 ElementCreator::ScriptCreated,
                 CustomElementCreationMode::Asynchronous,
                 None,
-                can_gc,
+                CanGc::from_cx(cx),
             );
-            doc_html.AppendChild(doc_body.upcast(), can_gc).unwrap();
+            doc_html
+                .AppendChild(doc_body.upcast(), CanGc::from_cx(cx))
+                .unwrap();
         }
 
         // Step 9. Return doc.

--- a/components/script/dom/execcommand/contenteditable.rs
+++ b/components/script/dom/execcommand/contenteditable.rs
@@ -201,7 +201,7 @@ impl Document {
             StringOrElementCreationOptions::ElementCreationOptions(ElementCreationOptions {
                 is: None,
             });
-        match self.CreateElement("br".into(), element_options, CanGc::from_cx(cx)) {
+        match self.CreateElement(cx, "br".into(), element_options) {
             Err(_) => unreachable!("Must always be able to create br"),
             Ok(br) => br,
         }

--- a/components/script/dom/html/htmlaudioelement.rs
+++ b/components/script/dom/html/htmlaudioelement.rs
@@ -4,6 +4,7 @@
 
 use dom_struct::dom_struct;
 use html5ever::{LocalName, Prefix, QualName, local_name, ns};
+use js::context::JSContext;
 use js::rust::HandleObject;
 use style::attr::AttrValue;
 
@@ -56,9 +57,9 @@ impl HTMLAudioElement {
 impl HTMLAudioElementMethods<crate::DomTypeHolder> for HTMLAudioElement {
     /// <https://html.spec.whatwg.org/multipage/#dom-audio>
     fn Audio(
+        cx: &mut JSContext,
         window: &Window,
         proto: Option<HandleObject>,
-        can_gc: CanGc,
         src: Option<DOMString>,
     ) -> Fallible<DomRoot<HTMLAudioElement>> {
         // Step 1. Let document be the current global object's associated Document.
@@ -73,21 +74,25 @@ impl HTMLAudioElementMethods<crate::DomTypeHolder> for HTMLAudioElement {
             ElementCreator::ScriptCreated,
             CustomElementCreationMode::Synchronous,
             proto,
-            can_gc,
+            CanGc::from_cx(cx),
         );
 
         // Step 3. Set an attribute value for audio using "preload" and "auto".
         audio.set_attribute(
             &local_name!("preload"),
             AttrValue::String("auto".to_owned()),
-            can_gc,
+            CanGc::from_cx(cx),
         );
 
         // Step 4. If src is given, then set an attribute value for audio using "src" and src. (This
         // will cause the user agent to invoke the object's resource selection algorithm before
         // returning).
         if let Some(s) = src {
-            audio.set_attribute(&local_name!("src"), AttrValue::String(s.into()), can_gc);
+            audio.set_attribute(
+                &local_name!("src"),
+                AttrValue::String(s.into()),
+                CanGc::from_cx(cx),
+            );
         }
 
         // Step 5. Return audio.

--- a/components/script/dom/html/htmlimageelement.rs
+++ b/components/script/dom/html/htmlimageelement.rs
@@ -1747,9 +1747,9 @@ fn parse_a_sizes_attribute(value: &str) -> SourceSizeList {
 impl HTMLImageElementMethods<crate::DomTypeHolder> for HTMLImageElement {
     /// <https://html.spec.whatwg.org/multipage/#dom-image>
     fn Image(
+        cx: &mut JSContext,
         window: &Window,
         proto: Option<HandleObject>,
-        can_gc: CanGc,
         width: Option<u32>,
         height: Option<u32>,
     ) -> Fallible<DomRoot<HTMLImageElement>> {
@@ -1765,7 +1765,7 @@ impl HTMLImageElementMethods<crate::DomTypeHolder> for HTMLImageElement {
             ElementCreator::ScriptCreated,
             CustomElementCreationMode::Synchronous,
             proto,
-            can_gc,
+            CanGc::from_cx(cx),
         );
 
         let image = DomRoot::downcast::<HTMLImageElement>(element).unwrap();

--- a/components/script/dom/html/htmloptionelement.rs
+++ b/components/script/dom/html/htmloptionelement.rs
@@ -7,6 +7,7 @@ use std::convert::TryInto;
 
 use dom_struct::dom_struct;
 use html5ever::{LocalName, Prefix, QualName, local_name, ns};
+use js::context::JSContext;
 use js::rust::HandleObject;
 use style::str::{split_html_space_chars, str_join};
 use stylo_dom::ElementState;
@@ -246,9 +247,9 @@ impl HTMLOptionElement {
 impl HTMLOptionElementMethods<crate::DomTypeHolder> for HTMLOptionElement {
     /// <https://html.spec.whatwg.org/multipage/#dom-option>
     fn Option(
+        cx: &mut JSContext,
         window: &Window,
         proto: Option<HandleObject>,
-        can_gc: CanGc,
         text: DOMString,
         value: Option<DOMString>,
         default_selected: bool,
@@ -261,7 +262,7 @@ impl HTMLOptionElementMethods<crate::DomTypeHolder> for HTMLOptionElement {
             ElementCreator::ScriptCreated,
             CustomElementCreationMode::Synchronous,
             proto,
-            can_gc,
+            CanGc::from_cx(cx),
         );
 
         let option = DomRoot::downcast::<HTMLOptionElement>(element).unwrap();
@@ -269,7 +270,7 @@ impl HTMLOptionElementMethods<crate::DomTypeHolder> for HTMLOptionElement {
         if !text.is_empty() {
             option
                 .upcast::<Node>()
-                .set_text_content_for_element(Some(text), can_gc)
+                .set_text_content_for_element(Some(text), CanGc::from_cx(cx))
         }
 
         if let Some(val) = value {
@@ -278,7 +279,7 @@ impl HTMLOptionElementMethods<crate::DomTypeHolder> for HTMLOptionElement {
 
         option.SetDefaultSelected(default_selected);
         option.set_selectedness(selected);
-        option.update_select_validity(can_gc);
+        option.update_select_validity(CanGc::from_cx(cx));
         Ok(option)
     }
 

--- a/components/script/dom/html/htmloptionscollection.rs
+++ b/components/script/dom/html/htmloptionscollection.rs
@@ -6,6 +6,7 @@ use std::cmp::Ordering;
 
 use dom_struct::dom_struct;
 use html5ever::{QualName, local_name, ns};
+use js::context::JSContext;
 
 use crate::dom::bindings::codegen::Bindings::ElementBinding::ElementMethods;
 use crate::dom::bindings::codegen::Bindings::HTMLCollectionBinding::HTMLCollectionMethods;
@@ -56,7 +57,7 @@ impl HTMLOptionsCollection {
         )
     }
 
-    fn add_new_elements(&self, count: u32, can_gc: CanGc) -> ErrorResult {
+    fn add_new_elements(&self, cx: &mut JSContext, count: u32) -> ErrorResult {
         let root = self.upcast().root_node();
         let document = root.owner_document();
 
@@ -68,10 +69,10 @@ impl HTMLOptionsCollection {
                 ElementCreator::ScriptCreated,
                 CustomElementCreationMode::Asynchronous,
                 None,
-                can_gc,
+                CanGc::from_cx(cx),
             );
             let node = element.upcast::<Node>();
-            root.AppendChild(node, can_gc)?;
+            root.AppendChild(node, CanGc::from_cx(cx))?;
         }
         Ok(())
     }
@@ -104,9 +105,9 @@ impl HTMLOptionsCollectionMethods<crate::DomTypeHolder> for HTMLOptionsCollectio
     /// <https://html.spec.whatwg.org/multipage/#dom-htmloptionscollection-setter>
     fn IndexedSetter(
         &self,
+        cx: &mut JSContext,
         index: u32,
         value: Option<&HTMLOptionElement>,
-        can_gc: CanGc,
     ) -> ErrorResult {
         if let Some(value) = value {
             // Step 2
@@ -117,19 +118,20 @@ impl HTMLOptionsCollectionMethods<crate::DomTypeHolder> for HTMLOptionsCollectio
 
             // Step 4
             if n > 0 {
-                self.add_new_elements(n as u32, can_gc)?;
+                self.add_new_elements(cx, n as u32)?;
             }
 
             // Step 5
             let node = value.upcast::<Node>();
             let root = self.upcast().root_node();
             if n >= 0 {
-                Node::pre_insert(node, &root, None, can_gc).map(|_| ())
+                Node::pre_insert(node, &root, None, CanGc::from_cx(cx)).map(|_| ())
             } else {
                 let child = self.upcast().IndexedGetter(index).unwrap();
                 let child_node = child.upcast::<Node>();
 
-                root.ReplaceChild(node, child_node, can_gc).map(|_| ())
+                root.ReplaceChild(node, child_node, CanGc::from_cx(cx))
+                    .map(|_| ())
             }
         } else {
             // Step 1
@@ -144,7 +146,7 @@ impl HTMLOptionsCollectionMethods<crate::DomTypeHolder> for HTMLOptionsCollectio
     }
 
     /// <https://html.spec.whatwg.org/multipage/#dom-htmloptionscollection-length>
-    fn SetLength(&self, length: u32, can_gc: CanGc) {
+    fn SetLength(&self, cx: &mut JSContext, length: u32) {
         // Step 1. Let current be the number of nodes represented by the collection.
         let current = self.upcast().Length();
 
@@ -161,7 +163,7 @@ impl HTMLOptionsCollectionMethods<crate::DomTypeHolder> for HTMLOptionsCollectio
 
                 // Step 2.3 Append n new option elements with no attributes and no child
                 // nodes to the select element on which this is rooted.
-                self.add_new_elements(n, can_gc).unwrap();
+                self.add_new_elements(cx, n).unwrap();
             },
             // Step 3. If the given value is less than current, then:
             Ordering::Less => {

--- a/components/script/dom/html/htmlselectelement.rs
+++ b/components/script/dom/html/htmlselectelement.rs
@@ -573,8 +573,8 @@ impl HTMLSelectElementMethods<crate::DomTypeHolder> for HTMLSelectElement {
     }
 
     /// <https://html.spec.whatwg.org/multipage/#dom-select-length>
-    fn SetLength(&self, length: u32, can_gc: CanGc) {
-        self.Options().SetLength(length, can_gc)
+    fn SetLength(&self, cx: &mut JSContext, length: u32) {
+        self.Options().SetLength(cx, length)
     }
 
     /// <https://html.spec.whatwg.org/multipage/#dom-select-item>
@@ -590,11 +590,11 @@ impl HTMLSelectElementMethods<crate::DomTypeHolder> for HTMLSelectElement {
     /// <https://html.spec.whatwg.org/multipage/#dom-select-setter>
     fn IndexedSetter(
         &self,
+        cx: &mut JSContext,
         index: u32,
         value: Option<&HTMLOptionElement>,
-        can_gc: CanGc,
     ) -> ErrorResult {
-        self.Options().IndexedSetter(index, value, can_gc)
+        self.Options().IndexedSetter(cx, index, value)
     }
 
     /// <https://html.spec.whatwg.org/multipage/#dom-select-nameditem>

--- a/components/script/dom/html/htmltableelement.rs
+++ b/components/script/dom/html/htmltableelement.rs
@@ -6,6 +6,7 @@ use std::cell::Cell;
 
 use dom_struct::dom_struct;
 use html5ever::{LocalName, Prefix, QualName, local_name, ns};
+use js::context::JSContext;
 use js::rust::HandleObject;
 use style::attr::{AttrValue, LengthOrPercentageOrAuto, parse_unsigned_integer};
 use style::color::AbsoluteColor;
@@ -144,8 +145,8 @@ impl HTMLTableElement {
     /// <https://html.spec.whatwg.org/multipage/#dom-table-createtfoot>
     fn create_section_of_type(
         &self,
+        cx: &mut JSContext,
         atom: &LocalName,
-        can_gc: CanGc,
     ) -> DomRoot<HTMLTableSectionElement> {
         if let Some(section) = self.get_first_section_of_type(atom) {
             return section;
@@ -158,7 +159,7 @@ impl HTMLTableElement {
             ElementCreator::ScriptCreated,
             CustomElementCreationMode::Asynchronous,
             None,
-            can_gc,
+            CanGc::from_cx(cx),
         );
 
         let section = DomRoot::downcast::<HTMLTableSectionElement>(section).unwrap();
@@ -231,7 +232,7 @@ impl HTMLTableElementMethods<crate::DomTypeHolder> for HTMLTableElement {
     }
 
     /// <https://html.spec.whatwg.org/multipage/#dom-table-createcaption>
-    fn CreateCaption(&self, can_gc: CanGc) -> DomRoot<HTMLTableCaptionElement> {
+    fn CreateCaption(&self, cx: &mut JSContext) -> DomRoot<HTMLTableCaptionElement> {
         match self.GetCaption() {
             Some(caption) => caption,
             None => {
@@ -242,7 +243,7 @@ impl HTMLTableElementMethods<crate::DomTypeHolder> for HTMLTableElement {
                     ElementCreator::ScriptCreated,
                     CustomElementCreationMode::Asynchronous,
                     None,
-                    can_gc,
+                    CanGc::from_cx(cx),
                 );
                 let caption = DomRoot::downcast::<HTMLTableCaptionElement>(caption).unwrap();
 
@@ -276,8 +277,8 @@ impl HTMLTableElementMethods<crate::DomTypeHolder> for HTMLTableElement {
     }
 
     /// <https://html.spec.whatwg.org/multipage/#dom-table-createthead>
-    fn CreateTHead(&self, can_gc: CanGc) -> DomRoot<HTMLTableSectionElement> {
-        self.create_section_of_type(&local_name!("thead"), can_gc)
+    fn CreateTHead(&self, cx: &mut JSContext) -> DomRoot<HTMLTableSectionElement> {
+        self.create_section_of_type(cx, &local_name!("thead"))
     }
 
     /// <https://html.spec.whatwg.org/multipage/#dom-table-deletethead>
@@ -314,8 +315,8 @@ impl HTMLTableElementMethods<crate::DomTypeHolder> for HTMLTableElement {
     }
 
     /// <https://html.spec.whatwg.org/multipage/#dom-table-createtfoot>
-    fn CreateTFoot(&self, can_gc: CanGc) -> DomRoot<HTMLTableSectionElement> {
-        self.create_section_of_type(&local_name!("tfoot"), can_gc)
+    fn CreateTFoot(&self, cx: &mut JSContext) -> DomRoot<HTMLTableSectionElement> {
+        self.create_section_of_type(cx, &local_name!("tfoot"))
     }
 
     /// <https://html.spec.whatwg.org/multipage/#dom-table-deletetfoot>
@@ -340,7 +341,7 @@ impl HTMLTableElementMethods<crate::DomTypeHolder> for HTMLTableElement {
     }
 
     /// <https://html.spec.whatwg.org/multipage/#dom-table-createtbody>
-    fn CreateTBody(&self, can_gc: CanGc) -> DomRoot<HTMLTableSectionElement> {
+    fn CreateTBody(&self, cx: &mut JSContext) -> DomRoot<HTMLTableSectionElement> {
         let tbody = Element::create(
             QualName::new(None, ns!(html), local_name!("tbody")),
             None,
@@ -348,7 +349,7 @@ impl HTMLTableElementMethods<crate::DomTypeHolder> for HTMLTableElement {
             ElementCreator::ScriptCreated,
             CustomElementCreationMode::Asynchronous,
             None,
-            can_gc,
+            CanGc::from_cx(cx),
         );
         let tbody = DomRoot::downcast::<HTMLTableSectionElement>(tbody).unwrap();
         let node = self.upcast::<Node>();
@@ -358,13 +359,17 @@ impl HTMLTableElementMethods<crate::DomTypeHolder> for HTMLTableElement {
             .find(|n| n.is::<HTMLTableSectionElement>() && n.local_name() == &local_name!("tbody"));
         let reference_element = last_tbody.and_then(|t| t.upcast::<Node>().GetNextSibling());
 
-        node.InsertBefore(tbody.upcast(), reference_element.as_deref(), can_gc)
-            .expect("Insertion failed");
+        node.InsertBefore(
+            tbody.upcast(),
+            reference_element.as_deref(),
+            CanGc::from_cx(cx),
+        )
+        .expect("Insertion failed");
         tbody
     }
 
     /// <https://html.spec.whatwg.org/multipage/#dom-table-insertrow>
-    fn InsertRow(&self, index: i32, can_gc: CanGc) -> Fallible<DomRoot<HTMLTableRowElement>> {
+    fn InsertRow(&self, cx: &mut JSContext, index: i32) -> Fallible<DomRoot<HTMLTableRowElement>> {
         let rows = self.Rows();
         let number_of_row_elements = rows.Length();
 
@@ -379,7 +384,7 @@ impl HTMLTableElementMethods<crate::DomTypeHolder> for HTMLTableElement {
             ElementCreator::ScriptCreated,
             CustomElementCreationMode::Asynchronous,
             None,
-            can_gc,
+            CanGc::from_cx(cx),
         );
         let new_row = DomRoot::downcast::<HTMLTableRowElement>(new_row).unwrap();
         let node = self.upcast::<Node>();
@@ -395,16 +400,16 @@ impl HTMLTableElementMethods<crate::DomTypeHolder> for HTMLTableElement {
             {
                 last_tbody
                     .upcast::<Node>()
-                    .AppendChild(new_row.upcast::<Node>(), can_gc)
+                    .AppendChild(new_row.upcast::<Node>(), CanGc::from_cx(cx))
                     .expect("InsertRow failed to append first row.");
             } else {
-                let tbody = self.CreateTBody(can_gc);
-                node.AppendChild(tbody.upcast(), can_gc)
+                let tbody = self.CreateTBody(cx);
+                node.AppendChild(tbody.upcast(), CanGc::from_cx(cx))
                     .expect("InsertRow failed to append new tbody.");
 
                 tbody
                     .upcast::<Node>()
-                    .AppendChild(new_row.upcast::<Node>(), can_gc)
+                    .AppendChild(new_row.upcast::<Node>(), CanGc::from_cx(cx))
                     .expect("InsertRow failed to append first row.");
             }
         } else if index == number_of_row_elements as i32 || index == -1 {
@@ -420,7 +425,7 @@ impl HTMLTableElementMethods<crate::DomTypeHolder> for HTMLTableElement {
 
             last_row_parent
                 .upcast::<Node>()
-                .AppendChild(new_row.upcast::<Node>(), can_gc)
+                .AppendChild(new_row.upcast::<Node>(), CanGc::from_cx(cx))
                 .expect("InsertRow failed to append last row.");
         } else {
             // insert new row before the index-th row in rows using the same parent
@@ -438,7 +443,7 @@ impl HTMLTableElementMethods<crate::DomTypeHolder> for HTMLTableElement {
                 .InsertBefore(
                     new_row.upcast::<Node>(),
                     Some(ith_row.upcast::<Node>()),
-                    can_gc,
+                    CanGc::from_cx(cx),
                 )
                 .expect("InsertRow failed to append row");
         }

--- a/components/script/dom/html/htmltablerowelement.rs
+++ b/components/script/dom/html/htmltablerowelement.rs
@@ -4,6 +4,7 @@
 
 use dom_struct::dom_struct;
 use html5ever::{LocalName, Prefix, QualName, local_name, ns};
+use js::context::JSContext;
 use js::rust::HandleObject;
 use style::attr::{AttrValue, LengthOrPercentageOrAuto};
 use style::color::AbsoluteColor;
@@ -101,12 +102,13 @@ impl HTMLTableRowElementMethods<crate::DomTypeHolder> for HTMLTableRowElement {
     }
 
     /// <https://html.spec.whatwg.org/multipage/#dom-tr-insertcell>
-    fn InsertCell(&self, index: i32, can_gc: CanGc) -> Fallible<DomRoot<HTMLElement>> {
+    fn InsertCell(&self, cx: &mut JSContext, index: i32) -> Fallible<DomRoot<HTMLElement>> {
         let node = self.upcast::<Node>();
         node.insert_cell_or_row(
+            cx,
             index,
             || self.Cells(),
-            || {
+            |cx| {
                 let cell = Element::create(
                     QualName::new(None, ns!(html), local_name!("td")),
                     None,
@@ -114,11 +116,10 @@ impl HTMLTableRowElementMethods<crate::DomTypeHolder> for HTMLTableRowElement {
                     ElementCreator::ScriptCreated,
                     CustomElementCreationMode::Asynchronous,
                     None,
-                    can_gc,
+                    CanGc::from_cx(cx),
                 );
                 DomRoot::downcast::<HTMLTableCellElement>(cell).unwrap()
             },
-            can_gc,
         )
     }
 

--- a/components/script/dom/html/htmltablesectionelement.rs
+++ b/components/script/dom/html/htmltablesectionelement.rs
@@ -4,6 +4,7 @@
 
 use dom_struct::dom_struct;
 use html5ever::{LocalName, Prefix, QualName, local_name, ns};
+use js::context::JSContext;
 use js::rust::HandleObject;
 use style::attr::{AttrValue, LengthOrPercentageOrAuto};
 use style::color::AbsoluteColor;
@@ -78,12 +79,13 @@ impl HTMLTableSectionElementMethods<crate::DomTypeHolder> for HTMLTableSectionEl
     }
 
     /// <https://html.spec.whatwg.org/multipage/#dom-tbody-insertrow>
-    fn InsertRow(&self, index: i32, can_gc: CanGc) -> Fallible<DomRoot<HTMLElement>> {
+    fn InsertRow(&self, cx: &mut JSContext, index: i32) -> Fallible<DomRoot<HTMLElement>> {
         let node = self.upcast::<Node>();
         node.insert_cell_or_row(
+            cx,
             index,
             || self.Rows(),
-            || {
+            |cx| {
                 let row = Element::create(
                     QualName::new(None, ns!(html), local_name!("tr")),
                     None,
@@ -91,11 +93,10 @@ impl HTMLTableSectionElementMethods<crate::DomTypeHolder> for HTMLTableSectionEl
                     ElementCreator::ScriptCreated,
                     CustomElementCreationMode::Asynchronous,
                     None,
-                    can_gc,
+                    CanGc::from_cx(cx),
                 );
                 DomRoot::downcast::<HTMLTableRowElement>(row).unwrap()
             },
-            can_gc,
         )
     }
 

--- a/components/script/dom/node.rs
+++ b/components/script/dom/node.rs
@@ -22,7 +22,7 @@ use euclid::default::Size2D;
 use euclid::{Point2D, Rect};
 use html5ever::serialize::HtmlSerializer;
 use html5ever::{Namespace, Prefix, QualName, ns, serialize as html_serialize};
-use js::context::NoGC;
+use js::context::{JSContext, NoGC};
 use js::jsapi::JSObject;
 use js::rust::HandleObject;
 use keyboard_types::Modifiers;
@@ -342,7 +342,7 @@ impl Node {
         target: &Node,
         context_element: &Element,
         html: DOMString,
-        cx: &mut js::context::JSContext,
+        cx: &mut JSContext,
     ) {
         // Step 1. Let newChildren be the result of the HTML fragment parsing algorithm.
         let new_children = ServoParser::parse_html_fragment(context_element, html, true, cx);
@@ -1412,26 +1412,26 @@ impl Node {
     /// Used by `HTMLTableSectionElement::InsertRow` and `HTMLTableRowElement::InsertCell`
     pub(crate) fn insert_cell_or_row<F, G, I>(
         &self,
+        cx: &mut JSContext,
         index: i32,
         get_items: F,
         new_child: G,
-        can_gc: CanGc,
     ) -> Fallible<DomRoot<HTMLElement>>
     where
         F: Fn() -> DomRoot<HTMLCollection>,
-        G: Fn() -> DomRoot<I>,
+        G: Fn(&mut JSContext) -> DomRoot<I>,
         I: DerivedFrom<Node> + DerivedFrom<HTMLElement> + DomObject,
     {
         if index < -1 {
             return Err(Error::IndexSize(None));
         }
 
-        let tr = new_child();
+        let tr = new_child(cx);
 
         {
             let tr_node = tr.upcast::<Node>();
             if index == -1 {
-                self.InsertBefore(tr_node, None, can_gc)?;
+                self.InsertBefore(tr_node, None, CanGc::from_cx(cx))?;
             } else {
                 let items = get_items();
                 let node = match items
@@ -1444,7 +1444,7 @@ impl Node {
                     None => return Err(Error::IndexSize(None)),
                     Some(node) => node,
                 };
-                self.InsertBefore(tr_node, node.as_deref(), can_gc)?;
+                self.InsertBefore(tr_node, node.as_deref(), CanGc::from_cx(cx))?;
             }
         }
 

--- a/components/script_bindings/codegen/Bindings.conf
+++ b/components/script_bindings/codegen/Bindings.conf
@@ -512,7 +512,8 @@ DOMInterfaces = {
 },
 
 'HTMLOptionsCollection': {
-    'canGc': ['IndexedSetter', 'SetLength', 'SetSelectedIndex']
+    'canGc': ['SetSelectedIndex'],
+    'cx': ['IndexedSetter', 'SetLength'],
 },
 
 'HTMLOutputElement': {
@@ -530,8 +531,8 @@ DOMInterfaces = {
 },
 
 'HTMLSelectElement': {
-    'canGc': ['SetLength', 'IndexedSetter', 'SetSelectedIndex', 'SetCustomValidity', 'SetValue', 'Validity'],
-    'cx': ['CheckValidity', 'ReportValidity'],
+    'canGc': ['SetSelectedIndex', 'SetCustomValidity', 'SetValue', 'Validity'],
+    'cx': ['CheckValidity', 'IndexedSetter', 'ReportValidity', 'SetLength'],
 },
 
 'HTMLStyleElement': {

--- a/components/script_bindings/codegen/Bindings.conf
+++ b/components/script_bindings/codegen/Bindings.conf
@@ -193,8 +193,20 @@ DOMInterfaces = {
 
 'Document': {
     'additionalTraits': ["crate::interfaces::DocumentHelpers"],
-    'canGc': ['CreateElement', 'CreateElementNS', 'ImportNode', 'SetTitle', 'CreateEvent', 'CreateRange', 'CreateComment', 'CreateAttribute', 'CreateAttributeNS', 'CreateDocumentFragment', 'CreateTextNode', 'CreateCDATASection', 'CreateProcessingInstruction', 'Prepend', 'Append', 'ReplaceChildren', 'SetBgColor', 'SetFgColor', 'Fonts', 'ExitFullscreen', 'CreateExpression', 'CreateNSResolver', 'Evaluate', 'StyleSheets', 'Implementation', 'GetElementsByTagName', 'GetElementsByTagNameNS', 'GetElementsByClassName', 'AdoptNode', 'CreateNodeIterator', 'SetBody', 'GetElementsByName', 'Images', 'Embeds', 'Plugins', 'Links', 'Forms', 'Scripts', 'Anchors', 'Applets', 'Children', 'GetSelection', 'NamedGetter', 'AdoptedStyleSheets', 'SetAdoptedStyleSheets'],
-    'cx': ['Close', 'Open', 'Open_', 'ParseHTMLUnsafe', 'Write', 'Writeln', 'ExecCommand', 'QueryCommandEnabled'],
+    'canGc': ['ImportNode', 'CreateEvent', 'CreateRange', 'CreateComment', 'CreateAttribute', 'CreateAttributeNS', 'CreateDocumentFragment', 'CreateTextNode', 'CreateCDATASection', 'CreateProcessingInstruction', 'Prepend', 'Append', 'ReplaceChildren', 'SetBgColor', 'SetFgColor', 'Fonts', 'ExitFullscreen', 'CreateExpression', 'CreateNSResolver', 'Evaluate', 'StyleSheets', 'Implementation', 'GetElementsByTagName', 'GetElementsByTagNameNS', 'GetElementsByClassName', 'AdoptNode', 'CreateNodeIterator', 'SetBody', 'GetElementsByName', 'Images', 'Embeds', 'Plugins', 'Links', 'Forms', 'Scripts', 'Anchors', 'Applets', 'Children', 'GetSelection', 'NamedGetter', 'AdoptedStyleSheets', 'SetAdoptedStyleSheets'],
+    'cx': [
+        'Close',
+        'CreateElement',
+        'CreateElementNS',
+        'ExecCommand',
+        'Open',
+        'Open_',
+        'ParseHTMLUnsafe',
+        'QueryCommandEnabled',
+        'SetTitle',
+        'Write',
+        'Writeln',
+    ],
 },
 
 'DissimilarOriginWindow': {
@@ -211,7 +223,8 @@ DOMInterfaces = {
 },
 
 'DOMImplementation': {
-    'canGc': ['CreateDocument', 'CreateHTMLDocument', 'CreateDocumentType'],
+    'canGc': ['CreateDocumentType'],
+    'cx': ['CreateDocument', 'CreateHTMLDocument'],
 },
 
 'DOMMatrix': {
@@ -382,6 +395,7 @@ DOMInterfaces = {
 },
 
 "HTMLAudioElement": {
+    'cx': ['Audio'],
     'weakReferenceable': True,
 },
 
@@ -458,7 +472,7 @@ DOMInterfaces = {
 
 'HTMLImageElement': {
     'canGc': ['RequestSubmit', 'Reset','SetRel', 'Decode'],
-    'cx': ['ReportValidity', 'SetCrossOrigin'],
+    'cx': ['Image', 'ReportValidity', 'SetCrossOrigin'],
 },
 
 'HTMLInputElement': {
@@ -493,7 +507,8 @@ DOMInterfaces = {
 },
 
 'HTMLOptionElement': {
-    'canGc': ['SetSelected', 'SetText']
+    'canGc': ['SetSelected', 'SetText'],
+    'cx': ['Option'],
 },
 
 'HTMLOptionsCollection': {
@@ -524,15 +539,16 @@ DOMInterfaces = {
 },
 
 'HTMLTableElement': {
-    'canGc': ['CreateCaption', 'CreateTBody', 'InsertRow', 'InsertCell', 'InsertRow', 'CreateTHead', 'CreateTFoot']
+    'canGc': ['InsertCell', 'InsertRow'],
+    'cx': ['CreateCaption', 'CreateTBody', 'CreateTFoot', 'CreateTHead', 'InsertRow'],
 },
 
 'HTMLTableRowElement': {
-    'canGc': ['InsertCell']
+    'cx': ['InsertCell']
 },
 
 'HTMLTableSectionElement': {
-    'canGc': ['InsertRow']
+    'cx': ['InsertRow']
 },
 
 'HTMLTemplateElement': {


### PR DESCRIPTION


Testing: No behaviour change, a successful build is enough.
Part of #40600 
