### PR TITLE
mach: Set up build mode (Side effect: Stylo thread stack size reduced to 512 KiB again for most build)

### DIFF
--- a/python/servo/command_base.py
+++ b/python/servo/command_base.py
@@ -651,12 +651,17 @@ class CommandBase(object):
                 return BuildType.dev()
 
         if release:
+            self.config["build"]["mode"] = "release"
             return BuildType.release()
         elif dev:
+            self.config["build"]["mode"] = "dev"
             return BuildType.dev()
         elif prod:
+            self.config["build"]["mode"] = "production"
             return BuildType.prod()
         else:
+            # Guaranteed non-None.
+            self.config["build"]["mode"] = profile
             return BuildType.from_string(profile)
 
     def configure_build_target(self, kwargs: dict[str, Any], suppress_log: bool = False) -> None:


### PR DESCRIPTION
Previously the mode is always "". Now we set it to the real profile.
Note that previously, all the build has 2MiB stylo thread stack size, which is unintended.
What we wanted is to make it so for debug build, and 8MiB for ASAN.

Now, those other than debug/ASAN would have 512KiB default stack size again.

Testing: Manually tested and printed the mode at https://github.com/servo/servo/blob/0b6b97384de7f4af04c3bd2b97372146007c2ac3/python/servo/command_base.py#L419-L420.
Fixes: #43927
