### PR TITLE
script: Move `BlobMethods` to `&mut JSContext`

### DIFF
--- a/components/script/dom/blob.rs
+++ b/components/script/dom/blob.rs
@@ -21,7 +21,9 @@ use crate::dom::bindings::codegen::Bindings::BlobBinding;
 use crate::dom::bindings::codegen::Bindings::BlobBinding::BlobMethods;
 use crate::dom::bindings::codegen::UnionTypes::ArrayBufferOrArrayBufferViewOrBlobOrString;
 use crate::dom::bindings::error::{Error, Fallible};
-use crate::dom::bindings::reflector::{DomGlobal, Reflector, reflect_dom_object_with_proto};
+use crate::dom::bindings::reflector::{
+    DomGlobal, Reflector, reflect_dom_object_with_proto, reflect_dom_object_with_proto_and_cx,
+};
 use crate::dom::bindings::root::DomRoot;
 use crate::dom::bindings::serializable::Serializable;
 use crate::dom::bindings::str::DOMString;
@@ -56,6 +58,22 @@ impl Blob {
             global,
             proto,
             can_gc,
+        );
+        global.track_blob(&dom_blob, blob_impl);
+        dom_blob
+    }
+
+    fn new_with_proto_and_cx(
+        global: &GlobalScope,
+        proto: Option<HandleObject>,
+        blob_impl: BlobImpl,
+        cx: &mut js::context::JSContext,
+    ) -> DomRoot<Blob> {
+        let dom_blob = reflect_dom_object_with_proto_and_cx(
+            Box::new(Blob::new_inherited(&blob_impl)),
+            global,
+            proto,
+            cx,
         );
         global.track_blob(&dom_blob, blob_impl);
         dom_blob
@@ -161,9 +179,9 @@ impl BlobMethods<crate::DomTypeHolder> for Blob {
     // https://w3c.github.io/FileAPI/#constructorBlob
     #[expect(non_snake_case)]
     fn Constructor(
+        cx: &mut js::context::JSContext,
         global: &GlobalScope,
         proto: Option<HandleObject>,
-        can_gc: CanGc,
         blobParts: Option<Vec<ArrayBufferOrArrayBufferViewOrBlobOrString>>,
         blobPropertyBag: &BlobBinding::BlobPropertyBag,
     ) -> Fallible<DomRoot<Blob>> {
@@ -178,7 +196,7 @@ impl BlobMethods<crate::DomTypeHolder> for Blob {
         let type_string = normalize_type_string(&blobPropertyBag.type_.str());
         let blob_impl = BlobImpl::new_from_bytes(bytes, type_string);
 
-        Ok(Blob::new_with_proto(global, proto, blob_impl, can_gc))
+        Ok(Blob::new_with_proto_and_cx(global, proto, blob_impl, cx))
     }
 
     /// <https://w3c.github.io/FileAPI/#dfn-size>
@@ -192,17 +210,17 @@ impl BlobMethods<crate::DomTypeHolder> for Blob {
     }
 
     // <https://w3c.github.io/FileAPI/#blob-get-stream>
-    fn Stream(&self, can_gc: CanGc) -> Fallible<DomRoot<ReadableStream>> {
-        self.get_stream(can_gc)
+    fn Stream(&self, cx: &mut js::context::JSContext) -> Fallible<DomRoot<ReadableStream>> {
+        self.get_stream(CanGc::from_cx(cx))
     }
 
     /// <https://w3c.github.io/FileAPI/#slice-method-algo>
     fn Slice(
         &self,
+        cx: &mut js::context::JSContext,
         start: Option<i64>,
         end: Option<i64>,
         content_type: Option<DOMString>,
-        can_gc: CanGc,
     ) -> DomRoot<Blob> {
         let global = self.global();
         let type_string = normalize_type_string(&content_type.unwrap_or_default().str());
@@ -221,26 +239,27 @@ impl BlobMethods<crate::DomTypeHolder> for Blob {
         };
 
         let blob_impl = BlobImpl::new_sliced(range, parent, type_string);
-        Blob::new(&global, blob_impl, can_gc)
+        Blob::new(&global, blob_impl, CanGc::from_cx(cx))
     }
 
     /// <https://w3c.github.io/FileAPI/#text-method-algo>
-    fn Text(&self, can_gc: CanGc) -> Rc<Promise> {
+    fn Text(&self, cx: &mut js::context::JSContext) -> Rc<Promise> {
         let global = self.global();
         let in_realm_proof = AlreadyInRealm::assert::<crate::DomTypeHolder>();
-        let p = Promise::new_in_current_realm(InRealm::Already(&in_realm_proof), can_gc);
+        let p =
+            Promise::new_in_current_realm(InRealm::Already(&in_realm_proof), CanGc::from_cx(cx));
         let id = self.get_blob_url_id();
         global.read_file_async(
             id,
             p.clone(),
-            Box::new(|promise, bytes| match bytes {
+            Box::new(|cx, promise, bytes| match bytes {
                 Ok(b) => {
                     let (text, _) = UTF_8.decode_with_bom_removal(&b);
                     let text = DOMString::from(text);
-                    promise.resolve_native(&text, CanGc::note());
+                    promise.resolve_native(&text, CanGc::from_cx(cx));
                 },
                 Err(e) => {
-                    promise.reject_error(e, CanGc::note());
+                    promise.reject_error(e, CanGc::from_cx(cx));
                 },
             }),
         );

--- a/components/script/dom/blob.rs
+++ b/components/script/dom/blob.rs
@@ -10,6 +10,7 @@ use constellation_traits::{BlobData, BlobImpl};
 use dom_struct::dom_struct;
 use encoding_rs::UTF_8;
 use js::jsapi::JSObject;
+use js::realm::CurrentRealm;
 use js::rust::HandleObject;
 use js::typedarray::{ArrayBufferU8, Uint8};
 use net_traits::filemanager_thread::RelativePos;
@@ -31,7 +32,7 @@ use crate::dom::bindings::structuredclone::StructuredData;
 use crate::dom::globalscope::GlobalScope;
 use crate::dom::promise::Promise;
 use crate::dom::stream::readablestream::ReadableStream;
-use crate::realms::{AlreadyInRealm, InRealm};
+use crate::realms::InRealm;
 use crate::script_runtime::CanGc;
 
 /// <https://w3c.github.io/FileAPI/#dfn-Blob>
@@ -243,11 +244,9 @@ impl BlobMethods<crate::DomTypeHolder> for Blob {
     }
 
     /// <https://w3c.github.io/FileAPI/#text-method-algo>
-    fn Text(&self, cx: &mut js::context::JSContext) -> Rc<Promise> {
+    fn Text(&self, cx: &mut CurrentRealm) -> Rc<Promise> {
         let global = self.global();
-        let in_realm_proof = AlreadyInRealm::assert::<crate::DomTypeHolder>();
-        let p =
-            Promise::new_in_current_realm(InRealm::Already(&in_realm_proof), CanGc::from_cx(cx));
+        let p = Promise::new_in_realm(cx);
         let id = self.get_blob_url_id();
         global.read_file_async(
             id,

--- a/components/script/dom/globalscope.rs
+++ b/components/script/dom/globalscope.rs
@@ -142,7 +142,7 @@ use crate::fetch::{DeferredFetchRecordId, FetchGroup, QueuedDeferredFetchRecord}
 use crate::messaging::{CommonScriptMsg, ScriptEventLoopReceiver, ScriptEventLoopSender};
 use crate::microtask::Microtask;
 use crate::network_listener::{FetchResponseListener, NetworkListener};
-use crate::realms::{InRealm, enter_realm};
+use crate::realms::{InRealm, enter_auto_realm, enter_realm};
 use crate::script_module::{
     ImportMap, ModuleRequest, ModuleStatus, ResolvedModule, ScriptFetchOptions,
 };
@@ -693,8 +693,8 @@ impl FileListener {
                     FileListenerTarget::Promise(trusted_promise, callback) => {
                         let task = task!(resolve_promise: move |cx| {
                             let promise = trusted_promise.root();
-                            let _ac = enter_realm(&*promise.global());
-                            callback(cx, promise, Ok(bytes));
+                            let mut realm = enter_auto_realm(cx, &*promise.global());
+                            callback(&mut realm, promise, Ok(bytes));
                         });
 
                         self.task_source.queue(task);
@@ -723,8 +723,8 @@ impl FileListener {
                         FileListenerTarget::Promise(trusted_promise, callback) => {
                             self.task_source.queue(task!(reject_promise: move |cx| {
                                 let promise = trusted_promise.root();
-                                let _ac = enter_realm(&*promise.global());
-                                callback(cx, promise, error);
+                                let mut realm = enter_auto_realm(cx, &*promise.global());
+                                callback(&mut realm, promise, error);
                             }));
                         },
                         FileListenerTarget::Stream(trusted_stream) => {

--- a/components/script/dom/globalscope.rs
+++ b/components/script/dom/globalscope.rs
@@ -426,7 +426,8 @@ struct BroadcastListener {
     context: Trusted<GlobalScope>,
 }
 
-type FileListenerCallback = Box<dyn Fn(Rc<Promise>, Fallible<Vec<u8>>) + Send>;
+type FileListenerCallback =
+    Box<dyn Fn(&mut js::context::JSContext, Rc<Promise>, Fallible<Vec<u8>>) + Send>;
 
 /// A wrapper for the handling of file data received by the ipc router
 struct FileListener {
@@ -690,10 +691,10 @@ impl FileListener {
             Ok(ReadFileProgress::EOF) => match self.state.take() {
                 Some(FileListenerState::Receiving(bytes, target)) => match target {
                     FileListenerTarget::Promise(trusted_promise, callback) => {
-                        let task = task!(resolve_promise: move || {
+                        let task = task!(resolve_promise: move |cx| {
                             let promise = trusted_promise.root();
                             let _ac = enter_realm(&*promise.global());
-                            callback(promise, Ok(bytes));
+                            callback(cx, promise, Ok(bytes));
                         });
 
                         self.task_source.queue(task);
@@ -720,10 +721,10 @@ impl FileListener {
 
                     match target {
                         FileListenerTarget::Promise(trusted_promise, callback) => {
-                            self.task_source.queue(task!(reject_promise: move || {
+                            self.task_source.queue(task!(reject_promise: move |cx| {
                                 let promise = trusted_promise.root();
                                 let _ac = enter_realm(&*promise.global());
-                                callback(promise, error);
+                                callback(cx, promise, error);
                             }));
                         },
                         FileListenerTarget::Stream(trusted_stream) => {

--- a/components/script_bindings/codegen/Bindings.conf
+++ b/components/script_bindings/codegen/Bindings.conf
@@ -51,7 +51,8 @@ DOMInterfaces = {
     'weakReferenceable': True,
     'canGc': ['ArrayBuffer', 'Bytes'],
     'inRealms': ['Bytes', 'ArrayBuffer'],
-    'cx': ['Stream', 'Slice', 'Text', 'Constructor']
+    'realm': ['Text'],
+    'cx': ['Stream', 'Slice', 'Constructor']
 },
 
 'Bluetooth': {

--- a/components/script_bindings/codegen/Bindings.conf
+++ b/components/script_bindings/codegen/Bindings.conf
@@ -49,8 +49,9 @@ DOMInterfaces = {
 
 'Blob': {
     'weakReferenceable': True,
-    'canGc': ['Slice', 'Text', 'ArrayBuffer', 'Stream', 'Bytes'],
+    'canGc': ['ArrayBuffer', 'Bytes'],
     'inRealms': ['Bytes', 'ArrayBuffer'],
+    'cx': ['Stream', 'Slice', 'Text', 'Constructor']
 },
 
 'Bluetooth': {


### PR DESCRIPTION
Move from CanGc to &mut js::context:JSContext. `ArrayBuffer` and `Bytes` require many changes in `dom/stream` for which I'm going to create a seperate pull request before porting the two methods.

Testing: Just a refactor, `./mach test-unit` still passes.
Fixes: Part of #42638
