### PR TITLE
script: Use encoding-parse algorithm when handling iframe and Document URL attributes

### DIFF
--- a/components/script/dom/element.rs
+++ b/components/script/dom/element.rs
@@ -2425,10 +2425,8 @@ impl Element {
             return Default::default();
         };
         let value = &**attribute.value();
-        // XXXManishearth this doesn't handle `javascript:` urls properly
         self.owner_document()
-            .base_url()
-            .join(value)
+            .encoding_parse_a_url(value)
             .map(|parsed| USVString(parsed.into_string()))
             .unwrap_or_else(|_| USVString(value.to_owned()))
     }
@@ -2450,10 +2448,8 @@ impl Element {
             return TrustedScriptURLOrUSVString::USVString(USVString::default());
         };
         let value = &**attribute.value();
-        // XXXManishearth this doesn't handle `javascript:` urls properly
         self.owner_document()
-            .base_url()
-            .join(value)
+            .encoding_parse_a_url(value)
             .map(|parsed| TrustedScriptURLOrUSVString::USVString(USVString(parsed.into_string())))
             .unwrap_or_else(|_| TrustedScriptURLOrUSVString::USVString(USVString(value.to_owned())))
     }

--- a/components/script/dom/html/htmliframeelement.rs
+++ b/components/script/dom/html/htmliframeelement.rs
@@ -129,7 +129,7 @@ impl HTMLIFrameElement {
                     // Step 2.1. Let maybeURL be the result of encoding-parsing a URL given that attribute's value,
                     // relative to element's node document.
                     // Step 2.2. If maybeURL is not failure, then set url to maybeURL.
-                    self.owner_document().base_url().join(&url).ok()
+                    self.owner_document().encoding_parse_a_url(&url).ok()
                 }
             })
             // Step 1. Let url be the URL record about:blank.

--- a/tests/wpt/tests/html/semantics/embedded-content/the-iframe-element/iframe-src-encoding.html
+++ b/tests/wpt/tests/html/semantics/embedded-content/the-iframe-element/iframe-src-encoding.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<meta charset=windows-1252>
+<title>iframe src URL is parsed using document encoding</title>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<body>
+<script>
+async_test(t => {
+  let frame = document.createElement('iframe');
+  frame.src = "resources/frame-encoding.html?\u00DF";
+  document.body.appendChild(frame);
+  frame.onload = t.step_func(() => {
+    assert_equals(frame.contentWindow.location.search, "?%DF");
+    assert_equals(frame.contentWindow.test.textContent, "?%DF");
+    assert_equals(frame.src, new URL("resources/frame-encoding.html?%DF", location.href).href);
+    t.done();
+  });
+});
+</script>

--- a/tests/wpt/tests/html/semantics/embedded-content/the-iframe-element/resources/frame-encoding.html
+++ b/tests/wpt/tests/html/semantics/embedded-content/the-iframe-element/resources/frame-encoding.html
@@ -1,0 +1,6 @@
+<!doctype html>
+<meta charset="utf-8">
+<div id=test></div>
+<script>
+test.textContent = location.search;
+</script>


### PR DESCRIPTION
This PR fixes iframe URL parsing to use document encoding, so non-UTF-8 pages reflect iframe.src  correctly, and adds a WPT test for it.

Testing: added Test file 
Fixes: #43559 