### PR TITLE
net: Implement on disk cache

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4925,7 +4925,6 @@ version = "0.36.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "95b4103cffefa72eb8428cb6b47d6627161e51c2739fc5e3b734584157bc642a"
 dependencies = [
- "cc",
  "pkg-config",
  "vcpkg",
 ]
@@ -8693,13 +8692,17 @@ dependencies = [
  "mime_guess",
  "nom 8.0.0",
  "parking_lot",
+ "postcard",
  "quick_cache",
  "regex",
  "resvg",
+ "rusqlite",
  "rustc-hash 2.1.3",
  "rustls",
  "rustls-pki-types",
  "rustls-platform-verifier",
+ "sea-query",
+ "sea-query-rusqlite",
  "serde",
  "servo-base",
  "servo-config",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4925,6 +4925,7 @@ version = "0.36.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "95b4103cffefa72eb8428cb6b47d6627161e51c2739fc5e3b734584157bc642a"
 dependencies = [
+ "cc",
  "pkg-config",
  "vcpkg",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -208,7 +208,7 @@ read-fonts = "0.41.0"
 regex = "1.12"
 resvg = "0.47.0"
 rsa = "=0.10.0-rc.18"
-rusqlite = "0.38"
+rusqlite = { version = "0.38", features = ["bundled"] }
 rustc-demangle = "0.1"
 rustc-hash = "2.1.2"
 rustls = { version = "0.23", default-features = false, features = ["logging", "std", "tls12"] }

--- a/components/config/prefs.rs
+++ b/components/config/prefs.rs
@@ -364,6 +364,10 @@ pub struct Preferences {
     pub network_enforce_tls_localhost: bool,
     pub network_enforce_tls_onion: bool,
     pub network_http_cache_disabled: bool,
+    /// The path to a disk cache file. Empty string disables the disk cache.
+    pub network_http_disk_cache: String,
+    /// Maximum size of the disk cache file in bytes.
+    pub network_http_disk_cache_size: u64,
     /// A url for a http proxy. We treat an empty string as no proxy.
     pub network_http_proxy_uri: String,
     /// A url for a https proxy. We treat an empty string as no proxy.
@@ -576,6 +580,8 @@ impl Preferences {
             network_enforce_tls_localhost: false,
             network_enforce_tls_onion: false,
             network_http_cache_disabled: false,
+            network_http_disk_cache: String::new(),
+            network_http_disk_cache_size: 1024 * 1024 * 100, // Roughtly 100MB
             network_http_proxy_uri: String::new(),
             network_https_proxy_uri: String::new(),
             network_http_no_proxy: String::new(),

--- a/components/malloc_size_of/lib.rs
+++ b/components/malloc_size_of/lib.rs
@@ -753,6 +753,18 @@ impl<T: MallocSizeOf> MallocSizeOf for parking_lot::Mutex<T> {
     }
 }
 
+impl<T: MallocSizeOf> MallocSizeOf for tokio::sync::Mutex<T> {
+    fn size_of(&self, ops: &mut MallocSizeOfOps) -> usize {
+        self.blocking_lock().size_of(ops)
+    }
+}
+
+impl<T: MallocSizeOf> MallocSizeOf for tokio::sync::RwLock<T> {
+    fn size_of(&self, ops: &mut MallocSizeOfOps) -> usize {
+        self.blocking_read().size_of(ops)
+    }
+}
+
 impl<T: MallocSizeOf> MallocSizeOf for parking_lot::RwLock<T> {
     fn size_of(&self, ops: &mut MallocSizeOfOps) -> usize {
         (*self.read()).size_of(ops)

--- a/components/net/Cargo.toml
+++ b/components/net/Cargo.toml
@@ -59,6 +59,7 @@ paint_api = { workspace = true }
 parking_lot = { workspace = true }
 pixels = { workspace = true }
 profile_traits = { workspace = true }
+postcard = { workspace = true }
 quick_cache = { workspace = true, features = ["ahash"] }
 regex = { workspace = true }
 resvg = { workspace = true }
@@ -66,6 +67,7 @@ rustc-hash = { workspace = true }
 rustls = { workspace = true, features = ["aws-lc-rs"] }
 rustls-pki-types = { workspace = true }
 rustls-platform-verifier = { workspace = true }
+rusqlite = { workspace = true }
 serde = { workspace = true }
 servo-base = { workspace = true }
 servo-config = { workspace = true }
@@ -73,6 +75,8 @@ servo-default-resources = { workspace = true, optional = true }
 servo-tracing = { workspace = true }
 servo-url = { workspace = true }
 servo_arc = { workspace = true }
+sea-query = { workspace = true }
+sea-query-rusqlite = { workspace = true }
 sha2 = { workspace = true }
 smallvec = { workspace = true }
 time = { workspace = true }

--- a/components/net/disk_cache.rs
+++ b/components/net/disk_cache.rs
@@ -1,0 +1,344 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+use std::collections::VecDeque;
+use std::sync::Arc;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use log::error;
+use malloc_size_of_derive::MallocSizeOf;
+use rusqlite::Row;
+use sea_query::{ColumnDef, Expr, ExprTrait, Iden, Query, SqliteQueryBuilder, Table};
+use sea_query_rusqlite::RusqliteBinder;
+use servo_config::pref;
+use servo_url::ServoUrl;
+use tokio::sync::{Mutex as TokioMutex, RwLock as TokioRwLock};
+
+use crate::http_cache::{
+    CacheEntry, CacheKey, CachedResource, HttpCacheAssignment, MemoryCacheLifecycle,
+};
+
+#[derive(MallocSizeOf)]
+pub(crate) struct DiskCacheMetadata {
+    key: CacheKey,
+    /// The size of the serialization or the exact size from the cache metadata.
+    size: usize,
+}
+
+impl From<&Row<'_>> for DiskCacheMetadata {
+    fn from(row: &Row) -> Self {
+        let s: String = row.get_unwrap("key");
+        Self {
+            key: CacheKey::from_url(ServoUrl::parse(&s).unwrap()),
+            size: row.get_unwrap("size"),
+        }
+    }
+}
+
+/// This data structure will be per [`HttpCacheAssignment`]. Currently, we only store HttpCacheAssignment::Public and otherwise return zero.
+/// As this data structure stores the state of the cache, if other instances share the same sqlite database, special care has to be taken
+/// to ensure conistency.
+#[derive(MallocSizeOf)]
+struct DiskCacheInner {
+    entries: VecDeque<DiskCacheMetadata>,
+    size: usize,
+    #[ignore_malloc_size_of = "Find a better way"]
+    db: rusqlite::Connection,
+    cache_assignment: HttpCacheAssignment,
+}
+
+#[derive(MallocSizeOf)]
+/// A struct representing the disk cache.
+pub(crate) struct DiskCache {
+    path: String,
+    max_size: usize,
+    // the non constant data.
+    inner: TokioMutex<DiskCacheInner>,
+}
+
+/// Identifications for sea_query of the cache table.
+enum DiskCacheTable {
+    Table,
+    Key,
+    Data,
+    Size,
+    InsertionTimestamp,
+}
+
+// Mapping between Enum variant and its corresponding string value
+impl Iden for DiskCacheTable {
+    fn unquoted(&self) -> &str {
+        match self {
+            DiskCacheTable::Table => "disk_cache",
+            DiskCacheTable::Key => "key",
+            DiskCacheTable::Data => "data",
+            DiskCacheTable::Size => "size",
+            DiskCacheTable::InsertionTimestamp => "insertion_timestamp",
+        }
+    }
+}
+
+impl DiskCache {
+    /// Creates a new [`DiskCache`] if the preference if set.
+    /// Creates the sqlite table if it does not exist and starts the db connection.
+    /// TODO: Implement WAL and other sqlite pragma.
+    pub(crate) fn new(
+        cache_assignment: HttpCacheAssignment,
+    ) -> (Option<Arc<DiskCache>>, MemoryCacheLifecycle) {
+        let disk_cache_path = pref!(network_http_disk_cache);
+        // For private browsing we currently do not want to store any disk cache.
+        if disk_cache_path.is_empty() || cache_assignment == HttpCacheAssignment::Private {
+            (None, MemoryCacheLifecycle::empty())
+        } else {
+            let Ok(max_disk_cache_size) = pref!(network_http_disk_cache_size).try_into() else {
+                return (None, MemoryCacheLifecycle::empty());
+            };
+
+            let Ok(db) = rusqlite::Connection::open(&disk_cache_path) else {
+                error!("Could not open disk cache database");
+                return (None, MemoryCacheLifecycle::empty());
+            };
+
+            let _ = db.execute("PRAGMA journal_mode = WAL;", ());
+            let query = Table::create()
+                .table(DiskCacheTable::Table)
+                .if_not_exists()
+                .col(
+                    ColumnDef::new(DiskCacheTable::Key)
+                        .text()
+                        .not_null()
+                        .primary_key(),
+                )
+                .col(ColumnDef::new(DiskCacheTable::Data).blob().not_null())
+                .col(ColumnDef::new(DiskCacheTable::Size).integer().not_null())
+                .col(
+                    ColumnDef::new(DiskCacheTable::InsertionTimestamp)
+                        .integer()
+                        .not_null(),
+                )
+                .build(SqliteQueryBuilder);
+            if let Err(e) = db.execute(query.as_str(), ()) {
+                error!("Could not create table. DB Error {:?}", e);
+                return (None, MemoryCacheLifecycle::empty());
+            }
+
+            let (query, values) = Query::select()
+                .columns([DiskCacheTable::Key, DiskCacheTable::Size])
+                .from(DiskCacheTable::Table)
+                .build_rusqlite(SqliteQueryBuilder);
+
+            let (entries, size) = {
+                let Ok(mut st) = db.prepare(query.as_str()) else {
+                    error!("Could not get disk data");
+                    return (None, MemoryCacheLifecycle::empty());
+                };
+                let entries = st
+                    .query_map(&*values.as_params(), |row| Ok(DiskCacheMetadata::from(row)))
+                    .unwrap()
+                    .map(|entry| entry.unwrap())
+                    .collect::<VecDeque<_>>();
+
+                let size = entries.iter().map(|entry| entry.size).sum();
+                (entries, size)
+            };
+            let inner = DiskCacheInner {
+                entries,
+                size,
+                db,
+                cache_assignment,
+            };
+            let disk_cache_data = std::sync::Arc::new(DiskCache {
+                inner: TokioMutex::new(inner),
+                path: disk_cache_path,
+                max_size: max_disk_cache_size,
+            });
+
+            (
+                Some(disk_cache_data.clone()),
+                MemoryCacheLifecycle {
+                    disk_cache: Some(disk_cache_data),
+                },
+            )
+        }
+    }
+
+    /// Restores a cache entry from the disk if it exists.
+    /// Deletes the entry from the disk cache
+    #[servo_tracing::instrument(skip(self))]
+    pub(crate) async fn get(&self, key: CacheKey) -> Option<Arc<TokioRwLock<Vec<CachedResource>>>> {
+        let bytes = {
+            // we lock the metadata before we update the sqlite database so that
+            // the database and metadata are consistent when this lock is released.
+            let mut inner = self.inner.lock().await;
+            let (bytes, new_size) = {
+                let _span = profile_traits::trace_span!("query disk cache").entered();
+                let (query, query_values) = Query::select()
+                    .columns([DiskCacheTable::Data])
+                    .from(DiskCacheTable::Table)
+                    .and_where(Expr::col(DiskCacheTable::Key).eq(key.as_ref()))
+                    .build_rusqlite(SqliteQueryBuilder);
+                let (delete, delete_values) = Query::delete()
+                    .from_table(DiskCacheTable::Table)
+                    .and_where(Expr::col(DiskCacheTable::Key).eq(key.as_ref()))
+                    .build_rusqlite(SqliteQueryBuilder);
+
+                let mut st = inner.db.prepare(query.as_str()).ok()?;
+                let data: Vec<u8> = st
+                    .query_one(&*query_values.as_params(), |row| Ok(row.get_unwrap("data")))
+                    .ok()?;
+
+                if inner
+                    .db
+                    .execute(delete.as_str(), &*delete_values.as_params())
+                    .is_err()
+                {
+                    error!("Could not delete cached data from disk");
+                    return None;
+                }
+
+                (data, self.get_disk_cache_total_size(&inner.db))
+            };
+
+            {
+                // update the metadata
+                let entry_index = inner
+                    .entries
+                    .iter()
+                    .position(|metadata| metadata.key == key);
+                if let Some(entry_index) = entry_index {
+                    inner.entries.remove(entry_index);
+                }
+                if let Some(new_size) = new_size {
+                    inner.size = new_size;
+                } else {
+                    error!("Could not get disk cache size");
+                }
+            }
+            bytes
+        };
+        let _span = profile_traits::trace_span!("deserialize cache request").entered();
+        let Ok(value) = postcard::from_bytes(&bytes) else {
+            error!("Could not deserialize cached resource");
+            return None;
+        };
+        let deserialized_vec_cached_response = std::sync::Arc::new(TokioRwLock::new(value));
+
+        Some(deserialized_vec_cached_response)
+    }
+
+    /// Stores a [`CacheEntry`]` to disk.
+    #[servo_tracing::instrument(skip(self))]
+    pub(crate) async fn store(&self, key: CacheKey, entry: CacheEntry) {
+        let data_to_serialize = entry.read().await;
+        let Ok(data) = postcard::to_stdvec(&*data_to_serialize) else {
+            error!("Could not deserialize value");
+            return;
+        };
+
+        {
+            let mut inner = self.inner.lock().await;
+            let data_size = data.len();
+
+            let timestamp = SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .map(|duration| duration.as_secs())
+                .unwrap_or(0);
+            let (query, params) = Query::insert()
+                .into_table(DiskCacheTable::Table)
+                .columns([
+                    DiskCacheTable::Key,
+                    DiskCacheTable::Data,
+                    DiskCacheTable::Size,
+                    DiskCacheTable::InsertionTimestamp,
+                ])
+                .values_panic([
+                    key.as_ref().into(),
+                    data.into(),
+                    (data_size as u32).into(),
+                    timestamp.into(),
+                ])
+                .build_rusqlite(SqliteQueryBuilder);
+
+            if let Err(e) = inner.db.execute(query.as_str(), &*params.as_params()) {
+                error!("Could not insert cache data. Error {}", e);
+            }
+            inner.entries.push_back(DiskCacheMetadata {
+                key,
+                size: data_size,
+            });
+            if let Some(new_cache_size) = self.get_disk_cache_total_size(&inner.db) {
+                inner.size = new_cache_size;
+            }
+        }
+        self.delete_until_cache_size().await;
+    }
+
+    /// Deletes data from the cache until the size is <= max_size
+    #[servo_tracing::instrument(skip(self))]
+    async fn delete_until_cache_size(&self) {
+        let mut inner = self.inner.lock().await;
+        let mut keys_to_delete = vec![];
+        while self.max_size < inner.size {
+            if let Some(metadata) = inner.entries.pop_back() {
+                keys_to_delete.push(metadata.key);
+                inner.size -= metadata.size;
+            }
+        }
+
+        let keys_ref = keys_to_delete.iter().map(|key| key.as_ref());
+        let (query, values) = Query::delete()
+            .from_table(DiskCacheTable::Table)
+            .and_where(Expr::col(DiskCacheTable::Key).is_in(keys_ref))
+            .build_rusqlite(SqliteQueryBuilder);
+
+        if inner
+            .db
+            .execute(query.as_str(), &*values.as_params())
+            .is_err()
+        {
+            error!("Could not delete old disk cache entries");
+        }
+    }
+
+    /// Queries the current disk cache size from the sql database.
+    #[servo_tracing::instrument(skip(self))]
+    fn get_disk_cache_total_size(&self, conn: &rusqlite::Connection) -> Option<usize> {
+        let (size, size_values) = Query::select()
+            .expr(Expr::col(DiskCacheTable::Size).sum())
+            .from(DiskCacheTable::Table)
+            .build_rusqlite(SqliteQueryBuilder);
+        let Ok(mut st) = conn.prepare(size.as_str()) else {
+            return None;
+        };
+
+        // According to the sqlite documentation we will return NULL on an empty table.
+        let query_result =
+            st.query_one(&*size_values.as_params(), |row| Ok(row.get(0).unwrap_or(0)));
+        if let Err(query_result) = query_result {
+            error!("Could nto get new sum size {}", query_result);
+            None
+        } else {
+            query_result.ok()
+        }
+    }
+
+    /// Clears the disk cache.
+    /// Should only be called in sync context and will panic.
+    #[servo_tracing::instrument(skip(self))]
+    pub(crate) fn clear(&self) {
+        let mut inner = self.inner.blocking_lock();
+        let (query, params) = Query::delete()
+            .from_table(DiskCacheTable::Table)
+            .build_rusqlite(SqliteQueryBuilder);
+        if inner
+            .db
+            .execute(query.as_str(), &*params.as_params())
+            .is_err()
+        {
+            error!("Could not clear disk cache");
+        }
+        inner.entries.clear();
+        inner.size = 0;
+    }
+}

--- a/components/net/disk_cache.rs
+++ b/components/net/disk_cache.rs
@@ -9,7 +9,7 @@ use std::time::{SystemTime, UNIX_EPOCH};
 use log::error;
 use malloc_size_of_derive::MallocSizeOf;
 use rusqlite::Row;
-use sea_query::{ColumnDef, Expr, ExprTrait, Iden, Query, SqliteQueryBuilder, Table};
+use sea_query::{ColumnDef, Expr, ExprTrait, Iden, OnConflict, Query, SqliteQueryBuilder, Table};
 use sea_query_rusqlite::RusqliteBinder;
 use servo_config::pref;
 use servo_url::ServoUrl;
@@ -230,7 +230,11 @@ impl DiskCache {
     /// Stores a [`CacheEntry`]` to disk.
     #[servo_tracing::instrument(skip(self))]
     pub(crate) async fn store(&self, key: CacheKey, entry: CacheEntry) {
-        let data_to_serialize = entry.read().await;
+        let entry = entry.read().await;
+        let data_to_serialize: Vec<&CachedResource> = entry
+            .iter()
+            .filter(|cached_resource| cached_resource.is_done())
+            .collect();
         let Ok(data) = postcard::to_stdvec(&*data_to_serialize) else {
             error!("Could not deserialize value");
             return;
@@ -252,6 +256,16 @@ impl DiskCache {
                     DiskCacheTable::Size,
                     DiskCacheTable::InsertionTimestamp,
                 ])
+                .on_conflict(
+                    OnConflict::column(DiskCacheTable::Key)
+                        .update_columns([
+                            DiskCacheTable::Data,
+                            DiskCacheTable::Data,
+                            DiskCacheTable::Size,
+                            DiskCacheTable::InsertionTimestamp,
+                        ])
+                        .to_owned(),
+                )
                 .values_panic([
                     key.as_ref().into(),
                     data.into(),

--- a/components/net/http_cache.rs
+++ b/components/net/http_cache.rs
@@ -10,7 +10,7 @@
 use std::ops::Bound;
 use std::sync::Arc as StdArc;
 use std::sync::atomic::{AtomicBool, Ordering};
-use std::time::{Duration, Instant, SystemTime};
+use std::time::{Duration, SystemTime};
 
 use headers::{
     CacheControl, ContentRange, Expires, HeaderMapExt, LastModified, Pragma, Range, Vary,
@@ -24,20 +24,28 @@ use net_traits::request::{CacheMode, Request};
 use net_traits::response::{Response, ResponseBody};
 use net_traits::{CacheEntryDescriptor, FetchMetadata, Metadata, ResourceFetchTiming};
 use parking_lot::Mutex as ParkingLotMutex;
-use quick_cache::sync::{Cache, DefaultLifecycle, PlaceholderGuard};
-use quick_cache::{DefaultHashBuilder, UnitWeighter};
+use quick_cache::sync::{Cache, PlaceholderGuard};
+use quick_cache::{DefaultHashBuilder, Lifecycle, UnitWeighter};
+use serde::{Deserialize, Serialize};
 use servo_arc::Arc;
 use servo_config::pref;
 use servo_url::ServoUrl;
 use tokio::sync::mpsc::{UnboundedSender as TokioSender, unbounded_channel as unbounded};
 use tokio::sync::{OwnedRwLockWriteGuard, RwLock as TokioRwLock};
 
+use crate::disk_cache::DiskCache;
 use crate::fetch::methods::{Data, DoneChannel};
 
 /// The key used to differentiate requests in the cache.
-#[derive(Clone, Eq, Hash, MallocSizeOf, PartialEq)]
+#[derive(Clone, Debug, Eq, Hash, MallocSizeOf, PartialEq)]
 pub struct CacheKey {
     url: ServoUrl,
+}
+
+impl AsRef<str> for CacheKey {
+    fn as_ref(&self) -> &str {
+        self.url.as_str()
+    }
 }
 
 impl CacheKey {
@@ -55,15 +63,16 @@ impl CacheKey {
 }
 
 /// A complete cached resource.
-#[derive(Clone, MallocSizeOf)]
+#[derive(Clone, Debug, Deserialize, MallocSizeOf, Serialize)]
 pub struct CachedResource {
     #[conditional_malloc_size_of]
-    request_headers: Arc<ParkingLotMutex<HeaderMap>>,
+    request_headers: Arc<ParkingLotMutex<SerializeableHeaderMap>>,
     #[conditional_malloc_size_of]
     body: Arc<ParkingLotMutex<ResponseBody>>,
     #[conditional_malloc_size_of]
     aborted: Arc<AtomicBool>,
     #[conditional_malloc_size_of]
+    #[serde(skip)]
     awaiting_body: Arc<ParkingLotMutex<Vec<TokioSender<Data>>>>,
     metadata: CachedMetadata,
     location_url: Option<Result<ServoUrl, String>>,
@@ -73,15 +82,45 @@ pub struct CachedResource {
     stale_while_revalidate: Duration,
     #[conditional_malloc_size_of]
     revalidating: StdArc<AtomicBool>,
-    last_validated: Instant,
+    last_validated: SystemTime,
+}
+
+#[derive(Debug, Deserialize, MallocSizeOf, Serialize)]
+/// Wrapper type for HeaderMap
+struct SerializeableHeaderMap(
+    #[serde(
+        deserialize_with = "hyper_serde::deserialize",
+        serialize_with = "hyper_serde::serialize"
+    )]
+    HeaderMap,
+);
+
+impl std::ops::Deref for SerializeableHeaderMap {
+    type Target = HeaderMap;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl std::ops::DerefMut for SerializeableHeaderMap {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.0
+    }
+}
+
+impl From<HeaderMap> for SerializeableHeaderMap {
+    fn from(value: HeaderMap) -> Self {
+        SerializeableHeaderMap(value)
+    }
 }
 
 /// Metadata about a loaded resource, such as is obtained from HTTP headers.
-#[derive(Clone, MallocSizeOf)]
+#[derive(Clone, Debug, Deserialize, Serialize, MallocSizeOf)]
 struct CachedMetadata {
     /// Headers
     #[conditional_malloc_size_of]
-    pub headers: Arc<ParkingLotMutex<HeaderMap>>,
+    pub headers: Arc<ParkingLotMutex<SerializeableHeaderMap>>,
     /// Final URL after redirects.
     pub final_url: ServoUrl,
     /// MIME type / subtype.
@@ -115,11 +154,26 @@ pub(crate) struct CachedResponse {
     pub revalidation_guard: StdArc<AtomicBool>,
 }
 
-type CacheEntry = std::sync::Arc<TokioRwLock<Vec<CachedResource>>>;
-type QuickCache = Cache<CacheKey, CacheEntry, UnitWeighter>;
-type OurLifecycle = DefaultLifecycle<CacheKey, CacheEntry>;
-type QuickCachePlaceeholderGuard<'a> =
-    PlaceholderGuard<'a, CacheKey, CacheEntry, UnitWeighter, DefaultHashBuilder, OurLifecycle>;
+pub(crate) type CacheEntry = std::sync::Arc<TokioRwLock<Vec<CachedResource>>>;
+type QuickCache =
+    Cache<CacheKey, CacheEntry, UnitWeighter, DefaultHashBuilder, MemoryCacheLifecycle>;
+type QuickCachePlaceholderGuard<'a> = PlaceholderGuard<
+    'a,
+    CacheKey,
+    CacheEntry,
+    UnitWeighter,
+    DefaultHashBuilder,
+    MemoryCacheLifecycle,
+>;
+
+/// Is this state assigned to the private or public side.
+#[derive(Debug, MallocSizeOf, PartialEq)]
+pub enum HttpCacheAssignment {
+    /// Public Cache State, possibly stored to disk.
+    Public,
+    /// Private Cache State, not stored to disk.
+    Private,
+}
 
 /// A simple memory cache.
 /// Elements will be evicted based on the cache heuristic. We weight elements
@@ -129,6 +183,7 @@ type QuickCachePlaceeholderGuard<'a> =
 pub struct HttpCache {
     /// cached responses.
     entries: QuickCache,
+    disk_cache: Option<std::sync::Arc<DiskCache>>,
 }
 
 impl MallocSizeOf for HttpCache {
@@ -136,17 +191,58 @@ impl MallocSizeOf for HttpCache {
         self.entries
             .iter()
             .map(|(_key, entry)| entry.blocking_read().size_of(ops))
-            .sum()
+            .sum::<usize>() +
+            self.disk_cache
+                .as_ref()
+                .map(|data| data.size_of(ops))
+                .unwrap_or(0)
     }
 }
 
-impl Default for HttpCache {
-    fn default() -> Self {
+impl HttpCache {
+    /// Create a new HttpCache with [`HttpCacheAssignment`]
+    pub fn new(assignment: HttpCacheAssignment) -> Self {
         let size = pref!(network_http_cache_size)
             .try_into()
             .expect("http_cache_size needs to fit into u64");
+        let (disk_cache, lifecycle) = DiskCache::new(assignment);
+        let memory_cache = Cache::with(
+            size,
+            size as u64,
+            UnitWeighter,
+            DefaultHashBuilder::new(),
+            lifecycle,
+        );
+
         Self {
-            entries: Cache::new(size),
+            entries: memory_cache,
+            disk_cache,
+        }
+    }
+}
+
+#[derive(Clone)]
+/// The lifecycle hooks of the HttpCache.
+/// Responsible for moving data to the disk.
+pub struct MemoryCacheLifecycle {
+    pub(crate) disk_cache: Option<std::sync::Arc<DiskCache>>,
+}
+
+impl MemoryCacheLifecycle {
+    pub(crate) fn empty() -> MemoryCacheLifecycle {
+        MemoryCacheLifecycle { disk_cache: None }
+    }
+}
+
+impl Lifecycle<CacheKey, CacheEntry> for MemoryCacheLifecycle {
+    type RequestState = ();
+
+    fn begin_request(&self) -> Self::RequestState {}
+
+    fn on_evict(&self, _state: &mut Self::RequestState, key: CacheKey, value: CacheEntry) {
+        if let Some(disk_cache_data) = &self.disk_cache {
+            let disk_cache_data = disk_cache_data.clone();
+            tokio::spawn(async move { disk_cache_data.store(key, value).await });
         }
     }
 }
@@ -390,7 +486,10 @@ fn create_cached_response(
 
     let expires = cached_resource.expires;
     let adjusted_expires = get_expiry_adjustment_from_request_headers(request, expires);
-    let time_since_validated = Instant::now() - cached_resource.last_validated;
+    let Ok(time_since_validated) = SystemTime::now().duration_since(cached_resource.last_validated)
+    else {
+        return None;
+    };
 
     // TODO: take must-revalidate into account <https://tools.ietf.org/html/rfc7234#section-5.2.2.1>
     // TODO: if this cache is to be considered shared, take proxy-revalidate into account
@@ -785,7 +884,7 @@ pub fn refresh(
         cached_resource.expires = get_response_expiry(constructed_response);
         cached_resource.stale_while_revalidate =
             get_stale_while_revalidate(&constructed_response.headers);
-        cached_resource.last_validated = Instant::now();
+        cached_resource.last_validated = SystemTime::now();
     }
 
     constructed_response
@@ -869,6 +968,9 @@ impl HttpCache {
     /// Clear the contents of this cache.
     pub(crate) fn clear(&self) {
         self.entries.clear();
+        if let Some(disk_cache) = &self.disk_cache {
+            disk_cache.clear();
+        }
     }
 
     /// Insert a response for `request` into the cache (used by tests that need direct access).
@@ -930,10 +1032,28 @@ impl HttpCache {
 
     /// If the value exist in the cache, return it. If the value does not exist, return a guard you can use to insert values in the cache.
     /// If the guard is alive, all other accesses to this function will block.
+    #[servo_tracing::instrument(skip(self))]
     pub async fn get_or_guard(&self, entry_key: CacheKey) -> CachedResourcesOrGuard<'_> {
-        match self.entries.get_value_or_guard_async(&entry_key).await {
-            Ok(val) => CachedResourcesOrGuard::Value(val.write_owned().await),
-            Err(guard) => CachedResourcesOrGuard::Guard(guard),
+        let guard_or_value = self.entries.get_value_or_guard_async(&entry_key).await;
+        if let Ok(value) = guard_or_value {
+            return CachedResourcesOrGuard::Value(value.write_owned().await);
+        }
+        let guard = guard_or_value.unwrap_err();
+
+        if let Some(disk_cache) = &self.disk_cache {
+            if let Some(response) = disk_cache.get(entry_key).await {
+                if guard.insert(response.clone()).is_err() {
+                    error!(
+                        "Cache guard is invalid. This should not happen. Cache will be in inconsistent state."
+                    );
+                }
+                let response = response.write_owned().await;
+                CachedResourcesOrGuard::Value(response)
+            } else {
+                CachedResourcesOrGuard::Guard(guard)
+            }
+        } else {
+            CachedResourcesOrGuard::Guard(guard)
         }
     }
 }
@@ -944,7 +1064,7 @@ pub enum CachedResourcesOrGuard<'a> {
     /// The value of the resource in the cache.
     Value(OwnedRwLockWriteGuard<Vec<CachedResource>>),
     /// A guard that blocks requests to the cache entry this guard is for.
-    Guard(QuickCachePlaceeholderGuard<'a>),
+    Guard(QuickCachePlaceholderGuard<'a>),
 }
 
 impl<'a> CachedResourcesOrGuard<'a> {
@@ -981,14 +1101,14 @@ impl<'a> CachedResourcesOrGuard<'a> {
         let expiry = get_response_expiry(response);
         let stale_while_revalidate = get_stale_while_revalidate(&response.headers);
         let cacheable_metadata = CachedMetadata {
-            headers: Arc::new(ParkingLotMutex::new(response.headers.clone())),
+            headers: Arc::new(ParkingLotMutex::new(response.headers.clone().into())),
             final_url: metadata.final_url,
             content_type: metadata.content_type.map(|v| v.0.to_string()),
             charset: metadata.charset,
             status: metadata.status,
         };
         let entry_resource = CachedResource {
-            request_headers: Arc::new(ParkingLotMutex::new(request.headers.clone())),
+            request_headers: Arc::new(ParkingLotMutex::new(request.headers.clone().into())),
             body: response.body.clone(),
             aborted: response.aborted.clone(),
             awaiting_body: Arc::new(ParkingLotMutex::new(vec![])),
@@ -999,7 +1119,7 @@ impl<'a> CachedResourcesOrGuard<'a> {
             expires: expiry,
             stale_while_revalidate,
             revalidating: StdArc::new(AtomicBool::new(false)),
-            last_validated: Instant::now(),
+            last_validated: SystemTime::now(),
         };
 
         match self {

--- a/components/net/http_cache.rs
+++ b/components/net/http_cache.rs
@@ -81,8 +81,15 @@ pub struct CachedResource {
     expires: Duration,
     stale_while_revalidate: Duration,
     #[conditional_malloc_size_of]
+    #[serde(skip)]
     revalidating: StdArc<AtomicBool>,
     last_validated: SystemTime,
+}
+
+impl CachedResource {
+    pub(crate) fn is_done(&self) -> bool {
+        self.body.lock().is_done()
+    }
 }
 
 #[derive(Debug, Deserialize, MallocSizeOf, Serialize)]

--- a/components/net/lib.rs
+++ b/components/net/lib.rs
@@ -10,6 +10,7 @@ pub mod cookie;
 pub mod cookie_storage;
 mod decoder;
 mod devtools;
+mod disk_cache;
 pub mod embedder;
 pub mod filemanager_thread;
 mod hosts;

--- a/components/net/resource_thread.rs
+++ b/components/net/resource_thread.rs
@@ -65,7 +65,7 @@ use crate::fetch::methods::{
 };
 use crate::filemanager_thread::FileManager;
 use crate::hsts::{self, HstsList};
-use crate::http_cache::HttpCache;
+use crate::http_cache::{HttpCache, HttpCacheAssignment};
 use crate::http_loader::{HttpState, http_redirect_fetch};
 use crate::protocols::ProtocolRegistry;
 use crate::request_interceptor::RequestInterceptor;
@@ -219,7 +219,7 @@ fn create_http_states(
         cookie_jar: RwLock::new(cookie_jar),
         auth_cache: RwLock::new(auth_cache),
         history_states: RwLock::new(FxHashMap::default()),
-        http_cache: HttpCache::default(),
+        http_cache: HttpCache::new(HttpCacheAssignment::Public),
         client: create_http_client(create_tls_config(
             ca_certificates.clone(),
             ignore_certificate_errors,
@@ -235,7 +235,7 @@ fn create_http_states(
         cookie_jar: RwLock::new(CookieStorage::new(150)),
         auth_cache: RwLock::new(AuthCache::default()),
         history_states: RwLock::new(FxHashMap::default()),
-        http_cache: HttpCache::default(),
+        http_cache: HttpCache::new(HttpCacheAssignment::Private),
         client: create_http_client(create_tls_config(
             ca_certificates,
             ignore_certificate_errors,
@@ -674,6 +674,7 @@ impl ResourceChannelManager {
                     servo_base::write_json_to_file(&*hsts, config_dir, "hsts_list.json");
                 }
                 self.resource_manager.exit();
+
                 let _ = sender.send(());
                 return false;
             },

--- a/components/net/tests/http_cache.rs
+++ b/components/net/tests/http_cache.rs
@@ -4,7 +4,7 @@
 
 use http::header::{CACHE_CONTROL, CONTENT_LENGTH, CONTENT_RANGE, EXPIRES, HeaderValue, RANGE};
 use http::{HeaderMap, StatusCode};
-use net::http_cache::{CacheKey, HttpCache, ValidationStatus, refresh};
+use net::http_cache::{CacheKey, HttpCache, HttpCacheAssignment, ValidationStatus, refresh};
 use net_traits::blob_url_store::UrlWithBlobClaim;
 use net_traits::request::{Referrer, RequestBuilder};
 use net_traits::response::{Response, ResponseBody};
@@ -35,7 +35,7 @@ async fn test_refreshing_resource_sets_done_chan_the_appropriate_value() {
     response
         .headers
         .insert(EXPIRES, HeaderValue::from_str("-10").unwrap());
-    let cache = HttpCache::default();
+    let cache = HttpCache::new(HttpCacheAssignment::Public);
     for body in response_bodies {
         *response.body.lock() = body.clone();
         // First, store the 'normal' response.
@@ -69,7 +69,7 @@ async fn test_skip_incomplete_cache_for_range_request_with_no_end_bound() {
     let incomplete_response_body = &[1, 2, 3, 4, 5];
     let url = ServoUrl::parse("https://servo.org").unwrap();
 
-    let cache = HttpCache::default();
+    let cache = HttpCache::new(HttpCacheAssignment::Public);
     let mut headers = HeaderMap::new();
 
     headers.insert(
@@ -146,7 +146,7 @@ async fn stale_while_revalidate_freshness_for_cache_control(
         .headers
         .insert(CACHE_CONTROL, HeaderValue::from_str(cache_control).unwrap());
 
-    let cache = HttpCache::default();
+    let cache = HttpCache::new(HttpCacheAssignment::Public);
     cache.store(&request, &response).await;
 
     let mut done_chan = None;
@@ -197,7 +197,7 @@ async fn test_stale_while_revalidate_not_used_when_request_demands_revalidation(
     );
 
     let store_request = build_stale_while_revalidate_test_request();
-    let cache = HttpCache::default();
+    let cache = HttpCache::new(HttpCacheAssignment::Public);
     cache.store(&store_request, &response).await;
 
     let mut req_headers = HeaderMap::new();

--- a/components/net/tests/main.rs
+++ b/components/net/tests/main.rs
@@ -115,7 +115,7 @@ fn create_http_state(fc: Option<GenericEmbedderProxy<NetToEmbedderMsg>>) -> Http
         cookie_jar: RwLock::new(net::cookie_storage::CookieStorage::new(150)),
         auth_cache: RwLock::new(net::resource_thread::AuthCache::default()),
         history_states: RwLock::new(FxHashMap::default()),
-        http_cache: net::http_cache::HttpCache::default(),
+        http_cache: net::http_cache::HttpCache::new(net::http_cache::HttpCacheAssignment::Public),
         client: create_http_client(create_tls_config(
             net::connector::CACertificates::Default,
             false, /* ignore_certificate_errors */

--- a/components/script/dom/stream/readablestream.rs
+++ b/components/script/dom/stream/readablestream.rs
@@ -29,7 +29,6 @@ use crate::dom::bindings::codegen::Bindings::ReadableStreamBinding::{
     ReadableWritablePair, StreamPipeOptions,
 };
 use script_bindings::str::DOMString;
-
 use crate::dom::domexception::{DOMErrorName, DOMException};
 use crate::dom::encoding::textdecoderstream::TextDecoderStream;
 use script_bindings::codegen::GenericBindings::TextDecoderStreamBinding::TextDecoderStreamMethods;

--- a/components/script/dom/webxr/xrsession.rs
+++ b/components/script/dom/webxr/xrsession.rs
@@ -9,7 +9,6 @@ use std::rc::Rc;
 use std::{mem, ptr};
 
 use script_bindings::reflector::reflect_weak_referenceable_dom_object;
-use servo_base::cross_process_instant::CrossProcessInstant;
 use dom_struct::dom_struct;
 use js::context::JSContext;
 use js::realm::CurrentRealm;
@@ -22,6 +21,7 @@ use js::typedarray::HeapFloat32Array;
 use profile_traits::generic_callback::GenericCallback as ProfileGenericCallback;
 use rustc_hash::FxBuildHasher;
 use script_bindings::trace::RootedTraceableBox;
+use servo_base::cross_process_instant::CrossProcessInstant;
 use stylo_atoms::Atom;
 use webxr_api::{
     self, ApiSpace, ContextId as WebXRContextId, Display, EntityTypes, EnvironmentBlendMode,

--- a/components/storage/Cargo.toml
+++ b/components/storage/Cargo.toml
@@ -22,7 +22,7 @@ malloc_size_of_derive = { workspace = true }
 net_traits = { workspace = true }
 postcard = { workspace = true }
 profile_traits = { workspace = true }
-rusqlite = { workspace = true, features = ["bundled"] }
+rusqlite = { workspace = true }
 rustc-hash = { workspace = true }
 sea-query = { workspace = true }
 sea-query-rusqlite = { workspace = true }


### PR DESCRIPTION
This implements an on disk cache using the cacache library.

This is currently not ready for merging as I did not do any performance testing.

Design:
- On cache miss in the quick_cache we check the on disk cache for an element and restore it by putting it in the memory cache and reloading.
- We hook into the lifecycle components of quick_cache to save to disk the elements evicted from the
memory cache.
- Spawn a long running tokio task to delete the oldest cache entry from the list if we are over a specific size.

Current limitations:
- The cache is currently disabled in the preferences.
- While the cache is persistent, we do not store any elements that are in the memory cache to the disk.
- Currently there is no way to clear the on disk cache.
- ./mach test-tidy complains because of multiple versions of some libraries.
- We do not update the timestamps of the on disk cache.

Fixes: https://github.com/servo/servo/issues/47012
