### PR TITLE
devtools: Rename registry in tab, watcher and browsing_context

### DIFF
--- a/components/devtools/actors/browsing_context.rs
+++ b/components/devtools/actors/browsing_context.rs
@@ -207,16 +207,16 @@ impl BrowsingContextActor {
         pipeline_id: PipelineId,
         outer_window_id: DevtoolsOuterWindowId,
         script_sender: GenericSender<DevtoolScriptControlMsg>,
-        actors: &ActorRegistry,
+        registry: &ActorRegistry,
     ) -> BrowsingContextActor {
-        let name = actors.new_name::<BrowsingContextActor>();
+        let name = registry.new_name::<BrowsingContextActor>();
         let DevtoolsPageInfo {
             title,
             url,
             is_top_level_global,
         } = page_info;
 
-        let accessibility = AccessibilityActor::new(actors.new_name::<AccessibilityActor>());
+        let accessibility = AccessibilityActor::new(registry.new_name::<AccessibilityActor>());
 
         let properties = (|| {
             let (properties_sender, properties_receiver) = generic_channel::channel()?;
@@ -225,24 +225,24 @@ impl BrowsingContextActor {
         })()
         .unwrap_or_default();
         let css_properties =
-            CssPropertiesActor::new(actors.new_name::<CssPropertiesActor>(), properties);
+            CssPropertiesActor::new(registry.new_name::<CssPropertiesActor>(), properties);
 
-        let inspector = InspectorActor::register(actors, name.clone());
+        let inspector = InspectorActor::register(registry, name.clone());
 
-        let reflow = ReflowActor::new(actors.new_name::<ReflowActor>());
+        let reflow = ReflowActor::new(registry.new_name::<ReflowActor>());
 
-        let style_sheets = StyleSheetsActor::new(actors.new_name::<StyleSheetsActor>());
+        let style_sheets = StyleSheetsActor::new(registry.new_name::<StyleSheetsActor>());
 
-        let tabdesc = TabDescriptorActor::new(actors, name.clone(), is_top_level_global);
+        let tabdesc = TabDescriptorActor::new(registry, name.clone(), is_top_level_global);
 
         let thread = ThreadActor::new(
-            actors.new_name::<ThreadActor>(),
+            registry.new_name::<ThreadActor>(),
             script_sender.clone(),
             Some(name.clone()),
         );
 
         let watcher = WatcherActor::new(
-            actors,
+            registry,
             name.clone(),
             SessionContext::new(SessionContextType::BrowserElement),
         );
@@ -270,13 +270,13 @@ impl BrowsingContextActor {
             watcher: watcher.name(),
         };
 
-        actors.register(accessibility);
-        actors.register(css_properties);
-        actors.register(reflow);
-        actors.register(style_sheets);
-        actors.register(tabdesc);
-        actors.register(thread);
-        actors.register(watcher);
+        registry.register(accessibility);
+        registry.register(css_properties);
+        registry.register(reflow);
+        registry.register(style_sheets);
+        registry.register(tabdesc);
+        registry.register(thread);
+        registry.register(watcher);
 
         target
     }

--- a/components/devtools/actors/tab.rs
+++ b/components/devtools/actors/tab.rs
@@ -167,12 +167,12 @@ impl Actor for TabDescriptorActor {
 
 impl TabDescriptorActor {
     pub(crate) fn new(
-        actors: &ActorRegistry,
+        registry: &ActorRegistry,
         browsing_context_actor: String,
         is_top_level_global: bool,
     ) -> TabDescriptorActor {
-        let name = actors.new_name::<Self>();
-        let root = actors.find::<RootActor>("root");
+        let name = registry.new_name::<Self>();
+        let root = registry.find::<RootActor>("root");
         root.tabs.borrow_mut().push(name.clone());
         TabDescriptorActor {
             name,

--- a/components/devtools/actors/watcher.rs
+++ b/components/devtools/actors/watcher.rs
@@ -423,22 +423,22 @@ impl ResourceAvailable for WatcherActor {
 
 impl WatcherActor {
     pub fn new(
-        actors: &ActorRegistry,
+        registry: &ActorRegistry,
         browsing_context_actor: String,
         session_context: SessionContext,
     ) -> Self {
-        let network_parent = NetworkParentActor::new(actors.new_name::<NetworkParentActor>());
+        let network_parent = NetworkParentActor::new(registry.new_name::<NetworkParentActor>());
         let target_configuration =
-            TargetConfigurationActor::new(actors.new_name::<TargetConfigurationActor>());
+            TargetConfigurationActor::new(registry.new_name::<TargetConfigurationActor>());
         let thread_configuration =
-            ThreadConfigurationActor::new(actors.new_name::<ThreadConfigurationActor>());
+            ThreadConfigurationActor::new(registry.new_name::<ThreadConfigurationActor>());
         let breakpoint_list = BreakpointListActor::new(
-            actors.new_name::<BreakpointListActor>(),
+            registry.new_name::<BreakpointListActor>(),
             browsing_context_actor.clone(),
         );
 
         let watcher = Self {
-            name: actors.new_name::<WatcherActor>(),
+            name: registry.new_name::<WatcherActor>(),
             browsing_context_actor,
             network_parent: network_parent.name(),
             target_configuration: target_configuration.name(),
@@ -447,10 +447,10 @@ impl WatcherActor {
             session_context,
         };
 
-        actors.register(network_parent);
-        actors.register(target_configuration);
-        actors.register(thread_configuration);
-        actors.register(breakpoint_list);
+        registry.register(network_parent);
+        registry.register(target_configuration);
+        registry.register(thread_configuration);
+        registry.register(breakpoint_list);
 
         watcher
     }


### PR DESCRIPTION
Renamed `actors` to `registry` in `actors/tab.rs`, `actors/watcher.rs` and `actors/browsing_context.rs`.

Testing: No tests were required, however compilation was successful
Part of: #43605 
