### PR TITLE
Metadata: Add missing repository information

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,9 @@ exclude = [".cargo", "support/crown"]
 [workspace.package]
 version = "0.0.6"
 authors = ["The Servo Project Developers"]
+repository = "https://github.com/servo/servo"
+# A generic description for packages that don't have a meaningful description yet.
+description = "A component of the servo web-engine."
 license = "MPL-2.0"
 edition = "2024"
 publish = false

--- a/components/allocator/Cargo.toml
+++ b/components/allocator/Cargo.toml
@@ -6,6 +6,8 @@ license.workspace = true
 edition.workspace = true
 publish.workspace = true
 rust-version.workspace = true
+repository.workspace = true
+description.workspace = true
 
 [lib]
 path = "lib.rs"

--- a/components/background_hang_monitor/Cargo.toml
+++ b/components/background_hang_monitor/Cargo.toml
@@ -6,6 +6,8 @@ license.workspace = true
 edition.workspace = true
 publish.workspace = true
 rust-version.workspace = true
+repository.workspace = true
+description.workspace = true
 
 [lib]
 name = "background_hang_monitor"

--- a/components/bluetooth/Cargo.toml
+++ b/components/bluetooth/Cargo.toml
@@ -6,6 +6,8 @@ license.workspace = true
 edition.workspace = true
 publish.workspace = true
 rust-version.workspace = true
+repository.workspace = true
+description.workspace = true
 
 [lib]
 name = "bluetooth"

--- a/components/canvas/Cargo.toml
+++ b/components/canvas/Cargo.toml
@@ -6,6 +6,8 @@ license.workspace = true
 edition.workspace = true
 publish.workspace = true
 rust-version.workspace = true
+repository.workspace = true
+description.workspace = true
 
 [lib]
 name = "canvas"

--- a/components/config/Cargo.toml
+++ b/components/config/Cargo.toml
@@ -6,6 +6,8 @@ license.workspace = true
 edition.workspace = true
 publish.workspace = true
 rust-version.workspace = true
+repository.workspace = true
+description.workspace = true
 
 [lib]
 name = "servo_config"

--- a/components/config/macro/Cargo.toml
+++ b/components/config/macro/Cargo.toml
@@ -6,6 +6,8 @@ license.workspace = true
 edition.workspace = true
 publish.workspace = true
 rust-version.workspace = true
+repository.workspace = true
+description.workspace = true
 
 [lib]
 name = "servo_config_macro"

--- a/components/constellation/Cargo.toml
+++ b/components/constellation/Cargo.toml
@@ -6,6 +6,8 @@ license.workspace = true
 edition.workspace = true
 publish.workspace = true
 rust-version.workspace = true
+repository.workspace = true
+description.workspace = true
 
 [lib]
 name = "constellation"

--- a/components/deny_public_fields/Cargo.toml
+++ b/components/deny_public_fields/Cargo.toml
@@ -6,6 +6,8 @@ license.workspace = true
 edition.workspace = true
 publish.workspace = true
 rust-version.workspace = true
+repository.workspace = true
+description.workspace = true
 
 [lib]
 path = "lib.rs"

--- a/components/devtools/Cargo.toml
+++ b/components/devtools/Cargo.toml
@@ -6,6 +6,8 @@ license.workspace = true
 edition.workspace = true
 publish.workspace = true
 rust-version.workspace = true
+repository.workspace = true
+description.workspace = true
 
 [lib]
 name = "devtools"

--- a/components/dom_struct/Cargo.toml
+++ b/components/dom_struct/Cargo.toml
@@ -6,6 +6,8 @@ authors.workspace = true
 license.workspace = true
 publish.workspace = true
 rust-version.workspace = true
+repository.workspace = true
+description.workspace = true
 
 [dependencies]
 quote = { workspace = true }

--- a/components/fonts/Cargo.toml
+++ b/components/fonts/Cargo.toml
@@ -6,6 +6,8 @@ license.workspace = true
 edition.workspace = true
 publish.workspace = true
 rust-version.workspace = true
+repository.workspace = true
+description.workspace = true
 
 [lib]
 name = "fonts"

--- a/components/geometry/Cargo.toml
+++ b/components/geometry/Cargo.toml
@@ -6,6 +6,8 @@ license.workspace = true
 edition.workspace = true
 publish.workspace = true
 rust-version.workspace = true
