### PR TITLE
layout: Add `effective_visual_size` to `PaintTimingHandler`

### DIFF
--- a/components/layout/display_list/mod.rs
+++ b/components/layout/display_list/mod.rs
@@ -648,13 +648,16 @@ impl DisplayListBuilder<'_> {
         }
     }
 
+    #[allow(clippy::too_many_arguments)]
     fn check_for_lcp_candidate(
         &mut self,
         state: &TraversalState,
-        clip_rect: LayoutRect,
         bounds: LayoutRect,
+        clip_rect: LayoutRect,
         tag: Option<Tag>,
         url: Option<ServoUrl>,
+        natural_width: Option<Au>,
+        natural_height: Option<Au>,
     ) {
         if !pref!(largest_contentful_paint_enabled) {
             return;
@@ -665,8 +668,15 @@ impl DisplayListBuilder<'_> {
             .scroll_tree
             .cumulative_node_to_root_transform(state.spatial_id);
 
-        self.paint_timing_handler
-            .update_lcp_candidate(tag, bounds, clip_rect, transform, url);
+        self.paint_timing_handler.compute_new_lcp_candidate(
+            tag,
+            bounds,
+            clip_rect,
+            transform,
+            url,
+            natural_width,
+            natural_height,
+        );
     }
 
     fn visit_stacking_context_reference_frame_info(
@@ -843,10 +853,12 @@ impl PaintTraversalHandler for DisplayListBuilder<'_> {
 
                 self.check_for_lcp_candidate(
                     state,
-                    common.clip_rect,
                     rect,
+                    common.clip_rect,
                     fragment.base.tag,
                     fragment.url.clone(),
+                    fragment.natural_width,
+                    fragment.natural_height,
                 );
             }
         }
@@ -1894,12 +1906,16 @@ impl<'a> BuilderForBoxFragment<'a> {
                         // > background-size has non-zero width and height values.
                         builder.mark_is_contentful();
 
+                        let natural_width = Some(Au::from_f32_px(size.width / dppx));
+                        let natural_height = Some(Au::from_f32_px(size.height / dppx));
                         builder.check_for_lcp_candidate(
                             state,
-                            layer.common.clip_rect,
                             layer.bounds,
+                            layer.common.clip_rect,
                             self.fragment.base.tag,
                             None,
+                            natural_width,
+                            natural_height,
                         );
                     }
                 },

--- a/components/layout/display_list/paint_timing_handler.rs
+++ b/components/layout/display_list/paint_timing_handler.rs
@@ -7,13 +7,13 @@ use std::collections::HashSet;
 use app_units::Au;
 use euclid::Rect;
 use paint_api::largest_contentful_paint_candidate::{LCPCandidate, LCPCandidateID};
-use servo_geometry::{FastLayoutTransform, au_rect_to_f32_rect, f32_rect_to_au_rect};
+use servo_geometry::FastLayoutTransform;
 use servo_url::ServoUrl;
 use style::dom::OpaqueNode;
 use webrender_api::units::{LayoutRect, LayoutSize};
 
 use crate::fragment_tree::Tag;
