### PR TITLE
script: Report CSP violations for child navigations in parent page

### DIFF
--- a/components/script/dom/servoparser/mod.rs
+++ b/components/script/dom/servoparser/mod.rs
@@ -61,7 +61,7 @@ use crate::dom::bindings::settings_stack::is_execution_stack_empty;
 use crate::dom::bindings::str::{DOMString, USVString};
 use crate::dom::characterdata::CharacterData;
 use crate::dom::comment::Comment;
-use crate::dom::csp::{GlobalCspReporting, Violation, parse_csp_list_from_metadata};
+use crate::dom::csp::{Violation, parse_csp_list_from_metadata};
 use crate::dom::customelementregistry::CustomElementReactionStack;
 use crate::dom::document::{Document, DocumentSource, HasBrowsingContext, IsHTMLDocument};
 use crate::dom::documentfragment::DocumentFragment;
@@ -922,6 +922,8 @@ pub(crate) struct ParserContext {
     pushed_entry_index: Option<usize>,
     /// params required in document load algorithms
     navigation_params: NavigationParams,
+    /// To report CSP violations to the global that initiated the navigation
+    parent_info: Option<PipelineId>,
 }
 
 impl ParserContext {
@@ -930,6 +932,7 @@ impl ParserContext {
         pipeline_id: PipelineId,
         url: ServoUrl,
         creation_sandboxing_flag_set: SandboxingFlagSet,
+        parent_info: Option<PipelineId>,
     ) -> ParserContext {
         ParserContext {
             parser: None,
@@ -938,6 +941,7 @@ impl ParserContext {
             webview_id,
             pipeline_id,
             url,
+            parent_info,
             pushed_entry_index: None,
             navigation_params: NavigationParams {
                 policy_container: Default::default(),
@@ -965,6 +969,10 @@ impl ParserContext {
         self.parser
             .as_ref()
             .map(|parser| parser.root().document.as_rooted())
+    }
+
+    pub(crate) fn parent_info(&self) -> Option<PipelineId> {
+        self.parent_info
     }
 
     /// <https://html.spec.whatwg.org/multipage/#creating-a-policy-container-from-a-fetch-response>
@@ -1130,6 +1138,7 @@ impl ParserContext {
         self.initialize_document_object(&parser.document);
         // Step 8. Act as if the user agent had stopped parsing document.
         self.is_synthesized_document = true;
+        parser.last_chunk_received.set(true);
         // Step 3. Populate with html/head/body given document.
         let page = "<html><body></body></html>".into();
         parser.push_string_input_chunk(page);
@@ -1188,7 +1197,7 @@ impl ParserContext {
         process_link_headers(&link_headers, doc, LinkProcessingPhase::Media);
     }
 
-    /// <https://html.spec.whatwg.org/multipage/#read-ua-inline>
+    /// <https://html.spec.whatwg.org/multipage/#navigate-ua-inline>
     fn load_inline_unknown_content(
         &mut self,
         parser: &ServoParser,
@@ -1198,6 +1207,8 @@ impl ParserContext {
         self.is_synthesized_document = true;
         parser.document.mark_as_internal();
         parser.push_string_input_chunk(page);
+        // Step 7. Act as if the user agent had stopped parsing document.
+        parser.last_chunk_received.set(true);
         parser.parse_sync(cx);
     }
 
@@ -1467,7 +1478,7 @@ impl FetchResponseListener for ParserContext {
             Some(parser) => parser.root(),
             None => return,
         };
-        if parser.aborted.get() {
+        if parser.aborted.get() || self.is_synthesized_document {
             return;
         }
 
@@ -1512,15 +1523,8 @@ impl FetchResponseListener for ParserContext {
         }
     }
 
-    fn process_csp_violations(&mut self, _request_id: RequestId, violations: Vec<Violation>) {
-        let parser = match self.parser.as_ref() {
-            Some(parser) => parser.root(),
-            None => return,
-        };
-        let document = &parser.document;
-        let global = &document.global();
-        // TODO(https://github.com/w3c/webappsec-csp/issues/687): Update after spec is resolved
-        global.report_csp_violations(violations, None, None);
+    fn process_csp_violations(&mut self, _: RequestId, _: Vec<Violation>) {
+        unreachable!("Script_thread should handle reporting violations for parser contexts");
     }
 }
 

--- a/components/script/script_thread.rs
+++ b/components/script/script_thread.rs
@@ -3816,6 +3816,7 @@ impl ScriptThread {
             incomplete.pipeline_id,
             incomplete.load_data.url.clone(),
             incomplete.load_data.creation_sandboxing_flag_set,
+            incomplete.parent_info,
         );
         self.incomplete_parser_contexts
             .0
@@ -3937,9 +3938,22 @@ impl ScriptThread {
         }
     }
 
-    fn handle_csp_violations(&self, id: PipelineId, _: RequestId, violations: Vec<Violation>) {
-        if let Some(global) = self.documents.borrow().find_global(id) {
-            // TODO(https://github.com/w3c/webappsec-csp/issues/687): Update after spec is resolved
+    fn handle_csp_violations(
+        &self,
+        pipeline_id: PipelineId,
+        _request_id: RequestId,
+        violations: Vec<Violation>,
+    ) {
+        let mut incomplete_parser_contexts = self.incomplete_parser_contexts.0.borrow_mut();
+        let parser = incomplete_parser_contexts
+            .iter_mut()
+            .find(|&&mut (parser_pipeline_id, _)| parser_pipeline_id == pipeline_id);
+        let Some(&mut (_, ref mut ctxt)) = parser else {
+            return;
+        };
+        // We need to report violations for navigations in iframes in the parent page
+        let pipeline_id = ctxt.parent_info().unwrap_or(pipeline_id);
+        if let Some(global) = self.documents.borrow().find_global(pipeline_id) {
             global.report_csp_violations(violations, None, None);
         }
     }
@@ -4010,6 +4024,7 @@ impl ScriptThread {
             incomplete.pipeline_id,
             url.clone(),
             incomplete.load_data.creation_sandboxing_flag_set,
+            incomplete.parent_info,
         );
 
         let mut meta = Metadata::default(url);
@@ -4063,11 +4078,17 @@ impl ScriptThread {
 
         let webview_id = incomplete.webview_id;
         let pipeline_id = incomplete.pipeline_id;
+        let parent_info = incomplete.parent_info;
         let about_base_url = incomplete.load_data.about_base_url.clone();
         self.incomplete_loads.borrow_mut().push(incomplete);
 
-        let mut context =
-            ParserContext::new(webview_id, pipeline_id, url, creation_sandboxing_flag_set);
+        let mut context = ParserContext::new(
+            webview_id,
+            pipeline_id,
+            url,
+            creation_sandboxing_flag_set,
+            parent_info,
+        );
         let dummy_request_id = RequestId::default();
 
         context.process_response(cx, dummy_request_id, Ok(FetchMetadata::Unfiltered(meta)));

--- a/tests/wpt/meta/content-security-policy/child-src/child-src-blocked.sub.html.ini
+++ b/tests/wpt/meta/content-security-policy/child-src/child-src-blocked.sub.html.ini
@@ -1,3 +1,0 @@
-[child-src-blocked.sub.html]
-  [Expecting logs: ["PASS IFrame #1 generated a load event.", "violated-directive=frame-src"\]]
-    expected: FAIL

--- a/tests/wpt/meta/content-security-policy/child-src/child-src-conflicting-frame-src.sub.html.ini
+++ b/tests/wpt/meta/content-security-policy/child-src/child-src-conflicting-frame-src.sub.html.ini
@@ -1,3 +1,0 @@
-[child-src-conflicting-frame-src.sub.html]
-  [Expecting logs: ["PASS IFrame #1 generated a load event.", "violated-directive=frame-src"\]]
-    expected: FAIL

--- a/tests/wpt/meta/content-security-policy/child-src/child-src-redirect-blocked.sub.html.ini
+++ b/tests/wpt/meta/content-security-policy/child-src/child-src-redirect-blocked.sub.html.ini
@@ -1,3 +1,0 @@
-[child-src-redirect-blocked.sub.html]
-  [Expecting logs: ["PASS IFrame #1 generated a load event.", "violated-directive=frame-src"\]]
-    expected: FAIL

--- a/tests/wpt/meta/content-security-policy/frame-src/frame-src-blocked-path-matching.sub.html.ini
+++ b/tests/wpt/meta/content-security-policy/frame-src/frame-src-blocked-path-matching.sub.html.ini
@@ -1,7 +1,6 @@
 [frame-src-blocked-path-matching.sub.html]
-  expected: TIMEOUT
   [Cross-origin frame with other path is blocked]
-    expected: TIMEOUT
+    expected: FAIL
 
   [Cross-origin frame with other path is blocked even after replacing the already loaded URL]
-    expected: TIMEOUT
+    expected: FAIL

--- a/tests/wpt/meta/content-security-policy/frame-src/frame-src-blocked.sub.html.ini
+++ b/tests/wpt/meta/content-security-policy/frame-src/frame-src-blocked.sub.html.ini
@@ -1,3 +1,0 @@
-[frame-src-blocked.sub.html]
-  [Expecting logs: ["PASS IFrame #1 generated a load event.","violated-directive=frame-src"\]]
-    expected: FAIL

--- a/tests/wpt/meta/content-security-policy/frame-src/frame-src-cross-origin-same-document-navigation.window.js.ini
+++ b/tests/wpt/meta/content-security-policy/frame-src/frame-src-cross-origin-same-document-navigation.window.js.ini
@@ -1,4 +1,3 @@
 [frame-src-cross-origin-same-document-navigation.window.html]
-  expected: TIMEOUT
   [frame-src-cross-origin-same-document-navigation]
-    expected: TIMEOUT
+    expected: FAIL

--- a/tests/wpt/meta/content-security-policy/frame-src/frame-src-same-document.sub.html.ini
+++ b/tests/wpt/meta/content-security-policy/frame-src/frame-src-same-document.sub.html.ini
@@ -1,4 +1,0 @@
-[frame-src-same-document.sub.html]
-  expected: TIMEOUT
-  [Same-document navigation in an iframe blocked by CSP frame-src]
-    expected: TIMEOUT

--- a/tests/wpt/meta/content-security-policy/generic/policy-inherited-correctly-by-plznavigate.html.ini
+++ b/tests/wpt/meta/content-security-policy/generic/policy-inherited-correctly-by-plznavigate.html.ini
@@ -1,7 +1,2 @@
 [policy-inherited-correctly-by-plznavigate.html]
   expected: ERROR
-  [iframe still inherits correct CSP]
-    expected: NOTRUN
-
-  [Violation report status OK.]
-    expected: FAIL

--- a/tests/wpt/meta/content-security-policy/inheritance/frame-src-javascript-url.html.ini
+++ b/tests/wpt/meta/content-security-policy/inheritance/frame-src-javascript-url.html.ini
@@ -1,4 +1,0 @@
-[frame-src-javascript-url.html]
-  expected: TIMEOUT
-  [<iframe src='javascript:...'>'s inherits policy (dynamically inserted <iframe> is blocked)]
-    expected: TIMEOUT

--- a/tests/wpt/meta/content-security-policy/reporting-api/reporting-api-works-on-frame-src.https.sub.html.ini
+++ b/tests/wpt/meta/content-security-policy/reporting-api/reporting-api-works-on-frame-src.https.sub.html.ini
@@ -1,7 +1,0 @@
-[reporting-api-works-on-frame-src.https.sub.html]
-  expected: TIMEOUT
-  [Event is fired]
-    expected: TIMEOUT
-
-  [Violation report status OK.]
-    expected: FAIL

--- a/tests/wpt/meta/content-security-policy/reporting/report-only-cross-origin-frame.sub.html.ini
+++ b/tests/wpt/meta/content-security-policy/reporting/report-only-cross-origin-frame.sub.html.ini
@@ -1,7 +1,3 @@
 [report-only-cross-origin-frame.sub.html]
-  expected: TIMEOUT
   [The securitypolicyviolation is triggered.]
-    expected: NOTRUN
-
-  [Violation report status OK.]
     expected: FAIL

--- a/tests/wpt/meta/content-security-policy/securitypolicyviolation/upgrade-insecure-requests-reporting.https.html.ini
+++ b/tests/wpt/meta/content-security-policy/securitypolicyviolation/upgrade-insecure-requests-reporting.https.html.ini
@@ -1,7 +1,4 @@
 [upgrade-insecure-requests-reporting.https.html]
   expected: TIMEOUT
-  [Upgraded iframe is reported]
-    expected: TIMEOUT
-
   [Navigated iframe is upgraded and reported]
     expected: TIMEOUT


### PR DESCRIPTION
There were two issues here:
1. We weren't firing the `load` event when we would show an error page because of a CSP failure. This is to avoid web pages knowing wheter a page has failed because of CSP.
2. We were reporting the violations in the wrong global. We shouldn't fire these in the global of the child, but instead in the parent.