### PR TITLE
servo: Rename `WebView::pinch_zoom` to `adjust_pinch_zoom` and add pinch zoom getter

### DIFF
--- a/components/paint/paint.rs
+++ b/components/paint/paint.rs
@@ -802,12 +802,21 @@ impl Paint {
             .notify_scroll_event(webview_id, scroll, point);
     }
 
-    pub fn pinch_zoom(&self, webview_id: WebViewId, pinch_zoom_delta: f32, center: DevicePoint) {
+    pub fn adjust_pinch_zoom(
+        &self,
+        webview_id: WebViewId,
+        pinch_zoom_delta: f32,
+        center: DevicePoint,
+    ) {
         if self.shutdown_state() != ShutdownState::NotShuttingDown {
             return;
         }
         self.painter_mut(webview_id.into())
-            .pinch_zoom(webview_id, pinch_zoom_delta, center);
+            .adjust_pinch_zoom(webview_id, pinch_zoom_delta, center);
+    }
+
+    pub fn pinch_zoom(&self, webview_id: WebViewId) -> f32 {
+        self.painter(webview_id.into()).pinch_zoom(webview_id)
     }
 
     pub fn device_pixels_per_page_pixel(

--- a/components/paint/painter.rs
+++ b/components/paint/painter.rs
@@ -1299,7 +1299,7 @@ impl Painter {
         self.webview_renderers
             .get(&webview_id)
             .map(|webview_renderer| webview_renderer.page_zoom.get())
-            .unwrap_or_default()
+            .unwrap_or(1.)
     }
 
     pub(crate) fn notify_input_event(&mut self, webview_id: WebViewId, event: InputEventAndId) {
@@ -1348,7 +1348,7 @@ impl Painter {
         self.lcp_calculator.enabled_for_webview(webview_id)
     }
 
-    pub(crate) fn pinch_zoom(
+    pub(crate) fn adjust_pinch_zoom(
         &mut self,
         webview_id: WebViewId,
         pinch_zoom_delta: f32,
@@ -1357,6 +1357,13 @@ impl Painter {
         if let Some(webview_renderer) = self.webview_renderers.get_mut(&webview_id) {
             webview_renderer.adjust_pinch_zoom(pinch_zoom_delta, center);
         }
+    }
+
+    pub(crate) fn pinch_zoom(&self, webview_id: WebViewId) -> f32 {
+        self.webview_renderers
+            .get(&webview_id)
+            .map(|webview_renderer| webview_renderer.pinch_zoom().zoom_factor().0)
+            .unwrap_or(1.)
     }
 
     pub(crate) fn device_pixels_per_page_pixel(

--- a/components/servo/tests/webview.rs
+++ b/components/servo/tests/webview.rs
@@ -861,7 +861,7 @@ fn test_pinch_zoom_update_dom_visual_viewport() {
     assert_eq!(eval_visual_viewport("offsetLeft"), Ok(JSValue::Number(0.)));
     assert_eq!(eval_visual_viewport("offsetTop"), Ok(JSValue::Number(0.)));
 
-    webview.pinch_zoom(5., DevicePoint::new(100., 100.));
+    webview.adjust_pinch_zoom(5., DevicePoint::new(100., 100.));
     wait_for_webview_scene_to_be_up_to_date(&servo_test, &webview);
 
     // The visual viewport dimension is correct after a pinch zoom.

--- a/components/servo/webview.rs
+++ b/components/servo/webview.rs
@@ -553,11 +553,16 @@ impl WebView {
     ///
     /// The final pinch zoom values will be clamped to reasonable defaults (currently to
     /// the inclusive range [1.0, 10.0]).
-    pub fn pinch_zoom(&self, pinch_zoom_delta: f32, center: DevicePoint) {
+    pub fn adjust_pinch_zoom(&self, pinch_zoom_delta: f32, center: DevicePoint) {
         self.inner()
             .servo
             .paint()
-            .pinch_zoom(self.id(), pinch_zoom_delta, center);
+            .adjust_pinch_zoom(self.id(), pinch_zoom_delta, center);
+    }
+
+    /// Get the pinch zoom of the [`WebView`].
+    pub fn pinch_zoom(&self) -> f32 {
+        self.inner().servo.paint().pinch_zoom(self.id())
     }
 
     pub fn device_pixels_per_css_pixel(&self) -> Scale<f32, CSSPixel, DevicePixel> {

--- a/ports/servoshell/desktop/headed_window.rs
+++ b/ports/servoshell/desktop/headed_window.rs
@@ -712,7 +712,7 @@ impl HeadedWindow {
                         )));
                     },
                     WindowEvent::PinchGesture { delta, .. } => {
-                        webview.pinch_zoom(
+                        webview.adjust_pinch_zoom(
                             delta as f32 + 1.0,
                             self.webview_relative_mouse_point.get(),
                         );

--- a/ports/servoshell/egl/app.rs
+++ b/ports/servoshell/egl/app.rs
@@ -536,7 +536,7 @@ impl App {
     /// x/y are pinch origin coordinates.
     pub fn pinchzoom_start(&self, factor: f32, x: f32, y: f32) {
         if let Some(webview) = self.active_or_newest_webview() {
-            webview.pinch_zoom(factor, DevicePoint::new(x, y));
+            webview.adjust_pinch_zoom(factor, DevicePoint::new(x, y));
             self.spin_event_loop();
         }
     }
@@ -545,7 +545,7 @@ impl App {
     /// x/y are pinch origin coordinates.
     pub fn pinchzoom(&self, factor: f32, x: f32, y: f32) {
         if let Some(webview) = self.active_or_newest_webview() {
-            webview.pinch_zoom(factor, DevicePoint::new(x, y));
+            webview.adjust_pinch_zoom(factor, DevicePoint::new(x, y));
             self.spin_event_loop();
         }
     }
@@ -554,7 +554,7 @@ impl App {
     /// x/y are pinch origin coordinates.
     pub fn pinchzoom_end(&self, factor: f32, x: f32, y: f32) {
         if let Some(webview) = self.active_or_newest_webview() {
-            webview.pinch_zoom(factor, DevicePoint::new(x, y));
+            webview.adjust_pinch_zoom(factor, DevicePoint::new(x, y));
             self.spin_event_loop();
         }
     }


### PR DESCRIPTION
Previously the `pinch_zoom` method on `WebView` would be used to update the page's pinch zoom level, however there was no way for the embedder to retrieve the current pinch zoom.

This patch renames the existing `pinch_zoom` method to `adjust_pinch_zoom` and changes the `pinch_zoom` method to instead return the current pinch zoom level.

---

Decided to go for the breaking change since I'd find `pinch_zoom` combined with `get_pinch_zoom` to be confusing, however I'm happy to change that if a non-breaking change is preferred.

Motivation for this patch is just that I'd like to display the zoom level in my UI while rendering.

Testing: Since this change adds a simple getter to the API, we can probably avoid a unit test in this case.
