### PR TITLE
embedder_traits: Upgrade `InputEventHandled` to `InputEventsHandled` to batch IPC response

### DIFF
--- a/components/constellation/constellation.rs
+++ b/components/constellation/constellation.rs
@@ -132,11 +132,11 @@ use embedder_traits::resources::{self, Resource};
 use embedder_traits::user_contents::{UserContentManagerId, UserContents};
 use embedder_traits::{
     AnimationState, EmbedderControlId, EmbedderControlResponse, EmbedderMsg, EmbedderProxy,
-    FocusSequenceNumber, InputEvent, InputEventAndId, JSValue, JavaScriptEvaluationError,
-    JavaScriptEvaluationId, KeyboardEvent, MediaSessionActionType, MediaSessionEvent,
-    MediaSessionPlaybackState, MouseButton, MouseButtonAction, MouseButtonEvent, NewWebViewDetails,
-    PaintHitTestResult, Theme, ViewportDetails, WebDriverCommandMsg, WebDriverLoadStatus,
-    WebDriverScriptCommand,
+    FocusSequenceNumber, InputEvent, InputEventAndId, InputEventOutcome, JSValue,
+    JavaScriptEvaluationError, JavaScriptEvaluationId, KeyboardEvent, MediaSessionActionType,
+    MediaSessionEvent, MediaSessionPlaybackState, MouseButton, MouseButtonAction, MouseButtonEvent,
+    NewWebViewDetails, PaintHitTestResult, Theme, ViewportDetails, WebDriverCommandMsg,
+    WebDriverLoadStatus, WebDriverScriptCommand,
 };
 use euclid::Size2D;
 use euclid::default::Size2D as UntypedSize2D;
