### PR TITLE
devtools: Rename BrowsingContextActor variable names

### DIFF
--- a/components/devtools/actors/network_event.rs
+++ b/components/devtools/actors/network_event.rs
@@ -625,8 +625,8 @@ impl NetworkEventActor {
 
     pub fn resource_updates(&self, registry: &ActorRegistry) -> NetworkEventResource {
         let watcher = registry.find::<WatcherActor>(&self.watcher);
-        let browsing_context =
-            registry.find::<BrowsingContextActor>(&watcher.browsing_context_actor);
+        let browsing_context_actor =
+            registry.find::<BrowsingContextActor>(&watcher.browsing_context_name);
 
         NetworkEventResource {
             resource_id: self.resource_id,
@@ -637,7 +637,7 @@ impl NetworkEventActor {
                 response: self.response_fields(),
                 security: self.security_fields(),
             },
-            browsing_context_id: browsing_context.browsing_context_id.value(),
+            browsing_context_id: browsing_context_actor.browsing_context_id.value(),
             inner_window_id: 0,
         }
     }
@@ -703,12 +703,12 @@ impl ActorEncode<NetworkEventMsg> for NetworkEventActor {
         };
 
         let watcher = registry.find::<WatcherActor>(&self.watcher);
-        let browsing_context =
-            registry.find::<BrowsingContextActor>(&watcher.browsing_context_actor);
+        let browsing_context_actor =
+            registry.find::<BrowsingContextActor>(&watcher.browsing_context_name);
 
         NetworkEventMsg {
             actor: self.name(),
-            browsing_context_id: browsing_context.browsing_context_id.value(),
+            browsing_context_id: browsing_context_actor.browsing_context_id.value(),
             cause: Cause {
                 type_: request.destination.as_str().to_string(),
                 loading_document_uri: None, // Set if available

--- a/components/devtools/actors/tab.rs
+++ b/components/devtools/actors/tab.rs
@@ -72,7 +72,7 @@ struct GetWatcherReply {
 #[derive(MallocSizeOf)]
 pub(crate) struct TabDescriptorActor {
     name: String,
-    browsing_context_actor: String,
+    browsing_context_name: String,
     is_top_level_global: bool,
 }
 
@@ -99,13 +99,14 @@ impl Actor for TabDescriptorActor {
         msg: &Map<String, Value>,
         _id: StreamId,
     ) -> Result<(), ActorError> {
-        let ctx_actor = registry.find::<BrowsingContextActor>(&self.browsing_context_actor);
-        let pipeline = ctx_actor.pipeline_id();
+        let browsing_context_actor =
+            registry.find::<BrowsingContextActor>(&self.browsing_context_name);
+        let pipeline = browsing_context_actor.pipeline_id();
 
         match msg_type {
             "getTarget" => request.reply_final(&GetTargetReply {
                 from: self.name(),
-                frame: registry.encode::<BrowsingContextActor, _>(&self.browsing_context_actor),
+                frame: registry.encode::<BrowsingContextActor, _>(&self.browsing_context_name),
             })?,
             "getFavicon" => {
                 // TODO: Return a favicon when available
@@ -116,17 +117,17 @@ impl Actor for TabDescriptorActor {
             },
             "getWatcher" => request.reply_final(&GetWatcherReply {
                 from: self.name(),
-                watcher: registry.encode::<WatcherActor, _>(&ctx_actor.watcher),
+                watcher: registry.encode::<WatcherActor, _>(&browsing_context_actor.watcher),
             })?,
             "goBack" => {
-                ctx_actor
+                browsing_context_actor
                     .script_chan()
                     .send(DevtoolScriptControlMsg::GoBack(pipeline))
                     .map_err(|_| ActorError::Internal)?;
                 request.reply_final(&EmptyReplyMsg { from: self.name() })?
             },
             "goForward" => {
-                ctx_actor
+                browsing_context_actor
                     .script_chan()
                     .send(DevtoolScriptControlMsg::GoForward(pipeline))
                     .map_err(|_| ActorError::Internal)?;
@@ -143,7 +144,7 @@ impl Actor for TabDescriptorActor {
                     .ok_or(ActorError::Internal)?
                     .map_err(|_| ActorError::Internal)?;
 
-                ctx_actor
+                browsing_context_actor
                     .script_chan()
                     .send(DevtoolScriptControlMsg::NavigateTo(pipeline, url))
                     .map_err(|_| ActorError::Internal)?;
@@ -152,7 +153,7 @@ impl Actor for TabDescriptorActor {
             },
             "reloadDescriptor" => {
                 // There is an extra bypassCache parameter that we don't currently use.
-                ctx_actor
+                browsing_context_actor
                     .script_chan()
                     .send(DevtoolScriptControlMsg::Reload(pipeline))
                     .map_err(|_| ActorError::Internal)?;
@@ -168,7 +169,7 @@ impl Actor for TabDescriptorActor {
 impl TabDescriptorActor {
     pub(crate) fn new(
         registry: &ActorRegistry,
-        browsing_context_actor: String,
+        browsing_context_name: String,
         is_top_level_global: bool,
     ) -> TabDescriptorActor {
         let name = registry.new_name::<Self>();
@@ -176,7 +177,7 @@ impl TabDescriptorActor {
         root.tabs.borrow_mut().push(name.clone());
         TabDescriptorActor {
             name,
-            browsing_context_actor,
+            browsing_context_name,
             is_top_level_global,
         }
     }
@@ -186,22 +187,23 @@ impl TabDescriptorActor {
     }
 
     pub fn browsing_context(&self) -> String {
-        self.browsing_context_actor.clone()
+        self.browsing_context_name.clone()
     }
 }
 
 impl ActorEncode<TabDescriptorActorMsg> for TabDescriptorActor {
     fn encode(&self, registry: &ActorRegistry) -> TabDescriptorActorMsg {
-        let ctx_actor = registry.find::<BrowsingContextActor>(&self.browsing_context_actor);
-        let title = ctx_actor.title.borrow().clone();
-        let url = ctx_actor.url.borrow().clone();
+        let browsing_context_actor =
+            registry.find::<BrowsingContextActor>(&self.browsing_context_name);
+        let title = browsing_context_actor.title.borrow().clone();
+        let url = browsing_context_actor.url.borrow().clone();
 
         TabDescriptorActorMsg {
             actor: self.name(),
-            browser_id: ctx_actor.browser_id.value(),
-            browsing_context_id: ctx_actor.browsing_context_id.value(),
+            browser_id: browsing_context_actor.browser_id.value(),
+            browsing_context_id: browsing_context_actor.browsing_context_id.value(),
             is_zombie_tab: false,
-            outer_window_id: ctx_actor.outer_window_id().value(),
+            outer_window_id: browsing_context_actor.outer_window_id().value(),
             selected: false,
             title,
             traits: DescriptorTraits {

--- a/components/devtools/actors/watcher.rs
+++ b/components/devtools/actors/watcher.rs
@@ -182,7 +182,7 @@ pub(crate) struct WatcherActorMsg {
 #[derive(MallocSizeOf)]
 pub(crate) struct WatcherActor {
     name: String,
-    pub browsing_context_actor: String,
+    pub browsing_context_name: String,
     network_parent_name: String,
     target_configuration: String,
     thread_configuration: String,
@@ -238,7 +238,8 @@ impl Actor for WatcherActor {
         msg: &Map<String, Value>,
         _id: StreamId,
     ) -> Result<(), ActorError> {
-        let target = registry.find::<BrowsingContextActor>(&self.browsing_context_actor);
+        let browsing_context_actor =
+            registry.find::<BrowsingContextActor>(&self.browsing_context_name);
         let root = registry.find::<RootActor>("root");
         match msg_type {
             "watchTargets" => {
@@ -252,11 +253,13 @@ impl Actor for WatcherActor {
                     let msg = WatchTargetsReply {
                         from: self.name(),
                         type_: "target-available-form".into(),
-                        target: TargetActorMsg::BrowsingContext(target.encode(registry)),
+                        target: TargetActorMsg::BrowsingContext(
+                            browsing_context_actor.encode(registry),
+                        ),
                     };
                     let _ = request.write_json_packet(&msg);
 
-                    target.frame_update(&mut request);
+                    browsing_context_actor.frame_update(&mut request);
                 } else if target_type == "worker" {
                     for worker_name in &*root.workers.borrow() {
                         let worker_msg = WatchTargetsReply {
@@ -316,10 +319,10 @@ impl Actor for WatcherActor {
                                     name: name.into(),
                                     new_uri: None,
                                     time: get_time_stamp(),
-                                    title: Some(target.title.borrow().clone()),
-                                    url: Some(target.url.borrow().clone()),
+                                    title: Some(browsing_context_actor.title.borrow().clone()),
+                                    url: Some(browsing_context_actor.url.borrow().clone()),
                                 };
-                                target.resource_array(
+                                browsing_context_actor.resource_array(
                                     event,
                                     resource.into(),
                                     ResourceArrayType::Available,
@@ -328,8 +331,9 @@ impl Actor for WatcherActor {
                             }
                         },
                         "source" => {
-                            let thread_actor = registry.find::<ThreadActor>(&target.thread);
-                            target.resources_array(
+                            let thread_actor =
+                                registry.find::<ThreadActor>(&browsing_context_actor.thread);
+                            browsing_context_actor.resources_array(
                                 thread_actor.source_manager.source_forms(registry),
                                 resource.into(),
                                 ResourceArrayType::Available,
@@ -349,9 +353,10 @@ impl Actor for WatcherActor {
                             }
                         },
                         "console-message" | "error-message" => {
-                            let console_actor = registry.find::<ConsoleActor>(&target.console_name);
+                            let console_actor =
+                                registry.find::<ConsoleActor>(&browsing_context_actor.console_name);
                             console_actor.received_first_message_from_client();
-                            target.resources_array(
+                            browsing_context_actor.resources_array(
                                 console_actor.get_cached_messages(registry, resource),
                                 resource.into(),
                                 ResourceArrayType::Available,
@@ -385,7 +390,7 @@ impl Actor for WatcherActor {
             "getParentBrowsingContextID" => {
                 let msg = GetParentBrowsingContextIDReply {
                     from: self.name(),
-                    browsing_context_id: target.browsing_context_id.value(),
+                    browsing_context_id: browsing_context_actor.browsing_context_id.value(),
                 };
                 request.reply_final(&msg)?
             },
@@ -435,7 +440,7 @@ impl ResourceAvailable for WatcherActor {
 impl WatcherActor {
     pub fn new(
         registry: &ActorRegistry,
-        browsing_context_actor: String,
+        browsing_context_name: String,
         session_context: SessionContext,
     ) -> Self {
         let network_parent_actor =
@@ -446,12 +451,12 @@ impl WatcherActor {
             ThreadConfigurationActor::new(registry.new_name::<ThreadConfigurationActor>());
         let breakpoint_list = BreakpointListActor::new(
             registry.new_name::<BreakpointListActor>(),
-            browsing_context_actor.clone(),
+            browsing_context_name.clone(),
         );
 
         let watcher = Self {
             name: registry.new_name::<WatcherActor>(),
-            browsing_context_actor,
+            browsing_context_name,
             network_parent_name: network_parent_actor.name(),
             target_configuration: target_configuration.name(),
             thread_configuration: thread_configuration.name(),

--- a/components/devtools/lib.rs
+++ b/components/devtools/lib.rs
@@ -263,9 +263,11 @@ impl DevtoolsInstance {
                         if connections.is_empty() {
                             // We used to have no connection, now we have one.
                             // Therefore, we need updates from script threads.
-                            for name in self.browsing_contexts.values() {
-                                let actor = self.registry.find::<BrowsingContextActor>(name);
-                                actor.instruct_script_to_send_live_updates(true);
+                            for browsing_context_name in self.browsing_contexts.values() {
+                                let browsing_context_actor = self
+                                    .registry
+                                    .find::<BrowsingContextActor>(browsing_context_name);
+                                browsing_context_actor.instruct_script_to_send_live_updates(true);
                             }
                         }
                     }
@@ -409,10 +411,11 @@ impl DevtoolsInstance {
                     if self.connections.lock().unwrap().is_empty() {
                         // Tell every browsing context to stop sending us updates, because we have nowhere to
                         // send them to.
-                        for browsing_context in self.browsing_contexts.values() {
-                            let actor =
-                                self.registry.find::<BrowsingContextActor>(browsing_context);
-                            actor.instruct_script_to_send_live_updates(false);
+                        for browsing_context_name in self.browsing_contexts.values() {
+                            let browsing_context_actor = self
+                                .registry
+                                .find::<BrowsingContextActor>(browsing_context_name);
+                            browsing_context_actor.instruct_script_to_send_live_updates(false);
                         }
                     }
                 },
@@ -433,12 +436,16 @@ impl DevtoolsInstance {
     }
 
     fn handle_navigate(&self, browsing_context_id: BrowsingContextId, state: NavigationState) {
-        let actor_name = self.browsing_contexts.get(&browsing_context_id).unwrap();
-        let actor = self.registry.find::<BrowsingContextActor>(actor_name);
+        let browsing_context_name = self.browsing_contexts.get(&browsing_context_id).unwrap();
+        let browsing_context_actor = self
+            .registry
+            .find::<BrowsingContextActor>(browsing_context_name);
         let mut id_map = self.id_map.lock().unwrap();
         let mut connections = self.connections.lock().unwrap();
         if let NavigationState::Start(url) = &state {
-            let watcher_actor = self.registry.find::<WatcherActor>(&actor.watcher);
+            let watcher_actor = self
+                .registry
+                .find::<WatcherActor>(&browsing_context_actor.watcher);
             watcher_actor.emit_will_navigate(
                 browsing_context_id,
                 url.clone(),
@@ -447,7 +454,7 @@ impl DevtoolsInstance {
             );
         }
 
-        actor.handle_navigate(state, &mut id_map, connections.values_mut());
+        browsing_context_actor.handle_navigate(state, &mut id_map, connections.values_mut());
     }
 
     // We need separate actor representations for each script global that exists;
@@ -505,7 +512,7 @@ impl DevtoolsInstance {
             Root::DedicatedWorker(worker_name)
         } else {
             self.pipelines.insert(pipeline_id, browsing_context_id);
-            let name = self
+            let browsing_context_name = self
                 .browsing_contexts
                 .entry(browsing_context_id)
                 .or_insert_with(|| {
@@ -519,13 +526,15 @@ impl DevtoolsInstance {
                         script_sender.clone(),
                         &self.registry,
                     );
-                    let name = browsing_context_actor.name();
+                    let browsing_context_name = browsing_context_actor.name();
                     self.registry.register(browsing_context_actor);
-                    name
+                    browsing_context_name
                 });
-            let browsing_context_actor = self.registry.find::<BrowsingContextActor>(name);
+            let browsing_context_actor = self
+                .registry
+                .find::<BrowsingContextActor>(browsing_context_name);
             browsing_context_actor.handle_new_global(pipeline_id, script_sender);
-            Root::BrowsingContext(name.clone())
+            Root::BrowsingContext(browsing_context_name.clone())
         };
 
         let console_actor = ConsoleActor::new(console_name, parent_actor);
@@ -534,16 +543,18 @@ impl DevtoolsInstance {
     }
 
     fn handle_title_changed(&self, pipeline_id: PipelineId, title: String) {
-        let bc = match self.pipelines.get(&pipeline_id) {
+        let browsing_context_id = match self.pipelines.get(&pipeline_id) {
             Some(bc) => bc,
             None => return,
         };
-        let name = match self.browsing_contexts.get(bc) {
+        let browsing_context_name = match self.browsing_contexts.get(browsing_context_id) {
             Some(name) => name,
             None => return,
         };
-        let browsing_context = self.registry.find::<BrowsingContextActor>(name);
-        browsing_context.title_changed(pipeline_id, title);
+        let browsing_context_actor = self
+            .registry
+            .find::<BrowsingContextActor>(browsing_context_name);
+        browsing_context_actor.title_changed(pipeline_id, title);
     }
 
     fn handle_console_resource(
@@ -578,13 +589,12 @@ impl DevtoolsInstance {
             log::warn!("Devtools received notification for unknown pipeline {pipeline_id}");
             return Err(ActorError::Internal);
         };
-        let Some(browsing_context_actor_id) = self.browsing_contexts.get(browsing_context_id)
-        else {
+        let Some(browsing_context_name) = self.browsing_contexts.get(browsing_context_id) else {
             return Err(ActorError::Internal);
         };
         let browsing_context_actor = self
             .registry
-            .find::<BrowsingContextActor>(browsing_context_actor_id);
+            .find::<BrowsingContextActor>(browsing_context_name);
         let inspector_actor = self
             .registry
             .find::<InspectorActor>(&browsing_context_actor.inspector);
@@ -624,11 +634,11 @@ impl DevtoolsInstance {
                     .clone(),
             )
         } else {
-            let id = self.pipelines.get(&pipeline_id)?;
-            let actor_name = self.browsing_contexts.get(id)?;
+            let browsing_context_id = self.pipelines.get(&pipeline_id)?;
+            let browsing_context_name = self.browsing_contexts.get(browsing_context_id)?;
             Some(
                 self.registry
-                    .find::<BrowsingContextActor>(actor_name)
+                    .find::<BrowsingContextActor>(browsing_context_name)
                     .console_name
                     .clone(),
             )
@@ -648,13 +658,12 @@ impl DevtoolsInstance {
             NetworkEvent::SecurityInfo(update) => update.browsing_context_id,
         };
 
-        let Some(browsing_context_actor_name) = self.browsing_contexts.get(&browsing_context_id)
-        else {
+        let Some(browsing_context_name) = self.browsing_contexts.get(&browsing_context_id) else {
             return;
         };
         let watcher_name = self
             .registry
-            .find::<BrowsingContextActor>(browsing_context_actor_name)
+            .find::<BrowsingContextActor>(browsing_context_name)
             .watcher
             .clone();
 
@@ -737,23 +746,28 @@ impl DevtoolsInstance {
             let Some(browsing_context_id) = self.pipelines.get(&pipeline_id) else {
                 return;
             };
-            let Some(actor_name) = self.browsing_contexts.get(browsing_context_id) else {
+            let Some(browsing_context_name) = self.browsing_contexts.get(browsing_context_id)
+            else {
                 return;
             };
 
             let thread_actor_name = {
-                let browsing_context = self.registry.find::<BrowsingContextActor>(actor_name);
-                browsing_context.thread.clone()
+                let browsing_context_actor = self
+                    .registry
+                    .find::<BrowsingContextActor>(browsing_context_name);
+                browsing_context_actor.thread.clone()
             };
 
             let thread_actor = self.registry.find::<ThreadActor>(&thread_actor_name);
             thread_actor.source_manager.add_source(&source_actor);
 
             // Notify browsing context about the new source
-            let browsing_context = self.registry.find::<BrowsingContextActor>(actor_name);
+            let browsing_context_actor = self
+                .registry
+                .find::<BrowsingContextActor>(browsing_context_name);
 
             for stream in self.connections.lock().unwrap().values_mut() {
-                browsing_context.resource_array(
+                browsing_context_actor.resource_array(
                     &source_form,
                     "source".into(),
                     ResourceArrayType::Available,
@@ -784,7 +798,7 @@ impl DevtoolsInstance {
         frame_offset: FrameOffset,
         pause_reason: PauseReason,
     ) {
-        let Some(browsing_context) = self
+        let Some(browsing_context_name) = self
             .pipelines
             .get(&pipeline_id)
             .and_then(|id| self.browsing_contexts.get(id))
@@ -792,8 +806,12 @@ impl DevtoolsInstance {
             return;
         };
 
-        let browsing_context = self.registry.find::<BrowsingContextActor>(browsing_context);
-        let thread = self.registry.find::<ThreadActor>(&browsing_context.thread);
+        let browsing_context_actor = self
+            .registry
+            .find::<BrowsingContextActor>(browsing_context_name);
+        let thread = self
+            .registry
+            .find::<ThreadActor>(&browsing_context_actor.thread);
 
         let pause = self.registry.new_name::<PauseActor>();
         self.registry.register(PauseActor {
@@ -822,7 +840,7 @@ impl DevtoolsInstance {
         pipeline_id: PipelineId,
         frame: FrameInfo,
     ) {
-        let Some(browsing_context) = self
+        let Some(browsing_context_name) = self
             .pipelines
             .get(&pipeline_id)
             .and_then(|id| self.browsing_contexts.get(id))
@@ -830,8 +848,12 @@ impl DevtoolsInstance {
             return;
         };
 
-        let browsing_context = self.registry.find::<BrowsingContextActor>(browsing_context);
-        let thread = self.registry.find::<ThreadActor>(&browsing_context.thread);
+        let browsing_context_actor = self
+            .registry
+            .find::<BrowsingContextActor>(browsing_context_name);
+        let thread = self
+            .registry
+            .find::<ThreadActor>(&browsing_context_actor.thread);
 
         let source = match thread
             .source_manager


### PR DESCRIPTION
Renamed BrowsingContext in tab, network_event, watcher actors & lib.rs

Testing: No testing required - only renaming done
Fixes: Part o #43606 