### PR TITLE
devtools: Remove `reply_unchecked` in favour of `mark_handled`

### DIFF
--- a/components/devtools/actors/frame.rs
+++ b/components/devtools/actors/frame.rs
@@ -14,7 +14,7 @@ use crate::actor::{Actor, ActorEncode, ActorError, ActorRegistry};
 use crate::actors::environment::{EnvironmentActor, EnvironmentActorMsg};
 use crate::actors::object::{ObjectActor, ObjectActorMsg};
 use crate::actors::source::SourceActor;
-use crate::protocol::ClientRequest;
+use crate::protocol::{ClientRequest, JsonPacketStream};
 
 #[derive(Serialize)]
 struct FrameEnvironmentReply {
@@ -73,7 +73,7 @@ impl Actor for FrameActor {
     // https://searchfox.org/firefox-main/source/devtools/shared/specs/frame.js
     fn handle_message(
         &self,
-        request: ClientRequest,
+        mut request: ClientRequest,
         registry: &ActorRegistry,
         msg_type: &str,
         _msg: &Map<String, Value>,
@@ -97,7 +97,8 @@ impl Actor for FrameActor {
                 };
                 // This reply has a `type` field but it doesn't need a followup,
                 // unlike most messages. We need to skip the validity check.
-                request.reply_unchecked(&msg)?;
+                request.write_json_packet(&msg)?;
+                request.mark_handled();
             },
             _ => return Err(ActorError::UnrecognizedPacketType),
         };

--- a/components/devtools/protocol.rs
+++ b/components/devtools/protocol.rs
@@ -142,15 +142,6 @@ impl<'req> ClientRequest<'req, '_> {
     /// allowing other messages to be sent after replying to a request.
     pub fn reply<T: Serialize>(self, reply: &T) -> Result<&'req mut TcpStream, ActorError> {
         debug_assert!(self.is_valid_reply(reply), "Message is not a valid reply");
-        self.reply_unchecked(reply)
-    }
-
-    /// Like `reply`, but it doesn't check if it is a valid reply.
-    /// Sometimes the client breaks the rules and expects an out of form message.
-    pub fn reply_unchecked<T: Serialize>(
-        self,
-        reply: &T,
-    ) -> Result<&'req mut TcpStream, ActorError> {
         self.stream.write_json_packet(reply)?;
         *self.handled = true;
         Ok(self.stream)


### PR DESCRIPTION
`reply_unchecked` was added in #42007 since `getEnvironment` from the frame actor has a `type` field but it already counts as a final reply, unlike every other message like it. Since it is only used there, we can revert the `reply_unchecked` change and use the new `mark_handled` instead.

Depends on: #43230
Testing: DevTools tests
