### PR TITLE
devtools: wrap TcpStream to synchronize network operations

### DIFF
--- a/components/devtools/actor.rs
+++ b/components/devtools/actor.rs
@@ -5,7 +5,6 @@
 use std::any::{Any, type_name};
 use std::collections::HashMap;
 use std::marker::PhantomData;
-use std::net::TcpStream;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicU32, Ordering};
 
@@ -18,7 +17,7 @@ use serde_json::{Map, Value, json};
 use servo_base::id::PipelineId;
 
 use crate::StreamId;
-use crate::protocol::{ClientRequest, JsonPacketStream};
+use crate::protocol::{ClientRequest, DevtoolsConnection, JsonPacketStream};
 
 /// Error replies.
 ///
@@ -198,7 +197,7 @@ impl ActorRegistry {
     pub(crate) fn handle_message(
         &self,
         msg: &Map<String, Value>,
-        stream: &mut TcpStream,
+        stream: &mut DevtoolsConnection,
         stream_id: StreamId,
     ) -> Result<(), ()> {
         let to = match msg.get("to") {
@@ -221,7 +220,7 @@ impl ActorRegistry {
             },
             Some(actor) => {
                 let msg_type = msg.get("type").unwrap().as_str().unwrap();
-                if let Err(error) = ClientRequest::handle(stream, to, |req| {
+                if let Err(error) = ClientRequest::handle(stream.clone(), to, |req| {
                     actor.handle_message(req, self, msg_type, msg, stream_id)
                 }) {
                     // <https://firefox-source-docs.mozilla.org/devtools/backend/protocol.html#error-packets>

--- a/components/devtools/actors/browsing_context.rs
+++ b/components/devtools/actors/browsing_context.rs
@@ -6,8 +6,6 @@
 //! Connection point for remote devtools that wish to investigate a particular Browsing Context's contents.
 //! Supports dynamic attaching and detaching which control notifications of navigation, etc.
 
-use std::net::TcpStream;
-
 use atomic_refcell::AtomicRefCell;
 use devtools_traits::DevtoolScriptControlMsg::{self, GetCssDatabase, SimulateColorScheme};
 use devtools_traits::{DevtoolsPageInfo, NavigationState};
@@ -29,7 +27,7 @@ use crate::actors::tab::TabDescriptorActor;
 use crate::actors::thread::ThreadActor;
 use crate::actors::watcher::{SessionContext, SessionContextType, WatcherActor};
 use crate::id::{DevtoolsBrowserId, DevtoolsBrowsingContextId, DevtoolsOuterWindowId, IdMap};
-use crate::protocol::{ClientRequest, JsonPacketStream};
+use crate::protocol::{ClientRequest, DevtoolsConnection, JsonPacketStream};
 use crate::resource::ResourceAvailable;
 use crate::{EmptyReplyMsg, StreamId};
 
@@ -295,7 +293,7 @@ impl BrowsingContextActor {
         &self,
         state: NavigationState,
         id_map: &mut IdMap,
-        connections: impl Iterator<Item = &'a mut TcpStream>,
+        connections: impl Iterator<Item = &'a mut DevtoolsConnection>,
     ) {
         let (pipeline_id, title, url, state) = match state {
             NavigationState::Start(url) => (None, None, url, "start"),

--- a/components/devtools/actors/console.rs
+++ b/components/devtools/actors/console.rs
@@ -7,7 +7,6 @@
 //! inspection, JS evaluation, autocompletion) in Servo.
 
 use std::collections::HashMap;
-use std::net::TcpStream;
 use std::sync::atomic::{AtomicBool, Ordering};
 
 use atomic_refcell::AtomicRefCell;
@@ -29,7 +28,7 @@ use crate::actor::{Actor, ActorError, ActorRegistry};
 use crate::actors::browsing_context::BrowsingContextActor;
 use crate::actors::object::{ObjectActor, ObjectPropertyDescriptor};
 use crate::actors::worker::WorkerActor;
-use crate::protocol::{ClientRequest, JsonPacketStream};
+use crate::protocol::{ClientRequest, DevtoolsConnection, JsonPacketStream};
 use crate::resource::{ResourceArrayType, ResourceAvailable};
 use crate::{EmptyReplyMsg, StreamId, UniqueId};
 
@@ -474,7 +473,7 @@ impl ConsoleActor {
         resource: ConsoleResource,
         id: UniqueId,
         registry: &ActorRegistry,
-        stream: &mut TcpStream,
+        stream: &mut DevtoolsConnection,
     ) {
         self.cached_events
             .borrow_mut()
@@ -506,7 +505,7 @@ impl ConsoleActor {
         &self,
         id: UniqueId,
         registry: &ActorRegistry,
-        stream: &mut TcpStream,
+        stream: &mut DevtoolsConnection,
     ) {
         if id == self.current_unique_id(registry) {
             if let Root::BrowsingContext(browsing_context_name) = &self.root {
@@ -593,7 +592,7 @@ impl Actor for ConsoleActor {
                 };
                 // Emit an eager reply so that the client starts listening
                 // for an async event with the resultID
-                let stream = request.reply(&early_reply)?;
+                let mut stream = request.reply(&early_reply)?;
 
                 if msg.get("eager").and_then(|v| v.as_bool()).unwrap_or(false) {
                     // We don't support the side-effect free evaluation that eager evaluation

--- a/components/devtools/actors/inspector/walker.rs
+++ b/components/devtools/actors/inspector/walker.rs
@@ -4,8 +4,6 @@
 
 //! The walker actor is responsible for traversing the DOM tree in various ways to create new nodes
 
-use std::net::TcpStream;
-
 use atomic_refcell::AtomicRefCell;
 use devtools_traits::DevtoolScriptControlMsg::{GetChildren, GetDocumentElement, GetRootNode};
 use devtools_traits::{DevtoolScriptControlMsg, DomMutation};
@@ -19,7 +17,7 @@ use crate::actor::{Actor, ActorEncode, ActorError, ActorRegistry, DowncastableAc
 use crate::actors::browsing_context::BrowsingContextActor;
 use crate::actors::inspector::layout::LayoutInspectorActor;
 use crate::actors::inspector::node::{NodeActorMsg, NodeInfoToProtocol};
-use crate::protocol::{ClientRequest, JsonPacketStream};
+use crate::protocol::{ClientRequest, DevtoolsConnection, JsonPacketStream};
 use crate::{ActorMsg, EmptyReplyMsg, StreamId};
 
 #[derive(Serialize)]
@@ -312,7 +310,7 @@ impl WalkerActor {
     pub(crate) fn handle_dom_mutation(
         &self,
         dom_mutation: DomMutation,
-        stream: &mut TcpStream,
+        stream: &mut DevtoolsConnection,
     ) -> Result<(), ActorError> {
         let mut pending_mutations = self.mutations.borrow_mut();
 

--- a/components/devtools/actors/timeline.rs
+++ b/components/devtools/actors/timeline.rs
@@ -4,7 +4,6 @@
 
 #![expect(dead_code)]
 
-use std::net::TcpStream;
 use std::sync::{Arc, Mutex};
 use std::thread;
 use std::time::Duration;
@@ -23,7 +22,7 @@ use crate::StreamId;
 use crate::actor::{Actor, ActorError, ActorRegistry};
 use crate::actors::framerate::FramerateActor;
 use crate::actors::memory::{MemoryActor, TimelineMemoryReply};
-use crate::protocol::{ClientRequest, JsonPacketStream};
+use crate::protocol::{ClientRequest, DevtoolsConnection, JsonPacketStream};
 
 #[derive(MallocSizeOf)]
 pub(crate) struct TimelineActor {
@@ -33,7 +32,6 @@ pub(crate) struct TimelineActor {
     pipeline_id: PipelineId,
     #[conditional_malloc_size_of]
     is_recording: Arc<Mutex<bool>>,
-    stream: AtomicRefCell<Option<TcpStream>>,
     framerate_actor: AtomicRefCell<Option<String>>,
     memory_actor: AtomicRefCell<Option<String>>,
     #[conditional_malloc_size_of]
@@ -43,7 +41,7 @@ pub(crate) struct TimelineActor {
 
 struct Emitter {
     from: String,
-    stream: TcpStream,
+    stream: DevtoolsConnection,
     registry: Arc<Mutex<ActorRegistry>>,
     start_stamp: CrossProcessInstant,
 
@@ -148,7 +146,6 @@ impl TimelineActor {
             marker_types,
             script_sender,
             is_recording: Arc::new(Mutex::new(false)),
-            stream: AtomicRefCell::new(None),
             framerate_actor: AtomicRefCell::new(None),
             memory_actor: AtomicRefCell::new(None),
             start_stamp: CrossProcessInstant::now(),
@@ -216,9 +213,6 @@ impl Actor for TimelineActor {
                     ))
                     .unwrap();
 
-                // TODO: support multiple connections by using root actor's streams instead.
-                *self.stream.borrow_mut() = request.try_clone_stream().ok();
-
                 // init memory actor
                 if let Some(with_memory) = msg.get("withMemory") {
                     if let Some(true) = with_memory.as_bool() {
@@ -242,7 +236,7 @@ impl Actor for TimelineActor {
                     self.name(),
                     self.registry.clone(),
                     self.start_stamp,
-                    request.try_clone_stream().unwrap(),
+                    request.stream(),
                     self.memory_actor.borrow().clone(),
                     self.framerate_actor.borrow().clone(),
                 );
@@ -279,7 +273,6 @@ impl Actor for TimelineActor {
                 }
 
                 **self.is_recording.lock().as_mut().unwrap() = false;
-                self.stream.borrow_mut().take();
                 request.reply_final(&msg)?
             },
 
@@ -303,7 +296,7 @@ impl Emitter {
         name: String,
         registry: Arc<Mutex<ActorRegistry>>,
         start_stamp: CrossProcessInstant,
-        stream: TcpStream,
+        stream: DevtoolsConnection,
         memory_actor_name: Option<String>,
         framerate_actor_name: Option<String>,
     ) -> Emitter {

--- a/components/devtools/actors/watcher.rs
+++ b/components/devtools/actors/watcher.rs
@@ -11,7 +11,6 @@
 //! [Firefox JS implementation]: https://searchfox.org/mozilla-central/source/devtools/server/actors/descriptors/watcher.js
 
 use std::collections::HashMap;
-use std::net::TcpStream;
 
 use devtools_traits::get_time_stamp;
 use log::warn;
@@ -33,7 +32,7 @@ use crate::actors::watcher::target_configuration::{
     TargetConfigurationActor, TargetConfigurationActorMsg,
 };
 use crate::actors::watcher::thread_configuration::ThreadConfigurationActor;
-use crate::protocol::{ClientRequest, JsonPacketStream};
+use crate::protocol::{ClientRequest, DevtoolsConnection, JsonPacketStream};
 use crate::resource::{ResourceArrayType, ResourceAvailable};
 use crate::{ActorMsg, EmptyReplyMsg, IdMap, StreamId, WorkerActor};
 
@@ -460,7 +459,7 @@ impl WatcherActor {
         &self,
         browsing_context_id: BrowsingContextId,
         url: ServoUrl,
-        connections: impl Iterator<Item = &'a mut TcpStream>,
+        connections: impl Iterator<Item = &'a mut DevtoolsConnection>,
         id_map: &mut IdMap,
     ) {
         let msg = WillNavigateMessage {

--- a/components/devtools/actors/worker.rs
+++ b/components/devtools/actors/worker.rs
@@ -2,13 +2,11 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-use std::collections::HashMap;
-use std::net::TcpStream;
-
 use atomic_refcell::AtomicRefCell;
 use devtools_traits::DevtoolScriptControlMsg::WantsLiveNotifications;
 use devtools_traits::{DevtoolScriptControlMsg, WorkerId};
 use malloc_size_of_derive::MallocSizeOf;
+use rustc_hash::FxHashSet;
 use serde::Serialize;
 use serde_json::{Map, Value};
 use servo_base::generic_channel::GenericSender;
@@ -37,7 +35,7 @@ pub(crate) struct WorkerActor {
     pub url: ServoUrl,
     pub type_: WorkerType,
     pub script_chan: GenericSender<DevtoolScriptControlMsg>,
-    pub streams: AtomicRefCell<HashMap<StreamId, TcpStream>>,
+    pub streams: AtomicRefCell<FxHashSet<StreamId>>,
 }
 
 impl ResourceAvailable for WorkerActor {
@@ -67,9 +65,7 @@ impl Actor for WorkerActor {
                 };
                 // FIXME: we don’t send an actual reply (message without type), which seems to be a bug?
                 request.write_json_packet(&msg)?;
-                self.streams
-                    .borrow_mut()
-                    .insert(stream_id, request.try_clone_stream().unwrap());
+                self.streams.borrow_mut().insert(stream_id);
                 // FIXME: fix messages to not require forging a pipeline for worker messages
                 self.script_chan
                     .send(WantsLiveNotifications(TEST_PIPELINE_ID, true))

--- a/components/devtools/lib.rs
+++ b/components/devtools/lib.rs
@@ -56,7 +56,7 @@ use crate::actors::watcher::WatcherActor;
 use crate::actors::worker::{WorkerActor, WorkerType};
 use crate::id::IdMap;
 use crate::network_handler::handle_network_event;
-use crate::protocol::JsonPacketStream;
+use crate::protocol::{DevtoolsConnection, JsonPacketStream};
 
 mod actor;
 /// <https://searchfox.org/mozilla-central/source/devtools/server/actors>
@@ -166,7 +166,7 @@ struct DevtoolsInstance {
     ///
     /// Client threads remove their connection from here once they exit.
     #[conditional_malloc_size_of]
-    connections: Arc<Mutex<FxHashMap<StreamId, TcpStream>>>,
+    connections: Arc<Mutex<FxHashMap<StreamId, DevtoolsConnection>>>,
     next_resource_id: u64,
 }
 
@@ -255,30 +255,31 @@ impl DevtoolsInstance {
             trace!("{:?}", msg);
             match msg {
                 DevtoolsControlMsg::FromChrome(ChromeToDevtoolsControlMsg::AddClient(stream)) => {
-                    let registry = self.registry.clone();
                     let id = next_id;
                     next_id = StreamId(id.0 + 1);
 
-                    let mut connections = self.connections.lock().unwrap();
-                    if connections.is_empty() {
-                        // We used to have no connection, now we have one.
-                        // Therefore, we need updates from script threads.
-                        for browsing_context in self.browsing_contexts.values() {
-                            let actor =
-                                self.registry.find::<BrowsingContextActor>(browsing_context);
-                            actor.instruct_script_to_send_live_updates(true);
+                    {
+                        let connections = self.connections.lock().expect("Mutex poisoned.");
+                        if connections.is_empty() {
+                            // We used to have no connection, now we have one.
+                            // Therefore, we need updates from script threads.
+                            for name in self.browsing_contexts.values() {
+                                let actor = self.registry.find::<BrowsingContextActor>(name);
+                                actor.instruct_script_to_send_live_updates(true);
+                            }
                         }
                     }
-                    connections.insert(id, stream.try_clone().unwrap());
 
+                    let connection: DevtoolsConnection = stream.into();
+                    let registry_clone = self.registry.clone();
                     let connections_clone = self.connections.clone();
                     let sender_clone = self.sender.clone();
                     thread::Builder::new()
                         .name("DevtoolsClientHandler".to_owned())
                         .spawn(move || {
                             handle_client(
-                                registry,
-                                stream.try_clone().unwrap(),
+                                registry_clone,
+                                connection,
                                 id,
                                 connections_clone,
                                 sender_clone,
@@ -391,9 +392,9 @@ impl DevtoolsInstance {
                     // FIXME: Why do we need to do this? Cloning the connections here is
                     // almost certainly wrong and means that they might shut down without
                     // us noticing.
-                    let mut connections = Vec::<TcpStream>::new();
-                    for stream in self.connections.lock().unwrap().values() {
-                        connections.push(stream.try_clone().unwrap());
+                    let mut connections = Vec::<DevtoolsConnection>::new();
+                    for connection in self.connections.lock().unwrap().values() {
+                        connections.push(connection.clone());
                     }
                     self.handle_network_event(connections, request_id, network_event);
                 },
@@ -558,12 +559,12 @@ impl DevtoolsInstance {
         let console_actor = self.registry.find::<ConsoleActor>(&console_actor_name);
         let id = worker_id.map_or(UniqueId::Pipeline(pipeline_id), UniqueId::Worker);
 
-        for stream in self.connections.lock().unwrap().values_mut() {
+        for connection in self.connections.lock().unwrap().values_mut() {
             console_actor.handle_console_resource(
                 resource.clone(),
                 id.clone(),
                 &self.registry,
-                stream,
+                connection,
             );
         }
     }
@@ -589,8 +590,8 @@ impl DevtoolsInstance {
             .find::<InspectorActor>(&browsing_context_actor.inspector);
         let walker_actor = self.registry.find::<WalkerActor>(&inspector_actor.walker);
 
-        for stream in self.connections.lock().unwrap().values_mut() {
-            walker_actor.handle_dom_mutation(dom_mutation.clone(), stream)?;
+        for connection in self.connections.lock().unwrap().values_mut() {
+            walker_actor.handle_dom_mutation(dom_mutation.clone(), connection)?;
         }
 
         Ok(())
@@ -636,7 +637,7 @@ impl DevtoolsInstance {
 
     fn handle_network_event(
         &mut self,
-        connections: Vec<TcpStream>,
+        connections: Vec<DevtoolsConnection>,
         request_id: String,
         network_event: NetworkEvent,
     ) {
@@ -890,11 +891,16 @@ fn allow_devtools_client(stream: &mut TcpStream, embedder: &EmbedderProxy, token
 /// Process the input from a single devtools client until EOF.
 fn handle_client(
     registry: Arc<ActorRegistry>,
-    mut stream: TcpStream,
+    mut stream: DevtoolsConnection,
     stream_id: StreamId,
-    connections: Arc<Mutex<FxHashMap<StreamId, TcpStream>>>,
+    connections: Arc<Mutex<FxHashMap<StreamId, DevtoolsConnection>>>,
     sender: Sender<DevtoolsControlMsg>,
 ) {
+    connections
+        .lock()
+        .expect("Mutex poisoned.")
+        .insert(stream_id, stream.clone());
+
     log::info!("Connection established to {}", stream.peer_addr().unwrap());
     let msg = registry.encode::<RootActor, _>("root");
     if let Err(error) = stream.write_json_packet(&msg) {

--- a/components/devtools/lib.rs
+++ b/components/devtools/lib.rs
@@ -259,7 +259,7 @@ impl DevtoolsInstance {
                     next_id = StreamId(id.0 + 1);
 
                     {
-                        let connections = self.connections.lock().expect("Mutex poisoned.");
+                        let connections = self.connections.lock().unwrap();
                         if connections.is_empty() {
                             // We used to have no connection, now we have one.
                             // Therefore, we need updates from script threads.
@@ -441,7 +441,7 @@ impl DevtoolsInstance {
     fn handle_navigate(&self, browsing_context_id: BrowsingContextId, state: NavigationState) {
         let actor_name = self.browsing_contexts.get(&browsing_context_id).unwrap();
         let actor = self.registry.find::<BrowsingContextActor>(actor_name);
-        let mut id_map = self.id_map.lock().expect("Mutex poisoned");
+        let mut id_map = self.id_map.lock().unwrap();
         let mut connections = self.connections.lock().unwrap();
         if let NavigationState::Start(url) = &state {
             let watcher_actor = self.registry.find::<WatcherActor>(&actor.watcher);
@@ -466,7 +466,7 @@ impl DevtoolsInstance {
         page_info: DevtoolsPageInfo,
     ) {
         let (browsing_context_id, pipeline_id, worker_id, webview_id) = ids;
-        let id_map = &mut self.id_map.lock().expect("Mutex poisoned");
+        let id_map = &mut self.id_map.lock().unwrap();
         let devtools_browser_id = id_map.browser_id(webview_id);
         let devtools_browsing_context_id = id_map.browsing_context_id(browsing_context_id);
         let devtools_outer_window_id = id_map.outer_window_id(pipeline_id);
@@ -898,7 +898,7 @@ fn handle_client(
 ) {
     connections
         .lock()
-        .expect("Mutex poisoned.")
+        .unwrap()
         .insert(stream_id, stream.clone());
 
     log::info!("Connection established to {}", stream.peer_addr().unwrap());

--- a/components/devtools/lib.rs
+++ b/components/devtools/lib.rs
@@ -271,19 +271,13 @@ impl DevtoolsInstance {
                     }
 
                     let connection: DevtoolsConnection = stream.into();
-                    let registry_clone = self.registry.clone();
-                    let connections_clone = self.connections.clone();
+                    let registry = self.registry.clone();
+                    let connections = self.connections.clone();
                     let sender_clone = self.sender.clone();
                     thread::Builder::new()
                         .name("DevtoolsClientHandler".to_owned())
                         .spawn(move || {
-                            handle_client(
-                                registry_clone,
-                                connection,
-                                id,
-                                connections_clone,
-                                sender_clone,
-                            )
+                            handle_client(registry, connection, id, connections, sender_clone)
                         })
                         .expect("Thread spawning failed");
                 },

--- a/components/devtools/network_handler.rs
+++ b/components/devtools/network_handler.rs
@@ -2,7 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-use std::net::TcpStream;
 use std::sync::Arc;
 
 use devtools_traits::NetworkEvent;
@@ -11,6 +10,7 @@ use serde::Serialize;
 use crate::actor::{ActorEncode, ActorRegistry};
 use crate::actors::network_event::NetworkEventActor;
 use crate::actors::watcher::WatcherActor;
+use crate::protocol::DevtoolsConnection;
 use crate::resource::{ResourceArrayType, ResourceAvailable};
 
 #[derive(Clone, Serialize)]
@@ -24,7 +24,7 @@ pub(crate) struct Cause {
 pub(crate) fn handle_network_event(
     registry: Arc<ActorRegistry>,
     netevent_actor_name: String,
-    mut connections: Vec<TcpStream>,
+    mut connections: Vec<DevtoolsConnection>,
     network_event: NetworkEvent,
 ) {
     let actor = registry.find::<NetworkEventActor>(&netevent_actor_name);

--- a/components/devtools/protocol.rs
+++ b/components/devtools/protocol.rs
@@ -124,8 +124,7 @@ impl JsonPacketStream for DevtoolsConnection {
         let s = serde_json::to_string(message).map_err(|_| ActorError::Internal)?;
         log::debug!("<- {}", s);
         let mut stream = self.sender.lock().unwrap();
-        write!(*stream, "{}:{}", s.len(), s).map_err(|_| ActorError::Internal)?;
-        Ok(())
+        write!(*stream, "{}:{}", s.len(), s).map_err(|_| ActorError::Internal)
     }
 
     fn read_json_packet(&mut self) -> Result<Option<Value>, String> {

--- a/components/devtools/protocol.rs
+++ b/components/devtools/protocol.rs
@@ -135,23 +135,14 @@ impl JsonPacketStream for DevtoolsConnection {
         let mut stream = self.receiver.lock().unwrap();
         loop {
             let mut buf = [0];
-            let byte = match (*stream).read(&mut buf) {
-                Ok(0) => return Ok(None),                                            // EOF
-                Err(e) if e.kind() == ErrorKind::ConnectionReset => return Ok(None), // EOF
-                Ok(1) => buf[0],
-                Ok(_) => unreachable!(),
-                Err(e) => return Err(e.to_string()),
-            };
-            match byte {
-                b':' => {
-                    let packet_len_str = match String::from_utf8(buffer) {
-                        Ok(packet_len) => packet_len,
-                        Err(_) => return Err("nonvalid UTF8 in packet length".to_owned()),
-                    };
-                    let packet_len = match packet_len_str.parse::<u64>() {
-                        Ok(packet_len) => packet_len,
-                        Err(_) => return Err("packet length missing / not parsable".to_owned()),
-                    };
+            match (*stream).read(&mut buf) {
+                Ok(0) => return Ok(None), // EOF
+                Ok(1) if buf[0] == b':' => {
+                    let packet_len_str = String::from_utf8(buffer)
+                        .map_err(|_| "nonvalid UTF8 in packet length".to_owned())?;
+                    let packet_len = packet_len_str
+                        .parse::<u64>()
+                        .map_err(|_| "packet length missing / not parsable".to_owned())?;
                     let mut packet = String::new();
                     stream
                         // Temporarily clone stream to allow the object to be
@@ -163,12 +154,14 @@ impl JsonPacketStream for DevtoolsConnection {
                         .read_to_string(&mut packet)
                         .map_err(|e| e.to_string())?;
                     log::debug!("{}", packet);
-                    return match serde_json::from_str(&packet) {
-                        Ok(json) => Ok(Some(json)),
-                        Err(err) => Err(err.to_string()),
-                    };
+                    return serde_json::from_str(&packet)
+                        .map(Some)
+                        .map_err(|e| e.to_string());
                 },
-                c => buffer.push(c),
+                Ok(1) => buffer.push(buf[0]),
+                Ok(_) => unreachable!(),
+                Err(e) if e.kind() == ErrorKind::ConnectionReset => return Ok(None), // EOF
+                Err(e) => return Err(e.to_string()),
             }
         }
     }

--- a/components/devtools/protocol.rs
+++ b/components/devtools/protocol.rs
@@ -5,10 +5,12 @@
 //! Low-level wire protocol implementation. Currently only supports
 //! [JSON packets](https://firefox-source-docs.mozilla.org/devtools/backend/protocol.html#json-packets).
 
-use std::io::{ErrorKind, Read, Write};
-use std::net::TcpStream;
+use std::io::{self, ErrorKind, Read, Write};
+use std::net::{Shutdown, SocketAddr, TcpStream};
+use std::sync::{Arc, Mutex};
 
 use log::debug;
+use malloc_size_of_derive::MallocSizeOf;
 use serde::Serialize;
 use serde_json::{self, Value, json};
 
@@ -81,33 +83,126 @@ impl JsonPacketStream for TcpStream {
     }
 }
 
+/// Wraps a Remote Debugging Protocol TCP stream, guaranteeing that network
+/// operations are synchronized when cloning across threads.
+#[derive(Clone, MallocSizeOf)]
+// `TcpStream::read` is a mutating I/O operation that doesn't fit with `RwLock`.
+// We clone a single stream handle into two mutexes so we can still lock
+// reads and writes independently.
+pub(crate) struct DevtoolsConnection {
+    /// Copy of [`TcpStream`] handle to use for receiving from the client.
+    #[conditional_malloc_size_of]
+    receiver: Arc<Mutex<TcpStream>>,
+    /// Copy of [`TcpStream`] handle to use for sending bytes to the client.
+    #[conditional_malloc_size_of]
+    sender: Arc<Mutex<TcpStream>>,
+}
+
+impl From<TcpStream> for DevtoolsConnection {
+    fn from(value: TcpStream) -> Self {
+        Self {
+            receiver: Arc::new(Mutex::new(value.try_clone().unwrap())),
+            sender: Arc::new(Mutex::new(value)),
+        }
+    }
+}
+
+impl DevtoolsConnection {
+    /// Calls [`TcpStream::peer_addr`] on the underlying stream.
+    pub(crate) fn peer_addr(&self) -> io::Result<SocketAddr> {
+        self.receiver.lock().expect("Mutex poisoned.").peer_addr()
+    }
+
+    /// Calls [`TcpStream::shutdown`] on the underlying stream.
+    pub(crate) fn shutdown(&self, how: Shutdown) -> io::Result<()> {
+        self.receiver.lock().expect("Mutex poisoned.").shutdown(how)
+    }
+}
+
+impl JsonPacketStream for DevtoolsConnection {
+    fn write_json_packet<T: serde::Serialize>(&mut self, message: &T) -> Result<(), ActorError> {
+        let s = serde_json::to_string(message).map_err(|_| ActorError::Internal)?;
+        log::debug!("<- {}", s);
+        let mut stream = self.sender.lock().expect("Mutex poisoned.");
+        write!(*stream, "{}:{}", s.len(), s).map_err(|_| ActorError::Internal)?;
+        Ok(())
+    }
+
+    fn read_json_packet(&mut self) -> Result<Option<Value>, String> {
+        // https://firefox-source-docs.mozilla.org/devtools/backend/protocol.html#stream-transport
+        // In short, each JSON packet is [ascii length]:[JSON data of given length]
+        let mut buffer = vec![];
+        // Guard should be held until exactly one complete message has been read.
+        let mut stream = self.receiver.lock().expect("Mutex poisoned.");
+        loop {
+            let mut buf = [0];
+            let byte = match (*stream).read(&mut buf) {
+                Ok(0) => return Ok(None),                                            // EOF
+                Err(e) if e.kind() == ErrorKind::ConnectionReset => return Ok(None), // EOF
+                Ok(1) => buf[0],
+                Ok(_) => unreachable!(),
+                Err(e) => return Err(e.to_string()),
+            };
+            match byte {
+                b':' => {
+                    let packet_len_str = match String::from_utf8(buffer) {
+                        Ok(packet_len) => packet_len,
+                        Err(_) => return Err("nonvalid UTF8 in packet length".to_owned()),
+                    };
+                    let packet_len = match packet_len_str.parse::<u64>() {
+                        Ok(packet_len) => packet_len,
+                        Err(_) => return Err("packet length missing / not parsable".to_owned()),
+                    };
+                    let mut packet = String::new();
+                    stream
+                        // Temporarily clone stream to allow the object to be
+                        // moved out of the guard. This is okay as long as we
+                        // guarantee that the clone does not outlive the guard.
+                        .try_clone()
+                        .unwrap()
+                        .take(packet_len)
+                        .read_to_string(&mut packet)
+                        .map_err(|e| e.to_string())?;
+                    log::debug!("{}", packet);
+                    return match serde_json::from_str(&packet) {
+                        Ok(json) => Ok(Some(json)),
+                        Err(err) => Err(err.to_string()),
+                    };
+                },
+                c => buffer.push(c),
+            }
+        }
+    }
+}
+
 /// Wrapper around a client stream that guarantees request/reply invariants.
 ///
 /// Client messages, which are always requests, are dispatched to Actor instances one at a time via
-/// [`crate::Actor::handle_message`]. Each request must be paired with exactly one reply from the
-/// same actor the request was sent to, where a reply is a message with no type (if a message from
-/// the server has a type, it’s a notification, not a reply).
+/// [`crate::Actor::handle_message`]. In most cases, each request must be paired with exactly one
+/// reply from the same actor the request was sent to, where a reply is a message with no type. (If
+/// a message from the server has a type, it’s a notification, not a reply).
 ///
-/// Failing to reply to a request will almost always permanently break that actor, because either
-/// the client gets stuck waiting for a reply, or the client receives the reply for a subsequent
-/// request as if it was the reply for the current request. If an actor fails to reply to a request,
-/// we want the dispatcher ([`crate::ActorRegistry::handle_message`]) to send an error of type
-/// `unrecognizedPacketType`, to keep the conversation for that actor in sync.
+/// Unless a request is of one of the few types considered "one-way", failing to reply will almost
+/// always permanently break that actor, because either the client gets stuck waiting for a reply,
+/// or the client receives the reply for a subsequent request as if it was the reply for the current
+/// request. If an actor fails to reply to a request, we want the dispatcher
+/// ([`crate::ActorRegistry::handle_message`]) to send an error of type `unrecognizedPacketType`,
+/// to keep the conversation for that actor in sync.
 ///
 /// Since replies come in all shapes and sizes, we want to allow Actor types to send replies without
 /// having to return them to the dispatcher. This wrapper type allows the dispatcher to check if a
 /// valid reply was sent, and guarantees that if the actor tries to send a reply, it’s actually a
 /// valid reply (see [`Self::is_valid_reply`]).
 ///
-/// It does not currently guarantee anything about messages sent via the [`TcpStream`] released via
-/// [`Self::try_clone_stream`] or the return value of [`Self::reply`].
-pub(crate) struct ClientRequest<'req, 'sent> {
+/// It does not currently guarantee anything about messages sent via the [`DevtoolsConnection`]
+/// released via [`Self::stream`] or the return value of [`Self::reply`].
+pub(crate) struct ClientRequest<'req, 'handled> {
     /// Client stream.
-    stream: &'req mut TcpStream,
+    stream: DevtoolsConnection,
     /// Expected actor name.
     actor_name: &'req str,
     /// Flag allowing ActorRegistry to check for unhandled requests.
-    handled: &'sent mut bool,
+    handled: &'handled mut bool,
 }
 
 impl ClientRequest<'_, '_> {
@@ -115,13 +210,13 @@ impl ClientRequest<'_, '_> {
     ///
     /// Returns [`ActorError::UnrecognizedPacketType`] if the actor did not send a reply.
     pub fn handle<'req>(
-        client: &'req mut TcpStream,
+        stream: DevtoolsConnection,
         actor_name: &'req str,
         handler: impl FnOnce(ClientRequest<'req, '_>) -> Result<(), ActorError>,
     ) -> Result<(), ActorError> {
         let mut sent = false;
         let request = ClientRequest {
-            stream: client,
+            stream,
             actor_name,
             handled: &mut sent,
         };
@@ -140,21 +235,17 @@ impl<'req> ClientRequest<'req, '_> {
     ///
     /// If successful, sets the sent flag and returns the underlying stream,
     /// allowing other messages to be sent after replying to a request.
-    pub fn reply<T: Serialize>(self, reply: &T) -> Result<&'req mut TcpStream, ActorError> {
+    pub fn reply<T: Serialize>(mut self, reply: &T) -> Result<Self, ActorError> {
         debug_assert!(self.is_valid_reply(reply), "Message is not a valid reply");
         self.stream.write_json_packet(reply)?;
         *self.handled = true;
-        Ok(self.stream)
+        Ok(self)
     }
 
     /// Like `reply`, but for cases where the actor no longer needs the stream.
     pub fn reply_final<T: Serialize>(self, reply: &T) -> Result<(), ActorError> {
         let _stream = self.reply(reply)?;
         Ok(())
-    }
-
-    pub fn try_clone_stream(&self) -> std::io::Result<TcpStream> {
-        self.stream.try_clone()
     }
 
     /// Return true iff the given message is a reply (has no `type` or `to`), and is from the expected actor.
@@ -168,8 +259,14 @@ impl<'req> ClientRequest<'req, '_> {
     }
 
     /// Manually mark the request as handled, for one-way message types.
-    pub fn mark_handled(self) {
+    pub fn mark_handled(self) -> Self {
         *self.handled = true;
+        self
+    }
+
+    /// Get a copy of the client connection.
+    pub fn stream(&self) -> DevtoolsConnection {
+        self.stream.clone()
     }
 }
 

--- a/components/devtools/protocol.rs
+++ b/components/devtools/protocol.rs
@@ -86,11 +86,12 @@ impl JsonPacketStream for TcpStream {
 /// Wraps a Remote Debugging Protocol TCP stream, guaranteeing that network
 /// operations are synchronized when cloning across threads.
 #[derive(Clone, MallocSizeOf)]
-// `TcpStream::read` is a mutating I/O operation that doesn't fit with `RwLock`.
-// We clone a single stream handle into two mutexes so we can still lock
-// reads and writes independently.
 pub(crate) struct DevtoolsConnection {
     /// Copy of [`TcpStream`] handle to use for receiving from the client.
+    ///
+    /// `TcpStream::read` is a mutating I/O operation that doesn't fit with `RwLock`.
+    /// We clone a single stream handle into two mutexes so we can still lock
+    /// reads and writes independently.
     #[conditional_malloc_size_of]
     receiver: Arc<Mutex<TcpStream>>,
     /// Copy of [`TcpStream`] handle to use for sending bytes to the client.

--- a/components/devtools/protocol.rs
+++ b/components/devtools/protocol.rs
@@ -110,12 +110,12 @@ impl From<TcpStream> for DevtoolsConnection {
 impl DevtoolsConnection {
     /// Calls [`TcpStream::peer_addr`] on the underlying stream.
     pub(crate) fn peer_addr(&self) -> io::Result<SocketAddr> {
-        self.receiver.lock().expect("Mutex poisoned.").peer_addr()
+        self.receiver.lock().unwrap().peer_addr()
     }
 
     /// Calls [`TcpStream::shutdown`] on the underlying stream.
     pub(crate) fn shutdown(&self, how: Shutdown) -> io::Result<()> {
-        self.receiver.lock().expect("Mutex poisoned.").shutdown(how)
+        self.receiver.lock().unwrap().shutdown(how)
     }
 }
 
@@ -123,7 +123,7 @@ impl JsonPacketStream for DevtoolsConnection {
     fn write_json_packet<T: serde::Serialize>(&mut self, message: &T) -> Result<(), ActorError> {
         let s = serde_json::to_string(message).map_err(|_| ActorError::Internal)?;
         log::debug!("<- {}", s);
-        let mut stream = self.sender.lock().expect("Mutex poisoned.");
+        let mut stream = self.sender.lock().unwrap();
         write!(*stream, "{}:{}", s.len(), s).map_err(|_| ActorError::Internal)?;
         Ok(())
     }
@@ -133,7 +133,7 @@ impl JsonPacketStream for DevtoolsConnection {
         // In short, each JSON packet is [ascii length]:[JSON data of given length]
         let mut buffer = vec![];
         // Guard should be held until exactly one complete message has been read.
-        let mut stream = self.receiver.lock().expect("Mutex poisoned.");
+        let mut stream = self.receiver.lock().unwrap();
         loop {
             let mut buf = [0];
             let byte = match (*stream).read(&mut buf) {


### PR DESCRIPTION
Introduces a new type `DevtoolsConnection`, which implements the `JsonPacketStream` trait with proper coordination of I/O across threads. This replaces the implementation of `JsonPacketStream` for raw `TcpStream`s, which was susceptible to interleaving writes when cloned across threads.

`DevtoolsConnection` also defensively synchronizes read operations. These are less likely to cause issues: in practice actors should never independently pull incoming messages without centralized coordination.

Testing: No new tests, as interleaving writes are difficult to evoke deterministically. Removing the `JsonPacketStream` implementation for `TcpStream` should discourage regressions due to improper use of raw streams.