### PR TITLE
layout: Allow block-levels inside an inline directly, without wrapper

### DIFF
--- a/components/layout/flow/construct.rs
+++ b/components/layout/flow/construct.rs
@@ -687,7 +687,7 @@ impl<'dom> BlockContainerBuilder<'dom, '_> {
         };
         if let Some(builder) = self.inline_formatting_context_builder.as_mut() {
             if builder.currently_processing_inline_box() {
-                builder.push_block_level_box(job.finish(self.context), self.info, self.context);
+                builder.push_block_level_box(job.finish(self.context));
                 return;
             }
             if let Some(context) = self.finish_ongoing_inline_formatting_context() {

--- a/components/layout/flow/inline/construct.rs
+++ b/components/layout/flow/inline/construct.rs
@@ -9,7 +9,6 @@ use icu_segmenter::WordSegmenter;
 use layout_api::wrapper_traits::{SharedSelection, ThreadSafeLayoutNode};
 use style::computed_values::_webkit_text_security::T as WebKitTextSecurity;
 use style::computed_values::white_space_collapse::T as WhiteSpaceCollapse;
-use style::selector_parser::PseudoElement;
 use style::values::specified::text::TextTransformCase;
 use unicode_bidi::Level;
 
@@ -22,11 +21,9 @@ use crate::cell::ArcRefCell;
 use crate::context::LayoutContext;
 use crate::dom::LayoutBox;
 use crate::dom_traversal::NodeAndStyleInfo;
+use crate::flow::BlockLevelBox;
 use crate::flow::float::FloatBox;
-use crate::flow::inline::AnonymousBlockBox;
-use crate::flow::{BlockContainer, BlockLevelBox};
 use crate::formatting_contexts::IndependentFormattingContext;
-use crate::layout_box_base::LayoutBoxBase;
 use crate::positioned::AbsolutelyPositionedBox;
 use crate::style_ext::ComputedValuesExt;
 
@@ -207,33 +204,10 @@ impl InlineFormattingContextBuilder {
         inline_level_box
     }
 
-    pub(crate) fn push_block_level_box(
-        &mut self,
-        block_level_box: ArcRefCell<BlockLevelBox>,
-        block_builder_info: &NodeAndStyleInfo,
-        layout_context: &LayoutContext,
-    ) {
+    pub(crate) fn push_block_level_box(&mut self, block_level: ArcRefCell<BlockLevelBox>) {
         assert!(self.currently_processing_inline_box());
-        self.contains_floats = self.contains_floats || block_level_box.borrow().contains_floats();
-
-        if let Some(InlineItem::AnonymousBlock(anonymous_block)) = self.inline_items.last() {
-            if let BlockContainer::BlockLevelBoxes(ref mut block_level_boxes) =
-                anonymous_block.borrow_mut().contents
-            {
-                block_level_boxes.push(block_level_box);
-                return;
-            }
-        }
-        let info = &block_builder_info
-            .with_pseudo_element(layout_context, PseudoElement::ServoAnonymousBox)
-            .expect("Should never fail to create anonymous box");
-        self.inline_items
-            .push(InlineItem::AnonymousBlock(ArcRefCell::new(
-                AnonymousBlockBox {
-                    base: LayoutBoxBase::new(info.into(), info.style.clone()),
-                    contents: BlockContainer::BlockLevelBoxes(vec![block_level_box]),
-                },
-            )));
+        self.contains_floats = self.contains_floats || block_level.borrow().contains_floats();
+        self.inline_items.push(InlineItem::BlockLevel(block_level));
     }
 
     pub(crate) fn start_inline_box(

--- a/components/layout/flow/inline/line.rs
+++ b/components/layout/flow/inline/line.rs
@@ -231,7 +231,7 @@ impl LineItemLayout<'_, '_> {
                         // position it's fragment has in the order of line items.
                         last_level
                     },
-                    LineItem::AnonymousBlockBox(..) => last_level,
+                    LineItem::BlockLevel(..) => last_level,
                 };
                 last_level = level;
                 level
@@ -280,7 +280,7 @@ impl LineItemLayout<'_, '_> {
                 LineItem::Atomic(_, atomic) => self.layout_atomic(atomic),
                 LineItem::AbsolutelyPositioned(_, absolute) => self.layout_absolute(absolute),
                 LineItem::Float(_, float) => self.layout_float(float),
-                LineItem::AnonymousBlockBox(_, block_box) => self.layout_block(block_box),
+                LineItem::BlockLevel(_, block_level) => self.layout_block_level(block_level),
             }
         }
 
@@ -735,13 +735,16 @@ impl LineItemLayout<'_, '_> {
             .push((Fragment::Float(float.fragment), LogicalRect::zero()));
     }
 
-    fn layout_block(&mut self, block: ArcRefCell<BoxFragment>) {
+    fn layout_block_level(&mut self, block_level: ArcRefCell<BoxFragment>) {
         let containing_block = self.containing_block();
-        let mut content_rect = block.borrow().content_rect().to_logical(containing_block);
-        // Anonymous blocks are always placed at the logical origin of the line.
+        let mut content_rect = block_level
+            .borrow()
+            .content_rect()
+            .to_logical(containing_block);
+        // Block-level boxes are always placed at the logical origin of the line.
         content_rect.start_corner.inline -= self.current_state.parent_offset.inline;
         content_rect.start_corner.block -= self.line_metrics.block_offset;
-        let fragment_and_rect = (Fragment::Box(block), content_rect);
+        let fragment_and_rect = (Fragment::Box(block_level), content_rect);
         self.current_state.fragments.push(fragment_and_rect);
     }
 
@@ -758,7 +761,7 @@ pub(super) enum LineItem {
     Atomic(Option<InlineBoxIdentifier>, AtomicLineItem),
     AbsolutelyPositioned(Option<InlineBoxIdentifier>, AbsolutelyPositionedLineItem),
     Float(Option<InlineBoxIdentifier>, FloatLineItem),
-    AnonymousBlockBox(Option<InlineBoxIdentifier>, ArcRefCell<BoxFragment>),
+    BlockLevel(Option<InlineBoxIdentifier>, ArcRefCell<BoxFragment>),
 }
 
 impl LineItem {
@@ -770,7 +773,7 @@ impl LineItem {
             LineItem::Atomic(identifier, _) => *identifier,
             LineItem::AbsolutelyPositioned(identifier, _) => *identifier,
             LineItem::Float(identifier, _) => *identifier,
-            LineItem::AnonymousBlockBox(identifier, _) => *identifier,
+            LineItem::BlockLevel(identifier, _) => *identifier,
         }
     }
 
@@ -782,7 +785,7 @@ impl LineItem {
             LineItem::Atomic(..) => false,
             LineItem::AbsolutelyPositioned(..) => true,
             LineItem::Float(..) => true,
-            LineItem::AnonymousBlockBox(..) => true,
+            LineItem::BlockLevel(..) => true,
         }
     }
 
@@ -794,7 +797,7 @@ impl LineItem {
             LineItem::Atomic(..) => false,
             LineItem::AbsolutelyPositioned(..) => true,
             LineItem::Float(..) => true,
-            LineItem::AnonymousBlockBox(..) => true,
+            LineItem::BlockLevel(..) => true,
         }
     }
 }

