### PR TITLE
blurmac: Disable publishing

### DIFF
--- a/third_party/blurmac/Cargo.toml
+++ b/third_party/blurmac/Cargo.toml
@@ -8,6 +8,7 @@ repository = "https://github.com/akosthekiss/blurmac"
 authors = ["Akos Kiss <akiss@inf.u-szeged.hu>"]
 license = "BSD-3-Clause"
 edition = "2024"
+publish = false
 
 [lib]
 name = "blurmac"


### PR DESCRIPTION
`cargo publish --workspace` should ignore this crate, we currently don't plan to release it.

Testing: Not tested

