### PR TITLE
devtools: Rename console_actor and console in actors

### DIFF
--- a/components/devtools/actors/browsing_context.rs
+++ b/components/devtools/actors/browsing_context.rs
@@ -104,7 +104,7 @@ pub(crate) struct BrowsingContextActorMsg {
     traits: BrowsingContextTraits,
     // Implemented actors
     accessibility_actor: String,
-    console_actor: String,
+    console_name: String,
     css_properties_actor: String,
     inspector_actor: String,
     reflow_actor: String,
@@ -142,7 +142,7 @@ pub(crate) struct BrowsingContextActor {
     active_outer_window_id: AtomicRefCell<DevtoolsOuterWindowId>,
     pub browsing_context_id: DevtoolsBrowsingContextId,
     accessibility: String,
-    pub console: String,
+    pub console_name: String,
     css_properties: String,
     pub(crate) inspector: String,
     reflow_name: String,
@@ -200,7 +200,7 @@ impl Actor for BrowsingContextActor {
 impl BrowsingContextActor {
     #[expect(clippy::too_many_arguments)]
     pub(crate) fn new(
-        console: String,
+        console_name: String,
         browser_id: DevtoolsBrowserId,
         browsing_context_id: DevtoolsBrowsingContextId,
         page_info: DevtoolsPageInfo,
@@ -260,7 +260,7 @@ impl BrowsingContextActor {
             browser_id,
             browsing_context_id,
             accessibility: accessibility.name(),
-            console,
+            console_name,
             css_properties: css_properties.name(),
             inspector,
             reflow_name: reflow_actor.name(),
@@ -404,7 +404,7 @@ impl ActorEncode<BrowsingContextActorMsg> for BrowsingContextActor {
             outer_window_id: self.outer_window_id().value(),
             is_top_level_target: true,
             accessibility_actor: self.accessibility.clone(),
-            console_actor: self.console.clone(),
+            console_name: self.console_name.clone(),
             css_properties_actor: self.css_properties.clone(),
             inspector_actor: self.inspector.clone(),
             reflow_actor: self.reflow_name.clone(),

--- a/components/devtools/actors/browsing_context.rs
+++ b/components/devtools/actors/browsing_context.rs
@@ -104,7 +104,7 @@ pub(crate) struct BrowsingContextActorMsg {
     traits: BrowsingContextTraits,
     // Implemented actors
     accessibility_actor: String,
-    console_name: String,
+    console_actor: String,
     css_properties_actor: String,
     inspector_actor: String,
     reflow_actor: String,
@@ -404,7 +404,7 @@ impl ActorEncode<BrowsingContextActorMsg> for BrowsingContextActor {
             outer_window_id: self.outer_window_id().value(),
             is_top_level_target: true,
             accessibility_actor: self.accessibility.clone(),
-            console_name: self.console_name.clone(),
+            console_actor: self.console_name.clone(),
             css_properties_actor: self.css_properties.clone(),
             inspector_actor: self.inspector.clone(),
             reflow_actor: self.reflow_name.clone(),

--- a/components/devtools/actors/watcher.rs
+++ b/components/devtools/actors/watcher.rs
@@ -339,10 +339,10 @@ impl Actor for WatcherActor {
                             }
                         },
                         "console-message" | "error-message" => {
-                            let console = registry.find::<ConsoleActor>(&target.console);
-                            console.received_first_message_from_client();
+                            let console_actor = registry.find::<ConsoleActor>(&target.console_name);
+                            console_actor.received_first_message_from_client();
                             target.resources_array(
-                                console.get_cached_messages(registry, resource),
+                                console_actor.get_cached_messages(registry, resource),
                                 resource.into(),
                                 ResourceArrayType::Available,
                                 &mut request,
@@ -350,10 +350,10 @@ impl Actor for WatcherActor {
 
                             for worker_name in &*root.workers.borrow() {
                                 let worker = registry.find::<WorkerActor>(worker_name);
-                                let console = registry.find::<ConsoleActor>(&worker.console);
+                                let console_actor = registry.find::<ConsoleActor>(&worker.console_name);
 
                                 worker.resources_array(
-                                    console.get_cached_messages(registry, resource),
+                                    console_actor.get_cached_messages(registry, resource),
                                     resource.into(),
                                     ResourceArrayType::Available,
                                     &mut request,

--- a/components/devtools/actors/watcher.rs
+++ b/components/devtools/actors/watcher.rs
@@ -350,7 +350,8 @@ impl Actor for WatcherActor {
 
                             for worker_name in &*root.workers.borrow() {
                                 let worker = registry.find::<WorkerActor>(worker_name);
-                                let console_actor = registry.find::<ConsoleActor>(&worker.console_name);
+                                let console_actor =
+                                    registry.find::<ConsoleActor>(&worker.console_name);
 
                                 worker.resources_array(
                                     console_actor.get_cached_messages(registry, resource),

--- a/components/devtools/actors/worker.rs
+++ b/components/devtools/actors/worker.rs
@@ -81,7 +81,7 @@ impl Actor for WorkerActor {
                     from: self.name(),
                     type_: "connected".to_owned(),
                     thread_actor: self.thread.clone(),
-                    console_name: self.console_name.clone(),
+                    console_actor: self.console_name.clone(),
                 };
                 // FIXME: we don’t send an actual reply (message without type), which seems to be a bug?
                 request.write_json_packet(&msg)?;
@@ -134,7 +134,7 @@ struct ConnectReply {
     #[serde(rename = "type")]
     type_: String,
     thread_actor: String,
-    console_name: String,
+    console_actor: String,
 }
 
 #[derive(Serialize)]
@@ -148,7 +148,7 @@ struct WorkerTraits {
 #[serde(rename_all = "camelCase")]
 pub(crate) struct WorkerActorMsg {
     actor: String,
-    console_name: String,
+    console_actor: String,
     thread_actor: String,
     id: String,
     url: String,
@@ -163,7 +163,7 @@ impl ActorEncode<WorkerActorMsg> for WorkerActor {
     fn encode(&self, _: &ActorRegistry) -> WorkerActorMsg {
         WorkerActorMsg {
             actor: self.name(),
-            console_name: self.console_name.clone(),
+            console_actor: self.console_name.clone(),
             thread_actor: self.thread.clone(),
             id: self.worker_id.0.to_string(),
             url: self.url.to_string(),

--- a/components/devtools/actors/worker.rs
+++ b/components/devtools/actors/worker.rs
@@ -31,7 +31,7 @@ pub enum WorkerType {
 #[derive(MallocSizeOf)]
 pub(crate) struct WorkerActor {
     pub name: String,
-    pub console: String,
+    pub console_name: String,
     pub thread: String,
     pub worker_id: WorkerId,
     pub url: ServoUrl,
@@ -81,7 +81,7 @@ impl Actor for WorkerActor {
                     from: self.name(),
                     type_: "connected".to_owned(),
                     thread_actor: self.thread.clone(),
-                    console_actor: self.console.clone(),
+                    console_name: self.console_name.clone(),
                 };
                 // FIXME: we don’t send an actual reply (message without type), which seems to be a bug?
                 request.write_json_packet(&msg)?;
@@ -134,7 +134,7 @@ struct ConnectReply {
     #[serde(rename = "type")]
     type_: String,
     thread_actor: String,
-    console_actor: String,
+    console_name: String,
 }
 
 #[derive(Serialize)]
@@ -148,7 +148,7 @@ struct WorkerTraits {
 #[serde(rename_all = "camelCase")]
 pub(crate) struct WorkerActorMsg {
     actor: String,
-    console_actor: String,
+    console_name: String,
     thread_actor: String,
     id: String,
     url: String,
@@ -163,7 +163,7 @@ impl ActorEncode<WorkerActorMsg> for WorkerActor {
     fn encode(&self, _: &ActorRegistry) -> WorkerActorMsg {
         WorkerActorMsg {
             actor: self.name(),
-            console_actor: self.console.clone(),
+            console_name: self.console_name.clone(),
             thread_actor: self.thread.clone(),
             id: self.worker_id.0.to_string(),
             url: self.url.to_string(),

--- a/components/devtools/lib.rs
+++ b/components/devtools/lib.rs
@@ -529,7 +529,8 @@ impl DevtoolsInstance {
 
         let console_actor = ConsoleActor::new(console_name, parent_actor);
 
-        actors.register(console_actor);
+        // actors.register(console_actor);
+        self.registry.register(console_actor);
     }
 
     fn handle_title_changed(&self, pipeline_id: PipelineId, title: String) {
@@ -616,7 +617,7 @@ impl DevtoolsInstance {
     ) -> Option<String> {
         if let Some(worker_id) = worker_id {
             let actor_name = self.actor_workers.get(&worker_id)?;
-            Some(actors.find::<WorkerActor>(actor_name).console_name.clone())
+            Some(self.registry.find::<WorkerActor>(actor_name).console_name.clone())
         } else {
             let id = self.pipelines.get(&pipeline_id)?;
             let actor_name = self.browsing_contexts.get(id)?;

--- a/components/devtools/lib.rs
+++ b/components/devtools/lib.rs
@@ -487,7 +487,7 @@ impl DevtoolsInstance {
             let worker_name = self.registry.new_name::<WorkerActor>();
             let worker = WorkerActor {
                 name: worker_name.clone(),
-                console: console_name.clone(),
+                console_name: console_name.clone(),
                 thread: thread_name,
                 worker_id: id,
                 url: page_info.url,
@@ -527,9 +527,9 @@ impl DevtoolsInstance {
             Root::BrowsingContext(name.clone())
         };
 
-        let console = ConsoleActor::new(console_name, parent_actor);
+        let console_actor = ConsoleActor::new(console_name, parent_actor);
 
-        self.registry.register(console);
+        actors.register(console_actor);
     }
 
     fn handle_title_changed(&self, pipeline_id: PipelineId, title: String) {
@@ -616,19 +616,14 @@ impl DevtoolsInstance {
     ) -> Option<String> {
         if let Some(worker_id) = worker_id {
             let actor_name = self.actor_workers.get(&worker_id)?;
-            Some(
-                self.registry
-                    .find::<WorkerActor>(actor_name)
-                    .console
-                    .clone(),
-            )
+            Some(actors.find::<WorkerActor>(actor_name).console_name.clone())
         } else {
             let id = self.pipelines.get(&pipeline_id)?;
             let actor_name = self.browsing_contexts.get(id)?;
             Some(
                 self.registry
                     .find::<BrowsingContextActor>(actor_name)
-                    .console
+                    .console_name
                     .clone(),
             )
         }

--- a/components/devtools/lib.rs
+++ b/components/devtools/lib.rs
@@ -529,7 +529,6 @@ impl DevtoolsInstance {
 
         let console_actor = ConsoleActor::new(console_name, parent_actor);
 
-        // actors.register(console_actor);
         self.registry.register(console_actor);
     }
 

--- a/components/devtools/lib.rs
+++ b/components/devtools/lib.rs
@@ -617,7 +617,12 @@ impl DevtoolsInstance {
     ) -> Option<String> {
         if let Some(worker_id) = worker_id {
             let actor_name = self.actor_workers.get(&worker_id)?;
-            Some(self.registry.find::<WorkerActor>(actor_name).console_name.clone())
+            Some(
+                self.registry
+                    .find::<WorkerActor>(actor_name)
+                    .console_name
+                    .clone(),
+            )
         } else {
             let id = self.pipelines.get(&pipeline_id)?;
             let actor_name = self.browsing_contexts.get(id)?;


### PR DESCRIPTION
Rename console_actor and console in  actors.

Testing: ran `./mach test-devtools`.

Fixes: Part of #43606
