### PR TITLE
Fix error message for illegal HTML element constructors (#41107)

### DIFF
--- a/components/script/dom/bindings/constructor.rs
+++ b/components/script/dom/bindings/constructor.rs
@@ -91,7 +91,7 @@ fn html_constructor(
         throw_dom_exception(
             cx.into(),
             global,
-            Error::Type(c"new.target must not be the active function object".to_owned()),
+            Error::Type(c"Illegal constructor.".to_owned()),
             CanGc::from_cx(cx),
         );
         return Err(());


### PR DESCRIPTION
Changes the error message for illegal HTML element constructors like `new HTMLElement()` from `new.target must not be the active function object` to `Illegal constructor.`, matching Chrome, Firefox, and the HTML spec.

Ran `./mach test-wpt tests/wpt/tests/custom-elements`. 180 tests passed as expected, 1 pre-existing unrelated crash in `HTMLMediaElement`.

#41107 