### PR TITLE
script: Pass down &mut JSContext to CookieStore methods

### DIFF
--- a/components/script/dom/cookiestore.rs
+++ b/components/script/dom/cookiestore.rs
@@ -10,6 +10,7 @@ use cookie::{Cookie, SameSite};
 use dom_struct::dom_struct;
 use hyper_serde::Serde;
 use itertools::Itertools;
+use js::context::JSContext;
 use js::jsval::NullValue;
 use net_traits::CookieSource::NonHTTP;
 use net_traits::{CookieAsyncResponse, CookieData, CoreResourceMsg};
@@ -181,7 +182,7 @@ fn cookie_to_list_item(cookie: Cookie) -> CookieListItem {
 
 impl CookieStoreMethods<crate::DomTypeHolder> for CookieStore {
     /// <https://cookiestore.spec.whatwg.org/#dom-cookiestore-get>
-    fn Get(&self, name: USVString, can_gc: CanGc) -> Rc<Promise> {
+    fn Get(&self, cx: &mut JSContext, name: USVString) -> Rc<Promise> {
         // 1. Let settings be this’s relevant settings object.
         let global = self.global();
 
@@ -189,11 +190,11 @@ impl CookieStoreMethods<crate::DomTypeHolder> for CookieStore {
         let origin = global.origin();
 
         // 5. Let p be a new promise.
-        let p = Promise::new(&global, can_gc);
+        let p = Promise::new(&global, CanGc::from_cx(cx));
 
         // 3. If origin is an opaque origin, then return a promise rejected with a "SecurityError" DOMException.
         if !origin.is_tuple() {
-            p.reject_error(Error::Security(None), can_gc);
+            p.reject_error(Error::Security(None), CanGc::from_cx(cx));
             return p;
         }
 
@@ -222,7 +223,7 @@ impl CookieStoreMethods<crate::DomTypeHolder> for CookieStore {
     }
 
     /// <https://cookiestore.spec.whatwg.org/#dom-cookiestore-get-options>
-    fn Get_(&self, options: &CookieStoreGetOptions, can_gc: CanGc) -> Rc<Promise> {
+    fn Get_(&self, cx: &mut JSContext, options: &CookieStoreGetOptions) -> Rc<Promise> {
         // 1. Let settings be this’s relevant settings object.
         let global = self.global();
 
@@ -230,11 +231,11 @@ impl CookieStoreMethods<crate::DomTypeHolder> for CookieStore {
         let origin = global.origin();
 
         // 7. Let p be a new promise.
-        let p = Promise::new(&global, can_gc);
+        let p = Promise::new(&global, CanGc::from_cx(cx));
 
         // 3. If origin is an opaque origin, then return a promise rejected with a "SecurityError" DOMException.
         if !origin.is_tuple() {
-            p.reject_error(Error::Security(None), can_gc);
+            p.reject_error(Error::Security(None), CanGc::from_cx(cx));
             return p;
         }
 
@@ -244,7 +245,10 @@ impl CookieStoreMethods<crate::DomTypeHolder> for CookieStore {
         // 5. If options is empty, then return a promise rejected with a TypeError.
         // "is empty" is not strictly defined anywhere in the spec but the only value we require here is "url"
         if options.url.is_none() && options.name.is_none() {
-            p.reject_error(Error::Type(c"Options cannot be empty".to_owned()), can_gc);
+            p.reject_error(
+                Error::Type(c"Options cannot be empty".to_owned()),
+                CanGc::from_cx(cx),
+            );
             return p;
         }
 
@@ -264,7 +268,7 @@ impl CookieStoreMethods<crate::DomTypeHolder> for CookieStore {
                 {
                     p.reject_error(
                         Error::Type(c"URL does not match context".to_owned()),
-                        can_gc,
+                        CanGc::from_cx(cx),
                     );
                     return p;
                 }
@@ -276,7 +280,10 @@ impl CookieStoreMethods<crate::DomTypeHolder> for CookieStore {
                 .as_ref()
                 .is_ok_and(|parsed| creation_url.origin() != parsed.origin())
             {
-                p.reject_error(Error::Type(c"Not same origin".to_owned()), can_gc);
+                p.reject_error(
+                    Error::Type(c"Not same origin".to_owned()),
+                    CanGc::from_cx(cx),
+                );
                 return p;
             }
 
@@ -305,7 +312,7 @@ impl CookieStoreMethods<crate::DomTypeHolder> for CookieStore {
     }
 
     /// <https://cookiestore.spec.whatwg.org/#dom-cookiestore-getall>
-    fn GetAll(&self, name: USVString, can_gc: CanGc) -> Rc<Promise> {
+    fn GetAll(&self, cx: &mut JSContext, name: USVString) -> Rc<Promise> {
         // 1. Let settings be this’s relevant settings object.
         let global = self.global();
 
@@ -313,11 +320,11 @@ impl CookieStoreMethods<crate::DomTypeHolder> for CookieStore {
         let origin = global.origin();
 
         // 5. Let p be a new promise.
-        let p = Promise::new(&global, can_gc);
+        let p = Promise::new(&global, CanGc::from_cx(cx));
 
         // 3. If origin is an opaque origin, then return a promise rejected with a "SecurityError" DOMException.
         if !origin.is_tuple() {
-            p.reject_error(Error::Security(None), can_gc);
+            p.reject_error(Error::Security(None), CanGc::from_cx(cx));
             return p;
         }
         // 4. Let url be settings’s creation URL.
@@ -346,7 +353,7 @@ impl CookieStoreMethods<crate::DomTypeHolder> for CookieStore {
     }
 
     /// <https://cookiestore.spec.whatwg.org/#dom-cookiestore-getall-options>
-    fn GetAll_(&self, options: &CookieStoreGetOptions, can_gc: CanGc) -> Rc<Promise> {
+    fn GetAll_(&self, cx: &mut JSContext, options: &CookieStoreGetOptions) -> Rc<Promise> {
         // 1. Let settings be this’s relevant settings object.
         let global = self.global();
 
@@ -354,11 +361,11 @@ impl CookieStoreMethods<crate::DomTypeHolder> for CookieStore {
         let origin = global.origin();
 
         // 6. Let p be a new promise.
-        let p = Promise::new(&global, can_gc);
+        let p = Promise::new(&global, CanGc::from_cx(cx));
 
         // 3. If origin is an opaque origin, then return a promise rejected with a "SecurityError" DOMException.
         if !origin.is_tuple() {
-            p.reject_error(Error::Security(None), can_gc);
+            p.reject_error(Error::Security(None), CanGc::from_cx(cx));
             return p;
         }
 
@@ -381,7 +388,7 @@ impl CookieStoreMethods<crate::DomTypeHolder> for CookieStore {
                 {
                     p.reject_error(
                         Error::Type(c"URL does not match context".to_owned()),
-                        can_gc,
+                        CanGc::from_cx(cx),
                     );
                     return p;
                 }
@@ -393,7 +400,10 @@ impl CookieStoreMethods<crate::DomTypeHolder> for CookieStore {
                 .as_ref()
                 .is_ok_and(|parsed| creation_url.origin() != parsed.origin())
             {
-                p.reject_error(Error::Type(c"Not same origin".to_owned()), can_gc);
+                p.reject_error(
+                    Error::Type(c"Not same origin".to_owned()),
+                    CanGc::from_cx(cx),
+                );
                 return p;
             }
 
@@ -423,7 +433,7 @@ impl CookieStoreMethods<crate::DomTypeHolder> for CookieStore {
     }
 
     /// <https://cookiestore.spec.whatwg.org/#dom-cookiestore-set>
-    fn Set(&self, name: USVString, value: USVString, can_gc: CanGc) -> Rc<Promise> {
+    fn Set(&self, cx: &mut JSContext, name: USVString, value: USVString) -> Rc<Promise> {
         // 1. Let settings be this’s relevant settings object.
         let global = self.global();
 
@@ -431,11 +441,11 @@ impl CookieStoreMethods<crate::DomTypeHolder> for CookieStore {
         let origin = global.origin();
 
         // 9. Let p be a new promise.
-        let p = Promise::new(&global, can_gc);
+        let p = Promise::new(&global, CanGc::from_cx(cx));
 
         // 3. If origin is an opaque origin, then return a promise rejected with a "SecurityError" DOMException.
         if !origin.is_tuple() {
-            p.reject_error(Error::Security(None), can_gc);
+            p.reject_error(Error::Security(None), CanGc::from_cx(cx));
             return p;
         }
 
@@ -452,7 +462,10 @@ impl CookieStoreMethods<crate::DomTypeHolder> for CookieStore {
         let creation_url = global.creation_url();
         let Some(cookie) = CookieStore::set_a_cookie(&creation_url, &properties) else {
             // If r is failure, then reject p with a TypeError and abort these steps.
-            p.reject_error(Error::Type(c"Invalid cookie".to_owned()), can_gc);
+            p.reject_error(
+                Error::Type(c"Invalid cookie".to_owned()),
+                CanGc::from_cx(cx),
+            );
             return p;
         };
 
@@ -477,7 +490,7 @@ impl CookieStoreMethods<crate::DomTypeHolder> for CookieStore {
     }
 
     /// <https://cookiestore.spec.whatwg.org/#dom-cookiestore-set-options>
-    fn Set_(&self, options: &CookieInit, can_gc: CanGc) -> Rc<Promise> {
+    fn Set_(&self, cx: &mut JSContext, options: &CookieInit) -> Rc<Promise> {
         // 1. Let settings be this’s relevant settings object.
         let global = self.global();
 
@@ -485,11 +498,11 @@ impl CookieStoreMethods<crate::DomTypeHolder> for CookieStore {
         let origin = global.origin();
 
         // 5. Let p be a new promise.
-        let p = Promise::new(&global, can_gc);
+        let p = Promise::new(&global, CanGc::from_cx(cx));
 
         // 3. If origin is an opaque origin, then return a promise rejected with a "SecurityError" DOMException.
         if !origin.is_tuple() {
-            p.reject_error(Error::Security(None), can_gc);
+            p.reject_error(Error::Security(None), CanGc::from_cx(cx));
             return p;
         }
 
@@ -499,7 +512,10 @@ impl CookieStoreMethods<crate::DomTypeHolder> for CookieStore {
         // 6.1. Let r be the result of running set a cookie with url, options["name"], options["value"],
         // options["expires"], options["domain"], options["path"], options["sameSite"], and options["partitioned"].
         let Some(cookie) = CookieStore::set_a_cookie(&creation_url, options) else {
-            p.reject_error(Error::Type(c"Invalid cookie".to_owned()), can_gc);
+            p.reject_error(
+                Error::Type(c"Invalid cookie".to_owned()),
+                CanGc::from_cx(cx),
+            );
             return p;
         };
 
@@ -524,7 +540,7 @@ impl CookieStoreMethods<crate::DomTypeHolder> for CookieStore {
     }
 
     /// <https://cookiestore.spec.whatwg.org/#dom-cookiestore-delete>
-    fn Delete(&self, name: USVString, can_gc: CanGc) -> Rc<Promise> {
+    fn Delete(&self, cx: &mut JSContext, name: USVString) -> Rc<Promise> {
         // 1. Let settings be this’s relevant settings object.
         let global = self.global();
 
@@ -532,11 +548,11 @@ impl CookieStoreMethods<crate::DomTypeHolder> for CookieStore {
         let origin = global.origin();
 
         // 5. Let p be a new promise.
-        let p = Promise::new(&global, can_gc);
+        let p = Promise::new(&global, CanGc::from_cx(cx));
 
         // 3. If origin is an opaque origin, then return a promise rejected with a "SecurityError" DOMException.
         if !origin.is_tuple() {
-            p.reject_error(Error::Security(None), can_gc);
+            p.reject_error(Error::Security(None), CanGc::from_cx(cx));
             return p;
         }
 
@@ -560,7 +576,7 @@ impl CookieStoreMethods<crate::DomTypeHolder> for CookieStore {
     }
 
     /// <https://cookiestore.spec.whatwg.org/#dom-cookiestore-delete-options>
-    fn Delete_(&self, options: &CookieStoreDeleteOptions, can_gc: CanGc) -> Rc<Promise> {
+    fn Delete_(&self, cx: &mut JSContext, options: &CookieStoreDeleteOptions) -> Rc<Promise> {
         // 1. Let settings be this’s relevant settings object.
         let global = self.global();
 
@@ -568,11 +584,11 @@ impl CookieStoreMethods<crate::DomTypeHolder> for CookieStore {
         let origin = global.origin();
 
         // 5. Let p be a new promise.
-        let p = Promise::new(&global, can_gc);
+        let p = Promise::new(&global, CanGc::from_cx(cx));
 
         // 3. If origin is an opaque origin, then return a promise rejected with a "SecurityError" DOMException.
         if !origin.is_tuple() {
-            p.reject_error(Error::Security(None), can_gc);
+            p.reject_error(Error::Security(None), CanGc::from_cx(cx));
             return p;
         }
 

--- a/components/script_bindings/codegen/Bindings.conf
+++ b/components/script_bindings/codegen/Bindings.conf
@@ -111,7 +111,7 @@ DOMInterfaces = {
 },
 
 'CookieStore': {
-    'canGc': ['Set', 'Set_', 'Get', 'Get_', 'GetAll', 'GetAll_', 'Delete', 'Delete_'],
+    'cx': ['Set', 'Set_', 'Get', 'Get_', 'GetAll', 'GetAll_', 'Delete', 'Delete_'],
 },
 
 'CountQueuingStrategy': {


### PR DESCRIPTION
Move CookieStore methods from CanGc to &mut JSContext.

Testing:  Just refactor.
Fixes: Part of #42638
