### PR TITLE
devtools: Rename WatcherActor variable names

### DIFF
--- a/components/devtools/actors/browsing_context.rs
+++ b/components/devtools/actors/browsing_context.rs
@@ -154,7 +154,7 @@ pub(crate) struct BrowsingContextActor {
     //       detect when `ScriptThread`s are destroyed and remove the associated
     //       entries.
     script_chans: AtomicRefCell<FxHashMap<PipelineId, GenericSender<DevtoolScriptControlMsg>>>,
-    pub watcher: String,
+    pub watcher_name: String,
 }
 
 impl ResourceAvailable for BrowsingContextActor {
@@ -241,7 +241,7 @@ impl BrowsingContextActor {
             Some(name.clone()),
         );
 
-        let watcher = WatcherActor::new(
+        let watcher_actor = WatcherActor::new(
             registry,
             name.clone(),
             SessionContext::new(SessionContextType::BrowserElement),
@@ -267,7 +267,7 @@ impl BrowsingContextActor {
             style_sheets: style_sheets.name(),
             _tab: tab_descriptor_actor.name(),
             thread: thread.name(),
-            watcher: watcher.name(),
+            watcher_name: watcher_actor.name(),
         };
 
         registry.register(accessibility);
@@ -276,7 +276,7 @@ impl BrowsingContextActor {
         registry.register(style_sheets);
         registry.register(tab_descriptor_actor);
         registry.register(thread);
-        registry.register(watcher);
+        registry.register(watcher_actor);
 
         target
     }

--- a/components/devtools/actors/network_event.rs
+++ b/components/devtools/actors/network_event.rs
@@ -37,7 +37,7 @@ pub(crate) struct NetworkEventActor {
     resource_id: u64,
     response: AtomicRefCell<Option<NetworkEventResponse>>,
     security_info: AtomicRefCell<TlsSecurityInfo>,
-    pub watcher: String,
+    pub watcher_name: String,
 }
 
 #[derive(Clone, Serialize)]
@@ -535,11 +535,11 @@ impl Actor for NetworkEventActor {
 }
 
 impl NetworkEventActor {
-    pub fn new(name: String, resource_id: u64, watcher: String) -> NetworkEventActor {
+    pub fn new(name: String, resource_id: u64, watcher_name: String) -> NetworkEventActor {
         NetworkEventActor {
             name,
             resource_id,
-            watcher,
+            watcher_name,
             ..Default::default()
         }
     }
@@ -624,9 +624,9 @@ impl NetworkEventActor {
     }
 
     pub fn resource_updates(&self, registry: &ActorRegistry) -> NetworkEventResource {
-        let watcher = registry.find::<WatcherActor>(&self.watcher);
+        let watcher_actor = registry.find::<WatcherActor>(&self.watcher_name);
         let browsing_context_actor =
-            registry.find::<BrowsingContextActor>(&watcher.browsing_context_name);
+            registry.find::<BrowsingContextActor>(&watcher_actor.browsing_context_name);
 
         NetworkEventResource {
             resource_id: self.resource_id,
@@ -702,9 +702,9 @@ impl ActorEncode<NetworkEventMsg> for NetworkEventActor {
             LocalResult::Ambiguous(date_time, _) => date_time.to_rfc3339(),
         };
 
-        let watcher = registry.find::<WatcherActor>(&self.watcher);
+        let watcher_actor = registry.find::<WatcherActor>(&self.watcher_name);
         let browsing_context_actor =
-            registry.find::<BrowsingContextActor>(&watcher.browsing_context_name);
+            registry.find::<BrowsingContextActor>(&watcher_actor.browsing_context_name);
 
         NetworkEventMsg {
             actor: self.name(),

--- a/components/devtools/actors/tab.rs
+++ b/components/devtools/actors/tab.rs
@@ -117,7 +117,7 @@ impl Actor for TabDescriptorActor {
             },
             "getWatcher" => request.reply_final(&GetWatcherReply {
                 from: self.name(),
-                watcher: registry.encode::<WatcherActor, _>(&browsing_context_actor.watcher),
+                watcher: registry.encode::<WatcherActor, _>(&browsing_context_actor.watcher_name),
             })?,
             "goBack" => {
                 browsing_context_actor

--- a/components/devtools/actors/watcher.rs
+++ b/components/devtools/actors/watcher.rs
@@ -454,7 +454,7 @@ impl WatcherActor {
             browsing_context_name.clone(),
         );
 
-        let watcher = Self {
+        let watcher_actor = Self {
             name: registry.new_name::<WatcherActor>(),
             browsing_context_name,
             network_parent_name: network_parent_actor.name(),
@@ -469,7 +469,7 @@ impl WatcherActor {
         registry.register(thread_configuration);
         registry.register(breakpoint_list);
 
-        watcher
+        watcher_actor
     }
 
     pub fn emit_will_navigate<'a>(

--- a/components/devtools/lib.rs
+++ b/components/devtools/lib.rs
@@ -445,7 +445,7 @@ impl DevtoolsInstance {
         if let NavigationState::Start(url) = &state {
             let watcher_actor = self
                 .registry
-                .find::<WatcherActor>(&browsing_context_actor.watcher);
+                .find::<WatcherActor>(&browsing_context_actor.watcher_name);
             watcher_actor.emit_will_navigate(
                 browsing_context_id,
                 url.clone(),
@@ -664,7 +664,7 @@ impl DevtoolsInstance {
         let watcher_name = self
             .registry
             .find::<BrowsingContextActor>(browsing_context_name)
-            .watcher
+            .watcher_name
             .clone();
 
         let network_event_name = match self.actor_requests.get(&request_id) {

--- a/components/devtools/network_handler.rs
+++ b/components/devtools/network_handler.rs
@@ -28,7 +28,7 @@ pub(crate) fn handle_network_event(
     network_event: NetworkEvent,
 ) {
     let network_event_actor = registry.find::<NetworkEventActor>(&network_event_name);
-    let watcher = registry.find::<WatcherActor>(&network_event_actor.watcher);
+    let watcher_actor = registry.find::<WatcherActor>(&network_event_actor.watcher_name);
 
     match network_event {
         NetworkEvent::HttpRequest(httprequest) => {
@@ -37,7 +37,7 @@ pub(crate) fn handle_network_event(
             let resource = network_event_actor.resource_updates(&registry);
 
             for stream in &mut connections {
-                watcher.resource_array(
+                watcher_actor.resource_array(
                     msg.clone(),
                     "network-event".to_string(),
                     ResourceArrayType::Available,
@@ -45,7 +45,7 @@ pub(crate) fn handle_network_event(
                 );
 
                 // Also push initial resource update (request headers, cookies)
-                watcher.resource_array(
+                watcher_actor.resource_array(
                     resource.clone(),
                     "network-event".to_string(),
                     ResourceArrayType::Updated,
@@ -59,7 +59,7 @@ pub(crate) fn handle_network_event(
             let resource = network_event_actor.resource_updates(&registry);
 
             for stream in &mut connections {
-                watcher.resource_array(
+                watcher_actor.resource_array(
                     resource.clone(),
                     "network-event".to_string(),
                     ResourceArrayType::Updated,
@@ -72,7 +72,7 @@ pub(crate) fn handle_network_event(
             let resource = network_event_actor.resource_updates(&registry);
 
             for stream in &mut connections {
-                watcher.resource_array(
+                watcher_actor.resource_array(
                     resource.clone(),
                     "network-event".to_string(),
                     ResourceArrayType::Updated,
@@ -85,7 +85,7 @@ pub(crate) fn handle_network_event(
             let resource = network_event_actor.resource_updates(&registry);
 
             for stream in &mut connections {
-                watcher.resource_array(
+                watcher_actor.resource_array(
                     resource.clone(),
                     "network-event".to_string(),
                     ResourceArrayType::Updated,


### PR DESCRIPTION
Renamed WatcherActor variable names in browsing_context, network_handler, network_event, tab, watcher & lib.rs

Testing: Ran `./mach test-devtools` locally.
Fixes: Part of #43606
