### PR TITLE
layout: Use scrollable overflow to calculate sticky offset boundary when the containing block of sticky node is a scroll node

### DIFF
--- a/components/layout/display_list/stacking_context.rs
+++ b/components/layout/display_list/stacking_context.rs
@@ -798,7 +798,11 @@ impl BoxFragment {
         let mut new_sticky_data = containing_block_info
             .for_non_absolute_descendants
             .sticky_data;
-        if let Some(ref mut sticky_data) = new_sticky_data {
+        // We want to skip leaving scroll frame for anonymous fragments,
+        // because anonymous fragment belong to same node as its closest non-anonymous child.
+        if let Some(ref mut sticky_data) = new_sticky_data &&
+            !self.base.is_anonymous()
+        {
             sticky_data.leave_scroll_frame();
         }
         let mut new_clip_id = containing_block.clip_id;

--- a/components/layout/display_list/stacking_context.rs
+++ b/components/layout/display_list/stacking_context.rs
@@ -42,7 +42,9 @@ use crate::fragment_tree::{
     FragmentTree, PositioningFragment,
 };
 use crate::geom::{
-    AuOrAuto, LengthPercentageOrAuto, PhysicalPoint, PhysicalRect, PhysicalSides, PhysicalVec,
+    
+    AuOrAuto, LengthPercentageOrAuto, PhysicalPoint, PhysicalRect, PhysicalSides, PhysicalSize,
+, PhysicalVec,
 };
 use crate::style_ext::{ComputedValuesExt, TransformExt};
 
@@ -1087,17 +1089,48 @@ impl BoxFragment {
         // The logic below is a simplified (but equivalent) version of the description above.
         let border_rect = self.border_rect();
         let computed_margin = style.physical_margin();
-
+        let parent_scroll_node = stacking_context_tree
+            .paint_info
+            .scroll_tree
+            .get_node(parent_scroll_node_id);
+        let sticky_offset_boundary = match parent_scroll_node.info {
+            SpatialTreeNodeInfo::Scroll(ref scrollable_node_info) => {
+                let cb_rect_wr = containing_block_rect.to_webrender();
+                let clip_rect = scrollable_node_info.clip_rect;
+                // When the scroll container IS the containing block, the containing
+                // block rect (content box) is inset within the clip_rect (padding box)
+                // by exactly the scroll container's padding.
+                let scroll_container_is_cb = clip_rect.min.x <= cb_rect_wr.min.x &&
+                    clip_rect.min.y <= cb_rect_wr.min.y &&
+                    clip_rect.max.x >= cb_rect_wr.max.x &&
+                    clip_rect.max.y >= cb_rect_wr.max.y;
+                if scroll_container_is_cb {
+                    let content_rect = &scrollable_node_info.content_rect;
+                    &PhysicalRect::new(
+                        PhysicalPoint::new(
+                            Au::from_f32_px(content_rect.min.x),
+                            Au::from_f32_px(content_rect.min.y),
+                        ),
+                        PhysicalSize::new(
+                            Au::from_f32_px(content_rect.max.x - content_rect.min.x),
+                            Au::from_f32_px(content_rect.max.y - content_rect.min.y),
+                        ),
+                    )
+                } else {
+                    containing_block_rect
+                }
+            },
+            _ => containing_block_rect,
+        };
         // Signed distance between each side of the border box to the corresponding side of the
         // containing block. Note that |border_rect| is already in the coordinate system of the
         // containing block.
         let distance_from_border_box_to_cb = PhysicalSides::new(
             border_rect.min_y(),
-            containing_block_rect.width() - border_rect.max_x(),
-            containing_block_rect.height() - border_rect.max_y(),
+            sticky_offset_boundary.width() - border_rect.max_x(),
+            sticky_offset_boundary.height() - border_rect.max_y(),
             border_rect.min_x(),
         );
-
         // Shrinks the signed distance by the margin, producing a limit on how much we can shift
         // the sticky positioned box without forcing the margin to move outside of the containing
         // block.

--- a/components/layout/display_list/stacking_context.rs
+++ b/components/layout/display_list/stacking_context.rs
@@ -696,14 +696,13 @@ impl BoxFragment {
             return;
         };
 
-        let mut new_sticky_data = containing_block_info
-            .for_non_absolute_descendants
-            .sticky_data;
         let spatial_id = self.build_sticky_frame_if_necessary(
             stacking_context_tree,
             containing_block.scroll_node_id,
             &containing_block.rect,
-            &new_sticky_data,
+            &containing_block_info
+                .for_non_absolute_descendants
+                .sticky_data,
         );
 
         let clip_id = self.build_clip_frame_if_necessary(
@@ -725,10 +724,7 @@ impl BoxFragment {
             )
             .or(clip_id);
 
-        let containing_block = if clip_id.is_some() ||
-            spatial_id.is_some() ||
-            (new_sticky_data.is_some_and(|s| s.is_in_scroll_frame))
-        {
+        let containing_block = if clip_id.is_some() || spatial_id.is_some() {
             if let Some(clip_id) = clip_id {
                 self.set_generated_clip_id(clip_id);
             }

--- a/components/layout/display_list/stacking_context.rs
+++ b/components/layout/display_list/stacking_context.rs
@@ -42,11 +42,34 @@ use crate::fragment_tree::{
     FragmentTree, PositioningFragment,
 };
 use crate::geom::{
-    
     AuOrAuto, LengthPercentageOrAuto, PhysicalPoint, PhysicalRect, PhysicalSides, PhysicalSize,
-, PhysicalVec,
+    PhysicalVec,
 };
 use crate::style_ext::{ComputedValuesExt, TransformExt};
+
+#[derive(Copy, Clone, Debug)]
+pub(crate) struct StickyData {
+    /// The size of the parent scroll frame of this containing block, used for resolving
+    /// sticky margins.
+    scroll_frame_size: LayoutSize,
+
+    /// Whether the containing block that contains this sticky data
+    /// is in a scroll frame.
+    is_in_scroll_frame: bool,
+}
+
+impl StickyData {
+    pub(crate) fn enter_scroll_frame(scroll_frame_size: LayoutSize) -> Self {
+        Self {
+            scroll_frame_size,
+            is_in_scroll_frame: true,
+        }
+    }
+
+    pub(crate) fn leave_scroll_frame(&mut self) {
+        self.is_in_scroll_frame = false;
+    }
+}
 
 #[derive(Clone)]
 pub(crate) struct ContainingBlock {
@@ -54,10 +77,10 @@ pub(crate) struct ContainingBlock {
     /// of this containing block.
     scroll_node_id: ScrollTreeNodeId,
 
-    /// The size of the parent scroll frame of this containing block, used for resolving
-    /// sticky margins. If this is None, then this is a direct descendant of a reference
+    /// The sticky data for this containing block, if any.
+    /// If this is None, then this is a direct descendant of a reference
     /// frame and sticky positioning isn't taken into account.
-    scroll_frame_size: Option<LayoutSize>,
+    sticky_data: Option<StickyData>,
 
     /// The [`ClipId`] to use for the children of this containing block.
     clip_id: ClipId,
@@ -77,13 +100,13 @@ impl ContainingBlock {
     pub(crate) fn new(
         rect: PhysicalRect<Au>,
         scroll_node_id: ScrollTreeNodeId,
-        scroll_frame_size: Option<LayoutSize>,
+        sticky_data: Option<StickyData>,
         clip_id: ClipId,
         accumulated_reference_frame_offset: PhysicalVec<Au>,
     ) -> Self {
         ContainingBlock {
             scroll_node_id,
-            scroll_frame_size,
+            sticky_data,
             clip_id,
             rect,
             accumulated_reference_frame_offset,
@@ -149,7 +172,7 @@ impl StackingContextTree {
         let cb_for_non_fixed_descendants = ContainingBlock::new(
             fragment_tree.initial_containing_block,
             root_scroll_node_id,
-            Some(viewport_size),
+            Some(StickyData::enter_scroll_frame(viewport_size)),
             ClipId::INVALID,
             PhysicalVec::zero(),
         );
@@ -673,14 +696,14 @@ impl BoxFragment {
             return;
         };
 
-        let new_scroll_frame_size = containing_block_info
+        let mut new_sticky_data = containing_block_info
             .for_non_absolute_descendants
-            .scroll_frame_size;
+            .sticky_data;
         let spatial_id = self.build_sticky_frame_if_necessary(
             stacking_context_tree,
             containing_block.scroll_node_id,
             &containing_block.rect,
-            &new_scroll_frame_size,
+            &new_sticky_data,
         );
 
         let clip_id = self.build_clip_frame_if_necessary(
@@ -702,7 +725,10 @@ impl BoxFragment {
             )
             .or(clip_id);
 
-        let containing_block = if clip_id.is_some() || spatial_id.is_some() {
+        let containing_block = if clip_id.is_some() ||
+            spatial_id.is_some() ||
+            (new_sticky_data.is_some_and(|s| s.is_in_scroll_frame))
+        {
             if let Some(clip_id) = clip_id {
                 self.set_generated_clip_id(clip_id);
             }
@@ -773,9 +799,12 @@ impl BoxFragment {
 
         // We want to build the scroll frame after the background and border, because
         // they shouldn't scroll with the rest of the box content.
-        let mut new_scroll_frame_size = containing_block_info
+        let mut new_sticky_data = containing_block_info
             .for_non_absolute_descendants
-            .scroll_frame_size;
+            .sticky_data;
+        if let Some(ref mut sticky_data) = new_sticky_data {
+            sticky_data.leave_scroll_frame();
+        }
         let mut new_clip_id = containing_block.clip_id;
         if let Some(overflow_frame_data) = self.build_overflow_frame_if_necessary(
             stacking_context_tree,
@@ -788,7 +817,9 @@ impl BoxFragment {
 
             if let Some(scroll_frame_data) = overflow_frame_data.scroll_frame_data {
                 new_scroll_node_id = scroll_frame_data.scroll_tree_node_id;
-                new_scroll_frame_size = Some(scroll_frame_data.scroll_frame_rect.size());
+                new_sticky_data = Some(StickyData::enter_scroll_frame(
+                    scroll_frame_data.scroll_frame_rect.size(),
+                ));
                 self.set_generated_scroll_tree_node_id(new_scroll_node_id);
             }
         }
@@ -803,14 +834,14 @@ impl BoxFragment {
         let for_absolute_descendants = ContainingBlock::new(
             padding_rect,
             new_scroll_node_id,
-            new_scroll_frame_size,
+            new_sticky_data,
             new_clip_id,
             containing_block.accumulated_reference_frame_offset,
         );
         let for_non_absolute_descendants = ContainingBlock::new(
             content_rect,
             new_scroll_node_id,
-            new_scroll_frame_size,
+            new_sticky_data,
             new_clip_id,
             containing_block.accumulated_reference_frame_offset,
         );
@@ -1025,15 +1056,15 @@ impl BoxFragment {
         stacking_context_tree: &mut StackingContextTree,
         parent_scroll_node_id: ScrollTreeNodeId,
         containing_block_rect: &PhysicalRect<Au>,
-        scroll_frame_size: &Option<LayoutSize>,
+        sticky_data: &Option<StickyData>,
     ) -> Option<ScrollTreeNodeId> {
         let style = self.style();
         if style.get_box().position != ComputedPosition::Sticky {
             return None;
         }
 
-        let scroll_frame_size_for_resolve = match scroll_frame_size {
-            Some(size) => size,
+        let scroll_frame_size_for_resolve = match sticky_data {
+            Some(data) => &data.scroll_frame_size,
             None => {
                 // This is a direct descendant of a reference frame.
                 &stacking_context_tree
@@ -1057,9 +1088,9 @@ impl BoxFragment {
         );
         self.set_resolved_sticky_insets(offsets);
 
-        if scroll_frame_size.is_none() {
+        let Some(sticky_data) = sticky_data else {
             return None;
-        }
+        };
 
         if offsets.top.is_auto() &&
             offsets.right.is_auto() &&
@@ -1095,16 +1126,7 @@ impl BoxFragment {
             .get_node(parent_scroll_node_id);
         let sticky_offset_boundary = match parent_scroll_node.info {
             SpatialTreeNodeInfo::Scroll(ref scrollable_node_info) => {
-                let cb_rect_wr = containing_block_rect.to_webrender();
-                let clip_rect = scrollable_node_info.clip_rect;
-                // When the scroll container IS the containing block, the containing
-                // block rect (content box) is inset within the clip_rect (padding box)
-                // by exactly the scroll container's padding.
-                let scroll_container_is_cb = clip_rect.min.x <= cb_rect_wr.min.x &&
-                    clip_rect.min.y <= cb_rect_wr.min.y &&
-                    clip_rect.max.x >= cb_rect_wr.max.x &&
-                    clip_rect.max.y >= cb_rect_wr.max.y;
-                if scroll_container_is_cb {
+                if sticky_data.is_in_scroll_frame {
                     let content_rect = &scrollable_node_info.content_rect;
                     &PhysicalRect::new(
                         PhysicalPoint::new(

--- a/components/layout/display_list/stacking_context.rs
+++ b/components/layout/display_list/stacking_context.rs
@@ -74,7 +74,7 @@ pub(crate) struct ContainingBlock {
     /// containing block.
     accumulated_reference_frame_offset: PhysicalVec<Au>,
 
-    /// Whether current containing block established a scroll frome.
+    /// Whether current containing block established a scroll frame.
     established_scroll_frame: bool,
 }
 
@@ -1148,22 +1148,18 @@ impl BoxFragment {
             .scroll_tree
             .get_node(parent_scroll_node_id);
         let sticky_offset_boundary = match parent_scroll_node.info {
-            SpatialTreeNodeInfo::Scroll(ref scrollable_node_info) => {
-                if established_scroll_frame {
-                    let content_rect = &scrollable_node_info.content_rect;
-                    &PhysicalRect::new(
-                        PhysicalPoint::new(
-                            Au::from_f32_px(content_rect.min.x),
-                            Au::from_f32_px(content_rect.min.y),
-                        ),
-                        PhysicalSize::new(
-                            Au::from_f32_px(content_rect.max.x - content_rect.min.x),
-                            Au::from_f32_px(content_rect.max.y - content_rect.min.y),
-                        ),
-                    )
-                } else {
-                    containing_block_rect
-                }
+            SpatialTreeNodeInfo::Scroll(ref scrollable_node_info) if established_scroll_frame => {
+                let content_rect = &scrollable_node_info.content_rect;
+                &PhysicalRect::new(
+                    PhysicalPoint::new(
+                        Au::from_f32_px(content_rect.min.x),
+                        Au::from_f32_px(content_rect.min.y),
+                    ),
+                    PhysicalSize::new(
+                        Au::from_f32_px(content_rect.max.x - content_rect.min.x),
+                        Au::from_f32_px(content_rect.max.y - content_rect.min.y),
+                    ),
+                )
             },
             _ => containing_block_rect,
         };

--- a/components/layout/display_list/stacking_context.rs
+++ b/components/layout/display_list/stacking_context.rs
@@ -45,7 +45,8 @@ use crate::fragment_tree::{
     Fragment, FragmentFlags, FragmentTree, PositioningFragment,
 };
 use crate::geom::{
-    AuOrAuto, LengthPercentageOrAuto, PhysicalPoint, PhysicalRect, PhysicalSides, PhysicalVec,
+    AuOrAuto, LengthPercentageOrAuto, PhysicalPoint, PhysicalRect, PhysicalSides, PhysicalSize,
+    PhysicalVec,
 };
 use crate::style_ext::{ComputedValuesExt, TransformExt};
 
@@ -72,6 +73,9 @@ pub(crate) struct ContainingBlock {
     /// accumulated offset from the origin of the parent reference frame of this
     /// containing block.
     accumulated_reference_frame_offset: PhysicalVec<Au>,
+
+    /// Whether current containing block established a scroll frome.
+    established_scroll_frame: bool,
 }
 
 impl ContainingBlock {
@@ -81,6 +85,7 @@ impl ContainingBlock {
         scroll_frame_size: Option<LayoutSize>,
         clip_id: ClipId,
         accumulated_reference_frame_offset: PhysicalVec<Au>,
+        established_scroll_frame: bool,
     ) -> Self {
         ContainingBlock {
             scroll_node_id,
@@ -88,6 +93,7 @@ impl ContainingBlock {
             clip_id,
             rect,
             accumulated_reference_frame_offset,
+            established_scroll_frame,
         }
     }
 
@@ -153,6 +159,7 @@ impl StackingContextTree {
             Some(viewport_size),
             ClipId::INVALID,
             PhysicalVec::zero(),
+            true,
         );
         let cb_for_fixed_descendants = ContainingBlock::new(
             fragment_tree.initial_containing_block,
@@ -160,6 +167,7 @@ impl StackingContextTree {
             None,
             ClipId::INVALID,
             PhysicalVec::zero(),
+            false,
         );
 
         // We need to specify all three containing blocks here, because absolute
@@ -657,6 +665,7 @@ impl BoxFragment {
             None,
             ClipId::INVALID,
             containing_block.accumulated_reference_frame_offset + reference_frame_offset,
+            false,
         );
         let new_containing_block_info =
             containing_block_info.new_for_non_absolute_descendants(&adjusted_containing_block);
@@ -709,6 +718,7 @@ impl BoxFragment {
             containing_block.scroll_node_id,
             &containing_block.rect,
             &new_scroll_frame_size,
+            containing_block.established_scroll_frame,
         );
 
         let clip_id = with_style.build_clip_frame_if_necessary(
@@ -806,6 +816,13 @@ impl BoxFragmentWithStyle<'_> {
         let mut new_scroll_frame_size = containing_block_info
             .for_non_absolute_descendants
             .scroll_frame_size;
+
+        let mut established_scroll_frame = containing_block.established_scroll_frame;
+        // We want to skip leaving scroll frame for anonymous fragments,
+        // because anonymous fragment belong to same node as its closest non-anonymous child.
+        if established_scroll_frame && !self.base.is_anonymous() {
+            established_scroll_frame = false;
+        }
         let mut new_clip_id = containing_block.clip_id;
         if let Some(overflow_frame_data) = self.build_overflow_frame_if_necessary(
             stacking_context_tree,
@@ -819,6 +836,7 @@ impl BoxFragmentWithStyle<'_> {
             if let Some(scroll_frame_data) = overflow_frame_data.scroll_frame_data {
                 new_scroll_node_id = scroll_frame_data.scroll_tree_node_id;
                 new_scroll_frame_size = Some(scroll_frame_data.scroll_frame_rect.size());
+                established_scroll_frame = true;
                 self.set_generated_scroll_tree_node_id(new_scroll_node_id);
             }
         }
@@ -836,6 +854,7 @@ impl BoxFragmentWithStyle<'_> {
             new_scroll_frame_size,
             new_clip_id,
             containing_block.accumulated_reference_frame_offset,
+            established_scroll_frame,
         );
         let for_non_absolute_descendants = ContainingBlock::new(
             content_rect,
@@ -843,6 +862,7 @@ impl BoxFragmentWithStyle<'_> {
             new_scroll_frame_size,
             new_clip_id,
             containing_block.accumulated_reference_frame_offset,
+            established_scroll_frame,
         );
 
         // Create a new `ContainingBlockInfo` for descendants depending on
@@ -1059,6 +1079,7 @@ impl BoxFragment {
         parent_scroll_node_id: ScrollTreeNodeId,
         containing_block_rect: &PhysicalRect<Au>,
         scroll_frame_size: &Option<LayoutSize>,
+        established_scroll_frame: bool,
     ) -> Option<ScrollTreeNodeId> {
         let style = self.style();
         if style.get_box().position != ComputedPosition::Sticky {
@@ -1122,17 +1143,39 @@ impl BoxFragment {
         // The logic below is a simplified (but equivalent) version of the description above.
         let border_rect = self.border_rect();
         let computed_margin = style.physical_margin();
-
+        let parent_scroll_node = stacking_context_tree
+            .paint_info
+            .scroll_tree
+            .get_node(parent_scroll_node_id);
+        let sticky_offset_boundary = match parent_scroll_node.info {
+            SpatialTreeNodeInfo::Scroll(ref scrollable_node_info) => {
+                if established_scroll_frame {
+                    let content_rect = &scrollable_node_info.content_rect;
+                    &PhysicalRect::new(
+                        PhysicalPoint::new(
+                            Au::from_f32_px(content_rect.min.x),
+                            Au::from_f32_px(content_rect.min.y),
+                        ),
+                        PhysicalSize::new(
+                            Au::from_f32_px(content_rect.max.x - content_rect.min.x),
+                            Au::from_f32_px(content_rect.max.y - content_rect.min.y),
+                        ),
+                    )
+                } else {
+                    containing_block_rect
+                }
+            },
+            _ => containing_block_rect,
+        };
         // Signed distance between each side of the border box to the corresponding side of the
         // containing block. Note that |border_rect| is already in the coordinate system of the
         // containing block.
         let distance_from_border_box_to_cb = PhysicalSides::new(
             border_rect.min_y(),
-            containing_block_rect.width() - border_rect.max_x(),
-            containing_block_rect.height() - border_rect.max_y(),
+            sticky_offset_boundary.width() - border_rect.max_x(),
+            sticky_offset_boundary.height() - border_rect.max_y(),
             border_rect.min_x(),
         );
-
         // Shrinks the signed distance by the margin, producing a limit on how much we can shift
         // the sticky positioned box without forcing the margin to move outside of the containing
         // block.

--- a/tests/wpt/meta/css/css-position/sticky/position-sticky-child-multicolumn.html.ini
+++ b/tests/wpt/meta/css/css-position/sticky/position-sticky-child-multicolumn.html.ini
@@ -1,2 +1,0 @@
-[position-sticky-child-multicolumn.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-position/sticky/position-sticky-get-bounding-client-rect.html.ini
+++ b/tests/wpt/meta/css/css-position/sticky/position-sticky-get-bounding-client-rect.html.ini
@@ -1,9 +1,0 @@
-[position-sticky-get-bounding-client-rect.html]
-  [sticky positioned element should be observable by getBoundingClientRect.]
-    expected: FAIL
-
-  [getBoundingClientRect should be correct for sticky after script insertion]
-    expected: FAIL
-
-  [getBoundingClientRect should be correct for sticky after script-caused layout]
-    expected: FAIL

--- a/tests/wpt/meta/css/css-position/sticky/position-sticky-hyperlink.html.ini
+++ b/tests/wpt/meta/css/css-position/sticky/position-sticky-hyperlink.html.ini
@@ -1,2 +1,0 @@
-[position-sticky-hyperlink.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-position/sticky/position-sticky-input-box-gets-focused-after-scroll.html.ini
+++ b/tests/wpt/meta/css/css-position/sticky/position-sticky-input-box-gets-focused-after-scroll.html.ini
@@ -1,0 +1,3 @@
+[position-sticky-input-box-gets-focused-after-scroll.html]
+  [Focusing on visible sticky input box should reset the scroll to unshifted sticky position.]
+    expected: FAIL

--- a/tests/wpt/meta/css/css-position/sticky/position-sticky-input-box-gets-focused-after-scroll.html.ini
+++ b/tests/wpt/meta/css/css-position/sticky/position-sticky-input-box-gets-focused-after-scroll.html.ini
@@ -1,3 +1,0 @@
-[position-sticky-input-box-gets-focused-after-scroll.html]
-  [Focusing on visible sticky input box should reset the scroll to unshifted sticky position.]
-    expected: FAIL

--- a/tests/wpt/meta/css/css-position/sticky/position-sticky-large-top.tentative.html.ini
+++ b/tests/wpt/meta/css/css-position/sticky/position-sticky-large-top.tentative.html.ini
@@ -1,2 +1,0 @@
-[position-sticky-large-top.tentative.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-position/sticky/position-sticky-left-and-right-overconstrained.html.ini
+++ b/tests/wpt/meta/css/css-position/sticky/position-sticky-left-and-right-overconstrained.html.ini
@@ -4,9 +4,3 @@
 
   [right before the in-flow position of the sticky box]
     expected: FAIL
-
-  [right after the in-flow position the sticky box]
-    expected: FAIL
-
-  [end of scroll container]
-    expected: FAIL

--- a/tests/wpt/meta/css/css-position/sticky/position-sticky-offset-top-left.html.ini
+++ b/tests/wpt/meta/css/css-position/sticky/position-sticky-offset-top-left.html.ini
@@ -1,6 +1,0 @@
-[position-sticky-offset-top-left.html]
-  [offsetTop/offsetLeft should be correct for sticky after script insertion]
-    expected: FAIL
-
-  [offsetTop/offsetLeft should be correct for sticky after script-caused layout]
-    expected: FAIL

--- a/tests/wpt/meta/css/css-position/sticky/position-sticky-top-and-bottom-003.html.ini
+++ b/tests/wpt/meta/css/css-position/sticky/position-sticky-top-and-bottom-003.html.ini
@@ -1,2 +1,0 @@
-[position-sticky-top-and-bottom-003.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-position/sticky/position-sticky-top-and-bottom-overconstrained.html.ini
+++ b/tests/wpt/meta/css/css-position/sticky/position-sticky-top-and-bottom-overconstrained.html.ini
@@ -4,9 +4,3 @@
 
   [right before the in-flow position of the sticky box]
     expected: FAIL
-
-  [right after the in-flow position the sticky box]
-    expected: FAIL
-
-  [end of scroll container]
-    expected: FAIL

--- a/tests/wpt/meta/css/css-position/sticky/sticky-after-input.html.ini
+++ b/tests/wpt/meta/css/css-position/sticky/sticky-after-input.html.ini
@@ -1,0 +1,3 @@
+[sticky-after-input.html]
+  [Sticky positioned element should reset the scroll position to unshifted position]
+    expected: FAIL

--- a/tests/wpt/meta/css/cssom-view/scrollIntoView-stuck.tentative.html.ini
+++ b/tests/wpt/meta/css/cssom-view/scrollIntoView-stuck.tentative.html.ini
@@ -1,3 +1,0 @@
-[scrollIntoView-stuck.tentative.html]
-  [CSSOM View - scrollIntoView doesn't consider scroll-padding when target is stuck]
-    expected: FAIL


### PR DESCRIPTION
When `build_sticky_frame_if_necessary`, if the containing block is scrollable, we should use its content rect to calculate sticky offset boundary.

Testing: More WPTs are passing, while the new failure related to input focus should be falsely passed previously.
Fixes: #38259
