### PR TITLE
script: Pass &mut JSContext to FetchResponseListener::process_response

### DIFF
--- a/components/script/dom/eventsource.rs
+++ b/components/script/dom/eventsource.rs
@@ -370,7 +370,12 @@ impl FetchResponseListener for EventSourceContext {
         // TODO
     }
 
-    fn process_response(&mut self, _: RequestId, metadata: Result<FetchMetadata, NetworkError>) {
+    fn process_response(
+        &mut self,
+        _: &mut js::context::JSContext,
+        _: RequestId,
+        metadata: Result<FetchMetadata, NetworkError>,
+    ) {
         match metadata {
             Ok(fm) => {
                 let meta = match fm {

--- a/components/script/dom/html/htmlimageelement.rs
+++ b/components/script/dom/html/htmlimageelement.rs
@@ -254,6 +254,7 @@ impl FetchResponseListener for ImageContext {
 
     fn process_response(
         &mut self,
+        _: &mut js::context::JSContext,
         request_id: RequestId,
         metadata: Result<FetchMetadata, NetworkError>,
     ) {

--- a/components/script/dom/html/htmllinkelement.rs
+++ b/components/script/dom/html/htmllinkelement.rs
@@ -1266,6 +1266,7 @@ impl FetchResponseListener for FaviconFetchContext {
 
     fn process_response(
         &mut self,
+        _: &mut js::context::JSContext,
         request_id: RequestId,
         metadata: Result<FetchMetadata, NetworkError>,
     ) {

--- a/components/script/dom/html/htmlmediaelement.rs
+++ b/components/script/dom/html/htmlmediaelement.rs
@@ -35,7 +35,6 @@ use script_bindings::codegen::InheritTypes::{
     ElementTypeId, HTMLElementTypeId, HTMLMediaElementTypeId, NodeTypeId,
 };
 use script_bindings::root::assert_in_script;
-use script_bindings::script_runtime::temp_cx;
 use script_bindings::weakref::WeakRef;
 use servo_config::pref;
 use servo_media::player::audio::AudioRenderer;

--- a/components/script/dom/html/htmlmediaelement.rs
+++ b/components/script/dom/html/htmlmediaelement.rs
@@ -3713,11 +3713,12 @@ impl FetchResponseListener for HTMLMediaElementFetchListener {
 
     fn process_request_eof(&mut self, _: RequestId) {}
 
-    #[expect(unsafe_code)]
-    fn process_response(&mut self, _: RequestId, metadata: Result<FetchMetadata, NetworkError>) {
-        // TODO: https://github.com/servo/servo/issues/42840
-        let mut cx = unsafe { temp_cx() };
-        let cx = &mut cx;
+    fn process_response(
+        &mut self,
+        cx: &mut js::context::JSContext,
+        _: RequestId,
+        metadata: Result<FetchMetadata, NetworkError>,
+    ) {
         let element = self.element.root();
 
         let (metadata, origin_clean) = match metadata {

--- a/components/script/dom/html/htmlscriptelement.rs
+++ b/components/script/dom/html/htmlscriptelement.rs
@@ -341,7 +341,12 @@ impl FetchResponseListener for ClassicContext {
     // TODO(KiChjang): Perhaps add custom steps to perform fetch here?
     fn process_request_eof(&mut self, _: RequestId) {}
 
-    fn process_response(&mut self, _: RequestId, metadata: Result<FetchMetadata, NetworkError>) {
+    fn process_response(
+        &mut self,
+        _: &mut js::context::JSContext,
+        _: RequestId,
+        metadata: Result<FetchMetadata, NetworkError>,
+    ) {
         self.metadata = metadata.ok().map(|meta| {
             self.response_was_cors_cross_origin = meta.is_cors_cross_origin();
             match meta {

--- a/components/script/dom/html/htmlvideoelement.rs
+++ b/components/script/dom/html/htmlvideoelement.rs
@@ -419,6 +419,7 @@ impl FetchResponseListener for PosterFrameFetchContext {
 
     fn process_response(
         &mut self,
+        _: &mut js::context::JSContext,
         request_id: RequestId,
         metadata: Result<FetchMetadata, NetworkError>,
     ) {

--- a/components/script/dom/navigator.rs
+++ b/components/script/dom/navigator.rs
@@ -618,6 +618,7 @@ impl FetchResponseListener for BeaconFetchListener {
 
     fn process_response(
         &mut self,
+        _: &mut js::context::JSContext,
         _: RequestId,
         fetch_metadata: Result<FetchMetadata, NetworkError>,
     ) {

--- a/components/script/dom/notification.rs
+++ b/components/script/dom/notification.rs
@@ -758,6 +758,7 @@ impl FetchResponseListener for ResourceFetchListener {
 
     fn process_response(
         &mut self,
+        _: &mut js::context::JSContext,
         request_id: RequestId,
         metadata: Result<FetchMetadata, NetworkError>,
     ) {

--- a/components/script/dom/processingoptions.rs
+++ b/components/script/dom/processingoptions.rs
@@ -468,6 +468,7 @@ impl FetchResponseListener for LinkFetchContext {
 
     fn process_response(
         &mut self,
+        _: &mut js::context::JSContext,
         _: RequestId,
         fetch_metadata: Result<FetchMetadata, NetworkError>,
     ) {

--- a/components/script/dom/reporting/reportingendpoint.rs
+++ b/components/script/dom/reporting/reportingendpoint.rs
@@ -318,6 +318,7 @@ impl FetchResponseListener for CSPReportEndpointFetchListener {
 
     fn process_response(
         &mut self,
+        _: &mut js::context::JSContext,
         _: RequestId,
         fetch_metadata: Result<FetchMetadata, NetworkError>,
     ) {

--- a/components/script/dom/security/cspviolationreporttask.rs
+++ b/components/script/dom/security/cspviolationreporttask.rs
@@ -187,6 +187,7 @@ impl FetchResponseListener for CSPReportUriFetchListener {
 
     fn process_response(
         &mut self,
+        _: &mut js::context::JSContext,
         _: RequestId,
         fetch_metadata: Result<FetchMetadata, NetworkError>,
     ) {

--- a/components/script/dom/servoparser/mod.rs
+++ b/components/script/dom/servoparser/mod.rs
@@ -1230,11 +1230,12 @@ impl FetchResponseListener for ParserContext {
 
     fn process_request_eof(&mut self, _: RequestId) {}
 
-    #[expect(unsafe_code)]
-    fn process_response(&mut self, _: RequestId, meta_result: Result<FetchMetadata, NetworkError>) {
-        // TODO: https://github.com/servo/servo/issues/42840
-        let mut cx = unsafe { temp_cx() };
-        let cx = &mut cx;
+    fn process_response(
+        &mut self,
+        cx: &mut js::context::JSContext,
+        _: RequestId,
+        meta_result: Result<FetchMetadata, NetworkError>,
+    ) {
         let (metadata, error) = match meta_result {
             Ok(meta) => (
                 Some(match meta {

--- a/components/script/dom/workers/workerglobalscope.rs
+++ b/components/script/dom/workers/workerglobalscope.rs
@@ -143,6 +143,7 @@ impl FetchResponseListener for ScriptFetchContext {
 
     fn process_response(
         &mut self,
+        _: &mut js::context::JSContext,
         _request_id: RequestId,
         metadata: Result<FetchMetadata, NetworkError>,
     ) {

--- a/components/script/dom/xmlhttprequest.rs
+++ b/components/script/dom/xmlhttprequest.rs
@@ -110,7 +110,12 @@ impl FetchResponseListener for XHRContext {
         // todo
     }
 
-    fn process_response(&mut self, _: RequestId, metadata: Result<FetchMetadata, NetworkError>) {
+    fn process_response(
+        &mut self,
+        _: &mut js::context::JSContext,
+        _: RequestId,
+        metadata: Result<FetchMetadata, NetworkError>,
+    ) {
         let xhr = self.xhr.root();
         let rv = xhr.process_headers_available(self.gen_id, metadata, CanGc::note());
         if rv.is_err() {

--- a/components/script/dom/xmlhttprequest.rs
+++ b/components/script/dom/xmlhttprequest.rs
@@ -112,12 +112,12 @@ impl FetchResponseListener for XHRContext {
 
     fn process_response(
         &mut self,
-        _: &mut js::context::JSContext,
+        cx: &mut js::context::JSContext,
         _: RequestId,
         metadata: Result<FetchMetadata, NetworkError>,
     ) {
         let xhr = self.xhr.root();
-        let rv = xhr.process_headers_available(self.gen_id, metadata, CanGc::note());
+        let rv = xhr.process_headers_available(self.gen_id, metadata, CanGc::from_cx(cx));
         if rv.is_err() {
             *self.sync_status.borrow_mut() = Some(rv);
         }

--- a/components/script/fetch.rs
+++ b/components/script/fetch.rs
@@ -57,7 +57,7 @@ use crate::dom::window::Window;
 use crate::network_listener::{
     self, FetchResponseListener, NetworkListener, ResourceTimingListener, submit_timing_data,
 };
-use crate::realms::enter_realm;
+use crate::realms::{enter_auto_realm, enter_realm};
 use crate::script_runtime::CanGc;
 
 /// Fetch canceller object. By default initialized to having a
@@ -551,7 +551,8 @@ impl FetchResponseListener for FetchContext {
             .expect("fetch promise is missing")
             .root();
 
-        let _ac = enter_realm(&*promise);
+        let mut realm = enter_auto_realm(cx, &*promise);
+        let cx = &mut realm.current_realm();
         match fetch_metadata {
             // Step 12.3. If response is a network error, then reject
             // p with a TypeError and abort these steps.

--- a/components/script/fetch.rs
+++ b/components/script/fetch.rs
@@ -563,7 +563,7 @@ impl FetchResponseListener for FetchContext {
                 );
                 self.fetch_promise = Some(TrustedPromise::new(promise));
                 let response = self.response_object.root();
-                response.set_type(DOMResponseType::Error, CanGc::note());
+                response.set_type(DOMResponseType::Error, CanGc::from_cx(cx));
                 response.error_stream(
                     Error::Type(c"Network error occurred".to_owned()),
                     CanGc::from_cx(cx),
@@ -581,7 +581,7 @@ impl FetchResponseListener for FetchContext {
                 },
                 FetchMetadata::Filtered { filtered, .. } => match filtered {
                     FilteredMetadata::Basic(m) => {
-                        fill_headers_with_metadata(self.response_object.root(), m, CanGc::note());
+                        fill_headers_with_metadata(self.response_object.root(), m, CanGc::from_cx(cx));
                         self.response_object
                             .root()
                             .set_type(DOMResponseType::Basic, CanGc::from_cx(cx));

--- a/components/script/fetch.rs
+++ b/components/script/fetch.rs
@@ -537,6 +537,7 @@ impl FetchResponseListener for FetchContext {
 
     fn process_response(
         &mut self,
+        _: &mut js::context::JSContext,
         _: RequestId,
         fetch_metadata: Result<FetchMetadata, NetworkError>,
     ) {
@@ -669,6 +670,7 @@ impl FetchResponseListener for FetchLaterListener {
 
     fn process_response(
         &mut self,
+        _: &mut js::context::JSContext,
         _: RequestId,
         fetch_metadata: Result<FetchMetadata, NetworkError>,
     ) {

--- a/components/script/fetch.rs
+++ b/components/script/fetch.rs
@@ -537,7 +537,7 @@ impl FetchResponseListener for FetchContext {
 
     fn process_response(
         &mut self,
-        _: &mut js::context::JSContext,
+        cx: &mut js::context::JSContext,
         _: RequestId,
         fetch_metadata: Result<FetchMetadata, NetworkError>,
     ) {
@@ -558,14 +558,14 @@ impl FetchResponseListener for FetchContext {
             Err(error) => {
                 promise.reject_error(
                     Error::Type(cformat!("Network error: {:?}", error)),
-                    CanGc::note(),
+                    CanGc::from_cx(cx),
                 );
                 self.fetch_promise = Some(TrustedPromise::new(promise));
                 let response = self.response_object.root();
                 response.set_type(DOMResponseType::Error, CanGc::note());
                 response.error_stream(
                     Error::Type(c"Network error occurred".to_owned()),
-                    CanGc::note(),
+                    CanGc::from_cx(cx),
                 );
                 return;
             },
@@ -573,32 +573,36 @@ impl FetchResponseListener for FetchContext {
             // given response, "immutable", and relevantRealm.
             Ok(metadata) => match metadata {
                 FetchMetadata::Unfiltered(m) => {
-                    fill_headers_with_metadata(self.response_object.root(), m, CanGc::note());
+                    fill_headers_with_metadata(self.response_object.root(), m, CanGc::from_cx(cx));
                     self.response_object
                         .root()
-                        .set_type(DOMResponseType::Default, CanGc::note());
+                        .set_type(DOMResponseType::Default, CanGc::from_cx(cx));
                 },
                 FetchMetadata::Filtered { filtered, .. } => match filtered {
                     FilteredMetadata::Basic(m) => {
                         fill_headers_with_metadata(self.response_object.root(), m, CanGc::note());
                         self.response_object
                             .root()
-                            .set_type(DOMResponseType::Basic, CanGc::note());
+                            .set_type(DOMResponseType::Basic, CanGc::from_cx(cx));
                     },
                     FilteredMetadata::Cors(m) => {
-                        fill_headers_with_metadata(self.response_object.root(), m, CanGc::note());
+                        fill_headers_with_metadata(
+                            self.response_object.root(),
+                            m,
+                            CanGc::from_cx(cx),
+                        );
                         self.response_object
                             .root()
-                            .set_type(DOMResponseType::Cors, CanGc::note());
+                            .set_type(DOMResponseType::Cors, CanGc::from_cx(cx));
                     },
                     FilteredMetadata::Opaque => {
                         self.response_object
                             .root()
-                            .set_type(DOMResponseType::Opaque, CanGc::note());
+                            .set_type(DOMResponseType::Opaque, CanGc::from_cx(cx));
                     },
                     FilteredMetadata::OpaqueRedirect(url) => {
                         let r = self.response_object.root();
-                        r.set_type(DOMResponseType::Opaqueredirect, CanGc::note());
+                        r.set_type(DOMResponseType::Opaqueredirect, CanGc::from_cx(cx));
                         r.set_final_url(url);
                     },
                 },
@@ -606,7 +610,7 @@ impl FetchResponseListener for FetchContext {
         }
 
         // Step 12.5. Resolve p with responseObject.
-        promise.resolve_native(&self.response_object.root(), CanGc::note());
+        promise.resolve_native(&self.response_object.root(), CanGc::from_cx(cx));
         self.fetch_promise = Some(TrustedPromise::new(promise));
     }
 

--- a/components/script/fetch.rs
+++ b/components/script/fetch.rs
@@ -581,7 +581,11 @@ impl FetchResponseListener for FetchContext {
                 },
                 FetchMetadata::Filtered { filtered, .. } => match filtered {
                     FilteredMetadata::Basic(m) => {
-                        fill_headers_with_metadata(self.response_object.root(), m, CanGc::from_cx(cx));
+                        fill_headers_with_metadata(
+                            self.response_object.root(),
+                            m,
+                            CanGc::from_cx(cx),
+                        );
                         self.response_object
                             .root()
                             .set_type(DOMResponseType::Basic, CanGc::from_cx(cx));

--- a/components/script/layout_image.rs
+++ b/components/script/layout_image.rs
@@ -37,6 +37,7 @@ impl FetchResponseListener for LayoutImageContext {
     fn process_request_eof(&mut self, _: RequestId) {}
     fn process_response(
         &mut self,
+        _: &mut js::context::JSContext,
         request_id: RequestId,
         metadata: Result<FetchMetadata, NetworkError>,
     ) {

--- a/components/script/network_listener.rs
+++ b/components/script/network_listener.rs
@@ -104,6 +104,7 @@ pub(crate) trait FetchResponseListener: Send + 'static {
     fn process_request_eof(&mut self, request_id: RequestId);
     fn process_response(
         &mut self,
+        cx: &mut js::context::JSContext,
         request_id: RequestId,
         metadata: Result<FetchMetadata, NetworkError>,
     );
@@ -154,7 +155,7 @@ impl<Listener: FetchResponseListener> NetworkListener<Listener> {
                         fetch_listener.process_request_eof(request_id)
                     },
                     FetchResponseMsg::ProcessResponse(request_id, meta) => {
-                        fetch_listener.process_response(request_id, meta)
+                        fetch_listener.process_response(cx, request_id, meta)
                     },
                     FetchResponseMsg::ProcessResponseChunk(request_id, data) => {
                         fetch_listener.process_response_chunk(request_id, data.0)

--- a/components/script/script_module.rs
+++ b/components/script/script_module.rs
@@ -693,7 +693,12 @@ impl FetchResponseListener for ModuleContext {
     // TODO(cybai): Perhaps add custom steps to perform fetch here?
     fn process_request_eof(&mut self, _: RequestId) {}
 
-    fn process_response(&mut self, _: RequestId, metadata: Result<FetchMetadata, NetworkError>) {
+    fn process_response(
+        &mut self,
+        _: &mut js::context::JSContext,
+        _: RequestId,
+        metadata: Result<FetchMetadata, NetworkError>,
+    ) {
         self.metadata = metadata.ok().map(|meta| match meta {
             FetchMetadata::Unfiltered(m) => m,
             FetchMetadata::Filtered { unsafe_, .. } => unsafe_,

--- a/components/script/script_thread.rs
+++ b/components/script/script_thread.rs
@@ -3871,7 +3871,7 @@ impl ScriptThread {
 
         match message {
             FetchResponseMsg::ProcessResponse(request_id, metadata) => {
-                self.handle_fetch_metadata(pipeline_id, request_id, metadata)
+                self.handle_fetch_metadata(cx, pipeline_id, request_id, metadata)
             },
             FetchResponseMsg::ProcessResponseChunk(request_id, chunk) => {
                 self.handle_fetch_chunk(pipeline_id, request_id, chunk.0)
@@ -3889,6 +3889,7 @@ impl ScriptThread {
 
     fn handle_fetch_metadata(
         &self,
+        cx: &mut js::context::JSContext,
         id: PipelineId,
         request_id: RequestId,
         fetch_metadata: Result<FetchMetadata, NetworkError>,
@@ -3906,7 +3907,7 @@ impl ScriptThread {
             .iter_mut()
             .find(|&&mut (pipeline_id, _)| pipeline_id == id);
         if let Some(&mut (_, ref mut ctxt)) = parser {
-            ctxt.process_response(request_id, fetch_metadata);
+            ctxt.process_response(cx, request_id, fetch_metadata);
         }
     }
 
@@ -4057,7 +4058,7 @@ impl ScriptThread {
         self.incomplete_loads.borrow_mut().push(incomplete);
 
         let dummy_request_id = RequestId::default();
-        context.process_response(dummy_request_id, Ok(FetchMetadata::Unfiltered(meta)));
+        context.process_response(cx, dummy_request_id, Ok(FetchMetadata::Unfiltered(meta)));
         context.set_policy_container(policy_container.as_ref());
         context.set_about_base_url(about_base_url);
         context.process_response_chunk(dummy_request_id, chunk);
@@ -4095,7 +4096,7 @@ impl ScriptThread {
             ParserContext::new(webview_id, pipeline_id, url, creation_sandboxing_flag_set);
         let dummy_request_id = RequestId::default();
 
-        context.process_response(dummy_request_id, Ok(FetchMetadata::Unfiltered(meta)));
+        context.process_response(cx, dummy_request_id, Ok(FetchMetadata::Unfiltered(meta)));
         context.set_policy_container(policy_container.as_ref());
         context.set_about_base_url(about_base_url);
         context.process_response_chunk(dummy_request_id, chunk);

--- a/components/script/stylesheet_loader.rs
+++ b/components/script/stylesheet_loader.rs
@@ -337,7 +337,12 @@ impl FetchResponseListener for StylesheetContext {
 
     fn process_request_eof(&mut self, _: RequestId) {}
 
-    fn process_response(&mut self, _: RequestId, metadata: Result<FetchMetadata, NetworkError>) {
+    fn process_response(
+        &mut self,
+        _: &mut js::context::JSContext,
+        _: RequestId,
+        metadata: Result<FetchMetadata, NetworkError>,
+    ) {
         if let Ok(FetchMetadata::Filtered {
             filtered: FilteredMetadata::Opaque | FilteredMetadata::OpaqueRedirect(_),
             ..


### PR DESCRIPTION
Add the cx parameter to `fn process_response` in the `FetchResponseListener` trait and the traits that that interface change requires. Chose to add it as the first parameter, following the same order that `FetchResponseListener::process_response_eof` uses.

Testing: Checked that servo builds locally as well as `./mach fmt` and `./mach test-tidy`. I don't think more tests are needed as we are not introducing new functionality
Fixes: #42840 
