### PR TITLE
devtools: Allow registering environment actor from debugger.js

### DIFF
--- a/components/devtools/actors/environment.rs
+++ b/components/devtools/actors/environment.rs
@@ -2,6 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
+use devtools_traits::EnvironmentInfo;
 use malloc_size_of_derive::MallocSizeOf;
 use serde::Serialize;
 use serde_json::{Map, Value};
@@ -9,22 +10,7 @@ use serde_json::{Map, Value};
 use crate::actor::{Actor, ActorEncode, ActorRegistry};
 use crate::actors::object::ObjectActorMsg;
 
-#[derive(Serialize)]
-#[serde(rename_all = "camelCase")]
-pub enum EnvironmentType {
-    Function,
-    _Block,
-    _Object,
-}
-
-#[derive(Serialize)]
-#[serde(rename_all = "camelCase")]
-pub enum EnvironmentScope {
-    Function,
-    _Global,
-}
-
-#[derive(Serialize)]
+#[derive(Default, Serialize)]
 struct EnvironmentBindings {
     arguments: Vec<Value>,
     variables: Map<String, Value>,
@@ -41,8 +27,8 @@ struct EnvironmentFunction {
 pub(crate) struct EnvironmentActorMsg {
     actor: String,
     #[serde(rename = "type")]
-    type_: EnvironmentType,
-    scope_kind: EnvironmentScope,
+    type_: Option<String>,
+    scope_kind: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     parent: Option<Box<EnvironmentActorMsg>>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -60,13 +46,31 @@ pub(crate) struct EnvironmentActorMsg {
 /// <https://searchfox.org/firefox-main/source/devtools/server/actors/environment.js>
 #[derive(MallocSizeOf)]
 pub(crate) struct EnvironmentActor {
-    pub name: String,
-    pub parent: Option<String>,
+    name: String,
+    environment: EnvironmentInfo,
+    parent: Option<String>,
 }
 
 impl Actor for EnvironmentActor {
     fn name(&self) -> String {
         self.name.clone()
+    }
+}
+
+impl EnvironmentActor {
+    pub fn register(
+        registry: &ActorRegistry,
+        environment: EnvironmentInfo,
+        parent: Option<String>,
+    ) -> String {
+        let name = registry.new_name::<Self>();
+        let actor = Self {
+            name: name.clone(),
+            parent,
+            environment,
+        };
+        registry.register(actor);
+        name
     }
 }
 
@@ -80,11 +84,15 @@ impl ActorEncode<EnvironmentActorMsg> for EnvironmentActor {
         // TODO: Change hardcoded values.
         EnvironmentActorMsg {
             actor: self.name(),
-            type_: EnvironmentType::Function,
-            scope_kind: EnvironmentScope::Function,
+            type_: self.environment.type_.clone(),
+            scope_kind: self.environment.scope_kind.clone(),
             parent,
             bindings: None,
-            function: None,
+            function: self
+                .environment
+                .function_display_name
+                .clone()
+                .map(|display_name| EnvironmentFunction { display_name }),
             object: None,
         }
     }

--- a/components/devtools/actors/frame.rs
+++ b/components/devtools/actors/frame.rs
@@ -3,7 +3,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 use atomic_refcell::AtomicRefCell;
-use devtools_traits::FrameInfo;
+use devtools_traits::{EnvironmentInfo, FrameInfo};
 use malloc_size_of_derive::MallocSizeOf;
 use serde::Serialize;
 use serde_json::{Map, Value};
@@ -79,15 +79,20 @@ impl Actor for FrameActor {
     ) -> Result<(), ActorError> {
         match msg_type {
             "getEnvironment" => {
-                let environment = EnvironmentActor {
-                    name: registry.new_name::<EnvironmentActor>(),
-                    parent: None,
-                };
+                // TODO: Register from debugger.js instead
+                let environment = EnvironmentActor::register(
+                    registry,
+                    EnvironmentInfo {
+                        type_: Some("function".into()),
+                        scope_kind: Some("function".into()),
+                        ..Default::default()
+                    },
+                    None,
+                );
                 let msg = FrameEnvironmentReply {
                     from: self.name(),
-                    environment: environment.encode(registry),
+                    environment: registry.encode::<EnvironmentActor, _>(&environment),
                 };
-                registry.register(environment);
                 // This reply has a `type` field but it doesn't need a followup,
                 // unlike most messages. We need to skip the validity check.
                 request.reply_unchecked(&msg)?;

--- a/components/devtools/lib.rs
+++ b/components/devtools/lib.rs
@@ -24,8 +24,8 @@ use base::id::{BrowsingContextId, PipelineId, WebViewId};
 use crossbeam_channel::{Receiver, Sender, unbounded};
 use devtools_traits::{
     ChromeToDevtoolsControlMsg, ConsoleLogLevel, ConsoleMessage, ConsoleMessageFields,
-    DevtoolScriptControlMsg, DevtoolsControlMsg, DevtoolsPageInfo, DomMutation, FrameInfo,
-    FrameOffset, NavigationState, NetworkEvent, PauseReason, ScriptToDevtoolsControlMsg,
+    DevtoolScriptControlMsg, DevtoolsControlMsg, DevtoolsPageInfo, DomMutation, EnvironmentInfo,
+    FrameInfo, FrameOffset, NavigationState, NetworkEvent, PauseReason, ScriptToDevtoolsControlMsg,
     SourceInfo, WorkerId, get_time_stamp,
 };
 use embedder_traits::{AllowOrDeny, EmbedderMsg, EmbedderProxy};
@@ -42,6 +42,7 @@ use servo_config::pref;
 use crate::actor::{Actor, ActorEncode, ActorError, ActorRegistry};
 use crate::actors::browsing_context::BrowsingContextActor;
 use crate::actors::console::{ConsoleActor, ConsoleResource, DevtoolsConsoleMessage, Root};
+use crate::actors::environment::EnvironmentActor;
 use crate::actors::frame::FrameActor;
 use crate::actors::framerate::FramerateActor;
 use crate::actors::inspector::InspectorActor;
@@ -374,6 +375,13 @@ impl DevtoolsInstance {
                     pipeline_id,
                     frame_info,
                 )) => self.handle_create_frame_actor(result_sender, pipeline_id, frame_info),
+                DevtoolsControlMsg::FromScript(
+                    ScriptToDevtoolsControlMsg::CreateEnvironmentActor(
+                        result_sender,
+                        environment,
+                        parent,
+                    ),
+                ) => self.handle_create_environment_actor(result_sender, environment, parent),
                 DevtoolsControlMsg::FromChrome(ChromeToDevtoolsControlMsg::NetworkEvent(
                     request_id,
                     network_event,
@@ -831,6 +839,17 @@ impl DevtoolsInstance {
 
         let frame = FrameActor::register(actors, source, frame);
 
+        let _ = result_sender.send(frame);
+    }
+
+    fn handle_create_environment_actor(
+        &mut self,
+        result_sender: GenericSender<String>,
+        environment: EnvironmentInfo,
+        parent: Option<String>,
+    ) {
+        let actors = &self.registry;
+        let frame = EnvironmentActor::register(actors, environment, parent);
         let _ = result_sender.send(frame);
     }
 }

--- a/components/script/dom/debuggerglobalscope.rs
+++ b/components/script/dom/debuggerglobalscope.rs
@@ -28,6 +28,7 @@ use script_bindings::str::DOMString;
 use servo_url::{ImmutableOrigin, MutableOrigin, ServoUrl};
 use storage_traits::StorageThreads;
 
+use crate::dom::bindings::codegen::Bindings::DebuggerGetEnvironmentEventBinding::EnvironmentInfo;
 use crate::dom::bindings::codegen::Bindings::DebuggerGlobalScopeBinding;
 use crate::dom::bindings::codegen::Bindings::DebuggerInterruptEventBinding::{
     FrameInfo, FrameOffset, PauseReason,
@@ -564,5 +565,29 @@ impl DebuggerGlobalScopeMethods<crate::DomTypeHolder> for DebuggerGlobalScope {
             .expect("Guaranteed by Self::fire_list_frames()");
 
         let _ = sender.send(frame_actor_ids.into_iter().map(|i| i.into()).collect());
+    }
+
+    fn RegisterEnvironmentActor(
+        &self,
+        environment: &EnvironmentInfo,
+        parent: Option<DOMString>,
+    ) -> Option<DOMString> {
+        let chan = self.upcast::<GlobalScope>().devtools_chan()?;
+        let (tx, rx) = channel::<String>().unwrap();
+
+        let environment = devtools_traits::EnvironmentInfo {
+            type_: environment.type_.clone().map(String::from),
+            scope_kind: environment.scopeKind.clone().map(String::from),
+            function_display_name: environment.functionDisplayName.clone().map(String::from),
+        };
+
+        let msg = ScriptToDevtoolsControlMsg::CreateEnvironmentActor(
+            tx,
+            environment,
+            parent.map(String::from),
+        );
+        let _ = chan.send(msg);
+
+        rx.recv().ok().map(DOMString::from)
     }
 }

--- a/components/script_bindings/webidls/DebuggerGetEnvironmentEvent.webidl
+++ b/components/script_bindings/webidls/DebuggerGetEnvironmentEvent.webidl
@@ -1,0 +1,18 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+// This interface is entirely internal to Servo, and should not be accessible to
+// web pages.
+partial interface DebuggerGlobalScope {
+    DOMString? registerEnvironmentActor(
+        EnvironmentInfo result,
+        DOMString? parent
+    );
+};
+
+dictionary EnvironmentInfo {
+    DOMString type_;
+    DOMString scopeKind;
+    DOMString functionDisplayName;
+};

--- a/components/shared/devtools/lib.rs
+++ b/components/shared/devtools/lib.rs
@@ -137,6 +137,9 @@ pub enum ScriptToDevtoolsControlMsg {
 
     /// Get frame information from script
     CreateFrameActor(GenericSender<String>, PipelineId, FrameInfo),
+
+    /// Get environment information from script
+    CreateEnvironmentActor(GenericSender<String>, EnvironmentInfo, Option<String>),
 }
 
 #[derive(Clone, Debug, Deserialize, MallocSizeOf, Serialize)]
@@ -595,15 +598,20 @@ pub struct RecommendedBreakpointLocation {
 }
 
 #[derive(Clone, Debug, Deserialize, MallocSizeOf, Serialize)]
-#[serde(rename_all = "camelCase")]
 pub struct FrameInfo {
     pub display_name: String,
     pub on_stack: bool,
     pub oldest: bool,
     pub terminated: bool,
-    #[serde(rename = "type")]
     pub type_: String,
     pub url: String,
+}
+
+#[derive(Clone, Debug, Default, Deserialize, MallocSizeOf, Serialize)]
+pub struct EnvironmentInfo {
+    pub type_: Option<String>,
+    pub scope_kind: Option<String>,
+    pub function_display_name: Option<String>,
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize)]

--- a/resources/debugger.js
+++ b/resources/debugger.js
@@ -7,6 +7,7 @@ const debuggeesToPipelineIds = new Map;
 const debuggeesToWorkerIds = new Map;
 const sourceIdsToScripts = new Map;
 const frameActorsToFrames = new Map;
+const environmentActorsToEnvironments = new Map;
 
 // <https://searchfox.org/firefox-main/source/devtools/server/actors/thread.js#155>
 // Possible values for the `why.type` attribute in "paused" event
@@ -386,3 +387,33 @@ addEventListener("clearBreakpoint", event => {
         target.clearAllBreakpoints(offset);
     }
 });
+
+// TODO: Get variables (scopes don't show if they don't have a variable)
+function createEnvironmentActor(environment) {
+    let actor = findKeyByValue(environmentActorsToEnvironments, environment);
+
+    if (!actor) {
+        let info = {};
+        if (environment.type == "declarative") {
+            info.type_ = environment.calleeScript ? "function" : "block";
+        } else {
+            info.type_ = environment.type;
+        }
+
+        info.scopeKind = environment.scopeKind;
+
+        if (environment.calleeScript) {
+            info.functionDisplayName = environment.calleeScript.displayName;
+        }
+
+        let parent = null;
+        if (environment.parent) {
+            parent = createEnvironmentActor(environment.parent);
+        }
+
+        actor = registerEnvironmentActor(info, parent);
+        environmentActorsToEnvironments.set(actor, environment);
+    }
+
+    return actor;
+}


### PR DESCRIPTION
This functionality will be used in a follow up patch to implement the getEnvironment message.

Testing: Check `mach test-devtools` and manual test
Part of: #36027
