### PR TITLE
script: Allow for implicit cx for setters

### DIFF
--- a/components/script/devtools.rs
+++ b/components/script/devtools.rs
@@ -610,10 +610,10 @@ pub(crate) fn handle_modify_rule(
 
     for modification in modifications {
         let _ = style.SetProperty(
+            cx,
             modification.name.into(),
             modification.value.into(),
             modification.priority.into(),
-            CanGc::from_cx(cx),
         );
     }
 }

--- a/components/script/dom/css/cssstyledeclaration.rs
+++ b/components/script/dom/css/cssstyledeclaration.rs
@@ -8,6 +8,7 @@ use std::sync::LazyLock;
 
 use dom_struct::dom_struct;
 use html5ever::local_name;
+use js::context::JSContext;
 use servo_arc::Arc;
 use servo_url::ServoUrl;
 use style::attr::AttrValue;
@@ -204,12 +205,12 @@ macro_rules! css_properties(
                 );
                 self.get_property_value($id)
             }
-            fn $setter(&self, value: DOMString) -> ErrorResult {
+            fn $setter(&self, cx: &mut JSContext, value: DOMString) -> ErrorResult {
                 debug_assert!(
                     $id.enabled_for_all_content(),
                     "Someone forgot a #[Pref] annotation"
                 );
-                self.set_property($id, value, DOMString::new(), CanGc::note())
+                self.set_property(cx, $id, value, DOMString::new())
             }
         )*
     );
