### PR TITLE
devtools: Implement `object` and `function` property preview

### DIFF
--- a/components/devtools/actors/console.rs
+++ b/components/devtools/actors/console.rs
@@ -27,7 +27,7 @@ use uuid::Uuid;
 
 use crate::actor::{Actor, ActorError, ActorRegistry};
 use crate::actors::browsing_context::BrowsingContextActor;
-use crate::actors::object::ObjectActor;
+use crate::actors::object::{ObjectActor, PropertyDescriptor};
 use crate::actors::worker::WorkerActor;
 use crate::protocol::{ClientRequest, JsonPacketStream};
 use crate::resource::{ResourceArrayType, ResourceAvailable};
@@ -74,14 +74,6 @@ fn console_argument_to_value(argument: ConsoleArgument, registry: &ActorRegistry
             // These are currently never cleaned up, and we make no attempt at re-using the same actor
             // if the same object is logged repeatedly.
             let actor = ObjectActor::register(registry, None, object.class.clone());
-
-            #[derive(Serialize)]
-            struct PropertyDescriptor {
-                configurable: bool,
-                enumerable: bool,
-                writable: bool,
-                value: Value,
-            }
 
             #[derive(Serialize)]
             #[serde(rename_all = "camelCase")]
@@ -378,9 +370,26 @@ impl ConsoleActor {
                 }
             },
             StringValue(s) => Value::String(s),
