### PR TITLE
net: Clear cache entries when corsWithPreflightResponse has network error

### DIFF
--- a/components/net/fetch/cors_cache.rs
+++ b/components/net/fetch/cors_cache.rs
@@ -189,4 +189,11 @@ impl CorsCache {
         self.cleanup();
         self.0.push(entry);
     }
+
+    /// <https://fetch.spec.whatwg.org/#concept-cache-clear>
+    pub(crate) fn clear_entries_for_origin_and_url(&mut self, origin: &Origin, url: &ServoUrl) {
+        self.cleanup();
+        self.0
+            .retain(|cache_entry| !(cache_entry.origin == *origin && cache_entry.url == *url));
+    }
 }

--- a/components/net/fetch/methods.rs
+++ b/components/net/fetch/methods.rs
@@ -560,9 +560,12 @@ pub async fn main_fetch(
                             !is_cors_safelisted_request_header(&name, &value)
                         })))
             {
-                // Substep 1.
+                // Substep 1. Set request’s response tainting to "cors".
                 request.response_tainting = ResponseTainting::CorsTainting;
-                // Substep 2.
+                let origin = request.origin.clone();
+                let url = request.current_url().clone();
+                // Substep 2. Let corsWithPreflightResponse be the result
+                // of running override fetch given "http-fetch", fetchParams, and true.
                 let response = http_fetch(
                     fetch_params,
                     cache,
@@ -574,9 +577,10 @@ pub async fn main_fetch(
                     context,
                 )
                 .await;
-                // Substep 3.
+                // Substep 3. If corsWithPreflightResponse is a network error,
+                // then clear cache entries using request.
                 if response.is_network_error() {
-                    // TODO clear cache entries using request
+                    cache.clear_entries_for_origin_and_url(&origin, &url);
                 }
                 // Substep 4.
                 response


### PR DESCRIPTION
This was a TODO left here. [Spec](https://fetch.spec.whatwg.org/#concept-main-fetch:~:text=If%20corsWithPreflightResponse%20is%20a%20network%20error%2C%20then%20clear%20cache%20entries%20using%20request%2E).

Testing: Don't know how to add test for this :(
