### PR TITLE
libservo: Expose `StringRequest` in public API

### DIFF
--- a/components/servo/lib.rs
+++ b/components/servo/lib.rs
@@ -64,7 +64,7 @@ pub use webrender_api::units::{
     DeviceIntPoint, DeviceIntRect, DeviceIntSize, DevicePixel, DevicePoint, DeviceVector2D,
 };
 
-pub use crate::clipboard_delegate::ClipboardDelegate;
+pub use crate::clipboard_delegate::{ClipboardDelegate, StringRequest};
 #[cfg(feature = "gamepad")]
 pub use crate::gamepad_delegate::{
     GamepadDelegate, GamepadHapticEffectRequest, GamepadHapticEffectRequestType,


### PR DESCRIPTION
This is a follow-up to 69d4353eca2a8f0cfffea11f205e7e0192ff4227, which attempted to make the `ClipboardDelegate` trait implementable, but missed that the `StringRequest` type required by this trait was still private.

*Describe the changes that this pull request makes here. This will be the commit message.*

Testing: I ran this against my browser to make sure this time pasting works end-to-end, which it did. So hopefully this should be all.
