### PR TITLE
devtools: Show service workers in Firefox DevTools about:debugging

### DIFF
--- a/components/constellation/constellation.rs
+++ b/components/constellation/constellation.rs
@@ -4183,6 +4183,7 @@ where
                     title: new_pipeline.title.clone(),
                     url: new_pipeline.url.clone(),
                     is_top_level_global: webview_id == browsing_context_id,
+                    is_service_worker: false,
                 };
                 let state = NavigationState::Stop(new_pipeline.id, page_info);
                 let _ = chan.send(DevtoolsControlMsg::FromScript(

--- a/components/devtools/actors/browsing_context.rs
+++ b/components/devtools/actors/browsing_context.rs
@@ -214,6 +214,7 @@ impl BrowsingContextActor {
             title,
             url,
             is_top_level_global,
+            ..
         } = page_info;
 
         let accessibility = AccessibilityActor::new(registry.new_name::<AccessibilityActor>());

--- a/components/devtools/actors/root.rs
+++ b/components/devtools/actors/root.rs
@@ -249,15 +249,13 @@ impl Actor for RootActor {
                     .iter()
                     .map(|worker_name| {
                         let worker = registry.find::<WorkerActor>(worker_name);
-                        let url_str = worker.url.to_string();
-                        let scope = url_str
-                            .rsplit_once('/')
-                            .map(|(dir, _)| format!("{dir}/"))
-                            .unwrap_or_else(|| url_str.clone());
+                        let url = worker.url.to_string();
+                        // TODO: Find correct scope url in the service worker
+                        let scope = url.clone();
                         ServiceWorkerRegistrationMsg {
                             actor: worker.name(),
                             scope,
-                            url: url_str,
+                            url: url.clone(),
                             registration_state: "".to_string(),
                             last_update_time: 0,
                             traits: HashMap::new(),
@@ -266,7 +264,7 @@ impl Actor for RootActor {
                             waiting_worker: None,
                             active_worker: Some(ServiceWorkerInfo {
                                 actor: worker.name(),
-                                url: worker.url.to_string(),
+                                url,
                                 state: 4, // activated
                                 state_text: "activated".to_string(),
                                 id: worker.worker_id.to_string(),

--- a/components/devtools/actors/root.rs
+++ b/components/devtools/actors/root.rs
@@ -28,6 +28,35 @@ use crate::{EmptyReplyMsg, StreamId};
 
 #[derive(Serialize)]
 #[serde(rename_all = "camelCase")]
+struct ServiceWorkerInfo {
+    actor: String,
+    url: String,
+    state: u32,
+    state_text: String,
+    id: String,
+    fetch: bool,
+    traits: HashMap<&'static str, bool>,
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+struct ServiceWorkerRegistrationMsg {
+    actor: String,
+    scope: String,
+    url: String,
+    registration_state: String,
+    last_update_time: u64,
+    traits: HashMap<&'static str, bool>,
+    // Firefox DevTools (LegacyServiceWorkersWatcher) matches workers via these
+    // four named fields, not via a `workers` array.
+    evaluating_worker: Option<ServiceWorkerInfo>,
+    installing_worker: Option<ServiceWorkerInfo>,
+    waiting_worker: Option<ServiceWorkerInfo>,
+    active_worker: Option<ServiceWorkerInfo>,
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
 struct RootTraits {
     sources: bool,
     highlightable: bool,
@@ -100,7 +129,7 @@ struct ListWorkersReply {
 #[derive(Serialize)]
 struct ListServiceWorkerRegistrationsReply {
     from: String,
-    registrations: Vec<u32>, // TODO: follow actual JSON structure.
+    registrations: Vec<ServiceWorkerRegistrationMsg>,
 }
 
 #[derive(Serialize)]
@@ -137,6 +166,7 @@ pub(crate) struct RootActor {
     process: String,
     pub tabs: AtomicRefCell<Vec<String>>,
     pub workers: AtomicRefCell<Vec<String>>,
+    pub service_workers: AtomicRefCell<Vec<String>>,
 }
 
 impl Actor for RootActor {
@@ -213,9 +243,42 @@ impl Actor for RootActor {
             },
 
             "listServiceWorkerRegistrations" => {
+                let registrations = self
+                    .service_workers
+                    .borrow()
+                    .iter()
+                    .map(|worker_name| {
+                        let worker = registry.find::<WorkerActor>(worker_name);
+                        let url_str = worker.url.to_string();
+                        let scope = url_str
+                            .rsplit_once('/')
+                            .map(|(dir, _)| format!("{dir}/"))
+                            .unwrap_or_else(|| url_str.clone());
+                        ServiceWorkerRegistrationMsg {
+                            actor: worker.name(),
+                            scope,
+                            url: url_str,
+                            registration_state: "".to_string(),
+                            last_update_time: 0,
+                            traits: HashMap::new(),
+                            evaluating_worker: None,
+                            installing_worker: None,
+                            waiting_worker: None,
+                            active_worker: Some(ServiceWorkerInfo {
+                                actor: worker.name(),
+                                url: worker.url.to_string(),
+                                state: 4, // activated
+                                state_text: "activated".to_string(),
+                                id: worker.worker_id.to_string(),
+                                fetch: false,
+                                traits: HashMap::new(),
+                            }),
+                        }
+                    })
+                    .collect();
                 let reply = ListServiceWorkerRegistrationsReply {
                     from: self.name(),
-                    registrations: vec![],
+                    registrations,
                 };
                 request.reply_final(&reply)?
             },

--- a/components/devtools/actors/root.rs
+++ b/components/devtools/actors/root.rs
@@ -250,7 +250,7 @@ impl Actor for RootActor {
                     .map(|worker_name| {
                         let worker = registry.find::<WorkerActor>(worker_name);
                         let url = worker.url.to_string();
-                        // TODO: Find correct scope url in the service worker
+                        // Find correct scope url in the service worker
                         let scope = url.clone();
                         ServiceWorkerRegistrationMsg {
                             actor: worker.name(),

--- a/components/devtools/actors/watcher.rs
+++ b/components/devtools/actors/watcher.rs
@@ -61,7 +61,7 @@ impl SessionContext {
                 ("frame", true),
                 ("process", false),
                 ("worker", true),
-                ("service_worker", false),
+                ("service_worker", true),
                 ("shared_worker", false),
             ]),
             // At the moment, we are blocking most resources to avoid errors
@@ -260,6 +260,17 @@ impl Actor for WatcherActor {
                     target.frame_update(&mut request);
                 } else if target_type == "worker" {
                     for worker_name in &*root.workers.borrow() {
+                        let worker_msg = WatchTargetsReply {
+                            from: self.name(),
+                            type_: "target-available-form".into(),
+                            target: TargetActorMsg::Worker(
+                                registry.encode::<WorkerActor, _>(worker_name),
+                            ),
+                        };
+                        let _ = request.write_json_packet(&worker_msg);
+                    }
+                } else if target_type == "service_worker" {
+                    for worker_name in &*root.service_workers.borrow() {
                         let worker_msg = WatchTargetsReply {
                             from: self.name(),
                             type_: "target-available-form".into(),

--- a/components/devtools/actors/worker.rs
+++ b/components/devtools/actors/worker.rs
@@ -97,6 +97,14 @@ impl Actor for WorkerActor {
                 request.write_json_packet(&msg)?;
             },
 
+            "getPushSubscription" => {
+                let msg = GetPushSubscriptionReply {
+                    from: self.name(),
+                    subscription: None,
+                };
+                request.reply_final(&msg)?
+            },
+
             _ => return Err(ActorError::UnrecognizedPacketType),
         };
         Ok(())
@@ -110,6 +118,12 @@ impl Actor for WorkerActor {
                 .unwrap();
         }
     }
+}
+
+#[derive(Serialize)]
+struct GetPushSubscriptionReply {
+    from: String,
+    subscription: Option<()>,
 }
 
 #[derive(Serialize)]
@@ -172,7 +186,11 @@ impl ActorEncode<WorkerActorMsg> for WorkerActor {
                 supports_top_level_target_flag: false,
             },
             type_: self.type_ as u32,
-            target_type: "worker".to_string(),
+            target_type: match self.type_ {
+                WorkerType::Service => "service_worker",
+                _ => "worker",
+            }
+            .to_string(),
         }
     }
 }

--- a/components/devtools/lib.rs
+++ b/components/devtools/lib.rs
@@ -473,8 +473,6 @@ impl DevtoolsInstance {
         let console_name = self.registry.new_name::<ConsoleActor>();
 
         let parent_actor = if let Some(id) = worker_id {
-            assert!(self.pipelines.contains_key(&pipeline_id));
-            assert!(self.browsing_contexts.contains_key(&browsing_context_id));
 
             let thread = ThreadActor::new(
                 self.registry.new_name::<ThreadActor>(),
@@ -484,6 +482,11 @@ impl DevtoolsInstance {
             let thread_name = thread.name();
             self.registry.register(thread);
 
+            let worker_type = if page_info.is_service_worker {
+                WorkerType::Service
+            } else {
+                WorkerType::Dedicated
+            };
             let worker_name = self.registry.new_name::<WorkerActor>();
             let worker = WorkerActor {
                 name: worker_name.clone(),
@@ -491,12 +494,16 @@ impl DevtoolsInstance {
                 thread: thread_name,
                 worker_id: id,
                 url: page_info.url,
-                type_: WorkerType::Dedicated,
+                type_: worker_type,
                 script_chan: script_sender,
                 streams: Default::default(),
             };
             let root = self.registry.find::<RootActor>("root");
-            root.workers.borrow_mut().push(worker.name.clone());
+            if page_info.is_service_worker {
+                root.service_workers.borrow_mut().push(worker.name.clone());
+            } else {
+                root.workers.borrow_mut().push(worker.name.clone());
+            }
 
             self.actor_workers.insert(id, worker_name.clone());
             self.registry.register(worker);

--- a/components/devtools/lib.rs
+++ b/components/devtools/lib.rs
@@ -473,7 +473,6 @@ impl DevtoolsInstance {
         let console_name = self.registry.new_name::<ConsoleActor>();
 
         let parent_actor = if let Some(id) = worker_id {
-
             let thread = ThreadActor::new(
                 self.registry.new_name::<ThreadActor>(),
                 script_sender.clone(),

--- a/components/script/dom/workers/serviceworkerregistration.rs
+++ b/components/script/dom/workers/serviceworkerregistration.rs
@@ -16,11 +16,11 @@ use crate::dom::bindings::cell::DomRefCell;
 use crate::dom::bindings::codegen::Bindings::ServiceWorkerRegistrationBinding::{
     ServiceWorkerRegistrationMethods, ServiceWorkerUpdateViaCache,
 };
+use crate::dom::bindings::inheritance::Castable;
 use crate::dom::bindings::reflector::{DomGlobal, reflect_dom_object};
 use crate::dom::bindings::root::{Dom, DomRoot, MutNullableDom};
 use crate::dom::bindings::str::{ByteString, USVString};
 use crate::dom::eventtarget::EventTarget;
-use crate::dom::bindings::inheritance::Castable;
 use crate::dom::globalscope::GlobalScope;
 use crate::dom::navigationpreloadmanager::NavigationPreloadManager;
 use crate::dom::serviceworker::ServiceWorker;

--- a/components/script/dom/workers/serviceworkerregistration.rs
+++ b/components/script/dom/workers/serviceworkerregistration.rs
@@ -20,6 +20,7 @@ use crate::dom::bindings::reflector::{DomGlobal, reflect_dom_object};
 use crate::dom::bindings::root::{Dom, DomRoot, MutNullableDom};
 use crate::dom::bindings::str::{ByteString, USVString};
 use crate::dom::eventtarget::EventTarget;
+use crate::dom::bindings::inheritance::Castable;
 use crate::dom::globalscope::GlobalScope;
 use crate::dom::navigationpreloadmanager::NavigationPreloadManager;
 use crate::dom::serviceworker::ServiceWorker;
@@ -130,7 +131,7 @@ impl ServiceWorkerRegistration {
         let init = prepare_workerscope_init(global, None, Some(worker_id));
         let browsing_context_id = global
             .downcast::<Window>()
-            .map(|w| w.window_proxy().browsing_context_id())
+            .map(|w: &Window| w.window_proxy().browsing_context_id())
             .expect("Service worker must be registered from a Window global");
         let webview_id = global
             .webview_id()

--- a/components/script/dom/workers/serviceworkerregistration.rs
+++ b/components/script/dom/workers/serviceworkerregistration.rs
@@ -23,6 +23,7 @@ use crate::dom::eventtarget::EventTarget;
 use crate::dom::globalscope::GlobalScope;
 use crate::dom::navigationpreloadmanager::NavigationPreloadManager;
 use crate::dom::serviceworker::ServiceWorker;
+use crate::dom::window::Window;
 use crate::dom::workerglobalscope::prepare_workerscope_init;
 use crate::script_runtime::CanGc;
 
@@ -127,12 +128,21 @@ impl ServiceWorkerRegistration {
         let worker_id = WorkerId(Uuid::new_v4());
         let devtools_chan = global.devtools_chan().cloned();
         let init = prepare_workerscope_init(global, None, Some(worker_id));
+        let browsing_context_id = global
+            .downcast::<Window>()
+            .map(|w| w.window_proxy().browsing_context_id())
+            .expect("Service worker must be registered from a Window global");
+        let webview_id = global
+            .webview_id()
+            .expect("Service worker must have a WebViewId");
         ScopeThings {
             script_url,
             init,
             worker_load_origin,
             devtools_chan,
             worker_id,
+            browsing_context_id,
+            webview_id,
         }
     }
 

--- a/components/script/dom/workers/worker.rs
+++ b/components/script/dom/workers/worker.rs
@@ -227,6 +227,7 @@ impl WorkerMethods<crate::DomTypeHolder> for Worker {
                     title,
                     url: worker_url.clone(),
                     is_top_level_global: false,
+                    is_service_worker: false,
                 };
                 let _ = chan.send(ScriptToDevtoolsControlMsg::NewGlobal(
                     (browsing_context, pipeline_id, Some(worker_id), webview_id),

--- a/components/script/script_thread.rs
+++ b/components/script/script_thread.rs
@@ -3713,6 +3713,7 @@ impl ScriptThread {
                 title: String::from(title),
                 url,
                 is_top_level_global,
+                is_service_worker: false,
             };
             chan.send(ScriptToDevtoolsControlMsg::NewGlobal(
                 (browsing_context_id, pipeline_id, worker_id, webview_id),

--- a/components/script/serviceworker_manager.rs
+++ b/components/script/serviceworker_manager.rs
@@ -13,6 +13,7 @@ use std::sync::atomic::{AtomicBool, Ordering};
 use std::thread::{self, JoinHandle};
 
 use crossbeam_channel::{Receiver, Sender, select, unbounded};
+use devtools_traits::{DevtoolsPageInfo, ScriptToDevtoolsControlMsg};
 use fonts::FontContext;
 use ipc_channel::ipc;
 use ipc_channel::router::ROUTER;
@@ -24,7 +25,6 @@ use servo_constellation_traits::{
     DOMMessage, Job, JobError, JobResult, JobResultValue, JobType, SWManagerMsg, SWManagerSenders,
     ScopeThings, ServiceWorkerManagerFactory, ServiceWorkerMsg,
 };
-use devtools_traits::{DevtoolsPageInfo, ScriptToDevtoolsControlMsg};
 use servo_url::{ImmutableOrigin, ServoUrl};
 
 use crate::dom::abstractworker::{MessageData, WorkerScriptMsg};

--- a/components/script/serviceworker_manager.rs
+++ b/components/script/serviceworker_manager.rs
@@ -24,6 +24,7 @@ use servo_constellation_traits::{
     DOMMessage, Job, JobError, JobResult, JobResultValue, JobType, SWManagerMsg, SWManagerSenders,
     ScopeThings, ServiceWorkerManagerFactory, ServiceWorkerMsg,
 };
+use devtools_traits::{DevtoolsPageInfo, ScriptToDevtoolsControlMsg};
 use servo_url::{ImmutableOrigin, ServoUrl};
 
 use crate::dom::abstractworker::{MessageData, WorkerScriptMsg};
@@ -467,6 +468,27 @@ fn update_serviceworker(
     let (sender, receiver) = unbounded();
     let (devtools_sender, devtools_receiver) = generic_channel::channel().unwrap();
     scope_things.init.from_devtools_sender = Some(devtools_sender);
+
+    if let Some(ref chan) = scope_things.devtools_chan {
+        if let Some(ref sender) = scope_things.init.from_devtools_sender {
+            let page_info = DevtoolsPageInfo {
+                title: format!("Service Worker for {}", scope_things.script_url),
+                url: scope_things.script_url.clone(),
+                is_top_level_global: false,
+            };
+            let _ = chan.send(ScriptToDevtoolsControlMsg::NewGlobal(
+                (
+                    scope_things.browsing_context_id,
+                    scope_things.init.pipeline_id,
+                    Some(scope_things.worker_id),
+                    scope_things.webview_id,
+                ),
+                sender.clone(),
+                page_info,
+            ));
+        }
+    }
+
     let worker_id = ServiceWorkerId::new();
 
     let (control_sender, control_receiver) = unbounded();

--- a/components/script/serviceworker_manager.rs
+++ b/components/script/serviceworker_manager.rs
@@ -475,6 +475,7 @@ fn update_serviceworker(
                 title: format!("Service Worker for {}", scope_things.script_url),
                 url: scope_things.script_url.clone(),
                 is_top_level_global: false,
+                is_service_worker: true,
             };
             let _ = chan.send(ScriptToDevtoolsControlMsg::NewGlobal(
                 (

--- a/components/shared/constellation/from_script_message.rs
+++ b/components/shared/constellation/from_script_message.rs
@@ -219,6 +219,10 @@ pub struct ScopeThings {
     pub devtools_chan: Option<GenericCallback<ScriptToDevtoolsControlMsg>>,
     /// service worker id
     pub worker_id: WorkerId,
+    /// the browsing context id of the page that registered the service worker
+    pub browsing_context_id: BrowsingContextId,
+    /// the webview id of the page that registered the service worker
+    pub webview_id: WebViewId,
 }
 
 /// Message that gets passed to service worker scope on postMessage

--- a/components/shared/devtools/lib.rs
+++ b/components/shared/devtools/lib.rs
@@ -45,6 +45,7 @@ pub struct DevtoolsPageInfo {
     pub title: String,
     pub url: ServoUrl,
     pub is_top_level_global: bool,
+    pub is_service_worker: bool,
 }
 
 #[derive(Clone, Debug, Deserialize, MallocSizeOf, Serialize)]


### PR DESCRIPTION
This update makes service workers properly show up in DevTools and behave more like dedicated workers.

- Added an is_service_worker field to DevtoolsPageInfo so the devtools server can tell service workers apart from dedicated workers
- Triggered a NewGlobal message when a service worker is created in serviceworker_manager.rs, similar to what already happens for dedicated workers
- Routed service workers to root.service_workers so they appear under "Service Workers" in about:debugging instead of "Other Workers"
- Implemented listServiceWorkerRegistrations with the expected response format (activeWorker, installingWorker, waitingWorker, evaluatingWorker) to match Firefox’s LegacyServiceWorkersWatcher
- Added support for getPushSubscription in WorkerActor, currently returning subscription: null
Enabled the service_worker target type in the watcher’s SessionContext and handled watchTargets("service_worker")

Testing

Start Servo with:

`RUST_LOG="error,devtools=debug" ./mach run -- --pref=dom_serviceworker_enabled --devtools=6080 "https://mdn.github.io/dom-examples/service-worker/simple-service-worker/"
`

In Firefox, go to about:debugging and connect to localhost:6080
Confirm the service worker shows up under "Service Workers"



Fixes #43574
