### PR TITLE
script: Fix --unminify-js failing for URLs with query strings on Windows

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7181,6 +7181,7 @@ dependencies = [
  "servo-base",
  "servo-script",
  "servo-url",
+ "tempfile",
 ]
 
 [[package]]

--- a/components/script/dom/html/htmlscriptelement.rs
+++ b/components/script/dom/html/htmlscriptelement.rs
@@ -426,8 +426,10 @@ impl FetchResponseListener for ClassicContext {
         let elem = self.elem.root();
         let global = elem.global();
 
-        if let Some(window) = global.downcast::<Window>() {
-            substitute_with_local_script(window, &mut source_text, final_url.clone());
+        if let Some(window) = global.downcast::<Window>() &&
+            let Some(script_source) = window.local_script_source()
+        {
+            substitute_with_local_script(script_source, &mut source_text, final_url.clone());
         }
 
         // Step 5.6. Let mutedErrors be true if response was CORS-cross-origin, and false otherwise.
@@ -1455,16 +1457,9 @@ impl HTMLScriptElementMethods<crate::DomTypeHolder> for HTMLScriptElement {
     }
 }
 
-pub(crate) fn substitute_with_local_script(
-    window: &Window,
-    script: &mut Cow<'_, str>,
-    url: ServoUrl,
-) {
-    if window.local_script_source().is_none() {
-        return;
-    }
-    let mut path = PathBuf::from(window.local_script_source().clone().unwrap());
-    path = path.join(&url[url::Position::BeforeHost..]);
+pub fn substitute_with_local_script(script_source: &str, script: &mut Cow<'_, str>, url: ServoUrl) {
+    let mut path = PathBuf::from(script_source);
+    path = path.join(&url[url::Position::BeforeHost..url::Position::AfterPath]);
     debug!("Attempting to read script stored at: {:?}", path);
     match read_to_string(path.clone()) {
         Ok(local_script) => {

--- a/components/script/script_module.rs
+++ b/components/script/script_module.rs
@@ -845,8 +845,10 @@ impl FetchResponseListener for ModuleContext {
             if SCRIPT_JS_MIMES.contains(&mime.essence_str()) &&
                 matches!(module_type, ModuleType::JavaScript)
             {
-                if let Some(window) = global.downcast::<Window>() {
-                    substitute_with_local_script(window, &mut source_text, final_url.clone());
+                if let Some(window) = global.downcast::<Window>() &&
+                    let Some(script_souce) = window.local_script_source()
+                {
+                    substitute_with_local_script(script_souce, &mut source_text, final_url.clone());
                 }
 
                 let module_tree = Rc::new(ModuleTree::create_a_javascript_module_script(

--- a/components/script/test.rs
+++ b/components/script/test.rs
@@ -79,3 +79,7 @@ pub mod encoding_detection {
         get_xml_encoding, prescan_the_byte_stream_to_determine_the_encoding,
     };
 }
+
+pub mod unminify {
+    pub use crate::unminify::create_output_file;
+}

--- a/components/script/test.rs
+++ b/components/script/test.rs
@@ -81,5 +81,6 @@ pub mod encoding_detection {
 }
 
 pub mod unminify {
+    pub use crate::dom::html::htmlscriptelement::substitute_with_local_script;
     pub use crate::unminify::create_output_file;
 }

--- a/components/script/unminify.rs
+++ b/components/script/unminify.rs
@@ -65,22 +65,27 @@ pub(crate) fn execute_js_beautify(input: &Path, output: File, file_type: Beautif
     }
 }
 
-pub(crate) fn create_output_file(
+pub fn create_output_file(
     unminified_dir: String,
     url: &ServoUrl,
     external: Option<bool>,
 ) -> Result<File, Error> {
     let path = PathBuf::from(unminified_dir);
 
+    // Strip the query string from the URL before using it as a file path.
+    // '?' is a reserved character on Windows and causes file creation to fail
+    // silently. BeforeHost..AfterPath stops the slice before the '?' separator.
+    let url_path = &url[url::Position::BeforeHost..url::Position::AfterPath];
+
     let (base, has_name) = match url.as_str().ends_with('/') {
         true => (
-            path.join(&url[url::Position::BeforeHost..])
+            path.join(url_path)
                 .as_path()
                 .to_owned(),
             false,
         ),
         false => (
-            path.join(&url[url::Position::BeforeHost..])
+            path.join(url_path)
                 .parent()
                 .unwrap()
                 .to_owned(),
@@ -92,7 +97,7 @@ pub(crate) fn create_output_file(
 
     let path = if external.unwrap_or(true) && has_name {
         // External.
-        path.join(&url[url::Position::BeforeHost..])
+        path.join(url_path)
     } else {
         // Inline file or url ends with '/'
         base.join(Uuid::new_v4().to_string())

--- a/components/script/unminify.rs
+++ b/components/script/unminify.rs
@@ -78,19 +78,8 @@ pub fn create_output_file(
     let url_path = &url[url::Position::BeforeHost..url::Position::AfterPath];
 
     let (base, has_name) = match url.as_str().ends_with('/') {
-        true => (
-            path.join(url_path)
-                .as_path()
-                .to_owned(),
-            false,
-        ),
-        false => (
-            path.join(url_path)
-                .parent()
-                .unwrap()
-                .to_owned(),
-            true,
-        ),
+        true => (path.join(url_path).as_path().to_owned(), false),
+        false => (path.join(url_path).parent().unwrap().to_owned(), true),
     };
 
     create_dir_all(&base)?;

--- a/tests/unit/script/Cargo.toml
+++ b/tests/unit/script/Cargo.toml
@@ -18,3 +18,4 @@ keyboard-types = { workspace = true }
 script = { workspace = true }
 servo-base = { workspace = true }
 servo-url = { workspace = true }
+tempfile = "3"

--- a/tests/unit/script/Cargo.toml
+++ b/tests/unit/script/Cargo.toml
@@ -18,4 +18,4 @@ keyboard-types = { workspace = true }
 script = { workspace = true }
 servo-base = { workspace = true }
 servo-url = { workspace = true }
-tempfile = "3"
+tempfile = { workspace = true }

--- a/tests/unit/script/lib.rs
+++ b/tests/unit/script/lib.rs
@@ -5,6 +5,8 @@
 #[cfg(test)]
 mod encoding_detection;
 #[cfg(test)]
+mod unminify;
+#[cfg(test)]
 mod htmlareaelement;
 #[cfg(test)]
 mod htmlimageelement;

--- a/tests/unit/script/lib.rs
+++ b/tests/unit/script/lib.rs
@@ -5,8 +5,6 @@
 #[cfg(test)]
 mod encoding_detection;
 #[cfg(test)]
-mod unminify;
-#[cfg(test)]
 mod htmlareaelement;
 #[cfg(test)]
 mod htmlimageelement;
@@ -18,6 +16,8 @@ mod size_of;
 mod textinput;
 #[cfg(test)]
 mod timeranges;
+#[cfg(test)]
+mod unminify;
 
 /**
 ```compile_fail,E0277

--- a/tests/unit/script/unminify.rs
+++ b/tests/unit/script/unminify.rs
@@ -1,0 +1,35 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+use script::test::unminify::create_output_file;
+use servo_url::ServoUrl;
+
+#[test]
+fn test_create_output_file_with_query_string() {
+    let dir = tempfile::tempdir().expect("create temp dir");
+    let url = ServoUrl::parse("https://example.com/app.js?v=abc123&t=456").unwrap();
+
+    let result = create_output_file(dir.path().to_str().unwrap().to_owned(), &url, Some(true));
+
+    assert!(result.is_ok(), "file creation failed: {:?}", result.err());
+    assert!(
+        dir.path().join("example.com/app.js").exists(),
+        "expected file at path without query string"
+    );
+    assert!(
+        !dir.path().join("example.com/app.js?v=abc123&t=456").exists(),
+        "file must not have '?' in its name (reserved on Windows)"
+    );
+}
+
+#[test]
+fn test_create_output_file_without_query_string() {
+    let dir = tempfile::tempdir().expect("create temp dir");
+    let url = ServoUrl::parse("https://example.com/app.js").unwrap();
+
+    let result = create_output_file(dir.path().to_str().unwrap().to_owned(), &url, Some(true));
+
+    assert!(result.is_ok());
+    assert!(dir.path().join("example.com/app.js").exists());
+}

--- a/tests/unit/script/unminify.rs
+++ b/tests/unit/script/unminify.rs
@@ -2,7 +2,10 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-use script::test::unminify::create_output_file;
+use std::borrow::Cow;
+use std::io::Write;
+
+use script::test::unminify::{create_output_file, substitute_with_local_script};
 use servo_url::ServoUrl;
 
 #[test]
@@ -18,7 +21,9 @@ fn test_create_output_file_with_query_string() {
         "expected file at path without query string"
     );
     assert!(
-        !dir.path().join("example.com/app.js?v=abc123&t=456").exists(),
+        !dir.path()
+            .join("example.com/app.js?v=abc123&t=456")
+            .exists(),
         "file must not have '?' in its name (reserved on Windows)"
     );
 }
@@ -32,4 +37,36 @@ fn test_create_output_file_without_query_string() {
 
     assert!(result.is_ok());
     assert!(dir.path().join("example.com/app.js").exists());
+}
+
+#[test]
+fn replace_script_with_query_string() {
+    let dir = tempfile::tempdir().expect("create temp dir");
+    let url = ServoUrl::parse("https://example.com/app.js?query=true").unwrap();
+
+    {
+        let mut result =
+            create_output_file(dir.path().to_str().unwrap().to_owned(), &url, Some(true)).unwrap();
+        result.write(b"pass").unwrap();
+    }
+
+    let mut script = Cow::from("fail");
+    substitute_with_local_script(&format!("{}", dir.path().display()), &mut script, url);
+    assert_eq!(script, "pass");
+}
+
+#[test]
+fn replace_script_without_query_string() {
+    let dir = tempfile::tempdir().expect("create temp dir");
+    let url = ServoUrl::parse("https://example.com/app.js").unwrap();
+
+    {
+        let mut result =
+            create_output_file(dir.path().to_str().unwrap().to_owned(), &url, Some(true)).unwrap();
+        result.write(b"pass").unwrap();
+    }
+
+    let mut script = Cow::from("fail");
+    substitute_with_local_script(&format!("{}", dir.path().display()), &mut script, url);
+    assert_eq!(script, "pass");
 }


### PR DESCRIPTION
 `?` is a reserved character in Windows filenames. When `--unminify-js` is used
  with a script URL containing a query string (e.g. `app.js?v=abc123`), passing
  the full URL directly to `PathBuf` causes file creation to fail silently with
  `ERROR_INVALID_NAME`. Fix by slicing the URL up to `url::Position::AfterPath`
  (before `?`) when building the output file path.

  Testing: Tested manually by running Servo with `--unminify-js` against a page
  with query-string script URLs and verifying the output file is created without
  `?` in the filename. Unit tests added in `tests/unit/script/unminify.rs`.
  Fixes: #41108
