### PR TITLE
devtools: Replace new with register for ProcessActor

### DIFF
--- a/components/devtools/actors/process.rs
+++ b/components/devtools/actors/process.rs
@@ -68,8 +68,11 @@ impl Actor for ProcessActor {
 }
 
 impl ProcessActor {
-    pub fn new(name: String) -> Self {
-        Self { name }
+    pub fn register(registry: &ActorRegistry) -> String {
+        let name = registry.new_name::<Self>();
+        let actor = Self { name: name.clone() };
+        registry.register::<Self>(actor);
+        name
     }
 }
 

--- a/components/devtools/actors/root.rs
+++ b/components/devtools/actors/root.rs
@@ -352,7 +352,7 @@ impl RootActor {
         let preference_name = PreferenceActor::register(registry);
 
         // Process descriptor
-        let process_actor = ProcessActor::new(registry.new_name::<ProcessActor>());
+        let process_name = ProcessActor::register(registry);
 
         // Root actor
         let root_actor = Self {
@@ -361,11 +361,10 @@ impl RootActor {
                 perf_actor: performance_name,
                 preference_actor: preference_name,
             },
-            process_name: process_actor.name(),
+            process_name,
             ..Default::default()
         };
 
-        registry.register(process_actor);
         registry.register(root_actor);
     }
 


### PR DESCRIPTION
Replaced new with register for ProcessActor in process.rs & root.rs

Testing: No testing required, compiles successfully.
Fixes: Part of #43800