--- a/components/layout/flow/inline/mod.rs
+++ b/components/layout/flow/inline/mod.rs
@@ -124,8 +124,8 @@ use crate::dom_traversal::NodeAndStyleInfo;
 use crate::flow::float::{FloatBox, SequentialLayoutState};
 use crate::flow::inline::line::TextRunOffsets;
 use crate::flow::{
-    BlockContainer, CollapsibleWithParentStartMargin, FloatSide, PlacementState,
-    layout_in_flow_non_replaced_block_level_same_formatting_context,
+    BlockLevelBox, CollapsibleWithParentStartMargin, FloatSide, PlacementState,
+    compute_inline_content_sizes_for_block_level_boxes, layout_block_level_child,
 };
 use crate::formatting_contexts::{Baselines, IndependentFormattingContext};
 use crate::fragment_tree::{
@@ -134,9 +134,7 @@ use crate::fragment_tree::{
 use crate::geom::{LogicalRect, LogicalSides1D, LogicalVec2, ToLogical};
 use crate::layout_box_base::LayoutBoxBase;
 use crate::positioned::{AbsolutelyPositionedBox, PositioningContext};
-use crate::sizing::{
-    ComputeInlineContentSizes, ContentSizes, InlineContentSizesResult, outer_inline,
-};
+use crate::sizing::{ComputeInlineContentSizes, ContentSizes, InlineContentSizesResult};
 use crate::style_ext::{ComputedValuesExt, PaddingBorderMargin};
 use crate::{ConstraintSpace, ContainingBlock, IndefiniteContainingBlock, SharedStyle};
 
@@ -207,74 +205,34 @@ impl SharedInlineStyles {
     }
 }
 
-/// Each sequence of block-level boxes that participate in an inline formatting context
-/// (because their parent is an inline box) gets wrapped inside an [`AnonymousBlockBox`].
-/// This way we don't have to deal with the block-levels directly.
-#[derive(Debug, MallocSizeOf)]
-pub(crate) struct AnonymousBlockBox {
-    base: LayoutBoxBase,
-    contents: BlockContainer,
-}
-
-impl AnonymousBlockBox {
+impl BlockLevelBox {
     fn layout_into_line_items(&self, layout: &mut InlineFormattingContextLayout) {
         layout.process_soft_wrap_opportunity();
         layout.commit_current_segment_to_line();
         layout.process_line_break(true);
         layout.current_line.for_block_level = true;
 
-        let positioning_context_length = layout.positioning_context.len();
-        let fragment = layout
-            .positioning_context
-            .layout_maybe_position_relative_fragment(
-                layout.layout_context,
-                layout.placement_state.containing_block,
-                &self.base,
-                |positioning_context| {
-                    layout_in_flow_non_replaced_block_level_same_formatting_context(
-                        layout.layout_context,
-                        positioning_context,
-                        layout.placement_state.containing_block,
-                        &self.base,
-                        &self.contents,
-                        layout.sequential_layout_state.as_deref_mut(),
-                        Some(CollapsibleWithParentStartMargin(
-                            layout
-                                .placement_state
-                                .next_in_flow_margin_collapses_with_parent_start_margin,
-                        )),
-                        // This doesn't matter, because the anonymous block doesn't stretch in the
-                        // block axis. However, it's not clear what to do for the block-levels inside,
-                        // see <https://github.com/w3c/csswg-drafts/issues/13260>
-                        LogicalSides1D::new(false, false),
-                    )
-                },
-            );
+        let fragment = layout_block_level_child(
+            layout.layout_context,
+            layout.positioning_context,
+            self,
+            layout.sequential_layout_state.as_deref_mut(),
+            &mut layout.placement_state,
+            // Under discussion in <https://github.com/w3c/csswg-drafts/issues/13260>.
+            LogicalSides1D::new(false, false),
+        );
+
+        let Fragment::Box(fragment) = fragment else {
+            unreachable!("The fragment should be a Fragment::Box()");
+        };
 
         // If this Fragment's layout depends on the block size of the containing block,
         // then the entire layout of the inline formatting context does as well.
-        layout.depends_on_block_constraints |= fragment.base.flags.contains(
+        layout.depends_on_block_constraints |= fragment.borrow().base.flags.contains(
             FragmentFlags::SIZE_DEPENDS_ON_BLOCK_CONSTRAINTS_AND_CAN_BE_CHILD_OF_FLEX_ITEM,
         );
 
-        let mut fragment = Fragment::Box(ArcRefCell::new(fragment));
-        layout.placement_state.place_fragment_and_update_baseline(
-            &mut fragment,
-            layout.sequential_layout_state.as_deref_mut(),
-        );
-
-        // Adjust the static positions of any absolutely positioned boxes that were hoisted
-        // during layout of this anonymous block to account for the block's final position,
-        // including any resolved margin-top. This mirrors the identical pattern in
-        // `layout_block_level_children_sequentially`.
-        layout
-            .positioning_context
-            .adjust_static_position_of_hoisted_fragments(&fragment, positioning_context_length);
-
-        let Fragment::Box(fragment) = fragment else {
-            unreachable!("The fragment should still be a Fragment::Box()");
-        };
-        layout.push_line_item_to_unbreakable_segment(LineItem::AnonymousBlockBox(
+        layout.push_line_item_to_unbreakable_segment(LineItem::BlockLevel(
             layout.current_inline_box_identifier(),
             fragment,
         ));
@@ -300,7 +258,7 @@ pub(crate) enum InlineItem {
         usize, /* offset_in_text */
         Level, /* bidi_level */
     ),
-    AnonymousBlock(ArcRefCell<AnonymousBlockBox>),
+    BlockLevel(ArcRefCell<BlockLevelBox>),
 }
 
 impl InlineItem {
@@ -331,11 +289,9 @@ impl InlineItem {
             InlineItem::Atomic(atomic, ..) => {
                 atomic.borrow_mut().repair_style(context, node, new_style)
             },
-            InlineItem::AnonymousBlock(block_box) => {
-                let mut block_box = block_box.borrow_mut();
-                block_box.base.repair_style(new_style);
-                block_box.contents.repair_style(context, node, new_style);
-            },
+            InlineItem::BlockLevel(block_level) => block_level
+                .borrow_mut()
+                .repair_style(context, node, new_style),
         }
     }
 
@@ -352,7 +308,7 @@ impl InlineItem {
             InlineItem::Atomic(independent_formatting_context, ..) => {
                 callback(&independent_formatting_context.borrow().base)
             },
-            InlineItem::AnonymousBlock(block_box) => callback(&block_box.borrow().base),
+            InlineItem::BlockLevel(block_level) => block_level.borrow().with_base(callback),
         }
     }
 
@@ -371,7 +327,7 @@ impl InlineItem {
             InlineItem::Atomic(independent_formatting_context, ..) => {
                 callback(&mut independent_formatting_context.borrow_mut().base)
             },
-            InlineItem::AnonymousBlock(block_box) => callback(&mut block_box.borrow_mut().base),
+            InlineItem::BlockLevel(block_level) => block_level.borrow_mut().with_base_mut(callback),
         }
     }
 
@@ -391,9 +347,7 @@ impl InlineItem {
                 float_box.borrow().contents.attached_to_tree(layout_box)
             },
             Self::Atomic(atomic, ..) => atomic.borrow().attached_to_tree(layout_box),
-            Self::AnonymousBlock(block_box) => {
-                block_box.borrow().contents.attached_to_tree(layout_box)
-            },
+            Self::BlockLevel(block_level) => block_level.borrow().attached_to_tree(layout_box),
         }
     }
 
@@ -416,9 +370,7 @@ impl InlineItem {
             Self::Atomic(atomic, offset_in_text, bidi_level) => {
                 WeakInlineItem::Atomic(atomic.downgrade(), *offset_in_text, *bidi_level)
             },
-            Self::AnonymousBlock(block_box) => {
-                WeakInlineItem::AnonymousBlock(block_box.downgrade())
-            },
+            Self::BlockLevel(block_level) => WeakInlineItem::BlockLevel(block_level.downgrade()),
         }
     }
 }
