### PR TITLE
layout: Improve the rendering of the `<marquee>` element

### DIFF
--- a/components/layout/stylesheets/user-agent.css
+++ b/components/layout/stylesheets/user-agent.css
@@ -423,3 +423,13 @@ iframe:fullscreen {
   font-variant-numeric: tabular-nums;
   white-space: pre;
 }
+
+/* https://html.spec.whatwg.org/multipage/#the-marquee-element-2 */
+marquee {
+  display: inline-block;
+  text-align: initial;
+  overflow: hidden !important;
+  inline-size: stretch;
+  vertical-align: text-bottom;
+  white-space: nowrap;
+}

--- a/tests/wpt/meta/html/obsolete/requirements-for-implementations/the-marquee-element-0/marquee-min-intrinsic-size.html.ini
+++ b/tests/wpt/meta/html/obsolete/requirements-for-implementations/the-marquee-element-0/marquee-min-intrinsic-size.html.ini
@@ -1,0 +1,2 @@
+[marquee-min-intrinsic-size.html]
+  expected: FAIL

--- a/tests/wpt/meta/html/obsolete/requirements-for-implementations/the-marquee-element-0/marquee-overflow.html.ini
+++ b/tests/wpt/meta/html/obsolete/requirements-for-implementations/the-marquee-element-0/marquee-overflow.html.ini
@@ -1,3 +1,0 @@
-[marquee-overflow.html]
-  [Marquee should have overflow: hidden !important in the UA stylesheet]
-    expected: FAIL

--- a/tests/wpt/meta/html/obsolete/requirements-for-implementations/the-marquee-element-0/marquee-with-trusted-types.html.ini
+++ b/tests/wpt/meta/html/obsolete/requirements-for-implementations/the-marquee-element-0/marquee-with-trusted-types.html.ini
@@ -1,2 +1,0 @@
-[marquee-with-trusted-types.html]
-  expected: FAIL

--- a/tests/wpt/meta/html/rendering/non-replaced-elements/form-controls/resets.html.ini
+++ b/tests/wpt/meta/html/rendering/non-replaced-elements/form-controls/resets.html.ini
@@ -1,6 +1,0 @@
-[resets.html]
-  [<marquee> - text-align]
-    expected: FAIL
-
-  [<marquee> - overflow]
-    expected: FAIL

--- a/tests/wpt/mozilla/meta/MANIFEST.json
+++ b/tests/wpt/mozilla/meta/MANIFEST.json
@@ -269,6 +269,19 @@
       {}
      ]
     ],
+    "marquee.html": [
+     "4a5b8a6d16d85dcf6b74e704c55231dddee26e0b",
+     [
+      null,
+      [
+       [
+        "/_mozilla/appearance/marquee-ref.html",
+        "=="
+       ]
+      ],
+      {}
+     ]
+    ],
     "text-advance-less-than-ink-clipping.html": [
      "a726bd2881ff7cb29a9e68f8e7f1fae728b9382e",
      [
@@ -8358,6 +8371,10 @@
     ],
     "input-textual-vertical-align-ref.html": [
      "ee442170edc3543c2838be3ef4edf78d1aae4753",
+     []
+    ],
+    "marquee-ref.html": [
+     "3bbe99f30eba1dfeda637b2e44e21d366c7fda6f",
      []
     ],
     "supports": {

--- a/tests/wpt/mozilla/tests/appearance/marquee-ref.html
+++ b/tests/wpt/mozilla/tests/appearance/marquee-ref.html
@@ -1,0 +1,45 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>Appearance of the &lt;marquee&gt; element</title>
+</head>
+<body>
+    <style>
+        .marquee {
+        display: inline-block;
+        text-align: initial;
+        overflow: hidden !important;
+        inline-size: stretch;
+        vertical-align: text-bottom;
+        white-space: nowrap;
+        background: teal;
+        }
+    </style>
+    <div class="marquee">
+        text text text text text text text text text text text
+        text text text text text text text text text text text
+        text text text text text text text text text text text
+        text text text text text text text text text text text
+        text text text text text text text text text text text
+        text text text text text text text text text text text
+        text text text text text text text text text text text
+        text text text text text text text text text text text
+        text text text text text text text text text text text
+        text text text text text text text text text text text
+    </div>
+    <div style="width: 200px">
+        <div class="marquee">
+            text text text text text text text text text text text
+            text text text text text text text text text text text
+            text text text text text text text text text text text
+            text text text text text text text text text text text
+            text text text text text text text text text text text
+            text text text text text text text text text text text
+            text text text text text text text text text text text
+            text text text text text text text text text text text
+            text text text text text text text text text text text
+            text text text text text text text text text text text
+        </div>
+    </div>
+</body>
+</html>

--- a/tests/wpt/mozilla/tests/appearance/marquee.html
+++ b/tests/wpt/mozilla/tests/appearance/marquee.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>Appearance of the &lt;marquee&gt; element</title>
+    <link rel="match" href="marquee-ref.html">
+</head>
+<body>
+    <marquee style="background: teal">
+        text text text text text text text text text text text
+        text text text text text text text text text text text
+        text text text text text text text text text text text
+        text text text text text text text text text text text
+        text text text text text text text text text text text
+        text text text text text text text text text text text
+        text text text text text text text text text text text
+        text text text text text text text text text text text
+        text text text text text text text text text text text
+        text text text text text text text text text text text
+    </marquee>
+    <div style="width: 200px">
+        <marquee style="background: teal">
+            text text text text text text text text text text text
+            text text text text text text text text text text text
+            text text text text text text text text text text text
+            text text text text text text text text text text text
+            text text text text text text text text text text text
+            text text text text text text text text text text text
+            text text text text text text text text text text text
+            text text text text text text text text text text text
+            text text text text text text text text text text text
+            text text text text text text text text text text text
+        </marquee>
+    </div>
+</body>
+</html>


### PR DESCRIPTION
The change makes it so that `<marquee>` elements render more like the do
in Chrome. The text will not animate, but likewise it does not wrap and
the element will stretch to fill the inline space in its containing block.

Testing: This change adds a Servo-specific appearance test. This essentially
just replicates the user agent style of `<marquee>`. It's quite difficult to
write tests for appearance. Some WPT tests start to pass, but
`/html/obsolete/requirements-for-implementations/the-marquee-element-0/marquee-min-intrinsic-size.html`
starts to fail. This is due to the fact that though the `<marquee>` style
is improved, we do not yet correctly handle the minimum intrinsic size
properly.
Fixes: #43517
