### PR TITLE
Version releases with the workspace version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1770,7 +1770,7 @@ dependencies = [
 
 [[package]]
 name = "deny_public_fields_tests"
-version = "0.0.1"
+version = "0.0.6"
 dependencies = [
  "servo-deny-public-fields",
 ]
@@ -4792,7 +4792,7 @@ dependencies = [
 
 [[package]]
 name = "malloc_size_of_tests"
-version = "0.0.1"
+version = "0.0.6"
 dependencies = [
  "servo-malloc-size-of",
  "servo_arc",
@@ -6371,7 +6371,7 @@ dependencies = [
 
 [[package]]
 name = "profile_tests"
-version = "0.0.1"
+version = "0.0.6"
 dependencies = [
  "ipc-channel",
  "servo-config",
@@ -7060,7 +7060,7 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "script_tests"
-version = "0.0.1"
+version = "0.0.6"
 dependencies = [
  "encoding_rs",
  "euclid",
@@ -7277,7 +7277,7 @@ dependencies = [
 
 [[package]]
 name = "servo"
-version = "0.0.1"
+version = "0.0.6"
 dependencies = [
  "accesskit",
  "arboard",
@@ -7350,7 +7350,7 @@ dependencies = [
 
 [[package]]
 name = "servo-allocator"
-version = "0.0.1"
+version = "0.0.6"
 dependencies = [
  "backtrace",
  "libc",
@@ -7363,7 +7363,7 @@ dependencies = [
 
 [[package]]
 name = "servo-background-hang-monitor"
-version = "0.0.1"
+version = "0.0.6"
 dependencies = [
  "backtrace",
  "crossbeam-channel",
@@ -7380,7 +7380,7 @@ dependencies = [
 
 [[package]]
 name = "servo-background-hang-monitor-api"
-version = "0.0.1"
+version = "0.0.6"
 dependencies = [
  "serde",
  "servo-base",
@@ -7388,7 +7388,7 @@ dependencies = [
 
 [[package]]
 name = "servo-base"
-version = "0.0.1"
+version = "0.0.6"
 dependencies = [
  "accesskit",
  "crossbeam-channel",
@@ -7412,7 +7412,7 @@ dependencies = [
 
 [[package]]
 name = "servo-bluetooth"
-version = "0.0.1"
+version = "0.0.6"
 dependencies = [
  "bitflags 2.11.0",
  "blurdroid",
@@ -7430,7 +7430,7 @@ dependencies = [
 
 [[package]]
 name = "servo-bluetooth-traits"
-version = "0.0.1"
+version = "0.0.6"
 dependencies = [
  "regex",
  "serde",
@@ -7440,7 +7440,7 @@ dependencies = [
 
 [[package]]
 name = "servo-canvas"
-version = "0.0.1"
+version = "0.0.6"
 dependencies = [
  "bytemuck",
  "crossbeam-channel",
@@ -7468,7 +7468,7 @@ dependencies = [
 
 [[package]]
 name = "servo-canvas-traits"
-version = "0.0.1"
+version = "0.0.6"
 dependencies = [
  "crossbeam-channel",
  "euclid",
@@ -7489,7 +7489,7 @@ dependencies = [
 
 [[package]]
 name = "servo-config"
-version = "0.0.1"
+version = "0.0.6"
 dependencies = [
  "serde",
  "serde_json",
@@ -7499,7 +7499,7 @@ dependencies = [
 
 [[package]]
 name = "servo-config-macro"
-version = "0.0.1"
+version = "0.0.6"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -7509,7 +7509,7 @@ dependencies = [
 
 [[package]]
 name = "servo-constellation"
-version = "0.0.1"
+version = "0.0.6"
 dependencies = [
  "backtrace",
  "content-security-policy",
@@ -7557,7 +7557,7 @@ dependencies = [
 
 [[package]]
 name = "servo-constellation-traits"
-version = "0.0.1"
+version = "0.0.6"
 dependencies = [
  "content-security-policy",
  "encoding_rs",
@@ -7592,7 +7592,7 @@ dependencies = [
 
 [[package]]
 name = "servo-deny-public-fields"
-version = "0.0.1"
+version = "0.0.6"
 dependencies = [
  "syn",
  "synstructure",
@@ -7600,7 +7600,7 @@ dependencies = [
 
 [[package]]
 name = "servo-devtools"
-version = "0.0.1"
+version = "0.0.6"
 dependencies = [
  "atomic_refcell",
  "base64 0.22.1",
@@ -7628,7 +7628,7 @@ dependencies = [
 
 [[package]]
 name = "servo-devtools-traits"
-version = "0.0.1"
+version = "0.0.6"
 dependencies = [
  "bitflags 2.11.0",
  "http 1.4.0",
@@ -7646,7 +7646,7 @@ dependencies = [
 
 [[package]]
 name = "servo-dom-struct"
-version = "0.0.1"
+version = "0.0.6"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -7655,7 +7655,7 @@ dependencies = [
 
 [[package]]
 name = "servo-embedder-traits"
-version = "0.0.1"
+version = "0.0.6"
 dependencies = [
  "accesskit",
  "bitflags 2.11.0",
@@ -7687,7 +7687,7 @@ dependencies = [
 
 [[package]]
 name = "servo-fonts"
-version = "0.0.1"
+version = "0.0.6"
 dependencies = [
  "app_units",
  "bitflags 2.11.0",
@@ -7740,7 +7740,7 @@ dependencies = [
 
 [[package]]
 name = "servo-fonts-traits"
-version = "0.0.1"
+version = "0.0.6"
 dependencies = [
  "atomic_refcell",
  "dwrote",
@@ -7762,7 +7762,7 @@ dependencies = [
 
 [[package]]
 name = "servo-geometry"
-version = "0.0.1"
+version = "0.0.6"
 dependencies = [
  "app_units",
  "euclid",
@@ -7789,7 +7789,7 @@ dependencies = [
 
 [[package]]
 name = "servo-jstraceable-derive"
-version = "0.0.1"
+version = "0.0.6"
 dependencies = [
  "proc-macro2",
  "syn",
@@ -7798,7 +7798,7 @@ dependencies = [
 
 [[package]]
 name = "servo-layout"
-version = "0.0.1"
+version = "0.0.6"
 dependencies = [
  "accesskit",
  "app_units",
@@ -7854,7 +7854,7 @@ dependencies = [
 
 [[package]]
 name = "servo-layout-api"
-version = "0.0.1"
+version = "0.0.6"
 dependencies = [
  "app_units",
  "atomic_refcell",
@@ -7887,7 +7887,7 @@ dependencies = [
 
 [[package]]
 name = "servo-malloc-size-of"
-version = "0.0.1"
+version = "0.0.6"
 dependencies = [
  "accountable-refcell",
  "app_units",
@@ -7926,7 +7926,7 @@ dependencies = [
 
 [[package]]
 name = "servo-media"
-version = "0.0.1"
+version = "0.0.6"
 dependencies = [
  "once_cell",
  "servo-media-audio",
@@ -7938,7 +7938,7 @@ dependencies = [
 
 [[package]]
 name = "servo-media-audio"
-version = "0.0.1"
+version = "0.0.6"
 dependencies = [
  "byte-slice-cast",
  "euclid",
@@ -7960,7 +7960,7 @@ dependencies = [
 
 [[package]]
 name = "servo-media-auto"
-version = "0.0.1"
+version = "0.0.6"
 dependencies = [
  "servo-media-dummy",
  "servo-media-gstreamer",
@@ -7968,7 +7968,7 @@ dependencies = [
 
 [[package]]
 name = "servo-media-derive"
-version = "0.0.1"
+version = "0.0.6"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -7977,7 +7977,7 @@ dependencies = [
 
 [[package]]
 name = "servo-media-dummy"
-version = "0.0.1"
+version = "0.0.6"
 dependencies = [
  "ipc-channel",
  "servo-media",
@@ -7990,7 +7990,7 @@ dependencies = [
 
 [[package]]
 name = "servo-media-examples"
-version = "0.0.1"
+version = "0.0.6"
 dependencies = [
  "euclid",
  "rand 0.9.2",
@@ -8002,7 +8002,7 @@ dependencies = [
 
 [[package]]
 name = "servo-media-gstreamer"
-version = "0.0.1"
+version = "0.0.6"
 dependencies = [
  "byte-slice-cast",
  "glib",
@@ -8034,7 +8034,7 @@ dependencies = [
 
 [[package]]
 name = "servo-media-gstreamer-render"
-version = "0.0.1"
+version = "0.0.6"
 dependencies = [
  "gstreamer",
  "gstreamer-video",
@@ -8043,7 +8043,7 @@ dependencies = [
 
 [[package]]
 name = "servo-media-gstreamer-render-android"
-version = "0.0.1"
+version = "0.0.6"
 dependencies = [
  "glib",
  "gstreamer",
@@ -8056,7 +8056,7 @@ dependencies = [
 
 [[package]]
 name = "servo-media-gstreamer-render-unix"
-version = "0.0.1"
+version = "0.0.6"
 dependencies = [
  "glib",
  "gstreamer",
@@ -8071,7 +8071,7 @@ dependencies = [
 
 [[package]]
 name = "servo-media-player"
-version = "0.0.1"
+version = "0.0.6"
 dependencies = [
  "ipc-channel",
  "malloc_size_of_derive",
@@ -8084,7 +8084,7 @@ dependencies = [
 
 [[package]]
 name = "servo-media-streams"
-version = "0.0.1"
+version = "0.0.6"
 dependencies = [
  "malloc_size_of_derive",
  "servo-malloc-size-of",
@@ -8093,7 +8093,7 @@ dependencies = [
 
 [[package]]
 name = "servo-media-thread"
-version = "0.0.1"
+version = "0.0.6"
 dependencies = [
  "euclid",
  "ipc-channel",
@@ -8110,7 +8110,7 @@ dependencies = [
 
 [[package]]
 name = "servo-media-traits"
-version = "0.0.1"
+version = "0.0.6"
 dependencies = [
  "malloc_size_of_derive",
  "servo-malloc-size-of",
@@ -8118,7 +8118,7 @@ dependencies = [
 
 [[package]]
 name = "servo-media-webrtc"
-version = "0.0.1"
+version = "0.0.6"
 dependencies = [
  "log",
  "servo-media-streams",
@@ -8127,7 +8127,7 @@ dependencies = [
 
 [[package]]
 name = "servo-metrics"
-version = "0.0.1"
+version = "0.0.6"
 dependencies = [
  "malloc_size_of_derive",
  "servo-base",
@@ -8141,7 +8141,7 @@ dependencies = [
 
 [[package]]
 name = "servo-net"
-version = "0.0.1"
+version = "0.0.6"
 dependencies = [
  "async-compression",
  "async-recursion",
@@ -8211,7 +8211,7 @@ dependencies = [
 
 [[package]]
 name = "servo-net-traits"
-version = "0.0.1"
+version = "0.0.6"
 dependencies = [
  "content-security-policy",
  "cookie 0.18.1",
@@ -8250,7 +8250,7 @@ dependencies = [
 
 [[package]]
 name = "servo-paint"
-version = "0.0.1"
+version = "0.0.6"
 dependencies = [
  "bitflags 2.11.0",
  "crossbeam-channel",
@@ -8290,7 +8290,7 @@ dependencies = [
 
 [[package]]
 name = "servo-paint-api"
-version = "0.0.1"
+version = "0.0.6"
 dependencies = [
  "bitflags 2.11.0",
  "crossbeam-channel",
@@ -8326,7 +8326,7 @@ dependencies = [
 
 [[package]]
 name = "servo-pixels"
-version = "0.0.1"
+version = "0.0.6"
 dependencies = [
  "criterion",
  "euclid",
@@ -8341,7 +8341,7 @@ dependencies = [
 
 [[package]]
 name = "servo-profile"
-version = "0.0.1"
+version = "0.0.6"
 dependencies = [
  "libc",
  "log",
@@ -8359,7 +8359,7 @@ dependencies = [
 
 [[package]]
 name = "servo-profile-traits"
-version = "0.0.1"
+version = "0.0.6"
 dependencies = [
  "crossbeam-channel",
  "ipc-channel",
@@ -8376,7 +8376,7 @@ dependencies = [
 
 [[package]]
 name = "servo-script"
-version = "0.0.1"
+version = "0.0.6"
 dependencies = [
  "accountable-refcell",
  "aes",
@@ -8518,7 +8518,7 @@ dependencies = [
 
 [[package]]
 name = "servo-script-bindings"
-version = "0.0.1"
+version = "0.0.6"
 dependencies = [
  "bitflags 2.11.0",
  "crossbeam-channel",
@@ -8557,7 +8557,7 @@ dependencies = [
 
 [[package]]
 name = "servo-script-traits"
-version = "0.0.1"
+version = "0.0.6"
 dependencies = [
  "accesskit",
  "content-security-policy",
@@ -8595,7 +8595,7 @@ dependencies = [
 
 [[package]]
 name = "servo-storage"
-version = "0.0.1"
+version = "0.0.6"
 dependencies = [
  "libc",
  "log",
@@ -8626,7 +8626,7 @@ dependencies = [
 
 [[package]]
 name = "servo-storage-traits"
-version = "0.0.1"
+version = "0.0.6"
 dependencies = [
  "malloc_size_of_derive",
  "serde",
@@ -8639,7 +8639,7 @@ dependencies = [
 
 [[package]]
 name = "servo-timers"
-version = "0.0.1"
+version = "0.0.6"
 dependencies = [
  "crossbeam-channel",
  "malloc_size_of_derive",
@@ -8648,7 +8648,7 @@ dependencies = [
 
 [[package]]
 name = "servo-tracing"
-version = "0.0.1"
+version = "0.0.6"
 dependencies = [
  "prettyplease",
  "proc-macro2",
@@ -8658,7 +8658,7 @@ dependencies = [
 
 [[package]]
 name = "servo-url"
-version = "0.0.1"
+version = "0.0.6"
 dependencies = [
  "encoding_rs",
  "malloc_size_of_derive",
@@ -8671,7 +8671,7 @@ dependencies = [
 
 [[package]]
 name = "servo-webdriver-server"
-version = "0.0.1"
+version = "0.0.6"
 dependencies = [
  "base64 0.22.1",
  "cookie 0.18.1",
@@ -8697,7 +8697,7 @@ dependencies = [
 
 [[package]]
 name = "servo-webgl"
-version = "0.0.1"
+version = "0.0.6"
 dependencies = [
  "bitflags 2.11.0",
  "byteorder",
@@ -8722,7 +8722,7 @@ dependencies = [
 
 [[package]]
 name = "servo-webgpu"
-version = "0.0.1"
+version = "0.0.6"
 dependencies = [
  "arrayvec",
  "euclid",
@@ -8740,7 +8740,7 @@ dependencies = [
 
 [[package]]
 name = "servo-webgpu-traits"
-version = "0.0.1"
+version = "0.0.6"
 dependencies = [
  "arrayvec",
  "malloc_size_of_derive",
@@ -8755,7 +8755,7 @@ dependencies = [
 
 [[package]]
 name = "servo-webxr"
-version = "0.0.1"
+version = "0.0.6"
 dependencies = [
  "crossbeam-channel",
  "euclid",
@@ -8773,7 +8773,7 @@ dependencies = [
 
 [[package]]
 name = "servo-webxr-api"
-version = "0.0.1"
+version = "0.0.6"
 dependencies = [
  "euclid",
  "ipc-channel",
@@ -8788,7 +8788,7 @@ dependencies = [
 
 [[package]]
 name = "servo-xpath"
-version = "0.0.1"
+version = "0.0.6"
 dependencies = [
  "log",
  "malloc_size_of_derive",
@@ -9200,7 +9200,7 @@ dependencies = [
 
 [[package]]
 name = "style_tests"
-version = "0.0.1"
+version = "0.0.6"
 dependencies = [
  "app_units",
  "cssparser",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ default-members = ["ports/servoshell"]
 exclude = [".cargo", "support/crown"]
 
 [workspace.package]
-version = "0.0.1"
+version = "0.0.6"
 authors = ["The Servo Project Developers"]
 license = "MPL-2.0"
 edition = "2024"
@@ -226,68 +226,68 @@ xml5ever = "0.38"
 # be listed here, between the `Begin` and `End` comments, so that we can easily find and
 # update the version requirements when bumping the workspace version.
 # Begin workspace-version dependencies - Don't change this comment, we grep for it in scripts!
-background_hang_monitor = { package = "servo-background-hang-monitor", version = "0.0.1", path = "components/background_hang_monitor" }
-background_hang_monitor_api = { package = "servo-background-hang-monitor-api", version = "0.0.1", path = "components/shared/background_hang_monitor" }
-base = { package = "servo-base", version = "0.0.1", path = "components/shared/base" }
-bluetooth = { package = "servo-bluetooth", version = "0.0.1", path = "components/bluetooth" }
-bluetooth_traits = { package = "servo-bluetooth-traits", version = "0.0.1", path = "components/shared/bluetooth" }
-canvas = { package = "servo-canvas", version = "0.0.1", path = "components/canvas" }
-canvas_traits = { package = "servo-canvas-traits", version = "0.0.1", path = "components/shared/canvas" }
-constellation = { package = "servo-constellation", version = "0.0.1", path = "components/constellation" }
-constellation_traits = { package = "servo-constellation-traits", version = "0.0.1", path = "components/shared/constellation" }
-deny_public_fields = { package = "servo-deny-public-fields", version = "0.0.1", path = "components/deny_public_fields" }
-devtools = { package = "servo-devtools", version = "0.0.1", path = "components/devtools" }
-devtools_traits = { package = "servo-devtools-traits", version = "0.0.1", path = "components/shared/devtools" }
-dom_struct = { package = "servo-dom-struct", version = "0.0.1", path = "components/dom_struct" }
-embedder_traits = { package = "servo-embedder-traits", version = "0.0.1", path = "components/shared/embedder" }
-fonts = { package = "servo-fonts", version = "0.0.1", path = "components/fonts" }
-fonts_traits = { package = "servo-fonts-traits", version = "0.0.1", path = "components/shared/fonts" }
-jstraceable_derive = { package = "servo-jstraceable-derive", version = "0.0.1", path = "components/jstraceable_derive" }
-layout = { package = "servo-layout", version = "0.0.1", path = "components/layout" }
-layout_api = { package = "servo-layout-api", version = "0.0.1", path = "components/shared/layout" }
-malloc_size_of = { package = "servo-malloc-size-of", version = "0.0.1", path = "components/malloc_size_of" }
-media = { package = "servo-media-thread", version = "0.0.1", path = "components/media/media-thread" }
-metrics = { package = "servo-metrics", version = "0.0.1", path = "components/metrics" }
-net = { package = "servo-net", version = "0.0.1", path = "components/net" }
-net_traits = { package = "servo-net-traits", version = "0.0.1", path = "components/shared/net" }
-paint = { package = "servo-paint", version = "0.0.1", path = "components/paint" }
-paint_api = { package = "servo-paint-api", version = "0.0.1", path = "components/shared/paint" }
-pixels = { package = "servo-pixels", version = "0.0.1", path = "components/pixels" }
-profile = { package = "servo-profile", version = "0.0.1", path = "components/profile" }
-profile_traits = { package = "servo-profile-traits", version = "0.0.1", path = "components/shared/profile" }
-script = { package = "servo-script", version = "0.0.1", path = "components/script" }
-script_bindings = { package = "servo-script-bindings", version = "0.0.1", path = "components/script_bindings" }
-script_traits = { package = "servo-script-traits", version = "0.0.1", path = "components/shared/script" }
-servo = { version = "0.0.1", path = "components/servo", default-features = false }
-servo-media = { version = "0.0.1", path = "components/media/servo-media" }
-servo-media-audio = { version = "0.0.1", path = "components/media/audio" }
-servo-media-auto = { version = "0.0.1", path = "components/media/backends/auto" }
-servo-media-derive = { version = "0.0.1", path = "components/media/servo-media-derive" }
-servo-media-dummy = { version = "0.0.1", path = "components/media/backends/dummy" }
-servo-media-gstreamer = { version = "0.0.1", path = "components/media/backends/gstreamer" }
-servo-media-gstreamer-render = { version = "0.0.1", path = "components/media/backends/gstreamer/render" }
-servo-media-gstreamer-render-android = { version = "0.0.1", path = "components/media/backends/gstreamer/render-android" }
-servo-media-gstreamer-render-unix = { version = "0.0.1", path = "components/media/backends/gstreamer/render-unix" }
-servo-media-player = { version = "0.0.1", path = "components/media/player" }
-servo-media-streams = { version = "0.0.1", path = "components/media/streams" }
-servo-media-traits = { version = "0.0.1", path = "components/media/traits" }
-servo-media-webrtc = { version = "0.0.1", path = "components/media/webrtc" }
-servo-tracing = { version = "0.0.1", path = "components/servo_tracing" }
-servo-url = { version = "0.0.1", path = "components/url" }
-servo_allocator = { package = "servo-allocator", version = "0.0.1", path = "components/allocator" }
-servo_config = { package = "servo-config", version = "0.0.1", path = "components/config" }
-servo_config_macro = { package = "servo-config-macro", version = "0.0.1", path = "components/config/macro" }
-servo_geometry = { package = "servo-geometry", version = "0.0.1", path = "components/geometry" }
-storage = { package = "servo-storage", version = "0.0.1", path = "components/storage" }
-storage_traits = { package = "servo-storage-traits", version = "0.0.1", path = "components/shared/storage" }
-timers = { package = "servo-timers", version = "0.0.1", path = "components/timers" }
-webdriver_server = { package = "servo-webdriver-server", version = "0.0.1", path = "components/webdriver_server" }
-webgl = { package = "servo-webgl", version = "0.0.1", path = "components/webgl", default-features = false }
-webgpu = { package = "servo-webgpu", version = "0.0.1", path = "components/webgpu" }
-webgpu_traits = { package = "servo-webgpu-traits", version = "0.0.1", path = "components/shared/webgpu" }
-webxr = { package = "servo-webxr", version = "0.0.1", path = "components/webxr" }
-webxr-api = { package = "servo-webxr-api", version = "0.0.1", path = "components/shared/webxr" }
-xpath = { package = "servo-xpath", version = "0.0.1", path = "components/xpath" }
+background_hang_monitor = { package = "servo-background-hang-monitor", version = "0.0.6", path = "components/background_hang_monitor" }
+background_hang_monitor_api = { package = "servo-background-hang-monitor-api", version = "0.0.6", path = "components/shared/background_hang_monitor" }
+base = { package = "servo-base", version = "0.0.6", path = "components/shared/base" }
+bluetooth = { package = "servo-bluetooth", version = "0.0.6", path = "components/bluetooth" }
+bluetooth_traits = { package = "servo-bluetooth-traits", version = "0.0.6", path = "components/shared/bluetooth" }
+canvas = { package = "servo-canvas", version = "0.0.6", path = "components/canvas" }
+canvas_traits = { package = "servo-canvas-traits", version = "0.0.6", path = "components/shared/canvas" }
+constellation = { package = "servo-constellation", version = "0.0.6", path = "components/constellation" }
+constellation_traits = { package = "servo-constellation-traits", version = "0.0.6", path = "components/shared/constellation" }
+deny_public_fields = { package = "servo-deny-public-fields", version = "0.0.6", path = "components/deny_public_fields" }
+devtools = { package = "servo-devtools", version = "0.0.6", path = "components/devtools" }
+devtools_traits = { package = "servo-devtools-traits", version = "0.0.6", path = "components/shared/devtools" }
+dom_struct = { package = "servo-dom-struct", version = "0.0.6", path = "components/dom_struct" }
+embedder_traits = { package = "servo-embedder-traits", version = "0.0.6", path = "components/shared/embedder" }
+fonts = { package = "servo-fonts", version = "0.0.6", path = "components/fonts" }
+fonts_traits = { package = "servo-fonts-traits", version = "0.0.6", path = "components/shared/fonts" }
+jstraceable_derive = { package = "servo-jstraceable-derive", version = "0.0.6", path = "components/jstraceable_derive" }
+layout = { package = "servo-layout", version = "0.0.6", path = "components/layout" }
+layout_api = { package = "servo-layout-api", version = "0.0.6", path = "components/shared/layout" }
+malloc_size_of = { package = "servo-malloc-size-of", version = "0.0.6", path = "components/malloc_size_of" }
+media = { package = "servo-media-thread", version = "0.0.6", path = "components/media/media-thread" }
+metrics = { package = "servo-metrics", version = "0.0.6", path = "components/metrics" }
+net = { package = "servo-net", version = "0.0.6", path = "components/net" }
+net_traits = { package = "servo-net-traits", version = "0.0.6", path = "components/shared/net" }
+paint = { package = "servo-paint", version = "0.0.6", path = "components/paint" }
+paint_api = { package = "servo-paint-api", version = "0.0.6", path = "components/shared/paint" }
+pixels = { package = "servo-pixels", version = "0.0.6", path = "components/pixels" }
+profile = { package = "servo-profile", version = "0.0.6", path = "components/profile" }
+profile_traits = { package = "servo-profile-traits", version = "0.0.6", path = "components/shared/profile" }
+script = { package = "servo-script", version = "0.0.6", path = "components/script" }
+script_bindings = { package = "servo-script-bindings", version = "0.0.6", path = "components/script_bindings" }
+script_traits = { package = "servo-script-traits", version = "0.0.6", path = "components/shared/script" }
+servo = { version = "0.0.6", path = "components/servo", default-features = false }
+servo-media = { version = "0.0.6", path = "components/media/servo-media" }
+servo-media-audio = { version = "0.0.6", path = "components/media/audio" }
+servo-media-auto = { version = "0.0.6", path = "components/media/backends/auto" }
+servo-media-derive = { version = "0.0.6", path = "components/media/servo-media-derive" }
+servo-media-dummy = { version = "0.0.6", path = "components/media/backends/dummy" }
+servo-media-gstreamer = { version = "0.0.6", path = "components/media/backends/gstreamer" }
+servo-media-gstreamer-render = { version = "0.0.6", path = "components/media/backends/gstreamer/render" }
+servo-media-gstreamer-render-android = { version = "0.0.6", path = "components/media/backends/gstreamer/render-android" }
+servo-media-gstreamer-render-unix = { version = "0.0.6", path = "components/media/backends/gstreamer/render-unix" }
+servo-media-player = { version = "0.0.6", path = "components/media/player" }
+servo-media-streams = { version = "0.0.6", path = "components/media/streams" }
+servo-media-traits = { version = "0.0.6", path = "components/media/traits" }
+servo-media-webrtc = { version = "0.0.6", path = "components/media/webrtc" }
+servo-tracing = { version = "0.0.6", path = "components/servo_tracing" }
+servo-url = { version = "0.0.6", path = "components/url" }
+servo_allocator = { package = "servo-allocator", version = "0.0.6", path = "components/allocator" }
+servo_config = { package = "servo-config", version = "0.0.6", path = "components/config" }
+servo_config_macro = { package = "servo-config-macro", version = "0.0.6", path = "components/config/macro" }
+servo_geometry = { package = "servo-geometry", version = "0.0.6", path = "components/geometry" }
+storage = { package = "servo-storage", version = "0.0.6", path = "components/storage" }
+storage_traits = { package = "servo-storage-traits", version = "0.0.6", path = "components/shared/storage" }
+timers = { package = "servo-timers", version = "0.0.6", path = "components/timers" }
+webdriver_server = { package = "servo-webdriver-server", version = "0.0.6", path = "components/webdriver_server" }
+webgl = { package = "servo-webgl", version = "0.0.6", path = "components/webgl", default-features = false }
+webgpu = { package = "servo-webgpu", version = "0.0.6", path = "components/webgpu" }
+webgpu_traits = { package = "servo-webgpu-traits", version = "0.0.6", path = "components/shared/webgpu" }
+webxr = { package = "servo-webxr", version = "0.0.6", path = "components/webxr" }
+webxr-api = { package = "servo-webxr-api", version = "0.0.6", path = "components/shared/webxr" }
+xpath = { package = "servo-xpath", version = "0.0.6", path = "components/xpath" }
 # End workspace-version dependencies - Don't change this comment, we grep for it in scripts!
 
 # Independently versioned workspace local crates. These crates will not take part in auto-bumps.

--- a/ports/servoshell/Cargo.toml
+++ b/ports/servoshell/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "servoshell"
 build = "build.rs"
-version = "0.0.6"
+version.workspace = true
 authors.workspace = true
 license.workspace = true
 edition.workspace = true

--- a/python/servo/package_commands.py
+++ b/python/servo/package_commands.py
@@ -91,10 +91,10 @@ class PackageCommands(CommandBase):
                 break
 
             if in_section and stripped_line.startswith("version"):
-                lines[index] = f"version = \"{new_version}\""
+                lines[index] = f'version = "{new_version}"'
                 return "\n".join(lines)
 
-        raise ValueError(f"Failed to update workspace package version.")
+        raise ValueError("Failed to update workspace package version.")
 
     @staticmethod
     def _replace_path_versions(content: str, new_version: str) -> str:
@@ -120,7 +120,9 @@ class PackageCommands(CommandBase):
         if count == 0:
             raise ValueError("No workspace-version dependency references found in Cargo.toml.")
         elif count == 1:
-            raise RuntimeError("Our regex only updated one version, but we expect to have many. Please check the regex.")
+            raise RuntimeError(
+                "Our regex only updated one version, but we expect to have many. Please check the regex."
+            )
 
         return f"{content[:block_start]}{updated_block}{content[block_end:]}"
 

--- a/python/servo/package_commands.py
+++ b/python/servo/package_commands.py
@@ -71,6 +71,59 @@ def check_call_with_randomized_backoff(args: list[str], retries: int) -> int:
 
 @CommandProvider
 class PackageCommands(CommandBase):
+    @staticmethod
+    def _replace_workspace_version(content: str, new_version: str) -> str:
+        """
+        Given the `content` of servo's workspace Cargo.toml, update the workspace version to
+        `new_version` and return the modified Cargo.toml content.
+        """
+        lines = content.splitlines()
+        section_header = "[workspace.package]"
+        in_section = False
+
+        for index, line in enumerate(lines):
+            stripped_line = line.strip()
+            if stripped_line == section_header:
+                in_section = True
+                continue
+
+            if in_section and stripped_line.startswith("[") and stripped_line.endswith("]"):
+                break
+
+            if in_section and stripped_line.startswith("version"):
+                lines[index] = f"version = \"{new_version}\""
+                return "\n".join(lines)
+
+        raise ValueError(f"Failed to update workspace package version.")
+
+    @staticmethod
+    def _replace_path_versions(content: str, new_version: str) -> str:
+        """
+        Given content of the workspace Cargo.toml file, update the version requirements of `path`
+        dependencies that are versioned with the workspace version.
+        We mark the relevant section in our Cargo.toml so we can easily find the dependencies
+        we need to update the version of.
+        """
+        begin_marker = "# Begin workspace-version dependencies - Don't change this comment, we grep for it in scripts!"
+        end_marker = "# End workspace-version dependencies - Don't change this comment, we grep for it in scripts!"
+        block_start = content.find(begin_marker)
+        if block_start == -1:
+            raise ValueError(f"Could not find begin marker: {begin_marker}")
+
+        block_start += len(begin_marker)
+        block_end = content.find(end_marker, block_start)
+        if block_end == -1:
+            raise ValueError(f"Could not find end marker: {end_marker}")
+
+        block = content[block_start:block_end]
+        updated_block, count = re.subn(r'version\s*=\s*"[^"]*"', f'version = "{new_version}"', block)
+        if count == 0:
+            raise ValueError("No workspace-version dependency references found in Cargo.toml.")
+        elif count == 1:
+            raise RuntimeError("Our regex only updated one version, but we expect to have many. Please check the regex.")
+
+        return f"{content[:block_start]}{updated_block}{content[block_end:]}"
+
     @Command("package", description="Package Servo", category="package")
     @CommandArgument("--android", default=None, action="store_true", help="Package Android")
     @CommandArgument("--ohos", default=None, action="store_true", help="Package OpenHarmony")
@@ -448,7 +501,7 @@ class PackageCommands(CommandBase):
         return 1
 
     @Command(
-        "release", description="Perform necessary updates before release a new servoshell version", category="package"
+        "release", description="Perform necessary updates before releasing a new servo version", category="package"
     )
     @CommandArgument("target", type=str, help="Target version to bump to")
     @CommandArgument("--allow-dirty", action="store_true", help="Allow working directory to be dirty")
@@ -461,8 +514,23 @@ class PackageCommands(CommandBase):
                 print("To bypass this check, use --allow-dirty.")
                 return 1
         print("\r ➤  Bumping version number...")
+        workspace_toml_path = path.join(self.get_top_dir(), "Cargo.toml")
+        with open(workspace_toml_path, "r") as file:
+            workspace_toml_content = file.read()
+
+        try:
+            workspace_toml_content = self._replace_workspace_version(workspace_toml_content, target)
+            workspace_toml_content = self._replace_path_versions(workspace_toml_content, target)
+        except (ValueError, RuntimeError) as error:
+            print(f"Failed to update workspace version: `{error}`", file=sys.stderr)
+            return 1
+
+        with open(workspace_toml_path, "w") as file:
+            file.write(workspace_toml_content)
+
+        print("Updated occurrences in workspace Cargo.toml.")
+
         replacements = {
-            "ports/servoshell/Cargo.toml": r'^version ?= ?"(?P<version>.*?)"',
             "ports/servoshell/platform/windows/servoshell.exe.manifest": r'assemblyIdentity[^\/>]+version="(?P<version>.*?).0\"[^\/>]*\/>',
             "support/windows/ServoShell.wxs.mako": r'<Product(.|\n)*Version="(?P<version>.*?)".*>',
             "ports/servoshell/platform/macos/Info.plist": r"<key>CFBundleShortVersionString</key>\n\s*<string>(?P<version>.*?)</string>",


### PR DESCRIPTION
In preparation for a release to crates.io, bump the workspace version to match the current servoshell version, and let the servoshell version use the workspace version again. This makes versioning for us easier, and makes more sense since servoshell is considered to be just a demo for servo.

The `./mach release` command is updated to support bumping the workspace version, and patch the version requirement of all workspace-versioned workspace dependencies. 

Testing: Can be manually verified by running `./mach release <new_version>`. Note that this just bumps the version numbers, and doesn't release anything, so it's perfectly safe to run. 

