### PR TITLE
layout: Paint the `<select>` chevon using an SVG

### DIFF
--- a/components/script/dom/html/htmlselectelement.rs
+++ b/components/script/dom/html/htmlselectelement.rs
@@ -67,7 +67,7 @@ const SELECT_BOX_STYLE: &str = "
 const TEXT_CONTAINER_STYLE: &str = "flex: 1;";
 
 const CHEVRON_CONTAINER_STYLE: &str = "
-    background-image: url('data:image/svg+xml,<svg xmlns=\"http://www.w3.org/2000/svg\" width=\"180\" height=\"180\" viewBox=\"0 0 180 180\"> <path d=\"M0 12h180L90 167z\" style=\"fill:currentcolor\"/> </svg>');
+    background-image: url('data:image/svg+xml,<svg xmlns=\"http://www.w3.org/2000/svg\" width=\"180\" height=\"180\" viewBox=\"0 0 180 180\"> <path d=\"M10 50h160L90 130z\" style=\"fill:currentcolor\"/> </svg>');
     background-size: 100%;
     background-repeat: no-repeat;
     background-position: center;

--- a/components/script/dom/html/htmlselectelement.rs
+++ b/components/script/dom/html/htmlselectelement.rs
@@ -61,13 +61,22 @@ const SELECT_BOX_STYLE: &str = "
     display: flex;
     align-items: center;
     height: 100%;
+    gap: 4px;
 ";
 
 const TEXT_CONTAINER_STYLE: &str = "flex: 1;";
 
 const CHEVRON_CONTAINER_STYLE: &str = "
-    font-size: 16px;
-    margin: 4px;
+    background-image: url('data:image/svg+xml,<svg xmlns=\"http://www.w3.org/2000/svg\" width=\"180\" height=\"180\" viewBox=\"0 0 180 180\"> <path d=\"M0 12h180L90 167z\" style=\"fill:currentcolor\"/> </svg>');
+    background-size: 100%;
+    background-repeat: no-repeat;
+    background-position: center;
+
+    vertical-align: middle;
+    line-height: 1;
+    display: inline-block;
+    width: 0.75em;
+    height: 0.75em;
 ";
 
 #[derive(JSTraceable, MallocSizeOf)]
@@ -328,9 +337,6 @@ impl HTMLSelectElement {
             CHEVRON_CONTAINER_STYLE.into(),
             can_gc,
         );
-        chevron_container
-            .upcast::<Node>()
-            .set_text_content_for_element(Some("▾".into()), can_gc);
         select_box
             .upcast::<Node>()
             .AppendChild(chevron_container.upcast::<Node>(), can_gc)


### PR DESCRIPTION
Previously there were two issues:

1. The select chevron had a 4px margin which should have just applied to the inline axis.
2. The chevron character had odd font metrics, so even once the margin is fixed the select is still too tall.

This is fixed by using an SVG as a background-image instead of using the ▾ character.

Testing: Tested with https://demo.lukewarlow.dev/css-forms.html (and the test case added in https://github.com/servo/servo/pull/42085).

| Before | After |
| ------|------|
| <img width="522" height="267" alt="image" src="https://github.com/user-attachments/assets/7cc2d840-3384-4a6c-8945-0277cfb4096d" /> | <img width="509" height="250" alt="image" src="https://github.com/user-attachments/assets/99742dca-3ce6-4964-98bd-0cdbf3e14937" /> |
