### PR TITLE
script: Fix dynamically hiding or showing controls of a `<media>` element

### DIFF
--- a/components/script/dom/html/htmlmediaelement.rs
+++ b/components/script/dom/html/htmlmediaelement.rs
@@ -2802,8 +2802,15 @@ impl HTMLMediaElement {
     }
 
     fn render_controls(&self, cx: &mut JSContext) {
-        if self.upcast::<Element>().is_shadow_host() {
-            // Bail out if we are already showing the controls.
+        if let Some(id) = self.media_controls_id.borrow().as_ref() {
+            // The shadow tree for these elements was already created, but we still need to re-register
+            // it with the document
+            let Some(shadow_root) = self.upcast::<Element>().shadow_root() else {
+                unreachable!("Should never have a media ID without an existing shadow root");
+            };
+
+            self.owner_document()
+                .register_media_controls(&id, &shadow_root);
             return;
         }
 
@@ -2865,7 +2872,7 @@ impl HTMLMediaElement {
     }
 
     fn remove_controls(&self) {
-        if let Some(id) = self.media_controls_id.borrow_mut().take() {
+        if let Some(id) = self.media_controls_id.borrow().as_ref() {
             self.owner_document().unregister_media_controls(&id);
         }
     }

--- a/components/script/resources/media-controls.css
+++ b/components/script/resources/media-controls.css
@@ -1,3 +1,7 @@
+.hidden {
+    display: none !important;
+}
+
 button {
   display: inline-block;
   width: 24px;

--- a/components/script/resources/media-controls.js
+++ b/components/script/resources/media-controls.js
@@ -85,9 +85,13 @@
       this.media = this.controls.host;
 
       this.mutationObserver = new MutationObserver(() => {
-        // We can only get here if the `controls` attribute is removed.
-        this.cleanup();
+        if (this.media.controls) {
+          this.root.classList.remove("hidden");
+        } else {
+          this.root.classList.add("hidden");
+        }
       });
+
       this.mutationObserver.observe(this.media, {
         attributeFilter: ["controls"]
       });
@@ -237,16 +241,6 @@
       // Set initial state.
       this.state = this.media.paused ? PAUSED : PLAYING;
       this.onStateChange(null);
-    }
-
-    cleanup() {
-      this.mutationObserver.disconnect();
-      this.mediaEvents.forEach(event => {
-        this.media.removeEventListener(event, this);
-      });
-      this.controlEvents.forEach(({ el, type }) => {
-        el.removeEventListener(type, this);
-      });
     }
 
     // State change handler


### PR DESCRIPTION
This change makes it so that the control widget hides itself with CSS when the `controls` attribute is removed. In the past we used to delete the whole shadow tree, but that functionality doesn't exist anymore.

Testing: ???
Fixes: https://github.com/servo/servo/issues/43512
