### PR TITLE
webdriver: Improve error reporting for Cookie Addition

### DIFF
--- a/components/script/webdriver_handlers.rs
+++ b/components/script/webdriver_handlers.rs
@@ -1486,8 +1486,8 @@ pub(crate) fn handle_add_cookie(
                 Ok(())
             },
             // If cookie domain is not equal to session's current browsing context's
-            // active document's domain, return error with error code invalid argument.
-            (false, Some(_)) => Err(ErrorStatus::InvalidArgument),
+            // active document's domain, return error with error code invalid cookie domain.
+            (false, Some(_)) => Err(ErrorStatus::InvalidCookieDomain),
             (false, None) => {
                 let _ = document
                     .window()

--- a/components/script/webdriver_handlers.rs
+++ b/components/script/webdriver_handlers.rs
@@ -1460,7 +1460,7 @@ pub(crate) fn handle_add_cookie(
     let document = match documents.find_document(pipeline) {
         Some(document) => document,
         None => {
-            return reply.send(Err(ErrorStatus::UnableToSetCookie)).unwrap();
+            return reply.send(Err(ErrorStatus::NoSuchWindow)).unwrap();
         },
     };
     let url = document.url();
@@ -1471,8 +1471,11 @@ pub(crate) fn handle_add_cookie(
     };
 
     let domain = cookie.domain().map(ToOwned::to_owned);
+    // Step 6.
     reply
         .send(match (document.is_cookie_averse(), domain) {
+            // If session's current browsing context's document element is a
+            // cookie-averse Document object, return error with error code invalid cookie domain.
             (true, _) => Err(ErrorStatus::InvalidCookieDomain),
             (false, Some(ref domain)) if url.host_str().is_some_and(|host| host == domain) => {
                 let _ = document
@@ -1482,6 +1485,9 @@ pub(crate) fn handle_add_cookie(
                     .send(SetCookieForUrl(url, Serde(cookie), method));
                 Ok(())
             },
+            // If cookie domain is not equal to session's current browsing context's
+            // active document's domain, return error with error code invalid argument.
+            (false, Some(_)) => Err(ErrorStatus::InvalidArgument),
             (false, None) => {
                 let _ = document
                     .window()
@@ -1490,7 +1496,6 @@ pub(crate) fn handle_add_cookie(
                     .send(SetCookieForUrl(url, Serde(cookie), method));
                 Ok(())
             },
-            (_, _) => Err(ErrorStatus::UnableToSetCookie),
         })
         .unwrap();
 }

--- a/components/webdriver_server/actions.rs
+++ b/components/webdriver_server/actions.rs
@@ -25,7 +25,10 @@ use webdriver::actions::{
 };
 use webdriver::error::{ErrorStatus, WebDriverError};
 
-use crate::{Handler, VerifyBrowsingContextIsOpen, WebElement, wait_for_oneshot_response};
+use crate::{
+    Handler, MAXIMUM_SAFE_INTEGER, VerifyBrowsingContextIsOpen, WebElement,
+    wait_for_oneshot_response,
+};
 
 /// Interval between wheelScroll and pointerMove increments in ms, based on common vsync
 static MOVESCROLL_INTERVAL: u64 = 16;
@@ -33,10 +36,6 @@ static MOVESCROLL_INTERVAL: u64 = 16;
 /// <https://w3c.github.io/webdriver/#dfn-element-click>
 /// This is hard-coded as 0 in spec.
 pub(crate) static ELEMENT_CLICK_BUTTON: u64 = 0;
-
-/// <https://262.ecma-international.org/6.0/#sec-number.max_safe_integer>
-/// 2^53 - 1
-static MAXIMUM_SAFE_INTEGER: u64 = 9_007_199_254_740_991;
 
 // A single action, corresponding to an `action object` in the spec.
 // In the spec, `action item` refers to a plain JSON object.

--- a/components/webdriver_server/lib.rs
+++ b/components/webdriver_server/lib.rs
@@ -77,6 +77,10 @@ use crate::actions::{ELEMENT_CLICK_BUTTON, InputSourceState, PendingActions, Poi
 use crate::session::{PageLoadStrategy, WebDriverSession};
 use crate::timeout::{DEFAULT_IMPLICIT_WAIT, DEFAULT_PAGE_LOAD_TIMEOUT, SCREENSHOT_TIMEOUT};
 
+/// <https://262.ecma-international.org/6.0/#sec-number.max_safe_integer>
+/// 2^53 - 1
+pub(crate) static MAXIMUM_SAFE_INTEGER: u64 = 9_007_199_254_740_991;
+
 fn extension_routes() -> Vec<(Method, &'static str, ServoExtensionRoute)> {
     vec![
         (
@@ -1859,6 +1863,18 @@ impl Handler {
         self.handle_any_user_prompts(self.webview_id()?)?;
         let (sender, receiver) = generic_channel::channel().unwrap();
 
+        // Step 6. cookie expiry time is not an integer type,
+        // or it less than 0 or greater than the maximum safe integer,
+        // return error with error code invalid argument.
+        if let Some(ref expiry) = params.expiry {
+            if expiry.0 > MAXIMUM_SAFE_INTEGER {
+                return Err(WebDriverError::new(
+                    ErrorStatus::InvalidArgument,
+                    "expiry time greater than maximum safe integer",
+                ));
+            }
+        }
+
         let mut cookie_builder =
             CookieBuilder::new(params.name.to_owned(), params.value.to_owned())
                 .secure(params.secure)
@@ -1870,9 +1886,10 @@ impl Handler {
             cookie_builder = cookie_builder.path(path.clone());
         }
         if let Some(ref expiry) = params.expiry {
-            if let Ok(datetime) = OffsetDateTime::from_unix_timestamp(expiry.0 as i64) {
-                cookie_builder = cookie_builder.expires(datetime);
-            }
+            let datetime = OffsetDateTime::from_unix_timestamp(expiry.0 as i64).map_err(|_| {
+                WebDriverError::new(ErrorStatus::InvalidArgument, "invalid expiry time")
+            })?;
+            cookie_builder = cookie_builder.expires(datetime);
         }
         if let Some(ref same_site) = params.sameSite {
             cookie_builder = match same_site.as_str() {

--- a/tests/wpt/meta/webdriver/tests/classic/add_cookie/add.py.ini
+++ b/tests/wpt/meta/webdriver/tests/classic/add_cookie/add.py.ini
@@ -1,27 +1,3 @@
 [add.py]
   [test_no_browsing_context]
     expected: FAIL
-
-  [test_cookie_unsupported_scheme[about\]]
-    expected: FAIL
-
-  [test_cookie_unsupported_scheme[blob\]]
-    expected: FAIL
-
-  [test_cookie_unsupported_scheme[data\]]
-    expected: FAIL
-
-  [test_cookie_unsupported_scheme[file\]]
-    expected: FAIL
-
-  [test_cookie_unsupported_scheme[ftp\]]
-    expected: FAIL
-
-  [test_cookie_unsupported_scheme[javascript\]]
-    expected: FAIL
-
-  [test_cookie_unsupported_scheme[websocket\]]
-    expected: FAIL
-
-  [test_cookie_unsupported_scheme[secure websocket\]]
-    expected: FAIL

--- a/tests/wpt/tests/webdriver/tests/classic/add_cookie/add.py
+++ b/tests/wpt/tests/webdriver/tests/classic/add_cookie/add.py
@@ -305,3 +305,17 @@ def test_add_cookie_with_invalid_samesite_type(session, url, same_site):
 
     response = add_cookie(session, new_cookie)
     assert_error(response, "invalid argument")
+
+
+@pytest.mark.parametrize("expiry", [2 ** 53, -1, 0.5])
+def test_add_cookie_with_invalid_expiry(session, url, expiry):
+    new_cookie = {
+        "name": "hello",
+        "value": "world",
+        "expiry": expiry
+    }
+
+    session.url = url("/common/blank.html")
+
+    response = add_cookie(session, new_cookie)
+    assert_error(response, "invalid argument")


### PR DESCRIPTION
Improve the error reporting for [cookie addition](https://w3c.github.io/webdriver/#add-cookie).
Most notably, when
- expiry time exceeds maximum safe integer
- cookie domain is not equal to session's current browsing context's active document's domain

There is a bug with spec: https://github.com/servo/servo/pull/43690#discussion_r2994771111.
We fix spec in https://github.com/w3c/webdriver/pull/1955 and
make sure Servo behaves consistently with other browsers.

Testing: Added one test for invalid expiry time. New passing with existing.