+repository.workspace = true
+description.workspace = true
 
 [lib]
 name = "servo_geometry"

--- a/components/jstraceable_derive/Cargo.toml
+++ b/components/jstraceable_derive/Cargo.toml
@@ -6,6 +6,8 @@ authors.workspace = true
 license.workspace = true
 publish.workspace = true
 rust-version.workspace = true
+repository.workspace = true
+description.workspace = true
 
 [lib]
 path = "lib.rs"

--- a/components/layout/Cargo.toml
+++ b/components/layout/Cargo.toml
@@ -6,6 +6,8 @@ license.workspace = true
 edition.workspace = true
 publish.workspace = true
 rust-version.workspace = true
+repository.workspace = true
+description.workspace = true
 
 [lib]
 name = "layout"

--- a/components/malloc_size_of/Cargo.toml
+++ b/components/malloc_size_of/Cargo.toml
@@ -6,6 +6,8 @@ authors.workspace = true
 edition.workspace = true
 publish.workspace = true
 rust-version.workspace = true
+repository.workspace = true
+description.workspace = true
 
 [lib]
 path = "lib.rs"

--- a/components/media/audio/Cargo.toml
+++ b/components/media/audio/Cargo.toml
@@ -6,6 +6,8 @@ license.workspace = true
 edition.workspace = true
 publish.workspace = true
 rust-version.workspace = true
+repository.workspace = true
+description.workspace = true
 
 [lib]
 name = "servo_media_audio"

--- a/components/media/backends/auto/Cargo.toml
+++ b/components/media/backends/auto/Cargo.toml
@@ -6,6 +6,8 @@ license.workspace = true
 edition.workspace = true
 publish.workspace = true
 rust-version.workspace = true
+repository.workspace = true
+description.workspace = true
 
 [lib]
 name = "servo_media_auto"

--- a/components/media/backends/dummy/Cargo.toml
+++ b/components/media/backends/dummy/Cargo.toml
@@ -6,6 +6,8 @@ license.workspace = true
 edition.workspace = true
 publish.workspace = true
 rust-version.workspace = true
+repository.workspace = true
+description.workspace = true
 
 [lib]
 name = "servo_media_dummy"

--- a/components/media/backends/gstreamer/Cargo.toml
+++ b/components/media/backends/gstreamer/Cargo.toml
@@ -6,6 +6,8 @@ license.workspace = true
 edition.workspace = true
 publish.workspace = true
 rust-version.workspace = true
+repository.workspace = true
+description.workspace = true
 
 [lib]
 name = "servo_media_gstreamer"

--- a/components/media/backends/gstreamer/render-android/Cargo.toml
+++ b/components/media/backends/gstreamer/render-android/Cargo.toml
@@ -6,6 +6,8 @@ license.workspace = true
 edition.workspace = true
 publish.workspace = true
 rust-version.workspace = true
+repository.workspace = true
+description.workspace = true
 
 [lib]
 name = "servo_media_gstreamer_render_android"

--- a/components/media/backends/gstreamer/render-unix/Cargo.toml
+++ b/components/media/backends/gstreamer/render-unix/Cargo.toml
@@ -6,6 +6,8 @@ license.workspace = true
 edition.workspace = true
 publish.workspace = true
 rust-version.workspace = true
+repository.workspace = true
+description.workspace = true
 
 [features]
 gl-egl = ["gstreamer-gl-egl"]

--- a/components/media/backends/gstreamer/render/Cargo.toml
+++ b/components/media/backends/gstreamer/render/Cargo.toml
@@ -6,6 +6,8 @@ license.workspace = true
 edition.workspace = true
 publish.workspace = true
 rust-version.workspace = true
+repository.workspace = true
+description.workspace = true
 
 [lib]
 name = "servo_media_gstreamer_render"

--- a/components/media/backends/ohos/Cargo.toml
+++ b/components/media/backends/ohos/Cargo.toml
@@ -6,6 +6,8 @@ license.workspace = true
 edition.workspace = true
 publish.workspace = true
 rust-version.workspace = true
+repository.workspace = true
+description.workspace = true
 
 [lib]
 name = "servo_media_ohos"

