### PR TITLE
wpt: Add test for form action encoding.

### DIFF
--- a/tests/wpt/tests/html/semantics/forms/form-submission-0/action-encoding.html
+++ b/tests/wpt/tests/html/semantics/forms/form-submission-0/action-encoding.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<title>Encoding of form action URL</title>
+<iframe id=frame src="resources/form-charset.html?start"></iframe>
+<script>
+  async_test(t => {
+      frame.onload = t.step_func(() => {
+          let step = frame.contentWindow.location.search;
+          if (step == "?start") {
+              frame.contentDocument.forms[0].submit();
+          } else if (step.indexOf("end=") !== -1) {
+              assert_equals(step, "?end=%DF");
+              t.done();
+          }
+      });
+  });
+</script>

--- a/tests/wpt/tests/html/semantics/forms/form-submission-0/resources/form-charset.html
+++ b/tests/wpt/tests/html/semantics/forms/form-submission-0/resources/form-charset.html
@@ -1,0 +1,7 @@
+<!DOCTYPE html>
+<meta charset="windows-1252">
+<form method=post></form>
+<script>
+  // This is the German "eszett" character.
+  document.forms[0].action = location.pathname + "?end=\u00DF";
+</script>


### PR DESCRIPTION
Verified that this test fails before #43521 and passes after it, and matches behaviour of other browsers.

Testing: Adds a new test.
Part of #43507
