### PR TITLE
servo: Fix gstreamer_plugins feature guard

### DIFF
--- a/components/servo/lib.rs
+++ b/components/servo/lib.rs
@@ -15,6 +15,7 @@
 mod clipboard_delegate;
 #[cfg(feature = "gamepad")]
 mod gamepad_delegate;
+#[cfg(feature = "media-gstreamer")]
 mod gstreamer_plugins;
 mod javascript_evaluator;
 mod network_manager;


### PR DESCRIPTION
Testing: gstreamer feature is enable in CI, and we test both mac and windows, which guard the elements in the module.

