### PR TITLE
script: Pass `&mut JSContext` to `TrustedScript::can_compile_string_with_trusted_type`

### DIFF
--- a/components/script/dom/trustedtypes/trustedscript.rs
+++ b/components/script/dom/trustedtypes/trustedscript.rs
@@ -4,6 +4,7 @@
 use std::fmt;
 
 use dom_struct::dom_struct;
+use js::context::JSContext;
 use js::jsapi::CompilationType;
 use js::rust::HandleValue;
 
@@ -19,7 +20,7 @@ use crate::dom::trustedtypes::trustedtypepolicy::TrustedType;
 use crate::dom::trustedtypes::trustedtypepolicyfactory::{
     DEFAULT_SCRIPT_SINK_GROUP, TrustedTypePolicyFactory,
 };
-use crate::script_runtime::{CanGc, JSContext};
+use crate::script_runtime::CanGc;
 
 #[dom_struct]
 pub struct TrustedScript {
@@ -36,11 +37,7 @@ impl TrustedScript {
         }
     }
 
-    pub(crate) fn new(
-        cx: &mut js::context::JSContext,
-        data: DOMString,
-        global: &GlobalScope,
-    ) -> DomRoot<Self> {
+    pub(crate) fn new(cx: &mut JSContext, data: DOMString, global: &GlobalScope) -> DomRoot<Self> {
         reflect_dom_object_with_cx(Box::new(Self::new_inherited(data)), global, cx)
     }
 
@@ -73,7 +70,7 @@ impl TrustedScript {
     /// <https://www.w3.org/TR/CSP/#can-compile-strings>
     #[allow(clippy::too_many_arguments)]
     pub(crate) fn can_compile_string_with_trusted_type(
-        cx: JSContext,
+        cx: &mut JSContext,
         global: &GlobalScope,
         code_string: DOMString,
         compilation_type: CompilationType,
@@ -81,7 +78,6 @@ impl TrustedScript {
         body_string: DOMString,
         parameter_args: Vec<TrustedScriptOrString>,
         body_arg: HandleValue,
-        can_gc: CanGc,
     ) -> bool {
         // Step 2.1. Let compilationSink be "Function" if compilationType is "FUNCTION",
         // and "eval" otherwise.
@@ -92,7 +88,8 @@ impl TrustedScript {
         };
         // Step 2.2. Let isTrusted be true if bodyArg implements TrustedScript,
         // and false otherwise.
-        let mut is_trusted = match TrustedTypePolicyFactory::is_trusted_script(cx, body_arg) {
+        let mut is_trusted = match TrustedTypePolicyFactory::is_trusted_script(cx.into(), body_arg)
+        {
             // Step 2.3. If isTrusted is true then:
             Ok(trusted_script) => {
                 // Step 2.3.1. If bodyString is not equal to bodyArg’s data, set isTrusted to false.
@@ -138,7 +135,7 @@ impl TrustedScript {
                 global,
                 TrustedScriptOrString::String(code_string.clone()),
                 compilation_sink,
-                can_gc,
+                CanGc::from_cx(cx),
             ) {
                 // Step 2.7. If the algorithm throws an error, throw an EvalError.
                 Err(_) => {

--- a/components/script/script_runtime.rs
+++ b/components/script/script_runtime.rs
@@ -41,6 +41,7 @@ use js::jsapi::{
 };
 use js::jsval::{JSVal, ObjectValue, UndefinedValue};
 use js::panic::wrap_panic;
+use js::realm::CurrentRealm;
 pub(crate) use js::rust::ThreadSafeJSContext;
 use js::rust::wrappers::{GetPromiseIsHandled, JS_GetPromiseResult};
 use js::rust::wrappers2::{
@@ -498,10 +499,10 @@ unsafe extern "C" fn promise_rejection_tracker(
 }
 
 #[expect(unsafe_code)]
-fn safely_convert_null_to_string(cx: JSContext, str_: HandleString) -> DOMString {
+fn safely_convert_null_to_string(cx: &mut js::context::JSContext, str_: HandleString) -> DOMString {
     DOMString::from(match std::ptr::NonNull::new(*str_) {
         None => "".to_owned(),
-        Some(str_) => unsafe { jsstr_to_string(*cx, str_) },
+        Some(str_) => unsafe { jsstr_to_string(cx.raw_cx(), str_) },
     })
 }
 
@@ -534,11 +535,13 @@ unsafe extern "C" fn content_security_policy_allows(
     can_compile_strings: *mut bool,
 ) -> bool {
     let mut allowed = false;
-    let cx = unsafe { JSContext::from_ptr(cx) };
+    // SAFETY: We are in SM hook
+    let mut cx = unsafe { js::context::JSContext::from_ptr(NonNull::new(cx).unwrap()) };
+    let cx = &mut cx;
     wrap_panic(&mut || {
         // SpiderMonkey provides null pointer when executing webassembly.
-        let in_realm_proof = AlreadyInRealm::assert_for_cx(cx);
-        let global = unsafe { &GlobalScope::from_context(*cx, InRealm::Already(&in_realm_proof)) };
+        let realm = CurrentRealm::assert(cx);
+        let global = GlobalScope::from_current_realm(&realm);
         let csp_list = global.get_csp_list();
 
         // If we don't have any CSP checks to run, short-circuit all logic here
@@ -567,9 +570,9 @@ unsafe extern "C" fn content_security_policy_allows(
                         };
                         let value = arg.into_handle().get();
                         if value.is_object() {
-                            if let Ok(trusted_script) =
-                                unsafe { root_from_object::<TrustedScript>(value.to_object(), *cx) }
-                            {
+                            if let Ok(trusted_script) = unsafe {
+                                root_from_object::<TrustedScript>(value.to_object(), cx.raw_cx())
+                            } {
                                 parameter_args_vec
                                     .push(TrustedScriptOrString::TrustedScript(trusted_script));
                             } else {
@@ -588,19 +591,21 @@ unsafe extern "C" fn content_security_policy_allows(
                         }
                     }
 
+                    let code_string = safely_convert_null_to_string(cx, code_string);
+                    let body_string = safely_convert_null_to_string(cx, body_string);
+
                     TrustedScript::can_compile_string_with_trusted_type(
                         cx,
-                        global,
-                        safely_convert_null_to_string(cx, code_string),
+                        &global,
+                        code_string,
                         compilation_type,
                         parameter_strings_vec,
-                        safely_convert_null_to_string(cx, body_string),
+                        body_string,
                         parameter_args_vec,
                         unsafe { HandleValue::from_raw(body_arg) },
-                        CanGc::note(),
                     )
                 },
-                RuntimeCode::WASM => global.get_csp_list().is_wasm_evaluation_allowed(global),
+                RuntimeCode::WASM => global.get_csp_list().is_wasm_evaluation_allowed(&global),
             };
     });
     unsafe { *can_compile_strings = allowed };


### PR DESCRIPTION
Part of #40600

Testing: It compiles