### PR TITLE
ci: Have `full` runs also trigger `macos-arm-unit-tests`

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -36,7 +36,7 @@ jobs:
         run: |
           {
             echo 'result<<EOF'
-            python ./python/servo/try_parser.py ${{ github.event_name == 'pull_request' && 'linux-unit-tests lint' || github.event_name == 'push' && 'full macos bencher production-bencher coverage' || 'fail-fast full macos-arm-unit-tests' }}
+            python ./python/servo/try_parser.py ${{ github.event_name == 'pull_request' && 'linux-unit-tests lint' || github.event_name == 'push' && 'full macos bencher production-bencher coverage' || 'fail-fast full' }}
             echo EOF
            } >> $GITHUB_OUTPUT
 

--- a/python/servo/try_parser.py
+++ b/python/servo/try_parser.py
@@ -200,8 +200,9 @@ class Config(object):
                 words.extend(["linux-wpt"])
                 continue  # skip over keyword
             if word == "full":
-                words.extend(["linux-unit-tests", "linux-wpt", "linux-bencher"])
-                words.extend(["windows-unit-tests", "android", "ohos", "lint"])
+                words.extend(["linux-unit-tests", "windows-unit-tests", "macos-arm-unit-tests"])
+                words.extend(["linux-wpt", "linux-bencher"])
+                words.extend(["android", "ohos", "lint"])
                 words.extend(["linux-build-libservo", "windows-build-libservo"])
                 continue  # skip over keyword
             if word == "bencher":
@@ -223,9 +224,9 @@ class Config(object):
                         "macos-production-bencher",
                         "macos-arm-production-bencher",
                         "windows-production-bencher",
+                        "ohos-production-bencher",
                     ]
                 )
-                words.extend(["ohos-production-bencher"])
                 continue  # skip over keyword
             if word in ["cov", "coverage", "test-coverage"]:
                 words.extend(["linux-coverage"])
@@ -310,6 +311,19 @@ class TestParser(unittest.TestCase):
                         "profile": "release",
                         "unit_tests": True,
                         "build_libservo": True,
+                        "bencher": False,
+                        "build_args": "",
+                        "coverage": False,
+                        "wpt_args": "",
+                        "number_of_wpt_chunks": 20,
+                    },
+                    {
+                        "name": "MacOS Arm64 (Unit Tests)",
+                        "workflow": "macos-arm64",
+                        "wpt": False,
+                        "profile": "release",
+                        "unit_tests": True,
+                        "build_libservo": False,
                         "bencher": False,
                         "build_args": "",
                         "coverage": False,


### PR DESCRIPTION
Just organizes full run.

Testing: No change expected. Successful landing is sufficient.
