### PR TITLE
devtools: Fix `worker` targets in debugger tab

### DIFF
--- a/components/devtools/actor.rs
+++ b/components/devtools/actor.rs
@@ -160,7 +160,15 @@ impl ActorRegistry {
     /// create new names without registering an actor.
     pub fn new_name<T: Actor>(&self) -> String {
         let suffix = self.next.fetch_add(1, Ordering::Relaxed);
-        format!("{}{}", Self::base_name::<T>(), suffix)
+        let base = Self::base_name::<T>();
+
+        // Firefox DevTools client requires "/workerTarget" in actor name to recognize workers
+        // <https://searchfox.org/firefox-main/source/devtools/client/fronts/watcher.js#65>
+        if base.contains("WorkerTarget") {
+            format!("/workerTarget{}", suffix)
+        } else {
+            format!("{}{}", base, suffix)
+        }
     }
 
     /// Add an actor to the registry of known actors that can receive messages.

--- a/components/devtools/actors/console.rs
+++ b/components/devtools/actors/console.rs
@@ -24,7 +24,7 @@ use uuid::Uuid;
 use crate::actor::{Actor, ActorError, ActorRegistry};
 use crate::actors::browsing_context::BrowsingContextActor;
 use crate::actors::object::{ObjectActor, ObjectPropertyDescriptor, debugger_value_to_json};
-use crate::actors::worker::WorkerActor;
+use crate::actors::worker::WorkerTargetActor;
 use crate::protocol::{ClientRequest, DevtoolsConnection, JsonPacketStream};
 use crate::resource::{ResourceArrayType, ResourceAvailable};
 use crate::{EmptyReplyMsg, StreamId, UniqueId};
@@ -287,7 +287,7 @@ impl ConsoleActor {
                 .find::<BrowsingContextActor>(browsing_context_name)
                 .script_chan(),
             Root::DedicatedWorker(worker_name) => registry
-                .find::<WorkerActor>(worker_name)
+                .find::<WorkerTargetActor>(worker_name)
                 .script_sender
                 .clone(),
         }
@@ -301,7 +301,7 @@ impl ConsoleActor {
                     .pipeline_id(),
             ),
             Root::DedicatedWorker(worker_name) => {
-                UniqueId::Worker(registry.find::<WorkerActor>(worker_name).worker_id)
+                UniqueId::Worker(registry.find::<WorkerTargetActor>(worker_name).worker_id)
             },
         }
     }

--- a/components/devtools/actors/root.rs
+++ b/components/devtools/actors/root.rs
@@ -22,7 +22,7 @@ use crate::actors::performance::PerformanceActor;
 use crate::actors::preference::PreferenceActor;
 use crate::actors::process::{ProcessActor, ProcessActorMsg};
 use crate::actors::tab::{TabDescriptorActor, TabDescriptorActorMsg};
-use crate::actors::worker::{WorkerActor, WorkerActorMsg};
+use crate::actors::worker::{WorkerTargetActor, WorkerTargetActorMsg};
 use crate::protocol::{ActorDescription, ClientRequest};
 use crate::{EmptyReplyMsg, StreamId};
 
