### PR TITLE
bootstrap: Sync packages with book

### DIFF
--- a/python/servo/platform/linux_packages/README.md
+++ b/python/servo/platform/linux_packages/README.md
@@ -4,5 +4,3 @@ The list of required packages should be kept in sync with the list in our book a
 https://book.servo.org/building/linux.html.
 This is currently automatically done in our CI via the `book-export.yml` workflow, after a PR
 has been merged to main.
-
-


### PR DESCRIPTION
This commit removes some unneeded lines from README.md in the linux_packages folder. This will trigger `book-export` to run, since it creates a diff in that folder.
Since the export only happens if there is a diff, and there have been not changes since the auto sync PR landed, the formatting related changes never got upstreamed (sorting the packages).

This also duplicates as a test of the #43920 (merged), to be absolutely sure that it works as intended.

Testing: not required / in a way this is a test of our book-export action. 

