### PR TITLE
wdspec: `tagName` IDL attribute should be upper case when in html

### DIFF
--- a/tests/wpt/meta/webdriver/tests/classic/get_element_tag_name/get.py.ini
+++ b/tests/wpt/meta/webdriver/tests/classic/get_element_tag_name/get.py.ini
@@ -1,6 +1,3 @@
 [get.py]
   [test_no_browsing_context]
     expected: FAIL
-
-  [test_get_element_tag_name]
-    expected: FAIL

--- a/tests/wpt/tests/webdriver/tests/classic/get_element_tag_name/get.py
+++ b/tests/wpt/tests/webdriver/tests/classic/get_element_tag_name/get.py
@@ -92,4 +92,4 @@ def test_get_element_tag_name(session, inline):
     element = session.find.css("input", all=False)
 
     result = get_element_tag_name(session, element.id)
-    assert_success(result, "input")
+    assert_success(result, "INPUT")


### PR DESCRIPTION
[Spec for `tagName`](https://dom.spec.whatwg.org/#element-html-uppercased-qualified-name). 

The expectation should use upper case here, as the test document is definitely in HTML:
https://github.com/servo/servo/blob/bc62b7475cb9ccb65f14e21974f9c111d743f151/tests/wpt/tests/webdriver/tests/support/fixtures.py#L149

https://github.com/servo/servo/blob/bc62b7475cb9ccb65f14e21974f9c111d743f151/tests/wpt/tests/webdriver/tests/support/inline.py#L33-L34


Testing: New passing WPT.
