### PR TITLE
servo: Rename `GamepadProvider` to `GamepadDelegate`

### DIFF
--- a/components/servo/gamepad_delegate.rs
+++ b/components/servo/gamepad_delegate.rs
@@ -57,11 +57,11 @@ impl Drop for GamepadHapticEffectRequest {
     }
 }
 
-pub trait GamepadProvider {
+pub trait GamepadDelegate {
     /// Handle a request to play or stop a haptic effect on a connected gamepad.
     fn handle_haptic_effect_request(&self, _request: GamepadHapticEffectRequest) {}
 }
 
-pub(crate) struct DefaultGamepadProvider;
+pub(crate) struct DefaultGamepadDelegate;
 
-impl GamepadProvider for DefaultGamepadProvider {}
+impl GamepadDelegate for DefaultGamepadDelegate {}

--- a/components/servo/lib.rs
+++ b/components/servo/lib.rs
@@ -14,7 +14,7 @@
 
 mod clipboard_delegate;
 #[cfg(feature = "gamepad")]
-mod gamepad_provider;
+mod gamepad_delegate;
 mod gstreamer_plugins;
 mod javascript_evaluator;
 mod network_manager;
@@ -66,8 +66,8 @@ pub use webrender_api::units::{
 
 pub use crate::clipboard_delegate::ClipboardDelegate;
 #[cfg(feature = "gamepad")]
-pub use crate::gamepad_provider::{
-    GamepadHapticEffectRequest, GamepadHapticEffectRequestType, GamepadProvider,
+pub use crate::gamepad_delegate::{
+    GamepadDelegate, GamepadHapticEffectRequest, GamepadHapticEffectRequestType,
 };
 pub use crate::network_manager::{CacheEntry, NetworkManager};
 pub use crate::servo::{Servo, ServoBuilder, run_content_process};

--- a/components/servo/servo.rs
+++ b/components/servo/servo.rs
@@ -75,7 +75,7 @@ use style::global_style_data::StyleThreadPool;
 
 use crate::clipboard_delegate::StringRequest;
 #[cfg(feature = "gamepad")]
-use crate::gamepad_provider::{GamepadHapticEffectRequest, GamepadHapticEffectRequestType};
+use crate::gamepad_delegate::{GamepadHapticEffectRequest, GamepadHapticEffectRequestType};
 use crate::javascript_evaluator::JavaScriptEvaluator;
 use crate::network_manager::NetworkManager;
 use crate::proxies::ConstellationProxy;
@@ -599,7 +599,7 @@ impl ServoInner {
                         }),
                     );
                     webview
-                        .gamepad_provider()
+                        .gamepad_delegate()
                         .handle_haptic_effect_request(request);
                 }
             },
@@ -616,7 +616,7 @@ impl ServoInner {
                         }),
                     );
                     webview
-                        .gamepad_provider()
+                        .gamepad_delegate()
                         .handle_haptic_effect_request(request);
                 }
             },

--- a/components/servo/webview.rs
+++ b/components/servo/webview.rs
@@ -29,7 +29,7 @@ use webrender_api::units::{DeviceIntRect, DevicePixel, DevicePoint, DeviceSize};
 
 use crate::clipboard_delegate::{ClipboardDelegate, DefaultClipboardDelegate};
 #[cfg(feature = "gamepad")]
