### PR TITLE
Use workspace deps consistently and add version requirement

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -219,77 +219,81 @@ x25519-dalek = { version = "2.0.1", features = ["static_secrets"] }
 xi-unicode = "0.3.0"
 xml5ever = "0.38"
 
+## Independently versioned local crates. These crates will not take part in auto-bumps.
+hyper_serde = { package = "servo-hyper-serde", version = "0.13.2", path = "components/hyper_serde" }
+# Todo: blurmac is the odd-one out here - How will we version it in the future?
+blurmac = { version = "0.1.0", path = "third_party/blurmac" }
+
+
 ############################################################################################
 ## Workspace-local dependencies
 ############################################################################################
 
-background_hang_monitor = { package = "servo-background-hang-monitor", path = "components/background_hang_monitor" }
-background_hang_monitor_api = { package = "servo-background-hang-monitor-api", path = "components/shared/background_hang_monitor" }
-base = { package = "servo-base", path = "components/shared/base" }
-bluetooth = { package = "servo-bluetooth", path = "components/bluetooth" }
-bluetooth_traits = { package = "servo-bluetooth-traits", path = "components/shared/bluetooth" }
-blurmac = { path = "third_party/blurmac" }
-canvas = { package = "servo-canvas", path = "components/canvas" }
-canvas_traits = { package = "servo-canvas-traits", path = "components/shared/canvas" }
-constellation = { package = "servo-constellation", path = "components/constellation" }
-constellation_traits = { package = "servo-constellation-traits", path = "components/shared/constellation" }
-deny_public_fields = { package = "servo-deny-public-fields", path = "components/deny_public_fields" }
-devtools = { package = "servo-devtools", path = "components/devtools" }
-devtools_traits = { package = "servo-devtools-traits", path = "components/shared/devtools" }
-dom_struct = { package = "servo-dom-struct", path = "components/dom_struct" }
-embedder_traits = { package = "servo-embedder-traits", path = "components/shared/embedder" }
-fonts = { package = "servo-fonts", path = "components/fonts" }
-fonts_traits = { package = "servo-fonts-traits", path = "components/shared/fonts" }
-hyper_serde = { package = "servo-hyper-serde", path = "components/hyper_serde" }
-jstraceable_derive = { package = "servo-jstraceable-derive", path = "components/jstraceable_derive" }
-layout = { package = "servo-layout", path = "components/layout" }
-layout_api = { package = "servo-layout-api", path = "components/shared/layout" }
-malloc_size_of = { package = "servo-malloc-size-of", path = "components/malloc_size_of" }
-media = { package = "servo-media-thread", path = "components/media/media-thread" }
-metrics = { package = "servo-metrics", path = "components/metrics" }
-net = { package = "servo-net", path = "components/net" }
-net_traits = { package = "servo-net-traits", path = "components/shared/net" }
-paint = { package = "servo-paint", path = "components/paint" }
-paint_api = { package = "servo-paint-api", path = "components/shared/paint" }
-pixels = { package = "servo-pixels", path = "components/pixels" }
-profile = { package = "servo-profile", path = "components/profile" }
-profile_traits = { package = "servo-profile-traits", path = "components/shared/profile" }
-script = { package = "servo-script", path = "components/script" }
-script_bindings = { package = "servo-script-bindings", path = "components/script_bindings" }
-script_traits = { package = "servo-script-traits", path = "components/shared/script" }
-servo = { path = "components/servo", default-features = false }
-servo-media = { path = "components/media/servo-media" }
-servo-media-audio = { path = "components/media/audio" }
-servo-media-auto = { path = "components/media/backends/auto" }
-servo-media-derive = { path = "components/media/servo-media-derive" }
-servo-media-dummy = { path = "components/media/backends/dummy" }
-servo-media-gstreamer = { path = "components/media/backends/gstreamer" }
-servo-media-gstreamer-render = { path = "components/media/backends/gstreamer/render" }
-servo-media-gstreamer-render-android = { path = "components/media/backends/gstreamer/render-android" }
-servo-media-gstreamer-render-unix = { path = "components/media/backends/gstreamer/render-unix" }
-servo-media-player = { path = "components/media/player" }
-servo-media-streams = { path = "components/media/streams" }
-servo-media-traits = { path = "components/media/traits" }
-servo-media-webrtc = { path = "components/media/webrtc" }
-servo-tracing = { path = "components/servo_tracing" }
-servo-url = { path = "components/url" }
-servo_allocator = { package = "servo-allocator", path = "components/allocator" }
-servo_config = { package = "servo-config", path = "components/config" }
-servo_config_macro = { package = "servo-config-macro", path = "components/config/macro" }
-servo_geometry = { package = "servo-geometry", path = "components/geometry" }
-servo_url = { package = "servo-url", path = "components/url" }
-sm-gst-render = { package = "servo-media-gstreamer-render", path = "components/media/backends/gstreamer/render" }
-sm-player = { package = "servo-media-player", path = "components/media/player" }
-storage = { package = "servo-storage", path = "components/storage" }
-storage_traits = { package = "servo-storage-traits", path = "components/shared/storage" }
-timers = { package = "servo-timers", path = "components/timers" }
-webdriver_server = { package = "servo-webdriver-server", path = "components/webdriver_server" }
-webgl = { package = "servo-webgl", path = "components/webgl", default-features = false }
-webgpu = { package = "servo-webgpu", path = "components/webgpu" }
-webgpu_traits = { package = "servo-webgpu-traits", path = "components/shared/webgpu" }
-webxr = { package = "servo-webxr", path = "components/webxr" }
-webxr-api = { package = "servo-webxr-api", path = "components/shared/webxr" }
-xpath = { package = "servo-xpath", path = "components/xpath" }
+background_hang_monitor = { package = "servo-background-hang-monitor", version = "0.0.1", path = "components/background_hang_monitor" }
+background_hang_monitor_api = { package = "servo-background-hang-monitor-api", version = "0.0.1", path = "components/shared/background_hang_monitor" }
+base = { package = "servo-base", version = "0.0.1", path = "components/shared/base" }
+bluetooth = { package = "servo-bluetooth", version = "0.0.1", path = "components/bluetooth" }
+bluetooth_traits = { package = "servo-bluetooth-traits", version = "0.0.1", path = "components/shared/bluetooth" }
+canvas = { package = "servo-canvas", version = "0.0.1", path = "components/canvas" }
+canvas_traits = { package = "servo-canvas-traits", version = "0.0.1", path = "components/shared/canvas" }
+constellation = { package = "servo-constellation", version = "0.0.1", path = "components/constellation" }
+constellation_traits = { package = "servo-constellation-traits", version = "0.0.1", path = "components/shared/constellation" }
+deny_public_fields = { package = "servo-deny-public-fields", version = "0.0.1", path = "components/deny_public_fields" }
+devtools = { package = "servo-devtools", version = "0.0.1", path = "components/devtools" }
+devtools_traits = { package = "servo-devtools-traits", version = "0.0.1", path = "components/shared/devtools" }
+dom_struct = { package = "servo-dom-struct", version = "0.0.1", path = "components/dom_struct" }
+embedder_traits = { package = "servo-embedder-traits", version = "0.0.1", path = "components/shared/embedder" }
+fonts = { package = "servo-fonts", version = "0.0.1", path = "components/fonts" }
+fonts_traits = { package = "servo-fonts-traits", version = "0.0.1", path = "components/shared/fonts" }
+jstraceable_derive = { package = "servo-jstraceable-derive", version = "0.0.1", path = "components/jstraceable_derive" }
+layout = { package = "servo-layout", version = "0.0.1", path = "components/layout" }
+layout_api = { package = "servo-layout-api", version = "0.0.1", path = "components/shared/layout" }
+malloc_size_of = { package = "servo-malloc-size-of", version = "0.0.1", path = "components/malloc_size_of" }
+media = { package = "servo-media-thread", version = "0.0.1", path = "components/media/media-thread" }
+metrics = { package = "servo-metrics", version = "0.0.1", path = "components/metrics" }
+net = { package = "servo-net", version = "0.0.1", path = "components/net" }
+net_traits = { package = "servo-net-traits", version = "0.0.1", path = "components/shared/net" }
+paint = { package = "servo-paint", version = "0.0.1", path = "components/paint" }
+paint_api = { package = "servo-paint-api", version = "0.0.1", path = "components/shared/paint" }
+pixels = { package = "servo-pixels", version = "0.0.1", path = "components/pixels" }
+profile = { package = "servo-profile", version = "0.0.1", path = "components/profile" }
+profile_traits = { package = "servo-profile-traits", version = "0.0.1", path = "components/shared/profile" }
+script = { package = "servo-script", version = "0.0.1", path = "components/script" }
+script_bindings = { package = "servo-script-bindings", version = "0.0.1", path = "components/script_bindings" }
+script_traits = { package = "servo-script-traits", version = "0.0.1", path = "components/shared/script" }
+servo = { version = "0.0.1", path = "components/servo", default-features = false }
+servo-media = { version = "0.0.1", path = "components/media/servo-media" }
+servo-media-audio = { version = "0.0.1", path = "components/media/audio" }
+servo-media-auto = { version = "0.0.1", path = "components/media/backends/auto" }
+servo-media-derive = { version = "0.0.1", path = "components/media/servo-media-derive" }
+servo-media-dummy = { version = "0.0.1", path = "components/media/backends/dummy" }
+servo-media-gstreamer = { version = "0.0.1", path = "components/media/backends/gstreamer" }
+servo-media-gstreamer-render = { version = "0.0.1", path = "components/media/backends/gstreamer/render" }
+servo-media-gstreamer-render-android = { version = "0.0.1", path = "components/media/backends/gstreamer/render-android" }
+servo-media-gstreamer-render-unix = { version = "0.0.1", path = "components/media/backends/gstreamer/render-unix" }
+servo-media-player = { version = "0.0.1", path = "components/media/player" }
+servo-media-streams = { version = "0.0.1", path = "components/media/streams" }
+servo-media-traits = { version = "0.0.1", path = "components/media/traits" }
+servo-media-webrtc = { version = "0.0.1", path = "components/media/webrtc" }
+servo-tracing = { version = "0.0.1", path = "components/servo_tracing" }
+servo-url = { version = "0.0.1", path = "components/url" }
+servo_allocator = { package = "servo-allocator", version = "0.0.1", path = "components/allocator" }
+servo_config = { package = "servo-config", version = "0.0.1", path = "components/config" }
+servo_config_macro = { package = "servo-config-macro", version = "0.0.1", path = "components/config/macro" }
+servo_geometry = { package = "servo-geometry", version = "0.0.1", path = "components/geometry" }
+servo_url = { package = "servo-url", version = "0.0.1", path = "components/url" }
+sm-gst-render = { package = "servo-media-gstreamer-render", version = "0.0.1", path = "components/media/backends/gstreamer/render" }
+sm-player = { package = "servo-media-player", version = "0.0.1", path = "components/media/player" }
+storage = { package = "servo-storage", version = "0.0.1", path = "components/storage" }
+storage_traits = { package = "servo-storage-traits", version = "0.0.1", path = "components/shared/storage" }
+timers = { package = "servo-timers", version = "0.0.1", path = "components/timers" }
+webdriver_server = { package = "servo-webdriver-server", version = "0.0.1", path = "components/webdriver_server" }
+webgl = { package = "servo-webgl", version = "0.0.1", path = "components/webgl", default-features = false }
+webgpu = { package = "servo-webgpu", version = "0.0.1", path = "components/webgpu" }
+webgpu_traits = { package = "servo-webgpu-traits", version = "0.0.1", path = "components/shared/webgpu" }
+webxr = { package = "servo-webxr", version = "0.0.1", path = "components/webxr" }
+webxr-api = { package = "servo-webxr-api", version = "0.0.1", path = "components/shared/webxr" }
+xpath = { package = "servo-xpath", version = "0.0.1", path = "components/xpath" }
 
 # RSA key generation could be very slow without compilation
 # optimizations, in development mode. Without optimizations, WPT might

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -242,6 +242,51 @@ xi-unicode = "0.3.0"
 xml5ever = "0.38"
 xpath = { package = "servo-xpath", path = "components/xpath" }
 
