### PR TITLE
mach: Fix typo in allocator feature name

### DIFF
--- a/python/servo/build_commands.py
+++ b/python/servo/build_commands.py
@@ -307,7 +307,7 @@ class MachCommands(CommandBase):
 
             # asan replaces system allocator with asan allocator
             # we need to make sure that we do not replace it with jemalloc
-            self.features.append("servo_allocator/use-system-allocator")
+            self.features.append("servo-allocator/use-system-allocator")
         elif sanitizer.is_tsan():
             if target_triple not in SUPPORTED_TSAN_TARGETS:
                 print(


### PR DESCRIPTION
This name was mistyped during the rename of the servo crates to be `servo-` prefixed.

Testing: Manual testing with `./mach build --with-asan`. This is not run in CI.

