### PR TITLE
servoshell: Only send `ImeEvent::Dismissed` when the user dismisses the IME

### DIFF
--- a/ports/servoshell/desktop/headed_window.rs
+++ b/ports/servoshell/desktop/headed_window.rs
@@ -752,7 +752,19 @@ impl HeadedWindow {
                             )));
                         },
                         Ime::Disabled => {
-                            webview.notify_input_event(InputEvent::Ime(ImeEvent::Dismissed));
+                            // There are two reasons we receive this message from winit:
+                            //
+                            // 1. The user dismissed the IME. In that case we want to inform Servo
+                            //    so it can unfocus the current editable element.
+                            // 2. Servo changed focus and requested that we dismiss the IME, which
+                            //    in turn triggers this message. We know this is the case when we don't
+                            //    expect any IME to be open and shouldn't send any more messages to
+                            //    Servo as it might cause unexpected blurring of the newly focused
+                            //    element.
+                            if !self.visible_input_methods.borrow().is_empty() {
+                                self.visible_input_methods.borrow_mut().clear();
+                                webview.notify_input_event(InputEvent::Ime(ImeEvent::Dismissed));
+                            }
                         },
                     },
                     _ => {},


### PR DESCRIPTION
We receive the `Ime::Disabled` event both when the user dismisses the IME and
when Servo itself dismisses it (for instance, when changing focus on the page).
Servo will blur the current element upon receiving `ImeEvent::Dismissed`,
leading to spurious focus behavior. Address this by only sending this message
to Servo when it was triggered by the user (as best as we can tell). This
problem was revealed by improvements in the internal focus APIs.

This is a bit of a bandaid until we have a more robust IME API. There are
still missing pieces in both Servo and in winit.

Testing: This is a bit tricky to test as it depends a lot on when messages are
sent to servoshell from winit / the windowing system and when Servo processes
focus events.
