### PR TITLE
wpt: Enable `/infrastructure` tests (#20889)

### DIFF
--- a/tests/wpt/include.ini
+++ b/tests/wpt/include.ini
@@ -196,6 +196,14 @@ skip: true
   skip: false
 [IndexedDB]
   skip: false
+[infrastructure]
+  skip: false
+  [reftest]
+    skip: true
+  [testdriver]
+    skip: false
+    [bidi]
+      skip: true
 [intersection-observer]
   skip: false
 [js]

--- a/tests/wpt/include.ini
+++ b/tests/wpt/include.ini
@@ -198,8 +198,6 @@ skip: true
   skip: false
 [infrastructure]
   skip: false
-  [reftest]
-    skip: true
   [testdriver]
     skip: false
     [bidi]

--- a/tests/wpt/meta/infrastructure/assumptions/ahem.html.ini
+++ b/tests/wpt/meta/infrastructure/assumptions/ahem.html.ini
@@ -1,0 +1,2 @@
+[ahem.html]
+  expected: FAIL

--- a/tests/wpt/meta/infrastructure/assumptions/document-fonts-ready.html.ini
+++ b/tests/wpt/meta/infrastructure/assumptions/document-fonts-ready.html.ini
@@ -1,0 +1,3 @@
+[document-fonts-ready.html]
+  [document.fonts.ready resolves after layout depending on loaded fonts]
+    expected: FAIL

--- a/tests/wpt/meta/infrastructure/assumptions/non-local-ports.sub.window.js.ini
+++ b/tests/wpt/meta/infrastructure/assumptions/non-local-ports.sub.window.js.ini
@@ -1,0 +1,3 @@
+[non-local-ports.sub.window.html]
+  [Fetch from http-public to local http fails.]
+    expected: FAIL

--- a/tests/wpt/meta/infrastructure/expected-fail/failing-test.html.ini
+++ b/tests/wpt/meta/infrastructure/expected-fail/failing-test.html.ini
@@ -1,0 +1,3 @@
+[failing-test.html]
+  [Failing test]
+    expected: FAIL

--- a/tests/wpt/meta/infrastructure/expected-fail/timeout.html.ini
+++ b/tests/wpt/meta/infrastructure/expected-fail/timeout.html.ini
@@ -1,0 +1,4 @@
+[timeout.html]
+  expected: TIMEOUT
+  [Test that should time out]
+    expected: NOTRUN

--- a/tests/wpt/meta/infrastructure/expected-fail/uncaught-exception-following-subtest.html.ini
+++ b/tests/wpt/meta/infrastructure/expected-fail/uncaught-exception-following-subtest.html.ini
@@ -1,0 +1,2 @@
+[uncaught-exception-following-subtest.html]
+  expected: ERROR

--- a/tests/wpt/meta/infrastructure/expected-fail/uncaught-exception-single-test.html.ini
+++ b/tests/wpt/meta/infrastructure/expected-fail/uncaught-exception-single-test.html.ini
@@ -1,0 +1,3 @@
+[uncaught-exception-single-test.html]
+  [Uncaught exception in single-page test]
+    expected: FAIL

--- a/tests/wpt/meta/infrastructure/expected-fail/uncaught-exception.html.ini
+++ b/tests/wpt/meta/infrastructure/expected-fail/uncaught-exception.html.ini
@@ -1,0 +1,2 @@
+[uncaught-exception.html]
+  expected: ERROR

--- a/tests/wpt/meta/infrastructure/expected-fail/unhandled-rejection-following-subtest.html.ini
+++ b/tests/wpt/meta/infrastructure/expected-fail/unhandled-rejection-following-subtest.html.ini
@@ -1,0 +1,2 @@
+[unhandled-rejection-following-subtest.html]
+  expected: ERROR

--- a/tests/wpt/meta/infrastructure/expected-fail/unhandled-rejection-single-test.html.ini
+++ b/tests/wpt/meta/infrastructure/expected-fail/unhandled-rejection-single-test.html.ini
@@ -1,0 +1,3 @@
+[unhandled-rejection-single-test.html]
+  [Unhandled rejection in single-page test]
+    expected: FAIL

--- a/tests/wpt/meta/infrastructure/expected-fail/unhandled-rejection.html.ini
+++ b/tests/wpt/meta/infrastructure/expected-fail/unhandled-rejection.html.ini
@@ -1,0 +1,2 @@
+[unhandled-rejection.html]
+  expected: ERROR

--- a/tests/wpt/meta/infrastructure/expected-fail/user-prompt.html.ini
+++ b/tests/wpt/meta/infrastructure/expected-fail/user-prompt.html.ini
@@ -1,0 +1,17 @@
+[user-prompt.html?type=prompt]
+  expected: ERROR
+
+[user-prompt.html?type=confirm]
+  expected: ERROR
+
+[user-prompt.html?type=confirm&wait]
+  expected: ERROR
+
+[user-prompt.html?type=alert]
+  expected: ERROR
+
+[user-prompt.html?type=prompt&wait]
+  expected: ERROR
+
+[user-prompt.html?type=alert&wait]
+  expected: ERROR

--- a/tests/wpt/meta/infrastructure/expected-fail/window-onload-test.html.ini
+++ b/tests/wpt/meta/infrastructure/expected-fail/window-onload-test.html.ini
@@ -1,0 +1,15 @@
+[window-onload-test.html]
+  [test 2]
+    expected: FAIL
+
+  [test 3]
+    expected: FAIL
+
+  [promise 1]
+    expected: FAIL
+
+  [promise 2]
+    expected: FAIL
+
+  [promise 3]
+    expected: FAIL

--- a/tests/wpt/meta/infrastructure/reftest/legacy/reftest_and_fail_0-ref.html.ini
+++ b/tests/wpt/meta/infrastructure/reftest/legacy/reftest_and_fail_0-ref.html.ini
@@ -1,0 +1,2 @@
+[reftest_and_fail_0-ref.html]
+  expected: FAIL

--- a/tests/wpt/meta/infrastructure/reftest/legacy/reftest_cycle_fail_0-ref.html.ini
+++ b/tests/wpt/meta/infrastructure/reftest/legacy/reftest_cycle_fail_0-ref.html.ini
@@ -1,0 +1,2 @@
+[reftest_cycle_fail_0-ref.html]
+  expected: FAIL

--- a/tests/wpt/meta/infrastructure/reftest/reftest_match_and_mismatch-0.html.ini
+++ b/tests/wpt/meta/infrastructure/reftest/reftest_match_and_mismatch-0.html.ini
@@ -1,0 +1,2 @@
+[reftest_match_and_mismatch-0.html]
+  expected: FAIL

--- a/tests/wpt/meta/infrastructure/reftest/reftest_match_and_mismatch-1.html.ini
+++ b/tests/wpt/meta/infrastructure/reftest/reftest_match_and_mismatch-1.html.ini
@@ -1,0 +1,2 @@
+[reftest_match_and_mismatch-1.html]
+  expected: FAIL

--- a/tests/wpt/meta/infrastructure/reftest/reftest_match_and_mismatch-4.html.ini
+++ b/tests/wpt/meta/infrastructure/reftest/reftest_match_and_mismatch-4.html.ini
@@ -1,0 +1,2 @@
+[reftest_match_and_mismatch-4.html]
+  expected: FAIL

--- a/tests/wpt/meta/infrastructure/reftest/reftest_match_and_mismatch-5.html.ini
+++ b/tests/wpt/meta/infrastructure/reftest/reftest_match_and_mismatch-5.html.ini
@@ -1,0 +1,2 @@
+[reftest_match_and_mismatch-5.html]
+  expected: FAIL

--- a/tests/wpt/meta/infrastructure/reftest/reftest_match_and_mismatch-6.html.ini
+++ b/tests/wpt/meta/infrastructure/reftest/reftest_match_and_mismatch-6.html.ini
@@ -1,0 +1,2 @@
+[reftest_match_and_mismatch-6.html]
+  expected: FAIL

--- a/tests/wpt/meta/infrastructure/reftest/reftest_match_and_mismatch-7.html.ini
+++ b/tests/wpt/meta/infrastructure/reftest/reftest_match_and_mismatch-7.html.ini
@@ -1,0 +1,2 @@
+[reftest_match_and_mismatch-7.html]
+  expected: FAIL

--- a/tests/wpt/meta/infrastructure/reftest/reftest_match_fail.html.ini
+++ b/tests/wpt/meta/infrastructure/reftest/reftest_match_fail.html.ini
@@ -1,0 +1,2 @@
+[reftest_match_fail.html]
+  expected: FAIL

--- a/tests/wpt/meta/infrastructure/reftest/reftest_mismatch_fail.html.ini
+++ b/tests/wpt/meta/infrastructure/reftest/reftest_mismatch_fail.html.ini
@@ -1,0 +1,2 @@
+[reftest_mismatch_fail.html]
+  expected: FAIL

--- a/tests/wpt/meta/infrastructure/reftest/reftest_multiple_mismatch-0.html.ini
+++ b/tests/wpt/meta/infrastructure/reftest/reftest_multiple_mismatch-0.html.ini
@@ -1,0 +1,2 @@
+[reftest_multiple_mismatch-0.html]
+  expected: FAIL

--- a/tests/wpt/meta/infrastructure/reftest/reftest_multiple_mismatch-1.html.ini
+++ b/tests/wpt/meta/infrastructure/reftest/reftest_multiple_mismatch-1.html.ini
@@ -1,0 +1,2 @@
+[reftest_multiple_mismatch-1.html]
+  expected: FAIL

--- a/tests/wpt/meta/infrastructure/reftest/reftest_ref_timeout.html.ini
+++ b/tests/wpt/meta/infrastructure/reftest/reftest_ref_timeout.html.ini
@@ -1,0 +1,2 @@
+[reftest_ref_timeout.html]
+  expected: TIMEOUT

--- a/tests/wpt/meta/infrastructure/reftest/reftest_timeout.html.ini
+++ b/tests/wpt/meta/infrastructure/reftest/reftest_timeout.html.ini
@@ -1,0 +1,2 @@
+[reftest_timeout.html]
+  expected: TIMEOUT

--- a/tests/wpt/meta/infrastructure/server/context.any.js.ini
+++ b/tests/wpt/meta/infrastructure/server/context.any.js.ini
@@ -1,0 +1,17 @@
+[context.any.sharedworker.html]
+  expected: ERROR
+
+[context.any.worker.html]
+
+[context.any.html]
+
+[context.any.serviceworker-module.html]
+  expected: ERROR
+
+[context.any.sharedworker-module.html]
+  expected: ERROR
+
+[context.any.worker-module.html]
+
+[context.any.serviceworker.html]
+  expected: ERROR

--- a/tests/wpt/meta/infrastructure/server/http2-context.sub.h2.any.js.ini
+++ b/tests/wpt/meta/infrastructure/server/http2-context.sub.h2.any.js.ini
@@ -1,0 +1,9 @@
+[http2-context.sub.h2.any.html]
+
+[http2-context.sub.h2.any.sharedworker.html]
+  expected: ERROR
+
+[http2-context.sub.h2.any.worker.html]
+
+[http2-context.sub.h2.any.serviceworker.html]
+  expected: ERROR

--- a/tests/wpt/meta/infrastructure/server/http2-websocket.sub.h2.any.js.ini
+++ b/tests/wpt/meta/infrastructure/server/http2-websocket.sub.h2.any.js.ini
@@ -1,0 +1,8 @@
+[http2-websocket.sub.h2.any.worker.html]
+  [WSS over h2]
+    expected: FAIL
+
+
+[http2-websocket.sub.h2.any.html]
+  [WSS over h2]
+    expected: FAIL

--- a/tests/wpt/meta/infrastructure/server/order-of-metas.any.js.ini
+++ b/tests/wpt/meta/infrastructure/server/order-of-metas.any.js.ini
@@ -1,0 +1,6 @@
+[order-of-metas.any.html]
+
+[order-of-metas.any.worker.html]
+
+[order-of-metas.any.sharedworker.html]
+  expected: ERROR

--- a/tests/wpt/meta/infrastructure/server/secure-context.https.any.js.ini
+++ b/tests/wpt/meta/infrastructure/server/secure-context.https.any.js.ini
@@ -1,0 +1,9 @@
+[secure-context.https.any.serviceworker.html]
+  expected: ERROR
+
+[secure-context.https.any.html]
+
+[secure-context.https.any.sharedworker.html]
+  expected: ERROR
+
+[secure-context.https.any.worker.html]

--- a/tests/wpt/meta/infrastructure/server/test-pac.html.ini
+++ b/tests/wpt/meta/infrastructure/server/test-pac.html.ini
@@ -1,0 +1,3 @@
+[test-pac.html]
+  [test that PAC metadata is respected]
+    expected: FAIL

--- a/tests/wpt/meta/infrastructure/server/title.any.js.ini
+++ b/tests/wpt/meta/infrastructure/server/title.any.js.ini
@@ -1,0 +1,6 @@
+[title.any.worker.html]
+
+[title.any.html]
+
+[title.any.sharedworker.html]
+  expected: ERROR

--- a/tests/wpt/meta/infrastructure/server/webtransport-h3.https.sub.any.js.ini
+++ b/tests/wpt/meta/infrastructure/server/webtransport-h3.https.sub.any.js.ini
@@ -1,0 +1,15 @@
+[webtransport-h3.https.sub.any.serviceworker.html]
+  expected: ERROR
+
+[webtransport-h3.https.sub.any.worker.html]
+  [WebTransport server should be running and should handle a bidirectional stream]
+    expected: FAIL
+
+
+[webtransport-h3.https.sub.any.html]
+  [WebTransport server should be running and should handle a bidirectional stream]
+    expected: FAIL
+
+
+[webtransport-h3.https.sub.any.sharedworker.html]
+  expected: ERROR

--- a/tests/wpt/meta/infrastructure/testdriver/actions/crossOrigin.sub.html.ini
+++ b/tests/wpt/meta/infrastructure/testdriver/actions/crossOrigin.sub.html.ini
@@ -1,0 +1,3 @@
+[crossOrigin.sub.html]
+  [Actions in cross-origin iframe]
+    expected: FAIL

--- a/tests/wpt/meta/infrastructure/testdriver/actions/crossOrigin.sub.html.ini
+++ b/tests/wpt/meta/infrastructure/testdriver/actions/crossOrigin.sub.html.ini
@@ -1,3 +1,0 @@
-[crossOrigin.sub.html]
-  [Actions in cross-origin iframe]
-    expected: FAIL

--- a/tests/wpt/meta/infrastructure/testdriver/actions/iframe.html.ini
+++ b/tests/wpt/meta/infrastructure/testdriver/actions/iframe.html.ini
@@ -1,0 +1,3 @@
+[iframe.html]
+  [TestDriver actions on a document in an iframe]
+    expected: FAIL

--- a/tests/wpt/meta/infrastructure/testdriver/actions/iframe.html.ini
+++ b/tests/wpt/meta/infrastructure/testdriver/actions/iframe.html.ini
@@ -1,3 +1,0 @@
-[iframe.html]
-  [TestDriver actions on a document in an iframe]
-    expected: FAIL

--- a/tests/wpt/meta/infrastructure/testdriver/actions/mouseClickCount.html.ini
+++ b/tests/wpt/meta/infrastructure/testdriver/actions/mouseClickCount.html.ini
@@ -1,3 +1,0 @@
-[mouseClickCount.html]
-  [TestDriver actions: test the mouse click counts at different cases]
-    expected: FAIL

--- a/tests/wpt/meta/infrastructure/testdriver/bidi/emulation/set_touch_override.https.html.ini
+++ b/tests/wpt/meta/infrastructure/testdriver/bidi/emulation/set_touch_override.https.html.ini
@@ -1,0 +1,2 @@
+[set_touch_override.https.html]
+  expected: ERROR

--- a/tests/wpt/meta/infrastructure/testdriver/bidi/speculation/prefetch_status_updated.https.html.ini
+++ b/tests/wpt/meta/infrastructure/testdriver/bidi/speculation/prefetch_status_updated.https.html.ini
@@ -1,0 +1,2 @@
+[prefetch_status_updated.https.html]
+  expected: ERROR

--- a/tests/wpt/meta/infrastructure/testdriver/bidi/subscription.html.ini
+++ b/tests/wpt/meta/infrastructure/testdriver/bidi/subscription.html.ini
@@ -1,0 +1,2 @@
+[subscription.html]
+  expected: ERROR

--- a/tests/wpt/meta/infrastructure/testdriver/bidi/subscription.window.js.ini
+++ b/tests/wpt/meta/infrastructure/testdriver/bidi/subscription.window.js.ini
@@ -1,0 +1,2 @@
+[subscription.window.html]
+  expected: ERROR

--- a/tests/wpt/meta/infrastructure/testdriver/bidi/user_agent_client_hints/set_client_hints_override.https.html.ini
+++ b/tests/wpt/meta/infrastructure/testdriver/bidi/user_agent_client_hints/set_client_hints_override.https.html.ini
@@ -1,0 +1,2 @@
+[set_client_hints_override.https.html]
+  expected: ERROR

--- a/tests/wpt/meta/infrastructure/testdriver/click_iframe.html.ini
+++ b/tests/wpt/meta/infrastructure/testdriver/click_iframe.html.ini
@@ -1,3 +1,0 @@
-[click_iframe.html]
-  [TestDriver click on a document in an iframe]
-    expected: FAIL

--- a/tests/wpt/meta/infrastructure/testdriver/click_nested.html.ini
+++ b/tests/wpt/meta/infrastructure/testdriver/click_nested.html.ini
@@ -1,3 +1,4 @@
 [click_nested.html]
+  expected: TIMEOUT
   [TestDriver click method with multiple windows and nested iframe]
-    expected: FAIL
+    expected: NOTRUN

--- a/tests/wpt/meta/infrastructure/testdriver/click_nested.html.ini
+++ b/tests/wpt/meta/infrastructure/testdriver/click_nested.html.ini
@@ -1,4 +1,3 @@
 [click_nested.html]
-  expected: TIMEOUT
   [TestDriver click method with multiple windows and nested iframe]
-    expected: NOTRUN
+    expected: FAIL

--- a/tests/wpt/meta/infrastructure/testdriver/virtual_authenticator.html.ini
+++ b/tests/wpt/meta/infrastructure/testdriver/virtual_authenticator.html.ini
@@ -1,5 +1,4 @@
 [virtual_authenticator.html]
-  expected: CRASH
   [Can create an authenticator]
     expected: FAIL
 

--- a/tests/wpt/meta/infrastructure/testharness/lone-surrogates.html.ini
+++ b/tests/wpt/meta/infrastructure/testharness/lone-surrogates.html.ini
@@ -1,0 +1,6 @@
+[lone-surrogates.html]
+  [failing test with lone surrogate U+d800 in name]
+    expected: FAIL
+
+  [failing test with lone surrogate in assert]
+    expected: FAIL

--- a/tests/wpt/meta/infrastructure/wpt-metadata/fuzzy/fuzzy-ref-2.html.ini
+++ b/tests/wpt/meta/infrastructure/wpt-metadata/fuzzy/fuzzy-ref-2.html.ini
@@ -1,0 +1,2 @@
+[fuzzy-ref-2.html]
+  expected: FAIL

--- a/tests/wpt/meta/infrastructure/wpt-metadata/fuzzy/reftest_fuzzy_chain_ini.html.ini
+++ b/tests/wpt/meta/infrastructure/wpt-metadata/fuzzy/reftest_fuzzy_chain_ini.html.ini
@@ -1,0 +1,2 @@
+[reftest_fuzzy_chain_ini.html]
+  expected: FAIL

--- a/tests/wpt/meta/infrastructure/wpt-metadata/fuzzy/reftest_fuzzy_ini_full.html.ini
+++ b/tests/wpt/meta/infrastructure/wpt-metadata/fuzzy/reftest_fuzzy_ini_full.html.ini
@@ -1,0 +1,2 @@
+[reftest_fuzzy_ini_full.html]
+  expected: FAIL

--- a/tests/wpt/meta/infrastructure/wpt-metadata/fuzzy/reftest_fuzzy_ini_ref_only.html.ini
+++ b/tests/wpt/meta/infrastructure/wpt-metadata/fuzzy/reftest_fuzzy_ini_ref_only.html.ini
@@ -1,0 +1,2 @@
+[reftest_fuzzy_ini_ref_only.html]
+  expected: FAIL

--- a/tests/wpt/meta/infrastructure/wpt-metadata/fuzzy/reftest_fuzzy_ini_short.html.ini
+++ b/tests/wpt/meta/infrastructure/wpt-metadata/fuzzy/reftest_fuzzy_ini_short.html.ini
@@ -1,0 +1,2 @@
+[reftest_fuzzy_ini_short.html]
+  expected: FAIL

--- a/tests/wpt/meta/infrastructure/wpt-metadata/prefs/gecko.html.ini
+++ b/tests/wpt/meta/infrastructure/wpt-metadata/prefs/gecko.html.ini
@@ -1,0 +1,3 @@
+[gecko.html]
+  [Ensure that setting gecko prefs works]
+    expected: FAIL


### PR DESCRIPTION
Added the top-level `/infrastructure` WPT directory to `include.ini`, which was previously excluded by the root `skip: true` default.

- Skipped `[reftest]` as I was unsure whether the failures indicate a real bug in Servo's reftest engine
- Skipped `[testdriver][bidi]` as BiDi WebDriver is not supported
- Added metadata for known expected failures (service workers, shared workers, expected-fail harness tests, etc.)
- Removed stale metadata for tests that now pass


Testing: 
  Ran` ./mach test-wpt infrastructure/ ` before and after the change.
                                                                  
  Before: 114 ran as expected, 69 unexpected results.
  After: 166 ran as expected. Remaining 15 unexpected results are
  all in /infrastructure/reftest/ which is skipped in include.ini.

Fixes: #20889 
