### PR TITLE
script: Remove check for zero request body length in `FetchLater`

### DIFF
--- a/components/script/fetch.rs
+++ b/components/script/fetch.rs
@@ -398,11 +398,13 @@ pub(crate) fn FetchLater(
     if !url.is_potentially_trustworthy() {
         return Err(Error::Type(c"URL is not trustworthy".to_owned()));
     }
-    // Step 10. If request’s body is not null, and request’s body length is null or zero, then throw a TypeError.
-    if let Some(body) = request.body.as_ref() {
-        if body.len().is_none_or(|len| len == 0) {
-            return Err(Error::Type(c"Body is empty".to_owned()));
-        }
+    // Step 10. If request’s body is not null, and request’s body length is null, then throw a TypeError.
+    if request
+        .body
+        .as_ref()
+        .is_some_and(|body| body.len().is_none())
+    {
+        return Err(Error::Type(c"Body is empty".to_owned()));
     }
     // Step 11. If the available deferred-fetch quota given request’s client and request’s URL’s
     // origin is less than request’s total request length, then throw a "QuotaExceededError" DOMException.

--- a/tests/wpt/meta/fetch/fetch-later/quota/cross-origin-iframe/empty-payload.https.window.js.ini
+++ b/tests/wpt/meta/fetch/fetch-later/quota/cross-origin-iframe/empty-payload.https.window.js.ini
@@ -1,6 +1,22 @@
 [empty-payload.https.window.html]
   expected: ERROR
-  [fetchLater() accepts a non-empty POST request body of FormData in a default cross-origin iframe.]
+
+  [fetchLater() accepts an empty POST request body of String in a default cross-origin iframe.]
+    expected: FAIL
+
+  [fetchLater() accepts an empty POST request body of ArrayBuffer in a default cross-origin iframe.]
+    expected: FAIL
+
+  [fetchLater() accepts an empty POST request body of FormData in a default cross-origin iframe.]
+    expected: FAIL
+
+  [fetchLater() accepts an empty POST request body of URLSearchParams in a default cross-origin iframe.]
+    expected: FAIL
+
+  [fetchLater() accepts an empty POST request body of Blob in a default cross-origin iframe.]
+    expected: FAIL
+
+  [fetchLater() accepts an empty POST request body of File in a default cross-origin iframe.]
     expected: FAIL
 
   [fetchLater() accepts an empty POST request body of String in a default cross-origin iframe.]

--- a/tests/wpt/meta/fetch/fetch-later/quota/empty-payload.https.window.js.ini
+++ b/tests/wpt/meta/fetch/fetch-later/quota/empty-payload.https.window.js.ini
@@ -1,2 +1,0 @@
-[empty-payload.https.window.html]
-  expected: ERROR


### PR DESCRIPTION
Per the spec discussion in [1] we should only check for a length of `null` and not zero.

[1]: https://github.com/whatwg/fetch/pull/1902

Testing: Updates WPT test according to spec
