### PR TITLE
servo-hyper-serde: Use the workspace version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7915,7 +7915,7 @@ dependencies = [
 
 [[package]]
 name = "servo-hyper-serde"
-version = "0.13.2"
+version = "0.1.0"
 dependencies = [
  "cookie 0.18.1",
  "headers 0.4.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -237,6 +237,7 @@ dom_struct = { package = "servo-dom-struct", version = "0.1.0", path = "componen
 embedder_traits = { package = "servo-embedder-traits", version = "0.1.0", path = "components/shared/embedder" }
 fonts = { package = "servo-fonts", version = "0.1.0", path = "components/fonts" }
 fonts_traits = { package = "servo-fonts-traits", version = "0.1.0", path = "components/shared/fonts" }
+hyper_serde = { package = "servo-hyper-serde", version = "0.1.0", path = "components/hyper_serde" }
 jstraceable_derive = { package = "servo-jstraceable-derive", version = "0.1.0", path = "components/jstraceable_derive" }
 layout = { package = "servo-layout", version = "0.1.0", path = "components/layout" }
 layout_api = { package = "servo-layout-api", version = "0.1.0", path = "components/shared/layout" }
@@ -294,9 +295,6 @@ webxr = { package = "servo-webxr", version = "0.1.0", path = "components/webxr" 
 webxr-api = { package = "servo-webxr-api", version = "0.1.0", path = "components/shared/webxr" }
 xpath = { package = "servo-xpath", version = "0.1.0", path = "components/xpath" }
 # End workspace-version dependencies - Don't change this comment, we grep for it in scripts!
-
-# Independently versioned workspace local crates. These crates will not take part in auto-bumps.
-hyper_serde = { package = "servo-hyper-serde", version = "0.13.2", path = "components/hyper_serde" }
 
 # RSA key generation could be very slow without compilation
 # optimizations, in development mode. Without optimizations, WPT might

--- a/components/hyper_serde/Cargo.toml
+++ b/components/hyper_serde/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "servo-hyper-serde"
-version = "0.13.2"
+version.workspace = true
 edition.workspace = true
 authors = ["The Servo Project Developers"]
 description = "Serde support for hyper types."

--- a/deny.toml
+++ b/deny.toml
@@ -231,8 +231,6 @@ skip = [
 # github.com organizations to allow git sources for
 [sources.allow-org]
 github = [
-    "servo",
-
     # Temporarily needed by servoshell: see root Cargo.toml
     "emilk",
 ]


### PR DESCRIPTION
This is a backport of #43866 to the release/v0.1 branch.

`hyper_serde` currently has no dependants on crates.io. We give up the independant versioning and simplify our setup by using the same version as our workspace. The new crate is servo-hyper-serde.

Testing: Not required, policy change.