### PR TITLE
layout: Display generated content for ::marker

### DIFF
--- a/components/layout/dom_traversal.rs
+++ b/components/layout/dom_traversal.rs
@@ -317,7 +317,13 @@ where
 }
 
 /// <https://www.w3.org/TR/CSS2/generate.html#propdef-content>
+<<<<<<< HEAD
 pub(crate) fn generate_pseudo_element_content(
+||||||| parent of b85c0364267 (feat: use generate_pseudo_element_content to get the content)
+fn generate_pseudo_element_content(
+=======
+pub fn generate_pseudo_element_content(
+>>>>>>> b85c0364267 (feat: use generate_pseudo_element_content to get the content)
     pseudo_element_info: &NodeAndStyleInfo,
     context: &LayoutContext,
 ) -> Vec<PseudoElementContentItem> {

--- a/components/layout/dom_traversal.rs
+++ b/components/layout/dom_traversal.rs
@@ -317,13 +317,7 @@ where
 }
 
 /// <https://www.w3.org/TR/CSS2/generate.html#propdef-content>
-<<<<<<< HEAD
 pub(crate) fn generate_pseudo_element_content(
-||||||| parent of b85c0364267 (feat: use generate_pseudo_element_content to get the content)
-fn generate_pseudo_element_content(
-=======
-pub fn generate_pseudo_element_content(
->>>>>>> b85c0364267 (feat: use generate_pseudo_element_content to get the content)
     pseudo_element_info: &NodeAndStyleInfo,
     context: &LayoutContext,
 ) -> Vec<PseudoElementContentItem> {

--- a/components/layout/dom_traversal.rs
+++ b/components/layout/dom_traversal.rs
@@ -317,7 +317,7 @@ where
 }
 
 /// <https://www.w3.org/TR/CSS2/generate.html#propdef-content>
-fn generate_pseudo_element_content(
+pub(crate) fn generate_pseudo_element_content(
     pseudo_element_info: &NodeAndStyleInfo,
     context: &LayoutContext,
 ) -> Vec<PseudoElementContentItem> {

--- a/components/layout/lists.rs
+++ b/components/layout/lists.rs
@@ -44,15 +44,19 @@ pub(crate) fn make_marker<'dom>(
     };
 
     let content = match &marker_info.style.get_counters().content {
-        Content::Items(_) => generate_pseudo_element_content(&marker_info, context),
-        _ => marker_image().or_else(|| {
+        Content::Items(_) => Some(generate_pseudo_element_content(&marker_info, context)),
+        Content::None => None,
+        Content::Normal => Some(marker_image().or_else(|| {
             Some(vec![PseudoElementContentItem::Text(marker_string(
                 &list_style.list_style_type,
             )?)])
-        })?,
+        })?),
     };
 
-    Some((marker_info, content))
+    match content {
+        Some(items) => Some((marker_info, items)),
+        None => None,
+    }
 }
 
 fn symbol_to_string(symbol: &Symbol) -> &str {

--- a/components/layout/lists.rs
+++ b/components/layout/lists.rs
@@ -53,10 +53,7 @@ pub(crate) fn make_marker<'dom>(
         })?),
     };
 
-    match content {
-        Some(items) => Some((marker_info, items)),
-        None => None,
-    }
+    content.map(|items| (marker_info, items))
 }
 
 fn symbol_to_string(symbol: &Symbol) -> &str {

--- a/components/layout/lists.rs
+++ b/components/layout/lists.rs
@@ -25,12 +25,19 @@ pub(crate) fn make_marker<'dom>(
     let list_style = style.get_list();
 
     // https://drafts.csswg.org/css-lists/#content-property
+<<<<<<< HEAD
     let marker_content = || match &marker_info.style.get_counters().content {
         Content::Items(_item) => {
             return Some(generate_pseudo_element_content(&marker_info, context));
         },
         Content::Normal | Content::None => None,
     };
+||||||| parent of b85c0364267 (feat: use generate_pseudo_element_content to get the content)
+=======
+    let _marker_content = generate_pseudo_element_content(&marker_info, context);
+    // TODO: Remove, comment is for debugging
+    // println!("{:?}", marker_content);
+>>>>>>> b85c0364267 (feat: use generate_pseudo_element_content to get the content)
 
     // https://drafts.csswg.org/css-lists/#marker-image
     let marker_image = || match &list_style.list_style_image {

--- a/components/layout/lists.rs
+++ b/components/layout/lists.rs
@@ -25,19 +25,12 @@ pub(crate) fn make_marker<'dom>(
     let list_style = style.get_list();
 
     // https://drafts.csswg.org/css-lists/#content-property
-<<<<<<< HEAD
     let marker_content = || match &marker_info.style.get_counters().content {
         Content::Items(_item) => {
             return Some(generate_pseudo_element_content(&marker_info, context));
         },
         Content::Normal | Content::None => None,
     };
-||||||| parent of b85c0364267 (feat: use generate_pseudo_element_content to get the content)
-=======
-    let _marker_content = generate_pseudo_element_content(&marker_info, context);
-    // TODO: Remove, comment is for debugging
-    // println!("{:?}", marker_content);
->>>>>>> b85c0364267 (feat: use generate_pseudo_element_content to get the content)
 
     // https://drafts.csswg.org/css-lists/#marker-image
     let marker_image = || match &list_style.list_style_image {

--- a/components/layout/lists.rs
+++ b/components/layout/lists.rs
@@ -5,10 +5,13 @@
 use style::counter_style::{CounterStyle, Symbol, SymbolsType};
 use style::properties::longhands::list_style_type::computed_value::T as ListStyleType;
 use style::values::computed::Image;
+use style::values::generics::counters::Content;
 use stylo_atoms::atom;
 
 use crate::context::LayoutContext;
-use crate::dom_traversal::{NodeAndStyleInfo, PseudoElementContentItem};
+use crate::dom_traversal::{
+    NodeAndStyleInfo, PseudoElementContentItem, generate_pseudo_element_content,
+};
 use crate::replaced::ReplacedContents;
 
 /// <https://drafts.csswg.org/css-lists/#content-property>
@@ -20,6 +23,14 @@ pub(crate) fn make_marker<'dom>(
         info.with_pseudo_element(context, style::selector_parser::PseudoElement::Marker)?;
     let style = &marker_info.style;
     let list_style = style.get_list();
+
+    // https://drafts.csswg.org/css-lists/#content-property
+    let marker_content = || match &marker_info.style.get_counters().content {
+        Content::Items(_item) => {
+            return Some(generate_pseudo_element_content(&marker_info, context));
+        },
+        Content::Normal | Content::None => None,
+    };
 
     // https://drafts.csswg.org/css-lists/#marker-image
     let marker_image = || match &list_style.list_style_image {
@@ -39,10 +50,13 @@ pub(crate) fn make_marker<'dom>(
         Image::None => None,
         Image::LightDark(..) => unreachable!("light-dark() should be disabled"),
     };
-    let content = marker_image().or_else(|| {
-        Some(vec![PseudoElementContentItem::Text(marker_string(
-            &list_style.list_style_type,
-        )?)])
+
+    let content = marker_content().or_else(|| {
+        marker_image().or_else(|| {
+            Some(vec![PseudoElementContentItem::Text(marker_string(
+                &list_style.list_style_type,
+            )?)])
+        })
     })?;
 
     Some((marker_info, content))

--- a/components/layout/lists.rs
+++ b/components/layout/lists.rs
@@ -44,7 +44,7 @@ pub(crate) fn make_marker<'dom>(
     };
 
     let content = match &marker_info.style.get_counters().content {
-        Content::Items(_) => generate_pseudo_element_content(&marker_info, context)),
+        Content::Items(_) => generate_pseudo_element_content(&marker_info, context),
         Content::None => return None,
         Content::Normal => marker_image().or_else(|| {
             Some(vec![PseudoElementContentItem::Text(marker_string(
@@ -53,7 +53,7 @@ pub(crate) fn make_marker<'dom>(
         })?,
     };
 
-    Some((marker_info, items))
+    Some((marker_info, content))
 }
 
 fn symbol_to_string(symbol: &Symbol) -> &str {

--- a/components/layout/lists.rs
+++ b/components/layout/lists.rs
@@ -44,16 +44,16 @@ pub(crate) fn make_marker<'dom>(
     };
 
     let content = match &marker_info.style.get_counters().content {
-        Content::Items(_) => Some(generate_pseudo_element_content(&marker_info, context)),
-        Content::None => None,
-        Content::Normal => Some(marker_image().or_else(|| {
+        Content::Items(_) => generate_pseudo_element_content(&marker_info, context)),
+        Content::None => return None,
+        Content::Normal => marker_image().or_else(|| {
             Some(vec![PseudoElementContentItem::Text(marker_string(
                 &list_style.list_style_type,
             )?)])
-        })?),
+        })?,
     };
 
-    content.map(|items| (marker_info, items))
+    Some((marker_info, items))
 }
 
 fn symbol_to_string(symbol: &Symbol) -> &str {

--- a/components/layout/lists.rs
+++ b/components/layout/lists.rs
@@ -24,14 +24,6 @@ pub(crate) fn make_marker<'dom>(
     let style = &marker_info.style;
     let list_style = style.get_list();
 
-    // https://drafts.csswg.org/css-lists/#content-property
-    let marker_content = || match &marker_info.style.get_counters().content {
-        Content::Items(_item) => {
-            return Some(generate_pseudo_element_content(&marker_info, context));
-        },
-        Content::Normal | Content::None => None,
-    };
-
     // https://drafts.csswg.org/css-lists/#marker-image
     let marker_image = || match &list_style.list_style_image {
         Image::Url(url) => Some(vec![
@@ -51,13 +43,14 @@ pub(crate) fn make_marker<'dom>(
         Image::LightDark(..) => unreachable!("light-dark() should be disabled"),
     };
 
-    let content = marker_content().or_else(|| {
-        marker_image().or_else(|| {
+    let content = match &marker_info.style.get_counters().content {
+        Content::Items(_) => generate_pseudo_element_content(&marker_info, context),
+        _ => marker_image().or_else(|| {
             Some(vec![PseudoElementContentItem::Text(marker_string(
                 &list_style.list_style_type,
             )?)])
-        })
-    })?;
+        })?,
+    };
 
     Some((marker_info, content))
 }

--- a/tests/wpt/meta/css/css-lists/marker-dynamic-content-change.html.ini
+++ b/tests/wpt/meta/css/css-lists/marker-dynamic-content-change.html.ini
@@ -1,0 +1,2 @@
+[marker-dynamic-content-change.html]
+  expected: FAIL

--- a/tests/wpt/meta/css/css-lists/marker-quotes.html.ini
+++ b/tests/wpt/meta/css/css-lists/marker-quotes.html.ini
@@ -1,0 +1,2 @@
+[marker-quotes.html]
+  expected: FAIL

--- a/tests/wpt/meta/css/css-pseudo/marker-content-001.html.ini
+++ b/tests/wpt/meta/css/css-pseudo/marker-content-001.html.ini
@@ -1,0 +1,2 @@
+[marker-content-001.html]
+  expected: FAIL

--- a/tests/wpt/meta/css/css-pseudo/marker-content-001b.html.ini
+++ b/tests/wpt/meta/css/css-pseudo/marker-content-001b.html.ini
@@ -1,0 +1,2 @@
+[marker-content-001b.html]
+  expected: FAIL

--- a/tests/wpt/meta/css/css-pseudo/marker-content-001c.html.ini
+++ b/tests/wpt/meta/css/css-pseudo/marker-content-001c.html.ini
@@ -1,0 +1,2 @@
+[marker-content-001c.html]
+  expected: FAIL

--- a/tests/wpt/meta/css/css-pseudo/marker-content-003.html.ini
+++ b/tests/wpt/meta/css/css-pseudo/marker-content-003.html.ini
@@ -1,2 +1,0 @@
-[marker-content-003.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-pseudo/marker-content-003b.html.ini
+++ b/tests/wpt/meta/css/css-pseudo/marker-content-003b.html.ini
@@ -1,2 +1,0 @@
-[marker-content-003b.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-pseudo/marker-content-004.html.ini
+++ b/tests/wpt/meta/css/css-pseudo/marker-content-004.html.ini
@@ -1,2 +1,0 @@
-[marker-content-004.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-pseudo/marker-content-006.html.ini
+++ b/tests/wpt/meta/css/css-pseudo/marker-content-006.html.ini
@@ -1,2 +1,0 @@
-[marker-content-006.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-pseudo/marker-content-015.html.ini
+++ b/tests/wpt/meta/css/css-pseudo/marker-content-015.html.ini
@@ -1,2 +1,0 @@
-[marker-content-015.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-pseudo/marker-content-016.html.ini
+++ b/tests/wpt/meta/css/css-pseudo/marker-content-016.html.ini
@@ -1,2 +1,0 @@
-[marker-content-016.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-pseudo/marker-content-018.html.ini
+++ b/tests/wpt/meta/css/css-pseudo/marker-content-018.html.ini
@@ -1,2 +1,0 @@
-[marker-content-018.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-pseudo/marker-content-019.html.ini
+++ b/tests/wpt/meta/css/css-pseudo/marker-content-019.html.ini
@@ -1,2 +1,0 @@
-[marker-content-019.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-pseudo/marker-content-020.html.ini
+++ b/tests/wpt/meta/css/css-pseudo/marker-content-020.html.ini
@@ -1,0 +1,2 @@
+[marker-content-020.html]
+  expected: FAIL

--- a/tests/wpt/meta/css/css-pseudo/marker-content-021.html.ini
+++ b/tests/wpt/meta/css/css-pseudo/marker-content-021.html.ini
@@ -1,2 +1,0 @@
-[marker-content-021.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-pseudo/marker-intrinsic-contribution-001.html.ini
+++ b/tests/wpt/meta/css/css-pseudo/marker-intrinsic-contribution-001.html.ini
@@ -1,3 +1,0 @@
-[marker-intrinsic-contribution-001.html]
-  [Intrinsic contribution of inside content marker]
-    expected: FAIL

--- a/tests/wpt/meta/css/css-pseudo/marker-unicode-bidi-default.html.ini
+++ b/tests/wpt/meta/css/css-pseudo/marker-unicode-bidi-default.html.ini
@@ -1,2 +1,0 @@
-[marker-unicode-bidi-default.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-pseudo/marker-unicode-bidi-normal.html.ini
+++ b/tests/wpt/meta/css/css-pseudo/marker-unicode-bidi-normal.html.ini
@@ -1,2 +1,0 @@
-[marker-unicode-bidi-normal.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/selectors/has-style-sharing-pseudo-007.html.ini
+++ b/tests/wpt/meta/css/selectors/has-style-sharing-pseudo-007.html.ini
@@ -1,0 +1,2 @@
+[has-style-sharing-pseudo-007.html]
+  expected: FAIL

--- a/tests/wpt/meta/css/selectors/has-style-sharing-pseudo-008.html.ini
+++ b/tests/wpt/meta/css/selectors/has-style-sharing-pseudo-008.html.ini
@@ -1,0 +1,2 @@
+[has-style-sharing-pseudo-008.html]
+  expected: FAIL


### PR DESCRIPTION
Implements a fix for #43036

- Renders content for `::marker`
- If content is not present render marker_image/marker_string

Here's a small webpage I wrote to test if my implementation works :) 

<img width="1136" height="880" alt="Screenshot 2026-03-21 at 4 50 43 PM" src="https://github.com/user-attachments/assets/91ccbfd9-2c18-446d-bac5-d559f483b08c" />

# Testing
The existing WPT ones should be sufficient, the tests need to be updated.


## (WPT) Stable Unexpected Results that are failing:

| Test  | Issue  | Remark |
|--------|--------|--------|
| /css/css-lists/marker-dynamic-content-change.html | #43120 | |
| /css/css-lists/marker-quotes.html                                | #30365 | Test File: Ordered List showing '0' for all `li` |
| /css/css-pseudo/marker-content-001.html                  | #30365 | Ref file: Ordered List showing '0' for all `li` |
| /css/css-pseudo/marker-content-001b.html                | #30365 | Ref file: Ordered List showing '0' for all `li` |
| /css/css-pseudo/marker-content-001c.html                | #30365 | Ref file: Ordered List showing '0' for all `li` |
| /css/css-pseudo/marker-content-020.html                  |  | Test File: JavaScript dynamically toggles the `no-marker` class, but it doesn't update the DOM when called from inside `addEventListener()` and `requestAnimationFrame()` functions. |
| /css/selectors/has-style-sharing-pseudo-007.html     | #25133 | Test file uses `has` to remove `content` from a `li`; `has` pseudo-class has not been implemented yet |
| /css/selectors/has-style-sharing-pseudo-008.html     | #25133 | Test file uses `has` to remove `content` from a `li`; `has` pseudo-class has not been implemented yet |


