### PR TITLE
script: Implement duplicate attribute check for CSP nonce validation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -383,7 +383,7 @@ dependencies = [
  "objc2-foundation 0.3.2",
  "parking_lot",
  "percent-encoding",
- "windows-sys 0.52.0",
+ "windows-sys 0.60.2",
  "x11rb",
 ]
 
@@ -2293,7 +2293,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2849,7 +2849,7 @@ dependencies = [
  "gobject-sys",
  "libc",
  "system-deps 7.0.5",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3608,9 +3608,9 @@ dependencies = [
 
 [[package]]
 name = "html5ever"
-version = "0.38.0"
+version = "0.39.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1054432bae2f14e0061e33d23402fbaa67a921d319d56adc6bcf887ddad1cbc2"
+checksum = "46a1761807faccc9a19e86944bbf40610014066306f96edcdedc2fb714bcb7b8"
 dependencies = [
  "log",
  "markup5ever",
@@ -4405,7 +4405,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4800,9 +4800,9 @@ dependencies = [
 
 [[package]]
 name = "markup5ever"
-version = "0.38.0"
+version = "0.39.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8983d30f2915feeaaab2d6babdd6bc7e9ed1a00b66b5e6d74df19aa9c0e91862"
+checksum = "7122d987ec5f704ee56f6e5b41a7d93722e9aae27ae07cafa4036c4d3f9757de"
 dependencies = [
  "log",
  "tendril",
@@ -6929,7 +6929,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.11.0",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6986,7 +6986,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -9508,7 +9508,7 @@ dependencies = [
  "getrandom 0.3.4",
  "once_cell",
  "rustix 1.1.2",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -10995,7 +10995,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -11818,9 +11818,9 @@ checksum = "3ae8337f8a065cfc972643663ea4279e04e7256de865aa66fe25cec5fb912d3f"
 
 [[package]]
 name = "xml5ever"
-version = "0.38.0"
+version = "0.39.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3dc9559429edf0cd3f327cc0afd9d6b36fa8cec6d93107b7fbe64f806b5f2d9"
+checksum = "5ab627f34ff61b80d756180d556f9c68801d836d271b3b8c094504ceca69d221"
 dependencies = [
  "log",
  "markup5ever",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -91,7 +91,7 @@ harfbuzz-sys = "0.6.1"
 headers = "0.4"
 hitrace = { version = "0.1.6", features = ["api-19", "tracing-rs"] }
 hkdf = "0.12"
-html5ever = "0.38"
+html5ever = "0.39"
 http = "1.4"
 http-body-util = "0.1"
 hyper = "1.8"
@@ -112,7 +112,7 @@ libc = "0.2"
 log = "0.4.29"
 mach2 = "0.6"
 malloc_size_of_derive = "0.1"
-markup5ever = "0.38"
+markup5ever = "0.39"
 memmap2 = "0.9.10"
 mime = "0.3.13"
 mime-multipart-hyper1 = "0.10.0"
@@ -217,7 +217,7 @@ wio = "0.2"
 wr_malloc_size_of = "0.2.2"
 x25519-dalek = { version = "2.0.1", features = ["static_secrets"] }
 xi-unicode = "0.3.0"
-xml5ever = "0.38"
+xml5ever = "0.39"
 
 ############################################################################################
 ## Workspace-local dependencies

--- a/components/script/dom/element.rs
+++ b/components/script/dom/element.rs
@@ -331,6 +331,10 @@ impl Element {
         }
     }
 
+    pub(crate) fn set_had_duplicate_attributes(&self) {
+        self.ensure_rare_data().had_duplicate_attributes = true;
+    }
+
     pub(crate) fn new(
         local_name: LocalName,
         namespace: Namespace,
@@ -2743,8 +2747,13 @@ impl Element {
             }
         }
         // Step 3: If element had a duplicate-attribute parse error during tokenization, return "Not Nonceable".
-        // TODO(https://github.com/servo/servo/issues/4577 and https://github.com/whatwg/html/issues/3257):
-        // Figure out how to retrieve this information from the parser
+        if self
+            .rare_data()
+            .as_ref()
+            .is_some_and(|d| d.had_duplicate_attributes)
+        {
+            return false;
+        }
         // Step 4: Return "Nonceable".
         true
     }

--- a/components/script/dom/raredata.rs
+++ b/components/script/dom/raredata.rs
@@ -99,4 +99,8 @@ pub(crate) struct ElementRareData {
     /// > This one selection must be shared by all the content of the document (though not by nested documents),
     /// > including any editing hosts in the document.
     pub(crate) contenteditable_selection_range: MutNullableDom<Range>,
+
+    /// Whether this element had duplicate attributes during tokenization.
+    /// Used for CSP nonce validation (step 3 of "is element nonceable").
+    pub(crate) had_duplicate_attributes: bool,
 }

--- a/components/script/dom/servoparser/async_html.rs
+++ b/components/script/dom/servoparser/async_html.rs
@@ -79,6 +79,7 @@ enum ParseOperation {
         name: QualName,
         attrs: Vec<Attribute>,
         current_line: u64,
+        had_duplicate_attributes: bool,
     },
     CreateComment {
         text: String,
@@ -485,6 +486,7 @@ impl Tokenizer {
                 name,
                 attrs,
                 current_line,
+                had_duplicate_attributes,
             } => {
                 self.current_line.set(current_line);
                 let attrs = attrs
@@ -498,6 +500,7 @@ impl Tokenizer {
                     ElementCreator::ParserCreated(current_line),
                     ParsingAlgorithm::Normal,
                     &self.custom_element_reaction_stack,
+                    had_duplicate_attributes,
                     cx,
                 );
                 self.insert_node(node, Dom::from_ref(element.upcast()));
@@ -836,7 +839,7 @@ impl TreeSink for Sink {
         &self,
         name: QualName,
         html_attrs: Vec<HtmlAttribute>,
-        _flags: ElementFlags,
+        flags: ElementFlags,
     ) -> Self::Handle {
         let mut node = self.new_parse_node();
         node.qual_name = Some(name.clone());
@@ -862,6 +865,7 @@ impl TreeSink for Sink {
             name,
             attrs,
             current_line: self.current_line.get(),
+            had_duplicate_attributes: flags.had_duplicate_attributes,
         });
         node
     }

--- a/components/script/dom/servoparser/mod.rs
+++ b/components/script/dom/servoparser/mod.rs
@@ -1630,6 +1630,7 @@ impl TreeSink for Sink {
             ElementCreator::ParserCreated(self.current_line.get()),
             parsing_algorithm,
             &self.custom_element_reaction_stack,
+            flags.had_duplicate_attributes,
             cx,
         );
         Dom::from_ref(element.upcast())
@@ -1882,6 +1883,7 @@ impl TreeSink for Sink {
 }
 
 /// <https://html.spec.whatwg.org/multipage/#create-an-element-for-the-token>
+#[expect(clippy::too_many_arguments)]
 fn create_element_for_token(
     name: QualName,
     attrs: Vec<ElementAttribute>,
@@ -1889,6 +1891,7 @@ fn create_element_for_token(
     creator: ElementCreator,
     parsing_algorithm: ParsingAlgorithm,
     custom_element_reaction_stack: &CustomElementReactionStack,
+    had_duplicate_attributes: bool,
     cx: &mut js::context::JSContext,
 ) -> DomRoot<Element> {
     // Step 1. If the active speculative HTML parser is not null, then return the result
@@ -1951,6 +1954,12 @@ fn create_element_for_token(
     // Step 11. Append each attribute in the given token to element.
     for attr in attrs {
         element.set_attribute_from_parser(attr.name, attr.value, None, CanGc::from_cx(cx));
+    }
+
+    // Record if the tokenizer saw duplicate attributes on this element,
+    // used for CSP nonce validation (step 3 of "is element nonceable").
+    if had_duplicate_attributes {
+        element.set_had_duplicate_attributes();
     }
 
     // Step 12. If willExecuteScript is true:

--- a/tests/wpt/meta/content-security-policy/script-src/nonce-enforce-blocked.html.ini
+++ b/tests/wpt/meta/content-security-policy/script-src/nonce-enforce-blocked.html.ini
@@ -1,3 +1,4 @@
 [nonce-enforce-blocked.html]
+  expected: TIMEOUT
   [Unnonced scripts generate reports.]
-    expected: FAIL
+    expected: TIMEOUT

--- a/tests/wpt/mozilla/meta/MANIFEST.json
+++ b/tests/wpt/mozilla/meta/MANIFEST.json
@@ -13560,7 +13560,7 @@
     },
     "csp": {
      "nonce-external-script-malformed-blocked.html": [
-      "845a7d7aba109769add506290aac1ce42eff2699",
+      "96b8d0ddb3d3945d2991fa873de0afb299b0e3b8",
       [
        null,
        {}

--- a/tests/wpt/mozilla/tests/mozilla/csp/nonce-external-script-malformed-blocked.html
+++ b/tests/wpt/mozilla/tests/mozilla/csp/nonce-external-script-malformed-blocked.html
@@ -8,12 +8,11 @@
 
     The remaining failures are blocked by required changes in the HTML parser:
     - SVG script support (https://github.com/servo/html5ever/issues/118)
-    - Duplicate attribute detection (https://github.com/servo/html5ever/pull/695)
 -->
 <script nonce="abc">
     var t = async_test("Unnonced scripts generate reports.");
     var events = 0;
-    var firstLine = 51;
+    var firstLine = 50;
     var expectations = {}
     expectations[firstLine] = true;
     expectations[firstLine + 3] = true;
@@ -22,14 +21,14 @@
     expectations[firstLine + 12] = true;
     expectations[firstLine + 15] = true;
     expectations[firstLine + 18] = true;
-    // expectations[firstLine + 21] = true;
-    // expectations[firstLine + 24] = true;
+    expectations[firstLine + 21] = true;
+    expectations[firstLine + 24] = true;
     // expectations[firstLine + 28] = true;
     expectations["/_mozilla/mozilla/csp/support/nonce-should-be-blocked.js?1"] = true;
     expectations["/_mozilla/mozilla/csp/support/nonce-should-be-blocked.js?2"] = true;
     expectations["/_mozilla/mozilla/csp/support/nonce-should-be-blocked.js?3"] = true;
     expectations["/_mozilla/mozilla/csp/support/nonce-should-be-blocked.js?4"] = true;
-    // expectations["/_mozilla/mozilla/csp/support/nonce-should-be-blocked.js?5"] = true;
+    expectations["/_mozilla/mozilla/csp/support/nonce-should-be-blocked.js?5"] = true;
     expectations["/_mozilla/mozilla/csp/support/nonce-should-be-blocked.js?6"] = true;
     expectations["/_mozilla/mozilla/csp/support/nonce-should-be-blocked.js?7"] = true;
 
@@ -69,12 +68,12 @@
 <script attribute=value<script nonce="abc">
     t.unreached_func("'value<script', no execution.")();
 </script>
-<!-- Blocked on html5ever duplicate-attribute detection (https://github.com/servo/html5ever/pull/695) <script attribute attribute nonce="abc">
+<script attribute attribute nonce="abc">
     t.unreached_func("Duplicate attribute, no execution.")();
 </script>
 <script attribute attribute=<style nonce="abc">
     t.unreached_func("2# Duplicate attribute, no execution.")();
-</script> -->
+</script>
 <!-- Blocked on html5ever SVG script support (https://github.com/servo/html5ever/issues/118) <svg xmlns="http://www.w3.org/2000/svg">
 <script attribute attribute nonce="abc">
     t.unreached_func("Duplicate attribute in SVG, no execution.")();
@@ -84,6 +83,6 @@
 <script src="support/nonce-should-be-blocked.js?2" attribute=<script nonce="abc"></script>
 <script src="support/nonce-should-be-blocked.js?3" <style nonce="abc"></script>
 <script src="support/nonce-should-be-blocked.js?4" attribute=<style nonce="abc"></script>
-<!-- Blocked on html5ever duplicate-attribute detection (https://github.com/servo/html5ever/pull/695) <script src="support/nonce-should-be-blocked.js?5" attribute attribute nonce="abc"></script> -->
+<script src="support/nonce-should-be-blocked.js?5" attribute attribute nonce="abc"></script>
 <script src="support/nonce-should-be-blocked.js?6" attribute<script nonce="abc"></script>
 <script src="support/nonce-should-be-blocked.js?7" attribute=value<script nonce="abc"></script>


### PR DESCRIPTION
Propagate the had_duplicate_attributes flag from html5ever's
ElementFlags through to the Element struct, enabling step 3 of the
CSP "is element nonceable" algorithm. Elements with duplicate
attributes are now correctly marked as "Not Nonceable", preventing
scripts with duplicate attributes from bypassing CSP nonce checks.

Testing: We still need https://github.com/servo/html5ever/issues/118 to fully pass the `content-security-policy/script-src/nonce-enforce-blocked.html` wpt test. But I was able to uncomment some of the remaining tests on `mozilla/csp/nonce-external-script-malformed-blocked.html`

