### PR TITLE
script: Pass `&mut JSContext` to `TrustedHTML::get_trusted_type_compliant_string`

### DIFF
--- a/components/script/dom/document.rs
+++ b/components/script/dom/document.rs
@@ -3605,11 +3605,11 @@ impl Document {
         // Get Trusted Type compliant string algorithm with TrustedHTML,
         // this's relevant global object, string, sink, and "script".
         if !is_trusted {
-            string = TrustedHTML::get_trusted_script_compliant_string(
+            string = TrustedHTML::get_trusted_type_compliant_string(
+                cx,
                 &self.global(),
                 TrustedHTMLOrString::String(string.into()),
                 &format!("{} {}", containing_class, field),
-                CanGc::from_cx(cx),
             )?
             .str()
             .to_owned();
@@ -5190,11 +5190,11 @@ impl DocumentMethods<crate::DomTypeHolder> for Document {
         // Step 1. Let compliantHTML be the result of invoking the
         // Get Trusted Type compliant string algorithm with TrustedHTML, the current global object,
         // html, "Document parseHTMLUnsafe", and "script".
-        let compliant_html = TrustedHTML::get_trusted_script_compliant_string(
+        let compliant_html = TrustedHTML::get_trusted_type_compliant_string(
+            cx,
             window.as_global_scope(),
             s,
             "Document parseHTMLUnsafe",
-            CanGc::from_cx(cx),
         )?;
 
         let url = window.get_url();
@@ -6601,11 +6601,11 @@ impl DocumentMethods<crate::DomTypeHolder> for Document {
         value: TrustedHTMLOrString,
     ) -> Fallible<bool> {
         let value = if command_id == "insertHTML" {
-            TrustedHTML::get_trusted_script_compliant_string(
+            TrustedHTML::get_trusted_type_compliant_string(
+                cx,
                 self.window.as_global_scope(),
                 value,
                 "Document execCommand",
-                CanGc::from_cx(cx),
             )?
         } else {
             match value {

--- a/components/script/dom/domparser.rs
+++ b/components/script/dom/domparser.rs
@@ -68,11 +68,11 @@ impl DOMParserMethods<crate::DomTypeHolder> for DOMParser {
         // Step 1. Let compliantString be the result of invoking the
         // Get Trusted Type compliant string algorithm with TrustedHTML,
         // this's relevant global object, string, "DOMParser parseFromString", and "script".
-        let compliant_string = TrustedHTML::get_trusted_script_compliant_string(
+        let compliant_string = TrustedHTML::get_trusted_type_compliant_string(
+            cx,
             self.window.as_global_scope(),
             s,
             "DOMParser parseFromString",
-            CanGc::from_cx(cx),
         )?;
         let url = self.window.get_url();
         let content_type = ty

--- a/components/script/dom/element.rs
+++ b/components/script/dom/element.rs
@@ -3699,11 +3699,11 @@ impl ElementMethods<crate::DomTypeHolder> for Element {
         // Step 1. Let compliantHTML be the result of invoking the
         // Get Trusted Type compliant string algorithm with TrustedHTML,
         // this's relevant global object, html, "Element setHTMLUnsafe", and "script".
-        let html = TrustedHTML::get_trusted_script_compliant_string(
+        let html = TrustedHTML::get_trusted_type_compliant_string(
+            cx,
             &self.owner_global(),
             html,
             "Element setHTMLUnsafe",
-            CanGc::from_cx(cx),
         )?;
         // Step 2. Let target be this's template contents if this is a template element; otherwise this.
         let target = if let Some(template) = self.downcast::<HTMLTemplateElement>() {
@@ -3759,11 +3759,11 @@ impl ElementMethods<crate::DomTypeHolder> for Element {
         // Step 1: Let compliantString be the result of invoking the
         // Get Trusted Type compliant string algorithm with TrustedHTML,
         // this's relevant global object, the given value, "Element innerHTML", and "script".
-        let value = TrustedHTML::get_trusted_script_compliant_string(
+        let value = TrustedHTML::get_trusted_type_compliant_string(
+            cx,
             &self.owner_global(),
             value.convert(),
             "Element innerHTML",
-            CanGc::from_cx(cx),
         )?;
         // https://github.com/w3c/DOM-Parsing/issues/1
         let target = if let Some(template) = self.downcast::<HTMLTemplateElement>() {
@@ -3819,11 +3819,11 @@ impl ElementMethods<crate::DomTypeHolder> for Element {
         // Step 1: Let compliantString be the result of invoking the
         // Get Trusted Type compliant string algorithm with TrustedHTML,
         // this's relevant global object, the given value, "Element outerHTML", and "script".
-        let value = TrustedHTML::get_trusted_script_compliant_string(
+        let value = TrustedHTML::get_trusted_type_compliant_string(
+            cx,
             &self.owner_global(),
             value.convert(),
             "Element outerHTML",
-            CanGc::from_cx(cx),
         )?;
         let context_document = self.owner_document();
         let context_node = self.upcast::<Node>();
@@ -4040,11 +4040,11 @@ impl ElementMethods<crate::DomTypeHolder> for Element {
         // Step 1: Let compliantString be the result of invoking the
         // Get Trusted Type compliant string algorithm with TrustedHTML,
         // this's relevant global object, string, "Element insertAdjacentHTML", and "script".
-        let text = TrustedHTML::get_trusted_script_compliant_string(
+        let text = TrustedHTML::get_trusted_type_compliant_string(
+            cx,
             &self.owner_global(),
             text,
             "Element insertAdjacentHTML",
-            CanGc::from_cx(cx),
         )?;
         let position = position.parse::<AdjacentPosition>()?;
 

--- a/components/script/dom/html/htmliframeelement.rs
+++ b/components/script/dom/html/htmliframeelement.rs
@@ -884,22 +884,26 @@ impl HTMLIFrameElementMethods<crate::DomTypeHolder> for HTMLIFrameElement {
     }
 
     /// <https://html.spec.whatwg.org/multipage/#dom-iframe-srcdoc>
-    fn SetSrcdoc(&self, value: TrustedHTMLOrString, can_gc: CanGc) -> Fallible<()> {
+    fn SetSrcdoc(
+        &self,
+        cx: &mut js::context::JSContext,
+        value: TrustedHTMLOrString,
+    ) -> Fallible<()> {
         // Step 1: Let compliantString be the result of invoking the
         // Get Trusted Type compliant string algorithm with TrustedHTML,
         // this's relevant global object, the given value, "HTMLIFrameElement srcdoc", and "script".
         let element = self.upcast::<Element>();
-        let value = TrustedHTML::get_trusted_script_compliant_string(
+        let value = TrustedHTML::get_trusted_type_compliant_string(
+            cx,
             &element.owner_global(),
             value,
             "HTMLIFrameElement srcdoc",
-            can_gc,
         )?;
         // Step 2: Set an attribute value given this, srcdoc's local name, and compliantString.
         element.set_attribute(
             &local_name!("srcdoc"),
             AttrValue::String(value.str().to_owned()),
-            can_gc,
+            CanGc::from_cx(cx),
         );
         Ok(())
     }
@@ -909,7 +913,7 @@ impl HTMLIFrameElementMethods<crate::DomTypeHolder> for HTMLIFrameElement {
     /// The supported tokens for sandbox's DOMTokenList are the allowed values defined in the
     /// sandbox attribute and supported by the user agent. These range of possible values is
     /// defined here: <https://html.spec.whatwg.org/multipage/#attr-iframe-sandbox>
-    fn Sandbox(&self, can_gc: CanGc) -> DomRoot<DOMTokenList> {
+    fn Sandbox(&self, cx: &mut js::context::JSContext) -> DomRoot<DOMTokenList> {
         self.sandbox.or_init(|| {
             DOMTokenList::new(
                 self.upcast::<Element>(),
@@ -929,7 +933,7 @@ impl HTMLIFrameElementMethods<crate::DomTypeHolder> for HTMLIFrameElement {
                     Atom::from("allow-top-navigation-by-user-activation"),
                     Atom::from("allow-top-navigation-to-custom-protocols"),
                 ]),
-                can_gc,
+                CanGc::from_cx(cx),
             )
         })
     }

--- a/components/script/dom/range.rs
+++ b/components/script/dom/range.rs
@@ -1150,11 +1150,11 @@ impl RangeMethods<crate::DomTypeHolder> for Range {
         // Step 1. Let compliantString be the result of invoking the
         // Get Trusted Type compliant string algorithm with TrustedHTML,
         // this's relevant global object, string, "Range createContextualFragment", and "script".
-        let fragment = TrustedHTML::get_trusted_script_compliant_string(
+        let fragment = TrustedHTML::get_trusted_type_compliant_string(
+            cx,
             node.owner_window().upcast(),
             fragment,
             "Range createContextualFragment",
-            CanGc::from_cx(cx),
         )?;
 
         let owner_doc = node.owner_doc();

--- a/components/script/dom/shadowroot.rs
+++ b/components/script/dom/shadowroot.rs
@@ -494,11 +494,11 @@ impl ShadowRootMethods<crate::DomTypeHolder> for ShadowRoot {
     ) -> ErrorResult {
         // Step 1. Let compliantString be the result of invoking the Get Trusted Type compliant string algorithm
         // with TrustedHTML, this's relevant global object, the given value, "ShadowRoot innerHTML", and "script".
-        let value = TrustedHTML::get_trusted_script_compliant_string(
+        let value = TrustedHTML::get_trusted_type_compliant_string(
+            cx,
             &self.owner_global(),
             value.convert(),
             "ShadowRoot innerHTML",
-            CanGc::from_cx(cx),
         )?;
 
         // Step 2. Let context be this's host.
@@ -530,11 +530,11 @@ impl ShadowRootMethods<crate::DomTypeHolder> for ShadowRoot {
         // Step 1. Let compliantHTML be the result of invoking the
         // Get Trusted Type compliant string algorithm with TrustedHTML,
         // this's relevant global object, html, "ShadowRoot setHTMLUnsafe", and "script".
-        let value = TrustedHTML::get_trusted_script_compliant_string(
+        let value = TrustedHTML::get_trusted_type_compliant_string(
+            cx,
             &self.owner_global(),
             value,
             "ShadowRoot setHTMLUnsafe",
-            CanGc::from_cx(cx),
         )?;
         // Step 2. Unsafely set HTMl given this, this's shadow host, and complaintHTML
         let target = self.upcast::<Node>();

--- a/components/script/dom/trustedtypes/trustedhtml.rs
+++ b/components/script/dom/trustedtypes/trustedhtml.rs
@@ -45,11 +45,11 @@ impl TrustedHTML {
         reflect_dom_object_with_cx(Box::new(Self::new_inherited(data)), global, cx)
     }
 
-    pub(crate) fn get_trusted_script_compliant_string(
+    pub(crate) fn get_trusted_type_compliant_string(
+        cx: &mut js::context::JSContext,
         global: &GlobalScope,
         value: TrustedHTMLOrString,
         sink: &str,
-        can_gc: CanGc,
     ) -> Fallible<DOMString> {
         match value {
             TrustedHTMLOrString::String(value) => {
@@ -59,7 +59,7 @@ impl TrustedHTML {
                     value,
                     sink,
                     DEFAULT_SCRIPT_SINK_GROUP,
-                    can_gc,
+                    CanGc::from_cx(cx),
                 )
             },
 

--- a/components/script_bindings/codegen/Bindings.conf
+++ b/components/script_bindings/codegen/Bindings.conf
@@ -473,7 +473,7 @@ DOMInterfaces = {
 },
 
 'HTMLIFrameElement': {
-    'canGc': ['Sandbox', 'SetSrcdoc'],
+    'cx': ['Sandbox', 'SetSrcdoc'],
 },
 
 'HTMLImageElement': {


### PR DESCRIPTION
Part of #40600

Testing: It compiles