### PR TITLE
devtools: rename the remaining `NodeActor` variables

### DIFF
--- a/components/devtools/actors/inspector/page_style.rs
+++ b/components/devtools/actors/inspector/page_style.rs
@@ -136,27 +136,27 @@ impl PageStyleActor {
         msg: &Map<String, Value>,
         registry: &ActorRegistry,
     ) -> Result<(), ActorError> {
-        let target = msg
+        let node_name = msg
             .get("node")
             .ok_or(ActorError::MissingParameter)?
             .as_str()
             .ok_or(ActorError::BadParameterType)?;
-        let node_actor = registry.find::<NodeActor>(target);
+        let node_actor = registry.find::<NodeActor>(node_name);
         let walker = registry.find::<WalkerActor>(&node_actor.walker);
         let browsing_context_actor = walker.browsing_context_actor(registry);
         let entries: Vec<_> = find_child(
             &node_actor.script_chan,
             node_actor.pipeline,
-            target,
+            node_name,
             registry,
             &walker.root(registry)?.actor,
             vec![],
-            |msg| msg.actor == target,
+            |msg| msg.actor == node_name,
         )
         .unwrap_or_default()
         .into_iter()
         .flat_map(|node| {
-            let inherited = (node.actor != target).then(|| node.actor.clone());
+            let inherited = (node.actor != node_name).then(|| node.actor.clone());
             let node_actor = registry.find::<NodeActor>(&node.actor);
 
             // Get the css selectors that match this node present in the currently active stylesheets.
@@ -226,12 +226,12 @@ impl PageStyleActor {
         msg: &Map<String, Value>,
         registry: &ActorRegistry,
     ) -> Result<(), ActorError> {
-        let target = msg
+        let node_name = msg
             .get("node")
             .ok_or(ActorError::MissingParameter)?
             .as_str()
             .ok_or(ActorError::BadParameterType)?;
-        let node_actor = registry.find::<NodeActor>(target);
+        let node_actor = registry.find::<NodeActor>(node_name);
         let computed = (|| match node_actor
             .style_rules
             .borrow_mut()
@@ -239,7 +239,7 @@ impl PageStyleActor {
         {
             Entry::Vacant(e) => {
                 let name = registry.new_name::<StyleRuleActor>();
-                let actor = StyleRuleActor::new(name.clone(), target.into(), None);
+                let actor = StyleRuleActor::new(name.clone(), node_name.into(), None);
                 let computed = actor.computed(registry)?;
                 registry.register(actor);
                 e.insert(name);

--- a/components/devtools/actors/inspector/page_style.rs
+++ b/components/devtools/actors/inspector/page_style.rs
@@ -264,12 +264,12 @@ impl PageStyleActor {
         msg: &Map<String, Value>,
         registry: &ActorRegistry,
     ) -> Result<(), ActorError> {
-        let target = msg
+        let node_name = msg
             .get("node")
             .ok_or(ActorError::MissingParameter)?
             .as_str()
             .ok_or(ActorError::BadParameterType)?;
-        let node_actor = registry.find::<NodeActor>(target);
+        let node_actor = registry.find::<NodeActor>(node_name);
         let walker = registry.find::<WalkerActor>(&node_actor.walker);
         let browsing_context_actor = walker.browsing_context_actor(registry);
         let (tx, rx) = generic_channel::channel().ok_or(ActorError::Internal)?;
@@ -277,7 +277,7 @@ impl PageStyleActor {
             .script_chan()
             .send(GetLayout(
                 browsing_context_actor.pipeline_id(),
-                registry.actor_to_script(target.to_owned()),
+                registry.actor_to_script(node_name.to_owned()),
                 tx,
             ))
             .map_err(|_| ActorError::Internal)?;

--- a/components/devtools/actors/inspector/style_rule.rs
+++ b/components/devtools/actors/inspector/style_rule.rs
@@ -82,7 +82,7 @@ pub(crate) struct StyleRuleActorMsg {
 #[derive(MallocSizeOf)]
 pub(crate) struct StyleRuleActor {
     name: String,
-    node: String,
+    node_name: String,
     selector: Option<(String, usize)>,
 }
 
@@ -121,14 +121,14 @@ impl Actor for StyleRuleActor {
                     .collect();
 
                 // Query the rule modification
-                let node_actor = registry.find::<NodeActor>(&self.node);
+                let node_actor = registry.find::<NodeActor>(&self.node_name);
                 let walker = registry.find::<WalkerActor>(&node_actor.walker);
                 let browsing_context_actor = walker.browsing_context_actor(registry);
                 browsing_context_actor
                     .script_chan()
                     .send(ModifyRule(
                         browsing_context_actor.pipeline_id(),
-                        registry.actor_to_script(self.node.clone()),
+                        registry.actor_to_script(self.node_name.clone()),
                         modifications,
                     ))
                     .map_err(|_| ActorError::Internal)?;
@@ -145,13 +145,13 @@ impl StyleRuleActor {
     pub fn new(name: String, node: String, selector: Option<(String, usize)>) -> Self {
         Self {
             name,
-            node,
+            node_name: node,
             selector,
         }
     }
 
     pub fn applied(&self, registry: &ActorRegistry) -> Option<AppliedRule> {
-        let node_actor = registry.find::<NodeActor>(&self.node);
+        let node_actor = registry.find::<NodeActor>(&self.node_name);
         let walker = registry.find::<WalkerActor>(&node_actor.walker);
         let browsing_context_actor = walker.browsing_context_actor(registry);
 
@@ -173,7 +173,7 @@ impl StyleRuleActor {
                 let (selector, stylesheet) = selector.clone();
                 GetStylesheetStyle(
                     browsing_context_actor.pipeline_id(),
-                    registry.actor_to_script(self.node.clone()),
+                    registry.actor_to_script(self.node_name.clone()),
                     selector,
                     stylesheet,
                     style_sender,
@@ -181,7 +181,7 @@ impl StyleRuleActor {
             },
             None => GetAttributeStyle(
                 browsing_context_actor.pipeline_id(),
-                registry.actor_to_script(self.node.clone()),
+                registry.actor_to_script(self.node_name.clone()),
                 style_sender,
             ),
         };
@@ -223,7 +223,7 @@ impl StyleRuleActor {
         &self,
         registry: &ActorRegistry,
     ) -> Option<HashMap<String, ComputedDeclaration>> {
-        let node_actor = registry.find::<NodeActor>(&self.node);
+        let node_actor = registry.find::<NodeActor>(&self.node_name);
         let walker = registry.find::<WalkerActor>(&node_actor.walker);
         let browsing_context_actor = walker.browsing_context_actor(registry);
 
@@ -232,7 +232,7 @@ impl StyleRuleActor {
             .script_chan()
             .send(GetComputedStyle(
                 browsing_context_actor.pipeline_id(),
-                registry.actor_to_script(self.node.clone()),
+                registry.actor_to_script(self.node_name.clone()),
                 style_sender,
             ))
             .ok()?;


### PR DESCRIPTION
- Renames variables containing the `NodeActor` name to `node_name`

Testing: Manually tested with `mach test-devtools` 
Part of: #43606
