### PR TITLE
script: ML-KEM/ML-DSA PKCS8 keys in non-seed-only formats

### DIFF
--- a/components/script/dom/subtlecrypto/ml_dsa_operation.rs
+++ b/components/script/dom/subtlecrypto/ml_dsa_operation.rs
@@ -531,14 +531,13 @@ pub(crate) fn import_key(
             // structure algorithm, with data as the privateKey field of privateKeyInfo, structure
             // as asn1Structure, and exactData set to true.
             // Step 2.8. If an error occurred while parsing, then throw a DataError.
+            // Step 2.9. If mlDsaPrivateKey represents an ML-DSA key in the expandedKey format, or
+            // if mlDsaPrivateKey represents an ML-DSA key in the both format and the both format
+            // is not supported, throw a NotSupportedError.
+            // Step 2.10. If mlDsaPrivateKey represents an ML-DSA key in the both format, and the
+            // seed field does not correspond to the expandedKey field, throw a DataError.
             //
-            // NOTE: There is an ongoing discussion on how to handle private keys in the
-            // "expandedKey" and "both" formats.
-            // - <https://github.com/WICG/webcrypto-modern-algos/issues/29>
-            // - <https://github.com/WICG/webcrypto-modern-algos/pull/34>
-            // For now, we accept the "seed" format, reject the "expandedKey" format with a
-            // NotSupportedError, and accept the "both" format subject to a consistency check. This
-            // behavior may change in the future once the discussion is settled.
+            // NOTE: We support the `both` format, with consistency check.
             let private_key_structure =
                 MlDsaPrivateKeyStructure::from_der(private_key_info.private_key).map_err(|_| {
                     Error::Data(Some(
@@ -572,13 +571,13 @@ pub(crate) fn import_key(
                 },
             };
 
-            // Step 2.9. Let key be a new CryptoKey that represents the ML-DSA private key
+            // Step 2.11. Let key be a new CryptoKey that represents the ML-DSA private key
             // identified by mlDsaPrivateKey.
-            // Step 2.10. Set the [[type]] internal slot of key to "private"
-            // Step 2.11. Let algorithm be a new KeyAlgorithm.
-            // Step 2.12. Set the name attribute of algorithm to the name attribute of
+            // Step 2.12. Set the [[type]] internal slot of key to "private"
+            // Step 2.13. Let algorithm be a new KeyAlgorithm.
+            // Step 2.14. Set the name attribute of algorithm to the name attribute of
             // normalizedAlgorithm.
-            // Step 2.13. Set the [[algorithm]] internal slot of key to algorithm.
+            // Step 2.15. Set the [[algorithm]] internal slot of key to algorithm.
             let algorithm = SubtleKeyAlgorithm {
                 name: normalized_algorithm.name,
             };

--- a/components/script/dom/subtlecrypto/ml_kem_operation.rs
+++ b/components/script/dom/subtlecrypto/ml_kem_operation.rs
@@ -557,14 +557,13 @@ pub(crate) fn import_key(
             // structure algorithm, with data as the privateKey field of privateKeyInfo, structure
             // as asn1Structure, and exactData set to true.
             // Step 2.8. If an error occurred while parsing, then throw a DataError.
+            // Step 2.9. If mlKemPrivateKey represents an ML-KEM key in the expandedKey format, or
+            // if mlKemPrivateKey represents an ML-KEM key in the both format and the both format
+            // is not supported, throw a NotSupportedError.
+            // Step 2.10. If mlKemPrivateKey represents an ML-KEM key in the both format, and the
+            // seed field does not correspond to the expandedKey field, throw a DataError.
             //
-            // NOTE: There is an ongoing discussion on how to handle private keys in the
-            // "expandedKey" and "both" formats.
-            // - <https://github.com/WICG/webcrypto-modern-algos/issues/29>
-            // - <https://github.com/WICG/webcrypto-modern-algos/pull/34>
-            // For now, we accept the "seed" format, reject the "expandedKey" format with a
-            // NotSupportedError, and accept the "both" format subject to a consistency check. This
-            // behavior may change in the future once the discussion is settled.
+            // NOTE: We support the `both` format, with consistency check.
             let private_key_structure =
                 MlKemPrivateKeyStructure::from_der(private_key_info.private_key).map_err(|_| {
                     Error::Data(Some(
@@ -598,13 +597,13 @@ pub(crate) fn import_key(
                 },
             };
 
-            // Step 2.9. Let key be a new CryptoKey that represents the ML-KEM private key
+            // Step 2.11. Let key be a new CryptoKey that represents the ML-KEM private key
             // identified by mlKemPrivateKey.
-            // Step 2.10. Set the [[type]] internal slot of key to "private"
-            // Step 2.11. Let algorithm be a new KeyAlgorithm.
-            // Step 2.12. Set the name attribute of algorithm to the name attribute of
+            // Step 2.12. Set the [[type]] internal slot of key to "private"
+            // Step 2.13. Let algorithm be a new KeyAlgorithm.
+            // Step 2.14. Set the name attribute of algorithm to the name attribute of
             // normalizedAlgorithm.
-            // Step 2.13. Set the [[algorithm]] internal slot of key to algorithm.
+            // Step 2.15. Set the [[algorithm]] internal slot of key to algorithm.
             let algorithm = SubtleKeyAlgorithm {
                 name: normalized_algorithm.name,
             };


### PR DESCRIPTION
The specification of Modern Algorithms in WebCrypto API has updated to specify how to handle ML-KEM/DSA PKCS8 keys in non-seed-only formats.

In the updated specification:

- When importing a key in the `expandedKey` format, throw a `NotSupportedError`.
- When importing a key in the `both` format, *optionally* throw a `NotSupportedError`.
- Alternatively, when importing a key in the `both` format, require checking that the seed and expanded key match.

Our implementation matches the updated specification, with support of the `both` format. Therefore, this patch only updates the specification text, without changing the code.

Related commit in specification repository: https://github.com/WICG/webcrypto-modern-algos/commit/6543db893e9f229c1381b6af60122e9a5db93ebd

Testing: Only changes in spec text. No code change.