### PR TITLE
servo: Wait for context menu to appear to avoid race from IME embedder control

### DIFF
--- a/components/servo/tests/webview.rs
+++ b/components/servo/tests/webview.rs
@@ -596,9 +596,15 @@ fn test_simple_context_menu() {
     show_webview_and_wait_for_rendering_to_be_ready(&servo_test, &webview, &delegate);
     open_context_menu_at_point(&webview, DevicePoint::new(50.0, 50.0));
 
-    // The form control should be shown.
+    // Wait for a context menu to appear.
     let captured_delegate = delegate.clone();
-    servo_test.spin(move || captured_delegate.number_of_controls_shown.get() == 0);
+    servo_test.spin(move || {
+        let controls = captured_delegate.controls_shown.borrow();
+        !controls
+            .iter()
+            .any(|control| matches!(control, EmbedderControl::ContextMenu(_)))
+    });
+    assert!(delegate.number_of_controls_shown.get() > 0);
 
     let context_menu = {
         let mut controls = delegate.controls_shown.borrow_mut();
@@ -658,8 +664,15 @@ fn test_open_context_menu_closes_existing() {
     show_webview_and_wait_for_rendering_to_be_ready(&servo_test, &webview, &delegate);
     open_context_menu_at_point(&webview, DevicePoint::new(50.0, 50.0));
 
+    // Wait for a context menu to appear.
     let captured_delegate = delegate.clone();
-    servo_test.spin(move || captured_delegate.number_of_controls_shown.get() == 0);
+    servo_test.spin(move || {
+        let controls = captured_delegate.controls_shown.borrow();
+        !controls
+            .iter()
+            .any(|control| matches!(control, EmbedderControl::ContextMenu(_)))
+    });
+    assert!(delegate.number_of_controls_shown.get() > 0);
 
     assert_eq!(delegate.number_of_controls_hidden.get(), 0);
 
@@ -699,9 +712,15 @@ fn test_contextual_context_menu_items() {
          expected_info: ContextMenuElementInformation| {
             assert!(delegate.controls_shown.borrow().is_empty());
 
-            // The form control should be shown.
+            // Wait for a context menu to appear.
             let captured_delegate = delegate.clone();
-            servo_test.spin(move || captured_delegate.number_of_controls_shown.get() == 0);
+            servo_test.spin(move || {
+                let controls = captured_delegate.controls_shown.borrow();
+                !controls
+                    .iter()
+                    .any(|control| matches!(control, EmbedderControl::ContextMenu(_)))
+            });
+            assert!(delegate.number_of_controls_shown.get() > 0);
 
             {
                 let mut controls = delegate.controls_shown.borrow_mut();


### PR DESCRIPTION
When we mouse down the right button, we focus an input element, 
but the InputMethod embedder control request always arrives 
before that of Context Menu.

https://github.com/servo/servo/blob/99132fe22b4dd47885926b258917159f16db68f5/components/script/dom/document/document_event_handler.rs#L906-L913

This causes race as when we stop spinning the event loop when `number_of_controls_shown`
is not 0, it is likely that servo has not received context menu request yet.

Testing: This is **not an abuse of resource**, since the build finishes within 9 sec and Unit tests 2m30s per run.
1. https://github.com/servo/servo/actions/runs/23711195455
2. https://github.com/servo/servo/actions/runs/23711197360
3. https://github.com/servo/servo/actions/runs/23711199228
4. https://github.com/servo/servo/actions/runs/23710867754
5. https://github.com/servo/servo/actions/runs/23710874271/job/69070302172
6. https://github.com/servo/servo/actions/runs/23710863934/job/69070280417
7. https://github.com/servo/servo/actions/runs/23710888811/job/69070509775
8. https://github.com/servo/servo/actions/runs/23711200872

Fixes: #43726