### PR TITLE
wpt: Add more tests to `css-device-adapt` to verify clamp behavior.

### DIFF
--- a/tests/wpt/meta/__dir__.ini
+++ b/tests/wpt/meta/__dir__.ini
@@ -5,4 +5,5 @@ prefs: [
   "dom_serviceworker_enabled:true",
   "dom_testutils_enabled:true",
   "dom_visual_viewport_enabled:true",
+  "viewport_meta_enabled:true",
 ]

--- a/tests/wpt/meta/css/css-device-adapt/viewport-clamp-initial-scale-to-max.tentative.html.ini
+++ b/tests/wpt/meta/css/css-device-adapt/viewport-clamp-initial-scale-to-max.tentative.html.ini
@@ -1,0 +1,3 @@
+[viewport-clamp-initial-scale-to-max.tentative.html]
+  [Page with meta viewport "width=device-width, initial-scale=10.0, maximum-scale=2.0" should scale to 2.0.]
+    expected: FAIL

--- a/tests/wpt/meta/css/css-device-adapt/viewport-clamp-initial-scale-to-min.tentative.html.ini
+++ b/tests/wpt/meta/css/css-device-adapt/viewport-clamp-initial-scale-to-min.tentative.html.ini
@@ -1,0 +1,3 @@
+[viewport-clamp-initial-scale-to-min.tentative.html]
+  [Page with meta viewport "width=device-width, initial-scale=1.0, minimum-scale=2.0" should scale to 2.0.]
+    expected: FAIL

--- a/tests/wpt/tests/css/css-device-adapt/viewport-clamp-initial-scale-to-max.tentative.html
+++ b/tests/wpt/tests/css/css-device-adapt/viewport-clamp-initial-scale-to-max.tentative.html
@@ -1,0 +1,31 @@
+<!doctype html>
+<meta charset=utf-8>
+<meta name="viewport" content="width=device-width, initial-scale=10.0, maximum-scale=2.0">
+<link rel="help" href="https://drafts.csswg.org/css-device-adapt/">
+<link rel=help href="https://github.com/w3c/csswg-drafts/issues/9004">
+<link rel=help href="https://github.com/servo/servo/issues/40390">
+<link rel="author" title="Shubham Gupta" href="mailto:shubham.gupta@chromium.org">
+<style>
+body {
+  margin: 0;
+}
+#content {
+  width: 100px;
+  height: 100px;
+  background: green;
+}
+</style>
+
+<div id="content">Content</div>
+
+<script src=/resources/testharness.js></script>
+<script src=/resources/testharnessreport.js></script>
+<script>
+'use strict';
+test(() => {
+  assert_equals(window.visualViewport.scale, 2.0,
+    'visual viewport scale should be 2.0');
+}, 'Page with meta viewport "width=device-width, ' +
+   'initial-scale=10.0, maximum-scale=2.0" ' +
+   'should scale to 2.0.');
+</script>

--- a/tests/wpt/tests/css/css-device-adapt/viewport-clamp-initial-scale-to-min.tentative.html
+++ b/tests/wpt/tests/css/css-device-adapt/viewport-clamp-initial-scale-to-min.tentative.html
@@ -1,0 +1,31 @@
+<!doctype html>
+<meta charset=utf-8>
+<meta name="viewport" content="width=device-width, initial-scale=1.0, minimum-scale=2.0">
+<link rel="help" href="https://drafts.csswg.org/css-device-adapt/">
+<link rel=help href="https://github.com/w3c/csswg-drafts/issues/9004">
+<link rel=help href="https://github.com/servo/servo/issues/40390">
+<link rel="author" title="Shubham Gupta" href="mailto:shubham.gupta@chromium.org">
+<style>
+body {
+  margin: 0;
+}
+#content {
+  width: 100px;
+  height: 100px;
+  background: green;
+}
+</style>
+
+<div id="content">Content</div>
+
+<script src=/resources/testharness.js></script>
+<script src=/resources/testharnessreport.js></script>
+<script>
+'use strict';
+test(() => {
+  assert_equals(window.visualViewport.scale, 2.0,
+    'visual viewport scale should be 2.0');
+}, 'Page with meta viewport "width=device-width, ' +
+   'initial-scale=1.0, minimum-scale=2.0" ' +
+   'should scale to 2.0.');
+</script>


### PR DESCRIPTION
Add more tests with values other than non-default values. 
Earlier tests were curated around default value. So, we never know if anything is wrong.

Testing: Add more tests and update test expectations. Tests fail right now, which will be dealt with in next patches. It requires two PRs to properly fix.