### PR TITLE
prefs: Move `Opts::print_pwm` to `DiagnosticsLogging::progressive_web_metrics`

### DIFF
--- a/components/config/opts.rs
+++ b/components/config/opts.rs
@@ -83,9 +83,6 @@ pub struct Opts {
 
     /// Unminify Css.
     pub unminify_css: bool,
-
-    /// Print Progressive Web Metrics to console.
-    pub print_pwm: bool,
 }
 
 /// Debug options for Servo, currently set on the command line with -Z
@@ -127,6 +124,9 @@ pub struct DiagnosticsLogging {
 
     /// Log garbage collection passes and their durations.
     pub gc_profile: bool,
+
+    /// Log Progressive Web Metrics.
+    pub progressive_web_metrics: bool,
 }
 
 impl DiagnosticsLogging {
@@ -174,6 +174,7 @@ impl DiagnosticsLogging {
         print_option("relayout-event", "Log when relayout occurs");
         print_option("profile-script-events", "Log script event processing time");
         print_option("gc-profile", "Log garbage collection statistics");
+        print_option("progressive-web-metrics", "Log Progressive Web Metrics");
         println!();
 
         process::exit(0);
@@ -197,6 +198,7 @@ impl DiagnosticsLogging {
                 "gc-profile" => self.gc_profile = true,
                 "profile-script-events" => self.profile_script_events = true,
                 "relayout-event" => self.relayout_event = true,
+                "progressive-web-metrics" => self.progressive_web_metrics = true,
                 "" => {},
                 _ => return Err(format!("Unknown diagnostic option: {option}")),
             };
@@ -235,7 +237,6 @@ impl Default for Opts {
             unminify_js: false,
             local_script_source: None,
             unminify_css: false,
-            print_pwm: false,
         }
     }
 }

--- a/components/metrics/lib.rs
+++ b/components/metrics/lib.rs
@@ -52,17 +52,12 @@ fn set_metric(
         metric_time,
     );
 
-    // Print the metric to console if the print-pwm option was given.
-    if opts::get().print_pwm {
+    if opts::get().debug.progressive_web_metrics {
         let navigation_start = pwm
             .navigation_start()
             .unwrap_or_else(CrossProcessInstant::epoch);
-        println!(
-            "{:?} {:?} {:?}",
-            url,
-            metric_type,
-            (metric_time - navigation_start).as_seconds_f64()
-        );
+        let duration = (metric_time - navigation_start).as_seconds_f64();
+        println!("{url:?} {metric_type:?} {duration:?}s");
     }
 }
 

--- a/components/script/script_thread.rs
+++ b/components/script/script_thread.rs
@@ -346,9 +346,6 @@ pub struct ScriptThread {
     /// Periodically print out on which events script threads spend their processing time.
     profile_script_events: bool,
 
-    /// Print Progressive Web Metrics to console.
-    print_pwm: bool,
-
     /// Unminify Javascript.
     unminify_js: bool,
 
@@ -1025,7 +1022,6 @@ impl ScriptThread {
                     custom_element_reaction_stack: Rc::new(CustomElementReactionStack::new()),
                     paint_api: state.cross_process_paint_api,
                     profile_script_events: opts.debug.profile_script_events,
-                    print_pwm: opts.print_pwm,
                     unminify_js: opts.unminify_js,
                     local_script_source: opts.local_script_source.clone(),
                     unminify_css: opts.unminify_css,
@@ -1719,10 +1715,9 @@ impl ScriptThread {
         for (doc_id, doc) in self.documents.borrow().iter() {
             if let Some(pipeline_id) = pipeline_id {
                 if pipeline_id == doc_id && task_duration.as_nanos() > MAX_TASK_NS {
-                    if self.print_pwm {
+                    if opts::get().debug.progressive_web_metrics {
                         println!(
-                            "Task took longer than max allowed ({:?}) {:?}",
-                            category,
+                            "Task took longer than max allowed ({category:?}) {:?}",
                             task_duration.as_nanos()
                         );
                     }

--- a/ports/servoshell/prefs.rs
+++ b/ports/servoshell/prefs.rs
@@ -495,10 +495,6 @@ struct CmdArgs {
     #[bpaf(long, argument("/path/to/prefs.json"), many)]
     prefs_file: Vec<PathBuf>,
 
-    /// Print Progressive Web Metrics.
-    #[bpaf(long)]
-    print_pwm: bool,
-
     ///
     ///  Probability of randomly closing a pipeline (for testing constellation hardening).
     #[bpaf(argument("0.25"))]
@@ -739,7 +735,6 @@ fn parse_arguments_helper(args_without_binary: Args) -> ArgumentParsingResult {
             .local_script_source
             .map(|p| p.to_string_lossy().into_owned()),
         unminify_css: cmd_args.unminify_css,
-        print_pwm: cmd_args.print_pwm,
         force_ipc: cmd_args.force_ipc,
     };
 


### PR DESCRIPTION
This option controls whether progressive web metrics are printed to the
system console, which is essentially the purpose of
`DiagnosticsLogging`. This makes the API a bit more uniform.

Testing: We do not really have automated testing for this kind of feature of the API.
Fixes: This is part of #34967.
