### PR TITLE
Embedder: Implement load_url_with_headers

### DIFF
--- a/components/constellation/constellation.rs
+++ b/components/constellation/constellation.rs
@@ -1394,8 +1394,11 @@ where
             // Load a new page from a typed url
             // If there is already a pending page (self.pending_changes), it will not be overridden;
             // However, if the id is not encompassed by another change, it will be.
-            EmbedderToConstellationMessage::LoadUrl(webview_id, url) => {
-                let load_data = LoadData::new_for_new_unrelated_webview(url);
+            EmbedderToConstellationMessage::LoadUrl(webview_id, url, optional_headers) => {
+                let mut load_data = LoadData::new_for_new_unrelated_webview(url);
+                if let Some(headers) = optional_headers {
+                    load_data.headers.extend(headers.into_iter());
+                }
                 let ctx_id = BrowsingContextId::from(webview_id);
                 let pipeline_id = match self.browsing_contexts.get(&ctx_id) {
                     Some(ctx) => ctx.pipeline_id,

--- a/components/servo/Cargo.toml
+++ b/components/servo/Cargo.toml
@@ -91,6 +91,7 @@ env_logger = { workspace = true }
 euclid = { workspace = true }
 fonts = { workspace = true }
 gstreamer = { workspace = true, optional = true }
+http = { workspace = true }
 image = { workspace = true }
 ipc-channel = { workspace = true }
 keyboard-types = { workspace = true }

--- a/components/servo/webview.rs
+++ b/components/servo/webview.rs
@@ -18,6 +18,7 @@ use embedder_traits::{
     Theme, TraversalId, ViewportDetails, WebViewPoint, WebViewRect,
 };
 use euclid::{Scale, Size2D};
+use http::HeaderMap;
 use image::RgbaImage;
 use paint_api::WebViewTrait;
 use paint_api::rendering_context::RenderingContext;
@@ -438,6 +439,19 @@ impl WebView {
             .send(EmbedderToConstellationMessage::LoadUrl(
                 self.id(),
                 url.into(),
+                None,
+            ))
+    }
+
+    /// Load a specific url in this webview with some additional headers
+    pub fn load_with_additional_headers(&self, url: Url, additional_headers: HeaderMap) {
+        self.inner()
+            .servo
+            .constellation_proxy()
+            .send(EmbedderToConstellationMessage::LoadUrl(
+                self.id(),
+                url.into(),
+                Some(additional_headers),
             ))
     }
 

--- a/components/shared/constellation/lib.rs
+++ b/components/shared/constellation/lib.rs
@@ -27,6 +27,7 @@ use embedder_traits::{
     ViewportDetails, WebDriverCommandMsg,
 };
 pub use from_script_message::*;
+use http::HeaderMap;
 use malloc_size_of_derive::MallocSizeOf;
 use paint_api::PinchZoomInfos;
 use profile_traits::mem::MemoryReportResult;
@@ -47,8 +48,8 @@ pub enum EmbedderToConstellationMessage {
     Exit,
     /// Whether to allow script to navigate.
     AllowNavigationResponse(PipelineId, bool),
-    /// Request to load a page.
-    LoadUrl(WebViewId, ServoUrl),
+    /// Request to load a page, optionally with additional headers.
+    LoadUrl(WebViewId, ServoUrl, Option<HeaderMap>),
     /// Request to traverse the joint session history of the provided browsing context.
     TraverseHistory(WebViewId, TraversalDirection, TraversalId),
     /// Inform the Constellation that a `WebView`'s [`ViewportDetails`] have changed.


### PR DESCRIPTION
This allows embedders to add some additional headers when they load a url.

Currently this functionality is untested and unused but some embedder can always use it..

Testing: Embedder methods do not have an automatic test and this is new functionality.
