### PR TITLE
devtools: Rename ProcessActor variable names

### DIFF
--- a/components/devtools/actors/root.rs
+++ b/components/devtools/actors/root.rs
@@ -163,7 +163,7 @@ struct GetProcessResponse {
 pub(crate) struct RootActor {
     active_tab: AtomicRefCell<Option<String>>,
     global_actors: GlobalActors,
-    process: String,
+    process_name: String,
     pub tabs: AtomicRefCell<Vec<String>>,
     pub workers: AtomicRefCell<Vec<String>>,
     pub service_workers: AtomicRefCell<Vec<String>>,
@@ -192,10 +192,10 @@ impl Actor for RootActor {
 
             // TODO: Unexpected message getTarget for process (when inspecting)
             "getProcess" => {
-                let process = registry.encode::<ProcessActor, _>(&self.process);
+                let process_descriptor = registry.encode::<ProcessActor, _>(&self.process_name);
                 let reply = GetProcessResponse {
                     from: self.name(),
-                    process_descriptor: process,
+                    process_descriptor,
                 };
                 request.reply_final(&reply)?
             },
@@ -234,10 +234,10 @@ impl Actor for RootActor {
             },
 
             "listProcesses" => {
-                let process = registry.encode::<ProcessActor, _>(&self.process);
+                let process_descriptor = registry.encode::<ProcessActor, _>(&self.process_name);
                 let reply = ListProcessesResponse {
                     from: self.name(),
-                    processes: vec![process],
+                    processes: vec![process_descriptor],
                 };
                 request.reply_final(&reply)?
             },
@@ -352,7 +352,7 @@ impl RootActor {
         let preference = PreferenceActor::new(registry.new_name::<PreferenceActor>());
 
         // Process descriptor
-        let process = ProcessActor::new(registry.new_name::<ProcessActor>());
+        let process_actor = ProcessActor::new(registry.new_name::<ProcessActor>());
 
         // Root actor
         let root_actor = Self {
@@ -361,14 +361,14 @@ impl RootActor {
                 perf_actor: perf.name(),
                 preference_actor: preference.name(),
             },
-            process: process.name(),
+            process_name: process_actor.name(),
             ..Default::default()
         };
 
         registry.register(perf);
         registry.register(device_actor);
         registry.register(preference);
-        registry.register(process);
+        registry.register(process_actor);
         registry.register(root_actor);
     }
 


### PR DESCRIPTION
Renamed ProcessActor variable names in root.rs.

Testing: No testing required.
Fixes: Part of #43606