### PR TITLE
webdriver: Remove TODO w.r.t. writing mode

### DIFF
--- a/components/script/dom/element.rs
+++ b/components/script/dom/element.rs
@@ -3390,6 +3390,7 @@ impl ElementMethods<crate::DomTypeHolder> for Element {
     fn GetBoundingClientRect(&self, can_gc: CanGc) -> DomRoot<DOMRect> {
         let win = self.owner_window();
         let rect = self.upcast::<Node>().border_box().unwrap_or_default();
+        debug_assert!(rect.size.width.to_f64_px() >= 0.0 && rect.size.height.to_f64_px() >= 0.0);
         DOMRect::new(
             win.upcast(),
             rect.origin.x.to_f64_px(),

--- a/components/webdriver_server/lib.rs
+++ b/components/webdriver_server/lib.rs
@@ -2476,7 +2476,6 @@ impl Handler {
 
         let rect = wait_for_ipc_response_flatten(receiver)?;
 
-        // TODO: Consider writing mode. Convert `rect` before requesting screenshot.
         // Step 5
         let encoded = self.take_screenshot(Some(Rect::from_untyped(&rect)))?;
 


### PR DESCRIPTION
The width and height should be guaranteed to be non-negative according to CSSOM regardless of the writing mode.

Testing: Existing tests.