--- a/components/media/examples/Cargo.toml
+++ b/components/media/examples/Cargo.toml
@@ -6,6 +6,8 @@ license.workspace = true
 edition.workspace = true
 publish.workspace = true
 rust-version.workspace = true
+repository.workspace = true
+description.workspace = true
 
 [dependencies]
 euclid = { workspace = true }

--- a/components/media/media-thread/Cargo.toml
+++ b/components/media/media-thread/Cargo.toml
@@ -6,6 +6,8 @@ license.workspace = true
 edition.workspace = true
 publish.workspace = true
 rust-version.workspace = true
+repository.workspace = true
+description.workspace = true
 
 [lib]
 name = "media"

--- a/components/media/player/Cargo.toml
+++ b/components/media/player/Cargo.toml
@@ -6,6 +6,8 @@ license.workspace = true
 edition.workspace = true
 publish.workspace = true
 rust-version.workspace = true
+repository.workspace = true
+description.workspace = true
 
 [lib]
 name = "servo_media_player"

--- a/components/media/servo-media-derive/Cargo.toml
+++ b/components/media/servo-media-derive/Cargo.toml
@@ -6,6 +6,8 @@ license.workspace = true
 edition.workspace = true
 publish.workspace = true
 rust-version.workspace = true
+repository.workspace = true
+description.workspace = true
 
 [lib]
 name = "servo_media_derive"

--- a/components/media/servo-media/Cargo.toml
+++ b/components/media/servo-media/Cargo.toml
@@ -6,6 +6,8 @@ license.workspace = true
 edition.workspace = true
 publish.workspace = true
 rust-version.workspace = true
+repository.workspace = true
+description.workspace = true
 
 [lib]
 name = "servo_media"

--- a/components/media/streams/Cargo.toml
+++ b/components/media/streams/Cargo.toml
@@ -6,6 +6,8 @@ license.workspace = true
 edition.workspace = true
 publish.workspace = true
 rust-version.workspace = true
+repository.workspace = true
+description.workspace = true
 
 [lib]
 name = "servo_media_streams"

--- a/components/media/traits/Cargo.toml
+++ b/components/media/traits/Cargo.toml
@@ -6,6 +6,8 @@ license.workspace = true
 edition.workspace = true
 publish.workspace = true
 rust-version.workspace = true
+repository.workspace = true
+description.workspace = true
 
 [lib]
 name = "servo_media_traits"

--- a/components/media/webrtc/Cargo.toml
+++ b/components/media/webrtc/Cargo.toml
@@ -6,6 +6,8 @@ license.workspace = true
 edition.workspace = true
 publish.workspace = true
 rust-version.workspace = true
+repository.workspace = true
+description.workspace = true
 
 [lib]
 path = "lib.rs"

--- a/components/metrics/Cargo.toml
+++ b/components/metrics/Cargo.toml
@@ -6,6 +6,8 @@ license.workspace = true
 edition.workspace = true
 publish.workspace = true
 rust-version.workspace = true
+repository.workspace = true
+description.workspace = true
 
 [lib]
 name = "metrics"

--- a/components/paint/Cargo.toml
+++ b/components/paint/Cargo.toml
@@ -6,6 +6,8 @@ license.workspace = true
 edition.workspace = true
 publish.workspace = true
 rust-version.workspace = true
+repository.workspace = true
+description.workspace = true
 
 [lib]
 name = "paint"

--- a/components/pixels/Cargo.toml
+++ b/components/pixels/Cargo.toml
@@ -6,6 +6,8 @@ license.workspace = true
 edition.workspace = true
 publish.workspace = true
 rust-version.workspace = true
+repository.workspace = true
+description.workspace = true
 
 [lib]
 name = "pixels"

--- a/components/profile/Cargo.toml
+++ b/components/profile/Cargo.toml
@@ -6,6 +6,8 @@ license.workspace = true
 edition.workspace = true
 publish.workspace = true
 rust-version.workspace = true
+repository.workspace = true
+description.workspace = true
 
 [lib]
 name = "profile"

--- a/components/script/Cargo.toml
+++ b/components/script/Cargo.toml
@@ -7,6 +7,8 @@ license.workspace = true
 edition.workspace = true
 publish.workspace = true
 rust-version.workspace = true
