### PR TITLE
net: Set "request-includes-credentials" and URL list of response for "HTTP-network-or-cache fetch"

### DIFF
--- a/components/net/http_loader.rs
+++ b/components/net/http_loader.rs
@@ -1761,14 +1761,16 @@ async fn http_network_or_cache_fetch(
         return Response::network_error(NetworkError::CorsGeneral);
     }
 
-    // TODO(#33616): Step 11. Set response’s URL list to a clone of httpRequest’s URL list.
+    // Step 11. Set response’s URL list to a clone of httpRequest’s URL list.
+    response.url_list = http_request.url_list.clone();
 
     // Step 12. If httpRequest’s header list contains `Range`, then set response’s range-requested flag.
     if http_request.headers.contains_key(RANGE) {
         response.range_requested = true;
     }
 
-    // TODO(#33616): Step 13 Set response’s request-includes-credentials to includeCredentials.
+    // Step 13 Set response’s request-includes-credentials to includeCredentials.
+    response.request_includes_credentials = include_credentials;
 
     // Step 14. If response’s status is 401, httpRequest’s response tainting is not "cors",
     // includeCredentials is true, and request’s window is an environment settings object, then:

--- a/components/shared/net/response.rs
+++ b/components/shared/net/response.rs
@@ -139,6 +139,10 @@ pub struct Response {
 
     /// <https://fetch.spec.whatwg.org/#concept-response-range-requested-flag>
     pub range_requested: bool,
+
+    /// <https://fetch.spec.whatwg.org/#response-request-includes-credentials>
+    /// A response has an associated request-includes-credentials, which is initially true.
+    pub request_includes_credentials: bool,
 }
 
 impl Response {
@@ -163,6 +167,7 @@ impl Response {
             aborted: Arc::new(AtomicBool::new(false)),
             resource_timing: Arc::new(Mutex::new(resource_timing)),
             range_requested: false,
+            request_includes_credentials: true,
             redirect_taint: Default::default(),
         }
     }
@@ -199,6 +204,7 @@ impl Response {
                 ResourceTimingType::Error,
             ))),
             range_requested: false,
+            request_includes_credentials: true,
             redirect_taint: Default::default(),
         }
     }


### PR DESCRIPTION
Part of #33616

Implement step 11, 13 of [HTTP-network-or-cache fetch](https://fetch.spec.whatwg.org/#concept-http-network-or-cache-fetch)

Testing: The value should be used in https://fetch.spec.whatwg.org/#cross-origin-resource-policy-internal-check, which will be done in a follow up. Right now it is not used.