### PR TITLE
script: Guarantee constant-time all-zero check on X25519 secret

### DIFF
--- a/components/script/dom/subtlecrypto/x25519_operation.rs
+++ b/components/script/dom/subtlecrypto/x25519_operation.rs
@@ -67,17 +67,14 @@ pub(crate) fn derive_bits(
     let Handle::X25519PublicKey(public_key) = public_key.handle() else {
         return Err(Error::Operation(None));
     };
-    let shared_key = private_key.diffie_hellman(public_key);
-    let secret = shared_key.as_bytes();
+    let secret = private_key.diffie_hellman(public_key);
 
     // Step 6. If secret is the all-zero value, then throw a OperationError. This check must be
     // performed in constant-time, as per [RFC7748] Section 6.1.
-    let mut is_all_zero = true;
-    for byte in secret {
-        is_all_zero &= *byte == 0;
-    }
-    if is_all_zero {
-        return Err(Error::Operation(None));
+    if !secret.was_contributory() {
+        return Err(Error::Operation(Some(
+            "Secret is the all-zero value".into(),
+        )));
     }
 
     // Step 7.
@@ -88,13 +85,14 @@ pub(crate) fn derive_bits(
     //         throw an OperationError.
     //     Otherwise:
     //         Return a byte sequence containing the first length bits of secret.
+    let secret_slice = secret.as_bytes();
     match length {
-        None => Ok(secret.to_vec()),
+        None => Ok(secret_slice.to_vec()),
         Some(length) => {
-            if secret.len() * 8 < length as usize {
+            if secret_slice.len() * 8 < length as usize {
                 Err(Error::Operation(None))
             } else {
-                let mut secret = secret[..length.div_ceil(8) as usize].to_vec();
+                let mut secret = secret_slice[..length.div_ceil(8) as usize].to_vec();
                 if length % 8 != 0 {
                     // Clean excess bits in last byte of secret.
                     let mask = u8::MAX << (8 - length % 8);


### PR DESCRIPTION
The "deriveBits" operation of X25519 in WebCrypto throws an OperationError when the secret is all-zero value. The check must be done in constant time.

Although our implementation enforces comparing all bytes one-by-one without early exit, it still does not guarantee the `u8` comparison is constant-time due to compiler optimization and CPU microarchitectural effects.

We switch to using the function `was_contributory` provided by the `x25519-dalek` crate to check whether the secret is all-zero value, as it guarantees constant-time execution. This enhances the security of our WebCrypto API.

Testing: Security enhancement. Existing tests suffice.