### PR TITLE
Implement SiteDataManager::cookies_for_url_async

### DIFF
--- a/components/net/embedder.rs
+++ b/components/net/embedder.rs
@@ -4,10 +4,12 @@
 
 use std::path::PathBuf;
 
+use cookie::Cookie;
 use embedder_traits::{
     AuthenticationResponse, EmbedderControlId, FilePickerRequest, WebResourceRequest,
     WebResourceResponseMsg,
 };
+use net_traits::CookieOperationId;
 use servo_base::id::WebViewId;
 use servo_url::ServoUrl;
 use tokio::sync::mpsc::UnboundedSender as TokioSender;
@@ -33,4 +35,6 @@ pub enum NetToEmbedderMsg {
         bool, /* for proxy */
         TokioOneshotSender<Option<AuthenticationResponse>>,
     ),
+    /// Response to a [`CoreResourceMsg::EmbedderGetCookiesForUrl`] request.
+    EmbedderGetCookiesForUrlResponse(CookieOperationId, Vec<Cookie<'static>>),
 }

--- a/components/net/embedder.rs
+++ b/components/net/embedder.rs
@@ -37,4 +37,6 @@ pub enum NetToEmbedderMsg {
     ),
     /// Response to a [`CoreResourceMsg::EmbedderGetCookiesForUrl`] request.
     EmbedderGetCookiesForUrlResponse(CookieOperationId, Vec<Cookie<'static>>),
+    /// Response to a [`CoreResourceMsg::EmbedderSetCookieForUrl`] request.
+    EmbedderSetCookieForUrlResponse(CookieOperationId),
 }

--- a/components/net/resource_thread.rs
+++ b/components/net/resource_thread.rs
@@ -574,6 +574,19 @@ impl ResourceChannelManager {
                         cookies,
                     ));
             },
+            CoreResourceMsg::EmbedderSetCookieForUrl(operation_id, url, cookie, source) => {
+                self.resource_manager.set_cookie_for_url(
+                    &url,
+                    cookie.into_inner(),
+                    source,
+                    http_state,
+                );
+                http_state
+                    .embedder_proxy
+                    .send(NetToEmbedderMsg::EmbedderSetCookieForUrlResponse(
+                        operation_id,
+                    ));
+            },
             CoreResourceMsg::NewCookieListener(cookie_store_id, callback, _url) => {
                 // TODO: Use the URL for setting up the actual monitoring
                 self.cookie_listeners.insert(cookie_store_id, callback);

--- a/components/net/resource_thread.rs
+++ b/components/net/resource_thread.rs
@@ -562,6 +562,18 @@ impl ResourceChannelManager {
                     .collect();
                 self.send_cookie_response(cookie_store_id, CookieData::GetAll(cookies));
             },
+            CoreResourceMsg::EmbedderGetCookiesForUrl(operation_id, url, source) => {
+                let mut cookie_jar = http_state.cookie_jar.write();
+                cookie_jar.remove_expired_cookies_for_url(&url);
+                let cookies: Vec<Cookie<'static>> =
+                    cookie_jar.cookies_data_for_url(&url, source).collect();
+                http_state
+                    .embedder_proxy
+                    .send(NetToEmbedderMsg::EmbedderGetCookiesForUrlResponse(
+                        operation_id,
+                        cookies,
+                    ));
+            },
             CoreResourceMsg::NewCookieListener(cookie_store_id, callback, _url) => {
                 // TODO: Use the URL for setting up the actual monitoring
                 self.cookie_listeners.insert(cookie_store_id, callback);

--- a/components/servo/servo.rs
+++ b/components/servo/servo.rs
@@ -250,6 +250,9 @@ impl ServoInner {
                 .notify_error(ServoError::LostConnectionWithBackend);
         }
 
+        self.site_data_manager
+            .borrow_mut()
+            .poll_pending_cookie_requests();
         self.paint.borrow_mut().perform_updates();
         self.send_new_frame_ready_messages();
         self.handle_delegate_errors();
@@ -1022,6 +1025,10 @@ impl Servo {
 
     pub fn site_data_manager(&self) -> &SiteDataManager {
         &self.0.site_data_manager
+    }
+
+    pub fn site_data_manager_mut<'a>(&'a self) -> RefMut<'a, SiteDataManager> {
+        self.0.site_data_manager.borrow_mut()
     }
 
     pub(crate) fn paint<'a>(&'a self) -> Ref<'a, Paint> {

