### PR TITLE
script: Propagate `&mut JSContext` from `GlobalScope::start_message_port` to stream code

### DIFF
--- a/components/script/dom/globalscope.rs
+++ b/components/script/dom/globalscope.rs
@@ -562,7 +562,7 @@ impl MessageListener {
             MessagePortMsg::CompleteTransfer(ports) => {
                 let context = self.context.clone();
                 self.task_source.queue(
-                    task!(process_complete_transfer: move || {
+                    task!(process_complete_transfer: move |cx| {
                         let global = context.root();
 
                         let router_id = match global.port_router_id() {
@@ -584,10 +584,10 @@ impl MessageListener {
                             if global.is_managing_port(&id) {
                                 succeeded.push(id);
                                 global.complete_port_transfer(
+                                    cx,
                                     id,
                                     info.port_message_queue,
                                     info.disentangled,
-                                    CanGc::note()
                                 );
                             } else {
                                 failed.insert(id, info);
@@ -601,9 +601,9 @@ impl MessageListener {
             },
             MessagePortMsg::CompletePendingTransfer(port_id, info) => {
                 let context = self.context.clone();
-                self.task_source.queue(task!(complete_pending: move || {
+                self.task_source.queue(task!(complete_pending: move |cx| {
                     let global = context.root();
-                    global.complete_port_transfer(port_id, info.port_message_queue, info.disentangled, CanGc::note());
+                    global.complete_port_transfer(cx, port_id, info.port_message_queue, info.disentangled);
                 }));
             },
             MessagePortMsg::CompleteDisentanglement(port_id) => {
@@ -616,9 +616,9 @@ impl MessageListener {
             },
             MessagePortMsg::NewTask(port_id, task) => {
                 let context = self.context.clone();
-                self.task_source.queue(task!(process_new_task: move || {
+                self.task_source.queue(task!(process_new_task: move |cx| {
                     let global = context.root();
-                    global.route_task_to_port(port_id, task, CanGc::note());
+                    global.route_task_to_port(cx, port_id, task);
                 }));
             },
         }
@@ -924,10 +924,10 @@ impl GlobalScope {
     /// Complete the transfer of a message-port.
     fn complete_port_transfer(
         &self,
+        cx: &mut js::context::JSContext,
         port_id: MessagePortId,
         tasks: VecDeque<PortMessageTask>,
         disentangled: bool,
-        can_gc: CanGc,
     ) {
         let should_start = if let MessagePortState::Managed(_id, message_ports) =
             &mut *self.message_port_state.borrow_mut()
@@ -956,7 +956,7 @@ impl GlobalScope {
             panic!("complete_port_transfer called for an unknown port.");
         };
         if should_start {
-            self.start_message_port(&port_id, can_gc);
+            self.start_message_port(cx, &port_id);
         }
     }
 
@@ -1164,7 +1164,11 @@ impl GlobalScope {
     }
 
     /// <https://html.spec.whatwg.org/multipage/#dom-messageport-start>
-    pub(crate) fn start_message_port(&self, port_id: &MessagePortId, can_gc: CanGc) {
+    pub(crate) fn start_message_port(
+        &self,
+        cx: &mut js::context::JSContext,
+        port_id: &MessagePortId,
+    ) {
         let (message_buffer, dom_port) = if let MessagePortState::Managed(_id, message_ports) =
             &mut *self.message_port_state.borrow_mut()
         {
@@ -1184,12 +1188,14 @@ impl GlobalScope {
         };
         if let Some(message_buffer) = message_buffer {
             for task in message_buffer {
-                self.route_task_to_port(*port_id, task, CanGc::note());
+                self.route_task_to_port(cx, *port_id, task);
             }
             if dom_port.disentangled() {
                 // <https://html.spec.whatwg.org/multipage/#disentangle>
                 // Fire an event named close at otherPort.
-                dom_port.upcast().fire_event(atom!("close"), can_gc);
+                dom_port
+                    .upcast()
+                    .fire_event(atom!("close"), CanGc::from_cx(cx));
 
                 let res = self.script_to_constellation_chan().send(
                     ScriptToConstellationMessage::DisentanglePorts(*port_id, None),
@@ -1243,11 +1249,11 @@ impl GlobalScope {
                 let this = Trusted::new(self);
                 self.task_manager()
                     .port_message_queue()
-                    .queue(task!(post_message: move || {
+                    .queue(task!(post_message: move |cx| {
                         let global = this.root();
                         // Note: we do this in a task, as this will ensure the global and constellation
                         // are aware of any transfer that might still take place in the current task.
-                        global.route_task_to_port(entangled_id, task, CanGc::note());
+                        global.route_task_to_port(cx, entangled_id, task);
                     }));
             }
         } else {
@@ -1426,14 +1432,13 @@ impl GlobalScope {
 
     /// Custom routing logic, followed by the task steps of
     /// <https://html.spec.whatwg.org/multipage/#message-port-post-message-steps>
-    pub(crate) fn route_task_to_port(
+    fn route_task_to_port(
         &self,
+        cx: &mut js::context::JSContext,
         port_id: MessagePortId,
         task: PortMessageTask,
-        can_gc: CanGc,
     ) {
-        let cx = GlobalScope::get_cx();
-        rooted!(in(*cx) let mut cross_realm_transform = None);
+        rooted!(&in(cx) let mut cross_realm_transform = None);
 
         let should_dispatch = if let MessagePortState::Managed(_id, message_ports) =
             &mut *self.message_port_state.borrow_mut()
@@ -1476,10 +1481,10 @@ impl GlobalScope {
 
             // Let messageClone be deserializeRecord.[[Deserialized]].
             // Re-ordered because we need to pass it to `structuredclone::read`.
-            rooted!(in(*cx) let mut message_clone = UndefinedValue());
+            rooted!(&in(cx) let mut message_clone = UndefinedValue());
 
-            let realm = enter_realm(self);
-            let comp = InRealm::Entered(&realm);
+            let mut realm = enter_auto_realm(cx, self);
+            let cx = &mut realm.current_realm();
 
             // Note: this is necessary, on top of entering the realm above,
             // for the call to `GlobalScope::incumbent`,
@@ -1490,9 +1495,12 @@ impl GlobalScope {
                 // consisting of all MessagePort objects in deserializeRecord.[[TransferredValues]],
                 // if any, maintaining their relative order.
                 // Note: both done in `structuredclone::read`.
-                if let Ok(ports) =
-                    structuredclone::read(self, data, message_clone.handle_mut(), can_gc)
-                {
+                if let Ok(ports) = structuredclone::read(
+                    self,
+                    data,
+                    message_clone.handle_mut(),
+                    CanGc::from_cx(cx),
+                ) {
                     // Note: if this port is used to transfer a stream, we handle the events in Rust.
                     if let Some(transform) = cross_realm_transform.deref().as_ref() {
                         match transform {
@@ -1504,20 +1512,12 @@ impl GlobalScope {
                                     self,
                                     &dom_port,
                                     message_clone.handle(),
-                                    comp,
-                                    can_gc,
                                 );
                             },
                             // Add a handler for port’s message event with the following steps:
                             // from <https://streams.spec.whatwg.org/#abstract-opdef-setupcrossrealmtransformwritable>
                             CrossRealmTransform::Writable(writable) => {
-                                writable.handle_message(
-                                    cx,
-                                    self,
-                                    message_clone.handle(),
-                                    comp,
-                                    can_gc,
-                                );
+                                writable.handle_message(cx, self, message_clone.handle());
                             },
                         }
                     } else {
@@ -1532,7 +1532,7 @@ impl GlobalScope {
                             Some(&origin.ascii_serialization()),
                             None,
                             ports,
-                            can_gc,
+                            CanGc::from_cx(cx),
                         );
                     }
                 } else if let Some(transform) = cross_realm_transform.deref().as_ref() {
@@ -1540,19 +1540,19 @@ impl GlobalScope {
                         // Add a handler for port’s messageerror event with the following steps:
                         // from <https://streams.spec.whatwg.org/#abstract-opdef-setupcrossrealmtransformreadable>
                         CrossRealmTransform::Readable(readable) => {
-                            readable.handle_error(cx, self, &dom_port, comp, can_gc);
+                            readable.handle_error(cx, self, &dom_port);
                         },
                         // Add a handler for port’s messageerror event with the following steps:
                         // from <https://streams.spec.whatwg.org/#abstract-opdef-setupcrossrealmtransformwritable>
                         CrossRealmTransform::Writable(writable) => {
-                            writable.handle_error(cx, self, &dom_port, comp, can_gc);
+                            writable.handle_error(cx, self, &dom_port);
                         },
                     }
                 } else {
                     // If this throws an exception, catch it,
                     // fire an event named messageerror at messageEventTarget,
                     // using MessageEvent, and then return.
-                    MessageEvent::dispatch_error(message_event_target, self, can_gc);
+                    MessageEvent::dispatch_error(message_event_target, self, CanGc::from_cx(cx));
                 }
             });
         }

--- a/components/script/dom/messageport.rs
+++ b/components/script/dom/messageport.rs
@@ -333,12 +333,11 @@ impl MessagePortMethods<crate::DomTypeHolder> for MessagePort {
     }
 
     /// <https://html.spec.whatwg.org/multipage/#dom-messageport-start>
-    fn Start(&self, can_gc: CanGc) {
+    fn Start(&self, cx: &mut JSContext) {
         if self.detached.get() {
             return;
         }
-        self.global()
-            .start_message_port(self.message_port_id(), can_gc);
+        self.global().start_message_port(cx, self.message_port_id());
     }
 
     /// <https://html.spec.whatwg.org/multipage/#dom-messageport-close>
@@ -363,14 +362,13 @@ impl MessagePortMethods<crate::DomTypeHolder> for MessagePort {
     }
 
     /// <https://html.spec.whatwg.org/multipage/#handler-messageport-onmessage>
-    fn SetOnmessage(&self, listener: Option<Rc<EventHandlerNonNull>>, can_gc: CanGc) {
+    fn SetOnmessage(&self, cx: &mut JSContext, listener: Option<Rc<EventHandlerNonNull>>) {
         if self.detached.get() {
             return;
         }
         self.set_onmessage(listener);
         // Note: we cannot use the event_handler macro, due to the need to start the port.
-        self.global()
-            .start_message_port(self.message_port_id(), can_gc);
+        self.global().start_message_port(cx, self.message_port_id());
     }
 
     // <https://html.spec.whatwg.org/multipage/#handler-messageport-onmessageerror>

--- a/components/script/dom/stream/defaultteereadrequest.rs
+++ b/components/script/dom/stream/defaultteereadrequest.rs
@@ -217,7 +217,7 @@ impl DefaultTeeReadRequest {
     ) {
         stream
             .get_default_controller()
-            .enqueue(cx.into(), chunk, CanGc::from_cx(cx))
+            .enqueue(cx, chunk)
             .expect("enqueue failed for stream controller in DefaultTeeReadRequest");
     }
 

--- a/components/script/dom/stream/readablestream.rs
+++ b/components/script/dom/stream/readablestream.rs
@@ -2030,9 +2030,8 @@ impl ReadableStream {
     /// <https://streams.spec.whatwg.org/#abstract-opdef-setupcrossrealmtransformreadable>
     pub(crate) fn setup_cross_realm_transform_readable(
         &self,
-        cx: SafeJSContext,
+        cx: &mut js::context::JSContext,
         port: &MessagePort,
-        can_gc: CanGc,
     ) {
         let port_id = port.message_port_id();
         let global = self.global();
@@ -2041,7 +2040,8 @@ impl ReadableStream {
         // Done in `new_inherited`.
 
         // Let sizeAlgorithm be an algorithm that returns 1.
-        let size_algorithm = extract_size_algorithm(&QueuingStrategy::default(), can_gc);
+        let size_algorithm =
+            extract_size_algorithm(&QueuingStrategy::default(), CanGc::from_cx(cx));
 
         // Note: other algorithms defined in the underlying source container.
 
@@ -2051,22 +2051,22 @@ impl ReadableStream {
             UnderlyingSourceType::Transfer(Dom::from_ref(port)),
             0.,
             size_algorithm,
-            can_gc,
+            CanGc::from_cx(cx),
         );
 
         // Add a handler for port’s message event with the following steps:
         // Add a handler for port’s messageerror event with the following steps:
-        rooted!(in(*cx) let cross_realm_transform_readable = CrossRealmTransformReadable {
+        rooted!(&in(cx) let cross_realm_transform_readable = CrossRealmTransformReadable {
             controller: Dom::from_ref(&controller),
         });
         global.note_cross_realm_transform_readable(&cross_realm_transform_readable, port_id);
 
         // Enable port’s port message queue.
-        port.Start(can_gc);
+        port.Start(cx);
 
         // Perform ! SetUpReadableStreamDefaultController
         controller
-            .setup(DomRoot::from_ref(self), can_gc)
+            .setup(DomRoot::from_ref(self), CanGc::from_cx(cx))
             .expect("Setting up controller for transfer cannot fail.");
     }
 }
@@ -2352,41 +2352,45 @@ impl CrossRealmTransformReadable {
     #[expect(unsafe_code)]
     pub(crate) fn handle_message(
         &self,
-        cx: SafeJSContext,
+        cx: &mut CurrentRealm,
         global: &GlobalScope,
         port: &MessagePort,
         message: SafeHandleValue,
-        _realm: InRealm,
-        can_gc: CanGc,
     ) {
-        rooted!(in(*cx) let mut value = UndefinedValue());
-        let type_string =
-            unsafe { get_type_and_value_from_message(cx, message, value.handle_mut(), can_gc) };
+        rooted!(&in(cx) let mut value = UndefinedValue());
+        let type_string = unsafe {
+            get_type_and_value_from_message(
+                cx.into(),
+                message,
+                value.handle_mut(),
+                CanGc::from_cx(cx),
+            )
+        };
 
         // If type is "chunk",
         if type_string == "chunk" {
             // Perform ! ReadableStreamDefaultControllerEnqueue(controller, value).
             self.controller
-                .enqueue(cx, value.handle(), can_gc)
+                .enqueue(cx, value.handle())
                 .expect("Enqueing a chunk should not fail.");
         }
 
         // Otherwise, if type is "close",
         if type_string == "close" {
             // Perform ! ReadableStreamDefaultControllerClose(controller).
-            self.controller.close(can_gc);
+            self.controller.close(CanGc::from_cx(cx));
 
             // Disentangle port.
-            global.disentangle_port(port, can_gc);
+            global.disentangle_port(port, CanGc::from_cx(cx));
         }
 
         // Otherwise, if type is "error",
         if type_string == "error" {
             // Perform ! ReadableStreamDefaultControllerError(controller, value).
-            self.controller.error(value.handle(), can_gc);
+            self.controller.error(value.handle(), CanGc::from_cx(cx));
 
             // Disentangle port.
-            global.disentangle_port(port, can_gc);
+            global.disentangle_port(port, CanGc::from_cx(cx));
         }
     }
 
@@ -2394,25 +2398,24 @@ impl CrossRealmTransformReadable {
     /// Add a handler for port’s messageerror event with the following steps:
     pub(crate) fn handle_error(
         &self,
-        cx: SafeJSContext,
+        cx: &mut CurrentRealm,
         global: &GlobalScope,
         port: &MessagePort,
-        _realm: InRealm,
-        can_gc: CanGc,
     ) {
         // Let error be a new "DataCloneError" DOMException.
-        let error = DOMException::new(global, DOMErrorName::DataCloneError, can_gc);
-        rooted!(in(*cx) let mut rooted_error = UndefinedValue());
-        error.safe_to_jsval(cx, rooted_error.handle_mut(), can_gc);
+        let error = DOMException::new(global, DOMErrorName::DataCloneError, CanGc::from_cx(cx));
+        rooted!(&in(cx) let mut rooted_error = UndefinedValue());
+        error.safe_to_jsval(cx.into(), rooted_error.handle_mut(), CanGc::from_cx(cx));
 
         // Perform ! CrossRealmTransformSendError(port, error).
-        port.cross_realm_transform_send_error(rooted_error.handle(), can_gc);
+        port.cross_realm_transform_send_error(rooted_error.handle(), CanGc::from_cx(cx));
 
         // Perform ! ReadableStreamDefaultControllerError(controller, error).
-        self.controller.error(rooted_error.handle(), can_gc);
+        self.controller
+            .error(rooted_error.handle(), CanGc::from_cx(cx));
 
         // Disentangle port.
-        global.disentangle_port(port, can_gc);
+        global.disentangle_port(port, CanGc::from_cx(cx));
     }
 }
 
@@ -2526,7 +2529,7 @@ impl Transferable for ReadableStream {
         let writable = WritableStream::new_with_proto(&global, None, CanGc::from_cx(cx));
 
         // Step 6. Perform ! SetUpCrossRealmTransformWritable(writable, port1).
-        writable.setup_cross_realm_transform_writable(cx.into(), &port_1, CanGc::from_cx(cx));
+        writable.setup_cross_realm_transform_writable(cx, &port_1);
 
         // Step 7. Let promise be ! ReadableStreamPipeTo(value, writable, false, false, false).
         let promise = self.pipe_to(cx, &global, &writable, false, false, false, None);
@@ -2558,11 +2561,7 @@ impl Transferable for ReadableStream {
         let transferred_port = MessagePort::transfer_receive(cx, owner, id, port_impl)?;
 
         // Step 3. Perform ! SetUpCrossRealmTransformReadable(value, port).
-        value.setup_cross_realm_transform_readable(
-            cx.into(),
-            &transferred_port,
-            CanGc::from_cx(cx),
-        );
+        value.setup_cross_realm_transform_readable(cx, &transferred_port);
         Ok(value)
     }
 

--- a/components/script/dom/stream/readablestreamdefaultcontroller.rs
+++ b/components/script/dom/stream/readablestreamdefaultcontroller.rs
@@ -11,7 +11,7 @@ use dom_struct::dom_struct;
 use js::jsapi::{Heap, JSObject};
 use js::jsval::{JSVal, UndefinedValue};
 use js::realm::CurrentRealm;
-use js::rust::wrappers::JS_GetPendingException;
+use js::rust::wrappers2::JS_GetPendingException;
 use js::rust::{HandleObject, HandleValue as SafeHandleValue, HandleValue, MutableHandleValue};
 use js::typedarray::Uint8;
 use script_bindings::conversions::SafeToJSValConvertible;
@@ -652,9 +652,8 @@ impl ReadableStreamDefaultController {
     #[expect(unsafe_code)]
     pub(crate) fn enqueue(
         &self,
-        cx: SafeJSContext,
+        cx: &mut js::context::JSContext,
         chunk: SafeHandleValue,
-        can_gc: CanGc,
     ) -> Result<(), Error> {
         // If ! ReadableStreamDefaultControllerCanCloseOrEnqueue(controller) is false, return.
         if !self.can_close_or_enqueue() {
@@ -670,7 +669,7 @@ impl ReadableStreamDefaultController {
         // and ! ReadableStreamGetNumReadRequests(stream) > 0,
         // perform ! ReadableStreamFulfillReadRequest(stream, chunk, false).
         if stream.is_locked() && stream.get_num_read_requests() > 0 {
-            stream.fulfill_read_request(chunk, false, can_gc);
+            stream.fulfill_read_request(chunk, false, CanGc::from_cx(cx));
         } else {
             // Otherwise,
             // Let result be the result of performing controller.[[strategySizeAlgorithm]],
@@ -683,17 +682,18 @@ impl ReadableStreamDefaultController {
             let size = if let Some(strategy_size) = strategy_size {
                 // Note: the Rethrow exception handling is necessary,
                 // otherwise returning JSFailed will panic because no exception is pending.
-                let result = strategy_size.Call__(chunk, ExceptionHandling::Rethrow, can_gc);
+                let result =
+                    strategy_size.Call__(chunk, ExceptionHandling::Rethrow, CanGc::from_cx(cx));
                 match result {
                     // Let chunkSize be result.[[Value]].
                     Ok(size) => size,
                     Err(error) => {
                         // If result is an abrupt completion,
-                        rooted!(in(*cx) let mut rval = UndefinedValue());
-                        unsafe { assert!(JS_GetPendingException(*cx, rval.handle_mut())) };
+                        rooted!(&in(cx) let mut rval = UndefinedValue());
+                        unsafe { assert!(JS_GetPendingException(cx, rval.handle_mut())) };
 
                         // Perform ! ReadableStreamDefaultControllerError(controller, result.[[Value]]).
-                        self.error(rval.handle(), can_gc);
+                        self.error(rval.handle(), CanGc::from_cx(cx));
 
                         // Return result.
                         // Note: we need to return a type error, because no exception is pending.
@@ -718,15 +718,15 @@ impl ReadableStreamDefaultController {
                     // First, throw the exception.
                     // Note: this must be done manually here,
                     // because `enqueue_value_with_size` does not call into JS.
-                    throw_dom_exception(cx, &self.global(), error, can_gc);
+                    throw_dom_exception(cx.into(), &self.global(), error, CanGc::from_cx(cx));
 
                     // Then, get a handle to the JS val for the exception,
                     // and use that to error the stream.
-                    rooted!(in(*cx) let mut rval = UndefinedValue());
-                    unsafe { assert!(JS_GetPendingException(*cx, rval.handle_mut())) };
+                    rooted!(&in(cx) let mut rval = UndefinedValue());
+                    unsafe { assert!(JS_GetPendingException(cx, rval.handle_mut())) };
 
                     // Perform ! ReadableStreamDefaultControllerError(controller, enqueueResult.[[Value]]).
-                    self.error(rval.handle(), can_gc);
+                    self.error(rval.handle(), CanGc::from_cx(cx));
 
                     // Return enqueueResult.
                     // Note: because we threw the exception above,
@@ -737,7 +737,7 @@ impl ReadableStreamDefaultController {
         }
 
         // Perform ! ReadableStreamDefaultControllerCallPullIfNeeded(controller).
-        self.call_pull_if_needed(can_gc);
+        self.call_pull_if_needed(CanGc::from_cx(cx));
 
         Ok(())
     }
@@ -903,7 +903,7 @@ impl ReadableStreamDefaultControllerMethods<crate::DomTypeHolder>
         }
 
         // Perform ? ReadableStreamDefaultControllerEnqueue(this, chunk).
-        self.enqueue(cx.into(), chunk, CanGc::from_cx(cx))
+        self.enqueue(cx, chunk)
     }
 
     /// <https://streams.spec.whatwg.org/#rs-default-controller-error>

--- a/components/script/dom/stream/transformstream.rs
+++ b/components/script/dom/stream/transformstream.rs
@@ -253,8 +253,6 @@ struct SourceCancelPromiseFulfillment {
 impl Callback for SourceCancelPromiseFulfillment {
     /// Reacting to backpressureChangePromise with the following fulfillment steps:
     fn callback(&self, cx: &mut CurrentRealm, _v: SafeHandleValue) {
-        let can_gc = CanGc::from_cx(cx);
-        let cx: SafeJSContext = cx.into();
         // If cancelPromise was fulfilled, then:
         let finish_promise = self
             .controller
@@ -264,26 +262,23 @@ impl Callback for SourceCancelPromiseFulfillment {
         let global = &self.writeable.global();
         // If writable.[[state]] is "errored", reject controller.[[finishPromise]] with writable.[[storedError]].
         if self.writeable.is_errored() {
-            rooted!(in(*cx) let mut error = UndefinedValue());
+            rooted!(&in(cx) let mut error = UndefinedValue());
             self.writeable.get_stored_error(error.handle_mut());
-            finish_promise.reject(cx, error.handle(), can_gc);
+            finish_promise.reject(cx.into(), error.handle(), CanGc::from_cx(cx));
         } else {
             // Otherwise:
             // Perform ! WritableStreamDefaultControllerErrorIfNeeded(writable.[[controller]], reason).
-            rooted!(in(*cx) let mut reason = UndefinedValue());
+            rooted!(&in(cx) let mut reason = UndefinedValue());
             reason.set(self.reason.get());
-            self.writeable.get_default_controller().error_if_needed(
-                cx,
-                reason.handle(),
-                global,
-                can_gc,
-            );
+            self.writeable
+                .get_default_controller()
+                .error_if_needed(cx, reason.handle(), global);
 
             // Perform ! TransformStreamUnblockWrite(stream).
-            self.stream.unblock_write(global, can_gc);
+            self.stream.unblock_write(global, CanGc::from_cx(cx));
 
             // Resolve controller.[[finishPromise]] with undefined.
-            finish_promise.resolve_native(&(), can_gc);
+            finish_promise.resolve_native(&(), CanGc::from_cx(cx));
         }
     }
 }
@@ -303,23 +298,21 @@ struct SourceCancelPromiseRejection {
 impl Callback for SourceCancelPromiseRejection {
     /// Reacting to backpressureChangePromise with the following fulfillment steps:
     fn callback(&self, cx: &mut CurrentRealm, v: SafeHandleValue) {
-        let can_gc = CanGc::from_cx(cx);
-        let cx: SafeJSContext = cx.into();
         // Perform ! WritableStreamDefaultControllerErrorIfNeeded(writable.[[controller]], r).
         let global = &self.writeable.global();
 
         self.writeable
             .get_default_controller()
-            .error_if_needed(cx, v, global, can_gc);
+            .error_if_needed(cx, v, global);
 
         // Perform ! TransformStreamUnblockWrite(stream).
-        self.stream.unblock_write(global, can_gc);
+        self.stream.unblock_write(global, CanGc::from_cx(cx));
 
         // Reject controller.[[finishPromise]] with r.
         self.controller
             .get_finish_promise()
             .expect("finish promise is not set")
-            .reject(cx, v, can_gc);
+            .reject(cx.into(), v, CanGc::from_cx(cx));
     }
 }
 
@@ -924,10 +917,9 @@ impl TransformStream {
     /// <https://streams.spec.whatwg.org/#transform-stream-error-writable-and-unblock-write>
     pub(crate) fn error_writable_and_unblock_write(
         &self,
-        cx: SafeJSContext,
+        cx: &mut js::context::JSContext,
         global: &GlobalScope,
         error: SafeHandleValue,
-        can_gc: CanGc,
     ) {
         // Perform ! TransformStreamDefaultControllerClearAlgorithms(stream.[[controller]]).
         self.get_controller().clear_algorithms();
@@ -935,10 +927,10 @@ impl TransformStream {
         // Perform ! WritableStreamDefaultControllerErrorIfNeeded(stream.[[writable]].[[controller]], e).
         self.get_writable()
             .get_default_controller()
-            .error_if_needed(cx, error, global, can_gc);
+            .error_if_needed(cx, error, global);
 
         // Perform ! TransformStreamUnblockWrite(stream).
-        self.unblock_write(global, can_gc)
+        self.unblock_write(global, CanGc::from_cx(cx))
     }
 
     /// <https://streams.spec.whatwg.org/#transform-stream-unblock-write>
@@ -962,7 +954,7 @@ impl TransformStream {
             .error(error, CanGc::from_cx(cx));
 
         // Perform ! TransformStreamErrorWritableAndUnblockWrite(stream, e).
-        self.error_writable_and_unblock_write(cx.into(), global, error, CanGc::from_cx(cx));
+        self.error_writable_and_unblock_write(cx, global, error);
     }
 }
 
@@ -1131,7 +1123,7 @@ impl Transferable for TransformStream {
         global.entangle_ports(*port1.message_port_id(), *port1_peer.message_port_id());
 
         let proxy_readable = ReadableStream::new_with_proto(&global, None, CanGc::from_cx(cx));
-        proxy_readable.setup_cross_realm_transform_readable(cx.into(), &port1, CanGc::from_cx(cx));
+        proxy_readable.setup_cross_realm_transform_readable(cx, &port1);
         proxy_readable
             .pipe_to(cx, &global, &writable, false, false, false, None)
             .set_promise_is_handled();
@@ -1144,7 +1136,7 @@ impl Transferable for TransformStream {
         global.entangle_ports(*port2.message_port_id(), *port2_peer.message_port_id());
 
         let proxy_writable = WritableStream::new_with_proto(&global, None, CanGc::from_cx(cx));
-        proxy_writable.setup_cross_realm_transform_writable(cx.into(), &port2, CanGc::from_cx(cx));
+        proxy_writable.setup_cross_realm_transform_writable(cx, &port2);
 
         // Pipe readable into the proxy writable (→ port_1)
         readable
@@ -1178,13 +1170,13 @@ impl Transferable for TransformStream {
         // StructuredDeserializeWithTransfer(dataHolder.[[readable]], the
         // current Realm).
         let proxy_readable = ReadableStream::new_with_proto(owner, None, CanGc::from_cx(cx));
-        proxy_readable.setup_cross_realm_transform_readable(cx.into(), &port2, CanGc::from_cx(cx));
+        proxy_readable.setup_cross_realm_transform_readable(cx, &port2);
 
         // Step 2. Let writableRecord be !
         // StructuredDeserializeWithTransfer(dataHolder.[[writable]], the
         // current Realm).
         let proxy_writable = WritableStream::new_with_proto(owner, None, CanGc::from_cx(cx));
-        proxy_writable.setup_cross_realm_transform_writable(cx.into(), &port1, CanGc::from_cx(cx));
+        proxy_writable.setup_cross_realm_transform_writable(cx, &port1);
 
         // Step 3. Set value.[[readable]] to readableRecord.[[Deserialized]].
         // Step 4. Set value.[[writable]] to writableRecord.[[Deserialized]].

--- a/components/script/dom/stream/transformstreamdefaultcontroller.rs
+++ b/components/script/dom/stream/transformstreamdefaultcontroller.rs
@@ -611,7 +611,7 @@ impl TransformStreamDefaultController {
 
         // Let enqueueResult be ReadableStreamDefaultControllerEnqueue(readableController, chunk).
         // If enqueueResult is an abrupt completion,
-        if let Err(error) = readable_controller.enqueue(cx.into(), chunk, CanGc::from_cx(cx)) {
+        if let Err(error) = readable_controller.enqueue(cx, chunk) {
             // Perform ! TransformStreamErrorWritableAndUnblockWrite(stream, enqueueResult.[[Value]]).
             rooted!(&in(cx) let mut rooted_error = UndefinedValue());
             error.clone().to_jsval(
@@ -620,12 +620,7 @@ impl TransformStreamDefaultController {
                 rooted_error.handle_mut(),
                 CanGc::from_cx(cx),
             );
-            stream.error_writable_and_unblock_write(
-                cx.into(),
-                global,
-                rooted_error.handle(),
-                CanGc::from_cx(cx),
-            );
+            stream.error_writable_and_unblock_write(cx, global, rooted_error.handle());
 
             // Throw stream.[[readable]].[[storedError]].
             unsafe {
@@ -692,7 +687,7 @@ impl TransformStreamDefaultController {
     }
 
     /// <https://streams.spec.whatwg.org/#transform-stream-default-controller-terminate>
-    pub(crate) fn terminate(&self, cx: SafeJSContext, global: &GlobalScope, can_gc: CanGc) {
+    fn terminate(&self, cx: &mut js::context::JSContext, global: &GlobalScope) {
         // Let stream be controller.[[stream]].
         let stream = self.stream.get().expect("stream is null");
 
@@ -701,15 +696,20 @@ impl TransformStreamDefaultController {
         let readable_controller = readable.get_default_controller();
 
         // Perform ! ReadableStreamDefaultControllerClose(readableController).
-        readable_controller.close(can_gc);
+        readable_controller.close(CanGc::from_cx(cx));
 
         // Let error be a TypeError exception indicating that the stream has been terminated.
         let error = Error::Type(c"stream has been terminated".to_owned());
 
         // Perform ! TransformStreamErrorWritableAndUnblockWrite(stream, error).
-        rooted!(in(*cx) let mut rooted_error = UndefinedValue());
-        error.to_jsval(cx, global, rooted_error.handle_mut(), can_gc);
-        stream.error_writable_and_unblock_write(cx, global, rooted_error.handle(), can_gc);
+        rooted!(&in(cx) let mut rooted_error = UndefinedValue());
+        error.to_jsval(
+            cx.into(),
+            global,
+            rooted_error.handle_mut(),
+            CanGc::from_cx(cx),
+        );
+        stream.error_writable_and_unblock_write(cx, global, rooted_error.handle());
     }
 }
 
@@ -744,9 +744,9 @@ impl TransformStreamDefaultControllerMethods<crate::DomTypeHolder>
     }
 
     /// <https://streams.spec.whatwg.org/#ts-default-controller-terminate>
-    fn Terminate(&self, can_gc: CanGc) -> Fallible<()> {
+    fn Terminate(&self, cx: &mut js::context::JSContext) -> Fallible<()> {
         // Perform ? TransformStreamDefaultControllerTerminate(this).
-        self.terminate(GlobalScope::get_cx(), &self.global(), can_gc);
+        self.terminate(cx, &self.global());
         Ok(())
     }
 }

--- a/components/script/dom/stream/writablestream.rs
+++ b/components/script/dom/stream/writablestream.rs
@@ -62,15 +62,14 @@ struct AbortAlgorithmFulfillmentHandler {
 
 impl Callback for AbortAlgorithmFulfillmentHandler {
     fn callback(&self, cx: &mut CurrentRealm, _v: SafeHandleValue) {
-        let can_gc = CanGc::from_cx(cx);
-        let cx: SafeJSContext = cx.into();
         // Resolve abortRequest’s promise with undefined.
-        self.abort_request_promise.resolve_native(&(), can_gc);
+        self.abort_request_promise
+            .resolve_native(&(), CanGc::from_cx(cx));
 
         // Perform ! WritableStreamRejectCloseAndClosedPromiseIfNeeded(stream).
         self.stream
             .as_rooted()
-            .reject_close_and_closed_promise_if_needed(cx, can_gc);
+            .reject_close_and_closed_promise_if_needed(cx);
     }
 }
 
@@ -88,15 +87,14 @@ struct AbortAlgorithmRejectionHandler {
 
 impl Callback for AbortAlgorithmRejectionHandler {
     fn callback(&self, cx: &mut CurrentRealm, reason: SafeHandleValue) {
-        let can_gc = CanGc::from_cx(cx);
-        let cx: SafeJSContext = cx.into();
         // Reject abortRequest’s promise with reason.
-        self.abort_request_promise.reject_native(&reason, can_gc);
+        self.abort_request_promise
+            .reject_native(&reason, CanGc::from_cx(cx));
 
         // Perform ! WritableStreamRejectCloseAndClosedPromiseIfNeeded(stream).
         self.stream
             .as_rooted()
-            .reject_close_and_closed_promise_if_needed(cx, can_gc);
+            .reject_close_and_closed_promise_if_needed(cx);
     }
 }
 
@@ -254,7 +252,7 @@ impl WritableStream {
     }
 
     /// <https://streams.spec.whatwg.org/#writable-stream-finish-erroring>
-    pub(crate) fn finish_erroring(&self, cx: SafeJSContext, global: &GlobalScope, can_gc: CanGc) {
+    pub(crate) fn finish_erroring(&self, cx: &mut js::context::JSContext, global: &GlobalScope) {
         // Assert: stream.[[state]] is "erroring".
         assert!(self.is_erroring());
 
@@ -271,14 +269,14 @@ impl WritableStream {
         controller.perform_error_steps();
 
         // Let storedError be stream.[[storedError]].
-        rooted!(in(*cx) let mut stored_error = UndefinedValue());
+        rooted!(&in(cx) let mut stored_error = UndefinedValue());
         self.get_stored_error(stored_error.handle_mut());
 
         // For each writeRequest of stream.[[writeRequests]]:
         let write_requests = mem::take(&mut *self.write_requests.borrow_mut());
         for request in write_requests {
             // Reject writeRequest with storedError.
-            request.reject(cx, stored_error.handle(), can_gc);
+            request.reject(cx.into(), stored_error.handle(), CanGc::from_cx(cx));
         }
 
         // Set stream.[[writeRequests]] to an empty list.
@@ -287,7 +285,7 @@ impl WritableStream {
         // If stream.[[pendingAbortRequest]] is undefined,
         if self.pending_abort_request.borrow().is_none() {
             // Perform ! WritableStreamRejectCloseAndClosedPromiseIfNeeded(stream).
-            self.reject_close_and_closed_promise_if_needed(cx, can_gc);
+            self.reject_close_and_closed_promise_if_needed(cx);
 
             // Return.
             return;
@@ -295,35 +293,37 @@ impl WritableStream {
 
         // Let abortRequest be stream.[[pendingAbortRequest]].
         // Set stream.[[pendingAbortRequest]] to undefined.
-        rooted!(in(*cx) let pending_abort_request = self.pending_abort_request.borrow_mut().take());
+        rooted!(&in(cx) let pending_abort_request = self.pending_abort_request.borrow_mut().take());
         if let Some(pending_abort_request) = &*pending_abort_request {
             // If abortRequest’s was already erroring is true,
             if pending_abort_request.was_already_erroring {
                 // Reject abortRequest’s promise with storedError.
-                pending_abort_request
-                    .promise
-                    .reject(cx, stored_error.handle(), can_gc);
+                pending_abort_request.promise.reject(
+                    cx.into(),
+                    stored_error.handle(),
+                    CanGc::from_cx(cx),
+                );
 
                 // Perform ! WritableStreamRejectCloseAndClosedPromiseIfNeeded(stream).
-                self.reject_close_and_closed_promise_if_needed(cx, can_gc);
+                self.reject_close_and_closed_promise_if_needed(cx);
 
                 // Return.
                 return;
             }
 
             // Let promise be ! stream.[[controller]].[[AbortSteps]](abortRequest’s reason).
-            rooted!(in(*cx) let mut reason = UndefinedValue());
+            rooted!(&in(cx) let mut reason = UndefinedValue());
             reason.set(pending_abort_request.reason.get());
-            let promise = controller.abort_steps(cx, global, reason.handle(), can_gc);
+            let promise = controller.abort_steps(cx, global, reason.handle());
 
             // Upon fulfillment of promise,
-            rooted!(in(*cx) let mut fulfillment_handler = Some(AbortAlgorithmFulfillmentHandler {
+            rooted!(&in(cx) let mut fulfillment_handler = Some(AbortAlgorithmFulfillmentHandler {
                 stream: Dom::from_ref(self),
                 abort_request_promise: pending_abort_request.promise.clone(),
             }));
 
             // Upon rejection of promise with reason r,
-            rooted!(in(*cx) let mut rejection_handler = Some(AbortAlgorithmRejectionHandler {
+            rooted!(&in(cx) let mut rejection_handler = Some(AbortAlgorithmRejectionHandler {
                 stream: Dom::from_ref(self),
                 abort_request_promise: pending_abort_request.promise.clone(),
             }));
@@ -332,20 +332,20 @@ impl WritableStream {
                 global,
                 fulfillment_handler.take().map(|h| Box::new(h) as Box<_>),
                 rejection_handler.take().map(|h| Box::new(h) as Box<_>),
-                can_gc,
+                CanGc::from_cx(cx),
             );
             let realm = enter_realm(global);
             let comp = InRealm::Entered(&realm);
-            promise.append_native_handler(&handler, comp, can_gc);
+            promise.append_native_handler(&handler, comp, CanGc::from_cx(cx));
         }
     }
 
     /// <https://streams.spec.whatwg.org/#writable-stream-reject-close-and-closed-promise-if-needed>
-    fn reject_close_and_closed_promise_if_needed(&self, cx: SafeJSContext, can_gc: CanGc) {
+    fn reject_close_and_closed_promise_if_needed(&self, cx: &mut js::context::JSContext) {
         // Assert: stream.[[state]] is "errored".
         assert!(self.is_errored());
 
-        rooted!(in(*cx) let mut stored_error = UndefinedValue());
+        rooted!(&in(cx) let mut stored_error = UndefinedValue());
         self.get_stored_error(stored_error.handle_mut());
 
         // If stream.[[closeRequest]] is not undefined
@@ -355,7 +355,7 @@ impl WritableStream {
             assert!(self.in_flight_close_request.borrow().is_none());
 
             // Reject stream.[[closeRequest]] with stream.[[storedError]].
-            close_request.reject_native(&stored_error.handle(), can_gc)
+            close_request.reject_native(&stored_error.handle(), CanGc::from_cx(cx))
 
             // Set stream.[[closeRequest]] to undefined.
             // Done with `take` above.
@@ -365,7 +365,7 @@ impl WritableStream {
         // If writer is not undefined,
         if let Some(writer) = self.writer.get() {
             // Reject writer.[[closedPromise]] with stream.[[storedError]].
-            writer.reject_closed_promise_with_stored_error(&stored_error.handle(), can_gc);
+            writer.reject_closed_promise_with_stored_error(cx, &stored_error.handle());
 
             // Set writer.[[closedPromise]].[[PromiseIsHandled]] to true.
             writer.set_close_promise_is_handled();
@@ -397,10 +397,9 @@ impl WritableStream {
     /// <https://streams.spec.whatwg.org/#writable-stream-start-erroring>
     pub(crate) fn start_erroring(
         &self,
-        cx: SafeJSContext,
+        cx: &mut js::context::JSContext,
         global: &GlobalScope,
         error: SafeHandleValue,
-        can_gc: CanGc,
     ) {
         // Assert: stream.[[storedError]] is undefined.
         assert!(self.stored_error.get().is_undefined());
@@ -423,30 +422,29 @@ impl WritableStream {
         // Let writer be stream.[[writer]].
         if let Some(writer) = self.writer.get() {
             // If writer is not undefined, perform ! WritableStreamDefaultWriterEnsureReadyPromiseRejected
-            writer.ensure_ready_promise_rejected(global, error, can_gc);
+            writer.ensure_ready_promise_rejected(global, error, CanGc::from_cx(cx));
         }
 
         // If ! WritableStreamHasOperationMarkedInFlight(stream) is false and controller.[[started]] is true
         if !self.has_operations_marked_inflight() && controller.started() {
             // perform ! WritableStreamFinishErroring
-            self.finish_erroring(cx, global, can_gc);
+            self.finish_erroring(cx, global);
         }
     }
 
     /// <https://streams.spec.whatwg.org/#writable-stream-deal-with-rejection>
     pub(crate) fn deal_with_rejection(
         &self,
-        cx: SafeJSContext,
+        cx: &mut js::context::JSContext,
         global: &GlobalScope,
         error: SafeHandleValue,
-        can_gc: CanGc,
     ) {
         // Let state be stream.[[state]].
 
         // If state is "writable",
         if self.is_writable() {
             // Perform ! WritableStreamStartErroring(stream, error).
-            self.start_erroring(cx, global, error, can_gc);
+            self.start_erroring(cx, global, error);
 
             // Return.
             return;
@@ -456,7 +454,7 @@ impl WritableStream {
         assert!(self.is_erroring());
 
         // Perform ! WritableStreamFinishErroring(stream).
-        self.finish_erroring(cx, global, can_gc);
+        self.finish_erroring(cx, global);
     }
 
     /// <https://streams.spec.whatwg.org/#writable-stream-mark-first-write-request-in-flight>
@@ -549,10 +547,9 @@ impl WritableStream {
     /// <https://streams.spec.whatwg.org/#writable-stream-finish-in-flight-close-with-error>
     pub(crate) fn finish_in_flight_close_with_error(
         &self,
-        cx: SafeJSContext,
+        cx: &mut js::context::JSContext,
         global: &GlobalScope,
         error: SafeHandleValue,
-        can_gc: CanGc,
     ) {
         let Some(in_flight_close_request) = self.in_flight_close_request.borrow_mut().take() else {
             // Assert: stream.[[inFlightCloseRequest]] is not undefined.
@@ -560,7 +557,7 @@ impl WritableStream {
         };
 
         // Reject stream.[[inFlightCloseRequest]] with error.
-        in_flight_close_request.reject_native(&error, can_gc);
+        in_flight_close_request.reject_native(&error, CanGc::from_cx(cx));
 
         // Set stream.[[inFlightCloseRequest]] to undefined.
         // Done above with `take`.
@@ -569,26 +566,27 @@ impl WritableStream {
         assert!(self.is_erroring() || self.is_writable());
 
         // If stream.[[pendingAbortRequest]] is not undefined,
-        rooted!(in(*cx) let pending_abort_request = self.pending_abort_request.borrow_mut().take());
+        rooted!(&in(cx) let pending_abort_request = self.pending_abort_request.borrow_mut().take());
         if let Some(pending_abort_request) = &*pending_abort_request {
             // Reject stream.[[pendingAbortRequest]]'s promise with error.
-            pending_abort_request.promise.reject_native(&error, can_gc);
+            pending_abort_request
+                .promise
+                .reject_native(&error, CanGc::from_cx(cx));
 
             // Set stream.[[pendingAbortRequest]] to undefined.
             // Done above with `take`.
         }
 
         // Perform ! WritableStreamDealWithRejection(stream, error).
-        self.deal_with_rejection(cx, global, error, can_gc);
+        self.deal_with_rejection(cx, global, error);
     }
 
     /// <https://streams.spec.whatwg.org/#writable-stream-finish-in-flight-write-with-error>
     pub(crate) fn finish_in_flight_write_with_error(
         &self,
-        cx: SafeJSContext,
+        cx: &mut js::context::JSContext,
         global: &GlobalScope,
         error: SafeHandleValue,
-        can_gc: CanGc,
     ) {
         let Some(in_flight_write_request) = self.in_flight_write_request.borrow_mut().take() else {
             // Assert: stream.[[inFlightWriteRequest]] is not undefined.
@@ -596,7 +594,7 @@ impl WritableStream {
         };
 
         // Reject stream.[[inFlightWriteRequest]] with error.
-        in_flight_write_request.reject_native(&error, can_gc);
+        in_flight_write_request.reject_native(&error, CanGc::from_cx(cx));
 
         // Set stream.[[inFlightWriteRequest]] to undefined.
         // Done above with `take`.
@@ -605,7 +603,7 @@ impl WritableStream {
         assert!(self.is_erroring() || self.is_writable());
 
         // Perform ! WritableStreamDealWithRejection(stream, error).
-        self.deal_with_rejection(cx, global, error, can_gc);
+        self.deal_with_rejection(cx, global, error);
     }
 
     pub(crate) fn get_writer(&self) -> Option<DomRoot<WritableStreamDefaultWriter>> {
@@ -730,7 +728,7 @@ impl WritableStream {
         // If wasAlreadyErroring is false,
         if !was_already_erroring {
             // perform ! WritableStreamStartErroring(stream, reason)
-            self.start_erroring(cx.into(), global, reason, CanGc::from_cx(cx));
+            self.start_erroring(cx, global, reason);
         }
 
         // Return promise.
@@ -869,9 +867,8 @@ impl WritableStream {
     /// <https://streams.spec.whatwg.org/#abstract-opdef-setupcrossrealmtransformwritable>
     pub(crate) fn setup_cross_realm_transform_writable(
         &self,
-        cx: SafeJSContext,
+        cx: &mut js::context::JSContext,
         port: &MessagePort,
-        can_gc: CanGc,
     ) {
         let port_id = port.message_port_id();
         let global = self.global();
@@ -881,12 +878,16 @@ impl WritableStream {
 
         // Let sizeAlgorithm be an algorithm that returns 1.
         // Re-ordered because of the need to pass it to `new`.
-        let size_algorithm = extract_size_algorithm(&QueuingStrategy::default(), can_gc);
+        let size_algorithm =
+            extract_size_algorithm(&QueuingStrategy::default(), CanGc::from_cx(cx));
 
         // Note: other algorithms defined in the controller at call site.
 
         // Let backpressurePromise be a new promise.
-        let backpressure_promise = Rc::new(RefCell::new(Some(Promise::new(&global, can_gc))));
+        let backpressure_promise = Rc::new(RefCell::new(Some(Promise::new(
+            &global,
+            CanGc::from_cx(cx),
+        ))));
 
         // Let controller be a new WritableStreamDefaultController.
         let controller = WritableStreamDefaultController::new(
@@ -897,23 +898,23 @@ impl WritableStream {
             },
             1.0,
             size_algorithm,
-            can_gc,
+            CanGc::from_cx(cx),
         );
 
         // Add a handler for port’s message event with the following steps:
         // Add a handler for port’s messageerror event with the following steps:
-        rooted!(in(*cx) let cross_realm_transform_writable = CrossRealmTransformWritable {
+        rooted!(&in(cx) let cross_realm_transform_writable = CrossRealmTransformWritable {
             controller: Dom::from_ref(&controller),
             backpressure_promise,
         });
         global.note_cross_realm_transform_writable(&cross_realm_transform_writable, port_id);
 
         // Enable port’s port message queue.
-        port.Start(can_gc);
+        port.Start(cx);
 
         // Perform ! SetUpWritableStreamDefaultController
         controller
-            .setup(cx, &global, self, can_gc)
+            .setup(cx.into(), &global, self, CanGc::from_cx(cx))
             .expect("Setup for transfer cannot fail");
     }
     /// <https://streams.spec.whatwg.org/#set-up-writable-stream-default-controller-from-underlying-sink>
@@ -1161,15 +1162,19 @@ impl CrossRealmTransformWritable {
     #[expect(unsafe_code)]
     pub(crate) fn handle_message(
         &self,
-        cx: SafeJSContext,
+        cx: &mut CurrentRealm,
         global: &GlobalScope,
         message: SafeHandleValue,
-        _realm: InRealm,
-        can_gc: CanGc,
     ) {
-        rooted!(in(*cx) let mut value = UndefinedValue());
-        let type_string =
-            unsafe { get_type_and_value_from_message(cx, message, value.handle_mut(), can_gc) };
+        rooted!(&in(cx) let mut value = UndefinedValue());
+        let type_string = unsafe {
+            get_type_and_value_from_message(
+                cx.into(),
+                message,
+                value.handle_mut(),
+                CanGc::from_cx(cx),
+            )
+        };
 
         // If type is "pull",
         // Done below as the steps are the same for both types.
@@ -1177,8 +1182,7 @@ impl CrossRealmTransformWritable {
         // Otherwise, if type is "error",
         if type_string == "error" {
             // Perform ! WritableStreamDefaultControllerErrorIfNeeded(controller, value).
-            self.controller
-                .error_if_needed(cx, value.handle(), global, can_gc);
+            self.controller.error_if_needed(cx, value.handle(), global);
         }
 
         let backpressure_promise = self.backpressure_promise.borrow_mut().take();
@@ -1187,7 +1191,7 @@ impl CrossRealmTransformWritable {
         // If backpressurePromise is not undefined,
         if let Some(promise) = backpressure_promise {
             // Resolve backpressurePromise with undefined.
-            promise.resolve_native(&(), can_gc);
+            promise.resolve_native(&(), CanGc::from_cx(cx));
 
             // Set backpressurePromise to undefined.
             // Done above with `take`.
@@ -1198,26 +1202,24 @@ impl CrossRealmTransformWritable {
     /// Add a handler for port’s messageerror event with the following steps:
     pub(crate) fn handle_error(
         &self,
-        cx: SafeJSContext,
+        cx: &mut CurrentRealm,
         global: &GlobalScope,
         port: &MessagePort,
-        _realm: InRealm,
-        can_gc: CanGc,
     ) {
         // Let error be a new "DataCloneError" DOMException.
-        let error = DOMException::new(global, DOMErrorName::DataCloneError, can_gc);
-        rooted!(in(*cx) let mut rooted_error = UndefinedValue());
-        error.safe_to_jsval(cx, rooted_error.handle_mut(), can_gc);
+        let error = DOMException::new(global, DOMErrorName::DataCloneError, CanGc::from_cx(cx));
+        rooted!(&in(cx) let mut rooted_error = UndefinedValue());
+        error.safe_to_jsval(cx.into(), rooted_error.handle_mut(), CanGc::from_cx(cx));
 
         // Perform ! CrossRealmTransformSendError(port, error).
-        port.cross_realm_transform_send_error(rooted_error.handle(), can_gc);
+        port.cross_realm_transform_send_error(rooted_error.handle(), CanGc::from_cx(cx));
 
         // Perform ! WritableStreamDefaultControllerErrorIfNeeded(controller, error).
         self.controller
-            .error_if_needed(cx, rooted_error.handle(), global, can_gc);
+            .error_if_needed(cx, rooted_error.handle(), global);
 
         // Disentangle port.
-        global.disentangle_port(port, can_gc);
+        global.disentangle_port(port, CanGc::from_cx(cx));
     }
 }
 
@@ -1257,7 +1259,7 @@ impl Transferable for WritableStream {
         let readable = ReadableStream::new_with_proto(&global, None, CanGc::from_cx(cx));
 
         // Step 6. Perform ! SetUpCrossRealmTransformReadable(readable, port1).
-        readable.setup_cross_realm_transform_readable(cx.into(), &port_1, CanGc::from_cx(cx));
+        readable.setup_cross_realm_transform_readable(cx, &port_1);
 
         // Step 7. Let promise be ! ReadableStreamPipeTo(readable, value, false, false, false).
         let promise = readable.pipe_to(cx, &global, self, false, false, false, None);
@@ -1289,11 +1291,7 @@ impl Transferable for WritableStream {
         let transferred_port = MessagePort::transfer_receive(cx, owner, id, port_impl)?;
 
         // Step 3. Perform ! SetUpCrossRealmTransformWritable(value, port).
-        value.setup_cross_realm_transform_writable(
-            cx.into(),
-            &transferred_port,
-            CanGc::from_cx(cx),
-        );
+        value.setup_cross_realm_transform_writable(cx, &transferred_port);
         Ok(value)
     }
 

--- a/components/script/dom/stream/writablestreamdefaultcontroller.rs
+++ b/components/script/dom/stream/writablestreamdefaultcontroller.rs
@@ -69,7 +69,7 @@ impl Callback for CloseAlgorithmRejectionHandler {
         let global = GlobalScope::from_current_realm(cx);
 
         // Perform ! WritableStreamFinishInFlightCloseWithError(stream, reason).
-        stream.finish_in_flight_close_with_error(cx.into(), &global, v, CanGc::from_cx(cx));
+        stream.finish_in_flight_close_with_error(cx, &global, v);
     }
 }
 
@@ -135,7 +135,7 @@ impl Callback for StartAlgorithmRejectionHandler {
         let global = GlobalScope::from_current_realm(cx);
 
         // Perform ! WritableStreamDealWithRejection(stream, r).
-        stream.deal_with_rejection(cx.into(), &global, v, CanGc::from_cx(cx));
+        stream.deal_with_rejection(cx, &global, v);
     }
 }
 
@@ -267,7 +267,7 @@ impl Callback for WriteAlgorithmRejectionHandler {
         let global = GlobalScope::from_current_realm(cx);
 
         // Perform ! WritableStreamFinishInFlightWriteWithError(stream, reason).
-        stream.finish_in_flight_write_with_error(cx.into(), &global, v, CanGc::from_cx(cx));
+        stream.finish_in_flight_write_with_error(cx, &global, v);
     }
 }
 
@@ -582,10 +582,9 @@ impl WritableStreamDefaultController {
     /// <https://streams.spec.whatwg.org/#ref-for-abstract-opdef-writablestreamcontroller-abortsteps>
     pub(crate) fn abort_steps(
         &self,
-        cx: SafeJSContext,
+        cx: &mut js::context::JSContext,
         global: &GlobalScope,
         reason: SafeHandleValue,
-        can_gc: CanGc,
     ) -> Rc<Promise> {
         let result = match &self.underlying_sink_type {
             UnderlyingSinkType::Js {
@@ -594,7 +593,7 @@ impl WritableStreamDefaultController {
                 close: _,
                 write: _,
             } => {
-                rooted!(in(*cx) let this_object = self.underlying_sink_obj.get());
+                rooted!(&in(cx) let this_object = self.underlying_sink_obj.get());
                 let algo = abort.borrow().clone();
                 // Let result be the result of performing this.[[abortAlgorithm]], passing reason.
                 let result = if let Some(algo) = algo {
@@ -602,14 +601,19 @@ impl WritableStreamDefaultController {
                         &this_object.handle(),
                         Some(reason),
                         ExceptionHandling::Rethrow,
-                        can_gc,
+                        CanGc::from_cx(cx),
                     )
                 } else {
-                    Ok(Promise::new_resolved(global, cx, (), can_gc))
+                    Ok(Promise::new_resolved(
+                        global,
+                        cx.into(),
+                        (),
+                        CanGc::from_cx(cx),
+                    ))
                 };
                 result.unwrap_or_else(|e| {
-                    let promise = Promise::new(global, can_gc);
-                    promise.reject_error(e, can_gc);
+                    let promise = Promise::new(global, CanGc::from_cx(cx));
+                    promise.reject_error(e, CanGc::from_cx(cx));
                     promise
                 })
             },
@@ -618,26 +622,32 @@ impl WritableStreamDefaultController {
                 // <https://streams.spec.whatwg.org/#abstract-opdef-setupcrossrealmtransformwritable>
 
                 // Let result be PackAndPostMessageHandlingError(port, "error", reason).
-                let result = port.pack_and_post_message_handling_error("error", reason, can_gc);
+                let result =
+                    port.pack_and_post_message_handling_error("error", reason, CanGc::from_cx(cx));
 
                 // Disentangle port.
-                global.disentangle_port(port, can_gc);
+                global.disentangle_port(port, CanGc::from_cx(cx));
 
-                let promise = Promise::new(global, can_gc);
+                let promise = Promise::new(global, CanGc::from_cx(cx));
 
                 // If result is an abrupt completion, return a promise rejected with result.[[Value]]
                 if let Err(error) = result {
-                    promise.reject_error(error, can_gc);
+                    promise.reject_error(error, CanGc::from_cx(cx));
                 } else {
                     // Otherwise, return a promise resolved with undefined.
-                    promise.resolve_native(&(), can_gc);
+                    promise.resolve_native(&(), CanGc::from_cx(cx));
                 }
                 promise
             },
             UnderlyingSinkType::Transform(stream, _) => {
                 // Return ! TransformStreamDefaultSinkAbortAlgorithm(stream, reason).
                 stream
-                    .transform_stream_default_sink_abort_algorithm(cx, global, reason, can_gc)
+                    .transform_stream_default_sink_abort_algorithm(
+                        cx.into(),
+                        global,
+                        reason,
+                        CanGc::from_cx(cx),
+                    )
                     .expect("Transform stream default sink abort algorithm should not fail.")
             },
         };
@@ -866,7 +876,7 @@ impl WritableStreamDefaultController {
         // If state is "erroring",
         if stream.is_erroring() {
             // Perform ! WritableStreamFinishErroring(stream).
-            stream.finish_erroring(cx.into(), global, CanGc::from_cx(cx));
+            stream.finish_erroring(cx, global);
 
             // Return.
             return;
@@ -959,10 +969,9 @@ impl WritableStreamDefaultController {
     /// <https://streams.spec.whatwg.org/#writable-stream-default-controller-get-chunk-size>
     pub(crate) fn get_chunk_size(
         &self,
-        cx: SafeJSContext,
+        cx: &mut js::context::JSContext,
         global: &GlobalScope,
         chunk: SafeHandleValue,
-        can_gc: CanGc,
     ) -> f64 {
         // If controller.[[strategySizeAlgorithm]] is undefined, then:
         let Some(strategy_size) = self.strategy_size.borrow().clone() else {
@@ -978,7 +987,7 @@ impl WritableStreamDefaultController {
 
         // Let returnValue be the result of performing controller.[[strategySizeAlgorithm]],
         // passing in chunk, and interpreting the result as a completion record.
-        let result = strategy_size.Call__(chunk, ExceptionHandling::Rethrow, can_gc);
+        let result = strategy_size.Call__(chunk, ExceptionHandling::Rethrow, CanGc::from_cx(cx));
 
         match result {
             // Let chunkSize be result.[[Value]].
@@ -988,9 +997,14 @@ impl WritableStreamDefaultController {
 
                 // Perform ! WritableStreamDefaultControllerErrorIfNeeded(controller, returnValue.[[Value]]).
                 // Create a rooted value for the error.
-                rooted!(in(*cx) let mut rooted_error = UndefinedValue());
-                error.to_jsval(cx, global, rooted_error.handle_mut(), can_gc);
-                self.error_if_needed(cx, rooted_error.handle(), global, can_gc);
+                rooted!(&in(cx) let mut rooted_error = UndefinedValue());
+                error.to_jsval(
+                    cx.into(),
+                    global,
+                    rooted_error.handle_mut(),
+                    CanGc::from_cx(cx),
+                );
+                self.error_if_needed(cx, rooted_error.handle(), global);
 
                 // Return 1.
                 1.0
@@ -1025,7 +1039,7 @@ impl WritableStreamDefaultController {
                 rooted_error.handle_mut(),
                 CanGc::from_cx(cx),
             );
-            self.error_if_needed(cx.into(), rooted_error.handle(), global, CanGc::from_cx(cx));
+            self.error_if_needed(cx, rooted_error.handle(), global);
 
             // Return.
             return;
@@ -1052,10 +1066,9 @@ impl WritableStreamDefaultController {
     /// <https://streams.spec.whatwg.org/#writable-stream-default-controller-error-if-needed>
     pub(crate) fn error_if_needed(
         &self,
-        cx: SafeJSContext,
+        cx: &mut js::context::JSContext,
         error: SafeHandleValue,
         global: &GlobalScope,
-        can_gc: CanGc,
     ) {
         // Let stream be controller.[[stream]].
         let Some(stream) = self.stream.get() else {
@@ -1065,18 +1078,17 @@ impl WritableStreamDefaultController {
         // If stream.[[state]] is "writable",
         if stream.is_writable() {
             // Perform ! WritableStreamDefaultControllerError(controller, e).
-            self.error(&stream, cx, error, global, can_gc);
+            self.error(cx, &stream, error, global);
         }
     }
 
     /// <https://streams.spec.whatwg.org/#writable-stream-default-controller-error>
-    pub(crate) fn error(
+    fn error(
         &self,
+        cx: &mut js::context::JSContext,
         stream: &WritableStream,
-        cx: SafeJSContext,
         e: SafeHandleValue,
         global: &GlobalScope,
-        can_gc: CanGc,
     ) {
         // Let stream be controller.[[stream]].
         // Done above with the argument.
@@ -1088,7 +1100,7 @@ impl WritableStreamDefaultController {
         self.clear_algorithms();
 
         // Perform ! WritableStreamStartErroring(stream, error).
-        stream.start_erroring(cx, global, e, can_gc);
+        stream.start_erroring(cx, global, e);
     }
 }
 
@@ -1096,7 +1108,7 @@ impl WritableStreamDefaultControllerMethods<crate::DomTypeHolder>
     for WritableStreamDefaultController
 {
     /// <https://streams.spec.whatwg.org/#ws-default-controller-error>
-    fn Error(&self, cx: SafeJSContext, e: SafeHandleValue, realm: InRealm, can_gc: CanGc) {
+    fn Error(&self, cx: &mut CurrentRealm, e: SafeHandleValue) {
         // Let state be this.[[stream]].[[state]].
         let Some(stream) = self.stream.get() else {
             unreachable!("Controller should have a stream");
@@ -1107,10 +1119,10 @@ impl WritableStreamDefaultControllerMethods<crate::DomTypeHolder>
             return;
         }
 
-        let global = GlobalScope::from_safe_context(cx, realm);
+        let global = GlobalScope::from_current_realm(cx);
 
         // Perform ! WritableStreamDefaultControllerError(this, e).
-        self.error(&stream, cx, e, &global, can_gc);
+        self.error(cx, &stream, e, &global);
     }
 
     /// <https://streams.spec.whatwg.org/#ws-default-controller-signal>

--- a/components/script/dom/stream/writablestreamdefaultwriter.rs
+++ b/components/script/dom/stream/writablestreamdefaultwriter.rs
@@ -155,10 +155,12 @@ impl WritableStreamDefaultWriter {
 
     pub(crate) fn reject_closed_promise_with_stored_error(
         &self,
+        cx: &mut js::context::JSContext,
         error: &SafeHandleValue,
-        can_gc: CanGc,
     ) {
-        self.closed_promise.borrow().reject_native(error, can_gc);
+        self.closed_promise
+            .borrow()
+            .reject_native(error, CanGc::from_cx(cx));
     }
 
     pub(crate) fn set_close_promise_is_handled(&self) {
@@ -280,7 +282,7 @@ impl WritableStreamDefaultWriter {
         };
 
         // Let chunkSize be ! WritableStreamDefaultControllerGetChunkSize(controller, chunk).
-        let chunk_size = controller.get_chunk_size(cx.into(), global, chunk, CanGc::from_cx(cx));
+        let chunk_size = controller.get_chunk_size(cx, global, chunk);
 
         // If stream is not equal to writer.[[stream]],
         // return a promise rejected with a TypeError exception.

--- a/components/script_bindings/codegen/Bindings.conf
+++ b/components/script_bindings/codegen/Bindings.conf
@@ -641,8 +641,8 @@ DOMInterfaces = {
 
 'MessagePort': {
     'weakReferenceable': True,
-    'canGc': ['Close', 'GetOnmessage', 'SetOnmessage', 'Start'],
-    'cx': ['PostMessage', 'PostMessage_']
+    'canGc': ['Close', 'GetOnmessage'],
+    'cx': ['PostMessage', 'PostMessage_', 'SetOnmessage', 'Start']
 },
 
 'MessageEvent': {
@@ -989,8 +989,7 @@ DOMInterfaces = {
 },
 
 'WritableStreamDefaultController': {
-    'canGc': ['Error'],
-    'inRealms': ['Error'],
+    'realm': ['Error']
 },
 
 'WritableStreamDefaultWriter': {
@@ -999,8 +998,7 @@ DOMInterfaces = {
 },
 
 'TransformStreamDefaultController': {
-    'canGc': ['Terminate'],
-    'cx': ['Error', 'Enqueue']
+    'cx': ['Enqueue', 'Error', 'Terminate']
 },
 
 'WorkerNavigator': {


### PR DESCRIPTION
Pass `&mut JSContext` to more stream related code.

Testing: A successful build is enough.
Part of #42347
