### PR TITLE
script: Modernize the `HTMLElement` WebIDL

### DIFF
--- a/components/script/dom/svg/svgelement.rs
+++ b/components/script/dom/svg/svgelement.rs
@@ -19,6 +19,7 @@ use crate::dom::css::cssstyledeclaration::{
     CSSModificationAccess, CSSStyleDeclaration, CSSStyleOwner,
 };
 use crate::dom::document::Document;
+use crate::dom::document::focus::{FocusInitiator, FocusOperation, FocusableArea};
 use crate::dom::element::{AttributeMutation, Element};
 use crate::dom::node::{Node, NodeTraits};
 use crate::dom::scrolling_box::{ScrollAxisState, ScrollRequirement};
@@ -177,6 +178,21 @@ impl SVGElementMethods<crate::DomTypeHolder> for SVGElement {
                 None,
             );
         }
+    }
+
+    /// <https://html.spec.whatwg.org/multipage/#dom-blur>
+    fn Blur(&self, cx: &mut js::context::JSContext) {
+        // TODO: Run the unfocusing steps. Focus the top-level document, not
+        //       the current document.
+        if !self.as_element().focus_state() {
+            return;
+        }
+        // https://html.spec.whatwg.org/multipage/#unfocusing-steps
+        self.owner_document().focus_handler().focus(
+            FocusOperation::Focus(FocusableArea::Viewport),
+            FocusInitiator::Local,
+            CanGc::from_cx(cx),
+        );
     }
 
     /// <https://html.spec.whatwg.org/multipage/#dom-tabindex>

--- a/components/script_bindings/codegen/Bindings.conf
+++ b/components/script_bindings/codegen/Bindings.conf
@@ -774,7 +774,7 @@ DOMInterfaces = {
 
 'SVGElement': {
     'canGc': ['Focus', 'SetAutofocus', 'SetTabIndex'],
-    'cx': ['Focus'],
+    'cx': ['Blur', 'Focus'],
 },
 
 #FIXME(jdm): This should be 'register': False, but then we don't generate enum types

--- a/components/script_bindings/webidls/HTMLElement.webidl
+++ b/components/script_bindings/webidls/HTMLElement.webidl
@@ -8,58 +8,51 @@ interface HTMLElement : Element {
   [HTMLConstructor] constructor();
 
   // metadata attributes
-  [CEReactions]
-           attribute DOMString title;
-  [CEReactions]
-           attribute DOMString lang;
-  [CEReactions]
-           attribute boolean translate;
-  [CEReactions]
-           attribute DOMString dir;
+  [CEReactions] attribute DOMString title;
+  [CEReactions] attribute DOMString lang;
+  [CEReactions] attribute boolean translate;
+  [CEReactions] attribute DOMString dir;
   readonly attribute DOMStringMap dataset;
 
-  // microdata
-  //         attribute boolean itemScope;
-
-  //         attribute DOMString itemId;
-  //readonly attribute HTMLPropertiesCollection properties;
-  //         attribute any itemValue; // acts as DOMString on setting
   [Pref="dom_microdata_testing_enabled"]
   sequence<DOMString>? propertyNames();
   [Pref="dom_microdata_testing_enabled"]
   sequence<DOMString>? itemtypes();
 
   // user interaction
-  [CEReactions]
-           attribute boolean hidden;
+  [CEReactions] attribute boolean hidden;
+  // [CEReactions, Reflect] attribute boolean inert;
   undefined click();
-  // [CEReactions]
-  //         attribute long tabIndex;
-  undefined blur();
-  [CEReactions]
-            attribute DOMString accessKey;
+  [CEReactions] attribute DOMString accessKey;
   readonly attribute DOMString accessKeyLabel;
-  // [CEReactions]
-  //         attribute boolean draggable;
-  // [SameObject, PutForwards=value] readonly attribute DOMTokenList dropzone;
-  //         attribute HTMLMenuElement? contextMenu;
-  // [CEReactions]
-  //         attribute boolean spellcheck;
-  // void forceSpellCheck();
+  // [CEReactions] attribute boolean draggable;
+  // [CEReactions] attribute boolean spellcheck;
+  // [CEReactions, ReflectSetter] attribute DOMString writingSuggestions;
+  // [CEReactions, ReflectSetter] attribute DOMString autocapitalize;
+  // [CEReactions] attribute boolean autocorrect;
 
   [CEReactions] attribute [LegacyNullToEmptyString] DOMString innerText;
   [CEReactions, Throws] attribute [LegacyNullToEmptyString] DOMString outerText;
 
   [Throws] ElementInternals attachInternals();
 
-  // command API
-  // readonly attribute DOMString? commandType;
-  // readonly attribute DOMString? commandLabel;
-  // readonly attribute DOMString? commandIcon;
-  // readonly attribute boolean? commandHidden;
-  // readonly attribute boolean? commandDisabled;
-  // readonly attribute boolean? commandChecked;
+  // The popover API
+  // undefined showPopover(optional ShowPopoverOptions options = {});
+  // undefined hidePopover();
+  // boolean togglePopover(optional (TogglePopoverOptions or boolean) options = {});
+  // [CEReactions] attribute DOMString? popover;
+
+  // [CEReactions, Reflect, ReflectRange=(0, 8)] attribute unsigned long headingOffset;
+  // [CEReactions, Reflect] attribute boolean headingReset;
 };
+
+// dictionary ShowPopoverOptions {
+//   HTMLElement source;
+// };
+//
+// dictionary TogglePopoverOptions : ShowPopoverOptions {
+//   boolean force;
+// };
 
 // http://dev.w3.org/csswg/cssom-view/#extensions-to-the-htmlelement-interface
 partial interface HTMLElement {

--- a/components/script_bindings/webidls/HTMLOrSVGElement.webidl
+++ b/components/script_bindings/webidls/HTMLOrSVGElement.webidl
@@ -21,5 +21,5 @@ interface mixin HTMLOrSVGElement {
   [CEReactions] attribute boolean autofocus;
   [CEReactions] attribute long tabIndex;
   undefined focus(optional FocusOptions options = {});
-  // undefined blur();
+  undefined blur();
 };

--- a/tests/wpt/meta/html/dom/idlharness.https.html.ini
+++ b/tests/wpt/meta/html/dom/idlharness.https.html.ini
@@ -4691,9 +4691,6 @@
   [SVGElement interface: attribute dataset]
     expected: FAIL
 
-  [SVGElement interface: operation blur()]
-    expected: FAIL
-
   [SVGSVGElement interface: attribute onafterprint]
     expected: FAIL
 


### PR DESCRIPTION
The WebIDL file for `HTMLElement` was quite out of date. This change
makes it match the current HTML specification and also moves `blur()` to
`HTMLOrSVGElement` as it is in the spec. The implementation is just a
copy of the one for `HTMLElement` as we do for `focus()`.

Testing: This should not change behavior (other than adding a `blur()` method
for SVG -- which we don't support), so should be covered by existing tests.
