### PR TITLE
script: Use UnrootedSimpleNodeIterator in delete_cell_or_row

### DIFF
--- a/components/script/dom/bindings/root.rs
+++ b/components/script/dom/bindings/root.rs
@@ -225,7 +225,7 @@ pub(crate) fn assert_in_layout() {
 #[cfg_attr(crown, crown::unrooted_must_root_lint::allow_unrooted_interior)]
 pub(crate) struct UnrootedDom<'a, T: DomObject> {
     inner: Dom<T>,
-    _no_gc: &'a NoGC,
+    no_gc: &'a NoGC,
 }
 
 impl<'a, T: DomObject> UnrootedDom<'a, T> {
@@ -234,7 +234,7 @@ impl<'a, T: DomObject> UnrootedDom<'a, T> {
     pub(crate) fn from_dom(object: Dom<T>, no_gc: &'a NoGC) -> UnrootedDom<'a, T> {
         UnrootedDom {
             inner: object,
-            _no_gc: no_gc,
+            no_gc,
         }
     }
 }
@@ -244,6 +244,39 @@ impl<'a, T: DomObject> Deref for UnrootedDom<'a, T> {
 
     fn deref(&self) -> &Self::Target {
         &self.inner
+    }
+}
+
+/// Safety:
+/// We enforce the same lifetime as the given `UnrootedDom`, so the same
+/// guarantee about no GC happening in this lifetime.
+impl<'a, T: Castable> UnrootedDom<'a, T> {
+    /// Cast a DOM object root upwards to one of the interfaces it derives from.
+    #[expect(dead_code)]
+    pub fn upcast<U>(dom: UnrootedDom<'a, T>) -> UnrootedDom<'a, U>
+    where
+        U: Castable,
+        T: DerivedFrom<U>,
+    {
+        UnrootedDom {
+            inner: unsafe { mem::transmute::<Dom<T>, Dom<U>>(dom.inner) },
+            no_gc: dom.no_gc,
+        }
+    }
+
+    /// Cast a DOM object root downwards to one of the interfaces it might implement.
+    pub fn downcast<U>(dom: UnrootedDom<'a, T>) -> Option<UnrootedDom<'a, U>>
+    where
+        U: DerivedFrom<T>,
+    {
+        if dom.is::<U>() {
+            Some(UnrootedDom {
+                inner: unsafe { mem::transmute::<Dom<T>, Dom<U>>(dom.inner) },
+                no_gc: dom.no_gc,
+            })
+        } else {
+            None
+        }
     }
 }
 
@@ -305,10 +338,8 @@ impl<T: DomObject> MutNullableDom<T> {
     pub(crate) fn get_unrooted<'a>(&self, no_gc: &'a NoGC) -> Option<UnrootedDom<'a, T>> {
         assert_in_script();
         let ptr = unsafe { ptr::read(self.ptr.get()) };
-        ptr.map(|o| Dom::from_ref(&*o)).map(|dom| UnrootedDom {
-            inner: dom,
-            _no_gc: no_gc,
-        })
+        ptr.map(|o| Dom::from_ref(&*o))
+            .map(|dom| UnrootedDom { inner: dom, no_gc })
     }
 
     /// Set this `MutNullableDom` to the given value.

--- a/components/script/dom/element.rs
+++ b/components/script/dom/element.rs
@@ -4844,7 +4844,7 @@ impl VirtualMethods for Element {
         } else {
             if flags.intersects(ElementSelectorFlags::HAS_SLOW_SELECTOR_LATER_SIBLINGS) {
                 if let Some(next_child) = mutation.next_child() {
-                    for child in next_child.inclusively_following_siblings() {
+                    for child in next_child.inclusively_following_siblings_unrooted(cx.no_gc()) {
                         if child.is::<Element>() {
                             child.dirty(NodeDamage::Other);
                         }

--- a/components/script/dom/node.rs
+++ b/components/script/dom/node.rs
@@ -1339,7 +1339,7 @@ impl Node {
             // or child is non-null and a doctype is following child
             if child.is_some_and(|child| {
                 child
-                    .inclusively_following_siblings()
+                    .inclusively_following_siblings_unrooted(cx.no_gc())
                     .any(|child| child.is_doctype())
             }) {
                 return Err(Error::HierarchyRequest(None));
@@ -1824,9 +1824,10 @@ impl Node {
             -1 => {
                 let last_child = self.upcast::<Node>().GetLastChild();
                 match last_child.and_then(|node| {
-                    node.inclusively_preceding_siblings()
-                        .filter_map(DomRoot::downcast::<Element>)
+                    node.inclusively_preceding_siblings_unrooted(cx.no_gc())
+                        .filter_map(UnrootedDom::downcast::<Element>)
                         .find(|elem| is_delete_type(elem))
+                        .map(|elem| elem.as_rooted())
                 }) {
                     Some(element) => element,
                     None => return Ok(()),


### PR DESCRIPTION
This uses UnrootedSimpleNodeIterator in a couple of places, namely
- delete_cell_or_row
- children_changed
- move_fn

More importantly this implements upcast and downcast for `UnrootedDom`.
These methods work the same as the DomRoot methods except that they carry the no_gc and, hence,
keep the lifetime.

Testing: WPT tests will see if this breaks something.
