### PR TITLE
Add README for the `servo` crate

### DIFF
--- a/components/servo/Cargo.toml
+++ b/components/servo/Cargo.toml
@@ -8,6 +8,7 @@ publish.workspace = true
 rust-version.workspace = true
 repository.workspace = true
 description.workspace = true
+readme = "../../README.md"
 
 [lib]
 name = "servo"


### PR DESCRIPTION
Add `readme` field to libservo's Cargo.toml, pointing to the repository root
README via `../../README.md`. This ensures the crates.io page displays content
when the crate is published, as Cargo copies the referenced file into the
package during `cargo publish`.

Testing: This change only adds a metadata field to Cargo.toml and does not
affect build output or runtime behavior. No tests are required.
fixes #43143