### PR TITLE
script: Add error messages for PBKDF2, SHA, and SHA-3 WebCrypto operations

### DIFF
--- a/components/script/dom/subtlecrypto/pbkdf2_operation.rs
+++ b/components/script/dom/subtlecrypto/pbkdf2_operation.rs
@@ -26,15 +26,19 @@ pub(crate) fn derive_bits(
 ) -> Result<Vec<u8>, Error> {
     // Step 1. If length is null or is not a multiple of 8, then throw an OperationError.
     let Some(length) = length else {
-        return Err(Error::Operation(None));
+        return Err(Error::Operation(Some("The length parameter is null".into())));
     };
     if length % 8 != 0 {
-        return Err(Error::Operation(None));
+        return Err(Error::Operation(Some(
+            "The length parameter must be a multiple of 8".into(),
+        )));
     };
 
     // Step 2. If the iterations member of normalizedAlgorithm is zero, then throw an OperationError.
     let Ok(iterations) = NonZero::<u32>::try_from(normalized_algorithm.iterations) else {
-        return Err(Error::Operation(None));
+        return Err(Error::Operation(Some(
+            "The iterations member of normalizedAlgorithm is zero".into(),
+        )));
     };
 
     // Step 3. If length is zero, return an empty byte sequence.
@@ -50,7 +54,9 @@ pub(crate) fn derive_bits(
         CryptoAlgorithm::Sha384 => pbkdf2::PBKDF2_HMAC_SHA384,
         CryptoAlgorithm::Sha512 => pbkdf2::PBKDF2_HMAC_SHA512,
         _ => {
-            return Err(Error::NotSupported(None));
+            return Err(Error::NotSupported(Some(
+                "Unsupported hash algorithm for PBKDF2".into(),
+            )));
         },
     };
 
@@ -88,7 +94,9 @@ pub(crate) fn import_key(
 ) -> Result<DomRoot<CryptoKey>, Error> {
     // Step 1. If format is not "raw", throw a NotSupportedError
     if !matches!(format, KeyFormat::Raw | KeyFormat::Raw_secret) {
-        return Err(Error::NotSupported(None));
+        return Err(Error::NotSupported(Some(
+            "PBKDF2 key import only supports the \"raw\" format".into(),
+        )));
     }
 
     // Step 2. If usages contains a value that is not "deriveKey" or "deriveBits", then throw a SyntaxError.
@@ -97,12 +105,17 @@ pub(crate) fn import_key(
         .any(|usage| !matches!(usage, KeyUsage::DeriveKey | KeyUsage::DeriveBits)) ||
         usages.is_empty()
     {
-        return Err(Error::Syntax(None));
+        return Err(Error::Syntax(Some(
+            "Usages contains an entry which is not \"deriveKey\" or \"deriveBits\", or is empty"
+                .into(),
+        )));
     }
 
     // Step 3. If extractable is not false, then throw a SyntaxError.
     if extractable {
-        return Err(Error::Syntax(None));
+        return Err(Error::Syntax(Some(
+            "PBKDF2 keys must not be extractable".into(),
+        )));
     }
 
     // Step 4. Let key be a new CryptoKey representing keyData.

--- a/components/script/dom/subtlecrypto/sha3_operation.rs
+++ b/components/script/dom/subtlecrypto/sha3_operation.rs
@@ -27,7 +27,11 @@ pub(crate) fn digest(
         CryptoAlgorithm::Sha3_256 => Sha3_256::new_with_prefix(message).finalize().to_vec(),
         CryptoAlgorithm::Sha3_384 => Sha3_384::new_with_prefix(message).finalize().to_vec(),
         CryptoAlgorithm::Sha3_512 => Sha3_512::new_with_prefix(message).finalize().to_vec(),
-        _ => return Err(Error::NotSupported(None)),
+        _ => {
+            return Err(Error::NotSupported(Some(
+                "Unsupported hash algorithm for SHA-3 digest".into(),
+            )));
+        },
     };
 
     // Step 3. Return result.

--- a/components/script/dom/subtlecrypto/sha_operation.rs
+++ b/components/script/dom/subtlecrypto/sha_operation.rs
@@ -34,7 +34,9 @@ pub(crate) fn digest(
         CryptoAlgorithm::Sha384 => digest::digest(&digest::SHA384, message).as_ref().to_vec(),
         CryptoAlgorithm::Sha512 => digest::digest(&digest::SHA512, message).as_ref().to_vec(),
         _ => {
-            return Err(Error::NotSupported(None));
+            return Err(Error::NotSupported(Some(
+                "Unsupported hash algorithm for SHA digest".into(),
+            )));
         },
     };
 


### PR DESCRIPTION
## Description

Add descriptive error messages to PBKDF2, SHA, and SHA-3 WebCrypto operations, replacing `None` with meaningful messages for better debugging and developer experience.

### Changes

| File | Errors Fixed | Examples |
|------|-------------|---------|
| `pbkdf2_operation.rs` | 7 | "The length parameter is null", "PBKDF2 keys must not be extractable" |
| `sha_operation.rs` | 1 | "Unsupported hash algorithm for SHA digest" |
| `sha3_operation.rs` | 1 | "Unsupported hash algorithm for SHA-3 digest" |

### Error Messages Added

Messages mirror the WebCrypto spec language where step comments exist:
- `Error::Operation(None)` -> `Error::Operation(Some("The length parameter is null".into()))`
- `Error::Operation(None)` -> `Error::Operation(Some("The length parameter must be a multiple of 8".into()))`
- `Error::Operation(None)` -> `Error::Operation(Some("The iterations member of normalizedAlgorithm is zero".into()))`
- `Error::NotSupported(None)` -> `Error::NotSupported(Some("Unsupported hash algorithm for PBKDF2".into()))`
- `Error::NotSupported(None)` -> `Error::NotSupported(Some("PBKDF2 key import only supports the \"raw\" format".into()))`
- `Error::Syntax(None)` -> `Error::Syntax(Some("Usages contains an entry which is not \"deriveKey\" or \"deriveBits\", or is empty".into()))`
- `Error::Syntax(None)` -> `Error::Syntax(Some("PBKDF2 keys must not be extractable".into()))`
- `Error::NotSupported(None)` -> `Error::NotSupported(Some("Unsupported hash algorithm for SHA digest".into()))`
- `Error::NotSupported(None)` -> `Error::NotSupported(Some("Unsupported hash algorithm for SHA-3 digest".into()))`

Part of #40756

### AI Disclosure

This contribution used AI assistance (Claude Code) for codebase exploration and implementation.