### PR TITLE
devtools: Replace new with register for TabDescriptorActor

### DIFF
--- a/components/devtools/actors/browsing_context.rs
+++ b/components/devtools/actors/browsing_context.rs
@@ -231,8 +231,8 @@ impl BrowsingContextActor {
 
         let style_sheets_name = StyleSheetsActor::register(registry);
 
-        let tab_descriptor_actor =
-            TabDescriptorActor::new(registry, name.clone(), is_top_level_global);
+        let tab_descriptor_name =
+            TabDescriptorActor::register(registry, name.clone(), is_top_level_global);
 
         let thread_name =
             ThreadActor::register(registry, script_sender.clone(), Some(name.clone()));
@@ -261,12 +261,11 @@ impl BrowsingContextActor {
             inspector_name,
             reflow_name,
             style_sheets_name,
-            _tab: tab_descriptor_actor.name(),
+            _tab: tab_descriptor_name,
             thread_name,
             watcher_name: watcher_actor.name(),
         };
 
-        registry.register(tab_descriptor_actor);
         registry.register(watcher_actor);
         registry.register::<Self>(actor);
 

--- a/components/devtools/actors/tab.rs
+++ b/components/devtools/actors/tab.rs
@@ -167,19 +167,21 @@ impl Actor for TabDescriptorActor {
 }
 
 impl TabDescriptorActor {
-    pub(crate) fn new(
+    pub(crate) fn register(
         registry: &ActorRegistry,
         browsing_context_name: String,
         is_top_level_global: bool,
-    ) -> TabDescriptorActor {
+    ) -> String {
         let name = registry.new_name::<Self>();
         let root_actor = registry.find::<RootActor>("root");
         root_actor.tabs.borrow_mut().push(name.clone());
-        TabDescriptorActor {
-            name,
+        let actor = TabDescriptorActor {
+            name: name.clone(),
             browsing_context_name,
             is_top_level_global,
-        }
+        };
+        registry.register::<Self>(actor);
+        name
     }
 
     pub(crate) fn is_top_level_global(&self) -> bool {


### PR DESCRIPTION
Replaced new with register for TabDescriptorActor in browsing_context & tab.rs

Testing: No testing required, compiles successfully.
Fixes: Part of #43800