### PR TITLE
devtools: Rename SourceActor variable names

### DIFF
--- a/components/devtools/actors/frame.rs
+++ b/components/devtools/actors/frame.rs
@@ -60,7 +60,7 @@ pub(crate) struct FrameActorMsg {
 pub(crate) struct FrameActor {
     name: String,
     object_actor: String,
-    source_actor: String,
+    source_name: String,
     frame_result: FrameInfo,
     current_offset: AtomicRefCell<(u32, u32)>,
 }
@@ -84,8 +84,8 @@ impl Actor for FrameActor {
                 let Some((tx, rx)) = channel() else {
                     return Err(ActorError::Internal);
                 };
-                let source = registry.find::<SourceActor>(&self.source_actor);
-                source
+                let source_actor = registry.find::<SourceActor>(&self.source_name);
+                source_actor
                     .script_sender
                     .send(DevtoolScriptControlMsg::GetEnvironment(self.name(), tx))
                     .map_err(|_| ActorError::Internal)?;
@@ -109,7 +109,7 @@ impl Actor for FrameActor {
 impl FrameActor {
     pub fn register(
         registry: &ActorRegistry,
-        source_actor: String,
+        source_name: String,
         frame_result: FrameInfo,
     ) -> String {
         let object_name = ObjectActor::register(registry, None, "Object".to_owned(), None);
@@ -118,7 +118,7 @@ impl FrameActor {
         let actor = Self {
             name: name.clone(),
             object_actor: object_name,
-            source_actor,
+            source_name,
             frame_result,
             current_offset: Default::default(),
         };
@@ -153,7 +153,7 @@ impl ActorEncode<FrameActorMsg> for FrameActor {
             oldest: self.frame_result.oldest,
             state,
             where_: FrameWhere {
-                actor: self.source_actor.clone(),
+                actor: self.source_name.clone(),
                 line,
                 column,
             },

--- a/components/devtools/lib.rs
+++ b/components/devtools/lib.rs
@@ -845,22 +845,22 @@ impl DevtoolsInstance {
         let browsing_context_actor = self
             .registry
             .find::<BrowsingContextActor>(browsing_context_name);
-        let thread = self
+        let thread_actor = self
             .registry
             .find::<ThreadActor>(&browsing_context_actor.thread_name);
 
-        let source = match thread
+        let source_name = match thread_actor
             .source_manager
             .find_source(&self.registry, &frame.url)
         {
-            Some(source) => source.name(),
+            Some(source_actor) => source_actor.name(),
             None => {
                 warn!("No source actor found for URL: {}", frame.url);
                 return;
             },
         };
 
-        let frame_name = FrameActor::register(&self.registry, source, frame);
+        let frame_name = FrameActor::register(&self.registry, source_name, frame);
 
         let _ = result_sender.send(frame_name);
     }


### PR DESCRIPTION
Renames local variable holding a `SourceActor` instance to `source_actor`, following the `{}_actor` convention for actor variables as described in #43606.

Changes:
- `actors/source.rs`: `actor` → `source_actor` in `SourceActor::register()`

Part of #43606.