### PR TITLE
devcontainer: Use new prebuilt devcontainer image.

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -2,10 +2,12 @@
 // README at: https://github.com/devcontainers/templates/tree/main/src/ubuntu
 {
 	"name": "Ubuntu",
-	"build": {
-		"dockerfile": "Ubuntu.Dockerfile",
-		"context": ".."
-	},
+	"image": "ghcr.io/servo/servo/devcontainer-ubuntu:latest",
+	// Alternatively, uncomment the "build" property below to build the image from the Dockerfile in this folder.
+	// "build": {
+	// 	"dockerfile": "Ubuntu.Dockerfile",
+	// 	"context": ".."
+	// },
 
 
 	// Most dependencies are installed in the image, but we run mach bootstrap to ensure


### PR DESCRIPTION
Follow-up to #43131.

Testing: Tested locally. Note: This only works for x86_64 based systems. Arm Linux users will need to build from source, but building in the devcontainer on arm linux is anyway not working currently.

