### PR TITLE
script: Base `accesskey` on keyboard key codes

### DIFF
--- a/components/script/dom/document_event_handler.rs
+++ b/components/script/dom/document_event_handler.rs
@@ -8,6 +8,7 @@ use std::cmp::Ordering;
 use std::f64::consts::PI;
 use std::mem;
 use std::rc::Rc;
+use std::str::FromStr;
 use std::time::{Duration, Instant};
 
 use base::generic_channel::GenericCallback;
@@ -32,6 +33,7 @@ use script_bindings::codegen::GenericBindings::ElementBinding::ScrollLogicalPosi
 use script_bindings::codegen::GenericBindings::EventBinding::EventMethods;
 use script_bindings::codegen::GenericBindings::HTMLElementBinding::HTMLElementMethods;
 use script_bindings::codegen::GenericBindings::HTMLLabelElementBinding::HTMLLabelElementMethods;
+use script_bindings::codegen::GenericBindings::KeyboardEventBinding::KeyboardEventMethods;
 use script_bindings::codegen::GenericBindings::NavigatorBinding::NavigatorMethods;
 use script_bindings::codegen::GenericBindings::PerformanceBinding::PerformanceMethods;
 use script_bindings::codegen::GenericBindings::TouchBinding::TouchMethods;
@@ -53,6 +55,7 @@ use crate::dom::bindings::cell::DomRefCell;
 use crate::dom::bindings::inheritance::{ElementTypeId, HTMLElementTypeId, NodeTypeId};
 use crate::dom::bindings::refcounted::Trusted;
 use crate::dom::bindings::root::MutNullableDom;
+use crate::dom::bindings::trace::NoTrace;
 use crate::dom::clipboardevent::ClipboardEventType;
 use crate::dom::document::{FireMouseEventType, FocusInitiator};
 use crate::dom::event::{EventBubbles, EventCancelable, EventComposed, EventFlags};
@@ -191,7 +194,7 @@ pub(crate) struct DocumentEventHandler {
     /// Counter for generating unique pointer IDs for touch inputs
     next_touch_pointer_id: Cell<i32>,
     /// A map holding information about currently registered access key handlers.
-    access_key_handlers: DomRefCell<FxHashMap<char, Dom<HTMLElement>>>,
+    access_key_handlers: DomRefCell<FxHashMap<NoTrace<Code>, Dom<HTMLElement>>>,
     /// <https://html.spec.whatwg.org/multipage/#sequential-focus-navigation-starting-point>
     sequential_focus_navigation_starting_point: MutNullableDom<Node>,
 }
@@ -2398,11 +2401,11 @@ impl DocumentEventHandler {
             .retain(|_, value| &**value != element)
     }
 
