### PR TITLE
servo-dom-struct: Enable required features

### DIFF
--- a/components/dom_struct/Cargo.toml
+++ b/components/dom_struct/Cargo.toml
@@ -11,7 +11,7 @@ description.workspace = true
 
 [dependencies]
 quote = { workspace = true }
-syn = { workspace = true }
+syn = { workspace = true, features = ["extra-traits", "full", "parsing", "printing", "proc-macro"] }
 proc-macro2 = { workspace = true }
 
 [lib]


### PR DESCRIPTION
Without these features, the crate does not build standalone. It worked in servo because of feature unification.
It seems like we should be able to refactor this crate quite easily to be able to disable some of the features again. 

Testing: Manual build: `cargo build -p servo-dom-struct`

