### PR TITLE
script: Use encoding-parsing algorithm in XMLHttpRequest::Open

### DIFF
--- a/components/script/dom/globalscope.rs
+++ b/components/script/dom/globalscope.rs
@@ -1374,6 +1374,17 @@ impl GlobalScope {
         }
     }
 
+    /// <https://html.spec.whatwg.org/multipage/#encoding-parsing-a-url>
+    pub(crate) fn encoding_parse_a_url(&self, url: &str) -> Result<ServoUrl, url::ParseError> {
+        if let Some(window) = self.downcast::<Window>() {
+            return window.Document().encoding_parse_a_url(url);
+        }
+
+        // encoding parsing for worker environments.
+        let base = self.api_base_url();
+        base.join(url)
+    }
+
     /// <https://streams.spec.whatwg.org/#abstract-opdef-setupcrossrealmtransformreadable>
     /// The "Add a handler for port’s message event with the following steps:"
     /// and "Add a handler for port’s messageerror event with the following steps:" part.

--- a/components/script/dom/xmlhttprequest.rs
+++ b/components/script/dom/xmlhttprequest.rs
@@ -362,10 +362,8 @@ impl XMLHttpRequestMethods<crate::DomTypeHolder> for XMLHttpRequest {
                     return Err(Error::Syntax(None));
                 }
 
-                // Step 2
-                let base = self.global().api_base_url();
-                // Step 6
-                let mut parsed_url = match base.join(&url.0) {
+                // Step 5 and 6
+                let mut parsed_url = match self.global().encoding_parse_a_url(&url.0) {
                     Ok(parsed) => parsed,
                     // Step 7
                     Err(_) => return Err(Error::Syntax(None)),

--- a/tests/wpt/meta/xhr/open-url-encoding.htm.ini
+++ b/tests/wpt/meta/xhr/open-url-encoding.htm.ini
@@ -1,6 +1,0 @@
-[open-url-encoding.htm]
-  [percent encode characters]
-    expected: PASS
-
-  [lone surrogate]
-    expected: PASS

--- a/tests/wpt/meta/xhr/open-url-encoding.htm.ini
+++ b/tests/wpt/meta/xhr/open-url-encoding.htm.ini
@@ -1,6 +1,6 @@
 [open-url-encoding.htm]
   [percent encode characters]
-    expected: FAIL
+    expected: PASS
 
   [lone surrogate]
-    expected: FAIL
+    expected: PASS


### PR DESCRIPTION
Add a new method to components/script/dom/globalscope.rs which checks if the global is a Window , then uses window.Document().encoding_parse_a_url(..) if so. For non-Window globals,  just use the existing logic of getting the api_base_url() value and calling join(..) on it.

Testing: Existing WPTs.
Fixes: #43509
