### PR TITLE
script: Remove focus transaction concept

### DIFF
--- a/components/script/dom/document/document.rs
+++ b/components/script/dom/document/document.rs
@@ -126,6 +126,7 @@ use crate::dom::customelementregistry::{
     CustomElementDefinition, CustomElementReactionStack, CustomElementRegistry,
 };
 use crate::dom::customevent::CustomEvent;
+use crate::dom::document::focus::{FocusOperation, FocusableArea};
 use crate::dom::document_embedder_controls::DocumentEmbedderControls;
 use crate::dom::document_event_handler::DocumentEventHandler;
 use crate::dom::documentfragment::DocumentFragment;
@@ -266,17 +267,6 @@ pub(crate) enum IsHTMLDocument {
     NonHTMLDocument,
 }
 
-#[derive(JSTraceable, MallocSizeOf)]
-#[cfg_attr(crown, crown::unrooted_must_root_lint::must_root)]
-struct FocusTransaction {
-    /// The focused element of this document.
-    element: Option<Dom<Element>>,
-    /// See [`Document::has_focus`].
-    has_focus: bool,
-    /// Focus options for the transaction
-    focus_options: FocusOptions,
-}
-
 /// Information about a declarative refresh
 #[derive(JSTraceable, MallocSizeOf)]
 pub(crate) enum DeclarativeRefresh {
@@ -381,8 +371,6 @@ pub(crate) struct Document {
     ready_state: Cell<DocumentReadyState>,
     /// Whether the DOMContentLoaded event has already been dispatched.
     domcontentloaded_dispatched: Cell<bool>,
-    /// The state of this document's focus transaction.
-    focus_transaction: DomRefCell<Option<FocusTransaction>>,
     /// The element that currently has the document focus context.
     focused: MutNullableDom<Element>,
     /// The last sequence number sent to the constellation.
@@ -1371,23 +1359,6 @@ impl Document {
         self.focus_sequence.get()
     }
 
-    pub(crate) fn has_focus_transaction(&self) -> bool {
-        self.focus_transaction.borrow().is_some()
-    }
-
-    /// Initiate a new round of checking for elements requesting focus. The last element to call
-    /// `request_focus` before `commit_focus_transaction` is called will receive focus.
-    pub(crate) fn begin_focus_transaction(&self) {
-        // Initialize it with the current state
-        *self.focus_transaction.borrow_mut() = Some(FocusTransaction {
-            element: self.focused.get().as_deref().map(Dom::from_ref),
-            has_focus: self.has_focus.get(),
-            focus_options: FocusOptions {
-                preventScroll: true,
-            },
-        });
-    }
-
     /// <https://html.spec.whatwg.org/multipage/#focus-fixup-rule>
     /// > For each doc of docs, if the focused area of doc is not a focusable area, then run the
     /// > focusing steps for doc's viewport, and set doc's relevant global object's navigation API's
@@ -1403,19 +1374,19 @@ impl Document {
         {
             return;
         }
-        self.request_focus(None, FocusInitiator::Script, can_gc);
+        self.request_focus(FocusableArea::Viewport, FocusInitiator::Local, can_gc);
     }
 
     /// Request that the given element receive focus with default options.
     /// See [`Self::request_focus_with_options`] for the details.
     pub(crate) fn request_focus(
         &self,
-        elem: Option<&Element>,
+        target: FocusableArea,
         focus_initiator: FocusInitiator,
         can_gc: CanGc,
     ) {
         self.request_focus_with_options(
-            elem,
+            target,
             focus_initiator,
             FocusOptions {
                 preventScroll: true,
@@ -1431,37 +1402,16 @@ impl Document {
     /// commits an implicit transaction.
     pub(crate) fn request_focus_with_options(
         &self,
-        target: Option<&Element>,
+        target: FocusableArea,
         focus_initiator: FocusInitiator,
         focus_options: FocusOptions,
         can_gc: CanGc,
     ) {
-        // If a target element is specified, and it's non-focusable, ignore the request.
-        if target.is_some_and(|target| match focus_initiator {
-            FocusInitiator::Keyboard => !target.is_sequentially_focusable(),
-            FocusInitiator::Click => !target.is_click_focusable(),
-            FocusInitiator::Script | FocusInitiator::Remote => !target.is_focusable_area(),
-        }) {
-            return;
-        }
-
-        let implicit_transaction = self.focus_transaction.borrow().is_none();
-
-        if implicit_transaction {
-            self.begin_focus_transaction();
-        }
-
-        {
-            let mut focus_transaction = self.focus_transaction.borrow_mut();
-            let focus_transaction = focus_transaction.as_mut().unwrap();
-            focus_transaction.element = target.map(Dom::from_ref);
-            focus_transaction.has_focus = true;
-            focus_transaction.focus_options = focus_options;
-        }
-
-        if implicit_transaction {
-            self.commit_focus_transaction(focus_initiator, can_gc);
-        }
+        self.focus(
+            FocusOperation::Focus(target, focus_options),
+            focus_initiator,
+            can_gc,
+        );
     }
 
     /// Update the local focus state accordingly after being notified that the
@@ -1472,45 +1422,32 @@ impl Document {
             warn!("Top-level document cannot be unfocused");
             return;
         }
-
-        // Since this method is called from an event loop, there mustn't be
-        // an in-progress focus transaction
-        assert!(
-            self.focus_transaction.borrow().is_none(),
-            "there mustn't be an in-progress focus transaction at this point"
-        );
-
-        // Start an implicit focus transaction
-        self.begin_focus_transaction();
-
-        // Update the transaction
-        {
-            let mut focus_transaction = self.focus_transaction.borrow_mut();
-            focus_transaction.as_mut().unwrap().has_focus = false;
-        }
-
-        // Commit the implicit focus transaction
-        self.commit_focus_transaction(FocusInitiator::Remote, can_gc);
+        self.focus(FocusOperation::Unfocus, FocusInitiator::Remote, can_gc);
     }
 
     /// Reassign the focus context to the element that last requested focus during this
     /// transaction, or the document if no elements requested it.
-    pub(crate) fn commit_focus_transaction(&self, focus_initiator: FocusInitiator, can_gc: CanGc) {
-        let (mut new_focused, new_focus_state, prevent_scroll) = {
-            let focus_transaction = self.focus_transaction.borrow();
-            let focus_transaction = focus_transaction
-                .as_ref()
-                .expect("no focus transaction in progress");
-            (
-                focus_transaction
-                    .element
-                    .as_ref()
-                    .map(|e| DomRoot::from_ref(&**e)),
-                focus_transaction.has_focus,
-                focus_transaction.focus_options.preventScroll,
-            )
+    fn focus(
+        &self,
+        focus_operation: FocusOperation,
+        focus_initiator: FocusInitiator,
+        can_gc: CanGc,
+    ) {
+        let (mut new_focused, new_focus_state, prevent_scroll) = match focus_operation {
+            FocusOperation::Focus(focusable_area, focus_options) => (
+                match focusable_area {
+                    FocusableArea::Node { node, .. } => DomRoot::downcast::<Element>(node),
+                    FocusableArea::Viewport => None,
+                },
+                true,
+                focus_options.preventScroll,
+            ),
+            FocusOperation::Unfocus => (
+                self.focused.get().as_deref().map(DomRoot::from_ref),
+                false,
+                false,
+            ),
         };
-        *self.focus_transaction.borrow_mut() = None;
 
         if !new_focus_state {
             // In many browsers, a document forgets its focused area when the
@@ -3974,7 +3911,7 @@ impl Document {
             stylesheet_list: MutNullableDom::new(None),
             ready_state: Cell::new(ready_state),
             domcontentloaded_dispatched: Cell::new(domcontentloaded_dispatched),
-            focus_transaction: DomRefCell::new(None),
+
             focused: Default::default(),
             focus_sequence: Cell::new(FocusSequenceNumber::default()),
             has_focus: Cell::new(has_focus),
@@ -6729,15 +6666,9 @@ pub(crate) enum FocusType {
 /// Specifies the initiator of a focus operation.
 #[derive(Clone, Copy, PartialEq)]
 pub enum FocusInitiator {
-    /// The operation is initiated by this document via a keyboard event to be broadcast through the
-    /// constellation.
-    Keyboard,
-    /// The operation is initiated by this document via a click event to be broadcast through the
-    /// constellation.
-    Click,
-    /// The operation is initiated by this document via script to be broadcast through the
-    /// constellation.
-    Script,
+    /// The operation is initiated by a focus change in this [`Document`]. This
+    /// means the change might trigger focus changes in parent [`Document`]s.
+    Local,
     /// The operation is initiated somewhere else, and we are updating our
     /// internal state accordingly.
     Remote,

--- a/components/script/dom/document/document_event_handler.rs
+++ b/components/script/dom/document/document_event_handler.rs
@@ -53,11 +53,13 @@ use style_traits::CSSPixel;
 use webrender_api::ExternalScrollId;
 
 use crate::dom::bindings::cell::DomRefCell;
+use crate::dom::bindings::codegen::Bindings::HTMLOrSVGElementBinding::FocusOptions;
 use crate::dom::bindings::inheritance::{ElementTypeId, HTMLElementTypeId, NodeTypeId};
 use crate::dom::bindings::refcounted::Trusted;
 use crate::dom::bindings::root::MutNullableDom;
 use crate::dom::bindings::trace::NoTrace;
 use crate::dom::clipboardevent::ClipboardEventType;
+use crate::dom::document::focus::FocusableArea;
 use crate::dom::document::{FireMouseEventType, FocusInitiator};
 use crate::dom::event::{EventBubbles, EventCancelable, EventComposed, EventFlags};
 #[cfg(feature = "gamepad")]
@@ -885,30 +887,20 @@ impl DocumentEventHandler {
 
                 self.down_button_count.set(down_button_count + 1);
 
-                let document = self.window.Document();
-                document.begin_focus_transaction();
-
-                // Try to focus `el`. If it's not focusable, focus the document instead.
-                //
-                // The specification says to run the focusing steps on `el` here, but we want a
-                // special behavior implemented by `Element::find_click_focusable_area` which climbs
-                // the tree finding the first ancestor with an associated focusable area.
-                document.request_focus(None, FocusInitiator::Click, can_gc);
-                if let Some(click_focusable_area) = element.find_click_focusable_area() {
-                    document.request_focus(
-                        Some(&*click_focusable_area),
-                        FocusInitiator::Click,
-                        can_gc,
-                    );
-                }
-
                 // Step 7. Let result = dispatch event at target
                 let result = dom_event.dispatch(node.upcast(), false, can_gc);
 
                 // Step 8. If result is true and target is a focusable area
                 // that is click focusable, then Run the focusing steps at target.
-                if result && document.has_focus_transaction() {
-                    document.commit_focus_transaction(FocusInitiator::Click, can_gc);
+                if result {
+                    // Note that this differs from the specification, because we are going to look
+                    // for the first inclusive ancestor that is click focusable and then focus it.
+                    // See documentation for [`Node::find_click_focusable_area`].
+                    self.window.Document().request_focus(
+                        node.find_click_focusable_area(),
+                        FocusInitiator::Local,
+                        can_gc,
+                    );
                 }
 
                 // Step 9. If mbutton is the secondary mouse button, then
@@ -991,10 +983,15 @@ impl DocumentEventHandler {
         // From <https://w3c.github.io/uievents/#event-type-click>
         // > The click event type MUST be dispatched on the topmost event target indicated by the
         // > pointer, when the user presses down and releases the primary pointer button.
+        //
         // For nodes inside a text input UA shadow DOM, dispatch dblclick at the shadow host.
-        let delegated = element.find_click_focusable_area();
-        let element = delegated.as_deref().unwrap_or(element);
-        self.most_recently_clicked_element.set(Some(element));
+        // TODO: This should likely be handled via event retargeting.
+        let element = match hit_test_result.node.find_click_focusable_area() {
+            FocusableArea::Node { node, .. } => DomRoot::downcast::<Element>(node),
+            _ => None,
+        }
+        .unwrap_or_else(|| DomRoot::from_ref(element));
+        self.most_recently_clicked_element.set(Some(&*element));
 
         let click_count = self.click_counting_info.borrow().count;
         element.set_click_in_progress(true);
@@ -1415,11 +1412,7 @@ impl DocumentEventHandler {
         let document = self.window.Document();
         let composition_event = match event {
             ImeEvent::Dismissed => {
-                document.request_focus(
-                    document.GetBody().as_ref().map(|e| e.upcast()),
-                    FocusInitiator::Keyboard,
-                    can_gc,
-                );
+                document.request_focus(FocusableArea::Viewport, FocusInitiator::Local, can_gc);
                 return Default::default();
             },
             ImeEvent::Composition(composition_event) => composition_event,
@@ -2483,8 +2476,8 @@ impl DocumentEventHandler {
 
     fn focus_and_scroll_to_element_for_key_event(&self, element: &Element, can_gc: CanGc) {
         element
-            .owner_document()
-            .request_focus(Some(element), FocusInitiator::Keyboard, can_gc);
+            .upcast::<Node>()
+            .run_the_focusing_steps(FocusOptions::default(), can_gc);
         let scroll_axis = ScrollAxisState {
             position: ScrollLogicalPosition::Center,
             requirement: ScrollRequirement::IfNotVisible,

--- a/components/script/dom/document/focus.rs
+++ b/components/script/dom/document/focus.rs
@@ -1,0 +1,53 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+use bitflags::bitflags;
+use script_bindings::root::DomRoot;
+
+use crate::dom::Node;
+use crate::dom::bindings::codegen::Bindings::HTMLOrSVGElementBinding::FocusOptions;
+
+pub(crate) enum FocusOperation {
+    Focus(FocusableArea, FocusOptions),
+    Unfocus,
+}
+
+/// The kind of focusable area a [`FocusableArea`] is. A [`FocusableArea`] may be click focusable,
+/// sequentially focusable, or both.
+#[derive(Clone, Copy, Debug, Default, MallocSizeOf)]
+pub(crate) struct FocusableAreaKind(u8);
+
+bitflags! {
+    impl FocusableAreaKind: u8 {
+        /// <https://html.spec.whatwg.org/multipage/#click-focusable>
+        ///
+        /// > A focusable area is said to be click focusable if the user agent determines that it is
+        /// > click focusable. User agents should consider focusable areas with non-null tabindex values
+        /// > to be click focusable.
+        const Click = 1 << 0;
+        /// <https://html.spec.whatwg.org/multipage/#sequentially-focusable>.
+        ///
+        /// > A focusable area is said to be sequentially focusable if it is included in its
+        /// > Document's sequential focus navigation order and the user agent determines that it is
+        /// > sequentially focusable.
+        const Sequential = 1 << 1;
+    }
+}
+
+pub(crate) enum FocusableArea {
+    Node {
+        node: DomRoot<Node>,
+        kind: FocusableAreaKind,
+    },
+    Viewport,
+}
+
+impl FocusableArea {
+    pub(crate) fn kind(&self) -> FocusableAreaKind {
+        match self {
+            FocusableArea::Node { kind, .. } => *kind,
+            FocusableArea::Viewport => FocusableAreaKind::Click | FocusableAreaKind::Sequential,
+        }
+    }
+}

--- a/components/script/dom/document/mod.rs
+++ b/components/script/dom/document/mod.rs
@@ -10,3 +10,4 @@ pub(crate) mod document_event_handler;
 pub(crate) mod documentfragment;
 pub(crate) mod documentorshadowroot;
 pub(crate) mod documenttype;
+pub(crate) mod focus;

--- a/components/script/dom/element/focus.rs
+++ b/components/script/dom/element/focus.rs
@@ -2,20 +2,17 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-use bitflags::bitflags;
 use script_bindings::codegen::GenericBindings::ElementBinding::ElementMethods;
 use script_bindings::codegen::GenericBindings::ShadowRootBinding::ShadowRootMethods;
 use script_bindings::codegen::InheritTypes::{ElementTypeId, HTMLElementTypeId, NodeTypeId};
 use script_bindings::inheritance::Castable;
-use script_bindings::root::DomRoot;
-use script_bindings::script_runtime::CanGc;
 use style::computed_values::visibility::T as Visibility;
 use style::values::computed::Overflow;
 use xml5ever::local_name;
 
-use crate::dom::bindings::codegen::Bindings::HTMLOrSVGElementBinding::FocusOptions;
-use crate::dom::types::{Element, HTMLDialogElement, HTMLElement};
-use crate::dom::{FocusInitiator, Node, NodeTraits, ShadowIncluding};
+use crate::dom::Node;
+use crate::dom::document::focus::FocusableAreaKind;
+use crate::dom::types::{Element, HTMLElement};
 
 impl Element {
     /// <https://html.spec.whatwg.org/multipage/#focusable-area>
@@ -28,7 +25,7 @@ impl Element {
     /// different types of focusable areas ahead of time so that the logic is useful for answering
     /// both "Is this element a focusable area?" and "Is this element click (or sequentially)
     /// focusable."
-    fn focusable_area_kind(&self) -> FocusableAreaKind {
+    pub(crate) fn focusable_area_kind(&self) -> FocusableAreaKind {
         // Do not allow unrendered, disconnected, or disabled nodes to be focusable areas ever.
         let node: &Node = self.upcast();
         if !node.is_connected() || !self.has_css_layout_box() || self.is_actually_disabled() {
@@ -148,246 +145,8 @@ impl Element {
             .contains(FocusableAreaKind::Sequential)
     }
 
-    /// <https://html.spec.whatwg.org/multipage/#click-focusable>
-    pub(crate) fn is_click_focusable(&self) -> bool {
-        self.focusable_area_kind()
-            .contains(FocusableAreaKind::Click)
-    }
-
     /// <https://html.spec.whatwg.org/multipage/#focusable-area>
     pub(crate) fn is_focusable_area(&self) -> bool {
         !self.focusable_area_kind().is_empty()
-    }
-
-    /// Returns the focusable appropriate DOM anchor for the focuable area when this element is
-    /// clicked on according to <https://www.w3.org/TR/pointerevents4/#handle-native-mouse-down>.
-    ///
-    /// Note that this is doing more than the specification which says to only take into account
-    /// the node from the hit test. This isn't exactly how browsers work though, as they seem
-    /// to look for the first inclusive ancestor node that has a focusable area associated with it.
-    pub(crate) fn find_click_focusable_area(&self) -> Option<DomRoot<Element>> {
-        Some(
-            self.upcast::<Node>()
-                .inclusive_ancestors(ShadowIncluding::Yes)
-                .find_map(|node| {
-                    DomRoot::downcast::<Element>(node)
-                        .iter()
-                        .filter_map(|element| element.get_the_focusable_area())
-                        .find(|(_, focusable_area_kind)| {
-                            focusable_area_kind.contains(FocusableAreaKind::Click)
-                        })
-                })?
-                .0,
-        )
-    }
-
-    /// <https://html.spec.whatwg.org/multipage/#get-the-focusable-area>
-    ///
-    /// There seems to be hole in the specification here. It describes how to get the focusable
-    /// area for a focus target that isn't a focuable area, but is ambiguous about how to do
-    /// this for a focus target that actually *is* a focusable area. The obvious thing is to
-    /// just return the focus target, but it's still odd that this isn't mentioned in the
-    /// specification.
-    fn get_the_focusable_area(&self) -> Option<(DomRoot<Element>, FocusableAreaKind)> {
-        let focusable_area_kind = self.focusable_area_kind();
-        if !focusable_area_kind.is_empty() {
-            return Some((DomRoot::from_ref(self), focusable_area_kind));
-        }
-        self.get_the_focusable_area_if_not_a_focusable_area()
-    }
-
-    /// <https://html.spec.whatwg.org/multipage/#get-the-focusable-area>
-    ///
-    /// In addition to returning the DOM anchor of the focusable area for this [`Element`], this
-    /// method also returns the [`FocusableAreaKind`] for efficiency reasons. Note that `None`
-    /// is returned if this [`Element`] does not have a focusable area or if its focusable area
-    /// is the `Document`'s viewport.
-    ///
-    /// TODO: It might be better to distinguish these two cases in the future.
-    fn get_the_focusable_area_if_not_a_focusable_area(
-        &self,
-    ) -> Option<(DomRoot<Element>, FocusableAreaKind)> {
-        // > To get the focusable area for a focus target that is either an element that is not a
-        // > focusable area, or is a navigable, given an optional string focus trigger (default
-        // > "other"), run the first matching set of steps from the following list:
-        //
-        // > ↪ If focus target is an area element with one or more shapes that are focusable areas
-        // >     Return the shape corresponding to the first img element in tree order that uses the image
-        // >     map to which the area element belongs.
-        // TODO: Implement this.
-
-        // > ↪ If focus target is an element with one or more scrollable regions that are focusable areas
-        // >     Return the element's first scrollable region, according to a pre-order, depth-first
-        // >     traversal of the flat tree. [CSSSCOPING]
-        // TODO: Implement this.
-
-        // > ↪ If focus target is the document element of its Document
-        // >     Return the Document's viewport.
-        // TODO: Implement this.
-
-        // > ↪ If focus target is a navigable
-        // >     Return the navigable's active document.
-        // TODO: Implement this.
-
-        // > ↪ If focus target is a navigable container with a non-null content navigable
-        // >     Return the navigable container's content navigable's active document.
-        // TODO: Implement this.
-
-        // > ↪ If focus target is a shadow host whose shadow root's delegates focus is true
-        // >     1. Let focusedElement be the currently focused area of a top-level traversable's DOM
-        // >        anchor.
-        // >     2. If focus target is a shadow-including inclusive ancestor of focusedElement, then
-        // >        return focusedElement.
-        // >     3. Return the focus delegate for focus target given focus trigger.
-        if self
-            .shadow_root()
-            .is_some_and(|shadow_root| shadow_root.DelegatesFocus())
-        {
-            if let Some(focused_element) = self.owner_document().get_focused_element() {
-                if self
-                    .upcast::<Node>()
-                    .is_shadow_including_inclusive_ancestor_of(focused_element.upcast())
-                {
-                    let focusable_area_kind = focused_element.focusable_area_kind();
-                    return Some((focused_element, focusable_area_kind));
-                }
-            }
-            return self.focus_delegate();
-        }
-
-        None
-    }
-
-    /// <https://html.spec.whatwg.org/multipage/#focus-delegate>
-    ///
-    /// In addition to returning the focus delegate for this [`Element`], this method also returns
-    /// the [`FocusableAreaKind`] for efficiency reasons.
-    fn focus_delegate(&self) -> Option<(DomRoot<Element>, FocusableAreaKind)> {
-        // > 1. If focusTarget is a shadow host and its shadow root's delegates focus is false, then
-        // >    return null.
-        let shadow_root = self.shadow_root();
-        if shadow_root
-            .as_ref()
-            .is_some_and(|shadow_root| !shadow_root.DelegatesFocus())
-        {
-            return None;
-        }
-
-        // > 2. Let whereToLook be focusTarget.
-        let mut where_to_look = self.upcast::<Node>();
-
-        // > 3. If whereToLook is a shadow host, then set whereToLook to whereToLook's shadow root.
-        if let Some(shadow_root) = shadow_root.as_ref() {
-            where_to_look = shadow_root.upcast();
-        }
-
-        // > 4. Let autofocusDelegate be the autofocus delegate for whereToLook given focusTrigger.
-        // TODO: Implement this.
-
-        // > 5. If autofocusDelegate is not null, then return autofocusDelegate.
-        // TODO: Implement this.
-
-        // > 6. For each descendant of whereToLook's descendants, in tree order:
-        let is_dialog_element = self.is::<HTMLDialogElement>();
-        for descendant in where_to_look.traverse_preorder(ShadowIncluding::No).skip(1) {
-            // > 6.1. Let focusableArea be null.
-            // Handled via early return.
-
-            let Some(descendant) = descendant.downcast::<Element>() else {
-                continue;
-            };
-
-            // > 6.2. If focusTarget is a dialog element and descendant is sequentially focusable, then
-            // >      set focusableArea to descendant.
-            let focusable_area_kind = descendant.focusable_area_kind();
-            if is_dialog_element && focusable_area_kind.contains(FocusableAreaKind::Sequential) {
-                return Some((DomRoot::from_ref(descendant), focusable_area_kind));
-            }
-
-            // > 6.3. Otherwise, if focusTarget is not a dialog and descendant is a focusable area, set
-            // >      focusableArea to descendant.
-            if !focusable_area_kind.is_empty() {
-                return Some((DomRoot::from_ref(descendant), focusable_area_kind));
-            }
-
-            // > 6.4. Otherwise, set focusableArea to the result of getting the focusable area for
-            //        descendant given focusTrigger.
-            if let Some(focusable_area) =
-                descendant.get_the_focusable_area_if_not_a_focusable_area()
-            {
-                // > 6.5. If focusableArea is not null, then return focusableArea.
-                return Some(focusable_area);
-            }
-        }
-
-        // > 7. Return null.
-        None
-    }
-
-    /// <https://html.spec.whatwg.org/multipage/#focusing-steps>
-    ///
-    /// This is an initial implementation of the "focusing steps" from the HTML specification. Note
-    /// that this is currently in a state of transition from Servo's old internal focus APIs to ones
-    /// that match the specification. That is why the arguments to this method do not match the
-    /// specification yet.
-    pub(crate) fn run_the_focusing_steps(
-        &self,
-        focus_initiator: FocusInitiator,
-        focus_options: FocusOptions,
-        can_gc: CanGc,
-    ) {
-        // > 1. If new focus target is not a focusable area, then set new focus target to the result
-        // >    of getting the focusable area for new focus target, given focus trigger if it was
-        // >    passed.
-        let Some((element, _)) = self.get_the_focusable_area() else {
-            return;
-        };
-
-        // > 2. If new focus target is null, then:
-        // > 2.1 If no fallback target was specified, then return.
-        // > 2.2 Otherwise, set new focus target to the fallback target.
-        // TODO: Handle the fallback.
-
-        // > 3. If new focus target is a navigable container with non-null content navigable, then
-        // >    set new focus target to the content navigable's active document.
-        // > 4. If new focus target is a focusable area and its DOM anchor is inert, then return.
-        // > 5. If new focus target is the currently focused area of a top-level traversable, then
-        // >    return.
-        // > 6. Let old chain be the current focus chain of the top-level traversable in which new
-        // >    focus target finds itself.
-        // > 6.1. Let new chain be the focus chain of new focus target.
-        // > 6.2. Run the focus update steps with old chain, new chain, and new focus target
-        // >      respectively.
-        //
-        // TODO: Handle all of these steps by converting the focus transaction code to follow
-        // the HTML focus specification.
-        let document = self.owner_document();
-        document.request_focus_with_options(
-            Some(&*element),
-            focus_initiator,
-            focus_options,
-            can_gc,
-        );
-    }
-}
-
-/// What kind of focusable area an [`Element`] is.
-#[derive(Clone, Copy, Debug, Default)]
-pub(crate) struct FocusableAreaKind(u8);
-
-bitflags! {
-    impl FocusableAreaKind: u8 {
-        /// <https://html.spec.whatwg.org/multipage/#click-focusable>
-        ///
-        /// > A focusable area is said to be click focusable if the user agent determines that it is
-        /// > click focusable. User agents should consider focusable areas with non-null tabindex values
-        /// > to be click focusable.
-        const Click = 1 << 0;
-        /// <https://html.spec.whatwg.org/multipage/#sequentially-focusable>.
-        ///
-        /// > A focusable area is said to be sequentially focusable if it is included in its
-        /// > Document's sequential focus navigation order and the user agent determines that it is
-        /// > sequentially focusable.
-        const Sequential = 1 << 1;
     }
 }

--- a/components/script/dom/html/htmlelement.rs
+++ b/components/script/dom/html/htmlelement.rs
@@ -36,6 +36,7 @@ use crate::dom::css::cssstyledeclaration::{
     CSSModificationAccess, CSSStyleDeclaration, CSSStyleOwner,
 };
 use crate::dom::customelementregistry::{CallbackReaction, CustomElementState};
+use crate::dom::document::focus::FocusableArea;
 use crate::dom::document::{Document, FocusInitiator};
 use crate::dom::document_event_handler::character_to_code;
 use crate::dom::documentfragment::DocumentFragment;
@@ -459,8 +460,8 @@ impl HTMLElementMethods<crate::DomTypeHolder> for HTMLElement {
         // TODO: Implement this.
 
         // 2. Run the focusing steps for this.
-        self.element
-            .run_the_focusing_steps(FocusInitiator::Script, *options, can_gc);
+        self.upcast::<Node>()
+            .run_the_focusing_steps(*options, can_gc);
 
         // > 3. If options["focusVisible"] is true, or does not exist but in an
         // >    implementation-defined  way the user agent determines it would be best to do so,
@@ -481,7 +482,7 @@ impl HTMLElementMethods<crate::DomTypeHolder> for HTMLElement {
         }
         // https://html.spec.whatwg.org/multipage/#unfocusing-steps
         let document = self.owner_document();
-        document.request_focus(None, FocusInitiator::Script, can_gc);
+        document.request_focus(FocusableArea::Viewport, FocusInitiator::Local, can_gc);
     }
 
     /// <https://drafts.csswg.org/cssom-view/#dom-htmlelement-scrollparent>
@@ -1320,7 +1321,7 @@ impl VirtualMethods for HTMLElement {
             .get_focused_element()
             .is_some_and(|focused_element| &*focused_element == element)
         {
-            document.request_focus(None, FocusInitiator::Script, can_gc);
+            document.request_focus(FocusableArea::Viewport, FocusInitiator::Local, can_gc);
         }
 
         // 3. If removedNode is an element whose namespace is the HTML namespace, and this standard

--- a/components/script/dom/html/interactive_element_command.rs
+++ b/components/script/dom/html/interactive_element_command.rs
@@ -13,11 +13,10 @@ use script_bindings::root::DomRoot;
 use script_bindings::script_runtime::CanGc;
 
 use crate::dom::bindings::codegen::Bindings::HTMLOrSVGElementBinding::FocusOptions;
-use crate::dom::document::FocusInitiator;
 use crate::dom::node::{Node, NodeTraits, ShadowIncluding};
 use crate::dom::types::{
-    Element, HTMLAnchorElement, HTMLButtonElement, HTMLElement, HTMLFieldSetElement,
-    HTMLInputElement, HTMLLabelElement, HTMLLegendElement, HTMLOptionElement,
+    HTMLAnchorElement, HTMLButtonElement, HTMLElement, HTMLFieldSetElement, HTMLInputElement,
+    HTMLLabelElement, HTMLLegendElement, HTMLOptionElement,
 };
 
 /// This is an implementation of <https://html.spec.whatwg.org/multipage/#concept-command>. Note
@@ -187,17 +186,14 @@ impl InteractiveElementCommand {
             // >  1. Run the focusing steps for the element.
             // >  2. Fire a click event at the element.
             InteractiveElementCommand::HTMLElement(html_element) => {
-                let element: &Element = html_element.upcast();
-                element.run_the_focusing_steps(
-                    FocusInitiator::Script,
+                let node: &Node = html_element.upcast();
+                node.run_the_focusing_steps(
                     FocusOptions {
                         preventScroll: true,
                     },
                     can_gc,
                 );
-                html_element
-                    .upcast::<Node>()
-                    .fire_synthetic_pointer_event_not_trusted(atom!("click"), can_gc);
+                node.fire_synthetic_pointer_event_not_trusted(atom!("click"), can_gc);
             },
         }
     }

--- a/components/script/dom/node/focus.rs
+++ b/components/script/dom/node/focus.rs
@@ -1,0 +1,231 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+use script_bindings::codegen::GenericBindings::ShadowRootBinding::ShadowRootMethods;
+use script_bindings::inheritance::Castable;
+use script_bindings::root::DomRoot;
+use script_bindings::script_runtime::CanGc;
+
+use crate::dom::bindings::codegen::Bindings::HTMLOrSVGElementBinding::FocusOptions;
+use crate::dom::document::focus::{FocusableArea, FocusableAreaKind};
+use crate::dom::types::{Element, HTMLDialogElement};
+use crate::dom::{FocusInitiator, Node, NodeTraits, ShadowIncluding};
+
+impl Node {
+    /// Returns the appropriate [`FocusableArea`] when this [`Node`] is clicked on according to
+    /// <https://www.w3.org/TR/pointerevents4/#handle-native-mouse-down>.
+    ///
+    /// Note that this is doing more than the specification which says to only take into account
+    /// the node from the hit test. This isn't exactly how browsers work though, as they seem
+    /// to look for the first inclusive ancestor node that has a focusable area associated with it.
+    /// Note also that this may return [`FocusableArea::Viewport`].
+    pub(crate) fn find_click_focusable_area(&self) -> FocusableArea {
+        self.inclusive_ancestors(ShadowIncluding::Yes)
+            .find_map(|node| {
+                node.get_the_focusable_area().filter(|focusable_area| {
+                    focusable_area.kind().contains(FocusableAreaKind::Click)
+                })
+            })
+            .unwrap_or(FocusableArea::Viewport)
+    }
+
+    /// <https://html.spec.whatwg.org/multipage/#get-the-focusable-area>
+    ///
+    /// There seems to be hole in the specification here. It describes how to get the focusable
+    /// area for a focus target that isn't a focuable area, but is ambiguous about how to do
+    /// this for a focus target that actually *is* a focusable area. The obvious thing is to
+    /// just return the focus target, but it's still odd that this isn't mentioned in the
+    /// specification.
+    pub(crate) fn get_the_focusable_area(&self) -> Option<FocusableArea> {
+        let kind = self
+            .downcast::<Element>()
+            .map(Element::focusable_area_kind)
+            .unwrap_or_default();
+        if !kind.is_empty() {
+            return Some(FocusableArea::Node {
+                node: DomRoot::from_ref(self),
+                kind,
+            });
+        }
+        self.get_the_focusable_area_if_not_a_focusable_area()
+    }
+
+    /// <https://html.spec.whatwg.org/multipage/#get-the-focusable-area>
+    ///
+    /// In addition to returning the DOM anchor of the focusable area for this [`Node`], this
+    /// method also returns the [`FocusableAreaKind`] for efficiency reasons. Note that `None`
+    /// is returned if this [`Node`] does not have a focusable area or if its focusable area
+    /// is the `Document`'s viewport.
+    ///
+    /// TODO: It might be better to distinguish these two cases in the future.
+    fn get_the_focusable_area_if_not_a_focusable_area(&self) -> Option<FocusableArea> {
+        // > To get the focusable area for a focus target that is either an element that is not a
+        // > focusable area, or is a navigable, given an optional string focus trigger (default
+        // > "other"), run the first matching set of steps from the following list:
+        //
+        // > ↪ If focus target is an area element with one or more shapes that are focusable areas
+        // >     Return the shape corresponding to the first img element in tree order that uses the image
+        // >     map to which the area element belongs.
+        // TODO: Implement this.
+
+        // > ↪ If focus target is an element with one or more scrollable regions that are focusable areas
+        // >     Return the element's first scrollable region, according to a pre-order, depth-first
+        // >     traversal of the flat tree. [CSSSCOPING]
+        // TODO: Implement this.
+
+        // > ↪ If focus target is the document element of its Document
+        // >     Return the Document's viewport.
+        if self == self.owner_document().upcast::<Node>() {
+            return Some(FocusableArea::Viewport);
+        }
+
+        // > ↪ If focus target is a navigable
+        // >     Return the navigable's active document.
+        // TODO: Implement this.
+
+        // > ↪ If focus target is a navigable container with a non-null content navigable
+        // >     Return the navigable container's content navigable's active document.
+        // TODO: Implement this.
+
+        // > ↪ If focus target is a shadow host whose shadow root's delegates focus is true
+        // >   Step 1. Let focusedElement be the currently focused area of a top-level
+        // >           traversable's DOM anchor.
+        if self
+            .downcast::<Element>()
+            .and_then(Element::shadow_root)
+            .is_some_and(|shadow_root| shadow_root.DelegatesFocus())
+        {
+            if let Some(focused_element) = self.owner_document().get_focused_element() {
+                // >   Step 2. If focus target is a shadow-including inclusive ancestor of
+                // >           focusedElement, then return focusedElement.
+                if self
+                    .upcast::<Node>()
+                    .is_shadow_including_inclusive_ancestor_of(focused_element.upcast())
+                {
+                    let kind = focused_element.focusable_area_kind();
+                    return Some(FocusableArea::Node {
+                        node: DomRoot::upcast(focused_element),
+                        kind,
+                    });
+                }
+            }
+            // >   Step 3. Return the focus delegate for focus target given focus trigger.
+            return self.focus_delegate();
+        }
+
+        None
+    }
+
+    /// <https://html.spec.whatwg.org/multipage/#focus-delegate>
+    ///
+    /// In addition to returning the focus delegate for this [`Node`], this method also returns
+    /// the [`FocusableAreaKind`] for efficiency reasons.
+    fn focus_delegate(&self) -> Option<FocusableArea> {
+        // > 1. If focusTarget is a shadow host and its shadow root's delegates focus is false, then
+        // >    return null.
+        let shadow_root = self.downcast::<Element>().and_then(Element::shadow_root);
+        if shadow_root
+            .as_ref()
+            .is_some_and(|shadow_root| !shadow_root.DelegatesFocus())
+        {
+            return None;
+        }
+
+        // > 2. Let whereToLook be focusTarget.
+        let mut where_to_look = self.upcast::<Node>();
+
+        // > 3. If whereToLook is a shadow host, then set whereToLook to whereToLook's shadow root.
+        if let Some(shadow_root) = shadow_root.as_ref() {
+            where_to_look = shadow_root.upcast();
+        }
+
+        // > 4. Let autofocusDelegate be the autofocus delegate for whereToLook given focusTrigger.
+        // TODO: Implement this.
+
+        // > 5. If autofocusDelegate is not null, then return autofocusDelegate.
+        // TODO: Implement this.
+
+        // > 6. For each descendant of whereToLook's descendants, in tree order:
+        let is_dialog_element = self.is::<HTMLDialogElement>();
+        for descendant in where_to_look.traverse_preorder(ShadowIncluding::No).skip(1) {
+            // > 6.1. Let focusableArea be null.
+            // Handled via early return.
+
+            // > 6.2. If focusTarget is a dialog element and descendant is sequentially focusable, then
+            // >      set focusableArea to descendant.
+            let kind = descendant
+                .downcast::<Element>()
+                .map(Element::focusable_area_kind)
+                .unwrap_or_default();
+            if is_dialog_element && kind.contains(FocusableAreaKind::Sequential) {
+                return Some(FocusableArea::Node {
+                    node: descendant,
+                    kind,
+                });
+            }
+
+            // > 6.3. Otherwise, if focusTarget is not a dialog and descendant is a focusable area, set
+            // >      focusableArea to descendant.
+            if !kind.is_empty() {
+                return Some(FocusableArea::Node {
+                    node: descendant,
+                    kind,
+                });
+            }
+
+            // > 6.4. Otherwise, set focusableArea to the result of getting the focusable area for
+            //        descendant given focusTrigger.
+            if let Some(focusable_area) =
+                descendant.get_the_focusable_area_if_not_a_focusable_area()
+            {
+                // > 6.5. If focusableArea is not null, then return focusableArea.
+                return Some(focusable_area);
+            }
+        }
+
+        // > 7. Return null.
+        None
+    }
+
+    /// <https://html.spec.whatwg.org/multipage/#focusing-steps>
+    ///
+    /// This is an initial implementation of the "focusing steps" from the HTML specification. Note
+    /// that this is currently in a state of transition from Servo's old internal focus APIs to ones
+    /// that match the specification. That is why the arguments to this method do not match the
+    /// specification yet.
+    pub(crate) fn run_the_focusing_steps(&self, focus_options: FocusOptions, can_gc: CanGc) {
+        // > 1. If new focus target is not a focusable area, then set new focus target to the result
+        // >    of getting the focusable area for new focus target, given focus trigger if it was
+        // >    passed.
+        let Some(focusable_area) = self.get_the_focusable_area() else {
+            return;
+        };
+
+        // > 2. If new focus target is null, then:
+        // > 2.1 If no fallback target was specified, then return.
+        // > 2.2 Otherwise, set new focus target to the fallback target.
+        // TODO: Handle the fallback.
+
+        // > 3. If new focus target is a navigable container with non-null content navigable, then
+        // >    set new focus target to the content navigable's active document.
+        // > 4. If new focus target is a focusable area and its DOM anchor is inert, then return.
+        // > 5. If new focus target is the currently focused area of a top-level traversable, then
+        // >    return.
+        // > 6. Let old chain be the current focus chain of the top-level traversable in which new
+        // >    focus target finds itself.
+        // > 6.1. Let new chain be the focus chain of new focus target.
+        // > 6.2. Run the focus update steps with old chain, new chain, and new focus target
+        // >      respectively.
+        //
+        // TODO: Handle all of these steps by converting the focus transaction code to follow
+        // the HTML focus specification.
+        let document = self.owner_document();
+        document.request_focus_with_options(
+            focusable_area,
+            FocusInitiator::Local,
+            focus_options,
+            can_gc,
+        );
+    }
+}

--- a/components/script/dom/node/mod.rs
+++ b/components/script/dom/node/mod.rs
@@ -3,6 +3,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 pub(crate) use self::node::*;
+pub(crate) mod focus;
 #[allow(clippy::module_inception, reason = "The interface name is node")]
 pub(crate) mod node;
 pub(crate) mod nodeiterator;

--- a/components/script/dom/svg/svgelement.rs
+++ b/components/script/dom/svg/svgelement.rs
@@ -16,7 +16,7 @@ use crate::dom::bindings::root::{Dom, DomRoot, MutNullableDom};
 use crate::dom::css::cssstyledeclaration::{
     CSSModificationAccess, CSSStyleDeclaration, CSSStyleOwner,
 };
-use crate::dom::document::{Document, FocusInitiator};
+use crate::dom::document::Document;
 use crate::dom::element::{AttributeMutation, Element};
 use crate::dom::node::{Node, NodeTraits};
 use crate::dom::virtualmethods::VirtualMethods;
@@ -144,11 +144,8 @@ impl SVGElementMethods<crate::DomTypeHolder> for SVGElement {
         // TODO: Implement this.
 
         // 2. Run the focusing steps for this.
-        self.upcast::<Element>().run_the_focusing_steps(
-            FocusInitiator::Script,
-            *options,
-            CanGc::from_cx(cx),
-        );
+        self.upcast::<Node>()
+            .run_the_focusing_steps(*options, CanGc::from_cx(cx));
 
         // > 3. If options["focusVisible"] is true, or does not exist but in an
         // >    implementation-defined  way the user agent determines it would be best to do so,

--- a/components/script/script_thread.rs
+++ b/components/script/script_thread.rs
@@ -115,6 +115,7 @@ use crate::dom::bindings::cell::DomRefCell;
 use crate::dom::bindings::codegen::Bindings::DocumentBinding::{
     DocumentMethods, DocumentReadyState,
 };
+use crate::dom::bindings::codegen::Bindings::HTMLOrSVGElementBinding::FocusOptions;
 use crate::dom::bindings::codegen::Bindings::NavigatorBinding::NavigatorMethods;
 use crate::dom::bindings::codegen::Bindings::WindowBinding::WindowMethods;
 use crate::dom::bindings::conversions::{
@@ -128,6 +129,7 @@ use crate::dom::csp::{CspReporting, GlobalCspReporting, Violation};
 use crate::dom::customelementregistry::{
     CallbackReaction, CustomElementDefinition, CustomElementReactionStack,
 };
+use crate::dom::document::focus::FocusableArea;
 use crate::dom::document::{
     Document, DocumentSource, FocusInitiator, HasBrowsingContext, IsHTMLDocument,
     RenderingUpdateReason,
@@ -2863,13 +2865,13 @@ impl ScriptThread {
             .find_document(parent_pipeline_id)
             .unwrap();
 
-        let Some(iframe_element_root) = ({
+        let Some(iframe_element) = ({
             // Enclose `iframes()` call and create a new root to avoid retaining
             // borrow.
             let iframes = document.iframes();
             iframes
                 .get(browsing_context_id)
-                .map(|iframe| DomRoot::from_ref(iframe.element.upcast()))
+                .map(|iframe| DomRoot::from_ref(iframe.element.upcast::<Node>()))
         }) else {
             return;
         };
@@ -2884,7 +2886,14 @@ impl ScriptThread {
             return;
         }
 
-        document.request_focus(Some(&iframe_element_root), FocusInitiator::Remote, can_gc);
+        if let Some(focusable_area) = iframe_element.get_the_focusable_area() {
+            iframe_element.owner_document().request_focus_with_options(
+                focusable_area,
+                FocusInitiator::Remote,
+                FocusOptions::default(),
+                can_gc,
+            );
+        }
     }
 
     fn handle_focus_document_msg(
@@ -2903,7 +2912,7 @@ impl ScriptThread {
                 );
                 return;
             }
-            doc.request_focus(None, FocusInitiator::Remote, can_gc);
+            doc.request_focus(FocusableArea::Viewport, FocusInitiator::Remote, can_gc);
         } else {
             warn!(
                 "Couldn't find document by pipleline_id:{pipeline_id:?} when handle_focus_document_msg."


### PR DESCRIPTION
For years Servo has had the concept of a focus transaction which was
used only to allow falling back to focusing the viewport when focusing a
clicked element failed. As this concept isn't part of the specification,
this change removes it.

Instead, a `FocusableArea` (a specification concept) is passed to
the `Document` focusing code. A `FocusableArea` might also be the
`Document`'s viewport.

As part of this change, some focus-related methods are moved to `Node`
from `Element` as the `Document` is not an `Element`.  This brings the
code closer to implementing the "focusing steps" from the specification.

Testing: This should not change behavior and is thus covered by existing tests.
