### PR TITLE
devtools: Rename FrameActor variable names

### DIFF
--- a/components/devtools/actors/thread.rs
+++ b/components/devtools/actors/thread.rs
@@ -243,7 +243,7 @@ impl Actor for ThreadActor {
                     from: self.name(),
                     frames: result
                         .iter()
-                        .map(|frame| registry.encode::<FrameActor, _>(frame))
+                        .map(|frame_name| registry.encode::<FrameActor, _>(frame_name))
                         .collect(),
                 };
                 request.reply_final(&msg)?

--- a/components/devtools/lib.rs
+++ b/components/devtools/lib.rs
@@ -823,14 +823,14 @@ impl DevtoolsInstance {
             name: pause.clone(),
         });
 
-        let frame = self.registry.find::<FrameActor>(&frame_offset.actor);
-        frame.set_offset(frame_offset.column, frame_offset.line);
+        let frame_actor = self.registry.find::<FrameActor>(&frame_offset.actor);
+        frame_actor.set_offset(frame_offset.column, frame_offset.line);
 
         let msg = ThreadInterruptedReply {
             from: thread.name(),
             type_: "paused".to_owned(),
             actor: pause,
-            frame: frame.encode(&self.registry),
+            frame: frame_actor.encode(&self.registry),
             why: pause_reason,
         };
 
@@ -871,9 +871,9 @@ impl DevtoolsInstance {
             },
         };
 
-        let frame = FrameActor::register(&self.registry, source, frame);
+        let frame_name = FrameActor::register(&self.registry, source, frame);
 
-        let _ = result_sender.send(frame);
+        let _ = result_sender.send(frame_name);
     }
 
     fn handle_create_environment_actor(


### PR DESCRIPTION
Renamed FrameActor variable names to match standards in thread & lib.rs

Testing: No testing required.
Fixes: Part of #43606
