### PR TITLE
layout: Fix `justify-self: auto` on block-in-inline

### DIFF
--- a/components/layout/flow/inline/mod.rs
+++ b/components/layout/flow/inline/mod.rs
@@ -220,6 +220,7 @@ impl BlockLevelBox {
             &mut layout.placement_state,
             // Under discussion in <https://github.com/w3c/csswg-drafts/issues/13260>.
             LogicalSides1D::new(false, false),
+            true, /* has_inline_parent */
         );
 
         let Fragment::Box(fragment) = fragment else {

--- a/components/layout/flow/mod.rs
+++ b/components/layout/flow/mod.rs
@@ -785,6 +785,7 @@ fn layout_block_level_children_in_parallel(
                 /* sequential_layout_state = */ None,
                 /* collapsible_with_parent_start_margin = */ None,
                 ignore_block_margins_for_stretch,
+                false, /* has_inline_parent */
             );
             (fragment, child_positioning_context)
         })
@@ -825,6 +826,7 @@ fn layout_block_level_children_sequentially(
                 Some(sequential_layout_state),
                 placement_state,
                 ignore_block_margins_for_stretch,
+                false, /* has_inline_parent */
             )
         })
         .collect()
@@ -837,6 +839,7 @@ fn layout_block_level_child(
     mut sequential_layout_state: Option<&mut SequentialLayoutState>,
     placement_state: &mut PlacementState,
     ignore_block_margins_for_stretch: LogicalSides1D<bool>,
+    has_inline_parent: bool,
 ) -> Fragment {
     let positioning_context_length_before_layout = positioning_context.len();
     let mut fragment = child_box.layout(
@@ -848,6 +851,7 @@ fn layout_block_level_child(
             placement_state.next_in_flow_margin_collapses_with_parent_start_margin,
         )),
         ignore_block_margins_for_stretch,
+        has_inline_parent,
     );
 
     placement_state.place_fragment_and_update_baseline(&mut fragment, sequential_layout_state);
@@ -860,6 +864,7 @@ fn layout_block_level_child(
 }
 
 impl BlockLevelBox {
+    #[allow(clippy::too_many_arguments)]
     fn layout(
         &self,
         layout_context: &LayoutContext,
@@ -868,6 +873,7 @@ impl BlockLevelBox {
         sequential_layout_state: Option<&mut SequentialLayoutState>,
         collapsible_with_parent_start_margin: Option<CollapsibleWithParentStartMargin>,
         ignore_block_margins_for_stretch: LogicalSides1D<bool>,
+        has_inline_parent: bool,
     ) -> Fragment {
         let fragment = match self {
             BlockLevelBox::SameFormattingContextBlock { base, contents, .. } => Fragment::Box(
@@ -885,6 +891,7 @@ impl BlockLevelBox {
                             sequential_layout_state,
                             collapsible_with_parent_start_margin,
                             ignore_block_margins_for_stretch,
+                            has_inline_parent,
                         )
                     },
                 )),
@@ -901,6 +908,7 @@ impl BlockLevelBox {
                             containing_block,
                             sequential_layout_state,
                             ignore_block_margins_for_stretch,
+                            has_inline_parent,
                         )
                     },
                 ),
