### PR TITLE
storage: construct and shut down public/private thread groups independently

### DIFF
--- a/components/constellation/constellation.rs
+++ b/components/constellation/constellation.rs
@@ -2683,11 +2683,17 @@ where
         // Channels to receive signals when threads are done exiting.
         let (core_ipc_sender, core_ipc_receiver) =
             generic_channel::oneshot().expect("Failed to create IPC channel!");
-        let (client_storage_generic_sender, client_storage_generic_receiver) =
+        let (public_client_storage_generic_sender, public_client_storage_generic_receiver) =
             generic_channel::channel().expect("Failed to create generic channel!");
-        let (indexeddb_ipc_sender, indexeddb_ipc_receiver) =
+        let (private_client_storage_generic_sender, private_client_storage_generic_receiver) =
             generic_channel::channel().expect("Failed to create generic channel!");
-        let (web_storage_generic_sender, web_storage_generic_receiver) =
+        let (public_indexeddb_ipc_sender, public_indexeddb_ipc_receiver) =
+            generic_channel::channel().expect("Failed to create generic channel!");
+        let (private_indexeddb_ipc_sender, private_indexeddb_ipc_receiver) =
+            generic_channel::channel().expect("Failed to create generic channel!");
+        let (public_web_storage_generic_sender, public_web_storage_generic_receiver) =
+            generic_channel::channel().expect("Failed to create generic channel!");
+        let (private_web_storage_generic_sender, private_web_storage_generic_receiver) =
             generic_channel::channel().expect("Failed to create generic channel!");
 
         debug!("Exiting core resource threads.");
@@ -2706,28 +2712,55 @@ where
             }
         }
 
-        debug!("Exiting client storage thread.");
+        debug!("Exiting public client storage thread.");
         if let Err(e) = generic_channel::GenericSend::send(
             &self.public_storage_threads,
-            ClientStorageThreadMessage::Exit(client_storage_generic_sender),
+            ClientStorageThreadMessage::Exit(public_client_storage_generic_sender),
         ) {
-            warn!("Exit client storage thread failed ({})", e);
+            warn!("Exit public client storage thread failed ({})", e);
         }
-        debug!("Exiting indexeddb resource threads.");
+        debug!("Exiting private client storage thread.");
+        if let Err(e) = generic_channel::GenericSend::send(
+            &self.private_storage_threads,
+            ClientStorageThreadMessage::Exit(private_client_storage_generic_sender),
+        ) {
+            warn!("Exit private client storage thread failed ({})", e);
+        }
+
+        debug!("Exiting public indexeddb resource threads.");
         if let Err(e) =
             self.public_storage_threads
                 .send(IndexedDBThreadMsg::Sync(SyncOperation::Exit(
-                    indexeddb_ipc_sender,
+                    public_indexeddb_ipc_sender,
                 )))
         {
-            warn!("Exit indexeddb thread failed ({})", e);
+            warn!("Exit public indexeddb thread failed ({})", e);
         }
-        debug!("Exiting web storage thread.");
+
+        debug!("Exiting private indexeddb resource threads.");
+        if let Err(e) =
+            self.private_storage_threads
+                .send(IndexedDBThreadMsg::Sync(SyncOperation::Exit(
+                    private_indexeddb_ipc_sender,
+                )))
+        {
+            warn!("Exit private indexeddb thread failed ({})", e);
+        }
+
+        debug!("Exiting public web storage thread.");
         if let Err(e) = generic_channel::GenericSend::send(
             &self.public_storage_threads,
-            WebStorageThreadMsg::Exit(web_storage_generic_sender),
+            WebStorageThreadMsg::Exit(public_web_storage_generic_sender),
         ) {
-            warn!("Exit web storage thread failed ({})", e);
+            warn!("Exit public web storage thread failed ({})", e);
+        }
+
+        debug!("Exiting private web storage thread.");
+        if let Err(e) = generic_channel::GenericSend::send(
+            &self.private_storage_threads,
+            WebStorageThreadMsg::Exit(private_web_storage_generic_sender),
+        ) {
+            warn!("Exit private web storage thread failed ({})", e);
         }
 
         #[cfg(feature = "bluetooth")]
@@ -2798,14 +2831,23 @@ where
         if let Err(e) = core_ipc_receiver.recv() {
             warn!("Exit resource thread failed ({:?})", e);
         }
