### PR TITLE
script: Only send objects with `ESClass::Object` to devtools

### DIFF
--- a/components/script/dom/console.rs
+++ b/components/script/dom/console.rs
@@ -12,10 +12,10 @@ use devtools_traits::{
 };
 use embedder_traits::EmbedderMsg;
 use js::conversions::jsstr_to_string;
-use js::jsapi::{self, ESClass, JS_IsTypedArrayObject, PropertyDescriptor};
+use js::jsapi::{self, ESClass, PropertyDescriptor};
 use js::jsval::{Int32Value, UndefinedValue};
 use js::rust::wrappers::{
-    GetBuiltinClass, GetPropertyKeys, IsArray, JS_GetOwnPropertyDescriptorById, JS_GetPropertyById,
+    GetBuiltinClass, GetPropertyKeys, JS_GetOwnPropertyDescriptorById, JS_GetPropertyById,
     JS_IdToValue, JS_Stringify, JS_ValueToSource,
 };
 use js::rust::{
@@ -193,13 +193,11 @@ fn console_object_from_handle_value(
     seen: &mut Vec<u64>,
 ) -> Option<ConsoleArgumentObject> {
     rooted!(in(*cx) let object = handle_value.to_object());
-
-    // We should not generate object previews for arrays, although they are objects
-    let mut is_array = false;
-    if !unsafe { IsArray(*cx, object.handle(), &mut is_array) } || is_array {
+    let mut object_class = ESClass::Other;
+    if !unsafe { GetBuiltinClass(*cx, object.handle(), &mut object_class as *mut _) } {
         return None;
     }
-    if unsafe { JS_IsTypedArrayObject(object.get()) } {
+    if object_class != ESClass::Object {
         return None;
     }
 

--- a/python/servo/devtools_tests.py
+++ b/python/servo/devtools_tests.py
@@ -1005,6 +1005,15 @@ class DevtoolsTests(unittest.IsolatedAsyncioTestCase):
         # properly yet. The important part is that we didn't crash and didn't time out waiting for
         # a console notification (meaning we got *something*).
 
+    def test_console_actor_log_window_object(self):
+        self.run_servoshell(url="data:text/html,")
+
+        self.evaluate_and_capture_console_log_output("console.log(window);")
+
+        # We don't run any assertions on the result because we don't implement previews for the window object
+        # yet. The important part is that we didn't crash and didn't time out waiting for
+        # a console notification (meaning we got *something*).
+
     def test_inspector_doesnt_crash_when_attribute_on_element_it_doesnt_know_about_is_mutated(self):
         self.run_servoshell(url=f"{self.base_urls[0]}/inspector/demo_dom.html")
         with Devtools.connect() as devtools:


### PR DESCRIPTION
We should only send previews of ordinary objects[^1] (i think that's the correct term) objects to the devtools. The code is not designed to handle other objects, which currently causes crashes.

Testing: This change adds a devtools test that crashes without this change.

[^1]: https://tc39.es/ecma262/#ordinary-object