### PR TITLE
script: Use `TextInputWidget` to implement `<textarea>` shadow DOM

### DIFF
--- a/components/layout/stylesheets/servo.css
+++ b/components/layout/stylesheets/servo.css
@@ -42,11 +42,6 @@ textarea:disabled {
   border-color: lightgrey;
 }
 
-input::-servo-text-control-inner-editor {
-  overflow-wrap: normal;
-  pointer-events: auto;
-}
-
 /* FIXME(#36982): Use `display: block; align-content: center` instead of flex. */
 input::-servo-text-control-inner-container {
   display: flex;
@@ -55,23 +50,46 @@ input::-servo-text-control-inner-container {
   position: relative;
 }
 
-input:not(:placeholder-shown)::placeholder {
-  visibility: hidden !important;
-}
-
-input::-servo-text-control-inner-editor, input::placeholder {
+input::-servo-text-control-inner-editor,
+input::placeholder {
+  /* This limits the block size of the inner div to that of the text size so that
+     it can be centered in the container. This is only necessary for <input>. */
   block-size: fit-content !important;
   inset-block: 0 !important;
   margin-block: auto !important;
-  min-width: stretch;
   white-space: pre;
 }
 
-input::placeholder {
+input::-servo-text-control-inner-editor,
+input::placeholder,
+textarea::-servo-text-control-inner-editor,
+textarea::placeholder {
+  min-width: stretch;
+  overflow-wrap: normal;
+}
+
+input:not(:placeholder-shown)::placeholder,
+textarea:not(:placeholder-shown)::placeholder {
+  display: none !important;
+}
+
+input:placeholder-shown::-servo-text-control-inner-editor,
+textarea:placeholder-shown::-servo-text-control-inner-editor {
+  display: none !important;
+}
+
+input::placeholder,
+textarea::placeholder {
   color: grey;
   overflow: hidden;
+}
+
+input::-servo-text-control-inner-editor {
+  pointer-events: auto !important;
+}
+
+input::placeholder {
   pointer-events: none !important;
-  position: absolute !important;
 }
 
 input::selection,

--- a/components/script/dom/html/htmltextareaelement.rs
+++ b/components/script/dom/html/htmltextareaelement.rs
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-use std::cell::{Cell, RefCell};
+use std::cell::{Cell, Ref, RefCell};
 use std::default::Default;
 
 use dom_struct::dom_struct;
@@ -12,8 +12,6 @@ use html5ever::{LocalName, Prefix, local_name, ns};
 use js::context::JSContext;
 use js::rust::HandleObject;
 use layout_api::wrapper_traits::{ScriptSelection, SharedSelection};
-use script_bindings::codegen::GenericBindings::CharacterDataBinding::CharacterDataMethods;
-use script_bindings::root::Dom;
 use servo_base::text::Utf16CodeUnitLength;
 use style::attr::AttrValue;
 use stylo_dom::ElementState;
@@ -39,14 +37,14 @@ use crate::dom::html::htmlelement::HTMLElement;
 use crate::dom::html::htmlfieldsetelement::HTMLFieldSetElement;
 use crate::dom::html::htmlformelement::{FormControl, HTMLFormElement};
 use crate::dom::html::input_element::HTMLInputElement;
+use crate::dom::htmlinputelement::text_input_widget::TextInputWidget;
 use crate::dom::keyboardevent::KeyboardEvent;
 use crate::dom::node::{
     BindContext, ChildrenMutation, CloneChildrenFlag, Node, NodeDamage, NodeTraits, UnbindContext,
 };
 use crate::dom::nodelist::NodeList;
-use crate::dom::text::Text;
 use crate::dom::textcontrol::{TextControlElement, TextControlSelection};
-use crate::dom::types::{CharacterData, FocusEvent, MouseEvent};
+use crate::dom::types::{FocusEvent, MouseEvent};
 use crate::dom::validation::{Validatable, is_barred_by_datalist_ancestor};
 use crate::dom::validitystate::{ValidationFlags, ValidityState};
 use crate::dom::virtualmethods::VirtualMethods;
@@ -64,9 +62,8 @@ pub(crate) struct HTMLTextAreaElement {
     form_owner: MutNullableDom<HTMLFormElement>,
     labels_node_list: MutNullableDom<NodeList>,
     validity_state: MutNullableDom<ValidityState>,
-    /// A DOM [`Text`] node that is the stored in the root of this [`HTMLTextArea`]'s
-    /// shadow tree. This how content from the text area is exposed to layout.
-    shadow_node: DomRefCell<Option<Dom<Text>>>,
+    /// A [`TextInputWidget`] that manages the shadow DOM for this `<textarea>`.
+    text_input_widget: DomRefCell<TextInputWidget>,
     /// A [`SharedSelection`] that is shared with layout. This can be updated dyanmnically
     /// and layout should reflect the new value after a display list update.
     #[no_trace]
@@ -138,7 +135,7 @@ impl HTMLTextAreaElement {
             form_owner: Default::default(),
             labels_node_list: Default::default(),
             validity_state: Default::default(),
-            shadow_node: Default::default(),
+            text_input_widget: Default::default(),
             shared_selection: Default::default(),
         }
     }
@@ -210,48 +207,16 @@ impl HTMLTextAreaElement {
         self.validity_state(CanGc::from_cx(cx))
             .perform_validation_and_update(ValidationFlags::all(), CanGc::from_cx(cx));
 
-        let textinput_content = self.textinput.borrow().get_content();
-        let element = self.upcast::<Element>();
         let placeholder_shown =
-            textinput_content.is_empty() && !self.placeholder.borrow().is_empty();
-        element.set_placeholder_shown_state(placeholder_shown);
+            self.textinput.borrow().is_empty() && !self.placeholder.borrow().is_empty();
+        self.upcast::<Element>()
+            .set_placeholder_shown_state(placeholder_shown);
 
-        let shadow_root = element
-            .shadow_root()
-            .unwrap_or_else(|| element.attach_ua_shadow_root(cx, true));
-        if self.shadow_node.borrow().is_none() {
-            let shadow_node = Text::new(
-                Default::default(),
-                &shadow_root.owner_document(),
-                CanGc::from_cx(cx),
-            );
-            Node::replace_all(cx, Some(shadow_node.upcast()), shadow_root.upcast());
-            self.shadow_node
-                .borrow_mut()
-                .replace(shadow_node.as_traced());
-        }
-
-        let content = if placeholder_shown {
-            self.placeholder.borrow().clone()
-        } else if textinput_content.is_empty() {
-            // The addition of zero-width space here forces the text input to have an inline formatting
-            // context that might otherwise be trimmed if there's no text. This is important to ensure
-            // that the input element is at least as tall as the line gap of the caret:
-            // <https://drafts.csswg.org/css-ui/#element-with-default-preferred-size>.
-            "\u{200B}".into()
-        } else {
-            textinput_content
-        };
-
-        let shadow_node = self.shadow_node.borrow_mut();
-        let character_data = shadow_node
-            .as_ref()
-            .expect("Should have always created a node at this point.")
-            .upcast::<CharacterData>();
-        if character_data.Data() != content {
-            character_data.SetData(content);
-            self.maybe_update_shared_selection();
-        }
+        self.text_input_widget.borrow().update_shadow_tree(cx, self);
+        self.text_input_widget
+            .borrow()
+            .update_placeholder_contents(cx, self);
+        self.maybe_update_shared_selection();
     }
 
     fn handle_mouse_event(&self, mouse_event: &MouseEvent) {
@@ -316,6 +281,14 @@ impl TextControlElement for HTMLTextAreaElement {
             enabled,
         };
         self.owner_window().layout().set_needs_new_display_list();
+    }
+
+    fn placeholder_text<'a>(&'a self) -> Ref<'a, DOMString> {
+        self.placeholder.borrow()
+    }
+
+    fn value_text(&self) -> DOMString {
+        self.Value()
     }
 }
 

