### PR TITLE
config: Remove unused `servo_url` dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7494,7 +7494,6 @@ dependencies = [
  "serde",
  "serde_json",
  "servo-config-macro",
- "servo-url",
  "stylo_static_prefs",
 ]
 

--- a/components/config/Cargo.toml
+++ b/components/config/Cargo.toml
@@ -15,5 +15,4 @@ path = "lib.rs"
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
 servo_config_macro = { package = "servo-config-macro", path = "macro" }
-servo_url = { package = "servo-url", path = "../url" }
 stylo_static_prefs = { workspace = true }


### PR DESCRIPTION
Doesn't seem to be used in the crate anymore.

Testing: If it builds it works. 

