### PR TITLE
servo: Use _ prefixed names for unused arguments for public API functions 

### DIFF
--- a/components/servo/webview_delegate.rs
+++ b/components/servo/webview_delegate.rs
@@ -883,7 +883,7 @@ pub trait WebViewDelegate {
     fn notify_load_status_changed(&self, _webview: WebView, _status: LoadStatus) {}
     /// The [`Cursor`] of the currently loaded page in this [`WebView`] has changed. The new
     /// cursor can accessed via [`WebView::cursor`].
-    fn notify_cursor_changed(&self, _webview: WebView, _: Cursor) {}
+    fn notify_cursor_changed(&self, _webview: WebView, _cursor: Cursor) {}
     /// The favicon of the currently loaded page in this [`WebView`] has changed. The new
     /// favicon [`Image`](embedder_traits::Image) can accessed via [`WebView::favicon`].
     fn notify_favicon_changed(&self, _webview: WebView) {}
@@ -894,7 +894,7 @@ pub trait WebViewDelegate {
     /// back navigation, and forward navigation modify this index.
     fn notify_history_changed(&self, _webview: WebView, _entries: Vec<Url>, _current: usize) {}
     /// A history traversal operation is complete.
-    fn notify_traversal_complete(&self, _webview: WebView, _: TraversalId) {}
+    fn notify_traversal_complete(&self, _webview: WebView, _traversal_id: TraversalId) {}
     /// Page content has closed this [`WebView`] via `window.close()`. It's the embedder's
     /// responsibility to remove the [`WebView`] from the interface when this notification
     /// occurs.
@@ -903,7 +903,13 @@ pub trait WebViewDelegate {
     /// An input event passed to this [`WebView`] via [`WebView::notify_input_event`] has been handled
     /// by Servo. This allows post-procesing of input events, such as chaining up unhandled events
     /// to parent UI elements.
-    fn notify_input_event_handled(&self, _webview: WebView, _: InputEventId, _: InputEventResult) {}
+    fn notify_input_event_handled(
+        &self,
+        _webview: WebView,
+        _event_id: InputEventId,
+        _result: InputEventResult,
+    ) {
+    }
     /// A pipeline in the webview panicked. First string is the reason, second one is the backtrace.
     fn notify_crashed(&self, _webview: WebView, _reason: String, _backtrace: Option<String>) {}
     /// Notifies the embedder about media session events
@@ -914,7 +920,7 @@ pub trait WebViewDelegate {
     /// mode and to show or hide extra UI elements. Regardless of how the notification is handled,
     /// the page will enter or leave fullscreen state internally according to the [Fullscreen
     /// API](https://fullscreen.spec.whatwg.org/).
-    fn notify_fullscreen_state_changed(&self, _webview: WebView, _: bool) {}
+    fn notify_fullscreen_state_changed(&self, _webview: WebView, _is_fullscreen: bool) {}
 
     /// Whether or not to allow a [`WebView`] to load a URL in its main frame or one of its
     /// nested `<iframe>`s. [`NavigationRequest`]s are accepted by default.
@@ -923,7 +929,7 @@ pub trait WebViewDelegate {
     /// of its nested `<iframe>`s. By default, unloads are allowed.
     fn request_unload(&self, _webview: WebView, _unload_request: AllowOrDenyRequest) {}
     /// Move the window to a point.
-    fn request_move_to(&self, _webview: WebView, _: DeviceIntPoint) {}
+    fn request_move_to(&self, _webview: WebView, _point: DeviceIntPoint) {}
     /// Whether or not to allow a [`WebView`] to (un)register a protocol handler (e.g. `mailto:`).
     /// Typically an embedder application will show a permissions prompt when this happens
     /// to confirm a protocol handler is allowed. By default, requests are denied.
@@ -961,11 +967,11 @@ pub trait WebViewDelegate {
     /// it will be immediately destroyed.
     ///
     /// [`window.open`]: https://developer.mozilla.org/en-US/docs/Web/API/Window/open
-    fn request_create_new(&self, _parent_webview: WebView, _: CreateNewWebViewRequest) {}
+    fn request_create_new(&self, _parent_webview: WebView, _request: CreateNewWebViewRequest) {}
     /// Content in a [`WebView`] is requesting permission to access a feature requiring
     /// permission from the user. The embedder should allow or deny the request, either by
     /// reading a cached value or querying the user for permission via the user interface.
-    fn request_permission(&self, _webview: WebView, _: PermissionRequest) {}
+    fn request_permission(&self, _webview: WebView, _request: PermissionRequest) {}
 
     fn request_authentication(
         &self,
@@ -975,7 +981,12 @@ pub trait WebViewDelegate {
     }
 
     /// Open dialog to select bluetooth device.
-    fn show_bluetooth_device_dialog(&self, _webview: WebView, _: BluetoothDeviceSelectionRequest) {}
+    fn show_bluetooth_device_dialog(
+        &self,
+        _webview: WebView,
+        _request: BluetoothDeviceSelectionRequest,
+    ) {
+    }
 
     /// Request that the embedder show UI elements for form controls that are not integrated
     /// into page content, such as dropdowns for `<select>` elements.

--- a/components/webxr/lib.rs
+++ b/components/webxr/lib.rs
@@ -22,5 +22,5 @@ pub(crate) mod gl_utils;
 
 pub trait WebXrRegistry {
     /// Register services with a WebXR Registry.
-    fn register(&self, _: &mut MainThreadRegistry) {}
+    fn register(&self, _registry: &mut MainThreadRegistry) {}
 }


### PR DESCRIPTION
updated all methods that were using underscore in arguments

- `WebViewDelegate`
   - `notify_cursor_changed`: Added _cursor.
   - `notify_traversal_complete`: Added _traversal_id.
   - `notify_input_event_handled`: Added _event_id and _result.
   - `notify_fullscreen_state_changed`: Added _is_fullscreen.
   - `request_move_to`: Added _point.
   - `request_create_new`: Added _request.
   - `request_permission:` Added _request.
   - `show_bluetooth_device_dialog`: Added _request.
 - `WebXrRegistry`
    - `register`: Added _registry

Testing: No tests necessary as this is just renaming argument.
Fixes: #43894
