### PR TITLE
layout: Set `text-indent: 0` in UA styles for `::marker`

### DIFF
--- a/components/layout/stylesheets/user-agent.css
+++ b/components/layout/stylesheets/user-agent.css
@@ -417,6 +417,7 @@ iframe:fullscreen {
 *::marker {
   text-align: end;
   text-align-last: end;
+  text-indent: 0;
   text-transform: none;
   unicode-bidi: isolate;
   font-variant-numeric: tabular-nums;

--- a/tests/wpt/meta/css/css-pseudo/marker-content-023.html.ini
+++ b/tests/wpt/meta/css/css-pseudo/marker-content-023.html.ini
@@ -1,2 +1,0 @@
-[marker-content-023.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-pseudo/marker-default-styles.html.ini
+++ b/tests/wpt/meta/css/css-pseudo/marker-default-styles.html.ini
@@ -2,47 +2,23 @@
   [Computed value of 'font-variant-numeric' for outside symbol]
     expected: FAIL
 
-  [Computed value of 'text-indent' for outside symbol]
-    expected: FAIL
-
   [Computed value of 'font-variant-numeric' for outside decimal]
-    expected: FAIL
-
-  [Computed value of 'text-indent' for outside decimal]
     expected: FAIL
 
   [Computed value of 'font-variant-numeric' for outside string]
     expected: FAIL
 
-  [Computed value of 'text-indent' for outside string]
-    expected: FAIL
-
   [Computed value of 'font-variant-numeric' for outside marker]
-    expected: FAIL
-
-  [Computed value of 'text-indent' for outside marker]
     expected: FAIL
 
   [Computed value of 'font-variant-numeric' for inside symbol]
     expected: FAIL
 
-  [Computed value of 'text-indent' for inside symbol]
-    expected: FAIL
-
   [Computed value of 'font-variant-numeric' for inside decimal]
-    expected: FAIL
-
-  [Computed value of 'text-indent' for inside decimal]
     expected: FAIL
 
   [Computed value of 'font-variant-numeric' for inside string]
     expected: FAIL
 
-  [Computed value of 'text-indent' for inside string]
-    expected: FAIL
-
   [Computed value of 'font-variant-numeric' for inside marker]
-    expected: FAIL
-
-  [Computed value of 'text-indent' for inside marker]
     expected: FAIL


### PR DESCRIPTION
Authors can't set `text-indent` directly to a `::marker`, but it was inheriting from the list item. This was causing undesirable behaviors on markers with an outside position and a different `direction` than the list item.

This matches other browsers:
 - Gecko: https://hg.mozilla.org/mozilla-central/rev/4366cfed8144
 - Blink: https://crrev.com/803126
 - WebKit: https://commits.webkit.org/296253@main

Testing: Improves WPT
