### PR TITLE
ci: Fail the action if artifact not found when uploading; Update `actions/upload-artifact` to v7

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -113,21 +113,21 @@ jobs:
       # - name: Script tests
       #   run: ./mach test-android-startup
       - name: Archive build timing
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@v7
         with:
           name: cargo-timings-android-${{ matrix.target }}-${{ inputs.profile }}
           # Using a wildcard here ensures that the archive includes the path.
           path: target/cargo-timings-*
           if-no-files-found: error
       - name: Upload APK artifact
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@v7
         id: upload-apk
         with:
           name: ${{ inputs.profile }}-binary-android-${{ matrix.target }}
           path: target/android/${{ matrix.target }}/${{ inputs.profile }}/servoapp.apk
           if-no-files-found: error
       - name: Upload AAR artifact
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@v7
         id: upload-aar
         with:
           name: ${{ inputs.profile }}-library-android-${{ matrix.target }}

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -118,18 +118,21 @@ jobs:
           name: cargo-timings-android-${{ matrix.target }}-${{ inputs.profile }}
           # Using a wildcard here ensures that the archive includes the path.
           path: target/cargo-timings-*
+          if-no-files-found: error
       - name: Upload APK artifact
         uses: actions/upload-artifact@v6
         id: upload-apk
         with:
           name: ${{ inputs.profile }}-binary-android-${{ matrix.target }}
           path: target/android/${{ matrix.target }}/${{ inputs.profile }}/servoapp.apk
+          if-no-files-found: error
       - name: Upload AAR artifact
         uses: actions/upload-artifact@v6
         id: upload-aar
         with:
           name: ${{ inputs.profile }}-library-android-${{ matrix.target }}
           path: target/android/${{ matrix.target }}/${{ inputs.profile }}/servoview.aar
+          if-no-files-found: error
       - name: Collect artifact IDs needed by the release workflow
         if: matrix.target == 'aarch64-linux-android'
         id: artifact_ids

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -107,7 +107,7 @@ jobs:
           APK_SIGNING_KEY_PASS: ${{ secrets.APK_SIGNING_KEY_PASS }}
         run: |
           ./mach build --use-crown --locked --target ${{ matrix.target }} --profile ${{ inputs.profile }}
-          cp -r target/cargo-timings target/cargo-timings-android-${{ matrix.target }}
+          mv target/cargo-timings target/cargo-timings-android-${{ matrix.target }}
       # TODO: This is disabled since APK crashes during startup.
       # See https://github.com/servo/servo/issues/31134
       # - name: Script tests

--- a/.github/workflows/linux-wpt.yml
+++ b/.github/workflows/linux-wpt.yml
@@ -123,14 +123,14 @@ jobs:
         env:
           GITHUB_CONTEXT: ${{ toJson(github) }}
       - name: Archive results (filtered)
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@v7
         if: ${{ always() }}
         with:
           name: wpt-filtered-logs-linux-${{ matrix.chunk_id }}
           path: wpt-filtered-logs/*/
           if-no-files-found: error
       - name: Archive results (full)
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@v7
         if: ${{ always() }}
         with:
           name: wpt-full-logs-linux-${{ matrix.chunk_id }}
@@ -176,7 +176,7 @@ jobs:
           cat results/linux/*.log > stable-unexpected-results.log || true
       - name: Upload aggregated results
         if: ${{ !cancelled() && !inputs.wpt-sync-from-upstream }}
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@v7
         with:
           name: stable-unexpected-results-linux
           path: stable-unexpected-results.log

--- a/.github/workflows/linux-wpt.yml
+++ b/.github/workflows/linux-wpt.yml
@@ -128,12 +128,14 @@ jobs:
         with:
           name: wpt-filtered-logs-linux-${{ matrix.chunk_id }}
           path: wpt-filtered-logs/*/
