### PR TITLE
script: Pass `&mut JSContext` in remaining parts of Trusted Types

### DIFF
--- a/components/script/dom/attr.rs
+++ b/components/script/dom/attr.rs
@@ -9,6 +9,7 @@ use std::sync::LazyLock;
 use devtools_traits::AttrInfo;
 use dom_struct::dom_struct;
 use html5ever::{LocalName, Namespace, Prefix, local_name, ns};
+use js::context::JSContext;
 use style::attr::{AttrIdentifier, AttrValue};
 use style::values::GenericAtomIdent;
 
@@ -109,7 +110,7 @@ impl AttrMethods<crate::DomTypeHolder> for Attr {
     }
 
     /// <https://dom.spec.whatwg.org/#set-an-existing-attribute-value>
-    fn SetValue(&self, value: DOMString, can_gc: CanGc) -> Fallible<()> {
+    fn SetValue(&self, cx: &mut JSContext, value: DOMString) -> Fallible<()> {
         // Step 2. Otherwise:
         if let Some(owner) = self.owner() {
             // Step 2.1. Let element be attribute’s element.
@@ -117,18 +118,18 @@ impl AttrMethods<crate::DomTypeHolder> for Attr {
             // get trusted type compliant attribute value with attribute’s local name,
             // attribute’s namespace, element, and value. [TRUSTED-TYPES]
             let value = TrustedTypePolicyFactory::get_trusted_types_compliant_attribute_value(
+                cx,
                 owner.namespace(),
                 owner.local_name(),
                 self.local_name(),
                 Some(self.namespace()),
                 TrustedTypeOrString::String(value),
                 &owner.owner_global(),
-                can_gc,
             )?;
             if let Some(owner) = self.owner() {
                 // Step 2.4. Change attribute to verifiedValue.
                 let value = owner.parse_attribute(self.namespace(), self.local_name(), value);
-                owner.change_attribute(self, value, can_gc);
+                owner.change_attribute(self, value, CanGc::from_cx(cx));
             } else {
                 // Step 2.3. If attribute’s element is null, then set attribute’s value to verifiedValue, and return.
                 self.set_value(value);

--- a/components/script/dom/element.rs
+++ b/components/script/dom/element.rs
@@ -2601,13 +2601,13 @@ impl Element {
         // get Trusted Types-compliant attribute value with attr’s local name,
         // attr’s namespace, element, and attr’s value. [TRUSTED-TYPES]
         let verified_value = TrustedTypePolicyFactory::get_trusted_types_compliant_attribute_value(
+            cx,
             self.namespace(),
             self.local_name(),
             attr.local_name(),
             Some(attr.namespace()),
             TrustedTypeOrString::String(attr.Value()),
             &self.owner_global(),
-            CanGc::from_cx(cx),
         )?;
 
         // Step 2. If attr’s element is neither null nor element,
@@ -3207,13 +3207,13 @@ impl ElementMethods<crate::DomTypeHolder> for Element {
         // Trusted Types-compliant attribute value with qualifiedName, null,
         // this, and value. [TRUSTED-TYPES]
         let value = TrustedTypePolicyFactory::get_trusted_types_compliant_attribute_value(
+            cx,
             self.namespace(),
             self.local_name(),
             &name,
             None,
             value,
             &self.owner_global(),
-            CanGc::from_cx(cx),
         )?;
 
         // Step 4. Let attribute be the first attribute in this’s attribute list whose qualified name is qualifiedName, and null otherwise.
@@ -3247,13 +3247,13 @@ impl ElementMethods<crate::DomTypeHolder> for Element {
         // Step 2. Let verifiedValue be the result of calling get
         // Trusted Types-compliant attribute value with localName, namespace, element, and value. [TRUSTED-TYPES]
         let value = TrustedTypePolicyFactory::get_trusted_types_compliant_attribute_value(
+            cx,
             self.namespace(),
             self.local_name(),
             &local_name,
             Some(&namespace),
             value,
             &self.owner_global(),
-            CanGc::from_cx(cx),
         )?;
         // Step 3. Set an attribute value for this using localName, verifiedValue, and also prefix and namespace.
         let value = self.parse_attribute(&namespace, &local_name, value);

--- a/components/script/dom/globalscope.rs
+++ b/components/script/dom/globalscope.rs
@@ -127,7 +127,6 @@ use crate::dom::serviceworker::ServiceWorker;
 use crate::dom::serviceworkerregistration::ServiceWorkerRegistration;
 use crate::dom::stream::underlyingsourcecontainer::UnderlyingSourceType;
 use crate::dom::stream::writablestream::CrossRealmTransformWritable;
-use crate::dom::trustedtypes::trustedtypepolicyfactory::TrustedTypePolicyFactory;
 use crate::dom::types::{AbortSignal, CookieStore, DebuggerGlobalScope, MessageEvent};
 #[cfg(feature = "webgpu")]
 use crate::dom::webgpu::gpudevice::GPUDevice;
@@ -3377,16 +3376,6 @@ impl GlobalScope {
         self.notification_permission_request_callback_map
             .borrow_mut()
             .remove(&callback_id)
-    }
-
-    pub(crate) fn trusted_types(&self, can_gc: CanGc) -> DomRoot<TrustedTypePolicyFactory> {
-        if let Some(window) = self.downcast::<Window>() {
-            return window.TrustedTypes(can_gc);
-        }
-        if let Some(worker) = self.downcast::<WorkerGlobalScope>() {
-            return worker.TrustedTypes(can_gc);
-        }
-        unreachable!();
     }
 
     pub(crate) fn append_deferred_fetch(

--- a/components/script/dom/node.rs
+++ b/components/script/dom/node.rs
@@ -4034,11 +4034,11 @@ impl NodeMethods<crate::DomTypeHolder> for Node {
     }
 
     /// <https://dom.spec.whatwg.org/#dom-node-nodevalue>
-    fn SetNodeValue(&self, val: Option<DOMString>, can_gc: CanGc) -> Fallible<()> {
+    fn SetNodeValue(&self, cx: &mut JSContext, val: Option<DOMString>) -> Fallible<()> {
         match self.type_id() {
             NodeTypeId::Attr => {
                 let attr = self.downcast::<Attr>().unwrap();
-                attr.SetValue(val.unwrap_or_default(), can_gc)?;
+                attr.SetValue(cx, val.unwrap_or_default())?;
             },
             NodeTypeId::CharacterData(_) => {
                 let character_data = self.downcast::<CharacterData>().unwrap();
@@ -4074,7 +4074,7 @@ impl NodeMethods<crate::DomTypeHolder> for Node {
             },
             NodeTypeId::Attr => {
                 let attr = self.downcast::<Attr>().unwrap();
-                attr.SetValue(value.unwrap_or_default(), CanGc::from_cx(cx))?;
+                attr.SetValue(cx, value.unwrap_or_default())?;
             },
             NodeTypeId::CharacterData(..) => {
                 let characterdata = self.downcast::<CharacterData>().unwrap();

--- a/components/script/dom/trustedtypes/trustedhtml.rs
+++ b/components/script/dom/trustedtypes/trustedhtml.rs
@@ -20,7 +20,6 @@ use crate::dom::trustedtypes::trustedtypepolicy::TrustedType;
 use crate::dom::trustedtypes::trustedtypepolicyfactory::{
     DEFAULT_SCRIPT_SINK_GROUP, TrustedTypePolicyFactory,
 };
-use crate::script_runtime::CanGc;
 
 #[dom_struct]
 pub struct TrustedHTML {
@@ -54,12 +53,12 @@ impl TrustedHTML {
         match value {
             TrustedHTMLOrString::String(value) => {
                 TrustedTypePolicyFactory::get_trusted_type_compliant_string(
+                    cx,
                     TrustedType::TrustedHTML,
                     global,
                     value,
                     sink,
                     DEFAULT_SCRIPT_SINK_GROUP,
-                    CanGc::from_cx(cx),
                 )
             },
 

--- a/components/script/dom/trustedtypes/trustedscript.rs
+++ b/components/script/dom/trustedtypes/trustedscript.rs
@@ -20,7 +20,6 @@ use crate::dom::trustedtypes::trustedtypepolicy::TrustedType;
 use crate::dom::trustedtypes::trustedtypepolicyfactory::{
     DEFAULT_SCRIPT_SINK_GROUP, TrustedTypePolicyFactory,
 };
-use crate::script_runtime::CanGc;
 
 #[dom_struct]
 pub struct TrustedScript {
@@ -50,12 +49,12 @@ impl TrustedScript {
         match value {
             TrustedScriptOrString::String(value) => {
                 TrustedTypePolicyFactory::get_trusted_type_compliant_string(
+                    cx,
                     TrustedType::TrustedScript,
                     global,
                     value,
                     sink,
                     DEFAULT_SCRIPT_SINK_GROUP,
-                    CanGc::from_cx(cx),
                 )
             },
 

--- a/components/script/dom/trustedtypes/trustedscripturl.rs
+++ b/components/script/dom/trustedtypes/trustedscripturl.rs
@@ -17,7 +17,6 @@ use crate::dom::trustedtypes::trustedtypepolicy::TrustedType;
 use crate::dom::trustedtypes::trustedtypepolicyfactory::{
     DEFAULT_SCRIPT_SINK_GROUP, TrustedTypePolicyFactory,
 };
-use crate::script_runtime::CanGc;
 
 #[dom_struct]
 pub struct TrustedScriptURL {
@@ -51,12 +50,12 @@ impl TrustedScriptURL {
         match value {
             TrustedScriptURLOrUSVString::USVString(value) => {
                 TrustedTypePolicyFactory::get_trusted_type_compliant_string(
+                    cx,
                     TrustedType::TrustedScriptURL,
                     global,
                     value.as_ref().into(),
                     sink,
                     DEFAULT_SCRIPT_SINK_GROUP,
-                    CanGc::from_cx(cx),
                 )
             },
             TrustedScriptURLOrUSVString::TrustedScriptURL(trusted_script_url) => {

--- a/components/script/dom/trustedtypes/trustedtypepolicy.rs
+++ b/components/script/dom/trustedtypes/trustedtypepolicy.rs
@@ -98,11 +98,11 @@ impl TrustedTypePolicy {
     /// <https://w3c.github.io/trusted-types/dist/spec/#get-trusted-type-policy-value-algorithm>
     pub(crate) fn get_trusted_type_policy_value(
         &self,
+        cx: &mut js::context::JSContext,
         expected_type: TrustedType,
         input: DOMString,
         arguments: Vec<HandleValue>,
         throw_if_missing: bool,
-        can_gc: CanGc,
     ) -> Fallible<Option<DOMString>> {
         // Step 1: Let functionName be a function name for the given trustedTypeName, based on the following table:
         match expected_type {
@@ -114,7 +114,12 @@ impl TrustedTypePolicy {
                     // Step 4: Let policyValue be the result of invoking function with value as a first argument,
                     // items of arguments as subsequent arguments, and callback **this** value set to undefined,
                     // rethrowing any exceptions.
-                    callback.Call__(input, arguments, ExceptionHandling::Rethrow, can_gc)
+                    callback.Call__(
+                        input,
+                        arguments,
+                        ExceptionHandling::Rethrow,
+                        CanGc::from_cx(cx),
+                    )
                 },
             },
             TrustedType::TrustedScript => match &self.create_script {
@@ -125,7 +130,12 @@ impl TrustedTypePolicy {
                     // Step 4: Let policyValue be the result of invoking function with value as a first argument,
                     // items of arguments as subsequent arguments, and callback **this** value set to undefined,
                     // rethrowing any exceptions.
-                    callback.Call__(input, arguments, ExceptionHandling::Rethrow, can_gc)
+                    callback.Call__(
+                        input,
+                        arguments,
+                        ExceptionHandling::Rethrow,
+                        CanGc::from_cx(cx),
+                    )
                 },
             },
             TrustedType::TrustedScriptURL => match &self.create_script_url {
@@ -137,7 +147,12 @@ impl TrustedTypePolicy {
                     // items of arguments as subsequent arguments, and callback **this** value set to undefined,
                     // rethrowing any exceptions.
                     callback
-                        .Call__(input, arguments, ExceptionHandling::Rethrow, can_gc)
+                        .Call__(
+                            input,
+                            arguments,
+                            ExceptionHandling::Rethrow,
+                            CanGc::from_cx(cx),
+                        )
                         .map(|result| result.map(DOMString::from))
                 },
             },
@@ -169,13 +184,8 @@ impl TrustedTypePolicy {
     {
         // Step 1: Let policyValue be the result of executing Get Trusted Type policy value
         // with the same arguments as this algorithm and additionally true as throwIfMissing.
-        let policy_value = self.get_trusted_type_policy_value(
-            expected_type,
-            input,
-            arguments,
-            true,
-            CanGc::from_cx(cx),
-        );
+        let policy_value =
+            self.get_trusted_type_policy_value(cx, expected_type, input, arguments, true);
         match policy_value {
             // Step 2: If the algorithm threw an error, rethrow the error and abort the following steps.
             Err(error) => Err(error),

--- a/components/script/dom/trustedtypes/trustedtypepolicyfactory.rs
+++ b/components/script/dom/trustedtypes/trustedtypepolicyfactory.rs
@@ -13,10 +13,13 @@ use crate::conversions::Convert;
 use crate::dom::bindings::codegen::Bindings::TrustedTypePolicyFactoryBinding::{
     TrustedTypePolicyFactoryMethods, TrustedTypePolicyOptions,
 };
+use crate::dom::bindings::codegen::Bindings::WindowBinding::WindowMethods;
+use crate::dom::bindings::codegen::Bindings::WorkerGlobalScopeBinding::WorkerGlobalScopeMethods;
 use crate::dom::bindings::codegen::UnionTypes::TrustedHTMLOrTrustedScriptOrTrustedScriptURLOrString as TrustedTypeOrString;
 use crate::dom::bindings::conversions::root_from_handlevalue;
 use crate::dom::bindings::error::{Error, Fallible};
-use crate::dom::bindings::reflector::{DomGlobal, Reflector, reflect_dom_object};
+use crate::dom::bindings::inheritance::Castable;
+use crate::dom::bindings::reflector::{DomGlobal, Reflector, reflect_dom_object_with_cx};
 use crate::dom::bindings::root::{DomRoot, MutNullableDom};
 use crate::dom::bindings::str::DOMString;
 use crate::dom::csp::CspReporting;
@@ -26,6 +29,8 @@ use crate::dom::trustedtypes::trustedhtml::TrustedHTML;
 use crate::dom::trustedtypes::trustedscript::TrustedScript;
 use crate::dom::trustedtypes::trustedscripturl::TrustedScriptURL;
 use crate::dom::trustedtypes::trustedtypepolicy::{TrustedType, TrustedTypePolicy};
+use crate::dom::types::WorkerGlobalScope;
+use crate::dom::window::Window;
 use crate::script_runtime::{CanGc, JSContext};
 
 #[dom_struct]
@@ -62,8 +67,8 @@ impl TrustedTypePolicyFactory {
         }
     }
 
-    pub(crate) fn new(global: &GlobalScope, can_gc: CanGc) -> DomRoot<Self> {
-        reflect_dom_object(Box::new(Self::new_inherited()), global, can_gc)
+    pub(crate) fn new(cx: &mut js::context::JSContext, global: &GlobalScope) -> DomRoot<Self> {
+        reflect_dom_object_with_cx(Box::new(Self::new_inherited()), global, cx)
     }
 
     /// <https://www.w3.org/TR/trusted-types/#create-trusted-type-policy-algorithm>
@@ -184,13 +189,13 @@ impl TrustedTypePolicyFactory {
 
     /// <https://w3c.github.io/trusted-types/dist/spec/#validate-attribute-mutation>
     pub(crate) fn get_trusted_types_compliant_attribute_value(
+        cx: &mut js::context::JSContext,
         element_namespace: &Namespace,
         element_name: &LocalName,
         attribute: &str,
         attribute_namespace: Option<&Namespace>,
         new_value: TrustedTypeOrString,
         global: &GlobalScope,
-        can_gc: CanGc,
     ) -> Fallible<DOMString> {
         // Step 1. If attributeNs is the empty string, set attributeNs to null.
         let attribute_namespace =
@@ -227,47 +232,48 @@ impl TrustedTypePolicyFactory {
         // Step 6. Return the result of executing Get Trusted Type compliant string with the following arguments:
         // If the algorithm threw an error, rethrow the error.
         Self::get_trusted_type_compliant_string(
+            cx,
             expected_type,
             global,
             new_value,
             &sink,
             DEFAULT_SCRIPT_SINK_GROUP,
-            can_gc,
         )
     }
 
     /// <https://w3c.github.io/trusted-types/dist/spec/#process-value-with-a-default-policy-algorithm>
     pub(crate) fn process_value_with_default_policy(
+        cx: &mut js::context::JSContext,
         expected_type: TrustedType,
         global: &GlobalScope,
         input: DOMString,
         sink: &str,
-        can_gc: CanGc,
     ) -> Fallible<Option<DOMString>> {
         // Step 1: Let defaultPolicy be the value of global’s trusted type policy factory's default policy.
-        let global_policy_factory = global.trusted_types(can_gc);
+        let global_policy_factory = global.trusted_types(cx);
         let default_policy = match global_policy_factory.default_policy.get() {
             None => return Ok(None),
             Some(default_policy) => default_policy,
         };
-        let cx = GlobalScope::get_cx();
         // Step 2: Let policyValue be the result of executing Get Trusted Type policy value,
         // with the following arguments:
-        rooted!(in(*cx) let mut trusted_type_name_value = NullValue());
-        expected_type
-            .as_ref()
-            .safe_to_jsval(cx, trusted_type_name_value.handle_mut(), can_gc);
+        rooted!(&in(cx) let mut trusted_type_name_value = NullValue());
+        expected_type.as_ref().safe_to_jsval(
+            cx.into(),
+            trusted_type_name_value.handle_mut(),
+            CanGc::from_cx(cx),
+        );
 
-        rooted!(in(*cx) let mut sink_value = NullValue());
-        sink.safe_to_jsval(cx, sink_value.handle_mut(), can_gc);
+        rooted!(&in(cx) let mut sink_value = NullValue());
+        sink.safe_to_jsval(cx.into(), sink_value.handle_mut(), CanGc::from_cx(cx));
 
         let arguments = vec![trusted_type_name_value.handle(), sink_value.handle()];
         let policy_value = default_policy.get_trusted_type_policy_value(
+            cx,
             expected_type,
             input,
             arguments,
             false,
-            can_gc,
         );
         let data_string = match policy_value {
             // Step 3: If the algorithm threw an error, rethrow the error and abort the following steps.
@@ -284,12 +290,12 @@ impl TrustedTypePolicyFactory {
     /// Step 1 is implemented by the caller
     /// <https://w3c.github.io/trusted-types/dist/spec/#get-trusted-type-compliant-string-algorithm>
     pub(crate) fn get_trusted_type_compliant_string(
+        cx: &mut js::context::JSContext,
         expected_type: TrustedType,
         global: &GlobalScope,
         input: DOMString,
         sink: &str,
         sink_group: &str,
-        can_gc: CanGc,
     ) -> Fallible<DOMString> {
         // Step 2: Let requireTrustedTypes be the result of executing Does sink type require trusted types?
         // algorithm, passing global, sinkGroup, and true.
@@ -303,11 +309,11 @@ impl TrustedTypePolicyFactory {
         // Step 4: Let convertedInput be the result of executing Process value with a default policy
         // with the same arguments as this algorithm.
         let converted_input = TrustedTypePolicyFactory::process_value_with_default_policy(
+            cx,
             expected_type,
             global,
             input.clone(),
             sink,
-            can_gc,
         );
         // Step 5: If the algorithm threw an error, rethrow the error and abort the following steps.
         match converted_input? {
@@ -476,5 +482,17 @@ impl TrustedTypePolicyFactoryMethods<crate::DomTypeHolder> for TrustedTypePolicy
     /// <https://www.w3.org/TR/trusted-types/#dom-trustedtypepolicyfactory-defaultpolicy>
     fn GetDefaultPolicy(&self) -> Option<DomRoot<TrustedTypePolicy>> {
         self.default_policy.get()
+    }
+}
+
+impl GlobalScope {
+    fn trusted_types(&self, cx: &mut js::context::JSContext) -> DomRoot<TrustedTypePolicyFactory> {
+        if let Some(window) = self.downcast::<Window>() {
+            return window.TrustedTypes(cx);
+        }
+        if let Some(worker) = self.downcast::<WorkerGlobalScope>() {
+            return worker.TrustedTypes(cx);
+        }
+        unreachable!();
     }
 }

--- a/components/script/dom/window.rs
+++ b/components/script/dom/window.rs
@@ -2334,9 +2334,9 @@ impl WindowMethods<crate::DomTypeHolder> for Window {
             .structured_clone(cx, value, options, retval, can_gc)
     }
 
-    fn TrustedTypes(&self, can_gc: CanGc) -> DomRoot<TrustedTypePolicyFactory> {
+    fn TrustedTypes(&self, cx: &mut JSContext) -> DomRoot<TrustedTypePolicyFactory> {
         self.trusted_types
-            .or_init(|| TrustedTypePolicyFactory::new(self.as_global_scope(), can_gc))
+            .or_init(|| TrustedTypePolicyFactory::new(cx, self.as_global_scope()))
     }
 }
 

--- a/components/script/dom/workers/workerglobalscope.rs
+++ b/components/script/dom/workers/workerglobalscope.rs
@@ -968,10 +968,10 @@ impl WorkerGlobalScopeMethods<crate::DomTypeHolder> for WorkerGlobalScope {
     }
 
     /// <https://www.w3.org/TR/trusted-types/#dom-windoworworkerglobalscope-trustedtypes>
-    fn TrustedTypes(&self, can_gc: CanGc) -> DomRoot<TrustedTypePolicyFactory> {
+    fn TrustedTypes(&self, cx: &mut js::context::JSContext) -> DomRoot<TrustedTypePolicyFactory> {
         self.trusted_types.or_init(|| {
             let global_scope = self.upcast::<GlobalScope>();
-            TrustedTypePolicyFactory::new(global_scope, can_gc)
+            TrustedTypePolicyFactory::new(cx, global_scope)
         })
     }
 }

--- a/components/script_bindings/codegen/Bindings.conf
+++ b/components/script_bindings/codegen/Bindings.conf
@@ -29,7 +29,7 @@ DOMInterfaces = {
 },
 
 'Attr': {
-    'canGc':['SetValue'],
+    'cx':['SetValue'],
 },
 
 'AudioBuffer': {
@@ -662,8 +662,8 @@ DOMInterfaces = {
 },
 
 'Node': {
-    'canGc': ['ChildNodes', 'SetNodeValue'],
-    'cx': ['AppendChild', 'CloneNode', 'InsertBefore', 'Normalize', 'RemoveChild', 'ReplaceChild', 'SetTextContent']
+    'canGc': ['ChildNodes'],
+    'cx': ['AppendChild', 'CloneNode', 'InsertBefore', 'Normalize', 'RemoveChild', 'ReplaceChild', 'SetNodeValue', 'SetTextContent']
 },
 
 'NodeIterator': {
@@ -852,11 +852,11 @@ DOMInterfaces = {
 },
 
 'Window': {
-    'canGc': ['CookieStore', 'Fetch', 'FetchLater', 'GetVisualViewport', 'ReportError', 'Screen', 'StructuredClone', 'TrustedTypes'],
+    'canGc': ['CookieStore', 'Fetch', 'FetchLater', 'GetVisualViewport', 'ReportError', 'Screen', 'StructuredClone'],
     'inRealms': ['Fetch'],
     'additionalTraits': ['crate::interfaces::WindowHelpers'],
     'realm': ['CreateImageBitmap', 'CreateImageBitmap_', 'WebdriverCallback', 'GetOpener'],
-    'cx': ['Open', 'PostMessage', 'PostMessage_', 'SetInterval', 'SetTimeout', 'Stop', 'WebdriverException']
+    'cx': ['Open', 'PostMessage', 'PostMessage_', 'SetInterval', 'SetTimeout', 'Stop', 'TrustedTypes', 'WebdriverException']
 },
 
 'WindowProxy' : {
@@ -870,8 +870,8 @@ DOMInterfaces = {
 
 'WorkerGlobalScope': {
     'inRealms': ['Fetch'],
-    'cx': ['ImportScripts', 'SetInterval', 'SetTimeout'],
-    'canGc': ['Fetch', 'ReportError', 'StructuredClone', 'TrustedTypes'],
+    'cx': ['ImportScripts', 'SetInterval', 'SetTimeout', 'TrustedTypes'],
+    'canGc': ['Fetch', 'ReportError', 'StructuredClone'],
     'realm': ['CreateImageBitmap', 'CreateImageBitmap_'],
 },
 


### PR DESCRIPTION
These are the remaining arguments of `CanGc`.

Part of #40600

Testing: it compiles