### PR TITLE
devtools: rename `ObjectActor` and `SymbolIteratorActor` variables names

### DIFF
--- a/components/devtools/actors/console.rs
+++ b/components/devtools/actors/console.rs
@@ -69,7 +69,7 @@ fn console_argument_to_value(argument: ConsoleArgument, registry: &ActorRegistry
             // Create a new actor for the object.
             // These are currently never cleaned up, and we make no attempt at re-using the same actor
             // if the same object is logged repeatedly.
-            let actor = ObjectActor::register(registry, None, object.class.clone(), None);
+            let object_name = ObjectActor::register(registry, None, object.class.clone(), None);
 
             // TODO: Replace these with ObjectActor::encode
             #[derive(Serialize)]
@@ -111,7 +111,7 @@ fn console_argument_to_value(argument: ConsoleArgument, registry: &ActorRegistry
 
             let argument = DevtoolsConsoleObjectArgument {
                 r#type: "object".to_owned(),
-                actor,
+                actor: object_name,
                 class: object.class,
                 own_property_length: own_properties.len(),
                 extensible: true,

--- a/components/devtools/actors/frame.rs
+++ b/components/devtools/actors/frame.rs
@@ -112,12 +112,12 @@ impl FrameActor {
         source_actor: String,
         frame_result: FrameInfo,
     ) -> String {
-        let object_actor = ObjectActor::register(registry, None, "Object".to_owned(), None);
+        let object_name = ObjectActor::register(registry, None, "Object".to_owned(), None);
 
         let name = registry.new_name::<Self>();
         let actor = Self {
             name: name.clone(),
-            object_actor,
+            object_actor: object_name,
             source_actor,
             frame_result,
             current_offset: Default::default(),

--- a/components/devtools/actors/object.rs
+++ b/components/devtools/actors/object.rs
@@ -169,18 +169,18 @@ impl Actor for ObjectActor {
             },
 
             "enumSymbols" => {
-                let symbol_iterator = SymbolIteratorActor {
+                let symbol_iterator_actor = SymbolIteratorActor {
                     name: registry.new_name::<SymbolIteratorActor>(),
                 };
                 let msg = EnumReply {
                     from: self.name(),
                     iterator: EnumIterator {
-                        actor: symbol_iterator.name(),
+                        actor: symbol_iterator_actor.name(),
                         type_: EnumIteratorType::SymbolIterator,
                         count: 0,
                     },
                 };
-                registry.register(symbol_iterator);
+                registry.register(symbol_iterator_actor);
                 request.reply_final(&msg)?
             },
 


### PR DESCRIPTION
Rename variables associated with `ObjectActor` and `SymbolIteratorActor`

Testing: Tested locally with mach test-devtools

Fixes: A part of https://github.com/servo/servo/issues/43606
