### PR TITLE
script: Pass `&mut JSContext` to more functions in `dom/stream`

### DIFF
--- a/components/script/dom/encoding/textdecoderstream.rs
+++ b/components/script/dom/encoding/textdecoderstream.rs
@@ -27,16 +27,15 @@ use crate::script_runtime::{CanGc, JSContext as SafeJSContext};
 /// <https://encoding.spec.whatwg.org/#decode-and-enqueue-a-chunk>
 #[expect(unsafe_code)]
 pub(crate) fn decode_and_enqueue_a_chunk(
-    cx: SafeJSContext,
+    cx: &mut js::context::JSContext,
     global: &GlobalScope,
     chunk: SafeHandleValue,
     decoder: &TextDecoderCommon,
     controller: &TransformStreamDefaultController,
-    can_gc: CanGc,
 ) -> Fallible<()> {
     // Step 1. Let bufferSource be the result of converting chunk to an AllowSharedBufferSource.
     let conversion_result = unsafe {
-        ArrayBufferViewOrArrayBuffer::from_jsval(*cx, chunk, ()).map_err(|_| {
+        ArrayBufferViewOrArrayBuffer::from_jsval(cx.raw_cx(), chunk, ()).map_err(|_| {
             Error::Type(c"Unable to convert chunk into ArrayBuffer or ArrayBufferView".to_owned())
         })?
     };
@@ -61,19 +60,18 @@ pub(crate) fn decode_and_enqueue_a_chunk(
     if output_chunk.is_empty() {
         return Ok(());
     }
-    rooted!(in(*cx) let mut rval = UndefinedValue());
-    unsafe { output_chunk.to_jsval(*cx, rval.handle_mut()) };
-    controller.enqueue(cx, global, rval.handle(), can_gc)
+    rooted!(&in(cx) let mut rval = UndefinedValue());
+    unsafe { output_chunk.to_jsval(cx.raw_cx(), rval.handle_mut()) };
+    controller.enqueue(cx, global, rval.handle())
 }
 
 /// <https://encoding.spec.whatwg.org/#flush-and-enqueue>
 #[expect(unsafe_code)]
 pub(crate) fn flush_and_enqueue(
-    cx: SafeJSContext,
+    cx: &mut js::context::JSContext,
     global: &GlobalScope,
     decoder: &TextDecoderCommon,
     controller: &TransformStreamDefaultController,
-    can_gc: CanGc,
 ) -> Fallible<()> {
     // Step 1. Let output be the I/O queue of scalar values « end-of-queue ».
     // Step 2. While true:
@@ -92,9 +90,9 @@ pub(crate) fn flush_and_enqueue(
     if output_chunk.is_empty() {
         return Ok(());
     }
-    rooted!(in(*cx) let mut rval = UndefinedValue());
-    unsafe { output_chunk.to_jsval(*cx, rval.handle_mut()) };
-    controller.enqueue(cx, global, rval.handle(), can_gc)
+    rooted!(&in(cx) let mut rval = UndefinedValue());
+    unsafe { output_chunk.to_jsval(cx.raw_cx(), rval.handle_mut()) };
+    controller.enqueue(cx, global, rval.handle())
 }
 
 /// <https://encoding.spec.whatwg.org/#textdecoderstream>

--- a/components/script/dom/encoding/textencoderstream.rs
+++ b/components/script/dom/encoding/textencoderstream.rs
@@ -212,28 +212,33 @@ fn code_point_type(value: u16) -> CodePointType {
 /// <https://encoding.spec.whatwg.org/#encode-and-enqueue-a-chunk>
 #[expect(unsafe_code)]
 pub(crate) fn encode_and_enqueue_a_chunk(
-    cx: SafeJSContext,
+    cx: &mut js::context::JSContext,
     global: &GlobalScope,
     chunk: SafeHandleValue,
     encoder: &Encoder,
     controller: &TransformStreamDefaultController,
-    can_gc: CanGc,
 ) -> Fallible<()> {
     // Step 1. Let input be the result of converting chunk to a DOMString.
     // Step 2. Convert input to an I/O queue of code units.
-    rooted!(in(*cx) let mut rval = UndefinedValue());
-    jsval_to_primitive(cx, global, chunk, rval.handle_mut(), can_gc)?;
+    rooted!(&in(cx) let mut rval = UndefinedValue());
+    jsval_to_primitive(
+        cx.into(),
+        global,
+        chunk,
+        rval.handle_mut(),
+        CanGc::from_cx(cx),
+    )?;
 
     assert!(!rval.is_object());
-    rooted!(in(*cx) let jsstr = unsafe { ToString(*cx, rval.handle()) });
+    rooted!(&in(cx) let jsstr = unsafe { ToString(cx.raw_cx(), rval.handle()) });
     if jsstr.is_null() {
         unsafe {
-            if !JS_IsExceptionPending(*cx) {
+            if !JS_IsExceptionPending(cx.raw_cx()) {
                 throw_dom_exception(
-                    cx,
+                    cx.into(),
                     global,
                     Error::Type(c"Cannot convert JS primitive to string".to_owned()),
-                    can_gc,
+                    CanGc::from_cx(cx),
                 );
             }
         }
@@ -244,10 +249,11 @@ pub(crate) fn encode_and_enqueue_a_chunk(
     let input = unsafe {
         if JS_DeprecatedStringHasLatin1Chars(*jsstr) {
             let s = NonNull::new(*jsstr).expect("jsstr cannot be null");
-            ConvertedInput::String(latin1_to_string(*cx, s))
+            ConvertedInput::String(latin1_to_string(cx.raw_cx(), s))
         } else {
             let mut len = 0;
-            let data = JS_GetTwoByteStringCharsAndLength(*cx, std::ptr::null(), *jsstr, &mut len);
+            let data =
+                JS_GetTwoByteStringCharsAndLength(cx.raw_cx(), std::ptr::null(), *jsstr, &mut len);
             let maybe_ill_formed_code_units = std::slice::from_raw_parts(data, len);
             ConvertedInput::CodeUnits(maybe_ill_formed_code_units)
         }
@@ -273,40 +279,44 @@ pub(crate) fn encode_and_enqueue_a_chunk(
 
     // Step 4.2.2.1 Let chunk be the result of creating a Uint8Array object
     //      given output and encoder’s relevant realm.
-    rooted!(in(*cx) let mut js_object = ptr::null_mut::<JSObject>());
-    let chunk = create_buffer_source::<Uint8>(cx, output, js_object.handle_mut(), can_gc)
-        .map_err(|_| Error::Type(c"Cannot convert byte sequence to Uint8Array".to_owned()))?;
-    rooted!(in(*cx) let mut rval = UndefinedValue());
-    chunk.safe_to_jsval(cx, rval.handle_mut(), can_gc);
+    rooted!(&in(cx) let mut js_object = ptr::null_mut::<JSObject>());
+    let chunk = create_buffer_source::<Uint8>(
+        cx.into(),
+        output,
+        js_object.handle_mut(),
+        CanGc::from_cx(cx),
+    )
+    .map_err(|_| Error::Type(c"Cannot convert byte sequence to Uint8Array".to_owned()))?;
+    rooted!(&in(cx) let mut rval = UndefinedValue());
+    chunk.safe_to_jsval(cx.into(), rval.handle_mut(), CanGc::from_cx(cx));
     // Step 4.2.2.2 Enqueue chunk into encoder’s transform.
-    controller.enqueue(cx, global, rval.handle(), can_gc)?;
+    controller.enqueue(cx, global, rval.handle())?;
     Ok(())
 }
 
 /// <https://encoding.spec.whatwg.org/#encode-and-flush>
 pub(crate) fn encode_and_flush(
-    cx: SafeJSContext,
+    cx: &mut js::context::JSContext,
     global: &GlobalScope,
     encoder: &Encoder,
     controller: &TransformStreamDefaultController,
-    can_gc: CanGc,
 ) -> Fallible<()> {
     // Step 1. If encoder’s leading surrogate is non-null:
     if encoder.leading_surrogate.get().is_some() {
         // Step 1.1 Let chunk be the result of creating a Uint8Array object
         //      given « 0xEF, 0xBF, 0xBD » and encoder’s relevant realm.
-        rooted!(in(*cx) let mut js_object = ptr::null_mut::<JSObject>());
+        rooted!(&in(cx) let mut js_object = ptr::null_mut::<JSObject>());
         let chunk = create_buffer_source::<Uint8>(
-            cx,
+            cx.into(),
             &[0xEF_u8, 0xBF, 0xBD],
             js_object.handle_mut(),
-            can_gc,
+            CanGc::from_cx(cx),
         )
         .map_err(|_| Error::Type(c"Cannot convert byte sequence to Uint8Array".to_owned()))?;
-        rooted!(in(*cx) let mut rval = UndefinedValue());
-        chunk.safe_to_jsval(cx, rval.handle_mut(), can_gc);
+        rooted!(&in(cx) let mut rval = UndefinedValue());
+        chunk.safe_to_jsval(cx.into(), rval.handle_mut(), CanGc::from_cx(cx));
         // Step 1.2 Enqueue chunk into encoder’s transform.
-        return controller.enqueue(cx, global, rval.handle(), can_gc);
+        return controller.enqueue(cx, global, rval.handle());
     }
 
     Ok(())

--- a/components/script/dom/stream/compressionstream.rs
+++ b/components/script/dom/stream/compressionstream.rs
@@ -207,15 +207,14 @@ impl CompressionStreamMethods<crate::DomTypeHolder> for CompressionStream {
 
 /// <https://compression.spec.whatwg.org/#compress-and-enqueue-a-chunk>
 pub(crate) fn compress_and_enqueue_a_chunk(
-    cx: SafeJSContext,
+    cx: &mut js::context::JSContext,
     global: &GlobalScope,
     cs: &CompressionStream,
     chunk: SafeHandleValue,
     controller: &TransformStreamDefaultController,
-    can_gc: CanGc,
 ) -> Fallible<()> {
     // Step 1. If chunk is not a BufferSource type, then throw a TypeError.
-    let chunk = convert_chunk_to_vec(cx, chunk, can_gc)?;
+    let chunk = convert_chunk_to_vec(cx.into(), chunk, CanGc::from_cx(cx))?;
 
     // Step 2. Let buffer be the result of compressing chunk with cs’s format and context.
     // NOTE: In our implementation, the enum type of context already indicates the format.
@@ -238,13 +237,17 @@ pub(crate) fn compress_and_enqueue_a_chunk(
     // converting them into Uint8Arrays.
     // Step 5. For each Uint8Array array of arrays, enqueue array in cs’s transform.
     // NOTE: We process the result in a single Uint8Array.
-    rooted!(in(*cx) let mut js_object = ptr::null_mut::<JSObject>());
-    let buffer_source =
-        create_buffer_source::<Uint8>(cx, buffer, js_object.handle_mut(), can_gc)
-            .map_err(|_| Error::Type(c"Cannot convert byte sequence to Uint8Array".to_owned()))?;
-    rooted!(in(*cx) let mut rval = UndefinedValue());
-    buffer_source.safe_to_jsval(cx, rval.handle_mut(), can_gc);
-    controller.enqueue(cx, global, rval.handle(), can_gc)?;
+    rooted!(&in(cx) let mut js_object = ptr::null_mut::<JSObject>());
+    let buffer_source = create_buffer_source::<Uint8>(
+        cx.into(),
+        buffer,
+        js_object.handle_mut(),
+        CanGc::from_cx(cx),
+    )
+    .map_err(|_| Error::Type(c"Cannot convert byte sequence to Uint8Array".to_owned()))?;
+    rooted!(&in(cx) let mut rval = UndefinedValue());
+    buffer_source.safe_to_jsval(cx.into(), rval.handle_mut(), CanGc::from_cx(cx));
+    controller.enqueue(cx, global, rval.handle())?;
 
     // NOTE: We don't need to keep result that has been copied to Uint8Array. Clear the inner
     // buffer of compressor to save memory.
@@ -255,11 +258,10 @@ pub(crate) fn compress_and_enqueue_a_chunk(
 
 /// <https://compression.spec.whatwg.org/#compress-flush-and-enqueue>
 pub(crate) fn compress_flush_and_enqueue(
-    cx: SafeJSContext,
+    cx: &mut js::context::JSContext,
     global: &GlobalScope,
     cs: &CompressionStream,
     controller: &TransformStreamDefaultController,
-    can_gc: CanGc,
 ) -> Fallible<()> {
     // Step 1. Let buffer be the result of compressing an empty input with cs’s format and context,
     // with the finish flag.
@@ -280,13 +282,17 @@ pub(crate) fn compress_flush_and_enqueue(
     // converting them into Uint8Arrays.
     // Step 4. For each Uint8Array array of arrays, enqueue array in cs’s transform.
     // NOTE: We process the result in a single Uint8Array.
-    rooted!(in(*cx) let mut js_object = ptr::null_mut::<JSObject>());
-    let buffer_source =
-        create_buffer_source::<Uint8>(cx, buffer, js_object.handle_mut(), can_gc)
-            .map_err(|_| Error::Type(c"Cannot convert byte sequence to Uint8Array".to_owned()))?;
-    rooted!(in(*cx) let mut rval = UndefinedValue());
-    buffer_source.safe_to_jsval(cx, rval.handle_mut(), can_gc);
-    controller.enqueue(cx, global, rval.handle(), can_gc)?;
+    rooted!(&in(cx) let mut js_object = ptr::null_mut::<JSObject>());
+    let buffer_source = create_buffer_source::<Uint8>(
+        cx.into(),
+        buffer,
+        js_object.handle_mut(),
+        CanGc::from_cx(cx),
+    )
+    .map_err(|_| Error::Type(c"Cannot convert byte sequence to Uint8Array".to_owned()))?;
+    rooted!(&in(cx) let mut rval = UndefinedValue());
+    buffer_source.safe_to_jsval(cx.into(), rval.handle_mut(), CanGc::from_cx(cx));
+    controller.enqueue(cx, global, rval.handle())?;
 
     // NOTE: We don't need to keep result that has been copied to Uint8Array. Clear the inner
     // buffer of compressor to save memory.

--- a/components/script/dom/stream/decompressionstream.rs
+++ b/components/script/dom/stream/decompressionstream.rs
@@ -27,7 +27,7 @@ use crate::dom::stream::transformstreamdefaultcontroller::TransformerType;
 use crate::dom::types::{
     GlobalScope, ReadableStream, TransformStream, TransformStreamDefaultController, WritableStream,
 };
-use crate::script_runtime::{CanGc, JSContext as SafeJSContext};
+use crate::script_runtime::CanGc;
 
 /// A wrapper to blend ZlibDecoder<Vec<u8>>, DeflateDecoder<Vec<u8>> and GzDecoder<Vec<u8>>
 /// together as a single type.
@@ -204,15 +204,14 @@ impl DecompressionStreamMethods<crate::DomTypeHolder> for DecompressionStream {
 
 /// <https://compression.spec.whatwg.org/#decompress-and-enqueue-a-chunk>
 pub(crate) fn decompress_and_enqueue_a_chunk(
-    cx: SafeJSContext,
+    cx: &mut js::context::JSContext,
     global: &GlobalScope,
     ds: &DecompressionStream,
     chunk: SafeHandleValue,
     controller: &TransformStreamDefaultController,
-    can_gc: CanGc,
 ) -> Fallible<()> {
     // Step 1. If chunk is not a BufferSource type, then throw a TypeError.
-    let chunk = convert_chunk_to_vec(cx, chunk, can_gc)?;
+    let chunk = convert_chunk_to_vec(cx.into(), chunk, CanGc::from_cx(cx))?;
 
     // Step 2. Let buffer be the result of decompressing chunk with ds’s format and context. If
     // this results in an error, then throw a TypeError.
@@ -240,12 +239,17 @@ pub(crate) fn decompress_and_enqueue_a_chunk(
     // converting them into Uint8Arrays.
     // Step 5. For each Uint8Array array of arrays, enqueue array in ds’s transform.
     // NOTE: We process the result in a single Uint8Array.
-    rooted!(in(*cx) let mut js_object = ptr::null_mut::<JSObject>());
-    let array = create_buffer_source::<Uint8>(cx, buffer, js_object.handle_mut(), can_gc)
-        .map_err(|_| Error::Type(c"Cannot convert byte sequence to Uint8Array".to_owned()))?;
-    rooted!(in(*cx) let mut rval = UndefinedValue());
-    array.safe_to_jsval(cx, rval.handle_mut(), can_gc);
-    controller.enqueue(cx, global, rval.handle(), can_gc)?;
+    rooted!(&in(cx) let mut js_object = ptr::null_mut::<JSObject>());
+    let array = create_buffer_source::<Uint8>(
+        cx.into(),
+        buffer,
+        js_object.handle_mut(),
+        CanGc::from_cx(cx),
+    )
+    .map_err(|_| Error::Type(c"Cannot convert byte sequence to Uint8Array".to_owned()))?;
+    rooted!(&in(cx) let mut rval = UndefinedValue());
+    array.safe_to_jsval(cx.into(), rval.handle_mut(), CanGc::from_cx(cx));
+    controller.enqueue(cx, global, rval.handle())?;
 
     // NOTE: We don't need to keep result that has been copied to Uint8Array. Clear the inner
     // buffer of decompressor to save memory.
@@ -264,11 +268,10 @@ pub(crate) fn decompress_and_enqueue_a_chunk(
 
 /// <https://compression.spec.whatwg.org/#decompress-flush-and-enqueue>
 pub(crate) fn decompress_flush_and_enqueue(
-    cx: SafeJSContext,
+    cx: &mut js::context::JSContext,
     global: &GlobalScope,
     ds: &DecompressionStream,
     controller: &TransformStreamDefaultController,
-    can_gc: CanGc,
 ) -> Fallible<()> {
     // Step 1. Let buffer be the result of decompressing an empty input with ds’s format and
     // context, with the finish flag.
@@ -290,12 +293,17 @@ pub(crate) fn decompress_flush_and_enqueue(
         // and converting them into Uint8Arrays.
         // Step 2.2. For each Uint8Array array of arrays, enqueue array in ds’s transform.
         // NOTE: We process the result in a single Uint8Array.
-        rooted!(in(*cx) let mut js_object = ptr::null_mut::<JSObject>());
-        let array = create_buffer_source::<Uint8>(cx, buffer, js_object.handle_mut(), can_gc)
-            .map_err(|_| Error::Type(c"Cannot convert byte sequence to Uint8Array".to_owned()))?;
-        rooted!(in(*cx) let mut rval = UndefinedValue());
-        array.safe_to_jsval(cx, rval.handle_mut(), can_gc);
-        controller.enqueue(cx, global, rval.handle(), can_gc)?;
+        rooted!(&in(cx) let mut js_object = ptr::null_mut::<JSObject>());
+        let array = create_buffer_source::<Uint8>(
+            cx.into(),
+            buffer,
+            js_object.handle_mut(),
+            CanGc::from_cx(cx),
+        )
+        .map_err(|_| Error::Type(c"Cannot convert byte sequence to Uint8Array".to_owned()))?;
+        rooted!(&in(cx) let mut rval = UndefinedValue());
+        array.safe_to_jsval(cx.into(), rval.handle_mut(), CanGc::from_cx(cx));
+        controller.enqueue(cx, global, rval.handle())?;
     }
 
     // NOTE: We don't need to keep result that has been copied to Uint8Array. Clear the inner

--- a/components/script/dom/stream/readablestream.rs
+++ b/components/script/dom/stream/readablestream.rs
@@ -263,7 +263,7 @@ impl Callback for PipeTo {
 
                     if !done {
                         // If any chunks have been read but not yet written, write them to dest.
-                        self.write_chunk(cx.into(), &global, result, CanGc::from_cx(cx));
+                        self.write_chunk(cx, &global, result);
                     }
                 }
             }
@@ -292,7 +292,7 @@ impl Callback for PipeTo {
             },
             PipeToState::PendingRead => {
                 // Write the chunk.
-                self.write_chunk(cx.into(), &global, result, CanGc::from_cx(cx));
+                self.write_chunk(cx, &global, result);
 
                 // An early return is necessary if the write algorithm aborted the pipe.
                 if self.shutting_down.get() {
@@ -426,21 +426,26 @@ impl PipeTo {
     #[expect(unsafe_code)]
     fn write_chunk(
         &self,
-        cx: SafeJSContext,
+        cx: &mut js::context::JSContext,
         global: &GlobalScope,
         chunk: SafeHandleValue,
-        can_gc: CanGc,
     ) -> bool {
         if chunk.is_object() {
-            rooted!(in(*cx) let object = chunk.to_object());
-            rooted!(in(*cx) let mut bytes = UndefinedValue());
+            rooted!(&in(cx) let object = chunk.to_object());
+            rooted!(&in(cx) let mut bytes = UndefinedValue());
             let has_value = unsafe {
-                get_dictionary_property(*cx, object.handle(), c"value", bytes.handle_mut(), can_gc)
-                    .expect("Chunk should have a value.")
+                get_dictionary_property(
+                    cx.raw_cx(),
+                    object.handle(),
+                    c"value",
+                    bytes.handle_mut(),
+                    CanGc::from_cx(cx),
+                )
+                .expect("Chunk should have a value.")
             };
             if has_value {
                 // Write the chunk.
-                let write_promise = self.writer.write(cx, global, bytes.handle(), can_gc);
+                let write_promise = self.writer.write(cx, global, bytes.handle());
                 self.pending_writes.borrow_mut().push_back(write_promise);
                 return true;
             }
@@ -669,9 +674,9 @@ impl PipeTo {
                     .expect("Reader should have a stream.");
                 source.cancel(cx, global, error.handle())
             },
-            ShutdownAction::WritableStreamDefaultWriterCloseWithErrorPropagation => self
-                .writer
-                .close_with_error_propagation(cx.into(), global, CanGc::from_cx(cx)),
+            ShutdownAction::WritableStreamDefaultWriterCloseWithErrorPropagation => {
+                self.writer.close_with_error_propagation(cx, global)
+            },
             ShutdownAction::Abort => {
                 // Note: implementation of the `abortAlgorithm`
                 // of the signal associated with this piping operation.

--- a/components/script/dom/stream/transformstream.rs
+++ b/components/script/dom/stream/transformstream.rs
@@ -68,15 +68,14 @@ struct TransformBackPressureChangePromiseFulfillment {
 impl Callback for TransformBackPressureChangePromiseFulfillment {
     /// Reacting to backpressureChangePromise with the following fulfillment steps:
     fn callback(&self, cx: &mut CurrentRealm, _v: SafeHandleValue) {
-        let can_gc = CanGc::from_cx(cx);
-        let cx: SafeJSContext = cx.into();
         // Let writable be stream.[[writable]].
         // Let state be writable.[[state]].
         // If state is "erroring", throw writable.[[storedError]].
         if self.writable.is_erroring() {
-            rooted!(in(*cx) let mut error = UndefinedValue());
+            rooted!(&in(cx) let mut error = UndefinedValue());
             self.writable.get_stored_error(error.handle_mut());
-            self.result_promise.reject(cx, error.handle(), can_gc);
+            self.result_promise
+                .reject(cx.into(), error.handle(), CanGc::from_cx(cx));
             return;
         }
 
@@ -84,7 +83,7 @@ impl Callback for TransformBackPressureChangePromiseFulfillment {
         assert!(self.writable.is_writable());
 
         // Return ! TransformStreamDefaultControllerPerformTransform(controller, chunk).
-        rooted!(in(*cx) let mut chunk = UndefinedValue());
+        rooted!(&in(cx) let mut chunk = UndefinedValue());
         chunk.set(self.chunk.get());
         let transform_result = self
             .controller
@@ -92,7 +91,6 @@ impl Callback for TransformBackPressureChangePromiseFulfillment {
                 cx,
                 &self.writable.global(),
                 chunk.handle(),
-                can_gc,
             )
             .expect("perform transform failed");
 
@@ -106,12 +104,14 @@ impl Callback for TransformBackPressureChangePromiseFulfillment {
             Some(Box::new(PerformTransformRejection {
                 result_promise: self.result_promise.clone(),
             })),
-            can_gc,
+            CanGc::from_cx(cx),
         );
 
-        let realm = enter_realm(&*self.writable.global());
-        let comp = InRealm::Entered(&realm);
-        transform_result.append_native_handler(&handler, comp, can_gc);
+        let mut realm = enter_auto_realm(cx, &*self.writable.global());
+        let realm = &mut realm.current_realm();
+        let in_realm_proof = realm.into();
+        let comp = InRealm::Already(&in_realm_proof);
+        transform_result.append_native_handler(&handler, comp, CanGc::from_cx(realm));
     }
 }
 
@@ -675,10 +675,9 @@ impl TransformStream {
     /// <https://streams.spec.whatwg.org/#transform-stream-default-sink-write-algorithm>
     pub(crate) fn transform_stream_default_sink_write_algorithm(
         &self,
-        cx: SafeJSContext,
+        cx: &mut js::context::JSContext,
         global: &GlobalScope,
         chunk: SafeHandleValue,
-        can_gc: CanGc,
     ) -> Fallible<Rc<Promise>> {
         // Assert: stream.[[writable]].[[state]] is "writable".
         assert!(self.writable.get().is_some());
@@ -695,8 +694,8 @@ impl TransformStream {
             assert!(backpressure_change_promise.is_some());
 
             // Return the result of reacting to backpressureChangePromise with the following fulfillment steps:
-            let result_promise = Promise::new(global, can_gc);
-            rooted!(in(*cx) let mut fulfillment_handler = Some(TransformBackPressureChangePromiseFulfillment {
+            let result_promise = Promise::new2(cx, global);
+            rooted!(&in(cx) let mut fulfillment_handler = Some(TransformBackPressureChangePromiseFulfillment {
                 controller: Dom::from_ref(&controller),
                 writable: Dom::from_ref(&self.writable.get().expect("writable stream")),
                 chunk: Heap::boxed(chunk.get()),
@@ -709,20 +708,22 @@ impl TransformStream {
                 Some(Box::new(BackpressureChangeRejection {
                     result_promise: result_promise.clone(),
                 })),
-                can_gc,
+                CanGc::from_cx(cx),
             );
-            let realm = enter_realm(global);
-            let comp = InRealm::Entered(&realm);
+            let mut realm = enter_auto_realm(cx, global);
+            let realm = &mut realm.current_realm();
+            let in_realm_proof = realm.into();
+            let comp = InRealm::Already(&in_realm_proof);
             backpressure_change_promise
                 .as_ref()
                 .expect("Promise must be some by now.")
-                .append_native_handler(&handler, comp, can_gc);
+                .append_native_handler(&handler, comp, CanGc::from_cx(realm));
 
             return Ok(result_promise);
         }
 
         // Return ! TransformStreamDefaultControllerPerformTransform(controller, chunk).
-        controller.transform_stream_default_controller_perform_transform(cx, global, chunk, can_gc)
+        controller.transform_stream_default_controller_perform_transform(cx, global, chunk)
     }
 
     /// <https://streams.spec.whatwg.org/#transform-stream-default-sink-abort-algorithm>
@@ -781,9 +782,8 @@ impl TransformStream {
     /// <https://streams.spec.whatwg.org/#transform-stream-default-sink-close-algorithm>
     pub(crate) fn transform_stream_default_sink_close_algorithm(
         &self,
-        cx: SafeJSContext,
+        cx: &mut js::context::JSContext,
         global: &GlobalScope,
-        can_gc: CanGc,
     ) -> Fallible<Rc<Promise>> {
         // Let controller be stream.[[controller]].
         let controller = self
@@ -803,10 +803,10 @@ impl TransformStream {
             .ok_or(Error::Type(c"readable stream is not set".to_owned()))?;
 
         // Let controller.[[finishPromise]] be a new promise.
-        controller.set_finish_promise(Promise::new(global, can_gc));
+        controller.set_finish_promise(Promise::new2(cx, global));
 
         // Let flushPromise be the result of performing controller.[[flushAlgorithm]].
-        let flush_promise = controller.perform_flush(cx, global, can_gc)?;
+        let flush_promise = controller.perform_flush(cx, global)?;
 
         // Perform ! TransformStreamDefaultControllerClearAlgorithms(controller).
         controller.clear_algorithms();
@@ -822,12 +822,14 @@ impl TransformStream {
                 readable: Dom::from_ref(&readable),
                 controller: Dom::from_ref(&controller),
             })),
-            can_gc,
+            CanGc::from_cx(cx),
         );
 
-        let realm = enter_realm(global);
-        let comp = InRealm::Entered(&realm);
-        flush_promise.append_native_handler(&handler, comp, can_gc);
+        let mut realm = enter_auto_realm(cx, global);
+        let realm = &mut realm.current_realm();
+        let in_realm_proof = realm.into();
+        let comp = InRealm::Already(&in_realm_proof);
+        flush_promise.append_native_handler(&handler, comp, CanGc::from_cx(realm));
         // Return controller.[[finishPromise]].
         let finish_promise = controller
             .get_finish_promise()

--- a/components/script/dom/stream/transformstreamdefaultcontroller.rs
+++ b/components/script/dom/stream/transformstreamdefaultcontroller.rs
@@ -37,7 +37,7 @@ use crate::dom::globalscope::GlobalScope;
 use crate::dom::promise::Promise;
 use crate::dom::promisenativehandler::{Callback, PromiseNativeHandler};
 use crate::dom::types::{DecompressionStream, TransformStream};
-use crate::realms::{InRealm, enter_realm};
+use crate::realms::{InRealm, enter_auto_realm};
 use crate::script_runtime::{CanGc, JSContext as SafeJSContext};
 
 impl js::gc::Rootable for TransformTransformPromiseRejection {}
@@ -175,16 +175,15 @@ impl TransformStreamDefaultController {
     /// <https://streams.spec.whatwg.org/#transform-stream-default-controller-perform-transform>
     pub(crate) fn transform_stream_default_controller_perform_transform(
         &self,
-        cx: SafeJSContext,
+        cx: &mut js::context::JSContext,
         global: &GlobalScope,
         chunk: SafeHandleValue,
-        can_gc: CanGc,
     ) -> Fallible<Rc<Promise>> {
         // Let transformPromise be the result of performing controller.[[transformAlgorithm]], passing chunk.
-        let transform_promise = self.perform_transform(cx, global, chunk, can_gc)?;
+        let transform_promise = self.perform_transform(cx, global, chunk)?;
 
         // Return the result of reacting to transformPromise with the following rejection steps given the argument r:
-        rooted!(in(*cx) let mut reject_handler = Some(TransformTransformPromiseRejection {
+        rooted!(&in(cx) let mut reject_handler = Some(TransformTransformPromiseRejection {
             controller: Dom::from_ref(self),
         }));
 
@@ -192,21 +191,22 @@ impl TransformStreamDefaultController {
             global,
             None,
             reject_handler.take().map(|h| Box::new(h) as Box<_>),
-            can_gc,
+            CanGc::from_cx(cx),
         );
-        let realm = enter_realm(global);
-        let comp = InRealm::Entered(&realm);
-        transform_promise.append_native_handler(&handler, comp, can_gc);
+        let mut realm = enter_auto_realm(cx, global);
+        let realm = &mut realm.current_realm();
+        let in_realm_proof = realm.into();
+        let comp = InRealm::Already(&in_realm_proof);
+        transform_promise.append_native_handler(&handler, comp, CanGc::from_cx(realm));
 
         Ok(transform_promise)
     }
 
     pub(crate) fn perform_transform(
         &self,
-        cx: SafeJSContext,
+        cx: &mut js::context::JSContext,
         global: &GlobalScope,
         chunk: SafeHandleValue,
-        can_gc: CanGc,
     ) -> Fallible<Rc<Promise>> {
         let result = match &self.transformer_type {
             // <https://streams.spec.whatwg.org/#set-up-transform-stream-default-controller-from-transformer>
@@ -222,31 +222,41 @@ impl TransformStreamDefaultController {
                 // controller » and callback this value transformer.
                 let algo = transform.borrow().clone();
                 if let Some(transform) = algo {
-                    rooted!(in(*cx) let this_object = transform_obj.get());
+                    rooted!(&in(cx) let this_object = transform_obj.get());
                     transform
                         .Call_(
                             &this_object.handle(),
                             chunk,
                             self,
                             ExceptionHandling::Rethrow,
-                            can_gc,
+                            CanGc::from_cx(cx),
                         )
                         .unwrap_or_else(|e| {
-                            let p = Promise::new(global, can_gc);
-                            p.reject_error(e, can_gc);
+                            let p = Promise::new2(cx, global);
+                            p.reject_error(e, CanGc::from_cx(cx));
                             p
                         })
                 } else {
                     // Step 2. Let transformAlgorithm be the following steps, taking a chunk argument:
                     // Let result be TransformStreamDefaultControllerEnqueue(controller, chunk).
                     // If result is an abrupt completion, return a promise rejected with result.[[Value]].
-                    if let Err(error) = self.enqueue(cx, global, chunk, can_gc) {
-                        rooted!(in(*cx) let mut error_val = UndefinedValue());
-                        error.to_jsval(cx, global, error_val.handle_mut(), can_gc);
-                        Promise::new_rejected(global, cx, error_val.handle(), can_gc)
+                    if let Err(error) = self.enqueue(cx, global, chunk) {
+                        rooted!(&in(cx) let mut error_val = UndefinedValue());
+                        error.to_jsval(
+                            cx.into(),
+                            global,
+                            error_val.handle_mut(),
+                            CanGc::from_cx(cx),
+                        );
+                        Promise::new_rejected(
+                            global,
+                            cx.into(),
+                            error_val.handle(),
+                            CanGc::from_cx(cx),
+                        )
                     } else {
                         // Otherwise, return a promise resolved with undefined.
-                        Promise::new_resolved(global, cx, (), can_gc)
+                        Promise::new_resolved(global, cx.into(), (), CanGc::from_cx(cx))
                     }
                 }
             },
@@ -255,21 +265,22 @@ impl TransformStreamDefaultController {
                 // Step 7. Let transformAlgorithm be an algorithm which takes a
                 // chunk argument and runs the decode and enqueue a chunk
                 // algorithm with this and chunk.
-                decode_and_enqueue_a_chunk(cx, global, chunk, decoder, self, can_gc)
+                decode_and_enqueue_a_chunk(cx, global, chunk, decoder, self)
                     // <https://streams.spec.whatwg.org/#transformstream-set-up>
                     // Step 5. Let transformAlgorithmWrapper be an algorithm that runs these steps given a value chunk:
                     // Step 5.1 Let result be the result of running transformAlgorithm given chunk.
                     // Step 5.2 If result is a Promise, then return result.
                     // Note: not applicable, the spec does NOT require deode_and_enqueue_a_chunk() to return a Promise
                     // Step 5.3 Return a promise resolved with undefined.
-                    .map(|_| Promise::new_resolved(global, cx, (), can_gc))
+                    .map(|_| Promise::new_resolved(global, cx.into(), (), CanGc::from_cx(cx)))
                     .unwrap_or_else(|e| {
                         // <https://streams.spec.whatwg.org/#transformstream-set-up>
                         // Step 5.1 If this throws an exception e,
-                        let realm = enter_realm(self);
-                        let p = Promise::new_in_current_realm((&realm).into(), can_gc);
+                        let mut realm = enter_auto_realm(cx, self);
+                        let realm = &mut realm.current_realm();
+                        let p = Promise::new_in_realm(realm);
                         // return a promise rejected with e.
-                        p.reject_error(e, can_gc);
+                        p.reject_error(e, CanGc::from_cx(realm));
                         p
                     })
             },
@@ -277,21 +288,22 @@ impl TransformStreamDefaultController {
                 // <https://encoding.spec.whatwg.org/#dom-textencoderstream>
                 // Step 2. Let transformAlgorithm be an algorithm which takes a chunk argument and runs the encode
                 //      and enqueue a chunk algorithm with this and chunk.
-                encode_and_enqueue_a_chunk(cx, global, chunk, encoder, self, can_gc)
+                encode_and_enqueue_a_chunk(cx, global, chunk, encoder, self)
                     // <https://streams.spec.whatwg.org/#transformstream-set-up>
                     // Step 5. Let transformAlgorithmWrapper be an algorithm that runs these steps given a value chunk:
                     // Step 5.1 Let result be the result of running transformAlgorithm given chunk.
                     // Step 5.2 If result is a Promise, then return result.
                     // Note: not applicable, the spec does NOT require encode_and_enqueue_a_chunk() to return a Promise
                     // Step 5.3 Return a promise resolved with undefined.
-                    .map(|_| Promise::new_resolved(global, cx, (), can_gc))
+                    .map(|_| Promise::new_resolved(global, cx.into(), (), CanGc::from_cx(cx)))
                     .unwrap_or_else(|e| {
                         // <https://streams.spec.whatwg.org/#transformstream-set-up>
                         // Step 5.1 If this throws an exception e,
-                        let realm = enter_realm(self);
-                        let p = Promise::new_in_current_realm((&realm).into(), can_gc);
+                        let mut realm = enter_auto_realm(cx, self);
+                        let realm = &mut realm.current_realm();
+                        let p = Promise::new_in_realm(realm);
                         // return a promise rejected with e.
-                        p.reject_error(e, can_gc);
+                        p.reject_error(e, CanGc::from_cx(realm));
                         p
                     })
             },
@@ -299,7 +311,7 @@ impl TransformStreamDefaultController {
                 // <https://compression.spec.whatwg.org/#dom-compressionstream-compressionstream>
                 // Step 3. Let transformAlgorithm be an algorithm which takes a chunk argument and
                 // runs the compress and enqueue a chunk algorithm with this and chunk.
-                compress_and_enqueue_a_chunk(cx, global, cs, chunk, self, can_gc)
+                compress_and_enqueue_a_chunk(cx, global, cs, chunk, self)
                     // <https://streams.spec.whatwg.org/#transformstream-set-up>
                     // Step 5. Let transformAlgorithmWrapper be an algorithm that runs these steps given a value chunk:
                     // Step 5.1 Let result be the result of running transformAlgorithm given chunk.
@@ -307,14 +319,15 @@ impl TransformStreamDefaultController {
                     // Note: not applicable, the spec does NOT require
                     // compress_and_enqueue_a_chunk() to return a Promise.
                     // Step 5.3 Return a promise resolved with undefined.
-                    .map(|_| Promise::new_resolved(global, cx, (), can_gc))
+                    .map(|_| Promise::new_resolved(global, cx.into(), (), CanGc::from_cx(cx)))
                     .unwrap_or_else(|e| {
                         // <https://streams.spec.whatwg.org/#transformstream-set-up>
                         // Step 5.1 If this throws an exception e,
-                        let realm = enter_realm(self);
-                        let p = Promise::new_in_current_realm((&realm).into(), can_gc);
+                        let mut realm = enter_auto_realm(cx, self);
+                        let realm = &mut realm.current_realm();
+                        let p = Promise::new_in_realm(realm);
                         // return a promise rejected with e.
-                        p.reject_error(e, can_gc);
+                        p.reject_error(e, CanGc::from_cx(realm));
                         p
                     })
             },
@@ -322,7 +335,7 @@ impl TransformStreamDefaultController {
                 // <https://compression.spec.whatwg.org/#dom-decompressionstream-decompressionstream>
                 // Step 3. Let transformAlgorithm be an algorithm which takes a chunk argument and
                 // runs the decompress and enqueue a chunk algorithm with this and chunk.
-                decompress_and_enqueue_a_chunk(cx, global, ds, chunk, self, can_gc)
+                decompress_and_enqueue_a_chunk(cx, global, ds, chunk, self)
                     // <https://streams.spec.whatwg.org/#transformstream-set-up>
                     // Step 5. Let transformAlgorithmWrapper be an algorithm that runs these steps given a value chunk:
                     // Step 5.1 Let result be the result of running transformAlgorithm given chunk.
@@ -330,14 +343,15 @@ impl TransformStreamDefaultController {
                     // Note: not applicable, the spec does NOT require
                     // decompress_and_enqueue_a_chunk() to return a Promise
                     // Step 5.3 Return a promise resolved with undefined.
-                    .map(|_| Promise::new_resolved(global, cx, (), can_gc))
+                    .map(|_| Promise::new_resolved(global, cx.into(), (), CanGc::from_cx(cx)))
                     .unwrap_or_else(|e| {
                         // <https://streams.spec.whatwg.org/#transformstream-set-up>
                         // Step 5.1 If this throws an exception e,
-                        let realm = enter_realm(self);
-                        let p = Promise::new_in_current_realm((&realm).into(), can_gc);
+                        let mut realm = enter_auto_realm(cx, self);
+                        let realm = &mut realm.current_realm();
+                        let p = Promise::new_in_realm(realm);
                         // return a promise rejected with e.
-                        p.reject_error(e, can_gc);
+                        p.reject_error(e, CanGc::from_cx(realm));
                         p
                     })
             },
@@ -436,9 +450,8 @@ impl TransformStreamDefaultController {
 
     pub(crate) fn perform_flush(
         &self,
-        cx: SafeJSContext,
+        cx: &mut js::context::JSContext,
         global: &GlobalScope,
-        can_gc: CanGc,
     ) -> Fallible<Rc<Promise>> {
         let result = match &self.transformer_type {
             // <https://streams.spec.whatwg.org/#set-up-transform-stream-default-controller-from-transformer>
@@ -453,29 +466,29 @@ impl TransformStreamDefaultController {
                 // and callback this value transformer.
                 let algo = flush.borrow().clone();
                 if let Some(flush) = algo {
-                    rooted!(in(*cx) let this_object = transform_obj.get());
+                    rooted!(&in(cx) let this_object = transform_obj.get());
                     flush
                         .Call_(
                             &this_object.handle(),
                             self,
                             ExceptionHandling::Rethrow,
-                            can_gc,
+                            CanGc::from_cx(cx),
                         )
                         .unwrap_or_else(|e| {
-                            let p = Promise::new(global, can_gc);
-                            p.reject_error(e, can_gc);
+                            let p = Promise::new2(cx, global);
+                            p.reject_error(e, CanGc::from_cx(cx));
                             p
                         })
                 } else {
                     // Step 3. Let flushAlgorithm be an algorithm which returns a promise resolved with undefined.
-                    Promise::new_resolved(global, cx, (), can_gc)
+                    Promise::new_resolved(global, cx.into(), (), CanGc::from_cx(cx))
                 }
             },
             TransformerType::Decoder(decoder) => {
                 // <https://encoding.spec.whatwg.org/#dom-textdecoderstream>
                 // Step 8. Let flushAlgorithm be an algorithm which takes no
                 // arguments and runs the flush and enqueue algorithm with this.
-                flush_and_enqueue(cx, global, decoder, self, can_gc)
+                flush_and_enqueue(cx, global, decoder, self)
                     // <https://streams.spec.whatwg.org/#transformstream-set-up>
                     // Step 6. Let flushAlgorithmWrapper be an algorithm that runs these steps:
                     // Step 6.1 Let result be the result of running flushAlgorithm,
@@ -483,21 +496,22 @@ impl TransformStreamDefaultController {
                     // Step 6.2 If result is a Promise, then return result.
                     // Note: Not applicable. The spec does NOT require flush_and_enqueue algo to return a Promise
                     // Step 6.3 Return a promise resolved with undefined.
-                    .map(|_| Promise::new_resolved(global, cx, (), can_gc))
+                    .map(|_| Promise::new_resolved(global, cx.into(), (), CanGc::from_cx(cx)))
                     .unwrap_or_else(|e| {
                         // <https://streams.spec.whatwg.org/#transformstream-set-up>
                         // Step 6.1 If this throws an exception e,
-                        let realm = enter_realm(self);
-                        let p = Promise::new_in_current_realm((&realm).into(), can_gc);
+                        let mut realm = enter_auto_realm(cx, self);
+                        let realm = &mut realm.current_realm();
+                        let p = Promise::new_in_realm(realm);
                         // return a promise rejected with e.
-                        p.reject_error(e, can_gc);
+                        p.reject_error(e, CanGc::from_cx(realm));
                         p
                     })
             },
             TransformerType::Encoder(encoder) => {
                 // <https://encoding.spec.whatwg.org/#textencoderstream-encoder>
                 // Step 3. Let flushAlgorithm be an algorithm which runs the encode and flush algorithm with this.
-                encode_and_flush(cx, global, encoder, self, can_gc)
+                encode_and_flush(cx, global, encoder, self)
                     // <https://streams.spec.whatwg.org/#transformstream-set-up>
                     // Step 6. Let flushAlgorithmWrapper be an algorithm that runs these steps:
                     // Step 6.1 Let result be the result of running flushAlgorithm,
@@ -505,14 +519,15 @@ impl TransformStreamDefaultController {
                     // Step 6.2 If result is a Promise, then return result.
                     // Note: Not applicable. The spec does NOT require encode_and_flush algo to return a Promise
                     // Step 6.3 Return a promise resolved with undefined.
-                    .map(|_| Promise::new_resolved(global, cx, (), can_gc))
+                    .map(|_| Promise::new_resolved(global, cx.into(), (), CanGc::from_cx(cx)))
                     .unwrap_or_else(|e| {
                         // <https://streams.spec.whatwg.org/#transformstream-set-up>
                         // Step 6.1 If this throws an exception e,
-                        let realm = enter_realm(self);
-                        let p = Promise::new_in_current_realm((&realm).into(), can_gc);
+                        let mut realm = enter_auto_realm(cx, self);
+                        let realm = &mut realm.current_realm();
+                        let p = Promise::new_in_realm(realm);
                         // return a promise rejected with e.
-                        p.reject_error(e, can_gc);
+                        p.reject_error(e, CanGc::from_cx(realm));
                         p
                     })
             },
@@ -520,7 +535,7 @@ impl TransformStreamDefaultController {
                 // <https://compression.spec.whatwg.org/#dom-compressionstream-compressionstream>
                 // Step 4. Let flushAlgorithm be an algorithm which takes no argument and runs the
                 // compress flush and enqueue algorithm with this.
-                compress_flush_and_enqueue(cx, global, cs, self, can_gc)
+                compress_flush_and_enqueue(cx, global, cs, self)
                     // <https://streams.spec.whatwg.org/#transformstream-set-up>
                     // Step 6. Let flushAlgorithmWrapper be an algorithm that runs these steps:
                     // Step 6.1 Let result be the result of running flushAlgorithm,
@@ -529,14 +544,15 @@ impl TransformStreamDefaultController {
                     // Note: Not applicable. The spec does NOT require compress_flush_and_enqueue
                     // algo to return a Promise.
                     // Step 6.3 Return a promise resolved with undefined.
-                    .map(|_| Promise::new_resolved(global, cx, (), can_gc))
+                    .map(|_| Promise::new_resolved(global, cx.into(), (), CanGc::from_cx(cx)))
                     .unwrap_or_else(|e| {
                         // <https://streams.spec.whatwg.org/#transformstream-set-up>
                         // Step 6.1 If this throws an exception e,
-                        let realm = enter_realm(self);
-                        let p = Promise::new_in_current_realm((&realm).into(), can_gc);
+                        let mut realm = enter_auto_realm(cx, self);
+                        let realm = &mut realm.current_realm();
+                        let p = Promise::new_in_realm(realm);
                         // return a promise rejected with e.
-                        p.reject_error(e, can_gc);
+                        p.reject_error(e, CanGc::from_cx(realm));
                         p
                     })
             },
@@ -544,7 +560,7 @@ impl TransformStreamDefaultController {
                 // <https://compression.spec.whatwg.org/#dom-decompressionstream-decompressionstream>
                 // Step 4. Let flushAlgorithm be an algorithm which takes no argument and runs the
                 // decompress flush and enqueue algorithm with this.
-                decompress_flush_and_enqueue(cx, global, ds, self, can_gc)
+                decompress_flush_and_enqueue(cx, global, ds, self)
                     // <https://streams.spec.whatwg.org/#transformstream-set-up>
                     // Step 6. Let flushAlgorithmWrapper be an algorithm that runs these steps:
                     // Step 6.1 Let result be the result of running flushAlgorithm,
@@ -553,14 +569,15 @@ impl TransformStreamDefaultController {
                     // Note: Not applicable. The spec does NOT require decompress_flush_and_enqueue
                     // algo to return a Promise.
                     // Step 6.3 Return a promise resolved with undefined.
-                    .map(|_| Promise::new_resolved(global, cx, (), can_gc))
+                    .map(|_| Promise::new_resolved(global, cx.into(), (), CanGc::from_cx(cx)))
                     .unwrap_or_else(|e| {
                         // <https://streams.spec.whatwg.org/#transformstream-set-up>
                         // Step 6.1 If this throws an exception e,
-                        let realm = enter_realm(self);
-                        let p = Promise::new_in_current_realm((&realm).into(), can_gc);
+                        let mut realm = enter_auto_realm(cx, self);
+                        let realm = &mut realm.current_realm();
+                        let p = Promise::new_in_realm(realm);
                         // return a promise rejected with e.
-                        p.reject_error(e, can_gc);
+                        p.reject_error(e, CanGc::from_cx(realm));
                         p
                     })
             },
@@ -573,10 +590,9 @@ impl TransformStreamDefaultController {
     #[expect(unsafe_code)]
     pub(crate) fn enqueue(
         &self,
-        cx: SafeJSContext,
+        cx: &mut js::context::JSContext,
         global: &GlobalScope,
         chunk: SafeHandleValue,
-        can_gc: CanGc,
     ) -> Fallible<()> {
         // Let stream be controller.[[stream]].
         let stream = self.stream.get().expect("stream is null");
@@ -595,22 +611,30 @@ impl TransformStreamDefaultController {
 
         // Let enqueueResult be ReadableStreamDefaultControllerEnqueue(readableController, chunk).
         // If enqueueResult is an abrupt completion,
-        if let Err(error) = readable_controller.enqueue(cx, chunk, can_gc) {
+        if let Err(error) = readable_controller.enqueue(cx.into(), chunk, CanGc::from_cx(cx)) {
             // Perform ! TransformStreamErrorWritableAndUnblockWrite(stream, enqueueResult.[[Value]]).
-            rooted!(in(*cx) let mut rooted_error = UndefinedValue());
-            error
-                .clone()
-                .to_jsval(cx, global, rooted_error.handle_mut(), can_gc);
-            stream.error_writable_and_unblock_write(cx, global, rooted_error.handle(), can_gc);
+            rooted!(&in(cx) let mut rooted_error = UndefinedValue());
+            error.clone().to_jsval(
+                cx.into(),
+                global,
+                rooted_error.handle_mut(),
+                CanGc::from_cx(cx),
+            );
+            stream.error_writable_and_unblock_write(
+                cx.into(),
+                global,
+                rooted_error.handle(),
+                CanGc::from_cx(cx),
+            );
 
             // Throw stream.[[readable]].[[storedError]].
             unsafe {
-                if !JS_IsExceptionPending(*cx) {
-                    rooted!(in(*cx) let mut stored_error = UndefinedValue());
+                if !JS_IsExceptionPending(cx.raw_cx()) {
+                    rooted!(&in(cx) let mut stored_error = UndefinedValue());
                     readable.get_stored_error(stored_error.handle_mut());
 
                     JS_SetPendingException(
-                        *cx,
+                        cx.raw_cx(),
                         stored_error.handle().into(),
                         ExceptionStackBehavior::Capture,
                     );
@@ -628,7 +652,7 @@ impl TransformStreamDefaultController {
             assert!(backpressure);
 
             // Perform ! TransformStreamSetBackpressure(stream, true).
-            stream.set_backpressure(global, true, can_gc);
+            stream.set_backpressure(global, true, CanGc::from_cx(cx));
         }
         Ok(())
     }
@@ -707,9 +731,9 @@ impl TransformStreamDefaultControllerMethods<crate::DomTypeHolder>
     }
 
     /// <https://streams.spec.whatwg.org/#ts-default-controller-enqueue>
-    fn Enqueue(&self, cx: SafeJSContext, chunk: SafeHandleValue, can_gc: CanGc) -> Fallible<()> {
+    fn Enqueue(&self, cx: &mut js::context::JSContext, chunk: SafeHandleValue) -> Fallible<()> {
         // Perform ? TransformStreamDefaultControllerEnqueue(this, chunk).
-        self.enqueue(cx, &self.global(), chunk, can_gc)
+        self.enqueue(cx, &self.global(), chunk)
     }
 
     /// <https://streams.spec.whatwg.org/#ts-default-controller-error>

--- a/components/script/dom/stream/writablestream.rs
+++ b/components/script/dom/stream/writablestream.rs
@@ -740,18 +740,17 @@ impl WritableStream {
     /// <https://streams.spec.whatwg.org/#writable-stream-close>
     pub(crate) fn close(
         &self,
-        cx: SafeJSContext,
+        cx: &mut js::context::JSContext,
         global: &GlobalScope,
-        can_gc: CanGc,
     ) -> Rc<Promise> {
         // Let state be stream.[[state]].
         // If state is "closed" or "errored",
         if self.is_closed() || self.is_errored() {
             // return a promise rejected with a TypeError exception.
-            let promise = Promise::new(global, can_gc);
+            let promise = Promise::new2(cx, global);
             promise.reject_error(
                 Error::Type(c"Stream is closed or errored.".to_owned()),
-                can_gc,
+                CanGc::from_cx(cx),
             );
             return promise;
         }
@@ -763,7 +762,7 @@ impl WritableStream {
         assert!(!self.close_queued_or_in_flight());
 
         // Let promise be a new promise.
-        let promise = Promise::new(global, can_gc);
+        let promise = Promise::new2(cx, global);
 
         // Set stream.[[closeRequest]] to promise.
         *self.close_request.borrow_mut() = Some(promise.clone());
@@ -775,7 +774,7 @@ impl WritableStream {
             // and state is "writable",
             if self.get_backpressure() && self.is_writable() {
                 // resolve writer.[[readyPromise]] with undefined.
-                writer.resolve_ready_promise_with_undefined(can_gc);
+                writer.resolve_ready_promise_with_undefined(CanGc::from_cx(cx));
             }
         }
 
@@ -783,7 +782,7 @@ impl WritableStream {
         let Some(controller) = self.controller.get() else {
             unreachable!("Stream must have a controller.");
         };
-        controller.close(cx, global, can_gc);
+        controller.close(cx, global);
 
         // Return promise.
         promise
@@ -1097,31 +1096,33 @@ impl WritableStreamMethods<crate::DomTypeHolder> for WritableStream {
     }
 
     /// <https://streams.spec.whatwg.org/#ws-close>
-    fn Close(&self, realm: InRealm, can_gc: CanGc) -> Rc<Promise> {
-        let cx = GlobalScope::get_cx();
-        let global = GlobalScope::from_safe_context(cx, realm);
+    fn Close(&self, cx: &mut CurrentRealm) -> Rc<Promise> {
+        let global = GlobalScope::from_current_realm(cx);
 
         // If ! IsWritableStreamLocked(this) is true,
         if self.is_locked() {
             // return a promise rejected with a TypeError exception.
-            let promise = Promise::new(&global, can_gc);
-            promise.reject_error(Error::Type(c"Stream is locked.".to_owned()), can_gc);
+            let promise = Promise::new2(cx, &global);
+            promise.reject_error(
+                Error::Type(c"Stream is locked.".to_owned()),
+                CanGc::from_cx(cx),
+            );
             return promise;
         }
 
         // If ! WritableStreamCloseQueuedOrInFlight(this) is true
         if self.close_queued_or_in_flight() {
             // return a promise rejected with a TypeError exception.
-            let promise = Promise::new(&global, can_gc);
+            let promise = Promise::new2(cx, &global);
             promise.reject_error(
                 Error::Type(c"Stream has closed queued or in-flight".to_owned()),
-                can_gc,
+                CanGc::from_cx(cx),
             );
             return promise;
         }
 
         // Return ! WritableStreamClose(this).
-        self.close(cx, &global, can_gc)
+        self.close(cx, &global)
     }
 
     /// <https://streams.spec.whatwg.org/#ws-get-writer>

--- a/components/script/dom/stream/writablestreamdefaultcontroller.rs
+++ b/components/script/dom/stream/writablestreamdefaultcontroller.rs
@@ -29,7 +29,7 @@ use crate::dom::promisenativehandler::{Callback, PromiseNativeHandler};
 use crate::dom::readablestreamdefaultcontroller::{EnqueuedValue, QueueWithSizes, ValueWithSize};
 use crate::dom::stream::writablestream::WritableStream;
 use crate::dom::types::{AbortController, AbortSignal, TransformStream};
-use crate::realms::{InRealm, enter_realm};
+use crate::realms::{InRealm, enter_auto_realm, enter_realm};
 use crate::script_runtime::{CanGc, JSContext as SafeJSContext};
 
 impl js::gc::Rootable for CloseAlgorithmFulfillmentHandler {}
@@ -102,7 +102,7 @@ impl Callback for StartAlgorithmFulfillmentHandler {
         let global = GlobalScope::from_current_realm(cx);
 
         // Perform ! WritableStreamDefaultControllerAdvanceQueueIfNeeded(controller).
-        controller.advance_queue_if_needed(cx.into(), &global, CanGc::from_cx(cx))
+        controller.advance_queue_if_needed(cx, &global)
     }
 }
 
@@ -236,7 +236,7 @@ impl Callback for WriteAlgorithmFulfillmentHandler {
         }
 
         // Perform ! WritableStreamDefaultControllerAdvanceQueueIfNeeded(controller).
-        controller.advance_queue_if_needed(cx.into(), &global, can_gc)
+        controller.advance_queue_if_needed(cx, &global)
     }
 }
 
@@ -513,13 +513,13 @@ impl WritableStreamDefaultController {
     }
 
     /// <https://streams.spec.whatwg.org/#writable-stream-default-controller-close>
-    pub(crate) fn close(&self, cx: SafeJSContext, global: &GlobalScope, can_gc: CanGc) {
+    pub(crate) fn close(&self, cx: &mut js::context::JSContext, global: &GlobalScope) {
         // Perform ! EnqueueValueWithSize(controller, close sentinel, 0).
         self.queue
             .enqueue_value_with_size(EnqueuedValue::CloseSentinel)
             .expect("Enqueuing the close sentinel should not fail.");
         // Perform ! WritableStreamDefaultControllerAdvanceQueueIfNeeded(controller).
-        self.advance_queue_if_needed(cx, global, can_gc);
+        self.advance_queue_if_needed(cx, global);
     }
 
     #[expect(unsafe_code)]
@@ -651,10 +651,9 @@ impl WritableStreamDefaultController {
     /// <https://streams.spec.whatwg.org/#writablestreamdefaultcontroller-writealgorithm>
     fn call_write_algorithm(
         &self,
-        cx: SafeJSContext,
+        cx: &mut js::context::JSContext,
         chunk: SafeHandleValue,
         global: &GlobalScope,
-        can_gc: CanGc,
     ) -> Rc<Promise> {
         match &self.underlying_sink_type {
             UnderlyingSinkType::Js {
@@ -663,7 +662,7 @@ impl WritableStreamDefaultController {
                 close: _,
                 write,
             } => {
-                rooted!(in(*cx) let this_object = self.underlying_sink_obj.get());
+                rooted!(&in(cx) let this_object = self.underlying_sink_obj.get());
                 let algo = write.borrow().clone();
                 let result = if let Some(algo) = algo {
                     algo.Call_(
@@ -671,14 +670,19 @@ impl WritableStreamDefaultController {
                         chunk,
                         self,
                         ExceptionHandling::Rethrow,
-                        can_gc,
+                        CanGc::from_cx(cx),
                     )
                 } else {
-                    Ok(Promise::new_resolved(global, cx, (), can_gc))
+                    Ok(Promise::new_resolved(
+                        global,
+                        cx.into(),
+                        (),
+                        CanGc::from_cx(cx),
+                    ))
                 };
                 result.unwrap_or_else(|e| {
-                    let promise = Promise::new(global, can_gc);
-                    promise.reject_error(e, can_gc);
+                    let promise = Promise::new2(cx, global);
+                    promise.reject_error(e, CanGc::from_cx(cx));
                     promise
                 })
             },
@@ -692,13 +696,13 @@ impl WritableStreamDefaultController {
                 // If backpressurePromise is undefined,
                 // set backpressurePromise to a promise resolved with undefined.
                 if backpressure_promise.borrow().is_none() {
-                    let promise = Promise::new_resolved(global, cx, (), can_gc);
+                    let promise = Promise::new_resolved(global, cx.into(), (), CanGc::from_cx(cx));
                     *backpressure_promise.borrow_mut() = Some(promise);
                 }
 
                 // Return the result of reacting to backpressurePromise with the following fulfillment steps:
-                let result_promise = Promise::new(global, can_gc);
-                rooted!(in(*cx) let mut fulfillment_handler = Some(TransferBackPressurePromiseReaction {
+                let result_promise = Promise::new2(cx, global);
+                rooted!(&in(cx) let mut fulfillment_handler = Some(TransferBackPressurePromiseReaction {
                     port: port.clone(),
                     backpressure_promise: backpressure_promise.clone(),
                     chunk: Heap::boxed(chunk.get()),
@@ -708,21 +712,23 @@ impl WritableStreamDefaultController {
                     global,
                     fulfillment_handler.take().map(|h| Box::new(h) as Box<_>),
                     None,
-                    can_gc,
+                    CanGc::from_cx(cx),
                 );
-                let realm = enter_realm(global);
-                let comp = InRealm::Entered(&realm);
+                let mut realm = enter_auto_realm(cx, global);
+                let realm = &mut realm.current_realm();
+                let in_realm_proof = realm.into();
+                let comp = InRealm::Already(&in_realm_proof);
                 backpressure_promise
                     .borrow()
                     .as_ref()
                     .expect("Promise must be some by now.")
-                    .append_native_handler(&handler, comp, can_gc);
+                    .append_native_handler(&handler, comp, CanGc::from_cx(realm));
                 result_promise
             },
             UnderlyingSinkType::Transform(stream, _) => {
                 // Return ! TransformStreamDefaultSinkWriteAlgorithm(stream, chunk).
                 stream
-                    .transform_stream_default_sink_write_algorithm(cx, global, chunk, can_gc)
+                    .transform_stream_default_sink_write_algorithm(cx, global, chunk)
                     .expect("Transform stream default sink write algorithm should not fail.")
             },
         }
@@ -731,9 +737,8 @@ impl WritableStreamDefaultController {
     /// <https://streams.spec.whatwg.org/#writablestreamdefaultcontroller-closealgorithm>
     fn call_close_algorithm(
         &self,
-        cx: SafeJSContext,
+        cx: &mut js::context::JSContext,
         global: &GlobalScope,
-        can_gc: CanGc,
     ) -> Rc<Promise> {
         match &self.underlying_sink_type {
             UnderlyingSinkType::Js {
@@ -742,17 +747,26 @@ impl WritableStreamDefaultController {
                 close,
                 write: _,
             } => {
-                rooted!(in(*cx) let mut this_object = ptr::null_mut::<JSObject>());
+                rooted!(&in(cx) let mut this_object = ptr::null_mut::<JSObject>());
                 this_object.set(self.underlying_sink_obj.get());
                 let algo = close.borrow().clone();
                 let result = if let Some(algo) = algo {
-                    algo.Call_(&this_object.handle(), ExceptionHandling::Rethrow, can_gc)
+                    algo.Call_(
+                        &this_object.handle(),
+                        ExceptionHandling::Rethrow,
+                        CanGc::from_cx(cx),
+                    )
                 } else {
-                    Ok(Promise::new_resolved(global, cx, (), can_gc))
+                    Ok(Promise::new_resolved(
+                        global,
+                        cx.into(),
+                        (),
+                        CanGc::from_cx(cx),
+                    ))
                 };
                 result.unwrap_or_else(|e| {
-                    let promise = Promise::new(global, can_gc);
-                    promise.reject_error(e, can_gc);
+                    let promise = Promise::new2(cx, global);
+                    promise.reject_error(e, CanGc::from_cx(cx));
                     promise
                 })
             },
@@ -761,27 +775,27 @@ impl WritableStreamDefaultController {
                 // <https://streams.spec.whatwg.org/#abstract-opdef-setupcrossrealmtransformwritable>
 
                 // Perform ! PackAndPostMessage(port, "close", undefined).
-                rooted!(in(*cx) let mut value = UndefinedValue());
-                port.pack_and_post_message("close", value.handle(), can_gc)
+                rooted!(&in(cx) let mut value = UndefinedValue());
+                port.pack_and_post_message("close", value.handle(), CanGc::from_cx(cx))
                     .expect("Sending close should not fail.");
 
                 // Disentangle port.
-                global.disentangle_port(port, can_gc);
+                global.disentangle_port(port, CanGc::from_cx(cx));
 
                 // Return a promise resolved with undefined.
-                Promise::new_resolved(global, cx, (), can_gc)
+                Promise::new_resolved(global, cx.into(), (), CanGc::from_cx(cx))
             },
             UnderlyingSinkType::Transform(stream, _) => {
                 // Return ! TransformStreamDefaultSinkCloseAlgorithm(stream).
                 stream
-                    .transform_stream_default_sink_close_algorithm(cx, global, can_gc)
+                    .transform_stream_default_sink_close_algorithm(cx, global)
                     .expect("Transform stream default sink close algorithm should not fail.")
             },
         }
     }
 
     /// <https://streams.spec.whatwg.org/#writable-stream-default-controller-process-close>
-    pub(crate) fn process_close(&self, cx: SafeJSContext, global: &GlobalScope, can_gc: CanGc) {
+    pub(crate) fn process_close(&self, cx: &mut js::context::JSContext, global: &GlobalScope) {
         // Let stream be controller.[[stream]].
         let Some(stream) = self.stream.get() else {
             unreachable!("Controller should have a stream");
@@ -791,24 +805,25 @@ impl WritableStreamDefaultController {
         stream.mark_close_request_in_flight();
 
         // Perform ! DequeueValue(controller).
-        self.queue.dequeue_value(cx, None, can_gc);
+        self.queue
+            .dequeue_value(cx.into(), None, CanGc::from_cx(cx));
 
         // Assert: controller.[[queue]] is empty.
         assert!(self.queue.is_empty());
 
         // Let sinkClosePromise be the result of performing controller.[[closeAlgorithm]].
-        let sink_close_promise = self.call_close_algorithm(cx, global, can_gc);
+        let sink_close_promise = self.call_close_algorithm(cx, global);
 
         // Perform ! WritableStreamDefaultControllerClearAlgorithms(controller).
         self.clear_algorithms();
 
         // Upon fulfillment of sinkClosePromise,
-        rooted!(in(*cx) let mut fulfillment_handler = Some(CloseAlgorithmFulfillmentHandler {
+        rooted!(&in(cx) let mut fulfillment_handler = Some(CloseAlgorithmFulfillmentHandler {
             stream: Dom::from_ref(&stream),
         }));
 
         // Upon rejection of sinkClosePromise with reason reason,
-        rooted!(in(*cx) let mut rejection_handler = Some(CloseAlgorithmRejectionHandler {
+        rooted!(&in(cx) let mut rejection_handler = Some(CloseAlgorithmRejectionHandler {
             stream: Dom::from_ref(&stream),
         }));
 
@@ -817,15 +832,17 @@ impl WritableStreamDefaultController {
             global,
             fulfillment_handler.take().map(|h| Box::new(h) as Box<_>),
             rejection_handler.take().map(|h| Box::new(h) as Box<_>),
-            can_gc,
+            CanGc::from_cx(cx),
         );
-        let realm = enter_realm(global);
-        let comp = InRealm::Entered(&realm);
-        sink_close_promise.append_native_handler(&handler, comp, can_gc);
+        let mut realm = enter_auto_realm(cx, global);
+        let realm = &mut realm.current_realm();
+        let in_realm_proof = realm.into();
+        let comp = InRealm::Already(&in_realm_proof);
+        sink_close_promise.append_native_handler(&handler, comp, CanGc::from_cx(realm));
     }
 
     /// <https://streams.spec.whatwg.org/#writable-stream-default-controller-advance-queue-if-needed>
-    fn advance_queue_if_needed(&self, cx: SafeJSContext, global: &GlobalScope, can_gc: CanGc) {
+    fn advance_queue_if_needed(&self, cx: &mut js::context::JSContext, global: &GlobalScope) {
         // Let stream be controller.[[stream]].
         let Some(stream) = self.stream.get() else {
             unreachable!("Controller should have a stream");
@@ -849,28 +866,29 @@ impl WritableStreamDefaultController {
         // If state is "erroring",
         if stream.is_erroring() {
             // Perform ! WritableStreamFinishErroring(stream).
-            stream.finish_erroring(cx, global, can_gc);
+            stream.finish_erroring(cx.into(), global, CanGc::from_cx(cx));
 
             // Return.
             return;
         }
 
         // Let value be ! PeekQueueValue(controller).
-        rooted!(in(*cx) let mut value = UndefinedValue());
+        rooted!(&in(cx) let mut value = UndefinedValue());
         let is_closed = {
             // If controller.[[queue]] is empty, return.
             if self.queue.is_empty() {
                 return;
             }
-            self.queue.peek_queue_value(cx, value.handle_mut(), can_gc)
+            self.queue
+                .peek_queue_value(cx.into(), value.handle_mut(), CanGc::from_cx(cx))
         };
 
         if is_closed {
             // If value is the close sentinel, perform ! WritableStreamDefaultControllerProcessClose(controller).
-            self.process_close(cx, global, can_gc);
+            self.process_close(cx, global);
         } else {
             // Otherwise, perform ! WritableStreamDefaultControllerProcessWrite(controller, value).
-            self.process_write(cx, value.handle(), global, can_gc);
+            self.process_write(cx, value.handle(), global);
         };
     }
 
@@ -883,10 +901,9 @@ impl WritableStreamDefaultController {
     /// <https://streams.spec.whatwg.org/#writable-stream-default-controller-process-write>
     fn process_write(
         &self,
-        cx: SafeJSContext,
+        cx: &mut js::context::JSContext,
         chunk: SafeHandleValue,
         global: &GlobalScope,
-        can_gc: CanGc,
     ) {
         // Let stream be controller.[[stream]].
         let Some(stream) = self.stream.get() else {
@@ -897,15 +914,15 @@ impl WritableStreamDefaultController {
         stream.mark_first_write_request_in_flight();
 
         // Let sinkWritePromise be the result of performing controller.[[writeAlgorithm]], passing in chunk.
-        let sink_write_promise = self.call_write_algorithm(cx, chunk, global, can_gc);
+        let sink_write_promise = self.call_write_algorithm(cx, chunk, global);
 
         // Upon fulfillment of sinkWritePromise,
-        rooted!(in(*cx) let mut fulfillment_handler = Some(WriteAlgorithmFulfillmentHandler {
+        rooted!(&in(cx) let mut fulfillment_handler = Some(WriteAlgorithmFulfillmentHandler {
             controller: Dom::from_ref(self),
         }));
 
         // Upon rejection of sinkWritePromise with reason,
-        rooted!(in(*cx) let mut rejection_handler = Some(WriteAlgorithmRejectionHandler {
+        rooted!(&in(cx) let mut rejection_handler = Some(WriteAlgorithmRejectionHandler {
             controller: Dom::from_ref(self),
         }));
 
@@ -914,11 +931,13 @@ impl WritableStreamDefaultController {
             global,
             fulfillment_handler.take().map(|h| Box::new(h) as Box<_>),
             rejection_handler.take().map(|h| Box::new(h) as Box<_>),
-            can_gc,
+            CanGc::from_cx(cx),
         );
-        let realm = enter_realm(global);
-        let comp = InRealm::Entered(&realm);
-        sink_write_promise.append_native_handler(&handler, comp, can_gc);
+        let mut realm = enter_auto_realm(cx, global);
+        let realm = &mut realm.current_realm();
+        let in_realm_proof = realm.into();
+        let comp = InRealm::Already(&in_realm_proof);
+        sink_write_promise.append_native_handler(&handler, comp, CanGc::from_cx(realm));
     }
 
     /// <https://streams.spec.whatwg.org/#writable-stream-default-controller-get-desired-size>
@@ -982,11 +1001,10 @@ impl WritableStreamDefaultController {
     /// <https://streams.spec.whatwg.org/#writable-stream-default-controller-write>
     pub(crate) fn write(
         &self,
-        cx: SafeJSContext,
+        cx: &mut js::context::JSContext,
         global: &GlobalScope,
         chunk: SafeHandleValue,
         chunk_size: f64,
-        can_gc: CanGc,
     ) {
         // Let enqueueResult be EnqueueValueWithSize(controller, chunk, chunkSize).
         let enqueue_result = self
@@ -1000,9 +1018,14 @@ impl WritableStreamDefaultController {
         if let Err(error) = enqueue_result {
             // Perform ! WritableStreamDefaultControllerErrorIfNeeded(controller, enqueueResult.[[Value]]).
             // Create a rooted value for the error.
-            rooted!(in(*cx) let mut rooted_error = UndefinedValue());
-            error.to_jsval(cx, global, rooted_error.handle_mut(), can_gc);
-            self.error_if_needed(cx, rooted_error.handle(), global, can_gc);
+            rooted!(&in(cx) let mut rooted_error = UndefinedValue());
+            error.to_jsval(
+                cx.into(),
+                global,
+                rooted_error.handle_mut(),
+                CanGc::from_cx(cx),
+            );
+            self.error_if_needed(cx.into(), rooted_error.handle(), global, CanGc::from_cx(cx));
 
             // Return.
             return;
@@ -1019,11 +1042,11 @@ impl WritableStreamDefaultController {
             let backpressure = self.get_backpressure();
 
             // Perform ! WritableStreamUpdateBackpressure(stream, backpressure).
-            stream.update_backpressure(backpressure, global, can_gc);
+            stream.update_backpressure(backpressure, global, CanGc::from_cx(cx));
         }
 
         // Perform ! WritableStreamDefaultControllerAdvanceQueueIfNeeded(controller).
-        self.advance_queue_if_needed(cx, global, can_gc);
+        self.advance_queue_if_needed(cx, global);
     }
 
     /// <https://streams.spec.whatwg.org/#writable-stream-default-controller-error-if-needed>

--- a/components/script/dom/stream/writablestreamdefaultwriter.rs
+++ b/components/script/dom/stream/writablestreamdefaultwriter.rs
@@ -518,7 +518,6 @@ impl WritableStreamDefaultWriterMethods<crate::DomTypeHolder> for WritableStream
         // If this.[[stream]] is undefined,
         if self.stream.get().is_none() {
             // return a promise rejected with a TypeError exception.
-            let global = GlobalScope::from_current_realm(cx);
             let promise = Promise::new2(cx, &global);
             promise.reject_error(
                 Error::Type(c"Stream is undefined".to_owned()),

--- a/components/script/dom/stream/writablestreamdefaultwriter.rs
+++ b/components/script/dom/stream/writablestreamdefaultwriter.rs
@@ -17,7 +17,6 @@ use crate::dom::bindings::root::{DomRoot, MutNullableDom};
 use crate::dom::globalscope::GlobalScope;
 use crate::dom::promise::Promise;
 use crate::dom::stream::writablestream::WritableStream;
-use crate::realms::InRealm;
 use crate::script_runtime::{CanGc, JSContext as SafeJSContext};
 
 /// <https://streams.spec.whatwg.org/#writablestreamdefaultwriter>
@@ -250,7 +249,7 @@ impl WritableStreamDefaultWriter {
     }
 
     /// <https://streams.spec.whatwg.org/#writable-stream-default-writer-close>
-    fn close(&self, cx: SafeJSContext, global: &GlobalScope, can_gc: CanGc) -> Rc<Promise> {
+    fn close(&self, cx: &mut js::context::JSContext, global: &GlobalScope) -> Rc<Promise> {
         // Let stream be writer.[[stream]].
         let Some(stream) = self.stream.get() else {
             // Assert: stream is not undefined.
@@ -258,16 +257,15 @@ impl WritableStreamDefaultWriter {
         };
 
         // Return ! WritableStreamClose(stream).
-        stream.close(cx, global, can_gc)
+        stream.close(cx, global)
     }
 
     /// <https://streams.spec.whatwg.org/#writable-stream-default-writer-write>
     pub(crate) fn write(
         &self,
-        cx: SafeJSContext,
+        cx: &mut js::context::JSContext,
         global: &GlobalScope,
         chunk: SafeHandleValue,
-        can_gc: CanGc,
     ) -> Rc<Promise> {
         // Let stream be writer.[[stream]].
         let Some(stream) = self.stream.get() else {
@@ -282,7 +280,7 @@ impl WritableStreamDefaultWriter {
         };
 
         // Let chunkSize be ! WritableStreamDefaultControllerGetChunkSize(controller, chunk).
-        let chunk_size = controller.get_chunk_size(cx, global, chunk, can_gc);
+        let chunk_size = controller.get_chunk_size(cx.into(), global, chunk, CanGc::from_cx(cx));
 
         // If stream is not equal to writer.[[stream]],
         // return a promise rejected with a TypeError exception.
@@ -291,10 +289,10 @@ impl WritableStreamDefaultWriter {
             .get()
             .is_some_and(|current_stream| current_stream == stream)
         {
-            let promise = Promise::new(global, can_gc);
+            let promise = Promise::new2(cx, global);
             promise.reject_error(
                 Error::Type(c"Stream is not equal to writer stream".to_owned()),
-                can_gc,
+                CanGc::from_cx(cx),
             );
             return promise;
         }
@@ -303,10 +301,10 @@ impl WritableStreamDefaultWriter {
         // If state is "errored",
         if stream.is_errored() {
             // return a promise rejected with stream.[[storedError]].
-            rooted!(in(*cx) let mut error = UndefinedValue());
+            rooted!(&in(cx) let mut error = UndefinedValue());
             stream.get_stored_error(error.handle_mut());
-            let promise = Promise::new(global, can_gc);
-            promise.reject_native(&error.handle(), can_gc);
+            let promise = Promise::new2(cx, global);
+            promise.reject_native(&error.handle(), CanGc::from_cx(cx));
             return promise;
         }
 
@@ -315,10 +313,10 @@ impl WritableStreamDefaultWriter {
         if stream.close_queued_or_in_flight() || stream.is_closed() {
             // return a promise rejected with a TypeError exception
             // indicating that the stream is closing or closed
-            let promise = Promise::new(global, can_gc);
+            let promise = Promise::new2(cx, global);
             promise.reject_error(
                 Error::Type(c"Stream has been closed, or has close queued or in-flight".to_owned()),
-                can_gc,
+                CanGc::from_cx(cx),
             );
             return promise;
         }
@@ -326,10 +324,10 @@ impl WritableStreamDefaultWriter {
         // If state is "erroring",
         if stream.is_erroring() {
             // return a promise rejected with stream.[[storedError]].
-            rooted!(in(*cx) let mut error = UndefinedValue());
+            rooted!(&in(cx) let mut error = UndefinedValue());
             stream.get_stored_error(error.handle_mut());
-            let promise = Promise::new(global, can_gc);
-            promise.reject_native(&error.handle(), can_gc);
+            let promise = Promise::new2(cx, global);
+            promise.reject_native(&error.handle(), CanGc::from_cx(cx));
             return promise;
         }
 
@@ -337,10 +335,10 @@ impl WritableStreamDefaultWriter {
         assert!(stream.is_writable());
 
         // Let promise be ! WritableStreamAddWriteRequest(stream).
-        let promise = stream.add_write_request(global, can_gc);
+        let promise = stream.add_write_request(global, CanGc::from_cx(cx));
 
         // Perform ! WritableStreamDefaultControllerWrite(controller, chunk, chunkSize).
-        controller.write(cx, global, chunk, chunk_size, can_gc);
+        controller.write(cx, global, chunk, chunk_size);
 
         // Return promise.
         promise
@@ -380,9 +378,8 @@ impl WritableStreamDefaultWriter {
     /// <https://streams.spec.whatwg.org/#writable-stream-default-writer-close-with-error-propagation>
     pub(crate) fn close_with_error_propagation(
         &self,
-        cx: SafeJSContext,
+        cx: &mut js::context::JSContext,
         global: &GlobalScope,
-        can_gc: CanGc,
     ) -> Rc<Promise> {
         // Let stream be writer.[[stream]].
         let Some(stream) = self.stream.get() else {
@@ -397,18 +394,18 @@ impl WritableStreamDefaultWriter {
         // or state is "closed",
         if stream.close_queued_or_in_flight() || stream.is_closed() {
             // return a promise resolved with undefined.
-            let promise = Promise::new(global, can_gc);
-            promise.resolve_native(&(), can_gc);
+            let promise = Promise::new2(cx, global);
+            promise.resolve_native(&(), CanGc::from_cx(cx));
             return promise;
         }
 
         // If state is "errored",
         if stream.is_errored() {
             // return a promise rejected with stream.[[storedError]].
-            rooted!(in(*cx) let mut error = UndefinedValue());
+            rooted!(&in(cx) let mut error = UndefinedValue());
             stream.get_stored_error(error.handle_mut());
-            let promise = Promise::new(global, can_gc);
-            promise.reject_native(&error.handle(), can_gc);
+            let promise = Promise::new2(cx, global);
+            promise.reject_native(&error.handle(), CanGc::from_cx(cx));
             return promise;
         }
 
@@ -416,7 +413,7 @@ impl WritableStreamDefaultWriter {
         assert!(stream.is_writable() || stream.is_erroring());
 
         // Return ! WritableStreamDefaultWriterClose(writer).
-        self.close(cx, global, can_gc)
+        self.close(cx, global)
     }
 
     pub(crate) fn get_stream(&self) -> Option<DomRoot<WritableStream>> {
@@ -468,16 +465,18 @@ impl WritableStreamDefaultWriterMethods<crate::DomTypeHolder> for WritableStream
     }
 
     /// <https://streams.spec.whatwg.org/#default-writer-close>
-    fn Close(&self, in_realm: InRealm, can_gc: CanGc) -> Rc<Promise> {
-        let cx = GlobalScope::get_cx();
-        let global = GlobalScope::from_safe_context(cx, in_realm);
-        let promise = Promise::new(&global, can_gc);
+    fn Close(&self, cx: &mut CurrentRealm) -> Rc<Promise> {
+        let global = GlobalScope::from_current_realm(cx);
+        let promise = Promise::new2(cx, &global);
 
         // Let stream be this.[[stream]].
         let Some(stream) = self.stream.get() else {
             // If stream is undefined,
             // return a promise rejected with a TypeError exception.
-            promise.reject_error(Error::Type(c"Stream is undefined".to_owned()), can_gc);
+            promise.reject_error(
+                Error::Type(c"Stream is undefined".to_owned()),
+                CanGc::from_cx(cx),
+            );
             return promise;
         };
 
@@ -486,12 +485,12 @@ impl WritableStreamDefaultWriterMethods<crate::DomTypeHolder> for WritableStream
             // return a promise rejected with a TypeError exception.
             promise.reject_error(
                 Error::Type(c"Stream has closed queued or in-flight".to_owned()),
-                can_gc,
+                CanGc::from_cx(cx),
             );
             return promise;
         }
 
-        self.close(cx, &global, can_gc)
+        self.close(cx, &global)
     }
 
     /// <https://streams.spec.whatwg.org/#default-writer-release-lock>
@@ -513,26 +512,23 @@ impl WritableStreamDefaultWriterMethods<crate::DomTypeHolder> for WritableStream
     }
 
     /// <https://streams.spec.whatwg.org/#default-writer-write>
-    fn Write(
-        &self,
-        cx: SafeJSContext,
-        chunk: SafeHandleValue,
-        realm: InRealm,
-        can_gc: CanGc,
-    ) -> Rc<Promise> {
-        let global = GlobalScope::from_safe_context(cx, realm);
+    fn Write(&self, cx: &mut CurrentRealm, chunk: SafeHandleValue) -> Rc<Promise> {
+        let global = GlobalScope::from_current_realm(cx);
 
         // If this.[[stream]] is undefined,
         if self.stream.get().is_none() {
             // return a promise rejected with a TypeError exception.
-            let global = GlobalScope::from_safe_context(cx, realm);
-            let promise = Promise::new(&global, can_gc);
-            promise.reject_error(Error::Type(c"Stream is undefined".to_owned()), can_gc);
+            let global = GlobalScope::from_current_realm(cx);
+            let promise = Promise::new2(cx, &global);
+            promise.reject_error(
+                Error::Type(c"Stream is undefined".to_owned()),
+                CanGc::from_cx(cx),
+            );
             return promise;
         }
 
         // Return ! WritableStreamDefaultWriterWrite(this, chunk).
-        self.write(cx, &global, chunk, can_gc)
+        self.write(cx, &global, chunk)
     }
 
     /// <https://streams.spec.whatwg.org/#default-writer-constructor>

--- a/components/script_bindings/codegen/Bindings.conf
+++ b/components/script_bindings/codegen/Bindings.conf
@@ -981,8 +981,8 @@ DOMInterfaces = {
 
 'WritableStream': {
     'canGc': ['Close', 'GetWriter'],
-    'inRealms': ['Close', 'GetWriter'],
-    'realm': ['Abort']
+    'inRealms': ['GetWriter'],
+    'realm': ['Abort', 'Close']
 },
 
 'WritableStreamDefaultController': {
@@ -991,14 +991,13 @@ DOMInterfaces = {
 },
 
 'WritableStreamDefaultWriter': {
-    'canGc': ['Write', 'ReleaseLock', 'Close'],
-    'inRealms': ['Write', 'Close'],
-    'realm': ['Abort',],
+    'canGc': ['ReleaseLock'],
+    'realm': ['Abort', 'Close', 'Write'],
 },
 
 'TransformStreamDefaultController': {
-    'canGc': ['Enqueue', 'Terminate'],
-    'cx': ['Error']
+    'canGc': ['Terminate'],
+    'cx': ['Error', 'Enqueue']
 },
 
 'WorkerNavigator': {


### PR DESCRIPTION
Pass `&mut JsContext` to `TransformStreamDefaultController::enqueue`, in preparation of porting the remaining BlobMethods.

Testing: Just a refactor, ./mach test-unit still passes.
Fixes: Part of #42638