### PR TITLE
layout: Render the caret on the last empty line of `<textarea>` elements

### DIFF
--- a/components/layout/flow/construct.rs
+++ b/components/layout/flow/construct.rs
@@ -226,6 +226,26 @@ impl BlockContainer {
         }
 
         contents.traverse(context, info, &mut builder);
+
+        // This serves two purposes:
+        // 1. Single line text inputs have a default preferred size, which means they are as tall as
+        //    the default text no matter if they are empty. Adding a newline here forces the creation
+        //    of an internal inline formatting context for these fields, meaning that they will have
+        //    at least one line as tall as the font line gap.
+        //    See <https://drafts.csswg.org/css-forms-1/#element-with-default-preferred-size>
+        // 2. When `<textarea>` elements end with a forced newline (not this one), then no final
+        //    line / content is added, as with other inline formatting contexts. Adding one more forced
+        //    newline here flushes the final newline and adds a strut for rendering a caret on the last
+        //    empty line.
+        //
+        // TODO: This may have some negative sizing effects when we implement the `field-sizing`
+        // property, so likely we need to do a bit more work then to force the creation an an empty
+        // inline formatting context and properly handle a final empty line. For now this is just a
+        // workaround.
+        if info.node.is_single_line_text_input_or_textarea() {
+            builder.handle_text(info, Cow::Borrowed("\n"));
+        }
+
         builder.finish()
     }
 }

