### PR TITLE
script: Pass `&mut JSContext` to `Element::create`

### DIFF
--- a/components/script/dom/create.rs
+++ b/components/script/dom/create.rs
@@ -3,6 +3,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 use html5ever::{LocalName, Prefix, QualName, local_name, ns};
+use js::context::JSContext;
 use js::rust::HandleObject;
 
 use crate::dom::bindings::error::{report_pending_exception, throw_dom_exception};
@@ -87,7 +88,7 @@ use crate::dom::html::htmlvideoelement::HTMLVideoElement;
 use crate::dom::svg::svgelement::SVGElement;
 use crate::dom::svg::svgimageelement::SVGImageElement;
 use crate::dom::svg::svgsvgelement::SVGSVGElement;
-use crate::realms::{InRealm, enter_realm};
+use crate::realms::{InRealm, enter_auto_realm};
 use crate::script_runtime::CanGc;
 use crate::script_thread::ScriptThread;
 
@@ -120,6 +121,7 @@ fn create_svg_element(
 /// <https://dom.spec.whatwg.org/#concept-create-element>
 #[expect(clippy::too_many_arguments)]
 fn create_html_element(
+    cx: &mut JSContext,
     name: QualName,
     prefix: Option<Prefix>,
     is: Option<LocalName>,
@@ -127,7 +129,6 @@ fn create_html_element(
     creator: ElementCreator,
     mode: CustomElementCreationMode,
     proto: Option<HandleObject>,
-    can_gc: CanGc,
 ) -> DomRoot<Element> {
     assert_eq!(name.ns, ns!(html));
 
@@ -157,7 +158,7 @@ fn create_html_element(
                 // Step 4.3. If synchronousCustomElements is true, then run this step while catching any exceptions:
                 CustomElementCreationMode::Synchronous => {
                     // Step 4.3.1. Upgrade result using definition.
-                    upgrade_element(definition, &element, can_gc);
+                    upgrade_element(definition, &element, CanGc::from_cx(cx));
                     // TODO: "If this step threw an exception exception:" steps.
                 },
                 // Step 4.4. Otherwise, enqueue a custom element upgrade reaction given result and definition.
@@ -179,7 +180,7 @@ fn create_html_element(
                         document,
                         prefix.clone(),
                         registry.clone(),
-                        can_gc,
+                        CanGc::from_cx(cx),
                     ) {
                         Ok(element) => {
                             element.set_custom_element_definition(definition.clone());
@@ -189,19 +190,26 @@ fn create_html_element(
                             // If any of these steps threw an exception exception:
                             let global =
                                 GlobalScope::current().unwrap_or_else(|| document.global());
-                            let cx = GlobalScope::get_cx();
+
+                            let mut realm = enter_auto_realm(cx, &*global);
+                            let cx = &mut realm.current_realm();
+
+                            let in_realm_proof = cx.into();
+                            let in_realm = InRealm::Already(&in_realm_proof);
 
                             // Substep 1. Report exception for definition’s constructor’s corresponding
                             // JavaScript object’s associated realm’s global object.
-
-                            let ar = enter_realm(&*global);
-                            throw_dom_exception(cx, &global, error, can_gc);
-                            report_pending_exception(cx, InRealm::Entered(&ar), can_gc);
+                            throw_dom_exception(cx.into(), &global, error, CanGc::from_cx(cx));
+                            report_pending_exception(cx.into(), in_realm, CanGc::from_cx(cx));
 
                             // Substep 2. Set result to the result of creating an element internal given document,
                             // HTMLUnknownElement, localName, the HTML namespace, prefix, "failed", null, and registry.
                             let element = DomRoot::upcast::<Element>(HTMLUnknownElement::new(
-                                local_name, prefix, document, proto, can_gc,
+                                local_name,
+                                prefix,
+                                document,
+                                proto,
+                                CanGc::from_cx(cx),
                             ));
                             element.set_custom_element_state(CustomElementState::Failed);
                             element.set_custom_element_registry(registry);
@@ -217,7 +225,11 @@ fn create_html_element(
                     // custom element definition set to null, is value set to null, and node document
                     // set to document.
                     let result = DomRoot::upcast::<Element>(HTMLElement::new(
-                        name.local, prefix, document, proto, can_gc,
+                        name.local,
+                        prefix,
+                        document,
+                        proto,
+                        CanGc::from_cx(cx),
                     ));
                     result.set_custom_element_state(CustomElementState::Undefined);
                     result.set_custom_element_registry(registry);
@@ -435,18 +447,25 @@ pub(crate) fn create_native_html_element(
 }
 
 pub(crate) fn create_element(
+    cx: &mut JSContext,
     name: QualName,
     is: Option<LocalName>,
     document: &Document,
     creator: ElementCreator,
     mode: CustomElementCreationMode,
     proto: Option<HandleObject>,
-    can_gc: CanGc,
 ) -> DomRoot<Element> {
     let prefix = name.prefix.clone();
     match name.ns {
-        ns!(html) => create_html_element(name, prefix, is, document, creator, mode, proto, can_gc),
+        ns!(html) => create_html_element(cx, name, prefix, is, document, creator, mode, proto),
         ns!(svg) => create_svg_element(name, prefix, document, proto),
-        _ => Element::new(name.local, name.ns, prefix, document, proto, can_gc),
+        _ => Element::new(
+            name.local,
+            name.ns,
+            prefix,
+            document,
+            proto,
+            CanGc::from_cx(cx),
+        ),
     }
 }

--- a/components/script/dom/document.rs
+++ b/components/script/dom/document.rs
@@ -5518,13 +5518,13 @@ impl DocumentMethods<crate::DomTypeHolder> for Document {
             },
         };
         Ok(Element::create(
+            cx,
             name,
             is,
             self,
             ElementCreator::ScriptCreated,
             CustomElementCreationMode::Synchronous,
             None,
-            CanGc::from_cx(cx),
         ))
     }
 
@@ -5554,13 +5554,13 @@ impl DocumentMethods<crate::DomTypeHolder> for Document {
 
         // Step 4. Return the result of creating an element given document, localName, namespace, prefix, is, and true.
         Ok(Element::create(
+            cx,
             name,
             is,
             self,
             ElementCreator::ScriptCreated,
             CustomElementCreationMode::Synchronous,
             None,
-            CanGc::from_cx(cx),
         ))
     }
 
@@ -5848,13 +5848,13 @@ impl DocumentMethods<crate::DomTypeHolder> for Document {
                 None => {
                     let name = QualName::new(None, ns!(svg), local_name!("title"));
                     let elem = Element::create(
+                        cx,
                         name,
                         None,
                         self,
                         ElementCreator::ScriptCreated,
                         CustomElementCreationMode::Synchronous,
                         None,
-                        CanGc::from_cx(cx),
                     );
                     let parent = root.upcast::<Node>();
                     let child = elem.upcast::<Node>();
@@ -5874,13 +5874,13 @@ impl DocumentMethods<crate::DomTypeHolder> for Document {
                     Some(head) => {
                         let name = QualName::new(None, ns!(html), local_name!("title"));
                         let elem = Element::create(
+                            cx,
                             name,
                             None,
                             self,
                             ElementCreator::ScriptCreated,
                             CustomElementCreationMode::Synchronous,
                             None,
-                            CanGc::from_cx(cx),
                         );
                         head.upcast::<Node>()
                             .AppendChild(cx, elem.upcast())

--- a/components/script/dom/domimplementation.rs
+++ b/components/script/dom/domimplementation.rs
@@ -213,13 +213,13 @@ impl DOMImplementationMethods<crate::DomTypeHolder> for DOMImplementation {
             // and the HTML namespace, to doc.
             let doc_node = doc.upcast::<Node>();
             let doc_html = DomRoot::upcast::<Node>(Element::create(
+                cx,
                 QualName::new(None, ns!(html), local_name!("html")),
                 None,
                 &doc,
                 ElementCreator::ScriptCreated,
                 CustomElementCreationMode::Asynchronous,
                 None,
-                CanGc::from_cx(cx),
             ));
             doc_node
                 .AppendChild(cx, &doc_html)
@@ -229,13 +229,13 @@ impl DOMImplementationMethods<crate::DomTypeHolder> for DOMImplementation {
                 // Step 5. Append the result of creating an element given doc, "head",
                 // and the HTML namespace, to the html element created earlier.
                 let doc_head = DomRoot::upcast::<Node>(Element::create(
+                    cx,
                     QualName::new(None, ns!(html), local_name!("head")),
                     None,
                     &doc,
                     ElementCreator::ScriptCreated,
                     CustomElementCreationMode::Asynchronous,
                     None,
-                    CanGc::from_cx(cx),
                 ));
                 doc_html.AppendChild(cx, &doc_head).unwrap();
 
@@ -244,13 +244,13 @@ impl DOMImplementationMethods<crate::DomTypeHolder> for DOMImplementation {
                     // Step 6.1. Append the result of creating an element given doc, "title",
                     // and the HTML namespace, to the head element created earlier.
                     let doc_title = DomRoot::upcast::<Node>(Element::create(
+                        cx,
                         QualName::new(None, ns!(html), local_name!("title")),
                         None,
                         &doc,
                         ElementCreator::ScriptCreated,
                         CustomElementCreationMode::Asynchronous,
                         None,
-                        CanGc::from_cx(cx),
                     ));
                     doc_head.AppendChild(cx, &doc_title).unwrap();
 
@@ -264,13 +264,13 @@ impl DOMImplementationMethods<crate::DomTypeHolder> for DOMImplementation {
             // Step 7. Append the result of creating an element given doc, "body",
             // and the HTML namespace, to the html element created earlier.
             let doc_body = Element::create(
+                cx,
                 QualName::new(None, ns!(html), local_name!("body")),
                 None,
                 &doc,
                 ElementCreator::ScriptCreated,
                 CustomElementCreationMode::Asynchronous,
                 None,
-                CanGc::from_cx(cx),
             );
             doc_html.AppendChild(cx, doc_body.upcast()).unwrap();
         }

--- a/components/script/dom/element.rs
+++ b/components/script/dom/element.rs
@@ -280,15 +280,15 @@ impl FromStr for AdjacentPosition {
 //
 impl Element {
     pub(crate) fn create(
+        cx: &mut JSContext,
         name: QualName,
         is: Option<LocalName>,
         document: &Document,
         creator: ElementCreator,
         mode: CustomElementCreationMode,
         proto: Option<HandleObject>,
-        can_gc: CanGc,
     ) -> DomRoot<Element> {
-        create_element(name, is, document, creator, mode, proto, can_gc)
+        create_element(cx, name, is, document, creator, mode, proto)
     }
 
     pub(crate) fn new_inherited(
@@ -2884,13 +2884,13 @@ impl Element {
             // set context to the result of creating an element
             // given this's node document, "body", and the HTML namespace.
             _ => Element::create(
+                cx,
                 QualName::new(None, ns!(html), local_name!("body")),
                 None,
                 owner_doc,
                 ElementCreator::ScriptCreated,
                 CustomElementCreationMode::Asynchronous,
-                None,
-                CanGc::from_cx(cx),
+                None
             ),
         }
     }
@@ -3853,13 +3853,13 @@ impl ElementMethods<crate::DomTypeHolder> for Element {
             // creating an element given this's node document, "body", and the HTML namespace.
             NodeTypeId::DocumentFragment(_) => {
                 let body_elem = Element::create(
+                    cx,
                     QualName::new(None, ns!(html), local_name!("body")),
                     None,
                     &context_document,
                     ElementCreator::ScriptCreated,
                     CustomElementCreationMode::Synchronous,
                     None,
-                    CanGc::from_cx(cx),
                 );
                 DomRoot::upcast(body_elem)
             },

--- a/components/script/dom/html/htmlaudioelement.rs
+++ b/components/script/dom/html/htmlaudioelement.rs
@@ -68,13 +68,13 @@ impl HTMLAudioElementMethods<crate::DomTypeHolder> for HTMLAudioElement {
         // Step 2. Let audio be the result of creating an element given document, "audio", and the
         // HTML namespace.
         let audio = Element::create(
+            cx,
             QualName::new(None, ns!(html), local_name!("audio")),
             None,
             &document,
             ElementCreator::ScriptCreated,
             CustomElementCreationMode::Synchronous,
             proto,
-            CanGc::from_cx(cx),
         );
 
         // Step 3. Set an attribute value for audio using "preload" and "auto".

--- a/components/script/dom/html/htmldetailselement.rs
+++ b/components/script/dom/html/htmldetailselement.rs
@@ -180,13 +180,13 @@ impl HTMLDetailsElement {
         let root = self.upcast::<Element>().attach_ua_shadow_root(cx, true);
 
         let summary = Element::create(
+            cx,
             QualName::new(None, ns!(html), local_name!("slot")),
             None,
             &document,
             ElementCreator::ScriptCreated,
             CustomElementCreationMode::Asynchronous,
             None,
-            CanGc::from_cx(cx),
         );
         let summary = DomRoot::downcast::<HTMLSlotElement>(summary).unwrap();
         root.upcast::<Node>()
@@ -194,13 +194,13 @@ impl HTMLDetailsElement {
             .unwrap();
 
         let fallback_summary = Element::create(
+            cx,
             QualName::new(None, ns!(html), local_name!("summary")),
             None,
             &document,
             ElementCreator::ScriptCreated,
             CustomElementCreationMode::Asynchronous,
             None,
-            CanGc::from_cx(cx),
         );
         let fallback_summary = DomRoot::downcast::<HTMLElement>(fallback_summary).unwrap();
         fallback_summary
@@ -212,13 +212,13 @@ impl HTMLDetailsElement {
             .unwrap();
 
         let details_content = Element::create(
+            cx,
             QualName::new(None, ns!(html), local_name!("slot")),
             None,
             &document,
             ElementCreator::ScriptCreated,
             CustomElementCreationMode::Asynchronous,
             None,
-            CanGc::from_cx(cx),
         );
         let details_content = DomRoot::downcast::<HTMLSlotElement>(details_content).unwrap();
 

--- a/components/script/dom/html/htmlelement.rs
+++ b/components/script/dom/html/htmlelement.rs
@@ -1058,13 +1058,13 @@ impl HTMLElement {
                     }
 
                     let br = Element::create(
+                        cx,
                         QualName::new(None, ns!(html), local_name!("br")),
                         None,
                         &document,
                         ElementCreator::ScriptCreated,
                         CustomElementCreationMode::Asynchronous,
                         None,
-                        CanGc::from_cx(cx),
                     );
                     fragment
                         .upcast::<Node>()

--- a/components/script/dom/html/htmlimageelement.rs
+++ b/components/script/dom/html/htmlimageelement.rs
@@ -1761,13 +1761,13 @@ impl HTMLImageElementMethods<crate::DomTypeHolder> for HTMLImageElement {
         // Step 2. Let img be the result of creating an element given document, "img", and the HTML
         // namespace.
         let element = Element::create(
+            cx,
             QualName::new(None, ns!(html), local_name!("img")),
             None,
             &document,
             ElementCreator::ScriptCreated,
             CustomElementCreationMode::Synchronous,
             proto,
-            CanGc::from_cx(cx),
         );
 
         let image = DomRoot::downcast::<HTMLImageElement>(element).unwrap();

--- a/components/script/dom/html/htmlinputelement.rs
+++ b/components/script/dom/html/htmlinputelement.rs
@@ -162,13 +162,13 @@ impl TextInputWidgetShadowTree {
     fn new(cx: &mut JSContext, shadow_root: &Node) -> Self {
         let document = shadow_root.owner_document();
         let inner_container = Element::create(
+            cx,
             QualName::new(None, ns!(html), local_name!("div")),
             None,
             &document,
             ElementCreator::ScriptCreated,
             CustomElementCreationMode::Asynchronous,
             None,
-            CanGc::from_cx(cx),
         );
 
         Node::replace_all(cx, Some(inner_container.upcast()), shadow_root.upcast());
@@ -293,13 +293,13 @@ struct ColorInputShadowTree {
 impl ColorInputShadowTree {
     fn new(cx: &mut JSContext, shadow_root: &Node) -> Self {
         let color_value = Element::create(
+            cx,
             QualName::new(None, ns!(html), local_name!("div")),
             None,
             &shadow_root.owner_document(),
             ElementCreator::ScriptCreated,
             CustomElementCreationMode::Asynchronous,
             None,
-            CanGc::from_cx(cx),
         );
 
         Node::replace_all(cx, Some(color_value.upcast()), shadow_root.upcast());
@@ -389,13 +389,13 @@ fn create_ua_widget_div_with_text_node(
     as_first_child: bool,
 ) -> DomRoot<Element> {
     let el = Element::create(
+        cx,
         QualName::new(None, ns!(html), local_name!("div")),
         None,
         document,
         ElementCreator::ScriptCreated,
         CustomElementCreationMode::Asynchronous,
         None,
-        CanGc::from_cx(cx),
     );
 
     parent

--- a/components/script/dom/html/htmlmediaelement.rs
+++ b/components/script/dom/html/htmlmediaelement.rs
@@ -2813,13 +2813,13 @@ impl HTMLMediaElement {
         let shadow_root = self.upcast::<Element>().attach_ua_shadow_root(cx, false);
         let document = self.owner_document();
         let script = Element::create(
+            cx,
             QualName::new(None, ns!(html), local_name!("script")),
             None,
             &document,
             ElementCreator::ScriptCreated,
             CustomElementCreationMode::Asynchronous,
             None,
-            CanGc::from_cx(cx),
         );
         // This is our hacky way to temporarily workaround the lack of a privileged
         // JS context.
@@ -2842,13 +2842,13 @@ impl HTMLMediaElement {
         }
 
         let style = Element::create(
+            cx,
             QualName::new(None, ns!(html), local_name!("style")),
             None,
             &document,
             ElementCreator::ScriptCreated,
             CustomElementCreationMode::Asynchronous,
             None,
-            CanGc::from_cx(cx),
         );
 
         style

--- a/components/script/dom/html/htmlmeterelement.rs
+++ b/components/script/dom/html/htmlmeterelement.rs
@@ -77,13 +77,13 @@ impl HTMLMeterElement {
         let root = self.upcast::<Element>().attach_ua_shadow_root(cx, true);
 
         let meter_value = Element::create(
+            cx,
             QualName::new(None, ns!(html), local_name!("div")),
             None,
             &document,
             crate::dom::element::ElementCreator::ScriptCreated,
             crate::dom::element::CustomElementCreationMode::Asynchronous,
             None,
-            CanGc::from_cx(cx),
         );
         root.upcast::<Node>()
             .AppendChild(cx, meter_value.upcast::<Node>())

--- a/components/script/dom/html/htmloptionelement.rs
+++ b/components/script/dom/html/htmloptionelement.rs
@@ -255,13 +255,13 @@ impl HTMLOptionElementMethods<crate::DomTypeHolder> for HTMLOptionElement {
         selected: bool,
     ) -> Fallible<DomRoot<HTMLOptionElement>> {
         let element = Element::create(
+            cx,
             QualName::new(None, ns!(html), local_name!("option")),
             None,
             &window.Document(),
             ElementCreator::ScriptCreated,
             CustomElementCreationMode::Synchronous,
             proto,
-            CanGc::from_cx(cx),
         );
 
         let option = DomRoot::downcast::<HTMLOptionElement>(element).unwrap();

--- a/components/script/dom/html/htmloptionscollection.rs
+++ b/components/script/dom/html/htmloptionscollection.rs
@@ -63,13 +63,13 @@ impl HTMLOptionsCollection {
 
         for _ in 0..count {
             let element = Element::create(
+                cx,
                 QualName::new(None, ns!(html), local_name!("option")),
                 None,
                 &document,
                 ElementCreator::ScriptCreated,
                 CustomElementCreationMode::Asynchronous,
                 None,
-                CanGc::from_cx(cx),
             );
             let node = element.upcast::<Node>();
             root.AppendChild(cx, node)?;

--- a/components/script/dom/html/htmlprogresselement.rs
+++ b/components/script/dom/html/htmlprogresselement.rs
@@ -75,13 +75,13 @@ impl HTMLProgressElement {
         let root = self.upcast::<Element>().attach_ua_shadow_root(cx, true);
 
         let progress_bar = Element::create(
+            cx,
             QualName::new(None, ns!(html), local_name!("div")),
             None,
             &document,
             ElementCreator::ScriptCreated,
             CustomElementCreationMode::Asynchronous,
             None,
-            CanGc::from_cx(cx),
         );
 
         // FIXME: This should use ::-moz-progress-bar

--- a/components/script/dom/html/htmlselectelement.rs
+++ b/components/script/dom/html/htmlselectelement.rs
@@ -285,13 +285,13 @@ impl HTMLSelectElement {
         let root = self.upcast::<Element>().attach_ua_shadow_root(cx, true);
 
         let select_box = Element::create(
+            cx,
             QualName::new(None, ns!(html), local_name!("div")),
             None,
             &document,
             ElementCreator::ScriptCreated,
             CustomElementCreationMode::Asynchronous,
             None,
-            CanGc::from_cx(cx),
         );
         select_box.set_string_attribute(
             &local_name!("style"),
@@ -300,13 +300,13 @@ impl HTMLSelectElement {
         );
 
         let text_container = Element::create(
+            cx,
             QualName::new(None, ns!(html), local_name!("div")),
             None,
             &document,
             ElementCreator::ScriptCreated,
             CustomElementCreationMode::Asynchronous,
             None,
-            CanGc::from_cx(cx),
         );
         text_container.set_string_attribute(
             &local_name!("style"),
@@ -328,13 +328,13 @@ impl HTMLSelectElement {
             .unwrap();
 
         let chevron_container = Element::create(
+            cx,
             QualName::new(None, ns!(html), local_name!("div")),
             None,
             &document,
             ElementCreator::ScriptCreated,
             CustomElementCreationMode::Asynchronous,
             None,
-            CanGc::from_cx(cx),
         );
         chevron_container.set_string_attribute(
             &local_name!("style"),

--- a/components/script/dom/html/htmltableelement.rs
+++ b/components/script/dom/html/htmltableelement.rs
@@ -153,13 +153,13 @@ impl HTMLTableElement {
         }
 
         let section = Element::create(
+            cx,
             QualName::new(None, ns!(html), atom.clone()),
             None,
             &self.owner_document(),
             ElementCreator::ScriptCreated,
             CustomElementCreationMode::Asynchronous,
             None,
-            CanGc::from_cx(cx),
         );
 
         let section = DomRoot::downcast::<HTMLTableSectionElement>(section).unwrap();
@@ -237,13 +237,13 @@ impl HTMLTableElementMethods<crate::DomTypeHolder> for HTMLTableElement {
             Some(caption) => caption,
             None => {
                 let caption = Element::create(
+                    cx,
                     QualName::new(None, ns!(html), local_name!("caption")),
                     None,
                     &self.owner_document(),
                     ElementCreator::ScriptCreated,
                     CustomElementCreationMode::Asynchronous,
                     None,
-                    CanGc::from_cx(cx),
                 );
                 let caption = DomRoot::downcast::<HTMLTableCaptionElement>(caption).unwrap();
 
@@ -335,13 +335,13 @@ impl HTMLTableElementMethods<crate::DomTypeHolder> for HTMLTableElement {
     /// <https://html.spec.whatwg.org/multipage/#dom-table-createtbody>
     fn CreateTBody(&self, cx: &mut JSContext) -> DomRoot<HTMLTableSectionElement> {
         let tbody = Element::create(
+            cx,
             QualName::new(None, ns!(html), local_name!("tbody")),
             None,
             &self.owner_document(),
             ElementCreator::ScriptCreated,
             CustomElementCreationMode::Asynchronous,
             None,
-            CanGc::from_cx(cx),
         );
         let tbody = DomRoot::downcast::<HTMLTableSectionElement>(tbody).unwrap();
         let node = self.upcast::<Node>();
@@ -366,13 +366,13 @@ impl HTMLTableElementMethods<crate::DomTypeHolder> for HTMLTableElement {
         }
 
         let new_row = Element::create(
+            cx,
             QualName::new(None, ns!(html), local_name!("tr")),
             None,
             &self.owner_document(),
             ElementCreator::ScriptCreated,
             CustomElementCreationMode::Asynchronous,
             None,
-            CanGc::from_cx(cx),
         );
         let new_row = DomRoot::downcast::<HTMLTableRowElement>(new_row).unwrap();
         let node = self.upcast::<Node>();

--- a/components/script/dom/html/htmltablerowelement.rs
+++ b/components/script/dom/html/htmltablerowelement.rs
@@ -110,13 +110,13 @@ impl HTMLTableRowElementMethods<crate::DomTypeHolder> for HTMLTableRowElement {
             || self.Cells(),
             |cx| {
                 let cell = Element::create(
+                    cx,
                     QualName::new(None, ns!(html), local_name!("td")),
                     None,
                     &node.owner_doc(),
                     ElementCreator::ScriptCreated,
                     CustomElementCreationMode::Asynchronous,
                     None,
-                    CanGc::from_cx(cx),
                 );
                 DomRoot::downcast::<HTMLTableCellElement>(cell).unwrap()
             },

--- a/components/script/dom/html/htmltablesectionelement.rs
+++ b/components/script/dom/html/htmltablesectionelement.rs
@@ -87,13 +87,13 @@ impl HTMLTableSectionElementMethods<crate::DomTypeHolder> for HTMLTableSectionEl
             || self.Rows(),
             |cx| {
                 let row = Element::create(
+                    cx,
                     QualName::new(None, ns!(html), local_name!("tr")),
                     None,
                     &node.owner_doc(),
                     ElementCreator::ScriptCreated,
                     CustomElementCreationMode::Asynchronous,
                     None,
-                    CanGc::from_cx(cx),
                 );
                 DomRoot::downcast::<HTMLTableRowElement>(row).unwrap()
             },

--- a/components/script/dom/node.rs
+++ b/components/script/dom/node.rs
@@ -3582,13 +3582,13 @@ impl Node {
                     local: element.local_name().clone(),
                 };
                 let element = Element::create(
+                    cx,
                     name,
                     element.get_is(),
                     &document,
                     ElementCreator::ScriptCreated,
                     CustomElementCreationMode::Asynchronous,
                     None,
-                    CanGc::from_cx(cx),
                 );
                 // TODO: Move this into `Element::create`
                 element.set_custom_element_registry(registry);

--- a/components/script/dom/servoparser/mod.rs
+++ b/components/script/dom/servoparser/mod.rs
@@ -1139,26 +1139,26 @@ impl ParserContext {
         // to the address of the image, video, or audio resource.
         let node = if media_type == MediaType::Image {
             let img = Element::create(
+                cx,
                 QualName::new(None, ns!(html), local_name!("img")),
                 None,
                 doc,
                 ElementCreator::ParserCreated(1),
                 CustomElementCreationMode::Asynchronous,
                 None,
-                CanGc::from_cx(cx),
             );
             let img = DomRoot::downcast::<HTMLImageElement>(img).unwrap();
             img.SetSrc(USVString(self.url.to_string()));
             DomRoot::upcast::<Node>(img)
         } else if mime_type.type_() == mime::AUDIO {
             let audio = Element::create(
+                cx,
                 QualName::new(None, ns!(html), local_name!("audio")),
                 None,
                 doc,
                 ElementCreator::ParserCreated(1),
                 CustomElementCreationMode::Asynchronous,
                 None,
-                CanGc::from_cx(cx),
             );
             let audio = DomRoot::downcast::<HTMLMediaElement>(audio).unwrap();
             audio.SetControls(true);
@@ -1166,13 +1166,13 @@ impl ParserContext {
             DomRoot::upcast::<Node>(audio)
         } else {
             let video = Element::create(
+                cx,
                 QualName::new(None, ns!(html), local_name!("video")),
                 None,
                 doc,
                 ElementCreator::ParserCreated(1),
                 CustomElementCreationMode::Asynchronous,
                 None,
-                CanGc::from_cx(cx),
             );
             let video = DomRoot::downcast::<HTMLMediaElement>(video).unwrap();
             video.SetControls(true);
@@ -1946,15 +1946,7 @@ fn create_element_for_token(
     } else {
         CustomElementCreationMode::Asynchronous
     };
-    let element = Element::create(
-        name,
-        is,
-        document,
-        creator,
-        creation_mode,
-        None,
-        CanGc::from_cx(cx),
-    );
+    let element = Element::create(cx, name, is, document, creator, creation_mode, None);
 
     // Step 11. Append each attribute in the given token to element.
     for attr in attrs {


### PR DESCRIPTION
Pass `&mut JSContext` to `Element::create` and `create_html_element`

Testing: No functionality changes, covered by existing tests.
Part of #40600 
