### PR TITLE
ci: No longer upload legacy GitHub release assets

### DIFF
--- a/etc/ci/upload_nightly.py
+++ b/etc/ci/upload_nightly.py
@@ -67,15 +67,6 @@ def upload_to_github_release(platform: str, package: str, package_hash: str, git
     nightly_repo = g.get_repo(os.environ["RELEASE_REPO"])
     release = nightly_repo.get_release(github_release_id)
 
-    if platform != "mac-arm64":
-        # Legacy assetname. Will be removed after a period with duplicate assets.
-        asset_name = f"servo-latest.{extension}"
-        package_hash_fileobj = io.BytesIO(f"{package_hash}  {asset_name}".encode("utf-8"))
-        release.upload_asset(package, name=asset_name)
-        # pyrefly: ignore[missing-attribute]
-        release.upload_asset_from_memory(
-            package_hash_fileobj, package_hash_fileobj.getbuffer().nbytes, name=f"{asset_name}.sha256"
-        )
     asset_platform = map_platform(platform)
     asset_name = f"servo-{asset_platform}.{extension}"
     package_hash_fileobj = io.BytesIO(f"{package_hash}  {asset_name}".encode("utf-8"))


### PR DESCRIPTION
We previously changed the asset name format in 84d0919a7f06fa59a88446a2dd54a10b22efe741.
We kept the old asset name to support bisection scripts. It's been 5 months since that change, so remove the old asset names.

Note: We never changed the asset names for our S3 upload, and this PR doesn't touch S3.

Testing: Not tested, trivial change.
Fixes: #42101
