### PR TITLE
script: Pass &mut JSContext to CSSStyleRule::Style

### DIFF
--- a/components/script/devtools.rs
+++ b/components/script/devtools.rs
@@ -342,7 +342,7 @@ pub(crate) fn handle_get_stylesheet_style(
                 if selector != style.SelectorText() {
                     return None;
                 };
-                Some(style.Style(CanGc::from_cx(cx)))
+                Some(style.Style(cx))
             })
             .flat_map(|style| {
                 (0..style.Length()).map(move |i| {

--- a/components/script/dom/css/cssstylerule.rs
+++ b/components/script/dom/css/cssstylerule.rs
@@ -7,6 +7,7 @@ use std::mem;
 
 use cssparser::{Parser as CssParser, ParserInput as CssParserInput, ToCss};
 use dom_struct::dom_struct;
+use js::context::JSContext;
 use selectors::parser::{ParseRelative, SelectorList};
 use servo_arc::Arc;
 use style::selector_parser::SelectorParser;
@@ -104,7 +105,7 @@ impl SpecificCSSRule for CSSStyleRule {
 
 impl CSSStyleRuleMethods<crate::DomTypeHolder> for CSSStyleRule {
     /// <https://drafts.csswg.org/cssom/#dom-cssstylerule-style>
-    fn Style(&self, can_gc: CanGc) -> DomRoot<CSSStyleDeclaration> {
+    fn Style(&self, cx: &mut JSContext) -> DomRoot<CSSStyleDeclaration> {
         self.style_declaration.or_init(|| {
             let guard = self.css_grouping_rule.shared_lock().read();
             CSSStyleDeclaration::new(
@@ -115,7 +116,7 @@ impl CSSStyleRuleMethods<crate::DomTypeHolder> for CSSStyleRule {
                 ),
                 None,
                 CSSModificationAccess::ReadWrite,
-                can_gc,
+                CanGc::from_cx(cx),
             )
         })
     }

--- a/components/script_bindings/codegen/Bindings.conf
+++ b/components/script_bindings/codegen/Bindings.conf
@@ -151,7 +151,7 @@ DOMInterfaces = {
 },
 
 'CSSStyleRule': {
-    'canGc': ['Style'],
+    'cx': ['Style'],
 },
 
 'CSSStyleSheet': {


### PR DESCRIPTION
Move `CSSStyleRule::Style` from `CanGc` to `&mut JSContext`. Also fix the caller in `devtools.rs` to pass `cx` directly.

Testing: Refactoring, It compiles.
Fixes: Part of #42638
