### PR TITLE
prefs: Remove `dom_command_invokers_enabled`

### DIFF
--- a/components/config/prefs.rs
+++ b/components/config/prefs.rs
@@ -108,7 +108,6 @@ pub struct Preferences {
     /// - vello_cpu
     pub dom_canvas_backend: String,
     pub dom_clipboardevent_enabled: bool,
-    pub dom_command_invokers_enabled: bool,
     pub dom_composition_event_enabled: bool,
     // feature: CookieStore | #37674 | Web/API/CookieStore
     pub dom_cookiestore_enabled: bool,
@@ -336,7 +335,6 @@ impl Preferences {
             dom_canvas_text_enabled: true,
             dom_canvas_backend: String::new(),
             dom_clipboardevent_enabled: true,
-            dom_command_invokers_enabled: false,
             dom_composition_event_enabled: false,
             dom_cookiestore_enabled: false,
             dom_credential_management_enabled: false,

--- a/components/script/dom/html/htmlbuttonelement.rs
+++ b/components/script/dom/html/htmlbuttonelement.rs
@@ -13,7 +13,6 @@ use script_bindings::codegen::GenericBindings::AttrBinding::AttrMethods;
 use script_bindings::codegen::GenericBindings::DocumentBinding::DocumentMethods;
 use script_bindings::codegen::GenericBindings::DocumentFragmentBinding::DocumentFragmentMethods;
 use script_bindings::codegen::GenericBindings::NodeBinding::NodeMethods;
-use servo_config::pref;
 use stylo_dom::ElementState;
 
 use crate::dom::activation::Activatable;
@@ -268,15 +267,11 @@ impl HTMLButtonElement {
             "button" => ButtonType::Button,
             "submit" => ButtonType::Submit,
             _ => {
-                if pref!(dom_command_invokers_enabled) {
-                    let element = self.upcast::<Element>();
-                    if element.has_attribute(&local_name!("command")) ||
-                        element.has_attribute(&local_name!("commandfor"))
-                    {
-                        ButtonType::Button
-                    } else {
-                        ButtonType::Submit
-                    }
+                let element = self.upcast::<Element>();
+                if element.has_attribute(&local_name!("command")) ||
+                    element.has_attribute(&local_name!("commandfor"))
+                {
+                    ButtonType::Button
                 } else {
                     ButtonType::Submit
                 }

--- a/components/script_bindings/webidls/CommandEvent.webidl
+++ b/components/script_bindings/webidls/CommandEvent.webidl
@@ -3,7 +3,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 // https://html.spec.whatwg.org/multipage/#the-commandevent-interface
-[Exposed=Window, Pref="dom_command_invokers_enabled"]
+[Exposed=Window]
 interface CommandEvent : Event {
   [Throws] constructor(DOMString type, optional CommandEventInit eventInitDict = {});
   readonly attribute Element? source;

--- a/components/script_bindings/webidls/HTMLButtonElement.webidl
+++ b/components/script_bindings/webidls/HTMLButtonElement.webidl
@@ -7,9 +7,9 @@
 interface HTMLButtonElement : HTMLElement {
   [HTMLConstructor] constructor();
 
-  [CEReactions, Pref="dom_command_invokers_enabled"]
+  [CEReactions]
   attribute DOMString command;
-  // [CEReactions, Pref="dom_command_invokers_enabled"]
+  // [CEReactions]
   // attribute Element? commandForElement;
   // [CEReactions]
   //         attribute boolean autofocus;

--- a/tests/wpt/meta/html/dom/idlharness.https.html.ini
+++ b/tests/wpt/meta/html/dom/idlharness.https.html.ini
@@ -4859,30 +4859,6 @@
   [NavigateEvent interface: attribute sourceElement]
     expected: FAIL
 
-  [CommandEvent interface: existence and properties of interface object]
-    expected: FAIL
-
-  [CommandEvent interface object length]
-    expected: FAIL
-
-  [CommandEvent interface object name]
-    expected: FAIL
-
-  [CommandEvent interface: existence and properties of interface prototype object]
-    expected: FAIL
-
-  [CommandEvent interface: existence and properties of interface prototype object's "constructor" property]
-    expected: FAIL
-
-  [CommandEvent interface: existence and properties of interface prototype object's @@unscopables property]
-    expected: FAIL
-
-  [CommandEvent interface: attribute source]
-    expected: FAIL
-
-  [CommandEvent interface: attribute command]
-    expected: FAIL
-
   [CanvasRenderingContext2D interface: attribute lang]
     expected: FAIL
 
@@ -6577,13 +6553,7 @@
   [HTMLDialogElement interface: operation requestClose(optional DOMString)]
     expected: FAIL
 
-  [HTMLButtonElement interface: attribute command]
-    expected: FAIL
-
   [HTMLButtonElement interface: attribute commandForElement]
-    expected: FAIL
-
-  [HTMLButtonElement interface: document.createElement("button") must inherit property "command" with the proper type]
     expected: FAIL
 
   [HTMLButtonElement interface: document.createElement("button") must inherit property "commandForElement" with the proper type]

--- a/tests/wpt/meta/html/semantics/forms/the-button-element/__dir__.ini
+++ b/tests/wpt/meta/html/semantics/forms/the-button-element/__dir__.ini
@@ -1,1 +1,0 @@
-prefs: [dom_command_invokers_enabled: true]

--- a/tests/wpt/meta/html/semantics/interactive-elements/the-dialog-element/__dir__.ini
+++ b/tests/wpt/meta/html/semantics/interactive-elements/the-dialog-element/__dir__.ini
@@ -1,1 +1,0 @@
-prefs: [dom_command_invokers_enabled: true]

--- a/tests/wpt/meta/html/semantics/popovers/__dir__.ini
+++ b/tests/wpt/meta/html/semantics/popovers/__dir__.ini
@@ -1,1 +1,0 @@
-prefs: [dom_command_invokers_enabled: true]

--- a/tests/wpt/meta/html/semantics/the-button-element/command-and-commandfor/__dir__.ini
+++ b/tests/wpt/meta/html/semantics/the-button-element/command-and-commandfor/__dir__.ini
@@ -1,1 +1,0 @@
-prefs: [dom_command_invokers_enabled: true]

--- a/tests/wpt/meta/html/semantics/the-button-element/command-and-commandfor/invalid-element-types.html.ini
+++ b/tests/wpt/meta/html/semantics/the-button-element/command-and-commandfor/invalid-element-types.html.ini
@@ -1,17 +1,8 @@
+[invalid-element-types.html?command=show-modal&half=second]
+  expected: ERROR
+
 [invalid-element-types.html?command=--custom-event&half=second]
-  disabled: until command attributes implemented
+  expected: ERROR
 
 [invalid-element-types.html?command=show-popover&half=second]
-  disabled: until command attributes implemented
-
-[invalid-element-types.html?command=show-modal&half=second]
-  disabled: until command attributes implemented
-
-[invalid-element-types.html?command=show-popover&half=first]
-  disabled: until command attributes implemented
-
-[invalid-element-types.html?command=show-modal&half=first]
-  disabled: until command attributes implemented
-
-[invalid-element-types.html?command=--custom-event&half=first]
-  disabled: until command attributes implemented
+  expected: ERROR

--- a/tests/wpt/mozilla/meta/MANIFEST.json
+++ b/tests/wpt/mozilla/meta/MANIFEST.json
@@ -14172,7 +14172,7 @@
      ]
     ],
     "interfaces.https.html": [
-     "60016f0fa3a3bcbf00cd632228cc486550f36c69",
+     "355890f678181ca25713ae68d2599d58b0244c39",
      [
       null,
       {}

--- a/tests/wpt/mozilla/tests/mozilla/interfaces.https.html
+++ b/tests/wpt/mozilla/tests/mozilla/interfaces.https.html
@@ -44,6 +44,7 @@ test_interfaces([
   "ClipboardEvent",
   "ClipboardItem",
   "CloseEvent",
+  "CommandEvent",
   "CompressionStream",
   "ConstantSourceNode",
   "CryptoKey",


### PR DESCRIPTION
Remove command invokers preference

This now passes most of the relevant tests. Most of the remaining failures are due to missing functionality such as the popover API, element reflection properties (see https://github.com/servo/servo/issues/42884), and issues with the event retargeting code that doesn't handle shadow dom correctly.