### PR TITLE
ci: Fix mitmproxy script

### DIFF
--- a/etc/ci/scenario/update_mitmproxy_dump.py
+++ b/etc/ci/scenario/update_mitmproxy_dump.py
@@ -61,7 +61,7 @@ if __name__ == "__main__":
             "-w",
             args.dump_file,
             "-p",
-            common_function_for_servo_test.MITMPROXY_PORT,
+            str(common_function_for_servo_test.MITMPROXY_PORT),
             # "--mode", "upstream:<YOUR_PROXY_ADDRESS>",
             "--set",
             "ssl_insecure=true",


### PR DESCRIPTION
Latest ohos CI scenario tests are failing, due to a type error (int instead of str).
This was presumably broken by #42509, where the type change. I'm a bit confused why my try run succeeded, and the failure only recently started happening (on an unrelated commit). This might be an effect of caching hiding / avoiding the failure.

Testing: Tested in CI. Apparently this file is not covered by the python type checker yet.
