### PR TITLE
devtools: Replace new with register for PerformanceActor

### DIFF
--- a/components/devtools/actors/performance.rs
+++ b/components/devtools/actors/performance.rs
@@ -98,8 +98,11 @@ impl Actor for PerformanceActor {
 }
 
 impl PerformanceActor {
-    pub fn new(name: String) -> PerformanceActor {
-        PerformanceActor { name }
+    pub fn register(registry: &ActorRegistry) -> String {
+        let name = registry.new_name::<Self>();
+        let actor = PerformanceActor { name: name.clone() };
+        registry.register::<Self>(actor);
+        name
     }
 
     pub fn description() -> ActorDescription {

--- a/components/devtools/actors/root.rs
+++ b/components/devtools/actors/root.rs
@@ -348,7 +348,7 @@ impl RootActor {
     pub fn register(registry: &mut ActorRegistry) {
         // Global actors
         let device_name = DeviceActor::register(registry);
-        let perf = PerformanceActor::new(registry.new_name::<PerformanceActor>());
+        let perf_actor = PerformanceActor::register(registry);
         let preference_name = PreferenceActor::register(registry);
 
         // Process descriptor
@@ -358,14 +358,13 @@ impl RootActor {
         let root_actor = Self {
             global_actors: GlobalActors {
                 device_actor: device_name,
-                perf_actor: perf.name(),
+                perf_actor,
                 preference_actor: preference_name,
             },
             process_name: process_actor.name(),
             ..Default::default()
         };
 
-        registry.register(perf);
         registry.register(process_actor);
         registry.register(root_actor);
     }

--- a/components/devtools/actors/root.rs
+++ b/components/devtools/actors/root.rs
@@ -348,7 +348,7 @@ impl RootActor {
     pub fn register(registry: &mut ActorRegistry) {
         // Global actors
         let device_name = DeviceActor::register(registry);
-        let perf_actor = PerformanceActor::register(registry);
+        let performance_name = PerformanceActor::register(registry);
         let preference_name = PreferenceActor::register(registry);
 
         // Process descriptor
@@ -358,7 +358,7 @@ impl RootActor {
         let root_actor = Self {
             global_actors: GlobalActors {
                 device_actor: device_name,
-                perf_actor,
+                perf_actor: performance_name,
                 preference_actor: preference_name,
             },
             process_name: process_actor.name(),


### PR DESCRIPTION
Replaced new with register for PerformanceActor in performance.rs & root.rs

Testing: No testing required, compiles successfully.
Fixes: Part of #43800