+          if-no-files-found: error
       - name: Archive results (full)
         uses: actions/upload-artifact@v6
         if: ${{ always() }}
         with:
           name: wpt-full-logs-linux-${{ matrix.chunk_id }}
           path: wpt-full-logs/*/
+          if-no-files-found: error
 
   report-test-results:
     name: Process WPT Results
@@ -178,6 +180,7 @@ jobs:
         with:
           name: stable-unexpected-results-linux
           path: stable-unexpected-results.log
+          if-no-files-found: error
       - name: Report results
         if: ${{ !cancelled() && !inputs.wpt-sync-from-upstream }}
         run: |

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -195,7 +195,7 @@ jobs:
         if: ${{ false && inputs.unit-tests }} # FIXME #39273
         run: ./mach test-devtools --profile ${{ inputs.profile }}
       - name: Archive build timing
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@v7
         with:
           name: cargo-timings-linux-${{ inputs.profile }}
           # Using a wildcard here ensures that the archive includes the path.
@@ -204,7 +204,7 @@ jobs:
       - name: Build mach package
         run: ./mach package --profile ${{ inputs.profile }}
       - name: Upload artifact for mach package
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@v7
         id: upload-tarball
         with:
           name: ${{ inputs.profile }}-binary-linux

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -166,7 +166,7 @@ jobs:
       - name: Build (${{ inputs.profile }})
         run: |
           ./mach build --use-crown --locked --profile ${{ inputs.profile }} ${{ inputs.build-args }}
-          cp -r target/cargo-timings target/cargo-timings-linux
+          mv target/cargo-timings target/cargo-timings-linux
       - name: Smoketest
         run: xvfb-run ./mach smoketest --profile ${{ inputs.profile  }}
       - name: Script tests

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -200,6 +200,7 @@ jobs:
           name: cargo-timings-linux-${{ inputs.profile }}
           # Using a wildcard here ensures that the archive includes the path.
           path: target/cargo-timings-*
+          if-no-files-found: error
       - name: Build mach package
         run: ./mach package --profile ${{ inputs.profile }}
       - name: Upload artifact for mach package
@@ -208,6 +209,7 @@ jobs:
         with:
           name: ${{ inputs.profile }}-binary-linux
           path: target/${{ inputs.profile }}/servo-tech-demo.tar.gz
+          if-no-files-found: error
       - name: Collect artifact IDs needed by the release workflow
         id: artifact_ids
         shell: bash

--- a/.github/workflows/mac-arm64.yml
+++ b/.github/workflows/mac-arm64.yml
@@ -170,14 +170,14 @@ jobs:
           max_attempts: 2
           command: ./etc/ci/macos_package_smoketest.sh target/${{ inputs.profile }}/servo-tech-demo.dmg
       - name: Archive build timing
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@v7
         with:
           name: cargo-timings-macos-arm64-${{ inputs.profile }}
           # Using a wildcard here ensures that the archive includes the path.
           path: target/cargo-timings-*
           if-no-files-found: error
       - name: Upload artifact for mach package
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@v7
         id: upload-dmg
         with:
           name: ${{ inputs.profile }}-binary-mac-arm64
@@ -191,7 +191,7 @@ jobs:
       - name: Build package for target
         run: gtar -czf target.tar.gz target/${{ inputs.profile }}/servoshell target/${{ inputs.profile }}/lib/*.dylib resources
       - name: Upload package for target
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@v7
         with:
           name: ${{ inputs.profile }}-binary-macos-arm64
           path: target.tar.gz

--- a/.github/workflows/mac-arm64.yml
+++ b/.github/workflows/mac-arm64.yml
@@ -130,7 +130,7 @@ jobs:
       - name: Build (${{ inputs.profile }})
         run: |
           ./mach build --use-crown --locked --profile ${{ inputs.profile }}  ${{ inputs.build-args }}
-          cp -r target/cargo-timings target/cargo-timings-macos-arm64
+          mv target/cargo-timings target/cargo-timings-macos-arm64
       - name: Smoketest
         uses: nick-fields/retry@v3
         with: # See https://github.com/servo/servo/issues/30757

--- a/.github/workflows/mac-arm64.yml
+++ b/.github/workflows/mac-arm64.yml
@@ -175,12 +175,14 @@ jobs:
           name: cargo-timings-macos-arm64-${{ inputs.profile }}
           # Using a wildcard here ensures that the archive includes the path.
           path: target/cargo-timings-*
+          if-no-files-found: error
       - name: Upload artifact for mach package
         uses: actions/upload-artifact@v6
         id: upload-dmg
         with:
           name: ${{ inputs.profile }}-binary-mac-arm64
           path: target/${{ inputs.profile }}/servo-tech-demo.dmg
+          if-no-files-found: error
       - name: Collect artifact IDs needed by the release workflow
         id: artifact_ids
         shell: bash
@@ -193,6 +195,7 @@ jobs:
         with:
           name: ${{ inputs.profile }}-binary-macos-arm64
           path: target.tar.gz
+          if-no-files-found: error
 
   wpt-2020:
     if: ${{ inputs.wpt }}

--- a/.github/workflows/mac-wpt.yml
+++ b/.github/workflows/mac-wpt.yml
@@ -67,12 +67,14 @@ jobs:
         with:
           name: wpt-filtered-logs-${{ env.NAME }}-${{ matrix.chunk_id }}
           path: wpt-filtered-logs/*/
