### PR TITLE
script: implement missing steps for form submission

### DIFF
--- a/components/script/dom/html/htmlformelement.rs
+++ b/components/script/dom/html/htmlformelement.rs
@@ -1135,7 +1135,8 @@ impl HTMLFormElement {
                 history_handling,
                 false,
                 load_data,
-            );
+            )
+        });
 
         // 5. Set the form's planned navigation to the just-queued task.
         // Done above as part of incrementing the planned navigation counter.

--- a/components/script/dom/html/htmlformelement.rs
+++ b/components/script/dom/html/htmlformelement.rs
@@ -877,15 +877,18 @@ impl HTMLFormElement {
             // Step 23. If targetNavigable is null, then return.
             return;
         };
-        // Step 24. Let historyHandling be "auto".
-        // TODO
-        // Step 25. If form document equals targetNavigable's active document, and form document has not yet completely loaded,
-        // then set historyHandling to "replace".
-        // TODO
-
         let target_document = match chosen.document() {
             Some(doc) => doc,
             None => return,
+        };
+
+        // Step 24. Let historyHandling be "auto".
+        // Step 25. If form document equals targetNavigable's active document, and form document has not yet completely loaded,
+        // then set historyHandling to "replace".
+        let history_handling = if doc == target_document && !doc.completely_loaded() {
+            NavigationHistoryBehavior::Replace
+        } else {
+            NavigationHistoryBehavior::Auto
         };
         let target_window = target_document.window();
         let mut load_data = LoadData::new(
@@ -914,7 +917,13 @@ impl HTMLFormElement {
                 load_data
                     .headers
                     .typed_insert(ContentType::from(mime::APPLICATION_WWW_FORM_URLENCODED));
-                self.mutate_action_url(&mut form_data, load_data, encoding, target_window);
+                self.mutate_action_url(
+                    &mut form_data,
+                    load_data,
+                    encoding,
+                    target_window,
+                    history_handling,
+                );
             },
             // https://html.spec.whatwg.org/multipage/#submit-body
             ("http", FormMethod::Post) | ("https", FormMethod::Post) => {
@@ -925,6 +934,7 @@ impl HTMLFormElement {
                     enctype,
                     encoding,
                     target_window,
+                    history_handling,
                     can_gc,
                 );
             },
@@ -934,7 +944,7 @@ impl HTMLFormElement {
             ("data", FormMethod::Post) |
             ("ftp", _) |
             ("javascript", _) => {
-                self.plan_to_navigate(load_data, target_window);
+                self.plan_to_navigate(load_data, target_window, history_handling);
             },
             ("mailto", FormMethod::Post) => {
                 // TODO: Mail as body
@@ -955,6 +965,7 @@ impl HTMLFormElement {
         mut load_data: LoadData,
         encoding: &'static Encoding,
         target: &Window,
+        history_handling: NavigationHistoryBehavior,
     ) {
         let charset = encoding.name();
 
@@ -965,7 +976,7 @@ impl HTMLFormElement {
                 .map(|field| (field.name.str(), field.replace_value(charset))),
         );
 
-        self.plan_to_navigate(load_data, target);
+        self.plan_to_navigate(load_data, target, history_handling);
     }
 
     /// <https://html.spec.whatwg.org/multipage/#submit-body>
@@ -976,6 +987,7 @@ impl HTMLFormElement {
         enctype: FormEncType,
         encoding: &'static Encoding,
         target: &Window,
+        history_handling: NavigationHistoryBehavior,
         can_gc: CanGc,
     ) {
         let boundary = generate_boundary();
@@ -1020,7 +1032,7 @@ impl HTMLFormElement {
             .0;
         load_data.data = Some(request_body);
 
-        self.plan_to_navigate(load_data, target);
+        self.plan_to_navigate(load_data, target, history_handling);
     }
 
     fn set_url_query_pairs<T>(
@@ -1039,7 +1051,12 @@ impl HTMLFormElement {
     }
 
     /// [Planned navigation](https://html.spec.whatwg.org/multipage/#planned-navigation)
-    fn plan_to_navigate(&self, mut load_data: LoadData, target: &Window) {
+    fn plan_to_navigate(
+        &self,
+        mut load_data: LoadData,
+        target: &Window,
+        history_handling: NavigationHistoryBehavior,
+    ) {
         // 1. Let referrerPolicy be the empty string.
         // 2. If the form element's link types include the noreferrer keyword,
         //    then set referrerPolicy to "no-referrer".
@@ -1113,11 +1130,10 @@ impl HTMLFormElement {
             navigate(
                 cx,
                 &window.root(),
-                NavigationHistoryBehavior::Push,
+                history_handling,
                 false,
                 load_data,
             );
-        });
 
         // 5. Set the form's planned navigation to the just-queued task.
         // Done above as part of incrementing the planned navigation counter.

--- a/components/script/dom/html/htmlformelement.rs
+++ b/components/script/dom/html/htmlformelement.rs
@@ -885,13 +885,12 @@ impl HTMLFormElement {
         // Step 24. Let historyHandling be "auto".
         // Step 25. If form document equals targetNavigable's active document, and form document has not yet completely loaded,
         // then set historyHandling to "replace".
-        let history_handling = if std::ptr::eq(&*doc as *const _, &*target_document as *const _) &&
-            !doc.completely_loaded()
-        {
+        let history_handling = if doc == target_document && !doc.completely_loaded() {
             NavigationHistoryBehavior::Replace
         } else {
             NavigationHistoryBehavior::Auto
         };
+
         let target_window = target_document.window();
         let mut load_data = LoadData::new(
             LoadOrigin::Script(doc.origin().snapshot()),

--- a/components/script/dom/html/htmlformelement.rs
+++ b/components/script/dom/html/htmlformelement.rs
@@ -980,6 +980,7 @@ impl HTMLFormElement {
     }
 
     /// <https://html.spec.whatwg.org/multipage/#submit-body>
+    #[allow(clippy::too_many_arguments)]
     fn submit_entity_body(
         &self,
         form_data: &mut [FormDatum],

--- a/components/script/dom/html/htmlformelement.rs
+++ b/components/script/dom/html/htmlformelement.rs
@@ -885,7 +885,9 @@ impl HTMLFormElement {
         // Step 24. Let historyHandling be "auto".
         // Step 25. If form document equals targetNavigable's active document, and form document has not yet completely loaded,
         // then set historyHandling to "replace".
-        let history_handling = if doc == target_document && !doc.completely_loaded() {
+        let history_handling = if std::ptr::eq(&*doc as *const _, &*target_document as *const _) &&
+            !doc.completely_loaded()
+        {
             NavigationHistoryBehavior::Replace
         } else {
             NavigationHistoryBehavior::Auto

--- a/tests/wpt/meta/html/browsers/browsing-the-web/navigating-across-documents/replace-before-load/a-click.html.ini
+++ b/tests/wpt/meta/html/browsers/browsing-the-web/navigating-across-documents/replace-before-load/a-click.html.ini
@@ -1,0 +1,3 @@
+[a-click.html]
+  [aElement.click() before the load event must NOT replace]
+    expected: FAIL

--- a/tests/wpt/meta/html/browsers/browsing-the-web/navigating-across-documents/replace-before-load/form-requestsubmit-during-load.html.ini
+++ b/tests/wpt/meta/html/browsers/browsing-the-web/navigating-across-documents/replace-before-load/form-requestsubmit-during-load.html.ini
@@ -1,3 +1,3 @@
 [form-requestsubmit-during-load.html]
   [Replace during the load event, triggered by formElement.submit()]
-    expected: FAIL
+    expected: TIMEOUT

--- a/tests/wpt/meta/html/browsers/browsing-the-web/navigating-across-documents/replace-before-load/form-requestsubmit-during-load.html.ini
+++ b/tests/wpt/meta/html/browsers/browsing-the-web/navigating-across-documents/replace-before-load/form-requestsubmit-during-load.html.ini
@@ -1,3 +1,4 @@
 [form-requestsubmit-during-load.html]
+  expected: TIMEOUT
   [Replace during the load event, triggered by formElement.submit()]
     expected: TIMEOUT

--- a/tests/wpt/meta/html/browsers/browsing-the-web/navigating-across-documents/replace-before-load/form-requestsubmit-during-pageshow.html.ini
+++ b/tests/wpt/meta/html/browsers/browsing-the-web/navigating-across-documents/replace-before-load/form-requestsubmit-during-pageshow.html.ini
@@ -1,3 +1,3 @@
 [form-requestsubmit-during-pageshow.html]
   [Replace during the pageshow event, triggered by formElement.submit()]
-    expected: FAIL
+    expected: TIMEOUT

--- a/tests/wpt/meta/html/browsers/browsing-the-web/navigating-across-documents/replace-before-load/form-requestsubmit-during-pageshow.html.ini
+++ b/tests/wpt/meta/html/browsers/browsing-the-web/navigating-across-documents/replace-before-load/form-requestsubmit-during-pageshow.html.ini
@@ -1,3 +1,4 @@
 [form-requestsubmit-during-pageshow.html]
+  expected: TIMEOUT
   [Replace during the pageshow event, triggered by formElement.submit()]
     expected: TIMEOUT

--- a/tests/wpt/meta/html/browsers/browsing-the-web/navigating-across-documents/replace-before-load/form-requestsubmit.html.ini
+++ b/tests/wpt/meta/html/browsers/browsing-the-web/navigating-across-documents/replace-before-load/form-requestsubmit.html.ini
@@ -1,3 +1,4 @@
 [form-requestsubmit.html]
+  expected: TIMEOUT
   [Replace before load, triggered by formElement.requestSubmit()]
-    expected: FAIL
+    expected: TIMEOUT

--- a/tests/wpt/meta/html/browsers/browsing-the-web/navigating-across-documents/replace-before-load/form-submit-button-click-during-load.html.ini
+++ b/tests/wpt/meta/html/browsers/browsing-the-web/navigating-across-documents/replace-before-load/form-submit-button-click-during-load.html.ini
@@ -1,3 +1,3 @@
 [form-submit-button-click-during-load.html]
   [Replace during load, triggered by submitButton.click()]
-    expected: [FAIL, TIMEOUT]
+    expected: TIMEOUT

--- a/tests/wpt/meta/html/browsers/browsing-the-web/navigating-across-documents/replace-before-load/form-submit-button-click-during-load.html.ini
+++ b/tests/wpt/meta/html/browsers/browsing-the-web/navigating-across-documents/replace-before-load/form-submit-button-click-during-load.html.ini
@@ -1,3 +1,3 @@
 [form-submit-button-click-during-load.html]
   [Replace during load, triggered by submitButton.click()]
-    expected: FAIL
+    expected: [FAIL, TIMEOUT]

--- a/tests/wpt/meta/html/browsers/browsing-the-web/navigating-across-documents/replace-before-load/form-submit-button-click-during-load.html.ini
+++ b/tests/wpt/meta/html/browsers/browsing-the-web/navigating-across-documents/replace-before-load/form-submit-button-click-during-load.html.ini
@@ -1,3 +1,4 @@
 [form-submit-button-click-during-load.html]
+  expected: TIMEOUT
   [Replace during load, triggered by submitButton.click()]
     expected: TIMEOUT

--- a/tests/wpt/meta/html/browsers/browsing-the-web/navigating-across-documents/replace-before-load/form-submit-button-click-during-pageshow.html.ini
+++ b/tests/wpt/meta/html/browsers/browsing-the-web/navigating-across-documents/replace-before-load/form-submit-button-click-during-pageshow.html.ini
@@ -1,3 +1,3 @@
 [form-submit-button-click-during-pageshow.html]
   [Replace during pageshow, triggered by submitButton.click()]
-    expected: FAIL
+    expected: TIMEOUT

--- a/tests/wpt/meta/html/browsers/browsing-the-web/navigating-across-documents/replace-before-load/form-submit-button-click-during-pageshow.html.ini
+++ b/tests/wpt/meta/html/browsers/browsing-the-web/navigating-across-documents/replace-before-load/form-submit-button-click-during-pageshow.html.ini
@@ -1,3 +1,4 @@
 [form-submit-button-click-during-pageshow.html]
+  expected: TIMEOUT
   [Replace during pageshow, triggered by submitButton.click()]
     expected: TIMEOUT

--- a/tests/wpt/meta/html/browsers/browsing-the-web/navigating-across-documents/replace-before-load/form-submit-button-click.html.ini
+++ b/tests/wpt/meta/html/browsers/browsing-the-web/navigating-across-documents/replace-before-load/form-submit-button-click.html.ini
@@ -1,3 +1,4 @@
 [form-submit-button-click.html]
+  expected: TIMEOUT
   [Replace before load, triggered by submitButton.click()]
-    expected: FAIL
+    expected: TIMEOUT

--- a/tests/wpt/meta/html/browsers/browsing-the-web/navigating-across-documents/replace-before-load/form-submit-during-load.html.ini
+++ b/tests/wpt/meta/html/browsers/browsing-the-web/navigating-across-documents/replace-before-load/form-submit-during-load.html.ini
@@ -1,3 +1,3 @@
 [form-submit-during-load.html]
   [Replace during the load event, triggered by formElement.submit()]
-    expected: [FAIL, TIMEOUT]
+    expected: TIMEOUT

--- a/tests/wpt/meta/html/browsers/browsing-the-web/navigating-across-documents/replace-before-load/form-submit-during-load.html.ini
+++ b/tests/wpt/meta/html/browsers/browsing-the-web/navigating-across-documents/replace-before-load/form-submit-during-load.html.ini
@@ -1,3 +1,3 @@
 [form-submit-during-load.html]
   [Replace during the load event, triggered by formElement.submit()]
-    expected: FAIL
+    expected: [FAIL, TIMEOUT]

--- a/tests/wpt/meta/html/browsers/browsing-the-web/navigating-across-documents/replace-before-load/form-submit-during-load.html.ini
+++ b/tests/wpt/meta/html/browsers/browsing-the-web/navigating-across-documents/replace-before-load/form-submit-during-load.html.ini
@@ -1,3 +1,4 @@
 [form-submit-during-load.html]
+  expected: TIMEOUT
   [Replace during the load event, triggered by formElement.submit()]
     expected: TIMEOUT

--- a/tests/wpt/meta/html/browsers/browsing-the-web/navigating-across-documents/replace-before-load/form-submit-during-pageshow.html.ini
+++ b/tests/wpt/meta/html/browsers/browsing-the-web/navigating-across-documents/replace-before-load/form-submit-during-pageshow.html.ini
@@ -1,3 +1,4 @@
 [form-submit-during-pageshow.html]
+  expected: TIMEOUT
   [Replace during the pageshow event, triggered by formElement.submit()]
     expected: TIMEOUT

--- a/tests/wpt/meta/html/browsers/browsing-the-web/navigating-across-documents/replace-before-load/form-submit-during-pageshow.html.ini
+++ b/tests/wpt/meta/html/browsers/browsing-the-web/navigating-across-documents/replace-before-load/form-submit-during-pageshow.html.ini
@@ -1,3 +1,3 @@
 [form-submit-during-pageshow.html]
   [Replace during the pageshow event, triggered by formElement.submit()]
-    expected: FAIL
+    expected: TIMEOUT

--- a/tests/wpt/meta/html/browsers/browsing-the-web/navigating-across-documents/replace-before-load/form-submit.html.ini
+++ b/tests/wpt/meta/html/browsers/browsing-the-web/navigating-across-documents/replace-before-load/form-submit.html.ini
@@ -1,6 +1,6 @@
 [form-submit.html]
   [Replace before load, triggered by formElement.submit()]
-    expected: FAIL
+    expected: [FAIL, TIMEOUT]
 
   [Replace before load, triggered by same-document formElement.submit()]
-    expected: FAIL
+    expected: [FAIL, TIMEOUT]

--- a/tests/wpt/meta/html/browsers/browsing-the-web/navigating-across-documents/replace-before-load/form-submit.html.ini
+++ b/tests/wpt/meta/html/browsers/browsing-the-web/navigating-across-documents/replace-before-load/form-submit.html.ini
@@ -1,6 +1,6 @@
 [form-submit.html]
+  expected: TIMEOUT
   [Replace before load, triggered by formElement.submit()]
     expected: TIMEOUT
-
   [Replace before load, triggered by same-document formElement.submit()]
-    expected: TIMEOUT
+    expected: [FAIL, TIMEOUT]

--- a/tests/wpt/meta/html/browsers/browsing-the-web/navigating-across-documents/replace-before-load/form-submit.html.ini
+++ b/tests/wpt/meta/html/browsers/browsing-the-web/navigating-across-documents/replace-before-load/form-submit.html.ini
@@ -1,5 +1,4 @@
 [form-submit.html]
-  expected: TIMEOUT
   [Replace before load, triggered by formElement.submit()]
     expected: TIMEOUT
   [Replace before load, triggered by same-document formElement.submit()]

--- a/tests/wpt/meta/html/browsers/browsing-the-web/navigating-across-documents/replace-before-load/form-submit.html.ini
+++ b/tests/wpt/meta/html/browsers/browsing-the-web/navigating-across-documents/replace-before-load/form-submit.html.ini
@@ -1,6 +1,6 @@
 [form-submit.html]
   [Replace before load, triggered by formElement.submit()]
-    expected: [FAIL, TIMEOUT]
+    expected: TIMEOUT
 
   [Replace before load, triggered by same-document formElement.submit()]
-    expected: [FAIL, TIMEOUT]
+    expected: TIMEOUT

--- a/tests/wpt/meta/html/browsers/history/the-session-history-of-browsing-contexts/navigation-in-onload.html.ini
+++ b/tests/wpt/meta/html/browsers/history/the-session-history-of-browsing-contexts/navigation-in-onload.html.ini
@@ -1,3 +1,3 @@
 [navigation-in-onload.html]
   [Navigation in onload handler]
-    expected: FAIL
+    expected: PASS

--- a/tests/wpt/meta/html/browsers/history/the-session-history-of-browsing-contexts/navigation-in-onload.html.ini
+++ b/tests/wpt/meta/html/browsers/history/the-session-history-of-browsing-contexts/navigation-in-onload.html.ini
@@ -1,3 +1,0 @@
-[navigation-in-onload.html]
-  [Navigation in onload handler]
-    expected: PASS

--- a/tests/wpt/meta/html/semantics/forms/form-submission-0/jsurl-form-submit.tentative.html.ini
+++ b/tests/wpt/meta/html/semantics/forms/form-submission-0/jsurl-form-submit.tentative.html.ini
@@ -1,0 +1,3 @@
+[jsurl-form-submit.tentative.html]
+  [Verifies that form submissions scheduled inside javascript: urls take precedence over the javascript: url's return value.]
+    expected: FAIL

--- a/tests/wpt/meta/html/semantics/forms/form-submission-0/jsurl-form-submit.tentative.html.ini
+++ b/tests/wpt/meta/html/semantics/forms/form-submission-0/jsurl-form-submit.tentative.html.ini
@@ -1,3 +1,0 @@
-[jsurl-form-submit.tentative.html]
-  [Verifies that form submissions scheduled inside javascript: urls take precedence over the javascript: url's return value.]
-    expected: FAIL

--- a/tests/wpt/meta/html/semantics/forms/form-submission-0/jsurl-form-submit.tentative.html.ini
+++ b/tests/wpt/meta/html/semantics/forms/form-submission-0/jsurl-form-submit.tentative.html.ini
@@ -1,1 +1,0 @@
-[jsurl-form-submit.tentative.html]

--- a/tests/wpt/meta/html/semantics/forms/form-submission-0/jsurl-form-submit.tentative.html.ini
+++ b/tests/wpt/meta/html/semantics/forms/form-submission-0/jsurl-form-submit.tentative.html.ini
@@ -1,3 +1,1 @@
 [jsurl-form-submit.tentative.html]
-  [Verifies that form submissions scheduled inside javascript: urls take precedence over the javascript: url's return value.]
-    expected: FAIL


### PR DESCRIPTION
Implement missing history handling steps for form submission 
Test: ./mach test-wpt tests/wpt/tests/html/semantics/forms/form-submission-0
Fixes: #43670

