### PR TITLE
devtools: Add support for one-way protocol messages

### DIFF
--- a/components/devtools/actors/inspector/highlighter.rs
+++ b/components/devtools/actors/inspector/highlighter.rs
@@ -40,6 +40,8 @@ impl Actor for HighlighterActor {
     /// - `show`: Enables highlighting for the selected node
     ///
     /// - `hide`: Disables highlighting for the selected node
+    ///
+    /// - `finalize`: Performs cleanup for this actor; currently a no-op
     fn handle_message(
         &self,
         request: ClientRequest,
@@ -84,6 +86,10 @@ impl Actor for HighlighterActor {
 
                 let msg = EmptyReplyMsg { from: self.name() };
                 request.reply_final(&msg)?
+            },
+
+            "finalize" => {
+                request.mark_handled();
             },
 
             _ => return Err(ActorError::UnrecognizedPacketType),

--- a/components/devtools/actors/watcher.rs
+++ b/components/devtools/actors/watcher.rs
@@ -215,8 +215,14 @@ impl Actor for WatcherActor {
     ///   returns the associated `BrowsingContextActor`. Every target sent creates a
     ///   `target-available-form` event.
     ///
+    /// - `unwatchTargets`: Stop watching a set of targets.
+    ///   This is currently a no-op because `watchTargets` only returns a point-in-time snapshot.
+    ///
     /// - `watchResources`: Start watching certain resource types. This sends
     ///   `resources-available-array` events.
+    ///
+    /// - `unwatchResources`: Stop watching a set of resources.
+    ///   This is currently a no-op because `watchResources` only returns a point-in-time snapshot.
     ///
     /// - `getNetworkParentActor`: Returns the network parent actor. It doesn't seem to do much at
     ///   the moment.
@@ -273,6 +279,10 @@ impl Actor for WatcherActor {
                 // and processed the message so that it can continue
                 let msg = EmptyReplyMsg { from: self.name() };
                 request.reply_final(&msg)?
+            },
+            "unwatchTargets" => {
+                // "unwatchTargets" messages are one-way and expect no reply.
+                request.mark_handled();
             },
             "watchResources" => {
                 let Some(resource_types) = msg.get("resourceTypes") else {
@@ -356,6 +366,10 @@ impl Actor for WatcherActor {
                 }
                 let msg = EmptyReplyMsg { from: self.name() };
                 request.reply_final(&msg)?
+            },
+            "unwatchResources" => {
+                // "unwatchResources" messages are one-way and expect no reply.
+                request.mark_handled();
             },
             "getParentBrowsingContextID" => {
                 let msg = GetParentBrowsingContextIDReply {

--- a/components/devtools/protocol.rs
+++ b/components/devtools/protocol.rs
@@ -106,8 +106,8 @@ pub(crate) struct ClientRequest<'req, 'sent> {
     stream: &'req mut TcpStream,
     /// Expected actor name.
     actor_name: &'req str,
-    /// Sent flag, allowing ActorRegistry to check for unhandled requests.
-    sent: &'sent mut bool,
+    /// Flag allowing ActorRegistry to check for unhandled requests.
+    handled: &'sent mut bool,
 }
 
 impl ClientRequest<'_, '_> {
@@ -123,7 +123,7 @@ impl ClientRequest<'_, '_> {
         let request = ClientRequest {
             stream: client,
             actor_name,
-            sent: &mut sent,
+            handled: &mut sent,
         };
         handler(request)?;
 
@@ -152,7 +152,7 @@ impl<'req> ClientRequest<'req, '_> {
         reply: &T,
     ) -> Result<&'req mut TcpStream, ActorError> {
         self.stream.write_json_packet(reply)?;
-        *self.sent = true;
+        *self.handled = true;
         Ok(self.stream)
     }
 
@@ -174,6 +174,11 @@ impl<'req> ClientRequest<'req, '_> {
         reply.get("from").and_then(|from| from.as_str()) == Some(self.actor_name) &&
             reply.get("to").is_none() &&
             reply.get("type").is_none()
+    }
+
+    /// Manually mark the request as handled, for one-way message types.
+    pub fn mark_handled(self) {
+        *self.handled = true;
     }
 }
 


### PR DESCRIPTION
Some Remote Debugging Protocol message types are specified as `oneway`, meaning that they expect no reply. Sending anything—including an error—in response to these messages throws the devtools client and actor out of sync.

As noted in the `ClientRequest` docstring, most client messages expect exactly one reply, so `ClientRequest::handle()` includes a fail-safe that automatically sends an error message if none of the `reply()`, `reply_unchecked()`, or `reply_final()` methods have been called.

This change introduces an additional method, `ClientRequest::mark_handled()`,  which allows the actor handling the request to disarm the fail-safe without sending a reply over the wire, and it adds handling logic for 3 one-way message types that are frequently emitted by the Firefox Toolbox.

Testing: This change introduces no new tests. Unless we take the unusual step of enumerating all supported one-way message types and validating each, automated tests provide little assurance of correctness. Meaningfully testing this feature would be cumbersome, and it would likely hamper future development more than it would help.