### PR TITLE
script: Check for render-blocking documents before continuing

### DIFF
--- a/components/script/dom/document.rs
+++ b/components/script/dom/document.rs
@@ -1880,15 +1880,48 @@ impl Document {
         self.render_blocking_element_count.get()
     }
 
+    /// <https://html.spec.whatwg.org/multipage/#block-rendering>
     pub(crate) fn increment_render_blocking_element_count(&self) {
+        // Step 1. Let document be el's node document.
+        //
+        // That's self
+
+        // Step 2. If document allows adding render-blocking elements,
+        // then append el to document's render-blocking element set.
+        assert!(self.allows_adding_render_blocking_elements());
         let count_cell = &self.render_blocking_element_count;
         count_cell.set(count_cell.get() + 1);
     }
 
+    /// <https://html.spec.whatwg.org/multipage/#unblock-rendering>
     pub(crate) fn decrement_render_blocking_element_count(&self) {
+        // Step 1. Let document be el's node document.
+        //
+        // That's self
+
+        // Step 2. Remove el from document's render-blocking element set.
         let count_cell = &self.render_blocking_element_count;
         assert!(count_cell.get() > 0);
         count_cell.set(count_cell.get() - 1);
+    }
+
+    /// <https://html.spec.whatwg.org/multipage/#allows-adding-render-blocking-elements>
+    pub(crate) fn allows_adding_render_blocking_elements(&self) -> bool {
+        // > A Document document allows adding render-blocking elements
+        // > if document's content type is "text/html" and the body element of document is null.
+        self.is_html_document && self.GetBody().is_none()
+    }
+
+    /// <https://html.spec.whatwg.org/multipage/#render-blocked>
+    pub(crate) fn is_render_blocked(&self) -> bool {
+        // > A Document document is render-blocked if both of the following are true:
+        // > document's render-blocking element set is non-empty,
+        // > or document allows adding render-blocking elements.
+        self.render_blocking_element_count() > 0
+        // TODO: add `allows_adding_render_blocking_elements` which currently breaks for empty iframes
+        // > The current high resolution time given document's relevant global object
+        // has not exceeded an implementation-defined timeout value.
+        // TODO
     }
 
     pub(crate) fn invalidate_stylesheets(&self) {
@@ -3150,9 +3183,7 @@ impl Document {
     //
     // Returns the set of reflow phases run as a [`ReflowPhasesRun`].
     pub(crate) fn update_the_rendering(&self) -> (ReflowPhasesRun, ReflowStatistics) {
-        if self.render_blocking_element_count() > 0 {
-            return Default::default();
-        }
+        assert!(!self.is_render_blocked());
 
         let mut phases = ReflowPhasesRun::empty();
         if self.has_pending_animated_image_update.get() {
@@ -5840,6 +5871,8 @@ impl DocumentMethods<crate::DomTypeHolder> for Document {
 
     /// <https://html.spec.whatwg.org/multipage/#dom-document-body>
     fn GetBody(&self) -> Option<DomRoot<HTMLElement>> {
+        // > The body element of a document is the first of the html element's children
+        // > that is either a body element or a frameset element, or null if there is no such element.
         self.get_html_element().and_then(|root| {
             let node = root.upcast::<Node>();
             node.children()
@@ -5859,7 +5892,7 @@ impl DocumentMethods<crate::DomTypeHolder> for Document {
 
     /// <https://html.spec.whatwg.org/multipage/#dom-document-body>
     fn SetBody(&self, new_body: Option<&HTMLElement>, can_gc: CanGc) -> ErrorResult {
-        // Step 1.
+        // Step 1. If the new value is not a body or frameset element, then throw a "HierarchyRequestError" DOMException.
         let new_body = match new_body {
             Some(new_body) => new_body,
             None => return Err(Error::HierarchyRequest(None)),
@@ -5874,30 +5907,31 @@ impl DocumentMethods<crate::DomTypeHolder> for Document {
             _ => return Err(Error::HierarchyRequest(None)),
         }
 
-        // Step 2.
+        // Step 2. Otherwise, if the new value is the same as the body element, return.
         let old_body = self.GetBody();
         if old_body.as_deref() == Some(new_body) {
             return Ok(());
         }
 
         match (self.GetDocumentElement(), &old_body) {
-            // Step 3.
+            // Step 3. Otherwise, if the body element is not null,
+            // then replace the body element with the new value within the body element's parent and return.
             (Some(ref root), Some(child)) => {
                 let root = root.upcast::<Node>();
                 root.ReplaceChild(new_body.upcast(), child.upcast(), can_gc)
-                    .unwrap();
+                    .map(|_| ())
             },
 
-            // Step 4.
-            (None, _) => return Err(Error::HierarchyRequest(None)),
+            // Step 4. Otherwise, if there is no document element, throw a "HierarchyRequestError" DOMException.
+            (None, _) => Err(Error::HierarchyRequest(None)),
 
-            // Step 5.
+            // Step 5. Otherwise, the body element is null, but there's a document element.
+            // Append the new value to the document element.
             (Some(ref root), &None) => {
                 let root = root.upcast::<Node>();
-                root.AppendChild(new_body.upcast(), can_gc).unwrap();
+                root.AppendChild(new_body.upcast(), can_gc).map(|_| ())
             },
         }
-        Ok(())
     }
 
     /// <https://html.spec.whatwg.org/multipage/#dom-document-getelementsbyname>

--- a/components/script/dom/html/htmlscriptelement.rs
+++ b/components/script/dom/html/htmlscriptelement.rs
@@ -29,6 +29,7 @@ use uuid::Uuid;
 use crate::document_loader::LoadType;
 use crate::dom::attr::Attr;
 use crate::dom::bindings::cell::DomRefCell;
+use crate::dom::bindings::codegen::Bindings::DOMTokenListBinding::DOMTokenListMethods;
 use crate::dom::bindings::codegen::Bindings::DocumentBinding::DocumentMethods;
 use crate::dom::bindings::codegen::Bindings::HTMLScriptElementBinding::HTMLScriptElementMethods;
 use crate::dom::bindings::codegen::Bindings::NodeBinding::NodeMethods;
@@ -43,6 +44,7 @@ use crate::dom::bindings::root::{Dom, DomRoot, MutNullableDom};
 use crate::dom::bindings::str::DOMString;
 use crate::dom::csp::{CspReporting, GlobalCspReporting, InlineCheckType, Violation};
 use crate::dom::document::Document;
+use crate::dom::domtokenlist::DOMTokenList;
 use crate::dom::element::{
     AttributeMutation, Element, ElementCreator, cors_setting_for_element,
     referrer_policy_for_element, reflect_cross_origin_attribute, reflect_referrer_policy_attribute,
@@ -52,7 +54,7 @@ use crate::dom::event::{Event, EventBubbles, EventCancelable};
 use crate::dom::global_scope_script_execution::{ClassicScript, ErrorReporting, RethrowErrors};
 use crate::dom::globalscope::GlobalScope;
 use crate::dom::html::htmlelement::HTMLElement;
-use crate::dom::node::{ChildrenMutation, CloneChildrenFlag, Node, NodeTraits};
+use crate::dom::node::{ChildrenMutation, CloneChildrenFlag, Node, NodeTraits, UnbindContext};
 use crate::dom::performance::performanceresourcetiming::InitiatorType;
 use crate::dom::trustedscript::TrustedScript;
 use crate::dom::trustedscripturl::TrustedScriptURL;
@@ -110,6 +112,13 @@ pub(crate) struct HTMLScriptElement {
     /// `srcScript` or `inlineScript` that this script would normally use.
     #[no_trace]
     introduction_type_override: Cell<Option<&'static CStr>>,
+
+    /// <https://html.spec.whatwg.org/multipage/#dom-script-blocking>
+    blocking: MutNullableDom<DOMTokenList>,
+
+    /// Used to keep track whether we consider this script element render blocking during
+    /// `prepare`
+    marked_as_render_blocking: Cell<bool>,
 }
 
 impl HTMLScriptElement {
@@ -131,6 +140,8 @@ impl HTMLScriptElement {
             script_text: DomRefCell::new(DOMString::new()),
             from_an_external_file: Cell::new(false),
             introduction_type_override: Cell::new(None),
+            blocking: Default::default(),
+            marked_as_render_blocking: Default::default(),
         }
     }
 
@@ -573,6 +584,31 @@ impl HTMLScriptElement {
         Ok(())
     }
 
+    fn has_render_blocking_attribute(&self) -> bool {
+        self.blocking
+            .get()
+            .is_some_and(|list| list.Contains("render".into()))
+    }
+
+    /// <https://html.spec.whatwg.org/multipage/#potentially-render-blocking>
+    fn potentially_render_blocking(&self) -> bool {
+        // An element is potentially render-blocking if its blocking tokens set contains "render",
+        // or if it is implicitly potentially render-blocking, which will be defined at the individual elements.
+        // By default, an element is not implicitly potentially render-blocking.
+        if self.has_render_blocking_attribute() {
+            return true;
+        }
+        let element = self.upcast::<Element>();
+        // https://html.spec.whatwg.org/multipage/#script-processing-model:implicitly-potentially-render-blocking
+        // > A script element el is implicitly potentially render-blocking if el's type is "classic",
+        // > el is parser-inserted, and el does not have an async or defer attribute.
+        self.get_script_type()
+            .is_some_and(|script_type| script_type == ScriptType::Classic) &&
+            self.parser_inserted.get() &&
+            !element.has_attribute(&local_name!("async")) &&
+            !element.has_attribute(&local_name!("defer"))
+    }
+
     /// <https://html.spec.whatwg.org/multipage/#prepare-the-script-element>
     pub(crate) fn prepare(&self, introduction_type_override: Option<&'static CStr>, can_gc: CanGc) {
         self.introduction_type_override
@@ -802,8 +838,13 @@ impl HTMLScriptElement {
                 },
             };
 
-            // TODO:
             // Step 31.7. If el is potentially render-blocking, then block rendering on el.
+            if self.potentially_render_blocking() && doc.allows_adding_render_blocking_elements() {
+                self.marked_as_render_blocking.set(true);
+                doc.increment_render_blocking_element_count();
+            }
+
+            // TODO:
             // Step 31.8. Set el's delaying the load event to true.
             // Step 31.9. If el is currently render-blocking, then set options's render-blocking to true.
 
@@ -960,7 +1001,11 @@ impl HTMLScriptElement {
             return;
         }
 
-        // TODO: Step 3. Unblock rendering on el.
+        // Step 3. Unblock rendering on el.
+        if self.marked_as_render_blocking.replace(false) {
+            doc.decrement_render_blocking_element_count();
+        }
+
         let script = match result {
             // Step 4. If el's result is null, then fire an event named error at el, and return.
             Err(_) => {
@@ -1170,6 +1215,12 @@ impl VirtualMethods for HTMLScriptElement {
                     self.prepare(Some(IntroductionType::INJECTED_SCRIPT), can_gc);
                 }
             }
+        } else if *attr.local_name() == local_name!("blocking") &&
+            !self.has_render_blocking_attribute() &&
+            self.marked_as_render_blocking.replace(false)
+        {
+            let document = self.owner_document();
+            document.decrement_render_blocking_element_count();
         }
     }
 
@@ -1219,6 +1270,13 @@ impl VirtualMethods for HTMLScriptElement {
             copy.downcast::<HTMLScriptElement>()
                 .unwrap()
                 .set_already_started(true);
+        }
+    }
+
+    fn unbind_from_tree(&self, _context: &UnbindContext, _can_gc: CanGc) {
+        if self.marked_as_render_blocking.replace(false) {
+            let document = self.owner_document();
+            document.decrement_render_blocking_element_count();
         }
     }
 }
@@ -1277,6 +1335,18 @@ impl HTMLScriptElementMethods<crate::DomTypeHolder> for HTMLScriptElement {
     make_bool_getter!(Defer, "defer");
     // https://html.spec.whatwg.org/multipage/#dom-script-defer
     make_bool_setter!(SetDefer, "defer");
+
+    /// <https://html.spec.whatwg.org/multipage/#attr-script-blocking>
+    fn Blocking(&self, cx: &mut JSContext) -> DomRoot<DOMTokenList> {
+        self.blocking.or_init(|| {
+            DOMTokenList::new(
+                self.upcast(),
+                &local_name!("blocking"),
+                Some(vec![Atom::from("render")]),
+                CanGc::from_cx(cx),
+            )
+        })
+    }
 
     // https://html.spec.whatwg.org/multipage/#dom-script-nomodule
     make_bool_getter!(NoModule, "nomodule");

--- a/components/script/dom/window.rs
+++ b/components/script/dom/window.rs
@@ -2768,7 +2768,8 @@ impl Window {
         // iframe size updates.
         //
         // See <https://github.com/servo/servo/issues/14719>
-        if self.Document().update_the_rendering().0.needs_frame() {
+        let document = self.Document();
+        if !document.is_render_blocked() && document.update_the_rendering().0.needs_frame() {
             self.paint_api()
                 .generate_frame(vec![self.webview_id().into()]);
         }

--- a/components/script/script_thread.rs
+++ b/components/script/script_thread.rs
@@ -1139,10 +1139,6 @@ impl ScriptThread {
             return false;
         }
 
-        // TODO: The specification says to filter out non-renderable documents,
-        // as well as those for which a rendering update would be unnecessary,
-        // but this isn't happening here.
-
         // TODO(#31242): the filtering of docs is extended to not exclude the ones that
         // has pending initial observation targets
         // https://w3c.github.io/IntersectionObserver/#pending-initial-observation
@@ -1180,6 +1176,25 @@ impl ScriptThread {
             }
 
             if document.waiting_on_canvas_image_updates() {
+                continue;
+            }
+
+            // Step 3. Filter non-renderable documents:
+            // Remove from docs any Document object doc for which any of the following are true:
+            if
+            // doc is render-blocked;
+            document.is_render_blocked()
+            // doc's visibility state is "hidden";
+            // TODO: Currently, this would mean that the script thread does nothing, since
+            // documents aren't currently correctly set to the visible state when navigating
+
+            // doc's rendering is suppressed for view transitions; or
+            // TODO
+
+            // doc's node navigable doesn't currently have a rendering opportunity.
+            //
+            // This is implicitly the case when we call this method
+            {
                 continue;
             }
 

--- a/components/script/stylesheet_loader.rs
+++ b/components/script/stylesheet_loader.rs
@@ -506,7 +506,8 @@ impl ElementStylesheetLoader<'_> {
         // If element's media attribute's value matches the environment and
         // element is potentially render-blocking, then block rendering on element.
         context.is_render_blocking = element.media_attribute_matches_media_environment() &&
-            owner.potentially_render_blocking();
+            owner.potentially_render_blocking() &&
+            document.allows_adding_render_blocking_elements();
         if context.is_render_blocking {
             document.increment_render_blocking_element_count();
         }

--- a/components/script_bindings/codegen/Bindings.conf
+++ b/components/script_bindings/codegen/Bindings.conf
@@ -527,7 +527,7 @@ DOMInterfaces = {
 
 'HTMLScriptElement': {
     'canGc': ['SetAsync', 'SetInnerText', 'SetSrc', 'SetText', 'SetTextContent'],
-    'cx': ['SetCrossOrigin'],
+    'cx': ['Blocking', 'SetCrossOrigin'],
 },
 
 'HTMLSelectElement': {

--- a/components/script_bindings/webidls/HTMLScriptElement.webidl
+++ b/components/script_bindings/webidls/HTMLScriptElement.webidl
@@ -19,6 +19,8 @@ interface HTMLScriptElement : HTMLElement {
            attribute boolean async;
   [CEReactions]
            attribute boolean defer;
+  [SameObject, PutForwards=value]
+           readonly attribute DOMTokenList blocking;
   [CEReactions]
            attribute DOMString? crossOrigin;
   [CEReactions, SetterThrows]

--- a/tests/wpt/meta/html/dom/idlharness.https.html.ini
+++ b/tests/wpt/meta/html/dom/idlharness.https.html.ini
@@ -6337,13 +6337,7 @@
   [HTMLLegendElement interface: document.createElement("legend") must inherit property "align" with the proper type]
     expected: FAIL
 
-  [HTMLScriptElement interface: attribute blocking]
-    expected: FAIL
-
   [HTMLScriptElement interface: attribute fetchPriority]
-    expected: FAIL
-
-  [HTMLScriptElement interface: document.createElement("script") must inherit property "blocking" with the proper type]
     expected: FAIL
 
   [HTMLScriptElement interface: document.createElement("script") must inherit property "fetchPriority" with the proper type]

--- a/tests/wpt/meta/html/dom/render-blocking/blocking-idl-attr.html.ini
+++ b/tests/wpt/meta/html/dom/render-blocking/blocking-idl-attr.html.ini
@@ -1,6 +1,0 @@
-[blocking-idl-attr.html]
-  [Supported tokens of the 'blocking' IDL attribute of the script element]
-    expected: FAIL
-
-  [Setting the 'blocking' IDL attribute of the script element]
-    expected: FAIL

--- a/tests/wpt/meta/html/dom/render-blocking/remove-attr-unblocks-rendering.optional.html.ini
+++ b/tests/wpt/meta/html/dom/render-blocking/remove-attr-unblocks-rendering.optional.html.ini
@@ -1,0 +1,24 @@
+[remove-attr-unblocks-rendering.optional.html]
+  [Render-blocking on parser-inserted async script is cancellable]
+    expected: FAIL
+
+  [Render-blocking on parser-inserted defer script is cancellable]
+    expected: FAIL
+
+  [Render-blocking on parser-inserted module script is cancellable]
+    expected: FAIL
+
+  [Render-blocking on parser-inserted async module script is cancellable]
+    expected: FAIL
+
+  [Render-blocking on script-inserted stylesheet link is cancellable]
+    expected: FAIL
+
+  [Render-blocking on script-inserted script is cancellable]
+    expected: FAIL
+
+  [Render-blocking on script-inserted module script is cancellable]
+    expected: FAIL
+
+  [Render-blocking on script-inserted inline style is cancellable]
+    expected: FAIL

--- a/tests/wpt/meta/html/dom/render-blocking/remove-element-unblocks-rendering.optional.html.ini
+++ b/tests/wpt/meta/html/dom/render-blocking/remove-element-unblocks-rendering.optional.html.ini
@@ -1,0 +1,21 @@
+[remove-element-unblocks-rendering.optional.html]
+  [Render-blocking on parser-inserted async script is cancellable]
+    expected: FAIL
+
+  [Render-blocking on parser-inserted defer script is cancellable]
+    expected: FAIL
+
+  [Render-blocking on parser-inserted module script is cancellable]
+    expected: FAIL
+
+  [Render-blocking on parser-inserted async module script is cancellable]
+    expected: FAIL
+
+  [Render-blocking on script-inserted script is cancellable]
+    expected: FAIL
+
+  [Render-blocking on script-inserted module script is cancellable]
+    expected: FAIL
+
+  [Render-blocking on script-inserted inline style is cancellable]
+    expected: FAIL

--- a/tests/wpt/meta/html/dom/render-blocking/script-inserted-module-script.html.ini
+++ b/tests/wpt/meta/html/dom/render-blocking/script-inserted-module-script.html.ini
@@ -1,3 +1,0 @@
-[script-inserted-module-script.html]
-  [Rendering is blocked before render-blocking resources are loaded]
-    expected: FAIL

--- a/tests/wpt/meta/html/dom/render-blocking/script-inserted-script.html.ini
+++ b/tests/wpt/meta/html/dom/render-blocking/script-inserted-script.html.ini
@@ -1,3 +1,0 @@
-[script-inserted-script.html]
-  [Rendering is blocked before render-blocking resources are loaded]
-    expected: FAIL


### PR DESCRIPTION
The spec expects us to check for render blocking (among some other state) before we start procesing a document. Therefore, add those checks and also check in the
stylesheet loader that we should only do so when we are allowed to do so.