### PR TITLE
net: Enable `fetch` and `http_loader` unit tests for Windows

### DIFF
--- a/components/net/tests/fetch.rs
+++ b/components/net/tests/fetch.rs
@@ -2,8 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-#![cfg(not(target_os = "windows"))]
-
 use std::fs;
 use std::iter::FromIterator;
 use std::path::Path;
@@ -1386,7 +1384,6 @@ fn test_opaque_redirect_filtered_fetch_async_returns_complete_response() {
 }
 
 #[test]
-#[cfg(not(target_os = "windows"))]
 fn test_fetch_with_devtools() {
     static MESSAGE: &'static [u8] = b"Yay!";
     let handler =

--- a/components/net/tests/http_loader.rs
+++ b/components/net/tests/http_loader.rs
@@ -2,8 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-#![cfg(not(target_os = "windows"))]
-
 use std::collections::HashMap;
 use std::io::Write;
 use std::sync::Arc;
@@ -431,7 +429,6 @@ fn test_request_and_response_data_with_network_messages() {
 }
 
 #[test]
-#[cfg(not(target_os = "windows"))]
 fn test_request_and_response_message_from_devtool_without_pipeline_id() {
     let handler =
         move |_: HyperRequest<Incoming>,
@@ -874,7 +871,6 @@ fn test_load_sends_cookie_if_nonhttp() {
 }
 
 #[test]
-#[cfg(not(target_os = "windows"))]
 fn test_cookie_set_with_httponly_should_not_be_available_using_getcookiesforurl() {
     let handler =
         move |_: HyperRequest<Incoming>,
@@ -928,7 +924,6 @@ fn test_cookie_set_with_httponly_should_not_be_available_using_getcookiesforurl(
 }
 
 #[test]
-#[cfg(not(target_os = "windows"))]
 fn test_when_cookie_received_marked_secure_is_ignored_for_http() {
     let handler =
         move |_: HyperRequest<Incoming>,


### PR DESCRIPTION
fetch and http_loader module were completely disabled for Windows. 
I ran them locally for a few rounds, and there's nothing abnormal.

Testing: [Windows Try with UT](https://github.com/servo/servo/actions/runs/23687830144/job/69010191251)
