### PR TITLE
Don’t print passing unit tests

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -1,6 +1,7 @@
 [profile.default]
 # Print a slow warning after period, terminate unit-test after 4x period.
 slow-timeout = { period = "5s", terminate-after = 4 }
+status-level = "leak"
 
 [profile.ci]
 fail-fast = false


### PR DESCRIPTION
This removes from the output of `./mach test-unit` hundreds of lines like:

```
        PASS [   0.011s] style_tests str::test_str_join_empty
```