### PR TITLE
devtools: Replace new with register for NetworkEventActor

### DIFF
--- a/components/devtools/actors/network_event.rs
+++ b/components/devtools/actors/network_event.rs
@@ -536,13 +536,16 @@ impl Actor for NetworkEventActor {
 }
 
 impl NetworkEventActor {
-    pub fn new(name: String, resource_id: u64, watcher_name: String) -> NetworkEventActor {
-        NetworkEventActor {
-            name,
+    pub fn register(registry: &ActorRegistry, resource_id: u64, watcher_name: String) -> String {
+        let name = registry.new_name::<Self>();
+        let actor = NetworkEventActor {
+            name: name.clone(),
             resource_id,
             watcher_name,
             ..Default::default()
-        }
+        };
+        registry.register::<Self>(actor);
+        name
     }
 
     pub fn add_request(&self, request: HttpRequest) {

--- a/components/devtools/lib.rs
+++ b/components/devtools/lib.rs
@@ -688,13 +688,11 @@ impl DevtoolsInstance {
         let resource_id = self.next_resource_id;
         self.next_resource_id += 1;
 
-        let network_event_name = self.registry.new_name::<NetworkEventActor>();
-        let network_event_actor =
-            NetworkEventActor::new(network_event_name.clone(), resource_id, watcher_name);
+        let network_event_name =
+            NetworkEventActor::register(&self.registry, resource_id, watcher_name);
 
         self.actor_requests
             .insert(request_id, network_event_name.clone());
-        self.registry.register(network_event_actor);
 
         network_event_name
     }


### PR DESCRIPTION
Replaced new with register for NetworkEventActor in network_event.rs & lib.rs

Testing: No testing required, compiles successfully.
Fixes: Part of #43800