### PR TITLE
chore: replace references to servo_url by servo-url

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -278,7 +278,6 @@ servo_allocator = { package = "servo-allocator", version = "0.0.1", path = "comp
 servo_config = { package = "servo-config", version = "0.0.1", path = "components/config" }
 servo_config_macro = { package = "servo-config-macro", version = "0.0.1", path = "components/config/macro" }
 servo_geometry = { package = "servo-geometry", version = "0.0.1", path = "components/geometry" }
-servo_url = { package = "servo-url", version = "0.0.1", path = "components/url" }
 sm-gst-render = { package = "servo-media-gstreamer-render", version = "0.0.1", path = "components/media/backends/gstreamer/render" }
 sm-player = { package = "servo-media-player", version = "0.0.1", path = "components/media/player" }
 storage = { package = "servo-storage", version = "0.0.1", path = "components/storage" }

--- a/components/constellation/Cargo.toml
+++ b/components/constellation/Cargo.toml
@@ -55,7 +55,7 @@ script_traits = { workspace = true }
 serde = { workspace = true }
 servo-tracing = { workspace = true }
 servo_config = { workspace = true }
-servo_url = { workspace = true }
+servo-url = { workspace = true }
 storage_traits = { workspace = true }
 stylo = { workspace = true }
 stylo_traits = { workspace = true }

--- a/components/devtools/Cargo.toml
+++ b/components/devtools/Cargo.toml
@@ -32,7 +32,7 @@ rustc-hash = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 servo_config = { workspace = true }
-servo_url = { workspace = true }
+servo-url = { workspace = true }
 uuid = { workspace = true }
 
 [build-dependencies]

--- a/components/fonts/Cargo.toml
+++ b/components/fonts/Cargo.toml
@@ -43,7 +43,7 @@ serde = { workspace = true }
 servo-tracing = { workspace = true }
 servo_arc = { workspace = true }
 servo_config = { workspace = true }
-servo_url = { workspace = true }
+servo-url = { workspace = true }
 skrifa = { workspace = true }
 smallvec = { workspace = true }
 rustc-hash = { workspace = true }

--- a/components/layout/Cargo.toml
+++ b/components/layout/Cargo.toml
@@ -51,7 +51,7 @@ servo-tracing = { workspace = true }
 servo_arc = { workspace = true }
 servo_config = { workspace = true }
 servo_geometry = { workspace = true }
-servo_url = { workspace = true }
+servo-url = { workspace = true }
 smallvec = { workspace = true }
 strum = { workspace = true }
 stylo = { workspace = true }

--- a/components/metrics/Cargo.toml
+++ b/components/metrics/Cargo.toml
@@ -19,4 +19,4 @@ paint_api = { workspace = true }
 profile_traits = { workspace = true }
 script_traits = { workspace = true }
 servo_config = { workspace = true }
-servo_url = { workspace = true }
+servo-url = { workspace = true }

--- a/components/net/Cargo.toml
+++ b/components/net/Cargo.toml
@@ -67,7 +67,7 @@ rustls-platform-verifier = { workspace = true }
 serde = { workspace = true }
 servo_arc = { workspace = true }
 servo_config = { workspace = true }
-servo_url = { workspace = true }
+servo-url = { workspace = true }
 sha2 = { workspace = true }
 time = { workspace = true }
 tokio = { workspace = true, features = ["macros", "rt-multi-thread", "sync"] }

--- a/components/script/Cargo.toml
+++ b/components/script/Cargo.toml
@@ -133,7 +133,7 @@ servo-media = { workspace = true }
 servo_arc = { workspace = true }
 servo_config = { workspace = true }
 servo_geometry = { workspace = true }
-servo_url = { workspace = true }
+servo-url = { workspace = true }
 sha1 = { workspace = true }
 sha2 = { workspace = true }
 sha3 = { workspace = true }

--- a/components/script_bindings/Cargo.toml
+++ b/components/script_bindings/Cargo.toml
@@ -40,7 +40,7 @@ profile_traits = { workspace = true }
 regex = { workspace = true }
 servo_arc = { workspace = true }
 servo_config = { workspace = true }
-servo_url = { workspace = true }
+servo-url = { workspace = true }
 smallvec = { workspace = true }
 stylo = { workspace = true }
 stylo_atoms = { workspace = true }

--- a/components/servo/Cargo.toml
+++ b/components/servo/Cargo.toml
@@ -117,7 +117,7 @@ servo-tracing = { workspace = true }
 servo_allocator = { workspace = true }
 servo_config = { workspace = true }
 servo_geometry = { workspace = true }
-servo_url = { workspace = true }
+servo-url = { workspace = true }
 storage = { workspace = true }
 storage_traits = { workspace = true }
 stylo = { workspace = true }

--- a/components/shared/constellation/Cargo.toml
+++ b/components/shared/constellation/Cargo.toml
@@ -37,7 +37,7 @@ profile_traits = { workspace = true }
 rustc-hash = { workspace = true }
 serde = { workspace = true }
 servo_config = { workspace = true }
-servo_url = { workspace = true }
+servo-url = { workspace = true }
 storage_traits = { workspace = true }
 strum = { workspace = true }
 stylo_traits = { workspace = true }

--- a/components/shared/devtools/Cargo.toml
+++ b/components/shared/devtools/Cargo.toml
@@ -22,5 +22,5 @@ malloc_size_of_derive = { workspace = true }
 net_traits = { workspace = true }
 profile_traits = { workspace = true }
 serde = { workspace = true }
-servo_url = { workspace = true }
+servo-url = { workspace = true }
 uuid = { workspace = true, features = ["serde"] }

--- a/components/shared/embedder/Cargo.toml
+++ b/components/shared/embedder/Cargo.toml
@@ -35,7 +35,7 @@ pixels = { workspace = true }
 rustc-hash = { workspace = true }
 serde = { workspace = true }
 servo_geometry = { workspace = true }
-servo_url = { workspace = true }
+servo-url = { workspace = true }
 strum = { workspace = true }
 stylo = { workspace = true }
 stylo_traits = { workspace = true }

--- a/components/shared/fonts/Cargo.toml
+++ b/components/shared/fonts/Cargo.toml
@@ -24,7 +24,7 @@ parking_lot = { workspace = true }
 profile_traits = { workspace = true }
 read-fonts = { workspace = true }
 serde = { workspace = true }
-servo_url = { workspace = true }
+servo-url = { workspace = true }
 stylo = { workspace = true }
 webrender_api = { workspace = true }
 

--- a/components/shared/layout/Cargo.toml
+++ b/components/shared/layout/Cargo.toml
@@ -35,7 +35,7 @@ script_traits = { workspace = true }
 selectors = { workspace = true }
 serde = { workspace = true }
 servo_arc = { workspace = true }
-servo_url = { workspace = true }
+servo-url = { workspace = true }
 stylo = { workspace = true }
 stylo_traits = { workspace = true }
 webrender_api = { workspace = true }

--- a/components/shared/net/Cargo.toml
+++ b/components/shared/net/Cargo.toml
@@ -41,7 +41,7 @@ rustls-pki-types = { workspace = true }
 serde = { workspace = true }
 servo_arc = { workspace = true }
 servo_config = { workspace = true }
-servo_url = { workspace = true }
+servo-url = { workspace = true }
 sys-locale = "0.3"
 tokio = { workspace = true }
 url = { workspace = true }

--- a/components/shared/script/Cargo.toml
+++ b/components/shared/script/Cargo.toml
@@ -40,7 +40,7 @@ profile_traits = { workspace = true }
 rustc-hash = { workspace = true }
 serde = { workspace = true }
 servo_config = { workspace = true }
-servo_url = { workspace = true }
+servo-url = { workspace = true }
 storage_traits = { workspace = true }
 strum = { workspace = true }
 stylo_atoms = { workspace = true }

--- a/components/shared/storage/Cargo.toml
+++ b/components/shared/storage/Cargo.toml
@@ -17,5 +17,5 @@ malloc_size_of = { workspace = true }
 malloc_size_of_derive = { workspace = true }
 profile_traits = { workspace = true }
 serde = { workspace = true }
-servo_url = { workspace = true }
+servo-url = { workspace = true }
 uuid = { workspace = true, features = ["serde"] }

--- a/components/storage/Cargo.toml
+++ b/components/storage/Cargo.toml
@@ -28,7 +28,7 @@ sea-query-rusqlite = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 servo_config = { workspace = true }
-servo_url = { workspace = true }
+servo-url = { workspace = true }
 storage_traits = { workspace = true }
 tempfile = "3"
 tokio = { workspace = true, features = ["macros", "rt-multi-thread", "sync"] }

--- a/components/webdriver_server/Cargo.toml
+++ b/components/webdriver_server/Cargo.toml
@@ -27,7 +27,7 @@ serde = { workspace = true }
 serde_json = { workspace = true }
 servo_config = { workspace = true }
 servo_geometry = { workspace = true }
-servo_url = { workspace = true }
+servo-url = { workspace = true }
 stylo_traits = { workspace = true }
 time = { workspace = true }
 uuid = { workspace = true }

--- a/tests/unit/script/Cargo.toml
+++ b/tests/unit/script/Cargo.toml
@@ -17,4 +17,4 @@ encoding_rs = { workspace = true }
 euclid = { workspace = true }
 keyboard-types = { workspace = true }
 script = { workspace = true }
-servo_url = { workspace = true }
+servo-url = { workspace = true }


### PR DESCRIPTION
It was decided to keep the kebab-case version.

Testing: Successful compilation is enough

