### PR TITLE
devtools: Handle `getEnvironment` message

### DIFF
--- a/components/devtools/actors/frame.rs
+++ b/components/devtools/actors/frame.rs
@@ -3,7 +3,8 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 use atomic_refcell::AtomicRefCell;
-use devtools_traits::{EnvironmentInfo, FrameInfo};
+use base::generic_channel::channel;
+use devtools_traits::{DevtoolScriptControlMsg, FrameInfo};
 use malloc_size_of_derive::MallocSizeOf;
 use serde::Serialize;
 use serde_json::{Map, Value};
@@ -12,6 +13,7 @@ use crate::StreamId;
 use crate::actor::{Actor, ActorEncode, ActorError, ActorRegistry};
 use crate::actors::environment::{EnvironmentActor, EnvironmentActorMsg};
 use crate::actors::object::{ObjectActor, ObjectActorMsg};
+use crate::actors::source::SourceActor;
 use crate::protocol::ClientRequest;
 
 #[derive(Serialize)]
@@ -79,16 +81,16 @@ impl Actor for FrameActor {
     ) -> Result<(), ActorError> {
         match msg_type {
             "getEnvironment" => {
-                // TODO: Register from debugger.js instead
-                let environment = EnvironmentActor::register(
-                    registry,
-                    EnvironmentInfo {
-                        type_: Some("function".into()),
-                        scope_kind: Some("function".into()),
-                        ..Default::default()
-                    },
-                    None,
-                );
+                let Some((tx, rx)) = channel() else {
+                    return Err(ActorError::Internal);
+                };
+                let source = registry.find::<SourceActor>(&self.source_actor);
+                source
+                    .script_sender
+                    .send(DevtoolScriptControlMsg::GetEnvironment(self.name(), tx))
+                    .map_err(|_| ActorError::Internal)?;
+                let environment = rx.recv().map_err(|_| ActorError::Internal)?;
+
                 let msg = FrameEnvironmentReply {
                     from: self.name(),
                     environment: registry.encode::<EnvironmentActor, _>(&environment),

--- a/components/script/dom/debuggergetenvironmentevent.rs
+++ b/components/script/dom/debuggergetenvironmentevent.rs
@@ -1,0 +1,59 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+use std::fmt::Debug;
+
+use dom_struct::dom_struct;
+use script_bindings::str::DOMString;
+
+use crate::dom::bindings::codegen::Bindings::DebuggerGetEnvironmentEventBinding::DebuggerGetEnvironmentEventMethods;
+use crate::dom::bindings::codegen::Bindings::EventBinding::Event_Binding::EventMethods;
+use crate::dom::bindings::reflector::reflect_dom_object;
+use crate::dom::bindings::root::DomRoot;
+use crate::dom::event::Event;
+use crate::dom::types::GlobalScope;
+use crate::script_runtime::CanGc;
+
+#[dom_struct]
+/// Event for Rust → JS calls in [`crate::dom::DebuggerGlobalScope`].
+pub(crate) struct DebuggerGetEnvironmentEvent {
+    event: Event,
+    frame_actor_id: DOMString,
+}
+
+impl DebuggerGetEnvironmentEvent {
+    pub(crate) fn new(
+        debugger_global: &GlobalScope,
+        frame_actor_id: DOMString,
+        can_gc: CanGc,
+    ) -> DomRoot<Self> {
+        let result = Box::new(Self {
+            event: Event::new_inherited(),
+            frame_actor_id,
+        });
+        let result = reflect_dom_object(result, debugger_global, can_gc);
+        result
+            .event
+            .init_event("getEnvironment".into(), false, false);
+
+        result
+    }
+}
+
+impl DebuggerGetEnvironmentEventMethods<crate::DomTypeHolder> for DebuggerGetEnvironmentEvent {
+    // check-tidy: no specs after this line
+    fn FrameActorId(&self) -> DOMString {
+        self.frame_actor_id.clone()
+    }
+
+    fn IsTrusted(&self) -> bool {
+        self.event.IsTrusted()
+    }
+}
+
+impl Debug for DebuggerGetEnvironmentEvent {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("DebuggerGetEnvironmentEvent").finish()
+    }
+}

--- a/components/script/dom/debuggerglobalscope.rs
+++ b/components/script/dom/debuggerglobalscope.rs
@@ -38,6 +38,7 @@ use crate::dom::bindings::root::DomRoot;
 use crate::dom::bindings::utils::define_all_exposed_interfaces;
 use crate::dom::debuggerclearbreakpointevent::DebuggerClearBreakpointEvent;
 use crate::dom::debuggerframeevent::DebuggerFrameEvent;
+use crate::dom::debuggergetenvironmentevent::DebuggerGetEnvironmentEvent;
 use crate::dom::debuggerinterruptevent::DebuggerInterruptEvent;
 use crate::dom::debuggerresumeevent::DebuggerResumeEvent;
 use crate::dom::debuggersetbreakpointevent::DebuggerSetBreakpointEvent;
@@ -66,6 +67,8 @@ pub(crate) struct DebuggerGlobalScope {
     eval_result_sender: RefCell<Option<GenericSender<EvaluateJSReply>>>,
     #[no_trace]
     get_list_frame_result_sender: RefCell<Option<GenericSender<Vec<String>>>>,
+    #[no_trace]
+    get_environment_result_sender: RefCell<Option<GenericSender<String>>>,
 }
 
 impl DebuggerGlobalScope {
@@ -113,6 +116,7 @@ impl DebuggerGlobalScope {
             devtools_to_script_sender,
             get_possible_breakpoints_result_sender: RefCell::new(None),
             get_list_frame_result_sender: RefCell::new(None),
+            get_environment_result_sender: RefCell::new(None),
             eval_result_sender: RefCell::new(None),
         });
         let global = DebuggerGlobalScopeBinding::Wrap::<crate::DomTypeHolder>(cx, global);
@@ -276,6 +280,29 @@ impl DebuggerGlobalScope {
         assert!(
             event.fire(self.upcast(), can_gc),
             "Guaranteed by DebuggerFrameEvent::new"
+        );
+    }
+
+    pub(crate) fn fire_get_environment(
+        &self,
+        frame_actor_id: String,
+        result_sender: GenericSender<String>,
+        can_gc: CanGc,
+    ) {
+        assert!(
+            self.get_environment_result_sender
+                .replace(Some(result_sender))
+                .is_none()
+        );
+        let _realm = enter_realm(self);
+        let event = DomRoot::upcast::<Event>(DebuggerGetEnvironmentEvent::new(
+            self.upcast(),
+            frame_actor_id.into(),
+            can_gc,
+        ));
+        assert!(
+            event.fire(self.upcast(), can_gc),
+            "Guaranteed by DebuggerGetEnvironmentEvent::new"
         );
     }
 
@@ -589,5 +616,14 @@ impl DebuggerGlobalScopeMethods<crate::DomTypeHolder> for DebuggerGlobalScope {
         let _ = chan.send(msg);
 
         rx.recv().ok().map(DOMString::from)
+    }
+
+    fn GetEnvironmentResult(&self, environment_actor_id: DOMString) {
+        let sender = self
+            .get_environment_result_sender
+            .take()
+            .expect("Guaranteed by Self::fire_get_environment()");
+
+        let _ = sender.send(environment_actor_id.into());
     }
 }

--- a/components/script/dom/mod.rs
+++ b/components/script/dom/mod.rs
@@ -258,6 +258,7 @@ pub(crate) mod debuggeradddebuggeeevent;
 pub(crate) mod debuggerclearbreakpointevent;
 pub(crate) mod debuggerevalevent;
 pub(crate) mod debuggerframeevent;
+pub(crate) mod debuggergetenvironmentevent;
 pub(crate) mod debuggergetpossiblebreakpointsevent;
 pub(crate) mod debuggerglobalscope;
 pub(crate) mod debuggerinterruptevent;

--- a/components/script/script_thread.rs
+++ b/components/script/script_thread.rs
@@ -2306,6 +2306,13 @@ impl ScriptThread {
                     CanGc::from_cx(cx),
                 );
             },
+            DevtoolScriptControlMsg::GetEnvironment(frame_actor_id, result_sender) => {
+                self.debugger_global.fire_get_environment(
+                    frame_actor_id,
+                    result_sender,
+                    CanGc::from_cx(cx),
+                );
+            },
             DevtoolScriptControlMsg::Resume(resume_limit_type, frame_actor_id) => {
                 self.debugger_global.fire_resume(
                     resume_limit_type,

--- a/components/script_bindings/webidls/DebuggerFrameEvent.webidl
+++ b/components/script_bindings/webidls/DebuggerFrameEvent.webidl
@@ -16,5 +16,3 @@ partial interface DebuggerGlobalScope {
         sequence<DOMString> frameActorId
     );
 };
-
-

--- a/components/script_bindings/webidls/DebuggerGetEnvironmentEvent.webidl
+++ b/components/script_bindings/webidls/DebuggerGetEnvironmentEvent.webidl
@@ -4,10 +4,18 @@
 
 // This interface is entirely internal to Servo, and should not be accessible to
 // web pages.
+[Exposed=DebuggerGlobalScope]
+interface DebuggerGetEnvironmentEvent : Event {
+    readonly attribute DOMString frameActorId;
+};
+
 partial interface DebuggerGlobalScope {
     DOMString? registerEnvironmentActor(
         EnvironmentInfo result,
         DOMString? parent
+    );
+    undefined getEnvironmentResult(
+        DOMString environmentActorId
     );
 };
 

--- a/components/shared/devtools/lib.rs
+++ b/components/shared/devtools/lib.rs
@@ -366,6 +366,7 @@ pub enum DevtoolScriptControlMsg {
     Interrupt,
     Resume(Option<String>, Option<String>),
     ListFrames(PipelineId, u32, u32, GenericSender<Vec<String>>),
+    GetEnvironment(String, GenericSender<String>),
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize, MallocSizeOf)]

--- a/resources/debugger.js
+++ b/resources/debugger.js
@@ -417,3 +417,13 @@ function createEnvironmentActor(environment) {
 
     return actor;
 }
+
+// Get a `Debugger.Environment` instance within which evaluation is taking place.
+// <https://searchfox.org/firefox-main/source/devtools/server/actors/frame.js#109>
+addEventListener("getEnvironment", event => {
+    const {frameActorId} = event;
+    frame = frameActorsToFrames.get(frameActorId);
+
+    const actor = createEnvironmentActor(frame.environment);
+    getEnvironmentResult(actor);
+});


### PR DESCRIPTION
Initial work to support scopes in the debugger. They don't show at the moment since we are not processing variables yet. Depends on #43166.

Testing: Ran `mach test-devtools` and manual testing.
Part of: #36027