### PR TITLE
devtools: rename `NodeActor` related variables

### DIFF
--- a/components/devtools/actors/inspector/highlighter.rs
+++ b/components/devtools/actors/inspector/highlighter.rs
@@ -99,10 +99,10 @@ impl Actor for HighlighterActor {
 impl HighlighterActor {
     fn instruct_script_thread_to_highlight_node(
         &self,
-        node_actor: Option<String>,
+        node_name: Option<String>,
         registry: &ActorRegistry,
     ) {
-        let node_id = node_actor.map(|node_actor| registry.actor_to_script(node_actor));
+        let node_id = node_name.map(|node_name| registry.actor_to_script(node_name));
         let browsing_context_actor =
             registry.find::<BrowsingContextActor>(&self.browsing_context_name);
         browsing_context_actor

--- a/components/devtools/actors/inspector/node.rs
+++ b/components/devtools/actors/inspector/node.rs
@@ -128,7 +128,7 @@ pub(crate) struct NodeActorMsg {
 
 #[derive(MallocSizeOf)]
 pub(crate) struct NodeActor {
-    name: String,
+    node_name: String,
     pub script_chan: GenericSender<DevtoolScriptControlMsg>,
     pub pipeline: PipelineId,
     pub walker: String,
@@ -137,7 +137,7 @@ pub(crate) struct NodeActor {
 
 impl Actor for NodeActor {
     fn name(&self) -> String {
-        self.name.clone()
+        self.node_name.clone()
     }
 
     /// The node actor can handle the following messages:
@@ -277,18 +277,18 @@ impl NodeInfoToProtocol for NodeInfo {
     ) -> NodeActorMsg {
         let get_or_register_node_actor = |id: &str| {
             if !registry.script_actor_registered(id.to_string()) {
-                let name = registry.new_name::<NodeActor>();
-                registry.register_script_actor(id.to_string(), name.clone());
+                let node_name = registry.new_name::<NodeActor>();
+                registry.register_script_actor(id.to_string(), node_name.clone());
 
                 let node_actor = NodeActor {
-                    name: name.clone(),
+                    node_name: node_name.clone(),
                     script_chan: script_chan.clone(),
                     pipeline,
                     walker: walker.clone(),
                     style_rules: AtomicRefCell::new(HashMap::new()),
                 };
                 registry.register(node_actor);
-                name
+                node_name
             } else {
                 registry.script_to_actor(id.to_string())
             }

--- a/components/devtools/actors/inspector/node.rs
+++ b/components/devtools/actors/inspector/node.rs
@@ -128,7 +128,7 @@ pub(crate) struct NodeActorMsg {
 
 #[derive(MallocSizeOf)]
 pub(crate) struct NodeActor {
-    node_name: String,
+    name: String,
     pub script_chan: GenericSender<DevtoolScriptControlMsg>,
     pub pipeline: PipelineId,
     pub walker: String,
@@ -137,7 +137,7 @@ pub(crate) struct NodeActor {
 
 impl Actor for NodeActor {
     fn name(&self) -> String {
-        self.node_name.clone()
+        self.name.clone()
     }
 
     /// The node actor can handle the following messages:
@@ -281,7 +281,7 @@ impl NodeInfoToProtocol for NodeInfo {
                 registry.register_script_actor(id.to_string(), node_name.clone());
 
                 let node_actor = NodeActor {
-                    node_name: node_name.clone(),
+                    name: node_name.clone(),
                     script_chan: script_chan.clone(),
                     pipeline,
                     walker: walker.clone(),

--- a/components/devtools/actors/inspector/page_style.rs
+++ b/components/devtools/actors/inspector/page_style.rs
@@ -141,12 +141,12 @@ impl PageStyleActor {
             .ok_or(ActorError::MissingParameter)?
             .as_str()
             .ok_or(ActorError::BadParameterType)?;
-        let node = registry.find::<NodeActor>(target);
-        let walker = registry.find::<WalkerActor>(&node.walker);
+        let node_actor = registry.find::<NodeActor>(target);
+        let walker = registry.find::<WalkerActor>(&node_actor.walker);
         let browsing_context_actor = walker.browsing_context_actor(registry);
         let entries: Vec<_> = find_child(
-            &node.script_chan,
-            node.pipeline,
+            &node_actor.script_chan,
+            node_actor.pipeline,
             target,
             registry,
             &walker.root(registry)?.actor,
@@ -269,8 +269,8 @@ impl PageStyleActor {
             .ok_or(ActorError::MissingParameter)?
             .as_str()
             .ok_or(ActorError::BadParameterType)?;
-        let node = registry.find::<NodeActor>(target);
-        let walker = registry.find::<WalkerActor>(&node.walker);
+        let node_actor = registry.find::<NodeActor>(target);
+        let walker = registry.find::<WalkerActor>(&node_actor.walker);
         let browsing_context_actor = walker.browsing_context_actor(registry);
         let (tx, rx) = generic_channel::channel().ok_or(ActorError::Internal)?;
         browsing_context_actor

--- a/components/devtools/actors/inspector/style_rule.rs
+++ b/components/devtools/actors/inspector/style_rule.rs
@@ -121,8 +121,8 @@ impl Actor for StyleRuleActor {
                     .collect();
 
                 // Query the rule modification
-                let node = registry.find::<NodeActor>(&self.node);
-                let walker = registry.find::<WalkerActor>(&node.walker);
+                let node_actor = registry.find::<NodeActor>(&self.node);
+                let walker = registry.find::<WalkerActor>(&node_actor.walker);
                 let browsing_context_actor = walker.browsing_context_actor(registry);
                 browsing_context_actor
                     .script_chan()
@@ -151,8 +151,8 @@ impl StyleRuleActor {
     }
 
     pub fn applied(&self, registry: &ActorRegistry) -> Option<AppliedRule> {
-        let node = registry.find::<NodeActor>(&self.node);
-        let walker = registry.find::<WalkerActor>(&node.walker);
+        let node_actor = registry.find::<NodeActor>(&self.node);
+        let walker = registry.find::<WalkerActor>(&node_actor.walker);
         let browsing_context_actor = walker.browsing_context_actor(registry);
 
         let (document_sender, document_receiver) = generic_channel::channel()?;
@@ -223,8 +223,8 @@ impl StyleRuleActor {
         &self,
         registry: &ActorRegistry,
     ) -> Option<HashMap<String, ComputedDeclaration>> {
-        let node = registry.find::<NodeActor>(&self.node);
-        let walker = registry.find::<WalkerActor>(&node.walker);
+        let node_actor = registry.find::<NodeActor>(&self.node);
+        let walker = registry.find::<WalkerActor>(&node_actor.walker);
         let browsing_context_actor = walker.browsing_context_actor(registry);
 
         let (style_sender, style_receiver) = generic_channel::channel()?;


### PR DESCRIPTION
Rename variables associated with `NodeActor`

Testing: Tested locally with mach test-devtools

Fixes: A part of https://github.com/servo/servo/issues/43606
