### PR TITLE
script: Do not fire simulated click on spacebar/enter in non-state-changing elements

### DIFF
--- a/components/malloc_size_of/lib.rs
+++ b/components/malloc_size_of/lib.rs
@@ -1122,6 +1122,7 @@ malloc_size_of_is_0!(app_units::Au);
 malloc_size_of_is_0!(content_security_policy::Destination);
 malloc_size_of_is_0!(content_security_policy::sandboxing_directive::SandboxingFlagSet);
 malloc_size_of_is_0!(http::StatusCode);
+malloc_size_of_is_0!(keyboard_types::Code);
 malloc_size_of_is_0!(keyboard_types::Modifiers);
 malloc_size_of_is_0!(mime::Mime);
 malloc_size_of_is_0!(resvg::usvg::fontdb::ID);

--- a/components/script/dom/document_event_handler.rs
+++ b/components/script/dom/document_event_handler.rs
@@ -1392,25 +1392,6 @@ impl DocumentEventHandler {
             flags = event.flags();
         }
 
-        if flags.contains(EventFlags::Canceled) {
-            return flags.into();
-        }
-
-        // This behavior is unspecced
-        // We are supposed to dispatch synthetic click activation for Space and/or Return,
-        // however *when* we do it is up to us.
-        // Here, we're dispatching it after the key event so the script has a chance to cancel it
-        // https://www.w3.org/Bugs/Public/show_bug.cgi?id=27337
-        if (keyboard_event.event.key == Key::Named(NamedKey::Enter) ||
-            keyboard_event.event.code == Code::Space) &&
-            keyboard_event.event.state == KeyState::Up
-        {
-            if let Some(elem) = target.downcast::<Element>() {
-                elem.upcast::<Node>()
-                    .fire_synthetic_pointer_event_not_trusted(atom!("click"), can_gc);
-            }
-        }
-
         flags.into()
     }
 
@@ -1887,8 +1868,48 @@ impl DocumentEventHandler {
         }
     }
 
