### PR TITLE
script: Skip RAII guard and early return when input event queue is empty

### DIFF
--- a/components/script/dom/document_event_handler.rs
+++ b/components/script/dom/document_event_handler.rs
@@ -292,6 +292,7 @@ impl DocumentEventHandler {
         }
     }
 
+    /// Guarantee: `pending_input_events` is non-empty.
     pub(crate) fn handle_pending_input_events(&self, can_gc: CanGc) {
         let _realm = enter_realm(&*self.window);
 
@@ -370,9 +371,7 @@ impl DocumentEventHandler {
             });
         }
 
-        if !input_event_outcomes.is_empty() {
-            self.notify_embedder_that_events_were_handled(input_event_outcomes);
-        }
+        self.notify_embedder_that_events_were_handled(input_event_outcomes);
     }
 
     fn notify_embedder_that_events_were_handled(

--- a/components/script/dom/document_event_handler.rs
+++ b/components/script/dom/document_event_handler.rs
@@ -292,8 +292,11 @@ impl DocumentEventHandler {
         }
     }
 
-    /// Guarantee: `pending_input_events` is non-empty.
     pub(crate) fn handle_pending_input_events(&self, can_gc: CanGc) {
+        debug_assert!(
+            !self.pending_input_events.borrow().is_empty(),
+            "handle_pending_input_events called with no events"
+        );
         let _realm = enter_realm(&*self.window);
 
         // Reset the mouse and wheel event indices.

--- a/components/script/script_thread.rs
+++ b/components/script/script_thread.rs
@@ -1092,6 +1092,9 @@ impl ScriptThread {
             warn!("Input event sent to a pipeline with a closed window {pipeline_id}.");
             return;
         }
+        if !document.event_handler().has_pending_input_events() {
+            return;
+        }
 
         let _guard = ScriptUserInteractingGuard::new(self.is_user_interacting.clone());
         document.event_handler().handle_pending_input_events(can_gc);


### PR DESCRIPTION
This is a hot path:
- there is a lot of processing in `handle_pending_input_events`: JS realm entry, temporary variable creation, value assignment etc.
- we acquire a RAII guard before calling the function.

If the event queue is empty, this would result in unnecessary overhead on the hot path.
We skip all above work in this case.

Testing: This is an optimization that should not change visible behaviour,
thus covered by all the testdriver tests.