### PR TITLE
script: Prevent invisible elements from being focusable

### DIFF
--- a/components/script/dom/element.rs
+++ b/components/script/dom/element.rs
@@ -37,6 +37,7 @@ use selectors::sink::Push;
 use servo_arc::Arc;
 use style::applicable_declarations::ApplicableDeclarationBlock;
 use style::attr::{AttrValue, LengthOrPercentageOrAuto};
+use style::computed_values::visibility::T as Visibility;
 use style::context::QuirksMode;
 use style::invalidation::element::restyle_hints::RestyleHint;
 use style::properties::longhands::{
@@ -1805,6 +1806,15 @@ impl Element {
         // Do not allow unrendered, disconnected, or disabled nodes to be focusable areas ever.
         let node: &Node = self.upcast();
         if !node.is_connected() || !self.has_css_layout_box() || self.is_actually_disabled() {
+            return Default::default();
+        }
+
+        // <https://www.w3.org/TR/css-display-4/#visibility>
+        // Invisible elements are removed from navigation.
+        if self
+            .style()
+            .is_some_and(|style| style.get_inherited_box().visibility != Visibility::Visible)
+        {
             return Default::default();
         }
 

--- a/tests/wpt/meta/html/interaction/focus/processing-model/focus-fixup-rule-one-no-dialogs.html.ini
+++ b/tests/wpt/meta/html/interaction/focus/processing-model/focus-fixup-rule-one-no-dialogs.html.ini
@@ -9,4 +9,4 @@
     expected: FAIL
 
   [#button6]
-    expected: FAIL
+    expected: PASS

--- a/tests/wpt/meta/webdriver/tests/classic/element_send_keys/interactability.py.ini
+++ b/tests/wpt/meta/webdriver/tests/classic/element_send_keys/interactability.py.ini
@@ -2,8 +2,5 @@
   [test_document_element_is_interactable]
     expected: FAIL
 
-  [test_visibility_hidden]
-    expected: FAIL
-
   [test_readonly_element]
     expected: FAIL


### PR DESCRIPTION
Elements with `visibility: hidden` or `visibility: collapse` could receive focus via both sequential navigation and the JS `focus()` API, and already-focused elements did not lose focus when becoming invisible. Per the CSS Display spec, invisible elements ”are removed from navigation”, which we can interpret to mean sequential focus navigation. In practical terms, all popular user agents also prevent elements with `visibility: hidden` from being focusable via click/the JS API, so this PR makes servo match that behaviour as well.

Specifically, this adds a visibility check to `Element::focusable_area_kind()` so that invisible elements are excluded from all focusable area kinds.

Fixes #41312.