-    pub(crate) fn run_default_keyboard_event_handler(&self, event: &KeyboardEvent, can_gc: CanGc) {
+    /// <https://w3c.github.io/uievents/#keydown>
+    ///
+    /// > If the key is the Enter or (Space) key and the current focus is on a state-changing element,
+    /// > the default action MUST be to dispatch a click event, and a DOMActivate event if that event
+    /// > type is supported by the user agent.
+    pub(crate) fn maybe_dispatch_simulated_click(
+        &self,
+        node: &Node,
+        event: &KeyboardEvent,
+        can_gc: CanGc,
+    ) -> bool {
+        if event.key() != Key::Named(NamedKey::Enter) && event.original_code() != Some(Code::Space)
+        {
+            return false;
+        }
+
+        // Check whether this node is a state-changing element. Note that the specification doesn't
+        // seem to have a good definition of what "state-changing" means, so we merely check to
+        // see if the element is activatable here.
+        if node
+            .downcast::<Element>()
+            .and_then(Element::as_maybe_activatable)
+            .is_none()
+        {
+            return false;
+        }
+
+        node.fire_synthetic_pointer_event_not_trusted(atom!("click"), can_gc);
+        true
+    }
+
+    pub(crate) fn run_default_keyboard_event_handler(
+        &self,
+        node: &Node,
+        event: &KeyboardEvent,
+        can_gc: CanGc,
+    ) {
         if event.upcast::<Event>().type_() != atom!("keydown") {
+            return;
+        }
+
+        if self.maybe_dispatch_simulated_click(node, event, can_gc) {
             return;
         }
 
@@ -1906,6 +1927,11 @@ impl DocumentEventHandler {
             Key::Named(NamedKey::PageDown) => KeyboardScroll::PageDown,
             Key::Named(NamedKey::PageUp) => KeyboardScroll::PageUp,
             Key::Named(NamedKey::Tab) => {
+                // From <https://w3c.github.io/uievents/#keydown>:
+                //
+                // > If the key is the Tab key, the default action MUST be to shift the document focus
+                // > from the currently focused element (if any) to the new focused element, as
+                // > described in Focus Event Types
                 self.sequential_focus_navigation_via_keyboard_event(event, can_gc);
                 return;
             },

--- a/components/script/dom/keyboardevent.rs
+++ b/components/script/dom/keyboardevent.rs
@@ -3,10 +3,11 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 use std::cell::Cell;
+use std::str::FromStr;
 
 use dom_struct::dom_struct;
 use js::rust::HandleObject;
-use keyboard_types::{Key, Modifiers, NamedKey};
+use keyboard_types::{Code, Key, Modifiers, NamedKey};
 use style::Atom;
 
 use crate::dom::bindings::cell::DomRefCell;
@@ -30,6 +31,8 @@ pub(crate) struct KeyboardEvent {
     #[no_trace]
     typed_key: DomRefCell<Key>,
     code: DomRefCell<DOMString>,
+    #[no_trace]
+    original_code: DomRefCell<Option<Code>>,
     location: Cell<u32>,
     #[no_trace]
     modifiers: Cell<Modifiers>,
@@ -40,18 +43,19 @@ pub(crate) struct KeyboardEvent {
 }
 
 impl KeyboardEvent {
-    fn new_inherited() -> KeyboardEvent {
-        KeyboardEvent {
+    fn new_inherited() -> Self {
+        Self {
             uievent: UIEvent::new_inherited(),
-            key: DomRefCell::new(DOMString::new()),
-            typed_key: DomRefCell::new(Key::Named(NamedKey::Unidentified)),
-            code: DomRefCell::new(DOMString::new()),
-            location: Cell::new(0),
-            modifiers: Cell::new(Modifiers::empty()),
-            repeat: Cell::new(false),
-            is_composing: Cell::new(false),
-            char_code: Cell::new(0),
-            key_code: Cell::new(0),
+            key: Default::default(),
+            typed_key: Default::default(),
+            code: Default::default(),
+            original_code: Default::default(),
+            location: Default::default(),
+            modifiers: Default::default(),
+            repeat: Default::default(),
+            is_composing: Default::default(),
+            char_code: Default::default(),
+            key_code: Default::default(),
         }
     }
 
@@ -88,6 +92,7 @@ impl KeyboardEvent {
             0,            /* detail */
             keyboard_event.key.clone(),
             DOMString::from(keyboard_event.code.to_string()),
+            Some(keyboard_event.code),
             keyboard_event.location as u32,
             keyboard_event.repeat,
             keyboard_event.is_composing,
@@ -109,6 +114,7 @@ impl KeyboardEvent {
         _detail: i32,
         key: Key,
         code: DOMString,
+        original_code: Option<Code>,
         location: u32,
         repeat: bool,
         is_composing: bool,
@@ -117,8 +123,8 @@ impl KeyboardEvent {
         key_code: u32,
         can_gc: CanGc,
     ) -> DomRoot<KeyboardEvent> {
-        let ev = KeyboardEvent::new_uninitialized_with_proto(window, proto, can_gc);
-        ev.init_event(
+        let event = KeyboardEvent::new_uninitialized_with_proto(window, proto, can_gc);
+        event.init_event(
             event_type,
             can_bubble,
             cancelable,
@@ -127,18 +133,23 @@ impl KeyboardEvent {
             location,
             repeat,
         );
-        *ev.typed_key.borrow_mut() = key;
-        *ev.code.borrow_mut() = code;
-        ev.modifiers.set(modifiers);
-        ev.is_composing.set(is_composing);
-        ev.char_code.set(char_code);
-        ev.key_code.set(key_code);
-        ev.uievent.set_which(key_code);
-        ev
+        *event.typed_key.borrow_mut() = key;
+        *event.code.borrow_mut() = code;
+        *event.original_code.borrow_mut() = original_code;
+        event.modifiers.set(modifiers);
+        event.is_composing.set(is_composing);
+        event.char_code.set(char_code);
+        event.key_code.set(key_code);
+        event.uievent.set_which(key_code);
+        event
     }
 
     pub(crate) fn key(&self) -> Key {
         self.typed_key.borrow().clone()
+    }
+
+    pub(crate) fn original_code(&self) -> Option<Code> {
+        *self.original_code.borrow()
     }
 
     pub(crate) fn modifiers(&self) -> Modifiers {
@@ -147,7 +158,7 @@ impl KeyboardEvent {
 
     /// <https://w3c.github.io/uievents/#widl-KeyboardEvent-initKeyboardEvent>
     #[expect(clippy::too_many_arguments)]
-    pub fn init_event(
+    pub(crate) fn init_event(
         &self,
         event_type: Atom,
         can_bubble_arg: bool,
@@ -198,6 +209,7 @@ impl KeyboardEventMethods<crate::DomTypeHolder> for KeyboardEvent {
             init.parent.parent.detail,
             Key::Named(NamedKey::Unidentified),
             init.code.clone(),
+            Code::from_str(&init.code.str()).ok(),
             init.location,
             init.repeat,
             init.isComposing,

--- a/components/script/dom/node.rs
+++ b/components/script/dom/node.rs
@@ -4758,7 +4758,7 @@ impl VirtualMethods for Node {
         if let Some(event) = event.downcast::<KeyboardEvent>() {
             self.owner_document()
                 .event_handler()
-                .run_default_keyboard_event_handler(event, can_gc);
+                .run_default_keyboard_event_handler(self, event, can_gc);
         }
     }
 }

--- a/tests/wpt/meta/html/semantics/forms/the-button-element/button-activate-keyup-prevented.html.ini
+++ b/tests/wpt/meta/html/semantics/forms/the-button-element/button-activate-keyup-prevented.html.ini
@@ -1,3 +1,0 @@
-[button-activate-keyup-prevented.html]
-  [Button activation submits on keyup, but not if keydown is defaultPrevented]
-    expected: FAIL

--- a/tests/wpt/meta/uievents/order-of-events/focus-events/focus-management-expectations.html.ini
+++ b/tests/wpt/meta/uievents/order-of-events/focus-events/focus-management-expectations.html.ini
@@ -1,3 +1,0 @@
-[focus-management-expectations.html]
-  [Keydown to focus should not trigger activation]
-    expected: FAIL

--- a/tests/wpt/mozilla/meta/MANIFEST.json
+++ b/tests/wpt/mozilla/meta/MANIFEST.json
@@ -13258,6 +13258,15 @@
       }
      ]
     ],
+    "spacebar-and-enter-in-input-text.html": [
+     "5bc302968caf6b31927e175eea188f5bab808d3b",
+     [
+      null,
+      {
+       "testdriver": true
+      }
+     ]
+    ],
     "spurious-mouse-move-events.html": [
      "9cfa22aaf90a0d3399fd03a80aa87dd0f16f76d6",
      [

--- a/tests/wpt/mozilla/tests/input-events/spacebar-and-enter-in-input-text.html
+++ b/tests/wpt/mozilla/tests/input-events/spacebar-and-enter-in-input-text.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<title>Spacebar and enter keys in text input should not cause a click event</title>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/resources/testdriver.js"></script>
+<script src="/resources/testdriver-actions.js"></script>
+<script src="/resources/testdriver-vendor.js"></script>
+<link rel="stylesheet" type="text/css" href="/fonts/ahem.css" />
+
+<input id="target">
+
+<script>
+promise_test(async test => {
+    target.focus();
+
+    let eventWatcher = new EventWatcher(test, target, ["keydown", "keyup", "click"]);
+    let eventPromise = eventWatcher.wait_for(["keydown", "keyup", "keydown", "keyup"]);
+    await test_driver.send_keys(document.body, " ");
+    await test_driver.send_keys(document.body, " ");
+    await eventPromise;
+
+    let enterKey = "\uE007";
+    let eventPromise2 = eventWatcher.wait_for(["keydown", "keyup", "keydown", "keyup"]);
+    await test_driver.send_keys(document.body, enterKey);
+    await test_driver.send_keys(document.body, enterKey);
+    await eventPromise2;
+});
+</script>


### PR DESCRIPTION
Servo has for years implemented a behavior where spacebar or enter click
on a focused element will trigger a click. That behavior used to be
unspecified, but now it is. The specification says that this should only
happen on state-changing elements. This change makes this happen using
activatable elements as a heuristic (as state-changing elements are not
defined in the specification). In addition, the behavior is integrated
into the default keyboard event handler code.

Testing: This change adds a Servo-specific test due to the ambiguities in the specification.
Fixes: #39028.
