### PR TITLE
servo: Add `SiteDataManager::set_cookie_for_url` and `SiteDataManager::cookies_for_url`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7408,6 +7408,7 @@ dependencies = [
  "accesskit_consumer",
  "arboard",
  "bitflags 2.11.0",
+ "cookie 0.18.1",
  "crossbeam-channel",
  "dpi",
  "env_logger",

--- a/components/net/resource_thread.rs
+++ b/components/net/resource_thread.rs
@@ -488,12 +488,21 @@ impl ResourceChannelManager {
                 );
                 self.send_cookie_response(cookie_store_id, CookieData::Set(Ok(())));
             },
-            CoreResourceMsg::GetCookiesForUrl(url, consumer, source) => {
+            CoreResourceMsg::GetCookieStringForUrl(url, consumer, source) => {
                 let mut cookie_jar = http_state.cookie_jar.write();
                 cookie_jar.remove_expired_cookies_for_url(&url);
                 consumer
                     .send(cookie_jar.cookies_for_url(&url, source))
                     .unwrap();
+            },
+            CoreResourceMsg::GetCookiesForUrl(url, consumer, source) => {
+                let mut cookie_jar = http_state.cookie_jar.write();
+                cookie_jar.remove_expired_cookies_for_url(&url);
+                let cookies = cookie_jar
+                    .cookies_data_for_url(&url, source)
+                    .map(Serde)
+                    .collect();
+                consumer.send(cookies).unwrap();
             },
             CoreResourceMsg::GetCookieDataForUrlAsync(cookie_store_id, url, name) => {
                 let mut cookie_jar = http_state.cookie_jar.write();

--- a/components/net/resource_thread.rs
+++ b/components/net/resource_thread.rs
@@ -458,9 +458,17 @@ impl ResourceChannelManager {
                     protocols,
                 )
             },
-            CoreResourceMsg::SetCookieForUrl(request, cookie, source) => self
-                .resource_manager
-                .set_cookie_for_url(&request, cookie.into_inner().to_owned(), source, http_state),
+            CoreResourceMsg::SetCookieForUrl(request, cookie, source, sender) => {
+                self.resource_manager.set_cookie_for_url(
+                    &request,
+                    cookie.into_inner().to_owned(),
+                    source,
+                    http_state,
+                );
+                if let Some(sender) = sender {
+                    let _ = sender.send(());
+                }
+            },
             CoreResourceMsg::SetCookiesForUrl(request, cookies, source) => {
                 for cookie in cookies {
                     self.resource_manager.set_cookie_for_url(

--- a/components/script/dom/document/document.rs
+++ b/components/script/dom/document/document.rs
@@ -37,7 +37,7 @@ use layout_api::{
 };
 use metrics::{InteractiveFlag, InteractiveWindow, ProgressiveWebMetrics};
 use net_traits::CookieSource::NonHTTP;
-use net_traits::CoreResourceMsg::{GetCookiesForUrl, SetCookiesForUrl};
+use net_traits::CoreResourceMsg::{GetCookieStringForUrl, SetCookiesForUrl};
 use net_traits::ReferrerPolicy;
 use net_traits::policy_container::PolicyContainer;
 use net_traits::pub_domains::is_pub_domain;
@@ -6242,7 +6242,7 @@ impl DocumentMethods<crate::DomTypeHolder> for Document {
             .window
             .as_global_scope()
             .resource_threads()
-            .send(GetCookiesForUrl(url, tx, NonHTTP));
+            .send(GetCookieStringForUrl(url, tx, NonHTTP));
         let cookies = rx.recv().unwrap();
         Ok(cookies.map_or(DOMString::new(), DOMString::from))
     }

--- a/components/script/webdriver_handlers.rs
+++ b/components/script/webdriver_handlers.rs
@@ -1479,7 +1479,7 @@ pub(crate) fn handle_add_cookie(
                     .window()
                     .as_global_scope()
                     .resource_threads()
-                    .send(SetCookieForUrl(url, Serde(cookie), method));
+                    .send(SetCookieForUrl(url, Serde(cookie), method, None));
                 Ok(())
             },
             (false, None) => {
@@ -1487,7 +1487,7 @@ pub(crate) fn handle_add_cookie(
                     .window()
                     .as_global_scope()
                     .resource_threads()
-                    .send(SetCookieForUrl(url, Serde(cookie), method));
+                    .send(SetCookieForUrl(url, Serde(cookie), method, None));
                 Ok(())
             },
             (_, _) => Err(ErrorStatus::UnableToSetCookie),

--- a/components/servo/Cargo.toml
+++ b/components/servo/Cargo.toml
@@ -77,6 +77,7 @@ webxr = [
 [dependencies]
 accesskit = { workspace = true }
 bitflags = { workspace = true }
+cookie = { workspace = true }
 crossbeam-channel = { workspace = true }
 devtools = { workspace = true }
 devtools_traits = { workspace = true }

--- a/components/servo/site_data_manager.rs
+++ b/components/servo/site_data_manager.rs
@@ -11,6 +11,7 @@ use rustc_hash::FxHashMap;
 use servo_url::ServoUrl;
 use storage_traits::StorageThreads;
 use storage_traits::webstorage_thread::{OriginDescriptor, WebStorageType};
+use url::Url;
 
 bitflags! {
     /// Identifies categories of site data associated with a site.
@@ -205,30 +206,22 @@ impl SiteDataManager {
         self.private_resource_threads.clear_cookies();
     }
 
-    /// Returns the cookies associated with the given URL as a header string, or `None` if there
-    /// are no cookies for that URL.
-    /// Only public cookies are returned.
-    pub fn get_cookies_for_url(&self, url: &str, source: CookieSource) -> Option<String> {
-        let url = ServoUrl::parse(url).ok()?;
-        self.public_resource_threads.cookies_for_url(url, source)
+    /// Returns the cookies for the domain associated with the given [`Url`].
+    pub fn cookies_for_url(&self, url: Url, source: CookieSource) -> Vec<Cookie<'static>> {
+        self.public_resource_threads
+            .cookies_for_url(url.into(), source)
     }
 
-    /// Stores a cookie for the given URL.
+    /// Sets a cookie for the domain associated with the given [`Url`].
+    ///
     /// Returns `true` if the request to set the cookie is successfully sent.
-    /// If `sync` is `true`, the call blocks until the cookie has been stored.
-    /// Only public cookies are set.
-    pub fn set_cookie_for_url(&self, url: &str, cookie: Cookie<'static>, sync: bool) -> bool {
-        let url = match ServoUrl::parse(url) {
-            Ok(url) => url,
-            Err(_) => return false,
-        };
-        if sync {
-            self.public_resource_threads
-                .set_cookie_for_url_sync(url, cookie, CookieSource::HTTP);
-        } else {
-            self.public_resource_threads
-                .set_cookie_for_url(url, cookie, CookieSource::HTTP);
-        }
-        true
+    /// This call will block, such that any operations triggered after the
+    /// call will use the provided cookie.
+    pub fn set_cookie_for_url(&self, url: Url, cookie: Cookie<'static>) {
+        self.public_resource_threads.set_cookie_for_url_sync(
+            url.into(),
+            cookie,
+            CookieSource::HTTP,
+        );
     }
 }

--- a/components/servo/site_data_manager.rs
+++ b/components/servo/site_data_manager.rs
@@ -205,32 +205,30 @@ impl SiteDataManager {
         self.private_resource_threads.clear_cookies();
     }
 
-    pub fn get_cookies_for_url(
-        &self,
-        url: ServoUrl,
-        private: bool,
-        source: CookieSource,
-    ) -> Option<String> {
-        let resource_threads = if private {
-            &self.private_resource_threads
-        } else {
-            &self.public_resource_threads
-        };
-        resource_threads.get_cookies_for_url(url, source)
+    /// Returns the cookies associated with the given URL as a header string, or `None` if there
+    /// are no cookies for that URL.
+    /// Only public cookies are returned.
+    pub fn get_cookies_for_url(&self, url: &str, source: CookieSource) -> Option<String> {
+        let url = ServoUrl::parse(url).ok()?;
+        self.public_resource_threads.cookies_for_url(url, source)
     }
 
-    pub fn set_cookie_for_url(
-        &self,
-        url: ServoUrl,
-        cookie: Cookie<'static>,
-        private: bool,
-        source: CookieSource,
-    ) {
-        let resource_threads = if private {
-            &self.private_resource_threads
-        } else {
-            &self.public_resource_threads
+    /// Stores a cookie for the given URL.
+    /// Returns `true` if the request to set the cookie is successfully sent.
+    /// If `sync` is `true`, the call blocks until the cookie has been stored.
+    /// Only public cookies are set.
+    pub fn set_cookie_for_url(&self, url: &str, cookie: Cookie<'static>, sync: bool) -> bool {
+        let url = match ServoUrl::parse(url) {
+            Ok(url) => url,
+            Err(_) => return false,
         };
-        resource_threads.set_cookie_for_url(url, cookie, source)
+        if sync {
+            self.public_resource_threads
+                .set_cookie_for_url_sync(url, cookie, CookieSource::HTTP);
+        } else {
+            self.public_resource_threads
+                .set_cookie_for_url(url, cookie, CookieSource::HTTP);
+        }
+        true
     }
 }

--- a/components/servo/site_data_manager.rs
+++ b/components/servo/site_data_manager.rs
@@ -3,9 +3,10 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 use bitflags::bitflags;
+use cookie::Cookie;
 use log::warn;
 use net_traits::pub_domains::registered_domain_name;
-use net_traits::{ResourceThreads, SiteDescriptor};
+use net_traits::{CookieSource, ResourceThreads, SiteDescriptor};
 use rustc_hash::FxHashMap;
 use servo_url::ServoUrl;
 use storage_traits::StorageThreads;
@@ -202,5 +203,34 @@ impl SiteDataManager {
     pub fn clear_cookies(&self) {
         self.public_resource_threads.clear_cookies();
         self.private_resource_threads.clear_cookies();
+    }
+
+    pub fn get_cookies_for_url(
+        &self,
+        url: ServoUrl,
+        private: bool,
+        source: CookieSource,
+    ) -> Option<String> {
+        let resource_threads = if private {
+            &self.private_resource_threads
+        } else {
+            &self.public_resource_threads
+        };
+        resource_threads.get_cookies_for_url(url, source)
+    }
+
+    pub fn set_cookie_for_url(
+        &self,
+        url: ServoUrl,
+        cookie: Cookie<'static>,
+        private: bool,
+        source: CookieSource,
+    ) {
+        let resource_threads = if private {
+            &self.private_resource_threads
+        } else {
+            &self.public_resource_threads
+        };
+        resource_threads.set_cookie_for_url(url, cookie, source)
     }
 }

--- a/components/servo/tests/site_data_manager.rs
+++ b/components/servo/tests/site_data_manager.rs
@@ -643,8 +643,10 @@ fn test_get_cookie() {
     let cookies = servo_test
         .servo()
         .site_data_manager()
-        .get_cookies_for_url(url.as_str(), CookieSource::NonHTTP);
-    assert_eq!(cookies, Some("foo=bar".to_string()));
+        .cookies_for_url(url.into_url(), CookieSource::NonHTTP);
+    assert_eq!(cookies.len(), 1);
+    assert_eq!(cookies[0].name(), "foo");
+    assert_eq!(cookies[0].value(), "bar");
 }
 
 #[test]
@@ -680,15 +682,17 @@ fn test_set_cookie() {
     servo_test
         .servo()
         .site_data_manager()
-        .set_cookie_for_url(page_url.as_str(), cookie, false);
+        .set_cookie_for_url(page_url.clone(), cookie);
 
     // Verify it is returned by get_cookies_for_url.
     // Don't need sync call because set and get messages are processed in order.
     let cookies = servo_test
         .servo()
         .site_data_manager()
-        .get_cookies_for_url(page_url.as_str(), CookieSource::HTTP);
-    assert_eq!(cookies, Some("foo=bar".to_string()));
+        .cookies_for_url(page_url.clone(), CookieSource::HTTP);
+    assert_eq!(cookies.len(), 1);
+    assert_eq!(cookies[0].name(), "foo");
+    assert_eq!(cookies[0].value(), "bar");
 
     // Load the page again and verify the cookie is sent in the request.
     delegate_clone.reset();

--- a/components/servo/tests/site_data_manager.rs
+++ b/components/servo/tests/site_data_manager.rs
@@ -7,10 +7,13 @@ mod common;
 use std::collections::HashMap;
 use std::rc::Rc;
 
+use cookie::Cookie;
+use http::HeaderValue;
 use http_body_util::combinators::BoxBody;
 use hyper::body::{Bytes, Incoming};
 use hyper::{Request as HyperRequest, Response as HyperResponse};
 use net::test_util::{Server, make_body, make_server, replace_host_table};
+use net_traits::CookieSource;
 use servo::{JSValue, Servo, ServoUrl, SiteData, StorageType, WebView, WebViewBuilder};
 
 use crate::common::{ServoTest, WebViewDelegateImpl, evaluate_javascript};
@@ -608,4 +611,79 @@ fn test_clear_cookies() {
 
     let result = evaluate_javascript(&servo_test, webview.clone(), "document.cookie");
     assert_eq!(result, Ok(JSValue::String("".into())));
+}
+
+#[test]
+fn test_get_cookie() {
+    let servo_test = ServoTest::new();
+
+    // Serve a minimal page that sets a cookie via Set-Cookie response header.
+    let handler =
+        move |_: HyperRequest<Incoming>,
+              response: &mut HyperResponse<BoxBody<Bytes, hyper::Error>>| {
+            response.headers_mut().insert(
+                http::header::SET_COOKIE,
+                HeaderValue::from_static("foo=bar; Path=/"),
+            );
+            *response.body_mut() = make_body(b"<!DOCTYPE html><p>hi</p>".to_vec());
+        };
+    let (server, url) = make_server(handler);
+    let page_url = url.clone().into_url();
+
+    let delegate = Rc::new(WebViewDelegateImpl::default());
+    let _webview = WebViewBuilder::new(servo_test.servo(), servo_test.rendering_context.clone())
+        .delegate(delegate.clone())
+        .url(page_url.clone())
+        .build();
+
+    // Wait for LoadStatus::Complete to ensure the HTTP response and Set-Cookie header are processed.
+    servo_test.spin(move || !delegate.load_status_changed.get());
+    let _ = server.close();
+
+    let cookies = servo_test.servo().site_data_manager().get_cookies_for_url(
+        ServoUrl::from_url(page_url),
+        false,
+        CookieSource::NonHTTP,
+    );
+    assert_eq!(cookies, Some("foo=bar".to_string()));
+}
+
+#[test]
+fn test_set_cookie() {
+    let servo_test = ServoTest::new();
+
+    // Serve a minimal page with no server-set cookies.
+    let handler =
+        move |_: HyperRequest<Incoming>,
+              response: &mut HyperResponse<BoxBody<Bytes, hyper::Error>>| {
+            *response.body_mut() = make_body(b"<!DOCTYPE html><p>hi</p>".to_vec());
+        };
+    let (server, url) = make_server(handler);
+    let page_url = url.clone().into_url();
+
+    let delegate = Rc::new(WebViewDelegateImpl::default());
+    let _webview = WebViewBuilder::new(servo_test.servo(), servo_test.rendering_context.clone())
+        .delegate(delegate.clone())
+        .url(page_url.clone())
+        .build();
+
+    servo_test.spin(move || !delegate.load_status_changed.get());
+    let _ = server.close();
+
+    // Set a cookie via the site data manager.
+    let cookie = Cookie::build(("foo", "bar")).path("/").build();
+    servo_test.servo().site_data_manager().set_cookie_for_url(
+        ServoUrl::from_url(page_url.clone()),
+        cookie,
+        false,
+        CookieSource::NonHTTP,
+    );
+
+    // Verify it is returned by get_cookies_for_url.
+    let cookies = servo_test.servo().site_data_manager().get_cookies_for_url(
+        ServoUrl::from_url(page_url),
+        false,
+        CookieSource::NonHTTP,
+    );
+    assert_eq!(cookies, Some("foo=bar".to_string()));
 }

--- a/components/servo/tests/site_data_manager.rs
+++ b/components/servo/tests/site_data_manager.rs
@@ -6,6 +6,7 @@ mod common;
 
 use std::collections::HashMap;
 use std::rc::Rc;
+use std::sync::{Arc, Mutex};
 
 use cookie::Cookie;
 use http::HeaderValue;
@@ -628,23 +629,21 @@ fn test_get_cookie() {
             *response.body_mut() = make_body(b"<!DOCTYPE html><p>hi</p>".to_vec());
         };
     let (server, url) = make_server(handler);
-    let page_url = url.clone().into_url();
 
     let delegate = Rc::new(WebViewDelegateImpl::default());
     let _webview = WebViewBuilder::new(servo_test.servo(), servo_test.rendering_context.clone())
         .delegate(delegate.clone())
-        .url(page_url.clone())
+        .url(url.clone().into_url())
         .build();
 
     // Wait for LoadStatus::Complete to ensure the HTTP response and Set-Cookie header are processed.
     servo_test.spin(move || !delegate.load_status_changed.get());
     let _ = server.close();
 
-    let cookies = servo_test.servo().site_data_manager().get_cookies_for_url(
-        ServoUrl::from_url(page_url),
-        false,
-        CookieSource::NonHTTP,
-    );
+    let cookies = servo_test
+        .servo()
+        .site_data_manager()
+        .get_cookies_for_url(url.as_str(), CookieSource::NonHTTP);
     assert_eq!(cookies, Some("foo=bar".to_string()));
 }
 
@@ -652,38 +651,56 @@ fn test_get_cookie() {
 fn test_set_cookie() {
     let servo_test = ServoTest::new();
 
-    // Serve a minimal page with no server-set cookies.
+    let received_cookie: Arc<Mutex<Option<String>>> = Arc::new(Mutex::new(None));
+    let received_cookie_clone = received_cookie.clone();
+
+    // Serve a minimal page; on the second load, capture the Cookie request header.
     let handler =
-        move |_: HyperRequest<Incoming>,
+        move |req: HyperRequest<Incoming>,
               response: &mut HyperResponse<BoxBody<Bytes, hyper::Error>>| {
+            if let Some(cookie) = req.headers().get(http::header::COOKIE) {
+                *received_cookie_clone.lock().unwrap() = Some(cookie.to_str().unwrap().to_string());
+            }
             *response.body_mut() = make_body(b"<!DOCTYPE html><p>hi</p>".to_vec());
         };
     let (server, url) = make_server(handler);
     let page_url = url.clone().into_url();
 
     let delegate = Rc::new(WebViewDelegateImpl::default());
-    let _webview = WebViewBuilder::new(servo_test.servo(), servo_test.rendering_context.clone())
+    let delegate_clone = delegate.clone();
+    let webview = WebViewBuilder::new(servo_test.servo(), servo_test.rendering_context.clone())
         .delegate(delegate.clone())
         .url(page_url.clone())
         .build();
 
     servo_test.spin(move || !delegate.load_status_changed.get());
-    let _ = server.close();
 
     // Set a cookie via the site data manager.
     let cookie = Cookie::build(("foo", "bar")).path("/").build();
-    servo_test.servo().site_data_manager().set_cookie_for_url(
-        ServoUrl::from_url(page_url.clone()),
-        cookie,
-        false,
-        CookieSource::NonHTTP,
-    );
+    servo_test
+        .servo()
+        .site_data_manager()
+        .set_cookie_for_url(page_url.as_str(), cookie, false);
 
     // Verify it is returned by get_cookies_for_url.
-    let cookies = servo_test.servo().site_data_manager().get_cookies_for_url(
-        ServoUrl::from_url(page_url),
-        false,
-        CookieSource::NonHTTP,
-    );
+    // Don't need sync call because set and get messages are processed in order.
+    let cookies = servo_test
+        .servo()
+        .site_data_manager()
+        .get_cookies_for_url(page_url.as_str(), CookieSource::HTTP);
     assert_eq!(cookies, Some("foo=bar".to_string()));
+
+    // Load the page again and verify the cookie is sent in the request.
+    delegate_clone.reset();
+    delegate_clone.load_status_changed.set(false);
+    webview.load(page_url.into());
+    let delegate_clone2 = delegate_clone.clone();
+    servo_test.spin(move || !delegate_clone2.load_status_changed.get());
+
+    let _ = server.close();
+
+    assert_eq!(
+        *received_cookie.lock().unwrap(),
+        Some("foo=bar".to_string())
+    );
 }

--- a/components/shared/net/lib.rs
+++ b/components/shared/net/lib.rs
@@ -541,6 +541,20 @@ impl ResourceThreads {
             .send(CoreResourceMsg::DeleteCookies(None, Some(sender)));
         let _ = receiver.recv();
     }
+
+    pub fn get_cookies_for_url(&self, url: ServoUrl, source: CookieSource) -> Option<String> {
+        let (sender, receiver) = generic_channel::channel().unwrap();
+        let _ = self
+            .core_thread
+            .send(CoreResourceMsg::GetCookiesForUrl(url, sender, source));
+        receiver.recv().unwrap()
+    }
+
+    pub fn set_cookie_for_url(&self, url: ServoUrl, cookie: Cookie<'static>, source: CookieSource) {
+        let _ = self
+            .core_thread
+            .send(CoreResourceMsg::SetCookieForUrl(url, Serde(cookie), source));
+    }
 }
 
 impl GenericSend<CoreResourceMsg> for ResourceThreads {

--- a/components/shared/net/lib.rs
+++ b/components/shared/net/lib.rs
@@ -542,7 +542,7 @@ impl ResourceThreads {
         let _ = receiver.recv();
     }
 
-    pub fn get_cookies_for_url(&self, url: ServoUrl, source: CookieSource) -> Option<String> {
+    pub fn cookies_for_url(&self, url: ServoUrl, source: CookieSource) -> Option<String> {
         let (sender, receiver) = generic_channel::channel().unwrap();
         let _ = self
             .core_thread
@@ -551,9 +551,28 @@ impl ResourceThreads {
     }
 
     pub fn set_cookie_for_url(&self, url: ServoUrl, cookie: Cookie<'static>, source: CookieSource) {
-        let _ = self
-            .core_thread
-            .send(CoreResourceMsg::SetCookieForUrl(url, Serde(cookie), source));
+        let _ = self.core_thread.send(CoreResourceMsg::SetCookieForUrl(
+            url,
+            Serde(cookie),
+            source,
+            None,
+        ));
+    }
+
+    pub fn set_cookie_for_url_sync(
+        &self,
+        url: ServoUrl,
+        cookie: Cookie<'static>,
+        source: CookieSource,
+    ) {
+        let (sender, receiver) = generic_channel::channel().unwrap();
+        let _ = self.core_thread.send(CoreResourceMsg::SetCookieForUrl(
+            url,
+            Serde(cookie),
+            source,
+            Some(sender),
+        ));
+        let _ = receiver.recv();
     }
 }
 
@@ -616,8 +635,14 @@ pub enum CoreResourceMsg {
     Cancel(Vec<RequestId>),
     /// Initiate a fetch in response to processing a redirection
     FetchRedirect(RequestBuilder, ResponseInit, IpcSender<FetchResponseMsg>),
-    /// Store a cookie for a given originating URL
-    SetCookieForUrl(ServoUrl, Serde<Cookie<'static>>, CookieSource),
+    /// Store a cookie for a given originating URL.
+    /// If a sender is provided, the caller will block until the cookie is stored.
+    SetCookieForUrl(
+        ServoUrl,
+        Serde<Cookie<'static>>,
+        CookieSource,
+        Option<GenericSender<()>>,
+    ),
     /// Store a set of cookies for a given originating URL
     SetCookiesForUrl(ServoUrl, Vec<Serde<Cookie<'static>>>, CookieSource),
     SetCookieForUrlAsync(

--- a/components/shared/net/lib.rs
+++ b/components/shared/net/lib.rs
@@ -542,12 +542,17 @@ impl ResourceThreads {
         let _ = receiver.recv();
     }
 
-    pub fn cookies_for_url(&self, url: ServoUrl, source: CookieSource) -> Option<String> {
+    pub fn cookies_for_url(&self, url: ServoUrl, source: CookieSource) -> Vec<Cookie<'static>> {
         let (sender, receiver) = generic_channel::channel().unwrap();
         let _ = self
             .core_thread
             .send(CoreResourceMsg::GetCookiesForUrl(url, sender, source));
-        receiver.recv().unwrap()
+        receiver
+            .recv()
+            .unwrap()
+            .into_iter()
+            .map(|cookie| cookie.into_inner())
+            .collect()
     }
 
     pub fn set_cookie_for_url(&self, url: ServoUrl, cookie: Cookie<'static>, source: CookieSource) {
@@ -651,8 +656,14 @@ pub enum CoreResourceMsg {
         Serde<Cookie<'static>>,
         CookieSource,
     ),
-    /// Retrieve the stored cookies for a given URL
-    GetCookiesForUrl(ServoUrl, GenericSender<Option<String>>, CookieSource),
+    /// Retrieve the stored cookies as a header string for a given URL.
+    GetCookieStringForUrl(ServoUrl, GenericSender<Option<String>>, CookieSource),
+    /// Retrieve the stored cookies as a vector for the given URL.
+    GetCookiesForUrl(
+        ServoUrl,
+        GenericSender<Vec<Serde<Cookie<'static>>>>,
+        CookieSource,
+    ),
     /// Get a cookie by name for a given originating URL
     GetCookiesDataForUrl(
         ServoUrl,


### PR DESCRIPTION
Expose set_cookie_for_url, get_cookie_for_url, allow applications to get/set cookies.

Testing: Unit test for `SiteDataManager` and manual test with ServoShell.
