### PR TITLE
script: Implement drop-down select multiple

### DIFF
--- a/components/script/dom/document/document_embedder_controls.rs
+++ b/components/script/dom/document/document_embedder_controls.rs
@@ -207,7 +207,7 @@ impl DocumentEmbedderControls {
                 ControlElement::Select(select_element),
                 EmbedderControlResponse::SelectElement(response),
             ) => {
-                select_element.handle_menu_response(cx, response);
+                select_element.handle_embedder_response(cx, response);
             },
             (
                 ControlElement::ColorInput(input_element),

--- a/components/script/dom/html/htmlselectelement.rs
+++ b/components/script/dom/html/htmlselectelement.rs
@@ -5,18 +5,6 @@
 use std::default::Default;
 use std::iter;
 
-use dom_struct::dom_struct;
-use embedder_traits::EmbedderControlRequest;
-use embedder_traits::{SelectElementOption, SelectElementOptionOrOptgroup};
-use html5ever::{LocalName, Prefix, QualName, local_name, ns};
-use js::context::JSContext;
-use js::rust::HandleObject;
-use style::attr::AttrValue;
-use stylo_dom::ElementState;
-use crate::dom::bindings::refcounted::Trusted;
-use crate::dom::document_embedder_controls::ControlElement;
-use crate::dom::event::{EventBubbles, EventCancelable, EventComposed};
-use crate::dom::bindings::codegen::GenericBindings::HTMLOptGroupElementBinding::HTMLOptGroupElement_Binding::HTMLOptGroupElementMethods;
 use crate::dom::activation::Activatable;
 use crate::dom::attr::Attr;
 use crate::dom::bindings::cell::{DomRefCell, Ref};
@@ -28,17 +16,21 @@ use crate::dom::bindings::codegen::Bindings::HTMLOptionsCollectionBinding::HTMLO
 use crate::dom::bindings::codegen::Bindings::HTMLSelectElementBinding::HTMLSelectElementMethods;
 use crate::dom::bindings::codegen::Bindings::NodeBinding::NodeMethods;
 use crate::dom::bindings::codegen::GenericBindings::CharacterDataBinding::CharacterData_Binding::CharacterDataMethods;
+use crate::dom::bindings::codegen::GenericBindings::HTMLOptGroupElementBinding::HTMLOptGroupElement_Binding::HTMLOptGroupElementMethods;
 use crate::dom::bindings::codegen::UnionTypes::{
     HTMLElementOrLong, HTMLOptionElementOrHTMLOptGroupElement,
 };
 use crate::dom::bindings::error::ErrorResult;
 use crate::dom::bindings::inheritance::Castable;
+use crate::dom::bindings::refcounted::Trusted;
 use crate::dom::bindings::root::{Dom, DomRoot, MutNullableDom};
 use crate::dom::bindings::str::DOMString;
 use crate::dom::characterdata::CharacterData;
 use crate::dom::document::Document;
+use crate::dom::document_embedder_controls::ControlElement;
 use crate::dom::element::{AttributeMutation, CustomElementCreationMode, Element, ElementCreator};
 use crate::dom::event::Event;
+use crate::dom::event::{EventBubbles, EventCancelable, EventComposed};
 use crate::dom::eventtarget::EventTarget;
 use crate::dom::html::htmlcollection::{CollectionFilter, CollectionSource, HTMLCollection};
 use crate::dom::html::htmlelement::HTMLElement;
@@ -51,10 +43,18 @@ use crate::dom::node::{BindContext, ChildrenMutation, Node, NodeTraits, ShadowIn
 use crate::dom::nodelist::NodeList;
 use crate::dom::text::Text;
 use crate::dom::types::FocusEvent;
-use crate::dom::validation::{Validatable, is_barred_by_datalist_ancestor};
+use crate::dom::validation::{is_barred_by_datalist_ancestor, Validatable};
 use crate::dom::validitystate::{ValidationFlags, ValidityState};
 use crate::dom::virtualmethods::VirtualMethods;
 use crate::script_runtime::CanGc;
+use dom_struct::dom_struct;
+use embedder_traits::{EmbedderControlRequest, SelectElementRequest};
+use embedder_traits::{SelectElementOption, SelectElementOptionOrOptgroup};
+use html5ever::{local_name, ns, LocalName, Prefix, QualName};
+use js::context::JSContext;
+use js::rust::HandleObject;
+use style::attr::AttrValue;
+use stylo_dom::ElementState;
 
 const DEFAULT_SELECT_SIZE: u32 = 0;
 
@@ -365,14 +365,23 @@ impl HTMLSelectElement {
     pub(crate) fn update_shadow_tree(&self, cx: &mut JSContext) {
         let shadow_tree = self.shadow_tree(cx);
 
-        let selected_option_text = self
-            .selected_option()
-            .or_else(|| self.list_of_options().next())
-            .map(|option| option.displayed_label())
-            .unwrap_or_default();
+        let selected_options = self.selected_options();
+        let selected_options_count = selected_options.len();
 
-        // Replace newlines with whitespace, then collapse and trim whitespace
-        let displayed_text = itertools::join(selected_option_text.str().split_whitespace(), " ");
+        let displayed_text = if selected_options_count == 1 {
+            let first_selected_option = self
+                .selected_option()
+                .or_else(|| self.list_of_options().next());
+
+            let first_selected_option_text = first_selected_option
+                .map(|option| option.displayed_label())
+                .unwrap_or_default();
+
+            // Replace newlines with whitespace, then collapse and trim whitespace
+            itertools::join(first_selected_option_text.str().split_whitespace(), " ")
+        } else {
+            format!("{selected_options_count} selected")
+        };
 
         shadow_tree
             .selected_option
@@ -384,6 +393,12 @@ impl HTMLSelectElement {
         self.list_of_options()
             .find(|opt_elem| opt_elem.Selected())
             .or_else(|| self.list_of_options().next())
+    }
+
+    pub(crate) fn selected_options(&self) -> Vec<DomRoot<HTMLOptionElement>> {
+        self.list_of_options()
+            .filter(|opt_elem| opt_elem.Selected())
+            .collect()
     }
 
     pub(crate) fn show_menu(&self) {
@@ -422,26 +437,84 @@ impl HTMLSelectElement {
             })
             .collect();
 
-        let selected_index = self.list_of_options().position(|option| option.Selected());
+        let selected_options = self
+            .list_of_options()
+            .enumerate()
+            .filter(|(_, option)| option.Selected())
+            .map(|(index, _)| index)
+            .collect();
 
         self.owner_document()
             .embedder_controls()
             .show_embedder_control(
                 ControlElement::Select(DomRoot::from_ref(self)),
-                EmbedderControlRequest::SelectElement(options, selected_index),
+                EmbedderControlRequest::SelectElement(SelectElementRequest {
+                    options,
+                    selected_options,
+                    allow_select_multiple: self.Multiple(),
+                }),
                 None,
             );
         self.upcast::<Element>().set_open_state(true);
     }
 
-    pub(crate) fn handle_menu_response(&self, cx: &mut JSContext, response: Option<usize>) {
+    pub(crate) fn handle_embedder_response(&self, cx: &mut JSContext, selected_values: Vec<usize>) {
         self.upcast::<Element>().set_open_state(false);
-        let Some(selected_value) = response else {
-            return;
+
+        let selected_values = if self.Multiple() {
+            selected_values
+        } else {
+            selected_values.into_iter().take(1).collect()
         };
 
-        self.SetSelectedIndex(cx, selected_value as i32);
-        self.send_update_notifications();
+        let mut selection_did_change = false;
+        for (index, option) in self.list_of_options().enumerate() {
+            let should_be_selected = selected_values.contains(&index);
+            let option_selected_did_change = option.Selected() != should_be_selected;
+
+            if option_selected_did_change {
+                selection_did_change = true;
+            }
+
+            option.set_selectedness(should_be_selected);
+
+            if option_selected_did_change {
+                option.set_dirtiness(true);
+            }
+        }
+
+        if selection_did_change {
+            self.update_shadow_tree(cx);
+            self.send_update_notifications();
+        }
+    }
+
+    fn multiple_attribute_mutated(&self, cx: &mut JSContext, mutation: AttributeMutation) {
+        if mutation.is_removal() {
+            let mut first_enabled: Option<DomRoot<HTMLOptionElement>> = None;
+            let mut first_selected: Option<DomRoot<HTMLOptionElement>> = None;
+
+            for option in self.list_of_options() {
+                if first_selected.is_none() && option.Selected() {
+                    first_selected = Some(DomRoot::from_ref(&option));
+                }
+                option.set_selectedness(false);
+                let element = option.upcast::<Element>();
+                if first_enabled.is_none() && !element.disabled_state() {
+                    first_enabled = Some(DomRoot::from_ref(&option));
+                }
+            }
+
+            if let Some(first_selected) = first_selected {
+                first_selected.set_selectedness(true);
+            } else if self.display_size() == 1 {
+                if let Some(first_enabled) = first_enabled {
+                    first_enabled.set_selectedness(true);
+                }
+            }
+
+            self.update_shadow_tree(cx);
+        }
     }
 
     /// <https://html.spec.whatwg.org/multipage/#send-select-update-notifications>
@@ -738,6 +811,9 @@ impl VirtualMethods for HTMLSelectElement {
             .unwrap()
             .attribute_mutated(cx, attr, mutation);
         match *attr.local_name() {
+            local_name!("multiple") => {
+                self.multiple_attribute_mutated(cx, mutation);
+            },
             local_name!("required") => {
                 self.validity_state(CanGc::from_cx(cx))
                     .perform_validation_and_update(

--- a/components/servo/webview.rs
+++ b/components/servo/webview.rs
@@ -724,11 +724,10 @@ impl WebView {
     ) {
         let constellation_proxy = self.inner().servo.constellation_proxy().clone();
         let embedder_control = match embedder_control_request {
-            EmbedderControlRequest::SelectElement(options, selected_option) => {
+            EmbedderControlRequest::SelectElement(request) => {
                 EmbedderControl::SelectElement(SelectElement {
                     id: control_id,
-                    options,
-                    selected_option,
+                    select_element_request: request,
                     position,
                     constellation_proxy,
                     response_sent: false,

--- a/components/servo/webview_delegate.rs
+++ b/components/servo/webview_delegate.rs
@@ -11,8 +11,8 @@ use embedder_traits::{
     ContextMenuItem, Cursor, EmbedderControlId, EmbedderControlResponse, FilePickerRequest,
     FilterPattern, InputEventId, InputEventResult, InputMethodType, LoadStatus, MediaSessionEvent,
     NewWebViewDetails, Notification, PermissionFeature, PromptResponse, RgbColor, ScreenGeometry,
-    SelectElementOptionOrOptgroup, SimpleDialogRequest, TraversalId, WebResourceRequest,
-    WebResourceResponse, WebResourceResponseMsg,
+    SelectElementOptionOrOptgroup, SelectElementRequest, SimpleDialogRequest, TraversalId,
+    WebResourceRequest, WebResourceResponse, WebResourceResponseMsg,
 };
 use paint_api::rendering_context::RenderingContext;
 use servo_base::generic_channel::{GenericSender, SendError};
@@ -412,10 +412,9 @@ impl Drop for ContextMenu {
 /// Represents a dialog triggered by clicking a `<select>` element.
 pub struct SelectElement {
     pub(crate) id: EmbedderControlId,
-    pub(crate) options: Vec<SelectElementOptionOrOptgroup>,
-    pub(crate) selected_option: Option<usize>,
     pub(crate) position: DeviceIntRect,
     pub(crate) constellation_proxy: ConstellationProxy,
+    pub(crate) select_element_request: SelectElementRequest,
     pub(crate) response_sent: bool,
 }
 
@@ -435,19 +434,23 @@ impl SelectElement {
     /// Consecutive `<option>` elements outside of an `<optgroup>` will be combined
     /// into a single anonymous group without a label.
     pub fn options(&self) -> &[SelectElementOptionOrOptgroup] {
-        &self.options
+        &self.select_element_request.options
     }
 
-    /// Mark a single option as selected.
+    /// Set the options that are selected.
     ///
-    /// If there is already a selected option and the `<select>` element does not
-    /// support selecting multiple options, then the previous option will be unselected.
-    pub fn select(&mut self, id: Option<usize>) {
-        self.selected_option = id;
+    /// If other options have previously been selected, this set of options
+    /// will replace them.
+    pub fn select(&mut self, selected_options: Vec<usize>) {
+        self.select_element_request.selected_options = selected_options
     }
 
-    pub fn selected_option(&self) -> Option<usize> {
-        self.selected_option
+    pub fn selected_options(&self) -> Vec<usize> {
+        self.select_element_request.selected_options.clone()
+    }
+
+    pub fn allow_select_multiple(&self) -> bool {
+        self.select_element_request.allow_select_multiple
     }
 
     /// Resolve the prompt with the options that have been selected by calling [`Self::select`] previously.
@@ -456,7 +459,7 @@ impl SelectElement {
         self.constellation_proxy
             .send(EmbedderToConstellationMessage::EmbedderControlResponse(
                 self.id,
-                EmbedderControlResponse::SelectElement(self.selected_option()),
+                EmbedderControlResponse::SelectElement(self.selected_options()),
             ));
     }
 }
@@ -467,7 +470,7 @@ impl Drop for SelectElement {
             self.constellation_proxy
                 .send(EmbedderToConstellationMessage::EmbedderControlResponse(
                     self.id,
-                    EmbedderControlResponse::SelectElement(self.selected_option()),
+                    EmbedderControlResponse::SelectElement(self.selected_options()),
                 ));
         }
     }

--- a/components/shared/embedder/embedder_controls.rs
+++ b/components/shared/embedder/embedder_controls.rs
@@ -34,7 +34,7 @@ pub struct EmbedderControlId {
 #[derive(Debug, Deserialize, Serialize)]
 pub enum EmbedderControlRequest {
     /// Indicates that the user has activated a `<select>` element.
-    SelectElement(Vec<SelectElementOptionOrOptgroup>, Option<usize>),
+    SelectElement(SelectElementRequest),
     /// Indicates that the user has activated a `<input type=color>` element.
     ColorPicker(RgbColor),
     /// Indicates that the user has activated a `<input type=file>` element.
@@ -162,8 +162,15 @@ pub struct FilePickerRequest {
 
 /// Response from the embedder to an [`EmbedderControlRequest`].
 #[derive(Debug, Deserialize, Serialize)]
+pub struct SelectElementRequest {
+    pub options: Vec<SelectElementOptionOrOptgroup>,
+    pub selected_options: Vec<usize>,
+    pub allow_select_multiple: bool,
+}
+
+#[derive(Debug, Deserialize, Serialize)]
 pub enum EmbedderControlResponse {
-    SelectElement(Option<usize>),
+    SelectElement(Vec<usize>),
     ColorPicker(Option<RgbColor>),
     FilePicker(Option<Vec<SelectedFile>>),
     ContextMenu(Option<ContextMenuAction>),

--- a/ports/servoshell/desktop/dialog.rs
+++ b/ports/servoshell/desktop/dialog.rs
@@ -515,7 +515,10 @@ impl Dialog {
                                 selected_options.iter().position(|id| *id == option.id)
                             {
                                 selected_options.remove(pos);
-                            } else {
+                            if let Some(position) =
+                                selected_options.iter().position(|id| *id == option.id)
+                            {
+                                selected_options.remove(position);
                                 selected_options.push(option.id);
                             }
                         } else {

--- a/ports/servoshell/desktop/dialog.rs
+++ b/ports/servoshell/desktop/dialog.rs
@@ -478,17 +478,17 @@ impl Dialog {
                 let area = egui::Area::new(egui::Id::new("select-window"))
                     .fixed_pos(egui::pos2(position.min.x as f32, position.max.y as f32));
 
-                let mut selected_option = prompt.selected_option();
+                let mut selected_options = prompt.selected_options();
 
                 fn display_option(
                     ui: &mut egui::Ui,
                     option: &SelectElementOption,
-                    selected_option: &mut Option<usize>,
+                    selected_options: &mut Vec<usize>,
                     is_open: &mut bool,
                     in_group: bool,
+                    allow_multiple: bool,
                 ) {
-                    let is_checked =
-                        selected_option.is_some_and(|selected_index| selected_index == option.id);
+                    let is_checked = selected_options.contains(&option.id);
 
                     // TODO: Surely there's a better way to align text in a selectable label in egui.
                     let label_text = if in_group {
@@ -510,8 +510,21 @@ impl Dialog {
                         .inner;
 
                     if clickable_area.clicked() && !option.is_disabled {
-                        *selected_option = Some(option.id);
-                        *is_open = false;
+                        if allow_multiple {
+                            if let Some(pos) =
+                                selected_options.iter().position(|id| *id == option.id)
+                            {
+                                selected_options.remove(pos);
+                            } else {
+                                selected_options.push(option.id);
+                            }
+                        } else {
+                            selected_options.clear();
+                            selected_options.push(option.id);
+                        }
+                        if !allow_multiple {
+                            *is_open = false;
+                        }
                     }
 
                     if clickable_area.hovered() && option.is_disabled {
@@ -533,9 +546,10 @@ impl Dialog {
                                         display_option(
                                             ui,
                                             option,
-                                            &mut selected_option,
+                                            &mut selected_options,
                                             &mut is_open,
                                             false,
+                                            prompt.allow_select_multiple(),
                                         );
                                     },
                                     SelectElementOptionOrOptgroup::Optgroup { label, options } => {
@@ -545,9 +559,10 @@ impl Dialog {
                                             display_option(
                                                 ui,
                                                 option,
-                                                &mut selected_option,
+                                                &mut selected_options,
                                                 &mut is_open,
                                                 true,
+                                                prompt.allow_select_multiple(),
                                             );
                                         }
                                     },
@@ -562,7 +577,7 @@ impl Dialog {
                     is_open = false;
                 }
 
-                prompt.select(selected_option);
+                prompt.select(selected_options);
 
                 if !is_open {
                     maybe_prompt.take().unwrap().submit();

--- a/ports/servoshell/desktop/dialog.rs
+++ b/ports/servoshell/desktop/dialog.rs
@@ -515,6 +515,7 @@ impl Dialog {
                                 selected_options.iter().position(|id| *id == option.id)
                             {
                                 selected_options.remove(pos);
+                            }
                             if let Some(position) =
                                 selected_options.iter().position(|id| *id == option.id)
                             {

--- a/tests/wpt/meta/html/rendering/non-replaced-elements/form-controls/text-transform.html.ini
+++ b/tests/wpt/meta/html/rendering/non-replaced-elements/form-controls/text-transform.html.ini
@@ -1,0 +1,2 @@
+[text-transform.html]
+  expected: FAIL

--- a/tests/wpt/meta/html/rendering/widgets/the-select-element/option-checked-styling.html.ini
+++ b/tests/wpt/meta/html/rendering/widgets/the-select-element/option-checked-styling.html.ini
@@ -1,0 +1,2 @@
+[option-checked-styling.html]
+  expected: FAIL

--- a/tests/wpt/meta/html/semantics/forms/the-select-element/customizable-select/select-size-multiple-new-content.html.ini
+++ b/tests/wpt/meta/html/semantics/forms/the-select-element/customizable-select/select-size-multiple-new-content.html.ini
@@ -1,2 +1,0 @@
-[select-size-multiple-new-content.html]
-  expected: FAIL

--- a/tests/wpt/meta/html/semantics/forms/the-select-element/select-dropdown-vs-listbox.html.ini
+++ b/tests/wpt/meta/html/semantics/forms/the-select-element/select-dropdown-vs-listbox.html.ini
@@ -1,2 +1,0 @@
-[select-dropdown-vs-listbox.html]
-  expected: FAIL

--- a/tests/wpt/meta/html/semantics/forms/the-select-element/select-multiple.html.ini
+++ b/tests/wpt/meta/html/semantics/forms/the-select-element/select-multiple.html.ini
@@ -1,3 +1,0 @@
-[select-multiple.html]
-  [Removing multiple attribute reduces the number of selected OPTIONs to 1]
-    expected: FAIL


### PR DESCRIPTION
Implement drop-down select multiple: 
 - Updates the embedder API to support multi-selects.
 - Updates the select element to correctly reset when multiple attribute is removed.
 - Select now renders "n selected" as button text when more than 1, or 0 options are selected.

Note that listbox selects are not yet supported, once they are these new features will be for `<select multiple size=1>`.

Testing: WPTs and also manually using https://demo.lukewarlow.dev/css-forms.html. The two test regressions are due to the lack of listbox support rather than an issue with this PR.
Fixes: #38509

