### PR TITLE
servo: Add a `BluetoothDeviceSelectionRequest` to the API for selecting Bluetooth devices

### DIFF
--- a/components/bluetooth/lib.rs
+++ b/components/bluetooth/lib.rs
@@ -14,7 +14,7 @@ use std::thread;
 use std::time::Duration;
 
 use bitflags::bitflags;
-use embedder_traits::{EmbedderMsg, EmbedderProxy};
+use embedder_traits::{BluetoothDeviceDescription, EmbedderMsg, EmbedderProxy};
 use log::warn;
 use rand::{self, Rng};
 #[cfg(not(feature = "native-bluetooth"))]
@@ -485,7 +485,7 @@ impl BluetoothManager {
             return None;
         }
 
-        let mut dialog_rows: Vec<String> = vec![];
+        let mut device_descriptions = Vec::with_capacity(devices.len());
         for device in devices {
             let address = device.get_address().unwrap_or_default();
             let name = device.get_name().await.unwrap_or_else(|_| {
@@ -496,7 +496,7 @@ impl BluetoothManager {
                 };
                 format!("Unknown ({}...)", short)
             });
-            dialog_rows.extend_from_slice(&[address, name]);
+            device_descriptions.push(BluetoothDeviceDescription { address, name });
         }
 
         let (ipc_sender, ipc_receiver) =
