### PR TITLE
devtools: Rename ThreadActor variable names

### DIFF
--- a/components/devtools/actors/breakpoint.rs
+++ b/components/devtools/actors/breakpoint.rs
@@ -62,8 +62,9 @@ impl Actor for BreakpointListActor {
 
                 let browsing_context_actor =
                     registry.find::<BrowsingContextActor>(&self.browsing_context_name);
-                let thread = registry.find::<ThreadActor>(&browsing_context_actor.thread);
-                let source = thread
+                let thread_actor =
+                    registry.find::<ThreadActor>(&browsing_context_actor.thread_name);
+                let source = thread_actor
                     .source_manager
                     .find_source(registry, &source_url)
                     .ok_or(ActorError::Internal)?;
@@ -98,8 +99,9 @@ impl Actor for BreakpointListActor {
 
                 let browsing_context_actor =
                     registry.find::<BrowsingContextActor>(&self.browsing_context_name);
-                let thread = registry.find::<ThreadActor>(&browsing_context_actor.thread);
-                let source = thread
+                let thread_actor =
+                    registry.find::<ThreadActor>(&browsing_context_actor.thread_name);
+                let source = thread_actor
                     .source_manager
                     .find_source(registry, &source_url)
                     .ok_or(ActorError::Internal)?;

--- a/components/devtools/actors/browsing_context.rs
+++ b/components/devtools/actors/browsing_context.rs
@@ -145,7 +145,7 @@ pub(crate) struct BrowsingContextActor {
     pub(crate) inspector: String,
     reflow_name: String,
     style_sheets_name: String,
-    pub thread: String,
+    pub thread_name: String,
     _tab: String,
     // Different pipelines may run on different script threads.
     // These should be kept around even when the active pipeline is updated,
@@ -236,7 +236,7 @@ impl BrowsingContextActor {
         let tab_descriptor_actor =
             TabDescriptorActor::new(registry, name.clone(), is_top_level_global);
 
-        let thread = ThreadActor::new(
+        let thread_actor = ThreadActor::new(
             registry.new_name::<ThreadActor>(),
             script_sender.clone(),
             Some(name.clone()),
@@ -267,7 +267,7 @@ impl BrowsingContextActor {
             reflow_name: reflow_actor.name(),
             style_sheets_name: style_sheets_actor.name(),
             _tab: tab_descriptor_actor.name(),
-            thread: thread.name(),
+            thread_name: thread_actor.name(),
             watcher_name: watcher_actor.name(),
         };
 
@@ -276,7 +276,7 @@ impl BrowsingContextActor {
         registry.register(reflow_actor);
         registry.register(style_sheets_actor);
         registry.register(tab_descriptor_actor);
-        registry.register(thread);
+        registry.register(thread_actor);
         registry.register(watcher_actor);
 
         target
@@ -410,7 +410,7 @@ impl ActorEncode<BrowsingContextActorMsg> for BrowsingContextActor {
             inspector_actor: self.inspector.clone(),
             reflow_actor: self.reflow_name.clone(),
             style_sheets_actor: self.style_sheets_name.clone(),
-            thread_actor: self.thread.clone(),
+            thread_actor: self.thread_name.clone(),
             target_type: TargetType::Frame,
         }
     }

--- a/components/devtools/actors/watcher.rs
+++ b/components/devtools/actors/watcher.rs
@@ -332,7 +332,7 @@ impl Actor for WatcherActor {
                         },
                         "source" => {
                             let thread_actor =
-                                registry.find::<ThreadActor>(&browsing_context_actor.thread);
+                                registry.find::<ThreadActor>(&browsing_context_actor.thread_name);
                             browsing_context_actor.resources_array(
                                 thread_actor.source_manager.source_forms(registry),
                                 resource.into(),
@@ -342,10 +342,11 @@ impl Actor for WatcherActor {
 
                             for worker_name in &*root_actor.workers.borrow() {
                                 let worker_actor = registry.find::<WorkerActor>(worker_name);
-                                let thread = registry.find::<ThreadActor>(&worker_actor.thread);
+                                let thread_actor =
+                                    registry.find::<ThreadActor>(&worker_actor.thread_name);
 
                                 worker_actor.resources_array(
-                                    thread.source_manager.source_forms(registry),
+                                    thread_actor.source_manager.source_forms(registry),
                                     resource.into(),
                                     ResourceArrayType::Available,
                                     &mut request,

--- a/components/devtools/actors/worker.rs
+++ b/components/devtools/actors/worker.rs
@@ -30,7 +30,7 @@ pub enum WorkerType {
 pub(crate) struct WorkerActor {
     pub name: String,
     pub console_name: String,
-    pub thread: String,
+    pub thread_name: String,
     pub worker_id: WorkerId,
     pub url: ServoUrl,
     pub type_: WorkerType,
@@ -76,7 +76,7 @@ impl Actor for WorkerActor {
                 let msg = ConnectReply {
                     from: self.name(),
                     type_: "connected".to_owned(),
-                    thread_actor: self.thread.clone(),
+                    thread_actor: self.thread_name.clone(),
                     console_actor: self.console_name.clone(),
                 };
                 // FIXME: we don’t send an actual reply (message without type), which seems to be a bug?
@@ -174,7 +174,7 @@ impl ActorEncode<WorkerActorMsg> for WorkerActor {
         WorkerActorMsg {
             actor: self.name(),
             console_actor: self.console_name.clone(),
-            thread_actor: self.thread.clone(),
+            thread_actor: self.thread_name.clone(),
             id: self.worker_id.0.to_string(),
             url: self.url.to_string(),
             traits: WorkerTraits {

--- a/components/devtools/lib.rs
+++ b/components/devtools/lib.rs
@@ -492,7 +492,7 @@ impl DevtoolsInstance {
             let worker = WorkerActor {
                 name: worker_name.clone(),
                 console_name: console_name.clone(),
-                thread: thread_name,
+                thread_name,
                 worker_id: id,
                 url: page_info.url,
                 type_: worker_type,
@@ -731,7 +731,7 @@ impl DevtoolsInstance {
             let thread_actor_name = self
                 .registry
                 .find::<WorkerActor>(worker_name)
-                .thread
+                .thread_name
                 .clone();
             let thread_actor = self.registry.find::<ThreadActor>(&thread_actor_name);
 
@@ -760,7 +760,7 @@ impl DevtoolsInstance {
                 let browsing_context_actor = self
                     .registry
                     .find::<BrowsingContextActor>(browsing_context_name);
-                browsing_context_actor.thread.clone()
+                browsing_context_actor.thread_name.clone()
             };
 
             let thread_actor = self.registry.find::<ThreadActor>(&thread_actor_name);
@@ -816,7 +816,7 @@ impl DevtoolsInstance {
             .find::<BrowsingContextActor>(browsing_context_name);
         let thread = self
             .registry
-            .find::<ThreadActor>(&browsing_context_actor.thread);
+            .find::<ThreadActor>(&browsing_context_actor.thread_name);
 
         let pause = self.registry.new_name::<PauseActor>();
         self.registry.register(PauseActor {
@@ -858,7 +858,7 @@ impl DevtoolsInstance {
             .find::<BrowsingContextActor>(browsing_context_name);
         let thread = self
             .registry
-            .find::<ThreadActor>(&browsing_context_actor.thread);
+            .find::<ThreadActor>(&browsing_context_actor.thread_name);
 
         let source = match thread
             .source_manager


### PR DESCRIPTION
Renamed ThreadActor variable names in breakpoint, browsing_context, watcher, worker & lib.rs.

Testing: No testing required.
Fixes: Part of #43606 
