### PR TITLE
servo: Force embedders to implement `EventLoopWaker::wake`

### DIFF
--- a/components/servo/servo.rs
+++ b/components/servo/servo.rs
@@ -1223,6 +1223,8 @@ impl EventLoopWaker for DefaultEventLoopWaker {
     fn clone_box(&self) -> Box<dyn EventLoopWaker> {
         Box::new(DefaultEventLoopWaker)
     }
+
+    fn wake(&self) {}
 }
 
 #[cfg(feature = "webxr")]

--- a/components/shared/embedder/lib.rs
+++ b/components/shared/embedder/lib.rs
@@ -216,9 +216,15 @@ pub enum Cursor {
     ZoomOut,
 }
 
+/// Waker for the Servo event loop.
 pub trait EventLoopWaker: 'static + Send + Sync {
     fn clone_box(&self) -> Box<dyn EventLoopWaker>;
-    fn wake(&self) {}
+
+    /// Handle an event loop wakeup.
+    ///
+    /// A wakeup indicates that new Servo events are pending, which should
+    /// trigger a call to [`Servo::spin_event_loop`].
+    fn wake(&self);
 }
 
 impl Clone for Box<dyn EventLoopWaker> {

--- a/components/shared/embedder/lib.rs
+++ b/components/shared/embedder/lib.rs
@@ -217,13 +217,17 @@ pub enum Cursor {
 }
 
 /// Waker for the Servo event loop.
+///
+/// A trait which embedders should implement to allow Servo to request that the
+/// embedder spin the Servo event loop on the main thread.
 pub trait EventLoopWaker: 'static + Send + Sync {
     fn clone_box(&self) -> Box<dyn EventLoopWaker>;
 
-    /// Handle an event loop wakeup.
+    /// Handle Servo event loop wake-up request.
     ///
-    /// A wakeup indicates that new Servo events are pending, which should
-    /// trigger a call to [`Servo::spin_event_loop`].
+    /// Note that this may be called on a different thread than the thread that
+    /// was used to start Servo. When called, the embedder is expected to call
+    /// [`Servo::spin_event_loop`] on the thread where Servo is running.
     fn wake(&self);
 }
 

--- a/components/shared/embedder/lib.rs
+++ b/components/shared/embedder/lib.rs
@@ -216,18 +216,18 @@ pub enum Cursor {
     ZoomOut,
 }
 
-/// Waker for the Servo event loop.
+/// A way for Servo to request that the embedder wake up the main event loop.
 ///
 /// A trait which embedders should implement to allow Servo to request that the
 /// embedder spin the Servo event loop on the main thread.
 pub trait EventLoopWaker: 'static + Send + Sync {
     fn clone_box(&self) -> Box<dyn EventLoopWaker>;
 
-    /// Handle Servo event loop wake-up request.
+    /// This method is called when Servo wants the embedder to wake up the event loop.
     ///
-    /// Note that this may be called on a different thread than the thread that
-    /// was used to start Servo. When called, the embedder is expected to call
-    /// [`Servo::spin_event_loop`] on the thread where Servo is running.
+    /// Note that this may be called on a different thread than the thread that was used to
+    /// start Servo. When called, the embedder is expected to call [`Servo::spin_event_loop`]
+    /// on the thread where Servo is running.
     fn wake(&self);
 }
 


### PR DESCRIPTION
Currently it is possible to define an `EventLoopWaker` which does nothing on `wake`, however there's no reason for a consumer to define a waker that does nothing on wake, since that is its only purpose. To make it a little bit harder to use the `EventLoopWaker` incorrectly, this makes the `wake` function on the trait mandatory for downstream to implement.

Testing: This just removes a default implementation for an exposed trait and updates documentation so new tests are not necessary.
