### PR TITLE
script: Run the focusing steps when navigating to a fragment

### DIFF
--- a/components/script/dom/document/document.rs
+++ b/components/script/dom/document/document.rs
@@ -1231,7 +1231,7 @@ impl Document {
     }
 
     /// <https://html.spec.whatwg.org/multipage/#scroll-to-the-fragment-identifier>
-    pub(crate) fn scroll_to_the_fragment(&self, fragment: &str) {
+    pub(crate) fn scroll_to_the_fragment(&self, fragment: &str, can_gc: CanGc) {
         // Step 1. If document's indicated part is null, then set document's target element to null.
         //
         // > For an HTML document document, its indicated part is the result of
@@ -1270,8 +1270,10 @@ impl Document {
             None,
             None,
         );
-        // Step 3.6. Run the focusing steps for target, with the Document's viewport as the fallback target.
-        // TODO
+
+        // Step 3.6. Run the focusing steps for target, with the Document's viewport as the fallback
+        // target.
+        indicated_part.run_the_focusing_steps(Some(FocusableArea::Viewport), can_gc);
 
         // Step 3.7. Move the sequential focus navigation starting point to target.
         self.event_handler()
@@ -2513,7 +2515,7 @@ impl Document {
                 // TODO
 
                 if let Some(fragment) = document.url().fragment() {
-                    document.scroll_to_the_fragment(fragment);
+                    document.scroll_to_the_fragment(fragment, CanGc::note());
                 }
             }));
 

