### PR TITLE
Cargo.toml: More publish preparation

### DIFF
--- a/components/net/Cargo.toml
+++ b/components/net/Cargo.toml
@@ -6,6 +6,8 @@ license.workspace = true
 edition.workspace = true
 publish.workspace = true
 rust-version.workspace = true
+repository.workspace = true
+description.workspace = true
 autotests = false # Inhibit lookup for tests/*.rs without [[test]] sections
 
 [lib]

--- a/components/net/Cargo.toml
+++ b/components/net/Cargo.toml
@@ -89,7 +89,9 @@ flate2 = { workspace = true }
 fst = "0.4"
 hyper = { workspace = true, features = ["full"] }
 hyper-util = { workspace = true, features = ["server-graceful"] }
-net = { workspace = true, features = ["test-util"] }
+# This must always be a path dependency, we don't want to add a dependency on a
+# crates.io version of ourselves - we want to enable a feature of ourselves.
+net = { package = "servo-net", path = ".", features = ["test-util"] }
 rustls = { workspace = true, features = ["aws-lc-rs"] }
 
 [[test]]

--- a/components/script_bindings/Cargo.toml
+++ b/components/script_bindings/Cargo.toml
@@ -6,6 +6,8 @@ authors.workspace = true
 edition.workspace = true
 publish.workspace = true
 rust-version.workspace = true
+repository.workspace = true
+description.workspace = true
 # BSD-3-Clause comes from third_party/ply, which doesn't end up in any produced build-artifact,
 # but is used during the build via build.rs.
 license = "MPL-2.0 AND BSD-3-Clause"

--- a/components/servo/Cargo.toml
+++ b/components/servo/Cargo.toml
@@ -151,7 +151,9 @@ accesskit_consumer = "0.35.0"
 http = { workspace = true }
 http-body-util = { workspace = true }
 hyper = { workspace = true }
-servo = { workspace = true, features = ["tracing"] }
+# This must always be a path dependency, we don't want to add a dependency on a
+# crates.io version of ourselves - we want to enable a feature of ourselves.
+servo = { path = ".", features = ["tracing"] }
 net = { workspace = true, features = ["test-util"] }
 rustls = { version = "0.23", default-features = false }
 tracing = { workspace = true }

--- a/components/shared/webxr/Cargo.toml
+++ b/components/shared/webxr/Cargo.toml
@@ -7,6 +7,7 @@ edition.workspace = true
 publish.workspace = true
 rust-version.workspace = true
 keywords = ["ar", "headset", "openxr", "vr", "webxr"]
+repository.workspace = true
 description = '''A safe Rust API that provides a way to interact with
 virtual reality and augmented reality devices and integration with OpenXR.
 The API is inspired by the WebXR Device API (https://www.w3.org/TR/webxr/)

--- a/components/storage/Cargo.toml
+++ b/components/storage/Cargo.toml
@@ -6,6 +6,8 @@ license.workspace = true
 edition.workspace = true
 publish.workspace = true
 rust-version.workspace = true
+repository.workspace = true
+description.workspace = true
 autotests = false # Inhibit lookup for tests/*.rs without [[test]] sections
 
 [lib]

--- a/components/webxr/Cargo.toml
+++ b/components/webxr/Cargo.toml
@@ -7,6 +7,7 @@ edition.workspace = true
 publish.workspace = true
 rust-version.workspace = true
 keywords = ["ar", "headset", "openxr", "vr", "webxr"]
+repository.workspace = true
 description = '''A safe Rust API that provides a way to interact with
 virtual reality and augmented reality devices and integration with OpenXR.
 The API is inspired by the WebXR Device API (https://www.w3.org/TR/webxr/)

--- a/python/tidy/test.py
+++ b/python/tidy/test.py
@@ -162,6 +162,12 @@ class CheckTidiness(unittest.TestCase):
         )
         self.assertNoMoreErrors(errors)
 
+    def test_toml_path_dependencies_self_reference(self):
+        errors = tidy.collect_errors_for_files(
+            iterFile("path_dependency/self-reference.Cargo.toml"), [], [tidy.check_toml], print_text=False
+        )
+        self.assertNoMoreErrors(errors)
+
     def test_modeline(self):
         errors = tidy.collect_errors_for_files(iterFile("modeline.txt"), [], [tidy.check_modeline], print_text=False)
         self.assertEqual("vi modeline present", next(errors)[2])

--- a/python/tidy/tests/path_dependency/self-reference.Cargo.toml
+++ b/python/tidy/tests/path_dependency/self-reference.Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "test-package"
+version = "0.0.1"
+license = "MPL-2.0"
+publish = false
+
+[features]
+test-feature = []
+
+[dev-dependencies]
+test-package = { path = "." }
+other-name = { package = "test-package", path = "."}

--- a/python/tidy/tidy.py
+++ b/python/tidy/tidy.py
@@ -565,13 +565,22 @@ def check_toml(file_name: str, lines: list[bytes]) -> Iterator[tuple[int, str]]:
 
 
 def path_dependency_names(cargo_toml: dict[str, Any]) -> list[str]:
-    """Scan a Cargo.toml dict for any dependencies using `path =`."""
+    """Scan a Cargo.toml dict for any dependencies using `path =`.
+
+    Entries that reference the own manifest are ignored.
+    """
     path_dependencies = []
+    manifest_package_name = cargo_toml.get("package", {}).get("name")
     for dependency_table in dependency_tables(cargo_toml):
         # dependency_value is everything in `{}` of `dependency_name = { ... }`
         for dependency_name, dependency_value in dependency_table.items():
             if "path" in dependency_value:
-                path_dependencies.append(dependency_name)
+                # When self-referencing the own package from within a packages manifest,
+                # we must use `path`, otherwise cargo will try to resolve from crates.io.
+                # This pattern is commonly used to enable extra code (features) in a library for integration tests.
+                dep_package_name = dependency_value.get("package", "")
+                if manifest_package_name != dependency_name and manifest_package_name != dep_package_name:
+                    path_dependencies.append(dependency_name)
     return path_dependencies
 
 


### PR DESCRIPTION
Add further missing repository keys / descriptions, which I missed in #43451 due to a suboptimal grep (assuming that rust-version.workspace is always the last item).
Additionally fix crate self-references, which caused cargo-publish to fail, due to it trying to fetch the crate from crates.io.
When specifying the current crate in `[dev-dependencies]` to enable a test feature or similar, apparently one should not use `workspace = true` and instead use `path`.
This requires extending the previously added `tidy` check, to allow `path` dependencies in this specific case outside of the workspace Cargo.toml.

Testing: Covered by existing tests

