### PR TITLE
devtools: Replace new with register for BrowsingContextActor

### DIFF
--- a/components/devtools/actors/browsing_context.rs
+++ b/components/devtools/actors/browsing_context.rs
@@ -197,7 +197,8 @@ impl Actor for BrowsingContextActor {
 
 impl BrowsingContextActor {
     #[expect(clippy::too_many_arguments)]
-    pub(crate) fn new(
+    pub(crate) fn register(
+        registry: &ActorRegistry,
         console_name: String,
         browser_id: DevtoolsBrowserId,
         browsing_context_id: DevtoolsBrowsingContextId,
@@ -205,8 +206,7 @@ impl BrowsingContextActor {
         pipeline_id: PipelineId,
         outer_window_id: DevtoolsOuterWindowId,
         script_sender: GenericSender<DevtoolScriptControlMsg>,
-        registry: &ActorRegistry,
-    ) -> BrowsingContextActor {
+    ) -> String {
         let name = registry.new_name::<BrowsingContextActor>();
         let DevtoolsPageInfo {
             title,
@@ -251,7 +251,7 @@ impl BrowsingContextActor {
         script_chans.insert(pipeline_id, script_sender);
 
         let target = BrowsingContextActor {
-            name,
+            name: name.clone(),
             script_chans: AtomicRefCell::new(script_chans),
             title: AtomicRefCell::new(title),
             url: AtomicRefCell::new(url.into_string()),
@@ -275,7 +275,9 @@ impl BrowsingContextActor {
         registry.register(thread_actor);
         registry.register(watcher_actor);
 
-        target
+        registry.register(target);
+
+        name
     }
 
     pub(crate) fn handle_new_global(

--- a/components/devtools/actors/browsing_context.rs
+++ b/components/devtools/actors/browsing_context.rs
@@ -250,7 +250,7 @@ impl BrowsingContextActor {
         let mut script_chans = FxHashMap::default();
         script_chans.insert(pipeline_id, script_sender);
 
-        let target = BrowsingContextActor {
+        let actor = BrowsingContextActor {
             name: name.clone(),
             script_chans: AtomicRefCell::new(script_chans),
             title: AtomicRefCell::new(title),
@@ -274,8 +274,7 @@ impl BrowsingContextActor {
         registry.register(tab_descriptor_actor);
         registry.register(thread_actor);
         registry.register(watcher_actor);
-
-        registry.register(target);
+        registry.register::<Self>(actor);
 
         name
     }

--- a/components/devtools/lib.rs
+++ b/components/devtools/lib.rs
@@ -519,7 +519,8 @@ impl DevtoolsInstance {
                 .browsing_contexts
                 .entry(browsing_context_id)
                 .or_insert_with(|| {
-                    let browsing_context_actor = BrowsingContextActor::new(
+                    BrowsingContextActor::register(
+                        &self.registry,
                         console_name.clone(),
                         devtools_browser_id,
                         devtools_browsing_context_id,
@@ -527,11 +528,7 @@ impl DevtoolsInstance {
                         pipeline_id,
                         devtools_outer_window_id,
                         script_sender.clone(),
-                        &self.registry,
-                    );
-                    let browsing_context_name = browsing_context_actor.name();
-                    self.registry.register(browsing_context_actor);
-                    browsing_context_name
+                    )
                 });
             let browsing_context_actor = self
                 .registry


### PR DESCRIPTION
Replaced new with register for BrowsingContextActor in browsing_context.rs & lib.rs

Testing: No testing required, compiles successfully.
Fixes: Part of #43800