### PR TITLE
[WIP] Implement overlay scrollbar 

### DIFF
--- a/components/config/prefs.rs
+++ b/components/config/prefs.rs
@@ -289,6 +289,8 @@ pub struct Preferences {
     /// default), then `rustls-platform-verifier` will be used, except on Android where
     /// `rust-webpki` is always used.
     pub network_use_webpki_roots: bool,
+    /// Whether the overlay scrollbar is enabled or not.
+    pub overlay_scrollbar_enabled: bool,
     /// The length of the session history, in navigations, for each `WebView. Back-forward
     /// cache entries that are more than `session_history_max_length` steps in the future or
     /// `session_history_max_length` steps in the past will be discarded. Navigating forward
@@ -470,6 +472,7 @@ impl Preferences {
             network_local_directory_listing_enabled: true,
             network_use_webpki_roots: false,
             session_history_max_length: 20,
+            overlay_scrollbar_enabled: false,
             shell_background_color_rgba: [1.0, 1.0, 1.0, 1.0],
             threadpools_async_runtime_workers_max: 6,
             threadpools_fallback_worker_num: 3,

--- a/components/layout/display_list/hit_test.rs
+++ b/components/layout/display_list/hit_test.rs
@@ -309,7 +309,7 @@ impl Fragment {
                     box_fragment.border_radius(),
                     box_fragment.base.flags,
                     Cursor::Default,
-                )
+                ) // MYTODO: also add hit test for scrollbar here.
             },
             Fragment::Text(text) => {
                 let text = &*text.borrow();

--- a/components/layout/display_list/hit_test.rs
+++ b/components/layout/display_list/hit_test.rs
@@ -125,6 +125,8 @@ impl StackingContext {
     fn hit_test(&self, hit_test: &mut HitTest) -> bool {
         let mut contents = self.contents.iter().rev().peekable();
 
+        // MYTODO: also add hit test for scrollbar here.
+
         // Step 10: Outlines
         // We only use `StackingContextSection::Outline` as an override when building the
         // display list. So we shouldn't encounter it here.
@@ -309,7 +311,7 @@ impl Fragment {
                     box_fragment.border_radius(),
                     box_fragment.base.flags,
                     Cursor::Default,
-                ) // MYTODO: also add hit test for scrollbar here.
+                )
             },
             Fragment::Text(text) => {
                 let text = &*text.borrow();

--- a/components/layout/display_list/mod.rs
+++ b/components/layout/display_list/mod.rs
@@ -1263,7 +1263,6 @@ impl<'a> BuilderForBoxFragment<'a> {
         self.build_border(builder);
     }
 
-    // MYTODO update this to include scrollnodeId
     fn build_scroll_bar(
         &self,
         builder: &mut DisplayListBuilder,

--- a/components/layout/display_list/mod.rs
+++ b/components/layout/display_list/mod.rs
@@ -31,7 +31,7 @@ use style::properties::longhands::visibility::computed_value::T as Visibility;
 use style::properties::style_structs::Border;
 use style::values::computed::{
     BorderImageSideWidth, BorderImageWidth, BorderStyle, LengthPercentage,
-    NonNegativeLengthOrNumber, NumberOrPercentage, OutlineStyle,
+    NonNegativeLengthOrNumber, NumberOrPercentage, OutlineStyle, Overflow,
 };
 use style::values::generics::NonNegative;
 use style::values::generics::color::ColorOrAuto;
@@ -622,6 +622,7 @@ impl Fragment {
         is_hit_test_for_scrollable_overflow: bool,
         is_collapsed_table_borders: bool,
         text_decorations: &Arc<Vec<FragmentTextDecoration>>,
+        scrollbar_descriptor: &Option<Box<ScrollbarDescriptor>>,
     ) {
         if let Some(mut base) = self.base_mut() {
             match base.status {
@@ -659,6 +660,7 @@ impl Fragment {
                         containing_block,
                         is_hit_test_for_scrollable_overflow,
                         is_collapsed_table_borders,
+                        scrollbar_descriptor.as_deref(),
                     )
                     .build(builder, section),
                     Visibility::Hidden => (),
@@ -1110,6 +1112,7 @@ struct BuilderForBoxFragment<'a> {
     content_edge_clip_chain_id: RefCell<Option<ClipChainId>>,
     is_hit_test_for_scrollable_overflow: bool,
     is_collapsed_table_borders: bool,
+    scrollbar_descriptor: Option<&'a ScrollbarDescriptor>,
 }
 
 impl<'a> BuilderForBoxFragment<'a> {
@@ -1118,6 +1121,7 @@ impl<'a> BuilderForBoxFragment<'a> {
         containing_block: &'a PhysicalRect<Au>,
         is_hit_test_for_scrollable_overflow: bool,
         is_collapsed_table_borders: bool,
+        scrollbar_descriptor: Option<&'a ScrollbarDescriptor>,
     ) -> Self {
         let border_rect = fragment
             .border_rect()
@@ -1135,6 +1139,7 @@ impl<'a> BuilderForBoxFragment<'a> {
             content_edge_clip_chain_id: RefCell::new(None),
             is_hit_test_for_scrollable_overflow,
             is_collapsed_table_borders,
+            scrollbar_descriptor,
         }
     }
 
@@ -1239,6 +1244,11 @@ impl<'a> BuilderForBoxFragment<'a> {
             return;
         }
 
+        if let Some(scorllbar_descriptor) = self.scrollbar_descriptor {
+            self.build_scroll_bar(builder, scorllbar_descriptor);
+            return;
+        }
+
         if self
             .fragment
             .base
@@ -1251,6 +1261,31 @@ impl<'a> BuilderForBoxFragment<'a> {
         self.build_background(builder);
         self.build_box_shadow(builder);
         self.build_border(builder);
+    }
+
+    // MYTODO update this to include scrollnodeId
+    fn build_scroll_bar(
+        &self,
+        builder: &mut DisplayListBuilder,
+        scrollbar_descriptor: &ScrollbarDescriptor,
+    ) {
+        let style = &self.fragment.base.style();
+        let SCROLLBAR_COLOR = AbsoluteColor::srgb_legacy(169, 169, 169, 0.7f32);
+
+        if let Some(horizontal_thumb) = scrollbar_descriptor.horizontal_thumb {
+            println!("horizontal_thumb: {:?}", horizontal_thumb);
+            let commons = builder.common_properties(horizontal_thumb, style);
+            builder
+                .wr()
+                .push_rect(&commons, horizontal_thumb, rgba(SCROLLBAR_COLOR))
+        }
+        if let Some(vertical_thumb) = scrollbar_descriptor.vertical_thumb {
+            println!("vertical_thumb: {:?}", vertical_thumb);
+            let commons = builder.common_properties(vertical_thumb, style);
+            builder
+                .wr()
+                .push_rect(&commons, vertical_thumb, rgba(SCROLLBAR_COLOR))
+        }
     }
 
     fn build_hit_test(&self, builder: &mut DisplayListBuilder, rect: LayoutRect) {

--- a/components/layout/display_list/mod.rs
+++ b/components/layout/display_list/mod.rs
@@ -31,7 +31,7 @@ use style::properties::longhands::visibility::computed_value::T as Visibility;
 use style::properties::style_structs::Border;
 use style::values::computed::{
     BorderImageSideWidth, BorderImageWidth, BorderStyle, LengthPercentage,
-    NonNegativeLengthOrNumber, NumberOrPercentage, OutlineStyle, Overflow,
+    NonNegativeLengthOrNumber, NumberOrPercentage, OutlineStyle,
 };
 use style::values::generics::NonNegative;
 use style::values::generics::color::ColorOrAuto;
@@ -622,7 +622,7 @@ impl Fragment {
         is_hit_test_for_scrollable_overflow: bool,
         is_collapsed_table_borders: bool,
         text_decorations: &Arc<Vec<FragmentTextDecoration>>,
-        scrollbar_descriptor: &Option<Box<ScrollbarDescriptor>>,
+        scrollbar_slider: &Option<Box<ScrollbarSlider>>,
     ) {
         if let Some(mut base) = self.base_mut() {
             match base.status {
@@ -660,7 +660,7 @@ impl Fragment {
                         containing_block,
                         is_hit_test_for_scrollable_overflow,
                         is_collapsed_table_borders,
-                        scrollbar_descriptor.as_deref(),
+                        scrollbar_slider.as_deref(),
                     )
                     .build(builder, section),
                     Visibility::Hidden => (),
@@ -1112,7 +1112,7 @@ struct BuilderForBoxFragment<'a> {
     content_edge_clip_chain_id: RefCell<Option<ClipChainId>>,
     is_hit_test_for_scrollable_overflow: bool,
     is_collapsed_table_borders: bool,
-    scrollbar_descriptor: Option<&'a ScrollbarDescriptor>,
+    scrollbar_slider: Option<&'a ScrollbarSlider>,
 }
 
 impl<'a> BuilderForBoxFragment<'a> {
@@ -1121,7 +1121,7 @@ impl<'a> BuilderForBoxFragment<'a> {
         containing_block: &'a PhysicalRect<Au>,
         is_hit_test_for_scrollable_overflow: bool,
         is_collapsed_table_borders: bool,
-        scrollbar_descriptor: Option<&'a ScrollbarDescriptor>,
+        scrollbar_slider: Option<&'a ScrollbarSlider>,
     ) -> Self {
         let border_rect = fragment
             .border_rect()
@@ -1139,7 +1139,7 @@ impl<'a> BuilderForBoxFragment<'a> {
             content_edge_clip_chain_id: RefCell::new(None),
             is_hit_test_for_scrollable_overflow,
             is_collapsed_table_borders,
-            scrollbar_descriptor,
+            scrollbar_slider,
         }
     }
 
@@ -1244,8 +1244,8 @@ impl<'a> BuilderForBoxFragment<'a> {
             return;
         }
 
-        if let Some(scorllbar_descriptor) = self.scrollbar_descriptor {
-            self.build_scroll_bar(builder, scorllbar_descriptor);
+        if let Some(scrollbar_descriptor) = self.scrollbar_slider {
+            self.build_scroll_bar(builder, scrollbar_descriptor);
             return;
         }
 
@@ -1267,25 +1267,19 @@ impl<'a> BuilderForBoxFragment<'a> {
     fn build_scroll_bar(
         &self,
         builder: &mut DisplayListBuilder,
-        scrollbar_descriptor: &ScrollbarDescriptor,
+        scrollbar_slider: &ScrollbarSlider,
     ) {
         let style = &self.fragment.base.style();
         let SCROLLBAR_COLOR = AbsoluteColor::srgb_legacy(169, 169, 169, 0.7f32);
 
-        if let Some(horizontal_thumb) = scrollbar_descriptor.horizontal_thumb {
-            println!("horizontal_thumb: {:?}", horizontal_thumb);
-            let commons = builder.common_properties(horizontal_thumb, style);
-            builder
-                .wr()
-                .push_rect(&commons, horizontal_thumb, rgba(SCROLLBAR_COLOR))
-        }
-        if let Some(vertical_thumb) = scrollbar_descriptor.vertical_thumb {
-            println!("vertical_thumb: {:?}", vertical_thumb);
-            let commons = builder.common_properties(vertical_thumb, style);
-            builder
-                .wr()
-                .push_rect(&commons, vertical_thumb, rgba(SCROLLBAR_COLOR))
-        }
+        // Because scroll node offset's move in an opposite direction we need to offset the scrollbar position.
+        let scrollable_size = scrollbar_slider.track.size() - scrollbar_slider.thumb.size();
+        let scrollbar_thumb_rect = scrollbar_slider.thumb.translate(scrollable_size.to_vector());
+
+        let commons = builder.common_properties(scrollbar_slider.track, style);
+        builder
+            .wr()
+            .push_rect(&commons, scrollbar_thumb_rect, rgba(SCROLLBAR_COLOR))
     }
 
     fn build_hit_test(&self, builder: &mut DisplayListBuilder, rect: LayoutRect) {

--- a/components/layout/display_list/mod.rs
+++ b/components/layout/display_list/mod.rs
@@ -1245,7 +1245,7 @@ impl<'a> BuilderForBoxFragment<'a> {
         }
 
         if let Some(scrollbar_descriptor) = self.scrollbar_slider {
-            self.build_scroll_bar(builder, scrollbar_descriptor);
+            self.build_scrollbar(builder, scrollbar_descriptor);
             return;
         }
 
@@ -1263,7 +1263,7 @@ impl<'a> BuilderForBoxFragment<'a> {
         self.build_border(builder);
     }
 
-    fn build_scroll_bar(
+    fn build_scrollbar(
         &self,
         builder: &mut DisplayListBuilder,
         scrollbar_slider: &ScrollbarSlider,
@@ -1273,7 +1273,9 @@ impl<'a> BuilderForBoxFragment<'a> {
 
         // Because scroll node offset's move in an opposite direction we need to offset the scrollbar position.
         let scrollable_size = scrollbar_slider.track.size() - scrollbar_slider.thumb.size();
-        let scrollbar_thumb_rect = scrollbar_slider.thumb.translate(scrollable_size.to_vector());
+        let scrollbar_thumb_rect = scrollbar_slider
+            .thumb
+            .translate(scrollable_size.to_vector());
 
         let commons = builder.common_properties(scrollbar_slider.track, style);
         builder

--- a/components/layout/display_list/stacking_context.rs
+++ b/components/layout/display_list/stacking_context.rs
@@ -12,7 +12,7 @@ use base::id::ScrollTreeNodeId;
 use base::print_tree::PrintTree;
 use embedder_traits::ViewportDetails;
 use euclid::{Point2D, Rect, SideOffsets2D, Size2D};
-use layout_api::{AxesOverflow, FragmentType, combine_id_with_fragment_type};
+use layout_api::{AxesOverflow, AuxiliaryFragmentType};
 use log::warn;
 use malloc_size_of_derive::MallocSizeOf;
 use paint_api::display_list::{
@@ -1811,7 +1811,7 @@ impl BoxFragment {
         })
     }
 
-    /// Need to define axes scroll sensitivity well for scrollbar
+    /// MYTODO: Need to define axes scroll sensitivity well for scrollbar
     fn build_scrollbar_if_necessary(
         &self,
         stacking_context_tree: &mut StackingContextTree,
@@ -1823,13 +1823,26 @@ impl BoxFragment {
     ) -> Option<Box<ScrollbarDescriptor>> {
         let padding_rect = self.padding_rect();
         let scrollable_overflow_size = self.scrollable_overflow().size;
-        let tag = self.base.tag?;
 
-        let vertical_slider = if ScrollbarDescriptor::should_render_vertical_scrollbar(
+        let render_horizontal_scrollbar = ScrollbarDescriptor::should_render_horizontal_scrollbar(
             overflow,
             &padding_rect,
             &scrollable_overflow_size,
-        ) {
+        );
+        let render_vertical_scrollbar = ScrollbarDescriptor::should_render_vertical_scrollbar(
+            overflow,
+            &padding_rect,
+            &scrollable_overflow_size,
+        );
+
+        if !render_horizontal_scrollbar && !render_vertical_scrollbar {
+            return None;
+        }
+
+        let tag = self.base.tag?;
+
+        // MYTODO: Maybe make a function to compute both of these.
+        let vertical_slider = if render_vertical_scrollbar {
             let (vertical_thumb, vertical_track, vertical_overflow_rect) =
                 ScrollbarDescriptor::place_vertical_scrollbar(
                     &padding_rect,
@@ -1838,16 +1851,18 @@ impl BoxFragment {
                 );
 
             let external_scroll_id = wr::ExternalScrollId(
-                combine_id_with_fragment_type(tag.node.id(), FragmentType::VerticalScrollbar),
+                tag.to_display_list_fragment_id_for_aux(AuxiliaryFragmentType::VerticalScrollbar),
                 stacking_context_tree.paint_info.pipeline_id,
             );
+            // The initial scroll offset of a scrollbar fragment should be reverse to the initial offset of scroll container.
+            let initial_offset = (vertical_overflow_rect.size() - vertical_track.size()).to_vector();
 
             let vertical_scroll_tree_node_id = stacking_context_tree.define_scroll_frame(
                 parent_scroll_node_id,
                 external_scroll_id,
                 vertical_overflow_rect,
                 vertical_track,
-                (vertical_overflow_rect.size() - vertical_track.size()).to_vector(), // MYTODO: maybe tidy up this
+                initial_offset,
                 *sensitivity,
             );
 
@@ -1860,11 +1875,7 @@ impl BoxFragment {
             None
         };
 
-        let horizontal_slider = if ScrollbarDescriptor::should_render_horizontal_scrollbar(
-            overflow,
-            &padding_rect,
-            &scrollable_overflow_size,
-        ) {
+        let horizontal_slider = if render_horizontal_scrollbar {
             let (horizontal_thumb, horizontal_track, horizontal_overflow_rect) =
                 ScrollbarDescriptor::place_horizontal_scrollbar(
                     &padding_rect,
@@ -1873,16 +1884,18 @@ impl BoxFragment {
                 );
 
             let external_scroll_id = wr::ExternalScrollId(
-                combine_id_with_fragment_type(tag.node.id(), FragmentType::HorizontalScrollbar),
+                tag.to_display_list_fragment_id_for_aux(AuxiliaryFragmentType::HorizontalScrollbar),
                 stacking_context_tree.paint_info.pipeline_id,
             );
+            // The initial scroll offset of a scrollbar fragment should be reverse to the initial offset of scroll container.
+            let initial_offset = (horizontal_overflow_rect.size() - horizontal_track.size()).to_vector();
 
             let horizontal_scroll_tree_node_id = stacking_context_tree.define_scroll_frame(
                 parent_scroll_node_id,
                 external_scroll_id,
                 horizontal_overflow_rect,
                 horizontal_track,
-                (horizontal_overflow_rect.size() - horizontal_track.size()).to_vector(), // MYTODO: maybe tidy up this
+                initial_offset,
                 *sensitivity,
             );
 

--- a/components/layout/display_list/stacking_context.rs
+++ b/components/layout/display_list/stacking_context.rs
@@ -16,8 +16,7 @@ use layout_api::{AuxiliaryFragmentType, AxesOverflow};
 use log::warn;
 use malloc_size_of_derive::MallocSizeOf;
 use paint_api::display_list::{
-    AxesScrollSensitivity, PaintDisplayListInfo, ReferenceFrameNodeInfo, ScrollableNodeInfo,
-    SpatialTreeNodeInfo, StickyNodeInfo,
+    AxesScrollSensitivity, PaintDisplayListInfo, ReferenceFrameNodeInfo, ScrollType, ScrollableNodeInfo, SpatialTreeNodeInfo, StickyNodeInfo
 };
 use servo_config::opts::DiagnosticsLogging;
 use style::Zero;
@@ -194,6 +193,8 @@ impl StackingContextTree {
             );
         }
         root_stacking_context.sort();
+
+
 
         if debug.stacking_context_tree {
             root_stacking_context.debug_print();
@@ -1039,25 +1040,19 @@ pub(crate) struct ScrollbarDescriptor {
 
 impl ScrollbarDescriptor {
     fn should_render_horizontal_scrollbar(
-        overflow: &AxesOverflow,
+        sensitivity: &AxesScrollSensitivity,
         padding_rect: &PhysicalRect<Au>,
         scrollable_overflow_size: &Size2D<Au, CSSPixel>,
     ) -> bool {
-        matches!(
-            overflow.x,
-            ComputedOverflow::Scroll | ComputedOverflow::Auto
-        ) && scrollable_overflow_size.width > padding_rect.width()
+        sensitivity.x.contains(ScrollType::InputEvents) && scrollable_overflow_size.width > padding_rect.width()
     }
 
     fn should_render_vertical_scrollbar(
-        overflow: &AxesOverflow,
+        sensitivity: &AxesScrollSensitivity,
         padding_rect: &PhysicalRect<Au>,
         scrollable_overflow_size: &Size2D<Au, CSSPixel>,
     ) -> bool {
-        matches!(
-            overflow.y,
-            ComputedOverflow::Scroll | ComputedOverflow::Auto
-        ) && scrollable_overflow_size.height > padding_rect.height()
+        sensitivity.y.contains(ScrollType::InputEvents) && scrollable_overflow_size.height > padding_rect.height()
     }
 
     fn place_horizontal_scrollbar(
@@ -1783,7 +1778,6 @@ impl BoxFragment {
             parent_scroll_node_id,
             scroll_tree_node_id,
             containing_block_rect,
-            &overflow,
             &sensitivity,
         );
 
@@ -1803,19 +1797,18 @@ impl BoxFragment {
         parent_scroll_node_id: ScrollTreeNodeId,
         main_scroll_tree_node_id: ScrollTreeNodeId,
         containing_block_rect: &PhysicalRect<Au>,
-        overflow: &AxesOverflow,
         sensitivity: &AxesScrollSensitivity,
     ) -> Option<Box<ScrollbarDescriptor>> {
         let padding_rect = self.padding_rect();
         let scrollable_overflow_size = self.scrollable_overflow().size;
 
         let render_horizontal_scrollbar = ScrollbarDescriptor::should_render_horizontal_scrollbar(
-            overflow,
+            sensitivity,
             &padding_rect,
             &scrollable_overflow_size,
         );
         let render_vertical_scrollbar = ScrollbarDescriptor::should_render_vertical_scrollbar(
-            overflow,
+            sensitivity,
             &padding_rect,
             &scrollable_overflow_size,
         );

--- a/components/layout/display_list/stacking_context.rs
+++ b/components/layout/display_list/stacking_context.rs
@@ -4,8 +4,8 @@
 
 use core::f32;
 use std::cell::{Cell, RefCell};
-use std::mem;
 use std::sync::Arc;
+use std::{i32, mem};
 
 use app_units::Au;
 use base::id::ScrollTreeNodeId;
@@ -410,17 +410,6 @@ impl StackingContextContent {
             StackingContextContent::AtomicInlineStackingContainer { .. } => false,
         }
     }
-
-    fn for_scrollbar_slider(&self) -> bool {
-        if let StackingContextContent::Fragment {
-            scrollbar_slider, ..
-        } = self
-        {
-            scrollbar_slider.is_some()
-        } else {
-            false
-        }
-    }
 }
 
 #[derive(Clone, Copy, Debug, Eq, MallocSizeOf, PartialEq)]
@@ -481,6 +470,9 @@ pub struct StackingContext {
     /// <https://drafts.csswg.org/css-position-4/#paint-a-box-in-a-line-box>
     pub(super) atomic_inline_stacking_containers: Vec<StackingContext>,
 
+    /// Whether the stacking context is specifically for a scrollbar.
+    pub(super) is_specifically_for_scrollbar: bool,
+
     /// Information gathered about the painting order, for [Self::debug_print].
     debug_print_items: Option<RefCell<Vec<DebugPrintItem>>>,
 }
@@ -525,6 +517,7 @@ impl StackingContext {
             real_stacking_contexts_and_positioned_stacking_containers: vec![],
             float_stacking_containers: vec![],
             atomic_inline_stacking_containers: vec![],
+            is_specifically_for_scrollbar: false,
             debug_print_items: self.debug_print_items.is_some().then(|| vec![].into()),
         }
     }
@@ -539,6 +532,7 @@ impl StackingContext {
             real_stacking_contexts_and_positioned_stacking_containers: vec![],
             float_stacking_containers: vec![],
             atomic_inline_stacking_containers: vec![],
+            is_specifically_for_scrollbar: false,
             debug_print_items: debug.stacking_context_tree.then(|| vec![].into()),
         }
     }
@@ -561,6 +555,12 @@ impl StackingContext {
     }
 
     pub(crate) fn z_index(&self) -> i32 {
+        // If the `StackingContext` is specifically for a scrollbar and this is a root stacking context we need to ensure
+        // that it render above the descendant.
+        if self.is_specifically_for_scrollbar && self.initializing_fragment.is_none() {
+            return i32::MAX;
+        }
+
         self.initializing_fragment.as_ref().map_or(0, |fragment| {
             let fragment = fragment.borrow();
             fragment.style().effective_z_index(fragment.base.flags)
@@ -758,16 +758,11 @@ impl StackingContext {
 
         // Steps 1 and 2: Borders and background for the root
         let mut content_with_outlines = Vec::new();
-        let mut content_with_scrollbar = Vec::new();
         let mut contents = self.contents.iter().enumerate().peekable();
         while contents.peek().is_some_and(|(_, child)| {
             child.section() == StackingContextSection::OwnBackgroundsAndBorders
         }) {
             let (i, child) = contents.next().unwrap();
-            if child.for_scrollbar_slider() {
-                content_with_scrollbar.push(child);
-                continue;
-            }
             self.debug_push_print_item(DebugPrintField::Contents, i);
             child.build_display_list(builder, &self.atomic_inline_stacking_containers);
 
@@ -801,11 +796,6 @@ impl StackingContext {
             child.section() == StackingContextSection::DescendantBackgroundsAndBorders
         }) {
             let (i, child) = contents.next().unwrap();
-            if child.for_scrollbar_slider() {
-                content_with_scrollbar.push(child);
-                continue;
-            }
-
             self.debug_push_print_item(DebugPrintField::Contents, i);
             child.build_display_list(builder, &self.atomic_inline_stacking_containers);
 
@@ -826,10 +816,6 @@ impl StackingContext {
             .is_some_and(|(_, child)| child.section() == StackingContextSection::Foreground)
         {
             let (i, child) = contents.next().unwrap();
-            if child.for_scrollbar_slider() {
-                content_with_scrollbar.push(child);
-                continue;
-            }
             self.debug_push_print_item(DebugPrintField::Contents, i);
             child.build_display_list(builder, &self.atomic_inline_stacking_containers);
 
@@ -855,10 +841,6 @@ impl StackingContext {
                 &self.atomic_inline_stacking_containers,
                 Some(StackingContextSection::Outline),
             );
-        }
-
-        for content in content_with_scrollbar {
-            content.build_display_list(builder, &self.atomic_inline_stacking_containers);
         }
 
         if pushed_context {
@@ -1489,10 +1471,19 @@ impl BoxFragment {
         ) {
             new_clip_id = overflow_frame_data.clip_id;
 
-            // MYTODO: need to document or tidy this
+            // Additionally, if the container have a scrollbar, build a stacking context for the scrollbar.
+            // This is necessary to ensure that the scrollbar's painting order is correct in relation to other element.
+            // Particularly we should ensure that the scrollbar is painted above the descendant.
             if let Some(scrollbar_descriptor) = overflow_frame_data.scrollbar_descriptor {
+                // Following Firefox, we assume scrollbar as a positioned descendant, thus making a new stacking context.
+                let mut new_stacking_context = stacking_context.create_descendant(
+                    new_scroll_node_id,
+                    new_clip_id,
+                    fragment.retrieve_box_fragment().cloned().unwrap(),
+                    StackingContextType::RealStackingContext,
+                );
                 if let Some(horizontal_slider) = scrollbar_descriptor.horizontal {
-                    stacking_context
+                    new_stacking_context
                         .contents
                         .push(StackingContextContent::Fragment {
                             scroll_node_id: horizontal_slider.scroll_node_id,
@@ -1509,7 +1500,7 @@ impl BoxFragment {
                         });
                 }
                 if let Some(vertical_slider) = scrollbar_descriptor.vertical {
-                    stacking_context
+                    new_stacking_context
                         .contents
                         .push(StackingContextContent::Fragment {
                             scroll_node_id: vertical_slider.scroll_node_id,
@@ -1525,6 +1516,8 @@ impl BoxFragment {
                             scrollbar_slider: Some(Box::new(vertical_slider)),
                         });
                 }
+                new_stacking_context.is_specifically_for_scrollbar = true;
+                stacking_context.add_stacking_context(new_stacking_context);
             }
 
             if let Some(scroll_frame_data) = overflow_frame_data.scroll_frame_data {

--- a/components/layout/display_list/stacking_context.rs
+++ b/components/layout/display_list/stacking_context.rs
@@ -352,7 +352,6 @@ impl StackingContextContent {
     }
 
     fn build_display_list_with_section_override(
-        // MYTODO need to modify here IG?
         &self,
         builder: &mut DisplayListBuilder,
         inline_stacking_containers: &[StackingContext],
@@ -981,8 +980,6 @@ impl Fragment {
                     stacking_context,
                     text_decorations,
                 );
-
-                // MYTODO: After building stackign context tree checks whether the scrollbar need to be built(?).
             },
             Fragment::AbsoluteOrFixedPositioned(fragment) => {
                 let shared_fragment = fragment.borrow();
@@ -1631,8 +1628,6 @@ impl BoxFragment {
             );
         }
 
-        // MYTODO: Or maybe built the scrollbar here
-
         if matches!(
             self.specific_layout_info(),
             Some(SpecificLayoutInfo::TableGridWithCollapsedBorders(_))
@@ -1811,7 +1806,7 @@ impl BoxFragment {
         })
     }
 
-    /// MYTODO: Need to define axes scroll sensitivity well for scrollbar
+    /// MYTODO: For sensitivity we technically should ignore it for scrollbar.
     fn build_scrollbar_if_necessary(
         &self,
         stacking_context_tree: &mut StackingContextTree,

--- a/components/layout/display_list/stacking_context.rs
+++ b/components/layout/display_list/stacking_context.rs
@@ -12,7 +12,7 @@ use base::id::ScrollTreeNodeId;
 use base::print_tree::PrintTree;
 use embedder_traits::ViewportDetails;
 use euclid::{Point2D, Rect, SideOffsets2D, Size2D};
-use layout_api::{AxesOverflow, AuxiliaryFragmentType};
+use layout_api::{AuxiliaryFragmentType, AxesOverflow};
 use log::warn;
 use malloc_size_of_derive::MallocSizeOf;
 use paint_api::display_list::{
@@ -231,7 +231,6 @@ impl StackingContextTree {
         external_id: wr::ExternalScrollId,
         content_rect: LayoutRect,
         clip_rect: LayoutRect,
-        offset: LayoutVector2D,
         scroll_sensitivity: AxesScrollSensitivity,
     ) -> ScrollTreeNodeId {
         self.paint_info.scroll_tree.add_scroll_tree_node(
@@ -241,7 +240,7 @@ impl StackingContextTree {
                 content_rect,
                 clip_rect,
                 scroll_sensitivity,
-                offset,
+                offset: LayoutVector2D::zero(),
                 offset_changed: Cell::new(false),
                 linked_nodes: None,
             }),
@@ -1783,7 +1782,6 @@ impl BoxFragment {
             external_scroll_id,
             self.scrollable_overflow().to_webrender(),
             scroll_frame_rect,
-            LayoutVector2D::zero(),
             sensitivity,
         );
 
@@ -1806,7 +1804,6 @@ impl BoxFragment {
         })
     }
 
-    /// MYTODO: For sensitivity we technically should ignore it for scrollbar.
     fn build_scrollbar_if_necessary(
         &self,
         stacking_context_tree: &mut StackingContextTree,
@@ -1849,15 +1846,12 @@ impl BoxFragment {
                 tag.to_display_list_fragment_id_for_aux(AuxiliaryFragmentType::VerticalScrollbar),
                 stacking_context_tree.paint_info.pipeline_id,
             );
-            // The initial scroll offset of a scrollbar fragment should be reverse to the initial offset of scroll container.
-            let initial_offset = (vertical_overflow_rect.size() - vertical_track.size()).to_vector();
 
             let vertical_scroll_tree_node_id = stacking_context_tree.define_scroll_frame(
                 parent_scroll_node_id,
                 external_scroll_id,
                 vertical_overflow_rect,
                 vertical_track,
-                initial_offset,
                 *sensitivity,
             );
 
@@ -1882,15 +1876,12 @@ impl BoxFragment {
                 tag.to_display_list_fragment_id_for_aux(AuxiliaryFragmentType::HorizontalScrollbar),
                 stacking_context_tree.paint_info.pipeline_id,
             );
-            // The initial scroll offset of a scrollbar fragment should be reverse to the initial offset of scroll container.
-            let initial_offset = (horizontal_overflow_rect.size() - horizontal_track.size()).to_vector();
 
             let horizontal_scroll_tree_node_id = stacking_context_tree.define_scroll_frame(
                 parent_scroll_node_id,
                 external_scroll_id,
                 horizontal_overflow_rect,
                 horizontal_track,
-                initial_offset,
                 *sensitivity,
             );
 
@@ -1906,7 +1897,7 @@ impl BoxFragment {
         stacking_context_tree
             .paint_info
             .scroll_tree
-            .set_linked_nodes(
+            .set_linked_scrollbar_nodes(
                 main_scroll_tree_node_id,
                 horizontal_slider
                     .as_ref()

--- a/components/layout/display_list/stacking_context.rs
+++ b/components/layout/display_list/stacking_context.rs
@@ -10,8 +10,10 @@ use std::sync::Arc;
 use app_units::Au;
 use base::id::ScrollTreeNodeId;
 use base::print_tree::PrintTree;
+use bitflags::bitflags;
 use embedder_traits::ViewportDetails;
-use euclid::{Point2D, Rect, SideOffsets2D, Size2D};
+use euclid::{Point2D, Rect, SideOffsets2D, Size2D, Vector2D};
+use layout_api::AxesOverflow;
 use log::warn;
 use malloc_size_of_derive::MallocSizeOf;
 use paint_api::display_list::{
@@ -329,6 +331,7 @@ pub(crate) enum StackingContextContent {
         is_collapsed_table_borders: bool,
         #[conditional_malloc_size_of]
         text_decorations: Arc<Vec<FragmentTextDecoration>>,
+        scrollbar_descriptor: Option<Box<ScrollbarDescriptor>>,
     },
 
     /// An index into [StackingContext::atomic_inline_stacking_containers].
@@ -346,6 +349,7 @@ impl StackingContextContent {
     }
 
     fn build_display_list_with_section_override(
+        // MYTODO need to modify here IG?
         &self,
         builder: &mut DisplayListBuilder,
         inline_stacking_containers: &[StackingContext],
@@ -362,6 +366,7 @@ impl StackingContextContent {
                 is_hit_test_for_scrollable_overflow,
                 is_collapsed_table_borders,
                 text_decorations,
+                scrollbar_descriptor,
             } => {
                 builder.current_scroll_node_id = *scroll_node_id;
                 builder.current_reference_frame_scroll_node_id = *reference_frame_scroll_node_id;
@@ -373,6 +378,7 @@ impl StackingContextContent {
                     *is_hit_test_for_scrollable_overflow,
                     *is_collapsed_table_borders,
                     text_decorations,
+                    scrollbar_descriptor,
                 );
             },
             Self::AtomicInlineStackingContainer { index } => {
@@ -401,6 +407,18 @@ impl StackingContextContent {
                 _ => false,
             },
             StackingContextContent::AtomicInlineStackingContainer { .. } => false,
+        }
+    }
+
+    fn has_scrollbar_descriptor(&self) -> bool {
+        if let StackingContextContent::Fragment {
+            scrollbar_descriptor,
+            ..
+        } = self
+        {
+            scrollbar_descriptor.is_some()
+        } else {
+            false
         }
     }
 }
@@ -715,6 +733,7 @@ impl StackingContext {
             &fragment_tree.initial_containing_block,
             false, /* is_hit_test_for_scrollable_overflow */
             false, /* is_collapsed_table_borders */
+            None,
         );
         let painter = super::background::BackgroundPainter {
             style: &source_style,
@@ -739,11 +758,16 @@ impl StackingContext {
 
         // Steps 1 and 2: Borders and background for the root
         let mut content_with_outlines = Vec::new();
+        let mut content_with_scrollbar = Vec::new();
         let mut contents = self.contents.iter().enumerate().peekable();
         while contents.peek().is_some_and(|(_, child)| {
             child.section() == StackingContextSection::OwnBackgroundsAndBorders
         }) {
             let (i, child) = contents.next().unwrap();
+            if child.has_scrollbar_descriptor() {
+                content_with_scrollbar.push(child);
+                continue;
+            }
             self.debug_push_print_item(DebugPrintField::Contents, i);
             child.build_display_list(builder, &self.atomic_inline_stacking_containers);
 
@@ -777,6 +801,11 @@ impl StackingContext {
             child.section() == StackingContextSection::DescendantBackgroundsAndBorders
         }) {
             let (i, child) = contents.next().unwrap();
+            if child.has_scrollbar_descriptor() {
+                content_with_scrollbar.push(child);
+                continue;
+            }
+
             self.debug_push_print_item(DebugPrintField::Contents, i);
             child.build_display_list(builder, &self.atomic_inline_stacking_containers);
 
@@ -797,6 +826,10 @@ impl StackingContext {
             .is_some_and(|(_, child)| child.section() == StackingContextSection::Foreground)
         {
             let (i, child) = contents.next().unwrap();
+            if child.has_scrollbar_descriptor() {
+                content_with_scrollbar.push(child);
+                continue;
+            }
             self.debug_push_print_item(DebugPrintField::Contents, i);
             child.build_display_list(builder, &self.atomic_inline_stacking_containers);
 
@@ -822,6 +855,10 @@ impl StackingContext {
                 &self.atomic_inline_stacking_containers,
                 Some(StackingContextSection::Outline),
             );
+        }
+
+        for content in content_with_scrollbar {
+            content.build_display_list(builder, &self.atomic_inline_stacking_containers);
         }
 
         if pushed_context {
@@ -942,6 +979,8 @@ impl Fragment {
                     stacking_context,
                     text_decorations,
                 );
+
+                // MYTODO: After building stackign context tree checks whether the scrollbar need to be built(?).
             },
             Fragment::AbsoluteOrFixedPositioned(fragment) => {
                 let shared_fragment = fragment.borrow();
@@ -983,6 +1022,7 @@ impl Fragment {
                         is_hit_test_for_scrollable_overflow: false,
                         is_collapsed_table_borders: false,
                         text_decorations: text_decorations.clone(),
+                        scrollbar_descriptor: None,
                     });
             },
         }
@@ -999,9 +1039,93 @@ struct ScrollFrameData {
     scroll_frame_rect: LayoutRect,
 }
 
+#[derive(MallocSizeOf)]
+pub(crate) struct ScrollbarDescriptor {
+    pub horizontal_thumb: Option<LayoutRect>,
+    pub vertical_thumb: Option<LayoutRect>,
+}
+
+impl ScrollbarDescriptor {
+    fn should_render_vertical_scrollbar(
+        overflow: &AxesOverflow,
+        padding_rect: &PhysicalRect<Au>,
+        scrollable_overflow_size: &Size2D<Au, CSSPixel>,
+    ) -> bool {
+        matches!(
+            overflow.x,
+            ComputedOverflow::Scroll | ComputedOverflow::Auto
+        ) && scrollable_overflow_size.width > padding_rect.width()
+    }
+
+    fn should_horizontal_vertical_scrollbar(
+        overflow: &AxesOverflow,
+        padding_rect: &PhysicalRect<Au>,
+        scrollable_overflow_size: &Size2D<Au, CSSPixel>,
+    ) -> bool {
+        matches!(
+            overflow.y,
+            ComputedOverflow::Scroll | ComputedOverflow::Auto
+        ) && scrollable_overflow_size.height > padding_rect.height()
+    }
+
+    fn compute_scrollbar_if_necessary(
+        overflow: &AxesOverflow,
+        padding_rect: &PhysicalRect<Au>,
+        scrollable_overflow_size: &Size2D<Au, CSSPixel>,
+        containing_block_rect: &PhysicalRect<Au>,
+    ) -> Option<Box<Self>> {
+        let SCROLLBAR_THICKNESS = Au::from_px(8);
+        let horizontal_thumb = if Self::should_render_vertical_scrollbar(overflow, padding_rect, scrollable_overflow_size)
+        {
+            let scrollbar_width =
+                padding_rect.width() * padding_rect.width().0 / scrollable_overflow_size.width.0;
+            Some(
+                Rect::new(
+                    Point2D::new(
+                        padding_rect.min_x(),
+                        padding_rect.max_y() - SCROLLBAR_THICKNESS,
+                    ),
+                    Size2D::new(scrollbar_width, SCROLLBAR_THICKNESS),
+                )
+                .translate(containing_block_rect.origin.to_vector())
+                .to_webrender(),
+            )
+        } else {
+            None
+        };
+        let vertical_thumb = if Self::should_horizontal_vertical_scrollbar(overflow, padding_rect, scrollable_overflow_size)
+        {
+            let scrollbar_height =
+                padding_rect.height() * padding_rect.height().0 / scrollable_overflow_size.height.0;
+            Some(
+                Rect::new(
+                    Point2D::new(
+                        padding_rect.max_x() - SCROLLBAR_THICKNESS,
+                        padding_rect.min_y(),
+                    ),
+                    Size2D::new(SCROLLBAR_THICKNESS, scrollbar_height),
+                )
+                .translate(containing_block_rect.origin.to_vector())
+                .to_webrender(),
+            )
+        } else {
+            None
+        };
+        if horizontal_thumb.is_some() || vertical_thumb.is_some() {
+            Some(Box::new(Self {
+                horizontal_thumb,
+                vertical_thumb,
+            }))
+        } else {
+            None
+        }
+    }
+}
+
 struct OverflowFrameData {
     clip_id: ClipId,
     scroll_frame_data: Option<ScrollFrameData>,
+    frame_scrollbar_data: Option<Box<ScrollbarDescriptor>>,
 }
 
 impl BoxFragment {
@@ -1185,6 +1309,7 @@ impl BoxFragment {
                     &containing_block.rect,
                     false, /* is_hit_test_for_scrollable_overflow */
                     false, /* is_collapsed_table_borders */
+                    None,
                 ),
             )
             .unwrap_or(containing_block.clip_id);
@@ -1270,6 +1395,7 @@ impl BoxFragment {
                 &containing_block.rect,
                 false, /* is_hit_test_for_scrollable_overflow */
                 false, /* is_collapsed_table_borders */
+                None,
             ),
         ) {
             new_clip_id = clip_id;
@@ -1302,6 +1428,7 @@ impl BoxFragment {
                     is_hit_test_for_scrollable_overflow: false,
                     is_collapsed_table_borders: false,
                     text_decorations: text_decorations.clone(),
+                    scrollbar_descriptor: None,
                 });
         };
 
@@ -1316,12 +1443,30 @@ impl BoxFragment {
         // We want to build the scroll frame after the background and border, because
         // they shouldn't scroll with the rest of the box content.
         if let Some(overflow_frame_data) = self.build_overflow_frame_if_necessary(
+            // MYTODO: need to store the information as well
             stacking_context_tree,
             new_scroll_node_id,
             new_clip_id,
             &containing_block.rect,
         ) {
             new_clip_id = overflow_frame_data.clip_id;
+            if overflow_frame_data.scroll_frame_data.is_some() {
+                stacking_context
+                    .contents
+                    .push(StackingContextContent::Fragment {
+                        scroll_node_id: new_scroll_node_id,
+                        reference_frame_scroll_node_id:
+                            reference_frame_scroll_node_id_for_fragments,
+                        clip_id: new_clip_id,
+                        section,
+                        containing_block: containing_block.rect,
+                        fragment: fragment.clone(),
+                        is_hit_test_for_scrollable_overflow: false,
+                        is_collapsed_table_borders: false,
+                        text_decorations: text_decorations.clone(),
+                        scrollbar_descriptor: overflow_frame_data.frame_scrollbar_data,
+                    });
+            }
             if let Some(scroll_frame_data) = overflow_frame_data.scroll_frame_data {
                 new_scroll_node_id = scroll_frame_data.scroll_tree_node_id;
                 new_scroll_frame_size = Some(scroll_frame_data.scroll_frame_rect.size());
@@ -1338,6 +1483,7 @@ impl BoxFragment {
                         is_hit_test_for_scrollable_overflow: true,
                         is_collapsed_table_borders: false,
                         text_decorations: text_decorations.clone(),
+                        scrollbar_descriptor: None,
                     });
             }
         }
@@ -1421,6 +1567,8 @@ impl BoxFragment {
             );
         }
 
+        // MYTODO: Or maybe built the scrollbar here
+
         if matches!(
             self.specific_layout_info(),
             Some(SpecificLayoutInfo::TableGridWithCollapsedBorders(_))
@@ -1437,6 +1585,7 @@ impl BoxFragment {
                     is_hit_test_for_scrollable_overflow: false,
                     is_collapsed_table_borders: true,
                     text_decorations: text_decorations.clone(),
+                    scrollbar_descriptor: None,
                 });
         }
     }
@@ -1509,7 +1658,8 @@ impl BoxFragment {
             // https://drafts.csswg.org/css-overflow-3/#corner-clipping
             let radii;
             if overflow.x == ComputedOverflow::Clip && overflow.y == ComputedOverflow::Clip {
-                let builder = BuilderForBoxFragment::new(self, containing_block_rect, false, false);
+                let builder =
+                    BuilderForBoxFragment::new(self, containing_block_rect, false, false, None);
                 let mut offsets_from_border = SideOffsets2D::new_all_same(clip_margin_offset);
                 match overflow_clip_margin.visual_box {
                     OverflowClipMarginBox::ContentBox => {
@@ -1541,6 +1691,7 @@ impl BoxFragment {
             return Some(OverflowFrameData {
                 clip_id,
                 scroll_frame_data: None,
+                frame_scrollbar_data: None,
             });
         }
 
@@ -1550,7 +1701,8 @@ impl BoxFragment {
             .to_webrender();
 
         let clip_id = stacking_context_tree.clip_store.add(
-            BuilderForBoxFragment::new(self, containing_block_rect, false, false).border_radius,
+            BuilderForBoxFragment::new(self, containing_block_rect, false, false, None)
+                .border_radius,
             scroll_frame_rect,
             parent_scroll_node_id,
             parent_clip_id,
@@ -1575,12 +1727,20 @@ impl BoxFragment {
             sensitivity,
         );
 
+        let frame_scrollbar_data = ScrollbarDescriptor::compute_scrollbar_if_necessary(
+            &overflow,
+            &self.padding_rect(),
+            &self.scrollable_overflow().size,
+            containing_block_rect,
+        );
+
         Some(OverflowFrameData {
             clip_id,
             scroll_frame_data: Some(ScrollFrameData {
                 scroll_tree_node_id,
                 scroll_frame_rect,
             }),
+            frame_scrollbar_data,
         })
     }
 

--- a/components/layout/display_list/stacking_context.rs
+++ b/components/layout/display_list/stacking_context.rs
@@ -1795,10 +1795,14 @@ impl BoxFragment {
         &self,
         stacking_context_tree: &mut StackingContextTree,
         parent_scroll_node_id: ScrollTreeNodeId,
-        main_scroll_tree_node_id: ScrollTreeNodeId,
+        scroll_container_scroll_node_id: ScrollTreeNodeId,
         containing_block_rect: &PhysicalRect<Au>,
         sensitivity: &AxesScrollSensitivity,
     ) -> Option<Box<ScrollbarDescriptor>> {
+        if !servo_config::pref!(overlay_scrollbar_enabled) {
+            return None;
+        }
+
         let padding_rect = self.padding_rect();
         let scrollable_overflow_size = self.scrollable_overflow().size;
 
@@ -1884,7 +1888,7 @@ impl BoxFragment {
             .paint_info
             .scroll_tree
             .set_linked_scrollbar_nodes(
-                main_scroll_tree_node_id,
+                scroll_container_scroll_node_id,
                 horizontal_slider
                     .as_ref()
                     .map(|slider| slider.scroll_node_id),

--- a/components/layout/display_list/stacking_context.rs
+++ b/components/layout/display_list/stacking_context.rs
@@ -12,7 +12,7 @@ use base::id::ScrollTreeNodeId;
 use base::print_tree::PrintTree;
 use embedder_traits::ViewportDetails;
 use euclid::{Point2D, Rect, SideOffsets2D, Size2D};
-use layout_api::AxesOverflow;
+use layout_api::{AxesOverflow, FragmentType, combine_id_with_fragment_type};
 use log::warn;
 use malloc_size_of_derive::MallocSizeOf;
 use paint_api::display_list::{
@@ -1838,7 +1838,7 @@ impl BoxFragment {
                 );
 
             let external_scroll_id = wr::ExternalScrollId(
-                tag.to_display_list_fragment_id_for_scrollbar(),
+                combine_id_with_fragment_type(tag.node.id(), FragmentType::VerticalScrollbar),
                 stacking_context_tree.paint_info.pipeline_id,
             );
 
@@ -1873,7 +1873,7 @@ impl BoxFragment {
                 );
 
             let external_scroll_id = wr::ExternalScrollId(
-                tag.to_display_list_fragment_id_for_scrollbar(),
+                combine_id_with_fragment_type(tag.node.id(), FragmentType::HorizontalScrollbar),
                 stacking_context_tree.paint_info.pipeline_id,
             );
 

--- a/components/layout/display_list/stacking_context.rs
+++ b/components/layout/display_list/stacking_context.rs
@@ -10,9 +10,8 @@ use std::sync::Arc;
 use app_units::Au;
 use base::id::ScrollTreeNodeId;
 use base::print_tree::PrintTree;
-use bitflags::bitflags;
 use embedder_traits::ViewportDetails;
-use euclid::{Point2D, Rect, SideOffsets2D, Size2D, Vector2D};
+use euclid::{Point2D, Rect, SideOffsets2D, Size2D};
 use layout_api::AxesOverflow;
 use log::warn;
 use malloc_size_of_derive::MallocSizeOf;
@@ -52,6 +51,8 @@ use crate::fragment_tree::{
 };
 use crate::geom::{AuOrAuto, LengthPercentageOrAuto, PhysicalPoint, PhysicalRect, PhysicalSides};
 use crate::style_ext::{ComputedValuesExt, TransformExt};
+
+const SCROLLBAR_THICKNESS: i32 = 8;
 
 #[derive(Clone)]
 pub(crate) struct ContainingBlock {
@@ -230,6 +231,7 @@ impl StackingContextTree {
         external_id: wr::ExternalScrollId,
         content_rect: LayoutRect,
         clip_rect: LayoutRect,
+        offset: LayoutVector2D,
         scroll_sensitivity: AxesScrollSensitivity,
     ) -> ScrollTreeNodeId {
         self.paint_info.scroll_tree.add_scroll_tree_node(
@@ -239,8 +241,9 @@ impl StackingContextTree {
                 content_rect,
                 clip_rect,
                 scroll_sensitivity,
-                offset: LayoutVector2D::zero(),
+                offset,
                 offset_changed: Cell::new(false),
+                linked_nodes: None,
             }),
         )
     }
@@ -331,7 +334,7 @@ pub(crate) enum StackingContextContent {
         is_collapsed_table_borders: bool,
         #[conditional_malloc_size_of]
         text_decorations: Arc<Vec<FragmentTextDecoration>>,
-        scrollbar_descriptor: Option<Box<ScrollbarDescriptor>>,
+        scrollbar_slider: Option<Box<ScrollbarSlider>>,
     },
 
     /// An index into [StackingContext::atomic_inline_stacking_containers].
@@ -366,7 +369,7 @@ impl StackingContextContent {
                 is_hit_test_for_scrollable_overflow,
                 is_collapsed_table_borders,
                 text_decorations,
-                scrollbar_descriptor,
+                scrollbar_slider,
             } => {
                 builder.current_scroll_node_id = *scroll_node_id;
                 builder.current_reference_frame_scroll_node_id = *reference_frame_scroll_node_id;
@@ -378,7 +381,7 @@ impl StackingContextContent {
                     *is_hit_test_for_scrollable_overflow,
                     *is_collapsed_table_borders,
                     text_decorations,
-                    scrollbar_descriptor,
+                    scrollbar_slider,
                 );
             },
             Self::AtomicInlineStackingContainer { index } => {
@@ -410,13 +413,12 @@ impl StackingContextContent {
         }
     }
 
-    fn has_scrollbar_descriptor(&self) -> bool {
+    fn for_scrollbar_slider(&self) -> bool {
         if let StackingContextContent::Fragment {
-            scrollbar_descriptor,
-            ..
+            scrollbar_slider, ..
         } = self
         {
-            scrollbar_descriptor.is_some()
+            scrollbar_slider.is_some()
         } else {
             false
         }
@@ -764,7 +766,7 @@ impl StackingContext {
             child.section() == StackingContextSection::OwnBackgroundsAndBorders
         }) {
             let (i, child) = contents.next().unwrap();
-            if child.has_scrollbar_descriptor() {
+            if child.for_scrollbar_slider() {
                 content_with_scrollbar.push(child);
                 continue;
             }
@@ -801,7 +803,7 @@ impl StackingContext {
             child.section() == StackingContextSection::DescendantBackgroundsAndBorders
         }) {
             let (i, child) = contents.next().unwrap();
-            if child.has_scrollbar_descriptor() {
+            if child.for_scrollbar_slider() {
                 content_with_scrollbar.push(child);
                 continue;
             }
@@ -826,7 +828,7 @@ impl StackingContext {
             .is_some_and(|(_, child)| child.section() == StackingContextSection::Foreground)
         {
             let (i, child) = contents.next().unwrap();
-            if child.has_scrollbar_descriptor() {
+            if child.for_scrollbar_slider() {
                 content_with_scrollbar.push(child);
                 continue;
             }
@@ -1022,7 +1024,7 @@ impl Fragment {
                         is_hit_test_for_scrollable_overflow: false,
                         is_collapsed_table_borders: false,
                         text_decorations: text_decorations.clone(),
-                        scrollbar_descriptor: None,
+                        scrollbar_slider: None,
                     });
             },
         }
@@ -1040,13 +1042,25 @@ struct ScrollFrameData {
 }
 
 #[derive(MallocSizeOf)]
+pub(crate) struct ScrollbarSlider {
+    /// The rectangle representing the moving part of the scrollbar.
+    pub thumb: LayoutRect,
+
+    /// The rectangle representing the track.
+    pub track: LayoutRect,
+
+    /// The scroll node which represent the thumb's offset.
+    pub scroll_node_id: ScrollTreeNodeId,
+}
+
+#[derive(MallocSizeOf)]
 pub(crate) struct ScrollbarDescriptor {
-    pub horizontal_thumb: Option<LayoutRect>,
-    pub vertical_thumb: Option<LayoutRect>,
+    pub horizontal: Option<ScrollbarSlider>,
+    pub vertical: Option<ScrollbarSlider>,
 }
 
 impl ScrollbarDescriptor {
-    fn should_render_vertical_scrollbar(
+    fn should_render_horizontal_scrollbar(
         overflow: &AxesOverflow,
         padding_rect: &PhysicalRect<Au>,
         scrollable_overflow_size: &Size2D<Au, CSSPixel>,
@@ -1057,7 +1071,7 @@ impl ScrollbarDescriptor {
         ) && scrollable_overflow_size.width > padding_rect.width()
     }
 
-    fn should_horizontal_vertical_scrollbar(
+    fn should_render_vertical_scrollbar(
         overflow: &AxesOverflow,
         padding_rect: &PhysicalRect<Au>,
         scrollable_overflow_size: &Size2D<Au, CSSPixel>,
@@ -1068,64 +1082,93 @@ impl ScrollbarDescriptor {
         ) && scrollable_overflow_size.height > padding_rect.height()
     }
 
-    fn compute_scrollbar_if_necessary(
-        overflow: &AxesOverflow,
+    fn place_horizontal_scrollbar(
         padding_rect: &PhysicalRect<Au>,
         scrollable_overflow_size: &Size2D<Au, CSSPixel>,
         containing_block_rect: &PhysicalRect<Au>,
-    ) -> Option<Box<Self>> {
-        let SCROLLBAR_THICKNESS = Au::from_px(8);
-        let horizontal_thumb = if Self::should_render_vertical_scrollbar(overflow, padding_rect, scrollable_overflow_size)
-        {
-            let scrollbar_width =
-                padding_rect.width() * padding_rect.width().0 / scrollable_overflow_size.width.0;
-            Some(
-                Rect::new(
-                    Point2D::new(
-                        padding_rect.min_x(),
-                        padding_rect.max_y() - SCROLLBAR_THICKNESS,
-                    ),
-                    Size2D::new(scrollbar_width, SCROLLBAR_THICKNESS),
-                )
-                .translate(containing_block_rect.origin.to_vector())
-                .to_webrender(),
-            )
-        } else {
-            None
-        };
-        let vertical_thumb = if Self::should_horizontal_vertical_scrollbar(overflow, padding_rect, scrollable_overflow_size)
-        {
-            let scrollbar_height =
-                padding_rect.height() * padding_rect.height().0 / scrollable_overflow_size.height.0;
-            Some(
-                Rect::new(
-                    Point2D::new(
-                        padding_rect.max_x() - SCROLLBAR_THICKNESS,
-                        padding_rect.min_y(),
-                    ),
-                    Size2D::new(SCROLLBAR_THICKNESS, scrollbar_height),
-                )
-                .translate(containing_block_rect.origin.to_vector())
-                .to_webrender(),
-            )
-        } else {
-            None
-        };
-        if horizontal_thumb.is_some() || vertical_thumb.is_some() {
-            Some(Box::new(Self {
-                horizontal_thumb,
-                vertical_thumb,
-            }))
-        } else {
-            None
-        }
+    ) -> (LayoutRect, LayoutRect, LayoutRect) {
+        let scrollbar_thickness = Au::from_px(SCROLLBAR_THICKNESS);
+
+        let scrollbar_track_width = padding_rect.width();
+        let scrollbar_thumb_width =
+            scrollbar_track_width * scrollbar_track_width.0 / scrollable_overflow_size.width.0;
+
+        let scroll_node_overflow_width = scrollbar_track_width * 2 - scrollbar_thumb_width;
+
+        let scrollbar_origin = Point2D::new(
+            padding_rect.min_x(),
+            padding_rect.max_y() - scrollbar_thickness,
+        ) + containing_block_rect.origin.to_vector();
+
+        let scrollbar_rect = Rect::new(
+            scrollbar_origin,
+            Size2D::new(scrollbar_thumb_width, scrollbar_thickness),
+        )
+        .to_webrender();
+        let scroll_node_clip_rect = Rect::new(
+            scrollbar_origin,
+            Size2D::new(scrollbar_track_width, scrollbar_thickness),
+        )
+        .to_webrender();
+        let scroll_node_content_rect = Rect::new(
+            scrollbar_origin,
+            Size2D::new(scroll_node_overflow_width, scrollbar_thickness),
+        )
+        .to_webrender();
+
+        (
+            scrollbar_rect,
+            scroll_node_clip_rect,
+            scroll_node_content_rect,
+        )
+    }
+
+    fn place_vertical_scrollbar(
+        padding_rect: &PhysicalRect<Au>,
+        scrollable_overflow_size: &Size2D<Au, CSSPixel>,
+        containing_block_rect: &PhysicalRect<Au>,
+    ) -> (LayoutRect, LayoutRect, LayoutRect) {
+        let scrollbar_thickness = Au::from_px(SCROLLBAR_THICKNESS);
+
+        let scrollbar_track_height = padding_rect.height();
+        let scrollbar_thumb_height =
+            scrollbar_track_height * scrollbar_track_height.0 / scrollable_overflow_size.height.0;
+
+        let scroll_node_overflow_height = scrollbar_track_height * 2 - scrollbar_thumb_height;
+
+        let scrollbar_origin = Point2D::new(
+            padding_rect.max_x() - scrollbar_thickness,
+            padding_rect.min_y(),
+        ) + containing_block_rect.origin.to_vector();
+
+        let scrollbar_rect = Rect::new(
+            scrollbar_origin,
+            Size2D::new(scrollbar_thickness, scrollbar_thumb_height),
+        )
+        .to_webrender();
+        let scroll_node_clip_rect = Rect::new(
+            scrollbar_origin,
+            Size2D::new(scrollbar_thickness, scrollbar_track_height),
+        )
+        .to_webrender();
+        let scroll_node_content_rect = Rect::new(
+            scrollbar_origin,
+            Size2D::new(scrollbar_thickness, scroll_node_overflow_height),
+        )
+        .to_webrender();
+
+        (
+            scrollbar_rect,
+            scroll_node_clip_rect,
+            scroll_node_content_rect,
+        )
     }
 }
 
 struct OverflowFrameData {
     clip_id: ClipId,
     scroll_frame_data: Option<ScrollFrameData>,
-    frame_scrollbar_data: Option<Box<ScrollbarDescriptor>>,
+    scrollbar_descriptor: Option<Box<ScrollbarDescriptor>>,
 }
 
 impl BoxFragment {
@@ -1428,7 +1471,7 @@ impl BoxFragment {
                     is_hit_test_for_scrollable_overflow: false,
                     is_collapsed_table_borders: false,
                     text_decorations: text_decorations.clone(),
-                    scrollbar_descriptor: None,
+                    scrollbar_slider: None,
                 });
         };
 
@@ -1443,30 +1486,51 @@ impl BoxFragment {
         // We want to build the scroll frame after the background and border, because
         // they shouldn't scroll with the rest of the box content.
         if let Some(overflow_frame_data) = self.build_overflow_frame_if_necessary(
-            // MYTODO: need to store the information as well
             stacking_context_tree,
             new_scroll_node_id,
             new_clip_id,
             &containing_block.rect,
         ) {
             new_clip_id = overflow_frame_data.clip_id;
-            if overflow_frame_data.scroll_frame_data.is_some() {
-                stacking_context
-                    .contents
-                    .push(StackingContextContent::Fragment {
-                        scroll_node_id: new_scroll_node_id,
-                        reference_frame_scroll_node_id:
-                            reference_frame_scroll_node_id_for_fragments,
-                        clip_id: new_clip_id,
-                        section,
-                        containing_block: containing_block.rect,
-                        fragment: fragment.clone(),
-                        is_hit_test_for_scrollable_overflow: false,
-                        is_collapsed_table_borders: false,
-                        text_decorations: text_decorations.clone(),
-                        scrollbar_descriptor: overflow_frame_data.frame_scrollbar_data,
-                    });
+
+            // MYTODO: need to document or tidy this
+            if let Some(scrollbar_descriptor) = overflow_frame_data.scrollbar_descriptor {
+                if let Some(horizontal_slider) = scrollbar_descriptor.horizontal {
+                    stacking_context
+                        .contents
+                        .push(StackingContextContent::Fragment {
+                            scroll_node_id: horizontal_slider.scroll_node_id,
+                            reference_frame_scroll_node_id:
+                                reference_frame_scroll_node_id_for_fragments,
+                            clip_id: new_clip_id,
+                            section,
+                            containing_block: containing_block.rect,
+                            fragment: fragment.clone(),
+                            is_hit_test_for_scrollable_overflow: false,
+                            is_collapsed_table_borders: false,
+                            text_decorations: text_decorations.clone(),
+                            scrollbar_slider: Some(Box::new(horizontal_slider)),
+                        });
+                }
+                if let Some(vertical_slider) = scrollbar_descriptor.vertical {
+                    stacking_context
+                        .contents
+                        .push(StackingContextContent::Fragment {
+                            scroll_node_id: vertical_slider.scroll_node_id,
+                            reference_frame_scroll_node_id:
+                                reference_frame_scroll_node_id_for_fragments,
+                            clip_id: new_clip_id,
+                            section,
+                            containing_block: containing_block.rect,
+                            fragment: fragment.clone(),
+                            is_hit_test_for_scrollable_overflow: false,
+                            is_collapsed_table_borders: false,
+                            text_decorations: text_decorations.clone(),
+                            scrollbar_slider: Some(Box::new(vertical_slider)),
+                        });
+                }
             }
+
             if let Some(scroll_frame_data) = overflow_frame_data.scroll_frame_data {
                 new_scroll_node_id = scroll_frame_data.scroll_tree_node_id;
                 new_scroll_frame_size = Some(scroll_frame_data.scroll_frame_rect.size());
@@ -1483,7 +1547,7 @@ impl BoxFragment {
                         is_hit_test_for_scrollable_overflow: true,
                         is_collapsed_table_borders: false,
                         text_decorations: text_decorations.clone(),
-                        scrollbar_descriptor: None,
+                        scrollbar_slider: None,
                     });
             }
         }
@@ -1585,7 +1649,7 @@ impl BoxFragment {
                     is_hit_test_for_scrollable_overflow: false,
                     is_collapsed_table_borders: true,
                     text_decorations: text_decorations.clone(),
-                    scrollbar_descriptor: None,
+                    scrollbar_slider: None,
                 });
         }
     }
@@ -1691,7 +1755,7 @@ impl BoxFragment {
             return Some(OverflowFrameData {
                 clip_id,
                 scroll_frame_data: None,
-                frame_scrollbar_data: None,
+                scrollbar_descriptor: None,
             });
         }
 
@@ -1724,14 +1788,17 @@ impl BoxFragment {
             external_scroll_id,
             self.scrollable_overflow().to_webrender(),
             scroll_frame_rect,
+            LayoutVector2D::zero(),
             sensitivity,
         );
 
-        let frame_scrollbar_data = ScrollbarDescriptor::compute_scrollbar_if_necessary(
-            &overflow,
-            &self.padding_rect(),
-            &self.scrollable_overflow().size,
+        let scrollbar_descriptor = self.build_scrollbar_if_necessary(
+            stacking_context_tree,
+            parent_scroll_node_id,
+            scroll_tree_node_id,
             containing_block_rect,
+            &overflow,
+            &sensitivity,
         );
 
         Some(OverflowFrameData {
@@ -1740,8 +1807,109 @@ impl BoxFragment {
                 scroll_tree_node_id,
                 scroll_frame_rect,
             }),
-            frame_scrollbar_data,
+            scrollbar_descriptor,
         })
+    }
+
+    /// Need to define axes scroll sensitivity well for scrollbar
+    fn build_scrollbar_if_necessary(
+        &self,
+        stacking_context_tree: &mut StackingContextTree,
+        parent_scroll_node_id: ScrollTreeNodeId,
+        main_scroll_tree_node_id: ScrollTreeNodeId,
+        containing_block_rect: &PhysicalRect<Au>,
+        overflow: &AxesOverflow,
+        sensitivity: &AxesScrollSensitivity,
+    ) -> Option<Box<ScrollbarDescriptor>> {
+        let padding_rect = self.padding_rect();
+        let scrollable_overflow_size = self.scrollable_overflow().size;
+        let tag = self.base.tag?;
+
+        let vertical_slider = if ScrollbarDescriptor::should_render_vertical_scrollbar(
+            overflow,
+            &padding_rect,
+            &scrollable_overflow_size,
+        ) {
+            let (vertical_thumb, vertical_track, vertical_overflow_rect) =
+                ScrollbarDescriptor::place_vertical_scrollbar(
+                    &padding_rect,
+                    &scrollable_overflow_size,
+                    containing_block_rect,
+                );
+
+            let external_scroll_id = wr::ExternalScrollId(
+                tag.to_display_list_fragment_id_for_scrollbar(),
+                stacking_context_tree.paint_info.pipeline_id,
+            );
+
+            let vertical_scroll_tree_node_id = stacking_context_tree.define_scroll_frame(
+                parent_scroll_node_id,
+                external_scroll_id,
+                vertical_overflow_rect,
+                vertical_track,
+                (vertical_overflow_rect.size() - vertical_track.size()).to_vector(), // MYTODO: maybe tidy up this
+                *sensitivity,
+            );
+
+            Some(ScrollbarSlider {
+                thumb: vertical_thumb,
+                track: vertical_track,
+                scroll_node_id: vertical_scroll_tree_node_id,
+            })
+        } else {
+            None
+        };
+
+        let horizontal_slider = if ScrollbarDescriptor::should_render_horizontal_scrollbar(
+            overflow,
+            &padding_rect,
+            &scrollable_overflow_size,
+        ) {
+            let (horizontal_thumb, horizontal_track, horizontal_overflow_rect) =
+                ScrollbarDescriptor::place_horizontal_scrollbar(
+                    &padding_rect,
+                    &scrollable_overflow_size,
+                    containing_block_rect,
+                );
+
+            let external_scroll_id = wr::ExternalScrollId(
+                tag.to_display_list_fragment_id_for_scrollbar(),
+                stacking_context_tree.paint_info.pipeline_id,
+            );
+
+            let horizontal_scroll_tree_node_id = stacking_context_tree.define_scroll_frame(
+                parent_scroll_node_id,
+                external_scroll_id,
+                horizontal_overflow_rect,
+                horizontal_track,
+                (horizontal_overflow_rect.size() - horizontal_track.size()).to_vector(), // MYTODO: maybe tidy up this
+                *sensitivity,
+            );
+
+            Some(ScrollbarSlider {
+                thumb: horizontal_thumb,
+                track: horizontal_track,
+                scroll_node_id: horizontal_scroll_tree_node_id,
+            })
+        } else {
+            None
+        };
+
+        stacking_context_tree
+            .paint_info
+            .scroll_tree
+            .set_linked_nodes(
+                main_scroll_tree_node_id,
+                horizontal_slider
+                    .as_ref()
+                    .map(|slider| slider.scroll_node_id),
+                vertical_slider.as_ref().map(|slider| slider.scroll_node_id),
+            );
+
+        Some(Box::new(ScrollbarDescriptor {
+            horizontal: horizontal_slider,
+            vertical: vertical_slider,
+        }))
     }
 
     fn build_sticky_frame_if_necessary(

--- a/components/layout/fragment_tree/base_fragment.rs
+++ b/components/layout/fragment_tree/base_fragment.rs
@@ -8,9 +8,11 @@ use app_units::Au;
 use atomic_refcell::AtomicRef;
 use bitflags::bitflags;
 use html5ever::local_name;
-use layout_api::{AuxiliaryFragmentType, combine_id_with_fragment_type, combine_id_with_fragment_type_and_aux};
 use layout_api::wrapper_traits::{
     PseudoElementChain, ThreadSafeLayoutElement, ThreadSafeLayoutNode,
+};
+use layout_api::{
+    AuxiliaryFragmentType, combine_id_with_fragment_type, combine_id_with_fragment_type_and_aux,
 };
 use malloc_size_of::malloc_size_of_is_0;
 use malloc_size_of_derive::MallocSizeOf;
@@ -285,8 +287,15 @@ impl Tag {
     pub(crate) fn to_display_list_fragment_id(self) -> u64 {
         combine_id_with_fragment_type(self.node.id(), self.pseudo_element_chain.primary.into())
     }
-    pub(crate) fn to_display_list_fragment_id_for_aux(self, aux_fragment_type: AuxiliaryFragmentType) -> u64 {
-        combine_id_with_fragment_type_and_aux(self.node.id(), self.pseudo_element_chain.primary.into(), aux_fragment_type)
+    pub(crate) fn to_display_list_fragment_id_for_aux(
+        self,
+        aux_fragment_type: AuxiliaryFragmentType,
+    ) -> u64 {
+        combine_id_with_fragment_type_and_aux(
+            self.node.id(),
+            self.pseudo_element_chain.primary.into(),
+            aux_fragment_type,
+        )
     }
 }
 

--- a/components/layout/fragment_tree/base_fragment.rs
+++ b/components/layout/fragment_tree/base_fragment.rs
@@ -285,6 +285,9 @@ impl Tag {
     pub(crate) fn to_display_list_fragment_id(self) -> u64 {
         combine_id_with_fragment_type(self.node.id(), self.pseudo_element_chain.primary.into())
     }
+    pub(crate) fn to_display_list_fragment_id_for_scrollbar(self) -> u64 {
+        combine_id_with_fragment_type(self.node.id(), layout_api::FragmentType::HorizontalScrollbar)
+    }
 }
 
 impl From<ServoThreadSafeLayoutNode<'_>> for Tag {

--- a/components/layout/fragment_tree/base_fragment.rs
+++ b/components/layout/fragment_tree/base_fragment.rs
@@ -8,7 +8,7 @@ use app_units::Au;
 use atomic_refcell::AtomicRef;
 use bitflags::bitflags;
 use html5ever::local_name;
-use layout_api::combine_id_with_fragment_type;
+use layout_api::{AuxiliaryFragmentType, combine_id_with_fragment_type, combine_id_with_fragment_type_and_aux};
 use layout_api::wrapper_traits::{
     PseudoElementChain, ThreadSafeLayoutElement, ThreadSafeLayoutNode,
 };
@@ -285,8 +285,8 @@ impl Tag {
     pub(crate) fn to_display_list_fragment_id(self) -> u64 {
         combine_id_with_fragment_type(self.node.id(), self.pseudo_element_chain.primary.into())
     }
-    pub(crate) fn to_display_list_fragment_id_for_scrollbar(self) -> u64 {
-        combine_id_with_fragment_type(self.node.id(), layout_api::FragmentType::HorizontalScrollbar)
+    pub(crate) fn to_display_list_fragment_id_for_aux(self, aux_fragment_type: AuxiliaryFragmentType) -> u64 {
+        combine_id_with_fragment_type_and_aux(self.node.id(), self.pseudo_element_chain.primary.into(), aux_fragment_type)
     }
 }
 

--- a/components/layout/layout_impl.rs
+++ b/components/layout/layout_impl.rs
@@ -1417,7 +1417,7 @@ impl LayoutThread {
             return false;
         };
 
-        if let Some(offset) = stacking_context_tree
+        if let Some(result) = stacking_context_tree
             .paint_info
             .scroll_tree
             .set_scroll_offset_for_node_with_external_scroll_id(
@@ -1426,10 +1426,11 @@ impl LayoutThread {
                 ScrollType::Script,
             )
         {
+            let (_, new_offset) = result.first();
             self.paint_api.scroll_node_by_delta(
                 self.webview_id,
                 self.id.into(),
-                offset,
+                *new_offset,
                 external_scroll_id,
             );
             true

--- a/components/paint/painter.rs
+++ b/components/paint/painter.rs
@@ -703,14 +703,16 @@ impl Painter {
         if need_zoom {
             self.send_root_pipeline_display_list_in_transaction(&mut transaction);
         }
-        for update in scroll_offset_updates {
-            transaction.set_scroll_offsets(
-                update.external_scroll_id,
-                vec![SampledScrollOffset {
-                    offset: update.offset,
-                    generation: 0,
-                }],
-            );
+        for result in scroll_offset_updates {
+            for (external_scroll_id, offset) in result.inner.iter() {
+                transaction.set_scroll_offsets(
+                    *external_scroll_id,
+                    vec![SampledScrollOffset {
+                        offset: *offset,
+                        generation: 0,
+                    }],
+                );
+            }
         }
 
         self.generate_frame(&mut transaction, RenderReasons::APZ);
@@ -859,7 +861,7 @@ impl Painter {
             return;
         };
 
-        let Some(offset) = pipeline_details
+        let Some(scroll_result) = pipeline_details
             .scroll_tree
             .set_scroll_offset_for_node_with_external_scroll_id(
                 external_scroll_id,
@@ -874,12 +876,11 @@ impl Painter {
         };
 
         let mut transaction = Transaction::new();
-        // MYTODO need to push only the changed offsets.
-        for (external_scroll_id, offset) in pipeline_details.scroll_tree.scroll_offsets() {
+        for (external_scroll_id, offset) in scroll_result.iter() {
             transaction.set_scroll_offsets(
-                external_scroll_id,
+                *external_scroll_id,
                 vec![SampledScrollOffset {
-                    offset,
+                    offset: *offset,
                     generation: 0,
                 }],
             );

--- a/components/paint/painter.rs
+++ b/components/paint/painter.rs
@@ -874,8 +874,8 @@ impl Painter {
         };
 
         let mut transaction = Transaction::new();
+        // MYTODO need to push only the changed offsets.
         for (external_scroll_id, offset) in pipeline_details.scroll_tree.scroll_offsets() {
-            println!("[ztp] external_scroll_id {:?}, offset {:?}", external_scroll_id, offset);
             transaction.set_scroll_offsets(
                 external_scroll_id,
                 vec![SampledScrollOffset {

--- a/components/paint/painter.rs
+++ b/components/paint/painter.rs
@@ -874,13 +874,16 @@ impl Painter {
         };
 
         let mut transaction = Transaction::new();
-        transaction.set_scroll_offsets(
-            external_scroll_id,
-            vec![SampledScrollOffset {
-                offset,
-                generation: 0,
-            }],
-        );
+        for (external_scroll_id, offset) in pipeline_details.scroll_tree.scroll_offsets() {
+            println!("[ztp] external_scroll_id {:?}, offset {:?}", external_scroll_id, offset);
+            transaction.set_scroll_offsets(
+                external_scroll_id,
+                vec![SampledScrollOffset {
+                    offset,
+                    generation: 0,
+                }],
+            );
+        }
 
         self.generate_frame(&mut transaction, RenderReasons::APZ);
         self.send_transaction(transaction);

--- a/components/paint/webview_renderer.rs
+++ b/components/paint/webview_renderer.rs
@@ -17,7 +17,7 @@ use embedder_traits::{
 use euclid::{Scale, Vector2D};
 use log::{debug, warn};
 use malloc_size_of::MallocSizeOf;
-use paint_api::display_list::ScrollType;
+use paint_api::display_list::{ScrollResult as ScrollTreeScrollResult, ScrollType};
 use paint_api::viewport_description::{
     DEFAULT_PAGE_ZOOM, MAX_PAGE_ZOOM, MIN_PAGE_ZOOM, ViewportDescription,
 };
@@ -61,12 +61,8 @@ pub(crate) enum ScrollZoomEvent {
 #[derive(Clone, Debug)]
 pub(crate) struct ScrollResult {
     pub hit_test_result: PaintHitTestResult,
-    /// The [`ExternalScrollId`] of the node that was actually scrolled.
-    ///
-    /// Note that this is an inclusive ancestor of `external_scroll_id` in
-    /// [`Self::hit_test_result`].
-    pub external_scroll_id: ExternalScrollId,
-    pub offset: LayoutVector2D,
+    /// The pairs of [`ExternalScrollId`] and offset of the nodes that was actually scrolled.
+    pub inner: ScrollTreeScrollResult,
 }
 
 #[derive(Debug, PartialEq)]
@@ -793,7 +789,7 @@ impl WebViewRenderer {
         if let Some(ref scroll_result) = scroll_result {
             self.send_scroll_positions_to_layout_for_pipeline(
                 scroll_result.hit_test_result.pipeline_id,
-                scroll_result.external_scroll_id,
+                scroll_result.inner.first().0,
             );
         } else {
             self.touch_handler.stop_fling_if_needed();
@@ -844,12 +840,12 @@ impl WebViewRenderer {
             if previous_pipeline_id.replace(hit_test_result.pipeline_id) !=
                 Some(hit_test_result.pipeline_id)
             {
-                let scroll_result = pipeline_details.scroll_tree.scroll_node_or_ancestor(
+                let maybe_scroll_result = pipeline_details.scroll_tree.scroll_node_or_ancestor(
                     hit_test_result.external_scroll_id,
                     scroll_location,
                     ScrollType::InputEvents,
                 );
-                if let Some((external_scroll_id, offset)) = scroll_result {
+                if let Some(scroll_result) = maybe_scroll_result {
                     // We would like to cache the hit test for the node that that actually scrolls
                     // while panning, which we don't know until right now (as some nodes
                     // might be at the end of their scroll area). In particular, directionality of
@@ -861,8 +857,7 @@ impl WebViewRenderer {
                     );
                     return Some(ScrollResult {
                         hit_test_result,
-                        external_scroll_id,
-                        offset,
+                        inner: scroll_result,
                     });
                 }
             }
@@ -900,7 +895,7 @@ impl WebViewRenderer {
         };
 
         let remaining = remaining / device_pixels_per_page_pixel;
-        let Some((external_scroll_id, offset)) = root_pipeline.scroll_tree.scroll_node_or_ancestor(
+        let Some(result) = root_pipeline.scroll_tree.scroll_node_or_ancestor(
             ExternalScrollId(0, root_pipeline_id.into()),
             ScrollLocation::Delta(remaining.cast_unit()),
             // These are initiated only by keyboard events currently.
@@ -909,15 +904,17 @@ impl WebViewRenderer {
             return (pinch_zoom_result, vec![]);
         };
 
+        let (external_scroll_id, _) = result.first();
+
         let hit_test_result = PaintHitTestResult {
             pipeline_id: root_pipeline_id,
             // It's difficult to get a good value for this as it needs to be piped
             // all the way through script and back here.
             point_in_viewport: Default::default(),
-            external_scroll_id,
+            external_scroll_id: *external_scroll_id,
         };
 
-        self.send_scroll_positions_to_layout_for_pipeline(root_pipeline_id, external_scroll_id);
+        self.send_scroll_positions_to_layout_for_pipeline(root_pipeline_id, *external_scroll_id);
 
         if pinch_zoom_result == PinchZoomResult::DidNotPinchZoom {
             self.send_pinch_zoom_infos_to_script();
@@ -925,8 +922,7 @@ impl WebViewRenderer {
 
         let scroll_result = ScrollResult {
             hit_test_result,
-            external_scroll_id,
-            offset,
+            inner: result,
         };
         (pinch_zoom_result, vec![scroll_result])
     }

--- a/components/script/dom/document_event_handler.rs
+++ b/components/script/dom/document_event_handler.rs
@@ -1801,7 +1801,7 @@ impl DocumentEventHandler {
             document.handle_viewport_scroll_event();
         } else {
             // Otherwise, check whether it is for a relevant element within the document.
-            let Some(node_id) = node_id_from_scroll_id(scrolled_node.0 as usize) else {
+            let Some(node_id) = node_id_from_scroll_id(scrolled_node.0) else {
                 return;
             };
             let node = unsafe {

--- a/components/shared/layout/lib.rs
+++ b/components/shared/layout/lib.rs
@@ -698,7 +698,13 @@ pub enum FragmentType {
     AfterPseudoContent,
     /// A StackingContextContent to represent the scrollbar. // MYTODO: need to expand the fragment type to include vertical scrollbar
     HorizontalScrollbar,
+    /// A StackingContextContent to represent the scrollbar. // MYTODO: need to expand the fragment type to include vertical scrollbar
+    VerticalScrollbar,
 }
+
+const SIZE_OF_FRAGMENT_TYPE: usize = 3;
+const FRAGMENT_TYPE_MASK: usize = (1 << SIZE_OF_FRAGMENT_TYPE) - 1;
+const SCROLL_ID_SHIFT: usize = SIZE_OF_FRAGMENT_TYPE - 2;
 
 impl From<Option<PseudoElement>> for FragmentType {
     fn from(value: Option<PseudoElement>) -> Self {
@@ -717,29 +723,31 @@ static NEXT_SPECIAL_SCROLL_ROOT_ID: AtomicU64 = AtomicU64::new(0);
 
 /// If none of the bits outside this mask are set, the scroll root is a special scroll root.
 /// Note that we assume that the top 16 bits of the address space are unused on the platform.
-const SPECIAL_SCROLL_ROOT_ID_MASK: u64 = 0xffff;
+const SPECIAL_SCROLL_ROOT_ID_MASK: u64 = 0xffff; //MYTODO: what is this
 
 /// Returns a new scroll root ID for a scroll root.
 fn next_special_id() -> u64 {
     // We shift this left by 2 to make room for the fragment type ID.
-    ((NEXT_SPECIAL_SCROLL_ROOT_ID.fetch_add(1, Ordering::SeqCst) + 1) << 2) &
+    ((NEXT_SPECIAL_SCROLL_ROOT_ID.fetch_add(1, Ordering::SeqCst) + 1) << SIZE_OF_FRAGMENT_TYPE) &
         SPECIAL_SCROLL_ROOT_ID_MASK
 }
 
 pub fn combine_id_with_fragment_type(id: usize, fragment_type: FragmentType) -> u64 {
-    debug_assert_eq!(id & (fragment_type as usize), 0);
+    debug_assert_eq!(id & FRAGMENT_TYPE_MASK, 0);
+    let shifted_id = (id as u64) << SCROLL_ID_SHIFT;
     if fragment_type == FragmentType::FragmentBody {
-        id as u64
-    } else if fragment_type == FragmentType::HorizontalScrollbar {
-        id as u64 | (fragment_type as u64)
+        shifted_id
+    } else if matches!(fragment_type, FragmentType::HorizontalScrollbar | FragmentType::VerticalScrollbar) {
+        shifted_id | (fragment_type as u64)
     } else {
         next_special_id() | (fragment_type as u64) // I have no idea why are we using next_special_id instead of node_id
     }
 }
 
-pub fn node_id_from_scroll_id(id: usize) -> Option<usize> {
-    if (id as u64 & !SPECIAL_SCROLL_ROOT_ID_MASK) != 0 {
-        return Some(id & !3);
+pub fn node_id_from_scroll_id(id: u64) -> Option<usize> {
+    if (id & !SPECIAL_SCROLL_ROOT_ID_MASK) != 0 {
+        let node_id = (id & (!FRAGMENT_TYPE_MASK as u64)) >> SCROLL_ID_SHIFT;
+        return Some(node_id.try_into().expect("We have ensured that this fits in u32"));
     }
     None
 }

--- a/components/shared/layout/lib.rs
+++ b/components/shared/layout/lib.rs
@@ -698,7 +698,6 @@ pub enum FragmentType {
     AfterPseudoContent,
 }
 
-
 /// The type to represent the additional fragment that is generated along with the main [`FragmentType`].
 ///
 /// Currently we use this to identify such fragment, maintain the offset of such fragment across reflow.
@@ -754,7 +753,11 @@ pub fn combine_id_with_fragment_type(id: usize, fragment_type: FragmentType) -> 
     combine_id_with_fragment_type_and_aux(id, fragment_type, AuxiliaryFragmentType::None)
 }
 
-pub fn combine_id_with_fragment_type_and_aux(id: usize, fragment_type: FragmentType, aux_fragment_type: AuxiliaryFragmentType) -> u64 {
+pub fn combine_id_with_fragment_type_and_aux(
+    id: usize,
+    fragment_type: FragmentType,
+    aux_fragment_type: AuxiliaryFragmentType,
+) -> u64 {
     let shifted_id = (id as u64) << TOTAL_SIZE_OF_FRAGMENT_TYPE;
     shifted_id | fragment_type.into_mask_with_aux(aux_fragment_type)
 }
@@ -762,7 +765,11 @@ pub fn combine_id_with_fragment_type_and_aux(id: usize, fragment_type: FragmentT
 pub fn node_id_from_scroll_id(id: u64) -> Option<usize> {
     if (id & !SPECIAL_SCROLL_ROOT_ID_MASK) != 0 {
         let node_id = id >> TOTAL_SIZE_OF_FRAGMENT_TYPE;
-        return Some(node_id.try_into().expect("We have ensured that this fits in u32"));
+        return Some(
+            node_id
+                .try_into()
+                .expect("We have ensured that this fits in u32"),
+        );
     }
     None
 }

--- a/components/shared/layout/lib.rs
+++ b/components/shared/layout/lib.rs
@@ -696,15 +696,33 @@ pub enum FragmentType {
     BeforePseudoContent,
     /// A StackingContext created to contain ::after pseudo-element content.
     AfterPseudoContent,
-    /// A StackingContextContent to represent the scrollbar. // MYTODO: need to expand the fragment type to include vertical scrollbar
+}
+
+
+/// The type to represent the additional fragment that is generated along with the main [`FragmentType`].
+///
+/// Currently we use this to identify such fragment, maintain the offset of such fragment across reflow.
+#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, MallocSizeOf, PartialEq, Serialize)]
+pub enum AuxiliaryFragmentType {
+    None,
+    /// Fragment representing the horizontal scrollbar of a scroll container.
     HorizontalScrollbar,
-    /// A StackingContextContent to represent the scrollbar. // MYTODO: need to expand the fragment type to include vertical scrollbar
+    /// Fragment representing the vertical scrollbar of a scroll container.
     VerticalScrollbar,
 }
 
-const SIZE_OF_FRAGMENT_TYPE: usize = 3;
-const FRAGMENT_TYPE_MASK: usize = (1 << SIZE_OF_FRAGMENT_TYPE) - 1;
-const SCROLL_ID_SHIFT: usize = SIZE_OF_FRAGMENT_TYPE - 2;
+/// The size of [`FragmentType`] in bits.
+const SIZE_OF_AUXILIRARY_FRAGMENT_TYPE: usize = 2;
+/// The size of [`AuxiliaryFragmentType`] in bits. MYTODO: maybe there is a programmatical way to get this.
+const SIZE_OF_FRAGMENT_TYPE: usize = 2;
+
+const TOTAL_SIZE_OF_FRAGMENT_TYPE: usize = SIZE_OF_FRAGMENT_TYPE + SIZE_OF_AUXILIRARY_FRAGMENT_TYPE;
+
+impl FragmentType {
+    const fn into_mask_with_aux(self, aux_fragment_type: AuxiliaryFragmentType) -> u64 {
+        ((self as u64) << SIZE_OF_AUXILIRARY_FRAGMENT_TYPE) | (aux_fragment_type as u64)
+    }
+}
 
 impl From<Option<PseudoElement>> for FragmentType {
     fn from(value: Option<PseudoElement>) -> Self {
@@ -733,20 +751,17 @@ fn next_special_id() -> u64 {
 }
 
 pub fn combine_id_with_fragment_type(id: usize, fragment_type: FragmentType) -> u64 {
-    debug_assert_eq!(id & FRAGMENT_TYPE_MASK, 0);
-    let shifted_id = (id as u64) << SCROLL_ID_SHIFT;
-    if fragment_type == FragmentType::FragmentBody {
-        shifted_id
-    } else if matches!(fragment_type, FragmentType::HorizontalScrollbar | FragmentType::VerticalScrollbar) {
-        shifted_id | (fragment_type as u64)
-    } else {
-        next_special_id() | (fragment_type as u64) // I have no idea why are we using next_special_id instead of node_id
-    }
+    combine_id_with_fragment_type_and_aux(id, fragment_type, AuxiliaryFragmentType::None)
+}
+
+pub fn combine_id_with_fragment_type_and_aux(id: usize, fragment_type: FragmentType, aux_fragment_type: AuxiliaryFragmentType) -> u64 {
+    let shifted_id = (id as u64) << TOTAL_SIZE_OF_FRAGMENT_TYPE;
+    shifted_id | fragment_type.into_mask_with_aux(aux_fragment_type)
 }
 
 pub fn node_id_from_scroll_id(id: u64) -> Option<usize> {
     if (id & !SPECIAL_SCROLL_ROOT_ID_MASK) != 0 {
-        let node_id = (id & (!FRAGMENT_TYPE_MASK as u64)) >> SCROLL_ID_SHIFT;
+        let node_id = id >> TOTAL_SIZE_OF_FRAGMENT_TYPE;
         return Some(node_id.try_into().expect("We have ensured that this fits in u32"));
     }
     None

--- a/components/shared/layout/lib.rs
+++ b/components/shared/layout/lib.rs
@@ -696,6 +696,8 @@ pub enum FragmentType {
     BeforePseudoContent,
     /// A StackingContext created to contain ::after pseudo-element content.
     AfterPseudoContent,
+    /// A StackingContextContent to represent the scrollbar. // MYTODO: need to expand the fragment type to include vertical scrollbar
+    HorizontalScrollbar,
 }
 
 impl From<Option<PseudoElement>> for FragmentType {
@@ -728,8 +730,10 @@ pub fn combine_id_with_fragment_type(id: usize, fragment_type: FragmentType) -> 
     debug_assert_eq!(id & (fragment_type as usize), 0);
     if fragment_type == FragmentType::FragmentBody {
         id as u64
+    } else if fragment_type == FragmentType::HorizontalScrollbar {
+        id as u64 | (fragment_type as u64)
     } else {
-        next_special_id() | (fragment_type as u64)
+        next_special_id() | (fragment_type as u64) // I have no idea why are we using next_special_id instead of node_id
     }
 }
 

--- a/components/shared/paint/display_list.rs
+++ b/components/shared/paint/display_list.rs
@@ -248,7 +248,6 @@ impl ScrollableNodeInfo {
     }
 
     fn scroll_to_webrender_location(
-        // need to handle this
         &mut self,
         scroll_location: ScrollLocation,
         context: ScrollType,
@@ -364,13 +363,13 @@ impl ScrollTreeNode {
         &mut self,
         scroll_location: ScrollLocation,
         context: ScrollType,
-    ) -> Option<(ExternalScrollId, LayoutVector2D)> {
+    ) -> Option<ScrollResult> {
         let SpatialTreeNodeInfo::Scroll(ref mut info) = self.info else {
             return None;
         };
 
         info.scroll_to_webrender_location(scroll_location, context)
-            .map(|location| (info.external_id, location))
+            .map(|location| ScrollResult::new(info.external_id, location))
     }
 
     pub fn debug_print(&self, print_tree: &mut PrintTree, node_index: usize) {
@@ -464,6 +463,39 @@ pub struct ScrollTree {
     pub nodes: Vec<ScrollTreeNode>,
 }
 
+/// The [`ScrollResult`] of a scroll operation for a node of the scroll tree.
+/// The first element would contains the main node to be scrolled, and the rest
+/// are containing the additional node that is affected by the scrolls.
+#[derive(Clone, Debug)]
+pub struct ScrollResult(Vec<(ExternalScrollId, LayoutVector2D)>);
+
+impl ScrollResult {
+    pub fn new_from_pair(scroll_pair: (ExternalScrollId, LayoutVector2D)) -> Self {
+        ScrollResult(
+            vec![scroll_pair]
+        )
+    }
+
+    pub fn new(external_scroll_id: ExternalScrollId, offset: LayoutVector2D) -> Self {
+        ScrollResult(
+            vec![(external_scroll_id, offset)]
+        )
+    }
+
+    pub fn push(&mut self, external_scroll_id: ExternalScrollId, offset: LayoutVector2D) {
+        self.0.push((external_scroll_id, offset));
+    }
+
+    pub fn first(&self) -> &(ExternalScrollId, LayoutVector2D) {
+        self.0.first().expect("We had ensured that ScrollResult is non-empty")
+    }
+
+    pub fn iter(&self) -> impl Iterator<Item = &(ExternalScrollId, LayoutVector2D)> {
+        self.0.iter()
+    }
+}
+
+
 impl ScrollTree {
     /// Add a scroll node to this ScrollTree returning the id of the new node.
     pub fn add_scroll_tree_node(
@@ -545,74 +577,59 @@ impl ScrollTree {
     pub fn maybe_push_scroll_update_for_scrollbar(
         &mut self,
         id: ScrollTreeNodeId,
-        new_offset: &LayoutVector2D,
+        result: &mut ScrollResult,
         context: ScrollType,
     ) {
-        let Some(info) = self.get_node(id).as_scroll_info().cloned() else {
+        let Some(info) = self.get_node(id).as_scroll_info() else {
             return;
         };
 
-        // MYTODO need to check this before to optimize
-        let Some(linked_nodes) = info.linked_nodes.as_deref() else {
+        let Some(linked_nodes) = info.linked_nodes.as_deref().cloned() else {
             return;
         };
+
+        let scrollable_size = info.scrollable_size();
+        let (_, new_offset) = *result.first();
 
         match linked_nodes {
-            LinkedScrollNodes::VerticalScrollbar(node_id) => {
-                let sc_node = self.get_node_mut(*node_id);
-                if let SpatialTreeNodeInfo::Scroll(ref mut sc_info) = sc_node.info {
-                    let sc_offset = LayoutVector2D::new(
-                        info.offset.x,
-                        new_offset.y * sc_info.content_rect.size().height /
-                            sc_info.clip_rect.size().height,
-                    );
-                    sc_info.scroll_to_offset(sc_offset, context);
-                }
-            },
             LinkedScrollNodes::ContainerWithScrollbars {
                 horizontal: horizontal_id,
                 vertical: vertical_id,
             } => {
                 if let Some(horizontal_id) = horizontal_id {
-                    let horizontal_node = self.get_node_mut(*horizontal_id);
+                    let horizontal_node = self.get_node_mut(horizontal_id);
                     if let SpatialTreeNodeInfo::Scroll(ref mut horizontal_info) =
                         horizontal_node.info
                     {
-                        let scrollable_width = horizontal_info.scrollable_size().width;
-                        let scaled_offset_x = new_offset.x * info.clip_rect.size().width /
-                                info.content_rect.size().width;
+                        let sc_scrollable_width = horizontal_info.scrollable_size().width;
+                        let scaled_offset_x = new_offset.x * sc_scrollable_width /
+                                scrollable_size.width;
                         let horizontal_offset = LayoutVector2D::new(
-                            scrollable_width - scaled_offset_x,
+                            sc_scrollable_width - scaled_offset_x,
                             0.,
                         );
-                        horizontal_info.scroll_to_offset(horizontal_offset, context);
+                        if let Some(new_offset) = horizontal_info.scroll_to_offset(horizontal_offset, context) {
+                            result.push(horizontal_info.external_id, new_offset);
+                        }
                     }
                 }
                 if let Some(vertical_id) = vertical_id {
-                    let vertical_node = self.get_node_mut(*vertical_id);
+                    let vertical_node = self.get_node_mut(vertical_id);
                     if let SpatialTreeNodeInfo::Scroll(ref mut vertical_info) = vertical_node.info {
-                        let scrollable_height = vertical_info.scrollable_size().height;
-                        let scaled_offset_y = new_offset.y * info.clip_rect.size().height /
-                                info.content_rect.size().height;
+                        let sc_scrollable_height = vertical_info.scrollable_size().height;
+                        let scaled_offset_y = new_offset.y * sc_scrollable_height /
+                                scrollable_size.height;
                         let vertical_offset = LayoutVector2D::new(
                             0.,
-                            scrollable_height - scaled_offset_y,
+                            sc_scrollable_height - scaled_offset_y,
                         );
-                        vertical_info.scroll_to_offset(vertical_offset, context);
+                        if let Some(new_offset) = vertical_info.scroll_to_offset(vertical_offset, context) {
+                            result.push(vertical_info.external_id, new_offset);
+                        }
                     }
                 }
             },
-            LinkedScrollNodes::HorizontalScrollbar(node_id) => {
-                let sc_node = self.get_node_mut(*node_id);
-                if let SpatialTreeNodeInfo::Scroll(ref mut sc_info) = sc_node.info {
-                    let sc_offset = LayoutVector2D::new(
-                        new_offset.x * sc_info.content_rect.size().width /
-                            sc_info.clip_rect.size().width,
-                        info.offset.y,
-                    );
-                    sc_info.scroll_to_offset(sc_offset, context);
-                }
-            },
+            _ => unreachable!("We doesn't allow node of a scrollbar to be scrolled yet."),
         };
     }
 
@@ -621,13 +638,13 @@ impl ScrollTree {
         scroll_node_id: ScrollTreeNodeId,
         scroll_location: ScrollLocation,
         context: ScrollType,
-    ) -> Option<(ExternalScrollId, LayoutVector2D)> {
+    ) -> Option<ScrollResult> {
         let parent = {
             let node = &mut self.get_node_mut(scroll_node_id);
-            let result = node.scroll(scroll_location, context);
-            if let Some((_, ref offset)) = result {
-                self.maybe_push_scroll_update_for_scrollbar(scroll_node_id, offset, context);
-                return result;
+            let mut maybe_result = node.scroll(scroll_location, context);
+            if let Some(ref mut result) = maybe_result {
+                self.maybe_push_scroll_update_for_scrollbar(scroll_node_id, result, context);
+                return maybe_result;
             }
             node.parent
         };
@@ -660,7 +677,7 @@ impl ScrollTree {
         external_id: ExternalScrollId,
         scroll_location: ScrollLocation,
         context: ScrollType,
-    ) -> Option<(ExternalScrollId, LayoutVector2D)> {
+    ) -> Option<ScrollResult> {
         let scroll_node_id = self.node_with_external_scroll_node_id(external_id)?;
         let result = self.scroll_node_or_ancestor_inner(scroll_node_id, scroll_location, context);
         if result.is_some() {
@@ -676,20 +693,20 @@ impl ScrollTree {
         external_scroll_id: ExternalScrollId,
         offset: LayoutVector2D,
         context: ScrollType,
-    ) -> Option<LayoutVector2D> {
+    ) -> Option<ScrollResult> {
         let scroll_tree_node_id = self.node_with_external_scroll_node_id(external_scroll_id)?;
 
-        let result = self
+        let new_offset = self
             .get_node_mut(scroll_tree_node_id)
             .as_scroll_info_mut()?
-            .scroll_to_offset(offset, context);
+            .scroll_to_offset(offset, context)?;
 
-        if let Some(new_offset) = result {
-            self.maybe_push_scroll_update_for_scrollbar(scroll_tree_node_id, &new_offset, context);
-            self.invalidate_cached_transforms();
-        }
+        let mut result = ScrollResult::new(external_scroll_id, new_offset);
 
-        result
+        self.maybe_push_scroll_update_for_scrollbar(scroll_tree_node_id, &mut result, context);
+        self.invalidate_cached_transforms();
+
+        Some(result)
     }
 
     /// Given a set of all scroll offsets coming from the Servo renderer, update all of the offsets
@@ -712,6 +729,7 @@ impl ScrollTree {
     /// Set the offsets of all scrolling nodes in this tree to 0.
     pub fn reset_all_scroll_offsets(&mut self) {
         for node in self.nodes.iter_mut() {
+            // MYTODO: this should handle the initial offsets of the scrollbar as well.
             if let SpatialTreeNodeInfo::Scroll(ref mut scroll_info) = node.info {
                 scroll_info.scroll_to_offset(LayoutVector2D::zero(), ScrollType::Script);
             }

--- a/components/shared/paint/display_list.rs
+++ b/components/shared/paint/display_list.rs
@@ -616,21 +616,6 @@ impl ScrollTree {
         };
     }
 
-    // pub fn scroll_node_info_to_offset(
-    //     &mut self,
-    //     info: &mut ScrollableNodeInfo,
-    //     new_offset: LayoutVector2D,
-    //     context: ScrollType,
-    // ) -> Option<LayoutVector2D> {
-    //     let new_offset = info.scroll_to_offset(new_offset, context);
-
-    //     if let Some(new_offset) = new_offset {
-    //         self.push_scroll_node_update(&info, &new_offset, context); //MYTODO need to rename new_offset
-    //     }
-
-    //     new_offset
-    // }
-
     pub fn scroll_node_or_ancestor_inner(
         &mut self,
         scroll_node_id: ScrollTreeNodeId,

--- a/components/shared/paint/display_list.rs
+++ b/components/shared/paint/display_list.rs
@@ -173,6 +173,17 @@ pub struct ReferenceFrameNodeInfo {
     pub kind: ReferenceFrameKind,
 }
 
+#[derive(Clone, Debug, Deserialize, MallocSizeOf, Serialize)]
+pub enum LinkedScrollNodes {
+    // MYTODO unit test
+    VerticalScrollbar(ScrollTreeNodeId),
+    HorizontalScrollbar(ScrollTreeNodeId),
+    ContainerWithScrollbars {
+        horizontal: Option<ScrollTreeNodeId>,
+        vertical: Option<ScrollTreeNodeId>,
+    },
+}
+
 /// Data stored for nodes in the [ScrollTree] that actually scroll,
 /// as opposed to reference frames and sticky nodes which do not.
 #[derive(Clone, Debug, Deserialize, MallocSizeOf, Serialize)]
@@ -196,9 +207,16 @@ pub struct ScrollableNodeInfo {
     /// Whether or not the scroll offset of this node has changed and it needs it's
     /// cached transformations invalidated.
     pub offset_changed: Cell<bool>,
+
+    /// For a scroll node with a scrollbar the scrollbar's offset also represented by the scroll node. MYTODO
+    pub linked_nodes: Option<Box<LinkedScrollNodes>>,
 }
 
 impl ScrollableNodeInfo {
+    fn set_linked_nodes(&mut self, linked_nodes: LinkedScrollNodes) {
+        self.linked_nodes = Some(Box::new(linked_nodes));
+    }
+
     fn scroll_to_offset(
         &mut self,
         new_offset: LayoutVector2D,
@@ -230,6 +248,7 @@ impl ScrollableNodeInfo {
     }
 
     fn scroll_to_webrender_location(
+        // need to handle this
         &mut self,
         scroll_location: ScrollLocation,
         context: ScrollType,
@@ -399,6 +418,22 @@ impl ScrollTreeNode {
         };
     }
 
+    fn as_scroll_info_mut(&mut self) -> Option<&mut ScrollableNodeInfo> {
+        if let SpatialTreeNodeInfo::Scroll(ref mut info) = self.info {
+            Some(info)
+        } else {
+            None
+        }
+    }
+
+    fn as_scroll_info(&self) -> Option<&ScrollableNodeInfo> {
+        if let SpatialTreeNodeInfo::Scroll(ref info) = self.info {
+            Some(info)
+        } else {
+            None
+        }
+    }
+
     fn invalidate_cached_transforms(&self, scroll_tree: &ScrollTree, ancestors_invalid: bool) {
         let node_invalid = match &self.info {
             SpatialTreeNodeInfo::Scroll(info) => info.offset_changed.take(),
@@ -479,6 +514,123 @@ impl ScrollTree {
         self.get_node(id).webrender_id()
     }
 
+    pub fn set_linked_nodes(
+        &mut self,
+        main_node_id: ScrollTreeNodeId,
+        horizontal_scrollbar_id: Option<ScrollTreeNodeId>,
+        vertical_scrollbar_id: Option<ScrollTreeNodeId>,
+    ) {
+        let Some(main_node) = self.get_node_mut(main_node_id).as_scroll_info_mut() else {
+            return;
+        };
+        main_node.set_linked_nodes(LinkedScrollNodes::ContainerWithScrollbars {
+            horizontal: horizontal_scrollbar_id,
+            vertical: vertical_scrollbar_id,
+        });
+
+        let horizontal_scrollbar =
+            horizontal_scrollbar_id.and_then(|id| self.get_node_mut(id).as_scroll_info_mut());
+        if let Some(horizontal_scrollbar) = horizontal_scrollbar {
+            horizontal_scrollbar
+                .set_linked_nodes(LinkedScrollNodes::HorizontalScrollbar(main_node_id));
+        }
+
+        let vertical_scrollbar =
+            vertical_scrollbar_id.and_then(|id| self.get_node_mut(id).as_scroll_info_mut());
+        if let Some(vertical_scrollbar) = vertical_scrollbar {
+            vertical_scrollbar.set_linked_nodes(LinkedScrollNodes::VerticalScrollbar(main_node_id));
+        }
+    }
+
+    pub fn maybe_push_scroll_update_for_scrollbar(
+        &mut self,
+        id: ScrollTreeNodeId,
+        new_offset: &LayoutVector2D,
+        context: ScrollType,
+    ) {
+        let Some(info) = self.get_node(id).as_scroll_info().cloned() else {
+            return;
+        };
+
+        // MYTODO need to check this before to optimize
+        let Some(linked_nodes) = info.linked_nodes.as_deref() else {
+            return;
+        };
+
+        match linked_nodes {
+            LinkedScrollNodes::VerticalScrollbar(node_id) => {
+                let sc_node = self.get_node_mut(*node_id);
+                if let SpatialTreeNodeInfo::Scroll(ref mut sc_info) = sc_node.info {
+                    let sc_offset = LayoutVector2D::new(
+                        info.offset.x,
+                        new_offset.y * sc_info.content_rect.size().height /
+                            sc_info.clip_rect.size().height,
+                    );
+                    sc_info.scroll_to_offset(sc_offset, context);
+                }
+            },
+            LinkedScrollNodes::ContainerWithScrollbars {
+                horizontal: horizontal_id,
+                vertical: vertical_id,
+            } => {
+                if let Some(horizontal_id) = horizontal_id {
+                    let horizontal_node = self.get_node_mut(*horizontal_id);
+                    if let SpatialTreeNodeInfo::Scroll(ref mut horizontal_info) =
+                        horizontal_node.info
+                    {
+                        let scrollable_width = horizontal_info.scrollable_size().width;
+                        let scaled_offset_x = new_offset.x * info.clip_rect.size().width /
+                                info.content_rect.size().width;
+                        let horizontal_offset = LayoutVector2D::new(
+                            scrollable_width - scaled_offset_x,
+                            0.,
+                        );
+                        horizontal_info.scroll_to_offset(horizontal_offset, context);
+                    }
+                }
+                if let Some(vertical_id) = vertical_id {
+                    let vertical_node = self.get_node_mut(*vertical_id);
+                    if let SpatialTreeNodeInfo::Scroll(ref mut vertical_info) = vertical_node.info {
+                        let scrollable_height = vertical_info.scrollable_size().height;
+                        let scaled_offset_y = new_offset.y * info.clip_rect.size().height /
+                                info.content_rect.size().height;
+                        let vertical_offset = LayoutVector2D::new(
+                            0.,
+                            scrollable_height - scaled_offset_y,
+                        );
+                        vertical_info.scroll_to_offset(vertical_offset, context);
+                    }
+                }
+            },
+            LinkedScrollNodes::HorizontalScrollbar(node_id) => {
+                let sc_node = self.get_node_mut(*node_id);
+                if let SpatialTreeNodeInfo::Scroll(ref mut sc_info) = sc_node.info {
+                    let sc_offset = LayoutVector2D::new(
+                        new_offset.x * sc_info.content_rect.size().width /
+                            sc_info.clip_rect.size().width,
+                        info.offset.y,
+                    );
+                    sc_info.scroll_to_offset(sc_offset, context);
+                }
+            },
+        };
+    }
+
+    // pub fn scroll_node_info_to_offset(
+    //     &mut self,
+    //     info: &mut ScrollableNodeInfo,
+    //     new_offset: LayoutVector2D,
+    //     context: ScrollType,
+    // ) -> Option<LayoutVector2D> {
+    //     let new_offset = info.scroll_to_offset(new_offset, context);
+
+    //     if let Some(new_offset) = new_offset {
+    //         self.push_scroll_node_update(&info, &new_offset, context); //MYTODO need to rename new_offset
+    //     }
+
+    //     new_offset
+    // }
+
     pub fn scroll_node_or_ancestor_inner(
         &mut self,
         scroll_node_id: ScrollTreeNodeId,
@@ -488,7 +640,8 @@ impl ScrollTree {
         let parent = {
             let node = &mut self.get_node_mut(scroll_node_id);
             let result = node.scroll(scroll_location, context);
-            if result.is_some() {
+            if let Some((_, ref offset)) = result {
+                self.maybe_push_scroll_update_for_scrollbar(scroll_node_id, offset, context);
                 return result;
             }
             node.parent
@@ -539,16 +692,15 @@ impl ScrollTree {
         offset: LayoutVector2D,
         context: ScrollType,
     ) -> Option<LayoutVector2D> {
-        let result = self.nodes.iter_mut().find_map(|node| match node.info {
-            SpatialTreeNodeInfo::Scroll(ref mut scroll_info)
-                if scroll_info.external_id == external_scroll_id =>
-            {
-                scroll_info.scroll_to_offset(offset, context)
-            },
-            _ => None,
-        });
+        let scroll_tree_node_id = self.node_with_external_scroll_node_id(external_scroll_id)?;
 
-        if result.is_some() {
+        let result = self
+            .get_node_mut(scroll_tree_node_id)
+            .as_scroll_info_mut()?
+            .scroll_to_offset(offset, context);
+
+        if let Some(new_offset) = result {
+            self.maybe_push_scroll_update_for_scrollbar(scroll_tree_node_id, &new_offset, context);
             self.invalidate_cached_transforms();
         }
 
@@ -886,6 +1038,7 @@ impl PaintDisplayListInfo {
                 scroll_sensitivity: viewport_scroll_sensitivity,
                 offset: LayoutVector2D::zero(),
                 offset_changed: Cell::new(false),
+                linked_nodes: None,
             }),
         );
 

--- a/components/shared/paint/display_list.rs
+++ b/components/shared/paint/display_list.rs
@@ -175,9 +175,11 @@ pub struct ReferenceFrameNodeInfo {
 
 #[derive(Clone, Debug, Deserialize, MallocSizeOf, Serialize)]
 pub enum LinkedScrollNodes {
-    // MYTODO unit test
-    VerticalScrollbar(ScrollTreeNodeId),
-    HorizontalScrollbar(ScrollTreeNodeId),
+    /// The node is a vertical scrollbar of a linked scroll node.
+    VerticalScrollbarOf(ScrollTreeNodeId),
+    /// The node is a vertical scrollbar of a linked scroll node.
+    HorizontalScrollbarOf(ScrollTreeNodeId),
+    /// The node is a vertical scrollbar of a main node.
     ContainerWithScrollbars {
         horizontal: Option<ScrollTreeNodeId>,
         vertical: Option<ScrollTreeNodeId>,
@@ -208,7 +210,8 @@ pub struct ScrollableNodeInfo {
     /// cached transformations invalidated.
     pub offset_changed: Cell<bool>,
 
-    /// For a scroll node with a scrollbar the scrollbar's offset also represented by the scroll node. MYTODO
+    /// For a scroll node with a scrollbar we handle the scrollbar by having an additional scroll node
+    /// for each scrollbar. These scroll node's offset would then be synced with the main scroll nodes.
     pub linked_nodes: Option<Box<LinkedScrollNodes>>,
 }
 
@@ -288,7 +291,7 @@ impl ScrollableNodeInfo {
 }
 
 impl ScrollableNodeInfo {
-    fn scrollable_size(&self) -> LayoutSize {
+    pub fn scrollable_size(&self) -> LayoutSize {
         self.content_rect.size() - self.clip_rect.size()
     }
 }
@@ -417,7 +420,7 @@ impl ScrollTreeNode {
         };
     }
 
-    fn as_scroll_info_mut(&mut self) -> Option<&mut ScrollableNodeInfo> {
+    pub fn as_scroll_info_mut(&mut self) -> Option<&mut ScrollableNodeInfo> {
         if let SpatialTreeNodeInfo::Scroll(ref mut info) = self.info {
             Some(info)
         } else {
@@ -425,7 +428,7 @@ impl ScrollTreeNode {
         }
     }
 
-    fn as_scroll_info(&self) -> Option<&ScrollableNodeInfo> {
+    pub fn as_scroll_info(&self) -> Option<&ScrollableNodeInfo> {
         if let SpatialTreeNodeInfo::Scroll(ref info) = self.info {
             Some(info)
         } else {
@@ -467,34 +470,41 @@ pub struct ScrollTree {
 /// The first element would contains the main node to be scrolled, and the rest
 /// are containing the additional node that is affected by the scrolls.
 #[derive(Clone, Debug)]
-pub struct ScrollResult(Vec<(ExternalScrollId, LayoutVector2D)>);
+pub struct ScrollResult {
+    inner: Vec<(ExternalScrollId, LayoutVector2D)>,
+}
 
 impl ScrollResult {
     pub fn new_from_pair(scroll_pair: (ExternalScrollId, LayoutVector2D)) -> Self {
-        ScrollResult(
-            vec![scroll_pair]
-        )
+        ScrollResult {
+            inner: vec![scroll_pair],
+        }
     }
 
     pub fn new(external_scroll_id: ExternalScrollId, offset: LayoutVector2D) -> Self {
-        ScrollResult(
-            vec![(external_scroll_id, offset)]
-        )
+        ScrollResult {
+            inner: vec![(external_scroll_id, offset)],
+        }
     }
 
     pub fn push(&mut self, external_scroll_id: ExternalScrollId, offset: LayoutVector2D) {
-        self.0.push((external_scroll_id, offset));
+        self.inner.push((external_scroll_id, offset));
     }
 
     pub fn first(&self) -> &(ExternalScrollId, LayoutVector2D) {
-        self.0.first().expect("We had ensured that ScrollResult is non-empty")
+        self.inner
+            .first()
+            .expect("We had ensured that ScrollResult is non-empty")
     }
 
     pub fn iter(&self) -> impl Iterator<Item = &(ExternalScrollId, LayoutVector2D)> {
-        self.0.iter()
+        self.inner.iter()
+    }
+
+    pub fn append(&mut self, result_list: &mut Vec<(ExternalScrollId, LayoutVector2D)>) {
+        self.inner.append(result_list);
     }
 }
-
 
 impl ScrollTree {
     /// Add a scroll node to this ScrollTree returning the id of the new node.
@@ -546,7 +556,7 @@ impl ScrollTree {
         self.get_node(id).webrender_id()
     }
 
-    pub fn set_linked_nodes(
+    pub fn set_linked_scrollbar_nodes(
         &mut self,
         main_node_id: ScrollTreeNodeId,
         horizontal_scrollbar_id: Option<ScrollTreeNodeId>,
@@ -564,32 +574,34 @@ impl ScrollTree {
             horizontal_scrollbar_id.and_then(|id| self.get_node_mut(id).as_scroll_info_mut());
         if let Some(horizontal_scrollbar) = horizontal_scrollbar {
             horizontal_scrollbar
-                .set_linked_nodes(LinkedScrollNodes::HorizontalScrollbar(main_node_id));
+                .set_linked_nodes(LinkedScrollNodes::HorizontalScrollbarOf(main_node_id));
         }
 
         let vertical_scrollbar =
             vertical_scrollbar_id.and_then(|id| self.get_node_mut(id).as_scroll_info_mut());
         if let Some(vertical_scrollbar) = vertical_scrollbar {
-            vertical_scrollbar.set_linked_nodes(LinkedScrollNodes::VerticalScrollbar(main_node_id));
+            vertical_scrollbar
+                .set_linked_nodes(LinkedScrollNodes::VerticalScrollbarOf(main_node_id));
         }
+
+        self.maybe_sync_scroll_offsets_for_scrollbar(main_node_id);
     }
 
-    pub fn maybe_push_scroll_update_for_scrollbar(
+    pub fn maybe_sync_scroll_offsets_for_scrollbar(
         &mut self,
         id: ScrollTreeNodeId,
-        result: &mut ScrollResult,
-        context: ScrollType,
-    ) {
-        let Some(info) = self.get_node(id).as_scroll_info() else {
-            return;
-        };
-
-        let Some(linked_nodes) = info.linked_nodes.as_deref().cloned() else {
-            return;
-        };
+    ) -> Option<Box<Vec<(ExternalScrollId, LayoutVector2D)>>> {
+        let info = self.get_node(id).as_scroll_info()?;
+        let linked_nodes = info.linked_nodes.as_deref().cloned()?;
 
         let scrollable_size = info.scrollable_size();
-        let (_, new_offset) = *result.first();
+        let new_offset = info.offset;
+
+        // Using scripts here would force the scroll operation to be synced, considering that
+        // scrollbar's offset should follow the scroll container offset no matter what is the inputs,
+        let context = ScrollType::Script;
+
+        let mut result = Box::new(vec![]);
 
         match linked_nodes {
             LinkedScrollNodes::ContainerWithScrollbars {
@@ -602,14 +614,14 @@ impl ScrollTree {
                         horizontal_node.info
                     {
                         let sc_scrollable_width = horizontal_info.scrollable_size().width;
-                        let scaled_offset_x = new_offset.x * sc_scrollable_width /
-                                scrollable_size.width;
-                        let horizontal_offset = LayoutVector2D::new(
-                            sc_scrollable_width - scaled_offset_x,
-                            0.,
-                        );
-                        if let Some(new_offset) = horizontal_info.scroll_to_offset(horizontal_offset, context) {
-                            result.push(horizontal_info.external_id, new_offset);
+                        let scaled_offset_x =
+                            new_offset.x * sc_scrollable_width / scrollable_size.width;
+                        let horizontal_offset =
+                            LayoutVector2D::new(sc_scrollable_width - scaled_offset_x, 0.);
+                        if let Some(new_offset) =
+                            horizontal_info.scroll_to_offset(horizontal_offset, context)
+                        {
+                            result.push((horizontal_info.external_id, new_offset));
                         }
                     }
                 }
@@ -617,20 +629,22 @@ impl ScrollTree {
                     let vertical_node = self.get_node_mut(vertical_id);
                     if let SpatialTreeNodeInfo::Scroll(ref mut vertical_info) = vertical_node.info {
                         let sc_scrollable_height = vertical_info.scrollable_size().height;
-                        let scaled_offset_y = new_offset.y * sc_scrollable_height /
-                                scrollable_size.height;
-                        let vertical_offset = LayoutVector2D::new(
-                            0.,
-                            sc_scrollable_height - scaled_offset_y,
-                        );
-                        if let Some(new_offset) = vertical_info.scroll_to_offset(vertical_offset, context) {
-                            result.push(vertical_info.external_id, new_offset);
+                        let scaled_offset_y =
+                            new_offset.y * sc_scrollable_height / scrollable_size.height;
+                        let vertical_offset =
+                            LayoutVector2D::new(0., sc_scrollable_height - scaled_offset_y);
+                        if let Some(new_offset) =
+                            vertical_info.scroll_to_offset(vertical_offset, context)
+                        {
+                            result.push((vertical_info.external_id, new_offset));
                         }
                     }
                 }
             },
-            _ => unreachable!("We doesn't allow node of a scrollbar to be scrolled yet."),
+            _ => unreachable!("We doesn't allow scroll node of a scrollbar to be scrolled yet."),
         };
+
+        Some(result)
     }
 
     pub fn scroll_node_or_ancestor_inner(
@@ -641,10 +655,13 @@ impl ScrollTree {
     ) -> Option<ScrollResult> {
         let parent = {
             let node = &mut self.get_node_mut(scroll_node_id);
-            let mut maybe_result = node.scroll(scroll_location, context);
-            if let Some(ref mut result) = maybe_result {
-                self.maybe_push_scroll_update_for_scrollbar(scroll_node_id, result, context);
-                return maybe_result;
+            if let Some(mut result) = node.scroll(scroll_location, context) {
+                if let Some(mut scrollbar_results) =
+                    self.maybe_sync_scroll_offsets_for_scrollbar(scroll_node_id)
+                {
+                    result.append(&mut scrollbar_results);
+                }
+                return Some(result);
             }
             node.parent
         };
@@ -703,7 +720,11 @@ impl ScrollTree {
 
         let mut result = ScrollResult::new(external_scroll_id, new_offset);
 
-        self.maybe_push_scroll_update_for_scrollbar(scroll_tree_node_id, &mut result, context);
+        if let Some(mut scrollbar_results) =
+            self.maybe_sync_scroll_offsets_for_scrollbar(scroll_tree_node_id)
+        {
+            result.append(&mut scrollbar_results);
+        }
         self.invalidate_cached_transforms();
 
         Some(result)
@@ -715,12 +736,28 @@ impl ScrollTree {
         &mut self,
         offsets: &FxHashMap<ExternalScrollId, LayoutVector2D>,
     ) {
-        for node in self.nodes.iter_mut() {
+        // The pending node with scroll offsets that require a syncing with the scrollbars.
+        let mut pending_node_to_sync = vec![];
+
+        for (index, node) in self.nodes.iter_mut().enumerate() {
             if let SpatialTreeNodeInfo::Scroll(ref mut scroll_info) = node.info {
                 if let Some(offset) = offsets.get(&scroll_info.external_id) {
-                    scroll_info.scroll_to_offset(*offset, ScrollType::Script);
+                    match scroll_info.linked_nodes.as_deref() {
+                        None => {
+                            scroll_info.scroll_to_offset(*offset, ScrollType::Script);
+                        },
+                        Some(LinkedScrollNodes::ContainerWithScrollbars { .. }) => {
+                            scroll_info.scroll_to_offset(*offset, ScrollType::Script);
+                            pending_node_to_sync.push(ScrollTreeNodeId { index });
+                        },
+                        _ => {},
+                    }
                 }
             }
+        }
+
+        for scroll_id in pending_node_to_sync {
+            self.maybe_sync_scroll_offsets_for_scrollbar(scroll_id);
         }
 
         self.invalidate_cached_transforms();
@@ -728,11 +765,26 @@ impl ScrollTree {
 
     /// Set the offsets of all scrolling nodes in this tree to 0.
     pub fn reset_all_scroll_offsets(&mut self) {
-        for node in self.nodes.iter_mut() {
-            // MYTODO: this should handle the initial offsets of the scrollbar as well.
+        // The pending node with scroll offsets that require a syncing with the scrollbars.
+        let mut pending_node_to_sync = vec![];
+
+        for (index, node) in self.nodes.iter_mut().enumerate() {
             if let SpatialTreeNodeInfo::Scroll(ref mut scroll_info) = node.info {
-                scroll_info.scroll_to_offset(LayoutVector2D::zero(), ScrollType::Script);
+                match scroll_info.linked_nodes.as_deref() {
+                    None => {
+                        scroll_info.scroll_to_offset(LayoutVector2D::zero(), ScrollType::Script);
+                    },
+                    Some(LinkedScrollNodes::ContainerWithScrollbars { .. }) => {
+                        scroll_info.scroll_to_offset(LayoutVector2D::zero(), ScrollType::Script);
+                        pending_node_to_sync.push(ScrollTreeNodeId { index });
+                    },
+                    _ => {},
+                }
             }
+        }
+
+        for scroll_id in pending_node_to_sync {
+            self.maybe_sync_scroll_offsets_for_scrollbar(scroll_id);
         }
 
         self.invalidate_cached_transforms();

--- a/components/shared/paint/tests/compositor.rs
+++ b/components/shared/paint/tests/compositor.rs
@@ -36,6 +36,7 @@ fn add_mock_scroll_node(tree: &mut ScrollTree) -> (ScrollTreeNodeId, ExternalScr
             },
             offset: LayoutVector2D::zero(),
             offset_changed: Cell::new(false),
+            linked_nodes: None,
         }),
     );
     (scroll_node_id, external_id)

--- a/components/shared/paint/tests/compositor.rs
+++ b/components/shared/paint/tests/compositor.rs
@@ -5,11 +5,11 @@
 use std::cell::Cell;
 
 use base::id::ScrollTreeNodeId;
-use euclid::Size2D;
+use euclid::{Box2D, Rect, Size2D};
 use paint_api::display_list::{
     AxesScrollSensitivity, ScrollTree, ScrollType, ScrollableNodeInfo, SpatialTreeNodeInfo,
 };
-use webrender_api::units::LayoutVector2D;
+use webrender_api::units::{LayoutRect, LayoutSize, LayoutVector2D};
 use webrender_api::{ExternalScrollId, PipelineId, ScrollLocation};
 
 fn add_mock_scroll_node(tree: &mut ScrollTree) -> (ScrollTreeNodeId, ExternalScrollId) {
@@ -42,30 +42,85 @@ fn add_mock_scroll_node(tree: &mut ScrollTree) -> (ScrollTreeNodeId, ExternalScr
     (scroll_node_id, external_id)
 }
 
+fn set_mock_scroll_node_rects(
+    tree: &mut ScrollTree,
+    id: ScrollTreeNodeId,
+    clip_rect: LayoutRect,
+    content_rect: LayoutRect,
+) {
+    let node = tree.get_node_mut(id);
+    let scroll_info = node.as_scroll_info_mut().unwrap();
+    scroll_info.clip_rect = clip_rect;
+    scroll_info.content_rect = content_rect;
+}
+
+fn add_mock_scroll_node_with_sizes(
+    tree: &mut ScrollTree,
+    clip_rect: LayoutSize,
+    content_rect: LayoutSize,
+) -> (ScrollTreeNodeId, ExternalScrollId) {
+    let (scroll_node_id, external_id) = add_mock_scroll_node(tree);
+    set_mock_scroll_node_rects(tree, scroll_node_id, clip_rect.into(), content_rect.into());
+    (scroll_node_id, external_id)
+}
+
+// Though there are multiple ways to layout the scrollbar rectangle, here we are placing it by assuming that it is purely
+// bases on the ratio of the clip rect and content rect.
+fn add_mock_scroll_node_with_scrollbars(
+    tree: &mut ScrollTree,
+    clip_rect: LayoutSize,
+    content_rect: LayoutSize,
+) -> (
+    (ScrollTreeNodeId, ExternalScrollId),
+    (ScrollTreeNodeId, ExternalScrollId),
+    (ScrollTreeNodeId, ExternalScrollId),
+) {
+    let main_ids = add_mock_scroll_node_with_rects(tree, clip_rect, content_rect);
+
+    let width_size_ratio = clip_rect.width / content_rect.width;
+    let height_size_ratio = clip_rect.height / content_rect.height;
+
+    let horizontal_scrollbar_ids = add_mock_scroll_node_with_rects(
+        tree,
+        Size2D::new(clip_rect.width * width_size_ratio, 10.0).into(),
+        Size2D::new(content_rect.width * width_size_ratio, 10.0).into(),
+    );
+
+    let vertical_scrollbar_ids = add_mock_scroll_node_with_rects(
+        tree,
+        Size2D::new(10.0, clip_rect.height * height_size_ratio).into(),
+        Size2D::new(10.0, content_rect.height * height_size_ratio).into(),
+    );
+
+    (main_ids, horizontal_scrollbar_ids, vertical_scrollbar_ids)
+}
+
 #[test]
 fn test_scroll_tree_simple_scroll() {
     let mut scroll_tree = ScrollTree::default();
     let (id, external_id) = add_mock_scroll_node(&mut scroll_tree);
 
-    let (scrolled_id, offset) = scroll_tree
+    let (scrolled_id, offset) = *scroll_tree
         .scroll_node_or_ancestor(
             external_id,
             ScrollLocation::Delta(LayoutVector2D::new(20.0, 40.0)),
             ScrollType::Script,
         )
-        .unwrap();
+        .unwrap()
+        .first();
     let expected_offset = LayoutVector2D::new(20.0, 40.0);
     assert_eq!(scrolled_id, external_id);
     assert_eq!(offset, expected_offset);
     assert_eq!(scroll_tree.get_node(id).offset(), Some(expected_offset));
 
-    let (scrolled_id, offset) = scroll_tree
+    let (scrolled_id, offset) = *scroll_tree
         .scroll_node_or_ancestor(
             external_id,
             ScrollLocation::Delta(LayoutVector2D::new(-20.0, -40.0)),
             ScrollType::Script,
         )
-        .unwrap();
+        .unwrap()
+        .first();
     let expected_offset = LayoutVector2D::new(0.0, 0.0);
     assert_eq!(scrolled_id, external_id);
     assert_eq!(offset, expected_offset);
@@ -108,13 +163,14 @@ fn test_scroll_tree_simple_scroll_chaining() {
         }),
     );
 
-    let (scrolled_id, offset) = scroll_tree
+    let (scrolled_id, offset) = *scroll_tree
         .scroll_node_or_ancestor(
             unscrollable_external_id,
             ScrollLocation::Delta(LayoutVector2D::new(20.0, 40.0)),
             ScrollType::Script,
         )
-        .unwrap();
+        .unwrap()
+        .first();
     let expected_offset = LayoutVector2D::new(20.0, 40.0);
     assert_eq!(scrolled_id, parent_external_id);
     assert_eq!(offset, expected_offset);
@@ -123,13 +179,14 @@ fn test_scroll_tree_simple_scroll_chaining() {
         Some(expected_offset)
     );
 
-    let (scrolled_id, offset) = scroll_tree
+    let (scrolled_id, offset) = *scroll_tree
         .scroll_node_or_ancestor(
             unscrollable_external_id,
             ScrollLocation::Delta(LayoutVector2D::new(10.0, 15.0)),
             ScrollType::Script,
         )
-        .unwrap();
+        .unwrap()
+        .first();
     let expected_offset = LayoutVector2D::new(30.0, 55.0);
     assert_eq!(scrolled_id, parent_external_id);
     assert_eq!(offset, expected_offset);
@@ -150,9 +207,10 @@ fn test_scroll_tree_chain_when_at_extent() {
     let (parent_id, parent_external_id) = add_mock_scroll_node(&mut scroll_tree);
     let (child_id, child_external_id) = add_mock_scroll_node(&mut scroll_tree);
 
-    let (scrolled_id, offset) = scroll_tree
+    let (scrolled_id, offset) = *scroll_tree
         .scroll_node_or_ancestor(child_external_id, ScrollLocation::End, ScrollType::Script)
-        .unwrap();
+        .unwrap()
+        .first();
 
     let expected_offset = LayoutVector2D::new(0.0, 100.0);
     assert_eq!(scrolled_id, child_external_id);
@@ -164,13 +222,14 @@ fn test_scroll_tree_chain_when_at_extent() {
 
     // The parent will have scrolled because the child is already at the extent
     // of its scroll area in the y axis.
-    let (scrolled_id, offset) = scroll_tree
+    let (scrolled_id, offset) = *scroll_tree
         .scroll_node_or_ancestor(
             child_external_id,
             ScrollLocation::Delta(LayoutVector2D::new(0.0, 10.0)),
             ScrollType::Script,
         )
-        .unwrap();
+        .unwrap()
+        .first();
     let expected_offset = LayoutVector2D::new(0.0, 10.0);
     assert_eq!(scrolled_id, parent_external_id);
     assert_eq!(offset, expected_offset);
@@ -197,13 +256,14 @@ fn test_scroll_tree_chain_through_overflow_hidden() {
         };
     }
 
-    let (scrolled_id, offset) = scroll_tree
+    let (scrolled_id, offset) = *scroll_tree
         .scroll_node_or_ancestor(
             overflow_hidden_external_id,
             ScrollLocation::Delta(LayoutVector2D::new(20.0, 40.0)),
             ScrollType::InputEvents,
         )
-        .unwrap();
+        .unwrap()
+        .first();
     let expected_offset = LayoutVector2D::new(20.0, 40.0);
     assert_eq!(scrolled_id, parent_external_id);
     assert_eq!(offset, expected_offset);
@@ -215,4 +275,161 @@ fn test_scroll_tree_chain_through_overflow_hidden() {
         scroll_tree.get_node(overflow_hidden_id).offset(),
         Some(LayoutVector2D::new(0.0, 0.0))
     );
+}
+
+#[test]
+fn test_link_scroll_nodes() {
+    let mut scroll_tree = ScrollTree::default();
+
+    let (
+        (main_id, main_external_id),
+        (horizontal_scrollbar_id, horizontal_scrollbar_external_id),
+        (vertical_scrollbar_id, vertical_scrollbar_external_id),
+    ) = add_mock_scroll_node_with_scrollbars(
+        tree,
+        Size2D::new(100.0, 200.0).into(),
+        Size2D::new(500.0, 800.0).into(),
+    );
+
+    scroll_tree.set_linked_scrollbar_nodes(
+        main_id,
+        Some(horizontal_scrollbar_id),
+        Some(vertical_scrollbar_id),
+    );
+
+    // Test that the offsets of the linked nodes is being reflected properly.
+    assert_eq!(
+        scroll_tree.get_node(main_id).offset(),
+        Some(LayoutVector2D::new(0.0, 0.0))
+    );
+    assert_eq!(
+        scroll_tree.get_node(horizontal_scrollbar_id).offset(),
+        Some(
+            scroll_tree
+                .get_node(horizontal_scrollbar_id)
+                .as_scroll_info()
+                .unwrap()
+                .scrollable_size()
+                .to_vector()
+        )
+    );
+    assert_eq!(
+        scroll_tree.get_node(vertical_scrollbar_id).offset(),
+        Some(
+            scroll_tree
+                .get_node(vertical_scrollbar_id)
+                .as_scroll_info()
+                .unwrap()
+                .scrollable_size()
+                .to_vector()
+        )
+    );
+}
+
+#[test]
+fn test_scroll_linked_scroll_nodes() {
+    let mut scroll_tree = ScrollTree::default();
+
+    let (
+        (main_id, main_external_id),
+        (horizontal_scrollbar_id, horizontal_scrollbar_external_id),
+        (vertical_scrollbar_id, vertical_scrollbar_external_id),
+    ) = add_mock_scroll_node_with_scrollbars(
+        tree,
+        Size2D::new(100.0, 200.0).into(),
+        Size2D::new(500.0, 800.0).into(),
+    );
+
+    scroll_tree.set_linked_scrollbar_nodes(
+        main_id,
+        Some(horizontal_scrollbar_id),
+        Some(vertical_scrollbar_id),
+    );
+
+    // Helper function to asserts the offsets of all three nodes.
+    let asserts_scroll_nodes_offset =
+        |scroll_tree: &ScrollTree,
+         scroll_results: Vec<&(ExternalScrollId, LayoutVector2D)>,
+         main_offset: LayoutVector2D,
+         horizontal_scrollbar_offset: LayoutVector2D,
+         vertical_scrollbar_offset: LayoutVector2D| {
+            // The first element must be the main scroll node.
+            assert_eq!(*scroll_results[0], (main_external_id, main_offset));
+
+            // Otherwise we looks for other scroll nodes.
+            assert_eq!(
+                **scroll_results
+                    .iter()
+                    .find(|result| result.0 == horizontal_scrollbar_external_id)
+                    .unwrap(),
+                (
+                    horizontal_scrollbar_external_id,
+                    horizontal_scrollbar_offset
+                )
+            );
+            assert_eq!(
+                **scroll_results
+                    .iter()
+                    .find(|result| result.0 == vertical_scrollbar_external_id)
+                    .unwrap(),
+                (vertical_scrollbar_external_id, vertical_scrollbar_offset)
+            );
+
+            // Additionally, check that the ScrollResult represent the current scroll offset.
+            let main_node = scroll_tree.get_node(main_id);
+            let horizontal_scrollbar_node = scroll_tree.get_node(horizontal_scrollbar_id);
+            let vertical_scrollbar_node = scroll_tree.get_node(vertical_scrollbar_id);
+
+            assert_eq!(main_node.offset(), Some(main_offset));
+            assert_eq!(
+                horizontal_scrollbar_node.offset(),
+                Some(horizontal_scrollbar_offset)
+            );
+            assert_eq!(
+                vertical_scrollbar_node.offset(),
+                Some(vertical_scrollbar_offset)
+            );
+        };
+
+    // Scroll to a certain offsets.
+    {
+        let scroll_results = scroll_tree
+            .scroll_node_or_ancestor(
+                main_external_id,
+                ScrollLocation::Delta(LayoutVector2D::new(100.0, 200.0)),
+                ScrollType::InputEvents,
+            )
+            .unwrap();
+
+        let scroll_results = scroll_results.iter().collect::<Vec<_>>();
+
+        asserts_scroll_nodes_offset(
+            &scroll_tree,
+            scroll_results,
+            LayoutVector2D::new(100.0, 200.0),
+            LayoutVector2D::new(60.0, 0.0),
+            LayoutVector2D::new(0.0, 100.0),
+        );
+    }
+
+    // Scroll to maximum, beyond the scrollable size.
+    {
+        let scroll_results = scroll_tree
+            .scroll_node_or_ancestor(
+                main_external_id,
+                ScrollLocation::Delta(LayoutVector2D::new(10000.0, 10000.0)),
+                ScrollType::InputEvents,
+            )
+            .unwrap();
+
+        let scroll_results = scroll_results.iter().collect::<Vec<_>>();
+
+        asserts_scroll_nodes_offset(
+            &scroll_tree,
+            scroll_results,
+            LayoutVector2D::new(400.0, 600.0),
+            LayoutVector2D::new(0.0, 0.0),
+            LayoutVector2D::new(0.0, 0.0),
+        );
+    }
 }

--- a/components/shared/paint/tests/compositor.rs
+++ b/components/shared/paint/tests/compositor.rs
@@ -104,6 +104,7 @@ fn test_scroll_tree_simple_scroll_chaining() {
             },
             offset: LayoutVector2D::zero(),
             offset_changed: Cell::new(false),
+            linked_nodes: None,
         }),
     );
 


### PR DESCRIPTION
This patch attempts to implement overlay scrollbar by building the components of scrollbar in `StackingContextTree` and `DisplayList`. It use an approach that build two additional "scroll" `ScrollTreeNode`, one for each axis, this is used to sync the scrollbar offset with the offset of the scroll container. Specifically, the nodes are "linked" so that when a scroll container is scrolled, the scrollbar is scrolled as well and vice versa. 

Design Docs: https://hackmd.io/@ChaKweTiau/rJDfPZNY-e

Testing: *Describe how this pull request is tested or why it doesn't require tests*
Part of: #21817
