### PR TITLE
devtools: Remove `EvaluateJS` in favor of `Eval`

### DIFF
--- a/components/script/devtools.rs
+++ b/components/script/devtools.rs
@@ -9,20 +9,14 @@ use std::str;
 use base::generic_channel::GenericSender;
 use base::id::PipelineId;
 use devtools_traits::{
-    AttrModification, AutoMargins, ComputedNodeLayout, CssDatabaseProperty, EvaluateJSReply,
-    EvaluateJSReplyValue, EventListenerInfo, NodeInfo, NodeStyle, RuleModification, TimelineMarker,
-    TimelineMarkerType,
+    AttrModification, AutoMargins, ComputedNodeLayout, CssDatabaseProperty, EventListenerInfo,
+    NodeInfo, NodeStyle, RuleModification, TimelineMarker, TimelineMarkerType,
 };
-use js::context::JSContext;
-use js::conversions::jsstr_to_string;
-use js::jsval::UndefinedValue;
-use js::rust::ToString;
 use markup5ever::{LocalName, ns};
 use rustc_hash::FxHashMap;
 use script_bindings::root::Dom;
 use servo_config::pref;
 use style::attr::AttrValue;
-use uuid::Uuid;
 
 use crate::document_collection::DocumentCollection;
 use crate::dom::bindings::codegen::Bindings::CSSRuleListBinding::CSSRuleListMethods;
@@ -35,7 +29,6 @@ use crate::dom::bindings::codegen::Bindings::ElementBinding::ElementMethods;
 use crate::dom::bindings::codegen::Bindings::HTMLElementBinding::HTMLElementMethods;
 use crate::dom::bindings::codegen::Bindings::NodeBinding::NodeConstants;
 use crate::dom::bindings::codegen::Bindings::WindowBinding::WindowMethods;
-use crate::dom::bindings::conversions::{ConversionResult, FromJSValConvertible};
 use crate::dom::bindings::inheritance::Castable;
 use crate::dom::bindings::root::DomRoot;
 use crate::dom::bindings::str::DOMString;
@@ -44,11 +37,10 @@ use crate::dom::css::cssstyledeclaration::ENABLED_LONGHAND_PROPERTIES;
 use crate::dom::css::cssstylerule::CSSStyleRule;
 use crate::dom::document::AnimationFrameCallback;
 use crate::dom::element::Element;
-use crate::dom::globalscope::GlobalScope;
 use crate::dom::node::{Node, NodeTraits, ShadowIncluding};
 use crate::dom::types::{EventTarget, HTMLElement};
-use crate::realms::{enter_auto_realm, enter_realm};
-use crate::script_runtime::{CanGc, IntroductionType};
+use crate::realms::enter_realm;
+use crate::script_runtime::CanGc;
 
 #[cfg_attr(crown, crown::unrooted_must_root_lint::must_root)]
 #[derive(JSTraceable)]
@@ -121,64 +113,6 @@ impl DevtoolsState {
             .get(node_id)
             .map(|node: &Dom<Node>| node.as_rooted())
     }
