### PR TITLE
script: Fix borrow hazard in script_modules

### DIFF
--- a/components/script/script_module.rs
+++ b/components/script/script_module.rs
@@ -1524,7 +1524,7 @@ pub(crate) fn fetch_a_single_module_script(
     let comp = InRealm::Entered(&realm);
     run_a_callback::<DomTypeHolder, _>(&global, || {
         let has_pending_fetch = pending.borrow().is_some();
-        // be careful of Borrow Hazard here
+        // be careful of a borrow hazard here (do not hold a RefCell over a possible GC pause)
         let pending_option = pending.borrow_mut().take();
         let new_pending =
             pending_option.unwrap_or(Promise::new_in_current_realm(comp, CanGc::note()));

--- a/components/script/script_module.rs
+++ b/components/script/script_module.rs
@@ -1527,7 +1527,7 @@ pub(crate) fn fetch_a_single_module_script(
         // be careful of a borrow hazard here (do not hold a RefCell over a possible GC pause)
         let pending_option = pending.borrow_mut().take();
         let new_pending =
-            pending_option.unwrap_or(Promise::new_in_current_realm(comp, CanGc::note()));
+            pending_option.unwrap_or_else(|| Promise::new_in_current_realm(comp, CanGc::note()));
         new_pending.append_native_handler(&handler, comp, CanGc::note());
         let _ = pending.borrow_mut().insert(new_pending);
 

--- a/components/script/script_module.rs
+++ b/components/script/script_module.rs
@@ -1524,10 +1524,12 @@ pub(crate) fn fetch_a_single_module_script(
     let comp = InRealm::Entered(&realm);
     run_a_callback::<DomTypeHolder, _>(&global, || {
         let has_pending_fetch = pending.borrow().is_some();
-        pending
-            .borrow_mut()
-            .get_or_insert_with(|| Promise::new_in_current_realm(comp, CanGc::note()))
-            .append_native_handler(&handler, comp, CanGc::note());
+        // be careful of Borrow Hazard here
+        let pending_option = pending.borrow_mut().take();
+        let new_pending =
+            pending_option.unwrap_or(Promise::new_in_current_realm(comp, CanGc::note()));
+        new_pending.append_native_handler(&handler, comp, CanGc::note());
+        let _ = pending.borrow_mut().insert(new_pending);
 
         // Step 5. If moduleMap[(url, moduleType)] is "fetching", wait in parallel until that entry's value changes,
         // then queue a task on the networking task source to proceed with running the following steps.


### PR DESCRIPTION
Fix the borrow hazard by simply taking the option and inserting it again.

Testing: This is a refactor and crown does not complain so it should be fine.
Fixes: https://github.com/servo/servo/issues/43377
