### PR TITLE
ci: Upload ohos nightly with correct path

### DIFF
--- a/.github/workflows/ohos.yml
+++ b/.github/workflows/ohos.yml
@@ -122,7 +122,7 @@ jobs:
         id: upload-library
         with:
           name: ${{ inputs.profile }}-library-ohos-${{ matrix.target }}
-          path: target/aarch64-unknown-linux-ohos/production/libservoshell.so
+          path: target/${{ matrix.target }}/${{ inputs.profile }}/libservoshell.so
           if-no-files-found: error
       - name: Upload signed HAP artifact
         if: ${{ env.SERVO_OHOS_SIGNING_CONFIG != '' }} # Build output has different name if not signed.


### PR DESCRIPTION
#43114 made the action error if the artifact is not found, which exposed an issue with uploading the wrong path. We don't really care about uploading the x86_64 version of the ohos library, since it is not used in the release (not now at least), but it's better to fix the condition anyway.
Fixes nightly upload failures like in https://github.com/servo/servo/actions/runs/22927035640/job/66539862051

Testing: Not tested

