### PR TITLE
devtools: Renamed WorkerActor variables in affected files

### DIFF
--- a/components/devtools/actors/console.rs
+++ b/components/devtools/actors/console.rs
@@ -287,9 +287,10 @@ impl ConsoleActor {
             Root::BrowsingContext(browsing_context_name) => registry
                 .find::<BrowsingContextActor>(browsing_context_name)
                 .script_chan(),
-            Root::DedicatedWorker(worker) => {
-                registry.find::<WorkerActor>(worker).script_chan.clone()
-            },
+            Root::DedicatedWorker(worker_name) => registry
+                .find::<WorkerActor>(worker_name)
+                .script_chan
+                .clone(),
         }
     }
 
@@ -300,8 +301,8 @@ impl ConsoleActor {
                     .find::<BrowsingContextActor>(browsing_context_name)
                     .pipeline_id(),
             ),
-            Root::DedicatedWorker(worker) => {
-                UniqueId::Worker(registry.find::<WorkerActor>(worker).worker_id)
+            Root::DedicatedWorker(worker_name) => {
+                UniqueId::Worker(registry.find::<WorkerActor>(worker_name).worker_id)
             },
         }
     }

--- a/components/devtools/actors/root.rs
+++ b/components/devtools/actors/root.rs
@@ -248,7 +248,7 @@ impl Actor for RootActor {
                         .workers
                         .borrow()
                         .iter()
-                        .map(|name| registry.encode::<WorkerActor, _>(name))
+                        .map(|worker_name| registry.encode::<WorkerActor, _>(worker_name))
                         .collect(),
                 };
                 request.reply_final(&reply)?

--- a/components/devtools/actors/watcher.rs
+++ b/components/devtools/actors/watcher.rs
@@ -327,10 +327,10 @@ impl Actor for WatcherActor {
                             );
 
                             for worker_name in &*root.workers.borrow() {
-                                let worker = registry.find::<WorkerActor>(worker_name);
-                                let thread = registry.find::<ThreadActor>(&worker.thread);
+                                let worker_actor = registry.find::<WorkerActor>(worker_name);
+                                let thread = registry.find::<ThreadActor>(&worker_actor.thread);
 
-                                worker.resources_array(
+                                worker_actor.resources_array(
                                     thread.source_manager.source_forms(registry),
                                     resource.into(),
                                     ResourceArrayType::Available,
@@ -349,11 +349,11 @@ impl Actor for WatcherActor {
                             );
 
                             for worker_name in &*root.workers.borrow() {
-                                let worker = registry.find::<WorkerActor>(worker_name);
+                                let worker_actor = registry.find::<WorkerActor>(worker_name);
                                 let console_actor =
-                                    registry.find::<ConsoleActor>(&worker.console_name);
+                                    registry.find::<ConsoleActor>(&worker_actor.console_name);
 
-                                worker.resources_array(
+                                worker_actor.resources_array(
                                     console_actor.get_cached_messages(registry, resource),
                                     resource.into(),
                                     ResourceArrayType::Available,

--- a/components/devtools/lib.rs
+++ b/components/devtools/lib.rs
@@ -615,10 +615,10 @@ impl DevtoolsInstance {
         worker_id: Option<WorkerId>,
     ) -> Option<String> {
         if let Some(worker_id) = worker_id {
-            let actor_name = self.actor_workers.get(&worker_id)?;
+            let worker_name = self.actor_workers.get(&worker_id)?;
             Some(
                 self.registry
-                    .find::<WorkerActor>(actor_name)
+                    .find::<WorkerActor>(worker_name)
                     .console_name
                     .clone(),
             )
@@ -709,20 +709,20 @@ impl DevtoolsInstance {
             .source_form();
 
         if let Some(worker_id) = source_info.worker_id {
-            let Some(worker_actor_name) = self.actor_workers.get(&worker_id) else {
+            let Some(worker_name) = self.actor_workers.get(&worker_id) else {
                 return;
             };
 
             let thread_actor_name = self
                 .registry
-                .find::<WorkerActor>(worker_actor_name)
+                .find::<WorkerActor>(worker_name)
                 .thread
                 .clone();
             let thread_actor = self.registry.find::<ThreadActor>(&thread_actor_name);
 
             thread_actor.source_manager.add_source(&source_actor);
 
-            let worker_actor = self.registry.find::<WorkerActor>(worker_actor_name);
+            let worker_actor = self.registry.find::<WorkerActor>(worker_name);
 
             for stream in self.connections.lock().unwrap().values_mut() {
                 worker_actor.resource_array(


### PR DESCRIPTION
Renamed WorkerActor variables in watcher, console, root and lib.rs

Testing: No testing required
Fixes: Part of #43606 