### PR TITLE
script: Do not record associated memory for Promises, and release associated memory for WindowProxy.

### DIFF
--- a/components/dom_struct/domobject.rs
+++ b/components/dom_struct/domobject.rs
@@ -60,6 +60,9 @@ pub(crate) fn expand_dom_object(
             unsafe fn init_reflector<Actual>(&self, obj: *mut js::jsapi::JSObject) {
                 self.#first_field_name.init_reflector::<Actual>(obj);
             }
+            unsafe fn init_reflector_without_associated_memory(&self, obj: *mut js::jsapi::JSObject) {
+                self.#first_field_name.init_reflector_without_associated_memory(obj);
+            }
         }
 
         impl #impl_generics Eq for #name #ty_generics #where_clause {}

--- a/components/script/dom/promise.rs
+++ b/components/script/dom/promise.rs
@@ -86,7 +86,6 @@ impl PromiseHelper for Rc<Promise> {
 impl Drop for Promise {
     #[expect(unsafe_code)]
     fn drop(&mut self) {
-        self.reflector.drop_memory(self);
         unsafe {
             let object = self.permanent_js_root.get().to_object();
             assert!(!object.is_null());
@@ -142,7 +141,7 @@ impl Promise {
                 permanent_js_root: Heap::default(),
             };
             let promise = Rc::new(promise);
-            promise.init_reflector::<Promise>(obj.get());
+            promise.init_reflector_without_associated_memory(obj.get());
             promise.initialize(cx);
             promise
         }

--- a/components/script/dom/windowproxy.rs
+++ b/components/script/dom/windowproxy.rs
@@ -1391,12 +1391,15 @@ unsafe extern "C" fn finalize(_fop: *mut GCContext, obj: *mut JSObject) {
         // GC during obj creation or after transplanting.
         return;
     }
-    let jsobject = unsafe { (*this).reflector.get_jsobject().get() };
-    debug!(
-        "WindowProxy finalize: {:p}, with reflector {:p} from {:p}.",
-        this, jsobject, obj
-    );
-    let _ = unsafe { Box::from_raw(this) };
+    unsafe {
+        (*this).reflector.drop_memory(&*this);
+        let jsobject = (*this).reflector.get_jsobject().get();
+        debug!(
+            "WindowProxy finalize: {:p}, with reflector {:p} from {:p}.",
+            this, jsobject, obj
+        );
+        let _ = Box::from_raw(this);
+    }
 }
 
 #[expect(unsafe_code)]

--- a/components/script_bindings/reflector.rs
+++ b/components/script_bindings/reflector.rs
@@ -148,7 +148,15 @@ pub trait MutDomObject: DomObject {
     /// # Safety
     ///
     /// The provided [`JSObject`] pointer must point to a valid [`JSObject`].
+    /// The provided [`JSObject`] pointer must not be allocated in the nursery.
     unsafe fn init_reflector<D>(&self, obj: *mut JSObject);
+
+    /// Initializes the Reflector without recording any associated memory usage.
+    ///
+    /// # Safety
+    ///
+    /// The provided [`JSObject`] pointer must point to a valid [`JSObject`].
+    unsafe fn init_reflector_without_associated_memory(&self, obj: *mut JSObject);
 }
 
 impl MutDomObject for Reflector<()> {
@@ -159,6 +167,12 @@ impl MutDomObject for Reflector<()> {
                 size_of::<D>() + size_of::<Box<D>>(),
                 MemoryUse::DOMBinding,
             );
+            self.init_reflector_without_associated_memory(obj);
+        }
+    }
+
+    unsafe fn init_reflector_without_associated_memory(&self, obj: *mut JSObject) {
+        unsafe {
             self.set_jsobject(obj);
         }
     }
@@ -172,6 +186,12 @@ impl MutDomObject for Reflector<AssociatedMemory> {
                 size_of::<D>() + size_of::<Box<D>>(),
                 MemoryUse::DOMBinding,
             );
+            self.init_reflector_without_associated_memory(obj);
+        }
+    }
+
+    unsafe fn init_reflector_without_associated_memory(&self, obj: *mut JSObject) {
+        unsafe {
             self.set_jsobject(obj);
         }
     }


### PR DESCRIPTION
This fixes two assertions observed in Servo using debug mozjs builds:
* `Assertion failure: !IsInsideNursery(obj)` for every promise object reflected into Rust code
* `Missing calls to JS::RemoveAssociatedMemory` when shutting down the browser

Testing: Verified locally that WPT tests can run to completion in debug mozjs builds, but we don't run those on CI.
Fixes: #43486
