### PR TITLE
webgpu: Fix feature guard

### DIFF
--- a/components/constellation/Cargo.toml
+++ b/components/constellation/Cargo.toml
@@ -19,7 +19,7 @@ bluetooth = ["servo-bluetooth-traits"]
 gamepad = ["embedder_traits/gamepad"]
 tracing = ["dep:tracing", "servo-canvas/tracing"]
 vello = ["servo-canvas/vello"]
-webgpu = ["script_traits/webgpu"]
+webgpu = ["dep:webgpu", "dep:webgpu_traits", "script_traits/webgpu"]
 
 [lints.clippy]
 unwrap_used = "deny"
@@ -62,8 +62,8 @@ storage_traits = { workspace = true }
 stylo = { workspace = true }
 stylo_traits = { workspace = true }
 tracing = { workspace = true, optional = true }
-webgpu = { workspace = true }
-webgpu_traits = { workspace = true }
+webgpu = { workspace = true, optional = true }
+webgpu_traits = { workspace = true, optional = true }
 webxr-api = { workspace = true }
 
 [target.'cfg(any(target_os="macos", all(not(target_os = "windows"), not(target_os = "ios"), not(target_os="android"), not(target_env="ohos"), not(target_arch="arm"), not(target_arch="aarch64"))))'.dependencies]

--- a/components/script/Cargo.toml
+++ b/components/script/Cargo.toml
@@ -27,7 +27,13 @@ refcell_backtrace = ["accountable-refcell"]
 testbinding = ["script_bindings/testbinding"]
 tracing = ["dep:tracing", "script_bindings/tracing"]
 webgl_backtrace = ["servo-canvas-traits/webgl_backtrace"]
-webgpu = ["script_bindings/webgpu", "script_traits/webgpu"]
+webgpu = [
+    "dep:webgpu_traits",
+    "dep:wgpu-core",
+    "dep:wgpu-types",
+    "script_bindings/webgpu",
+    "script_traits/webgpu",
+]
 webxr = ["gamepad", "webxr-api", "script_bindings/webxr"]
 
 [lints.rust]
@@ -158,11 +164,11 @@ url = { workspace = true }
 urlpattern = { workspace = true }
 uuid = { workspace = true, features = ["serde"] }
 webdriver = { workspace = true }
-webgpu_traits = { workspace = true }
+webgpu_traits = { workspace = true, optional = true }
 webrender_api = { workspace = true }
 webxr-api = { workspace = true, optional = true }
-wgpu-core = { workspace = true }
-wgpu-types = { workspace = true }
+wgpu-core = { workspace = true, optional = true }
+wgpu-types = { workspace = true, optional = true }
 x25519-dalek = { workspace = true }
 xml5ever = { workspace = true }
 xpath = { workspace = true }

--- a/components/script/dom/globalscope.rs
+++ b/components/script/dom/globalscope.rs
@@ -142,7 +142,7 @@ use crate::fetch::{DeferredFetchRecordId, FetchGroup, QueuedDeferredFetchRecord}
 use crate::messaging::{CommonScriptMsg, ScriptEventLoopReceiver, ScriptEventLoopSender};
 use crate::microtask::Microtask;
 use crate::network_listener::{FetchResponseListener, NetworkListener};
-use crate::realms::{InRealm, enter_auto_realm, enter_realm};
+use crate::realms::{InRealm, enter_auto_realm};
 use crate::script_module::{
     ImportMap, ModuleRequest, ModuleStatus, ResolvedModule, ScriptFetchOptions,
 };
@@ -3224,7 +3224,7 @@ impl GlobalScope {
             DeviceLostReason::Unknown => GPUDeviceLostReason::Unknown,
             DeviceLostReason::Destroyed => GPUDeviceLostReason::Destroyed,
         };
-        let _ac = enter_realm(self);
+        let _ac = crate::realms::enter_realm(self);
         if let Some(device) = self
             .gpu_devices
             .borrow_mut()

--- a/components/script/task_manager.rs
+++ b/components/script/task_manager.rs
@@ -162,5 +162,6 @@ impl TaskManager {
         intersection_observer_task_source,
         IntersectionObserver
     );
+    #[cfg(feature = "webgpu")]
     task_source_functions!(self, webgpu_task_source, WebGPU);
 }

--- a/components/servo/Cargo.toml
+++ b/components/servo/Cargo.toml
@@ -62,6 +62,7 @@ webgl_backtrace = [
     "servo-canvas-traits/webgl_backtrace",
 ]
 webgpu = [
+    "dep:webgpu",
     "script/webgpu",
     "paint/webgpu",
     "servo-constellation/webgpu",
@@ -130,7 +131,7 @@ tokio = { workspace = true, features = ["sync"] }
 tracing = { workspace = true, optional = true }
 url = { workspace = true }
 webgl = { workspace = true, default-features = false }
-webgpu = { workspace = true }
+webgpu = { workspace = true, optional = true }
 webrender = { workspace = true }
 webrender_api = { workspace = true }
 webxr-api = { workspace = true, optional = true }

--- a/components/shared/constellation/Cargo.toml
+++ b/components/shared/constellation/Cargo.toml
@@ -15,7 +15,7 @@ path = "lib.rs"
 
 [features]
 bluetooth = []
-webgpu = ["wgpu-core"]
+webgpu = ["dep:webgpu_traits", "dep:wgpu-core"]
 
 [dependencies]
 content-security-policy = { workspace = true }
@@ -43,6 +43,6 @@ servo-url = { workspace = true }
 storage_traits = { workspace = true }
 strum = { workspace = true }
 uuid = { workspace = true }
-webgpu_traits = { workspace = true }
+webgpu_traits = { workspace = true, optional = true }
 webrender_api = { workspace = true }
 wgpu-core = { workspace = true, optional = true }

--- a/components/shared/script/Cargo.toml
+++ b/components/shared/script/Cargo.toml
@@ -15,7 +15,7 @@ path = "lib.rs"
 
 [features]
 bluetooth = ["servo-bluetooth-traits"]
-webgpu = ["webgpu_traits"]
+webgpu = ["dep:webgpu_traits"]
 
 [dependencies]
 accesskit = { workspace = true }


### PR DESCRIPTION
Remove the dependency on the `webgpu` crate if the feature is disabled.

Note: This doesn't seem to improve the binary size in production mode, so presumably dead code elimination is already working well. Nevertheless, it's preferable to correctly feature guard and it should save a bit of compile-time (when not building with the webgpu feature).


Testing: `webgpu` feature is enabled by default in CI, and we test `--no-default-features` too in the HOS build in CI. `cargo tree -p servo --no-default-features` does not show webgpu anymore after this change.

