### PR TITLE
script: Invalidate texture if there's a bound framebuffer in `WebGLRenderingContext`

### DIFF
--- a/components/script/dom/webgl/webglrenderingcontext.rs
+++ b/components/script/dom/webgl/webglrenderingcontext.rs
@@ -2916,6 +2916,10 @@ impl WebGLRenderingContextMethods<crate::DomTypeHolder> for WebGLRenderingContex
         );
 
         self.send_command(msg);
+
+        if let Some(fb) = self.bound_draw_framebuffer.get() {
+            fb.invalidate_texture(&texture);
+        }
     }
 
     /// <https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.8>

--- a/components/script/dom/webgl/webglrenderingcontext.rs
+++ b/components/script/dom/webgl/webglrenderingcontext.rs
@@ -2917,8 +2917,8 @@ impl WebGLRenderingContextMethods<crate::DomTypeHolder> for WebGLRenderingContex
 
         self.send_command(msg);
 
-        if let Some(fb) = self.bound_draw_framebuffer.get() {
-            fb.invalidate_texture(&texture);
+        if let Some(framebuffer) = self.bound_draw_framebuffer.get() {
+            framebuffer.invalidate_texture(&texture);
         }
     }
 


### PR DESCRIPTION
This should be done for CopyTexImage2D, like it is already done for TexImage2D and CompressedTexImage2D.

Testing: Regular testsuite. I was unable to add a dedicated case because
all I could think of it check the bound buffer's status before and after
copyTexImage2D, but I could not find a way to change it from say
complete to something else.
Fixes: #23264
