### PR TITLE
Gate picker on trusted click

### DIFF
--- a/components/script/dom/html/htmlselectelement.rs
+++ b/components/script/dom/html/htmlselectelement.rs
@@ -20,6 +20,7 @@ use crate::dom::bindings::codegen::GenericBindings::HTMLOptGroupElementBinding::
 use crate::dom::activation::Activatable;
 use crate::dom::attr::Attr;
 use crate::dom::bindings::cell::{DomRefCell, Ref};
+use crate::dom::bindings::codegen::Bindings::EventBinding::EventMethods;
 use crate::dom::bindings::codegen::Bindings::ElementBinding::ElementMethods;
 use crate::dom::bindings::codegen::Bindings::HTMLCollectionBinding::HTMLCollectionMethods;
 use crate::dom::bindings::codegen::Bindings::HTMLOptionElementBinding::HTMLOptionElementMethods;
@@ -894,7 +895,11 @@ impl Activatable for HTMLSelectElement {
         !self.upcast::<Element>().disabled_state()
     }
 
-    fn activation_behavior(&self, _event: &Event, _target: &EventTarget, _can_gc: CanGc) {
+    fn activation_behavior(&self, event: &Event, _target: &EventTarget, _can_gc: CanGc) {
+        if !event.IsTrusted() {
+            return;
+        }
+
         self.show_menu();
     }
 }

--- a/tests/wpt/meta/dom/events/Event-dispatch-on-disabled-elements.html.ini
+++ b/tests/wpt/meta/dom/events/Event-dispatch-on-disabled-elements.html.ini
@@ -1,2 +1,13 @@
 [Event-dispatch-on-disabled-elements.html]
