### PR TITLE
fonts: Clean up application of `word-spacing`

### DIFF
--- a/components/fonts/font.rs
+++ b/components/fonts/font.rs
@@ -389,7 +389,7 @@ pub struct ShapingOptions {
     /// determine the amount of spacing to apply.
     pub letter_spacing: Option<Au>,
     /// Spacing to add between each word. Corresponds to the CSS 2.1 `word-spacing` property.
-    pub word_spacing: Au,
+    pub word_spacing: Option<Au>,
     /// The Unicode script property of the characters in this run.
     pub script: Script,
     /// The preferred language, obtained from the `lang` attribute.
@@ -478,26 +478,22 @@ impl Font {
                 continue;
             };
 
-            let mut advance = advance_for_shaped_glyph(
-                Au::from_f64_px(self.glyph_h_advance(glyph_id)),
-                character,
-                options,
-            );
+            let mut advance = Au::from_f64_px(self.glyph_h_advance(glyph_id));
             let offset = prev_glyph_id.map(|prev| {
                 let h_kerning = Au::from_f64_px(self.glyph_h_kerning(prev, glyph_id));
                 advance += h_kerning;
                 Point2D::new(h_kerning, Au::zero())
             });
 
-            glyph_store.add_glyph(
-                character,
-                &ShapedGlyph {
-                    glyph_id,
-                    string_byte_offset,
-                    advance,
-                    offset,
-                },
-            );
+            let mut glyph = ShapedGlyph {
+                glyph_id,
+                string_byte_offset,
+                advance,
+                offset,
+            };
+            glyph.adjust_for_character(character, options, self);
+
+            glyph_store.add_glyph(character, &glyph);
             prev_glyph_id = Some(glyph_id);
         }
         glyph_store
@@ -981,26 +977,4 @@ pub(crate) fn map_platform_values_to_style_values(mapping: &[(f64, f64)], value:
     }
 
     mapping[mapping.len() - 1].1
-}
-
-/// Computes the total advance for a glyph, taking `letter-spacing` and `word-spacing` into account.
-pub(super) fn advance_for_shaped_glyph(
-    mut advance: Au,
-    character: char,
-    options: &ShapingOptions,
-) -> Au {
-    if let Some(letter_spacing) = options.letter_spacing_for_character(character) {
-        advance += letter_spacing;
-    };
-
-    // CSS 2.1 § 16.4 states that "word spacing affects each space (U+0020) and non-breaking
-    // space (U+00A0) left in the text after the white space processing rules have been
-    // applied. The effect of the property on other word-separator characters is undefined."
-    // We elect to only space the two required code points.
-    if character == ' ' || character == '\u{a0}' {
-        // https://drafts.csswg.org/css-text-3/#word-spacing-property
-        advance += options.word_spacing;
-    }
-
-    advance
 }

