### PR TITLE
layout: Integrate `::first-letter` support into the `InlineFormattingContextBuilder`

### DIFF
--- a/components/layout/dom.rs
+++ b/components/layout/dom.rs
@@ -83,11 +83,13 @@ impl InnerDOMLayoutData {
     }
 
     fn repair_style(&self, node: &ServoThreadSafeLayoutNode, context: &SharedStyleContext) {
+        println!("repair style: {:?}", node);
         if let Some(layout_object) = &*self.self_box.borrow() {
             layout_object.repair_style(context, node, &node.style(context));
         }
 
         for pseudo_layout_data in self.pseudo_boxes.iter() {
+            println!("  - {:?}", pseudo_layout_data.pseudo);
             let Some(node_with_pseudo) = node.with_pseudo(pseudo_layout_data.pseudo) else {
                 continue;
             };

--- a/components/layout/flow/construct.rs
+++ b/components/layout/flow/construct.rs
@@ -11,7 +11,6 @@ use style::properties::longhands::list_style_position::computed_value::T as List
 use style::selector_parser::PseudoElement;
 use style::str::char_is_whitespace;
 use style::values::specified::box_::DisplayOutside as StyloDisplayOutside;
-use unicode_categories::UnicodeCategories;
 
 use super::OutsideMarker;
 use super::inline::construct::InlineFormattingContextBuilder;
@@ -365,89 +364,6 @@ impl<'dom, 'style> BlockContainerBuilder<'dom, 'style> {
     }
 }
 
-/// Computes the range of the first letter.
-///
-/// The range includes any preceding punctuation, and any spaces interleaved
-/// within the preceding punctuation or between the preceding punctuation
-/// and the first letter/number/symbol.
-/// Succeeding punctuation are included in the range, but any space
-/// following the letter/number/symbol ends the range. Intervening
-/// succeeding spaces are not supported yet.
-///
-/// <https://drafts.csswg.org/css-pseudo/#first-letter-pattern>
-fn first_letter_range(text: &str) -> std::ops::Range<usize> {
-    use unicode_categories::UnicodeCategories;
-
-    enum State {
-        Start,
-        PrecedingPunc,
-        /// Unicode general category L: letter, N: number and S: symbol
-        Lns,
-        SucceedingPunc,
-    }
-
-    let mut start = 0;
-    let mut end = None;
-    let mut state = State::Start;
-
-    for (i, c) in text.char_indices() {
-        match &mut state {
-            State::Start => {
-                if c.is_punctuation() {
-                    start = i;
-                    state = State::PrecedingPunc;
-                } else if c.is_letter() || c.is_number() || c.is_symbol() {
-                    start = i;
-                    state = State::Lns;
-                } else if c.is_separator_space() {
-                    continue;
-                } else {
-                    // Found invalid character
-                    return 0..0;
-                }
-            },
-            State::PrecedingPunc => {
-                if c.is_letter() || c.is_number() || c.is_symbol() {
-                    state = State::Lns;
-                } else if c.is_punctuation() || (c.is_separator_space() && c != '\u{3000}') {
-                    continue;
-                } else {
-                    // Found invalid character
-                    return 0..0;
-                }
-            },
-            State::Lns => {
-                // TODO: Implement support for intervening spaces
-                // <https://drafts.csswg.org/css-pseudo/#first-letter-pattern>
-                if c.is_punctuation() && !c.is_punctuation_open() && !c.is_punctuation_dash() {
-                    state = State::SucceedingPunc;
-                } else {
-                    end = Some(i);
-                    break;
-                }
-            },
-            State::SucceedingPunc => {
-                // TODO: Implement support for intervening spaces
-                // <https://drafts.csswg.org/css-pseudo/#first-letter-pattern>
-                if c.is_punctuation() && !c.is_punctuation_open() && !c.is_punctuation_dash() {
-                    continue;
-                } else {
-                    end = Some(i);
-                    break;
-                }
-            },
-        }
-    }
-
-    match state {
-        State::Start | State::PrecedingPunc => 0..0,
-        State::Lns | State::SucceedingPunc => {
-            let end = end.unwrap_or(text.len());
-            start..end
-        },
-    }
-}
-
 impl<'dom> TraversalHandler<'dom> for BlockContainerBuilder<'dom, '_> {
     fn handle_element(
         &mut self,
@@ -508,42 +424,11 @@ impl<'dom> TraversalHandler<'dom> for BlockContainerBuilder<'dom, '_> {
             self.finish_anonymous_table_if_needed();
         }
 
-        let container_info = self.info;
-        let context = self.context;
-        let builder = self.ensure_inline_formatting_context_builder();
-
-        // ::first-letter is an eager pseudo element and should not be nested
-        if let Some(pseudo_info) = (container_info.pseudo_element_chain().is_empty())
-            .then(|| container_info.with_pseudo_element(context, PseudoElement::FirstLetter))
-            .flatten()
-            .filter(|_| {
-                builder
-                    .text_segments
-                    .iter()
-                    .flat_map(|seg| seg.chars())
-                    .all(|c| c.is_separator_space())
-            })
-        {
-            let first_letter_range = first_letter_range(&text[..]);
-
-            // The first letter range may be some value larger than zero when
-            // there are preceding spaces.
-            if first_letter_range.start != 0 {
-                builder.push_text(Cow::Borrowed(&text[0..first_letter_range.start]), info);
-            }
-
-            builder.start_inline_box(
-                || ArcRefCell::new(InlineBox::new(&pseudo_info, context)),
-                None,
-            );
-            let first_letter_text = Cow::Borrowed(&text[first_letter_range.clone()]);
-            builder.push_text(first_letter_text, &pseudo_info);
-            builder.end_inline_box();
-
-            builder.push_text(Cow::Borrowed(&text[first_letter_range.end..]), info);
-        } else {
-            builder.push_text(text, info);
-        }
+        self.ensure_inline_formatting_context_builder();
+        self.inline_formatting_context_builder
+            .as_mut()
+            .expect("Should be guaranteed by line above")
+            .push_text_with_possible_first_letter(text, info, self.info, self.context);
     }
 
     fn enter_display_contents(&mut self, styles: SharedInlineStyles) {
@@ -635,13 +520,11 @@ impl<'dom> BlockContainerBuilder<'dom, '_> {
         // Otherwise, this is just a normal inline box. Whatever happened before, all we need to do
         // before recurring is to remember this ongoing inline level box.
         let inline_builder = self.ensure_inline_formatting_context_builder();
-        inline_builder.start_inline_box(
+        let inline_item = inline_builder.start_inline_box(
             || ArcRefCell::new(InlineBox::new(info, context)),
             old_layout_box,
         );
-        box_slot.set(LayoutBox::InlineLevel(
-            inline_builder.inline_items.last().unwrap().clone(),
-        ));
+        box_slot.set(LayoutBox::InlineLevel(inline_item));
 
         if is_list_item {
             if let Some((marker_info, marker_contents)) =
@@ -918,78 +801,5 @@ impl IntermediateBlockContainer {
             } => BlockContainer::construct(context, info, contents, propagated_data, is_list_item),
             IntermediateBlockContainer::InlineFormattingContext(block_container) => block_container,
         }
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    fn assert_first_letter_eq(text: &str, expected: &str) {
-        let range = first_letter_range(text);
-        assert_eq!(&text[range], expected);
-    }
-
-    #[test]
-    fn test_first_letter_range() {
-        // All spaces
-        assert_first_letter_eq("", "");
-        assert_first_letter_eq("  ", "");
-
-        // Spaces and punctuation only
-        assert_first_letter_eq("(", "");
-        assert_first_letter_eq(" (", "");
-        assert_first_letter_eq("( ", "");
-        assert_first_letter_eq("()", "");
-
-        // Invalid chars
-        assert_first_letter_eq("\u{0903}", "");
-
-        // First letter only
-        assert_first_letter_eq("A", "A");
-        assert_first_letter_eq(" A", "A");
-        assert_first_letter_eq("A ", "A");
-        assert_first_letter_eq(" A ", "A");
-
-        // Word
-        assert_first_letter_eq("App", "A");
-        assert_first_letter_eq(" App", "A");
-        assert_first_letter_eq("App ", "A");
-
-        // Preceding punctuation(s), intervening spaces and first letter
-        assert_first_letter_eq(r#""A"#, r#""A"#);
-        assert_first_letter_eq(r#" "A"#, r#""A"#);
-        assert_first_letter_eq(r#""A "#, r#""A"#);
-        assert_first_letter_eq(r#"" A"#, r#"" A"#);
-        assert_first_letter_eq(r#" "A "#, r#""A"#);
-        assert_first_letter_eq(r#"("A"#, r#"("A"#);
-        assert_first_letter_eq(r#" ("A"#, r#"("A"#);
-        assert_first_letter_eq(r#"( "A"#, r#"( "A"#);
-        assert_first_letter_eq(r#"[ ( "A"#, r#"[ ( "A"#);
-
-        // First letter and succeeding punctuation(s)
-        // TODO: modify test cases when intervening spaces in succeeding puntuations is supported
-        assert_first_letter_eq(r#"A""#, r#"A""#);
-        assert_first_letter_eq(r#"A" "#, r#"A""#);
-        assert_first_letter_eq(r#"A)]"#, r#"A)]"#);
-        assert_first_letter_eq(r#"A" )]"#, r#"A""#);
-        assert_first_letter_eq(r#"A)] >"#, r#"A)]"#);
-
-        // All
-        assert_first_letter_eq(r#" ("A" )]"#, r#"("A""#);
-        assert_first_letter_eq(r#" ("A")] >"#, r#"("A")]"#);
-
-        // Non ASCII chars
-        assert_first_letter_eq("一", "一");
-        assert_first_letter_eq(" 一 ", "一");
-        assert_first_letter_eq("一二三", "一");
-        assert_first_letter_eq(" 一二三 ", "一");
-        assert_first_letter_eq("（一二三）", "（一");
-        assert_first_letter_eq(" （一二三） ", "（一");
-        assert_first_letter_eq("（（一", "（（一");
-        assert_first_letter_eq(" （ （一", "（ （一");
-        assert_first_letter_eq("一）", "一）");
-        assert_first_letter_eq("一））", "一））");
-        assert_first_letter_eq("一） ）", "一）");
     }
 }

--- a/components/layout/flow/inline/construct.rs
+++ b/components/layout/flow/inline/construct.rs
@@ -4,13 +4,16 @@
 
 use std::borrow::Cow;
 use std::char::{ToLowercase, ToUppercase};
+use std::ops::Range;
 
 use icu_segmenter::WordSegmenter;
 use layout_api::wrapper_traits::{SharedSelection, ThreadSafeLayoutNode};
 use style::computed_values::_webkit_text_security::T as WebKitTextSecurity;
 use style::computed_values::white_space_collapse::T as WhiteSpaceCollapse;
+use style::selector_parser::PseudoElement;
 use style::values::specified::text::TextTransformCase;
 use unicode_bidi::Level;
+use unicode_categories::UnicodeCategories;
 
 use super::text_run::TextRun;
 use super::{
@@ -19,7 +22,7 @@ use super::{
 };
 use crate::cell::ArcRefCell;
 use crate::context::LayoutContext;
-use crate::dom::LayoutBox;
+use crate::dom::{LayoutBox, NodeExt};
 use crate::dom_traversal::NodeAndStyleInfo;
 use crate::flow::BlockLevelBox;
 use crate::flow::float::FloatBox;
@@ -90,6 +93,10 @@ pub(crate) struct InlineFormattingContextBuilder {
     /// during box tree construction. An IFC is empty if it only contains TextRuns with
     /// completely collapsible whitespace. When that happens it can be ignored completely.
     pub is_empty: bool,
+
+    /// Whether or not the `::first-letter` pseudo-element of this inline formatting context
+    /// has been processed yet.
+    has_processed_first_letter: bool,
 }
 
 impl InlineFormattingContextBuilder {
@@ -151,6 +158,9 @@ impl InlineFormattingContextBuilder {
 
         self.last_inline_box_ended_with_collapsible_white_space = false;
         self.on_word_boundary = true;
+
+        // Atomics such as images should prevent any following text as being interpreted as the first letter.
+        self.has_processed_first_letter = true;
 
         inline_level_box
     }
@@ -214,7 +224,7 @@ impl InlineFormattingContextBuilder {
         &mut self,
         inline_box_creator: impl FnOnce() -> ArcRefCell<InlineBox>,
         old_layout_box: Option<LayoutBox>,
-    ) {
+    ) -> InlineItem {
         // If there is an existing undamaged layout box that's compatible, use the `InlineBox` within it.
         let inline_box = old_layout_box
             .and_then(|layout_box| match layout_box {
@@ -231,10 +241,11 @@ impl InlineFormattingContextBuilder {
         std::mem::drop(borrowed_inline_box);
 
         let identifier = self.inline_boxes.start_inline_box(inline_box.clone());
-        self.inline_items
-            .push(InlineItem::StartInlineBox(inline_box));
+        let inline_item = InlineItem::StartInlineBox(inline_box);
+        self.inline_items.push(inline_item.clone());
         self.inline_box_stack.push(identifier);
         self.is_empty = false;
+        inline_item
     }
 
     /// End the ongoing inline box in this [`InlineFormattingContextBuilder`], returning
@@ -252,6 +263,61 @@ impl InlineFormattingContextBuilder {
         let inline_level_box = self.inline_boxes.get(&identifier);
         let bidi_control_chars = inline_level_box.borrow().base.style.bidi_control_chars();
         self.push_control_character_string(bidi_control_chars.1);
+    }
+
+    /// This is like [`Self::push_text`], except that it might possibly add an anonymous box if
+    ///
+    ///  - This inline formatting context has a `::first-letter` style.
+    ///  - No anonymous box for `::first-letter` has been added yet.
+    ///  - First letter content is detected in this text.
+    ///
+    /// Note that this should only be used when processing text in block containers.
+    pub(crate) fn push_text_with_possible_first_letter<'dom>(
+        &mut self,
+        text: Cow<'dom, str>,
+        info: &NodeAndStyleInfo<'dom>,
+        container_info: &NodeAndStyleInfo<'dom>,
+        layout_context: &LayoutContext,
+    ) -> bool {
+        if self.has_processed_first_letter || !container_info.pseudo_element_chain().is_empty() {
+            self.push_text(text, info);
+            return false;
+        }
+
+        let Some(first_letter_info) =
+            container_info.with_pseudo_element(layout_context, PseudoElement::FirstLetter)
+        else {
+            self.push_text(text, info);
+            return false;
+        };
+
+        let first_letter_range = first_letter_range(&text[..]);
+        if first_letter_range.is_empty() {
+            return false;
+        }
+
+        // Push any leading white space first.
+        if first_letter_range.start != 0 {
+            self.push_text(Cow::Borrowed(&text[0..first_letter_range.start]), info);
+        }
+
+        // Push the first-letter text into an anonymous box with the `::first-letter` style.
+        let box_slot = first_letter_info.node.box_slot();
+        let inline_item = self.start_inline_box(
+            || ArcRefCell::new(InlineBox::new(&first_letter_info, layout_context)),
+            None,
+        );
+        box_slot.set(LayoutBox::InlineLevel(inline_item));
+
+        let first_letter_text = Cow::Borrowed(&text[first_letter_range.clone()]);
+        self.push_text(first_letter_text, &first_letter_info);
+        self.end_inline_box();
+        self.has_processed_first_letter = true;
+
+        // Now push the non-first-letter text.
+        self.push_text(Cow::Borrowed(&text[first_letter_range.end..]), info);
+
+        true
     }
 
     pub(crate) fn push_text<'dom>(&mut self, text: Cow<'dom, str>, info: &NodeAndStyleInfo<'dom>) {
@@ -714,4 +780,152 @@ pub(crate) fn capitalize_string(string: &str, allow_word_at_start: bool) -> Stri
     }
 
     output_string
+}
+
+/// Computes the range of the first letter.
+///
+/// The range includes any preceding punctuation and white space, and any trailing punctuation. Any
+/// non-punctuation following the letter/number/symbol of first-letter ends the range. Intervening
+/// spaces within trailing punctuation are not supported yet.
+///
+/// If the resulting range is empty, no compatible first-letter text was found.
+///
+/// <https://drafts.csswg.org/css-pseudo/#first-letter-pattern>
+fn first_letter_range(text: &str) -> Range<usize> {
+    enum State {
+        /// All characters that precede the `PrecedingWhitespaceAndPunctuation` state.
+        Start,
+        /// All preceding punctuation and intervening whitepace that precedes the `Lns` state.
+        PrecedingPunctuation,
+        /// Unicode general category L: letter, N: number and S: symbol
+        Lns,
+        /// All punctuation (but no whitespace or other characters), that
+        /// come after the `Lns` state.
+        TrailingPunctuation,
+    }
+
+    let mut start = 0;
+    let mut state = State::Start;
+    for (index, character) in text.char_indices() {
+        match &mut state {
+            State::Start => {
+                if character.is_letter() || character.is_number() || character.is_symbol() {
+                    start = index;
+                    state = State::Lns;
+                } else if character.is_punctuation() {
+                    start = index;
+                    state = State::PrecedingPunctuation
+                }
+            },
+            State::PrecedingPunctuation => {
+                if character.is_letter() || character.is_number() || character.is_symbol() {
+                    state = State::Lns;
+                } else if !character.is_separator_space() && !character.is_punctuation() {
+                    return 0..0;
+                }
+            },
+            State::Lns => {
+                // TODO: Implement support for intervening spaces
+                // <https://drafts.csswg.org/css-pseudo/#first-letter-pattern>
+                if character.is_punctuation() &&
+                    !character.is_punctuation_open() &&
+                    !character.is_punctuation_dash()
+                {
+                    state = State::TrailingPunctuation;
+                } else {
+                    return start..index;
+                }
+            },
+            State::TrailingPunctuation => {
+                // TODO: Implement support for intervening spaces
+                // <https://drafts.csswg.org/css-pseudo/#first-letter-pattern>
+                if character.is_punctuation() &&
+                    !character.is_punctuation_open() &&
+                    !character.is_punctuation_dash()
+                {
+                    continue;
+                } else {
+                    return start..index;
+                }
+            },
+        }
+    }
+
+    match state {
+        State::Start | State::PrecedingPunctuation => 0..0,
+        State::Lns | State::TrailingPunctuation => start..text.len(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn assert_first_letter_eq(text: &str, expected: &str) {
+        let range = first_letter_range(text);
+        assert_eq!(&text[range], expected);
+    }
+
+    #[test]
+    fn test_first_letter_range() {
+        // All spaces
+        assert_first_letter_eq("", "");
+        assert_first_letter_eq("  ", "");
+
+        // Spaces and punctuation only
+        assert_first_letter_eq("(", "");
+        assert_first_letter_eq(" (", "");
+        assert_first_letter_eq("( ", "");
+        assert_first_letter_eq("()", "");
+
+        // Invalid chars
+        assert_first_letter_eq("\u{0903}", "");
+
+        // First letter only
+        assert_first_letter_eq("A", "A");
+        assert_first_letter_eq(" A", "A");
+        assert_first_letter_eq("A ", "A");
+        assert_first_letter_eq(" A ", "A");
+
+        // Word
+        assert_first_letter_eq("App", "A");
+        assert_first_letter_eq(" App", "A");
+        assert_first_letter_eq("App ", "A");
+
+        // Preceding punctuation(s), intervening spaces and first letter
+        assert_first_letter_eq(r#""A"#, r#""A"#);
+        assert_first_letter_eq(r#" "A"#, r#""A"#);
+        assert_first_letter_eq(r#""A "#, r#""A"#);
+        assert_first_letter_eq(r#"" A"#, r#"" A"#);
+        assert_first_letter_eq(r#" "A "#, r#""A"#);
+        assert_first_letter_eq(r#"("A"#, r#"("A"#);
+        assert_first_letter_eq(r#" ("A"#, r#"("A"#);
+        assert_first_letter_eq(r#"( "A"#, r#"( "A"#);
+        assert_first_letter_eq(r#"[ ( "A"#, r#"[ ( "A"#);
+
+        // First letter and succeeding punctuation(s)
+        // TODO: modify test cases when intervening spaces in succeeding puntuations is supported
+        assert_first_letter_eq(r#"A""#, r#"A""#);
+        assert_first_letter_eq(r#"A" "#, r#"A""#);
+        assert_first_letter_eq(r#"A)]"#, r#"A)]"#);
+        assert_first_letter_eq(r#"A" )]"#, r#"A""#);
+        assert_first_letter_eq(r#"A)] >"#, r#"A)]"#);
+
+        // All
+        assert_first_letter_eq(r#" ("A" )]"#, r#"("A""#);
+        assert_first_letter_eq(r#" ("A")] >"#, r#"("A")]"#);
+
+        // Non ASCII chars
+        assert_first_letter_eq("一", "一");
+        assert_first_letter_eq(" 一 ", "一");
+        assert_first_letter_eq("一二三", "一");
+        assert_first_letter_eq(" 一二三 ", "一");
+        assert_first_letter_eq("（一二三）", "（一");
+        assert_first_letter_eq(" （一二三） ", "（一");
+        assert_first_letter_eq("（（一", "（（一");
+        assert_first_letter_eq(" （ （一", "（ （一");
+        assert_first_letter_eq("一）", "一）");
+        assert_first_letter_eq("一））", "一））");
+        assert_first_letter_eq("一） ）", "一）");
+    }
 }

--- a/tests/wpt/meta/css/CSS2/selectors/first-letter-dynamic-002.xht.ini
+++ b/tests/wpt/meta/css/CSS2/selectors/first-letter-dynamic-002.xht.ini
@@ -1,0 +1,2 @@
+[first-letter-dynamic-002.xht]
+  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/selectors/first-letter-nested-001.xht.ini
+++ b/tests/wpt/meta/css/CSS2/selectors/first-letter-nested-001.xht.ini
@@ -1,2 +1,0 @@
-[first-letter-nested-001.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/selectors/first-letter-nested-002.xht.ini
+++ b/tests/wpt/meta/css/CSS2/selectors/first-letter-nested-002.xht.ini
@@ -1,2 +1,0 @@
-[first-letter-nested-002.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/selectors/first-letter-nested-006.xht.ini
+++ b/tests/wpt/meta/css/CSS2/selectors/first-letter-nested-006.xht.ini
@@ -1,2 +1,0 @@
-[first-letter-nested-006.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/selectors/first-letter-selector-005.xht.ini
+++ b/tests/wpt/meta/css/CSS2/selectors/first-letter-selector-005.xht.ini
@@ -1,0 +1,2 @@
+[first-letter-selector-005.xht]
+  expected: FAIL

--- a/tests/wpt/meta/css/css-grid/grid-model/grid-first-letter-003.html.ini
+++ b/tests/wpt/meta/css/css-grid/grid-model/grid-first-letter-003.html.ini
@@ -1,2 +1,0 @@
-[grid-first-letter-003.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-grid/grid-model/grid-inline-first-letter-003.html.ini
+++ b/tests/wpt/meta/css/css-grid/grid-model/grid-inline-first-letter-003.html.ini
@@ -1,2 +1,0 @@
-[grid-inline-first-letter-003.html]
-  expected: FAIL

--- a/tests/wpt/meta/paint-timing/fcp-only/fcp-typographic-pseudo.html.ini
+++ b/tests/wpt/meta/paint-timing/fcp-only/fcp-typographic-pseudo.html.ini
@@ -1,4 +1,0 @@
-[fcp-typographic-pseudo.html]
-  expected: TIMEOUT
-  [First contentful paint fires only when some of the text is visible, considering ::first-letter.]
-    expected: TIMEOUT


### PR DESCRIPTION
This change merges the first letter implementation into the
`InlineFormattingContextBuilder` as its more associated with inline
layout. The downside is that, due to ownership issues in Rust, the
builder must be unwrapped after ensuring it. Additionally, ensure
that `::first-letter` boxes are properly stored in a box slot meaning
that restyles work properly.

This change also makes a few small cleanups to the `first_letter_range`
function in addition to moving it to the inline code.

Testing: This does not change behavior and so should be covered by existing tests.