-  expected: ERROR
+  expected: TIMEOUT
+  [CSS Transitions transitioncancel event fires on disabled form elements]
+    expected: TIMEOUT
+
+  [CSS Animation animationstart, animationiteration, animationend fire on disabled form elements]
+    expected: NOTRUN
+
+  [CSS Animation's animationcancel event fires on disabled form elements]
+    expected: NOTRUN
+
+  [Real clicks on disabled elements must not dispatch events.]
+    expected: NOTRUN

--- a/tests/wpt/meta/html/semantics/forms/the-select-element/customizable-select/select-dialog-mode-focus.optional.html.ini
+++ b/tests/wpt/meta/html/semantics/forms/the-select-element/customizable-select/select-dialog-mode-focus.optional.html.ini
@@ -1,5 +1,4 @@
 [select-dialog-mode-focus.optional.html]
-  expected: ERROR
   [In dialog mode the first focusable element should get focus.]
     expected: FAIL
 

--- a/tests/wpt/meta/html/semantics/forms/the-select-element/customizable-select/select-keyboard-behavior.optional.html.ini
+++ b/tests/wpt/meta/html/semantics/forms/the-select-element/customizable-select/select-keyboard-behavior.optional.html.ini
@@ -1,37 +1,36 @@
 [select-keyboard-behavior.optional.html]
-  expected: ERROR
   [defaultbutton: When the listbox is closed, spacebar should open the listbox.]
     expected: FAIL
 
   [defaultbutton: When the listbox is closed, all arrow keys should open the listbox.]
-    expected: NOTRUN
+    expected: FAIL
 
   [defaultbutton: When the listbox is closed, the enter key should submit the form or do nothing.]
     expected: NOTRUN
 
   [defaultbutton: When the listbox is open, the enter key should commit the selected option.]
-    expected: NOTRUN
+    expected: FAIL
 
   [defaultbutton: When the listbox is open, the tab key should close the listbox.]
-    expected: NOTRUN
+    expected: FAIL
 
   [custombutton: When the listbox is closed, spacebar should open the listbox.]
-    expected: NOTRUN
+    expected: FAIL
 
   [custombutton: When the listbox is closed, all arrow keys should open the listbox.]
-    expected: NOTRUN
+    expected: FAIL
 
   [custombutton: When the listbox is closed, the enter key should submit the form or do nothing.]
     expected: NOTRUN
 
   [custombutton: When the listbox is open, the enter key should commit the selected option.]
-    expected: NOTRUN
+    expected: FAIL
 
   [custombutton: When the listbox is open, the tab key should close the listbox.]
-    expected: NOTRUN
+    expected: FAIL
 
   [defaultbutton: When the listbox is closed, the enter key should not trigger form submission.]
-    expected: NOTRUN
+    expected: FAIL
 
   [custombutton: When the listbox is closed, the enter key should not trigger form submission.]
-    expected: NOTRUN
+    expected: FAIL

--- a/tests/wpt/meta/html/semantics/forms/the-select-element/customizable-select/select-keyboard-focus-change-for-hidden-options.optional.html.ini
+++ b/tests/wpt/meta/html/semantics/forms/the-select-element/customizable-select/select-keyboard-focus-change-for-hidden-options.optional.html.ini
@@ -1,4 +1,3 @@
 [select-keyboard-focus-change-for-hidden-options.optional.html]
-  expected: ERROR
   [Hidden options should be skipped when changing focus using the up and down keys.]
     expected: FAIL

--- a/tests/wpt/meta/html/semantics/forms/the-select-element/customizable-select/select-type-to-search.tentative.html.ini
+++ b/tests/wpt/meta/html/semantics/forms/the-select-element/customizable-select/select-type-to-search.tentative.html.ini
@@ -1,4 +1,3 @@
 [select-type-to-search.tentative.html]
-  expected: ERROR
   [Type to search should focus but not select an option until selection is confirmed.]
     expected: FAIL

--- a/tests/wpt/meta/html/semantics/forms/the-select-element/customizable-select/select-vertical-writing-mode-navigation.optional.html.ini
+++ b/tests/wpt/meta/html/semantics/forms/the-select-element/customizable-select/select-vertical-writing-mode-navigation.optional.html.ini
@@ -1,2 +1,24 @@
 [select-vertical-writing-mode-navigation.optional.html]
-  expected: ERROR
+  [vertical-lr: Right/Left keys navigate as primary axis]
+    expected: FAIL
+
+  [vertical-lr: Down/Up keys navigate as secondary axis]
+    expected: FAIL
+
+  [vertical-rl: Left/Right keys navigate as primary axis (block-flipped)]
+    expected: FAIL
+
+  [vertical-rl: Down/Up keys navigate as secondary axis]
+    expected: FAIL
+
+  [sideways-lr: Right/Left keys navigate as primary axis]
+    expected: FAIL
+
+  [sideways-lr: Down/Up keys navigate as secondary axis]
+    expected: FAIL
+
+  [sideways-rl: Left/Right keys navigate as primary axis (block-flipped)]
+    expected: FAIL
+
+  [sideways-rl: Down/Up keys navigate as secondary axis]
+    expected: FAIL

--- a/tests/wpt/tests/html/semantics/forms/the-select-element/select-click-does-not-open-picker.html
+++ b/tests/wpt/tests/html/semantics/forms/the-select-element/select-click-does-not-open-picker.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<title>select.click() should not open select picker</title>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+
+<select id="select">
+  <option>one</option>
+  <option>two</option>
+</select>
+
+<script>
+test(() => {
+  assert_false(select.matches(':open'), 'select should start closed');
+
+  select.click();
+  assert_false(select.matches(':open'), 'select.click() should not open the picker');
+
+  select.dispatchEvent(new MouseEvent('click'));
+  assert_false(select.matches(':open'), 'dispatchEvent(click) should not open the picker');
+}, 'Synthetic click events do not open select picker');
+</script>


### PR DESCRIPTION
Fixes: #43360 
This PR makes `<select>` behave like other browsers by only opening the picker for trusted user clicks, and adds a regression test to ensure synthetic `.click()/dispatchEvent('click')` won’t open it.