+          if-no-files-found: error
       - name: Archive results (full)
         uses: actions/upload-artifact@v6
         if: ${{ always() }}
         with:
           name: wpt-full-logs-${{ env.NAME }}-${{ matrix.chunk_id }}
           path: wpt-full-logs/*/
+          if-no-files-found: error
 
   report-test-results:
     name: Process WPT Results
@@ -107,6 +109,7 @@ jobs:
         with:
           name: stable-unexpected-results-${{ env.NAME }}
           path: stable-unexpected-results.log
+          if-no-files-found: error
       - uses: actions/download-artifact@v4
         if: ${{ !cancelled() }}
         with:

--- a/.github/workflows/mac-wpt.yml
+++ b/.github/workflows/mac-wpt.yml
@@ -62,14 +62,14 @@ jobs:
             --filter-intermittents wpt-filtered-logs/${{ env.NAME }}/${{ matrix.chunk_id }}.json
             ${{ inputs.wpt-args }}
       - name: Archive results (filtered)
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@v7
         if: ${{ always() }}
         with:
           name: wpt-filtered-logs-${{ env.NAME }}-${{ matrix.chunk_id }}
           path: wpt-filtered-logs/*/
           if-no-files-found: error
       - name: Archive results (full)
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@v7
         if: ${{ always() }}
         with:
           name: wpt-full-logs-${{ env.NAME }}-${{ matrix.chunk_id }}