@@ -971,6 +979,7 @@ fn layout_in_flow_non_replaced_block_level_same_formatting_context(
     mut sequential_layout_state: Option<&mut SequentialLayoutState>,
     collapsible_with_parent_start_margin: Option<CollapsibleWithParentStartMargin>,
     ignore_block_margins_for_stretch: LogicalSides1D<bool>,
+    has_inline_parent: bool,
 ) -> BoxFragment {
     let style = &base.style;
     let layout_style = contents.layout_style(base);
@@ -993,6 +1002,7 @@ fn layout_in_flow_non_replaced_block_level_same_formatting_context(
         get_inline_content_sizes,
         ignore_block_margins_for_stretch,
         None,
+        has_inline_parent,
     );
     let ResolvedMargins {
         margin,
@@ -1250,6 +1260,7 @@ impl IndependentFormattingContext {
         containing_block: &ContainingBlock,
         sequential_layout_state: Option<&mut SequentialLayoutState>,
         ignore_block_margins_for_stretch: LogicalSides1D<bool>,
+        has_inline_parent: bool,
     ) -> BoxFragment {
         if let Some(sequential_layout_state) = sequential_layout_state {
             return self.layout_in_flow_block_level_sequentially(
@@ -1258,6 +1269,7 @@ impl IndependentFormattingContext {
                 containing_block,
                 sequential_layout_state,
                 ignore_block_margins_for_stretch,
+                has_inline_parent,
             );
         }
 
@@ -1280,6 +1292,7 @@ impl IndependentFormattingContext {
             get_inline_content_sizes,
             ignore_block_margins_for_stretch,
             Some(self),
+            has_inline_parent,
         );
 
         let lazy_block_size = LazySize::new(
@@ -1356,6 +1369,7 @@ impl IndependentFormattingContext {
         containing_block: &ContainingBlock<'_>,
         sequential_layout_state: &mut SequentialLayoutState,
         ignore_block_margins_for_stretch: LogicalSides1D<bool>,
+        has_inline_parent: bool,
     ) -> BoxFragment {
         let style = &self.base.style;
         let containing_block_writing_mode = containing_block.style.writing_mode;
@@ -1456,7 +1470,7 @@ impl IndependentFormattingContext {
                 .sizes
         };
 
-        let justify_self = resolve_justify_self(style, containing_block.style);
+        let justify_self = resolve_justify_self(style, containing_block.style, has_inline_parent);
         let automatic_inline_size = automatic_inline_size(justify_self, Some(self));
         let compute_inline_size = |cache: &mut Cache, stretch_size| {
             if cache.depends_on_stretch_size {
@@ -1731,6 +1745,7 @@ fn solve_containing_block_padding_and_border_for_in_flow_box<'a>(
     get_inline_content_sizes: impl FnOnce(&ConstraintSpace) -> ContentSizes,
     ignore_block_margins_for_stretch: LogicalSides1D<bool>,
     context: Option<&IndependentFormattingContext>,
+    has_inline_parent: bool,
 ) -> ContainingBlockPaddingAndBorder<'a> {
     let style = layout_style.style();
     if matches!(style.pseudo(), Some(PseudoElement::ServoAnonymousBox)) {
@@ -1813,7 +1828,7 @@ fn solve_containing_block_padding_and_border_for_in_flow_box<'a>(
             preferred_aspect_ratio,
         ))
     };
-    let justify_self = resolve_justify_self(style, containing_block.style);
+    let justify_self = resolve_justify_self(style, containing_block.style, has_inline_parent);
     let inline_size = content_box_sizes.inline.resolve(
         Direction::Inline,
         automatic_inline_size(justify_self, context),
@@ -1890,20 +1905,32 @@ fn solve_block_margins_for_in_flow_block_level(pbm: &PaddingBorderMargin) -> (Au
 }
 
 /// Resolves the `justify-self` value, preserving flags.
-fn resolve_justify_self(style: &ComputedValues, parent_style: &ComputedValues) -> AlignFlags {
-    let is_ltr = |style: &ComputedValues| style.writing_mode.line_left_is_inline_start();
+fn resolve_justify_self(
+    style: &ComputedValues,
+    containing_block_style: &ComputedValues,
+    has_inline_parent: bool,
+) -> AlignFlags {
+    // `justify-self: auto` behaves as the computed `justify-items` value of the parent box.
+    // The parent box is generally the containing block, but it can also be an inline box.
+    // In that case, since `justify-items` doesn't apply to inline boxes, we need to treat
+    // `justify-self: auto` as `normal`.
+    // See the resolution in <https://github.com/w3c/csswg-drafts/issues/11462>.
     let alignment = match style.clone_justify_self().0 {
-        AlignFlags::AUTO => parent_style.clone_justify_items().computed.0.0,
+        AlignFlags::AUTO if has_inline_parent => AlignFlags::NORMAL,
+        AlignFlags::AUTO => containing_block_style.clone_justify_items().computed.0.0,
         alignment => alignment,
     };
+    let is_ltr = |style: &ComputedValues| style.writing_mode.line_left_is_inline_start();
     let alignment_value = match alignment.value() {
-        AlignFlags::LEFT if is_ltr(parent_style) => AlignFlags::START,
+        AlignFlags::LEFT if is_ltr(containing_block_style) => AlignFlags::START,
         AlignFlags::LEFT => AlignFlags::END,
-        AlignFlags::RIGHT if is_ltr(parent_style) => AlignFlags::END,
+        AlignFlags::RIGHT if is_ltr(containing_block_style) => AlignFlags::END,
         AlignFlags::RIGHT => AlignFlags::START,
-        AlignFlags::SELF_START if is_ltr(parent_style) == is_ltr(style) => AlignFlags::START,
+        AlignFlags::SELF_START if is_ltr(containing_block_style) == is_ltr(style) => {
+            AlignFlags::START
+        },
         AlignFlags::SELF_START => AlignFlags::END,
-        AlignFlags::SELF_END if is_ltr(parent_style) == is_ltr(style) => AlignFlags::END,
+        AlignFlags::SELF_END if is_ltr(containing_block_style) == is_ltr(style) => AlignFlags::END,
         AlignFlags::SELF_END => AlignFlags::START,
         alignment_value => alignment_value,
     };

--- a/components/layout/table/layout.rs
+++ b/components/layout/table/layout.rs
@@ -1540,6 +1540,7 @@ impl<'a> TableLayout<'a> {
             containing_block,
             None, /* sequential_layout_state */
             ignore_block_margins_for_stretch,
+            false, /* has_inline_parent */
         );
 
         if let Some(mut positioning_context) = positioning_context.take() {

--- a/tests/wpt/tests/css/css-align/blocks/justify-self-block-in-inline-002.html
+++ b/tests/wpt/tests/css/css-align/blocks/justify-self-block-in-inline-002.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<link rel="author" title="Oriol Brufau" href="obrufau@igalia.com">
+<link rel="help" href="https://drafts.csswg.org/css-align/#justify-self-property">
+<link rel="help" href="https://github.com/w3c/csswg-drafts/issues/11462">
+<link rel="match" href="../../reference/ref-filled-green-200px-square.html">
+<meta name="assert" content="
+  On a block-level box with an inline parent, `justify-self: auto` behaves as
+  `justify-self: normal`. So in this case it should stretch.
+  The `justify-items: center` on the parent has no effect because `justify-items`
+  doesn't apply to inline boxes. The `justify-items: right` on the containing
+  block has no effect becasue it's not the parent box.
+">
+
+<p>Test passes if there is a filled green square and <strong>no red</strong>.</p>
+
+<div style="width: 200px; justify-items: right; background: red">
+  <span style="justify-items: center">
+    <div style="min-width: 50px; height: 200px; background: green"></div>
+  </span>
+</div>


### PR DESCRIPTION
We were resolving `justify-self: auto` according to the `justify-items` of the containing block. However, the CSSWG resolved to instead use the parent box; and if the parent is an inline box, then `justify-items` doesn't apply, so `justify-self: auto` behaves as `normal`.

Testing: Adding WPT test
Fixes: #43624
