### PR TITLE
script: Implement pending initial intersectionobserver targets (fixes #35767)

### DIFF
--- a/components/script/dom/document.rs
+++ b/components/script/dom/document.rs
@@ -562,6 +562,8 @@ pub(crate) struct Document {
     has_trustworthy_ancestor_origin: Cell<bool>,
     /// <https://w3c.github.io/IntersectionObserver/#document-intersectionobservertaskqueued>
     intersection_observer_task_queued: Cell<bool>,
+    /// <https://w3c.github.io/IntersectionObserver/#pending-initial-intersectionobserver-targets>
+    pending_initial_intersectionobserver_targets: DomRefCell<Vec<Dom<Element>>>,
     /// Active intersection observers that should be processed by this document in
     /// the update intersection observation steps.
     /// <https://w3c.github.io/IntersectionObserver/#run-the-update-intersection-observations-steps>
@@ -3441,6 +3443,24 @@ impl Document {
             .push(Dom::from_ref(intersection_observer));
     }
 
+    /// Add an element to the document's list of pending initial intersectionobserver targets.
+    /// <https://w3c.github.io/IntersectionObserver/#pending-initial-intersectionobserver-targets>
+    pub(crate) fn add_pending_intersection_observer_target(&self, target: &Element) {
+        self.pending_initial_intersectionobserver_targets
+            .borrow_mut()
+            .push(Dom::from_ref(target));
+    }
+
+    /// Drain and return the document's list of pending initial intersectionobserver targets.
+    /// <https://w3c.github.io/IntersectionObserver/#pending-initial-intersectionobserver-targets>
+    pub(crate) fn take_pending_intersection_observer_targets(&self) -> Vec<DomRoot<Element>> {
+        self.pending_initial_intersectionobserver_targets
+            .borrow_mut()
+            .drain(..)
+            .map(|e| DomRoot::from_ref(&*e))
+            .collect()
+    }
+
     /// Remove an [`IntersectionObserver`] from [`Document`], ommiting it from the event loop.
     /// An observer without any target, ideally should be removed to be conformant with
     /// <https://w3c.github.io/IntersectionObserver/#lifetime>.
@@ -3459,6 +3479,17 @@ impl Document {
         time: CrossProcessInstant,
         can_gc: CanGc,
     ) {
+        // Process pending initial targets first.
+        // <https://w3c.github.io/IntersectionObserver/#pending-initial-intersectionobserver-targets>
+        let pending_targets = self.take_pending_intersection_observer_targets();
+        for target in &pending_targets {
+            for intersection_observer in &*self.intersection_observers.borrow() {
+                intersection_observer.queue_initial_intersection_observation(
+                    self, time, target, can_gc,
+                );
+            }
+        }
+
         // Step 1-2
         for intersection_observer in &*self.intersection_observers.borrow() {
             self.update_single_intersection_observer_steps(intersection_observer, time, can_gc);
@@ -3980,6 +4011,7 @@ impl Document {
             inherited_insecure_requests_policy: Cell::new(inherited_insecure_requests_policy),
             has_trustworthy_ancestor_origin: Cell::new(has_trustworthy_ancestor_origin),
             intersection_observer_task_queued: Cell::new(false),
+            pending_initial_intersectionobserver_targets: Default::default(),
             intersection_observers: Default::default(),
             highlighted_dom_node: Default::default(),
             adopted_stylesheets: Default::default(),

--- a/components/script/dom/intersectionobserver.rs
+++ b/components/script/dom/intersectionobserver.rs
@@ -289,12 +289,16 @@ impl IntersectionObserver {
             .borrow_mut()
             .push(Dom::from_ref(target));
 
-        target
-            .owner_window()
-            .Document()
-            .add_rendering_update_reason(
-                RenderingUpdateReason::IntersectionObserverStartedObservingTarget,
-            );
+        let document = target.owner_window().Document();
+
+        // <https://w3c.github.io/IntersectionObserver/#pending-initial-intersectionobserver-targets>
+        // When a target element is added to an IntersectionObserver’s observation targets,
+        // add target to the document’s list of pending initial intersectionobserver targets.
+        document.add_pending_intersection_observer_target(target);
+
+        document.add_rendering_update_reason(
+            RenderingUpdateReason::IntersectionObserverStartedObservingTarget,
+        );
     }
 
     /// <https://w3c.github.io/IntersectionObserver/#unobserve-target-element>
@@ -609,6 +613,62 @@ impl IntersectionObserver {
     }
 
     /// Step 2.2.1-2.2.21 of <https://w3c.github.io/IntersectionObserver/#update-intersection-observations-algo>
+    /// Process a single target's initial intersection observation, queuing an entry unconditionally.
+    /// Called for targets in the document's pending initial intersectionobserver targets list.
+    /// <https://w3c.github.io/IntersectionObserver/#pending-initial-intersectionobserver-targets>
+    pub(crate) fn queue_initial_intersection_observation(
+        &self,
+        document: &Document,
+        time: CrossProcessInstant,
+        target: &Element,
+        can_gc: CanGc,
+    ) {
+        // Only process if this observer is actually observing this target.
+        let is_observing = self
+            .observation_targets
+            .borrow()
+            .iter()
+            .any(|t| &**t == target);
+        if !is_observing {
+            return;
+        }
+
+        let registration = match target.get_intersection_observer_registration(self) {
+            Some(r) => r,
+            None => return,
+        };
+
+        registration.last_update_time.set(time);
+
+        let root_bounds = self.root_intersection_rectangle(document);
+        let intersection_output =
+            self.maybe_compute_intersection_output(document, target, root_bounds);
+
+        // For initial observation, always queue an entry regardless of state change.
+        self.queue_an_intersectionobserverentry(
+            document,
+            time,
+            intersection_output.root_bounds,
+            intersection_output.target_rect,
+            intersection_output.intersection_rect,
+            intersection_output.is_intersecting,
+            intersection_output.is_visible,
+            intersection_output.intersection_ratio,
+            target,
+            can_gc,
+        );
+
+        registration
+            .previous_threshold_index
+            .set(intersection_output.threshold_index);
+        registration
+            .previous_is_intersecting
+            .set(intersection_output.is_intersecting);
+        registration
+            .previous_is_visible
+            .set(intersection_output.is_visible);
+    }
+
     pub(crate) fn update_intersection_observations_steps(
         &self,
         document: &Document,


### PR DESCRIPTION
## Summary

Implements the **pending initial intersectionobserver targets** algorithm as specified in:
https://w3c.github.io/IntersectionObserver/#pending-initial-intersectionobserver-targets

Fixes #35767.

### What changed

**`components/script/dom/document.rs`**
- Added `pending_initial_intersectionobserver_targets: DomRefCell<Vec<Dom<Element>>>` field to `Document`
- Added `add_pending_intersection_observer_target(&self, target: &Element)` — called from `observe()`
- Added `take_pending_intersection_observer_targets()` — drains the list and returns owned roots
- In `update_intersection_observer_steps()`: pending targets are processed **before** the regular observer loop, with an unconditional entry queued for each

**`components/script/dom/intersectionobserver.rs`**
- Added `queue_initial_intersection_observation()` — processes a single target and always queues an `IntersectionObserverEntry` regardless of whether the intersection state changed from the initial sentinel (`previousThresholdIndex = -1`)
- In `observe_target_element()`: calls `document.add_pending_intersection_observer_target(target)` after adding the target to `[[ObservationTargets]]`

### Why this matters

Without initial notifications, frameworks like **Next.js**, React (with `useIntersectionObserver`), and others that call `observe()` on already-visible elements at mount time never fire their callbacks. This caused Next.js apps to display "Application error: a client-side exception has occurred" immediately on load.

### Spec reference

> Each Document has a list of **pending initial intersectionobserver targets**, initially empty.  
> When a target element is added to an IntersectionObserver's observation targets, add target to the document's list of pending initial intersectionobserver targets.  
> During `update intersection observations steps`, initial targets are processed first.

https://w3c.github.io/IntersectionObserver/#pending-initial-intersectionobserver-targets

### Testing

```bash
./mach test-wpt tests/wpt/web-platform-tests/intersection-observer/
```

Build verified with `./mach build --dev` (exit 0, no new clippy warnings).