### PR TITLE
devtools: Implement initial support for `ArrayPreviewer`

### DIFF
--- a/components/devtools/actors/console.rs
+++ b/components/devtools/actors/console.rs
@@ -380,6 +380,8 @@ impl ConsoleActor {
                 is_generator,
                 own_properties,
                 own_properties_length,
+                kind,
+                array_length,
             } => {
                 let properties = own_properties.clone().unwrap_or_default();
                 // TODO: Replace this with a struct to avoid having the Map.
@@ -418,27 +420,34 @@ impl ConsoleActor {
                     m.insert("isGenerator".to_owned(), Value::Bool(is_generator));
                 }
 
-                // Build preview with ownProperties
+                // Build preview
                 // <https://searchfox.org/firefox-main/source/devtools/server/actors/object/previewers.js#849>
                 let mut preview = Map::new();
-                preview.insert("kind".to_owned(), Value::String("Object".to_owned()));
+                let preview_kind = kind.unwrap_or_else(|| "Object".to_owned());
+                preview.insert("kind".to_owned(), Value::String(preview_kind.clone()));
 
-                if let Some(ref props) = own_properties {
-                    let mut own_props_map = Map::new();
-                    for prop in props {
-                        let descriptor =
-                            serde_json::to_value(PropertyDescriptor::from(prop)).unwrap();
-                        own_props_map.insert(prop.name.clone(), descriptor);
+                if preview_kind == "ArrayLike" {
+                    if let Some(length) = array_length {
+                        preview.insert("length".to_owned(), Value::Number(length.into()));
                     }
-                    preview.insert("ownProperties".to_owned(), Value::Object(own_props_map));
-                }
+                } else {
+                    if let Some(ref props) = own_properties {
+                        let mut own_props_map = Map::new();
+                        for prop in props {
+                            let descriptor =
+                                serde_json::to_value(PropertyDescriptor::from(prop)).unwrap();
+                            own_props_map.insert(prop.name.clone(), descriptor);
+                        }
+                        preview.insert("ownProperties".to_owned(), Value::Object(own_props_map));
+                    }
 
-                if let Some(length) = own_properties_length {
-                    preview.insert(
-                        "ownPropertiesLength".to_owned(),
-                        Value::Number(length.into()),
-                    );
-                    m.insert("ownPropertyLength".to_owned(), Value::Number(length.into()));
+                    if let Some(length) = own_properties_length {
+                        preview.insert(
+                            "ownPropertiesLength".to_owned(),
+                            Value::Number(length.into()),
+                        );
+                        m.insert("ownPropertyLength".to_owned(), Value::Number(length.into()));
+                    }
                 }
 
                 m.insert("preview".to_owned(), Value::Object(preview));

--- a/components/script/dom/debugger/debuggerglobalscope.rs
+++ b/components/script/dom/debugger/debuggerglobalscope.rs
@@ -556,6 +556,12 @@ impl DebuggerGlobalScopeMethods<crate::DomTypeHolder> for DebuggerGlobalScope {
                     })
                 });
                 let own_properties_length = result.ownPropertiesLength.flatten();
+                let kind = result
+                    .kind
+                    .as_ref()
+                    .and_then(|o| o.as_ref())
+                    .map(|s| s.to_string());
+                let array_length = result.arrayLength.flatten();
 
                 EvaluateJSReplyValue::ActorValue {
                     class,
@@ -567,6 +573,8 @@ impl DebuggerGlobalScopeMethods<crate::DomTypeHolder> for DebuggerGlobalScope {
                     is_generator,
                     own_properties,
                     own_properties_length,
+                    kind,
+                    array_length,
                 }
             },
             _ => unreachable!(),

--- a/components/script_bindings/webidls/DebuggerEvalEvent.webidl
+++ b/components/script_bindings/webidls/DebuggerEvalEvent.webidl
@@ -50,6 +50,10 @@ dictionary EvalResultValue {
     // Object preview properties
     sequence<PropertyPreview>? ownProperties;
     unsigned long? ownPropertiesLength;
+
+    // Array-specific
+    DOMString? kind;
+    unsigned long? arrayLength;
 };
 
 // TODO: Maybe merge some parts of this with the EvalResultValue

--- a/components/shared/devtools/lib.rs
+++ b/components/shared/devtools/lib.rs
@@ -192,6 +192,9 @@ pub enum EvaluateJSReplyValue {
         // Object preview
         own_properties: Option<Vec<PropertyPreview>>,
         own_properties_length: Option<u32>,
+        // Array-specific
+        kind: Option<String>,
+        array_length: Option<u32>,
     },
 }
 

--- a/resources/debugger.js
+++ b/resources/debugger.js
@@ -79,8 +79,9 @@ const OBJECT_PREVIEW_MAX_ITEMS = 10;
 // <https://searchfox.org/mozilla-central/source/devtools/server/actors/object/previewers.js#80>
 const previewers = {
     Function: [],
+    Array: [],
     Object: [],
-    // TODO: Add Array, Map, FormData etc
+    // TODO: Add Map, FormData etc
 };
 
 // Convert debuggee value to property descriptor value
@@ -173,6 +174,18 @@ previewers.Function.push(function FunctionPreviewer(obj) {
         isGenerator: obj.isGeneratorFunction,
         ownProperties,
         ownPropertiesLength,
+    };
+});
+
+// <https://searchfox.org/mozilla-central/source/devtools/server/actors/object/previewers.js#172>
+// TODO: Add implementation for showing Array items
+previewers.Array.push(function ArrayPreviewer(obj) {
+    const lengthDescriptor = obj.getOwnPropertyDescriptor("length");
+    const length = lengthDescriptor ? lengthDescriptor.value : 0;
+
+    return {
+        kind: "ArrayLike",
+        arrayLength: length,
     };
 });
 


### PR DESCRIPTION
Previously arrays were falling back to Object previewer which was showing indices as properties- which was not correct. This PR implements dedicated `ArrayPreviewer` that follows Firefox's `ArrayLike` pattern. Currently array preview support only length display, it does not implement showing array items yet.

Now(Correct and follows Firefox pattern, Array items coming in a follow-up PR):
<img width="510" height="167" alt="image" src="https://github.com/user-attachments/assets/a51f04d4-333c-4d7c-8159-18121c967670" />


Before(We shouldn't see these values- it's incorrect):
<img width="1294" height="721" alt="image" src="https://github.com/user-attachments/assets/2218a622-c791-4436-958e-1a5553de7864" />




Testing: Current tests are passing.
Fixes: Part of #36027 
