### PR TITLE
devtools: Rename new_registered to register and standardize variable names for SourceActor

### DIFF
--- a/components/devtools/actors/source.rs
+++ b/components/devtools/actors/source.rs
@@ -64,7 +64,7 @@ impl SourceManager {
         self.source_actor_names
             .borrow()
             .iter()
-            .map(|actor_name| registry.find::<SourceActor>(actor_name).source_form())
+            .map(|source_name| registry.find::<SourceActor>(source_name).source_form())
             .collect()
     }
 
@@ -73,10 +73,10 @@ impl SourceManager {
         registry: &ActorRegistry,
         source_url: &str,
     ) -> Option<DowncastableActorArc<SourceActor>> {
-        for name in self.source_actor_names.borrow().iter() {
-            let source = registry.find::<SourceActor>(name);
-            if source.url == ServoUrl::from_str(source_url).ok()? {
-                return Some(source);
+        for source_name in self.source_actor_names.borrow().iter() {
+            let source_actor = registry.find::<SourceActor>(source_name);
+            if source_actor.url == ServoUrl::from_str(source_url).ok()? {
+                return Some(source_actor);
             }
         }
         None
@@ -143,29 +143,8 @@ struct GetBreakpointPositionsRequest {
 }
 
 impl SourceActor {
-    pub fn new(
-        name: String,
-        url: ServoUrl,
-        content: Option<String>,
-        content_type: Option<String>,
-        spidermonkey_id: u32,
-        introduction_type: String,
-        script_sender: GenericSender<DevtoolScriptControlMsg>,
-    ) -> SourceActor {
-        SourceActor {
-            name,
-            url,
-            content: AtomicRefCell::new(content),
-            content_type,
-            is_black_boxed: false,
-            spidermonkey_id,
-            introduction_type,
-            script_sender,
-        }
-    }
-
     #[expect(clippy::too_many_arguments)]
-    pub fn new_registered(
+    pub fn register(
         registry: &ActorRegistry,
         pipeline_id: PipelineId,
         url: ServoUrl,
@@ -175,21 +154,20 @@ impl SourceActor {
         introduction_type: String,
         script_sender: GenericSender<DevtoolScriptControlMsg>,
     ) -> String {
-        let source_actor_name = registry.new_name::<Self>();
-
-        let source_actor = SourceActor::new(
-            source_actor_name.clone(),
+        let name = registry.new_name::<Self>();
+        let actor = Self {
+            name: name.clone(),
             url,
-            content,
+            content: AtomicRefCell::new(content),
             content_type,
+            is_black_boxed: false,
             spidermonkey_id,
             introduction_type,
             script_sender,
-        );
-        registry.register(source_actor);
-        registry.register_source_actor(pipeline_id, &source_actor_name);
-
-        source_actor_name
+        };
+        registry.register::<Self>(actor);
+        registry.register_source_actor(pipeline_id, &name);
+        name
     }
 
     pub fn source_form(&self) -> SourceForm {

--- a/components/devtools/lib.rs
+++ b/components/devtools/lib.rs
@@ -708,7 +708,7 @@ impl DevtoolsInstance {
         let source_content = source_info
             .content
             .or_else(|| self.registry.inline_source_content(pipeline_id));
-        let source_actor = SourceActor::new_registered(
+        let source_actor = SourceActor::register(
             &self.registry,
             pipeline_id,
             source_info.url,
@@ -783,8 +783,8 @@ impl DevtoolsInstance {
     }
 
     fn handle_update_source_content(&mut self, pipeline_id: PipelineId, source_content: String) {
-        for actor_name in self.registry.source_actor_names_for_pipeline(pipeline_id) {
-            let source_actor = self.registry.find::<SourceActor>(&actor_name);
+        for source_name in self.registry.source_actor_names_for_pipeline(pipeline_id) {
+            let source_actor = self.registry.find::<SourceActor>(&source_name);
             let mut content = source_actor.content.borrow_mut();
             if content.is_none() {
                 *content = Some(source_content.clone());


### PR DESCRIPTION
Part of #43800 and #43606.

I removed the `new` method from `SourceActor` entirely, as it was only used internally by `new_registered`. I renamed `new_registered` to `register`, inlined the struct construction directly using `Self { ... }`, and updated the registration call to use `registry.register::<Self>(actor)` to match the standard pattern established across other actors.

I also standardized variable names throughout `SourceActor` and its call sites to follow the conventions set in #43606:
- Renamed `name` and `source` to `source_name` and `source_actor` respectively in `SourceManager::find_source`
- Renamed `actor_name` to `source_name` in `SourceManager::source_forms`
- Renamed `actor_name` to `source_name` in `handle_update_source_content` in lib.rs

Testing: Built with cargo and ran ./mach test-devtools. 59/60 tests pass; the one failure (test_manual_pause) is a pre-existing intermittent timeout unrelated to these changes.


Fixes: part of  #43606 and #43800
