### PR TITLE
script: Record state for nodes prior to executing commands

### DIFF
--- a/components/script/dom/document.rs
+++ b/components/script/dom/document.rs
@@ -139,7 +139,7 @@ use crate::dom::element::{
 };
 use crate::dom::event::{Event, EventBubbles, EventCancelable};
 use crate::dom::eventtarget::EventTarget;
-use crate::dom::execcommand::basecommand::DefaultSingleLineContainerName;
+use crate::dom::execcommand::basecommand::{CommandName, DefaultSingleLineContainerName};
 use crate::dom::execcommand::contenteditable::ContentEditableRange;
 use crate::dom::execcommand::execcommands::DocumentExecCommandSupport;
 use crate::dom::focusevent::FocusEvent;
@@ -631,10 +631,12 @@ pub(crate) struct Document {
     layout_animations_test_enabled: bool,
 
     /// <https://w3c.github.io/editing/docs/execCommand/#state-override>
-    state_override: Cell<bool>,
+    #[no_trace]
+    state_override: DomRefCell<FxHashMap<CommandName, bool>>,
 
     /// <https://w3c.github.io/editing/docs/execCommand/#value-override>
-    value_override: DomRefCell<Option<DOMString>>,
+    #[no_trace]
+    value_override: DomRefCell<FxHashMap<CommandName, DOMString>>,
 
     /// <https://w3c.github.io/editing/docs/execCommand/#default-single-line-container-name>
     #[no_trace]
@@ -5114,13 +5116,27 @@ impl Document {
     }
 
     /// <https://w3c.github.io/editing/docs/execCommand/#state-override>
-    pub(crate) fn state_override(&self) -> bool {
-        self.state_override.get()
+    pub(crate) fn state_override(&self, command_name: &CommandName) -> Option<bool> {
+        self.state_override.borrow().get(command_name).copied()
+    }
+
+    /// <https://w3c.github.io/editing/docs/execCommand/#state-override>
+    pub(crate) fn set_state_override(&self, command_name: CommandName, state: bool) {
+        self.state_override.borrow_mut().insert(command_name, state);
     }
 
     /// <https://w3c.github.io/editing/docs/execCommand/#value-override>
-    pub(crate) fn value_override(&self) -> Option<DOMString> {
-        self.value_override.borrow().clone()
+    pub(crate) fn value_override(&self, command_name: &CommandName) -> Option<DOMString> {
+        self.value_override.borrow().get(command_name).cloned()
+    }
+
+    /// <https://w3c.github.io/editing/docs/execCommand/#value-override>
+    pub(crate) fn set_value_override(&self, command_name: CommandName, value: Option<DOMString>) {
+        if let Some(value) = value {
+            self.value_override.borrow_mut().insert(command_name, value);
+        } else {
+            self.value_override.borrow_mut().remove(&command_name);
+        }
     }
 
     /// <https://w3c.github.io/editing/docs/execCommand/#default-single-line-container-name>

--- a/components/script/dom/execcommand/basecommand.rs
+++ b/components/script/dom/execcommand/basecommand.rs
@@ -4,37 +4,95 @@
 
 use crate::dom::bindings::str::DOMString;
 use crate::dom::document::Document;
+use crate::dom::execcommand::commands::defaultparagraphseparator::execute_default_paragraph_separator_command;
+use crate::dom::execcommand::commands::delete::execute_delete_command;
+use crate::dom::execcommand::commands::stylewithcss::execute_style_with_css_command;
 use crate::dom::selection::Selection;
-
-pub(crate) trait BaseCommand {
-    /// <https://w3c.github.io/editing/docs/execCommand/#indeterminate>
-    fn is_indeterminate(&self) -> bool {
-        false
-    }
-
-    /// <https://w3c.github.io/editing/docs/execCommand/#state>
-    fn current_state(&self, _document: &Document) -> Option<bool> {
-        None
-    }
-
-    /// <https://w3c.github.io/editing/docs/execCommand/#value>
-    fn current_value(&self, _document: &Document) -> Option<DOMString> {
-        None
-    }
-
-    /// <https://w3c.github.io/editing/docs/execCommand/#action>
-    fn execute(
-        &self,
-        cx: &mut js::context::JSContext,
-        document: &Document,
-        selection: &Selection,
-        value: DOMString,
-    ) -> bool;
-}
 
 #[derive(Default, Clone, Copy, MallocSizeOf)]
 pub(crate) enum DefaultSingleLineContainerName {
     #[default]
     Div,
     Paragraph,
+}
+
+impl From<DefaultSingleLineContainerName> for DOMString {
+    fn from(default_single_line_container_name: DefaultSingleLineContainerName) -> Self {
+        match default_single_line_container_name {
+            DefaultSingleLineContainerName::Div => DOMString::from("div"),
+            DefaultSingleLineContainerName::Paragraph => DOMString::from("p"),
+        }
+    }
+}
+
+#[derive(Clone, Copy, Eq, Hash, MallocSizeOf, PartialEq)]
+#[expect(unused)] // TODO(25005): implement all commands
+pub(crate) enum CommandName {
+    BackColor,
+    Bold,
+    CreateLink,
+    DefaultParagraphSeparator,
+    Delete,
+    FontSize,
+    HiliteColor,
+    Italic,
+    Redo,
+    SelectAll,
+    Strikethrough,
+    StyleWithCss,
+    Subscript,
+    Superscript,
+    Underline,
+    Undo,
+    Unlink,
+    Usecss,
+}
+
+impl CommandName {
+    /// <https://w3c.github.io/editing/docs/execCommand/#indeterminate>
+    pub(crate) fn is_indeterminate(&self) -> bool {
+        false
+    }
+
+    /// <https://w3c.github.io/editing/docs/execCommand/#state>
+    pub(crate) fn current_state(&self, document: &Document) -> Option<bool> {
+        Some(match self {
+            CommandName::StyleWithCss => {
+                // https://w3c.github.io/editing/docs/execCommand/#the-stylewithcss-command
+                // > True if the CSS styling flag is true, otherwise false.
+                document.css_styling_flag()
+            },
+            _ => return None,
+        })
+    }
+
+    /// <https://w3c.github.io/editing/docs/execCommand/#value>
+    pub(crate) fn current_value(&self, document: &Document) -> Option<DOMString> {
+        Some(match self {
+            CommandName::DefaultParagraphSeparator => {
+                // https://w3c.github.io/editing/docs/execCommand/#the-defaultparagraphseparator-command
+                // > Return the context object's default single-line container name.
+                document.default_single_line_container_name().into()
+            },
+            _ => return None,
+        })
+    }
+
+    /// <https://w3c.github.io/editing/docs/execCommand/#action>
+    pub(crate) fn execute(
+        &self,
+        cx: &mut js::context::JSContext,
+        document: &Document,
+        selection: &Selection,
+        value: DOMString,
+    ) -> bool {
+        match self {
+            CommandName::DefaultParagraphSeparator => {
+                execute_default_paragraph_separator_command(document, value)
+            },
+            CommandName::Delete => execute_delete_command(cx, document, selection),
+            CommandName::StyleWithCss => execute_style_with_css_command(document, value),
+            _ => false,
+        }
+    }
 }

--- a/components/script/dom/execcommand/commands/defaultparagraphseparator.rs
+++ b/components/script/dom/execcommand/commands/defaultparagraphseparator.rs
@@ -4,45 +4,22 @@
 
 use crate::dom::bindings::str::DOMString;
 use crate::dom::document::Document;
-use crate::dom::execcommand::basecommand::{BaseCommand, DefaultSingleLineContainerName};
-use crate::dom::selection::Selection;
+use crate::dom::execcommand::basecommand::DefaultSingleLineContainerName;
 
-impl From<DefaultSingleLineContainerName> for DOMString {
-    fn from(default_single_line_container_name: DefaultSingleLineContainerName) -> Self {
-        match default_single_line_container_name {
-            DefaultSingleLineContainerName::Div => DOMString::from("div"),
-            DefaultSingleLineContainerName::Paragraph => DOMString::from("p"),
-        }
-    }
-}
+/// <https://w3c.github.io/editing/docs/execCommand/#the-defaultparagraphseparator-command>
+pub(crate) fn execute_default_paragraph_separator_command(
+    document: &Document,
+    value: DOMString,
+) -> bool {
+    // > Let value be converted to ASCII lowercase. If value is then equal to "p" or "div",
+    // > set the context object's default single-line container name to value, then return true. Otherwise, return false.
+    let value = match value.to_ascii_lowercase().as_str() {
+        "div" => DefaultSingleLineContainerName::Div,
+        "p" => DefaultSingleLineContainerName::Paragraph,
+        _ => return false,
+    };
 
-pub(crate) struct DefaultParagraphSeparatorCommand {}
+    document.set_default_single_line_container_name(value);
 
-impl BaseCommand for DefaultParagraphSeparatorCommand {
-    /// <https://w3c.github.io/editing/docs/execCommand/#the-defaultparagraphseparator-command>
-    fn execute(
-        &self,
-        _cx: &mut js::context::JSContext,
-        document: &Document,
-        _selection: &Selection,
-        value: DOMString,
-    ) -> bool {
-        // > Let value be converted to ASCII lowercase. If value is then equal to "p" or "div",
-        // > set the context object's default single-line container name to value, then return true. Otherwise, return false.
-        let value = match value.to_ascii_lowercase().as_str() {
-            "div" => DefaultSingleLineContainerName::Div,
-            "p" => DefaultSingleLineContainerName::Paragraph,
-            _ => return false,
-        };
-
-        document.set_default_single_line_container_name(value);
-
-        true
-    }
-
-    /// <https://w3c.github.io/editing/docs/execCommand/#the-defaultparagraphseparator-command>
-    fn current_value(&self, document: &Document) -> Option<DOMString> {
-        // > Return the context object's default single-line container name.
-        Some(document.default_single_line_container_name().into())
-    }
+    true
 }

--- a/components/script/dom/execcommand/commands/delete.rs
+++ b/components/script/dom/execcommand/commands/delete.rs
@@ -6,9 +6,7 @@ use script_bindings::inheritance::Castable;
 
 use crate::dom::bindings::codegen::Bindings::NodeBinding::NodeMethods;
 use crate::dom::bindings::codegen::Bindings::SelectionBinding::SelectionMethods;
-use crate::dom::bindings::str::DOMString;
 use crate::dom::document::Document;
-use crate::dom::execcommand::basecommand::BaseCommand;
 use crate::dom::execcommand::contenteditable::{
     NodeExecCommandSupport, SelectionDeleteDirection, SelectionExecCommandSupport, split_the_parent,
 };
@@ -22,316 +20,310 @@ use crate::dom::selection::Selection;
 use crate::dom::text::Text;
 use crate::script_runtime::CanGc;
 
-pub(crate) struct DeleteCommand {}
-
-impl BaseCommand for DeleteCommand {
-    /// <https://w3c.github.io/editing/docs/execCommand/#the-delete-command>
-    fn execute(
-        &self,
-        cx: &mut js::context::JSContext,
-        document: &Document,
-        selection: &Selection,
-        _value: DOMString,
-    ) -> bool {
-        let active_range = selection
-            .active_range()
-            .expect("Must always have an active range");
-        // Step 1. If the active range is not collapsed, delete the selection and return true.
-        if !active_range.collapsed() {
-            selection.delete_the_selection(
-                cx,
-                document,
-                Default::default(),
-                Default::default(),
-                Default::default(),
-            );
-            return true;
-        }
-
-        // Step 2. Canonicalize whitespace at the active range's start.
-        active_range
-            .start_container()
-            .canonicalize_whitespace(active_range.start_offset(), true);
-
-        // Step 3. Let node and offset be the active range's start node and offset.
-        let mut node = active_range.start_container();
-        let mut offset = active_range.start_offset();
-
-        // Step 4. Repeat the following steps:
-        loop {
-            // Step 4.1. If offset is zero and node's previousSibling is an editable invisible node,
-            // remove node's previousSibling from its parent.
-            if offset == 0 {
-                if let Some(sibling) = node.GetPreviousSibling() {
-                    if sibling.is_editable() && sibling.is_invisible() {
-                        sibling.remove_self(cx);
-                        continue;
-                    }
-                }
-            }
-            // Step 4.2. Otherwise, if node has a child with index offset − 1 and that child is an editable invisible node,
-            // remove that child from node, then subtract one from offset.
-            if offset > 0 {
-                if let Some(child) = node.children().nth(offset as usize - 1) {
-                    if child.is_editable() && child.is_invisible() {
-                        child.remove_self(cx);
-                        offset -= 1;
-                        continue;
-                    }
-                }
-            }
-            // Step 4.3. Otherwise, if offset is zero and node is an inline node, or if node is an invisible node,
-            // set offset to the index of node, then set node to its parent.
-            if (offset == 0 && node.is_inline_node()) || node.is_invisible() {
-                offset = node.index();
-                node = node.GetParentNode().expect("Must always have a parent");
-                continue;
-            }
-            if offset > 0 {
-                if let Some(child) = node.children().nth(offset as usize - 1) {
-                    // Step 4.4. Otherwise, if node has a child with index offset − 1 and that child is an editable a,
-                    // remove that child from node, preserving its descendants. Then return true.
-                    if child.is_editable() && child.is::<HTMLAnchorElement>() {
-                        child.remove_preserving_its_descendants(cx);
-                        return true;
-                    }
-                    // Step 4.5. Otherwise, if node has a child with index offset − 1 and that child is not a block node or a br or an img,
-                    // set node to that child, then set offset to the length of node.
-                    if !(child.is_block_node() ||
-                        child.is::<HTMLBRElement>() ||
-                        child.is::<HTMLImageElement>())
-                    {
-                        node = child;
-                        offset = node.len();
-                        continue;
-                    }
-                }
-            }
-            // Step 4.6. Otherwise, break from this loop.
-            break;
-        }
-
-        // Step 5. If node is a Text node and offset is not zero, or if node is
-        // a block node that has a child with index offset − 1 and that child is a br or hr or img:
-        if (node.is::<Text>() && offset != 0) ||
-            (offset > 0 &&
-                node.is_block_node() &&
-                node.children()
-                    .nth(offset as usize - 1)
-                    .is_some_and(|child| {
-                        child.is::<HTMLBRElement>() ||
-                            child.is::<HTMLHRElement>() ||
-                            child.is::<HTMLImageElement>()
-                    }))
-        {
-            // Step 5.1. Call collapse(node, offset) on the context object's selection.
-            if selection
-                .Collapse(Some(&node), offset, CanGc::from_cx(cx))
-                .is_err()
-            {
-                unreachable!("Must not fail to collapse");
-            }
-            // Step 5.2. Call extend(node, offset − 1) on the context object's selection.
-            if selection
-                .Extend(&node, offset - 1, CanGc::from_cx(cx))
-                .is_err()
-            {
-                unreachable!("Must not fail to extend");
-            }
-            // Step 5.3. Delete the selection.
-            selection.delete_the_selection(
-                cx,
-                document,
-                Default::default(),
-                Default::default(),
-                Default::default(),
-            );
-            // Step 5.4. Return true.
-            return true;
-        }
-
-        // Step 6. If node is an inline node, return true.
-        if node.is_inline_node() {
-            return true;
-        }
-
-        // Step 7. If node is an li or dt or dd and is the first child of its parent, and offset is zero:
-        //
-        // TODO: Handle dt or dd
-        if offset == 0 &&
-            node.is::<HTMLLIElement>() &&
-            node.GetParentNode()
-                .and_then(|parent| parent.children().next())
-                .is_some_and(|first| first == node)
-        {
-            // Step 7.1. Let items be a list of all lis that are ancestors of node.
-            // TODO
-            // Step 7.2. Normalize sublists of each item in items.
-            // TODO
-            // Step 7.3. Record the values of the one-node list consisting of node, and let values be the result.
-            // TODO
-            // Step 7.4. Split the parent of the one-node list consisting of node.
-            split_the_parent(cx, &[&node]);
-            // Step 7.5. Restore the values from values.
-            // TODO
-            // Step 7.6. If node is a dd or dt, and it is not an allowed child of
-            // any of its ancestors in the same editing host,
-            // set the tag name of node to the default single-line container name
-            // and let node be the result.
-            // TODO
-            // Step 7.7. Fix disallowed ancestors of node.
-            // TODO
-            // Step 7.8. Return true.
-            return true;
-        }
-
-        // Step 8. Let start node equal node and let start offset equal offset.
-        let mut start_node = node.clone();
-        let mut start_offset = offset;
-
-        // Step 9. Repeat the following steps:
-        loop {
-            // Step 9.1. If start offset is zero,
-            // set start offset to the index of start node and then set start node to its parent.
-            if start_offset == 0 {
-                start_offset = start_node.index();
-                start_node = start_node
-                    .GetParentNode()
-                    .expect("Must always have a parent");
-                continue;
-            }
-            // Step 9.2. Otherwise, if start node has an editable invisible child with index start offset minus one,
-            // remove it from start node and subtract one from start offset.
-            assert!(
-                start_offset > 0,
-                "Must always have a start_offset greater than one"
-            );
-            if let Some(child) = start_node.children().nth(start_offset as usize - 1) {
-                if child.is_editable() && child.is_invisible() {
-                    child.remove_self(cx);
-                    start_offset -= 1;
-                    continue;
-                }
-            }
-            // Step 9.3. Otherwise, break from this loop.
-            break;
-        }
-
-        // Step 10. If offset is zero, and node has an editable inclusive ancestor in the same editing host that's an indentation element:
-        // TODO
-
-        // Step 11. If the child of start node with index start offset is a table, return true.
-        if start_node
-            .children()
-            .nth(start_offset as usize)
-            .is_some_and(|child| child.is::<HTMLTableElement>())
-        {
-            return true;
-        }
-
-        // Step 12. If start node has a child with index start offset − 1, and that child is a table:
-        // TODO
-
-        // Step 13. If offset is zero; and either the child of start node with index start offset
-        // minus one is an hr, or the child is a br whose previousSibling is either a br or not an inline node:
-        if offset == 0 &&
-            (start_offset > 0 &&
-                start_node
-                    .children()
-                    .nth(start_offset as usize - 1)
-                    .is_some_and(|child| {
-                        child.is::<HTMLHRElement>() ||
-                            (child.is::<HTMLBRElement>() &&
-                                child.GetPreviousSibling().is_some_and(|previous| {
-                                    previous.is::<HTMLBRElement>() || !previous.is_inline_node()
-                                }))
-                    }))
-        {
-            // Step 13.1. Call collapse(start node, start offset − 1) on the context object's selection.
-            if selection
-                .Collapse(Some(&start_node), start_offset - 1, CanGc::from_cx(cx))
-                .is_err()
-            {
-                unreachable!("Must not fail to collapse");
-            }
-            // Step 13.2. Call extend(start node, start offset) on the context object's selection.
-            if selection
-                .Extend(&start_node, start_offset, CanGc::from_cx(cx))
-                .is_err()
-            {
-                unreachable!("Must not fail to extend");
-            }
-            // Step 13.3. Delete the selection.
-            selection.delete_the_selection(
-                cx,
-                document,
-                Default::default(),
-                Default::default(),
-                Default::default(),
-            );
-            // Step 13.4. Call collapse(node, offset) on the selection.
-            if selection
-                .Collapse(Some(&node), offset, CanGc::from_cx(cx))
-                .is_err()
-            {
-                unreachable!("Must not fail to collapse");
-            }
-            // Step 13.5. Return true.
-            return true;
-        }
-
-        // Step 14. If the child of start node with index start offset is an li or dt or dd, and
-        // that child's firstChild is an inline node, and start offset is not zero:
-        // TODO
-
-        // Step 15. If start node's child with index start offset is an li or dt or dd, and
-        // that child's previousSibling is also an li or dt or dd:
-        // TODO
-
-        // Step 16. While start node has a child with index start offset minus one:
-        loop {
-            if start_offset == 0 {
-                break;
-            }
-            let Some(child) = start_node.children().nth(start_offset as usize - 1) else {
-                break;
-            };
-            // Step 16.1. If start node's child with index start offset minus one
-            // is editable and invisible, remove it from start node, then subtract one from start offset.
-            if child.is_editable() && child.is_invisible() {
-                child.remove_self(cx);
-                start_offset -= 1;
-            } else {
-                // Step 16.2. Otherwise, set start node to its child with index start offset minus one,
-                // then set start offset to the length of start node.
-                start_node = child;
-                start_offset = start_node.len();
-            }
-        }
-
-        // Step 17. Call collapse(start node, start offset) on the context object's selection.
-        if selection
-            .Collapse(Some(&start_node), start_offset, CanGc::from_cx(cx))
-            .is_err()
-        {
-            unreachable!("Must not fail to collapse");
-        }
-
-        // Step 18. Call extend(node, offset) on the context object's selection.
-        if selection.Extend(&node, offset, CanGc::from_cx(cx)).is_err() {
-            unreachable!("Must not fail to extend");
-        }
-
-        // Step 19. Delete the selection, with direction "backward".
+/// <https://w3c.github.io/editing/docs/execCommand/#the-delete-command>
+pub(crate) fn execute_delete_command(
+    cx: &mut js::context::JSContext,
+    document: &Document,
+    selection: &Selection,
+) -> bool {
+    let active_range = selection
+        .active_range()
+        .expect("Must always have an active range");
+    // Step 1. If the active range is not collapsed, delete the selection and return true.
+    if !active_range.collapsed() {
         selection.delete_the_selection(
             cx,
             document,
             Default::default(),
             Default::default(),
-            SelectionDeleteDirection::Backward,
+            Default::default(),
         );
-
-        // Step 20. Return true.
-        true
+        return true;
     }
+
+    // Step 2. Canonicalize whitespace at the active range's start.
+    active_range
+        .start_container()
+        .canonicalize_whitespace(active_range.start_offset(), true);
+
+    // Step 3. Let node and offset be the active range's start node and offset.
+    let mut node = active_range.start_container();
+    let mut offset = active_range.start_offset();
+
+    // Step 4. Repeat the following steps:
+    loop {
+        // Step 4.1. If offset is zero and node's previousSibling is an editable invisible node,
+        // remove node's previousSibling from its parent.
+        if offset == 0 {
+            if let Some(sibling) = node.GetPreviousSibling() {
+                if sibling.is_editable() && sibling.is_invisible() {
+                    sibling.remove_self(cx);
+                    continue;
+                }
+            }
+        }
+        // Step 4.2. Otherwise, if node has a child with index offset − 1 and that child is an editable invisible node,
+        // remove that child from node, then subtract one from offset.
+        if offset > 0 {
+            if let Some(child) = node.children().nth(offset as usize - 1) {
+                if child.is_editable() && child.is_invisible() {
+                    child.remove_self(cx);
+                    offset -= 1;
+                    continue;
+                }
+            }
+        }
+        // Step 4.3. Otherwise, if offset is zero and node is an inline node, or if node is an invisible node,
+        // set offset to the index of node, then set node to its parent.
+        if (offset == 0 && node.is_inline_node()) || node.is_invisible() {
+            offset = node.index();
+            node = node.GetParentNode().expect("Must always have a parent");
+            continue;
+        }
+        if offset > 0 {
+            if let Some(child) = node.children().nth(offset as usize - 1) {
+                // Step 4.4. Otherwise, if node has a child with index offset − 1 and that child is an editable a,
+                // remove that child from node, preserving its descendants. Then return true.
+                if child.is_editable() && child.is::<HTMLAnchorElement>() {
+                    child.remove_preserving_its_descendants(cx);
+                    return true;
+                }
+                // Step 4.5. Otherwise, if node has a child with index offset − 1 and that child is not a block node or a br or an img,
+                // set node to that child, then set offset to the length of node.
+                if !(child.is_block_node() ||
+                    child.is::<HTMLBRElement>() ||
+                    child.is::<HTMLImageElement>())
+                {
+                    node = child;
+                    offset = node.len();
+                    continue;
+                }
+            }
+        }
+        // Step 4.6. Otherwise, break from this loop.
+        break;
+    }
+
+    // Step 5. If node is a Text node and offset is not zero, or if node is
+    // a block node that has a child with index offset − 1 and that child is a br or hr or img:
+    if (node.is::<Text>() && offset != 0) ||
+        (offset > 0 &&
+            node.is_block_node() &&
+            node.children()
+                .nth(offset as usize - 1)
+                .is_some_and(|child| {
+                    child.is::<HTMLBRElement>() ||
+                        child.is::<HTMLHRElement>() ||
+                        child.is::<HTMLImageElement>()
+                }))
+    {
+        // Step 5.1. Call collapse(node, offset) on the context object's selection.
+        if selection
+            .Collapse(Some(&node), offset, CanGc::from_cx(cx))
+            .is_err()
+        {
+            unreachable!("Must not fail to collapse");
+        }
+        // Step 5.2. Call extend(node, offset − 1) on the context object's selection.
+        if selection
+            .Extend(&node, offset - 1, CanGc::from_cx(cx))
+            .is_err()
+        {
+            unreachable!("Must not fail to extend");
+        }
+        // Step 5.3. Delete the selection.
+        selection.delete_the_selection(
+            cx,
+            document,
+            Default::default(),
+            Default::default(),
+            Default::default(),
+        );
+        // Step 5.4. Return true.
+        return true;
+    }
+
+    // Step 6. If node is an inline node, return true.
+    if node.is_inline_node() {
+        return true;
+    }
+
+    // Step 7. If node is an li or dt or dd and is the first child of its parent, and offset is zero:
+    //
+    // TODO: Handle dt or dd
+    if offset == 0 &&
+        node.is::<HTMLLIElement>() &&
+        node.GetParentNode()
+            .and_then(|parent| parent.children().next())
+            .is_some_and(|first| first == node)
+    {
+        // Step 7.1. Let items be a list of all lis that are ancestors of node.
+        // TODO
+        // Step 7.2. Normalize sublists of each item in items.
+        // TODO
+        // Step 7.3. Record the values of the one-node list consisting of node, and let values be the result.
+        // TODO
+        // Step 7.4. Split the parent of the one-node list consisting of node.
+        split_the_parent(cx, &[&node]);
+        // Step 7.5. Restore the values from values.
+        // TODO
+        // Step 7.6. If node is a dd or dt, and it is not an allowed child of
+        // any of its ancestors in the same editing host,
+        // set the tag name of node to the default single-line container name
+        // and let node be the result.
+        // TODO
+        // Step 7.7. Fix disallowed ancestors of node.
+        // TODO
+        // Step 7.8. Return true.
+        return true;
+    }
+
+    // Step 8. Let start node equal node and let start offset equal offset.
+    let mut start_node = node.clone();
+    let mut start_offset = offset;
+
+    // Step 9. Repeat the following steps:
+    loop {
+        // Step 9.1. If start offset is zero,
+        // set start offset to the index of start node and then set start node to its parent.
+        if start_offset == 0 {
+            start_offset = start_node.index();
+            start_node = start_node
+                .GetParentNode()
+                .expect("Must always have a parent");
+            continue;
+        }
+        // Step 9.2. Otherwise, if start node has an editable invisible child with index start offset minus one,
+        // remove it from start node and subtract one from start offset.
+        assert!(
+            start_offset > 0,
+            "Must always have a start_offset greater than one"
+        );
+        if let Some(child) = start_node.children().nth(start_offset as usize - 1) {
+            if child.is_editable() && child.is_invisible() {
+                child.remove_self(cx);
+                start_offset -= 1;
+                continue;
+            }
+        }
+        // Step 9.3. Otherwise, break from this loop.
+        break;
+    }
+
+    // Step 10. If offset is zero, and node has an editable inclusive ancestor in the same editing host that's an indentation element:
+    // TODO
+
+    // Step 11. If the child of start node with index start offset is a table, return true.
+    if start_node
+        .children()
+        .nth(start_offset as usize)
+        .is_some_and(|child| child.is::<HTMLTableElement>())
+    {
+        return true;
+    }
+
+    // Step 12. If start node has a child with index start offset − 1, and that child is a table:
+    // TODO
+
+    // Step 13. If offset is zero; and either the child of start node with index start offset
+    // minus one is an hr, or the child is a br whose previousSibling is either a br or not an inline node:
+    if offset == 0 &&
+        (start_offset > 0 &&
+            start_node
+                .children()
+                .nth(start_offset as usize - 1)
+                .is_some_and(|child| {
+                    child.is::<HTMLHRElement>() ||
+                        (child.is::<HTMLBRElement>() &&
+                            child.GetPreviousSibling().is_some_and(|previous| {
+                                previous.is::<HTMLBRElement>() || !previous.is_inline_node()
+                            }))
+                }))
+    {
+        // Step 13.1. Call collapse(start node, start offset − 1) on the context object's selection.
+        if selection
+            .Collapse(Some(&start_node), start_offset - 1, CanGc::from_cx(cx))
+            .is_err()
+        {
+            unreachable!("Must not fail to collapse");
+        }
+        // Step 13.2. Call extend(start node, start offset) on the context object's selection.
+        if selection
+            .Extend(&start_node, start_offset, CanGc::from_cx(cx))
+            .is_err()
+        {
+            unreachable!("Must not fail to extend");
+        }
+        // Step 13.3. Delete the selection.
+        selection.delete_the_selection(
+            cx,
+            document,
+            Default::default(),
+            Default::default(),
+            Default::default(),
+        );
+        // Step 13.4. Call collapse(node, offset) on the selection.
+        if selection
+            .Collapse(Some(&node), offset, CanGc::from_cx(cx))
+            .is_err()
+        {
+            unreachable!("Must not fail to collapse");
+        }
+        // Step 13.5. Return true.
+        return true;
+    }
+
+    // Step 14. If the child of start node with index start offset is an li or dt or dd, and
+    // that child's firstChild is an inline node, and start offset is not zero:
+    // TODO
+
+    // Step 15. If start node's child with index start offset is an li or dt or dd, and
+    // that child's previousSibling is also an li or dt or dd:
+    // TODO
+
+    // Step 16. While start node has a child with index start offset minus one:
+    loop {
+        if start_offset == 0 {
+            break;
+        }
+        let Some(child) = start_node.children().nth(start_offset as usize - 1) else {
+            break;
+        };
+        // Step 16.1. If start node's child with index start offset minus one
+        // is editable and invisible, remove it from start node, then subtract one from start offset.
+        if child.is_editable() && child.is_invisible() {
+            child.remove_self(cx);
+            start_offset -= 1;
+        } else {
+            // Step 16.2. Otherwise, set start node to its child with index start offset minus one,
+            // then set start offset to the length of start node.
+            start_node = child;
+            start_offset = start_node.len();
+        }
+    }
+
+    // Step 17. Call collapse(start node, start offset) on the context object's selection.
+    if selection
+        .Collapse(Some(&start_node), start_offset, CanGc::from_cx(cx))
+        .is_err()
+    {
+        unreachable!("Must not fail to collapse");
+    }
+
+    // Step 18. Call extend(node, offset) on the context object's selection.
+    if selection.Extend(&node, offset, CanGc::from_cx(cx)).is_err() {
+        unreachable!("Must not fail to extend");
+    }
+
+    // Step 19. Delete the selection, with direction "backward".
+    selection.delete_the_selection(
+        cx,
+        document,
+        Default::default(),
+        Default::default(),
+        SelectionDeleteDirection::Backward,
+    );
+
+    // Step 20. Return true.
+    true
 }

--- a/components/script/dom/execcommand/commands/stylewithcss.rs
+++ b/components/script/dom/execcommand/commands/stylewithcss.rs
@@ -4,31 +4,14 @@
 
 use crate::dom::bindings::str::DOMString;
 use crate::dom::document::Document;
-use crate::dom::execcommand::basecommand::BaseCommand;
-use crate::dom::selection::Selection;
 
-pub(crate) struct StyleWithCssCommand {}
+/// <https://w3c.github.io/editing/docs/execCommand/#the-stylewithcss-command>
+pub(crate) fn execute_style_with_css_command(document: &Document, value: DOMString) -> bool {
+    // > If value is an ASCII case-insensitive match for the string "false", set the CSS styling flag to false.
+    // > Otherwise, set the CSS styling flag to true. Either way, return true.
+    let value = value.to_ascii_lowercase().as_str() != "false";
 
-impl BaseCommand for StyleWithCssCommand {
-    /// <https://w3c.github.io/editing/docs/execCommand/#the-stylewithcss-command>
-    fn execute(
-        &self,
-        _cx: &mut js::context::JSContext,
-        document: &Document,
-        _selection: &Selection,
-        value: DOMString,
-    ) -> bool {
-        // > If value is an ASCII case-insensitive match for the string "false", set the CSS styling flag to false.
-        // > Otherwise, set the CSS styling flag to true. Either way, return true.
-        let value = value.to_ascii_lowercase().as_str() != "false";
+    document.set_css_styling_flag(value);
 
-        document.set_css_styling_flag(value);
-
-        true
-    }
-
-    /// <https://w3c.github.io/editing/docs/execCommand/#the-stylewithcss-command>
-    fn current_state(&self, document: &Document) -> Option<bool> {
-        Some(document.css_styling_flag())
-    }
+    true
 }

--- a/components/script/dom/execcommand/contenteditable.rs
+++ b/components/script/dom/execcommand/contenteditable.rs
@@ -22,9 +22,11 @@ use crate::dom::bindings::codegen::Bindings::SelectionBinding::SelectionMethods;
 use crate::dom::bindings::codegen::UnionTypes::StringOrElementCreationOptions;
 use crate::dom::bindings::inheritance::{ElementTypeId, HTMLElementTypeId, NodeTypeId};
 use crate::dom::bindings::root::{DomRoot, DomSlice};
+use crate::dom::bindings::str::DOMString;
 use crate::dom::characterdata::CharacterData;
 use crate::dom::document::Document;
 use crate::dom::element::Element;
+use crate::dom::execcommand::basecommand::CommandName;
 use crate::dom::html::htmlanchorelement::HTMLAnchorElement;
 use crate::dom::html::htmlbrelement::HTMLBRElement;
 use crate::dom::html::htmlelement::HTMLElement;
@@ -34,6 +36,7 @@ use crate::dom::html::htmltablecellelement::HTMLTableCellElement;
 use crate::dom::html::htmltablerowelement::HTMLTableRowElement;
 use crate::dom::html::htmltablesectionelement::HTMLTableSectionElement;
 use crate::dom::node::{Node, NodeTraits, ShadowIncluding};
+use crate::dom::range::Range;
 use crate::dom::selection::Selection;
 use crate::dom::text::Text;
 use crate::script_runtime::CanGc;
@@ -669,6 +672,7 @@ pub(crate) trait NodeExecCommandSupport {
     fn block_node_of(&self) -> Option<DomRoot<Node>>;
     fn is_visible(&self) -> bool;
     fn is_invisible(&self) -> bool;
+    fn is_formattable(&self) -> bool;
     fn is_block_start_point(&self, offset: usize) -> bool;
     fn is_block_end_point(&self, offset: u32) -> bool;
     fn is_block_boundary_point(&self, offset: u32) -> bool;
@@ -684,6 +688,7 @@ pub(crate) trait NodeExecCommandSupport {
     fn remove_extraneous_line_breaks_before(&self, cx: &mut js::context::JSContext);
     fn remove_extraneous_line_breaks_at_the_end_of(&self, cx: &mut js::context::JSContext);
     fn remove_preserving_its_descendants(&self, cx: &mut js::context::JSContext);
+    fn effective_command_value(&self, command_name: CommandName) -> Option<DOMString>;
 }
 
 impl NodeExecCommandSupport for Node {
@@ -777,6 +782,14 @@ impl NodeExecCommandSupport for Node {
     fn is_invisible(&self) -> bool {
         // > Something is invisible if it is a node that is not visible.
         !self.is_visible()
+    }
+
+    /// <https://w3c.github.io/editing/docs/execCommand/#formattable-node>
+    fn is_formattable(&self) -> bool {
+        // > A formattable node is an editable visible node that is either a Text node, an img, or a br.
+        self.is_editable() &&
+            self.is_visible() &&
+            (self.is::<Text>() || self.is::<HTMLImageElement>() || self.is::<HTMLBRElement>())
     }
 
     /// <https://w3c.github.io/editing/docs/execCommand/#block-start-point>
@@ -1293,6 +1306,99 @@ impl NodeExecCommandSupport for Node {
             split_the_parent(cx, children.r());
         }
     }
+
+    /// <https://w3c.github.io/editing/docs/execCommand/#effective-command-value>
+    fn effective_command_value(&self, command_name: CommandName) -> Option<DOMString> {
+        // Step 1. If neither node nor its parent is an Element, return null.
+        // Step 2. If node is not an Element, return the effective command value of its parent for command.
+        if !self.is::<Element>() {
+            return self.GetParentElement().and_then(|parent| {
+                parent
+                    .upcast::<Node>()
+                    .effective_command_value(command_name)
+            });
+        }
+        match command_name {
+            // Step 3. If command is "createLink" or "unlink":
+            CommandName::CreateLink | CommandName::Unlink => {
+                // Step 3.1. While node is not null, and is not an a element that has an href attribute, set node to its parent.
+                let mut current_node = Some(DomRoot::from_ref(self));
+                while let Some(node) = current_node {
+                    if let Some(anchor_value) =
+                        node.downcast::<HTMLAnchorElement>().and_then(|anchor| {
+                            anchor
+                                .upcast::<Element>()
+                                .get_attribute(&local_name!("href"))
+                        })
+                    {
+                        // Step 3.3. Return the value of node's href attribute.
+                        return Some(DOMString::from(&**anchor_value.value()));
+                    }
+                    current_node = node.GetParentNode();
+                }
+                // Step 3.2. If node is null, return null.
+                None
+            },
+            // Step 4. If command is "backColor" or "hiliteColor":
+            CommandName::BackColor | CommandName::HiliteColor => {
+                // Step 4.1. While the resolved value of "background-color" on node is any fully transparent value,
+                // and node's parent is an Element, set node to its parent.
+                // TODO
+                // Step 4.2. Return the resolved value of "background-color" for node.
+                // TODO
+                None
+            },
+            // Step 5. If command is "subscript" or "superscript":
+            CommandName::Subscript | CommandName::Superscript => {
+                // Step 5.1. Let affected by subscript and affected by superscript be two boolean variables,
+                // both initially false.
+                let mut affected_by_subscript = false;
+                let mut affected_by_superscript = false;
+                // Step 5.2. While node is an inline node:
+                let mut current_node = Some(DomRoot::from_ref(self));
+                while let Some(node) = current_node {
+                    if !node.is_inline_node() {
+                        break;
+                    }
+                    if let Some(element) = node.downcast::<Element>() {
+                        // Step 5.2.1. If node is a sub, set affected by subscript to true.
+                        if *element.local_name() == local_name!("sub") {
+                            affected_by_subscript = true;
+                        } else if *element.local_name() == local_name!("sup") {
+                            // Step 5.2.2. Otherwise, if node is a sup, set affected by superscript to true.
+                            affected_by_superscript = true;
+                        }
+                    }
+                    // Step 5.2.3. Set node to its parent.
+                    current_node = node.GetParentNode();
+                }
+                Some(match (affected_by_subscript, affected_by_superscript) {
+                    // Step 5.3. If affected by subscript and affected by superscript are both true,
+                    // return the string "mixed".
+                    (true, true) => "mixed".into(),
+                    // Step 5.4. If affected by subscript is true, return "subscript".
+                    (true, false) => "subscript".into(),
+                    // Step 5.5. If affected by superscript is true, return "superscript".
+                    (false, true) => "superscript".into(),
+                    // Step 5.6. Return null.
+                    (false, false) => return None,
+                })
+            },
+            // Step 6. If command is "strikethrough",
+            // and the "text-decoration" property of node or any of its ancestors has resolved value containing "line-through",
+            // return "line-through". Otherwise, return null.
+            // TODO
+            CommandName::Strikethrough => None,
+            // Step 7. If command is "underline",
+            // and the "text-decoration" property of node or any of its ancestors has resolved value containing "underline",
+            // return "underline". Otherwise, return null.
+            // TODO
+            CommandName::Underline => None,
+            // Step 8. Return the resolved value for node of the relevant CSS property for command.
+            // TODO
+            _ => None,
+        }
+    }
 }
 
 pub(crate) trait ContentEditableRange {
@@ -1505,6 +1611,180 @@ impl EquivalentPoint for (DomRoot<Node>, u32) {
     }
 }
 
+enum BoolOrOptionalString {
+    Bool(bool),
+    OptionalString(Option<DOMString>),
+}
+
+impl From<Option<DOMString>> for BoolOrOptionalString {
+    fn from(optional_string: Option<DOMString>) -> Self {
+        Self::OptionalString(optional_string)
+    }
+}
+
+impl From<bool> for BoolOrOptionalString {
+    fn from(bool_: bool) -> Self {
+        Self::Bool(bool_)
+    }
+}
+
+struct RecordedStateOfNode {
+    name: CommandName,
+    value: BoolOrOptionalString,
+}
+
+impl Range {
+    /// <https://w3c.github.io/editing/docs/execCommand/#effectively-contained>
+    fn is_effectively_contained_node(&self, node: &Node) -> bool {
+        assert!(!self.collapsed());
+        // > A node node is effectively contained in a range range if range is not collapsed,
+        // > and at least one of the following holds:
+        // > node is range's start node, it is a Text node, and its length is different from range's start offset.
+        let start_container = self.start_container();
+        if *start_container == *node && node.is::<Text>() && node.len() != self.start_offset() {
+            return true;
+        }
+        // > node is range's end node, it is a Text node, and range's end offset is not 0.
+        let end_container = self.end_container();
+        if *end_container == *node && node.is::<Text>() && self.end_offset() != 0 {
+            return true;
+        }
+        // > node is contained in range.
+        //
+        // Already checked by caller
+
+        // > node has at least one child; and all its children are effectively contained in range;
+        node.children_count() > 0 && node.children().all(|child| self.is_effectively_contained_node(&child))
+        // > and either range's start node is not a descendant of node or is not a Text node or range's start offset is zero;
+        && (!node.is_ancestor_of(&start_container) || !start_container.is::<Text>() || self.start_offset() == 0)
+        // > and either range's end node is not a descendant of node or is not a Text node or range's end offset is its end node's length.
+        && (!node.is_ancestor_of(&end_container) || !end_container.is::<Text>() || self.end_offset() == end_container.len())
+    }
+
+    fn first_formattable_contained_node(&self) -> Option<DomRoot<Node>> {
+        if self.collapsed() {
+            return None;
+        }
+        let Ok(contained_children) = self.contained_children() else {
+            unreachable!("Must always be able to obtain contained children");
+        };
+        contained_children
+            .first_partially_contained_child
+            .as_ref()
+            .filter(|child| child.is_formattable() && self.is_effectively_contained_node(child))
+            .or_else(|| {
+                // We don't call `is_effectively_contained_node` here, since nodes are considered
+                // effectively contained if they are in `contained_children`
+                contained_children
+                    .contained_children
+                    .iter()
+                    .find(|child| child.is_formattable())
+            })
+            .or_else(|| {
+                contained_children
+                    .last_partially_contained_child
+                    .as_ref()
+                    .filter(|child| {
+                        child.is_formattable() && self.is_effectively_contained_node(child)
+                    })
+            })
+            .cloned()
+    }
+
+    /// <https://w3c.github.io/editing/docs/execCommand/#record-current-states-and-values>
+    fn record_current_states_and_values(&self) -> Vec<RecordedStateOfNode> {
+        // Step 1. Let overrides be a list of (string, string or boolean) ordered pairs, initially empty.
+        //
+        // We return the vec in one go for the relevant values
+
+        // Step 2. Let node be the first formattable node effectively contained in the active range,
+        // or null if there is none.
+        let Some(node) = self.first_formattable_contained_node() else {
+            // Step 3. If node is null, return overrides.
+            return vec![];
+        };
+        // Step 8. Return overrides.
+        vec![
+            // Step 4. Add ("createLink", node's effective command value for "createLink") to overrides.
+            RecordedStateOfNode {
+                name: CommandName::CreateLink,
+                value: node.effective_command_value(CommandName::CreateLink).into(),
+            },
+            // Step 5. For each command in the list
+            // "bold", "italic", "strikethrough", "subscript", "superscript", "underline", in order:
+            // if node's effective command value for command is one of its inline command activated values,
+            // add (command, true) to overrides, and otherwise add (command, false) to overrides.
+            // TODO
+
+            // Step 6. For each command in the list "fontName", "foreColor", "hiliteColor", in order:
+            // add (command, command's value) to overrides.
+            // TODO
+
+            // Step 7. Add ("fontSize", node's effective command value for "fontSize") to overrides.
+            RecordedStateOfNode {
+                name: CommandName::FontSize,
+                value: node.effective_command_value(CommandName::FontSize).into(),
+            },
+        ]
+    }
+
+    /// <https://w3c.github.io/editing/docs/execCommand/#restore-states-and-values>
+    fn restore_states_and_values(
+        &self,
+        context_object: &Document,
+        overrides: Vec<RecordedStateOfNode>,
+    ) {
+        // Step 1. Let node be the first formattable node effectively contained in the active range,
+        // or null if there is none.
+        let Some(_node) = self.first_formattable_contained_node() else {
+            // Step 3. Otherwise, for each (command, override) pair in overrides, in order:
+            for override_state in overrides {
+                // Step 3.1. If override is a boolean, set the state override for command to override.
+                match override_state.value {
+                    BoolOrOptionalString::Bool(bool_) => {
+                        context_object.set_state_override(override_state.name, bool_)
+                    },
+                    // Step 3.2. If override is a string, set the value override for command to override.
+                    BoolOrOptionalString::OptionalString(optional_string) => {
+                        context_object.set_value_override(override_state.name, optional_string)
+                    },
+                }
+            }
+            return;
+        };
+        // Step 2. If node is not null, then for each (command, override) pair in overrides, in order:
+        // TODO
+
+        // Step 2.1. If override is a boolean, and queryCommandState(command)
+        // returns something different from override, take the action for command,
+        // with value equal to the empty string.
+        // TODO
+
+        // Step 2.2. Otherwise, if override is a string, and command is neither "createLink" nor "fontSize",
+        // and queryCommandValue(command) returns something not equivalent to override,
+        // take the action for command, with value equal to override.
+        // TODO
+
+        // Step 2.3. Otherwise, if override is a string; and command is "createLink";
+        // and either there is a value override for "createLink" that is not equal to override,
+        // or there is no value override for "createLink" and node's effective command value
+        // for "createLink" is not equal to override: take the action for "createLink", with value equal to override.
+        // TODO
+
+        // Step 2.4. Otherwise, if override is a string; and command is "fontSize";
+        // and either there is a value override for "fontSize" that is not equal to override,
+        // or there is no value override for "fontSize" and node's effective command value for "fontSize"
+        // is not loosely equivalent to override:
+        // TODO
+
+        // Step 2.5. Otherwise, continue this loop from the beginning.
+        // TODO
+
+        // Step 2.6. Set node to the first formattable node effectively contained in the active range, if there is one.
+        // TODO
+    }
+}
+
 #[derive(Default, PartialEq)]
 pub(crate) enum SelectionDeletionBlockMerging {
     #[default]
@@ -1693,7 +1973,7 @@ impl SelectionExecCommandSupport for Selection {
         // This step does not exist in the spec
 
         // Step 19. Record current states and values, and let overrides be the result.
-        // TODO
+        let overrides = active_range.record_current_states_and_values();
 
         // Step 20.
         //
@@ -1724,8 +2004,7 @@ impl SelectionExecCommandSupport for Selection {
                     }
                 }
                 // Step 21.5. Restore states and values from overrides.
-                //
-                // TODO
+                active_range.restore_states_and_values(context_object, overrides);
 
                 // Step 21.6. Abort these steps.
                 return;
@@ -1865,8 +2144,7 @@ impl SelectionExecCommandSupport for Selection {
                 }
             }
             // Step 30.3. Restore states and values from overrides.
-            //
-            // TODO
+            active_range.restore_states_and_values(context_object, overrides);
 
             // Step 30.4. Abort these steps.
             return;
@@ -1961,8 +2239,7 @@ impl SelectionExecCommandSupport for Selection {
                     end_block.remove_self(cx);
                 }
                 // Step 32.4.4. Restore states and values from overrides.
-                //
-                // TODO
+                active_range.restore_states_and_values(context_object, overrides);
 
                 // Step 32.4.5. Abort these steps.
                 return;
@@ -2181,6 +2458,6 @@ impl SelectionExecCommandSupport for Selection {
         start_block.remove_extraneous_line_breaks_at_the_end_of(cx);
 
         // Step 41. Restore states and values from overrides.
-        // TODO
+        active_range.restore_states_and_values(context_object, overrides);
     }
 }

--- a/components/script/dom/execcommand/execcommands.rs
+++ b/components/script/dom/execcommand/execcommands.rs
@@ -6,18 +6,20 @@ use crate::dom::bindings::codegen::Bindings::DocumentBinding::DocumentMethods;
 use crate::dom::bindings::root::DomRoot;
 use crate::dom::bindings::str::DOMString;
 use crate::dom::document::Document;
-use crate::dom::execcommand::basecommand::BaseCommand;
-use crate::dom::execcommand::commands::defaultparagraphseparator::DefaultParagraphSeparatorCommand;
-use crate::dom::execcommand::commands::delete::DeleteCommand;
-use crate::dom::execcommand::commands::stylewithcss::StyleWithCssCommand;
+use crate::dom::execcommand::basecommand::CommandName;
 use crate::dom::selection::Selection;
 use crate::script_runtime::CanGc;
 
 /// <https://w3c.github.io/editing/docs/execCommand/#miscellaneous-commands>
-fn is_command_listed_in_miscellaneous_section(command_id: &str) -> bool {
+fn is_command_listed_in_miscellaneous_section(command_name: CommandName) -> bool {
     matches!(
-        command_id.to_lowercase().as_str(),
-        "defaultparagraphseparator" | "redo" | "selectall" | "stylewithcss" | "undo" | "usecss"
+        command_name,
+        CommandName::DefaultParagraphSeparator |
+            CommandName::Redo |
+            CommandName::SelectAll |
+            CommandName::StyleWithCss |
+            CommandName::Undo |
+            CommandName::Usecss
     )
 }
 
@@ -26,14 +28,14 @@ impl Document {
     fn selection_if_command_is_enabled(
         &self,
         cx: &mut js::context::JSContext,
-        command_id: &DOMString,
+        command_name: CommandName,
     ) -> Option<DomRoot<Selection>> {
         let selection = self.GetSelection(CanGc::from_cx(cx))?;
         // > Among commands defined in this specification, those listed in Miscellaneous commands are always enabled,
         // > except for the cut command and the paste command.
         //
         // Note: cut and paste are listed in the "clipboard commands" section, not the miscellaneous section
-        if is_command_listed_in_miscellaneous_section(&command_id.str()) {
+        if is_command_listed_in_miscellaneous_section(command_name) {
             return Some(selection);
         }
         // > The other commands defined here are enabled if the active range is not null,
@@ -56,16 +58,13 @@ impl Document {
     }
 
     /// <https://w3c.github.io/editing/docs/execCommand/#supported>
-    fn command_if_command_is_supported(
-        &self,
-        command_id: &DOMString,
-    ) -> Option<Box<dyn BaseCommand>> {
+    fn command_if_command_is_supported(&self, command_id: &DOMString) -> Option<CommandName> {
         // https://w3c.github.io/editing/docs/execCommand/#methods-to-query-and-execute-commands
         // > All of these methods must treat their command argument ASCII case-insensitively.
         Some(match &*command_id.str().to_lowercase() {
-            "delete" => Box::new(DeleteCommand {}),
-            "defaultparagraphseparator" => Box::new(DefaultParagraphSeparatorCommand {}),
-            "stylewithcss" => Box::new(StyleWithCssCommand {}),
+            "delete" => CommandName::Delete,
+            "defaultparagraphseparator" => CommandName::DefaultParagraphSeparator,
+            "stylewithcss" => CommandName::StyleWithCss,
             _ => return None,
         })
     }
@@ -80,7 +79,7 @@ pub(crate) trait DocumentExecCommandSupport {
         &self,
         cx: &mut js::context::JSContext,
         command_id: &DOMString,
-    ) -> Option<(Box<dyn BaseCommand>, DomRoot<Selection>)>;
+    ) -> Option<(CommandName, DomRoot<Selection>)>;
     fn exec_command_for_command_id(
         &self,
         cx: &mut js::context::JSContext,
@@ -113,11 +112,8 @@ impl DocumentExecCommandSupport for Document {
             return false;
         };
         // Step 2. If the state override for command is set, return it.
-        if self.state_override() {
-            return true;
-        }
         // Step 3. Return true if command's state is true, otherwise false.
-        state
+        self.state_override(&command).unwrap_or(state)
     }
 
     /// <https://w3c.github.io/editing/docs/execCommand/#querycommandvalue()>
@@ -134,7 +130,7 @@ impl DocumentExecCommandSupport for Document {
         // TODO
 
         // Step 3. If the value override for command is set, return it.
-        if let Some(value_override) = self.value_override() {
+        if let Some(value_override) = self.value_override(&command) {
             return value_override;
         }
         // Step 4. Return command's value.
@@ -146,10 +142,11 @@ impl DocumentExecCommandSupport for Document {
         &self,
         cx: &mut js::context::JSContext,
         command_id: &DOMString,
-    ) -> Option<(Box<dyn BaseCommand>, DomRoot<Selection>)> {
+    ) -> Option<(CommandName, DomRoot<Selection>)> {
         // Step 2. Return true if command is both supported and enabled, false otherwise.
-        self.command_if_command_is_supported(command_id)
-            .zip(self.selection_if_command_is_enabled(cx, command_id))
+        let command = self.command_if_command_is_supported(command_id)?;
+        let selection = self.selection_if_command_is_enabled(cx, command)?;
+        Some((command, selection))
     }
 
     /// <https://w3c.github.io/editing/docs/execCommand/#execcommand()>

--- a/components/script/dom/range.rs
+++ b/components/script/dom/range.rs
@@ -61,8 +61,8 @@ pub(crate) struct Range {
 }
 
 pub(crate) struct ContainedChildren {
-    first_partially_contained_child: Option<DomRoot<Node>>,
-    last_partially_contained_child: Option<DomRoot<Node>>,
+    pub(crate) first_partially_contained_child: Option<DomRoot<Node>>,
+    pub(crate) last_partially_contained_child: Option<DomRoot<Node>>,
     pub(crate) contained_children: Vec<DomRoot<Node>>,
 }
 


### PR DESCRIPTION
There is a chicken and egg problem here: to be able to restore the state of nodes, we need the implementation of several other commands. However, those commands then need some of the algorithms that are implemented for storing the state.

Therefore, this PR has no behavioral changes, but includes preparations to be able to first implement the functionality of the relevant commands.

To that end, several changes were necessary:
1. Remove BaseCommand and instead use CommandName enum to define behavior. The majority of the action part of the commands still exists in separate files for readability (turn off whitespace changes in the diff to make things readable)
2. Change the usages of a DOMString to the new CommandName enum in the methods of execCommand. Both to make the enum work, but also as an improvement to avoid operating on strings.
3. The {value,state}_override values in document need to be a map, not a single boolean. I didn't understand these when I first implemented it, but now it's clearer to me what their structure is.

In the end, the relevant recording and restoring state is implemented, to the extent that it is possible. It does some light-weight interaction, but most of the code doesn't do anything yet since the relevant commands aren't implemented.

Part of #25005 

Testing: no behavioral changes, only preparations for future work