-use crate::query::transform_au_rectangle;
+use crate::query::transform_f32_rectangle;
 
 pub(crate) struct PaintTimingHandler {
     /// The rect of viewport.
@@ -109,12 +109,8 @@ impl PaintTimingHandler {
 
         // Step 8.4: Let clientContentRect be the smallest DOMRectReadOnly
         // containing visibleDimensions with element's transforms applied.
-        let client_content_rect = transform_au_rectangle(
-            f32_rect_to_au_rect(visible_dimensions.to_rect().cast_unit()),
-            transform,
-        )
-        .unwrap_or_default();
-        let client_content_rect = au_rect_to_f32_rect(client_content_rect);
+        let client_content_rect =
+            transform_f32_rectangle(visible_dimensions.to_rect(), transform).unwrap_or_default();
 
         // Step 8.5: Let intersectingClientContentRect be the intersection of
         // clientContentRect with intersectionRect.

--- a/components/layout/display_list/paint_timing_handler.rs
+++ b/components/layout/display_list/paint_timing_handler.rs
@@ -4,12 +4,12 @@
 
 use std::collections::HashSet;
 
+use app_units::Au;
 use euclid::Rect;
 use paint_api::largest_contentful_paint_candidate::{LCPCandidate, LCPCandidateID};
 use servo_geometry::{FastLayoutTransform, au_rect_to_f32_rect, f32_rect_to_au_rect};
 use servo_url::ServoUrl;
 use style::dom::OpaqueNode;
-use style_traits::CSSPixel;
 use webrender_api::units::{LayoutRect, LayoutSize};
 
 use crate::fragment_tree::Tag;
@@ -60,37 +60,112 @@ impl PaintTimingHandler {
         !bounding_rect.is_empty()
     }
 
-    fn calculate_intersection_rect(
+    /// <https://www.w3.org/TR/largest-contentful-paint/#sec-effective-visual-size>
+    fn effective_visual_size(
         &self,
         bounds: LayoutRect,
         clip_rect: LayoutRect,
+        intersection_rect: LayoutRect,
         transform: FastLayoutTransform,
-    ) -> Rect<f32, CSSPixel> {
-        let clipped_rect = bounds
+        natural_width: Option<Au>,
+        natural_height: Option<Au>,
+    ) -> Option<f32> {
+        // Step 1. Let width be intersectionRect's width, rounded up to the
+        // nearest integer.
+        // Step 2. Let height be intersectionRect's height, rounded up to the
+        // nearest integer.
+        // Step 3. Let size be width * height.
+        let size = intersection_rect.area();
+
+        // Step 4. Let root be document's browsing context's top-level browsing
+        // context's active document.
+        // Note: This is not needed as we already have the viewport rect.
+
+        // Step 5. Let rootWidth be root's visual viewport's width,
+        // excluding any scrollbars.
+        // Step 6. Let rootHeight be root's visual viewport's height excluding
+        // any scrollbars.
+        // Step 7. If size is equal to rootWidth times rootHeight, return null.
+        if size >= self.viewport_rect.area() {
+            return None;
+        }
+
+        // Step 8: If imageRequest is not null, run the following steps to
+        // adjust for image position and upscaling:
+        // Note: This is handled by check for [showing_broken_image_icon] earlier
+
+        // TODO Step 8.1: If imageRequest's response's content length in bytes
+        // is less than size * 0.004, then return null. (Not Implemented)
+
+        // Step 8.2: Let concreteDimensions be imageRequest's concrete object
+        // size within element.
+        // Step 8.3: Let visibleDimensions be concreteDimensions, adjusted for
+        // positioning by object-position or background-position and element's
+        // content box.
+        // Note: bounds are already adjusted for positioning and content box
+        let visible_dimensions = bounds
             .intersection(&clip_rect)
             .unwrap_or(LayoutRect::zero());
 
-        let transformed_rect = transform_au_rectangle(
-            f32_rect_to_au_rect(clipped_rect.to_rect().cast_unit()),
+        // Step 8.4: Let clientContentRect be the smallest DOMRectReadOnly
+        // containing visibleDimensions with element's transforms applied.
+        let client_content_rect = transform_au_rectangle(
+            f32_rect_to_au_rect(visible_dimensions.to_rect().cast_unit()),
             transform,
         )
         .unwrap_or_default();
+        let client_content_rect = au_rect_to_f32_rect(client_content_rect);
 
-        let transformed_rect = au_rect_to_f32_rect(transformed_rect);
+        // Step 8.5: Let intersectingClientContentRect be the intersection of
+        // clientContentRect with intersectionRect.
+        let intersecting_client_content_rect = client_content_rect
+            .intersection(&intersection_rect.to_rect())
+            .unwrap_or(Rect::zero());
 
-        let intersection_rect =
-            transformed_rect.intersection(&self.viewport_rect.to_rect().cast_unit());
+        // Step 8.6: Set width to intersectingClientContentRect's width,
+        // rounded up to the nearest integer.
+        // Step 8.7: Set height to intersectingClientContentRect's height,
+        // rounded up to the nearest integer.
+        // Step 8.8: Set size to width * height.
+        let mut size = intersecting_client_content_rect.area();
 
-        intersection_rect.unwrap_or(Rect::zero())
+        // Step 8.9: Let naturalArea be imageRequest's natural width * imageRequest's natural height.
+        if let (Some(natural_width), Some(natural_height)) = (natural_width, natural_height) {
+            let natural_area = natural_width.to_f32_px() * natural_height.to_f32_px();
+
+            // Step 8.10: If naturalArea is 0, then return null.
+            if natural_area == 0.0 {
+                return None;
+            }
+            // Step 8.11: Let boundingClientArea be clientContentRect's width *
+            // clientContentRect's height.
+            let bounding_client_area = client_content_rect.width() * client_content_rect.height();
+
+            // Step 8.12: Let scaleFactor be boundingClientArea / naturalArea.
+            let scale_factor = bounding_client_area / natural_area;
+
+            // Step 8.13: If scaleFactor is greater than 1, then divide size by scaleFactor.
+            if scale_factor > 1.0 {
+                size /= scale_factor;
+            }
+        }
+
+        // Step 9: Return an effective visual size result with size set to size,
+        // width set to width, and height set to height.
+        Some(size)
     }
 
-    pub(crate) fn update_lcp_candidate(
+    /// <https://www.w3.org/TR/largest-contentful-paint/#compute-a-new-largest-contentful-paint-candidate>
+    #[allow(clippy::too_many_arguments)]
+    pub(crate) fn compute_new_lcp_candidate(
         &mut self,
         tag: Option<Tag>,
         bounds: LayoutRect,
         clip_rect: LayoutRect,
         transform: FastLayoutTransform,
         url: Option<ServoUrl>,
+        natural_width: Option<Au>,
+        natural_height: Option<Au>,
     ) {
         // From <https://www.w3.org/TR/largest-contentful-paint/#sec-report-largest-contentful-paint>:
         // Each pending image record in paintedImages and text element in
@@ -104,24 +179,53 @@ impl PaintTimingHandler {
             return;
         }
 
-        // From <https://www.w3.org/TR/largest-contentful-paint/#sec-report-largest-contentful-paint>:
-        //  Let intersectionRect be the value returned by the intersection rect algorithm using imageElement as the target and viewport as the root.
-        let intersection_rect = self.calculate_intersection_rect(bounds, clip_rect, transform);
+        // Step 4.1. Let imageElement be record’s element.
+        // TODO Step 4.2. If imageElement is not exposed for paint timing, given
+        // document, continue.
+        // Note: We are only dealing with images for now.
 
-        // Let size be the effective visual size of candidate’s element given intersectionRect.
-        let size = intersection_rect.size.width * intersection_rect.size.height;
+        // Step 4.3. Let intersectionRect be the value returned by the intersection rect
+        // algorithm using imageElement as the target and viewport as the root.
+        let intersection_rect = transform_f32_rectangle(clip_rect.to_rect(), transform)
+            .unwrap_or_default()
+            .intersection(&self.viewport_rect.to_rect())
+            .map(|rect| rect.to_box2d())
+            .unwrap_or_default();
 
-        // If size is less than or equal to document’s largest contentful paint size, return.
-        if size <= self.lcp_size {
+        // Step 4.4. Let result be the effective visual size of imageElement
+        // given intersectionRect and record’s request.
+        let result = self.effective_visual_size(
+            bounds,
+            clip_rect,
+            intersection_rect,
+            transform,
+            natural_width,
+            natural_height,
+        );
+
+        // Step 4.5. If result is null, continue.
+        let Some(result) = result else {
+            return;
+        };
+
+        // Step 4.6. If result’s size is less than or equal to largestSize, continue.
+        if result <= self.lcp_size {
             return;
         }
 
+        // Step 4.7. Set largestSize to result’s size.
+        self.lcp_size = result;
+
         let uuid = self.lcp_next_uuid;
         self.lcp_next_uuid += 1;
-
-        self.lcp_size = size;
         self.lcp_node = tag.map(|tag| tag.node);
-        self.lcp_candidate = Some(LCPCandidate::new(LCPCandidateID(uuid), size as usize, url));
+
+        // Step 4.8. Set newCandidate to be a new largest contentful paint candidate ...
+        self.lcp_candidate = Some(LCPCandidate::new(
+            LCPCandidateID(uuid),
+            self.lcp_size as usize,
+            url,
+        ));
 
         self.lcp_candidate_updated = true;
     }

--- a/components/layout/fragment_tree/fragment.rs
+++ b/components/layout/fragment_tree/fragment.rs
@@ -119,6 +119,10 @@ pub(crate) struct ImageFragment {
     pub image_key: Option<ImageKey>,
     pub showing_broken_image_icon: bool,
     pub url: Option<ServoUrl>,
+    /// The intrinsic (natural) width of the image, if known.
+    pub natural_width: Option<Au>,
+    /// The intrinsic (natural) height of the image, if known.
+    pub natural_height: Option<Au>,
 }
 
 #[derive(MallocSizeOf)]

--- a/components/layout/query.rs
+++ b/components/layout/query.rs
@@ -45,6 +45,7 @@ use style::values::generics::position::AspectRatio;
 use style::values::specified::GenericGridTemplateComponent;
 use style::values::specified::box_::DisplayInside;
 use style_traits::{CSSPixel, ParsingMode, ToCss};
+use webrender_api::units::LayoutPixel;
 
 use crate::cell::RefOrAtomicRef;
 use crate::display_list::{StackingContextTree, au_rect_to_length_rect};
@@ -1581,14 +1582,23 @@ pub(crate) fn transform_au_rectangle(
     rect_to_transform: Rect<Au, CSSPixel>,
     transform: FastLayoutTransform,
 ) -> Option<Rect<Au, CSSPixel>> {
-    let rect_to_transform = &au_rect_to_f32_rect(rect_to_transform).cast_unit();
-    let outer_transformed_rect = match transform {
+    transform_f32_rectangle(
+        au_rect_to_f32_rect(rect_to_transform).cast_unit(),
+        transform,
+    )
+    .map(|transformed_rect| f32_rect_to_au_rect(transformed_rect).cast_unit())
+}
+
+pub(crate) fn transform_f32_rectangle(
+    rect_to_transform: Rect<f32, LayoutPixel>,
+    transform: FastLayoutTransform,
+) -> Option<Rect<f32, LayoutPixel>> {
+    match transform {
         FastLayoutTransform::Offset(offset) => Some(rect_to_transform.translate(offset)),
         FastLayoutTransform::Transform { transform, .. } => {
-            transform.outer_transformed_rect(rect_to_transform)
+            transform.outer_transformed_rect(&rect_to_transform)
         },
-    };
-    outer_transformed_rect.map(|transformed_rect| f32_rect_to_au_rect(transformed_rect).cast_unit())
+    }
 }
 
 pub(crate) fn process_effective_overflow_query(node: ServoLayoutNode<'_>) -> Option<AxesOverflow> {

--- a/components/layout/replaced.rs
+++ b/components/layout/replaced.rs
@@ -539,6 +539,8 @@ impl ReplacedContents {
                         image_key: Some(image_key),
                         showing_broken_image_icon: image_info.showing_broken_image_icon,
                         url: image_info.url.clone(),
+                        natural_width: self.natural_size.width,
+                        natural_height: self.natural_size.height,
                     }))
                 })
                 .into_iter()
@@ -551,6 +553,8 @@ impl ReplacedContents {
                     image_key: video_info.image_key,
                     showing_broken_image_icon: false,
                     url: video_info.poster_url.clone(),
+                    natural_width: self.natural_size.width,
+                    natural_height: self.natural_size.height,
                 }))]
             },
             ReplacedContentKind::IFrame(iframe) => {
@@ -593,6 +597,8 @@ impl ReplacedContents {
                     image_key: Some(image_key),
                     showing_broken_image_icon: false,
                     url: None,
+                    natural_width: self.natural_size.width,
+                    natural_height: self.natural_size.height,
                 }))]
             },
             ReplacedContentKind::SVGElement {
@@ -646,6 +652,8 @@ impl ReplacedContents {
                             image_key: Some(image_key),
                             showing_broken_image_icon: false,
                             url: None,
+                            natural_width: self.natural_size.width,
+                            natural_height: self.natural_size.height,
                         }))
                     })
                     .into_iter()

