### PR TITLE
script: Only trigger one default event handler for form controls

### DIFF
--- a/components/script/dom/html/htmlinputelement.rs
+++ b/components/script/dom/html/htmlinputelement.rs
@@ -1438,6 +1438,7 @@ impl HTMLInputElement {
         match action {
             KeyReaction::TriggerDefaultAction => {
                 self.implicit_submission(can_gc);
+                event.mark_as_handled();
             },
             KeyReaction::DispatchInput(text, is_composing, input_type) => {
                 if event.IsTrusted() {
@@ -3347,12 +3348,9 @@ impl VirtualMethods for HTMLInputElement {
     // https://w3c.github.io/uievents/#default-action
     /// <https://dom.spec.whatwg.org/#action-versus-occurance>
     fn handle_event(&self, event: &Event, can_gc: CanGc) {
-        if let Some(s) = self.super_type() {
-            s.handle_event(event, can_gc);
-        }
-
         if let Some(mouse_event) = event.downcast::<MouseEvent>() {
             self.handle_mouse_event(mouse_event);
+            event.mark_as_handled();
         } else if event.type_() == atom!("keydown") &&
             !event.DefaultPrevented() &&
             self.input_type().is_textual_or_password()
@@ -3363,13 +3361,6 @@ impl VirtualMethods for HTMLInputElement {
                 let action = self.textinput.borrow_mut().handle_keydown(keyevent);
                 self.handle_key_reaction(action, event, can_gc);
             }
-        } else if event.type_() == atom!("keypress") &&
-            !event.DefaultPrevented() &&
-            self.input_type().is_textual_or_password()
-        {
-            // keypress should be deprecated and replaced by beforeinput.
-            // keypress was supposed to fire "blur" and "focus" events
-            // but already done in `document.rs`
         } else if (event.type_() == atom!("compositionstart") ||
             event.type_() == atom!("compositionupdate") ||
             event.type_() == atom!("compositionend")) &&
@@ -3420,6 +3411,7 @@ impl VirtualMethods for HTMLInputElement {
                 );
             }
             if !flags.is_empty() {
+                event.mark_as_handled();
                 self.upcast::<Node>().dirty(NodeDamage::ContentOrHeritage);
             }
         } else if let Some(event) = event.downcast::<FocusEvent>() {
@@ -3427,6 +3419,10 @@ impl VirtualMethods for HTMLInputElement {
         }
 
         self.value_changed(can_gc);
+
+        if let Some(super_type) = self.super_type() {
+            super_type.handle_event(event, can_gc);
+        }
     }
 
     /// <https://html.spec.whatwg.org/multipage/#the-input-element%3Aconcept-node-clone-ext>

--- a/components/script/dom/html/htmltextareaelement.rs
+++ b/components/script/dom/html/htmltextareaelement.rs
@@ -755,23 +755,16 @@ impl VirtualMethods for HTMLTextAreaElement {
 
     // copied and modified from htmlinputelement.rs
     fn handle_event(&self, event: &Event, can_gc: CanGc) {
-        if let Some(s) = self.super_type() {
-            s.handle_event(event, can_gc);
-        }
-
         if let Some(mouse_event) = event.downcast::<MouseEvent>() {
             self.handle_mouse_event(mouse_event);
+            event.mark_as_handled();
         } else if event.type_() == atom!("keydown") && !event.DefaultPrevented() {
-            if let Some(kevent) = event.downcast::<KeyboardEvent>() {
+            if let Some(keyboard_event) = event.downcast::<KeyboardEvent>() {
                 // This can't be inlined, as holding on to textinput.borrow_mut()
                 // during self.implicit_submission will cause a panic.
-                let action = self.textinput.borrow_mut().handle_keydown(kevent);
+                let action = self.textinput.borrow_mut().handle_keydown(keyboard_event);
                 self.handle_key_reaction(action, event, can_gc);
             }
-        } else if event.type_() == atom!("keypress") && !event.DefaultPrevented() {
-            // keypress should be deprecated and replaced by beforeinput.
-            // keypress was supposed to fire "blur" and "focus" events
-            // but already done in `document.rs`
         } else if event.type_() == atom!("compositionstart") ||
             event.type_() == atom!("compositionupdate") ||
             event.type_() == atom!("compositionend")
@@ -818,6 +811,7 @@ impl VirtualMethods for HTMLTextAreaElement {
                 );
             }
             if !flags.is_empty() {
+                event.mark_as_handled();
                 self.handle_text_content_changed(can_gc);
             }
         } else if let Some(event) = event.downcast::<FocusEvent>() {
@@ -826,6 +820,10 @@ impl VirtualMethods for HTMLTextAreaElement {
 
         self.validity_state(can_gc)
             .perform_validation_and_update(ValidationFlags::all(), can_gc);
+
+        if let Some(super_type) = self.super_type() {
+            super_type.handle_event(event, can_gc);
+        }
     }
 
     fn pop(&self) {

--- a/components/script/dom/node.rs
+++ b/components/script/dom/node.rs
@@ -37,6 +37,7 @@ use libc::{self, c_void, uintptr_t};
 use malloc_size_of::{MallocSizeOf, MallocSizeOfOps};
 use net_traits::image_cache::Image;
 use pixels::ImageMetadata;
+use script_bindings::codegen::GenericBindings::EventBinding::EventMethods;
 use script_bindings::codegen::InheritTypes::DocumentFragmentTypeId;
 use script_traits::DocumentActivity;
 use servo_arc::Arc as ServoArc;
@@ -102,7 +103,7 @@ use crate::dom::documenttype::DocumentType;
 use crate::dom::element::{
     AttributeMutationReason, CustomElementCreationMode, Element, ElementCreator,
 };
-use crate::dom::event::{Event, EventBubbles, EventCancelable};
+use crate::dom::event::{Event, EventBubbles, EventCancelable, EventFlags};
 use crate::dom::eventtarget::EventTarget;
 use crate::dom::globalscope::GlobalScope;
 use crate::dom::html::htmlcanvaselement::{HTMLCanvasElement, LayoutHTMLCanvasElementHelpers};
@@ -4747,6 +4748,10 @@ impl VirtualMethods for Node {
     }
 
     fn handle_event(&self, event: &Event, can_gc: CanGc) {
+        if event.DefaultPrevented() || event.flags().contains(EventFlags::Handled) {
+            return;
+        }
+
         if let Some(event) = event.downcast::<KeyboardEvent>() {
             self.owner_document()
                 .event_handler()

--- a/tests/wpt/mozilla/meta/MANIFEST.json
+++ b/tests/wpt/mozilla/meta/MANIFEST.json
@@ -13171,6 +13171,15 @@
       }
      ]
     ],
+    "key-events-in-text-input-prevent-scrolling.html": [
+     "62c69c903205cd626b141fc8beea055ea5f7c53d",
+     [
+      null,
+      {
+       "testdriver": true
+      }
+     ]
+    ],
     "mouse-button-events-detail-increases-indefinitely.html": [
      "6bf57fe3accad4d3cbfb454e10f31b0a8540b5a5",
      [

--- a/tests/wpt/mozilla/tests/input-events/key-events-in-text-input-prevent-scrolling.html
+++ b/tests/wpt/mozilla/tests/input-events/key-events-in-text-input-prevent-scrolling.html
@@ -1,0 +1,51 @@
+<!DOCTYPE html>
+<title>Key events that are captured by a text input should not go on to cause document scrolling</title>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/resources/testdriver.js"></script>
+<script src="/resources/testdriver-actions.js"></script>
+<script src="/resources/testdriver-vendor.js"></script>
+<link rel="stylesheet" type="text/css" href="/fonts/ahem.css" />
+
+<style>
+    .text {
+        width: 100px;
+    }
+</style>
+
+<input class="text" id="input" value="123456">
+<textarea class="text" id="textarea">123456</textarea>
+
+<div style="height: 10000px"></div>
+
+<script>
+promise_test(async test => {
+    input.focus();
+    assert_equals(input.selectionStart, 0);
+    assert_equals(input.selectionEnd, 0);
+
+    input.setSelectionRange(2, 2);
+
+    const arrowDown = "\uE015";
+    await test_driver.send_keys(input, arrowDown);
+
+    assert_equals(input.selectionStart, 6);
+    assert_equals(input.selectionEnd, 6);
+    assert_equals(document.scrollingElement.scrollTop, 0);
+}, 'A key down keypress in an input element should not scroll its container');
+
+promise_test(async test => {
+    textarea.focus();
+    assert_equals(textarea.selectionStart, 0);
+    assert_equals(textarea.selectionEnd, 0);
+
+    textarea.setSelectionRange(2, 2);
+
+    const arrowDown = "\uE015";
+    await test_driver.send_keys(textarea, arrowDown);
+
+    assert_equals(textarea.selectionStart, 6);
+    assert_equals(textarea.selectionEnd, 6);
+    assert_equals(document.scrollingElement.scrollTop, 0);
+}, 'A key down keypress in an textarea element should not scroll its container');
+</script>


### PR DESCRIPTION
There is a `handle_event` virtual method on `Node` that triggers the
default event handler. Typically the "superclass" virtual method is
called and then the specific type runs its default event handler. This
isn't good for form controls, because typically the event handler should
prevent further event handlers from running. This badness can be
observed by pressing down in a text input, which will both move the
cursor as well as scroll the page. 🙃

This change makes it so that the default form control event handler
consistently calls the `Event::mark_as_handled` method and triggers the
"superclass" event handler *after* running its own. In addition, the
scrolling default event handler on `Node` now doesn't run if the `Event`
was already handled.

Finally, a little bit of dead event handling code is removed.

Testing: This change adds a Servo-specific test for this behavior.
Fixes: #40785
