### PR TITLE
Port Servo to FreeBSD

### DIFF
--- a/components/background_hang_monitor/lib.rs
+++ b/components/background_hang_monitor/lib.rs
@@ -37,6 +37,7 @@ pub use self::background_hang_monitor::*;
         )
     ),
     all(target_os = "windows", target_arch = "aarch64"),
+    target_os = "freebsd"
 ))]
 pub(crate) use crate::sampler::DummySampler as SamplerImpl;
 #[cfg(all(

--- a/components/fonts/Cargo.toml
+++ b/components/fonts/Cargo.toml
@@ -62,11 +62,11 @@ objc2-core-foundation = { workspace = true }
 objc2-core-graphics = { workspace = true }
 objc2-core-text = { workspace = true }
 
-[target.'cfg(any(target_os = "linux", target_os = "android"))'.dependencies]
+[target.'cfg(any(target_os = "linux", target_os = "android", target_os = "freebsd"))'.dependencies]
 freetype-sys = { workspace = true }
 servo_allocator = { package = "servo-allocator", path = "../allocator" }
 
-[target.'cfg(all(target_os = "linux", not(target_env = "ohos")))'.dependencies]
+[target.'cfg(all(any(target_os = "linux", target_os = "freebsd"), not(target_env = "ohos")))'.dependencies]
 fontconfig_sys = { package = "yeslogic-fontconfig-sys", version = "6" }
 
 [target.'cfg(target_os = "android")'.dependencies]

--- a/components/fonts/font.rs
+++ b/components/fonts/font.rs
@@ -959,7 +959,7 @@ pub struct FontBaseline {
 /// let mapped_weight = apply_font_config_to_style_mapping(&mapping, weight as f64);
 /// ```
 #[cfg(all(
-    any(target_os = "linux", target_os = "macos"),
+    any(target_os = "linux", target_os = "macos", target_os = "freebsd"),
     not(target_env = "ohos")
 ))]
 pub(crate) fn map_platform_values_to_style_values(mapping: &[(f64, f64)], value: f64) -> f64 {

--- a/components/fonts/platform/freetype/mod.rs
+++ b/components/fonts/platform/freetype/mod.rs
@@ -5,7 +5,10 @@
 pub mod font;
 mod freetype_face;
 
-#[cfg(all(target_os = "linux", not(target_env = "ohos"), not(ohos_mock)))]
+#[cfg(any(
+    all(target_os = "linux", not(target_env = "ohos"), not(ohos_mock)),
+    target_os = "freebsd"
+))]
 pub mod font_list;
 
 #[cfg(target_os = "android")]

--- a/components/fonts/platform/mod.rs
+++ b/components/fonts/platform/mod.rs
@@ -3,32 +3,32 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 #[cfg(all(
-    any(target_os = "linux", target_os = "macos"),
+    any(target_os = "linux", target_os = "macos", target_os = "freebsd"),
     not(target_os = "android"),
     not(target_env = "ohos")
 ))]
 use base::text::{UnicodeBlock, UnicodeBlockMethod};
 #[cfg(all(
-    any(target_os = "linux", target_os = "macos"),
+    any(target_os = "linux", target_os = "macos", target_os = "freebsd"),
     not(target_os = "android"),
     not(target_env = "ohos")
 ))]
 use unicode_script::Script;
 
 #[cfg(all(
-    any(target_os = "linux", target_os = "macos"),
+    any(target_os = "linux", target_os = "macos", target_os = "freebsd"),
     not(target_os = "android"),
     not(target_env = "ohos")
 ))]
 use crate::FallbackFontSelectionOptions;
-#[cfg(any(target_os = "linux", target_os = "android"))]
+#[cfg(any(target_os = "linux", target_os = "android", target_os = "freebsd"))]
 pub use crate::platform::freetype::{font, font_list};
 #[cfg(target_os = "macos")]
 pub use crate::platform::macos::{core_text_font_cache, font, font_list};
 #[cfg(target_os = "windows")]
 pub use crate::platform::windows::{font, font_list};
 
-#[cfg(any(target_os = "linux", target_os = "android"))]
+#[cfg(any(target_os = "linux", target_os = "android", target_os = "freebsd"))]
 pub mod freetype;
 
 #[cfg(target_os = "macos")]
