### PR TITLE
servo: Fix rustdoc warnings

### DIFF
--- a/components/servo/clipboard_delegate.rs
+++ b/components/servo/clipboard_delegate.rs
@@ -122,10 +122,10 @@ mod clipboard {
     use super::StringRequest;
     use crate::clipboard_delegate::fallback_clipboard;
 
-    /// A shared clipboard for use by the [`DefaultClipboardDelegate`]. This is protected by
-    /// a mutex so that it can only be used by one thread at a time. The `arboard` documentation
-    /// suggests that more than one thread shouldn't try to access the Windows clipboard at a
-    /// time. See <https://docs.rs/arboard/latest/arboard/struct.Clipboard.html>.
+    /// A shared clipboard for use by the [`DefaultClipboardDelegate`](super::DefaultClipboardDelegate).
+    /// This is protected by a mutex so that it can only be used by one thread at a time.
+    /// The `arboard` documentation suggests that more than one thread shouldn't try to access
+    /// the Windows clipboard at a time. See <https://docs.rs/arboard/latest/arboard/struct.Clipboard.html>.
     static SHARED_CLIPBOARD: OnceLock<Option<Mutex<Clipboard>>> = OnceLock::new();
 
     fn with_shared_clipboard<ResultType>(

--- a/components/servo/responders.rs
+++ b/components/servo/responders.rs
@@ -28,7 +28,7 @@ impl ServoErrorSender {
     }
 }
 
-/// Channel for errors raised by [`WebViewDelegate`] request objects.
+/// Channel for errors raised by [`WebViewDelegate`](crate::WebViewDelegate) request objects.
 ///
 /// This allows errors to be raised asynchronously.
 pub(crate) struct ServoErrorChannel {

--- a/components/servo/servo_delegate.rs
+++ b/components/servo/servo_delegate.rs
@@ -32,14 +32,16 @@ pub trait ServoDelegate {
     /// [`WebResourceLoad::intercept`]. If not handled, the load will continue as normal.
     ///
     /// Note: This delegate method is called for all resource loads not associated with a
-    /// [`WebView`].  For loads associated with a [`WebView`], Servo  will call
-    /// [`crate::WebViewDelegate::load_web_resource`].
+    /// [`WebView`](crate::WebView).  For loads associated with a [`WebView`](crate::WebView),
+    /// Servo  will call [`crate::WebViewDelegate::load_web_resource`].
     fn load_web_resource(&self, _load: WebResourceLoad) {}
 
     /// Request to display a notification.
     fn show_notification(&self, _notification: Notification) {}
 
-    /// A console message was logged by content not associated with a specific [`WebView`].
+    /// A console message was logged by content not associated with a specific
+    /// [`WebView`](crate::WebView).
+    ///
     /// <https://developer.mozilla.org/en-US/docs/Web/API/Console_API>
     fn show_console_message(&self, _level: ConsoleLogLevel, _message: String) {}
 }

--- a/components/servo/webview.rs
+++ b/components/servo/webview.rs
@@ -55,8 +55,8 @@ pub(crate) const MINIMUM_WEBVIEW_SIZE: Size2D<i32, DevicePixel> = Size2D::new(1,
 ///
 /// ## Rendering Model
 ///
-/// Every [`WebView`] has a [`RenderingContext`](crate::RenderingContext). The embedder manages when
-/// the contents of the [`WebView`] paint to the [`RenderingContext`](crate::RenderingContext). When
+/// Every [`WebView`] has a [`RenderingContext`]. The embedder manages when
+/// the contents of the [`WebView`] paint to the [`RenderingContext`]. When
 /// a [`WebView`] needs to be painted, for instance, because its contents have changed, Servo will
 /// call [`WebViewDelegate::notify_new_frame_ready`] in order to signal that it is time to repaint
 /// the [`WebView`] using [`WebView::paint`].
@@ -66,8 +66,8 @@ pub(crate) const MINIMUM_WEBVIEW_SIZE: Size2D<i32, DevicePixel> = Size2D::new(1,
 /// 1. [`WebViewDelegate::notify_new_frame_ready`] is called. The applications triggers a request
 ///    to repaint the window that contains this [`WebView`].
 /// 2. During window repainting, the application calls [`WebView::paint`] and the contents of the
-///    [`RenderingContext`][crate::RenderingContext] are updated.
-/// 3. If the [`RenderingContext`][crate::RenderingContext] is double-buffered, the
+///    [`RenderingContext`] are updated.
+/// 3. If the [`RenderingContext`] is double-buffered, the
 ///    application then calls [`crate::RenderingContext::present()`] in order to swap the back buffer
 ///    to the front, finally displaying the updated [`WebView`] contents.
 ///

--- a/components/servo/webview_delegate.rs
+++ b/components/servo/webview_delegate.rs
@@ -235,6 +235,7 @@ impl WebResourceLoad {
     pub fn request(&self) -> &WebResourceRequest {
         &self.request
     }
+
     /// Intercept this [`WebResourceLoad`] and control the response via the returned
     /// [`InterceptedWebResourceLoad`].
     pub fn intercept(mut self, response: WebResourceResponse) -> InterceptedWebResourceLoad {
@@ -434,7 +435,7 @@ impl SelectElement {
     }
 
     /// Consecutive `<option>` elements outside of an `<optgroup>` will be combined
-    /// into a single anonymous group, whose [`label`](SelectElementGroup::label) is `None`.
+    /// into a single anonymous group without a label.
     pub fn options(&self) -> &[SelectElementOptionOrOptgroup] {
         &self.options
     }
@@ -451,7 +452,7 @@ impl SelectElement {
         self.selected_option
     }
 
-    /// Resolve the prompt with the options that have been selected by calling [select] previously.
+    /// Resolve the prompt with the options that have been selected by calling [`Self::select`] previously.
     pub fn submit(mut self) {
         self.response_sent = true;
         self.constellation_proxy
@@ -506,7 +507,7 @@ impl ColorPicker {
         self.current_color = color;
     }
 
-    /// Resolve the prompt with the options that have been selected by calling [select] previously.
+    /// Resolve the prompt with the options that have been selected by calling [`Self::select`] previously.
     pub fn submit(mut self) {
         self.response_sent = true;
         self.constellation_proxy
@@ -560,7 +561,7 @@ impl FilePicker {
         self.file_picker_request.current_paths = paths.to_owned();
     }
 
-    /// Resolve the prompt with the options that have been selected by calling [select] previously.
+    /// Resolve the prompt with the options that have been selected by calling [`Self::select`] previously.
     pub fn submit(mut self) {
         if let Some(sender) = self.response_sender.take() {
             let _ = sender.send(Some(std::mem::take(
@@ -796,7 +797,7 @@ impl Drop for ConfirmDialog {
 /// The prompt dialog is expected to be represented by a mesage, a text entry field, and
 /// an "Ok" and "Cancel" buttons. When "Ok" is selected the current prompt value is sent
 /// as the response to the DOM API. A default value may be sent with the [`PromptDialog`],
-/// which be be retrieved by calling [`Self::current_value`]. Before calling [`Self::ok`]
+/// which be be retrieved by calling [`Self::current_value`]. Before calling [`Self::confirm`]
 /// or as the prompt field changes, the embedder is expected to call
 /// [`Self::set_current_value`].
 pub struct PromptDialog {
@@ -886,7 +887,7 @@ pub trait WebViewDelegate {
     /// cursor can accessed via [`WebView::cursor`].
     fn notify_cursor_changed(&self, _webview: WebView, _: Cursor) {}
     /// The favicon of the currently loaded page in this [`WebView`] has changed. The new
-    /// favicon [`Image`] can accessed via [`WebView::favicon`].
+    /// favicon [`Image`](embedder_traits::Image) can accessed via [`WebView::favicon`].
     fn notify_favicon_changed(&self, _webview: WebView) {}
     /// Notify the embedder that it needs to present a new frame.
     fn notify_new_frame_ready(&self, _webview: WebView) {}


### PR DESCRIPTION
One warning remains:
```
warning: public documentation for `intercept` links to private item `InterceptedWebResourceLoad`
   --> components/servo/webview_delegate.rs:240:11
    |
240 |     /// [`InterceptedWebResourceLoad`].
    |           ^^^^^^^^^^^^^^^^^^^^^^^^^^ this item is private
    |
    = note: this link resolves only because you passed `--document-private-items`, but will break without
    = note: `#[warn(rustdoc::private_intra_doc_links)]` on by default

warning: `servo` (lib doc) generated 1 warning
```

I think that's a false positive, because `InterceptedWebResourceLoad` *is* public.

Testing: We don't run `./mach doc` in CI, so there's no way to test this