@@ -438,7 +390,7 @@ pub(crate) enum WeakInlineItem {
         usize, /* offset_in_text */
         Level, /* bidi_level */
     ),
-    AnonymousBlock(WeakRefCell<AnonymousBlockBox>),
+    BlockLevel(WeakRefCell<BlockLevelBox>),
 }
 
 impl WeakInlineItem {
@@ -459,7 +411,7 @@ impl WeakInlineItem {
             Self::Atomic(atomic, offset_in_text, bidi_level) => {
                 InlineItem::Atomic(atomic.upgrade()?, *offset_in_text, *bidi_level)
             },
-            Self::AnonymousBlock(block_box) => InlineItem::AnonymousBlock(block_box.upgrade()?),
+            Self::BlockLevel(block_level) => InlineItem::BlockLevel(block_level.upgrade()?),
         })
     }
 }
@@ -1936,7 +1888,7 @@ impl InlineFormattingContext {
                 InlineItem::OutOfFlowAbsolutelyPositionedBox(..) |
                 InlineItem::OutOfFlowFloatBox(_) |
                 InlineItem::EndInlineBox |
-                InlineItem::AnonymousBlock { .. } => {},
+                InlineItem::BlockLevel { .. } => {},
             }
         }
 
@@ -2070,8 +2022,8 @@ impl InlineFormattingContext {
                 InlineItem::OutOfFlowFloatBox(float_box) => {
                     float_box.borrow().layout_into_line_items(&mut layout);
                 },
-                InlineItem::AnonymousBlock(block_box) => {
-                    block_box.borrow().layout_into_line_items(&mut layout);
+                InlineItem::BlockLevel(block_level) => {
+                    block_level.borrow().layout_into_line_items(&mut layout);
                 },
             }
         }
