### PR TITLE
devtools: Rename DeviceActor variables for consistency

### DIFF
--- a/components/devtools/actors/root.rs
+++ b/components/devtools/actors/root.rs
@@ -285,7 +285,7 @@ impl RootActor {
     /// Registers the root actor and its global actors (those not associated with a specific target).
     pub fn register(registry: &mut ActorRegistry) {
         // Global actors
-        let device = DeviceActor::new(registry.new_name::<DeviceActor>());
+        let device_actor = DeviceActor::new(registry.new_name::<DeviceActor>());
         let perf = PerformanceActor::new(registry.new_name::<PerformanceActor>());
         let preference = PreferenceActor::new(registry.new_name::<PreferenceActor>());
 
@@ -295,7 +295,7 @@ impl RootActor {
         // Root actor
         let root = Self {
             global_actors: GlobalActors {
-                device_actor: device.name(),
+                device_actor: device_actor.name(),
                 perf_actor: perf.name(),
                 preference_actor: preference.name(),
             },
@@ -304,7 +304,7 @@ impl RootActor {
         };
 
         registry.register(perf);
-        registry.register(device);
+        registry.register(device_actor);
         registry.register(preference);
         registry.register(process);
         registry.register(root);


### PR DESCRIPTION
Rename `DeviceActor` local variable in `root.rs` from `device` to `device_actor` for naming consistency across the devtools crate.

This follows the convention discussed in #43557:
- `{}_actor` for variables holding the actor 
- `{}_name` for variables holding the actor name string

The `device_actor` field in the `GlobalActors` struct was not renamed, as it is part of a `#[derive(Serialize)]` struct used for devtools message serialization.

Testing: `./mach test-devtools`  all 60 tests pass (6 expected failures). One unrelated flaky test (`test_breakpoint_at_invalid_entry_point_does_not_crash`) occasionally fails due to a race condition tracked separately. opened an isssue for it at #43667
 

fixes part of #43606