--- a/components/script/dom/html/htmlinputelement.rs
+++ b/components/script/dom/html/htmlinputelement.rs
@@ -251,25 +251,16 @@ impl TextInputWidgetShadowTree {
     // TODO(stevennovaryo): The rest of textual input shadow dom structure should act
     // like an exstension to this one.
     fn update(&self, input_element: &HTMLInputElement) {
-        // The addition of zero-width space here forces the text input to have an inline formatting
-        // context that might otherwise be trimmed if there's no text. This is important to ensure
-        // that the input element is at least as tall as the line gap of the caret:
-        // <https://drafts.csswg.org/css-ui/#element-with-default-preferred-size>.
-        //
-        // This is also used to ensure that the caret will still be rendered when the input is empty.
-        // TODO: Could append `<br>` element to prevent collapses and avoid this hack, but we would
-        //       need to fix the rendering of caret beforehand.
         let value = input_element.Value();
-        let value_text = match (value.is_empty(), input_element.input_type()) {
+        let value_text = match input_element.input_type() {
             // For a password input, we replace all of the character with its replacement char.
-            (false, InputType::Password) => value
+            InputType::Password => value
                 .str()
                 .chars()
                 .map(|_| PASSWORD_REPLACEMENT_CHAR)
                 .collect::<String>()
                 .into(),
-            (false, _) => value,
-            (true, _) => "\u{200B}".into(),
+            _ => value,
         };
 
         if let Some(character_data) = self.value_character_data() {

--- a/components/script/dom/html/htmltextareaelement.rs
+++ b/components/script/dom/html/htmltextareaelement.rs
@@ -239,12 +239,6 @@ impl HTMLTextAreaElement {
                 .replace("\r\n", "\n")
                 .replace('\r', "\n")
                 .into()
-        } else if textinput_content.is_empty() {
-            // The addition of zero-width space here forces the text input to have an inline formatting
-            // context that might otherwise be trimmed if there's no text. This is important to ensure
-            // that the input element is at least as tall as the line gap of the caret:
-            // <https://drafts.csswg.org/css-ui/#element-with-default-preferred-size>.
-            "\u{200B}".into()
         } else {
             textinput_content
         };

--- a/components/script/dom/node.rs
+++ b/components/script/dom/node.rs
@@ -2131,13 +2131,10 @@ pub(crate) trait LayoutNodeHelpers<'dom> {
     /// attempting to read or modify the opaque layout data of this node.
     unsafe fn clear_style_and_layout_data(self);
 
-    /// Whether this element serve as a container of editable text for a text input
-    /// that is implemented as an UA widget.
-    fn is_single_line_text_inner_editor(&self) -> bool;
-
     /// Whether this element serve as a container of any text inside a text input
     /// that is implemented as an UA widget.
-    fn is_text_container_of_single_line_input(&self) -> bool;
+    fn is_text_field_for_single_line_text_input(&self) -> bool;
+
     fn text_content(self) -> Cow<'dom, str>;
     fn selection(self) -> Option<SharedSelection>;
     fn image_url(self) -> Option<ServoUrl>;
@@ -2318,28 +2315,11 @@ impl<'dom> LayoutNodeHelpers<'dom> for LayoutDom<'dom, Node> {
         }
     }
 
-    fn is_single_line_text_inner_editor(&self) -> bool {
+    fn is_text_field_for_single_line_text_input(&self) -> bool {
         matches!(
             self.implemented_pseudo_element(),
-            Some(PseudoElement::ServoTextControlInnerEditor)
+            Some(PseudoElement::Placeholder | PseudoElement::ServoTextControlInnerEditor)
         )
-    }
-
-    fn is_text_container_of_single_line_input(&self) -> bool {
-        let is_single_line_text_inner_placeholder = matches!(
-            self.implemented_pseudo_element(),
-            Some(PseudoElement::Placeholder)
-        );
-        // Currently `::placeholder` is only implemented for single line text input element.
-        debug_assert!(
-            !is_single_line_text_inner_placeholder ||
-                self.containing_shadow_root_for_layout()
-                    .map(|root| root.get_host_for_layout())
-                    .map(|host| host.downcast::<HTMLInputElement>())
-                    .is_some()
-        );
-
-        self.is_single_line_text_inner_editor() || is_single_line_text_inner_placeholder
     }
 
     fn text_content(self) -> Cow<'dom, str> {

--- a/components/script/layout_dom/node.rs
+++ b/components/script/layout_dom/node.rs
@@ -303,17 +303,22 @@ impl<'dom> ServoThreadSafeLayoutNode<'dom> {
             .map(Self::new)
     }
 
-    /// Whether this is a container for the text within a single-line text input. This
-    /// is used to solve the special case of line height for a text entry widget.
-    /// <https://html.spec.whatwg.org/multipage/#the-input-element-as-a-text-entry-widget>
-    // TODO(stevennovaryo): Remove the addition of HTMLInputElement here once all of the
-    //                      input element is implemented with UA shadow DOM. This is temporary
-    //                      workaround for past version of input element where we are
-    //                      rendering it as a bare html element.
+    /// Whether this is a container for the text within a single-line textual `<input>` element.
     pub fn is_single_line_text_input(&self) -> bool {
-        self.type_id() == Some(LayoutNodeType::Element(LayoutElementType::HTMLInputElement)) ||
-            (self.pseudo_element_chain.is_empty() &&
-                self.node.node.is_text_container_of_single_line_input())
+        self.pseudo_element_chain.is_empty() &&
+            self.node.node.is_text_field_for_single_line_text_input()
+    }
+
+    /// Whether this is a container for the text within a single-line textual `<input>` or a
+    /// `<textarea>` element.
+    pub fn is_single_line_text_input_or_textarea(&self) -> bool {
+        self.is_single_line_text_input() ||
+            matches!(
+                self.type_id(),
+                Some(LayoutNodeType::Element(
+                    LayoutElementType::HTMLTextAreaElement
+                ))
+            )
     }
 
     pub fn selected_style(&self, context: &SharedStyleContext) -> Arc<ComputedValues> {

--- a/tests/wpt/mozilla/meta/MANIFEST.json
+++ b/tests/wpt/mozilla/meta/MANIFEST.json
@@ -295,6 +295,19 @@
       {}
      ]
     ],
+    "textarea-caret-following-linebreak-last-line.html": [
+     "d526f4771f3778cfbd367069a2e678ca4e25305d",
+     [
+      null,
+      [
+       [
+        "/_mozilla/appearance/textarea-caret-following-linebreak-last-line-ref.html",
+        "=="
+       ]
+      ],
+      {}
+     ]
+    ],
     "textarea-caret-following-linebreak.html": [
      "55bc06e372e9ce8ad4d62d368a644c1f1cd3ffd9",
      [
@@ -8372,6 +8385,10 @@
     ],
     "textarea-caret-following-linebreak-blank-line-ref.html": [
      "5e70ba743b12012fe3b1116414107cf50ef6a8ab",
+     []
+    ],
+    "textarea-caret-following-linebreak-last-line-ref.html": [
+     "35d4565fbe85244236ffc9c9c8d8821878604ef3",
      []
     ],
     "textarea-caret-following-linebreak-ref.html": [

--- a/tests/wpt/mozilla/tests/appearance/textarea-caret-following-linebreak-last-line-ref.html
+++ b/tests/wpt/mozilla/tests/appearance/textarea-caret-following-linebreak-last-line-ref.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <style>
+    textarea {
+        caret-animation: manual;
+    }
+    </style>
+</head>
+<body>
+    <textarea id="target" cols=50 rows="5">ABC&#13;&#13;</textarea>
+    <script>
+        target.focus();
+        target.setSelectionRange(4, 4);
+    </script>
+</body>

--- a/tests/wpt/mozilla/tests/appearance/textarea-caret-following-linebreak-last-line.html
+++ b/tests/wpt/mozilla/tests/appearance/textarea-caret-following-linebreak-last-line.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <link rel="match" href="textarea-caret-following-linebreak-last-line-ref.html">
+    <style>
+    textarea {
+        caret-animation: manual;
+    }
+    </style>
+</head>
+<body>
+    <textarea id="target" cols=50 rows="5">ABC&#13;</textarea>
+    <script>
+        target.focus();
+        target.setSelectionRange(4, 4);
+    </script>
+</body>


### PR DESCRIPTION
This change adds a workaround that allows the text caret to render
properly on the last empty line of `<textare>` elements. In addition,
the workaround replaces the existing workaround for creating inline
formatting contexts in empty textual `<input>` and `<textarea>`
elements for sizing and caret rendering.

Testing: This change adds a Servo-specific appearance test for this case.
Fixes: #41338.
