### PR TITLE
script: Move drop logic for several WebGPU types to helper structs

### DIFF
--- a/components/script/dom/webgpu/gpushadermodule.rs
+++ b/components/script/dom/webgpu/gpushadermodule.rs
@@ -23,16 +23,36 @@ use crate::realms::InRealm;
 use crate::routed_promise::{RoutedPromiseListener, callback_promise};
 use crate::script_runtime::CanGc;
 
+#[derive(JSTraceable, MallocSizeOf)]
+struct DroppableGPUShaderModule {
+    #[no_trace]
+    channel: WebGPU,
+    #[no_trace]
+    shader_module: WebGPUShaderModule,
+}
+
+impl Drop for DroppableGPUShaderModule {
+    fn drop(&mut self) {
+        if let Err(e) = self
+            .channel
+            .0
+            .send(WebGPURequest::DropShaderModule(self.shader_module.0))
+        {
+            warn!(
+                "Failed to send DropShaderModule ({:?}) ({})",
+                self.shader_module.0, e
+            );
+        }
+    }
+}
+
 #[dom_struct]
 pub(crate) struct GPUShaderModule {
     reflector_: Reflector,
-    #[no_trace]
-    channel: WebGPU,
     label: DomRefCell<USVString>,
-    #[no_trace]
-    shader_module: WebGPUShaderModule,
     #[ignore_malloc_size_of = "promise"]
     compilation_info_promise: Rc<Promise>,
+    droppable: DroppableGPUShaderModule,
 }
 
 impl GPUShaderModule {
@@ -44,10 +64,12 @@ impl GPUShaderModule {
     ) -> Self {
         Self {
             reflector_: Reflector::new(),
-            channel,
             label: DomRefCell::new(label),
-            shader_module,
             compilation_info_promise: promise,
+            droppable: DroppableGPUShaderModule {
+                channel,
+                shader_module,
+            },
         }
     }
 
@@ -74,7 +96,7 @@ impl GPUShaderModule {
 
 impl GPUShaderModule {
     pub(crate) fn id(&self) -> WebGPUShaderModule {
-        self.shader_module
+        self.droppable.shader_module
     }
 
     /// <https://gpuweb.github.io/gpuweb/#dom-gpudevice-createshadermodule>
@@ -143,20 +165,5 @@ impl RoutedPromiseListener<Option<ShaderCompilationInfo>> for GPUShaderModule {
     ) {
         let info = GPUCompilationInfo::from(&self.global(), response, can_gc);
         promise.resolve_native(&info, can_gc);
-    }
-}
-
-impl Drop for GPUShaderModule {
-    fn drop(&mut self) {
-        if let Err(e) = self
-            .channel
-            .0
-            .send(WebGPURequest::DropShaderModule(self.shader_module.0))
-        {
-            warn!(
-                "Failed to send DropShaderModule ({:?}) ({})",
-                self.shader_module.0, e
-            );
-        }
     }
 }

--- a/components/script/dom/webgpu/gputexture.rs
+++ b/components/script/dom/webgpu/gputexture.rs
@@ -24,15 +24,34 @@ use crate::dom::webgpu::gpudevice::GPUDevice;
 use crate::dom::webgpu::gputextureview::GPUTextureView;
 use crate::script_runtime::CanGc;
 
+#[derive(JSTraceable, MallocSizeOf)]
+struct DroppableGPUTexture {
+    #[no_trace]
+    channel: WebGPU,
+    #[no_trace]
+    texture: WebGPUTexture,
+}
+
+impl Drop for DroppableGPUTexture {
+    fn drop(&mut self) {
+        if let Err(e) = self
+            .channel
+            .0
+            .send(WebGPURequest::DropTexture(self.texture.0))
+        {
+            warn!(
+                "Failed to send WebGPURequest::DropTexture({:?}) ({})",
+                self.texture.0, e
+            );
+        };
+    }
+}
+
 #[dom_struct]
 pub(crate) struct GPUTexture {
     reflector_: Reflector,
-    #[no_trace]
-    texture: WebGPUTexture,
     label: DomRefCell<USVString>,
     device: Dom<GPUDevice>,
-    #[no_trace]
-    channel: WebGPU,
     #[no_trace]
     #[ignore_malloc_size_of = "External type"]
     texture_size: wgpu_types::Extent3d,
@@ -41,6 +60,7 @@ pub(crate) struct GPUTexture {
     dimension: GPUTextureDimension,
     format: GPUTextureFormat,
     texture_usage: u32,
+    droppable: DroppableGPUTexture,
 }
 
 impl GPUTexture {
@@ -59,16 +79,15 @@ impl GPUTexture {
     ) -> Self {
         Self {
             reflector_: Reflector::new(),
-            texture,
             label: DomRefCell::new(label),
             device: Dom::from_ref(device),
-            channel,
             texture_size,
             mip_level_count,
             sample_count,
             dimension,
             format,
             texture_usage,
+            droppable: DroppableGPUTexture { channel, texture },
         }
     }
 
@@ -106,24 +125,9 @@ impl GPUTexture {
     }
 }
 
-impl Drop for GPUTexture {
-    fn drop(&mut self) {
-        if let Err(e) = self
-            .channel
-            .0
-            .send(WebGPURequest::DropTexture(self.texture.0))
-        {
-            warn!(
-                "Failed to send WebGPURequest::DropTexture({:?}) ({})",
-                self.texture.0, e
-            );
-        };
-    }
-}
-
 impl GPUTexture {
     pub(crate) fn id(&self) -> WebGPUTexture {
-        self.texture
+        self.droppable.texture
     }
 
     /// <https://gpuweb.github.io/gpuweb/#dom-gpudevice-createtexture>
@@ -216,10 +220,11 @@ impl GPUTextureMethods<crate::DomTypeHolder> for GPUTexture {
 
         let texture_view_id = self.global().wgpu_id_hub().create_texture_view_id();
 
-        self.channel
+        self.droppable
+            .channel
             .0
             .send(WebGPURequest::CreateTextureView {
-                texture_id: self.texture.0,
+                texture_id: self.id().0,
                 texture_view_id,
                 device_id: self.device.id().0,
                 descriptor: desc,
@@ -230,7 +235,7 @@ impl GPUTextureMethods<crate::DomTypeHolder> for GPUTexture {
 
         Ok(GPUTextureView::new(
             &self.global(),
-            self.channel.clone(),
+            self.droppable.channel.clone(),
             texture_view,
             self,
             descriptor.parent.label.clone(),
@@ -241,13 +246,15 @@ impl GPUTextureMethods<crate::DomTypeHolder> for GPUTexture {
     /// <https://gpuweb.github.io/gpuweb/#dom-gputexture-destroy>
     fn Destroy(&self) {
         if let Err(e) = self
+            .droppable
             .channel
             .0
-            .send(WebGPURequest::DestroyTexture(self.texture.0))
+            .send(WebGPURequest::DestroyTexture(self.id().0))
         {
             warn!(
                 "Failed to send WebGPURequest::DestroyTexture({:?}) ({})",
-                self.texture.0, e
+                self.id().0,
+                e
             );
         };
     }

--- a/components/script/dom/webgpu/gputextureview.rs
+++ b/components/script/dom/webgpu/gputextureview.rs
@@ -14,16 +14,36 @@ use crate::dom::globalscope::GlobalScope;
 use crate::dom::webgpu::gputexture::GPUTexture;
 use crate::script_runtime::CanGc;
 
-#[dom_struct]
-pub(crate) struct GPUTextureView {
-    reflector_: Reflector,
+#[derive(JSTraceable, MallocSizeOf)]
+struct DroppableGPUTextureView {
     #[ignore_malloc_size_of = "defined in webgpu"]
     #[no_trace]
     channel: WebGPU,
-    label: DomRefCell<USVString>,
     #[no_trace]
     texture_view: WebGPUTextureView,
+}
+
+impl Drop for DroppableGPUTextureView {
+    fn drop(&mut self) {
+        if let Err(e) = self
+            .channel
+            .0
+            .send(WebGPURequest::DropTextureView(self.texture_view.0))
+        {
+            warn!(
+                "Failed to send DropTextureView ({:?}) ({})",
+                self.texture_view.0, e
+            );
+        }
+    }
+}
+
+#[dom_struct]
+pub(crate) struct GPUTextureView {
+    reflector_: Reflector,
+    label: DomRefCell<USVString>,
     texture: Dom<GPUTexture>,
+    droppable: DroppableGPUTextureView,
 }
 
 impl GPUTextureView {
@@ -35,10 +55,12 @@ impl GPUTextureView {
     ) -> GPUTextureView {
         Self {
             reflector_: Reflector::new(),
-            channel,
             texture: Dom::from_ref(texture),
             label: DomRefCell::new(label),
-            texture_view,
+            droppable: DroppableGPUTextureView {
+                channel,
+                texture_view,
+            },
         }
     }
 
@@ -65,7 +87,7 @@ impl GPUTextureView {
 
 impl GPUTextureView {
     pub(crate) fn id(&self) -> WebGPUTextureView {
-        self.texture_view
+        self.droppable.texture_view
     }
 }
 
@@ -78,20 +100,5 @@ impl GPUTextureViewMethods<crate::DomTypeHolder> for GPUTextureView {
     /// <https://gpuweb.github.io/gpuweb/#dom-gpuobjectbase-label>
     fn SetLabel(&self, value: USVString) {
         *self.label.borrow_mut() = value;
-    }
-}
-
-impl Drop for GPUTextureView {
-    fn drop(&mut self) {
-        if let Err(e) = self
-            .channel
-            .0
-            .send(WebGPURequest::DropTextureView(self.texture_view.0))
-        {
-            warn!(
-                "Failed to send DropTextureView ({:?}) ({})",
-                self.texture_view.0, e
-            );
-        }
     }
 }

--- a/components/script_bindings/codegen/Bindings.conf
+++ b/components/script_bindings/codegen/Bindings.conf
@@ -376,18 +376,6 @@ DOMInterfaces = {
     'canGc': ['OnSubmittedWorkDone'],
 },
 
-'GPUShaderModule': {
-    'allowDropImpl': True,
-},
-
-'GPUTexture': {
-    'allowDropImpl': True,
-},
-
-'GPUTextureView': {
-    'allowDropImpl': True,
-},
-
 'History': {
     'cx': ['PushState', 'ReplaceState', 'GetState', 'Go']
 },


### PR DESCRIPTION
Implementing `Drop` for DOM types is being forbidden. This moves the resource cleanup logic for `GPUShaderModule`, `GPUTexture`, and `GPUTextureView` to separate helper structs and removes the `allowDropImpl` flag from the bindings configuration.

Testing: WebGpu tests just cover their cases
Fixes: Partially #26488 
