### PR TITLE
script/mach: Increase stack size of `ScriptThread`/`StyleThread` to 8MiB to match recursion depth of other browsers

### DIFF
--- a/components/script/script_thread.rs
+++ b/components/script/script_thread.rs
@@ -468,6 +468,7 @@ impl ScriptThreadFactory for ScriptThread {
         let script_thread_id = state.id;
         thread::Builder::new()
             .name(format!("Script#{script_thread_id}"))
+            .stack_size(8 * 1024 * 1024) // 8 MiB stack to be consistent with other browsers.
             .spawn(move || {
                 thread_state::initialize(ThreadState::SCRIPT);
                 PipelineNamespace::install(state.pipeline_namespace_id);

--- a/python/servo/build_commands.py
+++ b/python/servo/build_commands.py
@@ -301,10 +301,6 @@ class MachCommands(CommandBase):
             env["TARGET_CFLAGS"] += " -fsanitize=address"
             env["TARGET_CXXFLAGS"] += " -fsanitize=address"
 
-            # Set servo style thread stack size to 8 MB for ASAN builds since the stack usage is higher.
-            # We don't care about efficiency, we just want to avoid crashes.
-            env["SERVO_STYLE_THREAD_STACK_SIZE_KB"] = str(1024 * 8)
-
             # asan replaces system allocator with asan allocator
             # we need to make sure that we do not replace it with jemalloc
             self.features.append("servo-allocator/use-system-allocator")

--- a/python/servo/command_base.py
+++ b/python/servo/command_base.py
@@ -417,10 +417,11 @@ class CommandBase(object):
                 print("Hint: Ninja-build is available on github at: https://github.com/ninja-build/ninja/releases")
                 exit(1)
 
-        if self.config["build"]["mode"] in ["", "dev"]:
-            # Increase stylo thread stack size to 2 MiB for debug builds since the stack usage is higher
-            # and crashes have been reported. The default is 512 KiB.
-            env["SERVO_STYLE_THREAD_STACK_SIZE_KB"] = env.get("SERVO_STYLE_THREAD_STACK_SIZE_KB", str(2 * 1024))
+        # Increase stylo thread stack size to 8 MiB for all builds
+        # to match the recursion depth of Chromium.
+        # This only reserves virtual memory space and has almost no overhead.
+        # See https://github.com/servo/servo/pull/43888
+        env["SERVO_STYLE_THREAD_STACK_SIZE_KB"] = env.get("SERVO_STYLE_THREAD_STACK_SIZE_KB", str(8 * 1024))
 
         return env
 

--- a/tests/wpt/mozilla/meta/MANIFEST.json
+++ b/tests/wpt/mozilla/meta/MANIFEST.json
@@ -15235,6 +15235,13 @@
       null,
       {}
      ]
+    ],
+    "set-innerHTML-in-deeply-nested-shadow-tree.html": [
+     "e26bbee95f2cee40f47a640bbd38420332d32f73",
+     [
+      null,
+      {}
+     ]
     ]
    },
    "webxr": {

--- a/tests/wpt/mozilla/tests/shadow-dom/set-innerHTML-in-deeply-nested-shadow-tree.html
+++ b/tests/wpt/mozilla/tests/shadow-dom/set-innerHTML-in-deeply-nested-shadow-tree.html
@@ -1,0 +1,27 @@
+<!doctype html>
+<meta charset="utf-8">
+<title>Set innerHTML in deeply nested shadow tree</title>
+<link rel="help" href="https://github.com/servo/servo/issues/43845">
+<link rel="author" title="Euclid Ye" href="mailto:yezhizhenjiakang@gmail.com">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+
+<div id="X"></div>
+
+<script>
+    test(() => {
+        let p = X;
+        for (let i = 0; i < 1549; i++) {
+            let x = document.createElement('div');
+            let r = x.attachShadow({
+                mode: 'open',
+                clonable: true
+            });
+            p.appendChild(x);
+            p = r;
+        }
+        p.innerHTML = "Hello!";
+        assert_equals(p.innerHTML, "Hello!",
+            "innerHTML should be set correctly on deeply nested shadow root without crashing");
+    }, "Setting innerHTML on a deeply nested shadow root works");
+</script>


### PR DESCRIPTION
TL;DR: We increase stack size of `ScriptThread` to 8MiB, and set Stylo stack size environment var
to 8 MiB for all builds. This only reserves virtual memory space which is
basically unlimited for 64-bit machine,
matches the recursion depth of Chromium for the example, which also uses 8MiB.

Stylo stack increase is necessary to prevent overflow when refreshing/navigating to the example,
probably because initial load restyle incrementally but not refresh.

Testing: Added a Servo-specific test.

---
For example in #43845, we get stack overflow when we got more than 394 nested shadow roots.
For Chromium, it happens for more than 1631: 
<img width="290" height="127" alt="image" src="https://github.com/user-attachments/assets/b3d75627-4e80-4586-9b85-4b58d8a0cd33" />
For Firefox, it overflows for more than 1052.

Initially I thought we didn't implement this optimally, and have unnecessary recursion depth.
But the real reason is explained in Rust std:
> The default stack size is platform-dependent and subject to change. Currently, it is 2 MiB on all Tier-1 platforms.

For Chromium, the visual studio dumpbin shows the stack size :
```
Dump of file C:\Program Files (x86)\Microsoft\Edge\Application\msedge.exe
OPTIONAL HEADER VALUES
          800000 size of stack reserve
```
This is hex value, which is $8*16^5$, exactly 8MiB.

After we make the same change in Servo, we are fine at 1601 and overflows at 1602.
This matches Chromium behaviour, defeating firefox, and should not create much overhead,
as this only reserves virtual memory space: 
I tried to increase the value to 512MiB, but task manager still says 73MB RAM used,
and we won't crash even with 10000 nested shadow roots. 
But that is just for more evidence and uncalled for.

Fixes: #43845
