### PR TITLE
Everywhere: Remove instances of clippy::redundant-clone

### DIFF
--- a/components/canvas/canvas_paint_thread.rs
+++ b/components/canvas/canvas_paint_thread.rs
@@ -30,7 +30,7 @@ impl CanvasPaintThread {
         CanvasPaintThread {
             canvases: FxHashMap::default(),
             next_canvas_id: CanvasId(0),
-            paint_api: paint_api.clone(),
+            paint_api,
         }
     }
 

--- a/components/constellation/constellation.rs
+++ b/components/constellation/constellation.rs
@@ -3652,7 +3652,7 @@ where
             .send(EmbedderMsg::AllowNavigationRequest(
                 webview_id,
                 source_id,
-                load_data.url.clone(),
+                load_data.url,
             ));
     }
 
@@ -4151,8 +4151,7 @@ where
         history_state_id: Option<HistoryStateId>,
         url: ServoUrl,
     ) {
-        let msg =
-            ScriptThreadMessage::UpdateHistoryState(pipeline_id, history_state_id, url.clone());
+        let msg = ScriptThreadMessage::UpdateHistoryState(pipeline_id, history_state_id, url);
         self.send_message_to_pipeline(pipeline_id, msg, "History state updated after closure");
     }
 

--- a/components/devtools/actors/inspector/style_rule.rs
+++ b/components/devtools/actors/inspector/style_rule.rs
@@ -204,7 +204,7 @@ impl StyleRuleActor {
                     }
                 })
                 .collect(),
-            href: node.base_uri.clone(),
+            href: node.base_uri,
             selectors: self.selector.iter().map(|(s, _)| s).cloned().collect(),
             selectors_specificity: self.selector.iter().map(|_| 1).collect(),
             type_: ELEMENT_STYLE_TYPE,

--- a/components/devtools/actors/network_event.rs
+++ b/components/devtools/actors/network_event.rs
@@ -698,8 +698,8 @@ impl ActorEncode<NetworkEventMsg> for NetworkEventActor {
                 .as_millis() as i64,
         ) {
             LocalResult::None => "".to_owned(),
-            LocalResult::Single(date_time) => date_time.to_rfc3339().to_string(),
-            LocalResult::Ambiguous(date_time, _) => date_time.to_rfc3339().to_string(),
+            LocalResult::Single(date_time) => date_time.to_rfc3339(),
+            LocalResult::Ambiguous(date_time, _) => date_time.to_rfc3339(),
         };
 
         let watcher = registry.find::<WatcherActor>(&self.watcher);

