### PR TITLE
ci: Upgrade soon deprecated GitHub Actions

### DIFF
--- a/.github/actions/setup-python/action.yml
+++ b/.github/actions/setup-python/action.yml
@@ -15,7 +15,7 @@ runs:
     # symlink to this version.
     - name: Setup system python
       if: ${{ inputs.skip-python-setup != 'true' }}
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v6
       with:
         python-version-file: ${{ inputs.python-version-file-path }}
     - name: Install uv

--- a/.github/workflows/bencher.yml
+++ b/.github/workflows/bencher.yml
@@ -78,7 +78,7 @@ jobs:
     runs-on: ${{ needs.runner-select.outputs.selected-runner-label }}
     steps:
       - uses: servo/ci-runners/actions/checkout@6d88b19dda997f1ce2a11e4c1c34717c2bbcafba
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v8
         with:
           name: ${{ inputs.profile }}-binary-${{ inputs.target }}
           path: ${{ inputs.profile }}-binary-${{ inputs.target }}

--- a/.github/workflows/linux-wpt.yml
+++ b/.github/workflows/linux-wpt.yml
@@ -144,14 +144,14 @@ jobs:
     needs: linux-wpt
     steps:
       - name: Merge logs (full)
-        uses: actions/upload-artifact/merge@v4
+        uses: actions/upload-artifact/merge@v7
         with:
           name: wpt-full-logs-linux
           pattern: wpt-full-logs-linux-*
           delete-merged: true
       # This job needs to be last. If no filtered results were uploaded, it will fail, but we want to merge other archives in that case.
       - name: Merge logs (filtered)
-        uses: actions/upload-artifact/merge@v4
+        uses: actions/upload-artifact/merge@v7
         with:
           name: wpt-filtered-logs-linux
           pattern: wpt-filtered-logs-linux-*

--- a/.github/workflows/linux-wpt.yml
+++ b/.github/workflows/linux-wpt.yml
@@ -80,7 +80,7 @@ jobs:
         if: github.event_name == 'pull_request_target'
         with:
           ref: refs/pull/${{ github.event.number }}/head
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v8
         with:
           name: ${{ inputs.profile }}-binary-linux
           path: ${{ inputs.profile }}-binary-linux
@@ -164,7 +164,7 @@ jobs:
         if: ${{ !cancelled() && !inputs.wpt-sync-from-upstream && github.event_name == 'pull_request_target' }}
         with:
           ref: refs/pull/${{ github.event.number }}/head
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v8
         if: ${{ !cancelled() && !inputs.wpt-sync-from-upstream }}
         with:
           name: wpt-filtered-logs-linux

--- a/.github/workflows/mac-wpt.yml
+++ b/.github/workflows/mac-wpt.yml
@@ -83,13 +83,13 @@ jobs:
     needs: mac-wpt
     steps:
       - name: Merge logs (filtered)
-        uses: actions/upload-artifact/merge@v4
+        uses: actions/upload-artifact/merge@v7
         with:
           name: wpt-filtered-logs-${{ env.NAME }}
           pattern: wpt-filtered-logs-${{ env.NAME }}-*
           delete-merged: true
       - name: Merge logs (full)
-        uses: actions/upload-artifact/merge@v4
+        uses: actions/upload-artifact/merge@v7
         with:
           name: wpt-full-logs-${{ env.NAME }}
           pattern: wpt-full-logs-${{ env.NAME }}-*

--- a/.github/workflows/mac-wpt.yml
+++ b/.github/workflows/mac-wpt.yml
@@ -38,7 +38,7 @@ jobs:
         if: github.event_name == 'pull_request_target'
         with:
           ref: refs/pull/${{ github.event.number }}/head
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v8
         with:
           name: ${{ inputs.profile }}-binary-${{ env.NAME }}
       - name: Setup Python
@@ -110,7 +110,7 @@ jobs:
           name: stable-unexpected-results-${{ env.NAME }}
           path: stable-unexpected-results.log
           if-no-files-found: error
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v8
         if: ${{ !cancelled() }}
         with:
           name: wpt-filtered-logs-${{ env.NAME }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -71,7 +71,7 @@ jobs:
       - build
     steps:
       - name: Merge build timings
-        uses: actions/upload-artifact/merge@v4
+        uses: actions/upload-artifact/merge@v7
         with:
           name: cargo-timings
           pattern: cargo-timings-*

--- a/.github/workflows/scheduled-wpt-import.yml
+++ b/.github/workflows/scheduled-wpt-import.yml
@@ -29,7 +29,7 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v5
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v8
         with:
           name: wpt-full-logs-linux
       - name: Setup Python

--- a/.github/workflows/try-label.yml
+++ b/.github/workflows/try-label.yml
@@ -15,7 +15,7 @@ jobs:
       try_string: ${{ steps.try_string.outputs.result }}
     steps:
       - name: Collect Labels
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         id: try_string
         with:
           result-encoding: string
@@ -87,7 +87,7 @@ jobs:
            } >> $GITHUB_OUTPUT
       - name: Comment Run Start
         if: ${{ steps.try_string.outputs.result }}
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           result-encoding: string
           script: |

--- a/.github/workflows/try.yml
+++ b/.github/workflows/try.yml
@@ -128,7 +128,7 @@ jobs:
     steps:
       - name: Merge build timings
         continue-on-error: true
-        uses: actions/upload-artifact/merge@v4
+        uses: actions/upload-artifact/merge@v7
         with:
           name: cargo-timings
           pattern: cargo-timings-*

--- a/.github/workflows/try.yml
+++ b/.github/workflows/try.yml
@@ -56,7 +56,7 @@ jobs:
            } >> $GITHUB_OUTPUT
       - name: Configuration
         id: configuration
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: |
             // When triggered via a push try the `try` branch, search the last commit for a configuration object.

--- a/.github/workflows/upload_release.yml
+++ b/.github/workflows/upload_release.yml
@@ -48,7 +48,7 @@ jobs:
             echo "parameter then this might be the cause of the error."
             exit 1
           fi
-      - uses: actions/download-artifact@v7
+      - uses: actions/download-artifact@v8
         with:
           artifact-ids: ${{ inputs.artifact_ids }}
           merge-multiple: true


### PR DESCRIPTION
I got so many warnings about [Node 20 EOL](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/) in the [try](https://github.com/servo/servo/actions/runs/22945103342):

> The following actions are running on Node.js 20 and may not work as expected...

We avoid touching those actions forked from web-platform-tests.

Testing: If this can merge, it is successful.