### PR TITLE
script: Require HMAC comparison to be constant time

### DIFF
--- a/components/script/dom/subtlecrypto/hmac_operation.rs
+++ b/components/script/dom/subtlecrypto/hmac_operation.rs
@@ -2,6 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
+use aws_lc_rs::constant_time::verify_slices_are_equal;
 use aws_lc_rs::hmac;
 use js::context::JSContext;
 use rand::TryRngCore;
@@ -79,8 +80,9 @@ pub(crate) fn verify(key: &CryptoKey, message: &[u8], signature: &[u8]) -> Resul
     let sign_key = hmac::Key::new(hash_function, key.handle().as_bytes());
     let mac = hmac::sign(&sign_key, message);
 
-    // Step 2. Return true if mac is equal to signature and false otherwise.
-    Ok(mac.as_ref() == signature)
+    // Step 2. Return true if mac is equal to signature and false otherwise. This comparison must
+    // be performed in constant-time.
+    Ok(verify_slices_are_equal(mac.as_ref(), signature).is_ok())
 }
 
 /// <https://w3c.github.io/webcrypto/#hmac-operations-generate-key>


### PR DESCRIPTION
We should compare HMAC signatures in constant time when validating user-provided signatures, to prevent leaking timing information proportional to the number of matching bytes. The WebCrypto specification has also updated to require to use constant-time comparison in HMAC signatures.

We update our implementation accordingly. Since we are still using the `aws-lc-rs` crate for our HMAC implementation, we use the function `verify_slices_are_equal` provided by `aws_lc_rs::constant_time` to guarantees the comparison is constant-time.

Specification Update: https://github.com/w3c/webcrypto/commit/c962bc7ebba3c5995c150ac22d9f38b6e8b2b0be
Testing: Existing tests suffice.