### PR TITLE
script: Pass `&mut JSContext` to `ReadableStream::cancel`

### DIFF
--- a/components/script/dom/abortsignal.rs
+++ b/components/script/dom/abortsignal.rs
@@ -199,7 +199,7 @@ impl AbortSignal {
                 rooted!(&in(cx) let mut reason = UndefinedValue());
                 reason.set(self.abort_reason.get());
                 if let Some(fetch_context) = &mut *fetch_context.lock().unwrap() {
-                    fetch_context.abort_fetch(reason.handle(), cx.into(), CanGc::from_cx(cx));
+                    fetch_context.abort_fetch(reason.handle(), cx);
                 }
             },
             AbortAlgorithm::FetchLater(deferred_fetch_record_id) => {

--- a/components/script/dom/stream/byteteereadintorequest.rs
+++ b/components/script/dom/stream/byteteereadintorequest.rs
@@ -159,12 +159,9 @@ impl ByteTeeReadIntoRequest {
                 other_branch_controller.error(error_value.handle(), CanGc::from_cx(cx));
 
                 // Resolve cancelPromise with ! ReadableStreamCancel(stream, cloneResult.[[Value]]).
-                let cancel_result = self.stream.cancel(
-                    cx.into(),
-                    &self.stream.global(),
-                    error_value.handle(),
-                    CanGc::from_cx(cx),
-                );
+                let cancel_result =
+                    self.stream
+                        .cancel(cx, &self.stream.global(), error_value.handle());
                 self.cancel_promise
                     .resolve_native(&cancel_result, CanGc::from_cx(cx));
 

--- a/components/script/dom/stream/byteteereadrequest.rs
+++ b/components/script/dom/stream/byteteereadrequest.rs
@@ -146,12 +146,9 @@ impl ByteTeeReadRequest {
             branch_1_controller.error(error_value.handle(), CanGc::from_cx(cx));
             branch_2_controller.error(error_value.handle(), CanGc::from_cx(cx));
 
-            let cancel_result = self.stream.cancel(
-                cx.into(),
-                &self.stream.global(),
-                error_value.handle(),
-                CanGc::from_cx(cx),
-            );
+            let cancel_result = self
+                .stream
+                .cancel(cx, &self.stream.global(), error_value.handle());
             self.cancel_promise
                 .resolve_native(&cancel_result, CanGc::from_cx(cx));
         };

--- a/components/script/dom/stream/byteteeunderlyingsource.rs
+++ b/components/script/dom/stream/byteteeunderlyingsource.rs
@@ -431,8 +431,8 @@ impl ByteTeeUnderlyingSource {
     /// Let cancel2Algorithm be the following steps, taking a reason argument
     pub(crate) fn cancel_algorithm(
         &self,
+        cx: &mut js::context::JSContext,
         reason: SafeHandleValue,
-        can_gc: CanGc,
     ) -> Option<Result<Rc<Promise>, Error>> {
         match self.tee_cancel_algorithm {
             ByteTeeCancelAlgorithm::Cancel1Algorithm => {
@@ -444,7 +444,7 @@ impl ByteTeeUnderlyingSource {
 
                 // If canceled2 is true,
                 if self.canceled_2.get() {
-                    self.resolve_cancel_promise(can_gc);
+                    self.resolve_cancel_promise(cx);
                 }
 
                 // Return cancelPromise.
@@ -459,7 +459,7 @@ impl ByteTeeUnderlyingSource {
 
                 // If canceled_1 is true,
                 if self.canceled_1.get() {
-                    self.resolve_cancel_promise(can_gc);
+                    self.resolve_cancel_promise(cx);
                 }
                 // Return cancelPromise.
                 Some(Ok(self.cancel_promise.clone()))
@@ -468,23 +468,23 @@ impl ByteTeeUnderlyingSource {
     }
 
     #[expect(unsafe_code)]
-    fn resolve_cancel_promise(&self, can_gc: CanGc) {
+    fn resolve_cancel_promise(&self, cx: &mut js::context::JSContext) {
         // Let compositeReason be ! CreateArrayFromList(« reason_1, reason_2 »).
-        let cx = GlobalScope::get_cx();
         rooted_vec!(let mut reasons_values);
         reasons_values.push(self.reason_1.get());
         reasons_values.push(self.reason_2.get());
 
         let reasons_values_array = HandleValueArray::from(&reasons_values);
-        rooted!(in(*cx) let reasons = unsafe { NewArrayObject(*cx, &reasons_values_array) });
-        rooted!(in(*cx) let reasons_value = ObjectValue(reasons.get()));
+        rooted!(&in(cx) let reasons = unsafe { NewArrayObject(cx.raw_cx(), &reasons_values_array) });
+        rooted!(&in(cx) let reasons_value = ObjectValue(reasons.get()));
 
         // Let cancelResult be ! ReadableStreamCancel(stream, compositeReason).
-        let cancel_result =
-            self.stream
-                .cancel(cx, &self.stream.global(), reasons_value.handle(), can_gc);
+        let cancel_result = self
+            .stream
+            .cancel(cx, &self.stream.global(), reasons_value.handle());
 
         // Resolve cancelPromise with cancelResult.
-        self.cancel_promise.resolve_native(&cancel_result, can_gc);
+        self.cancel_promise
+            .resolve_native(&cancel_result, CanGc::from_cx(cx));
     }
 }

--- a/components/script/dom/stream/defaultteereadrequest.rs
+++ b/components/script/dom/stream/defaultteereadrequest.rs
@@ -103,8 +103,7 @@ impl DefaultTeeReadRequest {
         global: &GlobalScope,
         reason: SafeHandleValue,
     ) {
-        self.stream
-            .cancel(cx.into(), global, reason, CanGc::from_cx(cx));
+        self.stream.cancel(cx, global, reason);
     }
     /// Enqueue a microtask to perform the chunk steps
     /// <https://streams.spec.whatwg.org/#ref-for-read-request-chunk-steps%E2%91%A2>

--- a/components/script/dom/stream/defaultteeunderlyingsource.rs
+++ b/components/script/dom/stream/defaultteeunderlyingsource.rs
@@ -18,7 +18,7 @@ use crate::dom::promise::Promise;
 use crate::dom::stream::defaultteereadrequest::DefaultTeeReadRequest;
 use crate::dom::stream::readablestreamdefaultreader::ReadRequest;
 use crate::dom::types::{ReadableStream, ReadableStreamDefaultReader};
-use crate::script_runtime::{CanGc, JSContext as SafeJSContext};
+use crate::script_runtime::CanGc;
 
 #[derive(JSTraceable, MallocSizeOf)]
 pub(crate) enum DefaultTeeCancelAlgorithm {
@@ -152,10 +152,9 @@ impl DefaultTeeUnderlyingSource {
     /// Let cancel2Algorithm be the following steps, taking a reason argument
     pub(crate) fn cancel_algorithm(
         &self,
-        cx: SafeJSContext,
+        cx: &mut js::context::JSContext,
         global: &GlobalScope,
         reason: SafeHandleValue,
-        can_gc: CanGc,
     ) -> Option<Result<Rc<Promise>, Error>> {
         match self.tee_cancel_algorithm {
             DefaultTeeCancelAlgorithm::Cancel1Algorithm => {
@@ -167,7 +166,7 @@ impl DefaultTeeUnderlyingSource {
 
                 // If canceled_2 is true,
                 if self.canceled_2.get() {
-                    self.resolve_cancel_promise(cx, global, can_gc);
+                    self.resolve_cancel_promise(cx, global);
                 }
                 // Return cancelPromise.
                 Some(Ok(self.cancel_promise.clone()))
@@ -181,7 +180,7 @@ impl DefaultTeeUnderlyingSource {
 
                 // If canceled_1 is true,
                 if self.canceled_1.get() {
-                    self.resolve_cancel_promise(cx, global, can_gc);
+                    self.resolve_cancel_promise(cx, global);
                 }
                 // Return cancelPromise.
                 Some(Ok(self.cancel_promise.clone()))
@@ -190,22 +189,21 @@ impl DefaultTeeUnderlyingSource {
     }
 
     #[expect(unsafe_code)]
-    fn resolve_cancel_promise(&self, cx: SafeJSContext, global: &GlobalScope, can_gc: CanGc) {
+    fn resolve_cancel_promise(&self, cx: &mut js::context::JSContext, global: &GlobalScope) {
         // Let compositeReason be ! CreateArrayFromList(« reason_1, reason_2 »).
         rooted_vec!(let mut reasons_values);
         reasons_values.push(self.reason_1.get());
         reasons_values.push(self.reason_2.get());
 
         let reasons_values_array = HandleValueArray::from(&reasons_values);
-        rooted!(in(*cx) let reasons = unsafe { NewArrayObject(*cx, &reasons_values_array) });
-        rooted!(in(*cx) let reasons_value = ObjectValue(reasons.get()));
+        rooted!(&in(cx) let reasons = unsafe { NewArrayObject(cx.raw_cx(), &reasons_values_array) });
+        rooted!(&in(cx) let reasons_value = ObjectValue(reasons.get()));
 
         // Let cancelResult be ! ReadableStreamCancel(stream, compositeReason).
-        let cancel_result = self
-            .stream
-            .cancel(cx, global, reasons_value.handle(), can_gc);
+        let cancel_result = self.stream.cancel(cx, global, reasons_value.handle());
 
         // Resolve cancelPromise with cancelResult.
-        self.cancel_promise.resolve_native(&cancel_result, can_gc);
+        self.cancel_promise
+            .resolve_native(&cancel_result, CanGc::from_cx(cx));
     }
 }

--- a/components/script/dom/stream/readablebytestreamcontroller.rs
+++ b/components/script/dom/stream/readablebytestreamcontroller.rs
@@ -1798,10 +1798,9 @@ impl ReadableByteStreamController {
     /// <https://streams.spec.whatwg.org/#rbs-controller-private-cancel>
     pub(crate) fn perform_cancel_steps(
         &self,
-        cx: SafeJSContext,
+        cx: &mut js::context::JSContext,
         global: &GlobalScope,
         reason: SafeHandleValue,
-        can_gc: CanGc,
     ) -> Rc<Promise> {
         // Perform ! ReadableByteStreamControllerClearPendingPullIntos(this).
         self.clear_pending_pull_intos();
@@ -1816,19 +1815,18 @@ impl ReadableByteStreamController {
 
         // Let result be the result of performing this.[[cancelAlgorithm]], passing in reason.
         let result = underlying_source
-            .call_cancel_algorithm(cx, global, reason, can_gc)
+            .call_cancel_algorithm(cx, global, reason)
             .unwrap_or_else(|| {
-                let promise = Promise::new(global, can_gc);
-                promise.resolve_native(&(), can_gc);
+                let promise = Promise::new2(cx, global);
+                promise.resolve_native(&(), CanGc::from_cx(cx));
                 Ok(promise)
             });
 
         let promise = result.unwrap_or_else(|error| {
-            let cx = GlobalScope::get_cx();
-            rooted!(in(*cx) let mut rval = UndefinedValue());
-            error.to_jsval(cx, global, rval.handle_mut(), can_gc);
-            let promise = Promise::new(global, can_gc);
-            promise.reject_native(&rval.handle(), can_gc);
+            rooted!(&in(cx) let mut rval = UndefinedValue());
+            error.to_jsval(cx.into(), global, rval.handle_mut(), CanGc::from_cx(cx));
+            let promise = Promise::new2(cx, global);
+            promise.reject_native(&rval.handle(), CanGc::from_cx(cx));
             promise
         });
 

--- a/components/script/dom/stream/readablestream.rs
+++ b/components/script/dom/stream/readablestream.rs
@@ -667,7 +667,7 @@ impl PipeTo {
                     .reader
                     .get_stream()
                     .expect("Reader should have a stream.");
-                source.cancel(cx.into(), global, error.handle(), CanGc::from_cx(cx))
+                source.cancel(cx, global, error.handle())
             },
             ShutdownAction::WritableStreamDefaultWriterCloseWithErrorPropagation => self
                 .writer
@@ -708,7 +708,7 @@ impl PipeTo {
                     // If source.[[state]] is "readable",
                     let promise = if source.is_readable() {
                         // return ! ReadableStreamCancel(source, error).
-                        source.cancel(cx.into(), global, error.handle(), CanGc::from_cx(cx))
+                        source.cancel(cx, global, error.handle())
                     } else {
                         // Otherwise, return a promise resolved with undefined.
                         Promise::new_resolved(global, cx.into(), (), CanGc::from_cx(cx))
@@ -1568,29 +1568,28 @@ impl ReadableStream {
     /// <https://streams.spec.whatwg.org/#readable-stream-cancel>
     pub(crate) fn cancel(
         &self,
-        cx: SafeJSContext,
+        cx: &mut js::context::JSContext,
         global: &GlobalScope,
         reason: SafeHandleValue,
-        can_gc: CanGc,
     ) -> Rc<Promise> {
         // Set stream.[[disturbed]] to true.
         self.disturbed.set(true);
 
         // If stream.[[state]] is "closed", return a promise resolved with undefined.
         if self.is_closed() {
-            return Promise::new_resolved(global, cx, (), can_gc);
+            return Promise::new_resolved(global, cx.into(), (), CanGc::from_cx(cx));
         }
         // If stream.[[state]] is "errored", return a promise rejected with stream.[[storedError]].
         if self.is_errored() {
-            let promise = Promise::new(global, can_gc);
-            rooted!(in(*cx) let mut rval = UndefinedValue());
+            let promise = Promise::new2(cx, global);
+            rooted!(&in(cx) let mut rval = UndefinedValue());
             self.stored_error
-                .safe_to_jsval(cx, rval.handle_mut(), can_gc);
-            promise.reject_native(&rval.handle(), can_gc);
+                .safe_to_jsval(cx.into(), rval.handle_mut(), CanGc::from_cx(cx));
+            promise.reject_native(&rval.handle(), CanGc::from_cx(cx));
             return promise;
         }
         // Perform ! ReadableStreamClose(stream).
-        self.close(can_gc);
+        self.close(CanGc::from_cx(cx));
 
         // If reader is not undefined and reader implements ReadableStreamBYOBReader,
         let byob_reader = {
@@ -1603,7 +1602,7 @@ impl ReadableStream {
 
         if let Some(reader) = byob_reader {
             // step 6.1, 6.2 & 6.3 of https://streams.spec.whatwg.org/#readable-stream-cancel
-            reader.cancel(can_gc);
+            reader.cancel(CanGc::from_cx(cx));
         }
 
         // Let sourceCancelPromise be ! stream.[[controller]].[[CancelSteps]](reason).
@@ -1612,11 +1611,11 @@ impl ReadableStream {
             Some(ControllerType::Default(controller)) => controller
                 .get()
                 .expect("Stream should have controller.")
-                .perform_cancel_steps(cx, global, reason, can_gc),
+                .perform_cancel_steps(cx, global, reason),
             Some(ControllerType::Byte(controller)) => controller
                 .get()
                 .expect("Stream should have controller.")
-                .perform_cancel_steps(cx, global, reason, can_gc),
+                .perform_cancel_steps(cx, global, reason),
             None => {
                 panic!("Stream does not have a controller.");
             },
@@ -1625,7 +1624,7 @@ impl ReadableStream {
         // Create a new promise,
         // and setup a handler in order to react to the fulfillment of sourceCancelPromise.
         let global = self.global();
-        let result_promise = Promise::new(&global, can_gc);
+        let result_promise = Promise::new2(cx, &global);
         let fulfillment_handler = Box::new(SourceCancelPromiseFulfillmentHandler {
             result: result_promise.clone(),
         });
@@ -1636,11 +1635,11 @@ impl ReadableStream {
             &global,
             Some(fulfillment_handler),
             Some(rejection_handler),
-            can_gc,
+            CanGc::from_cx(cx),
         );
         let realm = enter_realm(&*global);
         let comp = InRealm::Entered(&realm);
-        source_cancel_promise.append_native_handler(&handler, comp, can_gc);
+        source_cancel_promise.append_native_handler(&handler, comp, CanGc::from_cx(cx));
 
         // Return the result of reacting to sourceCancelPromise
         // with a fulfillment step that returns undefined.
@@ -2165,7 +2164,7 @@ impl ReadableStreamMethods<crate::DomTypeHolder> for ReadableStream {
             promise
         } else {
             // Return ! ReadableStreamCancel(this, reason).
-            self.cancel(cx.into(), &global, reason, CanGc::from_cx(cx))
+            self.cancel(cx, &global, reason)
         }
     }
 

--- a/components/script/dom/stream/readablestreamdefaultcontroller.rs
+++ b/components/script/dom/stream/readablestreamdefaultcontroller.rs
@@ -569,10 +569,9 @@ impl ReadableStreamDefaultController {
     /// <https://streams.spec.whatwg.org/#rs-default-controller-private-cancel>
     pub(crate) fn perform_cancel_steps(
         &self,
-        cx: SafeJSContext,
+        cx: &mut js::context::JSContext,
         global: &GlobalScope,
         reason: SafeHandleValue,
-        can_gc: CanGc,
     ) -> Rc<Promise> {
         // Perform ! ResetQueue(this).
         self.queue.reset();
@@ -583,18 +582,18 @@ impl ReadableStreamDefaultController {
             .expect("Controller should have a source when the cancel steps are called into.");
         // Let result be the result of performing this.[[cancelAlgorithm]], passing reason.
         let result = underlying_source
-            .call_cancel_algorithm(cx, global, reason, can_gc)
+            .call_cancel_algorithm(cx, global, reason)
             .unwrap_or_else(|| {
-                let promise = Promise::new(global, can_gc);
-                promise.resolve_native(&(), can_gc);
+                let promise = Promise::new2(cx, global);
+                promise.resolve_native(&(), CanGc::from_cx(cx));
                 Ok(promise)
             });
         let promise = result.unwrap_or_else(|error| {
-            rooted!(in(*cx) let mut rval = UndefinedValue());
+            rooted!(&in(cx) let mut rval = UndefinedValue());
 
-            error.to_jsval(cx, global, rval.handle_mut(), can_gc);
-            let promise = Promise::new(global, can_gc);
-            promise.reject_native(&rval.handle(), can_gc);
+            error.to_jsval(cx.into(), global, rval.handle_mut(), CanGc::from_cx(cx));
+            let promise = Promise::new2(cx, global);
+            promise.reject_native(&rval.handle(), CanGc::from_cx(cx));
             promise
         });
 

--- a/components/script/dom/stream/readablestreamgenericreader.rs
+++ b/components/script/dom/stream/readablestreamgenericreader.rs
@@ -75,7 +75,7 @@ pub(crate) trait ReadableStreamGenericReader {
             stream.expect("Reader should have a stream when generic cancel is called into.");
 
         // Return ! ReadableStreamCancel(stream, reason).
-        stream.cancel(cx.into(), global, reason, CanGc::from_cx(cx))
+        stream.cancel(cx, global, reason)
     }
 
     /// <https://streams.spec.whatwg.org/#readable-stream-reader-generic-release>

--- a/components/script/dom/stream/underlyingsourcecontainer.rs
+++ b/components/script/dom/stream/underlyingsourcecontainer.rs
@@ -22,7 +22,7 @@ use crate::dom::messageport::MessagePort;
 use crate::dom::promise::Promise;
 use crate::dom::stream::defaultteeunderlyingsource::DefaultTeeUnderlyingSource;
 use crate::dom::stream::transformstream::TransformStream;
-use crate::script_runtime::{CanGc, JSContext as SafeJSContext};
+use crate::script_runtime::CanGc;
 
 /// <https://streams.spec.whatwg.org/#underlying-source-api>
 /// The `Js` variant corresponds to
@@ -118,10 +118,9 @@ impl UnderlyingSourceContainer {
     #[expect(unsafe_code)]
     pub(crate) fn call_cancel_algorithm(
         &self,
-        cx: SafeJSContext,
+        cx: &mut js::context::JSContext,
         global: &GlobalScope,
         reason: SafeHandleValue,
-        can_gc: CanGc,
     ) -> Option<Result<Rc<Promise>, Error>> {
         match &self.underlying_source_type {
             UnderlyingSourceType::Js(source, this_obj) => {
@@ -131,7 +130,7 @@ impl UnderlyingSourceContainer {
                             &SafeHandle::from_raw(this_obj.handle()),
                             Some(reason),
                             ExceptionHandling::Rethrow,
-                            can_gc,
+                            CanGc::from_cx(cx),
                         )
                     };
                     return Some(result);
@@ -140,37 +139,43 @@ impl UnderlyingSourceContainer {
             },
             UnderlyingSourceType::Tee(tee_underlying_source) => {
                 // Call the cancel algorithm for the appropriate branch.
-                tee_underlying_source.cancel_algorithm(cx, global, reason, can_gc)
+                tee_underlying_source.cancel_algorithm(cx, global, reason)
             },
             UnderlyingSourceType::Transform(stream, _) => {
                 // Return ! TransformStreamDefaultSourceCancelAlgorithm(stream, reason).
-                Some(stream.transform_stream_default_source_cancel(cx, global, reason, can_gc))
+                Some(stream.transform_stream_default_source_cancel(
+                    cx.into(),
+                    global,
+                    reason,
+                    CanGc::from_cx(cx),
+                ))
             },
             UnderlyingSourceType::Transfer(port) => {
                 // Let cancelAlgorithm be the following steps, taking a reason argument:
                 // from <https://streams.spec.whatwg.org/#abstract-opdef-setupcrossrealmtransformreadable
 
                 // Let result be PackAndPostMessageHandlingError(port, "error", reason).
-                let result = port.pack_and_post_message_handling_error("error", reason, can_gc);
+                let result =
+                    port.pack_and_post_message_handling_error("error", reason, CanGc::from_cx(cx));
 
                 // Disentangle port.
-                self.global().disentangle_port(port, can_gc);
+                self.global().disentangle_port(port, CanGc::from_cx(cx));
 
-                let promise = Promise::new(&self.global(), can_gc);
+                let promise = Promise::new2(cx, &self.global());
 
                 // If result is an abrupt completion,
                 if let Err(error) = result {
                     // Return a promise rejected with result.[[Value]].
-                    promise.reject_error(error, can_gc);
+                    promise.reject_error(error, CanGc::from_cx(cx));
                 } else {
                     // Otherwise, return a promise resolved with undefined.
-                    promise.resolve_native(&(), can_gc);
+                    promise.resolve_native(&(), CanGc::from_cx(cx));
                 }
                 Some(Ok(promise))
             },
             UnderlyingSourceType::TeeByte(tee_underlyin_source) => {
                 // Call the cancel algorithm for the appropriate branch.
-                tee_underlyin_source.cancel_algorithm(reason, can_gc)
+                tee_underlyin_source.cancel_algorithm(cx, reason)
             },
             _ => None,
         }

--- a/components/script/dom/window.rs
+++ b/components/script/dom/window.rs
@@ -191,7 +191,7 @@ use crate::layout_image::fetch_image_for_layout;
 use crate::messaging::{MainThreadScriptMsg, ScriptEventLoopReceiver, ScriptEventLoopSender};
 use crate::microtask::{Microtask, UserMicrotask};
 use crate::network_listener::{ResourceTimingListener, submit_timing};
-use crate::realms::{InRealm, enter_realm};
+use crate::realms::enter_realm;
 use crate::script_runtime::{CanGc, JSContext as SafeJSContext, Runtime};
 use crate::script_thread::ScriptThread;
 use crate::script_window_proxies::ScriptWindowProxies;
@@ -2101,12 +2101,11 @@ impl WindowMethods<crate::DomTypeHolder> for Window {
     /// <https://fetch.spec.whatwg.org/#dom-global-fetch>
     fn Fetch(
         &self,
+        realm: &mut CurrentRealm,
         input: RequestOrUSVString,
         init: RootedTraceableBox<RequestInit>,
-        comp: InRealm,
-        can_gc: CanGc,
     ) -> Rc<Promise> {
-        fetch::Fetch(self.upcast(), input, init, comp, can_gc)
+        fetch::Fetch(self.upcast(), input, init, realm)
     }
 
     /// <https://fetch.spec.whatwg.org/#dom-window-fetchlater>

--- a/components/script/dom/workers/workerglobalscope.rs
+++ b/components/script/dom/workers/workerglobalscope.rs
@@ -81,7 +81,7 @@ use crate::fetch::{CspViolationsProcessor, Fetch, RequestWithGlobalScope, load_w
 use crate::messaging::{CommonScriptMsg, ScriptEventLoopReceiver, ScriptEventLoopSender};
 use crate::microtask::{Microtask, MicrotaskQueue, UserMicrotask};
 use crate::network_listener::{FetchResponseListener, ResourceTimingListener, submit_timing};
-use crate::realms::{InRealm, enter_auto_realm};
+use crate::realms::enter_auto_realm;
 use crate::script_module::ScriptFetchOptions;
 use crate::script_runtime::{CanGc, IntroductionType, JSContext, JSContextHelper, Runtime};
 use crate::task::TaskCanceller;
@@ -923,12 +923,11 @@ impl WorkerGlobalScopeMethods<crate::DomTypeHolder> for WorkerGlobalScope {
     /// <https://fetch.spec.whatwg.org/#dom-global-fetch>
     fn Fetch(
         &self,
+        realm: &mut CurrentRealm,
         input: RequestOrUSVString,
         init: RootedTraceableBox<RequestInit>,
-        comp: InRealm,
-        can_gc: CanGc,
     ) -> Rc<Promise> {
-        Fetch(self.upcast(), input, init, comp, can_gc)
+        Fetch(self.upcast(), input, init, realm)
     }
 
     /// <https://w3c.github.io/hr-time/#the-performance-attribute>

--- a/components/script/fetch.rs
+++ b/components/script/fetch.rs
@@ -10,6 +10,7 @@ use base::id::WebViewId;
 use ipc_channel::ipc;
 use js::jsapi::{ExceptionStackBehavior, JS_IsExceptionPending};
 use js::jsval::UndefinedValue;
+use js::realm::CurrentRealm;
 use js::rust::HandleValue;
 use js::rust::wrappers::JS_SetPendingException;
 use net_traits::request::{
@@ -37,7 +38,6 @@ use crate::dom::bindings::codegen::Bindings::ResponseBinding::Response_Binding::
 use crate::dom::bindings::codegen::Bindings::ResponseBinding::ResponseType as DOMResponseType;
 use crate::dom::bindings::codegen::Bindings::WindowBinding::{DeferredRequestInit, WindowMethods};
 use crate::dom::bindings::error::{Error, Fallible};
-use crate::dom::bindings::import::module::SafeJSContext;
 use crate::dom::bindings::inheritance::Castable;
 use crate::dom::bindings::num::Finite;
 use crate::dom::bindings::refcounted::{Trusted, TrustedPromise};
@@ -57,7 +57,7 @@ use crate::dom::window::Window;
 use crate::network_listener::{
     self, FetchResponseListener, NetworkListener, ResourceTimingListener, submit_timing_data,
 };
-use crate::realms::{InRealm, enter_realm};
+use crate::realms::enter_realm;
 use crate::script_runtime::CanGc;
 
 /// Fetch canceller object. By default initialized to having a
@@ -179,15 +179,14 @@ fn abort_fetch_call(
     response_object: Option<&Response>,
     abort_reason: HandleValue,
     global: &GlobalScope,
-    cx: SafeJSContext,
-    can_gc: CanGc,
+    cx: &mut js::context::JSContext,
 ) {
     // Step 1. Reject promise with error.
-    promise.reject(cx, abort_reason, can_gc);
+    promise.reject(cx.into(), abort_reason, CanGc::from_cx(cx));
     // Step 2. If request’s body is non-null and is readable, then cancel request’s body with error.
     if let Some(body) = request.body() {
         if body.is_readable() {
-            body.cancel(cx, global, abort_reason, can_gc);
+            body.cancel(cx, global, abort_reason);
         }
     }
     // Step 3. If responseObject is null, then return.
@@ -198,7 +197,7 @@ fn abort_fetch_call(
     // Step 5. If response’s body is non-null and is readable, then error response’s body with error.
     if let Some(body) = response.body() {
         if body.is_readable() {
-            body.error(abort_reason, can_gc);
+            body.error(abort_reason, CanGc::from_cx(cx));
         }
     }
 }
@@ -209,24 +208,24 @@ pub(crate) fn Fetch(
     global: &GlobalScope,
     input: RequestInfo,
     init: RootedTraceableBox<RequestInit>,
-    comp: InRealm,
-    can_gc: CanGc,
+    cx: &mut CurrentRealm,
 ) -> Rc<Promise> {
     // Step 1. Let p be a new promise.
-    let promise = Promise::new_in_current_realm(comp, can_gc);
-    let cx = GlobalScope::get_cx();
+    let promise = Promise::new_in_realm(cx);
 
     // Step 7. Let responseObject be null.
     // NOTE: We do initialize the object earlier earlier so we can use it to track errors
-    let response = Response::new(global, can_gc);
-    response.Headers(can_gc).set_guard(Guard::Immutable);
+    let response = Response::new(global, CanGc::from_cx(cx));
+    response
+        .Headers(CanGc::from_cx(cx))
+        .set_guard(Guard::Immutable);
 
     // Step 2. Let requestObject be the result of invoking the initial value of Request as constructor
     //         with input and init as arguments. If this throws an exception, reject p with it and return p.
-    let request_object = match Request::Constructor(global, None, can_gc, input, init) {
+    let request_object = match Request::Constructor(global, None, CanGc::from_cx(cx), input, init) {
         Err(e) => {
-            response.error_stream(e.clone(), can_gc);
-            promise.reject_error(e, can_gc);
+            response.error_stream(e.clone(), CanGc::from_cx(cx));
+            promise.reject_error(e, CanGc::from_cx(cx));
             return promise;
         },
         Ok(r) => r,
@@ -239,8 +238,8 @@ pub(crate) fn Fetch(
     let signal = request_object.Signal();
     if signal.aborted() {
         // Step 4.1. Abort the fetch() call with p, request, null, and requestObject’s signal’s abort reason.
-        rooted!(in(*cx) let mut abort_reason = UndefinedValue());
-        signal.Reason(cx, abort_reason.handle_mut());
+        rooted!(&in(cx) let mut abort_reason = UndefinedValue());
+        signal.Reason(cx.into(), abort_reason.handle_mut());
         abort_fetch_call(
             promise.clone(),
             &request_object,
@@ -248,7 +247,6 @@ pub(crate) fn Fetch(
             abort_reason.handle(),
             global,
             cx,
-            can_gc,
         );
         // Step 4.2. Return p.
         return promise;
@@ -498,8 +496,7 @@ impl FetchContext {
     pub(crate) fn abort_fetch(
         &mut self,
         abort_reason: HandleValue,
-        cx: SafeJSContext,
-        can_gc: CanGc,
+        cx: &mut js::context::JSContext,
     ) {
         // Step 11.1. Set locallyAborted to true.
         self.locally_aborted = true;
@@ -524,7 +521,6 @@ impl FetchContext {
             abort_reason,
             &self.global.root(),
             cx,
-            can_gc,
         );
     }
 }

--- a/components/script_bindings/codegen/Bindings.conf
+++ b/components/script_bindings/codegen/Bindings.conf
@@ -852,10 +852,9 @@ DOMInterfaces = {
 },
 
 'Window': {
-    'canGc': ['CookieStore', 'Fetch', 'FetchLater', 'GetVisualViewport', 'ReportError', 'Screen', 'StructuredClone'],
-    'inRealms': ['Fetch'],
+    'canGc': ['CookieStore', 'FetchLater', 'GetVisualViewport', 'ReportError', 'Screen', 'StructuredClone'],
     'additionalTraits': ['crate::interfaces::WindowHelpers'],
-    'realm': ['CreateImageBitmap', 'CreateImageBitmap_', 'WebdriverCallback', 'GetOpener'],
+    'realm': ['CreateImageBitmap', 'CreateImageBitmap_', 'WebdriverCallback', 'GetOpener', 'Fetch'],
     'cx': ['Open', 'PostMessage', 'PostMessage_', 'SetInterval', 'SetTimeout', 'Stop', 'TrustedTypes', 'WebdriverException']
 },
 
@@ -869,10 +868,9 @@ DOMInterfaces = {
 },
 
 'WorkerGlobalScope': {
-    'inRealms': ['Fetch'],
     'cx': ['ImportScripts', 'SetInterval', 'SetTimeout', 'TrustedTypes'],
-    'canGc': ['Fetch', 'ReportError', 'StructuredClone'],
-    'realm': ['CreateImageBitmap', 'CreateImageBitmap_'],
+    'canGc': ['ReportError', 'StructuredClone'],
+    'realm': ['CreateImageBitmap', 'CreateImageBitmap_', 'Fetch'],
 },
 
 'Worklet': {


### PR DESCRIPTION
Pass `&mut JSContext` to `ReadableStream::cancel`, in preparation of porting the remaining `BlobMethods`.

Testing: Just a refactor, ./mach test-unit still passes.
Fixes: Part of #42638