-}
-
-#[expect(unsafe_code)]
-pub(crate) fn handle_evaluate_js(
-    global: &GlobalScope,
-    eval: String,
-    reply: GenericSender<EvaluateJSReply>,
-    cx: &mut JSContext,
-) {
-    let value = unsafe {
-        let mut realm = enter_auto_realm(cx, global);
-        let cx = &mut realm.current_realm();
-        rooted!(&in(cx) let mut rval = UndefinedValue());
-        // TODO: run code with SpiderMonkey Debugger API, like Firefox does
-        // <https://searchfox.org/mozilla-central/rev/f6a806c38c459e0e0d797d264ca0e8ad46005105/devtools/server/actors/webconsole/eval-with-debugger.js#270>
-        _ = global.evaluate_js_on_global(
-            cx,
-            eval.into(),
-            "<eval>",
-            Some(IntroductionType::DEBUGGER_EVAL),
-            Some(rval.handle_mut()),
-        );
-
-        if rval.is_undefined() {
-            EvaluateJSReplyValue::VoidValue
-        } else if rval.is_boolean() {
-            EvaluateJSReplyValue::BooleanValue(rval.to_boolean())
-        } else if rval.is_double() || rval.is_int32() {
-            EvaluateJSReplyValue::NumberValue(
-                match FromJSValConvertible::from_jsval(cx.raw_cx(), rval.handle(), ()) {
-                    Ok(ConversionResult::Success(v)) => v,
-                    _ => unreachable!(),
-                },
-            )
-        } else if rval.is_string() {
-            let jsstr = std::ptr::NonNull::new(rval.to_string()).unwrap();
-            EvaluateJSReplyValue::StringValue(jsstr_to_string(cx.raw_cx(), jsstr))
-        } else if rval.is_null() {
-            EvaluateJSReplyValue::NullValue
-        } else {
-            assert!(rval.is_object());
-
-            let jsstr = std::ptr::NonNull::new(ToString(cx.raw_cx(), rval.handle())).unwrap();
-            let class_name = jsstr_to_string(cx.raw_cx(), jsstr);
-
-            EvaluateJSReplyValue::ActorValue {
-                class: class_name,
-                uuid: Uuid::new_v4().to_string(),
-                name: None,
-            }
-        }
-    };
-
-    let result = EvaluateJSReply {
-        value,
-        has_exception: false,
-    };
-    reply.send(result).unwrap();
 }
 
 pub(crate) fn handle_set_timeline_markers(

--- a/components/script/dom/workers/dedicatedworkerglobalscope.rs
+++ b/components/script/dom/workers/dedicatedworkerglobalscope.rs
@@ -26,7 +26,6 @@ use net_traits::request::{
 use servo_url::{ImmutableOrigin, ServoUrl};
 use style::thread_state::{self, ThreadState};
 
-use crate::devtools;
 use crate::dom::abstractworker::{MessageData, SimpleWorkerErrorHandler, WorkerScriptMsg};
 use crate::dom::abstractworkerglobalscope::{WorkerEventLoopMethods, run_worker_event_loop};
 use crate::dom::bindings::cell::DomRefCell;
@@ -648,9 +647,6 @@ impl DedicatedWorkerGlobalScope {
         // FIXME(#26324): `self.worker` is None in devtools messages.
         match msg {
             MixedMessage::Devtools(msg) => match msg {
-                DevtoolScriptControlMsg::EvaluateJS(_pipe_id, string, sender) => {
-                    devtools::handle_evaluate_js(self.upcast(), string, sender, cx)
-                },
                 DevtoolScriptControlMsg::WantsLiveNotifications(_pipe_id, bool_val) => {
                     self.upcast::<GlobalScope>()
                         .set_devtools_wants_updates(bool_val);

--- a/components/script/dom/workers/serviceworkerglobalscope.rs
+++ b/components/script/dom/workers/serviceworkerglobalscope.rs
@@ -27,7 +27,6 @@ use servo_config::pref;
 use servo_url::ServoUrl;
 use style::thread_state::{self, ThreadState};
 
-use crate::devtools;
 use crate::dom::abstractworker::WorkerScriptMsg;
 use crate::dom::abstractworkerglobalscope::{WorkerEventLoopMethods, run_worker_event_loop};
 use crate::dom::bindings::codegen::Bindings::ServiceWorkerGlobalScopeBinding;
@@ -458,9 +457,6 @@ impl ServiceWorkerGlobalScope {
     fn handle_mixed_message(&self, msg: MixedMessage, cx: &mut js::context::JSContext) -> bool {
         match msg {
             MixedMessage::Devtools(msg) => match msg {
-                DevtoolScriptControlMsg::EvaluateJS(_pipe_id, string, sender) => {
-                    devtools::handle_evaluate_js(self.upcast(), string, sender, cx)
-                },
                 DevtoolScriptControlMsg::WantsLiveNotifications(_pipe_id, wants_updates) => {
                     self.upcast::<GlobalScope>()
                         .set_devtools_wants_updates(wants_updates);

--- a/components/script/script_thread.rs
+++ b/components/script/script_thread.rs
@@ -86,7 +86,6 @@ use profile_traits::time::ProfilerCategory;
 use profile_traits::time_profile;
 use rustc_hash::{FxHashMap, FxHashSet};
 use script_bindings::script_runtime::{JSContext, temp_cx};
-use script_bindings::settings_stack::run_a_script;
 use script_traits::{
     ConstellationInputEvent, DiscardBrowsingContext, DocumentActivity, InitialScriptState,
     NewPipelineInfo, Painter, ProgressiveWebMetricType, ScriptThreadMessage,
@@ -164,7 +163,7 @@ use crate::script_runtime::{
 use crate::script_window_proxies::ScriptWindowProxies;
 use crate::task_queue::TaskQueue;
 use crate::webdriver_handlers::jsval_to_webdriver;
-use crate::{DomTypeHolder, devtools, webdriver_handlers};
+use crate::{devtools, webdriver_handlers};
 
 thread_local!(static SCRIPT_THREAD_ROOT: Cell<Option<*const ScriptThread>> = const { Cell::new(None) });
 
@@ -2121,15 +2120,6 @@ impl ScriptThread {
     ) {
         let documents = self.documents.borrow();
         match msg {
-            DevtoolScriptControlMsg::EvaluateJS(id, s, reply) => match documents.find_window(id) {
-                Some(window) => {
-                    let global = window.as_global_scope();
-                    run_a_script::<DomTypeHolder, _>(global, || {
-                        devtools::handle_evaluate_js(global, s, reply, cx)
-                    });
-                },
-                None => warn!("Message sent to closed pipeline {}.", id),
-            },
             DevtoolScriptControlMsg::GetEventListenerInfo(id, node, reply) => {
                 devtools::handle_get_event_listener_info(&self.devtools_state, id, &node, reply)
             },

--- a/components/shared/devtools/lib.rs
+++ b/components/shared/devtools/lib.rs
@@ -282,8 +282,6 @@ pub struct AutoMargins {
 /// TODO: better error handling, e.g. if pipeline id lookup fails?
 #[derive(Debug, Deserialize, Serialize)]
 pub enum DevtoolScriptControlMsg {
-    /// Evaluate a JS snippet in the context of the global for the given pipeline.
-    EvaluateJS(PipelineId, String, GenericSender<EvaluateJSReply>),
     /// Retrieve the details of the root node (ie. the document) for the given pipeline.
     GetRootNode(PipelineId, GenericSender<Option<NodeInfo>>),
     /// Retrieve the details of the document element for the given pipeline.


### PR DESCRIPTION
The console actor sends `Eval` via debugger.js, not `EvaluateJS`. Workers only handled `EvaluateJS` which was never sent. We would want to use `Eval` for workers as well. The worker evaluation was already non-functional.

One more motivation behind not keeping this legacy path is because it requires passing `None` for all new fields added to `EvaluateJSReplyValue`, that is extra burden.

Testing: All existing tests are passing.
