### PR TITLE
script: Move GPUSampler drop logic to a helper struct

### DIFF
--- a/components/script/dom/webgpu/gpusampler.rs
+++ b/components/script/dom/webgpu/gpusampler.rs
@@ -18,17 +18,34 @@ use crate::dom::globalscope::GlobalScope;
 use crate::dom::webgpu::gpudevice::GPUDevice;
 use crate::script_runtime::CanGc;
 
+#[derive(JSTraceable, MallocSizeOf)]
+struct DroppableGPUSampler {
+    #[no_trace]
+    channel: WebGPU,
+    #[no_trace]
+    sampler: WebGPUSampler,
+}
+
+impl Drop for DroppableGPUSampler {
+    fn drop(&mut self) {
+        if let Err(e) = self
+            .channel
+            .0
+            .send(WebGPURequest::DropSampler(self.sampler.0))
+        {
+            warn!("Failed to send DropSampler ({:?}) ({})", self.sampler.0, e);
+        }
+    }
+}
+
 #[dom_struct]
 pub(crate) struct GPUSampler {
     reflector_: Reflector,
-    #[no_trace]
-    channel: WebGPU,
     label: DomRefCell<USVString>,
     #[no_trace]
     device: WebGPUDevice,
     compare_enable: bool,
-    #[no_trace]
-    sampler: WebGPUSampler,
+    dropppable: DroppableGPUSampler,
 }
 
 impl GPUSampler {
@@ -41,11 +58,10 @@ impl GPUSampler {
     ) -> Self {
         Self {
             reflector_: Reflector::new(),
-            channel,
             label: DomRefCell::new(label),
             device,
-            sampler,
             compare_enable,
+            dropppable: DroppableGPUSampler { channel, sampler },
         }
     }
 
@@ -74,7 +90,7 @@ impl GPUSampler {
 
 impl GPUSampler {
     pub(crate) fn id(&self) -> WebGPUSampler {
-        self.sampler
+        self.dropppable.sampler
     }
 
     /// <https://gpuweb.github.io/gpuweb/#dom-gpudevice-createsampler>
@@ -135,17 +151,5 @@ impl GPUSamplerMethods<crate::DomTypeHolder> for GPUSampler {
     /// <https://gpuweb.github.io/gpuweb/#dom-gpuobjectbase-label>
     fn SetLabel(&self, value: USVString) {
         *self.label.borrow_mut() = value;
-    }
-}
-
-impl Drop for GPUSampler {
-    fn drop(&mut self) {
-        if let Err(e) = self
-            .channel
-            .0
-            .send(WebGPURequest::DropSampler(self.sampler.0))
-        {
-            warn!("Failed to send DropSampler ({:?}) ({})", self.sampler.0, e);
-        }
     }
 }

--- a/components/script_bindings/codegen/Bindings.conf
+++ b/components/script_bindings/codegen/Bindings.conf
@@ -367,10 +367,6 @@ DOMInterfaces = {
     'canGc': ['OnSubmittedWorkDone'],
 },
 
-'GPUSampler': {
-    'allowDropImpl': True,
-},
-
 'GPUShaderModule': {
     'allowDropImpl': True,
 },


### PR DESCRIPTION
Implementing `Drop` for DOM types is being forbidden. This moves the resource cleanup logic for `GPUSampler` to a separate `DroppableGPUSampler` struct and removes the `allowDropImpl` flag from the bindings configuration.

Testing: WebGpu tests just cover its cases
Fixes: Partially #26488 
