### PR TITLE
devtools: Replace `new` with `register` for PerformanceActor

### DIFF
--- a/components/devtools/actors/performance.rs
+++ b/components/devtools/actors/performance.rs
@@ -98,8 +98,11 @@ impl Actor for PerformanceActor {
 }
 
 impl PerformanceActor {
-    pub fn new(name: String) -> PerformanceActor {
-        PerformanceActor { name }
+    pub fn register(registry: &ActorRegistry) -> String {
+        let name = registry.new_name::<Self>();
+        let actor = PerformanceActor { name: name.clone() };
+        registry.register(actor);
+        name
     }
 
     pub fn description() -> ActorDescription {

--- a/components/devtools/actors/root.rs
+++ b/components/devtools/actors/root.rs
@@ -348,7 +348,7 @@ impl RootActor {
     pub fn register(registry: &mut ActorRegistry) {
         // Global actors
         let device_actor = DeviceActor::new(registry.new_name::<DeviceActor>());
-        let perf = PerformanceActor::new(registry.new_name::<PerformanceActor>());
+        let performance_name = PerformanceActor::register(registry);
         let preference_name = PreferenceActor::register(registry);
 
         // Process descriptor
@@ -358,14 +358,13 @@ impl RootActor {
         let root_actor = Self {
             global_actors: GlobalActors {
                 device_actor: device_actor.name(),
-                perf_actor: perf.name(),
+                perf_actor: performance_name,
                 preference_actor: preference_name,
             },
             process_name: process_actor.name(),
             ..Default::default()
         };
 
-        registry.register(perf);
         registry.register(device_actor);
         registry.register(process_actor);
         registry.register(root_actor);


### PR DESCRIPTION
Replace the `PerformanceActor::new(name)` constructor with a `register(registry)` method that handles name creation, instantiation, and registration internally, returning the actor name. This follows the pattern established in #43800 and matches the existing `PreferenceActor::register` implementation (#43801).

### Changes

- **performance.rs**: Replace `pub fn new(name: String) -> PerformanceActor` with `pub fn register(registry: &ActorRegistry) -> String`
- **root.rs**: Update caller to use `PerformanceActor::register(registry)`; rename local variable from `perf` to `performance_name` per #43606 naming convention; remove now-unnecessary `registry.register(perf)` call

---

Part of #43800.