--- a/components/servo/servo.rs
+++ b/components/servo/servo.rs
@@ -250,9 +250,6 @@ impl ServoInner {
                 .notify_error(ServoError::LostConnectionWithBackend);
         }
 
-        self.site_data_manager
-            .borrow()
-            .poll_pending_cookie_requests();
         self.paint.borrow_mut().perform_updates();
         self.send_new_frame_ready_messages();
         self.handle_delegate_errors();
@@ -389,6 +386,10 @@ impl ServoInner {
                         .delegate()
                         .request_authentication(webview, authentication_request);
                 }
+            },
+            NetToEmbedderMsg::EmbedderGetCookiesForUrlResponse(operation_id, cookies) => {
+                self.site_data_manager
+                    .handle_cookie_response(operation_id, cookies);
             },
         }
     }

--- a/components/servo/servo.rs
+++ b/components/servo/servo.rs
@@ -251,7 +251,7 @@ impl ServoInner {
         }
 
         self.site_data_manager
-            .borrow_mut()
+            .borrow()
             .poll_pending_cookie_requests();
         self.paint.borrow_mut().perform_updates();
         self.send_new_frame_ready_messages();
@@ -1025,10 +1025,6 @@ impl Servo {
 
     pub fn site_data_manager(&self) -> &SiteDataManager {
         &self.0.site_data_manager
-    }
-
-    pub fn site_data_manager_mut<'a>(&'a self) -> RefMut<'a, SiteDataManager> {
-        self.0.site_data_manager.borrow_mut()
     }
 
     pub(crate) fn paint<'a>(&'a self) -> Ref<'a, Paint> {

--- a/components/servo/servo.rs
+++ b/components/servo/servo.rs
@@ -81,7 +81,7 @@ use crate::network_manager::NetworkManager;
 use crate::proxies::ConstellationProxy;
 use crate::responders::ServoErrorChannel;
 use crate::servo_delegate::{DefaultServoDelegate, ServoDelegate, ServoError};
-use crate::site_data_manager::SiteDataManager;
+use crate::site_data_manager::{CookieOperationResponse, SiteDataManager};
 use crate::webview::{MINIMUM_WEBVIEW_SIZE, WebView, WebViewInner};
 use crate::webview_delegate::{
     AllowOrDenyRequest, AuthenticationRequest, BluetoothDeviceSelectionRequest, EmbedderControl,
@@ -388,8 +388,14 @@ impl ServoInner {
                 }
             },
             NetToEmbedderMsg::EmbedderGetCookiesForUrlResponse(operation_id, cookies) => {
+                self.site_data_manager.handle_cookie_response(
+                    operation_id,
+                    CookieOperationResponse::Cookies(cookies),
+                );
+            },
+            NetToEmbedderMsg::EmbedderSetCookieForUrlResponse(operation_id) => {
                 self.site_data_manager
-                    .handle_cookie_response(operation_id, cookies);
+                    .handle_cookie_response(operation_id, CookieOperationResponse::Done);
             },
         }
     }

--- a/components/servo/site_data_manager.rs
+++ b/components/servo/site_data_manager.rs
@@ -2,13 +2,13 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-use std::cell::RefCell;
+use std::cell::{Cell, RefCell};
 
 use bitflags::bitflags;
 use cookie::Cookie;
 use log::warn;
 use net_traits::pub_domains::registered_domain_name;
-use net_traits::{CookieSource, PendingCookieRequest, ResourceThreads, SiteDescriptor};
+use net_traits::{CookieOperationId, ResourceThreads, SiteDescriptor};
 use rustc_hash::FxHashMap;
 use servo_url::ServoUrl;
 use storage_traits::StorageThreads;
@@ -64,6 +64,8 @@ impl SiteData {
     }
 }
 
