### PR TITLE
Implement "tables inherit color from body quirk"

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7165,8 +7165,8 @@ dependencies = [
 
 [[package]]
 name = "selectors"
-version = "0.36.0"
-source = "git+https://github.com/servo/stylo?rev=dca3934667dae76c49bb579b268c5eb142d09c6a#dca3934667dae76c49bb579b268c5eb142d09c6a"
+version = "0.36.1"
+source = "git+https://github.com/servo/stylo?rev=f9d940629a7fd0389cc4ecb58c12927b09286478#f9d940629a7fd0389cc4ecb58c12927b09286478"
 dependencies = [
  "bitflags 2.11.0",
  "cssparser",
@@ -8784,7 +8784,7 @@ dependencies = [
 [[package]]
 name = "servo_arc"
 version = "0.4.3"
-source = "git+https://github.com/servo/stylo?rev=dca3934667dae76c49bb579b268c5eb142d09c6a#dca3934667dae76c49bb579b268c5eb142d09c6a"
+source = "git+https://github.com/servo/stylo?rev=f9d940629a7fd0389cc4ecb58c12927b09286478#f9d940629a7fd0389cc4ecb58c12927b09286478"
 dependencies = [
  "serde",
  "stable_deref_trait",
@@ -9203,8 +9203,8 @@ dependencies = [
 
 [[package]]
 name = "stylo"
-version = "0.13.0"
-source = "git+https://github.com/servo/stylo?rev=dca3934667dae76c49bb579b268c5eb142d09c6a#dca3934667dae76c49bb579b268c5eb142d09c6a"
+version = "0.14.0"
+source = "git+https://github.com/servo/stylo?rev=f9d940629a7fd0389cc4ecb58c12927b09286478#f9d940629a7fd0389cc4ecb58c12927b09286478"
 dependencies = [
  "app_units",
  "arrayvec",
@@ -9259,8 +9259,8 @@ dependencies = [
 
 [[package]]
 name = "stylo_atoms"
-version = "0.13.0"
-source = "git+https://github.com/servo/stylo?rev=dca3934667dae76c49bb579b268c5eb142d09c6a#dca3934667dae76c49bb579b268c5eb142d09c6a"
+version = "0.14.0"
+source = "git+https://github.com/servo/stylo?rev=f9d940629a7fd0389cc4ecb58c12927b09286478#f9d940629a7fd0389cc4ecb58c12927b09286478"
 dependencies = [
  "string_cache",
  "string_cache_codegen",
@@ -9268,8 +9268,8 @@ dependencies = [
 
 [[package]]
 name = "stylo_derive"
-version = "0.13.0"
-source = "git+https://github.com/servo/stylo?rev=dca3934667dae76c49bb579b268c5eb142d09c6a#dca3934667dae76c49bb579b268c5eb142d09c6a"
+version = "0.14.0"
+source = "git+https://github.com/servo/stylo?rev=f9d940629a7fd0389cc4ecb58c12927b09286478#f9d940629a7fd0389cc4ecb58c12927b09286478"
 dependencies = [
  "darling",
  "proc-macro2",
@@ -9280,8 +9280,8 @@ dependencies = [
 
 [[package]]
 name = "stylo_dom"
-version = "0.13.0"
-source = "git+https://github.com/servo/stylo?rev=dca3934667dae76c49bb579b268c5eb142d09c6a#dca3934667dae76c49bb579b268c5eb142d09c6a"
+version = "0.14.0"
+source = "git+https://github.com/servo/stylo?rev=f9d940629a7fd0389cc4ecb58c12927b09286478#f9d940629a7fd0389cc4ecb58c12927b09286478"
 dependencies = [
  "bitflags 2.11.0",
  "stylo_malloc_size_of",
@@ -9289,8 +9289,8 @@ dependencies = [
 
 [[package]]
 name = "stylo_malloc_size_of"
-version = "0.13.0"
-source = "git+https://github.com/servo/stylo?rev=dca3934667dae76c49bb579b268c5eb142d09c6a#dca3934667dae76c49bb579b268c5eb142d09c6a"
+version = "0.14.0"
+source = "git+https://github.com/servo/stylo?rev=f9d940629a7fd0389cc4ecb58c12927b09286478#f9d940629a7fd0389cc4ecb58c12927b09286478"
 dependencies = [
  "app_units",
  "cssparser",
@@ -9306,13 +9306,13 @@ dependencies = [
 
 [[package]]
 name = "stylo_static_prefs"
-version = "0.13.0"
-source = "git+https://github.com/servo/stylo?rev=dca3934667dae76c49bb579b268c5eb142d09c6a#dca3934667dae76c49bb579b268c5eb142d09c6a"
+version = "0.14.0"
+source = "git+https://github.com/servo/stylo?rev=f9d940629a7fd0389cc4ecb58c12927b09286478#f9d940629a7fd0389cc4ecb58c12927b09286478"
 
 [[package]]
 name = "stylo_traits"
-version = "0.13.0"
-source = "git+https://github.com/servo/stylo?rev=dca3934667dae76c49bb579b268c5eb142d09c6a#dca3934667dae76c49bb579b268c5eb142d09c6a"
+version = "0.14.0"
+source = "git+https://github.com/servo/stylo?rev=f9d940629a7fd0389cc4ecb58c12927b09286478#f9d940629a7fd0389cc4ecb58c12927b09286478"
 dependencies = [
  "app_units",
  "bitflags 2.11.0",
@@ -9734,7 +9734,7 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 [[package]]
 name = "to_shmem"
 version = "0.3.0"
-source = "git+https://github.com/servo/stylo?rev=dca3934667dae76c49bb579b268c5eb142d09c6a#dca3934667dae76c49bb579b268c5eb142d09c6a"
+source = "git+https://github.com/servo/stylo?rev=f9d940629a7fd0389cc4ecb58c12927b09286478#f9d940629a7fd0389cc4ecb58c12927b09286478"
 dependencies = [
  "cssparser",
  "servo_arc",
@@ -9747,7 +9747,7 @@ dependencies = [
 [[package]]
 name = "to_shmem_derive"
 version = "0.1.0"
-source = "git+https://github.com/servo/stylo?rev=dca3934667dae76c49bb579b268c5eb142d09c6a#dca3934667dae76c49bb579b268c5eb142d09c6a"
+source = "git+https://github.com/servo/stylo?rev=f9d940629a7fd0389cc4ecb58c12927b09286478#f9d940629a7fd0389cc4ecb58c12927b09286478"
 dependencies = [
  "darling",
  "proc-macro2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -157,12 +157,12 @@ rustls-platform-verifier = "0.6.2"
 sea-query = { version = "1.0.0-rc.31", default-features = false, features = ["backend-sqlite", "derive"] }
 sea-query-rusqlite = { version = "0.8.0-rc.15" }
 sec1 = "0.7"
-selectors = { git = "https://github.com/servo/stylo", rev = "dca3934667dae76c49bb579b268c5eb142d09c6a" }
+selectors = { git = "https://github.com/servo/stylo", rev = "f9d940629a7fd0389cc4ecb58c12927b09286478" }
 serde = "1.0.228"
 serde_bytes = "0.11"
 serde_core = "1.0.226"
 serde_json = "1.0"
-servo_arc = { git = "https://github.com/servo/stylo", rev = "dca3934667dae76c49bb579b268c5eb142d09c6a" }
+servo_arc = { git = "https://github.com/servo/stylo", rev = "f9d940629a7fd0389cc4ecb58c12927b09286478" }
 sha1 = "0.10"
 sha2 = "0.10"
 sha3 = "0.10"
@@ -170,12 +170,12 @@ skrifa = "0.37.0"
 smallvec = { version = "1.15", features = ["serde", "union"] }
 string_cache = "0.9"
 strum = { version = "0.28", features = ["derive"] }
-stylo = { git = "https://github.com/servo/stylo", rev = "dca3934667dae76c49bb579b268c5eb142d09c6a" }
-stylo_atoms = { git = "https://github.com/servo/stylo", rev = "dca3934667dae76c49bb579b268c5eb142d09c6a" }
-stylo_dom = { git = "https://github.com/servo/stylo", rev = "dca3934667dae76c49bb579b268c5eb142d09c6a" }
-stylo_malloc_size_of = { git = "https://github.com/servo/stylo", rev = "dca3934667dae76c49bb579b268c5eb142d09c6a" }
-stylo_static_prefs = { git = "https://github.com/servo/stylo", rev = "dca3934667dae76c49bb579b268c5eb142d09c6a" }
-stylo_traits = { git = "https://github.com/servo/stylo", rev = "dca3934667dae76c49bb579b268c5eb142d09c6a" }
+stylo = { git = "https://github.com/servo/stylo", rev = "f9d940629a7fd0389cc4ecb58c12927b09286478" }
+stylo_atoms = { git = "https://github.com/servo/stylo", rev = "f9d940629a7fd0389cc4ecb58c12927b09286478" }
+stylo_dom = { git = "https://github.com/servo/stylo", rev = "f9d940629a7fd0389cc4ecb58c12927b09286478" }
+stylo_malloc_size_of = { git = "https://github.com/servo/stylo", rev = "f9d940629a7fd0389cc4ecb58c12927b09286478" }
+stylo_static_prefs = { git = "https://github.com/servo/stylo", rev = "f9d940629a7fd0389cc4ecb58c12927b09286478" }
+stylo_traits = { git = "https://github.com/servo/stylo", rev = "f9d940629a7fd0389cc4ecb58c12927b09286478" }
 surfman = { version = "0.11.0", features = ["chains"] }
 syn = { version = "2", default-features = false, features = ["clone-impls", "derive", "parsing"] }
 synstructure = "0.13"

--- a/components/script/dom/element.rs
+++ b/components/script/dom/element.rs
@@ -40,7 +40,7 @@ use style::attr::{AttrValue, LengthOrPercentageOrAuto};
 use style::context::QuirksMode;
 use style::invalidation::element::restyle_hints::RestyleHint;
 use style::properties::longhands::{
-    self, background_image, border_spacing, font_family, font_size,
+    self, background_image, border_spacing, color, font_family, font_size,
 };
 use style::properties::{
     ComputedValues, Importance, PropertyDeclaration, PropertyDeclarationBlock,
@@ -1099,6 +1099,7 @@ impl<'dom> LayoutElementHelpers<'dom> for LayoutDom<'dom, Element> {
     where
         V: Push<ApplicableDeclarationBlock>,
     {
+        let document = self.upcast::<Node>().owner_doc_for_layout();
         let mut property_declaration_block = None;
         let mut push = |declaration| {
             property_declaration_block
@@ -1189,16 +1190,6 @@ impl<'dom> LayoutElementHelpers<'dom> for LayoutDom<'dom, Element> {
             push(PropertyDeclaration::FontSize(
                 font_size::SpecifiedValue::from_html_size(font_size as u8),
             ));
-        }
-
-        let cellspacing = self
-            .downcast::<HTMLTableElement>()
-            .and_then(HTMLTableElementLayoutHelpers::get_cellspacing);
-        if let Some(cellspacing) = cellspacing {
-            let width_value = specified::Length::from_px(cellspacing as f32);
-            push(PropertyDeclaration::BorderSpacing(Box::new(
-                border_spacing::SpecifiedValue::new(width_value.clone().into(), width_value.into()),
-            )));
         }
 
         // Textual input, specifically text entry and domain specific input has
@@ -1365,15 +1356,29 @@ impl<'dom> LayoutElementHelpers<'dom> for LayoutDom<'dom, Element> {
             }
         }
 
-        let border = self
-            .downcast::<HTMLTableElement>()
-            .and_then(|table| table.get_border());
-        if let Some(border) = border {
-            let width_value = specified::BorderSideWidth::from_px(border as f32);
-            push(PropertyDeclaration::BorderTopWidth(width_value.clone()));
-            push(PropertyDeclaration::BorderLeftWidth(width_value.clone()));
-            push(PropertyDeclaration::BorderBottomWidth(width_value.clone()));
-            push(PropertyDeclaration::BorderRightWidth(width_value));
+        if let Some(table) = self.downcast::<HTMLTableElement>() {
+            if let Some(cellspacing) = table.get_cellspacing() {
+                let width_value = specified::Length::from_px(cellspacing as f32);
+                push(PropertyDeclaration::BorderSpacing(Box::new(
+                    border_spacing::SpecifiedValue::new(
+                        width_value.clone().into(),
+                        width_value.into(),
+                    ),
+                )));
+            }
+            if let Some(border) = table.get_border() {
+                let width_value = specified::BorderSideWidth::from_px(border as f32);
+                push(PropertyDeclaration::BorderTopWidth(width_value.clone()));
+                push(PropertyDeclaration::BorderLeftWidth(width_value.clone()));
+                push(PropertyDeclaration::BorderBottomWidth(width_value.clone()));
+                push(PropertyDeclaration::BorderRightWidth(width_value));
+            }
+            if document.quirks_mode() == QuirksMode::Quirks {
+                // <https://quirks.spec.whatwg.org/#the-tables-inherit-color-from-body-quirk>
+                push(PropertyDeclaration::Color(color::SpecifiedValue(
+                    specified::Color::InheritFromBodyQuirk,
+                )));
+            }
         }
 
         if let Some(cellpadding) = self
@@ -1417,7 +1422,6 @@ impl<'dom> LayoutElementHelpers<'dom> for LayoutDom<'dom, Element> {
             return;
         };
 
-        let document = self.upcast::<Node>().owner_doc_for_layout();
         let shared_lock = document.style_shared_lock();
         hints.push(ApplicableDeclarationBlock::from_declarations(
             Arc::new(shared_lock.wrap(property_declaration_block)),

--- a/tests/wpt/tests/quirks/tables-inherit-color-from-body-quirk-001.html
+++ b/tests/wpt/tests/quirks/tables-inherit-color-from-body-quirk-001.html
@@ -1,0 +1,22 @@
+<!-- Quirks Mode -->
+<title>Quirks Mode: The tables inherit color from body quirk - Table inside the body</title>
+<link rel="author" title="Oriol Brufau" href="obrufau@igalia.com">
+<link rel="help" href="https://quirks.spec.whatwg.org/#the-tables-inherit-color-from-body-quirk">
+<link rel="match" href="../css/reference/ref-filled-green-200px-square.html">
+<link rel="stylesheet" type="text/css" href="/fonts/ahem.css">
+<style>
+body { color: green; height: min-content; margin: 0; }
+p { color: initial; }
+div { color: red; display: flow-root; margin: 0 8px; }
+table { font: 200px/1 Ahem; }
+</style>
+<body>
+  <div>
+    <p>Test passes if there is a filled green square and <strong>no red</strong>.</p>
+    <table cellspacing="0" cellpadding="0">
+      <tr>
+        <td>X</td>
+      </tr>
+    </table>
+  </div>
+</body>

--- a/tests/wpt/tests/quirks/tables-inherit-color-from-body-quirk-002.html
+++ b/tests/wpt/tests/quirks/tables-inherit-color-from-body-quirk-002.html
@@ -1,0 +1,25 @@
+<!-- Quirks Mode -->
+<title>Quirks Mode: The tables inherit color from body quirk - Table after the body</title>
+<link rel="author" title="Oriol Brufau" href="obrufau@igalia.com">
+<link rel="help" href="https://quirks.spec.whatwg.org/#the-tables-inherit-color-from-body-quirk">
+<link rel="match" href="../css/reference/ref-filled-green-200px-square.html">
+<link rel="stylesheet" type="text/css" href="/fonts/ahem.css">
+<style>
+body { color: green; height: min-content; margin: 0; }
+p { color: initial; }
+div { color: red; display: flow-root; margin: 0 8px; }
+table { font: 200px/1 Ahem; }
+</style>
+<body>
+  <div>
+    <p>Test passes if there is a filled green square and <strong>no red</strong>.</p>
+    <table cellspacing="0" cellpadding="0">
+      <tr>
+        <td>X</td>
+      </tr>
+    </table>
+  </div>
+</body>
+<script>
+  document.body.after(document.querySelector("div"));
+</script>

--- a/tests/wpt/tests/quirks/tables-inherit-color-from-body-quirk-003.html
+++ b/tests/wpt/tests/quirks/tables-inherit-color-from-body-quirk-003.html
@@ -1,0 +1,25 @@
+<!-- Quirks Mode -->
+<title>Quirks Mode: The tables inherit color from body quirk - Table before the body</title>
+<link rel="author" title="Oriol Brufau" href="obrufau@igalia.com">
+<link rel="help" href="https://quirks.spec.whatwg.org/#the-tables-inherit-color-from-body-quirk">
+<link rel="match" href="../css/reference/ref-filled-green-200px-square.html">
+<link rel="stylesheet" type="text/css" href="/fonts/ahem.css">
+<style>
+body { color: green; height: min-content; margin: 0; }
+p { color: initial; }
+div { color: red; display: flow-root; margin: 0 8px; }
+table { font: 200px/1 Ahem; }
+</style>
+<body>
+  <div>
+    <p>Test passes if there is a filled green square and <strong>no red</strong>.</p>
+    <table cellspacing="0" cellpadding="0">
+      <tr>
+        <td>X</td>
+      </tr>
+    </table>
+  </div>
+</body>
+<script>
+  document.body.before(document.querySelector("div"));
+</script>

--- a/tests/wpt/tests/quirks/tables-inherit-color-from-body-quirk-004-ref.html
+++ b/tests/wpt/tests/quirks/tables-inherit-color-from-body-quirk-004-ref.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<title>Quirks Mode Reference: The tables inherit color from body quirk - Table with body removed, light mode</title>
+<link rel="author" title="Oriol Brufau" href="obrufau@igalia.com">
+<link rel="stylesheet" type="text/css" href="/fonts/ahem.css">
+<style>
+html { color-scheme: light; }
+p { color: initial; }
+table { font: 200px/1 Ahem; color: initial; }
+</style>
+<p>Test passes if there is a square filled with initial color and <strong>no red</strong>.</p>
+<table cellspacing="0" cellpadding="0">
+  <tr>
+    <td>X</td>
+  </tr>
+</table>

--- a/tests/wpt/tests/quirks/tables-inherit-color-from-body-quirk-004.html
+++ b/tests/wpt/tests/quirks/tables-inherit-color-from-body-quirk-004.html
@@ -1,0 +1,26 @@
+<!-- Quirks Mode -->
+<title>Quirks Mode: The tables inherit color from body quirk - Table with body removed, light mode</title>
+<link rel="author" title="Oriol Brufau" href="obrufau@igalia.com">
+<link rel="help" href="https://quirks.spec.whatwg.org/#the-tables-inherit-color-from-body-quirk">
+<link rel="match" href="tables-inherit-color-from-body-quirk-004-ref.html">
+<link rel="stylesheet" type="text/css" href="/fonts/ahem.css">
+<style>
+html { color-scheme: light; }
+body { color: green; height: min-content; margin: 0; }
+p { color: initial; }
+div { color: red; display: flow-root; margin: 0 8px; }
+table { font: 200px/1 Ahem; }
+</style>
+<body>
+  <div>
+    <p>Test passes if there is a square filled with initial color and <strong>no red</strong>.</p>
+    <table cellspacing="0" cellpadding="0">
+      <tr>
+        <td>X</td>
+      </tr>
+    </table>
+  </div>
+</body>
+<script>
+  document.body.replaceWith(document.querySelector("div"));
+</script>

--- a/tests/wpt/tests/quirks/tables-inherit-color-from-body-quirk-005-ref.html
+++ b/tests/wpt/tests/quirks/tables-inherit-color-from-body-quirk-005-ref.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<title>Quirks Mode Reference: The tables inherit color from body quirk - Table with body removed, light mode</title>
+<link rel="author" title="Oriol Brufau" href="obrufau@igalia.com">
+<link rel="stylesheet" type="text/css" href="/fonts/ahem.css">
+<style>
+html { color-scheme: dark; }
+p { color: initial; }
+table { font: 200px/1 Ahem; color: initial; }
+</style>
+<p>Test passes if there is a square filled with initial color and <strong>no red</strong>.</p>
+<table cellspacing="0" cellpadding="0">
+  <tr>
+    <td>X</td>
+  </tr>
+</table>

--- a/tests/wpt/tests/quirks/tables-inherit-color-from-body-quirk-005.html
+++ b/tests/wpt/tests/quirks/tables-inherit-color-from-body-quirk-005.html
@@ -1,0 +1,26 @@
+<!-- Quirks Mode -->
+<title>Quirks Mode: The tables inherit color from body quirk - Table with body removed, dark mode</title>
+<link rel="author" title="Oriol Brufau" href="obrufau@igalia.com">
+<link rel="help" href="https://quirks.spec.whatwg.org/#the-tables-inherit-color-from-body-quirk">
+<link rel="match" href="tables-inherit-color-from-body-quirk-005-ref.html">
+<link rel="stylesheet" type="text/css" href="/fonts/ahem.css">
+<style>
+html { color-scheme: dark; }
+body { color: green; height: min-content; margin: 0; }
+p { color: initial; }
+div { color: red; display: flow-root; margin: 0 8px; }
+table { font: 200px/1 Ahem; }
+</style>
+<body>
+  <div>
+    <p>Test passes if there is a square filled with initial color and <strong>no red</strong>.</p>
+    <table cellspacing="0" cellpadding="0">
+      <tr>
+        <td>X</td>
+      </tr>
+    </table>
+  </div>
+</body>
+<script>
+  document.body.replaceWith(document.querySelector("div"));
+</script>

--- a/tests/wpt/tests/quirks/tables-inherit-color-from-body-quirk-006.html
+++ b/tests/wpt/tests/quirks/tables-inherit-color-from-body-quirk-006.html
@@ -1,0 +1,30 @@
+<!-- Quirks Mode -->
+<title>Quirks Mode: The tables inherit color from body quirk - Table without body, light mode</title>
+<link rel="author" title="Oriol Brufau" href="obrufau@igalia.com">
+<link rel="help" href="https://quirks.spec.whatwg.org/#the-tables-inherit-color-from-body-quirk">
+<link rel="match" href="tables-inherit-color-from-body-quirk-004-ref.html">
+<link rel="stylesheet" type="text/css" href="/fonts/ahem.css">
+<style>
+html { color-scheme: light; }
+body { color: green; height: min-content; margin: 0; }
+p { color: initial; }
+div { color: red; display: flow-root; margin: 0 8px; }
+table { font: 200px/1 Ahem; }
+</style>
+<script>
+  // At this point, the <body> has not been created yet.
+  // And replacing the <html> prevents the creation of the <body>.
+  let root = document.documentElement;
+  let div = document.createElement("div");
+  div.innerHTML = `
+    <p>Test passes if there is a square filled with initial color and <strong>no red</strong>.</p>
+    <table cellspacing="0" cellpadding="0">
+      <tr>
+        <td>X</td>
+      </tr>
+    </table>
+  `;
+  root.append(div);
+  document.documentElement.remove();
+  document.append(root.cloneNode(true));
+</script>

--- a/tests/wpt/tests/quirks/tables-inherit-color-from-body-quirk-007.html
+++ b/tests/wpt/tests/quirks/tables-inherit-color-from-body-quirk-007.html
@@ -1,0 +1,30 @@
+<!-- Quirks Mode -->
+<title>Quirks Mode: The tables inherit color from body quirk - Table without body, dark mode</title>
+<link rel="author" title="Oriol Brufau" href="obrufau@igalia.com">
+<link rel="help" href="https://quirks.spec.whatwg.org/#the-tables-inherit-color-from-body-quirk">
+<link rel="match" href="tables-inherit-color-from-body-quirk-005-ref.html">
+<link rel="stylesheet" type="text/css" href="/fonts/ahem.css">
+<style>
+html { color-scheme: dark; }
+body { color: green; height: min-content; margin: 0; }
+p { color: initial; }
+div { color: red; display: flow-root; margin: 0 8px; }
+table { font: 200px/1 Ahem; }
+</style>
+<script>
+  // At this point, the <body> has not been created yet.
+  // And replacing the <html> prevents the creation of the <body>.
+  let root = document.documentElement;
+  let div = document.createElement("div");
+  div.innerHTML = `
+    <p>Test passes if there is a square filled with initial color and <strong>no red</strong>.</p>
+    <table cellspacing="0" cellpadding="0">
+      <tr>
+        <td>X</td>
+      </tr>
+    </table>
+  `;
+  root.append(div);
+  document.documentElement.remove();
+  document.append(root.cloneNode(true));
+</script>


### PR DESCRIPTION
Bumps Stylo to https://github.com/servo/stylo/pull/333

Spec: https://quirks.spec.whatwg.org/#the-tables-inherit-color-from-body-quirk

Testing: Adding 7 new tests. They expose some bugs in other browsers:
 - WebKit and Blink don't use the body color when the table appears before the body
 - Firefox uses the body color even after removing the body
