### PR TITLE
script: Fix GC tracing of compiled JSScript pointers in ClassicScript

### DIFF
--- a/components/script/dom/global_scope_script_execution.rs
+++ b/components/script/dom/global_scope_script_execution.rs
@@ -8,6 +8,7 @@ use std::rc::Rc;
 
 use content_security_policy::sandboxing_directive::SandboxingFlagSet;
 use js::context::JSContext;
+use js::gc::RootedTraceableBox;
 use js::jsapi::{ExceptionStackBehavior, Heap, JSScript, SetScriptPrivate};
 use js::jsval::{PrivateValue, UndefinedValue};
 use js::panic::maybe_resume_unwind;
@@ -16,7 +17,6 @@ use js::rust::wrappers2::{
     JS_GetScriptPrivate, JS_SetPendingException,
 };
 use js::rust::{CompileOptionsWrapper, MutableHandleValue, transform_str_to_source_text};
-use js::gc::RootedTraceableBox;
 use script_bindings::cformat;
 use script_bindings::settings_stack::run_a_script;
 use servo_url::ServoUrl;
@@ -120,7 +120,9 @@ impl GlobalScope {
             // Step 11.2. Return script.
             Err(RethrowError::from_pending_exception(cx.into()))
         } else {
-            Ok(RootedTraceableBox::from_box(Heap::boxed(compiled_script.get())))
+            Ok(RootedTraceableBox::from_box(Heap::boxed(
+                compiled_script.get(),
+            )))
         };
 
         // Step 3. Let script be a new classic script that this algorithm will subsequently initialize.

--- a/components/script/dom/global_scope_script_execution.rs
+++ b/components/script/dom/global_scope_script_execution.rs
@@ -4,12 +4,11 @@
 
 use std::borrow::Cow;
 use std::ffi::CStr;
-use std::ptr::NonNull;
 use std::rc::Rc;
 
 use content_security_policy::sandboxing_directive::SandboxingFlagSet;
 use js::context::JSContext;
