### PR TITLE
script: Merge Window::load_url with ScriptThread::navigate

### DIFF
--- a/components/script/dom/document/document.rs
+++ b/components/script/dom/document/document.rs
@@ -198,9 +198,9 @@ use crate::iframe_collection::IFrameCollection;
 use crate::image_animation::ImageAnimationManager;
 use crate::messaging::{CommonScriptMsg, MainThreadScriptMsg};
 use crate::mime::{APPLICATION, CHARSET};
+use crate::navigation::navigate;
 use crate::network_listener::{FetchResponseListener, NetworkListener};
 use crate::realms::{AlreadyInRealm, InRealm, enter_realm};
-use crate::navigation::navigate;
 use crate::script_runtime::{CanGc, ScriptThreadEventCategory};
 use crate::script_thread::ScriptThread;
 use crate::stylesheet_set::StylesheetSetRef;
@@ -252,7 +252,13 @@ impl RefreshRedirectDue {
         let load_data = self
             .window
             .load_data_for_document(self.url.clone(), self.window.pipeline_id());
-        navigate(&self.window, NavigationHistoryBehavior::Replace, false, load_data, can_gc);
+        navigate(
+            &self.window,
+            NavigationHistoryBehavior::Replace,
+            false,
+            load_data,
+            can_gc,
+        );
     }
 }
 

--- a/components/script/dom/document/document.rs
+++ b/components/script/dom/document/document.rs
@@ -200,6 +200,7 @@ use crate::messaging::{CommonScriptMsg, MainThreadScriptMsg};
 use crate::mime::{APPLICATION, CHARSET};
 use crate::network_listener::{FetchResponseListener, NetworkListener};
 use crate::realms::{AlreadyInRealm, InRealm, enter_realm};
+use crate::navigation::navigate;
 use crate::script_runtime::{CanGc, ScriptThreadEventCategory};
 use crate::script_thread::ScriptThread;
 use crate::stylesheet_set::StylesheetSetRef;
@@ -251,8 +252,7 @@ impl RefreshRedirectDue {
         let load_data = self
             .window
             .load_data_for_document(self.url.clone(), self.window.pipeline_id());
-        self.window
-            .load_url(NavigationHistoryBehavior::Replace, false, load_data, can_gc);
+        navigate(&self.window, NavigationHistoryBehavior::Replace, false, load_data, can_gc);
     }
 }
 

--- a/components/script/dom/document/document_embedder_controls.rs
+++ b/components/script/dom/document/document_embedder_controls.rs
@@ -39,6 +39,7 @@ use crate::dom::types::{
     HTMLTextAreaElement, Window,
 };
 use crate::messaging::MainThreadScriptMsg;
+use crate::navigation::navigate;
 
 #[derive(JSTraceable, MallocSizeOf)]
 pub(crate) enum ControlElement {
@@ -439,7 +440,7 @@ impl ContextMenuNodes {
             let target = Trusted::new(target_window);
             let load_data = LoadData::new_for_new_unrelated_webview(url);
             let task = task!(open_link_in_new_webview: move || {
-                target.root().load_url(NavigationHistoryBehavior::Replace, false, load_data, CanGc::note());
+                navigate(&target.root(), NavigationHistoryBehavior::Replace, false, load_data, CanGc::note());
             });
             target_document
                 .owner_global()

--- a/components/script/dom/html/htmlformelement.rs
+++ b/components/script/dom/html/htmlformelement.rs
@@ -86,6 +86,7 @@ use crate::dom::types::HTMLIFrameElement;
 use crate::dom::virtualmethods::VirtualMethods;
 use crate::dom::window::Window;
 use crate::links::{LinkRelations, get_element_target, valid_navigable_target_name_or_keyword};
+use crate::navigation::navigate;
 use crate::script_runtime::CanGc;
 use crate::script_thread::ScriptThread;
 
@@ -1109,14 +1110,13 @@ impl HTMLFormElement {
             }
 
             // 4.2 Navigate targetNavigable to url
-            window
-                .root()
-                .load_url(
-                    NavigationHistoryBehavior::Push,
-                    false,
-                    load_data,
-                    CanGc::note(),
-                );
+            navigate(
+                &window.root(),
+                NavigationHistoryBehavior::Push,
+                false,
+                load_data,
+                CanGc::note(),
+            );
         });
 
         // 5. Set the form's planned navigation to the just-queued task.

--- a/components/script/dom/location.rs
+++ b/components/script/dom/location.rs
@@ -84,7 +84,13 @@ impl Location {
             history_handling
         };
         // Step 4. Navigate navigable to url using sourceDocument, with exceptionsEnabled set to true and historyHandling set to historyHandling.
-        navigate(navigable, history_handling, false, load_data, CanGc::from_cx(cx));
+        navigate(
+            navigable,
+            history_handling,
+            false,
+            load_data,
+            CanGc::from_cx(cx),
+        );
     }
 
     /// Navigate the relevant `Document`'s browsing context.
