### PR TITLE
script: move element interfaces into `element/`

### DIFF
--- a/components/script/dom/element/attributes.rs
+++ b/components/script/dom/element/attributes.rs
@@ -1,0 +1,20 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+use html5ever::LocalName;
+use style::attr::AttrValue;
+
+use crate::dom::element::Element;
+
+impl Element {
+    pub(crate) fn get_int_attribute(&self, local_name: &LocalName, default: i32) -> i32 {
+        match self.get_attribute(local_name) {
+            Some(ref attribute) => match *attribute.value() {
+                AttrValue::Int(_, value) => value,
+                _ => unreachable!("Expected an AttrValue::Int: implement parse_plain_attribute"),
+            },
+            None => default,
+        }
+    }
+}

--- a/components/script/dom/element/element.rs
+++ b/components/script/dom/element/element.rs
@@ -1080,12 +1080,6 @@ pub(crate) trait LayoutElementHelpers<'dom> {
     fn each_custom_state_for_layout(self, allback: impl FnMut(&AtomIdent));
 }
 
-impl LayoutDom<'_, Element> {
-    pub(super) fn focus_state(self) -> bool {
-        self.unsafe_get().state.get().contains(ElementState::FOCUS)
-    }
-}
-
 impl<'dom> LayoutElementHelpers<'dom> for LayoutDom<'dom, Element> {
     #[expect(unsafe_code)]
     #[inline]
@@ -2542,16 +2536,6 @@ impl Element {
         can_gc: CanGc,
     ) {
         self.set_attribute(local_name, AttrValue::from_atomic_tokens(tokens), can_gc);
-    }
-
-    pub(crate) fn get_int_attribute(&self, local_name: &LocalName, default: i32) -> i32 {
-        match self.get_attribute(local_name) {
-            Some(ref attribute) => match *attribute.value() {
-                AttrValue::Int(_, value) => value,
-                _ => unreachable!("Expected an AttrValue::Int: implement parse_plain_attribute"),
-            },
-            None => default,
-        }
     }
 
     pub(crate) fn set_int_attribute(&self, local_name: &LocalName, value: i32, can_gc: CanGc) {
@@ -5416,24 +5400,6 @@ impl Element {
             .set_flag(NodeFlags::CLICK_IN_PROGRESS, click)
     }
 
-    // https://html.spec.whatwg.org/multipage/#nearest-activatable-element
-    pub(crate) fn nearest_activable_element(&self) -> Option<DomRoot<Element>> {
-        match self.as_maybe_activatable() {
-            Some(el) => Some(DomRoot::from_ref(el.as_element())),
-            None => {
-                let node = self.upcast::<Node>();
-                for node in node.ancestors() {
-                    if let Some(node) = node.downcast::<Element>() {
-                        if node.as_maybe_activatable().is_some() {
-                            return Some(DomRoot::from_ref(node));
-                        }
-                    }
-                }
-                None
-            },
-        }
-    }
-
     pub fn state(&self) -> ElementState {
         self.state.get()
     }
@@ -5486,10 +5452,6 @@ impl Element {
         self.set_state(ElementState::FOCUS, value);
     }
 
-    pub(crate) fn hover_state(&self) -> bool {
-        self.state.get().contains(ElementState::HOVER)
-    }
-
     pub(crate) fn set_hover_state(&self, value: bool) {
         self.set_state(ElementState::HOVER, value);
     }
@@ -5518,16 +5480,8 @@ impl Element {
         self.set_state(ElementState::READWRITE, value)
     }
 
-    pub(crate) fn open_state(&self) -> bool {
-        self.state.get().contains(ElementState::OPEN)
-    }
-
     pub(crate) fn set_open_state(&self, value: bool) {
         self.set_state(ElementState::OPEN, value);
-    }
-
-    pub(crate) fn placeholder_shown_state(&self) -> bool {
-        self.state.get().contains(ElementState::PLACEHOLDER_SHOWN)
     }
 
     pub(crate) fn set_placeholder_shown_state(&self, value: bool) {

--- a/components/script/dom/element/mod.rs
+++ b/components/script/dom/element/mod.rs
@@ -1,0 +1,8 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+pub(crate) use self::element::*;
+pub(crate) mod attributes;
+#[allow(clippy::module_inception, reason = "The interface name is element")]
+pub(crate) mod element;

--- a/components/script/dom/macros.rs
+++ b/components/script/dom/macros.rs
@@ -69,7 +69,7 @@ macro_rules! make_int_getter(
     ($attr:ident, $htmlname:tt, $default:expr) => (
         fn $attr(&self) -> i32 {
             use $crate::dom::bindings::inheritance::Castable;
-            use $crate::dom::element::Element;
+            use $crate::dom::element::element::Element;
             let element = self.upcast::<Element>();
             element.get_int_attribute(&html5ever::local_name!($htmlname), $default)
         }

--- a/components/script/dom/mod.rs
+++ b/components/script/dom/mod.rs
@@ -267,7 +267,6 @@ pub(crate) mod domrectreadonly;
 pub(crate) mod domstringlist;
 pub(crate) mod domstringmap;
 pub(crate) mod domtokenlist;
-#[expect(dead_code)]
 pub(crate) mod element;
 pub(crate) mod elementinternals;
 pub(crate) mod encoding;


### PR DESCRIPTION
It moves `Element.rs` into a subdirectory and turns on dead code detection (found 4 methods that could be removed). Then it also extracts the first attribute-related method into a separate file, to reduce the file size of `Element` and add more structure as part of #43709.

Part of #38901
Part of #43709

Testing: It compiles