### PR TITLE
devtools: Renamed BrowsingContext in inspector & its actors

### DIFF
--- a/components/devtools/actors/inspector.rs
+++ b/components/devtools/actors/inspector.rs
@@ -111,10 +111,10 @@ impl Actor for InspectorActor {
 }
 
 impl InspectorActor {
-    pub fn register(registry: &ActorRegistry, browsing_context: String) -> String {
+    pub fn register(registry: &ActorRegistry, browsing_context_name: String) -> String {
         let highlighter = HighlighterActor {
             name: registry.new_name::<HighlighterActor>(),
-            browsing_context: browsing_context.clone(),
+            browsing_context_name: browsing_context_name.clone(),
         };
 
         let page_style = PageStyleActor {
@@ -124,7 +124,7 @@ impl InspectorActor {
         let walker = WalkerActor {
             name: registry.new_name::<WalkerActor>(),
             mutations: AtomicRefCell::new(vec![]),
-            browsing_context,
+            browsing_context_name,
         };
 
         let actor = Self {

--- a/components/devtools/actors/inspector/highlighter.rs
+++ b/components/devtools/actors/inspector/highlighter.rs
@@ -19,7 +19,7 @@ use crate::{ActorMsg, EmptyReplyMsg, StreamId};
 #[derive(MallocSizeOf)]
 pub(crate) struct HighlighterActor {
     pub name: String,
-    pub browsing_context: String,
+    pub browsing_context_name: String,
 }
 
 #[derive(Serialize)]
@@ -103,11 +103,12 @@ impl HighlighterActor {
         registry: &ActorRegistry,
     ) {
         let node_id = node_actor.map(|node_actor| registry.actor_to_script(node_actor));
-        let browsing_context = registry.find::<BrowsingContextActor>(&self.browsing_context);
-        browsing_context
+        let browsing_context_actor =
+            registry.find::<BrowsingContextActor>(&self.browsing_context_name);
+        browsing_context_actor
             .script_chan()
             .send(DevtoolScriptControlMsg::HighlightDomNode(
-                browsing_context.pipeline_id(),
+                browsing_context_actor.pipeline_id(),
                 node_id,
             ))
             .unwrap();

--- a/components/devtools/actors/inspector/page_style.rs
+++ b/components/devtools/actors/inspector/page_style.rs
@@ -143,7 +143,7 @@ impl PageStyleActor {
             .ok_or(ActorError::BadParameterType)?;
         let node = registry.find::<NodeActor>(target);
         let walker = registry.find::<WalkerActor>(&node.walker);
-        let browsing_context = walker.browsing_context(registry);
+        let browsing_context_actor = walker.browsing_context_actor(registry);
         let entries: Vec<_> = find_child(
             &node.script_chan,
             node.pipeline,
@@ -162,10 +162,10 @@ impl PageStyleActor {
             // Get the css selectors that match this node present in the currently active stylesheets.
             let selectors = (|| {
                 let (selectors_sender, selector_receiver) = generic_channel::channel()?;
-                browsing_context
+                browsing_context_actor
                     .script_chan()
                     .send(GetSelectors(
-                        browsing_context.pipeline_id(),
+                        browsing_context_actor.pipeline_id(),
                         registry.actor_to_script(node.actor.clone()),
                         selectors_sender,
                     ))
@@ -271,12 +271,12 @@ impl PageStyleActor {
             .ok_or(ActorError::BadParameterType)?;
         let node = registry.find::<NodeActor>(target);
         let walker = registry.find::<WalkerActor>(&node.walker);
-        let browsing_context = walker.browsing_context(registry);
+        let browsing_context_actor = walker.browsing_context_actor(registry);
         let (tx, rx) = generic_channel::channel().ok_or(ActorError::Internal)?;
-        browsing_context
+        browsing_context_actor
             .script_chan()
             .send(GetLayout(
-                browsing_context.pipeline_id(),
+                browsing_context_actor.pipeline_id(),
                 registry.actor_to_script(target.to_owned()),
                 tx,
             ))

--- a/components/devtools/actors/inspector/style_rule.rs
+++ b/components/devtools/actors/inspector/style_rule.rs
@@ -123,11 +123,11 @@ impl Actor for StyleRuleActor {
                 // Query the rule modification
                 let node = registry.find::<NodeActor>(&self.node);
                 let walker = registry.find::<WalkerActor>(&node.walker);
-                let browsing_context = walker.browsing_context(registry);
-                browsing_context
+                let browsing_context_actor = walker.browsing_context_actor(registry);
+                browsing_context_actor
                     .script_chan()
                     .send(ModifyRule(
-                        browsing_context.pipeline_id(),
+                        browsing_context_actor.pipeline_id(),
                         registry.actor_to_script(self.node.clone()),
                         modifications,
                     ))
@@ -153,13 +153,13 @@ impl StyleRuleActor {
     pub fn applied(&self, registry: &ActorRegistry) -> Option<AppliedRule> {
         let node = registry.find::<NodeActor>(&self.node);
         let walker = registry.find::<WalkerActor>(&node.walker);
-        let browsing_context = walker.browsing_context(registry);
+        let browsing_context_actor = walker.browsing_context_actor(registry);
 
         let (document_sender, document_receiver) = generic_channel::channel()?;
-        browsing_context
+        browsing_context_actor
             .script_chan()
             .send(GetDocumentElement(
-                browsing_context.pipeline_id(),
+                browsing_context_actor.pipeline_id(),
                 document_sender,
             ))
             .ok()?;
@@ -172,7 +172,7 @@ impl StyleRuleActor {
             Some(selector) => {
                 let (selector, stylesheet) = selector.clone();
                 GetStylesheetStyle(
-                    browsing_context.pipeline_id(),
+                    browsing_context_actor.pipeline_id(),
                     registry.actor_to_script(self.node.clone()),
                     selector,
                     stylesheet,
@@ -180,12 +180,12 @@ impl StyleRuleActor {
                 )
             },
             None => GetAttributeStyle(
-                browsing_context.pipeline_id(),
+                browsing_context_actor.pipeline_id(),
                 registry.actor_to_script(self.node.clone()),
                 style_sender,
             ),
         };
-        browsing_context.script_chan().send(req).ok()?;
+        browsing_context_actor.script_chan().send(req).ok()?;
         let style = style_receiver.recv().ok()??;
 
         Some(AppliedRule {
@@ -225,13 +225,13 @@ impl StyleRuleActor {
     ) -> Option<HashMap<String, ComputedDeclaration>> {
         let node = registry.find::<NodeActor>(&self.node);
         let walker = registry.find::<WalkerActor>(&node.walker);
-        let browsing_context = walker.browsing_context(registry);
+        let browsing_context_actor = walker.browsing_context_actor(registry);
 
         let (style_sender, style_receiver) = generic_channel::channel()?;
-        browsing_context
+        browsing_context_actor
             .script_chan()
             .send(GetComputedStyle(
-                browsing_context.pipeline_id(),
+                browsing_context_actor.pipeline_id(),
                 registry.actor_to_script(self.node.clone()),
                 style_sender,
             ))

--- a/components/devtools/actors/inspector/walker.rs
+++ b/components/devtools/actors/inspector/walker.rs
@@ -33,7 +33,7 @@ pub(crate) struct WalkerActor {
     pub name: String,
     pub mutations: AtomicRefCell<Vec<DomMutation>>,
     /// Name of the [`BrowsingContextActor`] that owns this walker.
-    pub browsing_context: String,
+    pub browsing_context_name: String,
 }
 
 #[derive(Serialize)]
@@ -142,7 +142,7 @@ impl Actor for WalkerActor {
         msg: &Map<String, Value>,
         _id: StreamId,
     ) -> Result<(), ActorError> {
-        let browsing_context = self.browsing_context(registry);
+        let browsing_context_actor = self.browsing_context_actor(registry);
         match msg_type {
             "children" => {
                 let target = msg
@@ -153,10 +153,10 @@ impl Actor for WalkerActor {
                 let Some((tx, rx)) = generic_channel::channel() else {
                     return Err(ActorError::Internal);
                 };
-                browsing_context
+                browsing_context_actor
                     .script_chan()
                     .send(GetChildren(
-                        browsing_context.pipeline_id(),
+                        browsing_context_actor.pipeline_id(),
                         registry.actor_to_script(target.into()),
                         tx,
                     ))
@@ -174,8 +174,8 @@ impl Actor for WalkerActor {
                         .map(|child| {
                             child.encode(
                                 registry,
-                                browsing_context.script_chan(),
-                                browsing_context.pipeline_id(),
+                                browsing_context_actor.script_chan(),
+                                browsing_context_actor.pipeline_id(),
                                 self.name(),
                             )
                         })
@@ -192,9 +192,9 @@ impl Actor for WalkerActor {
                 let Some((tx, rx)) = generic_channel::channel() else {
                     return Err(ActorError::Internal);
                 };
-                browsing_context
+                browsing_context_actor
                     .script_chan()
-                    .send(GetDocumentElement(browsing_context.pipeline_id(), tx))
+                    .send(GetDocumentElement(browsing_context_actor.pipeline_id(), tx))
                     .map_err(|_| ActorError::Internal)?;
                 let doc_elem_info = rx
                     .recv()
@@ -202,8 +202,8 @@ impl Actor for WalkerActor {
                     .ok_or(ActorError::Internal)?;
                 let node = doc_elem_info.encode(
                     registry,
-                    browsing_context.script_chan(),
-                    browsing_context.pipeline_id(),
+                    browsing_context_actor.script_chan(),
+                    browsing_context_actor.pipeline_id(),
                     self.name(),
                 );
 
@@ -245,8 +245,8 @@ impl Actor for WalkerActor {
                     .as_str()
                     .ok_or(ActorError::BadParameterType)?;
                 let mut hierarchy = find_child(
-                    &browsing_context.script_chan(),
-                    browsing_context.pipeline_id(),
+                    &browsing_context_actor.script_chan(),
+                    browsing_context_actor.pipeline_id(),
                     &self.name,
                     registry,
                     node,
@@ -282,18 +282,18 @@ impl Actor for WalkerActor {
 }
 
 impl WalkerActor {
-    pub(crate) fn browsing_context(
+    pub(crate) fn browsing_context_actor(
         &self,
         registry: &ActorRegistry,
     ) -> DowncastableActorArc<BrowsingContextActor> {
-        registry.find::<BrowsingContextActor>(&self.browsing_context)
+        registry.find::<BrowsingContextActor>(&self.browsing_context_name)
     }
 
     pub(crate) fn root(&self, registry: &ActorRegistry) -> Result<NodeActorMsg, ActorError> {
-        let browsing_context = self.browsing_context(registry);
-        let pipeline = browsing_context.pipeline_id();
+        let browsing_context_actor = self.browsing_context_actor(registry);
+        let pipeline = browsing_context_actor.pipeline_id();
         let (tx, rx) = generic_channel::channel().ok_or(ActorError::Internal)?;
-        browsing_context
+        browsing_context_actor
             .script_chan()
             .send(GetRootNode(pipeline, tx))
             .map_err(|_| ActorError::Internal)?;
@@ -303,7 +303,7 @@ impl WalkerActor {
             .ok_or(ActorError::Internal)?;
         Ok(root_node.encode(
             registry,
-            browsing_context.script_chan(),
+            browsing_context_actor.script_chan(),
             pipeline,
             self.name(),
         ))


### PR DESCRIPTION
Renamed BrowsingContext in inspector, highlighter, page_style, style_rule & walker actors

Testing: No testing required.

Fixes: Part of #43606 