### PR TITLE
script: Use the containing node as the activable element for UA widgets

### DIFF
--- a/components/script/dom/document/document_event_handler.rs
+++ b/components/script/dom/document/document_event_handler.rs
@@ -34,6 +34,7 @@ use script_bindings::codegen::GenericBindings::HTMLLabelElementBinding::HTMLLabe
 use script_bindings::codegen::GenericBindings::KeyboardEventBinding::KeyboardEventMethods;
 use script_bindings::codegen::GenericBindings::NavigatorBinding::NavigatorMethods;
 use script_bindings::codegen::GenericBindings::PerformanceBinding::PerformanceMethods;
+use script_bindings::codegen::GenericBindings::ShadowRootBinding::ShadowRootMethods;
 use script_bindings::codegen::GenericBindings::TouchBinding::TouchMethods;
 use script_bindings::codegen::GenericBindings::WindowBinding::{ScrollBehavior, WindowMethods};
 use script_bindings::inheritance::Castable;
@@ -758,8 +759,15 @@ impl DocumentEventHandler {
     }
 
     fn element_for_activation(&self, element: DomRoot<Element>) -> DomRoot<Element> {
+        let node: &Node = element.upcast();
+        if node.is_in_ua_widget() {
+            if let Some(containing_shadow_root) = node.containing_shadow_root() {
+                return containing_shadow_root.Host();
+            }
+        }
+
         // If the element is a label, the activable element is the control element.
-        if element.upcast::<Node>().type_id() ==
+        if node.type_id() ==
             NodeTypeId::Element(ElementTypeId::HTMLElement(
                 HTMLElementTypeId::HTMLLabelElement,
             ))
@@ -769,6 +777,7 @@ impl DocumentEventHandler {
                 return DomRoot::from_ref(control.upcast::<Element>());
             }
         }
+
         element
     }
 

--- a/tests/wpt/meta/html/semantics/selectors/pseudo-classes/active-disabled.html.ini
+++ b/tests/wpt/meta/html/semantics/selectors/pseudo-classes/active-disabled.html.ini
@@ -1,3 +1,0 @@
-[active-disabled.html]
-  [Clicking on a disabled input should make it match the :active selector.]
-    expected: FAIL


### PR DESCRIPTION
UA widgets (such as textual `<input>`) create a shadow DOM to contain
their various parts. When clicking on these parts (such as the text node
of the widget contents), we should use the root node of the widget as
the activable node. This means that wehen you click on the inside of an
`<input>` element, the input matches the `:active` pseudo-selector.

Testing: This improves WPT tests.
Fixes: #41102
