### PR TITLE
script_bindings: Remove non-existent entries

### DIFF
--- a/components/script_bindings/codegen/Bindings.conf
+++ b/components/script_bindings/codegen/Bindings.conf
@@ -477,7 +477,7 @@ DOMInterfaces = {
 },
 
 'HTMLImageElement': {
-    'canGc': ['RequestSubmit', 'Reset','SetRel', 'Decode'],
+    'canGc': ['Decode'],
     'cx': ['Image', 'ReportValidity', 'SetCrossOrigin'],
 },
 


### PR DESCRIPTION
These methods do not exist in DOM.

Testing: It compiles.
