### PR TITLE
parser: add a pretty printer for top-level json documents

### DIFF
--- a/components/default-resources/lib.rs
+++ b/components/default-resources/lib.rs
@@ -30,6 +30,7 @@ impl ResourceReaderMethods for DefaultResourceReader {
             },
             Resource::AboutMemoryHTML => &include_bytes!("resources/about-memory.html")[..],
             Resource::DebuggerJS => &include_bytes!("resources/debugger.js")[..],
+            Resource::JsonViewerHTML => &include_bytes!("resources/json-viewer.html")[..],
         }
         .to_owned()
     }

--- a/components/default-resources/resources/json-viewer.html
+++ b/components/default-resources/resources/json-viewer.html
@@ -1,0 +1,277 @@
+<html>
+  <head>
+    <style>
+      body {
+        font-family: monospace;
+        margin: 0;
+        padding: 0;
+        background: #fff;
+        color: #333;
+      }
+
+      #json-raw {
+        display: none;
+      }
+
+      #viewer {
+        padding: 0.5em 1em;
+        line-height: 1.5;
+      }
+
+      #toolbar {
+        display: flex;
+        gap: 1em;
+        padding: 0.5em;
+        align-items: center;
+        background: #f5f5f5;
+        border-bottom: 1px solid #ddd;
+      }
+
+      #toolbar button {
+        min-width: 5em;
+      }
+
+      #toolbar button.active {
+        background: #ddd;
+        font-weight: bold;
+      }
+
+      #raw-view {
+        display: none;
+        padding: 0.5em 1em;
+        white-space: pre-wrap;
+        word-break: break-all;
+      }
+
+      .json-error {
+        padding: 0.5em 1em;
+        color: #c00;
+        font-weight: bold;
+      }
+
+      /* Syntax highlighting for Json data types */
+      .json-key {
+        color: #881391;
+      }
+
+      .json-string {
+        color: #1a1aa6;
+      }
+
+      .json-number {
+        color: #1c00cf;
+      }
+
+      .json-boolean {
+        color: #0d22aa;
+      }
+
+      .json-null {
+        color: #808080;
+      }
+
+      /* Collapsible tree */
+      .toggle {
+        cursor: pointer;
+        user-select: none;
+      }
+
+      .toggle::before {
+        content: "\25BC";
+        display: inline-block;
+        width: 1em;
+        transition: transform 0.1s;
+      }
+
+      .toggle.collapsed::before {
+        transform: rotate(-90deg);
+      }
+
+      .collapsible {
+        margin-left: 1.5em;
+      }
+
+      .collapsible.hidden {
+        display: none;
+      }
+
+      .bracket {
+        color: #333;
+      }
+
+      .comma {
+        color: #333;
+      }
+
+      .line {
+        padding-left: 0;
+      }
+    </style>
+    <script>
+      // Shortcut to create an element with an optional class and text content.
+      function createElement(name, classes = null, textContent = null) {
+        let node = document.createElement(name);
+        if (classes) {
+          node.className = classes;
+        }
+        if (textContent) {
+          node.textContent = textContent;
+        }
+        return node;
+      }
+
+      document.addEventListener("DOMContentLoaded", function () {
+        let rawEl = document.getElementById("json-raw");
+        if (!rawEl) {
+          return;
+        }
+        let rawText = rawEl.textContent;
+
+        let data;
+        let parseError = null;
+        try {
+          data = JSON.parse(rawText);
+        } catch (e) {
+          parseError = e;
+        }
+
+        // Build the page structure
+        document.body.innerHTML = "";
+
+        // Toolbar
+        let toolbar = createElement("div");
+        toolbar.id = "toolbar";
+        let prettyBtn = createElement("button", "active", "Pretty");
+        let rawBtn = createElement("button", null, "Raw");
+        toolbar.append(prettyBtn);
+        toolbar.append(rawBtn);
+        document.body.append(toolbar);
+
+        // Pretty view
+        let viewer = createElement("div");
+        viewer.id = "viewer";
+        document.body.append(viewer);
+
+        // Raw view
+        let rawView = createElement("pre");
+        rawView.id = "raw-view";
+        document.body.append(rawView);
+
+        if (parseError) {
+          let errDiv = createElement(
+            "div",
+            "json-error",
+            "Invalid JSON: " + parseError.message,
+          );
+          viewer.append(errDiv);
+          let pre = createElement("pre", null, rawText);
+          viewer.append(pre);
+          rawView.textContent = rawText;
+        } else {
+          renderNode(data, viewer);
+          rawView.textContent = JSON.stringify(data, null, 2);
+        }
+
+        // Toggle buttons
+        prettyBtn.onclick = function () {
+          viewer.style.display = "";
+          rawView.style.display = "none";
+          prettyBtn.className = "active";
+          rawBtn.className = "";
+        };
+        rawBtn.onclick = function () {
+          viewer.style.display = "none";
+          rawView.style.display = "block";
+          rawBtn.className = "active";
+          prettyBtn.className = "";
+        };
+
+        function renderNode(value, container) {
+          if (value === null) {
+            let s = createElement("span", "json-null", "null");
+            container.append(s);
+          } else if (typeof value === "boolean") {
+            let s = createElement("span", "json-boolean", String(value));
+            container.append(s);
+          } else if (typeof value === "number") {
+            let s = createElement("span", "json-number", String(value));
+            container.append(s);
+          } else if (typeof value === "string") {
+            let s = createElement("span", "json-string", JSON.stringify(value));
+            container.append(s);
+          } else if (Array.isArray(value)) {
+            renderArray(value, container);
+          } else if (typeof value === "object") {
+            renderObject(value, container);
+          }
+        }
+
+        function renderObject(obj, container) {
+          let keys = Object.keys(obj);
+          if (keys.length === 0) {
+            container.append(createElement("span", "bracket", "{}"));
+            return;
+          }
+
+          let toggle = createElement("span", "toggle");
+          container.append(toggle);
+
+          container.append(createElement("span", "bracket", "{"));
+
+          let inner = createElement("div", "collapsible");
+          container.append(inner);
+
+          keys.forEach((key, i) => {
+            let line = createElement("div", "line");
+            line.append(createElement("span", "json-key", JSON.stringify(key)));
+            line.append(document.createTextNode(": "));
+            renderNode(obj[key], line);
+            if (i < keys.length - 1) {
+              line.append(createElement("span", "comma", ","));
+            }
+            inner.append(line);
+          });
+
+          container.append(createElement("span", "bracket", "}"));
+
+          toggle.onclick = function () {
+            toggle.classList.toggle("collapsed");
+            inner.classList.toggle("hidden");
+          };
+        }
+
+        function renderArray(arr, container) {
+          if (arr.length === 0) {
+            container.append(createElement("span", "bracket", "[]"));
+            return;
+          }
+
+          let toggle = createElement("span", "toggle");
+          container.append(toggle);
+
+          container.append(createElement("span", "bracket", "["));
+
+          let inner = createElement("div", "collapsible");
+          container.append(inner);
+
+          arr.forEach((item, i) => {
+            let line = createElement("div", "line");
+            renderNode(item, line);
+            if (i < arr.length - 1) {
+              line.append(createElement("span", "comma", ","));
+            }
+            inner.append(line);
+          });
+
+          container.append(createElement("span", "bracket", "]"));
+
+          toggle.onclick = function () {
+            toggle.classList.toggle("collapsed");
+            inner.classList.toggle("hidden");
+          };
+        }
+      });
+    </script>
+  </head>
+  <body>
+    <pre id="json-raw">

