### PR TITLE
script: Pass `&mut JSContext` to `reflect_node_with_proto`

### DIFF
--- a/components/script/dom/attr.rs
+++ b/components/script/dom/attr.rs
@@ -62,6 +62,7 @@ impl Attr {
     }
     #[expect(clippy::too_many_arguments)]
     pub(crate) fn new(
+        cx: &mut js::context::JSContext,
         document: &Document,
         local_name: LocalName,
         value: AttrValue,
@@ -69,14 +70,13 @@ impl Attr {
         namespace: Namespace,
         prefix: Option<Prefix>,
         owner: Option<&Element>,
-        can_gc: CanGc,
     ) -> DomRoot<Attr> {
         Node::reflect_node(
+            cx,
             Box::new(Attr::new_inherited(
                 document, local_name, value, name, namespace, prefix, owner,
             )),
             document,
-            can_gc,
         )
     }
 

--- a/components/script/dom/bindings/constructor.rs
+++ b/components/script/dom/bindings/constructor.rs
@@ -171,13 +171,7 @@ fn html_constructor(
             // Any prototype used to create these elements will be overwritten before returning
             // from this function, so we don't bother overwriting the defaults here.
             let element = if definition.is_autonomous() {
-                DomRoot::upcast(HTMLElement::new(
-                    name.local,
-                    None,
-                    &document,
-                    None,
-                    CanGc::from_cx(cx),
-                ))
+                DomRoot::upcast(HTMLElement::new(cx, name.local, None, &document, None))
             } else {
                 create_native_html_element(
                     cx,

--- a/components/script/dom/cdatasection.rs
+++ b/components/script/dom/cdatasection.rs
@@ -9,7 +9,6 @@ use crate::dom::bindings::str::DOMString;
 use crate::dom::document::Document;
 use crate::dom::node::Node;
 use crate::dom::text::Text;
-use crate::script_runtime::CanGc;
 
 #[dom_struct]
 pub(crate) struct CDATASection {
@@ -24,14 +23,14 @@ impl CDATASection {
     }
 
     pub(crate) fn new(
+        cx: &mut js::context::JSContext,
         text: DOMString,
         document: &Document,
-        can_gc: CanGc,
     ) -> DomRoot<CDATASection> {
         Node::reflect_node(
+            cx,
             Box::new(CDATASection::new_inherited(text, document)),
             document,
-            can_gc,
         )
     }
 }

--- a/components/script/dom/characterdata.rs
+++ b/components/script/dom/characterdata.rs
@@ -27,7 +27,6 @@ use crate::dom::node::{ChildrenMutation, Node, NodeDamage};
 use crate::dom::processinginstruction::ProcessingInstruction;
 use crate::dom::text::Text;
 use crate::dom::virtualmethods::vtable_for;
-use crate::script_runtime::CanGc;
 
 // https://dom.spec.whatwg.org/#characterdata
 #[dom_struct]
@@ -46,28 +45,23 @@ impl CharacterData {
 
     pub(crate) fn clone_with_data(
         &self,
+        cx: &mut js::context::JSContext,
         data: DOMString,
         document: &Document,
-        can_gc: CanGc,
     ) -> DomRoot<Node> {
         match self.upcast::<Node>().type_id() {
             NodeTypeId::CharacterData(CharacterDataTypeId::Comment) => {
-                DomRoot::upcast(Comment::new(data, document, None, can_gc))
+                DomRoot::upcast(Comment::new(cx, data, document, None))
             },
             NodeTypeId::CharacterData(CharacterDataTypeId::ProcessingInstruction) => {
                 let pi = self.downcast::<ProcessingInstruction>().unwrap();
-                DomRoot::upcast(ProcessingInstruction::new(
-                    pi.Target(),
-                    data,
-                    document,
-                    can_gc,
-                ))
+                DomRoot::upcast(ProcessingInstruction::new(cx, pi.Target(), data, document))
             },
             NodeTypeId::CharacterData(CharacterDataTypeId::Text(TextTypeId::CDATASection)) => {
-                DomRoot::upcast(CDATASection::new(data, document, can_gc))
+                DomRoot::upcast(CDATASection::new(cx, data, document))
             },
             NodeTypeId::CharacterData(CharacterDataTypeId::Text(TextTypeId::Text)) => {
-                DomRoot::upcast(Text::new(data, document, can_gc))
+                DomRoot::upcast(Text::new(cx, data, document))
             },
             _ => unreachable!(),
         }

--- a/components/script/dom/comment.rs
+++ b/components/script/dom/comment.rs
@@ -14,7 +14,6 @@ use crate::dom::characterdata::CharacterData;
 use crate::dom::document::Document;
 use crate::dom::node::Node;
 use crate::dom::window::Window;
-use crate::script_runtime::CanGc;
 
 /// An HTML comment.
 #[dom_struct]
@@ -30,16 +29,16 @@ impl Comment {
     }
 
     pub(crate) fn new(
+        cx: &mut js::context::JSContext,
         text: DOMString,
         document: &Document,
         proto: Option<HandleObject>,
-        can_gc: CanGc,
     ) -> DomRoot<Comment> {
         Node::reflect_node_with_proto(
+            cx,
             Box::new(Comment::new_inherited(text, document)),
             document,
             proto,
-            can_gc,
         )
     }
 }
@@ -47,12 +46,12 @@ impl Comment {
 impl CommentMethods<crate::DomTypeHolder> for Comment {
     /// <https://dom.spec.whatwg.org/#dom-comment-comment>
     fn Constructor(
+        cx: &mut js::context::JSContext,
         window: &Window,
         proto: Option<HandleObject>,
-        can_gc: CanGc,
         data: DOMString,
     ) -> Fallible<DomRoot<Comment>> {
         let document = window.Document();
-        Ok(Comment::new(data, &document, proto, can_gc))
+        Ok(Comment::new(cx, data, &document, proto))
     }
 }

--- a/components/script/dom/create.rs
+++ b/components/script/dom/create.rs
@@ -104,13 +104,9 @@ fn create_svg_element(
 
     macro_rules! make(
         ($ctor:ident) => ({
-            let obj = $ctor::new(name.local, prefix, document, proto, CanGc::from_cx(cx));
+            let obj = $ctor::new(cx, name.local, prefix, document, proto);
             DomRoot::upcast(obj)
         });
-        ($ctor:ident, $($arg:expr),+) => ({
-            let obj = $ctor::new(name.local, prefix, document, proto, $($arg),+, CanGc::from_cx(cx));
-            DomRoot::upcast(obj)
-        })
     );
 
     match name.local {
@@ -207,11 +203,7 @@ fn create_html_element(
                             // Substep 2. Set result to the result of creating an element internal given document,
                             // HTMLUnknownElement, localName, the HTML namespace, prefix, "failed", null, and registry.
                             let element = DomRoot::upcast::<Element>(HTMLUnknownElement::new(
-                                local_name,
-                                prefix,
-                                document,
-                                proto,
-                                CanGc::from_cx(cx),
+                                cx, local_name, prefix, document, proto,
                             ));
                             element.set_custom_element_state(CustomElementState::Failed);
                             element.set_custom_element_registry(registry);
@@ -227,11 +219,7 @@ fn create_html_element(
                     // custom element definition set to null, is value set to null, and node document
                     // set to document.
                     let result = DomRoot::upcast::<Element>(HTMLElement::new(
-                        name.local,
-                        prefix,
-                        document,
-                        proto,
-                        CanGc::from_cx(cx),
+                        cx, name.local, prefix, document, proto,
                     ));
                     result.set_custom_element_state(CustomElementState::Undefined);
                     result.set_custom_element_registry(registry);
@@ -286,11 +274,11 @@ pub(crate) fn create_native_html_element(
 
     macro_rules! make(
         ($ctor:ident) => ({
-            let obj = $ctor::new(name.local, prefix, document, proto, CanGc::from_cx(cx));
+            let obj = $ctor::new(cx, name.local, prefix, document, proto);
             DomRoot::upcast(obj)
         });
         ($ctor:ident, $($arg:expr),+) => ({
-            let obj = $ctor::new(name.local, prefix, document, proto, $($arg),+, CanGc::from_cx(cx));
+            let obj = $ctor::new(cx, name.local, prefix, document, proto, $($arg),+);
             DomRoot::upcast(obj)
         })
     );
@@ -462,13 +450,6 @@ pub(crate) fn create_element(
     match name.ns {
         ns!(html) => create_html_element(cx, name, prefix, is, document, creator, mode, proto),
         ns!(svg) => create_svg_element(cx, name, prefix, document, proto),
-        _ => Element::new(
-            name.local,
-            name.ns,
-            prefix,
-            document,
-            proto,
-            CanGc::from_cx(cx),
-        ),
+        _ => Element::new(cx, name.local, name.ns, prefix, document, proto),
     }
 }

--- a/components/script/dom/document/document.rs
+++ b/components/script/dom/document/document.rs
@@ -1536,21 +1536,17 @@ impl Document {
         if nodes.len() == 1 {
             Ok(match nodes.pop().unwrap() {
                 NodeOrString::Node(node) => node,
-                NodeOrString::String(string) => {
-                    DomRoot::upcast(self.CreateTextNode(string, CanGc::from_cx(cx)))
-                },
+                NodeOrString::String(string) => DomRoot::upcast(self.CreateTextNode(cx, string)),
             })
         } else {
-            let fragment = DomRoot::upcast::<Node>(self.CreateDocumentFragment(CanGc::from_cx(cx)));
+            let fragment = DomRoot::upcast::<Node>(self.CreateDocumentFragment(cx));
             for node in nodes {
                 match node {
                     NodeOrString::Node(node) => {
                         fragment.AppendChild(cx, &node)?;
                     },
                     NodeOrString::String(string) => {
-                        let node = DomRoot::upcast::<Node>(
-                            self.CreateTextNode(string, CanGc::from_cx(cx)),
-                        );
+                        let node = DomRoot::upcast::<Node>(self.CreateTextNode(cx, string));
                         // No try!() here because appending a text node
                         // should not fail.
                         fragment.AppendChild(cx, &node).unwrap();
@@ -5082,7 +5078,11 @@ impl DocumentMethods<crate::DomTypeHolder> for Document {
     }
 
     /// <https://dom.spec.whatwg.org/#dom-document-createattribute>
-    fn CreateAttribute(&self, mut local_name: DOMString, can_gc: CanGc) -> Fallible<DomRoot<Attr>> {
+    fn CreateAttribute(
+        &self,
+        cx: &mut js::context::JSContext,
+        mut local_name: DOMString,
+    ) -> Fallible<DomRoot<Attr>> {
         // Step 1. If localName is not a valid attribute local name,
         //      then throw an "InvalidCharacterError" DOMException
         if !is_valid_attribute_local_name(&local_name.str()) {
@@ -5096,6 +5096,7 @@ impl DocumentMethods<crate::DomTypeHolder> for Document {
         let value = AttrValue::String("".to_owned());
 
         Ok(Attr::new(
+            cx,
             self,
             name.clone(),
             value,
@@ -5103,16 +5104,15 @@ impl DocumentMethods<crate::DomTypeHolder> for Document {
             ns!(),
             None,
             None,
-            can_gc,
         ))
     }
 
     /// <https://dom.spec.whatwg.org/#dom-document-createattributens>
     fn CreateAttributeNS(
         &self,
+        cx: &mut js::context::JSContext,
         namespace: Option<DOMString>,
         qualified_name: DOMString,
-        can_gc: CanGc,
     ) -> Fallible<DomRoot<Attr>> {
         // Step 1. Let (namespace, prefix, localName) be the result of validating and
         //      extracting namespace and qualifiedName given "attribute".
@@ -5122,6 +5122,7 @@ impl DocumentMethods<crate::DomTypeHolder> for Document {
         let value = AttrValue::String("".to_owned());
         let qualified_name = LocalName::from(qualified_name);
         Ok(Attr::new(
+            cx,
             self,
             local_name,
             value,
@@ -5129,25 +5130,24 @@ impl DocumentMethods<crate::DomTypeHolder> for Document {
             namespace,
             prefix,
             None,
-            can_gc,
         ))
     }
 
     /// <https://dom.spec.whatwg.org/#dom-document-createdocumentfragment>
-    fn CreateDocumentFragment(&self, can_gc: CanGc) -> DomRoot<DocumentFragment> {
-        DocumentFragment::new(self, can_gc)
+    fn CreateDocumentFragment(&self, cx: &mut js::context::JSContext) -> DomRoot<DocumentFragment> {
+        DocumentFragment::new(cx, self)
     }
 
     /// <https://dom.spec.whatwg.org/#dom-document-createtextnode>
-    fn CreateTextNode(&self, data: DOMString, can_gc: CanGc) -> DomRoot<Text> {
-        Text::new(data, self, can_gc)
+    fn CreateTextNode(&self, cx: &mut js::context::JSContext, data: DOMString) -> DomRoot<Text> {
+        Text::new(cx, data, self)
     }
 
     /// <https://dom.spec.whatwg.org/#dom-document-createcdatasection>
     fn CreateCDATASection(
         &self,
+        cx: &mut js::context::JSContext,
         data: DOMString,
-        can_gc: CanGc,
     ) -> Fallible<DomRoot<CDATASection>> {
         // Step 1
         if self.is_html_document {
@@ -5160,20 +5160,20 @@ impl DocumentMethods<crate::DomTypeHolder> for Document {
         }
 
         // Step 3
-        Ok(CDATASection::new(data, self, can_gc))
+        Ok(CDATASection::new(cx, data, self))
     }
 
     /// <https://dom.spec.whatwg.org/#dom-document-createcomment>
-    fn CreateComment(&self, data: DOMString, can_gc: CanGc) -> DomRoot<Comment> {
-        Comment::new(data, self, None, can_gc)
+    fn CreateComment(&self, cx: &mut js::context::JSContext, data: DOMString) -> DomRoot<Comment> {
+        Comment::new(cx, data, self, None)
     }
 
     /// <https://dom.spec.whatwg.org/#dom-document-createprocessinginstruction>
     fn CreateProcessingInstruction(
         &self,
+        cx: &mut js::context::JSContext,
         target: DOMString,
         data: DOMString,
-        can_gc: CanGc,
     ) -> Fallible<DomRoot<ProcessingInstruction>> {
         // Step 1. If target does not match the Name production, then throw an "InvalidCharacterError" DOMException.
         if !matches_name_production(&target.str()) {
@@ -5186,7 +5186,7 @@ impl DocumentMethods<crate::DomTypeHolder> for Document {
         }
 
         // Step 3.
-        Ok(ProcessingInstruction::new(target, data, self, can_gc))
+        Ok(ProcessingInstruction::new(cx, target, data, self))
     }
 
     /// <https://dom.spec.whatwg.org/#dom-document-importnode>

--- a/components/script/dom/document/documentfragment.rs
+++ b/components/script/dom/document/documentfragment.rs
@@ -47,20 +47,23 @@ impl DocumentFragment {
         }
     }
 
-    pub(crate) fn new(document: &Document, can_gc: CanGc) -> DomRoot<DocumentFragment> {
-        Self::new_with_proto(document, None, can_gc)
+    pub(crate) fn new(
+        cx: &mut js::context::JSContext,
+        document: &Document,
+    ) -> DomRoot<DocumentFragment> {
+        Self::new_with_proto(cx, document, None)
     }
 
     fn new_with_proto(
+        cx: &mut js::context::JSContext,
         document: &Document,
         proto: Option<HandleObject>,
-        can_gc: CanGc,
     ) -> DomRoot<DocumentFragment> {
         Node::reflect_node_with_proto(
+            cx,
             Box::new(DocumentFragment::new_inherited(document, None)),
             document,
             proto,
-            can_gc,
         )
     }
 
@@ -101,13 +104,13 @@ impl<'dom> LayoutDocumentFragmentHelpers<'dom> for LayoutDom<'dom, DocumentFragm
 impl DocumentFragmentMethods<crate::DomTypeHolder> for DocumentFragment {
     /// <https://dom.spec.whatwg.org/#dom-documentfragment-documentfragment>
     fn Constructor(
+        cx: &mut js::context::JSContext,
         window: &Window,
         proto: Option<HandleObject>,
-        can_gc: CanGc,
     ) -> Fallible<DomRoot<DocumentFragment>> {
         let document = window.Document();
 
-        Ok(DocumentFragment::new_with_proto(&document, proto, can_gc))
+        Ok(DocumentFragment::new_with_proto(cx, &document, proto))
     }
 
     /// <https://dom.spec.whatwg.org/#dom-parentnode-children>

--- a/components/script/dom/document/documenttype.rs
+++ b/components/script/dom/document/documenttype.rs
@@ -13,7 +13,6 @@ use crate::dom::bindings::root::DomRoot;
 use crate::dom::bindings::str::DOMString;
 use crate::dom::document::Document;
 use crate::dom::node::Node;
-use crate::script_runtime::CanGc;
 
 // https://dom.spec.whatwg.org/#documenttype
 /// The `DOCTYPE` tag.
@@ -40,18 +39,18 @@ impl DocumentType {
         }
     }
     pub(crate) fn new(
+        cx: &mut js::context::JSContext,
         name: DOMString,
         public_id: Option<DOMString>,
         system_id: Option<DOMString>,
         document: &Document,
-        can_gc: CanGc,
     ) -> DomRoot<DocumentType> {
         Node::reflect_node(
+            cx,
             Box::new(DocumentType::new_inherited(
                 name, public_id, system_id, document,
             )),
             document,
-            can_gc,
         )
     }
 

--- a/components/script/dom/domimplementation.rs
+++ b/components/script/dom/domimplementation.rs
@@ -60,10 +60,10 @@ impl DOMImplementationMethods<crate::DomTypeHolder> for DOMImplementation {
     /// <https://dom.spec.whatwg.org/#dom-domimplementation-createdocumenttype>
     fn CreateDocumentType(
         &self,
+        cx: &mut js::context::JSContext,
         qualified_name: DOMString,
         pubid: DOMString,
         sysid: DOMString,
-        can_gc: CanGc,
     ) -> Fallible<DomRoot<DocumentType>> {
         // Step 1. If name is not a valid doctype name, then throw an
         //      "InvalidCharacterError" DOMException.
@@ -73,11 +73,11 @@ impl DOMImplementationMethods<crate::DomTypeHolder> for DOMImplementation {
         }
 
         Ok(DocumentType::new(
+            cx,
             qualified_name,
             Some(pubid),
             Some(sysid),
             &self.document,
-            can_gc,
         ))
     }
 
@@ -198,13 +198,7 @@ impl DOMImplementationMethods<crate::DomTypeHolder> for DOMImplementation {
         {
             // Step 3. Append a new doctype, with "html" as its name and with its node document set to doc, to doc.
             let doc_node = doc.upcast::<Node>();
-            let doc_type = DocumentType::new(
-                DOMString::from("html"),
-                None,
-                None,
-                &doc,
-                CanGc::from_cx(cx),
-            );
+            let doc_type = DocumentType::new(cx, DOMString::from("html"), None, None, &doc);
             doc_node.AppendChild(cx, doc_type.upcast()).unwrap();
         }
 
@@ -256,7 +250,7 @@ impl DOMImplementationMethods<crate::DomTypeHolder> for DOMImplementation {
 
                     // Step 6.2. Append a new Text node, with its data set to title (which could be the empty string)
                     // and its node document set to doc, to the title element created earlier.
-                    let title_text = Text::new(title_str, &doc, CanGc::from_cx(cx));
+                    let title_text = Text::new(cx, title_str, &doc);
                     doc_title.AppendChild(cx, title_text.upcast()).unwrap();
                 }
             }

--- a/components/script/dom/element/element.rs
+++ b/components/script/dom/element/element.rs
@@ -331,20 +331,20 @@ impl Element {
     }
 
     pub(crate) fn new(
+        cx: &mut js::context::JSContext,
         local_name: LocalName,
         namespace: Namespace,
         prefix: Option<Prefix>,
         document: &Document,
         proto: Option<HandleObject>,
-        can_gc: CanGc,
     ) -> DomRoot<Element> {
         Node::reflect_node_with_proto(
+            cx,
             Box::new(Element::new_inherited(
                 local_name, namespace, prefix, document,
             )),
             document,
             proto,
-            can_gc,
         )
     }
 
@@ -1849,6 +1849,7 @@ impl Element {
         }
     }
 
+    #[expect(unsafe_code)]
     #[allow(clippy::too_many_arguments)]
     pub(crate) fn push_new_attribute(
         &self,
@@ -1860,7 +1861,11 @@ impl Element {
         reason: AttributeMutationReason,
         can_gc: CanGc,
     ) {
+        // TODO: https://github.com/servo/servo/issues/42812
+        let mut cx = unsafe { script_bindings::script_runtime::temp_cx() };
+        let cx = &mut cx;
         let attr = Attr::new(
+            cx,
             &self.node.owner_doc(),
             local_name,
             value,
@@ -1868,7 +1873,6 @@ impl Element {
             namespace,
             prefix,
             Some(self),
-            can_gc,
         );
         self.push_attribute(&attr, reason, can_gc);
     }
@@ -2564,15 +2568,12 @@ impl Element {
         // See https://github.com/w3c/DOM-Parsing/issues/61.
         let context_document = {
             if let Some(template) = self.downcast::<HTMLTemplateElement>() {
-                template
-                    .Content(CanGc::from_cx(cx))
-                    .upcast::<Node>()
-                    .owner_doc()
+                template.Content(cx).upcast::<Node>().owner_doc()
             } else {
                 self.owner_document()
             }
         };
-        let fragment = DocumentFragment::new(&context_document, CanGc::from_cx(cx));
+        let fragment = DocumentFragment::new(cx, &context_document);
         // Step 4.
         for child in new_children {
             fragment.upcast::<Node>().AppendChild(cx, &child).unwrap();
@@ -2648,8 +2649,8 @@ impl Element {
         }))
     }
 
-    pub(crate) fn outer_html(&self, can_gc: CanGc) -> Fallible<DOMString> {
-        match self.GetOuterHTML(can_gc)? {
+    pub(crate) fn outer_html(&self, cx: &mut js::context::JSContext) -> Fallible<DOMString> {
+        match self.GetOuterHTML(cx)? {
             TrustedHTMLOrNullIsEmptyString::NullIsEmptyString(str) => Ok(str),
             TrustedHTMLOrNullIsEmptyString::TrustedHTML(_) => unreachable!(),
         }
@@ -3426,7 +3427,7 @@ impl ElementMethods<crate::DomTypeHolder> for Element {
         )?;
         // Step 2. Let target be this's template contents if this is a template element; otherwise this.
         let target = if let Some(template) = self.downcast::<HTMLTemplateElement>() {
-            DomRoot::upcast(template.Content(CanGc::from_cx(cx)))
+            DomRoot::upcast(template.Content(cx))
         } else {
             DomRoot::from_ref(self.upcast())
         };
@@ -3437,19 +3438,22 @@ impl ElementMethods<crate::DomTypeHolder> for Element {
     }
 
     /// <https://html.spec.whatwg.org/multipage/#dom-element-gethtml>
-    fn GetHTML(&self, options: &GetHTMLOptions, can_gc: CanGc) -> DOMString {
+    fn GetHTML(&self, cx: &mut js::context::JSContext, options: &GetHTMLOptions) -> DOMString {
         // > Element's getHTML(options) method steps are to return the result of HTML fragment serialization
         // > algorithm with this, options["serializableShadowRoots"], and options["shadowRoots"].
         self.upcast::<Node>().html_serialize(
+            cx,
             TraversalScope::ChildrenOnly(None),
             options.serializableShadowRoots,
             options.shadowRoots.clone(),
-            can_gc,
         )
     }
 
     /// <https://html.spec.whatwg.org/multipage/#dom-element-innerhtml>
-    fn GetInnerHTML(&self, can_gc: CanGc) -> Fallible<TrustedHTMLOrNullIsEmptyString> {
+    fn GetInnerHTML(
+        &self,
+        cx: &mut js::context::JSContext,
+    ) -> Fallible<TrustedHTMLOrNullIsEmptyString> {
         let qname = QualName::new(
             self.prefix().clone(),
             self.namespace().clone(),
@@ -3460,7 +3464,7 @@ impl ElementMethods<crate::DomTypeHolder> for Element {
         // care of distinguishing between html/xml documents
         let result = if self.owner_document().is_html_document() {
             self.upcast::<Node>()
-                .html_serialize(ChildrenOnly(Some(qname)), false, vec![], can_gc)
+                .html_serialize(cx, ChildrenOnly(Some(qname)), false, vec![])
         } else {
             self.upcast::<Node>()
                 .xml_serialize(XmlChildrenOnly(Some(qname)))?
@@ -3488,7 +3492,7 @@ impl ElementMethods<crate::DomTypeHolder> for Element {
         let target = if let Some(template) = self.downcast::<HTMLTemplateElement>() {
             // Step 4: If context is a template element, then set context to
             // the template element's template contents (a DocumentFragment).
-            DomRoot::upcast(template.Content(CanGc::from_cx(cx)))
+            DomRoot::upcast(template.Content(cx))
         } else {
             // Step 2: Let context be this.
             DomRoot::from_ref(self.upcast())
@@ -3516,12 +3520,15 @@ impl ElementMethods<crate::DomTypeHolder> for Element {
     }
 
     /// <https://html.spec.whatwg.org/multipage/#dom-element-outerhtml>
-    fn GetOuterHTML(&self, can_gc: CanGc) -> Fallible<TrustedHTMLOrNullIsEmptyString> {
+    fn GetOuterHTML(
+        &self,
+        cx: &mut js::context::JSContext,
+    ) -> Fallible<TrustedHTMLOrNullIsEmptyString> {
         // FIXME: This should use the fragment serialization algorithm, which takes
         // care of distinguishing between html/xml documents
         let result = if self.owner_document().is_html_document() {
             self.upcast::<Node>()
-                .html_serialize(IncludeNode, false, vec![], can_gc)
+                .html_serialize(cx, IncludeNode, false, vec![])
         } else {
             self.upcast::<Node>().xml_serialize(XmlIncludeNode)?
         };
@@ -3742,7 +3749,7 @@ impl ElementMethods<crate::DomTypeHolder> for Element {
         data: DOMString,
     ) -> ErrorResult {
         // Step 1.
-        let text = Text::new(data, &self.owner_document(), CanGc::from_cx(cx));
+        let text = Text::new(cx, data, &self.owner_document());
 
         // Step 2.
         let where_ = where_.parse::<AdjacentPosition>()?;

--- a/components/script/dom/html/htmlanchorelement.rs
+++ b/components/script/dom/html/htmlanchorelement.rs
@@ -63,19 +63,19 @@ impl HTMLAnchorElement {
     }
 
     pub(crate) fn new(
+        cx: &mut js::context::JSContext,
         local_name: LocalName,
         prefix: Option<Prefix>,
         document: &Document,
         proto: Option<HandleObject>,
-        can_gc: CanGc,
     ) -> DomRoot<HTMLAnchorElement> {
         Node::reflect_node_with_proto(
+            cx,
             Box::new(HTMLAnchorElement::new_inherited(
                 local_name, prefix, document,
             )),
             document,
             proto,
-            can_gc,
         )
     }
 

--- a/components/script/dom/html/htmlareaelement.rs
+++ b/components/script/dom/html/htmlareaelement.rs
@@ -288,17 +288,17 @@ impl HTMLAreaElement {
     }
 
     pub(crate) fn new(
+        cx: &mut js::context::JSContext,
         local_name: LocalName,
         prefix: Option<Prefix>,
         document: &Document,
         proto: Option<HandleObject>,
-        can_gc: CanGc,
     ) -> DomRoot<HTMLAreaElement> {
         Node::reflect_node_with_proto(
+            cx,
             Box::new(HTMLAreaElement::new_inherited(local_name, prefix, document)),
             document,
             proto,
-            can_gc,
         )
     }
 

--- a/components/script/dom/html/htmlaudioelement.rs
+++ b/components/script/dom/html/htmlaudioelement.rs
@@ -37,19 +37,19 @@ impl HTMLAudioElement {
     }
 
     pub(crate) fn new(
+        cx: &mut js::context::JSContext,
         local_name: LocalName,
         prefix: Option<Prefix>,
         document: &Document,
         proto: Option<HandleObject>,
-        can_gc: CanGc,
     ) -> DomRoot<HTMLAudioElement> {
         Node::reflect_node_with_proto(
+            cx,
             Box::new(HTMLAudioElement::new_inherited(
                 local_name, prefix, document,
             )),
             document,
             proto,
-            can_gc,
         )
     }
 }

--- a/components/script/dom/html/htmlbaseelement.rs
+++ b/components/script/dom/html/htmlbaseelement.rs
@@ -45,17 +45,17 @@ impl HTMLBaseElement {
     }
 
     pub(crate) fn new(
+        cx: &mut js::context::JSContext,
         local_name: LocalName,
         prefix: Option<Prefix>,
         document: &Document,
         proto: Option<HandleObject>,
-        can_gc: CanGc,
     ) -> DomRoot<HTMLBaseElement> {
         Node::reflect_node_with_proto(
+            cx,
             Box::new(HTMLBaseElement::new_inherited(local_name, prefix, document)),
             document,
             proto,
-            can_gc,
         )
     }
 

--- a/components/script/dom/html/htmlbodyelement.rs
+++ b/components/script/dom/html/htmlbodyelement.rs
@@ -41,17 +41,17 @@ impl HTMLBodyElement {
     }
 
     pub(crate) fn new(
+        cx: &mut js::context::JSContext,
         local_name: LocalName,
         prefix: Option<Prefix>,
         document: &Document,
         proto: Option<HandleObject>,
-        can_gc: CanGc,
     ) -> DomRoot<HTMLBodyElement> {
         Node::reflect_node_with_proto(
+            cx,
             Box::new(HTMLBodyElement::new_inherited(local_name, prefix, document)),
             document,
             proto,
-            can_gc,
         )
     }
 }

--- a/components/script/dom/html/htmlbrelement.rs
+++ b/components/script/dom/html/htmlbrelement.rs
@@ -10,7 +10,6 @@ use crate::dom::bindings::root::DomRoot;
 use crate::dom::document::Document;
 use crate::dom::html::htmlelement::HTMLElement;
 use crate::dom::node::Node;
-use crate::script_runtime::CanGc;
 
 #[dom_struct]
 pub(crate) struct HTMLBRElement {
@@ -29,17 +28,17 @@ impl HTMLBRElement {
     }
 
     pub(crate) fn new(
+        cx: &mut js::context::JSContext,
         local_name: LocalName,
         prefix: Option<Prefix>,
         document: &Document,
         proto: Option<HandleObject>,
-        can_gc: CanGc,
     ) -> DomRoot<HTMLBRElement> {
         Node::reflect_node_with_proto(
+            cx,
             Box::new(HTMLBRElement::new_inherited(local_name, prefix, document)),
             document,
             proto,
-            can_gc,
         )
     }
 }

--- a/components/script/dom/html/htmlbuttonelement.rs
+++ b/components/script/dom/html/htmlbuttonelement.rs
@@ -80,19 +80,19 @@ impl HTMLButtonElement {
     }
 
     pub(crate) fn new(
+        cx: &mut js::context::JSContext,
         local_name: LocalName,
         prefix: Option<Prefix>,
         document: &Document,
         proto: Option<HandleObject>,
-        can_gc: CanGc,
     ) -> DomRoot<HTMLButtonElement> {
         Node::reflect_node_with_proto(
+            cx,
             Box::new(HTMLButtonElement::new_inherited(
                 local_name, prefix, document,
             )),
             document,
             proto,
-            can_gc,
         )
     }
 

--- a/components/script/dom/html/htmlcanvaselement.rs
+++ b/components/script/dom/html/htmlcanvaselement.rs
@@ -104,19 +104,19 @@ impl HTMLCanvasElement {
     }
 
     pub(crate) fn new(
+        cx: &mut js::context::JSContext,
         local_name: LocalName,
         prefix: Option<Prefix>,
         document: &Document,
         proto: Option<HandleObject>,
-        can_gc: CanGc,
     ) -> DomRoot<HTMLCanvasElement> {
         Node::reflect_node_with_proto(
+            cx,
             Box::new(HTMLCanvasElement::new_inherited(
                 local_name, prefix, document,
             )),
             document,
             proto,
-            can_gc,
         )
     }
 

--- a/components/script/dom/html/htmldataelement.rs
+++ b/components/script/dom/html/htmldataelement.rs
@@ -12,7 +12,6 @@ use crate::dom::bindings::str::DOMString;
 use crate::dom::document::Document;
 use crate::dom::html::htmlelement::HTMLElement;
 use crate::dom::node::Node;
-use crate::script_runtime::CanGc;
 
 #[dom_struct]
 pub(crate) struct HTMLDataElement {
@@ -31,17 +30,17 @@ impl HTMLDataElement {
     }
 
     pub(crate) fn new(
+        cx: &mut js::context::JSContext,
         local_name: LocalName,
         prefix: Option<Prefix>,
         document: &Document,
         proto: Option<HandleObject>,
-        can_gc: CanGc,
     ) -> DomRoot<HTMLDataElement> {
         Node::reflect_node_with_proto(
+            cx,
             Box::new(HTMLDataElement::new_inherited(local_name, prefix, document)),
             document,
             proto,
-            can_gc,
         )
     }
 }

--- a/components/script/dom/html/htmldatalistelement.rs
+++ b/components/script/dom/html/htmldatalistelement.rs
@@ -33,19 +33,19 @@ impl HTMLDataListElement {
     }
 
     pub(crate) fn new(
+        cx: &mut js::context::JSContext,
         local_name: LocalName,
         prefix: Option<Prefix>,
         document: &Document,
         proto: Option<HandleObject>,
-        can_gc: CanGc,
     ) -> DomRoot<HTMLDataListElement> {
         Node::reflect_node_with_proto(
+            cx,
             Box::new(HTMLDataListElement::new_inherited(
                 local_name, prefix, document,
             )),
             document,
             proto,
-            can_gc,
         )
     }
 }

--- a/components/script/dom/html/htmldetailselement.rs
+++ b/components/script/dom/html/htmldetailselement.rs
@@ -143,19 +143,19 @@ impl HTMLDetailsElement {
     }
 
     pub(crate) fn new(
+        cx: &mut js::context::JSContext,
         local_name: LocalName,
         prefix: Option<Prefix>,
         document: &Document,
         proto: Option<HandleObject>,
-        can_gc: CanGc,
     ) -> DomRoot<HTMLDetailsElement> {
         Node::reflect_node_with_proto(
+            cx,
             Box::new(HTMLDetailsElement::new_inherited(
                 local_name, prefix, document,
             )),
             document,
             proto,
-            can_gc,
         )
     }
 

--- a/components/script/dom/html/htmldialogelement.rs
+++ b/components/script/dom/html/htmldialogelement.rs
@@ -45,19 +45,19 @@ impl HTMLDialogElement {
     }
 
     pub(crate) fn new(
+        cx: &mut js::context::JSContext,
         local_name: LocalName,
         prefix: Option<Prefix>,
         document: &Document,
         proto: Option<HandleObject>,
-        can_gc: CanGc,
     ) -> DomRoot<HTMLDialogElement> {
         Node::reflect_node_with_proto(
+            cx,
             Box::new(HTMLDialogElement::new_inherited(
                 local_name, prefix, document,
             )),
             document,
             proto,
-            can_gc,
         )
     }
 

--- a/components/script/dom/html/htmldirectoryelement.rs
+++ b/components/script/dom/html/htmldirectoryelement.rs
@@ -10,7 +10,6 @@ use crate::dom::bindings::root::DomRoot;
 use crate::dom::document::Document;
 use crate::dom::html::htmlelement::HTMLElement;
 use crate::dom::node::Node;
-use crate::script_runtime::CanGc;
 
 #[dom_struct]
 pub(crate) struct HTMLDirectoryElement {
@@ -29,19 +28,19 @@ impl HTMLDirectoryElement {
     }
 
     pub(crate) fn new(
+        cx: &mut js::context::JSContext,
         local_name: LocalName,
         prefix: Option<Prefix>,
         document: &Document,
         proto: Option<HandleObject>,
-        can_gc: CanGc,
     ) -> DomRoot<HTMLDirectoryElement> {
         Node::reflect_node_with_proto(
+            cx,
             Box::new(HTMLDirectoryElement::new_inherited(
                 local_name, prefix, document,
             )),
             document,
             proto,
-            can_gc,
         )
     }
 }

--- a/components/script/dom/html/htmldivelement.rs
+++ b/components/script/dom/html/htmldivelement.rs
@@ -12,7 +12,6 @@ use crate::dom::bindings::str::DOMString;
 use crate::dom::document::Document;
 use crate::dom::html::htmlelement::HTMLElement;
 use crate::dom::node::Node;
-use crate::script_runtime::CanGc;
 
 #[dom_struct]
 pub(crate) struct HTMLDivElement {
@@ -31,17 +30,17 @@ impl HTMLDivElement {
     }
 
     pub(crate) fn new(
+        cx: &mut js::context::JSContext,
         local_name: LocalName,
         prefix: Option<Prefix>,
         document: &Document,
         proto: Option<HandleObject>,
-        can_gc: CanGc,
     ) -> DomRoot<HTMLDivElement> {
         Node::reflect_node_with_proto(
+            cx,
             Box::new(HTMLDivElement::new_inherited(local_name, prefix, document)),
             document,
             proto,
-            can_gc,
         )
     }
 }

--- a/components/script/dom/html/htmldlistelement.rs
+++ b/components/script/dom/html/htmldlistelement.rs
@@ -10,7 +10,6 @@ use crate::dom::bindings::root::DomRoot;
 use crate::dom::document::Document;
 use crate::dom::html::htmlelement::HTMLElement;
 use crate::dom::node::Node;
-use crate::script_runtime::CanGc;
 
 #[dom_struct]
 pub(crate) struct HTMLDListElement {
@@ -29,19 +28,19 @@ impl HTMLDListElement {
     }
 
     pub(crate) fn new(
+        cx: &mut js::context::JSContext,
         local_name: LocalName,
         prefix: Option<Prefix>,
         document: &Document,
         proto: Option<HandleObject>,
-        can_gc: CanGc,
     ) -> DomRoot<HTMLDListElement> {
         Node::reflect_node_with_proto(
+            cx,
             Box::new(HTMLDListElement::new_inherited(
                 local_name, prefix, document,
             )),
             document,
             proto,
-            can_gc,
         )
     }
 }

--- a/components/script/dom/html/htmlelement.rs
+++ b/components/script/dom/html/htmlelement.rs
@@ -108,17 +108,17 @@ impl HTMLElement {
     }
 
     pub(crate) fn new(
+        cx: &mut js::context::JSContext,
         local_name: LocalName,
         prefix: Option<Prefix>,
         document: &Document,
         proto: Option<HandleObject>,
-        can_gc: CanGc,
     ) -> DomRoot<HTMLElement> {
         Node::reflect_node_with_proto(
+            cx,
             Box::new(HTMLElement::new_inherited(local_name, prefix, document)),
             document,
             proto,
-            can_gc,
         )
     }
 
@@ -618,11 +618,7 @@ impl HTMLElementMethods<crate::DomTypeHolder> for HTMLElement {
         // Step 5: If fragment has no children, then append a new Text node whose data is the empty
         // string and node document is this's node document to fragment.
         if fragment.upcast::<Node>().children_count() == 0 {
-            let text_node = Text::new(
-                DOMString::from("".to_owned()),
-                &document,
-                CanGc::from_cx(cx),
-            );
+            let text_node = Text::new(cx, DOMString::from("".to_owned()), &document);
 
             fragment
                 .upcast::<Node>()
@@ -820,7 +816,7 @@ fn append_text_node_to_fragment(
     fragment: &DocumentFragment,
     text: String,
 ) {
-    let text = Text::new(DOMString::from(text), document, CanGc::from_cx(cx));
+    let text = Text::new(cx, DOMString::from(text), document);
     fragment
         .upcast::<Node>()
         .AppendChild(cx, text.upcast())
@@ -1058,7 +1054,7 @@ impl HTMLElement {
     ) -> DomRoot<DocumentFragment> {
         // Step 1: Let fragment be a new DocumentFragment whose node document is document.
         let document = self.owner_document();
-        let fragment = DocumentFragment::new(&document, CanGc::from_cx(cx));
+        let fragment = DocumentFragment::new(cx, &document);
 
         // Step 2: Let position be a position variable for input, initially pointing at the start
         // of input.

--- a/components/script/dom/html/htmlembedelement.rs
+++ b/components/script/dom/html/htmlembedelement.rs
@@ -10,7 +10,6 @@ use crate::dom::bindings::root::DomRoot;
 use crate::dom::document::Document;
 use crate::dom::html::htmlelement::HTMLElement;
 use crate::dom::node::Node;
-use crate::script_runtime::CanGc;
 
 #[dom_struct]
 pub(crate) struct HTMLEmbedElement {
@@ -29,19 +28,19 @@ impl HTMLEmbedElement {
     }
 
     pub(crate) fn new(
+        cx: &mut js::context::JSContext,
         local_name: LocalName,
         prefix: Option<Prefix>,
         document: &Document,
         proto: Option<HandleObject>,
-        can_gc: CanGc,
     ) -> DomRoot<HTMLEmbedElement> {
         Node::reflect_node_with_proto(
+            cx,
             Box::new(HTMLEmbedElement::new_inherited(
                 local_name, prefix, document,
             )),
             document,
             proto,
-            can_gc,
         )
     }
 }

--- a/components/script/dom/html/htmlfieldsetelement.rs
+++ b/components/script/dom/html/htmlfieldsetelement.rs
@@ -55,19 +55,19 @@ impl HTMLFieldSetElement {
     }
 
     pub(crate) fn new(
+        cx: &mut js::context::JSContext,
         local_name: LocalName,
         prefix: Option<Prefix>,
         document: &Document,
         proto: Option<HandleObject>,
-        can_gc: CanGc,
     ) -> DomRoot<HTMLFieldSetElement> {
         Node::reflect_node_with_proto(
+            cx,
             Box::new(HTMLFieldSetElement::new_inherited(
                 local_name, prefix, document,
             )),
             document,
             proto,
-            can_gc,
         )
     }
 

--- a/components/script/dom/html/htmlfontelement.rs
+++ b/components/script/dom/html/htmlfontelement.rs
@@ -43,17 +43,17 @@ impl HTMLFontElement {
     }
 
     pub(crate) fn new(
+        cx: &mut js::context::JSContext,
         local_name: LocalName,
         prefix: Option<Prefix>,
         document: &Document,
         proto: Option<HandleObject>,
-        can_gc: CanGc,
     ) -> DomRoot<HTMLFontElement> {
         Node::reflect_node_with_proto(
+            cx,
             Box::new(HTMLFontElement::new_inherited(local_name, prefix, document)),
             document,
             proto,
-            can_gc,
         )
     }
 

--- a/components/script/dom/html/htmlformelement.rs
+++ b/components/script/dom/html/htmlformelement.rs
@@ -144,17 +144,17 @@ impl HTMLFormElement {
     }
 
     pub(crate) fn new(
+        cx: &mut js::context::JSContext,
         local_name: LocalName,
         prefix: Option<Prefix>,
         document: &Document,
         proto: Option<HandleObject>,
-        can_gc: CanGc,
     ) -> DomRoot<HTMLFormElement> {
         Node::reflect_node_with_proto(
+            cx,
             Box::new(HTMLFormElement::new_inherited(local_name, prefix, document)),
             document,
             proto,
-            can_gc,
         )
     }
 

--- a/components/script/dom/html/htmlframeelement.rs
+++ b/components/script/dom/html/htmlframeelement.rs
@@ -12,7 +12,6 @@ use crate::dom::bindings::str::USVString;
 use crate::dom::document::Document;
 use crate::dom::html::htmlelement::HTMLElement;
 use crate::dom::node::Node;
-use crate::script_runtime::CanGc;
 
 #[dom_struct]
 pub(crate) struct HTMLFrameElement {
@@ -31,19 +30,19 @@ impl HTMLFrameElement {
     }
 
     pub(crate) fn new(
+        cx: &mut js::context::JSContext,
         local_name: LocalName,
         prefix: Option<Prefix>,
         document: &Document,
         proto: Option<HandleObject>,
-        can_gc: CanGc,
     ) -> DomRoot<HTMLFrameElement> {
         Node::reflect_node_with_proto(
+            cx,
             Box::new(HTMLFrameElement::new_inherited(
                 local_name, prefix, document,
             )),
             document,
             proto,
-            can_gc,
         )
     }
 }

--- a/components/script/dom/html/htmlframesetelement.rs
+++ b/components/script/dom/html/htmlframesetelement.rs
@@ -13,7 +13,6 @@ use crate::dom::bindings::root::DomRoot;
 use crate::dom::document::Document;
 use crate::dom::html::htmlelement::HTMLElement;
 use crate::dom::node::{Node, NodeTraits};
-use crate::script_runtime::CanGc;
 
 #[dom_struct]
 pub(crate) struct HTMLFrameSetElement {
@@ -32,19 +31,19 @@ impl HTMLFrameSetElement {
     }
 
     pub(crate) fn new(
+        cx: &mut js::context::JSContext,
         local_name: LocalName,
         prefix: Option<Prefix>,
         document: &Document,
         proto: Option<HandleObject>,
-        can_gc: CanGc,
     ) -> DomRoot<HTMLFrameSetElement> {
         let n = Node::reflect_node_with_proto(
+            cx,
             Box::new(HTMLFrameSetElement::new_inherited(
                 local_name, prefix, document,
             )),
             document,
             proto,
-            can_gc,
         );
         n.upcast::<Node>().set_weird_parser_insertion_mode();
         n

--- a/components/script/dom/html/htmlheadelement.rs
+++ b/components/script/dom/html/htmlheadelement.rs
@@ -14,7 +14,6 @@ use crate::dom::html::htmlelement::HTMLElement;
 use crate::dom::node::{BindContext, Node};
 use crate::dom::userscripts::load_script;
 use crate::dom::virtualmethods::VirtualMethods;
-use crate::script_runtime::CanGc;
 
 #[dom_struct]
 pub(crate) struct HTMLHeadElement {
@@ -33,17 +32,17 @@ impl HTMLHeadElement {
     }
 
     pub(crate) fn new(
+        cx: &mut js::context::JSContext,
         local_name: LocalName,
         prefix: Option<Prefix>,
         document: &Document,
         proto: Option<HandleObject>,
-        can_gc: CanGc,
     ) -> DomRoot<HTMLHeadElement> {
         let n = Node::reflect_node_with_proto(
+            cx,
             Box::new(HTMLHeadElement::new_inherited(local_name, prefix, document)),
             document,
             proto,
-            can_gc,
         );
 
         n.upcast::<Node>().set_weird_parser_insertion_mode();

--- a/components/script/dom/html/htmlheadingelement.rs
+++ b/components/script/dom/html/htmlheadingelement.rs
@@ -10,7 +10,6 @@ use crate::dom::bindings::root::DomRoot;
 use crate::dom::document::Document;
 use crate::dom::html::htmlelement::HTMLElement;
 use crate::dom::node::Node;
-use crate::script_runtime::CanGc;
 
 #[derive(JSTraceable, MallocSizeOf)]
 pub(crate) enum HeadingLevel {
@@ -42,20 +41,20 @@ impl HTMLHeadingElement {
     }
 
     pub(crate) fn new(
+        cx: &mut js::context::JSContext,
         local_name: LocalName,
         prefix: Option<Prefix>,
         document: &Document,
         proto: Option<HandleObject>,
         level: HeadingLevel,
-        can_gc: CanGc,
     ) -> DomRoot<HTMLHeadingElement> {
         Node::reflect_node_with_proto(
+            cx,
             Box::new(HTMLHeadingElement::new_inherited(
                 local_name, prefix, document, level,
             )),
             document,
             proto,
-            can_gc,
         )
     }
 }

--- a/components/script/dom/html/htmlhrelement.rs
+++ b/components/script/dom/html/htmlhrelement.rs
@@ -24,7 +24,6 @@ use crate::dom::element::{Element, LayoutElementHelpers};
 use crate::dom::html::htmlelement::HTMLElement;
 use crate::dom::node::Node;
 use crate::dom::virtualmethods::VirtualMethods;
-use crate::script_runtime::CanGc;
 
 #[dom_struct]
 pub(crate) struct HTMLHRElement {
@@ -43,17 +42,17 @@ impl HTMLHRElement {
     }
 
     pub(crate) fn new(
+        cx: &mut js::context::JSContext,
         local_name: LocalName,
         prefix: Option<Prefix>,
         document: &Document,
         proto: Option<HandleObject>,
-        can_gc: CanGc,
     ) -> DomRoot<HTMLHRElement> {
         Node::reflect_node_with_proto(
+            cx,
             Box::new(HTMLHRElement::new_inherited(local_name, prefix, document)),
             document,
             proto,
-            can_gc,
         )
     }
 }

--- a/components/script/dom/html/htmlhtmlelement.rs
+++ b/components/script/dom/html/htmlhtmlelement.rs
@@ -11,7 +11,6 @@ use crate::dom::bindings::root::DomRoot;
 use crate::dom::document::Document;
 use crate::dom::html::htmlelement::HTMLElement;
 use crate::dom::node::Node;
-use crate::script_runtime::CanGc;
 
 #[dom_struct]
 pub(crate) struct HTMLHtmlElement {
@@ -31,17 +30,17 @@ impl HTMLHtmlElement {
     }
 
     pub(crate) fn new(
-        localName: LocalName,
+        cx: &mut js::context::JSContext,
+        local_name: LocalName,
         prefix: Option<Prefix>,
         document: &Document,
         proto: Option<HandleObject>,
-        can_gc: CanGc,
     ) -> DomRoot<HTMLHtmlElement> {
         let n = Node::reflect_node_with_proto(
-            Box::new(HTMLHtmlElement::new_inherited(localName, prefix, document)),
+            cx,
+            Box::new(HTMLHtmlElement::new_inherited(local_name, prefix, document)),
             document,
             proto,
-            can_gc,
         );
 
         n.upcast::<Node>().set_weird_parser_insertion_mode();

--- a/components/script/dom/html/htmliframeelement.rs
+++ b/components/script/dom/html/htmliframeelement.rs
@@ -692,19 +692,19 @@ impl HTMLIFrameElement {
     }
 
     pub(crate) fn new(
+        cx: &mut js::context::JSContext,
         local_name: LocalName,
         prefix: Option<Prefix>,
         document: &Document,
         proto: Option<HandleObject>,
-        can_gc: CanGc,
     ) -> DomRoot<HTMLIFrameElement> {
         Node::reflect_node_with_proto(
+            cx,
             Box::new(HTMLIFrameElement::new_inherited(
                 local_name, prefix, document,
             )),
             document,
             proto,
-            can_gc,
         )
     }
 

--- a/components/script/dom/html/htmlimageelement.rs
+++ b/components/script/dom/html/htmlimageelement.rs
@@ -1535,20 +1535,20 @@ impl HTMLImageElement {
     }
 
     pub(crate) fn new(
+        cx: &mut js::context::JSContext,
         local_name: LocalName,
         prefix: Option<Prefix>,
         document: &Document,
         proto: Option<HandleObject>,
         creator: ElementCreator,
-        can_gc: CanGc,
     ) -> DomRoot<HTMLImageElement> {
         let image_element = Node::reflect_node_with_proto(
+            cx,
             Box::new(HTMLImageElement::new_inherited(
                 local_name, prefix, document, creator,
             )),
             document,
             proto,
-            can_gc,
         );
         image_element
             .dimension_attribute_source

--- a/components/script/dom/html/htmllabelelement.rs
+++ b/components/script/dom/html/htmllabelelement.rs
@@ -44,19 +44,19 @@ impl HTMLLabelElement {
     }
 
     pub(crate) fn new(
+        cx: &mut js::context::JSContext,
         local_name: LocalName,
         prefix: Option<Prefix>,
         document: &Document,
         proto: Option<HandleObject>,
-        can_gc: CanGc,
     ) -> DomRoot<HTMLLabelElement> {
         Node::reflect_node_with_proto(
+            cx,
             Box::new(HTMLLabelElement::new_inherited(
                 local_name, prefix, document,
             )),
             document,
             proto,
-            can_gc,
         )
     }
 }

--- a/components/script/dom/html/htmllegendelement.rs
+++ b/components/script/dom/html/htmllegendelement.rs
@@ -39,19 +39,19 @@ impl HTMLLegendElement {
     }
 
     pub(crate) fn new(
+        cx: &mut js::context::JSContext,
         local_name: LocalName,
         prefix: Option<Prefix>,
         document: &Document,
         proto: Option<HandleObject>,
-        can_gc: CanGc,
     ) -> DomRoot<HTMLLegendElement> {
         Node::reflect_node_with_proto(
+            cx,
             Box::new(HTMLLegendElement::new_inherited(
                 local_name, prefix, document,
             )),
             document,
             proto,
-            can_gc,
         )
     }
 }

--- a/components/script/dom/html/htmllielement.rs
+++ b/components/script/dom/html/htmllielement.rs
@@ -15,7 +15,6 @@ use crate::dom::document::Document;
 use crate::dom::html::htmlelement::HTMLElement;
 use crate::dom::node::Node;
 use crate::dom::virtualmethods::VirtualMethods;
-use crate::script_runtime::CanGc;
 
 #[dom_struct]
 pub(crate) struct HTMLLIElement {
@@ -34,17 +33,17 @@ impl HTMLLIElement {
     }
 
     pub(crate) fn new(
+        cx: &mut js::context::JSContext,
         local_name: LocalName,
         prefix: Option<Prefix>,
         document: &Document,
         proto: Option<HandleObject>,
-        can_gc: CanGc,
     ) -> DomRoot<HTMLLIElement> {
         Node::reflect_node_with_proto(
+            cx,
             Box::new(HTMLLIElement::new_inherited(local_name, prefix, document)),
             document,
             proto,
-            can_gc,
         )
     }
 }

--- a/components/script/dom/html/htmllinkelement.rs
+++ b/components/script/dom/html/htmllinkelement.rs
@@ -140,20 +140,20 @@ impl HTMLLinkElement {
     }
 
     pub(crate) fn new(
+        cx: &mut js::context::JSContext,
         local_name: LocalName,
         prefix: Option<Prefix>,
         document: &Document,
         proto: Option<HandleObject>,
         creator: ElementCreator,
-        can_gc: CanGc,
     ) -> DomRoot<HTMLLinkElement> {
         Node::reflect_node_with_proto(
+            cx,
             Box::new(HTMLLinkElement::new_inherited(
                 local_name, prefix, document, creator,
             )),
             document,
             proto,
-            can_gc,
         )
     }
 

--- a/components/script/dom/html/htmlmapelement.rs
+++ b/components/script/dom/html/htmlmapelement.rs
@@ -38,17 +38,17 @@ impl HTMLMapElement {
     }
 
     pub(crate) fn new(
+        cx: &mut js::context::JSContext,
         local_name: LocalName,
         prefix: Option<Prefix>,
         document: &Document,
         proto: Option<HandleObject>,
-        can_gc: CanGc,
     ) -> DomRoot<HTMLMapElement> {
         Node::reflect_node_with_proto(
+            cx,
             Box::new(HTMLMapElement::new_inherited(local_name, prefix, document)),
             document,
             proto,
-            can_gc,
         )
     }
 

--- a/components/script/dom/html/htmlmarqueeelement.rs
+++ b/components/script/dom/html/htmlmarqueeelement.rs
@@ -10,7 +10,6 @@ use crate::dom::bindings::root::DomRoot;
 use crate::dom::document::Document;
 use crate::dom::html::htmlelement::HTMLElement;
 use crate::dom::node::Node;
-use crate::script_runtime::CanGc;
 
 #[dom_struct]
 pub(crate) struct HTMLMarqueeElement {
@@ -25,17 +24,17 @@ impl HTMLMarqueeElement {
     }
 
     pub(crate) fn new(
+        cx: &mut js::context::JSContext,
         local_name: LocalName,
         prefix: Option<Prefix>,
         document: &Document,
         proto: Option<HandleObject>,
-        can_gc: CanGc,
     ) -> DomRoot<Self> {
         Node::reflect_node_with_proto(
+            cx,
             Box::new(Self::new_inherited(local_name, prefix, document)),
             document,
             proto,
-            can_gc,
         )
     }
 }

--- a/components/script/dom/html/htmlmenuelement.rs
+++ b/components/script/dom/html/htmlmenuelement.rs
@@ -11,7 +11,6 @@ use crate::dom::bindings::root::DomRoot;
 use crate::dom::document::Document;
 use crate::dom::html::htmlelement::HTMLElement;
 use crate::dom::node::Node;
-use crate::script_runtime::CanGc;
 
 #[dom_struct]
 pub(crate) struct HTMLMenuElement {
@@ -30,17 +29,17 @@ impl HTMLMenuElement {
     }
 
     pub(crate) fn new(
+        cx: &mut js::context::JSContext,
         local_name: LocalName,
         prefix: Option<Prefix>,
         document: &Document,
         proto: Option<HandleObject>,
-        can_gc: CanGc,
     ) -> DomRoot<HTMLMenuElement> {
         Node::reflect_node_with_proto(
+            cx,
             Box::new(HTMLMenuElement::new_inherited(local_name, prefix, document)),
             document,
             proto,
-            can_gc,
         )
     }
 }

--- a/components/script/dom/html/htmlmetaelement.rs
+++ b/components/script/dom/html/htmlmetaelement.rs
@@ -45,17 +45,17 @@ impl HTMLMetaElement {
     }
 
     pub(crate) fn new(
+        cx: &mut js::context::JSContext,
         local_name: LocalName,
         prefix: Option<Prefix>,
         document: &Document,
         proto: Option<HandleObject>,
-        can_gc: CanGc,
     ) -> DomRoot<HTMLMetaElement> {
         Node::reflect_node_with_proto(
+            cx,
             Box::new(HTMLMetaElement::new_inherited(local_name, prefix, document)),
             document,
             proto,
-            can_gc,
         )
     }
 

--- a/components/script/dom/html/htmlmeterelement.rs
+++ b/components/script/dom/html/htmlmeterelement.rs
@@ -56,19 +56,19 @@ impl HTMLMeterElement {
     }
 
     pub(crate) fn new(
+        cx: &mut js::context::JSContext,
         local_name: LocalName,
         prefix: Option<Prefix>,
         document: &Document,
         proto: Option<HandleObject>,
-        can_gc: CanGc,
     ) -> DomRoot<HTMLMeterElement> {
         Node::reflect_node_with_proto(
+            cx,
             Box::new(HTMLMeterElement::new_inherited(
                 local_name, prefix, document,
             )),
             document,
             proto,
-            can_gc,
         )
     }
 

--- a/components/script/dom/html/htmlmodelement.rs
+++ b/components/script/dom/html/htmlmodelement.rs
@@ -10,7 +10,6 @@ use crate::dom::bindings::root::DomRoot;
 use crate::dom::document::Document;
 use crate::dom::html::htmlelement::HTMLElement;
 use crate::dom::node::Node;
-use crate::script_runtime::CanGc;
 
 #[dom_struct]
 pub(crate) struct HTMLModElement {
@@ -29,17 +28,17 @@ impl HTMLModElement {
     }
 
     pub(crate) fn new(
+        cx: &mut js::context::JSContext,
         local_name: LocalName,
         prefix: Option<Prefix>,
         document: &Document,
         proto: Option<HandleObject>,
-        can_gc: CanGc,
     ) -> DomRoot<HTMLModElement> {
         Node::reflect_node_with_proto(
+            cx,
             Box::new(HTMLModElement::new_inherited(local_name, prefix, document)),
             document,
             proto,
-            can_gc,
         )
     }
 }

--- a/components/script/dom/html/htmlobjectelement.rs
+++ b/components/script/dom/html/htmlobjectelement.rs
@@ -52,19 +52,19 @@ impl HTMLObjectElement {
     }
 
     pub(crate) fn new(
+        cx: &mut js::context::JSContext,
         local_name: LocalName,
         prefix: Option<Prefix>,
         document: &Document,
         proto: Option<HandleObject>,
-        can_gc: CanGc,
     ) -> DomRoot<HTMLObjectElement> {
         Node::reflect_node_with_proto(
+            cx,
             Box::new(HTMLObjectElement::new_inherited(
                 local_name, prefix, document,
             )),
             document,
             proto,
-            can_gc,
         )
     }
 }

--- a/components/script/dom/html/htmlolistelement.rs
+++ b/components/script/dom/html/htmlolistelement.rs
@@ -10,7 +10,6 @@ use crate::dom::bindings::root::DomRoot;
 use crate::dom::document::Document;
 use crate::dom::html::htmlelement::HTMLElement;
 use crate::dom::node::Node;
-use crate::script_runtime::CanGc;
 
 #[dom_struct]
 pub(crate) struct HTMLOListElement {
@@ -29,19 +28,19 @@ impl HTMLOListElement {
     }
 
     pub(crate) fn new(
+        cx: &mut js::context::JSContext,
         local_name: LocalName,
         prefix: Option<Prefix>,
         document: &Document,
         proto: Option<HandleObject>,
-        can_gc: CanGc,
     ) -> DomRoot<HTMLOListElement> {
         Node::reflect_node_with_proto(
+            cx,
             Box::new(HTMLOListElement::new_inherited(
                 local_name, prefix, document,
             )),
             document,
             proto,
-            can_gc,
         )
     }
 }

--- a/components/script/dom/html/htmloptgroupelement.rs
+++ b/components/script/dom/html/htmloptgroupelement.rs
@@ -48,19 +48,19 @@ impl HTMLOptGroupElement {
     }
 
     pub(crate) fn new(
+        cx: &mut js::context::JSContext,
         local_name: LocalName,
         prefix: Option<Prefix>,
         document: &Document,
         proto: Option<HandleObject>,
-        can_gc: CanGc,
     ) -> DomRoot<HTMLOptGroupElement> {
         Node::reflect_node_with_proto(
+            cx,
             Box::new(HTMLOptGroupElement::new_inherited(
                 local_name, prefix, document,
             )),
             document,
             proto,
-            can_gc,
         )
     }
 

--- a/components/script/dom/html/htmloptionelement.rs
+++ b/components/script/dom/html/htmloptionelement.rs
@@ -72,19 +72,19 @@ impl HTMLOptionElement {
     }
 
     pub(crate) fn new(
+        cx: &mut js::context::JSContext,
         local_name: LocalName,
         prefix: Option<Prefix>,
         document: &Document,
         proto: Option<HandleObject>,
-        can_gc: CanGc,
     ) -> DomRoot<HTMLOptionElement> {
         Node::reflect_node_with_proto(
+            cx,
             Box::new(HTMLOptionElement::new_inherited(
                 local_name, prefix, document,
             )),
             document,
             proto,
-            can_gc,
         )
     }
 
@@ -221,7 +221,7 @@ impl HTMLOptionElement {
     /// <https://html.spec.whatwg.org/multipage/#clone-an-option-into-a-selectedcontent>
     fn clone_an_option_into_selectedcontent(&self, cx: &mut JSContext, selectedcontent: &Element) {
         // Step 1. Let documentFragment be a new DocumentFragment whose node document is option's node document.
-        let document_fragment = DocumentFragment::new(&self.owner_document(), CanGc::from_cx(cx));
+        let document_fragment = DocumentFragment::new(cx, &self.owner_document());
 
         // Step 2. For each child of option's children:
         for child in self.upcast::<Node>().children() {

--- a/components/script/dom/html/htmloutputelement.rs
+++ b/components/script/dom/html/htmloutputelement.rs
@@ -49,19 +49,19 @@ impl HTMLOutputElement {
     }
 
     pub(crate) fn new(
+        cx: &mut js::context::JSContext,
         local_name: LocalName,
         prefix: Option<Prefix>,
         document: &Document,
         proto: Option<HandleObject>,
-        can_gc: CanGc,
     ) -> DomRoot<HTMLOutputElement> {
         Node::reflect_node_with_proto(
+            cx,
             Box::new(HTMLOutputElement::new_inherited(
                 local_name, prefix, document,
             )),
             document,
             proto,
-            can_gc,
         )
     }
 

--- a/components/script/dom/html/htmlparagraphelement.rs
+++ b/components/script/dom/html/htmlparagraphelement.rs
@@ -12,7 +12,6 @@ use crate::dom::bindings::str::DOMString;
 use crate::dom::document::Document;
 use crate::dom::html::htmlelement::HTMLElement;
 use crate::dom::node::Node;
-use crate::script_runtime::CanGc;
 
 #[dom_struct]
 pub(crate) struct HTMLParagraphElement {
@@ -31,19 +30,19 @@ impl HTMLParagraphElement {
     }
 
     pub(crate) fn new(
+        cx: &mut js::context::JSContext,
         local_name: LocalName,
         prefix: Option<Prefix>,
         document: &Document,
         proto: Option<HandleObject>,
-        can_gc: CanGc,
     ) -> DomRoot<HTMLParagraphElement> {
         Node::reflect_node_with_proto(
+            cx,
             Box::new(HTMLParagraphElement::new_inherited(
                 local_name, prefix, document,
             )),
             document,
             proto,
-            can_gc,
         )
     }
 }

--- a/components/script/dom/html/htmlparamelement.rs
+++ b/components/script/dom/html/htmlparamelement.rs
@@ -10,7 +10,6 @@ use crate::dom::bindings::root::DomRoot;
 use crate::dom::document::Document;
 use crate::dom::html::htmlelement::HTMLElement;
 use crate::dom::node::Node;
-use crate::script_runtime::CanGc;
 
 #[dom_struct]
 pub(crate) struct HTMLParamElement {
@@ -29,19 +28,19 @@ impl HTMLParamElement {
     }
 
     pub(crate) fn new(
+        cx: &mut js::context::JSContext,
         local_name: LocalName,
         prefix: Option<Prefix>,
         document: &Document,
         proto: Option<HandleObject>,
-        can_gc: CanGc,
     ) -> DomRoot<HTMLParamElement> {
         Node::reflect_node_with_proto(
+            cx,
             Box::new(HTMLParamElement::new_inherited(
                 local_name, prefix, document,
             )),
             document,
             proto,
-            can_gc,
         )
     }
 }

--- a/components/script/dom/html/htmlpictureelement.rs
+++ b/components/script/dom/html/htmlpictureelement.rs
@@ -10,7 +10,6 @@ use crate::dom::bindings::root::DomRoot;
 use crate::dom::document::Document;
 use crate::dom::html::htmlelement::HTMLElement;
 use crate::dom::node::Node;
-use crate::script_runtime::CanGc;
 
 #[dom_struct]
 pub(crate) struct HTMLPictureElement {
@@ -29,19 +28,19 @@ impl HTMLPictureElement {
     }
 
     pub(crate) fn new(
+        cx: &mut js::context::JSContext,
         local_name: LocalName,
         prefix: Option<Prefix>,
         document: &Document,
         proto: Option<HandleObject>,
-        can_gc: CanGc,
     ) -> DomRoot<HTMLPictureElement> {
         Node::reflect_node_with_proto(
+            cx,
             Box::new(HTMLPictureElement::new_inherited(
                 local_name, prefix, document,
             )),
             document,
             proto,
-            can_gc,
         )
     }
 }

--- a/components/script/dom/html/htmlpreelement.rs
+++ b/components/script/dom/html/htmlpreelement.rs
@@ -15,7 +15,6 @@ use crate::dom::document::Document;
 use crate::dom::html::htmlelement::HTMLElement;
 use crate::dom::node::Node;
 use crate::dom::virtualmethods::VirtualMethods;
-use crate::script_runtime::CanGc;
 
 #[dom_struct]
 pub(crate) struct HTMLPreElement {
@@ -34,17 +33,17 @@ impl HTMLPreElement {
     }
 
     pub(crate) fn new(
+        cx: &mut js::context::JSContext,
         local_name: LocalName,
         prefix: Option<Prefix>,
         document: &Document,
         proto: Option<HandleObject>,
-        can_gc: CanGc,
     ) -> DomRoot<HTMLPreElement> {
         Node::reflect_node_with_proto(
+            cx,
             Box::new(HTMLPreElement::new_inherited(local_name, prefix, document)),
             document,
             proto,
-            can_gc,
         )
     }
 }

--- a/components/script/dom/html/htmlprogresselement.rs
+++ b/components/script/dom/html/htmlprogresselement.rs
@@ -54,19 +54,19 @@ impl HTMLProgressElement {
     }
 
     pub(crate) fn new(
+        cx: &mut js::context::JSContext,
         local_name: LocalName,
         prefix: Option<Prefix>,
         document: &Document,
         proto: Option<HandleObject>,
-        can_gc: CanGc,
     ) -> DomRoot<HTMLProgressElement> {
         Node::reflect_node_with_proto(
+            cx,
             Box::new(HTMLProgressElement::new_inherited(
                 local_name, prefix, document,
             )),
             document,
             proto,
-            can_gc,
         )
     }
 

--- a/components/script/dom/html/htmlquoteelement.rs
+++ b/components/script/dom/html/htmlquoteelement.rs
@@ -12,7 +12,6 @@ use crate::dom::bindings::str::USVString;
 use crate::dom::document::Document;
 use crate::dom::html::htmlelement::HTMLElement;
 use crate::dom::node::Node;
-use crate::script_runtime::CanGc;
 
 #[dom_struct]
 pub(crate) struct HTMLQuoteElement {
@@ -31,19 +30,19 @@ impl HTMLQuoteElement {
     }
 
     pub(crate) fn new(
+        cx: &mut js::context::JSContext,
         local_name: LocalName,
         prefix: Option<Prefix>,
         document: &Document,
         proto: Option<HandleObject>,
-        can_gc: CanGc,
     ) -> DomRoot<HTMLQuoteElement> {
         Node::reflect_node_with_proto(
+            cx,
             Box::new(HTMLQuoteElement::new_inherited(
                 local_name, prefix, document,
             )),
             document,
             proto,
-            can_gc,
         )
     }
 }

--- a/components/script/dom/html/htmlscriptelement.rs
+++ b/components/script/dom/html/htmlscriptelement.rs
@@ -146,20 +146,20 @@ impl HTMLScriptElement {
     }
 
     pub(crate) fn new(
+        cx: &mut js::context::JSContext,
         local_name: LocalName,
         prefix: Option<Prefix>,
         document: &Document,
         proto: Option<HandleObject>,
         creator: ElementCreator,
-        can_gc: CanGc,
     ) -> DomRoot<HTMLScriptElement> {
         Node::reflect_node_with_proto(
+            cx,
             Box::new(HTMLScriptElement::new_inherited(
                 local_name, prefix, document, creator,
             )),
             document,
             proto,
-            can_gc,
         )
     }
 

--- a/components/script/dom/html/htmlselectelement.rs
+++ b/components/script/dom/html/htmlselectelement.rs
@@ -159,19 +159,19 @@ impl HTMLSelectElement {
     }
 
     pub(crate) fn new(
+        cx: &mut js::context::JSContext,
         local_name: LocalName,
         prefix: Option<Prefix>,
         document: &Document,
         proto: Option<HandleObject>,
-        can_gc: CanGc,
     ) -> DomRoot<HTMLSelectElement> {
         let n = Node::reflect_node_with_proto(
+            cx,
             Box::new(HTMLSelectElement::new_inherited(
                 local_name, prefix, document,
             )),
             document,
             proto,
-            can_gc,
         );
 
         n.upcast::<Node>().set_weird_parser_insertion_mode();
@@ -319,7 +319,7 @@ impl HTMLSelectElement {
             .AppendChild(cx, text_container.upcast::<Node>())
             .unwrap();
 
-        let text = Text::new(DOMString::new(), &document, CanGc::from_cx(cx));
+        let text = Text::new(cx, DOMString::new(), &document);
         let _ = self.shadow_tree.borrow_mut().insert(ShadowTree {
             selected_option: text.as_traced(),
         });

--- a/components/script/dom/html/htmlslotelement.rs
+++ b/components/script/dom/html/htmlslotelement.rs
@@ -183,17 +183,17 @@ impl HTMLSlotElement {
     }
 
     pub(crate) fn new(
+        cx: &mut js::context::JSContext,
         local_name: LocalName,
         prefix: Option<Prefix>,
         document: &Document,
         proto: Option<HandleObject>,
-        can_gc: CanGc,
     ) -> DomRoot<HTMLSlotElement> {
         Node::reflect_node_with_proto(
+            cx,
             Box::new(HTMLSlotElement::new_inherited(local_name, prefix, document)),
             document,
             proto,
-            can_gc,
         )
     }
 

--- a/components/script/dom/html/htmlsourceelement.rs
+++ b/components/script/dom/html/htmlsourceelement.rs
@@ -42,19 +42,19 @@ impl HTMLSourceElement {
     }
 
     pub(crate) fn new(
+        cx: &mut js::context::JSContext,
         local_name: LocalName,
         prefix: Option<Prefix>,
         document: &Document,
         proto: Option<HandleObject>,
-        can_gc: CanGc,
     ) -> DomRoot<HTMLSourceElement> {
         Node::reflect_node_with_proto(
+            cx,
             Box::new(HTMLSourceElement::new_inherited(
                 local_name, prefix, document,
             )),
             document,
             proto,
-            can_gc,
         )
     }
 

--- a/components/script/dom/html/htmlspanelement.rs
+++ b/components/script/dom/html/htmlspanelement.rs
@@ -10,7 +10,6 @@ use crate::dom::bindings::root::DomRoot;
 use crate::dom::document::Document;
 use crate::dom::html::htmlelement::HTMLElement;
 use crate::dom::node::Node;
-use crate::script_runtime::CanGc;
 
 #[dom_struct]
 pub(crate) struct HTMLSpanElement {
@@ -29,17 +28,17 @@ impl HTMLSpanElement {
     }
 
     pub(crate) fn new(
+        cx: &mut js::context::JSContext,
         local_name: LocalName,
         prefix: Option<Prefix>,
         document: &Document,
         proto: Option<HandleObject>,
-        can_gc: CanGc,
     ) -> DomRoot<HTMLSpanElement> {
         Node::reflect_node_with_proto(
+            cx,
             Box::new(HTMLSpanElement::new_inherited(local_name, prefix, document)),
             document,
             proto,
-            can_gc,
         )
     }
 }

--- a/components/script/dom/html/htmlstyleelement.rs
+++ b/components/script/dom/html/htmlstyleelement.rs
@@ -80,20 +80,20 @@ impl HTMLStyleElement {
     }
 
     pub(crate) fn new(
+        cx: &mut js::context::JSContext,
         local_name: LocalName,
         prefix: Option<Prefix>,
         document: &Document,
         proto: Option<HandleObject>,
         creator: ElementCreator,
-        can_gc: CanGc,
     ) -> DomRoot<HTMLStyleElement> {
         Node::reflect_node_with_proto(
+            cx,
             Box::new(HTMLStyleElement::new_inherited(
                 local_name, prefix, document, creator,
             )),
             document,
             proto,
-            can_gc,
         )
     }
 

--- a/components/script/dom/html/htmltablecaptionelement.rs
+++ b/components/script/dom/html/htmltablecaptionelement.rs
@@ -11,7 +11,6 @@ use crate::dom::bindings::root::DomRoot;
 use crate::dom::document::Document;
 use crate::dom::html::htmlelement::HTMLElement;
 use crate::dom::node::Node;
-use crate::script_runtime::CanGc;
 
 #[dom_struct]
 pub(crate) struct HTMLTableCaptionElement {
@@ -30,19 +29,19 @@ impl HTMLTableCaptionElement {
     }
 
     pub(crate) fn new(
+        cx: &mut js::context::JSContext,
         local_name: LocalName,
         prefix: Option<Prefix>,
         document: &Document,
         proto: Option<HandleObject>,
-        can_gc: CanGc,
     ) -> DomRoot<HTMLTableCaptionElement> {
         let n = Node::reflect_node_with_proto(
+            cx,
             Box::new(HTMLTableCaptionElement::new_inherited(
                 local_name, prefix, document,
             )),
             document,
             proto,
-            can_gc,
         );
 
         n.upcast::<Node>().set_weird_parser_insertion_mode();

--- a/components/script/dom/html/htmltablecellelement.rs
+++ b/components/script/dom/html/htmltablecellelement.rs
@@ -22,7 +22,6 @@ use crate::dom::html::htmltablerowelement::HTMLTableRowElement;
 use crate::dom::html::htmltablesectionelement::HTMLTableSectionElement;
 use crate::dom::node::{LayoutNodeHelpers, Node, NodeDamage};
 use crate::dom::virtualmethods::VirtualMethods;
-use crate::script_runtime::CanGc;
 
 const DEFAULT_COLSPAN: u32 = 1;
 const DEFAULT_ROWSPAN: u32 = 1;
@@ -44,19 +43,19 @@ impl HTMLTableCellElement {
     }
 
     pub(crate) fn new(
+        cx: &mut js::context::JSContext,
         local_name: LocalName,
         prefix: Option<Prefix>,
         document: &Document,
         proto: Option<HandleObject>,
-        can_gc: CanGc,
     ) -> DomRoot<HTMLTableCellElement> {
         let n = Node::reflect_node_with_proto(
+            cx,
             Box::new(HTMLTableCellElement::new_inherited(
                 local_name, prefix, document,
             )),
             document,
             proto,
-            can_gc,
         );
 
         n.upcast::<Node>().set_weird_parser_insertion_mode();

--- a/components/script/dom/html/htmltablecolelement.rs
+++ b/components/script/dom/html/htmltablecolelement.rs
@@ -17,7 +17,6 @@ use crate::dom::element::{AttributeMutation, Element, LayoutElementHelpers};
 use crate::dom::html::htmlelement::HTMLElement;
 use crate::dom::node::{Node, NodeDamage};
 use crate::dom::virtualmethods::VirtualMethods;
-use crate::script_runtime::CanGc;
 
 #[dom_struct]
 pub(crate) struct HTMLTableColElement {
@@ -36,19 +35,19 @@ impl HTMLTableColElement {
     }
 
     pub(crate) fn new(
+        cx: &mut js::context::JSContext,
         local_name: LocalName,
         prefix: Option<Prefix>,
         document: &Document,
         proto: Option<HandleObject>,
-        can_gc: CanGc,
     ) -> DomRoot<HTMLTableColElement> {
         let n = Node::reflect_node_with_proto(
+            cx,
             Box::new(HTMLTableColElement::new_inherited(
                 local_name, prefix, document,
             )),
             document,
             proto,
-            can_gc,
         );
 
         n.upcast::<Node>().set_weird_parser_insertion_mode();

--- a/components/script/dom/html/htmltableelement.rs
+++ b/components/script/dom/html/htmltableelement.rs
@@ -74,19 +74,19 @@ impl HTMLTableElement {
     }
 
     pub(crate) fn new(
+        cx: &mut js::context::JSContext,
         local_name: LocalName,
         prefix: Option<Prefix>,
         document: &Document,
         proto: Option<HandleObject>,
-        can_gc: CanGc,
     ) -> DomRoot<HTMLTableElement> {
         let n = Node::reflect_node_with_proto(
+            cx,
             Box::new(HTMLTableElement::new_inherited(
                 local_name, prefix, document,
             )),
             document,
             proto,
-            can_gc,
         );
 
         n.upcast::<Node>().set_weird_parser_insertion_mode();

--- a/components/script/dom/html/htmltablerowelement.rs
+++ b/components/script/dom/html/htmltablerowelement.rs
@@ -50,19 +50,19 @@ impl HTMLTableRowElement {
     }
 
     pub(crate) fn new(
+        cx: &mut js::context::JSContext,
         local_name: LocalName,
         prefix: Option<Prefix>,
         document: &Document,
         proto: Option<HandleObject>,
-        can_gc: CanGc,
     ) -> DomRoot<HTMLTableRowElement> {
         let n = Node::reflect_node_with_proto(
+            cx,
             Box::new(HTMLTableRowElement::new_inherited(
                 local_name, prefix, document,
             )),
             document,
             proto,
-            can_gc,
         );
 
         n.upcast::<Node>().set_weird_parser_insertion_mode();

--- a/components/script/dom/html/htmltablesectionelement.rs
+++ b/components/script/dom/html/htmltablesectionelement.rs
@@ -44,19 +44,19 @@ impl HTMLTableSectionElement {
     }
 
     pub(crate) fn new(
+        cx: &mut js::context::JSContext,
         local_name: LocalName,
         prefix: Option<Prefix>,
         document: &Document,
         proto: Option<HandleObject>,
-        can_gc: CanGc,
     ) -> DomRoot<HTMLTableSectionElement> {
         let n = Node::reflect_node_with_proto(
+            cx,
             Box::new(HTMLTableSectionElement::new_inherited(
                 local_name, prefix, document,
             )),
             document,
             proto,
-            can_gc,
         );
 
         n.upcast::<Node>().set_weird_parser_insertion_mode();

--- a/components/script/dom/html/htmltemplateelement.rs
+++ b/components/script/dom/html/htmltemplateelement.rs
@@ -41,19 +41,19 @@ impl HTMLTemplateElement {
     }
 
     pub(crate) fn new(
+        cx: &mut js::context::JSContext,
         local_name: LocalName,
         prefix: Option<Prefix>,
         document: &Document,
         proto: Option<HandleObject>,
-        can_gc: CanGc,
     ) -> DomRoot<HTMLTemplateElement> {
         let n = Node::reflect_node_with_proto(
+            cx,
             Box::new(HTMLTemplateElement::new_inherited(
                 local_name, prefix, document,
             )),
             document,
             proto,
-            can_gc,
         );
 
         n.upcast::<Node>().set_weird_parser_insertion_mode();
@@ -98,15 +98,15 @@ impl HTMLTemplateElementMethods<crate::DomTypeHolder> for HTMLTemplateElement {
     make_bool_setter!(SetShadowRootSerializable, "shadowrootserializable");
 
     /// <https://html.spec.whatwg.org/multipage/#dom-template-content>
-    fn Content(&self, can_gc: CanGc) -> DomRoot<DocumentFragment> {
+    fn Content(&self, cx: &mut js::context::JSContext) -> DomRoot<DocumentFragment> {
         self.contents.or_init(|| {
             // https://html.spec.whatwg.org/multipage/#template-contents
             // Step 1. Let document be the template element's node document's appropriate template contents owner document.
             let doc = self.owner_document();
             // Step 2. Create a DocumentFragment object whose node document is document and host is the template element.
             let document_fragment = doc
-                .appropriate_template_contents_owner_document(can_gc)
-                .CreateDocumentFragment(can_gc);
+                .appropriate_template_contents_owner_document(CanGc::from_cx(cx))
+                .CreateDocumentFragment(cx);
             document_fragment.set_host(self.upcast());
             // Step 3. Set the template element's template contents to the newly created DocumentFragment object.
             document_fragment
@@ -127,7 +127,7 @@ impl VirtualMethods for HTMLTemplateElement {
             .owner_document()
             .appropriate_template_contents_owner_document(CanGc::from_cx(cx));
         // Step 2.
-        let content = self.Content(CanGc::from_cx(cx));
+        let content = self.Content(cx);
         Node::adopt(cx, content.upcast(), &doc);
     }
 
@@ -148,9 +148,9 @@ impl VirtualMethods for HTMLTemplateElement {
         }
         let copy = copy.downcast::<HTMLTemplateElement>().unwrap();
         // Steps 2-3.
-        let copy_contents = DomRoot::upcast::<Node>(copy.Content(CanGc::from_cx(cx)));
+        let copy_contents = DomRoot::upcast::<Node>(copy.Content(cx));
         let copy_contents_doc = copy_contents.owner_doc();
-        for child in self.Content(CanGc::from_cx(cx)).upcast::<Node>().children() {
+        for child in self.Content(cx).upcast::<Node>().children() {
             let copy_child = Node::clone(
                 cx,
                 &child,

--- a/components/script/dom/html/htmltextareaelement.rs
+++ b/components/script/dom/html/htmltextareaelement.rs
@@ -141,19 +141,19 @@ impl HTMLTextAreaElement {
     }
 
     pub(crate) fn new(
+        cx: &mut js::context::JSContext,
         local_name: LocalName,
         prefix: Option<Prefix>,
         document: &Document,
         proto: Option<HandleObject>,
-        can_gc: CanGc,
     ) -> DomRoot<HTMLTextAreaElement> {
         Node::reflect_node_with_proto(
+            cx,
             Box::new(HTMLTextAreaElement::new_inherited(
                 local_name, prefix, document,
             )),
             document,
             proto,
-            can_gc,
         )
     }
 

--- a/components/script/dom/html/htmltimeelement.rs
+++ b/components/script/dom/html/htmltimeelement.rs
@@ -12,7 +12,6 @@ use crate::dom::bindings::str::DOMString;
 use crate::dom::document::Document;
 use crate::dom::html::htmlelement::HTMLElement;
 use crate::dom::node::Node;
-use crate::script_runtime::CanGc;
 
 #[dom_struct]
 pub(crate) struct HTMLTimeElement {
@@ -31,17 +30,17 @@ impl HTMLTimeElement {
     }
 
     pub(crate) fn new(
+        cx: &mut js::context::JSContext,
         local_name: LocalName,
         prefix: Option<Prefix>,
         document: &Document,
         proto: Option<HandleObject>,
-        can_gc: CanGc,
     ) -> DomRoot<HTMLTimeElement> {
         Node::reflect_node_with_proto(
+            cx,
             Box::new(HTMLTimeElement::new_inherited(local_name, prefix, document)),
             document,
             proto,
-            can_gc,
         )
     }
 }

--- a/components/script/dom/html/htmltitleelement.rs
+++ b/components/script/dom/html/htmltitleelement.rs
@@ -17,7 +17,6 @@ use crate::dom::document::Document;
 use crate::dom::html::htmlelement::HTMLElement;
 use crate::dom::node::{BindContext, ChildrenMutation, Node};
 use crate::dom::virtualmethods::VirtualMethods;
-use crate::script_runtime::CanGc;
 
 #[dom_struct]
 pub(crate) struct HTMLTitleElement {
@@ -38,19 +37,19 @@ impl HTMLTitleElement {
     }
 
     pub(crate) fn new(
+        cx: &mut js::context::JSContext,
         local_name: LocalName,
         prefix: Option<Prefix>,
         document: &Document,
         proto: Option<HandleObject>,
-        can_gc: CanGc,
     ) -> DomRoot<HTMLTitleElement> {
         Node::reflect_node_with_proto(
+            cx,
             Box::new(HTMLTitleElement::new_inherited(
                 local_name, prefix, document,
             )),
             document,
             proto,
-            can_gc,
         )
     }
 

--- a/components/script/dom/html/htmltrackelement.rs
+++ b/components/script/dom/html/htmltrackelement.rs
@@ -51,11 +51,11 @@ impl HTMLTrackElement {
     }
 
     pub(crate) fn new(
+        cx: &mut js::context::JSContext,
         local_name: LocalName,
         prefix: Option<Prefix>,
         document: &Document,
         proto: Option<HandleObject>,
-        can_gc: CanGc,
     ) -> DomRoot<HTMLTrackElement> {
         let track = TextTrack::new(
             document.window(),
@@ -65,15 +65,15 @@ impl HTMLTrackElement {
             Default::default(),
             Default::default(),
             None,
-            can_gc,
+            CanGc::from_cx(cx),
         );
         Node::reflect_node_with_proto(
+            cx,
             Box::new(HTMLTrackElement::new_inherited(
                 local_name, prefix, document, &track,
             )),
             document,
             proto,
-            can_gc,
         )
     }
 }

--- a/components/script/dom/html/htmlulistelement.rs
+++ b/components/script/dom/html/htmlulistelement.rs
@@ -12,7 +12,6 @@ use crate::dom::bindings::str::DOMString;
 use crate::dom::document::Document;
 use crate::dom::html::htmlelement::HTMLElement;
 use crate::dom::node::Node;
-use crate::script_runtime::CanGc;
 
 #[dom_struct]
 pub(crate) struct HTMLUListElement {
@@ -31,19 +30,19 @@ impl HTMLUListElement {
     }
 
     pub(crate) fn new(
+        cx: &mut js::context::JSContext,
         local_name: LocalName,
         prefix: Option<Prefix>,
         document: &Document,
         proto: Option<HandleObject>,
-        can_gc: CanGc,
     ) -> DomRoot<HTMLUListElement> {
         Node::reflect_node_with_proto(
+            cx,
             Box::new(HTMLUListElement::new_inherited(
                 local_name, prefix, document,
             )),
             document,
             proto,
-            can_gc,
         )
     }
 }

--- a/components/script/dom/html/htmlunknownelement.rs
+++ b/components/script/dom/html/htmlunknownelement.rs
@@ -10,7 +10,6 @@ use crate::dom::bindings::root::DomRoot;
 use crate::dom::document::Document;
 use crate::dom::html::htmlelement::HTMLElement;
 use crate::dom::node::Node;
-use crate::script_runtime::CanGc;
 
 #[dom_struct]
 pub(crate) struct HTMLUnknownElement {
@@ -29,19 +28,19 @@ impl HTMLUnknownElement {
     }
 
     pub(crate) fn new(
+        cx: &mut js::context::JSContext,
         local_name: LocalName,
         prefix: Option<Prefix>,
         document: &Document,
         proto: Option<HandleObject>,
-        can_gc: CanGc,
     ) -> DomRoot<HTMLUnknownElement> {
         Node::reflect_node_with_proto(
+            cx,
             Box::new(HTMLUnknownElement::new_inherited(
                 local_name, prefix, document,
             )),
             document,
             proto,
-            can_gc,
         )
     }
 }

--- a/components/script/dom/html/htmlvideoelement.rs
+++ b/components/script/dom/html/htmlvideoelement.rs
@@ -42,7 +42,6 @@ use crate::dom::performance::performanceresourcetiming::InitiatorType;
 use crate::dom::virtualmethods::VirtualMethods;
 use crate::fetch::{FetchCanceller, RequestWithGlobalScope};
 use crate::network_listener::{self, FetchResponseListener, ResourceTimingListener};
-use crate::script_runtime::CanGc;
 
 #[dom_struct]
 pub(crate) struct HTMLVideoElement {
@@ -79,19 +78,19 @@ impl HTMLVideoElement {
     }
 
     pub(crate) fn new(
+        cx: &mut js::context::JSContext,
         local_name: LocalName,
         prefix: Option<Prefix>,
         document: &Document,
         proto: Option<HandleObject>,
-        can_gc: CanGc,
     ) -> DomRoot<HTMLVideoElement> {
         Node::reflect_node_with_proto(
+            cx,
             Box::new(HTMLVideoElement::new_inherited(
                 local_name, prefix, document,
             )),
             document,
             proto,
-            can_gc,
         )
     }
 

--- a/components/script/dom/html/input_element/mod.rs
+++ b/components/script/dom/html/input_element/mod.rs
@@ -211,19 +211,19 @@ impl HTMLInputElement {
     }
 
     pub(crate) fn new(
+        cx: &mut js::context::JSContext,
         local_name: LocalName,
         prefix: Option<Prefix>,
         document: &Document,
         proto: Option<HandleObject>,
-        can_gc: CanGc,
     ) -> DomRoot<HTMLInputElement> {
         Node::reflect_node_with_proto(
+            cx,
             Box::new(HTMLInputElement::new_inherited(
                 local_name, prefix, document,
             )),
             document,
             proto,
-            can_gc,
         )
     }
 

--- a/components/script/dom/html/input_element/text_input_widget.rs
+++ b/components/script/dom/html/input_element/text_input_widget.rs
@@ -11,7 +11,6 @@ use script_bindings::codegen::GenericBindings::DocumentBinding::DocumentMethods;
 use script_bindings::codegen::GenericBindings::NodeBinding::NodeMethods;
 use script_bindings::inheritance::Castable;
 use script_bindings::root::{Dom, DomRoot};
-use script_bindings::script_runtime::CanGc;
 use style::selector_parser::PseudoElement;
 
 use crate::dom::bindings::cell::DomRefCell;
@@ -243,7 +242,7 @@ fn create_ua_widget_div_with_text_node(
         .unwrap();
     el.upcast::<Node>()
         .set_implemented_pseudo_element(implemented_pseudo);
-    let text_node = document.CreateTextNode("".into(), CanGc::from_cx(cx));
+    let text_node = document.CreateTextNode(cx, "".into());
 
     if !as_first_child {
         el.upcast::<Node>()

--- a/components/script/dom/html/input_element/text_value_widget.rs
+++ b/components/script/dom/html/input_element/text_value_widget.rs
@@ -7,7 +7,6 @@ use std::cell::Ref;
 use js::context::JSContext;
 use script_bindings::codegen::GenericBindings::CharacterDataBinding::CharacterDataMethods;
 use script_bindings::root::Dom;
-use script_bindings::script_runtime::CanGc;
 
 use crate::dom::bindings::cell::DomRefCell;
 use crate::dom::bindings::inheritance::Castable;
@@ -61,11 +60,7 @@ struct TextValueShadowTree {
 
 impl TextValueShadowTree {
     fn new(cx: &mut JSContext, shadow_root: &Node) -> Self {
-        let value = Text::new(
-            Default::default(),
-            &shadow_root.owner_document(),
-            CanGc::from_cx(cx),
-        );
+        let value = Text::new(cx, Default::default(), &shadow_root.owner_document());
         Node::replace_all(cx, Some(value.upcast()), shadow_root);
         Self {
             value: value.as_traced(),

--- a/components/script/dom/node/node.rs
+++ b/components/script/dom/node/node.rs
@@ -85,7 +85,9 @@ use crate::dom::bindings::inheritance::{
     Castable, CharacterDataTypeId, ElementTypeId, EventTargetTypeId, HTMLElementTypeId, NodeTypeId,
     SVGElementTypeId, SVGGraphicsElementTypeId, TextTypeId,
 };
-use crate::dom::bindings::reflector::{DomObject, DomObjectWrap, reflect_dom_object_with_proto};
+use crate::dom::bindings::reflector::{
+    DomObject, DomObjectWrap, reflect_dom_object_with_proto_and_cx,
+};
 use crate::dom::bindings::root::{
     Dom, DomRoot, DomSlice, LayoutDom, MutNullableDom, ToLayout, UnrootedDom,
 };
@@ -351,7 +353,7 @@ impl Node {
         // Step 2. Let fragment be a new DocumentFragment whose node document is contextElement's node document.
 
         let context_document = context_element.owner_document();
-        let fragment = DocumentFragment::new(&context_document, CanGc::from_cx(cx));
+        let fragment = DocumentFragment::new(cx, &context_document);
 
         // Step 3. For each node in newChildren, append node to fragment.
         for child in new_children {
@@ -2806,24 +2808,28 @@ fn as_uintptr<T>(t: &T) -> uintptr_t {
 }
 
 impl Node {
-    pub(crate) fn reflect_node<N>(node: Box<N>, document: &Document, can_gc: CanGc) -> DomRoot<N>
+    pub(crate) fn reflect_node<N>(
+        cx: &mut js::context::JSContext,
+        node: Box<N>,
+        document: &Document,
+    ) -> DomRoot<N>
     where
         N: DerivedFrom<Node> + DomObject + DomObjectWrap<crate::DomTypeHolder>,
     {
-        Self::reflect_node_with_proto(node, document, None, can_gc)
+        Self::reflect_node_with_proto(cx, node, document, None)
     }
 
     pub(crate) fn reflect_node_with_proto<N>(
+        cx: &mut js::context::JSContext,
         node: Box<N>,
         document: &Document,
         proto: Option<HandleObject>,
-        can_gc: CanGc,
     ) -> DomRoot<N>
     where
         N: DerivedFrom<Node> + DomObject + DomObjectWrap<crate::DomTypeHolder>,
     {
         let window = document.window();
-        reflect_dom_object_with_proto(node, window, proto, can_gc)
+        reflect_dom_object_with_proto_and_cx(node, window, proto, cx)
     }
 
     pub(crate) fn new_inherited(doc: &Document) -> Node {
@@ -3313,7 +3319,7 @@ impl Node {
         if string.is_empty() {
             Node::replace_all(cx, None, parent);
         } else {
-            let text = Text::new(string, &parent.owner_document(), CanGc::from_cx(cx));
+            let text = Text::new(cx, string, &parent.owner_document());
             Node::replace_all(cx, Some(text.upcast::<Node>()), parent);
         };
     }
@@ -3490,17 +3496,18 @@ impl Node {
             NodeTypeId::DocumentType => {
                 let doctype = node.downcast::<DocumentType>().unwrap();
                 let doctype = DocumentType::new(
+                    cx,
                     doctype.name().clone(),
                     Some(doctype.public_id().clone()),
                     Some(doctype.system_id().clone()),
                     &document,
-                    CanGc::from_cx(cx),
                 );
                 DomRoot::upcast::<Node>(doctype)
             },
             NodeTypeId::Attr => {
                 let attr = node.downcast::<Attr>().unwrap();
                 let attr = Attr::new(
+                    cx,
                     &document,
                     attr.local_name().clone(),
                     attr.value().clone(),
@@ -3508,17 +3515,16 @@ impl Node {
                     attr.namespace().clone(),
                     attr.prefix().cloned(),
                     None,
-                    CanGc::from_cx(cx),
                 );
                 DomRoot::upcast::<Node>(attr)
             },
             NodeTypeId::DocumentFragment(_) => {
-                let doc_fragment = DocumentFragment::new(&document, CanGc::from_cx(cx));
+                let doc_fragment = DocumentFragment::new(cx, &document);
                 DomRoot::upcast::<Node>(doc_fragment)
             },
             NodeTypeId::CharacterData(_) => {
                 let cdata = node.downcast::<CharacterData>().unwrap();
-                cdata.clone_with_data(cdata.Data(), &document, CanGc::from_cx(cx))
+                cdata.clone_with_data(cx, cdata.Data(), &document)
             },
             NodeTypeId::Document(_) => {
                 // Step 1. Set copy’s encoding, content type, URL, origin, type, mode,
@@ -3741,9 +3747,7 @@ impl Node {
         } else {
             // Step 2. If string is not the empty string, then set node to
             // a new Text node whose data is string and node document is parent’s node document.
-            Some(DomRoot::upcast(
-                self.owner_doc().CreateTextNode(value, CanGc::from_cx(cx)),
-            ))
+            Some(DomRoot::upcast(self.owner_doc().CreateTextNode(cx, value)))
         };
 
         // Step 3. Replace all with node within parent.
@@ -3805,10 +3809,10 @@ impl Node {
 
     pub(crate) fn html_serialize(
         &self,
+        cx: &mut js::context::JSContext,
         traversal_scope: html_serialize::TraversalScope,
         serialize_shadow_roots: bool,
         shadow_roots: Vec<DomRoot<ShadowRoot>>,
-        can_gc: CanGc,
     ) -> DOMString {
         let mut writer = vec![];
         let mut serializer = HtmlSerializer::new(
@@ -3820,12 +3824,12 @@ impl Node {
         );
 
         serialize_html_fragment(
+            cx,
             self,
             &mut serializer,
             traversal_scope,
             serialize_shadow_roots,
             shadow_roots,
-            can_gc,
         )
         .expect("Serializing node failed");
 
@@ -3861,8 +3865,8 @@ impl Node {
     /// <https://html.spec.whatwg.org/multipage/#fragment-serializing-algorithm-steps>
     pub(crate) fn fragment_serialization_algorithm(
         &self,
+        cx: &mut js::context::JSContext,
         require_well_formed: bool,
-        can_gc: CanGc,
     ) -> Fallible<DOMString> {
         // Step 1. Let context document be node's node document.
         let context_document = self.owner_document();
@@ -3871,10 +3875,10 @@ impl Node {
         // with node, false, and « ».
         if context_document.is_html_document() {
             return Ok(self.html_serialize(
+                cx,
                 html_serialize::TraversalScope::ChildrenOnly(None),
                 false,
                 vec![],
-                can_gc,
             ));
         }
 

--- a/components/script/dom/processinginstruction.rs
+++ b/components/script/dom/processinginstruction.rs
@@ -10,7 +10,6 @@ use crate::dom::bindings::str::DOMString;
 use crate::dom::characterdata::CharacterData;
 use crate::dom::document::Document;
 use crate::dom::node::Node;
-use crate::script_runtime::CanGc;
 
 /// An HTML processing instruction node.
 #[dom_struct]
@@ -32,15 +31,15 @@ impl ProcessingInstruction {
     }
 
     pub(crate) fn new(
+        cx: &mut js::context::JSContext,
         target: DOMString,
         data: DOMString,
         document: &Document,
-        can_gc: CanGc,
     ) -> DomRoot<ProcessingInstruction> {
         Node::reflect_node(
+            cx,
             Box::new(ProcessingInstruction::new_inherited(target, data, document)),
             document,
-            can_gc,
         )
     }
 }

--- a/components/script/dom/range.rs
+++ b/components/script/dom/range.rs
@@ -609,7 +609,7 @@ impl RangeMethods<crate::DomTypeHolder> for Range {
         let end_offset = self.end_offset();
 
         // Step 1.
-        let fragment = DocumentFragment::new(&start_node.owner_doc(), CanGc::from_cx(cx));
+        let fragment = DocumentFragment::new(cx, &start_node.owner_doc());
 
         // Step 2.
         if self.start() == self.end() {
@@ -622,8 +622,7 @@ impl RangeMethods<crate::DomTypeHolder> for Range {
                 let data = cdata
                     .SubstringData(start_offset, end_offset - start_offset)
                     .unwrap();
-                let clone =
-                    cdata.clone_with_data(data, &start_node.owner_doc(), CanGc::from_cx(cx));
+                let clone = cdata.clone_with_data(cx, data, &start_node.owner_doc());
                 // Step 4.3.
                 fragment.upcast::<Node>().AppendChild(cx, &clone)?;
                 // Step 4.4
@@ -646,8 +645,7 @@ impl RangeMethods<crate::DomTypeHolder> for Range {
                 let data = cdata
                     .SubstringData(start_offset, start_node.len() - start_offset)
                     .unwrap();
-                let clone =
-                    cdata.clone_with_data(data, &start_node.owner_doc(), CanGc::from_cx(cx));
+                let clone = cdata.clone_with_data(cx, data, &start_node.owner_doc());
                 // Step 13.3.
                 fragment.upcast::<Node>().AppendChild(cx, &clone)?;
             } else {
@@ -685,8 +683,7 @@ impl RangeMethods<crate::DomTypeHolder> for Range {
                 assert!(child == end_node);
                 // Steps 16.1-2.
                 let data = cdata.SubstringData(0, end_offset).unwrap();
-                let clone =
-                    cdata.clone_with_data(data, &start_node.owner_doc(), CanGc::from_cx(cx));
+                let clone = cdata.clone_with_data(cx, data, &start_node.owner_doc());
                 // Step 16.3.
                 fragment.upcast::<Node>().AppendChild(cx, &clone)?;
             } else {
@@ -724,7 +721,7 @@ impl RangeMethods<crate::DomTypeHolder> for Range {
         let end_offset = self.end_offset();
 
         // Step 1.
-        let fragment = DocumentFragment::new(&start_node.owner_doc(), CanGc::from_cx(cx));
+        let fragment = DocumentFragment::new(cx, &start_node.owner_doc());
 
         // Step 2.
         if self.collapsed() {

--- a/components/script/dom/servoparser/async_html.rs
+++ b/components/script/dom/servoparser/async_html.rs
@@ -476,10 +476,7 @@ impl Tokenizer {
                 let template = target
                     .downcast::<HTMLTemplateElement>()
                     .expect("Tried to extract contents from non-template element while parsing");
-                self.insert_node(
-                    contents,
-                    Dom::from_ref(template.Content(CanGc::from_cx(cx)).upcast()),
-                );
+                self.insert_node(contents, Dom::from_ref(template.Content(cx).upcast()));
             },
             ParseOperation::CreateElement {
                 node,
@@ -506,8 +503,7 @@ impl Tokenizer {
                 self.insert_node(node, Dom::from_ref(element.upcast()));
             },
             ParseOperation::CreateComment { text, node } => {
-                let comment =
-                    Comment::new(DOMString::from(text), document, None, CanGc::from_cx(cx));
+                let comment = Comment::new(cx, DOMString::from(text), document, None);
                 self.insert_node(node, Dom::from_ref(comment.upcast()));
             },
             ParseOperation::AppendBeforeSibling { sibling, node } => {
@@ -533,11 +529,11 @@ impl Tokenizer {
                 system_id,
             } => {
                 let doctype = DocumentType::new(
+                    cx,
                     DOMString::from(name),
                     Some(DOMString::from(public_id)),
                     Some(DOMString::from(system_id)),
                     document,
-                    CanGc::from_cx(cx),
                 );
 
                 document
@@ -612,10 +608,10 @@ impl Tokenizer {
             },
             ParseOperation::CreatePI { node, target, data } => {
                 let pi = ProcessingInstruction::new(
+                    cx,
                     DOMString::from(target),
                     DOMString::from(data),
                     document,
-                    CanGc::from_cx(cx),
                 );
                 self.insert_node(node, Dom::from_ref(pi.upcast()));
             },

--- a/components/script/dom/servoparser/html.rs
+++ b/components/script/dom/servoparser/html.rs
@@ -14,6 +14,7 @@ use html5ever::tokenizer::{Tokenizer as HtmlTokenizer, TokenizerOpts};
 use html5ever::tree_builder::{QuirksMode as HTML5EverQuirksMode, TreeBuilder, TreeBuilderOpts};
 use html5ever::{QualName, local_name, ns};
 use markup5ever::TokenizerResult;
+use script_bindings::script_runtime::temp_cx;
 use script_bindings::trace::CustomTraceable;
 use servo_url::ServoUrl;
 use style::attr::AttrValue;
@@ -36,7 +37,6 @@ use crate::dom::node::Node;
 use crate::dom::processinginstruction::ProcessingInstruction;
 use crate::dom::servoparser::{ParsingAlgorithm, Sink};
 use crate::dom::shadowroot::ShadowRoot;
-use crate::script_runtime::CanGc;
 
 #[derive(JSTraceable, MallocSizeOf)]
 #[cfg_attr(crown, crown::unrooted_must_root_lint::must_root)]
@@ -187,11 +187,11 @@ enum SerializationChildrenIterator<C, S> {
 
 impl SerializationIterator {
     fn new(
+        cx: &mut js::context::JSContext,
         node: &Node,
         skip_first: bool,
         serialize_shadow_roots: bool,
         shadow_roots: Vec<DomRoot<ShadowRoot>>,
-        can_gc: CanGc,
     ) -> SerializationIterator {
         let mut ret = SerializationIterator {
             stack: vec![],
@@ -199,24 +199,20 @@ impl SerializationIterator {
             shadow_roots,
         };
         if skip_first || node.is::<DocumentFragment>() || node.is::<Document>() {
-            ret.handle_node_contents(node, can_gc);
+            ret.handle_node_contents(cx, node);
         } else {
             ret.push_node(node);
         }
         ret
     }
 
-    fn handle_node_contents(&mut self, node: &Node, can_gc: CanGc) {
+    fn handle_node_contents(&mut self, cx: &mut js::context::JSContext, node: &Node) {
         if node.downcast::<Element>().is_some_and(Element::is_void) {
             return;
         }
 
         if let Some(template_element) = node.downcast::<HTMLTemplateElement>() {
-            for child in template_element
-                .Content(can_gc)
-                .upcast::<Node>()
-                .rev_children()
-            {
+            for child in template_element.Content(cx).upcast::<Node>().rev_children() {
                 self.push_node(&child);
             }
         } else {
@@ -253,7 +249,11 @@ impl SerializationIterator {
 impl Iterator for SerializationIterator {
     type Item = SerializationCommand;
 
+    #[expect(unsafe_code)]
     fn next(&mut self) -> Option<SerializationCommand> {
+        // TODO: https://github.com/servo/servo/issues/42839
+        let mut cx = unsafe { temp_cx() };
+        let cx = &mut cx;
         let res = self.stack.pop()?;
 
         match &res {
@@ -264,7 +264,7 @@ impl Iterator for SerializationIterator {
                     element.local_name().clone(),
                 );
                 self.stack.push(SerializationCommand::CloseElement(name));
-                self.handle_node_contents(element.upcast(), CanGc::note());
+                self.handle_node_contents(cx, element.upcast());
             },
             SerializationCommand::SerializeShadowRoot(shadow_root) => {
                 self.stack
@@ -273,7 +273,7 @@ impl Iterator for SerializationIterator {
                         ns!(),
                         local_name!("template"),
                     )));
-                self.handle_node_contents(shadow_root.upcast(), CanGc::note());
+                self.handle_node_contents(cx, shadow_root.upcast());
             },
             _ => {},
         }
@@ -284,19 +284,19 @@ impl Iterator for SerializationIterator {
 
 /// <https://html.spec.whatwg.org/multipage/#html-fragment-serialisation-algorithm>
 pub(crate) fn serialize_html_fragment<S: Serializer>(
+    cx: &mut js::context::JSContext,
     node: &Node,
     serializer: &mut S,
     traversal_scope: TraversalScope,
     serialize_shadow_roots: bool,
     shadow_roots: Vec<DomRoot<ShadowRoot>>,
-    can_gc: CanGc,
 ) -> io::Result<()> {
     let iter = SerializationIterator::new(
+        cx,
         node,
         traversal_scope != IncludeNode,
         serialize_shadow_roots,
         shadow_roots,
-        can_gc,
     );
 
     for cmd in iter {
@@ -383,17 +383,14 @@ impl<'a> HtmlSerialize<'a> {
 }
 
 impl Serialize for HtmlSerialize<'_> {
+    #[expect(unsafe_code)]
     fn serialize<S>(&self, serializer: &mut S, traversal_scope: TraversalScope) -> io::Result<()>
     where
         S: Serializer,
     {
-        serialize_html_fragment(
-            self.node,
-            serializer,
-            traversal_scope,
-            false,
-            vec![],
-            CanGc::note(),
-        )
+        // TODO: https://github.com/servo/servo/issues/42839
+        let mut cx = unsafe { temp_cx() };
+        let cx = &mut cx;
+        serialize_html_fragment(cx, self.node, serializer, traversal_scope, false, vec![])
     }
 }

--- a/components/script/dom/servoparser/mod.rs
+++ b/components/script/dom/servoparser/mod.rs
@@ -1611,11 +1611,7 @@ fn insert(
             if let Some(text) = text {
                 text.upcast::<CharacterData>().append_data(&t);
             } else {
-                let text = Text::new(
-                    String::from(t).into(),
-                    &parent.owner_doc(),
-                    CanGc::from_cx(cx),
-                );
+                let text = Text::new(cx, String::from(t).into(), &parent.owner_doc());
                 parent
                     .InsertBefore(cx, text.upcast(), reference_child)
                     .unwrap();
@@ -1668,12 +1664,16 @@ impl TreeSink for Sink {
         Dom::from_ref(self.document.upcast())
     }
 
+    #[expect(unsafe_code)]
     #[cfg_attr(crown, expect(crown::unrooted_must_root))]
     fn get_template_contents(&self, target: &Dom<Node>) -> Dom<Node> {
+        // TODO: https://github.com/servo/servo/issues/42839
+        let mut cx = unsafe { temp_cx() };
+        let cx = &mut cx;
         let template = target
             .downcast::<HTMLTemplateElement>()
             .expect("tried to get template contents of non-HTMLTemplateElement in HTML parsing");
-        Dom::from_ref(template.Content(CanGc::note()).upcast())
+        Dom::from_ref(template.Content(cx).upcast())
     }
 
     fn same_node(&self, x: &Dom<Node>, y: &Dom<Node>) -> bool {
@@ -1723,25 +1723,33 @@ impl TreeSink for Sink {
         Dom::from_ref(element.upcast())
     }
 
+    #[expect(unsafe_code)]
     #[cfg_attr(crown, expect(crown::unrooted_must_root))]
     fn create_comment(&self, text: StrTendril) -> Dom<Node> {
+        // TODO: https://github.com/servo/servo/issues/42839
+        let mut cx = unsafe { temp_cx() };
+        let cx = &mut cx;
         let comment = Comment::new(
+            cx,
             DOMString::from(String::from(text)),
             &self.document,
             None,
-            CanGc::note(),
         );
         Dom::from_ref(comment.upcast())
     }
 
+    #[expect(unsafe_code)]
     #[cfg_attr(crown, expect(crown::unrooted_must_root))]
     fn create_pi(&self, target: StrTendril, data: StrTendril) -> Dom<Node> {
+        // TODO: https://github.com/servo/servo/issues/42839
+        let mut cx = unsafe { temp_cx() };
+        let cx = &mut cx;
         let doc = &*self.document;
         let pi = ProcessingInstruction::new(
+            cx,
             DOMString::from(String::from(target)),
             DOMString::from(String::from(data)),
             doc,
-            CanGc::note(),
         );
         Dom::from_ref(pi.upcast())
     }
@@ -1854,11 +1862,11 @@ impl TreeSink for Sink {
 
         let doc = &*self.document;
         let doctype = DocumentType::new(
+            cx,
             DOMString::from(String::from(name)),
             Some(DOMString::from(String::from(public_id))),
             Some(DOMString::from(String::from(system_id))),
             doc,
-            CanGc::from_cx(cx),
         );
         doc.upcast::<Node>()
             .AppendChild(cx, doctype.upcast())

--- a/components/script/dom/shadowroot.rs
+++ b/components/script/dom/shadowroot.rs
@@ -460,23 +460,26 @@ impl ShadowRootMethods<crate::DomTypeHolder> for ShadowRoot {
     }
 
     /// <https://html.spec.whatwg.org/multipage/#dom-shadowroot-gethtml>
-    fn GetHTML(&self, options: &GetHTMLOptions, can_gc: CanGc) -> DOMString {
+    fn GetHTML(&self, cx: &mut js::context::JSContext, options: &GetHTMLOptions) -> DOMString {
         // > ShadowRoot's getHTML(options) method steps are to return the result of HTML fragment serialization
         // >  algorithm with this, options["serializableShadowRoots"], and options["shadowRoots"].
         self.upcast::<Node>().html_serialize(
+            cx,
             TraversalScope::ChildrenOnly(None),
             options.serializableShadowRoots,
             options.shadowRoots.clone(),
-            can_gc,
         )
     }
 
     /// <https://html.spec.whatwg.org/multipage/#dom-shadowroot-innerhtml>
-    fn GetInnerHTML(&self, can_gc: CanGc) -> Fallible<TrustedHTMLOrNullIsEmptyString> {
+    fn GetInnerHTML(
+        &self,
+        cx: &mut js::context::JSContext,
+    ) -> Fallible<TrustedHTMLOrNullIsEmptyString> {
         // ShadowRoot's innerHTML getter steps are to return the result of running fragment serializing
         // algorithm steps with this and true.
         self.upcast::<Node>()
-            .fragment_serialization_algorithm(true, can_gc)
+            .fragment_serialization_algorithm(cx, true)
             .map(TrustedHTMLOrNullIsEmptyString::NullIsEmptyString)
     }
 

--- a/components/script/dom/svg/svgelement.rs
+++ b/components/script/dom/svg/svgelement.rs
@@ -54,17 +54,17 @@ impl SVGElement {
     }
 
     pub(crate) fn new(
+        cx: &mut js::context::JSContext,
         tag_name: LocalName,
         prefix: Option<Prefix>,
         document: &Document,
         proto: Option<HandleObject>,
-        can_gc: CanGc,
     ) -> DomRoot<SVGElement> {
         Node::reflect_node_with_proto(
+            cx,
             Box::new(SVGElement::new_inherited(tag_name, prefix, document)),
             document,
             proto,
-            can_gc,
         )
     }
 

--- a/components/script/dom/svg/svgimageelement.rs
+++ b/components/script/dom/svg/svgimageelement.rs
@@ -16,7 +16,6 @@ use crate::dom::element::AttributeMutation;
 use crate::dom::node::{Node, NodeTraits};
 use crate::dom::svg::svggraphicselement::SVGGraphicsElement;
 use crate::dom::virtualmethods::VirtualMethods;
-use crate::script_runtime::CanGc;
 
 /// <https://svgwg.org/svg2-draft/embedded.html#Placement>
 const DEFAULT_WIDTH: u32 = 300;
@@ -39,17 +38,17 @@ impl SVGImageElement {
     }
 
     pub(crate) fn new(
+        cx: &mut js::context::JSContext,
         local_name: LocalName,
         prefix: Option<Prefix>,
         document: &Document,
         proto: Option<HandleObject>,
-        can_gc: CanGc,
     ) -> DomRoot<SVGImageElement> {
         Node::reflect_node_with_proto(
+            cx,
             Box::new(SVGImageElement::new_inherited(local_name, prefix, document)),
             document,
             proto,
-            can_gc,
         )
     }
 

--- a/components/script/dom/svg/svgsvgelement.rs
+++ b/components/script/dom/svg/svgsvgelement.rs
@@ -61,17 +61,17 @@ impl SVGSVGElement {
 
     #[cfg_attr(crown, allow(crown::unrooted_must_root))]
     pub(crate) fn new(
+        cx: &mut js::context::JSContext,
         local_name: LocalName,
         prefix: Option<Prefix>,
         document: &Document,
         proto: Option<HandleObject>,
-        can_gc: CanGc,
     ) -> DomRoot<SVGSVGElement> {
         Node::reflect_node_with_proto(
+            cx,
             Box::new(SVGSVGElement::new_inherited(local_name, prefix, document)),
             document,
             proto,
-            can_gc,
         )
     }
 

--- a/components/script/dom/text.rs
+++ b/components/script/dom/text.rs
@@ -21,7 +21,6 @@ use crate::dom::globalscope::GlobalScope;
 use crate::dom::html::htmlslotelement::{HTMLSlotElement, Slottable};
 use crate::dom::node::Node;
 use crate::dom::window::Window;
-use crate::script_runtime::CanGc;
 
 /// An HTML text node.
 #[dom_struct]
@@ -36,21 +35,25 @@ impl Text {
         }
     }
 
-    pub(crate) fn new(text: DOMString, document: &Document, can_gc: CanGc) -> DomRoot<Text> {
-        Self::new_with_proto(text, document, None, can_gc)
+    pub(crate) fn new(
+        cx: &mut js::context::JSContext,
+        text: DOMString,
+        document: &Document,
+    ) -> DomRoot<Text> {
+        Self::new_with_proto(cx, text, document, None)
     }
 
     fn new_with_proto(
+        cx: &mut js::context::JSContext,
         text: DOMString,
         document: &Document,
         proto: Option<HandleObject>,
-        can_gc: CanGc,
     ) -> DomRoot<Text> {
         Node::reflect_node_with_proto(
+            cx,
             Box::new(Text::new_inherited(text, document)),
             document,
             proto,
-            can_gc,
         )
     }
 }
@@ -58,13 +61,13 @@ impl Text {
 impl TextMethods<crate::DomTypeHolder> for Text {
     /// <https://dom.spec.whatwg.org/#dom-text-text>
     fn Constructor(
+        cx: &mut js::context::JSContext,
         window: &Window,
         proto: Option<HandleObject>,
-        can_gc: CanGc,
         text: DOMString,
     ) -> Fallible<DomRoot<Text>> {
         let document = window.Document();
-        Ok(Text::new_with_proto(text, &document, proto, can_gc))
+        Ok(Text::new_with_proto(cx, text, &document, proto))
     }
 
     // https://dom.spec.whatwg.org/#dom-text-splittext
@@ -84,7 +87,7 @@ impl TextMethods<crate::DomTypeHolder> for Text {
         // Step 5.
         let node = self.upcast::<Node>();
         let owner_doc = node.owner_doc();
-        let new_node = owner_doc.CreateTextNode(new_data, CanGc::from_cx(cx));
+        let new_node = owner_doc.CreateTextNode(cx, new_data);
         // Step 6.
         let parent = node.GetParentNode();
         if let Some(ref parent) = parent {

--- a/components/script/script_thread.rs
+++ b/components/script/script_thread.rs
@@ -2542,12 +2542,7 @@ impl ScriptThread {
                 )
             },
             WebDriverScriptCommand::GetPageSource(reply) => {
-                webdriver_handlers::handle_get_page_source(
-                    &documents,
-                    pipeline_id,
-                    reply,
-                    CanGc::from_cx(cx),
-                )
+                webdriver_handlers::handle_get_page_source(cx, &documents, pipeline_id, reply)
             },
             WebDriverScriptCommand::GetCookies(reply) => {
                 webdriver_handlers::handle_get_cookies(&documents, pipeline_id, reply)

--- a/components/script/webdriver_handlers.rs
+++ b/components/script/webdriver_handlers.rs
@@ -1370,10 +1370,10 @@ pub(crate) fn handle_get_computed_role(
 }
 
 pub(crate) fn handle_get_page_source(
+    cx: &mut js::context::JSContext,
     documents: &DocumentCollection,
     pipeline: PipelineId,
     reply: GenericSender<Result<String, ErrorStatus>>,
-    can_gc: CanGc,
 ) {
     reply
         .send(
@@ -1381,10 +1381,10 @@ pub(crate) fn handle_get_page_source(
                 .find_document(pipeline)
                 .ok_or(ErrorStatus::UnknownError)
                 .and_then(|document| match document.GetDocumentElement() {
-                    Some(element) => match element.outer_html(can_gc) {
+                    Some(element) => match element.outer_html(cx) {
                         Ok(source) => Ok(source.to_string()),
                         Err(_) => {
-                            match XMLSerializer::new(document.window(), None, can_gc)
+                            match XMLSerializer::new(document.window(), None, CanGc::from_cx(cx))
                                 .SerializeToString(element.upcast::<Node>())
                             {
                                 Ok(source) => Ok(source.to_string()),

--- a/components/script_bindings/codegen/Bindings.conf
+++ b/components/script_bindings/codegen/Bindings.conf
@@ -110,6 +110,10 @@ DOMInterfaces = {
     'canGc': ['GetType', 'Types']
 },
 
+'Comment': {
+    'cx': ['Constructor']
+},
+
 'CookieStore': {
     'cx': ['Set', 'Set_', 'Get', 'Get_', 'GetAll', 'GetAll_', 'Delete', 'Delete_'],
 },
@@ -196,13 +200,20 @@ DOMInterfaces = {
 
 'Document': {
     'additionalTraits': ["crate::interfaces::DocumentHelpers"],
-    'canGc': ['CreateEvent', 'CreateRange', 'CreateComment', 'CreateAttribute', 'CreateAttributeNS', 'CreateDocumentFragment', 'CreateTextNode', 'CreateCDATASection', 'CreateProcessingInstruction', 'SetBgColor', 'SetFgColor', 'Fonts', 'ExitFullscreen', 'CreateExpression', 'CreateNSResolver', 'Evaluate', 'StyleSheets', 'Implementation', 'GetElementsByTagName', 'GetElementsByTagNameNS', 'GetElementsByClassName', 'CreateNodeIterator', 'GetElementsByName', 'Images', 'Embeds', 'Plugins', 'Links', 'Forms', 'Scripts', 'Anchors', 'Applets', 'Children', 'GetSelection', 'NamedGetter', 'AdoptedStyleSheets', 'SetAdoptedStyleSheets'],
+    'canGc': ['CreateEvent', 'CreateRange', 'SetBgColor', 'SetFgColor', 'Fonts', 'ExitFullscreen', 'CreateExpression', 'CreateNSResolver', 'Evaluate', 'StyleSheets', 'Implementation', 'GetElementsByTagName', 'GetElementsByTagNameNS', 'GetElementsByClassName', 'CreateNodeIterator', 'GetElementsByName', 'Images', 'Embeds', 'Plugins', 'Links', 'Forms', 'Scripts', 'Anchors', 'Applets', 'Children', 'GetSelection', 'NamedGetter', 'AdoptedStyleSheets', 'SetAdoptedStyleSheets'],
     'cx': [
         'AdoptNode',
         'Append',
         'Close',
+        'CreateAttribute',
+        'CreateAttributeNS',
+        'CreateCDATASection',
+        'CreateComment',
+        'CreateDocumentFragment',
         'CreateElement',
         'CreateElementNS',
+        'CreateProcessingInstruction',
+        'CreateTextNode',
         'ExecCommand',
         'GetLocation',
         'ImportNode',
@@ -227,7 +238,7 @@ DOMInterfaces = {
 
 'DocumentFragment': {
     'canGc': ['Children'],
-    'cx': ['Append', 'MoveBefore', 'Prepend', 'ReplaceChildren']
+    'cx': ['Append', 'Constructor', 'MoveBefore', 'Prepend', 'ReplaceChildren']
 },
 
 'DocumentType': {
@@ -235,8 +246,7 @@ DOMInterfaces = {
 },
 
 'DOMImplementation': {
-    'canGc': ['CreateDocumentType'],
-    'cx': ['CreateDocument', 'CreateHTMLDocument'],
+    'cx': ['CreateDocument', 'CreateDocumentType', 'CreateHTMLDocument'],
 },
 
 'DOMMatrix': {
@@ -280,8 +290,8 @@ DOMInterfaces = {
 },
 
 'Element': {
-    'cx': ['SetHTMLUnsafe', 'SetInnerHTML', 'SetOuterHTML', 'InsertAdjacentHTML', 'ToggleAttribute', 'SetAttribute', 'SetAttributeNS', 'SetAttributeNode', 'SetAttributeNodeNS', 'RemoveAttributeNS', 'RemoveAttributeNode', 'SetRole', 'SetAriaAtomic', 'SetAriaAutoComplete', 'SetAriaBrailleLabel', 'SetAriaBrailleRoleDescription', 'SetAriaBusy', 'SetAriaChecked', 'SetAriaColCount', 'SetAriaColIndex', 'SetAriaColIndexText', 'SetAriaColSpan', 'SetAriaCurrent', 'SetAriaDescription', 'SetAriaDisabled', 'SetAriaExpanded', 'SetAriaHasPopup', 'SetAriaHidden', 'SetAriaInvalid', 'SetAriaKeyShortcuts', 'SetAriaLabel', 'SetAriaLevel', 'SetAriaLive', 'SetAriaModal', 'SetAriaMultiLine', 'SetAriaMultiSelectable', 'SetAriaOrientation', 'SetAriaPlaceholder', 'SetAriaPosInSet', 'SetAriaPressed','SetAriaReadOnly', 'SetAriaRelevant', 'SetAriaRequired', 'SetAriaRoleDescription', 'SetAriaRowCount', 'SetAriaRowIndex', 'SetAriaRowIndexText', 'SetAriaRowSpan', 'SetAriaSelected', 'SetAriaSetSize','SetAriaSort', 'SetAriaValueMax', 'SetAriaValueMin', 'SetAriaValueNow', 'SetAriaValueText', 'ReplaceWith', 'MoveBefore', 'InsertAdjacentElement', 'InsertAdjacentText', 'Before', 'After', 'Prepend', 'Remove', 'ReplaceChildren', 'Append', 'AttachShadow'],
-    'canGc': ['GetClientRects', 'GetBoundingClientRect', 'SetId','SetClassName', 'RequestFullscreen', 'GetHTML', 'GetInnerHTML', 'GetOuterHTML', 'ClassList', 'Attributes', 'GetElementsByTagName', 'GetElementsByTagNameNS', 'GetElementsByClassName', 'Children', 'RemoveAttribute'],
+    'cx': ['GetHTML', 'GetInnerHTML', 'GetOuterHTML', 'SetHTMLUnsafe', 'SetInnerHTML', 'SetOuterHTML', 'InsertAdjacentHTML', 'ToggleAttribute', 'SetAttribute', 'SetAttributeNS', 'SetAttributeNode', 'SetAttributeNodeNS', 'RemoveAttributeNS', 'RemoveAttributeNode', 'SetRole', 'SetAriaAtomic', 'SetAriaAutoComplete', 'SetAriaBrailleLabel', 'SetAriaBrailleRoleDescription', 'SetAriaBusy', 'SetAriaChecked', 'SetAriaColCount', 'SetAriaColIndex', 'SetAriaColIndexText', 'SetAriaColSpan', 'SetAriaCurrent', 'SetAriaDescription', 'SetAriaDisabled', 'SetAriaExpanded', 'SetAriaHasPopup', 'SetAriaHidden', 'SetAriaInvalid', 'SetAriaKeyShortcuts', 'SetAriaLabel', 'SetAriaLevel', 'SetAriaLive', 'SetAriaModal', 'SetAriaMultiLine', 'SetAriaMultiSelectable', 'SetAriaOrientation', 'SetAriaPlaceholder', 'SetAriaPosInSet', 'SetAriaPressed','SetAriaReadOnly', 'SetAriaRelevant', 'SetAriaRequired', 'SetAriaRoleDescription', 'SetAriaRowCount', 'SetAriaRowIndex', 'SetAriaRowIndexText', 'SetAriaRowSpan', 'SetAriaSelected', 'SetAriaSetSize','SetAriaSort', 'SetAriaValueMax', 'SetAriaValueMin', 'SetAriaValueNow', 'SetAriaValueText', 'ReplaceWith', 'MoveBefore', 'InsertAdjacentElement', 'InsertAdjacentText', 'Before', 'After', 'Prepend', 'Remove', 'ReplaceChildren', 'Append', 'AttachShadow'],
+    'canGc': ['GetClientRects', 'GetBoundingClientRect', 'SetId','SetClassName', 'RequestFullscreen', 'ClassList', 'Attributes', 'GetElementsByTagName', 'GetElementsByTagNameNS', 'GetElementsByClassName', 'Children', 'RemoveAttribute'],
 },
 
 'ElementInternals': {
@@ -570,7 +580,7 @@ DOMInterfaces = {
 },
 
 'HTMLTemplateElement': {
-    'canGc': ['Content'],
+    'cx': ['Content'],
 },
 
 'HTMLTextAreaElement': {
@@ -769,8 +779,8 @@ DOMInterfaces = {
 },
 
 'ShadowRoot': {
-    'canGc': ['GetHTML', 'GetInnerHTML', 'AdoptedStyleSheets', 'SetAdoptedStyleSheets'],
-    'cx': ['SetHTMLUnsafe', 'SetInnerHTML'],
+    'canGc': ['AdoptedStyleSheets', 'SetAdoptedStyleSheets'],
+    'cx': ['GetHTML', 'GetInnerHTML', 'SetHTMLUnsafe', 'SetInnerHTML'],
 },
 
 'StaticRange': {
@@ -801,7 +811,7 @@ DOMInterfaces = {
 },
 
 'Text': {
-    'cx': ['SplitText'],
+    'cx': ['Constructor', 'SplitText'],
     'cx_no_gc': ['WholeText']
 },
 


### PR DESCRIPTION
A lot (and I mean, really a lot) depends on these constructors. Therefore, this is the one spaghetti ball that I could extract and convert all `can_gc` to `cx`. There are some new introductions of `temp_cx` in the callbacks of the servo parser, but we already had some in other callbacks.

Part of #40600

Testing: It compiles