### PR TITLE
servo: No longer call `show_webview_and_wait_for_rendering_to_be_ready` in PerformancePaintTiming unit tests

### DIFF
--- a/components/servo/tests/performance_paint_timing.rs
+++ b/components/servo/tests/performance_paint_timing.rs
@@ -94,7 +94,11 @@ fn verify_first_paint(servo_test: &ServoTest, data_url: &str, expected_fp: i32) 
         .url(Url::parse(data_url).unwrap())
         .build();
 
-    show_webview_and_wait_for_rendering_to_be_ready(&servo_test, &webview, &delegate);
+    let _ = evaluate_javascript(
+        &servo_test,
+        webview.clone(),
+        "await new Promise(requestAnimationFrame);",
+    );
 
     let paint_entries = evaluate_javascript(
         &servo_test,


### PR DESCRIPTION
Instead of calling `show_webview_and_wait_for_rendering_to_be_ready`, run `requestAnimationFrame` on JavaScript.

1. Because `show_webview_and_wait_for_rendering_to_be_ready` changes the `backgroundColor` which deceives the whole purpose of verifying the `first-paint`.
2. Running `requestAnimationFrame` requests browser to update an animation before the next repaint.


Testing: `servo/tests/performance_paint_timing.rs`
Fixes: #43484

Test | Run Summary
-|-
test_default_pref_with_unset_background |<img width="1280" height="141" alt="Screenshot 2026-03-21 at 5 33 13 PM" src="https://github.com/user-attachments/assets/481b635d-aa4b-4f62-beb7-02f77a256a50" />
test_non_default_pref_with_unset_background | <img width="1280" height="163" alt="Screenshot 2026-03-21 at 5 34 43 PM" src="https://github.com/user-attachments/assets/2db5cd43-af54-4241-8fd5-ba781c73469c" />
test_default_pref_with_transparent_background | <img width="1280" height="163" alt="Screenshot 2026-03-21 at 5 35 23 PM" src="https://github.com/user-attachments/assets/6e7d9efb-352a-4d39-894d-37681b14eb11" />
test_non_default_pref_with_transparent_background | <img width="1280" height="163" alt="Screenshot 2026-03-21 at 5 37 13 PM" src="https://github.com/user-attachments/assets/64975e7b-8e67-4ce7-af3e-6977f4c123ac" />
test_default_pref_with_background | <img width="1280" height="137" alt="Screenshot 2026-03-21 at 5 37 54 PM" src="https://github.com/user-attachments/assets/8684a20d-6695-4977-adee-7f0c436dee2c" />
test_non_default_pref_with_background | <img width="1280" height="137" alt="Screenshot 2026-03-21 at 5 38 30 PM" src="https://github.com/user-attachments/assets/781f5f70-72a7-40a2-8ae6-11acf5eb8abf" />
test_non_default_pref_with_same_background | <img width="1280" height="164" alt="Screenshot 2026-03-21 at 5 39 05 PM" src="https://github.com/user-attachments/assets/07012ba4-c2a2-41fe-be04-1b625abbfb1e" />


