### PR TITLE
devtools: Replace new with register for ThreadActor

### DIFF
--- a/components/devtools/actors/browsing_context.rs
+++ b/components/devtools/actors/browsing_context.rs
@@ -236,11 +236,8 @@ impl BrowsingContextActor {
         let tab_descriptor_actor =
             TabDescriptorActor::new(registry, name.clone(), is_top_level_global);
 
-        let thread_actor = ThreadActor::new(
-            registry.new_name::<ThreadActor>(),
-            script_sender.clone(),
-            Some(name.clone()),
-        );
+        let thread_name =
+            ThreadActor::register(registry, script_sender.clone(), Some(name.clone()));
 
         let watcher_actor = WatcherActor::new(
             registry,
@@ -267,7 +264,7 @@ impl BrowsingContextActor {
             reflow_name: reflow_actor.name(),
             style_sheets_name,
             _tab: tab_descriptor_actor.name(),
-            thread_name: thread_actor.name(),
+            thread_name,
             watcher_name: watcher_actor.name(),
         };
 
@@ -275,7 +272,6 @@ impl BrowsingContextActor {
         registry.register(css_properties_actor);
         registry.register(reflow_actor);
         registry.register(tab_descriptor_actor);
-        registry.register(thread_actor);
         registry.register(watcher_actor);
 
         target

--- a/components/devtools/actors/thread.rs
+++ b/components/devtools/actors/thread.rs
@@ -116,18 +116,21 @@ pub(crate) struct ThreadActor {
 }
 
 impl ThreadActor {
-    pub fn new(
-        name: String,
+    pub fn register(
+        registry: &ActorRegistry,
         script_sender: GenericSender<DevtoolScriptControlMsg>,
         browsing_context_name: Option<String>,
-    ) -> ThreadActor {
-        ThreadActor {
-            name,
+    ) -> String {
+        let name = registry.new_name::<Self>();
+        let actor = ThreadActor {
+            name: name.clone(),
             source_manager: SourceManager::new(),
             script_sender,
             frames: Default::default(),
             browsing_context_name,
-        }
+        };
+        registry.register::<Self>(actor);
+        name
     }
 }
 

--- a/components/devtools/lib.rs
+++ b/components/devtools/lib.rs
@@ -475,13 +475,7 @@ impl DevtoolsInstance {
         let console_name = self.registry.new_name::<ConsoleActor>();
 
         let parent_actor = if let Some(id) = worker_id {
-            let thread = ThreadActor::new(
-                self.registry.new_name::<ThreadActor>(),
-                script_sender.clone(),
-                None,
-            );
-            let thread_name = thread.name();
-            self.registry.register(thread);
+            let thread_name = ThreadActor::register(&self.registry, script_sender.clone(), None);
 
             let worker_type = if page_info.is_service_worker {
                 WorkerType::Service


### PR DESCRIPTION
Replaced new with register for ThreadActor in browsing_context, thread.rs & lib.rs

Testing: No testing required, compiles successfully.
Fixes: Part of #43800