### PR TITLE
Re-enable sccache for the mac-arm64 workflow

### DIFF
--- a/.github/workflows/mac-arm64.yml
+++ b/.github/workflows/mac-arm64.yml
@@ -72,6 +72,11 @@ on:
 env:
   RUST_BACKTRACE: 1
   SHELL: /bin/bash
+  # Increment this to purge the cache (https://github.com/mozilla/sccache/blob/main/docs/GHA.md)
+  SCCACHE_GHA_VERSION: 1
+  SCCACHE_GHA_ENABLED: "true"
+  RUSTC_WRAPPER: "sccache"
+  CCACHE: "sccache"
   CARGO_INCREMENTAL: 0
 
 jobs:
@@ -111,6 +116,8 @@ jobs:
       - if: runner.environment != 'self-hosted'
         name: Setup Python
         uses: ./.github/actions/setup-python
+      - name: Run sccache-cache
+        uses: mozilla-actions/sccache-action@v0.0.9
 
       # Always install crown, even on self-hosted runners, because it is tightly
       # coupled to the rustc version, and we may have the wrong version if the


### PR DESCRIPTION
This partially reverts 017b12a627820e8de834fbdda68f650629dddaee. The intermittent issues should be resolved now.

./mach build --release results in ~3GiB of sccache size locally. Since we build multiple configurations (with crown, tests, profiles) we will easily hit the 10GiB cache limit even with just one architecture. Hence, it doesn't make sense to add sccache to more workflows, at least not before we decide to buy more cache or not.
This should hopefully make the macos-arm64 workflows faster. Locally the speed-up on clean builds is significant.

Testing: [mach try (no existing cache)](https://github.com/jschwe/servo/actions/runs/23507308462/job/68418624068), [mach try #2](https://github.com/jschwe/servo/actions/runs/23508733572/job/68423715413) - i.e. 34 minutes vs. 19 minutes total runtime, and 30 m vs 15 m build time (with ideal conditions for the caching)

