### PR TITLE
script: Correctly setup request for worker module scripts

### DIFF
--- a/components/script/dom/workers/dedicatedworkerglobalscope.rs
+++ b/components/script/dom/workers/dedicatedworkerglobalscope.rs
@@ -59,7 +59,7 @@ use crate::script_module::{ModuleFetchClient, ModuleOwner, fetch_a_module_worker
 use crate::script_runtime::ScriptThreadEventCategory::WorkerEvent;
 use crate::script_runtime::{CanGc, JSContext as SafeJSContext, Runtime, ThreadSafeJSContext};
 use crate::task_queue::{QueuedTask, QueuedTaskConversion, TaskQueue};
-use crate::task_source::{SendableTaskSource, TaskSourceName};
+use crate::task_source::TaskSourceName;
 
 /// Set the `worker` field of a related DedicatedWorkerGlobalScope object to a particular
 /// value for the duration of this object's lifetime. This ensures that the related Worker
@@ -400,8 +400,8 @@ impl DedicatedWorkerGlobalScope {
 
                 let WorkerScriptLoadOrigin {
                     referrer_url,
-                    referrer_policy,
                     pipeline_id,
+                    ..
                 } = worker_load_origin;
 
                 let referrer = referrer_url.map(Referrer::ReferrerUrl).unwrap_or(referrer);
@@ -415,20 +415,6 @@ impl DedicatedWorkerGlobalScope {
                     is_nested_browsing_context,
                     insecure_requests_policy,
                 };
-
-                let request = RequestBuilder::new(Some(webview_id), worker_url.clone(), referrer)
-                    .destination(Destination::Worker)
-                    .mode(RequestMode::SameOrigin)
-                    .credentials_mode(CredentialsMode::CredentialsSameOrigin)
-                    .parser_metadata(ParserMetadata::NotParserInserted)
-                    .use_url_credentials(true)
-                    .pipeline_id(Some(pipeline_id))
-                    .referrer_policy(referrer_policy)
-                    .insecure_requests_policy(insecure_requests_policy)
-                    .has_trustworthy_ancestor_origin(current_global_ancestor_trustworthy)
-                    .policy_container(policy_container.clone())
-                    .origin(origin.clone())
-                    .client(request_client.clone());
 
                 let event_loop_sender = ScriptEventLoopSender::DedicatedWorker {
                     sender: own_sender.clone(),
@@ -488,7 +474,7 @@ impl DedicatedWorkerGlobalScope {
                     webview_id,
                     worker_name.into(),
                     worker_type,
-                    worker_url,
+                    worker_url.clone(),
                     devtools_mpsc_port,
                     runtime,
                     parent_event_loop_sender,
@@ -512,10 +498,6 @@ impl DedicatedWorkerGlobalScope {
                     Some(worker_id),
                 );
                 let scope = global.upcast::<WorkerGlobalScope>();
-                let global_scope = global.upcast::<GlobalScope>();
-
-                global_scope.set_https_state(current_global_https_state);
-                let request = request.https_state(global_scope.get_https_state());
 
                 let fetch_client = ModuleFetchClient {
                     insecure_requests_policy: insecure_requests_policy,
@@ -532,27 +514,22 @@ impl DedicatedWorkerGlobalScope {
                 // Step 12. Obtain script by switching on options["type"]:
                 match worker_type {
                     WorkerType::Classic => {
-                        let task_source = SendableTaskSource {
-                            sender: event_loop_sender.clone(),
-                            pipeline_id,
-                            name: TaskSourceName::Networking,
-                            canceller: scope.shared_task_canceller(),
-                        };
-
-                        let context = ScriptFetchContext::new(
-                            Trusted::new(scope),
-                            request.url.clone(),
-                            policy_container,
+                        fetch_a_classic_worker_script(
+                            scope,
+                            worker_url,
+                            fetch_client,
+                            Destination::Worker,
+                            webview_id,
+                            referrer,
                         );
-                        global_scope.fetch(request, context, task_source);
                     },
                     WorkerType::Module => {
                         fetch_a_module_worker_script_graph(
                             cx,
-                            request.url,
+                            worker_url,
                             fetch_client,
                             ModuleOwner::Worker(Trusted::new(scope)),
-                            request.referrer,
+                            referrer,
                             credentials,
                         );
                     },
@@ -821,6 +798,47 @@ pub(crate) unsafe extern "C" fn interrupt_callback(cx: *mut RawJSContext) -> boo
     // A false response causes the script to terminate
     assert!(worker.is::<DedicatedWorkerGlobalScope>());
     !worker.is_closing()
+}
+
+/// <https://html.spec.whatwg.org/multipage/#fetch-a-classic-worker-script>
+fn fetch_a_classic_worker_script(
+    workerscope: &WorkerGlobalScope,
+    url: ServoUrl,
+    fetch_client: ModuleFetchClient,
+    destination: Destination,
+    webview_id: WebViewId,
+    referrer: Referrer,
+) {
+    // Step 1. Let request be a new request whose URL is url,
+    let request = RequestBuilder::new(Some(webview_id), url.clone(), referrer)
+        // client is fetchClient,
+        .insecure_requests_policy(fetch_client.insecure_requests_policy)
+        .has_trustworthy_ancestor_origin(fetch_client.has_trustworthy_ancestor_origin)
+        .policy_container(fetch_client.policy_container.clone())
+        .client(fetch_client.client)
+        .pipeline_id(Some(fetch_client.pipeline_id))
+        .origin(fetch_client.origin)
+        .https_state(fetch_client.https_state)
+        // destination is destination,
+        .destination(destination)
+        // TODO initiator type is "other",
+        // mode is "same-origin",
+        .mode(RequestMode::SameOrigin)
+        // credentials mode is "same-origin",
+        .credentials_mode(CredentialsMode::CredentialsSameOrigin)
+        // parser metadata is "not parser-inserted",
+        .parser_metadata(ParserMetadata::NotParserInserted)
+        // and whose use-URL-credentials flag is set.
+        .use_url_credentials(true);
+
+    let context = ScriptFetchContext::new(
+        Trusted::new(workerscope),
+        url,
+        fetch_client.policy_container,
+    );
+    let global = workerscope.upcast::<GlobalScope>();
+    let task_source = global.task_manager().networking_task_source().to_sendable();
+    global.fetch(request, context, task_source);
 }
 
 impl DedicatedWorkerGlobalScopeMethods<crate::DomTypeHolder> for DedicatedWorkerGlobalScope {

--- a/components/script/dom/workers/dedicatedworkerglobalscope.rs
+++ b/components/script/dom/workers/dedicatedworkerglobalscope.rs
@@ -55,7 +55,7 @@ use crate::dom::worker::{TrustedWorkerAddress, Worker};
 use crate::dom::workerglobalscope::{ScriptFetchContext, WorkerGlobalScope};
 use crate::messaging::{CommonScriptMsg, ScriptEventLoopReceiver, ScriptEventLoopSender};
 use crate::realms::{AlreadyInRealm, InRealm, enter_realm};
-use crate::script_module::{ModuleOwner, fetch_a_module_worker_script_graph};
+use crate::script_module::{ModuleFetchClient, ModuleOwner, fetch_a_module_worker_script_graph};
 use crate::script_runtime::ScriptThreadEventCategory::WorkerEvent;
 use crate::script_runtime::{CanGc, JSContext as SafeJSContext, Runtime, ThreadSafeJSContext};
 use crate::task_queue::{QueuedTask, QueuedTaskConversion, TaskQueue};
@@ -427,8 +427,8 @@ impl DedicatedWorkerGlobalScope {
                     .insecure_requests_policy(insecure_requests_policy)
                     .has_trustworthy_ancestor_origin(current_global_ancestor_trustworthy)
                     .policy_container(policy_container.clone())
-                    .origin(origin)
-                    .client(request_client);
+                    .origin(origin.clone())
+                    .client(request_client.clone());
 
                 let event_loop_sender = ScriptEventLoopSender::DedicatedWorker {
                     sender: own_sender.clone(),
@@ -517,59 +517,67 @@ impl DedicatedWorkerGlobalScope {
                 global_scope.set_https_state(current_global_https_state);
                 let request = request.https_state(global_scope.get_https_state());
 
-                let task_source = SendableTaskSource {
-                    sender: event_loop_sender.clone(),
-                    pipeline_id,
-                    name: TaskSourceName::Networking,
-                    canceller: scope.shared_task_canceller(),
+                let fetch_client = ModuleFetchClient {
+                    insecure_requests_policy: insecure_requests_policy,
+                    has_trustworthy_ancestor_origin: current_global_ancestor_trustworthy,
+                    policy_container: policy_container.clone(),
+                    client: request_client,
+                    pipeline_id: pipeline_id,
+                    origin: origin,
+                    https_state: current_global_https_state,
                 };
 
-                // Step 12. Obtain script by switching on options["type"]:
-                {
-                    let _ar = AutoWorkerReset::new(&global, worker.clone());
-                    match worker_type {
-                        WorkerType::Classic => {
-                            let context = ScriptFetchContext::new(
-                                Trusted::new(scope),
-                                request.url.clone(),
-                                policy_container,
-                            );
-                            global_scope.fetch(request, context, task_source);
-                        },
-                        WorkerType::Module => {
-                            fetch_a_module_worker_script_graph(
-                                cx,
-                                request.url,
-                                request.client,
-                                ModuleOwner::Worker(Trusted::new(scope)),
-                                request.referrer,
-                                credentials,
-                                policy_container,
-                            );
-                        },
-                    };
+                let _ar = AutoWorkerReset::new(&global, worker.clone());
 
-                    let reporter_name = format!("dedicated-worker-reporter-{}", worker_id);
-                    scope
-                        .upcast::<GlobalScope>()
-                        .mem_profiler_chan()
-                        .run_with_memory_reporting(
-                            || {
-                                // Step 27, Run the responsible event loop specified
-                                // by inside settings until it is destroyed.
-                                // The worker processing model remains on this step
-                                // until the event loop is destroyed,
-                                // which happens after the closing flag is set to true.
-                                while !scope.is_closing() {
-                                    run_worker_event_loop(&*global, Some(&worker), cx);
-                                }
-                            },
-                            reporter_name,
-                            event_loop_sender,
-                            CommonScriptMsg::CollectReports,
+                // Step 12. Obtain script by switching on options["type"]:
+                match worker_type {
+                    WorkerType::Classic => {
+                        let task_source = SendableTaskSource {
+                            sender: event_loop_sender.clone(),
+                            pipeline_id,
+                            name: TaskSourceName::Networking,
+                            canceller: scope.shared_task_canceller(),
+                        };
+
+                        let context = ScriptFetchContext::new(
+                            Trusted::new(scope),
+                            request.url.clone(),
+                            policy_container,
                         );
+                        global_scope.fetch(request, context, task_source);
+                    },
+                    WorkerType::Module => {
+                        fetch_a_module_worker_script_graph(
+                            cx,
+                            request.url,
+                            fetch_client,
+                            ModuleOwner::Worker(Trusted::new(scope)),
+                            request.referrer,
+                            credentials,
+                        );
+                    },
                 }
 
+                let reporter_name = format!("dedicated-worker-reporter-{}", worker_id);
+                scope
+                    .upcast::<GlobalScope>()
+                    .mem_profiler_chan()
+                    .run_with_memory_reporting(
+                        || {
+                            // Step 27, Run the responsible event loop specified
+                            // by inside settings until it is destroyed.
+                            // The worker processing model remains on this step
+                            // until the event loop is destroyed,
+                            // which happens after the closing flag is set to true.
+                            while !scope.is_closing() {
+                                run_worker_event_loop(&*global, Some(&worker), cx);
+                            }
+                        },
+                        reporter_name,
+                        event_loop_sender,
+                        CommonScriptMsg::CollectReports,
+                    );
+                drop(_ar);
                 scope.clear_js_runtime();
             })
             .expect("Thread spawning failed")

--- a/components/script/dom/workers/dedicatedworkerglobalscope.rs
+++ b/components/script/dom/workers/dedicatedworkerglobalscope.rs
@@ -500,61 +500,62 @@ impl DedicatedWorkerGlobalScope {
                 let scope = global.upcast::<WorkerGlobalScope>();
 
                 let fetch_client = ModuleFetchClient {
-                    insecure_requests_policy: insecure_requests_policy,
+                    insecure_requests_policy,
                     has_trustworthy_ancestor_origin: current_global_ancestor_trustworthy,
-                    policy_container: policy_container.clone(),
+                    policy_container,
                     client: request_client,
-                    pipeline_id: pipeline_id,
-                    origin: origin,
+                    pipeline_id,
+                    origin,
                     https_state: current_global_https_state,
                 };
 
-                let _ar = AutoWorkerReset::new(&global, worker.clone());
-
                 // Step 12. Obtain script by switching on options["type"]:
-                match worker_type {
-                    WorkerType::Classic => {
-                        fetch_a_classic_worker_script(
-                            scope,
-                            worker_url,
-                            fetch_client,
-                            Destination::Worker,
-                            webview_id,
-                            referrer,
+                {
+                    let _ar = AutoWorkerReset::new(&global, worker.clone());
+                    match worker_type {
+                        WorkerType::Classic => {
+                            fetch_a_classic_worker_script(
+                                scope,
+                                worker_url,
+                                fetch_client,
+                                Destination::Worker,
+                                webview_id,
+                                referrer,
+                            );
+                        },
+                        WorkerType::Module => {
+                            fetch_a_module_worker_script_graph(
+                                cx,
+                                worker_url,
+                                fetch_client,
+                                ModuleOwner::Worker(Trusted::new(scope)),
+                                referrer,
+                                credentials,
+                            );
+                        },
+                    }
+
+                    let reporter_name = format!("dedicated-worker-reporter-{}", worker_id);
+                    scope
+                        .upcast::<GlobalScope>()
+                        .mem_profiler_chan()
+                        .run_with_memory_reporting(
+                            || {
+                                // Step 27, Run the responsible event loop specified
+                                // by inside settings until it is destroyed.
+                                // The worker processing model remains on this step
+                                // until the event loop is destroyed,
+                                // which happens after the closing flag is set to true.
+                                while !scope.is_closing() {
+                                    run_worker_event_loop(&*global, Some(&worker), cx);
+                                }
+                            },
+                            reporter_name,
+                            event_loop_sender,
+                            CommonScriptMsg::CollectReports,
                         );
-                    },
-                    WorkerType::Module => {
-                        fetch_a_module_worker_script_graph(
-                            cx,
-                            worker_url,
-                            fetch_client,
-                            ModuleOwner::Worker(Trusted::new(scope)),
-                            referrer,
-                            credentials,
-                        );
-                    },
                 }
 
-                let reporter_name = format!("dedicated-worker-reporter-{}", worker_id);
-                scope
-                    .upcast::<GlobalScope>()
-                    .mem_profiler_chan()
-                    .run_with_memory_reporting(
-                        || {
-                            // Step 27, Run the responsible event loop specified
-                            // by inside settings until it is destroyed.
-                            // The worker processing model remains on this step
-                            // until the event loop is destroyed,
-                            // which happens after the closing flag is set to true.
-                            while !scope.is_closing() {
-                                run_worker_event_loop(&*global, Some(&worker), cx);
-                            }
-                        },
-                        reporter_name,
-                        event_loop_sender,
-                        CommonScriptMsg::CollectReports,
-                    );
-                drop(_ar);
                 scope.clear_js_runtime();
             })
             .expect("Thread spawning failed")

--- a/components/script/module_loading.rs
+++ b/components/script/module_loading.rs
@@ -428,7 +428,7 @@ pub(crate) fn host_load_imported_module(
 ) {
     // Step 1. Let settingsObject be the current settings object.
     let realm = CurrentRealm::assert(cx);
-    let global_scope = GlobalScope::from_current_realm(&realm);
+    let mut global_scope = GlobalScope::from_current_realm(&realm);
 
     // TODO Step 2. If settingsObject's global object implements WorkletGlobalScope or ServiceWorkerGlobalScope and loadState is undefined, then:
 
@@ -452,12 +452,18 @@ pub(crate) fn host_load_imported_module(
         ),
     };
 
+    // TODO: investigate providing a `ModuleOwner` to classic scripts.
+    let script_owner = referencing_script.and_then(|script| script.owner.clone());
+
     // Step 6.2. Set settingsObject to referencingScript's settings object.
-    let owner = referencing_script
-        .and_then(|script| script.owner.clone())
+    if let Some(ref owner) = script_owner {
+        global_scope = owner.global();
+    }
+
+    // Note: loadState is undefined when performing a dynamic import, fall back to `ModuleOwner::DynamicModule`.
+    let owner = script_owner
+        .filter(|_| load_state.is_some())
         .unwrap_or(ModuleOwner::DynamicModule(Trusted::new(&global_scope)));
-    // Note: We later set fetchClient to the `ModuleOwner` provided by loadState,
-    // which provides the `GlobalScope` that we will use for fetching.
 
     // Step 7 If referrer is a Cyclic Module Record and moduleRequest is equal to the first element of referrer.[[RequestedModules]], then:
     // Note: These substeps are implemented by `GetRequestedModuleSpecifier`,

--- a/components/script/module_loading.rs
+++ b/components/script/module_loading.rs
@@ -22,7 +22,6 @@ use js::rust::wrappers2::{
     GetRequestedModulesCount, JS_GetModulePrivate, ModuleEvaluate, ModuleLink,
 };
 use js::rust::{HandleValue, IntoHandle};
-use net_traits::policy_container::PolicyContainer;
 use net_traits::request::{Destination, Referrer};
 use script_bindings::settings_stack::run_a_callback;
 use servo_url::ServoUrl;
@@ -37,8 +36,9 @@ use crate::dom::promise::Promise;
 use crate::dom::promisenativehandler::{Callback, PromiseNativeHandler};
 use crate::realms::{InRealm, enter_auto_realm};
 use crate::script_module::{
-    ModuleHandler, ModuleObject, ModuleOwner, ModuleTree, RethrowError, ScriptFetchOptions,
-    fetch_a_single_module_script, gen_type_error, module_script_from_reference_private,
+    ModuleFetchClient, ModuleHandler, ModuleObject, ModuleOwner, ModuleTree, RethrowError,
+    ScriptFetchOptions, fetch_a_single_module_script, gen_type_error,
+    module_script_from_reference_private,
 };
 use crate::script_runtime::{CanGc, IntroductionType};
 
@@ -65,9 +65,8 @@ pub(crate) struct LoadState {
     pub(crate) error_to_rethrow: RefCell<Option<RethrowError>>,
     #[no_trace]
     pub(crate) destination: Destination,
-    pub(crate) fetch_client: ModuleOwner,
     #[no_trace]
-    pub(crate) policy_container: Option<PolicyContainer>,
+    pub(crate) fetch_client: ModuleFetchClient,
 }
 
 /// <https://tc39.es/ecma262/#graphloadingstate-record>
@@ -454,6 +453,9 @@ pub(crate) fn host_load_imported_module(
     };
 
     // Step 6.2. Set settingsObject to referencingScript's settings object.
+    let owner = referencing_script
+        .and_then(|script| script.owner.clone())
+        .unwrap_or(ModuleOwner::DynamicModule(Trusted::new(&global_scope)));
     // Note: We later set fetchClient to the `ModuleOwner` provided by loadState,
     // which provides the `GlobalScope` that we will use for fetching.
 
@@ -511,16 +513,15 @@ pub(crate) fn host_load_imported_module(
             // Step 11. Let destination be "script".
             Destination::Script,
             // Step 12. Let fetchClient be settingsObject.
-            ModuleOwner::DynamicModule(Trusted::new(&global_scope)),
+            ModuleFetchClient::from_global_scope(&global_scope),
         ),
     };
 
-    let policy_container = load_state
-        .clone()
-        .and_then(|state| state.policy_container.clone());
-
     let on_single_fetch_complete =
         move |cx: &mut JSContext, module_tree: Option<Rc<ModuleTree>>| {
+            let mut realm = CurrentRealm::assert(cx);
+            let cx = &mut realm;
+
             // Step 1. Let completion be null.
             let completion = match module_tree {
                 // Step 2. If moduleScript is null, then set completion to ThrowCompletion(a new TypeError).
@@ -552,14 +553,7 @@ pub(crate) fn host_load_imported_module(
             };
 
             // Step 5. Perform FinishLoadingImportedModule(referrer, moduleRequest, payload, completion).
-            let mut realm = CurrentRealm::assert(cx);
-            finish_loading_imported_module(
-                &mut realm,
-                referrer_module,
-                specifier,
-                payload,
-                completion,
-            );
+            finish_loading_imported_module(cx, referrer_module, specifier, payload, completion);
         };
 
     // Step 14 Fetch a single imported module script given url, fetchClient, destination, fetchOptions, settingsObject,
@@ -570,11 +564,11 @@ pub(crate) fn host_load_imported_module(
         cx,
         url,
         fetch_client,
+        owner,
         destination,
         fetch_options,
         fetch_referrer,
         module_type,
-        policy_container,
         on_single_fetch_complete,
     );
 }
@@ -584,12 +578,12 @@ pub(crate) fn host_load_imported_module(
 fn fetch_a_single_imported_module_script(
     cx: &mut JSContext,
     url: ServoUrl,
+    fetch_client: ModuleFetchClient,
     owner: ModuleOwner,
     destination: Destination,
     options: ScriptFetchOptions,
     referrer: Referrer,
     module_type: ModuleType,
-    policy_container: Option<PolicyContainer>,
     on_complete: impl FnOnce(&mut JSContext, Option<Rc<ModuleTree>>) + 'static,
 ) {
     // TODO Step 1. Assert: moduleRequest.[[Attributes]] does not contain any Record entry such that entry.[[Key]] is not "type",
@@ -609,7 +603,7 @@ fn fetch_a_single_imported_module_script(
     fetch_a_single_module_script(
         cx,
         url,
-        None,
+        fetch_client,
         owner,
         destination,
         options,
@@ -617,7 +611,6 @@ fn fetch_a_single_imported_module_script(
         Some(module_type),
         false,
         Some(IntroductionType::IMPORTED_MODULE),
-        policy_container,
         on_complete,
     );
 }

--- a/components/script/script_module.rs
+++ b/components/script/script_module.rs
@@ -12,6 +12,7 @@ use std::ptr::NonNull;
 use std::rc::Rc;
 use std::{mem, ptr};
 
+use base::id::PipelineId;
 use encoding_rs::UTF_8;
 use headers::{HeaderMapExt, ReferrerPolicy as ReferrerPolicyHeader};
 use html5ever::local_name;
@@ -46,9 +47,10 @@ use net_traits::http_status::HttpStatus;
 use net_traits::mime_classifier::MimeClassifier;
 use net_traits::policy_container::PolicyContainer;
 use net_traits::request::{
-    CredentialsMode, Destination, ParserMetadata, Referrer, RequestBuilder, RequestClient,
-    RequestId, RequestMode,
+    CredentialsMode, Destination, InsecureRequestsPolicy, ParserMetadata, Referrer, RequestBuilder,
+    RequestClient, RequestId, RequestMode,
 };
+use net_traits::response::HttpsState;
 use net_traits::{FetchMetadata, Metadata, NetworkError, ReferrerPolicy, ResourceFetchTiming};
 use script_bindings::cformat;
 use script_bindings::domstring::BytesView;
@@ -57,7 +59,7 @@ use script_bindings::settings_stack::run_a_callback;
 use script_bindings::trace::CustomTraceable;
 use serde_json::{Map as JsonMap, Value as JsonValue};
 use servo_config::pref;
-use servo_url::ServoUrl;
+use servo_url::{ImmutableOrigin, ServoUrl};
 
 use crate::DomTypeHolder;
 use crate::document_loader::LoadType;
@@ -86,7 +88,6 @@ use crate::dom::promise::Promise;
 use crate::dom::promisenativehandler::{Callback, PromiseNativeHandler};
 use crate::dom::types::{Console, DedicatedWorkerGlobalScope, WorkerGlobalScope};
 use crate::dom::window::Window;
-use crate::fetch::RequestWithGlobalScope;
 use crate::module_loading::{
     LoadState, Payload, host_load_imported_module, load_requested_modules,
 };
@@ -154,7 +155,7 @@ impl Clone for RethrowError {
 pub(crate) struct ModuleScript {
     pub(crate) base_url: ServoUrl,
     pub(crate) options: ScriptFetchOptions,
-    owner: Option<ModuleOwner>,
+    pub(crate) owner: Option<ModuleOwner>,
 }
 
 impl ModuleScript {
@@ -673,6 +674,31 @@ impl ModuleOwner {
     }
 }
 
+#[derive(Clone)]
+pub(crate) struct ModuleFetchClient {
+    pub insecure_requests_policy: InsecureRequestsPolicy,
+    pub has_trustworthy_ancestor_origin: bool,
+    pub policy_container: PolicyContainer,
+    pub client: RequestClient,
+    pub pipeline_id: PipelineId,
+    pub origin: ImmutableOrigin,
+    pub https_state: HttpsState,
+}
+
+impl ModuleFetchClient {
+    pub(crate) fn from_global_scope(global: &GlobalScope) -> Self {
+        Self {
+            insecure_requests_policy: global.insecure_requests_policy(),
+            has_trustworthy_ancestor_origin: global.has_trustworthy_ancestor_or_current_origin(),
+            policy_container: global.policy_container(),
+            client: global.request_client(),
+            pipeline_id: global.pipeline_id(),
+            origin: global.origin().immutable().clone(),
+            https_state: global.get_https_state(),
+        }
+    }
+}
+
 /// The context required for asynchronously loading an external module script source.
 struct ModuleContext {
     /// The owner of the module that initiated the request.
@@ -689,9 +715,6 @@ struct ModuleContext {
     status: Result<(), NetworkError>,
     /// `introductionType` value to set in the `CompileOptionsWrapper`.
     introduction_type: Option<&'static CStr>,
-    /// Indicates whether the fetch is top-level
-    /// <https://html.spec.whatwg.org/multipage/#fetching-scripts-is-top-level>
-    is_top_level: bool,
     /// <https://html.spec.whatwg.org/multipage/#policy-container>
     policy_container: Option<PolicyContainer>,
 }
@@ -782,15 +805,11 @@ impl FetchResponseListener for ModuleContext {
 
         // The processResponseConsumeBody steps defined inside
         // [run a worker](https://html.spec.whatwg.org/multipage/#run-a-worker)
-        if self.is_top_level {
-            if let Some(scope) = self.owner.global().downcast::<WorkerGlobalScope>() {
-                scope.process_response_for_workerscope(
-                    &metadata,
-                    &self
-                        .policy_container
-                        .expect("top level worker fetch must have a policy container"),
-                );
-            }
+        if let Some(policy_container) = self.policy_container {
+            let workerscope = global.downcast::<WorkerGlobalScope>().expect(
+                "We only need a policy container when initializing a worker's globalscope.",
+            );
+            workerscope.process_response_for_workerscope(&metadata, &policy_container);
         }
 
         let final_url = metadata.final_url;
@@ -1193,11 +1212,10 @@ unsafe extern "C" fn import_meta_resolve(cx: *mut RawJSContext, argc: u32, vp: *
 pub(crate) fn fetch_a_module_worker_script_graph(
     cx: &mut JSContext,
     url: ServoUrl,
-    fetch_client: Option<RequestClient>,
+    fetch_client: ModuleFetchClient,
     owner: ModuleOwner,
     referrer: Referrer,
     credentials_mode: CredentialsMode,
-    policy_container: PolicyContainer,
 ) {
     // Step 1. Let options be a script fetch options whose cryptographic nonce
     // is the empty string, integrity metadata is the empty string, parser
@@ -1210,12 +1228,13 @@ pub(crate) fn fetch_a_module_worker_script_graph(
         parser_metadata: ParserMetadata::NotParserInserted,
         referrer_policy: ReferrerPolicy::EmptyString,
     };
+
     // Step 2. Fetch a single module script given url, fetchClient, destination, options,
     // settingsObject, "client", true, and onSingleFetchComplete as defined below.
     fetch_a_single_module_script(
         cx,
         url,
-        fetch_client,
+        fetch_client.clone(),
         owner.clone(),
         Destination::Worker,
         options,
@@ -1223,7 +1242,6 @@ pub(crate) fn fetch_a_module_worker_script_graph(
         None,
         true,
         Some(IntroductionType::WORKER),
-        Some(policy_container.clone()),
         move |cx, module_tree| {
             let Some(module) = module_tree else {
                 // Step 1.1. If result is null, run onComplete given null, and abort these steps.
@@ -1235,9 +1253,9 @@ pub(crate) fn fetch_a_module_worker_script_graph(
             fetch_the_descendants_and_link_module_script(
                 cx,
                 module,
+                fetch_client,
                 Destination::Worker,
                 owner,
-                Some(policy_container),
             );
         },
     );
@@ -1251,13 +1269,14 @@ pub(crate) fn fetch_an_external_module_script(
     options: ScriptFetchOptions,
 ) {
     let referrer = owner.global().get_referrer();
+    let fetch_client = ModuleFetchClient::from_global_scope(&owner.global());
 
     // Step 1. Fetch a single module script given url, settingsObject, "script", options, settingsObject, "client", true,
     // and with the following steps given result:
     fetch_a_single_module_script(
         cx,
         url,
-        None,
+        fetch_client.clone(),
         owner.clone(),
         Destination::Script,
         options,
@@ -1265,7 +1284,6 @@ pub(crate) fn fetch_an_external_module_script(
         None,
         true,
         Some(IntroductionType::SRC_SCRIPT),
-        None,
         move |cx, module_tree| {
             let Some(module) = module_tree else {
                 // Step 1.1. If result is null, run onComplete given null, and abort these steps.
@@ -1276,9 +1294,9 @@ pub(crate) fn fetch_an_external_module_script(
             fetch_the_descendants_and_link_module_script(
                 cx,
                 module,
+                fetch_client,
                 Destination::Script,
                 owner,
-                None,
             );
         },
     );
@@ -1294,6 +1312,7 @@ pub(crate) fn fetch_a_modulepreload_module(
     on_complete: impl FnOnce(&mut JSContext, bool) + 'static,
 ) {
     let referrer = global.get_referrer();
+    let fetch_client = ModuleFetchClient::from_global_scope(global);
     let owner = ModuleOwner::DynamicModule(Trusted::new(global));
 
     // Note: There is a specification inconsistency, `fetch_a_single_module_script` doesn't allow
@@ -1309,7 +1328,7 @@ pub(crate) fn fetch_a_modulepreload_module(
     fetch_a_single_module_script(
         cx,
         url,
-        None,
+        fetch_client.clone(),
         owner.clone(),
         destination,
         options,
@@ -1317,7 +1336,6 @@ pub(crate) fn fetch_a_modulepreload_module(
         module_type,
         true,
         Some(IntroductionType::SRC_SCRIPT),
-        None,
         move |cx, result| {
             // Step 1. Run onComplete given result.
             on_complete(cx, result.is_none());
@@ -1332,9 +1350,9 @@ pub(crate) fn fetch_a_modulepreload_module(
                     fetch_the_descendants_and_link_module_script(
                         cx,
                         module,
+                        fetch_client,
                         destination,
                         owner,
-                        None,
                     );
                 }
             }
@@ -1362,9 +1380,16 @@ pub(crate) fn fetch_inline_module_script(
         Some(IntroductionType::INLINE_SCRIPT),
         CanGc::from_cx(cx),
     ));
+    let fetch_client = ModuleFetchClient::from_global_scope(&owner.global());
 
     // Step 2. Fetch the descendants of and link script, given settingsObject, "script", and onComplete.
-    fetch_the_descendants_and_link_module_script(cx, module_tree, Destination::Script, owner, None);
+    fetch_the_descendants_and_link_module_script(
+        cx,
+        module_tree,
+        fetch_client,
+        Destination::Script,
+        owner,
+    );
 }
 
 #[expect(unsafe_code)]
@@ -1372,9 +1397,9 @@ pub(crate) fn fetch_inline_module_script(
 fn fetch_the_descendants_and_link_module_script(
     cx: &mut JSContext,
     module_script: Rc<ModuleTree>,
+    fetch_client: ModuleFetchClient,
     destination: Destination,
     owner: ModuleOwner,
-    policy_container: Option<PolicyContainer>,
 ) {
     let global = owner.global();
 
@@ -1398,8 +1423,7 @@ fn fetch_the_descendants_and_link_module_script(
     let state = Rc::new(LoadState {
         error_to_rethrow: RefCell::new(None),
         destination,
-        fetch_client: owner.clone(),
-        policy_container,
+        fetch_client,
     });
 
     // TODO Step 4. If performFetch was given, set state.[[PerformFetch]] to performFetch.
@@ -1477,7 +1501,7 @@ fn fetch_the_descendants_and_link_module_script(
 pub(crate) fn fetch_a_single_module_script(
     cx: &mut JSContext,
     url: ServoUrl,
-    fetch_client: Option<RequestClient>,
+    fetch_client: ModuleFetchClient,
     owner: ModuleOwner,
     destination: Destination,
     options: ScriptFetchOptions,
@@ -1485,7 +1509,6 @@ pub(crate) fn fetch_a_single_module_script(
     module_type: Option<ModuleType>,
     is_top_level: bool,
     introduction_type: Option<&'static CStr>,
-    policy_container: Option<PolicyContainer>,
     on_complete: impl FnOnce(&mut JSContext, Option<Rc<ModuleTree>>) + 'static,
 ) {
     let global = owner.global();
@@ -1544,6 +1567,10 @@ pub(crate) fn fetch_a_single_module_script(
             return;
         }
 
+        // We only need a policy container when fetching the root of a module worker.
+        let policy_container = (is_top_level && matches!(owner, ModuleOwner::Worker(_)))
+            .then(|| fetch_client.policy_container.clone());
+
         // Step 7. Set moduleMap[(url, moduleType)] to "fetching".
         global.set_module_map(module_request.clone(), ModuleStatus::Fetching(pending));
 
@@ -1564,7 +1591,8 @@ pub(crate) fn fetch_a_single_module_script(
             _ => RequestMode::CorsMode,
         };
 
-        // Step 9. Set request's destination to the result of running the fetch destination from module type steps given destination and moduleType.
+        // Step 9. Set request's destination to the result of running the
+        // fetch destination from module type steps given destination and moduleType.
         let destination = match module_type {
             ModuleType::JSON => Destination::Json,
             ModuleType::JavaScript | ModuleType::Unknown => destination,
@@ -1573,23 +1601,21 @@ pub(crate) fn fetch_a_single_module_script(
         // TODO Step 11. Set request's initiator type to "script".
 
         // Step 12. Set up the module script request given request and options.
-        let mut request = RequestBuilder::new(webview_id, url.clone(), referrer)
+        let request = RequestBuilder::new(webview_id, url.clone(), referrer)
             .destination(destination)
             .parser_metadata(options.parser_metadata)
             .integrity_metadata(options.integrity_metadata.clone())
             .credentials_mode(options.credentials_mode)
             .referrer_policy(options.referrer_policy)
             .mode(mode)
-            .with_global_scope(&global)
-            .cryptographic_nonce_metadata(options.cryptographic_nonce.clone());
-
-        if let Some(client) = fetch_client {
-            request = request.client(client);
-        }
-
-        if let Some(container) = policy_container.clone() {
-            request = request.policy_container(container);
-        }
+            .cryptographic_nonce_metadata(options.cryptographic_nonce.clone())
+            .insecure_requests_policy(fetch_client.insecure_requests_policy)
+            .has_trustworthy_ancestor_origin(fetch_client.has_trustworthy_ancestor_origin)
+            .policy_container(fetch_client.policy_container)
+            .client(fetch_client.client)
+            .pipeline_id(Some(fetch_client.pipeline_id))
+            .origin(fetch_client.origin)
+            .https_state(fetch_client.https_state);
 
         let context = ModuleContext {
             owner,
@@ -1599,7 +1625,6 @@ pub(crate) fn fetch_a_single_module_script(
             options,
             status: Ok(()),
             introduction_type,
-            is_top_level,
             policy_container,
         };
 

--- a/components/script/script_module.rs
+++ b/components/script/script_module.rs
@@ -12,7 +12,6 @@ use std::ptr::NonNull;
 use std::rc::Rc;
 use std::{mem, ptr};
 
-use base::id::PipelineId;
 use encoding_rs::UTF_8;
 use headers::{HeaderMapExt, ReferrerPolicy as ReferrerPolicyHeader};
 use html5ever::local_name;
@@ -58,6 +57,7 @@ use script_bindings::error::Fallible;
 use script_bindings::settings_stack::run_a_callback;
 use script_bindings::trace::CustomTraceable;
 use serde_json::{Map as JsonMap, Value as JsonValue};
+use servo_base::id::PipelineId;
 use servo_config::pref;
 use servo_url::{ImmutableOrigin, ServoUrl};
 

--- a/tests/wpt/meta/mixed-content/gen/top.http-rp/opt-in/worker-import-data.https.html.ini
+++ b/tests/wpt/meta/mixed-content/gen/top.http-rp/opt-in/worker-import-data.https.html.ini
@@ -1,6 +1,3 @@
 [worker-import-data.https.html]
   [Mixed-Content: Expects blocked for worker-import-data to cross-https origin and swap-scheme redirection from https context.]
     expected: FAIL
-
-  [Mixed-Content: Expects blocked for worker-import-data to same-https origin and swap-scheme redirection from https context.]
-    expected: FAIL

--- a/tests/wpt/meta/workers/modules/dedicated-worker-import-data-url-cross-origin.html.ini
+++ b/tests/wpt/meta/workers/modules/dedicated-worker-import-data-url-cross-origin.html.ini
@@ -1,3 +1,0 @@
-[dedicated-worker-import-data-url-cross-origin.html]
-  [static import script from data: URL should be allowed.]
-    expected: FAIL

--- a/tests/wpt/meta/workers/modules/dedicated-worker-import-data-url.any.js.ini
+++ b/tests/wpt/meta/workers/modules/dedicated-worker-import-data-url.any.js.ini
@@ -1,8 +1,0 @@
-[dedicated-worker-import-data-url.any.html]
-  [Static import (redirect).]
-    expected: FAIL
-
-
-[dedicated-worker-import-data-url.any.worker.html]
-  [Static import (redirect).]
-    expected: FAIL


### PR DESCRIPTION
According to spec we should fetch worker modules using the _outside settings_, however we can't use it directly since we are on a different thread. To fix it, a new struct `ModuleFetchClient` is now part of `LoadState` and replace the `with_global_scope` call done in `fetch_a_single_module_script`.
This also tidy worker classic script related code.

Testing: There are new passes
