### PR TITLE
script: Clear hover pseudo-class on the shadow-including ancestors

### DIFF
--- a/components/script/dom/document/document_event_handler.rs
+++ b/components/script/dom/document/document_event_handler.rs
@@ -619,7 +619,7 @@ impl DocumentEventHandler {
                 if !old_target_is_ancestor_of_new_target {
                     for element in old_target
                         .upcast::<Node>()
-                        .inclusive_ancestors(ShadowIncluding::No)
+                        .inclusive_ancestors(ShadowIncluding::Yes)
                         .filter_map(DomRoot::downcast::<Element>)
                     {
                         element.set_hover_state(false);

--- a/tests/wpt/tests/shadow-dom/nested-hover-pseudo-class-removal.html
+++ b/tests/wpt/tests/shadow-dom/nested-hover-pseudo-class-removal.html
@@ -1,0 +1,45 @@
+<!DOCTYPE html>
+<html class="reftest-wait">
+<meta charset="utf-8">
+<title>Shadow DOM: :hover pseudo-class should be removed from all ancestors when cursor moves away</title>
+<link rel="author" href="mailto:martin@abandonedwig.info">
+<link rel="help" href="https://drafts.csswg.org/selectors/#the-hover-pseudo">
+<link rel="help" href="https://github.com/servo/servo/issues/43863">
+<link rel="match" href="/css/reference/ref-filled-green-100px-square.xht">
+<script src="/common/reftest-wait.js"></script>
+<script src="/resources/testdriver.js"></script>
+<script src="/resources/testdriver-actions.js"></script>
+<script src="/resources/testdriver-vendor.js"></script>
+
+<style>
+    #host {
+        width: 100px;
+        height: 100px;
+        background: green;
+    }
+
+    #host:hover {
+        background:red;
+    }
+</style>
+
+<p>Test passes if there is a filled green square and <strong>no red</strong>.</p>
+<div id="host">
+    <template shadowrootmode="open">
+        <div style="width: 100px; height: 100px"></div>
+    </template>
+</div>
+
+<script>
+    window.onload = async () => {
+        let rectangle = host.getBoundingClientRect();
+        await new test_driver.Actions()
+          .pointerMove(rectangle.left + 5, rectangle.top + 5)
+              .send();
+        await new test_driver.Actions()
+          .pointerMove(rectangle.right + 100, rectangle.bottom + 100)
+              .send();
+        takeScreenshot();
+    }
+</script>
+</html>


### PR DESCRIPTION
This change makes it so that the `:hover` pseudo-class is cleared on shadow-including ancestors when a node is no longer hovered. This prevents `:hover` from being stuck on, as the pseudo-class was applied to shadow-including ancestors, but not removed in the same way.

Fixes: #43863
Testing: This change adds a new WPT test.