### PR TITLE
devtools: rename `LongStringActor` name variables

### DIFF
--- a/components/devtools/actors/long_string.rs
+++ b/components/devtools/actors/long_string.rs
@@ -73,12 +73,14 @@ impl Actor for LongStringActor {
 }
 
 impl LongStringActor {
-    pub fn new(registry: &ActorRegistry, full_string: String) -> Self {
-        let long_string_name = registry.new_name::<Self>();
-        LongStringActor {
-            name: long_string_name,
+    pub fn register(registry: &ActorRegistry, full_string: String) -> String {
+        let name = registry.new_name::<Self>();
+        let actor = Self {
+            name: name.clone(),
             full_string,
-        }
+        };
+        registry.register::<Self>(actor);
+        name
     }
 
     pub fn long_string_obj(&self) -> LongStringObj {

--- a/components/devtools/actors/long_string.rs
+++ b/components/devtools/actors/long_string.rs
@@ -74,8 +74,11 @@ impl Actor for LongStringActor {
 
 impl LongStringActor {
     pub fn new(registry: &ActorRegistry, full_string: String) -> Self {
-        let name = registry.new_name::<Self>();
-        LongStringActor { name, full_string }
+        let long_string_name = registry.new_name::<Self>();
+        LongStringActor {
+            name: long_string_name,
+            full_string,
+        }
     }
 
     pub fn long_string_obj(&self) -> LongStringObj {

--- a/components/devtools/actors/network_event.rs
+++ b/components/devtools/actors/network_event.rs
@@ -468,9 +468,10 @@ impl Actor for NetworkEventActor {
                     let (encoding, text) = if mime_type.is_some() {
                         // Queue a LongStringActor for this body
                         let body_string = String::from_utf8_lossy(body).to_string();
-                        let long_string_actor = LongStringActor::new(registry, body_string);
-                        let value = long_string_actor.long_string_obj();
-                        registry.register(long_string_actor);
+                        let long_string_name = LongStringActor::register(registry, body_string);
+                        let value = registry
+                            .find::<LongStringActor>(&long_string_name)
+                            .long_string_obj();
                         (None, serde_json::to_value(value).unwrap())
                     } else {
                         let b64 = STANDARD.encode(&body.0);

--- a/components/devtools/actors/network_event.rs
+++ b/components/devtools/actors/network_event.rs
@@ -468,9 +468,9 @@ impl Actor for NetworkEventActor {
                     let (encoding, text) = if mime_type.is_some() {
                         // Queue a LongStringActor for this body
                         let body_string = String::from_utf8_lossy(body).to_string();
-                        let long_string = LongStringActor::new(registry, body_string);
-                        let value = long_string.long_string_obj();
-                        registry.register(long_string);
+                        let long_string_actor = LongStringActor::new(registry, body_string);
+                        let value = long_string_actor.long_string_obj();
+                        registry.register(long_string_actor);
                         (None, serde_json::to_value(value).unwrap())
                     } else {
                         let b64 = STANDARD.encode(&body.0);


### PR DESCRIPTION
Changes `name` to `long_string_name`
`long_string` to `long_string_actor`

Testing: Tested locally with mach test-devtools

Fixes: A part of #43606
