### PR TITLE
paint: Remove the scroll event averaging workaround

### DIFF
--- a/components/paint/touch.rs
+++ b/components/paint/touch.rs
@@ -475,7 +475,6 @@ impl TouchHandler {
                     Some(ScrollZoomEvent::Scroll(ScrollEvent {
                         scroll: Scroll::Delta((-delta).into()),
                         point,
-                        event_count: 1,
                     }))
                 } else if delta.x.abs() > TOUCH_PAN_MIN_SCREEN_PX * scale ||
                     delta.y.abs() > TOUCH_PAN_MIN_SCREEN_PX * scale
@@ -497,7 +496,6 @@ impl TouchHandler {
                     Some(ScrollZoomEvent::Scroll(ScrollEvent {
                         scroll: Scroll::Delta((-delta).into()),
                         point,
-                        event_count: 1,
                     }))
                 } else {
                     // We don't update the touchpoint, so multiple small moves can

--- a/components/paint/webview_renderer.rs
+++ b/components/paint/webview_renderer.rs
@@ -44,8 +44,6 @@ pub(crate) struct ScrollEvent {
     pub scroll: Scroll,
     /// Scroll the scroll node that is found at this point.
     pub point: DevicePoint,
-    /// The number of OS events that have been coalesced together into this one event.
-    pub event_count: u32,
 }
 
 #[derive(Clone, Copy)]
@@ -729,7 +727,6 @@ impl WebViewRenderer {
             .push(ScrollZoomEvent::Scroll(ScrollEvent {
                 scroll,
                 point: cursor,
-                event_count: 1,
             }));
     }
 
@@ -769,19 +766,11 @@ impl WebViewRenderer {
 
                     match (combined_event.scroll, scroll_event_info.scroll) {
                         (Scroll::Delta(old_delta), Scroll::Delta(new_delta)) => {
-                            // Mac OS X sometimes delivers scroll events out of vsync during a
-                            // fling. This causes events to get bunched up occasionally, causing
-                            // nasty-looking "pops". To mitigate this, during a fling we average
-                            // deltas instead of summing them.
-                            let old_event_count = combined_event.event_count as f32;
-                            combined_event.event_count += 1;
-                            let new_event_count = combined_event.event_count as f32;
                             let old_delta =
                                 old_delta.as_device_vector(device_pixels_per_page_pixel);
                             let new_delta =
                                 new_delta.as_device_vector(device_pixels_per_page_pixel);
-                            let delta = (old_delta * old_event_count + new_delta) / new_event_count;
-                            combined_event.scroll = Scroll::Delta(delta.into());
+                            combined_event.scroll = Scroll::Delta((old_delta + new_delta).into());
                         },
                         (Scroll::Start, _) | (Scroll::End, _) => {
                             // Once we see Start or End, we shouldn't process any more events.


### PR DESCRIPTION
This workaround was added in 2016
(90e970a6d2c0f3eebbff23edd2aa74f3a201e6d8) when the architecture of
Servo, macOS, and Apple hardware was very different. It has been
highlighted as causing issues on Linux machines (#42065). I've confirmed
that removing it does not seem degrade behavior when scrolling with a
Macbook touchpad. I think we should just remove it for now as it seems
like a workaround rather than a real fix for the original problem.

Testing: There isn't a very good way to test this unfortunately.
Closes #42065.
