### PR TITLE
Draft: load with http headers and load data with

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7513,6 +7513,7 @@ name = "servo-constellation"
 version = "0.0.1"
 dependencies = [
  "backtrace",
+ "base64 0.22.1",
  "content-security-policy",
  "crossbeam-channel",
  "euclid",

--- a/components/constellation/Cargo.toml
+++ b/components/constellation/Cargo.toml
@@ -28,6 +28,7 @@ background_hang_monitor = { package = "servo-background-hang-monitor", path = ".
 background_hang_monitor_api = { workspace = true }
 backtrace = { workspace = true }
 base = { workspace = true }
+base64 = { workspace = true }
 bluetooth_traits = { workspace = true, optional = true }
 canvas = { package = "servo-canvas", path = "../canvas" }
 canvas_traits = { workspace = true }

--- a/components/constellation/constellation.rs
+++ b/components/constellation/constellation.rs
@@ -99,6 +99,8 @@ use background_hang_monitor::HangMonitorRegister;
 use background_hang_monitor_api::{
     BackgroundHangMonitorControlMsg, BackgroundHangMonitorRegister, HangMonitorAlert,
 };
+use base64::engine::general_purpose::STANDARD as BASE64_STANDARD;
+use base64::Engine;
 use base::generic_channel::{
     GenericCallback, GenericSend, GenericSender, RoutedReceiver, SendError,
 };
@@ -1394,8 +1396,11 @@ where
             // Load a new page from a typed url
             // If there is already a pending page (self.pending_changes), it will not be overridden;
             // However, if the id is not encompassed by another change, it will be.
-            EmbedderToConstellationMessage::LoadUrl(webview_id, url) => {
-                let load_data = LoadData::new_for_new_unrelated_webview(url);
+            EmbedderToConstellationMessage::LoadUrl(webview_id, url, optional_headers) => {
+                let mut load_data = LoadData::new_for_new_unrelated_webview(url);
+                if let Some(headers) = optional_headers {
+                    load_data.headers.extend(headers);
+                }
                 let ctx_id = BrowsingContextId::from(webview_id);
                 let pipeline_id = match self.browsing_contexts.get(&ctx_id) {
                     Some(ctx) => ctx.pipeline_id,
@@ -1405,6 +1410,51 @@ where
                 };
                 // Since this is a top-level load, initiated by the embedder, go straight to load_url,
                 // bypassing schedule_navigation.
+                self.load_url(
+                    webview_id,
+                    pipeline_id,
+                    load_data,
+                    NavigationHistoryBehavior::Push,
+                );
+            },
+            // Load inline content from a data string with a base URL.
+            EmbedderToConstellationMessage::LoadData(
+                webview_id,
+                base_url,
+                data,
+                mime_type,
+                encoding,
+                _history_url,
+            ) => {
+                let mime = mime_type.as_deref().unwrap_or("text/html");
+                let encoded = BASE64_STANDARD.encode(data.as_bytes());
+                let charset_part = match &encoding {
+                    Some(enc) => format!(";charset={}", enc),
+                    None => String::new(),
+                };
+                let data_url_string =
+                    format!("data:{}{};base64,{}", mime, charset_part, encoded);
+                let url = match ServoUrl::parse(&data_url_string) {
+                    Ok(url) => url,
+                    Err(e) => {
+                        return warn!(
+                            "{}: LoadData failed to construct data URL: {}",
+                            webview_id, e
+                        );
+                    },
+                };
+                let mut load_data = LoadData::new_for_new_unrelated_webview(url);
+                load_data.about_base_url = base_url;
+                let ctx_id = BrowsingContextId::from(webview_id);
+                let pipeline_id = match self.browsing_contexts.get(&ctx_id) {
+                    Some(ctx) => ctx.pipeline_id,
+                    None => {
+                        return warn!(
+                            "{}: LoadData for unknown browsing context",
+                            webview_id
+                        );
+                    },
+                };
                 self.load_url(
                     webview_id,
                     pipeline_id,

--- a/components/constellation/tracing.rs
+++ b/components/constellation/tracing.rs
@@ -52,6 +52,7 @@ mod from_embedder {
                 Self::Exit => target!("Exit"),
                 Self::AllowNavigationResponse(..) => target!("AllowNavigationResponse"),
                 Self::LoadUrl(..) => target!("LoadUrl"),
+                Self::LoadData(..) => target!("LoadData"),
                 Self::TraverseHistory(..) => target!("TraverseHistory"),
                 Self::ChangeViewportDetails(..) => target!("ChangeViewportDetails"),
                 Self::ThemeChange(..) => target!("ThemeChange"),

--- a/components/servo/Cargo.toml
+++ b/components/servo/Cargo.toml
@@ -91,6 +91,7 @@ env_logger = { workspace = true }
 euclid = { workspace = true }
 fonts = { package = "servo-fonts", path = "../fonts" }
 gstreamer = { workspace = true, optional = true }
+http = { workspace = true }
 image = { workspace = true }
 ipc-channel = { workspace = true }
 keyboard-types = { workspace = true }

--- a/components/servo/webview.rs
+++ b/components/servo/webview.rs
@@ -447,6 +447,41 @@ impl WebView {
             .send(EmbedderToConstellationMessage::LoadUrl(
                 self.id(),
                 url.into(),
+                None,
+            ))
+    }
+
+    /// Load a URL with additional HTTP headers.
+    pub fn load_url_with_headers(&self, url: Url, headers: http::HeaderMap) {
+        self.inner()
+            .servo
+            .constellation_proxy()
+            .send(EmbedderToConstellationMessage::LoadUrl(
+                self.id(),
+                url.into(),
+                Some(headers),
+            ))
+    }
+
+    /// Loads the given data into this WebView, using `base_url` as the base URL for the content.
+    pub fn load_data(
+        &self,
+        base_url: Option<Url>,
+        data: String,
+        mime_type: Option<String>,
+        encoding: Option<String>,
+        history_url: Option<Url>,
+    ) {
+        self.inner()
+            .servo
+            .constellation_proxy()
+            .send(EmbedderToConstellationMessage::LoadData(
+                self.id(),
+                base_url.map(Into::into),
+                data,
+                mime_type,
+                encoding,
+                history_url.map(Into::into),
             ))
     }
 

--- a/components/shared/constellation/lib.rs
+++ b/components/shared/constellation/lib.rs
@@ -18,6 +18,7 @@ use std::time::Duration;
 use base::cross_process_instant::CrossProcessInstant;
 use base::generic_channel::GenericCallback;
 use base::id::{MessagePortId, PipelineId, ScriptEventLoopId, WebViewId};
+use http::HeaderMap;
 use embedder_traits::user_contents::{
     UserContentManagerId, UserScript, UserScriptId, UserStyleSheet, UserStyleSheetId,
 };
@@ -47,8 +48,17 @@ pub enum EmbedderToConstellationMessage {
     Exit,
     /// Whether to allow script to navigate.
     AllowNavigationResponse(PipelineId, bool),
-    /// Request to load a page.
-    LoadUrl(WebViewId, ServoUrl),
+    /// Request to load a page, optionally with additional HTTP headers.
+    LoadUrl(WebViewId, ServoUrl, Option<HeaderMap>),
+    /// Request to load inline content from a data string with a base URL.
+    LoadData(
+        WebViewId,
+        Option<ServoUrl>,
+        String,
+        Option<String>,
+        Option<String>,
+        Option<ServoUrl>,
+    ),
     /// Request to traverse the joint session history of the provided browsing context.
     TraverseHistory(WebViewId, TraversalDirection, TraversalId),
     /// Inform the Constellation that a `WebView`'s [`ViewportDetails`] have changed.


### PR DESCRIPTION
Draft: load with http headers and load data

Co-authored-by: Narfinger <Narfinger@users.noreply.github.com>: https://github.com/servo/servo/pull/43305
cc: @Narfinger 

Implement [load with http headers](https://developer.android.com/reference/android/webkit/WebView#loadUrl(java.lang.String,%20java.util.Map%3Cjava.lan)g.String,java.lang.String%3E) and load [data with base url](
https://developer.android.com/reference/android/webkit/WebView#loadDataWithBaseURL(java.lang.String,%20java.lang.String,%20java.lang.String,%20java.lang.String,%20java.lang.String))
