### PR TITLE
script: Implement support for `X-Frame-Options`

### DIFF
--- a/components/script/dom/document.rs
+++ b/components/script/dom/document.rs
@@ -460,7 +460,7 @@ pub(crate) struct Document {
     https_state: Cell<HttpsState>,
     /// The document's origin.
     #[no_trace]
-    origin: MutableOrigin,
+    origin: DomRefCell<MutableOrigin>,
     /// <https://html.spec.whatwg.org/multipage/#dom-document-referrer>
     referrer: Option<String>,
     /// <https://html.spec.whatwg.org/multipage/#target-element>
@@ -937,8 +937,14 @@ impl Document {
             }))
     }
 
-    pub(crate) fn origin(&self) -> &MutableOrigin {
-        &self.origin
+    pub(crate) fn origin(&self) -> Ref<'_, MutableOrigin> {
+        self.origin.borrow()
+    }
+
+    /// Part of <https://html.spec.whatwg.org/multipage/#navigate-ua-inline>
+    /// TODO: Remove this when we create documents after processing headers
+    pub(crate) fn mark_as_internal(&self) {
+        *self.origin.borrow_mut() = MutableOrigin::new(ImmutableOrigin::new_opaque());
     }
 
     pub(crate) fn set_protocol_handler_automation_mode(&self, mode: CustomHandlersAutomationMode) {
@@ -3994,7 +4000,7 @@ impl Document {
             unload_event_start: Cell::new(Default::default()),
             unload_event_end: Cell::new(Default::default()),
             https_state: Cell::new(HttpsState::None),
-            origin,
+            origin: DomRefCell::new(origin),
             referrer,
             target_element: MutNullableDom::new(None),
             policy_container: DomRefCell::new(PolicyContainer::default()),
@@ -4351,6 +4357,16 @@ impl Document {
 
     pub(crate) fn salvageable(&self) -> bool {
         self.salvageable.get()
+    }
+
+    /// <https://html.spec.whatwg.org/multipage/#make-document-unsalvageable>
+    pub(crate) fn make_document_unsalvageable(&self) {
+        // Step 1. Let details be a new not restored reason details whose reason is reason.
+        // TODO
+        // Step 2. Append details to document's bfcache blocking details.
+        // TODO
+        // Step 3. Set document's salvageable state to false.
+        self.salvageable.set(false);
     }
 
     /// <https://html.spec.whatwg.org/multipage/#appropriate-template-contents-owner-document>
@@ -5376,7 +5392,7 @@ impl DocumentMethods<crate::DomTypeHolder> for Document {
     /// <https://html.spec.whatwg.org/multipage/#dom-document-domain>
     fn Domain(&self) -> DOMString {
         // Step 1. Let effectiveDomain be this's origin's effective domain.
-        match self.origin.effective_domain() {
+        match self.origin().effective_domain() {
             // Step 2. If effectiveDomain is null, then return the empty string.
             None => DOMString::new(),
             // Step 3. Return effectiveDomain, serialized.
@@ -5401,7 +5417,7 @@ impl DocumentMethods<crate::DomTypeHolder> for Document {
         }
 
         // Step 3. Let effectiveDomain be this's origin's effective domain.
-        let effective_domain = match self.origin.effective_domain() {
+        let effective_domain = match self.origin().effective_domain() {
             Some(effective_domain) => effective_domain,
             // Step 4. If effectiveDomain is null, then throw a "SecurityError" DOMException.
             None => return Err(Error::Security(None)),
@@ -5418,7 +5434,7 @@ impl DocumentMethods<crate::DomTypeHolder> for Document {
         // TODO
 
         // Step 7. Set this's origin's domain to the result of parsing the given value.
-        self.origin.set_domain(host);
+        self.origin().set_domain(host);
 
         Ok(())
     }
@@ -6215,7 +6231,7 @@ impl DocumentMethods<crate::DomTypeHolder> for Document {
             return Ok(DOMString::new());
         }
 
-        if !self.origin.is_tuple() {
+        if !self.origin().is_tuple() {
             return Err(Error::Security(None));
         }
 
@@ -6237,7 +6253,7 @@ impl DocumentMethods<crate::DomTypeHolder> for Document {
             return Ok(());
         }
 
-        if !self.origin.is_tuple() {
+        if !self.origin().is_tuple() {
             return Err(Error::Security(None));
         }
 
@@ -6503,7 +6519,10 @@ impl DocumentMethods<crate::DomTypeHolder> for Document {
         let entry_responsible_document = GlobalScope::entry().as_window().Document();
 
         // Step 4
-        if !self.origin.same_origin(&entry_responsible_document.origin) {
+        if !self
+            .origin()
+            .same_origin(&entry_responsible_document.origin())
+        {
             return Err(Error::Security(None));
         }
 

--- a/components/script/dom/html/htmliframeelement.rs
+++ b/components/script/dom/html/htmliframeelement.rs
@@ -958,7 +958,7 @@ impl HTMLIFrameElementMethods<crate::DomTypeHolder> for HTMLIFrameElement {
         if !self
             .owner_document()
             .origin()
-            .same_origin_domain(document.origin())
+            .same_origin_domain(&document.origin())
         {
             return None;
         }

--- a/components/script/dom/location.rs
+++ b/components/script/dom/location.rs
@@ -212,7 +212,7 @@ impl Location {
             if let Some(document) = window_proxy.document().filter(|document| {
                 self.entry_settings_object()
                     .origin()
-                    .same_origin_domain(document.origin())
+                    .same_origin_domain(&document.origin())
             }) {
                 Ok(Some(document))
             } else {

--- a/components/script/dom/security/mod.rs
+++ b/components/script/dom/security/mod.rs
@@ -6,3 +6,4 @@ pub(crate) mod csp;
 pub(crate) mod csppolicyviolationreport;
 pub(crate) mod cspviolationreporttask;
 pub(crate) mod securitypolicyviolationevent;
+pub(crate) mod xframeoptions;

--- a/components/script/dom/security/xframeoptions.rs
+++ b/components/script/dom/security/xframeoptions.rs
@@ -1,0 +1,96 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+use content_security_policy::{CspList, PolicyDisposition};
+use http::header::HeaderMap;
+use hyper_serde::Serde;
+use net_traits::fetch::headers::get_decode_and_split_header_name;
+use rustc_hash::FxHashSet;
+use servo_url::MutableOrigin;
+
+use crate::dom::node::NodeTraits;
+use crate::dom::window::Window;
+
+/// <https://html.spec.whatwg.org/multipage/#check-a-navigation-response%027s-adherence-to-x-frame-options>
+pub(crate) fn check_a_navigation_response_adherence_to_x_frame_options(
+    window: &Window,
+    csp_list: Option<&CspList>,
+    destination_origin: &MutableOrigin,
+    headers: Option<&Serde<HeaderMap>>,
+) -> bool {
+    // Step 1. If navigable is not a child navigable, then return true.
+    if window.window_proxy().parent().is_none() {
+        return true;
+    }
+    // Step 2. For each policy of cspList:
+    if let Some(csp_list) = csp_list {
+        for policy in csp_list.0.iter() {
+            // Step 2.1. If policy's disposition is not "enforce", then continue.
+            if policy.disposition != PolicyDisposition::Enforce {
+                continue;
+            }
+            // Step 2.2. If policy's directive set contains a frame-ancestors directive, then return true.
+            if policy.contains_a_directive_whose_name_is("frame-ancestors") {
+                return true;
+            }
+        }
+    }
+    // Step 3. Let rawXFrameOptions be the result of getting, decoding,
+    // and splitting `X-Frame-Options` from response's header list.
+    let Some(headers) = headers else {
+        return true;
+    };
+    let Some(raw_xframe_options) = get_decode_and_split_header_name("X-Frame-Options", headers)
+    else {
+        return true;
+    };
+    // Step 4. Let xFrameOptions be a new set.
+    // Step 5. For each value of rawXFrameOptions, append value, converted to ASCII lowercase, to xFrameOptions.
+    let x_frame_options =
+        FxHashSet::from_iter(raw_xframe_options.iter().map(|value| value.to_lowercase()));
+    // Step 6. If xFrameOptions's size is greater than 1,
+    // and xFrameOptions contains any of "deny", "allowall", or "sameorigin", then return false.
+    if x_frame_options.len() > 1 &&
+        x_frame_options
+            .iter()
+            .any(|value| value == "deny" || value == "allowall" || value == "sameorigin")
+    {
+        return false;
+    }
+    // Step 7. If xFrameOptions's size is greater than 1, then return true.
+    if x_frame_options.len() > 1 {
+        return true;
+    }
+    let Some(first_item) = x_frame_options.iter().next() else {
+        return true;
+    };
+    // Step 8. If xFrameOptions[0] is "deny", then return false.
+    if first_item == "deny" {
+        return false;
+    }
+    // Step 9. If xFrameOptions[0] is "sameorigin", then:
+    if first_item == "sameorigin" {
+        let mut window_proxy = window.window_proxy();
+        // Step 9.2. While containerDocument is not null:
+        while let Some(container_element) = window_proxy.frame_element() {
+            // Step 9.1. Let containerDocument be navigable's container document.
+            let container_document = container_element.owner_document();
+            // Step 9.2.1. If containerDocument's origin is not same origin with destinationOrigin, then return false.
+            if !container_document.origin().same_origin(destination_origin) {
+                return false;
+            }
+            // Step 9.2.2. Set containerDocument to containerDocument's container document.
+            window_proxy = container_document.window().window_proxy()
+        }
+        // If the `frame_element` is None, it could be two options:
+        // 1. There is no parent, in which case we are top-level. We can stop the loop
+        // 2. There is a parent, but it isn't same origin. Therefore, we need to double
+        //    check here that we actually cover this case.
+        if window_proxy.parent().is_some() {
+            return false;
+        }
+    }
+    // Step 10. Return true.
+    true
+}

--- a/components/script/dom/servoparser/mod.rs
+++ b/components/script/dom/servoparser/mod.rs
@@ -80,6 +80,7 @@ use crate::dom::processingoptions::{
     LinkHeader, LinkProcessingPhase, extract_links_from_headers, process_link_headers,
 };
 use crate::dom::reporting::reportingendpoint::ReportingEndpoint;
+use crate::dom::security::xframeoptions::check_a_navigation_response_adherence_to_x_frame_options;
 use crate::dom::shadowroot::IsUserAgentWidget;
 use crate::dom::text::Text;
 use crate::dom::types::{HTMLElement, HTMLMediaElement, HTMLOptionElement};
@@ -1195,6 +1196,7 @@ impl ParserContext {
         cx: &mut js::context::JSContext,
     ) {
         self.is_synthesized_document = true;
+        parser.document.mark_as_internal();
         parser.push_string_input_chunk(page);
         parser.parse_sync(cx);
     }
@@ -1228,13 +1230,15 @@ impl ParserContext {
 impl FetchResponseListener for ParserContext {
     fn process_request_body(&mut self, _: RequestId) {}
 
+    /// Implements parts of
+    /// <https://html.spec.whatwg.org/multipage/#attempt-to-populate-the-history-entry's-document>
     fn process_response(
         &mut self,
         cx: &mut js::context::JSContext,
         _: RequestId,
         meta_result: Result<FetchMetadata, NetworkError>,
     ) {
-        let (metadata, error) = match meta_result {
+        let (metadata, mut error) = match meta_result {
             Ok(meta) => (
                 Some(match meta {
                     FetchMetadata::Unfiltered(m) => m,
@@ -1279,7 +1283,7 @@ impl FetchResponseListener for ParserContext {
         let parser = match ScriptThread::page_headers_available(
             self.webview_id,
             self.pipeline_id,
-            metadata,
+            metadata.as_ref(),
             cx,
         ) {
             Some(parser) => parser,
@@ -1291,7 +1295,44 @@ impl FetchResponseListener for ParserContext {
 
         let mut realm = enter_auto_realm(cx, &*parser.document);
         let cx = &mut realm;
-        let window = parser.document.window();
+        let document = &parser.document;
+        let window = document.window();
+
+        // https://html.spec.whatwg.org/multipage/#attempt-to-populate-the-history-entry%27s-document
+        // Step 4. Otherwise, if any of the following are true:
+        // navigationParams is null;
+        // TODO
+        // the result of should navigation response to navigation request of
+        // type in target be blocked by Content Security Policy? given
+        // navigationParams's request, navigationParams's response, navigationParams's policy container's CSP list,
+        // cspNavigationType, and navigable is "Blocked";
+        // TODO
+        // navigationParams's reserved environment is non-null and the result of
+        // checking a navigation response's adherence to its embedder policy given navigationParams's response,
+        // navigable, and navigationParams's policy container's embedder policy is false; or
+        // TODO
+        // the result of checking a navigation response's adherence to `X-Frame-Options`
+        // given navigationParams's response, navigable, navigationParams's policy container's CSP list,
+        // and navigationParams's origin is false,
+        if !check_a_navigation_response_adherence_to_x_frame_options(
+            window,
+            policy_container.csp_list.as_ref(),
+            &document.origin(),
+            metadata
+                .as_ref()
+                .and_then(|metadata| metadata.headers.as_ref()),
+        ) {
+            // Step 4.1. Set entry's document state's document to the result of creating a document for inline content
+            // that doesn't have a DOM, given navigable, null, navTimingType, and userInvolvement.
+            // The inline content should indicate to the user the sort of error that occurred.
+            error = Some(NetworkError::ContentSecurityPolicy);
+            // Step 4.2. Make document unsalvageable given entry's document state's document and "navigation-failure".
+            document.make_document_unsalvageable();
+            // Step 4.3. Set saveExtraDocumentState to false.
+            // TODO
+            // Step 4.4. If navigationParams is not null, then:
+            // TODO
+        }
 
         // From Step 23.8.3 of https://html.spec.whatwg.org/multipage/#navigate
         // Let finalSandboxFlags be the union of targetSnapshotParams's sandboxing flags and
@@ -1304,7 +1345,7 @@ impl FetchResponseListener for ParserContext {
             .as_ref()
             .and_then(|csp| csp.get_sandboxing_flag_set_for_document())
             .unwrap_or(SandboxingFlagSet::empty())
-            .union(parser.document.creation_sandboxing_flag_set());
+            .union(document.creation_sandboxing_flag_set());
 
         if let Some(endpoints) = endpoints_list {
             window.set_endpoints_list(endpoints);
@@ -1315,7 +1356,7 @@ impl FetchResponseListener for ParserContext {
             content_type,
             final_sandboxing_flag_set,
             link_headers,
-            about_base_url: parser.document.about_base_url(),
+            about_base_url: document.about_base_url(),
             resource_header: vec![],
         };
         self.submit_resource_timing();

--- a/components/script/dom/webgl/webglrenderingcontext.rs
+++ b/components/script/dom/webgl/webglrenderingcontext.rs
@@ -719,7 +719,7 @@ impl WebGLRenderingContext {
                         return Ok(None);
                     },
                 };
-                if !image.same_origin(document.origin()) {
+                if !image.same_origin(&document.origin()) {
                     return Err(Error::Security(None));
                 }
 

--- a/components/script/dom/window.rs
+++ b/components/script/dom/window.rs
@@ -1476,7 +1476,7 @@ impl WindowMethods<crate::DomTypeHolder> for Window {
             .Document();
         if !current_doc
             .origin()
-            .same_origin_domain(container_doc.origin())
+            .same_origin_domain(&container_doc.origin())
         {
             return None;
         }
@@ -3197,7 +3197,7 @@ impl Window {
                 // Note: `targetNavigable` is not actually defined in the spec, "active document" is
                 // assumed to be the correct reference based on WPT results
                 if let LoadOrigin::Script(initiator_origin) = initiator_origin_snapshot {
-                    if load_data.url == doc.url() && initiator_origin.same_origin(doc.origin()) {
+                    if load_data.url == doc.url() && initiator_origin.same_origin(&*doc.origin()) {
                         NavigationHistoryBehavior::Replace
                     } else {
                         // Step 12.2. Otherwise, set historyHandling to "push".
@@ -3938,7 +3938,7 @@ impl Window {
 
             // Step 7.1.
             if let Some(ref target_origin) = target_origin {
-                if !target_origin.same_origin(document.origin()) {
+                if !target_origin.same_origin(&*document.origin()) {
                     return;
                 }
             }

--- a/components/script/script_thread.rs
+++ b/components/script/script_thread.rs
@@ -536,7 +536,7 @@ impl ScriptThread {
     pub(crate) fn page_headers_available(
         webview_id: WebViewId,
         pipeline_id: PipelineId,
-        metadata: Option<Metadata>,
+        metadata: Option<&Metadata>,
         cx: &mut js::context::JSContext,
     ) -> Option<DomRoot<ServoParser>> {
         with_script_thread(|script_thread| {
@@ -3088,7 +3088,7 @@ impl ScriptThread {
         &self,
         webview_id: WebViewId,
         pipeline_id: PipelineId,
-        metadata: Option<Metadata>,
+        metadata: Option<&Metadata>,
         cx: &mut js::context::JSContext,
     ) -> Option<DomRoot<ServoParser>> {
         if self.closed_pipelines.borrow().contains(&pipeline_id) {
@@ -3107,8 +3107,10 @@ impl ScriptThread {
 
         // https://html.spec.whatwg.org/multipage/#process-a-navigate-response
         // 2. If response's status is 204 or 205, then abort these steps.
+        //
+        // TODO: The specification has been updated and we no longer should abort.
         let is_204_205 = match metadata {
-            Some(ref metadata) => metadata.status.in_range(204..=205),
+            Some(metadata) => metadata.status.in_range(204..=205),
             _ => false,
         };
 
@@ -3345,7 +3347,7 @@ impl ScriptThread {
     /// objects, parses HTML and CSS, and kicks off initial layout.
     fn load(
         &self,
-        metadata: Metadata,
+        metadata: &Metadata,
         incomplete: InProgressLoad,
         cx: &mut js::context::JSContext,
     ) -> DomRoot<ServoParser> {
@@ -3489,6 +3491,13 @@ impl ScriptThread {
         }
         window.init_window_proxy(&window_proxy);
 
+        // https://html.spec.whatwg.org/multipage/#resource-metadata-management
+        // > The Document's source file's last modification date and time must be derived from
+        // > relevant features of the networking protocols used, e.g.
+        // > from the value of the HTTP `Last-Modified` header of the document,
+        // > or from metadata in the file system for local files.
+        // > If the last modification date and time are not known,
+        // > the attribute must return the current date and time in the above format.
         let last_modified = metadata.headers.as_ref().and_then(|headers| {
             headers.typed_get::<LastModified>().map(|tm| {
                 let tm: SystemTime = tm.into();
@@ -3504,6 +3513,7 @@ impl ScriptThread {
 
         let content_type: Option<Mime> = metadata
             .content_type
+            .clone()
             .map(Serde::into_inner)
             .map(Mime::from_ct);
         let encoding_hint_from_content_type = content_type

--- a/tests/wpt/include.ini
+++ b/tests/wpt/include.ini
@@ -344,5 +344,7 @@ skip: true
   skip: false
 [visual-viewport]
   skip: false
+[x-frame-options]
+  skip: false
 [xhr]
   skip: false

--- a/tests/wpt/meta/mimesniff/mime-types/charset-parameter.window.js.ini
+++ b/tests/wpt/meta/mimesniff/mime-types/charset-parameter.window.js.ini
@@ -22,3 +22,15 @@
 
   [text/html;charset="\\ gbk"]
     expected: FAIL
+
+  [text/html;charset=\x0bgbk]
+    expected: FAIL
+
+  [text/html;charset=\x0cgbk]
+    expected: FAIL
+
+  [text/html;\x0bcharset=gbk]
+    expected: FAIL
+
+  [text/html;\x0ccharset=gbk]
+    expected: FAIL

--- a/tests/wpt/meta/x-frame-options/deny.html.ini
+++ b/tests/wpt/meta/x-frame-options/deny.html.ini
@@ -1,0 +1,3 @@
+[deny.html]
+  [`DENY` blocks cross-origin framing with CSP frame-ancestors 'self']
+    expected: FAIL

--- a/tests/wpt/meta/x-frame-options/get-decode-split.html.ini
+++ b/tests/wpt/meta/x-frame-options/get-decode-split.html.ini
@@ -1,0 +1,13 @@
+[get-decode-split.html]
+  expected: TIMEOUT
+  [`\x0bDENY` allows same-origin framing]
+    expected: TIMEOUT
+
+  [`\x0bDENY` allows cross-origin framing]
+    expected: TIMEOUT
+
+  [`\x0cDENY` allows same-origin framing]
+    expected: TIMEOUT
+
+  [`\x0cDENY` allows cross-origin framing]
+    expected: TIMEOUT

--- a/tests/wpt/meta/x-frame-options/multiple.html.ini
+++ b/tests/wpt/meta/x-frame-options/multiple.html.ini
@@ -1,0 +1,9 @@
+[multiple.html]
+  [`SAMEORIGIN,(the empty string)` blocks same-origin framing]
+    expected: FAIL
+
+  [`ALLOWALL,(the empty string)` blocks same-origin framing]
+    expected: FAIL
+
+  [`ALLOWALL,(the empty string)` blocks cross-origin framing]
+    expected: FAIL


### PR DESCRIPTION
We now check for this header and corresponding logic. The WPT tests mostly pass, but rely on the `contentDocument` of the iframe to be `null`. This is not something we did before, which means that iframes were able to access the contents of error pages.

Instead, we now mark the document as internal with an opaque origin according to the spec [1]. We shouldn't do this post-fact, but is required since we first need to construct the document and enter its realm, before we determine that it is an invalid document.

Fixes #16103

[1]: https://html.spec.whatwg.org/multipage/document-lifecycle.html#navigate-ua-inline