--- a/components/script/dom/html/input_element/mod.rs
+++ b/components/script/dom/html/input_element/mod.rs
@@ -905,10 +905,6 @@ impl HTMLInputElement {
     fn textinput_mut(&self) -> RefMut<'_, TextInput<EmbedderClipboardProvider>> {
         self.textinput.borrow_mut()
     }
-
-    fn placeholder(&self) -> Ref<'_, DOMString> {
-        self.placeholder.borrow()
-    }
 }
 
 pub(crate) trait LayoutHTMLInputElementHelpers<'dom> {
@@ -992,6 +988,18 @@ impl TextControlElement for HTMLInputElement {
             enabled,
         };
         self.owner_window().layout().set_needs_new_display_list();
+    }
+
+    fn is_password_field(&self) -> bool {
+        matches!(*self.input_type(), InputType::Password(_))
+    }
+
+    fn placeholder_text<'a>(&'a self) -> Ref<'a, DOMString> {
+        self.placeholder.borrow()
+    }
+
+    fn value_text(&self) -> DOMString {
+        self.Value()
     }
 }
 

--- a/components/script/dom/html/input_element/text_input_widget.rs
+++ b/components/script/dom/html/input_element/text_input_widget.rs
@@ -8,7 +8,6 @@ use js::context::JSContext;
 use markup5ever::QualName;
 use script_bindings::codegen::GenericBindings::CharacterDataBinding::CharacterDataMethods;
 use script_bindings::codegen::GenericBindings::DocumentBinding::DocumentMethods;
