### PR TITLE
Allow blob URL fetches to bypass CORS origin

### DIFF
--- a/components/net/fetch/methods.rs
+++ b/components/net/fetch/methods.rs
@@ -567,6 +567,9 @@ pub async fn main_fetch(
             else if (same_origin && request.response_tainting == ResponseTainting::Basic) ||
                 // request's current URL's scheme is "data"
                 current_scheme == "data" ||
+                // Added Blob URLs here because, the origin check is handled by the
+                // blob protocol handler itself, similar to how it is done with data: URLs.
+                current_scheme == "blob" ||
                 // Note: Although it is not part of the specification, we make an exception here
                 // for custom protocols that are explicitly marked as active for fetch.
                 context.protocols.is_fetchable(current_scheme) ||

--- a/tests/wpt/meta/FileAPI/url/sandboxed-iframe.html.ini
+++ b/tests/wpt/meta/FileAPI/url/sandboxed-iframe.html.ini
@@ -3,47 +3,17 @@
   [Generated Blob URLs are unique]
     expected: FAIL
 
-  [Blob URLs can be used in <script> tags]
-    expected: TIMEOUT
-
   [Blob URLs can be used in iframes, and are treated same origin]
     expected: FAIL
 
   [Blob URL fragment is implemented.]
     expected: TIMEOUT
 
-  [Blob URLs can be used in XHR]
-    expected: FAIL
-
-  [XHR with a fragment should succeed]
-    expected: FAIL
-
-  [Only exact matches should revoke URLs, using XHR]
-    expected: FAIL
-
-  [XHR should return Content-Type from Blob]
-    expected: FAIL
-
-  [Revoke blob URL after open(), will fetch]
-    expected: FAIL
-
-  [Blob URLs can be used in fetch]
-    expected: FAIL
-
-  [fetch with a fragment should succeed]
-    expected: FAIL
-
-  [Only exact matches should revoke URLs, using fetch]
-    expected: FAIL
-
-  [fetch should return Content-Type from Blob]
-    expected: FAIL
-
-  [Revoke blob URL after creating Request, will fetch]
-    expected: FAIL
-
   [Revoke blob URL after creating Request, then clone Request, will fetch]
     expected: FAIL
 
-  [Revoke blob URL after calling fetch, fetch should succeed]
+  [XHR of a revoked URL should fail]
+    expected: FAIL
+
+  [fetch of a revoked URL should fail]
     expected: FAIL

--- a/tests/wpt/meta/fetch/corb/script-html-via-cross-origin-blob-url.sub.html.ini
+++ b/tests/wpt/meta/fetch/corb/script-html-via-cross-origin-blob-url.sub.html.ini
@@ -1,4 +1,0 @@
-[script-html-via-cross-origin-blob-url.sub.html]
-  expected: ERROR
-  [script-html-via-cross-origin-blob-url]
-    expected: FAIL

--- a/tests/wpt/meta/workers/opaque-origin.html.ini
+++ b/tests/wpt/meta/workers/opaque-origin.html.ini
@@ -1,4 +1,4 @@
 [opaque-origin.html]
   expected: TIMEOUT
-  [Worker has an opaque origin.]
-    expected: FAIL
+  [Worker can access BroadcastChannel]
+    expected: TIMEOUT


### PR DESCRIPTION
Allow workers to load scripts from blob URLs

Blob URLs were failing with "Cross-origin response" because the fetch CORS check compared the request origin against the blob URL's parsed origin. For origins like file:// pages, each parse creates a new unique origin, so they never matched.

The fix was to treat blob: URLs like data: URLs in the fetch pipeline, as they bypass the CORS origin check and go straight to the blob protocol handler, which does its own origin validation against the stored entry.

Also I used the request's origin instead of the re-parsed blob URL origin in the blob handler, so the origin comparison works correctly for opaque origins.

I then tested with the testcase from the issue and the worker loads successfully from a blob URL.

Fixes: #43326