### PR TITLE
servo: Remove `WebViewDelegate::play_gamepad_haptic_effect` and `WebViewDelegate::stop_gamepad_haptic_effect`

### DIFF
--- a/components/servo/webview_delegate.rs
+++ b/components/servo/webview_delegate.rs
@@ -5,8 +5,6 @@
 use std::path::PathBuf;
 use std::rc::Rc;
 
-#[cfg(feature = "gamepad")]
-use embedder_traits::GamepadHapticEffectType;
 use embedder_traits::{
     AlertResponse, AllowOrDeny, AuthenticationResponse, BluetoothDeviceDescription,
     ConfirmResponse, ConsoleLogLevel, ContextMenuAction, ContextMenuElementInformation,
@@ -987,24 +985,6 @@ pub trait WebViewDelegate {
     ///
     /// After this point, any further responses to that request will be ignored.
     fn hide_embedder_control(&self, _webview: WebView, _control_id: EmbedderControlId) {}
-
-    /// Request to play a haptic effect on a connected gamepad. The embedder is expected to
-    /// call the provided callback when the effect is complete with `true` for success
-    /// and `false` for failure.
-    #[cfg(feature = "gamepad")]
-    fn play_gamepad_haptic_effect(
-        &self,
-        _webview: WebView,
-        _: usize,
-        _: GamepadHapticEffectType,
-        _: Box<dyn FnOnce(bool)>,
-    ) {
-    }
-    /// Request to stop a haptic effect on a connected gamepad. The embedder is expected to
-    /// call the provided callback when the effect is complete with `true` for success
-    /// and `false` for failure.
-    #[cfg(feature = "gamepad")]
-    fn stop_gamepad_haptic_effect(&self, _webview: WebView, _: usize, _: Box<dyn FnOnce(bool)>) {}
 
     /// Triggered when this [`WebView`] will load a web (HTTP/HTTPS) resource. The load may be
     /// intercepted and alternate contents can be loaded by the client by calling


### PR DESCRIPTION
This functionality was moved to the `GamepadDelegate`, but the old
delegate methods were never removed. They are currently unused.

Testing: This change just removes dead code, so no tests are necessary.
Fixes: #43743
