### PR TITLE
script: Use encoding-parse algorithm in Worker::Constructor

### DIFF
--- a/components/script/dom/workers/worker.rs
+++ b/components/script/dom/workers/worker.rs
@@ -179,7 +179,7 @@ impl WorkerMethods<crate::DomTypeHolder> for Worker {
             "Worker constructor",
         )?;
         // Step 2-4.
-        let worker_url = match global.api_base_url().join(&compliant_script_url.str()) {
+        let worker_url = match global.encoding_parse_a_url(&compliant_script_url.str()) {
             Ok(url) => url,
             Err(_) => return Err(Error::Syntax(None)),
         };

--- a/tests/wpt/tests/workers/resources/worker-url-encoding.js
+++ b/tests/wpt/tests/workers/resources/worker-url-encoding.js
@@ -1,0 +1,1 @@
+postMessage(location.search);

--- a/tests/wpt/tests/workers/worker-url-encoding.html
+++ b/tests/wpt/tests/workers/worker-url-encoding.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<meta charset=windows-1252>
+<title>Worker URL is parsed using document encoding</title>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script>
+  async_test(t => {
+    let worker = new Worker("resources/worker-url-encoding.js?\u00DF");
+    worker.onmessage = t.step_func(e => {
+      assert_equals(e.data, "?%DF");
+      t.done();
+    });
+  }, "Worker URL is parsed using document encoding");
+</script>


### PR DESCRIPTION
Updated api base url to encoding_parse_a_url and wrote tests referencing the suggested format

Fixes: #43557 
Testing: new passing test