### PR TITLE
release: Bump version number to 0.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1830,7 +1830,7 @@ dependencies = [
 
 [[package]]
 name = "deny_public_fields_tests"
-version = "0.0.6"
+version = "0.1.0"
 dependencies = [
  "servo-deny-public-fields",
 ]
@@ -4903,7 +4903,7 @@ dependencies = [
 
 [[package]]
 name = "malloc_size_of_tests"
-version = "0.0.6"
+version = "0.1.0"
 dependencies = [
  "servo-malloc-size-of",
  "servo_arc",
@@ -6484,7 +6484,7 @@ dependencies = [
 
 [[package]]
 name = "profile_tests"
-version = "0.0.6"
+version = "0.1.0"
 dependencies = [
  "ipc-channel",
  "servo-config",
@@ -7182,7 +7182,7 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "script_tests"
-version = "0.0.6"
+version = "0.1.0"
 dependencies = [
  "encoding_rs",
  "euclid",
@@ -7411,7 +7411,7 @@ dependencies = [
 
 [[package]]
 name = "servo"
-version = "0.0.6"
+version = "0.1.0"
 dependencies = [
  "accesskit",
  "accesskit_consumer",
@@ -7486,7 +7486,7 @@ dependencies = [
 
 [[package]]
 name = "servo-allocator"
-version = "0.0.6"
+version = "0.1.0"
 dependencies = [
  "backtrace",
  "libc",
@@ -7499,7 +7499,7 @@ dependencies = [
 
 [[package]]
 name = "servo-background-hang-monitor"
-version = "0.0.6"
+version = "0.1.0"
 dependencies = [
  "backtrace",
  "crossbeam-channel",
@@ -7516,7 +7516,7 @@ dependencies = [
 
 [[package]]
 name = "servo-background-hang-monitor-api"
-version = "0.0.6"
+version = "0.1.0"
 dependencies = [
  "serde",
  "servo-base",
@@ -7524,7 +7524,7 @@ dependencies = [
 
 [[package]]
 name = "servo-base"
-version = "0.0.6"
+version = "0.1.0"
 dependencies = [
  "accesskit",
  "crossbeam-channel",
@@ -7548,7 +7548,7 @@ dependencies = [
 
 [[package]]
 name = "servo-bluetooth"
-version = "0.0.6"
+version = "0.1.0"
 dependencies = [
  "bitflags 2.11.0",
  "blurmock",
@@ -7566,7 +7566,7 @@ dependencies = [
 
 [[package]]
 name = "servo-bluetooth-traits"
-version = "0.0.6"
+version = "0.1.0"
 dependencies = [
  "regex",
  "serde",
@@ -7576,7 +7576,7 @@ dependencies = [
 
 [[package]]
 name = "servo-canvas"
-version = "0.0.6"
+version = "0.1.0"
 dependencies = [
  "bytemuck",
  "crossbeam-channel",
@@ -7604,7 +7604,7 @@ dependencies = [
 
 [[package]]
 name = "servo-canvas-traits"
-version = "0.0.6"
+version = "0.1.0"
 dependencies = [
  "crossbeam-channel",
  "euclid",
@@ -7624,7 +7624,7 @@ dependencies = [
 
 [[package]]
 name = "servo-config"
-version = "0.0.6"
+version = "0.1.0"
 dependencies = [
  "serde",
  "serde_json",
@@ -7634,7 +7634,7 @@ dependencies = [
 
 [[package]]
 name = "servo-config-macro"
-version = "0.0.6"
+version = "0.1.0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -7644,7 +7644,7 @@ dependencies = [
 
 [[package]]
 name = "servo-constellation"
-version = "0.0.6"
+version = "0.1.0"
 dependencies = [
  "accesskit",
  "backtrace",
@@ -7690,7 +7690,7 @@ dependencies = [
 
 [[package]]
 name = "servo-constellation-traits"
-version = "0.0.6"
+version = "0.1.0"
 dependencies = [
  "content-security-policy",
  "encoding_rs",
@@ -7724,14 +7724,14 @@ dependencies = [
 
 [[package]]
 name = "servo-default-resources"
-version = "0.0.6"
+version = "0.1.0"
 dependencies = [
  "servo-embedder-traits",
 ]
 
 [[package]]
 name = "servo-deny-public-fields"
-version = "0.0.6"
+version = "0.1.0"
 dependencies = [
  "syn",
  "synstructure",
@@ -7739,7 +7739,7 @@ dependencies = [
 
 [[package]]
 name = "servo-devtools"
-version = "0.0.6"
+version = "0.1.0"
 dependencies = [
  "atomic_refcell",
  "base64 0.22.1",
@@ -7767,7 +7767,7 @@ dependencies = [
 
 [[package]]
 name = "servo-devtools-traits"
-version = "0.0.6"
+version = "0.1.0"
 dependencies = [
  "http 1.4.0",
  "malloc_size_of_derive",
@@ -7783,7 +7783,7 @@ dependencies = [
 
 [[package]]
 name = "servo-dom-struct"
-version = "0.0.6"
+version = "0.1.0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -7792,7 +7792,7 @@ dependencies = [
 
 [[package]]
 name = "servo-embedder-traits"
-version = "0.0.6"
+version = "0.1.0"
 dependencies = [
  "accesskit",
  "bitflags 2.11.0",
@@ -7824,7 +7824,7 @@ dependencies = [
 
 [[package]]
 name = "servo-fonts"
-version = "0.0.6"
+version = "0.1.0"
 dependencies = [
  "app_units",
  "bitflags 2.11.0",
@@ -7879,7 +7879,7 @@ dependencies = [
 
 [[package]]
 name = "servo-fonts-traits"
-version = "0.0.6"
+version = "0.1.0"
 dependencies = [
  "atomic_refcell",
  "dwrote",
@@ -7902,7 +7902,7 @@ dependencies = [
 
 [[package]]
 name = "servo-geometry"
-version = "0.0.6"
+version = "0.1.0"
 dependencies = [
  "app_units",
  "euclid",
@@ -7929,7 +7929,7 @@ dependencies = [
 
 [[package]]
 name = "servo-jstraceable-derive"
-version = "0.0.6"
+version = "0.1.0"
 dependencies = [
  "proc-macro2",
  "syn",
@@ -7938,7 +7938,7 @@ dependencies = [
 
 [[package]]
 name = "servo-layout"
-version = "0.0.6"
+version = "0.1.0"
 dependencies = [
  "app_units",
  "atomic_refcell",
@@ -7992,7 +7992,7 @@ dependencies = [
 
 [[package]]
 name = "servo-layout-api"
-version = "0.0.6"
+version = "0.1.0"
 dependencies = [
  "app_units",
  "atomic_refcell",
@@ -8024,7 +8024,7 @@ dependencies = [
 
 [[package]]
 name = "servo-malloc-size-of"
-version = "0.0.6"
+version = "0.1.0"
 dependencies = [
  "accountable-refcell",
  "app_units",
@@ -8064,7 +8064,7 @@ dependencies = [
 
 [[package]]
 name = "servo-media"
-version = "0.0.6"
+version = "0.1.0"
 dependencies = [
  "once_cell",
  "servo-media-audio",
@@ -8076,7 +8076,7 @@ dependencies = [
 
 [[package]]
 name = "servo-media-audio"
-version = "0.0.6"
+version = "0.1.0"
 dependencies = [
  "byte-slice-cast",
  "euclid",
@@ -8098,7 +8098,7 @@ dependencies = [
 
 [[package]]
 name = "servo-media-auto"
-version = "0.0.6"
+version = "0.1.0"
 dependencies = [
  "servo-media-dummy",
  "servo-media-gstreamer",
@@ -8106,7 +8106,7 @@ dependencies = [
 
 [[package]]
 name = "servo-media-derive"
-version = "0.0.6"
+version = "0.1.0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -8115,7 +8115,7 @@ dependencies = [
 
 [[package]]
 name = "servo-media-dummy"
-version = "0.0.6"
+version = "0.1.0"
 dependencies = [
  "ipc-channel",
  "servo-media",
@@ -8128,7 +8128,7 @@ dependencies = [
 
 [[package]]
 name = "servo-media-examples"
-version = "0.0.6"
+version = "0.1.0"
 dependencies = [
  "euclid",
  "rand 0.9.2",
@@ -8140,7 +8140,7 @@ dependencies = [
 
 [[package]]
 name = "servo-media-gstreamer"
-version = "0.0.6"
+version = "0.1.0"
 dependencies = [
  "byte-slice-cast",
  "glib",
@@ -8172,7 +8172,7 @@ dependencies = [
 
 [[package]]
 name = "servo-media-gstreamer-render"
-version = "0.0.6"
+version = "0.1.0"
 dependencies = [
  "gstreamer",
  "gstreamer-video",
@@ -8181,7 +8181,7 @@ dependencies = [
 
 [[package]]
 name = "servo-media-gstreamer-render-android"
-version = "0.0.6"
+version = "0.1.0"
 dependencies = [
  "glib",
  "gstreamer",
@@ -8194,7 +8194,7 @@ dependencies = [
 
 [[package]]
 name = "servo-media-gstreamer-render-unix"
-version = "0.0.6"
+version = "0.1.0"
 dependencies = [
  "glib",
  "gstreamer",
@@ -8209,7 +8209,7 @@ dependencies = [
 
 [[package]]
 name = "servo-media-player"
-version = "0.0.6"
+version = "0.1.0"
 dependencies = [
  "ipc-channel",
  "malloc_size_of_derive",
@@ -8222,7 +8222,7 @@ dependencies = [
 
 [[package]]
 name = "servo-media-streams"
-version = "0.0.6"
+version = "0.1.0"
 dependencies = [
  "malloc_size_of_derive",
  "servo-malloc-size-of",
@@ -8231,7 +8231,7 @@ dependencies = [
 
 [[package]]
 name = "servo-media-thread"
-version = "0.0.6"
+version = "0.1.0"
 dependencies = [
  "euclid",
  "ipc-channel",
@@ -8248,7 +8248,7 @@ dependencies = [
 
 [[package]]
 name = "servo-media-traits"
-version = "0.0.6"
+version = "0.1.0"
 dependencies = [
  "malloc_size_of_derive",
  "servo-malloc-size-of",
@@ -8256,7 +8256,7 @@ dependencies = [
 
 [[package]]
 name = "servo-media-webrtc"
-version = "0.0.6"
+version = "0.1.0"
 dependencies = [
  "log",
  "servo-media-streams",
@@ -8265,7 +8265,7 @@ dependencies = [
 
 [[package]]
 name = "servo-metrics"
-version = "0.0.6"
+version = "0.1.0"
 dependencies = [
  "malloc_size_of_derive",
  "servo-base",
@@ -8279,7 +8279,7 @@ dependencies = [
 
 [[package]]
 name = "servo-net"
-version = "0.0.6"
+version = "0.1.0"
 dependencies = [
  "async-compression",
  "async-recursion",
@@ -8350,7 +8350,7 @@ dependencies = [
 
 [[package]]
 name = "servo-net-traits"
-version = "0.0.6"
+version = "0.1.0"
 dependencies = [
  "content-security-policy",
  "cookie 0.18.1",
@@ -8390,7 +8390,7 @@ dependencies = [
 
 [[package]]
 name = "servo-paint"
-version = "0.0.6"
+version = "0.1.0"
 dependencies = [
  "bitflags 2.11.0",
  "crossbeam-channel",
@@ -8430,7 +8430,7 @@ dependencies = [
 
 [[package]]
 name = "servo-paint-api"
-version = "0.0.6"
+version = "0.1.0"
 dependencies = [
  "bitflags 2.11.0",
  "crossbeam-channel",
@@ -8465,7 +8465,7 @@ dependencies = [
 
 [[package]]
 name = "servo-pixels"
-version = "0.0.6"
+version = "0.1.0"
 dependencies = [
  "criterion",
  "euclid",
@@ -8480,7 +8480,7 @@ dependencies = [
 
 [[package]]
 name = "servo-profile"
-version = "0.0.6"
+version = "0.1.0"
 dependencies = [
  "libc",
  "log",
@@ -8498,7 +8498,7 @@ dependencies = [
 
 [[package]]
 name = "servo-profile-traits"
-version = "0.0.6"
+version = "0.1.0"
 dependencies = [
  "crossbeam-channel",
  "ipc-channel",
@@ -8514,7 +8514,7 @@ dependencies = [
 
 [[package]]
 name = "servo-script"
-version = "0.0.6"
+version = "0.1.0"
 dependencies = [
  "accountable-refcell",
  "aes",
@@ -8653,7 +8653,7 @@ dependencies = [
 
 [[package]]
 name = "servo-script-bindings"
-version = "0.0.6"
+version = "0.1.0"
 dependencies = [
  "bitflags 2.11.0",
  "crossbeam-channel",
@@ -8692,7 +8692,7 @@ dependencies = [
 
 [[package]]
 name = "servo-script-traits"
-version = "0.0.6"
+version = "0.1.0"
 dependencies = [
  "accesskit",
  "crossbeam-channel",
@@ -8727,7 +8727,7 @@ dependencies = [
 
 [[package]]
 name = "servo-storage"
-version = "0.0.6"
+version = "0.1.0"
 dependencies = [
  "libc",
  "log",
@@ -8754,7 +8754,7 @@ dependencies = [
 
 [[package]]
 name = "servo-storage-traits"
-version = "0.0.6"
+version = "0.1.0"
 dependencies = [
  "malloc_size_of_derive",
  "serde",
@@ -8767,7 +8767,7 @@ dependencies = [
 
 [[package]]
 name = "servo-timers"
-version = "0.0.6"
+version = "0.1.0"
 dependencies = [
  "crossbeam-channel",
  "malloc_size_of_derive",
@@ -8776,7 +8776,7 @@ dependencies = [
 
 [[package]]
 name = "servo-tracing"
-version = "0.0.6"
+version = "0.1.0"
 dependencies = [
  "prettyplease",
  "proc-macro2",
@@ -8786,7 +8786,7 @@ dependencies = [
 
 [[package]]
 name = "servo-url"
-version = "0.0.6"
+version = "0.1.0"
 dependencies = [
  "encoding_rs",
  "malloc_size_of_derive",
@@ -8799,7 +8799,7 @@ dependencies = [
 
 [[package]]
 name = "servo-webdriver-server"
-version = "0.0.6"
+version = "0.1.0"
 dependencies = [
  "base64 0.22.1",
  "cookie 0.18.1",
@@ -8825,7 +8825,7 @@ dependencies = [
 
 [[package]]
 name = "servo-webgl"
-version = "0.0.6"
+version = "0.1.0"
 dependencies = [
  "bitflags 2.11.0",
  "byteorder",
@@ -8849,7 +8849,7 @@ dependencies = [
 
 [[package]]
 name = "servo-webgpu"
-version = "0.0.6"
+version = "0.1.0"
 dependencies = [
  "arrayvec",
  "euclid",
@@ -8867,7 +8867,7 @@ dependencies = [
 
 [[package]]
 name = "servo-webgpu-traits"
-version = "0.0.6"
+version = "0.1.0"
 dependencies = [
  "arrayvec",
  "malloc_size_of_derive",
@@ -8882,7 +8882,7 @@ dependencies = [
 
 [[package]]
 name = "servo-webxr"
-version = "0.0.6"
+version = "0.1.0"
 dependencies = [
  "crossbeam-channel",
  "euclid",
@@ -8900,7 +8900,7 @@ dependencies = [
 
 [[package]]
 name = "servo-webxr-api"
-version = "0.0.6"
+version = "0.1.0"
 dependencies = [
  "euclid",
  "ipc-channel",
@@ -8915,7 +8915,7 @@ dependencies = [
 
 [[package]]
 name = "servo-xpath"
-version = "0.0.6"
+version = "0.1.0"
 dependencies = [
  "log",
  "malloc_size_of_derive",
@@ -8934,7 +8934,7 @@ dependencies = [
 
 [[package]]
 name = "servoshell"
-version = "0.0.6"
+version = "0.1.0"
 dependencies = [
  "accesskit",
  "android_logger",
@@ -9327,7 +9327,7 @@ dependencies = [
 
 [[package]]
 name = "style_tests"
-version = "0.0.6"
+version = "0.1.0"
 dependencies = [
  "app_units",
  "cssparser",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ default-members = ["ports/servoshell"]
 exclude = [".cargo", "support/crown"]
 
 [workspace.package]
-version = "0.0.6"
+version = "0.1.0"
 authors = ["The Servo Project Developers"]
 repository = "https://github.com/servo/servo"
 # A generic description for packages that don't have a meaningful description yet.
@@ -230,69 +230,69 @@ xml5ever = "0.39"
 # be listed here, between the `Begin` and `End` comments, so that we can easily find and
 # update the version requirements when bumping the workspace version.
 # Begin workspace-version dependencies - Don't change this comment, we grep for it in scripts!
-deny_public_fields = { package = "servo-deny-public-fields", version = "0.0.6", path = "components/deny_public_fields" }
-devtools = { package = "servo-devtools", version = "0.0.6", path = "components/devtools" }
-devtools_traits = { package = "servo-devtools-traits", version = "0.0.6", path = "components/shared/devtools" }
-dom_struct = { package = "servo-dom-struct", version = "0.0.6", path = "components/dom_struct" }
-embedder_traits = { package = "servo-embedder-traits", version = "0.0.6", path = "components/shared/embedder" }
-fonts = { package = "servo-fonts", version = "0.0.6", path = "components/fonts" }
-fonts_traits = { package = "servo-fonts-traits", version = "0.0.6", path = "components/shared/fonts" }
-jstraceable_derive = { package = "servo-jstraceable-derive", version = "0.0.6", path = "components/jstraceable_derive" }
-layout = { package = "servo-layout", version = "0.0.6", path = "components/layout" }
-layout_api = { package = "servo-layout-api", version = "0.0.6", path = "components/shared/layout" }
-malloc_size_of = { package = "servo-malloc-size-of", version = "0.0.6", path = "components/malloc_size_of" }
-media = { package = "servo-media-thread", version = "0.0.6", path = "components/media/media-thread" }
-metrics = { package = "servo-metrics", version = "0.0.6", path = "components/metrics" }
-net = { package = "servo-net", version = "0.0.6", path = "components/net" }
-net_traits = { package = "servo-net-traits", version = "0.0.6", path = "components/shared/net" }
-paint = { package = "servo-paint", version = "0.0.6", path = "components/paint" }
-paint_api = { package = "servo-paint-api", version = "0.0.6", path = "components/shared/paint" }
-pixels = { package = "servo-pixels", version = "0.0.6", path = "components/pixels" }
-profile = { package = "servo-profile", version = "0.0.6", path = "components/profile" }
-profile_traits = { package = "servo-profile-traits", version = "0.0.6", path = "components/shared/profile" }
-script = { package = "servo-script", version = "0.0.6", path = "components/script" }
-script_bindings = { package = "servo-script-bindings", version = "0.0.6", path = "components/script_bindings" }
-script_traits = { package = "servo-script-traits", version = "0.0.6", path = "components/shared/script" }
-servo = { version = "0.0.6", path = "components/servo", default-features = false }
-servo-allocator = { version = "0.0.6", path = "components/allocator" }
-servo-background-hang-monitor = { version = "0.0.6", path = "components/background_hang_monitor" }
-servo-background-hang-monitor-api = { version = "0.0.6", path = "components/shared/background_hang_monitor" }
-servo-base = { version = "0.0.6", path = "components/shared/base" }
-servo-bluetooth = { version = "0.0.6", path = "components/bluetooth" }
-servo-bluetooth-traits = { version = "0.0.6", path = "components/shared/bluetooth" }
-servo-canvas = { version = "0.0.6", path = "components/canvas" }
-servo-canvas-traits = { version = "0.0.6", path = "components/shared/canvas" }
-servo-config = { version = "0.0.6", path = "components/config" }
-servo-config-macro = { version = "0.0.6", path = "components/config/macro" }
-servo-constellation = { version = "0.0.6", path = "components/constellation" }
-servo-constellation-traits = { version = "0.0.6", path = "components/shared/constellation" }
-servo-default-resources = { version = "0.0.6", path = "components/default-resources" }
-servo-geometry = { version = "0.0.6", path = "components/geometry" }
-servo-media = { version = "0.0.6", path = "components/media/servo-media" }
-servo-media-audio = { version = "0.0.6", path = "components/media/audio" }
-servo-media-auto = { version = "0.0.6", path = "components/media/backends/auto" }
-servo-media-derive = { version = "0.0.6", path = "components/media/servo-media-derive" }
-servo-media-dummy = { version = "0.0.6", path = "components/media/backends/dummy" }
-servo-media-gstreamer = { version = "0.0.6", path = "components/media/backends/gstreamer" }
-servo-media-gstreamer-render = { version = "0.0.6", path = "components/media/backends/gstreamer/render" }
-servo-media-gstreamer-render-android = { version = "0.0.6", path = "components/media/backends/gstreamer/render-android" }
-servo-media-gstreamer-render-unix = { version = "0.0.6", path = "components/media/backends/gstreamer/render-unix" }
-servo-media-player = { version = "0.0.6", path = "components/media/player" }
-servo-media-streams = { version = "0.0.6", path = "components/media/streams" }
-servo-media-traits = { version = "0.0.6", path = "components/media/traits" }
-servo-media-webrtc = { version = "0.0.6", path = "components/media/webrtc" }
-servo-tracing = { version = "0.0.6", path = "components/servo_tracing" }
-servo-url = { version = "0.0.6", path = "components/url" }
-storage = { package = "servo-storage", version = "0.0.6", path = "components/storage" }
-storage_traits = { package = "servo-storage-traits", version = "0.0.6", path = "components/shared/storage" }
-timers = { package = "servo-timers", version = "0.0.6", path = "components/timers" }
-webdriver_server = { package = "servo-webdriver-server", version = "0.0.6", path = "components/webdriver_server" }
-webgl = { package = "servo-webgl", version = "0.0.6", path = "components/webgl", default-features = false }
-webgpu = { package = "servo-webgpu", version = "0.0.6", path = "components/webgpu" }
-webgpu_traits = { package = "servo-webgpu-traits", version = "0.0.6", path = "components/shared/webgpu" }
-webxr = { package = "servo-webxr", version = "0.0.6", path = "components/webxr" }
-webxr-api = { package = "servo-webxr-api", version = "0.0.6", path = "components/shared/webxr" }
-xpath = { package = "servo-xpath", version = "0.0.6", path = "components/xpath" }
+deny_public_fields = { package = "servo-deny-public-fields", version = "0.1.0", path = "components/deny_public_fields" }
+devtools = { package = "servo-devtools", version = "0.1.0", path = "components/devtools" }
+devtools_traits = { package = "servo-devtools-traits", version = "0.1.0", path = "components/shared/devtools" }
+dom_struct = { package = "servo-dom-struct", version = "0.1.0", path = "components/dom_struct" }
+embedder_traits = { package = "servo-embedder-traits", version = "0.1.0", path = "components/shared/embedder" }
+fonts = { package = "servo-fonts", version = "0.1.0", path = "components/fonts" }
+fonts_traits = { package = "servo-fonts-traits", version = "0.1.0", path = "components/shared/fonts" }
+jstraceable_derive = { package = "servo-jstraceable-derive", version = "0.1.0", path = "components/jstraceable_derive" }
+layout = { package = "servo-layout", version = "0.1.0", path = "components/layout" }
+layout_api = { package = "servo-layout-api", version = "0.1.0", path = "components/shared/layout" }
+malloc_size_of = { package = "servo-malloc-size-of", version = "0.1.0", path = "components/malloc_size_of" }
+media = { package = "servo-media-thread", version = "0.1.0", path = "components/media/media-thread" }
+metrics = { package = "servo-metrics", version = "0.1.0", path = "components/metrics" }
+net = { package = "servo-net", version = "0.1.0", path = "components/net" }
+net_traits = { package = "servo-net-traits", version = "0.1.0", path = "components/shared/net" }
+paint = { package = "servo-paint", version = "0.1.0", path = "components/paint" }
+paint_api = { package = "servo-paint-api", version = "0.1.0", path = "components/shared/paint" }
+pixels = { package = "servo-pixels", version = "0.1.0", path = "components/pixels" }
+profile = { package = "servo-profile", version = "0.1.0", path = "components/profile" }
+profile_traits = { package = "servo-profile-traits", version = "0.1.0", path = "components/shared/profile" }
+script = { package = "servo-script", version = "0.1.0", path = "components/script" }
+script_bindings = { package = "servo-script-bindings", version = "0.1.0", path = "components/script_bindings" }
+script_traits = { package = "servo-script-traits", version = "0.1.0", path = "components/shared/script" }
+servo = { version = "0.1.0", path = "components/servo", default-features = false }
+servo-allocator = { version = "0.1.0", path = "components/allocator" }
+servo-background-hang-monitor = { version = "0.1.0", path = "components/background_hang_monitor" }
+servo-background-hang-monitor-api = { version = "0.1.0", path = "components/shared/background_hang_monitor" }
+servo-base = { version = "0.1.0", path = "components/shared/base" }
+servo-bluetooth = { version = "0.1.0", path = "components/bluetooth" }
+servo-bluetooth-traits = { version = "0.1.0", path = "components/shared/bluetooth" }
+servo-canvas = { version = "0.1.0", path = "components/canvas" }
+servo-canvas-traits = { version = "0.1.0", path = "components/shared/canvas" }
+servo-config = { version = "0.1.0", path = "components/config" }
+servo-config-macro = { version = "0.1.0", path = "components/config/macro" }
+servo-constellation = { version = "0.1.0", path = "components/constellation" }
+servo-constellation-traits = { version = "0.1.0", path = "components/shared/constellation" }
+servo-default-resources = { version = "0.1.0", path = "components/default-resources" }
+servo-geometry = { version = "0.1.0", path = "components/geometry" }
+servo-media = { version = "0.1.0", path = "components/media/servo-media" }
+servo-media-audio = { version = "0.1.0", path = "components/media/audio" }
+servo-media-auto = { version = "0.1.0", path = "components/media/backends/auto" }
+servo-media-derive = { version = "0.1.0", path = "components/media/servo-media-derive" }
+servo-media-dummy = { version = "0.1.0", path = "components/media/backends/dummy" }
+servo-media-gstreamer = { version = "0.1.0", path = "components/media/backends/gstreamer" }
+servo-media-gstreamer-render = { version = "0.1.0", path = "components/media/backends/gstreamer/render" }
+servo-media-gstreamer-render-android = { version = "0.1.0", path = "components/media/backends/gstreamer/render-android" }
+servo-media-gstreamer-render-unix = { version = "0.1.0", path = "components/media/backends/gstreamer/render-unix" }
+servo-media-player = { version = "0.1.0", path = "components/media/player" }
+servo-media-streams = { version = "0.1.0", path = "components/media/streams" }
+servo-media-traits = { version = "0.1.0", path = "components/media/traits" }
+servo-media-webrtc = { version = "0.1.0", path = "components/media/webrtc" }
+servo-tracing = { version = "0.1.0", path = "components/servo_tracing" }
+servo-url = { version = "0.1.0", path = "components/url" }
+storage = { package = "servo-storage", version = "0.1.0", path = "components/storage" }
+storage_traits = { package = "servo-storage-traits", version = "0.1.0", path = "components/shared/storage" }
+timers = { package = "servo-timers", version = "0.1.0", path = "components/timers" }
+webdriver_server = { package = "servo-webdriver-server", version = "0.1.0", path = "components/webdriver_server" }
+webgl = { package = "servo-webgl", version = "0.1.0", path = "components/webgl", default-features = false }
+webgpu = { package = "servo-webgpu", version = "0.1.0", path = "components/webgpu" }
+webgpu_traits = { package = "servo-webgpu-traits", version = "0.1.0", path = "components/shared/webgpu" }
+webxr = { package = "servo-webxr", version = "0.1.0", path = "components/webxr" }
+webxr-api = { package = "servo-webxr-api", version = "0.1.0", path = "components/shared/webxr" }
+xpath = { package = "servo-xpath", version = "0.1.0", path = "components/xpath" }
 # End workspace-version dependencies - Don't change this comment, we grep for it in scripts!
 
 # Independently versioned workspace local crates. These crates will not take part in auto-bumps.

--- a/ports/servoshell/platform/macos/Info.plist
+++ b/ports/servoshell/platform/macos/Info.plist
@@ -17,7 +17,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.0.6</string>
+	<string>0.1.0</string>
 	<key>NSHighResolutionCapable</key>
 	<true/>
 	<key>NSPrincipalClass</key>

--- a/ports/servoshell/platform/windows/servoshell.exe.manifest
+++ b/ports/servoshell/platform/windows/servoshell.exe.manifest
@@ -4,7 +4,7 @@
           xmlns:asmv3="urn:schemas-microsoft-com:asm.v3">
   <assemblyIdentity type="win32"
                     name="servo.ServoShell"
-                    version="0.0.6.0"/>
+                    version="0.1.0.0"/>
 
   <compatibility xmlns="urn:schemas-microsoft-com:compatibility.v1">
     <application>

--- a/resources/resource_protocol/license.html
+++ b/resources/resource_protocol/license.html
@@ -61,7 +61,6 @@
             <li><a href="#CC0-1.0">Creative Commons Zero v1.0 Universal</a></li>
             <li><a href="#NCSA">University of Illinois/NCSA Open Source License</a></li>
             <li><a href="#OFL-1.1">SIL Open Font License 1.1</a></li>
-            <li><a href="#OpenSSL">OpenSSL License</a></li>
             <li><a href="#Ubuntu-font-1.0">Ubuntu Font Licence v1.0</a></li>
         </ul>
 
@@ -1341,7 +1340,7 @@
                         <li><a href=" https://github.com/paritytech/nohash-hasher ">nohash-hasher 0.2.0</a></li>
                         <li><a href=" https://github.com/Ralith/openxrs ">openxr-sys 0.12.0</a></li>
                         <li><a href=" https://github.com/nvzqz/static-assertions-rs ">static_assertions 1.1.0</a></li>
-                        <li><a href=" https://github.com/Lokathor/tinyvec ">tinyvec 1.10.0</a></li>
+                        <li><a href=" https://github.com/Lokathor/tinyvec ">tinyvec 1.11.0</a></li>
                         <li><a href=" https://github.com/hsivonen/utf16_iter ">utf16_iter 1.0.5</a></li>
                         <li><a href=" https://github.com/hsivonen/utf8_iter ">utf8_iter 1.0.4</a></li>
                         <li><a href=" https://github.com/hsivonen/write16 ">write16 1.0.0</a></li>
@@ -2230,6 +2229,7 @@ Software.
                         <li><a href=" https://github.com/microsoft/windows-rs ">windows-strings 0.5.1</a></li>
                         <li><a href=" https://github.com/microsoft/windows-rs ">windows-sys 0.45.0</a></li>
                         <li><a href=" https://github.com/microsoft/windows-rs ">windows-sys 0.52.0</a></li>
+                        <li><a href=" https://github.com/microsoft/windows-rs ">windows-sys 0.59.0</a></li>
                         <li><a href=" https://github.com/microsoft/windows-rs ">windows-sys 0.60.2</a></li>
                         <li><a href=" https://github.com/microsoft/windows-rs ">windows-sys 0.61.2</a></li>
                         <li><a href=" https://github.com/microsoft/windows-rs ">windows-targets 0.42.2</a></li>
@@ -2681,8 +2681,8 @@ Software.
                 <h3 id="Apache-2.0">Apache License 2.0</h3>
                     <h4>Used by:</h4>
                     <ul class="license-used-by">
-                        <li><a href=" https://github.com/google/zerocopy ">zerocopy-derive 0.8.40</a></li>
-                        <li><a href=" https://github.com/google/zerocopy ">zerocopy 0.8.40</a></li>
+                        <li><a href=" https://github.com/google/zerocopy ">zerocopy-derive 0.8.48</a></li>
+                        <li><a href=" https://github.com/google/zerocopy ">zerocopy 0.8.48</a></li>
                     </ul>
                 <pre class="license-text">                                 Apache License
                            Version 2.0, January 2004
@@ -3525,7 +3525,7 @@ Software.
                 <h3 id="Apache-2.0">Apache License 2.0</h3>
                     <p>
                         Used by
-                            <a href=" https://github.com/krisprice/ipnet ">ipnet 2.11.0</a>
+                            <a href=" https://github.com/krisprice/ipnet ">ipnet 2.12.0</a>
                     </p>
                 <pre class="license-text">                                 Apache License
                            Version 2.0, January 2004
@@ -3949,13 +3949,13 @@ Software.
                         <li><a href=" https://github.com/rust-cli/anstyle.git ">anstyle-parse 0.2.7</a></li>
                         <li><a href=" https://github.com/rust-cli/anstyle.git ">anstyle-query 1.1.5</a></li>
                         <li><a href=" https://github.com/rust-cli/anstyle.git ">anstyle-wincon 3.0.11</a></li>
-                        <li><a href=" https://github.com/rust-cli/anstyle.git ">anstyle 1.0.13</a></li>
-                        <li><a href=" https://github.com/clap-rs/clap ">clap 4.5.60</a></li>
-                        <li><a href=" https://github.com/clap-rs/clap ">clap_builder 4.5.60</a></li>
-                        <li><a href=" https://github.com/clap-rs/clap ">clap_lex 1.0.0</a></li>
+                        <li><a href=" https://github.com/rust-cli/anstyle.git ">anstyle 1.0.14</a></li>
+                        <li><a href=" https://github.com/clap-rs/clap ">clap 4.6.0</a></li>
+                        <li><a href=" https://github.com/clap-rs/clap ">clap_builder 4.6.0</a></li>
+                        <li><a href=" https://github.com/clap-rs/clap ">clap_lex 1.1.0</a></li>
                         <li><a href=" https://github.com/jamesmunns/cobs.rs ">cobs 0.3.0</a></li>
-                        <li><a href=" https://github.com/rust-cli/anstyle.git ">colorchoice 1.0.4</a></li>
-                        <li><a href=" https://github.com/rust-ammonia/rust-content-security-policy ">content-security-policy 0.6.0</a></li>
+                        <li><a href=" https://github.com/rust-cli/anstyle.git ">colorchoice 1.0.5</a></li>
+                        <li><a href=" https://github.com/rust-ammonia/rust-content-security-policy ">content-security-policy 0.8.0</a></li>
                         <li><a href=" https://github.com/srijs/rust-crc32fast ">crc32fast 1.5.0</a></li>
                         <li><a href=" https://github.com/rust-cli/env_logger ">env_filter 0.1.4</a></li>
                         <li><a href=" https://github.com/rust-cli/env_logger ">env_logger 0.11.8</a></li>
@@ -3967,19 +3967,21 @@ Software.
                         <li><a href=" https://github.com/KokaKiwi/rust-hex ">hex 0.3.2</a></li>
                         <li><a href=" https://github.com/KokaKiwi/rust-hex ">hex 0.4.3</a></li>
                         <li><a href=" https://github.com/polyfill-rs/is_terminal_polyfill ">is_terminal_polyfill 1.70.2</a></li>
-                        <li><a href=" https://github.com/sfackler/rust-jni-sys ">jni-sys 0.3.0</a></li>
+                        <li><a href=" https://github.com/jni-rs/jni-sys ">jni-sys 0.3.1</a></li>
+                        <li><a href=" https://github.com/jni-rs/jni-sys ">jni-sys 0.4.1</a></li>
                         <li><a href=" https://github.com/cobalt-org/kstring ">kstring 2.0.2</a></li>
                         <li><a href=" https://github.com/polyfill-rs/once_cell_polyfill ">once_cell_polyfill 1.70.2</a></li>
                         <li><a href=" http://github.com/tailhook/quick-error ">quick-error 2.0.1</a></li>
                         <li><a href=" https://github.com/toml-rs/toml ">serde_spanned 0.6.9</a></li>
                         <li><a href=" https://github.com/toml-rs/toml ">toml 0.8.23</a></li>
                         <li><a href=" https://github.com/toml-rs/toml ">toml_datetime 0.6.11</a></li>
-                        <li><a href=" https://github.com/toml-rs/toml ">toml_datetime 0.7.3</a></li>
+                        <li><a href=" https://github.com/toml-rs/toml ">toml_datetime 1.0.0+spec-1.1.0</a></li>
                         <li><a href=" https://github.com/toml-rs/toml ">toml_edit 0.22.27</a></li>
-                        <li><a href=" https://github.com/toml-rs/toml ">toml_edit 0.23.7</a></li>
+                        <li><a href=" https://github.com/toml-rs/toml ">toml_edit 0.25.4+spec-1.1.0</a></li>
                         <li><a href=" https://github.com/toml-rs/toml ">toml_parser 1.0.9+spec-1.1.0</a></li>
                         <li><a href=" https://github.com/toml-rs/toml ">toml_write 0.1.2</a></li>
                         <li><a href=" https://github.com/gifnksm/topological-sort-rs ">topological-sort 0.1.0</a></li>
+                        <li><a href=" https://github.com/swgillespie/unicode-categories ">unicode_categories 0.1.1</a></li>
                     </ul>
                 <pre class="license-text">                                 Apache License
                            Version 2.0, January 2004
@@ -7541,12 +7543,12 @@ limitations under the License.</pre>
                     <h4>Used by:</h4>
                     <ul class="license-used-by">
                         <li><a href=" https://github.com/servo/stylo ">servo_arc 0.4.3</a></li>
-                        <li><a href=" https://github.com/servo/stylo ">stylo_malloc_size_of 0.12.0</a></li>
-                        <li><a href=" https://crates.io/crates/servo_malloc_size_of ">servo_malloc_size_of 0.0.1</a></li>
+                        <li><a href=" https://github.com/servo/stylo ">stylo_malloc_size_of 0.14.0</a></li>
+                        <li><a href=" https://github.com/servo/servo ">servo-malloc-size-of 0.1.0</a></li>
                         <li><a href=" https://github.com/gimli-rs/addr2line ">addr2line 0.25.1</a></li>
                         <li><a href=" https://github.com/tkaitchuck/ahash ">ahash 0.8.12</a></li>
                         <li><a href=" https://github.com/rust-fuzz/arbitrary/ ">arbitrary 1.4.2</a></li>
-                        <li><a href=" https://github.com/vorner/arc-swap ">arc-swap 1.8.2</a></li>
+                        <li><a href=" https://github.com/vorner/arc-swap ">arc-swap 1.9.0</a></li>
                         <li><a href=" https://github.com/bluss/arrayvec ">arrayvec 0.7.6</a></li>
                         <li><a href=" https://github.com/smol-rs/async-channel ">async-channel 2.5.0</a></li>
                         <li><a href=" https://github.com/smol-rs/async-executor ">async-executor 1.14.0</a></li>
@@ -7565,16 +7567,16 @@ limitations under the License.</pre>
                         <li><a href=" https://github.com/bitflags/bitflags ">bitflags 2.11.0</a></li>
                         <li><a href=" https://github.com/tuffy/bitstream-io ">bitstream-io 2.6.0</a></li>
                         <li><a href=" https://github.com/smol-rs/blocking ">blocking 1.6.2</a></li>
-                        <li><a href=" https://github.com/pacak/bpaf ">bpaf 0.9.23</a></li>
+                        <li><a href=" https://github.com/pacak/bpaf ">bpaf 0.9.24</a></li>
                         <li><a href=" https://github.com/pacak/bpaf ">bpaf_derive 0.5.23</a></li>
                         <li><a href=" https://github.com/mikedilger/buf-read-ext ">buf-read-ext 0.4.0</a></li>
                         <li><a href=" https://github.com/fitzgen/bumpalo ">bumpalo 3.20.2</a></li>
                         <li><a href=" https://github.com/japaric/cast.rs ">cast 0.3.0</a></li>
-                        <li><a href=" https://github.com/rust-lang/cc-rs ">cc 1.2.56</a></li>
+                        <li><a href=" https://github.com/rust-lang/cc-rs ">cc 1.2.58</a></li>
                         <li><a href=" https://github.com/jethrogb/rust-cexpr ">cexpr 0.6.0</a></li>
                         <li><a href=" https://github.com/rust-lang/cfg-if ">cfg-if 1.0.4</a></li>
                         <li><a href=" https://github.com/servo/cgl-rs ">cgl 0.3.2</a></li>
-                        <li><a href=" https://github.com/rust-lang/cmake-rs ">cmake 0.1.57</a></li>
+                        <li><a href=" https://github.com/rust-lang/cmake-rs ">cmake 0.1.58</a></li>
                         <li><a href=" https://github.com/smol-rs/concurrent-queue ">concurrent-queue 2.5.0</a></li>
                         <li><a href=" https://github.com/servo/core-foundation-rs ">core-foundation-sys 0.8.7</a></li>
                         <li><a href=" https://github.com/servo/core-foundation-rs ">core-foundation 0.10.1</a></li>
@@ -7595,7 +7597,7 @@ limitations under the License.</pre>
                         <li><a href=" https://github.com/rayon-rs/either ">either 1.15.0</a></li>
                         <li><a href=" https://github.com/indexmap-rs/equivalent ">equivalent 1.0.2</a></li>
                         <li><a href=" https://github.com/lambda-fairy/rust-errno ">errno 0.3.14</a></li>
-                        <li><a href=" https://github.com/servo/euclid ">euclid 0.22.13</a></li>
+                        <li><a href=" https://github.com/servo/euclid ">euclid 0.22.14</a></li>
                         <li><a href=" https://github.com/smol-rs/event-listener-strategy ">event-listener-strategy 0.5.4</a></li>
                         <li><a href=" https://github.com/smol-rs/event-listener ">event-listener 5.4.1</a></li>
                         <li><a href=" https://github.com/smol-rs/fastrand ">fastrand 2.3.0</a></li>
@@ -7621,14 +7623,14 @@ limitations under the License.</pre>
                         <li><a href=" https://gitlab.freedesktop.org/gstreamer/gstreamer-rs ">gstreamer-sdp 0.25.0</a></li>
                         <li><a href=" https://gitlab.freedesktop.org/gstreamer/gstreamer-rs ">gstreamer-video 0.25.0</a></li>
                         <li><a href=" https://gitlab.freedesktop.org/gstreamer/gstreamer-rs ">gstreamer-webrtc 0.25.0</a></li>
-                        <li><a href=" https://gitlab.freedesktop.org/gstreamer/gstreamer-rs ">gstreamer 0.25.0</a></li>
+                        <li><a href=" https://gitlab.freedesktop.org/gstreamer/gstreamer-rs ">gstreamer 0.25.1</a></li>
                         <li><a href=" https://github.com/servo/rust-harfbuzz ">harfbuzz-sys 0.6.1</a></li>
                         <li><a href=" https://github.com/rust-lang/hashbrown ">hashbrown 0.15.5</a></li>
                         <li><a href=" https://github.com/rust-lang/hashbrown ">hashbrown 0.16.0</a></li>
                         <li><a href=" https://github.com/withoutboats/heck ">heck 0.4.1</a></li>
                         <li><a href=" https://github.com/withoutboats/heck ">heck 0.5.0</a></li>
                         <li><a href=" https://github.com/hermit-os/hermit-rs ">hermit-abi 0.5.2</a></li>
-                        <li><a href=" https://github.com/servo/html5ever ">html5ever 0.38.0</a></li>
+                        <li><a href=" https://github.com/servo/html5ever ">html5ever 0.39.0</a></li>
                         <li><a href=" https://github.com/seanmonstar/httparse ">httparse 1.10.1</a></li>
                         <li><a href=" https://github.com/rustls/hyper-rustls ">hyper-rustls 0.27.7</a></li>
                         <li><a href=" https://github.com/servo/rust-url/ ">idna 1.1.0</a></li>
@@ -7645,13 +7647,13 @@ limitations under the License.</pre>
                         <li><a href=" https://github.com/timothee-haudebourg/khronos-egl ">khronos-egl 6.0.0</a></li>
                         <li><a href=" https://github.com/rust-lang-nursery/lazy-static.rs ">lazy_static 1.5.0</a></li>
                         <li><a href=" https://github.com/rust-fuzz/libfuzzer ">libfuzzer-sys 0.4.12</a></li>
-                        <li><a href=" https://github.com/rust-lang/libz-sys ">libz-sys 1.1.24</a></li>
+                        <li><a href=" https://github.com/rust-lang/libz-sys ">libz-sys 1.1.25</a></li>
                         <li><a href=" https://github.com/sunfishcode/linux-raw-sys ">linux-raw-sys 0.11.0</a></li>
                         <li><a href=" https://github.com/sunfishcode/linux-raw-sys ">linux-raw-sys 0.4.15</a></li>
                         <li><a href=" https://github.com/Amanieu/parking_lot ">lock_api 0.4.14</a></li>
                         <li><a href=" https://github.com/rust-lang/log ">log 0.4.29</a></li>
                         <li><a href=" https://github.com/bholley/malloc_size_of_derive ">malloc_size_of_derive 0.1.3</a></li>
-                        <li><a href=" https://github.com/servo/html5ever ">markup5ever 0.38.0</a></li>
+                        <li><a href=" https://github.com/servo/html5ever ">markup5ever 0.39.0</a></li>
                         <li><a href=" https://github.com/gfx-rs/metal-rs ">metal 0.32.0</a></li>
                         <li><a href=" https://github.com/gw-de/mime-multipart-hyper1 ">mime-multipart-hyper1 0.10.0</a></li>
                         <li><a href=" https://github.com/hyperium/mime ">mime 0.3.17</a></li>
@@ -7665,7 +7667,7 @@ limitations under the License.</pre>
                         <li><a href=" https://github.com/rust-num/num-traits ">num-traits 0.2.19</a></li>
                         <li><a href=" https://github.com/seanmonstar/num_cpus ">num_cpus 1.17.0</a></li>
                         <li><a href=" https://github.com/gimli-rs/object ">object 0.37.3</a></li>
-                        <li><a href=" https://github.com/matklad/once_cell ">once_cell 1.21.3</a></li>
+                        <li><a href=" https://github.com/matklad/once_cell ">once_cell 1.21.4</a></li>
                         <li><a href=" https://github.com/rustls/openssl-probe ">openssl-probe 0.2.1</a></li>
                         <li><a href=" https://github.com/fengalin/option-operations ">option-operations 0.6.1</a></li>
                         <li><a href=" https://github.com/danieldg/ordered-stream ">ordered-stream 0.2.0</a></li>
@@ -7677,8 +7679,9 @@ limitations under the License.</pre>
                         <li><a href=" https://github.com/servo/webrender ">peek-poke 0.3.0</a></li>
                         <li><a href=" https://github.com/servo/rust-url/ ">percent-encoding 2.3.2</a></li>
                         <li><a href=" https://github.com/bluss/petgraph ">petgraph 0.4.13</a></li>
-                        <li><a href=" https://github.com/smol-rs/piper ">piper 0.2.4</a></li>
+                        <li><a href=" https://github.com/smol-rs/piper ">piper 0.2.5</a></li>
                         <li><a href=" https://github.com/rust-lang/pkg-config-rs ">pkg-config 0.3.32</a></li>
+                        <li><a href=" https://github.com/randomites/plain ">plain 0.2.3</a></li>
                         <li><a href=" https://github.com/image-rs/image-png ">png 0.17.16</a></li>
                         <li><a href=" https://github.com/smol-rs/polling ">polling 3.11.0</a></li>
                         <li><a href=" https://github.com/jamesmunns/postcard ">postcard 1.1.3</a></li>
@@ -7715,7 +7718,7 @@ limitations under the License.</pre>
                         <li><a href=" https://github.com/linebender/svgtypes ">svgtypes 0.15.3</a></li>
                         <li><a href=" https://github.com/gdesmott/system-deps ">system-deps 6.2.2</a></li>
                         <li><a href=" https://github.com/gdesmott/system-deps ">system-deps 7.0.5</a></li>
-                        <li><a href=" https://github.com/alexcrichton/tar-rs ">tar 0.4.44</a></li>
+                        <li><a href=" https://github.com/alexcrichton/tar-rs ">tar 0.4.45</a></li>
                         <li><a href=" https://github.com/Stebalien/tempfile ">tempfile 3.23.0</a></li>
                         <li><a href=" https://github.com/servo/html5ever ">tendril 0.5.0</a></li>
                         <li><a href=" https://github.com/mikedilger/textnonce ">textnonce 1.0.0</a></li>
@@ -7723,17 +7726,17 @@ limitations under the License.</pre>
                         <li><a href=" https://github.com/tikv/jemallocator ">tikv-jemallocator 0.6.1</a></li>
                         <li><a href=" https://github.com/bheisler/TinyTemplate ">tinytemplate 1.2.1</a></li>
                         <li><a href=" https://github.com/harfbuzz/ttf-parser ">ttf-parser 0.25.1</a></li>
-                        <li><a href=" https://github.com/snapview/tungstenite-rs ">tungstenite 0.28.0</a></li>
+                        <li><a href=" https://github.com/snapview/tungstenite-rs ">tungstenite 0.29.0</a></li>
                         <li><a href=" https://github.com/seanmonstar/unicase ">unicase 2.9.0</a></li>
                         <li><a href=" https://github.com/RazrFalcon/unicode-bidi-mirroring ">unicode-bidi-mirroring 0.4.0</a></li>
                         <li><a href=" https://github.com/servo/unicode-bidi ">unicode-bidi 0.3.18</a></li>
                         <li><a href=" https://github.com/RazrFalcon/unicode-ccc ">unicode-ccc 0.4.0</a></li>
                         <li><a href=" https://github.com/unicode-rs/unicode-properties ">unicode-properties 0.1.4</a></li>
-                        <li><a href=" https://github.com/unicode-rs/unicode-segmentation ">unicode-segmentation 1.12.0</a></li>
+                        <li><a href=" https://github.com/unicode-rs/unicode-segmentation ">unicode-segmentation 1.13.2</a></li>
                         <li><a href=" https://github.com/RazrFalcon/unicode-vo ">unicode-vo 0.1.0</a></li>
                         <li><a href=" https://github.com/unicode-rs/unicode-width ">unicode-width 0.2.2</a></li>
                         <li><a href=" https://github.com/servo/rust-url ">url 2.5.8</a></li>
-                        <li><a href=" https://github.com/uuid-rs/uuid ">uuid 1.21.0</a></li>
+                        <li><a href=" https://github.com/uuid-rs/uuid ">uuid 1.23.0</a></li>
                         <li><a href=" https://github.com/SergioBenitez/version_check ">version_check 0.9.5</a></li>
                         <li><a href=" https://github.com/bytecodealliance/wasi ">wasi 0.11.1+wasi-snapshot-preview1</a></li>
                         <li><a href=" https://github.com/bytecodealliance/wasi ">wasi 0.9.0+wasi-snapshot-preview1</a></li>
@@ -7747,7 +7750,7 @@ limitations under the License.</pre>
                         <li><a href=" https://github.com/bytecodealliance/wit-bindgen ">wit-bindgen 0.51.0</a></li>
                         <li><a href=" https://crates.io/crates/wr_malloc_size_of ">wr_malloc_size_of 0.2.2</a></li>
                         <li><a href=" https://github.com/Stebalien/xattr ">xattr 1.6.1</a></li>
-                        <li><a href=" https://github.com/servo/html5ever ">xml5ever 0.38.0</a></li>
+                        <li><a href=" https://github.com/servo/html5ever ">xml5ever 0.39.0</a></li>
                     </ul>
                 <pre class="license-text">                              Apache License
                         Version 2.0, January 2004
@@ -9679,7 +9682,7 @@ limitations under the License.
                     <h4>Used by:</h4>
                     <ul class="license-used-by">
                         <li><a href=" https://github.com/oyvindln/adler2 ">adler2 2.0.1</a></li>
-                        <li><a href=" https://github.com/bkchr/proc-macro-crate ">proc-macro-crate 3.4.0</a></li>
+                        <li><a href=" https://github.com/bkchr/proc-macro-crate ">proc-macro-crate 3.5.0</a></li>
                     </ul>
                 <pre class="license-text">                              Apache License
                         Version 2.0, January 2004
@@ -11240,7 +11243,7 @@ limitations under the License.
                     <h4>Used by:</h4>
                     <ul class="license-used-by">
                         <li><a href=" https://github.com/rust-windowing/winit ">dpi 0.1.2</a></li>
-                        <li><a href=" https://github.com/rust-windowing/winit ">winit 0.30.12</a></li>
+                        <li><a href=" https://github.com/rust-windowing/winit ">winit 0.30.13</a></li>
                     </ul>
                 <pre class="license-text">Apache License
                            Version 2.0, January 2004
@@ -12363,24 +12366,25 @@ limitations under the License.
                         <li><a href=" https://github.com/emilk/egui/tree/main/crates/emath ">emath 0.33.3</a></li>
                         <li><a href=" https://github.com/emilk/egui/tree/main/crates/epaint ">epaint 0.33.3</a></li>
                         <li><a href=" https://github.com/emilk/egui/tree/main/crates/epaint_default_fonts ">epaint_default_fonts 0.33.3</a></li>
-                        <li><a href=" https://github.com/servo/servo ">hyper_serde 0.13.2</a></li>
+                        <li><a href=" https://github.com/servo/servo ">servo-hyper-serde 0.13.2</a></li>
                         <li><a href=" https://github.com/alexheretic/ab-glyph ">ab_glyph 0.2.32</a></li>
                         <li><a href=" https://github.com/alexheretic/ab-glyph ">ab_glyph_rasterizer 0.1.10</a></li>
                         <li><a href=" https://github.com/AccessKit/accesskit ">accesskit 0.24.0</a></li>
-                        <li><a href=" https://github.com/AccessKit/accesskit ">accesskit_atspi_common 0.17.0</a></li>
-                        <li><a href=" https://github.com/AccessKit/accesskit ">accesskit_consumer 0.34.0</a></li>
-                        <li><a href=" https://github.com/AccessKit/accesskit ">accesskit_macos 0.25.0</a></li>
-                        <li><a href=" https://github.com/AccessKit/accesskit ">accesskit_unix 0.20.0</a></li>
-                        <li><a href=" https://github.com/AccessKit/accesskit ">accesskit_windows 0.32.0</a></li>
-                        <li><a href=" https://github.com/AccessKit/accesskit ">accesskit_winit 0.32.1</a></li>
+                        <li><a href=" https://github.com/AccessKit/accesskit ">accesskit_atspi_common 0.18.0</a></li>
+                        <li><a href=" https://github.com/AccessKit/accesskit ">accesskit_consumer 0.35.0</a></li>
+                        <li><a href=" https://github.com/AccessKit/accesskit ">accesskit_macos 0.26.0</a></li>
+                        <li><a href=" https://github.com/AccessKit/accesskit ">accesskit_unix 0.21.0</a></li>
+                        <li><a href=" https://github.com/AccessKit/accesskit ">accesskit_windows 0.32.1</a></li>
+                        <li><a href=" https://github.com/AccessKit/accesskit ">accesskit_winit 0.32.2</a></li>
                         <li><a href=" https://github.com/zakarumych/allocator-api2 ">allocator-api2 0.2.21</a></li>
                         <li><a href=" https://github.com/rust-mobile/android-activity ">android-activity 0.6.0</a></li>
                         <li><a href=" https://github.com/nical/android_system_properties ">android_system_properties 0.1.5</a></li>
                         <li><a href=" https://github.com/zrzka/anes-rs ">anes 0.1.6</a></li>
                         <li><a href=" https://github.com/dtolnay/anyhow ">anyhow 1.0.102</a></li>
                         <li><a href=" https://github.com/1Password/arboard ">arboard 3.6.1</a></li>
-                        <li><a href=" https://github.com/Nullus157/async-compression ">async-compression 0.4.40</a></li>
+                        <li><a href=" https://github.com/Nullus157/async-compression ">async-compression 0.4.41</a></li>
                         <li><a href=" https://github.com/dtolnay/async-trait ">async-trait 0.1.89</a></li>
+                        <li><a href=" https://github.com/aws/aws-lc-rs ">aws-lc-sys 0.39.1</a></li>
                         <li><a href=" https://github.com/jrmuizel/build-parallel ">build-parallel 0.1.2</a></li>
                         <li><a href=" https://github.com/emk/cesu8-rs ">cesu8 1.1.0</a></li>
                         <li><a href=" https://github.com/linebender/color ">color 0.3.2</a></li>
@@ -12413,10 +12417,12 @@ limitations under the License.
                         <li><a href=" https://github.com/image-rs/image-webp ">image-webp 0.2.4</a></li>
                         <li><a href=" https://github.com/image-rs/image ">image 0.25.6</a></li>
                         <li><a href=" https://github.com/dtolnay/inherent ">inherent 1.0.13</a></li>
-                        <li><a href=" https://github.com/dtolnay/itoa ">itoa 1.0.17</a></li>
+                        <li><a href=" https://github.com/dtolnay/inventory ">inventory 0.3.24</a></li>
+                        <li><a href=" https://github.com/dtolnay/itoa ">itoa 1.0.18</a></li>
+                        <li><a href=" https://github.com/jni-rs/jni-sys ">jni-sys-macros 0.4.1</a></li>
                         <li><a href=" https://github.com/RustCrypto/traits/tree/master/kem ">kem 0.3.0-pre.0</a></li>
                         <li><a href=" https://github.com/brendanzab/gl-rs/ ">khronos_api 3.1.0</a></li>
-                        <li><a href=" https://github.com/rust-lang/libc ">libc 0.2.182</a></li>
+                        <li><a href=" https://github.com/rust-lang/libc ">libc 0.2.183</a></li>
                         <li><a href=" https://github.com/linebender/raw_resource_handle ">linebender_resource_handle 0.1.1</a></li>
                         <li><a href=" https://github.com/LukasKalbertodt/litrs ">litrs 1.0.0</a></li>
                         <li><a href=" https://github.com/JohnTitor/mach2 ">mach2 0.6.0</a></li>
@@ -12426,8 +12432,8 @@ limitations under the License.
                         <li><a href=" https://github.com/rust-mobile/ndk ">ndk-sys 0.6.0+11769913</a></li>
                         <li><a href=" https://github.com/rust-mobile/ndk ">ndk 0.9.0</a></li>
                         <li><a href=" https://github.com/mishazharov/nom-rfc8288 ">nom-rfc8288 0.4.0</a></li>
-                        <li><a href=" https://github.com/illicitonion/num_enum ">num_enum 0.7.5</a></li>
-                        <li><a href=" https://github.com/illicitonion/num_enum ">num_enum_derive 0.7.5</a></li>
+                        <li><a href=" https://github.com/illicitonion/num_enum ">num_enum 0.7.6</a></li>
+                        <li><a href=" https://github.com/illicitonion/num_enum ">num_enum_derive 0.7.6</a></li>
                         <li><a href=" https://github.com/madsmtm/objc2 ">objc2-app-kit 0.3.2</a></li>
                         <li><a href=" https://github.com/madsmtm/objc2 ">objc2-core-foundation 0.3.2</a></li>
                         <li><a href=" https://github.com/madsmtm/objc2 ">objc2-core-graphics 0.3.2</a></li>
@@ -12450,25 +12456,25 @@ limitations under the License.
                         <li><a href=" https://github.com/alexheretic/owned-ttf-parser ">owned_ttf_parser 0.25.1</a></li>
                         <li><a href=" https://github.com/dtolnay/paste ">paste 1.0.15</a></li>
                         <li><a href=" https://github.com/as1100k/pastey ">pastey 0.2.1</a></li>
-                        <li><a href=" https://github.com/taiki-e/pin-project ">pin-project-internal 1.1.10</a></li>
-                        <li><a href=" https://github.com/taiki-e/pin-project-lite ">pin-project-lite 0.2.16</a></li>
-                        <li><a href=" https://github.com/taiki-e/pin-project ">pin-project 1.1.10</a></li>
-                        <li><a href=" https://github.com/taiki-e/portable-atomic ">portable-atomic-util 0.2.5</a></li>
+                        <li><a href=" https://github.com/taiki-e/pin-project ">pin-project-internal 1.1.11</a></li>
+                        <li><a href=" https://github.com/taiki-e/pin-project-lite ">pin-project-lite 0.2.17</a></li>
+                        <li><a href=" https://github.com/taiki-e/pin-project ">pin-project 1.1.11</a></li>
+                        <li><a href=" https://github.com/taiki-e/portable-atomic-util ">portable-atomic-util 0.2.6</a></li>
                         <li><a href=" https://github.com/taiki-e/portable-atomic ">portable-atomic 1.13.1</a></li>
                         <li><a href=" https://github.com/dtolnay/prettyplease ">prettyplease 0.2.37</a></li>
                         <li><a href=" https://github.com/dtolnay/proc-macro2 ">proc-macro2 1.0.106</a></li>
                         <li><a href=" https://github.com/aclysma/profiling ">profiling-procmacros 1.0.17</a></li>
                         <li><a href=" https://github.com/aclysma/profiling ">profiling 1.0.17</a></li>
-                        <li><a href=" https://github.com/dtolnay/quote ">quote 1.0.44</a></li>
+                        <li><a href=" https://github.com/dtolnay/quote ">quote 1.0.45</a></li>
                         <li><a href=" https://github.com/r-efi/r-efi ">r-efi 5.3.0</a></li>
                         <li><a href=" https://github.com/rust-random/rand ">rand 0.10.0</a></li>
                         <li><a href=" https://github.com/rust-random/rand ">rand 0.8.5</a></li>
                         <li><a href=" https://github.com/rust-random/rand ">rand 0.9.2</a></li>
                         <li><a href=" https://github.com/rust-random/rand ">rand_chacha 0.9.0</a></li>
-                        <li><a href=" https://github.com/gfx-rs/range-alloc ">range-alloc 0.1.4</a></li>
+                        <li><a href=" https://github.com/gfx-rs/range-alloc ">range-alloc 0.1.5</a></li>
                         <li><a href=" https://github.com/rust-windowing/raw-window-handle ">raw-window-handle 0.6.2</a></li>
                         <li><a href=" https://github.com/linebender/resvg ">resvg 0.45.1</a></li>
-                        <li><a href=" https://github.com/rust-lang/rustc-hash ">rustc-hash 2.1.1</a></li>
+                        <li><a href=" https://github.com/rust-lang/rustc-hash ">rustc-hash 2.1.2</a></li>
                         <li><a href=" https://github.com/rustls/rustls-platform-verifier ">rustls-platform-verifier-android 0.1.1</a></li>
                         <li><a href=" https://github.com/dtolnay/rustversion ">rustversion 1.0.22</a></li>
                         <li><a href=" https://github.com/dtolnay/ryu ">ryu 1.0.23</a></li>
@@ -12491,9 +12497,9 @@ limitations under the License.
                         <li><a href=" https://github.com/Actyx/sync_wrapper ">sync_wrapper 1.0.2</a></li>
                         <li><a href=" https://github.com/gankra/thin-vec ">thin-vec 0.2.14</a></li>
                         <li><a href=" https://github.com/dtolnay/thiserror ">thiserror-impl 1.0.69</a></li>
-                        <li><a href=" https://github.com/dtolnay/thiserror ">thiserror-impl 2.0.17</a></li>
+                        <li><a href=" https://github.com/dtolnay/thiserror ">thiserror-impl 2.0.18</a></li>
                         <li><a href=" https://github.com/dtolnay/thiserror ">thiserror 1.0.69</a></li>
-                        <li><a href=" https://github.com/dtolnay/thiserror ">thiserror 2.0.17</a></li>
+                        <li><a href=" https://github.com/dtolnay/thiserror ">thiserror 2.0.18</a></li>
                         <li><a href=" https://github.com/time-rs/time ">time-core 0.1.7</a></li>
                         <li><a href=" https://github.com/time-rs/time ">time-macros 0.2.25</a></li>
                         <li><a href=" https://github.com/time-rs/time ">time 0.3.45</a></li>
@@ -13019,7 +13025,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
                 <h3 id="BSD-3-Clause">BSD 3-Clause &quot;New&quot; or &quot;Revised&quot; License</h3>
                     <p>
                         Used by
-                            <a href=" https://github.com/servo/mozangle ">mozangle 0.5.4</a>
+                            <a href=" https://github.com/servo/mozangle ">mozangle 0.5.5</a>
                     </p>
                 <pre class="license-text">// Copyright (C) 2002-2013 The ANGLE Project Authors. 
 // All rights reserved.
@@ -13302,41 +13308,6 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
                 <h3 id="BSD-3-Clause">BSD 3-Clause &quot;New&quot; or &quot;Revised&quot; License</h3>
                     <p>
                         Used by
-                            <a href=" https://github.com/akosthekiss/blurmac ">blurmac 0.1.0</a>
-                    </p>
-                <pre class="license-text">Copyright (c) 2017 Akos Kiss.
-All rights reserved.
-
-Redistribution and use in source and binary forms, with or without
-modification, are permitted provided that the following conditions are met:
-
-1. Redistributions of source code must retain the above copyright notice, this
-   list of conditions and the following disclaimer.
-
-2. Redistributions in binary form must reproduce the above copyright notice,
-   this list of conditions and the following disclaimer in the documentation
-   and/or other materials provided with the distribution.
-
-3. Neither the name of the copyright holder nor the names of its contributors
-   may be used to endorse or promote products derived from this software
-   without specific prior written permission.
-
-THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS &quot;AS IS&quot; AND
-ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
-WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
-DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
-FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
-DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
-SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
-CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
-OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-</pre>
-            </li>
-            <li class="license">
-                <h3 id="BSD-3-Clause">BSD 3-Clause &quot;New&quot; or &quot;Revised&quot; License</h3>
-                    <p>
-                        Used by
                             <a href=" https://github.com/dalek-cryptography/curve25519-dalek/tree/main/x25519-dalek ">x25519-dalek 2.0.1</a>
                     </p>
                 <pre class="license-text">Copyright (c) 2017-2021 isis agora lovecruft. All rights reserved.
@@ -13374,7 +13345,9 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
                 <h3 id="BSD-3-Clause">BSD 3-Clause &quot;New&quot; or &quot;Revised&quot; License</h3>
                     <h4>Used by:</h4>
                     <ul class="license-used-by">
+                        <li><a href=" https://github.com/servo/servo ">servo-script-bindings 0.1.0</a></li>
                         <li><a href=" https://github.com/dropbox/rust-alloc-no-stdlib ">alloc-stdlib 0.2.2</a></li>
+                        <li><a href=" https://github.com/aws/aws-lc-rs ">aws-lc-sys 0.39.1</a></li>
                         <li><a href=" https://github.com/dropbox/rust-brotli ">brotli 8.0.2</a></li>
                         <li><a href=" https://github.com/dalek-cryptography/curve25519-dalek/tree/main/curve25519-dalek ">curve25519-dalek 4.1.3</a></li>
                         <li><a href=" https://github.com/mitsuhiko/sha1-smol ">sha1_smol 1.0.1</a></li>
@@ -13718,38 +13691,6 @@ insights.
                 <h3 id="ISC">ISC License</h3>
                     <p>
                         Used by
-                            <a href=" https://github.com/aws/aws-lc-rs ">aws-lc-sys 0.37.1</a>
-                    </p>
-                <pre class="license-text">/* Copyright (c) 2018, Google Inc.
- *
- * Permission to use, copy, modify, and/or distribute this software for any
- * purpose with or without fee is hereby granted, provided that the above
- * copyright notice and this permission notice appear in all copies.
- *
- * THE SOFTWARE IS PROVIDED &quot;AS IS&quot; AND THE AUTHOR DISCLAIMS ALL WARRANTIES
- * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
- * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY
- * SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
- * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION
- * OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN
- * CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE. */
-
-#include &lt;openssl/crypto.h&gt;
-
-#include &lt;gtest/gtest.h&gt;
-
-
-TEST(SelfTests, KAT) {
-#if !defined(_MSC_VER)
-  EXPECT_TRUE(BORINGSSL_self_test());
-#endif
-}
-</pre>
-            </li>
-            <li class="license">
-                <h3 id="ISC">ISC License</h3>
-                    <p>
-                        Used by
                             <a href=" https://github.com/briansmith/untrusted ">untrusted 0.9.0</a>
                     </p>
                 <pre class="license-text">// Copyright 2015-2016 Brian Smith.
@@ -13791,7 +13732,7 @@ THIS SOFTWARE.</pre>
                 <h3 id="ISC">ISC License</h3>
                     <p>
                         Used by
-                            <a href=" https://github.com/hannobraun/inotify ">inotify 0.11.0</a>
+                            <a href=" https://github.com/hannobraun/inotify ">inotify 0.11.1</a>
                     </p>
                 <pre class="license-text">Copyright (c) Hanno Braun and contributors
 
@@ -13833,7 +13774,7 @@ THIS SOFTWARE.
                 <h3 id="ISC">ISC License</h3>
                     <p>
                         Used by
-                            <a href=" https://github.com/rustls/webpki ">rustls-webpki 0.103.9</a>
+                            <a href=" https://github.com/rustls/webpki ">rustls-webpki 0.103.10</a>
                     </p>
                 <pre class="license-text">Except as otherwise noted, this project is licensed under the following
 (ISC-style) terms:
@@ -13858,10 +13799,11 @@ third-party/chromium/LICENSE.
             </li>
             <li class="license">
                 <h3 id="ISC">ISC License</h3>
-                    <p>
-                        Used by
-                            <a href=" https://github.com/aws/aws-lc-rs ">aws-lc-rs 1.16.0</a>
-                    </p>
+                    <h4>Used by:</h4>
+                    <ul class="license-used-by">
+                        <li><a href=" https://github.com/aws/aws-lc-rs ">aws-lc-rs 1.16.2</a></li>
+                        <li><a href=" https://github.com/aws/aws-lc-rs ">aws-lc-sys 0.39.1</a></li>
+                    </ul>
                 <pre class="license-text">ISC License:
 
 Copyright (c) 2004-2010 by Internet Systems Consortium, Inc. (&quot;ISC&quot;)
@@ -13905,7 +13847,7 @@ THE SOFTWARE IS PROVIDED &quot;AS IS&quot; AND ISC DISCLAIMS ALL WARRANTIES WITH
                 <h3 id="MIT">MIT License</h3>
                     <p>
                         Used by
-                            <a href=" https://github.com/haraldh/rust_uds_windows ">uds_windows 1.1.0</a>
+                            <a href=" https://github.com/haraldh/rust_uds_windows ">uds_windows 1.2.1</a>
                     </p>
                 <pre class="license-text">    MIT License
 
@@ -13988,7 +13930,7 @@ THE SOFTWARE.
                 <h3 id="MIT">MIT License</h3>
                     <p>
                         Used by
-                            <a href=" https://github.com/tokio-rs/mio ">mio 1.1.1</a>
+                            <a href=" https://github.com/tokio-rs/mio ">mio 1.2.0</a>
                     </p>
                 <pre class="license-text">Copyright (c) 2014 Carl Lerche and other MIO contributors
 
@@ -14266,14 +14208,14 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
                 <h3 id="MIT">MIT License</h3>
                     <h4>Used by:</h4>
                     <ul class="license-used-by">
-                        <li><a href=" https://github.com/smithay/wayland-rs ">wayland-backend 0.3.12</a></li>
-                        <li><a href=" https://github.com/smithay/wayland-rs ">wayland-client 0.31.12</a></li>
-                        <li><a href=" https://github.com/smithay/wayland-rs ">wayland-cursor 0.31.12</a></li>
-                        <li><a href=" https://github.com/smithay/wayland-rs ">wayland-protocols-plasma 0.3.10</a></li>
-                        <li><a href=" https://github.com/smithay/wayland-rs ">wayland-protocols-wlr 0.3.10</a></li>
-                        <li><a href=" https://github.com/smithay/wayland-rs ">wayland-protocols 0.32.10</a></li>
-                        <li><a href=" https://github.com/smithay/wayland-rs ">wayland-scanner 0.31.8</a></li>
-                        <li><a href=" https://github.com/smithay/wayland-rs ">wayland-sys 0.31.8</a></li>
+                        <li><a href=" https://github.com/smithay/wayland-rs ">wayland-backend 0.3.15</a></li>
+                        <li><a href=" https://github.com/smithay/wayland-rs ">wayland-client 0.31.13</a></li>
+                        <li><a href=" https://github.com/smithay/wayland-rs ">wayland-cursor 0.31.13</a></li>
+                        <li><a href=" https://github.com/smithay/wayland-rs ">wayland-protocols-plasma 0.3.11</a></li>
+                        <li><a href=" https://github.com/smithay/wayland-rs ">wayland-protocols-wlr 0.3.11</a></li>
+                        <li><a href=" https://github.com/smithay/wayland-rs ">wayland-protocols 0.32.11</a></li>
+                        <li><a href=" https://github.com/smithay/wayland-rs ">wayland-scanner 0.31.10</a></li>
+                        <li><a href=" https://github.com/smithay/wayland-rs ">wayland-sys 0.31.11</a></li>
                     </ul>
                 <pre class="license-text">Copyright (c) 2015 Elinor Berger
 
@@ -14334,7 +14276,7 @@ DEALINGS IN THE SOFTWARE.
                 <h3 id="MIT">MIT License</h3>
                     <p>
                         Used by
-                            <a href=" https://github.com/elinorbgr/dlib ">dlib 0.5.2</a>
+                            <a href=" https://github.com/elinorbgr/dlib ">dlib 0.5.3</a>
                     </p>
                 <pre class="license-text">Copyright (c) 2015 Victor Berger
 
@@ -14360,7 +14302,7 @@ THE SOFTWARE.</pre>
                 <h3 id="MIT">MIT License</h3>
                     <p>
                         Used by
-                            <a href=" https://github.com/steffengy/schannel-rs ">schannel 0.1.28</a>
+                            <a href=" https://github.com/steffengy/schannel-rs ">schannel 0.1.29</a>
                     </p>
                 <pre class="license-text">Copyright (c) 2015 steffengy
 
@@ -14375,7 +14317,7 @@ THE SOFTWARE IS PROVIDED &quot;AS IS&quot;, WITHOUT WARRANTY OF ANY KIND, EXPRES
                 <h3 id="MIT">MIT License</h3>
                     <p>
                         Used by
-                            <a href=" https://github.com/sdroege/async-tungstenite ">async-tungstenite 0.33.0</a>
+                            <a href=" https://github.com/sdroege/async-tungstenite ">async-tungstenite 0.34.0</a>
                     </p>
                 <pre class="license-text">Copyright (c) 2017 Daniel Abramov
 Copyright (c) 2017 Alexey Galakhov
@@ -15470,8 +15412,8 @@ SOFTWARE.
                 <h3 id="MIT">MIT License</h3>
                     <h4>Used by:</h4>
                     <ul class="license-used-by">
-                        <li><a href=" https://github.com/Peternator7/strum ">strum 0.27.2</a></li>
-                        <li><a href=" https://github.com/Peternator7/strum ">strum_macros 0.27.2</a></li>
+                        <li><a href=" https://github.com/Peternator7/strum ">strum 0.28.0</a></li>
+                        <li><a href=" https://github.com/Peternator7/strum ">strum_macros 0.28.0</a></li>
                     </ul>
                 <pre class="license-text">MIT License
 
@@ -15500,7 +15442,7 @@ SOFTWARE.
                 <h3 id="MIT">MIT License</h3>
                     <p>
                         Used by
-                            <a href=" https://github.com/tokio-rs/tokio ">tokio-macros 2.6.0</a>
+                            <a href=" https://github.com/tokio-rs/tokio ">tokio-macros 2.6.1</a>
                     </p>
                 <pre class="license-text">MIT License
 
@@ -15663,7 +15605,7 @@ SOFTWARE.
                 <h3 id="MIT">MIT License</h3>
                     <p>
                         Used by
-                            <a href=" https://github.com/arthurprs/quick-cache ">quick_cache 0.6.18</a>
+                            <a href=" https://github.com/arthurprs/quick-cache ">quick_cache 0.6.21</a>
                     </p>
                 <pre class="license-text">MIT License
 
@@ -15750,7 +15692,7 @@ SOFTWARE.
                 <h3 id="MIT">MIT License</h3>
                     <p>
                         Used by
-                            <a href=" https://gitlab.redox-os.org/redox-os/libredox.git ">libredox 0.1.12</a>
+                            <a href=" https://gitlab.redox-os.org/redox-os/libredox.git ">libredox 0.1.15</a>
                     </p>
                 <pre class="license-text">MIT License
 
@@ -15891,7 +15833,7 @@ SOFTWARE.</pre>
                         <li><a href=" https://github.com/plotters-rs/plotters.git ">plotters-svg 0.3.7</a></li>
                         <li><a href=" https://github.com/plotters-rs/plotters ">plotters 0.3.7</a></li>
                         <li><a href=" https://github.com/lu-zero/simd_helpers ">simd_helpers 0.1.0</a></li>
-                        <li><a href=" https://github.com/DioxusLabs/taffy ">taffy 0.9.2</a></li>
+                        <li><a href=" https://github.com/DioxusLabs/taffy ">taffy 0.10.0</a></li>
                         <li><a href=" https://github.com/reem/rust-void.git ">void 1.0.2</a></li>
                     </ul>
                 <pre class="license-text">MIT License
@@ -15916,11 +15858,10 @@ USE OR OTHER DEALINGS IN THE SOFTWARE.
             </li>
             <li class="license">
                 <h3 id="MIT">MIT License</h3>
-                    <h4>Used by:</h4>
-                    <ul class="license-used-by">
-                        <li><a href=" http://github.com/SSheldon/rust-objc ">objc2 0.2.7</a></li>
-                        <li><a href=" http://github.com/SSheldon/rust-objc ">objc 0.2.7</a></li>
-                    </ul>
+                    <p>
+                        Used by
+                            <a href=" http://github.com/SSheldon/rust-objc ">objc 0.2.7</a>
+                    </p>
                 <pre class="license-text">MIT License
 
 Copyright (c) Steven Sheldon
@@ -15950,7 +15891,7 @@ SOFTWARE.
                     <ul class="license-used-by">
                         <li><a href=" https://github.com/tokio-rs/tokio ">tokio-stream 0.1.18</a></li>
                         <li><a href=" https://github.com/tokio-rs/tokio ">tokio-util 0.7.18</a></li>
-                        <li><a href=" https://github.com/tokio-rs/tokio ">tokio 1.49.0</a></li>
+                        <li><a href=" https://github.com/tokio-rs/tokio ">tokio 1.50.0</a></li>
                     </ul>
                 <pre class="license-text">MIT License
 
@@ -15979,7 +15920,7 @@ SOFTWARE.
                 <h3 id="MIT">MIT License</h3>
                     <p>
                         Used by
-                            <a href=" https://github.com/mcountryman/simd-adler32 ">simd-adler32 0.3.8</a>
+                            <a href=" https://github.com/mcountryman/simd-adler32 ">simd-adler32 0.3.9</a>
                     </p>
                 <pre class="license-text">MIT License
 
@@ -16141,7 +16082,7 @@ DEALINGS IN THE SOFTWARE.
                 <h3 id="MIT">MIT License</h3>
                     <p>
                         Used by
-                            <a href=" https://github.com/winnow-rs/winnow ">winnow 0.7.14</a>
+                            <a href=" https://github.com/winnow-rs/winnow ">winnow 0.7.15</a>
                     </p>
                 <pre class="license-text">Permission is hereby granted, free of charge, to any person obtaining
 a copy of this software and associated documentation files (the
@@ -16168,9 +16109,9 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
                     <h4>Used by:</h4>
                     <ul class="license-used-by">
                         <li><a href=" https://github.com/gtk-rs/gtk-rs-core ">gio-sys 0.22.0</a></li>
-                        <li><a href=" https://github.com/gtk-rs/gtk-rs-core ">glib-macros 0.22.0</a></li>
-                        <li><a href=" https://github.com/gtk-rs/gtk-rs-core ">glib-sys 0.22.0</a></li>
-                        <li><a href=" https://github.com/gtk-rs/gtk-rs-core ">glib 0.22.0</a></li>
+                        <li><a href=" https://github.com/gtk-rs/gtk-rs-core ">glib-macros 0.22.2</a></li>
+                        <li><a href=" https://github.com/gtk-rs/gtk-rs-core ">glib-sys 0.22.3</a></li>
+                        <li><a href=" https://github.com/gtk-rs/gtk-rs-core ">glib 0.22.3</a></li>
                         <li><a href=" https://github.com/gtk-rs/gtk-rs-core ">gobject-sys 0.22.0</a></li>
                     </ul>
                 <pre class="license-text">Permission is hereby granted, free of charge, to any person obtaining a copy
@@ -16321,7 +16262,7 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
                         <li><a href=" https://github.com/image-rs/byteorder-lite ">byteorder-lite 0.1.0</a></li>
                         <li><a href=" https://github.com/BurntSushi/byteorder ">byteorder 1.5.0</a></li>
                         <li><a href=" https://github.com/BurntSushi/fst ">fst 0.4.7</a></li>
-                        <li><a href=" https://github.com/BurntSushi/jiff ">jiff 0.2.21</a></li>
+                        <li><a href=" https://github.com/BurntSushi/jiff ">jiff 0.2.23</a></li>
                         <li><a href=" https://github.com/BurntSushi/memchr ">memchr 2.8.0</a></li>
                         <li><a href=" https://github.com/BurntSushi/quickcheck ">quickcheck 1.1.0</a></li>
                         <li><a href=" https://github.com/BurntSushi/walkdir ">walkdir 2.5.0</a></li>
@@ -16442,7 +16383,7 @@ THE SOFTWARE.
                 <h3 id="MIT">MIT License</h3>
                     <p>
                         Used by
-                            <a href=" https://gitlab.redox-os.org/redox-os/orbclient ">orbclient 0.3.50</a>
+                            <a href=" https://gitlab.redox-os.org/redox-os/orbclient ">orbclient 0.3.51</a>
                     </p>
                 <pre class="license-text">The MIT License (MIT)
 
@@ -16477,6 +16418,36 @@ SOFTWARE.
 
 Copyright (c) 2015-2020 Julien Cretin
 Copyright (c) 2017-2020 Google Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the &quot;Software&quot;), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED &quot;AS IS&quot;, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+</pre>
+            </li>
+            <li class="license">
+                <h3 id="MIT">MIT License</h3>
+                    <p>
+                        Used by
+                            <a href=" https://github.com/aws/aws-lc-rs ">aws-lc-sys 0.39.1</a>
+                    </p>
+                <pre class="license-text">The MIT License (MIT)
+
+Copyright (c) 2015-2020 the fiat-crypto authors (see
+https://github.com/mit-plv/fiat-crypto/blob/master/AUTHORS).
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the &quot;Software&quot;), to deal
@@ -16930,10 +16901,11 @@ SOFTWARE.</pre>
             </li>
             <li class="license">
                 <h3 id="MIT">MIT License</h3>
-                    <p>
-                        Used by
-                            <a href=" https://github.com/tafia/quick-xml ">quick-xml 0.38.4</a>
-                    </p>
+                    <h4>Used by:</h4>
+                    <ul class="license-used-by">
+                        <li><a href=" https://github.com/tafia/quick-xml ">quick-xml 0.38.4</a></li>
+                        <li><a href=" https://github.com/tafia/quick-xml ">quick-xml 0.39.2</a></li>
+                    </ul>
                 <pre class="license-text">The MIT License (MIT)
 
 Copyright (c) 2016 Johann Tuffe
@@ -18890,86 +18862,87 @@ Exhibit B - &quot;Incompatible With Secondary Licenses&quot; Notice
                 <h3 id="MPL-2.0">Mozilla Public License 2.0</h3>
                     <h4>Used by:</h4>
                     <ul class="license-used-by">
-                        <li><a href=" https://github.com/servo/stylo ">stylo 0.12.0</a></li>
-                        <li><a href=" https://github.com/servo/stylo ">selectors 0.35.0</a></li>
-                        <li><a href=" https://github.com/servo/stylo ">stylo_atoms 0.12.0</a></li>
-                        <li><a href=" https://github.com/servo/stylo ">stylo_derive 0.12.0</a></li>
-                        <li><a href=" https://github.com/servo/stylo ">stylo_dom 0.12.0</a></li>
-                        <li><a href=" https://github.com/servo/stylo ">stylo_static_prefs 0.12.0</a></li>
-                        <li><a href=" https://github.com/servo/stylo ">stylo_traits 0.12.0</a></li>
+                        <li><a href=" https://github.com/servo/stylo ">stylo 0.14.0</a></li>
+                        <li><a href=" https://github.com/servo/stylo ">selectors 0.36.1</a></li>
+                        <li><a href=" https://github.com/servo/stylo ">stylo_atoms 0.14.0</a></li>
+                        <li><a href=" https://github.com/servo/stylo ">stylo_derive 0.14.0</a></li>
+                        <li><a href=" https://github.com/servo/stylo ">stylo_dom 0.14.0</a></li>
+                        <li><a href=" https://github.com/servo/stylo ">stylo_static_prefs 0.14.0</a></li>
+                        <li><a href=" https://github.com/servo/stylo ">stylo_traits 0.14.0</a></li>
                         <li><a href=" https://github.com/servo/stylo ">to_shmem 0.3.0</a></li>
                         <li><a href=" https://github.com/servo/stylo ">to_shmem_derive 0.1.0</a></li>
-                        <li><a href=" https://crates.io/crates/servo_allocator ">servo_allocator 0.0.1</a></li>
-                        <li><a href=" https://crates.io/crates/background_hang_monitor ">background_hang_monitor 0.0.1</a></li>
-                        <li><a href=" https://crates.io/crates/bluetooth ">bluetooth 0.0.1</a></li>
-                        <li><a href=" https://crates.io/crates/canvas ">canvas 0.0.1</a></li>
-                        <li><a href=" https://crates.io/crates/servo_config ">servo_config 0.0.1</a></li>
-                        <li><a href=" https://crates.io/crates/servo_config_macro ">servo_config_macro 0.0.1</a></li>
-                        <li><a href=" https://crates.io/crates/constellation ">constellation 0.0.1</a></li>
-                        <li><a href=" https://crates.io/crates/deny_public_fields ">deny_public_fields 0.0.1</a></li>
-                        <li><a href=" https://crates.io/crates/devtools ">devtools 0.0.1</a></li>
-                        <li><a href=" https://crates.io/crates/dom_struct ">dom_struct 0.0.1</a></li>
-                        <li><a href=" https://crates.io/crates/fonts ">fonts 0.0.1</a></li>
-                        <li><a href=" https://crates.io/crates/servo_geometry ">servo_geometry 0.0.1</a></li>
-                        <li><a href=" https://crates.io/crates/jstraceable_derive ">jstraceable_derive 0.0.1</a></li>
-                        <li><a href=" https://crates.io/crates/layout ">layout 0.0.1</a></li>
-                        <li><a href=" https://crates.io/crates/servo-media-audio ">servo-media-audio 0.0.1</a></li>
-                        <li><a href=" https://crates.io/crates/servo-media-auto ">servo-media-auto 0.0.1</a></li>
-                        <li><a href=" https://crates.io/crates/servo-media-dummy ">servo-media-dummy 0.0.1</a></li>
-                        <li><a href=" https://crates.io/crates/servo-media-gstreamer ">servo-media-gstreamer 0.0.1</a></li>
-                        <li><a href=" https://crates.io/crates/servo-media-gstreamer-render ">servo-media-gstreamer-render 0.0.1</a></li>
-                        <li><a href=" https://crates.io/crates/servo-media-gstreamer-render-android ">servo-media-gstreamer-render-android 0.0.1</a></li>
-                        <li><a href=" https://crates.io/crates/servo-media-gstreamer-render-unix ">servo-media-gstreamer-render-unix 0.0.1</a></li>
-                        <li><a href=" https://crates.io/crates/media-examples ">media-examples 0.0.1</a></li>
-                        <li><a href=" https://crates.io/crates/media ">media 0.0.1</a></li>
-                        <li><a href=" https://crates.io/crates/servo-media-player ">servo-media-player 0.0.1</a></li>
-                        <li><a href=" https://crates.io/crates/servo-media ">servo-media 0.0.1</a></li>
-                        <li><a href=" https://crates.io/crates/servo-media-derive ">servo-media-derive 0.0.1</a></li>
-                        <li><a href=" https://crates.io/crates/servo-media-streams ">servo-media-streams 0.0.1</a></li>
-                        <li><a href=" https://crates.io/crates/servo-media-traits ">servo-media-traits 0.0.1</a></li>
-                        <li><a href=" https://crates.io/crates/servo-media-webrtc ">servo-media-webrtc 0.0.1</a></li>
-                        <li><a href=" https://crates.io/crates/metrics ">metrics 0.0.1</a></li>
-                        <li><a href=" https://crates.io/crates/net ">net 0.0.1</a></li>
-                        <li><a href=" https://crates.io/crates/paint ">paint 0.0.1</a></li>
-                        <li><a href=" https://crates.io/crates/pixels ">pixels 0.0.1</a></li>
-                        <li><a href=" https://crates.io/crates/profile ">profile 0.0.1</a></li>
-                        <li><a href=" https://crates.io/crates/script ">script 0.0.1</a></li>
-                        <li><a href=" https://crates.io/crates/script_bindings ">script_bindings 0.0.1</a></li>
-                        <li><a href=" https://crates.io/crates/libservo ">libservo 0.0.1</a></li>
-                        <li><a href=" https://crates.io/crates/servo-tracing ">servo-tracing 0.0.1</a></li>
-                        <li><a href=" https://crates.io/crates/background_hang_monitor_api ">background_hang_monitor_api 0.0.1</a></li>
-                        <li><a href=" https://crates.io/crates/base ">base 0.0.1</a></li>
-                        <li><a href=" https://crates.io/crates/bluetooth_traits ">bluetooth_traits 0.0.1</a></li>
-                        <li><a href=" https://crates.io/crates/canvas_traits ">canvas_traits 0.0.1</a></li>
-                        <li><a href=" https://crates.io/crates/constellation_traits ">constellation_traits 0.0.1</a></li>
-                        <li><a href=" https://crates.io/crates/devtools_traits ">devtools_traits 0.0.1</a></li>
-                        <li><a href=" https://crates.io/crates/embedder_traits ">embedder_traits 0.0.1</a></li>
-                        <li><a href=" https://crates.io/crates/fonts_traits ">fonts_traits 0.0.1</a></li>
-                        <li><a href=" https://crates.io/crates/layout_api ">layout_api 0.0.1</a></li>
-                        <li><a href=" https://crates.io/crates/net_traits ">net_traits 0.0.1</a></li>
-                        <li><a href=" https://crates.io/crates/paint_api ">paint_api 0.0.1</a></li>
-                        <li><a href=" https://crates.io/crates/profile_traits ">profile_traits 0.0.1</a></li>
-                        <li><a href=" https://crates.io/crates/script_traits ">script_traits 0.0.1</a></li>
-                        <li><a href=" https://crates.io/crates/storage_traits ">storage_traits 0.0.1</a></li>
-                        <li><a href=" https://crates.io/crates/webgpu_traits ">webgpu_traits 0.0.1</a></li>
-                        <li><a href=" https://crates.io/crates/webxr-api ">webxr-api 0.0.1</a></li>
-                        <li><a href=" https://crates.io/crates/storage ">storage 0.0.1</a></li>
-                        <li><a href=" https://crates.io/crates/timers ">timers 0.0.1</a></li>
-                        <li><a href=" https://crates.io/crates/servo_url ">servo_url 0.0.1</a></li>
-                        <li><a href=" https://crates.io/crates/webdriver_server ">webdriver_server 0.0.1</a></li>
-                        <li><a href=" https://crates.io/crates/webgl ">webgl 0.0.1</a></li>
-                        <li><a href=" https://crates.io/crates/webgpu ">webgpu 0.0.1</a></li>
-                        <li><a href=" https://crates.io/crates/webxr ">webxr 0.0.1</a></li>
-                        <li><a href=" https://crates.io/crates/xpath ">xpath 0.0.1</a></li>
-                        <li><a href=" https://crates.io/crates/servoshell ">servoshell 0.0.6</a></li>
-                        <li><a href=" https://crates.io/crates/deny_public_fields_tests ">deny_public_fields_tests 0.0.1</a></li>
-                        <li><a href=" https://crates.io/crates/malloc_size_of_tests ">malloc_size_of_tests 0.0.1</a></li>
-                        <li><a href=" https://crates.io/crates/profile_tests ">profile_tests 0.0.1</a></li>
-                        <li><a href=" https://crates.io/crates/script_tests ">script_tests 0.0.1</a></li>
-                        <li><a href=" https://crates.io/crates/style_tests ">style_tests 0.0.1</a></li>
+                        <li><a href=" https://github.com/servo/servo ">servo-allocator 0.1.0</a></li>
+                        <li><a href=" https://github.com/servo/servo ">servo-background-hang-monitor 0.1.0</a></li>
+                        <li><a href=" https://github.com/servo/servo ">servo-bluetooth 0.1.0</a></li>
+                        <li><a href=" https://github.com/servo/servo ">servo-canvas 0.1.0</a></li>
+                        <li><a href=" https://github.com/servo/servo ">servo-config 0.1.0</a></li>
+                        <li><a href=" https://github.com/servo/servo ">servo-config-macro 0.1.0</a></li>
+                        <li><a href=" https://github.com/servo/servo ">servo-constellation 0.1.0</a></li>
+                        <li><a href=" https://github.com/servo/servo ">servo-default-resources 0.1.0</a></li>
+                        <li><a href=" https://github.com/servo/servo ">servo-deny-public-fields 0.1.0</a></li>
+                        <li><a href=" https://github.com/servo/servo ">servo-devtools 0.1.0</a></li>
+                        <li><a href=" https://github.com/servo/servo ">servo-dom-struct 0.1.0</a></li>
+                        <li><a href=" https://github.com/servo/servo ">servo-fonts 0.1.0</a></li>
+                        <li><a href=" https://github.com/servo/servo ">servo-geometry 0.1.0</a></li>
+                        <li><a href=" https://github.com/servo/servo ">servo-jstraceable-derive 0.1.0</a></li>
+                        <li><a href=" https://github.com/servo/servo ">servo-layout 0.1.0</a></li>
+                        <li><a href=" https://github.com/servo/servo ">servo-media-audio 0.1.0</a></li>
+                        <li><a href=" https://github.com/servo/servo ">servo-media-auto 0.1.0</a></li>
+                        <li><a href=" https://github.com/servo/servo ">servo-media-dummy 0.1.0</a></li>
+                        <li><a href=" https://github.com/servo/servo ">servo-media-gstreamer 0.1.0</a></li>
+                        <li><a href=" https://github.com/servo/servo ">servo-media-gstreamer-render 0.1.0</a></li>
+                        <li><a href=" https://github.com/servo/servo ">servo-media-gstreamer-render-android 0.1.0</a></li>
+                        <li><a href=" https://github.com/servo/servo ">servo-media-gstreamer-render-unix 0.1.0</a></li>
+                        <li><a href=" https://github.com/servo/servo ">servo-media-examples 0.1.0</a></li>
+                        <li><a href=" https://github.com/servo/servo ">servo-media-thread 0.1.0</a></li>
+                        <li><a href=" https://github.com/servo/servo ">servo-media-player 0.1.0</a></li>
+                        <li><a href=" https://github.com/servo/servo ">servo-media 0.1.0</a></li>
+                        <li><a href=" https://github.com/servo/servo ">servo-media-derive 0.1.0</a></li>
+                        <li><a href=" https://github.com/servo/servo ">servo-media-streams 0.1.0</a></li>
+                        <li><a href=" https://github.com/servo/servo ">servo-media-traits 0.1.0</a></li>
+                        <li><a href=" https://github.com/servo/servo ">servo-media-webrtc 0.1.0</a></li>
+                        <li><a href=" https://github.com/servo/servo ">servo-metrics 0.1.0</a></li>
+                        <li><a href=" https://github.com/servo/servo ">servo-net 0.1.0</a></li>
+                        <li><a href=" https://github.com/servo/servo ">servo-paint 0.1.0</a></li>
+                        <li><a href=" https://github.com/servo/servo ">servo-pixels 0.1.0</a></li>
+                        <li><a href=" https://github.com/servo/servo ">servo-profile 0.1.0</a></li>
+                        <li><a href=" https://github.com/servo/servo ">servo-script 0.1.0</a></li>
+                        <li><a href=" https://github.com/servo/servo ">servo-script-bindings 0.1.0</a></li>
+                        <li><a href=" https://github.com/servo/servo ">servo 0.1.0</a></li>
+                        <li><a href=" https://github.com/servo/servo ">servo-tracing 0.1.0</a></li>
+                        <li><a href=" https://github.com/servo/servo ">servo-background-hang-monitor-api 0.1.0</a></li>
+                        <li><a href=" https://github.com/servo/servo ">servo-base 0.1.0</a></li>
+                        <li><a href=" https://github.com/servo/servo ">servo-bluetooth-traits 0.1.0</a></li>
+                        <li><a href=" https://github.com/servo/servo ">servo-canvas-traits 0.1.0</a></li>
+                        <li><a href=" https://github.com/servo/servo ">servo-constellation-traits 0.1.0</a></li>
+                        <li><a href=" https://github.com/servo/servo ">servo-devtools-traits 0.1.0</a></li>
+                        <li><a href=" https://github.com/servo/servo ">servo-embedder-traits 0.1.0</a></li>
+                        <li><a href=" https://github.com/servo/servo ">servo-fonts-traits 0.1.0</a></li>
+                        <li><a href=" https://github.com/servo/servo ">servo-layout-api 0.1.0</a></li>
+                        <li><a href=" https://github.com/servo/servo ">servo-net-traits 0.1.0</a></li>
+                        <li><a href=" https://github.com/servo/servo ">servo-paint-api 0.1.0</a></li>
+                        <li><a href=" https://github.com/servo/servo ">servo-profile-traits 0.1.0</a></li>
+                        <li><a href=" https://github.com/servo/servo ">servo-script-traits 0.1.0</a></li>
+                        <li><a href=" https://github.com/servo/servo ">servo-storage-traits 0.1.0</a></li>
+                        <li><a href=" https://github.com/servo/servo ">servo-webgpu-traits 0.1.0</a></li>
+                        <li><a href=" https://github.com/servo/servo ">servo-webxr-api 0.1.0</a></li>
+                        <li><a href=" https://github.com/servo/servo ">servo-storage 0.1.0</a></li>
+                        <li><a href=" https://github.com/servo/servo ">servo-timers 0.1.0</a></li>
+                        <li><a href=" https://github.com/servo/servo ">servo-url 0.1.0</a></li>
+                        <li><a href=" https://github.com/servo/servo ">servo-webdriver-server 0.1.0</a></li>
+                        <li><a href=" https://github.com/servo/servo ">servo-webgl 0.1.0</a></li>
+                        <li><a href=" https://github.com/servo/servo ">servo-webgpu 0.1.0</a></li>
+                        <li><a href=" https://github.com/servo/servo ">servo-webxr 0.1.0</a></li>
+                        <li><a href=" https://github.com/servo/servo ">servo-xpath 0.1.0</a></li>
+                        <li><a href=" https://github.com/servo/servo ">servoshell 0.1.0</a></li>
+                        <li><a href=" https://crates.io/crates/deny_public_fields_tests ">deny_public_fields_tests 0.1.0</a></li>
+                        <li><a href=" https://crates.io/crates/malloc_size_of_tests ">malloc_size_of_tests 0.1.0</a></li>
+                        <li><a href=" https://crates.io/crates/profile_tests ">profile_tests 0.1.0</a></li>
+                        <li><a href=" https://crates.io/crates/script_tests ">script_tests 0.1.0</a></li>
+                        <li><a href=" https://crates.io/crates/style_tests ">style_tests 0.1.0</a></li>
                         <li><a href=" https://github.com/servo/app_units ">app_units 0.7.8</a></li>
                         <li><a href=" https://github.com/servo/dwrote-rs ">dwrote 0.11.5</a></li>
-                        <li><a href=" https://github.com/servo/mozjs/ ">mozjs_sys 0.140.5-11</a></li>
+                        <li><a href=" https://github.com/servo/mozjs/ ">mozjs_sys 0.140.8-2</a></li>
                         <li><a href=" https://github.com/soc/option-ext.git ">option-ext 0.2.0</a></li>
                         <li><a href=" https://hg.mozilla.org/mozilla-central/file/tip/testing/webdriver ">webdriver 0.53.0</a></li>
                         <li><a href=" https://github.com/servo/webrender ">webrender 0.68.0</a></li>
@@ -19356,7 +19329,7 @@ Exhibit B - &quot;Incompatible With Secondary Licenses&quot; Notice
                 <h3 id="MPL-2.0">Mozilla Public License 2.0</h3>
                     <p>
                         Used by
-                            <a href=" https://github.com/servo/mozjs/ ">mozjs 0.15.1</a>
+                            <a href=" https://github.com/servo/mozjs/ ">mozjs 0.15.7</a>
                     </p>
                 <pre class="license-text">Mozilla Public License Version 2.0
 &#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;
@@ -19855,180 +19828,6 @@ INCLUDING ANY GENERAL, SPECIAL, INDIRECT, INCIDENTAL, OR CONSEQUENTIAL
 DAMAGES, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
 FROM, OUT OF THE USE OR INABILITY TO USE THE FONT SOFTWARE OR FROM
 OTHER DEALINGS IN THE FONT SOFTWARE.
-</pre>
-            </li>
-            <li class="license">
-                <h3 id="OpenSSL">OpenSSL License</h3>
-                    <p>
-                        Used by
-                            <a href=" https://github.com/aws/aws-lc-rs ">aws-lc-sys 0.37.1</a>
-                    </p>
-                <pre class="license-text">/* Copyright (C) 1995-1998 Eric Young (eay@cryptsoft.com)
- * All rights reserved.
- *
- * This package is an SSL implementation written
- * by Eric Young (eay@cryptsoft.com).
- * The implementation was written so as to conform with Netscapes SSL.
- *
- * This library is free for commercial and non-commercial use as long as
- * the following conditions are aheared to.  The following conditions
- * apply to all code found in this distribution, be it the RC4, RSA,
- * lhash, DES, etc., code; not just the SSL code.  The SSL documentation
- * included with this distribution is covered by the same copyright terms
- * except that the holder is Tim Hudson (tjh@cryptsoft.com).
- *
- * Copyright remains Eric Young&#x27;s, and as such any Copyright notices in
- * the code are not to be removed.
- * If this package is used in a product, Eric Young should be given attribution
- * as the author of the parts of the library used.
- * This can be in the form of a textual message at program startup or
- * in documentation (online or textual) provided with the package.
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions
- * are met:
- * 1. Redistributions of source code must retain the copyright
- *    notice, this list of conditions and the following disclaimer.
- * 2. Redistributions in binary form must reproduce the above copyright
- *    notice, this list of conditions and the following disclaimer in the
- *    documentation and/or other materials provided with the distribution.
- * 3. All advertising materials mentioning features or use of this software
- *    must display the following acknowledgement:
- *    &quot;This product includes cryptographic software written by
- *     Eric Young (eay@cryptsoft.com)&quot;
- *    The word &#x27;cryptographic&#x27; can be left out if the rouines from the library
- *    being used are not cryptographic related :-).
- * 4. If you include any Windows specific code (or a derivative thereof) from
- *    the apps directory (application code) you must include an acknowledgement:
- *    &quot;This product includes software written by Tim Hudson (tjh@cryptsoft.com)&quot;
- *
- * THIS SOFTWARE IS PROVIDED BY ERIC YOUNG &#x60;&#x60;AS IS&#x27;&#x27; AND
- * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED.  IN NO EVENT SHALL THE AUTHOR OR CONTRIBUTORS BE LIABLE
- * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
- * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
- * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
- * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
- * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
- * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
- * SUCH DAMAGE.
- *
- * The licence and distribution terms for any publically available version or
- * derivative of this code cannot be changed.  i.e. this code cannot simply be
- * copied and put under another distribution licence
- * [including the GNU Public Licence.]
- */
-/* &#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;
- * Copyright (c) 1998-2007 The OpenSSL Project.  All rights reserved.
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions
- * are met:
- *
- * 1. Redistributions of source code must retain the above copyright
- *    notice, this list of conditions and the following disclaimer.
- *
- * 2. Redistributions in binary form must reproduce the above copyright
- *    notice, this list of conditions and the following disclaimer in
- *    the documentation and/or other materials provided with the
- *    distribution.
- *
- * 3. All advertising materials mentioning features or use of this
- *    software must display the following acknowledgment:
- *    &quot;This product includes software developed by the OpenSSL Project
- *    for use in the OpenSSL Toolkit. (http://www.openssl.org/)&quot;
- *
- * 4. The names &quot;OpenSSL Toolkit&quot; and &quot;OpenSSL Project&quot; must not be used to
- *    endorse or promote products derived from this software without
- *    prior written permission. For written permission, please contact
- *    openssl-core@openssl.org.
- *
- * 5. Products derived from this software may not be called &quot;OpenSSL&quot;
- *    nor may &quot;OpenSSL&quot; appear in their names without prior written
- *    permission of the OpenSSL Project.
- *
- * 6. Redistributions of any form whatsoever must retain the following
- *    acknowledgment:
- *    &quot;This product includes software developed by the OpenSSL Project
- *    for use in the OpenSSL Toolkit (http://www.openssl.org/)&quot;
- *
- * THIS SOFTWARE IS PROVIDED BY THE OpenSSL PROJECT &#x60;&#x60;AS IS&#x27;&#x27; AND ANY
- * EXPRESSED OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
- * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE OpenSSL PROJECT OR
- * ITS CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
- * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
- * NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
- * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
- * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
- * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
- * OF THE POSSIBILITY OF SUCH DAMAGE.
- * &#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;
- *
- * This product includes cryptographic software written by Eric Young
- * (eay@cryptsoft.com).  This product includes software written by Tim
- * Hudson (tjh@cryptsoft.com).
- *
- */
-
-#include &lt;openssl/ssl.h&gt;
-
-#if !defined(OPENSSL_WINDOWS) &amp;&amp; !defined(OPENSSL_PNACL) &amp;&amp; \
-    !defined(OPENSSL_NO_FILESYSTEM)
-
-#include &lt;dirent.h&gt;
-#include &lt;errno.h&gt;
-#include &lt;string.h&gt;
-
-#include &lt;openssl/err.h&gt;
-#include &lt;openssl/mem.h&gt;
-
-
-int SSL_add_dir_cert_subjects_to_stack(STACK_OF(X509_NAME) *stack,
-                                       const char *path) {
-  DIR *dir &#x3D; opendir(path);
-  if (dir &#x3D;&#x3D; NULL) {
-    OPENSSL_PUT_ERROR(SSL, ERR_R_SYS_LIB);
-    ERR_add_error_data(3, &quot;opendir(&#x27;&quot;, dir, &quot;&#x27;)&quot;);
-    return 0;
-  }
-
-  int ret &#x3D; 0;
-  for (;;) {
-    // |readdir| may fail with or without setting |errno|.
-    errno &#x3D; 0;
-    struct dirent *dirent &#x3D; readdir(dir);
-    if (dirent &#x3D;&#x3D; NULL) {
-      if (errno) {
-        OPENSSL_PUT_ERROR(SSL, ERR_R_SYS_LIB);
-        ERR_add_error_data(3, &quot;readdir(&#x27;&quot;, path, &quot;&#x27;)&quot;);
-      } else {
-        ret &#x3D; 1;
-      }
-      break;
-    }
-
-    char buf[1024];
-    if (strlen(path) + strlen(dirent-&gt;d_name) + 2 &gt; sizeof(buf)) {
-      OPENSSL_PUT_ERROR(SSL, SSL_R_PATH_TOO_LONG);
-      break;
-    }
-
-    int r &#x3D; snprintf(buf, sizeof(buf), &quot;%s/%s&quot;, path, dirent-&gt;d_name);
-    if (r &lt;&#x3D; 0 ||
-        r &gt;&#x3D; (int)sizeof(buf) ||
-        !SSL_add_file_cert_subjects_to_stack(stack, buf)) {
-      break;
-    }
-  }
-
-  closedir(dir);
-  return ret;
-}
-
-#endif  // !WINDOWS &amp;&amp; !PNACL &amp;&amp; !OPENSSL_NO_FILESYSTEM
 </pre>
             </li>
             <li class="license">

--- a/support/android/apk/servoapp/build.gradle.kts
+++ b/support/android/apk/servoapp/build.gradle.kts
@@ -17,7 +17,7 @@ android {
         minSdk = 30
         targetSdk = 33
         versionCode = generatedVersionCode
-        versionName = "0.0.6"
+        versionName = "0.1.0"
     }
 
     compileOptions {

--- a/support/openharmony/entry/oh-package.json5
+++ b/support/openharmony/entry/oh-package.json5
@@ -5,7 +5,7 @@
   "name": "servoshell",
   "description": "Please describe the basic information.",
   "main": "",
-  "version": "0.0.6",
+  "version": "0.1.0",
   "dependencies": {
     "libservoshell.so": "file:./src/main/cpp/types/libentry"
   }

--- a/support/openharmony/oh-package.json5
+++ b/support/openharmony/oh-package.json5
@@ -8,6 +8,6 @@
   "name": "servoshell",
   "description": "Servo browser shell",
   "main": "",
-  "version": "0.0.6",
+  "version": "0.1.0",
   "dependencies": {}
 }

--- a/support/windows/servoshell.wxs.mako
+++ b/support/windows/servoshell.wxs.mako
@@ -6,7 +6,7 @@
            UpgradeCode="060cd15d-eab1-4614-b438-3988e3efdcf1"
            Language="1033"
            Codepage="1252"
-           Version="0.0.6">
+           Version="0.1.0">
     <Package Id="*"
              Keywords="Installer"
              Description="Servo Tech Demo Installer"


### PR DESCRIPTION
In preparation for the next release, bump the version number to 0.1. 0.1 will be an LTS release, which receives extended support in terms of security updates (e.g. spidermonkey security updates). Please keep in mind that as always no specific guarantees or response times are given, and any updated are provided on a best effort basis.

Previously some projects had a demo integration of servo based on some version of servo, and then never or rarely updated it. Providing an LTS release offers an option to embedders to integrate servo, while reducing API churn and having a somewhat fixed schedule to adhere to in terms of upgrades. Currently, the plan is for a new LTS release every 6 months, with additional documentation regarding API changes and recommended migration patterns (best-effort and subject to change).

Testing: No functional changes. Additional testing will be performed post-merge on the newly created release branch.
