### PR TITLE
script: Pass `&mut JSContext` to Clipboard API's

### DIFF
--- a/components/script/dom/clipboard/clipboard.rs
+++ b/components/script/dom/clipboard/clipboard.rs
@@ -8,6 +8,7 @@ use std::str::FromStr;
 use data_url::mime::Mime;
 use dom_struct::dom_struct;
 use embedder_traits::EmbedderMsg;
+use js::context::JSContext;
 use js::realm::CurrentRealm;
 use js::rust::HandleValue as SafeHandleValue;
 use servo_constellation_traits::BlobImpl;
@@ -18,7 +19,7 @@ use crate::dom::bindings::codegen::Bindings::ClipboardBinding::{
 };
 use crate::dom::bindings::error::Error;
 use crate::dom::bindings::refcounted::TrustedPromise;
-use crate::dom::bindings::reflector::{DomGlobal, reflect_dom_object};
+use crate::dom::bindings::reflector::{DomGlobal, reflect_dom_object_with_cx};
 use crate::dom::bindings::root::DomRoot;
 use crate::dom::bindings::str::DOMString;
 use crate::dom::blob::Blob;
@@ -27,7 +28,7 @@ use crate::dom::globalscope::GlobalScope;
 use crate::dom::promise::Promise;
 use crate::dom::promisenativehandler::{Callback, PromiseNativeHandler};
 use crate::dom::window::Window;
-use crate::realms::{InRealm, enter_realm};
+use crate::realms::{InRealm, enter_auto_realm};
 use crate::routed_promise::{RoutedPromiseListener, callback_promise};
 use crate::script_runtime::CanGc;
 
@@ -87,19 +88,19 @@ impl Clipboard {
         }
     }
 