-use js::jsapi::{ExceptionStackBehavior, JSScript, SetScriptPrivate};
+use js::jsapi::{ExceptionStackBehavior, Heap, JSScript, SetScriptPrivate};
 use js::jsval::{PrivateValue, UndefinedValue};
 use js::panic::maybe_resume_unwind;
 use js::rust::wrappers2::{
@@ -17,6 +16,7 @@ use js::rust::wrappers2::{
     JS_GetScriptPrivate, JS_SetPendingException,
 };
 use js::rust::{CompileOptionsWrapper, MutableHandleValue, transform_str_to_source_text};
+use js::gc::RootedTraceableBox;
 use script_bindings::cformat;
 use script_bindings::settings_stack::run_a_script;
 use servo_url::ServoUrl;
@@ -39,9 +39,8 @@ use crate::unminify::unminify_js;
 pub(crate) struct ClassicScript {
     /// On script parsing success this will be <https://html.spec.whatwg.org/multipage/#concept-script-record>
     /// On failure <https://html.spec.whatwg.org/multipage/#concept-script-error-to-rethrow>
-    #[no_trace]
     #[ignore_malloc_size_of = "mozjs"]
-    pub record: Result<NonNull<JSScript>, RethrowError>,
+    pub record: Result<RootedTraceableBox<Heap<*mut JSScript>>, RethrowError>,
     /// <https://html.spec.whatwg.org/multipage/#concept-script-script-fetch-options>
     fetch_options: ScriptFetchOptions,
     /// <https://html.spec.whatwg.org/multipage/#concept-script-base-url>
@@ -121,7 +120,7 @@ impl GlobalScope {
             // Step 11.2. Return script.
             Err(RethrowError::from_pending_exception(cx.into()))
         } else {
-            Ok(NonNull::new(*compiled_script).expect("Can't be null"))
+            Ok(RootedTraceableBox::from_box(Heap::boxed(compiled_script.get())))
         };
 
         // Step 3. Let script be a new classic script that this algorithm will subsequently initialize.
@@ -174,9 +173,11 @@ impl GlobalScope {
                 // Step 7. Otherwise, set evaluationStatus to ScriptEvaluation(script's record).
                 Ok(compiled_script) => {
                     rooted!(&in(cx) let mut rval = UndefinedValue());
+                    let script_ptr = compiled_script.get();
+                    assert!(!script_ptr.is_null(), "Compiled script must not be null");
                     result = evaluate_script(
                         cx,
-                        compiled_script,
+                        script_ptr,
                         script.url,
                         script.fetch_options,
                         rval.handle_mut(),
@@ -347,12 +348,12 @@ pub(crate) fn compile_script(
 #[expect(unsafe_code)]
 pub(crate) fn evaluate_script(
     cx: &mut JSContext,
-    compiled_script: NonNull<JSScript>,
+    compiled_script: *mut JSScript,
     url: ServoUrl,
     fetch_options: ScriptFetchOptions,
     rval: MutableHandleValue,
 ) -> bool {
-    rooted!(&in(cx) let record = compiled_script.as_ptr());
+    rooted!(&in(cx) let record = compiled_script);
     rooted!(&in(cx) let mut script_private = UndefinedValue());
 
     unsafe { JS_GetScriptPrivate(*record, script_private.handle_mut()) };

--- a/components/script/dom/global_scope_script_execution.rs
+++ b/components/script/dom/global_scope_script_execution.rs
@@ -9,7 +9,6 @@ use std::rc::Rc;
 
 use content_security_policy::sandboxing_directive::SandboxingFlagSet;
 use js::context::JSContext;
-use js::gc::RootedTraceableBox;
 use js::jsapi::{ExceptionStackBehavior, Heap, JSScript, SetScriptPrivate};
 use js::jsval::{PrivateValue, UndefinedValue};
 use js::panic::maybe_resume_unwind;
@@ -20,6 +19,7 @@ use js::rust::wrappers2::{
 use js::rust::{CompileOptionsWrapper, MutableHandleValue, transform_str_to_source_text};
 use script_bindings::cformat;
 use script_bindings::settings_stack::run_a_script;
+use script_bindings::trace::RootedTraceableBox;
 use servo_url::ServoUrl;
 
 use crate::DomTypeHolder;
@@ -36,7 +36,6 @@ use crate::script_runtime::CanGc;
 use crate::unminify::unminify_js;
 
 /// <https://html.spec.whatwg.org/multipage/#classic-script>
-#[cfg_attr(crown, expect(crown::unrooted_must_root))]
 #[derive(JSTraceable, MallocSizeOf)]
 pub(crate) struct ClassicScript {
     /// On script parsing success this will be <https://html.spec.whatwg.org/multipage/#concept-script-record>
@@ -76,7 +75,6 @@ pub(crate) enum RethrowErrors {
 impl GlobalScope {
     /// <https://html.spec.whatwg.org/multipage/#creating-a-classic-script>
     #[expect(clippy::too_many_arguments)]
-    #[cfg_attr(crown, expect(crown::unrooted_must_root))]
     pub(crate) fn create_a_classic_script(
         &self,
         cx: &mut JSContext,
@@ -144,7 +142,6 @@ impl GlobalScope {
 
     /// <https://html.spec.whatwg.org/multipage/#run-a-classic-script>
     #[expect(unsafe_code)]
-    #[cfg_attr(crown, expect(crown::unrooted_must_root))]
     pub(crate) fn run_a_classic_script(
         &self,
         cx: &mut JSContext,

--- a/components/script/dom/global_scope_script_execution.rs
+++ b/components/script/dom/global_scope_script_execution.rs
@@ -4,6 +4,7 @@
 
 use std::borrow::Cow;
 use std::ffi::CStr;
+use std::ptr::NonNull;
 use std::rc::Rc;
 
 use content_security_policy::sandboxing_directive::SandboxingFlagSet;
@@ -178,8 +179,8 @@ impl GlobalScope {
                 // Step 7. Otherwise, set evaluationStatus to ScriptEvaluation(script's record).
                 Ok(compiled_script) => {
                     rooted!(&in(cx) let mut rval = UndefinedValue());
-                    let script_ptr = compiled_script.get();
-                    assert!(!script_ptr.is_null(), "Compiled script must not be null");
+                    let script_ptr = NonNull::new(compiled_script.get())
+                        .expect("Compiled script must not be null");
                     result = evaluate_script(
                         cx,
                         script_ptr,
@@ -353,12 +354,12 @@ pub(crate) fn compile_script(
 #[expect(unsafe_code)]
 pub(crate) fn evaluate_script(
     cx: &mut JSContext,
-    compiled_script: *mut JSScript,
+    compiled_script: NonNull<JSScript>,
     url: ServoUrl,
     fetch_options: ScriptFetchOptions,
     rval: MutableHandleValue,
 ) -> bool {
-    rooted!(&in(cx) let record = compiled_script);
+    rooted!(&in(cx) let record = compiled_script.as_ptr());
     rooted!(&in(cx) let mut script_private = UndefinedValue());
 
     unsafe { JS_GetScriptPrivate(*record, script_private.handle_mut()) };

--- a/components/script/dom/global_scope_script_execution.rs
+++ b/components/script/dom/global_scope_script_execution.rs
@@ -35,6 +35,7 @@ use crate::script_runtime::CanGc;
 use crate::unminify::unminify_js;
 
 /// <https://html.spec.whatwg.org/multipage/#classic-script>
+#[cfg_attr(crown, expect(crown::unrooted_must_root))]
 #[derive(JSTraceable, MallocSizeOf)]
 pub(crate) struct ClassicScript {
     /// On script parsing success this will be <https://html.spec.whatwg.org/multipage/#concept-script-record>
@@ -74,6 +75,7 @@ pub(crate) enum RethrowErrors {
 impl GlobalScope {
     /// <https://html.spec.whatwg.org/multipage/#creating-a-classic-script>
     #[expect(clippy::too_many_arguments)]
+    #[cfg_attr(crown, expect(crown::unrooted_must_root))]
     pub(crate) fn create_a_classic_script(
         &self,
         cx: &mut JSContext,
@@ -141,6 +143,7 @@ impl GlobalScope {
 
     /// <https://html.spec.whatwg.org/multipage/#run-a-classic-script>
     #[expect(unsafe_code)]
+    #[cfg_attr(crown, expect(crown::unrooted_must_root))]
     pub(crate) fn run_a_classic_script(
         &self,
         cx: &mut JSContext,

--- a/components/script/dom/globalscope.rs
+++ b/components/script/dom/globalscope.rs
@@ -9,6 +9,7 @@ use std::collections::{HashMap, HashSet, VecDeque};
 use std::ffi::CStr;
 use std::mem;
 use std::ops::{Deref, Index};
+use std::ptr::NonNull;
 use std::rc::Rc;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
@@ -2902,10 +2903,12 @@ impl GlobalScope {
                 return Err(JavaScriptEvaluationError::CompilationFailure);
             }
 
+            let script = NonNull::new(*compiled_script).expect("Can't be null");
+
             rooted!(&in(cx) let mut value = UndefinedValue());
             let rval = rval.unwrap_or_else(|| value.handle_mut());
 
-            if !evaluate_script(cx, *compiled_script, url, fetch_options, rval) {
+            if !evaluate_script(cx, script, url, fetch_options, rval) {
                 let error_info = take_and_report_pending_exception_for_api(cx);
                 return Err(JavaScriptEvaluationError::EvaluationFailure(error_info));
             }

--- a/components/script/dom/globalscope.rs
+++ b/components/script/dom/globalscope.rs
@@ -9,7 +9,6 @@ use std::collections::{HashMap, HashSet, VecDeque};
 use std::ffi::CStr;
 use std::mem;
 use std::ops::{Deref, Index};
-use std::ptr::NonNull;
 use std::rc::Rc;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
@@ -2903,12 +2902,10 @@ impl GlobalScope {
                 return Err(JavaScriptEvaluationError::CompilationFailure);
             }
 
-            let script = NonNull::new(*compiled_script).expect("Can't be null");
-
             rooted!(&in(cx) let mut value = UndefinedValue());
             let rval = rval.unwrap_or_else(|| value.handle_mut());
 
-            if !evaluate_script(cx, script, url, fetch_options, rval) {
+            if !evaluate_script(cx, *compiled_script, url, fetch_options, rval) {
                 let error_info = take_and_report_pending_exception_for_api(cx);
                 return Err(JavaScriptEvaluationError::EvaluationFailure(error_info));
             }


### PR DESCRIPTION
Stores the compiled JSScript pointer in a rooted location that is traceable by the GC. This fixes a crash observed in an experimental C# Servo binding that could not be reproduced in servoshell.

Testing: No automated deterministic way to trigger this problem.