### PR TITLE
chore: remove abbreviated crate names

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -278,8 +278,6 @@ servo_allocator = { package = "servo-allocator", version = "0.0.1", path = "comp
 servo_config = { package = "servo-config", version = "0.0.1", path = "components/config" }
 servo_config_macro = { package = "servo-config-macro", version = "0.0.1", path = "components/config/macro" }
 servo_geometry = { package = "servo-geometry", version = "0.0.1", path = "components/geometry" }
-sm-gst-render = { package = "servo-media-gstreamer-render", version = "0.0.1", path = "components/media/backends/gstreamer/render" }
-sm-player = { package = "servo-media-player", version = "0.0.1", path = "components/media/player" }
 storage = { package = "servo-storage", version = "0.0.1", path = "components/storage" }
 storage_traits = { package = "servo-storage-traits", version = "0.0.1", path = "components/shared/storage" }
 timers = { package = "servo-timers", version = "0.0.1", path = "components/timers" }

--- a/components/media/backends/gstreamer/render-android/Cargo.toml
+++ b/components/media/backends/gstreamer/render-android/Cargo.toml
@@ -17,5 +17,5 @@ gstreamer = { workspace = true }
 gstreamer-gl = { workspace = true }
 gstreamer-gl-egl = { workspace = true }
 gstreamer-video = { workspace = true }
-sm-player = { workspace = true }
-sm-gst-render = { workspace = true }
+servo-media-player = { workspace = true }
+servo-media-gstreamer-render = { workspace = true }

--- a/components/media/backends/gstreamer/render-android/lib.rs
+++ b/components/media/backends/gstreamer/render-android/lib.rs
@@ -13,10 +13,10 @@ use std::sync::{Arc, Mutex};
 
 use gstreamer::prelude::*;
 use gstreamer_gl::prelude::*;
-use sm_gst_render::Render;
-use sm_player::PlayerError;
-use sm_player::context::{GlApi, GlContext, NativeDisplay, PlayerGLContext};
-use sm_player::video::{Buffer, VideoFrame, VideoFrameData};
+use servo_media_gstreamer_render::Render;
+use servo_media_player::PlayerError;
+use servo_media_player::context::{GlApi, GlContext, NativeDisplay, PlayerGLContext};
+use servo_media_player::video::{Buffer, VideoFrame, VideoFrameData};
 
 struct GStreamerBuffer {
     is_external_oes: bool,

--- a/components/media/backends/gstreamer/render-unix/Cargo.toml
+++ b/components/media/backends/gstreamer/render-unix/Cargo.toml
@@ -24,5 +24,5 @@ gstreamer-gl-egl = { workspace = true, optional = true }
 gstreamer-gl-x11 = { workspace = true, optional = true }
 gstreamer-gl-wayland = { workspace = true, optional = true }
 gstreamer-video = { workspace = true }
-sm-player = { workspace = true }
-sm-gst-render = { workspace = true }
+servo-media-player = { workspace = true }
+servo-media-gstreamer-render = { workspace = true }

--- a/components/media/backends/gstreamer/render-unix/lib.rs
+++ b/components/media/backends/gstreamer/render-unix/lib.rs
@@ -13,10 +13,10 @@
 use std::sync::{Arc, Mutex};
 
 use gstreamer_gl::prelude::*;
-use sm_gst_render::Render;
-use sm_player::PlayerError;
-use sm_player::context::{GlApi, GlContext, NativeDisplay, PlayerGLContext};
-use sm_player::video::{Buffer, VideoFrame, VideoFrameData};
+use servo_media_gstreamer_render::Render;
+use servo_media_player::PlayerError;
+use servo_media_player::context::{GlApi, GlContext, NativeDisplay, PlayerGLContext};
+use servo_media_player::video::{Buffer, VideoFrame, VideoFrameData};
 
 struct GStreamerBuffer {
     is_external_oes: bool,

--- a/components/media/backends/gstreamer/render/Cargo.toml
+++ b/components/media/backends/gstreamer/render/Cargo.toml
@@ -14,5 +14,4 @@ path = "lib.rs"
 [dependencies]
 gstreamer = { workspace = true }
 gstreamer-video = { workspace = true }
-sm-player = { workspace = true }
-
+servo-media-player = { workspace = true }

--- a/components/media/backends/gstreamer/render/lib.rs
+++ b/components/media/backends/gstreamer/render/lib.rs
@@ -17,6 +17,8 @@
 //! pipeline, and handle the produced buffers.
 //!
 
+use servo_media_player::{PlayerError, video};
+
 pub trait Render {
     /// Returns `True` if the render implementation uses any version
     /// or flavor of OpenGL
@@ -32,7 +34,7 @@ pub trait Render {
     /// # Arguments
     ///
     /// * `sample` -  the GStreamer sample with the buffer to map
-    fn build_frame(&self, sample: gstreamer::Sample) -> Option<sm_player::video::VideoFrame>;
+    fn build_frame(&self, sample: gstreamer::Sample) -> Option<video::VideoFrame>;
 
     /// Sets the proper *video-sink* to GStreamer's `pipeline`, this
     /// video sink is simply a decorator of the passed `appsink`.
@@ -45,5 +47,5 @@ pub trait Render {
         &self,
         appsink: &gstreamer::Element,
         pipeline: &gstreamer::Element,
-    ) -> Result<(), sm_player::PlayerError>;
+    ) -> Result<(), PlayerError>;
 }


### PR DESCRIPTION
This remove `sm-player` and `sm-gst-render` that point to the same crates as `servo-media-player` and `servo-media-gstreamer-render`

Testing: a successful build is enough

