### PR TITLE
webdriver: Always wait for `mousemove`/`wheel` in a blocking manner

### DIFF
--- a/components/webdriver_server/actions.rs
+++ b/components/webdriver_server/actions.rs
@@ -857,7 +857,7 @@ impl Handler {
         };
 
         // Step 5. If delta x != 0 or delta y != 0, run the following steps:
-        if delta_x != 0.0 || delta_y != 0.0 || last {
+        if delta_x != 0.0 || delta_y != 0.0 {
             // Step 5.1. Perform implementation-specific action dispatch steps
             let delta = WheelDelta {
                 x: -delta_x,

--- a/components/webdriver_server/actions.rs
+++ b/components/webdriver_server/actions.rs
@@ -660,8 +660,7 @@ impl Handler {
         } = self.get_pointer_input_state(input_id);
 
         // Step 7. If x != current x or y != current y, run the following steps:
-        // FIXME: Actually "last" should not be checked here based on spec.
-        if x != *current_x || y != *current_y || last {
+        if x != *current_x || y != *current_y {
             // Step 7.1. Let buttons be equal to input state's pressed property.
             // Step 7.2. Perform implementation-specific action dispatch steps
             let point = WebViewPoint::Page(Point2D::new(x as f32, y as f32));
@@ -671,11 +670,7 @@ impl Handler {
             match subtype {
                 PointerType::Mouse => {
                     let input_event = InputEvent::MouseMove(MouseMoveEvent::new(point));
-                    if last {
-                        self.send_blocking_input_event_to_embedder(input_event);
-                    } else {
-                        self.send_input_event_to_embedder(input_event);
-                    }
+                    self.send_blocking_input_event_to_embedder(input_event);
                 },
                 // In the case where the pointerType is "pen" or "touch", and buttons is empty,
                 // this may be a no-op.
@@ -862,8 +857,6 @@ impl Handler {
         };
 
         // Step 5. If delta x != 0 or delta y != 0, run the following steps:
-        // Actually "last" should not be checked here based on spec.
-        // However, we need to send the webdriver id at the final perform.
         if delta_x != 0.0 || delta_y != 0.0 || last {
             // Step 5.1. Perform implementation-specific action dispatch steps
             let delta = WheelDelta {
@@ -874,11 +867,8 @@ impl Handler {
             };
             let point = WebViewPoint::Page(Point2D::new(x as f32, y as f32));
             let input_event = InputEvent::Wheel(WheelEvent::new(delta, point));
-            if last {
-                self.send_blocking_input_event_to_embedder(input_event);
-            } else {
-                self.send_input_event_to_embedder(input_event);
-            }
+
+            self.send_blocking_input_event_to_embedder(input_event);
 
             // Step 5.2. Let current delta x property equal delta x + current delta x
             // and current delta y property equal delta y + current delta y.


### PR DESCRIPTION
This is now possible since #43202. We remove the workaround introduced long ago.

Testing: Before #43202, this would deadlock in many tests, and is therefore covered by existing tests.
[Try](https://github.com/servo/servo/actions/runs/23080857516)