### PR TITLE
stylo: Enable multiple color arguments in `color-mix()`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7272,7 +7272,7 @@ dependencies = [
 [[package]]
 name = "selectors"
 version = "0.37.0"
-source = "git+https://github.com/servo/stylo?rev=6cfce6f3293b5e13c2246838380e514b8b206a27#6cfce6f3293b5e13c2246838380e514b8b206a27"
+source = "git+https://github.com/servo/stylo?rev=ddf2109bdfff62c83a14e3a3c7dc1c6130653283#ddf2109bdfff62c83a14e3a3c7dc1c6130653283"
 dependencies = [
  "bitflags 2.11.0",
  "cssparser",
@@ -8920,7 +8920,7 @@ dependencies = [
 [[package]]
 name = "servo_arc"
 version = "0.4.3"
-source = "git+https://github.com/servo/stylo?rev=6cfce6f3293b5e13c2246838380e514b8b206a27#6cfce6f3293b5e13c2246838380e514b8b206a27"
+source = "git+https://github.com/servo/stylo?rev=ddf2109bdfff62c83a14e3a3c7dc1c6130653283#ddf2109bdfff62c83a14e3a3c7dc1c6130653283"
 dependencies = [
  "serde",
  "stable_deref_trait",
@@ -9340,7 +9340,7 @@ dependencies = [
 [[package]]
 name = "stylo"
 version = "0.16.0"
-source = "git+https://github.com/servo/stylo?rev=6cfce6f3293b5e13c2246838380e514b8b206a27#6cfce6f3293b5e13c2246838380e514b8b206a27"
+source = "git+https://github.com/servo/stylo?rev=ddf2109bdfff62c83a14e3a3c7dc1c6130653283#ddf2109bdfff62c83a14e3a3c7dc1c6130653283"
 dependencies = [
  "app_units",
  "arrayvec",
@@ -9396,7 +9396,7 @@ dependencies = [
 [[package]]
 name = "stylo_atoms"
 version = "0.16.0"
-source = "git+https://github.com/servo/stylo?rev=6cfce6f3293b5e13c2246838380e514b8b206a27#6cfce6f3293b5e13c2246838380e514b8b206a27"
+source = "git+https://github.com/servo/stylo?rev=ddf2109bdfff62c83a14e3a3c7dc1c6130653283#ddf2109bdfff62c83a14e3a3c7dc1c6130653283"
 dependencies = [
  "string_cache",
  "string_cache_codegen",
@@ -9405,7 +9405,7 @@ dependencies = [
 [[package]]
 name = "stylo_derive"
 version = "0.16.0"
-source = "git+https://github.com/servo/stylo?rev=6cfce6f3293b5e13c2246838380e514b8b206a27#6cfce6f3293b5e13c2246838380e514b8b206a27"
+source = "git+https://github.com/servo/stylo?rev=ddf2109bdfff62c83a14e3a3c7dc1c6130653283#ddf2109bdfff62c83a14e3a3c7dc1c6130653283"
 dependencies = [
  "darling",
  "proc-macro2",
@@ -9417,7 +9417,7 @@ dependencies = [
 [[package]]
 name = "stylo_dom"
 version = "0.16.0"
-source = "git+https://github.com/servo/stylo?rev=6cfce6f3293b5e13c2246838380e514b8b206a27#6cfce6f3293b5e13c2246838380e514b8b206a27"
+source = "git+https://github.com/servo/stylo?rev=ddf2109bdfff62c83a14e3a3c7dc1c6130653283#ddf2109bdfff62c83a14e3a3c7dc1c6130653283"
 dependencies = [
  "bitflags 2.11.0",
  "stylo_malloc_size_of",
@@ -9426,7 +9426,7 @@ dependencies = [
 [[package]]
 name = "stylo_malloc_size_of"
 version = "0.16.0"
-source = "git+https://github.com/servo/stylo?rev=6cfce6f3293b5e13c2246838380e514b8b206a27#6cfce6f3293b5e13c2246838380e514b8b206a27"
+source = "git+https://github.com/servo/stylo?rev=ddf2109bdfff62c83a14e3a3c7dc1c6130653283#ddf2109bdfff62c83a14e3a3c7dc1c6130653283"
 dependencies = [
  "app_units",
  "cssparser",
@@ -9443,12 +9443,12 @@ dependencies = [
 [[package]]
 name = "stylo_static_prefs"
 version = "0.16.0"
-source = "git+https://github.com/servo/stylo?rev=6cfce6f3293b5e13c2246838380e514b8b206a27#6cfce6f3293b5e13c2246838380e514b8b206a27"
+source = "git+https://github.com/servo/stylo?rev=ddf2109bdfff62c83a14e3a3c7dc1c6130653283#ddf2109bdfff62c83a14e3a3c7dc1c6130653283"
 
 [[package]]
 name = "stylo_traits"
 version = "0.16.0"
-source = "git+https://github.com/servo/stylo?rev=6cfce6f3293b5e13c2246838380e514b8b206a27#6cfce6f3293b5e13c2246838380e514b8b206a27"
+source = "git+https://github.com/servo/stylo?rev=ddf2109bdfff62c83a14e3a3c7dc1c6130653283#ddf2109bdfff62c83a14e3a3c7dc1c6130653283"
 dependencies = [
  "app_units",
  "bitflags 2.11.0",
@@ -9870,7 +9870,7 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 [[package]]
 name = "to_shmem"
 version = "0.3.0"
-source = "git+https://github.com/servo/stylo?rev=6cfce6f3293b5e13c2246838380e514b8b206a27#6cfce6f3293b5e13c2246838380e514b8b206a27"
+source = "git+https://github.com/servo/stylo?rev=ddf2109bdfff62c83a14e3a3c7dc1c6130653283#ddf2109bdfff62c83a14e3a3c7dc1c6130653283"
 dependencies = [
  "cssparser",
  "servo_arc",
@@ -9883,7 +9883,7 @@ dependencies = [
 [[package]]
 name = "to_shmem_derive"
 version = "0.1.0"
-source = "git+https://github.com/servo/stylo?rev=6cfce6f3293b5e13c2246838380e514b8b206a27#6cfce6f3293b5e13c2246838380e514b8b206a27"
+source = "git+https://github.com/servo/stylo?rev=ddf2109bdfff62c83a14e3a3c7dc1c6130653283#ddf2109bdfff62c83a14e3a3c7dc1c6130653283"
 dependencies = [
  "darling",
  "proc-macro2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -161,12 +161,12 @@ rustls-platform-verifier = "0.6.2"
 sea-query = { version = "1.0.0-rc.31", default-features = false, features = ["backend-sqlite", "derive"] }
 sea-query-rusqlite = { version = "0.8.0-rc.15" }
 sec1 = "0.7"
-selectors = { git = "https://github.com/servo/stylo", rev = "6cfce6f3293b5e13c2246838380e514b8b206a27" }
+selectors = { git = "https://github.com/servo/stylo", rev = "ddf2109bdfff62c83a14e3a3c7dc1c6130653283" }
 serde = "1.0.228"
 serde_bytes = "0.11"
 serde_core = "1.0.226"
 serde_json = "1.0"
-servo_arc = { git = "https://github.com/servo/stylo", rev = "6cfce6f3293b5e13c2246838380e514b8b206a27" }
+servo_arc = { git = "https://github.com/servo/stylo", rev = "ddf2109bdfff62c83a14e3a3c7dc1c6130653283" }
 sha1 = "0.10"
 sha2 = "0.10"
 sha3 = "0.10"
@@ -174,12 +174,12 @@ skrifa = "0.37.0"
 smallvec = { version = "1.15", features = ["serde", "union"] }
 string_cache = "0.9"
 strum = { version = "0.28", features = ["derive"] }
-stylo = { git = "https://github.com/servo/stylo", rev = "6cfce6f3293b5e13c2246838380e514b8b206a27" }
-stylo_atoms = { git = "https://github.com/servo/stylo", rev = "6cfce6f3293b5e13c2246838380e514b8b206a27" }
-stylo_dom = { git = "https://github.com/servo/stylo", rev = "6cfce6f3293b5e13c2246838380e514b8b206a27" }
-stylo_malloc_size_of = { git = "https://github.com/servo/stylo", rev = "6cfce6f3293b5e13c2246838380e514b8b206a27" }
-stylo_static_prefs = { git = "https://github.com/servo/stylo", rev = "6cfce6f3293b5e13c2246838380e514b8b206a27" }
-stylo_traits = { git = "https://github.com/servo/stylo", rev = "6cfce6f3293b5e13c2246838380e514b8b206a27" }
+stylo = { git = "https://github.com/servo/stylo", rev = "ddf2109bdfff62c83a14e3a3c7dc1c6130653283" }
+stylo_atoms = { git = "https://github.com/servo/stylo", rev = "ddf2109bdfff62c83a14e3a3c7dc1c6130653283" }
+stylo_dom = { git = "https://github.com/servo/stylo", rev = "ddf2109bdfff62c83a14e3a3c7dc1c6130653283" }
+stylo_malloc_size_of = { git = "https://github.com/servo/stylo", rev = "ddf2109bdfff62c83a14e3a3c7dc1c6130653283" }
+stylo_static_prefs = { git = "https://github.com/servo/stylo", rev = "ddf2109bdfff62c83a14e3a3c7dc1c6130653283" }
+stylo_traits = { git = "https://github.com/servo/stylo", rev = "ddf2109bdfff62c83a14e3a3c7dc1c6130653283" }
 surfman = { version = "0.11.0", features = ["chains"] }
 syn = { version = "2", default-features = false, features = ["clone-impls", "derive", "parsing"] }
 synstructure = "0.13"

--- a/tests/wpt/meta/css/css-color/parsing/color-computed-color-mix-function.html.ini
+++ b/tests/wpt/meta/css/css-color/parsing/color-computed-color-mix-function.html.ini
@@ -1,21 +1,3 @@
 [color-computed-color-mix-function.html]
   [Property color value 'color-mix(in srgb, red calc(50% + (sign(100em - 1px) * 10%)), blue)']
     expected: FAIL
-
-  [Property color value 'color-mix(in srgb, red)']
-    expected: FAIL
-
-  [Property color value 'color-mix(in srgb, red 50%)']
-    expected: FAIL
-
-  [Property color value 'color-mix(in srgb, red, green, blue)']
-    expected: FAIL
-
-  [Property color value 'color-mix(in srgb, red 50%, green 30%, blue 20%)']
-    expected: FAIL
-
-  [Property color value 'color-mix(in srgb, red 30%, green 60%, blue 90%)']
-    expected: FAIL
-
-  [Property color value 'color-mix(in srgb, red, green, blue, white)']
-    expected: FAIL

--- a/tests/wpt/meta/css/css-color/parsing/color-valid-color-mix-function.html.ini
+++ b/tests/wpt/meta/css/css-color/parsing/color-valid-color-mix-function.html.ini
@@ -1,36 +1,3 @@
 [color-valid-color-mix-function.html]
   [e.style['color'\] = "color-mix(in hsl, red calc(50% * sign(100em - 1px)), blue)" should set the property value]
     expected: FAIL
-
-  [e.style['color'\] = "color-mix(in srgb, red)" should set the property value]
-    expected: FAIL
-
-  [e.style['color'\] = "color-mix(in srgb, red 100%)" should set the property value]
-    expected: FAIL
-
-  [e.style['color'\] = "color-mix(in srgb, red 50%)" should set the property value]
-    expected: FAIL
-
-  [e.style['color'\] = "color-mix(in srgb, red, green, blue)" should set the property value]
-    expected: FAIL
-
-  [e.style['color'\] = "color-mix(in hsl, red, green, blue)" should set the property value]
-    expected: FAIL
-
-  [e.style['color'\] = "color-mix(in srgb, red 50%, green 30%, blue 20%)" should set the property value]
-    expected: FAIL
-
-  [e.style['color'\] = "color-mix(in srgb, red 30%, green 60%, blue 90%)" should set the property value]
-    expected: FAIL
-
-  [e.style['color'\] = "color-mix(in srgb, red 50%, green, blue)" should set the property value]
-    expected: FAIL
-
-  [e.style['color'\] = "color-mix(in srgb, red, green 25%, blue 25%)" should set the property value]
-    expected: FAIL
-
-  [e.style['color'\] = "color-mix(in srgb, red, green, blue, white)" should set the property value]
-    expected: FAIL
-
-  [e.style['color'\] = "color-mix(in srgb, currentcolor, red, blue)" should set the property value]
-    expected: FAIL


### PR DESCRIPTION
Bumps Stylo to https://github.com/servo/stylo/pull/348

Testing: 2 WPT improve