### PR TITLE
script: Pass down &mut JSContext to CSSGroupingRule methods

### DIFF
--- a/components/script/dom/css/cssgroupingrule.rs
+++ b/components/script/dom/css/cssgroupingrule.rs
@@ -3,6 +3,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 use dom_struct::dom_struct;
+use js::context::JSContext;
 use servo_arc::Arc;
 use style::shared_lock::{Locked, SharedRwLock, SharedRwLockReadGuard};
 use style::stylesheets::{CssRuleType, CssRuleTypes, CssRules};
@@ -35,7 +36,7 @@ impl CSSGroupingRule {
         }
     }
 
-    fn rulelist(&self, can_gc: CanGc) -> DomRoot<CSSRuleList> {
+    fn rulelist(&self, cx: &mut JSContext) -> DomRoot<CSSRuleList> {
         let parent_stylesheet = self.upcast::<CSSRule>().parent_stylesheet();
         self.rule_list.or_init(|| {
             let rules = if let Some(rule) = self.downcast::<CSSConditionRule>() {
@@ -51,7 +52,7 @@ impl CSSGroupingRule {
                 self.global().as_window(),
                 parent_stylesheet,
                 RulesSource::Rules(rules),
-                can_gc,
+                CanGc::from_cx(cx),
             )
         })
     }
@@ -77,13 +78,13 @@ impl CSSGroupingRule {
 
 impl CSSGroupingRuleMethods<crate::DomTypeHolder> for CSSGroupingRule {
     /// <https://drafts.csswg.org/cssom/#dom-cssgroupingrule-cssrules>
-    fn CssRules(&self, can_gc: CanGc) -> DomRoot<CSSRuleList> {
+    fn CssRules(&self, cx: &mut JSContext) -> DomRoot<CSSRuleList> {
         // XXXManishearth check origin clean flag
-        self.rulelist(can_gc)
+        self.rulelist(cx)
     }
 
     /// <https://drafts.csswg.org/cssom/#dom-cssgroupingrule-insertrule>
-    fn InsertRule(&self, rule: DOMString, index: u32, can_gc: CanGc) -> Fallible<u32> {
+    fn InsertRule(&self, cx: &mut JSContext, rule: DOMString, index: u32) -> Fallible<u32> {
         // TODO: this should accumulate the rule types of all ancestors.
         let rule_type = self.css_rule.as_specific().ty();
         let containing_rule_types = CssRuleTypes::from(rule_type);
@@ -91,17 +92,17 @@ impl CSSGroupingRuleMethods<crate::DomTypeHolder> for CSSGroupingRule {
             CssRuleType::Style | CssRuleType::Scope => Some(rule_type),
             _ => None,
         };
-        self.rulelist(can_gc).insert_rule(
+        self.rulelist(cx).insert_rule(
             &rule,
             index,
             containing_rule_types,
             parse_relative_rule_type,
-            can_gc,
+            CanGc::from_cx(cx),
         )
     }
 
     /// <https://drafts.csswg.org/cssom/#dom-cssgroupingrule-deleterule>
-    fn DeleteRule(&self, index: u32, can_gc: CanGc) -> ErrorResult {
-        self.rulelist(can_gc).remove_rule(index)
+    fn DeleteRule(&self, cx: &mut JSContext, index: u32) -> ErrorResult {
+        self.rulelist(cx).remove_rule(index)
     }
 }

--- a/components/script_bindings/codegen/Bindings.conf
+++ b/components/script_bindings/codegen/Bindings.conf
@@ -123,7 +123,7 @@ DOMInterfaces = {
 },
 
 'CSSGroupingRule': {
-    'canGc': ['CssRules', 'DeleteRule', 'InsertRule'],
+    'cx': ['CssRules', 'InsertRule', 'DeleteRule'],
 },
 
 'CSSKeyframeRule': {


### PR DESCRIPTION
Move `CSSGroupingRule` methods from `CanGc` to `&mut JSContext`.

Testing:  Just refactor.
Fixes: Part of  #42638
