### PR TITLE
constellation: Convert constellation's EmbedderProxy to GenericEmbedderProxy

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7635,6 +7635,7 @@ dependencies = [
 name = "servo-constellation"
 version = "0.0.6"
 dependencies = [
+ "accesskit",
  "backtrace",
  "content-security-policy",
  "crossbeam-channel",

--- a/components/constellation/Cargo.toml
+++ b/components/constellation/Cargo.toml
@@ -26,6 +26,7 @@ unwrap_used = "deny"
 panic = "deny"
 
 [dependencies]
+accesskit = { workspace = true }
 backtrace = { workspace = true }
 content-security-policy = { workspace = true }
 crossbeam-channel = { workspace = true }

--- a/components/constellation/constellation.rs
+++ b/components/constellation/constellation.rs
@@ -107,7 +107,7 @@ use devtools_traits::{
 use embedder_traits::resources::{self, Resource};
 use embedder_traits::user_contents::{UserContentManagerId, UserContents};
 use embedder_traits::{
-    AnimationState, EmbedderControlId, EmbedderControlResponse, FocusSequenceNumber,
+    AnimationState, EmbedderControlId, EmbedderControlResponse, EmbedderProxy, FocusSequenceNumber,
     GenericEmbedderProxy, InputEvent, InputEventAndId, InputEventOutcome, JSValue,
     JavaScriptEvaluationError, JavaScriptEvaluationId, KeyboardEvent, MediaSessionActionType,
     MediaSessionEvent, MediaSessionPlaybackState, MouseButton, MouseButtonAction, MouseButtonEvent,
@@ -317,8 +317,11 @@ pub struct Constellation<STF, SWF> {
     /// A channel for the embedder (renderer and libservo) to send messages to the [`Constellation`].
     embedder_to_constellation_receiver: Receiver<EmbedderToConstellationMessage>,
 
+    /// A channel through which messages can be sent to the script embedder.
+    pub(crate) embedder_proxy: EmbedderProxy,
+
     /// A channel through which messages can be sent to the embedder.
-    pub(crate) embedder_proxy: GenericEmbedderProxy<ConstellationToEmbedderMsg>,
+    pub(crate) constellation_to_embedder_proxy: GenericEmbedderProxy<ConstellationToEmbedderMsg>,
 
     /// A channel (the implementation of which is port-specific) for the
     /// constellation to send messages to `Paint`.
@@ -512,8 +515,11 @@ pub struct Constellation<STF, SWF> {
 
 /// State needed to construct a constellation.
 pub struct InitialConstellationState {
+    /// A channel through which messages can be sent to the script embedder.
+    pub embedder_proxy: EmbedderProxy,
+
     /// A channel through which messages can be sent to the embedder.
-    pub embedder_proxy: GenericEmbedderProxy<ConstellationToEmbedderMsg>,
+    pub constellation_to_embedder_proxy: GenericEmbedderProxy<ConstellationToEmbedderMsg>,
 
     /// A channel through which messages can be sent to `Paint` in-process.
     pub paint_proxy: PaintProxy,
@@ -666,6 +672,7 @@ where
                     embedder_to_constellation_receiver,
                     layout_factory,
                     embedder_proxy: state.embedder_proxy,
+                    constellation_to_embedder_proxy: state.constellation_to_embedder_proxy,
                     paint_proxy: state.paint_proxy,
                     webviews: Default::default(),
                     devtools_sender: state.devtools_sender,
@@ -785,7 +792,7 @@ where
         // shut down. This helps ensure we've shut down all our internal threads before
         // de-initializing Servo (see the `thread_count` warning on MacOS).
         debug!("Asking embedding layer to complete shutdown.");
-        self.embedder_proxy
+        self.constellation_to_embedder_proxy
             .send(ConstellationToEmbedderMsg::ShutdownComplete);
     }
 
@@ -1309,7 +1316,7 @@ where
     fn handle_request_from_background_hang_monitor(&self, message: HangMonitorAlert) {
         match message {
             HangMonitorAlert::Profile(bytes) => self
-                .embedder_proxy
+                .constellation_to_embedder_proxy
                 .send(ConstellationToEmbedderMsg::ReportProfile(bytes)),
             HangMonitorAlert::Hang(hang) => {
                 // TODO: In case of a permanent hang being reported, add a "kill script" workflow,
@@ -1423,7 +1430,7 @@ where
                 self.handle_focus_web_view(webview_id);
             },
             EmbedderToConstellationMessage::BlurWebView => {
-                self.embedder_proxy
+                self.constellation_to_embedder_proxy
                     .send(ConstellationToEmbedderMsg::WebViewBlurred);
             },
             // Handle a forward or back request
@@ -1433,11 +1440,9 @@ where
                 traversal_id,
             ) => {
                 self.handle_traverse_history_msg(webview_id, direction);
-                self.embedder_proxy
-                    .send(ConstellationToEmbedderMsg::HistoryTraversalComplete(
-                        webview_id,
-                        traversal_id,
-                    ));
+                self.constellation_to_embedder_proxy.send(
+                    ConstellationToEmbedderMsg::HistoryTraversalComplete(webview_id, traversal_id),
+                );
             },
             EmbedderToConstellationMessage::ChangeViewportDetails(
                 webview_id,
@@ -1993,10 +1998,9 @@ where
                     };
                 }
                 self.active_media_session = Some(pipeline_id);
-                self.embedder_proxy
-                    .send(ConstellationToEmbedderMsg::MediaSessionEvent(
-                        webview_id, event,
-                    ));
+                self.constellation_to_embedder_proxy.send(
+                    ConstellationToEmbedderMsg::MediaSessionEvent(webview_id, event),
+                );
             },
             #[cfg(feature = "webgpu")]
             ScriptToConstellationMessage::RequestAdapter(response_sender, options, ids) => self
@@ -2946,11 +2950,12 @@ where
         backtrace: &Option<String>,
     ) {
         let browsing_context_id = BrowsingContextId::from(webview_id);
-        self.embedder_proxy.send(ConstellationToEmbedderMsg::Panic(
-            webview_id,
-            reason.clone(),
-            backtrace.clone(),
-        ));
+        self.constellation_to_embedder_proxy
+            .send(ConstellationToEmbedderMsg::Panic(
+                webview_id,
+                reason.clone(),
+                backtrace.clone(),
+            ));
 
         let Some(browsing_context) = self.browsing_contexts.get(&browsing_context_id) else {
             return warn!("failed browsing context is missing");
@@ -3018,7 +3023,7 @@ where
 
     #[servo_tracing::instrument(skip_all)]
     fn handle_focus_web_view(&mut self, webview_id: WebViewId) {
-        self.embedder_proxy
+        self.constellation_to_embedder_proxy
             .send(ConstellationToEmbedderMsg::WebViewFocused(webview_id, true));
     }
 
@@ -3154,14 +3159,15 @@ where
         let event_id = event.id;
         let Some(webview) = self.webviews.get_mut(&webview_id) else {
             warn!("Got input event for unknown WebViewId: {webview_id:?}");
-            self.embedder_proxy
-                .send(ConstellationToEmbedderMsg::InputEventsHandled(
+            self.constellation_to_embedder_proxy.send(
+                ConstellationToEmbedderMsg::InputEventsHandled(
                     webview_id,
                     vec![InputEventOutcome {
                         id: event_id,
                         result: Default::default(),
                     }],
-                ));
+                ),
+            );
             return;
         };
 
@@ -3173,14 +3179,15 @@ where
         };
 
         if !webview.forward_input_event(event, &self.pipelines, &self.browsing_contexts) {
-            self.embedder_proxy
-                .send(ConstellationToEmbedderMsg::InputEventsHandled(
+            self.constellation_to_embedder_proxy.send(
+                ConstellationToEmbedderMsg::InputEventsHandled(
                     webview_id,
                     vec![InputEventOutcome {
                         id: event_id,
                         result: Default::default(),
                     }],
-                ));
+                ),
+            );
         }
     }
 
@@ -3262,7 +3269,7 @@ where
             self.close_browsing_context(browsing_context_id, ExitPipelineMode::Normal);
         // Step 4. Remove traversable from the user interface (e.g., close or hide its tab in a tabbed browser).
         self.webviews.remove(&webview_id);
-        self.embedder_proxy
+        self.constellation_to_embedder_proxy
             .send(ConstellationToEmbedderMsg::WebViewClosed(webview_id));
 
         let Some(browsing_context) = browsing_context else {
@@ -3313,11 +3320,9 @@ where
         evaluation_id: JavaScriptEvaluationId,
         result: Result<JSValue, JavaScriptEvaluationError>,
     ) {
-        self.embedder_proxy
-            .send(ConstellationToEmbedderMsg::FinishJavaScriptEvaluation(
-                evaluation_id,
-                result,
-            ));
+        self.constellation_to_embedder_proxy.send(
+            ConstellationToEmbedderMsg::FinishJavaScriptEvaluation(evaluation_id, result),
+        );
     }
 
     #[servo_tracing::instrument(skip_all)]
@@ -3539,7 +3544,7 @@ where
             let _ = response_sender.send(None);
             return;
         };
-        self.embedder_proxy
+        self.constellation_to_embedder_proxy
             .send(ConstellationToEmbedderMsg::AllowOpeningWebView(
                 opener_webview_id,
                 webview_id_sender,
@@ -3728,12 +3733,13 @@ where
             },
         };
         // Allow the embedder to handle the url itself
-        self.embedder_proxy
-            .send(ConstellationToEmbedderMsg::AllowNavigationRequest(
+        self.constellation_to_embedder_proxy.send(
+            ConstellationToEmbedderMsg::AllowNavigationRequest(
                 webview_id,
                 source_id,
                 load_data.url,
-            ));
+            ),
+        );
     }
 
     #[servo_tracing::instrument(skip_all)]
@@ -4420,7 +4426,7 @@ where
         }
 
         // Focus the top-level browsing context.
-        self.embedder_proxy
+        self.constellation_to_embedder_proxy
             .send(ConstellationToEmbedderMsg::WebViewFocused(webview_id, true));
 
         // If a container with a non-null nested browsing context is focused,
@@ -4861,7 +4867,7 @@ where
                 .rev()
                 .scan(current_url, &resolve_url_future),
         );
