### PR TITLE
script: Pass `&mut JSContext` to `children_changed` and `adopting_steps`

### DIFF
--- a/components/script/dom/characterdata.rs
+++ b/components/script/dom/characterdata.rs
@@ -84,7 +84,11 @@ impl CharacterData {
         self.content_changed();
     }
 
+    #[expect(unsafe_code)]
     fn content_changed(&self) {
+        let mut cx = unsafe { script_bindings::script_runtime::temp_cx() };
+        let cx = &mut cx;
+
         let node = self.upcast::<Node>();
         node.dirty(NodeDamage::Other);
 
@@ -94,7 +98,7 @@ impl CharacterData {
         if self.is::<Text>() {
             if let Some(parent_node) = node.GetParentNode() {
                 let mutation = ChildrenMutation::ChangeText;
-                vtable_for(&parent_node).children_changed(&mutation, CanGc::note());
+                vtable_for(&parent_node).children_changed(cx, &mutation);
             }
         }
     }

--- a/components/script/dom/characterdata.rs
+++ b/components/script/dom/characterdata.rs
@@ -273,9 +273,8 @@ impl CharacterDataMethods<crate::DomTypeHolder> for CharacterData {
     }
 
     /// <https://dom.spec.whatwg.org/#dom-childnode-remove>
-    fn Remove(&self, can_gc: CanGc) {
-        let node = self.upcast::<Node>();
-        node.remove_self(can_gc);
+    fn Remove(&self, cx: &mut JSContext) {
+        self.upcast::<Node>().remove_self(cx);
     }
 
     /// <https://dom.spec.whatwg.org/#dom-nondocumenttypechildnode-previouselementsibling>

--- a/components/script/dom/characterdata.rs
+++ b/components/script/dom/characterdata.rs
@@ -6,6 +6,7 @@
 use std::cell::LazyCell;
 
 use dom_struct::dom_struct;
+use js::context::JSContext;
 use script_bindings::codegen::InheritTypes::{CharacterDataTypeId, NodeTypeId, TextTypeId};
 
 use crate::dom::bindings::cell::{DomRefCell, Ref};
@@ -267,8 +268,8 @@ impl CharacterDataMethods<crate::DomTypeHolder> for CharacterData {
     }
 
     /// <https://dom.spec.whatwg.org/#dom-childnode-replacewith>
-    fn ReplaceWith(&self, nodes: Vec<NodeOrString>, can_gc: CanGc) -> ErrorResult {
-        self.upcast::<Node>().replace_with(nodes, can_gc)
+    fn ReplaceWith(&self, cx: &mut JSContext, nodes: Vec<NodeOrString>) -> ErrorResult {
+        self.upcast::<Node>().replace_with(cx, nodes)
     }
 
     /// <https://dom.spec.whatwg.org/#dom-childnode-remove>

--- a/components/script/dom/characterdata.rs
+++ b/components/script/dom/characterdata.rs
@@ -87,6 +87,7 @@ impl CharacterData {
 
     #[expect(unsafe_code)]
     fn content_changed(&self) {
+        // TODO https://github.com/servo/servo/issues/43234
         let mut cx = unsafe { script_bindings::script_runtime::temp_cx() };
         let cx = &mut cx;
 

--- a/components/script/dom/document.rs
+++ b/components/script/dom/document.rs
@@ -5909,7 +5909,11 @@ impl DocumentMethods<crate::DomTypeHolder> for Document {
     }
 
     /// <https://html.spec.whatwg.org/multipage/#dom-document-body>
-    fn SetBody(&self, new_body: Option<&HTMLElement>, can_gc: CanGc) -> ErrorResult {
+    fn SetBody(
+        &self,
+        cx: &mut js::context::JSContext,
+        new_body: Option<&HTMLElement>,
+    ) -> ErrorResult {
         // Step 1. If the new value is not a body or frameset element, then throw a "HierarchyRequestError" DOMException.
         let new_body = match new_body {
             Some(new_body) => new_body,
@@ -5936,7 +5940,7 @@ impl DocumentMethods<crate::DomTypeHolder> for Document {
             // then replace the body element with the new value within the body element's parent and return.
             (Some(ref root), Some(child)) => {
                 let root = root.upcast::<Node>();
-                root.ReplaceChild(new_body.upcast(), child.upcast(), can_gc)
+                root.ReplaceChild(cx, new_body.upcast(), child.upcast())
                     .map(|_| ())
             },
 
@@ -5947,7 +5951,8 @@ impl DocumentMethods<crate::DomTypeHolder> for Document {
             // Append the new value to the document element.
             (Some(ref root), &None) => {
                 let root = root.upcast::<Node>();
-                root.AppendChild(new_body.upcast(), can_gc).map(|_| ())
+                root.AppendChild(new_body.upcast(), CanGc::from_cx(cx))
+                    .map(|_| ())
             },
         }
     }

--- a/components/script/dom/document.rs
+++ b/components/script/dom/document.rs
@@ -5691,7 +5691,7 @@ impl DocumentMethods<crate::DomTypeHolder> for Document {
     }
 
     /// <https://dom.spec.whatwg.org/#dom-document-adoptnode>
-    fn AdoptNode(&self, node: &Node, can_gc: CanGc) -> Fallible<DomRoot<Node>> {
+    fn AdoptNode(&self, cx: &mut js::context::JSContext, node: &Node) -> Fallible<DomRoot<Node>> {
         // Step 1.
         if node.is::<Document>() {
             return Err(Error::NotSupported(None));
@@ -5703,7 +5703,7 @@ impl DocumentMethods<crate::DomTypeHolder> for Document {
         }
 
         // Step 3.
-        Node::adopt(node, self, can_gc);
+        Node::adopt(cx, node, self);
 
         // Step 4.
         Ok(DomRoot::from_ref(node))

--- a/components/script/dom/documenttype.rs
+++ b/components/script/dom/documenttype.rs
@@ -3,6 +3,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 use dom_struct::dom_struct;
+use js::context::JSContext;
 
 use crate::dom::bindings::codegen::Bindings::DocumentTypeBinding::DocumentTypeMethods;
 use crate::dom::bindings::codegen::UnionTypes::NodeOrString;
@@ -97,8 +98,8 @@ impl DocumentTypeMethods<crate::DomTypeHolder> for DocumentType {
     }
 
     /// <https://dom.spec.whatwg.org/#dom-childnode-replacewith>
-    fn ReplaceWith(&self, nodes: Vec<NodeOrString>, can_gc: CanGc) -> ErrorResult {
-        self.upcast::<Node>().replace_with(nodes, can_gc)
+    fn ReplaceWith(&self, cx: &mut JSContext, nodes: Vec<NodeOrString>) -> ErrorResult {
+        self.upcast::<Node>().replace_with(cx, nodes)
     }
 
     /// <https://dom.spec.whatwg.org/#dom-childnode-remove>

--- a/components/script/dom/documenttype.rs
+++ b/components/script/dom/documenttype.rs
@@ -103,7 +103,7 @@ impl DocumentTypeMethods<crate::DomTypeHolder> for DocumentType {
     }
 
     /// <https://dom.spec.whatwg.org/#dom-childnode-remove>
-    fn Remove(&self, can_gc: CanGc) {
-        self.upcast::<Node>().remove_self(can_gc);
+    fn Remove(&self, cx: &mut JSContext) {
+        self.upcast::<Node>().remove_self(cx);
     }
 }

--- a/components/script/dom/element.rs
+++ b/components/script/dom/element.rs
@@ -3870,7 +3870,7 @@ impl ElementMethods<crate::DomTypeHolder> for Element {
         // fragment parsing algorithm steps given parent and compliantString.
         let frag = parent.parse_fragment(value, cx)?;
         // Step 7: Replace this with fragment within this's parent.
-        context_parent.ReplaceChild(frag.upcast(), context_node, CanGc::from_cx(cx))?;
+        context_parent.ReplaceChild(cx, frag.upcast(), context_node)?;
         Ok(())
     }
 
@@ -3954,8 +3954,8 @@ impl ElementMethods<crate::DomTypeHolder> for Element {
     }
 
     /// <https://dom.spec.whatwg.org/#dom-childnode-replacewith>
-    fn ReplaceWith(&self, nodes: Vec<NodeOrString>, can_gc: CanGc) -> ErrorResult {
-        self.upcast::<Node>().replace_with(nodes, can_gc)
+    fn ReplaceWith(&self, cx: &mut JSContext, nodes: Vec<NodeOrString>) -> ErrorResult {
+        self.upcast::<Node>().replace_with(cx, nodes)
     }
 
     /// <https://dom.spec.whatwg.org/#dom-childnode-remove>

--- a/components/script/dom/element.rs
+++ b/components/script/dom/element.rs
@@ -616,6 +616,7 @@ impl Element {
         slot_assignment_mode: SlotAssignmentMode,
         _can_gc: CanGc,
     ) -> Fallible<DomRoot<ShadowRoot>> {
+        // TODO https://github.com/servo/servo/issues/43241
         let mut cx = unsafe { script_bindings::script_runtime::temp_cx() };
         let cx = &mut cx;
 

--- a/components/script/dom/element.rs
+++ b/components/script/dom/element.rs
@@ -4778,9 +4778,9 @@ impl VirtualMethods for Element {
         doc.decrement_dom_count();
     }
 
-    fn children_changed(&self, mutation: &ChildrenMutation, can_gc: CanGc) {
+    fn children_changed(&self, cx: &mut JSContext, mutation: &ChildrenMutation) {
         if let Some(s) = self.super_type() {
-            s.children_changed(mutation, can_gc);
+            s.children_changed(cx, mutation);
         }
 
         let flags = self.get_selector_flags();

--- a/components/script/dom/element.rs
+++ b/components/script/dom/element.rs
@@ -605,6 +605,7 @@ impl Element {
 
     /// <https://dom.spec.whatwg.org/#dom-element-attachshadow>
     #[allow(clippy::too_many_arguments)]
+    #[expect(unsafe_code)]
     pub(crate) fn attach_shadow(
         &self,
         is_ua_widget: IsUserAgentWidget,
@@ -613,8 +614,11 @@ impl Element {
         serializable: bool,
         delegates_focus: bool,
         slot_assignment_mode: SlotAssignmentMode,
-        can_gc: CanGc,
+        _can_gc: CanGc,
     ) -> Fallible<DomRoot<ShadowRoot>> {
+        let mut cx = unsafe { script_bindings::script_runtime::temp_cx() };
+        let cx = &mut cx;
+
         // Step 1. If element’s namespace is not the HTML namespace,
         // then throw a "NotSupportedError" DOMException.
         if self.namespace != ns!(html) {
@@ -670,7 +674,7 @@ impl Element {
 
             // Step 4.3.1. Remove all of currentShadowRoot’s children, in tree order.
             for child in current_shadow_root.upcast::<Node>().children() {
-                child.remove_self(can_gc);
+                child.remove_self(cx);
             }
 
             // Step 4.3.2. Set currentShadowRoot’s declarative to false.
@@ -693,7 +697,7 @@ impl Element {
             slot_assignment_mode,
             clonable,
             is_ua_widget,
-            can_gc,
+            CanGc::from_cx(cx),
         );
 
         // This is not in the specification, but this is where we ensure that the
@@ -727,7 +731,7 @@ impl Element {
             .set_containing_shadow_root(Some(&shadow_root));
 
         let bind_context = BindContext::new(self.upcast(), IsShadowTree::Yes);
-        shadow_root.bind_to_tree(&bind_context, can_gc);
+        shadow_root.bind_to_tree(&bind_context, CanGc::from_cx(cx));
 
         node.dirty(NodeDamage::Other);
 
@@ -3959,8 +3963,8 @@ impl ElementMethods<crate::DomTypeHolder> for Element {
     }
 
     /// <https://dom.spec.whatwg.org/#dom-childnode-remove>
-    fn Remove(&self, can_gc: CanGc) {
-        self.upcast::<Node>().remove_self(can_gc);
+    fn Remove(&self, cx: &mut JSContext) {
+        self.upcast::<Node>().remove_self(cx);
     }
 
     /// <https://dom.spec.whatwg.org/#dom-element-matches>

--- a/components/script/dom/element.rs
+++ b/components/script/dom/element.rs
@@ -4809,8 +4809,8 @@ impl VirtualMethods for Element {
         }
     }
 
-    fn adopting_steps(&self, old_doc: &Document, can_gc: CanGc) {
-        self.super_type().unwrap().adopting_steps(old_doc, can_gc);
+    fn adopting_steps(&self, cx: &mut JSContext, old_doc: &Document) {
+        self.super_type().unwrap().adopting_steps(cx, old_doc);
 
         if self.owner_document().is_html_document() != old_doc.is_html_document() {
             self.tag_name.clear();

--- a/components/script/dom/execcommand/commands/delete.rs
+++ b/components/script/dom/execcommand/commands/delete.rs
@@ -64,7 +64,7 @@ impl BaseCommand for DeleteCommand {
             if offset == 0 {
                 if let Some(sibling) = node.GetPreviousSibling() {
                     if sibling.is_editable() && sibling.is_invisible() {
-                        sibling.remove_self(CanGc::from_cx(cx));
+                        sibling.remove_self(cx);
                         continue;
                     }
                 }
@@ -74,7 +74,7 @@ impl BaseCommand for DeleteCommand {
             if offset > 0 {
                 if let Some(child) = node.children().nth(offset as usize - 1) {
                     if child.is_editable() && child.is_invisible() {
-                        child.remove_self(CanGc::from_cx(cx));
+                        child.remove_self(cx);
                         offset -= 1;
                         continue;
                     }
@@ -208,7 +208,7 @@ impl BaseCommand for DeleteCommand {
             );
             if let Some(child) = start_node.children().nth(start_offset as usize - 1) {
                 if child.is_editable() && child.is_invisible() {
-                    child.remove_self(CanGc::from_cx(cx));
+                    child.remove_self(cx);
                     start_offset -= 1;
                     continue;
                 }
@@ -299,7 +299,7 @@ impl BaseCommand for DeleteCommand {
             // Step 16.1. If start node's child with index start offset minus one
             // is editable and invisible, remove it from start node, then subtract one from start offset.
             if child.is_editable() && child.is_invisible() {
-                child.remove_self(CanGc::from_cx(cx));
+                child.remove_self(cx);
                 start_offset -= 1;
             } else {
                 // Step 16.2. Otherwise, set start node to its child with index start offset minus one,

--- a/components/script/dom/execcommand/contenteditable.rs
+++ b/components/script/dom/execcommand/contenteditable.rs
@@ -626,7 +626,7 @@ pub(crate) fn split_the_parent<'a>(cx: &mut js::context::JSContext, node_list: &
         if let Some(first_of_original) = original_parent.children().next() {
             if first_of_original.is::<HTMLBRElement>() {
                 assert!(first_of_original.has_parent());
-                first_of_original.remove_self(CanGc::from_cx(cx));
+                first_of_original.remove_self(cx);
             }
         }
     }
@@ -634,7 +634,7 @@ pub(crate) fn split_the_parent<'a>(cx: &mut js::context::JSContext, node_list: &
     if original_parent.children_count() == 0 {
         // Step 11.1. Remove original parent from its parent.
         assert!(original_parent.has_parent());
-        original_parent.remove_self(CanGc::from_cx(cx));
+        original_parent.remove_self(cx);
         // Step 11.2. If precedes line break is true, and the last member of node list does not precede a line break,
         // call createElement("br") on the context object and insert the result immediately after the last member of node list.
         if precedes_line_break {
@@ -1244,7 +1244,7 @@ impl NodeExecCommandSupport for Node {
                 .is_some_and(|br| br.is_extraneous_line_break())
         {
             assert!(ref_.has_parent());
-            ref_.remove_self(CanGc::from_cx(cx));
+            ref_.remove_self(cx);
         }
     }
 
@@ -1291,7 +1291,7 @@ impl NodeExecCommandSupport for Node {
             }
             // Step 4.2. Remove ref from its parent.
             assert!(ref_.has_parent());
-            ref_.remove_self(CanGc::from_cx(cx));
+            ref_.remove_self(cx);
         }
     }
 
@@ -1302,7 +1302,7 @@ impl NodeExecCommandSupport for Node {
         // > If it has no children, instead remove it from its parent.
         if self.children_count() == 0 {
             assert!(self.has_parent());
-            self.remove_self(CanGc::from_cx(cx));
+            self.remove_self(cx);
         } else {
             rooted_vec!(let children <- self.children().map(|child| DomRoot::as_traced(&child)));
             split_the_parent(cx, children.r());
@@ -1798,7 +1798,7 @@ impl SelectionExecCommandSupport for Selection {
             let parent = node.GetParentNode().expect("Must always have a parent");
             // Step 25.2. Remove node from parent.
             assert!(node.has_parent());
-            node.remove_self(CanGc::from_cx(cx));
+            node.remove_self(cx);
             // Step 25.3. If the block node of parent has no visible children, and parent is editable or an editing host,
             // call createElement("br") on the context object and append the result as the last child of parent.
             if parent
@@ -1823,7 +1823,7 @@ impl SelectionExecCommandSupport for Selection {
                         let grand_parent =
                             parent.GetParentNode().expect("Must always have a parent");
                         assert!(parent.has_parent());
-                        parent.remove_self(CanGc::from_cx(cx));
+                        parent.remove_self(cx);
                         parent = grand_parent;
                         continue;
                     }
@@ -1896,7 +1896,7 @@ impl SelectionExecCommandSupport for Selection {
             };
             if child.is_collapsed_block_prop() {
                 assert!(child.has_parent());
-                child.remove_self(CanGc::from_cx(cx));
+                child.remove_self(cx);
             }
         }
 
@@ -1938,7 +1938,7 @@ impl SelectionExecCommandSupport for Selection {
                         if let Some(parent) = end_block.GetParentNode() {
                             if parent.children_count() == 1 {
                                 assert!(end_block.has_parent());
-                                end_block.remove_self(CanGc::from_cx(cx));
+                                end_block.remove_self(cx);
                                 end_block = parent;
                                 continue;
                             }
@@ -1977,7 +1977,7 @@ impl SelectionExecCommandSupport for Selection {
                 // Step 32.4.3. If end block is editable, remove it from its parent.
                 if end_block.is_editable() {
                     assert!(end_block.has_parent());
-                    end_block.remove_self(CanGc::from_cx(cx));
+                    end_block.remove_self(cx);
                 }
                 // Step 32.4.4. Restore states and values from overrides.
                 //
@@ -2041,7 +2041,7 @@ impl SelectionExecCommandSupport for Selection {
                 if let Some(previous_of_first) = first.GetPreviousSibling() {
                     if previous_of_first.is_editable() && previous_of_first.is::<HTMLBRElement>() {
                         assert!(previous_of_first.has_parent());
-                        previous_of_first.remove_self(CanGc::from_cx(cx));
+                        previous_of_first.remove_self(cx);
                     }
                 }
             }
@@ -2076,7 +2076,7 @@ impl SelectionExecCommandSupport for Selection {
                 if let Some(last) = start_block.children().last() {
                     if last.is::<HTMLBRElement>() {
                         assert!(last.has_parent());
-                        last.remove_self(CanGc::from_cx(cx));
+                        last.remove_self(cx);
                     }
                 }
             }
@@ -2136,7 +2136,7 @@ impl SelectionExecCommandSupport for Selection {
                 if let Some(last) = start_block.children().last() {
                     if last.is::<HTMLBRElement>() {
                         assert!(last.has_parent());
-                        last.remove_self(CanGc::from_cx(cx));
+                        last.remove_self(cx);
                     }
                 }
             }
@@ -2166,7 +2166,7 @@ impl SelectionExecCommandSupport for Selection {
                 if end_block.children_count() == 0 {
                     if let Some(parent) = end_block.GetParentNode() {
                         assert!(end_block.has_parent());
-                        end_block.remove_self(CanGc::from_cx(cx));
+                        end_block.remove_self(cx);
                         end_block = parent;
                         continue;
                     }

--- a/components/script/dom/html/htmldetailselement.rs
+++ b/components/script/dom/html/htmldetailselement.rs
@@ -8,6 +8,7 @@ use std::collections::hash_map::Entry;
 
 use dom_struct::dom_struct;
 use html5ever::{LocalName, Prefix, QualName, local_name, ns};
+use js::context::JSContext;
 use js::rust::HandleObject;
 use script_bindings::domstring::DOMString;
 use style::selector_parser::PseudoElement;
@@ -490,12 +491,10 @@ impl VirtualMethods for HTMLDetailsElement {
         }
     }
 
-    fn children_changed(&self, mutation: &ChildrenMutation, can_gc: CanGc) {
-        self.super_type()
-            .unwrap()
-            .children_changed(mutation, can_gc);
+    fn children_changed(&self, cx: &mut JSContext, mutation: &ChildrenMutation) {
+        self.super_type().unwrap().children_changed(cx, mutation);
 
-        self.update_shadow_tree_contents(can_gc);
+        self.update_shadow_tree_contents(CanGc::from_cx(cx));
     }
 
     /// <https://html.spec.whatwg.org/multipage/#the-details-element:html-element-insertion-steps>

--- a/components/script/dom/html/htmlelement.rs
+++ b/components/script/dom/html/htmlelement.rs
@@ -608,13 +608,13 @@ impl HTMLElementMethods<crate::DomTypeHolder> for HTMLElement {
         // the next text node given next's previous sibling.
         if let Some(next_sibling) = next {
             if let Some(node) = next_sibling.GetPreviousSibling() {
-                Self::merge_with_the_next_text_node(node, CanGc::from_cx(cx));
+                Self::merge_with_the_next_text_node(cx, node);
             }
         }
 
         // Step 8: If previous is a Text node, then merge with the next text node given previous.
         if let Some(previous) = previous {
-            Self::merge_with_the_next_text_node(previous, CanGc::from_cx(cx))
+            Self::merge_with_the_next_text_node(cx, previous)
         }
 
         Ok(())
@@ -1089,7 +1089,7 @@ impl HTMLElement {
     /// node.
     ///
     /// <https://html.spec.whatwg.org/multipage/#merge-with-the-next-text-node>
-    fn merge_with_the_next_text_node(node: DomRoot<Node>, can_gc: CanGc) {
+    fn merge_with_the_next_text_node(cx: &mut JSContext, node: DomRoot<Node>) {
         // Make sure node is a Text node
         if !node.is::<Text>() {
             return;
@@ -1113,7 +1113,7 @@ impl HTMLElement {
             .expect("Got chars from Text");
 
         // Step 4:Remove next.
-        next.remove_self(can_gc);
+        next.remove_self(cx);
     }
 
     /// <https://html.spec.whatwg.org/multipage/#keyboard-shortcuts-processing-model>

--- a/components/script/dom/html/htmlelement.rs
+++ b/components/script/dom/html/htmlelement.rs
@@ -8,6 +8,7 @@ use std::rc::Rc;
 
 use dom_struct::dom_struct;
 use html5ever::{LocalName, Prefix, QualName, local_name, ns};
+use js::context::JSContext;
 use js::rust::HandleObject;
 use layout_api::{QueryMsg, ScrollContainerQueryFlags, ScrollContainerResponse};
 use script_bindings::codegen::GenericBindings::DocumentBinding::DocumentMethods;
@@ -567,7 +568,7 @@ impl HTMLElementMethods<crate::DomTypeHolder> for HTMLElement {
     }
 
     /// <https://html.spec.whatwg.org/multipage/#the-innertext-idl-attribute:dom-outertext-2>
-    fn SetOuterText(&self, input: DOMString, can_gc: CanGc) -> Fallible<()> {
+    fn SetOuterText(&self, cx: &mut JSContext, input: DOMString) -> Fallible<()> {
         // Step 1: If this's parent is null, then throw a "NoModificationAllowedError" DOMException.
         let Some(parent) = self.upcast::<Node>().GetParentNode() else {
             return Err(Error::NoModificationAllowed(None));
@@ -584,32 +585,36 @@ impl HTMLElementMethods<crate::DomTypeHolder> for HTMLElement {
 
         // Step 4: Let fragment be the rendered text fragment for the given value given this's node
         // document.
-        let fragment = self.rendered_text_fragment(input, can_gc);
+        let fragment = self.rendered_text_fragment(input, CanGc::from_cx(cx));
 
         // Step 5: If fragment has no children, then append a new Text node whose data is the empty
         // string and node document is this's node document to fragment.
         if fragment.upcast::<Node>().children_count() == 0 {
-            let text_node = Text::new(DOMString::from("".to_owned()), &document, can_gc);
+            let text_node = Text::new(
+                DOMString::from("".to_owned()),
+                &document,
+                CanGc::from_cx(cx),
+            );
 
             fragment
                 .upcast::<Node>()
-                .AppendChild(text_node.upcast(), can_gc)?;
+                .AppendChild(text_node.upcast(), CanGc::from_cx(cx))?;
         }
 
         // Step 6: Replace this with fragment within this's parent.
-        parent.ReplaceChild(fragment.upcast(), node, can_gc)?;
+        parent.ReplaceChild(cx, fragment.upcast(), node)?;
 
         // Step 7: If next is non-null and next's previous sibling is a Text node, then merge with
         // the next text node given next's previous sibling.
         if let Some(next_sibling) = next {
             if let Some(node) = next_sibling.GetPreviousSibling() {
-                Self::merge_with_the_next_text_node(node, can_gc);
+                Self::merge_with_the_next_text_node(node, CanGc::from_cx(cx));
             }
         }
 
         // Step 8: If previous is a Text node, then merge with the next text node given previous.
         if let Some(previous) = previous {
-            Self::merge_with_the_next_text_node(previous, can_gc)
+            Self::merge_with_the_next_text_node(previous, CanGc::from_cx(cx))
         }
 
         Ok(())

--- a/components/script/dom/html/htmlimageelement.rs
+++ b/components/script/dom/html/htmlimageelement.rs
@@ -1995,13 +1995,8 @@ impl VirtualMethods for HTMLImageElement {
         Some(self.upcast::<HTMLElement>() as &dyn VirtualMethods)
     }
 
-    #[expect(unsafe_code)]
-    fn adopting_steps(&self, old_doc: &Document, _can_gc: CanGc) {
-        let mut cx = unsafe { temp_cx() };
-        let cx = &mut cx;
-        self.super_type()
-            .unwrap()
-            .adopting_steps(old_doc, CanGc::from_cx(cx));
+    fn adopting_steps(&self, cx: &mut JSContext, old_doc: &Document) {
+        self.super_type().unwrap().adopting_steps(cx, old_doc);
         self.update_the_image_data(cx);
     }
 

--- a/components/script/dom/html/htmlmediaelement.rs
+++ b/components/script/dom/html/htmlmediaelement.rs
@@ -3427,8 +3427,8 @@ impl VirtualMethods for HTMLMediaElement {
         }
     }
 
-    fn adopting_steps(&self, old_doc: &Document, can_gc: CanGc) {
-        self.super_type().unwrap().adopting_steps(old_doc, can_gc);
+    fn adopting_steps(&self, cx: &mut JSContext, old_doc: &Document) {
+        self.super_type().unwrap().adopting_steps(cx, old_doc);
 
         // Note that media control id should be adopting between documents so "privileged"
         // document.servoGetMediaControls(id) API is keeping access to the whitelist of media

--- a/components/script/dom/html/htmlmeterelement.rs
+++ b/components/script/dom/html/htmlmeterelement.rs
@@ -7,6 +7,7 @@ use std::ops::{Add, Div};
 
 use dom_struct::dom_struct;
 use html5ever::{LocalName, Prefix, QualName, local_name, ns};
+use js::context::JSContext;
 use js::rust::HandleObject;
 use stylo_dom::ElementState;
 
@@ -328,12 +329,10 @@ impl VirtualMethods for HTMLMeterElement {
         }
     }
 
-    fn children_changed(&self, mutation: &ChildrenMutation, can_gc: CanGc) {
-        self.super_type()
-            .unwrap()
-            .children_changed(mutation, can_gc);
+    fn children_changed(&self, cx: &mut JSContext, mutation: &ChildrenMutation) {
+        self.super_type().unwrap().children_changed(cx, mutation);
 
-        self.update_state(can_gc);
+        self.update_state(CanGc::from_cx(cx));
     }
 
     fn bind_to_tree(&self, context: &BindContext, can_gc: CanGc) {

--- a/components/script/dom/html/htmloptionelement.rs
+++ b/components/script/dom/html/htmloptionelement.rs
@@ -475,9 +475,9 @@ impl VirtualMethods for HTMLOptionElement {
         }
     }
 
-    fn children_changed(&self, mutation: &ChildrenMutation, can_gc: CanGc) {
+    fn children_changed(&self, cx: &mut JSContext, mutation: &ChildrenMutation) {
         if let Some(super_type) = self.super_type() {
-            super_type.children_changed(mutation, can_gc);
+            super_type.children_changed(cx, mutation);
         }
 
         // Changing the descendants of a selected option can change it's displayed label
@@ -491,7 +491,7 @@ impl VirtualMethods for HTMLOptionElement {
                     .selected_option()
                     .is_some_and(|selected_option| self == &*selected_option)
                 {
-                    owner_select.update_shadow_tree(can_gc);
+                    owner_select.update_shadow_tree(CanGc::from_cx(cx));
                 }
             }
         }

--- a/components/script/dom/html/htmloptionscollection.rs
+++ b/components/script/dom/html/htmloptionscollection.rs
@@ -134,7 +134,7 @@ impl HTMLOptionsCollectionMethods<crate::DomTypeHolder> for HTMLOptionsCollectio
             }
         } else {
             // Step 1
-            self.Remove(index as i32);
+            self.Remove(cx, index as i32);
             Ok(())
         }
     }
@@ -169,7 +169,7 @@ impl HTMLOptionsCollectionMethods<crate::DomTypeHolder> for HTMLOptionsCollectio
                 // Step 3.1. Let n be current − value.
                 // Step 3.2 Remove the last n nodes in the collection from their parent nodes.
                 for index in (length..current).rev() {
-                    self.Remove(index as i32)
+                    self.Remove(cx, index as i32)
                 }
             },
             _ => {},
@@ -240,9 +240,9 @@ impl HTMLOptionsCollectionMethods<crate::DomTypeHolder> for HTMLOptionsCollectio
     }
 
     /// <https://html.spec.whatwg.org/multipage/#dom-htmloptionscollection-remove>
-    fn Remove(&self, index: i32) {
+    fn Remove(&self, cx: &mut JSContext, index: i32) {
         if let Some(element) = self.upcast().IndexedGetter(index as u32) {
-            element.Remove(CanGc::note());
+            element.Remove(cx);
         }
     }
 

--- a/components/script/dom/html/htmloptionscollection.rs
+++ b/components/script/dom/html/htmloptionscollection.rs
@@ -130,8 +130,7 @@ impl HTMLOptionsCollectionMethods<crate::DomTypeHolder> for HTMLOptionsCollectio
                 let child = self.upcast().IndexedGetter(index).unwrap();
                 let child_node = child.upcast::<Node>();
 
-                root.ReplaceChild(node, child_node, CanGc::from_cx(cx))
-                    .map(|_| ())
+                root.ReplaceChild(cx, node, child_node).map(|_| ())
             }
         } else {
             // Step 1

--- a/components/script/dom/html/htmlscriptelement.rs
+++ b/components/script/dom/html/htmlscriptelement.rs
@@ -1225,9 +1225,9 @@ impl VirtualMethods for HTMLScriptElement {
     }
 
     /// <https://html.spec.whatwg.org/multipage/#script-processing-model:the-script-element-26>
-    fn children_changed(&self, mutation: &ChildrenMutation, can_gc: CanGc) {
+    fn children_changed(&self, cx: &mut JSContext, mutation: &ChildrenMutation) {
         if let Some(s) = self.super_type() {
-            s.children_changed(mutation, can_gc);
+            s.children_changed(cx, mutation);
         }
 
         if self.upcast::<Node>().is_connected() && !self.parser_inserted.get() {

--- a/components/script/dom/html/htmlselectelement.rs
+++ b/components/script/dom/html/htmlselectelement.rs
@@ -788,12 +788,12 @@ impl VirtualMethods for HTMLSelectElement {
             .hide_embedder_control(self.upcast());
     }
 
-    fn children_changed(&self, mutation: &ChildrenMutation, can_gc: CanGc) {
+    fn children_changed(&self, cx: &mut JSContext, mutation: &ChildrenMutation) {
         if let Some(s) = self.super_type() {
-            s.children_changed(mutation, can_gc);
+            s.children_changed(cx, mutation);
         }
 
-        self.update_shadow_tree(can_gc);
+        self.update_shadow_tree(CanGc::from_cx(cx));
     }
 
     fn parse_plain_attribute(&self, local_name: &LocalName, value: DOMString) -> AttrValue {

--- a/components/script/dom/html/htmlselectelement.rs
+++ b/components/script/dom/html/htmlselectelement.rs
@@ -611,13 +611,13 @@ impl HTMLSelectElementMethods<crate::DomTypeHolder> for HTMLSelectElement {
     }
 
     /// <https://html.spec.whatwg.org/multipage/#dom-select-remove>
-    fn Remove_(&self, index: i32) {
-        self.Options().Remove(index)
+    fn Remove_(&self, cx: &mut JSContext, index: i32) {
+        self.Options().Remove(cx, index)
     }
 
     /// <https://html.spec.whatwg.org/multipage/#dom-select-remove>
-    fn Remove(&self) {
-        self.upcast::<Element>().Remove(CanGc::note())
+    fn Remove(&self, cx: &mut JSContext) {
+        self.upcast::<Element>().Remove(cx)
     }
 
     /// <https://html.spec.whatwg.org/multipage/#dom-select-value>

--- a/components/script/dom/html/htmlstyleelement.rs
+++ b/components/script/dom/html/htmlstyleelement.rs
@@ -7,6 +7,7 @@ use std::sync::atomic::{AtomicBool, Ordering};
 
 use dom_struct::dom_struct;
 use html5ever::{LocalName, Prefix, local_name};
+use js::context::JSContext;
 use js::rust::HandleObject;
 use net_traits::ReferrerPolicy;
 use script_bindings::root::Dom;
@@ -317,10 +318,8 @@ impl VirtualMethods for HTMLStyleElement {
         Some(self.upcast::<HTMLElement>() as &dyn VirtualMethods)
     }
 
-    fn children_changed(&self, mutation: &ChildrenMutation, can_gc: CanGc) {
-        self.super_type()
-            .unwrap()
-            .children_changed(mutation, can_gc);
+    fn children_changed(&self, cx: &mut JSContext, mutation: &ChildrenMutation) {
+        self.super_type().unwrap().children_changed(cx, mutation);
 
         // https://html.spec.whatwg.org/multipage/#update-a-style-block
         // > The element is not on the stack of open elements of an HTML parser or XML parser, and its children changed steps run.

--- a/components/script/dom/html/htmltableelement.rs
+++ b/components/script/dom/html/htmltableelement.rs
@@ -113,10 +113,10 @@ impl HTMLTableElement {
     /// <https://html.spec.whatwg.org/multipage/#dom-table-tfoot>
     fn set_first_section_of_type<P>(
         &self,
+        cx: &mut JSContext,
         atom: &LocalName,
         section: Option<&HTMLTableSectionElement>,
         reference_predicate: P,
-        can_gc: CanGc,
     ) -> ErrorResult
     where
         P: FnMut(&DomRoot<Element>) -> bool,
@@ -127,7 +127,7 @@ impl HTMLTableElement {
             }
         }
 
-        self.delete_first_section_of_type(atom, can_gc);
+        self.delete_first_section_of_type(cx, atom);
 
         let node = self.upcast::<Node>();
 
@@ -135,7 +135,7 @@ impl HTMLTableElement {
             let reference_element = node.child_elements().find(reference_predicate);
             let reference_node = reference_element.as_ref().map(|e| e.upcast());
 
-            node.InsertBefore(section.upcast(), reference_node, can_gc)?;
+            node.InsertBefore(section.upcast(), reference_node, CanGc::from_cx(cx))?;
         }
 
         Ok(())
@@ -165,8 +165,8 @@ impl HTMLTableElement {
         let section = DomRoot::downcast::<HTMLTableSectionElement>(section).unwrap();
 
         match *atom {
-            local_name!("thead") => self.SetTHead(Some(&section)),
-            local_name!("tfoot") => self.SetTFoot(Some(&section)),
+            local_name!("thead") => self.SetTHead(cx, Some(&section)),
+            local_name!("tfoot") => self.SetTFoot(cx, Some(&section)),
             _ => unreachable!("unexpected section type"),
         }
         .expect("unexpected section type");
@@ -176,9 +176,9 @@ impl HTMLTableElement {
 
     /// <https://html.spec.whatwg.org/multipage/#dom-table-deletethead>
     /// <https://html.spec.whatwg.org/multipage/#dom-table-deletetfoot>
-    fn delete_first_section_of_type(&self, atom: &LocalName, can_gc: CanGc) {
+    fn delete_first_section_of_type(&self, cx: &mut JSContext, atom: &LocalName) {
         if let Some(thead) = self.get_first_section_of_type(atom) {
-            thead.upcast::<Node>().remove_self(can_gc);
+            thead.upcast::<Node>().remove_self(cx);
         }
     }
 
@@ -214,9 +214,13 @@ impl HTMLTableElementMethods<crate::DomTypeHolder> for HTMLTableElement {
     }
 
     /// <https://html.spec.whatwg.org/multipage/#dom-table-caption>
-    fn SetCaption(&self, new_caption: Option<&HTMLTableCaptionElement>) -> Fallible<()> {
+    fn SetCaption(
+        &self,
+        cx: &mut JSContext,
+        new_caption: Option<&HTMLTableCaptionElement>,
+    ) -> Fallible<()> {
         if let Some(ref caption) = self.GetCaption() {
-            caption.upcast::<Node>().remove_self(CanGc::note());
+            caption.upcast::<Node>().remove_self(cx);
         }
 
         if let Some(caption) = new_caption {
@@ -224,7 +228,7 @@ impl HTMLTableElementMethods<crate::DomTypeHolder> for HTMLTableElement {
             node.InsertBefore(
                 caption.upcast(),
                 node.GetFirstChild().as_deref(),
-                CanGc::note(),
+                CanGc::from_cx(cx),
             )?;
         }
 
@@ -247,7 +251,7 @@ impl HTMLTableElementMethods<crate::DomTypeHolder> for HTMLTableElement {
                 );
                 let caption = DomRoot::downcast::<HTMLTableCaptionElement>(caption).unwrap();
 
-                self.SetCaption(Some(&caption))
+                self.SetCaption(cx, Some(&caption))
                     .expect("Generated caption is invalid");
                 caption
             },
@@ -255,9 +259,9 @@ impl HTMLTableElementMethods<crate::DomTypeHolder> for HTMLTableElement {
     }
 
     /// <https://html.spec.whatwg.org/multipage/#dom-table-deletecaption>
-    fn DeleteCaption(&self) {
+    fn DeleteCaption(&self, cx: &mut JSContext) {
         if let Some(caption) = self.GetCaption() {
-            caption.upcast::<Node>().remove_self(CanGc::note());
+            caption.upcast::<Node>().remove_self(cx);
         }
     }
 
@@ -267,13 +271,10 @@ impl HTMLTableElementMethods<crate::DomTypeHolder> for HTMLTableElement {
     }
 
     /// <https://html.spec.whatwg.org/multipage/#dom-table-thead>
-    fn SetTHead(&self, thead: Option<&HTMLTableSectionElement>) -> ErrorResult {
-        self.set_first_section_of_type(
-            &local_name!("thead"),
-            thead,
-            |n| !n.is::<HTMLTableCaptionElement>() && !n.is::<HTMLTableColElement>(),
-            CanGc::note(),
-        )
+    fn SetTHead(&self, cx: &mut JSContext, thead: Option<&HTMLTableSectionElement>) -> ErrorResult {
+        self.set_first_section_of_type(cx, &local_name!("thead"), thead, |n| {
+            !n.is::<HTMLTableCaptionElement>() && !n.is::<HTMLTableColElement>()
+        })
     }
 
     /// <https://html.spec.whatwg.org/multipage/#dom-table-createthead>
@@ -282,8 +283,8 @@ impl HTMLTableElementMethods<crate::DomTypeHolder> for HTMLTableElement {
     }
 
     /// <https://html.spec.whatwg.org/multipage/#dom-table-deletethead>
-    fn DeleteTHead(&self) {
-        self.delete_first_section_of_type(&local_name!("thead"), CanGc::note())
+    fn DeleteTHead(&self, cx: &mut JSContext) {
+        self.delete_first_section_of_type(cx, &local_name!("thead"))
     }
 
     /// <https://html.spec.whatwg.org/multipage/#dom-table-tfoot>
@@ -292,26 +293,21 @@ impl HTMLTableElementMethods<crate::DomTypeHolder> for HTMLTableElement {
     }
 
     /// <https://html.spec.whatwg.org/multipage/#dom-table-tfoot>
-    fn SetTFoot(&self, tfoot: Option<&HTMLTableSectionElement>) -> ErrorResult {
-        self.set_first_section_of_type(
-            &local_name!("tfoot"),
-            tfoot,
-            |n| {
-                if n.is::<HTMLTableCaptionElement>() || n.is::<HTMLTableColElement>() {
+    fn SetTFoot(&self, cx: &mut JSContext, tfoot: Option<&HTMLTableSectionElement>) -> ErrorResult {
+        self.set_first_section_of_type(cx, &local_name!("tfoot"), tfoot, |n| {
+            if n.is::<HTMLTableCaptionElement>() || n.is::<HTMLTableColElement>() {
+                return false;
+            }
+
+            if n.is::<HTMLTableSectionElement>() {
+                let name = n.local_name();
+                if name == &local_name!("thead") || name == &local_name!("tbody") {
                     return false;
                 }
+            }
 
-                if n.is::<HTMLTableSectionElement>() {
-                    let name = n.local_name();
-                    if name == &local_name!("thead") || name == &local_name!("tbody") {
-                        return false;
-                    }
-                }
-
-                true
-            },
-            CanGc::note(),
-        )
+            true
+        })
     }
 
     /// <https://html.spec.whatwg.org/multipage/#dom-table-createtfoot>
@@ -320,8 +316,8 @@ impl HTMLTableElementMethods<crate::DomTypeHolder> for HTMLTableElement {
     }
 
     /// <https://html.spec.whatwg.org/multipage/#dom-table-deletetfoot>
-    fn DeleteTFoot(&self) {
-        self.delete_first_section_of_type(&local_name!("tfoot"), CanGc::note())
+    fn DeleteTFoot(&self, cx: &mut JSContext) {
+        self.delete_first_section_of_type(cx, &local_name!("tfoot"))
     }
 
     /// <https://html.spec.whatwg.org/multipage/#dom-table-tbodies>
@@ -452,7 +448,7 @@ impl HTMLTableElementMethods<crate::DomTypeHolder> for HTMLTableElement {
     }
 
     /// <https://html.spec.whatwg.org/multipage/#dom-table-deleterow>
-    fn DeleteRow(&self, mut index: i32) -> Fallible<()> {
+    fn DeleteRow(&self, cx: &mut JSContext, mut index: i32) -> Fallible<()> {
         let rows = self.Rows();
         let num_rows = rows.Length() as i32;
 
@@ -475,7 +471,7 @@ impl HTMLTableElementMethods<crate::DomTypeHolder> for HTMLTableElement {
         }
 
         // Step 3: Otherwise, remove the indexth element in the rows collection from its parent.
-        DomRoot::upcast::<Node>(rows.Item(index as u32).unwrap()).remove_self(CanGc::note());
+        DomRoot::upcast::<Node>(rows.Item(index as u32).unwrap()).remove_self(cx);
 
         Ok(())
     }

--- a/components/script/dom/html/htmltablerowelement.rs
+++ b/components/script/dom/html/htmltablerowelement.rs
@@ -124,13 +124,13 @@ impl HTMLTableRowElementMethods<crate::DomTypeHolder> for HTMLTableRowElement {
     }
 
     /// <https://html.spec.whatwg.org/multipage/#dom-tr-deletecell>
-    fn DeleteCell(&self, index: i32) -> ErrorResult {
+    fn DeleteCell(&self, cx: &mut JSContext, index: i32) -> ErrorResult {
         let node = self.upcast::<Node>();
         node.delete_cell_or_row(
+            cx,
             index,
             || self.Cells(),
             |n| n.is::<HTMLTableCellElement>(),
-            CanGc::note(),
         )
     }
 

--- a/components/script/dom/html/htmltablesectionelement.rs
+++ b/components/script/dom/html/htmltablesectionelement.rs
@@ -101,14 +101,9 @@ impl HTMLTableSectionElementMethods<crate::DomTypeHolder> for HTMLTableSectionEl
     }
 
     /// <https://html.spec.whatwg.org/multipage/#dom-tbody-deleterow>
-    fn DeleteRow(&self, index: i32) -> ErrorResult {
+    fn DeleteRow(&self, cx: &mut JSContext, index: i32) -> ErrorResult {
         let node = self.upcast::<Node>();
-        node.delete_cell_or_row(
-            index,
-            || self.Rows(),
-            |n| n.is::<HTMLTableRowElement>(),
-            CanGc::note(),
-        )
+        node.delete_cell_or_row(cx, index, || self.Rows(), |n| n.is::<HTMLTableRowElement>())
     }
 }
 

--- a/components/script/dom/html/htmltemplateelement.rs
+++ b/components/script/dom/html/htmltemplateelement.rs
@@ -120,14 +120,15 @@ impl VirtualMethods for HTMLTemplateElement {
     }
 
     /// <https://html.spec.whatwg.org/multipage/#template-adopting-steps>
-    fn adopting_steps(&self, old_doc: &Document, can_gc: CanGc) {
-        self.super_type().unwrap().adopting_steps(old_doc, can_gc);
+    fn adopting_steps(&self, cx: &mut JSContext, old_doc: &Document) {
+        self.super_type().unwrap().adopting_steps(cx, old_doc);
         // Step 1.
         let doc = self
             .owner_document()
-            .appropriate_template_contents_owner_document(CanGc::note());
+            .appropriate_template_contents_owner_document(CanGc::from_cx(cx));
         // Step 2.
-        Node::adopt(self.Content(CanGc::note()).upcast(), &doc, can_gc);
+        let content = self.Content(CanGc::from_cx(cx));
+        Node::adopt(cx, content.upcast(), &doc);
     }
 
     /// <https://html.spec.whatwg.org/multipage/#the-template-element:concept-node-clone-ext>

--- a/components/script/dom/html/htmltextareaelement.rs
+++ b/components/script/dom/html/htmltextareaelement.rs
@@ -744,12 +744,12 @@ impl VirtualMethods for HTMLTextAreaElement {
             .perform_validation_and_update(ValidationFlags::all(), CanGc::from_cx(cx));
     }
 
-    fn children_changed(&self, mutation: &ChildrenMutation, can_gc: CanGc) {
+    fn children_changed(&self, cx: &mut JSContext, mutation: &ChildrenMutation) {
         if let Some(s) = self.super_type() {
-            s.children_changed(mutation, can_gc);
+            s.children_changed(cx, mutation);
         }
         if !self.value_dirty.get() {
-            self.reset(can_gc);
+            self.reset(CanGc::from_cx(cx));
         }
     }
 

--- a/components/script/dom/html/htmltitleelement.rs
+++ b/components/script/dom/html/htmltitleelement.rs
@@ -6,6 +6,7 @@ use std::cell::Cell;
 
 use dom_struct::dom_struct;
 use html5ever::{LocalName, Prefix};
+use js::context::JSContext;
 use js::rust::HandleObject;
 
 use crate::dom::bindings::codegen::Bindings::HTMLTitleElementBinding::HTMLTitleElementMethods;
@@ -79,9 +80,9 @@ impl VirtualMethods for HTMLTitleElement {
         Some(self.upcast::<HTMLElement>() as &dyn VirtualMethods)
     }
 
-    fn children_changed(&self, mutation: &ChildrenMutation, can_gc: CanGc) {
+    fn children_changed(&self, cx: &mut JSContext, mutation: &ChildrenMutation) {
         if let Some(s) = self.super_type() {
-            s.children_changed(mutation, can_gc);
+            s.children_changed(cx, mutation);
         }
 
         // Notify of title changes only after the initial full parsing

--- a/components/script/dom/node.rs
+++ b/components/script/dom/node.rs
@@ -3071,13 +3071,17 @@ impl Node {
     }
 
     /// <https://dom.spec.whatwg.org/#concept-node-insert>
+    #[expect(unsafe_code)]
     fn insert(
         node: &Node,
         parent: &Node,
         child: Option<&Node>,
         suppress_observers: SuppressObserver,
-        can_gc: CanGc,
+        _can_gc: CanGc,
     ) {
+        let mut cx = unsafe { script_bindings::script_runtime::temp_cx() };
+        let cx = &mut cx;
+
         debug_assert!(child.is_none_or(|child| Some(parent) == child.GetParentNode().as_deref()));
 
         // Step 1. Let nodes be node’s children, if node is a DocumentFragment node; otherwise « node ».
@@ -3108,10 +3112,9 @@ impl Node {
         if let NodeTypeId::DocumentFragment(_) = node.type_id() {
             // Step 4.1. Remove its children with the suppress observers flag set.
             for kid in new_nodes {
-                Node::remove(kid, node, SuppressObserver::Suppressed, can_gc);
+                Node::remove(kid, node, SuppressObserver::Suppressed, CanGc::from_cx(cx));
             }
-            vtable_for(node)
-                .children_changed(&ChildrenMutation::replace_all(new_nodes, &[]), can_gc);
+            vtable_for(node).children_changed(cx, &ChildrenMutation::replace_all(new_nodes, &[]));
 
             // Step 4.2. Queue a tree mutation record for node with « », nodes, null, and null.
             let mutation = LazyCell::new(|| Mutation::ChildList {
@@ -3157,11 +3160,11 @@ impl Node {
         // Step 7. For each node in nodes, in tree order:
         for kid in new_nodes {
             // Step 7.1. Adopt node into parent’s node document.
-            Node::adopt(kid, &parent.owner_document(), can_gc);
+            Node::adopt(kid, &parent.owner_document(), CanGc::from_cx(cx));
 
             // Step 7.2. If child is null, then append node to parent’s children.
             // Step 7.3. Otherwise, insert node into parent’s children before child’s index.
-            parent.add_child(kid, child, can_gc);
+            parent.add_child(kid, child, CanGc::from_cx(cx));
 
             // Step 7.4 If parent is a shadow host whose shadow root’s slot assignment is "named"
             // and node is a slottable, then assign a slot for node.
@@ -3223,8 +3226,8 @@ impl Node {
             // Step 9. Run the children changed steps for parent.
             // TODO(xiaochengh): If we follow the spec and move it out of the if block, some WPT fail. Investigate.
             vtable_for(parent).children_changed(
+                cx,
                 &ChildrenMutation::insert(previous_sibling.as_deref(), new_nodes, child),
-                can_gc,
             );
 
             // Step 8. If suppress observers flag is unset, then queue a tree mutation record for parent
@@ -3263,7 +3266,11 @@ impl Node {
     }
 
     /// <https://dom.spec.whatwg.org/#concept-node-replace-all>
-    pub(crate) fn replace_all(node: Option<&Node>, parent: &Node, can_gc: CanGc) {
+    #[expect(unsafe_code)]
+    pub(crate) fn replace_all(node: Option<&Node>, parent: &Node, _can_gc: CanGc) {
+        let mut cx = unsafe { script_bindings::script_runtime::temp_cx() };
+        let cx = &mut cx;
+
         parent.owner_doc().add_script_and_layout_blocker();
 
         // Step 1. Let removedNodes be parent’s children.
@@ -3286,17 +3293,28 @@ impl Node {
 
         // Step 5. Remove all parent’s children, in tree order, with suppressObservers set to true.
         for child in &*removed_nodes {
-            Node::remove(child, parent, SuppressObserver::Suppressed, can_gc);
+            Node::remove(
+                child,
+                parent,
+                SuppressObserver::Suppressed,
+                CanGc::from_cx(cx),
+            );
         }
 
         // Step 6. If node is non-null, then insert node into parent before null with suppressObservers set to true.
         if let Some(node) = node {
-            Node::insert(node, parent, None, SuppressObserver::Suppressed, can_gc);
+            Node::insert(
+                node,
+                parent,
+                None,
+                SuppressObserver::Suppressed,
+                CanGc::from_cx(cx),
+            );
         }
 
         vtable_for(parent).children_changed(
+            cx,
             &ChildrenMutation::replace_all(removed_nodes.r(), added_nodes),
-            can_gc,
         );
 
         // Step 7. If either addedNodes or removedNodes is not empty, then queue a tree mutation record
@@ -3340,7 +3358,11 @@ impl Node {
     }
 
     /// <https://dom.spec.whatwg.org/#concept-node-remove>
+    #[expect(unsafe_code)]
     fn remove(node: &Node, parent: &Node, suppress_observers: SuppressObserver, can_gc: CanGc) {
+        let mut cx = unsafe { script_bindings::script_runtime::temp_cx() };
+        let cx = &mut cx;
+
         parent.owner_doc().add_script_and_layout_blocker();
 
         // Step 1. Let parent be node’s parent.
@@ -3401,13 +3423,13 @@ impl Node {
         // Step 16.
         if let SuppressObserver::Unsuppressed = suppress_observers {
             vtable_for(parent).children_changed(
+                cx,
                 &ChildrenMutation::replace(
                     old_previous_sibling.as_deref(),
                     &Some(node),
                     &[],
                     old_next_sibling.as_deref(),
                 ),
-                can_gc,
             );
 
             let removed = [node];
@@ -4102,7 +4124,11 @@ impl NodeMethods<crate::DomTypeHolder> for Node {
     }
 
     /// <https://dom.spec.whatwg.org/#concept-node-replace>
-    fn ReplaceChild(&self, node: &Node, child: &Node, can_gc: CanGc) -> Fallible<DomRoot<Node>> {
+    #[expect(unsafe_code)]
+    fn ReplaceChild(&self, node: &Node, child: &Node, _can_gc: CanGc) -> Fallible<DomRoot<Node>> {
+        let mut cx = unsafe { script_bindings::script_runtime::temp_cx() };
+        let cx = &mut cx;
+
         // Step 1. If parent is not a Document, DocumentFragment, or Element node,
         // then throw a "HierarchyRequestError" DOMException.
         match self.type_id() {
@@ -4211,7 +4237,7 @@ impl NodeMethods<crate::DomTypeHolder> for Node {
         // However, if we follow the spec and delay adoption to inside `Node::insert()`, then the mutation records will
         // be different, and we will fail WPT dom/nodes/MutationObserver-childList.html.
         let document = self.owner_document();
-        Node::adopt(node, &document, can_gc);
+        Node::adopt(node, &document, CanGc::from_cx(cx));
 
         // Step 10. Let removedNodes be the empty set.
         // Step 11. If child’s parent is non-null:
@@ -4219,7 +4245,12 @@ impl NodeMethods<crate::DomTypeHolder> for Node {
         //     2. Remove child with the suppress observers flag set.
         let removed_child = if node != child {
             // Step 11.
-            Node::remove(child, self, SuppressObserver::Suppressed, can_gc);
+            Node::remove(
+                child,
+                self,
+                SuppressObserver::Suppressed,
+                CanGc::from_cx(cx),
+            );
             Some(child)
         } else {
             None
@@ -4243,17 +4274,17 @@ impl NodeMethods<crate::DomTypeHolder> for Node {
             self,
             reference_child,
             SuppressObserver::Suppressed,
-            can_gc,
+            CanGc::from_cx(cx),
         );
 
         vtable_for(self).children_changed(
+            cx,
             &ChildrenMutation::replace(
                 previous_sibling.as_deref(),
                 &removed_child,
                 nodes,
                 reference_child,
             ),
-            can_gc,
         );
 
         // Step 14. Queue a tree mutation record for parent with nodes, removedNodes,
@@ -4278,7 +4309,7 @@ impl NodeMethods<crate::DomTypeHolder> for Node {
     }
 
     /// <https://dom.spec.whatwg.org/#dom-node-normalize>
-    fn Normalize(&self, can_gc: CanGc) {
+    fn Normalize(&self, cx: &mut JSContext) {
         let mut children = self.children().enumerate().peekable();
         while let Some((_, node)) = children.next() {
             if let Some(text) = node.downcast::<Text>() {
@@ -4288,7 +4319,12 @@ impl NodeMethods<crate::DomTypeHolder> for Node {
                 let cdata = text.upcast::<CharacterData>();
                 let mut length = cdata.Length();
                 if length == 0 {
-                    Node::remove(&node, self, SuppressObserver::Unsuppressed, can_gc);
+                    Node::remove(
+                        &node,
+                        self,
+                        SuppressObserver::Unsuppressed,
+                        CanGc::from_cx(cx),
+                    );
                     continue;
                 }
                 while children.peek().is_some_and(|(_, sibling)| {
@@ -4303,10 +4339,15 @@ impl NodeMethods<crate::DomTypeHolder> for Node {
                     let sibling_cdata = sibling.downcast::<CharacterData>().unwrap();
                     length += sibling_cdata.Length();
                     cdata.append_data(&sibling_cdata.data());
-                    Node::remove(&sibling, self, SuppressObserver::Unsuppressed, can_gc);
+                    Node::remove(
+                        &sibling,
+                        self,
+                        SuppressObserver::Unsuppressed,
+                        CanGc::from_cx(cx),
+                    );
                 }
             } else {
-                node.Normalize(can_gc);
+                node.Normalize(cx);
             }
         }
     }
@@ -4698,9 +4739,9 @@ impl VirtualMethods for Node {
         Some(self.upcast::<EventTarget>() as &dyn VirtualMethods)
     }
 
-    fn children_changed(&self, mutation: &ChildrenMutation, can_gc: CanGc) {
+    fn children_changed(&self, cx: &mut JSContext, mutation: &ChildrenMutation) {
         if let Some(s) = self.super_type() {
-            s.children_changed(mutation, can_gc);
+            s.children_changed(cx, mutation);
         }
 
         if let Some(data) = self.rare_data().as_ref() {

--- a/components/script/dom/node.rs
+++ b/components/script/dom/node.rs
@@ -3042,12 +3042,16 @@ impl Node {
     }
 
     /// <https://dom.spec.whatwg.org/#concept-node-pre-insert>
+    #[expect(unsafe_code)]
     pub(crate) fn pre_insert(
         node: &Node,
         parent: &Node,
         child: Option<&Node>,
-        can_gc: CanGc,
+        _can_gc: CanGc,
     ) -> Fallible<DomRoot<Node>> {
+        let mut cx = unsafe { script_bindings::script_runtime::temp_cx() };
+        let cx = &mut cx;
+
         // Step 1. Ensure pre-insert validity of node into parent before child.
         Node::ensure_pre_insertion_validity(node, parent, child)?;
 
@@ -3064,11 +3068,11 @@ impl Node {
 
         // Step 4. Insert node into parent before referenceChild.
         Node::insert(
+            cx,
             node,
             parent,
             reference_child,
             SuppressObserver::Unsuppressed,
-            can_gc,
         );
 
         // Step 5. Return node.
@@ -3076,17 +3080,13 @@ impl Node {
     }
 
     /// <https://dom.spec.whatwg.org/#concept-node-insert>
-    #[expect(unsafe_code)]
     fn insert(
+        cx: &mut JSContext,
         node: &Node,
         parent: &Node,
         child: Option<&Node>,
         suppress_observers: SuppressObserver,
-        _can_gc: CanGc,
     ) {
-        let mut cx = unsafe { script_bindings::script_runtime::temp_cx() };
-        let cx = &mut cx;
-
         debug_assert!(child.is_none_or(|child| Some(parent) == child.GetParentNode().as_deref()));
 
         // Step 1. Let nodes be node’s children, if node is a DocumentFragment node; otherwise « node ».
@@ -3303,13 +3303,7 @@ impl Node {
 
         // Step 6. If node is non-null, then insert node into parent before null with suppressObservers set to true.
         if let Some(node) = node {
-            Node::insert(
-                node,
-                parent,
-                None,
-                SuppressObserver::Suppressed,
-                CanGc::from_cx(cx),
-            );
+            Node::insert(cx, node, parent, None, SuppressObserver::Suppressed);
         }
 
         vtable_for(parent).children_changed(
@@ -4267,11 +4261,11 @@ impl NodeMethods<crate::DomTypeHolder> for Node {
 
         // Step 13. Insert node into parent before referenceChild with the suppress observers flag set.
         Node::insert(
+            cx,
             node,
             self,
             reference_child,
             SuppressObserver::Suppressed,
-            CanGc::from_cx(cx),
         );
 
         vtable_for(self).children_changed(

--- a/components/script/dom/node.rs
+++ b/components/script/dom/node.rs
@@ -2866,11 +2866,7 @@ impl Node {
     }
 
     /// <https://dom.spec.whatwg.org/#concept-node-adopt>
-    #[expect(unsafe_code)]
-    pub(crate) fn adopt(node: &Node, document: &Document, can_gc: CanGc) {
-        let mut cx = unsafe { script_bindings::script_runtime::temp_cx() };
-        let cx = &mut cx;
-
+    pub(crate) fn adopt(cx: &mut JSContext, node: &Node, document: &Document) {
         document.add_script_and_layout_blocker();
 
         // Step 1. Let oldDocument be node’s node document.
@@ -2914,7 +2910,7 @@ impl Node {
             // Step 3.3 For each inclusiveDescendant in node’s shadow-including inclusive descendants,
             // in shadow-including tree order, run the adopting steps with inclusiveDescendant and oldDocument.
             for descendant in node.traverse_preorder(ShadowIncluding::Yes) {
-                vtable_for(&descendant).adopting_steps(&old_doc, can_gc);
+                vtable_for(&descendant).adopting_steps(cx, &old_doc);
             }
         }
 
@@ -3169,7 +3165,7 @@ impl Node {
         // Step 7. For each node in nodes, in tree order:
         for kid in new_nodes {
             // Step 7.1. Adopt node into parent’s node document.
-            Node::adopt(kid, &parent.owner_document(), CanGc::from_cx(cx));
+            Node::adopt(cx, kid, &parent.owner_document());
 
             // Step 7.2. If child is null, then append node to parent’s children.
             // Step 7.3. Otherwise, insert node into parent’s children before child’s index.
@@ -4243,7 +4239,7 @@ impl NodeMethods<crate::DomTypeHolder> for Node {
         // However, if we follow the spec and delay adoption to inside `Node::insert()`, then the mutation records will
         // be different, and we will fail WPT dom/nodes/MutationObserver-childList.html.
         let document = self.owner_document();
-        Node::adopt(node, &document, CanGc::from_cx(cx));
+        Node::adopt(cx, node, &document);
 
         // Step 10. Let removedNodes be the empty set.
         // Step 11. If child’s parent is non-null:

--- a/components/script/dom/node.rs
+++ b/components/script/dom/node.rs
@@ -1197,7 +1197,7 @@ impl Node {
     }
 
     /// <https://dom.spec.whatwg.org/#dom-childnode-replacewith>
-    pub(crate) fn replace_with(&self, nodes: Vec<NodeOrString>, can_gc: CanGc) -> ErrorResult {
+    pub(crate) fn replace_with(&self, cx: &mut JSContext, nodes: Vec<NodeOrString>) -> ErrorResult {
         // Step 1. Let parent be this’s parent.
         let Some(parent) = self.GetParentNode() else {
             // Step 2. If parent is null, then return.
@@ -1210,14 +1210,19 @@ impl Node {
         // Step 4. Let node be the result of converting nodes into a node, given nodes and this’s node document.
         let node = self
             .owner_doc()
-            .node_from_nodes_and_strings(nodes, can_gc)?;
+            .node_from_nodes_and_strings(nodes, CanGc::from_cx(cx))?;
 
         if self.parent_node == Some(&*parent) {
             // Step 5. If this’s parent is parent, replace this with node within parent.
-            parent.ReplaceChild(&node, self, can_gc)?;
+            parent.ReplaceChild(cx, &node, self)?;
         } else {
             // Step 6. Otherwise, pre-insert node into parent before viableNextSibling.
-            Node::pre_insert(&node, &parent, viable_next_sibling.as_deref(), can_gc)?;
+            Node::pre_insert(
+                &node,
+                &parent,
+                viable_next_sibling.as_deref(),
+                CanGc::from_cx(cx),
+            )?;
         }
         Ok(())
     }
@@ -4124,11 +4129,12 @@ impl NodeMethods<crate::DomTypeHolder> for Node {
     }
 
     /// <https://dom.spec.whatwg.org/#concept-node-replace>
-    #[expect(unsafe_code)]
-    fn ReplaceChild(&self, node: &Node, child: &Node, _can_gc: CanGc) -> Fallible<DomRoot<Node>> {
-        let mut cx = unsafe { script_bindings::script_runtime::temp_cx() };
-        let cx = &mut cx;
-
+    fn ReplaceChild(
+        &self,
+        cx: &mut JSContext,
+        node: &Node,
+        child: &Node,
+    ) -> Fallible<DomRoot<Node>> {
         // Step 1. If parent is not a Document, DocumentFragment, or Element node,
         // then throw a "HierarchyRequestError" DOMException.
         match self.type_id() {

--- a/components/script/dom/node.rs
+++ b/components/script/dom/node.rs
@@ -1670,9 +1670,9 @@ impl Node {
             .peekable()
     }
 
-    pub(crate) fn remove_self(&self, can_gc: CanGc) {
+    pub(crate) fn remove_self(&self, cx: &mut JSContext) {
         if let Some(ref parent) = self.GetParentNode() {
-            Node::remove(self, parent, SuppressObserver::Unsuppressed, can_gc);
+            Node::remove(cx, self, parent, SuppressObserver::Unsuppressed);
         }
     }
 
@@ -1820,10 +1820,10 @@ impl Node {
     /// Used by `HTMLTableSectionElement::DeleteRow` and `HTMLTableRowElement::DeleteCell`
     pub(crate) fn delete_cell_or_row<F, G>(
         &self,
+        cx: &mut JSContext,
         index: i32,
         get_items: F,
         is_delete_type: G,
-        can_gc: CanGc,
     ) -> ErrorResult
     where
         F: Fn() -> DomRoot<HTMLCollection>,
@@ -1848,7 +1848,7 @@ impl Node {
             },
         };
 
-        element.upcast::<Node>().remove_self(can_gc);
+        element.upcast::<Node>().remove_self(cx);
         Ok(())
     }
 
@@ -2866,7 +2866,11 @@ impl Node {
     }
 
     /// <https://dom.spec.whatwg.org/#concept-node-adopt>
+    #[expect(unsafe_code)]
     pub(crate) fn adopt(node: &Node, document: &Document, can_gc: CanGc) {
+        let mut cx = unsafe { script_bindings::script_runtime::temp_cx() };
+        let cx = &mut cx;
+
         document.add_script_and_layout_blocker();
 
         // Step 1. Let oldDocument be node’s node document.
@@ -2874,7 +2878,7 @@ impl Node {
         old_doc.add_script_and_layout_blocker();
 
         // Step 2. If node’s parent is non-null, then remove node.
-        node.remove_self(can_gc);
+        node.remove_self(cx);
 
         // Step 3. If document is not oldDocument:
         if &*old_doc != document {
@@ -3117,7 +3121,7 @@ impl Node {
         if let NodeTypeId::DocumentFragment(_) = node.type_id() {
             // Step 4.1. Remove its children with the suppress observers flag set.
             for kid in new_nodes {
-                Node::remove(kid, node, SuppressObserver::Suppressed, CanGc::from_cx(cx));
+                Node::remove(cx, kid, node, SuppressObserver::Suppressed);
             }
             vtable_for(node).children_changed(cx, &ChildrenMutation::replace_all(new_nodes, &[]));
 
@@ -3298,12 +3302,7 @@ impl Node {
 
         // Step 5. Remove all parent’s children, in tree order, with suppressObservers set to true.
         for child in &*removed_nodes {
-            Node::remove(
-                child,
-                parent,
-                SuppressObserver::Suppressed,
-                CanGc::from_cx(cx),
-            );
+            Node::remove(cx, child, parent, SuppressObserver::Suppressed);
         }
 
         // Step 6. If node is non-null, then insert node into parent before null with suppressObservers set to true.
@@ -3347,7 +3346,7 @@ impl Node {
     }
 
     /// <https://dom.spec.whatwg.org/#concept-node-pre-remove>
-    fn pre_remove(child: &Node, parent: &Node, can_gc: CanGc) -> Fallible<DomRoot<Node>> {
+    fn pre_remove(cx: &mut JSContext, child: &Node, parent: &Node) -> Fallible<DomRoot<Node>> {
         // Step 1.
         match child.GetParentNode() {
             Some(ref node) if &**node != parent => return Err(Error::NotFound(None)),
@@ -3356,18 +3355,19 @@ impl Node {
         }
 
         // Step 2.
-        Node::remove(child, parent, SuppressObserver::Unsuppressed, can_gc);
+        Node::remove(cx, child, parent, SuppressObserver::Unsuppressed);
 
         // Step 3.
         Ok(DomRoot::from_ref(child))
     }
 
     /// <https://dom.spec.whatwg.org/#concept-node-remove>
-    #[expect(unsafe_code)]
-    fn remove(node: &Node, parent: &Node, suppress_observers: SuppressObserver, can_gc: CanGc) {
-        let mut cx = unsafe { script_bindings::script_runtime::temp_cx() };
-        let cx = &mut cx;
-
+    fn remove(
+        cx: &mut JSContext,
+        node: &Node,
+        parent: &Node,
+        suppress_observers: SuppressObserver,
+    ) {
         parent.owner_doc().add_script_and_layout_blocker();
 
         // Step 1. Let parent be node’s parent.
@@ -3392,7 +3392,7 @@ impl Node {
 
         // Step 7. Remove node from its parent's children.
         // Step 11-14. Run removing steps and enqueue disconnected custom element reactions for the subtree.
-        parent.remove_child(node, cached_index, can_gc);
+        parent.remove_child(node, cached_index, CanGc::from_cx(cx));
 
         // Step 8. If node is assigned, then run assign slottables for node’s assigned slot.
         if let Some(slot) = node.assigned_slot() {
@@ -4251,12 +4251,7 @@ impl NodeMethods<crate::DomTypeHolder> for Node {
         //     2. Remove child with the suppress observers flag set.
         let removed_child = if node != child {
             // Step 11.
-            Node::remove(
-                child,
-                self,
-                SuppressObserver::Suppressed,
-                CanGc::from_cx(cx),
-            );
+            Node::remove(cx, child, self, SuppressObserver::Suppressed);
             Some(child)
         } else {
             None
@@ -4310,8 +4305,8 @@ impl NodeMethods<crate::DomTypeHolder> for Node {
     }
 
     /// <https://dom.spec.whatwg.org/#dom-node-removechild>
-    fn RemoveChild(&self, node: &Node, can_gc: CanGc) -> Fallible<DomRoot<Node>> {
-        Node::pre_remove(node, self, can_gc)
+    fn RemoveChild(&self, cx: &mut JSContext, node: &Node) -> Fallible<DomRoot<Node>> {
+        Node::pre_remove(cx, node, self)
     }
 
     /// <https://dom.spec.whatwg.org/#dom-node-normalize>
@@ -4325,12 +4320,7 @@ impl NodeMethods<crate::DomTypeHolder> for Node {
                 let cdata = text.upcast::<CharacterData>();
                 let mut length = cdata.Length();
                 if length == 0 {
-                    Node::remove(
-                        &node,
-                        self,
-                        SuppressObserver::Unsuppressed,
-                        CanGc::from_cx(cx),
-                    );
+                    Node::remove(cx, &node, self, SuppressObserver::Unsuppressed);
                     continue;
                 }
                 while children.peek().is_some_and(|(_, sibling)| {
@@ -4345,12 +4335,7 @@ impl NodeMethods<crate::DomTypeHolder> for Node {
                     let sibling_cdata = sibling.downcast::<CharacterData>().unwrap();
                     length += sibling_cdata.Length();
                     cdata.append_data(&sibling_cdata.data());
-                    Node::remove(
-                        &sibling,
-                        self,
-                        SuppressObserver::Unsuppressed,
-                        CanGc::from_cx(cx),
-                    );
+                    Node::remove(cx, &sibling, self, SuppressObserver::Unsuppressed);
                 }
             } else {
                 node.Normalize(cx);

--- a/components/script/dom/node.rs
+++ b/components/script/dom/node.rs
@@ -3049,6 +3049,7 @@ impl Node {
         child: Option<&Node>,
         _can_gc: CanGc,
     ) -> Fallible<DomRoot<Node>> {
+        // TODO github.com/servo/servo/issues/43239
         let mut cx = unsafe { script_bindings::script_runtime::temp_cx() };
         let cx = &mut cx;
 
@@ -3273,6 +3274,7 @@ impl Node {
     /// <https://dom.spec.whatwg.org/#concept-node-replace-all>
     #[expect(unsafe_code)]
     pub(crate) fn replace_all(node: Option<&Node>, parent: &Node, _can_gc: CanGc) {
+        // TODO https://github.com/servo/servo/issues/43240
         let mut cx = unsafe { script_bindings::script_runtime::temp_cx() };
         let cx = &mut cx;
 

--- a/components/script/dom/range.rs
+++ b/components/script/dom/range.rs
@@ -894,7 +894,7 @@ impl RangeMethods<crate::DomTypeHolder> for Range {
 
     /// <https://dom.spec.whatwg.org/#dom-range-insertnode>
     /// <https://dom.spec.whatwg.org/#concept-range-insert>
-    fn InsertNode(&self, node: &Node, can_gc: CanGc) -> ErrorResult {
+    fn InsertNode(&self, cx: &mut JSContext, node: &Node) -> ErrorResult {
         let start_node = self.start_container();
         let start_offset = self.start_offset();
 
@@ -923,7 +923,7 @@ impl RangeMethods<crate::DomTypeHolder> for Range {
             },
             _ => {
                 // Steps 4-5.
-                let child = start_node.ChildNodes(can_gc).Item(start_offset);
+                let child = start_node.ChildNodes(CanGc::from_cx(cx)).Item(start_offset);
                 (child, DomRoot::from_ref(&*start_node))
             },
         };
@@ -935,7 +935,7 @@ impl RangeMethods<crate::DomTypeHolder> for Range {
         let split_text;
         let reference_node = match start_node.downcast::<Text>() {
             Some(text) => {
-                split_text = text.SplitText(start_offset, can_gc)?;
+                split_text = text.SplitText(start_offset, CanGc::from_cx(cx))?;
                 let new_reference = DomRoot::upcast::<Node>(split_text);
                 assert!(new_reference.GetParentNode().as_deref() == Some(&parent));
                 Some(new_reference)
@@ -951,7 +951,7 @@ impl RangeMethods<crate::DomTypeHolder> for Range {
         };
 
         // Step 9.
-        node.remove_self(can_gc);
+        node.remove_self(cx);
 
         // Step 10.
         let new_offset = reference_node
@@ -967,7 +967,7 @@ impl RangeMethods<crate::DomTypeHolder> for Range {
             };
 
         // Step 12.
-        Node::pre_insert(node, &parent, reference_node.as_deref(), can_gc)?;
+        Node::pre_insert(node, &parent, reference_node.as_deref(), CanGc::from_cx(cx))?;
 
         // Step 13.
         if self.collapsed() {
@@ -978,7 +978,7 @@ impl RangeMethods<crate::DomTypeHolder> for Range {
     }
 
     /// <https://dom.spec.whatwg.org/#dom-range-deletecontents>
-    fn DeleteContents(&self) -> ErrorResult {
+    fn DeleteContents(&self, cx: &mut JSContext) -> ErrorResult {
         // Step 1.
         if self.collapsed() {
             return Ok(());
@@ -1047,7 +1047,7 @@ impl RangeMethods<crate::DomTypeHolder> for Range {
 
         // Step 8.
         for child in &*contained_children {
-            child.remove_self(CanGc::note());
+            child.remove_self(cx);
         }
 
         // Step 9.
@@ -1093,7 +1093,7 @@ impl RangeMethods<crate::DomTypeHolder> for Range {
         Node::replace_all(None, new_parent, CanGc::from_cx(cx));
 
         // Step 5.
-        self.InsertNode(new_parent, CanGc::from_cx(cx))?;
+        self.InsertNode(cx, new_parent)?;
 
         // Step 6.
         new_parent.AppendChild(fragment.upcast(), CanGc::from_cx(cx))?;

--- a/components/script/dom/selection.rs
+++ b/components/script/dom/selection.rs
@@ -5,6 +5,7 @@
 use std::cell::Cell;
 
 use dom_struct::dom_struct;
+use js::context::JSContext;
 
 use crate::dom::bindings::codegen::Bindings::NodeBinding::{GetRootNodeOptions, NodeMethods};
 use crate::dom::bindings::codegen::Bindings::RangeBinding::RangeMethods;
@@ -459,11 +460,11 @@ impl SelectionMethods<crate::DomTypeHolder> for Selection {
     }
 
     /// <https://w3c.github.io/selection-api/#dom-selection-deletecontents>
-    fn DeleteFromDocument(&self) -> ErrorResult {
+    fn DeleteFromDocument(&self, cx: &mut JSContext) -> ErrorResult {
         if let Some(range) = self.range.get() {
             // Since the range is changing, it should trigger a
             // selectionchange event as it would if if mutated any other way
-            return range.DeleteContents();
+            return range.DeleteContents(cx);
         }
         Ok(())
     }

--- a/components/script/dom/servoparser/async_html.rs
+++ b/components/script/dom/servoparser/async_html.rs
@@ -553,9 +553,7 @@ impl Tokenizer {
             },
             ParseOperation::RemoveFromParent { target } => {
                 if let Some(ref parent) = self.get_node(&target).GetParentNode() {
-                    parent
-                        .RemoveChild(&self.get_node(&target), CanGc::from_cx(cx))
-                        .unwrap();
+                    parent.RemoveChild(cx, &self.get_node(&target)).unwrap();
                 }
             },
             ParseOperation::MarkScriptAlreadyStarted { node } => {

--- a/components/script/dom/servoparser/mod.rs
+++ b/components/script/dom/servoparser/mod.rs
@@ -792,9 +792,13 @@ where
 {
     type Item = DomRoot<Node>;
 
+    #[expect(unsafe_code)]
     fn next(&mut self) -> Option<DomRoot<Node>> {
+        let mut cx = unsafe { script_bindings::script_runtime::temp_cx() };
+        let cx = &mut cx;
+
         let next = self.inner.next()?;
-        next.remove_self(CanGc::note());
+        next.remove_self(cx);
         Some(next)
     }
 
@@ -1770,9 +1774,14 @@ impl TreeSink for Sink {
         }
     }
 
+    #[expect(unsafe_code)]
     fn remove_from_parent(&self, target: &Dom<Node>) {
+        // TODO: https://github.com/servo/servo/issues/42839
+        let mut cx = unsafe { temp_cx() };
+        let cx = &mut cx;
+
         if let Some(ref parent) = target.GetParentNode() {
-            parent.RemoveChild(target, CanGc::note()).unwrap();
+            parent.RemoveChild(cx, target).unwrap();
         }
     }
 

--- a/components/script/dom/svg/svgsvgelement.rs
+++ b/components/script/dom/svg/svgsvgelement.rs
@@ -249,9 +249,9 @@ impl VirtualMethods for SVGSVGElement {
         }
     }
 
-    fn children_changed(&self, mutation: &ChildrenMutation, can_gc: CanGc) {
+    fn children_changed(&self, cx: &mut JSContext, mutation: &ChildrenMutation) {
         if let Some(super_type) = self.super_type() {
-            super_type.children_changed(mutation, can_gc);
+            super_type.children_changed(cx, mutation);
         }
 
         self.invalidate_cached_serialized_subtree();

--- a/components/script/dom/svg/svgsvgelement.rs
+++ b/components/script/dom/svg/svgsvgelement.rs
@@ -86,7 +86,7 @@ impl SVGSVGElement {
             .upcast::<Node>()
             .xml_serialize(TraversalScope::IncludeNode);
 
-        self.cleanup_cloned_nodes(&cloned_nodes, CanGc::from_cx(cx));
+        self.cleanup_cloned_nodes(cx, &cloned_nodes);
 
         let Ok(xml_source) = serialize_result else {
             *self.cached_serialized_data_url.borrow_mut() = Some(Err(()));
@@ -150,14 +150,14 @@ impl SVGSVGElement {
         Some(cloned_node)
     }
 
-    fn cleanup_cloned_nodes(&self, cloned_nodes: &[DomRoot<Node>], can_gc: CanGc) {
+    fn cleanup_cloned_nodes(&self, cx: &mut JSContext, cloned_nodes: &[DomRoot<Node>]) {
         if cloned_nodes.is_empty() {
             return;
         }
         let root_node = self.upcast::<Node>();
 
         for cloned_node in cloned_nodes {
-            let _ = root_node.RemoveChild(cloned_node, can_gc);
+            let _ = root_node.RemoveChild(cx, cloned_node);
         }
     }
 

--- a/components/script/dom/virtualmethods.rs
+++ b/components/script/dom/virtualmethods.rs
@@ -168,9 +168,9 @@ pub(crate) trait VirtualMethods {
     }
 
     /// <https://dom.spec.whatwg.org/#concept-node-adopt-ext>
-    fn adopting_steps(&self, old_doc: &Document, can_gc: CanGc) {
+    fn adopting_steps(&self, cx: &mut JSContext, old_doc: &Document) {
         if let Some(s) = self.super_type() {
-            s.adopting_steps(old_doc, can_gc);
+            s.adopting_steps(cx, old_doc);
         }
     }
 

--- a/components/script/dom/virtualmethods.rs
+++ b/components/script/dom/virtualmethods.rs
@@ -137,9 +137,9 @@ pub(crate) trait VirtualMethods {
     }
 
     /// Called on the parent when its children are changed.
-    fn children_changed(&self, mutation: &ChildrenMutation, can_gc: CanGc) {
+    fn children_changed(&self, cx: &mut JSContext, mutation: &ChildrenMutation) {
         if let Some(s) = self.super_type() {
-            s.children_changed(mutation, can_gc);
+            s.children_changed(cx, mutation);
         }
     }
 

--- a/components/script_bindings/codegen/Bindings.conf
+++ b/components/script_bindings/codegen/Bindings.conf
@@ -99,8 +99,8 @@ DOMInterfaces = {
 },
 
 'CharacterData': {
-    'canGc': ['Before', 'After', 'Remove'],
-    'cx': ['ReplaceWith']
+    'canGc': ['Before', 'After'],
+    'cx': ['Remove', 'ReplaceWith']
 },
 
 'Clipboard': {
@@ -224,8 +224,8 @@ DOMInterfaces = {
 },
 
 'DocumentType': {
-    'canGc': ['Before', 'After', 'Remove'],
-    'cx': ['ReplaceWith']
+    'canGc': ['Before', 'After'],
+    'cx': ['Remove', 'ReplaceWith']
 },
 
 'DOMImplementation': {
@@ -274,8 +274,8 @@ DOMInterfaces = {
 },
 
 'Element': {
-    'cx': ['SetHTMLUnsafe', 'SetInnerHTML', 'SetOuterHTML', 'InsertAdjacentHTML', 'ToggleAttribute', 'SetAttribute', 'SetAttributeNS', 'SetAttributeNode', 'SetAttributeNodeNS', 'RemoveAttributeNS', 'RemoveAttributeNode', 'SetRole', 'SetAriaAtomic', 'SetAriaAutoComplete', 'SetAriaBrailleLabel', 'SetAriaBrailleRoleDescription', 'SetAriaBusy', 'SetAriaChecked', 'SetAriaColCount', 'SetAriaColIndex', 'SetAriaColIndexText', 'SetAriaColSpan', 'SetAriaCurrent', 'SetAriaDescription', 'SetAriaDisabled', 'SetAriaExpanded', 'SetAriaHasPopup', 'SetAriaHidden', 'SetAriaInvalid', 'SetAriaKeyShortcuts', 'SetAriaLabel', 'SetAriaLevel', 'SetAriaLive', 'SetAriaModal', 'SetAriaMultiLine', 'SetAriaMultiSelectable', 'SetAriaOrientation', 'SetAriaPlaceholder', 'SetAriaPosInSet', 'SetAriaPressed','SetAriaReadOnly', 'SetAriaRelevant', 'SetAriaRequired', 'SetAriaRoleDescription', 'SetAriaRowCount', 'SetAriaRowIndex', 'SetAriaRowIndexText', 'SetAriaRowSpan', 'SetAriaSelected', 'SetAriaSetSize','SetAriaSort', 'SetAriaValueMax', 'SetAriaValueMin', 'SetAriaValueNow', 'SetAriaValueText', 'ReplaceWith'],
-    'canGc': ['GetClientRects', 'GetBoundingClientRect', 'InsertAdjacentText', 'SetId','SetClassName','Prepend','Append','ReplaceChildren','Before','After', 'RequestFullscreen', 'GetHTML', 'GetInnerHTML', 'GetOuterHTML', 'ClassList', 'Attributes', 'GetElementsByTagName', 'GetElementsByTagNameNS', 'GetElementsByClassName', 'Children', 'Remove', 'InsertAdjacentElement', 'AttachShadow', 'RemoveAttribute', 'MoveBefore'],
+    'cx': ['SetHTMLUnsafe', 'SetInnerHTML', 'SetOuterHTML', 'InsertAdjacentHTML', 'ToggleAttribute', 'SetAttribute', 'SetAttributeNS', 'SetAttributeNode', 'SetAttributeNodeNS', 'RemoveAttributeNS', 'RemoveAttributeNode', 'SetRole', 'SetAriaAtomic', 'SetAriaAutoComplete', 'SetAriaBrailleLabel', 'SetAriaBrailleRoleDescription', 'SetAriaBusy', 'SetAriaChecked', 'SetAriaColCount', 'SetAriaColIndex', 'SetAriaColIndexText', 'SetAriaColSpan', 'SetAriaCurrent', 'SetAriaDescription', 'SetAriaDisabled', 'SetAriaExpanded', 'SetAriaHasPopup', 'SetAriaHidden', 'SetAriaInvalid', 'SetAriaKeyShortcuts', 'SetAriaLabel', 'SetAriaLevel', 'SetAriaLive', 'SetAriaModal', 'SetAriaMultiLine', 'SetAriaMultiSelectable', 'SetAriaOrientation', 'SetAriaPlaceholder', 'SetAriaPosInSet', 'SetAriaPressed','SetAriaReadOnly', 'SetAriaRelevant', 'SetAriaRequired', 'SetAriaRoleDescription', 'SetAriaRowCount', 'SetAriaRowIndex', 'SetAriaRowIndexText', 'SetAriaRowSpan', 'SetAriaSelected', 'SetAriaSetSize','SetAriaSort', 'SetAriaValueMax', 'SetAriaValueMin', 'SetAriaValueNow', 'SetAriaValueText', 'ReplaceWith', 'Remove'],
+    'canGc': ['GetClientRects', 'GetBoundingClientRect', 'InsertAdjacentText', 'SetId','SetClassName','Prepend','Append','ReplaceChildren','Before','After', 'RequestFullscreen', 'GetHTML', 'GetInnerHTML', 'GetOuterHTML', 'ClassList', 'Attributes', 'GetElementsByTagName', 'GetElementsByTagNameNS', 'GetElementsByClassName', 'Children', 'InsertAdjacentElement', 'AttachShadow', 'RemoveAttribute', 'MoveBefore'],
 },
 
 'ElementInternals': {
@@ -515,7 +515,7 @@ DOMInterfaces = {
 
 'HTMLOptionsCollection': {
     'canGc': ['SetSelectedIndex'],
-    'cx': ['IndexedSetter', 'SetLength'],
+    'cx': ['IndexedSetter', 'Remove', 'SetLength'],
 },
 
 'HTMLOutputElement': {
@@ -534,7 +534,7 @@ DOMInterfaces = {
 
 'HTMLSelectElement': {
     'canGc': ['SetSelectedIndex', 'SetCustomValidity', 'SetValue', 'Validity'],
-    'cx': ['CheckValidity', 'IndexedSetter', 'ReportValidity', 'SetLength'],
+    'cx': ['CheckValidity', 'IndexedSetter', 'Remove', 'Remove_','ReportValidity', 'SetLength'],
 },
 
 'HTMLStyleElement': {
@@ -543,15 +543,28 @@ DOMInterfaces = {
 
 'HTMLTableElement': {
     'canGc': ['InsertCell', 'InsertRow'],
-    'cx': ['CreateCaption', 'CreateTBody', 'CreateTFoot', 'CreateTHead', 'InsertRow'],
+    'cx': [
+        'CreateCaption',
+        'CreateTBody',
+        'CreateTFoot',
+        'CreateTHead',
+        'DeleteCaption',
+        'DeleteRow',
+        'DeleteTFoot',
+        'DeleteTHead',
+        'InsertRow',
+        'SetCaption',
+        'SetTFoot',
+        'SetTHead'
+    ],
 },
 
 'HTMLTableRowElement': {
-    'cx': ['InsertCell']
+    'cx': ['DeleteCell', 'InsertCell']
 },
 
 'HTMLTableSectionElement': {
-    'cx': ['InsertRow']
+    'cx': ['DeleteRow', 'InsertRow']
 },
 
 'HTMLTemplateElement': {
@@ -659,8 +672,8 @@ DOMInterfaces = {
 },
 
 'Node': {
-    'canGc': ['AppendChild', 'ChildNodes', 'InsertBefore', 'SetNodeValue', 'SetTextContent', 'RemoveChild'],
-    'cx': ['CloneNode', 'Normalize', 'ReplaceChild']
+    'canGc': ['AppendChild', 'ChildNodes', 'InsertBefore', 'SetNodeValue', 'SetTextContent'],
+    'cx': ['CloneNode', 'Normalize', 'RemoveChild', 'ReplaceChild']
 },
 
 'NodeIterator': {
@@ -708,9 +721,9 @@ DOMInterfaces = {
 },
 
 'Range': {
-    'canGc': ['CloneRange', 'InsertNode', 'GetClientRects', 'GetBoundingClientRect'],
+    'canGc': ['CloneRange', 'GetClientRects', 'GetBoundingClientRect'],
     'weakReferenceable': True,
-    'cx': ['CloneContents', 'CreateContextualFragment', 'ExtractContents', 'SurroundContents'],
+    'cx': ['CloneContents', 'CreateContextualFragment', 'DeleteContents', 'ExtractContents', 'InsertNode', 'SurroundContents'],
 },
 
 'Request': {
@@ -733,6 +746,7 @@ DOMInterfaces = {
 
 'Selection': {
     'canGc': ['Collapse', 'CollapseToEnd', 'CollapseToStart', 'Extend', 'SelectAllChildren', 'SetBaseAndExtent', 'SetPosition'],
+    'cx': ['DeleteFromDocument']
 },
 
 'ServiceWorker': {

--- a/components/script_bindings/codegen/Bindings.conf
+++ b/components/script_bindings/codegen/Bindings.conf
@@ -196,8 +196,9 @@ DOMInterfaces = {
 
 'Document': {
     'additionalTraits': ["crate::interfaces::DocumentHelpers"],
-    'canGc': ['CreateEvent', 'CreateRange', 'CreateComment', 'CreateAttribute', 'CreateAttributeNS', 'CreateDocumentFragment', 'CreateTextNode', 'CreateCDATASection', 'CreateProcessingInstruction', 'Prepend', 'Append', 'ReplaceChildren', 'SetBgColor', 'SetFgColor', 'Fonts', 'ExitFullscreen', 'CreateExpression', 'CreateNSResolver', 'Evaluate', 'StyleSheets', 'Implementation', 'GetElementsByTagName', 'GetElementsByTagNameNS', 'GetElementsByClassName', 'AdoptNode', 'CreateNodeIterator', 'GetElementsByName', 'Images', 'Embeds', 'Plugins', 'Links', 'Forms', 'Scripts', 'Anchors', 'Applets', 'Children', 'GetSelection', 'NamedGetter', 'AdoptedStyleSheets', 'SetAdoptedStyleSheets', 'MoveBefore'],
+    'canGc': ['CreateEvent', 'CreateRange', 'CreateComment', 'CreateAttribute', 'CreateAttributeNS', 'CreateDocumentFragment', 'CreateTextNode', 'CreateCDATASection', 'CreateProcessingInstruction', 'Prepend', 'Append', 'ReplaceChildren', 'SetBgColor', 'SetFgColor', 'Fonts', 'ExitFullscreen', 'CreateExpression', 'CreateNSResolver', 'Evaluate', 'StyleSheets', 'Implementation', 'GetElementsByTagName', 'GetElementsByTagNameNS', 'GetElementsByClassName', 'CreateNodeIterator', 'GetElementsByName', 'Images', 'Embeds', 'Plugins', 'Links', 'Forms', 'Scripts', 'Anchors', 'Applets', 'Children', 'GetSelection', 'NamedGetter', 'AdoptedStyleSheets', 'SetAdoptedStyleSheets', 'MoveBefore'],
     'cx': [
+        'AdoptNode',
         'Close',
         'CreateElement',
         'CreateElementNS',

--- a/components/script_bindings/codegen/Bindings.conf
+++ b/components/script_bindings/codegen/Bindings.conf
@@ -99,7 +99,8 @@ DOMInterfaces = {
 },
 
 'CharacterData': {
-    'canGc': ['Before', 'After', 'Remove', 'ReplaceWith'],
+    'canGc': ['Before', 'After', 'Remove'],
+    'cx': ['ReplaceWith']
 },
 
 'Clipboard': {
@@ -195,7 +196,7 @@ DOMInterfaces = {
 
 'Document': {
     'additionalTraits': ["crate::interfaces::DocumentHelpers"],
-    'canGc': ['CreateEvent', 'CreateRange', 'CreateComment', 'CreateAttribute', 'CreateAttributeNS', 'CreateDocumentFragment', 'CreateTextNode', 'CreateCDATASection', 'CreateProcessingInstruction', 'Prepend', 'Append', 'ReplaceChildren', 'SetBgColor', 'SetFgColor', 'Fonts', 'ExitFullscreen', 'CreateExpression', 'CreateNSResolver', 'Evaluate', 'StyleSheets', 'Implementation', 'GetElementsByTagName', 'GetElementsByTagNameNS', 'GetElementsByClassName', 'AdoptNode', 'CreateNodeIterator', 'SetBody', 'GetElementsByName', 'Images', 'Embeds', 'Plugins', 'Links', 'Forms', 'Scripts', 'Anchors', 'Applets', 'Children', 'GetSelection', 'NamedGetter', 'AdoptedStyleSheets', 'SetAdoptedStyleSheets', 'MoveBefore'],
+    'canGc': ['CreateEvent', 'CreateRange', 'CreateComment', 'CreateAttribute', 'CreateAttributeNS', 'CreateDocumentFragment', 'CreateTextNode', 'CreateCDATASection', 'CreateProcessingInstruction', 'Prepend', 'Append', 'ReplaceChildren', 'SetBgColor', 'SetFgColor', 'Fonts', 'ExitFullscreen', 'CreateExpression', 'CreateNSResolver', 'Evaluate', 'StyleSheets', 'Implementation', 'GetElementsByTagName', 'GetElementsByTagNameNS', 'GetElementsByClassName', 'AdoptNode', 'CreateNodeIterator', 'GetElementsByName', 'Images', 'Embeds', 'Plugins', 'Links', 'Forms', 'Scripts', 'Anchors', 'Applets', 'Children', 'GetSelection', 'NamedGetter', 'AdoptedStyleSheets', 'SetAdoptedStyleSheets', 'MoveBefore'],
     'cx': [
         'Close',
         'CreateElement',
@@ -206,6 +207,7 @@ DOMInterfaces = {
         'Open_',
         'ParseHTMLUnsafe',
         'QueryCommandEnabled',
+        'SetBody',
         'SetTitle',
         'Write',
         'Writeln',
@@ -222,7 +224,8 @@ DOMInterfaces = {
 },
 
 'DocumentType': {
-    'canGc': ['Before', 'After', 'Remove', 'ReplaceWith']
+    'canGc': ['Before', 'After', 'Remove'],
+    'cx': ['ReplaceWith']
 },
 
 'DOMImplementation': {
@@ -271,8 +274,8 @@ DOMInterfaces = {
 },
 
 'Element': {
-    'cx': ['SetHTMLUnsafe', 'SetInnerHTML', 'SetOuterHTML', 'InsertAdjacentHTML', 'ToggleAttribute', 'SetAttribute', 'SetAttributeNS', 'SetAttributeNode', 'SetAttributeNodeNS', 'RemoveAttributeNS', 'RemoveAttributeNode', 'SetRole', 'SetAriaAtomic', 'SetAriaAutoComplete', 'SetAriaBrailleLabel', 'SetAriaBrailleRoleDescription', 'SetAriaBusy', 'SetAriaChecked', 'SetAriaColCount', 'SetAriaColIndex', 'SetAriaColIndexText', 'SetAriaColSpan', 'SetAriaCurrent', 'SetAriaDescription', 'SetAriaDisabled', 'SetAriaExpanded', 'SetAriaHasPopup', 'SetAriaHidden', 'SetAriaInvalid', 'SetAriaKeyShortcuts', 'SetAriaLabel', 'SetAriaLevel', 'SetAriaLive', 'SetAriaModal', 'SetAriaMultiLine', 'SetAriaMultiSelectable', 'SetAriaOrientation', 'SetAriaPlaceholder', 'SetAriaPosInSet', 'SetAriaPressed','SetAriaReadOnly', 'SetAriaRelevant', 'SetAriaRequired', 'SetAriaRoleDescription', 'SetAriaRowCount', 'SetAriaRowIndex', 'SetAriaRowIndexText', 'SetAriaRowSpan', 'SetAriaSelected', 'SetAriaSetSize','SetAriaSort', 'SetAriaValueMax', 'SetAriaValueMin', 'SetAriaValueNow', 'SetAriaValueText'],
-    'canGc': ['GetClientRects', 'GetBoundingClientRect', 'InsertAdjacentText', 'SetId','SetClassName','Prepend','Append','ReplaceChildren','Before','After','ReplaceWith', 'RequestFullscreen', 'GetHTML', 'GetInnerHTML', 'GetOuterHTML', 'ClassList', 'Attributes', 'GetElementsByTagName', 'GetElementsByTagNameNS', 'GetElementsByClassName', 'Children', 'Remove', 'InsertAdjacentElement', 'AttachShadow', 'RemoveAttribute', 'MoveBefore'],
+    'cx': ['SetHTMLUnsafe', 'SetInnerHTML', 'SetOuterHTML', 'InsertAdjacentHTML', 'ToggleAttribute', 'SetAttribute', 'SetAttributeNS', 'SetAttributeNode', 'SetAttributeNodeNS', 'RemoveAttributeNS', 'RemoveAttributeNode', 'SetRole', 'SetAriaAtomic', 'SetAriaAutoComplete', 'SetAriaBrailleLabel', 'SetAriaBrailleRoleDescription', 'SetAriaBusy', 'SetAriaChecked', 'SetAriaColCount', 'SetAriaColIndex', 'SetAriaColIndexText', 'SetAriaColSpan', 'SetAriaCurrent', 'SetAriaDescription', 'SetAriaDisabled', 'SetAriaExpanded', 'SetAriaHasPopup', 'SetAriaHidden', 'SetAriaInvalid', 'SetAriaKeyShortcuts', 'SetAriaLabel', 'SetAriaLevel', 'SetAriaLive', 'SetAriaModal', 'SetAriaMultiLine', 'SetAriaMultiSelectable', 'SetAriaOrientation', 'SetAriaPlaceholder', 'SetAriaPosInSet', 'SetAriaPressed','SetAriaReadOnly', 'SetAriaRelevant', 'SetAriaRequired', 'SetAriaRoleDescription', 'SetAriaRowCount', 'SetAriaRowIndex', 'SetAriaRowIndexText', 'SetAriaRowSpan', 'SetAriaSelected', 'SetAriaSetSize','SetAriaSort', 'SetAriaValueMax', 'SetAriaValueMin', 'SetAriaValueNow', 'SetAriaValueText', 'ReplaceWith'],
+    'canGc': ['GetClientRects', 'GetBoundingClientRect', 'InsertAdjacentText', 'SetId','SetClassName','Prepend','Append','ReplaceChildren','Before','After', 'RequestFullscreen', 'GetHTML', 'GetInnerHTML', 'GetOuterHTML', 'ClassList', 'Attributes', 'GetElementsByTagName', 'GetElementsByTagNameNS', 'GetElementsByClassName', 'Children', 'Remove', 'InsertAdjacentElement', 'AttachShadow', 'RemoveAttribute', 'MoveBefore'],
 },
 
 'ElementInternals': {
@@ -440,11 +443,11 @@ DOMInterfaces = {
         'SetAutofocus',
         'SetContentEditable',
         'SetInnerText',
-        'SetOuterText',
         'SetTabIndex',
         'SetTranslate',
         'Style',
     ],
+    'cx': ['SetOuterText']
 },
 
 'HTMLFieldSetElement': {
@@ -656,8 +659,8 @@ DOMInterfaces = {
 },
 
 'Node': {
-    'canGc': ['AppendChild', 'ChildNodes', 'InsertBefore', 'SetNodeValue', 'SetTextContent', 'RemoveChild', 'ReplaceChild'],
-    'cx': ['CloneNode', 'Normalize']
+    'canGc': ['AppendChild', 'ChildNodes', 'InsertBefore', 'SetNodeValue', 'SetTextContent', 'RemoveChild'],
+    'cx': ['CloneNode', 'Normalize', 'ReplaceChild']
 },
 
 'NodeIterator': {

--- a/components/script_bindings/codegen/Bindings.conf
+++ b/components/script_bindings/codegen/Bindings.conf
@@ -99,7 +99,7 @@ DOMInterfaces = {
 },
 
 'CharacterData': {
-    'canGc': ['Before', 'After', 'Remove', 'ReplaceWith']
+    'canGc': ['Before', 'After', 'Remove', 'ReplaceWith'],
 },
 
 'Clipboard': {
@@ -656,8 +656,8 @@ DOMInterfaces = {
 },
 
 'Node': {
-    'canGc': ['AppendChild', 'ChildNodes', 'InsertBefore', 'Normalize', 'SetNodeValue', 'SetTextContent', 'RemoveChild', 'ReplaceChild'],
-    'cx': ['CloneNode']
+    'canGc': ['AppendChild', 'ChildNodes', 'InsertBefore', 'SetNodeValue', 'SetTextContent', 'RemoveChild', 'ReplaceChild'],
+    'cx': ['CloneNode', 'Normalize']
 },
 
 'NodeIterator': {


### PR DESCRIPTION
Switch `VirtualMethods::children_changed` and `VirtualMethods::adopting_steps` to `&mut JSContext`.

Testing: No behaviour change, a successful build is enough.
Part of #40600
