### PR TITLE
script: Use snapshot of navigation target when navigating.

### DIFF
--- a/components/constellation/constellation.rs
+++ b/components/constellation/constellation.rs
@@ -163,7 +163,8 @@ use servo_constellation_traits::{
     LoadData, LogEntry, MessagePortMsg, NavigationHistoryBehavior, PaintMetricEvent,
     PortMessageTask, PortTransferInfo, SWManagerMsg, SWManagerSenders, ScreenshotReadinessResponse,
     ScriptToConstellationMessage, ScrollStateUpdate, ServiceWorkerManagerFactory, ServiceWorkerMsg,
-    StructuredSerializedData, TraversalDirection, UserContentManagerAction, WindowSizeType,
+    StructuredSerializedData, TargetSnapshotParams, TraversalDirection, UserContentManagerAction,
+    WindowSizeType,
 };
 use servo_url::{Host, ImmutableOrigin, ServoUrl};
 use storage_traits::StorageThreads;
@@ -189,7 +190,13 @@ use crate::process_manager::ProcessManager;
 use crate::serviceworker::ServiceWorkerUnprivilegedContent;
 use crate::session_history::{NeedsToReload, SessionHistoryChange, SessionHistoryDiff};
 
-type PendingApprovalNavigations = FxHashMap<PipelineId, (LoadData, NavigationHistoryBehavior)>;
+struct PendingApprovalNavigation {
+    load_data: LoadData,
+    history_behaviour: NavigationHistoryBehavior,
+    target_snapshot_params: TargetSnapshotParams,
+}
+
+type PendingApprovalNavigations = FxHashMap<PipelineId, PendingApprovalNavigation>;
 
 #[derive(Debug)]
 /// The state used by MessagePortInfo to represent the various states the port can be in.
@@ -1023,6 +1030,7 @@ where
         load_data: LoadData,
         is_private: bool,
         throttled: bool,
