### PR TITLE
servoshell: Remove --userscripts option

### DIFF
--- a/etc/ci/performance/runner.py
+++ b/etc/ci/performance/runner.py
@@ -8,7 +8,6 @@ import argparse
 import csv
 import itertools
 import json
-import os
 import platform
 import subprocess
 from datetime import datetime
@@ -68,11 +67,9 @@ def run_servo_test(testcase, url, date, timeout, is_async):
         # Return a placeholder
         return parse_log("", testcase, url, date)
 
-    ua_script_path = "{}/user-agent-js".format(os.getcwd())
     command = [
         "../../../target/release/servoshell",
         url,
-        "--userscripts=" + ua_script_path,
         "--headless",
         "-x",
         "-o",

--- a/ports/servoshell/desktop/app.rs
+++ b/ports/servoshell/desktop/app.rs
@@ -4,15 +4,12 @@
 
 //! Application entry point, runs the event loop.
 
-use std::path::Path;
 use std::rc::Rc;
 use std::time::Instant;
 use std::{env, fs};
 
 use servo::protocol_handler::ProtocolRegistry;
-use servo::{
-    EventLoopWaker, Opts, Preferences, ServoBuilder, ServoUrl, UserContentManager, UserScript,
-};
+use servo::{EventLoopWaker, Opts, Preferences, ServoBuilder, ServoUrl, UserContentManager};
 use url::Url;
 use winit::application::ApplicationHandler;
 use winit::event::WindowEvent;
@@ -113,11 +110,6 @@ impl App {
         servo.setup_logging();
 
         let user_content_manager = Rc::new(UserContentManager::new(&servo));
-        for script in load_userscripts(self.servoshell_preferences.userscripts_directory.as_deref())
-            .expect("Loading userscripts failed")
-        {
-            user_content_manager.add_script(Rc::new(script));
-        }
 
         for user_stylesheet in &self.servoshell_preferences.user_stylesheets {
             user_content_manager.add_stylesheet(user_stylesheet.clone());
@@ -233,19 +225,4 @@ impl ApplicationHandler<AppEvent> for App {
         // Block until the window gets an event
         event_loop.set_control_flow(ControlFlow::Wait);
     }
-}
-
-fn load_userscripts(userscripts_directory: Option<&Path>) -> std::io::Result<Vec<UserScript>> {
-    let mut userscripts = Vec::new();
-    if let Some(userscripts_directory) = &userscripts_directory {
-        let mut files = std::fs::read_dir(userscripts_directory)?
-            .map(|e| e.map(|entry| entry.path()))
-            .collect::<Result<Vec<_>, _>>()?;
-        files.sort_unstable();
-        for file in files {
-            let script = std::fs::read_to_string(&file)?;
-            userscripts.push(UserScript::new(script, Some(file)));
-        }
-    }
-    Ok(userscripts)
 }

--- a/ports/servoshell/prefs.rs
+++ b/ports/servoshell/prefs.rs
@@ -78,9 +78,6 @@ pub(crate) struct ServoShellPreferences {
     pub output_image_path: Option<String>,
     /// Whether or not to exit after Servo detects a stable output image in all WebViews.
     pub exit_after_stable_image: bool,
-    /// Where to load userscripts from, if any.
-    /// and if the option isn't passed userscripts won't be loaded.
-    pub userscripts_directory: Option<PathBuf>,
     /// A set of [`UserStylesheets`] to load for content.
     pub user_stylesheets: Vec<Rc<UserStyleSheet>>,
     /// `None` to disable WebDriver or `Some` with a port number to start a server to listen to
@@ -113,7 +110,6 @@ impl Default for ServoShellPreferences {
             url: None,
             output_image_path: None,
             exit_after_stable_image: false,
-            userscripts_directory: None,
             user_stylesheets: Default::default(),
             webdriver_port: Cell::new(None),
             #[cfg(target_env = "ohos")]
@@ -338,17 +334,6 @@ fn profile() -> impl Parser<Option<OutputOptions>> {
     )
 }
 
-fn userscripts() -> impl Parser<Option<PathBuf>> {
-    flag_with_default_parser(
-        None,
-        "userscripts_directory",
-        "your/directory",
-        "Uses userscripts in resources/user-agent-js, or a specified full path",
-        PathBuf::from("resources/user-agent-js"),
-        |val: String| PathBuf::from(val),
-    )
-}
-
 fn webdriver_port() -> impl Parser<Option<u16>> {
     flag_with_default_parser(
         None,
@@ -533,11 +518,6 @@ struct CmdArgs {
     user_agent: Option<String>,
 
     ///
-    ///  Uses userscripts in resources/user-agent-js, or a specified full path.
-    #[bpaf(external)]
-    userscripts: Option<PathBuf>,
-
-    ///
     /// Add each of the given UTF-8 encoded CSS files in the space or comma-separated
     /// list as user stylesheet to apply to every page loaded.
     #[bpaf(argument::<String>("file.css"), parse(parse_user_stylesheets),
@@ -685,7 +665,6 @@ fn parse_arguments_helper(args_without_binary: Args) -> ArgumentParsingResult {
         webdriver_port: Cell::new(cmd_args.webdriver_port),
         output_image_path: cmd_args.output.map(|p| p.to_string_lossy().into_owned()),
         exit_after_stable_image: cmd_args.exit,
-        userscripts_directory: cmd_args.userscripts,
         user_stylesheets: cmd_args.user_stylesheet,
         experimental_preferences_enabled: cmd_args.enable_experimental_web_platform_features,
         #[cfg(target_env = "ohos")]

--- a/resources/user-agent-js/00.example.js
+++ b/resources/user-agent-js/00.example.js
@@ -1,6 +1,0 @@
-// Keep files in this directory which you would like executed before
-// any other script when servo is run with `--userscripts`
-// Files are sorted alphabetically. When committing polyfills
-// order them with numbers, e.g. `01.innerhtml.js` will be executed before
-// `05.jquery.js`
-onunhandledrejection = (e) => console.error("xxxjdm error: " + JSON.stringify(e.reason));


### PR DESCRIPTION
In #43182 it was [suggested to remove the userscripts](https://github.com/servo/servo/pull/43182#issuecomment-4048383093) option, since embedders can use the (new) `UserContentManager` API instead.

Testing: This removes a commandline flag from servoshell. Existing tests passing is sufficient.

