### PR TITLE
script: Pass `&mut JSContext` to `TrustedScriptURL::get_trusted_type_compliant_string`

### DIFF
--- a/components/script/dom/html/htmlscriptelement.rs
+++ b/components/script/dom/html/htmlscriptelement.rs
@@ -1289,20 +1289,19 @@ impl HTMLScriptElementMethods<crate::DomTypeHolder> for HTMLScriptElement {
     }
 
     /// <https://w3c.github.io/trusted-types/dist/spec/#the-src-idl-attribute>
-    fn SetSrc(&self, value: TrustedScriptURLOrUSVString, can_gc: CanGc) -> Fallible<()> {
+    fn SetSrc(&self, cx: &mut JSContext, value: TrustedScriptURLOrUSVString) -> Fallible<()> {
         let element = self.upcast::<Element>();
         let local_name = &local_name!("src");
-        let value = TrustedScriptURL::get_trusted_script_url_compliant_string(
+        let value = TrustedScriptURL::get_trusted_type_compliant_string(
+            cx,
             &element.owner_global(),
             value,
-            "HTMLScriptElement",
-            local_name,
-            can_gc,
+            &format!("HTMLScriptElement {}", local_name),
         )?;
         element.set_attribute(
             local_name,
             AttrValue::String(value.str().to_owned()),
-            can_gc,
+            CanGc::from_cx(cx),
         );
         Ok(())
     }

--- a/components/script/dom/trustedtypes/trustedscripturl.rs
+++ b/components/script/dom/trustedtypes/trustedscripturl.rs
@@ -42,23 +42,21 @@ impl TrustedScriptURL {
         reflect_dom_object_with_cx(Box::new(Self::new_inherited(data)), global, cx)
     }
 
-    pub(crate) fn get_trusted_script_url_compliant_string(
+    pub(crate) fn get_trusted_type_compliant_string(
+        cx: &mut js::context::JSContext,
         global: &GlobalScope,
         value: TrustedScriptURLOrUSVString,
-        containing_class: &str,
-        field: &str,
-        can_gc: CanGc,
+        sink: &str,
     ) -> Fallible<DOMString> {
         match value {
             TrustedScriptURLOrUSVString::USVString(value) => {
-                let sink = format!("{} {}", containing_class, field);
                 TrustedTypePolicyFactory::get_trusted_type_compliant_string(
                     TrustedType::TrustedScriptURL,
                     global,
                     value.as_ref().into(),
-                    &sink,
+                    sink,
                     DEFAULT_SCRIPT_SINK_GROUP,
-                    can_gc,
+                    CanGc::from_cx(cx),
                 )
             },
             TrustedScriptURLOrUSVString::TrustedScriptURL(trusted_script_url) => {

--- a/components/script/dom/workers/worker.rs
+++ b/components/script/dom/workers/worker.rs
@@ -163,21 +163,20 @@ impl Worker {
 impl WorkerMethods<crate::DomTypeHolder> for Worker {
     // https://html.spec.whatwg.org/multipage/#dom-worker
     fn Constructor(
+        cx: &mut js::context::JSContext,
         global: &GlobalScope,
         proto: Option<HandleObject>,
-        can_gc: CanGc,
         script_url: TrustedScriptURLOrUSVString,
         worker_options: &WorkerOptions,
     ) -> Fallible<DomRoot<Worker>> {
         // Step 1: Let compliantScriptURL be the result of invoking the
         // Get Trusted Type compliant string algorithm with TrustedScriptURL,
         // this's relevant global object, scriptURL, "Worker constructor", and "script".
-        let compliant_script_url = TrustedScriptURL::get_trusted_script_url_compliant_string(
+        let compliant_script_url = TrustedScriptURL::get_trusted_type_compliant_string(
+            cx,
             global,
             script_url,
-            "Worker",
-            "constructor",
-            can_gc,
+            "Worker constructor",
         )?;
         // Step 2-4.
         let worker_url = match global.api_base_url().join(&compliant_script_url.str()) {
@@ -187,7 +186,13 @@ impl WorkerMethods<crate::DomTypeHolder> for Worker {
 
         let (sender, receiver) = unbounded();
         let closing = Arc::new(AtomicBool::new(false));
-        let worker = Worker::new(global, proto, sender.clone(), closing.clone(), can_gc);
+        let worker = Worker::new(
+            global,
+            proto,
+            sender.clone(),
+            closing.clone(),
+            CanGc::from_cx(cx),
+        );
         let worker_ref = Trusted::new(&*worker);
 
         let worker_load_origin = WorkerScriptLoadOrigin {

--- a/components/script/dom/workers/workerglobalscope.rs
+++ b/components/script/dom/workers/workerglobalscope.rs
@@ -666,12 +666,11 @@ impl WorkerGlobalScopeMethods<crate::DomTypeHolder> for WorkerGlobalScope {
             // Step 3: Append the result of invoking the Get Trusted Type compliant string algorithm
             // with TrustedScriptURL, this's relevant global object, url, "WorkerGlobalScope importScripts",
             // and "script" to urlStrings.
-            let url = TrustedScriptURL::get_trusted_script_url_compliant_string(
+            let url = TrustedScriptURL::get_trusted_type_compliant_string(
+                cx,
                 self.upcast::<GlobalScope>(),
                 url,
-                "WorkerGlobalScope",
-                "importScripts",
-                CanGc::from_cx(cx),
+                "WorkerGlobalScope importScripts",
             )?;
             let url = self.worker_url.borrow().join(&url.str());
             match url {

--- a/components/script_bindings/codegen/Bindings.conf
+++ b/components/script_bindings/codegen/Bindings.conf
@@ -525,8 +525,8 @@ DOMInterfaces = {
 },
 
 'HTMLScriptElement': {
-    'canGc': ['SetAsync', 'SetInnerText', 'SetSrc', 'SetText', 'SetTextContent'],
-    'cx': ['Blocking', 'SetCrossOrigin'],
+    'canGc': ['SetAsync', 'SetInnerText',  'SetText', 'SetTextContent'],
+    'cx': ['Blocking', 'SetCrossOrigin', 'SetSrc'],
 },
 
 'HTMLSelectElement': {
@@ -859,7 +859,7 @@ DOMInterfaces = {
 },
 
 'Worker': {
-    'cx': ['PostMessage', 'PostMessage_'],
+    'cx': ['Constructor', 'PostMessage', 'PostMessage_'],
 },
 
 'WorkerGlobalScope': {


### PR DESCRIPTION
Also rename the method and consolidate the sink to be consistent with both `TrustedHTML` and `TrustedScript`

Part of #42638

Testing: It compiles