--- a/components/script/dom/document/document_event_handler.rs
+++ b/components/script/dom/document/document_event_handler.rs
@@ -2488,7 +2488,9 @@ impl DocumentEventHandler {
     }
 
     fn focus_and_scroll_to_element_for_key_event(&self, element: &Element, can_gc: CanGc) {
-        element.upcast::<Node>().run_the_focusing_steps(can_gc);
+        element
+            .upcast::<Node>()
+            .run_the_focusing_steps(None, can_gc);
         let scroll_axis = ScrollAxisState {
             position: ScrollLogicalPosition::Center,
             requirement: ScrollRequirement::IfNotVisible,

--- a/components/script/dom/history.rs
+++ b/components/script/dom/history.rs
@@ -101,7 +101,7 @@ impl History {
 
         // Step 8
         if let Some(fragment) = url.fragment() {
-            document.scroll_to_the_fragment(fragment);
+            document.scroll_to_the_fragment(fragment, can_gc);
         }
 
         // Step 11

--- a/components/script/dom/html/htmlelement.rs
+++ b/components/script/dom/html/htmlelement.rs
@@ -463,7 +463,7 @@ impl HTMLElementMethods<crate::DomTypeHolder> for HTMLElement {
         // TODO: Implement this.
 
         // 2. Run the focusing steps for this.
-        if !self.upcast::<Node>().run_the_focusing_steps(can_gc) {
+        if !self.upcast::<Node>().run_the_focusing_steps(None, can_gc) {
             // The specification seems to imply we should scroll into view even if this element
             // is not a focusable area. No browser does this, so we return early in that case.
             // See https://github.com/whatwg/html/issues/12231.

--- a/components/script/dom/html/interactive_element_command.rs
+++ b/components/script/dom/html/interactive_element_command.rs
@@ -186,7 +186,7 @@ impl InteractiveElementCommand {
             // >  2. Fire a click event at the element.
             InteractiveElementCommand::HTMLElement(html_element) => {
                 let node: &Node = html_element.upcast();
-                node.run_the_focusing_steps(can_gc);
+                node.run_the_focusing_steps(None, can_gc);
                 node.fire_synthetic_pointer_event_not_trusted(atom!("click"), can_gc);
             },
         }

--- a/components/script/dom/node/focus.rs
+++ b/components/script/dom/node/focus.rs
@@ -195,18 +195,20 @@ impl Node {
     /// specification yet.
     ///
     /// Return `true` if anything was focused or `false` otherwise.
-    pub(crate) fn run_the_focusing_steps(&self, can_gc: CanGc) -> bool {
+    pub(crate) fn run_the_focusing_steps(
+        &self,
+        fallback_target: Option<FocusableArea>,
+        can_gc: CanGc,
+    ) -> bool {
         // > 1. If new focus target is not a focusable area, then set new focus target to the result
         // >    of getting the focusable area for new focus target, given focus trigger if it was
         // >    passed.
-        let Some(focusable_area) = self.get_the_focusable_area() else {
-            return false;
-        };
-
         // > 2. If new focus target is null, then:
         // > 2.1 If no fallback target was specified, then return.
         // > 2.2 Otherwise, set new focus target to the fallback target.
-        // TODO: Handle the fallback.
+        let Some(focusable_area) = self.get_the_focusable_area().or(fallback_target) else {
+            return false;
+        };
 
         // > 3. If new focus target is a navigable container with non-null content navigable, then
         // >    set new focus target to the content navigable's active document.

--- a/components/script/dom/svg/svgelement.rs
+++ b/components/script/dom/svg/svgelement.rs
@@ -149,7 +149,7 @@ impl SVGElementMethods<crate::DomTypeHolder> for SVGElement {
         // 2. Run the focusing steps for this.
         if !self
             .upcast::<Node>()
-            .run_the_focusing_steps(CanGc::from_cx(cx))
+            .run_the_focusing_steps(None, CanGc::from_cx(cx))
         {
             // The specification seems to imply we should scroll into view even if this element
             // is not a focusable area. No browser does this, so we return early in that case.

--- a/components/script/navigation.rs
+++ b/components/script/navigation.rs
@@ -307,6 +307,7 @@ pub(crate) fn determine_the_origin(
 
 /// <https://html.spec.whatwg.org/multipage/#navigate-fragid>
 fn navigate_to_fragment(
+    cx: &mut JSContext,
     window: &Window,
     url: &ServoUrl,
     history_handling: NavigationHistoryBehavior,
@@ -348,7 +349,7 @@ fn navigate_to_fragment(
     let Some(fragment) = url.fragment() else {
         unreachable!("Must always have a fragment");
     };
-    doc.scroll_to_the_fragment(fragment);
+    doc.scroll_to_the_fragment(fragment, CanGc::from_cx(cx));
     // Step 16. Let traversable be navigable's traversable navigable.
     // TODO
     // Step 17. Append the following session history synchronous navigation steps involving navigable to traversable:
@@ -430,7 +431,7 @@ pub(crate) fn navigate(
         if let Some(ref sender) = webdriver_sender {
             let _ = sender.send(WebDriverLoadStatus::NavigationStart);
         }
-        navigate_to_fragment(window, &load_data.url, history_handling);
+        navigate_to_fragment(cx, window, &load_data.url, history_handling);
         // Step 14.2. Return.
         if let Some(sender) = webdriver_sender {
             let _ = sender.send(WebDriverLoadStatus::NavigationStop);

--- a/tests/wpt/tests/html/browsers/browsing-the-web/scroll-to-fragid/focus-changes-after-scroll-to-fragment.html
+++ b/tests/wpt/tests/html/browsers/browsing-the-web/scroll-to-fragid/focus-changes-after-scroll-to-fragment.html
@@ -1,0 +1,35 @@
+<!doctype HTML>
+<head>
+  <meta charset=utf-8>
+  <title>Fragment Navigation: Scrolling to a fragment focuses the fragment, falling back to the viewport</title>
+  <link rel="help" href="https://html.spec.whatwg.org/multipage/browsing-the-web.html#scrolling-to-a-fragment:focusing-steps">
+  <link rel="author" href="mailto:mrobinson@igalia.com" title="Martin Robinson">
+  <script src=/resources/testharness.js></script>
+  <script src=/resources/testharnessreport.js></script>
+</head>
+<body>
+    <div id="initial" tabindex="1">Initial</div>
+    <!-- This div is focusable, so navigating to it should focus it. -->
+    <div id="target1" tabindex="1">Target 1</div>
+    <!-- This div is not focusable, so navigating to it should focus the viewport. -->
+    <div id="target2">Target 1</div>
+</body>
+<script>
+test((t) => {
+  initial.focus();
+  assert_equals(document.activeElement, initial);
+
+  let sawTarget1FocusEvent = false;
+  target1.addEventListener("focus", () => sawTarget1FocusEvent = true);
+  location.hash = "target1";
+  assert_equals(document.activeElement, target1);
+  assert_true(sawTarget1FocusEvent);
+
+  initial.focus();
+  assert_equals(document.activeElement, initial);
+
+  location.hash = "target2";
+  assert_equals(document.activeElement, document.body);
+
+});
+</script>


### PR DESCRIPTION
When navigating to a fragment the specification says to run the focusing
steps. This is possible now that the focusing steps are properly
exposed. This change also adds support for the fallback option, which is
used when the focus target is not associated with a focuable area. In
this case the fallback is to focus the viewport.

Testing: This change adds a new WPT for this behavior, which was seemingly not tested before.
