### PR TITLE
devtools: Replace new with register for BreakpointListActor

### DIFF
--- a/components/devtools/actors/breakpoint.rs
+++ b/components/devtools/actors/breakpoint.rs
@@ -126,11 +126,14 @@ impl Actor for BreakpointListActor {
 }
 
 impl BreakpointListActor {
-    pub fn new(name: String, browsing_context_name: String) -> Self {
-        Self {
-            name,
+    pub fn register(registry: &ActorRegistry, browsing_context_name: String) -> String {
+        let name = registry.new_name::<Self>();
+        let actor = Self {
+            name: name.clone(),
             browsing_context_name,
-        }
+        };
+        registry.register::<Self>(actor);
+        name
     }
 }
 

--- a/components/devtools/actors/watcher.rs
+++ b/components/devtools/actors/watcher.rs
@@ -450,10 +450,8 @@ impl WatcherActor {
             TargetConfigurationActor::new(registry.new_name::<TargetConfigurationActor>());
         let thread_configuration_actor =
             ThreadConfigurationActor::new(registry.new_name::<ThreadConfigurationActor>());
-        let breakpoint_list_actor = BreakpointListActor::new(
-            registry.new_name::<BreakpointListActor>(),
-            browsing_context_name.clone(),
-        );
+        let breakpoint_list_name =
+            BreakpointListActor::register(registry, browsing_context_name.clone());
 
         let watcher_actor = Self {
             name: registry.new_name::<WatcherActor>(),
@@ -461,14 +459,13 @@ impl WatcherActor {
             network_parent_name: network_parent_actor.name(),
             target_configuration: target_configuration.name(),
             thread_configuration_name: thread_configuration_actor.name(),
-            breakpoint_list_name: breakpoint_list_actor.name(),
+            breakpoint_list_name,
             session_context,
         };
 
         registry.register(network_parent_actor);
         registry.register(target_configuration);
         registry.register(thread_configuration_actor);
-        registry.register(breakpoint_list_actor);
 
         watcher_actor
     }


### PR DESCRIPTION
Replaced new with register for BreakpointListActor in breakpoint.rs & watcher.rs

Testing: No testing required, compiles successfully.
Fixes: Part of #43800