### PR TITLE
script: Move easy IpcChannel usage to GenericChannel usage

### DIFF
--- a/components/net/filemanager_thread.rs
+++ b/components/net/filemanager_thread.rs
@@ -9,6 +9,7 @@ use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use std::sync::atomic::{self, AtomicBool, AtomicUsize, Ordering};
 
+use base::generic_channel::GenericSender;
 use embedder_traits::{
     EmbedderControlId, EmbedderControlResponse, FilePickerRequest, GenericEmbedderProxy,
     SelectedFile,
@@ -511,7 +512,7 @@ impl FileManagerStore {
         &self,
         parent_id: Uuid,
         rel_pos: RelativePos,
-        sender: IpcSender<Result<Uuid, BlobURLStoreError>>,
+        sender: GenericSender<Result<Uuid, BlobURLStoreError>>,
         origin_in: ImmutableOrigin,
     ) {
         match self.inc_ref(&parent_id, &origin_in) {

--- a/components/net/resource_thread.rs
+++ b/components/net/resource_thread.rs
@@ -13,7 +13,8 @@ use std::sync::{Arc, Weak};
 use std::thread;
 
 use base::generic_channel::{
-    self, CallbackSetter, GenericReceiver, GenericReceiverSet, GenericSelectionResult,
+    self, CallbackSetter, GenericCallback, GenericReceiver, GenericReceiverSet,
+    GenericSelectionResult,
 };
 use base::id::CookieStoreId;
 use cookie::Cookie;
@@ -183,7 +184,7 @@ struct ResourceChannelManager {
     ca_certificates: CACertificates<'static>,
     ignore_certificate_errors: bool,
     cancellation_listeners: FxHashMap<RequestId, Weak<CancellationListener>>,
-    cookie_listeners: FxHashMap<CookieStoreId, IpcSender<CookieAsyncResponse>>,
+    cookie_listeners: FxHashMap<CookieStoreId, GenericCallback<CookieAsyncResponse>>,
 }
 
 /// This returns a tuple HttpState and a private HttpState.
@@ -504,9 +505,9 @@ impl ResourceChannelManager {
                     .collect();
                 self.send_cookie_response(cookie_store_id, CookieData::GetAll(cookies));
             },
-            CoreResourceMsg::NewCookieListener(cookie_store_id, sender, _url) => {
+            CoreResourceMsg::NewCookieListener(cookie_store_id, callback, _url) => {
                 // TODO: Use the URL for setting up the actual monitoring
-                self.cookie_listeners.insert(cookie_store_id, sender);
+                self.cookie_listeners.insert(cookie_store_id, callback);
             },
             CoreResourceMsg::RemoveCookieListener(cookie_store_id) => {
                 self.cookie_listeners.remove(&cookie_store_id);

--- a/components/net/tests/filemanager_thread.rs
+++ b/components/net/tests/filemanager_thread.rs
@@ -6,8 +6,8 @@ use std::fs::File;
 use std::io::Read;
 use std::path::PathBuf;
 
-use base::Epoch;
 use base::id::{TEST_PIPELINE_ID, TEST_WEBVIEW_ID};
+use base::{Epoch, generic_channel};
 use embedder_traits::{
     EmbedderControlId, EmbedderControlResponse, FilePickerRequest, FilterPattern,
 };
@@ -46,7 +46,14 @@ fn test_filemanager() {
 
     {
         // Try to select a dummy file "components/net/tests/test.jpeg"
-        let (result_sender, result_receiver) = ipc::channel().unwrap();
+        let (result_sender, result_receiver) = crossbeam_channel::unbounded();
+        let callback = profile_traits::generic_callback::GenericCallback::new(
+            profile_traits::time::ProfilerChan(None),
+            move |msg| {
+                result_sender.send(msg.unwrap()).unwrap();
+            },
+        )
+        .unwrap();
         let control_id = EmbedderControlId {
             webview_id: TEST_WEBVIEW_ID,
             pipeline_id: TEST_PIPELINE_ID,
@@ -62,7 +69,7 @@ fn test_filemanager() {
         filemanager.handle(FileManagerThreadMsg::SelectFiles(
             control_id,
             file_picker_request,
-            result_sender,
+            callback,
         ));
 
         loop {
@@ -134,15 +141,14 @@ fn test_filemanager() {
 
         // Delete the id
         {
-            let (tx2, rx2) = ipc::channel().unwrap();
+            let (tx2, rx2) = generic_channel::channel().unwrap();
             filemanager.handle(FileManagerThreadMsg::DecRef(
                 selected.id.clone(),
                 origin.clone(),
                 tx2,
             ));
 
-            let ret = rx2.recv().expect("Broken channel");
-            assert!(ret.is_ok(), "DecRef is not okay");
+            assert!(rx2.recv().is_ok(), "DecRef is not okay");
         }
 
         // Test by reading again, expecting read error because we invalidated the id

--- a/components/script/dom/cookiestore.rs
+++ b/components/script/dom/cookiestore.rs
@@ -6,13 +6,11 @@ use std::borrow::Cow;
 use std::collections::VecDeque;
 use std::rc::Rc;
 
-use base::generic_channel::{GenericSend, GenericSender};
+use base::generic_channel::{GenericCallback, GenericSend, GenericSender};
 use base::id::CookieStoreId;
 use cookie::{Cookie, SameSite};
 use dom_struct::dom_struct;
 use hyper_serde::Serde;
-use ipc_channel::ipc;
-use ipc_channel::router::ROUTER;
 use itertools::Itertools;
 use js::jsval::NullValue;
 use net_traits::CookieSource::NonHTTP;
@@ -138,8 +136,6 @@ impl CookieStore {
     }
 
     fn setup_route(&self) {
-        let (cookie_sender, cookie_receiver) = ipc::channel().expect("ipc channel failure");
-
         let context = Trusted::new(self);
         let cs_listener = CookieListener {
             task_source: self
@@ -150,20 +146,18 @@ impl CookieStore {
             context,
         };
 
-        ROUTER.add_typed_route(
-            cookie_receiver,
-            Box::new(move |message| match message {
-                Ok(msg) => cs_listener.handle(msg),
-                Err(err) => warn!("Error receiving a CookieStore message: {:?}", err),
-            }),
-        );
+        let callback = GenericCallback::new(move |message| match message {
+            Ok(msg) => cs_listener.handle(msg),
+            Err(err) => warn!("Error receiving a CookieStore message: {:?}", err),
+        })
+        .expect("Could not create cookie store callback");
 
         let res = self
             .global()
             .resource_threads()
             .send(CoreResourceMsg::NewCookieListener(
                 self.droppable.store_id,
-                cookie_sender,
+                callback,
                 self.global().creation_url(),
             ));
         if res.is_err() {

--- a/components/script/dom/document.rs
+++ b/components/script/dom/document.rs
@@ -50,7 +50,7 @@ use net_traits::request::{
 };
 use net_traits::response::HttpsState;
 use percent_encoding::percent_decode;
-use profile_traits::ipc as profile_ipc;
+use profile_traits::generic_channel as profile_generic_channel;
 use profile_traits::time::TimerMetadataFrameType;
 use regex::bytes::Regex;
 use rustc_hash::{FxBuildHasher, FxHashMap};
@@ -6164,7 +6164,8 @@ impl DocumentMethods<crate::DomTypeHolder> for Document {
         }
 
         let url = self.url();
-        let (tx, rx) = profile_ipc::channel(self.global().time_profiler_chan().clone()).unwrap();
+        let (tx, rx) =
+            profile_generic_channel::channel(self.global().time_profiler_chan().clone()).unwrap();
         let _ = self
             .window
             .as_global_scope()

--- a/components/script/dom/document_embedder_controls.rs
+++ b/components/script/dom/document_embedder_controls.rs
@@ -13,7 +13,6 @@ use embedder_traits::{
     EmbedderControlRequest, EmbedderControlResponse, EmbedderMsg,
 };
 use euclid::{Point2D, Rect, Size2D};
-use ipc_channel::router::ROUTER;
 use js::context::JSContext;
 use net_traits::CoreResourceMsg;
 use net_traits::filemanager_thread::FileManagerThreadMsg;
@@ -134,14 +133,10 @@ impl DocumentEmbedderControls {
                 .window
                 .send_to_embedder(EmbedderMsg::ShowEmbedderControl(id, rect, request)),
             EmbedderControlRequest::FilePicker(file_picker_request) => {
-                let (sender, receiver) = profile_traits::ipc::channel(
-                    self.window.as_global_scope().time_profiler_chan().clone(),
-                )
-                .expect("Error initializing channel");
                 let main_thread_sender = self.window.main_thread_script_chan().clone();
-                ROUTER.add_typed_route(
-                    receiver.to_ipc_receiver(),
-                    Box::new(move |result| {
+                let callback = profile_traits::generic_callback::GenericCallback::new(
+                    self.window.as_global_scope().time_profiler_chan().clone(),
+                    move |result| {
                         let Ok(embedder_control_response) = result else {
                             return;
                         };
@@ -153,14 +148,15 @@ impl DocumentEmbedderControls {
                         ) {
                             warn!("Could not send FileManager response to main thread: {error}")
                         }
-                    }),
-                );
+                    },
+                )
+                .expect("Could not create callback");
                 self.window
                     .as_global_scope()
                     .resource_threads()
                     .sender()
                     .send(CoreResourceMsg::ToFileManager(
-                        FileManagerThreadMsg::SelectFiles(id, file_picker_request, sender),
+                        FileManagerThreadMsg::SelectFiles(id, file_picker_request, callback),
                     ))
                     .unwrap();
             },

--- a/components/script/dom/globalscope.rs
+++ b/components/script/dom/globalscope.rs
@@ -59,7 +59,10 @@ use net_traits::response::HttpsState;
 use net_traits::{
     CoreResourceMsg, CoreResourceThread, ReferrerPolicy, ResourceThreads, fetch_async,
 };
-use profile_traits::{ipc as profile_ipc, mem as profile_mem, time as profile_time};
+use profile_traits::{
+    generic_channel as profile_generic_channel, ipc as profile_ipc, mem as profile_mem,
+    time as profile_time,
+};
 use rustc_hash::{FxBuildHasher, FxHashMap};
 use script_bindings::interfaces::GlobalScopeHelpers;
 use script_bindings::settings_stack::run_a_script;
@@ -1877,7 +1880,7 @@ impl GlobalScope {
     fn decrement_file_ref(&self, id: Uuid) {
         let origin = self.origin().immutable();
 
-        let (tx, rx) = profile_ipc::channel(self.time_profiler_chan().clone()).unwrap();
+        let (tx, rx) = profile_generic_channel::channel(self.time_profiler_chan().clone()).unwrap();
 
         let msg = FileManagerThreadMsg::DecRef(id, origin.clone(), tx);
         self.send_to_file_manager(msg);
@@ -2072,7 +2075,7 @@ impl GlobalScope {
     ) -> Uuid {
         let origin = self.origin().immutable();
 
-        let (tx, rx) = profile_ipc::channel(self.time_profiler_chan().clone()).unwrap();
+        let (tx, rx) = profile_generic_channel::channel(self.time_profiler_chan().clone()).unwrap();
         let msg =
             FileManagerThreadMsg::AddSlicedURLEntry(*parent_file_id, *rel_pos, tx, origin.clone());
         self.send_to_file_manager(msg);

--- a/components/script/dom/history.rs
+++ b/components/script/dom/history.rs
@@ -16,7 +16,7 @@ use js::jsapi::Heap;
 use js::jsval::{JSVal, NullValue, UndefinedValue};
 use js::rust::{HandleValue, MutableHandleValue};
 use net_traits::CoreResourceMsg;
-use profile_traits::{generic_channel, ipc};
+use profile_traits::generic_channel;
 use servo_url::ServoUrl;
 
 use crate::dom::bindings::codegen::Bindings::HistoryBinding::HistoryMethods;
@@ -109,7 +109,8 @@ impl History {
         self.state_id.set(state_id);
         let serialized_data = match state_id {
             Some(state_id) => {
-                let (tx, rx) = ipc::channel(self.global().time_profiler_chan().clone()).unwrap();
+                let (tx, rx) =
+                    generic_channel::channel(self.global().time_profiler_chan().clone()).unwrap();
                 let _ = self
                     .window
                     .as_global_scope()

--- a/components/script/dom/html/htmlcanvaselement.rs
+++ b/components/script/dom/html/htmlcanvaselement.rs
@@ -13,8 +13,6 @@ use constellation_traits::ScriptToConstellationMessage;
 use dom_struct::dom_struct;
 use euclid::default::Size2D;
 use html5ever::{LocalName, Prefix, local_name, ns};
-#[cfg(feature = "webgpu")]
-use ipc_channel::ipc::{self as ipcchan};
 use js::error::throw_type_error;
 use js::rust::{HandleObject, HandleValue};
 use layout_api::HTMLCanvasData;
@@ -322,13 +320,15 @@ impl HTMLCanvasElement {
 
     #[cfg(feature = "webgpu")]
     fn get_or_init_webgpu_context(&self, can_gc: CanGc) -> Option<DomRoot<GPUCanvasContext>> {
+        use base::generic_channel;
+
         if let Some(ctx) = self.context() {
             return match *ctx {
                 RenderingContext::WebGPU(ref ctx) => Some(DomRoot::from_ref(ctx)),
                 _ => None,
             };
         }
-        let (sender, receiver) = ipcchan::channel().unwrap();
+        let (sender, receiver) = generic_channel::channel().unwrap();
         let global_scope = self.owner_global();
         let _ = global_scope
             .script_to_constellation_chan()

--- a/components/script/dom/url.rs
+++ b/components/script/dom/url.rs
@@ -10,7 +10,7 @@ use js::rust::HandleObject;
 use net_traits::CoreResourceMsg;
 use net_traits::blob_url_store::parse_blob_url;
 use net_traits::filemanager_thread::FileManagerThreadMsg;
-use profile_traits::ipc;
+use profile_traits::generic_channel;
 use script_bindings::cformat;
 use servo_url::{ImmutableOrigin, ServoUrl};
 use uuid::Uuid;
@@ -215,7 +215,8 @@ impl URLMethods<crate::DomTypeHolder> for URL {
             if url.fragment().is_none() && *origin == url.origin() {
                 if let Ok((id, _)) = parse_blob_url(&url) {
                     let resource_threads = global.resource_threads();
-                    let (tx, rx) = ipc::channel(global.time_profiler_chan().clone()).unwrap();
+                    let (tx, rx) =
+                        generic_channel::channel(global.time_profiler_chan().clone()).unwrap();
                     let msg = FileManagerThreadMsg::RevokeBlobURL(id, origin.clone(), tx);
                     let _ = resource_threads.send(CoreResourceMsg::ToFileManager(msg));
 

--- a/components/script/dom/windowproxy.rs
+++ b/components/script/dom/windowproxy.rs
@@ -17,7 +17,6 @@ use content_security_policy::sandboxing_directive::SandboxingFlagSet;
 use dom_struct::dom_struct;
 use html5ever::local_name;
 use indexmap::map::IndexMap;
-use ipc_channel::ipc;
 use js::JSCLASS_IS_GLOBAL;
 use js::glue::{
     CreateWrapperProxyHandler, DeleteWrapperProxyHandler, GetProxyPrivate, GetProxyReservedSlot,
@@ -300,7 +299,7 @@ impl WindowProxy {
         name: DOMString,
         noopener: bool,
     ) -> Option<DomRoot<WindowProxy>> {
-        let (response_sender, response_receiver) = ipc::channel().unwrap();
+        let (response_sender, response_receiver) = generic_channel::channel().unwrap();
         let window = self
             .currently_active
             .get()
@@ -939,7 +938,7 @@ unsafe fn GetSubframeWindowProxy(
         let script_window_proxies = ScriptThread::window_proxies();
         if let Ok(win) = root_from_handleobject::<Window>(target.handle(), cx) {
             let browsing_context_id = win.window_proxy().browsing_context_id();
-            let (result_sender, result_receiver) = ipc::channel().unwrap();
+            let (result_sender, result_receiver) = generic_channel::channel().unwrap();
 
             let _ = win.as_global_scope().script_to_constellation_chan().send(
                 ScriptToConstellationMessage::GetChildBrowsingContextId(
@@ -958,7 +957,7 @@ unsafe fn GetSubframeWindowProxy(
             root_from_handleobject::<DissimilarOriginWindow>(target.handle(), cx)
         {
             let browsing_context_id = win.window_proxy().browsing_context_id();
-            let (result_sender, result_receiver) = ipc::channel().unwrap();
+            let (result_sender, result_receiver) = generic_channel::channel().unwrap();
 
             let _ = win.global().script_to_constellation_chan().send(
                 ScriptToConstellationMessage::GetChildBrowsingContextId(

--- a/components/script/script_thread.rs
+++ b/components/script/script_thread.rs
@@ -62,7 +62,6 @@ use fonts::{FontContext, SystemFontServiceProxy};
 use headers::{HeaderMapExt, LastModified, ReferrerPolicy as ReferrerPolicyHeader};
 use http::header::REFRESH;
 use hyper_serde::Serde;
-use ipc_channel::ipc;
 use ipc_channel::router::ROUTER;
 use js::glue::GetWindowProxyClass;
 use js::jsapi::{GCReason, JS_GC, JSContext as UnsafeJSContext};
@@ -3367,7 +3366,7 @@ impl ScriptThread {
         sender_pipeline_id: PipelineId,
         browsing_context_id: BrowsingContextId,
     ) -> Option<WebViewId> {
-        let (result_sender, result_receiver) = ipc::channel().unwrap();
+        let (result_sender, result_receiver) = generic_channel::channel().unwrap();
         let msg = ScriptToConstellationMessage::GetTopForBrowsingContext(
             browsing_context_id,
             result_sender,

--- a/components/script/script_window_proxies.rs
+++ b/components/script/script_window_proxies.rs
@@ -2,9 +2,9 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
+use base::generic_channel;
 use base::id::{BrowsingContextId, PipelineId, WebViewId};
 use constellation_traits::ScriptToConstellationMessage;
-use ipc_channel::ipc;
 use rustc_hash::FxBuildHasher;
 use script_bindings::inheritance::Castable;
 use script_bindings::root::{Dom, DomRoot};
@@ -165,7 +165,7 @@ impl ScriptWindowProxies {
         webview_id: WebViewId,
         pipeline_id: PipelineId,
     ) -> Option<(BrowsingContextId, Option<PipelineId>)> {
-        let (result_sender, result_receiver) = ipc::channel().unwrap();
+        let (result_sender, result_receiver) = generic_channel::channel().unwrap();
         let msg = ScriptToConstellationMessage::GetBrowsingContextInfo(pipeline_id, result_sender);
         senders
             .pipeline_to_constellation_sender

--- a/components/script/webdriver_handlers.rs
+++ b/components/script/webdriver_handlers.rs
@@ -6,7 +6,7 @@ use std::collections::{HashMap, HashSet};
 use std::ffi::CString;
 use std::ptr::NonNull;
 
-use base::generic_channel::{GenericOneshotSender, GenericSend, GenericSender};
+use base::generic_channel::{self, GenericOneshotSender, GenericSend, GenericSender};
 use base::id::{BrowsingContextId, PipelineId};
 use cookie::Cookie;
 use embedder_traits::{
@@ -16,7 +16,6 @@ use embedder_traits::{
 };
 use euclid::default::{Point2D, Rect, Size2D};
 use hyper_serde::Serde;
-use ipc_channel::ipc::{self};
 use js::context::JSContext;
 use js::conversions::jsstr_to_string;
 use js::jsapi::{
@@ -1405,7 +1404,7 @@ pub(crate) fn handle_get_cookies(
             match documents.find_document(pipeline) {
                 Some(document) => {
                     let url = document.url();
-                    let (sender, receiver) = ipc::channel().unwrap();
+                    let (sender, receiver) = generic_channel::channel().unwrap();
                     let _ = document
                         .window()
                         .as_global_scope()
@@ -1432,7 +1431,7 @@ pub(crate) fn handle_get_cookie(
             match documents.find_document(pipeline) {
                 Some(document) => {
                     let url = document.url();
-                    let (sender, receiver) = ipc::channel().unwrap();
+                    let (sender, receiver) = generic_channel::channel().unwrap();
                     let _ = document
                         .window()
                         .as_global_scope()

--- a/components/shared/constellation/from_script_message.rs
+++ b/components/shared/constellation/from_script_message.rs
@@ -408,7 +408,7 @@ pub struct AuxiliaryWebViewCreationRequest {
     /// The pipeline opener browsing context.
     pub opener_pipeline_id: PipelineId,
     /// Sender for the constellation’s response to our request.
-    pub response_sender: IpcSender<Option<AuxiliaryWebViewCreationResponse>>,
+    pub response_sender: GenericSender<Option<AuxiliaryWebViewCreationResponse>>,
 }
 
 /// Constellation’s response to auxiliary browsing context creation requests.
@@ -621,18 +621,18 @@ pub enum ScriptToConstellationMessage {
     /// Requests the constellation to focus the specified browsing context.
     FocusRemoteDocument(BrowsingContextId),
     /// Get the top-level browsing context info for a given browsing context.
-    GetTopForBrowsingContext(BrowsingContextId, IpcSender<Option<WebViewId>>),
+    GetTopForBrowsingContext(BrowsingContextId, GenericSender<Option<WebViewId>>),
     /// Get the browsing context id of the browsing context in which pipeline is
     /// embedded and the parent pipeline id of that browsing context.
     GetBrowsingContextInfo(
         PipelineId,
-        IpcSender<Option<(BrowsingContextId, Option<PipelineId>)>>,
+        GenericSender<Option<(BrowsingContextId, Option<PipelineId>)>>,
     ),
     /// Get the nth child browsing context ID for a given browsing context, sorted in tree order.
     GetChildBrowsingContextId(
         BrowsingContextId,
         usize,
-        IpcSender<Option<BrowsingContextId>>,
+        GenericSender<Option<BrowsingContextId>>,
     ),
     /// All pending loads are complete, and the `load` event for this pipeline
     /// has been dispatched.
@@ -708,7 +708,7 @@ pub enum ScriptToConstellationMessage {
     ),
     #[cfg(feature = "webgpu")]
     /// Get WebGPU channel
-    GetWebGPUChan(IpcSender<Option<WebGPU>>),
+    GetWebGPUChan(GenericSender<Option<WebGPU>>),
     /// Notify the constellation of a pipeline's document's title.
     TitleChanged(PipelineId, String),
     /// Notify the constellation that the size of some `<iframe>`s has changed.

--- a/components/shared/net/filemanager_thread.rs
+++ b/components/shared/net/filemanager_thread.rs
@@ -5,10 +5,12 @@
 use std::cmp::{max, min};
 use std::ops::Range;
 
+use base::generic_channel::GenericSender;
 use embedder_traits::{EmbedderControlId, EmbedderControlResponse, FilePickerRequest};
 use ipc_channel::ipc::IpcSender;
 use malloc_size_of_derive::MallocSizeOf;
 use num_traits::ToPrimitive;
+use profile_traits::generic_callback::GenericCallback;
 use serde::{Deserialize, Serialize};
 use servo_url::ImmutableOrigin;
 use uuid::Uuid;
@@ -122,7 +124,7 @@ pub enum FileManagerThreadMsg {
     SelectFiles(
         EmbedderControlId,
         FilePickerRequest,
-        IpcSender<EmbedderControlResponse>,
+        GenericCallback<EmbedderControlResponse>,
     ),
 
     /// Read FileID-indexed file in chunks, optionally check URL validity based on boolean flag
@@ -140,7 +142,7 @@ pub enum FileManagerThreadMsg {
     AddSlicedURLEntry(
         Uuid,
         RelativePos,
-        IpcSender<Result<Uuid, BlobURLStoreError>>,
+        GenericSender<Result<Uuid, BlobURLStoreError>>,
         ImmutableOrigin,
     ),
 
@@ -148,7 +150,7 @@ pub enum FileManagerThreadMsg {
     DecRef(
         Uuid,
         ImmutableOrigin,
-        IpcSender<Result<(), BlobURLStoreError>>,
+        GenericSender<Result<(), BlobURLStoreError>>,
     ),
 
     /// Activate an internal FileID so it becomes valid as part of a Blob URL
@@ -162,7 +164,7 @@ pub enum FileManagerThreadMsg {
     RevokeBlobURL(
         Uuid,
         ImmutableOrigin,
-        IpcSender<Result<(), BlobURLStoreError>>,
+        GenericSender<Result<(), BlobURLStoreError>>,
     ),
 }
 

--- a/components/shared/net/lib.rs
+++ b/components/shared/net/lib.rs
@@ -10,7 +10,8 @@ use std::thread::{self, JoinHandle};
 
 use base::cross_process_instant::CrossProcessInstant;
 use base::generic_channel::{
-    self, CallbackSetter, GenericOneshotSender, GenericSend, GenericSender, SendResult,
+    self, CallbackSetter, GenericCallback, GenericOneshotSender, GenericSend, GenericSender,
+    SendResult,
 };
 use base::id::{CookieStoreId, HistoryStateId, PipelineId};
 use content_security_policy::{self as csp};
@@ -625,11 +626,11 @@ pub enum CoreResourceMsg {
         CookieSource,
     ),
     /// Retrieve the stored cookies for a given URL
-    GetCookiesForUrl(ServoUrl, IpcSender<Option<String>>, CookieSource),
+    GetCookiesForUrl(ServoUrl, GenericSender<Option<String>>, CookieSource),
     /// Get a cookie by name for a given originating URL
     GetCookiesDataForUrl(
         ServoUrl,
-        IpcSender<Vec<Serde<Cookie<'static>>>>,
+        GenericSender<Vec<Serde<Cookie<'static>>>>,
         CookieSource,
     ),
     GetCookieDataForUrlAsync(CookieStoreId, ServoUrl, Option<String>),
@@ -640,11 +641,15 @@ pub enum CoreResourceMsg {
     DeleteCookies(Option<ServoUrl>, Option<IpcSender<()>>),
     DeleteCookie(ServoUrl, String),
     DeleteCookieAsync(CookieStoreId, ServoUrl, String),
-    NewCookieListener(CookieStoreId, IpcSender<CookieAsyncResponse>, ServoUrl),
+    NewCookieListener(
+        CookieStoreId,
+        GenericCallback<CookieAsyncResponse>,
+        ServoUrl,
+    ),
     RemoveCookieListener(CookieStoreId),
     ListCookies(GenericSender<Vec<SiteDescriptor>>),
     /// Get a history state by a given history state id
-    GetHistoryState(HistoryStateId, IpcSender<Option<Vec<u8>>>),
+    GetHistoryState(HistoryStateId, GenericSender<Option<Vec<u8>>>),
     /// Set a history state for a given history state id
     SetHistoryState(HistoryStateId, Vec<u8>),
     /// Removes history states for the given ids

--- a/tests/wpt/meta/cookiestore/cookieStore_set_limit.https.any.js.ini
+++ b/tests/wpt/meta/cookiestore/cookieStore_set_limit.https.any.js.ini
@@ -1,13 +1,2 @@
 [cookieStore_set_limit.https.any.serviceworker.html]
   expected: ERROR
-
-[cookieStore_set_limit.https.any.html]
-  expected: TIMEOUT
-  [Set max-size name-less cookie]
-    expected: TIMEOUT
-
-  [Ignore name-less cookie with value larger than 4096 bytes]
-    expected: NOTRUN
-
-  [Ignore name-less cookie (without leading =) with value larger than 4096 bytes]
-    expected: NOTRUN


### PR DESCRIPTION
This moves some easy elements in Script from IpcChannel and related methods to GenericChannel and related methods and some callbacks. 

Testing: This will be covered by WPT if the channels behave differently.
