### PR TITLE
cleanup: Remove unused GlobalScope argument from call_pull_algorithm

### DIFF
--- a/components/script/dom/stream/readablebytestreamcontroller.rs
+++ b/components/script/dom/stream/readablebytestreamcontroller.rs
@@ -1631,7 +1631,7 @@ impl ReadableByteStreamController {
             let realm = enter_realm(&*global);
             let comp = InRealm::Entered(&realm);
             let result = underlying_source
-                .call_pull_algorithm(controller, &global, can_gc)
+                .call_pull_algorithm(controller, can_gc)
                 .unwrap_or_else(|| {
                     let promise = Promise::new(&global, can_gc);
                     promise.resolve_native(&(), can_gc);

--- a/components/script/dom/stream/readablestreamdefaultcontroller.rs
+++ b/components/script/dom/stream/readablestreamdefaultcontroller.rs
@@ -548,7 +548,7 @@ impl ReadableStreamDefaultController {
         let realm = enter_realm(&*global);
         let comp = InRealm::Entered(&realm);
         let result = underlying_source
-            .call_pull_algorithm(controller, &global, can_gc)
+            .call_pull_algorithm(controller, can_gc)
             .unwrap_or_else(|| {
                 let promise = Promise::new(&global, can_gc);
                 promise.resolve_native(&(), can_gc);

--- a/components/script/dom/stream/underlyingsourcecontainer.rs
+++ b/components/script/dom/stream/underlyingsourcecontainer.rs
@@ -186,7 +186,6 @@ impl UnderlyingSourceContainer {
     pub(crate) fn call_pull_algorithm(
         &self,
         controller: Controller,
-        _global: &GlobalScope,
         can_gc: CanGc,
     ) -> Option<Result<Rc<Promise>, Error>> {
         match &self.underlying_source_type {


### PR DESCRIPTION
This PR involves cleaning up the unused GlobalScope argument in UnderlyingSourceContainer::call_pull_algorithm. This PR involves changes across three files. Only removing the unused GlobalScope and suppressed reference with underscore prefix.

Testing: This PR involves cleanup of the unused GlobalScope argument in UnderlyingSourceContainer::call_pull_algorithm. The argument was suppressed using underscore earlier. Thus it was not involved in any runtime instances. Thus this PR does not require additional testing. I was able to successfully build the repo after changes. There is no other dependency of removed variable, thus no impact outside.

Fixes: #43460 