### PR TITLE
Used encoding-parsing algorithm in follow_hyperlink

### DIFF
--- a/components/script/links.rs
+++ b/components/script/links.rs
@@ -463,7 +463,7 @@ pub(crate) fn follow_hyperlink(
         if let Some(suffix) = hyperlink_suffix {
             href.push_str(&suffix);
         }
-        let Ok(url) = document.base_url().join(&href.str()) else {
+        let Ok(url) = document.encoding_parse_a_url(&href.str()) else {
             return;
         };
 

--- a/tests/wpt/tests/html/semantics/links/links-created-by-a-and-area-elements/anchor-src-encoding.html
+++ b/tests/wpt/tests/html/semantics/links/links-created-by-a-and-area-elements/anchor-src-encoding.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<title>anchor href URL is parsed using document encoding</title>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<body>
+<script>
+async_test(t => {
+  let frame = document.createElement('iframe');
+  frame.src = "support/anchor-src-encoding-iframe.html";
+  document.body.appendChild(frame);
+
+  let loaded = false;
+  frame.onload = t.step_func(() => {
+    if (!loaded) {
+      loaded = true;
+      let a = frame.contentDocument.createElement('a');
+      a.href = '?\u00DF'; // U+00DF
+      frame.contentDocument.body.appendChild(a);
+      a.click();
+    } else {
+      assert_equals(frame.contentWindow.location.search, "?%DF", "anchor href URL is parsed using document encoding");
+      t.done();
+    }
+  });
+});
+</script>

--- a/tests/wpt/tests/html/semantics/links/links-created-by-a-and-area-elements/support/anchor-src-encoding-iframe.html
+++ b/tests/wpt/tests/html/semantics/links/links-created-by-a-and-area-elements/support/anchor-src-encoding-iframe.html
@@ -1,0 +1,3 @@
+<!doctype html>
+<meta charset="windows-1252">
+<body></body>


### PR DESCRIPTION
Used encoding-parsing algorithm in follow_hyperlink

Testing: Ran ```./mach test-wpt tests/wpt/tests/html/semantics/links/links-created-by-a-and-area-elements```
Result;
```
Running 11 tests in web-platform-tests

Ran 11 tests finished in 74.9 seconds.
  • 11 ran as expected.
```

Second test;
```./mach test-wpt tests/wpt/tests/html/semantics/links/links-created-by-a-and-area-elements/anchor-src-encoding.html```
Result;
```
web-platform-test
~~~~~~~~~~~~~~~~~
Ran 2 checks (1 subtests, 1 tests)
Expected results: 2
Unexpected results: 0
OK
```

Fixes: #43508