-use script_bindings::codegen::GenericBindings::HTMLInputElementBinding::HTMLInputElementMethods;
 use script_bindings::codegen::GenericBindings::NodeBinding::NodeMethods;
 use script_bindings::inheritance::Castable;
 use script_bindings::root::{Dom, DomRoot};
@@ -19,9 +18,8 @@ use crate::dom::bindings::cell::DomRefCell;
 use crate::dom::characterdata::CharacterData;
 use crate::dom::document::Document;
 use crate::dom::element::{CustomElementCreationMode, Element, ElementCreator};
-use crate::dom::htmlinputelement::HTMLInputElement;
-use crate::dom::htmlinputelement::input_type::InputType;
 use crate::dom::node::{Node, NodeTraits};
+use crate::dom::textcontrol::TextControlElement;
 
 const PASSWORD_REPLACEMENT_CHAR: char = '●';
 
@@ -37,7 +35,7 @@ impl TextInputWidget {
     fn get_or_create_shadow_tree(
         &self,
         cx: &mut JSContext,
-        input: &HTMLInputElement,
+        text_control_element: &impl TextControlElement,
     ) -> Ref<'_, TextInputWidgetShadowTree> {
         {
             if let Ok(shadow_tree) = Ref::filter_map(self.shadow_tree.borrow(), |shadow_tree| {
@@ -47,22 +45,26 @@ impl TextInputWidget {
             }
         }
 
-        let element = input.upcast::<Element>();
+        let element = text_control_element.upcast::<Element>();
         let shadow_root = element
             .shadow_root()
             .unwrap_or_else(|| element.attach_ua_shadow_root(cx, true));
         let shadow_root = shadow_root.upcast();
         *self.shadow_tree.borrow_mut() = Some(TextInputWidgetShadowTree::new(cx, shadow_root));
-        self.get_or_create_shadow_tree(cx, input)
+        self.get_or_create_shadow_tree(cx, text_control_element)
     }
 
-    pub(crate) fn update_shadow_tree(&self, cx: &mut JSContext, input: &HTMLInputElement) {
-        self.get_or_create_shadow_tree(cx, input).update(input)
+    pub(crate) fn update_shadow_tree(&self, cx: &mut JSContext, element: &impl TextControlElement) {
+        self.get_or_create_shadow_tree(cx, element).update(element)
     }
 
-    pub(crate) fn update_placeholder_contents(&self, cx: &mut JSContext, input: &HTMLInputElement) {
-        self.get_or_create_shadow_tree(cx, input)
-            .update_placeholder(cx, input);
+    pub(crate) fn update_placeholder_contents(
+        &self,
+        cx: &mut JSContext,
+        element: &impl TextControlElement,
+    ) {
+        self.get_or_create_shadow_tree(cx, element)
+            .update_placeholder(cx, element);
     }
 }
 
@@ -131,20 +133,21 @@ impl TextInputWidgetShadowTree {
     fn init_placeholder_container_if_necessary(
         &self,
         cx: &mut JSContext,
-        host: &HTMLInputElement,
+        element: &impl TextControlElement,
     ) -> Option<DomRoot<Element>> {
         if let Some(placeholder_container) = &*self.placeholder_container.borrow() {
             return Some(placeholder_container.root_element());
         }
         // If there is no placeholder text and we haven't already created one then it is
         // not necessary to initialize a new placeholder container.
-        if host.placeholder().is_empty() {
+        let placeholder = element.placeholder_text();
+        if placeholder.is_empty() {
             return None;
         }
 
         let placeholder_container = create_ua_widget_div_with_text_node(
             cx,
-            &host.owner_document(),
+            &element.owner_document(),
             self.inner_container.upcast::<Node>(),
             PseudoElement::Placeholder,
             true,
@@ -156,20 +159,20 @@ impl TextInputWidgetShadowTree {
     fn placeholder_character_data(
         &self,
         cx: &mut JSContext,
-        input_element: &HTMLInputElement,
+        element: &impl TextControlElement,
     ) -> Option<DomRoot<CharacterData>> {
-        self.init_placeholder_container_if_necessary(cx, input_element)
+        self.init_placeholder_container_if_necessary(cx, element)
             .and_then(|placeholder_container| {
                 let first_child = placeholder_container.upcast::<Node>().GetFirstChild()?;
                 Some(DomRoot::from_ref(first_child.downcast::<CharacterData>()?))
             })
     }
 
-    pub(crate) fn update_placeholder(&self, cx: &mut JSContext, input_element: &HTMLInputElement) {
-        if let Some(character_data) = self.placeholder_character_data(cx, input_element) {
-            let placeholder_value = input_element.placeholder().clone();
-            if character_data.Data() != placeholder_value {
-                character_data.SetData(placeholder_value);
+    pub(crate) fn update_placeholder(&self, cx: &mut JSContext, element: &impl TextControlElement) {
+        if let Some(character_data) = self.placeholder_character_data(cx, element) {
+            let placeholder_value = element.placeholder_text();
+            if character_data.Data() != *placeholder_value {
+                character_data.SetData(placeholder_value.clone());
             }
         }
     }
@@ -185,7 +188,7 @@ impl TextInputWidgetShadowTree {
 
     // TODO(stevennovaryo): The rest of textual input shadow dom structure should act
     // like an exstension to this one.
-    pub(crate) fn update(&self, input_element: &HTMLInputElement) {
+    pub(crate) fn update(&self, element: &impl TextControlElement) {
         // The addition of zero-width space here forces the text input to have an inline formatting
         // context that might otherwise be trimmed if there's no text. This is important to ensure
         // that the input element is at least as tall as the line gap of the caret:
@@ -194,11 +197,10 @@ impl TextInputWidgetShadowTree {
         // This is also used to ensure that the caret will still be rendered when the input is empty.
         // TODO: Could append `<br>` element to prevent collapses and avoid this hack, but we would
         //       need to fix the rendering of caret beforehand.
-        let value = input_element.Value();
-        let input_type = &*input_element.input_type();
-        let value_text = match (value.is_empty(), input_type) {
+        let value = element.value_text();
+        let value_text = match (value.is_empty(), element.is_password_field()) {
             // For a password input, we replace all of the character with its replacement char.
-            (false, InputType::Password(_)) => value
+            (false, true) => value
                 .str()
                 .chars()
                 .map(|_| PASSWORD_REPLACEMENT_CHAR)

--- a/components/script/dom/textcontrol.rs
+++ b/components/script/dom/textcontrol.rs
@@ -7,6 +7,8 @@
 //!
 //! <https://html.spec.whatwg.org/multipage/#textFieldSelection>
 
+use std::cell::Ref;
+
 use servo_base::text::Utf16CodeUnitLength;
 
 use crate::clipboard_provider::EmbedderClipboardProvider;
@@ -18,15 +20,23 @@ use crate::dom::bindings::str::DOMString;
 use crate::dom::event::{EventBubbles, EventCancelable};
 use crate::dom::eventtarget::EventTarget;
 use crate::dom::node::{Node, NodeTraits};
+use crate::dom::types::Element;
 use crate::textinput::{SelectionDirection, SelectionState, TextInput};
 
-pub(crate) trait TextControlElement: DerivedFrom<EventTarget> + DerivedFrom<Node> {
+pub(crate) trait TextControlElement:
+    DerivedFrom<EventTarget> + DerivedFrom<Node> + DerivedFrom<Element>
+{
     fn selection_api_applies(&self) -> bool;
     fn has_selectable_text(&self) -> bool;
     fn has_uncollapsed_selection(&self) -> bool;
     fn set_dirty_value_flag(&self, value: bool);
     fn select_all(&self);
     fn maybe_update_shared_selection(&self);
+    fn is_password_field(&self) -> bool {
+        false
+    }
+    fn placeholder_text<'a>(&'a self) -> Ref<'a, DOMString>;
+    fn value_text(&self) -> DOMString;
 }
 
 pub(crate) struct TextControlSelection<'a, E: TextControlElement> {

--- a/tests/wpt/meta/html/semantics/forms/the-textarea-element/multiline-placeholder-cr.html.ini
+++ b/tests/wpt/meta/html/semantics/forms/the-textarea-element/multiline-placeholder-cr.html.ini
@@ -1,2 +1,0 @@
-[multiline-placeholder-cr.html]
-  expected: FAIL

--- a/tests/wpt/meta/html/semantics/forms/the-textarea-element/multiline-placeholder-crlf.html.ini
+++ b/tests/wpt/meta/html/semantics/forms/the-textarea-element/multiline-placeholder-crlf.html.ini
@@ -1,2 +1,0 @@
-[multiline-placeholder-crlf.html]
-  expected: FAIL

--- a/tests/wpt/meta/html/semantics/forms/the-textarea-element/multiline-placeholder.html.ini
+++ b/tests/wpt/meta/html/semantics/forms/the-textarea-element/multiline-placeholder.html.ini
@@ -1,2 +1,0 @@
-[multiline-placeholder.html]
-  expected: FAIL

--- a/tests/wpt/mozilla/meta/MANIFEST.json
+++ b/tests/wpt/mozilla/meta/MANIFEST.json
@@ -11196,7 +11196,7 @@
      []
     ],
     "textarea_placeholder_ref.html": [
-     "46d2686144f9bf3b33b4954f3667b06d8f6a6117",
+     "ff3893cde8b7445d8a740568899bda489b7e8815",
      []
     ],
     "timer_eventInvalidation_test.html": [

--- a/tests/wpt/mozilla/tests/mozilla/textarea_placeholder_ref.html
+++ b/tests/wpt/mozilla/tests/mozilla/textarea_placeholder_ref.html
@@ -1,11 +1,15 @@
 <!doctype html>
 <meta charset="utf-8">
 
+<style>
+.has-placeholder { color: grey; }
+</style>
+
 <textarea></textarea>
 <textarea></textarea>
-<textarea>foobar</textarea>
-<textarea>  foo  bar  </textarea>
-<textarea rows=5>
+<textarea class="has-placeholder">foobar</textarea>
+<textarea class="has-placeholder">  foo  bar  </textarea>
+<textarea class="has-placeholder" rows=5>
 
  foo
  bar


### PR DESCRIPTION
In addition to making it so that textual `<input>` and `<textarea>`
share a common shadow DOM structure, this allows styling the
`<textarea>` placeholder. It is now properly shown in grey.

Testing: This fixes a few WPT tests.
