### PR TITLE
paint: Avoid sending display list each time we pinch zoom

### DIFF
--- a/components/layout/display_list/mod.rs
+++ b/components/layout/display_list/mod.rs
@@ -13,6 +13,7 @@ use gradient::WebRenderGradient;
 use layout_api::ReflowStatistics;
 use net_traits::image_cache::Image as CachedImage;
 use paint_api::display_list::{PaintDisplayListInfo, SpatialTreeNodeInfo};
+use paint_api::{PropertyBindingType, get_property_binding_key};
 use servo_arc::Arc as ServoArc;
 use servo_base::id::{PipelineId, ScrollTreeNodeId};
 use servo_config::opts::{DiagnosticsLogging, DiagnosticsLoggingOption};
@@ -1129,7 +1130,8 @@ impl Fragment {
             // there is currently only a single thing that animates in this way (the caret).
             // This code should be updated if we ever add more paint-side animations.
             let pipeline_id: PipelineId = builder.paint_info.pipeline_id.into();
-            let property_binding_key = PropertyBindingKey::new(pipeline_id.into());
+            let property_binding_key =
+                get_property_binding_key(PropertyBindingType::Caret, pipeline_id);
             builder.paint_info.caret_property_binding = Some((property_binding_key, caret_color));
             PropertyBinding::Binding(property_binding_key, caret_color)
         } else {

--- a/components/layout/display_list/mod.rs
+++ b/components/layout/display_list/mod.rs
@@ -13,9 +13,8 @@ use gradient::WebRenderGradient;
 use layout_api::ReflowStatistics;
 use net_traits::image_cache::Image as CachedImage;
 use paint_api::display_list::{PaintDisplayListInfo, SpatialTreeNodeInfo};
-use paint_api::{PropertyBindingType, get_property_binding_key};
 use servo_arc::Arc as ServoArc;
-use servo_base::id::{PipelineId, ScrollTreeNodeId};
+use servo_base::id::{PropertyBindingType, ScrollTreeNodeId, get_property_binding_key};
 use servo_config::opts::{DiagnosticsLogging, DiagnosticsLoggingOption};
 use servo_config::{pref, prefs};
 use servo_url::ServoUrl;
@@ -46,7 +45,7 @@ use webrender_api::{
     self as wr, BorderDetails, BorderRadius, BorderSide, BoxShadowClipMode, BuiltDisplayList,
     ClipChainId, ClipMode, ColorF, CommonItemProperties, ComplexClipRegion, GlyphInstance,
     NinePatchBorder, NinePatchBorderSource, NormalBorder, PrimitiveFlags, PropertyBinding,
-    PropertyBindingKey, RasterSpace, SpatialId, SpatialTreeItemKey, StackingContextFlags, units,
+    RasterSpace, SpatialId, SpatialTreeItemKey, StackingContextFlags, units,
 };
 use wr::units::LayoutVector2D;
 
@@ -1126,12 +1125,7 @@ impl Fragment {
 
         let caret_color = rgba(caret_color);
         let property_binding = if prefs::get().editing_caret_blink_time().is_some() {
-            // It's okay to always use the same property binding key for this pipeline, as
-            // there is currently only a single thing that animates in this way (the caret).
-            // This code should be updated if we ever add more paint-side animations.
-            let pipeline_id: PipelineId = builder.paint_info.pipeline_id.into();
-            let property_binding_key =
-                get_property_binding_key(PropertyBindingType::Caret, pipeline_id);
+            let property_binding_key = get_property_binding_key(PropertyBindingType::Caret);
             builder.paint_info.caret_property_binding = Some((property_binding_key, caret_color));
             PropertyBinding::Binding(property_binding_key, caret_color)
         } else {

--- a/components/paint/painter.rs
+++ b/components/paint/painter.rs
@@ -23,8 +23,9 @@ use paint_api::largest_contentful_paint_candidate::LCPCandidate;
 use paint_api::rendering_context::RenderingContext;
 use paint_api::viewport_description::ViewportDescription;
 use paint_api::{
-    ImageUpdate, PipelineExitSource, SendableFrameTree, SerializableDisplayListPayload,
-    SerializableImageData, WebRenderExternalImageHandlers, WebRenderImageHandlerType, WebViewTrait,
+    ImageUpdate, PipelineExitSource, PropertyBindingType, SendableFrameTree,
+    SerializableDisplayListPayload, SerializableImageData, WebRenderExternalImageHandlers,
+    WebRenderImageHandlerType, WebViewTrait, get_property_binding_key,
 };
 use profile_traits::time::{ProfilerCategory, ProfilerChan};
 use profile_traits::time_profile;
@@ -42,15 +43,15 @@ use webrender::{
     MemoryReport, ONE_TIME_USAGE_HINT, RenderApi, ShaderPrecacheFlags, Transaction, UploadMethod,
 };
 use webrender_api::units::{
-    DevicePixel, DevicePoint, LayoutPoint, LayoutRect, LayoutSize, LayoutTransform, LayoutVector2D,
-    WorldPoint,
+    DevicePixel, DevicePoint, LayoutPoint, LayoutRect, LayoutSize, LayoutVector2D, WorldPoint,
 };
 use webrender_api::{
     self, BuiltDisplayList, BuiltDisplayListDescriptor, ColorF, DirtyRect, DisplayListPayload,
     DocumentId, DynamicProperties, Epoch as WebRenderEpoch, ExternalScrollId, FontInstanceFlags,
     FontInstanceKey, FontInstanceOptions, FontKey, FontVariation, ImageData, ImageKey,
-    NativeFontHandle, PipelineId as WebRenderPipelineId, PropertyBinding, ReferenceFrameKind,
-    RenderReasons, SampledScrollOffset, SpaceAndClipInfo, SpatialId, TransformStyle,
+    NativeFontHandle, PipelineId as WebRenderPipelineId, PropertyBinding, PropertyValue,
+    ReferenceFrameKind, RenderReasons, SampledScrollOffset, SpaceAndClipInfo, SpatialId,
+    TransformStyle,
 };
 use wr_malloc_size_of::MallocSizeOfOps;
 
@@ -312,7 +313,6 @@ impl Painter {
 
         if let Some(colors) = self.web_content_animator.update(&self.webview_renderers) {
             let mut transaction = Transaction::new();
-            transaction.reset_dynamic_properties();
             transaction.append_dynamic_properties(DynamicProperties {
                 transforms: Vec::new(),
                 floats: Vec::new(),
@@ -591,6 +591,29 @@ impl Painter {
             .send_transaction(self.webrender_document, transaction);
     }
 
+    fn send_pinch_zoom_update_in_transaction(&self, transaction: &mut Transaction) {
+        let mut dynamic_properties = vec![];
+
+        for webview_renderer in self.webview_renderers.values() {
+            if webview_renderer.hidden() {
+                continue;
+            }
+            let Some(pipeline_id) = webview_renderer.root_pipeline_id else {
+                continue;
+            };
+
+            let transform = webview_renderer.get_webview_transform();
+
+            let property_binding_key =
+                get_property_binding_key(PropertyBindingType::PinchZoom, pipeline_id);
+            dynamic_properties.push(PropertyValue {
+                key: property_binding_key,
+                value: transform,
+            });
+        }
+        transaction.append_dynamic_transform_properties(dynamic_properties);
+    }
+
     /// Set the root pipeline for our WebRender scene to a display list that consists of an iframe
     /// for each visible top-level browsing context, applying a transformation on the root for
     /// pinch zoom, page zoom, and HiDPI scaling.
@@ -622,25 +645,17 @@ impl Painter {
                 continue;
             };
 
-            let pinch_zoom_transform = webview_renderer.pinch_zoom().transform().to_untyped();
-            let device_pixels_per_page_pixel_not_including_pinch_zoom = webview_renderer
-                .device_pixels_per_page_pixel_not_including_pinch_zoom()
-                .get();
-
-            let transform = LayoutTransform::scale(
-                device_pixels_per_page_pixel_not_including_pinch_zoom,
-                device_pixels_per_page_pixel_not_including_pinch_zoom,
-                1.0,
-            )
-            .then(&LayoutTransform::from_untyped(
-                &pinch_zoom_transform.to_3d(),
-            ));
+            let transform = webview_renderer.get_webview_transform();
+            let property_binding = PropertyBinding::Binding(
+                get_property_binding_key(PropertyBindingType::PinchZoom, pipeline_id),
+                transform,
+            );
 
             let webview_reference_frame = builder.push_reference_frame(
                 LayoutPoint::zero(),
                 root_reference_frame,
                 TransformStyle::Flat,
-                PropertyBinding::Value(transform),
+                property_binding,
                 ReferenceFrameKind::Transform {
                     is_2d_scale_translation: true,
                     should_snap: true,
@@ -725,7 +740,7 @@ impl Painter {
 
         let mut transaction = Transaction::new();
         if need_zoom {
-            self.send_root_pipeline_display_list_in_transaction(&mut transaction);
+            self.send_pinch_zoom_update_in_transaction(&mut transaction);
         }
         for update in scroll_offset_updates {
             transaction.set_scroll_offsets(

--- a/components/paint/painter.rs
+++ b/components/paint/painter.rs
@@ -23,9 +23,8 @@ use paint_api::largest_contentful_paint_candidate::LCPCandidate;
 use paint_api::rendering_context::RenderingContext;
 use paint_api::viewport_description::ViewportDescription;
 use paint_api::{
-    ImageUpdate, PipelineExitSource, PropertyBindingType, SendableFrameTree,
-    SerializableDisplayListPayload, SerializableImageData, WebRenderExternalImageHandlers,
-    WebRenderImageHandlerType, WebViewTrait, get_property_binding_key,
+    ImageUpdate, PipelineExitSource, SendableFrameTree, SerializableDisplayListPayload,
+    SerializableImageData, WebRenderExternalImageHandlers, WebRenderImageHandlerType, WebViewTrait,
 };
 use profile_traits::time::{ProfilerCategory, ProfilerChan};
 use profile_traits::time_profile;
@@ -33,7 +32,9 @@ use rustc_hash::{FxHashMap, FxHashSet};
 use servo_base::Epoch;
 use servo_base::cross_process_instant::CrossProcessInstant;
 use servo_base::generic_channel::{GenericReceiver, GenericSharedMemory};
-use servo_base::id::{PainterId, PipelineId, WebViewId};
+use servo_base::id::{
+    PainterId, PipelineId, PropertyBindingType, WebViewId, get_property_binding_key,
+};
 use servo_config::{opts, pref};
 use servo_constellation_traits::{EmbedderToConstellationMessage, PaintMetricEvent};
 use servo_geometry::DeviceIndependentPixel;
@@ -605,7 +606,7 @@ impl Painter {
             let transform = webview_renderer.get_webview_transform();
 
             let property_binding_key =
-                get_property_binding_key(PropertyBindingType::PinchZoom, pipeline_id);
+                get_property_binding_key(PropertyBindingType::PinchZoom(pipeline_id));
             dynamic_properties.push(PropertyValue {
                 key: property_binding_key,
                 value: transform,
@@ -647,7 +648,7 @@ impl Painter {
 
             let transform = webview_renderer.get_webview_transform();
             let property_binding = PropertyBinding::Binding(
-                get_property_binding_key(PropertyBindingType::PinchZoom, pipeline_id),
+                get_property_binding_key(PropertyBindingType::PinchZoom(pipeline_id)),
                 transform,
             );
 

--- a/components/paint/webview_renderer.rs
+++ b/components/paint/webview_renderer.rs
@@ -28,7 +28,9 @@ use servo_constellation_traits::{
 use servo_geometry::DeviceIndependentPixel;
 use style_traits::CSSPixel;
 use webrender::RenderApi;
-use webrender_api::units::{DevicePixel, DevicePoint, DeviceRect, DeviceVector2D, LayoutVector2D};
+use webrender_api::units::{
+    DevicePixel, DevicePoint, DeviceRect, DeviceVector2D, LayoutTransform, LayoutVector2D,
+};
 use webrender_api::{DocumentId, ExternalScrollId, ScrollLocation};
 
 use crate::paint::RepaintReason;
@@ -1131,6 +1133,25 @@ impl WebViewRenderer {
                 DeviceVector2D::new(-wheel_event.delta.x as f32, -wheel_event.delta.y as f32);
             self.notify_scroll_event(Scroll::Delta(scroll_delta.into()), wheel_event.point);
         }
+    }
+
+    /// Get the device to layout transformation of a webview, currently containing the HiDPI,
+    /// page zoom and pinch zoom. Returning [`LayoutTransform`] to support its inclusion in
+    /// webrender.
+    pub(crate) fn get_webview_transform(&self) -> LayoutTransform {
+        let pinch_zoom_transform = self.pinch_zoom.transform().to_untyped();
+        let device_pixels_per_page_pixel_not_including_pinch_zoom = self
+            .device_pixels_per_page_pixel_not_including_pinch_zoom()
+            .get();
+
+        LayoutTransform::scale(
+            device_pixels_per_page_pixel_not_including_pinch_zoom,
+            device_pixels_per_page_pixel_not_including_pinch_zoom,
+            1.0,
+        )
+        .then(&LayoutTransform::from_untyped(
+            &pinch_zoom_transform.to_3d(),
+        ))
     }
 }
 

--- a/components/shared/base/id.rs
+++ b/components/shared/base/id.rs
@@ -21,7 +21,7 @@ use regex::Regex;
 use serde::{Deserialize, Serialize};
 use webrender_api::{
     ExternalScrollId, FontInstanceKey, FontKey, IdNamespace, ImageKey,
-    PipelineId as WebRenderPipelineId, SpatialTreeItemKey,
+    PipelineId as WebRenderPipelineId, PropertyBindingKey, SpatialTreeItemKey,
 };
 
 use crate::generic_channel::{self, GenericReceiver, GenericSender};
@@ -560,4 +560,28 @@ impl fmt::Display for ScriptEventLoopId {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{}", self.0)
     }
+}
+
+#[derive(
+    Clone, Copy, Debug, Deserialize, Eq, Hash, MallocSizeOf, Ord, PartialEq, PartialOrd, Serialize,
+)]
+pub enum PropertyBindingType {
+    Caret,
+    PinchZoom(PipelineId),
+}
+
+pub fn get_property_binding_key<T>(binding_type: PropertyBindingType) -> PropertyBindingKey<T> {
+    let inner_id = match binding_type {
+        PropertyBindingType::Caret => {
+            // Caret is identified with the `PipelineNamespaceId` of the thread similar to how a `PipelineId` is defined.
+            // However, it wouldn't intersect with any `PipelineId` since the index part for `PipelineId` is `NonZeroU32`.
+            let namespace_id = PIPELINE_NAMESPACE
+                .get()
+                .expect("No namespace set for this thread!")
+                .id;
+            (namespace_id.0 as u64) << 32
+        },
+        PropertyBindingType::PinchZoom(pipeline_id) => pipeline_id.into(),
+    };
+    PropertyBindingKey::<T>::new(inner_id)
 }

--- a/components/shared/paint/lib.rs
+++ b/components/shared/paint/lib.rs
@@ -6,13 +6,14 @@
 
 use std::collections::HashMap;
 use std::fmt::{Debug, Error, Formatter};
+use std::sync::atomic::{AtomicU64, Ordering};
 
 use crossbeam_channel::Sender;
 use embedder_traits::{AnimationState, EventLoopWaker};
 use euclid::{Rect, Scale, Size2D};
 use log::warn;
 use malloc_size_of_derive::MallocSizeOf;
-use parking_lot::RwLock;
+use parking_lot::{Mutex, RwLock};
 use rustc_hash::FxHashMap;
 use servo_base::Epoch;
 use servo_base::id::{PainterId, PipelineId, WebViewId};
@@ -20,14 +21,14 @@ use smallvec::SmallVec;
 use strum::IntoStaticStr;
 use style_traits::CSSPixel;
 use surfman::{Adapter, Connection};
-use webrender_api::{DocumentId, FontVariation};
+use webrender_api::{DocumentId, FontVariation, PropertyBindingKey};
 
 pub mod display_list;
 pub mod largest_contentful_paint_candidate;
 pub mod rendering_context;
 pub mod viewport_description;
 
-use std::sync::{Arc, Mutex};
+use std::sync::{Arc, LazyLock, Mutex as StdMutex};
 
 use bitflags::bitflags;
 use display_list::PaintDisplayListInfo;
@@ -551,7 +552,7 @@ pub struct PainterSurfmanDetails {
 }
 
 #[derive(Clone, Default)]
-pub struct PainterSurfmanDetailsMap(Arc<Mutex<HashMap<PainterId, PainterSurfmanDetails>>>);
+pub struct PainterSurfmanDetailsMap(Arc<StdMutex<HashMap<PainterId, PainterSurfmanDetails>>>);
 
 impl PainterSurfmanDetailsMap {
     pub fn get(&self, painter_id: PainterId) -> Option<PainterSurfmanDetails> {
@@ -840,4 +841,36 @@ impl PinchZoomInfos {
             rect: Rect::from_size(size),
         }
     }
+}
+
+static NEXT_AVAILABLE_PROPERTY_BINDING_ID: AtomicU64 = AtomicU64::new(0);
+
+#[derive(
+    Clone, Copy, Debug, Deserialize, Eq, Hash, MallocSizeOf, Ord, PartialEq, PartialOrd, Serialize,
+)]
+pub enum PropertyBindingType {
+    Caret,
+    PinchZoom,
+}
+
+#[expect(clippy::type_complexity)]
+static PROPERTY_BINDING_ID_RECORD: LazyLock<
+    Arc<Mutex<FxHashMap<(PropertyBindingType, PipelineId), u64>>>,
+> = LazyLock::new(|| Arc::new(Mutex::new(FxHashMap::default())));
+
+pub fn get_property_binding_key<T>(
+    binding_type: PropertyBindingType,
+    pipeline_id: PipelineId,
+) -> PropertyBindingKey<T> {
+    let mut records = PROPERTY_BINDING_ID_RECORD.lock();
+    let inner_id = match records.get(&(binding_type, pipeline_id)) {
+        Some(id) => *id,
+        None => {
+            let next_available_id =
+                NEXT_AVAILABLE_PROPERTY_BINDING_ID.fetch_add(1, Ordering::SeqCst) + 1;
+            records.insert((binding_type, pipeline_id), next_available_id);
+            next_available_id
+        },
+    };
+    PropertyBindingKey::<T>::new(inner_id)
 }

--- a/components/shared/paint/lib.rs
+++ b/components/shared/paint/lib.rs
@@ -6,14 +6,13 @@
 
 use std::collections::HashMap;
 use std::fmt::{Debug, Error, Formatter};
-use std::sync::atomic::{AtomicU64, Ordering};
 
 use crossbeam_channel::Sender;
 use embedder_traits::{AnimationState, EventLoopWaker};
 use euclid::{Rect, Scale, Size2D};
 use log::warn;
 use malloc_size_of_derive::MallocSizeOf;
-use parking_lot::{Mutex, RwLock};
+use parking_lot::RwLock;
 use rustc_hash::FxHashMap;
 use servo_base::Epoch;
 use servo_base::id::{PainterId, PipelineId, WebViewId};
@@ -21,14 +20,14 @@ use smallvec::SmallVec;
 use strum::IntoStaticStr;
 use style_traits::CSSPixel;
 use surfman::{Adapter, Connection};
-use webrender_api::{DocumentId, FontVariation, PropertyBindingKey};
+use webrender_api::{DocumentId, FontVariation};
 
 pub mod display_list;
 pub mod largest_contentful_paint_candidate;
 pub mod rendering_context;
 pub mod viewport_description;
 
-use std::sync::{Arc, LazyLock, Mutex as StdMutex};
+use std::sync::{Arc, Mutex as StdMutex};
 
 use bitflags::bitflags;
 use display_list::PaintDisplayListInfo;
@@ -841,36 +840,4 @@ impl PinchZoomInfos {
             rect: Rect::from_size(size),
         }
     }
-}
-
-static NEXT_AVAILABLE_PROPERTY_BINDING_ID: AtomicU64 = AtomicU64::new(0);
-
-#[derive(
-    Clone, Copy, Debug, Deserialize, Eq, Hash, MallocSizeOf, Ord, PartialEq, PartialOrd, Serialize,
-)]
-pub enum PropertyBindingType {
-    Caret,
-    PinchZoom,
-}
-
-#[expect(clippy::type_complexity)]
-static PROPERTY_BINDING_ID_RECORD: LazyLock<
-    Arc<Mutex<FxHashMap<(PropertyBindingType, PipelineId), u64>>>,
-> = LazyLock::new(|| Arc::new(Mutex::new(FxHashMap::default())));
-
-pub fn get_property_binding_key<T>(
-    binding_type: PropertyBindingType,
-    pipeline_id: PipelineId,
-) -> PropertyBindingKey<T> {
-    let mut records = PROPERTY_BINDING_ID_RECORD.lock();
-    let inner_id = match records.get(&(binding_type, pipeline_id)) {
-        Some(id) => *id,
-        None => {
-            let next_available_id =
-                NEXT_AVAILABLE_PROPERTY_BINDING_ID.fetch_add(1, Ordering::SeqCst) + 1;
-            records.insert((binding_type, pipeline_id), next_available_id);
-            next_available_id
-        },
-    };
-    PropertyBindingKey::<T>::new(inner_id)
 }


### PR DESCRIPTION
To handle PinchZoom and other scaling like HiDPI or page zoom, we are using display list reference frame that stores such scale and translation. Because of this, currently we are rebuilding the display list each time we need to update such zoom. For pinch zoom's perspective this would be costly because pinch zoom itself doesn't affects the layout. 

Therefore following the changes to caret animation, this PR uses WebRender `PropertyBinding` to optimize such cases. Where we are sending the `PropertyBinding` transforms update instead.

Testing: Manual test with `/visual-viewport/` WPTs.
