### PR TITLE
servoshell: Add `largest_contentful_paint_enabled` to `EXPERIMENTAL_PREFS`

### DIFF
--- a/ports/servoshell/prefs.rs
+++ b/ports/servoshell/prefs.rs
@@ -36,6 +36,7 @@ pub(crate) static EXPERIMENTAL_PREFS: &[&str] = &[
     "dom_permissions_enabled",
     "dom_webgl2_enabled",
     "dom_webgpu_enabled",
+    "largest_contentful_paint_enabled",
     "layout_columns_enabled",
     "layout_container_queries_enabled",
     "layout_grid_enabled",

--- a/tests/wpt/meta/largest-contentful-paint/__dir__.ini
+++ b/tests/wpt/meta/largest-contentful-paint/__dir__.ini
@@ -1,1 +1,0 @@
-prefs: [largest_contentful_paint_enabled: true]

--- a/tests/wpt/meta/paint-timing/with-lcp/__dir__.ini
+++ b/tests/wpt/meta/paint-timing/with-lcp/__dir__.ini
@@ -1,1 +1,0 @@
-prefs: [largest_contentful_paint_enabled: true]


### PR DESCRIPTION
Add `largest_contentful_paint_enabled` to `EXPERIMENTAL_PREFS`.
Deleting its occurrences  from `__dir__.ini`.

Testing: Verified locally.