### PR TITLE
paint: Correctly apply viewport <meta> initial-scale

### DIFF
--- a/components/paint/webview_renderer.rs
+++ b/components/paint/webview_renderer.rs
@@ -1046,13 +1046,16 @@ impl WebViewRenderer {
         // The device pixel ratio used by the style system should include the scale from page pixels
         // to device pixels, but not including any pinch zoom.
         let device_pixel_ratio = self.device_pixels_per_page_pixel_not_including_pinch_zoom();
-        let initial_viewport = self.rect.size().to_f32() / device_pixel_ratio;
+        // From <https://www.w3.org/TR/css-viewport-1/#actual-viewport>:
+        // This is the viewport you get after processing the viewport <meta> tag.
+        let layout_viewport = self.rect.size().to_f32() /
+            (device_pixel_ratio * Scale::new(self.viewport_description.initial_scale.get()));
         let _ = self.embedder_to_constellation_sender.send(
             EmbedderToConstellationMessage::ChangeViewportDetails(
                 self.id,
                 ViewportDetails {
                     hidpi_scale_factor: device_pixel_ratio,
-                    size: initial_viewport,
+                    size: layout_viewport,
                 },
                 WindowSizeType::Resize,
             ),
@@ -1085,8 +1088,12 @@ impl WebViewRenderer {
     }
 
     pub fn set_viewport_description(&mut self, viewport_description: ViewportDescription) {
-        self.set_page_zoom(viewport_description.initial_scale);
         self.viewport_description = viewport_description;
+        self.send_window_size_message();
+        self.adjust_pinch_zoom(
+            self.viewport_description.initial_scale.get(),
+            DevicePoint::origin(),
+        );
     }
 
     pub(crate) fn scroll_trees_memory_usage(

--- a/components/servo/tests/webview.rs
+++ b/components/servo/tests/webview.rs
@@ -449,32 +449,52 @@ fn test_page_zoom() {
 }
 
 #[test]
-fn test_viewport_meta_tag_initial_zoom() {
+fn test_viewport_meta_tag_initial_scale() {
     let servo_test = ServoTest::new_with_builder(|builder| {
         let mut preferences = Preferences::default();
         preferences.viewport_meta_enabled = true;
+        preferences.dom_visual_viewport_enabled = true;
         builder.preferences(preferences)
     });
+
+    let initial_scale: f64 = 2.0;
 
     let delegate = Rc::new(WebViewDelegateImpl::default());
     let webview = WebViewBuilder::new(servo_test.servo(), servo_test.rendering_context.clone())
         .delegate(delegate.clone())
         .url(
             Url::parse(
-                "data:text/html,\
+                format!(
+                    "data:text/html,\
                     <!DOCTYPE html>\
-                    <meta name=viewport content=\"initial-scale=5\">",
+                    <meta name=viewport content=\"initial-scale={}\">",
+                    initial_scale
+                )
+                .as_str(),
             )
             .unwrap(),
         )
         .build();
 
-    let load_webview = webview.clone();
-    let _ = servo_test.spin(move || load_webview.load_status() != LoadStatus::Complete);
+    // Initially HiDPI should be 1.0
+    assert_eq!(webview.hidpi_scale_factor().get(), 1.0);
 
-    // Wait for at least one frame after the load completes.
-    delegate.reset();
-    servo_test.spin(move || webview.page_zoom() != 5.0);
+    show_webview_and_wait_for_rendering_to_be_ready(&servo_test, &webview, &delegate);
+
+    // HiDPI should be same after parsing the viewport meta from page.
+    assert_eq!(webview.hidpi_scale_factor().get(), 1.0);
+
+    // devicePixelRatio should be unaffected by Meta Tag.
+    assert_eq!(
+        Ok(JSValue::Number(webview.hidpi_scale_factor().get() as f64)),
+        evaluate_javascript(&servo_test, webview.clone(), "window.devicePixelRatio;")
+    );
+
+    // Meta Tag should affect VisualViewport Scale.
+    assert_eq!(
+        Ok(JSValue::Number(initial_scale)),
+        evaluate_javascript(&servo_test, webview.clone(), "window.visualViewport.scale;")
+    );
 }
 
 #[test]

--- a/tests/wpt/meta/css/css-device-adapt/viewport-clamp-initial-scale-to-max.tentative.html.ini
+++ b/tests/wpt/meta/css/css-device-adapt/viewport-clamp-initial-scale-to-max.tentative.html.ini
@@ -1,3 +1,0 @@
-[viewport-clamp-initial-scale-to-max.tentative.html]
-  [Page with meta viewport "width=device-width, initial-scale=10.0, maximum-scale=2.0" should scale to 2.0.]
-    expected: FAIL

--- a/tests/wpt/meta/css/css-device-adapt/viewport-clamp-initial-scale-to-min.tentative.html.ini
+++ b/tests/wpt/meta/css/css-device-adapt/viewport-clamp-initial-scale-to-min.tentative.html.ini
@@ -1,3 +1,0 @@
-[viewport-clamp-initial-scale-to-min.tentative.html]
-  [Page with meta viewport "width=device-width, initial-scale=1.0, minimum-scale=2.0" should scale to 2.0.]
-    expected: FAIL

--- a/tests/wpt/meta/css/css-device-adapt/viewport-should-not-affect-devicePixelRatio.html.ini
+++ b/tests/wpt/meta/css/css-device-adapt/viewport-should-not-affect-devicePixelRatio.html.ini
@@ -1,3 +1,0 @@
-[viewport-should-not-affect-devicePixelRatio.html]
-  [devicePixelRatio is unaffected by viewport's initial-scale]
-    expected: FAIL


### PR DESCRIPTION
Fixup: #40055

Instead of applying initial scale to page. 
- An `initial-scale` should directly affect the `visualviewport.scale`as it is layer that manages zoom factor https://github.com/w3c/csswg-drafts/issues/9004
- `initial-scale` should be considered with `device_pixel_ratio` while calculating `layout_viewport` as per following spec gudelines.

Specs: 

1. https://drafts.csswg.org/css-viewport/ 
2. https://drafts.csswg.org/cssom-view-1/#visual-viewport

> This specification introduces a way of overriding the size of the viewport provided by the user agent (UA). Because of this, we need to introduce the difference between the initial viewport and the actual viewport.
> 
> _initial viewport_
> This refers to the viewport before any UA or author styles have overridden the viewport given by the window or viewing area of the UA. Note that the initial viewport size will change with the size of the window or viewing area.
> _layout viewport_
> This is the viewport you get after processing the viewport <meta> tag.
> _visual viewport_
> The scale transform of the visual viewport is often referred to as "pinch-zoom". Conceptually, this transform changes the size of the CSS [reference pixel](https://drafts.csswg.org/css-values-4/#reference-pixel) but changes the size of the layout viewport proportionally so that it does not cause reflow of the page’s contents.


Sample Page: [viewport_meta_with_style_2.html](https://github.com/user-attachments/files/26271786/viewport_meta_with_style_2.html)


Testing: `tests/webview.rs`: `test_viewport_meta_tag_initial_scale`

Fixes: #39002