### PR TITLE
layout: Scope table row-group children with TableRowGroupBuilder

### DIFF
--- a/components/layout/table/construct.rs
+++ b/components/layout/table/construct.rs
@@ -770,16 +770,20 @@ impl<'dom> TraversalHandler<'dom> for TableBuilderTraversal<'_, 'dom> {
                     self.builder.table.row_groups.push(row_group.clone());
 
                     let new_row_group_index = self.builder.table.row_groups.len() - 1;
-                    self.current_row_group_index = Some(new_row_group_index);
+                    let context = self.context;
+                    let mut row_group_builder = TableRowGroupBuilder::new(
+                        self,
+                        info,
+                        self.current_propagated_data,
+                        new_row_group_index,
+                    );
 
                     contents
                         .non_replaced_contents()
                         .expect("Replaced should not have a LayoutInternal display type.")
-                        .traverse(self.context, info, self);
-                    self.finish_anonymous_row_if_needed();
+                        .traverse(context, info, &mut row_group_builder);
 
-                    self.current_row_group_index = None;
-                    self.builder.incoming_rowspans.clear();
+                    row_group_builder.finish();
 
                     box_slot.set(LayoutBox::TableLevelBox(TableLevelBox::TrackGroup(
                         row_group,
@@ -904,6 +908,141 @@ impl<'dom> TraversalHandler<'dom> for TableBuilderTraversal<'_, 'dom> {
                         });
                 },
             },
+            _ => {
+                self.current_anonymous_row_content
+                    .push(AnonymousTableContent::Element {
+                        info: info.clone(),
+                        display,
+                        contents,
+                        box_slot,
+                    });
+            },
+        }
+    }
+}
+
+struct TableRowGroupBuilder<'style, 'builder, 'dom, 'a> {
+    table_traversal: &'builder mut TableBuilderTraversal<'style, 'dom>,
+    info: &'a NodeAndStyleInfo<'dom>,
+    propagated_data: PropagatedBoxTreeData,
+    current_anonymous_row_content: Vec<AnonymousTableContent<'dom>>,
+}
+
+impl<'style, 'builder, 'dom, 'a> TableRowGroupBuilder<'style, 'builder, 'dom, 'a> {
+    fn new(
+        table_traversal: &'builder mut TableBuilderTraversal<'style, 'dom>,
+        info: &'a NodeAndStyleInfo<'dom>,
+        propagated_data: PropagatedBoxTreeData,
+        row_group_index: usize,
+    ) -> Self {
+        // Row groups are only opened from TableBuilderTraversal, never nested, so current_row_group_index is always None here.
+        debug_assert!(table_traversal.current_row_group_index.is_none());
+        table_traversal.current_row_group_index = Some(row_group_index);
+
+        Self {
+            table_traversal,
+            info,
+            propagated_data,
+            current_anonymous_row_content: Vec::new(),
+        }
+    }
+
+    fn finish(mut self) {
+        self.finish_anonymous_row_if_needed();
+        self.table_traversal.current_row_group_index = None;
+        self.table_traversal.builder.incoming_rowspans.clear();
+    }
+
+    fn finish_anonymous_row_if_needed(&mut self) {
+        if AnonymousTableContent::contents_are_whitespace_only(&self.current_anonymous_row_content)
+        {
+            self.current_anonymous_row_content.clear();
+            return;
+        }
+
+        let row_content = std::mem::take(&mut self.current_anonymous_row_content);
+        let anonymous_info = self
+            .info
+            .with_pseudo_element(
+                self.table_traversal.context,
+                PseudoElement::ServoAnonymousTableRow,
+            )
+            .expect("Should never fail to create anonymous row info.");
+
+        let mut row_builder =
+            TableRowBuilder::new(self.table_traversal, &anonymous_info, self.propagated_data);
+
+        for cell_content in row_content {
+            match cell_content {
+                AnonymousTableContent::Element {
+                    info,
+                    display,
+                    contents,
+                    box_slot,
+                } => {
+                    row_builder.handle_element(&info, display, contents, box_slot);
+                },
+                AnonymousTableContent::Text(info, text) => {
+                    row_builder.handle_text(&info, text);
+                },
+            }
+        }
+
+        row_builder.finish();
+
+        let style = anonymous_info.style.clone();
+        let table_row = ArcRefCell::new(TableTrack {
+            base: LayoutBoxBase::new((&anonymous_info).into(), style.clone()),
+            group_index: self.table_traversal.current_row_group_index,
+            is_anonymous: true,
+            shared_background_style: SharedStyle::new(style),
+        });
+        self.table_traversal.push_table_row(table_row.clone());
+
+        anonymous_info
+            .node
+            .box_slot()
+            .set(LayoutBox::TableLevelBox(TableLevelBox::Track(table_row)));
+    }
+}
+
+impl<'dom> TraversalHandler<'dom> for TableRowGroupBuilder<'_, '_, 'dom, '_> {
+    fn handle_text(&mut self, info: &NodeAndStyleInfo<'dom>, text: Cow<'dom, str>) {
+        self.current_anonymous_row_content
+            .push(AnonymousTableContent::Text(info.clone(), text));
+    }
+
+    fn handle_element(
+        &mut self,
+        info: &NodeAndStyleInfo<'dom>,
+        display: DisplayGeneratingBox,
+        contents: Contents,
+        box_slot: BoxSlot<'dom>,
+    ) {
+        match display {
+            DisplayGeneratingBox::LayoutInternal(DisplayLayoutInternal::TableRow) => {
+                self.finish_anonymous_row_if_needed();
+
+                let context = self.table_traversal.context;
+                let mut row_builder =
+                    TableRowBuilder::new(self.table_traversal, info, self.propagated_data);
+
+                contents
+                    .non_replaced_contents()
+                    .expect("Replaced should not have a LayoutInternal display type.")
+                    .traverse(context, info, &mut row_builder);
+                row_builder.finish();
+
+                let row = ArcRefCell::new(TableTrack {
+                    base: LayoutBoxBase::new(info.into(), info.style.clone()),
+                    group_index: self.table_traversal.current_row_group_index,
+                    is_anonymous: false,
+                    shared_background_style: SharedStyle::new(info.style.clone()),
+                });
+                self.table_traversal.push_table_row(row.clone());
+                box_slot.set(LayoutBox::TableLevelBox(TableLevelBox::Track(row)));
+            },
+
             _ => {
                 self.current_anonymous_row_content
                     .push(AnonymousTableContent::Element {

--- a/tests/wpt/meta/css/css-tables/table-model-fixup.html.ini
+++ b/tests/wpt/meta/css/css-tables/table-model-fixup.html.ini
@@ -1,12 +1,3 @@
 [table-model-fixup.html]
-  [2.2. An anonymous table-row box must be generated around each sequence of consecutive children of a table-row-grouping box which are not table-row boxes. (1/3)]
-    expected: FAIL
-
-  [2.2. An anonymous table-row box must be generated around each sequence of consecutive children of a table-row-grouping box which are not table-row boxes. (2/3)]
-    expected: FAIL
-
-  [2.2. An anonymous table-row box must be generated around each sequence of consecutive children of a table-row-grouping box which are not table-row boxes. (3/3)]
-    expected: FAIL
-
   [2.3 happens after 2.1. and 2.2. (1/2)]
     expected: FAIL

--- a/tests/wpt/tests/css/css-tables/table-row-group-color-inheritance-001.html
+++ b/tests/wpt/tests/css/css-tables/table-row-group-color-inheritance-001.html
@@ -1,0 +1,11 @@
+<!doctype html>
+<meta charset="utf-8">
+<title>CSS Test: Row-group color wins over table color</title>
+<link rel="help" href="https://drafts.csswg.org/css-tables/#fixup-algorithm">
+<link rel="help" href="https://github.com/servo/servo/issues/43660">
+<link rel="match" href="../reference/ref-filled-green-200px-square.html">
+<link rel="stylesheet" type="text/css" href="/fonts/ahem.css">
+<p>Test passes if there is a filled green square and <strong>no red</strong>.</p>
+<div style="display: table; color: red">
+  <div style="display: table-row-group; color: green; font: 200px/1 Ahem">X</div>
+</div>

--- a/tests/wpt/tests/css/css-tables/table-row-group-nested-anonymous-001-ref.html
+++ b/tests/wpt/tests/css/css-tables/table-row-group-nested-anonymous-001-ref.html
@@ -1,0 +1,16 @@
+<!doctype html>
+<meta charset="utf-8">
+<style>
+  .t { display: table; }
+  .r { display: table-row; }
+  .c { display: table-cell; border: 1px solid gray; padding: 4px; font: 16px serif; }
+</style>
+
+<div class="t">
+  <div class="r">
+    <div class="c">a</div>
+    <div class="c">b</div>
+    <div class="c">cccc</div>
+    <div class="c">dddd</div>
+  </div>
+</div>

--- a/tests/wpt/tests/css/css-tables/table-row-group-nested-anonymous-001.html
+++ b/tests/wpt/tests/css/css-tables/table-row-group-nested-anonymous-001.html
@@ -1,0 +1,18 @@
+<!doctype html>
+<meta charset="utf-8">
+<title>CSS Test: Nested table-row-group anonymous table fixup</title>
+<link rel="help" href="https://drafts.csswg.org/css-tables/#fixup-algorithm">
+<link rel="help" href="https://github.com/servo/servo/issues/43660">
+<link rel="match" href="table-row-group-nested-anonymous-001-ref.html">
+<style>
+  .cell { display: table-cell; border: 1px solid gray; padding: 4px; font: 16px serif; }
+</style>
+
+<div style="display: table-row-group">
+  <div style="display: table-row-group">
+    <div class="cell">a</div>
+    <div class="cell">b</div>
+  </div>
+  <div class="cell">cccc</div>
+  <div class="cell">dddd</div>
+</div>


### PR DESCRIPTION
This pr adds the following changes:
- Introduces `TableRowGroupBuilder` to handle row-group-scoped traversal more cleanly and explicitly.  
- Adds logic to save and restore `current_row_group_index`, ensuring correct behavior when processing nested row groups.  
- Prevents direct traversal of row-group children from the main table traversal flow to avoid incorrect context handling.  
- Ensures that anonymous rows created within a row group correctly inherit the row-group context.  
- Keeps existing row handling logic unchanged by continuing to delegate row-specific behavior to `TableRowBuilder`.

Fixes: #43660

Testing: One existing test improves, and adding 2 new tests