### PR TITLE
devtools: Replace new with register for PauseActor

### DIFF
--- a/components/devtools/actors/pause.rs
+++ b/components/devtools/actors/pause.rs
@@ -4,17 +4,26 @@
 
 use malloc_size_of_derive::MallocSizeOf;
 
-use crate::actor::Actor;
+use crate::actor::{Actor, ActorRegistry};
 
 /// Referenced by `ThreadActor` when replying to `interupt` messages.
 /// <https://searchfox.org/firefox-main/source/devtools/server/actors/thread.js#1699>
 #[derive(MallocSizeOf)]
 pub(crate) struct PauseActor {
-    pub name: String,
+    name: String,
 }
 
 impl Actor for PauseActor {
     fn name(&self) -> String {
         self.name.clone()
+    }
+}
+
+impl PauseActor {
+    pub fn register(registry: &ActorRegistry) -> String {
+        let name = registry.new_name::<Self>();
+        let actor = Self { name: name.clone() };
+        registry.register::<Self>(actor);
+        name
     }
 }

--- a/components/devtools/actors/thread.rs
+++ b/components/devtools/actors/thread.rs
@@ -149,10 +149,7 @@ impl Actor for ThreadActor {
     ) -> Result<(), ActorError> {
         match msg_type {
             "attach" => {
-                let pause_name = registry.new_name::<PauseActor>();
-                registry.register(PauseActor {
-                    name: pause_name.clone(),
-                });
+                let pause_name = PauseActor::register(registry);
                 let msg = ThreadAttached {
                     from: self.name(),
                     type_: "paused".to_owned(),

--- a/components/devtools/lib.rs
+++ b/components/devtools/lib.rs
@@ -807,10 +807,7 @@ impl DevtoolsInstance {
             .registry
             .find::<ThreadActor>(&browsing_context_actor.thread_name);
 
-        let pause_name = self.registry.new_name::<PauseActor>();
-        self.registry.register(PauseActor {
-            name: pause_name.clone(),
-        });
+        let pause_name = PauseActor::register(&self.registry);
 
         let frame_actor = self.registry.find::<FrameActor>(&frame_offset.actor);
         frame_actor.set_offset(frame_offset.column, frame_offset.line);


### PR DESCRIPTION
Replaced new with register for PauseActor in pause.rs & lib.rs

Testing: No testing required, compiles successfully.
Fixes: Part of #43800