### PR TITLE
pixels: support AVIF images

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -678,6 +678,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
+name = "av-data"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fca67ba5d317924c02180c576157afd54babe48a76ebc66ce6d34bb8ba08308e"
+dependencies = [
+ "byte-slice-cast",
+ "bytes",
+ "num-derive",
+ "num-rational",
+ "num-traits",
+]
+
+[[package]]
 name = "av1-grain"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -822,6 +835,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
 dependencies = [
  "serde_core",
+]
+
+[[package]]
+name = "bitreader"
+version = "0.3.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "886559b1e163d56c765bc3a985febb4eee8009f625244511d8ee3c432e08c066"
+dependencies = [
+ "cfg-if",
 ]
 
 [[package]]
@@ -1805,6 +1827,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be1e0bca6c3637f992fc1cc7cbc52a78c1ef6db076dbf1059c4323d6a2048376"
 
 [[package]]
+name = "dav1d"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "80c3f80814db85397819d464bb553268992c393b4b3b5554b89c1655996d5926"
+dependencies = [
+ "av-data",
+ "bitflags 2.11.0",
+ "dav1d-sys",
+ "static_assertions",
+]
+
+[[package]]
+name = "dav1d-sys"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3c91aea6668645415331133ed6f8ddf0e7f40160cd97a12d59e68716a58704b"
+dependencies = [
+ "libc",
+ "system-deps 7.0.5",
+]
+
+[[package]]
 name = "dbus"
 version = "0.9.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2415,6 +2459,15 @@ name = "fallible-streaming-iterator"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7360491ce676a36bf9bb3c56c1aa791658183a54d2744120f27285738d90465a"
+
+[[package]]
+name = "fallible_collections"
+version = "0.4.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a88c69768c0a15262df21899142bc6df9b9b823546d4b4b9a7bc2d6c448ec6fd"
+dependencies = [
+ "hashbrown 0.13.2",
+]
 
 [[package]]
 name = "fastrand"
@@ -3499,6 +3552,15 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43a3c133739dddd0d2990f9a4bdf8eb4b21ef50e4851ca85ab661199821d510e"
+dependencies = [
+ "ahash",
+]
+
+[[package]]
+name = "hashbrown"
 version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
@@ -4334,8 +4396,10 @@ dependencies = [
  "bytemuck",
  "byteorder-lite",
  "color_quant",
+ "dav1d",
  "gif",
  "image-webp",
+ "mp4parse",
  "num-traits",
  "png",
  "ravif",
@@ -5098,6 +5162,20 @@ dependencies = [
  "libz-sys",
  "tar",
  "walkdir",
+]
+
+[[package]]
+name = "mp4parse"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63a35203d3c6ce92d5251c77520acb2e57108c88728695aa883f70023624c570"
+dependencies = [
+ "bitreader",
+ "byteorder",
+ "fallible_collections",
+ "log",
+ "num-traits",
+ "static_assertions",
 ]
 
 [[package]]

--- a/components/pixels/Cargo.toml
+++ b/components/pixels/Cargo.toml
@@ -15,7 +15,7 @@ path = "lib.rs"
 
 [dependencies]
 euclid = { workspace = true }
-image = { workspace = true }
+image = { workspace = true, features = ["avif-native"] }
 log = { workspace = true }
 malloc_size_of = { workspace = true }
 malloc_size_of_derive = { workspace = true }

--- a/components/pixels/lib.rs
+++ b/components/pixels/lib.rs
@@ -12,7 +12,7 @@ use std::time::Duration;
 use std::{cmp, fmt, vec};
 
 use euclid::default::{Point2D, Rect, Size2D};
-use image::codecs::{bmp, gif, ico, jpeg, png, webp};
+use image::codecs::{avif, bmp, gif, ico, jpeg, png, webp};
 use image::error::ImageFormatHint;
 use image::imageops::{self, FilterType};
 use image::{
@@ -557,6 +557,9 @@ pub fn load_from_memory(buffer: &[u8], cors_status: CorsStatus) -> Option<Raster
                 GenericImageDecoder::Ico(image_decoder) => {
                     decode_static_image(cors_status, *image_decoder)
                 },
+                GenericImageDecoder::Avif(image_decoder) => {
+                    decode_static_image(cors_status, *image_decoder)
+                },
             }
         },
     }
@@ -576,6 +579,8 @@ pub fn detect_image_format(buffer: &[u8]) -> Result<ImageFormat, &str> {
         Ok(ImageFormat::Bmp)
     } else if is_ico(buffer) {
         Ok(ImageFormat::Ico)
+    } else if is_avif(buffer) {
+        Ok(ImageFormat::Avif)
     } else {
         Err("Image Format Not Supported")
     }
@@ -705,6 +710,29 @@ fn is_webp(buffer: &[u8]) -> bool {
     buffer[8..].len() >= len && &buffer[8..12] == b"WEBP"
 }
 
+fn is_avif(buffer: &[u8]) -> bool {
+    // Need at least 12 bytes: size (4) + "ftyp" (4) + brand (4)
+    if buffer.len() < 12 {
+        return false;
+    }
+
+    // Ignore the first 4 bytes that are the MP4 box size.
+
+    // Check for "ftyp" box at offset 4
+    if &buffer[4..8] != b"ftyp" {
+        return false;
+    }
+
+    // Check major brand
+    let major_brand = &buffer[8..12];
+
+    if major_brand == b"avif" || major_brand == b"avis" {
+        return true;
+    }
+
+    false
+}
+
 enum GenericImageDecoder<R: std::io::BufRead + std::io::Seek> {
     Png(Box<png::PngDecoder<R>>),
     Gif(Box<gif::GifDecoder<R>>),
@@ -712,6 +740,7 @@ enum GenericImageDecoder<R: std::io::BufRead + std::io::Seek> {
     Jpeg(Box<jpeg::JpegDecoder<R>>),
     Bmp(Box<bmp::BmpDecoder<R>>),
     Ico(Box<ico::IcoDecoder<R>>),
+    Avif(Box<avif::AvifDecoder<R>>),
 }
 
 fn make_decoder(
@@ -729,6 +758,7 @@ fn make_decoder(
         ImageFormat::Jpeg => GenericImageDecoder::Jpeg(Box::new(jpeg::JpegDecoder::new(reader)?)),
         ImageFormat::Bmp => GenericImageDecoder::Bmp(Box::new(bmp::BmpDecoder::new(reader)?)),
         ImageFormat::Ico => GenericImageDecoder::Ico(Box::new(ico::IcoDecoder::new(reader)?)),
+        ImageFormat::Avif => GenericImageDecoder::Avif(Box::new(avif::AvifDecoder::new(reader)?)),
         _ => {
             return Err(ImageError::Unsupported(
                 ImageFormatHint::Exact(format).into(),

--- a/components/script/dom/html/htmlimageelement.rs
+++ b/components/script/dom/html/htmlimageelement.rs
@@ -104,6 +104,7 @@ const SUPPORTED_IMAGE_MIME_TYPES: &[&str] = &[
     "image/vnd.microsoft.icon",
     "image/x-icon",
     "image/webp",
+    "image/avif",
 ];
 
 #[derive(Clone, Copy, Debug)]


### PR DESCRIPTION
This enable support for the image/avif image format, which is more efficient than jpeg and webp.

Testing: For instance check that avif images are loading in https://jakearchibald.com/2020/avif-has-landed/

