### PR TITLE
layout: Do not trigger `dirty_all_nodes` when web font loading fails

### DIFF
--- a/components/layout/layout_impl.rs
+++ b/components/layout/layout_impl.rs
@@ -767,9 +767,11 @@ impl LayoutThread {
         let locked_script_channel = Mutex::new(self.script_chan.clone());
         let pipeline_id = self.id;
         let web_font_finished_loading_callback = move |succeeded: bool| {
-            let _ = locked_script_channel
-                .lock()
-                .send(ScriptThreadMessage::WebFontLoaded(pipeline_id, succeeded));
+            if succeeded {
+                let _ = locked_script_channel
+                    .lock()
+                    .send(ScriptThreadMessage::WebFontLoaded(pipeline_id));
+            }
         };
 
         self.font_context.add_all_web_fonts_from_stylesheet(

--- a/components/script/messaging.rs
+++ b/components/script/messaging.rs
@@ -80,7 +80,7 @@ impl MixedMessage {
                 ScriptThreadMessage::Unfocus(id, ..) => Some(*id),
                 ScriptThreadMessage::WebDriverScriptCommand(id, ..) => Some(*id),
                 ScriptThreadMessage::TickAllAnimations(..) => None,
-                ScriptThreadMessage::WebFontLoaded(id, ..) => Some(*id),
+                ScriptThreadMessage::WebFontLoaded(id) => Some(*id),
                 ScriptThreadMessage::DispatchIFrameLoadEvent {
                     target: _,
                     parent: id,

--- a/components/script/script_thread.rs
+++ b/components/script/script_thread.rs
@@ -1849,8 +1849,8 @@ impl ScriptThread {
             ScriptThreadMessage::WebDriverScriptCommand(pipeline_id, msg) => {
                 self.handle_webdriver_msg(pipeline_id, msg, cx)
             },
-            ScriptThreadMessage::WebFontLoaded(pipeline_id, success) => {
-                self.handle_web_font_loaded(pipeline_id, success)
+            ScriptThreadMessage::WebFontLoaded(pipeline_id) => {
+                self.handle_web_font_loaded(pipeline_id)
             },
             ScriptThreadMessage::DispatchIFrameLoadEvent {
                 target: browsing_context_id,
@@ -3265,7 +3265,7 @@ impl ScriptThread {
     }
 
     /// Handles a Web font being loaded. Does nothing if the page no longer exists.
-    fn handle_web_font_loaded(&self, pipeline_id: PipelineId, _success: bool) {
+    fn handle_web_font_loaded(&self, pipeline_id: PipelineId) {
         let Some(document) = self.documents.borrow().find_document(pipeline_id) else {
             warn!("Web font loaded in closed pipeline {}.", pipeline_id);
             return;

--- a/components/shared/script/lib.rs
+++ b/components/shared/script/lib.rs
@@ -237,7 +237,7 @@ pub enum ScriptThreadMessage {
     TickAllAnimations(Vec<WebViewId>),
     /// Notifies the script thread that a new Web font has been loaded, and thus the page should be
     /// reflowed.
-    WebFontLoaded(PipelineId, bool /* success */),
+    WebFontLoaded(PipelineId),
     /// Cause a `load` event to be dispatched at the appropriate iframe element.
     DispatchIFrameLoadEvent {
         /// The frame that has been marked as loaded.


### PR DESCRIPTION
Currently, the `web_font_finished_loading_callback` sends a `ScriptThreadMessage::WebFontLoaded` message regardless of whether web font loading succeeds or not, which leads to dirtying all nodes in `script_thread.rs`. This creates unnecessary reflow. This PR removes the boolean field from the `WebFontLoaded` message and only sends the message when the web font loading is successful.

Testing: Existing WPT tests
