### PR TITLE
embedder: Allow the embedder to receive network erros if they occur

### DIFF
--- a/components/net/embedder.rs
+++ b/components/net/embedder.rs
@@ -39,4 +39,6 @@ pub enum NetToEmbedderMsg {
     EmbedderGetCookiesForUrlResponse(CookieOperationId, Vec<Cookie<'static>>),
     /// Response to a [`CoreResourceMsg::EmbedderSetCookieForUrl`] request.
     EmbedderSetCookieForUrlResponse(CookieOperationId),
+    /// Returns errors that we encounter while handling the networking.
+    RequestError(WebViewId, http::StatusCode),
 }

--- a/components/net/resource_thread.rs
+++ b/components/net/resource_thread.rs
@@ -773,6 +773,7 @@ impl CoreResourceManager {
         let request = request_builder.build();
         let url = request.current_url();
         let target_webview_id = request.target_webview_id;
+        let is_for_main_frame = matches!(request.destination, Destination::Document);
         let embedder_proxy = self.embedder_proxy.clone();
 
         // In the case of a valid blob URL, acquiring a token granting access to a file,
@@ -858,7 +859,7 @@ impl CoreResourceManager {
             };
 
             // Forward error to embedder
-            if !response.status.is_success() {
+            if !response.status.is_success() && is_for_main_frame {
                 if let Some(target_webview_id) = target_webview_id {
                     if let Some(status_code) = response.status.try_code() {
                         embedder_proxy.send(NetToEmbedderMsg::RequestError(

--- a/components/net/resource_thread.rs
+++ b/components/net/resource_thread.rs
@@ -18,7 +18,7 @@ use devtools_traits::DevtoolsControlMsg;
 use embedder_traits::GenericEmbedderProxy;
 use hyper_serde::Serde;
 use ipc_channel::ipc::IpcSender;
-use log::{debug, trace, warn};
+use log::{debug, error, trace, warn};
 use net_traits::blob_url_store::{BlobTokenCommunicator, parse_blob_url};
 use net_traits::filemanager_thread::FileTokenCheck;
 use net_traits::pub_domains::public_suffix_list_size_of;
@@ -693,6 +693,7 @@ pub struct AuthCache {
 
 pub struct CoreResourceManager {
     devtools_sender: Option<Sender<DevtoolsControlMsg>>,
+    embedder_proxy: GenericEmbedderProxy<NetToEmbedderMsg>,
     sw_managers: HashMap<ImmutableOrigin, IpcSender<CustomResponseMediator>>,
     filemanager: FileManager,
     request_interceptor: RequestInterceptor,
@@ -714,6 +715,7 @@ impl CoreResourceManager {
     ) -> CoreResourceManager {
         CoreResourceManager {
             devtools_sender,
+            embedder_proxy: embedder_proxy.clone(),
             sw_managers: Default::default(),
             filemanager: FileManager::new(embedder_proxy.clone(), blob_token_communicator),
             request_interceptor: RequestInterceptor::new(embedder_proxy),
@@ -770,6 +772,8 @@ impl CoreResourceManager {
 
         let request = request_builder.build();
         let url = request.current_url();
+        let target_webview_id = request.target_webview_id;
+        let embedder_proxy = self.embedder_proxy.clone();
 
         // In the case of a valid blob URL, acquiring a token granting access to a file,
         // regardless if the URL is revoked after token acquisition.
@@ -825,7 +829,7 @@ impl CoreResourceManager {
                 in_flight_keep_alive_records,
             };
 
-            match res_init_ {
+            let response = match res_init_ {
                 Some(res_init) => {
                     let response = Response::from_init(res_init, timing_type);
 
@@ -848,11 +852,26 @@ impl CoreResourceManager {
                     ) {
                         request_body_stream_closer.disarm();
                     }
+                    response
                 },
-                None => {
-                    fetch(request, &mut sender, &context).await;
-                },
+                None => fetch(request, &mut sender, &context).await,
             };
+
+            // Forward error to embedder
+            if !response.status.is_success() {
+                if let Some(target_webview_id) = target_webview_id {
+                    if let Some(status_code) = response.status.try_code() {
+                        embedder_proxy.send(NetToEmbedderMsg::RequestError(
+                            target_webview_id,
+                            status_code,
+                        ));
+                    } else {
+                        error!("Could not convert status code");
+                    }
+                } else {
+                    error!("Response error while target_webview_id or get_network_error is None.");
+                };
+            }
 
             // Remove token after fetch.
             if let Some(id) = blob_url_file_id.as_ref() {

--- a/components/servo/servo.rs
+++ b/components/servo/servo.rs
@@ -398,6 +398,11 @@ impl ServoInner {
                 self.site_data_manager
                     .handle_cookie_response(operation_id, CookieOperationResponse::Done);
             },
+            NetToEmbedderMsg::RequestError(webview_id, status) => {
+                if let Some(webview) = self.get_webview_handle(webview_id) {
+                    webview.set_load_status(LoadStatus::Failed(status));
+                }
+            },
         }
     }
 

--- a/components/servo/tests/network_manager.rs
+++ b/components/servo/tests/network_manager.rs
@@ -104,12 +104,10 @@ fn test_clear_cache() {
 #[test]
 fn test_network_error() {
     let has_run = Arc::new(AtomicBool::new(false));
-    let has_run_notify_error = Arc::new(AtomicBool::new(false));
     let servo_test = ServoTest::new();
     let servo = servo_test.servo();
 
     struct NetworkErrorDelegate {
-        has_run_notify_error: Arc<AtomicBool>,
         has_run: Arc<AtomicBool>,
     }
 
@@ -117,8 +115,6 @@ fn test_network_error() {
         fn notify_load_status_changed(&self, _webview: servo::WebView, status: servo::LoadStatus) {
             if let servo::LoadStatus::Failed(status_code) = status {
                 assert_eq!(status_code, StatusCode::NOT_FOUND);
-                self.has_run_notify_error
-                    .store(true, std::sync::atomic::Ordering::SeqCst);
                 self.has_run
                     .store(true, std::sync::atomic::Ordering::SeqCst);
             }
@@ -126,7 +122,6 @@ fn test_network_error() {
     }
 
     let delegate = Rc::new(NetworkErrorDelegate {
-        has_run_notify_error: has_run_notify_error.clone(),
         has_run: has_run.clone(),
     });
     let _webview = WebViewBuilder::new(servo, servo_test.rendering_context.clone())
@@ -150,5 +145,52 @@ fn test_network_error() {
     servo_test.spin(move || !has_run_clone.load(std::sync::atomic::Ordering::SeqCst));
 
     let _ = server.close();
-    assert!(has_run_notify_error.load(std::sync::atomic::Ordering::SeqCst));
+}
+
+#[test]
+fn test_no_network_error_in_iframe() {
+    let has_run = Arc::new(AtomicBool::new(false));
+    let servo_test = ServoTest::new();
+    let servo = servo_test.servo();
+
+    static MESSAGE: &'static [u8] = b"<iframe src=\"example.com\"></iframe>";
+    struct NetworkErrorDelegate {
+        has_run: Arc<AtomicBool>,
+    }
+
+    impl WebViewDelegate for NetworkErrorDelegate {
+        fn notify_load_status_changed(&self, _webview: servo::WebView, status: servo::LoadStatus) {
+            if let servo::LoadStatus::Complete = status {
+                self.has_run
+                    .store(true, std::sync::atomic::Ordering::SeqCst);
+            } else if let servo::LoadStatus::Failed(_status_code) = status {
+                assert!(false);
+            }
+        }
+    }
+
+    let delegate = Rc::new(NetworkErrorDelegate {
+        has_run: has_run.clone(),
+    });
+    let _webview = WebViewBuilder::new(servo, servo_test.rendering_context.clone())
+        .delegate(delegate.clone())
+        .build();
+    servo_test.spin(move || false);
+
+    let handler =
+        move |_: HyperRequest<Incoming>,
+              response: &mut HyperResponse<BoxBody<Bytes, hyper::Error>>| {
+            *response.body_mut() = make_body(MESSAGE.to_vec());
+        };
+    let (server, url) = make_server(handler);
+
+    let _webview = WebViewBuilder::new(servo_test.servo(), servo_test.rendering_context.clone())
+        .delegate(delegate.clone())
+        .url(url.as_url().clone())
+        .build();
+
+    let has_run_clone = has_run.clone();
+    servo_test.spin(move || !has_run_clone.load(std::sync::atomic::Ordering::SeqCst));
+
+    let _ = server.close();
 }

--- a/components/servo/tests/network_manager.rs
+++ b/components/servo/tests/network_manager.rs
@@ -5,13 +5,16 @@
 mod common;
 
 use std::rc::Rc;
+use std::sync::Arc;
+use std::sync::atomic::AtomicBool;
 
+use http::StatusCode;
 use http_body_util::combinators::BoxBody;
 use hyper::body::{Bytes, Incoming};
 use hyper::header::{self, HeaderValue};
 use hyper::{Request as HyperRequest, Response as HyperResponse};
 use net::test_util::{make_body, make_server};
-use servo::{CacheEntry, WebViewBuilder};
+use servo::{CacheEntry, WebViewBuilder, WebViewDelegate};
 
 use crate::common::{ServoTest, WebViewDelegateImpl};
 
@@ -96,4 +99,56 @@ fn test_clear_cache() {
 
     let cache_entries = network_manager.cache_entries();
     assert_eq!(cache_entries.len(), 0);
+}
+
+#[test]
+fn test_network_error() {
+    let has_run = Arc::new(AtomicBool::new(false));
+    let has_run_notify_error = Arc::new(AtomicBool::new(false));
+    let servo_test = ServoTest::new();
+    let servo = servo_test.servo();
+
+    struct NetworkErrorDelegate {
+        has_run_notify_error: Arc<AtomicBool>,
+        has_run: Arc<AtomicBool>,
+    }
+
+    impl WebViewDelegate for NetworkErrorDelegate {
+        fn notify_load_status_changed(&self, _webview: servo::WebView, status: servo::LoadStatus) {
+            if let servo::LoadStatus::Failed(status_code) = status {
+                assert_eq!(status_code, StatusCode::NOT_FOUND);
+                self.has_run_notify_error
+                    .store(true, std::sync::atomic::Ordering::SeqCst);
+                self.has_run
+                    .store(true, std::sync::atomic::Ordering::SeqCst);
+            }
+        }
+    }
+
+    let delegate = Rc::new(NetworkErrorDelegate {
+        has_run_notify_error: has_run_notify_error.clone(),
+        has_run: has_run.clone(),
+    });
+    let _webview = WebViewBuilder::new(servo, servo_test.rendering_context.clone())
+        .delegate(delegate.clone())
+        .build();
+    servo_test.spin(move || false);
+
+    let handler =
+        move |_: HyperRequest<Incoming>,
+              response: &mut HyperResponse<BoxBody<Bytes, hyper::Error>>| {
+            *response.status_mut() = StatusCode::from_u16(404).unwrap();
+        };
+    let (server, url) = make_server(handler);
+
+    let _webview = WebViewBuilder::new(servo_test.servo(), servo_test.rendering_context.clone())
+        .delegate(delegate.clone())
+        .url(url.as_url().clone())
+        .build();
+
+    let has_run_clone = has_run.clone();
+    servo_test.spin(move || !has_run_clone.load(std::sync::atomic::Ordering::SeqCst));
+
+    let _ = server.close();
+    assert!(has_run_notify_error.load(std::sync::atomic::Ordering::SeqCst));
 }

--- a/components/shared/embedder/lib.rs
+++ b/components/shared/embedder/lib.rs
@@ -775,6 +775,14 @@ pub enum LoadStatus {
     /// `document.readyState` == `complete`.
     /// See <https://developer.mozilla.org/en-US/docs/Web/API/Document/readyState>
     Complete,
+    /// The load failed with a StatusCode.
+    Failed(
+        #[serde(
+            deserialize_with = "hyper_serde::deserialize",
+            serialize_with = "hyper_serde::serialize"
+        )]
+        http::StatusCode,
+    ),
 }
 
 /// Data that could be used to display a desktop notification to the end user

--- a/ports/servoshell/desktop/gui.rs
+++ b/ports/servoshell/desktop/gui.rs
@@ -425,6 +425,7 @@ impl Gui {
                                         );
                                     }
                                 },
+                                LoadStatus::Failed(_) => {},
                             }
                             ui.add_space(2.0);
 


### PR DESCRIPTION
This allows the embedder to receive NetworkErrors if they occur.

We do this by checking the status code after http_network_or_cache_fetch in http_fetch and then forward the request, response and NetworkError to the embedder via HttpState and EmbedderProxy. The embedder will be notified via LoadStatus::Failure(http::StatusCode).

Testing: Embedder API does not have any tests. 
