### PR TITLE
canvas: Support all Unicode variation selectors in text runs

### DIFF
--- a/components/script/dom/canvas/2d/canvas_state.rs
+++ b/components/script/dom/canvas/2d/canvas_state.rs
@@ -2371,7 +2371,7 @@ impl CanvasState {
                 x_language.clone(),
             );
 
-            if (!is_variation_selector(character) || current_text_run.string.is_empty()) &&
+            if !is_variation_selector(character) &&
                 !current_text_run.script_and_font_compatible(script, &font)
             {
                 let previous_text_run = std::mem::replace(

--- a/components/script/dom/canvas/2d/canvas_state.rs
+++ b/components/script/dom/canvas/2d/canvas_state.rs
@@ -2360,10 +2360,7 @@ impl CanvasState {
         }
 
         for (index, character) in text.char_indices() {
-            let next_char = text[index + character.len_utf8()..]
-                .chars()
-                .next()
-                .filter(|&c| is_variation_selector(c));
+            let next_char = text[index + character.len_utf8()..].chars().next();
 
             let script = Script::from(character);
 

--- a/components/script/dom/canvas/2d/canvas_state.rs
+++ b/components/script/dom/canvas/2d/canvas_state.rs
@@ -2350,14 +2350,33 @@ impl CanvasState {
         let mut current_text_run = UnshapedTextRun::new(language);
         let mut current_text_run_start_index = 0;
 
-        for (index, character) in text.char_indices() {
-            // TODO: This should ultimately handle emoji variation selectors, but raqote does not yet
-            // have support for color glyphs.
-            let script = Script::from(character);
-            let font =
-                font_group.find_by_codepoint(font_context, character, None, x_language.clone());
+        // Variation Selectors (U+FE00–U+FE0F) and Variation Selectors Supplement (U+E0100–U+E01EF)
+        // are used to select specific glyph variants (e.g., text vs. emoji presentation).
+        // They must be attached to the preceding base character and do not start new runs.
+        // - VS1–VS16 (U+FE00..U+FE0F) in the Variation Selectors block.
+        // - VS17–VS256 (U+E0100..U+E01EF) in the Variation Selectors Supplement block.
+        fn is_variation_selector(c: char) -> bool {
+            matches!(c as u32, 0xFE00..=0xFE0F | 0xE0100..=0xE01EF)
+        }
 
-            if !current_text_run.script_and_font_compatible(script, &font) {
+        for (index, character) in text.char_indices() {
+            let next_char = text[index + character.len_utf8()..]
+                .chars()
+                .next()
+                .filter(|&c| is_variation_selector(c));
+
+            let script = Script::from(character);
+
+            let font = font_group.find_by_codepoint(
+                font_context,
+                character,
+                next_char,
+                x_language.clone(),
+            );
+
+            if (!is_variation_selector(character) || current_text_run.string.is_empty()) &&
+                !current_text_run.script_and_font_compatible(script, &font)
+            {
                 let previous_text_run = std::mem::replace(
                     &mut current_text_run,
                     UnshapedTextRun {
@@ -2368,7 +2387,7 @@ impl CanvasState {
                     },
                 );
                 current_text_run_start_index = index;
-                runs.push(previous_text_run)
+                runs.push(previous_text_run);
             }
 
             current_text_run.string =

--- a/tests/wpt/tests/html/canvas/element/text/2d.text.variationSelectors.html
+++ b/tests/wpt/tests/html/canvas/element/text/2d.text.variationSelectors.html
@@ -3,12 +3,14 @@
 <link rel="author" title="Euclid Ye" href="mailto:yezhizhenjiakang@gmail.com">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
+<link rel="stylesheet" href="/css/css-fonts/support/css/variation-sequences.css">
+<link rel="help" href="https://github.com/servo/servo/issues/43650">
 <canvas id="canvas" width="400" height="200"></canvas>
 <script>
 test(() => {
     const canvas = document.getElementById('canvas');
     const ctx = canvas.getContext('2d');
-
+    ctx.font = '32px ColorEmojiFont';
     // Anchor: U+2693
     const base = '\u2693';
     const vs15 = '\uFE0E'; // text selector

--- a/tests/wpt/tests/html/canvas/element/text/2d.text.variationSelectors.html
+++ b/tests/wpt/tests/html/canvas/element/text/2d.text.variationSelectors.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<title>Canvas text: Variation selectors affect glyph width</title>
+<link rel="author" title="Euclid Ye" href="mailto:yezhizhenjiakang@gmail.com">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<canvas id="canvas" width="400" height="200"></canvas>
+<script>
+test(() => {
+    const canvas = document.getElementById('canvas');
+    const ctx = canvas.getContext('2d');
+
+    // Anchor: U+2693
+    const base = '\u2693';
+    const vs15 = '\uFE0E'; // text selector
+    const vs16 = '\uFE0F'; // emoji selector
+
+    const widthText = ctx.measureText(base + vs15).width;
+    const widthEmoji = ctx.measureText(base + vs16).width;
+
+    // Emoji should be wider.
+    assert_not_equals(widthText, widthEmoji, 'Widths with VS15 and VS16 should differ');
+}, 'Variation selectors (VS15/VS16) affect text width');
+</script>


### PR DESCRIPTION
Initially I just want to update the legacy comment, since raqote backend is gone.

This also enforces other variation selectors properly: see anchor ⚓ below, 
which ignored our text selector previously.

Fixes: https://github.com/servo/servo/issues/43448
Fixes: https://github.com/servo/servo/issues/43650
Testing: Added a test that all other browsers pass as well.

| Before | After |
|----------|----------|
| <img width="483" height="211" alt="image" src="https://github.com/user-attachments/assets/436493bc-ec42-4641-bcf8-c39afac6cfdc" /> | <img width="461" height="186" alt="image" src="https://github.com/user-attachments/assets/348375a8-45a4-4fde-aea6-9657cac211d3" />  |
| <img width="669" height="449" alt="image" src="https://github.com/user-attachments/assets/c791e840-9791-43b6-9147-1c250ea37721" /> | <img width="653" height="433" alt="image" src="https://github.com/user-attachments/assets/4fd06581-ac62-48f1-8135-d3c287e898cf" /> |