### PR TITLE
deps: Update mozjs to 0.15.7

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5069,9 +5069,9 @@ dependencies = [
 
 [[package]]
 name = "mozjs"
-version = "0.15.5"
+version = "0.15.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6efb4331060c22cc64e136c11c810eec22c063dd7cdeffdee394cb4e7f4d2880"
+checksum = "226edc79aa3f990a61330d4011471910273f6ee6bbfd0dcb93b18f5a03505f6b"
 dependencies = [
  "bindgen",
  "cc",
@@ -5084,9 +5084,9 @@ dependencies = [
 
 [[package]]
 name = "mozjs_sys"
-version = "0.140.8-0"
+version = "0.140.8-2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d84f9f721dd87b500958f5815c118adb8adcd8e310e30b0188647c179ea7bcb"
+checksum = "4b50224a02c96e1e703f7d055377431333dfc5cd3a09ccf03f8a2c8a156c7af8"
 dependencies = [
  "bindgen",
  "cc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -108,7 +108,7 @@ imsz = "0.4"
 indexmap = { version = "2.11.4", features = ["std"] }
 ipc-channel = "0.21"
 itertools = "0.14"
-js = { package = "mozjs", version = "=0.15.5", default-features = false, features = ["libz-sys", "intl"] }
+js = { package = "mozjs", version = "=0.15.7", default-features = false, features = ["libz-sys", "intl"] }
 keyboard-types = { version = "0.8.3", features = ["serde", "webdriver"] }
 kurbo = { version = "0.12", features = ["euclid"] }
 libc = "0.2"


### PR DESCRIPTION
This mainly includes:

- https://github.com/servo/mozjs/pull/717
- https://github.com/servo/mozjs/pull/725

Testing: Covered by existing tests.
