### PR TITLE
libservo: Set up graft node in AccessKit trees for webviews

### DIFF
--- a/components/constellation/constellation.rs
+++ b/components/constellation/constellation.rs
@@ -3109,6 +3109,11 @@ where
         };
 
         webview.accessibility_active = active;
+        self.embedder_proxy
+            .send(EmbedderMsg::AccessibilityTreeIdChanged(
+                webview_id,
+                webview.active_top_level_pipeline_id.into(),
+            ));
 
         // Forward the activation to the webview’s active pipelines (of those that represent
         // documents). For inactive pipelines (documents in bfcache), we only need to forward the
@@ -3193,6 +3198,7 @@ where
         self.webviews.insert(
             webview_id,
             ConstellationWebView::new(
+                &self.embedder_proxy,
                 webview_id,
                 pipeline_id,
                 browsing_context_id,
@@ -3585,6 +3591,7 @@ where
         self.webviews.insert(
             new_webview_id,
             ConstellationWebView::new(
+                &self.embedder_proxy,
                 new_webview_id,
                 new_pipeline_id,
                 new_browsing_context_id,
@@ -5728,6 +5735,11 @@ where
             if let Some(webview) = self.webviews.get_mut(&webview_id) {
                 if frame_tree.pipeline.id != webview.active_top_level_pipeline_id {
                     webview.active_top_level_pipeline_id = frame_tree.pipeline.id;
+                    self.embedder_proxy
+                        .send(EmbedderMsg::AccessibilityTreeIdChanged(
+                            webview_id,
+                            webview.active_top_level_pipeline_id.into(),
+                        ));
                 }
             }
 

--- a/components/constellation/constellation_webview.rs
+++ b/components/constellation/constellation_webview.rs
@@ -3,7 +3,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 use embedder_traits::user_contents::UserContentManagerId;
-use embedder_traits::{InputEvent, MouseLeftViewportEvent, Theme};
+use embedder_traits::{EmbedderMsg, EmbedderProxy, InputEvent, MouseLeftViewportEvent, Theme};
 use euclid::Point2D;
 use log::warn;
 use rustc_hash::FxHashMap;
@@ -60,11 +60,17 @@ pub(crate) struct ConstellationWebView {
 
 impl ConstellationWebView {
     pub(crate) fn new(
+        embedder_proxy: &EmbedderProxy,
         webview_id: WebViewId,
         active_top_level_pipeline_id: PipelineId,
         focused_browsing_context_id: BrowsingContextId,
         user_content_manager_id: Option<UserContentManagerId>,
     ) -> Self {
+        embedder_proxy.send(EmbedderMsg::AccessibilityTreeIdChanged(
+            webview_id,
+            active_top_level_pipeline_id.into(),
+        ));
+
         Self {
             webview_id,
             user_content_manager_id,

--- a/components/servo/servo.rs
+++ b/components/servo/servo.rs
@@ -717,6 +717,11 @@ impl ServoInner {
                     warn!("Failed to respond to GetScreenMetrics: {error}");
                 }
             },
+            EmbedderMsg::AccessibilityTreeIdChanged(webview_id, tree_id) => {
+                if let Some(webview) = self.get_webview_handle(webview_id) {
+                    webview.notify_accessibility_tree_id(tree_id);
+                }
+            },
             EmbedderMsg::AccessibilityTreeUpdate(webview_id, tree_update) => {
                 if let Some(webview) = self.get_webview_handle(webview_id) {
                     webview

--- a/components/servo/tests/accessibility.rs
+++ b/components/servo/tests/accessibility.rs
@@ -8,6 +8,7 @@ mod common;
 use std::collections::VecDeque;
 use std::rc::Rc;
 
+use accesskit::Role;
 use servo::{LoadStatus, Preferences, WebViewBuilder};
 use url::Url;
 
@@ -46,11 +47,16 @@ fn test_basic_accessibility_update() {
     let load_webview = webview.clone();
     servo_test.spin(move || load_webview.load_status() != LoadStatus::Complete);
 
-    let updates = wait_for_min_updates(&servo_test, delegate.clone(), 1);
+    let updates = wait_for_min_updates(&servo_test, delegate.clone(), 2);
     let tree = build_tree(updates);
+
     let root_node = tree.state().root();
-    find_first_matching_node(root_node, |node| node.role() == accesskit::Role::ScrollView)
+    let scroll_view = find_first_matching_node(root_node, |node| node.role() == Role::ScrollView)
         .expect("Tree should include a scroll view corresponding to the WebView.");
+    let scroll_view_children = scroll_view.children().collect::<Vec<_>>();
+    assert_eq!(scroll_view_children.len(), 1);
+    let graft_node = scroll_view_children[0];
+    assert!(graft_node.is_graft());
 }
 
 fn wait_for_min_updates(
@@ -76,12 +82,12 @@ fn build_tree(tree_updates: Vec<accesskit::TreeUpdate>) -> accesskit_consumer::T
 
     // We need to make a TreeUpdate with a TreeId of ROOT, which can have the subtrees grafted in
     let root_node_id = accesskit::NodeId(0x0);
-    let mut root_node = accesskit::Node::new(accesskit::Role::GenericContainer);
+    let mut root_node = accesskit::Node::new(Role::GenericContainer);
 
     // We need to make a graft node so that we have a non-graft node to set as the initial focused
     // node for the tree.
     let graft_node_id = accesskit::NodeId(0x1);
-    let mut graft_node = accesskit::Node::new(accesskit::Role::GenericContainer);
+    let mut graft_node = accesskit::Node::new(Role::GenericContainer);
     graft_node.set_tree_id(tree_id);
 
     root_node.set_children(vec![graft_node_id]);

--- a/components/servo/tests/accessibility.rs
+++ b/components/servo/tests/accessibility.rs
@@ -8,7 +8,8 @@ mod common;
 use std::collections::VecDeque;
 use std::rc::Rc;
 
-use accesskit::Role;
+use accesskit::{NodeId, Role, TreeId, TreeUpdate};
+use accesskit_consumer::TreeChangeHandler;
 use servo::{LoadStatus, Preferences, WebViewBuilder};
 use url::Url;
 
@@ -16,7 +17,7 @@ use crate::common::{ServoTest, WebViewDelegateImpl};
 
 struct NoOpChangeHandler;
 
-impl accesskit_consumer::TreeChangeHandler for NoOpChangeHandler {
+impl TreeChangeHandler for NoOpChangeHandler {
     fn node_added(&mut self, _: &accesskit_consumer::Node) {}
     fn node_updated(&mut self, _: &accesskit_consumer::Node, _: &accesskit_consumer::Node) {}
     fn focus_moved(
@@ -63,7 +64,7 @@ fn wait_for_min_updates(
     servo_test: &ServoTest,
     delegate: Rc<WebViewDelegateImpl>,
     min_num_updates: usize,
-) -> Vec<accesskit::TreeUpdate> {
+) -> Vec<TreeUpdate> {
     let captured_delegate = delegate.clone();
     servo_test.spin(move || {
         captured_delegate.last_accesskit_tree_updates.borrow().len() < min_num_updates
@@ -76,17 +77,17 @@ fn wait_for_min_updates(
         .collect()
 }
 
-fn build_tree(tree_updates: Vec<accesskit::TreeUpdate>) -> accesskit_consumer::Tree {
+fn build_tree(tree_updates: Vec<TreeUpdate>) -> accesskit_consumer::Tree {
     let first_update = tree_updates[0].clone();
     let tree_id = first_update.tree_id;
 
     // We need to make a TreeUpdate with a TreeId of ROOT, which can have the subtrees grafted in
-    let root_node_id = accesskit::NodeId(0x0);
+    let root_node_id = NodeId(0x0);
     let mut root_node = accesskit::Node::new(Role::GenericContainer);
 
     // We need to make a graft node so that we have a non-graft node to set as the initial focused
     // node for the tree.
-    let graft_node_id = accesskit::NodeId(0x1);
+    let graft_node_id = NodeId(0x1);
     let mut graft_node = accesskit::Node::new(Role::GenericContainer);
     graft_node.set_tree_id(tree_id);
 
@@ -98,10 +99,10 @@ fn build_tree(tree_updates: Vec<accesskit::TreeUpdate>) -> accesskit_consumer::T
         toolkit_version: None,
     };
 
-    let root_update = accesskit::TreeUpdate {
+    let root_update = TreeUpdate {
         nodes: vec![(root_node_id, root_node), (graft_node_id, graft_node)],
         tree: Some(root_tree),
-        tree_id: accesskit::TreeId::ROOT,
+        tree_id: TreeId::ROOT,
         focus: root_node_id,
     };
 

--- a/components/servo/webview.rs
+++ b/components/servo/webview.rs
@@ -7,6 +7,9 @@ use std::hash::Hash;
 use std::rc::{Rc, Weak};
 use std::time::Duration;
 
+use accesskit::{
+    Node as AccesskitNode, NodeId, Role, Tree, TreeId, TreeUpdate, Uuid as AccesskitUuid,
+};
 use dpi::PhysicalSize;
 use embedder_traits::{
     ContextMenuAction, ContextMenuItem, Cursor, EmbedderControlId, EmbedderControlRequest, Image,
@@ -95,7 +98,10 @@ pub(crate) struct WebViewInner {
     ///
     /// Set by [`WebView::set_accessibility_active()`], and forwarded to the constellation via
     /// [`EmbedderToConstellationMessage::SetAccessibilityActive`].
-    pub(crate) accesskit_tree_id: Option<accesskit::TreeId>,
+    pub(crate) accesskit_tree_id: Option<TreeId>,
+    /// [`TreeId`] of the web contents of this [`WebView`]’s active top-level pipeline,
+    /// which is grafted into the tree for this [`WebView`].
+    pub(crate) grafted_accesskit_tree_id: Option<TreeId>,
 
     rendering_context: Rc<dyn RenderingContext>,
     user_content_manager: Option<Rc<UserContentManager>>,
@@ -145,6 +151,7 @@ impl WebView {
                 .gamepad_delegate
                 .unwrap_or_else(|| Rc::new(DefaultGamepadDelegate)),
             accesskit_tree_id: None,
+            grafted_accesskit_tree_id: None,
             hidpi_scale_factor: builder.hidpi_scale_factor,
             load_status: LoadStatus::Started,
             status_text: None,
@@ -768,7 +775,7 @@ impl WebView {
     }
 
     /// AccessKit subtree id for this [`WebView`], if accessibility is active.
-    pub fn accesskit_tree_id(&self) -> Option<accesskit::TreeId> {
+    pub fn accesskit_tree_id(&self) -> Option<TreeId> {
         self.inner().accesskit_tree_id
     }
 
@@ -776,9 +783,9 @@ impl WebView {
     /// AccessKit subtree id if accessibility is now active.
     ///
     /// After accessibility is activated, you must [graft] (with [`set_tree_id()`]) the returned
-    /// [`accesskit::TreeId`] into your application’s main AccessKit tree as soon as possible,
-    /// *before* sending any tree updates from the webview to your AccessKit adapter. Otherwise you
-    /// may violate AccessKit’s subtree invariants and **panic**.
+    /// [`TreeId`] into your application’s main AccessKit tree as soon as possible, *before*
+    /// sending any tree updates from the webview to your AccessKit adapter. Otherwise you may
+    /// violate AccessKit’s subtree invariants and **panic**.
     ///
     /// This method may call [`WebViewDelegate::notify_accessibility_tree_update()`] synchronously
     /// with an initial tree update, so if your impl for that method can’t create the graft node
@@ -787,7 +794,7 @@ impl WebView {
     ///
     /// [graft]: https://docs.rs/accesskit/0.24.0/accesskit/struct.Node.html#method.tree_id
     /// [`set_tree_id()`]: https://docs.rs/accesskit/0.24.0/accesskit/struct.Node.html#method.set_tree_id
-    pub fn set_accessibility_active(&self, active: bool) -> Option<accesskit::TreeId> {
+    pub fn set_accessibility_active(&self, active: bool) -> Option<TreeId> {
         if !pref!(accessibility_enabled) {
             return None;
         }
@@ -797,17 +804,17 @@ impl WebView {
         }
 
         if active {
-            let accesskit_tree_id = accesskit::TreeId(accesskit::Uuid::new_v4());
+            let accesskit_tree_id = TreeId(AccesskitUuid::new_v4());
             self.inner_mut().accesskit_tree_id = Some(accesskit_tree_id);
 
             // Synchronously emit a TreeUpdate containing just a ScrollView, but no graft node yet.
-            let root_node_id = accesskit::NodeId(0);
-            let root_node = accesskit::Node::new(accesskit::Role::ScrollView);
+            let root_node_id = NodeId(0);
+            let root_node = AccesskitNode::new(Role::ScrollView);
             self.delegate().notify_accessibility_tree_update(
                 self.clone(),
-                accesskit::TreeUpdate {
+                TreeUpdate {
                     nodes: vec![(root_node_id, root_node)],
-                    tree: Some(accesskit::Tree {
+                    tree: Some(Tree {
                         root: root_node_id,
                         toolkit_name: None,
                         toolkit_version: None,
@@ -825,6 +832,40 @@ impl WebView {
         );
 
         self.accesskit_tree_id()
+    }
+
+    pub fn notify_accessibility_tree_id(&self, grafted_tree_id: TreeId) {
+        let Some(webview_accesskit_tree_id) = self.inner().accesskit_tree_id else {
+            return;
+        };
+        let old_grafted_tree_id = self
+            .inner_mut()
+            .grafted_accesskit_tree_id
+            .replace(grafted_tree_id);
+        // TODO(accessibility): try to avoid duplicate notifications in the first place?
+        if old_grafted_tree_id == Some(grafted_tree_id) {
+            return;
+        }
+        let root_node_id = NodeId(0);
+        let mut root_node = AccesskitNode::new(Role::ScrollView);
+        let graft_node_id = NodeId(1);
+        let mut graft_node = AccesskitNode::new(Role::GenericContainer);
+        graft_node.set_label("graft");
+        graft_node.set_tree_id(grafted_tree_id);
+        root_node.set_children(vec![graft_node_id]);
+        self.delegate().notify_accessibility_tree_update(
+            self.clone(),
+            TreeUpdate {
+                nodes: vec![(root_node_id, root_node), (graft_node_id, graft_node)],
+                tree: Some(Tree {
+                    root: root_node_id,
+                    toolkit_name: None,
+                    toolkit_version: None,
+                }),
+                tree_id: webview_accesskit_tree_id,
+                focus: root_node_id,
+            },
+        );
     }
 }
 

--- a/components/shared/embedder/lib.rs
+++ b/components/shared/embedder/lib.rs
@@ -21,6 +21,7 @@ use std::hash::Hash;
 use std::ops::Range;
 use std::sync::Arc;
 
+use accesskit::{TreeId, TreeUpdate};
 use crossbeam_channel::Sender;
 use euclid::{Box2D, Point2D, Scale, Size2D, Vector2D};
 use http::{HeaderMap, Method, StatusCode};
@@ -538,8 +539,11 @@ pub enum EmbedderMsg {
     /// Inform the embedding layer that a particular `InputEvent` was handled by Servo
     /// and the embedder can continue processing it, if necessary.
     InputEventsHandled(WebViewId, Vec<InputEventOutcome>),
+    /// Notifies the embedder that the AccessKit [`TreeId`] for the top-level document in this
+    /// WebView has been changed (or initially set).
+    AccessibilityTreeIdChanged(WebViewId, TreeId),
     /// Send the embedder an accessibility tree update.
-    AccessibilityTreeUpdate(WebViewId, accesskit::TreeUpdate),
+    AccessibilityTreeUpdate(WebViewId, TreeUpdate),
 }
 
 impl Debug for EmbedderMsg {


### PR DESCRIPTION
in #43029, we defined an accessibility tree for each webview. we create those trees when accessibility is activated for that webview, then the embedder can graft it into their main accessibility tree. at the time, this accessibility tree was empty, but we ultimately want it to contain the accessibility tree of the documents loaded in the webview at any given time. to do that, we need to graft the active top-level pipeline’s accessibility tree into the webview accessibility tree. we should be able to ignore nested documents inside iframes here, and leave it to their parent documents to graft those in as part of layout accessibility.

this patch hooks into the moment in the constellation where we detect that the top-level document has changed (#43013), and notifies libservo of the new AccessKit TreeId for the webview-to-pipeline graft node. this moment covers navigating to a new top-level document and navigating back or forward, but not the initial document loaded in the webview, so we also hook into the moment a ConstellationWebView is created, and do the same for that initial document. now the accessibility tree for a webview with accessibility activated should look like this:

- embedder’s main tree
  - graft node for webview tree → webview tree
    - ~~graft node for document back in history~~
    - graft node for active top-level document → (nothing yet)
    - ~~graft node for document forward in history~~

Testing: this patch updates the relevant accessibility test in libservo
Fixes: part of #4344, extracted from our work in #42338