### PR TITLE
devtools: Rename PreferenceActor variable names

### DIFF
--- a/components/devtools/actors/root.rs
+++ b/components/devtools/actors/root.rs
@@ -349,7 +349,7 @@ impl RootActor {
         // Global actors
         let device_actor = DeviceActor::new(registry.new_name::<DeviceActor>());
         let perf = PerformanceActor::new(registry.new_name::<PerformanceActor>());
-        let preference = PreferenceActor::new(registry.new_name::<PreferenceActor>());
+        let preference_actor = PreferenceActor::new(registry.new_name::<PreferenceActor>());
 
         // Process descriptor
         let process = ProcessActor::new(registry.new_name::<ProcessActor>());
@@ -359,7 +359,7 @@ impl RootActor {
             global_actors: GlobalActors {
                 device_actor: device_actor.name(),
                 perf_actor: perf.name(),
-                preference_actor: preference.name(),
+                preference_actor: preference_actor.name(),
             },
             process: process.name(),
             ..Default::default()
@@ -367,7 +367,7 @@ impl RootActor {
 
         registry.register(perf);
         registry.register(device_actor);
-        registry.register(preference);
+        registry.register(preference_actor);
         registry.register(process);
         registry.register(root_actor);
     }


### PR DESCRIPTION
Renamed PreferenceActor variable names in root.rs.

Testing: No testing required.
Fixes: Part of #43606