### PR TITLE
script: Pass `&mut JSContext` in more places

### DIFF
--- a/components/script/dom/document.rs
+++ b/components/script/dom/document.rs
@@ -5875,7 +5875,7 @@ impl DocumentMethods<crate::DomTypeHolder> for Document {
             return;
         };
 
-        node.set_text_content_for_element(Some(title), CanGc::from_cx(cx));
+        node.set_text_content_for_element(cx, Some(title));
     }
 
     /// <https://html.spec.whatwg.org/multipage/#dom-document-head>

--- a/components/script/dom/document.rs
+++ b/components/script/dom/document.rs
@@ -6477,7 +6477,7 @@ impl DocumentMethods<crate::DomTypeHolder> for Document {
         }
 
         // Step 11. Replace all with null within document.
-        Node::replace_all(None, self.upcast::<Node>(), CanGc::from_cx(cx));
+        Node::replace_all(cx, None, self.upcast::<Node>());
 
         // Specs and tests are in a state of flux about whether
         // we want to clear the selection when we remove the contents;

--- a/components/script/dom/document_embedder_controls.rs
+++ b/components/script/dom/document_embedder_controls.rs
@@ -14,6 +14,7 @@ use embedder_traits::{
 };
 use euclid::{Point2D, Rect, Size2D};
 use ipc_channel::router::ROUTER;
+use js::context::JSContext;
 use net_traits::CoreResourceMsg;
 use net_traits::filemanager_thread::FileManagerThreadMsg;
 use rustc_hash::FxHashMap;
