### PR TITLE
chore: relax mozlog version requirement

### DIFF
--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -4,9 +4,11 @@
 blessed == 1.20.0
 distro == 1.4
 mozinfo == 1.2.3
-mozlog == 8.0.0
 setuptools == 78.1.1
 toml == 0.9.2
+
+# exact version is specified by WPT
+mozlog ~= 8.0.0
 
 # For Python linting and formatting
 ruff == 0.11.10


### PR DESCRIPTION
Having strict versions here prevents WPT imports. Because we resolve our deps together with WPT deps: https://github.com/servo/servo/blob/c32b720ca4fda982b8d8942fdfbdf137fd1ee572/pyproject.toml#L9 we will effectively use pinned version from WPT (which will work in upgrades).

Testing: None
Fixes: https://servo.zulipchat.com/#narrow/channel/263398-general/topic/WPT.20import.20failed.20today
