### PR TITLE
script-bindings: Don't write bytecode during build.rs

### DIFF
--- a/components/script_bindings/build.rs
+++ b/components/script_bindings/build.rs
@@ -31,6 +31,7 @@ fn main() {
         .arg("codegen/run.py")
         .arg(&css_properties_json)
         .arg(&out_dir)
+        .env("PYTHONDONTWRITEBYTECODE", "1")
         .status()
         .unwrap();
     if !status.success() {


### PR DESCRIPTION
Fixes the following error:

```
error: failed to verify package tarball

Caused by:
  Source directory was modified by build.rs during cargo publish. Build scripts should not modify anything outside of OUT_DIR.
  Added: /Users/jschwender/Dev/servo/target/package/servo-script-bindings-0.0.6/codegen/__pycache__
        /Users/jschwender/Dev/servo/target/package/servo-script-bindings-0.0.6/codegen/__pycache__/codegen.cpython-311.pyc
        /Users/jschwender/Dev/servo/target/package/servo-script-bindings-0.0.6/codegen/__pycache__/configuration.cpython-311.pyc
        /Users/jschwender/Dev/servo/target/package/servo-script-bindings-0.0.6/third_party/WebIDL/__pycache__
        /Users/jschwender/Dev/servo/target/package/servo-script-bindings-0.0.6/third_party/WebIDL/__pycache__/WebIDL.cpython-311.pyc
        /Users/jschwender/Dev/servo/target/package/servo-script-bindings-0.0.6/third_party/ply/ply/__pycache__
        /Users/jschwender/Dev/servo/target/package/servo-script-bindings-0.0.6/third_party/ply/ply/__pycache__/__init__.cpython-311.pyc
        /Users/jschwender/Dev/servo/target/package/servo-script-bindings-0.0.6/third_party/ply/ply/__pycache__/lex.cpython-311.pyc
        /Users/jschwender/Dev/servo/target/package/servo-script-bindings-0.0.6/third_party/ply/ply/__pycache__/yacc.cpython-311.pyc
```

Testing: Manual testing. The same approach was already successfully applied in `mozjs`.