### PR TITLE
Script: Do not convert to and from DOMString multiple times

### DIFF
--- a/components/script/dom/html/htmldialogelement.rs
+++ b/components/script/dom/html/htmldialogelement.rs
@@ -123,11 +123,7 @@ impl HTMLDialogElement {
         // TODO: Step 9. If subject is in the popover showing state, then return.
 
         // Step 10. Queue a dialog toggle event task given subject, "closed", "open", and source.
-        self.queue_dialog_toggle_event_task(
-            "closed",
-            "open",
-            source,
-        );
+        self.queue_dialog_toggle_event_task("closed", "open", source);
 
         // Step 11. Add an open attribute to subject, whose value is the empty string.
         subject.set_bool_attribute(&local_name!("open"), true, can_gc);
@@ -191,11 +187,7 @@ impl HTMLDialogElement {
         }
 
         // Step 4. Queue a dialog toggle event task given subject, "open", "closed", and source.
-        self.queue_dialog_toggle_event_task(
-            "open",
-            "closed",
-            source,
-        );
+        self.queue_dialog_toggle_event_task("open", "closed", source);
 
         // Step 5. Remove subject's open attribute.
         subject.remove_attribute(&ns!(), &local_name!("open"), can_gc);
@@ -337,11 +329,7 @@ impl HTMLDialogElementMethods<crate::DomTypeHolder> for HTMLDialogElement {
         }
 
         // Step 5. Queue a dialog toggle event task given this, "closed", "open", and null.
-        self.queue_dialog_toggle_event_task(
-            "closed",
-            "open",
-            None,
-        );
+        self.queue_dialog_toggle_event_task("closed", "open", None);
 
         // Step 6. Add an open attribute to this, whose value is the empty string.
         element.set_bool_attribute(&local_name!("open"), true, can_gc);

--- a/components/script/dom/html/htmldialogelement.rs
+++ b/components/script/dom/html/htmldialogelement.rs
@@ -124,8 +124,8 @@ impl HTMLDialogElement {
 
         // Step 10. Queue a dialog toggle event task given subject, "closed", "open", and source.
         self.queue_dialog_toggle_event_task(
-            DOMString::from("closed"),
-            DOMString::from("open"),
+            "closed",
+            "open",
             source,
         );
 
@@ -192,8 +192,8 @@ impl HTMLDialogElement {
 
         // Step 4. Queue a dialog toggle event task given subject, "open", "closed", and source.
         self.queue_dialog_toggle_event_task(
-            DOMString::from("open"),
-            DOMString::from("closed"),
+            "open",
+            "closed",
             source,
         );
 
@@ -233,8 +233,8 @@ impl HTMLDialogElement {
     /// <https://html.spec.whatwg.org/multipage/#queue-a-dialog-toggle-event-task>
     pub fn queue_dialog_toggle_event_task(
         &self,
-        old_state: DOMString,
-        new_state: DOMString,
+        old_state: &str,
+        new_state: &str,
         source: Option<DomRoot<Element>>,
     ) {
         // TODO: Step 1. If element's dialog toggle task tracker is not null, then:
@@ -338,8 +338,8 @@ impl HTMLDialogElementMethods<crate::DomTypeHolder> for HTMLDialogElement {
 
         // Step 5. Queue a dialog toggle event task given this, "closed", "open", and null.
         self.queue_dialog_toggle_event_task(
-            DOMString::from("closed"),
-            DOMString::from("open"),
+            "closed",
+            "open",
             None,
         );
 


### PR DESCRIPTION
Previously we called queue_dialog_toggle_break_event_task with DOMStrings which converted them to strings to then convert them back to DOMStrings.

Because DOMString is !Send we cannot use the DOMString directly so we just change queue_dialog_toggle_break_event_task to get &str.


Testiing: Compilation is the test.
