### PR TITLE
devtools: Rename InspectorActor variable names

### DIFF
--- a/components/devtools/actors/browsing_context.rs
+++ b/components/devtools/actors/browsing_context.rs
@@ -142,7 +142,7 @@ pub(crate) struct BrowsingContextActor {
     accessibility: String,
     pub console_name: String,
     css_properties_name: String,
-    pub(crate) inspector: String,
+    pub(crate) inspector_name: String,
     reflow_name: String,
     style_sheets_name: String,
     pub thread: String,
@@ -227,7 +227,7 @@ impl BrowsingContextActor {
         let css_properties_actor =
             CssPropertiesActor::new(registry.new_name::<CssPropertiesActor>(), properties);
 
-        let inspector = InspectorActor::register(registry, name.clone());
+        let inspector_name = InspectorActor::register(registry, name.clone());
 
         let reflow_actor = ReflowActor::new(registry.new_name::<ReflowActor>());
 
@@ -263,7 +263,7 @@ impl BrowsingContextActor {
             accessibility: accessibility_actor.name(),
             console_name,
             css_properties_name: css_properties_actor.name(),
-            inspector,
+            inspector_name,
             reflow_name: reflow_actor.name(),
             style_sheets_name: style_sheets_actor.name(),
             _tab: tab_descriptor_actor.name(),
@@ -407,7 +407,7 @@ impl ActorEncode<BrowsingContextActorMsg> for BrowsingContextActor {
             accessibility_actor: self.accessibility.clone(),
             console_actor: self.console_name.clone(),
             css_properties_actor: self.css_properties_name.clone(),
-            inspector_actor: self.inspector.clone(),
+            inspector_actor: self.inspector_name.clone(),
             reflow_actor: self.reflow_name.clone(),
             style_sheets_actor: self.style_sheets_name.clone(),
             thread_actor: self.thread.clone(),

--- a/components/devtools/actors/inspector.rs
+++ b/components/devtools/actors/inspector.rs
@@ -127,19 +127,19 @@ impl InspectorActor {
             browsing_context_name,
         };
 
-        let actor = Self {
+        let inspector_actor = Self {
             name: registry.new_name::<InspectorActor>(),
             highlighter_name: highlighter_actor.name(),
             page_style_name: page_style_actor.name(),
             walker: walker.name(),
         };
-        let name = actor.name();
+        let inspector_name = inspector_actor.name();
 
         registry.register(highlighter_actor);
         registry.register(page_style_actor);
         registry.register(walker);
-        registry.register(actor);
+        registry.register(inspector_actor);
 
-        name
+        inspector_name
     }
 }

--- a/components/devtools/lib.rs
+++ b/components/devtools/lib.rs
@@ -600,7 +600,7 @@ impl DevtoolsInstance {
             .find::<BrowsingContextActor>(browsing_context_name);
         let inspector_actor = self
             .registry
-            .find::<InspectorActor>(&browsing_context_actor.inspector);
+            .find::<InspectorActor>(&browsing_context_actor.inspector_name);
         let walker_actor = self.registry.find::<WalkerActor>(&inspector_actor.walker);
 
         for connection in self.connections.lock().unwrap().values_mut() {


### PR DESCRIPTION
Renamed InspectorActor variable names in browsing_context, inspector & lib.rs

Testing: No testing required.
Fixes: Part of #43606