-    pub(crate) fn assign_access_key(&self, element: &HTMLElement, character: char) {
+    pub(crate) fn assign_access_key(&self, element: &HTMLElement, code: Code) {
         let mut access_key_handlers = self.access_key_handlers.borrow_mut();
         // If an element is already assigned this access key, ignore the request.
         access_key_handlers
-            .entry(character)
+            .entry(code.into())
             .or_insert(Dom::from_ref(element));
     }
 
@@ -2416,22 +2419,14 @@ impl DocumentEventHandler {
             return false;
         }
 
-        let Key::Character(ref string) = event.key() else {
-            return false;
-        };
-
-        let mut characters = string.chars();
-        let Some(character) = characters.next() else {
-            return false;
-        };
-        if characters.count() > 0 {
+        let Ok(code) = Code::from_str(&event.Code().str()) else {
             return false;
         };
 
         let Some(html_element) = self
             .access_key_handlers
             .borrow()
-            .get(&character)
+            .get(&code.into())
             .map(|html_element| html_element.as_rooted())
         else {
             return false;
@@ -2512,4 +2507,58 @@ fn compare_tab_indices(a: i32, b: i32) -> Ordering {
     } else {
         a.cmp(&b)
     }
+}
+
+pub(crate) fn character_to_code(character: char) -> Option<Code> {
+    Some(match character.to_ascii_lowercase() {
+        '`' => Code::Backquote,
+        '\\' => Code::Backslash,
+        '[' | '{' => Code::BracketLeft,
+        ']' | '}' => Code::BracketRight,
+        ',' | '<' => Code::Comma,
+        '0' => Code::Digit0,
+        '1' => Code::Digit1,
+        '2' => Code::Digit2,
+        '3' => Code::Digit3,
+        '4' => Code::Digit4,
+        '5' => Code::Digit5,
+        '6' => Code::Digit6,
+        '7' => Code::Digit7,
+        '8' => Code::Digit8,
+        '9' => Code::Digit9,
+        '=' => Code::Equal,
+        'a' => Code::KeyA,
+        'b' => Code::KeyB,
+        'c' => Code::KeyC,
+        'd' => Code::KeyD,
+        'e' => Code::KeyE,
+        'f' => Code::KeyF,
+        'g' => Code::KeyG,
+        'h' => Code::KeyH,
+        'i' => Code::KeyI,
+        'j' => Code::KeyJ,
+        'k' => Code::KeyK,
+        'l' => Code::KeyL,
+        'm' => Code::KeyM,
+        'n' => Code::KeyN,
+        'o' => Code::KeyO,
+        'p' => Code::KeyP,
+        'q' => Code::KeyQ,
+        'r' => Code::KeyR,
+        's' => Code::KeyS,
+        't' => Code::KeyT,
+        'u' => Code::KeyU,
+        'v' => Code::KeyV,
+        'w' => Code::KeyW,
+        'x' => Code::KeyX,
+        'y' => Code::KeyY,
+        'z' => Code::KeyZ,
+        '-' => Code::Minus,
+        '.' => Code::Period,
+        '\'' | '"' => Code::Quote,
+        ';' => Code::Semicolon,
+        '/' => Code::Slash,
+        ' ' => Code::Space,
+        _ => return None,
+    })
 }

--- a/components/script/dom/html/htmlelement.rs
+++ b/components/script/dom/html/htmlelement.rs
@@ -37,6 +37,7 @@ use crate::dom::css::cssstyledeclaration::{
 };
 use crate::dom::customelementregistry::{CallbackReaction, CustomElementState};
 use crate::dom::document::{Document, FocusInitiator};
+use crate::dom::document_event_handler::character_to_code;
 use crate::dom::documentfragment::DocumentFragment;
 use crate::dom::domstringmap::DOMStringMap;
 use crate::dom::element::{
@@ -1152,12 +1153,9 @@ impl HTMLElement {
 
             // 2. If the value does not correspond to a key on the system's keyboard, then skip the
             //    remainder of these steps for this value.
-            //    TODO: This is just a heuristic for whether or not the character is on the keyboard.
-            //    We should do better here, but as we don't know anything about the keyboard hardware,
-            //    it's quite difficult at the moment.
-            if !character.is_ascii_graphic() {
+            let Some(code) = character_to_code(character) else {
                 continue;
-            }
+            };
 
             // 3. If the user agent can find a mix of zero or more modifier keys that, combined with
             //    the key that corresponds to the value given in the attribute, can be used as the
@@ -1165,7 +1163,7 @@ impl HTMLElement {
             //    assigned access key and return.
             self.owner_document()
                 .event_handler()
-                .assign_access_key(self, character);
+                .assign_access_key(self, code);
             return;
         }
 

--- a/tests/wpt/mozilla/meta/MANIFEST.json
+++ b/tests/wpt/mozilla/meta/MANIFEST.json
@@ -13124,7 +13124,7 @@
    },
    "input-events": {
     "accesskey-on-html-element.html": [
-     "f531e2101852997165c642df2974a9ce7bb57a47",
+     "062cf605c3eb30717bace5fd94c0d43c943238e3",
      [
       null,
       {

--- a/tests/wpt/mozilla/tests/input-events/accesskey-on-html-element.html
+++ b/tests/wpt/mozilla/tests/input-events/accesskey-on-html-element.html
@@ -8,15 +8,25 @@
 <script src="/resources/testdriver-actions.js"></script>
 <script src="/resources/accesskey.js"></script>
 <div style="height: 10000px"></div>
-<div id="target" accesskey="P" tabindex="0">Access Key</div>
+<div id="target1" accesskey="p" tabindex="0">Access Key</div>
+<div style="height: 10000px"></div>
+<div id="target2" accesskey="t" tabindex="0">Access Key Lowercase</div>
+<div style="height: 10000px"></div>
 
 <script>
 promise_test(async function() {
     await pressAccessKey('P');
-    let boundingRect = target.getBoundingClientRect();
+    let boundingRect = target1.getBoundingClientRect();
     assert_true(boundingRect.x > 0);
     assert_true(boundingRect.x < document.scrollingElement.clientWidth);
     assert_true(boundingRect.y > 0);
     assert_true(boundingRect.y < document.scrollingElement.clientHeight);
+
+    await pressAccessKey('t');
+    let boundingRect2 = target2.getBoundingClientRect();
+    assert_true(boundingRect2.x > 0);
+    assert_true(boundingRect2.x < document.scrollingElement.clientWidth);
+    assert_true(boundingRect2.y > 0);
+    assert_true(boundingRect2.y < document.scrollingElement.clientHeight);
 });
 </script>


### PR DESCRIPTION
Instead of using ASCII character to process the `accesskey` attribute
use the hardware key code that comes with the platform key event. This
aligns our implementation closer to the spec and allows `accesskey` to
work properly with lowercase letters on Linux machines (where shift is
part of the access key sequence). This might introduce some issues with
non-US keyboards, but those issues are inherent in the specification --
one reason why `accesskey` is not recommended for use.

Testing: A Servo-specific accesskey test is extended to cover this case.
