### PR TITLE
script: Pass &mut JSContext to CSSNestedDeclarations::Style

### DIFF
--- a/components/script/dom/css/cssnesteddeclarations.rs
+++ b/components/script/dom/css/cssnesteddeclarations.rs
@@ -5,6 +5,7 @@
 use std::cell::RefCell;
 
 use dom_struct::dom_struct;
+use js::context::JSContext;
 use servo_arc::Arc;
 use style::shared_lock::{Locked, SharedRwLockReadGuard, ToCssWithGuard};
 use style::stylesheets::{CssRuleType, NestedDeclarationsRule};
@@ -87,7 +88,7 @@ impl SpecificCSSRule for CSSNestedDeclarations {
 
 impl CSSNestedDeclarationsMethods<crate::DomTypeHolder> for CSSNestedDeclarations {
     /// <https://drafts.csswg.org/css-nesting/#dom-cssnesteddeclarations-style>
-    fn Style(&self, can_gc: CanGc) -> DomRoot<CSSStyleDeclaration> {
+    fn Style(&self, cx: &mut JSContext) -> DomRoot<CSSStyleDeclaration> {
         self.style_declaration.or_init(|| {
             let guard = self.css_rule.shared_lock().read();
             CSSStyleDeclaration::new(
@@ -104,7 +105,7 @@ impl CSSNestedDeclarationsMethods<crate::DomTypeHolder> for CSSNestedDeclaration
                 ),
                 None,
                 CSSModificationAccess::ReadWrite,
-                can_gc,
+                CanGc::from_cx(cx),
             )
         })
     }

--- a/components/script_bindings/codegen/Bindings.conf
+++ b/components/script_bindings/codegen/Bindings.conf
@@ -143,7 +143,7 @@ DOMInterfaces = {
 },
 
 'CSSNestedDeclarations': {
-    'canGc': ['Style'],
+    'cx': ['Style'],
 },
 
 'CSSRuleList': {


### PR DESCRIPTION
Move `CSSNestedDeclarations::Style` from `CanGc` to `&mut JSContext`.

Testing: It compiles.
Fixes: Part of #42638
