### PR TITLE
webgl: Remove manual Drop implementation for WebGLRenderbuffer

### DIFF
--- a/components/script/dom/webgl/webglframebuffer.rs
+++ b/components/script/dom/webgl/webglframebuffer.rs
@@ -892,11 +892,10 @@ impl WebGLFramebuffer {
         Ok(())
     }
 
-    fn with_matching_renderbuffers<F>(&self, rb: &WebGLRenderbuffer, mut closure: F)
+    fn with_matching_renderbuffers_id<F>(&self, rb_id: &WebGLRenderbufferId, mut closure: F)
     where
         F: FnMut(&DomRefCell<Option<WebGLFramebufferAttachment>>, u32),
     {
-        let rb_id = rb.id();
         let attachments = [
             (&self.depth, constants::DEPTH_ATTACHMENT),
             (&self.stencil, constants::STENCIL_ATTACHMENT),
@@ -916,13 +915,13 @@ impl WebGLFramebuffer {
         }
 
         for (attachment, name) in &attachments {
-            if has_matching_id(attachment, &rb_id) {
+            if has_matching_id(attachment, rb_id) {
                 closure(attachment, *name);
             }
         }
 
         for (idx, attachment) in self.colors.iter().enumerate() {
-            if has_matching_id(attachment, &rb_id) {
+            if has_matching_id(attachment, rb_id) {
                 let name = constants::COLOR_ATTACHMENT0 + idx as u32;
                 closure(attachment, name);
             }
@@ -964,13 +963,13 @@ impl WebGLFramebuffer {
         }
     }
 
-    pub(crate) fn detach_renderbuffer(&self, rb: &WebGLRenderbuffer) -> WebGLResult<()> {
+    pub(crate) fn detach_renderbuffer_by_id(&self, rb_id: &WebGLRenderbufferId) -> WebGLResult<()> {
         // Opaque framebuffers cannot have their attachments changed
         // https://immersive-web.github.io/webxr/#opaque-framebuffer
         self.validate_transparent()?;
 
         let mut depth_or_stencil_updated = false;
-        self.with_matching_renderbuffers(rb, |att, name| {
+        self.with_matching_renderbuffers_id(rb_id, |att, name| {
             depth_or_stencil_updated |= INTERESTING_ATTACHMENT_POINTS.contains(&name);
             if let Some(att) = &*att.borrow() {
                 att.detach();
@@ -1007,7 +1006,7 @@ impl WebGLFramebuffer {
     }
 
     pub(crate) fn invalidate_renderbuffer(&self, rb: &WebGLRenderbuffer) {
-        self.with_matching_renderbuffers(rb, |_att, _| {
+        self.with_matching_renderbuffers_id(&rb.id(), |_att, _| {
             self.is_initialized.set(false);
             self.update_status();
         });

--- a/components/script/dom/webgl/webglrenderbuffer.rs
+++ b/components/script/dom/webgl/webglrenderbuffer.rs
@@ -10,6 +10,7 @@ use canvas_traits::webgl::{
     WebGLVersion, webgl_channel,
 };
 use dom_struct::dom_struct;
+use script_bindings::weakref::WeakRef;
 
 use crate::dom::bindings::codegen::Bindings::EXTColorBufferHalfFloatBinding::EXTColorBufferHalfFloatConstants;
 use crate::dom::bindings::codegen::Bindings::WEBGLColorBufferFloatBinding::WEBGLColorBufferFloatConstants;
@@ -20,32 +21,88 @@ use crate::dom::bindings::root::{DomRoot, MutNullableDom};
 use crate::dom::webgl::webglframebuffer::WebGLFramebuffer;
 use crate::dom::webgl::webglobject::WebGLObject;
 use crate::dom::webgl::webglrenderingcontext::{Operation, WebGLRenderingContext};
+use crate::dom::webglrenderingcontext::capture_webgl_backtrace;
 use crate::script_runtime::CanGc;
+
+#[derive(JSTraceable, MallocSizeOf)]
+struct DroppableWebGLRenderbuffer {
+    context: WeakRef<WebGLRenderingContext>,
+    #[no_trace]
+    id: WebGLRenderbufferId,
+    is_deleted: Cell<bool>,
+}
+
+impl DroppableWebGLRenderbuffer {
+    fn send_with_fallibility(&self, command: WebGLCommand, fallibility: Operation) {
+        if let Some(root) = self.context.root() {
+            let result = root.sender().send(command, capture_webgl_backtrace());
+            if matches!(fallibility, Operation::Infallible) {
+                result.expect("Operation failed");
+            }
+        }
+    }
+
+    fn delete(&self, operation_fallibility: Operation) {
+        if !self.is_deleted.get() {
+            self.is_deleted.set(true);
+
+            /*
+            If a renderbuffer object is deleted while its image is attached to one or more
+            attachment points in a currently bound framebuffer object, then it is as if
+            FramebufferRenderbuffer had been called, with a renderbuffer of zero, for each
+            attachment point to which this image was attached in that framebuffer object.
+            In other words,the renderbuffer image is first detached from all attachment points
+            in that frame-buffer object.
+            - GLES 3.0, 4.4.2.3, "Attaching Renderbuffer Images to a Framebuffer"
+            */
+            if let Some(context) = self.context.root() {
+                if let Some(fb) = context.get_draw_framebuffer_slot().get() {
+                    let _ = fb.detach_renderbuffer_by_id(&self.id);
+                }
+                if let Some(fb) = context.get_read_framebuffer_slot().get() {
+                    let _ = fb.detach_renderbuffer_by_id(&self.id);
+                }
+            }
+
+            self.send_with_fallibility(
+                WebGLCommand::DeleteRenderbuffer(self.id),
+                operation_fallibility,
+            );
+        }
+    }
+}
+
+impl Drop for DroppableWebGLRenderbuffer {
+    fn drop(&mut self) {
+        self.delete(Operation::Fallible);
+    }
+}
 
 #[dom_struct(associated_memory)]
 pub(crate) struct WebGLRenderbuffer {
     webgl_object: WebGLObject,
-    #[no_trace]
-    id: WebGLRenderbufferId,
     ever_bound: Cell<bool>,
-    is_deleted: Cell<bool>,
     size: Cell<Option<(i32, i32)>>,
     internal_format: Cell<Option<u32>>,
     is_initialized: Cell<bool>,
     attached_framebuffer: MutNullableDom<WebGLFramebuffer>,
+    droppable: DroppableWebGLRenderbuffer,
 }
 
 impl WebGLRenderbuffer {
     fn new_inherited(context: &WebGLRenderingContext, id: WebGLRenderbufferId) -> Self {
         Self {
             webgl_object: WebGLObject::new_inherited(context),
-            id,
             ever_bound: Cell::new(false),
-            is_deleted: Cell::new(false),
             internal_format: Cell::new(None),
             size: Cell::new(None),
             is_initialized: Cell::new(false),
             attached_framebuffer: Default::default(),
+            droppable: DroppableWebGLRenderbuffer {
+                context: WeakRef::new(context),
+                id,
+                is_deleted: Cell::new(false),
+            },
         }
     }
 
@@ -73,7 +130,7 @@ impl WebGLRenderbuffer {
 
 impl WebGLRenderbuffer {
     pub(crate) fn id(&self) -> WebGLRenderbufferId {
-        self.id
+        self.droppable.id
     }
 
     pub(crate) fn size(&self) -> Option<(i32, i32)> {
@@ -95,41 +152,15 @@ impl WebGLRenderbuffer {
     pub(crate) fn bind(&self, target: u32) {
         self.ever_bound.set(true);
         self.upcast()
-            .send_command(WebGLCommand::BindRenderbuffer(target, Some(self.id)));
+            .send_command(WebGLCommand::BindRenderbuffer(target, Some(self.id())));
     }
 
     pub(crate) fn delete(&self, operation_fallibility: Operation) {
-        if !self.is_deleted.get() {
-            self.is_deleted.set(true);
-
-            /*
-            If a renderbuffer object is deleted while its image is attached to one or more
-            attachment points in a currently bound framebuffer object, then it is as if
-            FramebufferRenderbuffer had been called, with a renderbuffer of zero, for each
-            attachment point to which this image was attached in that framebuffer object.
-            In other words,the renderbuffer image is first detached from all attachment points
-            in that frame-buffer object.
-            - GLES 3.0, 4.4.2.3, "Attaching Renderbuffer Images to a Framebuffer"
-            */
-            let webgl_object = self.upcast();
-            if let Some(context) = webgl_object.context() {
-                if let Some(fb) = context.get_draw_framebuffer_slot().get() {
-                    let _ = fb.detach_renderbuffer(self);
-                }
-                if let Some(fb) = context.get_read_framebuffer_slot().get() {
-                    let _ = fb.detach_renderbuffer(self);
-                }
-            }
-
-            webgl_object.send_with_fallibility(
-                WebGLCommand::DeleteRenderbuffer(self.id),
-                operation_fallibility,
-            );
-        }
+        self.droppable.delete(operation_fallibility);
     }
 
     pub(crate) fn is_deleted(&self) -> bool {
-        self.is_deleted.get()
+        self.droppable.is_deleted.get()
     }
 
     pub(crate) fn ever_bound(&self) -> bool {
@@ -275,11 +306,5 @@ impl WebGLRenderbuffer {
 
     pub(crate) fn detach_from_framebuffer(&self) {
         self.attached_framebuffer.set(None);
-    }
-}
-
-impl Drop for WebGLRenderbuffer {
-    fn drop(&mut self) {
-        self.delete(Operation::Fallible);
     }
 }

--- a/components/script_bindings/codegen/Bindings.conf
+++ b/components/script_bindings/codegen/Bindings.conf
@@ -824,10 +824,6 @@ DOMInterfaces = {
     'additionalTraits': ['crate::interfaces::WebGL2RenderingContextHelpers'],
 },
 
-'WebGLRenderbuffer': {
-    'allowDropImpl': True,
-},
-
 'WebGLSampler': {
     'allowDropImpl': True,
 },


### PR DESCRIPTION
Moves the cleanup logic to a separate helper struct to comply with the prohibition of manual `Drop` implementations for DOM types.

Testing: WebGL tests just cover its cases
Fixes: Partially #26488 
