### PR TITLE
script: Move by word in text fields on Windows and Linux with control

### DIFF
--- a/components/script/textinput.rs
+++ b/components/script/textinput.rs
@@ -594,6 +594,13 @@ impl<T: ClipboardProvider> TextInput<T> {
         } else {
             Selection::NotSelected
         };
+
+        let alt_or_control = if macos {
+            Modifiers::ALT
+        } else {
+            Modifiers::CONTROL
+        };
+
         mods.remove(Modifiers::SHIFT);
         ShortcutMatcher::new(KeyState::Down, key.clone(), mods)
             .shortcut(Modifiers::CONTROL | Modifiers::ALT, 'B', || {
@@ -728,11 +735,11 @@ impl<T: ClipboardProvider> TextInput<T> {
                     KeyReaction::RedrawSelection
                 },
             )
-            .shortcut(Modifiers::ALT, Key::Named(NamedKey::ArrowLeft), || {
+            .shortcut(alt_or_control, Key::Named(NamedKey::ArrowLeft), || {
                 self.modify_selection_or_edit_point(-1, RopeMovement::Word, maybe_select);
                 KeyReaction::RedrawSelection
             })
-            .shortcut(Modifiers::ALT, Key::Named(NamedKey::ArrowRight), || {
+            .shortcut(alt_or_control, Key::Named(NamedKey::ArrowRight), || {
                 self.modify_selection_or_edit_point(1, RopeMovement::Word, maybe_select);
                 KeyReaction::RedrawSelection
             })

--- a/tests/wpt/meta/selection/move-by-word-with-symbol.html.ini
+++ b/tests/wpt/meta/selection/move-by-word-with-symbol.html.ini
@@ -4,15 +4,3 @@
 
   [Symbols should be included while moving forward by word]
     expected: FAIL
-
-  [Symbols should be included while moving backward by word in textarea element]
-    expected: FAIL
-
-  [Symbols should be included while moving forward by word in textarea element]
-    expected: FAIL
-
-  [Symbols should be included while moving backward by word in input element]
-    expected: FAIL
-
-  [Symbols should be included while moving forward by word in input element]
-    expected: FAIL

--- a/tests/wpt/mozilla/meta/MANIFEST.json
+++ b/tests/wpt/mozilla/meta/MANIFEST.json
@@ -13177,6 +13177,15 @@
       }
      ]
     ],
+    "key-event-text-input-motion.html": [
+     "1e14f2dca3b8e019050396030c7de84bdf06b255",
+     [
+      null,
+      {
+       "testdriver": true
+      }
+     ]
+    ],
     "key-events-in-text-input-prevent-scrolling.html": [
      "62c69c903205cd626b141fc8beea055ea5f7c53d",
      [

--- a/tests/wpt/mozilla/tests/input-events/key-event-text-input-motion.html
+++ b/tests/wpt/mozilla/tests/input-events/key-event-text-input-motion.html
@@ -1,0 +1,129 @@
+<!DOCTYPE html>
+<title>Arrow keys should move the selection in an input field</title>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/resources/testdriver.js"></script>
+<script src="/resources/testdriver-actions.js"></script>
+<script src="/resources/testdriver-vendor.js"></script>
+<link rel="stylesheet" type="text/css" href="/fonts/ahem.css" />
+
+<style>
+    .text {
+        width: 100px;
+    }
+</style>
+
+<input class="text" id="input" value="word word">
+<textarea class="text" id="textarea">
+word word
+abc
+word word
+</textarea>
+
+<script>
+const arrowLeftKey = "\uE012";
+const arrowUpKey = "\uE013";
+const arrowRightKey = "\uE014";
+const arrowDownKey = "\uE015";
+const controlKey = "\uE009";
+const altKey = "\uE00A";
+const isMacOSX = navigator.userAgent.indexOf("Mac") != -1;
+const wordMoveKey = isMacOSX ? altKey : controlKey;
+
+async function pressKeyWithWordMoveModifier(key) {
+     await new test_driver.Actions()
+        .keyDown(wordMoveKey)
+        .keyDown(key)
+        .keyUp(key)
+        .keyUp(wordMoveKey)
+        .send();
+}
+
+promise_test(async test => {
+    input.focus();
+    assert_equals(input.selectionStart, 0);
+    assert_equals(input.selectionEnd, 0);
+
+    await test_driver.send_keys(input, arrowRightKey);
+    assert_equals(input.selectionStart, 1);
+    assert_equals(input.selectionEnd, 1);
+
+    await test_driver.send_keys(input, arrowRightKey);
+    assert_equals(input.selectionStart, 2);
+    assert_equals(input.selectionEnd, 2);
+
+    await pressKeyWithWordMoveModifier(arrowRightKey);
+    assert_equals(input.selectionStart, 4);
+    assert_equals(input.selectionEnd, 4);
+
+    await pressKeyWithWordMoveModifier(arrowRightKey);
+    assert_equals(input.selectionStart, 9);
+    assert_equals(input.selectionEnd, 9);
+
+    await pressKeyWithWordMoveModifier(arrowRightKey);
+    assert_equals(input.selectionStart, 9);
+    assert_equals(input.selectionEnd, 9);
+
+    await pressKeyWithWordMoveModifier(arrowLeftKey);
+    assert_equals(input.selectionStart, 5);
+    assert_equals(input.selectionEnd, 5);
+
+    await pressKeyWithWordMoveModifier(arrowLeftKey);
+    assert_equals(input.selectionStart, 0);
+    assert_equals(input.selectionEnd, 0);
+
+    await pressKeyWithWordMoveModifier(arrowLeftKey);
+    assert_equals(input.selectionStart, 0);
+    assert_equals(input.selectionEnd, 0);
+}, 'Arrows keys move the selection in an input field');
+
+promise_test(async test => {
+    textarea.focus();
+    assert_equals(textarea.selectionStart, 0);
+    assert_equals(textarea.selectionEnd, 0);
+
+    await test_driver.send_keys(textarea, arrowRightKey);
+    assert_equals(textarea.selectionStart, 1);
+    assert_equals(textarea.selectionEnd, 1);
+
+    await test_driver.send_keys(textarea, arrowRightKey);
+    assert_equals(textarea.selectionStart, 2);
+    assert_equals(textarea.selectionEnd, 2);
+
+    await pressKeyWithWordMoveModifier(arrowRightKey);
+    assert_equals(textarea.selectionStart, 4);
+    assert_equals(textarea.selectionEnd, 4);
+
+    await pressKeyWithWordMoveModifier(arrowRightKey);
+    assert_equals(textarea.selectionStart, 9);
+    assert_equals(textarea.selectionEnd, 9);
+
+    await test_driver.send_keys(textarea, arrowDownKey);
+    assert_equals(textarea.selectionStart, 13);
+    assert_equals(textarea.selectionEnd, 13);
+
+    await test_driver.send_keys(textarea, arrowUpKey);
+    assert_equals(textarea.selectionStart, 3);
+    assert_equals(textarea.selectionEnd, 3);
+
+    await pressKeyWithWordMoveModifier(arrowRightKey);
+    assert_equals(textarea.selectionStart, 4);
+    assert_equals(textarea.selectionEnd, 4);
+
+    await pressKeyWithWordMoveModifier(arrowRightKey);
+    assert_equals(textarea.selectionStart, 9);
+    assert_equals(textarea.selectionEnd, 9);
+
+    await pressKeyWithWordMoveModifier(arrowLeftKey);
+    assert_equals(textarea.selectionStart, 5);
+    assert_equals(textarea.selectionEnd, 5);
+
+    await pressKeyWithWordMoveModifier(arrowLeftKey);
+    assert_equals(textarea.selectionStart, 0);
+    assert_equals(textarea.selectionEnd, 0);
+
+    pressKeyWithWordMoveModifier(arrowLeftKey);
+    assert_equals(textarea.selectionStart, 0);
+    assert_equals(textarea.selectionEnd, 0);
+}, 'Arrow keys move the selection in an textarea');
+</script>


### PR DESCRIPTION
On Windows and Linux the control key is expected to move the text caret
by word. In addition, it seems like the alt wasn't working properly on
Linux. This change makes the modifier key for word movement dependent on
the platform.

Testing: This change adds a Servo-specific keyboard motion test. Keyboard motion events are not specified AFAIK.
