### PR TITLE
layout: Update group index when reusing table-column box

### DIFF
--- a/components/layout/table/construct.rs
+++ b/components/layout/table/construct.rs
@@ -1169,14 +1169,18 @@ fn add_column(
     // The HTML specification clamps value of `span` for `<col>` to [1, 1000].
     assert!((1..=1000).contains(&span));
 
-    let column = old_column.unwrap_or_else(|| {
-        ArcRefCell::new(TableTrack {
+    let column = match old_column {
+        Some(column) => {
+            column.borrow_mut().group_index = group_index;
+            column
+        },
+        None => ArcRefCell::new(TableTrack {
             base: LayoutBoxBase::new(column_info.into(), column_info.style.clone()),
             group_index,
             is_anonymous,
             shared_background_style: SharedStyle::new(column_info.style.clone()),
-        })
-    });
+        }),
+    };
     collection.extend(repeat_n(column.clone(), span as usize));
     column
 }

--- a/tests/wpt/tests/css/css-tables/crashtests/remove-table-column-group.html
+++ b/tests/wpt/tests/css/css-tables/crashtests/remove-table-column-group.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html class="test-wait">
+<link rel="author" title="Oriol Brufau" href="obrufau@igalia.com">
+<link rel="help" href="https://github.com/servo/servo/issues/39142">
+<meta name="assert" content="Removing a column group should not crash">
+
+<div style="display: table">
+  <div style="display: table-column-group" id="colgroup"></div>
+  <div style="display: table-column-group">
+    <!-- This column is in the 2nd column group. But after removing the
+         original 1st column group, the column needs to be associated with
+         the new 1st column group, since there is no 2nd column group
+         anymore. -->
+    <div style="display: table-column"></div>
+  </div>
+  <div style="display: table-cell"></div>
+</div>
+
+<script>
+window.onload = function() {
+  colgroup.remove();
+  document.documentElement.classList.remove("test-wait")
+};
+</script>
+
+</html>


### PR DESCRIPTION
Even if we can reuse the box, its column group index may have changed, e.g. due to the removal of a previous column group. So just update it.

Testing: Adding crash test
Fixes: #39142
