### PR TITLE
script: Add basic implementation of font-size command

### DIFF
--- a/components/script/dom/document/document.rs
+++ b/components/script/dom/document/document.rs
@@ -4638,8 +4638,12 @@ impl Document {
     }
 
     /// <https://w3c.github.io/editing/docs/execCommand/#state-override>
-    pub(crate) fn set_state_override(&self, command_name: CommandName, state: bool) {
-        self.state_override.borrow_mut().insert(command_name, state);
+    pub(crate) fn set_state_override(&self, command_name: CommandName, state: Option<bool>) {
+        if let Some(state) = state {
+            self.state_override.borrow_mut().insert(command_name, state);
+        } else {
+            self.value_override.borrow_mut().remove(&command_name);
+        }
     }
 
     /// <https://w3c.github.io/editing/docs/execCommand/#value-override>
@@ -6181,8 +6185,12 @@ impl DocumentMethods<crate::DomTypeHolder> for Document {
     }
 
     /// <https://w3c.github.io/editing/docs/execCommand/#querycommandvalue()>
-    fn QueryCommandValue(&self, command_id: DOMString) -> DOMString {
-        self.command_value_for_command(command_id)
+    fn QueryCommandValue(
+        &self,
+        cx: &mut js::context::JSContext,
+        command_id: DOMString,
+    ) -> DOMString {
+        self.command_value_for_command(cx, command_id)
     }
 
     // https://fullscreen.spec.whatwg.org/#handler-document-onfullscreenerror

--- a/components/script/dom/execcommand/basecommand.rs
+++ b/components/script/dom/execcommand/basecommand.rs
@@ -2,12 +2,26 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
+use servo_arc::Arc as ServoArc;
+use style::properties::declaration_block::PropertyDeclarationBlock;
+use style::properties::generated::LonghandId;
+use style::properties::{ComputedValues, PropertyDeclarationId};
+use style_traits::ToCss;
+
+use crate::dom::bindings::codegen::Bindings::CSSStyleDeclarationBinding::CSSStyleDeclarationMethods;
+use crate::dom::bindings::codegen::Bindings::HTMLElementBinding::HTMLElementMethods;
 use crate::dom::bindings::str::DOMString;
 use crate::dom::document::Document;
+use crate::dom::element::Element;
 use crate::dom::execcommand::commands::defaultparagraphseparator::execute_default_paragraph_separator_command;
 use crate::dom::execcommand::commands::delete::execute_delete_command;
+use crate::dom::execcommand::commands::fontsize::{
+    execute_fontsize_command, value_for_fontsize_command,
+};
 use crate::dom::execcommand::commands::stylewithcss::execute_style_with_css_command;
+use crate::dom::html::htmlelement::HTMLElement;
 use crate::dom::selection::Selection;
+use crate::script_runtime::CanGc;
 
 #[derive(Default, Clone, Copy, MallocSizeOf)]
 pub(crate) enum DefaultSingleLineContainerName {
@@ -25,11 +39,76 @@ impl From<DefaultSingleLineContainerName> for DOMString {
     }
 }
 
+/// <https://w3c.github.io/editing/docs/execCommand/#relevant-css-property>
+#[derive(Clone, Copy, Eq, PartialEq)]
+#[expect(unused)] // TODO(25005): implement all commands
+pub(crate) enum CssPropertyName {
+    BackgroundColor,
+    FontSize,
+    FontWeight,
+    FontStyle,
+}
+
+impl CssPropertyName {
+    fn resolved_value_for_node(&self, style: ServoArc<ComputedValues>) -> String {
+        match self {
+            CssPropertyName::BackgroundColor => style.clone_background_color().to_css_string(),
+            CssPropertyName::FontSize => style.clone_font_size().to_css_string(),
+            CssPropertyName::FontWeight => style.clone_font_weight().to_css_string(),
+            CssPropertyName::FontStyle => style.clone_font_style().to_css_string(),
+        }
+    }
+
+    /// Retrieves a respective css longhand value from the style declarations of an
+    /// element. Note that this is different than the computed values, since this is
+    /// only relevant when the author specified rules on the specific element.
+    pub(crate) fn value_set_for_style(
+        &self,
+        style: &PropertyDeclarationBlock,
+    ) -> Option<DOMString> {
+        let longhand_id = match self {
+            CssPropertyName::BackgroundColor => LonghandId::BackgroundColor,
+            CssPropertyName::FontSize => LonghandId::FontSize,
+            CssPropertyName::FontWeight => LonghandId::FontWeight,
+            CssPropertyName::FontStyle => LonghandId::FontStyle,
+        };
+        style
+            .get(PropertyDeclarationId::Longhand(longhand_id))
+            .and_then(|value| {
+                let mut dest = String::new();
+                value.0.to_css(&mut dest).ok()?;
+                Some(dest.into())
+            })
+    }
+
+    fn property_name(&self) -> DOMString {
+        match self {
+            CssPropertyName::BackgroundColor => "background-color",
+            CssPropertyName::FontSize => "font-size",
+            CssPropertyName::FontWeight => "font-weight",
+            CssPropertyName::FontStyle => "font-style",
+        }
+        .into()
+    }
+
+    pub(crate) fn set_for_element(
+        &self,
+        cx: &mut js::context::JSContext,
+        element: &HTMLElement,
+        new_value: DOMString,
+    ) {
+        let style = element.Style(CanGc::from_cx(cx));
+
+        let _ = style.SetProperty(cx, self.property_name(), new_value, "".into());
+    }
+}
+
 #[derive(Clone, Copy, Eq, Hash, MallocSizeOf, PartialEq)]
 #[expect(unused)] // TODO(25005): implement all commands
 pub(crate) enum CommandName {
     BackColor,
     Bold,
+    Copy,
     CreateLink,
     Cut,
     DefaultParagraphSeparator,
@@ -37,10 +116,12 @@ pub(crate) enum CommandName {
     FontName,
     FontSize,
     ForeColor,
+    FormatBlock,
     ForwardDelete,
     HiliteColor,
     Indent,
     InsertHorizontalRule,
+    InsertHtml,
     InsertLineBreak,
     InsertOrderedList,
     InsertParagraph,
@@ -84,15 +165,109 @@ impl CommandName {
     }
 
     /// <https://w3c.github.io/editing/docs/execCommand/#value>
-    pub(crate) fn current_value(&self, document: &Document) -> Option<DOMString> {
+    pub(crate) fn current_value(
+        &self,
+        cx: &mut js::context::JSContext,
+        document: &Document,
+    ) -> Option<DOMString> {
         Some(match self {
             CommandName::DefaultParagraphSeparator => {
                 // https://w3c.github.io/editing/docs/execCommand/#the-defaultparagraphseparator-command
                 // > Return the context object's default single-line container name.
                 document.default_single_line_container_name().into()
             },
+            CommandName::FontSize => value_for_fontsize_command(cx, document)?,
             _ => return None,
         })
+    }
+
+    /// <https://w3c.github.io/editing/docs/execCommand/#equivalent-values>
+    pub(crate) fn are_equivalent_values(
+        &self,
+        first: Option<&DOMString>,
+        second: Option<&DOMString>,
+    ) -> bool {
+        match (first, second) {
+            // > Two quantities are equivalent values for a command if either both are null,
+            (None, None) => true,
+            (Some(first_str), Some(second_str)) => {
+                // > or both are strings and the command defines equivalent values and they match the definition.
+                match self {
+                    CommandName::Bold => {
+                        // https://w3c.github.io/editing/docs/execCommand/#the-bold-command
+                        // > Either the two strings are equal, or one is "bold" and the other is "700",
+                        // > or one is "normal" and the other is "400".
+                        first_str == second_str ||
+                            matches!(
+                                (first_str.str().as_ref(), second_str.str().as_ref()),
+                                ("bold", "700") |
+                                    ("700", "bold") |
+                                    ("normal", "400") |
+                                    ("400", "normal")
+                            )
+                    },
+                    // > or both are strings and they're equal and the command does not define any equivalent values,
+                    _ => first_str == second_str,
+                }
+            },
+            _ => false,
+        }
+    }
+
+    /// <https://w3c.github.io/editing/docs/execCommand/#loosely-equivalent-values>
+    pub(crate) fn are_loosely_equivalent_values(
+        &self,
+        first: Option<&DOMString>,
+        second: Option<&DOMString>,
+    ) -> bool {
+        // > Two quantities are loosely equivalent values for a command if either they are equivalent values for the command,
+        self.are_equivalent_values(first, second)
+        // > or if the command is the fontSize command;
+        // > one of the quantities is one of "x-small", "small", "medium", "large", "x-large", "xx-large", or "xxx-large";
+        // > and the other quantity is the resolved value of "font-size" on a font element whose size attribute
+        // > has the corresponding value set ("1" through "7" respectively).
+        // TODO
+    }
+
+    /// <https://w3c.github.io/editing/docs/execCommand/#relevant-css-property>
+    pub(crate) fn relevant_css_property(&self) -> Option<CssPropertyName> {
+        // > This is defined for certain inline formatting commands, and is used in algorithms specific to those commands.
+        // > It is an implementation detail, and is not exposed to authors.
+        Some(match self {
+            CommandName::FontSize => CssPropertyName::FontSize,
+            CommandName::Bold => CssPropertyName::FontWeight,
+            CommandName::Italic => CssPropertyName::FontStyle,
+            // > If a command does not have a relevant CSS property specified, it defaults to null.
+            _ => return None,
+        })
+    }
+
+    pub(crate) fn resolved_value_for_node(&self, element: &Element) -> Option<DOMString> {
+        let property = self.relevant_css_property()?;
+        element
+            .style()
+            .map(|style| property.resolved_value_for_node(style).into())
+    }
+
+    pub(crate) fn is_enabled_in_plaintext_only_state(&self) -> bool {
+        matches!(
+            self,
+            CommandName::Copy |
+                CommandName::Cut |
+                CommandName::DefaultParagraphSeparator |
+                CommandName::FormatBlock |
+                CommandName::ForwardDelete |
+                CommandName::InsertHtml |
+                CommandName::InsertLineBreak |
+                CommandName::InsertParagraph |
+                CommandName::InsertText |
+                CommandName::Paste |
+                CommandName::Redo |
+                CommandName::StyleWithCss |
+                CommandName::Undo |
+                CommandName::Usecss |
+                CommandName::Delete
+        )
     }
 
     /// <https://w3c.github.io/editing/docs/execCommand/#action>
@@ -108,6 +283,7 @@ impl CommandName {
                 execute_default_paragraph_separator_command(document, value)
             },
             CommandName::Delete => execute_delete_command(cx, document, selection),
+            CommandName::FontSize => execute_fontsize_command(cx, document, selection, value),
             CommandName::StyleWithCss => execute_style_with_css_command(document, value),
             _ => false,
         }

--- a/components/script/dom/execcommand/commands/fontsize.rs
+++ b/components/script/dom/execcommand/commands/fontsize.rs
@@ -1,0 +1,168 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+use html5ever::local_name;
+use script_bindings::inheritance::Castable;
+use style::attr::parse_integer;
+
+use crate::dom::ShadowIncluding;
+use crate::dom::bindings::codegen::Bindings::DocumentBinding::DocumentMethods;
+use crate::dom::bindings::root::DomRoot;
+use crate::dom::bindings::str::DOMString;
+use crate::dom::document::Document;
+use crate::dom::element::Element;
+use crate::dom::execcommand::basecommand::CommandName;
+use crate::dom::execcommand::contenteditable::{
+    NodeExecCommandSupport, SelectionExecCommandSupport,
+};
+use crate::dom::html::htmlfontelement::HTMLFontElement;
+use crate::dom::node::Node;
+use crate::dom::selection::Selection;
+use crate::script_runtime::CanGc;
+
+impl HTMLFontElement {
+    fn font_size_if_size_matches(&self, should_match_size: i32) -> Option<i32> {
+        if should_match_size !=
+            self.upcast::<Element>()
+                .get_int_attribute(&local_name!("size"), 0)
+        {
+            return None;
+        }
+        self.upcast::<Node>()
+            .style()
+            .map(|style| style.clone_font().font_size.computed_size().px() as i32)
+    }
+}
+
+/// <https://w3c.github.io/editing/docs/execCommand/#legacy-font-size-for>
+pub(crate) fn legacy_font_size_for(pixel_size: i32, document: &Document) -> DOMString {
+    let font_elements: Vec<DomRoot<HTMLFontElement>> = document
+        .upcast::<Node>()
+        .traverse_preorder(ShadowIncluding::No)
+        .filter_map(DomRoot::downcast::<HTMLFontElement>)
+        .collect();
+    // Step 1. Let returned size be 1.
+    let mut returned_size = 1;
+    // Step 2. While returned size is less than 7:
+    while returned_size < 7 {
+        // Step 2.1. Let lower bound be the resolved value of "font-size" in pixels
+        // of a font element whose size attribute is set to returned size.
+        let lower_bound = font_elements
+            .iter()
+            .find_map(|font_element| font_element.font_size_if_size_matches(returned_size))
+            .unwrap_or_default();
+        // Step 2.2. Let upper bound be the resolved value of "font-size" in pixels
+        // of a font element whose size attribute is set to one plus returned size.
+        let upper_bound = font_elements
+            .iter()
+            .find_map(|font_element| font_element.font_size_if_size_matches(returned_size + 1))
+            .unwrap_or_default();
+        // Step 2.3. Let average be the average of upper bound and lower bound.
+        let average = (lower_bound + upper_bound) / 2;
+        // Step 2.4. If pixel size is less than average,
+        // return the one-code unit string consisting of the digit returned size.
+        //
+        // We return once at the end of this method
+        if pixel_size < average {
+            break;
+        }
+        // Step 2.5. Add one to returned size.
+        returned_size += 1;
+    }
+    // Step 3. Return "7".
+    returned_size.to_string().into()
+}
+
+enum ParsingMode {
+    RelativePlus,
+    RelativeMinus,
+    Absolute,
+}
+
+/// <https://w3c.github.io/editing/docs/execCommand/#the-fontsize-command>
+pub(crate) fn execute_fontsize_command(
+    cx: &mut js::context::JSContext,
+    document: &Document,
+    selection: &Selection,
+    value: DOMString,
+) -> bool {
+    // Step 1. Strip leading and trailing whitespace from value.
+    let value = {
+        let mut value = value;
+        value.strip_leading_and_trailing_ascii_whitespace();
+        value
+    };
+    // Step 2. If value is not a valid floating point number,
+    // and would not be a valid floating point number if a single leading "+" character were stripped, return false.
+    //
+    // The second part is checked in conjunction with step 3 for optimization
+    if !value.is_valid_floating_point_number_string() {
+        return false;
+    }
+    // Step 3. If the first character of value is "+",
+    // delete the character and let mode be "relative-plus".
+    let (value, mode) = if value.starts_with('+') {
+        let stripped_plus = &value.str()[1..];
+        // FIXME: This is not optimal, but not sure how to both delete the first character and check here
+        if !DOMString::from(stripped_plus).is_valid_floating_point_number_string() {
+            return false;
+        }
+        (stripped_plus.to_owned(), ParsingMode::RelativePlus)
+    } else if value.starts_with('-') {
+        // Step 4. Otherwise, if the first character of value is "-",
+        // delete the character and let mode be "relative-minus".
+        (value.str()[1..].to_owned(), ParsingMode::RelativeMinus)
+    } else {
+        // Step 5. Otherwise, let mode be "absolute".
+        (value.into(), ParsingMode::Absolute)
+    };
+    // Step 6. Apply the rules for parsing non-negative integers to value, and let number be the result.
+    let number = parse_integer(value.chars()).expect("Already validated floating number before");
+    let number = match mode {
+        // Step 7. If mode is "relative-plus", add three to number.
+        ParsingMode::RelativePlus => number + 3,
+        // Step 8. If mode is "relative-minus", negate number, then add three to it.
+        ParsingMode::RelativeMinus => (-number) + 3,
+        ParsingMode::Absolute => number,
+    };
+    // Step 9. If number is less than one, let number equal 1.
+    // Step 10. If number is greater than seven, let number equal 7.
+    let number = number.clamp(1, 7);
+    // Step 11. Set value to the string here corresponding to number:
+    let value = match number {
+        1 => "x-small",
+        2 => "small",
+        3 => "medium",
+        4 => "large",
+        5 => "x-large",
+        6 => "xx-large",
+        7 => "xxx-large",
+        _ => unreachable!("Must be bounded by 1 and 7"),
+    };
+    // Step 12. Set the selection's value to value.
+    selection.set_the_selection_value(cx, Some(value.into()), CommandName::FontSize, document);
+    // Step 13. Return true.
+    true
+}
+
+/// <https://w3c.github.io/editing/docs/execCommand/#the-fontsize-command>
+pub(crate) fn value_for_fontsize_command(
+    cx: &mut js::context::JSContext,
+    document: &Document,
+) -> Option<DOMString> {
+    // Step 1. If the active range is null, return the empty string.
+    let selection = document.GetSelection(CanGc::from_cx(cx))?;
+    let active_range = selection.active_range()?;
+    // Step 2. Let pixel size be the effective command value of the first formattable
+    // node that is effectively contained in the active range, or if there is no such node,
+    // the effective command value of the active range's start node,
+    // in either case interpreted as a number of pixels.
+    let command_value = active_range
+        .first_formattable_contained_node()
+        .unwrap_or_else(|| active_range.start_container())
+        .effective_command_value(&CommandName::FontSize)?;
+    let pixel_size = command_value.parse::<i32>().ok()?;
+    // Step 3. Return the legacy font size for pixel size.
+    Some(legacy_font_size_for(pixel_size, document))
+}

--- a/components/script/dom/execcommand/commands/mod.rs
+++ b/components/script/dom/execcommand/commands/mod.rs
@@ -4,4 +4,5 @@
 
 pub(crate) mod defaultparagraphseparator;
 pub(crate) mod delete;
+pub(crate) mod fontsize;
 pub(crate) mod stylewithcss;

--- a/components/script/dom/execcommand/contenteditable.rs
+++ b/components/script/dom/execcommand/contenteditable.rs
@@ -18,7 +18,9 @@ use crate::dom::bindings::codegen::Bindings::DocumentBinding::{
 };
 use crate::dom::bindings::codegen::Bindings::HTMLElementBinding::HTMLElementMethods;
 use crate::dom::bindings::codegen::Bindings::NodeBinding::NodeMethods;
+use crate::dom::bindings::codegen::Bindings::RangeBinding::RangeMethods;
 use crate::dom::bindings::codegen::Bindings::SelectionBinding::SelectionMethods;
+use crate::dom::bindings::codegen::Bindings::TextBinding::TextMethods;
 use crate::dom::bindings::codegen::UnionTypes::StringOrElementCreationOptions;
 use crate::dom::bindings::inheritance::{ElementTypeId, HTMLElementTypeId, NodeTypeId};
 use crate::dom::bindings::root::{DomRoot, DomSlice};
@@ -26,7 +28,7 @@ use crate::dom::bindings::str::DOMString;
 use crate::dom::characterdata::CharacterData;
 use crate::dom::document::Document;
 use crate::dom::element::Element;
-use crate::dom::execcommand::basecommand::CommandName;
+use crate::dom::execcommand::basecommand::{CommandName, CssPropertyName};
 use crate::dom::html::htmlanchorelement::HTMLAnchorElement;
 use crate::dom::html::htmlbrelement::HTMLBRElement;
 use crate::dom::html::htmlelement::HTMLElement;
@@ -199,21 +201,130 @@ impl HTMLBRElement {
 }
 
 impl Document {
-    fn create_br_element(&self, cx: &mut js::context::JSContext) -> DomRoot<Element> {
+    pub(crate) fn create_element(
+        &self,
+        cx: &mut js::context::JSContext,
+        name: &str,
+    ) -> DomRoot<Element> {
         let element_options =
             StringOrElementCreationOptions::ElementCreationOptions(ElementCreationOptions {
                 is: None,
             });
-        match self.CreateElement(cx, "br".into(), element_options) {
-            Err(_) => unreachable!("Must always be able to create br"),
-            Ok(br) => br,
-        }
+        self.CreateElement(cx, name.into(), element_options)
+            .expect("Must always be able to create element")
     }
 }
 
 impl HTMLElement {
     fn local_name(&self) -> &str {
         self.upcast::<Element>().local_name()
+    }
+}
+
+impl Element {
+    /// <https://w3c.github.io/editing/docs/execCommand/#clear-the-value>
+    fn clear_the_value(&self) {
+        // Step 1. Let command be the current command.
+        // TODO
+        // Step 2. If element is not editable, return the empty list.
+        // TODO
+        // Step 3. If element's specified command value for command is null,
+        // return the empty list.
+        // TODO
+        // Step 4. If element is a simple modifiable element:
+        // TODO
+        // Step 5. If command is "strikethrough", and element has a style attribute
+        // that sets "text-decoration" to some value containing "line-through",
+        // delete "line-through" from the value.
+        // TODO
+        // Step 6. If command is "underline", and element has a style attribute that
+        // sets "text-decoration" to some value containing "underline", delete "underline" from the value.
+        // TODO
+        // Step 7. If the relevant CSS property for command is not null,
+        // unset that property of element.
+        // TODO
+        // Step 8. If element is a font element:
+        // TODO
+        // Step 9. If element is an a element and command is "createLink" or "unlink",
+        // unset the href property of element.
+        // TODO
+        // Step 10. If element's specified command value for command is null,
+        // return the empty list.
+        // TODO
+        // Step 11. Set the tag name of element to "span",
+        // and return the one-node list consisting of the result.
+        // TODO
+    }
+
+    /// <https://w3c.github.io/editing/docs/execCommand/#specified-command-value>
+    pub(crate) fn specified_command_value(&self, command: &CommandName) -> Option<DOMString> {
+        match command {
+            // Step 1. If command is "backColor" or "hiliteColor" and the Element's display property does not have resolved value "inline", return null.
+            CommandName::BackColor | CommandName::HiliteColor => {
+                // TODO
+            },
+            // Step 2. If command is "createLink" or "unlink":
+            CommandName::CreateLink | CommandName::Unlink => {
+                // TODO
+            },
+            // Step 3. If command is "subscript" or "superscript":
+            CommandName::Subscript | CommandName::Superscript => {
+                // TODO
+            },
+            CommandName::Strikethrough => {
+                // Step 4. If command is "strikethrough", and element has a style attribute set, and that attribute sets "text-decoration":
+                // TODO
+                // Step 5. If command is "strikethrough" and element is an s or strike element, return "line-through".
+                // TODO
+            },
+            CommandName::Underline => {
+                // Step 6. If command is "underline", and element has a style attribute set, and that attribute sets "text-decoration":
+                // TODO
+                // Step 7. If command is "underline" and element is a u element, return "underline".
+                // TODO
+            },
+            _ => {},
+        };
+        // Step 8. Let property be the relevant CSS property for command.
+        // Step 9. If property is null, return null.
+        let property = command.relevant_css_property()?;
+        // Step 10. If element has a style attribute set, and that attribute has the effect of setting property,
+        // return the value that it sets property to.
+        if let Some(value) = self
+            .style_attribute()
+            .borrow()
+            .as_ref()
+            .and_then(|declarations| {
+                let document = self.owner_document();
+                let shared_lock = document.style_shared_lock();
+                let read_lock = shared_lock.read();
+                let declarations = declarations.read_with(&read_lock);
+                property.value_set_for_style(declarations)
+            })
+        {
+            return Some(value);
+        }
+        // Step 11. If element is a font element that has an attribute whose effect is to create a presentational hint for property,
+        // return the value that the hint sets property to. (For a size of 7, this will be the non-CSS value "xxx-large".)
+        // TODO
+
+        // Step 12. If element is in the following list, and property is equal to the CSS property name listed for it,
+        // return the string listed for it.
+        let element_name = self.local_name();
+        match property {
+            CssPropertyName::FontWeight
+                if element_name == &local_name!("b") || element_name == &local_name!("strong") =>
+            {
+                Some("bold".into())
+            },
+            CssPropertyName::FontStyle
+                if element_name == &local_name!("i") || element_name == &local_name!("em") =>
+            {
+                Some("italic".into())
+            },
+            // Step 13. Return null.
+            _ => None,
+        }
     }
 }
 
@@ -527,7 +638,7 @@ pub(crate) fn split_the_parent<'a>(cx: &mut js::context::JSContext, node_list: &
         if precedes_line_break {
             if let Some(last) = node_list.last() {
                 if !last.precedes_a_line_break() {
-                    let br = context_object.create_br_element(cx);
+                    let br = context_object.create_element(cx, "br");
                     if last
                         .GetParentNode()
                         .expect("Must always have a parent")
@@ -595,7 +706,7 @@ pub(crate) fn split_the_parent<'a>(cx: &mut js::context::JSContext, node_list: &
     if follows_line_break {
         if let Some(first) = node_list.first() {
             if !first.follows_a_line_break() {
-                let br = context_object.create_br_element(cx);
+                let br = context_object.create_element(cx, "br");
                 if first
                     .GetParentNode()
                     .expect("Must always have a parent")
@@ -632,7 +743,7 @@ pub(crate) fn split_the_parent<'a>(cx: &mut js::context::JSContext, node_list: &
         if precedes_line_break {
             if let Some(last) = node_list.last() {
                 if !last.precedes_a_line_break() {
-                    let br = context_object.create_br_element(cx);
+                    let br = context_object.create_element(cx, "br");
                     if last
                         .GetParentNode()
                         .expect("Must always have a parent")
@@ -659,9 +770,434 @@ pub(crate) fn split_the_parent<'a>(cx: &mut js::context::JSContext, node_list: &
     }
 }
 
+/// <https://w3c.github.io/editing/docs/execCommand/#wrap>
+fn wrap_node_list<'a, SiblingCriteria, NewParentInstructions>(
+    cx: &mut js::context::JSContext,
+    node_list: &'a [&'a Node],
+    sibling_criteria: SiblingCriteria,
+    new_parent_instructions: NewParentInstructions,
+) -> Option<DomRoot<Node>>
+where
+    SiblingCriteria: Fn(&Node) -> bool,
+    NewParentInstructions: Fn() -> Option<DomRoot<Node>>,
+{
+    // Step 1. If every member of node list is invisible,
+    // and none is a br, return null and abort these steps.
+    // TODO
+    // Step 2. If node list's first member's parent is null, return null and abort these steps.
+    // TODO
+    // Step 3. If node list's last member is an inline node that's not a br,
+    // and node list's last member's nextSibling is a br, append that br to node list.
+    // TODO
+    // Step 4. While node list's first member's previousSibling is invisible, prepend it to node list.
+    // TODO
+    // Step 5. While node list's last member's nextSibling is invisible, append it to node list.
+    // TODO
+    // Step 6. If the previousSibling of the first member of node list is editable
+    // and running sibling criteria on it returns true,
+    // let new parent be the previousSibling of the first member of node list.
+    let new_parent = node_list
+        .first()
+        .and_then(|first| first.GetPreviousSibling())
+        .filter(|previous_of_first| {
+            previous_of_first.is_editable() && sibling_criteria(previous_of_first)
+        });
+    // Step 7. Otherwise, if the nextSibling of the last member of node list is editable
+    // and running sibling criteria on it returns true,
+    // let new parent be the nextSibling of the last member of node list.
+    let new_parent = new_parent.or_else(|| {
+        node_list
+            .last()
+            .and_then(|first| first.GetNextSibling())
+            .filter(|next_of_last| next_of_last.is_editable() && sibling_criteria(next_of_last))
+    });
+    // Step 8. Otherwise, run new parent instructions, and let new parent be the result.
+    // Step 9. If new parent is null, abort these steps and return null.
+    let new_parent = new_parent.or_else(new_parent_instructions)?;
+    // Step 11. Let original parent be the parent of the first member of node list.
+    let first_in_node_list = node_list
+        .first()
+        .expect("Must always have at least one node");
+    let original_parent = first_in_node_list
+        .GetParentNode()
+        .expect("First node must have a parent");
+    // Step 10. If new parent's parent is null:
+    if new_parent.GetParentNode().is_none() {
+        // Step 10.1. Insert new parent into the parent of the first member
+        // of node list immediately before the first member of node list.
+        if original_parent
+            .InsertBefore(cx, &new_parent, Some(first_in_node_list))
+            .is_err()
+        {
+            unreachable!("Must always be able to insert");
+        }
+        // Step 10.2. If any range has a boundary point with node equal
+        // to the parent of new parent and offset equal to the index of new parent,
+        // add one to that boundary point's offset.
+        // TODO
+    }
+    // Step 12. If new parent is before the first member of node list in tree order:
+    if new_parent.is_before(first_in_node_list) {
+        // Step 12.1. If new parent is not an inline node, but the last visible child of new parent
+        // and the first visible member of node list are both inline nodes,
+        // and the last child of new parent is not a br,
+        // call createElement("br") on the ownerDocument of new parent
+        // and append the result as the last child of new parent.
+        // TODO
+        // Step 12.2. For each node in node list, append node as the last child of new parent, preserving ranges.
+        for node in node_list {
+            if new_parent.AppendChild(cx, node).is_err() {
+                unreachable!("Must always be able to append");
+            }
+        }
+    } else {
+        // Step 13. Otherwise:
+        // Step 13.1. If new parent is not an inline node, but the first visible child of new parent
+        // and the last visible member of node list are both inline nodes,
+        // and the last member of node list is not a br,
+        // call createElement("br") on the ownerDocument of new parent
+        // and insert the result as the first child of new parent.
+        // TODO
+        // Step 13.2. For each node in node list, in reverse order,
+        // insert node as the first child of new parent, preserving ranges.
+        let mut before = new_parent.GetFirstChild();
+        for node in node_list.iter().rev() {
+            if let Err(err) = new_parent.InsertBefore(cx, node, before.as_deref()) {
+                unreachable!("Must always be able to append: {:?}", err);
+            }
+            before = Some(DomRoot::from_ref(node));
+        }
+    }
+    // Step 14. If original parent is editable and has no children, remove it from its parent.
+    if original_parent.is_editable() && original_parent.children_count() == 0 {
+        original_parent.remove_self(cx);
+    }
+    // Step 15. If new parent's nextSibling is editable and running sibling criteria on it returns true:
+    // TODO
+    // Step 16. Remove extraneous line breaks from new parent.
+    new_parent.remove_extraneous_line_breaks_from(cx);
+    // Step 17. Return new parent.
+    Some(new_parent)
+}
+
 impl Node {
     fn resolved_display_value(&self) -> Option<DisplayOutside> {
         self.style().map(|style| style.get_box().display.outside())
+    }
+
+    /// <https://w3c.github.io/editing/docs/execCommand/#push-down-values>
+    fn push_down_values(
+        &self,
+        cx: &mut js::context::JSContext,
+        command: &CommandName,
+        new_value: Option<DOMString>,
+    ) {
+        // Step 1. Let command be the current command.
+        //
+        // Passed in as argument
+
+        // Step 4. Let current ancestor be node's parent.
+        let mut current_ancestor = self.GetParentElement();
+        // Step 2. If node's parent is not an Element, abort this algorithm.
+        if current_ancestor.is_none() {
+            return;
+        };
+        // Step 3. If the effective command value of command is loosely equivalent to new value on node,
+        // abort this algorithm.
+        if command.are_loosely_equivalent_values(
+            self.effective_command_value(command).as_ref(),
+            new_value.as_ref(),
+        ) {
+            return;
+        }
+        // Step 5. Let ancestor list be a list of nodes, initially empty.
+        rooted_vec!(let mut ancestor_list);
+        // Step 6. While current ancestor is an editable Element and
+        // the effective command value of command is not loosely equivalent to new value on it,
+        // append current ancestor to ancestor list, then set current ancestor to its parent.
+        while let Some(ancestor) = current_ancestor {
+            let ancestor_node = ancestor.upcast::<Node>();
+            if ancestor_node.is_editable() &&
+                !command.are_loosely_equivalent_values(
+                    ancestor_node.effective_command_value(command).as_ref(),
+                    new_value.as_ref(),
+                )
+            {
+                ancestor_list.push(ancestor.clone());
+                current_ancestor = ancestor_node.GetParentElement();
+                continue;
+            }
+            break;
+        }
+        let Some(last_ancestor) = ancestor_list.last() else {
+            // Step 7. If ancestor list is empty, abort this algorithm.
+            return;
+        };
+        // Step 8. Let propagated value be the specified command value of command on the last member of ancestor list.
+        let mut propagated_value = last_ancestor.specified_command_value(command);
+        // Step 9. If propagated value is null and is not equal to new value, abort this algorithm.
+        if propagated_value.is_none() && new_value.is_some() {
+            return;
+        }
+        // Step 10. If the effective command value of command is not loosely equivalent to new value on the parent
+        // of the last member of ancestor list, and new value is not null, abort this algorithm.
+        if new_value.is_some() &&
+            !last_ancestor
+                .upcast::<Node>()
+                .GetParentNode()
+                .is_some_and(|last_ancestor| {
+                    command.are_loosely_equivalent_values(
+                        last_ancestor.effective_command_value(command).as_ref(),
+                        new_value.as_ref(),
+                    )
+                })
+        {
+            return;
+        }
+        // Step 11. While ancestor list is not empty:
+        let mut ancestor_list_iter = ancestor_list.iter().rev().peekable();
+        while let Some(current_ancestor) = ancestor_list_iter.next() {
+            let current_ancestor_node = current_ancestor.upcast::<Node>();
+            // Step 11.1. Let current ancestor be the last member of ancestor list.
+            // Step 11.2. Remove the last member from ancestor list.
+            //
+            // Both of these steps done by iterating and reversing the iterator
+
+            // Step 11.3. If the specified command value of current ancestor for command is not null, set propagated value to that value.
+            let command_value = current_ancestor.specified_command_value(command);
+            let has_command_value = command_value.is_some();
+            propagated_value = command_value.or(propagated_value);
+            // Step 11.4. Let children be the children of current ancestor.
+            let children = current_ancestor_node.children();
+            // Step 11.5. If the specified command value of current ancestor for command is not null, clear the value of current ancestor.
+            if has_command_value {
+                current_ancestor.clear_the_value();
+            }
+            // Step 11.6. For every child in children:
+            for child in children {
+                // Step 11.6.1. If child is node, continue with the next child.
+                if *child == *self {
+                    continue;
+                }
+                // Step 11.6.2. If child is an Element whose specified command value for command is neither null
+                // nor equivalent to propagated value, continue with the next child.
+                // TODO
+
+                // Step 11.6.3. If child is the last member of ancestor list, continue with the next child.
+                //
+                // Since we had to remove the last member in step 11.2, if we now peek at the next possible
+                // value, we essentially have the "last member after removal"
+                if ancestor_list_iter
+                    .peek()
+                    .is_some_and(|ancestor| *ancestor.upcast::<Node>() == *child)
+                {
+                    continue;
+                }
+                // step 11.6.4. Force the value of child, with command as in this algorithm and new value equal to propagated value.
+                child.force_the_value(cx, command, propagated_value.as_ref());
+            }
+        }
+    }
+
+    /// <https://w3c.github.io/editing/docs/execCommand/#force-the-value>
+    pub(crate) fn force_the_value(
+        &self,
+        cx: &mut js::context::JSContext,
+        command: &CommandName,
+        new_value: Option<&DOMString>,
+    ) {
+        // Step 1. Let command be the current command.
+        //
+        // That's command
+
+        // Step 2. If node's parent is null, abort this algorithm.
+        let Some(parent_node) = self.GetParentNode() else {
+            return;
+        };
+        // Step 3. If new value is null, abort this algorithm.
+        let Some(new_value) = new_value else {
+            return;
+        };
+        // Step 4. If node is an allowed child of "span":
+        if is_allowed_child(
+            NodeOrString::String("span".to_owned()),
+            NodeOrString::Node(DomRoot::from_ref(self)),
+        ) {
+            // Step 4.1. Reorder modifiable descendants of node's previousSibling.
+            // TODO
+            // Step 4.2. Reorder modifiable descendants of node's nextSibling.
+            // TODO
+            // Step 4.3. Wrap the one-node list consisting of node,
+            // with sibling criteria returning true for a simple modifiable element whose
+            // specified command value is equivalent to new value and whose effective command value
+            // is loosely equivalent to new value and false otherwise,
+            // and with new parent instructions returning null.
+            wrap_node_list(
+                cx,
+                &[self],
+                |sibling| {
+                    // TODO: Check for simple modifiable
+                    sibling
+                        .downcast::<Element>()
+                        .is_some_and(|sibling_element| {
+                            command.are_equivalent_values(
+                                sibling_element.specified_command_value(command).as_ref(),
+                                Some(new_value),
+                            ) && command.are_loosely_equivalent_values(
+                                sibling.effective_command_value(command).as_ref(),
+                                Some(new_value),
+                            )
+                        })
+                },
+                || None,
+            );
+        }
+        // Step 5. If node is invisible, abort this algorithm.
+        if self.is_invisible() {
+            return;
+        }
+        // Step 6. If the effective command value of command is loosely equivalent to new value on node, abort this algorithm.
+        if command.are_loosely_equivalent_values(
+            self.effective_command_value(command).as_ref(),
+            Some(new_value),
+        ) {
+            return;
+        }
+        // Step 7. If node is not an allowed child of "span":
+        // TODO
+        // Step 8. If the effective command value of command is loosely equivalent to new value on node, abort this algorithm.
+        if command.are_loosely_equivalent_values(
+            self.effective_command_value(command).as_ref(),
+            Some(new_value),
+        ) {
+            return;
+        }
+        // Step 9. Let new parent be null.
+        let mut new_parent = None;
+        let document = self.owner_document();
+        let css_styling_flag = document.css_styling_flag();
+        // Step 10. If the CSS styling flag is false:
+        // TODO
+        match command {
+            // Step 11. If command is "createLink" or "unlink":
+            // TODO
+            // Step 12. If command is "fontSize"; and new value is one of
+            // "x-small", "small", "medium", "large", "x-large", "xx-large", or "xxx-large";
+            // and either the CSS styling flag is false, or new value is "xxx-large":
+            // let new parent be the result of calling createElement("font") on the ownerDocument of node,
+            // then set the size attribute of new parent to the number from the following table based on new value:
+            CommandName::FontSize => {
+                if !css_styling_flag || new_value == "xxx-large" {
+                    let size = match &*new_value.str() {
+                        "x-small" => 1,
+                        "small" => 2,
+                        "medium" => 3,
+                        "large" => 4,
+                        "x-large" => 5,
+                        "xx-large" => 6,
+                        "xxx-large" => 7,
+                        _ => 0,
+                    };
+
+                    if size > 0 {
+                        let new_font_element = document.create_element(cx, "font");
+                        new_font_element.set_int_attribute(
+                            &local_name!("size"),
+                            size,
+                            CanGc::from_cx(cx),
+                        );
+                        new_parent = Some(new_font_element);
+                    }
+                }
+            },
+            CommandName::Subscript | CommandName::Superscript => {
+                // Step 13. If command is "subscript" or "superscript" and new value is "subscript",
+                // let new parent be the result of calling createElement("sub") on the ownerDocument of node.
+                if new_value == "subscript" {
+                    new_parent = Some(document.create_element(cx, "sub"));
+                }
+                // Step 14. If command is "subscript" or "superscript" and new value is "superscript",
+                // let new parent be the result of calling createElement("sup") on the ownerDocument of node.
+                if new_value == "superscript" {
+                    new_parent = Some(document.create_element(cx, "sup"));
+                }
+            },
+            _ => {},
+        }
+        // Step 15. If new parent is null, let new parent be the result of calling createElement("span") on the ownerDocument of node.
+        let new_parent = new_parent.unwrap_or_else(|| document.create_element(cx, "span"));
+        // Step 16. Insert new parent in node's parent before node.
+        if parent_node
+            .InsertBefore(cx, new_parent.upcast(), Some(self))
+            .is_err()
+        {
+            unreachable!("Must always be able to insert");
+        }
+        // Step 17. If the effective command value of command for new parent is not loosely equivalent to new value,
+        // and the relevant CSS property for command is not null,
+        // set that CSS property of new parent to new value (if the new value would be valid).
+        if !command.are_loosely_equivalent_values(
+            self.effective_command_value(command).as_ref(),
+            Some(new_value),
+        ) {
+            if let Some(css_property) = command.relevant_css_property() {
+                css_property.set_for_element(
+                    cx,
+                    new_parent
+                        .downcast::<HTMLElement>()
+                        .expect("Must always create a HTML element"),
+                    new_value.clone(),
+                );
+            }
+        }
+        // Step 18. If command is "strikethrough", and new value is "line-through",
+        // and the effective command value of "strikethrough" for new parent is not "line-through",
+        // set the "text-decoration" property of new parent to "line-through".
+        // TODO
+        // Step 19. If command is "underline", and new value is "underline",
+        // and the effective command value of "underline" for new parent is not "underline",
+        // set the "text-decoration" property of new parent to "underline".
+        // TODO
+        // Step 20. Append node to new parent as its last child, preserving ranges.
+        let new_parent = new_parent.upcast::<Node>();
+        if new_parent.AppendChild(cx, self).is_err() {
+            unreachable!("Must always be able to append");
+        }
+        // Step 21. If node is an Element and the effective command value of command for node is not loosely equivalent to new value:
+        if self.is::<Element>() &&
+            !command.are_loosely_equivalent_values(
+                self.effective_command_value(command).as_ref(),
+                Some(new_value),
+            )
+        {
+            // Step 21.1. Insert node into the parent of new parent before new parent, preserving ranges.
+            let parent_of_new_parent = new_parent.GetParentNode().expect("Must have a parent");
+            if parent_of_new_parent
+                .InsertBefore(cx, self, Some(new_parent))
+                .is_err()
+            {
+                unreachable!("Must always be able to insert");
+            }
+            // Step 21.2. Remove new parent from its parent.
+            new_parent.remove_self(cx);
+            // Step 21.3. Let children be all children of node,
+            // omitting any that are Elements whose specified command value for command is neither null nor equivalent to new value.
+            for child in self.children() {
+                if child.downcast::<Element>().is_some_and(|child_element| {
+                    let specified_command_value = child_element.specified_command_value(command);
+                    specified_command_value.is_some() &&
+                        !command.are_equivalent_values(
+                            specified_command_value.as_ref(),
+                            Some(new_value),
+                        )
+                }) {
+                    continue;
+                }
+                // Step 21.4. Force the value of each node in children,
+                // with command and new value as in this invocation of the algorithm.
+                child.force_the_value(cx, command, Some(new_value));
+            }
+        }
     }
 }
 
@@ -687,8 +1223,9 @@ pub(crate) trait NodeExecCommandSupport {
     fn canonicalize_whitespace(&self, offset: u32, fix_collapsed_space: bool);
     fn remove_extraneous_line_breaks_before(&self, cx: &mut js::context::JSContext);
     fn remove_extraneous_line_breaks_at_the_end_of(&self, cx: &mut js::context::JSContext);
+    fn remove_extraneous_line_breaks_from(&self, cx: &mut js::context::JSContext);
     fn remove_preserving_its_descendants(&self, cx: &mut js::context::JSContext);
-    fn effective_command_value(&self, command_name: CommandName) -> Option<DOMString>;
+    fn effective_command_value(&self, command: &CommandName) -> Option<DOMString>;
 }
 
 impl NodeExecCommandSupport for Node {
@@ -1293,6 +1830,14 @@ impl NodeExecCommandSupport for Node {
         }
     }
 
+    /// <https://w3c.github.io/editing/docs/execCommand/#remove-extraneous-line-breaks-from>
+    fn remove_extraneous_line_breaks_from(&self, cx: &mut js::context::JSContext) {
+        // > To remove extraneous line breaks from a node, first remove extraneous line breaks before it,
+        // > then remove extraneous line breaks at the end of it.
+        self.remove_extraneous_line_breaks_before(cx);
+        self.remove_extraneous_line_breaks_at_the_end_of(cx);
+    }
+
     /// <https://w3c.github.io/editing/docs/execCommand/#preserving-its-descendants>
     fn remove_preserving_its_descendants(&self, cx: &mut js::context::JSContext) {
         // > To remove a node node while preserving its descendants,
@@ -1308,17 +1853,15 @@ impl NodeExecCommandSupport for Node {
     }
 
     /// <https://w3c.github.io/editing/docs/execCommand/#effective-command-value>
-    fn effective_command_value(&self, command_name: CommandName) -> Option<DOMString> {
+    fn effective_command_value(&self, command: &CommandName) -> Option<DOMString> {
         // Step 1. If neither node nor its parent is an Element, return null.
         // Step 2. If node is not an Element, return the effective command value of its parent for command.
-        if !self.is::<Element>() {
-            return self.GetParentElement().and_then(|parent| {
-                parent
-                    .upcast::<Node>()
-                    .effective_command_value(command_name)
-            });
-        }
-        match command_name {
+        let Some(element) = self.downcast::<Element>() else {
+            return self
+                .GetParentElement()
+                .and_then(|parent| parent.upcast::<Node>().effective_command_value(command));
+        };
+        match command {
             // Step 3. If command is "createLink" or "unlink":
             CommandName::CreateLink | CommandName::Unlink => {
                 // Step 3.1. While node is not null, and is not an a element that has an href attribute, set node to its parent.
@@ -1360,14 +1903,12 @@ impl NodeExecCommandSupport for Node {
                     if !node.is_inline_node() {
                         break;
                     }
-                    if let Some(element) = node.downcast::<Element>() {
-                        // Step 5.2.1. If node is a sub, set affected by subscript to true.
-                        if *element.local_name() == local_name!("sub") {
-                            affected_by_subscript = true;
-                        } else if *element.local_name() == local_name!("sup") {
-                            // Step 5.2.2. Otherwise, if node is a sup, set affected by superscript to true.
-                            affected_by_superscript = true;
-                        }
+                    // Step 5.2.1. If node is a sub, set affected by subscript to true.
+                    if *element.local_name() == local_name!("sub") {
+                        affected_by_subscript = true;
+                    } else if *element.local_name() == local_name!("sup") {
+                        // Step 5.2.2. Otherwise, if node is a sup, set affected by superscript to true.
+                        affected_by_superscript = true;
                     }
                     // Step 5.2.3. Set node to its parent.
                     current_node = node.GetParentNode();
@@ -1395,8 +1936,7 @@ impl NodeExecCommandSupport for Node {
             // TODO
             CommandName::Underline => None,
             // Step 8. Return the resolved value for node of the relevant CSS property for command.
-            // TODO
-            _ => None,
+            _ => command.resolved_value_for_node(element),
         }
     }
 }
@@ -1629,15 +2169,24 @@ impl From<bool> for BoolOrOptionalString {
 }
 
 struct RecordedStateOfNode {
-    name: CommandName,
+    command: CommandName,
     value: BoolOrOptionalString,
+}
+
+impl RecordedStateOfNode {
+    fn for_command_node(command: CommandName, node: &Node) -> Self {
+        let value = node.effective_command_value(&command).into();
+        Self { command, value }
+    }
 }
 
 impl Range {
     /// <https://w3c.github.io/editing/docs/execCommand/#effectively-contained>
     fn is_effectively_contained_node(&self, node: &Node) -> bool {
-        assert!(!self.collapsed());
         // > A node node is effectively contained in a range range if range is not collapsed,
+        if self.collapsed() {
+            return false;
+        }
         // > and at least one of the following holds:
         // > node is range's start node, it is a Text node, and its length is different from range's start offset.
         let start_container = self.start_container();
@@ -1650,9 +2199,9 @@ impl Range {
             return true;
         }
         // > node is contained in range.
-        //
-        // Already checked by caller
-
+        if self.contains(node) {
+            return true;
+        }
         // > node has at least one child; and all its children are effectively contained in range;
         node.children_count() > 0 && node.children().all(|child| self.is_effectively_contained_node(&child))
         // > and either range's start node is not a descendant of node or is not a Text node or range's start offset is zero;
@@ -1661,34 +2210,29 @@ impl Range {
         && (!node.is_ancestor_of(&end_container) || !end_container.is::<Text>() || self.end_offset() == end_container.len())
     }
 
-    fn first_formattable_contained_node(&self) -> Option<DomRoot<Node>> {
+    pub(crate) fn first_formattable_contained_node(&self) -> Option<DomRoot<Node>> {
         if self.collapsed() {
             return None;
         }
-        let Ok(contained_children) = self.contained_children() else {
-            unreachable!("Must always be able to obtain contained children");
-        };
-        contained_children
-            .first_partially_contained_child
-            .as_ref()
-            .filter(|child| child.is_formattable() && self.is_effectively_contained_node(child))
-            .or_else(|| {
-                // We don't call `is_effectively_contained_node` here, since nodes are considered
-                // effectively contained if they are in `contained_children`
-                contained_children
-                    .contained_children
-                    .iter()
-                    .find(|child| child.is_formattable())
-            })
-            .or_else(|| {
-                contained_children
-                    .last_partially_contained_child
-                    .as_ref()
-                    .filter(|child| {
-                        child.is_formattable() && self.is_effectively_contained_node(child)
-                    })
-            })
-            .cloned()
+
+        self.CommonAncestorContainer()
+            .traverse_preorder(ShadowIncluding::No)
+            .find(|child| child.is_formattable() && self.is_effectively_contained_node(child))
+    }
+
+    fn for_each_effectively_contained_child<Callback: FnMut(&Node)>(&self, mut callback: Callback) {
+        if self.collapsed() {
+            return;
+        }
+
+        for child in self
+            .CommonAncestorContainer()
+            .traverse_preorder(ShadowIncluding::No)
+        {
+            if self.is_effectively_contained_node(&child) {
+                callback(&child);
+            }
+        }
     }
 
     /// <https://w3c.github.io/editing/docs/execCommand/#record-current-states-and-values>
@@ -1706,10 +2250,7 @@ impl Range {
         // Step 8. Return overrides.
         vec![
             // Step 4. Add ("createLink", node's effective command value for "createLink") to overrides.
-            RecordedStateOfNode {
-                name: CommandName::CreateLink,
-                value: node.effective_command_value(CommandName::CreateLink).into(),
-            },
+            RecordedStateOfNode::for_command_node(CommandName::CreateLink, &node),
             // Step 5. For each command in the list
             // "bold", "italic", "strikethrough", "subscript", "superscript", "underline", in order:
             // if node's effective command value for command is one of its inline command activated values,
@@ -1721,10 +2262,7 @@ impl Range {
             // TODO
 
             // Step 7. Add ("fontSize", node's effective command value for "fontSize") to overrides.
-            RecordedStateOfNode {
-                name: CommandName::FontSize,
-                value: node.effective_command_value(CommandName::FontSize).into(),
-            },
+            RecordedStateOfNode::for_command_node(CommandName::FontSize, &node),
         ]
     }
 
@@ -1742,11 +2280,11 @@ impl Range {
                 // Step 3.1. If override is a boolean, set the state override for command to override.
                 match override_state.value {
                     BoolOrOptionalString::Bool(bool_) => {
-                        context_object.set_state_override(override_state.name, bool_)
+                        context_object.set_state_override(override_state.command, Some(bool_))
                     },
                     // Step 3.2. If override is a string, set the value override for command to override.
                     BoolOrOptionalString::OptionalString(optional_string) => {
-                        context_object.set_value_override(override_state.name, optional_string)
+                        context_object.set_value_override(override_state.command, optional_string)
                     },
                 }
             }
@@ -1813,6 +2351,13 @@ pub(crate) trait SelectionExecCommandSupport {
         block_merging: SelectionDeletionBlockMerging,
         strip_wrappers: SelectionDeletionStripWrappers,
         direction: SelectionDeleteDirection,
+    );
+    fn set_the_selection_value(
+        &self,
+        cx: &mut js::context::JSContext,
+        new_value: Option<DOMString>,
+        command: CommandName,
+        context_object: &Document,
     );
 }
 
@@ -2070,7 +2615,7 @@ impl SelectionExecCommandSupport for Selection {
                 .is_some_and(|block_node| block_node.children().all(|child| child.is_invisible())) &&
                 parent.is_editable_or_editing_host()
             {
-                let br = context_object.create_br_element(cx);
+                let br = context_object.create_element(cx, "br");
                 if parent.AppendChild(cx, br.upcast()).is_err() {
                     unreachable!("Must always be able to append");
                 }
@@ -2220,7 +2765,7 @@ impl SelectionExecCommandSupport for Selection {
                 {
                     if let Some(next_of_end_block) = end_block.GetNextSibling() {
                         if next_of_end_block.is_inline_node() {
-                            let br = context_object.create_br_element(cx);
+                            let br = context_object.create_element(cx, "br");
                             let parent = end_block
                                 .GetParentNode()
                                 .expect("Must always have a parent");
@@ -2448,7 +2993,7 @@ impl SelectionExecCommandSupport for Selection {
         // Step 39. If start block has no children, call createElement("br") on the context object and
         // append the result as the last child of start block.
         if start_block.children_count() == 0 {
-            let br = context_object.create_br_element(cx);
+            let br = context_object.create_element(cx, "br");
             if start_block.AppendChild(cx, br.upcast()).is_err() {
                 unreachable!("Must always be able to append");
             }
@@ -2459,5 +3004,94 @@ impl SelectionExecCommandSupport for Selection {
 
         // Step 41. Restore states and values from overrides.
         active_range.restore_states_and_values(context_object, overrides);
+    }
+
+    /// <https://w3c.github.io/editing/docs/execCommand/#set-the-selection%27s-value>
+    fn set_the_selection_value(
+        &self,
+        cx: &mut js::context::JSContext,
+        new_value: Option<DOMString>,
+        command: CommandName,
+        context_object: &Document,
+    ) {
+        let active_range = self
+            .active_range()
+            .expect("Must always have an active range");
+
+        // Step 1. Let command be the current command.
+        //
+        // Passed as argument
+
+        // Step 2. If there is no formattable node effectively contained in the active range:
+        if active_range.first_formattable_contained_node().is_none() {
+            // Step 2.1. If command has inline command activated values, set the state override to true if new value is among them and false if it's not.
+            // TODO
+
+            // Step 2.2. If command is "subscript", unset the state override for "superscript".
+            if command == CommandName::Subscript {
+                context_object.set_state_override(CommandName::Superscript, None);
+            }
+            // Step 2.3. If command is "superscript", unset the state override for "subscript".
+            if command == CommandName::Superscript {
+                context_object.set_state_override(CommandName::Subscript, None);
+            }
+            // Step 2.4. If new value is null, unset the value override (if any).
+            // Step 2.5. Otherwise, if command is "createLink" or it has a value specified, set the value override to new value.
+            context_object.set_value_override(command, new_value);
+            // Step 2.6. Abort these steps.
+            return;
+        }
+        // Step 3. If the active range's start node is an editable Text node,
+        // and its start offset is neither zero nor its start node's length,
+        // call splitText() on the active range's start node,
+        // with argument equal to the active range's start offset.
+        // Then set the active range's start node to the result, and its start offset to zero.
+        let start_node = active_range.start_container();
+        let start_offset = active_range.start_offset();
+        if start_node.is_editable() && start_offset != 0 && start_offset != start_node.len() {
+            if let Some(start_text) = start_node.downcast::<Text>() {
+                let Ok(start_text) = start_text.SplitText(cx, start_offset) else {
+                    unreachable!("Must always be able to split");
+                };
+                active_range.set_start(start_text.upcast(), 0);
+            }
+        }
+        // Step 4. If the active range's end node is an editable Text node,
+        // and its end offset is neither zero nor its end node's length,
+        // call splitText() on the active range's end node,
+        // with argument equal to the active range's end offset.
+        let end_node = active_range.end_container();
+        let end_offset = active_range.end_offset();
+        if end_node.is_editable() && end_offset != 0 && end_offset != end_node.len() {
+            if let Some(end_text) = end_node.downcast::<Text>() {
+                if end_text.SplitText(cx, end_offset).is_err() {
+                    unreachable!("Must always be able to split");
+                };
+            }
+        }
+        // Step 5. Let element list be all editable Elements effectively contained in the active range.
+        // Step 6. For each element in element list, clear the value of element.
+        active_range.for_each_effectively_contained_child(|child| {
+            if child.upcast::<Node>().is_editable() {
+                if let Some(element_child) = child.downcast::<Element>() {
+                    element_child.clear_the_value();
+                }
+            }
+        });
+        // Step 7. Let node list be all editable nodes effectively contained in the active range.
+        // Step 8. For each node in node list:
+        active_range.for_each_effectively_contained_child(|child| {
+            if child.is_editable() {
+                // Step 8.1. Push down values on node.
+                child.push_down_values(cx, &command, new_value.clone());
+                // Step 8.2. If node is an allowed child of "span", force the value of node.
+                if is_allowed_child(
+                    NodeOrString::String("span".to_owned()),
+                    NodeOrString::Node(DomRoot::from_ref(child)),
+                ) {
+                    child.force_the_value(cx, &command, new_value.as_ref());
+                }
+            }
+        });
     }
 }

--- a/components/script/dom/execcommand/execcommands.rs
+++ b/components/script/dom/execcommand/execcommands.rs
@@ -5,6 +5,7 @@
 use script_bindings::inheritance::Castable;
 
 use crate::dom::bindings::codegen::Bindings::DocumentBinding::DocumentMethods;
+use crate::dom::bindings::codegen::Bindings::HTMLElementBinding::HTMLElementMethods;
 use crate::dom::bindings::codegen::Bindings::RangeBinding::RangeMethods;
 use crate::dom::bindings::root::DomRoot;
 use crate::dom::bindings::str::DOMString;
@@ -12,6 +13,9 @@ use crate::dom::document::Document;
 use crate::dom::event::Event;
 use crate::dom::event::inputevent::InputEvent;
 use crate::dom::execcommand::basecommand::CommandName;
+use crate::dom::execcommand::commands::fontsize::legacy_font_size_for;
+use crate::dom::html::htmlelement::HTMLElement;
+use crate::dom::node::Node;
 use crate::dom::selection::Selection;
 use crate::script_runtime::CanGc;
 
@@ -61,6 +65,13 @@ fn mapped_value_of_command(command: CommandName) -> DOMString {
     .into()
 }
 
+impl Node {
+    fn is_in_plaintext_only_state(&self) -> bool {
+        self.downcast::<HTMLElement>()
+            .is_some_and(|el| el.ContentEditable().str() == "plaintext-only")
+    }
+}
+
 impl Document {
     /// <https://w3c.github.io/editing/docs/execCommand/#enabled>
     fn selection_if_command_is_enabled(
@@ -79,20 +90,25 @@ impl Document {
         // > The other commands defined here are enabled if the active range is not null,
         let range = selection.active_range()?;
         // > its start node is either editable or an editing host,
-        if !range.start_container().is_editable_or_editing_host() {
-            return None;
-        }
+        let start_container_editing_host = range.start_container().editing_host_of()?;
         // > the editing host of its start node is not an EditContext editing host,
         // TODO
         // > its end node is either editable or an editing host,
-        if !range.end_container().is_editable_or_editing_host() {
-            return None;
-        }
+        let end_container_editing_host = range.end_container().editing_host_of()?;
         // > the editing host of its end node is not an EditContext editing host,
         // TODO
         // > and there is some editing host that is an inclusive ancestor of both its start node and its end node.
         // TODO
-        Some(selection)
+
+        // Some commands are only enabled if the editing host is *not* in plaintext-only state.
+        if !command_name.is_enabled_in_plaintext_only_state() &&
+            (start_container_editing_host.is_in_plaintext_only_state() ||
+                end_container_editing_host.is_in_plaintext_only_state())
+        {
+            None
+        } else {
+            Some(selection)
+        }
     }
 
     /// <https://w3c.github.io/editing/docs/execCommand/#supported>
@@ -102,6 +118,7 @@ impl Document {
         Some(match &*command_id.str().to_lowercase() {
             "delete" => CommandName::Delete,
             "defaultparagraphseparator" => CommandName::DefaultParagraphSeparator,
+            "fontsize" => CommandName::FontSize,
             "stylewithcss" => CommandName::StyleWithCss,
             _ => return None,
         })
@@ -112,7 +129,11 @@ pub(crate) trait DocumentExecCommandSupport {
     fn is_command_supported(&self, command_id: DOMString) -> bool;
     fn is_command_indeterminate(&self, command_id: DOMString) -> bool;
     fn command_state_for_command(&self, command_id: DOMString) -> bool;
-    fn command_value_for_command(&self, command_id: DOMString) -> DOMString;
+    fn command_value_for_command(
+        &self,
+        cx: &mut js::context::JSContext,
+        command_id: DOMString,
+    ) -> DOMString;
     fn check_support_and_enabled(
         &self,
         cx: &mut js::context::JSContext,
@@ -155,24 +176,34 @@ impl DocumentExecCommandSupport for Document {
     }
 
     /// <https://w3c.github.io/editing/docs/execCommand/#querycommandvalue()>
-    fn command_value_for_command(&self, command_id: DOMString) -> DOMString {
+    fn command_value_for_command(
+        &self,
+        cx: &mut js::context::JSContext,
+        command_id: DOMString,
+    ) -> DOMString {
         // Step 1. If command is not supported or has no value, return the empty string.
         let Some(command) = self.command_if_command_is_supported(&command_id) else {
             return DOMString::new();
         };
-        let Some(value) = command.current_value(self) else {
+        let Some(value) = command.current_value(cx, self) else {
             return DOMString::new();
         };
-        // Step 2. If command is "fontSize" and its value override is set,
-        // convert the value override to an integer number of pixels and return the legacy font size for the result.
-        // TODO
-
         // Step 3. If the value override for command is set, return it.
-        if let Some(value_override) = self.value_override(&command) {
-            return value_override;
-        }
-        // Step 4. Return command's value.
-        value
+        self.value_override(&command)
+            .map(|value_override| {
+                // Step 2. If command is "fontSize" and its value override is set,
+                // convert the value override to an integer number of pixels and return the legacy font size for the result.
+                if command == CommandName::FontSize {
+                    value_override
+                        .parse()
+                        .map(|parsed| legacy_font_size_for(parsed, self))
+                        .unwrap_or(value_override)
+                } else {
+                    value_override
+                }
+            })
+            // Step 4. Return command's value.
+            .unwrap_or(value)
     }
 
     /// <https://w3c.github.io/editing/docs/execCommand/#querycommandenabled()>

--- a/components/script/dom/node/node.rs
+++ b/components/script/dom/node/node.rs
@@ -2925,41 +2925,58 @@ impl Node {
         match parent.type_id() {
             NodeTypeId::Document(_) | NodeTypeId::DocumentFragment(_) | NodeTypeId::Element(..) => {
             },
-            _ => return Err(Error::HierarchyRequest(None)),
+            _ => {
+                return Err(Error::HierarchyRequest(Some(
+                    "Parent is not a Document, DocumentFragment, or Element node".to_owned(),
+                )));
+            },
         }
 
         // Step 2. If node is a host-including inclusive ancestor of parent, then throw a "HierarchyRequestError" DOMException.
         if node.is_host_including_inclusive_ancestor(parent) {
-            return Err(Error::HierarchyRequest(None));
+            return Err(Error::HierarchyRequest(Some(
+                "Node is a host-including inclusive ancestor of parent".to_owned(),
+            )));
         }
 
         // Step 3. If child is non-null and its parent is not parent, then throw a "NotFoundError" DOMException.
         if let Some(child) = child {
             if !parent.is_parent_of(child) {
-                return Err(Error::NotFound(None));
+                return Err(Error::NotFound(Some(
+                    "Child is non-null and its parent is not parent".to_owned(),
+                )));
             }
         }
 
-        // Step 4. If node is not a DocumentFragment, DocumentType, Element, or CharacterData node, then throw a "HierarchyRequestError" DOMException.
         match node.type_id() {
             // Step 5. If either node is a Text node and parent is a document,
-            // or node is a doctype and parent is not a document, then throw a "HierarchyRequestError" DOMException.
+            // or node is a doctype and parent is not a document,
+            // then throw a "HierarchyRequestError" DOMException.
             NodeTypeId::CharacterData(CharacterDataTypeId::Text(_)) => {
                 if parent.is::<Document>() {
-                    return Err(Error::HierarchyRequest(None));
+                    return Err(Error::HierarchyRequest(Some(
+                        "Node is a Text node and parent is a document".to_owned(),
+                    )));
                 }
             },
             NodeTypeId::DocumentType => {
                 if !parent.is::<Document>() {
-                    return Err(Error::HierarchyRequest(None));
+                    return Err(Error::HierarchyRequest(Some(
+                        "Node is a doctype and parent is not a document".to_owned(),
+                    )));
                 }
             },
             NodeTypeId::DocumentFragment(_) |
             NodeTypeId::Element(_) |
             NodeTypeId::CharacterData(CharacterDataTypeId::ProcessingInstruction) |
             NodeTypeId::CharacterData(CharacterDataTypeId::Comment) => (),
+            // Step 4. If node is not a DocumentFragment, DocumentType, Element,
+            // or CharacterData node, then throw a "HierarchyRequestError" DOMException.
             NodeTypeId::Document(_) | NodeTypeId::Attr => {
-                return Err(Error::HierarchyRequest(None));
+                return Err(Error::HierarchyRequest(Some(
+                    "Node is not a DocumentFragment, DocumentType, Element, or CharacterData node"
+                        .to_owned(),
+                )));
             },
         }
 
@@ -2995,14 +3012,18 @@ impl Node {
                 NodeTypeId::Element(_) => {
                     // Step 6."Element". parent has an element child, child is a doctype, or child is non-null and a doctype is following child.
                     if parent.child_elements().next().is_some() {
-                        return Err(Error::HierarchyRequest(None));
+                        return Err(Error::HierarchyRequest(Some(
+                            "Parent has an element child".to_owned(),
+                        )));
                     }
                     if let Some(child) = child {
                         if child
                             .inclusively_following_siblings()
-                            .any(|child| child.is_doctype())
+                            .any(|following| following.is_doctype())
                         {
-                            return Err(Error::HierarchyRequest(None));
+                            return Err(Error::HierarchyRequest(Some(
+                                "Child is a doctype, or child is non-null and a doctype is following child".to_owned(),
+                            )));
                         }
                     }
                 },

--- a/components/script/dom/range.rs
+++ b/components/script/dom/range.rs
@@ -142,7 +142,7 @@ impl Range {
     }
 
     /// <https://dom.spec.whatwg.org/#contained>
-    fn contains(&self, node: &Node) -> bool {
+    pub(crate) fn contains(&self, node: &Node) -> bool {
         // > A node node is contained in a live range range if node’s root is range’s root,
         // > and (node, 0) is after range’s start, and (node, node’s length) is before range’s end.
         matches!(

--- a/components/script_bindings/codegen/Bindings.conf
+++ b/components/script_bindings/codegen/Bindings.conf
@@ -223,6 +223,7 @@ DOMInterfaces = {
         'ParseHTMLUnsafe',
         'Prepend',
         'QueryCommandEnabled',
+        'QueryCommandValue',
         'ReplaceChildren',
         'SetBody',
         'SetTitle',

--- a/components/script_bindings/domstring.rs
+++ b/components/script_bindings/domstring.rs
@@ -442,6 +442,7 @@ impl DOMString {
             .push_str(string_to_push);
     }
 
+    /// <https://infra.spec.whatwg.org/#strip-leading-and-trailing-ascii-whitespace>
     pub fn strip_leading_and_trailing_ascii_whitespace(&mut self) {
         if self.is_empty() {
             return;
@@ -463,7 +464,7 @@ impl DOMString {
         string.replace_range(0..first_non_whitespace, "");
     }
 
-    /// This is a dom spec
+    /// <https://html.spec.whatwg.org/multipage/#valid-floating-point-number>
     pub fn is_valid_floating_point_number_string(&self) -> bool {
         static RE: LazyLock<Regex> = LazyLock::new(|| {
             Regex::new(r"^-?(?:\d+\.\d+|\d+|\.\d+)(?:(e|E)(\+|\-)?\d+)?$").unwrap()

--- a/tests/wpt/meta/editing/event.html.ini
+++ b/tests/wpt/meta/editing/event.html.ini
@@ -44,9 +44,6 @@
   [Command fontSize, value "quasit": input event]
     expected: FAIL
 
-  [Command fontSize, value "6": input event]
-    expected: FAIL
-
   [Command fontSize, value "15px": input event]
     expected: FAIL
 

--- a/tests/wpt/meta/editing/other/exec-command-with-text-editor.tentative.html.ini
+++ b/tests/wpt/meta/editing/other/exec-command-with-text-editor.tentative.html.ini
@@ -98,9 +98,6 @@
   [In <input type="password">, execCommand("fontname", false, DummyFont), a[b\]c): The command should be supported]
     expected: FAIL
 
-  [In <input type="password">, execCommand("fontsize", false, 5), a[b\]c): The command should be supported]
-    expected: FAIL
-
   [In <input type="password">, execCommand("inserthorizontalrule", false, null), a[b\]c): The command should be supported]
     expected: FAIL
 
@@ -254,9 +251,6 @@
   [In <input type="password"> in contenteditable, execCommand("fontname", false, DummyFont), a[b\]c): The command should be supported]
     expected: FAIL
 
-  [In <input type="password"> in contenteditable, execCommand("fontsize", false, 5), a[b\]c): The command should be supported]
-    expected: FAIL
-
   [In <input type="password"> in contenteditable, execCommand("inserthorizontalrule", false, null), a[b\]c): The command should be supported]
     expected: FAIL
 
@@ -407,6 +401,21 @@
   [In <input type="password"> in contenteditable, execCommand("delete", false, null), a[b\]c): should not fire beforeinput event]
     expected: FAIL
 
+  [In <input type="password"> in contenteditable, execCommand("fontsize", false, 5), a[b\]c): The command should not be enabled]
+    expected: FAIL
+
+  [In <input type="password"> in contenteditable, execCommand("fontsize", false, 5), a[b\]c): execCommand() should return false]
+    expected: FAIL
+
+  [In <input type="password"> in contenteditable, execCommand("fontsize", false, 5), a[b\]c): should not fire beforeinput event]
+    expected: FAIL
+
+  [In <input type="password"> in contenteditable, execCommand("fontsize", false, 5), a[b\]c): input.inputType should be undefined]
+    expected: FAIL
+
+  [In <input type="password"> in contenteditable, execCommand("fontsize", false, 5), a[b\]c): input.target should be undefined]
+    expected: FAIL
+
 
 [exec-command-with-text-editor.tentative.html?type=text]
   [In <input type="text">, execCommand("bold", false, bold), a[b\]c): The command should be supported]
@@ -506,9 +515,6 @@
     expected: FAIL
 
   [In <input type="text">, execCommand("fontname", false, DummyFont), a[b\]c): The command should be supported]
-    expected: FAIL
-
-  [In <input type="text">, execCommand("fontsize", false, 5), a[b\]c): The command should be supported]
     expected: FAIL
 
   [In <input type="text">, execCommand("inserthorizontalrule", false, null), a[b\]c): The command should be supported]
@@ -664,9 +670,6 @@
   [In <input type="text"> in contenteditable, execCommand("fontname", false, DummyFont), a[b\]c): The command should be supported]
     expected: FAIL
 
-  [In <input type="text"> in contenteditable, execCommand("fontsize", false, 5), a[b\]c): The command should be supported]
-    expected: FAIL
-
   [In <input type="text"> in contenteditable, execCommand("inserthorizontalrule", false, null), a[b\]c): The command should be supported]
     expected: FAIL
 
@@ -817,6 +820,21 @@
   [In <input type="text"> in contenteditable, execCommand("delete", false, null), a[b\]c): should not fire beforeinput event]
     expected: FAIL
 
+  [In <input type="text"> in contenteditable, execCommand("fontsize", false, 5), a[b\]c): The command should not be enabled]
+    expected: FAIL
+
+  [In <input type="text"> in contenteditable, execCommand("fontsize", false, 5), a[b\]c): execCommand() should return false]
+    expected: FAIL
+
+  [In <input type="text"> in contenteditable, execCommand("fontsize", false, 5), a[b\]c): should not fire beforeinput event]
+    expected: FAIL
+
+  [In <input type="text"> in contenteditable, execCommand("fontsize", false, 5), a[b\]c): input.inputType should be undefined]
+    expected: FAIL
+
+  [In <input type="text"> in contenteditable, execCommand("fontsize", false, 5), a[b\]c): input.target should be undefined]
+    expected: FAIL
+
 
 [exec-command-with-text-editor.tentative.html?type=textarea]
   [In <textarea>, execCommand("bold", false, bold), a[b\]c): The command should be supported]
@@ -916,9 +934,6 @@
     expected: FAIL
 
   [In <textarea>, execCommand("fontname", false, DummyFont), a[b\]c): The command should be supported]
-    expected: FAIL
-
-  [In <textarea>, execCommand("fontsize", false, 5), a[b\]c): The command should be supported]
     expected: FAIL
 
   [In <textarea>, execCommand("inserthorizontalrule", false, null), a[b\]c): The command should be supported]
@@ -1080,9 +1095,6 @@
   [In <textarea> in contenteditable, execCommand("fontname", false, DummyFont), a[b\]c): The command should be supported]
     expected: FAIL
 
-  [In <textarea> in contenteditable, execCommand("fontsize", false, 5), a[b\]c): The command should be supported]
-    expected: FAIL
-
   [In <textarea> in contenteditable, execCommand("inserthorizontalrule", false, null), a[b\]c): The command should be supported]
     expected: FAIL
 
@@ -1237,4 +1249,19 @@
     expected: FAIL
 
   [In <textarea> in contenteditable, execCommand("delete", false, null), a[b\]c): should not fire beforeinput event]
+    expected: FAIL
+
+  [In <textarea> in contenteditable, execCommand("fontsize", false, 5), a[b\]c): The command should not be enabled]
+    expected: FAIL
+
+  [In <textarea> in contenteditable, execCommand("fontsize", false, 5), a[b\]c): execCommand() should return false]
+    expected: FAIL
+
+  [In <textarea> in contenteditable, execCommand("fontsize", false, 5), a[b\]c): should not fire beforeinput event]
+    expected: FAIL
+
+  [In <textarea> in contenteditable, execCommand("fontsize", false, 5), a[b\]c): input.inputType should be undefined]
+    expected: FAIL
+
+  [In <textarea> in contenteditable, execCommand("fontsize", false, 5), a[b\]c): input.target should be undefined]
     expected: FAIL

--- a/tests/wpt/meta/editing/run/fontsize.html.ini
+++ b/tests/wpt/meta/editing/run/fontsize.html.ini
@@ -1,14 +1,8 @@
 [fontsize.html?1-1000]
-  [[["fontsize","4"\]\] "foo[\]bar": execCommand("fontsize", false, "4") return value]
-    expected: FAIL
-
   [[["fontsize","4"\]\] "foo[\]bar" queryCommandValue("fontsize") before]
     expected: FAIL
 
   [[["fontsize","4"\]\] "foo[\]bar" queryCommandValue("fontsize") after]
-    expected: FAIL
-
-  [[["stylewithcss","true"\],["fontsize","4"\]\] "<p>[foo</p> <p>bar\]</p>": execCommand("fontsize", false, "4") return value]
     expected: FAIL
 
   [[["stylewithcss","true"\],["fontsize","4"\]\] "<p>[foo</p> <p>bar\]</p>" compare innerHTML]
@@ -20,9 +14,6 @@
   [[["stylewithcss","true"\],["fontsize","4"\]\] "<p>[foo</p> <p>bar\]</p>" queryCommandValue("fontsize") after]
     expected: FAIL
 
-  [[["stylewithcss","false"\],["fontsize","4"\]\] "<p>[foo</p> <p>bar\]</p>": execCommand("fontsize", false, "4") return value]
-    expected: FAIL
-
   [[["stylewithcss","false"\],["fontsize","4"\]\] "<p>[foo</p> <p>bar\]</p>" compare innerHTML]
     expected: FAIL
 
@@ -30,9 +21,6 @@
     expected: FAIL
 
   [[["stylewithcss","false"\],["fontsize","4"\]\] "<p>[foo</p> <p>bar\]</p>" queryCommandValue("fontsize") after]
-    expected: FAIL
-
-  [[["stylewithcss","true"\],["fontsize","4"\]\] "<span>[foo</span> <span>bar\]</span>": execCommand("fontsize", false, "4") return value]
     expected: FAIL
 
   [[["stylewithcss","true"\],["fontsize","4"\]\] "<span>[foo</span> <span>bar\]</span>" compare innerHTML]
@@ -44,9 +32,6 @@
   [[["stylewithcss","true"\],["fontsize","4"\]\] "<span>[foo</span> <span>bar\]</span>" queryCommandValue("fontsize") after]
     expected: FAIL
 
-  [[["stylewithcss","false"\],["fontsize","4"\]\] "<span>[foo</span> <span>bar\]</span>": execCommand("fontsize", false, "4") return value]
-    expected: FAIL
-
   [[["stylewithcss","false"\],["fontsize","4"\]\] "<span>[foo</span> <span>bar\]</span>" compare innerHTML]
     expected: FAIL
 
@@ -54,9 +39,6 @@
     expected: FAIL
 
   [[["stylewithcss","false"\],["fontsize","4"\]\] "<span>[foo</span> <span>bar\]</span>" queryCommandValue("fontsize") after]
-    expected: FAIL
-
-  [[["stylewithcss","true"\],["fontsize","4"\]\] "<p>[foo</p><p> <span>bar</span> </p><p>baz\]</p>": execCommand("fontsize", false, "4") return value]
     expected: FAIL
 
   [[["stylewithcss","true"\],["fontsize","4"\]\] "<p>[foo</p><p> <span>bar</span> </p><p>baz\]</p>" compare innerHTML]
@@ -68,9 +50,6 @@
   [[["stylewithcss","true"\],["fontsize","4"\]\] "<p>[foo</p><p> <span>bar</span> </p><p>baz\]</p>" queryCommandValue("fontsize") after]
     expected: FAIL
 
-  [[["stylewithcss","false"\],["fontsize","4"\]\] "<p>[foo</p><p> <span>bar</span> </p><p>baz\]</p>": execCommand("fontsize", false, "4") return value]
-    expected: FAIL
-
   [[["stylewithcss","false"\],["fontsize","4"\]\] "<p>[foo</p><p> <span>bar</span> </p><p>baz\]</p>" compare innerHTML]
     expected: FAIL
 
@@ -78,9 +57,6 @@
     expected: FAIL
 
   [[["stylewithcss","false"\],["fontsize","4"\]\] "<p>[foo</p><p> <span>bar</span> </p><p>baz\]</p>" queryCommandValue("fontsize") after]
-    expected: FAIL
-
-  [[["stylewithcss","true"\],["fontsize","4"\]\] "<p>[foo<p><br><p>bar\]": execCommand("fontsize", false, "4") return value]
     expected: FAIL
 
   [[["stylewithcss","true"\],["fontsize","4"\]\] "<p>[foo<p><br><p>bar\]" compare innerHTML]
@@ -95,9 +71,6 @@
   [[["stylewithcss","true"\],["fontsize","4"\]\] "<p>[foo<p><br><p>bar\]" queryCommandValue("fontsize") after]
     expected: FAIL
 
-  [[["stylewithcss","false"\],["fontsize","4"\]\] "<p>[foo<p><br><p>bar\]": execCommand("fontsize", false, "4") return value]
-    expected: FAIL
-
   [[["stylewithcss","false"\],["fontsize","4"\]\] "<p>[foo<p><br><p>bar\]" compare innerHTML]
     expected: FAIL
 
@@ -110,16 +83,10 @@
   [[["stylewithcss","false"\],["fontsize","4"\]\] "<p>[foo<p><br><p>bar\]" queryCommandValue("fontsize") after]
     expected: FAIL
 
-  [[["fontsize","4"\]\] "<b>foo[\]bar</b>": execCommand("fontsize", false, "4") return value]
-    expected: FAIL
-
   [[["fontsize","4"\]\] "<b>foo[\]bar</b>" queryCommandValue("fontsize") before]
     expected: FAIL
 
   [[["fontsize","4"\]\] "<b>foo[\]bar</b>" queryCommandValue("fontsize") after]
-    expected: FAIL
-
-  [[["fontsize","4"\]\] "<i>foo[\]bar</i>": execCommand("fontsize", false, "4") return value]
     expected: FAIL
 
   [[["fontsize","4"\]\] "<i>foo[\]bar</i>" queryCommandValue("fontsize") before]
@@ -128,25 +95,16 @@
   [[["fontsize","4"\]\] "<i>foo[\]bar</i>" queryCommandValue("fontsize") after]
     expected: FAIL
 
-  [[["fontsize","4"\]\] "<span>foo</span>{}<span>bar</span>": execCommand("fontsize", false, "4") return value]
-    expected: FAIL
-
   [[["fontsize","4"\]\] "<span>foo</span>{}<span>bar</span>" queryCommandValue("fontsize") before]
     expected: FAIL
 
   [[["fontsize","4"\]\] "<span>foo</span>{}<span>bar</span>" queryCommandValue("fontsize") after]
     expected: FAIL
 
-  [[["fontsize","4"\]\] "<span>foo[</span><span>\]bar</span>": execCommand("fontsize", false, "4") return value]
-    expected: FAIL
-
   [[["fontsize","4"\]\] "<span>foo[</span><span>\]bar</span>" queryCommandValue("fontsize") before]
     expected: FAIL
 
   [[["fontsize","4"\]\] "<span>foo[</span><span>\]bar</span>" queryCommandValue("fontsize") after]
-    expected: FAIL
-
-  [[["stylewithcss","true"\],["fontsize","4"\]\] "foo[bar\]baz": execCommand("fontsize", false, "4") return value]
     expected: FAIL
 
   [[["stylewithcss","true"\],["fontsize","4"\]\] "foo[bar\]baz" compare innerHTML]
@@ -158,9 +116,6 @@
   [[["stylewithcss","true"\],["fontsize","4"\]\] "foo[bar\]baz" queryCommandValue("fontsize") after]
     expected: FAIL
 
-  [[["stylewithcss","false"\],["fontsize","4"\]\] "foo[bar\]baz": execCommand("fontsize", false, "4") return value]
-    expected: FAIL
-
   [[["stylewithcss","false"\],["fontsize","4"\]\] "foo[bar\]baz" compare innerHTML]
     expected: FAIL
 
@@ -168,9 +123,6 @@
     expected: FAIL
 
   [[["stylewithcss","false"\],["fontsize","4"\]\] "foo[bar\]baz" queryCommandValue("fontsize") after]
-    expected: FAIL
-
-  [[["stylewithcss","true"\],["fontsize","4"\]\] "foo[bar<b>baz\]qoz</b>quz": execCommand("fontsize", false, "4") return value]
     expected: FAIL
 
   [[["stylewithcss","true"\],["fontsize","4"\]\] "foo[bar<b>baz\]qoz</b>quz" compare innerHTML]
@@ -182,9 +134,6 @@
   [[["stylewithcss","true"\],["fontsize","4"\]\] "foo[bar<b>baz\]qoz</b>quz" queryCommandValue("fontsize") after]
     expected: FAIL
 
-  [[["stylewithcss","false"\],["fontsize","4"\]\] "foo[bar<b>baz\]qoz</b>quz": execCommand("fontsize", false, "4") return value]
-    expected: FAIL
-
   [[["stylewithcss","false"\],["fontsize","4"\]\] "foo[bar<b>baz\]qoz</b>quz" compare innerHTML]
     expected: FAIL
 
@@ -192,9 +141,6 @@
     expected: FAIL
 
   [[["stylewithcss","false"\],["fontsize","4"\]\] "foo[bar<b>baz\]qoz</b>quz" queryCommandValue("fontsize") after]
-    expected: FAIL
-
-  [[["stylewithcss","true"\],["fontsize","4"\]\] "foo[bar<i>baz\]qoz</i>quz": execCommand("fontsize", false, "4") return value]
     expected: FAIL
 
   [[["stylewithcss","true"\],["fontsize","4"\]\] "foo[bar<i>baz\]qoz</i>quz" compare innerHTML]
@@ -206,9 +152,6 @@
   [[["stylewithcss","true"\],["fontsize","4"\]\] "foo[bar<i>baz\]qoz</i>quz" queryCommandValue("fontsize") after]
     expected: FAIL
 
-  [[["stylewithcss","false"\],["fontsize","4"\]\] "foo[bar<i>baz\]qoz</i>quz": execCommand("fontsize", false, "4") return value]
-    expected: FAIL
-
   [[["stylewithcss","false"\],["fontsize","4"\]\] "foo[bar<i>baz\]qoz</i>quz" compare innerHTML]
     expected: FAIL
 
@@ -218,19 +161,10 @@
   [[["stylewithcss","false"\],["fontsize","4"\]\] "foo[bar<i>baz\]qoz</i>quz" queryCommandValue("fontsize") after]
     expected: FAIL
 
-  [[["stylewithcss","true"\],["fontsize","4"\]\] "{<p><p> <p>foo</p>}": execCommand("fontsize", false, "4") return value]
-    expected: FAIL
-
-  [[["stylewithcss","true"\],["fontsize","4"\]\] "{<p><p> <p>foo</p>}" compare innerHTML]
-    expected: FAIL
-
   [[["stylewithcss","true"\],["fontsize","4"\]\] "{<p><p> <p>foo</p>}" queryCommandValue("fontsize") before]
     expected: FAIL
 
   [[["stylewithcss","true"\],["fontsize","4"\]\] "{<p><p> <p>foo</p>}" queryCommandValue("fontsize") after]
-    expected: FAIL
-
-  [[["stylewithcss","false"\],["fontsize","4"\]\] "{<p><p> <p>foo</p>}": execCommand("fontsize", false, "4") return value]
     expected: FAIL
 
   [[["stylewithcss","false"\],["fontsize","4"\]\] "{<p><p> <p>foo</p>}" compare innerHTML]
@@ -242,9 +176,6 @@
   [[["stylewithcss","false"\],["fontsize","4"\]\] "{<p><p> <p>foo</p>}" queryCommandValue("fontsize") after]
     expected: FAIL
 
-  [[["stylewithcss","true"\],["fontsize","1"\]\] "foo[bar\]baz": execCommand("fontsize", false, "1") return value]
-    expected: FAIL
-
   [[["stylewithcss","true"\],["fontsize","1"\]\] "foo[bar\]baz" compare innerHTML]
     expected: FAIL
 
@@ -252,9 +183,6 @@
     expected: FAIL
 
   [[["stylewithcss","true"\],["fontsize","1"\]\] "foo[bar\]baz" queryCommandValue("fontsize") after]
-    expected: FAIL
-
-  [[["stylewithcss","false"\],["fontsize","1"\]\] "foo[bar\]baz": execCommand("fontsize", false, "1") return value]
     expected: FAIL
 
   [[["stylewithcss","false"\],["fontsize","1"\]\] "foo[bar\]baz" compare innerHTML]
@@ -266,9 +194,6 @@
   [[["stylewithcss","false"\],["fontsize","1"\]\] "foo[bar\]baz" queryCommandValue("fontsize") after]
     expected: FAIL
 
-  [[["stylewithcss","true"\],["fontsize","0"\]\] "foo[bar\]baz": execCommand("fontsize", false, "0") return value]
-    expected: FAIL
-
   [[["stylewithcss","true"\],["fontsize","0"\]\] "foo[bar\]baz" compare innerHTML]
     expected: FAIL
 
@@ -276,9 +201,6 @@
     expected: FAIL
 
   [[["stylewithcss","true"\],["fontsize","0"\]\] "foo[bar\]baz" queryCommandValue("fontsize") after]
-    expected: FAIL
-
-  [[["stylewithcss","false"\],["fontsize","0"\]\] "foo[bar\]baz": execCommand("fontsize", false, "0") return value]
     expected: FAIL
 
   [[["stylewithcss","false"\],["fontsize","0"\]\] "foo[bar\]baz" compare innerHTML]
@@ -290,9 +212,6 @@
   [[["stylewithcss","false"\],["fontsize","0"\]\] "foo[bar\]baz" queryCommandValue("fontsize") after]
     expected: FAIL
 
-  [[["stylewithcss","true"\],["fontsize","-5"\]\] "foo[bar\]baz": execCommand("fontsize", false, "-5") return value]
-    expected: FAIL
-
   [[["stylewithcss","true"\],["fontsize","-5"\]\] "foo[bar\]baz" compare innerHTML]
     expected: FAIL
 
@@ -300,9 +219,6 @@
     expected: FAIL
 
   [[["stylewithcss","true"\],["fontsize","-5"\]\] "foo[bar\]baz" queryCommandValue("fontsize") after]
-    expected: FAIL
-
-  [[["stylewithcss","false"\],["fontsize","-5"\]\] "foo[bar\]baz": execCommand("fontsize", false, "-5") return value]
     expected: FAIL
 
   [[["stylewithcss","false"\],["fontsize","-5"\]\] "foo[bar\]baz" compare innerHTML]
@@ -314,9 +230,6 @@
   [[["stylewithcss","false"\],["fontsize","-5"\]\] "foo[bar\]baz" queryCommandValue("fontsize") after]
     expected: FAIL
 
-  [[["stylewithcss","true"\],["fontsize","6"\]\] "foo[bar\]baz": execCommand("fontsize", false, "6") return value]
-    expected: FAIL
-
   [[["stylewithcss","true"\],["fontsize","6"\]\] "foo[bar\]baz" compare innerHTML]
     expected: FAIL
 
@@ -324,9 +237,6 @@
     expected: FAIL
 
   [[["stylewithcss","true"\],["fontsize","6"\]\] "foo[bar\]baz" queryCommandValue("fontsize") after]
-    expected: FAIL
-
-  [[["stylewithcss","false"\],["fontsize","6"\]\] "foo[bar\]baz": execCommand("fontsize", false, "6") return value]
     expected: FAIL
 
   [[["stylewithcss","false"\],["fontsize","6"\]\] "foo[bar\]baz" compare innerHTML]
@@ -338,9 +248,6 @@
   [[["stylewithcss","false"\],["fontsize","6"\]\] "foo[bar\]baz" queryCommandValue("fontsize") after]
     expected: FAIL
 
-  [[["stylewithcss","true"\],["fontsize","7"\]\] "foo[bar\]baz": execCommand("fontsize", false, "7") return value]
-    expected: FAIL
-
   [[["stylewithcss","true"\],["fontsize","7"\]\] "foo[bar\]baz" compare innerHTML]
     expected: FAIL
 
@@ -348,9 +255,6 @@
     expected: FAIL
 
   [[["stylewithcss","true"\],["fontsize","7"\]\] "foo[bar\]baz" queryCommandValue("fontsize") after]
-    expected: FAIL
-
-  [[["stylewithcss","false"\],["fontsize","7"\]\] "foo[bar\]baz": execCommand("fontsize", false, "7") return value]
     expected: FAIL
 
   [[["stylewithcss","false"\],["fontsize","7"\]\] "foo[bar\]baz" compare innerHTML]
@@ -362,9 +266,6 @@
   [[["stylewithcss","false"\],["fontsize","7"\]\] "foo[bar\]baz" queryCommandValue("fontsize") after]
     expected: FAIL
 
-  [[["stylewithcss","true"\],["fontsize","8"\]\] "foo[bar\]baz": execCommand("fontsize", false, "8") return value]
-    expected: FAIL
-
   [[["stylewithcss","true"\],["fontsize","8"\]\] "foo[bar\]baz" compare innerHTML]
     expected: FAIL
 
@@ -372,9 +273,6 @@
     expected: FAIL
 
   [[["stylewithcss","true"\],["fontsize","8"\]\] "foo[bar\]baz" queryCommandValue("fontsize") after]
-    expected: FAIL
-
-  [[["stylewithcss","false"\],["fontsize","8"\]\] "foo[bar\]baz": execCommand("fontsize", false, "8") return value]
     expected: FAIL
 
   [[["stylewithcss","false"\],["fontsize","8"\]\] "foo[bar\]baz" compare innerHTML]
@@ -386,9 +284,6 @@
   [[["stylewithcss","false"\],["fontsize","8"\]\] "foo[bar\]baz" queryCommandValue("fontsize") after]
     expected: FAIL
 
-  [[["stylewithcss","true"\],["fontsize","100"\]\] "foo[bar\]baz": execCommand("fontsize", false, "100") return value]
-    expected: FAIL
-
   [[["stylewithcss","true"\],["fontsize","100"\]\] "foo[bar\]baz" compare innerHTML]
     expected: FAIL
 
@@ -396,9 +291,6 @@
     expected: FAIL
 
   [[["stylewithcss","true"\],["fontsize","100"\]\] "foo[bar\]baz" queryCommandValue("fontsize") after]
-    expected: FAIL
-
-  [[["stylewithcss","false"\],["fontsize","100"\]\] "foo[bar\]baz": execCommand("fontsize", false, "100") return value]
     expected: FAIL
 
   [[["stylewithcss","false"\],["fontsize","100"\]\] "foo[bar\]baz" compare innerHTML]
@@ -428,9 +320,6 @@
   [[["fontsize","xx-large"\]\] "foo[bar\]baz" queryCommandValue("fontsize") after]
     expected: FAIL
 
-  [[["stylewithcss","true"\],["fontsize"," 1 "\]\] "foo[bar\]baz": execCommand("fontsize", false, " 1 ") return value]
-    expected: FAIL
-
   [[["stylewithcss","true"\],["fontsize"," 1 "\]\] "foo[bar\]baz" compare innerHTML]
     expected: FAIL
 
@@ -438,9 +327,6 @@
     expected: FAIL
 
   [[["stylewithcss","true"\],["fontsize"," 1 "\]\] "foo[bar\]baz" queryCommandValue("fontsize") after]
-    expected: FAIL
-
-  [[["stylewithcss","false"\],["fontsize"," 1 "\]\] "foo[bar\]baz": execCommand("fontsize", false, " 1 ") return value]
     expected: FAIL
 
   [[["stylewithcss","false"\],["fontsize"," 1 "\]\] "foo[bar\]baz" compare innerHTML]
@@ -458,9 +344,6 @@
   [[["fontsize","1."\]\] "foo[bar\]baz" queryCommandValue("fontsize") after]
     expected: FAIL
 
-  [[["stylewithcss","true"\],["fontsize","1.0"\]\] "foo[bar\]baz": execCommand("fontsize", false, "1.0") return value]
-    expected: FAIL
-
   [[["stylewithcss","true"\],["fontsize","1.0"\]\] "foo[bar\]baz" compare innerHTML]
     expected: FAIL
 
@@ -468,9 +351,6 @@
     expected: FAIL
 
   [[["stylewithcss","true"\],["fontsize","1.0"\]\] "foo[bar\]baz" queryCommandValue("fontsize") after]
-    expected: FAIL
-
-  [[["stylewithcss","false"\],["fontsize","1.0"\]\] "foo[bar\]baz": execCommand("fontsize", false, "1.0") return value]
     expected: FAIL
 
   [[["stylewithcss","false"\],["fontsize","1.0"\]\] "foo[bar\]baz" compare innerHTML]
@@ -482,9 +362,6 @@
   [[["stylewithcss","false"\],["fontsize","1.0"\]\] "foo[bar\]baz" queryCommandValue("fontsize") after]
     expected: FAIL
 
-  [[["stylewithcss","true"\],["fontsize","1.0e2"\]\] "foo[bar\]baz": execCommand("fontsize", false, "1.0e2") return value]
-    expected: FAIL
-
   [[["stylewithcss","true"\],["fontsize","1.0e2"\]\] "foo[bar\]baz" compare innerHTML]
     expected: FAIL
 
@@ -492,9 +369,6 @@
     expected: FAIL
 
   [[["stylewithcss","true"\],["fontsize","1.0e2"\]\] "foo[bar\]baz" queryCommandValue("fontsize") after]
-    expected: FAIL
-
-  [[["stylewithcss","false"\],["fontsize","1.0e2"\]\] "foo[bar\]baz": execCommand("fontsize", false, "1.0e2") return value]
     expected: FAIL
 
   [[["stylewithcss","false"\],["fontsize","1.0e2"\]\] "foo[bar\]baz" compare innerHTML]
@@ -506,9 +380,6 @@
   [[["stylewithcss","false"\],["fontsize","1.0e2"\]\] "foo[bar\]baz" queryCommandValue("fontsize") after]
     expected: FAIL
 
-  [[["stylewithcss","true"\],["fontsize","1.1"\]\] "foo[bar\]baz": execCommand("fontsize", false, "1.1") return value]
-    expected: FAIL
-
   [[["stylewithcss","true"\],["fontsize","1.1"\]\] "foo[bar\]baz" compare innerHTML]
     expected: FAIL
 
@@ -516,9 +387,6 @@
     expected: FAIL
 
   [[["stylewithcss","true"\],["fontsize","1.1"\]\] "foo[bar\]baz" queryCommandValue("fontsize") after]
-    expected: FAIL
-
-  [[["stylewithcss","false"\],["fontsize","1.1"\]\] "foo[bar\]baz": execCommand("fontsize", false, "1.1") return value]
     expected: FAIL
 
   [[["stylewithcss","false"\],["fontsize","1.1"\]\] "foo[bar\]baz" compare innerHTML]
@@ -530,9 +398,6 @@
   [[["stylewithcss","false"\],["fontsize","1.1"\]\] "foo[bar\]baz" queryCommandValue("fontsize") after]
     expected: FAIL
 
-  [[["stylewithcss","true"\],["fontsize","1.9"\]\] "foo[bar\]baz": execCommand("fontsize", false, "1.9") return value]
-    expected: FAIL
-
   [[["stylewithcss","true"\],["fontsize","1.9"\]\] "foo[bar\]baz" compare innerHTML]
     expected: FAIL
 
@@ -540,9 +405,6 @@
     expected: FAIL
 
   [[["stylewithcss","true"\],["fontsize","1.9"\]\] "foo[bar\]baz" queryCommandValue("fontsize") after]
-    expected: FAIL
-
-  [[["stylewithcss","false"\],["fontsize","1.9"\]\] "foo[bar\]baz": execCommand("fontsize", false, "1.9") return value]
     expected: FAIL
 
   [[["stylewithcss","false"\],["fontsize","1.9"\]\] "foo[bar\]baz" compare innerHTML]
@@ -611,16 +473,10 @@
   [[["stylewithcss","false"\],["fontsize","+9"\]\] "foo[bar\]baz" queryCommandValue("fontsize") after]
     expected: FAIL
 
-  [[["fontsize","-0"\]\] "foo[bar\]baz": execCommand("fontsize", false, "-0") return value]
-    expected: FAIL
-
   [[["fontsize","-0"\]\] "foo[bar\]baz" queryCommandValue("fontsize") before]
     expected: FAIL
 
   [[["fontsize","-0"\]\] "foo[bar\]baz" queryCommandValue("fontsize") after]
-    expected: FAIL
-
-  [[["stylewithcss","true"\],["fontsize","-1"\]\] "foo[bar\]baz": execCommand("fontsize", false, "-1") return value]
     expected: FAIL
 
   [[["stylewithcss","true"\],["fontsize","-1"\]\] "foo[bar\]baz" compare innerHTML]
@@ -632,9 +488,6 @@
   [[["stylewithcss","true"\],["fontsize","-1"\]\] "foo[bar\]baz" queryCommandValue("fontsize") after]
     expected: FAIL
 
-  [[["stylewithcss","false"\],["fontsize","-1"\]\] "foo[bar\]baz": execCommand("fontsize", false, "-1") return value]
-    expected: FAIL
-
   [[["stylewithcss","false"\],["fontsize","-1"\]\] "foo[bar\]baz" compare innerHTML]
     expected: FAIL
 
@@ -644,9 +497,6 @@
   [[["stylewithcss","false"\],["fontsize","-1"\]\] "foo[bar\]baz" queryCommandValue("fontsize") after]
     expected: FAIL
 
-  [[["stylewithcss","true"\],["fontsize","-9"\]\] "foo[bar\]baz": execCommand("fontsize", false, "-9") return value]
-    expected: FAIL
-
   [[["stylewithcss","true"\],["fontsize","-9"\]\] "foo[bar\]baz" compare innerHTML]
     expected: FAIL
 
@@ -654,9 +504,6 @@
     expected: FAIL
 
   [[["stylewithcss","true"\],["fontsize","-9"\]\] "foo[bar\]baz" queryCommandValue("fontsize") after]
-    expected: FAIL
-
-  [[["stylewithcss","false"\],["fontsize","-9"\]\] "foo[bar\]baz": execCommand("fontsize", false, "-9") return value]
     expected: FAIL
 
   [[["stylewithcss","false"\],["fontsize","-9"\]\] "foo[bar\]baz" compare innerHTML]
@@ -674,9 +521,6 @@
   [[["fontsize",""\]\] "foo[bar\]baz" queryCommandValue("fontsize") after]
     expected: FAIL
 
-  [[["stylewithcss","true"\],["fontsize","4"\]\] "<table><tbody><tr><td>foo<td>b[a\]r<td>baz</table>": execCommand("fontsize", false, "4") return value]
-    expected: FAIL
-
   [[["stylewithcss","true"\],["fontsize","4"\]\] "<table><tbody><tr><td>foo<td>b[a\]r<td>baz</table>" compare innerHTML]
     expected: FAIL
 
@@ -684,9 +528,6 @@
     expected: FAIL
 
   [[["stylewithcss","true"\],["fontsize","4"\]\] "<table><tbody><tr><td>foo<td>b[a\]r<td>baz</table>" queryCommandValue("fontsize") after]
-    expected: FAIL
-
-  [[["stylewithcss","false"\],["fontsize","4"\]\] "<table><tbody><tr><td>foo<td>b[a\]r<td>baz</table>": execCommand("fontsize", false, "4") return value]
     expected: FAIL
 
   [[["stylewithcss","false"\],["fontsize","4"\]\] "<table><tbody><tr><td>foo<td>b[a\]r<td>baz</table>" compare innerHTML]
@@ -698,19 +539,10 @@
   [[["stylewithcss","false"\],["fontsize","4"\]\] "<table><tbody><tr><td>foo<td>b[a\]r<td>baz</table>" queryCommandValue("fontsize") after]
     expected: FAIL
 
-  [[["stylewithcss","true"\],["fontsize","4"\]\] "<table><tbody><tr data-start=1 data-end=2><td>foo<td>bar<td>baz</table>": execCommand("fontsize", false, "4") return value]
-    expected: FAIL
-
-  [[["stylewithcss","true"\],["fontsize","4"\]\] "<table><tbody><tr data-start=1 data-end=2><td>foo<td>bar<td>baz</table>" compare innerHTML]
-    expected: FAIL
-
   [[["stylewithcss","true"\],["fontsize","4"\]\] "<table><tbody><tr data-start=1 data-end=2><td>foo<td>bar<td>baz</table>" queryCommandValue("fontsize") before]
     expected: FAIL
 
   [[["stylewithcss","true"\],["fontsize","4"\]\] "<table><tbody><tr data-start=1 data-end=2><td>foo<td>bar<td>baz</table>" queryCommandValue("fontsize") after]
-    expected: FAIL
-
-  [[["stylewithcss","false"\],["fontsize","4"\]\] "<table><tbody><tr data-start=1 data-end=2><td>foo<td>bar<td>baz</table>": execCommand("fontsize", false, "4") return value]
     expected: FAIL
 
   [[["stylewithcss","false"\],["fontsize","4"\]\] "<table><tbody><tr data-start=1 data-end=2><td>foo<td>bar<td>baz</table>" compare innerHTML]
@@ -722,9 +554,6 @@
   [[["stylewithcss","false"\],["fontsize","4"\]\] "<table><tbody><tr data-start=1 data-end=2><td>foo<td>bar<td>baz</table>" queryCommandValue("fontsize") after]
     expected: FAIL
 
-  [[["stylewithcss","true"\],["fontsize","4"\]\] "<table><tbody><tr data-start=0 data-end=2><td>foo<td>bar<td>baz</table>": execCommand("fontsize", false, "4") return value]
-    expected: FAIL
-
   [[["stylewithcss","true"\],["fontsize","4"\]\] "<table><tbody><tr data-start=0 data-end=2><td>foo<td>bar<td>baz</table>" compare innerHTML]
     expected: FAIL
 
@@ -732,9 +561,6 @@
     expected: FAIL
 
   [[["stylewithcss","true"\],["fontsize","4"\]\] "<table><tbody><tr data-start=0 data-end=2><td>foo<td>bar<td>baz</table>" queryCommandValue("fontsize") after]
-    expected: FAIL
-
-  [[["stylewithcss","false"\],["fontsize","4"\]\] "<table><tbody><tr data-start=0 data-end=2><td>foo<td>bar<td>baz</table>": execCommand("fontsize", false, "4") return value]
     expected: FAIL
 
   [[["stylewithcss","false"\],["fontsize","4"\]\] "<table><tbody><tr data-start=0 data-end=2><td>foo<td>bar<td>baz</table>" compare innerHTML]
@@ -746,9 +572,6 @@
   [[["stylewithcss","false"\],["fontsize","4"\]\] "<table><tbody><tr data-start=0 data-end=2><td>foo<td>bar<td>baz</table>" queryCommandValue("fontsize") after]
     expected: FAIL
 
-  [[["stylewithcss","true"\],["fontsize","4"\]\] "<table><tbody data-start=0 data-end=1><tr><td>foo<td>bar<td>baz</table>": execCommand("fontsize", false, "4") return value]
-    expected: FAIL
-
   [[["stylewithcss","true"\],["fontsize","4"\]\] "<table><tbody data-start=0 data-end=1><tr><td>foo<td>bar<td>baz</table>" compare innerHTML]
     expected: FAIL
 
@@ -756,9 +579,6 @@
     expected: FAIL
 
   [[["stylewithcss","true"\],["fontsize","4"\]\] "<table><tbody data-start=0 data-end=1><tr><td>foo<td>bar<td>baz</table>" queryCommandValue("fontsize") after]
-    expected: FAIL
-
-  [[["stylewithcss","false"\],["fontsize","4"\]\] "<table><tbody data-start=0 data-end=1><tr><td>foo<td>bar<td>baz</table>": execCommand("fontsize", false, "4") return value]
     expected: FAIL
 
   [[["stylewithcss","false"\],["fontsize","4"\]\] "<table><tbody data-start=0 data-end=1><tr><td>foo<td>bar<td>baz</table>" compare innerHTML]
@@ -775,19 +595,10 @@
   [[["stylewithcss","false"\],["fontsize","4"\]\] "<table><tbody data-start=0 data-end=1><tr><td>foo<td>bar<td>baz</table>" queryCommandValue("fontsize") after]
     expected: FAIL
 
-  [[["stylewithcss","true"\],["fontsize","4"\]\] "<table data-start=0 data-end=1><tbody><tr><td>foo<td>bar<td>baz</table>": execCommand("fontsize", false, "4") return value]
-    expected: FAIL
-
-  [[["stylewithcss","true"\],["fontsize","4"\]\] "<table data-start=0 data-end=1><tbody><tr><td>foo<td>bar<td>baz</table>" compare innerHTML]
-    expected: FAIL
-
   [[["stylewithcss","true"\],["fontsize","4"\]\] "<table data-start=0 data-end=1><tbody><tr><td>foo<td>bar<td>baz</table>" queryCommandValue("fontsize") before]
     expected: FAIL
 
   [[["stylewithcss","true"\],["fontsize","4"\]\] "<table data-start=0 data-end=1><tbody><tr><td>foo<td>bar<td>baz</table>" queryCommandValue("fontsize") after]
-    expected: FAIL
-
-  [[["stylewithcss","false"\],["fontsize","4"\]\] "<table data-start=0 data-end=1><tbody><tr><td>foo<td>bar<td>baz</table>": execCommand("fontsize", false, "4") return value]
     expected: FAIL
 
   [[["stylewithcss","false"\],["fontsize","4"\]\] "<table data-start=0 data-end=1><tbody><tr><td>foo<td>bar<td>baz</table>" compare innerHTML]
@@ -799,19 +610,10 @@
   [[["stylewithcss","false"\],["fontsize","4"\]\] "<table data-start=0 data-end=1><tbody><tr><td>foo<td>bar<td>baz</table>" queryCommandValue("fontsize") after]
     expected: FAIL
 
-  [[["stylewithcss","true"\],["fontsize","4"\]\] "{<table><tr><td>foo<td>bar<td>baz</table>}": execCommand("fontsize", false, "4") return value]
-    expected: FAIL
-
-  [[["stylewithcss","true"\],["fontsize","4"\]\] "{<table><tr><td>foo<td>bar<td>baz</table>}" compare innerHTML]
-    expected: FAIL
-
   [[["stylewithcss","true"\],["fontsize","4"\]\] "{<table><tr><td>foo<td>bar<td>baz</table>}" queryCommandValue("fontsize") before]
     expected: FAIL
 
   [[["stylewithcss","true"\],["fontsize","4"\]\] "{<table><tr><td>foo<td>bar<td>baz</table>}" queryCommandValue("fontsize") after]
-    expected: FAIL
-
-  [[["stylewithcss","false"\],["fontsize","4"\]\] "{<table><tr><td>foo<td>bar<td>baz</table>}": execCommand("fontsize", false, "4") return value]
     expected: FAIL
 
   [[["stylewithcss","false"\],["fontsize","4"\]\] "{<table><tr><td>foo<td>bar<td>baz</table>}" compare innerHTML]
@@ -823,9 +625,6 @@
   [[["stylewithcss","false"\],["fontsize","4"\]\] "{<table><tr><td>foo<td>bar<td>baz</table>}" queryCommandValue("fontsize") after]
     expected: FAIL
 
-  [[["stylewithcss","true"\],["fontsize","4"\]\] "foo<font size=1>[bar\]</font>baz": execCommand("fontsize", false, "4") return value]
-    expected: FAIL
-
   [[["stylewithcss","true"\],["fontsize","4"\]\] "foo<font size=1>[bar\]</font>baz" compare innerHTML]
     expected: FAIL
 
@@ -833,9 +632,6 @@
     expected: FAIL
 
   [[["stylewithcss","true"\],["fontsize","4"\]\] "foo<font size=1>[bar\]</font>baz" queryCommandValue("fontsize") after]
-    expected: FAIL
-
-  [[["stylewithcss","false"\],["fontsize","4"\]\] "foo<font size=1>[bar\]</font>baz": execCommand("fontsize", false, "4") return value]
     expected: FAIL
 
   [[["stylewithcss","false"\],["fontsize","4"\]\] "foo<font size=1>[bar\]</font>baz" compare innerHTML]
@@ -847,9 +643,6 @@
   [[["stylewithcss","false"\],["fontsize","4"\]\] "foo<font size=1>[bar\]</font>baz" queryCommandValue("fontsize") after]
     expected: FAIL
 
-  [[["stylewithcss","true"\],["fontsize","4"\]\] "<font size=1>foo[bar\]baz</font>": execCommand("fontsize", false, "4") return value]
-    expected: FAIL
-
   [[["stylewithcss","true"\],["fontsize","4"\]\] "<font size=1>foo[bar\]baz</font>" compare innerHTML]
     expected: FAIL
 
@@ -857,9 +650,6 @@
     expected: FAIL
 
   [[["stylewithcss","true"\],["fontsize","4"\]\] "<font size=1>foo[bar\]baz</font>" queryCommandValue("fontsize") after]
-    expected: FAIL
-
-  [[["stylewithcss","false"\],["fontsize","4"\]\] "<font size=1>foo[bar\]baz</font>": execCommand("fontsize", false, "4") return value]
     expected: FAIL
 
   [[["stylewithcss","false"\],["fontsize","4"\]\] "<font size=1>foo[bar\]baz</font>" compare innerHTML]
@@ -871,9 +661,6 @@
   [[["stylewithcss","false"\],["fontsize","4"\]\] "<font size=1>foo[bar\]baz</font>" queryCommandValue("fontsize") after]
     expected: FAIL
 
-  [[["stylewithcss","true"\],["fontsize","4"\]\] "foo<font size=3>[bar\]</font>baz": execCommand("fontsize", false, "4") return value]
-    expected: FAIL
-
   [[["stylewithcss","true"\],["fontsize","4"\]\] "foo<font size=3>[bar\]</font>baz" compare innerHTML]
     expected: FAIL
 
@@ -881,9 +668,6 @@
     expected: FAIL
 
   [[["stylewithcss","true"\],["fontsize","4"\]\] "foo<font size=3>[bar\]</font>baz" queryCommandValue("fontsize") after]
-    expected: FAIL
-
-  [[["stylewithcss","false"\],["fontsize","4"\]\] "foo<font size=3>[bar\]</font>baz": execCommand("fontsize", false, "4") return value]
     expected: FAIL
 
   [[["stylewithcss","false"\],["fontsize","4"\]\] "foo<font size=3>[bar\]</font>baz" compare innerHTML]
@@ -895,9 +679,6 @@
   [[["stylewithcss","false"\],["fontsize","4"\]\] "foo<font size=3>[bar\]</font>baz" queryCommandValue("fontsize") after]
     expected: FAIL
 
-  [[["stylewithcss","true"\],["fontsize","4"\]\] "<font size=3>foo[bar\]baz</font>": execCommand("fontsize", false, "4") return value]
-    expected: FAIL
-
   [[["stylewithcss","true"\],["fontsize","4"\]\] "<font size=3>foo[bar\]baz</font>" compare innerHTML]
     expected: FAIL
 
@@ -905,9 +686,6 @@
     expected: FAIL
 
   [[["stylewithcss","true"\],["fontsize","4"\]\] "<font size=3>foo[bar\]baz</font>" queryCommandValue("fontsize") after]
-    expected: FAIL
-
-  [[["stylewithcss","false"\],["fontsize","4"\]\] "<font size=3>foo[bar\]baz</font>": execCommand("fontsize", false, "4") return value]
     expected: FAIL
 
   [[["stylewithcss","false"\],["fontsize","4"\]\] "<font size=3>foo[bar\]baz</font>" compare innerHTML]
@@ -919,9 +697,6 @@
   [[["stylewithcss","false"\],["fontsize","4"\]\] "<font size=3>foo[bar\]baz</font>" queryCommandValue("fontsize") after]
     expected: FAIL
 
-  [[["stylewithcss","true"\],["fontsize","4"\]\] "foo<font size=4>[bar\]</font>baz": execCommand("fontsize", false, "4") return value]
-    expected: FAIL
-
   [[["stylewithcss","true"\],["fontsize","4"\]\] "foo<font size=4>[bar\]</font>baz" compare innerHTML]
     expected: FAIL
 
@@ -931,25 +706,16 @@
   [[["stylewithcss","true"\],["fontsize","4"\]\] "foo<font size=4>[bar\]</font>baz" queryCommandValue("fontsize") after]
     expected: FAIL
 
-  [[["stylewithcss","false"\],["fontsize","4"\]\] "foo<font size=4>[bar\]</font>baz": execCommand("fontsize", false, "4") return value]
-    expected: FAIL
-
   [[["stylewithcss","false"\],["fontsize","4"\]\] "foo<font size=4>[bar\]</font>baz" queryCommandValue("fontsize") before]
     expected: FAIL
 
   [[["stylewithcss","false"\],["fontsize","4"\]\] "foo<font size=4>[bar\]</font>baz" queryCommandValue("fontsize") after]
     expected: FAIL
 
-  [[["fontsize","4"\]\] "<font size=4>foo[bar\]baz</font>": execCommand("fontsize", false, "4") return value]
-    expected: FAIL
-
   [[["fontsize","4"\]\] "<font size=4>foo[bar\]baz</font>" queryCommandValue("fontsize") before]
     expected: FAIL
 
   [[["fontsize","4"\]\] "<font size=4>foo[bar\]baz</font>" queryCommandValue("fontsize") after]
-    expected: FAIL
-
-  [[["stylewithcss","true"\],["fontsize","4"\]\] "foo<font size=+1>[bar\]</font>baz": execCommand("fontsize", false, "4") return value]
     expected: FAIL
 
   [[["stylewithcss","true"\],["fontsize","4"\]\] "foo<font size=+1>[bar\]</font>baz" compare innerHTML]
@@ -961,9 +727,6 @@
   [[["stylewithcss","true"\],["fontsize","4"\]\] "foo<font size=+1>[bar\]</font>baz" queryCommandValue("fontsize") after]
     expected: FAIL
 
-  [[["stylewithcss","false"\],["fontsize","4"\]\] "foo<font size=+1>[bar\]</font>baz": execCommand("fontsize", false, "4") return value]
-    expected: FAIL
-
   [[["stylewithcss","false"\],["fontsize","4"\]\] "foo<font size=+1>[bar\]</font>baz" compare innerHTML]
     expected: FAIL
 
@@ -973,16 +736,10 @@
   [[["stylewithcss","false"\],["fontsize","4"\]\] "foo<font size=+1>[bar\]</font>baz" queryCommandValue("fontsize") after]
     expected: FAIL
 
-  [[["fontsize","4"\]\] "<font size=+1>foo[bar\]baz</font>": execCommand("fontsize", false, "4") return value]
-    expected: FAIL
-
   [[["fontsize","4"\]\] "<font size=+1>foo[bar\]baz</font>" queryCommandValue("fontsize") before]
     expected: FAIL
 
   [[["fontsize","4"\]\] "<font size=+1>foo[bar\]baz</font>" queryCommandValue("fontsize") after]
-    expected: FAIL
-
-  [[["stylewithcss","true"\],["fontsize","4"\]\] "<font size=4>foo<font size=1>b[a\]r</font>baz</font>": execCommand("fontsize", false, "4") return value]
     expected: FAIL
 
   [[["stylewithcss","true"\],["fontsize","4"\]\] "<font size=4>foo<font size=1>b[a\]r</font>baz</font>" compare innerHTML]
@@ -994,9 +751,6 @@
   [[["stylewithcss","true"\],["fontsize","4"\]\] "<font size=4>foo<font size=1>b[a\]r</font>baz</font>" queryCommandValue("fontsize") after]
     expected: FAIL
 
-  [[["stylewithcss","false"\],["fontsize","4"\]\] "<font size=4>foo<font size=1>b[a\]r</font>baz</font>": execCommand("fontsize", false, "4") return value]
-    expected: FAIL
-
   [[["stylewithcss","false"\],["fontsize","4"\]\] "<font size=4>foo<font size=1>b[a\]r</font>baz</font>" compare innerHTML]
     expected: FAIL
 
@@ -1004,9 +758,6 @@
     expected: FAIL
 
   [[["stylewithcss","false"\],["fontsize","4"\]\] "<font size=4>foo<font size=1>b[a\]r</font>baz</font>" queryCommandValue("fontsize") after]
-    expected: FAIL
-
-  [[["stylewithcss","true"\],["fontsize","4"\]\] "foo<span style=\\"font-size: xx-small\\">[bar\]</span>baz": execCommand("fontsize", false, "4") return value]
     expected: FAIL
 
   [[["stylewithcss","true"\],["fontsize","4"\]\] "foo<span style=\\"font-size: xx-small\\">[bar\]</span>baz" compare innerHTML]
@@ -1018,9 +769,6 @@
   [[["stylewithcss","true"\],["fontsize","4"\]\] "foo<span style=\\"font-size: xx-small\\">[bar\]</span>baz" queryCommandValue("fontsize") after]
     expected: FAIL
 
-  [[["stylewithcss","false"\],["fontsize","4"\]\] "foo<span style=\\"font-size: xx-small\\">[bar\]</span>baz": execCommand("fontsize", false, "4") return value]
-    expected: FAIL
-
   [[["stylewithcss","false"\],["fontsize","4"\]\] "foo<span style=\\"font-size: xx-small\\">[bar\]</span>baz" compare innerHTML]
     expected: FAIL
 
@@ -1028,9 +776,6 @@
     expected: FAIL
 
   [[["stylewithcss","false"\],["fontsize","4"\]\] "foo<span style=\\"font-size: xx-small\\">[bar\]</span>baz" queryCommandValue("fontsize") after]
-    expected: FAIL
-
-  [[["stylewithcss","true"\],["fontsize","4"\]\] "<span style=\\"font-size: xx-small\\">foo[bar\]baz</span>": execCommand("fontsize", false, "4") return value]
     expected: FAIL
 
   [[["stylewithcss","true"\],["fontsize","4"\]\] "<span style=\\"font-size: xx-small\\">foo[bar\]baz</span>" compare innerHTML]
@@ -1042,9 +787,6 @@
   [[["stylewithcss","true"\],["fontsize","4"\]\] "<span style=\\"font-size: xx-small\\">foo[bar\]baz</span>" queryCommandValue("fontsize") after]
     expected: FAIL
 
-  [[["stylewithcss","false"\],["fontsize","4"\]\] "<span style=\\"font-size: xx-small\\">foo[bar\]baz</span>": execCommand("fontsize", false, "4") return value]
-    expected: FAIL
-
   [[["stylewithcss","false"\],["fontsize","4"\]\] "<span style=\\"font-size: xx-small\\">foo[bar\]baz</span>" compare innerHTML]
     expected: FAIL
 
@@ -1052,9 +794,6 @@
     expected: FAIL
 
   [[["stylewithcss","false"\],["fontsize","4"\]\] "<span style=\\"font-size: xx-small\\">foo[bar\]baz</span>" queryCommandValue("fontsize") after]
-    expected: FAIL
-
-  [[["stylewithcss","true"\],["fontsize","4"\]\] "foo<span style=\\"font-size: medium\\">[bar\]</span>baz": execCommand("fontsize", false, "4") return value]
     expected: FAIL
 
   [[["stylewithcss","true"\],["fontsize","4"\]\] "foo<span style=\\"font-size: medium\\">[bar\]</span>baz" compare innerHTML]
@@ -1066,9 +805,6 @@
   [[["stylewithcss","true"\],["fontsize","4"\]\] "foo<span style=\\"font-size: medium\\">[bar\]</span>baz" queryCommandValue("fontsize") after]
     expected: FAIL
 
-  [[["stylewithcss","false"\],["fontsize","4"\]\] "foo<span style=\\"font-size: medium\\">[bar\]</span>baz": execCommand("fontsize", false, "4") return value]
-    expected: FAIL
-
   [[["stylewithcss","false"\],["fontsize","4"\]\] "foo<span style=\\"font-size: medium\\">[bar\]</span>baz" compare innerHTML]
     expected: FAIL
 
@@ -1076,9 +812,6 @@
     expected: FAIL
 
   [[["stylewithcss","false"\],["fontsize","4"\]\] "foo<span style=\\"font-size: medium\\">[bar\]</span>baz" queryCommandValue("fontsize") after]
-    expected: FAIL
-
-  [[["stylewithcss","true"\],["fontsize","4"\]\] "<span style=\\"font-size: medium\\">foo[bar\]baz</span>": execCommand("fontsize", false, "4") return value]
     expected: FAIL
 
   [[["stylewithcss","true"\],["fontsize","4"\]\] "<span style=\\"font-size: medium\\">foo[bar\]baz</span>" compare innerHTML]
@@ -1090,9 +823,6 @@
   [[["stylewithcss","true"\],["fontsize","4"\]\] "<span style=\\"font-size: medium\\">foo[bar\]baz</span>" queryCommandValue("fontsize") after]
     expected: FAIL
 
-  [[["stylewithcss","false"\],["fontsize","4"\]\] "<span style=\\"font-size: medium\\">foo[bar\]baz</span>": execCommand("fontsize", false, "4") return value]
-    expected: FAIL
-
   [[["stylewithcss","false"\],["fontsize","4"\]\] "<span style=\\"font-size: medium\\">foo[bar\]baz</span>" compare innerHTML]
     expected: FAIL
 
@@ -1102,16 +832,10 @@
   [[["stylewithcss","false"\],["fontsize","4"\]\] "<span style=\\"font-size: medium\\">foo[bar\]baz</span>" queryCommandValue("fontsize") after]
     expected: FAIL
 
-  [[["stylewithcss","true"\],["fontsize","4"\]\] "foo<span style=\\"font-size: large\\">[bar\]</span>baz": execCommand("fontsize", false, "4") return value]
-    expected: FAIL
-
   [[["stylewithcss","true"\],["fontsize","4"\]\] "foo<span style=\\"font-size: large\\">[bar\]</span>baz" queryCommandValue("fontsize") before]
     expected: FAIL
 
   [[["stylewithcss","true"\],["fontsize","4"\]\] "foo<span style=\\"font-size: large\\">[bar\]</span>baz" queryCommandValue("fontsize") after]
-    expected: FAIL
-
-  [[["stylewithcss","false"\],["fontsize","4"\]\] "foo<span style=\\"font-size: large\\">[bar\]</span>baz": execCommand("fontsize", false, "4") return value]
     expected: FAIL
 
   [[["stylewithcss","false"\],["fontsize","4"\]\] "foo<span style=\\"font-size: large\\">[bar\]</span>baz" compare innerHTML]
@@ -1123,16 +847,10 @@
   [[["stylewithcss","false"\],["fontsize","4"\]\] "foo<span style=\\"font-size: large\\">[bar\]</span>baz" queryCommandValue("fontsize") after]
     expected: FAIL
 
-  [[["fontsize","4"\]\] "<span style=\\"font-size: large\\">foo[bar\]baz</span>": execCommand("fontsize", false, "4") return value]
-    expected: FAIL
-
   [[["fontsize","4"\]\] "<span style=\\"font-size: large\\">foo[bar\]baz</span>" queryCommandValue("fontsize") before]
     expected: FAIL
 
   [[["fontsize","4"\]\] "<span style=\\"font-size: large\\">foo[bar\]baz</span>" queryCommandValue("fontsize") after]
-    expected: FAIL
-
-  [[["stylewithcss","true"\],["fontsize","4"\]\] "<span style=\\"font-size: large\\">foo<span style=\\"font-size: xx-small\\">b[a\]r</span>baz</span>": execCommand("fontsize", false, "4") return value]
     expected: FAIL
 
   [[["stylewithcss","true"\],["fontsize","4"\]\] "<span style=\\"font-size: large\\">foo<span style=\\"font-size: xx-small\\">b[a\]r</span>baz</span>" compare innerHTML]
@@ -1144,9 +862,6 @@
   [[["stylewithcss","true"\],["fontsize","4"\]\] "<span style=\\"font-size: large\\">foo<span style=\\"font-size: xx-small\\">b[a\]r</span>baz</span>" queryCommandValue("fontsize") after]
     expected: FAIL
 
-  [[["stylewithcss","false"\],["fontsize","4"\]\] "<span style=\\"font-size: large\\">foo<span style=\\"font-size: xx-small\\">b[a\]r</span>baz</span>": execCommand("fontsize", false, "4") return value]
-    expected: FAIL
-
   [[["stylewithcss","false"\],["fontsize","4"\]\] "<span style=\\"font-size: large\\">foo<span style=\\"font-size: xx-small\\">b[a\]r</span>baz</span>" compare innerHTML]
     expected: FAIL
 
@@ -1154,9 +869,6 @@
     expected: FAIL
 
   [[["stylewithcss","false"\],["fontsize","4"\]\] "<span style=\\"font-size: large\\">foo<span style=\\"font-size: xx-small\\">b[a\]r</span>baz</span>" queryCommandValue("fontsize") after]
-    expected: FAIL
-
-  [[["stylewithcss","true"\],["fontsize","4"\]\] "foo<span style=\\"font-size: 2em\\">[bar\]</span>baz": execCommand("fontsize", false, "4") return value]
     expected: FAIL
 
   [[["stylewithcss","true"\],["fontsize","4"\]\] "foo<span style=\\"font-size: 2em\\">[bar\]</span>baz" compare innerHTML]
@@ -1168,9 +880,6 @@
   [[["stylewithcss","true"\],["fontsize","4"\]\] "foo<span style=\\"font-size: 2em\\">[bar\]</span>baz" queryCommandValue("fontsize") after]
     expected: FAIL
 
-  [[["stylewithcss","false"\],["fontsize","4"\]\] "foo<span style=\\"font-size: 2em\\">[bar\]</span>baz": execCommand("fontsize", false, "4") return value]
-    expected: FAIL
-
   [[["stylewithcss","false"\],["fontsize","4"\]\] "foo<span style=\\"font-size: 2em\\">[bar\]</span>baz" compare innerHTML]
     expected: FAIL
 
@@ -1178,9 +887,6 @@
     expected: FAIL
 
   [[["stylewithcss","false"\],["fontsize","4"\]\] "foo<span style=\\"font-size: 2em\\">[bar\]</span>baz" queryCommandValue("fontsize") after]
-    expected: FAIL
-
-  [[["stylewithcss","true"\],["fontsize","4"\]\] "<span style=\\"font-size: 2em\\">foo[bar\]baz</span>": execCommand("fontsize", false, "4") return value]
     expected: FAIL
 
   [[["stylewithcss","true"\],["fontsize","4"\]\] "<span style=\\"font-size: 2em\\">foo[bar\]baz</span>" compare innerHTML]
@@ -1192,9 +898,6 @@
   [[["stylewithcss","true"\],["fontsize","4"\]\] "<span style=\\"font-size: 2em\\">foo[bar\]baz</span>" queryCommandValue("fontsize") after]
     expected: FAIL
 
-  [[["stylewithcss","false"\],["fontsize","4"\]\] "<span style=\\"font-size: 2em\\">foo[bar\]baz</span>": execCommand("fontsize", false, "4") return value]
-    expected: FAIL
-
   [[["stylewithcss","false"\],["fontsize","4"\]\] "<span style=\\"font-size: 2em\\">foo[bar\]baz</span>" compare innerHTML]
     expected: FAIL
 
@@ -1202,9 +905,6 @@
     expected: FAIL
 
   [[["stylewithcss","false"\],["fontsize","4"\]\] "<span style=\\"font-size: 2em\\">foo[bar\]baz</span>" queryCommandValue("fontsize") after]
-    expected: FAIL
-
-  [[["stylewithcss","true"\],["fontsize","4"\]\] "<p style=\\"font-size: xx-small\\">foo[bar\]baz</p>": execCommand("fontsize", false, "4") return value]
     expected: FAIL
 
   [[["stylewithcss","true"\],["fontsize","4"\]\] "<p style=\\"font-size: xx-small\\">foo[bar\]baz</p>" compare innerHTML]
@@ -1216,9 +916,6 @@
   [[["stylewithcss","true"\],["fontsize","4"\]\] "<p style=\\"font-size: xx-small\\">foo[bar\]baz</p>" queryCommandValue("fontsize") after]
     expected: FAIL
 
-  [[["stylewithcss","false"\],["fontsize","4"\]\] "<p style=\\"font-size: xx-small\\">foo[bar\]baz</p>": execCommand("fontsize", false, "4") return value]
-    expected: FAIL
-
   [[["stylewithcss","false"\],["fontsize","4"\]\] "<p style=\\"font-size: xx-small\\">foo[bar\]baz</p>" compare innerHTML]
     expected: FAIL
 
@@ -1226,9 +923,6 @@
     expected: FAIL
 
   [[["stylewithcss","false"\],["fontsize","4"\]\] "<p style=\\"font-size: xx-small\\">foo[bar\]baz</p>" queryCommandValue("fontsize") after]
-    expected: FAIL
-
-  [[["stylewithcss","true"\],["fontsize","4"\]\] "<p style=\\"font-size: medium\\">foo[bar\]baz</p>": execCommand("fontsize", false, "4") return value]
     expected: FAIL
 
   [[["stylewithcss","true"\],["fontsize","4"\]\] "<p style=\\"font-size: medium\\">foo[bar\]baz</p>" compare innerHTML]
@@ -1240,9 +934,6 @@
   [[["stylewithcss","true"\],["fontsize","4"\]\] "<p style=\\"font-size: medium\\">foo[bar\]baz</p>" queryCommandValue("fontsize") after]
     expected: FAIL
 
-  [[["stylewithcss","false"\],["fontsize","4"\]\] "<p style=\\"font-size: medium\\">foo[bar\]baz</p>": execCommand("fontsize", false, "4") return value]
-    expected: FAIL
-
   [[["stylewithcss","false"\],["fontsize","4"\]\] "<p style=\\"font-size: medium\\">foo[bar\]baz</p>" compare innerHTML]
     expected: FAIL
 
@@ -1252,16 +943,10 @@
   [[["stylewithcss","false"\],["fontsize","4"\]\] "<p style=\\"font-size: medium\\">foo[bar\]baz</p>" queryCommandValue("fontsize") after]
     expected: FAIL
 
-  [[["fontsize","4"\]\] "<p style=\\"font-size: large\\">foo[bar\]baz</p>": execCommand("fontsize", false, "4") return value]
-    expected: FAIL
-
   [[["fontsize","4"\]\] "<p style=\\"font-size: large\\">foo[bar\]baz</p>" queryCommandValue("fontsize") before]
     expected: FAIL
 
   [[["fontsize","4"\]\] "<p style=\\"font-size: large\\">foo[bar\]baz</p>" queryCommandValue("fontsize") after]
-    expected: FAIL
-
-  [[["stylewithcss","true"\],["fontsize","4"\]\] "<p style=\\"font-size: 2em\\">foo[bar\]baz</p>": execCommand("fontsize", false, "4") return value]
     expected: FAIL
 
   [[["stylewithcss","true"\],["fontsize","4"\]\] "<p style=\\"font-size: 2em\\">foo[bar\]baz</p>" compare innerHTML]
@@ -1273,9 +958,6 @@
   [[["stylewithcss","true"\],["fontsize","4"\]\] "<p style=\\"font-size: 2em\\">foo[bar\]baz</p>" queryCommandValue("fontsize") after]
     expected: FAIL
 
-  [[["stylewithcss","false"\],["fontsize","4"\]\] "<p style=\\"font-size: 2em\\">foo[bar\]baz</p>": execCommand("fontsize", false, "4") return value]
-    expected: FAIL
-
   [[["stylewithcss","false"\],["fontsize","4"\]\] "<p style=\\"font-size: 2em\\">foo[bar\]baz</p>" compare innerHTML]
     expected: FAIL
 
@@ -1283,9 +965,6 @@
     expected: FAIL
 
   [[["stylewithcss","false"\],["fontsize","4"\]\] "<p style=\\"font-size: 2em\\">foo[bar\]baz</p>" queryCommandValue("fontsize") after]
-    expected: FAIL
-
-  [[["stylewithcss","true"\],["fontsize","3"\]\] "<p style=\\"font-size: xx-small\\">foo[bar\]baz</p>": execCommand("fontsize", false, "3") return value]
     expected: FAIL
 
   [[["stylewithcss","true"\],["fontsize","3"\]\] "<p style=\\"font-size: xx-small\\">foo[bar\]baz</p>" compare innerHTML]
@@ -1297,9 +976,6 @@
   [[["stylewithcss","true"\],["fontsize","3"\]\] "<p style=\\"font-size: xx-small\\">foo[bar\]baz</p>" queryCommandValue("fontsize") after]
     expected: FAIL
 
-  [[["stylewithcss","false"\],["fontsize","3"\]\] "<p style=\\"font-size: xx-small\\">foo[bar\]baz</p>": execCommand("fontsize", false, "3") return value]
-    expected: FAIL
-
   [[["stylewithcss","false"\],["fontsize","3"\]\] "<p style=\\"font-size: xx-small\\">foo[bar\]baz</p>" compare innerHTML]
     expected: FAIL
 
@@ -1309,16 +985,10 @@
   [[["stylewithcss","false"\],["fontsize","3"\]\] "<p style=\\"font-size: xx-small\\">foo[bar\]baz</p>" queryCommandValue("fontsize") after]
     expected: FAIL
 
-  [[["fontsize","3"\]\] "<p style=\\"font-size: medium\\">foo[bar\]baz</p>": execCommand("fontsize", false, "3") return value]
-    expected: FAIL
-
   [[["fontsize","3"\]\] "<p style=\\"font-size: medium\\">foo[bar\]baz</p>" queryCommandValue("fontsize") before]
     expected: FAIL
 
   [[["fontsize","3"\]\] "<p style=\\"font-size: medium\\">foo[bar\]baz</p>" queryCommandValue("fontsize") after]
-    expected: FAIL
-
-  [[["stylewithcss","true"\],["fontsize","3"\]\] "<p style=\\"font-size: large\\">foo[bar\]baz</p>": execCommand("fontsize", false, "3") return value]
     expected: FAIL
 
   [[["stylewithcss","true"\],["fontsize","3"\]\] "<p style=\\"font-size: large\\">foo[bar\]baz</p>" compare innerHTML]
@@ -1330,9 +1000,6 @@
   [[["stylewithcss","true"\],["fontsize","3"\]\] "<p style=\\"font-size: large\\">foo[bar\]baz</p>" queryCommandValue("fontsize") after]
     expected: FAIL
 
-  [[["stylewithcss","false"\],["fontsize","3"\]\] "<p style=\\"font-size: large\\">foo[bar\]baz</p>": execCommand("fontsize", false, "3") return value]
-    expected: FAIL
-
   [[["stylewithcss","false"\],["fontsize","3"\]\] "<p style=\\"font-size: large\\">foo[bar\]baz</p>" compare innerHTML]
     expected: FAIL
 
@@ -1340,9 +1007,6 @@
     expected: FAIL
 
   [[["stylewithcss","false"\],["fontsize","3"\]\] "<p style=\\"font-size: large\\">foo[bar\]baz</p>" queryCommandValue("fontsize") after]
-    expected: FAIL
-
-  [[["stylewithcss","true"\],["fontsize","3"\]\] "<p style=\\"font-size: 2em\\">foo[bar\]baz</p>": execCommand("fontsize", false, "3") return value]
     expected: FAIL
 
   [[["stylewithcss","true"\],["fontsize","3"\]\] "<p style=\\"font-size: 2em\\">foo[bar\]baz</p>" compare innerHTML]
@@ -1354,9 +1018,6 @@
   [[["stylewithcss","true"\],["fontsize","3"\]\] "<p style=\\"font-size: 2em\\">foo[bar\]baz</p>" queryCommandValue("fontsize") after]
     expected: FAIL
 
-  [[["stylewithcss","false"\],["fontsize","3"\]\] "<p style=\\"font-size: 2em\\">foo[bar\]baz</p>": execCommand("fontsize", false, "3") return value]
-    expected: FAIL
-
   [[["stylewithcss","false"\],["fontsize","3"\]\] "<p style=\\"font-size: 2em\\">foo[bar\]baz</p>" compare innerHTML]
     expected: FAIL
 
@@ -1364,9 +1025,6 @@
     expected: FAIL
 
   [[["stylewithcss","false"\],["fontsize","3"\]\] "<p style=\\"font-size: 2em\\">foo[bar\]baz</p>" queryCommandValue("fontsize") after]
-    expected: FAIL
-
-  [[["stylewithcss","true"\],["fontsize","3"\]\] "<font size=6>foo <span style=\\"font-size: 2em\\">b[a\]r</span> baz</font>": execCommand("fontsize", false, "3") return value]
     expected: FAIL
 
   [[["stylewithcss","true"\],["fontsize","3"\]\] "<font size=6>foo <span style=\\"font-size: 2em\\">b[a\]r</span> baz</font>" compare innerHTML]
@@ -1378,9 +1036,6 @@
   [[["stylewithcss","true"\],["fontsize","3"\]\] "<font size=6>foo <span style=\\"font-size: 2em\\">b[a\]r</span> baz</font>" queryCommandValue("fontsize") after]
     expected: FAIL
 
-  [[["stylewithcss","false"\],["fontsize","3"\]\] "<font size=6>foo <span style=\\"font-size: 2em\\">b[a\]r</span> baz</font>": execCommand("fontsize", false, "3") return value]
-    expected: FAIL
-
   [[["stylewithcss","false"\],["fontsize","3"\]\] "<font size=6>foo <span style=\\"font-size: 2em\\">b[a\]r</span> baz</font>" compare innerHTML]
     expected: FAIL
 
@@ -1388,9 +1043,6 @@
     expected: FAIL
 
   [[["stylewithcss","false"\],["fontsize","3"\]\] "<font size=6>foo <span style=\\"font-size: 2em\\">b[a\]r</span> baz</font>" queryCommandValue("fontsize") after]
-    expected: FAIL
-
-  [[["stylewithcss","true"\],["fontsize","3"\]\] "foo<big>[bar\]</big>baz": execCommand("fontsize", false, "3") return value]
     expected: FAIL
 
   [[["stylewithcss","true"\],["fontsize","3"\]\] "foo<big>[bar\]</big>baz" compare innerHTML]
@@ -1402,9 +1054,6 @@
   [[["stylewithcss","true"\],["fontsize","3"\]\] "foo<big>[bar\]</big>baz" queryCommandValue("fontsize") after]
     expected: FAIL
 
-  [[["stylewithcss","false"\],["fontsize","3"\]\] "foo<big>[bar\]</big>baz": execCommand("fontsize", false, "3") return value]
-    expected: FAIL
-
   [[["stylewithcss","false"\],["fontsize","3"\]\] "foo<big>[bar\]</big>baz" compare innerHTML]
     expected: FAIL
 
@@ -1412,9 +1061,6 @@
     expected: FAIL
 
   [[["stylewithcss","false"\],["fontsize","3"\]\] "foo<big>[bar\]</big>baz" queryCommandValue("fontsize") after]
-    expected: FAIL
-
-  [[["stylewithcss","true"\],["fontsize","3"\]\] "foo<big>b[a\]r</big>baz": execCommand("fontsize", false, "3") return value]
     expected: FAIL
 
   [[["stylewithcss","true"\],["fontsize","3"\]\] "foo<big>b[a\]r</big>baz" compare innerHTML]
@@ -1426,9 +1072,6 @@
   [[["stylewithcss","true"\],["fontsize","3"\]\] "foo<big>b[a\]r</big>baz" queryCommandValue("fontsize") after]
     expected: FAIL
 
-  [[["stylewithcss","false"\],["fontsize","3"\]\] "foo<big>b[a\]r</big>baz": execCommand("fontsize", false, "3") return value]
-    expected: FAIL
-
   [[["stylewithcss","false"\],["fontsize","3"\]\] "foo<big>b[a\]r</big>baz" compare innerHTML]
     expected: FAIL
 
@@ -1436,9 +1079,6 @@
     expected: FAIL
 
   [[["stylewithcss","false"\],["fontsize","3"\]\] "foo<big>b[a\]r</big>baz" queryCommandValue("fontsize") after]
-    expected: FAIL
-
-  [[["stylewithcss","true"\],["fontsize","3"\]\] "foo<small>[bar\]</small>baz": execCommand("fontsize", false, "3") return value]
     expected: FAIL
 
   [[["stylewithcss","true"\],["fontsize","3"\]\] "foo<small>[bar\]</small>baz" compare innerHTML]
@@ -1450,9 +1090,6 @@
   [[["stylewithcss","true"\],["fontsize","3"\]\] "foo<small>[bar\]</small>baz" queryCommandValue("fontsize") after]
     expected: FAIL
 
-  [[["stylewithcss","false"\],["fontsize","3"\]\] "foo<small>[bar\]</small>baz": execCommand("fontsize", false, "3") return value]
-    expected: FAIL
-
   [[["stylewithcss","false"\],["fontsize","3"\]\] "foo<small>[bar\]</small>baz" compare innerHTML]
     expected: FAIL
 
@@ -1460,9 +1097,6 @@
     expected: FAIL
 
   [[["stylewithcss","false"\],["fontsize","3"\]\] "foo<small>[bar\]</small>baz" queryCommandValue("fontsize") after]
-    expected: FAIL
-
-  [[["stylewithcss","true"\],["fontsize","3"\]\] "foo<small>b[a\]r</small>baz": execCommand("fontsize", false, "3") return value]
     expected: FAIL
 
   [[["stylewithcss","true"\],["fontsize","3"\]\] "foo<small>b[a\]r</small>baz" compare innerHTML]
@@ -1474,9 +1108,6 @@
   [[["stylewithcss","true"\],["fontsize","3"\]\] "foo<small>b[a\]r</small>baz" queryCommandValue("fontsize") after]
     expected: FAIL
 
-  [[["stylewithcss","false"\],["fontsize","3"\]\] "foo<small>b[a\]r</small>baz": execCommand("fontsize", false, "3") return value]
-    expected: FAIL
-
   [[["stylewithcss","false"\],["fontsize","3"\]\] "foo<small>b[a\]r</small>baz" compare innerHTML]
     expected: FAIL
 
@@ -1484,9 +1115,6 @@
     expected: FAIL
 
   [[["stylewithcss","false"\],["fontsize","3"\]\] "foo<small>b[a\]r</small>baz" queryCommandValue("fontsize") after]
-    expected: FAIL
-
-  [[["stylewithcss","true"\],["fontsize","4"\]\] "fo[o<font size=2>b\]ar</font>baz": execCommand("fontsize", false, "4") return value]
     expected: FAIL
 
   [[["stylewithcss","true"\],["fontsize","4"\]\] "fo[o<font size=2>b\]ar</font>baz" compare innerHTML]
@@ -1501,9 +1129,6 @@
   [[["stylewithcss","true"\],["fontsize","4"\]\] "fo[o<font size=2>b\]ar</font>baz" queryCommandValue("fontsize") after]
     expected: FAIL
 
-  [[["stylewithcss","false"\],["fontsize","4"\]\] "fo[o<font size=2>b\]ar</font>baz": execCommand("fontsize", false, "4") return value]
-    expected: FAIL
-
   [[["stylewithcss","false"\],["fontsize","4"\]\] "fo[o<font size=2>b\]ar</font>baz" compare innerHTML]
     expected: FAIL
 
@@ -1516,9 +1141,6 @@
   [[["stylewithcss","false"\],["fontsize","4"\]\] "fo[o<font size=2>b\]ar</font>baz" queryCommandValue("fontsize") after]
     expected: FAIL
 
-  [[["stylewithcss","true"\],["fontsize","4"\]\] "foo<font size=2>ba[r</font>b\]az": execCommand("fontsize", false, "4") return value]
-    expected: FAIL
-
   [[["stylewithcss","true"\],["fontsize","4"\]\] "foo<font size=2>ba[r</font>b\]az" compare innerHTML]
     expected: FAIL
 
@@ -1529,9 +1151,6 @@
     expected: FAIL
 
   [[["stylewithcss","true"\],["fontsize","4"\]\] "foo<font size=2>ba[r</font>b\]az" queryCommandValue("fontsize") after]
-    expected: FAIL
-
-  [[["stylewithcss","false"\],["fontsize","4"\]\] "foo<font size=2>ba[r</font>b\]az": execCommand("fontsize", false, "4") return value]
     expected: FAIL
 
   [[["stylewithcss","false"\],["fontsize","4"\]\] "foo<font size=2>ba[r</font>b\]az" compare innerHTML]
@@ -1551,9 +1170,6 @@
   [[["stylewithcss","false"\],["fontsize","4"\]\] "foo<font size=2>ba[r</font>b\]az" queryCommandValue("fontsize") after]
     expected: FAIL
 
-  [[["stylewithcss","true"\],["fontsize","4"\]\] "fo[o<font size=2>bar</font>b\]az": execCommand("fontsize", false, "4") return value]
-    expected: FAIL
-
   [[["stylewithcss","true"\],["fontsize","4"\]\] "fo[o<font size=2>bar</font>b\]az" compare innerHTML]
     expected: FAIL
 
@@ -1564,9 +1180,6 @@
     expected: FAIL
 
   [[["stylewithcss","true"\],["fontsize","4"\]\] "fo[o<font size=2>bar</font>b\]az" queryCommandValue("fontsize") after]
-    expected: FAIL
-
-  [[["stylewithcss","false"\],["fontsize","4"\]\] "fo[o<font size=2>bar</font>b\]az": execCommand("fontsize", false, "4") return value]
     expected: FAIL
 
   [[["stylewithcss","false"\],["fontsize","4"\]\] "fo[o<font size=2>bar</font>b\]az" compare innerHTML]
@@ -1581,9 +1194,6 @@
   [[["stylewithcss","false"\],["fontsize","4"\]\] "fo[o<font size=2>bar</font>b\]az" queryCommandValue("fontsize") after]
     expected: FAIL
 
-  [[["stylewithcss","true"\],["fontsize","4"\]\] "foo[<font size=2>b\]ar</font>baz": execCommand("fontsize", false, "4") return value]
-    expected: FAIL
-
   [[["stylewithcss","true"\],["fontsize","4"\]\] "foo[<font size=2>b\]ar</font>baz" compare innerHTML]
     expected: FAIL
 
@@ -1591,9 +1201,6 @@
     expected: FAIL
 
   [[["stylewithcss","true"\],["fontsize","4"\]\] "foo[<font size=2>b\]ar</font>baz" queryCommandValue("fontsize") after]
-    expected: FAIL
-
-  [[["stylewithcss","false"\],["fontsize","4"\]\] "foo[<font size=2>b\]ar</font>baz": execCommand("fontsize", false, "4") return value]
     expected: FAIL
 
   [[["stylewithcss","false"\],["fontsize","4"\]\] "foo[<font size=2>b\]ar</font>baz" compare innerHTML]
@@ -1605,9 +1212,6 @@
   [[["stylewithcss","false"\],["fontsize","4"\]\] "foo[<font size=2>b\]ar</font>baz" queryCommandValue("fontsize") after]
     expected: FAIL
 
-  [[["stylewithcss","true"\],["fontsize","4"\]\] "foo<font size=2>ba[r</font>\]baz": execCommand("fontsize", false, "4") return value]
-    expected: FAIL
-
   [[["stylewithcss","true"\],["fontsize","4"\]\] "foo<font size=2>ba[r</font>\]baz" compare innerHTML]
     expected: FAIL
 
@@ -1615,9 +1219,6 @@
     expected: FAIL
 
   [[["stylewithcss","true"\],["fontsize","4"\]\] "foo<font size=2>ba[r</font>\]baz" queryCommandValue("fontsize") after]
-    expected: FAIL
-
-  [[["stylewithcss","false"\],["fontsize","4"\]\] "foo<font size=2>ba[r</font>\]baz": execCommand("fontsize", false, "4") return value]
     expected: FAIL
 
   [[["stylewithcss","false"\],["fontsize","4"\]\] "foo<font size=2>ba[r</font>\]baz" compare innerHTML]
@@ -1629,9 +1230,6 @@
   [[["stylewithcss","false"\],["fontsize","4"\]\] "foo<font size=2>ba[r</font>\]baz" queryCommandValue("fontsize") after]
     expected: FAIL
 
-  [[["stylewithcss","true"\],["fontsize","4"\]\] "foo[<font size=2>bar</font>\]baz": execCommand("fontsize", false, "4") return value]
-    expected: FAIL
-
   [[["stylewithcss","true"\],["fontsize","4"\]\] "foo[<font size=2>bar</font>\]baz" compare innerHTML]
     expected: FAIL
 
@@ -1639,9 +1237,6 @@
     expected: FAIL
 
   [[["stylewithcss","true"\],["fontsize","4"\]\] "foo[<font size=2>bar</font>\]baz" queryCommandValue("fontsize") after]
-    expected: FAIL
-
-  [[["stylewithcss","false"\],["fontsize","4"\]\] "foo[<font size=2>bar</font>\]baz": execCommand("fontsize", false, "4") return value]
     expected: FAIL
 
   [[["stylewithcss","false"\],["fontsize","4"\]\] "foo[<font size=2>bar</font>\]baz" compare innerHTML]
@@ -1653,9 +1248,6 @@
   [[["stylewithcss","false"\],["fontsize","4"\]\] "foo[<font size=2>bar</font>\]baz" queryCommandValue("fontsize") after]
     expected: FAIL
 
-  [[["stylewithcss","true"\],["fontsize","4"\]\] "foo<font size=2>[bar\]</font>baz": execCommand("fontsize", false, "4") return value]
-    expected: FAIL
-
   [[["stylewithcss","true"\],["fontsize","4"\]\] "foo<font size=2>[bar\]</font>baz" compare innerHTML]
     expected: FAIL
 
@@ -1663,9 +1255,6 @@
     expected: FAIL
 
   [[["stylewithcss","true"\],["fontsize","4"\]\] "foo<font size=2>[bar\]</font>baz" queryCommandValue("fontsize") after]
-    expected: FAIL
-
-  [[["stylewithcss","false"\],["fontsize","4"\]\] "foo<font size=2>[bar\]</font>baz": execCommand("fontsize", false, "4") return value]
     expected: FAIL
 
   [[["stylewithcss","false"\],["fontsize","4"\]\] "foo<font size=2>[bar\]</font>baz" compare innerHTML]
@@ -1677,9 +1266,6 @@
   [[["stylewithcss","false"\],["fontsize","4"\]\] "foo<font size=2>[bar\]</font>baz" queryCommandValue("fontsize") after]
     expected: FAIL
 
-  [[["stylewithcss","true"\],["fontsize","4"\]\] "foo{<font size=2>bar</font>}baz": execCommand("fontsize", false, "4") return value]
-    expected: FAIL
-
   [[["stylewithcss","true"\],["fontsize","4"\]\] "foo{<font size=2>bar</font>}baz" compare innerHTML]
     expected: FAIL
 
@@ -1689,9 +1275,6 @@
   [[["stylewithcss","true"\],["fontsize","4"\]\] "foo{<font size=2>bar</font>}baz" queryCommandValue("fontsize") after]
     expected: FAIL
 
-  [[["stylewithcss","false"\],["fontsize","4"\]\] "foo{<font size=2>bar</font>}baz": execCommand("fontsize", false, "4") return value]
-    expected: FAIL
-
   [[["stylewithcss","false"\],["fontsize","4"\]\] "foo{<font size=2>bar</font>}baz" compare innerHTML]
     expected: FAIL
 
@@ -1699,9 +1282,6 @@
     expected: FAIL
 
   [[["stylewithcss","false"\],["fontsize","4"\]\] "foo{<font size=2>bar</font>}baz" queryCommandValue("fontsize") after]
-    expected: FAIL
-
-  [[["stylewithcss","true"\],["fontsize","4"\]\] "<font size=1>fo[o</font><span style=font-size:xx-small>b\]ar</span>": execCommand("fontsize", false, "4") return value]
     expected: FAIL
 
   [[["stylewithcss","true"\],["fontsize","4"\]\] "<font size=1>fo[o</font><span style=font-size:xx-small>b\]ar</span>" compare innerHTML]
@@ -1716,9 +1296,6 @@
   [[["stylewithcss","true"\],["fontsize","4"\]\] "<font size=1>fo[o</font><span style=font-size:xx-small>b\]ar</span>" queryCommandValue("fontsize") after]
     expected: FAIL
 
-  [[["stylewithcss","false"\],["fontsize","4"\]\] "<font size=1>fo[o</font><span style=font-size:xx-small>b\]ar</span>": execCommand("fontsize", false, "4") return value]
-    expected: FAIL
-
   [[["stylewithcss","false"\],["fontsize","4"\]\] "<font size=1>fo[o</font><span style=font-size:xx-small>b\]ar</span>" compare innerHTML]
     expected: FAIL
 
@@ -1731,9 +1308,6 @@
   [[["stylewithcss","false"\],["fontsize","4"\]\] "<font size=1>fo[o</font><span style=font-size:xx-small>b\]ar</span>" queryCommandValue("fontsize") after]
     expected: FAIL
 
-  [[["stylewithcss","true"\],["fontsize","4"\]\] "<font size=2>fo[o</font><span style=font-size:small>b\]ar</span>": execCommand("fontsize", false, "4") return value]
-    expected: FAIL
-
   [[["stylewithcss","true"\],["fontsize","4"\]\] "<font size=2>fo[o</font><span style=font-size:small>b\]ar</span>" compare innerHTML]
     expected: FAIL
 
@@ -1741,9 +1315,6 @@
     expected: FAIL
 
   [[["stylewithcss","true"\],["fontsize","4"\]\] "<font size=2>fo[o</font><span style=font-size:small>b\]ar</span>" queryCommandValue("fontsize") after]
-    expected: FAIL
-
-  [[["stylewithcss","false"\],["fontsize","4"\]\] "<font size=2>fo[o</font><span style=font-size:small>b\]ar</span>": execCommand("fontsize", false, "4") return value]
     expected: FAIL
 
   [[["stylewithcss","false"\],["fontsize","4"\]\] "<font size=2>fo[o</font><span style=font-size:small>b\]ar</span>" compare innerHTML]
@@ -1755,9 +1326,6 @@
   [[["stylewithcss","false"\],["fontsize","4"\]\] "<font size=2>fo[o</font><span style=font-size:small>b\]ar</span>" queryCommandValue("fontsize") after]
     expected: FAIL
 
-  [[["stylewithcss","true"\],["fontsize","4"\]\] "<font size=3>fo[o</font><span style=font-size:medium>b\]ar</span>": execCommand("fontsize", false, "4") return value]
-    expected: FAIL
-
   [[["stylewithcss","true"\],["fontsize","4"\]\] "<font size=3>fo[o</font><span style=font-size:medium>b\]ar</span>" compare innerHTML]
     expected: FAIL
 
@@ -1765,9 +1333,6 @@
     expected: FAIL
 
   [[["stylewithcss","true"\],["fontsize","4"\]\] "<font size=3>fo[o</font><span style=font-size:medium>b\]ar</span>" queryCommandValue("fontsize") after]
-    expected: FAIL
-
-  [[["stylewithcss","false"\],["fontsize","4"\]\] "<font size=3>fo[o</font><span style=font-size:medium>b\]ar</span>": execCommand("fontsize", false, "4") return value]
     expected: FAIL
 
   [[["stylewithcss","false"\],["fontsize","4"\]\] "<font size=3>fo[o</font><span style=font-size:medium>b\]ar</span>" compare innerHTML]
@@ -1779,16 +1344,10 @@
   [[["stylewithcss","false"\],["fontsize","4"\]\] "<font size=3>fo[o</font><span style=font-size:medium>b\]ar</span>" queryCommandValue("fontsize") after]
     expected: FAIL
 
-  [[["fontsize","4"\]\] "<font size=4>fo[o</font><span style=font-size:large>b\]ar</span>": execCommand("fontsize", false, "4") return value]
-    expected: FAIL
-
   [[["fontsize","4"\]\] "<font size=4>fo[o</font><span style=font-size:large>b\]ar</span>" queryCommandValue("fontsize") before]
     expected: FAIL
 
   [[["fontsize","4"\]\] "<font size=4>fo[o</font><span style=font-size:large>b\]ar</span>" queryCommandValue("fontsize") after]
-    expected: FAIL
-
-  [[["stylewithcss","true"\],["fontsize","4"\]\] "<font size=5>fo[o</font><span style=font-size:x-large>b\]ar</span>": execCommand("fontsize", false, "4") return value]
     expected: FAIL
 
   [[["stylewithcss","true"\],["fontsize","4"\]\] "<font size=5>fo[o</font><span style=font-size:x-large>b\]ar</span>" compare innerHTML]
@@ -1800,9 +1359,6 @@
   [[["stylewithcss","true"\],["fontsize","4"\]\] "<font size=5>fo[o</font><span style=font-size:x-large>b\]ar</span>" queryCommandValue("fontsize") after]
     expected: FAIL
 
-  [[["stylewithcss","false"\],["fontsize","4"\]\] "<font size=5>fo[o</font><span style=font-size:x-large>b\]ar</span>": execCommand("fontsize", false, "4") return value]
-    expected: FAIL
-
   [[["stylewithcss","false"\],["fontsize","4"\]\] "<font size=5>fo[o</font><span style=font-size:x-large>b\]ar</span>" compare innerHTML]
     expected: FAIL
 
@@ -1810,9 +1366,6 @@
     expected: FAIL
 
   [[["stylewithcss","false"\],["fontsize","4"\]\] "<font size=5>fo[o</font><span style=font-size:x-large>b\]ar</span>" queryCommandValue("fontsize") after]
-    expected: FAIL
-
-  [[["stylewithcss","true"\],["fontsize","4"\]\] "<font size=6>fo[o</font><span style=font-size:xx-large>b\]ar</span>": execCommand("fontsize", false, "4") return value]
     expected: FAIL
 
   [[["stylewithcss","true"\],["fontsize","4"\]\] "<font size=6>fo[o</font><span style=font-size:xx-large>b\]ar</span>" compare innerHTML]
@@ -1824,9 +1377,6 @@
   [[["stylewithcss","true"\],["fontsize","4"\]\] "<font size=6>fo[o</font><span style=font-size:xx-large>b\]ar</span>" queryCommandValue("fontsize") after]
     expected: FAIL
 
-  [[["stylewithcss","false"\],["fontsize","4"\]\] "<font size=6>fo[o</font><span style=font-size:xx-large>b\]ar</span>": execCommand("fontsize", false, "4") return value]
-    expected: FAIL
-
   [[["stylewithcss","false"\],["fontsize","4"\]\] "<font size=6>fo[o</font><span style=font-size:xx-large>b\]ar</span>" compare innerHTML]
     expected: FAIL
 
@@ -1836,79 +1386,40 @@
   [[["stylewithcss","false"\],["fontsize","4"\]\] "<font size=6>fo[o</font><span style=font-size:xx-large>b\]ar</span>" queryCommandValue("fontsize") after]
     expected: FAIL
 
-  [[["styleWithCSS","false"\],["fontSize","7"\]\] "<font color=#ff0000>[abc\]</font>": execCommand("fontSize", false, "7") return value]
-    expected: FAIL
-
   [[["styleWithCSS","false"\],["fontSize","7"\]\] "<font color=#ff0000>[abc\]</font>" compare innerHTML]
-    expected: FAIL
-
-  [[["styleWithCSS","false"\],["fontSize","7"\]\] "<font face=monospace>[abc\]</font>": execCommand("fontSize", false, "7") return value]
     expected: FAIL
 
   [[["styleWithCSS","false"\],["fontSize","7"\]\] "<font face=monospace>[abc\]</font>" compare innerHTML]
     expected: FAIL
 
-  [[["styleWithCSS","false"\],["fontSize","7"\]\] "<font color=#ff0000 face=monospace>[abc\]</font>": execCommand("fontSize", false, "7") return value]
-    expected: FAIL
-
   [[["styleWithCSS","false"\],["fontSize","7"\]\] "<font color=#ff0000 face=monospace>[abc\]</font>" compare innerHTML]
-    expected: FAIL
-
-  [[["styleWithCSS","false"\],["fontSize","7"\]\] "<font color=#ff0000>[a\]bc</font>": execCommand("fontSize", false, "7") return value]
     expected: FAIL
 
   [[["styleWithCSS","false"\],["fontSize","7"\]\] "<font color=#ff0000>[a\]bc</font>" compare innerHTML]
     expected: FAIL
 
-  [[["styleWithCSS","false"\],["fontSize","7"\]\] "<font color=#ff0000>ab[c\]</font>": execCommand("fontSize", false, "7") return value]
-    expected: FAIL
-
   [[["styleWithCSS","false"\],["fontSize","7"\]\] "<font color=#ff0000>ab[c\]</font>" compare innerHTML]
-    expected: FAIL
-
-  [[["styleWithCSS","false"\],["fontSize","7"\]\] "<font face=monospace>[a\]bc</font>": execCommand("fontSize", false, "7") return value]
     expected: FAIL
 
   [[["styleWithCSS","false"\],["fontSize","7"\]\] "<font face=monospace>[a\]bc</font>" compare innerHTML]
     expected: FAIL
 
-  [[["styleWithCSS","false"\],["fontSize","7"\]\] "<font face=monospace>ab[c\]</font>": execCommand("fontSize", false, "7") return value]
-    expected: FAIL
-
   [[["styleWithCSS","false"\],["fontSize","7"\]\] "<font face=monospace>ab[c\]</font>" compare innerHTML]
-    expected: FAIL
-
-  [[["styleWithCSS","false"\],["fontSize","5"\]\] "<span style=\\"font-size:32px; background-color:rgb(0, 128, 128)\\">[abc\]</span>": execCommand("fontSize", false, "5") return value]
     expected: FAIL
 
   [[["styleWithCSS","false"\],["fontSize","5"\]\] "<span style=\\"font-size:32px; background-color:rgb(0, 128, 128)\\">[abc\]</span>" compare innerHTML]
     expected: FAIL
 
-  [[["styleWithCSS","false"\],["fontSize","5"\]\] "<span style=\\"font-size:32px; background-color:rgb(0, 128, 128)\\">[a\]bc</span>": execCommand("fontSize", false, "5") return value]
-    expected: FAIL
-
   [[["styleWithCSS","false"\],["fontSize","5"\]\] "<span style=\\"font-size:32px; background-color:rgb(0, 128, 128)\\">[a\]bc</span>" compare innerHTML]
-    expected: FAIL
-
-  [[["styleWithCSS","false"\],["fontSize","5"\]\] "<span style=\\"font-size:32px; background-color:rgb(0, 128, 128)\\">a[b\]c</span>": execCommand("fontSize", false, "5") return value]
     expected: FAIL
 
   [[["styleWithCSS","false"\],["fontSize","5"\]\] "<span style=\\"font-size:32px; background-color:rgb(0, 128, 128)\\">a[b\]c</span>" compare innerHTML]
     expected: FAIL
 
-  [[["styleWithCSS","false"\],["fontSize","5"\]\] "<span style=\\"font-size:32px; background-color:rgb(0, 128, 128)\\">ab[c\]</span>": execCommand("fontSize", false, "5") return value]
-    expected: FAIL
-
   [[["styleWithCSS","false"\],["fontSize","5"\]\] "<span style=\\"font-size:32px; background-color:rgb(0, 128, 128)\\">ab[c\]</span>" compare innerHTML]
     expected: FAIL
 
-  [[["styleWithCSS","false"\],["fontSize","5"\]\] "<p><span style=\\"font-size:32px; background-color:rgb(0, 128, 128)\\">[abc</span></p><p><span style=\\"font-size:64px; background-color:rgb(128, 128, 0)\\">def\]</span></p>": execCommand("fontSize", false, "5") return value]
-    expected: FAIL
-
   [[["styleWithCSS","false"\],["fontSize","5"\]\] "<p><span style=\\"font-size:32px; background-color:rgb(0, 128, 128)\\">[abc</span></p><p><span style=\\"font-size:64px; background-color:rgb(128, 128, 0)\\">def\]</span></p>" compare innerHTML]
-    expected: FAIL
-
-  [[["stylewithcss","false"\],["fontsize","5"\]\] "{ <span contenteditable=\\"false\\">A</span> ; <span contenteditable=\\"false\\">B</span> ; <span contenteditable=\\"false\\">C</span> }": execCommand("fontsize", false, "5") return value]
     expected: FAIL
 
   [[["stylewithcss","false"\],["fontsize","5"\]\] "{ <span contenteditable=\\"false\\">A</span> ; <span contenteditable=\\"false\\">B</span> ; <span contenteditable=\\"false\\">C</span> }" compare innerHTML]

--- a/tests/wpt/meta/editing/run/multitest.html.ini
+++ b/tests/wpt/meta/editing/run/multitest.html.ini
@@ -2495,9 +2495,6 @@
 
 
 [multitest.html?6001-7000]
-  [[["fontsize","4"\],["insertimage","/img/lion.svg"\]\] "foo[\]bar": execCommand("fontsize", false, "4") return value]
-    expected: FAIL
-
   [[["fontsize","4"\],["insertimage","/img/lion.svg"\]\] "foo[\]bar": execCommand("insertimage", false, "/img/lion.svg") return value]
     expected: FAIL
 
@@ -2508,9 +2505,6 @@
     expected: FAIL
 
   [[["fontsize","4"\],["insertimage","/img/lion.svg"\]\] "foo[\]bar" queryCommandValue("fontsize") after]
-    expected: FAIL
-
-  [[["fontsize","4"\],["insertimage","/img/lion.svg"\],["inserttext","a"\]\] "foo[\]bar": execCommand("fontsize", false, "4") return value]
     expected: FAIL
 
   [[["fontsize","4"\],["insertimage","/img/lion.svg"\],["inserttext","a"\]\] "foo[\]bar": execCommand("insertimage", false, "/img/lion.svg") return value]
@@ -2528,9 +2522,6 @@
   [[["fontsize","4"\],["insertimage","/img/lion.svg"\],["inserttext","a"\]\] "foo[\]bar" queryCommandValue("fontsize") after]
     expected: FAIL
 
-  [[["fontsize","4"\],["insertlinebreak",""\]\] "foo[\]bar": execCommand("fontsize", false, "4") return value]
-    expected: FAIL
-
   [[["fontsize","4"\],["insertlinebreak",""\]\] "foo[\]bar": execCommand("insertlinebreak", false, "") return value]
     expected: FAIL
 
@@ -2541,9 +2532,6 @@
     expected: FAIL
 
   [[["fontsize","4"\],["insertlinebreak",""\]\] "foo[\]bar" queryCommandValue("fontsize") after]
-    expected: FAIL
-
-  [[["fontsize","4"\],["insertlinebreak",""\],["inserttext","a"\]\] "foo[\]bar": execCommand("fontsize", false, "4") return value]
     expected: FAIL
 
   [[["fontsize","4"\],["insertlinebreak",""\],["inserttext","a"\]\] "foo[\]bar": execCommand("insertlinebreak", false, "") return value]
@@ -2561,9 +2549,6 @@
   [[["fontsize","4"\],["insertlinebreak",""\],["inserttext","a"\]\] "foo[\]bar" queryCommandValue("fontsize") after]
     expected: FAIL
 
-  [[["fontsize","4"\],["insertorderedlist",""\]\] "foo[\]bar": execCommand("fontsize", false, "4") return value]
-    expected: FAIL
-
   [[["fontsize","4"\],["insertorderedlist",""\]\] "foo[\]bar": execCommand("insertorderedlist", false, "") return value]
     expected: FAIL
 
@@ -2577,9 +2562,6 @@
     expected: FAIL
 
   [[["fontsize","4"\],["insertorderedlist",""\]\] "foo[\]bar" queryCommandState("insertorderedlist") after]
-    expected: FAIL
-
-  [[["fontsize","4"\],["insertorderedlist",""\],["inserttext","a"\]\] "foo[\]bar": execCommand("fontsize", false, "4") return value]
     expected: FAIL
 
   [[["fontsize","4"\],["insertorderedlist",""\],["inserttext","a"\]\] "foo[\]bar": execCommand("insertorderedlist", false, "") return value]
@@ -2600,9 +2582,6 @@
   [[["fontsize","4"\],["insertorderedlist",""\],["inserttext","a"\]\] "foo[\]bar" queryCommandState("insertorderedlist") after]
     expected: FAIL
 
-  [[["fontsize","4"\],["insertparagraph",""\]\] "foo[\]bar": execCommand("fontsize", false, "4") return value]
-    expected: FAIL
-
   [[["fontsize","4"\],["insertparagraph",""\]\] "foo[\]bar": execCommand("insertparagraph", false, "") return value]
     expected: FAIL
 
@@ -2613,9 +2592,6 @@
     expected: FAIL
 
   [[["fontsize","4"\],["insertparagraph",""\]\] "foo[\]bar" queryCommandValue("fontsize") after]
-    expected: FAIL
-
-  [[["fontsize","4"\],["insertparagraph",""\],["inserttext","a"\]\] "foo[\]bar": execCommand("fontsize", false, "4") return value]
     expected: FAIL
 
   [[["fontsize","4"\],["insertparagraph",""\],["inserttext","a"\]\] "foo[\]bar": execCommand("insertparagraph", false, "") return value]
@@ -2633,9 +2609,6 @@
   [[["fontsize","4"\],["insertparagraph",""\],["inserttext","a"\]\] "foo[\]bar" queryCommandValue("fontsize") after]
     expected: FAIL
 
-  [[["fontsize","4"\],["insertunorderedlist",""\]\] "foo[\]bar": execCommand("fontsize", false, "4") return value]
-    expected: FAIL
-
   [[["fontsize","4"\],["insertunorderedlist",""\]\] "foo[\]bar": execCommand("insertunorderedlist", false, "") return value]
     expected: FAIL
 
@@ -2649,9 +2622,6 @@
     expected: FAIL
 
   [[["fontsize","4"\],["insertunorderedlist",""\]\] "foo[\]bar" queryCommandState("insertunorderedlist") after]
-    expected: FAIL
-
-  [[["fontsize","4"\],["insertunorderedlist",""\],["inserttext","a"\]\] "foo[\]bar": execCommand("fontsize", false, "4") return value]
     expected: FAIL
 
   [[["fontsize","4"\],["insertunorderedlist",""\],["inserttext","a"\]\] "foo[\]bar": execCommand("insertunorderedlist", false, "") return value]
@@ -2670,9 +2640,6 @@
     expected: FAIL
 
   [[["fontsize","4"\],["insertunorderedlist",""\],["inserttext","a"\]\] "foo[\]bar" queryCommandState("insertunorderedlist") after]
-    expected: FAIL
-
-  [[["fontsize","4"\],["justifycenter",""\]\] "foo[\]bar": execCommand("fontsize", false, "4") return value]
     expected: FAIL
 
   [[["fontsize","4"\],["justifycenter",""\]\] "foo[\]bar": execCommand("justifycenter", false, "") return value]
@@ -2694,9 +2661,6 @@
     expected: FAIL
 
   [[["fontsize","4"\],["justifycenter",""\]\] "foo[\]bar" queryCommandValue("justifycenter") after]
-    expected: FAIL
-
-  [[["fontsize","4"\],["justifycenter",""\],["inserttext","a"\]\] "foo[\]bar": execCommand("fontsize", false, "4") return value]
     expected: FAIL
 
   [[["fontsize","4"\],["justifycenter",""\],["inserttext","a"\]\] "foo[\]bar": execCommand("justifycenter", false, "") return value]
@@ -2723,9 +2687,6 @@
   [[["fontsize","4"\],["justifycenter",""\],["inserttext","a"\]\] "foo[\]bar" queryCommandValue("justifycenter") after]
     expected: FAIL
 
-  [[["fontsize","4"\],["justifyfull",""\]\] "foo[\]bar": execCommand("fontsize", false, "4") return value]
-    expected: FAIL
-
   [[["fontsize","4"\],["justifyfull",""\]\] "foo[\]bar": execCommand("justifyfull", false, "") return value]
     expected: FAIL
 
@@ -2745,9 +2706,6 @@
     expected: FAIL
 
   [[["fontsize","4"\],["justifyfull",""\]\] "foo[\]bar" queryCommandValue("justifyfull") after]
-    expected: FAIL
-
-  [[["fontsize","4"\],["justifyfull",""\],["inserttext","a"\]\] "foo[\]bar": execCommand("fontsize", false, "4") return value]
     expected: FAIL
 
   [[["fontsize","4"\],["justifyfull",""\],["inserttext","a"\]\] "foo[\]bar": execCommand("justifyfull", false, "") return value]
@@ -2774,9 +2732,6 @@
   [[["fontsize","4"\],["justifyfull",""\],["inserttext","a"\]\] "foo[\]bar" queryCommandValue("justifyfull") after]
     expected: FAIL
 
-  [[["fontsize","4"\],["justifyleft",""\]\] "foo[\]bar": execCommand("fontsize", false, "4") return value]
-    expected: FAIL
-
   [[["fontsize","4"\],["justifyleft",""\]\] "foo[\]bar": execCommand("justifyleft", false, "") return value]
     expected: FAIL
 
@@ -2796,9 +2751,6 @@
     expected: FAIL
 
   [[["fontsize","4"\],["justifyleft",""\]\] "foo[\]bar" queryCommandValue("justifyleft") after]
-    expected: FAIL
-
-  [[["fontsize","4"\],["justifyleft",""\],["inserttext","a"\]\] "foo[\]bar": execCommand("fontsize", false, "4") return value]
     expected: FAIL
 
   [[["fontsize","4"\],["justifyleft",""\],["inserttext","a"\]\] "foo[\]bar": execCommand("justifyleft", false, "") return value]
@@ -2828,9 +2780,6 @@
   [[["fontsize","4"\],["justifyleft",""\],["inserttext","a"\]\] "foo[\]bar" queryCommandValue("justifyleft") after]
     expected: FAIL
 
-  [[["fontsize","4"\],["justifyright",""\]\] "foo[\]bar": execCommand("fontsize", false, "4") return value]
-    expected: FAIL
-
   [[["fontsize","4"\],["justifyright",""\]\] "foo[\]bar": execCommand("justifyright", false, "") return value]
     expected: FAIL
 
@@ -2850,9 +2799,6 @@
     expected: FAIL
 
   [[["fontsize","4"\],["justifyright",""\]\] "foo[\]bar" queryCommandValue("justifyright") after]
-    expected: FAIL
-
-  [[["fontsize","4"\],["justifyright",""\],["inserttext","a"\]\] "foo[\]bar": execCommand("fontsize", false, "4") return value]
     expected: FAIL
 
   [[["fontsize","4"\],["justifyright",""\],["inserttext","a"\]\] "foo[\]bar": execCommand("justifyright", false, "") return value]
@@ -2879,9 +2825,6 @@
   [[["fontsize","4"\],["justifyright",""\],["inserttext","a"\]\] "foo[\]bar" queryCommandValue("justifyright") after]
     expected: FAIL
 
-  [[["fontsize","4"\],["outdent",""\]\] "foo[\]bar": execCommand("fontsize", false, "4") return value]
-    expected: FAIL
-
   [[["fontsize","4"\],["outdent",""\]\] "foo[\]bar": execCommand("outdent", false, "") return value]
     expected: FAIL
 
@@ -2889,9 +2832,6 @@
     expected: FAIL
 
   [[["fontsize","4"\],["outdent",""\]\] "foo[\]bar" queryCommandValue("fontsize") after]
-    expected: FAIL
-
-  [[["fontsize","4"\],["outdent",""\],["inserttext","a"\]\] "foo[\]bar": execCommand("fontsize", false, "4") return value]
     expected: FAIL
 
   [[["fontsize","4"\],["outdent",""\],["inserttext","a"\]\] "foo[\]bar": execCommand("outdent", false, "") return value]
@@ -4135,9 +4075,6 @@
   [[["fontname","sans-serif"\],["outdent",""\],["inserttext","a"\]\] "foo[\]bar" queryCommandValue("fontname") after]
     expected: FAIL
 
-  [[["fontsize","4"\],["inserttext","a"\]\] "foo[\]bar": execCommand("fontsize", false, "4") return value]
-    expected: FAIL
-
   [[["fontsize","4"\],["inserttext","a"\]\] "foo[\]bar": execCommand("inserttext", false, "a") return value]
     expected: FAIL
 
@@ -4150,16 +4087,10 @@
   [[["fontsize","4"\],["inserttext","a"\]\] "foo[\]bar" queryCommandValue("fontsize") after]
     expected: FAIL
 
-  [[["fontsize","4"\],["delete",""\]\] "foo[\]bar": execCommand("fontsize", false, "4") return value]
-    expected: FAIL
-
   [[["fontsize","4"\],["delete",""\]\] "foo[\]bar" queryCommandValue("fontsize") before]
     expected: FAIL
 
   [[["fontsize","4"\],["delete",""\]\] "foo[\]bar" queryCommandValue("fontsize") after]
-    expected: FAIL
-
-  [[["fontsize","4"\],["delete",""\],["inserttext","a"\]\] "foo[\]bar": execCommand("fontsize", false, "4") return value]
     expected: FAIL
 
   [[["fontsize","4"\],["delete",""\],["inserttext","a"\]\] "foo[\]bar": execCommand("inserttext", false, "a") return value]
@@ -4172,9 +4103,6 @@
     expected: FAIL
 
   [[["fontsize","4"\],["delete",""\],["inserttext","a"\]\] "foo[\]bar" queryCommandValue("fontsize") after]
-    expected: FAIL
-
-  [[["fontsize","4"\],["formatblock","<div>"\]\] "foo[\]bar": execCommand("fontsize", false, "4") return value]
     expected: FAIL
 
   [[["fontsize","4"\],["formatblock","<div>"\]\] "foo[\]bar": execCommand("formatblock", false, "<div>") return value]
@@ -4190,9 +4118,6 @@
     expected: FAIL
 
   [[["fontsize","4"\],["formatblock","<div>"\]\] "foo[\]bar" queryCommandValue("formatblock") after]
-    expected: FAIL
-
-  [[["fontsize","4"\],["formatblock","<div>"\],["inserttext","a"\]\] "foo[\]bar": execCommand("fontsize", false, "4") return value]
     expected: FAIL
 
   [[["fontsize","4"\],["formatblock","<div>"\],["inserttext","a"\]\] "foo[\]bar": execCommand("formatblock", false, "<div>") return value]
@@ -4213,9 +4138,6 @@
   [[["fontsize","4"\],["formatblock","<div>"\],["inserttext","a"\]\] "foo[\]bar" queryCommandValue("formatblock") after]
     expected: FAIL
 
-  [[["fontsize","4"\],["forwarddelete",""\]\] "foo[\]bar": execCommand("fontsize", false, "4") return value]
-    expected: FAIL
-
   [[["fontsize","4"\],["forwarddelete",""\]\] "foo[\]bar": execCommand("forwarddelete", false, "") return value]
     expected: FAIL
 
@@ -4226,9 +4148,6 @@
     expected: FAIL
 
   [[["fontsize","4"\],["forwarddelete",""\]\] "foo[\]bar" queryCommandValue("fontsize") after]
-    expected: FAIL
-
-  [[["fontsize","4"\],["forwarddelete",""\],["inserttext","a"\]\] "foo[\]bar": execCommand("fontsize", false, "4") return value]
     expected: FAIL
 
   [[["fontsize","4"\],["forwarddelete",""\],["inserttext","a"\]\] "foo[\]bar": execCommand("forwarddelete", false, "") return value]
@@ -4246,9 +4165,6 @@
   [[["fontsize","4"\],["forwarddelete",""\],["inserttext","a"\]\] "foo[\]bar" queryCommandValue("fontsize") after]
     expected: FAIL
 
-  [[["fontsize","4"\],["indent",""\]\] "foo[\]bar": execCommand("fontsize", false, "4") return value]
-    expected: FAIL
-
   [[["fontsize","4"\],["indent",""\]\] "foo[\]bar": execCommand("indent", false, "") return value]
     expected: FAIL
 
@@ -4259,9 +4175,6 @@
     expected: FAIL
 
   [[["fontsize","4"\],["indent",""\]\] "foo[\]bar" queryCommandValue("fontsize") after]
-    expected: FAIL
-
-  [[["fontsize","4"\],["indent",""\],["inserttext","a"\]\] "foo[\]bar": execCommand("fontsize", false, "4") return value]
     expected: FAIL
 
   [[["fontsize","4"\],["indent",""\],["inserttext","a"\]\] "foo[\]bar": execCommand("indent", false, "") return value]
@@ -4279,9 +4192,6 @@
   [[["fontsize","4"\],["indent",""\],["inserttext","a"\]\] "foo[\]bar" queryCommandValue("fontsize") after]
     expected: FAIL
 
-  [[["fontsize","4"\],["inserthorizontalrule",""\]\] "foo[\]bar": execCommand("fontsize", false, "4") return value]
-    expected: FAIL
-
   [[["fontsize","4"\],["inserthorizontalrule",""\]\] "foo[\]bar": execCommand("inserthorizontalrule", false, "") return value]
     expected: FAIL
 
@@ -4292,9 +4202,6 @@
     expected: FAIL
 
   [[["fontsize","4"\],["inserthorizontalrule",""\]\] "foo[\]bar" queryCommandValue("fontsize") after]
-    expected: FAIL
-
-  [[["fontsize","4"\],["inserthorizontalrule",""\],["inserttext","a"\]\] "foo[\]bar": execCommand("fontsize", false, "4") return value]
     expected: FAIL
 
   [[["fontsize","4"\],["inserthorizontalrule",""\],["inserttext","a"\]\] "foo[\]bar": execCommand("inserthorizontalrule", false, "") return value]
@@ -4312,9 +4219,6 @@
   [[["fontsize","4"\],["inserthorizontalrule",""\],["inserttext","a"\]\] "foo[\]bar" queryCommandValue("fontsize") after]
     expected: FAIL
 
-  [[["fontsize","4"\],["inserthtml","ab<b>c</b>d"\]\] "foo[\]bar": execCommand("fontsize", false, "4") return value]
-    expected: FAIL
-
   [[["fontsize","4"\],["inserthtml","ab<b>c</b>d"\]\] "foo[\]bar": execCommand("inserthtml", false, "ab<b>c</b>d") return value]
     expected: FAIL
 
@@ -4325,9 +4229,6 @@
     expected: FAIL
 
   [[["fontsize","4"\],["inserthtml","ab<b>c</b>d"\]\] "foo[\]bar" queryCommandValue("fontsize") after]
-    expected: FAIL
-
-  [[["fontsize","4"\],["inserthtml","ab<b>c</b>d"\],["inserttext","a"\]\] "foo[\]bar": execCommand("fontsize", false, "4") return value]
     expected: FAIL
 
   [[["fontsize","4"\],["inserthtml","ab<b>c</b>d"\],["inserttext","a"\]\] "foo[\]bar": execCommand("inserthtml", false, "ab<b>c</b>d") return value]
@@ -5138,9 +5039,6 @@
   [[["subscript",""\],["fontsize","2"\],["inserttext","a"\]\] "foo[\]bar": execCommand("subscript", false, "") return value]
     expected: FAIL
 
-  [[["subscript",""\],["fontsize","2"\],["inserttext","a"\]\] "foo[\]bar": execCommand("fontsize", false, "2") return value]
-    expected: FAIL
-
   [[["subscript",""\],["fontsize","2"\],["inserttext","a"\]\] "foo[\]bar": execCommand("inserttext", false, "a") return value]
     expected: FAIL
 
@@ -5154,9 +5052,6 @@
     expected: FAIL
 
   [[["subscript",""\],["fontsize","2"\],["inserttext","a"\]\] "foo[\]bar" queryCommandValue("fontsize") after]
-    expected: FAIL
-
-  [[["fontsize","2"\],["subscript",""\],["inserttext","a"\]\] "foo[\]bar": execCommand("fontsize", false, "2") return value]
     expected: FAIL
 
   [[["fontsize","2"\],["subscript",""\],["inserttext","a"\]\] "foo[\]bar": execCommand("subscript", false, "") return value]
@@ -5180,9 +5075,6 @@
   [[["subscript",""\],["fontsize","3"\],["inserttext","a"\]\] "foo[\]bar": execCommand("subscript", false, "") return value]
     expected: FAIL
 
-  [[["subscript",""\],["fontsize","3"\],["inserttext","a"\]\] "foo[\]bar": execCommand("fontsize", false, "3") return value]
-    expected: FAIL
-
   [[["subscript",""\],["fontsize","3"\],["inserttext","a"\]\] "foo[\]bar": execCommand("inserttext", false, "a") return value]
     expected: FAIL
 
@@ -5196,9 +5088,6 @@
     expected: FAIL
 
   [[["subscript",""\],["fontsize","3"\],["inserttext","a"\]\] "foo[\]bar" queryCommandValue("fontsize") after]
-    expected: FAIL
-
-  [[["fontsize","3"\],["subscript",""\],["inserttext","a"\]\] "foo[\]bar": execCommand("fontsize", false, "3") return value]
     expected: FAIL
 
   [[["fontsize","3"\],["subscript",""\],["inserttext","a"\]\] "foo[\]bar": execCommand("subscript", false, "") return value]
@@ -6652,9 +6541,6 @@
   [[["insertlinebreak",""\],["inserttext","d"\],["inserttext","e"\]\] "<div>abc{<s></s><b><i>de\]f</i></b>ghi</div>" compare innerHTML]
     expected: FAIL
 
-  [[["stylewithcss","false"\],["fontsize","4"\],["insertText","a"\]\] "<font size=7>{}<br></font>": execCommand("fontsize", false, "4") return value]
-    expected: FAIL
-
   [[["stylewithcss","false"\],["fontsize","4"\],["insertText","a"\]\] "<font size=7>{}<br></font>": execCommand("insertText", false, "a") return value]
     expected: FAIL
 
@@ -6674,9 +6560,6 @@
     expected: FAIL
 
   [[["stylewithcss","true"\],["italic",""\],["insertText","a"\]\] "<span style=font-weight:bold>{}<br></span></b>" compare innerHTML]
-    expected: FAIL
-
-  [[["stylewithcss","false"\],["fontSize","4"\],["backColor","#00dddd"\],["insertText","d"\]\] "abc[\]ef": execCommand("fontSize", false, "4") return value]
     expected: FAIL
 
   [[["stylewithcss","false"\],["fontSize","4"\],["backColor","#00dddd"\],["insertText","d"\]\] "abc[\]ef": execCommand("backColor", false, "#00dddd") return value]
@@ -6715,9 +6598,6 @@
   [[["stylewithcss","false"\],["backColor","#00dddd"\],["fontSize","4"\],["insertText","d"\]\] "abc[\]ef": execCommand("backColor", false, "#00dddd") return value]
     expected: FAIL
 
-  [[["stylewithcss","false"\],["backColor","#00dddd"\],["fontSize","4"\],["insertText","d"\]\] "abc[\]ef": execCommand("fontSize", false, "4") return value]
-    expected: FAIL
-
   [[["stylewithcss","false"\],["backColor","#00dddd"\],["fontSize","4"\],["insertText","d"\]\] "abc[\]ef": execCommand("insertText", false, "d") return value]
     expected: FAIL
 
@@ -6752,9 +6632,6 @@
     expected: FAIL
 
   [[["stylewithcss","false"\],["fontName","monospace"\],["foreColor","#ff0000"\],["fontSize","7"\],["backColor","#00dddd"\],["insertText","d"\]\] "abc[\]ef": execCommand("foreColor", false, "#ff0000") return value]
-    expected: FAIL
-
-  [[["stylewithcss","false"\],["fontName","monospace"\],["foreColor","#ff0000"\],["fontSize","7"\],["backColor","#00dddd"\],["insertText","d"\]\] "abc[\]ef": execCommand("fontSize", false, "7") return value]
     expected: FAIL
 
   [[["stylewithcss","false"\],["fontName","monospace"\],["foreColor","#ff0000"\],["fontSize","7"\],["backColor","#00dddd"\],["insertText","d"\]\] "abc[\]ef": execCommand("backColor", false, "#00dddd") return value]
@@ -7006,9 +6883,6 @@
   [[["styleWithCSS","false"\],["bold",""\],["fontName","monospace"\],["insertText","b"\]\] "a[\]c" compare innerHTML]
     expected: FAIL
 
-  [[["styleWithCSS","false"\],["fontSize","5"\],["bold",""\],["insertText","b"\]\] "a[\]c": execCommand("fontSize", false, "5") return value]
-    expected: FAIL
-
   [[["styleWithCSS","false"\],["fontSize","5"\],["bold",""\],["insertText","b"\]\] "a[\]c": execCommand("bold", false, "") return value]
     expected: FAIL
 
@@ -7019,9 +6893,6 @@
     expected: FAIL
 
   [[["styleWithCSS","false"\],["bold",""\],["fontSize","5"\],["insertText","b"\]\] "a[\]c": execCommand("bold", false, "") return value]
-    expected: FAIL
-
-  [[["styleWithCSS","false"\],["bold",""\],["fontSize","5"\],["insertText","b"\]\] "a[\]c": execCommand("fontSize", false, "5") return value]
     expected: FAIL
 
   [[["styleWithCSS","false"\],["bold",""\],["fontSize","5"\],["insertText","b"\]\] "a[\]c": execCommand("insertText", false, "b") return value]
@@ -7036,9 +6907,6 @@
   [[["styleWithCSS","false"\],["foreColor","#ff0000"\],["bold",""\],["fontSize","5"\],["fontName","monospace"\],["insertText","b"\]\] "a[\]c": execCommand("bold", false, "") return value]
     expected: FAIL
 
-  [[["styleWithCSS","false"\],["foreColor","#ff0000"\],["bold",""\],["fontSize","5"\],["fontName","monospace"\],["insertText","b"\]\] "a[\]c": execCommand("fontSize", false, "5") return value]
-    expected: FAIL
-
   [[["styleWithCSS","false"\],["foreColor","#ff0000"\],["bold",""\],["fontSize","5"\],["fontName","monospace"\],["insertText","b"\]\] "a[\]c": execCommand("fontName", false, "monospace") return value]
     expected: FAIL
 
@@ -7048,16 +6916,10 @@
   [[["styleWithCSS","false"\],["foreColor","#ff0000"\],["bold",""\],["fontSize","5"\],["fontName","monospace"\],["insertText","b"\]\] "a[\]c" compare innerHTML]
     expected: FAIL
 
-  [[["styleWithCSS","false"\],["delete",""\],["fontSize","5"\],["insertText","b"\]\] "<p><font size=\\"5\\">a</font></p><p>[\]c</p>": execCommand("fontSize", false, "5") return value]
-    expected: FAIL
-
   [[["styleWithCSS","false"\],["delete",""\],["fontSize","5"\],["insertText","b"\]\] "<p><font size=\\"5\\">a</font></p><p>[\]c</p>": execCommand("insertText", false, "b") return value]
     expected: FAIL
 
   [[["styleWithCSS","false"\],["delete",""\],["fontSize","5"\],["insertText","b"\]\] "<p><font size=\\"5\\">a</font></p><p>[\]c</p>" compare innerHTML]
-    expected: FAIL
-
-  [[["styleWithCSS","false"\],["delete",""\],["fontSize","5"\],["foreColor","#ff0000"\],["insertText","b"\]\] "<p><font size=\\"5\\" color=\\"#ff0000\\">a</font></p><p>[\]c</p>": execCommand("fontSize", false, "5") return value]
     expected: FAIL
 
   [[["styleWithCSS","false"\],["delete",""\],["fontSize","5"\],["foreColor","#ff0000"\],["insertText","b"\]\] "<p><font size=\\"5\\" color=\\"#ff0000\\">a</font></p><p>[\]c</p>": execCommand("foreColor", false, "#ff0000") return value]
@@ -7069,16 +6931,10 @@
   [[["styleWithCSS","false"\],["delete",""\],["fontSize","5"\],["foreColor","#ff0000"\],["insertText","b"\]\] "<p><font size=\\"5\\" color=\\"#ff0000\\">a</font></p><p>[\]c</p>" compare innerHTML]
     expected: FAIL
 
-  [[["styleWithCSS","false"\],["delete",""\],["fontSize","5"\],["insertText","b"\]\] "<p><font size=\\"5\\"><b>a</b></font></p><p>[\]c</p>": execCommand("fontSize", false, "5") return value]
-    expected: FAIL
-
   [[["styleWithCSS","false"\],["delete",""\],["fontSize","5"\],["insertText","b"\]\] "<p><font size=\\"5\\"><b>a</b></font></p><p>[\]c</p>": execCommand("insertText", false, "b") return value]
     expected: FAIL
 
   [[["styleWithCSS","false"\],["delete",""\],["fontSize","5"\],["insertText","b"\]\] "<p><font size=\\"5\\"><b>a</b></font></p><p>[\]c</p>" compare innerHTML]
-    expected: FAIL
-
-  [[["styleWithCSS","false"\],["delete",""\],["fontSize","5"\],["insertText","b"\]\] "<p><font size=\\"5\\"><b>a</b></font></p><p><i>[\]c</i></p>": execCommand("fontSize", false, "5") return value]
     expected: FAIL
 
   [[["styleWithCSS","false"\],["delete",""\],["fontSize","5"\],["insertText","b"\]\] "<p><font size=\\"5\\"><b>a</b></font></p><p><i>[\]c</i></p>": execCommand("insertText", false, "b") return value]
@@ -7090,9 +6946,6 @@
   [[["styleWithCSS","false"\],["forwardDelete",""\],["fontSize","5"\],["insertText","b"\]\] "<p><font size=\\"5\\">a[\]</font></p><p>c</p>": execCommand("forwardDelete", false, "") return value]
     expected: FAIL
 
-  [[["styleWithCSS","false"\],["forwardDelete",""\],["fontSize","5"\],["insertText","b"\]\] "<p><font size=\\"5\\">a[\]</font></p><p>c</p>": execCommand("fontSize", false, "5") return value]
-    expected: FAIL
-
   [[["styleWithCSS","false"\],["forwardDelete",""\],["fontSize","5"\],["insertText","b"\]\] "<p><font size=\\"5\\">a[\]</font></p><p>c</p>": execCommand("insertText", false, "b") return value]
     expected: FAIL
 
@@ -7100,9 +6953,6 @@
     expected: FAIL
 
   [[["styleWithCSS","false"\],["forwardDelete",""\],["fontSize","5"\],["foreColor","#ff0000"\],["insertText","b"\]\] "<p><font size=\\"5\\" color=\\"#ff0000\\">a[\]</font></p><p>c</p>": execCommand("forwardDelete", false, "") return value]
-    expected: FAIL
-
-  [[["styleWithCSS","false"\],["forwardDelete",""\],["fontSize","5"\],["foreColor","#ff0000"\],["insertText","b"\]\] "<p><font size=\\"5\\" color=\\"#ff0000\\">a[\]</font></p><p>c</p>": execCommand("fontSize", false, "5") return value]
     expected: FAIL
 
   [[["styleWithCSS","false"\],["forwardDelete",""\],["fontSize","5"\],["foreColor","#ff0000"\],["insertText","b"\]\] "<p><font size=\\"5\\" color=\\"#ff0000\\">a[\]</font></p><p>c</p>": execCommand("foreColor", false, "#ff0000") return value]
@@ -7117,9 +6967,6 @@
   [[["styleWithCSS","false"\],["forwardDelete",""\],["fontSize","5"\],["insertText","b"\]\] "<p><font size=\\"5\\"><b>a[\]</b></font></p><p>c</p>": execCommand("forwardDelete", false, "") return value]
     expected: FAIL
 
-  [[["styleWithCSS","false"\],["forwardDelete",""\],["fontSize","5"\],["insertText","b"\]\] "<p><font size=\\"5\\"><b>a[\]</b></font></p><p>c</p>": execCommand("fontSize", false, "5") return value]
-    expected: FAIL
-
   [[["styleWithCSS","false"\],["forwardDelete",""\],["fontSize","5"\],["insertText","b"\]\] "<p><font size=\\"5\\"><b>a[\]</b></font></p><p>c</p>": execCommand("insertText", false, "b") return value]
     expected: FAIL
 
@@ -7127,9 +6974,6 @@
     expected: FAIL
 
   [[["styleWithCSS","false"\],["forwardDelete",""\],["fontSize","5"\],["insertText","b"\]\] "<p><font size=\\"5\\"><b>a[\]</b></font></p><p><i>c</i></p>": execCommand("forwardDelete", false, "") return value]
-    expected: FAIL
-
-  [[["styleWithCSS","false"\],["forwardDelete",""\],["fontSize","5"\],["insertText","b"\]\] "<p><font size=\\"5\\"><b>a[\]</b></font></p><p><i>c</i></p>": execCommand("fontSize", false, "5") return value]
     expected: FAIL
 
   [[["styleWithCSS","false"\],["forwardDelete",""\],["fontSize","5"\],["insertText","b"\]\] "<p><font size=\\"5\\"><b>a[\]</b></font></p><p><i>c</i></p>": execCommand("insertText", false, "b") return value]


### PR DESCRIPTION
This makes the most basic tests pass for the font-size command. Future PR's will continue the work,
but since this is already large enough, this is a good save point.

Part of #25005