-use crate::gamepad_provider::{DefaultGamepadProvider, GamepadProvider};
+use crate::gamepad_delegate::{DefaultGamepadDelegate, GamepadDelegate};
 use crate::responders::IpcResponder;
 use crate::webview_delegate::{CreateNewWebViewRequest, DefaultWebViewDelegate, WebViewDelegate};
 use crate::{
@@ -87,7 +87,7 @@ pub(crate) struct WebViewInner {
     pub(crate) delegate: Rc<dyn WebViewDelegate>,
     pub(crate) clipboard_delegate: Rc<dyn ClipboardDelegate>,
     #[cfg(feature = "gamepad")]
-    pub(crate) gamepad_provider: Rc<dyn GamepadProvider>,
+    pub(crate) gamepad_delegate: Rc<dyn GamepadDelegate>,
 
     rendering_context: Rc<dyn RenderingContext>,
     user_content_manager: Option<Rc<UserContentManager>>,
@@ -133,9 +133,9 @@ impl WebView {
                 .clipboard_delegate
                 .unwrap_or_else(|| Rc::new(DefaultClipboardDelegate)),
             #[cfg(feature = "gamepad")]
-            gamepad_provider: builder
-                .gamepad_provider
-                .unwrap_or_else(|| Rc::new(DefaultGamepadProvider)),
+            gamepad_delegate: builder
+                .gamepad_delegate
+                .unwrap_or_else(|| Rc::new(DefaultGamepadDelegate)),
             hidpi_scale_factor: builder.hidpi_scale_factor,
             load_status: LoadStatus::Started,
             status_text: None,
@@ -248,8 +248,8 @@ impl WebView {
     }
 
     #[cfg(feature = "gamepad")]
-    pub fn gamepad_provider(&self) -> Rc<dyn GamepadProvider> {
-        self.inner().gamepad_provider.clone()
+    pub fn gamepad_delegate(&self) -> Rc<dyn GamepadDelegate> {
+        self.inner().gamepad_delegate.clone()
     }
 
     pub fn id(&self) -> WebViewId {
@@ -786,7 +786,7 @@ pub struct WebViewBuilder {
     user_content_manager: Option<Rc<UserContentManager>>,
     clipboard_delegate: Option<Rc<dyn ClipboardDelegate>>,
     #[cfg(feature = "gamepad")]
-    gamepad_provider: Option<Rc<dyn GamepadProvider>>,
+    gamepad_delegate: Option<Rc<dyn GamepadDelegate>>,
 }
 
 impl WebViewBuilder {
@@ -801,7 +801,7 @@ impl WebViewBuilder {
             user_content_manager: None,
             clipboard_delegate: None,
             #[cfg(feature = "gamepad")]
-            gamepad_provider: None,
+            gamepad_delegate: None,
         }
     }
 
@@ -848,11 +848,11 @@ impl WebViewBuilder {
         self
     }
 
-    /// Set the [`GamepadProvider`] for the `WebView` being created. The same
-    /// [`GamepadProvider`] can be shared among multiple `WebView`s.
+    /// Set the [`GamepadDelegate`] for the `WebView` being created. The same
+    /// [`GamepadDelegate`] can be shared among multiple `WebView`s.
     #[cfg(feature = "gamepad")]
-    pub fn gamepad_provider(mut self, gamepad_provider: Rc<dyn GamepadProvider>) -> Self {
-        self.gamepad_provider = Some(gamepad_provider);
+    pub fn gamepad_delegate(mut self, gamepad_delegate: Rc<dyn GamepadDelegate>) -> Self {
+        self.gamepad_delegate = Some(gamepad_delegate);
         self
     }
 

--- a/ports/servoshell/desktop/app.rs
+++ b/ports/servoshell/desktop/app.rs
@@ -29,7 +29,7 @@ use crate::parser::get_default_url;
 use crate::prefs::ServoShellPreferences;
 use crate::running_app_state::RunningAppState;
 #[cfg(feature = "gamepad")]
-use crate::running_app_state::ServoshellGamepadProvider;
+use crate::running_app_state::ServoshellGamepadDelegate;
 use crate::window::{PlatformWindow, ServoShellWindowId};
 
 pub(crate) enum AppState {
@@ -130,7 +130,7 @@ impl App {
             user_content_manager,
             self.preferences.clone(),
             #[cfg(feature = "gamepad")]
-            ServoshellGamepadProvider::maybe_new().map(Rc::new),
+            ServoshellGamepadDelegate::maybe_new().map(Rc::new),
         ));
         running_state.open_window(platform_window, self.initial_url.as_url().clone());
 

--- a/ports/servoshell/desktop/gamepad.rs
+++ b/ports/servoshell/desktop/gamepad.rs
@@ -9,9 +9,9 @@ use gilrs::ff::{BaseEffect, BaseEffectType, Effect, EffectBuilder, Repeat, Repla
 use gilrs::{EventType, Gilrs};
 use log::{debug, warn};
 use servo::{
-    GamepadEvent, GamepadHapticEffectRequest, GamepadHapticEffectRequestType,
-    GamepadHapticEffectType, GamepadIndex, GamepadInputBounds, GamepadProvider,
-    GamepadSupportedHapticEffects, GamepadUpdateType, InputEvent, WebView,
+    GamepadDelegate, GamepadEvent, GamepadHapticEffectRequest, GamepadHapticEffectRequestType,
+    GamepadHapticEffectType, GamepadIndex, GamepadInputBounds, GamepadSupportedHapticEffects,
+    GamepadUpdateType, InputEvent, WebView,
 };
 
 pub struct HapticEffect {
@@ -19,12 +19,12 @@ pub struct HapticEffect {
     pub request: GamepadHapticEffectRequest,
 }
 
-pub(crate) struct ServoshellGamepadProvider {
+pub(crate) struct ServoshellGamepadDelegate {
     handle: RefCell<Gilrs>,
     haptic_effects: RefCell<HashMap<usize, HapticEffect>>,
 }
 
-impl ServoshellGamepadProvider {
+impl ServoshellGamepadDelegate {
     pub(crate) fn maybe_new() -> Option<Self> {
         let handle = match Gilrs::new() {
             Ok(handle) => handle,
@@ -242,7 +242,7 @@ impl ServoshellGamepadProvider {
     }
 }
 
-impl GamepadProvider for ServoshellGamepadProvider {
+impl GamepadDelegate for ServoshellGamepadDelegate {
     fn handle_haptic_effect_request(&self, request: GamepadHapticEffectRequest) {
         match request.request_type() {
             GamepadHapticEffectRequestType::Play(effect_type) => {

--- a/ports/servoshell/running_app_state.rs
+++ b/ports/servoshell/running_app_state.rs
@@ -33,7 +33,7 @@ use url::Url;
     feature = "gamepad",
     not(any(target_os = "android", target_env = "ohos"))
 ))]
-pub(crate) use crate::desktop::gamepad::ServoshellGamepadProvider;
+pub(crate) use crate::desktop::gamepad::ServoshellGamepadDelegate;
 use crate::prefs::{EXPERIMENTAL_PREFS, ServoShellPreferences};
 use crate::webdriver::WebDriverEmbedderControls;
 use crate::window::{PlatformWindow, ServoShellWindow, ServoShellWindowId};
@@ -169,7 +169,7 @@ pub(crate) struct RunningAppState {
         feature = "gamepad",
         not(any(target_os = "android", target_env = "ohos"))
     ))]
-    gamepad_provider: Option<Rc<ServoshellGamepadProvider>>,
+    gamepad_delegate: Option<Rc<ServoshellGamepadDelegate>>,
 
     /// The [`WebDriverSenders`] used to reply to pending WebDriver requests.
     pub(crate) webdriver_senders: RefCell<WebDriverSenders>,
@@ -229,7 +229,7 @@ impl RunningAppState {
             feature = "gamepad",
             not(any(target_os = "android", target_env = "ohos"))
         ))]
-        gamepad_provider: Option<Rc<ServoshellGamepadProvider>>,
+        gamepad_delegate: Option<Rc<ServoshellGamepadDelegate>>,
     ) -> Self {
         servo.set_delegate(Rc::new(ServoShellServoDelegate));
 
@@ -254,7 +254,7 @@ impl RunningAppState {
                 feature = "gamepad",
                 not(any(target_os = "android", target_env = "ohos"))
             ))]
-            gamepad_provider,
+            gamepad_delegate,
             webdriver_senders: RefCell::default(),
             webdriver_embedder_controls: Default::default(),
             pending_webdriver_events: Default::default(),
@@ -324,8 +324,8 @@ impl RunningAppState {
         feature = "gamepad",
         not(any(target_os = "android", target_env = "ohos"))
     ))]
-    pub(crate) fn gamepad_provider(&self) -> Option<Rc<ServoshellGamepadProvider>> {
-        self.gamepad_provider.clone()
+    pub(crate) fn gamepad_delegate(&self) -> Option<Rc<ServoshellGamepadDelegate>> {
+        self.gamepad_delegate.clone()
     }
 
     pub(crate) fn schedule_exit(&self) {
@@ -623,7 +623,7 @@ impl RunningAppState {
         not(any(target_os = "android", target_env = "ohos"))
     ))]
     pub(crate) fn handle_gamepad_events(&self) {
-        let Some(gamepad_provider) = self.gamepad_provider.as_ref() else {
+        let Some(gamepad_delegate) = self.gamepad_delegate.as_ref() else {
             return;
         };
         let Some(active_webview) = self
@@ -632,7 +632,7 @@ impl RunningAppState {
         else {
             return;
         };
-        gamepad_provider.handle_gamepad_events(active_webview);
+        gamepad_delegate.handle_gamepad_events(active_webview);
     }
 
     pub(crate) fn handle_focused(&self, window: Rc<ServoShellWindow>) {

--- a/ports/servoshell/window.rs
+++ b/ports/servoshell/window.rs
@@ -96,8 +96,8 @@ impl ServoShellWindow {
             feature = "gamepad",
             not(any(target_os = "android", target_env = "ohos"))
         ))]
-        if let Some(gamepad_provider) = state.gamepad_provider() {
-            webview_builder = webview_builder.gamepad_provider(gamepad_provider);
+        if let Some(gamepad_delegate) = state.gamepad_delegate() {
+            webview_builder = webview_builder.gamepad_delegate(gamepad_delegate);
         }
 
         let webview = webview_builder.build();


### PR DESCRIPTION
This makes the name of the `GamepadDelegate` consistent with the other
delegates.

Testing: No tests necessary as this is just renaming some structs and members. Compilation should be enough.
