### PR TITLE
devtools: Rename `PauseActor` Variable Names

### DIFF
--- a/components/devtools/actors/thread.rs
+++ b/components/devtools/actors/thread.rs
@@ -146,14 +146,14 @@ impl Actor for ThreadActor {
     ) -> Result<(), ActorError> {
         match msg_type {
             "attach" => {
-                let pause = registry.new_name::<PauseActor>();
+                let pause_name = registry.new_name::<PauseActor>();
                 registry.register(PauseActor {
-                    name: pause.clone(),
+                    name: pause_name.clone(),
                 });
                 let msg = ThreadAttached {
                     from: self.name(),
                     type_: "paused".to_owned(),
-                    actor: pause,
+                    actor: pause_name,
                     frame: 0,
                     error: 0,
                     recording_endpoint: 0,

--- a/components/devtools/lib.rs
+++ b/components/devtools/lib.rs
@@ -818,9 +818,9 @@ impl DevtoolsInstance {
             .registry
             .find::<ThreadActor>(&browsing_context_actor.thread_name);
 
-        let pause = self.registry.new_name::<PauseActor>();
+        let pause_name = self.registry.new_name::<PauseActor>();
         self.registry.register(PauseActor {
-            name: pause.clone(),
+            name: pause_name.clone(),
         });
 
         let frame_actor = self.registry.find::<FrameActor>(&frame_offset.actor);
@@ -829,7 +829,7 @@ impl DevtoolsInstance {
         let msg = ThreadInterruptedReply {
             from: thread.name(),
             type_: "paused".to_owned(),
-            actor: pause,
+            actor: pause_name,
             frame: frame_actor.encode(&self.registry),
             why: pause_reason,
         };


### PR DESCRIPTION
- `PauseActor` is passed as a generic for only `new_name`
- Update the variable `pause` to `pause_name`

**Testing**: Tested locally with `mach test-devtools`

```
Ran 60 tests in 74.781s

OK (expected failures=6)
```

**Fixes**: A part of #43606
