### PR TITLE
script: Pass down &mut JSContext to MediaStream methods

### DIFF
--- a/components/script/dom/media/mediastream.rs
+++ b/components/script/dom/media/mediastream.rs
@@ -3,6 +3,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 use dom_struct::dom_struct;
+use js::context::JSContext;
 use js::rust::HandleObject;
 use servo_media::streams::MediaStreamType;
 use servo_media::streams::registry::MediaStreamId;
@@ -161,8 +162,8 @@ impl MediaStreamMethods<crate::DomTypeHolder> for MediaStream {
     }
 
     /// <https://w3c.github.io/mediacapture-main/#dom-mediastream-clone>
-    fn Clone(&self, can_gc: CanGc) -> DomRoot<MediaStream> {
-        self.clone_with_proto(None, can_gc)
+    fn Clone(&self, cx: &mut JSContext) -> DomRoot<MediaStream> {
+        self.clone_with_proto(None, CanGc::from_cx(cx))
     }
 }
 

--- a/components/script/dom/media/mediastream.rs
+++ b/components/script/dom/media/mediastream.rs
@@ -51,6 +51,14 @@ impl MediaStream {
         )
     }
 
+    fn clone_with_proto(&self, proto: Option<HandleObject>, can_gc: CanGc) -> DomRoot<MediaStream> {
+        let new = MediaStream::new_with_proto(&self.global(), proto, can_gc);
+        for track in &*self.tracks.borrow() {
+            new.add_track(track)
+        }
+        new
+    }
+
     pub(crate) fn new_single(
         global: &GlobalScope,
         id: MediaStreamId,
@@ -164,15 +172,5 @@ impl MediaStreamMethods<crate::DomTypeHolder> for MediaStream {
     /// <https://w3c.github.io/mediacapture-main/#dom-mediastream-clone>
     fn Clone(&self, cx: &mut JSContext) -> DomRoot<MediaStream> {
         self.clone_with_proto(None, CanGc::from_cx(cx))
-    }
-}
-
-impl MediaStream {
-    fn clone_with_proto(&self, proto: Option<HandleObject>, can_gc: CanGc) -> DomRoot<MediaStream> {
-        let new = MediaStream::new_with_proto(&self.global(), proto, can_gc);
-        for track in &*self.tracks.borrow() {
-            new.add_track(track)
-        }
-        new
     }
 }

--- a/components/script_bindings/codegen/Bindings.conf
+++ b/components/script_bindings/codegen/Bindings.conf
@@ -636,7 +636,7 @@ DOMInterfaces = {
 },
 
 'MediaStream': {
-    'canGc': ['Clone'],
+    'cx': ['Clone'],
 },
 
 'MessagePort': {


### PR DESCRIPTION
Move MediaStream methods from CanGc to &mut JSContext.

Testing: Just refactor.
Fixes: Part of #42638