-    pub(crate) fn new(global: &GlobalScope, can_gc: CanGc) -> DomRoot<Clipboard> {
-        reflect_dom_object(Box::new(Clipboard::new_inherited()), global, can_gc)
+    pub(crate) fn new(cx: &mut JSContext, global: &GlobalScope) -> DomRoot<Clipboard> {
+        reflect_dom_object_with_cx(Box::new(Clipboard::new_inherited()), global, cx)
     }
 }
 
 impl ClipboardMethods<crate::DomTypeHolder> for Clipboard {
     /// <https://w3c.github.io/clipboard-apis/#dom-clipboard-readtext>
-    fn ReadText(&self, can_gc: CanGc) -> Rc<Promise> {
+    fn ReadText(&self, realm: &mut CurrentRealm) -> Rc<Promise> {
         // Step 1 Let realm be this's relevant realm.
         let global = self.global();
 
         // Step 2 Let p be a new promise in realm.
-        let p = Promise::new(&global, can_gc);
+        let p = Promise::new_in_realm(realm);
 
         // Step 3 Run the following steps in parallel:
 
@@ -122,10 +123,11 @@ impl ClipboardMethods<crate::DomTypeHolder> for Clipboard {
     }
 
     /// <https://w3c.github.io/clipboard-apis/#dom-clipboard-writetext>
-    fn WriteText(&self, data: DOMString, can_gc: CanGc) -> Rc<Promise> {
+    fn WriteText(&self, realm: &mut CurrentRealm, data: DOMString) -> Rc<Promise> {
         // Step 1 Let realm be this's relevant realm.
+        let global = self.global();
         // Step 2 Let p be a new promise in realm.
-        let p = Promise::new(&self.global(), can_gc);
+        let p = Promise::new_in_realm(realm);
 
         // Step 3 Run the following steps in parallel:
 
@@ -141,8 +143,8 @@ impl ClipboardMethods<crate::DomTypeHolder> for Clipboard {
 
         // Step 3.3 Queue a global task on the clipboard task source,
         // given realm’s global object, to perform the below steps:
-        self.global().task_manager().clipboard_task_source().queue(
-            task!(write_to_system_clipboard: move || {
+        global.task_manager().clipboard_task_source().queue(
+            task!(write_to_system_clipboard: move |cx| {
                 let promise = trusted_promise.root();
                 let global = promise.global();
 
@@ -154,7 +156,7 @@ impl ClipboardMethods<crate::DomTypeHolder> for Clipboard {
                 let text_blob = Blob::new(
                     &global,
                     BlobImpl::new_from_bytes(bytes, "text/plain;charset=utf-8".into()),
-                    CanGc::note(),
+                    CanGc::from_cx(cx),
                 );
 
                 // Step 3.3.3 Add textBlob to itemList.
@@ -167,7 +169,7 @@ impl ClipboardMethods<crate::DomTypeHolder> for Clipboard {
                 write_blobs_and_option_to_the_clipboard(global.as_window(), item_list, option);
 
                 // Step 3.3.6 Resolve p.
-                promise.resolve_native(&(), CanGc::note());
+                promise.resolve_native(&(), CanGc::from_cx(cx));
             }),
         );
 
@@ -229,8 +231,10 @@ impl RoutedPromiseListener<Result<String, String>> for Clipboard {
             Some(rejection_handler),
             CanGc::from_cx(cx),
         );
-        let realm = enter_realm(&*global);
-        let comp = InRealm::Entered(&realm);
+        let mut realm = enter_auto_realm(cx, &*global);
+        let cx = &mut realm.current_realm();
+        let in_realm_proof = cx.into();
+        let comp = InRealm::Already(&in_realm_proof);
         representation
             .data
             .append_native_handler(&handler, comp, CanGc::from_cx(cx));

--- a/components/script/dom/clipboard/clipboarditem.rs
+++ b/components/script/dom/clipboard/clipboarditem.rs
@@ -8,6 +8,7 @@ use std::str::FromStr;
 
 use data_url::mime::Mime;
 use dom_struct::dom_struct;
+use js::context::JSContext;
 use js::realm::CurrentRealm;
 use js::rust::{HandleObject, HandleValue as SafeHandleValue, MutableHandleValue};
 use script_bindings::record::Record;
@@ -22,15 +23,15 @@ use crate::dom::bindings::conversions::{
 };
 use crate::dom::bindings::error::{Error, Fallible};
 use crate::dom::bindings::frozenarray::CachedFrozenArray;
-use crate::dom::bindings::reflector::{DomGlobal, Reflector, reflect_dom_object_with_proto};
+use crate::dom::bindings::reflector::{DomGlobal, Reflector, reflect_dom_object_with_proto_and_cx};
 use crate::dom::bindings::root::DomRoot;
 use crate::dom::bindings::str::DOMString;
 use crate::dom::blob::Blob;
 use crate::dom::promise::Promise;
 use crate::dom::promisenativehandler::{Callback, PromiseNativeHandler};
 use crate::dom::window::Window;
-use crate::realms::{InRealm, enter_realm};
-use crate::script_runtime::{CanGc, JSContext as SafeJSContext};
+use crate::realms::InRealm;
+use crate::script_runtime::CanGc;
 
 /// The fulfillment handler for the reacting to representationDataPromise part of
 /// <https://w3c.github.io/clipboard-apis/#dom-clipboarditem-gettype>.
@@ -89,9 +90,9 @@ struct RepresentationDataPromiseRejectionHandler {
 impl Callback for RepresentationDataPromiseRejectionHandler {
     /// Substeps of 8.1.2.2 If representationDataPromise was rejected, then:
     fn callback(&self, cx: &mut CurrentRealm, _v: SafeHandleValue) {
-        let can_gc = CanGc::from_cx(cx);
         // 1. Reject p with "NotFoundError" DOMException in realm.
-        self.promise.reject_error(Error::NotFound(None), can_gc);
+        self.promise
+            .reject_error(Error::NotFound(None), CanGc::from_cx(cx));
     }
 }
 
@@ -128,12 +129,16 @@ impl ClipboardItem {
         }
     }
 
-    fn new(window: &Window, proto: Option<HandleObject>, can_gc: CanGc) -> DomRoot<ClipboardItem> {
-        reflect_dom_object_with_proto(
+    fn new(
+        cx: &mut JSContext,
+        window: &Window,
+        proto: Option<HandleObject>,
+    ) -> DomRoot<ClipboardItem> {
+        reflect_dom_object_with_proto_and_cx(
             Box::new(ClipboardItem::new_inherited()),
             window,
             proto,
-            can_gc,
+            cx,
         )
     }
 }
@@ -141,9 +146,9 @@ impl ClipboardItem {
 impl ClipboardItemMethods<crate::DomTypeHolder> for ClipboardItem {
     /// <https://w3c.github.io/clipboard-apis/#dom-clipboarditem-clipboarditem>
     fn Constructor(
+        cx: &mut JSContext,
         global: &Window,
         proto: Option<HandleObject>,
-        can_gc: CanGc,
         items: Record<DOMString, Rc<Promise>>,
         options: &ClipboardItemOptions,
     ) -> Fallible<DomRoot<ClipboardItem>> {
@@ -156,7 +161,7 @@ impl ClipboardItemMethods<crate::DomTypeHolder> for ClipboardItem {
         // NOTE: This is done inside bindings
 
         // Step 3 Set this's clipboard item to a new clipboard item.
-        let clipboard_item = ClipboardItem::new(global, proto, can_gc);
+        let clipboard_item = ClipboardItem::new(cx, global, proto);
 
         // Step 4 Set this's clipboard item's presentation style to options["presentationStyle"].
         *clipboard_item.presentation_style.borrow_mut() = options.presentationStyle;
@@ -220,7 +225,7 @@ impl ClipboardItemMethods<crate::DomTypeHolder> for ClipboardItem {
     }
 
     /// <https://w3c.github.io/clipboard-apis/#dom-clipboarditem-types>
-    fn Types(&self, cx: SafeJSContext, can_gc: CanGc, retval: MutableHandleValue) {
+    fn Types(&self, cx: &mut JSContext, retval: MutableHandleValue) {
         self.frozen_types.get_or_init(
             || {
                 // Step 5 Let types be a list of DOMString.
@@ -245,14 +250,14 @@ impl ClipboardItemMethods<crate::DomTypeHolder> for ClipboardItem {
                     });
                 types
             },
-            cx,
+            cx.into(),
             retval,
-            can_gc,
+            CanGc::from_cx(cx),
         );
     }
 
     /// <https://w3c.github.io/clipboard-apis/#dom-clipboarditem-gettype>
-    fn GetType(&self, type_: DOMString, can_gc: CanGc) -> Fallible<Rc<Promise>> {
+    fn GetType(&self, realm: &mut CurrentRealm, type_: DOMString) -> Fallible<Rc<Promise>> {
         // Step 1 Let realm be this’s relevant realm.
         let global = self.global();
 
@@ -276,7 +281,7 @@ impl ClipboardItemMethods<crate::DomTypeHolder> for ClipboardItem {
         let item_type_list = self.representations.borrow();
 
         // Step 7 Let p be a new promise in realm.
-        let p = Promise::new(&global, can_gc);
+        let p = Promise::new_in_realm(realm);
 
         // Step 8 For each representation in itemTypeList
         for representation in item_type_list.iter() {
@@ -292,15 +297,20 @@ impl ClipboardItemMethods<crate::DomTypeHolder> for ClipboardItem {
                 });
                 let rejection_handler =
                     Box::new(RepresentationDataPromiseRejectionHandler { promise: p.clone() });
+                let in_realm_proof = realm.into();
+                let comp = InRealm::Already(&in_realm_proof);
                 let handler = PromiseNativeHandler::new(
                     &global,
                     Some(fulfillment_handler),
                     Some(rejection_handler),
-                    can_gc,
+                    CanGc::from_cx(realm),
                 );
-                let realm = enter_realm(&*global);
-                let comp = InRealm::Entered(&realm);
-                representation_data_promise.append_native_handler(&handler, comp, can_gc);
+
+                representation_data_promise.append_native_handler(
+                    &handler,
+                    comp,
+                    CanGc::from_cx(realm),
+                );
 
                 // Step 8.1.3 Return p.
                 return Ok(p);
@@ -308,7 +318,7 @@ impl ClipboardItemMethods<crate::DomTypeHolder> for ClipboardItem {
         }
 
         // Step 9 Reject p with "NotFoundError" DOMException in realm.
-        p.reject_error(Error::NotFound(None), can_gc);
+        p.reject_error(Error::NotFound(None), CanGc::from_cx(realm));
 
         // Step 10 Return p.
         Ok(p)

--- a/components/script/dom/navigator.rs
+++ b/components/script/dom/navigator.rs
@@ -468,9 +468,9 @@ impl NavigatorMethods<crate::DomTypeHolder> for Navigator {
     }
 
     /// <https://w3c.github.io/clipboard-apis/#h-navigator-clipboard>
-    fn Clipboard(&self) -> DomRoot<Clipboard> {
+    fn Clipboard(&self, cx: &mut js::context::JSContext) -> DomRoot<Clipboard> {
         self.clipboard
-            .or_init(|| Clipboard::new(&self.global(), CanGc::note()))
+            .or_init(|| Clipboard::new(cx, &self.global()))
     }
 
     /// <https://w3c.github.io/beacon/#sec-processing-model>

--- a/components/script_bindings/codegen/Bindings.conf
+++ b/components/script_bindings/codegen/Bindings.conf
@@ -103,11 +103,12 @@ DOMInterfaces = {
 },
 
 'Clipboard': {
-    'canGc': ['ReadText', 'WriteText']
+    'realm': ['ReadText', 'WriteText']
 },
 
 'ClipboardItem': {
-    'canGc': ['GetType', 'Types']
+    'cx': ['Constructor', 'Types'],
+    'realm': ['GetType']
 },
 
 'Comment': {
@@ -681,6 +682,7 @@ DOMInterfaces = {
 'Navigator': {
     'inRealms': ['GetVRDisplays'],
     'canGc': ['Languages', 'SendBeacon', 'UserActivation'],
+    'cx': ['Clipboard']
 },
 
 'Node': {


### PR DESCRIPTION
Part of #40600
Follow-up to #43943

Testing: It compiles