### PR TITLE
script: Use the shared task canceller in `DedicatedWorkerGlobalScope::run_worker_scope`

### DIFF
--- a/components/script/dom/workers/dedicatedworkerglobalscope.rs
+++ b/components/script/dom/workers/dedicatedworkerglobalscope.rs
@@ -511,7 +511,7 @@ impl DedicatedWorkerGlobalScope {
                     sender: event_loop_sender.clone(),
                     pipeline_id,
                     name: TaskSourceName::Networking,
-                    canceller: Default::default(),
+                    canceller: scope.shared_task_canceller(),
                 };
                 let context = ScriptFetchContext::new(
                     Trusted::new(scope),


### PR DESCRIPTION
On initializing the `task_source` when fetching a classic script, we resorted to the default value for the task canceller. This has now been replaced with the shared task canceller from the current global worked scope.

Testing: Ran the unit tests and the WPT tests
Fixes:  #42536