--- a/components/default-resources/resources/json-viewer.html
+++ b/components/default-resources/resources/json-viewer.html
@@ -14,8 +14,13 @@
       }
 
       #viewer {
+        display: none;
         padding: 0.5em 1em;
         line-height: 1.5;
+
+        &.active {
+          display: block;
+        }
       }
 
       #toolbar {
@@ -25,15 +30,15 @@
         align-items: center;
         background: #f5f5f5;
         border-bottom: 1px solid #ddd;
-      }
 
-      #toolbar button {
-        min-width: 5em;
-      }
+        & button {
+          min-width: 5em;
 
-      #toolbar button.active {
-        background: #ddd;
-        font-weight: bold;
+          &.active {
+            background: #ddd;
+            font-weight: bold;
+          }
+        }
       }
 
       #raw-view {
@@ -41,6 +46,10 @@
         padding: 0.5em 1em;
         white-space: pre-wrap;
         word-break: break-all;
+
+        &.active {
+          display: block;
+        }
       }
 
       .json-error {
@@ -74,25 +83,25 @@
       .toggle {
         cursor: pointer;
         user-select: none;
-      }
 
-      .toggle::before {
-        content: "\25BC";
-        display: inline-block;
-        width: 1em;
-        transition: transform 0.1s;
-      }
+        &::before {
+          content: "\25BC";
+          display: inline-block;
+          width: 1em;
+          transition: transform 0.1s;
+        }
 
-      .toggle.collapsed::before {
-        transform: rotate(-90deg);
+        &.collapsed::before {
+          transform: rotate(-90deg);
+        }
       }
 
       .collapsible {
         margin-left: 1.5em;
-      }
 
-      .collapsible.hidden {
-        display: none;
+        &.hidden {
+          display: none;
+        }
       }
 
       .bracket {
@@ -120,12 +129,97 @@
         return node;
       }
 
-      document.addEventListener("DOMContentLoaded", function () {
-        let rawEl = document.getElementById("json-raw");
-        if (!rawEl) {
+      function renderNode(value, container) {
+        if (value === null) {
+          let s = createElement("span", "json-null", "null");
+          container.append(s);
+        } else if (typeof value === "boolean") {
+          let s = createElement("span", "json-boolean", String(value));
+          container.append(s);
+        } else if (typeof value === "number") {
+          let s = createElement("span", "json-number", String(value));
+          container.append(s);
+        } else if (typeof value === "string") {
+          let s = createElement("span", "json-string", JSON.stringify(value));
+          container.append(s);
+        } else if (Array.isArray(value)) {
+          renderArray(value, container);
+        } else if (typeof value === "object") {
+          renderObject(value, container);
+        }
+      }
+
+      function renderObject(obj, container) {
+        let keys = Object.keys(obj);
+        if (keys.length === 0) {
+          container.append(createElement("span", "bracket", "{}"));
           return;
         }
-        let rawText = rawEl.textContent;
+
+        let toggle = createElement("span", "toggle");
+        container.append(toggle);
+
+        container.append(createElement("span", "bracket", "{"));
+
+        let inner = createElement("div", "collapsible");
+        container.append(inner);
+
+        keys.forEach((key, i) => {
+          let line = createElement("div", "line");
+          line.append(createElement("span", "json-key", JSON.stringify(key)));
+          line.append(document.createTextNode(": "));
+          renderNode(obj[key], line);
+          if (i < keys.length - 1) {
+            line.append(createElement("span", "comma", ","));
+          }
+          inner.append(line);
+        });
+
+        container.append(createElement("span", "bracket", "}"));
+
+        toggle.onclick = function () {
+          toggle.classList.toggle("collapsed");
+          inner.classList.toggle("hidden");
+        };
+      }
+
+      function renderArray(arr, container) {
+        if (arr.length === 0) {
+          container.append(createElement("span", "bracket", "[]"));
+          return;
+        }
+
+        let toggle = createElement("span", "toggle");
+        container.append(toggle);
+
+        container.append(createElement("span", "bracket", "["));
+
+        let inner = createElement("div", "collapsible");
+        container.append(inner);
+
+        arr.forEach((item, i) => {
+          let line = createElement("div", "line");
+          renderNode(item, line);
+          if (i < arr.length - 1) {
+            line.append(createElement("span", "comma", ","));
+          }
+          inner.append(line);
+        });
+
+        container.append(createElement("span", "bracket", "]"));
+
+        toggle.onclick = function () {
+          toggle.classList.toggle("collapsed");
+          inner.classList.toggle("hidden");
+        };
+      }
+
+      document.addEventListener("DOMContentLoaded", function () {
+        const viewer = document.getElementById("viewer");
+        const prettyButton = document.getElementById("pretty-toggle");
+        const rawButton = document.getElementById("raw-toggle");
+        const rawView = document.getElementById("raw-view");
+        const rawText = rawView.innerText;
 
         let data;
         let parseError = null;
@@ -135,28 +229,6 @@
           parseError = e;
         }
 
-        // Build the page structure
-        document.body.innerHTML = "";
-
-        // Toolbar
-        let toolbar = createElement("div");
-        toolbar.id = "toolbar";
-        let prettyBtn = createElement("button", "active", "Pretty");
-        let rawBtn = createElement("button", null, "Raw");
-        toolbar.append(prettyBtn);
-        toolbar.append(rawBtn);
-        document.body.append(toolbar);
-
-        // Pretty view
-        let viewer = createElement("div");
-        viewer.id = "viewer";
-        document.body.append(viewer);
-
-        // Raw view
-        let rawView = createElement("pre");
-        rawView.id = "raw-view";
-        document.body.append(rawView);
-
         if (parseError) {
           let errDiv = createElement(
             "div",
@@ -164,114 +236,34 @@
             "Invalid JSON: " + parseError.message,
           );
           viewer.append(errDiv);
-          let pre = createElement("pre", null, rawText);
-          viewer.append(pre);
-          rawView.textContent = rawText;
+          viewer.append(createElement("pre", null, rawText));
         } else {
           renderNode(data, viewer);
           rawView.textContent = JSON.stringify(data, null, 2);
         }
 
         // Toggle buttons
-        prettyBtn.onclick = function () {
-          viewer.style.display = "";
-          rawView.style.display = "none";
-          prettyBtn.className = "active";
-          rawBtn.className = "";
+        prettyButton.onclick = function () {
+          viewer.classList.add("active");
+          rawView.classList.remove("active");
+
+          prettyButton.classList.add("active");
+          rawButton.classList.remove("active");
         };
-        rawBtn.onclick = function () {
-          viewer.style.display = "none";
-          rawView.style.display = "block";
-          rawBtn.className = "active";
-          prettyBtn.className = "";
+        rawButton.onclick = function () {
+          rawView.classList.add("active");
+          viewer.classList.remove("active");
+
+          rawButton.classList.add("active");
+          prettyButton.classList.remove("active");
         };
-
-        function renderNode(value, container) {
-          if (value === null) {
-            let s = createElement("span", "json-null", "null");
-            container.append(s);
-          } else if (typeof value === "boolean") {
-            let s = createElement("span", "json-boolean", String(value));
-            container.append(s);
-          } else if (typeof value === "number") {
-            let s = createElement("span", "json-number", String(value));
-            container.append(s);
-          } else if (typeof value === "string") {
-            let s = createElement("span", "json-string", JSON.stringify(value));
-            container.append(s);
-          } else if (Array.isArray(value)) {
-            renderArray(value, container);
-          } else if (typeof value === "object") {
-            renderObject(value, container);
-          }
-        }
-
-        function renderObject(obj, container) {
-          let keys = Object.keys(obj);
-          if (keys.length === 0) {
-            container.append(createElement("span", "bracket", "{}"));
-            return;
-          }
-
-          let toggle = createElement("span", "toggle");
-          container.append(toggle);
-
-          container.append(createElement("span", "bracket", "{"));
-
-          let inner = createElement("div", "collapsible");
-          container.append(inner);
-
-          keys.forEach((key, i) => {
-            let line = createElement("div", "line");
-            line.append(createElement("span", "json-key", JSON.stringify(key)));
-            line.append(document.createTextNode(": "));
-            renderNode(obj[key], line);
-            if (i < keys.length - 1) {
-              line.append(createElement("span", "comma", ","));
-            }
-            inner.append(line);
-          });
-
-          container.append(createElement("span", "bracket", "}"));
-
-          toggle.onclick = function () {
-            toggle.classList.toggle("collapsed");
-            inner.classList.toggle("hidden");
-          };
-        }
-
-        function renderArray(arr, container) {
-          if (arr.length === 0) {
-            container.append(createElement("span", "bracket", "[]"));
-            return;
-          }
-
-          let toggle = createElement("span", "toggle");
-          container.append(toggle);
-
-          container.append(createElement("span", "bracket", "["));
-
-          let inner = createElement("div", "collapsible");
-          container.append(inner);
-
-          arr.forEach((item, i) => {
-            let line = createElement("div", "line");
-            renderNode(item, line);
-            if (i < arr.length - 1) {
-              line.append(createElement("span", "comma", ","));
-            }
-            inner.append(line);
-          });
-
-          container.append(createElement("span", "bracket", "]"));
-
-          toggle.onclick = function () {
-            toggle.classList.toggle("collapsed");
-            inner.classList.toggle("hidden");
-          };
-        }
       });
     </script>
   </head>
   <body>
-    <pre id="json-raw">
+    <div id="toolbar">
+      <button id="pretty-toggle" class="active">Pretty</button>
+      <button id="raw-toggle">Raw</button>
+    </div>
+    <div id="viewer" class="active"></div>
+    <pre id="raw-view">

--- a/components/script/dom/servoparser/mod.rs
+++ b/components/script/dom/servoparser/mod.rs
@@ -1064,9 +1064,11 @@ impl ParserContext {
             // Return the result of loading an XML document given navigationParams and type.
             MediaType::Xml => self.load_xml_document(parser),
             // Return the result of loading a text document given navigationParams and type.
-            MediaType::JavaScript | MediaType::Json | MediaType::Text | MediaType::Css => {
+            MediaType::JavaScript | MediaType::Text | MediaType::Css => {
                 self.load_text_document(parser, cx)
             },
+            // Return the result of loading a json document given navigationParams and type.
+            MediaType::Json => self.load_json_document(parser, cx),
             // Return the result of loading a media document given navigationParams and type.
             MediaType::Image | MediaType::AudioVideo => {
                 self.load_media_document(parser, media_type, &mime_type, cx);
@@ -1204,6 +1206,15 @@ impl ParserContext {
         // Step 7. Process link headers given document, navigationParams's response, and "media".
         let link_headers = std::mem::take(&mut self.navigation_params.link_headers);
         process_link_headers(&link_headers, doc, LinkProcessingPhase::Media);
+    }
+
+    /// Load a JSON document with a pretty-printing, interactive viewer.
+    fn load_json_document(&mut self, parser: &ServoParser, cx: &mut js::context::JSContext) {
+        self.initialize_document_object(&parser.document);
+        parser.push_string_input_chunk(resources::read_string(Resource::JsonViewerHTML));
+        parser.parse_sync(cx);
+        parser.tokenizer.set_plaintext_state();
+        self.process_link_headers_in_media_phase_with_task(&parser.document);
     }
 
     /// <https://html.spec.whatwg.org/multipage/#navigate-ua-inline>

--- a/components/shared/embedder/resources.rs
+++ b/components/shared/embedder/resources.rs
@@ -138,6 +138,8 @@ pub enum Resource {
     AboutMemoryHTML,
     /// RPC script for the Debugger API on behalf of devtools.
     DebuggerJS,
+    /// A HTML page to display a pretty printed view of a json document.
+    JsonViewerHTML,
 }
 
 impl Resource {
@@ -153,6 +155,7 @@ impl Resource {
             Resource::DirectoryListingHTML => "directory-listing.html",
             Resource::AboutMemoryHTML => "about-memory.html",
             Resource::DebuggerJS => "debugger.js",
+            Resource::JsonViewerHTML => "json-viewer.html",
         }
     }
 }


### PR DESCRIPTION
This adds a new resource implementing a simple pretty printer  for json documents.

Testing: build this branch and launch with `./mach run https://httpbin.org/json`

<img width="1044" height="1064" alt="image" src="https://github.com/user-attachments/assets/42680c4b-2971-482a-af2b-9017f0f81752" />
