### PR TITLE
script: Add an initial implementation of `relatedTarget` for`focus`/`blur` events

### DIFF
--- a/components/script/dom/document/focus.rs
+++ b/components/script/dom/document/focus.rs
@@ -254,9 +254,13 @@ impl DocumentFocusHandler {
             self.set_focused_element(None);
 
             if let Some(element) = &old_focused_filtered {
-                // FIXME: pass appropriate relatedTarget
                 if element.upcast::<Node>().is_connected() {
-                    self.fire_focus_event(FocusEventType::Blur, element.upcast(), None, can_gc);
+                    self.fire_focus_event(
+                        FocusEventType::Blur,
+                        element.upcast(),
+                        new_focused_filtered.map(|element| element.upcast()),
+                        can_gc,
+                    );
                 }
             }
         }
@@ -273,14 +277,17 @@ impl DocumentFocusHandler {
         }
 
         if old_focused_filtered != new_focused_filtered {
-            if let Some(elem) = &new_focused_filtered {
-                elem.set_focus_state(true);
-                let node = elem.upcast::<Node>();
-                if let Some(html_element) = elem.downcast::<HTMLElement>() {
+            if let Some(element) = &new_focused_filtered {
+                if let Some(html_element) = element.downcast::<HTMLElement>() {
                     html_element.handle_focus_state_for_contenteditable(can_gc);
                 }
-                // FIXME: pass appropriate relatedTarget
-                self.fire_focus_event(FocusEventType::Focus, node.upcast(), None, can_gc);
+
+                self.fire_focus_event(
+                    FocusEventType::Focus,
+                    element.upcast(),
+                    old_focused_filtered.map(|element| element.upcast()),
+                    can_gc,
+                );
             }
         }
 

--- a/tests/wpt/meta/dom/events/shadow-relatedTarget.html.ini
+++ b/tests/wpt/meta/dom/events/shadow-relatedTarget.html.ini
@@ -1,6 +1,0 @@
-[shadow-relatedTarget.html]
-  [relatedTarget should not leak at capturing phase, at window object.]
-    expected: FAIL
-
-  [relatedTarget should not leak at target.]
-    expected: FAIL


### PR DESCRIPTION
This is an initial implementation for `relatedTarget` of `focus` and
`blur` events. As the code doesn't yet follow the specification this is
a bit tricky to associate with specification text, but this should be
correct. A later change will adapt the code to the "focusing steps" part
of the specification.

In addition, a duplicated call to `Element::set_focus_state` is removed.

Testing: This gets one more WPT test passing.
