### PR TITLE
net: Fix header parsing for empty strings

### DIFF
--- a/components/shared/net/fetch/headers.rs
+++ b/components/shared/net/fetch/headers.rs
@@ -47,54 +47,57 @@ pub fn get_decode_and_split_header_value(value: Vec<u8>) -> Vec<String> {
         c != '\u{0022}' && c != '\u{002C}'
     }
 
-    // Step 1: Let input be the result of isomorphic decoding value.
+    // Step 1. Let input be the result of isomorphic decoding value.
     let input = value.into_iter().map(char::from).collect::<String>();
 
-    // Step 2: Let position be a position variable for input, initially pointing at the start of
-    // input.
+    // Step 2. Let position be a position variable for input,
+    // initially pointing at the start of input.
     let mut position = input.chars().peekable();
 
-    // Step 3: Let values be a list of strings, initially « ».
+    // Step 3. Let values be a list of strings, initially « ».
     let mut values: Vec<String> = vec![];
 
-    // Step 4: Let temporaryValue be the empty string.
+    // Step 4. Let temporaryValue be the empty string.
     let mut temporary_value = String::new();
 
-    // Step 5: While true:
-    while position.peek().is_some() {
-        // Step 5.1: Append the result of collecting a sequence of code points that are not U+0022
-        // (") or U+002C (,) from input, given position, to temporaryValue.
+    // Step 5. While true:
+    loop {
+        // Step 5.1. Append the result of collecting a sequence of code points that
+        // are not U+0022 (") or U+002C (,) from input, given position, to temporaryValue.
         temporary_value += &*collect_sequence(&mut position, char_is_not_quote_or_comma);
 
-        // Step 5.2: If position is not past the end of input and the code point at position within
-        // input is U+0022 ("):
+        // Step 5.2. If position is not past the end of input and the code point
+        // at position within input is U+0022 ("):
         if let Some(&ch) = position.peek() {
             if ch == '\u{0022}' {
-                // Step 5.2.1: Append the result of collecting an HTTP quoted string from input,
+                // Step 5.2.1. Append the result of collecting an HTTP quoted string from input,
                 // given position, to temporaryValue.
                 temporary_value += &*collect_http_quoted_string(&mut position, false);
 
-                // Step 5.2.2: If position is not past the end of input, then continue.
+                // Step 5.2.2. If position is not past the end of input, then continue.
                 if position.peek().is_some() {
                     continue;
                 }
-            } else {
-                // Step 5.2.2: If position is not past the end of input, then continue.
-                position.next();
             }
         }
 
-        // Step 5.3: Remove all HTTP tab or space from the start and end of temporaryValue.
+        // Step 5.3. Remove all HTTP tab or space from the start and end of temporaryValue.
         temporary_value = temporary_value.trim_matches(HTTP_TAB_OR_SPACE).to_string();
 
-        // Step 5.4: Append temporaryValue to values.
+        // Step 5.4. Append temporaryValue to values.
         values.push(temporary_value);
 
-        // Step 5.5: Set temporaryValue to the empty string.
+        // Step 5.5. Set temporaryValue to the empty string.
         temporary_value = String::new();
-    }
 
-    values
+        // Step 5.8. Advance position by 1.
+        let Some(ch) = position.next() else {
+            // Step 5.6. If position is past the end of input, then return values.
+            return values;
+        };
+        // Step 5.7. Assert: the code point at position within input is U+002C (,).
+        assert_eq!(ch, '\u{002C}');
+    }
 }
 
 /// <https://infra.spec.whatwg.org/#collect-a-sequence-of-code-points>
@@ -130,12 +133,16 @@ fn collect_http_quoted_string(position: &mut Peekable<Chars>, extract_value: boo
     }
 
     // Step 2: let value be the empty string
+    //
     // We will store the 'extracted value' or the raw value
     let mut value = String::new();
 
-    // Step 3, 4
+    // Step 4. Advance position by 1.
     let should_be_quote = position.next();
     if let Some(ch) = should_be_quote {
+        // Step 3. Assert: the code point at position within input is U+0022 (").
+        assert_eq!(ch, '\u{0022}');
+
         if !extract_value {
             value.push(ch)
         }
@@ -147,42 +154,43 @@ fn collect_http_quoted_string(position: &mut Peekable<Chars>, extract_value: boo
         // (") or U+005C (\) from input, given position, to value.
         value += &*collect_sequence(position, char_is_not_quote_or_backslash);
 
-        // Step 5.2: If position is past the end of input, then break.
-        if position.peek().is_none() {
-            break;
-        }
-
         // Step 5.3: Let quoteOrBackslash be the code point at position within input.
         // Step 5.4: Advance position by 1.
-        let quote_or_backslash = position.next().unwrap();
+        let Some(quote_or_backslash) = position.next() else {
+            // Step 5.2: If position is past the end of input, then break.
+            break;
+        };
 
         if !extract_value {
             value.push(quote_or_backslash);
         }
 
-        // Step 5.5: If quoteOrBackslash is U+005C (\), then:
+        // Step 5.5. If quoteOrBackslash is U+005C (\), then:
         if quote_or_backslash == '\u{005C}' {
+            // Step 5.5.3. Advance position by 1.
             if let Some(ch) = position.next() {
-                // Step 5.5.2: Append the code point at position within input to value.
+                // Step 5.5.2. Append the code point at position within input to value.
                 value.push(ch);
             } else {
-                // Step 5.5.1: If position is past the end of input, then append U+005C (\) to value and break.
+                // Step 5.5.1. If position is past the end of input, then append U+005C (\) to value and break.
                 if extract_value {
                     value.push('\u{005C}');
                 }
 
                 break;
             }
+        // Step 5.6. Otherwise:
         } else {
-            // Step 5.6.1: Assert quote_or_backslash is a quote
+            // Step 5.6.1. Assert: quoteOrBackslash is U+0022 (").
             assert_eq!(quote_or_backslash, '\u{0022}');
 
-            // Step 5.6.2: break
+            // Step 5.6.2. Break.
             break;
         }
     }
 
-    // Step 6, 7
+    // Step 6. If extract-value is true, then return value.
+    // Step 7. Return the code points from positionStart to position, inclusive, within input.
     value
 }
 

--- a/tests/wpt/meta/x-frame-options/multiple.html.ini
+++ b/tests/wpt/meta/x-frame-options/multiple.html.ini
@@ -1,9 +1,0 @@
-[multiple.html]
-  [`SAMEORIGIN,(the empty string)` blocks same-origin framing]
-    expected: FAIL
-
-  [`ALLOWALL,(the empty string)` blocks same-origin framing]
-    expected: FAIL
-
-  [`ALLOWALL,(the empty string)` blocks cross-origin framing]
-    expected: FAIL


### PR DESCRIPTION
If there are multiple header values and one of them is empty, we should append the empty string rather than skipping it. The algorithm was incorrectly advancing the operation and continuing the loop, rather than appending and later returning the `values`.