@@ -3079,10 +3079,12 @@ where
         let event_id = event.id;
         let Some(webview) = self.webviews.get_mut(&webview_id) else {
             warn!("Got input event for unknown WebViewId: {webview_id:?}");
-            self.embedder_proxy.send(EmbedderMsg::InputEventHandled(
+            self.embedder_proxy.send(EmbedderMsg::InputEventsHandled(
                 webview_id,
-                event_id,
-                Default::default(),
+                vec![InputEventOutcome {
+                    id: event_id,
+                    result: Default::default(),
+                }],
             ));
             return;
         };
@@ -3095,10 +3097,12 @@ where
         };
 
         if !webview.forward_input_event(event, &self.pipelines, &self.browsing_contexts) {
-            self.embedder_proxy.send(EmbedderMsg::InputEventHandled(
+            self.embedder_proxy.send(EmbedderMsg::InputEventsHandled(
                 webview_id,
-                event_id,
-                Default::default(),
+                vec![InputEventOutcome {
+                    id: event_id,
+                    result: Default::default(),
+                }],
             ));
         }
     }

--- a/components/script/dom/document_event_handler.rs
+++ b/components/script/dom/document_event_handler.rs
@@ -13,7 +13,7 @@ use std::time::{Duration, Instant};
 use base::generic_channel::GenericCallback;
 use constellation_traits::{KeyboardScroll, ScriptToConstellationMessage};
 use embedder_traits::{
-    Cursor, EditingActionEvent, EmbedderMsg, ImeEvent, InputEvent, InputEventAndId,
+    Cursor, EditingActionEvent, EmbedderMsg, ImeEvent, InputEvent, InputEventOutcome,
     InputEventResult, KeyboardEvent as EmbedderKeyboardEvent, MouseButton, MouseButtonAction,
     MouseButtonEvent, MouseLeftViewportEvent, TouchEvent as EmbedderTouchEvent, TouchEventType,
     TouchId, UntrustedNodeAddress, WheelEvent as EmbedderWheelEvent,
@@ -276,7 +276,7 @@ impl DocumentEventHandler {
         *self.mouse_move_event_index.borrow_mut() = None;
         *self.wheel_event_index.borrow_mut() = None;
         let pending_input_events = mem::take(&mut *self.pending_input_events.borrow_mut());
-
+        let mut input_event_outcomes = Vec::with_capacity(pending_input_events.len());
         for event in pending_input_events {
             self.active_keyboard_modifiers
                 .set(event.active_keyboard_modifiers);
@@ -319,18 +319,22 @@ impl DocumentEventHandler {
                 },
             };
 
-            self.notify_embedder_that_event_was_handled(event.event, result);
+            input_event_outcomes.push(InputEventOutcome {
+                id: event.event.id,
+                result,
+            });
+        }
+        if !input_event_outcomes.is_empty() {
+            self.notify_embedder_that_events_were_handled(input_event_outcomes);
         }
     }
 
-    fn notify_embedder_that_event_was_handled(
+    fn notify_embedder_that_events_were_handled(
         &self,
-        event: InputEventAndId,
-        result: InputEventResult,
+        input_event_outcomes: Vec<InputEventOutcome>,
     ) {
-        // Wait to to notify the embedder that the vent was handled until all pending DOM
+        // Wait to to notify the embedder that the event was handled until all pending DOM
         // event processing is finished.
-        let id = event.id;
         let trusted_window = Trusted::new(&*self.window);
         self.window
             .as_global_scope()
@@ -339,7 +343,7 @@ impl DocumentEventHandler {
             .queue(task!(notify_webdriver_input_event_completed: move || {
                 let window = trusted_window.root();
                 window.send_to_embedder(
-                    EmbedderMsg::InputEventHandled(window.webview_id(), id, result));
+                    EmbedderMsg::InputEventsHandled(window.webview_id(), input_event_outcomes));
             }));
     }
 

--- a/components/script/dom/document_event_handler.rs
+++ b/components/script/dom/document_event_handler.rs
@@ -276,54 +276,55 @@ impl DocumentEventHandler {
         *self.mouse_move_event_index.borrow_mut() = None;
         *self.wheel_event_index.borrow_mut() = None;
         let pending_input_events = mem::take(&mut *self.pending_input_events.borrow_mut());
-        let mut input_event_outcomes = Vec::with_capacity(pending_input_events.len());
-        for event in pending_input_events {
-            self.active_keyboard_modifiers
-                .set(event.active_keyboard_modifiers);
+        let input_event_outcomes: Vec<InputEventOutcome> = pending_input_events
+            .into_iter()
+            .map(|event| {
+                self.active_keyboard_modifiers
+                    .set(event.active_keyboard_modifiers);
+                // TODO: For some of these we still aren't properly calculating whether or not
+                // the event was handled or if `preventDefault()` was called on it. Each of
+                // these cases needs to be examined and some of them either fire more than one
+                // event or fire events later. We have to make a good decision about what to
+                // return to the embedder when that happens.
+                let result = match event.event.event.clone() {
+                    InputEvent::MouseButton(mouse_button_event) => {
+                        self.handle_native_mouse_button_event(mouse_button_event, &event, can_gc);
+                        InputEventResult::default()
+                    },
+                    InputEvent::MouseMove(_) => {
+                        self.handle_native_mouse_move_event(&event, can_gc);
+                        InputEventResult::default()
+                    },
+                    InputEvent::MouseLeftViewport(mouse_leave_event) => {
+                        self.handle_mouse_left_viewport_event(&event, &mouse_leave_event, can_gc);
+                        InputEventResult::default()
+                    },
+                    InputEvent::Touch(touch_event) => {
+                        self.handle_touch_event(touch_event, &event, can_gc)
+                    },
+                    InputEvent::Wheel(wheel_event) => {
+                        self.handle_wheel_event(wheel_event, &event, can_gc)
+                    },
+                    InputEvent::Keyboard(keyboard_event) => {
+                        self.handle_keyboard_event(keyboard_event, can_gc)
+                    },
+                    InputEvent::Ime(ime_event) => self.handle_ime_event(ime_event, can_gc),
+                    #[cfg(feature = "gamepad")]
+                    InputEvent::Gamepad(gamepad_event) => {
+                        self.handle_gamepad_event(gamepad_event);
+                        InputEventResult::default()
+                    },
+                    InputEvent::EditingAction(editing_action_event) => {
+                        self.handle_editing_action(None, editing_action_event, can_gc)
+                    },
+                };
 
-            // TODO: For some of these we still aren't properly calculating whether or not
-            // the event was handled or if `preventDefault()` was called on it. Each of
-            // these cases needs to be examined and some of them either fire more than one
-            // event or fire events later. We have to make a good decision about what to
-            // return to the embedder when that happens.
-            let result = match event.event.event.clone() {
-                InputEvent::MouseButton(mouse_button_event) => {
-                    self.handle_native_mouse_button_event(mouse_button_event, &event, can_gc);
-                    InputEventResult::default()
-                },
-                InputEvent::MouseMove(_) => {
-                    self.handle_native_mouse_move_event(&event, can_gc);
-                    InputEventResult::default()
-                },
-                InputEvent::MouseLeftViewport(mouse_leave_event) => {
-                    self.handle_mouse_left_viewport_event(&event, &mouse_leave_event, can_gc);
-                    InputEventResult::default()
-                },
-                InputEvent::Touch(touch_event) => {
-                    self.handle_touch_event(touch_event, &event, can_gc)
-                },
-                InputEvent::Wheel(wheel_event) => {
-                    self.handle_wheel_event(wheel_event, &event, can_gc)
-                },
-                InputEvent::Keyboard(keyboard_event) => {
-                    self.handle_keyboard_event(keyboard_event, can_gc)
-                },
-                InputEvent::Ime(ime_event) => self.handle_ime_event(ime_event, can_gc),
-                #[cfg(feature = "gamepad")]
-                InputEvent::Gamepad(gamepad_event) => {
-                    self.handle_gamepad_event(gamepad_event);
-                    InputEventResult::default()
-                },
-                InputEvent::EditingAction(editing_action_event) => {
-                    self.handle_editing_action(None, editing_action_event, can_gc)
-                },
-            };
-
-            input_event_outcomes.push(InputEventOutcome {
-                id: event.event.id,
-                result,
-            });
-        }
+                InputEventOutcome {
+                    id: event.event.id,
+                    result,
+                }
+            })
+            .collect();
         if !input_event_outcomes.is_empty() {
             self.notify_embedder_that_events_were_handled(input_event_outcomes);
         }

--- a/components/script/script_thread.rs
+++ b/components/script/script_thread.rs
@@ -54,8 +54,8 @@ use devtools_traits::{
 use embedder_traits::user_contents::{UserContentManagerId, UserContents, UserScript};
 use embedder_traits::{
     EmbedderControlId, EmbedderControlResponse, EmbedderMsg, FocusSequenceNumber,
-    JavaScriptEvaluationError, JavaScriptEvaluationId, MediaSessionActionType, Theme,
-    ViewportDetails, WebDriverScriptCommand,
+    InputEventOutcome, JavaScriptEvaluationError, JavaScriptEvaluationId, MediaSessionActionType,
+    Theme, ViewportDetails, WebDriverScriptCommand,
 };
 use encoding_rs::Encoding;
 use fonts::{FontContext, SystemFontServiceProxy};
@@ -3717,10 +3717,12 @@ impl ScriptThread {
             let _ = self
                 .senders
                 .pipeline_to_embedder_sender
-                .send(EmbedderMsg::InputEventHandled(
+                .send(EmbedderMsg::InputEventsHandled(
                     webview_id,
-                    event.event.id,
-                    Default::default(),
+                    vec![InputEventOutcome {
+                        id: event.event.id,
+                        result: Default::default(),
+                    }],
                 ));
             return;
         };

--- a/components/servo/servo.rs
+++ b/components/servo/servo.rs
@@ -458,17 +458,25 @@ impl ServoInner {
                     .borrow_mut()
                     .finish_evaluation(evaluation_id, result);
             },
-            EmbedderMsg::InputEventHandled(webview_id, input_event_id, result) => {
-                self.paint.borrow_mut().notify_input_event_handled(
-                    webview_id,
-                    input_event_id,
+            EmbedderMsg::InputEventsHandled(webview_id, event_outcomes) => {
+                let webview = self.get_webview_handle(webview_id);
+                for InputEventOutcome {
+                    id: input_event_id,
                     result,
-                );
-
-                if let Some(webview) = self.get_webview_handle(webview_id) {
-                    webview
-                        .delegate()
-                        .notify_input_event_handled(webview, input_event_id, result);
+                } in event_outcomes
+                {
+                    self.paint.borrow_mut().notify_input_event_handled(
+                        webview_id,
+                        input_event_id,
+                        result,
+                    );
+                    if let Some(ref webview) = webview {
+                        webview.delegate().notify_input_event_handled(
+                            webview.clone(),
+                            input_event_id,
+                            result,
+                        );
+                    }
                 }
             },
             EmbedderMsg::ClearClipboard(webview_id) => {

--- a/components/shared/embedder/input_events.rs
+++ b/components/shared/embedder/input_events.rs
@@ -36,6 +36,12 @@ bitflags! {
     }
 }
 
+#[derive(Deserialize, Serialize)]
+pub struct InputEventOutcome {
+    pub id: InputEventId,
+    pub result: InputEventResult,
+}
+
 /// An input event that is sent from the embedder to Servo.
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub enum InputEvent {

--- a/components/shared/embedder/lib.rs
+++ b/components/shared/embedder/lib.rs
@@ -515,7 +515,7 @@ pub enum EmbedderMsg {
     ),
     /// Inform the embedding layer that a particular `InputEvent` was handled by Servo
     /// and the embedder can continue processing it, if necessary.
-    InputEventHandled(WebViewId, InputEventId, InputEventResult),
+    InputEventsHandled(WebViewId, Vec<InputEventOutcome>),
     /// Send the embedder an accessibility tree update.
     AccessibilityTreeUpdate(WebViewId, accesskit::TreeUpdate),
 }

--- a/components/webdriver_server/actions.rs
+++ b/components/webdriver_server/actions.rs
@@ -708,7 +708,7 @@ impl Handler {
         // Step 9.1. Asynchronously wait for an implementation defined amount of time to pass.
         // Step 9.2. Perform a pointer move with arguments input state,
         // duration, start x, start y, target x, target y.
-        // This is done in `fn process_pending_pointer_moves`.
+        // This is done in `fn process_pending_actions`.
 
         // NOTE: The initial pointer movement is performed synchronously.
         // This ensures determinism in the sequence of the first event


### PR DESCRIPTION
We send back input events handling results in batch. This reduces IPC,
and make the following **TODO** possible in a follow-up.

Testing: I hope existing tests results won't change.
Part of https://github.com/servo/servo/issues/43136#issuecomment-4031915873
**TODO**: We have not done 
> collect ids and send back a reply for each of them once the coalesced event has been handled.

yet.