@@ -504,7 +504,7 @@ impl BluetoothManager {
         self.embedder_proxy
             .send(EmbedderMsg::GetSelectedBluetoothDevice(
                 webview_id,
-                dialog_rows,
+                device_descriptions,
                 ipc_sender,
             ));
 

--- a/components/servo/lib.rs
+++ b/components/servo/lib.rs
@@ -76,10 +76,10 @@ pub use crate::site_data_manager::{SiteData, SiteDataManager, StorageType};
 pub use crate::user_content_manager::UserContentManager;
 pub use crate::webview::{WebView, WebViewBuilder};
 pub use crate::webview_delegate::{
-    AlertDialog, AllowOrDenyRequest, AuthenticationRequest, ColorPicker, ConfirmDialog,
-    ContextMenu, CreateNewWebViewRequest, EmbedderControl, FilePicker, InputMethodControl,
-    NavigationRequest, PermissionRequest, PromptDialog, SelectElement, SimpleDialog,
-    WebResourceLoad, WebViewDelegate,
+    AlertDialog, AllowOrDenyRequest, AuthenticationRequest, BluetoothPickDeviceRequest,
+    ColorPicker, ConfirmDialog, ContextMenu, CreateNewWebViewRequest, EmbedderControl, FilePicker,
+    InputMethodControl, NavigationRequest, PermissionRequest, PromptDialog, SelectElement,
+    SimpleDialog, WebResourceLoad, WebViewDelegate,
 };
 
 #[cfg(feature = "webxr")]

--- a/components/servo/lib.rs
+++ b/components/servo/lib.rs
@@ -76,7 +76,7 @@ pub use crate::site_data_manager::{SiteData, SiteDataManager, StorageType};
 pub use crate::user_content_manager::UserContentManager;
 pub use crate::webview::{WebView, WebViewBuilder};
 pub use crate::webview_delegate::{
-    AlertDialog, AllowOrDenyRequest, AuthenticationRequest, BluetoothPickDeviceRequest,
+    AlertDialog, AllowOrDenyRequest, AuthenticationRequest, BluetoothDeviceSelectionRequest,
     ColorPicker, ConfirmDialog, ContextMenu, CreateNewWebViewRequest, EmbedderControl, FilePicker,
     InputMethodControl, NavigationRequest, PermissionRequest, PromptDialog, SelectElement,
     SimpleDialog, WebResourceLoad, WebViewDelegate,

--- a/components/servo/servo.rs
+++ b/components/servo/servo.rs
@@ -84,7 +84,7 @@ use crate::servo_delegate::{DefaultServoDelegate, ServoDelegate, ServoError};
 use crate::site_data_manager::SiteDataManager;
 use crate::webview::{MINIMUM_WEBVIEW_SIZE, WebView, WebViewInner};
 use crate::webview_delegate::{
-    AllowOrDenyRequest, AuthenticationRequest, BluetoothPickDeviceRequest, EmbedderControl,
+    AllowOrDenyRequest, AuthenticationRequest, BluetoothDeviceSelectionRequest, EmbedderControl,
     FilePicker, NavigationRequest, PermissionRequest, ProtocolHandlerRegistration, WebResourceLoad,
 };
 
@@ -564,7 +564,7 @@ impl ServoInner {
                 if let Some(webview) = self.get_webview_handle(webview_id) {
                     webview.delegate().show_bluetooth_device_dialog(
                         webview,
-                        BluetoothPickDeviceRequest::new(items, response_sender),
+                        BluetoothDeviceSelectionRequest::new(items, response_sender),
                     );
                 }
             },

--- a/components/servo/servo.rs
+++ b/components/servo/servo.rs
@@ -84,8 +84,8 @@ use crate::servo_delegate::{DefaultServoDelegate, ServoDelegate, ServoError};
 use crate::site_data_manager::SiteDataManager;
 use crate::webview::{MINIMUM_WEBVIEW_SIZE, WebView, WebViewInner};
 use crate::webview_delegate::{
-    AllowOrDenyRequest, AuthenticationRequest, EmbedderControl, FilePicker, NavigationRequest,
-    PermissionRequest, ProtocolHandlerRegistration, WebResourceLoad,
+    AllowOrDenyRequest, AuthenticationRequest, BluetoothPickDeviceRequest, EmbedderControl,
+    FilePicker, NavigationRequest, PermissionRequest, ProtocolHandlerRegistration, WebResourceLoad,
 };
 
 #[cfg(feature = "media-gstreamer")]
@@ -564,8 +564,7 @@ impl ServoInner {
                 if let Some(webview) = self.get_webview_handle(webview_id) {
                     webview.delegate().show_bluetooth_device_dialog(
                         webview,
-                        items,
-                        response_sender,
+                        BluetoothPickDeviceRequest::new(items, response_sender),
                     );
                 }
             },

--- a/components/servo/webview_delegate.rs
+++ b/components/servo/webview_delegate.rs
@@ -127,32 +127,35 @@ pub struct ProtocolHandlerRegistration {
 }
 
 /// A request to let the user chose a Bluetooth device.
-pub struct BluetoothPickDeviceRequest {
-    pub devices: Vec<BluetoothDeviceDescription>,
+pub struct BluetoothDeviceSelectionRequest {
+    devices: Vec<BluetoothDeviceDescription>,
     responder: IpcResponder<Option<String>>,
-    response_sent: bool,
 }
 
-impl BluetoothPickDeviceRequest {
-    pub fn new(
+impl BluetoothDeviceSelectionRequest {
+    pub(crate) fn new(
         devices: Vec<BluetoothDeviceDescription>,
         responder: GenericSender<Option<String>>,
     ) -> Self {
         Self {
             devices,
             responder: IpcResponder::new(responder, None),
-            response_sent: false,
         }
     }
 
-    pub fn pick_device(&mut self, device: &str) -> Result<(), SendError> {
-        self.response_sent = true;
-        self.responder.send(Some(device.to_owned()))
+    /// Set the device chosen by the user.
+    pub fn pick_device(mut self, device: &BluetoothDeviceDescription) -> Result<(), SendError> {
+        self.responder.send(Some(device.address.clone()))
     }
 
-    pub fn cancel(&mut self) -> Result<(), SendError> {
-        self.response_sent = true;
+    /// Cancel this request.
+    pub fn cancel(mut self) -> Result<(), SendError> {
         self.responder.send(None)
+    }
+
+    /// The set of devices that the user can chose from.
+    pub fn devices(&self) -> &Vec<BluetoothDeviceDescription> {
+        &self.devices
     }
 }
 
@@ -973,7 +976,7 @@ pub trait WebViewDelegate {
     }
 
     /// Open dialog to select bluetooth device.
-    fn show_bluetooth_device_dialog(&self, _webview: WebView, _: BluetoothPickDeviceRequest) {}
+    fn show_bluetooth_device_dialog(&self, _webview: WebView, _: BluetoothDeviceSelectionRequest) {}
 
     /// Request that the embedder show UI elements for form controls that are not integrated
     /// into page content, such as dropdowns for `<select>` elements.

--- a/components/servo/webview_delegate.rs
+++ b/components/servo/webview_delegate.rs
@@ -9,16 +9,16 @@ use constellation_traits::EmbedderToConstellationMessage;
 #[cfg(feature = "gamepad")]
 use embedder_traits::GamepadHapticEffectType;
 use embedder_traits::{
-    AlertResponse, AllowOrDeny, AuthenticationResponse, ConfirmResponse, ConsoleLogLevel,
-    ContextMenuAction, ContextMenuElementInformation, ContextMenuItem, Cursor, EmbedderControlId,
-    EmbedderControlResponse, FilePickerRequest, FilterPattern, InputEventId, InputEventResult,
-    InputMethodType, LoadStatus, MediaSessionEvent, NewWebViewDetails, Notification,
-    PermissionFeature, PromptResponse, RgbColor, ScreenGeometry, SelectElementOptionOrOptgroup,
-    SimpleDialogRequest, TraversalId, WebResourceRequest, WebResourceResponse,
-    WebResourceResponseMsg,
+    AlertResponse, AllowOrDeny, AuthenticationResponse, BluetoothDeviceDescription,
+    ConfirmResponse, ConsoleLogLevel, ContextMenuAction, ContextMenuElementInformation,
+    ContextMenuItem, Cursor, EmbedderControlId, EmbedderControlResponse, FilePickerRequest,
+    FilterPattern, InputEventId, InputEventResult, InputMethodType, LoadStatus, MediaSessionEvent,
+    NewWebViewDetails, Notification, PermissionFeature, PromptResponse, RgbColor, ScreenGeometry,
+    SelectElementOptionOrOptgroup, SimpleDialogRequest, TraversalId, WebResourceRequest,
+    WebResourceResponse, WebResourceResponseMsg,
 };
 use paint_api::rendering_context::RenderingContext;
-use servo_base::generic_channel::GenericSender;
+use servo_base::generic_channel::{GenericSender, SendError};
 use servo_base::id::PipelineId;
 use tokio::sync::mpsc::UnboundedSender as TokioSender;
 use tokio::sync::oneshot::Sender;
@@ -124,6 +124,36 @@ pub struct ProtocolHandlerRegistration {
     pub scheme: String,
     pub url: Url,
     pub register_or_unregister: RegisterOrUnregister,
+}
+
+/// A request to let the user chose a Bluetooth device.
+pub struct BluetoothPickDeviceRequest {
+    pub devices: Vec<BluetoothDeviceDescription>,
+    responder: IpcResponder<Option<String>>,
+    response_sent: bool,
+}
+
+impl BluetoothPickDeviceRequest {
+    pub fn new(
+        devices: Vec<BluetoothDeviceDescription>,
+        responder: GenericSender<Option<String>>,
+    ) -> Self {
+        Self {
+            devices,
+            responder: IpcResponder::new(responder, None),
+            response_sent: false,
+        }
+    }
+
+    pub fn pick_device(&mut self, device: &str) -> Result<(), SendError> {
+        self.response_sent = true;
+        self.responder.send(Some(device.to_owned()))
+    }
+
+    pub fn cancel(&mut self) -> Result<(), SendError> {
+        self.response_sent = true;
+        self.responder.send(None)
+    }
 }
 
 /// A request to authenticate a [`WebView`] navigation. Embedders may choose to prompt
@@ -943,15 +973,7 @@ pub trait WebViewDelegate {
     }
 
     /// Open dialog to select bluetooth device.
-    /// TODO: This API needs to be reworked to match the new model of how responses are sent.
-    fn show_bluetooth_device_dialog(
-        &self,
-        _webview: WebView,
-        _: Vec<String>,
-        response_sender: GenericSender<Option<String>>,
-    ) {
-        let _ = response_sender.send(None);
-    }
+    fn show_bluetooth_device_dialog(&self, _webview: WebView, _: BluetoothPickDeviceRequest) {}
 
     /// Request that the embedder show UI elements for form controls that are not integrated
     /// into page content, such as dropdowns for `<select>` elements.

--- a/components/shared/embedder/lib.rs
+++ b/components/shared/embedder/lib.rs
@@ -424,6 +424,12 @@ impl From<ConsoleLogLevel> for log::Level {
     }
 }
 
+#[derive(Deserialize, Serialize)]
+pub struct BluetoothDeviceDescription {
+    pub address: String,
+    pub name: String,
+}
+
 /// Messages towards the embedder.
 #[derive(Deserialize, IntoStaticStr, Serialize)]
 pub enum EmbedderMsg {
@@ -483,7 +489,11 @@ pub enum EmbedderMsg {
     /// A pipeline panicked. First string is the reason, second one is the backtrace.
     Panic(WebViewId, String, Option<String>),
     /// Open dialog to select bluetooth device.
-    GetSelectedBluetoothDevice(WebViewId, Vec<String>, GenericSender<Option<String>>),
+    GetSelectedBluetoothDevice(
+        WebViewId,
+        Vec<BluetoothDeviceDescription>,
+        GenericSender<Option<String>>,
+    ),
     /// Open interface to request permission specified by prompt.
     PromptPermission(WebViewId, PermissionFeature, GenericSender<AllowOrDeny>),
     /// Report a complete sampled profile

--- a/components/shared/embedder/lib.rs
+++ b/components/shared/embedder/lib.rs
@@ -424,7 +424,7 @@ impl From<ConsoleLogLevel> for log::Level {
     }
 }
 
-#[derive(Deserialize, Serialize)]
+#[derive(Clone, Deserialize, Serialize)]
 pub struct BluetoothDeviceDescription {
     pub address: String,
     pub name: String,

--- a/ports/servoshell/desktop/dialog.rs
+++ b/ports/servoshell/desktop/dialog.rs
@@ -12,10 +12,10 @@ use egui_file_dialog::{DialogState, FileDialog as EguiFileDialog};
 use euclid::Length;
 use log::warn;
 use servo::{
-    AlertDialog, AuthenticationRequest, ColorPicker, ConfirmDialog, ContextMenu, ContextMenuItem,
-    DeviceIndependentPixel, EmbedderControlId, FilePicker, GenericSender, PermissionRequest,
-    PromptDialog, RgbColor, SelectElement, SelectElementOption, SelectElementOptionOrOptgroup,
-    SimpleDialog,
+    AlertDialog, AuthenticationRequest, BluetoothPickDeviceRequest, ColorPicker, ConfirmDialog,
+    ContextMenu, ContextMenuItem, DeviceIndependentPixel, EmbedderControlId, FilePicker,
+    PermissionRequest, PromptDialog, RgbColor, SelectElement, SelectElementOption,
+    SelectElementOptionOrOptgroup, SimpleDialog,
 };
 
 /// The minimum width of many UI elements including dialog boxes and menus,
@@ -41,9 +41,8 @@ pub enum Dialog {
         request: Option<PermissionRequest>,
     },
     SelectDevice {
-        devices: Vec<String>,
+        request: BluetoothPickDeviceRequest,
         selected_device_index: usize,
-        response_sender: GenericSender<Option<String>>,
     },
     SelectElement {
         maybe_prompt: Option<SelectElement>,
@@ -113,14 +112,10 @@ impl Dialog {
         }
     }
 
-    pub fn new_device_selection_dialog(
-        devices: Vec<String>,
-        response_sender: GenericSender<Option<String>>,
-    ) -> Self {
+    pub fn new_device_selection_dialog(request: BluetoothPickDeviceRequest) -> Self {
         Dialog::SelectDevice {
-            devices,
+            request,
             selected_device_index: 0,
-            response_sender,
         }
     }
 
@@ -406,9 +401,8 @@ impl Dialog {
                 is_open
             },
             Dialog::SelectDevice {
-                devices,
+                request,
                 selected_device_index,
-                response_sender,
             } => {
                 let mut is_open = true;
                 let modal = Modal::new("device_picker".into());
@@ -420,11 +414,14 @@ impl Dialog {
                     frame.content_ui.add_space(10.0);
 
                     egui::ComboBox::from_label("")
-                        .selected_text(&devices[*selected_device_index + 1])
+                        .selected_text(request.devices[*selected_device_index].name.clone())
                         .show_ui(&mut frame.content_ui, |ui| {
-                            for i in (0..devices.len() - 1).step_by(2) {
-                                let device_name = &devices[i + 1];
-                                ui.selectable_value(selected_device_index, i, device_name);
+                            for i in 0..request.devices.len() - 1 {
+                                ui.selectable_value(
+                                    selected_device_index,
+                                    i,
+                                    request.devices[i].name.clone(),
+                                );
                             }
                         });
 
@@ -437,18 +434,18 @@ impl Dialog {
                             if ui.button("Ok").clicked() ||
                                 ui.input(|i| i.key_pressed(egui::Key::Enter))
                             {
-                                if let Err(e) = response_sender
-                                    .send(Some(devices[*selected_device_index].clone()))
-                                {
-                                    warn!("Failed to send device selection: {}", e);
+                                let choice =
+                                    request.devices[*selected_device_index].address.clone();
+                                if let Err(error) = request.pick_device(&choice) {
+                                    warn!("Failed to send device selection: {error}");
                                 }
                                 is_open = false;
                             }
                             if ui.button("Cancel").clicked() ||
                                 ui.input(|i| i.key_pressed(egui::Key::Escape))
                             {
-                                if let Err(e) = response_sender.send(None) {
-                                    warn!("Failed to send cancellation: {}", e);
+                                if let Err(error) = request.cancel() {
+                                    warn!("Failed to send cancellation: {error}");
                                 }
                                 is_open = false;
                             }

--- a/ports/servoshell/desktop/dialog.rs
+++ b/ports/servoshell/desktop/dialog.rs
@@ -10,11 +10,11 @@ use egui::{
 };
 use egui_file_dialog::{DialogState, FileDialog as EguiFileDialog};
 use euclid::Length;
-use log::warn;
+use log::{error, warn};
 use servo::{
-    AlertDialog, AuthenticationRequest, BluetoothPickDeviceRequest, ColorPicker, ConfirmDialog,
-    ContextMenu, ContextMenuItem, DeviceIndependentPixel, EmbedderControlId, FilePicker,
-    PermissionRequest, PromptDialog, RgbColor, SelectElement, SelectElementOption,
+    AlertDialog, AuthenticationRequest, BluetoothDeviceSelectionRequest, ColorPicker,
+    ConfirmDialog, ContextMenu, ContextMenuItem, DeviceIndependentPixel, EmbedderControlId,
+    FilePicker, PermissionRequest, PromptDialog, RgbColor, SelectElement, SelectElementOption,
     SelectElementOptionOrOptgroup, SimpleDialog,
 };
 
@@ -41,7 +41,7 @@ pub enum Dialog {
         request: Option<PermissionRequest>,
     },
     SelectDevice {
-        request: BluetoothPickDeviceRequest,
+        request: Option<BluetoothDeviceSelectionRequest>,
         selected_device_index: usize,
     },
     SelectElement {
@@ -112,9 +112,9 @@ impl Dialog {
         }
     }
 
-    pub fn new_device_selection_dialog(request: BluetoothPickDeviceRequest) -> Self {
+    pub fn new_device_selection_dialog(request: BluetoothDeviceSelectionRequest) -> Self {
         Dialog::SelectDevice {
-            request,
+            request: Some(request),
             selected_device_index: 0,
         }
     }
@@ -407,25 +407,30 @@ impl Dialog {
                 let mut is_open = true;
                 let modal = Modal::new("device_picker".into());
                 modal.show(ctx, |ui| {
-                    let mut frame = egui::Frame::default().inner_margin(10.0).begin(ui);
-                    frame.content_ui.set_min_width(MINIMUM_UI_ELEMENT_WIDTH);
+                    if let Some(request) = request {
+                        let mut frame = egui::Frame::default().inner_margin(10.0).begin(ui);
+                        frame.content_ui.set_min_width(MINIMUM_UI_ELEMENT_WIDTH);
 
-                    frame.content_ui.heading("Choose a Device");
-                    frame.content_ui.add_space(10.0);
+                        frame.content_ui.heading("Choose a Device");
+                        frame.content_ui.add_space(10.0);
 
-                    egui::ComboBox::from_label("")
-                        .selected_text(request.devices[*selected_device_index].name.clone())
-                        .show_ui(&mut frame.content_ui, |ui| {
-                            for i in 0..request.devices.len() - 1 {
-                                ui.selectable_value(
-                                    selected_device_index,
-                                    i,
-                                    request.devices[i].name.clone(),
-                                );
-                            }
-                        });
+                        let devices = request.devices();
+                        egui::ComboBox::from_label("")
+                            .selected_text(devices[*selected_device_index].name.clone())
+                            .show_ui(&mut frame.content_ui, |ui| {
+                                for (i, device) in devices.into_iter().enumerate() {
+                                    ui.selectable_value(
+                                        selected_device_index,
+                                        i,
+                                        device.name.clone(),
+                                    );
+                                }
+                            });
 
-                    frame.end(ui);
+                        frame.end(ui);
+                    } else {
+                        error!("Unexpected: None SelectDevice while the dialog is open");
+                    }
 
                     egui::Sides::new().show(
                         ui,
@@ -434,9 +439,10 @@ impl Dialog {
                             if ui.button("Ok").clicked() ||
                                 ui.input(|i| i.key_pressed(egui::Key::Enter))
                             {
-                                let choice =
-                                    request.devices[*selected_device_index].address.clone();
-                                if let Err(error) = request.pick_device(&choice) {
+                                let request =
+                                    request.take().expect("non-None until dialog is closed");
+                                let choice = &request.devices()[*selected_device_index].clone();
+                                if let Err(error) = request.pick_device(choice) {
                                     warn!("Failed to send device selection: {error}");
                                 }
                                 is_open = false;
@@ -444,6 +450,8 @@ impl Dialog {
                             if ui.button("Cancel").clicked() ||
                                 ui.input(|i| i.key_pressed(egui::Key::Escape))
                             {
+                                let request =
+                                    request.take().expect("non-None until dialog is closed");
                                 if let Err(error) = request.cancel() {
                                     warn!("Failed to send cancellation: {error}");
                                 }

--- a/ports/servoshell/desktop/dialog.rs
+++ b/ports/servoshell/desktop/dialog.rs
@@ -418,7 +418,7 @@ impl Dialog {
                         egui::ComboBox::from_label("")
                             .selected_text(devices[*selected_device_index].name.clone())
                             .show_ui(&mut frame.content_ui, |ui| {
-                                for (i, device) in devices.into_iter().enumerate() {
+                                for (i, device) in devices.iter().enumerate() {
                                     ui.selectable_value(
                                         selected_device_index,
                                         i,

--- a/ports/servoshell/desktop/headed_window.rs
+++ b/ports/servoshell/desktop/headed_window.rs
@@ -18,9 +18,9 @@ use keyboard_types::ShortcutMatcher;
 use log::{debug, info};
 use raw_window_handle::{HasDisplayHandle, HasWindowHandle, RawWindowHandle};
 use servo::{
-    AuthenticationRequest, Cursor, DeviceIndependentIntRect, DeviceIndependentPixel,
-    DeviceIntPoint, DeviceIntRect, DeviceIntSize, DevicePixel, DevicePoint, EmbedderControl,
-    EmbedderControlId, GenericSender, ImeEvent, InputEvent, InputEventId, InputEventResult,
+    AuthenticationRequest, BluetoothPickDeviceRequest, Cursor, DeviceIndependentIntRect,
+    DeviceIndependentPixel, DeviceIntPoint, DeviceIntRect, DeviceIntSize, DevicePixel, DevicePoint,
+    EmbedderControl, EmbedderControlId, ImeEvent, InputEvent, InputEventId, InputEventResult,
     InputMethodControl, Key, KeyState, KeyboardEvent, Modifiers, MouseButton as ServoMouseButton,
     MouseButtonAction, MouseButtonEvent, MouseLeftViewportEvent, MouseMoveEvent, NamedKey,
     OffscreenRenderingContext, PermissionRequest, RenderingContext, ScreenGeometry, Theme,
@@ -1106,18 +1106,9 @@ impl PlatformWindow for HeadedWindow {
     fn show_bluetooth_device_dialog(
         &self,
         webview_id: WebViewId,
-        devices: Vec<String>,
-        response_sender: GenericSender<Option<String>>,
+        request: BluetoothPickDeviceRequest,
     ) {
-        if devices.is_empty() {
-            let _ = response_sender.send(None);
-            return;
-        }
-
-        self.add_dialog(
-            webview_id,
-            Dialog::new_device_selection_dialog(devices, response_sender),
-        );
+        self.add_dialog(webview_id, Dialog::new_device_selection_dialog(request));
     }
 
     fn show_permission_dialog(&self, webview_id: WebViewId, permission_request: PermissionRequest) {

--- a/ports/servoshell/desktop/headed_window.rs
+++ b/ports/servoshell/desktop/headed_window.rs
@@ -18,7 +18,7 @@ use keyboard_types::ShortcutMatcher;
 use log::{debug, info};
 use raw_window_handle::{HasDisplayHandle, HasWindowHandle, RawWindowHandle};
 use servo::{
-    AuthenticationRequest, BluetoothPickDeviceRequest, Cursor, DeviceIndependentIntRect,
+    AuthenticationRequest, BluetoothDeviceSelectionRequest, Cursor, DeviceIndependentIntRect,
     DeviceIndependentPixel, DeviceIntPoint, DeviceIntRect, DeviceIntSize, DevicePixel, DevicePoint,
     EmbedderControl, EmbedderControlId, ImeEvent, InputEvent, InputEventId, InputEventResult,
     InputMethodControl, Key, KeyState, KeyboardEvent, Modifiers, MouseButton as ServoMouseButton,
@@ -1106,7 +1106,7 @@ impl PlatformWindow for HeadedWindow {
     fn show_bluetooth_device_dialog(
         &self,
         webview_id: WebViewId,
-        request: BluetoothPickDeviceRequest,
+        request: BluetoothDeviceSelectionRequest,
     ) {
         self.add_dialog(webview_id, Dialog::new_device_selection_dialog(request));
     }

--- a/ports/servoshell/running_app_state.rs
+++ b/ports/servoshell/running_app_state.rs
@@ -19,7 +19,7 @@ use image::{DynamicImage, ImageFormat, RgbaImage};
 use libc::c_char;
 use log::{error, info, warn};
 use servo::{
-    AllowOrDenyRequest, AuthenticationRequest, BluetoothPickDeviceRequest, CSSPixel,
+    AllowOrDenyRequest, AuthenticationRequest, BluetoothDeviceSelectionRequest, CSSPixel,
     ConsoleLogLevel, CreateNewWebViewRequest, DeviceIntPoint, DeviceIntSize, EmbedderControl,
     EmbedderControlId, EventLoopWaker, GenericSender, InputEvent, InputEventId, InputEventResult,
     JSValue, LoadStatus, MediaSessionEvent, PermissionRequest, PrefValue, Preferences,
@@ -776,7 +776,11 @@ impl WebViewDelegate for RunningAppState {
             .set_fullscreen(fullscreen_state);
     }
 
-    fn show_bluetooth_device_dialog(&self, webview: WebView, request: BluetoothPickDeviceRequest) {
+    fn show_bluetooth_device_dialog(
+        &self,
+        webview: WebView,
+        request: BluetoothDeviceSelectionRequest,
+    ) {
         self.platform_window_for_webview_id(webview.id())
             .show_bluetooth_device_dialog(webview.id(), request);
     }

--- a/ports/servoshell/running_app_state.rs
+++ b/ports/servoshell/running_app_state.rs
@@ -19,13 +19,13 @@ use image::{DynamicImage, ImageFormat, RgbaImage};
 use libc::c_char;
 use log::{error, info, warn};
 use servo::{
-    AllowOrDenyRequest, AuthenticationRequest, CSSPixel, ConsoleLogLevel, CreateNewWebViewRequest,
-    DeviceIntPoint, DeviceIntSize, EmbedderControl, EmbedderControlId, EventLoopWaker,
-    GenericSender, InputEvent, InputEventId, InputEventResult, JSValue, LoadStatus,
-    MediaSessionEvent, PermissionRequest, PrefValue, Preferences, ScreenshotCaptureError, Servo,
-    ServoDelegate, ServoError, TraversalId, UserContentManager, WebDriverCommandMsg,
-    WebDriverJSResult, WebDriverLoadStatus, WebDriverScriptCommand, WebDriverSenders, WebView,
-    WebViewDelegate, WebViewId, pref,
+    AllowOrDenyRequest, AuthenticationRequest, BluetoothPickDeviceRequest, CSSPixel,
+    ConsoleLogLevel, CreateNewWebViewRequest, DeviceIntPoint, DeviceIntSize, EmbedderControl,
+    EmbedderControlId, EventLoopWaker, GenericSender, InputEvent, InputEventId, InputEventResult,
+    JSValue, LoadStatus, MediaSessionEvent, PermissionRequest, PrefValue, Preferences,
+    ScreenshotCaptureError, Servo, ServoDelegate, ServoError, TraversalId, UserContentManager,
+    WebDriverCommandMsg, WebDriverJSResult, WebDriverLoadStatus, WebDriverScriptCommand,
+    WebDriverSenders, WebView, WebViewDelegate, WebViewId, pref,
 };
 use url::Url;
 
@@ -776,14 +776,9 @@ impl WebViewDelegate for RunningAppState {
             .set_fullscreen(fullscreen_state);
     }
 
-    fn show_bluetooth_device_dialog(
-        &self,
-        webview: WebView,
-        devices: Vec<String>,
-        response_sender: GenericSender<Option<String>>,
-    ) {
+    fn show_bluetooth_device_dialog(&self, webview: WebView, request: BluetoothPickDeviceRequest) {
         self.platform_window_for_webview_id(webview.id())
-            .show_bluetooth_device_dialog(webview.id(), devices, response_sender);
+            .show_bluetooth_device_dialog(webview.id(), request);
     }
 
     fn request_permission(&self, webview: WebView, permission_request: PermissionRequest) {

--- a/ports/servoshell/window.rs
+++ b/ports/servoshell/window.rs
@@ -8,9 +8,9 @@ use std::rc::Rc;
 use euclid::Scale;
 use log::warn;
 use servo::{
-    AuthenticationRequest, ConsoleLogLevel, Cursor, DeviceIndependentIntRect,
-    DeviceIndependentPixel, DeviceIntPoint, DeviceIntSize, DevicePixel, EmbedderControl,
-    EmbedderControlId, GenericSender, InputEventId, InputEventResult, MediaSessionEvent,
+    AuthenticationRequest, BluetoothPickDeviceRequest, ConsoleLogLevel, Cursor,
+    DeviceIndependentIntRect, DeviceIndependentPixel, DeviceIntPoint, DeviceIntSize, DevicePixel,
+    EmbedderControl, EmbedderControlId, InputEventId, InputEventResult, MediaSessionEvent,
     PermissionRequest, RenderingContext, ScreenGeometry, WebView, WebViewBuilder, WebViewId,
 };
 use url::Url;
@@ -409,13 +409,7 @@ pub(crate) trait PlatformWindow {
     fn show_embedder_control(&self, _: WebViewId, _: EmbedderControl) {}
     fn hide_embedder_control(&self, _: WebViewId, _: EmbedderControlId) {}
     fn dismiss_embedder_controls_for_webview(&self, _: WebViewId) {}
-    fn show_bluetooth_device_dialog(
-        &self,
-        _: WebViewId,
-        _devices: Vec<String>,
-        _: GenericSender<Option<String>>,
-    ) {
-    }
+    fn show_bluetooth_device_dialog(&self, _: WebViewId, _request: BluetoothPickDeviceRequest) {}
     fn show_permission_dialog(&self, _: WebViewId, _: PermissionRequest) {}
     fn show_http_authentication_dialog(&self, _: WebViewId, _: AuthenticationRequest) {}
 

--- a/ports/servoshell/window.rs
+++ b/ports/servoshell/window.rs
@@ -8,7 +8,7 @@ use std::rc::Rc;
 use euclid::Scale;
 use log::warn;
 use servo::{
-    AuthenticationRequest, BluetoothPickDeviceRequest, ConsoleLogLevel, Cursor,
+    AuthenticationRequest, BluetoothDeviceSelectionRequest, ConsoleLogLevel, Cursor,
     DeviceIndependentIntRect, DeviceIndependentPixel, DeviceIntPoint, DeviceIntSize, DevicePixel,
     EmbedderControl, EmbedderControlId, InputEventId, InputEventResult, MediaSessionEvent,
     PermissionRequest, RenderingContext, ScreenGeometry, WebView, WebViewBuilder, WebViewId,
@@ -409,7 +409,12 @@ pub(crate) trait PlatformWindow {
     fn show_embedder_control(&self, _: WebViewId, _: EmbedderControl) {}
     fn hide_embedder_control(&self, _: WebViewId, _: EmbedderControlId) {}
     fn dismiss_embedder_controls_for_webview(&self, _: WebViewId) {}
-    fn show_bluetooth_device_dialog(&self, _: WebViewId, _request: BluetoothPickDeviceRequest) {}
+    fn show_bluetooth_device_dialog(
+        &self,
+        _: WebViewId,
+        _request: BluetoothDeviceSelectionRequest,
+    ) {
+    }
     fn show_permission_dialog(&self, _: WebViewId, _: PermissionRequest) {}
     fn show_http_authentication_dialog(&self, _: WebViewId, _: AuthenticationRequest) {}
 


### PR DESCRIPTION
This change has 2 parts:
- adding `BluetoothPickDeviceRequest`, similar to other request structs used to communicate with the embedder.
-  switch from a `Vec<String>` that expected 2 * <device count>  strings to `Vec<BluetoothDeviceDescription>` which is easier to reason about.

Testing: Manual testing with a build that has the `native-bluetooth` feature enabled.

