### PR TITLE
devtools: Rename RootActor variable names

### DIFF
--- a/components/devtools/actors/root.rs
+++ b/components/devtools/actors/root.rs
@@ -355,7 +355,7 @@ impl RootActor {
         let process = ProcessActor::new(registry.new_name::<ProcessActor>());
 
         // Root actor
-        let root = Self {
+        let root_actor = Self {
             global_actors: GlobalActors {
                 device_actor: device_actor.name(),
                 perf_actor: perf.name(),
@@ -369,7 +369,7 @@ impl RootActor {
         registry.register(device_actor);
         registry.register(preference);
         registry.register(process);
-        registry.register(root);
+        registry.register(root_actor);
     }
 
     fn get_tab_msg_by_browser_id(

--- a/components/devtools/actors/tab.rs
+++ b/components/devtools/actors/tab.rs
@@ -173,8 +173,8 @@ impl TabDescriptorActor {
         is_top_level_global: bool,
     ) -> TabDescriptorActor {
         let name = registry.new_name::<Self>();
-        let root = registry.find::<RootActor>("root");
-        root.tabs.borrow_mut().push(name.clone());
+        let root_actor = registry.find::<RootActor>("root");
+        root_actor.tabs.borrow_mut().push(name.clone());
         TabDescriptorActor {
             name,
             browsing_context_name,

--- a/components/devtools/actors/watcher.rs
+++ b/components/devtools/actors/watcher.rs
@@ -240,7 +240,7 @@ impl Actor for WatcherActor {
     ) -> Result<(), ActorError> {
         let browsing_context_actor =
             registry.find::<BrowsingContextActor>(&self.browsing_context_name);
-        let root = registry.find::<RootActor>("root");
+        let root_actor = registry.find::<RootActor>("root");
         match msg_type {
             "watchTargets" => {
                 // As per logs we either get targetType as "frame" or "worker"
@@ -261,7 +261,7 @@ impl Actor for WatcherActor {
 
                     browsing_context_actor.frame_update(&mut request);
                 } else if target_type == "worker" {
-                    for worker_name in &*root.workers.borrow() {
+                    for worker_name in &*root_actor.workers.borrow() {
                         let worker_msg = WatchTargetsReply {
                             from: self.name(),
                             type_: "target-available-form".into(),
@@ -272,7 +272,7 @@ impl Actor for WatcherActor {
                         let _ = request.write_json_packet(&worker_msg);
                     }
                 } else if target_type == "service_worker" {
-                    for worker_name in &*root.service_workers.borrow() {
+                    for worker_name in &*root_actor.service_workers.borrow() {
                         let worker_msg = WatchTargetsReply {
                             from: self.name(),
                             type_: "target-available-form".into(),
@@ -340,7 +340,7 @@ impl Actor for WatcherActor {
                                 &mut request,
                             );
 
-                            for worker_name in &*root.workers.borrow() {
+                            for worker_name in &*root_actor.workers.borrow() {
                                 let worker_actor = registry.find::<WorkerActor>(worker_name);
                                 let thread = registry.find::<ThreadActor>(&worker_actor.thread);
 
@@ -363,7 +363,7 @@ impl Actor for WatcherActor {
                                 &mut request,
                             );
 
-                            for worker_name in &*root.workers.borrow() {
+                            for worker_name in &*root_actor.workers.borrow() {
                                 let worker_actor = registry.find::<WorkerActor>(worker_name);
                                 let console_actor =
                                     registry.find::<ConsoleActor>(&worker_actor.console_name);

--- a/components/devtools/lib.rs
+++ b/components/devtools/lib.rs
@@ -499,11 +499,14 @@ impl DevtoolsInstance {
                 script_chan: script_sender,
                 streams: Default::default(),
             };
-            let root = self.registry.find::<RootActor>("root");
+            let root_actor = self.registry.find::<RootActor>("root");
             if page_info.is_service_worker {
-                root.service_workers.borrow_mut().push(worker.name.clone());
+                root_actor
+                    .service_workers
+                    .borrow_mut()
+                    .push(worker.name.clone());
             } else {
-                root.workers.borrow_mut().push(worker.name.clone());
+                root_actor.workers.borrow_mut().push(worker.name.clone());
             }
 
             self.actor_workers.insert(id, worker_name.clone());


### PR DESCRIPTION
Renamed RootActor variable names in root, watcher, tab & lib.rs

Testing: No testing required.
Fixes: Part of #43606