+background_hang_monitor = { package = "servo-background-hang-monitor", path = "components/background_hang_monitor" }
+bluetooth = { package = "servo-bluetooth", path = "components/bluetooth" }
+blurmac = { path = "third_party/blurmac" }
+canvas = { package = "servo-canvas", path = "components/canvas" }
+constellation = { package = "servo-constellation", path = "components/constellation" }
+deny_public_fields = { package = "servo-deny-public-fields", path = "components/deny_public_fields" }
+devtools = { package = "servo-devtools", path = "components/devtools" }
+dom_struct = { package = "servo-dom-struct", path = "components/dom_struct" }
+fonts = { package = "servo-fonts", path = "components/fonts" }
+jstraceable_derive = { package = "servo-jstraceable-derive", path = "components/jstraceable_derive" }
+layout = { package = "servo-layout", path = "components/layout" }
+media = { package = "servo-media-thread", path = "components/media/media-thread" }
+metrics = { package = "servo-metrics", path = "components/metrics" }
+net = { package = "servo-net", path = "components/net" }
+paint = { package = "servo-paint", path = "components/paint" }
+pixels = { package = "servo-pixels", path = "components/pixels" }
+profile = { package = "servo-profile", path = "components/profile" }
+script = { package = "servo-script", path = "components/script" }
+script_bindings = { package = "servo-script-bindings", path = "components/script_bindings" }
+servo = { path = "components/servo", default-features = false }
+servo-media-audio = { path = "components/media/audio" }
+servo-media-auto = { path = "components/media/backends/auto" }
+servo-media-derive = { path = "components/media/servo-media-derive" }
+servo-media-gstreamer-render = { path = "components/media/backends/gstreamer/render" }
+servo-media-gstreamer-render-android = { path = "components/media/backends/gstreamer/render-android" }
+servo-media-gstreamer-render-unix = { path = "components/media/backends/gstreamer/render-unix" }
+servo-media-player = { path = "components/media/player" }
+servo-media-streams = { path = "components/media/streams" }
+servo-media-traits = { path = "components/media/traits" }
+servo-media-webrtc = { path = "components/media/webrtc" }
+servo-url = { path = "components/url" }
+servo_allocator = { package = "servo-allocator", path = "components/allocator" }
+servo_config = { package = "servo-config", path = "components/config" }
+servo_config_macro = { package = "servo-config-macro", path = "components/config/macro" }
+servo_geometry = { package = "servo-geometry", path = "components/geometry" }
+servo_url = { package = "servo-url", path = "components/url" }
+sm-gst-render = { package = "servo-media-gstreamer-render", path = "components/media/backends/gstreamer/render" }
+sm-player = { package = "servo-media-player", path = "components/media/player" }
+storage = { package = "servo-storage", path = "components/storage" }
+timers = { package = "servo-timers", path = "components/timers" }
+webdriver_server = { package = "servo-webdriver-server", path = "components/webdriver_server" }
+webgl = { package = "servo-webgl", path = "components/webgl", default-features = false }
+webgpu = { package = "servo-webgpu", path = "components/webgpu" }
+webxr = { package = "servo-webxr", path = "components/webxr" }
+
 # RSA key generation could be very slow without compilation
 # optimizations, in development mode. Without optimizations, WPT might
 # consider RSA key generation tests fail due to timeout.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,24 +36,19 @@ arrayvec = "0.7"
 async-tungstenite = { version = "0.33", features = ["tokio-rustls-webpki-roots"] }
 atomic_refcell = "0.1.13"
 aws-lc-rs = { version = "1.16", default-features = false, features = ["aws-lc-sys"] }
-background_hang_monitor_api = { package = "servo-background-hang-monitor-api", path = "components/shared/background_hang_monitor" }
 backtrace = "0.3"
-base = { package = "servo-base", path = "components/shared/base" }
 base64 = "0.22.1"
 base64ct = { version = "1.8", features = ["alloc"] }
 bitflags = "2.11"
-bluetooth_traits = { package = "servo-bluetooth-traits", path = "components/shared/bluetooth" }
 brotli = "8.0.2"
 bytemuck = "1"
 byteorder = "1.5"
-canvas_traits = { package = "servo-canvas-traits", path = "components/shared/canvas" }
 cbc = "0.1.2"
 cfg-if = "1.0.4"
 chacha20poly1305 = "0.10"
 chardetng = "0.1"
 chrono = { version = "0.4", features = ["serde"] }
 cipher = { version = "0.4.4", features = ["alloc"] }
-constellation_traits = { package = "servo-constellation-traits", path = "components/shared/constellation" }
 content-security-policy = { version = "0.6.0", features = ["serde"] }
 cookie = { package = "cookie", version = "0.18" }
 crossbeam-channel = "0.5"
@@ -61,18 +56,15 @@ cssparser = { version = "0.36", features = ["serde"] }
 ctr = "0.9.2"
 data-url = "0.3"
 der = { version = "0.7", features = ["alloc", "derive"] }
-devtools_traits = { package = "servo-devtools-traits", path = "components/shared/devtools" }
 digest = "0.10"
 dpi = "0.1"
 dwrote = "0.11.5"
 ecdsa = "0.16"
 elliptic-curve = "0.13"
-embedder_traits = { package = "servo-embedder-traits", path = "components/shared/embedder" }
 encoding_rs = { version = "0.8", features = ["serde"] }
 env_logger = "0.11"
 euclid = "0.22"
 flate2 = "1.1"
-fonts_traits = { package = "servo-fonts-traits", path = "components/shared/fonts" }
 freetype-sys = "0.20"
 futures = { version = "0.3", default-features = false }
 futures-core = { version = "0.3", default-features = false }
@@ -105,7 +97,6 @@ http-body-util = "0.1"
 hyper = "1.8"
 hyper-rustls = { version = "0.27", default-features = false, features = ["http1", "http2", "logging", "tls12", "webpki-tokio"] }
 hyper-util = { version = "0.1", features = ["client-legacy", "http2", "tokio", "client-proxy"] }
-hyper_serde = { package = "servo-hyper-serde", path = "components/hyper_serde" }
 icu_locid = "1.5.0"
 icu_properties = "1.5.0"
 icu_segmenter = "1.5.0"
@@ -117,11 +108,9 @@ itertools = "0.14"
 js = { package = "mozjs", version = "=0.15.5", default-features = false, features = ["libz-sys", "intl"] }
 keyboard-types = { version = "0.8.3", features = ["serde", "webdriver"] }
 kurbo = { version = "0.12", features = ["euclid"] }
-layout_api = { package = "servo-layout-api", path = "components/shared/layout" }
 libc = "0.2"
 log = "0.4.29"
 mach2 = "0.6"
-malloc_size_of = { package = "servo-malloc-size-of", path = "components/malloc_size_of" }
 malloc_size_of_derive = "0.1"
 markup5ever = "0.38"
 memmap2 = "0.9.10"
@@ -131,7 +120,6 @@ mime_guess = "2.0.5"
 ml-dsa = "0.0.4"
 ml-kem = { version = "0.2", features = ["deterministic"] }
 mozangle = "0.5.5"
-net_traits = { package = "servo-net-traits", path = "components/shared/net" }
 nix = "0.30"
 nom = "8.0.0"
 nom-rfc8288 = "0.4.0"
@@ -145,7 +133,6 @@ objc2-core-graphics = "0.3.2"
 objc2-core-text = "0.3.2"
 ocb3 = "0.1.0"
 openxr = "0.20"
-paint_api = { package = "servo-paint-api", path = "components/shared/paint" }
 p256 = { version = "0.13", features = ["ecdh"] }
 p384 = { version = "0.13", features = ["ecdh"] }
 p521 = { version = "0.13", features = ["ecdh"] }
@@ -155,7 +142,6 @@ percent-encoding = "2.3"
 pkcs8 = { version = "0.10", features = ["rand_core"] }
 postcard = { version = "1.1.3", default-features = false, features = ["use-std"] }
 proc-macro2 = "1"
-profile_traits = { package = "servo-profile-traits", path = "components/shared/profile" }
 quote = "1"
 rand = "0.9"
 raw-window-handle = "0.6"
@@ -168,7 +154,6 @@ rustc-hash = "2.1.1"
 rustls = { version = "0.23", default-features = false, features = ["logging", "std", "tls12"] }
 rustls-pki-types = "1.14"
 rustls-platform-verifier = "0.6.2"
-script_traits = { package = "servo-script-traits", path = "components/shared/script" }
 sea-query = { version = "1.0.0-rc.31", default-features = false, features = ["backend-sqlite", "derive"] }
 sea-query-rusqlite = { version = "0.8.0-rc.15" }
 sec1 = "0.7"
@@ -177,17 +162,12 @@ serde = "1.0.228"
 serde_bytes = "0.11"
 serde_core = "1.0.226"
 serde_json = "1.0"
-servo-media = { path = "components/media/servo-media" }
-servo-media-dummy = { path = "components/media/backends/dummy" }
-servo-media-gstreamer = { path = "components/media/backends/gstreamer" }
-servo-tracing = { path = "components/servo_tracing" }
 servo_arc = { git = "https://github.com/servo/stylo", rev = "dca3934667dae76c49bb579b268c5eb142d09c6a" }
 sha1 = "0.10"
 sha2 = "0.10"
 sha3 = "0.10"
 skrifa = "0.37.0"
 smallvec = { version = "1.15", features = ["serde", "union"] }
