### PR TITLE
doc: explain how to create a WebView (#43712)

### DIFF
--- a/components/servo/webview.rs
+++ b/components/servo/webview.rs
@@ -49,6 +49,10 @@ pub(crate) const MINIMUM_WEBVIEW_SIZE: Size2D<i32, DevicePixel> = Size2D::new(1,
 /// considers that the webview has closed and will clean up all associated resources related
 /// to this webview.
 ///
+/// ## Creating a WebView
+///
+/// To create a [`WebView`], use [`WebViewBuilder`].
+///
 /// ## Rendering Model
 ///
 /// Every [`WebView`] has a [`RenderingContext`](crate::RenderingContext). The embedder manages when
@@ -893,7 +897,7 @@ impl WebViewTrait for ServoRendererWebView {
     }
 }
 
-/// Builder for [`WebView`].
+/// Builder for creating a [`WebView`].
 pub struct WebViewBuilder {
     servo: Servo,
     rendering_context: Rc<dyn RenderingContext>,


### PR DESCRIPTION
Added a "Creating a WebView" section to the `WebView` doc comment explaining that `WebViewBuilder` is the correct way to create a `WebView`, with a usage example. Also expanded the `WebViewBuilder` doc comment to be more descriptive.
Fixes: #43712

