### PR TITLE
script: Pass `&mut JSContext` to more functions in `dom/stream`

### DIFF
--- a/components/script/body.rs
+++ b/components/script/body.rs
@@ -271,30 +271,30 @@ impl TransmitBodyConnectHandler {
             task!(setup_native_body_promise_handler: move |cx| {
                 let rooted_stream = stream.root();
                 let global = rooted_stream.global();
+                let mut realm = enter_auto_realm(cx, &*global);
+                let realm = &mut realm.current_realm();
 
                 // Step 4, the result of reading a chunk from body’s stream with reader.
-                let promise = rooted_stream.read_a_chunk(cx);
+                let promise = rooted_stream.read_a_chunk(realm);
 
                 // Step 5, the parallel steps waiting for and handling the result of the read promise,
                 // are a combination of the promise native handler here,
                 // and the corresponding IPC route in `component::net::http_loader`.
-                rooted!(&in(cx) let mut promise_handler = Some(TransmitBodyPromiseHandler {
+                rooted!(&in(realm) let mut promise_handler = Some(TransmitBodyPromiseHandler {
                     bytes_sender: bytes_sender.clone(),
                     stream: Dom::from_ref(&rooted_stream),
                     control_sender: control_sender.clone().unwrap(),
                 }));
 
-                rooted!(&in(cx) let mut rejection_handler = Some(TransmitBodyPromiseRejectionHandler {
+                rooted!(&in(realm) let mut rejection_handler = Some(TransmitBodyPromiseRejectionHandler {
                     bytes_sender,
                     stream: Dom::from_ref(&rooted_stream),
                     control_sender: control_sender.unwrap(),
                 }));
 
                 let handler =
-                    PromiseNativeHandler::new(&global, promise_handler.take().map(|h| Box::new(h) as Box<_>), rejection_handler.take().map(|h| Box::new(h) as Box<_>), CanGc::from_cx(cx));
+                    PromiseNativeHandler::new(&global, promise_handler.take().map(|h| Box::new(h) as Box<_>), rejection_handler.take().map(|h| Box::new(h) as Box<_>), CanGc::from_cx(realm));
 
-                let mut realm = enter_auto_realm(cx, &*global);
-                let realm = &mut realm.current_realm();
                 let in_realm_proof = realm.into();
                 let comp = InRealm::Already(&in_realm_proof);
                 promise.append_native_handler(&handler, comp, CanGc::from_cx(realm));

--- a/components/script/body.rs
+++ b/components/script/body.rs
@@ -46,7 +46,7 @@ use crate::dom::promise::Promise;
 use crate::dom::promisenativehandler::{Callback, PromiseNativeHandler};
 use crate::dom::readablestream::{ReadableStream, get_read_promise_bytes, get_read_promise_done};
 use crate::dom::urlsearchparams::URLSearchParams;
-use crate::realms::{AlreadyInRealm, InRealm, enter_realm};
+use crate::realms::{AlreadyInRealm, InRealm, enter_auto_realm, enter_realm};
 use crate::script_runtime::{CanGc, JSContext};
 use crate::task_source::SendableTaskSource;
 
@@ -268,35 +268,36 @@ impl TransmitBodyConnectHandler {
         }
 
         self.task_source.queue(
-            task!(setup_native_body_promise_handler: move || {
+            task!(setup_native_body_promise_handler: move |cx| {
                 let rooted_stream = stream.root();
                 let global = rooted_stream.global();
-                let cx = GlobalScope::get_cx();
 
                 // Step 4, the result of reading a chunk from body’s stream with reader.
-                let promise = rooted_stream.read_a_chunk(CanGc::note());
+                let promise = rooted_stream.read_a_chunk(cx);
 
                 // Step 5, the parallel steps waiting for and handling the result of the read promise,
                 // are a combination of the promise native handler here,
                 // and the corresponding IPC route in `component::net::http_loader`.
-                rooted!(in(*cx) let mut promise_handler = Some(TransmitBodyPromiseHandler {
+                rooted!(&in(cx) let mut promise_handler = Some(TransmitBodyPromiseHandler {
                     bytes_sender: bytes_sender.clone(),
                     stream: Dom::from_ref(&rooted_stream),
                     control_sender: control_sender.clone().unwrap(),
                 }));
 
-                rooted!(in(*cx) let mut rejection_handler = Some(TransmitBodyPromiseRejectionHandler {
+                rooted!(&in(cx) let mut rejection_handler = Some(TransmitBodyPromiseRejectionHandler {
                     bytes_sender,
                     stream: Dom::from_ref(&rooted_stream),
                     control_sender: control_sender.unwrap(),
                 }));
 
                 let handler =
-                    PromiseNativeHandler::new(&global, promise_handler.take().map(|h| Box::new(h) as Box<_>), rejection_handler.take().map(|h| Box::new(h) as Box<_>), CanGc::note());
+                    PromiseNativeHandler::new(&global, promise_handler.take().map(|h| Box::new(h) as Box<_>), rejection_handler.take().map(|h| Box::new(h) as Box<_>), CanGc::from_cx(cx));
 
-                let realm = enter_realm(&*global);
-                let comp = InRealm::Entered(&realm);
-                promise.append_native_handler(&handler, comp, CanGc::note());
+                let mut realm = enter_auto_realm(cx, &*global);
+                let realm = &mut realm.current_realm();
+                let in_realm_proof = realm.into();
+                let comp = InRealm::Already(&in_realm_proof);
+                promise.append_native_handler(&handler, comp, CanGc::from_cx(realm));
             })
         );
     }

--- a/components/script/body.rs
+++ b/components/script/body.rs
@@ -271,30 +271,30 @@ impl TransmitBodyConnectHandler {
             task!(setup_native_body_promise_handler: move |cx| {
                 let rooted_stream = stream.root();
                 let global = rooted_stream.global();
-                let mut realm = enter_auto_realm(cx, &*global);
-                let realm = &mut realm.current_realm();
 
                 // Step 4, the result of reading a chunk from body’s stream with reader.
-                let promise = rooted_stream.read_a_chunk(realm);
+                let promise = rooted_stream.read_a_chunk(cx);
 
                 // Step 5, the parallel steps waiting for and handling the result of the read promise,
                 // are a combination of the promise native handler here,
                 // and the corresponding IPC route in `component::net::http_loader`.
-                rooted!(&in(realm) let mut promise_handler = Some(TransmitBodyPromiseHandler {
+                rooted!(&in(cx) let mut promise_handler = Some(TransmitBodyPromiseHandler {
                     bytes_sender: bytes_sender.clone(),
                     stream: Dom::from_ref(&rooted_stream),
                     control_sender: control_sender.clone().unwrap(),
                 }));
 
-                rooted!(&in(realm) let mut rejection_handler = Some(TransmitBodyPromiseRejectionHandler {
+                rooted!(&in(cx) let mut rejection_handler = Some(TransmitBodyPromiseRejectionHandler {
                     bytes_sender,
                     stream: Dom::from_ref(&rooted_stream),
                     control_sender: control_sender.unwrap(),
                 }));
 
                 let handler =
-                    PromiseNativeHandler::new(&global, promise_handler.take().map(|h| Box::new(h) as Box<_>), rejection_handler.take().map(|h| Box::new(h) as Box<_>), CanGc::from_cx(realm));
+                    PromiseNativeHandler::new(&global, promise_handler.take().map(|h| Box::new(h) as Box<_>), rejection_handler.take().map(|h| Box::new(h) as Box<_>), CanGc::from_cx(cx));
 
+                let mut realm = enter_auto_realm(cx, &*global);
+                let realm = &mut realm.current_realm();
                 let in_realm_proof = realm.into();
                 let comp = InRealm::Already(&in_realm_proof);
                 promise.append_native_handler(&handler, comp, CanGc::from_cx(realm));

--- a/components/script/dom/stream/byteteereadintorequest.rs
+++ b/components/script/dom/stream/byteteereadintorequest.rs
@@ -187,7 +187,7 @@ impl ByteTeeReadIntoRequest {
 
                 // Perform ! ReadableByteStreamControllerEnqueue(otherBranch.[[controller]], clonedChunk).
                 let other_branch_controller = self.other_branch.get_byte_controller();
-                other_branch_controller.enqueue(cx.into(), cloned_chunk, CanGc::from_cx(cx))?;
+                other_branch_controller.enqueue(cx, cloned_chunk)?;
             }
         } else if !byob_canceled {
             // Otherwise, if byobCanceled is false, perform
@@ -202,16 +202,10 @@ impl ByteTeeReadIntoRequest {
 
         // If readAgainForBranch1 is true, perform pull1Algorithm.
         if self.read_again_for_branch_1.get() {
-            self.pull_algorithm(
-                Some(ByteTeePullAlgorithm::Pull1Algorithm),
-                CanGc::from_cx(cx),
-            );
+            self.pull_algorithm(cx, Some(ByteTeePullAlgorithm::Pull1Algorithm));
         } else if self.read_again_for_branch_2.get() {
             // Otherwise, if readAgainForBranch2 is true, perform pull2Algorithm.
-            self.pull_algorithm(
-                Some(ByteTeePullAlgorithm::Pull2Algorithm),
-                CanGc::from_cx(cx),
-            );
+            self.pull_algorithm(cx, Some(ByteTeePullAlgorithm::Pull2Algorithm));
         }
 
         Ok(())
@@ -297,10 +291,10 @@ impl ByteTeeReadIntoRequest {
 
     pub(crate) fn pull_algorithm(
         &self,
+        cx: &mut js::context::JSContext,
         byte_tee_pull_algorithm: Option<ByteTeePullAlgorithm>,
-        can_gc: CanGc,
     ) {
         self.tee_underlying_source
-            .pull_algorithm(byte_tee_pull_algorithm, can_gc);
+            .pull_algorithm(byte_tee_pull_algorithm, CanGc::from_cx(cx));
     }
 }

--- a/components/script/dom/stream/byteteereadrequest.rs
+++ b/components/script/dom/stream/byteteereadrequest.rs
@@ -204,13 +204,13 @@ impl ByteTeeReadRequest {
         // If canceled1 is false, perform ! ReadableByteStreamControllerEnqueue(branch1.[[controller]], chunk1).
         if let Some(chunk1_view) = chunk1_view {
             let branch_1_controller = self.branch_1.get_byte_controller();
-            branch_1_controller.enqueue(cx.into(), chunk1_view, CanGc::from_cx(cx))?;
+            branch_1_controller.enqueue(cx, chunk1_view)?;
         }
 
         // If canceled2 is false, perform ! ReadableByteStreamControllerEnqueue(branch2.[[controller]], chunk2).
         if let Some(chunk2_view) = chunk2_view {
             let branch_2_controller = self.branch_2.get_byte_controller();
-            branch_2_controller.enqueue(cx.into(), chunk2_view, CanGc::from_cx(cx))?;
+            branch_2_controller.enqueue(cx, chunk2_view)?;
         }
 
         // Set reading to false.
@@ -218,16 +218,10 @@ impl ByteTeeReadRequest {
 
         // If readAgainForBranch1 is true, perform pull1Algorithm.
         if self.read_again_for_branch_1.get() {
-            self.pull_algorithm(
-                Some(ByteTeePullAlgorithm::Pull1Algorithm),
-                CanGc::from_cx(cx),
-            );
+            self.pull_algorithm(cx, Some(ByteTeePullAlgorithm::Pull1Algorithm));
         } else if self.read_again_for_branch_2.get() {
             // Otherwise, if readAgainForBranch2 is true, perform pull2Algorithm.
-            self.pull_algorithm(
-                Some(ByteTeePullAlgorithm::Pull2Algorithm),
-                CanGc::from_cx(cx),
-            );
+            self.pull_algorithm(cx, Some(ByteTeePullAlgorithm::Pull2Algorithm));
         }
 
         Ok(())
@@ -280,10 +274,10 @@ impl ByteTeeReadRequest {
 
     pub(crate) fn pull_algorithm(
         &self,
+        cx: &mut js::context::JSContext,
         byte_tee_pull_algorithm: Option<ByteTeePullAlgorithm>,
-        can_gc: CanGc,
     ) {
         self.tee_underlying_source
-            .pull_algorithm(byte_tee_pull_algorithm, can_gc);
+            .pull_algorithm(byte_tee_pull_algorithm, CanGc::from_cx(cx));
     }
 }

--- a/components/script/dom/stream/defaultteereadrequest.rs
+++ b/components/script/dom/stream/defaultteereadrequest.rs
@@ -21,7 +21,7 @@ use crate::dom::stream::defaultteeunderlyingsource::DefaultTeeUnderlyingSource;
 use crate::dom::stream::readablestream::ReadableStream;
 use crate::microtask::{Microtask, MicrotaskRunnable};
 use crate::realms::enter_auto_realm;
-use crate::script_runtime::{CanGc, JSContext as SafeJSContext};
+use crate::script_runtime::CanGc;
 
 #[derive(JSTraceable, MallocSizeOf)]
 #[cfg_attr(crown, expect(crown::unrooted_must_root))]
@@ -99,12 +99,12 @@ impl DefaultTeeReadRequest {
     /// <https://streams.spec.whatwg.org/#readable-stream-cancel>
     pub(crate) fn stream_cancel(
         &self,
-        cx: SafeJSContext,
+        cx: &mut js::context::JSContext,
         global: &GlobalScope,
         reason: SafeHandleValue,
-        can_gc: CanGc,
     ) {
-        self.stream.cancel(cx, global, reason, can_gc);
+        self.stream
+            .cancel(cx.into(), global, reason, CanGc::from_cx(cx));
     }
     /// Enqueue a microtask to perform the chunk steps
     /// <https://streams.spec.whatwg.org/#ref-for-read-request-chunk-steps%E2%91%A2>
@@ -155,7 +155,7 @@ impl DefaultTeeReadRequest {
                     CanGc::from_cx(cx),
                 );
                 // Resolve cancelPromise with ! ReadableStreamCancel(stream, cloneResult.[[Value]]).
-                self.stream_cancel(cx.into(), global, clone_result.handle(), CanGc::from_cx(cx));
+                self.stream_cancel(cx, global, clone_result.handle());
                 // Return.
                 return;
             } else {
@@ -166,24 +166,24 @@ impl DefaultTeeReadRequest {
         // If canceled_1 is false, perform ! ReadableStreamDefaultControllerEnqueue(branch_1.[[controller]], chunk1).
         if !self.canceled_1.get() {
             self.readable_stream_default_controller_enqueue(
+                cx,
                 &self.branch_1,
                 chunk1_value.handle(),
-                CanGc::from_cx(cx),
             );
         }
         // If canceled_2 is false, perform ! ReadableStreamDefaultControllerEnqueue(branch_2.[[controller]], chunk2).
         if !self.canceled_2.get() {
             self.readable_stream_default_controller_enqueue(
+                cx,
                 &self.branch_2,
                 chunk2_value.handle(),
-                CanGc::from_cx(cx),
             );
         }
         // Set reading to false.
         self.reading.set(false);
         // If readAgain is true, perform pullAlgorithm.
         if self.read_again.get() {
-            self.pull_algorithm(CanGc::from_cx(cx));
+            self.pull_algorithm(cx);
         }
     }
     /// <https://streams.spec.whatwg.org/#read-request-close-steps>
@@ -212,13 +212,13 @@ impl DefaultTeeReadRequest {
     /// <https://streams.spec.whatwg.org/#readable-stream-default-controller-enqueue>
     fn readable_stream_default_controller_enqueue(
         &self,
+        cx: &mut js::context::JSContext,
         stream: &ReadableStream,
         chunk: SafeHandleValue,
-        can_gc: CanGc,
     ) {
         stream
             .get_default_controller()
-            .enqueue(GlobalScope::get_cx(), chunk, can_gc)
+            .enqueue(cx.into(), chunk, CanGc::from_cx(cx))
             .expect("enqueue failed for stream controller in DefaultTeeReadRequest");
     }
 
@@ -239,7 +239,8 @@ impl DefaultTeeReadRequest {
         stream.get_default_controller().error(error, can_gc);
     }
 
-    pub(crate) fn pull_algorithm(&self, can_gc: CanGc) {
-        self.tee_underlying_source.pull_algorithm(can_gc);
+    pub(crate) fn pull_algorithm(&self, cx: &mut js::context::JSContext) {
+        self.tee_underlying_source
+            .pull_algorithm(CanGc::from_cx(cx));
     }
 }

--- a/components/script/dom/stream/readablebytestreamcontroller.rs
+++ b/components/script/dom/stream/readablebytestreamcontroller.rs
@@ -984,9 +984,8 @@ impl ReadableByteStreamController {
     /// <https://streams.spec.whatwg.org/#readable-byte-stream-controller-enqueue>
     pub(crate) fn enqueue(
         &self,
-        cx: SafeJSContext,
+        cx: &mut js::context::JSContext,
         chunk: HeapBufferSource<ArrayBufferViewU8>,
-        can_gc: CanGc,
     ) -> Fallible<()> {
         // Let stream be controller.[[stream]].
         let stream = self.stream.get().unwrap();
@@ -997,7 +996,7 @@ impl ReadableByteStreamController {
         }
 
         // Let buffer be chunk.[[ViewedArrayBuffer]].
-        let buffer = chunk.get_array_buffer_view_buffer(cx);
+        let buffer = chunk.get_array_buffer_view_buffer(cx.into());
 
         // Let byteOffset be chunk.[[ByteOffset]].
         let byte_offset = chunk.get_byte_offset();
@@ -1006,12 +1005,12 @@ impl ReadableByteStreamController {
         let byte_length = chunk.byte_length();
 
         // If ! IsDetachedBuffer(buffer) is true, throw a TypeError exception.
-        if buffer.is_detached_buffer(cx) {
+        if buffer.is_detached_buffer(cx.into()) {
             return Err(Error::Type(c"buffer is detached".to_owned()));
         }
 
         // Let transferredBuffer be ? TransferArrayBuffer(buffer).
-        let transferred_buffer = buffer.transfer_array_buffer(cx)?;
+        let transferred_buffer = buffer.transfer_array_buffer(cx.into())?;
 
         // If controller.[[pendingPullIntos]] is not empty,
         {
@@ -1020,7 +1019,7 @@ impl ReadableByteStreamController {
                 // Let firstPendingPullInto be controller.[[pendingPullIntos]][0].
                 let first_descriptor = pending_pull_intos.first_mut().unwrap();
                 // If ! IsDetachedBuffer(firstPendingPullInto’s buffer) is true, throw a TypeError exception.
-                if first_descriptor.buffer.is_detached_buffer(cx) {
+                if first_descriptor.buffer.is_detached_buffer(cx.into()) {
                     return Err(Error::Type(c"buffer is detached".to_owned()));
                 }
 
@@ -1030,7 +1029,7 @@ impl ReadableByteStreamController {
                 // Set firstPendingPullInto’s buffer to ! TransferArrayBuffer(firstPendingPullInto’s buffer).
                 first_descriptor.buffer = first_descriptor
                     .buffer
-                    .transfer_array_buffer(cx)
+                    .transfer_array_buffer(cx.into())
                     .expect("TransferArrayBuffer failed");
 
                 // If firstPendingPullInto’s reader type is "none",
@@ -1040,7 +1039,7 @@ impl ReadableByteStreamController {
 
                     // perform ? ReadableByteStreamControllerEnqueueDetachedPullIntoToQueue(
                     // controller, firstPendingPullInto).
-                    self.enqueue_detached_pull_into_to_queue(cx, can_gc)?;
+                    self.enqueue_detached_pull_into_to_queue(cx.into(), CanGc::from_cx(cx))?;
                 }
             }
         }
@@ -1048,7 +1047,7 @@ impl ReadableByteStreamController {
         // If ! ReadableStreamHasDefaultReader(stream) is true,
         if stream.has_default_reader() {
             // Perform ! ReadableByteStreamControllerProcessReadRequestsUsingQueue(controller).
-            self.process_read_requests_using_queue(cx, can_gc)
+            self.process_read_requests_using_queue(cx)
                 .expect("process_read_requests_using_queue failed");
 
             // If ! ReadableStreamGetNumReadRequests(stream) is 0,
@@ -1084,7 +1083,7 @@ impl ReadableByteStreamController {
 
                 // Let transferredView be ! Construct(%Uint8Array%, « transferredBuffer, byteOffset, byteLength »).
                 let transferred_view = create_buffer_source_with_constructor(
-                    cx,
+                    cx.into(),
                     &Constructor::Name(Type::Uint8),
                     &transferred_buffer,
                     byte_offset,
@@ -1093,9 +1092,9 @@ impl ReadableByteStreamController {
                 .expect("Construct Uint8Array failed");
 
                 // Perform ! ReadableStreamFulfillReadRequest(stream, transferredView, false).
-                rooted!(in(*cx) let mut view_value = UndefinedValue());
-                transferred_view.get_buffer_view_value(cx, view_value.handle_mut());
-                stream.fulfill_read_request(view_value.handle(), false, can_gc);
+                rooted!(&in(cx) let mut view_value = UndefinedValue());
+                transferred_view.get_buffer_view_value(cx.into(), view_value.handle_mut());
+                stream.fulfill_read_request(view_value.handle(), false, CanGc::from_cx(cx));
             }
             // Otherwise, if ! ReadableStreamHasBYOBReader(stream) is true,
         } else if stream.has_byob_reader() {
@@ -1105,12 +1104,12 @@ impl ReadableByteStreamController {
 
             // Let filledPullIntos be the result of performing !
             // ReadableByteStreamControllerProcessPullIntoDescriptorsUsingQueue(controller).
-            let filled_pull_intos = self.process_pull_into_descriptors_using_queue(cx);
+            let filled_pull_intos = self.process_pull_into_descriptors_using_queue(cx.into());
 
             // For each filledPullInto of filledPullIntos,
             // Perform ! ReadableByteStreamControllerCommitPullIntoDescriptor(stream, filledPullInto).
             for filled_pull_into in filled_pull_intos {
-                self.commit_pull_into_descriptor(cx, &filled_pull_into, can_gc)
+                self.commit_pull_into_descriptor(cx.into(), &filled_pull_into, CanGc::from_cx(cx))
                     .expect("commit_pull_into_descriptor failed");
             }
         } else {
@@ -1123,7 +1122,7 @@ impl ReadableByteStreamController {
         }
 
         // Perform ! ReadableByteStreamControllerCallPullIfNeeded(controller).
-        self.call_pull_if_needed(can_gc);
+        self.call_pull_if_needed(CanGc::from_cx(cx));
 
         Ok(())
     }
@@ -1515,15 +1514,14 @@ impl ReadableByteStreamController {
     /// <https://streams.spec.whatwg.org/#abstract-opdef-readablebytestreamcontrollerprocessreadrequestsusingqueue>
     pub(crate) fn process_read_requests_using_queue(
         &self,
-        cx: SafeJSContext,
-        can_gc: CanGc,
+        cx: &mut js::context::JSContext,
     ) -> Fallible<()> {
         // Let reader be controller.[[stream]].[[reader]].
         // Assert: reader implements ReadableStreamDefaultReader.
         let reader = self.stream.get().unwrap().get_default_reader();
 
         // Step 3
-        reader.process_read_requests(cx, DomRoot::from_ref(self), can_gc)
+        reader.process_read_requests(cx, DomRoot::from_ref(self))
     }
 
     /// <https://streams.spec.whatwg.org/#abstract-opdef-readablebytestreamcontrollerfillreadrequestfromqueue>
@@ -1983,11 +1981,9 @@ impl ReadableByteStreamControllerMethods<crate::DomTypeHolder> for ReadableByteS
     /// <https://streams.spec.whatwg.org/#rbs-controller-enqueue>
     fn Enqueue(
         &self,
+        cx: &mut js::context::JSContext,
         chunk: js::gc::CustomAutoRooterGuard<js::typedarray::ArrayBufferView>,
-        can_gc: CanGc,
     ) -> Fallible<()> {
-        let cx = GlobalScope::get_cx();
-
         let chunk = HeapBufferSource::<ArrayBufferViewU8>::from_view(chunk);
 
         // If chunk.[[ByteLength]] is 0, throw a TypeError exception.
@@ -1996,7 +1992,7 @@ impl ReadableByteStreamControllerMethods<crate::DomTypeHolder> for ReadableByteS
         }
 
         // If chunk.[[ViewedArrayBuffer]].[[ByteLength]] is 0, throw a TypeError exception.
-        if chunk.viewed_buffer_array_byte_length(cx) == 0 {
+        if chunk.viewed_buffer_array_byte_length(cx.into()) == 0 {
             return Err(Error::Type(
                 c"chunk.ViewedArrayBuffer.ByteLength is 0".to_owned(),
             ));
@@ -2013,13 +2009,13 @@ impl ReadableByteStreamControllerMethods<crate::DomTypeHolder> for ReadableByteS
         }
 
         // Return ? ReadableByteStreamControllerEnqueue(this, chunk).
-        self.enqueue(cx, chunk, can_gc)
+        self.enqueue(cx, chunk)
     }
 
     /// <https://streams.spec.whatwg.org/#rbs-controller-error>
-    fn Error(&self, _cx: SafeJSContext, e: SafeHandleValue, can_gc: CanGc) -> Fallible<()> {
+    fn Error(&self, cx: &mut js::context::JSContext, e: SafeHandleValue) -> Fallible<()> {
         // Perform ! ReadableByteStreamControllerError(this, e).
-        self.error(e, can_gc);
+        self.error(e, CanGc::from_cx(cx));
         Ok(())
     }
 }

--- a/components/script/dom/stream/readablestream.rs
+++ b/components/script/dom/stream/readablestream.rs
@@ -1319,7 +1319,7 @@ impl ReadableStream {
     /// and before `stop_reading`.
     /// Native call to
     /// <https://streams.spec.whatwg.org/#readable-stream-default-reader-read>
-    pub(crate) fn read_a_chunk(&self, cx: &mut CurrentRealm) -> Rc<Promise> {
+    pub(crate) fn read_a_chunk(&self, cx: &mut js::context::JSContext) -> Rc<Promise> {
         match self.reader.borrow().as_ref() {
             Some(ReaderType::Default(reader)) => {
                 let Some(reader) = reader.get() else {
@@ -2152,12 +2152,12 @@ impl ReadableStreamMethods<crate::DomTypeHolder> for ReadableStream {
     }
 
     /// <https://streams.spec.whatwg.org/#rs-cancel>
-    fn Cancel(&self, cx: &mut CurrentRealm, reason: SafeHandleValue) -> Rc<Promise> {
+    fn Cancel(&self, cx: &mut js::context::JSContext, reason: SafeHandleValue) -> Rc<Promise> {
         let global = self.global();
         if self.is_locked() {
             // If ! IsReadableStreamLocked(this) is true,
             // return a promise rejected with a TypeError exception.
-            let promise = Promise::new_in_realm(cx);
+            let promise = Promise::new(&global, CanGc::from_cx(cx));
             promise.reject_error(
                 Error::Type(c"stream is locked".to_owned()),
                 CanGc::from_cx(cx),

--- a/components/script/dom/stream/readablestream.rs
+++ b/components/script/dom/stream/readablestream.rs
@@ -1319,7 +1319,7 @@ impl ReadableStream {
     /// and before `stop_reading`.
     /// Native call to
     /// <https://streams.spec.whatwg.org/#readable-stream-default-reader-read>
-    pub(crate) fn read_a_chunk(&self, cx: &mut js::context::JSContext) -> Rc<Promise> {
+    pub(crate) fn read_a_chunk(&self, cx: &mut CurrentRealm) -> Rc<Promise> {
         match self.reader.borrow().as_ref() {
             Some(ReaderType::Default(reader)) => {
                 let Some(reader) = reader.get() else {
@@ -2152,12 +2152,12 @@ impl ReadableStreamMethods<crate::DomTypeHolder> for ReadableStream {
     }
 
     /// <https://streams.spec.whatwg.org/#rs-cancel>
-    fn Cancel(&self, cx: &mut js::context::JSContext, reason: SafeHandleValue) -> Rc<Promise> {
+    fn Cancel(&self, cx: &mut CurrentRealm, reason: SafeHandleValue) -> Rc<Promise> {
         let global = self.global();
         if self.is_locked() {
             // If ! IsReadableStreamLocked(this) is true,
             // return a promise rejected with a TypeError exception.
-            let promise = Promise::new(&global, CanGc::from_cx(cx));
+            let promise = Promise::new_in_realm(cx);
             promise.reject_error(
                 Error::Type(c"stream is locked".to_owned()),
                 CanGc::from_cx(cx),

--- a/components/script/dom/stream/readablestream.rs
+++ b/components/script/dom/stream/readablestream.rs
@@ -288,7 +288,7 @@ impl Callback for PipeTo {
             PipeToState::Starting => unreachable!("PipeTo should not be in the Starting state."),
             PipeToState::PendingReady => {
                 // Read a chunk.
-                self.read_chunk(&global, realm, CanGc::from_cx(cx));
+                self.read_chunk(cx, &global);
             },
             PipeToState::PendingRead => {
                 // Write the chunk.
@@ -300,7 +300,7 @@ impl Callback for PipeTo {
                 }
 
                 // Wait for the writer to be ready again.
-                self.wait_for_writer_ready(&global, realm, CanGc::from_cx(cx));
+                self.wait_for_writer_ready(cx, &global);
             },
             PipeToState::ShuttingDownWithPendingWrites(action) => {
                 // Wait until every chunk that has been read has been written
@@ -316,7 +316,7 @@ impl Callback for PipeTo {
                     self.perform_action(cx, &global, action);
                 } else {
                     // Finalize, passing along error if it was given.
-                    self.finalize(cx.into(), &global, CanGc::from_cx(cx));
+                    self.finalize(cx, &global);
                 }
             },
             PipeToState::ShuttingDownPendingAction => {
@@ -351,7 +351,7 @@ impl Callback for PipeTo {
                     // and should overwrite the current shutdown error.
                     self.set_shutdown_error(result);
                 }
-                self.finalize(cx.into(), &global, CanGc::from_cx(cx));
+                self.finalize(cx, &global);
             },
             PipeToState::Finalized => {},
         }
@@ -371,7 +371,10 @@ impl PipeTo {
 
     /// Wait for the writer to be ready,
     /// which implements the constraint that backpressure must be enforced.
-    fn wait_for_writer_ready(&self, global: &GlobalScope, realm: InRealm, can_gc: CanGc) {
+    fn wait_for_writer_ready(&self, cx: &mut CurrentRealm, global: &GlobalScope) {
+        let realm = cx.into();
+        let realm = InRealm::Already(&realm);
+
         {
             let mut state = self.state.borrow_mut();
             *state = PipeToState::PendingReady;
@@ -379,40 +382,43 @@ impl PipeTo {
 
         let ready_promise = self.writer.Ready();
         if ready_promise.is_fulfilled() {
-            self.read_chunk(global, realm, can_gc);
+            self.read_chunk(cx, global);
         } else {
             let handler = PromiseNativeHandler::new(
                 global,
                 Some(Box::new(self.clone())),
                 Some(Box::new(self.clone())),
-                can_gc,
+                CanGc::from_cx(cx),
             );
-            ready_promise.append_native_handler(&handler, realm, can_gc);
+            ready_promise.append_native_handler(&handler, realm, CanGc::from_cx(cx));
 
             // Note: if the writer is not ready,
             // in order to ensure progress we must
             // also react to the closure of the source(because source may close empty).
             let closed_promise = self.reader.Closed();
-            closed_promise.append_native_handler(&handler, realm, can_gc);
+            closed_promise.append_native_handler(&handler, realm, CanGc::from_cx(cx));
         }
     }
 
     /// Read a chunk
-    fn read_chunk(&self, global: &GlobalScope, realm: InRealm, can_gc: CanGc) {
+    fn read_chunk(&self, cx: &mut CurrentRealm, global: &GlobalScope) {
+        let realm = cx.into();
+        let realm = InRealm::Already(&realm);
+
         *self.state.borrow_mut() = PipeToState::PendingRead;
-        let chunk_promise = self.reader.Read(can_gc);
+        let chunk_promise = self.reader.Read(cx);
         let handler = PromiseNativeHandler::new(
             global,
             Some(Box::new(self.clone())),
             Some(Box::new(self.clone())),
-            can_gc,
+            CanGc::from_cx(cx),
         );
-        chunk_promise.append_native_handler(&handler, realm, can_gc);
+        chunk_promise.append_native_handler(&handler, realm, CanGc::from_cx(cx));
 
         // Note: in order to ensure progress we must
         // also react to the closure of the destination.
         let ready_promise = self.writer.Closed();
-        ready_promise.append_native_handler(&handler, realm, can_gc);
+        ready_promise.append_native_handler(&handler, realm, CanGc::from_cx(cx));
     }
 
     /// Try to write a chunk using the jsval, and returns wether it succeeded
@@ -633,7 +639,7 @@ impl PipeTo {
                 self.perform_action(cx, global, action);
             } else {
                 // Finalize, passing along error if it was given.
-                self.finalize(cx.into(), global, CanGc::from_cx(cx));
+                self.finalize(cx, global);
             }
         }
     }
@@ -730,11 +736,11 @@ impl PipeTo {
     }
 
     /// <https://streams.spec.whatwg.org/#rs-pipeTo-finalize>
-    fn finalize(&self, cx: SafeJSContext, global: &GlobalScope, can_gc: CanGc) {
+    fn finalize(&self, cx: &mut js::context::JSContext, global: &GlobalScope) {
         *self.state.borrow_mut() = PipeToState::Finalized;
 
         // Perform ! WritableStreamDefaultWriterRelease(writer).
-        self.writer.release(cx, global, can_gc);
+        self.writer.release(cx.into(), global, CanGc::from_cx(cx));
 
         // If reader implements ReadableStreamBYOBReader,
         // perform ! ReadableStreamBYOBReaderRelease(reader).
@@ -742,7 +748,7 @@ impl PipeTo {
 
         // Otherwise, perform ! ReadableStreamDefaultReaderRelease(reader).
         self.reader
-            .release(can_gc)
+            .release(CanGc::from_cx(cx))
             .expect("Releasing the reader should not fail");
 
         // If signal is not undefined, remove abortAlgorithm from signal.
@@ -751,13 +757,14 @@ impl PipeTo {
         // so for now not implementing this step.
 
         if let Some(shutdown_error) = self.shutdown_error.borrow().as_ref() {
-            rooted!(in(*cx) let mut error = UndefinedValue());
+            rooted!(&in(cx) let mut error = UndefinedValue());
             error.set(shutdown_error.get());
             // If error was given, reject promise with error.
-            self.result_promise.reject_native(&error.handle(), can_gc);
+            self.result_promise
+                .reject_native(&error.handle(), CanGc::from_cx(cx));
         } else {
             // Otherwise, resolve promise with undefined.
-            self.result_promise.resolve_native(&(), can_gc);
+            self.result_promise.resolve_native(&(), CanGc::from_cx(cx));
         }
     }
 }
@@ -1312,7 +1319,7 @@ impl ReadableStream {
     /// and before `stop_reading`.
     /// Native call to
     /// <https://streams.spec.whatwg.org/#readable-stream-default-reader-read>
-    pub(crate) fn read_a_chunk(&self, can_gc: CanGc) -> Rc<Promise> {
+    pub(crate) fn read_a_chunk(&self, cx: &mut js::context::JSContext) -> Rc<Promise> {
         match self.reader.borrow().as_ref() {
             Some(ReaderType::Default(reader)) => {
                 let Some(reader) = reader.get() else {
@@ -1320,7 +1327,7 @@ impl ReadableStream {
                         "Attempt to read stream chunk without having first acquired a reader."
                     );
                 };
-                reader.Read(can_gc)
+                reader.Read(cx)
             },
             _ => {
                 unreachable!("Native reading of a chunk can only be done with a default reader.")
@@ -1857,8 +1864,6 @@ impl ReadableStream {
         prevent_cancel: bool,
         signal: Option<&AbortSignal>,
     ) -> Rc<Promise> {
-        let realm = cx.into();
-        let realm = InRealm::Already(&realm);
         // Assert: source implements ReadableStream.
         // Assert: dest implements WritableStream.
         // Assert: prevent_close, prevent_abort, and prevent_cancel are all booleans.
@@ -1941,7 +1946,7 @@ impl ReadableStream {
         // If we are not closed or errored,
         if *pipe_to.state.borrow() == PipeToState::Starting {
             // Start the pipe, by waiting on the writer being ready for a chunk.
-            pipe_to.wait_for_writer_ready(global, realm, CanGc::from_cx(cx));
+            pipe_to.wait_for_writer_ready(cx, global);
         }
 
         // Return promise.
@@ -2147,17 +2152,20 @@ impl ReadableStreamMethods<crate::DomTypeHolder> for ReadableStream {
     }
 
     /// <https://streams.spec.whatwg.org/#rs-cancel>
-    fn Cancel(&self, cx: SafeJSContext, reason: SafeHandleValue, can_gc: CanGc) -> Rc<Promise> {
+    fn Cancel(&self, cx: &mut js::context::JSContext, reason: SafeHandleValue) -> Rc<Promise> {
         let global = self.global();
         if self.is_locked() {
             // If ! IsReadableStreamLocked(this) is true,
             // return a promise rejected with a TypeError exception.
-            let promise = Promise::new(&global, can_gc);
-            promise.reject_error(Error::Type(c"stream is locked".to_owned()), can_gc);
+            let promise = Promise::new(&global, CanGc::from_cx(cx));
+            promise.reject_error(
+                Error::Type(c"stream is locked".to_owned()),
+                CanGc::from_cx(cx),
+            );
             promise
         } else {
             // Return ! ReadableStreamCancel(this, reason).
-            self.cancel(cx, &global, reason, can_gc)
+            self.cancel(cx.into(), &global, reason, CanGc::from_cx(cx))
         }
     }
 

--- a/components/script/dom/stream/readablestream.rs
+++ b/components/script/dom/stream/readablestream.rs
@@ -2157,7 +2157,7 @@ impl ReadableStreamMethods<crate::DomTypeHolder> for ReadableStream {
         if self.is_locked() {
             // If ! IsReadableStreamLocked(this) is true,
             // return a promise rejected with a TypeError exception.
-            let promise = Promise::new(&global, CanGc::from_cx(cx));
+            let promise = Promise::new2(cx, &global);
             promise.reject_error(
                 Error::Type(c"stream is locked".to_owned()),
                 CanGc::from_cx(cx),

--- a/components/script/dom/stream/readablestreambyobreader.rs
+++ b/components/script/dom/stream/readablestreambyobreader.rs
@@ -422,14 +422,14 @@ impl ReadableStreamBYOBReaderMethods<crate::DomTypeHolder> for ReadableStreamBYO
     /// <https://streams.spec.whatwg.org/#byob-reader-read>
     fn Read(
         &self,
-        cx: &mut CurrentRealm,
+        cx: &mut js::context::JSContext,
         view: CustomAutoRooterGuard<ArrayBufferView>,
         options: &ReadableStreamBYOBReaderReadOptions,
     ) -> Rc<Promise> {
         let view = HeapBufferSource::<ArrayBufferViewU8>::from_view(view);
         let min = options.min;
         // Let promise be a new promise.
-        let promise = Promise::new_in_realm(cx);
+        let promise = Promise::new(&self.global(), CanGc::from_cx(cx));
 
         // If view.[[ByteLength]] is 0, return a promise rejected with a TypeError exception.
         if view.byte_length() == 0 {
@@ -532,7 +532,7 @@ impl ReadableStreamBYOBReaderMethods<crate::DomTypeHolder> for ReadableStreamBYO
     }
 
     /// <https://streams.spec.whatwg.org/#generic-reader-cancel>
-    fn Cancel(&self, cx: &mut CurrentRealm, reason: SafeHandleValue) -> Rc<Promise> {
+    fn Cancel(&self, cx: &mut js::context::JSContext, reason: SafeHandleValue) -> Rc<Promise> {
         self.generic_cancel(cx, &self.global(), reason)
     }
 }

--- a/components/script/dom/stream/readablestreambyobreader.rs
+++ b/components/script/dom/stream/readablestreambyobreader.rs
@@ -429,7 +429,7 @@ impl ReadableStreamBYOBReaderMethods<crate::DomTypeHolder> for ReadableStreamBYO
         let view = HeapBufferSource::<ArrayBufferViewU8>::from_view(view);
         let min = options.min;
         // Let promise be a new promise.
-        let promise = Promise::new(&self.global(), CanGc::from_cx(cx));
+        let promise = Promise::new2(cx, &self.global());
 
         // If view.[[ByteLength]] is 0, return a promise rejected with a TypeError exception.
         if view.byte_length() == 0 {

--- a/components/script/dom/stream/readablestreambyobreader.rs
+++ b/components/script/dom/stream/readablestreambyobreader.rs
@@ -422,14 +422,14 @@ impl ReadableStreamBYOBReaderMethods<crate::DomTypeHolder> for ReadableStreamBYO
     /// <https://streams.spec.whatwg.org/#byob-reader-read>
     fn Read(
         &self,
-        cx: &mut js::context::JSContext,
+        cx: &mut CurrentRealm,
         view: CustomAutoRooterGuard<ArrayBufferView>,
         options: &ReadableStreamBYOBReaderReadOptions,
     ) -> Rc<Promise> {
         let view = HeapBufferSource::<ArrayBufferViewU8>::from_view(view);
         let min = options.min;
         // Let promise be a new promise.
-        let promise = Promise::new(&self.global(), CanGc::from_cx(cx));
+        let promise = Promise::new_in_realm(cx);
 
         // If view.[[ByteLength]] is 0, return a promise rejected with a TypeError exception.
         if view.byte_length() == 0 {
@@ -532,7 +532,7 @@ impl ReadableStreamBYOBReaderMethods<crate::DomTypeHolder> for ReadableStreamBYO
     }
 
     /// <https://streams.spec.whatwg.org/#generic-reader-cancel>
-    fn Cancel(&self, cx: &mut js::context::JSContext, reason: SafeHandleValue) -> Rc<Promise> {
+    fn Cancel(&self, cx: &mut CurrentRealm, reason: SafeHandleValue) -> Rc<Promise> {
         self.generic_cancel(cx, &self.global(), reason)
     }
 }

--- a/components/script/dom/stream/readablestreambyobreader.rs
+++ b/components/script/dom/stream/readablestreambyobreader.rs
@@ -422,41 +422,46 @@ impl ReadableStreamBYOBReaderMethods<crate::DomTypeHolder> for ReadableStreamBYO
     /// <https://streams.spec.whatwg.org/#byob-reader-read>
     fn Read(
         &self,
+        cx: &mut js::context::JSContext,
         view: CustomAutoRooterGuard<ArrayBufferView>,
         options: &ReadableStreamBYOBReaderReadOptions,
-        can_gc: CanGc,
     ) -> Rc<Promise> {
         let view = HeapBufferSource::<ArrayBufferViewU8>::from_view(view);
         let min = options.min;
         // Let promise be a new promise.
-        let promise = Promise::new(&self.global(), can_gc);
+        let promise = Promise::new(&self.global(), CanGc::from_cx(cx));
 
-        let cx = GlobalScope::get_cx();
         // If view.[[ByteLength]] is 0, return a promise rejected with a TypeError exception.
         if view.byte_length() == 0 {
-            promise.reject_error(Error::Type(c"view byte length is 0".to_owned()), can_gc);
+            promise.reject_error(
+                Error::Type(c"view byte length is 0".to_owned()),
+                CanGc::from_cx(cx),
+            );
             return promise;
         }
         // If view.[[ViewedArrayBuffer]].[[ArrayBufferByteLength]] is 0,
         // return a promise rejected with a TypeError exception.
-        if view.viewed_buffer_array_byte_length(cx) == 0 {
+        if view.viewed_buffer_array_byte_length(cx.into()) == 0 {
             promise.reject_error(
                 Error::Type(c"viewed buffer byte length is 0".to_owned()),
-                can_gc,
+                CanGc::from_cx(cx),
             );
             return promise;
         }
 
         // If ! IsDetachedBuffer(view.[[ViewedArrayBuffer]]) is true,
         // return a promise rejected with a TypeError exception.
-        if view.is_detached_buffer(cx) {
-            promise.reject_error(Error::Type(c"view is detached".to_owned()), can_gc);
+        if view.is_detached_buffer(cx.into()) {
+            promise.reject_error(
+                Error::Type(c"view is detached".to_owned()),
+                CanGc::from_cx(cx),
+            );
             return promise;
         }
 
         // If options["min"] is 0, return a promise rejected with a TypeError exception.
         if min == 0 {
-            promise.reject_error(Error::Type(c"min is 0".to_owned()), can_gc);
+            promise.reject_error(Error::Type(c"min is 0".to_owned()), CanGc::from_cx(cx));
             return promise;
         }
 
@@ -466,7 +471,7 @@ impl ReadableStreamBYOBReaderMethods<crate::DomTypeHolder> for ReadableStreamBYO
             if min > (view.get_typed_array_length() as u64) {
                 promise.reject_error(
                     Error::Range(c"min is greater than array length".to_owned()),
-                    can_gc,
+                    CanGc::from_cx(cx),
                 );
                 return promise;
             }
@@ -476,7 +481,7 @@ impl ReadableStreamBYOBReaderMethods<crate::DomTypeHolder> for ReadableStreamBYO
             if min > (view.byte_length() as u64) {
                 promise.reject_error(
                     Error::Range(c"min is greater than byte length".to_owned()),
-                    can_gc,
+                    CanGc::from_cx(cx),
                 );
                 return promise;
             }
@@ -486,7 +491,7 @@ impl ReadableStreamBYOBReaderMethods<crate::DomTypeHolder> for ReadableStreamBYO
         if self.stream.get().is_none() {
             promise.reject_error(
                 Error::Type(c"min is greater than byte length".to_owned()),
-                can_gc,
+                CanGc::from_cx(cx),
             );
             return promise;
         }
@@ -504,7 +509,7 @@ impl ReadableStreamBYOBReaderMethods<crate::DomTypeHolder> for ReadableStreamBYO
         let read_into_request = ReadIntoRequest::Read(promise.clone());
 
         // Perform ! ReadableStreamBYOBReaderRead(this, view, options["min"], readIntoRequest).
-        self.read(cx, view, min, &read_into_request, can_gc);
+        self.read(cx.into(), view, min, &read_into_request, CanGc::from_cx(cx));
 
         // Return promise.
         promise
@@ -527,8 +532,8 @@ impl ReadableStreamBYOBReaderMethods<crate::DomTypeHolder> for ReadableStreamBYO
     }
 
     /// <https://streams.spec.whatwg.org/#generic-reader-cancel>
-    fn Cancel(&self, cx: SafeJSContext, reason: SafeHandleValue, can_gc: CanGc) -> Rc<Promise> {
-        self.generic_cancel(cx, &self.global(), reason, can_gc)
+    fn Cancel(&self, cx: &mut js::context::JSContext, reason: SafeHandleValue) -> Rc<Promise> {
+        self.generic_cancel(cx, &self.global(), reason)
     }
 }
 

--- a/components/script/dom/stream/readablestreamdefaultcontroller.rs
+++ b/components/script/dom/stream/readablestreamdefaultcontroller.rs
@@ -897,19 +897,19 @@ impl ReadableStreamDefaultControllerMethods<crate::DomTypeHolder>
     }
 
     /// <https://streams.spec.whatwg.org/#rs-default-controller-enqueue>
-    fn Enqueue(&self, cx: SafeJSContext, chunk: SafeHandleValue, can_gc: CanGc) -> Fallible<()> {
+    fn Enqueue(&self, cx: &mut js::context::JSContext, chunk: SafeHandleValue) -> Fallible<()> {
         // If ! ReadableStreamDefaultControllerCanCloseOrEnqueue(this) is false, throw a TypeError exception.
         if !self.can_close_or_enqueue() {
             return Err(Error::Type(c"Stream cannot be enqueued to.".to_owned()));
         }
 
         // Perform ? ReadableStreamDefaultControllerEnqueue(this, chunk).
-        self.enqueue(cx, chunk, can_gc)
+        self.enqueue(cx.into(), chunk, CanGc::from_cx(cx))
     }
 
     /// <https://streams.spec.whatwg.org/#rs-default-controller-error>
-    fn Error(&self, _cx: SafeJSContext, e: SafeHandleValue, can_gc: CanGc) -> Fallible<()> {
-        self.error(e, can_gc);
+    fn Error(&self, cx: &mut js::context::JSContext, e: SafeHandleValue) -> Fallible<()> {
+        self.error(e, CanGc::from_cx(cx));
         Ok(())
     }
 }

--- a/components/script/dom/stream/readablestreamdefaultreader.rs
+++ b/components/script/dom/stream/readablestreamdefaultreader.rs
@@ -607,9 +607,8 @@ impl ReadableStreamDefaultReader {
     /// step 3 of <https://streams.spec.whatwg.org/#abstract-opdef-readablebytestreamcontrollerprocessreadrequestsusingqueue>
     pub(crate) fn process_read_requests(
         &self,
-        cx: SafeJSContext,
+        cx: &mut js::context::JSContext,
         controller: DomRoot<ReadableByteStreamController>,
-        can_gc: CanGc,
     ) -> Fallible<()> {
         // While reader.[[readRequests]] is not empty,
         while !self.read_requests.borrow().is_empty() {
@@ -624,7 +623,7 @@ impl ReadableStreamDefaultReader {
 
             // Perform ! ReadableByteStreamControllerFillReadRequestFromQueue(controller, readRequest).
             controller
-                .fill_read_request_from_queue(cx, &read_request, can_gc)
+                .fill_read_request_from_queue(cx.into(), &read_request, CanGc::from_cx(cx))
                 .expect("Fill read request from queue failed");
         }
         Ok(())
@@ -648,21 +647,25 @@ impl ReadableStreamDefaultReaderMethods<crate::DomTypeHolder> for ReadableStream
     }
 
     /// <https://streams.spec.whatwg.org/#default-reader-read>
-    fn Read(&self, can_gc: CanGc) -> Rc<Promise> {
-        let cx = GlobalScope::get_cx();
+    fn Read(&self, cx: &mut js::context::JSContext) -> Rc<Promise> {
         // If this.[[stream]] is undefined, return a promise rejected with a TypeError exception.
         if self.stream.get().is_none() {
-            rooted!(in(*cx) let mut error = UndefinedValue());
+            rooted!(&in(cx) let mut error = UndefinedValue());
             Error::Type(c"stream is undefined".to_owned()).to_jsval(
-                cx,
+                cx.into(),
                 &self.global(),
                 error.handle_mut(),
-                can_gc,
+                CanGc::from_cx(cx),
             );
-            return Promise::new_rejected(&self.global(), cx, error.handle(), can_gc);
+            return Promise::new_rejected(
+                &self.global(),
+                cx.into(),
+                error.handle(),
+                CanGc::from_cx(cx),
+            );
         }
         // Let promise be a new promise.
-        let promise = Promise::new(&self.global(), can_gc);
+        let promise = Promise::new(&self.global(), CanGc::from_cx(cx));
 
         // Let readRequest be a new read request with the following items:
         // chunk steps, given chunk
@@ -680,7 +683,7 @@ impl ReadableStreamDefaultReaderMethods<crate::DomTypeHolder> for ReadableStream
         let read_request = ReadRequest::Read(promise.clone());
 
         // Perform ! ReadableStreamDefaultReaderRead(this, readRequest).
-        self.read(cx, &read_request, can_gc);
+        self.read(cx.into(), &read_request, CanGc::from_cx(cx));
 
         // Return promise.
         promise
@@ -703,8 +706,8 @@ impl ReadableStreamDefaultReaderMethods<crate::DomTypeHolder> for ReadableStream
     }
 
     /// <https://streams.spec.whatwg.org/#generic-reader-cancel>
-    fn Cancel(&self, cx: SafeJSContext, reason: SafeHandleValue, can_gc: CanGc) -> Rc<Promise> {
-        self.generic_cancel(cx, &self.global(), reason, can_gc)
+    fn Cancel(&self, cx: &mut js::context::JSContext, reason: SafeHandleValue) -> Rc<Promise> {
+        self.generic_cancel(cx, &self.global(), reason)
     }
 }
 

--- a/components/script/dom/stream/readablestreamdefaultreader.rs
+++ b/components/script/dom/stream/readablestreamdefaultreader.rs
@@ -665,7 +665,7 @@ impl ReadableStreamDefaultReaderMethods<crate::DomTypeHolder> for ReadableStream
             );
         }
         // Let promise be a new promise.
-        let promise = Promise::new(&self.global(), CanGc::from_cx(cx));
+        let promise = Promise::new2(cx, &self.global());
 
         // Let readRequest be a new read request with the following items:
         // chunk steps, given chunk

--- a/components/script/dom/stream/readablestreamdefaultreader.rs
+++ b/components/script/dom/stream/readablestreamdefaultreader.rs
@@ -647,7 +647,7 @@ impl ReadableStreamDefaultReaderMethods<crate::DomTypeHolder> for ReadableStream
     }
 
     /// <https://streams.spec.whatwg.org/#default-reader-read>
-    fn Read(&self, cx: &mut CurrentRealm) -> Rc<Promise> {
+    fn Read(&self, cx: &mut js::context::JSContext) -> Rc<Promise> {
         // If this.[[stream]] is undefined, return a promise rejected with a TypeError exception.
         if self.stream.get().is_none() {
             rooted!(&in(cx) let mut error = UndefinedValue());
@@ -665,7 +665,7 @@ impl ReadableStreamDefaultReaderMethods<crate::DomTypeHolder> for ReadableStream
             );
         }
         // Let promise be a new promise.
-        let promise = Promise::new_in_realm(cx);
+        let promise = Promise::new(&self.global(), CanGc::from_cx(cx));
 
         // Let readRequest be a new read request with the following items:
         // chunk steps, given chunk
@@ -706,7 +706,7 @@ impl ReadableStreamDefaultReaderMethods<crate::DomTypeHolder> for ReadableStream
     }
 
     /// <https://streams.spec.whatwg.org/#generic-reader-cancel>
-    fn Cancel(&self, cx: &mut CurrentRealm, reason: SafeHandleValue) -> Rc<Promise> {
+    fn Cancel(&self, cx: &mut js::context::JSContext, reason: SafeHandleValue) -> Rc<Promise> {
         self.generic_cancel(cx, &self.global(), reason)
     }
 }

--- a/components/script/dom/stream/readablestreamdefaultreader.rs
+++ b/components/script/dom/stream/readablestreamdefaultreader.rs
@@ -647,7 +647,7 @@ impl ReadableStreamDefaultReaderMethods<crate::DomTypeHolder> for ReadableStream
     }
 
     /// <https://streams.spec.whatwg.org/#default-reader-read>
-    fn Read(&self, cx: &mut js::context::JSContext) -> Rc<Promise> {
+    fn Read(&self, cx: &mut CurrentRealm) -> Rc<Promise> {
         // If this.[[stream]] is undefined, return a promise rejected with a TypeError exception.
         if self.stream.get().is_none() {
             rooted!(&in(cx) let mut error = UndefinedValue());
@@ -665,7 +665,7 @@ impl ReadableStreamDefaultReaderMethods<crate::DomTypeHolder> for ReadableStream
             );
         }
         // Let promise be a new promise.
-        let promise = Promise::new(&self.global(), CanGc::from_cx(cx));
+        let promise = Promise::new_in_realm(cx);
 
         // Let readRequest be a new read request with the following items:
         // chunk steps, given chunk
@@ -706,7 +706,7 @@ impl ReadableStreamDefaultReaderMethods<crate::DomTypeHolder> for ReadableStream
     }
 
     /// <https://streams.spec.whatwg.org/#generic-reader-cancel>
-    fn Cancel(&self, cx: &mut js::context::JSContext, reason: SafeHandleValue) -> Rc<Promise> {
+    fn Cancel(&self, cx: &mut CurrentRealm, reason: SafeHandleValue) -> Rc<Promise> {
         self.generic_cancel(cx, &self.global(), reason)
     }
 }

--- a/components/script/dom/stream/readablestreamgenericreader.rs
+++ b/components/script/dom/stream/readablestreamgenericreader.rs
@@ -5,7 +5,6 @@
 use std::rc::Rc;
 
 use js::jsval::UndefinedValue;
-use js::realm::CurrentRealm;
 use js::rust::HandleValue as SafeHandleValue;
 
 use super::readablestream::ReaderType;
@@ -142,14 +141,14 @@ pub(crate) trait ReadableStreamGenericReader {
     // <https://streams.spec.whatwg.org/#generic-reader-cancel>
     fn generic_cancel(
         &self,
-        cx: &mut CurrentRealm,
+        cx: &mut js::context::JSContext,
         global: &GlobalScope,
         reason: SafeHandleValue,
     ) -> Rc<Promise> {
         if self.get_stream().is_none() {
             // If this.[[stream]] is undefined,
             // return a promise rejected with a TypeError exception.
-            let promise = Promise::new_in_realm(cx);
+            let promise = Promise::new(global, CanGc::from_cx(cx));
             promise.reject_error(
                 Error::Type(c"stream is undefined".to_owned()),
                 CanGc::from_cx(cx),

--- a/components/script/dom/stream/readablestreamgenericreader.rs
+++ b/components/script/dom/stream/readablestreamgenericreader.rs
@@ -5,6 +5,7 @@
 use std::rc::Rc;
 
 use js::jsval::UndefinedValue;
+use js::realm::CurrentRealm;
 use js::rust::HandleValue as SafeHandleValue;
 
 use super::readablestream::ReaderType;
@@ -141,14 +142,14 @@ pub(crate) trait ReadableStreamGenericReader {
     // <https://streams.spec.whatwg.org/#generic-reader-cancel>
     fn generic_cancel(
         &self,
-        cx: &mut js::context::JSContext,
+        cx: &mut CurrentRealm,
         global: &GlobalScope,
         reason: SafeHandleValue,
     ) -> Rc<Promise> {
         if self.get_stream().is_none() {
             // If this.[[stream]] is undefined,
             // return a promise rejected with a TypeError exception.
-            let promise = Promise::new(global, CanGc::from_cx(cx));
+            let promise = Promise::new_in_realm(cx);
             promise.reject_error(
                 Error::Type(c"stream is undefined".to_owned()),
                 CanGc::from_cx(cx),

--- a/components/script/dom/stream/readablestreamgenericreader.rs
+++ b/components/script/dom/stream/readablestreamgenericreader.rs
@@ -16,7 +16,7 @@ use crate::dom::promise::Promise;
 use crate::dom::stream::readablestreambyobreader::ReadableStreamBYOBReader;
 use crate::dom::stream::readablestreamdefaultreader::ReadableStreamDefaultReader;
 use crate::dom::types::ReadableStream;
-use crate::script_runtime::{CanGc, JSContext as SafeJSContext};
+use crate::script_runtime::CanGc;
 
 /// <https://streams.spec.whatwg.org/#readablestreamgenericreader>
 pub(crate) trait ReadableStreamGenericReader {
@@ -63,10 +63,9 @@ pub(crate) trait ReadableStreamGenericReader {
     /// <https://streams.spec.whatwg.org/#readable-stream-reader-generic-cancel>
     fn reader_generic_cancel(
         &self,
-        cx: SafeJSContext,
+        cx: &mut js::context::JSContext,
         global: &GlobalScope,
         reason: SafeHandleValue,
-        can_gc: CanGc,
     ) -> Rc<Promise> {
         // Let stream be reader.[[stream]].
         let stream = self.get_stream();
@@ -76,7 +75,7 @@ pub(crate) trait ReadableStreamGenericReader {
             stream.expect("Reader should have a stream when generic cancel is called into.");
 
         // Return ! ReadableStreamCancel(stream, reason).
-        stream.cancel(cx, global, reason, can_gc)
+        stream.cancel(cx.into(), global, reason, CanGc::from_cx(cx))
     }
 
     /// <https://streams.spec.whatwg.org/#readable-stream-reader-generic-release>
@@ -142,20 +141,22 @@ pub(crate) trait ReadableStreamGenericReader {
     // <https://streams.spec.whatwg.org/#generic-reader-cancel>
     fn generic_cancel(
         &self,
-        cx: SafeJSContext,
+        cx: &mut js::context::JSContext,
         global: &GlobalScope,
         reason: SafeHandleValue,
-        can_gc: CanGc,
     ) -> Rc<Promise> {
         if self.get_stream().is_none() {
             // If this.[[stream]] is undefined,
             // return a promise rejected with a TypeError exception.
-            let promise = Promise::new(global, can_gc);
-            promise.reject_error(Error::Type(c"stream is undefined".to_owned()), can_gc);
+            let promise = Promise::new(global, CanGc::from_cx(cx));
+            promise.reject_error(
+                Error::Type(c"stream is undefined".to_owned()),
+                CanGc::from_cx(cx),
+            );
             promise
         } else {
             // Return ! ReadableStreamReaderGenericCancel(this, reason).
-            self.reader_generic_cancel(cx, global, reason, can_gc)
+            self.reader_generic_cancel(cx, global, reason)
         }
     }
 

--- a/components/script/dom/stream/readablestreamgenericreader.rs
+++ b/components/script/dom/stream/readablestreamgenericreader.rs
@@ -148,7 +148,7 @@ pub(crate) trait ReadableStreamGenericReader {
         if self.get_stream().is_none() {
             // If this.[[stream]] is undefined,
             // return a promise rejected with a TypeError exception.
-            let promise = Promise::new(global, CanGc::from_cx(cx));
+            let promise = Promise::new2(cx, global);
             promise.reject_error(
                 Error::Type(c"stream is undefined".to_owned()),
                 CanGc::from_cx(cx),

--- a/components/script/dom/stream/transformstream.rs
+++ b/components/script/dom/stream/transformstream.rs
@@ -950,18 +950,17 @@ impl TransformStream {
     /// <https://streams.spec.whatwg.org/#transform-stream-error>
     pub(crate) fn error(
         &self,
-        cx: SafeJSContext,
+        cx: &mut js::context::JSContext,
         global: &GlobalScope,
         error: SafeHandleValue,
-        can_gc: CanGc,
     ) {
         // Perform ! ReadableStreamDefaultControllerError(stream.[[readable]].[[controller]], e).
         self.get_readable()
             .get_default_controller()
-            .error(error, can_gc);
+            .error(error, CanGc::from_cx(cx));
 
         // Perform ! TransformStreamErrorWritableAndUnblockWrite(stream, e).
-        self.error_writable_and_unblock_write(cx, global, error, can_gc);
+        self.error_writable_and_unblock_write(cx.into(), global, error, CanGc::from_cx(cx));
     }
 }
 

--- a/components/script/dom/stream/transformstreamdefaultcontroller.rs
+++ b/components/script/dom/stream/transformstreamdefaultcontroller.rs
@@ -51,11 +51,8 @@ struct TransformTransformPromiseRejection {
 impl Callback for TransformTransformPromiseRejection {
     /// Reacting to transformPromise with the following fulfillment steps:
     fn callback(&self, cx: &mut CurrentRealm, v: SafeHandleValue) {
-        let can_gc = CanGc::from_cx(cx);
-        let cx: SafeJSContext = cx.into();
         // Perform ! TransformStreamError(controller.[[stream]], r).
-        self.controller
-            .error(cx, &self.controller.global(), v, can_gc);
+        self.controller.error(cx, &self.controller.global(), v);
 
         // Throw r.
         // Note: this is done part of perform_transform().
@@ -637,16 +634,15 @@ impl TransformStreamDefaultController {
     /// <https://streams.spec.whatwg.org/#transform-stream-default-controller-error>
     pub(crate) fn error(
         &self,
-        cx: SafeJSContext,
+        cx: &mut js::context::JSContext,
         global: &GlobalScope,
         reason: SafeHandleValue,
-        can_gc: CanGc,
     ) {
         // Perform ! TransformStreamError(controller.[[stream]], e).
         self.stream
             .get()
             .expect("stream is undefined")
-            .error(cx, global, reason, can_gc);
+            .error(cx, global, reason);
     }
 
     /// <https://streams.spec.whatwg.org/#transform-stream-default-controller-clear-algorithms>
@@ -715,9 +711,9 @@ impl TransformStreamDefaultControllerMethods<crate::DomTypeHolder>
     }
 
     /// <https://streams.spec.whatwg.org/#ts-default-controller-error>
-    fn Error(&self, cx: SafeJSContext, reason: SafeHandleValue, can_gc: CanGc) -> Fallible<()> {
+    fn Error(&self, cx: &mut js::context::JSContext, reason: SafeHandleValue) -> Fallible<()> {
         // Perform ? TransformStreamDefaultControllerError(this, e).
-        self.error(cx, &self.global(), reason, can_gc);
+        self.error(cx, &self.global(), reason);
         Ok(())
     }
 

--- a/components/script_bindings/codegen/Bindings.conf
+++ b/components/script_bindings/codegen/Bindings.conf
@@ -945,8 +945,7 @@ DOMInterfaces = {
 
 'ReadableStream': {
     'canGc': ['GetReader', 'Tee'],
-    'realm': ['PipeTo', 'PipeThrough'],
-    'cx': ['Cancel']
+    'realm': ['Cancel', 'PipeTo', 'PipeThrough']
 },
 
 "ReadableStreamDefaultController": {
@@ -965,12 +964,12 @@ DOMInterfaces = {
 
 "ReadableStreamBYOBReader": {
     "canGc": ["ReleaseLock"],
-    "cx": ["Read", "Cancel"]
+    "realm": ["Read", "Cancel"]
 },
 
 "ReadableStreamDefaultReader": {
     "canGc": ["ReleaseLock"],
-    "cx": ["Read", "Cancel"]
+    "realm": ["Read", "Cancel"]
 },
 
 'ResizeObserverEntry': {

--- a/components/script_bindings/codegen/Bindings.conf
+++ b/components/script_bindings/codegen/Bindings.conf
@@ -944,16 +944,19 @@ DOMInterfaces = {
 },
 
 'ReadableStream': {
-    'canGc': ['GetReader', 'Cancel', 'Tee'],
-    'realm': ['PipeTo', 'PipeThrough']
+    'canGc': ['GetReader', 'Tee'],
+    'realm': ['PipeTo', 'PipeThrough'],
+    'cx': ['Cancel']
 },
 
 "ReadableStreamDefaultController": {
-    "canGc": ["Close", "Enqueue", "Error"]
+    "canGc": ["Close"],
+    "cx": ["Enqueue", "Error"]
 },
 
 "ReadableByteStreamController": {
-    "canGc": ["GetByobRequest", "Enqueue", "Close", "Error"]
+    "canGc": ["GetByobRequest", "Close"],
+    "cx": ["Enqueue", "Error"]
 },
 
 "ReadableStreamBYOBRequest": {
@@ -961,11 +964,13 @@ DOMInterfaces = {
 },
 
 "ReadableStreamBYOBReader": {
-    "canGc": ["Cancel", "Read", "ReleaseLock"]
+    "canGc": ["ReleaseLock"],
+    "cx": ["Read", "Cancel"]
 },
 
 "ReadableStreamDefaultReader": {
-    "canGc": ["Cancel", "Read", "ReleaseLock"]
+    "canGc": ["ReleaseLock"],
+    "cx": ["Read", "Cancel"]
 },
 
 'ResizeObserverEntry': {
@@ -994,7 +999,8 @@ DOMInterfaces = {
 },
 
 'TransformStreamDefaultController': {
-    'canGc': ['Enqueue', 'Error', 'Terminate'],
+    'canGc': ['Enqueue', 'Terminate'],
+    'cx': ['Error']
 },
 
 'WorkerNavigator': {

--- a/components/script_bindings/codegen/Bindings.conf
+++ b/components/script_bindings/codegen/Bindings.conf
@@ -945,7 +945,8 @@ DOMInterfaces = {
 
 'ReadableStream': {
     'canGc': ['GetReader', 'Tee'],
-    'realm': ['Cancel', 'PipeTo', 'PipeThrough']
+    'realm': ['PipeTo', 'PipeThrough'],
+    'cx': ['Cancel']
 },
 
 "ReadableStreamDefaultController": {
@@ -964,12 +965,12 @@ DOMInterfaces = {
 
 "ReadableStreamBYOBReader": {
     "canGc": ["ReleaseLock"],
-    "realm": ["Read", "Cancel"]
+    "cx": ["Read", "Cancel"]
 },
 
 "ReadableStreamDefaultReader": {
     "canGc": ["ReleaseLock"],
-    "realm": ["Read", "Cancel"]
+    "cx": ["Read", "Cancel"]
 },
 
 'ResizeObserverEntry': {


### PR DESCRIPTION
Pass `&mut JSContext` and `&mut CurrentRealm` to more functions in `dom/stream`, focusing on functions that need to be ported to finish porting the remaining methods in `Blob`.

Testing: Just a refactor, ./mach test-unit still passes.
Fixes: Part of #42638