### PR TITLE
embedder_traits: Specify clearly what the sign of `WheelDelta` means

### DIFF
--- a/components/shared/embedder/input_events.rs
+++ b/components/shared/embedder/input_events.rs
@@ -291,11 +291,11 @@ pub enum WheelMode {
 /// The Wheel event deltas in every direction
 #[derive(Clone, Copy, Debug, Deserialize, PartialEq, Serialize)]
 pub struct WheelDelta {
-    /// Delta in the left/right direction
-    /// A positive value means scrolling the scrollbar left. (Revealing more content left)
+    /// Delta in the left/right direction. A positive value means that the view scrolls left,
+    /// revealing more content to the left of the current viewport.
     pub x: f64,
-    /// Delta in the up/down direction
-    /// A positive value means scrolling the scrollbar up. (Revealing more content up)
+    /// Delta in the up/down direction. A positive value means that the view scrolls up, revealing
+    /// more content above the current viewport.
     pub y: f64,
     /// Delta in the direction going into/out of the screen
     pub z: f64,

--- a/components/shared/embedder/input_events.rs
+++ b/components/shared/embedder/input_events.rs
@@ -292,8 +292,10 @@ pub enum WheelMode {
 #[derive(Clone, Copy, Debug, Deserialize, PartialEq, Serialize)]
 pub struct WheelDelta {
     /// Delta in the left/right direction
+    /// A positive value means scrolling the scrollbar left. (Revealing more content left)
     pub x: f64,
     /// Delta in the up/down direction
+    /// A positive value means scrolling the scrollbar up. (Revealing more content up)
     pub y: f64,
     /// Delta in the direction going into/out of the screen
     pub z: f64,


### PR DESCRIPTION
Right now this is not documented and really confusing. I believe these decisions
are made to align with [winit](https://github.com/rust-windowing/winit/blob/e9809ef54b18499bb4f2cac945719ecc2a61061b/src/event.rs#L957-L958): 
> /// Positive values indicate that the content that is being scrolled should move
> /// right and down (revealing more content left and up).

I don't know about other people emebedding Servo, but I have always been thinking reversely.