+        target_snapshot_params: TargetSnapshotParams,
     ) {
         if self.shutting_down {
             return;
@@ -1064,6 +1072,7 @@ where
             viewport_details: initial_viewport_details,
             user_content_manager_id,
             theme,
+            target_snapshot_params,
         };
         let pipeline = match Pipeline::spawn(new_pipeline_info, event_loop, self, throttled) {
             Ok(pipeline) => pipeline,
@@ -1358,9 +1367,15 @@ where
                 };
 
                 match pending {
-                    Some((load_data, history_handling)) => {
+                    Some(pending) => {
                         if allowed {
-                            self.load_url(webview_id, pipeline_id, load_data, history_handling);
+                            self.load_url(
+                                webview_id,
+                                pipeline_id,
+                                pending.load_data,
+                                pending.history_behaviour,
+                                pending.target_snapshot_params,
+                            );
                         } else {
                             if let Some((sender, id)) = &self.webdriver_load_status_sender {
                                 if pipeline_id == *id {
@@ -1411,6 +1426,7 @@ where
                     pipeline_id,
                     load_data,
                     NavigationHistoryBehavior::Push,
+                    TargetSnapshotParams::default(),
                 );
             },
             // Create a new top level browsing context. Will use response_chan to return
@@ -1822,12 +1838,17 @@ where
                 self.handle_change_running_animations_state(source_pipeline_id, animation_state)
             },
             // Ask the embedder for permission to load a new page.
-            ScriptToConstellationMessage::LoadUrl(load_data, history_handling) => {
+            ScriptToConstellationMessage::LoadUrl(
+                load_data,
+                history_handling,
+                target_snapshot_params,
+            ) => {
                 self.schedule_navigation(
                     webview_id,
                     source_pipeline_id,
                     load_data,
                     history_handling,
+                    target_snapshot_params,
                 );
             },
             ScriptToConstellationMessage::AbortLoadUrl => {
@@ -3019,6 +3040,7 @@ where
             new_load_data,
             is_private,
             throttled,
+            TargetSnapshotParams::default(),
         );
         self.add_pending_change(SessionHistoryChange {
             webview_id,
@@ -3251,6 +3273,7 @@ where
             load_data,
             is_private,
             throttled,
+            TargetSnapshotParams::default(),
         );
         self.add_pending_change(SessionHistoryChange {
             webview_id,
@@ -3390,6 +3413,7 @@ where
             new_pipeline_id,
             is_private,
             mut history_handling,
+            target_snapshot_params,
             ..
         } = load_info.info;
 
@@ -3469,6 +3493,7 @@ where
             load_info.load_data,
             is_private,
             browsing_context_throttled,
+            target_snapshot_params,
         );
         self.add_pending_change(SessionHistoryChange {
             webview_id,
@@ -3732,6 +3757,7 @@ where
         source_id: PipelineId,
         load_data: LoadData,
         history_handling: NavigationHistoryBehavior,
+        target_snapshot_params: TargetSnapshotParams,
     ) {
         match self.pending_approval_navigations.entry(source_id) {
             Entry::Occupied(_) => {
@@ -3741,7 +3767,11 @@ where
                 );
             },
             Entry::Vacant(entry) => {
-                let _ = entry.insert((load_data.clone(), history_handling));
+                let _ = entry.insert(PendingApprovalNavigation {
+                    load_data: load_data.clone(),
+                    history_behaviour: history_handling,
+                    target_snapshot_params,
+                });
             },
         };
         // Allow the embedder to handle the url itself
@@ -3761,6 +3791,7 @@ where
         source_id: PipelineId,
         load_data: LoadData,
         history_handling: NavigationHistoryBehavior,
+        target_snapshot_params: TargetSnapshotParams,
     ) -> Option<PipelineId> {
         debug!(
             "{}: Loading ({}replacing): {}",
@@ -3823,6 +3854,7 @@ where
                     browsing_context_id,
                     load_data,
                     history_handling,
+                    target_snapshot_params,
                 );
                 let result = match self.pipelines.get(&parent_pipeline_id) {
                     Some(parent_pipeline) => parent_pipeline.event_loop.send(msg),
@@ -3880,6 +3912,7 @@ where
                     load_data,
                     is_private,
                     is_throttled,
+                    target_snapshot_params,
                 );
                 self.add_pending_change(SessionHistoryChange {
                     webview_id,
@@ -4174,6 +4207,7 @@ where
                     load_data.clone(),
                     is_private,
                     throttled,
+                    TargetSnapshotParams::default(), //XXXjdm wrong
                 );
                 self.add_pending_change(SessionHistoryChange {
                     webview_id,

--- a/components/constellation/constellation.rs
+++ b/components/constellation/constellation.rs
@@ -4207,7 +4207,7 @@ where
                     load_data.clone(),
                     is_private,
                     throttled,
-                    //TODO(jdm): We need to store the original target snapshot params
+                    // TODO(jdm): We need to store the original target snapshot params
                     // with the pipeline when it's created, so we can support reloading
                     // a discarded document properly.
                     TargetSnapshotParams::default(),

--- a/components/constellation/constellation.rs
+++ b/components/constellation/constellation.rs
@@ -4207,7 +4207,10 @@ where
                     load_data.clone(),
                     is_private,
                     throttled,
-                    TargetSnapshotParams::default(), //XXXjdm wrong
+                    //TODO(jdm): We need to store the original target snapshot params
+                    // with the pipeline when it's created, so we can support reloading
+                    // a discarded document properly.
+                    TargetSnapshotParams::default(),
                 );
                 self.add_pending_change(SessionHistoryChange {
                     webview_id,

--- a/components/script/dom/document/document.rs
+++ b/components/script/dom/document/document.rs
@@ -5151,6 +5151,10 @@ impl Document {
         self.custom_element_reaction_stack.clone()
     }
 
+    pub(crate) fn active_sandboxing_flag_set(&self) -> SandboxingFlagSet {
+        self.active_sandboxing_flag_set.get()
+    }
+
     pub(crate) fn has_active_sandboxing_flag(&self, flag: SandboxingFlagSet) -> bool {
         self.active_sandboxing_flag_set.get().contains(flag)
     }

--- a/components/script/dom/document/document.rs
+++ b/components/script/dom/document/document.rs
@@ -4062,7 +4062,7 @@ impl Document {
             waiting_on_canvas_image_updates: Cell::new(false),
             current_rendering_epoch: Default::default(),
             custom_element_reaction_stack,
-            active_sandboxing_flag_set: Cell::new(SandboxingFlagSet::empty()),
+            active_sandboxing_flag_set: Cell::new(creation_sandboxing_flag_set),
             creation_sandboxing_flag_set: Cell::new(creation_sandboxing_flag_set),
             favicon: RefCell::new(None),
             websockets: DOMTracker::new(),

--- a/components/script/dom/html/htmliframeelement.rs
+++ b/components/script/dom/html/htmliframeelement.rs
@@ -1301,7 +1301,10 @@ impl<'a> ResourceTimingListener for IframeContext<'a> {
 fn snapshot_self(iframe: &HTMLIFrameElement) -> TargetSnapshotParams {
     let child_navigable = iframe.GetContentWindow();
     TargetSnapshotParams {
-        sandboxing_flags: determine_creation_sandboxing_flags(child_navigable.as_deref(), Some(iframe.upcast())),
+        sandboxing_flags: determine_creation_sandboxing_flags(
+            child_navigable.as_deref(),
+            Some(iframe.upcast()),
+        ),
         iframe_element_referrer_policy: determine_iframe_element_referrer_policy(Some(
             iframe.upcast(),
         )),

--- a/components/script/dom/html/htmliframeelement.rs
+++ b/components/script/dom/html/htmliframeelement.rs
@@ -21,7 +21,7 @@ use script_traits::{NewPipelineInfo, UpdatePipelineIdReason};
 use servo_base::id::{BrowsingContextId, PipelineId, WebViewId};
 use servo_constellation_traits::{
     IFrameLoadInfo, IFrameLoadInfoWithData, LoadData, LoadOrigin, NavigationHistoryBehavior,
-    ScriptToConstellationMessage,
+    ScriptToConstellationMessage, TargetSnapshotParams,
 };
 use servo_url::ServoUrl;
 use style::attr::{AttrValue, LengthOrPercentageOrAuto};
@@ -52,6 +52,9 @@ use crate::dom::performance::performanceresourcetiming::InitiatorType;
 use crate::dom::trustedtypes::trustedhtml::TrustedHTML;
 use crate::dom::virtualmethods::VirtualMethods;
 use crate::dom::windowproxy::WindowProxy;
+use crate::navigation::{
+    determine_creation_sandboxing_flags, determine_iframe_element_referrer_policy,
+};
 use crate::network_listener::ResourceTimingListener;
 use crate::script_runtime::CanGc;
 use crate::script_thread::{ScriptThread, with_script_thread};
@@ -155,6 +158,7 @@ impl HTMLIFrameElement {
         load_data: LoadData,
         history_handling: NavigationHistoryBehavior,
         mode: ProcessingMode,
+        target_snapshot_params: TargetSnapshotParams,
         cx: &mut js::context::JSContext,
     ) {
         // In case we fired a synchronous load event, but navigate away
@@ -170,6 +174,7 @@ impl HTMLIFrameElement {
             PipelineType::Navigation,
             history_handling,
             mode,
+            target_snapshot_params,
             cx,
         );
     }
@@ -180,6 +185,7 @@ impl HTMLIFrameElement {
         pipeline_type: PipelineType,
         history_handling: NavigationHistoryBehavior,
         mode: ProcessingMode,
+        target_snapshot_params: TargetSnapshotParams,
         cx: &mut js::context::JSContext,
     ) {
         let document = self.owner_document();
@@ -197,7 +203,12 @@ impl HTMLIFrameElement {
         }
 
         if load_data.url.scheme() != "javascript" {
-            self.continue_navigation(load_data, pipeline_type, history_handling);
+            self.continue_navigation(
+                load_data,
+                pipeline_type,
+                history_handling,
+                target_snapshot_params,
+            );
             return;
         }
 
@@ -229,7 +240,7 @@ impl HTMLIFrameElement {
                     }
                     load_data.about_base_url = doc.root().about_base_url();
                 }
-                this.continue_navigation(load_data, pipeline_type, history_handling);
+                this.continue_navigation(load_data, pipeline_type, history_handling, target_snapshot_params);
             }));
     }
 
@@ -238,6 +249,7 @@ impl HTMLIFrameElement {
         load_data: LoadData,
         pipeline_type: PipelineType,
         history_handling: NavigationHistoryBehavior,
+        target_snapshot_params: TargetSnapshotParams,
     ) {
         let browsing_context_id = match self.browsing_context_id() {
             None => return warn!("Attempted to start a new pipeline on an unattached iframe."),
@@ -262,6 +274,7 @@ impl HTMLIFrameElement {
             is_private: false, // FIXME
             inherited_secure_context: load_data.inherited_secure_context,
             history_handling,
+            target_snapshot_params,
         };
 
         let viewport_details = window
@@ -298,6 +311,7 @@ impl HTMLIFrameElement {
                     viewport_details,
                     user_content_manager_id: None,
                     theme: window.theme(),
+                    target_snapshot_params: snapshot_self(self),
                 };
 
                 self.pipeline_id.set(Some(new_pipeline_id));
@@ -358,7 +372,14 @@ impl HTMLIFrameElement {
         // Step 4. Navigate element's content navigable to url using element's node document,
         // with historyHandling set to historyHandling, referrerPolicy set to referrerPolicy,
         // documentResource set to srcdocString, and initialInsertion set to initialInsertion.
-        self.navigate_or_reload_child_browsing_context(load_data, history_handling, mode, cx);
+        let target_snapshot_params = snapshot_self(self);
+        self.navigate_or_reload_child_browsing_context(
+            load_data,
+            history_handling,
+            mode,
+            target_snapshot_params,
+            cx,
+        );
     }
 
     /// <https://html.spec.whatwg.org/multipage/#will-lazy-load-element-steps>
@@ -552,7 +573,14 @@ impl HTMLIFrameElement {
             NavigationHistoryBehavior::Push
         };
 
-        self.navigate_or_reload_child_browsing_context(load_data, history_handling, mode, cx);
+        let target_snapshot_params = snapshot_self(self);
+        self.navigate_or_reload_child_browsing_context(
+            load_data,
+            history_handling,
+            mode,
+            target_snapshot_params,
+            cx,
+        );
     }
 
     /// <https://html.spec.whatwg.org/multipage/#create-a-new-child-navigable>
@@ -593,6 +621,7 @@ impl HTMLIFrameElement {
             PipelineType::InitialAboutBlank,
             NavigationHistoryBehavior::Push,
             ProcessingMode::FirstTime,
+            snapshot_self(self),
             cx,
         );
     }
@@ -1266,5 +1295,14 @@ impl<'a> ResourceTimingListener for IframeContext<'a> {
 
     fn resource_timing_global(&self) -> DomRoot<GlobalScope> {
         self.element.upcast::<Node>().owner_doc().global()
+    }
+}
+
+fn snapshot_self(iframe: &HTMLIFrameElement) -> TargetSnapshotParams {
+    TargetSnapshotParams {
+        sandboxing_flags: determine_creation_sandboxing_flags(Some(iframe.upcast())),
+        iframe_element_referrer_policy: determine_iframe_element_referrer_policy(Some(
+            iframe.upcast(),
+        )),
     }
 }

--- a/components/script/dom/html/htmliframeelement.rs
+++ b/components/script/dom/html/htmliframeelement.rs
@@ -311,7 +311,7 @@ impl HTMLIFrameElement {
                     viewport_details,
                     user_content_manager_id: None,
                     theme: window.theme(),
-                    target_snapshot_params: snapshot_self(self),
+                    target_snapshot_params,
                 };
 
                 self.pipeline_id.set(Some(new_pipeline_id));
@@ -1299,8 +1299,9 @@ impl<'a> ResourceTimingListener for IframeContext<'a> {
 }
 
 fn snapshot_self(iframe: &HTMLIFrameElement) -> TargetSnapshotParams {
+    let child_navigable = iframe.GetContentWindow();
     TargetSnapshotParams {
-        sandboxing_flags: determine_creation_sandboxing_flags(Some(iframe.upcast())),
+        sandboxing_flags: determine_creation_sandboxing_flags(child_navigable.as_deref(), Some(iframe.upcast())),
         iframe_element_referrer_policy: determine_iframe_element_referrer_policy(Some(
             iframe.upcast(),
         )),

--- a/components/script/dom/servoparser/mod.rs
+++ b/components/script/dom/servoparser/mod.rs
@@ -1284,6 +1284,10 @@ impl FetchResponseListener for ParserContext {
             .map(Serde::into_inner)
             .map(Into::into);
 
+        // <https://html.spec.whatwg.org/multipage/#create-navigation-params-by-fetching>
+        // Step 21.9. Set responsePolicyContainer to the result of creating a
+        // policy container from a fetch response given response and request's
+        // reserved client.
         let (policy_container, endpoints_list, link_headers) = match metadata.as_ref() {
             None => (PolicyContainer::default(), None, vec![]),
             Some(metadata) => (
@@ -1295,6 +1299,21 @@ impl FetchResponseListener for ParserContext {
                 extract_links_from_headers(&metadata.headers),
             ),
         };
+
+        // Step 21.10. Set finalSandboxFlags to the union of targetSnapshotParams's
+        // sandboxing flags and responsePolicyContainer's CSP list's CSP-derived
+        // sandboxing flags.
+        let final_sandboxing_flag_set = policy_container
+            .csp_list
+            .as_ref()
+            .and_then(|csp| csp.get_sandboxing_flag_set_for_document())
+            .unwrap_or(SandboxingFlagSet::empty())
+            .union(self.target_snapshot_params.sandboxing_flags);
+
+        // Step 21.11. Set responseOrigin to the result of determining the origin
+        // given response's URL, finalSandboxFlags, and entry's document state's
+        // initiator origin.
+        // TODO
 
         let parser = match ScriptThread::page_headers_available(
             self.webview_id,
@@ -1354,19 +1373,6 @@ impl FetchResponseListener for ParserContext {
             // Step 4.4. If navigationParams is not null, then:
             // TODO
         }
-
-        // From Step 23.8.3 of https://html.spec.whatwg.org/multipage/#navigate
-        // Let finalSandboxFlags be the union of targetSnapshotParams's sandboxing flags and
-        // policyContainer's CSP list's CSP-derived sandboxing flags.
-        //
-        // TODO: This deviates a bit from the specification, because there isn't a `targetSnapshotParam`
-        // concept yet.
-        let final_sandboxing_flag_set = policy_container
-            .csp_list
-            .as_ref()
-            .and_then(|csp| csp.get_sandboxing_flag_set_for_document())
-            .unwrap_or(SandboxingFlagSet::empty())
-            .union(document.creation_sandboxing_flag_set());
 
         if let Some(endpoints) = endpoints_list {
             window.set_endpoints_list(endpoints);

--- a/components/script/dom/servoparser/mod.rs
+++ b/components/script/dom/servoparser/mod.rs
@@ -36,8 +36,8 @@ use script_traits::DocumentActivity;
 use servo_base::cross_process_instant::CrossProcessInstant;
 use servo_base::id::{PipelineId, WebViewId};
 use servo_config::pref;
-use servo_constellation_traits::TargetSnapshotParams;
-use servo_url::ServoUrl;
+use servo_constellation_traits::{LoadOrigin, TargetSnapshotParams};
+use servo_url::{MutableOrigin, ServoUrl};
 use style::context::QuirksMode as ServoQuirksMode;
 use tendril::stream::LossyDecoder;
 use tendril::{ByteTendril, TendrilSink};
@@ -87,6 +87,7 @@ use crate::dom::shadowroot::IsUserAgentWidget;
 use crate::dom::text::Text;
 use crate::dom::types::{HTMLElement, HTMLMediaElement, HTMLOptionElement};
 use crate::dom::virtualmethods::vtable_for;
+use crate::navigation::determine_the_origin;
 use crate::network_listener::FetchResponseListener;
 use crate::realms::{enter_auto_realm, enter_realm};
 use crate::script_runtime::{CanGc, IntroductionType};
@@ -927,6 +928,7 @@ pub(crate) struct ParserContext {
     /// To report CSP violations to the global that initiated the navigation
     parent_info: Option<PipelineId>,
     target_snapshot_params: TargetSnapshotParams,
+    load_origin: LoadOrigin,
 }
 
 impl ParserContext {
@@ -937,6 +939,7 @@ impl ParserContext {
         creation_sandboxing_flag_set: SandboxingFlagSet,
         parent_info: Option<PipelineId>,
         target_snapshot_params: TargetSnapshotParams,
+        load_origin: LoadOrigin,
     ) -> ParserContext {
         ParserContext {
             parser: None,
@@ -956,6 +959,7 @@ impl ParserContext {
                 about_base_url: Default::default(),
             },
             target_snapshot_params,
+            load_origin,
         }
     }
 
@@ -1313,12 +1317,23 @@ impl FetchResponseListener for ParserContext {
         // Step 21.11. Set responseOrigin to the result of determining the origin
         // given response's URL, finalSandboxFlags, and entry's document state's
         // initiator origin.
-        // TODO
+        let source_origin = match self.load_origin {
+            LoadOrigin::Script(ref snapshot) => {
+                Some(MutableOrigin::from_snapshot(snapshot.clone()))
+            },
+            _ => None,
+        };
+        let origin = determine_the_origin(
+            metadata.as_ref().map(|metadata| &metadata.final_url),
+            final_sandboxing_flag_set,
+            source_origin,
+        );
 
         let parser = match ScriptThread::page_headers_available(
             self.webview_id,
             self.pipeline_id,
             metadata.as_ref(),
+            origin.clone(),
             cx,
         ) {
             Some(parser) => parser,
@@ -1345,7 +1360,7 @@ impl FetchResponseListener for ParserContext {
         policy_container.csp_list.should_navigation_response_to_navigation_request_be_blocked(
             window,
             self.url.clone().into_url(),
-            &document.origin().immutable().clone().into_url_origin(),
+            &origin.immutable().clone().into_url_origin(),
         )
         // navigationParams's reserved environment is non-null and the result of
         // checking a navigation response's adherence to its embedder policy given navigationParams's response,
@@ -1357,7 +1372,7 @@ impl FetchResponseListener for ParserContext {
         || !check_a_navigation_response_adherence_to_x_frame_options(
             window,
             policy_container.csp_list.as_ref(),
-            &document.origin(),
+            &origin,
             metadata
                 .as_ref()
                 .and_then(|metadata| metadata.headers.as_ref()),

--- a/components/script/dom/servoparser/mod.rs
+++ b/components/script/dom/servoparser/mod.rs
@@ -36,6 +36,7 @@ use script_traits::DocumentActivity;
 use servo_base::cross_process_instant::CrossProcessInstant;
 use servo_base::id::{PipelineId, WebViewId};
 use servo_config::pref;
+use servo_constellation_traits::TargetSnapshotParams;
 use servo_url::ServoUrl;
 use style::context::QuirksMode as ServoQuirksMode;
 use tendril::stream::LossyDecoder;
@@ -925,6 +926,7 @@ pub(crate) struct ParserContext {
     navigation_params: NavigationParams,
     /// To report CSP violations to the global that initiated the navigation
     parent_info: Option<PipelineId>,
+    target_snapshot_params: TargetSnapshotParams,
 }
 
 impl ParserContext {
@@ -934,6 +936,7 @@ impl ParserContext {
         url: ServoUrl,
         creation_sandboxing_flag_set: SandboxingFlagSet,
         parent_info: Option<PipelineId>,
+        target_snapshot_params: TargetSnapshotParams,
     ) -> ParserContext {
         ParserContext {
             parser: None,
@@ -952,6 +955,7 @@ impl ParserContext {
                 resource_header: vec![],
                 about_base_url: Default::default(),
             },
+            target_snapshot_params,
         }
     }
 

--- a/components/script/dom/windowproxy.rs
+++ b/components/script/dom/windowproxy.rs
@@ -38,7 +38,7 @@ use servo_base::generic_channel::GenericSend;
 use servo_base::id::{BrowsingContextId, PipelineId, WebViewId};
 use servo_constellation_traits::{
     AuxiliaryWebViewCreationRequest, LoadData, LoadOrigin, NavigationHistoryBehavior,
-    ScriptToConstellationMessage,
+    ScriptToConstellationMessage, TargetSnapshotParams,
 };
 use servo_url::{ImmutableOrigin, ServoUrl};
 use storage_traits::webstorage_thread::WebStorageThreadMsg;
@@ -352,6 +352,7 @@ impl WindowProxy {
             // Use the current `WebView`'s theme initially, but the embedder may
             // change this later.
             theme: window.theme(),
+            target_snapshot_params: TargetSnapshotParams::default(),
         };
 
         with_script_thread(|script_thread| {

--- a/components/script/dom/windowproxy.rs
+++ b/components/script/dom/windowproxy.rs
@@ -29,6 +29,7 @@ use js::realm::{AutoRealm, CurrentRealm};
 use js::rust::wrappers::{JS_TransplantObject, NewWindowProxy, SetWindowProxy};
 use js::rust::{Handle, MutableHandle, MutableHandleValue, get_object_class};
 use malloc_size_of::{MallocSizeOf, MallocSizeOfOps};
+use net_traits::ReferrerPolicy;
 use net_traits::request::Referrer;
 use script_bindings::reflector::MutDomObject;
 use script_traits::NewPipelineInfo;
@@ -313,6 +314,23 @@ impl WindowProxy {
             .get()
             .and_then(ScriptThread::find_document)
             .expect("A WindowProxy creating an auxiliary to have an active document");
+
+        // <https://html.spec.whatwg.org/multipage/#navigable-target-names>
+        // > If the user agent has been configured such that in this instance it
+        // > will create a new top-level traversable
+        // >
+        // Step 9. If sandboxingFlagSet's sandbox propagates to auxiliary browsing
+        //   contexts flag is set, then all the flags that are set in sandboxingFlagSet
+        // must be set in chosen's active browsing context's popup sandboxing flag set.
+        let sandboxing_flag_set = document.active_sandboxing_flag_set();
+        let propagate_sandbox = sandboxing_flag_set
+            .contains(SandboxingFlagSet::SANDBOX_PROPOGATES_TO_AUXILIARY_BROWSING_CONTEXTS_FLAG);
+        let sandboxing_flag_set = if propagate_sandbox {
+            sandboxing_flag_set
+        } else {
+            SandboxingFlagSet::empty()
+        };
+
         let blank_url = ServoUrl::parse("about:blank").ok().unwrap();
         let load_data = LoadData::new(
             LoadOrigin::Script(document.origin().snapshot()),
@@ -326,8 +344,7 @@ impl WindowProxy {
             None, // Doesn't inherit secure context
             None,
             false,
-            // There are no sandboxing restrictions when creating auxiliary browsing contexts.
-            SandboxingFlagSet::empty(),
+            sandboxing_flag_set,
         );
         let load_info = AuxiliaryWebViewCreationRequest {
             load_data: load_data.clone(),
@@ -352,7 +369,10 @@ impl WindowProxy {
             // Use the current `WebView`'s theme initially, but the embedder may
             // change this later.
             theme: window.theme(),
-            target_snapshot_params: TargetSnapshotParams::default(),
+            target_snapshot_params: TargetSnapshotParams {
+                sandboxing_flags: sandboxing_flag_set,
+                iframe_element_referrer_policy: ReferrerPolicy::EmptyString,
+            },
         };
 
         with_script_thread(|script_thread| {

--- a/components/script/navigation.rs
+++ b/components/script/navigation.rs
@@ -182,7 +182,7 @@ pub(crate) struct InProgressLoad {
     /// The [`Theme`] to use for this page, once it loads.
     #[no_trace]
     pub(crate) theme: Theme,
-    ///
+    /// The [`TargetSnapshotParams`] to use when creating this document.
     #[no_trace]
     pub(crate) target_snapshot_params: TargetSnapshotParams,
 }

--- a/components/script/navigation.rs
+++ b/components/script/navigation.rs
@@ -523,18 +523,19 @@ pub(crate) fn determine_iframe_element_referrer_policy(
 ) -> ReferrerPolicy {
     // Step 1. If embedder is an iframe element, then return embedder's referrerpolicy
     // attribute's state's corresponding keyword.
-    // Step 2. Return the empty string.
     element
         .and_then(|element| element.downcast::<HTMLIFrameElement>())
         .map(|iframe| {
             let token = iframe.ReferrerPolicy();
             ReferrerPolicy::from(&*token.str())
         })
+    // Step 2. Return the empty string.
         .unwrap_or(ReferrerPolicy::EmptyString)
 }
 
 /// <https://html.spec.whatwg.org/multipage/#snapshotting-target-snapshot-params>
 pub(crate) fn snapshot_target_snapshot_params(navigable: &WindowProxy) -> TargetSnapshotParams {
+    // TODO(jdm): This doesn't work for cross-origin parent frames.
     let container = navigable.frame_element();
     // the result of determining the creation sandboxing flags given targetNavigable's
     // active browsing context and targetNavigable's container

--- a/components/script/navigation.rs
+++ b/components/script/navigation.rs
@@ -489,15 +489,20 @@ pub(crate) fn navigate(
 }
 
 /// <https://html.spec.whatwg.org/multipage/#determining-the-creation-sandboxing-flags>
-pub(crate) fn determine_creation_sandboxing_flags(element: Option<&Element>) -> SandboxingFlagSet {
+pub(crate) fn determine_creation_sandboxing_flags(
+    browsing_context: Option<&WindowProxy>,
+    element: Option<&Element>,
+) -> SandboxingFlagSet {
     // To determine the creation sandboxing flags for a browsing context
     // browsing context, given null or an element embedder, return the union
     // of the flags that are present in the following sandboxing flag sets:
     match element {
         // If embedder is null, then: the flags set on browsing context's
         // popup sandboxing flag set.
-        // TODO
-        None => SandboxingFlagSet::empty(),
+        None => browsing_context
+            .and_then(|browsing_context| browsing_context.document())
+            .map(|document| document.active_sandboxing_flag_set())
+            .unwrap_or(SandboxingFlagSet::empty()),
         Some(element) => {
             // If embedder is an element, then: the flags set on embedder's
             // iframe sandboxing flag set.
@@ -533,7 +538,7 @@ pub(crate) fn snapshot_target_snapshot_params(navigable: &WindowProxy) -> Target
     let container = navigable.frame_element();
     // the result of determining the creation sandboxing flags given targetNavigable's
     // active browsing context and targetNavigable's container
-    let sandboxing_flags = determine_creation_sandboxing_flags(container);
+    let sandboxing_flags = determine_creation_sandboxing_flags(Some(navigable), container);
     // the result of determining the iframe element referrer policy given
     // targetNavigable's container
     let iframe_element_referrer_policy = determine_iframe_element_referrer_policy(container);

--- a/components/script/navigation.rs
+++ b/components/script/navigation.rs
@@ -529,7 +529,7 @@ pub(crate) fn determine_iframe_element_referrer_policy(
             let token = iframe.ReferrerPolicy();
             ReferrerPolicy::from(&*token.str())
         })
-    // Step 2. Return the empty string.
+        // Step 2. Return the empty string.
         .unwrap_or(ReferrerPolicy::EmptyString)
 }
 

--- a/components/script/navigation.rs
+++ b/components/script/navigation.rs
@@ -22,20 +22,27 @@ use net_traits::request::{
 use net_traits::response::ResponseInit;
 use net_traits::{
     BoxedFetchCallback, CoreResourceThread, DOCUMENT_ACCEPT_HEADER_VALUE, FetchResponseMsg,
-    Metadata, fetch_async, set_default_accept_language,
+    Metadata, ReferrerPolicy, fetch_async, set_default_accept_language,
 };
+use script_bindings::inheritance::Castable;
 use script_traits::{DocumentActivity, NewPipelineInfo};
 use servo_base::cross_process_instant::CrossProcessInstant;
 use servo_base::id::{BrowsingContextId, PipelineId, WebViewId};
 use servo_constellation_traits::{
     LoadData, LoadOrigin, NavigationHistoryBehavior, ScriptToConstellationMessage,
+    TargetSnapshotParams,
 };
 use servo_url::{ImmutableOrigin, MutableOrigin, ServoUrl};
 use url::Position;
 
+use crate::dom::bindings::codegen::Bindings::HTMLIFrameElementBinding::HTMLIFrameElementMethods;
 use crate::dom::bindings::codegen::Bindings::WindowBinding::WindowMethods;
 use crate::dom::bindings::refcounted::Trusted;
+use crate::dom::element::Element;
+use crate::dom::html::htmliframeelement::HTMLIFrameElement;
+use crate::dom::node::node::NodeTraits;
 use crate::dom::window::Window;
+use crate::dom::windowproxy::WindowProxy;
 use crate::fetch::FetchCanceller;
 use crate::messaging::MainThreadScriptMsg;
 use crate::script_runtime::CanGc;
@@ -175,6 +182,9 @@ pub(crate) struct InProgressLoad {
     /// The [`Theme`] to use for this page, once it loads.
     #[no_trace]
     pub(crate) theme: Theme,
+    ///
+    #[no_trace]
+    pub(crate) target_snapshot_params: TargetSnapshotParams,
 }
 
 impl InProgressLoad {
@@ -196,6 +206,7 @@ impl InProgressLoad {
             url_list: vec![url],
             user_content_manager_id: new_pipeline_info.user_content_manager_id,
             theme: new_pipeline_info.theme,
+            target_snapshot_params: new_pipeline_info.target_snapshot_params,
         }
     }
 
@@ -436,6 +447,10 @@ pub(crate) fn navigate(
             window_proxy.start_delaying_load_events_mode();
         }
 
+        // Step 16. Let targetSnapshotParams be the result of snapshotting target
+        // snapshot params given navigable.
+        let target_snapshot_params = snapshot_target_snapshot_params(&window_proxy);
+
         if let Some(sender) = window.webdriver_load_status_sender() {
             let _ = sender.send(WebDriverLoadStatus::NavigationStart);
         }
@@ -454,7 +469,7 @@ pub(crate) fn navigate(
                 let global = window.as_global_scope();
                 if ScriptThread::navigate_to_javascript_url(cx, global, global, &mut load_data, None, None) {
                     sender
-                        .send(ScriptToConstellationMessage::LoadUrl(load_data, history_handling))
+                        .send(ScriptToConstellationMessage::LoadUrl(load_data, history_handling, target_snapshot_params))
                         .unwrap();
                 }
             });
@@ -467,7 +482,63 @@ pub(crate) fn navigate(
             window.send_to_constellation(ScriptToConstellationMessage::LoadUrl(
                 load_data,
                 history_handling,
+                target_snapshot_params,
             ));
         }
     };
+}
+
+/// <https://html.spec.whatwg.org/multipage/#determining-the-creation-sandboxing-flags>
+pub(crate) fn determine_creation_sandboxing_flags(element: Option<&Element>) -> SandboxingFlagSet {
+    // To determine the creation sandboxing flags for a browsing context
+    // browsing context, given null or an element embedder, return the union
+    // of the flags that are present in the following sandboxing flag sets:
+    match element {
+        // If embedder is null, then: the flags set on browsing context's
+        // popup sandboxing flag set.
+        // TODO
+        None => SandboxingFlagSet::empty(),
+        Some(element) => {
+            // If embedder is an element, then: the flags set on embedder's
+            // iframe sandboxing flag set.
+            // If embedder is an element, then: the flags set on embedder's
+            // node document's active sandboxing flag set.
+            element
+                .downcast::<HTMLIFrameElement>()
+                .map(|iframe| iframe.sandboxing_flag_set())
+                .unwrap_or(SandboxingFlagSet::empty())
+                .union(element.owner_document().active_sandboxing_flag_set())
+        },
+    }
+}
+
+/// <https://html.spec.whatwg.org/multipage/#determining-the-iframe-element-referrer-policy>
+pub(crate) fn determine_iframe_element_referrer_policy(
+    element: Option<&Element>,
+) -> ReferrerPolicy {
+    // Step 1. If embedder is an iframe element, then return embedder's referrerpolicy
+    // attribute's state's corresponding keyword.
+    // Step 2. Return the empty string.
+    element
+        .and_then(|element| element.downcast::<HTMLIFrameElement>())
+        .map(|iframe| {
+            let token = iframe.ReferrerPolicy();
+            ReferrerPolicy::from(&*token.str())
+        })
+        .unwrap_or(ReferrerPolicy::EmptyString)
+}
+
+/// <https://html.spec.whatwg.org/multipage/#snapshotting-target-snapshot-params>
+pub(crate) fn snapshot_target_snapshot_params(navigable: &WindowProxy) -> TargetSnapshotParams {
+    let container = navigable.frame_element();
+    // the result of determining the creation sandboxing flags given targetNavigable's
+    // active browsing context and targetNavigable's container
+    let sandboxing_flags = determine_creation_sandboxing_flags(container);
+    // the result of determining the iframe element referrer policy given
+    // targetNavigable's container
+    let iframe_element_referrer_policy = determine_iframe_element_referrer_policy(container);
+    TargetSnapshotParams {
+        sandboxing_flags,
+        iframe_element_referrer_policy,
+    }
 }

--- a/components/script/script_thread.rs
+++ b/components/script/script_thread.rs
@@ -91,7 +91,7 @@ use servo_config::{opts, pref, prefs};
 use servo_constellation_traits::{
     LoadData, LoadOrigin, NavigationHistoryBehavior, ScreenshotReadinessResponse,
     ScriptToConstellationChan, ScriptToConstellationMessage, ScrollStateUpdate,
-    StructuredSerializedData, TraversalDirection, WindowSizeType,
+    StructuredSerializedData, TargetSnapshotParams, TraversalDirection, WindowSizeType,
 };
 use servo_url::{ImmutableOrigin, MutableOrigin, OriginSnapshot, ServoUrl};
 use storage_traits::StorageThreads;
@@ -1737,11 +1737,13 @@ impl ScriptThread {
                 browsing_context_id,
                 load_data,
                 history_handling,
+                target_snapshot_params,
             ) => self.handle_navigate_iframe(
                 parent_pipeline_id,
                 browsing_context_id,
                 load_data,
                 history_handling,
+                target_snapshot_params,
                 cx,
             ),
             ScriptThreadMessage::UnloadDocument(pipeline_id) => {
@@ -3725,6 +3727,7 @@ impl ScriptThread {
         browsing_context_id: BrowsingContextId,
         load_data: LoadData,
         history_handling: NavigationHistoryBehavior,
+        target_snapshot_params: TargetSnapshotParams,
         cx: &mut js::context::JSContext,
     ) {
         let iframe = self
@@ -3736,6 +3739,7 @@ impl ScriptThread {
                 load_data,
                 history_handling,
                 ProcessingMode::NotFirstTime,
+                target_snapshot_params,
                 cx,
             );
         }
@@ -3815,6 +3819,7 @@ impl ScriptThread {
             incomplete.load_data.url.clone(),
             incomplete.load_data.creation_sandboxing_flag_set,
             incomplete.parent_info,
+            incomplete.target_snapshot_params,
         );
         self.incomplete_parser_contexts
             .0
@@ -4034,6 +4039,7 @@ impl ScriptThread {
             incomplete.load_data.url.clone(),
             incomplete.load_data.creation_sandboxing_flag_set,
             incomplete.parent_info,
+            incomplete.target_snapshot_params,
         );
 
         let mut meta = Metadata::default(incomplete.load_data.url.clone());
@@ -4085,6 +4091,7 @@ impl ScriptThread {
         let pipeline_id = incomplete.pipeline_id;
         let parent_info = incomplete.parent_info;
         let about_base_url = incomplete.load_data.about_base_url.clone();
+        let target_snapshot_params = incomplete.target_snapshot_params;
         self.incomplete_loads.borrow_mut().push(incomplete);
 
         let mut context = ParserContext::new(
@@ -4093,6 +4100,7 @@ impl ScriptThread {
             url,
             creation_sandboxing_flag_set,
             parent_info,
+            target_snapshot_params,
         );
         let dummy_request_id = RequestId::default();
 
@@ -4146,6 +4154,7 @@ impl ScriptThread {
                     ScriptToConstellationMessage::LoadUrl(
                         LoadData::new_for_new_unrelated_webview(url),
                         NavigationHistoryBehavior::Push,
+                        TargetSnapshotParams::default(),
                     ),
                 ))
                 .unwrap();

--- a/components/script/script_thread.rs
+++ b/components/script/script_thread.rs
@@ -541,7 +541,13 @@ impl ScriptThread {
         cx: &mut js::context::JSContext,
     ) -> Option<DomRoot<ServoParser>> {
         with_script_thread(|script_thread| {
-            script_thread.handle_page_headers_available(webview_id, pipeline_id, metadata, origin, cx)
+            script_thread.handle_page_headers_available(
+                webview_id,
+                pipeline_id,
+                metadata,
+                origin,
+                cx,
+            )
         })
     }
 

--- a/components/script/script_thread.rs
+++ b/components/script/script_thread.rs
@@ -151,7 +151,7 @@ use crate::messaging::{
 };
 use crate::microtask::{Microtask, MicrotaskQueue};
 use crate::mime::{APPLICATION, CHARSET, MimeExt, TEXT, XML};
-use crate::navigation::{InProgressLoad, NavigationListener, determine_the_origin};
+use crate::navigation::{InProgressLoad, NavigationListener};
 use crate::network_listener::{FetchResponseListener, submit_timing};
 use crate::realms::{enter_auto_realm, enter_realm};
 use crate::script_mutation_observers::ScriptMutationObservers;
@@ -537,10 +537,11 @@ impl ScriptThread {
         webview_id: WebViewId,
         pipeline_id: PipelineId,
         metadata: Option<&Metadata>,
+        origin: MutableOrigin,
         cx: &mut js::context::JSContext,
     ) -> Option<DomRoot<ServoParser>> {
         with_script_thread(|script_thread| {
-            script_thread.handle_page_headers_available(webview_id, pipeline_id, metadata, cx)
+            script_thread.handle_page_headers_available(webview_id, pipeline_id, metadata, origin, cx)
         })
     }
 
@@ -3072,6 +3073,7 @@ impl ScriptThread {
         webview_id: WebViewId,
         pipeline_id: PipelineId,
         metadata: Option<&Metadata>,
+        origin: MutableOrigin,
         cx: &mut js::context::JSContext,
     ) -> Option<DomRoot<ServoParser>> {
         if self.closed_pipelines.borrow().contains(&pipeline_id) {
@@ -3124,7 +3126,7 @@ impl ScriptThread {
         };
 
         let load = self.incomplete_loads.borrow_mut().remove(idx);
-        metadata.map(|meta| self.load(meta, load, cx))
+        metadata.map(|meta| self.load(meta, load, origin, cx))
     }
 
     /// Handles a request for the window title.
@@ -3332,6 +3334,7 @@ impl ScriptThread {
         &self,
         metadata: &Metadata,
         incomplete: InProgressLoad,
+        origin: MutableOrigin,
         cx: &mut js::context::JSContext,
     ) -> DomRoot<ServoParser> {
         let script_to_constellation_chan = ScriptToConstellationChan {
@@ -3347,18 +3350,6 @@ impl ScriptThread {
         debug!(
             "ScriptThread: loading {} on pipeline {:?}",
             incomplete.load_data.url, incomplete.pipeline_id
-        );
-
-        let source_origin = match incomplete.load_data.load_origin {
-            LoadOrigin::Script(ref snapshot) => {
-                Some(MutableOrigin::from_snapshot(snapshot.clone()))
-            },
-            _ => None,
-        };
-        let origin = determine_the_origin(
-            Some(&final_url),
-            incomplete.load_data.creation_sandboxing_flag_set,
-            source_origin,
         );
 
         let font_context = Arc::new(FontContext::new(
@@ -3820,6 +3811,7 @@ impl ScriptThread {
             incomplete.load_data.creation_sandboxing_flag_set,
             incomplete.parent_info,
             incomplete.target_snapshot_params,
+            incomplete.load_data.load_origin.clone(),
         );
         self.incomplete_parser_contexts
             .0
@@ -4040,6 +4032,7 @@ impl ScriptThread {
             incomplete.load_data.creation_sandboxing_flag_set,
             incomplete.parent_info,
             incomplete.target_snapshot_params,
+            incomplete.load_data.load_origin.clone(),
         );
 
         let mut meta = Metadata::default(incomplete.load_data.url.clone());
@@ -4092,6 +4085,7 @@ impl ScriptThread {
         let parent_info = incomplete.parent_info;
         let about_base_url = incomplete.load_data.about_base_url.clone();
         let target_snapshot_params = incomplete.target_snapshot_params;
+        let load_origin = incomplete.load_data.load_origin.clone();
         self.incomplete_loads.borrow_mut().push(incomplete);
 
         let mut context = ParserContext::new(
@@ -4101,6 +4095,7 @@ impl ScriptThread {
             creation_sandboxing_flag_set,
             parent_info,
             target_snapshot_params,
+            load_origin,
         );
         let dummy_request_id = RequestId::default();
 

--- a/components/shared/constellation/from_script_message.rs
+++ b/components/shared/constellation/from_script_message.rs
@@ -739,7 +739,7 @@ impl fmt::Debug for ScriptToConstellationMessage {
 pub struct TargetSnapshotParams {
     /// <https://html.spec.whatwg.org/multipage/#target-snapshot-params-sandbox>
     pub sandboxing_flags: SandboxingFlagSet,
-    /// https://html.spec.whatwg.org/multipage/#target-snapshot-params-iframe-referrer-policy
+    /// <https://html.spec.whatwg.org/multipage/#target-snapshot-params-iframe-referrer-policy>
     pub iframe_element_referrer_policy: ReferrerPolicy,
 }
 

--- a/components/shared/constellation/from_script_message.rs
+++ b/components/shared/constellation/from_script_message.rs
@@ -434,6 +434,8 @@ pub struct IFrameLoadInfo {
     /// Whether this load should replace the current entry (reload). If true, the current
     /// entry will be replaced instead of a new entry being added.
     pub history_handling: NavigationHistoryBehavior,
+    ///
+    pub target_snapshot_params: TargetSnapshotParams,
 }
 
 /// Specifies the information required to load a URL in an iframe.
@@ -635,7 +637,7 @@ pub enum ScriptToConstellationMessage {
     LoadComplete,
     /// A new load has been requested, with an option to replace the current entry once loaded
     /// instead of adding a new entry.
-    LoadUrl(LoadData, NavigationHistoryBehavior),
+    LoadUrl(LoadData, NavigationHistoryBehavior, TargetSnapshotParams),
     /// Abort loading after sending a LoadUrl message.
     AbortLoadUrl,
     /// Post a message to the currently active window of a given browsing context.
@@ -728,5 +730,23 @@ impl fmt::Debug for ScriptToConstellationMessage {
     fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
         let variant_string: &'static str = self.into();
         write!(formatter, "ScriptMsg::{variant_string}")
+    }
+}
+
+/// <https://html.spec.whatwg.org/multipage/#target-snapshot-params>
+#[derive(Clone, Copy, Debug, Deserialize, Serialize)]
+pub struct TargetSnapshotParams {
+    /// <https://html.spec.whatwg.org/multipage/#target-snapshot-params-sandbox>
+    pub sandboxing_flags: SandboxingFlagSet,
+    /// https://html.spec.whatwg.org/multipage/#target-snapshot-params-iframe-referrer-policy
+    pub iframe_element_referrer_policy: ReferrerPolicy,
+}
+
+impl Default for TargetSnapshotParams {
+    fn default() -> Self {
+        Self {
+            sandboxing_flags: SandboxingFlagSet::empty(),
+            iframe_element_referrer_policy: ReferrerPolicy::EmptyString,
+        }
     }
 }

--- a/components/shared/constellation/from_script_message.rs
+++ b/components/shared/constellation/from_script_message.rs
@@ -434,7 +434,8 @@ pub struct IFrameLoadInfo {
     /// Whether this load should replace the current entry (reload). If true, the current
     /// entry will be replaced instead of a new entry being added.
     pub history_handling: NavigationHistoryBehavior,
-    ///
+    /// A snapshot of the navigation-related parameters of the target
+    /// of this navigation.
     pub target_snapshot_params: TargetSnapshotParams,
 }
 

--- a/components/shared/script/lib.rs
+++ b/components/shared/script/lib.rs
@@ -77,7 +77,7 @@ pub struct NewPipelineInfo {
     pub user_content_manager_id: Option<UserContentManagerId>,
     /// The [`Theme`] of the new layout.
     pub theme: Theme,
-    ///
+    /// A snapshot of the navigation parameters of the target of this navigation.
     pub target_snapshot_params: TargetSnapshotParams,
 }
 

--- a/components/shared/script/lib.rs
+++ b/components/shared/script/lib.rs
@@ -42,7 +42,7 @@ use servo_canvas_traits::webgl::WebGLPipeline;
 use servo_config::prefs::PrefValue;
 use servo_constellation_traits::{
     KeyboardScroll, LoadData, NavigationHistoryBehavior, ScriptToConstellationSender,
-    ScrollStateUpdate, StructuredSerializedData, WindowSizeType,
+    ScrollStateUpdate, StructuredSerializedData, TargetSnapshotParams, WindowSizeType,
 };
 use servo_url::{ImmutableOrigin, ServoUrl};
 use storage_traits::StorageThreads;
@@ -77,6 +77,8 @@ pub struct NewPipelineInfo {
     pub user_content_manager_id: Option<UserContentManagerId>,
     /// The [`Theme`] of the new layout.
     pub theme: Theme,
+    ///
+    pub target_snapshot_params: TargetSnapshotParams,
 }
 
 /// When a pipeline is closed, should its browsing context be discarded too?
@@ -192,6 +194,7 @@ pub enum ScriptThreadMessage {
         BrowsingContextId,
         LoadData,
         NavigationHistoryBehavior,
+        TargetSnapshotParams,
     ),
     /// Post a message to a given window.
     PostMessage {

--- a/tests/wpt/meta/content-security-policy/frame-src/frame-src-sandboxed-allowed.html.ini
+++ b/tests/wpt/meta/content-security-policy/frame-src/frame-src-sandboxed-allowed.html.ini
@@ -1,0 +1,3 @@
+[frame-src-sandboxed-allowed.html]
+  [SubframeLoaded]
+    expected: FAIL

--- a/tests/wpt/meta/content-security-policy/sandbox/sandbox-empty-subframe.sub.html.ini
+++ b/tests/wpt/meta/content-security-policy/sandbox/sandbox-empty-subframe.sub.html.ini
@@ -1,3 +1,0 @@
-[sandbox-empty-subframe.sub.html]
-  [Expecting logs: ["PASS2"\]]
-    expected: FAIL

--- a/tests/wpt/meta/html/browsers/sandboxing/popup-from-initial-empty-sandboxed-document.window.js.ini
+++ b/tests/wpt/meta/html/browsers/sandboxing/popup-from-initial-empty-sandboxed-document.window.js.ini
@@ -1,3 +1,0 @@
-[popup-from-initial-empty-sandboxed-document.window.html]
-  [popup-from-initial-empty-sandboxed-document]
-    expected: FAIL

--- a/tests/wpt/meta/html/browsers/sandboxing/sandbox-parse-noscript.html.ini
+++ b/tests/wpt/meta/html/browsers/sandboxing/sandbox-parse-noscript.html.ini
@@ -1,2 +1,0 @@
-[sandbox-parse-noscript.html]
-  expected: FAIL

--- a/tests/wpt/meta/html/semantics/embedded-content/the-iframe-element/iframe_sandbox_popups_escaping-2.html.ini
+++ b/tests/wpt/meta/html/semantics/embedded-content/the-iframe-element/iframe_sandbox_popups_escaping-2.html.ini
@@ -1,3 +1,0 @@
-[iframe_sandbox_popups_escaping-2.html]
-  [Check that popups from a sandboxed iframe escape the sandbox if\n       allow-popups-to-escape-sandbox is used]
-    expected: FAIL

--- a/tests/wpt/meta/html/semantics/embedded-content/the-iframe-element/iframe_sandbox_popups_escaping-3.html.ini
+++ b/tests/wpt/meta/html/semantics/embedded-content/the-iframe-element/iframe_sandbox_popups_escaping-3.html.ini
@@ -1,3 +1,0 @@
-[iframe_sandbox_popups_escaping-3.html]
-  [Check that popups from a sandboxed iframe escape the sandbox if\n       allow-popups-to-escape-sandbox is used]
-    expected: FAIL

--- a/tests/wpt/meta/html/semantics/embedded-content/the-iframe-element/iframe_sandbox_popups_nonescaping-1.html.ini
+++ b/tests/wpt/meta/html/semantics/embedded-content/the-iframe-element/iframe_sandbox_popups_nonescaping-1.html.ini
@@ -1,3 +1,0 @@
-[iframe_sandbox_popups_nonescaping-1.html]
-  [Check that popups from a sandboxed iframe do not escape the sandbox]
-    expected: FAIL

--- a/tests/wpt/meta/html/semantics/embedded-content/the-iframe-element/iframe_sandbox_popups_nonescaping-2.html.ini
+++ b/tests/wpt/meta/html/semantics/embedded-content/the-iframe-element/iframe_sandbox_popups_nonescaping-2.html.ini
@@ -1,0 +1,3 @@
+[iframe_sandbox_popups_nonescaping-2.html]
+  [Check that popups from a sandboxed iframe do not escape the sandbox]
+    expected: FAIL

--- a/tests/wpt/meta/html/semantics/embedded-content/the-iframe-element/iframe_sandbox_popups_nonescaping-2.html.ini
+++ b/tests/wpt/meta/html/semantics/embedded-content/the-iframe-element/iframe_sandbox_popups_nonescaping-2.html.ini
@@ -1,3 +1,0 @@
-[iframe_sandbox_popups_nonescaping-2.html]
-  [Check that popups from a sandboxed iframe do not escape the sandbox]
-    expected: FAIL

--- a/tests/wpt/meta/html/semantics/embedded-content/the-iframe-element/iframe_sandbox_popups_nonescaping-3.html.ini
+++ b/tests/wpt/meta/html/semantics/embedded-content/the-iframe-element/iframe_sandbox_popups_nonescaping-3.html.ini
@@ -1,0 +1,3 @@
+[iframe_sandbox_popups_nonescaping-3.html]
+  [Check that popups from a sandboxed iframe do not escape the sandbox]
+    expected: FAIL

--- a/tests/wpt/meta/html/semantics/embedded-content/the-iframe-element/iframe_sandbox_popups_nonescaping-3.html.ini
+++ b/tests/wpt/meta/html/semantics/embedded-content/the-iframe-element/iframe_sandbox_popups_nonescaping-3.html.ini
@@ -1,3 +1,0 @@
-[iframe_sandbox_popups_nonescaping-3.html]
-  [Check that popups from a sandboxed iframe do not escape the sandbox]
-    expected: FAIL

--- a/tests/wpt/meta/html/semantics/embedded-content/the-iframe-element/sandbox-inherit-to-blank-document-unsandboxed.html.ini
+++ b/tests/wpt/meta/html/semantics/embedded-content/the-iframe-element/sandbox-inherit-to-blank-document-unsandboxed.html.ini
@@ -1,7 +1,4 @@
 [sandbox-inherit-to-blank-document-unsandboxed.html]
-  [Document is sandboxed via its CSP.]
-    expected: FAIL
-
   [The initial empty document inherit sandbox via CSP.]
     expected: FAIL
 

--- a/tests/wpt/meta/html/syntax/parsing/inhead-noscript-head.html.ini
+++ b/tests/wpt/meta/html/syntax/parsing/inhead-noscript-head.html.ini
@@ -1,3 +1,0 @@
-[inhead-noscript-head.html]
-  [When the scripting flag is disabled, a head start tag in "in head noscript" mode should be ignored]
-    expected: FAIL

--- a/tests/wpt/meta/mixed-content/csp.https.window.js.ini
+++ b/tests/wpt/meta/mixed-content/csp.https.window.js.ini
@@ -1,0 +1,3 @@
+[csp.https.window.html]
+  [Mixed content checks apply to fetches in sandboxed documents]
+    expected: FAIL

--- a/tests/wpt/meta/service-workers/service-worker/worker-in-sandboxed-iframe-by-csp-fetch-event.https.html.ini
+++ b/tests/wpt/meta/service-workers/service-worker/worker-in-sandboxed-iframe-by-csp-fetch-event.https.html.ini
@@ -1,4 +1,5 @@
 [worker-in-sandboxed-iframe-by-csp-fetch-event.https.html]
+  expected: TIMEOUT
   [Prepare a service worker.]
     expected: FAIL
 
@@ -9,7 +10,7 @@
     expected: FAIL
 
   [Fetch request from a worker in iframe sandboxed by CSP HTTP header allow-scripts flag]
-    expected: FAIL
+    expected: TIMEOUT
 
   [Fetch request from a worker in iframe sandboxed by CSP HTTP header with allow-scripts and allow-same-origin flag]
-    expected: FAIL
+    expected: NOTRUN


### PR DESCRIPTION
This set of changes introduces a type matching the spec's "target snapshot params" and uses it as part of determining the origin of new documents. This has a side benefit of making our sandbox flag determination more accurate, which leads to a bunch of sandboxing tests passing as well as some new failures due to spec confusion about origins.

Testing: Many new passing tests.
Part of the long road to #43149
