### PR TITLE
layout: Rename confusing ```SequentialLayoutState::collapse_margins```

### DIFF
--- a/components/layout/flow/float.rs
+++ b/components/layout/flow/float.rs
@@ -991,12 +991,12 @@ impl SequentialLayoutState {
         self.bfc_relative_block_position + self.current_margin.solve()
     }
 
-    /// Collapses margins, moving the block position down by the collapsed value of `current_margin`
+    /// Commits margins, moving the block position down by the collapsed value of `current_margin`
     /// and resetting `current_margin` to zero.
     ///
     /// Call this method before laying out children when it is known that the start margin of the
     /// current fragment can't collapse with the margins of any of its children.
-    pub(crate) fn collapse_margins(&mut self) {
+    pub(crate) fn commit_margin(&mut self) {
         self.advance_block_position(self.current_margin.solve());
         self.current_margin = CollapsedMargin::zero();
     }

--- a/components/layout/flow/inline/mod.rs
+++ b/components/layout/flow/inline/mod.rs
@@ -1087,7 +1087,7 @@ impl InlineFormattingContextLayout<'_> {
             let mut block_end_position = block_start_position + resolved_block_advance;
             if let Some(sequential_layout_state) = self.sequential_layout_state.as_mut() {
                 if !is_phantom_line {
-                    sequential_layout_state.collapse_margins();
+                    sequential_layout_state.commit_margin();
                 }
 
                 // This amount includes both the block size of the line and any extra space

--- a/components/layout/flow/mod.rs
+++ b/components/layout/flow/mod.rs
@@ -1052,11 +1052,11 @@ fn layout_in_flow_non_replaced_block_level_same_formatting_context(
             // Introduce clearance if necessary.
             clearance = sequential_layout_state.calculate_clearance(clear, &block_start_margin);
             if clearance.is_some() {
-                sequential_layout_state.collapse_margins();
+                sequential_layout_state.commit_margin();
             }
             sequential_layout_state.adjoin_assign(&block_start_margin);
             if !start_margin_can_collapse_with_children {
-                sequential_layout_state.collapse_margins();
+                sequential_layout_state.commit_margin();
             }
 
             // NB: This will be a no-op if we're collapsing margins with our children since that
@@ -1200,7 +1200,7 @@ fn layout_in_flow_non_replaced_block_level_same_formatting_context(
         );
 
         if !end_margin_can_collapse_with_children {
-            sequential_layout_state.collapse_margins();
+            sequential_layout_state.commit_margin();
         }
         sequential_layout_state.adjoin_assign(&CollapsedMargin::new(margin.block_end));
     }
@@ -1666,12 +1666,12 @@ impl IndependentFormattingContext {
         // Clearance prevents margin collapse between this block and previous ones,
         // so in that case collapse margins before adjoining them below.
         if clearance.is_some() {
-            sequential_layout_state.collapse_margins();
+            sequential_layout_state.commit_margin();
         }
         sequential_layout_state.adjoin_assign(&collapsed_margin_block_start);
 
         // Margins can never collapse into independent formatting contexts.
-        sequential_layout_state.collapse_margins();
+        sequential_layout_state.commit_margin();
         sequential_layout_state.advance_block_position(
             pbm.padding_border_sums.block + content_size.block + clearance.unwrap_or_else(Au::zero),
         );


### PR DESCRIPTION
Renamed ```SequentialLayoutState::collapse_margins``` to ```commit_margin``` in ```float.rs```, ```mod.rs``` & ```inline/mod.rs```

Testing: No testing required - just renaming. Compiles successfully.
Fixes: #43941