### PR TITLE
script: Move navigation origin logic into a method with spec steps.

### DIFF
--- a/components/script/navigation.rs
+++ b/components/script/navigation.rs
@@ -11,6 +11,7 @@ use std::cell::Cell;
 use base::cross_process_instant::CrossProcessInstant;
 use base::id::{BrowsingContextId, PipelineId, WebViewId};
 use constellation_traits::LoadData;
+use content_security_policy::sandboxing_directive::SandboxingFlagSet;
 use crossbeam_channel::Sender;
 use embedder_traits::user_contents::UserContentManagerId;
 use embedder_traits::{Theme, ViewportDetails};
@@ -26,7 +27,7 @@ use net_traits::{
     Metadata, fetch_async, set_default_accept_language,
 };
 use script_traits::{DocumentActivity, NewPipelineInfo};
-use servo_url::{MutableOrigin, ServoUrl};
+use servo_url::{ImmutableOrigin, MutableOrigin, ServoUrl};
 
 use crate::fetch::FetchCanceller;
 use crate::messaging::MainThreadScriptMsg;
@@ -244,4 +245,42 @@ impl InProgressLoad {
 
         request_builder
     }
+}
+
+/// <https://html.spec.whatwg.org/multipage/#determining-the-origin>
+pub(crate) fn determine_the_origin(
+    url: Option<&ServoUrl>,
+    sandbox_flags: SandboxingFlagSet,
+    source_origin: Option<MutableOrigin>,
+) -> MutableOrigin {
+    // Step 1. If sandboxFlags has its sandboxed origin browsing context flag set, then return a new opaque origin.
+    let is_sandboxed =
+        sandbox_flags.contains(SandboxingFlagSet::SANDBOXED_ORIGIN_BROWSING_CONTEXT_FLAG);
+    if is_sandboxed {
+        return MutableOrigin::new(ImmutableOrigin::new_opaque());
+    }
+
+    // Step 2. If url is null, then return a new opaque origin.
+    let Some(url) = url else {
+        return MutableOrigin::new(ImmutableOrigin::new_opaque());
+    };
+
+    // Step 3. If url is about:srcdoc, then:
+    if url.as_str() == "about:srcdoc" {
+        // Step 3.1 Assert: sourceOrigin is non-null.
+        let source_origin =
+            source_origin.expect("Can't have a null source origin for about:srcdoc");
+        // Step 3.2 Return sourceOrigin
+        return source_origin;
+    }
+
+    // Step 4. If url matches about:blank and sourceOrigin is non-null, then return sourceOrigin.
+    if url.as_str() == "about:blank" {
+        if let Some(source_origin) = source_origin {
+            return source_origin;
+        }
+    }
+
+    // Step 5. Return url's origin.
+    MutableOrigin::new(url.origin())
 }

--- a/components/script/script_thread.rs
+++ b/components/script/script_thread.rs
@@ -152,7 +152,7 @@ use crate::messaging::{
 };
 use crate::microtask::{Microtask, MicrotaskQueue};
 use crate::mime::{APPLICATION, CHARSET, MimeExt, TEXT, XML};
-use crate::navigation::{InProgressLoad, NavigationListener};
+use crate::navigation::{InProgressLoad, NavigationListener, determine_the_origin};
 use crate::network_listener::{FetchResponseListener, submit_timing};
 use crate::realms::{enter_auto_realm, enter_realm};
 use crate::script_mutation_observers::ScriptMutationObservers;
@@ -2761,28 +2761,17 @@ impl ScriptThread {
             ScriptThreadEventCategory::SpawnPipeline,
             Some(new_pipeline_info.new_pipeline_id),
             || {
-                // If this is an about:blank or about:srcdoc load, it must share the
-                // creator's origin. This must match the logic in the constellation
-                // when creating a new pipeline
-                let not_an_about_blank_and_about_srcdoc_load =
-                    new_pipeline_info.load_data.url.as_str() != "about:blank" &&
-                        new_pipeline_info.load_data.url.as_str() != "about:srcdoc";
-                let origin = if not_an_about_blank_and_about_srcdoc_load {
-                    MutableOrigin::new(new_pipeline_info.load_data.url.origin())
-                } else if let Some(parent) = new_pipeline_info
-                    .parent_info
-                    .and_then(|pipeline_id| self.documents.borrow().find_document(pipeline_id))
-                {
-                    parent.origin().clone()
-                } else if let Some(creator) = new_pipeline_info
-                    .load_data
-                    .creator_pipeline_id
-                    .and_then(|pipeline_id| self.documents.borrow().find_document(pipeline_id))
-                {
-                    creator.origin().clone()
-                } else {
-                    MutableOrigin::new(ImmutableOrigin::new_opaque())
+                let source_origin = match new_pipeline_info.load_data.load_origin {
+                    LoadOrigin::Script(ref snapshot) => {
+                        Some(MutableOrigin::from_snapshot(snapshot.clone()))
+                    },
+                    _ => None,
                 };
+                let origin = determine_the_origin(
+                    Some(&new_pipeline_info.load_data.url),
+                    new_pipeline_info.load_data.creation_sandboxing_flag_set,
+                    source_origin,
+                );
 
                 self.devtools_state
                     .notify_pipeline_created(new_pipeline_info.new_pipeline_id);

--- a/components/url/origin.rs
+++ b/components/url/origin.rs
@@ -199,6 +199,10 @@ pub struct MutableOrigin(Rc<(ImmutableOrigin, RefCell<Option<Host>>)>);
 malloc_size_of_is_0!(MutableOrigin);
 
 impl MutableOrigin {
+    pub fn from_snapshot(snapshot: OriginSnapshot) -> MutableOrigin {
+        MutableOrigin(Rc::new((snapshot.0, RefCell::new(snapshot.1))))
+    }
+
     pub fn snapshot(&self) -> OriginSnapshot {
         OriginSnapshot(self.0.0.clone(), self.0.1.borrow().clone())
     }


### PR DESCRIPTION
This pulls one bit of navigation logic out into a method that is easier to cross-reference against the spec, and drops a bunch of custom logic that is better served by the existing LoadOrigin infrastructure.

Testing: Existing WPT coverage is sufficient.
