### PR TITLE
embedder_traits: Add missing Debug impl to `PixelFormat`

### DIFF
--- a/components/shared/embedder/lib.rs
+++ b/components/shared/embedder/lib.rs
@@ -339,7 +339,7 @@ impl TraversalId {
     }
 }
 
-#[derive(Clone, Copy, Deserialize, Eq, Hash, PartialEq, Serialize, MallocSizeOf, Debug)]
+#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, PartialEq, Serialize, MallocSizeOf)]
 pub enum PixelFormat {
     /// Luminance channel only
     K8,

--- a/components/shared/embedder/lib.rs
+++ b/components/shared/embedder/lib.rs
@@ -339,7 +339,7 @@ impl TraversalId {
     }
 }
 
-#[derive(Clone, Copy, Deserialize, Eq, Hash, PartialEq, Serialize, MallocSizeOf)]
+#[derive(Clone, Copy, Deserialize, Eq, Hash, PartialEq, Serialize, MallocSizeOf, Debug)]
 pub enum PixelFormat {
     /// Luminance channel only
     K8,


### PR DESCRIPTION

Testing: This just implements `Debug` on an API exposed type, so tests are not necessary.