### PR TITLE
devtools: Rename WorkerActor variables and add register method

### DIFF
--- a/components/devtools/actors/console.rs
+++ b/components/devtools/actors/console.rs
@@ -288,7 +288,7 @@ impl ConsoleActor {
                 .script_chan(),
             Root::DedicatedWorker(worker_name) => registry
                 .find::<WorkerActor>(worker_name)
-                .script_chan
+                .script_sender
                 .clone(),
         }
     }

--- a/components/devtools/actors/root.rs
+++ b/components/devtools/actors/root.rs
@@ -248,12 +248,12 @@ impl Actor for RootActor {
                     .borrow()
                     .iter()
                     .map(|worker_name| {
-                        let worker = registry.find::<WorkerActor>(worker_name);
-                        let url = worker.url.to_string();
+                        let worker_actor = registry.find::<WorkerActor>(worker_name);
+                        let url = worker_actor.url.to_string();
                         // Find correct scope url in the service worker
                         let scope = url.clone();
                         ServiceWorkerRegistrationMsg {
-                            actor: worker.name(),
+                            actor: worker_actor.name(),
                             scope,
                             url: url.clone(),
                             registration_state: "".to_string(),
@@ -263,11 +263,11 @@ impl Actor for RootActor {
                             installing_worker: None,
                             waiting_worker: None,
                             active_worker: Some(ServiceWorkerInfo {
-                                actor: worker.name(),
+                                actor: worker_actor.name(),
                                 url,
                                 state: 4, // activated
                                 state_text: "activated".to_string(),
-                                id: worker.worker_id.to_string(),
+                                id: worker_actor.worker_id.to_string(),
                                 fetch: false,
                                 traits: HashMap::new(),
                             }),

--- a/components/devtools/actors/worker.rs
+++ b/components/devtools/actors/worker.rs
@@ -34,13 +34,39 @@ pub(crate) struct WorkerActor {
     pub worker_id: WorkerId,
     pub url: ServoUrl,
     pub type_: WorkerType,
-    pub script_chan: GenericSender<DevtoolScriptControlMsg>,
+    pub script_sender: GenericSender<DevtoolScriptControlMsg>,
     pub streams: AtomicRefCell<FxHashSet<StreamId>>,
 }
 
 impl ResourceAvailable for WorkerActor {
     fn actor_name(&self) -> String {
         self.name.clone()
+    }
+}
+
+impl WorkerActor {
+    pub fn register(
+        registry: &ActorRegistry,
+        console_name: String,
+        thread_name: String,
+        worker_id: WorkerId,
+        url: ServoUrl,
+        worker_type: WorkerType,
+        script_sender: GenericSender<DevtoolScriptControlMsg>,
+    ) -> String {
+        let name = registry.new_name::<Self>();
+        let actor = Self {
+            name: name.clone(),
+            console_name,
+            thread_name,
+            worker_id,
+            url,
+            type_: worker_type,
+            script_sender,
+            streams: Default::default(),
+        };
+        registry.register::<Self>(actor);
+        name
     }
 }
 
@@ -67,7 +93,7 @@ impl Actor for WorkerActor {
                 request.write_json_packet(&msg)?;
                 self.streams.borrow_mut().insert(stream_id);
                 // FIXME: fix messages to not require forging a pipeline for worker messages
-                self.script_chan
+                self.script_sender
                     .send(WantsLiveNotifications(TEST_PIPELINE_ID, true))
                     .unwrap();
             },
@@ -109,7 +135,7 @@ impl Actor for WorkerActor {
     fn cleanup(&self, stream_id: StreamId) {
         self.streams.borrow_mut().remove(&stream_id);
         if self.streams.borrow().is_empty() {
-            self.script_chan
+            self.script_sender
                 .send(WantsLiveNotifications(TEST_PIPELINE_ID, false))
                 .unwrap();
         }

--- a/components/devtools/lib.rs
+++ b/components/devtools/lib.rs
@@ -482,29 +482,26 @@ impl DevtoolsInstance {
             } else {
                 WorkerType::Dedicated
             };
-            let worker_name = self.registry.new_name::<WorkerActor>();
-            let worker = WorkerActor {
-                name: worker_name.clone(),
-                console_name: console_name.clone(),
+            let worker_name = WorkerActor::register(
+                &self.registry,
+                console_name.clone(),
                 thread_name,
-                worker_id: id,
-                url: page_info.url,
-                type_: worker_type,
-                script_chan: script_sender,
-                streams: Default::default(),
-            };
+                id,
+                page_info.url,
+                worker_type,
+                script_sender,
+            );
             let root_actor = self.registry.find::<RootActor>("root");
             if page_info.is_service_worker {
                 root_actor
                     .service_workers
                     .borrow_mut()
-                    .push(worker.name.clone());
+                    .push(worker_name.clone());
             } else {
-                root_actor.workers.borrow_mut().push(worker.name.clone());
+                root_actor.workers.borrow_mut().push(worker_name.clone());
             }
 
             self.actor_workers.insert(id, worker_name.clone());
-            self.registry.register(worker);
 
             Root::DedicatedWorker(worker_name)
         } else {


### PR DESCRIPTION
Renames local variable `worker` to `worker_actor` in `lib.rs` and `root.rs`, following the `{}_actor` convention for actor struct variables and `{}_name` for actor name string variables established in #43606.

Also adds a `WorkerActor::register()` method (part of #43800), replacing the inline struct construction in `lib.rs` with a consistent pattern pattern matching other actors like `ThreadActor` and `SourceActor`.

**Changes:**
- `actors/worker.rs`: Add `WorkerActor::register()` method
- `actors/root.rs`: Rename `worker` → `worker_actor` in `listServiceWorkerRegistrations` handler
- `lib.rs`: Replace inline struct construction with `WorkerActor::register()` call

**Testing:** No testing required, compiles successfully.

Fixes: Part of #43606
Fixes: Part of #43800