### PR TITLE
prefs: Remove `Opts::nonincremental_layout`

### DIFF
--- a/components/config/opts.rs
+++ b/components/config/opts.rs
@@ -27,9 +27,6 @@ pub struct Opts {
     /// visualizing the traces as a timeline.
     pub time_profiler_trace_path: Option<String>,
 
-    /// True to turn off incremental layout.
-    pub nonincremental_layout: bool,
-
     /// True to exit on thread failure instead of displaying about:failure.
     pub hard_fail: bool,
 
@@ -215,7 +212,6 @@ impl Default for Opts {
         Self {
             time_profiling: None,
             time_profiler_trace_path: None,
-            nonincremental_layout: false,
             hard_fail: true,
             multiprocess: false,
             force_ipc: false,

--- a/components/script/dom/node.rs
+++ b/components/script/dom/node.rs
@@ -4742,6 +4742,8 @@ impl VirtualMethods for Node {
                     .drain_to_parent(old_parent, context.index(), self);
             }
         }
+
+        self.owner_doc().content_and_heritage_changed(self);
     }
 
     fn handle_event(&self, event: &Event, can_gc: CanGc) {

--- a/components/servo/servo.rs
+++ b/components/servo/servo.rs
@@ -742,8 +742,6 @@ impl Servo {
         );
         style::context::DEFAULT_DUMP_STYLE_STATISTICS
             .store(opts.debug.style_statistics, Ordering::Relaxed);
-        style::traversal::IS_SERVO_NONINCREMENTAL_LAYOUT
-            .store(opts.nonincremental_layout, Ordering::Relaxed);
 
         if !opts.multiprocess {
             media_platform::init();

--- a/ports/servoshell/prefs.rs
+++ b/ports/servoshell/prefs.rs
@@ -464,11 +464,6 @@ struct CmdArgs {
     #[bpaf(short('b'), long)]
     no_native_titlebar: bool,
 
-    ///
-    ///  Enable to turn off incremental layout.
-    #[bpaf(short('i'), long, flag(false, true))]
-    nonincremental_layout: bool,
-
     /// Path to an output image. The format of the image is determined by the extension.
     /// Supports all formats that `rust-image` does.
     #[bpaf(short('o'), argument("test.png"), long)]
@@ -722,7 +717,6 @@ fn parse_arguments_helper(args_without_binary: Args) -> ArgumentParsingResult {
         time_profiler_trace_path: cmd_args
             .profiler_trace_path
             .map(|p| p.to_string_lossy().into_owned()),
-        nonincremental_layout: cmd_args.nonincremental_layout,
         hard_fail: cmd_args.hard_fail,
         multiprocess: cmd_args.multiprocess,
         background_hang_monitor: cmd_args.background_hang_monitor,


### PR DESCRIPTION
This setting is used to control whether or not incremental legacy layout
was enabled. Nowadays incremental layout is always enabled as it is a
fundamental feature of how layout works. The setting also controls
whether or not nodes are traversed in Style, but that's also something
that's much less interesting today. This change just removes this
setting as it just controls the Stylo setting. A corresponding change in
Stylo will also remove the setting there.

Testing: This just removes a setting so existing tests should suffice.
Fixes: This is part of #34967.
