### PR TITLE
script: Remove extra task when following hyperlinks.

### DIFF
--- a/components/script/dom/html/htmlanchorelement.rs
+++ b/components/script/dom/html/htmlanchorelement.rs
@@ -332,7 +332,7 @@ impl Activatable for HTMLAnchorElement {
     }
 
     /// <https://html.spec.whatwg.org/multipage/#the-a-element:activation-behaviour>
-    fn activation_behavior(&self, event: &Event, target: &EventTarget, _: CanGc) {
+    fn activation_behavior(&self, event: &Event, target: &EventTarget, can_gc: CanGc) {
         let element = self.as_element();
         let mouse_event = event.downcast::<MouseEvent>().unwrap();
         let mut ismap_suffix = None;
@@ -353,6 +353,6 @@ impl Activatable for HTMLAnchorElement {
 
         // Step 2.
         // TODO: Download the link is `download` attribute is set.
-        follow_hyperlink(element, self.relations.get(), ismap_suffix);
+        follow_hyperlink(element, self.relations.get(), ismap_suffix, can_gc);
     }
 }

--- a/components/script/dom/html/htmlareaelement.rs
+++ b/components/script/dom/html/htmlareaelement.rs
@@ -527,7 +527,7 @@ impl Activatable for HTMLAreaElement {
         self.as_element().has_attribute(&local_name!("href"))
     }
 
-    fn activation_behavior(&self, _event: &Event, _target: &EventTarget, _can_gc: CanGc) {
-        follow_hyperlink(self.as_element(), self.relations.get(), None);
+    fn activation_behavior(&self, _event: &Event, _target: &EventTarget, can_gc: CanGc) {
+        follow_hyperlink(self.as_element(), self.relations.get(), None, can_gc);
     }
 }

--- a/components/script/links.rs
+++ b/components/script/links.rs
@@ -12,7 +12,6 @@ use style::str::HTML_SPACE_CHARACTERS;
 
 use crate::dom::bindings::codegen::Bindings::AttrBinding::Attr_Binding::AttrMethods;
 use crate::dom::bindings::inheritance::Castable;
-use crate::dom::bindings::refcounted::Trusted;
 use crate::dom::bindings::str::DOMString;
 use crate::dom::element::referrer_policy_for_element;
 use crate::dom::html::htmlanchorelement::HTMLAnchorElement;
@@ -389,6 +388,7 @@ pub(crate) fn follow_hyperlink(
     subject: &Element,
     relations: LinkRelations,
     hyperlink_suffix: Option<String>,
+    can_gc: CanGc,
 ) {
     // Step 1: If subject cannot navigate, then return.
     if subject.cannot_navigate() {
@@ -495,15 +495,7 @@ pub(crate) fn follow_hyperlink(
             document.has_trustworthy_ancestor_origin(),
             document.creation_sandboxing_flag_set_considering_parent_iframe(),
         );
-        let target = Trusted::new(target_window);
-        let task = task!(navigate_follow_hyperlink: move |cx| {
-            debug!("following hyperlink to {}", load_data.url);
-            target.root().load_url(history_handling, false, load_data, CanGc::from_cx(cx));
-        });
-        target_document
-            .owner_global()
-            .task_manager()
-            .dom_manipulation_task_source()
-            .queue(task);
+        debug!("following hyperlink to {}", load_data.url);
+        target_window.load_url(history_handling, false, load_data, can_gc);
     };
 }

--- a/tests/wpt/meta/html/browsers/browsing-the-web/navigating-across-documents/006.html.ini
+++ b/tests/wpt/meta/html/browsers/browsing-the-web/navigating-across-documents/006.html.ini
@@ -1,3 +1,0 @@
-[006.html]
-  [Link with onclick form submit and href navigation ]
-    expected: FAIL


### PR DESCRIPTION
The specification does not use a task here, and it throws off the timing expectations of tests that perform hyperlink navigations.

Testing: New passing WPT tests.