### PR TITLE
devtools: Rename registry in source, node, & network_handler

### DIFF
--- a/components/devtools/actors/inspector/node.rs
+++ b/components/devtools/actors/inspector/node.rs
@@ -260,7 +260,7 @@ impl Actor for NodeActor {
 pub trait NodeInfoToProtocol {
     fn encode(
         self,
-        actors: &ActorRegistry,
+        registry: &ActorRegistry,
         script_chan: GenericSender<DevtoolScriptControlMsg>,
         pipeline: PipelineId,
         walker: String,
@@ -270,15 +270,15 @@ pub trait NodeInfoToProtocol {
 impl NodeInfoToProtocol for NodeInfo {
     fn encode(
         self,
-        actors: &ActorRegistry,
+        registry: &ActorRegistry,
         script_chan: GenericSender<DevtoolScriptControlMsg>,
         pipeline: PipelineId,
         walker: String,
     ) -> NodeActorMsg {
         let get_or_register_node_actor = |id: &str| {
-            if !actors.script_actor_registered(id.to_string()) {
-                let name = actors.new_name::<NodeActor>();
-                actors.register_script_actor(id.to_string(), name.clone());
+            if !registry.script_actor_registered(id.to_string()) {
+                let name = registry.new_name::<NodeActor>();
+                registry.register_script_actor(id.to_string(), name.clone());
 
                 let node_actor = NodeActor {
                     name: name.clone(),
@@ -287,10 +287,10 @@ impl NodeInfoToProtocol for NodeInfo {
                     walker: walker.clone(),
                     style_rules: AtomicRefCell::new(HashMap::new()),
                 };
-                actors.register(node_actor);
+                registry.register(node_actor);
                 name
             } else {
-                actors.script_to_actor(id.to_string())
+                registry.script_to_actor(id.to_string())
             }
         };
 
@@ -300,7 +300,7 @@ impl NodeInfoToProtocol for NodeInfo {
             .as_ref()
             .map(|host_id| get_or_register_node_actor(host_id));
 
-        let name = actors.actor_to_script(actor.clone());
+        let name = registry.actor_to_script(actor.clone());
 
         // If a node only has a single text node as a child whith a small enough text,
         // return it with this node as an `inlineTextChild`.
@@ -321,7 +321,7 @@ impl NodeInfoToProtocol for NodeInfo {
             let mut children = rx.recv().ok()??;
 
             let child = children.pop()?;
-            let msg = child.encode(actors, script_chan.clone(), pipeline, walker);
+            let msg = child.encode(registry, script_chan.clone(), pipeline, walker);
 
             // If the node child is not a text node, do not represent it inline.
             if msg.node_type != TEXT_NODE {
@@ -361,7 +361,7 @@ impl NodeInfoToProtocol for NodeInfo {
             node_type: self.node_type,
             node_value: self.node_value,
             num_children: self.num_children,
-            parent: actors.script_to_actor(self.parent.clone()),
+            parent: registry.script_to_actor(self.parent.clone()),
             shadow_root_mode: self
                 .shadow_root_mode
                 .as_ref()

--- a/components/devtools/actors/source.rs
+++ b/components/devtools/actors/source.rs
@@ -60,11 +60,11 @@ impl SourceManager {
             .insert(actor_name.to_owned());
     }
 
-    pub fn source_forms(&self, actors: &ActorRegistry) -> Vec<SourceForm> {
+    pub fn source_forms(&self, registry: &ActorRegistry) -> Vec<SourceForm> {
         self.source_actor_names
             .borrow()
             .iter()
-            .map(|actor_name| actors.find::<SourceActor>(actor_name).source_form())
+            .map(|actor_name| registry.find::<SourceActor>(actor_name).source_form())
             .collect()
     }
 
@@ -166,7 +166,7 @@ impl SourceActor {
 
     #[expect(clippy::too_many_arguments)]
     pub fn new_registered(
-        actors: &ActorRegistry,
+        registry: &ActorRegistry,
         pipeline_id: PipelineId,
         url: ServoUrl,
         content: Option<String>,
@@ -175,7 +175,7 @@ impl SourceActor {
         introduction_type: String,
         script_sender: GenericSender<DevtoolScriptControlMsg>,
     ) -> String {
-        let source_actor_name = actors.new_name::<Self>();
+        let source_actor_name = registry.new_name::<Self>();
 
         let source_actor = SourceActor::new(
             source_actor_name.clone(),
@@ -186,8 +186,8 @@ impl SourceActor {
             introduction_type,
             script_sender,
         );
-        actors.register(source_actor);
-        actors.register_source_actor(pipeline_id, &source_actor_name);
+        registry.register(source_actor);
+        registry.register_source_actor(pipeline_id, &source_actor_name);
 
         source_actor_name
     }

--- a/components/devtools/network_handler.rs
+++ b/components/devtools/network_handler.rs
@@ -22,19 +22,19 @@ pub(crate) struct Cause {
 }
 
 pub(crate) fn handle_network_event(
-    actors: Arc<ActorRegistry>,
+    registry: Arc<ActorRegistry>,
     netevent_actor_name: String,
     mut connections: Vec<TcpStream>,
     network_event: NetworkEvent,
 ) {
-    let actor = actors.find::<NetworkEventActor>(&netevent_actor_name);
-    let watcher = actors.find::<WatcherActor>(&actor.watcher);
+    let actor = registry.find::<NetworkEventActor>(&netevent_actor_name);
+    let watcher = registry.find::<WatcherActor>(&actor.watcher);
 
     match network_event {
         NetworkEvent::HttpRequest(httprequest) => {
             actor.add_request(httprequest);
-            let msg = actor.encode(&actors);
-            let resource = actor.resource_updates(&actors);
+            let msg = actor.encode(&registry);
+            let resource = actor.resource_updates(&registry);
 
             for stream in &mut connections {
                 watcher.resource_array(
@@ -56,7 +56,7 @@ pub(crate) fn handle_network_event(
 
         NetworkEvent::HttpRequestUpdate(httprequest) => {
             actor.add_request(httprequest);
-            let resource = actor.resource_updates(&actors);
+            let resource = actor.resource_updates(&registry);
 
             for stream in &mut connections {
                 watcher.resource_array(
@@ -69,7 +69,7 @@ pub(crate) fn handle_network_event(
         },
         NetworkEvent::HttpResponse(httpresponse) => {
             actor.add_response(httpresponse);
-            let resource = actor.resource_updates(&actors);
+            let resource = actor.resource_updates(&registry);
 
             for stream in &mut connections {
                 watcher.resource_array(
@@ -82,7 +82,7 @@ pub(crate) fn handle_network_event(
         },
         NetworkEvent::SecurityInfo(update) => {
             actor.add_security_info(update.security_info);
-            let resource = actor.resource_updates(&actors);
+            let resource = actor.resource_updates(&registry);
 
             for stream in &mut connections {
                 watcher.resource_array(


### PR DESCRIPTION
Renamed actors to registry in source, node, & network_handler.

Testing: No tests were required, however compilation was successful
Part of #43605 