@@ -45,7 +45,7 @@ mod windows {
 }
 
 #[cfg(all(
-    any(target_os = "linux", target_os = "macos"),
+    any(target_os = "linux", target_os = "macos", target_os = "freebsd"),
     not(target_os = "android"),
     not(target_env = "ohos")
 ))]

--- a/components/script/dom/navigatorinfo.rs
+++ b/components/script/dom/navigatorinfo.rs
@@ -46,7 +46,7 @@ pub(crate) fn Platform() -> DOMString {
 }
 
 #[expect(non_snake_case)]
-#[cfg(any(target_os = "android", target_os = "linux"))]
+#[cfg(any(target_os = "android", target_os = "linux", target_os = "freebsd"))]
 pub(crate) fn Platform() -> DOMString {
     DOMString::from("Linux")
 }

--- a/components/shared/fonts/font_identifier.rs
+++ b/components/shared/fonts/font_identifier.rs
@@ -22,7 +22,7 @@ impl FontIdentifier {
     }
 }
 
-#[cfg(any(target_os = "linux", target_os = "android"))]
+#[cfg(any(target_os = "linux", target_os = "android", target_os = "freebsd"))]
 mod platform {
     use std::fs::File;
     use std::path::{Path, PathBuf};

--- a/python/servo/command_base.py
+++ b/python/servo/command_base.py
@@ -246,6 +246,10 @@ def is_linux() -> bool:
     return sys.platform.startswith("linux")
 
 
+def is_freebsd() -> bool:
+    return sys.platform.startswith("freebsd")
+
+
 class BuildNotFound(Exception):
     def __init__(self, message: str) -> None:
         self.message = message

--- a/python/servo/platform/__init__.py
+++ b/python/servo/platform/__init__.py
@@ -70,6 +70,10 @@ def get():  # noqa
         from .macos import MacOS
 
         __platform__ = MacOS(triple)
+    elif "unknown-freebsd" in triple:
+        from .freebsd import FreeBSD
+
+        __platform__ = FreeBSD(triple)
     else:
         from .base import Base
 

--- a/python/servo/platform/freebsd.py
+++ b/python/servo/platform/freebsd.py
@@ -1,0 +1,17 @@
+# Copyright 2026 The Servo Project Developers. See the COPYRIGHT
+# file at the top-level directory of this distribution.
+#
+# Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+# http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+# <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+# option. This file may not be copied, modified, or distributed
+# except according to those terms.
+
+from typing import Optional
+
+from .base import Base
+from .build_target import BuildTarget
+
+class FreeBSD(Base):
+    def gstreamer_root(self, target: BuildTarget) -> Optional[str]:
+        return None

--- a/python/servo/platform/freebsd.py
+++ b/python/servo/platform/freebsd.py
@@ -12,6 +12,7 @@ from typing import Optional
 from .base import Base
 from .build_target import BuildTarget
 
+
 class FreeBSD(Base):
     def gstreamer_root(self, target: BuildTarget) -> Optional[str]:
         return None

--- a/python/servo/post_build_commands.py
+++ b/python/servo/post_build_commands.py
@@ -30,6 +30,7 @@ from servo.command_base import (
     CommandBase,
     check_call,
     is_linux,
+    is_freebsd,
 )
 from servo.platform.build_target import is_android
 
@@ -101,8 +102,8 @@ class PostBuildCommands(CommandBase):
         env = self.build_env()
         env["RUST_BACKTRACE"] = "1"
         if software:
-            if not is_linux():
-                print("Software rendering is only supported on Linux at the moment.")
+            if not (is_linux() or is_freebsd()):
+                print("Software rendering is only supported on Linux and FreeBSD at the moment.")
                 return
 
             env["LIBGL_ALWAYS_SOFTWARE"] = "1"


### PR DESCRIPTION
Add the minimum amount of FreeBSD-specific code to Servo, where no platform-neutral fallback exists.

Testing: I've succesfully built and run Servo on FreeBSD with these changes (and some fixes to dependencies). There's no functional change to any other targets. This pull request was created with Servo running on FreeBSD.
Fixes: #11625 