@@ -2161,9 +2113,8 @@ impl InlineFormattingContext {
             InlineItem::OutOfFlowAbsolutelyPositionedBox(..) => true,
             InlineItem::OutOfFlowFloatBox(..) => true,
             InlineItem::Atomic(..) => false,
-            InlineItem::AnonymousBlock(block_box) => block_box
+            InlineItem::BlockLevel(block_level) => block_level
                 .borrow()
-                .contents
                 .find_block_margin_collapsing_with_parent(
                     layout_context,
                     collected_margin,
@@ -2856,29 +2807,15 @@ impl<'layout_data> ContentSizesComputation<'layout_data> {
                     FloatSide::InlineEnd => self.uncleared_floats.end.union_assign(&sizes),
                 }
             },
-            InlineItem::AnonymousBlock(block) => {
+            InlineItem::BlockLevel(block_level) => {
                 self.forced_line_break();
                 self.flush_floats();
-                let borrowed_block = block.borrow();
-                let AnonymousBlockBox {
-                    ref base,
-                    ref contents,
-                    ..
-                } = *borrowed_block;
-                let inline_content_sizes_result = outer_inline(
-                    base,
-                    &contents.layout_style(base),
-                    &self.constraint_space.into(),
-                    &LogicalVec2::zero(),
-                    false,    /* auto_block_size_stretches_to_containing_block */
-                    false,    /* is_replaced */
-                    false,    /* establishes_containing_block */
-                    |_| None, /* get_preferred_aspect_ratio */
-                    |constraint_space| {
-                        base.inline_content_sizes(self.layout_context, constraint_space, contents)
-                    },
-                    |_aspect_ratio| None,
-                );
+                let inline_content_sizes_result =
+                    compute_inline_content_sizes_for_block_level_boxes(
+                        std::slice::from_ref(block_level),
+                        self.layout_context,
+                        &self.constraint_space.into(),
+                    );
                 self.depends_on_block_constraints |=
                     inline_content_sizes_result.depends_on_block_constraints;
                 self.current_line = inline_content_sizes_result.sizes;

--- a/components/layout/flow/mod.rs
+++ b/components/layout/flow/mod.rs
@@ -731,7 +731,6 @@ fn layout_block_level_children(
             layout_context,
             positioning_context,
             child_boxes,
-            containing_block,
             sequential_layout_state,
             &mut placement_state,
             ignore_block_margins_for_stretch,
@@ -740,7 +739,6 @@ fn layout_block_level_children(
             layout_context,
             positioning_context,
             child_boxes,
-            containing_block,
             &mut placement_state,
             ignore_block_margins_for_stretch,
         ),
@@ -770,7 +768,6 @@ fn layout_block_level_children_in_parallel(
     layout_context: &LayoutContext,
     positioning_context: &mut PositioningContext,
     child_boxes: &[ArcRefCell<BlockLevelBox>],
-    containing_block: &ContainingBlock,
     placement_state: &mut PlacementState,
     ignore_block_margins_for_stretch: LogicalSides1D<bool>,
 ) -> Vec<Fragment> {
@@ -784,7 +781,7 @@ fn layout_block_level_children_in_parallel(
             let fragment = child_box.borrow().layout(
                 layout_context,
                 &mut child_positioning_context,
-                containing_block,
+                placement_state.containing_block,
                 /* sequential_layout_state = */ None,
                 /* collapsible_with_parent_start_margin = */ None,
                 ignore_block_margins_for_stretch,
@@ -811,7 +808,6 @@ fn layout_block_level_children_sequentially(
     layout_context: &LayoutContext,
     positioning_context: &mut PositioningContext,
     child_boxes: &[ArcRefCell<BlockLevelBox>],
-    containing_block: &ContainingBlock,
     sequential_layout_state: &mut SequentialLayoutState,
     placement_state: &mut PlacementState,
     ignore_block_margins_for_stretch: LogicalSides1D<bool>,
@@ -822,28 +818,45 @@ fn layout_block_level_children_sequentially(
     child_boxes
         .iter()
         .map(|child_box| {
-            let positioning_context_length_before_layout = positioning_context.len();
-            let mut fragment = child_box.borrow().layout(
+            layout_block_level_child(
                 layout_context,
                 positioning_context,
-                containing_block,
-                Some(&mut *sequential_layout_state),
-                Some(CollapsibleWithParentStartMargin(
-                    placement_state.next_in_flow_margin_collapses_with_parent_start_margin,
-                )),
+                &child_box.borrow(),
+                Some(sequential_layout_state),
+                placement_state,
                 ignore_block_margins_for_stretch,
-            );
-
-            placement_state
-                .place_fragment_and_update_baseline(&mut fragment, Some(sequential_layout_state));
-            positioning_context.adjust_static_position_of_hoisted_fragments(
-                &fragment,
-                positioning_context_length_before_layout,
-            );
-
-            fragment
+            )
         })
         .collect()
+}
+
+fn layout_block_level_child(
+    layout_context: &LayoutContext,
+    positioning_context: &mut PositioningContext,
+    child_box: &BlockLevelBox,
+    mut sequential_layout_state: Option<&mut SequentialLayoutState>,
+    placement_state: &mut PlacementState,
+    ignore_block_margins_for_stretch: LogicalSides1D<bool>,
+) -> Fragment {
+    let positioning_context_length_before_layout = positioning_context.len();
+    let mut fragment = child_box.layout(
+        layout_context,
+        positioning_context,
+        placement_state.containing_block,
+        sequential_layout_state.as_deref_mut(),
+        Some(CollapsibleWithParentStartMargin(
+            placement_state.next_in_flow_margin_collapses_with_parent_start_margin,
+        )),
+        ignore_block_margins_for_stretch,
+    );
+
+    placement_state.place_fragment_and_update_baseline(&mut fragment, sequential_layout_state);
+    positioning_context.adjust_static_position_of_hoisted_fragments(
+        &fragment,
+        positioning_context_length_before_layout,
+    );
+
+    fragment
 }
 
 impl BlockLevelBox {
@@ -949,7 +962,7 @@ impl BlockLevelBox {
 /// - <https://drafts.csswg.org/css2/visudet.html#blockwidth>
 /// - <https://drafts.csswg.org/css2/visudet.html#normal-block>
 #[allow(clippy::too_many_arguments)]
-pub(crate) fn layout_in_flow_non_replaced_block_level_same_formatting_context(
+fn layout_in_flow_non_replaced_block_level_same_formatting_context(
     layout_context: &LayoutContext,
     positioning_context: &mut PositioningContext,
     containing_block: &ContainingBlock,


### PR DESCRIPTION
When encountering a block-level inside an inline box, we would wrap it (together with other block-level siblings, if any) inside an anonymous block box.

That was complicating the logic for no real benefit, so just get rid of these anonymous wrappers, and allow block-levels as direct children of inlines.

This aligns Servo with WebKit, which did the same refactoring: https://commits.webkit.org/304357@main

Blink still generates these wrappers, but its design doc acknowledges that "the anonymous box is not strictly required".

Testing: No existing test fails. But note that, while minimal, this may have some observable implications. For example, as an accidental side-effect of #41492, Servo aligned with the CSSWG resolution in https://github.com/w3c/csswg-drafts/issues/11462, but now we will revert to the previous behavior. I will address it in a follow-up, and add a test.

Fixes: #41636
