### PR TITLE
servoshell: Port from `sig` to `signal_hook_registry`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8975,7 +8975,7 @@ dependencies = [
  "servo-allocator",
  "servo-base",
  "servo-webdriver-server",
- "sig",
+ "signal-hook-registry",
  "surfman",
  "tokio",
  "tracing",
@@ -9040,15 +9040,6 @@ name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
-
-[[package]]
-name = "sig"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6567e29578f9bfade6a5d94a32b9a4256348358d2a3f448cab0021f9a02614a2"
-dependencies = [
- "libc",
-]
 
 [[package]]
 name = "signal-hook-registry"

--- a/ports/servoshell/Cargo.toml
+++ b/ports/servoshell/Cargo.toml
@@ -130,7 +130,7 @@ surfman = { workspace = true, features = ["sm-raw-window-handle-06", "sm-x11"] }
 winit = { workspace = true }
 
 [target.'cfg(any(all(target_os = "linux", not(target_env = "ohos")), target_os = "macos"))'.dependencies]
-sig = "1.0"
+signal-hook-registry = "1.4.8"
 
 [target.'cfg(target_os = "windows")'.dependencies]
 servo = { workspace = true, features = ["no-wgl"] }

--- a/ports/servoshell/crash_handler.rs
+++ b/ports/servoshell/crash_handler.rs
@@ -11,11 +11,9 @@ pub fn install() {
     use std::sync::atomic;
     use std::thread;
 
-    use sig::signal;
-
     use crate::backtrace;
 
-    extern "C" fn handler(sig: i32) {
+    fn handler(siginfo: &libc::siginfo_t) {
         // Only print crash message and backtrace the first time, to avoid
         // infinite recursion if the printing causes another signal.
         static BEEN_HERE_BEFORE: atomic::AtomicBool = atomic::AtomicBool::new(false);
@@ -26,7 +24,7 @@ pub fn install() {
             // practice will often segfault (see below).
             let stderr = std::io::stderr();
             let mut stderr = stderr.lock();
-            let _ = write!(&mut stderr, "Caught signal {sig}");
+            let _ = write!(&mut stderr, "Caught signal {}", siginfo.si_signo);
             if let Some(name) = thread::current().name() {
                 let _ = write!(&mut stderr, " in thread \"{}\"", name);
             }
@@ -42,13 +40,19 @@ pub fn install() {
         // know to be “async-signal-safe”, which includes sigaction(), raise(),
         // and _exit(), but generally doesn’t include anything that allocates.
         // https://pubs.opengroup.org/onlinepubs/9699919799/functions/V2_chap02.html#tag_15_04_03_03
-        raise_signal_or_exit_with_error(sig);
+        raise_signal_or_exit_with_error(siginfo.si_signo);
     }
 
-    signal!(libc::SIGSEGV, handler); // handle segfaults
-    signal!(libc::SIGILL, handler); // handle stack overflow and unsupported CPUs
-    signal!(libc::SIGIOT, handler); // handle double panics
-    signal!(libc::SIGBUS, handler); // handle invalid memory access
+    unsafe {
+        signal_hook_registry::register_unchecked(libc::SIGSEGV, handler)
+            .expect("Could not register signal"); // handle segfaults
+        signal_hook_registry::register_unchecked(libc::SIGILL, handler)
+            .expect("Could not register signal"); // handle stack overflow and unsupported CPUs
+        signal_hook_registry::register_unchecked(libc::SIGIOT, handler)
+            .expect("Could not register signal"); // handle double panics
+        signal_hook_registry::register_unchecked(libc::SIGBUS, handler)
+            .expect("Could not register signal"); // handle invalid memory access
+    }
 }
 
 #[cfg(not(any(target_os = "macos", target_os = "linux", target_os = "android")))]

--- a/ports/servoshell/crash_handler.rs
+++ b/ports/servoshell/crash_handler.rs
@@ -11,9 +11,11 @@ pub fn install() {
     use std::sync::atomic;
     use std::thread;
 
+    use libc::siginfo_t;
+
     use crate::backtrace;
 
-    fn handler(siginfo: &libc::siginfo_t) {
+    fn handler(siginfo: &siginfo_t) {
         // Only print crash message and backtrace the first time, to avoid
         // infinite recursion if the printing causes another signal.
         static BEEN_HERE_BEFORE: atomic::AtomicBool = atomic::AtomicBool::new(false);
@@ -45,13 +47,13 @@ pub fn install() {
 
     unsafe {
         signal_hook_registry::register_unchecked(libc::SIGSEGV, handler)
-            .expect("Could not register signal"); // handle segfaults
+            .expect("Could not register SIGSEGV handler");
         signal_hook_registry::register_unchecked(libc::SIGILL, handler)
-            .expect("Could not register signal"); // handle stack overflow and unsupported CPUs
+            .expect("Could not register SIGILL handler");
         signal_hook_registry::register_unchecked(libc::SIGIOT, handler)
-            .expect("Could not register signal"); // handle double panics
+            .expect("Could not register SIGIOT handler");
         signal_hook_registry::register_unchecked(libc::SIGBUS, handler)
-            .expect("Could not register signal"); // handle invalid memory access
+            .expect("Could not register SIGBUS handler");
     }
 }
 


### PR DESCRIPTION

Testing: We do not currently have a way to test signal handling in the servoshell binary, so this change does not include tests.
Fixes: #43836