+repository.workspace = true
+description.workspace = true
 
 [lib]
 name = "script"

--- a/components/servo/Cargo.toml
+++ b/components/servo/Cargo.toml
@@ -6,6 +6,8 @@ license.workspace = true
 edition.workspace = true
 publish.workspace = true
 rust-version.workspace = true
+repository.workspace = true
+description.workspace = true
 
 [lib]
 name = "servo"

--- a/components/servo_tracing/Cargo.toml
+++ b/components/servo_tracing/Cargo.toml
@@ -6,6 +6,8 @@ authors.workspace = true
 license.workspace = true
 publish.workspace = true
 rust-version.workspace = true
+repository.workspace = true
+description.workspace = true
 
 [dependencies]
 proc-macro2 = { workspace = true }

--- a/components/shared/background_hang_monitor/Cargo.toml
+++ b/components/shared/background_hang_monitor/Cargo.toml
@@ -6,6 +6,8 @@ license.workspace = true
 edition.workspace = true
 publish.workspace = true
 rust-version.workspace = true
+repository.workspace = true
+description.workspace = true
 
 [lib]
 name = "background_hang_monitor_api"

--- a/components/shared/base/Cargo.toml
+++ b/components/shared/base/Cargo.toml
@@ -6,6 +6,8 @@ license.workspace = true
 edition.workspace = true
 publish.workspace = true
 rust-version.workspace = true
+repository.workspace = true
+description.workspace = true
 
 [lib]
 name = "base"

--- a/components/shared/bluetooth/Cargo.toml
+++ b/components/shared/bluetooth/Cargo.toml
@@ -6,6 +6,8 @@ license.workspace = true
 edition.workspace = true
 publish.workspace = true
 rust-version.workspace = true
+repository.workspace = true
+description.workspace = true
 
 [lib]
 name = "bluetooth_traits"

--- a/components/shared/canvas/Cargo.toml
+++ b/components/shared/canvas/Cargo.toml
@@ -6,6 +6,8 @@ license.workspace = true
 edition.workspace = true
 publish.workspace = true
 rust-version.workspace = true
+repository.workspace = true
+description.workspace = true
 
 [lib]
 name = "canvas_traits"

--- a/components/shared/constellation/Cargo.toml
+++ b/components/shared/constellation/Cargo.toml
@@ -6,6 +6,8 @@ license.workspace = true
 edition.workspace = true
 publish.workspace = true
 rust-version.workspace = true
+repository.workspace = true
+description.workspace = true
 
 [lib]
 name = "constellation_traits"

--- a/components/shared/devtools/Cargo.toml
+++ b/components/shared/devtools/Cargo.toml
@@ -6,6 +6,8 @@ license.workspace = true
 edition.workspace = true
 publish.workspace = true
 rust-version.workspace = true
+repository.workspace = true
+description.workspace = true
 
 [lib]
 name = "devtools_traits"

--- a/components/shared/embedder/Cargo.toml
+++ b/components/shared/embedder/Cargo.toml
@@ -6,6 +6,8 @@ license.workspace = true
 edition.workspace = true
 publish.workspace = true
 rust-version.workspace = true
+repository.workspace = true
+description.workspace = true
 
 [lib]
 name = "embedder_traits"

--- a/components/shared/fonts/Cargo.toml
+++ b/components/shared/fonts/Cargo.toml
@@ -6,6 +6,8 @@ license.workspace = true
 edition.workspace = true
 publish.workspace = true
 rust-version.workspace = true
+repository.workspace = true
+description.workspace = true
 
 [lib]
 name = "fonts_traits"

--- a/components/shared/layout/Cargo.toml
+++ b/components/shared/layout/Cargo.toml
@@ -6,6 +6,8 @@ license.workspace = true
 edition.workspace = true
 publish.workspace = true
 rust-version.workspace = true
+repository.workspace = true
+description.workspace = true
 
 [lib]
 name = "layout_api"

--- a/components/shared/net/Cargo.toml
+++ b/components/shared/net/Cargo.toml
@@ -6,6 +6,8 @@ license.workspace = true
 edition.workspace = true
 publish.workspace = true
 rust-version.workspace = true
+repository.workspace = true
+description.workspace = true
 
 [lib]
 name = "net_traits"

