### PR TITLE
libservo: Expose ClipboardDelegate in public API.

### DIFF
--- a/components/servo/lib.rs
+++ b/components/servo/lib.rs
@@ -63,6 +63,7 @@ pub use webrender_api::units::{
     DeviceIntPoint, DeviceIntRect, DeviceIntSize, DevicePixel, DevicePoint, DeviceVector2D,
 };
 
+pub use crate::clipboard_delegate::ClipboardDelegate;
 #[cfg(feature = "gamepad")]
 pub use crate::gamepad_provider::{
     GamepadHapticEffectRequest, GamepadHapticEffectRequestType, GamepadProvider,


### PR DESCRIPTION
Per [#embedding > Miscellaneous Embedding Questions](https://servo.zulipchat.com/#narrow/channel/437943-embedding/topic/Miscellaneous.20Embedding.20Questions/with/578835363), it is impossible to call `WebView::set_clipboard_delegate` because the ClipboardDelegate trait is not exposed in the public embedding API.

Testing: Compile-only, and doesn't feel worth implementing additional functionality in servoshell to verify this.
