### PR TITLE
paint: Anchor the minimum value of clamp to the initial scale

### DIFF
--- a/components/servo/tests/webview.rs
+++ b/components/servo/tests/webview.rs
@@ -498,6 +498,45 @@ fn test_viewport_meta_tag_initial_scale() {
 }
 
 #[test]
+fn test_viewport_clamp_pinch_min_by_initial_scale() {
+    let servo_test = ServoTest::new_with_builder(|builder| {
+        let mut preferences = Preferences::default();
+        preferences.viewport_meta_enabled = true;
+        preferences.dom_visual_viewport_enabled = true;
+        builder.preferences(preferences)
+    });
+
+    let initial_scale: f64 = 1.0;
+
+    let delegate = Rc::new(WebViewDelegateImpl::default());
+    let webview = WebViewBuilder::new(servo_test.servo(), servo_test.rendering_context.clone())
+        .delegate(delegate.clone())
+        .url(
+            Url::parse(
+                format!(
+                    "data:text/html,\
+                    <!DOCTYPE html>\
+                    <meta name=viewport content=\"initial-scale={}, minimum-scale=1.0\">",
+                    initial_scale
+                )
+                .as_str(),
+            )
+            .unwrap(),
+        )
+        .build();
+
+    show_webview_and_wait_for_rendering_to_be_ready(&servo_test, &webview, &delegate);
+
+    webview.adjust_pinch_zoom(0.5, DevicePoint::new(100., 100.));
+    wait_for_webview_scene_to_be_up_to_date(&servo_test, &webview);
+
+    assert_eq!(
+        Ok(JSValue::Number(initial_scale)),
+        evaluate_javascript(&servo_test, webview.clone(), "window.visualViewport.scale;")
+    );
+}
+
+#[test]
 fn test_show_and_hide_ime() {
     let servo_test = ServoTest::new();
 

--- a/components/shared/paint/viewport_description.rs
+++ b/components/shared/paint/viewport_description.rs
@@ -124,8 +124,9 @@ impl ViewportDescription {
                 _ => (),
             }
         }
-        description.initial_scale =
-            Scale::new(description.clamp_zoom(description.initial_scale.get()));
+        description.initial_scale = description
+            .initial_scale
+            .clamp(description.minimum_scale, description.maximum_scale);
         description
     }
 
@@ -144,7 +145,11 @@ impl ViewportDescription {
 
     /// Constrains a zoom value within the allowed scale range
     pub fn clamp_zoom(&self, zoom: f32) -> f32 {
-        zoom.clamp(self.minimum_scale.get(), self.maximum_scale.get())
+        zoom.clamp(
+            // For mobile friendliness: Anchor the minimum value of clamp to the initial scale if it's smaller than the default scale.
+            self.initial_scale.get().min(DEFAULT_PAGE_ZOOM.get()),
+            self.maximum_scale.get(),
+        )
     }
 }
 


### PR DESCRIPTION
This ensures we don't go below the initial scale. 
This saves from unnecessary zoom behavior by going to 0.1 when pinch zooming out.

Document referencing Case Study: [viewport meta](https://docs.google.com/document/d/1NBu9rC4sHm51I2yOsWJxeDOd17sNIchEhoNLyOFbAJM/edit?usp=sharing) 

**Case Study**

**Meta Values**: `initial-scale=0.5, minimum-scale=0.1, maximum-scale=10.0`
**Scenario**: We apply scale transform to visual-viewport and resize layout-viewport aka page-rect inversely. 
**Problem**: At this point if we allow pinch Zoom-Out operation to 0.1. We will observe the blank canvas on the sides. Because The page is rendered according to the size of the layout viewport which is calculated considering the initial scale of 0.5. 
**Solution**: We should clamp the pinch scale with minimum range anchoring at the initial scale to save this unexpected behavior.
**Reference**: That’s what Chrome does in mobile devices.


Testing: `webview`:`test_viewport_clamp_pinch_min_by_initial_scale`
Fixes: A concern from #40098

https://github.com/servo/servo/pull/40098#discussion_r3032426990

> In those cases it seems that the ViewportDescription will no longer be the default one and so when you call clamp on the new value it will be clamped properly to [0.5, ...].
