### PR TITLE
deny.toml: Clarify time-rs CVE.

### DIFF
--- a/.clippy.toml
+++ b/.clippy.toml
@@ -1,0 +1,2 @@
+# Lint for https://github.com/advisories/GHSA-r6v5-fh4h-64xc until we upgrade to time >=0.3.47
+disallowed-types = ["time::format_description::well_known::Rfc2822"]

--- a/deny.toml
+++ b/deny.toml
@@ -35,9 +35,9 @@ ignore = [
     # The attack complexity of this vulnerability is high,
     # and no exploit is known yet.
     "RUSTSEC-2025-0144",
-    # The crate `time` has vulnerability.
-    # Need to upgrade to 0.3.47 above.
-    # Cannot right now due to MSRV.
+    # The crate `time` has DOS stack exhaustion vulnerability, which is fixed in version 0.3.47.
+    # We can't upgrade yet due to MSRV. However, we do not use the vulnerable API at all.
+    # As per <https://github.com/advisories/GHSA-r6v5-fh4h-64xc> this can be verified with clippy.
     "RUSTSEC-2026-0009",
 ]
 

--- a/python/servo/devenv_commands.py
+++ b/python/servo/devenv_commands.py
@@ -127,6 +127,14 @@ class MachCommands(CommandBase):
         env = self.build_env()
         env["RUSTC"] = "rustc"
 
+        # arguments to be passed through to clippy (as opposed to the cargo clippy wrapper)
+        # These should mainly be `--allow`, `--warn`, `--deny`, `--forbid`
+        clippy_args = ["--deny=clippy::disallowed_types"]
+
+        if "--" not in params:
+            params.append("--")
+        params.extend(clippy_args)
+
         if github_annotations:
             if "--message-format=json" not in params:
                 params.insert(0, "--message-format=json")

--- a/python/servo/devenv_commands.py
+++ b/python/servo/devenv_commands.py
@@ -129,6 +129,7 @@ class MachCommands(CommandBase):
 
         # arguments to be passed through to clippy (as opposed to the cargo clippy wrapper)
         # These should mainly be `--allow`, `--warn`, `--deny`, `--forbid`
+        # Note that some lints can additionally be configured by `.clippy.toml` at the repository root.
         clippy_args = ["--deny=clippy::disallowed_types"]
 
         if "--" not in params:


### PR DESCRIPTION
The CVE doesn't impact us, so we can ignore it safely. This improves the comment above the ignored entry in deny.toml. We test our own code via `clippy` and we aren't using the vulnerable type. Our dependencies could in theory use it, but that seems rather unlikely.

Testing: test-tidy is tested in CI. 

