### PR TITLE
script: Use the shared task canceller in `DedicatedWorkerGlobalScope::run_worker_scope`

### DIFF
--- a/components/script/dom/workers/dedicatedworkerglobalscope.rs
+++ b/components/script/dom/workers/dedicatedworkerglobalscope.rs
@@ -511,7 +511,7 @@ impl DedicatedWorkerGlobalScope {
                     sender: event_loop_sender.clone(),
                     pipeline_id,
                     name: TaskSourceName::Networking,
-                    canceller: Default::default(),
+                    canceller: scope.shared_task_canceller(),
                 };
                 let context = ScriptFetchContext::new(
                     Trusted::new(scope),


### PR DESCRIPTION
Replaces the default task canceler with the shared task canceler found in the global scope.

Testing: #42536 specifies that building is enough.
Fixes: #42536