### PR TITLE
base: Tidy up the usage of `PipelineNamespaceId`

### DIFF
--- a/components/constellation/constellation.rs
+++ b/components/constellation/constellation.rs
@@ -145,7 +145,8 @@ use servo_base::generic_channel::{
     GenericCallback, GenericSend, GenericSender, RoutedReceiver, SendError,
 };
 use servo_base::id::{
-    BrowsingContextGroupId, BrowsingContextId, HistoryStateId, MessagePortId, MessagePortRouterId,
+    BrowsingContextGroupId, BrowsingContextId, CONSTELLATION_PIPELINE_NAMESPACE_ID,
+    FIRST_CONTENT_PIPELINE_NAMESPACE_ID, HistoryStateId, MessagePortId, MessagePortRouterId,
     PainterId, PipelineId, PipelineNamespace, PipelineNamespaceId, PipelineNamespaceRequest,
     ScriptEventLoopId, WebViewId,
 };
@@ -651,8 +652,7 @@ where
 
                 let swmanager_receiver = swmanager_ipc_receiver.route_preserving_errors();
 
-                // Zero is reserved for the embedder.
-                PipelineNamespace::install(PipelineNamespaceId(1));
+                PipelineNamespace::install(CONSTELLATION_PIPELINE_NAMESPACE_ID);
 
                 #[cfg(feature = "webgpu")]
                 let webrender_wgpu = WebRenderWGPU {
@@ -699,9 +699,7 @@ where
                     pipelines: Default::default(),
                     browsing_contexts: Default::default(),
                     pending_changes: vec![],
-                    // We initialize the namespace at 2, since we reserved
-                    // namespace 0 for the embedder, and 0 for the constellation
-                    next_pipeline_namespace_id: Cell::new(PipelineNamespaceId(2)),
+                    next_pipeline_namespace_id: Cell::new(FIRST_CONTENT_PIPELINE_NAMESPACE_ID),
                     time_profiler_chan: state.time_profiler_chan,
                     mem_profiler_chan: state.mem_profiler_chan.clone(),
                     phantom: PhantomData,

--- a/components/servo/servo.rs
+++ b/components/servo/servo.rs
@@ -42,7 +42,7 @@ use script::{JSEngineSetup, ServiceWorkerManager};
 use servo_background_hang_monitor::HangMonitorRegister;
 use servo_base::generic_channel::{GenericCallback, GenericSender, RoutedReceiver};
 pub use servo_base::id::WebViewId;
-use servo_base::id::{PipelineNamespace, PipelineNamespaceId};
+use servo_base::id::{EMBEDDER_PIPELINE_NAMESPACE_ID, PipelineNamespace};
 #[cfg(feature = "bluetooth")]
 use servo_bluetooth::BluetoothThreadFactory;
 #[cfg(feature = "bluetooth")]
@@ -829,7 +829,7 @@ impl Servo {
         }
 
         // Reserving a namespace to create WebViewId.
-        PipelineNamespace::install(PipelineNamespaceId(0));
+        PipelineNamespace::install(EMBEDDER_PIPELINE_NAMESPACE_ID);
 
         // Get both endpoints of a special channel for communication between
         // the client window and `Paint`. This channel is unique because

--- a/components/shared/base/id.rs
+++ b/components/shared/base/id.rs
@@ -251,6 +251,12 @@ thread_local!(pub static PIPELINE_NAMESPACE: Cell<Option<PipelineNamespace>> = c
 )]
 pub struct PipelineNamespaceId(pub u32);
 
+pub const EMBEDDER_PIPELINE_NAMESPACE_ID: PipelineNamespaceId = PipelineNamespaceId(0);
+pub const CONSTELLATION_PIPELINE_NAMESPACE_ID: PipelineNamespaceId = PipelineNamespaceId(1);
+/// The next available [`PipelineNamespaceId`] for the allocation in the constellation. Starting from 2,
+/// since we reserved namespace 0 for the embedder, and 1 for the constellation.
+pub const FIRST_CONTENT_PIPELINE_NAMESPACE_ID: PipelineNamespaceId = PipelineNamespaceId(2);
+
 namespace_id! {PipelineId, PipelineIndex, "Pipeline"}
 
 size_of_test!(PipelineId, 8);


### PR DESCRIPTION
Use constant variable to define the `PipelineNamespaceId` for `Constellation` and `Embedder`, and fix the comment describing the declaration `next_pipeline_namespace_id`.

Testing: A successful build should be enough for the minimal refactoring.