-storage_traits = { package = "servo-storage-traits", path = "components/shared/storage" }
 string_cache = "0.9"
 strum = { version = "0.28", features = ["derive"] }
 stylo = { git = "https://github.com/servo/stylo", rev = "dca3934667dae76c49bb579b268c5eb142d09c6a" }
@@ -225,11 +205,9 @@ uuid = { version = "1.22.0", features = ["v4", "v5"] }
 vello = "0.6"
 vello_cpu = "0.0.4"
 webdriver = "0.53.0"
-webgpu_traits = { package = "servo-webgpu-traits", path = "components/shared/webgpu" }
 webpki-roots = "1.0"
 webrender = { version = "0.68", features = ["capture"] }
 webrender_api = "0.68"
-webxr-api = { package = "servo-webxr-api", path = "components/shared/webxr" }
 wgpu-core = "26"
 wgpu-types = "26"
 winapi = "0.3"
@@ -240,31 +218,52 @@ wr_malloc_size_of = "0.2.2"
 x25519-dalek = { version = "2.0.1", features = ["static_secrets"] }
 xi-unicode = "0.3.0"
 xml5ever = "0.38"
-xpath = { package = "servo-xpath", path = "components/xpath" }
+
+############################################################################################
+## Workspace-local dependencies
+############################################################################################
 
 background_hang_monitor = { package = "servo-background-hang-monitor", path = "components/background_hang_monitor" }
+background_hang_monitor_api = { package = "servo-background-hang-monitor-api", path = "components/shared/background_hang_monitor" }
+base = { package = "servo-base", path = "components/shared/base" }
 bluetooth = { package = "servo-bluetooth", path = "components/bluetooth" }
+bluetooth_traits = { package = "servo-bluetooth-traits", path = "components/shared/bluetooth" }
 blurmac = { path = "third_party/blurmac" }
 canvas = { package = "servo-canvas", path = "components/canvas" }
+canvas_traits = { package = "servo-canvas-traits", path = "components/shared/canvas" }
 constellation = { package = "servo-constellation", path = "components/constellation" }
+constellation_traits = { package = "servo-constellation-traits", path = "components/shared/constellation" }
 deny_public_fields = { package = "servo-deny-public-fields", path = "components/deny_public_fields" }
 devtools = { package = "servo-devtools", path = "components/devtools" }
+devtools_traits = { package = "servo-devtools-traits", path = "components/shared/devtools" }
 dom_struct = { package = "servo-dom-struct", path = "components/dom_struct" }
+embedder_traits = { package = "servo-embedder-traits", path = "components/shared/embedder" }
 fonts = { package = "servo-fonts", path = "components/fonts" }
+fonts_traits = { package = "servo-fonts-traits", path = "components/shared/fonts" }
+hyper_serde = { package = "servo-hyper-serde", path = "components/hyper_serde" }
 jstraceable_derive = { package = "servo-jstraceable-derive", path = "components/jstraceable_derive" }
 layout = { package = "servo-layout", path = "components/layout" }
+layout_api = { package = "servo-layout-api", path = "components/shared/layout" }
+malloc_size_of = { package = "servo-malloc-size-of", path = "components/malloc_size_of" }
 media = { package = "servo-media-thread", path = "components/media/media-thread" }
 metrics = { package = "servo-metrics", path = "components/metrics" }
 net = { package = "servo-net", path = "components/net" }
+net_traits = { package = "servo-net-traits", path = "components/shared/net" }
 paint = { package = "servo-paint", path = "components/paint" }
+paint_api = { package = "servo-paint-api", path = "components/shared/paint" }
 pixels = { package = "servo-pixels", path = "components/pixels" }
 profile = { package = "servo-profile", path = "components/profile" }
+profile_traits = { package = "servo-profile-traits", path = "components/shared/profile" }
 script = { package = "servo-script", path = "components/script" }
 script_bindings = { package = "servo-script-bindings", path = "components/script_bindings" }
+script_traits = { package = "servo-script-traits", path = "components/shared/script" }
 servo = { path = "components/servo", default-features = false }
+servo-media = { path = "components/media/servo-media" }
 servo-media-audio = { path = "components/media/audio" }
 servo-media-auto = { path = "components/media/backends/auto" }
 servo-media-derive = { path = "components/media/servo-media-derive" }
+servo-media-dummy = { path = "components/media/backends/dummy" }
+servo-media-gstreamer = { path = "components/media/backends/gstreamer" }
 servo-media-gstreamer-render = { path = "components/media/backends/gstreamer/render" }
 servo-media-gstreamer-render-android = { path = "components/media/backends/gstreamer/render-android" }
 servo-media-gstreamer-render-unix = { path = "components/media/backends/gstreamer/render-unix" }
@@ -272,6 +271,7 @@ servo-media-player = { path = "components/media/player" }
 servo-media-streams = { path = "components/media/streams" }
 servo-media-traits = { path = "components/media/traits" }
 servo-media-webrtc = { path = "components/media/webrtc" }
+servo-tracing = { path = "components/servo_tracing" }
 servo-url = { path = "components/url" }
 servo_allocator = { package = "servo-allocator", path = "components/allocator" }
 servo_config = { package = "servo-config", path = "components/config" }
@@ -281,11 +281,15 @@ servo_url = { package = "servo-url", path = "components/url" }
 sm-gst-render = { package = "servo-media-gstreamer-render", path = "components/media/backends/gstreamer/render" }
 sm-player = { package = "servo-media-player", path = "components/media/player" }
 storage = { package = "servo-storage", path = "components/storage" }
+storage_traits = { package = "servo-storage-traits", path = "components/shared/storage" }
 timers = { package = "servo-timers", path = "components/timers" }
 webdriver_server = { package = "servo-webdriver-server", path = "components/webdriver_server" }
 webgl = { package = "servo-webgl", path = "components/webgl", default-features = false }
 webgpu = { package = "servo-webgpu", path = "components/webgpu" }
+webgpu_traits = { package = "servo-webgpu-traits", path = "components/shared/webgpu" }
 webxr = { package = "servo-webxr", path = "components/webxr" }
+webxr-api = { package = "servo-webxr-api", path = "components/shared/webxr" }
+xpath = { package = "servo-xpath", path = "components/xpath" }
 
 # RSA key generation could be very slow without compilation
 # optimizations, in development mode. Without optimizations, WPT might

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -219,16 +219,13 @@ x25519-dalek = { version = "2.0.1", features = ["static_secrets"] }
 xi-unicode = "0.3.0"
 xml5ever = "0.38"
 
-## Independently versioned local crates. These crates will not take part in auto-bumps.
-hyper_serde = { package = "servo-hyper-serde", version = "0.13.2", path = "components/hyper_serde" }
-# Todo: blurmac is the odd-one out here - How will we version it in the future?
-blurmac = { version = "0.1.0", path = "third_party/blurmac" }
-
-
 ############################################################################################
 ## Workspace-local dependencies
 ############################################################################################
-
+# All local path dependencies in the servo workspace, that use the workspace version, should
+# be listed here, between the `Begin` and `End` comments, so that we can easily find and
+# update the version requirements when bumping the workspace version.
+# Begin workspace-version dependencies - Don't change this comment, we grep for it in scripts!
 background_hang_monitor = { package = "servo-background-hang-monitor", version = "0.0.1", path = "components/background_hang_monitor" }
 background_hang_monitor_api = { package = "servo-background-hang-monitor-api", version = "0.0.1", path = "components/shared/background_hang_monitor" }
 base = { package = "servo-base", version = "0.0.1", path = "components/shared/base" }