@@ -317,17 +318,12 @@ impl CSSStyleDeclaration {
     /// <https://drafts.csswg.org/cssom/#dom-cssstyledeclaration-setproperty>
     fn set_property(
         &self,
+        cx: &mut JSContext,
         id: PropertyId,
         value: DOMString,
         priority: DOMString,
-        can_gc: CanGc,
     ) -> ErrorResult {
-        self.set_property_inner(
-            PotentiallyParsedPropertyId::Parsed(id),
-            value,
-            priority,
-            can_gc,
-        )
+        self.set_property_inner(cx, PotentiallyParsedPropertyId::Parsed(id), value, priority)
     }
 
     /// <https://drafts.csswg.org/cssom/#dom-cssstyledeclaration-setproperty>
@@ -336,10 +332,10 @@ impl CSSStyleDeclaration {
     /// the caller already has a parsed property ID.
     fn set_property_inner(
         &self,
+        cx: &mut JSContext,
         id: PotentiallyParsedPropertyId,
         value: DOMString,
         priority: DOMString,
-        can_gc: CanGc,
     ) -> ErrorResult {
         // Step 1. If the readonly flag is set, then throw a NoModificationAllowedError exception.
         if self.readonly {
@@ -420,7 +416,7 @@ impl CSSStyleDeclaration {
 
                 Ok(())
             },
-            can_gc,
+            CanGc::from_cx(cx),
         )
     }
 }
@@ -511,21 +507,21 @@ impl CSSStyleDeclarationMethods<crate::DomTypeHolder> for CSSStyleDeclaration {
     /// <https://dev.w3.org/csswg/cssom/#dom-cssstyledeclaration-setproperty>
     fn SetProperty(
         &self,
+        cx: &mut JSContext,
         property: DOMString,
         value: DOMString,
         priority: DOMString,
-        can_gc: CanGc,
     ) -> ErrorResult {
         self.set_property_inner(
+            cx,
             PotentiallyParsedPropertyId::NotParsed(property),
             value,
             priority,
-            can_gc,
         )
     }
 
     /// <https://dev.w3.org/csswg/cssom/#dom-cssstyledeclaration-removeproperty>
-    fn RemoveProperty(&self, property: DOMString, can_gc: CanGc) -> Fallible<DOMString> {
+    fn RemoveProperty(&self, cx: &mut JSContext, property: DOMString) -> Fallible<DOMString> {
         // Step 1
         if self.readonly {
             return Err(Error::NoModificationAllowed(None));
@@ -542,7 +538,7 @@ impl CSSStyleDeclarationMethods<crate::DomTypeHolder> for CSSStyleDeclaration {
                 pdb.property_value_to_css(&id, &mut string).unwrap();
                 *changed = remove_property(pdb, &id);
             },
-            can_gc,
+            CanGc::from_cx(cx),
         );
 
         // Step 6
@@ -555,12 +551,12 @@ impl CSSStyleDeclarationMethods<crate::DomTypeHolder> for CSSStyleDeclaration {
     }
 
     /// <https://drafts.csswg.org/cssom/#dom-cssstyleproperties-cssfloat>
-    fn SetCssFloat(&self, value: DOMString, can_gc: CanGc) -> ErrorResult {
+    fn SetCssFloat(&self, cx: &mut JSContext, value: DOMString) -> ErrorResult {
         self.set_property(
+            cx,
             PropertyId::NonCustom(LonghandId::Float.into()),
             value,
             DOMString::new(),
-            can_gc,
         )
     }
 
@@ -595,7 +591,7 @@ impl CSSStyleDeclarationMethods<crate::DomTypeHolder> for CSSStyleDeclaration {
     }
 
     /// <https://drafts.csswg.org/cssom/#dom-cssstyledeclaration-csstext>
-    fn SetCssText(&self, value: DOMString, can_gc: CanGc) -> ErrorResult {
+    fn SetCssText(&self, cx: &mut JSContext, value: DOMString) -> ErrorResult {
         let window = self.owner.window();
 
         // Step 1
@@ -616,7 +612,7 @@ impl CSSStyleDeclarationMethods<crate::DomTypeHolder> for CSSStyleDeclaration {
                     CssRuleType::Style,
                 );
             },
-            can_gc,
+            CanGc::from_cx(cx),
         );
 
         Ok(())

--- a/components/script_bindings/codegen/Bindings.conf
+++ b/components/script_bindings/codegen/Bindings.conf
@@ -165,7 +165,8 @@ DOMInterfaces = {
 },
 
 'CSSStyleDeclaration': {
-    'canGc': ['RemoveProperty', 'SetCssText', 'SetProperty', 'SetCssFloat']
+    'implicitCxSetters': True,
+    'cx': ['RemoveProperty', 'SetProperty']
 },
 
 'CustomElementRegistry': {

--- a/components/script_bindings/codegen/codegen.py
+++ b/components/script_bindings/codegen/codegen.py
@@ -4142,6 +4142,7 @@ class CGCallGenerator(CGThing):
                  extendedAttributes: list[str],
                  descriptor: Descriptor,
                  nativeMethodName: str,
+                 is_attr: bool,
                  static: bool,
                  object: str = "this",
                  hasCEReactions: bool = False
@@ -4170,7 +4171,8 @@ class CGCallGenerator(CGThing):
             args.append(CGGeneric(name))
 
         needsCx = False
-        match needCx(returnType, (a for (a, _) in arguments), True):
+        is_implicit_cx_attribute = descriptor.implicitCxSetters and is_attr and nativeMethodName.startswith('Set')
+        match max([needCx(returnType, (a for (a, _) in arguments), True), Context.Cx if is_implicit_cx_attribute else Context.No]):
             case Context.Cx:
                 descriptor.cxMethods.append(nativeMethodName)
             case Context.CurrentRealm:
@@ -4318,7 +4320,7 @@ class CGPerSignatureCall(CGThing):
                 errorResult,
                 self.getArguments(), self.argsPre, returnType,
                 self.extendedAttributes, descriptor, nativeMethodName,
-                static, hasCEReactions=hasCEReactions))
+                idlNode.isAttr(), static, hasCEReactions=hasCEReactions))
 
         self.cgRoot = CGList(cgThings, "\n")
 
@@ -7075,7 +7077,7 @@ class CGInterfaceTrait(CGThing):
                                    m.type,
                                    m.type,
                                    cx_no_gc=name in descriptor.cx_no_gcMethods,
-                                   cx=name in descriptor.cxMethods,
+                                   cx=name in descriptor.cxMethods or descriptor.implicitCxSetters,
                                    realm=name in descriptor.realmMethods,
                                    inRealm=name in descriptor.inRealmMethods,
                                    canGc=name in descriptor.canGcMethods,

--- a/components/script_bindings/codegen/configuration.py
+++ b/components/script_bindings/codegen/configuration.py
@@ -301,6 +301,7 @@ class Descriptor(DescriptorProvider):
         self.weakReferenceable = desc.get('weakReferenceable', False)
         self.useSystemCompartment = desc.get('useSystemCompartment', False)
         self.allowDropImpl = desc.get('allowDropImpl', False)
+        self.implicitCxSetters = desc.get('implicitCxSetters', False)
 
         # If we're concrete, we need to crawl our ancestor interfaces and mark
         # them as having a concrete descendant.


### PR DESCRIPTION
Rather than specifying a cx for every single CSS property from Stylo, we instead make it implicit. This allows us to remove the `CanGc::note()` from the macro and pass in the `cx` as normal.

We can use a similar approach for setters in other elements where we use the setter macros.

Part of #42812

Testing: It compiles