### PR TITLE
script: Fix current URL for CSP requests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -331,7 +331,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -342,7 +342,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1389,9 +1389,9 @@ checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
 
 [[package]]
 name = "content-security-policy"
-version = "0.6.1"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92693f0f50d58b279ffb4a005722c509739e1d01bb53e6cf8d3c06ffb6b101ef"
+checksum = "47ed7d27b1e6023b7fce811326a8835769ca374149e1da7c8fcfb684bdb260fc"
 dependencies = [
  "base64 0.22.1",
  "bitflags 2.11.0",
@@ -1901,7 +1901,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2293,7 +2293,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2849,7 +2849,7 @@ dependencies = [
  "gobject-sys",
  "libc",
  "system-deps 7.0.5",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4405,7 +4405,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5193,7 +5193,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6929,7 +6929,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.11.0",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6986,7 +6986,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -9509,7 +9509,7 @@ dependencies = [
  "getrandom 0.3.4",
  "once_cell",
  "rustix 1.1.2",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -10052,7 +10052,7 @@ checksum = "f2f6fb2847f6742cd76af783a2a2c49e9375d0a111c7bef6f71cd9e738c72d6e"
 dependencies = [
  "memoffset",
  "tempfile",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -10996,7 +10996,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,7 +52,7 @@ chacha20poly1305 = "0.10"
 chardetng = "0.1"
 chrono = { version = "0.4", features = ["serde"] }
 cipher = { version = "0.4.4", features = ["alloc"] }
-content-security-policy = { version = "0.6.1", features = ["serde"] }
+content-security-policy = { version = "0.7.0", features = ["serde"] }
 cookie = { package = "cookie", version = "0.18" }
 crossbeam-channel = "0.5"
 cssparser = { version = "0.36", features = ["serde"] }

--- a/components/net/fetch/methods.rs
+++ b/components/net/fetch/methods.rs
@@ -251,15 +251,22 @@ pub(crate) fn convert_request_to_csp_request(request: &Request) -> Option<csp::R
         Origin::Origin(origin) => origin,
     };
 
-    // We need to retroactively upgrade the ws URL if the rewritten http URL was upgraded to a secure scheme.
-    // https://github.com/w3c/webappsec-csp/issues/532
     let mut original_url = request.original_url();
-    if original_url.scheme() == "ws" && request.url().scheme() == "https" {
-        original_url.as_mut_url().set_scheme("wss").unwrap();
-    }
+    let current_url = if original_url.scheme() == "ws" {
+        // We need to retroactively upgrade the ws URL if the rewritten http URL was upgraded to a secure scheme.
+        // https://github.com/w3c/webappsec-csp/issues/532
+        if request.url().scheme() == "https" {
+            original_url.as_mut_url().set_scheme("wss").unwrap();
+        }
+        // For ws scheme, we should check against the original URL, not the current HTTP URL
+        original_url.clone()
+    } else {
+        request.current_url()
+    };
 
     let csp_request = csp::Request {
         url: original_url.into_url(),
+        current_url: current_url.into_url(),
         origin: origin.clone().into_url_origin(),
         redirect_count: request.redirect_count,
         destination: request.destination,

--- a/components/script/dom/security/csp.rs
+++ b/components/script/dom/security/csp.rs
@@ -116,6 +116,8 @@ impl CspReporting for Option<CspList> {
         };
         let mut request = Request {
             url: load_data.url.clone().into_url(),
+            // TODO: Figure out how to propagate redirect data from LoadData into here
+            current_url: load_data.url.clone().into_url(),
             origin: match &load_data.load_origin {
                 LoadOrigin::Script(origin) => origin.immutable().clone().into_url_origin(),
                 _ => Origin::new_opaque(),

--- a/tests/wpt/meta/content-security-policy/connect-src/connect-src-eventsource-redirect-to-blocked.sub.html.ini
+++ b/tests/wpt/meta/content-security-policy/connect-src/connect-src-eventsource-redirect-to-blocked.sub.html.ini
@@ -1,3 +1,0 @@
-[connect-src-eventsource-redirect-to-blocked.sub.html]
-  [Expecting logs: ["PASS EventSource() did not follow the disallowed redirect.","TEST COMPLETE", "violated-directive=connect-src"\]]
-    expected: FAIL

--- a/tests/wpt/meta/content-security-policy/gen/top.http-rp/script-src-self/script-tag.http.html.ini
+++ b/tests/wpt/meta/content-security-policy/gen/top.http-rp/script-src-self/script-tag.http.html.ini
@@ -1,3 +1,0 @@
-[script-tag.http.html]
-  [Content Security Policy: Expects blocked for script-tag to same-http origin and swap-origin redirection from http context.]
-    expected: FAIL

--- a/tests/wpt/meta/content-security-policy/gen/top.http-rp/script-src-self/script-tag.https.html.ini
+++ b/tests/wpt/meta/content-security-policy/gen/top.http-rp/script-src-self/script-tag.https.html.ini
@@ -1,3 +1,0 @@
-[script-tag.https.html]
-  [Content Security Policy: Expects blocked for script-tag to same-https origin and swap-origin redirection from https context.]
-    expected: FAIL

--- a/tests/wpt/meta/content-security-policy/gen/top.http-rp/script-src-self/worker-import.http.html.ini
+++ b/tests/wpt/meta/content-security-policy/gen/top.http-rp/script-src-self/worker-import.http.html.ini
@@ -1,3 +1,0 @@
-[worker-import.http.html]
-  [Content Security Policy: Expects blocked for worker-import to same-http origin and swap-origin redirection from http context.]
-    expected: FAIL

--- a/tests/wpt/meta/content-security-policy/gen/top.http-rp/script-src-self/worker-import.https.html.ini
+++ b/tests/wpt/meta/content-security-policy/gen/top.http-rp/script-src-self/worker-import.https.html.ini
@@ -1,3 +1,0 @@
-[worker-import.https.html]
-  [Content Security Policy: Expects blocked for worker-import to same-https origin and swap-origin redirection from https context.]
-    expected: FAIL

--- a/tests/wpt/meta/content-security-policy/gen/top.http-rp/worker-src-self/worker-import.http.html.ini
+++ b/tests/wpt/meta/content-security-policy/gen/top.http-rp/worker-src-self/worker-import.http.html.ini
@@ -1,3 +1,0 @@
-[worker-import.http.html]
-  [Content Security Policy: Expects blocked for worker-import to same-http origin and swap-origin redirection from http context.]
-    expected: FAIL

--- a/tests/wpt/meta/content-security-policy/gen/top.http-rp/worker-src-self/worker-import.https.html.ini
+++ b/tests/wpt/meta/content-security-policy/gen/top.http-rp/worker-src-self/worker-import.https.html.ini
@@ -1,3 +1,0 @@
-[worker-import.https.html]
-  [Content Security Policy: Expects blocked for worker-import to same-https origin and swap-origin redirection from https context.]
-    expected: FAIL

--- a/tests/wpt/meta/content-security-policy/gen/top.meta/script-src-self/script-tag.http.html.ini
+++ b/tests/wpt/meta/content-security-policy/gen/top.meta/script-src-self/script-tag.http.html.ini
@@ -1,3 +1,0 @@
-[script-tag.http.html]
-  [Content Security Policy: Expects blocked for script-tag to same-http origin and swap-origin redirection from http context.]
-    expected: FAIL

--- a/tests/wpt/meta/content-security-policy/gen/top.meta/script-src-self/script-tag.https.html.ini
+++ b/tests/wpt/meta/content-security-policy/gen/top.meta/script-src-self/script-tag.https.html.ini
@@ -1,3 +1,0 @@
-[script-tag.https.html]
-  [Content Security Policy: Expects blocked for script-tag to same-https origin and swap-origin redirection from https context.]
-    expected: FAIL

--- a/tests/wpt/meta/content-security-policy/gen/top.meta/script-src-self/worker-import.http.html.ini
+++ b/tests/wpt/meta/content-security-policy/gen/top.meta/script-src-self/worker-import.http.html.ini
@@ -1,3 +1,0 @@
-[worker-import.http.html]
-  [Content Security Policy: Expects blocked for worker-import to same-http origin and swap-origin redirection from http context.]
-    expected: FAIL

--- a/tests/wpt/meta/content-security-policy/gen/top.meta/script-src-self/worker-import.https.html.ini
+++ b/tests/wpt/meta/content-security-policy/gen/top.meta/script-src-self/worker-import.https.html.ini
@@ -1,3 +1,0 @@
-[worker-import.https.html]
-  [Content Security Policy: Expects blocked for worker-import to same-https origin and swap-origin redirection from https context.]
-    expected: FAIL

--- a/tests/wpt/meta/content-security-policy/gen/top.meta/worker-src-self/worker-import.http.html.ini
+++ b/tests/wpt/meta/content-security-policy/gen/top.meta/worker-src-self/worker-import.http.html.ini
@@ -1,3 +1,0 @@
-[worker-import.http.html]
-  [Content Security Policy: Expects blocked for worker-import to same-http origin and swap-origin redirection from http context.]
-    expected: FAIL

--- a/tests/wpt/meta/content-security-policy/gen/top.meta/worker-src-self/worker-import.https.html.ini
+++ b/tests/wpt/meta/content-security-policy/gen/top.meta/worker-src-self/worker-import.https.html.ini
@@ -1,3 +1,0 @@
-[worker-import.https.html]
-  [Content Security Policy: Expects blocked for worker-import to same-https origin and swap-origin redirection from https context.]
-    expected: FAIL

--- a/tests/wpt/meta/content-security-policy/securitypolicyviolation/img-src-redirect-upgrade-reporting.https.html.ini
+++ b/tests/wpt/meta/content-security-policy/securitypolicyviolation/img-src-redirect-upgrade-reporting.https.html.ini
@@ -1,4 +1,0 @@
-[img-src-redirect-upgrade-reporting.https.html]
-  expected: TIMEOUT
-  [Image that redirects to http:// URL prohibited by Report-Only must generate a violation report, even with upgrade-insecure-requests]
-    expected: TIMEOUT

--- a/tests/wpt/meta/content-security-policy/securitypolicyviolation/inside-dedicated-worker.html.ini
+++ b/tests/wpt/meta/content-security-policy/securitypolicyviolation/inside-dedicated-worker.html.ini
@@ -1,4 +1,0 @@
-[inside-dedicated-worker.html]
-  expected: TIMEOUT
-  [SecurityPolicyViolation event fired on global with the correct blockedURI.]
-    expected: TIMEOUT

--- a/tests/wpt/meta/fetch/fetch-later/policies/csp-redirect-to-blocked.https.window.js.ini
+++ b/tests/wpt/meta/fetch/fetch-later/policies/csp-redirect-to-blocked.https.window.js.ini
@@ -1,3 +1,0 @@
-[csp-redirect-to-blocked.https.window.html]
-  [FetchLater redirect blocked by CSP should reject]
-    expected: FAIL


### PR DESCRIPTION
The CSP crate was incorrectly using the request URL for both checking if policies were matching, as well as reporting that URL. However, the CSP specification uses the current URL to check for policies and the url for reporting a violation.

Therefore, set the new current_url field for these requests, leaving the ws scheme URLs as a special case. We also should take redirects into account for navigations (which is only relevant for forms), but LoadData currently has no notion of keeping track of that.