### PR TITLE
devtools: Replace new with register for ThreadConfigurationActor

### DIFF
--- a/components/devtools/actors/watcher.rs
+++ b/components/devtools/actors/watcher.rs
@@ -447,8 +447,7 @@ impl WatcherActor {
         let network_parent_name = NetworkParentActor::register(registry);
         let target_configuration =
             TargetConfigurationActor::new(registry.new_name::<TargetConfigurationActor>());
-        let thread_configuration_actor =
-            ThreadConfigurationActor::new(registry.new_name::<ThreadConfigurationActor>());
+        let thread_configuration_name = ThreadConfigurationActor::register(registry);
         let breakpoint_list_name =
             BreakpointListActor::register(registry, browsing_context_name.clone());
 
@@ -457,13 +456,12 @@ impl WatcherActor {
             browsing_context_name,
             network_parent_name,
             target_configuration: target_configuration.name(),
-            thread_configuration_name: thread_configuration_actor.name(),
+            thread_configuration_name,
             breakpoint_list_name,
             session_context,
         };
 
         registry.register(target_configuration);
-        registry.register(thread_configuration_actor);
 
         watcher_actor
     }

--- a/components/devtools/actors/watcher/thread_configuration.rs
+++ b/components/devtools/actors/watcher/thread_configuration.rs
@@ -49,11 +49,14 @@ impl Actor for ThreadConfigurationActor {
 }
 
 impl ThreadConfigurationActor {
-    pub fn new(name: String) -> Self {
-        Self {
-            name,
+    pub fn register(registry: &ActorRegistry) -> String {
+        let name = registry.new_name::<Self>();
+        let actor = Self {
+            name: name.clone(),
             _configuration: HashMap::new(),
-        }
+        };
+        registry.register::<Self>(actor);
+        name
     }
 }
 


### PR DESCRIPTION
Replaced new with register for ThreadConfigurationActor in thread_configuration.rs & watcher.rs

Testing: No testing required, compiles successfully.
Fixes: Part of #43800