### PR TITLE
script: Fix panic in crypto.getRandomValues when random generation fails

### DIFF
--- a/components/script/dom/crypto.rs
+++ b/components/script/dom/crypto.rs
@@ -68,7 +68,9 @@ impl CryptoMethods<crate::DomTypeHolder> for Crypto {
             }
 
             if OsRng.try_fill_bytes(data).is_err() {
-                return Err(Error::JSFailed);
+                return Err(Error::Operation(Some(
+                    "Failed to generate random values".into(),
+                )));
             }
 
             let underlying_object = unsafe { input.underlying_object() };


### PR DESCRIPTION
## Summary

Fixes #43328

When `OsRng.try_fill_bytes` fails in `crypto.getRandomValues`, the code previously returned `Error::JSFailed`. This error type asserts that a JavaScript exception is already pending on the context — but `OsRng` is a Rust library that never sets a JS exception, causing Servo to panic with `assertion failed: JS_IsExceptionPending(*cx)`.

This PR replaces `Error::JSFailed` with `Error::Operation`, which throws a proper `OperationError` DOMException instead of crashing. This is consistent with how Servo's SubtleCrypto handles the same scenario (e.g., `ed25519_operation.rs`).

## Testing

Tested by unconditionally taking the error branch (`if true`):

**Before (panic):**

<img width="960" alt="Screenshot From 2026-03-20 23-42-35" src="https://github.com/user-attachments/assets/f15150ce-aa26-46c9-a381-985e6d850904" />

---


**After (fix):**

<img width="960" alt="Screenshot From 2026-03-20 23-43-05" src="https://github.com/user-attachments/assets/99490b06-aeaa-4dcc-b10a-56336efad87d" />