### PR TITLE
layout: Combine some common text segment data into `FontAndScriptInfo`

### DIFF
--- a/components/layout/flow/inline/line.rs
+++ b/components/layout/flow/inline/line.rs
@@ -7,7 +7,7 @@ use std::sync::Arc;
 
 use app_units::Au;
 use bitflags::bitflags;
-use fonts::{FontMetrics, GlyphStore};
+use fonts::GlyphStore;
 use itertools::Either;
 use layout_api::wrapper_traits::SharedSelection;
 use malloc_size_of_derive::MallocSizeOf;
@@ -19,11 +19,11 @@ use style::values::generics::box_::BaselineShiftKeyword;
 use style::values::specified::align::AlignFlags;
 use style::values::specified::box_::DisplayOutside;
 use unicode_bidi::{BidiInfo, Level};
-use webrender_api::FontInstanceKey;
 
 use super::inline_box::{InlineBoxContainerState, InlineBoxIdentifier, InlineBoxTreePathToken};
 use super::{InlineFormattingContextLayout, LineBlockSizes, SharedInlineStyles, line_height};
 use crate::cell::ArcRefCell;
+use crate::flow::inline::text_run::FontAndScriptInfo;
 use crate::fragment_tree::{BaseFragment, BaseFragmentInfo, BoxFragment, Fragment, TextFragment};
 use crate::geom::{
     LogicalRect, LogicalVec2, PhysicalRect, ToLogical, ToLogicalWithContainingBlock,
@@ -218,7 +218,7 @@ impl LineItemLayout<'_, '_> {
             .iter()
             .map(|item| {
                 let level = match item {
-                    LineItem::TextRun(_, text_run) => text_run.bidi_level,
+                    LineItem::TextRun(_, text_run) => text_run.info.bidi_level,
                     // TODO: This level needs either to be last_level, or if there were
                     // unicode characters inserted for the inline box, we need to get the
                     // level from them.
@@ -558,19 +558,25 @@ impl LineItemLayout<'_, '_> {
         // The block start of the TextRun is often zero (meaning it has the same font metrics as the
         // inline box's strut), but for children of the inline formatting context root or for
         // fallback fonts that use baseline relative alignment, it might be different.
+        let font_metrics = &text_item.info.font.metrics;
         let start_corner = LogicalVec2 {
             inline: self.current_state.inline_advance,
             block: self.current_state.baseline_offset -
-                text_item.font_metrics.ascent -
+                font_metrics.ascent -
                 self.current_state.parent_offset.block,
         };
         let content_rect = LogicalRect {
             start_corner,
             size: LogicalVec2 {
-                block: text_item.font_metrics.line_gap,
+                block: font_metrics.line_gap,
                 inline: inline_advance,
             },
         };
+
+        let font_key = text_item.info.font.key(
+            self.layout.layout_context.painter_id,
+            &self.layout.layout_context.font_context,
+        );
 
         self.current_state.inline_advance += inline_advance;
         self.current_state.fragments.push((
@@ -581,8 +587,8 @@ impl LineItemLayout<'_, '_> {
                     PhysicalRect::zero(),
                 ),
                 selected_style: text_item.inline_styles.selected.clone(),
-                font_metrics: text_item.font_metrics,
-                font_key: text_item.font_key,
+                font_metrics: font_metrics.clone(),
+                font_key,
                 glyphs: text_item.text,
                 justification_adjustment: self.justification_adjustment,
                 offsets: text_item.offsets,
@@ -813,13 +819,10 @@ pub(crate) struct TextRunOffsets {
 }
 
 pub(super) struct TextRunLineItem {
+    pub info: Arc<FontAndScriptInfo>,
     pub base_fragment_info: BaseFragmentInfo,
     pub inline_styles: SharedInlineStyles,
     pub text: Vec<std::sync::Arc<GlyphStore>>,
-    pub font_metrics: Arc<FontMetrics>,
-    pub font_key: FontInstanceKey,
-    /// The BiDi level of this [`TextRunLineItem`] to enable reordering.
-    pub bidi_level: Level,
     /// When necessary, this field store the [`TextRunOffsets`] for a particular
     /// [`TextRunLineItem`]. This is currently only used inside of text inputs.
     pub offsets: Option<Box<TextRunOffsets>>,
@@ -889,14 +892,13 @@ impl TextRunLineItem {
 
     pub(crate) fn merge_if_possible(
         &mut self,
-        new_font_key: FontInstanceKey,
-        new_bidi_level: Level,
+        new_info: &Arc<FontAndScriptInfo>,
         new_glyph_store: &Arc<GlyphStore>,
         new_offsets: &Option<TextRunOffsets>,
         new_inline_styles: &SharedInlineStyles,
     ) -> bool {
-        if self.font_key != new_font_key ||
-            self.bidi_level != new_bidi_level ||
+        if !Arc::ptr_eq(&self.info.font, &new_info.font) ||
+            self.info.bidi_level != new_info.bidi_level ||
             !self.inline_styles.ptr_eq(new_inline_styles)
         {
             return false;

--- a/components/layout/flow/inline/mod.rs
+++ b/components/layout/flow/inline/mod.rs
@@ -82,7 +82,7 @@ use std::sync::Arc;
 use app_units::{Au, MAX_AU};
 use bitflags::bitflags;
 use construct::InlineFormattingContextBuilder;
-use fonts::{FontMetrics, FontRef, GlyphStore};
+use fonts::{FontMetrics, GlyphStore};
 use icu_segmenter::{LineBreakOptions, LineBreakStrictness, LineBreakWordOption};
 use inline_box::{InlineBox, InlineBoxContainerState, InlineBoxIdentifier, InlineBoxes};
 use layout_api::wrapper_traits::SharedSelection;
@@ -123,6 +123,7 @@ use crate::dom::WeakLayoutBox;
 use crate::dom_traversal::NodeAndStyleInfo;
 use crate::flow::float::{FloatBox, SequentialLayoutState};
 use crate::flow::inline::line::TextRunOffsets;
+use crate::flow::inline::text_run::FontAndScriptInfo;
 use crate::flow::{
     BlockLevelBox, CollapsibleWithParentStartMargin, FloatSide, PlacementState,
     compute_inline_content_sizes_for_block_level_boxes, layout_block_level_child,
@@ -1531,8 +1532,7 @@ impl InlineFormattingContextLayout<'_> {
         &mut self,
         glyph_store: Arc<GlyphStore>,
         text_run: &TextRun,
-        font: &FontRef,
-        bidi_level: Level,
+        info: &Arc<FontAndScriptInfo>,
         offsets: Option<TextRunOffsets>,
     ) {
         let inline_advance = glyph_store.total_advance();
@@ -1541,12 +1541,6 @@ impl InlineFormattingContextLayout<'_> {
         } else {
             SegmentContentFlags::empty()
         };
-
-        let font_metrics = &font.metrics;
-        let font_key = font.key(
-            self.layout_context.painter_id,
-            &self.layout_context.font_context,
-        );
 
         let mut block_contribution = LineBlockSizes::zero();
         let quirks_mode = self.layout_context.style_context.quirks_mode() != QuirksMode::NoQuirks;
@@ -1561,10 +1555,11 @@ impl InlineFormattingContextLayout<'_> {
         // If the metrics of this font don't match the default font, we are likely using another
         // font from the font list or a fallback and should incorporate its block size into the block
         // size of the container.
+        let font_metrics = &info.font.metrics;
         if self
             .current_inline_container_state()
             .font_metrics
-            .block_metrics_meaningfully_differ(&font.metrics)
+            .block_metrics_meaningfully_differ(font_metrics)
         {
             // TODO(mrobinson): This value should probably be cached somewhere.
             let container_state = self.current_inline_container_state();
@@ -1589,8 +1584,7 @@ impl InlineFormattingContextLayout<'_> {
         {
             if *inline_box_identifier == current_inline_box_identifier &&
                 line_item.merge_if_possible(
-                    font_key,
-                    bidi_level,
+                    info,
                     &glyph_store,
                     &offsets,
                     &text_run.inline_styles,
@@ -1606,9 +1600,7 @@ impl InlineFormattingContextLayout<'_> {
                 text: vec![glyph_store],
                 base_fragment_info: text_run.base_fragment_info,
                 inline_styles: text_run.inline_styles.clone(),
-                font_metrics: font_metrics.clone(),
-                font_key,
-                bidi_level,
+                info: info.clone(),
                 offsets: offsets.map(Box::new),
                 is_empty_for_text_cursor: false,
             },
@@ -1621,19 +1613,12 @@ impl InlineFormattingContextLayout<'_> {
     fn possibly_push_empty_text_run_to_unbreakable_segment(
         &mut self,
         text_run: &TextRun,
-        font: &FontRef,
-        bidi_level: Level,
+        info: &Arc<FontAndScriptInfo>,
         offsets: Option<TextRunOffsets>,
     ) {
         if offsets.is_none() || self.current_line_segment.has_content {
             return;
         }
-
-        let font_metrics = &font.metrics;
-        let font_key = font.key(
-            self.layout_context.painter_id,
-            &self.layout_context.font_context,
-        );
 
         self.push_line_item_to_unbreakable_segment(LineItem::TextRun(
             self.current_inline_box_identifier(),
@@ -1641,9 +1626,7 @@ impl InlineFormattingContextLayout<'_> {
                 text: Default::default(),
                 base_fragment_info: text_run.base_fragment_info,
                 inline_styles: text_run.inline_styles.clone(),
-                font_metrics: font_metrics.clone(),
-                font_key,
-                bidi_level,
+                info: info.clone(),
                 offsets: offsets.map(Box::new),
                 is_empty_for_text_cursor: true,
             },

--- a/components/layout/flow/inline/text_run.rs
+++ b/components/layout/flow/inline/text_run.rs
@@ -54,17 +54,21 @@ enum SegmentStartSoftWrapPolicy {
     FollowLinebreaker,
 }
 
+/// A data structure which contains font and language information about a run of text or
+/// glyphs processed during inline layout.
+#[derive(Clone, Debug, MallocSizeOf)]
+pub(crate) struct FontAndScriptInfo {
+    pub font: FontRef,
+    pub script: Script,
+    pub bidi_level: Level,
+}
+
 #[derive(Debug, MallocSizeOf)]
 pub(crate) struct TextRunSegment {
-    /// The index of this font in the parent [`super::InlineFormattingContext`]'s collection of font
-    /// information.
-    pub font: FontRef,
-
-    /// The [`Script`] of this segment.
-    pub script: Script,
-
-    /// The bidi Level of this segment.
-    pub bidi_level: Level,
+    /// Information about the font and language used in this text run. This is produced by
+    /// segmenting the inline formatting context's text content by font, script, and bidi level.
+    #[conditional_malloc_size_of]
+    pub info: Arc<FontAndScriptInfo>,
 
     /// The range of bytes in the parent [`super::InlineFormattingContext`]'s text content.
     pub range: Range<usize>,
@@ -83,16 +87,12 @@ pub(crate) struct TextRunSegment {
 
 impl TextRunSegment {
     fn new(
-        font: FontRef,
-        script: Script,
-        bidi_level: Level,
+        info: Arc<FontAndScriptInfo>,
         start_offset: usize,
         start_character_offset: usize,
     ) -> Self {
         Self {
-            font,
-            script,
-            bidi_level,
+            info,
             range: start_offset..start_offset,
             character_range: start_character_offset..start_character_offset,
             runs: Vec::new(),
@@ -103,35 +103,18 @@ impl TextRunSegment {
     /// Update this segment if the Font and Script are compatible. The update will only
     /// ever make the Script specific. Returns true if the new Font and Script are
     /// compatible with this segment or false otherwise.
-    fn update_if_compatible(
-        &mut self,
-        layout_context: &LayoutContext,
-        new_font: &FontRef,
-        script: Script,
-        bidi_level: Level,
-    ) -> bool {
+    fn update_if_compatible(&mut self, info: &FontAndScriptInfo) -> bool {
+        if self.info.bidi_level != info.bidi_level || !Arc::ptr_eq(&self.info.font, &info.font) {
+            return false;
+        }
+
         fn is_specific(script: Script) -> bool {
             script != Script::Common && script != Script::Inherited
         }
-
-        if bidi_level != self.bidi_level {
-            return false;
+        if !is_specific(self.info.script) && is_specific(info.script) {
+            self.info = Arc::new(info.clone());
         }
-
-        let painter_id = layout_context.painter_id;
-        let font_context = &layout_context.font_context;
-        if new_font.key(painter_id, font_context) !=
-            self.font
-                .key(layout_context.painter_id, &layout_context.font_context) ||
-            new_font.descriptor.pt_size != self.font.descriptor.pt_size
-        {
-            return false;
-        }
-
-        if !is_specific(self.script) && is_specific(script) {
-            self.script = script;
-        }
-        script == self.script || !is_specific(script)
+        info.script == self.info.script || !is_specific(info.script)
     }
 
     fn layout_into_line_items(
@@ -164,10 +147,7 @@ impl TextRunSegment {
             // any ongoing inline boxes before ending the line.
             if run.is_single_preserved_newline() {
                 ifc.possibly_push_empty_text_run_to_unbreakable_segment(
-                    text_run,
-                    &self.font,
-                    self.bidi_level,
-                    offsets,
+                    text_run, &self.info, offsets,
                 );
                 character_range_start = new_character_range_end;
                 ifc.defer_forced_line_break();
@@ -180,13 +160,7 @@ impl TextRunSegment {
                 ifc.process_soft_wrap_opportunity();
             }
 
-            ifc.push_glyph_store_to_unbreakable_segment(
-                run.clone(),
-                text_run,
-                &self.font,
-                self.bidi_level,
-                offsets,
-            );
+            ifc.push_glyph_store_to_unbreakable_segment(run.clone(), text_run, &self.info, offsets);
             character_range_start = new_character_range_end;
         }
     }
@@ -198,7 +172,8 @@ impl TextRunSegment {
         options: &ShapingOptions,
     ) {
         self.runs.push(
-            self.font
+            self.info
+                .font
                 .shape_text(&formatting_context_text[range.clone()], options),
         );
     }
@@ -438,22 +413,23 @@ impl TextRun {
             .map(|mut segment| {
                 let word_spacing = style_word_spacing.unwrap_or_else(|| {
                     let space_width = segment
+                        .info
                         .font
                         .glyph_index(' ')
-                        .map(|glyph_id| segment.font.glyph_h_advance(glyph_id))
+                        .map(|glyph_id| segment.info.font.glyph_h_advance(glyph_id))
                         .unwrap_or(LAST_RESORT_GLYPH_ADVANCE);
                     specified_word_spacing.to_used_value(Au::from_f64_px(space_width))
                 });
 
                 let mut flags = flags;
-                if segment.bidi_level.is_rtl() {
+                if segment.info.bidi_level.is_rtl() {
                     flags.insert(ShapingFlags::RTL_FLAG);
                 }
 
                 // From https://www.w3.org/TR/css-text-3/#cursive-script:
                 // Cursive scripts do not admit gaps between their letters for either
                 // justification or letter-spacing.
-                let letter_spacing = if is_cursive_script(segment.script) {
+                let letter_spacing = if is_cursive_script(segment.info.script) {
                     None
                 } else {
                     letter_spacing
@@ -465,7 +441,7 @@ impl TextRun {
                 let shaping_options = ShapingOptions {
                     letter_spacing,
                     word_spacing,
-                    script: segment.script,
+                    script: segment.info.script,
                     language,
                     flags,
                 };
@@ -520,12 +496,6 @@ impl TextRun {
                 continue;
             }
 
-            // If the script and BiDi level do not change, use the current font as the first fallback. This
-            // can potentially speed up fallback on long font lists or with uncommon scripts which might be
-            // at the bottom of the list.
-            let script = Script::from(character);
-            let bidi_level = bidi_info.levels[current_byte_index];
-
             let Some(font) = font_group.find_by_codepoint(
                 &layout_context.font_context,
                 character,
@@ -535,9 +505,15 @@ impl TextRun {
                 continue;
             };
 
+            let info = FontAndScriptInfo {
+                font,
+                script: Script::from(character),
+                bidi_level: bidi_info.levels[current_byte_index],
+            };
+
             // If the existing segment is compatible with the character, keep going.
             if let Some(current) = current.as_mut() {
-                if current.update_if_compatible(layout_context, &font, script, bidi_level) {
+                if current.update_if_compatible(&info) {
                     continue;
                 }
             }
@@ -550,13 +526,7 @@ impl TextRun {
                 Some(_) => (current_byte_index, current_character_index),
                 None => (self.text_range.start, self.character_range.start),
             };
-            let new = TextRunSegment::new(
-                font,
-                script,
-                bidi_level,
-                start_byte_index,
-                start_character_index,
-            );
+            let new = TextRunSegment::new(Arc::new(info), start_byte_index, start_character_index);
             if let Some(mut finished) = current.replace(new) {
                 // The end of the previous segment is the start of the next one.
                 finished.range.end = current_byte_index;
@@ -570,9 +540,11 @@ impl TextRun {
         if current.is_none() {
             current = font_group.first(&layout_context.font_context).map(|font| {
                 TextRunSegment::new(
-                    font,
-                    Script::Common,
-                    Level::ltr(),
+                    Arc::new(FontAndScriptInfo {
+                        font,
+                        script: Script::Common,
+                        bidi_level: Level::ltr(),
+                    }),
                     self.text_range.start,
                     self.character_range.start,
                 )


### PR DESCRIPTION
This starts splitting out commonly shared data into a new data structure
that will make it easier to compare old shaping results to new ones in
the future. This eliminates some memory usage during inline layout, but
adds 8 bytes per segment (usually one per inline box). We hope to
recover this memory by storing one `GlyphStore` per `TextRunSegment`, which
should recover 16 bytes.

Testing: This should not change behavior so is covered by existing tests.