--- a/components/shared/paint/Cargo.toml
+++ b/components/shared/paint/Cargo.toml
@@ -6,6 +6,8 @@ license.workspace = true
 edition.workspace = true
 publish.workspace = true
 rust-version.workspace = true
+repository.workspace = true
+description.workspace = true
 
 [lib]
 name = "paint_api"

--- a/components/shared/profile/Cargo.toml
+++ b/components/shared/profile/Cargo.toml
@@ -6,6 +6,8 @@ license.workspace = true
 edition.workspace = true
 publish.workspace = true
 rust-version.workspace = true
+repository.workspace = true
+description.workspace = true
 
 [lib]
 name = "profile_traits"

--- a/components/shared/script/Cargo.toml
+++ b/components/shared/script/Cargo.toml
@@ -6,6 +6,8 @@ license.workspace = true
 edition.workspace = true
 publish.workspace = true
 rust-version.workspace = true
+repository.workspace = true
+description.workspace = true
 
 [lib]
 name = "script_traits"

--- a/components/shared/storage/Cargo.toml
+++ b/components/shared/storage/Cargo.toml
@@ -6,6 +6,8 @@ license.workspace = true
 edition.workspace = true
 publish.workspace = true
 rust-version.workspace = true
+repository.workspace = true
+description.workspace = true
 
 [lib]
 name = "storage_traits"

--- a/components/shared/webgpu/Cargo.toml
+++ b/components/shared/webgpu/Cargo.toml
@@ -6,6 +6,8 @@ license.workspace = true
 edition.workspace = true
 publish.workspace = true
 rust-version.workspace = true
+repository.workspace = true
+description.workspace = true
 
 [lib]
 name = "webgpu_traits"

--- a/components/timers/Cargo.toml
+++ b/components/timers/Cargo.toml
@@ -6,6 +6,8 @@ license.workspace = true
 edition.workspace = true
 publish.workspace = true
 rust-version.workspace = true
+repository.workspace = true
+description.workspace = true
 
 [lib]
 name = "timers"

--- a/components/url/Cargo.toml
+++ b/components/url/Cargo.toml
@@ -6,6 +6,8 @@ license.workspace = true
 edition.workspace = true
 publish.workspace = true
 rust-version.workspace = true
+repository.workspace = true
+description.workspace = true
 
 [lib]
 name = "servo_url"

--- a/components/webdriver_server/Cargo.toml
+++ b/components/webdriver_server/Cargo.toml
@@ -6,6 +6,8 @@ license.workspace = true
 edition.workspace = true
 publish.workspace = true
 rust-version.workspace = true
+repository.workspace = true
+description.workspace = true
 
 [lib]
 name = "webdriver_server"

--- a/components/webgl/Cargo.toml
+++ b/components/webgl/Cargo.toml
@@ -6,6 +6,8 @@ license.workspace = true
 edition.workspace = true
 publish.workspace = true
 rust-version.workspace = true
+repository.workspace = true
+description.workspace = true
 
 [lib]
 name = "webgl"

--- a/components/webgpu/Cargo.toml
+++ b/components/webgpu/Cargo.toml
@@ -6,6 +6,8 @@ license.workspace = true
 edition.workspace = true
 publish.workspace = true
 rust-version.workspace = true
+repository.workspace = true
+description.workspace = true
 
 [lib]
 name = "webgpu"

--- a/components/xpath/Cargo.toml
+++ b/components/xpath/Cargo.toml
@@ -6,6 +6,8 @@ license.workspace = true
 edition.workspace = true
 publish.workspace = true
 rust-version.workspace = true
+repository.workspace = true
+description.workspace = true
 
 [dependencies]
 log = { workspace = true }

--- a/ports/servoshell/Cargo.toml
+++ b/ports/servoshell/Cargo.toml
@@ -7,6 +7,8 @@ license.workspace = true
 edition.workspace = true
 publish.workspace = true
 rust-version.workspace = true
+repository.workspace = true
+description.workspace = true
 
 [lib]
 name = "servoshell"


### PR DESCRIPTION
This fixes a warning of `cargo publish`: 

```
warning: manifest has no description, documentation, homepage or repository
```

Testing: Compiling. Manual testing of `cargo publish --dry-run` (with some additional patches, and until the next error, shows this warning has been fixed)