@@ -294,6 +291,11 @@ webgpu_traits = { package = "servo-webgpu-traits", version = "0.0.1", path = "co
 webxr = { package = "servo-webxr", version = "0.0.1", path = "components/webxr" }
 webxr-api = { package = "servo-webxr-api", version = "0.0.1", path = "components/shared/webxr" }
 xpath = { package = "servo-xpath", version = "0.0.1", path = "components/xpath" }
+# End workspace-version dependencies - Don't change this comment, we grep for it in scripts!
+
+# Independently versioned workspace local crates. These crates will not take part in auto-bumps.
+hyper_serde = { package = "servo-hyper-serde", version = "0.13.2", path = "components/hyper_serde" }
+blurmac = { version = "0.1.0", path = "third_party/blurmac" }
 
 # RSA key generation could be very slow without compilation
 # optimizations, in development mode. Without optimizations, WPT might

--- a/components/bluetooth/Cargo.toml
+++ b/components/bluetooth/Cargo.toml
@@ -19,7 +19,7 @@ blurmock = { version = "0.1.2", optional = true }
 embedder_traits = { workspace = true }
 log = { workspace = true }
 rand = { workspace = true }
-servo_config = { package = "servo-config", path = "../config" }
+servo_config = { workspace = true }
 uuid = { workspace = true }
 
 [target.'cfg(target_os = "linux")'.dependencies]
@@ -29,7 +29,7 @@ blurz = { version = "0.3", optional = true }
 blurdroid = { version = "0.1.2", optional = true }
 
 [target.'cfg(target_os = "macos")'.dependencies]
-blurmac = { path = "../../third_party/blurmac", optional = true }
+blurmac = { workspace = true, optional = true }
 
 [features]
 default = ["bluetooth-test"]

--- a/components/canvas/Cargo.toml
+++ b/components/canvas/Cargo.toml
@@ -21,18 +21,18 @@ bytemuck = { workspace = true, features = ["extern_crate_alloc"] }
 canvas_traits = { workspace = true }
 crossbeam-channel = { workspace = true }
 euclid = { workspace = true }
-fonts = { package = "servo-fonts", path = "../fonts" }
+fonts = { workspace = true }
 futures-intrusive = { version = "0.5", optional = true }
 kurbo = { workspace = true }
 log = { workspace = true }
 paint_api = { workspace = true }
 peniko = { workspace = true }
-pixels = { package = "servo-pixels", path = "../pixels" }
+pixels = { workspace = true }
 profile_traits = { workspace = true }
 pollster = { version = "0.4", optional = true }
 rustc-hash = { workspace = true }
 servo-tracing = { workspace = true }
-servo_config = { package = "servo-config", path = "../config" }
+servo_config = { workspace = true }
 stylo = { workspace = true }
 tracing = { workspace = true, optional = true }
 vello = { workspace = true, optional = true }

--- a/components/config/Cargo.toml
+++ b/components/config/Cargo.toml
@@ -14,5 +14,5 @@ path = "lib.rs"
 [dependencies]
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
-servo_config_macro = { package = "servo-config-macro", path = "macro" }
+servo_config_macro = { workspace = true }
 stylo_static_prefs = { workspace = true }

--- a/components/constellation/Cargo.toml
+++ b/components/constellation/Cargo.toml
@@ -24,12 +24,12 @@ unwrap_used = "deny"
 panic = "deny"
 
 [dependencies]
-background_hang_monitor = { package = "servo-background-hang-monitor", path = "../background_hang_monitor" }
+background_hang_monitor = { workspace = true }
 background_hang_monitor_api = { workspace = true }
 backtrace = { workspace = true }
 base = { workspace = true }
 bluetooth_traits = { workspace = true, optional = true }
-canvas = { package = "servo-canvas", path = "../canvas" }
+canvas = { workspace = true }
 canvas_traits = { workspace = true }
 constellation_traits = { workspace = true }
 content-security-policy = { workspace = true }
@@ -37,30 +37,30 @@ crossbeam-channel = { workspace = true }
 devtools_traits = { workspace = true }
 embedder_traits = { workspace = true }
 euclid = { workspace = true }
-fonts = { package = "servo-fonts", path = "../fonts" }
+fonts = { workspace = true }
 ipc-channel = { workspace = true }
 keyboard-types = { workspace = true }
 layout_api = { workspace = true }
 log = { workspace = true }
-media = { package = "servo-media-thread", path = "../media/media-thread" }
-net = { package = "servo-net", path = "../net" }
+media = { workspace = true }
+net = { workspace = true }
 net_traits = { workspace = true }
 paint_api = { workspace = true }
 parking_lot = { workspace = true }
-profile = { package = "servo-profile", path = "../profile" }
+profile = { workspace = true }
 profile_traits = { workspace = true }
 rand = { workspace = true }
 rustc-hash = { workspace = true }
 script_traits = { workspace = true }
 serde = { workspace = true }
 servo-tracing = { workspace = true }
-servo_config = { package = "servo-config", path = "../config" }
-servo_url = { package = "servo-url", path = "../url" }
+servo_config = { workspace = true }
+servo_url = { workspace = true }
 storage_traits = { workspace = true }
 stylo = { workspace = true }
 stylo_traits = { workspace = true }
 tracing = { workspace = true, optional = true }
-webgpu = { package = "servo-webgpu", path = "../webgpu" }
+webgpu = { workspace = true }
 webgpu_traits = { workspace = true }
 webrender = { workspace = true }
 webrender_api = { workspace = true }

--- a/components/devtools/Cargo.toml
+++ b/components/devtools/Cargo.toml
@@ -24,15 +24,15 @@ http = { workspace = true }
 log = { workspace = true }
 malloc_size_of = { workspace = true }
 malloc_size_of_derive = { workspace = true }
-net = { package = "servo-net", path = "../net" }
+net = { workspace = true }
 net_traits = { workspace = true }
 profile_traits = { workspace = true }
 rand = { workspace = true }
 rustc-hash = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
-servo_config = { package = "servo-config", path = "../config" }
-servo_url = { package = "servo-url", path = "../url" }
+servo_config = { workspace = true }
+servo_url = { workspace = true }
 uuid = { workspace = true }
 
 [build-dependencies]

--- a/components/fonts/Cargo.toml
+++ b/components/fonts/Cargo.toml
@@ -42,8 +42,8 @@ read-fonts = { workspace = true }
 serde = { workspace = true }
 servo-tracing = { workspace = true }
 servo_arc = { workspace = true }
-servo_config = { package = "servo-config", path = "../config" }
-servo_url = { package = "servo-url", path = "../url" }
+servo_config = { workspace = true }
+servo_url = { workspace = true }
 skrifa = { workspace = true }
 smallvec = { workspace = true }
 rustc-hash = { workspace = true }
@@ -64,7 +64,7 @@ objc2-core-text = { workspace = true }
 
 [target.'cfg(any(target_os = "linux", target_os = "android"))'.dependencies]
 freetype-sys = { workspace = true }
-servo_allocator = { package = "servo-allocator", path = "../allocator" }
+servo_allocator = { workspace = true }
 
 [target.'cfg(all(target_os = "linux", not(target_env = "ohos")))'.dependencies]
 fontconfig_sys = { package = "yeslogic-fontconfig-sys", version = "6" }

--- a/components/layout/Cargo.toml
+++ b/components/layout/Cargo.toml
@@ -26,7 +26,7 @@ cssparser = { workspace = true }
 data-url = { workspace = true }
 embedder_traits = { workspace = true }
 euclid = { workspace = true }
-fonts = { package = "servo-fonts", path = "../fonts" }
+fonts = { workspace = true }
 fonts_traits = { workspace = true }
 html5ever = { workspace = true }
 icu_locid = { workspace = true }
@@ -40,18 +40,18 @@ malloc_size_of_derive = { workspace = true }
 net_traits = { workspace = true }
 paint_api = { workspace = true }
 parking_lot = { workspace = true }
-pixels = { package = "servo-pixels", path = "../pixels" }
+pixels = { workspace = true }
 profile_traits = { workspace = true }
 rayon = { workspace = true }
 rustc-hash = { workspace = true }
-script = { package = "servo-script", path = "../script" }
+script = { workspace = true }
 script_traits = { workspace = true }
 selectors = { workspace = true }
 servo-tracing = { workspace = true }
 servo_arc = { workspace = true }
-servo_config = { package = "servo-config", path = "../config" }
-servo_geometry = { package = "servo-geometry", path = "../geometry" }
-servo_url = { package = "servo-url", path = "../url" }
+servo_config = { workspace = true }
+servo_geometry = { workspace = true }
+servo_url = { workspace = true }
 smallvec = { workspace = true }
 strum = { workspace = true }
 stylo = { workspace = true }

--- a/components/malloc_size_of/Cargo.toml
+++ b/components/malloc_size_of/Cargo.toml
@@ -25,7 +25,7 @@ markup5ever = { workspace = true }
 mime = { workspace = true }
 parking_lot = { workspace = true }
 resvg = { workspace = true }
-servo_allocator = { package = "servo-allocator", path = "../allocator" }
+servo_allocator = { workspace = true }
 servo_arc = { workspace = true }
 smallvec = { workspace = true }
 string_cache = { workspace = true }

--- a/components/media/audio/Cargo.toml
+++ b/components/media/audio/Cargo.toml
@@ -16,10 +16,10 @@ euclid = "0.22"
 log = "0.4"
 serde_derive = "1.0.66"
 serde = "1.0.66"
-servo-media-derive = { path = "../servo-media-derive" }
-servo-media-player = { path = "../player" }
-servo-media-traits = { path = "../traits" }
-servo-media-streams = { path = "../streams" }
+servo-media-derive = { workspace = true }
+servo-media-player = { workspace = true }
+servo-media-traits = { workspace = true }
+servo-media-streams = { workspace = true }
 smallvec = "1"
 speexdsp-resampler = "0.1.0"
 malloc_size_of = { workspace = true }

--- a/components/media/backends/auto/Cargo.toml
+++ b/components/media/backends/auto/Cargo.toml
@@ -11,8 +11,9 @@ rust-version.workspace = true
 name = "servo_media_auto"
 path = "lib.rs"
 
-[target.'cfg(any(all(target_os = "android", any(target_arch = "arm", target_arch = "aarch64")), target_arch = "x86_64",target_arch = "aarch64"))'.dependencies.servo-media-gstreamer]
-path = "../gstreamer"
+[target.'cfg(any(all(target_os = "android", any(target_arch = "arm", target_arch = "aarch64")), target_arch = "x86_64",target_arch = "aarch64"))'.dependencies]
+servo-media-gstreamer = { workspace = true }
 
-[target.'cfg(not(any(all(target_os = "android", any(target_arch = "arm", target_arch = "aarch64")), target_arch = "x86_64", target_arch = "aarch64")))'.dependencies.servo-media-dummy]
-path = "../dummy"
+[target.'cfg(not(any(all(target_os = "android", any(target_arch = "arm", target_arch = "aarch64")), target_arch = "x86_64", target_arch = "aarch64")))'.dependencies]
+servo-media-dummy = { workspace = true }
+

--- a/components/media/backends/dummy/Cargo.toml
+++ b/components/media/backends/dummy/Cargo.toml
@@ -13,9 +13,9 @@ path = "lib.rs"
 
 [dependencies]
 ipc-channel = { workspace = true }
-servo-media = { path = "../../servo-media" }
-servo-media-audio = { path = "../../audio" }
-servo-media-player = { path = "../../player" }
-servo-media-streams = { path = "../../streams" }
-servo-media-traits = { path = "../../traits" }
-servo-media-webrtc = { path = "../../webrtc" }
+servo-media = { workspace = true }
+servo-media-audio = { workspace = true }
+servo-media-player = { workspace = true }
+servo-media-streams = { workspace = true }
+servo-media-traits = { workspace = true }
+servo-media-webrtc = { workspace = true }

--- a/components/media/backends/gstreamer/Cargo.toml
+++ b/components/media/backends/gstreamer/Cargo.toml
@@ -32,19 +32,19 @@ ipc-channel = { workspace = true }
 log = "0.4"
 mime = "0.3.13"
 once_cell = "1.18.0"
-servo-media = { path = "../../servo-media" }
-servo-media-audio = { path = "../../audio" }
-servo-media-gstreamer-render = { path = "render" }
-servo-media-player = { path = "../../player" }
-servo-media-streams = { path = "../../streams" }
-servo-media-traits = { path = "../../traits" }
-servo-media-webrtc = { path = "../../webrtc" }
+servo-media = { workspace = true }
+servo-media-audio = { workspace = true }
+servo-media-gstreamer-render = { workspace = true }
+servo-media-player = { workspace = true }
+servo-media-streams = { workspace = true }
+servo-media-traits = { workspace = true }
+servo-media-webrtc = { workspace = true }
 url = "2.0"
 
 [target.'cfg(any(target_os = "linux", target_os = "dragonfly", target_os = "freebsd", target_os = "netbsd", target_os = "openbsd"))'.dependencies]
-servo-media-gstreamer-render-unix = { path = "render-unix", features = [
+servo-media-gstreamer-render-unix = { workspace = true, features = [
     "gl-egl",
 ] }
 
 [target.'cfg(target_os = "android")'.dependencies]
-servo-media-gstreamer-render-android = { path = "render-android" }
+servo-media-gstreamer-render-android = { workspace = true }

--- a/components/media/backends/gstreamer/render-android/Cargo.toml
+++ b/components/media/backends/gstreamer/render-android/Cargo.toml
@@ -17,5 +17,5 @@ gstreamer = { workspace = true }
 gstreamer-gl = { workspace = true }
 gstreamer-gl-egl = { workspace = true }
 gstreamer-video = { workspace = true }
-sm-player = { package = "servo-media-player", path = "../../../player" }
-sm-gst-render = { package = "servo-media-gstreamer-render", path = "../render" }
+sm-player = { workspace = true }
+sm-gst-render = { workspace = true }

--- a/components/media/backends/gstreamer/render-unix/Cargo.toml
+++ b/components/media/backends/gstreamer/render-unix/Cargo.toml
@@ -24,5 +24,5 @@ gstreamer-gl-egl = { workspace = true, optional = true }
 gstreamer-gl-x11 = { workspace = true, optional = true }
 gstreamer-gl-wayland = { workspace = true, optional = true }
 gstreamer-video = { workspace = true }
-sm-player = { package = "servo-media-player", path = "../../../player" }
-sm-gst-render = { package = "servo-media-gstreamer-render", path = "../render" }
+sm-player = { workspace = true }
+sm-gst-render = { workspace = true }

--- a/components/media/backends/gstreamer/render/Cargo.toml
+++ b/components/media/backends/gstreamer/render/Cargo.toml
@@ -14,7 +14,5 @@ path = "lib.rs"
 [dependencies]
 gstreamer = { workspace = true }
 gstreamer-video = { workspace = true }
+sm-player = { workspace = true }
 
-[dependencies.sm-player]
-package = "servo-media-player"
-path = "../../../player"

--- a/components/media/backends/ohos/Cargo.toml
+++ b/components/media/backends/ohos/Cargo.toml
@@ -12,12 +12,12 @@ name = "servo_media_ohos"
 path = "lib.rs"
 
 [dependencies]
-servo-media = { path = "../../servo-media" }
-servo-media-audio = { path = "../../audio" }
-servo-media-player = { path = "../../player" }
-servo-media-streams = { path = "../../streams" }
-servo-media-traits = { path = "../../traits" }
-servo-media-webrtc = { path = "../../webrtc" }
+servo-media = { workspace = true }
+servo-media-audio = { workspace = true }
+servo-media-player = { workspace = true }
+servo-media-streams = { workspace = true }
+servo-media-traits = { workspace = true }
+servo-media-webrtc = { workspace = true }
 mime = "0.3.13"
 once_cell = "1.18.0"
 log = "0.4"

--- a/components/media/examples/Cargo.toml
+++ b/components/media/examples/Cargo.toml
@@ -12,5 +12,5 @@ euclid = { workspace = true }
 rand = { workspace = true }
 serde = { workspace = true }
 servo-media = { workspace = true }
-servo-media-auto = { path = "../backends/auto" }
-servo-media-dummy = { path = "../backends/dummy" }
+servo-media-auto = { workspace = true }
+servo-media-dummy = { workspace = true }

--- a/components/media/media-thread/Cargo.toml
+++ b/components/media/media-thread/Cargo.toml
@@ -19,7 +19,7 @@ paint_api = { workspace = true }
 rustc-hash = { workspace = true }
 serde = { workspace = true }
 servo-media = { workspace = true }
-servo_config = { package = "servo-config", path = "../../config" }
+servo_config = { workspace = true }
 malloc_size_of = { workspace = true }
 malloc_size_of_derive = { workspace = true }
 webrender_api = { workspace = true }

--- a/components/media/player/Cargo.toml
+++ b/components/media/player/Cargo.toml
@@ -17,9 +17,6 @@ serde_derive = "1.0.66"
 ipc-channel = { workspace = true }
 malloc_size_of = { workspace = true }
 malloc_size_of_derive = { workspace = true }
+servo-media-streams = { workspace = true }
+servo-media-traits = { workspace = true }
 
-[dependencies.servo-media-streams]
-path = "../streams"
-
-[dependencies.servo-media-traits]
-path = "../traits"

--- a/components/media/servo-media/Cargo.toml
+++ b/components/media/servo-media/Cargo.toml
@@ -13,18 +13,9 @@ path = "lib.rs"
 
 [dependencies]
 once_cell = "1.18.0"
+servo-media-audio = { workspace = true }
+servo-media-player = { workspace = true }
+servo-media-streams = { workspace = true }
+servo-media-traits = { workspace = true }
+servo-media-webrtc = { workspace = true }
 
-[dependencies.servo-media-audio]
-path = "../audio"
-
-[dependencies.servo-media-player]
-path = "../player"
-
-[dependencies.servo-media-streams]
-path = "../streams"
-
-[dependencies.servo-media-traits]
-path = "../traits"
-
-[dependencies.servo-media-webrtc]
-path = "../webrtc"

--- a/components/media/webrtc/Cargo.toml
+++ b/components/media/webrtc/Cargo.toml
@@ -13,6 +13,5 @@ path = "lib.rs"
 [dependencies]
 log = "0.4"
 uuid = { version = "1.4", features = ["v4"] }
+servo-media-streams = { workspace = true }
 
-[dependencies.servo-media-streams]
-path = "../streams"

--- a/components/media/webrtc/Cargo.toml
+++ b/components/media/webrtc/Cargo.toml
@@ -12,6 +12,5 @@ path = "lib.rs"
 
 [dependencies]
 log = "0.4"
-uuid = { version = "1.4", features = ["v4"] }
 servo-media-streams = { workspace = true }
-
+uuid = { version = "1.4", features = ["v4"] }

--- a/components/metrics/Cargo.toml
+++ b/components/metrics/Cargo.toml
@@ -18,5 +18,5 @@ malloc_size_of_derive = { workspace = true }
 paint_api = { workspace = true }
 profile_traits = { workspace = true }
 script_traits = { workspace = true }
-servo_config = { package = "servo-config", path = "../config" }
-servo_url = { package = "servo-url", path = "../url" }
+servo_config = { workspace = true }
+servo_url = { workspace = true }

--- a/components/net/Cargo.toml
+++ b/components/net/Cargo.toml
@@ -55,7 +55,7 @@ net_traits = { workspace = true }
 nom = { workspace = true }
 paint_api = { workspace = true }
 parking_lot = { workspace = true }
-pixels = { package = "servo-pixels", path = "../pixels" }
+pixels = { workspace = true }
 profile_traits = { workspace = true }
 quick_cache = { version = "0.6.18", default-features = false, features = ["ahash"] }
 regex = { workspace = true }
@@ -66,8 +66,8 @@ rustls-pki-types = { workspace = true }
 rustls-platform-verifier = { workspace = true }
 serde = { workspace = true }
 servo_arc = { workspace = true }
-servo_config = { package = "servo-config", path = "../config" }
-servo_url = { package = "servo-url", path = "../url" }
+servo_config = { workspace = true }
+servo_url = { workspace = true }
 sha2 = { workspace = true }
 time = { workspace = true }
 tokio = { workspace = true, features = ["macros", "rt-multi-thread", "sync"] }
@@ -87,7 +87,7 @@ flate2 = { workspace = true }
 fst = "0.4"
 hyper = { workspace = true, features = ["full"] }
 hyper-util = { workspace = true, features = ["server-graceful"] }
-net = { package = "servo-net", path = "../net", features = ["test-util"] }
+net = { workspace = true, features = ["test-util"] }
 rustls = { workspace = true, features = ["aws-lc-rs"] }
 
 [[test]]

--- a/components/paint/Cargo.toml
+++ b/components/paint/Cargo.toml
@@ -34,26 +34,26 @@ gleam = { workspace = true }
 image = { workspace = true }
 ipc-channel = { workspace = true }
 log = { workspace = true }
-media = { package = "servo-media-thread", path = "../media/media-thread" }
+media = { workspace = true }
 malloc_size_of = { workspace = true }
 paint_api = { workspace = true }
 profile_traits = { workspace = true }
 rayon = { workspace = true }
 rustc-hash = { workspace = true }
 servo-tracing = { workspace = true }
-servo_allocator = { package = "servo-allocator", path = "../allocator" }
-servo_config = { package = "servo-config", path = "../config" }
-servo_geometry = { package = "servo-geometry", path = "../geometry" }
+servo_allocator = { workspace = true }
+servo_config = { workspace = true }
+servo_geometry = { workspace = true }
 smallvec = { workspace = true }
 stylo_traits = { workspace = true }
 surfman = { workspace = true }
-timers = { package = "servo-timers", path = "../timers" }
+timers = { workspace = true }
 tracing = { workspace = true, optional = true }
-webgl = { package = "servo-webgl", path = "../webgl" }
-webgpu = { package = "servo-webgpu", path = "../webgpu", optional = true }
+webgl = { workspace = true }
+webgpu = { workspace = true, optional = true }
 webrender = { workspace = true }
 webrender_api = { workspace = true }
-webxr = { package = "servo-webxr", path = "../webxr", optional = true }
+webxr = { workspace = true, optional = true }
 webxr-api = { workspace = true, optional = true }
 wr_malloc_size_of = { workspace = true }
 

--- a/components/profile/Cargo.toml
+++ b/components/profile/Cargo.toml
@@ -17,8 +17,8 @@ log = { workspace = true }
 profile_traits = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
-servo_allocator = { package = "servo-allocator", path = "../allocator" }
-servo_config = { package = "servo-config", path = "../config" }
+servo_allocator = { workspace = true }
+servo_config = { workspace = true }
 time = { workspace = true }
 
 [target.'cfg(target_os = "macos")'.dependencies]

--- a/components/script/Cargo.toml
+++ b/components/script/Cargo.toml
@@ -62,18 +62,18 @@ crossbeam-channel = { workspace = true }
 cssparser = { workspace = true }
 ctr = { workspace = true }
 data-url = { workspace = true }
-deny_public_fields = { package = "servo-deny-public-fields", path = "../deny_public_fields" }
+deny_public_fields = { workspace = true }
 der = { workspace = true }
 devtools_traits = { workspace = true }
 digest = { workspace = true }
-dom_struct = { package = "servo-dom-struct", path = "../dom_struct" }
+dom_struct = { workspace = true }
 ecdsa = { workspace = true }
 elliptic-curve = { workspace = true }
 embedder_traits = { workspace = true }
 encoding_rs = { workspace = true }
 euclid = { workspace = true }
 flate2 = { workspace = true }
-fonts = { package = "servo-fonts", path = "../fonts" }
+fonts = { workspace = true }
 fonts_traits = { workspace = true }
 glow = { workspace = true }
 headers = { workspace = true }
@@ -86,7 +86,7 @@ indexmap = { workspace = true }
 ipc-channel = { workspace = true }
 itertools = { workspace = true }
 js = { workspace = true }
-jstraceable_derive = { package = "servo-jstraceable-derive", path = "../jstraceable_derive" }
+jstraceable_derive = { workspace = true }
 keyboard-types = { workspace = true }
 kurbo = { workspace = true }
 layout_api = { workspace = true }
@@ -95,8 +95,8 @@ log = { workspace = true }
 malloc_size_of = { workspace = true }
 malloc_size_of_derive = { workspace = true }
 markup5ever = { workspace = true }
-media = { package = "servo-media-thread", path = "../media/media-thread" }
-metrics = { package = "servo-metrics", path = "../metrics" }
+media = { workspace = true }
+metrics = { workspace = true }
 mime = { workspace = true }
 mime-multipart-hyper1 = { workspace = true }
 mime_guess = { workspace = true }
@@ -115,7 +115,7 @@ p521 = { workspace = true }
 parking_lot = { workspace = true }
 percent-encoding = { workspace = true }
 phf = "0.13"
-pixels = { package = "servo-pixels", path = "../pixels" }
+pixels = { workspace = true }
 pkcs8 = { workspace = true }
 postcard = { workspace = true }
 profile_traits = { workspace = true }
@@ -123,7 +123,7 @@ rand = { workspace = true }
 regex = { workspace = true }
 rsa = { workspace = true }
 rustc-hash = { workspace = true }
-script_bindings = { package = "servo-script-bindings", path = "../script_bindings" }
+script_bindings = { workspace = true }
 script_traits = { workspace = true }
 sec1 = { workspace = true }
 selectors = { workspace = true }
@@ -131,9 +131,9 @@ serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true, features = ["preserve_order"] }
 servo-media = { workspace = true }
 servo_arc = { workspace = true }
-servo_config = { package = "servo-config", path = "../config" }
-servo_geometry = { package = "servo-geometry", path = "../geometry" }
-servo_url = { package = "servo-url", path = "../url" }
+servo_config = { workspace = true }
+servo_geometry = { workspace = true }
+servo_url = { workspace = true }
 sha1 = { workspace = true }
 sha2 = { workspace = true }
 sha3 = { workspace = true }
@@ -149,7 +149,7 @@ swapper = "0.1"
 tempfile = "3"
 tendril = { workspace = true }
 time = { workspace = true }
-timers = { package = "servo-timers", path = "../timers" }
+timers = { workspace = true }
 tracing = { workspace = true, optional = true }
 unicode-bidi = { workspace = true }
 unicode-script = { workspace = true }

--- a/components/script_bindings/Cargo.toml
+++ b/components/script_bindings/Cargo.toml
@@ -21,13 +21,13 @@ path = "lib.rs"
 base = { workspace = true }
 bitflags = { workspace = true }
 crossbeam-channel = { workspace = true }
-deny_public_fields = { package = "servo-deny-public-fields", path = "../deny_public_fields" }
-dom_struct = { package = "servo-dom-struct", path = "../dom_struct" }
+deny_public_fields = { workspace = true }
+dom_struct = { workspace = true }
 encoding_rs = { workspace = true }
 html5ever = { workspace = true }
 indexmap = { workspace = true }
 js = { workspace = true }
-jstraceable_derive = { package = "servo-jstraceable-derive", path = "../jstraceable_derive" }
+jstraceable_derive = { workspace = true }
 keyboard-types = { workspace = true }
 libc = { workspace = true }
 log = { workspace = true }
@@ -39,8 +39,8 @@ phf = "0.13"
 profile_traits = { workspace = true }
 regex = { workspace = true }
 servo_arc = { workspace = true }
-servo_config = { package = "servo-config", path = "../config" }
-servo_url = { package = "servo-url", path = "../url" }
+servo_config = { workspace = true }
+servo_url = { workspace = true }
 smallvec = { workspace = true }
 stylo = { workspace = true }
 stylo_atoms = { workspace = true }

--- a/components/servo/Cargo.toml
+++ b/components/servo/Cargo.toml
@@ -74,51 +74,51 @@ webxr = [
 
 [dependencies]
 accesskit = { workspace = true }
-background_hang_monitor = { package = "servo-background-hang-monitor", path = "../background_hang_monitor" }
+background_hang_monitor = { workspace = true }
 base = { workspace = true }
 bitflags = { workspace = true }
-bluetooth = { package = "servo-bluetooth", path = "../bluetooth", optional = true }
+bluetooth = { workspace = true, optional = true }
 bluetooth_traits = { workspace = true, optional = true }
 canvas_traits = { workspace = true }
-constellation = { package = "servo-constellation", path = "../constellation" }
+constellation = { workspace = true }
 constellation_traits = { workspace = true }
 crossbeam-channel = { workspace = true }
-devtools = { package = "servo-devtools", path = "../devtools" }
+devtools = { workspace = true }
 devtools_traits = { workspace = true }
 dpi = { workspace = true }
 embedder_traits = { workspace = true }
 env_logger = { workspace = true }
 euclid = { workspace = true }
-fonts = { package = "servo-fonts", path = "../fonts" }
+fonts = { workspace = true }
 gstreamer = { workspace = true, optional = true }
 image = { workspace = true }
 ipc-channel = { workspace = true }
 keyboard-types = { workspace = true }
-layout = { package = "servo-layout", path = "../layout" }
+layout = { workspace = true }
 layout_api = { workspace = true }
 log = { workspace = true }
-media = { package = "servo-media-thread", path = "../media/media-thread" }
+media = { workspace = true }
 mozangle = { workspace = true }
-net = { package = "servo-net", path = "../net" }
+net = { workspace = true }
 net_traits = { workspace = true }
-paint = { package = "servo-paint", path = "../paint" }
+paint = { workspace = true }
 paint_api = { workspace = true }
 parking_lot = { workspace = true }
-profile = { package = "servo-profile", path = "../profile" }
+profile = { workspace = true }
 profile_traits = { workspace = true }
 rustc-hash = { workspace = true }
-script = { package = "servo-script", path = "../script" }
+script = { workspace = true }
 script_traits = { workspace = true }
 serde = { workspace = true }
 servo-media = { workspace = true }
 servo-media-dummy = { workspace = true }
 servo-media-gstreamer = { workspace = true, optional = true }
 servo-tracing = { workspace = true }
-servo_allocator = { package = "servo-allocator", path = "../allocator" }
-servo_config = { package = "servo-config", path = "../config" }
-servo_geometry = { package = "servo-geometry", path = "../geometry" }
-servo_url = { package = "servo-url", path = "../url" }
-storage = { package = "servo-storage", path = "../storage" }
+servo_allocator = { workspace = true }
+servo_config = { workspace = true }
+servo_geometry = { workspace = true }
+servo_url = { workspace = true }
+storage = { workspace = true }
 storage_traits = { workspace = true }
 stylo = { workspace = true }
 stylo_traits = { workspace = true }
@@ -126,31 +126,31 @@ surfman = { workspace = true }
 tokio = { workspace = true, features = ["sync"] }
 tracing = { workspace = true, optional = true }
 url = { workspace = true }
-webgl = { package = "servo-webgl", path = "../webgl", default-features = false }
-webgpu = { package = "servo-webgpu", path = "../webgpu" }
+webgl = { workspace = true, default-features = false }
+webgpu = { workspace = true }
 webrender = { workspace = true }
 webrender_api = { workspace = true }
 webxr-api = { workspace = true, optional = true }
 
 [target.'cfg(any(target_os = "android", target_env = "ohos"))'.dependencies]
-webxr = { package = "servo-webxr", path = "../webxr", optional = true }
+webxr = { workspace = true, optional = true }
 
 [target.'cfg(not(any(target_os = "android", target_env = "ohos")))'.dependencies]
 arboard = { workspace = true, optional = true }
-webxr = { package = "servo-webxr", path = "../webxr", features = ["glwindow", "headless"] }
+webxr = { workspace = true, features = ["glwindow", "headless"] }
 
 [target.'cfg(all(not(target_os = "windows"), not(target_os = "ios"), not(target_os = "android"), not(target_env = "ohos"), not(target_arch = "arm"), not(target_arch = "aarch64")))'.dependencies]
 gaol = "0.2.1"
 
 [target.'cfg(target_os = "windows")'.dependencies]
-webxr = { package = "servo-webxr", path = "../webxr", features = ["glwindow", "headless", "openxr-api"] }
+webxr = { workspace = true, features = ["glwindow", "headless", "openxr-api"] }
 
 [dev-dependencies]
 http = { workspace = true }
 http-body-util = { workspace = true }
 hyper = { workspace = true }
-servo = { path = ".", features = ["tracing"] }
-net = { package = "servo-net", path = "../net", features = ["test-util"] }
+servo = { workspace = true, features = ["tracing"] }
+net = { workspace = true, features = ["test-util"] }
 rustls = { version = "0.23", default-features = false }
 tracing = { workspace = true }
 winit = { workspace = true }

--- a/components/shared/base/Cargo.toml
+++ b/components/shared/base/Cargo.toml
@@ -23,7 +23,7 @@ parking_lot = { workspace = true }
 rayon = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
-servo_config = { package = "servo-config", path = "../../config" }
+servo_config = { workspace = true }
 time = { workspace = true }
 webrender_api = { workspace = true }
 log = { workspace = true }

--- a/components/shared/canvas/Cargo.toml
+++ b/components/shared/canvas/Cargo.toml
@@ -23,9 +23,9 @@ glow = { workspace = true }
 kurbo = { workspace = true, features = ["serde"] }
 malloc_size_of = { workspace = true }
 malloc_size_of_derive = { workspace = true }
-pixels = { package = "servo-pixels", path = "../../pixels" }
+pixels = { workspace = true }
 serde = { workspace = true }
-servo_config = { package = "servo-config", path = "../../config" }
+servo_config = { workspace = true }
 strum = { workspace = true }
 stylo = { workspace = true }
 webrender_api = { workspace = true }

--- a/components/shared/constellation/Cargo.toml
+++ b/components/shared/constellation/Cargo.toml
@@ -32,12 +32,12 @@ malloc_size_of = { workspace = true }
 malloc_size_of_derive = { workspace = true }
 net_traits = { workspace = true }
 paint_api = { workspace = true }
-pixels = { package = "servo-pixels", path = "../../pixels" }
+pixels = { workspace = true }
 profile_traits = { workspace = true }
 rustc-hash = { workspace = true }
 serde = { workspace = true }
-servo_config = { package = "servo-config", path = "../../config" }
-servo_url = { package = "servo-url", path = "../../url" }
+servo_config = { workspace = true }
+servo_url = { workspace = true }
 storage_traits = { workspace = true }
 strum = { workspace = true }
 stylo_traits = { workspace = true }

--- a/components/shared/devtools/Cargo.toml
+++ b/components/shared/devtools/Cargo.toml
@@ -22,5 +22,5 @@ malloc_size_of_derive = { workspace = true }
 net_traits = { workspace = true }
 profile_traits = { workspace = true }
 serde = { workspace = true }
-servo_url = { package = "servo-url", path = "../../url" }
+servo_url = { workspace = true }
 uuid = { workspace = true, features = ["serde"] }

--- a/components/shared/embedder/Cargo.toml
+++ b/components/shared/embedder/Cargo.toml
@@ -31,11 +31,11 @@ keyboard-types = { workspace = true }
 log = { workspace = true }
 malloc_size_of = { workspace = true }
 malloc_size_of_derive = { workspace = true }
-pixels = { package = "servo-pixels", path = "../../pixels" }
+pixels = { workspace = true }
 rustc-hash = { workspace = true }
 serde = { workspace = true }
-servo_geometry = { package = "servo-geometry", path = "../../geometry" }
-servo_url = { package = "servo-url", path = "../../url" }
+servo_geometry = { workspace = true }
+servo_url = { workspace = true }
 strum = { workspace = true }
 stylo = { workspace = true }
 stylo_traits = { workspace = true }

--- a/components/shared/fonts/Cargo.toml
+++ b/components/shared/fonts/Cargo.toml
@@ -24,7 +24,7 @@ parking_lot = { workspace = true }
 profile_traits = { workspace = true }
 read-fonts = { workspace = true }
 serde = { workspace = true }
-servo_url = { package = "servo-url", path = "../../url" }
+servo_url = { workspace = true }
 stylo = { workspace = true }
 webrender_api = { workspace = true }
 

--- a/components/shared/layout/Cargo.toml
+++ b/components/shared/layout/Cargo.toml
@@ -19,7 +19,7 @@ base = { workspace = true }
 bitflags = { workspace = true }
 embedder_traits = { workspace = true }
 euclid = { workspace = true }
-fonts = { package = "servo-fonts", path = "../../fonts" }
+fonts = { workspace = true }
 fonts_traits = { workspace = true }
 html5ever = { workspace = true }
 libc = { workspace = true }
@@ -28,14 +28,14 @@ malloc_size_of_derive = { workspace = true }
 net_traits = { workspace = true }
 paint_api = { workspace = true }
 parking_lot = { workspace = true }
-pixels = { package = "servo-pixels", path = "../../pixels" }
+pixels = { workspace = true }
 profile_traits = { workspace = true }
 rustc-hash = { workspace = true }
 script_traits = { workspace = true }
 selectors = { workspace = true }
 serde = { workspace = true }
 servo_arc = { workspace = true }
-servo_url = { package = "servo-url", path = "../../url" }
+servo_url = { workspace = true }
 stylo = { workspace = true }
 stylo_traits = { workspace = true }
 webrender_api = { workspace = true }

--- a/components/shared/net/Cargo.toml
+++ b/components/shared/net/Cargo.toml
@@ -33,15 +33,15 @@ num-traits = { workspace = true }
 paint_api = { workspace = true }
 parking_lot = { workspace = true }
 percent-encoding = { workspace = true }
-pixels = { package = "servo-pixels", path = "../../pixels" }
-profile_traits = { package = "servo-profile-traits", path = "../profile" }
+pixels = { workspace = true }
+profile_traits = { workspace = true }
 rand = { workspace = true }
 rustc-hash = { workspace = true }
 rustls-pki-types = { workspace = true }
 serde = { workspace = true }
 servo_arc = { workspace = true }
-servo_config = { package = "servo-config", path = "../../config" }
-servo_url = { package = "servo-url", path = "../../url" }
+servo_config = { workspace = true }
+servo_url = { workspace = true }
 sys-locale = "0.3"
 tokio = { workspace = true }
 url = { workspace = true }

--- a/components/shared/paint/Cargo.toml
+++ b/components/shared/paint/Cargo.toml
@@ -30,14 +30,14 @@ log = { workspace = true }
 malloc_size_of = { workspace = true }
 malloc_size_of_derive = { workspace = true }
 parking_lot = { workspace = true }
-pixels = { package = "servo-pixels", path = "../../pixels" }
-profile_traits = { package = "servo-profile-traits", path = "../profile" }
+pixels = { workspace = true }
+profile_traits = { workspace = true }
 raw-window-handle = { workspace = true }
 rustc-hash = { workspace = true }
 serde = { workspace = true }
 serde_bytes = { workspace = true }
-servo_geometry = { package = "servo-geometry", path = "../../geometry" }
-servo-url = { path = "../../url" }
+servo_geometry = { workspace = true }
+servo-url = { workspace = true }
 smallvec = { workspace = true }
 strum = { workspace = true }
 servo-tracing = { workspace = true }

--- a/components/shared/profile/Cargo.toml
+++ b/components/shared/profile/Cargo.toml
@@ -22,7 +22,7 @@ log = { workspace = true }
 malloc_size_of = { workspace = true }
 malloc_size_of_derive = { workspace = true }
 serde = { workspace = true }
-servo_allocator = { package = "servo-allocator", path = "../../allocator" }
-servo_config = { package = "servo-config", path = "../../config" }
+servo_allocator = { workspace = true }
+servo_config = { workspace = true }
 time = { workspace = true }
 tracing = { workspace = true, optional = true }

--- a/components/shared/script/Cargo.toml
+++ b/components/shared/script/Cargo.toml
@@ -32,15 +32,15 @@ keyboard-types = { workspace = true }
 log = { workspace = true }
 malloc_size_of = { workspace = true }
 malloc_size_of_derive = { workspace = true }
-media = { package = "servo-media-thread", path = "../../media/media-thread" }
+media = { workspace = true }
 net_traits = { workspace = true }
 paint_api = { workspace = true }
-pixels = { package = "servo-pixels", path = "../../pixels" }
+pixels = { workspace = true }
 profile_traits = { workspace = true }
 rustc-hash = { workspace = true }
 serde = { workspace = true }
-servo_config = { package = "servo-config", path = "../../config" }
-servo_url = { package = "servo-url", path = "../../url" }
+servo_config = { workspace = true }
+servo_url = { workspace = true }
 storage_traits = { workspace = true }
 strum = { workspace = true }
 stylo_atoms = { workspace = true }

--- a/components/shared/storage/Cargo.toml
+++ b/components/shared/storage/Cargo.toml
@@ -15,7 +15,7 @@ path = "lib.rs"
 base = { workspace = true }
 malloc_size_of = { workspace = true }
 malloc_size_of_derive = { workspace = true }
-profile_traits = { package = "servo-profile-traits", path = "../profile" }
+profile_traits = { workspace = true }
 serde = { workspace = true }
-servo_url = { package = "servo-url", path = "../../url" }
+servo_url = { workspace = true }
 uuid = { workspace = true, features = ["serde"] }

--- a/components/shared/webgpu/Cargo.toml
+++ b/components/shared/webgpu/Cargo.toml
@@ -16,7 +16,7 @@ arrayvec = { workspace = true }
 base = { workspace = true }
 malloc_size_of = { workspace = true }
 malloc_size_of_derive = { workspace = true }
-pixels = { package = "servo-pixels", path = "../../pixels" }
+pixels = { workspace = true }
 serde = { workspace = true }
 webrender_api = { workspace = true }
 wgpu-core = { workspace = true, features = ["serde", "wgsl"] }

--- a/components/storage/Cargo.toml
+++ b/components/storage/Cargo.toml
@@ -27,8 +27,8 @@ sea-query = { workspace = true }
 sea-query-rusqlite = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
-servo_config = { package = "servo-config", path = "../config" }
-servo_url = { package = "servo-url", path = "../url" }
+servo_config = { workspace = true }
+servo_url = { workspace = true }
 storage_traits = { workspace = true }
 tempfile = "3"
 tokio = { workspace = true, features = ["macros", "rt-multi-thread", "sync"] }
@@ -38,7 +38,7 @@ tokio-util = { workspace = true, features = ["codec", "io"] }
 uuid = { workspace = true }
 
 [dev-dependencies]
-profile = { package = "servo-profile", path = "../profile" }
+profile = { workspace = true }
 url = { workspace = true }
 
 [[test]]

--- a/components/webdriver_server/Cargo.toml
+++ b/components/webdriver_server/Cargo.toml
@@ -25,9 +25,9 @@ log = { workspace = true }
 rustc-hash = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
-servo_config = { package = "servo-config", path = "../config" }
-servo_geometry = { package = "servo-geometry", path = "../geometry" }
-servo_url = { package = "servo-url", path = "../url" }
+servo_config = { workspace = true }
+servo_geometry = { workspace = true }
+servo_url = { workspace = true }
 stylo_traits = { workspace = true }
 time = { workspace = true }
 uuid = { workspace = true }

--- a/components/webgl/Cargo.toml
+++ b/components/webgl/Cargo.toml
@@ -28,10 +28,10 @@ itertools = { workspace = true }
 log = { workspace = true }
 paint_api = { workspace = true }
 parking_lot = { workspace = true }
-pixels = { package = "servo-pixels", path = "../pixels" }
+pixels = { workspace = true }
 rustc-hash = { workspace = true }
 surfman = { workspace = true }
 webrender = { workspace = true }
 webrender_api = { workspace = true }
-webxr = { package = "servo-webxr", path = "../webxr", optional = true }
+webxr = { workspace = true, optional = true }
 webxr-api = { workspace = true, optional = true }

--- a/components/webgpu/Cargo.toml
+++ b/components/webgpu/Cargo.toml
@@ -17,25 +17,20 @@ base = { workspace = true }
 euclid = { workspace = true }
 log = { workspace = true }
 paint_api = { workspace = true }
-pixels = { package = "servo-pixels", path = "../pixels" }
+pixels = { workspace = true }
 rustc-hash = { workspace = true }
-servo_config = { package = "servo-config", path = "../config" }
+servo_config = { workspace = true }
 webgpu_traits = { workspace = true }
 webrender_api = { workspace = true }
 wgpu-core = { workspace = true, features = ["serde", "wgsl"] }
 wgpu-types = { workspace = true }
 
 # We want the wgpu-core Metal backend on macOS and iOS.
-[target.'cfg(any(target_os = "ios", target_os = "macos"))'.dependencies.wgpu-core]
-workspace = true
-features = ["metal"]
+[target.'cfg(any(target_os = "ios", target_os = "macos"))'.dependencies]
+wgpu-core = { workspace = true, features = ["metal"] }
 
-# We want the wgpu-core Vulkan backend on Linux and Windows.
-[target.'cfg(any(windows, all(unix, not(any(target_os = "macos", target_os = "ios")))))'.dependencies.wgpu-core]
-workspace = true
-features = ["gles", "vulkan"]
+[target.'cfg(any(windows, all(unix, not(any(target_os = "macos", target_os = "ios")))))'.dependencies]
+wgpu-core = { workspace = true, features = ["gles", "vulkan"] }
 
-# We want the wgpu-core Direct3D backends on Windows.
-[target.'cfg(windows)'.dependencies.wgpu-core]
-workspace = true
-features = ["dx12", "vulkan"]
+[target.'cfg(windows)'.dependencies]
+wgpu-core = { workspace = true, features = ["dx12", "vulkan"] }

--- a/ports/servoshell/Cargo.toml
+++ b/ports/servoshell/Cargo.toml
@@ -70,7 +70,7 @@ hitrace = { workspace = true, optional = true }
 image = { workspace = true }
 keyboard-types = { workspace = true }
 libc = { workspace = true }
-servo = { path = "../../components/servo", features = ["background_hang_monitor", "bluetooth", "testbinding"], default-features = false }
+servo = { workspace = true, features = ["background_hang_monitor", "bluetooth", "testbinding"], default-features = false }
 log = { workspace = true }
 mime_guess = { workspace = true }
 raw-window-handle = { workspace = true }
@@ -80,7 +80,7 @@ tracing = { workspace = true, optional = true }
 tracing-perfetto = { workspace = true, optional = true }
 tracing-subscriber = { workspace = true, optional = true, features = ["env-filter"] }
 url = { workspace = true }
-webdriver_server = { package = "servo-webdriver-server", path = "../../components/webdriver_server" }
+webdriver_server = { workspace = true }
 
 [target.'cfg(target_os = "android")'.dependencies]
 android_logger = "0.15"
@@ -122,7 +122,7 @@ glow = { workspace = true }
 headers = { workspace = true }
 serde_json = { workspace = true }
 # For optional feature servo_allocator/use-system-allocator and servo_allocator/allocation-tracking
-servo_allocator = { package = "servo-allocator", path = "../../components/allocator" }
+servo_allocator = { workspace = true }
 surfman = { workspace = true, features = ["sm-raw-window-handle-06", "sm-x11"] }
 winit = { workspace = true }
 
@@ -130,7 +130,7 @@ winit = { workspace = true }
 sig = "1.0"
 
 [target.'cfg(target_os = "windows")'.dependencies]
-servo = { path = "../../components/servo", features = ["no-wgl"] }
+servo = { workspace = true, features = ["no-wgl"] }
 windows-sys = { workspace = true, features = ["Win32_Graphics_Gdi", "Win32_System_Console"] }
 
 [target.'cfg(target_os = "macos")'.dependencies]

--- a/python/tidy/test.py
+++ b/python/tidy/test.py
@@ -152,6 +152,16 @@ class CheckTidiness(unittest.TestCase):
         self.assertEqual(".toml file should contain a valid license.", next(errors)[2])
         self.assertNoMoreErrors(errors)
 
+    def test_toml_path_dependencies_use_workspace(self):
+        errors = tidy.collect_errors_for_files(
+            iterFile("path_dependency/Cargo.toml"), [], [tidy.check_toml], print_text=False
+        )
+        self.assertEqual(
+            "path dependencies must be declared in the root Cargo.toml and referenced with workspace = true",
+            next(errors)[2],
+        )
+        self.assertNoMoreErrors(errors)
+
     def test_modeline(self):
         errors = tidy.collect_errors_for_files(iterFile("modeline.txt"), [], [tidy.check_modeline], print_text=False)
         self.assertEqual("vi modeline present", next(errors)[2])

--- a/python/tidy/tests/path_dependency/Cargo.toml
+++ b/python/tidy/tests/path_dependency/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "test"
+version = "0.0.1"
+license = "MPL-2.0"
+publish = false
+
+[dependencies]
+test-package = { path = "../crate" }

--- a/python/tidy/tidy.py
+++ b/python/tidy/tidy.py
@@ -23,8 +23,8 @@ from collections.abc import Iterator, Callable
 import types
 
 import colorama
-import toml
 import wpt.manifestupdate
+import tomllib
 
 from .licenseck import APACHE, COPYRIGHT, MPL, OLD_MPL, licenses_toml
 from .linting_report import GitHubAnnotationManager
@@ -38,6 +38,7 @@ URL_REGEX = re.compile(rb"https?://(?:[-\w.]|(?:%[\da-fA-F]{2}))+")
 UTF8_URL_REGEX = re.compile(r"https?://(?:[-\w.]|(?:%[\da-fA-F]{2}))+")
 CARGO_LOCK_FILE = os.path.join(TOPDIR, "Cargo.lock")
 CARGO_DENY_CONFIG_FILE = os.path.join(TOPDIR, "deny.toml")
+ROOT_CARGO_TOML = os.path.join(TOPDIR, "Cargo.toml")
 
 ERROR_RAW_URL_IN_RUSTDOC = "Found raw link in rustdoc. Please escape it with angle brackets or use a markdown link."
 
@@ -535,7 +536,8 @@ def check_toml(file_name: str, lines: list[bytes]) -> Iterator[tuple[int, str]]:
     if not file_name.endswith("Cargo.toml"):
         return
     ok_licensed = False
-    for idx, line in enumerate(map(lambda line: line.decode("utf-8"), lines)):
+    decoded_lines = [line.decode("utf-8") for line in lines]
+    for idx, line in enumerate(decoded_lines):
         if idx == 0 and "[workspace]" in line:
             return
         line_without_comment, _, _ = line.partition("#")
@@ -547,6 +549,62 @@ def check_toml(file_name: str, lines: list[bytes]) -> Iterator[tuple[int, str]]:
             ok_licensed = True
     if not ok_licensed:
         yield (0, ".toml file should contain a valid license.")
+
+    normalized_file_name = os.path.abspath(file_name)
+    if normalized_file_name != ROOT_CARGO_TOML:
+        try:
+            cargo_toml = tomllib.loads("".join(decoded_lines))
+        except tomllib.TOMLDecodeError as e:
+            print(f"Error parsing {file_name}: `{e}` - Invalid toml?")
+            raise
+        for dependency_name in path_dependency_names(cargo_toml):
+            yield (
+                line_number_of_dependency(dependency_name, decoded_lines),
+                "path dependencies must be declared in the root Cargo.toml and referenced with workspace = true",
+            )
+
+
+def path_dependency_names(cargo_toml: dict[str, Any]) -> list[str]:
+    """Scan a Cargo.toml dict for any dependencies using `path =`."""
+    path_dependencies = []
+    for dependency_table in dependency_tables(cargo_toml):
+        # dependency_value is everything in `{}` of `dependency_name = { ... }`
+        for dependency_name, dependency_value in dependency_table.items():
+            if "path" in dependency_value:
+                path_dependencies.append(dependency_name)
+    return path_dependencies
+
+
+def dependency_tables(cargo_toml: dict[str, Any]) -> Iterator[dict[str, Any]]:
+    dependency_keys = ("dependencies", "dev-dependencies", "build-dependencies")
+    for dependency_key in dependency_keys:
+        dependency_table = cargo_toml.get(dependency_key)
+        if dependency_table is not None:
+            yield dependency_table
+
+    # Support `[target.<target_triple>.dependencies]`
+    target_tables = cargo_toml.get("target")
+    if target_tables is None:
+        return
+
+    # The second portion can be pretty much any expression, so we just iterate over all
+    for target_table in target_tables.values():
+        for dependency_key in dependency_keys:
+            dependency_table = target_table.get(dependency_key)
+            if dependency_table is not None:
+                yield dependency_table
+
+
+def line_number_of_dependency(dependency_name: str, lines: list[str]) -> int:
+    # This is a best effort approach to find the offending line, since tomllib doesn't seem to
+    # preserve that information. We would miss `[dependencies.foo]` style declarations, but those
+    # are rare enough that I don't want to spend more time on writing a better regex.
+    dependency_pattern = re.compile(f"^\\s*{dependency_name}\\s*=")
+    for idx, line in enumerate(lines, start=1):
+        if dependency_pattern.search(line):
+            # We selected `start=1` so `idx` already starts at 1 as expected for line numbers.
+            return idx
+    return 0
 
 
 def check_shell(file_name: str, lines: list[bytes]) -> Iterator[tuple[int, str]]:
@@ -801,7 +859,7 @@ def check_config_file(config_file: LiteralString, print_text: bool = True) -> It
     if print_text:
         print(f"\r ➤  Checking config file ({config_file})...")
 
-    config_content = toml.loads(conf_file)
+    config_content = tomllib.loads(conf_file)
     exclude = config_content.get("ignore", {})
 
     # Check for invalid listed ignored directories

--- a/tests/unit/deny_public_fields/Cargo.toml
+++ b/tests/unit/deny_public_fields/Cargo.toml
@@ -12,4 +12,4 @@ path = "lib.rs"
 test = false
 
 [dependencies]
-deny_public_fields = { package = "servo-deny-public-fields", path = "../../../components/deny_public_fields"}
+deny_public_fields = { workspace = true }

--- a/tests/unit/profile/Cargo.toml
+++ b/tests/unit/profile/Cargo.toml
@@ -14,7 +14,7 @@ doctest = false
 
 [dependencies]
 ipc-channel = { workspace = true }
-profile = { package = "servo-profile", path = "../../../components/profile" }
+profile = { workspace = true }
 profile_traits = { workspace = true }
-servo_config = { package = "servo-config", path = "../../../components/config" }
+servo_config = { workspace = true }
 time = { workspace = true }

--- a/tests/unit/script/Cargo.toml
+++ b/tests/unit/script/Cargo.toml
@@ -16,5 +16,5 @@ base = { workspace = true }
 encoding_rs = { workspace = true }
 euclid = { workspace = true }
 keyboard-types = { workspace = true }
-script = { package = "servo-script", path = "../../../components/script"}
-servo_url = { package = "servo-url", path = "../../../components/url"}
+script = { workspace = true }
+servo_url = { workspace = true }


### PR DESCRIPTION
In order to prepare for publishing this PR does the following steps (see commits): 

- Move all `path` dependencies to the workspace Cargo.toml, and reference that.
- Move all path dependencies in the workspace Cargo.toml into a dedicated section, to make bumping version numbers easier later.
- Add the version requirement. Note that we currently only version bump servoshell. There was agreement to version everything with the same version as servoshell, but that be done in a follow-up. The diff is already large enough as is.
- Add a tidy lint to catch `path` usages outside the root Cargo.toml. I switched to [`tomllib`] (which was added to the python stdlib in 3.11), since the third-party `toml` library failed to parse Cargo.toml files with `workspace.version` (did not like the `.` in a `key`).


[`tomllib`]: https://docs.python.org/3/library/tomllib.html

Testing: Should be covered by regular CI testing. 