-        if let Err(e) = client_storage_generic_receiver.recv() {
-            warn!("Exit client storage thread failed ({:?})", e);
+        if let Err(e) = public_client_storage_generic_receiver.recv() {
+            warn!("Exit public client storage thread failed ({:?})", e);
         }
-        if let Err(e) = indexeddb_ipc_receiver.recv() {
-            warn!("Exit indexeddb thread failed ({:?})", e);
+        if let Err(e) = private_client_storage_generic_receiver.recv() {
+            warn!("Exit private client storage thread failed ({:?})", e);
         }
-        if let Err(e) = web_storage_generic_receiver.recv() {
-            warn!("Exit web storage thread failed ({:?})", e);
+        if let Err(e) = public_indexeddb_ipc_receiver.recv() {
+            warn!("Exit public indexeddb thread failed ({:?})", e);
+        }
+        if let Err(e) = private_indexeddb_ipc_receiver.recv() {
+            warn!("Exit private indexeddb thread failed ({:?})", e);
+        }
+        if let Err(e) = public_web_storage_generic_receiver.recv() {
+            warn!("Exit public web storage thread failed ({:?})", e);
+        }
+        if let Err(e) = private_web_storage_generic_receiver.recv() {
+            warn!("Exit private web storage thread failed ({:?})", e);
         }
 
         debug!("Shutting-down IPC router thread in constellation.");

--- a/components/storage/indexeddb/mod.rs
+++ b/components/storage/indexeddb/mod.rs
@@ -36,13 +36,18 @@ use crate::indexeddb::engines::{KvsEngine, KvsOperation, KvsTransaction, SqliteE
 use crate::shared::is_sqlite_disk_full_error;
 
 pub trait IndexedDBThreadFactory {
-    fn new(config_dir: Option<PathBuf>, mem_profiler_chan: MemProfilerChan) -> Self;
+    fn new(
+        config_dir: Option<PathBuf>,
+        mem_profiler_chan: MemProfilerChan,
+        reporter_name: String,
+    ) -> Self;
 }
 
 impl IndexedDBThreadFactory for GenericSender<IndexedDBThreadMsg> {
     fn new(
         config_dir: Option<PathBuf>,
         mem_profiler_chan: MemProfilerChan,
+        reporter_name: String,
     ) -> GenericSender<IndexedDBThreadMsg> {
         let (chan, port) = generic_channel::channel().unwrap();
         let chan2 = chan.clone();
@@ -60,7 +65,7 @@ impl IndexedDBThreadFactory for GenericSender<IndexedDBThreadMsg> {
             .spawn(move || {
                 mem_profiler_chan.run_with_memory_reporting(
                     || IndexedDBManager::new(port, manager_sender, idb_base_dir).start(),
-                    String::from("indexedDB-reporter"),
+                    reporter_name,
                     chan2,
                     IndexedDBThreadMsg::CollectMemoryReport,
                 );

--- a/components/storage/storage_thread.rs
+++ b/components/storage/storage_thread.rs
@@ -13,18 +13,27 @@ use storage_traits::webstorage_thread::WebStorageThreadMsg;
 
 use crate::{ClientStorageThreadFactory, IndexedDBThreadFactory, WebStorageThreadFactory};
 
-pub fn new_storage_threads(
+fn new_storage_thread_group(
     mem_profiler_chan: MemProfilerChan,
     config_dir: Option<PathBuf>,
-) -> (StorageThreads, StorageThreads) {
+) -> StorageThreads {
     let client_storage: GenericSender<ClientStorageThreadMessage> =
         ClientStorageThreadFactory::new(config_dir.clone());
     let idb: GenericSender<IndexedDBThreadMsg> =
         IndexedDBThreadFactory::new(config_dir.clone(), mem_profiler_chan.clone());
     let web_storage: GenericSender<WebStorageThreadMsg> =
         WebStorageThreadFactory::new(config_dir, mem_profiler_chan);
-    (
-        StorageThreads::new(client_storage.clone(), idb.clone(), web_storage.clone()),
-        StorageThreads::new(client_storage, idb, web_storage),
-    )
+
+    StorageThreads::new(client_storage, idb, web_storage)
+}
+
+pub fn new_storage_threads(
+    mem_profiler_chan: MemProfilerChan,
+    config_dir: Option<PathBuf>,
+) -> (StorageThreads, StorageThreads) {
+    let private_storage_threads =
+        new_storage_thread_group(mem_profiler_chan.clone(), config_dir.clone());
+    let public_storage_threads = new_storage_thread_group(mem_profiler_chan, config_dir);
+
+    (private_storage_threads, public_storage_threads)
 }

--- a/components/storage/storage_thread.rs
+++ b/components/storage/storage_thread.rs
@@ -16,13 +16,20 @@ use crate::{ClientStorageThreadFactory, IndexedDBThreadFactory, WebStorageThread
 fn new_storage_thread_group(
     mem_profiler_chan: MemProfilerChan,
     config_dir: Option<PathBuf>,
+    label: &str,
 ) -> StorageThreads {
     let client_storage: GenericSender<ClientStorageThreadMessage> =
         ClientStorageThreadFactory::new(config_dir.clone());
-    let idb: GenericSender<IndexedDBThreadMsg> =
-        IndexedDBThreadFactory::new(config_dir.clone(), mem_profiler_chan.clone());
-    let web_storage: GenericSender<WebStorageThreadMsg> =
-        WebStorageThreadFactory::new(config_dir, mem_profiler_chan);
+    let idb: GenericSender<IndexedDBThreadMsg> = IndexedDBThreadFactory::new(
+        config_dir.clone(),
+        mem_profiler_chan.clone(),
+        format!("indexedDB-reporter-{label}"),
+    );
+    let web_storage: GenericSender<WebStorageThreadMsg> = WebStorageThreadFactory::new(
+        config_dir,
+        mem_profiler_chan,
+        format!("storage-reporter-{label}"),
+    );
 
     StorageThreads::new(client_storage, idb, web_storage)
 }
@@ -32,8 +39,8 @@ pub fn new_storage_threads(
     config_dir: Option<PathBuf>,
 ) -> (StorageThreads, StorageThreads) {
     let private_storage_threads =
-        new_storage_thread_group(mem_profiler_chan.clone(), config_dir.clone());
-    let public_storage_threads = new_storage_thread_group(mem_profiler_chan, config_dir);
+        new_storage_thread_group(mem_profiler_chan.clone(), config_dir.clone(), "private");
+    let public_storage_threads = new_storage_thread_group(mem_profiler_chan, config_dir, "public");
 
     (private_storage_threads, public_storage_threads)
 }

--- a/components/storage/tests/main.rs
+++ b/components/storage/tests/main.rs
@@ -3,4 +3,5 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 mod client_storage;
+mod storage_thread;
 mod webstorage;

--- a/components/storage/tests/storage_thread.rs
+++ b/components/storage/tests/storage_thread.rs
@@ -1,0 +1,50 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+use base::generic_channel::{self, GenericSend};
+use profile::mem as profile_mem;
+use storage_traits::StorageThreads;
+use storage_traits::client_storage::ClientStorageThreadMessage;
+use storage_traits::indexeddb::{IndexedDBThreadMsg, SyncOperation};
+use storage_traits::webstorage_thread::WebStorageThreadMsg;
+
+fn shutdown_storage_group(threads: &StorageThreads) {
+    let (client_sender, client_receiver) = generic_channel::channel().unwrap();
+    GenericSend::send(threads, ClientStorageThreadMessage::Exit(client_sender))
+        .expect("failed to send client storage exit");
+    client_receiver
+        .recv()
+        .expect("failed to receive client storage exit ack");
+
+    let (idb_sender, idb_receiver) = generic_channel::channel().unwrap();
+    GenericSend::send(
+        threads,
+        IndexedDBThreadMsg::Sync(SyncOperation::Exit(idb_sender)),
+    )
+    .expect("failed to send indexeddb exit");
+    idb_receiver
+        .recv()
+        .expect("failed to receive indexeddb exit ack");
+
+    let (web_storage_sender, web_storage_receiver) = generic_channel::channel().unwrap();
+    GenericSend::send(threads, WebStorageThreadMsg::Exit(web_storage_sender))
+        .expect("failed to send web storage exit");
+    web_storage_receiver
+        .recv()
+        .expect("failed to receive web storage exit ack");
+}
+
+#[test]
+fn test_new_storage_threads_create_independent_groups() {
+    let mem_profiler_chan = profile_mem::Profiler::create();
+    let (private_storage_threads, public_storage_threads) =
+        storage::new_storage_threads(mem_profiler_chan, None);
+
+    shutdown_storage_group(&private_storage_threads);
+    shutdown_storage_group(&public_storage_threads);
+
+    // Workaround for https://github.com/servo/servo/issues/32912
+    #[cfg(windows)]
+    std::thread::sleep(std::time::Duration::from_millis(1000));
+}

--- a/components/storage/webstorage/mod.rs
+++ b/components/storage/webstorage/mod.rs
@@ -36,7 +36,11 @@ use crate::webstorage::engines::sqlite::SqliteEngine;
 const QUOTA_SIZE_LIMIT: usize = 5 * 1024 * 1024;
 
 pub trait WebStorageThreadFactory {
-    fn new(config_dir: Option<PathBuf>, mem_profiler_chan: MemProfilerChan) -> Self;
+    fn new(
+        config_dir: Option<PathBuf>,
+        mem_profiler_chan: MemProfilerChan,
+        reporter_name: String,
+    ) -> Self;
 }
 
 impl WebStorageThreadFactory for GenericSender<WebStorageThreadMsg> {
@@ -44,6 +48,7 @@ impl WebStorageThreadFactory for GenericSender<WebStorageThreadMsg> {
     fn new(
         config_dir: Option<PathBuf>,
         mem_profiler_chan: MemProfilerChan,
+        reporter_name: String,
     ) -> GenericSender<WebStorageThreadMsg> {
         let (chan, port) = generic_channel::channel().unwrap();
         let chan2 = chan.clone();
@@ -52,7 +57,7 @@ impl WebStorageThreadFactory for GenericSender<WebStorageThreadMsg> {
             .spawn(move || {
                 mem_profiler_chan.run_with_memory_reporting(
                     || WebStorageManager::new(port, config_dir).start(),
-                    String::from("storage-reporter"),
+                    reporter_name,
                     chan2,
                     WebStorageThreadMsg::CollectMemoryReport,
                 );


### PR DESCRIPTION
This PR makes public and private storage thread groups independent.

previously, `new_storage_threads()` returned two `StorageThreads` handles, but both handles were backed by the same underlying storage worker group. this meant Servo carried a public/private distinction through the API and wiring layers, while both sides still talked to the same storage backend threads.


Testing: Added shutdown_storage_group test, and should not effect WTP test.


Fixes: part of #40983
