### PR TITLE
script: Pass &mut JSContext to CSSKeyframeRule::Style

### DIFF
--- a/components/script/dom/css/csskeyframerule.rs
+++ b/components/script/dom/css/csskeyframerule.rs
@@ -5,6 +5,7 @@
 use std::cell::RefCell;
 
 use dom_struct::dom_struct;
+use js::context::JSContext;
 use servo_arc::Arc;
 use style::shared_lock::{Locked, SharedRwLockReadGuard, ToCssWithGuard};
 use style::stylesheets::CssRuleType;
@@ -72,7 +73,7 @@ impl CSSKeyframeRule {
 
 impl CSSKeyframeRuleMethods<crate::DomTypeHolder> for CSSKeyframeRule {
     /// <https://drafts.csswg.org/css-animations/#dom-csskeyframerule-style>
-    fn Style(&self, can_gc: CanGc) -> DomRoot<CSSStyleDeclaration> {
+    fn Style(&self, cx: &mut JSContext) -> DomRoot<CSSStyleDeclaration> {
         self.style_declaration.or_init(|| {
             let guard = self.css_rule.shared_lock().read();
             CSSStyleDeclaration::new(
@@ -83,7 +84,7 @@ impl CSSKeyframeRuleMethods<crate::DomTypeHolder> for CSSKeyframeRule {
                 ),
                 None,
                 CSSModificationAccess::ReadWrite,
-                can_gc,
+                CanGc::from_cx(cx),
             )
         })
     }

--- a/components/script_bindings/codegen/Bindings.conf
+++ b/components/script_bindings/codegen/Bindings.conf
@@ -127,7 +127,7 @@ DOMInterfaces = {
 },
 
 'CSSKeyframeRule': {
-    'canGc': ['Style'],
+    'cx': ['Style'],
 },
 
 'CSSKeyframesRule': {


### PR DESCRIPTION
Move `CSSKeyframeRule::Style` from `CanGc` to `&mut JSContext`.

Testing: Just a refactor, Existing tests suffice.
Fixes: Part of #42638
