### PR TITLE
paint: Support pinch-zoom for factors less than 1.

### DIFF
--- a/components/config/prefs.rs
+++ b/components/config/prefs.rs
@@ -341,7 +341,7 @@ pub struct Preferences {
     /// The user-agent to use for Servo. This can also be set via [`UserAgentPlatform`] in
     /// order to set the value to the default value for the given platform.
     pub user_agent: String,
-    /// Whether or not the viewport meta tag is enabled.
+    // feature: Viewport Meta | #36159 | Web/CSS/Viewport
     pub viewport_meta_enabled: bool,
     pub log_filter: String,
     /// Whether the accessibility code is enabled.

--- a/components/paint/painter.rs
+++ b/components/paint/painter.rs
@@ -649,8 +649,15 @@ impl Painter {
                 webview_renderer.id.into(),
             );
 
-            let scaled_webview_rect = webview_renderer.rect /
-                webview_renderer.device_pixels_per_page_pixel_not_including_pinch_zoom();
+            // When zoomed out, expand the iframe to match the larger CSS viewport,
+            // preventing blank areas around the scaled-down content.
+            let adjustment_for_less_than_1_pinch_zoom =
+                webview_renderer.pinch_zoom().zoom_factor().get().min(1.0);
+            let device_pixels_per_page_pixel = webview_renderer
+                .device_pixels_per_page_pixel_not_including_pinch_zoom()
+                .get() *
+                adjustment_for_less_than_1_pinch_zoom;
+            let scaled_webview_rect = webview_renderer.rect / (device_pixels_per_page_pixel);
             builder.push_iframe(
                 LayoutRect::from_untyped(&scaled_webview_rect.to_untyped()),
                 LayoutRect::from_untyped(&scaled_webview_rect.to_untyped()),

--- a/components/paint/pinch_zoom.rs
+++ b/components/paint/pinch_zoom.rs
@@ -63,25 +63,28 @@ impl PinchZoom {
             .inverse()
             .expect("Should always be able to invert provided transform")
             .outer_transformed_rect(&rect);
-        rect.origin = rect.origin.clamp(
-            Point2D::origin(),
-            (self.unscaled_viewport_size - rect.size)
-                .to_vector()
-                .to_point(),
-        );
+
         let scale = self.unscaled_viewport_size.width / rect.width();
+
+        // When zoomed in, clamp the origin to keep the contents centered to point of pinch zoom.
+        // When zoomed out, the content is smaller than the viewport, so just set to origin.
+        if scale > 1.0 {
+            rect.origin = rect.origin.clamp(
+                Point2D::origin(),
+                (self.unscaled_viewport_size - rect.size)
+                    .to_vector()
+                    .to_point(),
+            );
+        } else {
+            rect.origin = Point2D::origin();
+        }
+
         self.transform = Transform2D::identity()
             .then_translate(Vector2D::new(-rect.origin.x, -rect.origin.y))
             .then_scale(scale, scale);
     }
 
     pub(crate) fn set_zoom(&mut self, new_factor: f32, new_center: DevicePoint) {
-        if new_factor <= 1.0 {
-            self.zoom_factor = 1.0; // Update the zoom factor to 1.0 to avoid precision issues when zooming back in after zooming out fully.
-            self.transform = Transform2D::identity();
-            return;
-        }
-
         let old_factor = std::mem::replace(&mut self.zoom_factor, new_factor);
 
         let magnification = self.zoom_factor / old_factor;

--- a/components/paint/webview_renderer.rs
+++ b/components/paint/webview_renderer.rs
@@ -1047,8 +1047,15 @@ impl WebViewRenderer {
         let device_pixel_ratio = self.device_pixels_per_page_pixel_not_including_pinch_zoom();
         // From <https://www.w3.org/TR/css-viewport-1/#actual-viewport>:
         // This is the viewport you get after processing the viewport <meta> tag.
-        let layout_viewport = self.rect.size().to_f32() /
-            (device_pixel_ratio * Scale::new(self.viewport_description.initial_scale.get()));
+        // When `initial_scale` is less than 1, we scale up the layout viewport by
+        // `1.0 / initial_scale` to prevent showing blank area around it.
+        let effective_initial_scale = self
+            .viewport_description
+            .initial_scale
+            .get()
+            .min(DEFAULT_PAGE_ZOOM.get());
+        let layout_viewport =
+            self.rect.size().to_f32() / (device_pixel_ratio * Scale::new(effective_initial_scale));
         let _ = self.embedder_to_constellation_sender.send(
             EmbedderToConstellationMessage::ChangeViewportDetails(
                 self.id,

--- a/components/servo/tests/webview.rs
+++ b/components/servo/tests/webview.rs
@@ -498,6 +498,139 @@ fn test_viewport_meta_tag_initial_scale() {
 }
 
 #[test]
+fn test_viewport_clamp_pinch_min_by_initial_scale_1() {
+    let servo_test = ServoTest::new_with_builder(|builder| {
+        let mut preferences = Preferences::default();
+        preferences.viewport_meta_enabled = true;
+        preferences.dom_visual_viewport_enabled = true;
+        builder.preferences(preferences)
+    });
+
+    let initial_scale: f64 = 1.0;
+
+    let delegate = Rc::new(WebViewDelegateImpl::default());
+    let webview = WebViewBuilder::new(servo_test.servo(), servo_test.rendering_context.clone())
+        .delegate(delegate.clone())
+        .url(
+            Url::parse(
+                format!(
+                    "data:text/html,\
+                    <!DOCTYPE html>\
+                    <meta name=viewport content=\"initial-scale={}, minimum-scale=1.0\">",
+                    initial_scale
+                )
+                .as_str(),
+            )
+            .unwrap(),
+        )
+        .build();
+
+    show_webview_and_wait_for_rendering_to_be_ready(&servo_test, &webview, &delegate);
+
+    webview.adjust_pinch_zoom(0.5, DevicePoint::new(100., 100.));
+    wait_for_webview_scene_to_be_up_to_date(&servo_test, &webview);
+
+    // The pinch zoom should be clamped by the minimum scale defined in the meta tag.
+    assert_eq!(
+        Ok(JSValue::Number(initial_scale)),
+        evaluate_javascript(&servo_test, webview.clone(), "window.visualViewport.scale;")
+    );
+}
+
+#[test]
+fn test_viewport_clamp_pinch_min_by_initial_scale_2() {
+    let servo_test = ServoTest::new_with_builder(|builder| {
+        let mut preferences = Preferences::default();
+        preferences.viewport_meta_enabled = true;
+        preferences.dom_visual_viewport_enabled = true;
+        builder.preferences(preferences)
+    });
+
+    let initial_scale: f64 = 2.0;
+
+    let delegate = Rc::new(WebViewDelegateImpl::default());
+    let webview = WebViewBuilder::new(servo_test.servo(), servo_test.rendering_context.clone())
+        .delegate(delegate.clone())
+        .url(
+            Url::parse(
+                format!(
+                    "data:text/html,\
+                    <!DOCTYPE html>\
+                    <meta name=viewport content=\"initial-scale={}, minimum-scale=0.5\">",
+                    initial_scale
+                )
+                .as_str(),
+            )
+            .unwrap(),
+        )
+        .build();
+
+    show_webview_and_wait_for_rendering_to_be_ready(&servo_test, &webview, &delegate);
+
+    webview.adjust_pinch_zoom(0.5, DevicePoint::new(100., 100.));
+    wait_for_webview_scene_to_be_up_to_date(&servo_test, &webview);
+
+    // The pinch zoom is clamped at 1.0 i.e. the DEFAULT_PAGE_ZOOM,
+    // because the initial scale defined in the meta tag is greater than the default page zoom.
+    assert_eq!(
+        Ok(JSValue::Number(1.0)),
+        evaluate_javascript(&servo_test, webview.clone(), "window.visualViewport.scale;")
+    );
+}
+
+#[test]
+fn test_viewport_clamp_pinch_min_by_initial_scale_3() {
+    let servo_test = ServoTest::new_with_builder(|builder| {
+        let mut preferences = Preferences::default();
+        preferences.viewport_meta_enabled = true;
+        preferences.dom_visual_viewport_enabled = true;
+        builder.preferences(preferences)
+    });
+
+    let initial_scale: f64 = 0.5;
+
+    let delegate = Rc::new(WebViewDelegateImpl::default());
+    let webview = WebViewBuilder::new(servo_test.servo(), servo_test.rendering_context.clone())
+        .delegate(delegate.clone())
+        .url(
+            Url::parse(
+                format!(
+                    "data:text/html,\
+                    <!DOCTYPE html>\
+                    <meta name=viewport content=\"initial-scale={}, minimum-scale=0.25\">",
+                    initial_scale
+                )
+                .as_str(),
+            )
+            .unwrap(),
+        )
+        .build();
+
+    show_webview_and_wait_for_rendering_to_be_ready(&servo_test, &webview, &delegate);
+
+    webview.adjust_pinch_zoom(2.0, DevicePoint::new(100., 100.));
+    wait_for_webview_scene_to_be_up_to_date(&servo_test, &webview);
+
+    // Pinch Zoom-In: The pinch-zoom value greater than initial scale.
+    let JSValue::Number(scale) =
+        evaluate_javascript(&servo_test, webview.clone(), "window.visualViewport.scale;")
+            .expect("Failed to evaluate JavaScript")
+    else {
+        unreachable!("Expected visualViewport.scale to be a number");
+    };
+    assert!(initial_scale < scale);
+
+    webview.adjust_pinch_zoom(0.5, DevicePoint::new(100., 100.));
+    wait_for_webview_scene_to_be_up_to_date(&servo_test, &webview);
+
+    // Pinch Zoom-Out: The pinch zoom should be clamped by the initial scale defined in the meta tag.
+    assert_eq!(
+        Ok(JSValue::Number(initial_scale)),
+        evaluate_javascript(&servo_test, webview.clone(), "window.visualViewport.scale;")
+    );
+}
+
+#[test]
 fn test_show_and_hide_ime() {
     let servo_test = ServoTest::new();
 

--- a/components/shared/paint/viewport_description.rs
+++ b/components/shared/paint/viewport_description.rs
@@ -126,6 +126,11 @@ impl ViewportDescription {
         }
         description.initial_scale =
             Scale::new(description.clamp_zoom(description.initial_scale.get()));
+
+        // To prevent showing blank area around the layout viewport,
+        // do not allow scaling below the minimum of `initial_scale` and `1.0`.
+        description.minimum_scale = description.initial_scale.min(DEFAULT_PAGE_ZOOM);
+
         description
     }
 

--- a/tests/wpt/tests/visual-viewport/viewport-scale-clamped.html
+++ b/tests/wpt/tests/visual-viewport/viewport-scale-clamped.html
@@ -14,25 +14,15 @@
   <script src="/resources/testdriver.js"></script>
   <script src="/resources/testdriver-actions.js"></script>
   <script src="/resources/testdriver-vendor.js"></script>
+  <script src="/visual-viewport/viewport_support.js"></script>
 </head>
 
 <body>
   <div style="font-size: 50px;">This page can not be pinch zoomed, it is clamped using meta viewport scale.</div>
   <script> promise_test(async () => {
-      const x = 200, y = 200;
       const initialScale = window.visualViewport.scale;
-      // Perform pinch zoom
-      await new test_driver.Actions()
-        .addPointer("f1", "touch")
-        .addPointer("f2", "touch")
-        .pointerMove(x, y, { origin: "viewport", sourceName: "f1" })
-        .pointerMove(x + 100, y + 100, { origin: "viewport", sourceName: "f2" })
-        .pointerDown({ sourceName: "f1" })
-        .pointerDown({ sourceName: "f2" })
-        .pointerMove(x - 100, y - 100, { origin: "viewport", sourceName: "f1", duration: 0 })
-        .pointerMove(x + 100, y + 100, { origin: "viewport", sourceName: "f2", duration: 0 })
-        .pointerUp({ sourceName: "f1" })
-        .pointerUp({ sourceName: "f2" }).send();
+      // Perform Pinch Zoom-In
+      await pinchZoomIn();
       assert_equals(window.visualViewport.scale, initialScale, "Scale should be same");
     }) </script>
 </body>

--- a/tests/wpt/tests/visual-viewport/viewport-scale-with-pinch-zoom.html
+++ b/tests/wpt/tests/visual-viewport/viewport-scale-with-pinch-zoom.html
@@ -1,0 +1,38 @@
+<!DOCTYPE html>
+<html>
+
+<head>
+  <meta charset="utf-8">
+  <title>Viewport Scale : Pinch Zoom</title>
+  <link rel=help href="https://github.com/w3c/csswg-drafts/issues/9004">
+  <link rel=help href="https://www.w3.org/TR/2015/WD-mobile-accessibility-mapping-20150226/#zoom-magnification">
+  <link rel="author" title="Shubham Gupta" href="mailto:shubham.gupta@chromium.org">
+  <meta name="assert" content="The page can be pinch zoomed-in and zoomed-out.">
+  <meta name="viewport" content="minimum-scale=0.1, initial-scale=1.0, maximum-scale=10.0">
+  <script src="/resources/testharness.js"></script>
+  <script src="/resources/testharnessreport.js"></script>
+  <script src="/resources/testdriver.js"></script>
+  <script src="/resources/testdriver-actions.js"></script>
+  <script src="/resources/testdriver-vendor.js"></script>
+  <script src="/visual-viewport/viewport_support.js"></script>
+
+</head>
+
+<body>
+  <div style="font-size: 50px;">Pinch Zoom Test: Zoom In</div>
+  <script>
+    promise_test(async () => {
+      const initialScale = window.visualViewport.scale;
+
+      await pinchZoomIn();
+      assert_greater_than(window.visualViewport.scale, initialScale,
+        "Scale should be greater than initial scale after pinch zoom in");
+      const afterZoomIn = window.visualViewport.scale;
+
+      await pinchZoomOut();
+      assert_less_than(window.visualViewport.scale, afterZoomIn,
+        "Scale should be less than after pinch zoom in scale after pinch zoom out");
+    }) </script>
+</body>
+
+</html>

--- a/tests/wpt/tests/visual-viewport/viewport_support.js
+++ b/tests/wpt/tests/visual-viewport/viewport_support.js
@@ -25,6 +25,28 @@ function pinchZoomIn() {
       .send();
 }
 
+// Simulates two fingers, 100px apart, pulling closer vertically to 50px of
+// separation.
+function pinchZoomOut() {
+  const viewport = window.visualViewport;
+  const center_x = Math.floor(viewport.width / 2);
+  const center_y = Math.floor(viewport.height / 2);
+
+  return new test_driver.Actions()
+      .setContext(window)
+      .addPointer("finger1", "touch")
+      .addPointer("finger2", "touch")
+      .pointerMove(center_x, center_y, {origin: "viewport", sourceName: "finger1"})
+      .pointerMove(center_x, center_y + 100, {origin: "viewport", sourceName: "finger2"})
+      .pointerDown({sourceName: "finger1"})
+      .pointerDown({sourceName: "finger2"})
+      .pointerMove(center_x, center_y, {origin: "viewport", sourceName: "finger1"})
+      .pointerMove(center_x, center_y + 50, {origin: "viewport", sourceName: "finger2"})
+      .pointerUp({sourceName: "finger1"})
+      .pointerUp({sourceName: "finger2"})
+      .send();
+}
+
 // If scrollbars affect layout (i.e. what the CSS Overflow spec calls "classic
 // scrollbars", as opposed to overlay scrollbars), return the scrollbar
 // thickness in CSS pixels. Returns 0 otherwise.


### PR DESCRIPTION
Now it fully support pinch-zoom over whole range 0.1 to 10.0 

CSSWG Issue: https://github.com/w3c/csswg-drafts/issues/9004

> "minimum-scale-box" - the viewport when zoomed out to the minimum scale factor

Document referencing Case Study: [viewport meta](https://docs.google.com/document/d/1NBu9rC4sHm51I2yOsWJxeDOd17sNIchEhoNLyOFbAJM/edit?usp=sharing) 

Testing: 

- Tested Manually on Mobile Device
- WPT: `visual-viewport/viewport-scale-with-pinch-zoom.html`
- UT: `webview`:`test_viewport_clamp_pinch_min_by_initial_scale_1/2/3`

Fixes: #39002
Fixes: A concern from #40098

https://github.com/servo/servo/pull/40098#discussion_r3032426990
