### PR TITLE
everywhere: Remove unused deps

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7310,7 +7310,6 @@ dependencies = [
  "rustls",
  "serde",
  "servo",
- "servo-allocator",
  "servo-background-hang-monitor",
  "servo-base",
  "servo-bluetooth",
@@ -7486,7 +7485,6 @@ dependencies = [
  "malloc_size_of_derive",
  "serde",
  "servo-base",
- "servo-config",
  "servo-fonts-traits",
  "servo-malloc-size-of",
  "servo-pixels",
@@ -7548,7 +7546,6 @@ dependencies = [
  "servo-net",
  "servo-net-traits",
  "servo-paint-api",
- "servo-profile",
  "servo-profile-traits",
  "servo-script-traits",
  "servo-storage-traits",
@@ -7560,8 +7557,6 @@ dependencies = [
  "stylo",
  "stylo_traits",
  "tracing",
- "webrender",
- "webrender_api",
 ]
 
 [[package]]
@@ -7593,7 +7588,6 @@ dependencies = [
  "servo-url",
  "servo-webgpu-traits",
  "strum",
- "stylo_traits",
  "uuid",
  "webrender_api",
  "wgpu-core",
@@ -7639,9 +7633,7 @@ dependencies = [
 name = "servo-devtools-traits"
 version = "0.0.6"
 dependencies = [
- "bitflags 2.11.0",
  "http 1.4.0",
- "log",
  "malloc_size_of_derive",
  "serde",
  "servo-base",
@@ -7687,7 +7679,6 @@ dependencies = [
  "strum",
  "stylo",
  "stylo_traits",
- "tokio",
  "url",
  "uuid",
  "webdriver",
@@ -7811,11 +7802,9 @@ dependencies = [
 name = "servo-layout"
 version = "0.0.6"
 dependencies = [
- "accesskit",
  "app_units",
  "atomic_refcell",
  "bitflags 2.11.0",
- "cssparser",
  "data-url",
  "euclid",
  "html5ever",
@@ -7882,7 +7871,6 @@ dependencies = [
  "servo-base",
  "servo-embedder-traits",
  "servo-fonts",
- "servo-fonts-traits",
  "servo-malloc-size-of",
  "servo-net-traits",
  "servo-paint-api",
@@ -8322,7 +8310,6 @@ dependencies = [
  "servo-embedder-traits",
  "servo-geometry",
  "servo-malloc-size-of",
- "servo-pixels",
  "servo-profile-traits",
  "servo-tracing",
  "servo-url",
@@ -8379,7 +8366,6 @@ dependencies = [
  "serde",
  "servo-allocator",
  "servo-base",
- "servo-config",
  "servo-malloc-size-of",
  "time",
  "tracing",
@@ -8426,12 +8412,10 @@ dependencies = [
  "hkdf",
  "html5ever",
  "http 1.4.0",
- "image",
  "indexmap",
  "ipc-channel",
  "itertools 0.14.0",
  "keyboard-types",
- "kurbo 0.12.0",
  "libc",
  "log",
  "malloc_size_of_derive",
@@ -8514,7 +8498,6 @@ dependencies = [
  "tracing",
  "unicode-bidi",
  "unicode-script",
- "unicode-segmentation",
  "url",
  "urlpattern",
  "utf-8",
@@ -8571,15 +8554,12 @@ name = "servo-script-traits"
 version = "0.0.6"
 dependencies = [
  "accesskit",
- "content-security-policy",
  "crossbeam-channel",
  "euclid",
  "keyboard-types",
- "log",
  "malloc_size_of_derive",
  "rustc-hash 2.1.1",
  "serde",
- "servo-background-hang-monitor-api",
  "servo-base",
  "servo-bluetooth-traits",
  "servo-canvas-traits",
@@ -8617,7 +8597,6 @@ dependencies = [
  "sea-query",
  "sea-query-rusqlite",
  "serde",
- "serde_json",
  "servo-base",
  "servo-config",
  "servo-malloc-size-of",
@@ -8627,10 +8606,6 @@ dependencies = [
  "servo-storage-traits",
  "servo-url",
  "tempfile",
- "tokio",
- "tokio-rustls",
- "tokio-stream",
- "tokio-util",
  "url",
  "uuid",
 ]
@@ -8727,7 +8702,6 @@ dependencies = [
  "servo-webxr",
  "servo-webxr-api",
  "surfman",
- "webrender",
  "webrender_api",
 ]
 

--- a/components/constellation/Cargo.toml
+++ b/components/constellation/Cargo.toml
@@ -47,7 +47,6 @@ net = { workspace = true }
 net_traits = { workspace = true }
 paint_api = { workspace = true }
 parking_lot = { workspace = true }
-profile = { workspace = true }
 profile_traits = { workspace = true }
 rand = { workspace = true }
 rustc-hash = { workspace = true }
@@ -62,8 +61,6 @@ stylo_traits = { workspace = true }
 tracing = { workspace = true, optional = true }
 webgpu = { workspace = true }
 webgpu_traits = { workspace = true }
-webrender = { workspace = true }
-webrender_api = { workspace = true }
 webxr-api = { workspace = true }
 
 [target.'cfg(any(target_os="macos", all(not(target_os = "windows"), not(target_os = "ios"), not(target_os="android"), not(target_env="ohos"), not(target_arch="arm"), not(target_arch="aarch64"))))'.dependencies]

--- a/components/layout/Cargo.toml
+++ b/components/layout/Cargo.toml
@@ -17,12 +17,10 @@ doctest = false
 tracing = ["dep:tracing"]
 
 [dependencies]
-accesskit = { workspace = true }
 app_units = { workspace = true }
 atomic_refcell = { workspace = true }
 base = { workspace = true }
 bitflags = { workspace = true }
-cssparser = { workspace = true }
 data-url = { workspace = true }
 embedder_traits = { workspace = true }
 euclid = { workspace = true }

--- a/components/script/Cargo.toml
+++ b/components/script/Cargo.toml
@@ -81,14 +81,12 @@ hkdf = { workspace = true }
 html5ever = { workspace = true }
 http = { workspace = true }
 hyper_serde = { workspace = true }
-image = { workspace = true }
 indexmap = { workspace = true }
 ipc-channel = { workspace = true }
 itertools = { workspace = true }
 js = { workspace = true }
 jstraceable_derive = { workspace = true }
 keyboard-types = { workspace = true }
-kurbo = { workspace = true }
 layout_api = { workspace = true }
 libc = { workspace = true }
 log = { workspace = true }
@@ -153,7 +151,6 @@ timers = { workspace = true }
 tracing = { workspace = true, optional = true }
 unicode-bidi = { workspace = true }
 unicode-script = { workspace = true }
-unicode-segmentation = { workspace = true }
 url = { workspace = true }
 urlpattern = { workspace = true }
 utf-8 = { workspace = true }

--- a/components/servo/Cargo.toml
+++ b/components/servo/Cargo.toml
@@ -114,7 +114,6 @@ servo-media = { workspace = true }
 servo-media-dummy = { workspace = true }
 servo-media-gstreamer = { workspace = true, optional = true }
 servo-tracing = { workspace = true }
-servo_allocator = { workspace = true }
 servo_config = { workspace = true }
 servo_geometry = { workspace = true }
 servo-url = { workspace = true }

--- a/components/shared/canvas/Cargo.toml
+++ b/components/shared/canvas/Cargo.toml
@@ -25,7 +25,6 @@ malloc_size_of = { workspace = true }
 malloc_size_of_derive = { workspace = true }
 pixels = { workspace = true }
 serde = { workspace = true }
-servo_config = { workspace = true }
 strum = { workspace = true }
 stylo = { workspace = true }
 webrender_api = { workspace = true }

--- a/components/shared/constellation/Cargo.toml
+++ b/components/shared/constellation/Cargo.toml
@@ -40,7 +40,6 @@ servo_config = { workspace = true }
 servo-url = { workspace = true }
 storage_traits = { workspace = true }
 strum = { workspace = true }
-stylo_traits = { workspace = true }
 uuid = { workspace = true }
 webgpu_traits = { workspace = true }
 webrender_api = { workspace = true }

--- a/components/shared/devtools/Cargo.toml
+++ b/components/shared/devtools/Cargo.toml
@@ -13,10 +13,8 @@ path = "lib.rs"
 
 [dependencies]
 base = { workspace = true }
-bitflags = { workspace = true }
 embedder_traits = { workspace = true }
 http = { workspace = true }
-log = { workspace = true }
 malloc_size_of = { workspace = true }
 malloc_size_of_derive = { workspace = true }
 net_traits = { workspace = true }

--- a/components/shared/embedder/Cargo.toml
+++ b/components/shared/embedder/Cargo.toml
@@ -39,7 +39,6 @@ servo-url = { workspace = true }
 strum = { workspace = true }
 stylo = { workspace = true }
 stylo_traits = { workspace = true }
-tokio = { workspace = true, features = ["sync"] }
 url = { workspace = true }
 uuid = { workspace = true }
 webdriver = { workspace = true }

--- a/components/shared/layout/Cargo.toml
+++ b/components/shared/layout/Cargo.toml
@@ -20,7 +20,6 @@ bitflags = { workspace = true }
 embedder_traits = { workspace = true }
 euclid = { workspace = true }
 fonts = { workspace = true }
-fonts_traits = { workspace = true }
 html5ever = { workspace = true }
 libc = { workspace = true }
 malloc_size_of = { workspace = true }

--- a/components/shared/paint/Cargo.toml
+++ b/components/shared/paint/Cargo.toml
@@ -30,7 +30,6 @@ log = { workspace = true }
 malloc_size_of = { workspace = true }
 malloc_size_of_derive = { workspace = true }
 parking_lot = { workspace = true }
-pixels = { workspace = true }
 profile_traits = { workspace = true }
 raw-window-handle = { workspace = true }
 rustc-hash = { workspace = true }

--- a/components/shared/profile/Cargo.toml
+++ b/components/shared/profile/Cargo.toml
@@ -23,6 +23,5 @@ malloc_size_of = { workspace = true }
 malloc_size_of_derive = { workspace = true }
 serde = { workspace = true }
 servo_allocator = { workspace = true }
-servo_config = { workspace = true }
 time = { workspace = true }
 tracing = { workspace = true, optional = true }

--- a/components/shared/script/Cargo.toml
+++ b/components/shared/script/Cargo.toml
@@ -17,19 +17,16 @@ webgpu = ["webgpu_traits"]
 
 [dependencies]
 accesskit = { workspace = true }
-background_hang_monitor_api = { workspace = true }
 base = { workspace = true }
 bluetooth_traits = { workspace = true, optional = true }
 canvas_traits = { workspace = true }
 constellation_traits = { workspace = true }
-content-security-policy = { workspace = true }
 crossbeam-channel = { workspace = true }
 devtools_traits = { workspace = true }
 embedder_traits = { workspace = true }
 euclid = { workspace = true }
 fonts_traits = { workspace = true }
 keyboard-types = { workspace = true }
-log = { workspace = true }
 malloc_size_of = { workspace = true }
 malloc_size_of_derive = { workspace = true }
 media = { workspace = true }

--- a/components/storage/Cargo.toml
+++ b/components/storage/Cargo.toml
@@ -26,15 +26,10 @@ rustc-hash = { workspace = true }
 sea-query = { workspace = true }
 sea-query-rusqlite = { workspace = true }
 serde = { workspace = true }
-serde_json = { workspace = true }
 servo_config = { workspace = true }
 servo-url = { workspace = true }
 storage_traits = { workspace = true }
 tempfile = "3"
-tokio = { workspace = true, features = ["macros", "rt-multi-thread", "sync"] }
-tokio-rustls = { workspace = true }
-tokio-stream = { workspace = true }
-tokio-util = { workspace = true, features = ["codec", "io"] }
 uuid = { workspace = true }
 
 [dev-dependencies]

--- a/components/webgl/Cargo.toml
+++ b/components/webgl/Cargo.toml
@@ -31,7 +31,6 @@ parking_lot = { workspace = true }
 pixels = { workspace = true }
 rustc-hash = { workspace = true }
 surfman = { workspace = true }
-webrender = { workspace = true }
 webrender_api = { workspace = true }
 webxr = { workspace = true, optional = true }
 webxr-api = { workspace = true, optional = true }


### PR DESCRIPTION
RustRover flags unused dependencies gray in Cargo.toml, which works well except for macro / derive related crates (false-positives). Based on that I removed the flagged crates (after double checking with grep based search).
There is one weird case in `storage`, where `tokio` was added as a dependency with multiple feature flags enabled, without tokio actually being used. Since the same feature combination is present in `net`, probably this is a remnant of migrating storage from net.

Testing: If CI passes, this is fine. I additionally also searched for references of the packages I removed in the respective crate (I hope I didn't forget any, but should be 90% good).

