### PR TITLE
devtools: Renamed BrowsingContext in breakpoint, console & thread actors

### DIFF
--- a/components/devtools/actors/breakpoint.rs
+++ b/components/devtools/actors/breakpoint.rs
@@ -30,7 +30,7 @@ struct BreakpointRequest {
 #[derive(MallocSizeOf)]
 pub(crate) struct BreakpointListActor {
     name: String,
-    browsing_context: String,
+    browsing_context_name: String,
 }
 
 impl Actor for BreakpointListActor {
@@ -60,9 +60,9 @@ impl Actor for BreakpointListActor {
                 } = msg.location;
                 let source_url = source_url.ok_or(ActorError::Internal)?;
 
-                let browsing_context =
-                    registry.find::<BrowsingContextActor>(&self.browsing_context);
-                let thread = registry.find::<ThreadActor>(&browsing_context.thread);
+                let browsing_context_actor =
+                    registry.find::<BrowsingContextActor>(&self.browsing_context_name);
+                let thread = registry.find::<ThreadActor>(&browsing_context_actor.thread);
                 let source = thread
                     .source_manager
                     .find_source(registry, &source_url)
@@ -96,9 +96,9 @@ impl Actor for BreakpointListActor {
                 } = msg.location;
                 let source_url = source_url.ok_or(ActorError::Internal)?;
 
-                let browsing_context =
-                    registry.find::<BrowsingContextActor>(&self.browsing_context);
-                let thread = registry.find::<ThreadActor>(&browsing_context.thread);
+                let browsing_context_actor =
+                    registry.find::<BrowsingContextActor>(&self.browsing_context_name);
+                let thread = registry.find::<ThreadActor>(&browsing_context_actor.thread);
                 let source = thread
                     .source_manager
                     .find_source(registry, &source_url)
@@ -124,10 +124,10 @@ impl Actor for BreakpointListActor {
 }
 
 impl BreakpointListActor {
-    pub fn new(name: String, browsing_context: String) -> Self {
+    pub fn new(name: String, browsing_context_name: String) -> Self {
         Self {
             name,
-            browsing_context,
+            browsing_context_name,
         }
     }
 }

--- a/components/devtools/actors/console.rs
+++ b/components/devtools/actors/console.rs
@@ -284,8 +284,8 @@ impl ConsoleActor {
 
     fn script_chan(&self, registry: &ActorRegistry) -> GenericSender<DevtoolScriptControlMsg> {
         match &self.root {
-            Root::BrowsingContext(browsing_context) => registry
-                .find::<BrowsingContextActor>(browsing_context)
+            Root::BrowsingContext(browsing_context_name) => registry
+                .find::<BrowsingContextActor>(browsing_context_name)
                 .script_chan(),
             Root::DedicatedWorker(worker) => {
                 registry.find::<WorkerActor>(worker).script_chan.clone()
@@ -295,9 +295,9 @@ impl ConsoleActor {
 
     fn current_unique_id(&self, registry: &ActorRegistry) -> UniqueId {
         match &self.root {
-            Root::BrowsingContext(browsing_context) => UniqueId::Pipeline(
+            Root::BrowsingContext(browsing_context_name) => UniqueId::Pipeline(
                 registry
-                    .find::<BrowsingContextActor>(browsing_context)
+                    .find::<BrowsingContextActor>(browsing_context_name)
                     .pipeline_id(),
             ),
             Root::DedicatedWorker(worker) => {
@@ -489,8 +489,8 @@ impl ConsoleActor {
         }
         let resource_type = resource.resource_type();
         if id == self.current_unique_id(registry) {
-            if let Root::BrowsingContext(bc) = &self.root {
-                registry.find::<BrowsingContextActor>(bc).resource_array(
+            if let Root::BrowsingContext(browsing_context_name) = &self.root {
+                registry.find::<BrowsingContextActor>(browsing_context_name).resource_array(
                     resource,
                     resource_type,
                     ResourceArrayType::Available,
@@ -507,8 +507,8 @@ impl ConsoleActor {
         stream: &mut TcpStream,
     ) {
         if id == self.current_unique_id(registry) {
-            if let Root::BrowsingContext(bc) = &self.root {
-                registry.find::<BrowsingContextActor>(bc).resource_array(
+            if let Root::BrowsingContext(browsing_context_name) = &self.root {
+                registry.find::<BrowsingContextActor>(browsing_context_name).resource_array(
                     ConsoleClearMessage {
                         level: "clear".to_owned(),
                     },

--- a/components/devtools/actors/console.rs
+++ b/components/devtools/actors/console.rs
@@ -490,12 +490,14 @@ impl ConsoleActor {
         let resource_type = resource.resource_type();
         if id == self.current_unique_id(registry) {
             if let Root::BrowsingContext(browsing_context_name) = &self.root {
-                registry.find::<BrowsingContextActor>(browsing_context_name).resource_array(
-                    resource,
-                    resource_type,
-                    ResourceArrayType::Available,
-                    stream,
-                )
+                registry
+                    .find::<BrowsingContextActor>(browsing_context_name)
+                    .resource_array(
+                        resource,
+                        resource_type,
+                        ResourceArrayType::Available,
+                        stream,
+                    )
             };
         }
     }
@@ -508,14 +510,16 @@ impl ConsoleActor {
     ) {
         if id == self.current_unique_id(registry) {
             if let Root::BrowsingContext(browsing_context_name) = &self.root {
-                registry.find::<BrowsingContextActor>(browsing_context_name).resource_array(
-                    ConsoleClearMessage {
-                        level: "clear".to_owned(),
-                    },
-                    "console-message".into(),
-                    ResourceArrayType::Available,
-                    stream,
-                )
+                registry
+                    .find::<BrowsingContextActor>(browsing_context_name)
+                    .resource_array(
+                        ConsoleClearMessage {
+                            level: "clear".to_owned(),
+                        },
+                        "console-message".into(),
+                        ResourceArrayType::Available,
+                        stream,
+                    )
             };
         }
     }

--- a/components/devtools/actors/thread.rs
+++ b/components/devtools/actors/thread.rs
@@ -218,7 +218,8 @@ impl Actor for ThreadActor {
                 let Some(ref browsing_context_name) = self.browsing_context_name else {
                     return Err(ActorError::Internal);
                 };
-                let browsing_context_actor = registry.find::<BrowsingContextActor>(browsing_context_name);
+                let browsing_context_actor =
+                    registry.find::<BrowsingContextActor>(browsing_context_name);
 
                 let frames: FramesRequest =
                     serde_json::from_value(msg.clone().into()).map_err(|_| ActorError::Internal)?;

--- a/components/devtools/actors/thread.rs
+++ b/components/devtools/actors/thread.rs
@@ -112,21 +112,21 @@ pub(crate) struct ThreadActor {
     pub source_manager: SourceManager,
     script_sender: GenericSender<DevtoolScriptControlMsg>,
     pub frames: AtomicRefCell<HashSet<String>>,
-    browsing_context: Option<String>,
+    browsing_context_name: Option<String>,
 }
 
 impl ThreadActor {
     pub fn new(
         name: String,
         script_sender: GenericSender<DevtoolScriptControlMsg>,
-        browsing_context: Option<String>,
+        browsing_context_name: Option<String>,
     ) -> ThreadActor {
         ThreadActor {
             name,
             source_manager: SourceManager::new(),
             script_sender,
             frames: Default::default(),
-            browsing_context,
+            browsing_context_name,
         }
     }
 }
@@ -215,10 +215,10 @@ impl Actor for ThreadActor {
             },
 
             "frames" => {
-                let Some(ref browsing_context) = self.browsing_context else {
+                let Some(ref browsing_context_name) = self.browsing_context_name else {
                     return Err(ActorError::Internal);
                 };
-                let browsing_context = registry.find::<BrowsingContextActor>(browsing_context);
+                let browsing_context_actor = registry.find::<BrowsingContextActor>(browsing_context_name);
 
                 let frames: FramesRequest =
                     serde_json::from_value(msg.clone().into()).map_err(|_| ActorError::Internal)?;
@@ -228,7 +228,7 @@ impl Actor for ThreadActor {
                 };
                 self.script_sender
                     .send(DevtoolScriptControlMsg::ListFrames(
-                        browsing_context.pipeline_id(),
+                        browsing_context_actor.pipeline_id(),
                         frames.start,
                         frames.count,
                         tx,


### PR DESCRIPTION
Renamed BrowsingContext in breakpoint, console & thread actors

Testing: No testing required, however, I didn't forget to run ```/mach fmt``` and ```/mach test-tidy``` this time : )
Fixes: Part of #43606 