@@ -123,7 +123,7 @@ pub(crate) struct ProtocolDescriptionReply {
 #[derive(Serialize)]
 struct ListWorkersReply {
     from: String,
-    workers: Vec<WorkerActorMsg>,
+    workers: Vec<WorkerTargetActorMsg>,
 }
 
 #[derive(Serialize)]
@@ -248,7 +248,7 @@ impl Actor for RootActor {
                     .borrow()
                     .iter()
                     .map(|worker_name| {
-                        let worker_actor = registry.find::<WorkerActor>(worker_name);
+                        let worker_actor = registry.find::<WorkerTargetActor>(worker_name);
                         let url = worker_actor.url.to_string();
                         // Find correct scope url in the service worker
                         let scope = url.clone();
@@ -310,7 +310,7 @@ impl Actor for RootActor {
                         .workers
                         .borrow()
                         .iter()
-                        .map(|worker_name| registry.encode::<WorkerActor, _>(worker_name))
+                        .map(|worker_name| registry.encode::<WorkerTargetActor, _>(worker_name))
                         .collect(),
                 };
                 request.reply_final(&reply)?

--- a/components/devtools/actors/watcher.rs
+++ b/components/devtools/actors/watcher.rs
@@ -23,7 +23,7 @@ use servo_url::ServoUrl;
 use self::network_parent::NetworkParentActor;
 use super::breakpoint::BreakpointListActor;
 use super::thread::ThreadActor;
-use super::worker::WorkerActorMsg;
+use super::worker::WorkerTargetActorMsg;
 use crate::actor::{Actor, ActorEncode, ActorError, ActorRegistry};
 use crate::actors::browsing_context::{BrowsingContextActor, BrowsingContextActorMsg};
 use crate::actors::console::ConsoleActor;
@@ -34,7 +34,7 @@ use crate::actors::watcher::target_configuration::{
 use crate::actors::watcher::thread_configuration::ThreadConfigurationActor;
 use crate::protocol::{ClientRequest, DevtoolsConnection, JsonPacketStream};
 use crate::resource::{ResourceArrayType, ResourceAvailable};
-use crate::{ActorMsg, EmptyReplyMsg, IdMap, StreamId, WorkerActor};
+use crate::{ActorMsg, EmptyReplyMsg, IdMap, StreamId, WorkerTargetActor};
 
 pub mod network_parent;
 pub mod target_configuration;
@@ -110,7 +110,7 @@ pub enum SessionContextType {
 #[serde(untagged)]
 enum TargetActorMsg {
     BrowsingContext(BrowsingContextActorMsg),
-    Worker(WorkerActorMsg),
+    Worker(WorkerTargetActorMsg),
 }
 
 #[derive(Serialize)]
@@ -266,7 +266,7 @@ impl Actor for WatcherActor {
                             from: self.name(),
                             type_: "target-available-form".into(),
                             target: TargetActorMsg::Worker(
-                                registry.encode::<WorkerActor, _>(worker_name),
+                                registry.encode::<WorkerTargetActor, _>(worker_name),
                             ),
                         };
                         let _ = request.write_json_packet(&worker_msg);
@@ -277,7 +277,7 @@ impl Actor for WatcherActor {
                             from: self.name(),
                             type_: "target-available-form".into(),
                             target: TargetActorMsg::Worker(
-                                registry.encode::<WorkerActor, _>(worker_name),
+                                registry.encode::<WorkerTargetActor, _>(worker_name),
                             ),
                         };
                         let _ = request.write_json_packet(&worker_msg);
@@ -341,7 +341,7 @@ impl Actor for WatcherActor {
                             );
 
                             for worker_name in &*root_actor.workers.borrow() {
-                                let worker_actor = registry.find::<WorkerActor>(worker_name);
+                                let worker_actor = registry.find::<WorkerTargetActor>(worker_name);
                                 let thread_actor =
                                     registry.find::<ThreadActor>(&worker_actor.thread_name);
 
@@ -365,7 +365,7 @@ impl Actor for WatcherActor {
                             );
 
                             for worker_name in &*root_actor.workers.borrow() {
-                                let worker_actor = registry.find::<WorkerActor>(worker_name);
+                                let worker_actor = registry.find::<WorkerTargetActor>(worker_name);
                                 let console_actor =
                                     registry.find::<ConsoleActor>(&worker_actor.console_name);
 

--- a/components/devtools/actors/worker.rs
+++ b/components/devtools/actors/worker.rs
@@ -27,7 +27,7 @@ pub enum WorkerType {
 }
 
 #[derive(MallocSizeOf)]
-pub(crate) struct WorkerActor {
+pub(crate) struct WorkerTargetActor {
     pub name: String,
     pub console_name: String,
     pub thread_name: String,
@@ -38,13 +38,13 @@ pub(crate) struct WorkerActor {
     pub streams: AtomicRefCell<FxHashSet<StreamId>>,
 }
 
-impl ResourceAvailable for WorkerActor {
+impl ResourceAvailable for WorkerTargetActor {
     fn actor_name(&self) -> String {
         self.name.clone()
     }
 }
 
-impl WorkerActor {
+impl WorkerTargetActor {
     pub fn register(
         registry: &ActorRegistry,
         console_name: String,
@@ -70,7 +70,7 @@ impl WorkerActor {
     }
 }
 
-impl Actor for WorkerActor {
+impl Actor for WorkerTargetActor {
     fn name(&self) -> String {
         self.name.clone()
     }
@@ -182,7 +182,7 @@ struct WorkerTraits {
 
 #[derive(Serialize)]
 #[serde(rename_all = "camelCase")]
-pub(crate) struct WorkerActorMsg {
+pub(crate) struct WorkerTargetActorMsg {
     actor: String,
     console_actor: String,
     thread_actor: String,
@@ -195,9 +195,9 @@ pub(crate) struct WorkerActorMsg {
     target_type: String,
 }
 
-impl ActorEncode<WorkerActorMsg> for WorkerActor {
-    fn encode(&self, _: &ActorRegistry) -> WorkerActorMsg {
-        WorkerActorMsg {
+impl ActorEncode<WorkerTargetActorMsg> for WorkerTargetActor {
+    fn encode(&self, _: &ActorRegistry) -> WorkerTargetActorMsg {
+        WorkerTargetActorMsg {
             actor: self.name(),
             console_actor: self.console_name.clone(),
             thread_actor: self.thread_name.clone(),

--- a/components/devtools/lib.rs
+++ b/components/devtools/lib.rs
@@ -53,7 +53,7 @@ use crate::actors::root::RootActor;
 use crate::actors::source::SourceActor;
 use crate::actors::thread::{ThreadActor, ThreadInterruptedReply};
 use crate::actors::watcher::WatcherActor;
-use crate::actors::worker::{WorkerActor, WorkerType};
+use crate::actors::worker::{WorkerTargetActor, WorkerType};
 use crate::id::IdMap;
 use crate::network_handler::handle_network_event;
 use crate::protocol::{DevtoolsConnection, JsonPacketStream};
@@ -482,7 +482,7 @@ impl DevtoolsInstance {
             } else {
                 WorkerType::Dedicated
             };
-            let worker_name = WorkerActor::register(
+            let worker_name = WorkerTargetActor::register(
                 &self.registry,
                 console_name.clone(),
                 thread_name,
@@ -620,7 +620,7 @@ impl DevtoolsInstance {
             let worker_name = self.actor_workers.get(&worker_id)?;
             Some(
                 self.registry
-                    .find::<WorkerActor>(worker_name)
+                    .find::<WorkerTargetActor>(worker_name)
                     .console_name
                     .clone(),
             )
@@ -716,14 +716,14 @@ impl DevtoolsInstance {
 
             let thread_actor_name = self
                 .registry
-                .find::<WorkerActor>(worker_name)
+                .find::<WorkerTargetActor>(worker_name)
                 .thread_name
                 .clone();
             let thread_actor = self.registry.find::<ThreadActor>(&thread_actor_name);
 
             thread_actor.source_manager.add_source(&source_actor);
 
-            let worker_actor = self.registry.find::<WorkerActor>(worker_name);
+            let worker_actor = self.registry.find::<WorkerTargetActor>(worker_name);
 
             for stream in self.connections.lock().unwrap().values_mut() {
                 worker_actor.resource_array(


### PR DESCRIPTION
Firefox DevTools client determines target type by checking if the actor contains specific substring. For workers it [requires](https://searchfox.org/firefox-main/source/devtools/client/fronts/watcher.js#65) `/workerTarget` in the actor name to create a `WorkerTargetFront`.

Testing: Manual testing
Fixes: #36727 and #37012


<img width="1084" height="558" alt="Screenshot 2026-04-06 at 21 47 59" src="https://github.com/user-attachments/assets/207a8368-0f8a-48a6-ab7e-a5ee3750381f" />
