### PR TITLE
script: Support deleting words with backspace in textual inputs

### DIFF
--- a/components/script/textinput.rs
+++ b/components/script/textinput.rs
@@ -301,24 +301,29 @@ impl<T: ClipboardProvider> TextInput<T> {
         self.was_last_change_by_set_content
     }
 
-    /// Remove a character at the current editing point
+    /// If there is an uncollapsed selection, delete it, otherwise do nothing. Returns
+    /// true if any text was deleted.
+    fn delete_selection(&mut self) -> bool {
+        if self.selection_start() == self.selection_end() {
+            return false;
+        }
+        self.replace_selection(&DOMString::new());
+        true
+    }
+
+    /// If there is an uncollapsed selection, delete it. Otherwise delete the given [`unit`]
+    /// worth of text in [`direction`] Remove a character at the current editing point
     ///
-    /// Returns true if any character was deleted
-    pub fn delete_char(&mut self, direction: Direction) -> bool {
+    /// Returns true if any text was deleted.
+    pub fn delete_unit_or_selection(&mut self, unit: RopeMovement, direction: Direction) -> bool {
         if !self.has_uncollapsed_selection() {
             let amount = match direction {
                 Direction::Forward => 1,
                 Direction::Backward => -1,
             };
-            self.modify_selection(amount, RopeMovement::Grapheme);
+            self.modify_selection(amount, unit);
         }
-
-        if self.selection_start() == self.selection_end() {
-            return false;
-        }
-
-        self.replace_selection(&DOMString::new());
-        true
+        self.delete_selection()
     }
 
     /// Insert a string at the current editing point or replace the selection if
@@ -634,7 +639,7 @@ impl<T: ClipboardProvider> TextInput<T> {
             .shortcut(CMD_OR_CONTROL, 'X', || {
                 if let Some(text) = self.get_selection_text() {
                     self.clipboard_provider.set_text(text);
-                    self.delete_char(Direction::Backward);
+                    self.delete_selection();
                 }
                 KeyReaction::DispatchInput(None, IsComposing::NotComposing, InputType::DeleteByCut)
             })
@@ -662,7 +667,7 @@ impl<T: ClipboardProvider> TextInput<T> {
                 }
             })
             .shortcut(Modifiers::empty(), Key::Named(NamedKey::Delete), || {
-                if self.delete_char(Direction::Forward) {
+                if self.delete_unit_or_selection(RopeMovement::Grapheme, Direction::Forward) {
                     KeyReaction::DispatchInput(
                         None,
                         IsComposing::NotComposing,
@@ -673,7 +678,18 @@ impl<T: ClipboardProvider> TextInput<T> {
                 }
             })
             .shortcut(Modifiers::empty(), Key::Named(NamedKey::Backspace), || {
-                if self.delete_char(Direction::Backward) {
+                if self.delete_unit_or_selection(RopeMovement::Grapheme, Direction::Backward) {
+                    KeyReaction::DispatchInput(
+                        None,
+                        IsComposing::NotComposing,
+                        InputType::DeleteContentBackward,
+                    )
+                } else {
+                    KeyReaction::Nothing
+                }
+            })
+            .shortcut(alt_or_control, Key::Named(NamedKey::Backspace), || {
+                if self.delete_unit_or_selection(RopeMovement::Word, Direction::Backward) {
                     KeyReaction::DispatchInput(
                         None,
                         IsComposing::NotComposing,
@@ -1061,7 +1077,7 @@ impl<T: ClipboardProvider> TextInput<T> {
                 self.clipboard_provider.set_text(text);
 
                 // Step 3.1.2 Remove the contents of the selection from the document and collapse the selection.
-                self.delete_char(Direction::Backward);
+                self.delete_selection();
 
                 // Step 3.1.3 Fire a clipboard event named clipboardchange
                 // Step 3.1.4 Queue tasks to fire any events that should fire due to the modification.

--- a/tests/unit/script/textinput.rs
+++ b/tests/unit/script/textinput.rs
@@ -223,20 +223,20 @@ fn test_single_line_textinput_with_max_length_doesnt_allow_appending_characters_
 fn test_textinput_delete_char() {
     let mut textinput = text_input(Lines::Single, "abcdefg");
     textinput.modify_edit_point(2, RopeMovement::Grapheme);
-    textinput.delete_char(Direction::Backward);
+    textinput.delete_unit_or_selection(RopeMovement::Grapheme, Direction::Backward);
     assert_eq!(textinput.get_content(), "acdefg");
 
-    textinput.delete_char(Direction::Forward);
+    textinput.delete_unit_or_selection(RopeMovement::Grapheme, Direction::Forward);
     assert_eq!(textinput.get_content(), "adefg");
 
     textinput.modify_selection(2, RopeMovement::Grapheme);
-    textinput.delete_char(Direction::Forward);
+    textinput.delete_unit_or_selection(RopeMovement::Grapheme, Direction::Forward);
     assert_eq!(textinput.get_content(), "afg");
 
     let mut textinput = text_input(Lines::Single, "a🌠b");
     // Same as "Right" key
     textinput.modify_edit_point(1, RopeMovement::Grapheme);
-    textinput.delete_char(Direction::Forward);
+    textinput.delete_unit_or_selection(RopeMovement::Grapheme, Direction::Forward);
     // Not splitting surrogate pairs.
     assert_eq!(textinput.get_content(), "ab");
 
@@ -246,7 +246,7 @@ fn test_textinput_delete_char() {
         Utf8CodeUnitLength(2),
         SelectionDirection::None,
     );
-    textinput.delete_char(Direction::Backward);
+    textinput.delete_unit_or_selection(RopeMovement::Grapheme, Direction::Backward);
     assert_eq!(textinput.get_content(), "acdefg");
 }
 

--- a/tests/wpt/mozilla/meta/MANIFEST.json
+++ b/tests/wpt/mozilla/meta/MANIFEST.json
@@ -13240,6 +13240,15 @@
       }
      ]
     ],
+    "key-event-text-input-backspace.html": [
+     "fa6c35fd6a0ef966c313a9ef7ac720ea6be27113",
+     [
+      null,
+      {
+       "testdriver": true
+      }
+     ]
+    ],
     "key-event-text-input-motion.html": [
      "1e14f2dca3b8e019050396030c7de84bdf06b255",
      [

--- a/tests/wpt/mozilla/tests/input-events/key-event-text-input-backspace.html
+++ b/tests/wpt/mozilla/tests/input-events/key-event-text-input-backspace.html
@@ -1,0 +1,75 @@
+<!DOCTYPE html>
+<title>Backspace key should delete text in textual inputs</title>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/resources/testdriver.js"></script>
+<script src="/resources/testdriver-actions.js"></script>
+<script src="/resources/testdriver-vendor.js"></script>
+<link rel="stylesheet" type="text/css" href="/fonts/ahem.css" />
+
+<style>
+    .text {
+        width: 100px;
+    }
+</style>
+
+<input class="text" id="input" value="word word">
+<textarea class="text" id="textarea">
+word word
+abc
+word word
+</textarea>
+
+<script>
+const backspaceKey = "\uE003";
+const controlKey = "\uE009";
+const altKey = "\uE00A";
+const isMacOSX = navigator.userAgent.indexOf("Mac") != -1;
+const wordMoveKey = isMacOSX ? altKey : controlKey;
+
+async function pressKeyWithWordMoveModifier(key) {
+     await new test_driver.Actions()
+        .keyDown(wordMoveKey)
+        .keyDown(key)
+        .keyUp(key)
+        .keyUp(wordMoveKey)
+        .send();
+}
+
+promise_test(async test => {
+    input.focus();
+    input.setSelectionRange(9, 9);
+
+    await test_driver.send_keys(input, backspaceKey);
+    await test_driver.send_keys(input, backspaceKey);
+    assert_equals(input.value, "word wo");
+
+    await pressKeyWithWordMoveModifier(backspaceKey);
+    assert_equals(input.value, "word ");
+
+    await pressKeyWithWordMoveModifier(backspaceKey);
+    assert_equals(input.value, "");
+}, 'Backspace key properly deletes text in an input field');
+
+promise_test(async test => {
+    textarea.focus();
+    textarea.setSelectionRange(25, 25)
+
+    await test_driver.send_keys(textarea, backspaceKey);
+    await test_driver.send_keys(textarea, backspaceKey);
+    assert_equals(textarea.value, "word word\nabc\nword wor");
+
+    await pressKeyWithWordMoveModifier(backspaceKey);
+    assert_equals(textarea.value, "word word\nabc\nword ");
+
+    await pressKeyWithWordMoveModifier(backspaceKey);
+    assert_equals(textarea.value, "word word\nabc\n");
+
+    await pressKeyWithWordMoveModifier(backspaceKey);
+    assert_equals(textarea.value, "word word\n");
+
+    await test_driver.send_keys(textarea, backspaceKey);
+    await test_driver.send_keys(textarea, backspaceKey);
+    assert_equals(textarea.value, "word wor");
+}, 'Backspace key properly deletes text in a textarea');
+</script>


### PR DESCRIPTION
This change makes it so that when you press alt or control (depending on
the platform) while backspacing, entire words are deleted. This matches
the behavior of the major desktop platforms.

Testing: This change adds a Servo-specific test for this behavior as well
as for normal backspacing.
