### PR TITLE
layout: Do not consider broken image as contentful

### DIFF
--- a/components/layout/display_list/mod.rs
+++ b/components/layout/display_list/mod.rs
@@ -709,10 +709,13 @@ impl Fragment {
                             // From <https://www.w3.org/TR/paint-timing/#contentful>:
                             // An element target is contentful when one or more of the following apply:
                             // > target is a replaced element representing an available image.
-                            builder.mark_is_contentful();
-
-                            // Skip Broken Images for LCP
+                            // From: <https://html.spec.whatwg.org/multipage/#img-available>
+                            // When an image request's state is either partially available or completely available,
+                            // the image request is said to be available.
+                            // Hence, Skip Broken Images.
                             if !image.showing_broken_image_icon {
+                                builder.mark_is_contentful();
+
                                 builder.check_for_lcp_candidate(
                                     common.clip_rect,
                                     rect,

--- a/tests/wpt/tests/paint-timing/fcp-only/fcp-broken-image.html
+++ b/tests/wpt/tests/paint-timing/fcp-only/fcp-broken-image.html
@@ -5,17 +5,17 @@
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script src="../resources/utils.js"></script>
-<img id='broken'></div>
+<img id='broken'>
 <script>
 setup({"hide_test_state": true});
 promise_test(async t => {
   const onload = new Promise(r => window.addEventListener('load', r));
   await onload;
-  return assertNoFirstContentfulPaint(t).then(() => {
-    document.getElementById('broken').src = '../non-existent-image.jpg';
-  }).then(() => {
-    return assertFirstContentfulPaint(t);
-  });
-}, 'Broken image triggers First Contentful Paint.');
+  await assertNoFirstContentfulPaint(t);
+
+  document.getElementById('broken').src = '../non-existent-image.jpg';
+
+  await assertNoFirstContentfulPaint(t);
+}, 'Broken image should not trigger First Contentful Paint.');
 </script>
 </body>


### PR DESCRIPTION
1. Broken Images are skipped for FirstContentfulPaint as per specs.
2. Update the WPT test.

Testing: `tests/wpt/tests/paint-timing/fcp-only/fcp-broken-image.html`
