### PR TITLE
net: Update reported CSP urls for websockets

### DIFF
--- a/components/net/fetch/methods.rs
+++ b/components/net/fetch/methods.rs
@@ -307,22 +307,9 @@ pub(crate) fn convert_request_to_csp_request(request: &Request) -> Option<csp::R
         Origin::Origin(origin) => origin,
     };
 
-    let mut original_url = request.original_url();
-    let current_url = if original_url.scheme() == "ws" {
-        // We need to retroactively upgrade the ws URL if the rewritten http URL was upgraded to a secure scheme.
-        // https://github.com/w3c/webappsec-csp/issues/532
-        if request.url().scheme() == "https" {
-            original_url.as_mut_url().set_scheme("wss").unwrap();
-        }
-        // For ws scheme, we should check against the original URL, not the current HTTP URL
-        original_url.clone()
-    } else {
-        request.current_url()
-    };
-
     let csp_request = csp::Request {
-        url: original_url.into_url(),
-        current_url: current_url.into_url(),
+        url: request.url().into_url(),
+        current_url: request.current_url().into_url(),
         origin: origin.clone().into_url_origin(),
         redirect_count: request.redirect_count,
         destination: request.destination,

--- a/tests/wpt/meta/trusted-types/trusted-types-reporting.html.ini
+++ b/tests/wpt/meta/trusted-types/trusted-types-reporting.html.ini
@@ -14,8 +14,5 @@
   [Trusted Type violation report: sample for eval]
     expected: FAIL
 
-  [Trusted Type violation report: sample for custom element assignment]
-    expected: FAIL
-
   [Trusted Type violation report: Worker constructor]
     expected: FAIL

--- a/tests/wpt/tests/content-security-policy/inside-worker/support/connect-src-self-report-only.sub.js
+++ b/tests/wpt/tests/content-security-policy/inside-worker/support/connect-src-self-report-only.sub.js
@@ -78,11 +78,12 @@ promise_test(t => {
 }, "Same-origin => cross-origin 'fetch()'.");
 
 let websocket_url = "wss://{{host}}:{{ports[wss][0]}}/echo";
+let expected_websocket_csp_url = websocket_url.replace('wss://', 'https://');
 
 // The WebSocket URL is not the same as 'self'
 promise_test(t => {
   return Promise.all([
-    waitUntilCSPEventForURL(t, websocket_url),
+    waitUntilCSPEventForURL(t, expected_websocket_csp_url),
     new Promise(resolve => {
       let ws = new WebSocket(websocket_url);
       ws.onopen = resolve;
@@ -91,8 +92,8 @@ promise_test(t => {
 }, "WebSocket.");
 
 let expected_blocked_urls = self.XMLHttpRequest
-    ? [ fetch_cross_origin_url, xhr_cross_origin_url, redirect_url, websocket_url ]
-    : [ fetch_cross_origin_url, redirect_url, websocket_url ];
+    ? [ fetch_cross_origin_url, xhr_cross_origin_url, redirect_url, expected_websocket_csp_url ]
+    : [ fetch_cross_origin_url, redirect_url, expected_websocket_csp_url ];
 
 promise_test(async t => {
   let report_url = `{{location[server]}}/reporting/resources/report.py?` +

--- a/tests/wpt/tests/content-security-policy/inside-worker/support/connect-src-self.sub.js
+++ b/tests/wpt/tests/content-security-policy/inside-worker/support/connect-src-self.sub.js
@@ -90,11 +90,12 @@ promise_test(t => {
 
 
 let websocket_url = "wss://{{host}}:{{ports[wss][0]}}/echo";
+let expected_websocket_csp_url = websocket_url.replace('wss://', 'https://');
 
 // The WebSocket URL is not the same as 'self'
 promise_test(t => {
   return Promise.all([
-    waitUntilCSPEventForURL(t, websocket_url),
+    waitUntilCSPEventForURL(t, expected_websocket_csp_url),
     new Promise((resolve, reject) => {
       // Firefox throws in the constructor, Chrome triggers the error event.
       try {
@@ -109,8 +110,8 @@ promise_test(t => {
 }, "WebSocket in " + self.location.protocol + " with {{GET[test-name]}}");
 
 let expected_blocked_urls = self.XMLHttpRequest
-    ? [ fetch_cross_origin_url, xhr_cross_origin_url, redirect_url, websocket_url ]
-    : [ fetch_cross_origin_url, redirect_url, websocket_url ];
+    ? [ fetch_cross_origin_url, xhr_cross_origin_url, redirect_url, expected_websocket_csp_url ]
+    : [ fetch_cross_origin_url, redirect_url, expected_websocket_csp_url ];
 
 promise_test(async t => {
   let report_url = `{{location[server]}}/reporting/resources/report.py` +

--- a/tests/wpt/tests/content-security-policy/securitypolicyviolation/blockeduri-ws-wss-scheme.html
+++ b/tests/wpt/tests/content-security-policy/securitypolicyviolation/blockeduri-ws-wss-scheme.html
@@ -26,28 +26,28 @@ promise_test(async test => {
   const url = get_host_info().HTTP_ORIGIN.replace("http", "ws") + "/path";
   const violation = nextCSPViolation(test);
   try { new WebSocket(url); } catch (e) {}
-  assert_equals((await violation).blockedURI, url);
+  assert_equals((await violation).blockedURI, url.replace('ws://', 'http://'));
 }, "ws");
 
 promise_test(async test => {
   const url = get_host_info().HTTP_ORIGIN.replace("http", "wss") + "/path";
   const violation = nextCSPViolation(test);
   try { new WebSocket(url); } catch (e) {}
-  assert_equals((await violation).blockedURI, url);
+  assert_equals((await violation).blockedURI, url.replace('wss://', 'https://'));
 }, "wss");
 
 promise_test(async test => {
   const url = get_host_info().HTTP_REMOTE_ORIGIN.replace("http", "wss") + "/path";
   const violation = nextCSPViolation(test);
   try { new WebSocket(url); } catch (e) {}
-  assert_equals((await violation).blockedURI, url);
+  assert_equals((await violation).blockedURI, url.replace('wss://', 'https://'));
 }, "cross-origin");
 
 promise_test(async test => {
   const url = get_host_info().HTTP_ORIGIN.replace("http", "wss") + "/path";
   const violation = nextCSPViolation(test);
   try {new WebSocket(redirector + "?location=" + url); } catch (e) {}
-  assert_equals((await violation).blockedURI, url);
+  assert_equals((await violation).blockedURI, url.replace('wss://', 'https://'));
 }, "redirect");
 
 </script>


### PR DESCRIPTION
Per the spec discussion [1], we should report `http(s)` URLs rather than the original `ws(s)` URLs. The WPT tests are updated to reflect what the spec says and are reviewed by other browser engineers in the WPT PR.

[1]: https://github.com/w3c/webappsec-csp/issues/735