### PR TITLE
Use encoding-parse for form action

### DIFF
--- a/components/script/dom/html/htmlformelement.rs
+++ b/components/script/dom/html/htmlformelement.rs
@@ -836,7 +836,7 @@ impl HTMLFormElement {
             action = DOMString::from(base.as_str());
         }
         // Step 14. Let parsed action be the result of encoding-parsing a URL given action, relative to submitter's node document.
-        let action_components = match base.join(&action.str()) {
+        let action_components = match doc.encoding_parse_a_url(&action.str()) {
             Ok(url) => url,
             // Step 15. If parsed action is failure, then return.
             Err(_) => return,

--- a/components/script/dom/macros.rs
+++ b/components/script/dom/macros.rs
@@ -135,7 +135,7 @@ macro_rules! make_form_action_getter(
                 Some(ref value) if !value.is_empty() => &***value,
                 _ => return doc.url().into_string().into(),
             };
-            match doc.base_url().join(value) {
+            match doc.encoding_parse_a_url(value) {
                 Ok(parsed) => parsed.into_string().into(),
                 Err(_) => value.to_owned().into(),
             }


### PR DESCRIPTION
Parse form action URLs using the document's encoding-aware URL parser.

Testing: Verified with the WPT form-action tests `./mach test-wpt tests/wpt/tests/html/semantics/forms/the-form-element`, all relevant tests passed.

Fixes: #43507 
