### PR TITLE
canvas: Don't include text run without string or font when `build_unshaped_text_runs`

### DIFF
--- a/components/script/dom/canvas/2d/canvas_state.rs
+++ b/components/script/dom/canvas/2d/canvas_state.rs
@@ -2483,10 +2483,8 @@ impl UnshapedTextRun<'_> {
     }
 
     fn into_shaped_text_run(self, previous_advance: f32) -> Option<TextRun> {
+        debug_assert!(!self.string.is_empty() && self.font.is_some());
         let font = self.font?;
-        if self.string.is_empty() {
-            return None;
-        }
 
         let word_spacing = Au::from_f64_px(
             font.glyph_index(' ')

--- a/components/script/dom/canvas/2d/canvas_state.rs
+++ b/components/script/dom/canvas/2d/canvas_state.rs
@@ -2384,14 +2384,18 @@ impl CanvasState {
                     },
                 );
                 current_text_run_start_index = index;
-                runs.push(previous_text_run);
+                if !previous_text_run.string.is_empty() && previous_text_run.font.is_some() {
+                    runs.push(previous_text_run);
+                }
             }
 
             current_text_run.string =
                 &text[current_text_run_start_index..index + character.len_utf8()];
         }
 
-        runs.push(current_text_run);
+        if !current_text_run.string.is_empty() && current_text_run.font.is_some() {
+            runs.push(current_text_run);
+        }
         runs
     }
 

--- a/tests/wpt/mozilla/meta/MANIFEST.json
+++ b/tests/wpt/mozilla/meta/MANIFEST.json
@@ -24,6 +24,13 @@
      ]
     ],
     "canvas": {
+     "canvas-edge-cases-crash.html": [
+      "9259aff8d30a319da2632bacb5a912050e9e510e",
+      [
+       null,
+       {}
+      ]
+     ],
      "toblob-then-change-size-crash.html": [
       "355474b4832dde985a73baad925702bbb0cbc73f",
       [

--- a/tests/wpt/mozilla/tests/mozilla/canvas/canvas-edge-cases-crash.html
+++ b/tests/wpt/mozilla/tests/mozilla/canvas/canvas-edge-cases-crash.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<html class="test-wait">
+<title>Canvas text-run edge-case crash tests</title>
+<meta name="assert" content="fillText/measureText do not crash on empty string, single char, or invalid font.">
+<link rel="author" title="Euclid Ye" href="mailto:yezhizhenjiakang@gmail.com">
+
+<canvas id="canvas" width="400" height="200"></canvas>
+
+<script>
+  window.onload = () => {
+    const canvas = document.getElementById('canvas');
+    const ctx = canvas.getContext('2d');
+
+    // 1. Empty string
+    ctx.measureText('');
+    ctx.fillText('', 10, 30);
+
+    // 2. Single character (triggers empty previous-run logic)
+    ctx.font = '24px sans-serif';
+    ctx.measureText('A');
+    ctx.fillText('A', 10, 60);
+
+    // 3. Invalid font family (checks missing-font logic)
+    ctx.font = '24px ThisFontDoesNotExist123';
+    ctx.measureText('test');
+    ctx.fillText('test', 10, 180);
+
+    document.documentElement.classList.remove("test-wait");
+  };
+</script>
+</html>


### PR DESCRIPTION
As titled. The `Vec<UnshapedTextRun>` produced by `fn build_unshaped_text_runs`
is only used by `into_shaped_text_run`, which filters out those without string or font.

It is better to not allocate them in the first place.

Testing: [Try](https://github.com/servo/servo/actions/runs/23642089615). 
Added a Servo-specific crash test to ensure we will not have empty font/string in a text run.