-        self.embedder_proxy
+        self.constellation_to_embedder_proxy
             .send(ConstellationToEmbedderMsg::HistoryChanged(
                 webview_id,
                 entries,

--- a/components/constellation/constellation.rs
+++ b/components/constellation/constellation.rs
@@ -317,8 +317,8 @@ pub struct Constellation<STF, SWF> {
     /// A channel for the embedder (renderer and libservo) to send messages to the [`Constellation`].
     embedder_to_constellation_receiver: Receiver<EmbedderToConstellationMessage>,
 
-    /// A channel through which messages can be sent to the embedder. This is not used by the `Constellation` 
-    /// itself but only needed to create an `EventLoop`. 
+    /// A channel through which messages can be sent to the embedder. This is not used by the `Constellation`
+    /// itself but only needed to create an `EventLoop`.
     /// Messages from the `Constellation` to the embedder are sent using the `constellation_to_embedder_proxy`
     pub(crate) embedder_proxy: EmbedderProxy,
 
@@ -517,8 +517,8 @@ pub struct Constellation<STF, SWF> {
 
 /// State needed to construct a constellation.
 pub struct InitialConstellationState {
-    /// A channel through which messages can be sent to the embedder. This is not used by the `Constellation` 
-    /// itself but only needed to create an `EventLoop`. 
+    /// A channel through which messages can be sent to the embedder. This is not used by the `Constellation`
+    /// itself but only needed to create an `EventLoop`.
     /// Messages from the `Constellation` to the embedder are sent using the `constellation_to_embedder_proxy`
     pub embedder_proxy: EmbedderProxy,
 

--- a/components/constellation/constellation.rs
+++ b/components/constellation/constellation.rs
@@ -107,8 +107,8 @@ use devtools_traits::{
 use embedder_traits::resources::{self, Resource};
 use embedder_traits::user_contents::{UserContentManagerId, UserContents};
 use embedder_traits::{
-    AnimationState, EmbedderControlId, EmbedderControlResponse, EmbedderMsg, EmbedderProxy,
-    FocusSequenceNumber, InputEvent, InputEventAndId, InputEventOutcome, JSValue,
+    AnimationState, EmbedderControlId, EmbedderControlResponse, FocusSequenceNumber,
+    GenericEmbedderProxy, InputEvent, InputEventAndId, InputEventOutcome, JSValue,
     JavaScriptEvaluationError, JavaScriptEvaluationId, KeyboardEvent, MediaSessionActionType,
     MediaSessionEvent, MediaSessionPlaybackState, MouseButton, MouseButtonAction, MouseButtonEvent,
     NewWebViewDetails, PaintHitTestResult, Theme, ViewportDetails, WebDriverCommandMsg,
@@ -176,6 +176,7 @@ use webgpu::canvas_context::WebGpuExternalImageMap;
 #[cfg(feature = "webgpu")]
 use webgpu_traits::{WebGPU, WebGPURequest};
 
+use super::embedder::ConstellationToEmbedderMsg;
 use crate::broadcastchannel::BroadcastChannels;
 use crate::browsingcontext::{
     AllBrowsingContextsIterator, BrowsingContext, FullyActiveBrowsingContextsIterator,
@@ -317,7 +318,7 @@ pub struct Constellation<STF, SWF> {
     embedder_to_constellation_receiver: Receiver<EmbedderToConstellationMessage>,
 
     /// A channel through which messages can be sent to the embedder.
-    pub(crate) embedder_proxy: EmbedderProxy,
+    pub(crate) embedder_proxy: GenericEmbedderProxy<ConstellationToEmbedderMsg>,
 
     /// A channel (the implementation of which is port-specific) for the
     /// constellation to send messages to `Paint`.
@@ -512,7 +513,7 @@ pub struct Constellation<STF, SWF> {
 /// State needed to construct a constellation.
 pub struct InitialConstellationState {
     /// A channel through which messages can be sent to the embedder.
-    pub embedder_proxy: EmbedderProxy,
+    pub embedder_proxy: GenericEmbedderProxy<ConstellationToEmbedderMsg>,
 
     /// A channel through which messages can be sent to `Paint` in-process.
     pub paint_proxy: PaintProxy,
@@ -784,7 +785,8 @@ where
         // shut down. This helps ensure we've shut down all our internal threads before
         // de-initializing Servo (see the `thread_count` warning on MacOS).
         debug!("Asking embedding layer to complete shutdown.");
-        self.embedder_proxy.send(EmbedderMsg::ShutdownComplete);
+        self.embedder_proxy
+            .send(ConstellationToEmbedderMsg::ShutdownComplete);
     }
 
     /// Helper that sends a message to the event loop of a given pipeline, logging the
@@ -1306,9 +1308,9 @@ where
     #[servo_tracing::instrument(skip_all)]
     fn handle_request_from_background_hang_monitor(&self, message: HangMonitorAlert) {
         match message {
-            HangMonitorAlert::Profile(bytes) => {
-                self.embedder_proxy.send(EmbedderMsg::ReportProfile(bytes))
-            },
+            HangMonitorAlert::Profile(bytes) => self
+                .embedder_proxy
+                .send(ConstellationToEmbedderMsg::ReportProfile(bytes)),
             HangMonitorAlert::Hang(hang) => {
                 // TODO: In case of a permanent hang being reported, add a "kill script" workflow,
                 // via the embedder?
@@ -1421,7 +1423,8 @@ where
                 self.handle_focus_web_view(webview_id);
             },
             EmbedderToConstellationMessage::BlurWebView => {
-                self.embedder_proxy.send(EmbedderMsg::WebViewBlurred);
+                self.embedder_proxy
+                    .send(ConstellationToEmbedderMsg::WebViewBlurred);
             },
             // Handle a forward or back request
             EmbedderToConstellationMessage::TraverseHistory(
@@ -1431,7 +1434,7 @@ where
             ) => {
                 self.handle_traverse_history_msg(webview_id, direction);
                 self.embedder_proxy
-                    .send(EmbedderMsg::HistoryTraversalComplete(
+                    .send(ConstellationToEmbedderMsg::HistoryTraversalComplete(
                         webview_id,
                         traversal_id,
                     ));
@@ -1991,7 +1994,9 @@ where
                 }
                 self.active_media_session = Some(pipeline_id);
                 self.embedder_proxy
-                    .send(EmbedderMsg::MediaSessionEvent(webview_id, event));
+                    .send(ConstellationToEmbedderMsg::MediaSessionEvent(
+                        webview_id, event,
+                    ));
             },
             #[cfg(feature = "webgpu")]
             ScriptToConstellationMessage::RequestAdapter(response_sender, options, ids) => self
@@ -2941,7 +2946,7 @@ where
         backtrace: &Option<String>,
     ) {
         let browsing_context_id = BrowsingContextId::from(webview_id);
-        self.embedder_proxy.send(EmbedderMsg::Panic(
+        self.embedder_proxy.send(ConstellationToEmbedderMsg::Panic(
             webview_id,
             reason.clone(),
             backtrace.clone(),
@@ -3014,7 +3019,7 @@ where
     #[servo_tracing::instrument(skip_all)]
     fn handle_focus_web_view(&mut self, webview_id: WebViewId) {
         self.embedder_proxy
-            .send(EmbedderMsg::WebViewFocused(webview_id, true));
+            .send(ConstellationToEmbedderMsg::WebViewFocused(webview_id, true));
     }
 
     #[servo_tracing::instrument(skip_all)]
@@ -3149,13 +3154,14 @@ where
         let event_id = event.id;
         let Some(webview) = self.webviews.get_mut(&webview_id) else {
             warn!("Got input event for unknown WebViewId: {webview_id:?}");
-            self.embedder_proxy.send(EmbedderMsg::InputEventsHandled(
-                webview_id,
-                vec![InputEventOutcome {
-                    id: event_id,
-                    result: Default::default(),
-                }],
-            ));
+            self.embedder_proxy
+                .send(ConstellationToEmbedderMsg::InputEventsHandled(
+                    webview_id,
+                    vec![InputEventOutcome {
+                        id: event_id,
+                        result: Default::default(),
+                    }],
+                ));
             return;
         };
 
@@ -3167,13 +3173,14 @@ where
         };
 
         if !webview.forward_input_event(event, &self.pipelines, &self.browsing_contexts) {
-            self.embedder_proxy.send(EmbedderMsg::InputEventsHandled(
-                webview_id,
-                vec![InputEventOutcome {
-                    id: event_id,
-                    result: Default::default(),
-                }],
-            ));
+            self.embedder_proxy
+                .send(ConstellationToEmbedderMsg::InputEventsHandled(
+                    webview_id,
+                    vec![InputEventOutcome {
+                        id: event_id,
+                        result: Default::default(),
+                    }],
+                ));
         }
     }
 
@@ -3256,7 +3263,7 @@ where
         // Step 4. Remove traversable from the user interface (e.g., close or hide its tab in a tabbed browser).
         self.webviews.remove(&webview_id);
         self.embedder_proxy
-            .send(EmbedderMsg::WebViewClosed(webview_id));
+            .send(ConstellationToEmbedderMsg::WebViewClosed(webview_id));
 
         let Some(browsing_context) = browsing_context else {
             return warn!(
@@ -3307,7 +3314,7 @@ where
         result: Result<JSValue, JavaScriptEvaluationError>,
     ) {
         self.embedder_proxy
-            .send(EmbedderMsg::FinishJavaScriptEvaluation(
+            .send(ConstellationToEmbedderMsg::FinishJavaScriptEvaluation(
                 evaluation_id,
                 result,
             ));
@@ -3532,10 +3539,11 @@ where
             let _ = response_sender.send(None);
             return;
         };
-        self.embedder_proxy.send(EmbedderMsg::AllowOpeningWebView(
-            opener_webview_id,
-            webview_id_sender,
-        ));
+        self.embedder_proxy
+            .send(ConstellationToEmbedderMsg::AllowOpeningWebView(
+                opener_webview_id,
+                webview_id_sender,
+            ));
         let NewWebViewDetails {
             webview_id: new_webview_id,
             viewport_details,
@@ -3721,7 +3729,7 @@ where
         };
         // Allow the embedder to handle the url itself
         self.embedder_proxy
-            .send(EmbedderMsg::AllowNavigationRequest(
+            .send(ConstellationToEmbedderMsg::AllowNavigationRequest(
                 webview_id,
                 source_id,
                 load_data.url,
@@ -4413,7 +4421,7 @@ where
 
         // Focus the top-level browsing context.
         self.embedder_proxy
-            .send(EmbedderMsg::WebViewFocused(webview_id, true));
+            .send(ConstellationToEmbedderMsg::WebViewFocused(webview_id, true));
 
         // If a container with a non-null nested browsing context is focused,
         // the nested browsing context's active document becomes the focused
@@ -4853,11 +4861,12 @@ where
                 .rev()
                 .scan(current_url, &resolve_url_future),
         );
-        self.embedder_proxy.send(EmbedderMsg::HistoryChanged(
-            webview_id,
-            entries,
-            current_index,
-        ));
+        self.embedder_proxy
+            .send(ConstellationToEmbedderMsg::HistoryChanged(
+                webview_id,
+                entries,
+                current_index,
+            ));
     }
 
     #[servo_tracing::instrument(skip_all)]

--- a/components/constellation/constellation.rs
+++ b/components/constellation/constellation.rs
@@ -3123,11 +3123,12 @@ where
         };
 
         webview.accessibility_active = active;
-        self.embedder_proxy
-            .send(EmbedderMsg::AccessibilityTreeIdChanged(
+        self.constellation_to_embedder_proxy.send(
+            ConstellationToEmbedderMsg::AccessibilityTreeIdChanged(
                 webview_id,
                 webview.active_top_level_pipeline_id.into(),
-            ));
+            ),
+        );
 
         // Forward the activation to the webview’s active pipelines (of those that represent
         // documents). For inactive pipelines (documents in bfcache), we only need to forward the
@@ -3216,7 +3217,7 @@ where
         self.webviews.insert(
             webview_id,
             ConstellationWebView::new(
-                &self.embedder_proxy,
+                &self.constellation_to_embedder_proxy,
                 webview_id,
                 pipeline_id,
                 browsing_context_id,
@@ -3608,7 +3609,7 @@ where
         self.webviews.insert(
             new_webview_id,
             ConstellationWebView::new(
-                &self.embedder_proxy,
+                &self.constellation_to_embedder_proxy,
                 new_webview_id,
                 new_pipeline_id,
                 new_browsing_context_id,
@@ -5755,11 +5756,12 @@ where
             if let Some(webview) = self.webviews.get_mut(&webview_id) {
                 if frame_tree.pipeline.id != webview.active_top_level_pipeline_id {
                     webview.active_top_level_pipeline_id = frame_tree.pipeline.id;
-                    self.embedder_proxy
-                        .send(EmbedderMsg::AccessibilityTreeIdChanged(
+                    self.constellation_to_embedder_proxy.send(
+                        ConstellationToEmbedderMsg::AccessibilityTreeIdChanged(
                             webview_id,
                             webview.active_top_level_pipeline_id.into(),
-                        ));
+                        ),
+                    );
                 }
             }
 

--- a/components/constellation/constellation.rs
+++ b/components/constellation/constellation.rs
@@ -317,7 +317,9 @@ pub struct Constellation<STF, SWF> {
     /// A channel for the embedder (renderer and libservo) to send messages to the [`Constellation`].
     embedder_to_constellation_receiver: Receiver<EmbedderToConstellationMessage>,
 
-    /// A channel through which messages can be sent to the script embedder.
+    /// A channel through which messages can be sent to the embedder. This is not used by the `Constellation` 
+    /// itself but only needed to create an `EventLoop`. 
+    /// Messages from the `Constellation` to the embedder are sent using the `constellation_to_embedder_proxy`
     pub(crate) embedder_proxy: EmbedderProxy,
 
     /// A channel through which messages can be sent to the embedder.
@@ -515,7 +517,9 @@ pub struct Constellation<STF, SWF> {
 
 /// State needed to construct a constellation.
 pub struct InitialConstellationState {
-    /// A channel through which messages can be sent to the script embedder.
+    /// A channel through which messages can be sent to the embedder. This is not used by the `Constellation` 
+    /// itself but only needed to create an `EventLoop`. 
+    /// Messages from the `Constellation` to the embedder are sent using the `constellation_to_embedder_proxy`
     pub embedder_proxy: EmbedderProxy,
 
     /// A channel through which messages can be sent to the embedder.

--- a/components/constellation/constellation_webview.rs
+++ b/components/constellation/constellation_webview.rs
@@ -3,7 +3,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 use embedder_traits::user_contents::UserContentManagerId;
-use embedder_traits::{EmbedderMsg, EmbedderProxy, InputEvent, MouseLeftViewportEvent, Theme};
+use embedder_traits::{GenericEmbedderProxy, InputEvent, MouseLeftViewportEvent, Theme};
 use euclid::Point2D;
 use log::warn;
 use rustc_hash::FxHashMap;
@@ -11,6 +11,7 @@ use script_traits::{ConstellationInputEvent, ScriptThreadMessage};
 use servo_base::id::{BrowsingContextId, PipelineId, WebViewId};
 use style_traits::CSSPixel;
 
+use super::embedder::ConstellationToEmbedderMsg;
 use crate::browsingcontext::BrowsingContext;
 use crate::pipeline::Pipeline;
 use crate::session_history::JointSessionHistory;
@@ -60,13 +61,13 @@ pub(crate) struct ConstellationWebView {
 
 impl ConstellationWebView {
     pub(crate) fn new(
-        embedder_proxy: &EmbedderProxy,
+        embedder_proxy: &GenericEmbedderProxy<ConstellationToEmbedderMsg>,
         webview_id: WebViewId,
         active_top_level_pipeline_id: PipelineId,
         focused_browsing_context_id: BrowsingContextId,
         user_content_manager_id: Option<UserContentManagerId>,
     ) -> Self {
-        embedder_proxy.send(EmbedderMsg::AccessibilityTreeIdChanged(
+        embedder_proxy.send(ConstellationToEmbedderMsg::AccessibilityTreeIdChanged(
             webview_id,
             active_top_level_pipeline_id.into(),
         ));

--- a/components/constellation/embedder.rs
+++ b/components/constellation/embedder.rs
@@ -1,0 +1,50 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+use embedder_traits::{
+    InputEventOutcome, JSValue, JavaScriptEvaluationError, JavaScriptEvaluationId,
+    MediaSessionEvent, NewWebViewDetails, TraversalId,
+};
+use servo_base::generic_channel::GenericSender;
+use servo_base::id::{PipelineId, WebViewId};
+use servo_url::ServoUrl;
+
+/// Messages sent from the network threads to the embedder.
+pub enum ConstellationToEmbedderMsg {
+    /// Informs the embedder that the constellation has completed shutdown.
+    /// Required because the constellation can have pending calls to make
+    /// (e.g. SetFrameTree) at the time that we send it an ExitMsg.
+    ShutdownComplete,
+    /// Report a complete sampled profile
+    ReportProfile(Vec<u8>),
+    /// All webviews lost focus for keyboard events.
+    WebViewBlurred,
+    /// A history traversal operation completed.
+    HistoryTraversalComplete(WebViewId, TraversalId),
+    /// Notifies the embedder about media session events
+    /// (i.e. when there is metadata for the active media session, playback state changes...).
+    MediaSessionEvent(WebViewId, MediaSessionEvent),
+    /// A pipeline panicked. First string is the reason, second one is the backtrace.
+    Panic(WebViewId, String, Option<String>),
+    /// A webview potentially gained focus for keyboard events.
+    /// If the boolean value is false, the webiew could not be focused.
+    WebViewFocused(WebViewId, bool),
+    /// Inform the embedding layer that a particular `InputEvent` was handled by Servo
+    /// and the embedder can continue processing it, if necessary.
+    InputEventsHandled(WebViewId, Vec<InputEventOutcome>),
+    /// A webview was destroyed.
+    WebViewClosed(WebViewId),
+    /// Inform the embedding layer that a JavaScript evaluation has
+    /// finished with the given result.
+    FinishJavaScriptEvaluation(
+        JavaScriptEvaluationId,
+        Result<JSValue, JavaScriptEvaluationError>,
+    ),
+    /// Whether or not to allow script to open a new tab/browser
+    AllowOpeningWebView(WebViewId, GenericSender<Option<NewWebViewDetails>>),
+    /// Whether or not to allow a pipeline to load a url.
+    AllowNavigationRequest(WebViewId, PipelineId, ServoUrl),
+    /// The history state has changed.
+    HistoryChanged(WebViewId, Vec<ServoUrl>, usize),
+}

--- a/components/constellation/embedder.rs
+++ b/components/constellation/embedder.rs
@@ -2,6 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
+use accesskit::TreeId;
 use embedder_traits::{
     InputEventOutcome, JSValue, JavaScriptEvaluationError, JavaScriptEvaluationId,
     MediaSessionEvent, NewWebViewDetails, TraversalId,
@@ -47,4 +48,7 @@ pub enum ConstellationToEmbedderMsg {
     AllowNavigationRequest(WebViewId, PipelineId, ServoUrl),
     /// The history state has changed.
     HistoryChanged(WebViewId, Vec<ServoUrl>, usize),
+    /// Notifies the embedder that the AccessKit [`TreeId`] for the top-level document in this
+    /// WebView has been changed (or initially set).
+    AccessibilityTreeIdChanged(WebViewId, TreeId),
 }

--- a/components/constellation/embedder.rs
+++ b/components/constellation/embedder.rs
@@ -10,7 +10,7 @@ use servo_base::generic_channel::GenericSender;
 use servo_base::id::{PipelineId, WebViewId};
 use servo_url::ServoUrl;
 
-/// Messages sent from the `Constellation` to the `Embedder`.
+/// Messages sent from the `Constellation` to the embedder.
 pub enum ConstellationToEmbedderMsg {
     /// Informs the embedder that the constellation has completed shutdown.
     /// Required because the constellation can have pending calls to make

--- a/components/constellation/embedder.rs
+++ b/components/constellation/embedder.rs
@@ -10,7 +10,7 @@ use servo_base::generic_channel::GenericSender;
 use servo_base::id::{PipelineId, WebViewId};
 use servo_url::ServoUrl;
 
-/// Messages sent from the network threads to the embedder.
+/// Messages sent from the `Constellation` to the `Embedder`.
 pub enum ConstellationToEmbedderMsg {
     /// Informs the embedder that the constellation has completed shutdown.
     /// Required because the constellation can have pending calls to make

--- a/components/constellation/lib.rs
+++ b/components/constellation/lib.rs
@@ -21,6 +21,7 @@ mod serviceworker;
 mod session_history;
 
 pub use crate::constellation::{Constellation, InitialConstellationState};
+pub use crate::embedder::ConstellationToEmbedderMsg;
 pub use crate::event_loop::{EventLoop, NewScriptEventLoopProcessInfo};
 pub use crate::logging::{FromEmbedderLogger, FromScriptLogger};
 pub use crate::sandboxing::{UnprivilegedContent, content_process_sandbox_profile};

--- a/components/constellation/lib.rs
+++ b/components/constellation/lib.rs
@@ -11,6 +11,7 @@ mod broadcastchannel;
 mod browsingcontext;
 mod constellation;
 mod constellation_webview;
+mod embedder;
 mod event_loop;
 mod logging;
 mod pipeline;

--- a/components/servo/servo.rs
+++ b/components/servo/servo.rs
@@ -659,11 +659,6 @@ impl ServoInner {
                     warn!("Failed to respond to GetScreenMetrics: {error}");
                 }
             },
-            EmbedderMsg::AccessibilityTreeIdChanged(webview_id, tree_id) => {
-                if let Some(webview) = self.get_webview_handle(webview_id) {
-                    webview.notify_accessibility_tree_id(tree_id);
-                }
-            },
             EmbedderMsg::AccessibilityTreeUpdate(webview_id, tree_update) => {
                 if let Some(webview) = self.get_webview_handle(webview_id) {
                     webview
@@ -774,6 +769,11 @@ impl ServoInner {
                     webview
                         .delegate()
                         .notify_media_session_event(webview, media_session_event);
+                }
+            },
+            ConstellationToEmbedderMsg::AccessibilityTreeIdChanged(webview_id, tree_id) => {
+                if let Some(webview) = self.get_webview_handle(webview_id) {
+                    webview.notify_accessibility_tree_id(tree_id);
                 }
             },
         }

--- a/components/servo/servo.rs
+++ b/components/servo/servo.rs
@@ -8,7 +8,6 @@ use std::rc::{Rc, Weak};
 use std::sync::Arc;
 use std::time::Duration;
 
-use constellation::embedder::ConstellationToEmbedderMsg;
 use crossbeam_channel::{Receiver, Sender, unbounded};
 pub use embedder_traits::*;
 use env_logger::Builder as EnvLoggerBuilder;
@@ -61,8 +60,8 @@ use servo_config::{opts, pref, prefs};
 ))]
 use servo_constellation::content_process_sandbox_profile;
 use servo_constellation::{
-    Constellation, FromEmbedderLogger, FromScriptLogger, InitialConstellationState,
-    NewScriptEventLoopProcessInfo, UnprivilegedContent,
+    Constellation, ConstellationToEmbedderMsg, FromEmbedderLogger, FromScriptLogger,
+    InitialConstellationState, NewScriptEventLoopProcessInfo, UnprivilegedContent,
 };
 use servo_constellation_traits::{EmbedderToConstellationMessage, ScriptToConstellationSender};
 use servo_geometry::{
@@ -130,6 +129,7 @@ mod media_platform {
     }
 }
 
+#[allow(clippy::enum_variant_names)]
 enum Message {
     FromNet(NetToEmbedderMsg),
     FromConstellation(ConstellationToEmbedderMsg),
@@ -964,7 +964,6 @@ impl Servo {
                 time_profiler_chan.clone(),
                 mem_profiler_chan.clone(),
                 net_embedder_proxy,
-                constellation_embedder_proxy,
                 opts.config_dir.clone(),
                 opts.certificate_path.clone(),
                 opts.ignore_certificate_errors,
@@ -977,6 +976,7 @@ impl Servo {
         create_constellation(
             embedder_to_constellation_receiver,
             &paint.borrow(),
+            embedder_proxy,
             constellation_embedder_proxy,
             paint_proxy,
             time_profiler_chan,
@@ -1175,7 +1175,8 @@ fn create_paint_channel(
 fn create_constellation(
     embedder_to_constellation_receiver: Receiver<EmbedderToConstellationMessage>,
     paint: &Paint,
-    embedder_proxy: GenericEmbedderProxy<ConstellationToEmbedderMsg>,
+    embedder_proxy: EmbedderProxy,
+    constellation_to_embedder_proxy: GenericEmbedderProxy<ConstellationToEmbedderMsg>,
     paint_proxy: PaintProxy,
     time_profiler_chan: time::ProfilerChan,
     mem_profiler_chan: mem::ProfilerChan,
@@ -1207,6 +1208,7 @@ fn create_constellation(
     let initial_state = InitialConstellationState {
         paint_proxy,
         embedder_proxy,
+        constellation_to_embedder_proxy,
         devtools_sender,
         #[cfg(feature = "bluetooth")]
         bluetooth_thread,

--- a/components/servo/servo.rs
+++ b/components/servo/servo.rs
@@ -382,7 +382,6 @@ impl ServoInner {
 
     fn handle_embedder_message(&self, message: EmbedderMsg) {
         match message {
-            EmbedderMsg::ShutdownComplete => self.finish_shutting_down(),
             EmbedderMsg::Status(webview_id, status_text) => {
                 if let Some(webview) = self.get_webview_handle(webview_id) {
                     webview.set_status_text(status_text);
@@ -413,17 +412,6 @@ impl ServoInner {
                     );
                 }
             },
-            EmbedderMsg::AllowNavigationRequest(webview_id, pipeline_id, servo_url) => {
-                if let Some(webview) = self.get_webview_handle(webview_id) {
-                    let request = NavigationRequest {
-                        url: servo_url.into_url(),
-                        pipeline_id,
-                        constellation_proxy: self.constellation_proxy.clone(),
-                        response_sent: false,
-                    };
-                    webview.delegate().request_navigation(webview, request);
-                }
-            },
             EmbedderMsg::AllowProtocolHandlerRequest(
                 webview_id,
                 registration_update,
@@ -452,33 +440,6 @@ impl ServoInner {
                     );
                 }
             },
-            EmbedderMsg::AllowOpeningWebView(webview_id, response_sender) => {
-                if let Some(webview) = self.get_webview_handle(webview_id) {
-                    webview.request_create_new(response_sender);
-                }
-            },
-            EmbedderMsg::WebViewClosed(webview_id) => {
-                if let Some(webview) = self.get_webview_handle(webview_id) {
-                    webview.delegate().notify_closed(webview);
-                }
-            },
-            EmbedderMsg::WebViewFocused(webview_id, focus_result) => {
-                if focus_result {
-                    for id in self.webviews.borrow().keys() {
-                        if let Some(webview) = self.get_webview_handle(*id) {
-                            let focused = webview.id() == webview_id;
-                            webview.set_focused(focused);
-                        }
-                    }
-                }
-            },
-            EmbedderMsg::WebViewBlurred => {
-                for id in self.webviews.borrow().keys() {
-                    if let Some(webview) = self.get_webview_handle(*id) {
-                        webview.set_focused(false);
-                    }
-                }
-            },
             EmbedderMsg::AllowUnload(webview_id, response_sender) => {
                 if let Some(webview) = self.get_webview_handle(webview_id) {
                     let request = AllowOrDenyRequest::new(
@@ -488,11 +449,6 @@ impl ServoInner {
                     );
                     webview.delegate().request_unload(webview, request);
                 }
-            },
-            EmbedderMsg::FinishJavaScriptEvaluation(evaluation_id, result) => {
-                self.javascript_evaluator
-                    .borrow_mut()
-                    .finish_evaluation(evaluation_id, result);
             },
             EmbedderMsg::InputEventsHandled(webview_id, event_outcomes) => {
                 let webview = self.get_webview_handle(webview_id);
@@ -547,30 +503,11 @@ impl ServoInner {
                     webview.set_load_status(load_status);
                 }
             },
-            EmbedderMsg::HistoryTraversalComplete(webview_id, traversal_id) => {
-                if let Some(webview) = self.get_webview_handle(webview_id) {
-                    webview
-                        .delegate()
-                        .notify_traversal_complete(webview.clone(), traversal_id);
-                }
-            },
-            EmbedderMsg::HistoryChanged(webview_id, new_back_forward_list, current_list_index) => {
-                if let Some(webview) = self.get_webview_handle(webview_id) {
-                    webview.set_history(new_back_forward_list, current_list_index);
-                }
-            },
             EmbedderMsg::NotifyFullscreenStateChanged(webview_id, fullscreen) => {
                 if let Some(webview) = self.get_webview_handle(webview_id) {
                     webview
                         .delegate()
                         .notify_fullscreen_state_changed(webview, fullscreen);
-                }
-            },
-            EmbedderMsg::Panic(webview_id, reason, backtrace) => {
-                if let Some(webview) = self.get_webview_handle(webview_id) {
-                    webview
-                        .delegate()
-                        .notify_crashed(webview, reason, backtrace);
                 }
             },
             EmbedderMsg::GetSelectedBluetoothDevice(webview_id, items, response_sender) => {
@@ -594,14 +531,6 @@ impl ServoInner {
                     webview
                         .delegate()
                         .request_permission(webview, permission_request);
-                }
-            },
-            EmbedderMsg::ReportProfile(_items) => {},
-            EmbedderMsg::MediaSessionEvent(webview_id, media_session_event) => {
-                if let Some(webview) = self.get_webview_handle(webview_id) {
-                    webview
-                        .delegate()
-                        .notify_media_session_event(webview, media_session_event);
                 }
             },
             EmbedderMsg::OnDevtoolsStarted(port, token) => match port {

--- a/components/servo/servo.rs
+++ b/components/servo/servo.rs
@@ -8,6 +8,7 @@ use std::rc::{Rc, Weak};
 use std::sync::Arc;
 use std::time::Duration;
 
+use constellation::embedder::ConstellationToEmbedderMsg;
 use crossbeam_channel::{Receiver, Sender, unbounded};
 pub use embedder_traits::*;
 use env_logger::Builder as EnvLoggerBuilder;
@@ -131,6 +132,7 @@ mod media_platform {
 
 enum Message {
     FromNet(NetToEmbedderMsg),
+    FromConstellation(ConstellationToEmbedderMsg),
     FromUnknown(EmbedderMsg),
 }
 
@@ -145,6 +147,7 @@ struct ServoInner {
     constellation_proxy: ConstellationProxy,
     embedder_receiver: Receiver<EmbedderMsg>,
     net_embedder_receiver: Receiver<NetToEmbedderMsg>,
+    constellation_embedder_receiver: Receiver<ConstellationToEmbedderMsg>,
     network_manager: Rc<RefCell<NetworkManager>>,
     site_data_manager: Rc<RefCell<SiteDataManager>>,
     /// A struct that tracks ongoing JavaScript evaluations and is responsible for
@@ -202,6 +205,9 @@ impl ServoInner {
             match message {
                 Message::FromUnknown(message) => self.handle_embedder_message(message),
                 Message::FromNet(message) => self.handle_net_embedder_message(message),
+                Message::FromConstellation(message) => {
+                    self.handle_constellation_embedder_message(message)
+                },
             }
             if self.shutdown_state.get() == ShutdownState::FinishedShuttingDown {
                 break;
@@ -250,6 +256,8 @@ impl ServoInner {
         let mut select = crossbeam_channel::Select::new();
         let embedder_receiver_index = select.recv(&self.embedder_receiver);
         let net_embedder_receiver_index = select.recv(&self.net_embedder_receiver);
+        let constellation_embedder_receiver_index =
+            select.recv(&self.constellation_embedder_receiver);
         let Ok(operation) = select.try_select() else {
             return None;
         };
@@ -264,6 +272,11 @@ impl ServoInner {
                 return None;
             };
             Some(Message::FromNet(message))
+        } else if index == constellation_embedder_receiver_index {
+            let Ok(message) = operation.recv(&self.constellation_embedder_receiver) else {
+                return None;
+            };
+            Some(Message::FromConstellation(message))
         } else {
             log::error!("No select operation registered for {index:?}");
             None
@@ -731,6 +744,111 @@ impl ServoInner {
             },
         }
     }
+
+    fn handle_constellation_embedder_message(&self, message: ConstellationToEmbedderMsg) {
+        match message {
+            ConstellationToEmbedderMsg::ShutdownComplete => self.finish_shutting_down(),
+            ConstellationToEmbedderMsg::AllowNavigationRequest(
+                webview_id,
+                pipeline_id,
+                servo_url,
+            ) => {
+                if let Some(webview) = self.get_webview_handle(webview_id) {
+                    let request = NavigationRequest {
+                        url: servo_url.into_url(),
+                        pipeline_id,
+                        constellation_proxy: self.constellation_proxy.clone(),
+                        response_sent: false,
+                    };
+                    webview.delegate().request_navigation(webview, request);
+                }
+            },
+            ConstellationToEmbedderMsg::AllowOpeningWebView(webview_id, response_sender) => {
+                if let Some(webview) = self.get_webview_handle(webview_id) {
+                    webview.request_create_new(response_sender);
+                }
+            },
+            ConstellationToEmbedderMsg::WebViewClosed(webview_id) => {
+                if let Some(webview) = self.get_webview_handle(webview_id) {
+                    webview.delegate().notify_closed(webview);
+                }
+            },
+            ConstellationToEmbedderMsg::WebViewFocused(webview_id, focus_result) => {
+                if focus_result {
+                    for id in self.webviews.borrow().keys() {
+                        if let Some(webview) = self.get_webview_handle(*id) {
+                            let focused = webview.id() == webview_id;
+                            webview.set_focused(focused);
+                        }
+                    }
+                }
+            },
+            ConstellationToEmbedderMsg::WebViewBlurred => {
+                for id in self.webviews.borrow().keys() {
+                    if let Some(webview) = self.get_webview_handle(*id) {
+                        webview.set_focused(false);
+                    }
+                }
+            },
+            ConstellationToEmbedderMsg::FinishJavaScriptEvaluation(evaluation_id, result) => {
+                self.javascript_evaluator
+                    .borrow_mut()
+                    .finish_evaluation(evaluation_id, result);
+            },
+            ConstellationToEmbedderMsg::InputEventsHandled(webview_id, event_outcomes) => {
+                let webview = self.get_webview_handle(webview_id);
+                for InputEventOutcome {
+                    id: input_event_id,
+                    result,
+                } in event_outcomes
+                {
+                    self.paint.borrow_mut().notify_input_event_handled(
+                        webview_id,
+                        input_event_id,
+                        result,
+                    );
+                    if let Some(ref webview) = webview {
+                        webview.delegate().notify_input_event_handled(
+                            webview.clone(),
+                            input_event_id,
+                            result,
+                        );
+                    }
+                }
+            },
+            ConstellationToEmbedderMsg::HistoryTraversalComplete(webview_id, traversal_id) => {
+                if let Some(webview) = self.get_webview_handle(webview_id) {
+                    webview
+                        .delegate()
+                        .notify_traversal_complete(webview.clone(), traversal_id);
+                }
+            },
+            ConstellationToEmbedderMsg::HistoryChanged(
+                webview_id,
+                new_back_forward_list,
+                current_list_index,
+            ) => {
+                if let Some(webview) = self.get_webview_handle(webview_id) {
+                    webview.set_history(new_back_forward_list, current_list_index);
+                }
+            },
+            ConstellationToEmbedderMsg::Panic(webview_id, reason, backtrace) => {
+                if let Some(webview) = self.get_webview_handle(webview_id) {
+                    webview
+                        .delegate()
+                        .notify_crashed(webview, reason, backtrace);
+                }
+            },
+            ConstellationToEmbedderMsg::ReportProfile(_items) => {},
+            ConstellationToEmbedderMsg::MediaSessionEvent(webview_id, media_session_event) => {
+                if let Some(webview) = self.get_webview_handle(webview_id) {
+                    webview
+                        .delegate()
+                        .notify_media_session_event(webview, media_session_event);
+                }
+            },
+        }
+    }
 }
 
 impl Drop for ServoInner {
@@ -794,6 +912,8 @@ impl Servo {
         let (embedder_proxy, embedder_receiver) = create_embedder_channel(event_loop_waker.clone());
         let (net_embedder_proxy, net_embedder_receiver) =
             create_generic_embedder_channel::<NetToEmbedderMsg>(event_loop_waker.clone());
+        let (constellation_embedder_proxy, constellation_embedder_receiver) =
+            create_generic_embedder_channel::<ConstellationToEmbedderMsg>(event_loop_waker.clone());
         let time_profiler_chan = profile_time::Profiler::create(
             &opts.time_profiling,
             opts.time_profiler_trace_path.clone(),
@@ -844,6 +964,7 @@ impl Servo {
                 time_profiler_chan.clone(),
                 mem_profiler_chan.clone(),
                 net_embedder_proxy,
+                constellation_embedder_proxy,
                 opts.config_dir.clone(),
                 opts.certificate_path.clone(),
                 opts.ignore_certificate_errors,
@@ -856,7 +977,7 @@ impl Servo {
         create_constellation(
             embedder_to_constellation_receiver,
             &paint.borrow(),
-            embedder_proxy,
+            constellation_embedder_proxy,
             paint_proxy,
             time_profiler_chan,
             mem_profiler_chan,
@@ -892,6 +1013,7 @@ impl Servo {
             constellation_proxy,
             embedder_receiver,
             net_embedder_receiver,
+            constellation_embedder_receiver,
             shutdown_state,
             webviews: Default::default(),
             servo_errors: ServoErrorChannel::default(),
@@ -1053,7 +1175,7 @@ fn create_paint_channel(
 fn create_constellation(
     embedder_to_constellation_receiver: Receiver<EmbedderToConstellationMessage>,
     paint: &Paint,
-    embedder_proxy: EmbedderProxy,
+    embedder_proxy: GenericEmbedderProxy<ConstellationToEmbedderMsg>,
     paint_proxy: PaintProxy,
     time_profiler_chan: time::ProfilerChan,
     mem_profiler_chan: mem::ProfilerChan,

--- a/components/shared/embedder/lib.rs
+++ b/components/shared/embedder/lib.rs
@@ -446,23 +446,12 @@ pub enum EmbedderMsg {
     /// or `prompt()`). Since their messages are controlled by web content, they should be presented to the user in a
     /// way that makes them impossible to mistake for browser UI.
     ShowSimpleDialog(WebViewId, SimpleDialogRequest),
-    /// Whether or not to allow a pipeline to load a url.
-    AllowNavigationRequest(WebViewId, PipelineId, ServoUrl),
     /// Request to (un)register protocol handler by page content.
     AllowProtocolHandlerRequest(
         WebViewId,
         ProtocolHandlerUpdateRegistration,
         GenericSender<AllowOrDeny>,
     ),
-    /// Whether or not to allow script to open a new tab/browser
-    AllowOpeningWebView(WebViewId, GenericSender<Option<NewWebViewDetails>>),
-    /// A webview was destroyed.
-    WebViewClosed(WebViewId),
-    /// A webview potentially gained focus for keyboard events.
-    /// If the boolean value is false, the webiew could not be focused.
-    WebViewFocused(WebViewId, bool),
-    /// All webviews lost focus for keyboard events.
-    WebViewBlurred,
     /// Wether or not to unload a document
     AllowUnload(WebViewId, GenericSender<AllowOrDeny>),
     /// Inform embedder to clear the clipboard
@@ -475,10 +464,6 @@ pub enum EmbedderMsg {
     SetCursor(WebViewId, Cursor),
     /// A favicon was detected
     NewFavicon(WebViewId, Image),
-    /// The history state has changed.
-    HistoryChanged(WebViewId, Vec<ServoUrl>, usize),
-    /// A history traversal operation completed.
-    HistoryTraversalComplete(WebViewId, TraversalId),
     /// Get the device independent window rectangle.
     GetWindowRect(WebViewId, GenericSender<DeviceIndependentIntRect>),
     /// Get the device independent screen size and available size.
@@ -487,8 +472,6 @@ pub enum EmbedderMsg {
     NotifyFullscreenStateChanged(WebViewId, bool),
     /// The [`LoadStatus`] of the Given `WebView` has changed.
     NotifyLoadStatusChanged(WebViewId, LoadStatus),
-    /// A pipeline panicked. First string is the reason, second one is the backtrace.
-    Panic(WebViewId, String, Option<String>),
     /// Open dialog to select bluetooth device.
     GetSelectedBluetoothDevice(
         WebViewId,
@@ -497,11 +480,6 @@ pub enum EmbedderMsg {
     ),
     /// Open interface to request permission specified by prompt.
     PromptPermission(WebViewId, PermissionFeature, GenericSender<AllowOrDeny>),
-    /// Report a complete sampled profile
-    ReportProfile(Vec<u8>),
-    /// Notifies the embedder about media session events
-    /// (i.e. when there is metadata for the active media session, playback state changes...).
-    MediaSessionEvent(WebViewId, MediaSessionEvent),
     /// Report the status of Devtools Server with a token that can be used to bypass the permission prompt.
     OnDevtoolsStarted(Result<u16, ()>, String),
     /// Ask the user to allow a devtools client to connect.
@@ -517,10 +495,6 @@ pub enum EmbedderMsg {
     /// Request to stop a haptic effect on a connected gamepad.
     #[cfg(feature = "gamepad")]
     StopGamepadHapticEffect(WebViewId, usize, GenericCallback<bool>),
-    /// Informs the embedder that the constellation has completed shutdown.
-    /// Required because the constellation can have pending calls to make
-    /// (e.g. SetFrameTree) at the time that we send it an ExitMsg.
-    ShutdownComplete,
     /// Request to display a notification.
     ShowNotification(Option<WebViewId>, Notification),
     /// Let the embedder process a DOM Console API message.
@@ -530,12 +504,6 @@ pub enum EmbedderMsg {
     ShowEmbedderControl(EmbedderControlId, DeviceIntRect, EmbedderControlRequest),
     /// Request to the embedder to hide a user interface control.
     HideEmbedderControl(EmbedderControlId),
-    /// Inform the embedding layer that a JavaScript evaluation has
-    /// finished with the given result.
-    FinishJavaScriptEvaluation(
-        JavaScriptEvaluationId,
-        Result<JSValue, JavaScriptEvaluationError>,
-    ),
     /// Inform the embedding layer that a particular `InputEvent` was handled by Servo
     /// and the embedder can continue processing it, if necessary.
     InputEventsHandled(WebViewId, Vec<InputEventOutcome>),

--- a/components/shared/embedder/lib.rs
+++ b/components/shared/embedder/lib.rs
@@ -21,7 +21,7 @@ use std::hash::Hash;
 use std::ops::Range;
 use std::sync::Arc;
 
-use accesskit::{TreeId, TreeUpdate};
+use accesskit::TreeUpdate;
 use crossbeam_channel::Sender;
 use euclid::{Box2D, Point2D, Scale, Size2D, Vector2D};
 use http::{HeaderMap, Method, StatusCode};
@@ -507,9 +507,6 @@ pub enum EmbedderMsg {
     /// Inform the embedding layer that a particular `InputEvent` was handled by Servo
     /// and the embedder can continue processing it, if necessary.
     InputEventsHandled(WebViewId, Vec<InputEventOutcome>),
-    /// Notifies the embedder that the AccessKit [`TreeId`] for the top-level document in this
-    /// WebView has been changed (or initially set).
-    AccessibilityTreeIdChanged(WebViewId, TreeId),
     /// Send the embedder an accessibility tree update.
     AccessibilityTreeUpdate(WebViewId, TreeUpdate),
 }


### PR DESCRIPTION
Refactor Constellation module to use GenericEmbedderProxy
- [X] create the new enum in components/<component>
- [X] for each use of EmbedderMsg::<something> in components/<component>, extract that enum variant into the new enum
- [X] replace uses of EmbedderProxy in components/<component> with GenericEmbedderProxy<<component>ToEmbedderMsg>
- [X] create a new instance of the generic embedder proxy in [Servo::new](https://github.com/servo/servo/blob/c023d8edc77104969c71cb8571a045cb346ad05f/components/servo/servo.rs#L755-L756); store the receiver in a new field in Servo and pass the sender to the appropriate code that instantiates the component
- [X] add a new variant to the [Message](https://github.com/servo/servo/blob/c023d8edc77104969c71cb8571a045cb346ad05f/components/servo/servo.rs#L137) enum for the new component enum type
- [X] update [receive_one_message](https://github.com/servo/servo/blob/c023d8edc77104969c71cb8571a045cb346ad05f/components/servo/servo.rs#L224) to use the new receiver and return the new enum variant
- [X] extract the code from [handle_embedder_message](https://github.com/servo/servo/blob/c023d8edc77104969c71cb8571a045cb346ad05f/components/servo/servo.rs#L345) that handles the component-specific variants into a new method

Testing: Just a refactor shouldn't need any testing
Fixes: #42097
