### PR TITLE
devtools: Rename StyleSheetsActor variable names

### DIFF
--- a/components/devtools/actors/browsing_context.rs
+++ b/components/devtools/actors/browsing_context.rs
@@ -144,7 +144,7 @@ pub(crate) struct BrowsingContextActor {
     css_properties: String,
     pub(crate) inspector: String,
     reflow_name: String,
-    style_sheets: String,
+    style_sheets_name: String,
     pub thread: String,
     _tab: String,
     // Different pipelines may run on different script threads.
@@ -264,7 +264,7 @@ impl BrowsingContextActor {
             css_properties: css_properties.name(),
             inspector,
             reflow_name: reflow_actor.name(),
-            style_sheets_actor: style_sheets_actor.name(),
+            style_sheets_name: style_sheets_actor.name(),
             _tab: tab_descriptor_actor.name(),
             thread: thread.name(),
             watcher: watcher.name(),
@@ -408,7 +408,7 @@ impl ActorEncode<BrowsingContextActorMsg> for BrowsingContextActor {
             css_properties_actor: self.css_properties.clone(),
             inspector_actor: self.inspector.clone(),
             reflow_actor: self.reflow_name.clone(),
-            style_sheets_actor: self.style_sheets.clone(),
+            style_sheets_actor: self.style_sheets_name.clone(),
             thread_actor: self.thread.clone(),
             target_type: TargetType::Frame,
         }

--- a/components/devtools/actors/browsing_context.rs
+++ b/components/devtools/actors/browsing_context.rs
@@ -264,7 +264,7 @@ impl BrowsingContextActor {
             css_properties: css_properties.name(),
             inspector,
             reflow_name: reflow_actor.name(),
-            style_sheets: style_sheets_actor.name(),
+            style_sheets_actor: style_sheets_actor.name(),
             _tab: tab_descriptor_actor.name(),
             thread: thread.name(),
             watcher: watcher.name(),

--- a/components/devtools/actors/browsing_context.rs
+++ b/components/devtools/actors/browsing_context.rs
@@ -230,7 +230,7 @@ impl BrowsingContextActor {
 
         let reflow_actor = ReflowActor::new(registry.new_name::<ReflowActor>());
 
-        let style_sheets = StyleSheetsActor::new(registry.new_name::<StyleSheetsActor>());
+        let style_sheets_actor = StyleSheetsActor::new(registry.new_name::<StyleSheetsActor>());
 
         let tab_descriptor_actor =
             TabDescriptorActor::new(registry, name.clone(), is_top_level_global);
@@ -264,7 +264,7 @@ impl BrowsingContextActor {
             css_properties: css_properties.name(),
             inspector,
             reflow_name: reflow_actor.name(),
-            style_sheets: style_sheets.name(),
+            style_sheets: style_sheets_actor.name(),
             _tab: tab_descriptor_actor.name(),
             thread: thread.name(),
             watcher: watcher.name(),
@@ -273,7 +273,7 @@ impl BrowsingContextActor {
         registry.register(accessibility);
         registry.register(css_properties);
         registry.register(reflow_actor);
-        registry.register(style_sheets);
+        registry.register(style_sheets_actor);
         registry.register(tab_descriptor_actor);
         registry.register(thread);
         registry.register(watcher);


### PR DESCRIPTION
Renamed StyleSheetsActor variable names in browsing_context

Testing: Ran `./mach test-devtools` locally.
Fixes: Part of #43606