--- a/components/fonts/glyph.rs
+++ b/components/fonts/glyph.rs
@@ -540,7 +540,7 @@ impl ShapedGlyph {
     /// TODO: This should all likely move to layout. In particular, proper tab stops
     /// are context sensitive and be based on the size of the space character in the
     /// inline formatting context.
-    fn adjust_for_character(
+    pub(crate) fn adjust_for_character(
         &mut self,
         character: char,
         shaping_options: &ShapingOptions,
@@ -561,9 +561,11 @@ impl ShapedGlyph {
         // space (U+00A0) left in the text after the white space processing rules have been
         // applied. The effect of the property on other word-separator characters is undefined."
         // We elect to only space the two required code points.
-        if character == ' ' || character == '\u{a0}' {
-            // https://drafts.csswg.org/css-text-3/#word-spacing-property
-            self.advance += shaping_options.word_spacing;
+        if let Some(word_spacing) = shaping_options.word_spacing {
+            if character == ' ' || character == '\u{a0}' {
+                // https://drafts.csswg.org/css-text-3/#word-spacing-property
+                self.advance += word_spacing;
+            }
         }
     }
 }

--- a/components/fonts/tests/font.rs
+++ b/components/fonts/tests/font.rs
@@ -77,7 +77,7 @@ fn test_font_can_do_fast_shaping() {
     // Fast shaping requires a font with a kern table and no GPOS or GSUB tables.
     let shaping_options = ShapingOptions {
         letter_spacing: None,
-        word_spacing: Au::zero(),
+        word_spacing: None,
         script: Script::Latin,
         language: Language::UND,
         flags: ShapingFlags::empty(),
@@ -88,7 +88,7 @@ fn test_font_can_do_fast_shaping() {
     // Non-Latin script should never have fast shaping.
     let shaping_options = ShapingOptions {
         letter_spacing: None,
-        word_spacing: Au::zero(),
+        word_spacing: None,
         script: Script::Cherokee,
         language: Language::UND,
         flags: ShapingFlags::empty(),
@@ -99,7 +99,7 @@ fn test_font_can_do_fast_shaping() {
     // Right-to-left text should never use fast shaping.
     let shaping_options = ShapingOptions {
         letter_spacing: None,
-        word_spacing: Au::zero(),
+        word_spacing: None,
         script: Script::Latin,
         language: Language::UND,
         flags: ShapingFlags::RTL_FLAG,

--- a/components/layout/flow/inline/text_run.rs
+++ b/components/layout/flow/inline/text_run.rs
@@ -398,9 +398,7 @@ impl TextRun {
             flags.insert(ShapingFlags::IGNORE_LIGATURES_SHAPING_FLAG);
             flags.insert(ShapingFlags::DISABLE_KERNING_SHAPING_FLAG)
         }
-
-        let specified_word_spacing = &inherited_text_style.word_spacing;
-        let style_word_spacing: Option<Au> = specified_word_spacing.to_length().map(|l| l.into());
+        let word_spacing = inherited_text_style.word_spacing.to_length().map(Au::from);
 
         let segments = self
             .segment_text_by_font(
@@ -411,14 +409,16 @@ impl TextRun {
             )
             .into_iter()
             .map(|mut segment| {
-                let word_spacing = style_word_spacing.unwrap_or_else(|| {
+                let word_spacing = word_spacing.unwrap_or_else(|| {
                     let space_width = segment
                         .info
                         .font
                         .glyph_index(' ')
                         .map(|glyph_id| segment.info.font.glyph_h_advance(glyph_id))
                         .unwrap_or(LAST_RESORT_GLYPH_ADVANCE);
-                    specified_word_spacing.to_used_value(Au::from_f64_px(space_width))
+                    inherited_text_style
+                        .word_spacing
+                        .to_used_value(Au::from_f64_px(space_width))
                 });
 
                 let mut flags = flags;
@@ -440,7 +440,7 @@ impl TextRun {
 
                 let shaping_options = ShapingOptions {
                     letter_spacing,
-                    word_spacing,
+                    word_spacing: Some(word_spacing),
                     script: segment.info.script,
                     language,
                     flags,

--- a/components/script/dom/canvas/2d/canvas_state.rs
+++ b/components/script/dom/canvas/2d/canvas_state.rs
@@ -13,8 +13,8 @@ use cssparser::{Parser, ParserInput};
 use euclid::default::{Point2D, Rect, Size2D, Transform2D};
 use euclid::{Vector2D, vec2};
 use fonts::{
-    FontBaseline, FontContext, FontGroup, FontIdentifier, FontMetrics, FontRef,
-    LAST_RESORT_GLYPH_ADVANCE, ShapingFlags, ShapingOptions,
+    FontBaseline, FontContext, FontGroup, FontIdentifier, FontMetrics, FontRef, ShapingFlags,
+    ShapingOptions,
 };
 use icu_locid::subtags::Language;
 use js::context::JSContext;
@@ -2486,14 +2486,9 @@ impl UnshapedTextRun<'_> {
         debug_assert!(!self.string.is_empty() && self.font.is_some());
         let font = self.font?;
 
-        let word_spacing = Au::from_f64_px(
-            font.glyph_index(' ')
-                .map(|glyph_id| font.glyph_h_advance(glyph_id))
-                .unwrap_or(LAST_RESORT_GLYPH_ADVANCE),
-        );
         let options = ShapingOptions {
             letter_spacing: None,
-            word_spacing,
+            word_spacing: None,
             script: self.script,
             language: self.language,
             flags: ShapingFlags::empty(),

--- a/tests/wpt/meta/html/canvas/element/text/2d.text.draw.space.basic.html.ini
+++ b/tests/wpt/meta/html/canvas/element/text/2d.text.draw.space.basic.html.ini
@@ -1,3 +1,0 @@
-[2d.text.draw.space.basic.html]
-  [U+0020 is rendered the correct size (1em wide)]
-    expected: FAIL

--- a/tests/wpt/meta/html/canvas/element/text/2d.text.draw.space.collapse.end.html.ini
+++ b/tests/wpt/meta/html/canvas/element/text/2d.text.draw.space.collapse.end.html.ini
@@ -1,3 +1,0 @@
-[2d.text.draw.space.collapse.end.html]
-  [Space characters at the end of a line are NOT collapsed]
-    expected: FAIL

--- a/tests/wpt/meta/html/canvas/element/text/2d.text.draw.space.collapse.nonspace.html.ini
+++ b/tests/wpt/meta/html/canvas/element/text/2d.text.draw.space.collapse.nonspace.html.ini
@@ -1,3 +1,0 @@
-[2d.text.draw.space.collapse.nonspace.html]
-  [Non-space characters are not converted to U+0020 and collapsed]
-    expected: FAIL

--- a/tests/wpt/meta/html/canvas/element/text/2d.text.draw.space.collapse.start.html.ini
+++ b/tests/wpt/meta/html/canvas/element/text/2d.text.draw.space.collapse.start.html.ini
@@ -1,3 +1,0 @@
-[2d.text.draw.space.collapse.start.html]
-  [Space characters at the start of a line are NOT collapsed]
-    expected: FAIL

--- a/tests/wpt/meta/html/canvas/element/text/2d.text.measure.actualBoundingBox.whitespace.html.ini
+++ b/tests/wpt/meta/html/canvas/element/text/2d.text.measure.actualBoundingBox.whitespace.html.ini
@@ -1,3 +1,0 @@
-[2d.text.measure.actualBoundingBox.whitespace.html]
-  [Testing actualBoundingBox with leading/trailing whitespace]
-    expected: FAIL

--- a/tests/wpt/meta/html/canvas/element/text/2d.text.measure.width.space.html.ini
+++ b/tests/wpt/meta/html/canvas/element/text/2d.text.measure.width.space.html.ini
@@ -1,3 +1,0 @@
-[2d.text.measure.width.space.html]
-  [Space characters are converted to U+0020 and NOT collapsed]
-    expected: FAIL


### PR DESCRIPTION
Let `word_spacing` be optional in `ShapingOptions` like
`letter_spacing`. In addition, send `None` for Canvas rendering instead
of the width of the space character. It is supposed to represent *extra*
space added between words. Finally, remove duplicated code that applied
word and letter spacing for the fast shaper. This can just reuse the
code from the Harfbuzz shaper.

Testing: This causes some canvas tests to start passing.
