### PR TITLE
devtools: Replace new with register for LayoutInspectorActor

### DIFF
--- a/components/devtools/actors/inspector/layout.rs
+++ b/components/devtools/actors/inspector/layout.rs
@@ -74,8 +74,11 @@ impl Actor for LayoutInspectorActor {
 }
 
 impl LayoutInspectorActor {
-    pub fn new(name: String) -> Self {
-        Self { name }
+    pub fn register(registry: &ActorRegistry) -> String {
+        let name = registry.new_name::<Self>();
+        let actor = Self { name: name.clone() };
+        registry.register::<Self>(actor);
+        name
     }
 }
 

--- a/components/devtools/actors/inspector/walker.rs
+++ b/components/devtools/actors/inspector/walker.rs
@@ -213,14 +213,14 @@ impl Actor for WalkerActor {
             },
             "getLayoutInspector" => {
                 // TODO: Create actual layout inspector actor
+                let layout_inspector_name = LayoutInspectorActor::register(registry);
                 let layout_inspector_actor =
-                    LayoutInspectorActor::new(registry.new_name::<LayoutInspectorActor>());
+                    registry.find::<LayoutInspectorActor>(&layout_inspector_name);
 
                 let msg = GetLayoutInspectorReply {
                     from: self.name(),
                     actor: layout_inspector_actor.encode(registry),
                 };
-                registry.register(layout_inspector_actor);
                 request.reply_final(&msg)?
             },
             "getMutations" => self.handle_get_mutations(request, registry)?,


### PR DESCRIPTION
Replaced new with register for LayoutInspectorActor in walker.rs & layout.rs

Testing: No testing required, compiles successfully.
Fixes: Part of #43800