-            ActorValue { class, uuid, name } => {
+            ActorValue {
+                class,
+                uuid,
+                name,
+                display_name,
+                parameter_names,
+                is_async,
+                is_generator,
+                own_properties,
+                own_properties_length,
+            } => {
+                let properties = own_properties.clone().unwrap_or_default();
+
                 let mut m = Map::new();
-                let actor = ObjectActor::register(registry, Some(uuid), class.clone());
+                let actor = ObjectActor::register_with_properties(
+                    registry,
+                    Some(uuid),
+                    class.clone(),
+                    properties,
+                );
 
                 m.insert("type".to_owned(), Value::String("object".to_owned()));
                 m.insert("class".to_owned(), Value::String(class));
@@ -391,6 +400,49 @@ impl ConsoleActor {
                 if let Some(name) = name {
                     m.insert("name".to_owned(), Value::String(name));
                 }
+
+                // Function-specific metadata
+                if let Some(display_name) = display_name {
+                    m.insert("displayName".to_owned(), Value::String(display_name));
+                }
+                if let Some(param_names) = parameter_names {
+                    m.insert(
+                        "parameterNames".to_owned(),
+                        Value::Array(param_names.into_iter().map(Value::String).collect()),
+                    );
+                }
+                if let Some(is_async) = is_async {
+                    m.insert("isAsync".to_owned(), Value::Bool(is_async));
+                }
+                if let Some(is_generator) = is_generator {
+                    m.insert("isGenerator".to_owned(), Value::Bool(is_generator));
+                }
+
+                // Build preview with ownProperties
+                // <https://searchfox.org/firefox-main/source/devtools/server/actors/object/previewers.js#849>
+                let mut preview = Map::new();
+                preview.insert("kind".to_owned(), Value::String("Object".to_owned()));
+
+                if let Some(ref props) = own_properties {
+                    let mut own_props_map = Map::new();
+                    for prop in props {
+                        let descriptor =
+                            serde_json::to_value(PropertyDescriptor::from(prop)).unwrap();
+                        own_props_map.insert(prop.name.clone(), descriptor);
+                    }
+                    preview.insert("ownProperties".to_owned(), Value::Object(own_props_map));
+                }
+
+                if let Some(length) = own_properties_length {
+                    preview.insert(
+                        "ownPropertiesLength".to_owned(),
+                        Value::Number(length.into()),
+                    );
+                    m.insert("ownPropertyLength".to_owned(), Value::Number(length.into()));
+                }
+
+                m.insert("preview".to_owned(), Value::Object(preview));
+
                 Value::Object(m)
             },
         };

--- a/components/devtools/actors/console.rs
+++ b/components/devtools/actors/console.rs
@@ -382,7 +382,7 @@ impl ConsoleActor {
                 own_properties_length,
             } => {
                 let properties = own_properties.clone().unwrap_or_default();
-
+                // TODO: Replace this with a struct to avoid having the Map.
                 let mut m = Map::new();
                 let actor = ObjectActor::register_with_properties(
                     registry,

--- a/components/devtools/actors/object.rs
+++ b/components/devtools/actors/object.rs
@@ -2,12 +2,14 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
+use devtools_traits::PropertyPreview;
 use malloc_size_of_derive::MallocSizeOf;
 use serde::Serialize;
-use serde_json::{Map, Value};
+use serde_json::{Map, Number, Value};
 
 use crate::StreamId;
 use crate::actor::{Actor, ActorEncode, ActorError, ActorRegistry};
+use crate::actors::property_iterator::PropertyIteratorActor;
 use crate::protocol::ClientRequest;
 
 #[derive(Serialize)]
@@ -58,11 +60,76 @@ pub(crate) struct ObjectActorMsg {
     preview: ObjectPreview,
 }
 
+#[derive(Serialize)]
+pub(crate) struct PropertyDescriptor {
+    pub configurable: bool,
+    pub enumerable: bool,
+    pub writable: bool,
+    pub value: Value,
+}
+
+impl From<&PropertyPreview> for PropertyDescriptor {
+    fn from(prop: &PropertyPreview) -> Self {
+        Self {
+            configurable: prop.configurable,
+            enumerable: prop.enumerable,
+            writable: prop.writable,
+            value: property_value_to_json(prop),
+        }
+    }
+}
+
+/// <https://searchfox.org/mozilla-central/source/devtools/server/actors/object/utils.js#148>
+fn property_value_to_json(prop: &PropertyPreview) -> Value {
+    match prop.value_type.as_str() {
+        "undefined" => {
+            let mut v = Map::new();
+            v.insert("type".to_owned(), Value::String("undefined".to_owned()));
+            Value::Object(v)
+        },
+        "null" => Value::Null,
+        "boolean" => Value::Bool(prop.boolean_value.unwrap_or(false)),
+        "number" => {
+            let num = prop.number_value.unwrap_or(0.0);
+            if num.is_nan() {
+                let mut v = Map::new();
+                v.insert("type".to_owned(), Value::String("NaN".to_owned()));
+                Value::Object(v)
+            } else if num.is_infinite() {
+                let mut v = Map::new();
+                let type_str = if num.is_sign_positive() {
+                    "Infinity"
+                } else {
+                    "-Infinity"
+                };
+                v.insert("type".to_owned(), Value::String(type_str.to_owned()));
+                Value::Object(v)
+            } else {
+                Value::Number(Number::from_f64(num).unwrap_or(Number::from(0)))
+            }
+        },
+        "string" => Value::String(prop.string_value.clone().unwrap_or_default()),
+        "object" => {
+            let mut v = Map::new();
+            v.insert("type".to_owned(), Value::String("object".to_owned()));
+            if let Some(ref obj_class) = prop.object_class {
+                v.insert("class".to_owned(), Value::String(obj_class.clone()));
+            }
+            if let Some(ref obj_name) = prop.value_name {
+                v.insert("name".to_owned(), Value::String(obj_name.clone()));
+            }
+            Value::Object(v)
+        },
+        _ => Value::Null,
+    }
+}
+
 #[derive(MallocSizeOf)]
 pub(crate) struct ObjectActor {
     name: String,
     _uuid: Option<String>,
     class: String,
+    properties: Vec<PropertyPreview>,
 }
 
 impl Actor for ObjectActor {
@@ -81,15 +148,18 @@ impl Actor for ObjectActor {
     ) -> Result<(), ActorError> {
         match msg_type {
             "enumProperties" => {
-                let property_iterator = PropertyIteratorActor {
-                    name: registry.new_name::<PropertyIteratorActor>(),
-                };
+                let property_iterator = PropertyIteratorActor::new(
+                    registry.new_name::<PropertyIteratorActor>(),
+                    self.properties.clone(),
+                );
+                let count = property_iterator.count();
+                let actor_name = property_iterator.name();
                 let msg = EnumReply {
                     from: self.name(),
                     iterator: EnumIterator {
-                        actor: property_iterator.name(),
+                        actor: actor_name,
                         type_: EnumIteratorType::PropertyIterator,
-                        count: 0,
+                        count,
                     },
                 };
                 registry.register(property_iterator);
@@ -128,12 +198,22 @@ impl Actor for ObjectActor {
 
 impl ObjectActor {
     pub fn register(registry: &ActorRegistry, uuid: Option<String>, class: String) -> String {
+        Self::register_with_properties(registry, uuid, class, Vec::new())
+    }
+
+    pub fn register_with_properties(
+        registry: &ActorRegistry,
+        uuid: Option<String>,
+        class: String,
+        properties: Vec<PropertyPreview>,
+    ) -> String {
         let Some(uuid) = uuid else {
             let name = registry.new_name::<Self>();
             let actor = ObjectActor {
                 name: name.clone(),
                 _uuid: None,
                 class,
+                properties,
             };
             registry.register(actor);
             return name;
@@ -144,6 +224,7 @@ impl ObjectActor {
                 name: name.clone(),
                 _uuid: Some(uuid.clone()),
                 class,
+                properties,
             };
 
             registry.register_script_actor(uuid, name.clone());
@@ -162,7 +243,7 @@ impl ActorEncode<ObjectActorMsg> for ObjectActor {
             actor: self.name(),
             type_: "object".into(),
             class: self.class.clone(),
-            own_property_length: 0,
+            own_property_length: self.properties.len() as i32,
             extensible: true,
             frozen: false,
             sealed: false,
@@ -172,18 +253,6 @@ impl ActorEncode<ObjectActorMsg> for ObjectActor {
                 url: "".into(), // TODO: Use the correct url
             },
         }
-    }
-}
-
-// TODO: Implement functionality of property and symbol iterators
-#[derive(MallocSizeOf)]
-struct PropertyIteratorActor {
-    name: String,
-}
-
-impl Actor for PropertyIteratorActor {
-    fn name(&self) -> String {
-        self.name.clone()
     }
 }
 

--- a/components/devtools/actors/object.rs
+++ b/components/devtools/actors/object.rs
@@ -148,21 +148,20 @@ impl Actor for ObjectActor {
     ) -> Result<(), ActorError> {
         match msg_type {
             "enumProperties" => {
-                let property_iterator = PropertyIteratorActor::new(
-                    registry.new_name::<PropertyIteratorActor>(),
-                    self.properties.clone(),
-                );
+                let property_iterator_name =
+                    PropertyIteratorActor::register(registry, self.properties.clone());
+                let property_iterator =
+                    registry.find::<PropertyIteratorActor>(&property_iterator_name);
                 let count = property_iterator.count();
-                let actor_name = property_iterator.name();
                 let msg = EnumReply {
                     from: self.name(),
                     iterator: EnumIterator {
-                        actor: actor_name,
+                        actor: property_iterator_name,
                         type_: EnumIteratorType::PropertyIterator,
                         count,
                     },
                 };
-                registry.register(property_iterator);
+
                 request.reply_final(&msg)?
             },
 

--- a/components/devtools/actors/property_iterator.rs
+++ b/components/devtools/actors/property_iterator.rs
@@ -2,38 +2,41 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-// TODO: Remove once the actor is used
-#![allow(dead_code)]
-
 use std::collections::HashMap;
 
+use devtools_traits::PropertyPreview;
 use malloc_size_of_derive::MallocSizeOf;
 use serde::Serialize;
 use serde_json::{Map, Value};
 
 use crate::StreamId;
 use crate::actor::{Actor, ActorError, ActorRegistry};
+use crate::actors::object::PropertyDescriptor;
 use crate::protocol::ClientRequest;
 
 #[derive(Serialize)]
 #[serde(rename_all = "camelCase")]
 struct SliceReply {
     from: String,
-    own_properties: HashMap<String, Value>,
+    own_properties: HashMap<String, PropertyDescriptor>,
 }
 
 #[derive(MallocSizeOf)]
-pub struct PropertyIteratorActor {
+pub(crate) struct PropertyIteratorActor {
     name: String,
+    properties: Vec<PropertyPreview>,
 }
 
 impl PropertyIteratorActor {
-    pub fn new(name: String) -> Self {
-        Self { name }
+    pub fn new(name: String, properties: Vec<PropertyPreview>) -> Self {
+        Self { name, properties }
+    }
+
+    pub fn count(&self) -> u32 {
+        self.properties.len() as u32
     }
 }
 
-// <https://searchfox.org/firefox-main/source/devtools/server/actors/object/property-iterator.js>
 impl Actor for PropertyIteratorActor {
     fn name(&self) -> String {
         self.name.clone()
@@ -44,15 +47,25 @@ impl Actor for PropertyIteratorActor {
         request: ClientRequest,
         _registry: &ActorRegistry,
         msg_type: &str,
-        _msg: &Map<String, Value>,
+        msg: &Map<String, Value>,
         _id: StreamId,
     ) -> Result<(), ActorError> {
         match msg_type {
             "slice" => {
-                // TODO: Return actual properties based on start/count from msg
+                let start = msg.get("start").and_then(|v| v.as_u64()).unwrap_or(0) as usize;
+                let count = msg
+                    .get("count")
+                    .and_then(|v| v.as_u64())
+                    .unwrap_or(self.properties.len() as u64) as usize;
+
+                let mut own_properties = HashMap::new();
+                for prop in self.properties.iter().skip(start).take(count) {
+                    own_properties.insert(prop.name.clone(), PropertyDescriptor::from(prop));
+                }
+
                 let reply = SliceReply {
                     from: self.name(),
-                    own_properties: HashMap::new(),
+                    own_properties,
                 };
                 request.reply_final(&reply)?
             },

--- a/components/devtools/actors/property_iterator.rs
+++ b/components/devtools/actors/property_iterator.rs
@@ -28,8 +28,14 @@ pub(crate) struct PropertyIteratorActor {
 }
 
 impl PropertyIteratorActor {
-    pub fn new(name: String, properties: Vec<PropertyPreview>) -> Self {
-        Self { name, properties }
+    pub fn register(registry: &ActorRegistry, properties: Vec<PropertyPreview>) -> String {
+        let name = registry.new_name::<Self>();
+        let actor = Self {
+            name: name.clone(),
+            properties,
+        };
+        registry.register::<Self>(actor);
+        name
     }
 
     pub fn count(&self) -> u32 {

--- a/components/script/dom/debugger/debuggerglobalscope.rs
+++ b/components/script/dom/debugger/debuggerglobalscope.rs
@@ -507,10 +507,66 @@ impl DebuggerGlobalScopeMethods<crate::DomTypeHolder> for DebuggerGlobalScope {
                     .as_ref()
                     .and_then(|opt| opt.as_ref())
                     .map(|s| s.to_string());
+
+                // Function-specific metadata
+                let display_name = result
+                    .displayName
+                    .as_ref()
+                    .and_then(|opt| opt.as_ref())
+                    .map(|s| s.to_string());
+                let parameter_names = result
+                    .parameterNames
+                    .as_ref()
+                    .and_then(|opt| opt.as_ref())
+                    .map(|v| v.iter().map(|s| s.to_string()).collect());
+                let is_async = result.isAsync.flatten();
+                let is_generator = result.isGenerator.flatten();
+
+                // Object preview properties
+                let own_properties = result.ownProperties.as_ref().and_then(|opt| {
+                    opt.as_ref().map(|props| {
+                        props
+                            .iter()
+                            .map(|prop| devtools_traits::PropertyPreview {
+                                name: prop.name.to_string(),
+                                configurable: prop.configurable,
+                                enumerable: prop.enumerable,
+                                writable: prop.writable,
+                                is_accessor: prop.isAccessor,
+                                value_type: prop.valueType.to_string(),
+                                boolean_value: prop.booleanValue.flatten(),
+                                number_value: prop.numberValue.flatten().map(|f| *f),
+                                string_value: prop
+                                    .stringValue
+                                    .as_ref()
+                                    .and_then(|o| o.as_ref())
+                                    .map(|s| s.to_string()),
+                                object_class: prop
+                                    .objectClass
+                                    .as_ref()
+                                    .and_then(|o| o.as_ref())
+                                    .map(|s| s.to_string()),
+                                value_name: prop
+                                    .valueName
+                                    .as_ref()
+                                    .and_then(|o| o.as_ref())
+                                    .map(|s| s.to_string()),
+                            })
+                            .collect()
+                    })
+                });
+                let own_properties_length = result.ownPropertiesLength.flatten();
+
                 EvaluateJSReplyValue::ActorValue {
                     class,
                     uuid: uuid::Uuid::new_v4().to_string(),
                     name,
+                    display_name,
+                    parameter_names,
+                    is_async,
+                    is_generator,
+                    own_properties,
+                    own_properties_length,
                 }
             },
             _ => unreachable!(),

--- a/components/script_bindings/webidls/DebuggerEvalEvent.webidl
+++ b/components/script_bindings/webidls/DebuggerEvalEvent.webidl
@@ -52,6 +52,7 @@ dictionary EvalResultValue {
     unsigned long? ownPropertiesLength;
 };
 
+// TODO: Maybe merge some parts of this with the EvalResultValue
 dictionary PropertyPreview {
     required DOMString name;
     required boolean configurable;

--- a/components/script_bindings/webidls/DebuggerEvalEvent.webidl
+++ b/components/script_bindings/webidls/DebuggerEvalEvent.webidl
@@ -39,4 +39,29 @@ dictionary EvalResultValue {
     DOMString? objectClass;
     DOMString? name;
     boolean? hasException;
+
+    // Function-specific metadata
+    // <https://searchfox.org/mozilla-central/source/devtools/server/actors/object/previewers.js>
+    DOMString? displayName;
+    sequence<DOMString>? parameterNames;
+    boolean? isAsync;
+    boolean? isGenerator;
+
+    // Object preview properties
+    sequence<PropertyPreview>? ownProperties;
+    unsigned long? ownPropertiesLength;
+};
+
+dictionary PropertyPreview {
+    required DOMString name;
+    required boolean configurable;
+    required boolean enumerable;
+    required boolean writable;
+    required boolean isAccessor;
+    required DOMString valueType;
+    boolean? booleanValue;
+    double? numberValue;
+    DOMString? stringValue;
+    DOMString? objectClass;
+    DOMString? valueName;
 };

--- a/components/shared/devtools/lib.rs
+++ b/components/shared/devtools/lib.rs
@@ -151,7 +151,28 @@ pub enum DomMutation {
     },
 }
 
-/// Serialized JS return values
+/// <https://searchfox.org/mozilla-central/source/devtools/server/actors/object/property-iterator.js#51>
+#[derive(Clone, Debug, Deserialize, MallocSizeOf, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct PropertyPreview {
+    pub name: String,
+    pub configurable: bool,
+    pub enumerable: bool,
+    pub writable: bool,
+    pub is_accessor: bool,
+    pub value_type: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub boolean_value: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub number_value: Option<f64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub string_value: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub object_class: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub value_name: Option<String>,
+}
+
 #[derive(Debug, Deserialize, Serialize)]
 pub enum EvaluateJSReplyValue {
     VoidValue,
@@ -163,6 +184,14 @@ pub enum EvaluateJSReplyValue {
         class: String,
         uuid: String,
         name: Option<String>,
+        // Function-specific
+        display_name: Option<String>,
+        parameter_names: Option<Vec<String>>,
+        is_async: Option<bool>,
+        is_generator: Option<bool>,
+        // Object preview
+        own_properties: Option<Vec<PropertyPreview>>,
+        own_properties_length: Option<u32>,
     },
 }
 

--- a/resources/debugger.js
+++ b/resources/debugger.js
@@ -72,10 +72,133 @@ addEventListener("addDebuggee", event => {
     }
 });
 
-// Create a result value object from a debuggee value.
-// Debuggee values: <https://firefox-source-docs.mozilla.org/js/Debugger/Conventions.html#debuggee-values>
-// Type detection follows Firefox's createValueGrip pattern:
+// Maximum number of properties to include in preview
+// <https://searchfox.org/firefox-main/source/devtools/server/actors/object/previewers.js#29>
+const OBJECT_PREVIEW_MAX_ITEMS = 10;
+
+// <https://searchfox.org/mozilla-central/source/devtools/server/actors/object/previewers.js#80>
+const previewers = {
+    Function: [],
+    Object: [],
+    // TODO: Add Array, Map, FormData etc
+};
+
+// Convert debuggee value to property descriptor value
 // <https://searchfox.org/mozilla-central/source/devtools/server/actors/object/utils.js#116>
+function valueToPropertyValue(val) {
+    switch (typeof val) {
+        case "undefined":
+            return { valueType: "undefined" };
+        case "boolean":
+            return { valueType: "boolean", booleanValue: val };
+        case "number":
+            return { valueType: "number", numberValue: val };
+        case "string":
+            return { valueType: "string", stringValue: val };
+        case "object":
+            if (val === null) {
+                return { valueType: "null" };
+            }
+            return {
+                valueType: "object",
+                objectClass: val.class,
+                valueName: val.callable ? val.name : undefined,
+            };
+        default:
+            return { valueType: "string", stringValue: String(val) };
+    }
+}
+
+// Extract own properties from a debuggee object
+// <https://firefox-source-docs.mozilla.org/devtools-user/debugger-api/debugger.object/index.html#function-properties-of-the-debugger-object-prototype>
+function extractOwnProperties(obj, maxItems = OBJECT_PREVIEW_MAX_ITEMS) {
+    const ownProperties = [];
+    let totalLength = 0;
+
+    let names;
+    try {
+        names = obj.getOwnPropertyNames();
+        totalLength = names.length;
+    } catch (e) {
+        return { ownProperties, ownPropertiesLength: 0 };
+    }
+
+    let count = 0;
+    for (const name of names) {
+        if (count >= maxItems) break;
+        try {
+            const desc = obj.getOwnPropertyDescriptor(name);
+            if (desc) {
+                const prop = {
+                    name: name,
+                    configurable: desc.configurable ?? false,
+                    enumerable: desc.enumerable ?? false,
+                    writable: desc.writable ?? false,
+                    isAccessor: desc.get !== undefined || desc.set !== undefined,
+                    valueType: "undefined",
+                };
+
+                if (desc.value !== undefined) {
+                    Object.assign(prop, valueToPropertyValue(desc.value));
+                } else if (desc.get) {
+                    try {
+                        const result = desc.get.call(obj);
+                        if (result && "return" in result) {
+                            Object.assign(prop, valueToPropertyValue(result.return));
+                        }
+                    } catch (e) {
+                        prop.valueType = "undefined";
+                    }
+                }
+
+                ownProperties.push(prop);
+                count++;
+            }
+        } catch (e) {
+            // For now skip properties that throw on access
+        }
+    }
+
+    return { ownProperties, ownPropertiesLength: totalLength };
+}
+
+// <https://searchfox.org/mozilla-central/source/devtools/server/actors/object/previewers.js#125>
+previewers.Function.push(function FunctionPreviewer(obj) {
+    const { ownProperties, ownPropertiesLength } = extractOwnProperties(obj);
+
+    return {
+        displayName: obj.displayName,
+        parameterNames: obj.parameterNames,
+        isAsync: obj.isAsyncFunction,
+        isGenerator: obj.isGeneratorFunction,
+        ownProperties,
+        ownPropertiesLength,
+    };
+});
+
+// Generic fallback for object previewer
+// <https://searchfox.org/mozilla-central/source/devtools/server/actors/object/previewers.js#856>
+previewers.Object.push(function ObjectPreviewer(obj) {
+    const { ownProperties, ownPropertiesLength } = extractOwnProperties(obj);
+    return {
+        ownProperties,
+        ownPropertiesLength,
+    };
+});
+
+function getPreview(obj) {
+    const className = obj.class;
+
+    // <https://searchfox.org/mozilla-central/source/devtools/server/actors/object.js#295>
+    const typePreviewers = previewers[className] || previewers.Object;
+    for (const previewer of typePreviewers) {
+        const result = previewer(obj);
+        if (result) return result;
+    }
+
+    return { ownProperties: [], ownPropertiesLength: 0 };
+}
+
 function createValueResult(value) {
     switch (typeof value) {
         case "undefined":
@@ -90,16 +213,15 @@ function createValueResult(value) {
             if (value === null) {
                 return { valueType: "null" };
             }
-            // Debugger.Object - use the `class` accessor property
+            // Debugger.Object - get preview using registered previewers
             // <https://firefox-source-docs.mozilla.org/js/Debugger/Debugger.Object.html>
-            if (value.callable) {
-                return {
-                    valueType: "object",
-                    objectClass: value.class,
-                    name: value.name
-                };
-            }
-            return { valueType: "object", objectClass: value.class };
+            const preview = getPreview(value);
+            return {
+                valueType: "object",
+                objectClass: value.class,
+                name: value.name,
+                ...preview,
+            };
         default:
             return { valueType: "string", stringValue: String(value) };
     }


### PR DESCRIPTION
Implement property preview for the debugger popup. When hovering over variables while paused at a breakpoint, users can now see object properties and function metadata

Testing: Current tests are passing. Manual testing.
Fixes: Part of #36027 

<img width="1507" height="876" alt="image" src="https://github.com/user-attachments/assets/31c95010-dab9-4b2c-a9b1-da6a29aa0de1" />

<img width="360" height="365" alt="image" src="https://github.com/user-attachments/assets/50d19979-c0b2-4278-b19b-85c0c0318ab4" /> 
<img width="370" height="365" alt="image" src="https://github.com/user-attachments/assets/3b74ef26-055b-4e49-848e-e7758f8d1de6" />