### PR TITLE
fonts: Fix font-weight matching behavior for "simple" font families

### DIFF
--- a/components/fonts/font_store.rs
+++ b/components/fonts/font_store.rs
@@ -155,7 +155,7 @@ struct SimpleFamily {
 impl SimpleFamily {
     /// Find a font in this family that matches a given descriptor.
     fn find_for_descriptor(&self, descriptor_to_match: &FontDescriptor) -> Option<FontTemplateRef> {
-        let want_bold = descriptor_to_match.weight >= FontWeight::BOLD_THRESHOLD;
+        let want_bold = descriptor_to_match.weight > FontWeight::PREFER_BOLD_THRESHOLD;
         let want_italic = descriptor_to_match.style != FontStyle::NORMAL;
 
         // This represents the preference of which font to return from the [`SimpleFamily`],

--- a/tests/wpt/meta/css/css-fonts/matching/font-weight-search-direction.html.ini
+++ b/tests/wpt/meta/css/css-fonts/matching/font-weight-search-direction.html.ini
@@ -1,2 +1,0 @@
-[font-weight-search-direction.html]
-  expected: FAIL


### PR DESCRIPTION
This aligns with behavior with spec, by selecting `BOLD` for the weights greater than 500.

- W3C Specs: [font-style-matching](https://www.w3.org/TR/css-fonts-4/#font-style-matching)

> If the desired weight is greater than 500, weights greater than or equal to the desired weight are checked in ascending order followed by weights below the desired weight in descending order until a match is found.

- Firefox: https://phabricator.services.mozilla.com/D274775

Testing: This causes a WPT test to start passing.