### PR TITLE
IndexedDB: Implement IndexedDB abort rollback for object store metadata and key generators

### DIFF
--- a/components/script/dom/indexeddb/idbdatabase.rs
+++ b/components/script/dom/indexeddb/idbdatabase.rs
@@ -98,22 +98,29 @@ impl IDBDatabase {
     }
 
     pub(crate) fn object_store_names_snapshot(&self) -> Vec<DOMString> {
-        // https://w3c.github.io/IndexedDB/#abort-upgrade-transaction
+        // https://w3c.github.io/IndexedDB/#abort-an-upgrade-transaction
         // Step 4. Set connection’s object store set to the set of object stores in database if database previously existed,
         // or the empty set if database was newly created.
         self.object_store_names.borrow().clone()
     }
 
     pub(crate) fn set_object_store_names_from_backend(&self, names: Vec<String>) {
-        // https://w3c.github.io/IndexedDB/#abort-upgrade-transaction
+        // https://w3c.github.io/IndexedDB/#abort-an-upgrade-transaction
         // Step 4. NOTE: This reverts the value of objectStoreNames returned by the IDBDatabase object.
         *self.object_store_names.borrow_mut() = names.into_iter().map(Into::into).collect();
     }
 
     pub(crate) fn restore_object_store_names(&self, names: Vec<DOMString>) {
-        // https://w3c.github.io/IndexedDB/#abort-upgrade-transaction
+        // https://w3c.github.io/IndexedDB/#abort-an-upgrade-transaction
         // Step 4. NOTE: This reverts the value of objectStoreNames returned by the IDBDatabase object.
         *self.object_store_names.borrow_mut() = names;
+    }
+
+    pub(crate) fn rename_object_store_name(&self, old_name: &DOMString, new_name: DOMString) {
+        let mut object_store_names = self.object_store_names.borrow_mut();
+        if let Some(position) = object_store_names.iter().position(|name| name == old_name) {
+            object_store_names[position] = new_name;
+        }
     }
 
     pub(crate) fn object_store_exists(&self, name: &DOMString) -> bool {
@@ -313,6 +320,7 @@ impl IDBDatabaseMethods<crate::DomTypeHolder> for IDBDatabase {
             self.name.clone(),
             name.clone(),
             Some(options),
+            None,
             if auto_increment { Some(1) } else { None },
             CanGc::from_cx(cx),
             &transaction,
@@ -349,6 +357,7 @@ impl IDBDatabaseMethods<crate::DomTypeHolder> for IDBDatabase {
         };
 
         self.object_store_names.borrow_mut().push(name);
+        transaction.register_object_store_handle(&object_store.get_name(), &object_store);
 
         // Step 10. Return a new object store handle associated with store and transaction.
         Ok(object_store)

--- a/components/script/dom/indexeddb/idbdatabase.rs
+++ b/components/script/dom/indexeddb/idbdatabase.rs
@@ -27,7 +27,7 @@ use crate::dom::bindings::str::DOMString;
 use crate::dom::domstringlist::DOMStringList;
 use crate::dom::eventtarget::EventTarget;
 use crate::dom::globalscope::GlobalScope;
-use crate::dom::indexeddb::idbobjectstore::IDBObjectStore;
+use crate::dom::indexeddb::idbobjectstore::{IDBObjectStore, IDBObjectStoreAbortState};
 use crate::dom::indexeddb::idbtransaction::IDBTransaction;
 use crate::dom::indexeddb::idbversionchangeevent::IDBVersionChangeEvent;
 use crate::indexeddb::is_valid_key_path;
@@ -320,8 +320,11 @@ impl IDBDatabaseMethods<crate::DomTypeHolder> for IDBDatabase {
             self.name.clone(),
             name.clone(),
             Some(options),
-            None,
-            if auto_increment { Some(1) } else { None },
+            IDBObjectStoreAbortState {
+                newly_created_during_transaction: true,
+                rollback_indexes_on_abort: vec![],
+                key_generator_current_number: if auto_increment { Some(1_i64) } else { None },
+            },
             CanGc::from_cx(cx),
             &transaction,
         );

--- a/components/script/dom/indexeddb/idbobjectstore.rs
+++ b/components/script/dom/indexeddb/idbobjectstore.rs
@@ -86,10 +86,12 @@ impl From<KeyPath> for indexeddb::KeyPath {
 }
 
 #[derive(Clone, JSTraceable, MallocSizeOf)]
-struct IDBObjectStoreAbortState {
+struct IDBObjectStoreRollbackState {
+    newly_created_during_transaction: bool,
     rollback_name: Option<DOMString>,
     #[no_trace]
     rollback_indexes: Vec<indexeddb::IndexedDBIndex>,
+    key_generator_current_number: Option<i64>,
 }
 
 #[dom_struct]
@@ -98,7 +100,7 @@ pub struct IDBObjectStore {
     name: DomRefCell<DOMString>,
     key_path: Option<KeyPath>,
     index_set: DomRefCell<HashMap<DOMString, Dom<IDBIndex>>>,
-    abort_state_on_abort: DomRefCell<Option<IDBObjectStoreAbortState>>,
+    abort_state_on_abort: DomRefCell<Option<IDBObjectStoreRollbackState>>,
     transaction: Dom<IDBTransaction>,
     has_key_generator: bool,
     key_generator_current_number: Cell<Option<i64>>,
@@ -108,13 +110,18 @@ pub struct IDBObjectStore {
     db_name: DOMString,
 }
 
+pub(crate) struct IDBObjectStoreAbortState {
+    pub(crate) newly_created_during_transaction: bool,
+    pub(crate) rollback_indexes_on_abort: Vec<indexeddb::IndexedDBIndex>,
+    pub(crate) key_generator_current_number: Option<i64>,
+}
+
 impl IDBObjectStore {
     pub fn new_inherited(
         db_name: DOMString,
         name: DOMString,
         options: Option<&IDBObjectStoreParameters>,
-        rollback_indexes_on_abort: Option<Vec<indexeddb::IndexedDBIndex>>,
-        key_generator_current_number: Option<i64>,
+        abort_state: IDBObjectStoreAbortState,
         transaction: &IDBTransaction,
     ) -> IDBObjectStore {
         let key_path: Option<KeyPath> = match options {
@@ -127,6 +134,11 @@ impl IDBObjectStore {
             None => None,
         };
         let has_key_generator = options.is_some_and(|options| options.autoIncrement);
+        let IDBObjectStoreAbortState {
+            newly_created_during_transaction,
+            rollback_indexes_on_abort,
+            key_generator_current_number,
+        } = abort_state;
         let key_generator_current_number = if has_key_generator {
             Some(key_generator_current_number.unwrap_or(1))
         } else {
@@ -138,11 +150,11 @@ impl IDBObjectStore {
             name: DomRefCell::new(name),
             key_path,
             index_set: DomRefCell::new(HashMap::new()),
-            abort_state_on_abort: DomRefCell::new(rollback_indexes_on_abort.map(|indexes| {
-                IDBObjectStoreAbortState {
-                    rollback_name: None,
-                    rollback_indexes: indexes,
-                }
+            abort_state_on_abort: DomRefCell::new(Some(IDBObjectStoreRollbackState {
+                newly_created_during_transaction,
+                rollback_name: None,
+                rollback_indexes: rollback_indexes_on_abort,
+                key_generator_current_number,
             })),
             transaction: Dom::from_ref(transaction),
             has_key_generator,
@@ -156,8 +168,7 @@ impl IDBObjectStore {
         db_name: DOMString,
         name: DOMString,
         options: Option<&IDBObjectStoreParameters>,
-        rollback_indexes_on_abort: Option<Vec<indexeddb::IndexedDBIndex>>,
-        key_generator_current_number: Option<i64>,
+        abort_state: IDBObjectStoreAbortState,
         can_gc: CanGc,
         transaction: &IDBTransaction,
     ) -> DomRoot<IDBObjectStore> {
@@ -166,8 +177,7 @@ impl IDBObjectStore {
                 db_name,
                 name,
                 options,
-                rollback_indexes_on_abort,
-                key_generator_current_number,
+                abort_state,
                 transaction,
             )),
             global,
@@ -182,13 +192,14 @@ impl IDBObjectStore {
     /// <https://w3c.github.io/IndexedDB/#abort-an-upgrade-transaction>
     pub(crate) fn restore_metadata_after_abort(&self, can_gc: CanGc) {
         let Some(abort_state) = self.abort_state_on_abort.borrow().as_ref().cloned() else {
-            // Newly created object stores have no prior state to restore.
             return;
         };
 
         // Step 5.1. If handle’s object store was not newly created during transaction,
         // set handle’s name to its object store’s name.
-        if let Some(name) = abort_state.rollback_name {
+        if !abort_state.newly_created_during_transaction &&
+            let Some(name) = abort_state.rollback_name
+        {
             *self.name.borrow_mut() = name;
         }
 
@@ -197,14 +208,20 @@ impl IDBObjectStore {
         self.index_set.borrow_mut().clear();
         for index in abort_state.rollback_indexes {
             self.add_index(
-                index.name.into(),
+                index.name.clone().into(),
                 &IDBIndexParameters {
                     multiEntry: index.multi_entry,
                     unique: index.unique,
                 },
-                index.key_path.into(),
+                index.key_path.clone().into(),
                 can_gc,
             );
+        }
+
+        // Restore key generator state for existing object store handles.
+        if self.has_key_generator && !abort_state.newly_created_during_transaction {
+            self.key_generator_current_number
+                .set(abort_state.key_generator_current_number);
         }
     }
 
@@ -885,10 +902,10 @@ impl IDBObjectStoreMethods<crate::DomTypeHolder> for IDBObjectStore {
         }
 
         let old_name = self.name.borrow().clone();
-        if let Some(abort_state) = self.abort_state_on_abort.borrow_mut().as_mut() {
-            if abort_state.rollback_name.is_none() {
-                abort_state.rollback_name = Some(old_name.clone());
-            }
+        if let Some(abort_state) = self.abort_state_on_abort.borrow_mut().as_mut() &&
+            abort_state.rollback_name.is_none()
+        {
+            abort_state.rollback_name = Some(old_name.clone());
         }
 
         // Step 9. Set store’s name to name.

--- a/components/script/dom/indexeddb/idbobjectstore.rs
+++ b/components/script/dom/indexeddb/idbobjectstore.rs
@@ -85,15 +85,23 @@ impl From<KeyPath> for indexeddb::KeyPath {
     }
 }
 
+#[derive(Clone, JSTraceable, MallocSizeOf)]
+struct IDBObjectStoreAbortState {
+    rollback_name: Option<DOMString>,
+    #[no_trace]
+    rollback_indexes: Vec<indexeddb::IndexedDBIndex>,
+}
+
 #[dom_struct]
 pub struct IDBObjectStore {
     reflector_: Reflector,
     name: DomRefCell<DOMString>,
     key_path: Option<KeyPath>,
     index_set: DomRefCell<HashMap<DOMString, Dom<IDBIndex>>>,
+    abort_state_on_abort: DomRefCell<Option<IDBObjectStoreAbortState>>,
     transaction: Dom<IDBTransaction>,
     has_key_generator: bool,
-    key_generator_current_number: Cell<Option<i32>>,
+    key_generator_current_number: Cell<Option<i64>>,
 
     // We store the db name in the object store to address backend operations
     // that are keyed by (origin, database name, object store name).
@@ -105,7 +113,8 @@ impl IDBObjectStore {
         db_name: DOMString,
         name: DOMString,
         options: Option<&IDBObjectStoreParameters>,
-        key_generator_current_number: Option<i32>,
+        rollback_indexes_on_abort: Option<Vec<indexeddb::IndexedDBIndex>>,
+        key_generator_current_number: Option<i64>,
         transaction: &IDBTransaction,
     ) -> IDBObjectStore {
         let key_path: Option<KeyPath> = match options {
@@ -129,6 +138,12 @@ impl IDBObjectStore {
             name: DomRefCell::new(name),
             key_path,
             index_set: DomRefCell::new(HashMap::new()),
+            abort_state_on_abort: DomRefCell::new(rollback_indexes_on_abort.map(|indexes| {
+                IDBObjectStoreAbortState {
+                    rollback_name: None,
+                    rollback_indexes: indexes,
+                }
+            })),
             transaction: Dom::from_ref(transaction),
             has_key_generator,
             key_generator_current_number: Cell::new(key_generator_current_number),
@@ -141,7 +156,8 @@ impl IDBObjectStore {
         db_name: DOMString,
         name: DOMString,
         options: Option<&IDBObjectStoreParameters>,
-        key_generator_current_number: Option<i32>,
+        rollback_indexes_on_abort: Option<Vec<indexeddb::IndexedDBIndex>>,
+        key_generator_current_number: Option<i64>,
         can_gc: CanGc,
         transaction: &IDBTransaction,
     ) -> DomRoot<IDBObjectStore> {
@@ -150,6 +166,7 @@ impl IDBObjectStore {
                 db_name,
                 name,
                 options,
+                rollback_indexes_on_abort,
                 key_generator_current_number,
                 transaction,
             )),
@@ -160,6 +177,35 @@ impl IDBObjectStore {
 
     pub fn get_name(&self) -> DOMString {
         self.name.borrow().clone()
+    }
+
+    /// <https://w3c.github.io/IndexedDB/#abort-an-upgrade-transaction>
+    pub(crate) fn restore_metadata_after_abort(&self, can_gc: CanGc) {
+        let Some(abort_state) = self.abort_state_on_abort.borrow().as_ref().cloned() else {
+            // Newly created object stores have no prior state to restore.
+            return;
+        };
+
+        // Step 5.1. If handle’s object store was not newly created during transaction,
+        // set handle’s name to its object store’s name.
+        if let Some(name) = abort_state.rollback_name {
+            *self.name.borrow_mut() = name;
+        }
+
+        // Step 5.2. Set handle’s index set to the set of indexes that reference
+        // its object store.
+        self.index_set.borrow_mut().clear();
+        for index in abort_state.rollback_indexes {
+            self.add_index(
+                index.name.into(),
+                &IDBIndexParameters {
+                    multiEntry: index.multi_entry,
+                    unique: index.unique,
+                },
+                index.key_path.into(),
+                can_gc,
+            );
+        }
     }
 
     pub(crate) fn transaction(&self) -> DomRoot<IDBTransaction> {
@@ -208,7 +254,7 @@ impl IDBObjectStore {
     }
 
     /// <https://w3c.github.io/IndexedDB/#generate-a-key>
-    fn generate_key_for_put(&self) -> Fallible<(IndexedDBKeyType, i32)> {
+    fn generate_key_for_put(&self) -> Fallible<(IndexedDBKeyType, i64)> {
         // Step 1. Let generator be store's key generator.
         let Some(current_number) = self.key_generator_current_number.get() else {
             return Err(Error::Data(None));
@@ -228,7 +274,7 @@ impl IDBObjectStore {
     }
 
     /// <https://w3c.github.io/IndexedDB/#possibly-update-the-key-generator>
-    fn possibly_update_the_key_generator(&self, key: &IndexedDBKeyType) -> Option<i32> {
+    fn possibly_update_the_key_generator(&self, key: &IndexedDBKeyType) -> Option<i64> {
         // Step 1. If the type of key is not number, abort these steps.
         let IndexedDBKeyType::Number(number) = key else {
             return None;
@@ -249,12 +295,10 @@ impl IDBObjectStore {
         }
 
         let next = value + 1.0;
-        // Servo currently stores the key generator current number as i32.
-        // Saturate to keep "no more generated keys" behavior when this overflows.
-        if next >= i32::MAX as f64 {
-            return Some(i32::MAX);
+        if next > i64::MAX as f64 {
+            return Some(i64::MAX);
         }
-        Some(next as i32)
+        Some(next as i64)
     }
 
     /// <https://www.w3.org/TR/IndexedDB-3/#object-store-in-line-keys>
@@ -840,9 +884,20 @@ impl IDBObjectStoreMethods<crate::DomTypeHolder> for IDBObjectStore {
             return Err(Error::Constraint(None));
         }
 
+        let old_name = self.name.borrow().clone();
+        if let Some(abort_state) = self.abort_state_on_abort.borrow_mut().as_mut() {
+            if abort_state.rollback_name.is_none() {
+                abort_state.rollback_name = Some(old_name.clone());
+            }
+        }
+
         // Step 9. Set store’s name to name.
+        transaction
+            .Db()
+            .rename_object_store_name(&old_name, name.clone());
         // Step 10. Set this’s name to name.
-        *self.name.borrow_mut() = name;
+        *self.name.borrow_mut() = name.clone();
+        transaction.rename_object_store_handle_cache(&old_name, &name, self);
         Ok(())
     }
 

--- a/components/script/dom/indexeddb/idbtransaction.rs
+++ b/components/script/dom/indexeddb/idbtransaction.rs
@@ -63,7 +63,7 @@ pub struct IDBTransaction {
     committing: Cell<bool>,
     commit_started: Cell<bool>,
     version_change_old_version: Cell<Option<u64>>,
-    // https://w3c.github.io/IndexedDB/#abort-upgrade-transaction
+    // https://w3c.github.io/IndexedDB/#abort-an-upgrade-transaction
     // Step 4. NOTE: This reverts the value of objectStoreNames returned by the IDBDatabase object.
     version_change_old_object_store_names: DomRefCell<Option<Vec<DOMString>>>,
     // https://w3c.github.io/IndexedDB/#transaction-concept
@@ -268,6 +268,33 @@ impl IDBTransaction {
         self.version_change_old_version.set(Some(version));
     }
 
+    pub(crate) fn register_object_store_handle(&self, name: &DOMString, store: &IDBObjectStore) {
+        self.store_handles
+            .borrow_mut()
+            .insert(name.to_string(), Dom::from_ref(store));
+    }
+
+    pub(crate) fn rename_object_store_handle_cache(
+        &self,
+        old_name: &DOMString,
+        new_name: &DOMString,
+        store: &IDBObjectStore,
+    ) {
+        let mut store_handles = self.store_handles.borrow_mut();
+        store_handles.remove(&old_name.to_string());
+        store_handles.insert(new_name.to_string(), Dom::from_ref(store));
+    }
+
+    /// <https://w3c.github.io/IndexedDB/#abort-an-upgrade-transaction>
+    fn restore_associated_object_store_handles_after_abort(&self, can_gc: CanGc) {
+        // Step 5. For each object store handle handle associated with transaction,
+        // including those for object stores that were created or deleted during
+        // transaction:
+        for store in self.store_handles.borrow().values() {
+            store.restore_metadata_after_abort(can_gc);
+        }
+    }
+
     fn attempt_commit(&self) -> bool {
         if self.commit_started.get() {
             return true;
@@ -450,7 +477,7 @@ impl IDBTransaction {
             return;
         }
         if self.mode == IDBTransactionMode::Versionchange {
-            // https://w3c.github.io/IndexedDB/#abort-upgrade-transaction
+            // https://w3c.github.io/IndexedDB/#abort-an-upgrade-transaction
             // Step 4. Set connection’s object store set to the set of object stores in database if database previously existed,
             // or the empty set if database was newly created.
             if let Some(names) = self
@@ -461,6 +488,7 @@ impl IDBTransaction {
             {
                 self.db.restore_object_store_names(names);
             }
+            self.restore_associated_object_store_handles_after_abort(can_gc);
         }
         self.abort_initiated.set(true);
         // https://w3c.github.io/IndexedDB/#transaction-concept
@@ -652,7 +680,7 @@ impl IDBTransaction {
     fn object_store_parameters(
         &self,
         object_store_name: &DOMString,
-    ) -> Option<(IDBObjectStoreParameters, Vec<IndexedDBIndex>, Option<i32>)> {
+    ) -> Option<(IDBObjectStoreParameters, Vec<IndexedDBIndex>, Option<i64>)> {
         let global = self.global();
         let idb_sender = global.storage_threads().sender();
         let (sender, receiver) =
@@ -727,6 +755,12 @@ impl IDBTransactionMethods<crate::DomTypeHolder> for IDBTransaction {
             self.db.get_name(),
             name.clone(),
             parameters.as_ref().map(|(params, _, _)| params),
+            Some(
+                parameters
+                    .as_ref()
+                    .map(|(_, indexes, _)| indexes.clone())
+                    .unwrap_or_default(),
+            ),
             parameters
                 .as_ref()
                 .and_then(|(_, _, key_generator_current_number)| *key_generator_current_number),
@@ -746,9 +780,7 @@ impl IDBTransactionMethods<crate::DomTypeHolder> for IDBTransaction {
                 );
             }
         }
-        self.store_handles
-            .borrow_mut()
-            .insert(name.to_string(), Dom::from_ref(&*store));
+        self.register_object_store_handle(&name, &store);
         Ok(store)
     }
 

--- a/components/script/dom/indexeddb/idbtransaction.rs
+++ b/components/script/dom/indexeddb/idbtransaction.rs
@@ -38,7 +38,7 @@ use crate::dom::event::{Event, EventBubbles, EventCancelable};
 use crate::dom::eventtarget::EventTarget;
 use crate::dom::globalscope::GlobalScope;
 use crate::dom::indexeddb::idbdatabase::IDBDatabase;
-use crate::dom::indexeddb::idbobjectstore::IDBObjectStore;
+use crate::dom::indexeddb::idbobjectstore::{IDBObjectStore, IDBObjectStoreAbortState};
 use crate::dom::indexeddb::idbrequest::IDBRequest;
 use crate::script_runtime::CanGc;
 
@@ -761,15 +761,20 @@ impl IDBTransactionMethods<crate::DomTypeHolder> for IDBTransaction {
             self.db.get_name(),
             name.clone(),
             parameters.as_ref().map(|(params, _, _)| params),
-            Some(
-                parameters
+            IDBObjectStoreAbortState {
+                newly_created_during_transaction: false,
+                rollback_indexes_on_abort: if self.mode == IDBTransactionMode::Versionchange {
+                    parameters
+                        .as_ref()
+                        .map(|(_, indexes, _)| indexes.clone())
+                        .unwrap_or_default()
+                } else {
+                    Vec::new()
+                },
+                key_generator_current_number: parameters
                     .as_ref()
-                    .map(|(_, indexes, _)| indexes.clone())
-                    .unwrap_or_default(),
-            ),
-            parameters
-                .as_ref()
-                .and_then(|(_, _, key_generator_current_number)| *key_generator_current_number),
+                    .and_then(|(_, _, key_generator_current_number)| *key_generator_current_number),
+            },
             can_gc,
             self,
         );

--- a/components/script/dom/indexeddb/idbtransaction.rs
+++ b/components/script/dom/indexeddb/idbtransaction.rs
@@ -290,7 +290,13 @@ impl IDBTransaction {
         // Step 5. For each object store handle handle associated with transaction,
         // including those for object stores that were created or deleted during
         // transaction:
-        for store in self.store_handles.borrow().values() {
+        let stores = self
+            .store_handles
+            .borrow()
+            .values()
+            .map(|store| DomRoot::from_ref(&**store))
+            .collect::<Vec<_>>();
+        for store in stores {
             store.restore_metadata_after_abort(can_gc);
         }
     }

--- a/components/shared/storage/indexeddb.rs
+++ b/components/shared/storage/indexeddb.rs
@@ -272,7 +272,7 @@ pub struct IndexedDBObjectStore {
     pub name: String,
     pub key_path: Option<KeyPath>,
     pub has_key_generator: bool,
-    pub key_generator_current_number: Option<i32>,
+    pub key_generator_current_number: Option<i64>,
     pub indexes: Vec<IndexedDBIndex>,
 }
 
@@ -337,7 +337,7 @@ pub enum AsyncReadWriteOperation {
         value: Vec<u8>,
         should_overwrite: bool,
         /// New object store key generator current number to persist if the put succeeds.
-        key_generator_current_number: Option<i32>,
+        key_generator_current_number: Option<i64>,
     },
 
     /// Removes the key/value pair for the given key in the associated idb data

--- a/components/storage/indexeddb/engines/mod.rs
+++ b/components/storage/indexeddb/engines/mod.rs
@@ -49,7 +49,12 @@ pub trait KvsEngine: MallocSizeOf {
         on_complete: Box<dyn FnOnce() + Send + 'static>,
     );
 
-    fn key_generator_current_number(&self, store_name: &str) -> Option<i32>;
+    fn key_generator_current_number(&self, store_name: &str) -> Option<i64>;
+    fn set_key_generator_current_number(
+        &self,
+        store_name: &str,
+        current_number: i64,
+    ) -> Result<(), Self::Error>;
     fn key_path(&self, store_name: &str) -> Option<KeyPath>;
     fn object_store_names(&self) -> Result<Vec<String>, Self::Error>;
     fn indexes(&self, store_name: &str) -> Result<Vec<IndexedDBIndex>, Self::Error>;

--- a/components/storage/indexeddb/engines/sqlite.rs
+++ b/components/storage/indexeddb/engines/sqlite.rs
@@ -240,7 +240,7 @@ impl SqliteEngine {
         key: IndexedDBKeyType,
         value: Vec<u8>,
         should_overwrite: bool,
-        key_generator_current_number: Option<i32>,
+        key_generator_current_number: Option<i64>,
     ) -> Result<PutItemResult, Error> {
         let no_overwrite = !should_overwrite;
         let serialized_key: Vec<u8> = encoding::serialize(&key);
@@ -574,7 +574,7 @@ impl KvsEngine for SqliteEngine {
         });
     }
 
-    fn key_generator_current_number(&self, store_name: &str) -> Option<i32> {
+    fn key_generator_current_number(&self, store_name: &str) -> Option<i64> {
         self.connection
             .prepare("SELECT * FROM object_store WHERE name = ?")
             .and_then(|mut stmt| {
@@ -586,6 +586,32 @@ impl KvsEngine for SqliteEngine {
             .optional()
             .unwrap()
             .and_then(|current_number| (current_number != 0).then_some(current_number))
+    }
+
+    fn set_key_generator_current_number(
+        &self,
+        store_name: &str,
+        current_number: i64,
+    ) -> Result<(), Self::Error> {
+        // Ensure missing store is reported as QueryReturnedNoRows even when an
+        // UPDATE might affect zero rows due to no-op assignment.
+        let store_exists: bool = self.connection.query_row(
+            "SELECT EXISTS(SELECT 1 FROM object_store WHERE name = ?)",
+            params![store_name],
+            |row| row.get(0),
+        )?;
+        if !store_exists {
+            return Err(Error::QueryReturnedNoRows);
+        }
+
+        let rows_affected = self.connection.execute(
+            "UPDATE object_store SET auto_increment = ? WHERE name = ?",
+            params![current_number, store_name],
+        )?;
+        if rows_affected > 1 {
+            return Err(Error::QueryReturnedMoreThanOneRow);
+        }
+        Ok(())
     }
 
     fn key_path(&self, store_name: &str) -> Option<KeyPath> {

--- a/components/storage/indexeddb/engines/sqlite/object_store_model.rs
+++ b/components/storage/indexeddb/engines/sqlite/object_store_model.rs
@@ -20,7 +20,7 @@ pub struct Model {
     pub id: i32,
     pub name: String,
     pub key_path: Option<Vec<u8>>,
-    pub auto_increment: i32,
+    pub auto_increment: i64,
 }
 
 impl TryFrom<&Row<'_>> for Model {

--- a/components/storage/indexeddb/mod.rs
+++ b/components/storage/indexeddb/mod.rs
@@ -72,10 +72,25 @@ pub struct IndexedDBDescription {
 }
 
 #[derive(MallocSizeOf)]
+struct KeyGeneratorSnapshot {
+    // Mirrors IndexedDB's "key generator current number" for rollback on abort.
+    // https://w3c.github.io/IndexedDB/#key-generator-current-number
+    // Backed by i64 so we can represent the IndexedDB-mandated range.
+    store_name: String,
+    current_number: i64,
+}
+
+#[derive(MallocSizeOf)]
+struct TxnScopeStore {
+    name: String,
+    key_generator_snapshot: Option<KeyGeneratorSnapshot>,
+}
+
+#[derive(MallocSizeOf)]
 struct TxnInfo {
     created_seq: u64,
     mode: IndexedDBTxnMode,
-    scope: HashSet<String>,
+    scope: Vec<TxnScopeStore>,
     live: bool,
 }
 
@@ -125,6 +140,25 @@ impl<E: KvsEngine> IndexedDBEnvironment<E> {
         if self.txn_info.contains_key(&txn) {
             return;
         }
+        let scope: HashSet<String> = scope.into_iter().collect();
+        let scope: Vec<TxnScopeStore> = scope
+            .into_iter()
+            .map(|store_name| {
+                let key_generator_snapshot = if mode == IndexedDBTxnMode::Readwrite {
+                    self.key_generator_current_number(&store_name)
+                        .map(|current_number| KeyGeneratorSnapshot {
+                            store_name: store_name.clone(),
+                            current_number,
+                        })
+                } else {
+                    None
+                };
+                TxnScopeStore {
+                    name: store_name,
+                    key_generator_snapshot,
+                }
+            })
+            .collect();
         let created_seq = self.next_created_seq;
         self.next_created_seq += 1;
         self.txn_info.insert(
@@ -132,7 +166,7 @@ impl<E: KvsEngine> IndexedDBEnvironment<E> {
             TxnInfo {
                 created_seq,
                 mode: mode.clone(),
-                scope: scope.into_iter().collect(),
+                scope,
                 live: true,
             },
         );
@@ -145,7 +179,9 @@ impl<E: KvsEngine> IndexedDBEnvironment<E> {
     }
 
     fn scopes_overlap(a: &TxnInfo, b: &TxnInfo) -> bool {
-        a.scope.iter().any(|store| b.scope.contains(store))
+        a.scope
+            .iter()
+            .any(|store| b.scope.iter().any(|other| other.name == store.name))
     }
 
     fn earlier_overlapping_live_exists<F>(&self, txn: u64, predicate: F) -> bool
@@ -472,6 +508,28 @@ impl<E: KvsEngine> IndexedDBEnvironment<E> {
     }
 
     fn abort_transaction(&mut self, txn: u64) {
+        let key_generator_snapshots = self
+            .txn_info
+            .get(&txn)
+            .filter(|info| info.mode == IndexedDBTxnMode::Readwrite)
+            .map(|info| {
+                info.scope
+                    .iter()
+                    .filter_map(|store| store.key_generator_snapshot.as_ref())
+                    .map(|snapshot| KeyGeneratorSnapshot {
+                        store_name: snapshot.store_name.clone(),
+                        current_number: snapshot.current_number,
+                    })
+                    .collect::<Vec<_>>()
+            })
+            .unwrap_or_default();
+        // https://w3c.github.io/IndexedDB/#key-generator-construct
+        // Likewise, if a transaction is aborted, the current number of the
+        // key generator for each object store in the transaction’s scope is
+        // reverted to the value it had before the transaction was started.
+        let res = self.restore_key_generators_after_abort(&key_generator_snapshots);
+        debug_assert!(res.is_ok(), "Restoring key generators should not fail.");
+
         // Keep scheduling metadata until script reports TransactionFinished.
         // https://w3c.github.io/IndexedDB/#transaction-lifetime
         self.transactions.remove(&txn);
@@ -488,8 +546,52 @@ impl<E: KvsEngine> IndexedDBEnvironment<E> {
         self.pending_commit_callbacks.remove(&txn);
     }
 
-    fn key_generator_current_number(&self, store_name: &str) -> Option<i32> {
+    fn key_generator_current_number(&self, store_name: &str) -> Option<i64> {
         self.engine.key_generator_current_number(store_name)
+    }
+
+    fn set_key_generator_current_number(
+        &self,
+        store_name: &str,
+        current_number: i64,
+    ) -> DbResult<()> {
+        self.engine
+            .set_key_generator_current_number(store_name, current_number)
+            .map_err(|err| format!("{err:?}"))
+    }
+
+    /// <https://w3c.github.io/IndexedDB/#key-generator-construct>
+    fn restore_key_generators_after_abort(
+        &self,
+        key_generator_snapshots: &[KeyGeneratorSnapshot],
+    ) -> DbResult<()> {
+        // Likewise, if a transaction is aborted, the current number of the key
+        // generator for each object store in the transaction’s scope is
+        // reverted to the value it had before the transaction was started.
+        for snapshot in key_generator_snapshots {
+            self.set_key_generator_current_number(&snapshot.store_name, snapshot.current_number)?;
+        }
+        Ok(())
+    }
+
+    /// <https://w3c.github.io/IndexedDB/#key-generator-construct>
+    fn object_store(&self, store_name: &str) -> DbResult<IndexedDBObjectStore> {
+        // A key generator has a current number.
+        let key_generator_current_number = self.key_generator_current_number(store_name);
+        Ok(IndexedDBObjectStore {
+            key_path: self.key_path(store_name),
+            has_key_generator: key_generator_current_number.is_some(),
+            key_generator_current_number,
+            indexes: self.indexes(store_name)?,
+            name: store_name.to_string(),
+        })
+    }
+
+    fn object_stores(&self) -> DbResult<Vec<IndexedDBObjectStore>> {
+        self.object_store_names()?
+            .into_iter()
+            .map(|store_name| self.object_store(&store_name))
+            .collect()
     }
 
     fn key_path(&self, store_name: &str) -> Option<KeyPath> {
@@ -553,6 +655,85 @@ impl<E: KvsEngine> IndexedDBEnvironment<E> {
         self.engine
             .delete_store(store_name)
             .map_err(|err| format!("{err:?}"))
+    }
+
+    /// Restores the object-store metadata snapshot captured before an aborted
+    /// upgrade: remove stores/indexes created during the aborted upgrade, create
+    /// stores/indexes that existed before it, and reset key-generator current
+    /// numbers for stores that use key generators.
+    fn restore_object_stores(&mut self, object_stores: &[IndexedDBObjectStore]) -> DbResult<()> {
+        let mut current_store_names: HashSet<String> =
+            self.object_store_names()?.into_iter().collect();
+        let expected_store_names: HashSet<String> = object_stores
+            .iter()
+            .map(|store| store.name.clone())
+            .collect();
+
+        for store_name in current_store_names.clone() {
+            if !expected_store_names.contains(&store_name) {
+                self.delete_object_store(&store_name)?;
+                current_store_names.remove(&store_name);
+            }
+        }
+
+        for store in object_stores {
+            if !current_store_names.contains(&store.name) {
+                // https://w3c.github.io/IndexedDB/#key-generator-construct
+                // The initial value of a key generator’s current number is 1,
+                // set when the associated object store is created.
+                self.create_object_store(
+                    &store.name,
+                    store.key_path.clone(),
+                    store.has_key_generator,
+                )?;
+                current_store_names.insert(store.name.clone());
+            }
+
+            if let Some(current_number) = store.key_generator_current_number {
+                // https://w3c.github.io/IndexedDB/#key-generator-construct
+                // Modifying a key generator’s current number is considered part
+                // of a database operation. This means that if the operation
+                // fails and the operation is reverted, the current number is
+                // reverted to the value it had before the operation started.
+                // Likewise, if a transaction is aborted, the current number of
+                // the key generator for each object store in the transaction’s
+                // scope is reverted to the value it had before the transaction
+                // was started.
+                self.set_key_generator_current_number(&store.name, current_number)?;
+            }
+
+            let mut current_index_names: HashSet<String> = self
+                .indexes(&store.name)?
+                .into_iter()
+                .map(|index| index.name)
+                .collect();
+            let expected_index_names: HashSet<String> = store
+                .indexes
+                .iter()
+                .map(|index| index.name.clone())
+                .collect();
+
+            for index_name in current_index_names.clone() {
+                if !expected_index_names.contains(&index_name) {
+                    self.delete_index(&store.name, index_name.clone())?;
+                    current_index_names.remove(&index_name);
+                }
+            }
+
+            for index in &store.indexes {
+                if !current_index_names.contains(&index.name) {
+                    self.create_index(
+                        &store.name,
+                        index.name.clone(),
+                        index.key_path.clone(),
+                        index.unique,
+                        index.multi_entry,
+                    )?;
+                }
+            }
+        }
+
+        Ok(())
     }
 
     fn version(&self) -> Result<u64, E::Error> {
@@ -713,7 +894,7 @@ impl OpenRequest {
 
     /// Abort the open request,
     /// optionally returning a version to revert to.
-    fn abort(&self) -> Option<u64> {
+    fn abort(&self) -> Option<VersionUpgrade> {
         match self {
             OpenRequest::Open {
                 sender,
@@ -735,7 +916,7 @@ impl OpenRequest {
                 {
                     error!("Failed to send ConnectionMsg::Connection to script.");
                 };
-                pending_upgrade.as_ref().map(|upgrade| upgrade.old)
+                pending_upgrade.clone()
             },
             OpenRequest::Delete {
                 sender,
@@ -754,11 +935,12 @@ impl OpenRequest {
     }
 }
 
-#[derive(MallocSizeOf)]
+#[derive(Clone, MallocSizeOf)]
 struct VersionUpgrade {
     old: u64,
     new: u64,
     transaction: u64,
+    object_stores: Vec<IndexedDBObjectStore>,
 }
 
 /// <https://w3c.github.io/IndexedDB/#connection>
@@ -1021,7 +1203,7 @@ impl IndexedDBManager {
             return;
         }
 
-        let (request_id, proxy_map, db_name) = {
+        let (request_id, proxy_map) = {
             let Some(queue) = self.connection_queues.get_mut(&key) else {
                 return debug_assert!(false, "A connection queue should exist.");
             };
@@ -1032,7 +1214,7 @@ impl IndexedDBManager {
                 pending_upgrade: Some(pending_upgrade),
                 id,
                 proxy_map,
-                db_name,
+                db_name: _,
                 ..
             } = front
             else {
@@ -1041,10 +1223,10 @@ impl IndexedDBManager {
             if pending_upgrade.transaction != txn {
                 return;
             }
-            (*id, (*proxy_map).clone(), db_name.clone())
+            (*id, (*proxy_map).clone())
         };
 
-        self.abort_pending_upgrade(name, request_id, origin, db_name, &proxy_map);
+        self.abort_pending_upgrade(name, request_id, origin, &proxy_map);
     }
 
     /// Run the next open request in the queue.
@@ -1129,25 +1311,24 @@ impl IndexedDBManager {
     fn revert_aborted_upgrade(
         &mut self,
         key: &IndexedDBDescription,
-        old_version: u64,
-        db_name: String,
+        upgrade: &VersionUpgrade,
         proxy_map: &StorageProxyMap,
     ) {
-        if old_version == 0 {
+        if upgrade.old == 0 {
             if let Some(db) = self.databases.remove(key) {
                 // Note: ensure db is dropped before deleting directory,
                 // to get around windows file locks.
                 drop(db);
                 let response = proxy_map
                     .handle
-                    .delete_database(proxy_map.bottle_id, db_name.clone())
+                    .delete_database(proxy_map.bottle_id, key.name.clone())
                     .recv();
                 if response.is_err() {
                     error!("Failed to communicate with client storage.");
                     return;
                 }
                 if response.unwrap().is_err() {
-                    error!("Failed to delete database {:?}", db_name);
+                    error!("Failed to delete database {:?}", key.name);
                 }
             }
             return;
@@ -1156,23 +1337,27 @@ impl IndexedDBManager {
         let Some(db) = self.databases.get_mut(key) else {
             return debug_assert!(false, "Db should have been created");
         };
-        let res = db.set_version(old_version);
+        let res = db.set_version(upgrade.old);
         debug_assert!(res.is_ok(), "Setting a db version should not fail.");
+
+        // Step 4. Set connection’s object store set to the set of object stores
+        // in database if database previously existed, or the empty set if
+        // database was newly created.
+        let res = db.restore_object_stores(&upgrade.object_stores);
+        debug_assert!(res.is_ok(), "Restoring object stores should not fail.");
     }
 
     /// Aborting the current upgrade for an origin.
     // https://w3c.github.io/IndexedDB/#abort-an-upgrade-transaction
-    /// Note: this only reverts the version at this point.
     fn abort_pending_upgrade(
         &mut self,
         name: String,
         id: Uuid,
         origin: ImmutableOrigin,
-        db_name: String,
         proxy_map: &StorageProxyMap,
     ) {
         let key = IndexedDBDescription { name, origin };
-        let old = {
+        let upgrade = {
             let Some(queue) = self.connection_queues.get_mut(&key) else {
                 return debug_assert!(
                     false,
@@ -1190,8 +1375,8 @@ impl IndexedDBManager {
             }
             open_request.abort()
         };
-        if let Some(old_version) = old {
-            self.revert_aborted_upgrade(&key, old_version, db_name, proxy_map);
+        if let Some(upgrade) = upgrade {
+            self.revert_aborted_upgrade(&key, &upgrade, proxy_map);
         }
 
         self.remove_connection(&key, &id);
@@ -1209,7 +1394,7 @@ impl IndexedDBManager {
         proxy_map: StorageProxyMap,
     ) {
         for (name, ids) in pending_upgrades.into_iter() {
-            let mut version_to_revert: Option<u64> = None;
+            let mut upgrade_to_revert: Option<VersionUpgrade> = None;
             let key = IndexedDBDescription {
                 name: name.clone(),
                 origin: origin.clone(),
@@ -1224,11 +1409,11 @@ impl IndexedDBManager {
                     };
                     queue.retain_mut(|open_request| {
                         if ids.contains(&open_request.get_id()) {
-                            let old = open_request.abort();
-                            if version_to_revert.is_none() &&
-                                let Some(old) = old
-                            {
-                                version_to_revert = Some(old);
+                            let upgrade = open_request.abort();
+                            if upgrade_to_revert.is_none() {
+                                if let Some(upgrade) = upgrade {
+                                    upgrade_to_revert = Some(upgrade);
+                                }
                             }
                             false
                         } else {
@@ -1241,8 +1426,8 @@ impl IndexedDBManager {
                     self.connection_queues.remove(&key);
                 }
             }
-            if let Some(version) = version_to_revert {
-                self.revert_aborted_upgrade(&key, version, name, &proxy_map);
+            if let Some(upgrade) = upgrade_to_revert {
+                self.revert_aborted_upgrade(&key, &upgrade, &proxy_map);
             }
         }
     }
@@ -1365,6 +1550,9 @@ impl IndexedDBManager {
 
         // Step 7: Let old version be db’s version.
         let old_version = db.version().expect("DB should have a version.");
+        let object_stores = db
+            .object_stores()
+            .expect("Fetching object stores should not fail.");
 
         // Step 8: Set db’s version to version. This change is considered part of the
         // transaction, and so if the transaction is aborted, this change is reverted.
@@ -1377,6 +1565,7 @@ impl IndexedDBManager {
             old: old_version,
             new: new_version,
             transaction,
+            object_stores,
         });
 
         // Step 10: Queue a database task to run these steps.
@@ -2253,5 +2442,91 @@ impl IndexedDBManager {
             });
         });
         reports
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use servo_base::generic_channel;
+    use servo_base::threadpool::ThreadPool;
+    use servo_url::ImmutableOrigin;
+    use storage_traits::indexeddb::{IndexedDBTxnMode, KeyPath};
+    use url::Host;
+
+    use super::{IndexedDBDescription, IndexedDBEnvironment};
+    use crate::indexeddb::engines::SqliteEngine;
+
+    fn test_origin() -> ImmutableOrigin {
+        ImmutableOrigin::Tuple(
+            "test_origin".to_string(),
+            Host::Domain("localhost".to_string()),
+            80,
+        )
+    }
+
+    #[test]
+    fn test_restore_object_stores_removes_created_store_and_indexes() {
+        let base_dir = tempfile::tempdir().expect("Failed to create temp dir");
+        let thread_pool = ThreadPool::global();
+        let description = IndexedDBDescription {
+            name: "test_db".to_string(),
+            origin: test_origin(),
+        };
+        let engine = SqliteEngine::new(
+            base_dir.path().to_path_buf(),
+            true,
+            &description,
+            thread_pool,
+        )
+        .unwrap();
+        let (sender, _receiver) = generic_channel::channel().unwrap();
+        let mut env = IndexedDBEnvironment::new(engine, sender);
+
+        let object_stores = env.object_stores().unwrap();
+        assert!(object_stores.is_empty());
+
+        env.create_object_store("not_books", None, false).unwrap();
+        env.create_index(
+            "not_books",
+            "not_by_author".to_string(),
+            KeyPath::String("author".to_string()),
+            false,
+            false,
+        )
+        .unwrap();
+
+        env.restore_object_stores(&object_stores).unwrap();
+
+        assert_eq!(env.object_store_names().unwrap(), Vec::<String>::new());
+    }
+
+    #[test]
+    fn test_abort_transaction_restores_readwrite_key_generator_current_number() {
+        let base_dir = tempfile::tempdir().expect("Failed to create temp dir");
+        let thread_pool = ThreadPool::global();
+        let description = IndexedDBDescription {
+            name: "test_db".to_string(),
+            origin: test_origin(),
+        };
+        let engine = SqliteEngine::new(
+            base_dir.path().to_path_buf(),
+            true,
+            &description,
+            thread_pool,
+        )
+        .unwrap();
+        let (sender, _receiver) = generic_channel::channel().unwrap();
+        let mut env = IndexedDBEnvironment::new(engine, sender);
+
+        env.create_object_store("books", None, true).unwrap();
+        assert_eq!(env.key_generator_current_number("books"), Some(1));
+
+        env.register_transaction(1, IndexedDBTxnMode::Readwrite, vec!["books".to_string()]);
+        env.set_key_generator_current_number("books", 345680)
+            .unwrap();
+
+        env.abort_transaction(1);
+
+        assert_eq!(env.key_generator_current_number("books"), Some(1));
     }
 }

--- a/components/storage/indexeddb/mod.rs
+++ b/components/storage/indexeddb/mod.rs
@@ -1410,10 +1410,10 @@ impl IndexedDBManager {
                     queue.retain_mut(|open_request| {
                         if ids.contains(&open_request.get_id()) {
                             let upgrade = open_request.abort();
-                            if upgrade_to_revert.is_none() {
-                                if let Some(upgrade) = upgrade {
-                                    upgrade_to_revert = Some(upgrade);
-                                }
+                            if upgrade_to_revert.is_none() &&
+                                let Some(upgrade) = upgrade
+                            {
+                                upgrade_to_revert = Some(upgrade);
                             }
                             false
                         } else {

--- a/tests/wpt/meta/IndexedDB/idbindex-rename-abort.any.js.ini
+++ b/tests/wpt/meta/IndexedDB/idbindex-rename-abort.any.js.ini
@@ -5,15 +5,8 @@
   [IndexedDB index rename in aborted transaction]
     expected: FAIL
 
-  [IndexedDB index creation and rename in an aborted transaction]
-    expected: FAIL
-
-
 [idbindex-rename-abort.any.worker.html]
   [IndexedDB index rename in aborted transaction]
-    expected: FAIL
-
-  [IndexedDB index creation and rename in an aborted transaction]
     expected: FAIL
 
 

--- a/tests/wpt/meta/IndexedDB/idbobjectstore-rename-abort.any.js.ini
+++ b/tests/wpt/meta/IndexedDB/idbobjectstore-rename-abort.any.js.ini
@@ -3,18 +3,3 @@
 
 [idbobjectstore-rename-abort.any.serviceworker.html]
   expected: ERROR
-
-[idbobjectstore-rename-abort.any.worker.html]
-  [IndexedDB object store rename in aborted transaction]
-    expected: FAIL
-
-  [IndexedDB object store creation and rename in an aborted transaction]
-    expected: FAIL
-
-
-[idbobjectstore-rename-abort.any.html]
-  [IndexedDB object store rename in aborted transaction]
-    expected: FAIL
-
-  [IndexedDB object store creation and rename in an aborted transaction]
-    expected: FAIL

--- a/tests/wpt/meta/IndexedDB/transaction-abort-generator-revert.any.js.ini
+++ b/tests/wpt/meta/IndexedDB/transaction-abort-generator-revert.any.js.ini
@@ -1,20 +1,5 @@
-[transaction-abort-generator-revert.any.worker.html]
-  [The current number of a key generator is reverted when a versionchange transaction aborts]
-    expected: FAIL
-
-  [The current number of a key generator is reverted when a readwrite transaction aborts]
-    expected: FAIL
-
-
 [transaction-abort-generator-revert.any.sharedworker.html]
   expected: ERROR
 
 [transaction-abort-generator-revert.any.serviceworker.html]
   expected: ERROR
-
-[transaction-abort-generator-revert.any.html]
-  [The current number of a key generator is reverted when a versionchange transaction aborts]
-    expected: FAIL
-
-  [The current number of a key generator is reverted when a readwrite transaction aborts]
-    expected: FAIL


### PR DESCRIPTION
IndexedDB: Implement IndexedDB abort rollback for object store metadata and key generators

Testing: abort rollback  WPT test passed.
part of https://github.com/servo/servo/issues/40983
