### PR TITLE
script: Propagate `&mut JSContext` inside `global_scope_script_execution.rs`

### DIFF
--- a/components/script/dom/document.rs
+++ b/components/script/dom/document.rs
@@ -2283,7 +2283,7 @@ impl Document {
                 self.process_pending_parsing_blocking_script(cx);
 
                 // Step 3.
-                self.process_deferred_scripts(CanGc::from_cx(cx));
+                self.process_deferred_scripts(cx);
             },
             LoadType::PageSource(_) => {
                 // We finished loading the page, so if the `Window` is still waiting for
@@ -2296,7 +2296,7 @@ impl Document {
                 // this is the first opportunity to process them.
 
                 // Step 3.
-                self.process_deferred_scripts(CanGc::from_cx(cx));
+                self.process_deferred_scripts(cx);
             },
             _ => {},
         }
@@ -2691,9 +2691,9 @@ impl Document {
     /// <https://html.spec.whatwg.org/multipage/#prepare-a-script> step 22.d.
     pub(crate) fn asap_script_loaded(
         &self,
+        cx: &mut js::context::JSContext,
         element: &HTMLScriptElement,
         result: ScriptResult,
-        can_gc: CanGc,
     ) {
         {
             let mut scripts = self.asap_scripts_set.borrow_mut();
@@ -2703,7 +2703,7 @@ impl Document {
                 .unwrap();
             scripts.swap_remove(idx);
         }
-        element.execute(result, can_gc);
+        element.execute(cx, result);
     }
 
     // https://html.spec.whatwg.org/multipage/#list-of-scripts-that-will-execute-in-order-as-soon-as-possible
@@ -2715,16 +2715,16 @@ impl Document {
     /// <https://html.spec.whatwg.org/multipage/#prepare-a-script> step> 22.c.
     pub(crate) fn asap_in_order_script_loaded(
         &self,
+        cx: &mut js::context::JSContext,
         element: &HTMLScriptElement,
         result: ScriptResult,
-        can_gc: CanGc,
     ) {
         self.asap_in_order_scripts_list.loaded(element, result);
         while let Some((element, result)) = self
             .asap_in_order_scripts_list
             .take_next_ready_to_be_executed()
         {
-            element.execute(result, can_gc);
+            element.execute(cx, result);
         }
     }
 
@@ -2737,16 +2737,16 @@ impl Document {
     /// <https://html.spec.whatwg.org/multipage/#prepare-a-script> step 22.d.
     pub(crate) fn deferred_script_loaded(
         &self,
+        cx: &mut js::context::JSContext,
         element: &HTMLScriptElement,
         result: ScriptResult,
-        can_gc: CanGc,
     ) {
         self.deferred_scripts.loaded(element, result);
-        self.process_deferred_scripts(can_gc);
+        self.process_deferred_scripts(cx);
     }
 
     /// <https://html.spec.whatwg.org/multipage/#the-end> step 3.
-    fn process_deferred_scripts(&self, can_gc: CanGc) {
+    fn process_deferred_scripts(&self, cx: &mut js::context::JSContext) {
         if self.ready_state.get() != DocumentReadyState::Interactive {
             return;
         }
@@ -2757,7 +2757,7 @@ impl Document {
             }
             if let Some((element, result)) = self.deferred_scripts.take_next_ready_to_be_executed()
             {
-                element.execute(result, can_gc);
+                element.execute(cx, result);
             } else {
                 break;
             }

--- a/components/script/dom/global_scope_script_execution.rs
+++ b/components/script/dom/global_scope_script_execution.rs
@@ -8,13 +8,13 @@ use std::ptr::NonNull;
 use std::rc::Rc;
 
 use content_security_policy::sandboxing_directive::SandboxingFlagSet;
-use js::jsapi::{
-    Compile1, ExceptionStackBehavior, JS_ClearPendingException, JSScript, SetScriptPrivate,
-};
+use js::context::JSContext;
+use js::jsapi::{ExceptionStackBehavior, JSScript, SetScriptPrivate};
 use js::jsval::{PrivateValue, UndefinedValue};
 use js::panic::maybe_resume_unwind;
-use js::rust::wrappers::{
-    JS_ExecuteScript, JS_GetPendingException, JS_GetScriptPrivate, JS_SetPendingException,
+use js::rust::wrappers2::{
+    Compile1, JS_ClearPendingException, JS_ExecuteScript, JS_GetPendingException,
+    JS_GetScriptPrivate, JS_SetPendingException,
 };
 use js::rust::{CompileOptionsWrapper, MutableHandleValue, transform_str_to_source_text};
 use script_bindings::cformat;
@@ -31,7 +31,7 @@ use crate::dom::window::Window;
 use crate::script_module::{
     ModuleScript, ModuleSource, ModuleTree, RethrowError, ScriptFetchOptions,
 };
-use crate::script_runtime::{CanGc, JSContext as SafeJSContext};
+use crate::script_runtime::CanGc;
 use crate::unminify::unminify_js;
 
 /// <https://html.spec.whatwg.org/multipage/#classic-script>
@@ -77,6 +77,7 @@ impl GlobalScope {
     #[expect(clippy::too_many_arguments)]
     pub(crate) fn create_a_classic_script(
         &self,
+        cx: &mut JSContext,
         source: Cow<'_, str>,
         url: ServoUrl,
         fetch_options: ScriptFetchOptions,
@@ -85,8 +86,6 @@ impl GlobalScope {
         line_number: u32,
         external: bool,
     ) -> ClassicScript {
-        let cx = GlobalScope::get_cx();
-
         let mut script_source = ModuleSource {
             source: Rc::new(DOMString::from(source)),
             unminified_dir: self.unminified_js_dir(),
@@ -95,7 +94,7 @@ impl GlobalScope {
         };
         unminify_js(&mut script_source);
 
-        rooted!(in(*cx) let mut compiled_script = std::ptr::null_mut::<JSScript>());
+        rooted!(&in(cx) let mut compiled_script = std::ptr::null_mut::<JSScript>());
 
         // TODO Step 1. If mutedErrors is true, then set baseURL to about:blank.
 
@@ -120,7 +119,7 @@ impl GlobalScope {
         let record = if compiled_script.get().is_null() {
             // Step 11.1. Set script's parse error and its error to rethrow to result[0].
             // Step 11.2. Return script.
-            Err(RethrowError::from_pending_exception(cx))
+            Err(RethrowError::from_pending_exception(cx.into()))
         } else {
             Ok(NonNull::new(*compiled_script).expect("Can't be null"))
         };
@@ -143,11 +142,10 @@ impl GlobalScope {
     #[expect(unsafe_code)]
     pub(crate) fn run_a_classic_script(
         &self,
+        cx: &mut JSContext,
         script: ClassicScript,
         rethrow_errors: RethrowErrors,
-        can_gc: CanGc,
     ) -> ErrorResult {
-        let cx = GlobalScope::get_cx();
         // TODO Step 1. Let settings be the settings object of script.
 
         // Step 2. Check if we can run script with settings. If this returns "do not run", then return NormalCompletion(empty).
@@ -161,21 +159,21 @@ impl GlobalScope {
         // Once dropped this will run "Step 9. Clean up after running script" steps
         run_a_script::<DomTypeHolder, _>(self, || {
             // Step 5. Let evaluationStatus be null.
-            rooted!(in(*cx) let mut evaluation_status = UndefinedValue());
+            rooted!(&in(cx) let mut evaluation_status = UndefinedValue());
             let mut result = false;
 
             match script.record {
                 // Step 6. If script's error to rethrow is not null, then set evaluationStatus to ThrowCompletion(script's error to rethrow).
                 Err(error_to_rethrow) => unsafe {
                     JS_SetPendingException(
-                        *cx,
+                        cx,
                         error_to_rethrow.handle(),
                         ExceptionStackBehavior::Capture,
                     )
                 },
                 // Step 7. Otherwise, set evaluationStatus to ScriptEvaluation(script's record).
                 Ok(compiled_script) => {
-                    rooted!(in(*cx) let mut rval = UndefinedValue());
+                    rooted!(&in(cx) let mut rval = UndefinedValue());
                     result = evaluate_script(
                         cx,
                         compiled_script,
@@ -186,7 +184,7 @@ impl GlobalScope {
                 },
             }
 
-            unsafe { JS_GetPendingException(*cx, evaluation_status.handle_mut()) };
+            unsafe { JS_GetPendingException(cx, evaluation_status.handle_mut()) };
 
             // Step 8. If evaluationStatus is an abrupt completion, then:
             if !evaluation_status.is_undefined() {
@@ -200,15 +198,19 @@ impl GlobalScope {
                     },
                     // Step 8.2. If rethrow errors is true and script's muted errors is true, then:
                     (RethrowErrors::Yes, ErrorReporting::Muted) => {
-                        unsafe { JS_ClearPendingException(*cx) };
+                        unsafe { JS_ClearPendingException(cx) };
                         // Throw a "NetworkError" DOMException.
                         return Err(Error::Network(None));
                     },
                     // Step 8.3. Otherwise, rethrow errors is false. Perform the following steps:
                     _ => {
-                        unsafe { JS_ClearPendingException(*cx) };
+                        unsafe { JS_ClearPendingException(cx) };
                         // Report an exception given by evaluationStatus.[[Value]] for script's settings object's global object.
-                        self.report_an_exception(cx, evaluation_status.handle(), can_gc);
+                        self.report_an_exception(
+                            cx.into(),
+                            evaluation_status.handle(),
+                            CanGc::from_cx(cx),
+                        );
 
                         // Return evaluationStatus.
                         return Err(Error::JSFailed);
@@ -235,9 +237,9 @@ impl GlobalScope {
     /// <https://html.spec.whatwg.org/multipage/#run-a-module-script>
     pub(crate) fn run_a_module_script(
         &self,
+        cx: &mut JSContext,
         module_tree: Rc<ModuleTree>,
         _rethrow_errors: bool,
-        can_gc: CanGc,
     ) {
         // Step 1. Let settings be the settings object of script.
         // NOTE(pylbrecht): "settings" is `self` here.
@@ -258,7 +260,7 @@ impl GlobalScope {
             {
                 let module_error = module_tree.get_rethrow_error().borrow();
                 if module_error.is_some() {
-                    module_tree.report_error(self, can_gc);
+                    module_tree.report_error(self, CanGc::from_cx(cx));
                     return;
                 }
             }
@@ -268,15 +270,16 @@ impl GlobalScope {
 
             if let Some(record) = record {
                 // Step 7.2. Set evaluationPromise to record.Evaluate().
-                rooted!(in(*GlobalScope::get_cx()) let mut rval = UndefinedValue());
-                let evaluated = module_tree.execute_module(self, record, rval.handle_mut(), can_gc);
+                rooted!(&in(cx) let mut rval = UndefinedValue());
+                let evaluated =
+                    module_tree.execute_module(self, record, rval.handle_mut(), CanGc::from_cx(cx));
 
                 // Step 8. If preventErrorReporting is false, then upon rejection of evaluationPromise
                 // with reason, report an exception given by reason for script's settings object's
                 // global object.
                 if let Err(exception) = evaluated {
                     module_tree.set_rethrow_error(exception);
-                    module_tree.report_error(self, can_gc);
+                    module_tree.report_error(self, CanGc::from_cx(cx));
                 }
             }
         });
@@ -308,7 +311,7 @@ impl GlobalScope {
 
 #[expect(unsafe_code)]
 pub(crate) fn compile_script(
-    cx: SafeJSContext,
+    cx: &mut JSContext,
     text: &str,
     filename: &str,
     line_number: u32,
@@ -324,7 +327,7 @@ pub(crate) fn compile_script(
     // TODO: pass filename as CString to avoid allocation
     // See https://github.com/servo/servo/issues/42126
     let filename = cformat!("{filename}");
-    let mut options = unsafe { CompileOptionsWrapper::new_raw(*cx, filename, line_number) };
+    let mut options = CompileOptionsWrapper::new(cx, filename, line_number);
     if let Some(introduction_type) = introduction_type {
         options.set_introduction_type(introduction_type);
     }
@@ -337,20 +340,20 @@ pub(crate) fn compile_script(
     options.set_no_script_rval(no_script_rval);
 
     debug!("Compiling script");
-    unsafe { Compile1(*cx, options.ptr, &mut transform_str_to_source_text(text)) }
+    unsafe { Compile1(cx, options.ptr, &mut transform_str_to_source_text(text)) }
 }
 
 /// <https://tc39.es/ecma262/#sec-runtime-semantics-scriptevaluation>
 #[expect(unsafe_code)]
 pub(crate) fn evaluate_script(
-    cx: SafeJSContext,
+    cx: &mut JSContext,
     compiled_script: NonNull<JSScript>,
     url: ServoUrl,
     fetch_options: ScriptFetchOptions,
     rval: MutableHandleValue,
 ) -> bool {
-    rooted!(in(*cx) let record = compiled_script.as_ptr());
-    rooted!(in(*cx) let mut script_private = UndefinedValue());
+    rooted!(&in(cx) let record = compiled_script.as_ptr());
+    rooted!(&in(cx) let mut script_private = UndefinedValue());
 
     unsafe { JS_GetScriptPrivate(*record, script_private.handle_mut()) };
 
@@ -375,5 +378,5 @@ pub(crate) fn evaluate_script(
         }
     }
 
-    unsafe { JS_ExecuteScript(*cx, record.handle(), rval) }
+    unsafe { JS_ExecuteScript(cx, record.handle(), rval) }
 }

--- a/components/script/dom/globalscope.rs
+++ b/components/script/dom/globalscope.rs
@@ -2874,7 +2874,7 @@ impl GlobalScope {
 
             rooted!(&in(cx) let mut compiled_script = std::ptr::null_mut::<JSScript>());
             compiled_script.set(compile_script(
-                cx.into(),
+                cx,
                 &code,
                 filename,
                 1,
@@ -2894,7 +2894,7 @@ impl GlobalScope {
             rooted!(&in(cx) let mut value = UndefinedValue());
             let rval = rval.unwrap_or_else(|| value.handle_mut());
 
-            if !evaluate_script(cx.into(), script, url, fetch_options, rval) {
+            if !evaluate_script(cx, script, url, fetch_options, rval) {
                 let error_info = take_and_report_pending_exception_for_api(cx);
                 return Err(JavaScriptEvaluationError::EvaluationFailure(error_info));
             }

--- a/components/script/dom/html/htmlscriptelement.rs
+++ b/components/script/dom/html/htmlscriptelement.rs
@@ -437,6 +437,7 @@ impl FetchResponseListener for ClassicContext {
         // Step 5.7. Let script be the result of creating a classic script given
         // sourceText, settingsObject, response's URL, options, mutedErrors, and url.
         let script = global.create_a_classic_script(
+            cx,
             source_text,
             final_url,
             self.fetch_options.clone(),
@@ -920,6 +921,7 @@ impl HTMLScriptElement {
                     // Step 32.2.1 Let script be the result of creating a classic script
                     // using source text, settings object, base URL, and options.
                     let script = self.global().create_a_classic_script(
+                        cx,
                         std::borrow::Cow::Borrowed(&text.str()),
                         base_url,
                         options,
@@ -1041,9 +1043,9 @@ impl HTMLScriptElement {
 
                 // Step 6."classic".3. Run the classic script given by el's result.
                 _ = self.owner_window().as_global_scope().run_a_classic_script(
+                    cx,
                     script,
                     RethrowErrors::No,
-                    CanGc::from_cx(cx),
                 );
 
                 // Step 6."classic".4. Set document's currentScript attribute to oldCurrentScript.
@@ -1054,11 +1056,9 @@ impl HTMLScriptElement {
                 document.set_current_script(None);
 
                 // Step 6."module".2. Run the module script given by el's result.
-                self.owner_window().as_global_scope().run_a_module_script(
-                    module_tree,
-                    false,
-                    CanGc::from_cx(cx),
-                );
+                self.owner_window()
+                    .as_global_scope()
+                    .run_a_module_script(cx, module_tree, false);
             },
             Script::ImportMap(script) => {
                 // Step 6."importmap".1. Register an import map given el's relevant global object and el's result.

--- a/components/script/dom/html/htmlscriptelement.rs
+++ b/components/script/dom/html/htmlscriptelement.rs
@@ -281,15 +281,15 @@ fn finish_fetching_a_classic_script(
     match script_kind {
         ExternalScriptKind::Asap => {
             document = elem.preparation_time_document.get().unwrap();
-            document.asap_script_loaded(elem, load, CanGc::from_cx(cx))
+            document.asap_script_loaded(cx, elem, load)
         },
         ExternalScriptKind::AsapInOrder => {
             document = elem.preparation_time_document.get().unwrap();
-            document.asap_in_order_script_loaded(elem, load, CanGc::from_cx(cx))
+            document.asap_in_order_script_loaded(cx, elem, load)
         },
         ExternalScriptKind::Deferred => {
             document = elem.parser_document.as_rooted();
-            document.deferred_script_loaded(elem, load, CanGc::from_cx(cx));
+            document.deferred_script_loaded(cx, elem, load);
         },
         ExternalScriptKind::ParsingBlocking => {
             document = elem.parser_document.as_rooted();
@@ -939,7 +939,7 @@ impl HTMLScriptElement {
                         doc.set_pending_parsing_blocking_script(self, Some(result));
                     } else {
                         // Step 34.3: otherwise.
-                        self.execute(result, CanGc::from_cx(cx));
+                        self.execute(cx, result);
                     }
                 },
                 ScriptType::Module => {
@@ -981,14 +981,14 @@ impl HTMLScriptElement {
                     ));
 
                     // Step 34.3
-                    self.execute(Ok(script), CanGc::from_cx(cx));
+                    self.execute(cx, Ok(script));
                 },
             }
         }
     }
 
     /// <https://html.spec.whatwg.org/multipage/#execute-the-script-element>
-    pub(crate) fn execute(&self, result: ScriptResult, can_gc: CanGc) {
+    pub(crate) fn execute(&self, cx: &mut JSContext, result: ScriptResult) {
         // Step 1. Let document be el's node document.
         let doc = self.owner_document();
 
@@ -1005,12 +1005,7 @@ impl HTMLScriptElement {
         let script = match result {
             // Step 4. If el's result is null, then fire an event named error at el, and return.
             Err(_) => {
-                self.dispatch_event(
-                    atom!("error"),
-                    EventBubbles::DoesNotBubble,
-                    EventCancelable::NotCancelable,
-                    can_gc,
-                );
+                self.dispatch_event(cx, atom!("error"));
                 return;
             },
 
@@ -1048,7 +1043,7 @@ impl HTMLScriptElement {
                 _ = self.owner_window().as_global_scope().run_a_classic_script(
                     script,
                     RethrowErrors::No,
-                    can_gc,
+                    CanGc::from_cx(cx),
                 );
 
                 // Step 6."classic".4. Set document's currentScript attribute to oldCurrentScript.
@@ -1062,12 +1057,12 @@ impl HTMLScriptElement {
                 self.owner_window().as_global_scope().run_a_module_script(
                     module_tree,
                     false,
-                    can_gc,
+                    CanGc::from_cx(cx),
                 );
             },
             Script::ImportMap(script) => {
                 // Step 6."importmap".1. Register an import map given el's relevant global object and el's result.
-                register_import_map(&self.owner_global(), script.import_map, can_gc);
+                register_import_map(&self.owner_global(), script.import_map, CanGc::from_cx(cx));
             },
         }
 
@@ -1079,12 +1074,7 @@ impl HTMLScriptElement {
 
         // Step 8. If el's from an external file is true, then fire an event named load at el.
         if self.from_an_external_file.get() {
-            self.dispatch_event(
-                atom!("load"),
-                EventBubbles::DoesNotBubble,
-                EventCancelable::NotCancelable,
-                can_gc,
-            );
+            self.dispatch_event(cx, atom!("load"));
         }
     }
 
@@ -1166,16 +1156,16 @@ impl HTMLScriptElement {
         self.non_blocking.get()
     }
 
-    fn dispatch_event(
-        &self,
-        type_: Atom,
-        bubbles: EventBubbles,
-        cancelable: EventCancelable,
-        can_gc: CanGc,
-    ) -> bool {
+    fn dispatch_event(&self, cx: &mut JSContext, type_: Atom) -> bool {
         let window = self.owner_window();
-        let event = Event::new(window.upcast(), type_, bubbles, cancelable, can_gc);
-        event.fire(self.upcast(), can_gc)
+        let event = Event::new(
+            window.upcast(),
+            type_,
+            EventBubbles::DoesNotBubble,
+            EventCancelable::NotCancelable,
+            CanGc::from_cx(cx),
+        );
+        event.fire(self.upcast(), CanGc::from_cx(cx))
     }
 
     fn text(&self) -> DOMString {

--- a/components/script/dom/servoparser/mod.rs
+++ b/components/script/dom/servoparser/mod.rs
@@ -391,7 +391,7 @@ impl ServoParser {
         assert_eq!(script_nesting_level, 0);
 
         self.script_nesting_level.set(script_nesting_level + 1);
-        script.execute(result, CanGc::from_cx(cx));
+        script.execute(cx, result);
         self.script_nesting_level.set(script_nesting_level);
 
         if !self.suspended.get() && !self.aborted.get() {

--- a/components/script/dom/workers/serviceworkerglobalscope.rs
+++ b/components/script/dom/workers/serviceworkerglobalscope.rs
@@ -411,6 +411,7 @@ impl ServiceWorkerGlobalScope {
                     define_all_exposed_interfaces(&mut realm, global_scope);
 
                     let script = global_scope.create_a_classic_script(
+                        &mut realm,
                         String::from_utf8_lossy(&source),
                         url,
                         ScriptFetchOptions::default_classic_script(global_scope),
@@ -419,11 +420,7 @@ impl ServiceWorkerGlobalScope {
                         1,
                         true,
                     );
-                    _ = global_scope.run_a_classic_script(
-                        script,
-                        RethrowErrors::No,
-                        CanGc::from_cx(&mut realm),
-                    );
+                    _ = global_scope.run_a_classic_script(&mut realm, script, RethrowErrors::No);
                     let in_realm_proof = (&mut realm).into();
                     global.dispatch_activate(
                         CanGc::from_cx(&mut realm),

--- a/components/script/dom/workers/workerglobalscope.rs
+++ b/components/script/dom/workers/workerglobalscope.rs
@@ -210,6 +210,7 @@ impl FetchResponseListener for ScriptFetchContext {
         // Step 5 Let script be the result of creating a classic script using
         // sourceText, settingsObject, response's URL, and the default script fetch options.
         let script = global_scope.create_a_classic_script(
+            cx,
             source,
             scope.worker_url.borrow().clone(),
             ScriptFetchOptions::default_classic_script(global_scope),
@@ -595,27 +596,21 @@ impl WorkerGlobalScope {
 
         {
             let mut realm = enter_auto_realm(cx, self);
-            let mut realm = realm.current_realm();
-            define_all_exposed_interfaces(&mut realm, dedicated_worker_scope.upcast());
+            let cx = &mut realm.current_realm();
+            define_all_exposed_interfaces(cx, dedicated_worker_scope.upcast());
             self.execution_ready.store(true, Ordering::Relaxed);
             match script {
                 Script::Classic(script) => {
-                    _ = self.globalscope.run_a_classic_script(
-                        script,
-                        RethrowErrors::No,
-                        CanGc::from_cx(&mut realm),
-                    );
+                    _ = self
+                        .globalscope
+                        .run_a_classic_script(cx, script, RethrowErrors::No);
                 },
                 Script::Module(module_tree) => {
-                    self.globalscope.run_a_module_script(
-                        module_tree,
-                        false,
-                        CanGc::from_cx(&mut realm),
-                    );
+                    self.globalscope.run_a_module_script(cx, module_tree, false);
                 },
                 _ => unreachable!(),
             }
-            dedicated_worker_scope.fire_queued_messages(CanGc::from_cx(&mut realm));
+            dedicated_worker_scope.fire_queued_messages(CanGc::from_cx(cx));
         }
     }
 
@@ -747,6 +742,7 @@ impl WorkerGlobalScopeMethods<crate::DomTypeHolder> for WorkerGlobalScope {
             // Step 10. Let script be the result of creating a classic script
             // given sourceText, settingsObject, response's URL, the default script fetch options, and mutedErrors.
             let script = self.globalscope.create_a_classic_script(
+                cx,
                 source,
                 url,
                 ScriptFetchOptions::default_classic_script(&self.globalscope),
@@ -757,11 +753,9 @@ impl WorkerGlobalScopeMethods<crate::DomTypeHolder> for WorkerGlobalScope {
             );
 
             // Run the classic script script, with rethrow errors set to true.
-            let result = self.globalscope.run_a_classic_script(
-                script,
-                RethrowErrors::Yes,
-                CanGc::from_cx(cx),
-            );
+            let result = self
+                .globalscope
+                .run_a_classic_script(cx, script, RethrowErrors::Yes);
 
             if let Err(error) = result {
                 if self.is_closing() {

--- a/components/script/script_module.rs
+++ b/components/script/script_module.rs
@@ -659,14 +659,13 @@ impl ModuleOwner {
                 let asynch = script
                     .upcast::<Element>()
                     .has_attribute(&local_name!("async"));
-                let can_gc = CanGc::from_cx(cx);
 
                 if !asynch && script.get_parser_inserted() {
-                    document.deferred_script_loaded(&script, load, can_gc);
+                    document.deferred_script_loaded(cx, &script, load);
                 } else if !asynch && !script.get_non_blocking() {
-                    document.asap_in_order_script_loaded(&script, load, can_gc);
+                    document.asap_in_order_script_loaded(cx, &script, load);
                 } else {
-                    document.asap_script_loaded(&script, load, can_gc);
+                    document.asap_script_loaded(cx, &script, load);
                 };
             },
         }

--- a/components/script/timers.rs
+++ b/components/script/timers.rs
@@ -809,6 +809,7 @@ impl JsTimerTask {
                 // Step 9.6.8. Let script be the result of creating a classic script given handler,
                 // settings object, base URL, and fetch options.
                 let script = global.create_a_classic_script(
+                    cx,
                     (*code_str.str()).into(),
                     base_url,
                     fetch_options,
@@ -819,7 +820,7 @@ impl JsTimerTask {
                 );
 
                 // Step 9.6.9. Run the classic script script.
-                _ = global.run_a_classic_script(script, RethrowErrors::No, CanGc::from_cx(cx));
+                _ = global.run_a_classic_script(cx, script, RethrowErrors::No);
             },
             // Step 9.5. If handler is a Function, then invoke handler given arguments and
             // "report", and with callback this value set to thisArg.


### PR DESCRIPTION
Pass `&mut JSContext` to `HTMLScriptElement::execute`, propagate it inside `global_scope_script_execution.rs` and then switch to wrappers2 bindings.

Testing: A successful build is enough.
Part of #40600 
