### PR TITLE
profile: Add debug_span and minor refactoring

### DIFF
--- a/components/canvas/canvas_data.rs
+++ b/components/canvas/canvas_data.rs
@@ -318,7 +318,7 @@ impl<DrawTarget: GenericDrawTarget> CanvasData<DrawTarget> {
 
         let (descriptor, data) = {
             let _span =
-                profile_traits::trace_span!("image_descriptor_and_serializable_data",).entered();
+                profile_traits::trace_span!("image_descriptor_and_serializable_data").entered();
             self.draw_target.image_descriptor_and_serializable_data()
         };
 

--- a/components/paint/painter.rs
+++ b/components/paint/painter.rs
@@ -966,7 +966,7 @@ impl Painter {
             },
             display_list_descriptor,
         );
-        let _span = profile_traits::trace_span!("PaintMessage::SendDisplayList",).entered();
+        let _span = profile_traits::trace_span!("PaintMessage::SendDisplayList").entered();
         let Some(webview_renderer) = self.webview_renderers.get_mut(&webview_id) else {
             return warn!("Could not find WebView for incoming display list");
         };

--- a/components/shared/profile/lib.rs
+++ b/components/shared/profile/lib.rs
@@ -33,6 +33,25 @@ macro_rules! time_profile {
     }};
 }
 
+#[doc(hidden)]
+#[macro_export]
+macro_rules! __profiling_span {
+    ($backend_macro:ident, $span_name:literal $(, $field:tt)*) => {{
+        #[cfg(feature = "tracing")]
+        {
+            $crate::servo_tracing::$backend_macro!(
+                $span_name,
+                servo_profiling = true
+                $(, $field)*
+            )
+        }
+        #[cfg(not(feature = "tracing"))]
+        {
+            $crate::dummy_tracing::Span()
+        }
+    }};
+}
+
 /// Provides API compatible dummies for the tracing-rs APIs we use
 /// if tracing is disabled. Hence, nothing will be traced
 pub mod dummy_tracing {
@@ -114,32 +133,25 @@ pub mod dummy_tracing {
 /// which can be used to disable the effects of this macro.
 #[macro_export]
 macro_rules! trace_span {
-    ($span_name:literal, $($field:tt)*) => {
-        {
-        #[cfg(feature = "tracing")]
-        {
-            $crate::servo_tracing::trace_span!(
-                $span_name,
-                servo_profiling = true,
-                $($field)*
-            )
-        }
-        #[cfg(not(feature = "tracing"))]
-        { $crate::dummy_tracing::Span() }
-        }
+    ($span_name:literal $(, $field:tt)*) => {
+        $crate::__profiling_span!(trace_span, $span_name $(, $field)*)
     };
-    ($span_name:literal) => {
-        {
-         #[cfg(feature = "tracing")]
-         {
-             $crate::servo_tracing::trace_span!(
-                $span_name,
-                servo_profiling = true,
-             )
-         }
-        #[cfg(not(feature = "tracing"))]
-        { $crate::dummy_tracing::Span() }
-        }
+}
+
+/// Constructs a span at the debug level
+///
+/// This macro creates a Span for the purpose of instrumenting code to measure
+/// the execution time of the span.
+/// If the `tracing` feature (of the crate using this macro) is disabled, then
+/// the Span implementation will be replaced with a dummy, that does not record
+/// anything.
+///
+/// Attention: This macro requires the user crate to have a `tracing` feature,
+/// which can be used to disable the effects of this macro.
+#[macro_export]
+macro_rules! debug_span {
+    ($span_name:literal $(, $field:tt)*) => {
+        $crate::__profiling_span!(debug_span, $span_name $(, $field)*)
     };
 }
 
@@ -155,32 +167,8 @@ macro_rules! trace_span {
 /// which can be used to disable the effects of this macro.
 #[macro_export]
 macro_rules! info_span {
-    ($span_name:literal, $($field:tt)*) => {
-        {
-        #[cfg(feature = "tracing")]
-        {
-            $crate::servo_tracing::info_span!(
-                $span_name,
-                servo_profiling = true,
-                $($field)*
-            )
-        }
-        #[cfg(not(feature = "tracing"))]
-        { $crate::dummy_tracing::Span() }
-        }
-    };
-    ($span_name:literal) => {
-        {
-         #[cfg(feature = "tracing")]
-         {
-             $crate::servo_tracing::info_span!(
-                $span_name,
-                servo_profiling = true,
-             )
-         }
-        #[cfg(not(feature = "tracing"))]
-        { $crate::dummy_tracing::Span() }
-        }
+    ($span_name:literal $(, $field:tt)*) => {
+        $crate::__profiling_span!(info_span, $span_name $(, $field)*)
     };
 }
 

--- a/components/shared/profile/lib.rs
+++ b/components/shared/profile/lib.rs
@@ -36,13 +36,13 @@ macro_rules! time_profile {
 #[doc(hidden)]
 #[macro_export]
 macro_rules! __profiling_span {
-    ($backend_macro:ident, $span_name:literal $(, $field:tt)*) => {{
+    ($backend_macro:ident, $span_name:literal $(, $($fields:tt)+)?) => {{
         #[cfg(feature = "tracing")]
         {
             $crate::servo_tracing::$backend_macro!(
                 $span_name,
                 servo_profiling = true
-                $(, $field)*
+                $(, $($fields)+)?
             )
         }
         #[cfg(not(feature = "tracing"))]
@@ -133,8 +133,8 @@ pub mod dummy_tracing {
 /// which can be used to disable the effects of this macro.
 #[macro_export]
 macro_rules! trace_span {
-    ($span_name:literal $(, $field:tt)*) => {
-        $crate::__profiling_span!(trace_span, $span_name $(, $field)*)
+    ($span_name:literal $(, $($fields:tt)+)?) => {
+        $crate::__profiling_span!(trace_span, $span_name $(, $($fields)+)?)
     };
 }
 
@@ -150,8 +150,8 @@ macro_rules! trace_span {
 /// which can be used to disable the effects of this macro.
 #[macro_export]
 macro_rules! debug_span {
-    ($span_name:literal $(, $field:tt)*) => {
-        $crate::__profiling_span!(debug_span, $span_name $(, $field)*)
+    ($span_name:literal $(, $($fields:tt)+)?) => {
+        $crate::__profiling_span!(debug_span, $span_name $(, $($fields)+)?)
     };
 }
 
@@ -167,8 +167,8 @@ macro_rules! debug_span {
 /// which can be used to disable the effects of this macro.
 #[macro_export]
 macro_rules! info_span {
-    ($span_name:literal $(, $field:tt)*) => {
-        $crate::__profiling_span!(info_span, $span_name $(, $field)*)
+    ($span_name:literal $(, $($fields:tt)+)?) => {
+        $crate::__profiling_span!(info_span, $span_name $(, $($fields)+)?)
     };
 }
 


### PR DESCRIPTION
Add an internal macro to avoid duplication, and use that to implement the existing two `trace` and `info` macros and add `debug_span`. We skip `warn` and `error` (from the tracing-rs library), since those names don't fit our profiling usage too well, and 3 different levels should also be enough. If we need more levels in the future we could still add more macros than (after deciding on better names than warn and error)

Testing: Servo is built with the tracing feature in CI (for HarmonyOS)

