### PR TITLE
devtools: Rename TabDescriptorActor variable names

### DIFF
--- a/components/devtools/actors/browsing_context.rs
+++ b/components/devtools/actors/browsing_context.rs
@@ -233,7 +233,8 @@ impl BrowsingContextActor {
 
         let style_sheets = StyleSheetsActor::new(registry.new_name::<StyleSheetsActor>());
 
-        let tabdesc = TabDescriptorActor::new(registry, name.clone(), is_top_level_global);
+        let tab_descriptor_actor =
+            TabDescriptorActor::new(registry, name.clone(), is_top_level_global);
 
         let thread = ThreadActor::new(
             registry.new_name::<ThreadActor>(),
@@ -265,7 +266,7 @@ impl BrowsingContextActor {
             inspector,
             reflow: reflow.name(),
             style_sheets: style_sheets.name(),
-            _tab: tabdesc.name(),
+            _tab: tab_descriptor_actor.name(),
             thread: thread.name(),
             watcher: watcher.name(),
         };
@@ -274,7 +275,7 @@ impl BrowsingContextActor {
         registry.register(css_properties);
         registry.register(reflow);
         registry.register(style_sheets);
-        registry.register(tabdesc);
+        registry.register(tab_descriptor_actor);
         registry.register(thread);
         registry.register(watcher);
 

--- a/components/devtools/actors/root.rs
+++ b/components/devtools/actors/root.rs
@@ -14,7 +14,7 @@ use std::collections::HashMap;
 use atomic_refcell::AtomicRefCell;
 use malloc_size_of_derive::MallocSizeOf;
 use serde::Serialize;
-use serde_json::{Map, Value, json};
+use serde_json::{Map, Value};
 
 use crate::actor::{Actor, ActorEncode, ActorError, ActorRegistry};
 use crate::actors::device::DeviceActor;
@@ -154,9 +154,9 @@ impl Actor for RootActor {
     ) -> Result<(), ActorError> {
         match msg_type {
             "connect" => {
-                let message = json!({
-                    "from": "root",
-                });
+                let message = EmptyReplyMsg {
+                    from: "root".into(),
+                };
                 request.reply_final(&message)?
             },
 
@@ -171,11 +171,11 @@ impl Actor for RootActor {
             },
 
             "getRoot" => {
-                let actor = GetRootReply {
+                let reply = GetRootReply {
                     from: "root".to_owned(),
                     global_actors: self.global_actors.clone(),
                 };
-                request.reply_final(&actor)?
+                request.reply_final(&reply)?
             },
 
             "getTab" => {
@@ -196,11 +196,11 @@ impl Actor for RootActor {
             },
 
             "listAddons" => {
-                let actor = ListAddonsReply {
+                let reply = ListAddonsReply {
                     from: "root".to_owned(),
                     addons: vec![],
                 };
-                request.reply_final(&actor)?
+                request.reply_final(&reply)?
             },
 
             "listProcesses" => {
@@ -221,24 +221,25 @@ impl Actor for RootActor {
             },
 
             "listTabs" => {
-                let actor = ListTabsReply {
+                let reply = ListTabsReply {
                     from: "root".to_owned(),
                     tabs: self
                         .tabs
                         .borrow()
                         .iter()
-                        .filter_map(|target| {
-                            let tab_actor = registry.find::<TabDescriptorActor>(target);
+                        .filter_map(|tab_descriptor_name| {
+                            let tab_descriptor_actor =
+                                registry.find::<TabDescriptorActor>(tab_descriptor_name);
                             // Filter out iframes and workers
-                            if tab_actor.is_top_level_global() {
-                                Some(tab_actor.encode(registry))
+                            if tab_descriptor_actor.is_top_level_global() {
+                                Some(tab_descriptor_actor.encode(registry))
                             } else {
                                 None
                             }
                         })
                         .collect(),
                 };
-                request.reply_final(&actor)?
+                request.reply_final(&reply)?
             },
 
             "listWorkers" => {
@@ -319,8 +320,10 @@ impl RootActor {
             .tabs
             .borrow()
             .iter()
-            .map(|target| registry.encode::<TabDescriptorActor, _>(target))
-            .find(|tab| tab.browser_id() == browser_id);
+            .map(|tab_descriptor_name| {
+                registry.encode::<TabDescriptorActor, _>(tab_descriptor_name)
+            })
+            .find(|tab_descriptor_actor| tab_descriptor_actor.browser_id() == browser_id);
 
         if let Some(ref mut msg) = tab_msg {
             msg.selected = true;

--- a/components/devtools/actors/watcher/target_configuration.rs
+++ b/components/devtools/actors/watcher/target_configuration.rs
@@ -77,8 +77,8 @@ impl Actor for TargetConfigurationActor {
                     };
                     let root_actor = registry.find::<RootActor>("root");
                     if let Some(tab_name) = root_actor.active_tab() {
-                        let tab_actor = registry.find::<TabDescriptorActor>(&tab_name);
-                        let browsing_context_name = tab_actor.browsing_context();
+                        let tab_descriptor_actor = registry.find::<TabDescriptorActor>(&tab_name);
+                        let browsing_context_name = tab_descriptor_actor.browsing_context();
                         let browsing_context_actor =
                             registry.find::<BrowsingContextActor>(&browsing_context_name);
                         browsing_context_actor


### PR DESCRIPTION
Renamed TabDescriptorActor variable names in browsing_context, root & target_configuration

Cleaned up a few more names as suggested by eerii

Testing: No testing required
Fixes: Part of #43606 