### PR TITLE
layout/script: Free memory earlier by consuming instead of draining the temporary container if it is unused

### DIFF
--- a/components/layout/flexbox/layout.rs
+++ b/components/layout/flexbox/layout.rs
@@ -1125,7 +1125,7 @@ fn item_with_auto_cross_size_stretches_to_line_size(
         !margin.cross_end.is_auto()
 }
 
-/// “Collect flex items into flex lines”
+/// "Collect flex items into flex lines"
 /// <https://drafts.csswg.org/css-flexbox/#algo-line-break>
 fn do_initial_flex_line_layout<'items>(
     flex_context: &mut FlexContext,
@@ -1186,7 +1186,7 @@ fn do_initial_flex_line_layout<'items>(
     if flex_context.layout_context.use_rayon {
         lines.par_drain(..).map(construct_line).collect()
     } else {
-        lines.drain(..).map(construct_line).collect()
+        lines.into_iter().map(construct_line).collect()
     }
 }
 

--- a/components/script/dom/bluetooth/bluetooth.rs
+++ b/components/script/dom/bluetooth/bluetooth.rs
@@ -724,7 +724,7 @@ impl PermissionAlgorithm for Bluetooth {
         }
 
         // Step 7.
-        status.set_devices(matching_devices.drain(..).collect());
+        status.set_devices(std::mem::take(&mut matching_devices));
 
         // https://w3c.github.io/permissions/#dom-permissions-query
         // Step 7.

--- a/components/script/dom/css/stylepropertymapreadonly.rs
+++ b/components/script/dom/css/stylepropertymapreadonly.rs
@@ -55,7 +55,7 @@ impl StylePropertyMapReadOnly {
             keys.push(key);
             values.push(Dom::from_ref(&*value));
         }
-        let iter = keys.drain(..).zip(values.iter().cloned());
+        let iter = keys.into_iter().zip(values.iter().cloned());
         reflect_dom_object(
             Box::new(StylePropertyMapReadOnly::new_inherited(iter)),
             global,

--- a/components/script/dom/paintworkletglobalscope.rs
+++ b/components/script/dom/paintworkletglobalscope.rs
@@ -516,9 +516,9 @@ impl PaintWorkletGlobalScopeMethods<crate::DomTypeHolder> for PaintWorkletGlobal
         }
 
         // Step 4-6.
-        let mut property_names: Vec<String> =
+        let property_names: Vec<String> =
             get_property(cx, paint_obj.handle(), c"inputProperties", ())?.unwrap_or_default();
-        let properties = property_names.drain(..).map(Atom::from).collect();
+        let properties = property_names.into_iter().map(Atom::from).collect();
 
         // Step 7-9.
         let input_arguments: Vec<String> =

--- a/components/script/dom/webxr/xrtest.rs
+++ b/components/script/dom/webxr/xrtest.rs
@@ -198,8 +198,7 @@ impl XRTestMethods<crate::DomTypeHolder> for XRTest {
         } else {
             let mut len = devices.len();
 
-            let mut rooted_devices: Vec<_> =
-                devices.iter().map(|x| DomRoot::from_ref(&**x)).collect();
+            let rooted_devices: Vec<_> = devices.iter().map(|x| DomRoot::from_ref(&**x)).collect();
             devices.clear();
 
             let mut trusted = Some(TrustedPromise::new(p.clone()));
@@ -220,7 +219,7 @@ impl XRTestMethods<crate::DomTypeHolder> for XRTest {
                 })
                 .expect("Could not create callback");
 
-            for device in rooted_devices.drain(..) {
+            for device in rooted_devices {
                 device.disconnect(callback.clone());
             }
         };


### PR DESCRIPTION
Follow up of https://github.com/servo/servo/pull/43226
This also allows us to remove some `mut` declaration.
Fix some unintended Chinese quotation mark.

Testing: This is a micro-optimization which does not change visible behaviour.