### PR TITLE
servoshell: Only dismiss the most-recently opened IME

### DIFF
--- a/ports/servoshell/desktop/headed_window.rs
+++ b/ports/servoshell/desktop/headed_window.rs
@@ -97,8 +97,9 @@ pub struct HeadedWindow {
     last_title: RefCell<String>,
     /// The current set of open dialogs.
     dialogs: RefCell<HashMap<WebViewId, Vec<Dialog>>>,
-    /// A list of showing [`InputMethod`] interfaces.
-    visible_input_methods: RefCell<Vec<EmbedderControlId>>,
+    /// The [`EmbedderControlId`] of the currently showing [`InputMethod`] interfaces,
+    /// if one is showing.
+    visible_input_method: Cell<Option<EmbedderControlId>>,
     /// The position of the mouse cursor after the most recent `MouseMove` event.
     last_mouse_position: Cell<Option<Point2D<f32, DeviceIndependentPixel>>>,
 }
@@ -211,7 +212,7 @@ impl HeadedWindow {
             rendering_context,
             last_title: RefCell::new(String::from(INITIAL_WINDOW_TITLE)),
             dialogs: Default::default(),
-            visible_input_methods: Default::default(),
+            visible_input_method: Default::default(),
             last_mouse_position: Default::default(),
         })
     }
@@ -463,7 +464,9 @@ impl HeadedWindow {
         }
     }
 
-    fn show_ime(&self, input_method: InputMethodControl) {
+    fn show_ime(&self, control_id: EmbedderControlId, input_method: InputMethodControl) {
+        self.visible_input_method.set(Some(control_id));
+
         let position = input_method.position();
         self.winit_window.set_ime_allowed(true);
         self.winit_window.set_ime_cursor_area(
@@ -761,8 +764,7 @@ impl HeadedWindow {
                             //    expect any IME to be open and shouldn't send any more messages to
                             //    Servo as it might cause unexpected blurring of the newly focused
                             //    element.
-                            if !self.visible_input_methods.borrow().is_empty() {
-                                self.visible_input_methods.borrow_mut().clear();
+                            if self.visible_input_method.take().is_some() {
                                 webview.notify_input_event(InputEvent::Ime(ImeEvent::Dismissed));
                             }
                         },
@@ -1097,8 +1099,7 @@ impl PlatformWindow for HeadedWindow {
                 );
             },
             EmbedderControl::InputMethod(input_method_control) => {
-                self.visible_input_methods.borrow_mut().push(control_id);
-                self.show_ime(input_method_control);
+                self.show_ime(control_id, input_method_control);
             },
             EmbedderControl::FilePicker(file_picker) => {
                 self.add_dialog(webview_id, Dialog::new_file_dialog(file_picker));
@@ -1114,15 +1115,10 @@ impl PlatformWindow for HeadedWindow {
     }
 
     fn hide_embedder_control(&self, webview_id: WebViewId, embedder_control_id: EmbedderControlId) {
-        {
-            let mut visible_input_methods = self.visible_input_methods.borrow_mut();
-            if let Some(index) = visible_input_methods
-                .iter()
-                .position(|visible_id| *visible_id == embedder_control_id)
-            {
-                visible_input_methods.remove(index);
-                self.winit_window.set_ime_allowed(false);
-            }
+        if self.visible_input_method.get() == Some(embedder_control_id) {
+            self.visible_input_method.set(None);
+            self.winit_window.set_ime_allowed(false);
+            return;
         }
         self.remove_dialog(webview_id, embedder_control_id);
     }


### PR DESCRIPTION
Servo may hide and show IME when handling `blur` and `focus` events, but
those events can be fired asynchronously when `<iframe>`s are involved.
This change ensures that we only dismiss the IME when it was the
most-recently opened one, making it so that an asynchronously fired
'blur' event for another control doesn't dismiss a newly opened one.

Testing: We don't really have testing for this level of servoshell.
