### PR TITLE
config: add a preference to allow fetching modulepreload descendants

### DIFF
--- a/components/config/prefs.rs
+++ b/components/config/prefs.rs
@@ -96,6 +96,7 @@ pub struct Preferences {
     pub dom_abort_controller_enabled: bool,
     // feature: Adopted Stylesheet | #38132 | Web/API/Document/adoptedStyleSheets
     pub dom_adoptedstylesheet_enabled: bool,
+    pub dom_allow_preloading_module_descendants: bool,
     // feature: Clipboard API | #36084 | Web/API/Clipboard_API
     pub dom_async_clipboard_enabled: bool,
     pub dom_bluetooth_enabled: bool,
@@ -332,6 +333,7 @@ impl Preferences {
             devtools_server_listen_address: String::new(),
             dom_abort_controller_enabled: true,
             dom_adoptedstylesheet_enabled: false,
+            dom_allow_preloading_module_descendants: false,
             dom_allow_scripts_to_close_windows: false,
             dom_async_clipboard_enabled: false,
             dom_bluetooth_enabled: false,

--- a/components/script/script_module.rs
+++ b/components/script/script_module.rs
@@ -1329,10 +1329,10 @@ pub(crate) fn fetch_a_modulepreload_module(
 
             // Step 3. If result is not null, optionally fetch the descendants of and link result
             // given settingsObject, destination, and an empty algorithm.
-            if let Some(module) = result &&
-                pref!(dom_allow_preloading_module_descendants)
-            {
-                fetch_the_descendants_and_link_module_script(module, destination, owner, None);
+            if pref!(dom_allow_preloading_module_descendants) {
+                if let Some(module) = result {
+                    fetch_the_descendants_and_link_module_script(module, destination, owner, None);
+                }
             }
         },
     );

--- a/components/script/script_module.rs
+++ b/components/script/script_module.rs
@@ -56,6 +56,7 @@ use script_bindings::error::Fallible;
 use script_bindings::settings_stack::run_a_callback;
 use script_bindings::trace::CustomTraceable;
 use serde_json::{Map as JsonMap, Value as JsonValue};
+use servo_config::pref;
 use servo_url::ServoUrl;
 
 use crate::DomTypeHolder;
@@ -1328,7 +1329,9 @@ pub(crate) fn fetch_a_modulepreload_module(
 
             // Step 3. If result is not null, optionally fetch the descendants of and link result
             // given settingsObject, destination, and an empty algorithm.
-            if let Some(module) = result {
+            if let Some(module) = result &&
+                pref!(dom_allow_preloading_module_descendants)
+            {
                 fetch_the_descendants_and_link_module_script(module, destination, owner, None);
             }
         },


### PR DESCRIPTION
As suggested [here](https://github.com/servo/servo/pull/42964#issuecomment-4073998452), adds a preference to enable fetching modulepreload descendants, turned off by default.

Testing: A successful build is enough.
