### PR TITLE
devtools: Replace new with register for ConsoleActor

### DIFF
--- a/components/devtools/actors/console.rs
+++ b/components/devtools/actors/console.rs
@@ -270,13 +270,15 @@ pub(crate) struct ConsoleActor {
 }
 
 impl ConsoleActor {
-    pub fn new(name: String, root: Root) -> Self {
-        Self {
-            name,
+    pub fn register(registry: &ActorRegistry, name: String, root: Root) -> String {
+        let actor = Self {
+            name: name.clone(),
             root,
             cached_events: Default::default(),
             client_ready_to_receive_messages: false.into(),
-        }
+        };
+        registry.register(actor);
+        name
     }
 
     fn script_chan(&self, registry: &ActorRegistry) -> GenericSender<DevtoolScriptControlMsg> {

--- a/components/devtools/lib.rs
+++ b/components/devtools/lib.rs
@@ -540,9 +540,7 @@ impl DevtoolsInstance {
             Root::BrowsingContext(browsing_context_name.clone())
         };
 
-        let console_actor = ConsoleActor::new(console_name, parent_actor);
-
-        self.registry.register(console_actor);
+        ConsoleActor::register(&self.registry, console_name, parent_actor);
     }
 
     fn handle_title_changed(&self, pipeline_id: PipelineId, title: String) {


### PR DESCRIPTION
Replace new with register for ConsoleActor in console & lib.rs

Testing: No testing required, compiles successfully.
Fixes: Part of #43800