### PR TITLE
devtools: add `eval` support for dedicated workers

### DIFF
--- a/components/script/dom/workers/dedicatedworkerglobalscope.rs
+++ b/components/script/dom/workers/dedicatedworkerglobalscope.rs
@@ -37,7 +37,7 @@ use crate::dom::bindings::error::{ErrorInfo, ErrorResult};
 use crate::dom::bindings::inheritance::Castable;
 use crate::dom::bindings::refcounted::Trusted;
 use crate::dom::bindings::reflector::DomGlobal;
-use crate::dom::bindings::root::DomRoot;
+use crate::dom::bindings::root::{Dom, DomRoot};
 use crate::dom::bindings::str::DOMString;
 use crate::dom::bindings::structuredclone;
 use crate::dom::bindings::trace::{CustomTraceable, RootedTraceableBox};
@@ -211,6 +211,7 @@ pub(crate) struct DedicatedWorkerGlobalScope {
     control_receiver: Receiver<DedicatedWorkerControlMsg>,
     #[no_trace]
     queued_worker_tasks: DomRefCell<Vec<MessageData>>,
+    debugger_global: Dom<DebuggerGlobalScope>,
 }
 
 impl WorkerEventLoopMethods for DedicatedWorkerGlobalScope {
@@ -275,6 +276,7 @@ impl DedicatedWorkerGlobalScope {
         control_receiver: Receiver<DedicatedWorkerControlMsg>,
         insecure_requests_policy: InsecureRequestsPolicy,
         font_context: Option<Arc<FontContext>>,
+        debugger_global: &DebuggerGlobalScope,
     ) -> DedicatedWorkerGlobalScope {
         DedicatedWorkerGlobalScope {
             workerglobalscope: WorkerGlobalScope::new_inherited(
@@ -299,6 +301,7 @@ impl DedicatedWorkerGlobalScope {
             browsing_context,
             control_receiver,
             queued_worker_tasks: Default::default(),
+            debugger_global: Dom::from_ref(debugger_global),
         }
     }
 
@@ -321,6 +324,7 @@ impl DedicatedWorkerGlobalScope {
         control_receiver: Receiver<DedicatedWorkerControlMsg>,
         insecure_requests_policy: InsecureRequestsPolicy,
         font_context: Option<Arc<FontContext>>,
+        debugger_global: &DebuggerGlobalScope,
         cx: &mut js::context::JSContext,
     ) -> DomRoot<DedicatedWorkerGlobalScope> {
         let scope = Box::new(DedicatedWorkerGlobalScope::new_inherited(
@@ -342,6 +346,7 @@ impl DedicatedWorkerGlobalScope {
             control_receiver,
             insecure_requests_policy,
             font_context,
+            debugger_global,
         ));
         DedicatedWorkerGlobalScopeBinding::Wrap::<crate::DomTypeHolder>(cx, scope)
     }
@@ -492,6 +497,7 @@ impl DedicatedWorkerGlobalScope {
                     control_receiver,
                     insecure_requests_policy,
                     font_context,
+                    &debugger_global,
                     cx,
                 );
                 debugger_global.fire_add_debuggee(
@@ -650,6 +656,16 @@ impl DedicatedWorkerGlobalScope {
                 DevtoolScriptControlMsg::WantsLiveNotifications(_pipe_id, bool_val) => {
                     self.upcast::<GlobalScope>()
                         .set_devtools_wants_updates(bool_val);
+                },
+                DevtoolScriptControlMsg::Eval(code, id, frame_actor_id, reply) => {
+                    self.debugger_global.fire_eval(
+                        CanGc::from_cx(cx),
+                        code.into(),
+                        id,
+                        Some(self.upcast::<WorkerGlobalScope>().worker_id()),
+                        frame_actor_id,
+                        reply,
+                    );
                 },
                 _ => debug!("got an unusable devtools control message inside the worker!"),
             },


### PR DESCRIPTION
Added dedicated worker side handling, followed the same pattern used in main script handling by wiring worker global scope to `DebuggerGlobalScope` and invoking `fire_eval`

fixes: Part of #43317 