### PR TITLE
net: Allow opaque origins in `parse_blob_url`

### DIFF
--- a/components/shared/net/blob_url_store.rs
+++ b/components/shared/net/blob_url_store.rs
@@ -38,25 +38,25 @@ pub struct BlobBuf {
 
 /// Parse URL as Blob URL scheme's definition
 ///
-/// <https://w3c.github.io/FileAPI/#DefinitionOfScheme>
+/// <https://w3c.github.io/FileAPI/#url-intro>
 pub fn parse_blob_url(url: &ServoUrl) -> Result<(Uuid, ImmutableOrigin), &'static str> {
-    let url_inner = Url::parse(url.path()).map_err(|_| "Failed to parse URL path")?;
-    let segs = url_inner
-        .path_segments()
-        .map(|c| c.collect::<Vec<_>>())
-        .ok_or("URL has no path segments")?;
-
     if url.query().is_some() {
         return Err("URL should not contain a query");
     }
 
-    if segs.len() > 1 {
-        return Err("URL should not have more than one path segment");
-    }
-
-    let id = {
-        let id = segs.first().ok_or("URL has no path segments")?;
-        Uuid::from_str(id).map_err(|_| "Failed to parse UUID from path segment")?
+    let Some((_, uuid)) = url.path().rsplit_once('/') else {
+        return Err("Failed to split origin from uuid");
     };
-    Ok((id, ServoUrl::from_url(url_inner).origin()))
+
+    // See https://url.spec.whatwg.org/#origin - "blob" case
+    let origin = Url::parse(url.path())
+        .ok()
+        .filter(|url| matches!(url.scheme(), "http" | "https" | "file"))
+        .map(|url| url.origin())
+        .map(ImmutableOrigin::new)
+        .unwrap_or(ImmutableOrigin::new_opaque());
+
+    let id = Uuid::from_str(uuid).map_err(|_| "Failed to parse UUID from path segment")?;
+
+    Ok((id, origin))
 }

--- a/components/shared/net/tests/lib.rs
+++ b/components/shared/net/tests/lib.rs
@@ -2,8 +2,13 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
+use std::str::FromStr;
+
 use base::cross_process_instant::CrossProcessInstant;
+use net_traits::blob_url_store::parse_blob_url;
 use net_traits::{ResourceAttribute, ResourceFetchTiming, ResourceTimeValue, ResourceTimingType};
+use servo_url::ServoUrl;
+use uuid::Uuid;
 
 #[test]
 fn test_set_start_time_to_fetch_start_if_nonzero_tao() {
@@ -231,4 +236,14 @@ fn test_reset_start_time() {
         resource_timing.start_time.is_none(),
         "failed to reset `start_time`"
     );
+}
+
+#[test]
+fn parse_blob_url_with_opaque_origin() {
+    let input = ServoUrl::parse("blob:null/93947d57-a49f-4b00-bdcc-fbf1ed8b60ab").unwrap();
+    let expected_uuid = Uuid::from_str("93947d57-a49f-4b00-bdcc-fbf1ed8b60ab").unwrap();
+    let (uuid, origin) = parse_blob_url(&input).unwrap();
+
+    assert_eq!(uuid, expected_uuid);
+    assert!(!origin.is_tuple(), "Origin is not opaque");
 }


### PR DESCRIPTION
Blob URLs created with opaque origins (like those in https://github.com/servo/servo/issues/43326) were rejected when parsed during `fetch`.

Testing: This doesn't have an impact on WPT but I've added a unit test