### PR TITLE
script: Correct equality check when detecting whether element has access key assigned

### DIFF
--- a/components/script/dom/document_event_handler.rs
+++ b/components/script/dom/document_event_handler.rs
@@ -2246,7 +2246,7 @@ impl DocumentEventHandler {
         self.access_key_handlers
             .borrow()
             .values()
-            .any(|value| &**value != element)
+            .any(|value| &**value == element)
     }
 
     pub(crate) fn unassign_access_key(&self, element: &HTMLElement) {

--- a/tests/wpt/mozilla/meta/MANIFEST.json
+++ b/tests/wpt/mozilla/meta/MANIFEST.json
@@ -13117,6 +13117,15 @@
     ]
    },
    "input-events": {
+    "accesskey-on-html-element.html": [
+     "f531e2101852997165c642df2974a9ce7bb57a47",
+     [
+      null,
+      {
+       "testdriver": true
+      }
+     ]
+    ],
     "collapsed-selection-input-text.html": [
      "c80ddeff12b0ebc6568c03dabe848ac57e44737b",
      [

--- a/tests/wpt/mozilla/tests/input-events/accesskey-on-html-element.html
+++ b/tests/wpt/mozilla/tests/input-events/accesskey-on-html-element.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>The accesskey attribute should work properly on focusable divs</title>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/resources/testdriver.js"></script>
+<script src="/resources/testdriver-vendor.js"></script>
+<script src="/resources/testdriver-actions.js"></script>
+<script src="/resources/accesskey.js"></script>
+<div style="height: 10000px"></div>
+<div id="target" accesskey="P" tabindex="0">Access Key</div>
+
+<script>
+promise_test(async function() {
+    await pressAccessKey('P');
+    let boundingRect = target.getBoundingClientRect();
+    assert_true(boundingRect.x > 0);
+    assert_true(boundingRect.x < document.scrollingElement.clientWidth);
+    assert_true(boundingRect.y > 0);
+    assert_true(boundingRect.y < document.scrollingElement.clientHeight);
+});
+</script>


### PR DESCRIPTION
The equality check used to detect whether an element has an access key
assigned was reversed. This meant that access keys did not work on
non-form control elements. This change fixes the equality sign and adds
a test for this behavior.

Testing: A new Servo-specific test is added. Access key behavior activation
behavior is  very lightly specified so the way we deal with it is Servo-specific at the moment.
