### PR TITLE
devtools: Rename NetworkEventActor variable concerned files

### DIFF
--- a/components/devtools/lib.rs
+++ b/components/devtools/lib.rs
@@ -667,14 +667,14 @@ impl DevtoolsInstance {
             .watcher
             .clone();
 
-        let netevent_actor_name = match self.actor_requests.get(&request_id) {
+        let network_event_name = match self.actor_requests.get(&request_id) {
             Some(name) => name.clone(),
             None => self.create_network_event_actor(request_id, watcher_name),
         };
 
         handle_network_event(
             Arc::clone(&self.registry),
-            netevent_actor_name,
+            network_event_name,
             connections,
             network_event,
         )
@@ -685,13 +685,15 @@ impl DevtoolsInstance {
         let resource_id = self.next_resource_id;
         self.next_resource_id += 1;
 
-        let actor_name = self.registry.new_name::<NetworkEventActor>();
-        let actor = NetworkEventActor::new(actor_name.clone(), resource_id, watcher_name);
+        let network_event_name = self.registry.new_name::<NetworkEventActor>();
+        let network_event_actor =
+            NetworkEventActor::new(network_event_name.clone(), resource_id, watcher_name);
 
-        self.actor_requests.insert(request_id, actor_name.clone());
-        self.registry.register(actor);
+        self.actor_requests
+            .insert(request_id, network_event_name.clone());
+        self.registry.register(network_event_actor);
 
-        actor_name
+        network_event_name
     }
 
     fn handle_create_source_actor(

--- a/components/devtools/network_handler.rs
+++ b/components/devtools/network_handler.rs
@@ -23,18 +23,18 @@ pub(crate) struct Cause {
 
 pub(crate) fn handle_network_event(
     registry: Arc<ActorRegistry>,
-    netevent_actor_name: String,
+    network_event_name: String,
     mut connections: Vec<DevtoolsConnection>,
     network_event: NetworkEvent,
 ) {
-    let actor = registry.find::<NetworkEventActor>(&netevent_actor_name);
-    let watcher = registry.find::<WatcherActor>(&actor.watcher);
+    let network_event_actor = registry.find::<NetworkEventActor>(&network_event_name);
+    let watcher = registry.find::<WatcherActor>(&network_event_actor.watcher);
 
     match network_event {
         NetworkEvent::HttpRequest(httprequest) => {
-            actor.add_request(httprequest);
-            let msg = actor.encode(&registry);
-            let resource = actor.resource_updates(&registry);
+            network_event_actor.add_request(httprequest);
+            let msg = network_event_actor.encode(&registry);
+            let resource = network_event_actor.resource_updates(&registry);
 
             for stream in &mut connections {
                 watcher.resource_array(
@@ -55,8 +55,8 @@ pub(crate) fn handle_network_event(
         },
 
         NetworkEvent::HttpRequestUpdate(httprequest) => {
-            actor.add_request(httprequest);
-            let resource = actor.resource_updates(&registry);
+            network_event_actor.add_request(httprequest);
+            let resource = network_event_actor.resource_updates(&registry);
 
             for stream in &mut connections {
                 watcher.resource_array(
@@ -68,8 +68,8 @@ pub(crate) fn handle_network_event(
             }
         },
         NetworkEvent::HttpResponse(httpresponse) => {
-            actor.add_response(httpresponse);
-            let resource = actor.resource_updates(&registry);
+            network_event_actor.add_response(httpresponse);
+            let resource = network_event_actor.resource_updates(&registry);
 
             for stream in &mut connections {
                 watcher.resource_array(
@@ -81,8 +81,8 @@ pub(crate) fn handle_network_event(
             }
         },
         NetworkEvent::SecurityInfo(update) => {
-            actor.add_security_info(update.security_info);
-            let resource = actor.resource_updates(&registry);
+            network_event_actor.add_security_info(update.security_info);
+            let resource = network_event_actor.resource_updates(&registry);
 
             for stream in &mut connections {
                 watcher.resource_array(


### PR DESCRIPTION
Renamed NetworkEventActor variables in network_handler & lib.rs

Testing: No testing required
Fixes: Part of #43606 