### PR TITLE
devtools: Implement initial support for showing scope variables

### DIFF
--- a/components/devtools/actors/environment.rs
+++ b/components/devtools/actors/environment.rs
@@ -2,24 +2,34 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
+use std::collections::HashMap;
+
 use devtools_traits::EnvironmentInfo;
 use malloc_size_of_derive::MallocSizeOf;
 use serde::Serialize;
-use serde_json::{Map, Value};
+use serde_json::Value;
 
 use crate::actor::{Actor, ActorEncode, ActorRegistry};
 use crate::actors::object::ObjectActorMsg;
 
-#[derive(Default, Serialize)]
+#[derive(Serialize)]
 struct EnvironmentBindings {
     arguments: Vec<Value>,
-    variables: Map<String, Value>,
+    variables: HashMap<String, EnvironmentVariableDesc>,
 }
 
 #[derive(Serialize)]
 #[serde(rename_all = "camelCase")]
 struct EnvironmentFunction {
     display_name: String,
+}
+
+#[derive(Serialize)]
+struct EnvironmentVariableDesc {
+    value: String,
+    configurable: bool,
+    enumerable: bool,
+    writable: bool,
 }
 
 #[derive(Serialize)]
@@ -87,13 +97,32 @@ impl ActorEncode<EnvironmentActorMsg> for EnvironmentActor {
             type_: self.environment.type_.clone(),
             scope_kind: self.environment.scope_kind.clone(),
             parent,
-            bindings: None,
             function: self
                 .environment
                 .function_display_name
                 .clone()
                 .map(|display_name| EnvironmentFunction { display_name }),
             object: None,
+            bindings: Some(EnvironmentBindings {
+                arguments: [].to_vec(),
+                variables: self
+                    .environment
+                    .binding_variables
+                    .clone()
+                    .into_iter()
+                    .map(|(key, value)| {
+                        (
+                            key,
+                            EnvironmentVariableDesc {
+                                value,
+                                configurable: false,
+                                enumerable: true,
+                                writable: false,
+                            },
+                        )
+                    })
+                    .collect(),
+            }),
         }
     }
 }

--- a/components/script/dom/debugger/debuggerglobalscope.rs
+++ b/components/script/dom/debugger/debuggerglobalscope.rs
@@ -606,6 +606,13 @@ impl DebuggerGlobalScopeMethods<crate::DomTypeHolder> for DebuggerGlobalScope {
             type_: environment.type_.clone().map(String::from),
             scope_kind: environment.scopeKind.clone().map(String::from),
             function_display_name: environment.functionDisplayName.clone().map(String::from),
+            binding_variables: environment
+                .bindingVariables
+                .as_deref()
+                .into_iter()
+                .flatten()
+                .map(|(key, value)| (key.clone().into(), value.clone().into()))
+                .collect(),
         };
 
         let msg = ScriptToDevtoolsControlMsg::CreateEnvironmentActor(

--- a/components/script_bindings/webidls/DebuggerGetEnvironmentEvent.webidl
+++ b/components/script_bindings/webidls/DebuggerGetEnvironmentEvent.webidl
@@ -23,4 +23,5 @@ dictionary EnvironmentInfo {
     DOMString type_;
     DOMString scopeKind;
     DOMString functionDisplayName;
+    record<DOMString, DOMString> bindingVariables;
 };

--- a/components/shared/devtools/lib.rs
+++ b/components/shared/devtools/lib.rs
@@ -613,6 +613,7 @@ pub struct EnvironmentInfo {
     pub type_: Option<String>,
     pub scope_kind: Option<String>,
     pub function_display_name: Option<String>,
+    pub binding_variables: HashMap<String, String>,
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize)]

--- a/resources/debugger.js
+++ b/resources/debugger.js
@@ -411,11 +411,28 @@ function createEnvironmentActor(environment) {
             parent = createEnvironmentActor(environment.parent);
         }
 
+        if (environment.type == "declarative") {
+            info.bindingVariables = buildBindings(environment)
+        }
+
+        // TODO: Update this instead of registering
         actor = registerEnvironmentActor(info, parent);
         environmentActorsToEnvironments.set(actor, environment);
     }
 
     return actor;
+}
+
+function buildBindings(environment) {
+    let bindingVar = new Map();
+    for (const name of environment.names()) {
+        const value = environment.getVariable(name);
+        // <https://searchfox.org/firefox-main/source/devtools/server/actors/environment.js#87>
+        // We should not do this, it is more of a place holder for now.
+        // TODO: build and pass correct structure for this. This structure is very similar to "eval"
+        bindingVar[name] = JSON.stringify(value);
+    }
+    return bindingVar;
 }
 
 // Get a `Debugger.Environment` instance within which evaluation is taking place.


### PR DESCRIPTION
This change implements showing scope variable in Debugger tab. This is still early and we have more work to do.

Next step is building correct data structure and showing different types of variables.

Testing: Manual as well as current tests are passing.
Fixes: part of #36027 