### PR TITLE
Fix `-p servo` lib target build (and fix CI check accordingly)

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -288,7 +288,7 @@ jobs:
           # We can remove this after upgrading to Rust 1.90, where lld will be the default.
           RUSTFLAGS: "-C link-arg=-fuse-ld=lld"
         run: |
-          cargo +${{ steps.msrv.outputs.rust_version }} build -p servo --locked --all-targets
+          cargo +${{ steps.msrv.outputs.rust_version }} build -p servo --locked
 
   # Runs the underlying job (“workload”) on a self-hosted runner if available.
   runner-select-coverage:

--- a/.github/workflows/mac-arm64.yml
+++ b/.github/workflows/mac-arm64.yml
@@ -249,4 +249,4 @@ jobs:
           toolchain: ${{ steps.msrv.outputs.rust_version }}
       - name: Compile libservo with MSRV
         run: |
-          cargo +${{ steps.msrv.outputs.rust_version }} build -p servo --locked --all-targets
+          cargo +${{ steps.msrv.outputs.rust_version }} build -p servo --locked

--- a/.github/workflows/mac.yml
+++ b/.github/workflows/mac.yml
@@ -257,4 +257,4 @@ jobs:
           toolchain: ${{ steps.msrv.outputs.rust_version }}
       - name: Compile libservo with MSRV
         run: |
-          cargo +${{ steps.msrv.outputs.rust_version }} build -p servo --locked --all-targets
+          cargo +${{ steps.msrv.outputs.rust_version }} build -p servo --locked

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -266,4 +266,4 @@ jobs:
           toolchain: ${{ steps.msrv.outputs.rust_version }}
       - name: Compile libservo with MSRV
         run: |
-          cargo +${{ steps.msrv.outputs.rust_version }} build -p servo --locked --all-targets
+          cargo +${{ steps.msrv.outputs.rust_version }} build -p servo --locked

--- a/components/net/Cargo.toml
+++ b/components/net/Cargo.toml
@@ -61,7 +61,7 @@ quick_cache = { version = "0.6.18", default-features = false, features = ["ahash
 regex = { workspace = true }
 resvg = { workspace = true }
 rustc-hash = { workspace = true }
-rustls = { workspace = true }
+rustls = { workspace = true, features = ["aws-lc-rs"] }
 rustls-pki-types = { workspace = true }
 rustls-platform-verifier = { workspace = true }
 serde = { workspace = true }

--- a/components/servo/Cargo.toml
+++ b/components/servo/Cargo.toml
@@ -151,7 +151,7 @@ http-body-util = { workspace = true }
 hyper = { workspace = true }
 servo = { path = ".", features = ["tracing"] }
 net = { package = "servo-net", path = "../net", features = ["test-util"] }
-rustls = { version = "0.23", default-features = false, features = ["aws-lc-rs"] }
+rustls = { version = "0.23", default-features = false }
 tracing = { workspace = true }
 winit = { workspace = true }
 


### PR DESCRIPTION
the `-p servo` (formerly libservo) lib target was busted for anyone genuinely consuming it as a library, but we didn’t catch it because the CI job designed to check it built `-p servo` with --all-targets, which unlike library consumers pulls in [dev-dependencies].

this patch fixes the compile error, and fixes the CI check to build `-p servo` in a more realistic configuration.

Testing: tested in CI, and locally with `cargo build -p servo --locked`
Fixes: #43168 