@@ -105,7 +105,7 @@ jobs:
           cat results/${{ env.NAME }}/*.log > stable-unexpected-results.log || true
       - name: Upload aggregated results
         if: ${{ !cancelled() && !inputs.wpt-sync-from-upstream }}
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@v7
         with:
           name: stable-unexpected-results-${{ env.NAME }}
           path: stable-unexpected-results.log

--- a/.github/workflows/mac.yml
+++ b/.github/workflows/mac.yml
@@ -183,12 +183,14 @@ jobs:
           name: cargo-timings-macos-${{ inputs.profile }}
           # Using a wildcard here ensures that the archive includes the path.
           path: target/cargo-timings-*
+          if-no-files-found: error
       - name: Upload artifact for mach package
         uses: actions/upload-artifact@v6
         id: upload-dmg
         with:
           name: ${{ inputs.profile }}-binary-mac
           path: target/${{ inputs.profile }}/servo-tech-demo.dmg
+          if-no-files-found: error
       - name: Collect artifact IDs needed by the release workflow
         id: artifact_ids
         shell: bash
@@ -201,6 +203,7 @@ jobs:
         with:
           name: ${{ inputs.profile }}-binary-macos
           path: target.tar.gz
+          if-no-files-found: error
 
   wpt-2020:
     if: ${{ inputs.wpt }}

--- a/.github/workflows/mac.yml
+++ b/.github/workflows/mac.yml
@@ -178,14 +178,14 @@ jobs:
           max_attempts: 2
           command: ./etc/ci/macos_package_smoketest.sh target/${{ inputs.profile }}/servo-tech-demo.dmg
       - name: Archive build timing
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@v7
         with:
           name: cargo-timings-macos-${{ inputs.profile }}
           # Using a wildcard here ensures that the archive includes the path.
           path: target/cargo-timings-*
           if-no-files-found: error
       - name: Upload artifact for mach package
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@v7
         id: upload-dmg
         with:
           name: ${{ inputs.profile }}-binary-mac
@@ -199,7 +199,7 @@ jobs:
       - name: Build package for target
         run: gtar -czf target.tar.gz target/${{ inputs.profile }}/servoshell target/${{ inputs.profile }}/lib/*.dylib resources
       - name: Upload package for target
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@v7
         with:
           name: ${{ inputs.profile }}-binary-macos
           path: target.tar.gz

--- a/.github/workflows/mac.yml
+++ b/.github/workflows/mac.yml
@@ -138,7 +138,7 @@ jobs:
       - name: Build (${{ inputs.profile }})
         run: |
           ./mach build --use-crown --locked --profile ${{ inputs.profile }}  ${{ inputs.build-args }}
-          cp -r target/cargo-timings target/cargo-timings-macos
+          mv target/cargo-timings target/cargo-timings-macos
       - name: Smoketest
         uses: nick-fields/retry@v3
         with: # See https://github.com/servo/servo/issues/30757

--- a/.github/workflows/ohos.yml
+++ b/.github/workflows/ohos.yml
@@ -108,7 +108,7 @@ jobs:
           OHOS_BASE_SDK_HOME: ${{ steps.setup_sdk.outputs.ohos-base-sdk-home }}
         run: |
           ./mach build --locked --target ${{ matrix.target }} --profile ${{ inputs.profile }}
-          cp -r target/cargo-timings target/cargo-timings-ohos-${{ matrix.target }}
+          mv target/cargo-timings target/cargo-timings-ohos-${{ matrix.target }}
       - name: Archive build timing
         uses: actions/upload-artifact@v7
         with:

--- a/.github/workflows/ohos.yml
+++ b/.github/workflows/ohos.yml
@@ -427,7 +427,7 @@ jobs:
         run: uv run ./etc/ci/scenario/servo_test_slide.py
       - name: Upload failure screenshots
         if: ${{ steps.install_hap.outcome == 'success' && failure() }}
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@v7
         with:
           name: hos-${{ inputs.profile }}-scenario-failures-screenshots
           path: "servo_scenario_*_error.jpg"

--- a/.github/workflows/ohos.yml
+++ b/.github/workflows/ohos.yml
@@ -115,6 +115,7 @@ jobs:
           name: cargo-timings-ohos-${{ matrix.target }}-${{ inputs.profile }}
           # Using a wildcard here ensures that the archive includes the path.
           path: target/cargo-timings-*
+          if-no-files-found: error
       - name: Upload shared library
         if: ${{ inputs.upload_library }}
         uses: actions/upload-artifact@v7
@@ -122,6 +123,7 @@ jobs:
         with:
           name: ${{ inputs.profile }}-library-ohos-${{ matrix.target }}
           path: target/aarch64-unknown-linux-ohos/production/libservoshell.so
+          if-no-files-found: error
       - name: Upload signed HAP artifact
         if: ${{ env.SERVO_OHOS_SIGNING_CONFIG != '' }} # Build output has different name if not signed.
         uses: actions/upload-artifact@v7
@@ -129,6 +131,7 @@ jobs:
         with:
           name: ${{ inputs.profile }}-binary-ohos-${{ matrix.target }}
           path: target/openharmony/${{ matrix.target }}/${{ inputs.profile }}/entry/build/default/outputs/default/servoshell-default-signed.hap
+          if-no-files-found: error
       - name: Upload unsigned HAP artifact
         if: ${{ env.SERVO_OHOS_SIGNING_CONFIG == '' }} # Build output has different name if not signed.
         uses: actions/upload-artifact@v7
@@ -136,6 +139,7 @@ jobs:
         with:
           name: ${{ inputs.profile }}-binary-ohos-${{ matrix.target }}
           path: target/openharmony/${{ matrix.target }}/${{ inputs.profile }}/entry/build/default/outputs/default/servoshell-default-unsigned.hap
+          if-no-files-found: error
       - name: Collect artifact IDs needed by the release workflow
         # The implicit assumption here is that `upload_library` is true and the signed hap is uploaded,
         # since this output will only be consumed by the release workflow.
@@ -191,6 +195,7 @@ jobs:
           # Upload the **unsigned** artifact - We don't have the signing materials in pull request workflows
           name: servoshell-hos-${{ inputs.profile }}.hap
           path: target/openharmony/aarch64-unknown-linux-ohos/${{ inputs.profile }}/entry/build/harmonyos/outputs/default/servoshell-default-unsigned.hap
+          if-no-files-found: error
       - name: Save result as job output
         id: result
         if: always()
@@ -309,6 +314,7 @@ jobs:
         with:
           name: bencher-${{ inputs.profile }}-failure-screenshot
           path: "/tmp/servo.jpeg"
+          if-no-files-found: error
       - name: Run speedometer
         id: speedometer
         run: uv run ./etc/ci/scenario/servo_speedometer.py ${{ inputs.profile }}
@@ -328,6 +334,7 @@ jobs:
         with:
           name: ohos-speedometer-failure-${{ matrix.target }}-${{ inputs.profile }}
           path: speedometer_error_logs
+          if-no-files-found: error
       - name: Combining bencher files
         if: ${{ !cancelled() && steps.setup_complete.outcome == 'success' }}
         run: jq --compact-output --slurp add speedometer.json bench.json > combined-bencher.json
@@ -424,6 +431,7 @@ jobs:
         with:
           name: hos-${{ inputs.profile }}-scenario-failures-screenshots
           path: "servo_scenario_*_error.jpg"
+          if-no-files-found: error
       - name: Save result as job output
         id: result
         if: always()

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -193,6 +193,7 @@ jobs:
           name: cargo-timings-windows-${{ inputs.profile }}
           # Using a wildcard here ensures that the archive includes the path.
           path: C:\\a\\servo\\servo\\target\\cargo-timings-*
+          if-no-files-found: error
       - name: Build mach package
         run: .\mach package --profile ${{ inputs.profile }}
       # These files are available
@@ -205,6 +206,7 @@ jobs:
         with:
           name: ${{ inputs.profile }}-binary-windows
           path: C:\\a\\servo\\servo\\target\\${{ inputs.profile }}\\msi\\ServoShell.exe
+          if-no-files-found: error
       - name: Upload artifact for mach package (zip)
         uses: actions/upload-artifact@v6
         id: upload-zip
@@ -212,6 +214,7 @@ jobs:
         with:
           name: ${{ inputs.profile }}-binary-windows-zip
           path: C:\\a\\servo\\servo\\target\\${{ inputs.profile }}\\msi\\ServoShell.zip
+          if-no-files-found: error
       - name: Collect artifact IDs needed by the release workflow
         id: artifact_ids
         shell: bash

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -188,7 +188,7 @@ jobs:
         if: ${{ false && inputs.unit-tests }}  # FIXME #39273
         run: .\mach test-devtools --profile ${{ inputs.profile }}
       - name: Archive build timing
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@v7
         with:
           name: cargo-timings-windows-${{ inputs.profile }}
           # Using a wildcard here ensures that the archive includes the path.
@@ -201,14 +201,14 @@ jobs:
       # Bundle: C:\a\servo\servo\target\${{ inputs.profile }}\msi\ServoShell.exe
       # Zip: C:\a\servo\servo\target\${{ inputs.profile }}\msi\ServoShell.zip
       - name: Upload artifact for mach package
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@v7
         id: upload-exe
         with:
           name: ${{ inputs.profile }}-binary-windows
           path: C:\\a\\servo\\servo\\target\\${{ inputs.profile }}\\msi\\ServoShell.exe
           if-no-files-found: error
       - name: Upload artifact for mach package (zip)
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@v7
         id: upload-zip
         if: ${{ inputs.upload_zip }}
         with:

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -149,7 +149,7 @@ jobs:
       - name: Build (${{ inputs.profile }})
         run: |
           .\mach build --use-crown --locked --profile ${{ inputs.profile }} ${{ inputs.build-args }}
-          cp C:\a\servo\servo\target\cargo-timings C:\a\servo\servo\target\cargo-timings-windows -Recurse
+          mv C:\a\servo\servo\target\cargo-timings C:\a\servo\servo\target\cargo-timings-windows
       - name: Copy resources
         # GitHub-hosted runners sometimes check out the repo on D: drive.
         if: ${{ runner.environment != 'self-hosted' && startsWith(github.workspace, 'D:\') }}


### PR DESCRIPTION
- Rename instead of copy the `cargo-timings` folder
- Fail the action if artifact not found in upload-artifact. This should prevent things like #43102
- Update `actions/upload-artifact` to v7

Testing: If this can merge, it is successful.