@@ -480,9 +486,9 @@ impl LocationMethods<crate::DomTypeHolder> for Location {
         self.setter_common(cx, |mut copy_url| {
             // Step 4: If copyURL cannot have a username/password/port, then return.
             // https://url.spec.whatwg.org/#cannot-have-a-username-password-port
-            if copy_url.host().is_none() ||
-                copy_url.cannot_be_a_base() ||
-                copy_url.scheme() == "file"
+            if copy_url.host().is_none()
+                || copy_url.cannot_be_a_base()
+                || copy_url.scheme() == "file"
             {
                 return Ok(None);
             }
@@ -519,8 +525,8 @@ impl LocationMethods<crate::DomTypeHolder> for Location {
             }
 
             // Step 6: If copyURL's scheme is not an HTTP(S) scheme, then terminate these steps.
-            if !copy_url.scheme().eq_ignore_ascii_case("http") &&
-                !copy_url.scheme().eq_ignore_ascii_case("https")
+            if !copy_url.scheme().eq_ignore_ascii_case("http")
+                && !copy_url.scheme().eq_ignore_ascii_case("https")
             {
                 return Ok(None);
             }

--- a/components/script/dom/location.rs
+++ b/components/script/dom/location.rs
@@ -84,7 +84,7 @@ impl Location {
             history_handling
         };
         // Step 4. Navigate navigable to url using sourceDocument, with exceptionsEnabled set to true and historyHandling set to historyHandling.
-        navigate(&navigable, history_handling, false, load_data, CanGc::from_cx(cx));
+        navigate(navigable, history_handling, false, load_data, CanGc::from_cx(cx));
     }
 
     /// Navigate the relevant `Document`'s browsing context.

--- a/components/script/dom/location.rs
+++ b/components/script/dom/location.rs
@@ -486,9 +486,9 @@ impl LocationMethods<crate::DomTypeHolder> for Location {
         self.setter_common(cx, |mut copy_url| {
             // Step 4: If copyURL cannot have a username/password/port, then return.
             // https://url.spec.whatwg.org/#cannot-have-a-username-password-port
-            if copy_url.host().is_none()
-                || copy_url.cannot_be_a_base()
-                || copy_url.scheme() == "file"
+            if copy_url.host().is_none() ||
+                copy_url.cannot_be_a_base() ||
+                copy_url.scheme() == "file"
             {
                 return Ok(None);
             }
@@ -525,8 +525,8 @@ impl LocationMethods<crate::DomTypeHolder> for Location {
             }
 
             // Step 6: If copyURL's scheme is not an HTTP(S) scheme, then terminate these steps.
-            if !copy_url.scheme().eq_ignore_ascii_case("http")
-                && !copy_url.scheme().eq_ignore_ascii_case("https")
+            if !copy_url.scheme().eq_ignore_ascii_case("http") &&
+                !copy_url.scheme().eq_ignore_ascii_case("https")
             {
                 return Ok(None);
             }

--- a/components/script/dom/location.rs
+++ b/components/script/dom/location.rs
@@ -18,6 +18,7 @@ use crate::dom::document::Document;
 use crate::dom::globalscope::GlobalScope;
 use crate::dom::urlhelper::UrlHelper;
 use crate::dom::window::Window;
+use crate::navigation::navigate;
 use crate::script_runtime::CanGc;
 
 #[derive(PartialEq)]
@@ -83,7 +84,7 @@ impl Location {
             history_handling
         };
         // Step 4. Navigate navigable to url using sourceDocument, with exceptionsEnabled set to true and historyHandling set to historyHandling.
-        navigable.load_url(history_handling, false, load_data, CanGc::from_cx(cx));
+        navigate(&navigable, history_handling, false, load_data, CanGc::from_cx(cx));
     }
 
     /// Navigate the relevant `Document`'s browsing context.
@@ -155,7 +156,8 @@ impl Location {
             source_document.has_trustworthy_ancestor_origin(),
             source_document.creation_sandboxing_flag_set_considering_parent_iframe(),
         );
-        self.window.load_url(
+        navigate(
+            &self.window,
             history_handling,
             reload_triggered,
             load_data,

--- a/components/script/dom/window.rs
+++ b/components/script/dom/window.rs
@@ -1384,9 +1384,9 @@ impl WindowMethods<crate::DomTypeHolder> for Window {
             let is_auxiliary = window_proxy.is_auxiliary();
 
             // https://html.spec.whatwg.org/multipage/#script-closable
-            let is_script_closable = (self.is_top_level() && history_length == 1)
-                || is_auxiliary
-                || pref!(dom_allow_scripts_to_close_windows);
+            let is_script_closable = (self.is_top_level() && history_length == 1) ||
+                is_auxiliary ||
+                pref!(dom_allow_scripts_to_close_windows);
 
             // TODO: rest of Step 3:
             // Is the incumbent settings object's responsible browsing context familiar with current?
@@ -1802,8 +1802,8 @@ impl WindowMethods<crate::DomTypeHolder> for Window {
                 iframe
                     .browsing_context_id()
                     .as_ref()
-                    .map(BrowsingContextId::to_string)
-                    == Some(browsing_context_id.to_string())
+                    .map(BrowsingContextId::to_string) ==
+                    Some(browsing_context_id.to_string())
             })
             .and_then(|iframe| iframe.GetContentWindow())
     }
@@ -2240,10 +2240,10 @@ impl WindowMethods<crate::DomTypeHolder> for Window {
                     return true;
                 }
                 match type_ {
-                    HTMLElementTypeId::HTMLEmbedElement
-                    | HTMLElementTypeId::HTMLFormElement
-                    | HTMLElementTypeId::HTMLImageElement
-                    | HTMLElementTypeId::HTMLObjectElement => {
+                    HTMLElementTypeId::HTMLEmbedElement |
+                    HTMLElementTypeId::HTMLFormElement |
+                    HTMLElementTypeId::HTMLImageElement |
+                    HTMLElementTypeId::HTMLObjectElement => {
                         elem.get_name().as_ref() == Some(&self.name)
                     },
                     _ => false,
@@ -2561,8 +2561,8 @@ impl Window {
         // layouts (for queries and scrolling) are not blocked, as they do not display
         // anything and script expects the layout to be up-to-date after they run.
         let pipeline_id = self.pipeline_id();
-        if reflow_goal == ReflowGoal::UpdateTheRendering
-            && self.layout_blocker.get().layout_blocked()
+        if reflow_goal == ReflowGoal::UpdateTheRendering &&
+            self.layout_blocker.get().layout_blocked()
         {
             debug!("Suppressing pre-load-event reflow pipeline {pipeline_id}");
             return Default::default();
@@ -2673,8 +2673,8 @@ impl Window {
         // See http://testthewebforward.org/docs/reftests.html
         // and https://web-platform-tests.org/writing-tests/crashtest.html
         if document.GetDocumentElement().is_some_and(|elem| {
-            elem.has_class(&atom!("reftest-wait"), CaseSensitivity::CaseSensitive)
-                || elem.has_class(&Atom::from("test-wait"), CaseSensitivity::CaseSensitive)
+            elem.has_class(&atom!("reftest-wait"), CaseSensitivity::CaseSensitive) ||
+                elem.has_class(&Atom::from("test-wait"), CaseSensitivity::CaseSensitive)
         }) {
             return;
         }
@@ -2687,8 +2687,8 @@ impl Window {
             return;
         }
 
-        if !self.pending_layout_images.borrow().is_empty()
-            || !self.pending_images_for_rasterization.borrow().is_empty()
+        if !self.pending_layout_images.borrow().is_empty() ||
+            !self.pending_images_for_rasterization.borrow().is_empty()
         {
             return;
         }
@@ -3192,8 +3192,8 @@ impl Window {
     ) {
         // We doesn't need to do anything if the following condition is fulfilled. Since there are no JS listener
         // to fire and we could reconstruct visual viewport from layout viewport in case JS access it.
-        if pinch_zoom_infos.rect == Rect::from_size(self.viewport_details().size)
-            && self.visual_viewport.get().is_none()
+        if pinch_zoom_infos.rect == Rect::from_size(self.viewport_details().size) &&
+            self.visual_viewport.get().is_none()
         {
             return;
         }
@@ -3571,8 +3571,8 @@ impl Window {
     /// <https://html.spec.whatwg.org/multipage/#sticky-activation>
     pub(crate) fn has_sticky_activation(&self) -> bool {
         // > When the current high resolution time given W is greater than or equal to the last activation timestamp in W, W is said to have sticky activation.
-        UserActivationTimestamp::TimeStamp(CrossProcessInstant::now())
-            >= self.last_activation_timestamp.get()
+        UserActivationTimestamp::TimeStamp(CrossProcessInstant::now()) >=
+            self.last_activation_timestamp.get()
     }
 
     /// <https://html.spec.whatwg.org/multipage/#transient-activation>
@@ -3580,9 +3580,10 @@ impl Window {
         // > When the current high resolution time given W is greater than or equal to the last activation timestamp in W, and less than the last activation
         // > timestamp in W plus the transient activation duration, then W is said to have transient activation.
         let current_time = CrossProcessInstant::now();
-        UserActivationTimestamp::TimeStamp(current_time) >= self.last_activation_timestamp.get()
-            && UserActivationTimestamp::TimeStamp(current_time)
-                < self.last_activation_timestamp.get() + pref!(dom_transient_activation_duration_ms)
+        UserActivationTimestamp::TimeStamp(current_time) >= self.last_activation_timestamp.get() &&
+            UserActivationTimestamp::TimeStamp(current_time) <
+                self.last_activation_timestamp.get() +
+                    pref!(dom_transient_activation_duration_ms)
     }
 
     pub(crate) fn consume_last_activation_timestamp(&self) {
@@ -3822,10 +3823,10 @@ fn should_move_clip_rect(clip_rect: UntypedRect<Au>, new_viewport: UntypedRect<f
     static VIEWPORT_SCROLL_MARGIN_SIZE: f32 = 0.5;
     let viewport_scroll_margin = new_viewport.size * VIEWPORT_SCROLL_MARGIN_SIZE;
 
-    (clip_rect.origin.x - new_viewport.origin.x).abs() <= viewport_scroll_margin.width
-        || (clip_rect.max_x() - new_viewport.max_x()).abs() <= viewport_scroll_margin.width
-        || (clip_rect.origin.y - new_viewport.origin.y).abs() <= viewport_scroll_margin.height
-        || (clip_rect.max_y() - new_viewport.max_y()).abs() <= viewport_scroll_margin.height
+    (clip_rect.origin.x - new_viewport.origin.x).abs() <= viewport_scroll_margin.width ||
+        (clip_rect.max_x() - new_viewport.max_x()).abs() <= viewport_scroll_margin.width ||
+        (clip_rect.origin.y - new_viewport.origin.y).abs() <= viewport_scroll_margin.height ||
+        (clip_rect.max_y() - new_viewport.max_y()).abs() <= viewport_scroll_margin.height
 }
 
 impl Window {
@@ -3926,10 +3927,10 @@ fn is_named_element_with_name_attribute(elem: &Element) -> bool {
     };
     matches!(
         type_,
-        HTMLElementTypeId::HTMLEmbedElement
-            | HTMLElementTypeId::HTMLFormElement
-            | HTMLElementTypeId::HTMLImageElement
-            | HTMLElementTypeId::HTMLObjectElement
+        HTMLElementTypeId::HTMLEmbedElement |
+            HTMLElementTypeId::HTMLFormElement |
+            HTMLElementTypeId::HTMLImageElement |
+            HTMLElementTypeId::HTMLObjectElement
     )
 }
 

--- a/components/script/dom/window.rs
+++ b/components/script/dom/window.rs
@@ -1384,9 +1384,9 @@ impl WindowMethods<crate::DomTypeHolder> for Window {
             let is_auxiliary = window_proxy.is_auxiliary();
 
             // https://html.spec.whatwg.org/multipage/#script-closable
-            let is_script_closable = (self.is_top_level() && history_length == 1) ||
-                is_auxiliary ||
-                pref!(dom_allow_scripts_to_close_windows);
+            let is_script_closable = (self.is_top_level() && history_length == 1)
+                || is_auxiliary
+                || pref!(dom_allow_scripts_to_close_windows);
 
             // TODO: rest of Step 3:
             // Is the incumbent settings object's responsible browsing context familiar with current?
@@ -1802,8 +1802,8 @@ impl WindowMethods<crate::DomTypeHolder> for Window {
                 iframe
                     .browsing_context_id()
                     .as_ref()
-                    .map(BrowsingContextId::to_string) ==
-                    Some(browsing_context_id.to_string())
+                    .map(BrowsingContextId::to_string)
+                    == Some(browsing_context_id.to_string())
             })
             .and_then(|iframe| iframe.GetContentWindow())
     }
@@ -2240,10 +2240,10 @@ impl WindowMethods<crate::DomTypeHolder> for Window {
                     return true;
                 }
                 match type_ {
-                    HTMLElementTypeId::HTMLEmbedElement |
-                    HTMLElementTypeId::HTMLFormElement |
-                    HTMLElementTypeId::HTMLImageElement |
-                    HTMLElementTypeId::HTMLObjectElement => {
+                    HTMLElementTypeId::HTMLEmbedElement
+                    | HTMLElementTypeId::HTMLFormElement
+                    | HTMLElementTypeId::HTMLImageElement
+                    | HTMLElementTypeId::HTMLObjectElement => {
                         elem.get_name().as_ref() == Some(&self.name)
                     },
                     _ => false,
@@ -2561,8 +2561,8 @@ impl Window {
         // layouts (for queries and scrolling) are not blocked, as they do not display
         // anything and script expects the layout to be up-to-date after they run.
         let pipeline_id = self.pipeline_id();
-        if reflow_goal == ReflowGoal::UpdateTheRendering &&
-            self.layout_blocker.get().layout_blocked()
+        if reflow_goal == ReflowGoal::UpdateTheRendering
+            && self.layout_blocker.get().layout_blocked()
         {
             debug!("Suppressing pre-load-event reflow pipeline {pipeline_id}");
             return Default::default();
@@ -2673,8 +2673,8 @@ impl Window {
         // See http://testthewebforward.org/docs/reftests.html
         // and https://web-platform-tests.org/writing-tests/crashtest.html
         if document.GetDocumentElement().is_some_and(|elem| {
-            elem.has_class(&atom!("reftest-wait"), CaseSensitivity::CaseSensitive) ||
-                elem.has_class(&Atom::from("test-wait"), CaseSensitivity::CaseSensitive)
+            elem.has_class(&atom!("reftest-wait"), CaseSensitivity::CaseSensitive)
+                || elem.has_class(&Atom::from("test-wait"), CaseSensitivity::CaseSensitive)
         }) {
             return;
         }
@@ -2687,8 +2687,8 @@ impl Window {
             return;
         }
 
-        if !self.pending_layout_images.borrow().is_empty() ||
-            !self.pending_images_for_rasterization.borrow().is_empty()
+        if !self.pending_layout_images.borrow().is_empty()
+            || !self.pending_images_for_rasterization.borrow().is_empty()
         {
             return;
         }
@@ -3089,7 +3089,11 @@ impl Window {
     }
 
     /// <https://html.spec.whatwg.org/multipage/#navigate-fragid>
-    pub(crate) fn navigate_to_fragment(&self, url: &ServoUrl, history_handling: NavigationHistoryBehavior) {
+    pub(crate) fn navigate_to_fragment(
+        &self,
+        url: &ServoUrl,
+        history_handling: NavigationHistoryBehavior,
+    ) {
         let doc = self.Document();
         // Step 1. Let navigation be navigable's active window's navigation API.
         // TODO
@@ -3188,8 +3192,8 @@ impl Window {
     ) {
         // We doesn't need to do anything if the following condition is fulfilled. Since there are no JS listener
         // to fire and we could reconstruct visual viewport from layout viewport in case JS access it.
-        if pinch_zoom_infos.rect == Rect::from_size(self.viewport_details().size) &&
-            self.visual_viewport.get().is_none()
+        if pinch_zoom_infos.rect == Rect::from_size(self.viewport_details().size)
+            && self.visual_viewport.get().is_none()
         {
             return;
         }
@@ -3312,7 +3316,9 @@ impl Window {
         *self.webdriver_load_status_sender.borrow_mut() = sender;
     }
 
-    pub(crate) fn webdriver_load_status_sender(&self) -> Option<GenericSender<WebDriverLoadStatus>> {
+    pub(crate) fn webdriver_load_status_sender(
+        &self,
+    ) -> Option<GenericSender<WebDriverLoadStatus>> {
         self.webdriver_load_status_sender.borrow().clone()
     }
 
@@ -3565,8 +3571,8 @@ impl Window {
     /// <https://html.spec.whatwg.org/multipage/#sticky-activation>
     pub(crate) fn has_sticky_activation(&self) -> bool {
         // > When the current high resolution time given W is greater than or equal to the last activation timestamp in W, W is said to have sticky activation.
-        UserActivationTimestamp::TimeStamp(CrossProcessInstant::now()) >=
-            self.last_activation_timestamp.get()
+        UserActivationTimestamp::TimeStamp(CrossProcessInstant::now())
+            >= self.last_activation_timestamp.get()
     }
 
     /// <https://html.spec.whatwg.org/multipage/#transient-activation>
@@ -3574,10 +3580,9 @@ impl Window {
         // > When the current high resolution time given W is greater than or equal to the last activation timestamp in W, and less than the last activation
         // > timestamp in W plus the transient activation duration, then W is said to have transient activation.
         let current_time = CrossProcessInstant::now();
-        UserActivationTimestamp::TimeStamp(current_time) >= self.last_activation_timestamp.get() &&
-            UserActivationTimestamp::TimeStamp(current_time) <
-                self.last_activation_timestamp.get() +
-                    pref!(dom_transient_activation_duration_ms)
+        UserActivationTimestamp::TimeStamp(current_time) >= self.last_activation_timestamp.get()
+            && UserActivationTimestamp::TimeStamp(current_time)
+                < self.last_activation_timestamp.get() + pref!(dom_transient_activation_duration_ms)
     }
 
     pub(crate) fn consume_last_activation_timestamp(&self) {
@@ -3817,10 +3822,10 @@ fn should_move_clip_rect(clip_rect: UntypedRect<Au>, new_viewport: UntypedRect<f
     static VIEWPORT_SCROLL_MARGIN_SIZE: f32 = 0.5;
     let viewport_scroll_margin = new_viewport.size * VIEWPORT_SCROLL_MARGIN_SIZE;
 
-    (clip_rect.origin.x - new_viewport.origin.x).abs() <= viewport_scroll_margin.width ||
-        (clip_rect.max_x() - new_viewport.max_x()).abs() <= viewport_scroll_margin.width ||
-        (clip_rect.origin.y - new_viewport.origin.y).abs() <= viewport_scroll_margin.height ||
-        (clip_rect.max_y() - new_viewport.max_y()).abs() <= viewport_scroll_margin.height
+    (clip_rect.origin.x - new_viewport.origin.x).abs() <= viewport_scroll_margin.width
+        || (clip_rect.max_x() - new_viewport.max_x()).abs() <= viewport_scroll_margin.width
+        || (clip_rect.origin.y - new_viewport.origin.y).abs() <= viewport_scroll_margin.height
+        || (clip_rect.max_y() - new_viewport.max_y()).abs() <= viewport_scroll_margin.height
 }
 
 impl Window {
@@ -3921,10 +3926,10 @@ fn is_named_element_with_name_attribute(elem: &Element) -> bool {
     };
     matches!(
         type_,
-        HTMLElementTypeId::HTMLEmbedElement |
-            HTMLElementTypeId::HTMLFormElement |
-            HTMLElementTypeId::HTMLImageElement |
-            HTMLElementTypeId::HTMLObjectElement
+        HTMLElementTypeId::HTMLEmbedElement
+            | HTMLElementTypeId::HTMLFormElement
+            | HTMLElementTypeId::HTMLImageElement
+            | HTMLElementTypeId::HTMLObjectElement
     )
 }
 

--- a/components/script/dom/window.rs
+++ b/components/script/dom/window.rs
@@ -96,7 +96,6 @@ use style::str::HTML_SPACE_CHARACTERS;
 use style::stylesheets::UrlExtraData;
 use style_traits::CSSPixel;
 use stylo_atoms::Atom;
-use url::Position;
 use webrender_api::ExternalScrollId;
 use webrender_api::units::{DeviceIntSize, DevicePixel, LayoutPixel, LayoutPoint};
 
@@ -3090,7 +3089,7 @@ impl Window {
     }
 
     /// <https://html.spec.whatwg.org/multipage/#navigate-fragid>
-    fn navigate_to_fragment(&self, url: &ServoUrl, history_handling: NavigationHistoryBehavior) {
+    pub(crate) fn navigate_to_fragment(&self, url: &ServoUrl, history_handling: NavigationHistoryBehavior) {
         let doc = self.Document();
         // Step 1. Let navigation be navigable's active window's navigation API.
         // TODO
@@ -3158,112 +3157,6 @@ impl Window {
             source_document.has_trustworthy_ancestor_origin(),
             source_document.creation_sandboxing_flag_set_considering_parent_iframe(),
         )
-    }
-
-    /// <https://html.spec.whatwg.org/multipage/#navigate>
-    pub(crate) fn load_url(
-        &self,
-        history_handling: NavigationHistoryBehavior,
-        force_reload: bool,
-        load_data: LoadData,
-        can_gc: CanGc,
-    ) {
-        let doc = self.Document();
-
-        // Step 3. Let initiatorOriginSnapshot be sourceDocument's origin.
-        let initiator_origin_snapshot = &load_data.load_origin;
-
-        // TODO: Important re security. See https://github.com/servo/servo/issues/23373
-        // Step 5. check that the source browsing-context is "allowed to navigate" this window.
-
-        // Step 4 and 5
-        let pipeline_id = self.pipeline_id();
-        let window_proxy = self.window_proxy();
-        if let Some(active) = window_proxy.currently_active() {
-            if pipeline_id == active && doc.is_prompting_or_unloading() {
-                return;
-            }
-        }
-
-        // Step 23. Let unloadPromptCanceled be the result of checking if unloading
-        // is canceled for navigable's active document's inclusive descendant navigables.
-        if doc.check_if_unloading_is_cancelled(false, can_gc) {
-            // Step 12. If historyHandling is "auto", then:
-            let history_handling = if history_handling == NavigationHistoryBehavior::Auto {
-                // Step 12.1. If url equals navigable's active document's URL, and
-                // initiatorOriginSnapshot is same origin with targetNavigable's active document's
-                // origin, then set historyHandling to "replace".
-                //
-                // Note: `targetNavigable` is not actually defined in the spec, "active document" is
-                // assumed to be the correct reference based on WPT results
-                if let LoadOrigin::Script(initiator_origin) = initiator_origin_snapshot {
-                    if load_data.url == doc.url() && initiator_origin.same_origin(&*doc.origin()) {
-                        NavigationHistoryBehavior::Replace
-                    } else {
-                        // Step 12.2. Otherwise, set historyHandling to "push".
-                        NavigationHistoryBehavior::Push
-                    }
-                } else {
-                    // Step 12.2. Otherwise, set historyHandling to "push".
-                    NavigationHistoryBehavior::Push
-                }
-            } else {
-                history_handling
-            };
-            // Step 13. If the navigation must be a replace given url and navigable's active
-            // document, then set historyHandling to "replace".
-            //
-            // Inlines implementation of https://html.spec.whatwg.org/multipage/#the-navigation-must-be-a-replace
-            let history_handling =
-                if load_data.url.scheme() == "javascript" || doc.is_initial_about_blank() {
-                    NavigationHistoryBehavior::Replace
-                } else {
-                    history_handling
-                };
-
-            // Step 14. If all of the following are true:
-            // > documentResource is null;
-            // > response is null;
-            if !force_reload
-                // > url equals navigable's active session history entry's URL with exclude fragments set to true; and
-                && load_data.url.as_url()[..Position::AfterQuery] ==
-                    doc.url().as_url()[..Position::AfterQuery]
-                // > url's fragment is non-null,
-                && load_data.url.fragment().is_some()
-            {
-                // Step 14.1. Navigate to a fragment given navigable, url, historyHandling,
-                // userInvolvement, sourceElement, navigationAPIState, and navigationId.
-                let webdriver_sender = self.webdriver_load_status_sender.borrow().clone();
-                if let Some(ref sender) = webdriver_sender {
-                    let _ = sender.send(WebDriverLoadStatus::NavigationStart);
-                }
-                self.navigate_to_fragment(&load_data.url, history_handling);
-                // Step 14.2. Return.
-                if let Some(sender) = webdriver_sender {
-                    let _ = sender.send(WebDriverLoadStatus::NavigationStop);
-                }
-                return;
-            }
-
-            // Step 15. If navigable's parent is non-null, then set navigable's is delaying load events to true.
-            let window_proxy = self.window_proxy();
-            if window_proxy.parent().is_some() {
-                window_proxy.start_delaying_load_events_mode();
-            }
-
-            if let Some(sender) = self.webdriver_load_status_sender.borrow().as_ref() {
-                let _ = sender.send(WebDriverLoadStatus::NavigationStart);
-            }
-
-            // Step 13
-            ScriptThread::navigate(
-                self.webview_id,
-                pipeline_id,
-                load_data,
-                history_handling,
-                None,
-            );
-        };
     }
 
     /// Handle a potential change to the [`ViewportDetails`] of this [`Window`],
@@ -3417,6 +3310,10 @@ impl Window {
         sender: Option<GenericSender<WebDriverLoadStatus>>,
     ) {
         *self.webdriver_load_status_sender.borrow_mut() = sender;
+    }
+
+    pub(crate) fn webdriver_load_status_sender(&self) -> Option<GenericSender<WebDriverLoadStatus>> {
+        self.webdriver_load_status_sender.borrow().clone()
     }
 
     pub(crate) fn is_alive(&self) -> bool {

--- a/components/script/dom/windowproxy.rs
+++ b/components/script/dom/windowproxy.rs
@@ -584,7 +584,7 @@ impl WindowProxy {
             } else {
                 NavigationHistoryBehavior::Push
             };
-            navigate(&target_window, history_handling, false, load_data, CanGc::from_cx(cx));
+            navigate(target_window, history_handling, false, load_data, CanGc::from_cx(cx));
         }
         // Step 17 (Dis-owning has been done in create_auxiliary_browsing_context).
         if noopener {

--- a/components/script/dom/windowproxy.rs
+++ b/components/script/dom/windowproxy.rs
@@ -584,7 +584,13 @@ impl WindowProxy {
             } else {
                 NavigationHistoryBehavior::Push
             };
-            navigate(target_window, history_handling, false, load_data, CanGc::from_cx(cx));
+            navigate(
+                target_window,
+                history_handling,
+                false,
+                load_data,
+                CanGc::from_cx(cx),
+            );
         }
         // Step 17 (Dis-owning has been done in create_auxiliary_browsing_context).
         if noopener {

--- a/components/script/dom/windowproxy.rs
+++ b/components/script/dom/windowproxy.rs
@@ -59,6 +59,7 @@ use crate::dom::document::Document;
 use crate::dom::element::Element;
 use crate::dom::globalscope::GlobalScope;
 use crate::dom::window::Window;
+use crate::navigation::navigate;
 use crate::realms::{AlreadyInRealm, InRealm, enter_realm};
 use crate::script_runtime::{CanGc, JSContext as SafeJSContext};
 use crate::script_thread::{ScriptThread, with_script_thread};
@@ -583,7 +584,7 @@ impl WindowProxy {
             } else {
                 NavigationHistoryBehavior::Push
             };
-            target_window.load_url(history_handling, false, load_data, CanGc::from_cx(cx));
+            navigate(&target_window, history_handling, false, load_data, CanGc::from_cx(cx));
         }
         // Step 17 (Dis-owning has been done in create_auxiliary_browsing_context).
         if noopener {

--- a/components/script/links.rs
+++ b/components/script/links.rs
@@ -21,6 +21,7 @@ use crate::dom::html::htmlformelement::HTMLFormElement;
 use crate::dom::html::htmllinkelement::HTMLLinkElement;
 use crate::dom::node::NodeTraits;
 use crate::dom::types::Element;
+use crate::navigation::navigate;
 use crate::script_runtime::CanGc;
 
 bitflags::bitflags! {
@@ -498,7 +499,7 @@ pub(crate) fn follow_hyperlink(
         let target = Trusted::new(target_window);
         let task = task!(navigate_follow_hyperlink: move |cx| {
             debug!("following hyperlink to {}", load_data.url);
-            target.root().load_url(history_handling, false, load_data, CanGc::from_cx(cx));
+            navigate(&target.root(), history_handling, false, load_data, CanGc::from_cx(cx));
         });
         target_document
             .owner_global()

--- a/components/script/navigation.rs
+++ b/components/script/navigation.rs
@@ -32,6 +32,7 @@ use servo_constellation_traits::{
 use servo_url::{ImmutableOrigin, MutableOrigin, ServoUrl};
 use url::Position;
 
+use crate::dom::bindings::codegen::Bindings::WindowBinding::WindowMethods;
 use crate::dom::bindings::refcounted::Trusted;
 use crate::dom::window::Window;
 use crate::fetch::FetchCanceller;
@@ -392,19 +393,18 @@ pub(crate) fn navigate(
         let is_javascript = load_data.url.scheme() == "javascript";
         if is_javascript {
             let global = window.as_global_scope();
-            let trusted_global = Trusted::new(global);
+            let trusted_window = Trusted::new(window);
             let sender = global.script_to_constellation_chan().clone();
             let mut load_data = load_data;
             load_data.about_base_url = window.Document().about_base_url();
             let task = task!(navigate_javascript: move |cx| {
                 // Important re security. See https://github.com/servo/servo/issues/23373
-                if trusted_global.root().is::<Window>() {
-                    let global = &trusted_global.root();
-                    if ScriptThread::navigate_to_javascript_url(cx, global, global, &mut load_data, None) {
-                        sender
-                            .send(ScriptToConstellationMessage::LoadUrl(load_data, history_handling))
-                            .unwrap();
-                    }
+                let window = trusted_window.root();
+                let global = window.as_global_scope();
+                if ScriptThread::navigate_to_javascript_url(cx, global, global, &mut load_data, None) {
+                    sender
+                        .send(ScriptToConstellationMessage::LoadUrl(load_data, history_handling))
+                        .unwrap();
                 }
             });
             // Step 20 of <https://html.spec.whatwg.org/multipage/#navigate>

--- a/components/script/navigation.rs
+++ b/components/script/navigation.rs
@@ -11,7 +11,7 @@ use std::cell::Cell;
 use content_security_policy::sandboxing_directive::SandboxingFlagSet;
 use crossbeam_channel::Sender;
 use embedder_traits::user_contents::UserContentManagerId;
-use embedder_traits::{Theme, ViewportDetails};
+use embedder_traits::{Theme, ViewportDetails, WebDriverLoadStatus};
 use http::header;
 use net_traits::policy_container::RequestPolicyContainer;
 use net_traits::request::{
@@ -26,11 +26,18 @@ use net_traits::{
 use script_traits::{DocumentActivity, NewPipelineInfo};
 use servo_base::cross_process_instant::CrossProcessInstant;
 use servo_base::id::{BrowsingContextId, PipelineId, WebViewId};
-use servo_constellation_traits::LoadData;
+use servo_constellation_traits::{
+    LoadData, LoadOrigin, NavigationHistoryBehavior, ScriptToConstellationMessage,
+};
 use servo_url::{ImmutableOrigin, MutableOrigin, ServoUrl};
+use url::Position;
 
+use crate::dom::bindings::refcounted::Trusted;
+use crate::dom::window::Window;
 use crate::fetch::FetchCanceller;
 use crate::messaging::MainThreadScriptMsg;
+use crate::script_runtime::CanGc;
+use crate::script_thread::ScriptThread;
 
 #[derive(Clone)]
 pub struct NavigationListener {
@@ -283,4 +290,133 @@ pub(crate) fn determine_the_origin(
 
     // Step 5. Return url's origin.
     MutableOrigin::new(url.origin())
+}
+
+/// <https://html.spec.whatwg.org/multipage/#navigate>
+pub(crate) fn navigate(
+    window: &Window,
+    history_handling: NavigationHistoryBehavior,
+    force_reload: bool,
+    load_data: LoadData,
+    can_gc: CanGc,
+) {
+    let doc = window.Document();
+
+    // Step 3. Let initiatorOriginSnapshot be sourceDocument's origin.
+    let initiator_origin_snapshot = &load_data.load_origin;
+
+    // TODO: Important re security. See https://github.com/servo/servo/issues/23373
+    // Step 5. check that the source browsing-context is "allowed to navigate" this window.
+
+    // Step 4 and 5
+    let pipeline_id = window.pipeline_id();
+    let window_proxy = window.window_proxy();
+    if let Some(active) = window_proxy.currently_active() {
+        if pipeline_id == active && doc.is_prompting_or_unloading() {
+            return;
+        }
+    }
+
+    // Step 23. Let unloadPromptCanceled be the result of checking if unloading
+    // is canceled for navigable's active document's inclusive descendant navigables.
+    if doc.check_if_unloading_is_cancelled(false, can_gc) {
+        // Step 12. If historyHandling is "auto", then:
+        let history_handling = if history_handling == NavigationHistoryBehavior::Auto {
+            // Step 12.1. If url equals navigable's active document's URL, and
+            // initiatorOriginSnapshot is same origin with targetNavigable's active document's
+            // origin, then set historyHandling to "replace".
+            //
+            // Note: `targetNavigable` is not actually defined in the spec, "active document" is
+            // assumed to be the correct reference based on WPT results
+            if let LoadOrigin::Script(initiator_origin) = initiator_origin_snapshot {
+                if load_data.url == doc.url() && initiator_origin.same_origin(&*doc.origin()) {
+                    NavigationHistoryBehavior::Replace
+                } else {
+                    // Step 12.2. Otherwise, set historyHandling to "push".
+                    NavigationHistoryBehavior::Push
+                }
+            } else {
+                // Step 12.2. Otherwise, set historyHandling to "push".
+                NavigationHistoryBehavior::Push
+            }
+        } else {
+            history_handling
+        };
+
+        // Step 13. If the navigation must be a replace given url and navigable's active
+        // document, then set historyHandling to "replace".
+        //
+        // Inlines implementation of https://html.spec.whatwg.org/multipage/#the-navigation-must-be-a-replace
+        let history_handling =
+            if load_data.url.scheme() == "javascript" || doc.is_initial_about_blank() {
+                NavigationHistoryBehavior::Replace
+            } else {
+                history_handling
+            };
+
+        // Step 14. If all of the following are true:
+        // > documentResource is null;
+        // > response is null;
+        if !force_reload
+            // > url equals navigable's active session history entry's URL with exclude fragments set to true; and
+            && load_data.url.as_url()[..Position::AfterQuery] ==
+                doc.url().as_url()[..Position::AfterQuery]
+            // > url's fragment is non-null,
+            && load_data.url.fragment().is_some()
+        {
+            // Step 14.1. Navigate to a fragment given navigable, url, historyHandling,
+            // userInvolvement, sourceElement, navigationAPIState, and navigationId.
+            let webdriver_sender = window.webdriver_load_status_sender();
+            if let Some(ref sender) = webdriver_sender {
+                let _ = sender.send(WebDriverLoadStatus::NavigationStart);
+            }
+            window.navigate_to_fragment(&load_data.url, history_handling);
+            // Step 14.2. Return.
+            if let Some(sender) = webdriver_sender {
+                let _ = sender.send(WebDriverLoadStatus::NavigationStop);
+            }
+            return;
+        }
+
+        // Step 15. If navigable's parent is non-null, then set navigable's is delaying load events to true.
+        let window_proxy = window.window_proxy();
+        if window_proxy.parent().is_some() {
+            window_proxy.start_delaying_load_events_mode();
+        }
+
+        if let Some(sender) = window.webdriver_load_status_sender() {
+            let _ = sender.send(WebDriverLoadStatus::NavigationStart);
+        }
+
+        // Step 13 of <https://html.spec.whatwg.org/multipage/#navigate>
+        let is_javascript = load_data.url.scheme() == "javascript";
+        if is_javascript {
+            let global = window.as_global_scope();
+            let trusted_global = Trusted::new(global);
+            let sender = global.script_to_constellation_chan().clone();
+            let mut load_data = load_data;
+            load_data.about_base_url = window.Document().about_base_url();
+            let task = task!(navigate_javascript: move |cx| {
+                // Important re security. See https://github.com/servo/servo/issues/23373
+                if trusted_global.root().is::<Window>() {
+                    let global = &trusted_global.root();
+                    if ScriptThread::navigate_to_javascript_url(cx, global, global, &mut load_data, None) {
+                        sender
+                            .send(ScriptToConstellationMessage::LoadUrl(load_data, history_handling))
+                            .unwrap();
+                    }
+                }
+            });
+            // Step 20 of <https://html.spec.whatwg.org/multipage/#navigate>
+            global
+                .task_manager()
+                .navigation_and_traversal_task_source()
+                .queue(task);
+        } else {
+            window.send_to_constellation(ScriptToConstellationMessage::LoadUrl(
+                load_data,
+                history_handling,
+            ));
+        }
+    };
 }

--- a/components/script/navigation.rs
+++ b/components/script/navigation.rs
@@ -401,7 +401,7 @@ pub(crate) fn navigate(
                 // Important re security. See https://github.com/servo/servo/issues/23373
                 let window = trusted_window.root();
                 let global = window.as_global_scope();
-                if ScriptThread::navigate_to_javascript_url(cx, global, global, &mut load_data, None) {
+                if ScriptThread::navigate_to_javascript_url(cx, global, global, &mut load_data, None, None) {
                     sender
                         .send(ScriptToConstellationMessage::LoadUrl(load_data, history_handling))
                         .unwrap();

--- a/components/script/script_thread.rs
+++ b/components/script/script_thread.rs
@@ -120,7 +120,6 @@ use crate::dom::bindings::conversions::{
     ConversionResult, SafeFromJSValConvertible, StringificationBehavior,
 };
 use crate::dom::bindings::inheritance::Castable;
-use crate::dom::bindings::refcounted::Trusted;
 use crate::dom::bindings::reflector::DomGlobal;
 use crate::dom::bindings::root::{Dom, DomRoot};
 use crate::dom::bindings::str::DOMString;

--- a/components/script/script_thread.rs
+++ b/components/script/script_thread.rs
@@ -1286,10 +1286,10 @@ impl ScriptThread {
             .iter()
             .any(|(_, document)| document.needs_rendering_update());
         let running_animations = self.documents.borrow().iter().any(|(_, document)| {
-            document.is_fully_active()
-                && !document.window().throttled()
-                && (document.animations().running_animation_count() != 0
-                    || document.has_active_request_animation_frame_callbacks())
+            document.is_fully_active() &&
+                !document.window().throttled() &&
+                (document.animations().running_animation_count() != 0 ||
+                    document.has_active_request_animation_frame_callbacks())
         });
 
         // If we are not running animations and no rendering update is
@@ -1885,9 +1885,9 @@ impl ScriptThread {
                     document.handle_no_longer_waiting_on_asynchronous_image_updates();
                 }
             },
-            msg @ ScriptThreadMessage::SpawnPipeline(..)
-            | msg @ ScriptThreadMessage::ExitFullScreen(..)
-            | msg @ ScriptThreadMessage::ExitScriptThread => {
+            msg @ ScriptThreadMessage::SpawnPipeline(..) |
+            msg @ ScriptThreadMessage::ExitFullScreen(..) |
+            msg @ ScriptThreadMessage::ExitScriptThread => {
                 panic!("should have handled {:?} already", msg)
             },
             ScriptThreadMessage::SetScrollStates(pipeline_id, scroll_states) => {

--- a/components/script/script_thread.rs
+++ b/components/script/script_thread.rs
@@ -1286,10 +1286,10 @@ impl ScriptThread {
             .iter()
             .any(|(_, document)| document.needs_rendering_update());
         let running_animations = self.documents.borrow().iter().any(|(_, document)| {
-            document.is_fully_active() &&
-                !document.window().throttled() &&
-                (document.animations().running_animation_count() != 0 ||
-                    document.has_active_request_animation_frame_callbacks())
+            document.is_fully_active()
+                && !document.window().throttled()
+                && (document.animations().running_animation_count() != 0
+                    || document.has_active_request_animation_frame_callbacks())
         });
 
         // If we are not running animations and no rendering update is
@@ -1885,9 +1885,9 @@ impl ScriptThread {
                     document.handle_no_longer_waiting_on_asynchronous_image_updates();
                 }
             },
-            msg @ ScriptThreadMessage::SpawnPipeline(..) |
-            msg @ ScriptThreadMessage::ExitFullScreen(..) |
-            msg @ ScriptThreadMessage::ExitScriptThread => {
+            msg @ ScriptThreadMessage::SpawnPipeline(..)
+            | msg @ ScriptThreadMessage::ExitFullScreen(..)
+            | msg @ ScriptThreadMessage::ExitScriptThread => {
                 panic!("should have handled {:?} already", msg)
             },
             ScriptThreadMessage::SetScrollStates(pipeline_id, scroll_states) => {

--- a/components/script/script_thread.rs
+++ b/components/script/script_thread.rs
@@ -604,65 +604,6 @@ impl ScriptThread {
         self.needs_rendering_update.store(true, Ordering::Relaxed);
     }
 
-    /// <https://html.spec.whatwg.org/multipage/#navigate>
-    pub(crate) fn navigate(
-        webview_id: WebViewId,
-        pipeline_id: PipelineId,
-        mut load_data: LoadData,
-        history_handling: NavigationHistoryBehavior,
-        initial_insertion: Option<bool>,
-    ) {
-        with_script_thread(|script_thread| {
-            let is_javascript = load_data.url.scheme() == "javascript";
-            // Step 20. If url's scheme is "javascript", then:
-            if is_javascript {
-                let Some(window) = script_thread.documents.borrow().find_window(pipeline_id) else {
-                    return;
-                };
-                let global = window.as_global_scope();
-                let trusted_global = Trusted::new(global);
-                let sender = script_thread
-                    .senders
-                    .pipeline_to_constellation_sender
-                    .clone();
-                load_data.about_base_url = window.Document().about_base_url();
-                // Step 20.1 Queue a global task on the navigation and traversal
-                //   task source given navigable's active window to navigate to a
-                //   javascript: URL given navigable, url, historyHandling,
-                //   sourceSnapshotParams, initiatorOriginSnapshot, userInvolvement,
-                //   cspNavigationType, initialInsertion, and navigationId.
-                let task = task!(navigate_javascript: move |cx| {
-                    // Important re security. See https://github.com/servo/servo/issues/23373
-                    if trusted_global.root().is::<Window>() {
-                        let global = &trusted_global.root();
-                        // If this method returns true we are creating a new document
-                        if Self::navigate_to_javascript_url(cx, global, global, &mut load_data, None, initial_insertion) {
-                            sender
-                                .send((webview_id, pipeline_id, ScriptToConstellationMessage::LoadUrl(load_data, history_handling)))
-                                .unwrap();
-                        }
-                    }
-                });
-                global
-                    .task_manager()
-                    .navigation_and_traversal_task_source()
-                    .queue(task);
-                // Step 20.2. Return.
-                return;
-            }
-
-            script_thread
-                .senders
-                .pipeline_to_constellation_sender
-                .send((
-                    webview_id,
-                    pipeline_id,
-                    ScriptToConstellationMessage::LoadUrl(load_data, history_handling),
-                ))
-                .expect("Sending a LoadUrl message to the constellation failed");
-        });
-    }
-
     /// <https://html.spec.whatwg.org/multipage/#navigate-to-a-javascript:-url>
     pub(crate) fn can_navigate_to_javascript_url(
         cx: &mut js::context::JSContext,


### PR DESCRIPTION
Both `Window::load_url` and `ScriptThread::navigate` implement parts of the same navigate algorithm from the HTML spec (https://html.spec.whatwg.org/multipage/browsing-the-web.html#navigate). `ScriptThread::navigate` had only one caller: `Window::load_url`.

This merges both methods into a single `navigate` function in `navigation.rs`, which is the appropriate home for navigation logic. All previous callers of `Window::load_url` now call `navigation::navigate` directly.

Testing: This is a pure refactor with no behaviour changes, so no new tests are needed. Existing tests cover the navigation paths affected.
Fixes: #43494