### PR TITLE
devtools: Use active pipeline and script channel in inspector actors

### DIFF
--- a/components/devtools/actors/browsing_context.rs
+++ b/components/devtools/actors/browsing_context.rs
@@ -15,6 +15,7 @@ use devtools_traits::DevtoolScriptControlMsg::{self, GetCssDatabase, SimulateCol
 use devtools_traits::{DevtoolsPageInfo, NavigationState};
 use embedder_traits::Theme;
 use malloc_size_of_derive::MallocSizeOf;
+use rustc_hash::FxHashMap;
 use serde::Serialize;
 use serde_json::{Map, Value};
 
@@ -148,7 +149,13 @@ pub(crate) struct BrowsingContextActor {
     style_sheets: String,
     pub thread: String,
     _tab: String,
-    pub script_chan: GenericSender<DevtoolScriptControlMsg>,
+    // Different pipelines may run on different script threads.
+    // These should be kept around even when the active pipeline is updated,
+    // in case the browsing context revisits a pipeline via history navigation.
+    // TODO: Each entry is stored forever; ideally there should be a way to
+    //       detect when `ScriptThread`s are destroyed and remove the associated
+    //       entries.
+    script_chans: AtomicRefCell<FxHashMap<PipelineId, GenericSender<DevtoolScriptControlMsg>>>,
     pub watcher: String,
 }
 
@@ -220,7 +227,7 @@ impl BrowsingContextActor {
         let css_properties =
             CssPropertiesActor::new(actors.new_name::<CssPropertiesActor>(), properties);
 
-        let inspector = InspectorActor::register(actors, pipeline_id, script_sender.clone());
+        let inspector = InspectorActor::register(actors, name.clone());
 
         let reflow = ReflowActor::new(actors.new_name::<ReflowActor>());
 
@@ -240,9 +247,12 @@ impl BrowsingContextActor {
             SessionContext::new(SessionContextType::BrowserElement),
         );
 
+        let mut script_chans = FxHashMap::default();
+        script_chans.insert(pipeline_id, script_sender);
+
         let target = BrowsingContextActor {
             name,
-            script_chan: script_sender,
+            script_chans: AtomicRefCell::new(script_chans),
             title: AtomicRefCell::new(title),
             url: AtomicRefCell::new(url.into_string()),
             active_pipeline_id: AtomicRefCell::new(pipeline_id),
@@ -271,7 +281,17 @@ impl BrowsingContextActor {
         target
     }
 
-    pub(crate) fn navigate<'a>(
+    pub(crate) fn handle_new_global(
+        &self,
+        pipeline: PipelineId,
+        script_sender: GenericSender<DevtoolScriptControlMsg>,
+    ) {
+        self.script_chans
+            .borrow_mut()
+            .insert(pipeline, script_sender);
+    }
+
+    pub(crate) fn handle_navigate<'a>(
         &self,
         state: NavigationState,
         id_map: &mut IdMap,
@@ -329,7 +349,7 @@ impl BrowsingContextActor {
     }
 
     pub fn simulate_color_scheme(&self, theme: Theme) -> Result<(), ()> {
-        self.script_chan
+        self.script_chan()
             .send(SimulateColorScheme(self.pipeline_id(), theme))
             .map_err(|_| ())
     }
@@ -342,9 +362,18 @@ impl BrowsingContextActor {
         *self.active_outer_window_id.borrow()
     }
 
+    /// Returns the script sender for the active pipeline.
+    pub(crate) fn script_chan(&self) -> GenericSender<DevtoolScriptControlMsg> {
+        self.script_chans
+            .borrow()
+            .get(&self.pipeline_id())
+            .unwrap()
+            .clone()
+    }
+
     pub(crate) fn instruct_script_to_send_live_updates(&self, should_send_updates: bool) {
         let result = self
-            .script_chan
+            .script_chan()
             .send(DevtoolScriptControlMsg::WantsLiveNotifications(
                 self.pipeline_id(),
                 should_send_updates,

--- a/components/devtools/actors/console.rs
+++ b/components/devtools/actors/console.rs
@@ -294,8 +294,7 @@ impl ConsoleActor {
         match &self.root {
             Root::BrowsingContext(browsing_context) => registry
                 .find::<BrowsingContextActor>(browsing_context)
-                .script_chan
-                .clone(),
+                .script_chan(),
             Root::DedicatedWorker(worker) => {
                 registry.find::<WorkerActor>(worker).script_chan.clone()
             },

--- a/components/devtools/actors/inspector.rs
+++ b/components/devtools/actors/inspector.rs
@@ -5,9 +5,6 @@
 //! Liberally derived from the [Firefox JS implementation](http://mxr.mozilla.org/mozilla-central/source/toolkit/devtools/server/actors/inspector.js).
 
 use atomic_refcell::AtomicRefCell;
-use base::generic_channel::GenericSender;
-use base::id::PipelineId;
-use devtools_traits::DevtoolScriptControlMsg;
 use malloc_size_of_derive::MallocSizeOf;
 use serde::Serialize;
 use serde_json::{self, Map, Value};
@@ -116,28 +113,20 @@ impl Actor for InspectorActor {
 impl InspectorActor {
     // TODO: Passing the pipeline id here isn't correct. We should query the browsing
     // context for the active pipeline, otherwise reloading or navigating will break the inspector.
-    pub fn register(
-        registry: &ActorRegistry,
-        pipeline: PipelineId,
-        script_chan: GenericSender<DevtoolScriptControlMsg>,
-    ) -> String {
+    pub fn register(registry: &ActorRegistry, browsing_context: String) -> String {
         let highlighter = HighlighterActor {
             name: registry.new_name::<HighlighterActor>(),
-            script_sender: script_chan.clone(),
-            pipeline,
+            browsing_context: browsing_context.clone(),
         };
 
         let page_style = PageStyleActor {
             name: registry.new_name::<PageStyleActor>(),
-            script_chan: script_chan.clone(),
-            pipeline,
         };
 
         let walker = WalkerActor {
             name: registry.new_name::<WalkerActor>(),
             mutations: AtomicRefCell::new(vec![]),
-            script_chan,
-            pipeline,
+            browsing_context,
         };
 
         let actor = Self {

--- a/components/devtools/actors/inspector.rs
+++ b/components/devtools/actors/inspector.rs
@@ -111,8 +111,6 @@ impl Actor for InspectorActor {
 }
 
 impl InspectorActor {
-    // TODO: Passing the pipeline id here isn't correct. We should query the browsing
-    // context for the active pipeline, otherwise reloading or navigating will break the inspector.
     pub fn register(registry: &ActorRegistry, browsing_context: String) -> String {
         let highlighter = HighlighterActor {
             name: registry.new_name::<HighlighterActor>(),

--- a/components/devtools/actors/inspector/highlighter.rs
+++ b/components/devtools/actors/inspector/highlighter.rs
@@ -97,11 +97,11 @@ impl HighlighterActor {
         registry: &ActorRegistry,
     ) {
         let node_id = node_actor.map(|node_actor| registry.actor_to_script(node_actor));
-        let ctx_actor = registry.find::<BrowsingContextActor>(&self.browsing_context);
-        ctx_actor
+        let browsing_context = registry.find::<BrowsingContextActor>(&self.browsing_context);
+        browsing_context
             .script_chan()
             .send(DevtoolScriptControlMsg::HighlightDomNode(
-                ctx_actor.pipeline_id(),
+                browsing_context.pipeline_id(),
                 node_id,
             ))
             .unwrap();

--- a/components/devtools/actors/inspector/highlighter.rs
+++ b/components/devtools/actors/inspector/highlighter.rs
@@ -5,14 +5,13 @@
 //! Handles highlighting selected DOM nodes in the inspector. At the moment it only replies and
 //! changes nothing on Servo's side.
 
-use base::generic_channel::GenericSender;
-use base::id::PipelineId;
 use devtools_traits::DevtoolScriptControlMsg;
 use malloc_size_of_derive::MallocSizeOf;
 use serde::Serialize;
 use serde_json::{self, Map, Value};
 
 use crate::actor::{Actor, ActorEncode, ActorError, ActorRegistry};
+use crate::actors::browsing_context::BrowsingContextActor;
 use crate::actors::inspector::InspectorActor;
 use crate::protocol::ClientRequest;
 use crate::{ActorMsg, EmptyReplyMsg, StreamId};
@@ -20,8 +19,7 @@ use crate::{ActorMsg, EmptyReplyMsg, StreamId};
 #[derive(MallocSizeOf)]
 pub(crate) struct HighlighterActor {
     pub name: String,
-    pub script_sender: GenericSender<DevtoolScriptControlMsg>,
-    pub pipeline: PipelineId,
+    pub browsing_context: String,
 }
 
 #[derive(Serialize)]
@@ -99,9 +97,11 @@ impl HighlighterActor {
         registry: &ActorRegistry,
     ) {
         let node_id = node_actor.map(|node_actor| registry.actor_to_script(node_actor));
-        self.script_sender
+        let ctx_actor = registry.find::<BrowsingContextActor>(&self.browsing_context);
+        ctx_actor
+            .script_chan()
             .send(DevtoolScriptControlMsg::HighlightDomNode(
-                self.pipeline,
+                ctx_actor.pipeline_id(),
                 node_id,
             ))
             .unwrap();

--- a/components/devtools/actors/inspector/page_style.rs
+++ b/components/devtools/actors/inspector/page_style.rs
@@ -143,7 +143,7 @@ impl PageStyleActor {
             .ok_or(ActorError::BadParameterType)?;
         let node = registry.find::<NodeActor>(target);
         let walker = registry.find::<WalkerActor>(&node.walker);
-        let ctx_actor = walker.ctx_actor(registry);
+        let browsing_context = walker.browsing_context(registry);
         let entries: Vec<_> = find_child(
             &node.script_chan,
             node.pipeline,
@@ -162,10 +162,10 @@ impl PageStyleActor {
             // Get the css selectors that match this node present in the currently active stylesheets.
             let selectors = (|| {
                 let (selectors_sender, selector_receiver) = generic_channel::channel()?;
-                ctx_actor
+                browsing_context
                     .script_chan()
                     .send(GetSelectors(
-                        ctx_actor.pipeline_id(),
+                        browsing_context.pipeline_id(),
                         registry.actor_to_script(node.actor.clone()),
                         selectors_sender,
                     ))
@@ -271,12 +271,12 @@ impl PageStyleActor {
             .ok_or(ActorError::BadParameterType)?;
         let node = registry.find::<NodeActor>(target);
         let walker = registry.find::<WalkerActor>(&node.walker);
-        let ctx_actor = walker.ctx_actor(registry);
+        let browsing_context = walker.browsing_context(registry);
         let (tx, rx) = generic_channel::channel().ok_or(ActorError::Internal)?;
-        ctx_actor
+        browsing_context
             .script_chan()
             .send(GetLayout(
-                ctx_actor.pipeline_id(),
+                browsing_context.pipeline_id(),
                 registry.actor_to_script(target.to_owned()),
                 tx,
             ))

--- a/components/devtools/actors/inspector/page_style.rs
+++ b/components/devtools/actors/inspector/page_style.rs
@@ -9,10 +9,9 @@ use std::collections::HashMap;
 use std::collections::hash_map::Entry;
 use std::iter::once;
 
-use base::generic_channel::{self, GenericSender};
-use base::id::PipelineId;
+use base::generic_channel::{self};
 use devtools_traits::DevtoolScriptControlMsg::{GetLayout, GetSelectors};
-use devtools_traits::{AutoMargins, ComputedNodeLayout, DevtoolScriptControlMsg};
+use devtools_traits::{AutoMargins, ComputedNodeLayout};
 use malloc_size_of_derive::MallocSizeOf;
 use serde::Serialize;
 use serde_json::{self, Map, Value};
@@ -94,8 +93,6 @@ pub(crate) struct PageStyleMsg {
 #[derive(MallocSizeOf)]
 pub(crate) struct PageStyleActor {
     pub name: String,
-    pub script_chan: GenericSender<DevtoolScriptControlMsg>,
-    pub pipeline: PipelineId,
 }
 
 impl Actor for PageStyleActor {
@@ -146,6 +143,7 @@ impl PageStyleActor {
             .ok_or(ActorError::BadParameterType)?;
         let node = registry.find::<NodeActor>(target);
         let walker = registry.find::<WalkerActor>(&node.walker);
+        let ctx_actor = walker.ctx_actor(registry);
         let entries: Vec<_> = find_child(
             &node.script_chan,
             node.pipeline,
@@ -164,10 +162,10 @@ impl PageStyleActor {
             // Get the css selectors that match this node present in the currently active stylesheets.
             let selectors = (|| {
                 let (selectors_sender, selector_receiver) = generic_channel::channel()?;
-                walker
-                    .script_chan
+                ctx_actor
+                    .script_chan()
                     .send(GetSelectors(
-                        walker.pipeline,
+                        ctx_actor.pipeline_id(),
                         registry.actor_to_script(node.actor.clone()),
                         selectors_sender,
                     ))
@@ -271,10 +269,14 @@ impl PageStyleActor {
             .ok_or(ActorError::MissingParameter)?
             .as_str()
             .ok_or(ActorError::BadParameterType)?;
+        let node = registry.find::<NodeActor>(target);
+        let walker = registry.find::<WalkerActor>(&node.walker);
+        let ctx_actor = walker.ctx_actor(registry);
         let (tx, rx) = generic_channel::channel().ok_or(ActorError::Internal)?;
-        self.script_chan
+        ctx_actor
+            .script_chan()
             .send(GetLayout(
-                self.pipeline,
+                ctx_actor.pipeline_id(),
                 registry.actor_to_script(target.to_owned()),
                 tx,
             ))

--- a/components/devtools/actors/inspector/style_rule.rs
+++ b/components/devtools/actors/inspector/style_rule.rs
@@ -123,10 +123,10 @@ impl Actor for StyleRuleActor {
                 // Query the rule modification
                 let node = registry.find::<NodeActor>(&self.node);
                 let walker = registry.find::<WalkerActor>(&node.walker);
-                walker
-                    .script_chan
+                let ctx = walker.ctx_actor(registry);
+                ctx.script_chan()
                     .send(ModifyRule(
-                        walker.pipeline,
+                        ctx.pipeline_id(),
                         registry.actor_to_script(self.node.clone()),
                         modifications,
                     ))
@@ -152,11 +152,11 @@ impl StyleRuleActor {
     pub fn applied(&self, registry: &ActorRegistry) -> Option<AppliedRule> {
         let node = registry.find::<NodeActor>(&self.node);
         let walker = registry.find::<WalkerActor>(&node.walker);
+        let ctx = walker.ctx_actor(registry);
 
         let (document_sender, document_receiver) = generic_channel::channel()?;
-        walker
-            .script_chan
-            .send(GetDocumentElement(walker.pipeline, document_sender))
+        ctx.script_chan()
+            .send(GetDocumentElement(ctx.pipeline_id(), document_sender))
             .ok()?;
         let node = document_receiver.recv().ok()??;
 
@@ -167,7 +167,7 @@ impl StyleRuleActor {
             Some(selector) => {
                 let (selector, stylesheet) = selector.clone();
                 GetStylesheetStyle(
-                    walker.pipeline,
+                    ctx.pipeline_id(),
                     registry.actor_to_script(self.node.clone()),
                     selector,
                     stylesheet,
@@ -175,12 +175,12 @@ impl StyleRuleActor {
                 )
             },
             None => GetAttributeStyle(
-                walker.pipeline,
+                ctx.pipeline_id(),
                 registry.actor_to_script(self.node.clone()),
                 style_sender,
             ),
         };
-        walker.script_chan.send(req).ok()?;
+        ctx.script_chan().send(req).ok()?;
         let style = style_receiver.recv().ok()??;
 
         Some(AppliedRule {
@@ -220,12 +220,12 @@ impl StyleRuleActor {
     ) -> Option<HashMap<String, ComputedDeclaration>> {
         let node = registry.find::<NodeActor>(&self.node);
         let walker = registry.find::<WalkerActor>(&node.walker);
+        let ctx = walker.ctx_actor(registry);
 
         let (style_sender, style_receiver) = generic_channel::channel()?;
-        walker
-            .script_chan
+        ctx.script_chan()
             .send(GetComputedStyle(
-                walker.pipeline,
+                ctx.pipeline_id(),
                 registry.actor_to_script(self.node.clone()),
                 style_sender,
             ))

--- a/components/devtools/actors/inspector/style_rule.rs
+++ b/components/devtools/actors/inspector/style_rule.rs
@@ -123,10 +123,11 @@ impl Actor for StyleRuleActor {
                 // Query the rule modification
                 let node = registry.find::<NodeActor>(&self.node);
                 let walker = registry.find::<WalkerActor>(&node.walker);
-                let ctx = walker.ctx_actor(registry);
-                ctx.script_chan()
+                let browsing_context = walker.browsing_context(registry);
+                browsing_context
+                    .script_chan()
                     .send(ModifyRule(
-                        ctx.pipeline_id(),
+                        browsing_context.pipeline_id(),
                         registry.actor_to_script(self.node.clone()),
                         modifications,
                     ))
@@ -152,11 +153,15 @@ impl StyleRuleActor {
     pub fn applied(&self, registry: &ActorRegistry) -> Option<AppliedRule> {
         let node = registry.find::<NodeActor>(&self.node);
         let walker = registry.find::<WalkerActor>(&node.walker);
-        let ctx = walker.ctx_actor(registry);
+        let browsing_context = walker.browsing_context(registry);
 
         let (document_sender, document_receiver) = generic_channel::channel()?;
-        ctx.script_chan()
-            .send(GetDocumentElement(ctx.pipeline_id(), document_sender))
+        browsing_context
+            .script_chan()
+            .send(GetDocumentElement(
+                browsing_context.pipeline_id(),
+                document_sender,
+            ))
             .ok()?;
         let node = document_receiver.recv().ok()??;
 
@@ -167,7 +172,7 @@ impl StyleRuleActor {
             Some(selector) => {
                 let (selector, stylesheet) = selector.clone();
                 GetStylesheetStyle(
-                    ctx.pipeline_id(),
+                    browsing_context.pipeline_id(),
                     registry.actor_to_script(self.node.clone()),
                     selector,
                     stylesheet,
@@ -175,12 +180,12 @@ impl StyleRuleActor {
                 )
             },
             None => GetAttributeStyle(
-                ctx.pipeline_id(),
+                browsing_context.pipeline_id(),
                 registry.actor_to_script(self.node.clone()),
                 style_sender,
             ),
         };
-        ctx.script_chan().send(req).ok()?;
+        browsing_context.script_chan().send(req).ok()?;
         let style = style_receiver.recv().ok()??;
 
         Some(AppliedRule {
@@ -220,12 +225,13 @@ impl StyleRuleActor {
     ) -> Option<HashMap<String, ComputedDeclaration>> {
         let node = registry.find::<NodeActor>(&self.node);
         let walker = registry.find::<WalkerActor>(&node.walker);
-        let ctx = walker.ctx_actor(registry);
+        let browsing_context = walker.browsing_context(registry);
 
         let (style_sender, style_receiver) = generic_channel::channel()?;
-        ctx.script_chan()
+        browsing_context
+            .script_chan()
             .send(GetComputedStyle(
-                ctx.pipeline_id(),
+                browsing_context.pipeline_id(),
                 registry.actor_to_script(self.node.clone()),
                 style_sender,
             ))

--- a/components/devtools/actors/inspector/walker.rs
+++ b/components/devtools/actors/inspector/walker.rs
@@ -15,7 +15,8 @@ use malloc_size_of_derive::MallocSizeOf;
 use serde::Serialize;
 use serde_json::{self, Map, Value};
 
-use crate::actor::{Actor, ActorEncode, ActorError, ActorRegistry};
+use crate::actor::{Actor, ActorEncode, ActorError, ActorRegistry, DowncastableActorArc};
+use crate::actors::browsing_context::BrowsingContextActor;
 use crate::actors::inspector::layout::LayoutInspectorActor;
 use crate::actors::inspector::node::{NodeActorMsg, NodeInfoToProtocol};
 use crate::protocol::{ClientRequest, JsonPacketStream};
@@ -31,8 +32,8 @@ pub(crate) struct WalkerMsg {
 pub(crate) struct WalkerActor {
     pub name: String,
     pub mutations: AtomicRefCell<Vec<DomMutation>>,
-    pub pipeline: PipelineId,
-    pub script_chan: GenericSender<DevtoolScriptControlMsg>,
+    /// Name of the [`BrowsingContextActor`] that owns this walker.
+    pub browsing_context: String,
 }
 
 #[derive(Serialize)]
@@ -141,6 +142,7 @@ impl Actor for WalkerActor {
         msg: &Map<String, Value>,
         _id: StreamId,
     ) -> Result<(), ActorError> {
+        let ctx_actor = self.ctx_actor(registry);
         match msg_type {
             "children" => {
                 let target = msg
@@ -151,9 +153,10 @@ impl Actor for WalkerActor {
                 let Some((tx, rx)) = generic_channel::channel() else {
                     return Err(ActorError::Internal);
                 };
-                self.script_chan
+                ctx_actor
+                    .script_chan()
                     .send(GetChildren(
-                        self.pipeline,
+                        ctx_actor.pipeline_id(),
                         registry.actor_to_script(target.into()),
                         tx,
                     ))
@@ -171,8 +174,8 @@ impl Actor for WalkerActor {
                         .map(|child| {
                             child.encode(
                                 registry,
-                                self.script_chan.clone(),
-                                self.pipeline,
+                                ctx_actor.script_chan(),
+                                ctx_actor.pipeline_id(),
                                 self.name(),
                             )
                         })
@@ -189,8 +192,9 @@ impl Actor for WalkerActor {
                 let Some((tx, rx)) = generic_channel::channel() else {
                     return Err(ActorError::Internal);
                 };
-                self.script_chan
-                    .send(GetDocumentElement(self.pipeline, tx))
+                ctx_actor
+                    .script_chan()
+                    .send(GetDocumentElement(ctx_actor.pipeline_id(), tx))
                     .map_err(|_| ActorError::Internal)?;
                 let doc_elem_info = rx
                     .recv()
@@ -198,8 +202,8 @@ impl Actor for WalkerActor {
                     .ok_or(ActorError::Internal)?;
                 let node = doc_elem_info.encode(
                     registry,
-                    self.script_chan.clone(),
-                    self.pipeline,
+                    ctx_actor.script_chan().clone(),
+                    ctx_actor.pipeline_id(),
                     self.name(),
                 );
 
@@ -241,8 +245,8 @@ impl Actor for WalkerActor {
                     .as_str()
                     .ok_or(ActorError::BadParameterType)?;
                 let mut hierarchy = find_child(
-                    &self.script_chan,
-                    self.pipeline,
+                    &ctx_actor.script_chan(),
+                    ctx_actor.pipeline_id(),
                     &self.name,
                     registry,
                     node,
@@ -278,21 +282,26 @@ impl Actor for WalkerActor {
 }
 
 impl WalkerActor {
+    pub(crate) fn ctx_actor(
+        &self,
+        registry: &ActorRegistry,
+    ) -> DowncastableActorArc<BrowsingContextActor> {
+        registry.find::<BrowsingContextActor>(&self.browsing_context)
+    }
+
     pub(crate) fn root(&self, registry: &ActorRegistry) -> Result<NodeActorMsg, ActorError> {
+        let ctx_actor = self.ctx_actor(registry);
+        let pipeline = ctx_actor.pipeline_id();
         let (tx, rx) = generic_channel::channel().ok_or(ActorError::Internal)?;
-        self.script_chan
-            .send(GetRootNode(self.pipeline, tx))
+        ctx_actor
+            .script_chan()
+            .send(GetRootNode(pipeline, tx))
             .map_err(|_| ActorError::Internal)?;
         let root_node = rx
             .recv()
             .map_err(|_| ActorError::Internal)?
             .ok_or(ActorError::Internal)?;
-        Ok(root_node.encode(
-            registry,
-            self.script_chan.clone(),
-            self.pipeline,
-            self.name(),
-        ))
+        Ok(root_node.encode(registry, ctx_actor.script_chan(), pipeline, self.name()))
     }
 
     pub(crate) fn handle_dom_mutation(

--- a/components/devtools/actors/inspector/walker.rs
+++ b/components/devtools/actors/inspector/walker.rs
@@ -142,7 +142,7 @@ impl Actor for WalkerActor {
         msg: &Map<String, Value>,
         _id: StreamId,
     ) -> Result<(), ActorError> {
-        let ctx_actor = self.ctx_actor(registry);
+        let browsing_context = self.browsing_context(registry);
         match msg_type {
             "children" => {
                 let target = msg
@@ -153,10 +153,10 @@ impl Actor for WalkerActor {
                 let Some((tx, rx)) = generic_channel::channel() else {
                     return Err(ActorError::Internal);
                 };
-                ctx_actor
+                browsing_context
                     .script_chan()
                     .send(GetChildren(
-                        ctx_actor.pipeline_id(),
+                        browsing_context.pipeline_id(),
                         registry.actor_to_script(target.into()),
                         tx,
                     ))
@@ -174,8 +174,8 @@ impl Actor for WalkerActor {
                         .map(|child| {
                             child.encode(
                                 registry,
-                                ctx_actor.script_chan(),
-                                ctx_actor.pipeline_id(),
+                                browsing_context.script_chan(),
+                                browsing_context.pipeline_id(),
                                 self.name(),
                             )
                         })
@@ -192,9 +192,9 @@ impl Actor for WalkerActor {
                 let Some((tx, rx)) = generic_channel::channel() else {
                     return Err(ActorError::Internal);
                 };
-                ctx_actor
+                browsing_context
                     .script_chan()
-                    .send(GetDocumentElement(ctx_actor.pipeline_id(), tx))
+                    .send(GetDocumentElement(browsing_context.pipeline_id(), tx))
                     .map_err(|_| ActorError::Internal)?;
                 let doc_elem_info = rx
                     .recv()
@@ -202,8 +202,8 @@ impl Actor for WalkerActor {
                     .ok_or(ActorError::Internal)?;
                 let node = doc_elem_info.encode(
                     registry,
-                    ctx_actor.script_chan().clone(),
-                    ctx_actor.pipeline_id(),
+                    browsing_context.script_chan().clone(),
+                    browsing_context.pipeline_id(),
                     self.name(),
                 );
 
@@ -245,8 +245,8 @@ impl Actor for WalkerActor {
                     .as_str()
                     .ok_or(ActorError::BadParameterType)?;
                 let mut hierarchy = find_child(
-                    &ctx_actor.script_chan(),
-                    ctx_actor.pipeline_id(),
+                    &browsing_context.script_chan(),
+                    browsing_context.pipeline_id(),
                     &self.name,
                     registry,
                     node,
@@ -282,7 +282,7 @@ impl Actor for WalkerActor {
 }
 
 impl WalkerActor {
-    pub(crate) fn ctx_actor(
+    pub(crate) fn browsing_context(
         &self,
         registry: &ActorRegistry,
     ) -> DowncastableActorArc<BrowsingContextActor> {
@@ -290,10 +290,10 @@ impl WalkerActor {
     }
 
     pub(crate) fn root(&self, registry: &ActorRegistry) -> Result<NodeActorMsg, ActorError> {
-        let ctx_actor = self.ctx_actor(registry);
-        let pipeline = ctx_actor.pipeline_id();
+        let browsing_context = self.browsing_context(registry);
+        let pipeline = browsing_context.pipeline_id();
         let (tx, rx) = generic_channel::channel().ok_or(ActorError::Internal)?;
-        ctx_actor
+        browsing_context
             .script_chan()
             .send(GetRootNode(pipeline, tx))
             .map_err(|_| ActorError::Internal)?;
@@ -301,7 +301,12 @@ impl WalkerActor {
             .recv()
             .map_err(|_| ActorError::Internal)?
             .ok_or(ActorError::Internal)?;
-        Ok(root_node.encode(registry, ctx_actor.script_chan(), pipeline, self.name()))
+        Ok(root_node.encode(
+            registry,
+            browsing_context.script_chan(),
+            pipeline,
+            self.name(),
+        ))
     }
 
     pub(crate) fn handle_dom_mutation(

--- a/components/devtools/actors/inspector/walker.rs
+++ b/components/devtools/actors/inspector/walker.rs
@@ -202,7 +202,7 @@ impl Actor for WalkerActor {
                     .ok_or(ActorError::Internal)?;
                 let node = doc_elem_info.encode(
                     registry,
-                    browsing_context.script_chan().clone(),
+                    browsing_context.script_chan(),
                     browsing_context.pipeline_id(),
                     self.name(),
                 );

--- a/components/devtools/actors/tab.rs
+++ b/components/devtools/actors/tab.rs
@@ -120,14 +120,14 @@ impl Actor for TabDescriptorActor {
             })?,
             "goBack" => {
                 ctx_actor
-                    .script_chan
+                    .script_chan()
                     .send(DevtoolScriptControlMsg::GoBack(pipeline))
                     .map_err(|_| ActorError::Internal)?;
                 request.reply_final(&EmptyReplyMsg { from: self.name() })?
             },
             "goForward" => {
                 ctx_actor
-                    .script_chan
+                    .script_chan()
                     .send(DevtoolScriptControlMsg::GoForward(pipeline))
                     .map_err(|_| ActorError::Internal)?;
                 request.reply_final(&EmptyReplyMsg { from: self.name() })?
@@ -144,7 +144,7 @@ impl Actor for TabDescriptorActor {
                     .map_err(|_| ActorError::Internal)?;
 
                 ctx_actor
-                    .script_chan
+                    .script_chan()
                     .send(DevtoolScriptControlMsg::NavigateTo(pipeline, url))
                     .map_err(|_| ActorError::Internal)?;
 
@@ -153,7 +153,7 @@ impl Actor for TabDescriptorActor {
             "reloadDescriptor" => {
                 // There is an extra bypassCache parameter that we don't currently use.
                 ctx_actor
-                    .script_chan
+                    .script_chan()
                     .send(DevtoolScriptControlMsg::Reload(pipeline))
                     .map_err(|_| ActorError::Internal)?;
 

--- a/components/devtools/lib.rs
+++ b/components/devtools/lib.rs
@@ -435,17 +435,20 @@ impl DevtoolsInstance {
         let actor = actors.find::<BrowsingContextActor>(actor_name);
         let mut id_map = self.id_map.lock().expect("Mutex poisoned");
         let mut connections = self.connections.lock().unwrap();
-        if let NavigationState::Start(url) = &state {
-            let watcher_actor = actors.find::<WatcherActor>(&actor.watcher);
-            watcher_actor.emit_will_navigate(
-                browsing_context_id,
-                url.clone(),
-                &mut connections.values_mut(),
-                &mut id_map,
-            );
-        };
-
-        actor.navigate(state, &mut id_map, connections.values_mut());
+        match &state {
+            NavigationState::Start(url) => {
+                let watcher_actor = actors.find::<WatcherActor>(&actor.watcher);
+                watcher_actor.emit_will_navigate(
+                    browsing_context_id,
+                    url.clone(),
+                    &mut connections.values_mut(),
+                    &mut id_map,
+                );
+            },
+            NavigationState::Stop(_, _) => {
+                actor.handle_navigate(state, &mut id_map, connections.values_mut());
+            },
+        }
     }
 
     // We need separate actor representations for each script global that exists;
@@ -503,21 +506,22 @@ impl DevtoolsInstance {
                 .browsing_contexts
                 .entry(browsing_context_id)
                 .or_insert_with(|| {
-                    let browsing_context_actor = BrowsingContextActor::new(
+                    let ctx_actor = BrowsingContextActor::new(
                         console_name.clone(),
                         devtools_browser_id,
                         devtools_browsing_context_id,
                         page_info,
                         pipeline_id,
                         devtools_outer_window_id,
-                        script_sender,
+                        script_sender.clone(),
                         actors,
                     );
-                    let name = browsing_context_actor.name();
-                    actors.register(browsing_context_actor);
+                    let name = ctx_actor.name();
+                    actors.register(ctx_actor);
                     name
                 });
-
+            let ctx_actor = actors.find::<BrowsingContextActor>(name);
+            ctx_actor.handle_new_global(pipeline_id, script_sender);
             Root::BrowsingContext(name.clone())
         };
 

--- a/components/devtools/lib.rs
+++ b/components/devtools/lib.rs
@@ -503,7 +503,7 @@ impl DevtoolsInstance {
                 .browsing_contexts
                 .entry(browsing_context_id)
                 .or_insert_with(|| {
-                    let ctx_actor = BrowsingContextActor::new(
+                    let browsing_context_actor = BrowsingContextActor::new(
                         console_name.clone(),
                         devtools_browser_id,
                         devtools_browsing_context_id,
@@ -513,12 +513,12 @@ impl DevtoolsInstance {
                         script_sender.clone(),
                         actors,
                     );
-                    let name = ctx_actor.name();
-                    actors.register(ctx_actor);
+                    let name = browsing_context_actor.name();
+                    actors.register(browsing_context_actor);
                     name
                 });
-            let ctx_actor = actors.find::<BrowsingContextActor>(name);
-            ctx_actor.handle_new_global(pipeline_id, script_sender);
+            let browsing_context_actor = actors.find::<BrowsingContextActor>(name);
+            browsing_context_actor.handle_new_global(pipeline_id, script_sender);
             Root::BrowsingContext(name.clone())
         };
 

--- a/components/devtools/lib.rs
+++ b/components/devtools/lib.rs
@@ -435,20 +435,17 @@ impl DevtoolsInstance {
         let actor = actors.find::<BrowsingContextActor>(actor_name);
         let mut id_map = self.id_map.lock().expect("Mutex poisoned");
         let mut connections = self.connections.lock().unwrap();
-        match &state {
-            NavigationState::Start(url) => {
-                let watcher_actor = actors.find::<WatcherActor>(&actor.watcher);
-                watcher_actor.emit_will_navigate(
-                    browsing_context_id,
-                    url.clone(),
-                    &mut connections.values_mut(),
-                    &mut id_map,
-                );
-            },
-            NavigationState::Stop(_, _) => {
-                actor.handle_navigate(state, &mut id_map, connections.values_mut());
-            },
+        if let NavigationState::Start(url) = &state {
+            let watcher_actor = actors.find::<WatcherActor>(&actor.watcher);
+            watcher_actor.emit_will_navigate(
+                browsing_context_id,
+                url.clone(),
+                &mut connections.values_mut(),
+                &mut id_map,
+            );
         }
+
+        actor.handle_navigate(state, &mut id_map, connections.values_mut());
     }
 
     // We need separate actor representations for each script global that exists;

--- a/python/servo/devtools_tests.py
+++ b/python/servo/devtools_tests.py
@@ -1185,10 +1185,6 @@ class DevtoolsTests(unittest.IsolatedAsyncioTestCase):
                 devtools.client.send_receive({"to": devtools.tab.actor_id, **message_data})
 
                 done.result(1)
-                # History may momentarily report stale state when navigating
-                # rapidly. The code under test does not seem to be responsible,
-                # so wait it out.
-                time.sleep(0.1)
 
     # Sets `base_url` and `web_server` and `web_server_thread`.
     @classmethod

--- a/python/servo/devtools_tests.py
+++ b/python/servo/devtools_tests.py
@@ -1132,7 +1132,7 @@ class DevtoolsTests(unittest.IsolatedAsyncioTestCase):
             nav_done = Future()
 
             def on_tab_navigated(data):
-                if data.get("url").endswith("/tab/page2.html"):
+                if data.get("state") == "stop" and data.get("url").endswith("/tab/page2.html"):
                     nav_done.set_result(None)
                     return
 
@@ -1173,7 +1173,7 @@ class DevtoolsTests(unittest.IsolatedAsyncioTestCase):
                 done = Future()
 
                 def on_tab_navigated(data):
-                    if data.get("url").endswith(target_path):
+                    if data.get("state") == "stop" and data.get("url").endswith(target_path):
                         done.set_result(None)
                         return
 

--- a/python/servo/devtools_tests.py
+++ b/python/servo/devtools_tests.py
@@ -1122,6 +1122,46 @@ class DevtoolsTests(unittest.IsolatedAsyncioTestCase):
             self.assertFalse(did_see_new_mutations)
             self.assertEquals(walker.get_mutations(False), [])
 
+    def test_walker_observes_new_dom_after_nav(self):
+        # This tests that the walker actor can correctly recognize a new DOM across distinct
+        # pipelines and script threads. It does not exercise the full exchange of messages required
+        # for the Firefox toolbox to successfully refresh its inspector panel.
+
+        self.run_servoshell(url=f"{self.base_urls[0]}/tab/page1.html")
+        with Devtools.connect() as devtools:
+            nav_done = Future()
+
+            def on_tab_navigated(data):
+                if data.get("url").endswith("/tab/page2.html"):
+                    nav_done.set_result(None)
+                    return
+
+            devtools.client.add_event_listener(
+                devtools.targets[0]["actor"],
+                "tabNavigated",
+                on_tab_navigated,
+            )
+            devtools.client.send_receive(
+                {
+                    "to": devtools.tab.actor_id,
+                    "type": "navigateTo",
+                    # Use a different base URL to test walker across script threads.
+                    "url": f"{self.base_urls[1]}/tab/page2.html",
+                },
+            )
+            # Wait for navigation to complete.
+            nav_done.result(1)
+
+            inspector = InspectorActor(devtools.client, devtools.targets[0]["inspectorActor"])
+            walker_info = inspector.get_walker()
+            walker = WalkerActor(devtools.client, walker_info["actor"])
+            root_node = walker_info["root"]["actor"]
+
+            title_node = walker.query_selector(root_node, "title")
+            self.assertIsNotNone(title_node.get("node"))
+            self.assertIsNotNone(title_node["node"].get("inlineTextChild"))
+            self.assertEquals(title_node["node"]["inlineTextChild"].get("nodeValue"), "Page 2")
+
     def test_navigation(self):
         self.run_servoshell(url=f"{self.base_urls[0]}/tab/page1.html")
         with Devtools.connect() as devtools:


### PR DESCRIPTION
The `InspectorActor` and its children now query the `BrowsingContextActor` for the active pipeline ID and script sender instead of storing their own copies, which become outdated on navigation. Previously, the inspector remained permanently stuck to the pipeline that was active upon launch. Now, connecting a fresh devtools client session after navigation allows inspection of each `BrowsingContext`'s active DOM.

Navigation within a continuous remote debugging session still breaks the Firefox inspector panel. This is due to multiple compatibility issues with the protocol implementation, which will be addressed in separate PRs.

This PR does not touch `TimelineActor` or `FramerateActor`. These are theoretically affected by the same issue as the `InspectorActor`, but in practice neither is ever instantiated. It seems both have been effectively unreachable code since 1aab10f2 and will require more extensive work and testing that is beyond the scope of this change.

Testing: Updates to the `WalkerActor` and `BrowsingContextActor` are unit tested via the new `test_walker_observes_new_dom_after_nav` case in `devtools_tests.py`. There are no existing unit tests to reference for the highlighter and style actors; these have been tested manually but this PR does not introduce further automated tests. This PR also improves handling of `tabNavigated` messages to simplify the unit test written for 4c69d85.