### PR TITLE
script: Scroll targets into view during sequential tab navigation

### DIFF
--- a/components/script/dom/document_event_handler.rs
+++ b/components/script/dom/document_event_handler.rs
@@ -1914,14 +1914,7 @@ impl DocumentEventHandler {
         };
 
         if let Some(element) = self.find_element_for_tab_focus(focus_direction) {
-            let document = self.window.Document();
-            document.begin_focus_transaction();
-
-            document.request_focus(None, FocusInitiator::Keyboard, can_gc);
-            document.request_focus(Some(&*element), FocusInitiator::Keyboard, can_gc);
-
-            assert!(document.has_focus_transaction());
-            document.commit_focus_transaction(FocusInitiator::Keyboard, can_gc);
+            self.focus_and_scroll_to_element_for_key_event(&element, can_gc);
         }
     }
 
@@ -2350,16 +2343,17 @@ impl DocumentEventHandler {
 
         // This behavior is unspecified, but all browsers do this. When activating the element it is
         // focused and scrolled into view.
-        //
-        // TODO: Focusing the element should likely be part of the default event handler for "click"
-        // events, but currently it's done only for real hardware click events and not synthetic
-        // ones. When that's fixed, this code can likely just scroll the element into view.
-        let element = html_element.upcast();
-        html_element
+        self.focus_and_scroll_to_element_for_key_event(html_element.upcast(), can_gc);
+        command.perform_action(can_gc);
+        true
+    }
+
+    fn focus_and_scroll_to_element_for_key_event(&self, element: &Element, can_gc: CanGc) {
+        element
             .owner_document()
-            .request_focus(Some(element), FocusInitiator::Script, can_gc);
+            .request_focus(Some(element), FocusInitiator::Keyboard, can_gc);
         let scroll_axis = ScrollAxisState {
-            position: ScrollLogicalPosition::Nearest,
+            position: ScrollLogicalPosition::Center,
             requirement: ScrollRequirement::IfNotVisible,
         };
         element.scroll_into_view_with_options(
@@ -2369,9 +2363,6 @@ impl DocumentEventHandler {
             None,
             None,
         );
-
-        command.perform_action(can_gc);
-        true
     }
 }
 

--- a/tests/wpt/meta/css/css-overflow/scroll-markers/column-scroll-marker-focus-001.html.ini
+++ b/tests/wpt/meta/css/css-overflow/scroll-markers/column-scroll-marker-focus-001.html.ini
@@ -16,3 +16,6 @@
 
   [Column 5]
     expected: FAIL
+
+  [Column #0]
+    expected: FAIL

--- a/tests/wpt/meta/css/css-overflow/scroll-markers/column-scroll-marker-focus-002.html.ini
+++ b/tests/wpt/meta/css/css-overflow/scroll-markers/column-scroll-marker-focus-002.html.ini
@@ -1,7 +1,4 @@
 [column-scroll-marker-focus-002.html]
-  [Column #2]
-    expected: FAIL
-
   [Column #0]
     expected: FAIL
 

--- a/tests/wpt/mozilla/meta/MANIFEST.json
+++ b/tests/wpt/mozilla/meta/MANIFEST.json
@@ -13233,6 +13233,15 @@
        "testdriver": true
       }
      ]
+    ],
+    "tab-navigation-scroll-target-into-view.html": [
+     "5177c3459688101cfeb244909437f617aef13591",
+     [
+      null,
+      {
+       "testdriver": true
+      }
+     ]
     ]
    },
    "mozilla": {

--- a/tests/wpt/mozilla/tests/input-events/tab-navigation-scroll-target-into-view.html
+++ b/tests/wpt/mozilla/tests/input-events/tab-navigation-scroll-target-into-view.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>Tab navigation should scroll an element into view</title>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/resources/testdriver.js"></script>
+<script src="/resources/testdriver-vendor.js"></script>
+<script src="/resources/testdriver-actions.js"></script>
+<input id="start">
+<div style="height: 10000px"></div>
+<input id="target">
+
+<script>
+promise_test(async function() {
+    start.focus();
+    await test_driver.send_keys(start, "\uE004");
+    let boundingRect = target.getBoundingClientRect();
+    assert_true(boundingRect.x > 0);
+    assert_true(boundingRect.x < document.scrollingElement.clientWidth);
+    assert_true(boundingRect.y > 0);
+    assert_true(boundingRect.y < document.scrollingElement.clientHeight);
+});
+</script>


### PR DESCRIPTION
Instead of just focusing elements that are the target of tab navigation,
also scroll them into view. Though this is unspecified, this is what all
other browsers do.

Testing: This change adds a new Servo-specific test. The behavior isn't really specified.
