### PR TITLE
devtools: Standardize variable naming for TargetConfigurationActor

### DIFF
--- a/components/devtools/actors/watcher.rs
+++ b/components/devtools/actors/watcher.rs
@@ -184,7 +184,7 @@ pub(crate) struct WatcherActor {
     name: String,
     pub browsing_context_name: String,
     network_parent_name: String,
-    target_configuration: String,
+    target_configuration_name: String,
     thread_configuration_name: String,
     breakpoint_list_name: String,
     session_context: SessionContext,
@@ -406,7 +406,7 @@ impl Actor for WatcherActor {
                 let msg = GetTargetConfigurationActorReply {
                     from: self.name(),
                     configuration: registry
-                        .encode::<TargetConfigurationActor, _>(&self.target_configuration),
+                        .encode::<TargetConfigurationActor, _>(&self.target_configuration_name),
                 };
                 request.reply_final(&msg)?
             },
@@ -445,7 +445,7 @@ impl WatcherActor {
         session_context: SessionContext,
     ) -> Self {
         let network_parent_name = NetworkParentActor::register(registry);
-        let target_configuration =
+        let target_configuration_actor =
             TargetConfigurationActor::new(registry.new_name::<TargetConfigurationActor>());
         let thread_configuration_actor =
             ThreadConfigurationActor::new(registry.new_name::<ThreadConfigurationActor>());
@@ -456,13 +456,13 @@ impl WatcherActor {
             name: registry.new_name::<WatcherActor>(),
             browsing_context_name,
             network_parent_name,
-            target_configuration: target_configuration.name(),
+            target_configuration_name: target_configuration_actor.name(),
             thread_configuration_name: thread_configuration_actor.name(),
             breakpoint_list_name,
             session_context,
         };
 
-        registry.register(target_configuration);
+        registry.register(target_configuration_actor);
         registry.register(thread_configuration_actor);
 
         watcher_actor


### PR DESCRIPTION
Renames the `target_configuration` field and local variable in `watcher.rs` to use the `_name` and `_actor` suffixes, following the convention already used by other actors in the file (`thread_actor`, `tab_name`, etc.).

- `target_configuration: String` field → `target_configuration_name: String`
- `let target_configuration = ...` local → `let target_configuration_actor = ...`
- Updated all references accordingly (`.name()` call, registry insertion, struct literal)

Part of #43606.

<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[x]` to confirm the following: -->

<!-- Please include the following if applicable: -->

- [x] There are tests for these changes OR
- [ ] These changes do not require tests ??

<!-- If adding a new test that isn't part of the Web Platform Tests, please include a brief rationale for why: -->