### PR TITLE
devtools: Rework debugger value structure

### DIFF
--- a/components/devtools/actors/console.rs
+++ b/components/devtools/actors/console.rs
@@ -434,8 +434,7 @@ impl ConsoleActor {
             .and_then(|v| v.as_str())
             .map(String::from);
         let (chan, port) = generic_channel::channel().unwrap();
-        // FIXME: Redesign messages so we don't have to fake pipeline ids when
-        //        communicating with workers.
+        // FIXME: Redesign messages so we don't have to fake pipeline ids when communicating with workers.
         let pipeline = match self.current_unique_id(registry) {
             UniqueId::Pipeline(p) => p,
             UniqueId::Worker(_) => TEST_PIPELINE_ID,

--- a/components/devtools/actors/console.rs
+++ b/components/devtools/actors/console.rs
@@ -12,7 +12,7 @@ use std::sync::atomic::{AtomicBool, Ordering};
 
 use atomic_refcell::AtomicRefCell;
 use devtools_traits::DebuggerValue::{
-    BooleanValue, NullValue, NumberValue, ObjectValue, StringValue, VoidValue,
+    self, BooleanValue, NullValue, NumberValue, ObjectValue, StringValue, VoidValue,
 };
 use devtools_traits::{
     ConsoleArgument, ConsoleMessage, ConsoleMessageFields, DevtoolScriptControlMsg, PageError,
@@ -306,6 +306,123 @@ impl ConsoleActor {
         }
     }
 
+    // TODO: This should be handled with struct serialization instead of manually adding values to a map
+    fn value_to_json(value: DebuggerValue, registry: &ActorRegistry) -> Value {
+        let mut m = Map::new();
+        match value {
+            VoidValue => {
+                m.insert("type".to_owned(), Value::String("undefined".to_owned()));
+                Value::Object(m)
+            },
+            NullValue => {
+                m.insert("type".to_owned(), Value::String("null".to_owned()));
+                Value::Object(m)
+            },
+            BooleanValue(val) => Value::Bool(val),
+            NumberValue(val) => {
+                if val.is_nan() {
+                    m.insert("type".to_owned(), Value::String("NaN".to_owned()));
+                    Value::Object(m)
+                } else if val.is_infinite() {
+                    if val < 0. {
+                        m.insert("type".to_owned(), Value::String("-Infinity".to_owned()));
+                    } else {
+                        m.insert("type".to_owned(), Value::String("Infinity".to_owned()));
+                    }
+                    Value::Object(m)
+                } else if val == 0. && val.is_sign_negative() {
+                    m.insert("type".to_owned(), Value::String("-0".to_owned()));
+                    Value::Object(m)
+                } else {
+                    Value::Number(Number::from_f64(val).unwrap())
+                }
+            },
+            StringValue(s) => Value::String(s),
+            ObjectValue {
+                uuid,
+                class,
+                preview,
+            } => {
+                let properties = preview
+                    .clone()
+                    .and_then(|preview| preview.own_properties)
+                    .unwrap_or_default();
+                let actor = ObjectActor::register_with_properties(
+                    registry,
+                    Some(uuid),
+                    class.clone(),
+                    properties,
+                );
+
+                m.insert("type".to_owned(), Value::String("object".to_owned()));
+                m.insert("class".to_owned(), Value::String(class));
+                m.insert("actor".to_owned(), Value::String(actor));
+                m.insert("extensible".to_owned(), Value::Bool(true));
+                m.insert("frozen".to_owned(), Value::Bool(false));
+                m.insert("sealed".to_owned(), Value::Bool(false));
+
+                // Build preview
+                // <https://searchfox.org/firefox-main/source/devtools/server/actors/object/previewers.js#849>
+                let Some(preview) = preview else {
+                    return Value::Object(m);
+                };
+                let mut preview_map = Map::new();
+
+                if preview.kind == "ArrayLike" {
+                    if let Some(length) = preview.array_length {
+                        preview_map.insert("length".to_owned(), Value::Number(length.into()));
+                    }
+                } else {
+                    if let Some(ref props) = preview.own_properties {
+                        let mut own_props_map = Map::new();
+                        for prop in props {
+                            let descriptor =
+                                serde_json::to_value(ObjectPropertyDescriptor::from(prop)).unwrap();
+                            own_props_map.insert(prop.name.clone(), descriptor);
+                        }
+                        preview_map
+                            .insert("ownProperties".to_owned(), Value::Object(own_props_map));
+                    }
+
+                    if let Some(length) = preview.own_properties_length {
+                        preview_map.insert(
+                            "ownPropertiesLength".to_owned(),
+                            Value::Number(length.into()),
+                        );
+                        m.insert("ownPropertyLength".to_owned(), Value::Number(length.into()));
+                    }
+                }
+                preview_map.insert("kind".to_owned(), Value::String(preview.kind));
+
+                // Function-specific metadata
+                if let Some(function) = preview.function {
+                    if let Some(name) = function.name {
+                        m.insert("name".to_owned(), Value::String(name));
+                    }
+                    if let Some(display_name) = function.display_name {
+                        m.insert("displayName".to_owned(), Value::String(display_name));
+                    }
+                    m.insert(
+                        "parameterNames".to_owned(),
+                        Value::Array(
+                            function
+                                .parameter_names
+                                .into_iter()
+                                .map(Value::String)
+                                .collect(),
+                        ),
+                    );
+                    m.insert("isAsync".to_owned(), Value::Bool(function.is_async));
+                    m.insert("isGenerator".to_owned(), Value::Bool(function.is_generator));
+                }
+
+                m.insert("preview".to_owned(), Value::Object(preview_map));
+
+                Value::Object(m)
+            },
+        }
+    }
+
     fn evaluate_js(
         &self,
         registry: &ActorRegistry,
@@ -332,134 +449,13 @@ impl ConsoleActor {
             ))
             .unwrap();
 
-        // TODO: Extract conversion into protocol module or some other useful place
         let eval_result = port.recv().map_err(|_| ())?;
         let has_exception = eval_result.has_exception;
-
-        let result = match eval_result.value {
-            VoidValue => {
-                let mut m = Map::new();
-                m.insert("type".to_owned(), Value::String("undefined".to_owned()));
-                Value::Object(m)
-            },
-            NullValue => {
-                let mut m = Map::new();
-                m.insert("type".to_owned(), Value::String("null".to_owned()));
-                Value::Object(m)
-            },
-            BooleanValue(val) => Value::Bool(val),
-            NumberValue(val) => {
-                if val.is_nan() {
-                    let mut m = Map::new();
-                    m.insert("type".to_owned(), Value::String("NaN".to_owned()));
-                    Value::Object(m)
-                } else if val.is_infinite() {
-                    let mut m = Map::new();
-                    if val < 0. {
-                        m.insert("type".to_owned(), Value::String("-Infinity".to_owned()));
-                    } else {
-                        m.insert("type".to_owned(), Value::String("Infinity".to_owned()));
-                    }
-                    Value::Object(m)
-                } else if val == 0. && val.is_sign_negative() {
-                    let mut m = Map::new();
-                    m.insert("type".to_owned(), Value::String("-0".to_owned()));
-                    Value::Object(m)
-                } else {
-                    Value::Number(Number::from_f64(val).unwrap())
-                }
-            },
-            StringValue(s) => Value::String(s),
-            ObjectValue {
-                uuid,
-                class,
-                preview,
-            } => {
-                let properties = preview
-                    .clone()
-                    .map(|preview| preview.own_properties)
-                    .flatten()
-                    .unwrap_or_default();
-                // TODO: Replace this with a struct to avoid having the Map.
-                let mut m = Map::new();
-                let actor = ObjectActor::register_with_properties(
-                    registry,
-                    Some(uuid),
-                    class.clone(),
-                    properties,
-                );
-
-                m.insert("type".to_owned(), Value::String("object".to_owned()));
-                m.insert("class".to_owned(), Value::String(class));
-                m.insert("actor".to_owned(), Value::String(actor));
-                m.insert("extensible".to_owned(), Value::Bool(true));
-                m.insert("frozen".to_owned(), Value::Bool(false));
-                m.insert("sealed".to_owned(), Value::Bool(false));
-
-                // Build preview
-                // <https://searchfox.org/firefox-main/source/devtools/server/actors/object/previewers.js#849>
-                let mut preview_map = Map::new();
-                if let Some(preview) = preview {
-                    // Function-specific metadata
-                    if let Some(function) = preview.function {
-                        if let Some(name) = function.name {
-                            m.insert("name".to_owned(), Value::String(name));
-                        }
-                        if let Some(display_name) = function.display_name {
-                            m.insert("displayName".to_owned(), Value::String(display_name));
-                        }
-                        m.insert(
-                            "parameterNames".to_owned(),
-                            Value::Array(
-                                function
-                                    .parameter_names
-                                    .into_iter()
-                                    .map(Value::String)
-                                    .collect(),
-                            ),
-                        );
-                        m.insert("isAsync".to_owned(), Value::Bool(function.is_async));
-                        m.insert("isGenerator".to_owned(), Value::Bool(function.is_generator));
-                    }
-
-                    if preview.kind == "ArrayLike" {
-                        if let Some(length) = preview.array_length {
-                            preview_map.insert("length".to_owned(), Value::Number(length.into()));
-                        }
-                    } else {
-                        if let Some(ref props) = preview.own_properties {
-                            let mut own_props_map = Map::new();
-                            for prop in props {
-                                let descriptor =
-                                    serde_json::to_value(ObjectPropertyDescriptor::from(prop))
-                                        .unwrap();
-                                own_props_map.insert(prop.name.clone(), descriptor);
-                            }
-                            preview_map
-                                .insert("ownProperties".to_owned(), Value::Object(own_props_map));
-                        }
-
-                        if let Some(length) = preview.own_properties_length {
-                            preview_map.insert(
-                                "ownPropertiesLength".to_owned(),
-                                Value::Number(length.into()),
-                            );
-                            m.insert("ownPropertyLength".to_owned(), Value::Number(length.into()));
-                        }
-                    }
-                    preview_map.insert("kind".to_owned(), Value::String(preview.kind));
-                }
-
-                m.insert("preview".to_owned(), Value::Object(preview_map));
-
-                Value::Object(m)
-            },
-        };
 
         let reply = EvaluateJSReply {
             from: self.name(),
             input,
-            result,
+            result: Self::value_to_json(eval_result.value, registry),
             timestamp: get_time_stamp(),
             exception: Value::Null,
             exception_message: Value::Null,

--- a/components/devtools/actors/console.rs
+++ b/components/devtools/actors/console.rs
@@ -11,8 +11,8 @@ use std::net::TcpStream;
 use std::sync::atomic::{AtomicBool, Ordering};
 
 use atomic_refcell::AtomicRefCell;
-use devtools_traits::EvaluateJSReplyValue::{
-    ActorValue, BooleanValue, NullValue, NumberValue, StringValue, VoidValue,
+use devtools_traits::DebuggerValue::{
+    BooleanValue, NullValue, NumberValue, ObjectValue, StringValue, VoidValue,
 };
 use devtools_traits::{
     ConsoleArgument, ConsoleMessage, ConsoleMessageFields, DevtoolScriptControlMsg, PageError,
@@ -370,20 +370,16 @@ impl ConsoleActor {
                 }
             },
             StringValue(s) => Value::String(s),
-            ActorValue {
-                class,
+            ObjectValue {
                 uuid,
-                name,
-                display_name,
-                parameter_names,
-                is_async,
-                is_generator,
-                own_properties,
-                own_properties_length,
-                kind,
-                array_length,
+                class,
+                preview,
             } => {
-                let properties = own_properties.clone().unwrap_or_default();
+                let properties = preview
+                    .clone()
+                    .map(|preview| preview.own_properties)
+                    .flatten()
+                    .unwrap_or_default();
                 // TODO: Replace this with a struct to avoid having the Map.
                 let mut m = Map::new();
                 let actor = ObjectActor::register_with_properties(
@@ -399,58 +395,62 @@ impl ConsoleActor {
                 m.insert("extensible".to_owned(), Value::Bool(true));
                 m.insert("frozen".to_owned(), Value::Bool(false));
                 m.insert("sealed".to_owned(), Value::Bool(false));
-                if let Some(name) = name {
-                    m.insert("name".to_owned(), Value::String(name));
-                }
-
-                // Function-specific metadata
-                if let Some(display_name) = display_name {
-                    m.insert("displayName".to_owned(), Value::String(display_name));
-                }
-                if let Some(param_names) = parameter_names {
-                    m.insert(
-                        "parameterNames".to_owned(),
-                        Value::Array(param_names.into_iter().map(Value::String).collect()),
-                    );
-                }
-                if let Some(is_async) = is_async {
-                    m.insert("isAsync".to_owned(), Value::Bool(is_async));
-                }
-                if let Some(is_generator) = is_generator {
-                    m.insert("isGenerator".to_owned(), Value::Bool(is_generator));
-                }
 
                 // Build preview
                 // <https://searchfox.org/firefox-main/source/devtools/server/actors/object/previewers.js#849>
-                let mut preview = Map::new();
-                let preview_kind = kind.unwrap_or_else(|| "Object".to_owned());
-                preview.insert("kind".to_owned(), Value::String(preview_kind.clone()));
-
-                if preview_kind == "ArrayLike" {
-                    if let Some(length) = array_length {
-                        preview.insert("length".to_owned(), Value::Number(length.into()));
-                    }
-                } else {
-                    if let Some(ref props) = own_properties {
-                        let mut own_props_map = Map::new();
-                        for prop in props {
-                            let descriptor =
-                                serde_json::to_value(ObjectPropertyDescriptor::from(prop)).unwrap();
-                            own_props_map.insert(prop.name.clone(), descriptor);
+                let mut preview_map = Map::new();
+                if let Some(preview) = preview {
+                    // Function-specific metadata
+                    if let Some(function) = preview.function {
+                        if let Some(name) = function.name {
+                            m.insert("name".to_owned(), Value::String(name));
                         }
-                        preview.insert("ownProperties".to_owned(), Value::Object(own_props_map));
+                        if let Some(display_name) = function.display_name {
+                            m.insert("displayName".to_owned(), Value::String(display_name));
+                        }
+                        m.insert(
+                            "parameterNames".to_owned(),
+                            Value::Array(
+                                function
+                                    .parameter_names
+                                    .into_iter()
+                                    .map(Value::String)
+                                    .collect(),
+                            ),
+                        );
+                        m.insert("isAsync".to_owned(), Value::Bool(function.is_async));
+                        m.insert("isGenerator".to_owned(), Value::Bool(function.is_generator));
                     }
 
-                    if let Some(length) = own_properties_length {
-                        preview.insert(
-                            "ownPropertiesLength".to_owned(),
-                            Value::Number(length.into()),
-                        );
-                        m.insert("ownPropertyLength".to_owned(), Value::Number(length.into()));
+                    if preview.kind == "ArrayLike" {
+                        if let Some(length) = preview.array_length {
+                            preview_map.insert("length".to_owned(), Value::Number(length.into()));
+                        }
+                    } else {
+                        if let Some(ref props) = preview.own_properties {
+                            let mut own_props_map = Map::new();
+                            for prop in props {
+                                let descriptor =
+                                    serde_json::to_value(ObjectPropertyDescriptor::from(prop))
+                                        .unwrap();
+                                own_props_map.insert(prop.name.clone(), descriptor);
+                            }
+                            preview_map
+                                .insert("ownProperties".to_owned(), Value::Object(own_props_map));
+                        }
+
+                        if let Some(length) = preview.own_properties_length {
+                            preview_map.insert(
+                                "ownPropertiesLength".to_owned(),
+                                Value::Number(length.into()),
+                            );
+                            m.insert("ownPropertyLength".to_owned(), Value::Number(length.into()));
+                        }
                     }
+                    preview_map.insert("kind".to_owned(), Value::String(preview.kind));
                 }
 
-                m.insert("preview".to_owned(), Value::Object(preview));
+                m.insert("preview".to_owned(), Value::Object(preview_map));
 
                 Value::Object(m)
             },

--- a/components/devtools/actors/object.rs
+++ b/components/devtools/actors/object.rs
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-use devtools_traits::PropertyDescriptor;
+use devtools_traits::{DebuggerValue, PropertyDescriptor};
 use malloc_size_of_derive::MallocSizeOf;
 use serde::Serialize;
 use serde_json::{Map, Number, Value};
@@ -74,23 +74,22 @@ impl From<&PropertyDescriptor> for ObjectPropertyDescriptor {
             configurable: prop.configurable,
             enumerable: prop.enumerable,
             writable: prop.writable,
-            value: property_value_to_json(prop),
+            value: debugger_value_to_json(&prop.value, &prop.name),
         }
     }
 }
 
 /// <https://searchfox.org/mozilla-central/source/devtools/server/actors/object/utils.js#148>
-fn property_value_to_json(prop: &PropertyDescriptor) -> Value {
-    match prop.value_type.as_str() {
-        "undefined" => {
+fn debugger_value_to_json(value: &DebuggerValue, name: &str) -> Value {
+    match value {
+        DebuggerValue::VoidValue => {
             let mut v = Map::new();
             v.insert("type".to_owned(), Value::String("undefined".to_owned()));
             Value::Object(v)
         },
-        "null" => Value::Null,
-        "boolean" => Value::Bool(prop.boolean_value.unwrap_or(false)),
-        "number" => {
-            let num = prop.number_value.unwrap_or(0.0);
+        DebuggerValue::NullValue => Value::Null,
+        DebuggerValue::BooleanValue(boolean) => Value::Bool(*boolean),
+        DebuggerValue::NumberValue(num) => {
             if num.is_nan() {
                 let mut v = Map::new();
                 v.insert("type".to_owned(), Value::String("NaN".to_owned()));
@@ -105,22 +104,17 @@ fn property_value_to_json(prop: &PropertyDescriptor) -> Value {
                 v.insert("type".to_owned(), Value::String(type_str.to_owned()));
                 Value::Object(v)
             } else {
-                Value::Number(Number::from_f64(num).unwrap_or(Number::from(0)))
+                Value::Number(Number::from_f64(*num).unwrap_or(Number::from(0)))
             }
         },
-        "string" => Value::String(prop.string_value.clone().unwrap_or_default()),
-        "object" => {
+        DebuggerValue::StringValue(str) => Value::String(str.clone()),
+        DebuggerValue::ObjectValue { class, .. } => {
             let mut v = Map::new();
             v.insert("type".to_owned(), Value::String("object".to_owned()));
-            if let Some(ref obj_class) = prop.object_class {
-                v.insert("class".to_owned(), Value::String(obj_class.clone()));
-            }
-            if let Some(ref obj_name) = prop.value_name {
-                v.insert("name".to_owned(), Value::String(obj_name.clone()));
-            }
+            v.insert("class".to_owned(), Value::String(class.clone()));
+            v.insert("name".to_owned(), Value::String(name.into()));
             Value::Object(v)
         },
-        _ => Value::Null,
     }
 }
 

--- a/components/script/dom/debugger/debuggerglobalscope.rs
+++ b/components/script/dom/debugger/debuggerglobalscope.rs
@@ -6,8 +6,7 @@ use std::cell::RefCell;
 
 use constellation_traits::ScriptToConstellationChan;
 use devtools_traits::{
-    DevtoolScriptControlMsg, EvaluateJSReply, EvaluateJSReplyValue, ScriptToDevtoolsControlMsg,
-    SourceInfo, WorkerId,
+    DevtoolScriptControlMsg, EvaluateJSReply, ScriptToDevtoolsControlMsg, SourceInfo, WorkerId,
 };
 use dom_struct::dom_struct;
 use embedder_traits::ScriptToEmbedderChan;
@@ -16,25 +15,29 @@ use js::context::JSContext;
 use js::rust::wrappers2::JS_DefineDebuggerObject;
 use net_traits::ResourceThreads;
 use profile_traits::{mem, time};
-use script_bindings::codegen::GenericBindings::DebuggerEvalEventBinding::EvalResultValue;
-use script_bindings::codegen::GenericBindings::DebuggerGetPossibleBreakpointsEventBinding::RecommendedBreakpointLocation;
-use script_bindings::codegen::GenericBindings::DebuggerGlobalScopeBinding::{
-    DebuggerGlobalScopeMethods, NotifyNewSource, PipelineIdInit,
-};
-use script_bindings::reflector::DomObject;
-use script_bindings::str::DOMString;
 use servo_base::generic_channel::{GenericCallback, GenericSender, channel};
 use servo_base::id::{Index, PipelineId, PipelineNamespaceId};
 use servo_url::{ImmutableOrigin, MutableOrigin, ServoUrl};
 use storage_traits::StorageThreads;
 
+use crate::dom::bindings::codegen::Bindings::DebuggerEvalEventBinding::DebuggerValue;
+use crate::dom::bindings::codegen::Bindings::DebuggerEvalEventBinding::GenericBindings::ObjectPreview;
 use crate::dom::bindings::codegen::Bindings::DebuggerGetEnvironmentEventBinding::EnvironmentInfo;
 use crate::dom::bindings::codegen::Bindings::DebuggerGlobalScopeBinding;
 use crate::dom::bindings::codegen::Bindings::DebuggerInterruptEventBinding::{
     FrameInfo, FrameOffset, PauseReason,
 };
+use crate::dom::bindings::codegen::GenericBindings::DebuggerEvalEventBinding::{
+    EvalResult, PropertyDescriptor,
+};
+use crate::dom::bindings::codegen::GenericBindings::DebuggerGetPossibleBreakpointsEventBinding::RecommendedBreakpointLocation;
+use crate::dom::bindings::codegen::GenericBindings::DebuggerGlobalScopeBinding::{
+    DebuggerGlobalScopeMethods, NotifyNewSource, PipelineIdInit,
+};
 use crate::dom::bindings::inheritance::Castable;
+use crate::dom::bindings::reflector::DomObject;
 use crate::dom::bindings::root::DomRoot;
+use crate::dom::bindings::str::DOMString;
 use crate::dom::bindings::utils::define_all_exposed_interfaces;
 use crate::dom::debugger::debuggerclearbreakpointevent::DebuggerClearBreakpointEvent;
 use crate::dom::debugger::debuggerframeevent::DebuggerFrameEvent;
@@ -469,89 +472,15 @@ impl DebuggerGlobalScopeMethods<crate::DomTypeHolder> for DebuggerGlobalScope {
     ///
     /// The result contains completion value information from the SpiderMonkey Debugger API:
     /// <https://firefox-source-docs.mozilla.org/js/Debugger/Conventions.html#completion-values>
-    fn EvalResult(&self, _event: &DebuggerEvalEvent, result: &EvalResultValue) {
+    fn EvalResult(&self, _event: &DebuggerEvalEvent, result: &EvalResult) {
         let sender = self
             .eval_result_sender
             .take()
             .expect("Guaranteed by Self::fire_eval()");
 
-        let has_exception = result.hasException.unwrap_or(false);
-
-        let value = match &*result.valueType.str() {
-            "undefined" => EvaluateJSReplyValue::VoidValue,
-            "null" => EvaluateJSReplyValue::NullValue,
-            "boolean" => EvaluateJSReplyValue::BooleanValue(result.booleanValue.unwrap_or(false)),
-            "number" => {
-                let num = result.numberValue.map(|f| *f).unwrap_or(0.0);
-                EvaluateJSReplyValue::NumberValue(num)
-            },
-            "string" => EvaluateJSReplyValue::StringValue(
-                result
-                    .stringValue
-                    .as_ref()
-                    .map(|s| s.to_string())
-                    .unwrap_or_default(),
-            ),
-            "object" => {
-                let class = result
-                    .objectClass
-                    .as_ref()
-                    .map(|s| s.to_string())
-                    .unwrap_or_else(|| "Object".to_string());
-                let name = result.name.as_ref().map(|s| s.to_string());
-
-                // Function-specific metadata
-                let display_name = result.displayName.as_ref().map(|s| s.to_string());
-                let parameter_names = result
-                    .parameterNames
-                    .as_ref()
-                    .map(|v| v.iter().map(|s| s.to_string()).collect());
-                let is_async = result.isAsync;
-                let is_generator = result.isGenerator;
-
-                // Object preview properties
-                let own_properties = result.ownProperties.as_ref().map(|props| {
-                    props
-                        .iter()
-                        .map(|prop| devtools_traits::PropertyDescriptor {
-                            name: prop.name.to_string(),
-                            configurable: prop.configurable,
-                            enumerable: prop.enumerable,
-                            writable: prop.writable,
-                            is_accessor: prop.isAccessor,
-                            value_type: prop.valueType.to_string(),
-                            boolean_value: prop.booleanValue,
-                            number_value: prop.numberValue.map(|f| *f),
-                            string_value: prop.stringValue.as_ref().map(|s| s.to_string()),
-                            object_class: prop.objectClass.as_ref().map(|s| s.to_string()),
-                            value_name: prop.valueName.as_ref().map(|s| s.to_string()),
-                        })
-                        .collect()
-                });
-                let own_properties_length = result.ownPropertiesLength;
-                let kind = result.kind.as_ref().map(|s| s.to_string());
-                let array_length = result.arrayLength;
-
-                EvaluateJSReplyValue::ActorValue {
-                    class,
-                    uuid: uuid::Uuid::new_v4().to_string(),
-                    name,
-                    display_name,
-                    parameter_names,
-                    is_async,
-                    is_generator,
-                    own_properties,
-                    own_properties_length,
-                    kind,
-                    array_length,
-                }
-            },
-            _ => unreachable!(),
-        };
-
         let reply = EvaluateJSReply {
-            value,
-            has_exception,
+            value: parse_debugger_value(&result.value, result.preview.as_ref()),
+            has_exception: result.hasException.unwrap_or(false),
         };
 
         let _ = sender.send(reply);
@@ -665,5 +594,79 @@ impl DebuggerGlobalScopeMethods<crate::DomTypeHolder> for DebuggerGlobalScope {
             .expect("Guaranteed by Self::fire_get_environment()");
 
         let _ = sender.send(environment_actor_id.into());
+    }
+}
+
+fn parse_property_descriptor(property: &PropertyDescriptor) -> devtools_traits::PropertyDescriptor {
+    devtools_traits::PropertyDescriptor {
+        name: property.name.to_string(),
+        value: parse_debugger_value(&property.value, None),
+        configurable: property.configurable,
+        enumerable: property.enumerable,
+        writable: property.writable,
+        is_accessor: property.isAccessor,
+    }
+}
+
+fn parse_object_preview(preview: &ObjectPreview) -> devtools_traits::ObjectPreview {
+    devtools_traits::ObjectPreview {
+        kind: preview.kind.clone().into(),
+        own_properties: preview
+            .ownProperties
+            .as_ref()
+            .map(|properties| properties.iter().map(parse_property_descriptor).collect()),
+        own_properties_length: preview.ownPropertiesLength,
+        function: preview
+            .function
+            .as_ref()
+            .map(|fields| devtools_traits::FunctionPreview {
+                name: fields.name.as_ref().map(|s| s.to_string()),
+                display_name: fields.displayName.as_ref().map(|s| s.to_string()),
+                parameter_names: fields
+                    .parameterNames
+                    .iter()
+                    .map(|p| p.to_string())
+                    .collect(),
+                is_async: fields.isAsync,
+                is_generator: fields.isGenerator,
+            }),
+        array_length: preview.arrayLength,
+    }
+}
+
+fn parse_debugger_value(
+    value: &DebuggerValue,
+    preview: Option<&ObjectPreview>,
+) -> devtools_traits::DebuggerValue {
+    use devtools_traits::DebuggerValue::*;
+    match &*value.valueType.str() {
+        "undefined" => VoidValue,
+        "null" => NullValue,
+        "boolean" => BooleanValue(value.booleanValue.unwrap_or(false)),
+        "number" => {
+            let num = value.numberValue.map(|f| *f).unwrap_or(0.0);
+            NumberValue(num)
+        },
+        "string" => StringValue(
+            value
+                .stringValue
+                .as_ref()
+                .map(|s| s.to_string())
+                .unwrap_or_default(),
+        ),
+        "object" => {
+            let class = value
+                .objectClass
+                .as_ref()
+                .map(|s| s.to_string())
+                .unwrap_or_else(|| "Object".to_string());
+
+            ObjectValue {
+                uuid: uuid::Uuid::new_v4().to_string(),
+                class,
+                preview: preview.map(parse_object_preview),
+            }
+        },
+        _ => unreachable!(),
     }
 }

--- a/components/script/dom/workers/serviceworkerglobalscope.rs
+++ b/components/script/dom/workers/serviceworkerglobalscope.rs
@@ -11,7 +11,7 @@ use constellation_traits::{
     ScopeThings, ServiceWorkerMsg, WorkerGlobalScopeInit, WorkerScriptLoadOrigin,
 };
 use crossbeam_channel::{Receiver, Sender, after};
-use devtools_traits::{DevtoolScriptControlMsg, EvaluateJSReply, EvaluateJSReplyValue};
+use devtools_traits::{DebuggerValue, DevtoolScriptControlMsg, EvaluateJSReply};
 use dom_struct::dom_struct;
 use fonts::FontContext;
 use js::jsapi::{JS_AddInterruptCallback, JSContext};
@@ -509,7 +509,7 @@ impl ServiceWorkerGlobalScope {
                         );
                     } else {
                         let _ = reply.send(EvaluateJSReply {
-                            value: EvaluateJSReplyValue::VoidValue,
+                            value: DebuggerValue::VoidValue,
                             has_exception: true,
                         });
                     }

--- a/components/script_bindings/webidls/DebuggerEvalEvent.webidl
+++ b/components/script_bindings/webidls/DebuggerEvalEvent.webidl
@@ -16,17 +16,6 @@ partial interface DebuggerGlobalScope {
     undefined evalResult(DebuggerEvalEvent event, EvalResult result);
 };
 
-// Result from Debugger.Object.executeInGlobal() completion value.
-// <https://firefox-source-docs.mozilla.org/js/Debugger/Debugger.Object.html#executeinglobal-code-options>
-//
-// Completion values are described at:
-// <https://firefox-source-docs.mozilla.org/js/Debugger/Conventions.html#completion-values>
-// - { return: value } for normal completion
-// - { throw: value, stack } for thrown exception
-// - null for termination
-//
-// The `value` inside is a debuggee value:
-// <https://firefox-source-docs.mozilla.org/js/Debugger/Conventions.html#debuggee-values>
 dictionary EvalResult {
     required DebuggerValue value;
     ObjectPreview preview;

--- a/components/script_bindings/webidls/DebuggerEvalEvent.webidl
+++ b/components/script_bindings/webidls/DebuggerEvalEvent.webidl
@@ -13,7 +13,7 @@ interface DebuggerEvalEvent : Event {
 };
 
 partial interface DebuggerGlobalScope {
-    undefined evalResult(DebuggerEvalEvent event, EvalResultValue result);
+    undefined evalResult(DebuggerEvalEvent event, EvalResult result);
 };
 
 // Result from Debugger.Object.executeInGlobal() completion value.
@@ -27,46 +27,44 @@ partial interface DebuggerGlobalScope {
 //
 // The `value` inside is a debuggee value:
 // <https://firefox-source-docs.mozilla.org/js/Debugger/Conventions.html#debuggee-values>
-dictionary EvalResultValue {
+dictionary EvalResult {
+    required DebuggerValue value;
+    ObjectPreview preview;
     required DOMString completionType;
-    required DOMString valueType;
-    boolean booleanValue;
-    double numberValue;
-    DOMString stringValue;
-
-    // A string naming the ECMAScript [[Class]] of the referent.
-    // <https://firefox-source-docs.mozilla.org/js/Debugger/Debugger.Object.html#accessor-properties-of-the-debugger-object-prototype>
-    DOMString objectClass;
-    DOMString name;
     boolean hasException;
-
-    // Function-specific metadata
-    // <https://searchfox.org/mozilla-central/source/devtools/server/actors/object/previewers.js>
-    DOMString displayName;
-    sequence<DOMString> parameterNames;
-    boolean isAsync;
-    boolean isGenerator;
-
-    // Object preview properties
-    sequence<PropertyDescriptor> ownProperties;
-    unsigned long ownPropertiesLength;
-
-    // Array-specific
-    DOMString kind;
-    unsigned long arrayLength;
 };
 
-// TODO: Maybe merge some parts of this with the EvalResultValue
 dictionary PropertyDescriptor {
     required DOMString name;
+    required DebuggerValue value;
     required boolean configurable;
     required boolean enumerable;
     required boolean writable;
     required boolean isAccessor;
+};
+
+dictionary DebuggerValue {
     required DOMString valueType;
     boolean booleanValue;
     double numberValue;
     DOMString stringValue;
     DOMString objectClass;
-    DOMString valueName;
+};
+
+dictionary ObjectPreview {
+    required DOMString kind;
+    sequence<PropertyDescriptor> ownProperties;
+    unsigned long ownPropertiesLength;
+    unsigned long arrayLength;
+    FunctionPreview function;
+};
+
+// Function-specific metadata
+// <https://searchfox.org/mozilla-central/source/devtools/server/actors/object/previewers.js>
+dictionary FunctionPreview {
+    DOMString name;
+    DOMString displayName;
+    required sequence<DOMString> parameterNames;
+    required boolean isAsync;
+    required boolean isGenerator;
 };

--- a/components/shared/devtools/lib.rs
+++ b/components/shared/devtools/lib.rs
@@ -151,56 +151,52 @@ pub enum DomMutation {
     },
 }
 
-/// <https://searchfox.org/mozilla-central/source/devtools/server/actors/object/property-iterator.js#51>
 #[derive(Clone, Debug, Deserialize, MallocSizeOf, Serialize)]
-#[serde(rename_all = "camelCase")]
-pub struct PropertyDescriptor {
-    pub name: String,
-    pub configurable: bool,
-    pub enumerable: bool,
-    pub writable: bool,
-    pub is_accessor: bool,
-    pub value_type: String,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub boolean_value: Option<bool>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub number_value: Option<f64>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub string_value: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub object_class: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub value_name: Option<String>,
+pub struct ObjectPreview {
+    pub kind: String,
+    pub own_properties: Option<Vec<PropertyDescriptor>>,
+    pub own_properties_length: Option<u32>,
+    pub function: Option<FunctionPreview>,
+    pub array_length: Option<u32>,
 }
 
-#[derive(Debug, Deserialize, Serialize)]
-pub enum EvaluateJSReplyValue {
+#[derive(Clone, Debug, Deserialize, MallocSizeOf, Serialize)]
+pub struct FunctionPreview {
+    pub name: Option<String>,
+    pub display_name: Option<String>,
+    pub parameter_names: Vec<String>,
+    pub is_async: bool,
+    pub is_generator: bool,
+}
+
+#[derive(Clone, Debug, Deserialize, MallocSizeOf, Serialize)]
+pub enum DebuggerValue {
     VoidValue,
     NullValue,
     BooleanValue(bool),
     NumberValue(f64),
     StringValue(String),
-    ActorValue {
-        class: String,
+    ObjectValue {
         uuid: String,
-        name: Option<String>,
-        // Function-specific
-        display_name: Option<String>,
-        parameter_names: Option<Vec<String>>,
-        is_async: Option<bool>,
-        is_generator: Option<bool>,
-        // Object preview
-        own_properties: Option<Vec<PropertyDescriptor>>,
-        own_properties_length: Option<u32>,
-        // Array-specific
-        kind: Option<String>,
-        array_length: Option<u32>,
+        class: String,
+        preview: Option<ObjectPreview>,
     },
+}
+
+/// <https://searchfox.org/mozilla-central/source/devtools/server/actors/object/property-iterator.js#51>
+#[derive(Clone, Debug, Deserialize, MallocSizeOf, Serialize)]
+pub struct PropertyDescriptor {
+    pub name: String,
+    pub value: DebuggerValue,
+    pub configurable: bool,
+    pub enumerable: bool,
+    pub writable: bool,
+    pub is_accessor: bool,
 }
 
 #[derive(Debug, Deserialize, Serialize)]
 pub struct EvaluateJSReply {
-    pub value: EvaluateJSReplyValue,
+    pub value: DebuggerValue,
     pub has_exception: bool,
 }
 

--- a/resources/debugger.js
+++ b/resources/debugger.js
@@ -86,27 +86,29 @@ const previewers = {
 
 // Convert debuggee value to property descriptor value
 // <https://searchfox.org/mozilla-central/source/devtools/server/actors/object/utils.js#116>
-function valueToPropertyValue(val) {
-    switch (typeof val) {
+function createValueGrip(value) {
+    switch (typeof value) {
         case "undefined":
             return { valueType: "undefined" };
         case "boolean":
-            return { valueType: "boolean", booleanValue: val };
+            return { valueType: "boolean", booleanValue: value };
         case "number":
-            return { valueType: "number", numberValue: val };
+            return { valueType: "number", numberValue: value };
         case "string":
-            return { valueType: "string", stringValue: val };
+            return { valueType: "string", stringValue: value };
         case "object":
-            if (val === null) {
+            if (value === null) {
                 return { valueType: "null" };
             }
+            // Debugger.Object - get preview using registered previewers
+            // <https://firefox-source-docs.mozilla.org/js/Debugger/Debugger.Object.html>
             return {
                 valueType: "object",
-                objectClass: val.class,
-                valueName: val.callable ? val.name : undefined,
+                objectClass: value.class,
+                preview: getPreview(value),
             };
         default:
-            return { valueType: "string", stringValue: String(val) };
+            return { valueType: "string", stringValue: String(value) };
     }
 }
 
@@ -136,20 +138,18 @@ function extractOwnProperties(obj, maxItems = OBJECT_PREVIEW_MAX_ITEMS) {
                     enumerable: desc.enumerable ?? false,
                     writable: desc.writable ?? false,
                     isAccessor: desc.get !== undefined || desc.set !== undefined,
-                    valueType: "undefined",
+                    value: createValueGrip(undefined),
                 };
 
                 if (desc.value !== undefined) {
-                    Object.assign(prop, valueToPropertyValue(desc.value));
+                    prop.value = createValueGrip(desc.value);
                 } else if (desc.get) {
                     try {
                         const result = desc.get.call(obj);
                         if (result && "return" in result) {
-                            Object.assign(prop, valueToPropertyValue(result.return));
+                            prop.value = createValueGrip(result.return);
                         }
-                    } catch (e) {
-                        prop.valueType = "undefined";
-                    }
+                    } catch (e) { }
                 }
 
                 ownProperties.push(prop);
@@ -166,14 +166,17 @@ function extractOwnProperties(obj, maxItems = OBJECT_PREVIEW_MAX_ITEMS) {
 // <https://searchfox.org/mozilla-central/source/devtools/server/actors/object/previewers.js#125>
 previewers.Function.push(function FunctionPreviewer(obj) {
     const { ownProperties, ownPropertiesLength } = extractOwnProperties(obj);
-
     return {
-        displayName: obj.displayName,
-        parameterNames: obj.parameterNames,
-        isAsync: obj.isAsyncFunction,
-        isGenerator: obj.isGeneratorFunction,
+        kind: "Object",
         ownProperties,
         ownPropertiesLength,
+        function: {
+            name: obj.name,
+            displayName: obj.displayName,
+            parameterNames: obj.parameterNames,
+            isAsync: obj.isAsyncFunction,
+            isGenerator: obj.isGeneratorFunction,
+        }
     };
 });
 
@@ -194,6 +197,7 @@ previewers.Array.push(function ArrayPreviewer(obj) {
 previewers.Object.push(function ObjectPreviewer(obj) {
     const { ownProperties, ownPropertiesLength } = extractOwnProperties(obj);
     return {
+        kind: "Object",
         ownProperties,
         ownPropertiesLength,
     };
@@ -210,34 +214,6 @@ function getPreview(obj) {
     }
 
     return { ownProperties: [], ownPropertiesLength: 0 };
-}
-
-function createValueResult(value) {
-    switch (typeof value) {
-        case "undefined":
-            return { valueType: "undefined" };
-        case "boolean":
-            return { valueType: "boolean", booleanValue: value };
-        case "number":
-            return { valueType: "number", numberValue: value };
-        case "string":
-            return { valueType: "string", stringValue: value };
-        case "object":
-            if (value === null) {
-                return { valueType: "null" };
-            }
-            // Debugger.Object - get preview using registered previewers
-            // <https://firefox-source-docs.mozilla.org/js/Debugger/Debugger.Object.html>
-            const preview = getPreview(value);
-            return {
-                valueType: "object",
-                objectClass: value.class,
-                name: value.name,
-                ...preview,
-            };
-        default:
-            return { valueType: "string", stringValue: String(value) };
-    }
 }
 
 // Evaluate some javascript code in the global context of the debuggee
@@ -264,15 +240,21 @@ addEventListener("eval", event => {
     // Completion values: <https://firefox-source-docs.mozilla.org/js/Debugger/Conventions.html#completion-values>
     let resultValue;
     if (completionValue === null) {
-        resultValue = { completionType: "terminated", valueType: "undefined", hasException: false };
+        resultValue = { completionType: "terminated", value: createValueGrip(undefined), hasException: false };
     } else if ("throw" in completionValue) {
         // <https://firefox-source-docs.mozilla.org/js/Debugger/Debugger.html#adoptdebuggeevalue-value>
         // <https://searchfox.org/firefox-main/source/devtools/server/actors/webconsole/eval-with-debugger.js#312>
         // we probably don't need adoptDebuggeeValue, as we only have one debugger instance for now
         // let value = dbg.adoptDebuggeeValue(completionValue.throw);
-        resultValue = { completionType: "throw", ...createValueResult(completionValue.throw), hasException: true };
+        resultValue = { completionType: "throw", value: createValueGrip(completionValue.throw), hasException: true };
     } else if ("return" in completionValue) {
-        resultValue = { completionType: "return", ...createValueResult(completionValue.return), hasException: false };
+        resultValue = { completionType: "return", value: createValueGrip(completionValue.return), hasException: false };
+    }
+
+    // To avoid recursion errors in the WebIDL, preview needs to live outside of the property descriptor
+    if (resultValue.value.preview) {
+        resultValue.preview = resultValue.value.preview;
+        delete resultValue.value.preview;
     }
 
     evalResult(event, resultValue);

--- a/resources/debugger.js
+++ b/resources/debugger.js
@@ -85,7 +85,7 @@ const previewers = {
 };
 
 // Convert debuggee value to property descriptor value
-// <https://searchfox.org/mozilla-central/source/devtools/server/actors/object/utils.js#116>
+// <https://searchfox.org/firefox-main/source/devtools/server/actors/object/utils.js#116>
 function createValueGrip(value) {
     switch (typeof value) {
         case "undefined":


### PR DESCRIPTION
The WebIDLs for values were duplicated in PropertyDescriptor and EvalResultValue, with duplicated handlers across the code.

General cleanup of how debugger values are passed from debugger.js and how the conversion from JS and to JSON happens.

There shouldn't be a behaviour change.

Testing: Existing devtools tests and manual testing
Part of: #36027 