--- a/components/servo/tests/largest_contentful_paint.rs
+++ b/components/servo/tests/largest_contentful_paint.rs
@@ -63,7 +63,7 @@ fn test_largest_contentful_paint_js_api() {
             obj.get("entryType"),
             Some(JSValue::String("largest-contentful-paint".into())).as_ref()
         );
-        assert_eq!(obj.get("size"), Some(JSValue::Number(2500.0)).as_ref());
+        assert_eq!(obj.get("size"), Some(JSValue::Number(4.0)).as_ref());
         assert!(obj.get("renderTime").is_some());
         assert!(obj.get("loadTime").is_some());
     } else {

--- a/tests/wpt/meta/largest-contentful-paint/image-full-viewport.html.ini
+++ b/tests/wpt/meta/largest-contentful-paint/image-full-viewport.html.ini
@@ -1,3 +1,4 @@
 [image-full-viewport.html]
+  expected: TIMEOUT
   [The intersectionRect of an img element overflowing is computed correctly]
-    expected: FAIL
+    expected: TIMEOUT

--- a/tests/wpt/meta/largest-contentful-paint/image-upscaling-empty-url.html.ini
+++ b/tests/wpt/meta/largest-contentful-paint/image-upscaling-empty-url.html.ini
@@ -1,6 +1,0 @@
-[image-upscaling-empty-url.html]
-  [An upscaled image (width/height) should report the natural size]
-    expected: FAIL
-
-  [A background image smaller than the container should report the natural size]
-    expected: FAIL

--- a/tests/wpt/meta/largest-contentful-paint/initially-invisible-images.html.ini
+++ b/tests/wpt/meta/largest-contentful-paint/initially-invisible-images.html.ini
@@ -1,4 +1,2 @@
 [initially-invisible-images.html]
   expected: ERROR
-  [Image visibility: out-of-viewport images are observable by LargestContentfulPaint once they become visible.]
-    expected: FAIL


### PR DESCRIPTION
Align size calculations as much as possible close to W3C specs

Testing: More WPT Passed
Fixes: Part of #42000
