### PR TITLE
script: Move "scroll into view" call out of "focusing steps"

### DIFF
--- a/components/script/dom/document/document.rs
+++ b/components/script/dom/document/document.rs
@@ -87,7 +87,6 @@ use crate::dom::bindings::codegen::Bindings::DocumentBinding::{
 use crate::dom::bindings::codegen::Bindings::ElementBinding::ScrollLogicalPosition;
 use crate::dom::bindings::codegen::Bindings::EventBinding::Event_Binding::EventMethods;
 use crate::dom::bindings::codegen::Bindings::HTMLIFrameElementBinding::HTMLIFrameElement_Binding::HTMLIFrameElementMethods;
-use crate::dom::bindings::codegen::Bindings::HTMLOrSVGElementBinding::FocusOptions;
 #[cfg(any(feature = "webxr", feature = "gamepad"))]
 use crate::dom::bindings::codegen::Bindings::NavigatorBinding::Navigator_Binding::NavigatorMethods;
 use crate::dom::bindings::codegen::Bindings::NodeBinding::NodeMethods;
@@ -175,7 +174,7 @@ use crate::dom::processinginstruction::ProcessingInstruction;
 use crate::dom::promise::Promise;
 use crate::dom::range::Range;
 use crate::dom::resizeobserver::{ResizeObservationDepth, ResizeObserver};
-use crate::dom::scrolling_box::{ScrollAxisState, ScrollRequirement, ScrollingBox};
+use crate::dom::scrolling_box::{ScrollAxisState, ScrollingBox};
 use crate::dom::selection::Selection;
 use crate::dom::servoparser::ServoParser;
 use crate::dom::shadowroot::ShadowRoot;
@@ -1374,42 +1373,9 @@ impl Document {
         {
             return;
         }
-        self.request_focus(FocusableArea::Viewport, FocusInitiator::Local, can_gc);
-    }
-
-    /// Request that the given element receive focus with default options.
-    /// See [`Self::request_focus_with_options`] for the details.
-    pub(crate) fn request_focus(
-        &self,
-        target: FocusableArea,
-        focus_initiator: FocusInitiator,
-        can_gc: CanGc,
-    ) {
-        self.request_focus_with_options(
-            target,
-            focus_initiator,
-            FocusOptions {
-                preventScroll: true,
-            },
-            can_gc,
-        );
-    }
-
-    /// Request that the given element receive focus once the current
-    /// transaction is complete. `None` specifies to focus the document.
-    ///
-    /// If there's no ongoing transaction, this method automatically starts and
-    /// commits an implicit transaction.
-    pub(crate) fn request_focus_with_options(
-        &self,
-        target: FocusableArea,
-        focus_initiator: FocusInitiator,
-        focus_options: FocusOptions,
-        can_gc: CanGc,
-    ) {
         self.focus(
-            FocusOperation::Focus(target, focus_options),
-            focus_initiator,
+            FocusOperation::Focus(FocusableArea::Viewport),
+            FocusInitiator::Local,
             can_gc,
         );
     }
@@ -1427,26 +1393,23 @@ impl Document {
 
     /// Reassign the focus context to the element that last requested focus during this
     /// transaction, or the document if no elements requested it.
-    fn focus(
+    pub(crate) fn focus(
         &self,
         focus_operation: FocusOperation,
         focus_initiator: FocusInitiator,
         can_gc: CanGc,
     ) {
-        let (mut new_focused, new_focus_state, prevent_scroll) = match focus_operation {
-            FocusOperation::Focus(focusable_area, focus_options) => (
+        let (mut new_focused, new_focus_state) = match focus_operation {
+            FocusOperation::Focus(focusable_area) => (
                 match focusable_area {
                     FocusableArea::Node { node, .. } => DomRoot::downcast::<Element>(node),
                     FocusableArea::Viewport => None,
                 },
                 true,
-                focus_options.preventScroll,
             ),
-            FocusOperation::Unfocus => (
-                self.focused.get().as_deref().map(DomRoot::from_ref),
-                false,
-                false,
-            ),
+            FocusOperation::Unfocus => {
+                (self.focused.get().as_deref().map(DomRoot::from_ref), false)
+            },
         };
 
         if !new_focus_state {
@@ -1521,28 +1484,6 @@ impl Document {
                 }
                 // FIXME: pass appropriate relatedTarget
                 self.fire_focus_event(FocusEventType::Focus, node.upcast(), None, can_gc);
-
-                // Scroll operation to happen after element gets focus. This is needed to ensure that the
-                // focused element is visible. Only scroll if preventScroll was not specified.
-                if !prevent_scroll {
-                    // We are following the firefox implementation where we are only scrolling to the element
-                    // if the element itself it not visible.
-                    let scroll_axis = ScrollAxisState {
-                        position: ScrollLogicalPosition::Center,
-                        requirement: ScrollRequirement::IfNotVisible,
-                    };
-
-                    // TODO(stevennovaryo): we doesn't differentiate focus operation from script and from user
-                    //                      for a scroll yet.
-                    // TODO(#40474): Implement specific ScrollIntoView for a selection of text control element.
-                    elem.scroll_into_view_with_options(
-                        ScrollBehavior::Smooth,
-                        scroll_axis,
-                        scroll_axis,
-                        None,
-                        None,
-                    );
-                }
             }
         }
 

--- a/components/script/dom/document/document_event_handler.rs
+++ b/components/script/dom/document/document_event_handler.rs
@@ -53,13 +53,12 @@ use style_traits::CSSPixel;
 use webrender_api::ExternalScrollId;
 
 use crate::dom::bindings::cell::DomRefCell;
-use crate::dom::bindings::codegen::Bindings::HTMLOrSVGElementBinding::FocusOptions;
 use crate::dom::bindings::inheritance::{ElementTypeId, HTMLElementTypeId, NodeTypeId};
 use crate::dom::bindings::refcounted::Trusted;
 use crate::dom::bindings::root::MutNullableDom;
 use crate::dom::bindings::trace::NoTrace;
 use crate::dom::clipboardevent::ClipboardEventType;
-use crate::dom::document::focus::FocusableArea;
+use crate::dom::document::focus::{FocusOperation, FocusableArea};
 use crate::dom::document::{FireMouseEventType, FocusInitiator};
 use crate::dom::event::{EventBubbles, EventCancelable, EventComposed, EventFlags};
 #[cfg(feature = "gamepad")]
@@ -896,8 +895,8 @@ impl DocumentEventHandler {
                     // Note that this differs from the specification, because we are going to look
                     // for the first inclusive ancestor that is click focusable and then focus it.
                     // See documentation for [`Node::find_click_focusable_area`].
-                    self.window.Document().request_focus(
-                        node.find_click_focusable_area(),
+                    self.window.Document().focus(
+                        FocusOperation::Focus(node.find_click_focusable_area()),
                         FocusInitiator::Local,
                         can_gc,
                     );
@@ -1412,7 +1411,11 @@ impl DocumentEventHandler {
         let document = self.window.Document();
         let composition_event = match event {
             ImeEvent::Dismissed => {
-                document.request_focus(FocusableArea::Viewport, FocusInitiator::Local, can_gc);
+                document.focus(
+                    FocusOperation::Focus(FocusableArea::Viewport),
+                    FocusInitiator::Local,
+                    can_gc,
+                );
                 return Default::default();
             },
             ImeEvent::Composition(composition_event) => composition_event,
@@ -2475,9 +2478,7 @@ impl DocumentEventHandler {
     }
 
     fn focus_and_scroll_to_element_for_key_event(&self, element: &Element, can_gc: CanGc) {
-        element
-            .upcast::<Node>()
-            .run_the_focusing_steps(FocusOptions::default(), can_gc);
+        element.upcast::<Node>().run_the_focusing_steps(can_gc);
         let scroll_axis = ScrollAxisState {
             position: ScrollLogicalPosition::Center,
             requirement: ScrollRequirement::IfNotVisible,

--- a/components/script/dom/document/focus.rs
+++ b/components/script/dom/document/focus.rs
@@ -6,10 +6,9 @@ use bitflags::bitflags;
 use script_bindings::root::DomRoot;
 
 use crate::dom::Node;
-use crate::dom::bindings::codegen::Bindings::HTMLOrSVGElementBinding::FocusOptions;
 
 pub(crate) enum FocusOperation {
-    Focus(FocusableArea, FocusOptions),
+    Focus(FocusableArea),
     Unfocus,
 }
 

--- a/components/script/dom/html/htmlelement.rs
+++ b/components/script/dom/html/htmlelement.rs
@@ -12,6 +12,8 @@ use js::context::JSContext;
 use js::rust::HandleObject;
 use layout_api::{QueryMsg, ScrollContainerQueryFlags, ScrollContainerResponse};
 use script_bindings::codegen::GenericBindings::DocumentBinding::DocumentMethods;
+use script_bindings::codegen::GenericBindings::ElementBinding::ScrollLogicalPosition;
+use script_bindings::codegen::GenericBindings::WindowBinding::ScrollBehavior;
 use style::attr::AttrValue;
 use stylo_dom::ElementState;
 
@@ -36,7 +38,7 @@ use crate::dom::css::cssstyledeclaration::{
     CSSModificationAccess, CSSStyleDeclaration, CSSStyleOwner,
 };
 use crate::dom::customelementregistry::{CallbackReaction, CustomElementState};
-use crate::dom::document::focus::FocusableArea;
+use crate::dom::document::focus::{FocusOperation, FocusableArea};
 use crate::dom::document::{Document, FocusInitiator};
 use crate::dom::document_event_handler::character_to_code;
 use crate::dom::documentfragment::DocumentFragment;
@@ -63,6 +65,7 @@ use crate::dom::node::{
     BindContext, MoveContext, Node, NodeTraits, ShadowIncluding, UnbindContext,
     from_untrusted_node_address,
 };
+use crate::dom::scrolling_box::{ScrollAxisState, ScrollRequirement};
 use crate::dom::shadowroot::ShadowRoot;
 use crate::dom::text::Text;
 use crate::dom::virtualmethods::VirtualMethods;
@@ -460,8 +463,12 @@ impl HTMLElementMethods<crate::DomTypeHolder> for HTMLElement {
         // TODO: Implement this.
 
         // 2. Run the focusing steps for this.
-        self.upcast::<Node>()
-            .run_the_focusing_steps(*options, can_gc);
+        if !self.upcast::<Node>().run_the_focusing_steps(can_gc) {
+            // The specification seems to imply we should scroll into view even if this element
+            // is not a focusable area. No browser does this, so we return early in that case.
+            // See https://github.com/whatwg/html/issues/12231.
+            return;
+        }
 
         // > 3. If options["focusVisible"] is true, or does not exist but in an
         // >    implementation-defined  way the user agent determines it would be best to do so,
@@ -469,8 +476,19 @@ impl HTMLElementMethods<crate::DomTypeHolder> for HTMLElement {
 
         // > 4. If options["preventScroll"] is false, then scroll a target into view given this,
         // >    "auto", "center", and "center".
-        // TODO: This is currently handled as part of the focusing steps, but should eventually be
-        // handled here.
+        if !options.preventScroll {
+            let scroll_axis = ScrollAxisState {
+                position: ScrollLogicalPosition::Center,
+                requirement: ScrollRequirement::IfNotVisible,
+            };
+            self.upcast::<Element>().scroll_into_view_with_options(
+                ScrollBehavior::Smooth,
+                scroll_axis,
+                scroll_axis,
+                None,
+                None,
+            );
+        }
     }
 
     /// <https://html.spec.whatwg.org/multipage/#dom-blur>
@@ -481,8 +499,11 @@ impl HTMLElementMethods<crate::DomTypeHolder> for HTMLElement {
             return;
         }
         // https://html.spec.whatwg.org/multipage/#unfocusing-steps
-        let document = self.owner_document();
-        document.request_focus(FocusableArea::Viewport, FocusInitiator::Local, can_gc);
+        self.owner_document().focus(
+            FocusOperation::Focus(FocusableArea::Viewport),
+            FocusInitiator::Local,
+            can_gc,
+        );
     }
 
     /// <https://drafts.csswg.org/cssom-view/#dom-htmlelement-scrollparent>
@@ -1321,7 +1342,11 @@ impl VirtualMethods for HTMLElement {
             .get_focused_element()
             .is_some_and(|focused_element| &*focused_element == element)
         {
-            document.request_focus(FocusableArea::Viewport, FocusInitiator::Local, can_gc);
+            document.focus(
+                FocusOperation::Focus(FocusableArea::Viewport),
+                FocusInitiator::Local,
+                can_gc,
+            );
         }
 
         // 3. If removedNode is an element whose namespace is the HTML namespace, and this standard

--- a/components/script/dom/html/interactive_element_command.rs
+++ b/components/script/dom/html/interactive_element_command.rs
@@ -12,7 +12,6 @@ use script_bindings::inheritance::Castable;
 use script_bindings::root::DomRoot;
 use script_bindings::script_runtime::CanGc;
 
-use crate::dom::bindings::codegen::Bindings::HTMLOrSVGElementBinding::FocusOptions;
 use crate::dom::node::{Node, NodeTraits, ShadowIncluding};
 use crate::dom::types::{
     HTMLAnchorElement, HTMLButtonElement, HTMLElement, HTMLFieldSetElement, HTMLInputElement,
@@ -187,12 +186,7 @@ impl InteractiveElementCommand {
             // >  2. Fire a click event at the element.
             InteractiveElementCommand::HTMLElement(html_element) => {
                 let node: &Node = html_element.upcast();
-                node.run_the_focusing_steps(
-                    FocusOptions {
-                        preventScroll: true,
-                    },
-                    can_gc,
-                );
+                node.run_the_focusing_steps(can_gc);
                 node.fire_synthetic_pointer_event_not_trusted(atom!("click"), can_gc);
             },
         }

--- a/components/script/dom/node/focus.rs
+++ b/components/script/dom/node/focus.rs
@@ -7,8 +7,7 @@ use script_bindings::inheritance::Castable;
 use script_bindings::root::DomRoot;
 use script_bindings::script_runtime::CanGc;
 
-use crate::dom::bindings::codegen::Bindings::HTMLOrSVGElementBinding::FocusOptions;
-use crate::dom::document::focus::{FocusableArea, FocusableAreaKind};
+use crate::dom::document::focus::{FocusOperation, FocusableArea, FocusableAreaKind};
 use crate::dom::types::{Element, HTMLDialogElement};
 use crate::dom::{FocusInitiator, Node, NodeTraits, ShadowIncluding};
 
@@ -194,12 +193,14 @@ impl Node {
     /// that this is currently in a state of transition from Servo's old internal focus APIs to ones
     /// that match the specification. That is why the arguments to this method do not match the
     /// specification yet.
-    pub(crate) fn run_the_focusing_steps(&self, focus_options: FocusOptions, can_gc: CanGc) {
+    ///
+    /// Return `true` if anything was focused or `false` otherwise.
+    pub(crate) fn run_the_focusing_steps(&self, can_gc: CanGc) -> bool {
         // > 1. If new focus target is not a focusable area, then set new focus target to the result
         // >    of getting the focusable area for new focus target, given focus trigger if it was
         // >    passed.
         let Some(focusable_area) = self.get_the_focusable_area() else {
-            return;
+            return false;
         };
 
         // > 2. If new focus target is null, then:
@@ -221,11 +222,11 @@ impl Node {
         // TODO: Handle all of these steps by converting the focus transaction code to follow
         // the HTML focus specification.
         let document = self.owner_document();
-        document.request_focus_with_options(
-            focusable_area,
+        document.focus(
+            FocusOperation::Focus(focusable_area),
             FocusInitiator::Local,
-            focus_options,
             can_gc,
         );
+        true
     }
 }

--- a/components/script/dom/svg/svgelement.rs
+++ b/components/script/dom/svg/svgelement.rs
@@ -5,6 +5,8 @@
 use dom_struct::dom_struct;
 use html5ever::{LocalName, Prefix, local_name, ns};
 use js::rust::HandleObject;
+use script_bindings::codegen::GenericBindings::ElementBinding::ScrollLogicalPosition;
+use script_bindings::codegen::GenericBindings::WindowBinding::ScrollBehavior;
 use script_bindings::str::DOMString;
 use stylo_dom::ElementState;
 
@@ -19,6 +21,7 @@ use crate::dom::css::cssstyledeclaration::{
 use crate::dom::document::Document;
 use crate::dom::element::{AttributeMutation, Element};
 use crate::dom::node::{Node, NodeTraits};
+use crate::dom::scrolling_box::{ScrollAxisState, ScrollRequirement};
 use crate::dom::virtualmethods::VirtualMethods;
 use crate::script_runtime::CanGc;
 
@@ -144,8 +147,15 @@ impl SVGElementMethods<crate::DomTypeHolder> for SVGElement {
         // TODO: Implement this.
 
         // 2. Run the focusing steps for this.
-        self.upcast::<Node>()
-            .run_the_focusing_steps(*options, CanGc::from_cx(cx));
+        if !self
+            .upcast::<Node>()
+            .run_the_focusing_steps(CanGc::from_cx(cx))
+        {
+            // The specification seems to imply we should scroll into view even if this element
+            // is not a focusable area. No browser does this, so we return early in that case.
+            // See https://github.com/whatwg/html/issues/12231.
+            return;
+        }
 
         // > 3. If options["focusVisible"] is true, or does not exist but in an
         // >    implementation-defined  way the user agent determines it would be best to do so,
@@ -154,8 +164,19 @@ impl SVGElementMethods<crate::DomTypeHolder> for SVGElement {
 
         // > 4. If options["preventScroll"] is false, then scroll a target into view given this,
         // >    "auto", "center", and "center".
-        // TODO: This is currently handled as part of the focusing steps, but should eventually be
-        // handled here.
+        if !options.preventScroll {
+            let scroll_axis = ScrollAxisState {
+                position: ScrollLogicalPosition::Center,
+                requirement: ScrollRequirement::IfNotVisible,
+            };
+            self.upcast::<Element>().scroll_into_view_with_options(
+                ScrollBehavior::Smooth,
+                scroll_axis,
+                scroll_axis,
+                None,
+                None,
+            );
+        }
     }
 
     /// <https://html.spec.whatwg.org/multipage/#dom-tabindex>

--- a/components/script/script_thread.rs
+++ b/components/script/script_thread.rs
@@ -115,7 +115,6 @@ use crate::dom::bindings::cell::DomRefCell;
 use crate::dom::bindings::codegen::Bindings::DocumentBinding::{
     DocumentMethods, DocumentReadyState,
 };
-use crate::dom::bindings::codegen::Bindings::HTMLOrSVGElementBinding::FocusOptions;
 use crate::dom::bindings::codegen::Bindings::NavigatorBinding::NavigatorMethods;
 use crate::dom::bindings::codegen::Bindings::WindowBinding::WindowMethods;
 use crate::dom::bindings::conversions::{
@@ -129,7 +128,7 @@ use crate::dom::csp::{CspReporting, GlobalCspReporting, Violation};
 use crate::dom::customelementregistry::{
     CallbackReaction, CustomElementDefinition, CustomElementReactionStack,
 };
-use crate::dom::document::focus::FocusableArea;
+use crate::dom::document::focus::{FocusOperation, FocusableArea};
 use crate::dom::document::{
     Document, DocumentSource, FocusInitiator, HasBrowsingContext, IsHTMLDocument,
     RenderingUpdateReason,
@@ -2887,10 +2886,9 @@ impl ScriptThread {
         }
 
         if let Some(focusable_area) = iframe_element.get_the_focusable_area() {
-            iframe_element.owner_document().request_focus_with_options(
-                focusable_area,
+            iframe_element.owner_document().focus(
+                FocusOperation::Focus(focusable_area),
                 FocusInitiator::Remote,
-                FocusOptions::default(),
                 can_gc,
             );
         }
@@ -2912,7 +2910,11 @@ impl ScriptThread {
                 );
                 return;
             }
-            doc.request_focus(FocusableArea::Viewport, FocusInitiator::Remote, can_gc);
+            doc.focus(
+                FocusOperation::Focus(FocusableArea::Viewport),
+                FocusInitiator::Remote,
+                can_gc,
+            );
         } else {
             warn!(
                 "Couldn't find document by pipleline_id:{pipeline_id:?} when handle_focus_document_msg."

--- a/tests/wpt/meta/focus/focus-contenteditable-element-in-iframe-scroll-into-view.html.ini
+++ b/tests/wpt/meta/focus/focus-contenteditable-element-in-iframe-scroll-into-view.html.ini
@@ -1,3 +1,0 @@
-[focus-contenteditable-element-in-iframe-scroll-into-view.html]
-  [Check contenteditable element in an iframe scroll into view on second focusing]
-    expected: FAIL


### PR DESCRIPTION
`HTMLOrSVGElement#focus` specifies the "scroll into view" steps should
be run after focusing. This was happening implicitly as part of the
`Document`'s implementation of the "focusing steps." That behavior is
not in the specification, so this change moves the scrolling call to
where it is specified. Along with making the code match the
specification, this change simplifies it as well.

Testing: This should not modify behavior, so existing tests should suffice.
