### PR TITLE
devtools: Rename `BreakpointListActor` Variable Names

### DIFF
--- a/components/devtools/actors/watcher.rs
+++ b/components/devtools/actors/watcher.rs
@@ -450,7 +450,7 @@ impl WatcherActor {
             TargetConfigurationActor::new(registry.new_name::<TargetConfigurationActor>());
         let thread_configuration_actor =
             ThreadConfigurationActor::new(registry.new_name::<ThreadConfigurationActor>());
-        let breakpoint_list = BreakpointListActor::new(
+        let breakpoint_list_actor = BreakpointListActor::new(
             registry.new_name::<BreakpointListActor>(),
             browsing_context_name.clone(),
         );
@@ -461,14 +461,14 @@ impl WatcherActor {
             network_parent_name: network_parent_actor.name(),
             target_configuration: target_configuration.name(),
             thread_configuration_name: thread_configuration_actor.name(),
-            breakpoint_list: breakpoint_list.name(),
+            breakpoint_list: breakpoint_list_actor.name(),
             session_context,
         };
 
         registry.register(network_parent_actor);
         registry.register(target_configuration);
         registry.register(thread_configuration_actor);
-        registry.register(breakpoint_list);
+        registry.register(breakpoint_list_actor);
 
         watcher_actor
     }

--- a/components/devtools/actors/watcher.rs
+++ b/components/devtools/actors/watcher.rs
@@ -186,7 +186,7 @@ pub(crate) struct WatcherActor {
     network_parent_name: String,
     target_configuration: String,
     thread_configuration_name: String,
-    breakpoint_list: String,
+    breakpoint_list_name: String,
     session_context: SessionContext,
 }
 
@@ -422,7 +422,7 @@ impl Actor for WatcherActor {
                 let msg = GetBreakpointListActorReply {
                     from: self.name(),
                     breakpoint_list: registry
-                        .encode::<BreakpointListActor, _>(&self.breakpoint_list),
+                        .encode::<BreakpointListActor, _>(&self.breakpoint_list_name),
                 };
                 request.reply_final(&msg)?
             },
@@ -461,7 +461,7 @@ impl WatcherActor {
             network_parent_name: network_parent_actor.name(),
             target_configuration: target_configuration.name(),
             thread_configuration_name: thread_configuration_actor.name(),
-            breakpoint_list: breakpoint_list_actor.name(),
+            breakpoint_list_name: breakpoint_list_actor.name(),
             session_context,
         };
 


### PR DESCRIPTION
- Changes `breakpoint_list` to `breakpoint_list_actor`

Testing: Tested locally with `mach test-devtools`

Fixes: A part of #43606