### PR TITLE
devtools: Replace new with register for NetworkParentActor

### DIFF
--- a/components/devtools/actors/watcher.rs
+++ b/components/devtools/actors/watcher.rs
@@ -444,8 +444,7 @@ impl WatcherActor {
         browsing_context_name: String,
         session_context: SessionContext,
     ) -> Self {
-        let network_parent_actor =
-            NetworkParentActor::new(registry.new_name::<NetworkParentActor>());
+        let network_parent_name = NetworkParentActor::register(registry);
         let target_configuration =
             TargetConfigurationActor::new(registry.new_name::<TargetConfigurationActor>());
         let thread_configuration_actor =
@@ -458,14 +457,13 @@ impl WatcherActor {
         let watcher_actor = Self {
             name: registry.new_name::<WatcherActor>(),
             browsing_context_name,
-            network_parent_name: network_parent_actor.name(),
+            network_parent_name,
             target_configuration: target_configuration.name(),
             thread_configuration_name: thread_configuration_actor.name(),
             breakpoint_list_name: breakpoint_list_actor.name(),
             session_context,
         };
 
-        registry.register(network_parent_actor);
         registry.register(target_configuration);
         registry.register(thread_configuration_actor);
         registry.register(breakpoint_list_actor);

--- a/components/devtools/actors/watcher/network_parent.rs
+++ b/components/devtools/actors/watcher/network_parent.rs
@@ -46,8 +46,11 @@ impl Actor for NetworkParentActor {
 }
 
 impl NetworkParentActor {
-    pub fn new(name: String) -> Self {
-        Self { name }
+    pub fn register(registry: &ActorRegistry) -> String {
+        let name = registry.new_name::<Self>();
+        let actor = Self { name: name.clone() };
+        registry.register::<Self>(actor);
+        name
     }
 }
 


### PR DESCRIPTION
Replaced new with register for NetworkParentActor in network_parent.rs & watcher.rs

Testing: No testing required, compiles successfully.
Fixes: Part of #43800