### PR TITLE
servo: Add `id` method to `InputMethodControl`

### DIFF
--- a/components/servo/webview_delegate.rs
+++ b/components/servo/webview_delegate.rs
@@ -564,6 +564,11 @@ pub struct InputMethodControl {
 }
 
 impl InputMethodControl {
+    /// Return the [`EmbedderControlId`] associated with this element.
+    pub fn id(&self) -> EmbedderControlId {
+        self.id
+    }
+
     /// Return the type of input method that initated this request.
     pub fn input_method_type(&self) -> InputMethodType {
         self.input_method_type


### PR DESCRIPTION
While it is possible to acquire the embedder ID through `EmbedderControl::id`, it is no longer possible once the type is destructured into `InputMethodControl`.

Since `InputMethodControl` stores the `id` field internally anyway, it seems consistent with the other embedder controls to have a method to return this ID.

Testing: This is a simple addition to the API, so tests are probably not necessary.