+type CookieCallback = Box<dyn FnOnce(Vec<Cookie<'static>>)>;
+
 /// Provides APIs for inspecting and managing site data.
 ///
 /// `SiteDataManager` exposes information about data that is conceptually
@@ -81,7 +83,8 @@ pub struct SiteDataManager {
     private_resource_threads: ResourceThreads,
     public_storage_threads: StorageThreads,
     private_storage_threads: StorageThreads,
-    pending_cookie_requests: RefCell<Vec<PendingCookieRequest>>,
+    next_cookie_op_id: Cell<u64>,
+    pending_cookie_callbacks: RefCell<FxHashMap<CookieOperationId, CookieCallback>>,
 }
 
 impl SiteDataManager {
@@ -96,7 +99,8 @@ impl SiteDataManager {
             private_resource_threads,
             public_storage_threads,
             private_storage_threads,
-            pending_cookie_requests: RefCell::new(Vec::new()),
+            next_cookie_op_id: Cell::new(0),
+            pending_cookie_callbacks: RefCell::new(FxHashMap::default()),
         }
     }
 
@@ -232,30 +236,34 @@ impl SiteDataManager {
     }
 
     /// Asynchronously returns the cookies for the domain associated with the given [`Url`].
-    ///
-    /// The cookies are delivered via the provided callback during
-    /// [`Servo::spin_event_loop`](crate::Servo::spin_event_loop).
     pub fn cookies_for_url_async(
         &self,
         url: Url,
         source: CookieSource,
         callback: impl FnOnce(Vec<Cookie<'static>>) + 'static,
     ) {
-        let request =
-            self.public_resource_threads
-                .cookies_for_url_async(url.into(), source, callback);
-        self.pending_cookie_requests.borrow_mut().push(request);
+        let id = CookieOperationId(self.next_cookie_op_id.get());
+        self.next_cookie_op_id.set(id.0 + 1);
+        self.pending_cookie_callbacks
+            .borrow_mut()
+            .insert(id, Box::new(callback));
+        self.public_resource_threads
+            .cookies_for_url_async(id, url.into(), source);
     }
 
-    /// Poll pending asynchronous cookie requests, invoking callbacks for any
-    /// that have completed.
-    pub(crate) fn poll_pending_cookie_requests(&self) {
-        self.pending_cookie_requests
-            .borrow_mut()
-            .retain_mut(|request| match request.poll() {
-                Some(true) => false,
-                Some(false) => true,
-                None => false,
-            });
+    /// Handle a cookie response from the resource thread.
+    ///
+    /// This is called by the event loop when a
+    /// [`NetToEmbedderMsg::EmbedderGetCookiesForUrlResponse`] is received.
+    pub(crate) fn handle_cookie_response(
+        &self,
+        id: CookieOperationId,
+        cookies: Vec<Cookie<'static>>,
+    ) {
+        if let Some(callback) = self.pending_cookie_callbacks.borrow_mut().remove(&id) {
+            callback(cookies);
+        } else {
+            warn!("Received cookie response for unknown operation {id:?}");
+        }
     }
 }

--- a/components/servo/site_data_manager.rs
+++ b/components/servo/site_data_manager.rs
@@ -6,7 +6,7 @@ use bitflags::bitflags;
 use cookie::Cookie;
 use log::warn;
 use net_traits::pub_domains::registered_domain_name;
-use net_traits::{ResourceThreads, SiteDescriptor};
+use net_traits::{CookieSource, PendingCookieRequest, ResourceThreads, SiteDescriptor};
 use rustc_hash::FxHashMap;
 use servo_url::ServoUrl;
 use storage_traits::StorageThreads;
@@ -79,6 +79,7 @@ pub struct SiteDataManager {
     private_resource_threads: ResourceThreads,
     public_storage_threads: StorageThreads,
     private_storage_threads: StorageThreads,
+    pending_cookie_requests: Vec<PendingCookieRequest>,
 }
 
 impl SiteDataManager {
@@ -93,6 +94,7 @@ impl SiteDataManager {
             private_resource_threads,
             public_storage_threads,
             private_storage_threads,
+            pending_cookie_requests: Vec::new(),
         }
     }
 
@@ -225,5 +227,32 @@ impl SiteDataManager {
             cookie,
             CookieSource::HTTP,
         );
+    }
+
+    /// Asynchronously returns the cookies for the domain associated with the given [`Url`].
+    ///
+    /// The cookies are delivered via the provided callback during
+    /// [`Servo::spin_event_loop`](crate::Servo::spin_event_loop).
+    pub fn cookies_for_url_async(
+        &mut self,
+        url: Url,
+        source: CookieSource,
+        callback: impl FnOnce(Vec<Cookie<'static>>) + 'static,
+    ) {
+        let request =
+            self.public_resource_threads
+                .cookies_for_url_async(url.into(), source, callback);
+        self.pending_cookie_requests.push(request);
+    }
+
+    /// Poll all pending asynchronous cookie requests. Invoke callbacks for any
+    /// that have received a response. Called during the event loop spin.
+    pub(crate) fn poll_pending_cookie_requests(&mut self) {
+        self.pending_cookie_requests
+            .retain_mut(|request| match request.poll() {
+                Ok(true) => false,
+                Ok(false) => true,
+                Err(()) => false,
+            });
     }
 }

--- a/components/servo/site_data_manager.rs
+++ b/components/servo/site_data_manager.rs
@@ -2,6 +2,8 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
+use std::cell::RefCell;
+
 use bitflags::bitflags;
 use cookie::Cookie;
 use log::warn;
@@ -79,7 +81,7 @@ pub struct SiteDataManager {
     private_resource_threads: ResourceThreads,
     public_storage_threads: StorageThreads,
     private_storage_threads: StorageThreads,
-    pending_cookie_requests: Vec<PendingCookieRequest>,
+    pending_cookie_requests: RefCell<Vec<PendingCookieRequest>>,
 }
 
 impl SiteDataManager {
@@ -94,7 +96,7 @@ impl SiteDataManager {
             private_resource_threads,
             public_storage_threads,
             private_storage_threads,
-            pending_cookie_requests: Vec::new(),
+            pending_cookie_requests: RefCell::new(Vec::new()),
         }
     }
 
@@ -234,7 +236,7 @@ impl SiteDataManager {
     /// The cookies are delivered via the provided callback during
     /// [`Servo::spin_event_loop`](crate::Servo::spin_event_loop).
     pub fn cookies_for_url_async(
-        &mut self,
+        &self,
         url: Url,
         source: CookieSource,
         callback: impl FnOnce(Vec<Cookie<'static>>) + 'static,
@@ -242,17 +244,18 @@ impl SiteDataManager {
         let request =
             self.public_resource_threads
                 .cookies_for_url_async(url.into(), source, callback);
-        self.pending_cookie_requests.push(request);
+        self.pending_cookie_requests.borrow_mut().push(request);
     }
 
-    /// Poll all pending asynchronous cookie requests. Invoke callbacks for any
-    /// that have received a response. Called during the event loop spin.
-    pub(crate) fn poll_pending_cookie_requests(&mut self) {
+    /// Poll pending asynchronous cookie requests, invoking callbacks for any
+    /// that have completed.
+    pub(crate) fn poll_pending_cookie_requests(&self) {
         self.pending_cookie_requests
+            .borrow_mut()
             .retain_mut(|request| match request.poll() {
-                Ok(true) => false,
-                Ok(false) => true,
-                Err(()) => false,
+                Some(true) => false,
+                Some(false) => true,
+                None => false,
             });
     }
 }

--- a/components/servo/site_data_manager.rs
+++ b/components/servo/site_data_manager.rs
@@ -64,7 +64,20 @@ impl SiteData {
     }
 }
 
-type CookieCallback = Box<dyn FnOnce(Vec<Cookie<'static>>)>;
+/// The response data for a pending embedder cookie operation.
+pub(crate) enum CookieOperationResponse {
+    /// Cookies returned from a get operation.
+    Cookies(Vec<Cookie<'static>>),
+    /// Acknowledgement that a operation is completed.
+    Done,
+}
+
+/// A callback for a pending embedder cookie operation,
+/// paired with the [`CookieOperationResponse`].
+enum CookieOperationCallback {
+    Cookies(Box<dyn FnOnce(Vec<Cookie<'static>>)>),
+    Done(Box<dyn FnOnce()>),
+}
 
 /// Provides APIs for inspecting and managing site data.
 ///
@@ -84,7 +97,7 @@ pub struct SiteDataManager {
     public_storage_threads: StorageThreads,
     private_storage_threads: StorageThreads,
     next_cookie_op_id: Cell<u64>,
-    pending_cookie_callbacks: RefCell<FxHashMap<CookieOperationId, CookieCallback>>,
+    pending_cookie_callbacks: RefCell<FxHashMap<CookieOperationId, CookieOperationCallback>>,
 }
 
 impl SiteDataManager {
@@ -242,28 +255,61 @@ impl SiteDataManager {
         source: CookieSource,
         callback: impl FnOnce(Vec<Cookie<'static>>) + 'static,
     ) {
-        let id = CookieOperationId(self.next_cookie_op_id.get());
-        self.next_cookie_op_id.set(id.0 + 1);
+        let id = self.next_operation_id();
         self.pending_cookie_callbacks
             .borrow_mut()
-            .insert(id, Box::new(callback));
+            .insert(id, CookieOperationCallback::Cookies(Box::new(callback)));
         self.public_resource_threads
             .cookies_for_url_async(id, url.into(), source);
     }
 
-    /// Handle a cookie response from the resource thread.
+    /// Asynchronously sets a cookie for the domain associated with the given [`Url`].
+    pub fn set_cookie_for_url_async(
+        &self,
+        url: Url,
+        cookie: Cookie<'static>,
+        callback: impl FnOnce() + 'static,
+    ) {
+        let id = self.next_operation_id();
+        self.pending_cookie_callbacks
+            .borrow_mut()
+            .insert(id, CookieOperationCallback::Done(Box::new(callback)));
+        self.public_resource_threads.set_cookie_for_url_async(
+            id,
+            url.into(),
+            cookie,
+            CookieSource::HTTP,
+        );
+    }
+
+    /// Handle a cookie operation response from the resource thread.
     ///
-    /// This is called by the event loop when a
-    /// [`NetToEmbedderMsg::EmbedderGetCookiesForUrlResponse`] is received.
+    /// This is called by the event loop when an embedder cookie response is received.
     pub(crate) fn handle_cookie_response(
         &self,
         id: CookieOperationId,
-        cookies: Vec<Cookie<'static>>,
+        response: CookieOperationResponse,
     ) {
-        if let Some(callback) = self.pending_cookie_callbacks.borrow_mut().remove(&id) {
-            callback(cookies);
-        } else {
+        let Some(callback) = self.pending_cookie_callbacks.borrow_mut().remove(&id) else {
             warn!("Received cookie response for unknown operation {id:?}");
+            return;
+        };
+        match (callback, response) {
+            (CookieOperationCallback::Cookies(cb), CookieOperationResponse::Cookies(cookies)) => {
+                cb(cookies);
+            },
+            (CookieOperationCallback::Done(cb), CookieOperationResponse::Done) => {
+                cb();
+            },
+            _ => {
+                warn!("Cookie response type mismatch for operation {id:?}");
+            },
         }
+    }
+
+    fn next_operation_id(&self) -> CookieOperationId {
+        let id = CookieOperationId(self.next_cookie_op_id.get());
+        self.next_cookie_op_id.set(id.0 + 1);
+        id
     }
 }

--- a/components/servo/tests/site_data_manager.rs
+++ b/components/servo/tests/site_data_manager.rs
@@ -730,7 +730,7 @@ fn test_get_cookie_async() {
     let delegate = Rc::new(WebViewDelegateImpl::default());
     let _webview = WebViewBuilder::new(servo_test.servo(), servo_test.rendering_context.clone())
         .delegate(delegate.clone())
-        .url(url.clone().into_url())
+        .url(url.url().into_url())
         .build();
 
     // Wait for LoadStatus::Complete to ensure the HTTP response and Set-Cookie header are processed.
@@ -745,10 +745,14 @@ fn test_get_cookie_async() {
     servo_test
         .servo()
         .site_data_manager()
-        .cookies_for_url_async(url.into_url(), CookieSource::NonHTTP, move |cookies| {
-            assert!(continued_clone.get(), "callback fired synchronously");
-            *result_clone.borrow_mut() = Some(cookies);
-        });
+        .cookies_for_url_async(
+            url.as_url().clone(),
+            CookieSource::NonHTTP,
+            move |cookies| {
+                assert!(continued_clone.get(), "callback fired synchronously");
+                *result_clone.borrow_mut() = Some(cookies);
+            },
+        );
     assert!(result.borrow().is_none(), "result available before spin");
     continued_after_call.set(true);
 

--- a/components/servo/tests/site_data_manager.rs
+++ b/components/servo/tests/site_data_manager.rs
@@ -4,6 +4,7 @@
 
 mod common;
 
+use std::cell::{Cell, RefCell};
 use std::collections::HashMap;
 use std::rc::Rc;
 use std::sync::{Arc, Mutex};
@@ -708,4 +709,56 @@ fn test_set_cookie() {
         *received_cookie.lock().unwrap(),
         Some("foo=bar".to_string())
     );
+}
+
+#[test]
+fn test_get_cookie_async() {
+    let servo_test = ServoTest::new();
+
+    // Serve a minimal page that sets a cookie via Set-Cookie response header.
+    let handler =
+        move |_: HyperRequest<Incoming>,
+              response: &mut HyperResponse<BoxBody<Bytes, hyper::Error>>| {
+            response.headers_mut().insert(
+                http::header::SET_COOKIE,
+                HeaderValue::from_static("foo=bar; Path=/"),
+            );
+            *response.body_mut() = make_body(b"<!DOCTYPE html><p>hi</p>".to_vec());
+        };
+    let (server, url) = make_server(handler);
+
+    let delegate = Rc::new(WebViewDelegateImpl::default());
+    let _webview = WebViewBuilder::new(servo_test.servo(), servo_test.rendering_context.clone())
+        .delegate(delegate.clone())
+        .url(url.clone().into_url())
+        .build();
+
+    // Wait for LoadStatus::Complete to ensure the HTTP response and Set-Cookie header are processed.
+    servo_test.spin(move || !delegate.load_status_changed.get());
+    let _ = server.close();
+
+    // Issue an async cookie request and verify it does not block.
+    let result: Rc<RefCell<Option<Vec<Cookie<'static>>>>> = Rc::new(RefCell::new(None));
+    let continued_after_call = Rc::new(Cell::new(false));
+    let continued_clone = continued_after_call.clone();
+    let result_clone = result.clone();
+    servo_test
+        .servo()
+        .site_data_manager_mut()
+        .cookies_for_url_async(url.into_url(), CookieSource::NonHTTP, move |cookies| {
+            assert!(continued_clone.get(), "callback fired synchronously");
+            *result_clone.borrow_mut() = Some(cookies);
+        });
+    assert!(result.borrow().is_none(), "result available before spin");
+    continued_after_call.set(true);
+
+    // Spin the event loop until the callback fires.
+    let result_clone = result.clone();
+    servo_test.spin(move || result_clone.borrow().is_none());
+
+    let cookies = result.borrow();
+    let cookies = cookies.as_ref().unwrap();
+    assert_eq!(cookies.len(), 1);
+    assert_eq!(cookies[0].name(), "foo");
+    assert_eq!(cookies[0].value(), "bar");
 }

--- a/components/servo/tests/site_data_manager.rs
+++ b/components/servo/tests/site_data_manager.rs
@@ -744,7 +744,7 @@ fn test_get_cookie_async() {
     let result_clone = result.clone();
     servo_test
         .servo()
-        .site_data_manager_mut()
+        .site_data_manager()
         .cookies_for_url_async(url.into_url(), CookieSource::NonHTTP, move |cookies| {
             assert!(continued_clone.get(), "callback fired synchronously");
             *result_clone.borrow_mut() = Some(cookies);

--- a/components/shared/net/lib.rs
+++ b/components/shared/net/lib.rs
@@ -28,12 +28,16 @@ use rustls_pki_types::CertificateDer;
 use serde::{Deserialize, Serialize};
 use servo_base::cross_process_instant::CrossProcessInstant;
 use servo_base::generic_channel::{
-    self, CallbackSetter, GenericCallback, GenericOneshotSender, GenericReceiver, GenericSend,
-    GenericSender, SendResult, TryReceiveError,
+    self, CallbackSetter, GenericCallback, GenericOneshotSender, GenericSend, GenericSender,
+    SendResult,
 };
 use servo_base::id::{CookieStoreId, HistoryStateId, PipelineId};
 use servo_url::{ImmutableOrigin, ServoUrl};
 use uuid::Uuid;
+
+/// Identifies a pending asynchronous cookie operation initiated by the embedder.
+#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
+pub struct CookieOperationId(pub u64);
 
 use crate::fetch::headers::determine_nosniff;
 use crate::filemanager_thread::FileManagerThreadMsg;
@@ -478,34 +482,6 @@ pub trait AsyncRuntime: Send {
     fn shutdown(&mut self);
 }
 
-/// A pending asynchronous cookie request`.
-pub struct PendingCookieRequest {
-    receiver: GenericReceiver<Vec<Serde<Cookie<'static>>>>,
-    callback: Option<Box<dyn FnOnce(Vec<Cookie<'static>>)>>,
-}
-
-impl PendingCookieRequest {
-    /// Try to receive the cookie response without blocking.
-    ///
-    /// Returns `Some(true)` if the callback was invoked (request complete),
-    /// `Some(false)` if the response is not ready yet,
-    /// or `None` if the request was failed.
-    pub fn poll(&mut self) -> Option<bool> {
-        match self.receiver.try_recv() {
-            Ok(cookies) => {
-                if let Some(callback) = self.callback.take() {
-                    let cookies: Vec<Cookie<'static>> =
-                        cookies.into_iter().map(|c| c.into_inner()).collect();
-                    callback(cookies);
-                }
-                Some(true)
-            },
-            Err(TryReceiveError::Empty) => Some(false),
-            Err(TryReceiveError::ReceiveError(_)) => None,
-        }
-    }
-}
-
 /// Handle to a resource thread
 pub type CoreResourceThread = GenericSender<CoreResourceMsg>;
 
@@ -582,22 +558,6 @@ impl ResourceThreads {
             .collect()
     }
 
-    pub fn cookies_for_url_async(
-        &self,
-        url: ServoUrl,
-        source: CookieSource,
-        callback: impl FnOnce(Vec<Cookie<'static>>) + 'static,
-    ) -> PendingCookieRequest {
-        let (sender, receiver) = generic_channel::channel().unwrap();
-        let _ = self
-            .core_thread
-            .send(CoreResourceMsg::GetCookiesForUrl(url, sender, source));
-        PendingCookieRequest {
-            receiver,
-            callback: Some(Box::new(callback)),
-        }
-    }
-
     pub fn set_cookie_for_url(&self, url: ServoUrl, cookie: Cookie<'static>, source: CookieSource) {
         let _ = self.core_thread.send(CoreResourceMsg::SetCookieForUrl(
             url,
@@ -621,6 +581,17 @@ impl ResourceThreads {
             Some(sender),
         ));
         let _ = receiver.recv();
+    }
+
+    pub fn cookies_for_url_async(
+        &self,
+        id: CookieOperationId,
+        url: ServoUrl,
+        source: CookieSource,
+    ) {
+        let _ = self
+            .core_thread
+            .send(CoreResourceMsg::EmbedderGetCookiesForUrl(id, url, source));
     }
 }
 
@@ -702,11 +673,15 @@ pub enum CoreResourceMsg {
     /// Retrieve the stored cookies as a header string for a given URL.
     GetCookieStringForUrl(ServoUrl, GenericSender<Option<String>>, CookieSource),
     /// Retrieve the stored cookies as a vector for the given URL.
+    /// The response is sent via the provided sender.
     GetCookiesForUrl(
         ServoUrl,
         GenericSender<Vec<Serde<Cookie<'static>>>>,
         CookieSource,
     ),
+    /// Retrieve cookies for a URL for embedder. The response is
+    /// sent via [`NetToEmbedderMsg::EmbedderGetCookiesForUrlResponse`].
+    EmbedderGetCookiesForUrl(CookieOperationId, ServoUrl, CookieSource),
     GetCookieDataForUrlAsync(CookieStoreId, ServoUrl, Option<String>),
     GetAllCookieDataForUrlAsync(CookieStoreId, ServoUrl, Option<String>),
     DeleteCookiesForSites(Vec<String>, GenericSender<()>),

--- a/components/shared/net/lib.rs
+++ b/components/shared/net/lib.rs
@@ -487,10 +487,10 @@ pub struct PendingCookieRequest {
 impl PendingCookieRequest {
     /// Try to receive the cookie response without blocking.
     ///
-    /// Returns `Ok(true)` if the callback was invoked (request complete),
-    /// `Ok(false)` if the response is not ready yet,
-    /// or `Err(())` if the request was failed.
-    pub fn poll(&mut self) -> Result<bool, ()> {
+    /// Returns `Some(true)` if the callback was invoked (request complete),
+    /// `Some(false)` if the response is not ready yet,
+    /// or `None` if the request was failed.
+    pub fn poll(&mut self) -> Option<bool> {
         match self.receiver.try_recv() {
             Ok(cookies) => {
                 if let Some(callback) = self.callback.take() {
@@ -498,10 +498,10 @@ impl PendingCookieRequest {
                         cookies.into_iter().map(|c| c.into_inner()).collect();
                     callback(cookies);
                 }
-                Ok(true)
+                Some(true)
             },
-            Err(TryReceiveError::Empty) => Ok(false),
-            Err(TryReceiveError::ReceiveError(_)) => Err(()),
+            Err(TryReceiveError::Empty) => Some(false),
+            Err(TryReceiveError::ReceiveError(_)) => None,
         }
     }
 }

--- a/components/shared/net/lib.rs
+++ b/components/shared/net/lib.rs
@@ -28,8 +28,8 @@ use rustls_pki_types::CertificateDer;
 use serde::{Deserialize, Serialize};
 use servo_base::cross_process_instant::CrossProcessInstant;
 use servo_base::generic_channel::{
-    self, CallbackSetter, GenericCallback, GenericOneshotSender, GenericSend, GenericSender,
-    SendResult,
+    self, CallbackSetter, GenericCallback, GenericOneshotSender, GenericReceiver, GenericSend,
+    GenericSender, SendResult, TryReceiveError,
 };
 use servo_base::id::{CookieStoreId, HistoryStateId, PipelineId};
 use servo_url::{ImmutableOrigin, ServoUrl};
@@ -478,6 +478,34 @@ pub trait AsyncRuntime: Send {
     fn shutdown(&mut self);
 }
 
+/// A pending asynchronous cookie request`.
+pub struct PendingCookieRequest {
+    receiver: GenericReceiver<Vec<Serde<Cookie<'static>>>>,
+    callback: Option<Box<dyn FnOnce(Vec<Cookie<'static>>)>>,
+}
+
+impl PendingCookieRequest {
+    /// Try to receive the cookie response without blocking.
+    ///
+    /// Returns `Ok(true)` if the callback was invoked (request complete),
+    /// `Ok(false)` if the response is not ready yet,
+    /// or `Err(())` if the request was failed.
+    pub fn poll(&mut self) -> Result<bool, ()> {
+        match self.receiver.try_recv() {
+            Ok(cookies) => {
+                if let Some(callback) = self.callback.take() {
+                    let cookies: Vec<Cookie<'static>> =
+                        cookies.into_iter().map(|c| c.into_inner()).collect();
+                    callback(cookies);
+                }
+                Ok(true)
+            },
+            Err(TryReceiveError::Empty) => Ok(false),
+            Err(TryReceiveError::ReceiveError(_)) => Err(()),
+        }
+    }
+}
+
 /// Handle to a resource thread
 pub type CoreResourceThread = GenericSender<CoreResourceMsg>;
 
@@ -552,6 +580,22 @@ impl ResourceThreads {
             .into_iter()
             .map(|cookie| cookie.into_inner())
             .collect()
+    }
+
+    pub fn cookies_for_url_async(
+        &self,
+        url: ServoUrl,
+        source: CookieSource,
+        callback: impl FnOnce(Vec<Cookie<'static>>) + 'static,
+    ) -> PendingCookieRequest {
+        let (sender, receiver) = generic_channel::channel().unwrap();
+        let _ = self
+            .core_thread
+            .send(CoreResourceMsg::GetCookiesForUrl(url, sender, source));
+        PendingCookieRequest {
+            receiver,
+            callback: Some(Box::new(callback)),
+        }
     }
 
     pub fn set_cookie_for_url(&self, url: ServoUrl, cookie: Cookie<'static>, source: CookieSource) {

--- a/components/shared/net/lib.rs
+++ b/components/shared/net/lib.rs
@@ -593,6 +593,23 @@ impl ResourceThreads {
             .core_thread
             .send(CoreResourceMsg::EmbedderGetCookiesForUrl(id, url, source));
     }
+
+    pub fn set_cookie_for_url_async(
+        &self,
+        id: CookieOperationId,
+        url: ServoUrl,
+        cookie: Cookie<'static>,
+        source: CookieSource,
+    ) {
+        let _ = self
+            .core_thread
+            .send(CoreResourceMsg::EmbedderSetCookieForUrl(
+                id,
+                url,
+                Serde(cookie),
+                source,
+            ));
+    }
 }
 
 impl GenericSend<CoreResourceMsg> for ResourceThreads {
@@ -682,6 +699,14 @@ pub enum CoreResourceMsg {
     /// Retrieve cookies for a URL for embedder. The response is
     /// sent via [`NetToEmbedderMsg::EmbedderGetCookiesForUrlResponse`].
     EmbedderGetCookiesForUrl(CookieOperationId, ServoUrl, CookieSource),
+    /// Set a cookie for a URL on behalf of the embedder. The response is
+    /// sent via [`NetToEmbedderMsg::EmbedderSetCookieForUrlResponse`].
+    EmbedderSetCookieForUrl(
+        CookieOperationId,
+        ServoUrl,
+        Serde<Cookie<'static>>,
+        CookieSource,
+    ),
     GetCookieDataForUrlAsync(CookieStoreId, ServoUrl, Option<String>),
     GetAllCookieDataForUrlAsync(CookieStoreId, ServoUrl, Option<String>),
     DeleteCookiesForSites(Vec<String>, GenericSender<()>),


### PR DESCRIPTION
Support applications to get cookies asynchronously from embedder.

Testing: `servo/components/servo/tests/site_data_manager.rs::test_get_cookie_async`