### PR TITLE
devtools: Rename `PropertyPreview` to `PropertyDescriptor`

### DIFF
--- a/components/devtools/actors/console.rs
+++ b/components/devtools/actors/console.rs
@@ -27,7 +27,7 @@ use uuid::Uuid;
 
 use crate::actor::{Actor, ActorError, ActorRegistry};
 use crate::actors::browsing_context::BrowsingContextActor;
-use crate::actors::object::{ObjectActor, PropertyDescriptor};
+use crate::actors::object::{ObjectActor, ObjectPropertyDescriptor};
 use crate::actors::worker::WorkerActor;
 use crate::protocol::{ClientRequest, JsonPacketStream};
 use crate::resource::{ResourceArrayType, ResourceAvailable};
@@ -93,15 +93,15 @@ fn console_argument_to_value(argument: ConsoleArgument, registry: &ActorRegistry
             #[serde(rename_all = "camelCase")]
             struct DevtoolsConsoleObjectArgumentPreview {
                 kind: String,
-                own_properties: HashMap<String, PropertyDescriptor>,
+                own_properties: HashMap<String, ObjectPropertyDescriptor>,
                 own_properties_length: usize,
             }
 
-            let own_properties: HashMap<String, PropertyDescriptor> = object
+            let own_properties: HashMap<String, ObjectPropertyDescriptor> = object
                 .own_properties
                 .into_iter()
                 .map(|property| {
-                    let property_descriptor = PropertyDescriptor {
+                    let property_descriptor = ObjectPropertyDescriptor {
                         configurable: property.configurable,
                         enumerable: property.enumerable,
                         writable: property.writable,
@@ -435,7 +435,7 @@ impl ConsoleActor {
                         let mut own_props_map = Map::new();
                         for prop in props {
                             let descriptor =
-                                serde_json::to_value(PropertyDescriptor::from(prop)).unwrap();
+                                serde_json::to_value(ObjectPropertyDescriptor::from(prop)).unwrap();
                             own_props_map.insert(prop.name.clone(), descriptor);
                         }
                         preview.insert("ownProperties".to_owned(), Value::Object(own_props_map));

--- a/components/devtools/actors/object.rs
+++ b/components/devtools/actors/object.rs
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-use devtools_traits::PropertyPreview;
+use devtools_traits::PropertyDescriptor;
 use malloc_size_of_derive::MallocSizeOf;
 use serde::Serialize;
 use serde_json::{Map, Number, Value};
@@ -61,15 +61,15 @@ pub(crate) struct ObjectActorMsg {
 }
 
 #[derive(Serialize)]
-pub(crate) struct PropertyDescriptor {
+pub(crate) struct ObjectPropertyDescriptor {
     pub configurable: bool,
     pub enumerable: bool,
     pub writable: bool,
     pub value: Value,
 }
 
-impl From<&PropertyPreview> for PropertyDescriptor {
-    fn from(prop: &PropertyPreview) -> Self {
+impl From<&PropertyDescriptor> for ObjectPropertyDescriptor {
+    fn from(prop: &PropertyDescriptor) -> Self {
         Self {
             configurable: prop.configurable,
             enumerable: prop.enumerable,
@@ -80,7 +80,7 @@ impl From<&PropertyPreview> for PropertyDescriptor {
 }
 
 /// <https://searchfox.org/mozilla-central/source/devtools/server/actors/object/utils.js#148>
-fn property_value_to_json(prop: &PropertyPreview) -> Value {
+fn property_value_to_json(prop: &PropertyDescriptor) -> Value {
     match prop.value_type.as_str() {
         "undefined" => {
             let mut v = Map::new();
@@ -129,7 +129,7 @@ pub(crate) struct ObjectActor {
     name: String,
     _uuid: Option<String>,
     class: String,
-    properties: Vec<PropertyPreview>,
+    properties: Vec<PropertyDescriptor>,
 }
 
 impl Actor for ObjectActor {
@@ -204,7 +204,7 @@ impl ObjectActor {
         registry: &ActorRegistry,
         uuid: Option<String>,
         class: String,
-        properties: Vec<PropertyPreview>,
+        properties: Vec<PropertyDescriptor>,
     ) -> String {
         let Some(uuid) = uuid else {
             let name = registry.new_name::<Self>();

--- a/components/devtools/actors/property_iterator.rs
+++ b/components/devtools/actors/property_iterator.rs
@@ -4,31 +4,31 @@
 
 use std::collections::HashMap;
 
-use devtools_traits::PropertyPreview;
+use devtools_traits::PropertyDescriptor;
 use malloc_size_of_derive::MallocSizeOf;
 use serde::Serialize;
 use serde_json::{Map, Value};
 
 use crate::StreamId;
 use crate::actor::{Actor, ActorError, ActorRegistry};
-use crate::actors::object::PropertyDescriptor;
+use crate::actors::object::ObjectPropertyDescriptor;
 use crate::protocol::ClientRequest;
 
 #[derive(Serialize)]
 #[serde(rename_all = "camelCase")]
 struct SliceReply {
     from: String,
-    own_properties: HashMap<String, PropertyDescriptor>,
+    own_properties: HashMap<String, ObjectPropertyDescriptor>,
 }
 
 #[derive(MallocSizeOf)]
 pub(crate) struct PropertyIteratorActor {
     name: String,
-    properties: Vec<PropertyPreview>,
+    properties: Vec<PropertyDescriptor>,
 }
 
 impl PropertyIteratorActor {
-    pub fn register(registry: &ActorRegistry, properties: Vec<PropertyPreview>) -> String {
+    pub fn register(registry: &ActorRegistry, properties: Vec<PropertyDescriptor>) -> String {
         let name = registry.new_name::<Self>();
         let actor = Self {
             name: name.clone(),
@@ -66,7 +66,7 @@ impl Actor for PropertyIteratorActor {
 
                 let mut own_properties = HashMap::new();
                 for prop in self.properties.iter().skip(start).take(count) {
-                    own_properties.insert(prop.name.clone(), PropertyDescriptor::from(prop));
+                    own_properties.insert(prop.name.clone(), ObjectPropertyDescriptor::from(prop));
                 }
 
                 let reply = SliceReply {

--- a/components/script/dom/debugger/debuggerglobalscope.rs
+++ b/components/script/dom/debugger/debuggerglobalscope.rs
@@ -527,7 +527,7 @@ impl DebuggerGlobalScopeMethods<crate::DomTypeHolder> for DebuggerGlobalScope {
                     opt.as_ref().map(|props| {
                         props
                             .iter()
-                            .map(|prop| devtools_traits::PropertyPreview {
+                            .map(|prop| devtools_traits::PropertyDescriptor {
                                 name: prop.name.to_string(),
                                 configurable: prop.configurable,
                                 enumerable: prop.enumerable,

--- a/components/script_bindings/webidls/DebuggerEvalEvent.webidl
+++ b/components/script_bindings/webidls/DebuggerEvalEvent.webidl
@@ -48,7 +48,7 @@ dictionary EvalResultValue {
     boolean? isGenerator;
 
     // Object preview properties
-    sequence<PropertyPreview>? ownProperties;
+    sequence<PropertyDescriptor>? ownProperties;
     unsigned long? ownPropertiesLength;
 
     // Array-specific
@@ -57,7 +57,7 @@ dictionary EvalResultValue {
 };
 
 // TODO: Maybe merge some parts of this with the EvalResultValue
-dictionary PropertyPreview {
+dictionary PropertyDescriptor {
     required DOMString name;
     required boolean configurable;
     required boolean enumerable;

--- a/components/shared/devtools/lib.rs
+++ b/components/shared/devtools/lib.rs
@@ -154,7 +154,7 @@ pub enum DomMutation {
 /// <https://searchfox.org/mozilla-central/source/devtools/server/actors/object/property-iterator.js#51>
 #[derive(Clone, Debug, Deserialize, MallocSizeOf, Serialize)]
 #[serde(rename_all = "camelCase")]
-pub struct PropertyPreview {
+pub struct PropertyDescriptor {
     pub name: String,
     pub configurable: bool,
     pub enumerable: bool,
@@ -190,7 +190,7 @@ pub enum EvaluateJSReplyValue {
         is_async: Option<bool>,
         is_generator: Option<bool>,
         // Object preview
-        own_properties: Option<Vec<PropertyPreview>>,
+        own_properties: Option<Vec<PropertyDescriptor>>,
         own_properties_length: Option<u32>,
         // Array-specific
         kind: Option<String>,


### PR DESCRIPTION
Rename `PropertyPreview` to `PropertyDescriptor`

Testing: Internal refactor
Part of: #36027