### PR TITLE
servoshell: fix display of tooltip showing link target URL

### DIFF
--- a/ports/servoshell/desktop/gui.rs
+++ b/ports/servoshell/desktop/gui.rs
@@ -10,8 +10,8 @@ use dpi::PhysicalSize;
 use egui::text::{CCursor, CCursorRange};
 use egui::text_edit::TextEditState;
 use egui::{
-    Button, Key, Label, LayerId, Modifiers, PaintCallback, TopBottomPanel, Vec2, WidgetInfo,
-    WidgetType, pos2,
+    Button, Id, Key, Label, LayerId, Modifiers, Order, PaintCallback, TopBottomPanel, Vec2,
+    WidgetInfo, WidgetType, pos2,
 };
 use egui_glow::{CallbackFn, EguiGlow};
 use egui_winit::EventResponse;
@@ -485,11 +485,12 @@ impl Gui {
             if let Some(status_text) = &self.status_text {
                 egui::Tooltip::always_open(
                     ctx.clone(),
-                    LayerId::background(),
+                    LayerId::new(Order::Tooltip, Id::new("tooltip")),
                     "tooltip layer".into(),
                     pos2(0.0, ctx.available_rect().max.y),
                 )
                 .show(|ui| ui.add(Label::new(status_text.clone()).extend()));
+                window.set_needs_repaint();
             }
 
             window.repaint_webviews();


### PR DESCRIPTION
I noticed while investigating #42636 that whenever servoshell displays a link target URL, the associated tooltip is sometimes shown with some kind of transparency, that is usually - but not always - "fixed" after a bit of time.

The first problem is that we create the tooltip in the background, while we should put it on top of everything else. This is however not sufficient to fix the "flickering", hence the explicit call to set_needs_repaint, like was done for dialogs in 6d4937b5d6e47.

Testing: manual (servoshell's visual aspects not covered by any test)
Fixes: https://github.com/servo/servo/issues/42636
