### PR TITLE
script: Allow keyboard scrolling with the spacebar

### DIFF
--- a/components/script/dom/document_event_handler.rs
+++ b/components/script/dom/document_event_handler.rs
@@ -1917,6 +1917,7 @@ impl DocumentEventHandler {
             return;
         }
 
+        let mut is_space = false;
         let scroll = match event.key() {
             Key::Named(NamedKey::ArrowDown) => KeyboardScroll::Down,
             Key::Named(NamedKey::ArrowLeft) => KeyboardScroll::Left,
@@ -1926,6 +1927,14 @@ impl DocumentEventHandler {
             Key::Named(NamedKey::Home) => KeyboardScroll::Home,
             Key::Named(NamedKey::PageDown) => KeyboardScroll::PageDown,
             Key::Named(NamedKey::PageUp) => KeyboardScroll::PageUp,
+            Key::Character(string) if &string == " " => {
+                is_space = true;
+                if event.modifiers().contains(Modifiers::SHIFT) {
+                    KeyboardScroll::PageUp
+                } else {
+                    KeyboardScroll::PageDown
+                }
+            },
             Key::Named(NamedKey::Tab) => {
                 // From <https://w3c.github.io/uievents/#keydown>:
                 //
@@ -1938,9 +1947,11 @@ impl DocumentEventHandler {
             _ => return,
         };
 
-        if event.modifiers().is_empty() {
-            self.do_keyboard_scroll(scroll);
+        if !event.modifiers().is_empty() && !is_space {
+            return;
         }
+
+        self.do_keyboard_scroll(scroll);
     }
 
     pub(crate) fn set_sequential_focus_navigation_starting_point(&self, node: &Node) {

--- a/tests/wpt/mozilla/meta/MANIFEST.json
+++ b/tests/wpt/mozilla/meta/MANIFEST.json
@@ -13186,6 +13186,24 @@
       }
      ]
     ],
+    "keyboard-scrolling-iframe.sub.html": [
+     "1eb1d0966ccc5ece50e83ee410005a63416ddc39",
+     [
+      null,
+      {
+       "testdriver": true
+      }
+     ]
+    ],
+    "keyboard-scrolling.html": [
+     "756d6e68d03af791bd8f9670b2db3c28ce08cdfb",
+     [
+      null,
+      {
+       "testdriver": true
+      }
+     ]
+    ],
     "mouse-button-events-detail-increases-indefinitely.html": [
      "6bf57fe3accad4d3cbfb454e10f31b0a8540b5a5",
      [
@@ -14248,24 +14266,6 @@
      [
       null,
       {}
-     ]
-    ],
-    "keyboard-scrolling-iframe.sub.html": [
-     "e002eb6f2a35ed4f73a079acb05b3d99eb04813b",
-     [
-      null,
-      {
-       "testdriver": true
-      }
-     ]
-    ],
-    "keyboard-scrolling.html": [
-     "45916c5d11f351f0ca10cde5e52d5ee60c11bd9d",
-     [
-      null,
-      {
-       "testdriver": true
-      }
      ]
     ],
     "keyframe-infinite-percentage.html": [

--- a/tests/wpt/mozilla/tests/input-events/keyboard-scrolling-iframe.sub.html
+++ b/tests/wpt/mozilla/tests/input-events/keyboard-scrolling-iframe.sub.html
@@ -45,6 +45,7 @@
 </div>
 
 <script>
+const shift = "\uE008";
 const end = "\uE010";
 const home = "\uE011";
 const arrowDown = "\uE015";
@@ -56,8 +57,21 @@ const pageUp = "\uE00E";
 const lineSize = 76;
 const pageSize = scrollportHeight => scrollportHeight - 2 * lineSize;
 
-const pressKeyAndAssert = async (key, element, [expectedX, expectedY], description) => {
-    await test_driver.send_keys(document.body, key);
+const pressKeyAndAssert = async (keys, element, [expectedX, expectedY], description) => {
+    let actions = new test_driver.Actions();
+    if (!Array.isArray(keys)) {
+      keys = [keys];
+    }
+    for (key of keys) {
+      actions = actions.keyDown(key);
+    }
+
+    let reversedKeys = keys.reverse();
+    for (key of reversedKeys) {
+      actions = actions.keyUp(key);
+    }
+    await actions.send()
+
     const actualX =
         element == null ? scrollX
         : element.nodeName == "IFRAME" ? element.contentWindow.scrollX
@@ -87,6 +101,10 @@ promise_test(async () => {
     await pressKeyAndAssert(pageDown, iframe, [0, pageSize(iframe.contentWindow.innerHeight) * 2], "PageDown key scrolls #iframe down by almost a screenful");
     await pressKeyAndAssert(pageUp, iframe, [0, pageSize(iframe.contentWindow.innerHeight)], "PageUp key scrolls #iframe up by almost a screenful");
     await pressKeyAndAssert(pageUp, iframe, [0, 0], "PageUp key scrolls #iframe up by almost a screenful");
+    await pressKeyAndAssert(" ", iframe, [0, pageSize(iframe.contentWindow.innerHeight)], "Spacebar key scrolls #box down by almost a screenful");
+    await pressKeyAndAssert(" ", iframe, [0, pageSize(iframe.contentWindow.innerHeight) * 2], "Spacebar key scrolls #box down by almost a screenful");
+    await pressKeyAndAssert([shift, " "], iframe, [0, pageSize(iframe.contentWindow.innerHeight)], "Shift + spacebar key scrolls #box up by almost a screenful");
+    await pressKeyAndAssert([shift, " "], iframe, [0, 0], "Shift + spacebar key scrolls #box up by almost a screenful");
 
     // At the bottom of the IFRAME, we should not chain up to scrolling the document.
     await pressKeyAndAssert(end, iframe, [0, bottom], "End key scrolls #iframe to bottom");

--- a/tests/wpt/mozilla/tests/input-events/keyboard-scrolling.html
+++ b/tests/wpt/mozilla/tests/input-events/keyboard-scrolling.html
@@ -46,6 +46,7 @@
 </div>
 
 <script>
+const shift = "\uE008";
 const end = "\uE010";
 const home = "\uE011";
 const arrowDown = "\uE015";
@@ -56,8 +57,21 @@ const pageDown = "\uE00F";
 const pageUp = "\uE00E";
 const lineSize = 76;
 const pageSize = scrollportHeight => scrollportHeight - 2 * lineSize;
-const pressKeyAndAssert = async (key, element, [expectedX, expectedY], description) => {
-    await test_driver.send_keys(document.body, key);
+const pressKeyAndAssert = async (keys, element, [expectedX, expectedY], description) => {
+    let actions = new test_driver.Actions();
+    if (!Array.isArray(keys)) {
+      keys = [keys];
+    }
+    for (key of keys) {
+      actions = actions.keyDown(key);
+    }
+
+    let reversedKeys = keys.reverse();
+    for (key of reversedKeys) {
+      actions = actions.keyUp(key);
+    }
+    await actions.send()
+
     const actualX =
         element == null ? scrollX : element.scrollLeft;
     const actualY =
@@ -80,6 +94,10 @@ promise_test(async () => {
     await pressKeyAndAssert(pageDown, null, [0, pageSize(innerHeight) * 2], "PageDown key scrolls viewport down by almost a screenful");
     await pressKeyAndAssert(pageUp, null, [0, pageSize(innerHeight)], "PageUp key scrolls viewport up by almost a screenful");
     await pressKeyAndAssert(pageUp, null, [0, 0], "PageUp key scrolls viewport up by almost a screenful");
+    await pressKeyAndAssert(" ", null, [0, pageSize(innerHeight)], "Spacebar key scrolls #box down by almost a screenful");
+    await pressKeyAndAssert(" ", null, [0, pageSize(innerHeight) * 2], "Spacebar key scrolls #box down by almost a screenful");
+    await pressKeyAndAssert([shift, " "], null, [0, pageSize(innerHeight)], "Shift + spacebar key scrolls #box up by almost a screenful");
+    await pressKeyAndAssert([shift, " "], null, [0, 0], "Shift + spacebar key scrolls #box up by almost a screenful");
 }, "Keyboard scrolling works in the viewport");
 
 promise_test(async () => {
@@ -99,6 +117,10 @@ promise_test(async () => {
     await pressKeyAndAssert(pageDown, box, [0, pageSize(box.clientHeight) * 2], "PageDown key scrolls #box down by almost a screenful");
     await pressKeyAndAssert(pageUp, box, [0, pageSize(box.clientHeight)], "PageUp key scrolls #box up by almost a screenful");
     await pressKeyAndAssert(pageUp, box, [0, 0], "PageUp key scrolls #box up by almost a screenful");
+    await pressKeyAndAssert(" ", box, [0, pageSize(box.clientHeight)], "Spacebar key scrolls #box down by almost a screenful");
+    await pressKeyAndAssert(" ", box, [0, pageSize(box.clientHeight) * 2], "Spacebar key scrolls #box down by almost a screenful");
+    await pressKeyAndAssert([shift, " "], box, [0, pageSize(box.clientHeight)], "Shift + spacebar key scrolls #box up by almost a screenful");
+    await pressKeyAndAssert([shift, " "], box, [0, 0], "Shift + spacebar key scrolls #box up by almost a screenful");
 
     // At the bottom of the DIV, we should not chain up to scrolling the document.
     let bottom = box.scrollHeight - box.clientHeight;
@@ -126,6 +148,10 @@ promise_test(async () => {
     await pressKeyAndAssert(pageDown, focusableBox, [0, pageSize(box.clientHeight) * 2], "PageDown key scrolls #focusableBox down by almost a screenful");
     await pressKeyAndAssert(pageUp, focusableBox, [0, pageSize(box.clientHeight)], "PageUp key scrolls #focusableBox up by almost a screenful");
     await pressKeyAndAssert(pageUp, focusableBox, [0, 0], "PageUp key scrolls #focusableBox up by almost a screenful");
+    await pressKeyAndAssert(" ", focusableBox, [0, pageSize(box.clientHeight)], "Spacebar key scrolls #box down by almost a screenful");
+    await pressKeyAndAssert(" ", focusableBox, [0, pageSize(box.clientHeight) * 2], "Spacebar key scrolls #box down by almost a screenful");
+    await pressKeyAndAssert([shift, " "], focusableBox, [0, pageSize(box.clientHeight)], "Shift + spacebar key scrolls #box up by almost a screenful");
+    await pressKeyAndAssert([shift, " "], focusableBox, [0, 0], "Shift + spacebar key scrolls #box up by almost a screenful");
     focusableBox.blur();
 }, "Keyboard scrolling works in #focusableBox");
 


### PR DESCRIPTION
This change allows pressing the spacebar to cause a page down or page up
scroll. This matches the behavior of other browsers. In addition, keyboard
scrolling tests are moved to the same directory as other input method tests.

Testing: This change adds some additional testing to Servo-specific keyboard scrolling tests.
