### PR TITLE
mach: remove shorthand support for direct test file paths in mach test-unit

### DIFF
--- a/python/servo/testing_commands.py
+++ b/python/servo/testing_commands.py
@@ -12,7 +12,6 @@ import json
 import logging
 import os
 import os.path as path
-import re
 import shutil
 import subprocess
 import sys
@@ -155,12 +154,6 @@ class MachCommands(CommandBase):
         return call(cmd, env=env, cwd=path.join("etc", "ci", "performance"))
 
     @Command("test-unit", description="Run unit tests", category="testing")
-    @CommandArgument(
-        "--test-name",
-        nargs=argparse.ZERO_OR_MORE,
-        default=None,
-        help="Only run tests that match this pattern or file path",
-    )
     @CommandArgument("--package", "-p", default=None, help="Specific package to test")
     @CommandArgument("--bench", default=False, action="store_true", help="Run in bench mode")
     @CommandArgument(
@@ -174,7 +167,6 @@ class MachCommands(CommandBase):
     def test_unit(
         self,
         build_type: BuildType,
-        test_name: list[str] | None = None,
         params: list[str] | None = None,
         package: str | None = None,
         bench: bool = False,
@@ -184,34 +176,12 @@ class MachCommands(CommandBase):
         nextest_profile: str | None = None,
         **kwargs: Any,
     ) -> int:
-        if test_name is None:
-            test_name = []
-
         self.ensure_bootstrapped()
 
         if package:
             packages = {package}
         else:
             packages = set()
-
-        test_patterns = []
-        for test in test_name:
-            # add package if 'tests/unit/<package>'
-            match = re.search("tests/unit/(\\w+)/?$", test)
-            if match:
-                packages.add(match.group(1))
-            # add package & test if '<package>/<test>', 'tests/unit/<package>/<test>.rs', or similar
-            elif re.search("\\w/\\w", test):
-                tokens = test.split("/")
-                packages.add(tokens[-2])
-                test_prefix = tokens[-1]
-                if test_prefix.endswith(".rs"):
-                    test_prefix = test_prefix[:-3]
-                test_prefix += "::"
-                test_patterns.append(test_prefix)
-            # add test as-is otherwise
-            else:
-                test_patterns.append(test)
 
         self_contained_tests = [
             "servo-background-hang-monitor",
@@ -271,7 +241,6 @@ class MachCommands(CommandBase):
             args += ["-p", "%s_tests" % crate]
         for crate in in_crate_packages:
             args += ["-p", crate]
-        args += test_patterns
 
         if nocapture:
             args += ["--nocapture"]

--- a/python/servo/testing_commands.py
+++ b/python/servo/testing_commands.py
@@ -169,7 +169,6 @@ class MachCommands(CommandBase):
     def test_unit(
         self,
         build_type: BuildType,
-        test_name: list[str] | None = None,
         params: list[str] | None = None,
         package: str | None = None,
         bench: bool = False,
@@ -179,8 +178,8 @@ class MachCommands(CommandBase):
         nextest_profile: str | None = None,
         **kwargs: Any,
     ) -> int:
-        if test_name is None:
-            test_name = []
+        if params is None:
+            params = []
 
         self.ensure_bootstrapped()
 
@@ -190,7 +189,7 @@ class MachCommands(CommandBase):
             packages = set()
 
         test_patterns = []
-        for test in test_name:
+        for test in params:
             # add package if 'tests/unit/<package>'
             match = re.search("tests/unit/(\\w+)/?$", test)
             if match:
@@ -238,18 +237,6 @@ class MachCommands(CommandBase):
             packages = set(os.listdir(path.join(self.context.topdir, "tests", "unit"))) - set([".DS_Store"])
             packages |= set(self_contained_tests)
 
-            if params:
-                # We have added all the unit test packages, now we need to remove the ones that were specified as file paths in params.
-                # This is needed incase we want to run a single test file that is not in the default test suite, or if we want to run a single test function in a test file.
-                for i in range(len(params)):
-                    single_file_test = params[i]
-                    # Split by '/' and take the last part
-                    last_part = single_file_test.split("/")[-1]
-                    # Remove file extension if present (assuming .rs)
-                    if last_part.endswith(".rs"):
-                        last_part = last_part[:-3]
-                    params[i] = last_part
-
         in_crate_packages = []
         for crate in self_contained_tests:
             try:
@@ -262,7 +249,7 @@ class MachCommands(CommandBase):
         if len(packages) == 0 and len(in_crate_packages) == 0:
             return 0
 
-        args: list[str] = params or []
+        args: list[str] = []
 
         if build_type.is_release():
             args += ["--release"]

--- a/python/servo/testing_commands.py
+++ b/python/servo/testing_commands.py
@@ -155,7 +155,12 @@ class MachCommands(CommandBase):
         return call(cmd, env=env, cwd=path.join("etc", "ci", "performance"))
 
     @Command("test-unit", description="Run unit tests", category="testing")
-    @CommandArgument("test_name", nargs=argparse.REMAINDER, help="Only run tests that match this pattern or file path")
+    @CommandArgument(
+        "--test-name",
+        nargs=argparse.ZERO_OR_MORE,
+        default=None,
+        help="Only run tests that match this pattern or file path",
+    )
     @CommandArgument("--package", "-p", default=None, help="Specific package to test")
     @CommandArgument("--bench", default=False, action="store_true", help="Run in bench mode")
     @CommandArgument(
@@ -169,6 +174,7 @@ class MachCommands(CommandBase):
     def test_unit(
         self,
         build_type: BuildType,
+        test_name: list[str] | None = None,
         params: list[str] | None = None,
         package: str | None = None,
         bench: bool = False,
@@ -178,8 +184,8 @@ class MachCommands(CommandBase):
         nextest_profile: str | None = None,
         **kwargs: Any,
     ) -> int:
-        if params is None:
-            params = []
+        if test_name is None:
+            test_name = []
 
         self.ensure_bootstrapped()
 
@@ -189,7 +195,7 @@ class MachCommands(CommandBase):
             packages = set()
 
         test_patterns = []
-        for test in params:
+        for test in test_name:
             # add package if 'tests/unit/<package>'
             match = re.search("tests/unit/(\\w+)/?$", test)
             if match:
@@ -249,7 +255,7 @@ class MachCommands(CommandBase):
         if len(packages) == 0 and len(in_crate_packages) == 0:
             return 0
 
-        args: list[str] = []
+        args: list[str] = params or []
 
         if build_type.is_release():
             args += ["--release"]

--- a/python/servo/testing_commands.py
+++ b/python/servo/testing_commands.py
@@ -238,6 +238,18 @@ class MachCommands(CommandBase):
             packages = set(os.listdir(path.join(self.context.topdir, "tests", "unit"))) - set([".DS_Store"])
             packages |= set(self_contained_tests)
 
+            if params:
+                # We have added all the unit test packages, now we need to remove the ones that were specified as file paths in params.
+                # This is needed incase we want to run a single test file that is not in the default test suite, or if we want to run a single test function in a test file.
+                for i in range(len(params)):
+                    single_file_test = params[i]
+                    # Split by '/' and take the last part
+                    last_part = single_file_test.split("/")[-1]
+                    # Remove file extension if present (assuming .rs)
+                    if last_part.endswith(".rs"):
+                        last_part = last_part[:-3]
+                    params[i] = last_part
+
         in_crate_packages = []
         for crate in self_contained_tests:
             try:


### PR DESCRIPTION
This PR removes support for passing direct test file paths (e.g., `./mach test-unit <test_file.rs>`) to `mach test-unit`.

Previously, this shorthand was supported in `test-unit` but was subsequently broken in #39897. Supporting this behavior now requires extracting test names from a generic parameter list, which is error-prone due to the presence of arbitrary arguments and inconsistent argument ordering.

With this change, `mach test-unit` aligns more closely with standard Cargo test patterns. Users are expected to specify test modules or patterns instead (e.g., `./mach test-unit <module>::` or using Cargo-compatible arguments).

This simplifies the implementation and avoids maintaining fragile logic for shorthand support that was not widely used.

---

### Testing

* Ran `./mach test-unit` with various valid patterns and module-based inputs
* Verified that tests execute correctly across supported use cases
* Confirmed that removal of direct file path support does not affect standard workflows

---

Fixes: #41065