@@ -188,9 +189,9 @@ impl DocumentEmbedderControls {
 
     pub(crate) fn handle_embedder_control_response(
         &self,
+        cx: &mut JSContext,
         id: EmbedderControlId,
         response: EmbedderControlResponse,
-        can_gc: CanGc,
     ) {
         assert_eq!(self.window.pipeline_id(), id.pipeline_id);
         assert_eq!(self.window.webview_id(), id.webview_id);
@@ -209,25 +210,25 @@ impl DocumentEmbedderControls {
                 ControlElement::Select(select_element),
                 EmbedderControlResponse::SelectElement(response),
             ) => {
-                select_element.handle_menu_response(response, can_gc);
+                select_element.handle_menu_response(cx, response);
             },
             (
                 ControlElement::ColorInput(input_element),
                 EmbedderControlResponse::ColorPicker(response),
             ) => {
-                input_element.handle_color_picker_response(response, can_gc);
+                input_element.handle_color_picker_response(response, CanGc::from_cx(cx));
             },
             (
                 ControlElement::FileInput(input_element),
                 EmbedderControlResponse::FilePicker(response),
             ) => {
-                input_element.handle_file_picker_response(response, can_gc);
+                input_element.handle_file_picker_response(response, CanGc::from_cx(cx));
             },
             (
                 ControlElement::ContextMenu(context_menu_nodes),
                 EmbedderControlResponse::ContextMenu(action),
             ) => {
-                context_menu_nodes.handle_context_menu_action(action, can_gc);
+                context_menu_nodes.handle_context_menu_action(action, CanGc::from_cx(cx));
             },
             (_, _) => unreachable!(
                 "The response to a form control should always match it's originating type."

--- a/components/script/dom/element.rs
+++ b/components/script/dom/element.rs
@@ -3797,7 +3797,7 @@ impl ElementMethods<crate::DomTypeHolder> for Element {
         let frag = self.parse_fragment(value, cx)?;
 
         // Step 5: Replace all with fragment within context.
-        Node::replace_all(Some(frag.upcast()), &target, CanGc::from_cx(cx));
+        Node::replace_all(cx, Some(frag.upcast()), &target);
         Ok(())
     }
 

--- a/components/script/dom/element.rs
+++ b/components/script/dom/element.rs
@@ -605,21 +605,16 @@ impl Element {
 
     /// <https://dom.spec.whatwg.org/#dom-element-attachshadow>
     #[allow(clippy::too_many_arguments)]
-    #[expect(unsafe_code)]
     pub(crate) fn attach_shadow(
         &self,
+        cx: &mut JSContext,
         is_ua_widget: IsUserAgentWidget,
         mode: ShadowRootMode,
         clonable: bool,
         serializable: bool,
         delegates_focus: bool,
         slot_assignment_mode: SlotAssignmentMode,
-        _can_gc: CanGc,
     ) -> Fallible<DomRoot<ShadowRoot>> {
-        // TODO https://github.com/servo/servo/issues/43241
-        let mut cx = unsafe { script_bindings::script_runtime::temp_cx() };
-        let cx = &mut cx;
-
         // Step 1. If element’s namespace is not the HTML namespace,
         // then throw a "NotSupportedError" DOMException.
         if self.namespace != ns!(html) {
@@ -756,18 +751,18 @@ impl Element {
     //        for delegate focus, and we are using workarounds for that right now.
     pub(crate) fn attach_ua_shadow_root(
         &self,
+        cx: &mut JSContext,
         use_ua_widget_styling: bool,
-        can_gc: CanGc,
     ) -> DomRoot<ShadowRoot> {
         let root = self
             .attach_shadow(
+                cx,
                 IsUserAgentWidget::Yes,
                 ShadowRootMode::Closed,
                 false,
                 false,
                 false,
                 SlotAssignmentMode::Manual,
-                can_gc,
             )
             .expect("Attaching UA shadow root failed");
 
@@ -3789,7 +3784,7 @@ impl ElementMethods<crate::DomTypeHolder> for Element {
                 .iter()
                 .any(|c| matches!(*c, b'&' | b'\0' | b'<' | b'\r'))
         {
-            return Node::SetTextContent(&target, Some(value), CanGc::from_cx(cx));
+            return Node::SetTextContent(&target, cx, Some(value));
         }
 
         // Step 3: Let fragment be the result of invoking the fragment parsing algorithm steps
@@ -4121,17 +4116,21 @@ impl ElementMethods<crate::DomTypeHolder> for Element {
     }
 
     /// <https://dom.spec.whatwg.org/#dom-element-attachshadow>
-    fn AttachShadow(&self, init: &ShadowRootInit, can_gc: CanGc) -> Fallible<DomRoot<ShadowRoot>> {
+    fn AttachShadow(
+        &self,
+        cx: &mut JSContext,
+        init: &ShadowRootInit,
+    ) -> Fallible<DomRoot<ShadowRoot>> {
         // Step 1. Run attach a shadow root with this, init["mode"], init["clonable"], init["serializable"],
         // init["delegatesFocus"], and init["slotAssignment"].
         let shadow_root = self.attach_shadow(
+            cx,
             IsUserAgentWidget::No,
             init.mode,
             init.clonable,
             init.serializable,
             init.delegatesFocus,
             init.slotAssignment,
-            can_gc,
         )?;
 
         // Step 2. Return this’s shadow root.

--- a/components/script/dom/html/htmlanchorelement.rs
+++ b/components/script/dom/html/htmlanchorelement.rs
@@ -143,9 +143,9 @@ impl HTMLAnchorElementMethods<crate::DomTypeHolder> for HTMLAnchorElement {
     }
 
     /// <https://html.spec.whatwg.org/multipage/#dom-a-text>
-    fn SetText(&self, value: DOMString, can_gc: CanGc) {
+    fn SetText(&self, cx: &mut JSContext, value: DOMString) {
         self.upcast::<Node>()
-            .set_text_content_for_element(Some(value), can_gc)
+            .set_text_content_for_element(cx, Some(value))
     }
 
     // https://html.spec.whatwg.org/multipage/#dom-a-rel

--- a/components/script/dom/html/htmldetailselement.rs
+++ b/components/script/dom/html/htmldetailselement.rs
@@ -163,9 +163,9 @@ impl HTMLDetailsElement {
         self.SetOpen(!self.Open());
     }
 
-    fn shadow_tree(&self, can_gc: CanGc) -> Ref<'_, ShadowTree> {
+    fn shadow_tree(&self, cx: &mut JSContext) -> Ref<'_, ShadowTree> {
         if !self.upcast::<Element>().is_shadow_host() {
-            self.create_shadow_tree(can_gc);
+            self.create_shadow_tree(cx);
         }
 
         Ref::filter_map(self.shadow_tree.borrow(), Option::as_ref)
@@ -173,12 +173,7 @@ impl HTMLDetailsElement {
             .expect("UA shadow tree was not created")
     }
 
-    #[expect(unsafe_code)]
-    fn create_shadow_tree(&self, can_gc: CanGc) {
-        // TODO
-        let mut cx = unsafe { script_bindings::script_runtime::temp_cx() };
-        let cx = &mut cx;
-
+    fn create_shadow_tree(&self, cx: &mut JSContext) {
         let document = self.owner_document();
         // TODO(stevennovaryo): Reimplement details styling so that it would not
         //                      mess the cascading and require some reparsing.
@@ -191,7 +186,7 @@ impl HTMLDetailsElement {
             ElementCreator::ScriptCreated,
             CustomElementCreationMode::Asynchronous,
             None,
-            can_gc,
+            CanGc::from_cx(cx),
         );
         let summary = DomRoot::downcast::<HTMLSlotElement>(summary).unwrap();
         root.upcast::<Node>()
@@ -205,7 +200,7 @@ impl HTMLDetailsElement {
             ElementCreator::ScriptCreated,
             CustomElementCreationMode::Asynchronous,
             None,
-            can_gc,
+            CanGc::from_cx(cx),
         );
         let fallback_summary = DomRoot::downcast::<HTMLElement>(fallback_summary).unwrap();
         fallback_summary
@@ -223,7 +218,7 @@ impl HTMLDetailsElement {
             ElementCreator::ScriptCreated,
             CustomElementCreationMode::Asynchronous,
             None,
-            can_gc,
+            CanGc::from_cx(cx),
         );
         let details_content = DomRoot::downcast::<HTMLSlotElement>(details_content).unwrap();
 
@@ -252,8 +247,8 @@ impl HTMLDetailsElement {
             })
     }
 
-    fn update_shadow_tree_contents(&self, can_gc: CanGc) {
-        let shadow_tree = self.shadow_tree(can_gc);
+    fn update_shadow_tree_contents(&self, cx: &mut JSContext) {
+        let shadow_tree = self.shadow_tree(cx);
 
         if let Some(summary) = self.find_corresponding_summary_element() {
             shadow_tree
@@ -278,8 +273,8 @@ impl HTMLDetailsElement {
         shadow_tree.details_content.Assign(slottable_children);
     }
 
-    fn update_shadow_tree_styles(&self, can_gc: CanGc) {
-        let shadow_tree = self.shadow_tree(can_gc);
+    fn update_shadow_tree_styles(&self, cx: &mut JSContext) {
+        let shadow_tree = self.shadow_tree(cx);
 
         // Manually update the list item style of the implicit summary element.
         // Unlike the other summaries, this summary is in the shadow tree and
@@ -297,7 +292,11 @@ impl HTMLDetailsElement {
         shadow_tree
             .implicit_summary
             .upcast::<Element>()
-            .set_string_attribute(&local_name!("style"), implicit_summary_style.into(), can_gc);
+            .set_string_attribute(
+                &local_name!("style"),
+                implicit_summary_style.into(),
+                CanGc::from_cx(cx),
+            );
     }
 
     /// <https://html.spec.whatwg.org/multipage/#ensure-details-exclusivity-by-closing-the-given-element-if-needed>
@@ -400,10 +399,15 @@ impl VirtualMethods for HTMLDetailsElement {
     }
 
     /// <https://html.spec.whatwg.org/multipage/#the-details-element:concept-element-attributes-change-ext>
-    fn attribute_mutated(&self, attr: &Attr, mutation: AttributeMutation, can_gc: CanGc) {
+    #[expect(unsafe_code)]
+    fn attribute_mutated(&self, attr: &Attr, mutation: AttributeMutation, _can_gc: CanGc) {
+        // TODO: https://github.com/servo/servo/issues/42812
+        let mut cx = unsafe { script_bindings::script_runtime::temp_cx() };
+        let cx = &mut cx;
+
         self.super_type()
             .unwrap()
-            .attribute_mutated(attr, mutation, can_gc);
+            .attribute_mutated(attr, mutation, CanGc::from_cx(cx));
 
         // Step 1. If namespace is not null, then return.
         if *attr.namespace() != ns!() {
@@ -447,7 +451,7 @@ impl VirtualMethods for HTMLDetailsElement {
         }
         // Step 3. If localName is open, then:
         else if attr.local_name() == &local_name!("open") {
-            self.update_shadow_tree_styles(can_gc);
+            self.update_shadow_tree_styles(cx);
 
             let counter = self.toggle_counter.get().wrapping_add(1);
             self.toggle_counter.set(counter);
@@ -499,15 +503,15 @@ impl VirtualMethods for HTMLDetailsElement {
     fn children_changed(&self, cx: &mut JSContext, mutation: &ChildrenMutation) {
         self.super_type().unwrap().children_changed(cx, mutation);
 
-        self.update_shadow_tree_contents(CanGc::from_cx(cx));
+        self.update_shadow_tree_contents(cx);
     }
 
     /// <https://html.spec.whatwg.org/multipage/#the-details-element:html-element-insertion-steps>
     fn bind_to_tree(&self, cx: &mut JSContext, context: &BindContext) {
         self.super_type().unwrap().bind_to_tree(cx, context);
 
-        self.update_shadow_tree_contents(CanGc::from_cx(cx));
-        self.update_shadow_tree_styles(CanGc::from_cx(cx));
+        self.update_shadow_tree_contents(cx);
+        self.update_shadow_tree_styles(cx);
 
         if context.tree_is_in_a_document_tree {
             // If this is true then we can't have been in a document tree previously, so

--- a/components/script/dom/html/htmldetailselement.rs
+++ b/components/script/dom/html/htmldetailselement.rs
@@ -182,7 +182,7 @@ impl HTMLDetailsElement {
         let document = self.owner_document();
         // TODO(stevennovaryo): Reimplement details styling so that it would not
         //                      mess the cascading and require some reparsing.
-        let root = self.upcast::<Element>().attach_ua_shadow_root(true, can_gc);
+        let root = self.upcast::<Element>().attach_ua_shadow_root(cx, true);
 
         let summary = Element::create(
             QualName::new(None, ns!(html), local_name!("slot")),
@@ -210,7 +210,7 @@ impl HTMLDetailsElement {
         let fallback_summary = DomRoot::downcast::<HTMLElement>(fallback_summary).unwrap();
         fallback_summary
             .upcast::<Node>()
-            .set_text_content_for_element(Some(DEFAULT_SUMMARY.into()), can_gc);
+            .set_text_content_for_element(cx, Some(DEFAULT_SUMMARY.into()));
         summary
             .upcast::<Node>()
             .AppendChild(cx, fallback_summary.upcast::<Node>())

--- a/components/script/dom/html/htmlelement.rs
+++ b/components/script/dom/html/htmlelement.rs
@@ -1024,13 +1024,17 @@ impl HTMLElement {
 
     /// <https://html.spec.whatwg.org/multipage/#rendered-text-fragment>
     #[expect(unsafe_code)]
-    fn rendered_text_fragment(&self, input: DOMString, can_gc: CanGc) -> DomRoot<DocumentFragment> {
+    fn rendered_text_fragment(
+        &self,
+        input: DOMString,
+        _can_gc: CanGc,
+    ) -> DomRoot<DocumentFragment> {
         let mut cx = unsafe { script_bindings::script_runtime::temp_cx() };
         let cx = &mut cx;
 
         // Step 1: Let fragment be a new DocumentFragment whose node document is document.
         let document = self.owner_document();
-        let fragment = DocumentFragment::new(&document, can_gc);
+        let fragment = DocumentFragment::new(&document, CanGc::from_cx(cx));
 
         // Step 2: Let position be a position variable for input, initially pointing at the start
         // of input.
@@ -1064,7 +1068,7 @@ impl HTMLElement {
                         ElementCreator::ScriptCreated,
                         CustomElementCreationMode::Asynchronous,
                         None,
-                        can_gc,
+                        CanGc::from_cx(cx),
                     );
                     fragment
                         .upcast::<Node>()

--- a/components/script/dom/html/htmlelement.rs
+++ b/components/script/dom/html/htmlelement.rs
@@ -149,7 +149,7 @@ impl HTMLElement {
     pub(crate) fn set_inner_text(&self, cx: &mut JSContext, input: DOMString) {
         // Step 1: Let fragment be the rendered text fragment for value given element's node
         // document.
-        let fragment = self.rendered_text_fragment(input, CanGc::from_cx(cx));
+        let fragment = self.rendered_text_fragment(cx, input);
 
         // Step 2: Replace all with fragment within element.
         Node::replace_all(cx, Some(fragment.upcast()), self.upcast::<Node>());
@@ -585,7 +585,7 @@ impl HTMLElementMethods<crate::DomTypeHolder> for HTMLElement {
 
         // Step 4: Let fragment be the rendered text fragment for the given value given this's node
         // document.
-        let fragment = self.rendered_text_fragment(input, CanGc::from_cx(cx));
+        let fragment = self.rendered_text_fragment(cx, input);
 
         // Step 5: If fragment has no children, then append a new Text node whose data is the empty
         // string and node document is this's node document to fragment.
@@ -1023,15 +1023,11 @@ impl HTMLElement {
     }
 
     /// <https://html.spec.whatwg.org/multipage/#rendered-text-fragment>
-    #[expect(unsafe_code)]
     fn rendered_text_fragment(
         &self,
+        cx: &mut JSContext,
         input: DOMString,
-        _can_gc: CanGc,
     ) -> DomRoot<DocumentFragment> {
-        let mut cx = unsafe { script_bindings::script_runtime::temp_cx() };
-        let cx = &mut cx;
-
         // Step 1: Let fragment be a new DocumentFragment whose node document is document.
         let document = self.owner_document();
         let fragment = DocumentFragment::new(&document, CanGc::from_cx(cx));

--- a/components/script/dom/html/htmlelement.rs
+++ b/components/script/dom/html/htmlelement.rs
@@ -146,13 +146,13 @@ impl HTMLElement {
     }
 
     /// <https://html.spec.whatwg.org/multipage/#set-the-inner-text-steps>
-    pub(crate) fn set_inner_text(&self, input: DOMString, can_gc: CanGc) {
+    pub(crate) fn set_inner_text(&self, cx: &mut JSContext, input: DOMString) {
         // Step 1: Let fragment be the rendered text fragment for value given element's node
         // document.
-        let fragment = self.rendered_text_fragment(input, can_gc);
+        let fragment = self.rendered_text_fragment(input, CanGc::from_cx(cx));
 
         // Step 2: Replace all with fragment within element.
-        Node::replace_all(Some(fragment.upcast()), self.upcast::<Node>(), can_gc);
+        Node::replace_all(cx, Some(fragment.upcast()), self.upcast::<Node>());
     }
 
     /// <https://html.spec.whatwg.org/multipage/#matches-the-environment>
@@ -558,8 +558,8 @@ impl HTMLElementMethods<crate::DomTypeHolder> for HTMLElement {
     }
 
     /// <https://html.spec.whatwg.org/multipage/#set-the-inner-text-steps>
-    fn SetInnerText(&self, input: DOMString, can_gc: CanGc) {
-        self.set_inner_text(input, can_gc)
+    fn SetInnerText(&self, cx: &mut JSContext, input: DOMString) {
+        self.set_inner_text(cx, input)
     }
 
     /// <https://html.spec.whatwg.org/multipage/#dom-outertext>

--- a/components/script/dom/html/htmlformelement.rs
+++ b/components/script/dom/html/htmlformelement.rs
@@ -1427,6 +1427,7 @@ impl Element {
 
     #[expect(unsafe_code)]
     pub(crate) fn reset(&self, _can_gc: CanGc) {
+        // TODO https://github.com/servo/servo/issues/43235
         let mut cx = unsafe { script_bindings::script_runtime::temp_cx() };
         let cx = &mut cx;
 

--- a/components/script/dom/html/htmlinputelement.rs
+++ b/components/script/dom/html/htmlinputelement.rs
@@ -110,9 +110,13 @@ struct TextValueShadowTree {
 }
 
 impl TextValueShadowTree {
-    fn new(shadow_root: &Node, can_gc: CanGc) -> Self {
-        let value = Text::new(Default::default(), &shadow_root.owner_document(), can_gc);
-        Node::replace_all(Some(value.upcast()), shadow_root, can_gc);
+    fn new(cx: &mut JSContext, shadow_root: &Node) -> Self {
+        let value = Text::new(
+            Default::default(),
+            &shadow_root.owner_document(),
+            CanGc::from_cx(cx),
+        );
+        Node::replace_all(cx, Some(value.upcast()), shadow_root);
         Self {
             value: value.as_traced(),
         }
@@ -155,7 +159,7 @@ struct TextInputWidgetShadowTree {
 }
 
 impl TextInputWidgetShadowTree {
-    fn new(shadow_root: &Node, can_gc: CanGc) -> Self {
+    fn new(cx: &mut JSContext, shadow_root: &Node) -> Self {
         let document = shadow_root.owner_document();
         let inner_container = Element::create(
             QualName::new(None, ns!(html), local_name!("div")),
@@ -164,20 +168,20 @@ impl TextInputWidgetShadowTree {
             ElementCreator::ScriptCreated,
             CustomElementCreationMode::Asynchronous,
             None,
-            can_gc,
+            CanGc::from_cx(cx),
         );
 
-        Node::replace_all(Some(inner_container.upcast()), shadow_root.upcast(), can_gc);
+        Node::replace_all(cx, Some(inner_container.upcast()), shadow_root.upcast());
         inner_container
             .upcast::<Node>()
             .set_implemented_pseudo_element(PseudoElement::ServoTextControlInnerContainer);
 
         let text_container = create_ua_widget_div_with_text_node(
+            cx,
             &document,
             inner_container.upcast(),
             PseudoElement::ServoTextControlInnerEditor,
             false,
-            can_gc,
         );
 
         Self {
@@ -191,8 +195,8 @@ impl TextInputWidgetShadowTree {
     /// element with shadow dom that is quite bulky.
     fn init_placeholder_container_if_necessary(
         &self,
+        cx: &mut JSContext,
         host: &HTMLInputElement,
-        can_gc: CanGc,
     ) -> Option<DomRoot<Element>> {
         if let Some(placeholder_container) = &*self.placeholder_container.borrow() {
             return Some(placeholder_container.root_element());
@@ -204,11 +208,11 @@ impl TextInputWidgetShadowTree {
         }
 
         let placeholder_container = create_ua_widget_div_with_text_node(
+            cx,
             &host.owner_document(),
             self.inner_container.upcast::<Node>(),
             PseudoElement::Placeholder,
             true,
-            can_gc,
         );
         *self.placeholder_container.borrow_mut() = Some(placeholder_container.as_traced());
         Some(placeholder_container)
@@ -216,18 +220,18 @@ impl TextInputWidgetShadowTree {
 
     fn placeholder_character_data(
         &self,
+        cx: &mut JSContext,
         input_element: &HTMLInputElement,
-        can_gc: CanGc,
     ) -> Option<DomRoot<CharacterData>> {
-        self.init_placeholder_container_if_necessary(input_element, can_gc)
+        self.init_placeholder_container_if_necessary(cx, input_element)
             .and_then(|placeholder_container| {
                 let first_child = placeholder_container.upcast::<Node>().GetFirstChild()?;
                 Some(DomRoot::from_ref(first_child.downcast::<CharacterData>()?))
             })
     }
 
-    fn update_placeholder(&self, input_element: &HTMLInputElement, can_gc: CanGc) {
-        if let Some(character_data) = self.placeholder_character_data(input_element, can_gc) {
+    fn update_placeholder(&self, cx: &mut JSContext, input_element: &HTMLInputElement) {
+        if let Some(character_data) = self.placeholder_character_data(cx, input_element) {
             let placeholder_value = input_element.placeholder.borrow().clone();
             if character_data.Data() != placeholder_value {
                 character_data.SetData(placeholder_value);
@@ -287,7 +291,7 @@ struct ColorInputShadowTree {
 }
 
 impl ColorInputShadowTree {
-    fn new(shadow_root: &Node, can_gc: CanGc) -> Self {
+    fn new(cx: &mut JSContext, shadow_root: &Node) -> Self {
         let color_value = Element::create(
             QualName::new(None, ns!(html), local_name!("div")),
             None,
@@ -295,10 +299,10 @@ impl ColorInputShadowTree {
             ElementCreator::ScriptCreated,
             CustomElementCreationMode::Asynchronous,
             None,
-            can_gc,
+            CanGc::from_cx(cx),
         );
 
-        Node::replace_all(Some(color_value.upcast()), shadow_root.upcast(), can_gc);
+        Node::replace_all(cx, Some(color_value.upcast()), shadow_root.upcast());
         color_value
             .upcast::<Node>()
             .set_implemented_pseudo_element(PseudoElement::ColorSwatch);
@@ -327,20 +331,24 @@ enum InputElementShadowTree {
 }
 
 impl InputElementShadowTree {
-    fn new(input_element: &HTMLInputElement, can_gc: CanGc) -> Self {
+    #[expect(unsafe_code)]
+    fn new(input_element: &HTMLInputElement, _can_gc: CanGc) -> Self {
+        let mut cx = unsafe { script_bindings::script_runtime::temp_cx() };
+        let cx = &mut cx;
+
         let element = input_element.upcast::<Element>();
         let shadow_root = element
             .shadow_root()
-            .unwrap_or_else(|| element.attach_ua_shadow_root(true, can_gc));
+            .unwrap_or_else(|| element.attach_ua_shadow_root(true, CanGc::from_cx(cx)));
         let shadow_root = shadow_root.upcast();
 
         if input_element.input_type() == InputType::Color {
-            return Self::ColorInput(ColorInputShadowTree::new(shadow_root, can_gc));
+            return Self::ColorInput(ColorInputShadowTree::new(cx, shadow_root));
         }
         if input_element.renders_as_text_input_widget() {
-            return Self::TextInput(TextInputWidgetShadowTree::new(shadow_root, can_gc));
+            return Self::TextInput(TextInputWidgetShadowTree::new(cx, shadow_root));
         }
-        Self::TextValue(TextValueShadowTree::new(shadow_root, can_gc))
+        Self::TextValue(TextValueShadowTree::new(cx, shadow_root))
     }
 
     fn is_valid_for_element(&self, input_element: &HTMLInputElement) -> bool {
@@ -353,9 +361,9 @@ impl InputElementShadowTree {
         matches!(self, InputElementShadowTree::TextValue(_))
     }
 
-    fn update_placeholder_contents(&self, input_element: &HTMLInputElement, can_gc: CanGc) {
+    fn update_placeholder_contents(&self, cx: &mut JSContext, input_element: &HTMLInputElement) {
         if let InputElementShadowTree::TextInput(shadow_tree) = self {
-            shadow_tree.update_placeholder(input_element, can_gc);
+            shadow_tree.update_placeholder(cx, input_element);
         }
     }
 
@@ -372,17 +380,13 @@ impl InputElementShadowTree {
 
 /// Create a div element with a text node within an UA Widget and either append or prepend it to
 /// the designated parent. This is used to create the text container for input elements.
-#[expect(unsafe_code)]
 fn create_ua_widget_div_with_text_node(
+    cx: &mut JSContext,
     document: &Document,
     parent: &Node,
     implemented_pseudo: PseudoElement,
     as_first_child: bool,
-    can_gc: CanGc,
 ) -> DomRoot<Element> {
-    let mut cx = unsafe { script_bindings::script_runtime::temp_cx() };
-    let cx = &mut cx;
-
     let el = Element::create(
         QualName::new(None, ns!(html), local_name!("div")),
         None,
@@ -390,7 +394,7 @@ fn create_ua_widget_div_with_text_node(
         ElementCreator::ScriptCreated,
         CustomElementCreationMode::Asynchronous,
         None,
-        can_gc,
+        CanGc::from_cx(cx),
     );
 
     parent
@@ -399,7 +403,7 @@ fn create_ua_widget_div_with_text_node(
         .unwrap();
     el.upcast::<Node>()
         .set_implemented_pseudo_element(implemented_pseudo);
-    let text_node = document.CreateTextNode("".into(), can_gc);
+    let text_node = document.CreateTextNode("".into(), CanGc::from_cx(cx));
 
     if !as_first_child {
         el.upcast::<Node>()
@@ -3049,12 +3053,17 @@ impl VirtualMethods for HTMLInputElement {
         Some(self.upcast::<HTMLElement>() as &dyn VirtualMethods)
     }
 
-    fn attribute_mutated(&self, attr: &Attr, mutation: AttributeMutation, can_gc: CanGc) {
+    #[expect(unsafe_code)]
+    fn attribute_mutated(&self, attr: &Attr, mutation: AttributeMutation, _can_gc: CanGc) {
+        // TODO: https://github.com/servo/servo/issues/42812
+        let mut cx = unsafe { script_bindings::script_runtime::temp_cx() };
+        let cx = &mut cx;
+
         let could_have_had_embedder_control = self.may_have_embedder_control();
 
         self.super_type()
             .unwrap()
-            .attribute_mutated(attr, mutation, can_gc);
+            .attribute_mutated(attr, mutation, CanGc::from_cx(cx));
 
         match *attr.local_name() {
             local_name!("disabled") => {
@@ -3085,7 +3094,7 @@ impl VirtualMethods for HTMLInputElement {
                     },
                     AttributeMutation::Removed => false,
                 };
-                self.update_checked_state(checked_state, false, can_gc);
+                self.update_checked_state(checked_state, false, CanGc::from_cx(cx));
             },
             local_name!("size") => {
                 let size = mutation.new_value(attr).map(|value| value.as_uint());
@@ -3112,7 +3121,7 @@ impl VirtualMethods for HTMLInputElement {
 
                         if new_type == InputType::File {
                             let window = self.owner_window();
-                            let filelist = FileList::new(&window, vec![], can_gc);
+                            let filelist = FileList::new(&window, vec![], CanGc::from_cx(cx));
                             self.filelist.set(Some(&filelist));
                         }
 
@@ -3121,7 +3130,7 @@ impl VirtualMethods for HTMLInputElement {
                             // Step 1
                             (&ValueMode::Value, false, ValueMode::Default) |
                             (&ValueMode::Value, false, ValueMode::DefaultOn) => {
-                                self.SetValue(old_idl_value, can_gc)
+                                self.SetValue(old_idl_value, CanGc::from_cx(cx))
                                     .expect("Failed to set input value on type change to a default ValueMode.");
                             },
 
@@ -3133,7 +3142,7 @@ impl VirtualMethods for HTMLInputElement {
                                         .map_or(DOMString::from(""), |a| {
                                             DOMString::from(a.summarize().value)
                                         }),
-                                    can_gc,
+                                    CanGc::from_cx(cx),
                                 )
                                 .expect(
                                     "Failed to set input value on type change to ValueMode::Value.",
@@ -3145,7 +3154,7 @@ impl VirtualMethods for HTMLInputElement {
                             (_, _, ValueMode::Filename)
                                 if old_value_mode != ValueMode::Filename =>
                             {
-                                self.SetValue(DOMString::from(""), can_gc)
+                                self.SetValue(DOMString::from(""), CanGc::from_cx(cx))
                                     .expect("Failed to set input value on type change to ValueMode::Filename.");
                             },
                             _ => {},
@@ -3153,7 +3162,10 @@ impl VirtualMethods for HTMLInputElement {
 
                         // Step 5
                         if new_type == InputType::Radio {
-                            self.radio_group_updated(self.radio_group_name().as_ref(), can_gc);
+                            self.radio_group_updated(
+                                self.radio_group_name().as_ref(),
+                                CanGc::from_cx(cx),
+                            );
                         }
 
                         // Step 6
@@ -3170,7 +3182,11 @@ impl VirtualMethods for HTMLInputElement {
                     },
                     AttributeMutation::Removed => {
                         if self.input_type() == InputType::Radio {
-                            broadcast_radio_checked(self, self.radio_group_name().as_ref(), can_gc);
+                            broadcast_radio_checked(
+                                self,
+                                self.radio_group_name().as_ref(),
+                                CanGc::from_cx(cx),
+                            );
                         }
                         self.input_type.set(InputType::default());
                         let el = self.upcast::<Element>();
@@ -3181,8 +3197,8 @@ impl VirtualMethods for HTMLInputElement {
                 }
 
                 self.update_placeholder_shown_state();
-                self.get_or_create_shadow_tree(can_gc)
-                    .update_placeholder_contents(self, can_gc);
+                self.get_or_create_shadow_tree(CanGc::from_cx(cx))
+                    .update_placeholder_contents(cx, self);
             },
             local_name!("value") if !self.value_dirty.get() => {
                 // This is only run when the `value` or `defaultValue` attribute is set. It
@@ -3198,7 +3214,7 @@ impl VirtualMethods for HTMLInputElement {
             local_name!("name") if self.input_type() == InputType::Radio => {
                 self.radio_group_updated(
                     mutation.new_value(attr).as_ref().map(|name| name.as_atom()),
-                    can_gc,
+                    CanGc::from_cx(cx),
                 );
             },
             local_name!("maxlength") => match *attr.value() {
@@ -3235,8 +3251,8 @@ impl VirtualMethods for HTMLInputElement {
                     }
                 }
                 self.update_placeholder_shown_state();
-                self.get_or_create_shadow_tree(can_gc)
-                    .update_placeholder_contents(self, can_gc);
+                self.get_or_create_shadow_tree(CanGc::from_cx(cx))
+                    .update_placeholder_contents(cx, self);
             },
             local_name!("readonly") => {
                 if self.input_type().is_textual() {
@@ -3252,7 +3268,7 @@ impl VirtualMethods for HTMLInputElement {
                 }
             },
             local_name!("form") => {
-                self.form_attribute_mutated(mutation, can_gc);
+                self.form_attribute_mutated(mutation, CanGc::from_cx(cx));
             },
             local_name!("alpha") | local_name!("colorspace") => {
                 // https://html.spec.whatwg.org/multipage/#attr-input-colorspace
@@ -3266,7 +3282,7 @@ impl VirtualMethods for HTMLInputElement {
             _ => {},
         }
 
-        self.value_changed(can_gc);
+        self.value_changed(CanGc::from_cx(cx));
 
         if could_have_had_embedder_control && !self.may_have_embedder_control() {
             self.owner_document()

--- a/components/script/dom/html/htmlinputelement.rs
+++ b/components/script/dom/html/htmlinputelement.rs
@@ -339,7 +339,7 @@ impl InputElementShadowTree {
         let element = input_element.upcast::<Element>();
         let shadow_root = element
             .shadow_root()
-            .unwrap_or_else(|| element.attach_ua_shadow_root(true, CanGc::from_cx(cx)));
+            .unwrap_or_else(|| element.attach_ua_shadow_root(cx, true));
         let shadow_root = shadow_root.upcast();
 
         if input_element.input_type() == InputType::Color {

--- a/components/script/dom/html/htmlinputelement.rs
+++ b/components/script/dom/html/htmlinputelement.rs
@@ -333,6 +333,7 @@ enum InputElementShadowTree {
 impl InputElementShadowTree {
     #[expect(unsafe_code)]
     fn new(input_element: &HTMLInputElement, _can_gc: CanGc) -> Self {
+        // TODO https://github.com/servo/servo/issues/43253
         let mut cx = unsafe { script_bindings::script_runtime::temp_cx() };
         let cx = &mut cx;
 

--- a/components/script/dom/html/htmlmediaelement.rs
+++ b/components/script/dom/html/htmlmediaelement.rs
@@ -2802,12 +2802,7 @@ impl HTMLMediaElement {
             .unwrap_or_else(|_| self.current_playback_position.get())
     }
 
-    #[expect(unsafe_code)]
-    fn render_controls(&self, _can_gc: CanGc) {
-        // TODO
-        let mut cx = unsafe { script_bindings::script_runtime::temp_cx() };
-        let cx = &mut cx;
-
+    fn render_controls(&self, cx: &mut JSContext) {
         if self.upcast::<Element>().is_shadow_host() {
             // Bail out if we are already showing the controls.
             return;
@@ -3407,7 +3402,7 @@ impl VirtualMethods for HTMLMediaElement {
             },
             local_name!("controls") => {
                 if mutation.new_value(attr).is_some() {
-                    self.render_controls(CanGc::from_cx(cx));
+                    self.render_controls(cx);
                 } else {
                     self.remove_controls();
                 }

--- a/components/script/dom/html/htmlmediaelement.rs
+++ b/components/script/dom/html/htmlmediaelement.rs
@@ -2803,7 +2803,7 @@ impl HTMLMediaElement {
     }
 
     #[expect(unsafe_code)]
-    fn render_controls(&self, can_gc: CanGc) {
+    fn render_controls(&self, _can_gc: CanGc) {
         // TODO
         let mut cx = unsafe { script_bindings::script_runtime::temp_cx() };
         let cx = &mut cx;
@@ -2815,9 +2815,7 @@ impl HTMLMediaElement {
 
         // FIXME(stevennovaryo): Recheck styling of media element to avoid
         //                       reparsing styles.
-        let shadow_root = self
-            .upcast::<Element>()
-            .attach_ua_shadow_root(false, can_gc);
+        let shadow_root = self.upcast::<Element>().attach_ua_shadow_root(cx, false);
         let document = self.owner_document();
         let script = Element::create(
             QualName::new(None, ns!(html), local_name!("script")),
@@ -2826,7 +2824,7 @@ impl HTMLMediaElement {
             ElementCreator::ScriptCreated,
             CustomElementCreationMode::Asynchronous,
             None,
-            can_gc,
+            CanGc::from_cx(cx),
         );
         // This is our hacky way to temporarily workaround the lack of a privileged
         // JS context.
@@ -2839,7 +2837,7 @@ impl HTMLMediaElement {
         *self.media_controls_id.borrow_mut() = Some(id);
         script
             .upcast::<Node>()
-            .set_text_content_for_element(Some(DOMString::from(media_controls_script)), can_gc);
+            .set_text_content_for_element(cx, Some(DOMString::from(media_controls_script)));
         if let Err(e) = shadow_root
             .upcast::<Node>()
             .AppendChild(cx, script.upcast::<Node>())
@@ -2855,12 +2853,12 @@ impl HTMLMediaElement {
             ElementCreator::ScriptCreated,
             CustomElementCreationMode::Asynchronous,
             None,
-            can_gc,
+            CanGc::from_cx(cx),
         );
 
         style
             .upcast::<Node>()
-            .set_text_content_for_element(Some(DOMString::from(MEDIA_CONTROL_CSS)), can_gc);
+            .set_text_content_for_element(cx, Some(DOMString::from(MEDIA_CONTROL_CSS)));
 
         if let Err(e) = shadow_root
             .upcast::<Node>()

--- a/components/script/dom/html/htmlmeterelement.rs
+++ b/components/script/dom/html/htmlmeterelement.rs
@@ -72,11 +72,7 @@ impl HTMLMeterElement {
         )
     }
 
-    #[expect(unsafe_code)]
-    fn create_shadow_tree(&self, _can_gc: CanGc) {
-        let mut cx = unsafe { script_bindings::script_runtime::temp_cx() };
-        let cx = &mut cx;
-
+    fn create_shadow_tree(&self, cx: &mut JSContext) {
         let document = self.owner_document();
         let root = self.upcast::<Element>().attach_ua_shadow_root(cx, true);
 
@@ -100,9 +96,9 @@ impl HTMLMeterElement {
             .dirty(crate::dom::node::NodeDamage::Other);
     }
 
-    fn shadow_tree(&self, can_gc: CanGc) -> Ref<'_, ShadowTree> {
+    fn shadow_tree(&self, cx: &mut JSContext) -> Ref<'_, ShadowTree> {
         if !self.upcast::<Element>().is_shadow_host() {
-            self.create_shadow_tree(can_gc);
+            self.create_shadow_tree(cx);
         }
 
         Ref::filter_map(self.shadow_tree.borrow(), Option::as_ref)
@@ -110,7 +106,7 @@ impl HTMLMeterElement {
             .expect("UA shadow tree was not created")
     }
 
-    fn update_state(&self, can_gc: CanGc) {
+    fn update_state(&self, cx: &mut JSContext) {
         let value = *self.Value();
         let low = *self.Low();
         let high = *self.High();
@@ -159,12 +155,14 @@ impl HTMLMeterElement {
         self.upcast::<Element>().set_state(element_state, true);
 
         // Update the visual width of the meter
-        let shadow_tree = self.shadow_tree(can_gc);
+        let shadow_tree = self.shadow_tree(cx);
         let position = (value - min) / (max - min) * 100.0;
         let style = format!("width: {position}%");
-        shadow_tree
-            .meter_value
-            .set_string_attribute(&local_name!("style"), style.into(), can_gc);
+        shadow_tree.meter_value.set_string_attribute(
+            &local_name!("style"),
+            style.into(),
+            CanGc::from_cx(cx),
+        );
     }
 }
 
@@ -314,10 +312,15 @@ impl VirtualMethods for HTMLMeterElement {
         Some(self.upcast::<HTMLElement>() as &dyn VirtualMethods)
     }
 
-    fn attribute_mutated(&self, attr: &Attr, mutation: AttributeMutation, can_gc: CanGc) {
+    #[expect(unsafe_code)]
+    fn attribute_mutated(&self, attr: &Attr, mutation: AttributeMutation, _can_gc: CanGc) {
+        // TODO: https://github.com/servo/servo/issues/42812
+        let mut cx = unsafe { script_bindings::script_runtime::temp_cx() };
+        let cx = &mut cx;
+
         self.super_type()
             .unwrap()
-            .attribute_mutated(attr, mutation, can_gc);
+            .attribute_mutated(attr, mutation, CanGc::from_cx(cx));
 
         let is_important_attribute = matches!(
             attr.local_name(),
@@ -329,19 +332,19 @@ impl VirtualMethods for HTMLMeterElement {
                 &local_name!("value")
         );
         if is_important_attribute {
-            self.update_state(can_gc);
+            self.update_state(cx);
         }
     }
 
     fn children_changed(&self, cx: &mut JSContext, mutation: &ChildrenMutation) {
         self.super_type().unwrap().children_changed(cx, mutation);
 
-        self.update_state(CanGc::from_cx(cx));
+        self.update_state(cx);
     }
 
     fn bind_to_tree(&self, cx: &mut JSContext, context: &BindContext) {
         self.super_type().unwrap().bind_to_tree(cx, context);
 
-        self.update_state(CanGc::from_cx(cx));
+        self.update_state(cx);
     }
 }

--- a/components/script/dom/html/htmlmeterelement.rs
+++ b/components/script/dom/html/htmlmeterelement.rs
@@ -73,12 +73,12 @@ impl HTMLMeterElement {
     }
 
     #[expect(unsafe_code)]
-    fn create_shadow_tree(&self, can_gc: CanGc) {
+    fn create_shadow_tree(&self, _can_gc: CanGc) {
         let mut cx = unsafe { script_bindings::script_runtime::temp_cx() };
         let cx = &mut cx;
 
         let document = self.owner_document();
-        let root = self.upcast::<Element>().attach_ua_shadow_root(true, can_gc);
+        let root = self.upcast::<Element>().attach_ua_shadow_root(cx, true);
 
         let meter_value = Element::create(
             QualName::new(None, ns!(html), local_name!("div")),
@@ -87,7 +87,7 @@ impl HTMLMeterElement {
             crate::dom::element::ElementCreator::ScriptCreated,
             crate::dom::element::CustomElementCreationMode::Asynchronous,
             None,
-            can_gc,
+            CanGc::from_cx(cx),
         );
         root.upcast::<Node>()
             .AppendChild(cx, meter_value.upcast::<Node>())

--- a/components/script/dom/html/htmloptionelement.rs
+++ b/components/script/dom/html/htmloptionelement.rs
@@ -269,7 +269,7 @@ impl HTMLOptionElementMethods<crate::DomTypeHolder> for HTMLOptionElement {
         if !text.is_empty() {
             option
                 .upcast::<Node>()
-                .set_text_content_for_element(Some(text), CanGc::from_cx(cx))
+                .set_text_content_for_element(cx, Some(text))
         }
 
         if let Some(val) = value {
@@ -316,9 +316,9 @@ impl HTMLOptionElementMethods<crate::DomTypeHolder> for HTMLOptionElement {
     }
 
     /// <https://html.spec.whatwg.org/multipage/#dom-option-text>
-    fn SetText(&self, value: DOMString, can_gc: CanGc) {
+    fn SetText(&self, cx: &mut JSContext, value: DOMString) {
         self.upcast::<Node>()
-            .set_text_content_for_element(Some(value), can_gc)
+            .set_text_content_for_element(cx, Some(value))
     }
 
     /// <https://html.spec.whatwg.org/multipage/#dom-option-form>

--- a/components/script/dom/html/htmloptionelement.rs
+++ b/components/script/dom/html/htmloptionelement.rs
@@ -392,10 +392,15 @@ impl VirtualMethods for HTMLOptionElement {
         Some(self.upcast::<HTMLElement>() as &dyn VirtualMethods)
     }
 
-    fn attribute_mutated(&self, attr: &Attr, mutation: AttributeMutation, can_gc: CanGc) {
+    #[expect(unsafe_code)]
+    fn attribute_mutated(&self, attr: &Attr, mutation: AttributeMutation, _can_gc: CanGc) {
+        // TODO: https://github.com/servo/servo/issues/42812
+        let mut cx = unsafe { script_bindings::script_runtime::temp_cx() };
+        let cx = &mut cx;
+
         self.super_type()
             .unwrap()
-            .attribute_mutated(attr, mutation, can_gc);
+            .attribute_mutated(attr, mutation, CanGc::from_cx(cx));
         match *attr.local_name() {
             local_name!("disabled") => {
                 let el = self.upcast::<Element>();
@@ -410,7 +415,7 @@ impl VirtualMethods for HTMLOptionElement {
                         el.check_parent_disabled_state_for_option();
                     },
                 }
-                self.update_select_validity(can_gc);
+                self.update_select_validity(CanGc::from_cx(cx));
             },
             local_name!("selected") => {
                 match mutation {
@@ -427,13 +432,13 @@ impl VirtualMethods for HTMLOptionElement {
                         }
                     },
                 }
-                self.update_select_validity(can_gc);
+                self.update_select_validity(CanGc::from_cx(cx));
             },
             local_name!("label") => {
                 // The label of the selected option is displayed inside the select element, so we need to repaint
                 // when it changes
                 if let Some(select_element) = self.owner_select_element() {
-                    select_element.update_shadow_tree(CanGc::note());
+                    select_element.update_shadow_tree(cx);
                 }
             },
             _ => {},
@@ -491,7 +496,7 @@ impl VirtualMethods for HTMLOptionElement {
                     .selected_option()
                     .is_some_and(|selected_option| self == &*selected_option)
                 {
-                    owner_select.update_shadow_tree(CanGc::from_cx(cx));
+                    owner_select.update_shadow_tree(cx);
                 }
             }
         }

--- a/components/script/dom/html/htmloptionelement.rs
+++ b/components/script/dom/html/htmloptionelement.rs
@@ -236,9 +236,9 @@ impl HTMLOptionElement {
 
         // Step 3. Replace all with documentFragment within selectedcontent.
         Node::replace_all(
+            cx,
             Some(document_fragment.upcast()),
             selectedcontent.upcast(),
-            CanGc::from_cx(cx),
         );
     }
 }

--- a/components/script/dom/html/htmloptionscollection.rs
+++ b/components/script/dom/html/htmloptionscollection.rs
@@ -257,11 +257,11 @@ impl HTMLOptionsCollectionMethods<crate::DomTypeHolder> for HTMLOptionsCollectio
     }
 
     /// <https://html.spec.whatwg.org/multipage/#dom-htmloptionscollection-selectedindex>
-    fn SetSelectedIndex(&self, index: i32, can_gc: CanGc) {
+    fn SetSelectedIndex(&self, cx: &mut JSContext, index: i32) {
         self.upcast()
             .root_node()
             .downcast::<HTMLSelectElement>()
             .expect("HTMLOptionsCollection not rooted on a HTMLSelectElement")
-            .SetSelectedIndex(index, can_gc)
+            .SetSelectedIndex(cx, index)
     }
 }

--- a/components/script/dom/html/htmlprogresselement.rs
+++ b/components/script/dom/html/htmlprogresselement.rs
@@ -70,11 +70,7 @@ impl HTMLProgressElement {
         )
     }
 
-    #[expect(unsafe_code)]
-    fn create_shadow_tree(&self, _can_gc: CanGc) {
-        let mut cx = unsafe { script_bindings::script_runtime::temp_cx() };
-        let cx = &mut cx;
-
+    fn create_shadow_tree(&self, cx: &mut JSContext) {
         let document = self.owner_document();
         let root = self.upcast::<Element>().attach_ua_shadow_root(cx, true);
 
@@ -101,9 +97,9 @@ impl HTMLProgressElement {
             .dirty(crate::dom::node::NodeDamage::Other);
     }
 
-    fn shadow_tree(&self, can_gc: CanGc) -> Ref<'_, ShadowTree> {
+    fn shadow_tree(&self, cx: &mut JSContext) -> Ref<'_, ShadowTree> {
         if !self.upcast::<Element>().is_shadow_host() {
-            self.create_shadow_tree(can_gc);
+            self.create_shadow_tree(cx);
         }
 
         Ref::filter_map(self.shadow_tree.borrow(), Option::as_ref)
@@ -112,14 +108,16 @@ impl HTMLProgressElement {
     }
 
     /// Update the visual width of bar
-    fn update_state(&self, can_gc: CanGc) {
-        let shadow_tree = self.shadow_tree(can_gc);
+    fn update_state(&self, cx: &mut JSContext) {
+        let shadow_tree = self.shadow_tree(cx);
         let position = (*self.Value() / *self.Max()) * 100.0;
         let style = format!("width: {}%", position);
 
-        shadow_tree
-            .progress_bar
-            .set_string_attribute(&local_name!("style"), style.into(), can_gc);
+        shadow_tree.progress_bar.set_string_attribute(
+            &local_name!("style"),
+            style.into(),
+            CanGc::from_cx(cx),
+        );
     }
 }
 
@@ -217,23 +215,28 @@ impl VirtualMethods for HTMLProgressElement {
         Some(self.upcast::<HTMLElement>() as &dyn VirtualMethods)
     }
 
-    fn attribute_mutated(&self, attr: &Attr, mutation: AttributeMutation, can_gc: CanGc) {
+    #[expect(unsafe_code)]
+    fn attribute_mutated(&self, attr: &Attr, mutation: AttributeMutation, _can_gc: CanGc) {
+        // TODO: https://github.com/servo/servo/issues/42812
+        let mut cx = unsafe { script_bindings::script_runtime::temp_cx() };
+        let cx = &mut cx;
+
         self.super_type()
             .unwrap()
-            .attribute_mutated(attr, mutation, can_gc);
+            .attribute_mutated(attr, mutation, CanGc::from_cx(cx));
 
         let is_important_attribute = matches!(
             attr.local_name(),
             &local_name!("value") | &local_name!("max")
         );
         if is_important_attribute {
-            self.update_state(CanGc::note());
+            self.update_state(cx);
         }
     }
 
     fn bind_to_tree(&self, cx: &mut JSContext, context: &BindContext) {
         self.super_type().unwrap().bind_to_tree(cx, context);
 
-        self.update_state(CanGc::note());
+        self.update_state(cx);
     }
 }

--- a/components/script/dom/html/htmlprogresselement.rs
+++ b/components/script/dom/html/htmlprogresselement.rs
@@ -71,12 +71,12 @@ impl HTMLProgressElement {
     }
 
     #[expect(unsafe_code)]
-    fn create_shadow_tree(&self, can_gc: CanGc) {
+    fn create_shadow_tree(&self, _can_gc: CanGc) {
         let mut cx = unsafe { script_bindings::script_runtime::temp_cx() };
         let cx = &mut cx;
 
         let document = self.owner_document();
-        let root = self.upcast::<Element>().attach_ua_shadow_root(true, can_gc);
+        let root = self.upcast::<Element>().attach_ua_shadow_root(cx, true);
 
         let progress_bar = Element::create(
             QualName::new(None, ns!(html), local_name!("div")),
@@ -85,11 +85,11 @@ impl HTMLProgressElement {
             ElementCreator::ScriptCreated,
             CustomElementCreationMode::Asynchronous,
             None,
-            can_gc,
+            CanGc::from_cx(cx),
         );
 
         // FIXME: This should use ::-moz-progress-bar
-        progress_bar.SetId("-servo-progress-bar".into(), can_gc);
+        progress_bar.SetId("-servo-progress-bar".into(), CanGc::from_cx(cx));
         root.upcast::<Node>()
             .AppendChild(cx, progress_bar.upcast::<Node>())
             .unwrap();

--- a/components/script/dom/html/htmlscriptelement.rs
+++ b/components/script/dom/html/htmlscriptelement.rs
@@ -1438,20 +1438,24 @@ impl HTMLScriptElementMethods<crate::DomTypeHolder> for HTMLScriptElement {
     }
 
     /// <https://w3c.github.io/trusted-types/dist/spec/#the-textContent-idl-attribute>
-    fn SetTextContent(&self, value: Option<TrustedScriptOrString>, can_gc: CanGc) -> Fallible<()> {
+    fn SetTextContent(
+        &self,
+        cx: &mut JSContext,
+        value: Option<TrustedScriptOrString>,
+    ) -> Fallible<()> {
         // Step 1: Let value be the result of calling Get Trusted Type compliant string with TrustedScript,
         // this's relevant global object, the given value, HTMLScriptElement textContent, and script.
         let value = TrustedScript::get_trusted_script_compliant_string(
             &self.owner_global(),
             value.unwrap_or(TrustedScriptOrString::String(DOMString::from(""))),
             "HTMLScriptElement textContent",
-            can_gc,
+            CanGc::from_cx(cx),
         )?;
         // Step 2: Set this's script text value to value.
         *self.script_text.borrow_mut() = value.clone();
         // Step 3: Run set text content with this and value.
         self.upcast::<Node>()
-            .set_text_content_for_element(Some(value), can_gc);
+            .set_text_content_for_element(cx, Some(value));
         Ok(())
     }
 

--- a/components/script/dom/html/htmlscriptelement.rs
+++ b/components/script/dom/html/htmlscriptelement.rs
@@ -1392,18 +1392,18 @@ impl HTMLScriptElementMethods<crate::DomTypeHolder> for HTMLScriptElement {
     }
 
     /// <https://w3c.github.io/trusted-types/dist/spec/#the-innerText-idl-attribute>
-    fn SetInnerText(&self, input: TrustedScriptOrString, can_gc: CanGc) -> Fallible<()> {
+    fn SetInnerText(&self, cx: &mut JSContext, input: TrustedScriptOrString) -> Fallible<()> {
         // Step 1: Let value be the result of calling Get Trusted Type compliant string with TrustedScript,
         // this's relevant global object, the given value, HTMLScriptElement innerText, and script.
         let value = TrustedScript::get_trusted_script_compliant_string(
             &self.owner_global(),
             input,
             "HTMLScriptElement innerText",
-            can_gc,
+            CanGc::from_cx(cx),
         )?;
         *self.script_text.borrow_mut() = value.clone();
         // Step 3: Run set the inner text steps with this and value.
-        self.upcast::<HTMLElement>().set_inner_text(value, can_gc);
+        self.upcast::<HTMLElement>().set_inner_text(cx, value);
         Ok(())
     }
 

--- a/components/script/dom/html/htmlselectelement.rs
+++ b/components/script/dom/html/htmlselectelement.rs
@@ -280,11 +280,7 @@ impl HTMLSelectElement {
         }
     }
 
-    #[expect(unsafe_code)]
-    fn create_shadow_tree(&self, _can_gc: CanGc) {
-        let mut cx = unsafe { script_bindings::script_runtime::temp_cx() };
-        let cx = &mut cx;
-
+    fn create_shadow_tree(&self, cx: &mut JSContext) {
         let document = self.owner_document();
         let root = self.upcast::<Element>().attach_ua_shadow_root(cx, true);
 
@@ -355,9 +351,9 @@ impl HTMLSelectElement {
             .unwrap();
     }
 
-    fn shadow_tree(&self, can_gc: CanGc) -> Ref<'_, ShadowTree> {
+    fn shadow_tree(&self, cx: &mut JSContext) -> Ref<'_, ShadowTree> {
         if !self.upcast::<Element>().is_shadow_host() {
-            self.create_shadow_tree(can_gc);
+            self.create_shadow_tree(cx);
         }
 
         Ref::filter_map(self.shadow_tree.borrow(), Option::as_ref)
@@ -365,8 +361,8 @@ impl HTMLSelectElement {
             .expect("UA shadow tree was not created")
     }
 
-    pub(crate) fn update_shadow_tree(&self, can_gc: CanGc) {
-        let shadow_tree = self.shadow_tree(can_gc);
+    pub(crate) fn update_shadow_tree(&self, cx: &mut JSContext) {
+        let shadow_tree = self.shadow_tree(cx);
 
         let selected_option_text = self
             .selected_option()
@@ -437,13 +433,13 @@ impl HTMLSelectElement {
         self.upcast::<Element>().set_open_state(true);
     }
 
-    pub(crate) fn handle_menu_response(&self, response: Option<usize>, can_gc: CanGc) {
+    pub(crate) fn handle_menu_response(&self, cx: &mut JSContext, response: Option<usize>) {
         self.upcast::<Element>().set_open_state(false);
         let Some(selected_value) = response else {
             return;
         };
 
-        self.SetSelectedIndex(selected_value as i32, can_gc);
+        self.SetSelectedIndex(cx, selected_value as i32);
         self.send_update_notifications();
     }
 
@@ -669,7 +665,7 @@ impl HTMLSelectElementMethods<crate::DomTypeHolder> for HTMLSelectElement {
     }
 
     /// <https://html.spec.whatwg.org/multipage/#dom-select-selectedindex>
-    fn SetSelectedIndex(&self, index: i32, can_gc: CanGc) {
+    fn SetSelectedIndex(&self, cx: &mut JSContext, index: i32) {
         let mut selection_did_change = false;
 
         let mut opt_iter = self.list_of_options();
@@ -690,7 +686,7 @@ impl HTMLSelectElementMethods<crate::DomTypeHolder> for HTMLSelectElement {
         }
 
         if selection_did_change {
-            self.update_shadow_tree(can_gc);
+            self.update_shadow_tree(cx);
         }
     }
 
@@ -802,7 +798,7 @@ impl VirtualMethods for HTMLSelectElement {
             s.children_changed(cx, mutation);
         }
 
-        self.update_shadow_tree(CanGc::from_cx(cx));
+        self.update_shadow_tree(cx);
     }
 
     fn parse_plain_attribute(&self, local_name: &LocalName, value: DOMString) -> AttrValue {

--- a/components/script/dom/html/htmlselectelement.rs
+++ b/components/script/dom/html/htmlselectelement.rs
@@ -281,12 +281,12 @@ impl HTMLSelectElement {
     }
 
     #[expect(unsafe_code)]
-    fn create_shadow_tree(&self, can_gc: CanGc) {
+    fn create_shadow_tree(&self, _can_gc: CanGc) {
         let mut cx = unsafe { script_bindings::script_runtime::temp_cx() };
         let cx = &mut cx;
 
         let document = self.owner_document();
-        let root = self.upcast::<Element>().attach_ua_shadow_root(true, can_gc);
+        let root = self.upcast::<Element>().attach_ua_shadow_root(cx, true);
 
         let select_box = Element::create(
             QualName::new(None, ns!(html), local_name!("div")),
@@ -295,9 +295,13 @@ impl HTMLSelectElement {
             ElementCreator::ScriptCreated,
             CustomElementCreationMode::Asynchronous,
             None,
-            can_gc,
+            CanGc::from_cx(cx),
         );
-        select_box.set_string_attribute(&local_name!("style"), SELECT_BOX_STYLE.into(), can_gc);
+        select_box.set_string_attribute(
+            &local_name!("style"),
+            SELECT_BOX_STYLE.into(),
+            CanGc::from_cx(cx),
+        );
 
         let text_container = Element::create(
             QualName::new(None, ns!(html), local_name!("div")),
@@ -306,19 +310,19 @@ impl HTMLSelectElement {
             ElementCreator::ScriptCreated,
             CustomElementCreationMode::Asynchronous,
             None,
-            can_gc,
+            CanGc::from_cx(cx),
         );
         text_container.set_string_attribute(
             &local_name!("style"),
             TEXT_CONTAINER_STYLE.into(),
-            can_gc,
+            CanGc::from_cx(cx),
         );
         select_box
             .upcast::<Node>()
             .AppendChild(cx, text_container.upcast::<Node>())
             .unwrap();
 
-        let text = Text::new(DOMString::new(), &document, can_gc);
+        let text = Text::new(DOMString::new(), &document, CanGc::from_cx(cx));
         let _ = self.shadow_tree.borrow_mut().insert(ShadowTree {
             selected_option: text.as_traced(),
         });
@@ -334,12 +338,12 @@ impl HTMLSelectElement {
             ElementCreator::ScriptCreated,
             CustomElementCreationMode::Asynchronous,
             None,
-            can_gc,
+            CanGc::from_cx(cx),
         );
         chevron_container.set_string_attribute(
             &local_name!("style"),
             CHEVRON_CONTAINER_STYLE.into(),
-            can_gc,
+            CanGc::from_cx(cx),
         );
         select_box
             .upcast::<Node>()

--- a/components/script/dom/html/htmltextareaelement.rs
+++ b/components/script/dom/html/htmltextareaelement.rs
@@ -203,6 +203,7 @@ impl HTMLTextAreaElement {
 
     #[expect(unsafe_code)]
     fn handle_text_content_changed(&self, _can_gc: CanGc) {
+        // TODO https://github.com/servo/servo/issues/43255
         let mut cx = unsafe { script_bindings::script_runtime::temp_cx() };
         let cx = &mut cx;
 

--- a/components/script/dom/html/htmltextareaelement.rs
+++ b/components/script/dom/html/htmltextareaelement.rs
@@ -217,7 +217,7 @@ impl HTMLTextAreaElement {
 
         let shadow_root = element
             .shadow_root()
-            .unwrap_or_else(|| element.attach_ua_shadow_root(true, CanGc::from_cx(cx)));
+            .unwrap_or_else(|| element.attach_ua_shadow_root(cx, true));
         if self.shadow_node.borrow().is_none() {
             let shadow_node = Text::new(
                 Default::default(),
@@ -410,14 +410,14 @@ impl HTMLTextAreaElementMethods<crate::DomTypeHolder> for HTMLTextAreaElement {
     }
 
     /// <https://html.spec.whatwg.org/multipage/#dom-textarea-defaultvalue>
-    fn SetDefaultValue(&self, value: DOMString, can_gc: CanGc) {
+    fn SetDefaultValue(&self, cx: &mut JSContext, value: DOMString) {
         self.upcast::<Node>()
-            .set_text_content_for_element(Some(value), can_gc);
+            .set_text_content_for_element(cx, Some(value));
 
         // if the element's dirty value flag is false, then the element's
         // raw value must be set to the value of the element's textContent IDL attribute
         if !self.value_dirty.get() {
-            self.reset(can_gc);
+            self.reset(CanGc::from_cx(cx));
         }
     }
 

--- a/components/script/dom/html/htmltextareaelement.rs
+++ b/components/script/dom/html/htmltextareaelement.rs
@@ -201,9 +201,13 @@ impl HTMLTextAreaElement {
         self.maybe_update_shared_selection();
     }
 
-    fn handle_text_content_changed(&self, can_gc: CanGc) {
-        self.validity_state(can_gc)
-            .perform_validation_and_update(ValidationFlags::all(), can_gc);
+    #[expect(unsafe_code)]
+    fn handle_text_content_changed(&self, _can_gc: CanGc) {
+        let mut cx = unsafe { script_bindings::script_runtime::temp_cx() };
+        let cx = &mut cx;
+
+        self.validity_state(CanGc::from_cx(cx))
+            .perform_validation_and_update(ValidationFlags::all(), CanGc::from_cx(cx));
 
         let textinput_content = self.textinput.borrow().get_content();
         let element = self.upcast::<Element>();
@@ -213,10 +217,14 @@ impl HTMLTextAreaElement {
 
         let shadow_root = element
             .shadow_root()
-            .unwrap_or_else(|| element.attach_ua_shadow_root(true, can_gc));
+            .unwrap_or_else(|| element.attach_ua_shadow_root(true, CanGc::from_cx(cx)));
         if self.shadow_node.borrow().is_none() {
-            let shadow_node = Text::new(Default::default(), &shadow_root.owner_document(), can_gc);
-            Node::replace_all(Some(shadow_node.upcast()), shadow_root.upcast(), can_gc);
+            let shadow_node = Text::new(
+                Default::default(),
+                &shadow_root.owner_document(),
+                CanGc::from_cx(cx),
+            );
+            Node::replace_all(cx, Some(shadow_node.upcast()), shadow_root.upcast());
             self.shadow_node
                 .borrow_mut()
                 .replace(shadow_node.as_traced());

--- a/components/script/dom/html/htmltitleelement.rs
+++ b/components/script/dom/html/htmltitleelement.rs
@@ -69,9 +69,9 @@ impl HTMLTitleElementMethods<crate::DomTypeHolder> for HTMLTitleElement {
     }
 
     /// <https://html.spec.whatwg.org/multipage/#dom-title-text>
-    fn SetText(&self, value: DOMString, can_gc: CanGc) {
+    fn SetText(&self, cx: &mut JSContext, value: DOMString) {
         self.upcast::<Node>()
-            .set_text_content_for_element(Some(value), can_gc)
+            .set_text_content_for_element(cx, Some(value))
     }
 }
 

--- a/components/script/dom/node.rs
+++ b/components/script/dom/node.rs
@@ -3664,13 +3664,13 @@ impl Node {
                 // and node’s shadow root’s slot assignment.
                 let copy_shadow_root =
                     copy_elem.attach_shadow(
+                        cx,
                         IsUserAgentWidget::No,
                         shadow_root.Mode(),
                         shadow_root.Clonable(),
                         shadow_root.Serializable(),
                         shadow_root.DelegatesFocus(),
                         shadow_root.SlotAssignment(),
-                        CanGc::from_cx(cx),
                     )
                     .expect("placement of attached shadow root must be valid, as this is a copy of an existing one");
 
@@ -3722,11 +3722,11 @@ impl Node {
     }
 
     /// <https://dom.spec.whatwg.org/#string-replace-all>
-    #[expect(unsafe_code)]
-    pub(crate) fn set_text_content_for_element(&self, value: Option<DOMString>, _can_gc: CanGc) {
-        let mut cx = unsafe { script_bindings::script_runtime::temp_cx() };
-        let cx = &mut cx;
-
+    pub(crate) fn set_text_content_for_element(
+        &self,
+        cx: &mut JSContext,
+        value: Option<DOMString>,
+    ) {
         // This should only be called for elements and document fragments when setting the
         // text content: https://dom.spec.whatwg.org/#set-text-content
         assert!(matches!(
@@ -4067,14 +4067,14 @@ impl NodeMethods<crate::DomTypeHolder> for Node {
     }
 
     /// <https://dom.spec.whatwg.org/#set-text-content>
-    fn SetTextContent(&self, value: Option<DOMString>, can_gc: CanGc) -> Fallible<()> {
+    fn SetTextContent(&self, cx: &mut JSContext, value: Option<DOMString>) -> Fallible<()> {
         match self.type_id() {
             NodeTypeId::DocumentFragment(_) | NodeTypeId::Element(..) => {
-                self.set_text_content_for_element(value, can_gc);
+                self.set_text_content_for_element(cx, value);
             },
             NodeTypeId::Attr => {
                 let attr = self.downcast::<Attr>().unwrap();
-                attr.SetValue(value.unwrap_or_default(), can_gc)?;
+                attr.SetValue(value.unwrap_or_default(), CanGc::from_cx(cx))?;
             },
             NodeTypeId::CharacterData(..) => {
                 let characterdata = self.downcast::<CharacterData>().unwrap();

--- a/components/script/dom/node.rs
+++ b/components/script/dom/node.rs
@@ -360,7 +360,7 @@ impl Node {
         }
 
         // Step 4. Replace all with fragment within target.
-        Node::replace_all(Some(fragment.upcast()), target, CanGc::from_cx(cx));
+        Node::replace_all(cx, Some(fragment.upcast()), target);
     }
 
     /// Clear this [`Node`]'s layout data and also clear the layout data of all children.
@@ -1248,7 +1248,7 @@ impl Node {
         Node::ensure_pre_insertion_validity(&node, self, None)?;
 
         // Step 3. Replace all with node within this.
-        Node::replace_all(Some(&node), self, CanGc::from_cx(cx));
+        Node::replace_all(cx, Some(&node), self);
         Ok(())
     }
 
@@ -3257,12 +3257,7 @@ impl Node {
     }
 
     /// <https://dom.spec.whatwg.org/#concept-node-replace-all>
-    #[expect(unsafe_code)]
-    pub(crate) fn replace_all(node: Option<&Node>, parent: &Node, _can_gc: CanGc) {
-        // TODO https://github.com/servo/servo/issues/43240
-        let mut cx = unsafe { script_bindings::script_runtime::temp_cx() };
-        let cx = &mut cx;
-
+    pub(crate) fn replace_all(cx: &mut JSContext, node: Option<&Node>, parent: &Node) {
         parent.owner_doc().add_script_and_layout_blocker();
 
         // Step 1. Let removedNodes be parent’s children.
@@ -3315,10 +3310,10 @@ impl Node {
     /// <https://dom.spec.whatwg.org/multipage/#string-replace-all>
     pub(crate) fn string_replace_all(cx: &mut JSContext, string: DOMString, parent: &Node) {
         if string.is_empty() {
-            Node::replace_all(None, parent, CanGc::from_cx(cx));
+            Node::replace_all(cx, None, parent);
         } else {
             let text = Text::new(string, &parent.owner_document(), CanGc::from_cx(cx));
-            Node::replace_all(Some(text.upcast::<Node>()), parent, CanGc::from_cx(cx));
+            Node::replace_all(cx, Some(text.upcast::<Node>()), parent);
         };
     }
 
@@ -3727,7 +3722,11 @@ impl Node {
     }
 
     /// <https://dom.spec.whatwg.org/#string-replace-all>
-    pub(crate) fn set_text_content_for_element(&self, value: Option<DOMString>, can_gc: CanGc) {
+    #[expect(unsafe_code)]
+    pub(crate) fn set_text_content_for_element(&self, value: Option<DOMString>, _can_gc: CanGc) {
+        let mut cx = unsafe { script_bindings::script_runtime::temp_cx() };
+        let cx = &mut cx;
+
         // This should only be called for elements and document fragments when setting the
         // text content: https://dom.spec.whatwg.org/#set-text-content
         assert!(matches!(
@@ -3742,12 +3741,12 @@ impl Node {
             // Step 2. If string is not the empty string, then set node to
             // a new Text node whose data is string and node document is parent’s node document.
             Some(DomRoot::upcast(
-                self.owner_doc().CreateTextNode(value, can_gc),
+                self.owner_doc().CreateTextNode(value, CanGc::from_cx(cx)),
             ))
         };
 
         // Step 3. Replace all with node within parent.
-        Self::replace_all(node.as_deref(), self, can_gc);
+        Self::replace_all(cx, node.as_deref(), self);
     }
 
     pub(crate) fn namespace_to_string(namespace: Namespace) -> Option<DOMString> {

--- a/components/script/dom/range.rs
+++ b/components/script/dom/range.rs
@@ -1066,7 +1066,7 @@ impl RangeMethods<crate::DomTypeHolder> for Range {
         let fragment = self.ExtractContents(cx)?;
 
         // Step 4.
-        Node::replace_all(None, new_parent, CanGc::from_cx(cx));
+        Node::replace_all(cx, None, new_parent);
 
         // Step 5.
         self.InsertNode(cx, new_parent)?;

--- a/components/script/dom/servoparser/async_html.rs
+++ b/components/script/dom/servoparser/async_html.rs
@@ -636,7 +636,7 @@ impl Tokenizer {
                     .collect();
 
                 let did_succeed =
-                    attach_declarative_shadow_inner(&location, &template, &attributes);
+                    attach_declarative_shadow_inner(cx, &location, &template, &attributes);
                 sender.send(did_succeed).unwrap();
             },
         }

--- a/components/script/dom/servoparser/mod.rs
+++ b/components/script/dom/servoparser/mod.rs
@@ -1847,13 +1847,18 @@ impl TreeSink for Sink {
     /// <https://html.spec.whatwg.org/multipage/#parsing-main-inhead>
     /// A start tag whose tag name is "template"
     /// Attach shadow path
+    #[expect(unsafe_code)]
     fn attach_declarative_shadow(
         &self,
         host: &Dom<Node>,
         template: &Dom<Node>,
         attributes: &[Attribute],
     ) -> bool {
-        attach_declarative_shadow_inner(host, template, attributes)
+        // TODO: https://github.com/servo/servo/issues/42839
+        let mut cx = unsafe { temp_cx() };
+        let cx = &mut cx;
+
+        attach_declarative_shadow_inner(cx, host, template, attributes)
     }
 
     #[expect(unsafe_code)]
@@ -1994,7 +1999,12 @@ fn create_element_for_token(
     element
 }
 
-fn attach_declarative_shadow_inner(host: &Node, template: &Node, attributes: &[Attribute]) -> bool {
+fn attach_declarative_shadow_inner(
+    cx: &mut js::context::JSContext,
+    host: &Node,
+    template: &Node,
+    attributes: &[Attribute],
+) -> bool {
     let host_element = host.downcast::<Element>().unwrap();
 
     if host_element.shadow_root().is_some() {
@@ -2051,13 +2061,13 @@ fn attach_declarative_shadow_inner(host: &Node, template: &Node, attributes: &[A
     // Step 8.1. Attach a shadow root with declarative shadow host element,
     // mode, clonable, serializable, delegatesFocus, and "named".
     match host_element.attach_shadow(
+        cx,
         IsUserAgentWidget::No,
         shadow_root_mode,
         clonable,
         serializable,
         delegatesfocus,
         SlotAssignmentMode::Named,
-        CanGc::note(),
     ) {
         Ok(shadow_root) => {
             // Step 8.3. Set shadow's declarative to true.

--- a/components/script/dom/shadowroot.rs
+++ b/components/script/dom/shadowroot.rs
@@ -512,7 +512,7 @@ impl ShadowRootMethods<crate::DomTypeHolder> for ShadowRoot {
         let frag = context.parse_fragment(value, cx)?;
 
         // Step 4. Replace all with fragment within this.
-        Node::replace_all(Some(frag.upcast()), self.upcast(), CanGc::from_cx(cx));
+        Node::replace_all(cx, Some(frag.upcast()), self.upcast());
         Ok(())
     }
 

--- a/components/script/script_thread.rs
+++ b/components/script/script_thread.rs
@@ -1960,7 +1960,7 @@ impl ScriptThread {
                 );
             },
             ScriptThreadMessage::EmbedderControlResponse(id, response) => {
-                self.handle_embedder_control_response(id, response, CanGc::from_cx(cx));
+                self.handle_embedder_control_response(id, response, cx);
             },
             ScriptThreadMessage::SetUserContents(user_content_manager_id, user_contents) => {
                 self.user_contents_for_manager_id
@@ -2106,7 +2106,7 @@ impl ScriptThread {
                 control_id,
                 response,
             ) => {
-                self.handle_embedder_control_response(control_id, response, CanGc::from_cx(cx));
+                self.handle_embedder_control_response(control_id, response, cx);
             },
         }
     }
@@ -4318,14 +4318,14 @@ impl ScriptThread {
         &self,
         id: EmbedderControlId,
         response: EmbedderControlResponse,
-        can_gc: CanGc,
+        cx: &mut js::context::JSContext,
     ) {
         let Some(document) = self.documents.borrow().find_document(id.pipeline_id) else {
             return;
         };
         document
             .embedder_controls()
-            .handle_embedder_control_response(id, response, can_gc);
+            .handle_embedder_control_response(cx, id, response);
     }
 
     pub(crate) fn handle_update_pinch_zoom_infos(

--- a/components/script_bindings/codegen/Bindings.conf
+++ b/components/script_bindings/codegen/Bindings.conf
@@ -518,8 +518,7 @@ DOMInterfaces = {
 },
 
 'HTMLOptionsCollection': {
-    'canGc': ['SetSelectedIndex'],
-    'cx': ['Add', 'IndexedSetter', 'Remove', 'SetLength'],
+    'cx': ['Add', 'IndexedSetter', 'Remove', 'SetLength', 'SetSelectedIndex']
 },
 
 'HTMLOutputElement': {
@@ -537,8 +536,8 @@ DOMInterfaces = {
 },
 
 'HTMLSelectElement': {
-    'canGc': ['SetSelectedIndex', 'SetCustomValidity', 'SetValue', 'Validity'],
-    'cx': ['Add', 'CheckValidity', 'IndexedSetter', 'Remove', 'Remove_', 'ReportValidity', 'SetLength'],
+    'canGc': ['SetCustomValidity', 'SetValue', 'Validity'],
+    'cx': ['Add', 'CheckValidity', 'IndexedSetter', 'Remove', 'Remove_', 'ReportValidity', 'SetLength', 'SetSelectedIndex'],
 },
 
 'HTMLStyleElement': {

--- a/components/script_bindings/codegen/Bindings.conf
+++ b/components/script_bindings/codegen/Bindings.conf
@@ -446,12 +446,11 @@ DOMInterfaces = {
         'GetOnscroll',
         'SetAutofocus',
         'SetContentEditable',
-        'SetInnerText',
         'SetTabIndex',
         'SetTranslate',
         'Style',
     ],
-    'cx': ['SetOuterText']
+    'cx': ['SetInnerText', 'SetOuterText']
 },
 
 'HTMLFieldSetElement': {
@@ -532,8 +531,8 @@ DOMInterfaces = {
 },
 
 'HTMLScriptElement': {
-    'canGc': ['SetAsync', 'SetInnerText', 'SetTextContent'],
-    'cx': ['Blocking', 'SetCrossOrigin', 'SetSrc', 'SetText'],
+    'canGc': ['SetAsync', 'SetTextContent'],
+    'cx': ['Blocking', 'SetCrossOrigin', 'SetInnerText', 'SetSrc', 'SetText'],
 },
 
 'HTMLSelectElement': {

--- a/components/script_bindings/codegen/Bindings.conf
+++ b/components/script_bindings/codegen/Bindings.conf
@@ -278,8 +278,8 @@ DOMInterfaces = {
 },
 
 'Element': {
-    'cx': ['SetHTMLUnsafe', 'SetInnerHTML', 'SetOuterHTML', 'InsertAdjacentHTML', 'ToggleAttribute', 'SetAttribute', 'SetAttributeNS', 'SetAttributeNode', 'SetAttributeNodeNS', 'RemoveAttributeNS', 'RemoveAttributeNode', 'SetRole', 'SetAriaAtomic', 'SetAriaAutoComplete', 'SetAriaBrailleLabel', 'SetAriaBrailleRoleDescription', 'SetAriaBusy', 'SetAriaChecked', 'SetAriaColCount', 'SetAriaColIndex', 'SetAriaColIndexText', 'SetAriaColSpan', 'SetAriaCurrent', 'SetAriaDescription', 'SetAriaDisabled', 'SetAriaExpanded', 'SetAriaHasPopup', 'SetAriaHidden', 'SetAriaInvalid', 'SetAriaKeyShortcuts', 'SetAriaLabel', 'SetAriaLevel', 'SetAriaLive', 'SetAriaModal', 'SetAriaMultiLine', 'SetAriaMultiSelectable', 'SetAriaOrientation', 'SetAriaPlaceholder', 'SetAriaPosInSet', 'SetAriaPressed','SetAriaReadOnly', 'SetAriaRelevant', 'SetAriaRequired', 'SetAriaRoleDescription', 'SetAriaRowCount', 'SetAriaRowIndex', 'SetAriaRowIndexText', 'SetAriaRowSpan', 'SetAriaSelected', 'SetAriaSetSize','SetAriaSort', 'SetAriaValueMax', 'SetAriaValueMin', 'SetAriaValueNow', 'SetAriaValueText', 'ReplaceWith', 'MoveBefore', 'InsertAdjacentElement', 'InsertAdjacentText', 'Before', 'After', 'Prepend', 'Remove', 'ReplaceChildren', 'Append'],
-    'canGc': ['GetClientRects', 'GetBoundingClientRect', 'SetId','SetClassName', 'RequestFullscreen', 'GetHTML', 'GetInnerHTML', 'GetOuterHTML', 'ClassList', 'Attributes', 'GetElementsByTagName', 'GetElementsByTagNameNS', 'GetElementsByClassName', 'Children', 'AttachShadow', 'RemoveAttribute'],
+    'cx': ['SetHTMLUnsafe', 'SetInnerHTML', 'SetOuterHTML', 'InsertAdjacentHTML', 'ToggleAttribute', 'SetAttribute', 'SetAttributeNS', 'SetAttributeNode', 'SetAttributeNodeNS', 'RemoveAttributeNS', 'RemoveAttributeNode', 'SetRole', 'SetAriaAtomic', 'SetAriaAutoComplete', 'SetAriaBrailleLabel', 'SetAriaBrailleRoleDescription', 'SetAriaBusy', 'SetAriaChecked', 'SetAriaColCount', 'SetAriaColIndex', 'SetAriaColIndexText', 'SetAriaColSpan', 'SetAriaCurrent', 'SetAriaDescription', 'SetAriaDisabled', 'SetAriaExpanded', 'SetAriaHasPopup', 'SetAriaHidden', 'SetAriaInvalid', 'SetAriaKeyShortcuts', 'SetAriaLabel', 'SetAriaLevel', 'SetAriaLive', 'SetAriaModal', 'SetAriaMultiLine', 'SetAriaMultiSelectable', 'SetAriaOrientation', 'SetAriaPlaceholder', 'SetAriaPosInSet', 'SetAriaPressed','SetAriaReadOnly', 'SetAriaRelevant', 'SetAriaRequired', 'SetAriaRoleDescription', 'SetAriaRowCount', 'SetAriaRowIndex', 'SetAriaRowIndexText', 'SetAriaRowSpan', 'SetAriaSelected', 'SetAriaSetSize','SetAriaSort', 'SetAriaValueMax', 'SetAriaValueMin', 'SetAriaValueNow', 'SetAriaValueText', 'ReplaceWith', 'MoveBefore', 'InsertAdjacentElement', 'InsertAdjacentText', 'Before', 'After', 'Prepend', 'Remove', 'ReplaceChildren', 'Append', 'AttachShadow'],
+    'canGc': ['GetClientRects', 'GetBoundingClientRect', 'SetId','SetClassName', 'RequestFullscreen', 'GetHTML', 'GetInnerHTML', 'GetOuterHTML', 'ClassList', 'Attributes', 'GetElementsByTagName', 'GetElementsByTagNameNS', 'GetElementsByClassName', 'Children', 'RemoveAttribute'],
 },
 
 'ElementInternals': {
@@ -393,7 +393,8 @@ DOMInterfaces = {
 },
 
 "HTMLAnchorElement": {
-    "canGc": ["SetText","SetRel","SetHref", 'SetHash', 'SetHost', 'SetHostname', 'SetPassword', 'SetPathname', 'SetPort', 'SetProtocol', 'SetSearch', 'SetUsername', 'RelList']
+    "canGc": ["SetRel","SetHref", 'SetHash', 'SetHost', 'SetHostname', 'SetPassword', 'SetPathname', 'SetPort', 'SetProtocol', 'SetSearch', 'SetUsername', 'RelList'],
+    'cx': ["SetText"]
 },
 
 "HTMLAreaElement": {
@@ -512,8 +513,8 @@ DOMInterfaces = {
 },
 
 'HTMLOptionElement': {
-    'canGc': ['SetSelected', 'SetText'],
-    'cx': ['Option'],
+    'canGc': ['SetSelected'],
+    'cx': ['Option', 'SetText'],
 },
 
 'HTMLOptionsCollection': {
@@ -531,8 +532,8 @@ DOMInterfaces = {
 },
 
 'HTMLScriptElement': {
-    'canGc': ['SetAsync', 'SetTextContent'],
-    'cx': ['Blocking', 'SetCrossOrigin', 'SetInnerText', 'SetSrc', 'SetText'],
+    'canGc': ['SetAsync'],
+    'cx': ['Blocking', 'SetCrossOrigin', 'SetInnerText', 'SetSrc', 'SetText', 'SetTextContent'],
 },
 
 'HTMLSelectElement': {
@@ -575,12 +576,12 @@ DOMInterfaces = {
 },
 
 'HTMLTextAreaElement': {
-    'canGc': ['SetDefaultValue', 'SetCustomValidity', 'SetValue', 'Validity'],
-    'cx': ['CheckValidity', 'ReportValidity'],
+    'canGc': ['SetCustomValidity', 'SetValue', 'Validity'],
+    'cx': ['CheckValidity', 'ReportValidity', 'SetDefaultValue'],
 },
 
 'HTMLTitleElement': {
-    'canGc': ['SetText']
+    'cx': ['SetText']
 },
 
 'HTMLVideoElement': {
@@ -675,8 +676,8 @@ DOMInterfaces = {
 },
 
 'Node': {
-    'canGc': ['ChildNodes', 'SetNodeValue', 'SetTextContent'],
-    'cx': ['AppendChild', 'CloneNode', 'InsertBefore', 'Normalize', 'RemoveChild', 'ReplaceChild']
+    'canGc': ['ChildNodes', 'SetNodeValue'],
+    'cx': ['AppendChild', 'CloneNode', 'InsertBefore', 'Normalize', 'RemoveChild', 'ReplaceChild', 'SetTextContent']
 },
 
 'NodeIterator': {


### PR DESCRIPTION
Continuation of #43220, removes many `temp_cx` calls introduced by that.

Testing: No behaviour change, a successful build is enough.
Fixes: #43241 #43240