--- a/components/devtools/actors/thread.rs
+++ b/components/devtools/actors/thread.rs
@@ -122,7 +122,7 @@ impl ThreadActor {
         browsing_context: Option<String>,
     ) -> ThreadActor {
         ThreadActor {
-            name: name.clone(),
+            name,
             source_manager: SourceManager::new(),
             script_sender,
             frames: Default::default(),

--- a/components/devtools/lib.rs
+++ b/components/devtools/lib.rs
@@ -493,7 +493,7 @@ impl DevtoolsInstance {
                 console: console_name.clone(),
                 thread: thread_name,
                 worker_id: id,
-                url: page_info.url.clone(),
+                url: page_info.url,
                 type_: WorkerType::Dedicated,
                 script_chan: script_sender,
                 streams: Default::default(),

--- a/components/fonts/font_context.rs
+++ b/components/fonts/font_context.rs
@@ -371,7 +371,7 @@ impl FontContext {
         variations: Vec<FontVariation>,
         painter_id: PainterId,
     ) -> FontInstanceKey {
-        let identifier = font_template.identifier().clone();
+        let identifier = font_template.identifier();
         let font_data = self
             .get_font_data(&identifier)
             .expect("Web font should have associated font data");
@@ -837,7 +837,7 @@ impl FontContext {
                     .flatten()
                     .and_then(|local_template| {
                         let template = FontTemplate::new_for_local_web_font(
-                            local_template.clone(),
+                            local_template,
                             &state.css_font_face_descriptors,
                             state.initiator.stylesheet().cloned(),
                             state.initiator.font_face_rule().cloned(),

--- a/components/layout/context.rs
+++ b/components/layout/context.rs
@@ -194,7 +194,7 @@ impl ImageResolver {
             LayoutImageCacheResult::DataAvailable(img_or_meta) => match img_or_meta {
                 ImageOrMetadataAvailable::ImageAvailable { image, .. } => {
                     if let Some(image) = image.as_raster_image() {
-                        self.handle_animated_image(node, image.clone());
+                        self.handle_animated_image(node, image);
                     }
 
                     let mut resolved_images_cache = self.resolved_images_cache.write();

--- a/components/layout/flow/inline/construct.rs
+++ b/components/layout/flow/inline/construct.rs
@@ -135,7 +135,7 @@ impl InlineFormattingContextBuilder {
         // If there is an existing undamaged layout box that's compatible, use that.
         let independent_formatting_context = old_layout_box
             .and_then(|layout_box| match layout_box {
-                LayoutBox::InlineLevel(InlineItem::Atomic(atomic, ..)) => Some(atomic.clone()),
+                LayoutBox::InlineLevel(InlineItem::Atomic(atomic, ..)) => Some(atomic),
                 _ => None,
             })
             .unwrap_or_else(independent_formatting_context_creator);
@@ -168,7 +168,7 @@ impl InlineFormattingContextBuilder {
                 LayoutBox::InlineLevel(InlineItem::OutOfFlowAbsolutelyPositionedBox(
                     positioned_box,
                     ..,
-                )) => Some(positioned_box.clone()),
+                )) => Some(positioned_box),
                 _ => None,
             })
             .unwrap_or_else(absolutely_positioned_box_creator);

--- a/components/layout/replaced.rs
+++ b/components/layout/replaced.rs
@@ -344,11 +344,7 @@ impl ReplacedContents {
                                 .handle_animated_image(node.opaque(), image.clone());
                         }
                         let metadata = image.metadata();
-                        (
-                            Some(image.clone()),
-                            metadata.width as f32,
-                            metadata.height as f32,
-                        )
+                        (Some(image), metadata.width as f32, metadata.height as f32)
                     },
                     ImageOrMetadataAvailable::MetadataAvailable(metadata, _id) => {
                         (None, metadata.width as f32, metadata.height as f32)

--- a/components/layout/table/construct.rs
+++ b/components/layout/table/construct.rs
@@ -223,7 +223,7 @@ impl TableBuilder {
             ComputedValues::initial_values_with_font_override(Font::initial_values());
         Self::new(
             testing_style.clone(),
-            testing_style.clone(),
+            testing_style,
             BaseFragmentInfo::anonymous(),
             true, /* percentage_columns_allowed_for_inline_content_sizes */
         )

--- a/components/layout/table/layout.rs
+++ b/components/layout/table/layout.rs
@@ -620,10 +620,8 @@ impl<'a> TableLayout<'a> {
         let colspan_cell_min_size = (colspan_cell_constraints.content_sizes.min_content -
             total_border_spacing)
             .max(Au::zero());
-        let distributed_minimum = Self::distribute_width_to_columns(
-            colspan_cell_min_size,
-            &self.columns[column_range.clone()],
-        );
+        let distributed_minimum =
+            Self::distribute_width_to_columns(colspan_cell_min_size, &self.columns[column_range]);
         {
             let column_span = &mut self.columns[colspan_cell_constraints.range()];
             for (column, minimum_size) in column_span.iter_mut().zip(distributed_minimum) {
@@ -1056,7 +1054,7 @@ impl<'a> TableLayout<'a> {
         // > Otherwise, if there is any such column, the distributed widths of all columns that have
         // > originating cells are increased by equal amounts so the total increase adds to the excess
         // > width.
-        let has_originating_cells_columns = all_columns.clone().filter(has_originating_cells);
+        let has_originating_cells_columns = all_columns.filter(has_originating_cells);
         let total_has_originating_cells = has_originating_cells_columns.clone().count();
         if total_has_originating_cells > 0 {
             let extra_space_per_column =

--- a/components/media/audio/iir_filter_node.rs
+++ b/components/media/audio/iir_filter_node.rs
@@ -121,7 +121,7 @@ impl IIRFilterNode {
             "InvalidStateError: first feedback coeff must not be zero"
         );
 
-        let filter = IIRFilter::new(options.feedforward.clone(), options.feedback.clone());
+        let filter = IIRFilter::new(options.feedforward.clone(), options.feedback);
 
         Self {
             filters: vec![filter; channel_info.computed_number_of_channels() as usize],

--- a/components/media/audio/render_thread.rs
+++ b/components/media/audio/render_thread.rs
@@ -186,17 +186,16 @@ impl AudioRenderThread {
         options: AudioContextOptions,
         init_sender: Sender<Result<(), AudioSinkError>>,
     ) {
-        let mut thread =
-            match Self::prepare_thread::<B>(sender.clone(), sample_rate, graph, options) {
-                Ok(thread) => {
-                    let _ = init_sender.send(Ok(()));
-                    thread
-                },
-                Err(e) => {
-                    let _ = init_sender.send(Err(e));
-                    return;
-                },
-            };
+        let mut thread = match Self::prepare_thread::<B>(sender, sample_rate, graph, options) {
+            Ok(thread) => {
+                let _ = init_sender.send(Ok(()));
+                thread
+            },
+            Err(e) => {
+                let _ = init_sender.send(Err(e));
+                return;
+            },
+        };
 
         thread.event_loop(event_queue);
     }

--- a/components/media/backends/gstreamer/lib.rs
+++ b/components/media/backends/gstreamer/lib.rs
@@ -169,6 +169,7 @@ impl GStreamerBackend {
 }
 
 impl Backend for GStreamerBackend {
+    #[expect(clippy::redundant_clone, reason = "False positive")]
     fn create_player(
         &self,
         context_id: &ClientContextId,
@@ -195,6 +196,7 @@ impl Backend for GStreamerBackend {
         player
     }
 
+    #[expect(clippy::redundant_clone, reason = "False positive")]
     fn create_audio_context(
         &self,
         client_context_id: &ClientContextId,

--- a/components/net/fetch/fetch_params.rs
+++ b/components/net/fetch/fetch_params.rs
@@ -73,7 +73,7 @@ impl ConsumePreloadedResources for RequestClient {
         // Step 1. Let key be a preload key whose URL is url,
         // destination is destination, mode is mode, and credentials mode is credentialsMode.
         let key = PreloadKey {
-            url: request.url().clone(),
+            url: request.url(),
             destination: request.destination,
             mode: request.mode.clone(),
             credentials_mode: request.credentials_mode,

--- a/components/net/http_loader.rs
+++ b/components/net/http_loader.rs
@@ -527,7 +527,7 @@ pub fn send_security_info_to_devtools(
 
     if let (Some(devtools_chan), Some(security_info), Some(webview_id)) = (
         context.devtools_chan.clone(),
-        meta.tls_security_info.clone(),
+        meta.tls_security_info,
         request.target_webview_id,
     ) {
         let update = NetworkEvent::SecurityInfo(SecurityInfoUpdate {
@@ -553,7 +553,7 @@ pub fn send_early_httprequest_to_devtools(request: &Request, context: &FetchCont
     ) {
         // Build the partial DevtoolsHttpRequest
         let devtools_request = DevtoolsHttpRequest {
-            url: request.current_url().clone(),
+            url: request.current_url(),
             method: request.method.clone(),
             headers: request.headers.clone(),
             body: None,

--- a/components/net/resource_thread.rs
+++ b/components/net/resource_thread.rs
@@ -108,9 +108,9 @@ pub fn new_resource_threads(
     let (public_core, private_core) = new_core_resource_thread(
         devtools_sender,
         time_profiler_chan,
-        mem_profiler_chan.clone(),
+        mem_profiler_chan,
         embedder_proxy,
-        config_dir.clone(),
+        config_dir,
         ca_certificates,
         ignore_certificate_errors,
         protocols,

--- a/components/paint/paint.rs
+++ b/components/paint/paint.rs
@@ -781,7 +781,7 @@ impl Paint {
         log::info!("Saving WebRender capture to {capture_path:?}");
         self.painter(webview_id.into())
             .webrender_api
-            .save_capture(capture_path.clone(), CaptureBits::all());
+            .save_capture(capture_path, CaptureBits::all());
     }
 
     pub fn notify_input_event(&self, webview_id: WebViewId, event: InputEventAndId) {

--- a/components/script/body.rs
+++ b/components/script/body.rs
@@ -281,13 +281,13 @@ impl TransmitBodyConnectHandler {
                 // and the corresponding IPC route in `component::net::http_loader`.
                 rooted!(in(*cx) let mut promise_handler = Some(TransmitBodyPromiseHandler {
                     bytes_sender: bytes_sender.clone(),
-                    stream: Dom::from_ref(&rooted_stream.clone()),
+                    stream: Dom::from_ref(&rooted_stream),
                     control_sender: control_sender.clone().unwrap(),
                 }));
 
                 rooted!(in(*cx) let mut rejection_handler = Some(TransmitBodyPromiseRejectionHandler {
                     bytes_sender,
-                    stream: Dom::from_ref(&rooted_stream.clone()),
+                    stream: Dom::from_ref(&rooted_stream),
                     control_sender: control_sender.unwrap(),
                 }));
 

--- a/components/script/dom/bindings/constructor.rs
+++ b/components/script/dom/bindings/constructor.rs
@@ -193,7 +193,7 @@ fn html_constructor(
             element.set_custom_element_state(CustomElementState::Custom);
 
             // Step 7.7 Set element's custom element definition to definition.
-            element.set_custom_element_definition(definition.clone());
+            element.set_custom_element_definition(definition);
 
             // Step 7.8 Set element's is value to isValue.
             if let Some(is_value) = is_value {

--- a/components/script/dom/bluetooth/bluetooth.rs
+++ b/components/script/dom/bluetooth/bluetooth.rs
@@ -586,7 +586,7 @@ impl AsyncBluetoothListener for Bluetooth {
             // Step 11, 13 - 14.
             BluetoothResponse::RequestDevice(device) => {
                 let mut device_instance_map = self.device_instance_map.borrow_mut();
-                if let Some(existing_device) = device_instance_map.get(&device.id.clone()) {
+                if let Some(existing_device) = device_instance_map.get(&device.id) {
                     return promise.resolve_native(&**existing_device, CanGc::from_cx(cx));
                 }
                 let bt_device = BluetoothDevice::new(

--- a/components/script/dom/canvas/2d/canvas_state.rs
+++ b/components/script/dom/canvas/2d/canvas_state.rs
@@ -1492,7 +1492,7 @@ impl CanvasState {
         };
 
         let font_style = self.font_style();
-        let font_group = font_context.font_group(font_style.clone());
+        let font_group = font_context.font_group(font_style);
         let font = font_group.first(font_context).expect("couldn't find font");
         let ascent = font.metrics.ascent.to_f64_px();
         let descent = font.metrics.descent.to_f64_px();

--- a/components/script/dom/console.rs
+++ b/components/script/dom/console.rs
@@ -120,7 +120,7 @@ impl Console {
 
     // Directly logs a DOMString, without processing the message
     pub(crate) fn internal_warn(global: &GlobalScope, message: DOMString) {
-        Console::send_string_message(global, ConsoleLogLevel::Warn, String::from(message.clone()));
+        Console::send_string_message(global, ConsoleLogLevel::Warn, String::from(message));
     }
 }
 
@@ -544,7 +544,7 @@ impl consoleMethods<crate::DomTypeHolder> for Console {
         if !condition {
             let message = format!("Assertion failed: {}", stringify_handle_values(&messages));
 
-            Console::send_string_message(global, ConsoleLogLevel::Log, message.clone());
+            Console::send_string_message(global, ConsoleLogLevel::Log, message);
         }
     }
 
@@ -552,7 +552,7 @@ impl consoleMethods<crate::DomTypeHolder> for Console {
     fn Time(global: &GlobalScope, label: DOMString) {
         if let Ok(()) = global.time(label.clone()) {
             let message = format!("{label}: timer started");
-            Console::send_string_message(global, ConsoleLogLevel::Log, message.clone());
+            Console::send_string_message(global, ConsoleLogLevel::Log, message);
         }
     }
 
@@ -561,7 +561,7 @@ impl consoleMethods<crate::DomTypeHolder> for Console {
         if let Ok(delta) = global.time_log(&label) {
             let message = format!("{label}: {delta}ms {}", stringify_handle_values(&data));
 
-            Console::send_string_message(global, ConsoleLogLevel::Log, message.clone());
+            Console::send_string_message(global, ConsoleLogLevel::Log, message);
         }
     }
 
@@ -570,7 +570,7 @@ impl consoleMethods<crate::DomTypeHolder> for Console {
         if let Ok(delta) = global.time_end(&label) {
             let message = format!("{label}: {delta}ms");
 
-            Console::send_string_message(global, ConsoleLogLevel::Log, message.clone());
+            Console::send_string_message(global, ConsoleLogLevel::Log, message);
         }
     }
 
@@ -594,7 +594,7 @@ impl consoleMethods<crate::DomTypeHolder> for Console {
         let count = global.increment_console_count(&label);
         let message = format!("{label}: {count}");
 
-        Console::send_string_message(global, ConsoleLogLevel::Log, message.clone());
+        Console::send_string_message(global, ConsoleLogLevel::Log, message);
     }
 
     /// <https://console.spec.whatwg.org/#countreset>

--- a/components/script/dom/cookiestore.rs
+++ b/components/script/dom/cookiestore.rs
@@ -164,7 +164,7 @@ impl CookieStore {
             .send(CoreResourceMsg::NewCookieListener(
                 self.droppable.store_id,
                 cookie_sender,
-                self.global().creation_url().clone(),
+                self.global().creation_url(),
             ));
         if res.is_err() {
             error!("Failed to send cookiestore message to resource threads");
@@ -214,7 +214,7 @@ impl CookieStoreMethods<crate::DomTypeHolder> for CookieStore {
             .resource_threads()
             .send(CoreResourceMsg::GetCookieDataForUrlAsync(
                 self.droppable.store_id,
-                creation_url.clone(),
+                creation_url,
                 Some(name),
             ));
         if res.is_err() {
@@ -298,7 +298,7 @@ impl CookieStoreMethods<crate::DomTypeHolder> for CookieStore {
             .resource_threads()
             .send(CoreResourceMsg::GetCookieDataForUrlAsync(
                 self.droppable.store_id,
-                final_url.clone(),
+                final_url,
                 options.name.clone().map(|val| CookieStore::normalize(&val)),
             ));
         if res.is_err() {
@@ -338,7 +338,7 @@ impl CookieStoreMethods<crate::DomTypeHolder> for CookieStore {
                 .resource_threads()
                 .send(CoreResourceMsg::GetAllCookieDataForUrlAsync(
                     self.droppable.store_id,
-                    creation_url.clone(),
+                    creation_url,
                     Some(name),
                 ));
         if res.is_err() {
@@ -415,7 +415,7 @@ impl CookieStoreMethods<crate::DomTypeHolder> for CookieStore {
                 .resource_threads()
                 .send(CoreResourceMsg::GetAllCookieDataForUrlAsync(
                     self.droppable.store_id,
-                    final_url.clone(),
+                    final_url,
                     options.name.clone().map(|val| CookieStore::normalize(&val)),
                 ));
         if res.is_err() {
@@ -552,7 +552,7 @@ impl CookieStoreMethods<crate::DomTypeHolder> for CookieStore {
             .resource_threads()
             .send(CoreResourceMsg::DeleteCookieAsync(
                 self.droppable.store_id,
-                global.creation_url().clone(),
+                global.creation_url(),
                 name.0,
             ));
         if res.is_err() {
@@ -588,7 +588,7 @@ impl CookieStoreMethods<crate::DomTypeHolder> for CookieStore {
             .resource_threads()
             .send(CoreResourceMsg::DeleteCookieAsync(
                 self.droppable.store_id,
-                global.creation_url().clone(),
+                global.creation_url(),
                 options.name.to_string(),
             ));
         if res.is_err() {

--- a/components/script/dom/create.rs
+++ b/components/script/dom/create.rs
@@ -172,7 +172,7 @@ fn create_html_element(
                 // Step 5.1. If synchronousCustomElements is true, then run these
                 // steps while catching any exceptions:
                 CustomElementCreationMode::Synchronous => {
-                    let local_name = name.local.clone();
+                    let local_name = name.local;
                     // TODO(jdm) Pass proto to create_element?
                     // Steps 4.1.1-4.1.11
                     return match definition.create_element(
@@ -217,11 +217,7 @@ fn create_html_element(
                     // custom element definition set to null, is value set to null, and node document
                     // set to document.
                     let result = DomRoot::upcast::<Element>(HTMLElement::new(
-                        name.local.clone(),
-                        prefix.clone(),
-                        document,
-                        proto,
-                        can_gc,
+                        name.local, prefix, document, proto, can_gc,
                     ));
                     result.set_custom_element_state(CustomElementState::Undefined);
                     result.set_custom_element_registry(registry);

--- a/components/script/dom/css/cssstyledeclaration.rs
+++ b/components/script/dom/css/cssstyledeclaration.rs
@@ -183,8 +183,7 @@ impl CSSStyleOwner {
                     .url_data
                     .0
                     .clone()
-            })
-            .clone(),
+            }),
         }
     }
 }

--- a/components/script/dom/css/fontface.rs
+++ b/components/script/dom/css/fontface.rs
@@ -261,7 +261,7 @@ impl FontFace {
             descriptors: DomRefCell::new(serialize_parsed_descriptors(parsed_font_face_rule)),
 
             font_face_set: MutNullableDom::default(),
-            family_name: DomRefCell::new(family_name.clone()),
+            family_name: DomRefCell::new(family_name),
             urls: DomRefCell::new(Some(sources)),
             template: RefCell::default(),
             font_status_promise,

--- a/components/script/dom/customelementregistry.rs
+++ b/components/script/dom/customelementregistry.rs
@@ -963,7 +963,7 @@ pub(crate) fn upgrade_element(
                 ScriptThread::enqueue_callback_reaction(
                     element,
                     CallbackReaction::FormDisabled(true),
-                    Some(definition.clone()),
+                    Some(definition),
                 )
             }
         }

--- a/components/script/dom/dissimilaroriginwindow.rs
+++ b/components/script/dom/dissimilaroriginwindow.rs
@@ -62,7 +62,7 @@ impl DissimilarOriginWindow {
                 global_to_clone_from.resource_threads().clone(),
                 global_to_clone_from.storage_threads().clone(),
                 global_to_clone_from.origin().clone(),
-                global_to_clone_from.creation_url().clone(),
+                global_to_clone_from.creation_url(),
                 global_to_clone_from.top_level_creation_url().clone(),
                 #[cfg(feature = "webgpu")]
                 global_to_clone_from.wgpu_id_hub(),
@@ -235,7 +235,7 @@ impl DissimilarOriginWindow {
             "*" => None,
             "/" => Some(source_origin.clone()),
             url => match ServoUrl::parse(url) {
-                Ok(url) => Some(url.origin().clone()),
+                Ok(url) => Some(url.origin()),
                 Err(_) => return Err(Error::Syntax(None)),
             },
         };

--- a/components/script/dom/document_embedder_controls.rs
+++ b/components/script/dom/document_embedder_controls.rs
@@ -490,7 +490,7 @@ impl ContextMenuNodes {
                     .as_ref()
                     .map(ServoUrl::to_string)
                     .unwrap_or_else(|| image_element.CurrentSrc().to_string());
-                set_clipboard_text(url_string.to_string());
+                set_clipboard_text(url_string);
             },
             ContextMenuAction::OpenImageInNewView => {
                 let Some(image_element) = &self.image_element else {

--- a/components/script/dom/document_event_handler.rs
+++ b/components/script/dom/document_event_handler.rs
@@ -1733,7 +1733,7 @@ impl DocumentEventHandler {
                     // Step 7.1.2.1 For each clipboard-part on the OS clipboard:
 
                     // Step 7.1.2.1.1 If clipboard-part contains plain text, then
-                    let data = DOMString::from(text_contents.to_string());
+                    let data = DOMString::from(text_contents);
                     let type_ = DOMString::from("text/plain");
                     let _ = drag_data_store.add(Kind::Text { data, type_ });
 

--- a/components/script/dom/documentorshadowroot.rs
+++ b/components/script/dom/documentorshadowroot.rs
@@ -431,7 +431,7 @@ impl DocumentOrShadowRoot {
 
         match maybe_stylesheets {
             Ok(ConversionResult::Success(stylesheets)) => {
-                rooted_vec!(let stylesheets <- stylesheets.to_owned().iter().map(|s| s.as_traced()));
+                rooted_vec!(let stylesheets <- stylesheets.iter().map(|s| s.as_traced()));
 
                 DocumentOrShadowRoot::set_adopted_stylesheet(
                     adopted_stylesheets,

--- a/components/script/dom/gamepad/gamepadhapticactuator.rs
+++ b/components/script/dom/gamepad/gamepadhapticactuator.rs
@@ -271,7 +271,7 @@ impl GamepadHapticActuatorMethods<crate::DomTypeHolder> for GamepadHapticActuato
             );
         }
 
-        *self.playing_effect_promise.borrow_mut() = Some(promise.clone());
+        *self.playing_effect_promise.borrow_mut() = Some(promise);
 
         self.reset_sequence_id.set(self.sequence_id.get());
 

--- a/components/script/dom/globalscope.rs
+++ b/components/script/dom/globalscope.rs
@@ -697,10 +697,8 @@ impl FileListener {
                         self.task_source.queue(task);
                     },
                     FileListenerTarget::Stream(trusted_stream) => {
-                        let trusted = trusted_stream.clone();
-
                         let task = task!(enqueue_stream_chunk: move || {
-                            let stream = trusted.root();
+                            let stream = trusted_stream.root();
                             stream_handle_eof(&stream, CanGc::note());
                         });
 
@@ -1978,7 +1976,7 @@ impl GlobalScope {
     fn get_blob_bytes_non_sliced_or_file_id(&self, blob_id: &BlobId) -> BlobResult {
         match *self.get_blob_data(blob_id) {
             BlobData::File(ref f) => match f.get_cache() {
-                Some(bytes) => BlobResult::Bytes(bytes.clone()),
+                Some(bytes) => BlobResult::Bytes(bytes),
                 None => BlobResult::File(f.get_id(), f.get_size() as usize),
             },
             BlobData::Memory(ref s) => BlobResult::Bytes(s.clone()),
@@ -2184,7 +2182,7 @@ impl GlobalScope {
 
         let recv = self.send_msg(file_id);
 
-        let trusted_stream = Trusted::new(&*stream.clone());
+        let trusted_stream = Trusted::new(&*stream);
         let mut file_listener = FileListener {
             state: Some(FileListenerState::Empty(FileListenerTarget::Stream(
                 trusted_stream,
@@ -3352,7 +3350,7 @@ impl GlobalScope {
     ) {
         self.notification_permission_request_callback_map
             .borrow_mut()
-            .insert(callback_id, callback.clone());
+            .insert(callback_id, callback);
     }
 
     pub(crate) fn remove_notification_permission_request_callback(

--- a/components/script/dom/history.rs
+++ b/components/script/dom/history.rs
@@ -93,7 +93,7 @@ impl History {
     ) {
         // Steps 5
         let document = self.window.Document();
-        let old_url = document.url().clone();
+        let old_url = document.url();
         document.set_url(url.clone());
 
         // Step 6

--- a/components/script/dom/html/htmlinputelement.rs
+++ b/components/script/dom/html/htmlinputelement.rs
@@ -230,7 +230,7 @@ impl TextInputWidgetShadowTree {
         if let Some(character_data) = self.placeholder_character_data(input_element, can_gc) {
             let placeholder_value = input_element.placeholder.borrow().clone();
             if character_data.Data() != placeholder_value {
-                character_data.SetData(placeholder_value.clone());
+                character_data.SetData(placeholder_value);
             }
         }
     }
@@ -2245,8 +2245,8 @@ impl HTMLInputElement {
                         datums.push(FormDatum {
                             // XXX(izgzhen): Spec says 'application/octet-stream' as the type,
                             // but this is _type_ of element rather than content right?
-                            ty: ty.clone(),
-                            name: name.clone(),
+                            ty,
+                            name,
                             value: FormDatumValue::String(DOMString::from("")),
                         })
                     },
@@ -2261,7 +2261,7 @@ impl HTMLInputElement {
             InputType::Hidden => {
                 if name.to_ascii_lowercase() == "_charset_" {
                     return vec![FormDatum {
-                        ty: ty.clone(),
+                        ty,
                         name,
                         value: FormDatumValue::String(match encoding {
                             None => DOMString::from("UTF-8"),
@@ -2281,7 +2281,7 @@ impl HTMLInputElement {
 
         // Step 5.12
         vec![FormDatum {
-            ty: ty.clone(),
+            ty,
             name,
             value: FormDatumValue::String(self.Value()),
         }]

--- a/components/script/dom/html/htmllinkelement.rs
+++ b/components/script/dom/html/htmllinkelement.rs
@@ -1142,7 +1142,7 @@ impl FetchResponseListener for FaviconFetchContext {
     ) {
         self.image_cache.notify_pending_response(
             self.id,
-            FetchResponseMsg::ProcessResponse(request_id, metadata.clone()),
+            FetchResponseMsg::ProcessResponse(request_id, metadata),
         );
     }
 

--- a/components/script/dom/html/htmlmediaelement.rs
+++ b/components/script/dom/html/htmlmediaelement.rs
@@ -1459,7 +1459,7 @@ impl HTMLMediaElement {
             global.core_resource_thread(),
         ));
         let listener =
-            HTMLMediaElementFetchListener::new(self, request.id, url.clone(), offset.unwrap_or(0));
+            HTMLMediaElementFetchListener::new(self, request.id, url, offset.unwrap_or(0));
 
         self.owner_document().fetch_background(request, listener);
 
@@ -3646,7 +3646,7 @@ impl HTMLMediaElementFetchContext {
             is_seekable: false,
             origin_clean: true,
             data_source: RefCell::new(BufferedDataSource::new()),
-            fetch_canceller: FetchCanceller::new(request_id, false, core_resource_thread.clone()),
+            fetch_canceller: FetchCanceller::new(request_id, false, core_resource_thread),
         }
     }
 

--- a/components/script/dom/html/htmloutputelement.rs
+++ b/components/script/dom/html/htmloutputelement.rs
@@ -94,7 +94,7 @@ impl HTMLOutputElementMethods<crate::DomTypeHolder> for HTMLOutputElement {
     fn SetDefaultValue(&self, value: DOMString, can_gc: CanGc) {
         if self.default_value_override.borrow().is_none() {
             // Step 1 ("and return")
-            Node::string_replace_all(value.clone(), self.upcast::<Node>(), can_gc);
+            Node::string_replace_all(value, self.upcast::<Node>(), can_gc);
         } else {
             // Step 2, if not returned from step 1
             *self.default_value_override.borrow_mut() = Some(value);

--- a/components/script/dom/html/htmlscriptelement.rs
+++ b/components/script/dom/html/htmlscriptelement.rs
@@ -424,7 +424,7 @@ impl FetchResponseListener for ClassicContext {
         // sourceText, settingsObject, response's URL, options, mutedErrors, and url.
         let script = global.create_a_classic_script(
             source_text,
-            final_url.clone(),
+            final_url,
             self.fetch_options.clone(),
             ErrorReporting::from(muted_errors),
             Some(IntroductionType::SRC_SCRIPT),
@@ -851,7 +851,7 @@ impl HTMLScriptElement {
 
                     // Step 31.11. Fetch an external module script graph.
                     fetch_an_external_module_script(
-                        url.clone(),
+                        url,
                         ModuleOwner::Window(Trusted::new(self)),
                         options,
                         can_gc,
@@ -920,7 +920,7 @@ impl HTMLScriptElement {
                     fetch_inline_module_script(
                         ModuleOwner::Window(Trusted::new(self)),
                         text_rc,
-                        base_url.clone(),
+                        base_url,
                         options,
                         self.line_number as u32,
                         can_gc,

--- a/components/script/dom/indexeddb/idbfactory.rs
+++ b/components/script/dom/indexeddb/idbfactory.rs
@@ -601,7 +601,6 @@ impl IDBFactoryMethods<crate::DomTypeHolder> for IDBFactory {
                         let error = map_backend_error_to_dom_error(err);
                         rooted!(&in(cx) let mut rval = UndefinedValue());
                         error
-                            .clone()
                             .to_jsval(cx.into(), &promise.global(), rval.handle_mut(), CanGc::from_cx(cx));
                         promise.reject_native(&rval.handle(), CanGc::from_cx(cx));
                     },

--- a/components/script/dom/indexeddb/idbopendbrequest.rs
+++ b/components/script/dom/indexeddb/idbopendbrequest.rs
@@ -86,9 +86,7 @@ impl OpenRequestListener {
                 let error = map_backend_error_to_dom_error(err);
                 let cx = GlobalScope::get_cx();
                 rooted!(in(*cx) let mut rval = UndefinedValue());
-                error
-                    .clone()
-                    .to_jsval(cx, &global, rval.handle_mut(), can_gc);
+                error.to_jsval(cx, &global, rval.handle_mut(), can_gc);
                 open_request.set_result(rval.handle());
                 let event = Event::new(
                     &global,

--- a/components/script/dom/indexeddb/idbrequest.rs
+++ b/components/script/dom/indexeddb/idbrequest.rs
@@ -358,7 +358,7 @@ impl RequestListener {
         // An explicit call to abort() will initiate an abort. An abort will also be initiated following a failed request that is not handled by script.
         // When a transaction is aborted the implementation must undo (roll back) any changes that were made to the database during that transaction. This includes both changes to the contents of object stores as well as additions and removals of object stores and indexes.
         if default_not_prevented {
-            transaction.initiate_abort(error.clone(), CanGc::from_cx(cx));
+            transaction.initiate_abort(error, CanGc::from_cx(cx));
             transaction.request_backend_abort();
         }
         // Notify the transaction that this request has finished.

--- a/components/script/dom/indexeddb/idbtransaction.rs
+++ b/components/script/dom/indexeddb/idbtransaction.rs
@@ -618,12 +618,7 @@ impl IDBTransaction {
         let db_name = self.db.get_name().to_string();
         let object_store_name = object_store_name.to_string();
 
-        let operation = SyncOperation::GetObjectStore(
-            sender,
-            origin.clone(),
-            db_name.clone(),
-            object_store_name.clone(),
-        );
+        let operation = SyncOperation::GetObjectStore(sender, origin, db_name, object_store_name);
 
         let _ = idb_sender.send(IndexedDBThreadMsg::Sync(operation));
 

--- a/components/script/dom/media/mediasession.rs
+++ b/components/script/dom/media/mediasession.rs
@@ -203,7 +203,7 @@ impl MediaSessionMethods<crate::DomTypeHolder> for MediaSession {
             Some(handler) => self
                 .action_handlers
                 .borrow_mut()
-                .insert(action.convert(), handler.clone()),
+                .insert(action.convert(), handler),
             None => self.action_handlers.borrow_mut().remove(&action.convert()),
         };
     }

--- a/components/script/dom/messageevent.rs
+++ b/components/script/dom/messageevent.rs
@@ -332,9 +332,9 @@ impl MessageEventMethods<crate::DomTypeHolder> for MessageEvent {
         ports: Vec<DomRoot<MessagePort>>,
     ) {
         self.data.set(data.get());
-        *self.origin.borrow_mut() = origin.clone();
+        *self.origin.borrow_mut() = origin;
         *self.source.borrow_mut() = source.as_ref().map(|source| source.into());
-        *self.lastEventId.borrow_mut() = lastEventId.clone();
+        *self.lastEventId.borrow_mut() = lastEventId;
         *self.ports.borrow_mut() = ports
             .into_iter()
             .map(|port| Dom::from_ref(&*port))

--- a/components/script/dom/notification.rs
+++ b/components/script/dom/notification.rs
@@ -162,7 +162,6 @@ impl Notification {
         // TODO: missing call to https://html.spec.whatwg.org/multipage/#structuredserializeforstorage
         // may be find in `dom/bindings/structuredclone.rs`
 
-        let title = title.clone();
         let dir = options.dir;
         let lang = options.lang.clone();
         let body = options.body.clone();
@@ -331,7 +330,7 @@ impl Notification {
                     icon_resource: icon_resource.clone(),
                 })
                 .collect(),
-            icon_resource: icon_resource.clone(),
+            icon_resource,
             badge_resource: self
                 .badge_resource
                 .borrow()
@@ -417,7 +416,7 @@ impl NotificationMethods<crate::DomTypeHolder> for Notification {
         let uuid_ = uuid.clone();
 
         if let Some(callback) = permission_callback {
-            global.add_notification_permission_request_callback(uuid.clone(), callback.clone());
+            global.add_notification_permission_request_callback(uuid, callback);
         }
 
         global.task_manager().dom_manipulation_task_source().queue(
@@ -882,25 +881,13 @@ impl Notification {
                 _,
                 pending_image_id,
             )) => {
-                self.register_image_cache_callback(
-                    request_id,
-                    pending_image_id,
-                    resource_type.clone(),
-                );
+                self.register_image_cache_callback(request_id, pending_image_id, resource_type);
             },
             ImageCacheResult::Pending(pending_image_id) => {
-                self.register_image_cache_callback(
-                    request_id,
-                    pending_image_id,
-                    resource_type.clone(),
-                );
+                self.register_image_cache_callback(request_id, pending_image_id, resource_type);
             },
             ImageCacheResult::ReadyForRequest(pending_image_id) => {
-                self.register_image_cache_callback(
-                    request_id,
-                    pending_image_id,
-                    resource_type.clone(),
-                );
+                self.register_image_cache_callback(request_id, pending_image_id, resource_type);
                 self.fetch(pending_image_id, request, global);
             },
             ImageCacheResult::FailedToLoadOrDecode => {

--- a/components/script/dom/reportingobserver.rs
+++ b/components/script/dom/reportingobserver.rs
@@ -162,7 +162,7 @@ impl ReportingObserver {
         destination: DOMString,
     ) -> Report {
         // Step 2. If url was not provided by the caller, let url be settings’s creation URL.
-        let url = url.unwrap_or(global.creation_url().clone());
+        let url = url.unwrap_or(global.creation_url());
         // Step 3. Set url’s username to the empty string, and its password to null.
         // Step 4. Set report’s url to the result of executing the URL serializer
         // on url with the exclude fragment flag set.

--- a/components/script/dom/stream/byteteereadintorequest.rs
+++ b/components/script/dom/stream/byteteereadintorequest.rs
@@ -143,7 +143,7 @@ impl ByteTeeReadIntoRequest {
             // If cloneResult is an abrupt completion,
             if let Err(error) = clone_result {
                 rooted!(&in(cx) let mut error_value = UndefinedValue());
-                error.clone().to_jsval(
+                error.to_jsval(
                     cx.into(),
                     &self.global(),
                     error_value.handle_mut(),

--- a/components/script/dom/stream/byteteereadrequest.rs
+++ b/components/script/dom/stream/byteteereadrequest.rs
@@ -133,7 +133,7 @@ impl ByteTeeReadRequest {
         // Helper to surface clone failures exactly once
         let handle_clone_error = |cx: &mut js::context::JSContext, error: Error| {
             rooted!(&in(cx) let mut error_value = UndefinedValue());
-            error.clone().to_jsval(
+            error.to_jsval(
                 cx.into(),
                 &self.global(),
                 error_value.handle_mut(),

--- a/components/script/dom/stream/readablebytestreamcontroller.rs
+++ b/components/script/dom/stream/readablebytestreamcontroller.rs
@@ -451,9 +451,7 @@ impl ReadableByteStreamController {
 
                 // Perform readIntoRequest’s error steps, given bufferResult.[[Value]].
                 rooted!(in(*cx) let mut rval = UndefinedValue());
-                error
-                    .clone()
-                    .to_jsval(cx, &self.global(), rval.handle_mut(), can_gc);
+                error.to_jsval(cx, &self.global(), rval.handle_mut(), can_gc);
                 read_into_request.error_steps(rval.handle(), can_gc);
 
                 // Return.
@@ -1645,9 +1643,7 @@ impl ReadableByteStreamController {
                 let cx = GlobalScope::get_cx();
                 rooted!(in(*cx) let mut rval = UndefinedValue());
                 // TODO: check if `self.global()` is the right globalscope.
-                error
-                    .clone()
-                    .to_jsval(cx, &self.global(), rval.handle_mut(), can_gc);
+                error.to_jsval(cx, &self.global(), rval.handle_mut(), can_gc);
                 let promise = Promise::new(&global, can_gc);
                 promise.reject_native(&rval.handle(), can_gc);
                 promise
@@ -1832,9 +1828,7 @@ impl ReadableByteStreamController {
         let promise = result.unwrap_or_else(|error| {
             let cx = GlobalScope::get_cx();
             rooted!(in(*cx) let mut rval = UndefinedValue());
-            error
-                .clone()
-                .to_jsval(cx, global, rval.handle_mut(), can_gc);
+            error.to_jsval(cx, global, rval.handle_mut(), can_gc);
             let promise = Promise::new(global, can_gc);
             promise.reject_native(&rval.handle(), can_gc);
             promise
@@ -1913,9 +1907,7 @@ impl ReadableByteStreamController {
                     // Perform readRequest’s error steps, given buffer.[[Value]].
 
                     rooted!(in(*cx) let mut rval = UndefinedValue());
-                    error
-                        .clone()
-                        .to_jsval(cx, &self.global(), rval.handle_mut(), can_gc);
+                    error.to_jsval(cx, &self.global(), rval.handle_mut(), can_gc);
                     read_request.error_steps(rval.handle(), can_gc);
 
                     // Return.

--- a/components/script/dom/stream/readablestream.rs
+++ b/components/script/dom/stream/readablestream.rs
@@ -1709,7 +1709,7 @@ impl ReadableStream {
             canceled_2,
             reason_1,
             reason_2,
-            cancel_promise.clone(),
+            cancel_promise,
             reader_version,
             ByteTeeCancelAlgorithm::Cancel2Algorithm,
             ByteTeePullAlgorithm::Pull2Algorithm,

--- a/components/script/dom/stream/readablestreamdefaultcontroller.rs
+++ b/components/script/dom/stream/readablestreamdefaultcontroller.rs
@@ -558,9 +558,7 @@ impl ReadableStreamDefaultController {
             let cx = GlobalScope::get_cx();
             rooted!(in(*cx) let mut rval = UndefinedValue());
             // TODO: check if `self.global()` is the right globalscope.
-            error
-                .clone()
-                .to_jsval(cx, &self.global(), rval.handle_mut(), can_gc);
+            error.to_jsval(cx, &self.global(), rval.handle_mut(), can_gc);
             let promise = Promise::new(&global, can_gc);
             promise.reject_native(&rval.handle(), can_gc);
             promise
@@ -594,9 +592,7 @@ impl ReadableStreamDefaultController {
         let promise = result.unwrap_or_else(|error| {
             rooted!(in(*cx) let mut rval = UndefinedValue());
 
-            error
-                .clone()
-                .to_jsval(cx, global, rval.handle_mut(), can_gc);
+            error.to_jsval(cx, global, rval.handle_mut(), can_gc);
             let promise = Promise::new(global, can_gc);
             promise.reject_native(&rval.handle(), can_gc);
             promise

--- a/components/script/dom/stream/transformstream.rs
+++ b/components/script/dom/stream/transformstream.rs
@@ -489,7 +489,7 @@ impl TransformStream {
         self.initialize(
             cx,
             global,
-            start_promise.clone(),
+            start_promise,
             writable_high_water_mark,
             writable_size_algorithm,
             readable_high_water_mark,
@@ -571,7 +571,7 @@ impl TransformStream {
 
         let readable = create_readable_stream(
             global,
-            UnderlyingSourceType::Transform(Dom::from_ref(self), start_promise.clone()),
+            UnderlyingSourceType::Transform(Dom::from_ref(self), start_promise),
             Some(readable_size_algorithm),
             Some(readable_high_water_mark),
             can_gc,

--- a/components/script/dom/stream/writablestream.rs
+++ b/components/script/dom/stream/writablestream.rs
@@ -905,7 +905,7 @@ impl WritableStream {
         // Add a handler for port’s messageerror event with the following steps:
         rooted!(in(*cx) let cross_realm_transform_writable = CrossRealmTransformWritable {
             controller: Dom::from_ref(&controller),
-            backpressure_promise: backpressure_promise.clone(),
+            backpressure_promise,
         });
         global.note_cross_realm_transform_writable(&cross_realm_transform_writable, port_id);
 

--- a/components/script/dom/trustedtypes/trustedtypepolicyfactory.rs
+++ b/components/script/dom/trustedtypes/trustedtypepolicyfactory.rs
@@ -254,11 +254,9 @@ impl TrustedTypePolicyFactory {
         // Step 2: Let policyValue be the result of executing Get Trusted Type policy value,
         // with the following arguments:
         rooted!(in(*cx) let mut trusted_type_name_value = NullValue());
-        expected_type.clone().as_ref().safe_to_jsval(
-            cx,
-            trusted_type_name_value.handle_mut(),
-            can_gc,
-        );
+        expected_type
+            .as_ref()
+            .safe_to_jsval(cx, trusted_type_name_value.handle_mut(), can_gc);
 
         rooted!(in(*cx) let mut sink_value = NullValue());
         sink.safe_to_jsval(cx, sink_value.handle_mut(), can_gc);

--- a/components/script/dom/urlhelper.rs
+++ b/components/script/dom/urlhelper.rs
@@ -15,7 +15,7 @@ pub(crate) struct UrlHelper;
 #[expect(non_snake_case)]
 impl UrlHelper {
     pub(crate) fn Origin(url: &ServoUrl) -> USVString {
-        USVString(quirks::origin(url.as_url()).to_owned())
+        USVString(quirks::origin(url.as_url()))
     }
     pub(crate) fn Href(url: &ServoUrl) -> USVString {
         USVString(quirks::href(url.as_url()).to_owned())

--- a/components/script/dom/webgpu/gpubindgroup.rs
+++ b/components/script/dom/webgpu/gpubindgroup.rs
@@ -130,7 +130,7 @@ impl GPUBindGroup {
 
         GPUBindGroup::new(
             &device.global(),
-            device.channel().clone(),
+            device.channel(),
             bind_group,
             device.id(),
             &descriptor.layout,

--- a/components/script/dom/webgpu/gpubindgrouplayout.rs
+++ b/components/script/dom/webgpu/gpubindgrouplayout.rs
@@ -130,7 +130,7 @@ impl GPUBindGroupLayout {
 
         Ok(GPUBindGroupLayout::new(
             &device.global(),
-            device.channel().clone(),
+            device.channel(),
             bgl,
             descriptor.parent.label.clone(),
             can_gc,

--- a/components/script/dom/webgpu/gpubuffer.rs
+++ b/components/script/dom/webgpu/gpubuffer.rs
@@ -170,7 +170,7 @@ impl GPUBuffer {
 
         Ok(GPUBuffer::new(
             &device.global(),
-            device.channel().clone(),
+            device.channel(),
             buffer,
             device,
             descriptor.size,
@@ -414,7 +414,7 @@ impl GPUBuffer {
         match mapping {
             Err(error) => {
                 *self.pending_map.borrow_mut() = None;
-                p.reject_error(error.clone(), can_gc);
+                p.reject_error(error, can_gc);
             },
             Ok(mut mapping) => {
                 // Step 5

--- a/components/script/dom/webgpu/gpucommandencoder.rs
+++ b/components/script/dom/webgpu/gpucommandencoder.rs
@@ -106,7 +106,7 @@ impl GPUCommandEncoder {
 
         GPUCommandEncoder::new(
             &device.global(),
-            device.channel().clone(),
+            device.channel(),
             device,
             encoder,
             descriptor.parent.label.clone(),

--- a/components/script/dom/webgpu/gpupipelinelayout.rs
+++ b/components/script/dom/webgpu/gpupipelinelayout.rs
@@ -132,7 +132,7 @@ impl GPUPipelineLayout {
         let pipeline_layout = WebGPUPipelineLayout(pipeline_layout_id);
         GPUPipelineLayout::new(
             &device.global(),
-            device.channel().clone(),
+            device.channel(),
             pipeline_layout,
             descriptor.parent.label.clone(),
             bgls,

--- a/components/script/dom/webgpu/gpurenderbundleencoder.rs
+++ b/components/script/dom/webgpu/gpurenderbundleencoder.rs
@@ -122,7 +122,7 @@ impl GPURenderBundleEncoder {
             &device.global(),
             render_bundle_encoder,
             device,
-            device.channel().clone(),
+            device.channel(),
             descriptor.parent.parent.label.clone(),
             can_gc,
         ))

--- a/components/script/dom/webgpu/gpusampler.rs
+++ b/components/script/dom/webgpu/gpusampler.rs
@@ -116,7 +116,7 @@ impl GPUSampler {
 
         GPUSampler::new(
             &device.global(),
-            device.channel().clone(),
+            device.channel(),
             device.id(),
             compare_enable,
             sampler,

--- a/components/script/dom/webgpu/gpushadermodule.rs
+++ b/components/script/dom/webgpu/gpushadermodule.rs
@@ -88,7 +88,7 @@ impl GPUShaderModule {
         let promise = Promise::new_in_current_realm(comp, can_gc);
         let shader_module = GPUShaderModule::new(
             &device.global(),
-            device.channel().clone(),
+            device.channel(),
             WebGPUShaderModule(program_id),
             descriptor.parent.label.clone(),
             promise.clone(),

--- a/components/script/dom/webgpu/gputexture.rs
+++ b/components/script/dom/webgpu/gputexture.rs
@@ -152,7 +152,7 @@ impl GPUTexture {
             &device.global(),
             texture,
             device,
-            device.channel().clone(),
+            device.channel(),
             size,
             descriptor.mipLevelCount,
             descriptor.sampleCount,

--- a/components/script/dom/webvtt/texttracklist.rs
+++ b/components/script/dom/webvtt/texttracklist.rs
@@ -122,7 +122,7 @@ impl TextTrackListMethods<crate::DomTypeHolder> for TextTrackList {
 
     /// <https://html.spec.whatwg.org/multipage/#dom-texttracklist-gettrackbyid>
     fn GetTrackById(&self, id: DOMString) -> Option<DomRoot<TextTrack>> {
-        let id_str = String::from(id.clone());
+        let id_str = String::from(id);
         self.dom_tracks
             .borrow()
             .iter()

--- a/components/script/dom/window.rs
+++ b/components/script/dom/window.rs
@@ -2388,7 +2388,7 @@ impl Window {
             "*" => None,
             "/" => Some(source_origin.clone()),
             url => match ServoUrl::parse(url) {
-                Ok(url) => Some(url.origin().clone()),
+                Ok(url) => Some(url.origin()),
                 Err(_) => return Err(Error::Syntax(None)),
             },
         };
@@ -3775,7 +3775,7 @@ impl Window {
                 gpu_id_hub,
                 inherited_secure_context,
                 unminify_js,
-                Some(font_context.clone()),
+                Some(font_context),
             ),
             ongoing_navigation: Default::default(),
             script_chan,
@@ -3796,7 +3796,7 @@ impl Window {
             status: DomRefCell::new(DOMString::new()),
             parent_info,
             dom_static: GlobalStaticData::new(),
-            js_runtime: DomRefCell::new(Some(runtime.clone())),
+            js_runtime: DomRefCell::new(Some(runtime)),
             #[cfg(feature = "bluetooth")]
             bluetooth_thread,
             #[cfg(feature = "bluetooth")]

--- a/components/script/dom/workers/workerglobalscope.rs
+++ b/components/script/dom/workers/workerglobalscope.rs
@@ -212,7 +212,7 @@ impl FetchResponseListener for ScriptFetchContext {
         // response's URL's scheme is an HTTP(S) scheme;
         let is_http_scheme = matches!(metadata.final_url.scheme(), "http" | "https");
         // and the result of extracting a MIME type from response's header list is not a JavaScript MIME type,
-        let not_a_javascript_mime_type = !metadata.content_type.clone().is_some_and(|ct| {
+        let not_a_javascript_mime_type = !metadata.content_type.is_some_and(|ct| {
             let mime: Mime = ct.into_inner().into();
             SCRIPT_JS_MIMES.contains(&mime.essence_str())
         });
@@ -595,7 +595,7 @@ impl WorkerGlobalScope {
             _ => {
                 // Step 1.1 Queue a global task on the DOM manipulation task source given
                 // worker's relevant global object to fire an event named error at worker.
-                dedicated_worker_scope.forward_simple_error_at_worker(worker.clone());
+                dedicated_worker_scope.forward_simple_error_at_worker(worker);
 
                 // TODO Step 1.2. Run the environment discarding steps for inside settings.
                 // Step 1.3 Abort these steps.

--- a/components/script/dom/xmlhttprequest.rs
+++ b/components/script/dom/xmlhttprequest.rs
@@ -1120,7 +1120,7 @@ impl XMLHttpRequest {
                 // XXXManishearth handle errors, if any (substep 1)
                 // Substep 2
                 if !status.is_error() {
-                    *self.status.borrow_mut() = status.clone();
+                    *self.status.borrow_mut() = status;
                 }
                 if let Some(h) = headers.as_ref() {
                     *self.response_headers.borrow_mut() = h.clone();

--- a/components/script/fetch.rs
+++ b/components/script/fetch.rs
@@ -466,9 +466,8 @@ impl DeferredFetchRecord {
         // Step 2. Set deferredRecord’s invoke state to "sent".
         self.invoke_state.set(DeferredFetchRecordInvokeState::Sent);
         // Step 3. Fetch deferredRecord’s request.
-        let url = self.request.url().clone();
         let fetch_later_listener = FetchLaterListener {
-            url,
+            url: self.request.url(),
             global: Trusted::new(global),
         };
         let request_init = request_init_from_request(self.request.clone(), global);

--- a/components/script/indexeddb.rs
+++ b/components/script/indexeddb.rs
@@ -195,7 +195,7 @@ pub fn convert_value_to_key(
                 // FIXME:(arihant2math) implement it the correct way (is this correct?)
                 let key = structuredclone::write(cx.into(), input, None)?;
                 return Ok(ConversionResult::Valid(IndexedDBKeyType::Binary(
-                    key.serialized.clone(),
+                    key.serialized,
                 )));
             }
 

--- a/components/script/module_loading.rs
+++ b/components/script/module_loading.rs
@@ -383,7 +383,7 @@ fn continue_dynamic_import(
                 &global_scope,
                 Some(on_fulfilled),
                 Some(Box::new(OnRejectedHandler {
-                    promise: inner_promise.clone(),
+                    promise: inner_promise,
                 })),
                 CanGc::note(),
             );

--- a/components/script/script_module.rs
+++ b/components/script/script_module.rs
@@ -632,7 +632,7 @@ pub(crate) enum ModuleOwner {
 impl ModuleOwner {
     pub(crate) fn global(&self) -> DomRoot<GlobalScope> {
         match &self {
-            ModuleOwner::Worker(worker) => (*worker.root().clone()).global(),
+            ModuleOwner::Worker(worker) => (*worker.root()).global(),
             ModuleOwner::Window(script) => (*script.root()).global(),
             ModuleOwner::DynamicModule(dynamic_module) => (*dynamic_module.root()).global(),
         }
@@ -903,7 +903,7 @@ pub(crate) unsafe extern "C" fn host_import_module_dynamically(
     let specifier = unsafe { jsstr_to_string(cx.raw_cx(), NonNull::new(jsstr).unwrap()) };
 
     let mut realm = CurrentRealm::assert(cx);
-    let payload = Payload::PromiseRecord(promise.clone());
+    let payload = Payload::PromiseRecord(promise);
     host_load_imported_module(
         &mut realm,
         None,
@@ -1283,8 +1283,8 @@ fn fetch_the_descendants_and_link_module_script(
         }),
     ));
 
-    let rejection_owner = owner.clone();
-    let rejected_module = module_script.clone();
+    let rejection_owner = owner;
+    let rejected_module = module_script;
 
     // Step 7. Upon rejection of loadingPromise, run the following steps:
     let loading_promise_rejection = ModuleHandler::new_boxed(Box::new(
@@ -1536,7 +1536,7 @@ pub(crate) fn register_import_map(
         Err(exception) => {
             // Step 1. If result's error to rethrow is not null, then report
             // an exception given by result's error to rethrow for global and return.
-            throw_dom_exception(GlobalScope::get_cx(), global, exception.clone(), can_gc);
+            throw_dom_exception(GlobalScope::get_cx(), global, exception, can_gc);
         },
     }
 }

--- a/components/script/script_runtime.rs
+++ b/components/script/script_runtime.rs
@@ -333,7 +333,7 @@ unsafe extern "C" fn push_new_interrupt_queue(interrupt_queues: *mut c_void) -> 
             unsafe { Box::from_raw(interrupt_queues as *mut Vec<Rc<MicrotaskQueue>>) };
         let new_queue = Rc::new(MicrotaskQueue::default());
         result = Rc::as_ptr(&new_queue) as *const c_void;
-        interrupt_queues.push(new_queue.clone());
+        interrupt_queues.push(new_queue);
         std::mem::forget(interrupt_queues);
     });
     result
@@ -467,7 +467,7 @@ unsafe extern "C" fn promise_rejection_tracker(
                 let target = Trusted::new(global.upcast::<EventTarget>());
                 let promise =
                     Promise::new_with_js_promise(unsafe { Handle::from_raw(promise) }, cx);
-                let trusted_promise = TrustedPromise::new(promise.clone());
+                let trusted_promise = TrustedPromise::new(promise);
 
                 // Step 5-4.
                 global.task_manager().dom_manipulation_task_source().queue(

--- a/components/script/script_thread.rs
+++ b/components/script/script_thread.rs
@@ -2797,7 +2797,7 @@ impl ScriptThread {
             }
 
             let prefix = format!("url({urls})");
-            reports.extend(self.get_cx().get_reports(prefix.clone(), ops));
+            reports.extend(self.get_cx().get_reports(prefix, ops));
         });
 
         reports_chan.send(ProcessReports::new(reports));

--- a/components/script/script_thread.rs
+++ b/components/script/script_thread.rs
@@ -3908,6 +3908,7 @@ impl ScriptThread {
         }
     }
 
+    #[expect(clippy::redundant_clone, reason = "False positive")]
     fn handle_fetch_eof(
         &self,
         cx: &mut js::context::JSContext,

--- a/components/script/serviceworker_manager.rs
+++ b/components/script/serviceworker_manager.rs
@@ -478,7 +478,7 @@ fn update_serviceworker(
         receiver,
         devtools_receiver,
         own_sender,
-        scope_url.clone(),
+        scope_url,
         control_receiver,
         context_sender,
         closing.clone(),

--- a/components/script/webdriver_handlers.rs
+++ b/components/script/webdriver_handlers.rs
@@ -835,7 +835,7 @@ pub(crate) fn handle_find_elements_link_text(
         Ok(document) => reply
             .send(all_matching_links(
                 document.upcast::<Node>(),
-                selector.clone(),
+                selector,
                 partial,
             ))
             .unwrap(),

--- a/components/servo/servo.rs
+++ b/components/servo/servo.rs
@@ -803,7 +803,7 @@ impl Servo {
         let paint = Paint::new(InitialPaintState {
             paint_proxy: paint_proxy.clone(),
             receiver: paint_receiver,
-            embedder_to_constellation_sender: constellation_proxy.sender().clone(),
+            embedder_to_constellation_sender: constellation_proxy.sender(),
             time_profiler_chan: time_profiler_chan.clone(),
             mem_profiler_chan: mem_profiler_chan.clone(),
             shutdown_state: shutdown_state.clone(),
@@ -832,7 +832,7 @@ impl Servo {
             embedder_to_constellation_receiver,
             &paint.borrow(),
             embedder_proxy,
-            paint_proxy.clone(),
+            paint_proxy,
             time_profiler_chan,
             mem_profiler_chan,
             devtools_sender,

--- a/components/shared/base/generic_channel.rs
+++ b/components/shared/base/generic_channel.rs
@@ -425,7 +425,7 @@ where
         match self.0 {
             GenericReceiverVariants::Ipc(ipc_receiver) => {
                 let (crossbeam_sender, crossbeam_receiver) = crossbeam_channel::unbounded();
-                let crossbeam_sender_clone = crossbeam_sender.clone();
+                let crossbeam_sender_clone = crossbeam_sender;
                 ROUTER.add_typed_route(
                     ipc_receiver,
                     Box::new(move |message| {

--- a/components/storage/indexeddb/engines/sqlite.rs
+++ b/components/storage/indexeddb/engines/sqlite.rs
@@ -633,7 +633,7 @@ impl KvsEngine for SqliteEngine {
 
         let index_exists: bool = self.connection.query_row(
             "SELECT EXISTS(SELECT * FROM object_store_index WHERE name = ? AND object_store_id = ?)",
-            params![index_name.to_string(), object_store.id],
+            params![index_name, object_store.id],
             |row| row.get(0),
         )?;
         if index_exists {
@@ -645,7 +645,7 @@ impl KvsEngine for SqliteEngine {
             VALUES (?, ?, ?, ?, ?)",
             params![
                 object_store.id,
-                index_name.to_string(),
+                index_name,
                 postcard::to_stdvec(&key_path).unwrap(),
                 unique,
                 multi_entry,
@@ -664,7 +664,7 @@ impl KvsEngine for SqliteEngine {
         // Delete the index if it exists
         let _ = self.connection.execute(
             "DELETE FROM object_store_index WHERE name = ? AND object_store_id = ?",
-            params![index_name.to_string(), object_store.id],
+            params![index_name, object_store.id],
         )?;
         Ok(())
     }

--- a/components/storage/indexeddb/mod.rs
+++ b/components/storage/indexeddb/mod.rs
@@ -1156,10 +1156,7 @@ impl IndexedDBManager {
     // https://w3c.github.io/IndexedDB/#abort-an-upgrade-transaction
     /// Note: this only reverts the version at this point.
     fn abort_pending_upgrade(&mut self, name: String, id: Uuid, origin: ImmutableOrigin) {
-        let key = IndexedDBDescription {
-            name,
-            origin: origin.clone(),
-        };
+        let key = IndexedDBDescription { name, origin };
         let old = {
             let Some(queue) = self.connection_queues.get_mut(&key) else {
                 return debug_assert!(
@@ -1275,7 +1272,7 @@ impl IndexedDBManager {
     ) {
         let key = IndexedDBDescription {
             name: db_name.clone(),
-            origin: origin.clone(),
+            origin,
         };
         let open_request = OpenRequest::Open {
             sender,
@@ -1401,7 +1398,7 @@ impl IndexedDBManager {
                 version: new_version,
                 old_version,
                 transaction,
-                object_store_names: scope.clone(),
+                object_store_names: scope,
             })
             .is_err()
         {
@@ -1422,7 +1419,7 @@ impl IndexedDBManager {
     ) {
         let key = IndexedDBDescription {
             name: name.clone(),
-            origin: origin.clone(),
+            origin,
         };
         let (can_upgrade, version) = {
             let Some(queue) = self.connection_queues.get_mut(&key) else {
@@ -2004,10 +2001,10 @@ impl IndexedDBManager {
                     } else {
                         db.queue_pending_commit_callback(txn, callback);
                     }
-                    db.schedule_transactions(origin.clone(), &db_name);
+                    db.schedule_transactions(origin, &db_name);
                 } else if callback
                     .send(TxnCompleteMsg {
-                        origin: origin.clone(),
+                        origin,
                         db_name: db_name.clone(),
                         txn,
                         // If the database entry has already been removed, treat commit as a
@@ -2055,7 +2052,7 @@ impl IndexedDBManager {
                 }
                 if abort_callback
                     .send(storage_traits::indexeddb::TxnCompleteMsg {
-                        origin: origin.clone(),
+                        origin,
                         db_name: db_name.clone(),
                         txn,
                         result: Err(BackendError::Abort),

--- a/components/webgpu/canvas_context.rs
+++ b/components/webgpu/canvas_context.rs
@@ -586,7 +586,7 @@ impl crate::WGPU {
 
             let epoch = context_data.next_epoch();
             let wgpu_image_map = self.wgpu_image_map.clone();
-            let sender = sender.clone();
+            let sender = sender;
             drop(webgpu_contexts);
             self.texture_download(
                 texture_id,

--- a/components/xpath/src/eval.rs
+++ b/components/xpath/src/eval.rs
@@ -202,17 +202,14 @@ fn apply_node_test<D: Dom>(test: &NodeTest, node: &D::Node) -> Result<bool, Erro
                 } else {
                     NameTestComparisonMode::XHtml
                 };
-                let actual_name = QualName::new(
-                    element.prefix(),
-                    element.namespace().clone(),
-                    element.local_name().clone(),
-                );
+                let actual_name =
+                    QualName::new(element.prefix(), element.namespace(), element.local_name());
                 element_name_test(expected_name, actual_name, comparison_mode)
             } else if let Some(attribute) = node.as_attribute() {
                 let actual_name = QualName::new(
                     attribute.prefix(),
-                    attribute.namespace().clone(),
-                    attribute.local_name().clone(),
+                    attribute.namespace(),
+                    attribute.local_name(),
                 );
                 // attributes are always compared with strict namespace matching
                 let comparison_mode = NameTestComparisonMode::XHtml;

--- a/components/xpath/src/functions.rs
+++ b/components/xpath/src/functions.rs
@@ -193,7 +193,7 @@ impl CoreFunction {
                     None => Some(context.context_node.clone()),
                 };
                 let name = node.and_then(|n| local_name(&n)).unwrap_or_default();
-                Ok(Value::String(name.to_string()))
+                Ok(Value::String(name))
             },
             CoreFunction::NamespaceUri(expr_opt) => {
                 let node = match expr_opt {
@@ -204,7 +204,7 @@ impl CoreFunction {
                     None => Some(context.context_node.clone()),
                 };
                 let ns = node.and_then(|n| namespace_uri(&n)).unwrap_or_default();
-                Ok(Value::String(ns.to_string()))
+                Ok(Value::String(ns))
             },
             CoreFunction::Name(expr_opt) => {
                 let node = match expr_opt {

--- a/ports/servoshell/desktop/app.rs
+++ b/ports/servoshell/desktop/app.rs
@@ -72,7 +72,7 @@ impl App {
             servoshell_preferences: servo_shell_preferences,
             waker: event_loop.create_event_loop_waker(),
             event_loop_proxy: event_loop.event_loop_proxy(),
-            initial_url: initial_url.clone(),
+            initial_url,
             t_start: t,
             t,
             state: AppState::Initializing,

--- a/ports/servoshell/desktop/gui.rs
+++ b/ports/servoshell/desktop/gui.rs
@@ -535,7 +535,7 @@ impl Gui {
             .and_then(|webview| Some(webview.url()?.to_string()));
         match current_url_string {
             Some(location) if location != self.location => {
-                self.location = location.to_owned();
+                self.location = location;
                 true
             },
             _ => false,

--- a/ports/servoshell/desktop/headed_window.rs
+++ b/ports/servoshell/desktop/headed_window.rs
@@ -228,7 +228,7 @@ impl HeadedWindow {
     ) {
         // First, handle servoshell key bindings that are not overridable by, or visible to, the page.
         let keyboard_event = keyboard_event_from_winit(&winit_event, self.modifiers_state.get());
-        if self.handle_intercepted_key_bindings(state.clone(), window, &keyboard_event) {
+        if self.handle_intercepted_key_bindings(state, window, &keyboard_event) {
             return;
         }
 
@@ -659,7 +659,7 @@ impl HeadedWindow {
             if let Some(webview) = window.active_webview() {
                 match event {
                     WindowEvent::KeyboardInput { event, .. } => {
-                        self.handle_keyboard_input(state.clone(), &window, event)
+                        self.handle_keyboard_input(state, &window, event)
                     },
                     WindowEvent::ModifiersChanged(modifiers) => {
                         self.modifiers_state.set(modifiers.state())
@@ -824,7 +824,6 @@ impl PlatformWindow for HeadedWindow {
                 webview
                     .page_title()
                     .filter(|title| !title.is_empty())
-                    .map(|title| title.to_string())
                     .or_else(|| webview.url().map(|url| url.to_string()))
             })
             .unwrap_or_else(|| INITIAL_WINDOW_TITLE.to_string());

--- a/ports/servoshell/prefs.rs
+++ b/ports/servoshell/prefs.rs
@@ -728,7 +728,7 @@ fn parse_arguments_helper(args_without_binary: Args) -> ArgumentParsingResult {
         sandbox: cmd_args.sandbox,
         random_pipeline_closure_probability: cmd_args.random_pipeline_closure_probability,
         random_pipeline_closure_seed: cmd_args.random_pipeline_closure_seed,
-        config_dir: config_dir.clone(),
+        config_dir,
         shaders_path: cmd_args.shaders,
         certificate_path: cmd_args
             .certificate_path

--- a/ports/servoshell/running_app_state.rs
+++ b/ports/servoshell/running_app_state.rs
@@ -636,7 +636,7 @@ impl RunningAppState {
     }
 
     pub(crate) fn handle_focused(&self, window: Rc<ServoShellWindow>) {
-        *self.focused_window.borrow_mut() = Some(window.clone());
+        *self.focused_window.borrow_mut() = Some(window);
     }
 
     /// Interrupt any ongoing WebDriver-based script evaluation.

--- a/python/servo/devenv_commands.py
+++ b/python/servo/devenv_commands.py
@@ -130,7 +130,7 @@ class MachCommands(CommandBase):
         # arguments to be passed through to clippy (as opposed to the cargo clippy wrapper)
         # These should mainly be `--allow`, `--warn`, `--deny`, `--forbid`
         # Note that some lints can additionally be configured by `.clippy.toml` at the repository root.
-        clippy_args = ["--deny=clippy::disallowed_types"]
+        clippy_args = ["--deny=clippy::disallowed_types", "--warn=clippy::redundant-clone"]
 
         if "--" not in params:
             params.append("--")


### PR DESCRIPTION
This change fixes all instances where [`clippy::redundant-clone`](https://rust-lang.github.io/rust-clippy/master/index.html?groups=complexity%2Ccorrectness%2Cnursery%2Csuspicious&levels=allow#redundant_clone) would trigger. It's allowed by default

I've also changed the lint to warn-by-default for servo.

Testing: Covered by WPT