### PR TITLE
net: Remove `process_request_eof`

### DIFF
--- a/components/fonts/font_context.rs
+++ b/components/fonts/font_context.rs
@@ -1063,9 +1063,7 @@ impl RemoteWebFontDownloader {
         response_message: FetchResponseMsg,
     ) -> DownloaderResponseResult {
         match response_message {
-            FetchResponseMsg::ProcessRequestBody(..) | FetchResponseMsg::ProcessRequestEOF(..) => {
-                DownloaderResponseResult::InProcess
-            },
+            FetchResponseMsg::ProcessRequestBody(..) => DownloaderResponseResult::InProcess,
             FetchResponseMsg::ProcessCspViolations(_request_id, violations) => {
                 self.state
                     .as_ref()

--- a/components/net/fetch/methods.rs
+++ b/components/net/fetch/methods.rs
@@ -792,7 +792,6 @@ pub async fn main_fetch(
         // upload progress, so I'm keeping it here for now and pretending
         // the body got sent in one chunk
         target.process_request_body(request);
-        target.process_request_eof(request);
     }
 
     // Step 22.

--- a/components/net/image_cache.rs
+++ b/components/net/image_cache.rs
@@ -1098,7 +1098,6 @@ impl ImageCache for ImageCacheImpl {
     fn notify_pending_response(&self, id: PendingImageId, action: FetchResponseMsg) {
         match (action, id) {
             (FetchResponseMsg::ProcessRequestBody(..), _) |
-            (FetchResponseMsg::ProcessRequestEOF(..), _) |
             (FetchResponseMsg::ProcessCspViolations(..), _) => (),
             (FetchResponseMsg::ProcessResponse(_, response), _) => {
                 debug!("Received {:?} for {:?}", response.as_ref().map(|_| ()), id);

--- a/components/net/tests/fetch.rs
+++ b/components/net/tests/fetch.rs
@@ -159,7 +159,6 @@ fn test_fetch_blob() {
 
     impl FetchTaskTarget for FetchResponseCollector {
         fn process_request_body(&mut self, _: &Request) {}
-        fn process_request_eof(&mut self, _: &Request) {}
         fn process_response(&mut self, _: &Request, _: &Response) {}
         fn process_response_chunk(&mut self, _: &Request, chunk: Vec<u8>) {
             self.buffer.extend_from_slice(chunk.as_slice());

--- a/components/net/tests/http_loader.rs
+++ b/components/net/tests/http_loader.rs
@@ -1603,7 +1603,6 @@ fn test_fetch_compressed_response_update_count() {
     }
     impl FetchTaskTarget for FetchResponseCollector {
         fn process_request_body(&mut self, _: &Request) {}
-        fn process_request_eof(&mut self, _: &Request) {}
         fn process_response(&mut self, _: &Request, _: &Response) {}
         fn process_response_chunk(&mut self, _: &Request, _: Vec<u8>) {
             self.update_count += 1;

--- a/components/net/tests/main.rs
+++ b/components/net/tests/main.rs
@@ -152,7 +152,6 @@ fn new_fetch_context(
 }
 impl FetchTaskTarget for FetchResponseCollector {
     fn process_request_body(&mut self, _: &Request) {}
-    fn process_request_eof(&mut self, _: &Request) {}
     fn process_response(&mut self, _: &Request, _: &Response) {}
     fn process_response_chunk(&mut self, _: &Request, _: Vec<u8>) {}
     /// Fired when the response is fully fetched

--- a/components/script/dom/eventsource.rs
+++ b/components/script/dom/eventsource.rs
@@ -366,10 +366,6 @@ impl FetchResponseListener for EventSourceContext {
         // TODO
     }
 
-    fn process_request_eof(&mut self, _: RequestId) {
-        // TODO
-    }
-
     fn process_response(
         &mut self,
         _: &mut js::context::JSContext,

--- a/components/script/dom/html/htmlimageelement.rs
+++ b/components/script/dom/html/htmlimageelement.rs
@@ -250,7 +250,6 @@ impl FetchResponseListener for ImageContext {
     }
 
     fn process_request_body(&mut self, _: RequestId) {}
-    fn process_request_eof(&mut self, _: RequestId) {}
 
     fn process_response(
         &mut self,

--- a/components/script/dom/html/htmllinkelement.rs
+++ b/components/script/dom/html/htmllinkelement.rs
@@ -1270,8 +1270,6 @@ struct FaviconFetchContext {
 impl FetchResponseListener for FaviconFetchContext {
     fn process_request_body(&mut self, _: RequestId) {}
 
-    fn process_request_eof(&mut self, _: RequestId) {}
-
     fn process_response(
         &mut self,
         _: &mut js::context::JSContext,

--- a/components/script/dom/html/htmlmediaelement.rs
+++ b/components/script/dom/html/htmlmediaelement.rs
@@ -3710,8 +3710,6 @@ struct HTMLMediaElementFetchListener {
 impl FetchResponseListener for HTMLMediaElementFetchListener {
     fn process_request_body(&mut self, _: RequestId) {}
 
-    fn process_request_eof(&mut self, _: RequestId) {}
-
     fn process_response(
         &mut self,
         cx: &mut js::context::JSContext,

--- a/components/script/dom/html/htmlscriptelement.rs
+++ b/components/script/dom/html/htmlscriptelement.rs
@@ -338,9 +338,6 @@ impl FetchResponseListener for ClassicContext {
     // TODO(KiChjang): Perhaps add custom steps to perform fetch here?
     fn process_request_body(&mut self, _: RequestId) {}
 
-    // TODO(KiChjang): Perhaps add custom steps to perform fetch here?
-    fn process_request_eof(&mut self, _: RequestId) {}
-
     fn process_response(
         &mut self,
         _: &mut js::context::JSContext,

--- a/components/script/dom/html/htmlvideoelement.rs
+++ b/components/script/dom/html/htmlvideoelement.rs
@@ -411,9 +411,7 @@ struct PosterFrameFetchContext {
 }
 
 impl FetchResponseListener for PosterFrameFetchContext {
-    fn process_request_body(&mut self, _: RequestId) {}
-
-    fn process_request_eof(&mut self, _: RequestId) {
+    fn process_request_body(&mut self, _: RequestId) {
         self.fetch_canceller.ignore()
     }
 

--- a/components/script/dom/navigator.rs
+++ b/components/script/dom/navigator.rs
@@ -614,8 +614,6 @@ struct BeaconFetchListener {
 impl FetchResponseListener for BeaconFetchListener {
     fn process_request_body(&mut self, _: RequestId) {}
 
-    fn process_request_eof(&mut self, _: RequestId) {}
-
     fn process_response(
         &mut self,
         _: &mut js::context::JSContext,

--- a/components/script/dom/notification.rs
+++ b/components/script/dom/notification.rs
@@ -754,7 +754,6 @@ struct ResourceFetchListener {
 
 impl FetchResponseListener for ResourceFetchListener {
     fn process_request_body(&mut self, _: RequestId) {}
-    fn process_request_eof(&mut self, _: RequestId) {}
 
     fn process_response(
         &mut self,

--- a/components/script/dom/processingoptions.rs
+++ b/components/script/dom/processingoptions.rs
@@ -464,8 +464,6 @@ pub(crate) struct LinkFetchContext {
 impl FetchResponseListener for LinkFetchContext {
     fn process_request_body(&mut self, _: RequestId) {}
 
-    fn process_request_eof(&mut self, _: RequestId) {}
-
     fn process_response(
         &mut self,
         _: &mut js::context::JSContext,

--- a/components/script/dom/reporting/reportingendpoint.rs
+++ b/components/script/dom/reporting/reportingendpoint.rs
@@ -314,8 +314,6 @@ struct CSPReportEndpointFetchListener {
 impl FetchResponseListener for CSPReportEndpointFetchListener {
     fn process_request_body(&mut self, _: RequestId) {}
 
-    fn process_request_eof(&mut self, _: RequestId) {}
-
     fn process_response(
         &mut self,
         _: &mut js::context::JSContext,

--- a/components/script/dom/security/cspviolationreporttask.rs
+++ b/components/script/dom/security/cspviolationreporttask.rs
@@ -183,8 +183,6 @@ struct CSPReportUriFetchListener {
 impl FetchResponseListener for CSPReportUriFetchListener {
     fn process_request_body(&mut self, _: RequestId) {}
 
-    fn process_request_eof(&mut self, _: RequestId) {}
-
     fn process_response(
         &mut self,
         _: &mut js::context::JSContext,

--- a/components/script/dom/servoparser/mod.rs
+++ b/components/script/dom/servoparser/mod.rs
@@ -1228,8 +1228,6 @@ impl ParserContext {
 impl FetchResponseListener for ParserContext {
     fn process_request_body(&mut self, _: RequestId) {}
 
-    fn process_request_eof(&mut self, _: RequestId) {}
-
     fn process_response(
         &mut self,
         cx: &mut js::context::JSContext,

--- a/components/script/dom/workers/workerglobalscope.rs
+++ b/components/script/dom/workers/workerglobalscope.rs
@@ -133,8 +133,6 @@ impl ScriptFetchContext {
 impl FetchResponseListener for ScriptFetchContext {
     fn process_request_body(&mut self, _request_id: RequestId) {}
 
-    fn process_request_eof(&mut self, _request_id: RequestId) {}
-
     fn process_response(
         &mut self,
         _: &mut js::context::JSContext,

--- a/components/script/dom/xmlhttprequest.rs
+++ b/components/script/dom/xmlhttprequest.rs
@@ -106,10 +106,6 @@ impl FetchResponseListener for XHRContext {
         // todo
     }
 
-    fn process_request_eof(&mut self, _: RequestId) {
-        // todo
-    }
-
     fn process_response(
         &mut self,
         cx: &mut js::context::JSContext,

--- a/components/script/fetch.rs
+++ b/components/script/fetch.rs
@@ -531,10 +531,6 @@ impl FetchResponseListener for FetchContext {
         // TODO
     }
 
-    fn process_request_eof(&mut self, _: RequestId) {
-        // TODO
-    }
-
     fn process_response(
         &mut self,
         cx: &mut js::context::JSContext,
@@ -675,8 +671,6 @@ struct FetchLaterListener {
 impl FetchResponseListener for FetchLaterListener {
     fn process_request_body(&mut self, _: RequestId) {}
 
-    fn process_request_eof(&mut self, _: RequestId) {}
-
     fn process_response(
         &mut self,
         _: &mut js::context::JSContext,
@@ -750,8 +744,7 @@ pub(crate) fn load_whole_resource(
     let mut muted_errors = false;
     loop {
         match action_receiver.recv().unwrap() {
-            FetchResponseMsg::ProcessRequestBody(..) | FetchResponseMsg::ProcessRequestEOF(..) => {
-            },
+            FetchResponseMsg::ProcessRequestBody(..) => {},
             FetchResponseMsg::ProcessResponse(_, Ok(m)) => {
                 muted_errors = m.is_cors_cross_origin();
                 metadata = Some(match m {

--- a/components/script/layout_image.rs
+++ b/components/script/layout_image.rs
@@ -34,7 +34,6 @@ struct LayoutImageContext {
 
 impl FetchResponseListener for LayoutImageContext {
     fn process_request_body(&mut self, _: RequestId) {}
-    fn process_request_eof(&mut self, _: RequestId) {}
     fn process_response(
         &mut self,
         _: &mut js::context::JSContext,

--- a/components/script/network_listener.rs
+++ b/components/script/network_listener.rs
@@ -101,7 +101,6 @@ pub(crate) trait FetchResponseListener: Send + 'static {
     }
 
     fn process_request_body(&mut self, request_id: RequestId);
-    fn process_request_eof(&mut self, request_id: RequestId);
     fn process_response(
         &mut self,
         cx: &mut js::context::JSContext,
@@ -150,9 +149,6 @@ impl<Listener: FetchResponseListener> NetworkListener<Listener> {
                 match message {
                     FetchResponseMsg::ProcessRequestBody(request_id) => {
                         fetch_listener.process_request_body(request_id)
-                    },
-                    FetchResponseMsg::ProcessRequestEOF(request_id) => {
-                        fetch_listener.process_request_eof(request_id)
                     },
                     FetchResponseMsg::ProcessResponse(request_id, meta) => {
                         fetch_listener.process_response(cx, request_id, meta)

--- a/components/script/script_module.rs
+++ b/components/script/script_module.rs
@@ -700,9 +700,6 @@ impl FetchResponseListener for ModuleContext {
     // TODO(cybai): Perhaps add custom steps to perform fetch here?
     fn process_request_body(&mut self, _: RequestId) {}
 
-    // TODO(cybai): Perhaps add custom steps to perform fetch here?
-    fn process_request_eof(&mut self, _: RequestId) {}
-
     fn process_response(
         &mut self,
         _: &mut js::context::JSContext,

--- a/components/script/script_thread.rs
+++ b/components/script/script_thread.rs
@@ -3875,8 +3875,7 @@ impl ScriptThread {
             FetchResponseMsg::ProcessCspViolations(request_id, violations) => {
                 self.handle_csp_violations(pipeline_id, request_id, violations)
             },
-            FetchResponseMsg::ProcessRequestBody(..) | FetchResponseMsg::ProcessRequestEOF(..) => {
-            },
+            FetchResponseMsg::ProcessRequestBody(..) => {},
         }
     }
 

--- a/components/script/stylesheet_loader.rs
+++ b/components/script/stylesheet_loader.rs
@@ -335,8 +335,6 @@ impl StylesheetContext {
 impl FetchResponseListener for StylesheetContext {
     fn process_request_body(&mut self, _: RequestId) {}
 
-    fn process_request_eof(&mut self, _: RequestId) {}
-
     fn process_response(
         &mut self,
         _: &mut js::context::JSContext,

--- a/components/shared/net/lib.rs
+++ b/components/shared/net/lib.rs
@@ -245,7 +245,6 @@ impl From<ReferrerPolicy> for ReferrerPolicyHeader {
 pub enum FetchResponseMsg {
     // todo: should have fields for transmitted/total bytes
     ProcessRequestBody(RequestId),
-    ProcessRequestEOF(RequestId),
     // todo: send more info about the response (or perhaps the entire Response)
     ProcessResponse(RequestId, Result<FetchMetadata, NetworkError>),
     ProcessResponseChunk(RequestId, DebugVec),
@@ -279,7 +278,6 @@ impl FetchResponseMsg {
     pub fn request_id(&self) -> RequestId {
         match self {
             FetchResponseMsg::ProcessRequestBody(id) |
-            FetchResponseMsg::ProcessRequestEOF(id) |
             FetchResponseMsg::ProcessResponse(id, ..) |
             FetchResponseMsg::ProcessResponseChunk(id, ..) |
             FetchResponseMsg::ProcessResponseEOF(id, ..) |
@@ -293,11 +291,6 @@ pub trait FetchTaskTarget {
     ///
     /// Fired when a chunk of the request body is transmitted
     fn process_request_body(&mut self, request: &Request);
-
-    /// <https://fetch.spec.whatwg.org/#process-request-end-of-file>
-    ///
-    /// Fired when the entire request finishes being transmitted
-    fn process_request_eof(&mut self, request: &Request);
 
     /// <https://fetch.spec.whatwg.org/#process-response>
     ///
@@ -358,10 +351,6 @@ impl FetchMetadata {
 impl FetchTaskTarget for IpcSender<FetchResponseMsg> {
     fn process_request_body(&mut self, request: &Request) {
         let _ = self.send(FetchResponseMsg::ProcessRequestBody(request.id));
-    }
-
-    fn process_request_eof(&mut self, request: &Request) {
-        let _ = self.send(FetchResponseMsg::ProcessRequestEOF(request.id));
     }
 
     fn process_response(&mut self, request: &Request, response: &Response) {
@@ -459,7 +448,6 @@ pub struct TlsSecurityInfo {
 
 impl FetchTaskTarget for IpcSender<WebSocketNetworkEvent> {
     fn process_request_body(&mut self, _: &Request) {}
-    fn process_request_eof(&mut self, _: &Request) {}
     fn process_response(&mut self, _: &Request, response: &Response) {
         if response.is_network_error() {
             let _ = self.send(WebSocketNetworkEvent::Fail);
@@ -479,7 +467,6 @@ pub struct DiscardFetch;
 
 impl FetchTaskTarget for DiscardFetch {
     fn process_request_body(&mut self, _: &Request) {}
-    fn process_request_eof(&mut self, _: &Request) {}
     fn process_response(&mut self, _: &Request, _: &Response) {}
     fn process_response_chunk(&mut self, _: &Request, _: Vec<u8>) {}
     fn process_response_eof(&mut self, _: &Request, _: &Response) {}


### PR DESCRIPTION
This is no longer present in the spec. Instead, the `process_request_body` is the new way. These two
methods were called right after each other and there was only 1 implementation in `htmlvideoelement`. That implementation is now moved to `process_request_body` and hence we can remove the unnecessary method.

Testing: It compiles