### PR TITLE
devcontainer: Add workflow to build and publish Ubuntu amd64 devcontainer

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,45 @@
+#
+name: Build Docker image and push to GitHub Packages
+
+# This workflow file is adapted from the example at https://docs.github.com/en/packages/managing-github-packages-using-github-actions-workflows/publishing-and-installing-a-package-with-github-actions#upgrading-a-workflow-that-accesses-a-registry-using-a-personal-access-token
+on:
+  push:
+    branches:
+      - main
+      # For testing purposes. Remove before merging
+      - prebuilt_devcontainer
+  workflow_dispatch:
+
+jobs:
+  devcontainer_ubuntu:
+    runs-on: ubuntu-latest
+    permissions:
+      packages: write
+      contents: read
+    env:
+      IMAGE_NAME: devcontainer-ubuntu
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Build image
+        run: docker build . --file .devcontainer/Ubuntu.Dockerfile --tag $IMAGE_NAME --label "runnumber=${GITHUB_RUN_ID}"
+
+      - name: Log in to registry
+        run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
+
+      - name: Push image
+        run: |
+          IMAGE_ID=ghcr.io/${{ github.repository_owner }}/$IMAGE_NAME
+
+          # This changes all uppercase characters to lowercase.
+          IMAGE_ID=$(echo $IMAGE_ID | tr '[A-Z]' '[a-z]')
+          # This strips the git ref prefix from the version.
+          VERSION=$(echo "${{ github.ref }}" | sed -e 's,.*/\(.*\),\1,')
+
+          # This uses the Docker `latest` tag convention.
+          [ "$VERSION" == "main" ] && VERSION=latest
+          echo IMAGE_ID=$IMAGE_ID
+          echo VERSION=$VERSION
+          # Todo: It would be nice to add another tag here, that has a version number, or a date-tag.
+          docker tag $IMAGE_NAME $IMAGE_ID:$VERSION
+          docker push $IMAGE_ID:$VERSION

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -8,11 +8,20 @@ on:
       - main
       # For testing purposes. Remove before merging
       - prebuilt_devcontainer
+    # Only rebuild if the Dockerfile or dependencies change.
+    paths:
+      - '.devcontainer/**'
+      - 'python/servo/platform/linux_packages/**'
   workflow_dispatch:
 
 jobs:
   devcontainer_ubuntu:
     runs-on: ubuntu-latest
+    # We probably don't want to spam the package registry of every developer
+    # thats working on servo and has actions enabled on their fork.
+    # You can comment this if to test changes to the workflow locally in your fork,
+    # use manual workflow dispatch in your fork.
+    if: github.repository_owner == 'servo' || github.event_name == 'workflow_dispatch'
     permissions:
       packages: write
       contents: read

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -6,8 +6,6 @@ on:
   push:
     branches:
       - main
-      # For testing purposes. Remove before merging
-      - prebuilt_devcontainer
     # Only rebuild if the Dockerfile or dependencies change.
     paths:
       - '.devcontainer/**'

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -29,7 +29,7 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Build image
-        run: docker build . --file .devcontainer/Ubuntu.Dockerfile --tag $IMAGE_NAME --label "runnumber=${GITHUB_RUN_ID}"
+        run: docker build . --file .devcontainer/Ubuntu.Dockerfile --tag ${{ env.IMAGE_NAME }} --label "runnumber=${GITHUB_RUN_ID}"
 
       - name: Log in to registry
         run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -29,7 +29,7 @@ jobs:
 
       - name: Push image
         run: |
-          IMAGE_ID=ghcr.io/${{ github.repository_owner }}/$IMAGE_NAME
+          IMAGE_ID=ghcr.io/${{ github.repository_owner }}/servo/$IMAGE_NAME
 
           # This changes all uppercase characters to lowercase.
           IMAGE_ID=$(echo $IMAGE_ID | tr '[A-Z]' '[a-z]')


### PR DESCRIPTION
This adds a simple workflow to build and push the devcontainer to our github container registry. 
This would allow us (in a follow-up PR) to use the prebuild devcontainer image from ghcr, instead of needing to first build the image from scratch, which can save quite a bit of time.
This a part of #40656.

Testing: workflow run in my fork: https://github.com/jschwe/servo/actions/runs/22897536246/job/66435358111 -> created the following image: https://github.com/jschwe/servo/pkgs/container/servo%2Fdevcontainer-ubuntu