### PR TITLE
ci: Secure book-sync secrets with environment

### DIFF
--- a/.github/workflows/book-export.yml
+++ b/.github/workflows/book-export.yml
@@ -9,6 +9,9 @@ jobs:
     # Run job only on servo/servo
     if: github.repository == 'servo/servo'
     runs-on: ubuntu-latest
+    environment:
+      name: book-sync
+      deployment: false
     steps:
       - name: Check out Servo
         uses: actions/checkout@v6


### PR DESCRIPTION
We defined a github environment `book-sync` which contains the required secrets.
After merging this PR we can remove the secrets from the per-repository secrets, which reduces the scope the secrets are available in, and has the added restriction of only being available on protected branches.

Testing: Prior to this PR, the functionality was tested on the `environments` branch and discussed in the maintainers chat. After this PR is merged, a manual check should be done to ensure the book-export workflow still continues to work as expected.

