### PR TITLE
Replace normal struct instantiation with register for WalkerActor

### DIFF
--- a/components/devtools/actors/inspector.rs
+++ b/components/devtools/actors/inspector.rs
@@ -4,7 +4,6 @@
 
 //! Liberally derived from the [Firefox JS implementation](http://mxr.mozilla.org/mozilla-central/source/toolkit/devtools/server/actors/inspector.js).
 
-use atomic_refcell::AtomicRefCell;
 use malloc_size_of_derive::MallocSizeOf;
 use serde::Serialize;
 use serde_json::{self, Map, Value};
@@ -55,7 +54,7 @@ pub(crate) struct InspectorActor {
     name: String,
     highlighter_name: String,
     page_style_name: String,
-    pub(crate) walker: String,
+    pub(crate) walker_name: String,
 }
 
 impl Actor for InspectorActor {
@@ -91,7 +90,7 @@ impl Actor for InspectorActor {
             "getWalker" => {
                 let msg = GetWalkerReply {
                     from: self.name(),
-                    walker: registry.encode::<WalkerActor, _>(&self.walker),
+                    walker: registry.encode::<WalkerActor, _>(&self.walker_name),
                 };
                 request.reply_final(&msg)?
             },
@@ -121,23 +120,18 @@ impl InspectorActor {
             name: registry.new_name::<PageStyleActor>(),
         };
 
-        let walker = WalkerActor {
-            name: registry.new_name::<WalkerActor>(),
-            mutations: AtomicRefCell::new(vec![]),
-            browsing_context_name,
-        };
+        let walker_name = WalkerActor::register(registry, browsing_context_name);
 
         let inspector_actor = Self {
             name: registry.new_name::<InspectorActor>(),
             highlighter_name: highlighter_actor.name(),
             page_style_name: page_style_actor.name(),
-            walker: walker.name(),
+            walker_name,
         };
         let inspector_name = inspector_actor.name();
 
         registry.register(highlighter_actor);
         registry.register(page_style_actor);
-        registry.register(walker);
         registry.register(inspector_actor);
 
         inspector_name

--- a/components/devtools/actors/inspector/walker.rs
+++ b/components/devtools/actors/inspector/walker.rs
@@ -280,6 +280,17 @@ impl Actor for WalkerActor {
 }
 
 impl WalkerActor {
+    pub fn register(registry: &ActorRegistry, browsing_context_name: String) -> String {
+        let name = registry.new_name::<WalkerActor>();
+        let actor = WalkerActor {
+            name: name.clone(),
+            mutations: AtomicRefCell::new(vec![]),
+            browsing_context_name,
+        };
+        registry.register::<Self>(actor);
+        name
+    }
+
     pub(crate) fn browsing_context_actor(
         &self,
         registry: &ActorRegistry,

--- a/components/devtools/lib.rs
+++ b/components/devtools/lib.rs
@@ -599,7 +599,9 @@ impl DevtoolsInstance {
         let inspector_actor = self
             .registry
             .find::<InspectorActor>(&browsing_context_actor.inspector_name);
-        let walker_actor = self.registry.find::<WalkerActor>(&inspector_actor.walker);
+        let walker_actor = self
+            .registry
+            .find::<WalkerActor>(&inspector_actor.walker_name);
 
         for connection in self.connections.lock().unwrap().values_mut() {
             walker_actor.handle_dom_mutation(dom_mutation.clone(), connection)?;


### PR DESCRIPTION
Part of a larger refactor to name all actors and variables consistently, #43800.

Testing: not necessary beyond `mach test-devtools` per #43800 / #43606
Fixes: `#43800` ((not linking because it's one of many PR's).