### PR TITLE
script: Account for `multiple` in `<input type=file>` text

### DIFF
--- a/components/layout/stylesheets/servo.css
+++ b/components/layout/stylesheets/servo.css
@@ -145,6 +145,10 @@ input[type="file"]::before {
   margin-inline-end: 0.25em;
 }
 
+input[type="file"][multiple]::before {
+  content: "Choose Files";
+}
+
 input[type="file"] {
   display: inline-block;
   border: none;

--- a/components/script/dom/html/htmlinputelement.rs
+++ b/components/script/dom/html/htmlinputelement.rs
@@ -101,6 +101,7 @@ const DEFAULT_SUBMIT_VALUE: &str = "Submit";
 const DEFAULT_RESET_VALUE: &str = "Reset";
 const PASSWORD_REPLACEMENT_CHAR: char = '●';
 const DEFAULT_FILE_INPUT_VALUE: &str = "No file chosen";
+const DEFAULT_FILE_INPUT_MULTIPLE_VALUE: &str = "No files chosen";
 
 #[derive(Clone, JSTraceable, MallocSizeOf)]
 #[cfg_attr(crown, crown::unrooted_must_root_lint::must_root)]
@@ -1471,6 +1472,9 @@ impl HTMLInputElement {
             InputType::Range => "".into(),
             InputType::File => {
                 let Some(filelist) = self.filelist.get() else {
+                    if self.Multiple() {
+                        return DEFAULT_FILE_INPUT_MULTIPLE_VALUE.into();
+                    }
                     return DEFAULT_FILE_INPUT_VALUE.into();
                 };
                 let length = filelist.Length();
@@ -1479,6 +1483,9 @@ impl HTMLInputElement {
                 }
 
                 let Some(first_item) = filelist.Item(0) else {
+                    if self.Multiple() {
+                        return DEFAULT_FILE_INPUT_MULTIPLE_VALUE.into();
+                    }
                     return DEFAULT_FILE_INPUT_VALUE.into();
                 };
                 first_item.name().to_string().into()


### PR DESCRIPTION
File input button and description text now accounts for multiple file support.

Testing: Manual test via https://demo.lukewarlow.dev/css-forms.html

<img width="214" height="131" alt="image" src="https://github.com/user-attachments/assets/4894bca6-2d56-4d48-ac10-96f23fd70f2c" />
