### PR TITLE
script_bindings: Pass `&mut JSContext` to `CustomElementReaction::invoke`

### DIFF
--- a/components/script/dom/bindings/utils.rs
+++ b/components/script/dom/bindings/utils.rs
@@ -184,8 +184,8 @@ impl DomHelpers<crate::DomTypeHolder> for crate::DomTypeHolder {
     fn push_new_element_queue() {
         ScriptThread::custom_element_reaction_stack().push_new_element_queue()
     }
-    fn pop_current_element_queue(can_gc: CanGc) {
-        ScriptThread::custom_element_reaction_stack().pop_current_element_queue(can_gc)
+    fn pop_current_element_queue(cx: &mut js::context::JSContext) {
+        ScriptThread::custom_element_reaction_stack().pop_current_element_queue(cx)
     }
 
     fn reflect_dom_object<T, U>(obj: Box<T>, global: &U, can_gc: CanGc) -> DomRoot<T>

--- a/components/script/dom/create.rs
+++ b/components/script/dom/create.rs
@@ -158,7 +158,7 @@ fn create_html_element(
                 // Step 4.3. If synchronousCustomElements is true, then run this step while catching any exceptions:
                 CustomElementCreationMode::Synchronous => {
                     // Step 4.3.1. Upgrade result using definition.
-                    upgrade_element(definition, &element, CanGc::from_cx(cx));
+                    upgrade_element(cx, definition, &element);
                     // TODO: "If this step threw an exception exception:" steps.
                 },
                 // Step 4.4. Otherwise, enqueue a custom element upgrade reaction given result and definition.

--- a/components/script/dom/customelementregistry.rs
+++ b/components/script/dom/customelementregistry.rs
@@ -13,7 +13,9 @@ use html5ever::{LocalName, Namespace, Prefix, ns};
 use js::glue::UnwrapObjectStatic;
 use js::jsapi::{HandleValueArray, Heap, IsCallable, IsConstructor, JSAutoRealm, JSObject};
 use js::jsval::{BooleanValue, JSVal, NullValue, ObjectValue, UndefinedValue};
-use js::rust::wrappers::{Construct1, JS_GetProperty, SameValue};
+use js::realm::AutoRealm;
+use js::rust::wrappers::{Construct1, JS_GetProperty};
+use js::rust::wrappers2::SameValue;
 use js::rust::{HandleObject, MutableHandleValue};
 use rustc_hash::FxBuildHasher;
 use script_bindings::conversions::{SafeFromJSValConvertible, SafeToJSValConvertible};
@@ -47,7 +49,7 @@ use crate::dom::node::{Node, NodeTraits, ShadowIncluding};
 use crate::dom::promise::Promise;
 use crate::dom::window::Window;
 use crate::microtask::Microtask;
-use crate::realms::{InRealm, enter_realm};
+use crate::realms::{InRealm, enter_auto_realm};
 use crate::script_runtime::{CanGc, JSContext};
 use crate::script_thread::ScriptThread;
 
@@ -860,9 +862,9 @@ impl CustomElementDefinition {
 
 /// <https://html.spec.whatwg.org/multipage/#concept-upgrade-an-element>
 pub(crate) fn upgrade_element(
+    cx: &mut js::context::JSContext,
     definition: Rc<CustomElementDefinition>,
     element: &Element,
-    can_gc: CanGc,
 ) {
     // Step 1. If element's custom element state is not "undefined" or "uncustomized", then return.
     let state = element.get_custom_element_state();
@@ -908,7 +910,7 @@ pub(crate) fn upgrade_element(
         .push(ConstructionStackEntry::Element(DomRoot::from_ref(element)));
 
     // Steps 7-8, successful case
-    let result = run_upgrade_constructor(&definition, element, can_gc);
+    let result = run_upgrade_constructor(cx, &definition, element);
 
     // "regardless of whether the above steps threw an exception" step
     definition.construction_stack.borrow_mut().pop();
@@ -923,10 +925,15 @@ pub(crate) fn upgrade_element(
 
         // Step 8.exception.3
         let global = GlobalScope::current().expect("No current global");
-        let cx = GlobalScope::get_cx();
-        let ar = enter_realm(&*global);
-        throw_dom_exception(cx, &global, error, can_gc);
-        report_pending_exception(cx, InRealm::Entered(&ar), can_gc);
+
+        let mut realm = enter_auto_realm(cx, &*global);
+        let cx = &mut realm.current_realm();
+
+        let in_realm_proof = cx.into();
+        let in_realm = InRealm::Already(&in_realm_proof);
+
+        throw_dom_exception(cx.into(), &global, error, CanGc::from_cx(cx));
+        report_pending_exception(cx.into(), in_realm, CanGc::from_cx(cx));
 
         return;
     }
@@ -937,7 +944,7 @@ pub(crate) fn upgrade_element(
             // We know this element is is form-associated, so we can use the implementation of
             // `FormControl` for HTMLElement, which makes that assumption.
             // Step 9.1: Reset the form owner of element
-            html_element.reset_form_owner(can_gc);
+            html_element.reset_form_owner(CanGc::from_cx(cx));
             if let Some(form) = html_element.form_owner() {
                 // Even though the tree hasn't structurally mutated,
                 // HTMLCollections need to be invalidated.
@@ -977,18 +984,16 @@ pub(crate) fn upgrade_element(
 /// Steps 9.1-9.4
 #[expect(unsafe_code)]
 fn run_upgrade_constructor(
+    cx: &mut js::context::JSContext,
     definition: &CustomElementDefinition,
     element: &Element,
-    // This function can cause GC through AutoEntryScript::Drop, but we can't pass a CanGc there
-    can_gc: CanGc,
 ) -> ErrorResult {
     let constructor = &definition.constructor;
     let window = element.owner_window();
-    let cx = GlobalScope::get_cx();
-    rooted!(in(*cx) let constructor_val = ObjectValue(constructor.callback()));
-    rooted!(in(*cx) let mut element_val = UndefinedValue());
-    element.safe_to_jsval(cx, element_val.handle_mut(), can_gc);
-    rooted!(in(*cx) let mut construct_result = ptr::null_mut::<JSObject>());
+    rooted!(&in(cx) let constructor_val = ObjectValue(constructor.callback()));
+    rooted!(&in(cx) let mut element_val = UndefinedValue());
+    element.safe_to_jsval(cx.into(), element_val.handle_mut(), CanGc::from_cx(cx));
+    rooted!(&in(cx) let mut construct_result = ptr::null_mut::<JSObject>());
     {
         // Step 9.1. If definition's disable shadow is true and element's shadow root is non-null,
         // then throw a "NotSupportedError" DOMException.
@@ -997,7 +1002,9 @@ fn run_upgrade_constructor(
         }
 
         // Go into the constructor's realm
-        let _ac = JSAutoRealm::new(*cx, constructor.callback());
+        let mut realm = AutoRealm::new(cx, std::ptr::NonNull::new(constructor.callback()).unwrap());
+        let cx = &mut *realm;
+
         let args = HandleValueArray::empty();
         // Step 8.2. Set element's custom element state to "precustomized".
         element.set_custom_element_state(CustomElementState::Precustomized);
@@ -1008,7 +1015,7 @@ fn run_upgrade_constructor(
             run_a_callback::<DomTypeHolder, _>(window.upcast(), || {
                 if unsafe {
                     !Construct1(
-                        *cx,
+                        cx.raw_cx(),
                         constructor_val.handle(),
                         &args,
                         construct_result.handle_mut(),
@@ -1022,12 +1029,12 @@ fn run_upgrade_constructor(
         })?;
 
         let mut same = false;
-        rooted!(in(*cx) let construct_result_val = ObjectValue(construct_result.get()));
+        rooted!(&in(cx) let construct_result_val = ObjectValue(construct_result.get()));
 
         // Step 9.4. If SameValue(constructResult, element) is false, then throw a TypeError.
         if unsafe {
             !SameValue(
-                *cx,
+                cx,
                 construct_result_val.handle(),
                 element_val.handle(),
                 &mut same,
@@ -1073,22 +1080,22 @@ pub(crate) enum CustomElementReaction {
 
 impl CustomElementReaction {
     /// <https://html.spec.whatwg.org/multipage/#invoke-custom-element-reactions>
-    pub(crate) fn invoke(&self, element: &Element, can_gc: CanGc) {
+    pub(crate) fn invoke(&self, cx: &mut js::context::JSContext, element: &Element) {
         // Step 2.1
         match *self {
             CustomElementReaction::Upgrade(ref definition) => {
-                upgrade_element(definition.clone(), element, can_gc)
+                upgrade_element(cx, definition.clone(), element)
             },
             CustomElementReaction::Callback(ref callback, ref arguments) => {
                 // We're rooted, so it's safe to hand out a handle to objects in Heap
                 let arguments = arguments.iter().map(|arg| arg.as_handle_value()).collect();
-                rooted!(in(*GlobalScope::get_cx()) let mut value: JSVal);
+                rooted!(&in(cx) let mut value: JSVal);
                 let _ = callback.Call_(
                     element,
                     arguments,
                     value.handle_mut(),
                     ExceptionHandling::Report,
-                    can_gc,
+                    CanGc::from_cx(cx),
                 );
             },
         }
@@ -1139,12 +1146,12 @@ impl CustomElementReactionStack {
         self.stack.borrow_mut().push(ElementQueue::new());
     }
 
-    pub(crate) fn pop_current_element_queue(&self, can_gc: CanGc) {
+    pub(crate) fn pop_current_element_queue(&self, cx: &mut js::context::JSContext) {
         rooted_vec!(let mut stack);
         mem::swap(&mut *stack, &mut *self.stack.borrow_mut());
 
         if let Some(current_queue) = stack.last() {
-            current_queue.invoke_reactions(can_gc);
+            current_queue.invoke_reactions(cx);
         }
         stack.pop();
 
@@ -1154,9 +1161,9 @@ impl CustomElementReactionStack {
 
     /// <https://html.spec.whatwg.org/multipage/#enqueue-an-element-on-the-appropriate-element-queue>
     /// Step 4
-    pub(crate) fn invoke_backup_element_queue(&self, can_gc: CanGc) {
+    pub(crate) fn invoke_backup_element_queue(&self, cx: &mut js::context::JSContext) {
         // Step 4.1
-        self.backup_queue.invoke_reactions(can_gc);
+        self.backup_queue.invoke_reactions(cx);
 
         // Step 4.2
         self.processing_backup_element_queue
@@ -1369,10 +1376,10 @@ impl ElementQueue {
     }
 
     /// <https://html.spec.whatwg.org/multipage/#invoke-custom-element-reactions>
-    fn invoke_reactions(&self, can_gc: CanGc) {
+    fn invoke_reactions(&self, cx: &mut js::context::JSContext) {
         // Steps 1-2
         while let Some(element) = self.next_element() {
-            element.invoke_reactions(can_gc)
+            element.invoke_reactions(cx)
         }
         self.queue.borrow_mut().clear();
     }

--- a/components/script/dom/element.rs
+++ b/components/script/dom/element.rs
@@ -473,7 +473,7 @@ impl Element {
         }
     }
 
-    pub(crate) fn invoke_reactions(&self, can_gc: CanGc) {
+    pub(crate) fn invoke_reactions(&self, cx: &mut JSContext) {
         loop {
             rooted_vec!(let mut reactions);
             match *self.rare_data_mut() {
@@ -488,7 +488,7 @@ impl Element {
             }
 
             for reaction in reactions.iter() {
-                reaction.invoke(self, can_gc);
+                reaction.invoke(cx, self);
             }
 
             reactions.clear();

--- a/components/script/dom/servoparser/mod.rs
+++ b/components/script/dom/servoparser/mod.rs
@@ -1510,7 +1510,7 @@ fn insert(
             }
             parent.InsertBefore(cx, &n, reference_child).unwrap();
             if element_in_non_fragment {
-                custom_element_reaction_stack.pop_current_element_queue(CanGc::from_cx(cx));
+                custom_element_reaction_stack.pop_current_element_queue(cx);
             }
         },
         NodeOrText::AppendText(t) => {
@@ -1967,7 +1967,7 @@ fn create_element_for_token(
         // custom element reactions stack. (This will be the same element queue as was
         // pushed above.)
         // Step 12.2 Invoke custom element reactions in queue.
-        custom_element_reaction_stack.pop_current_element_queue(CanGc::from_cx(cx));
+        custom_element_reaction_stack.pop_current_element_queue(cx);
         // Step 12.3. Decrement document's throw-on-dynamic-markup-insertion counter.
         document.decrement_throw_on_dynamic_markup_insertion_counter();
     }

--- a/components/script/microtask.rs
+++ b/components/script/microtask.rs
@@ -163,7 +163,7 @@ impl MicrotaskQueue {
                         task.handler(cx);
                     },
                     Microtask::CustomElementReaction => {
-                        ScriptThread::invoke_backup_element_queue(CanGc::from_cx(cx));
+                        ScriptThread::invoke_backup_element_queue(cx);
                     },
                     Microtask::NotifyMutationObservers => {
                         ScriptThread::mutation_observers()

--- a/components/script/script_thread.rs
+++ b/components/script/script_thread.rs
@@ -848,11 +848,11 @@ impl ScriptThread {
         })
     }
 
-    pub(crate) fn invoke_backup_element_queue(can_gc: CanGc) {
+    pub(crate) fn invoke_backup_element_queue(cx: &mut js::context::JSContext) {
         with_script_thread(|script_thread| {
             script_thread
                 .custom_element_reaction_stack
-                .invoke_backup_element_queue(can_gc);
+                .invoke_backup_element_queue(cx);
         })
     }
 

--- a/components/script_bindings/codegen/codegen.py
+++ b/components/script_bindings/codegen/codegen.py
@@ -4187,7 +4187,7 @@ class CGCallGenerator(CGThing):
         ]))
 
         if hasCEReactions:
-            self.cgRoot.append(CGGeneric("<D as DomHelpers<D>>::pop_current_element_queue(CanGc::note());\n"))
+            self.cgRoot.append(CGGeneric("<D as DomHelpers<D>>::pop_current_element_queue(cx);\n"))
 
         if isFallible:
             if static:

--- a/components/script_bindings/interfaces.rs
+++ b/components/script_bindings/interfaces.rs
@@ -54,7 +54,7 @@ pub trait DomHelpers<D: DomTypes> {
     fn interface_map() -> &'static phf::Map<&'static [u8], Interface>;
 
     fn push_new_element_queue();
-    fn pop_current_element_queue(can_gc: CanGc);
+    fn pop_current_element_queue(cx: &mut js::context::JSContext);
 
     fn reflect_dom_object<T, U>(obj: Box<T>, global: &U, can_gc: CanGc) -> DomRoot<T>
     where


### PR DESCRIPTION
Pass `&mut JSContext` to `CustomElementReaction::invoke` and `upgrade_element` algorithm. 

Testing: A successful build is enough
Part of #40600 
