### PR TITLE
canvas: Make ImageBitmapRenderingContext render to the canvas

### DIFF
--- a/components/script/dom/canvas/canvas_context.rs
+++ b/components/script/dom/canvas/canvas_context.rs
@@ -182,9 +182,7 @@ impl RenderingContext {
                 unreachable!("Should never set an `ImageKey` on a Placeholder")
             },
             RenderingContext::Context2d(context) => context.set_image_key(image_key),
-            RenderingContext::BitmapRenderer(_) => {
-                unreachable!("Should never set an `ImageKey` on a ImageBitmapRenderingContext")
-            },
+            RenderingContext::BitmapRenderer(context) => context.set_image_key(image_key),
             RenderingContext::WebGL(context) => context.set_image_key(image_key),
             RenderingContext::WebGL2(context) => context.set_image_key(image_key),
             #[cfg(feature = "webgpu")]

--- a/components/script/dom/canvas/imagebitmaprenderingcontext.rs
+++ b/components/script/dom/canvas/imagebitmaprenderingcontext.rs
@@ -6,7 +6,11 @@ use std::cell::Cell;
 
 use dom_struct::dom_struct;
 use euclid::default::Size2D;
+use paint_api::SerializableImageData;
 use pixels::Snapshot;
+use servo_base::Epoch;
+use webrender_api::units::DeviceIntSize;
+use webrender_api::{ImageDescriptor, ImageFormat, ImageKey};
 
 use crate::canvas_context::{CanvasContext, CanvasHelpers, HTMLCanvasElementOrOffscreenCanvas};
 use crate::dom::bindings::cell::DomRefCell;
@@ -17,7 +21,9 @@ use crate::dom::bindings::error::{Error, Fallible};
 use crate::dom::bindings::reflector::{Reflector, reflect_dom_object};
 use crate::dom::bindings::root::DomRoot;
 use crate::dom::globalscope::GlobalScope;
+use crate::dom::html::htmlcanvaselement::HTMLCanvasElement;
 use crate::dom::imagebitmap::ImageBitmap;
+use crate::dom::node::node::NodeTraits;
 use crate::script_runtime::CanGc;
 
 /// <https://html.spec.whatwg.org/multipage/#imagebitmaprenderingcontext>
@@ -32,6 +38,11 @@ pub(crate) struct ImageBitmapRenderingContext {
     #[no_trace]
     bitmap: DomRefCell<Option<Snapshot>>,
     origin_clean: Cell<bool>,
+    #[no_trace]
+    image_key: Cell<Option<ImageKey>>,
+    /// Whether the image has been added to WebRender (first render uses add_image,
+    /// subsequent renders use update_image).
+    image_added: Cell<bool>,
 }
 
 impl ImageBitmapRenderingContext {
@@ -43,6 +54,8 @@ impl ImageBitmapRenderingContext {
             canvas,
             bitmap: DomRefCell::new(None),
             origin_clean: Cell::new(true),
+            image_key: Cell::new(None),
+            image_added: Cell::new(false),
         }
     }
 
@@ -58,6 +71,49 @@ impl ImageBitmapRenderingContext {
             global,
             can_gc,
         )
+    }
+
+    pub(crate) fn set_image_key(&self, image_key: ImageKey) {
+        self.image_key.set(Some(image_key));
+    }
+
+    pub(crate) fn update_rendering(&self, epoch: Epoch) -> bool {
+        let Some(image_key) = self.image_key.get() else {
+            return false;
+        };
+
+        let Some(snapshot) = self.bitmap.borrow().as_ref().cloned() else {
+            return false;
+        };
+
+        let size = snapshot.size();
+        let format = match snapshot.format() {
+            pixels::SnapshotPixelFormat::RGBA => ImageFormat::RGBA8,
+            pixels::SnapshotPixelFormat::BGRA => ImageFormat::BGRA8,
+        };
+        let shared = snapshot.to_shared();
+        let descriptor = ImageDescriptor {
+            format,
+            size: DeviceIntSize::new(size.width as i32, size.height as i32),
+            stride: None,
+            offset: 0,
+            flags: webrender_api::ImageDescriptorFlags::empty(),
+        };
+        let data = SerializableImageData::Raw(shared.shared_memory());
+
+        // Here we get the paint API from the canvas element's window.
+        if let HTMLCanvasElementOrOffscreenCanvas::HTMLCanvasElement(ref canvas) = self.canvas {
+            let canvas: &HTMLCanvasElement = canvas;
+            let doc = canvas.owner_document();
+            let paint_api = doc.window().paint_api();
+            if self.image_added.get() {
+                paint_api.update_image(image_key, descriptor, data, Some(epoch));
+            } else {
+                paint_api.add_image(image_key, descriptor, data, false);
+                self.image_added.set(true);
+            }
+        }
+        false
     }
 
     /// <https://html.spec.whatwg.org/multipage/#set-an-imagebitmaprenderingcontext's-output-bitmap>
@@ -147,7 +203,9 @@ impl CanvasContext for ImageBitmapRenderingContext {
             .map_or_else(|| self.canvas.size(), |bitmap| bitmap.size())
     }
 
-    fn mark_as_dirty(&self) {}
+    fn mark_as_dirty(&self) {
+        self.canvas.mark_as_dirty();
+    }
 }
 
 impl ImageBitmapRenderingContextMethods<crate::DomTypeHolder> for ImageBitmapRenderingContext {
@@ -164,6 +222,7 @@ impl ImageBitmapRenderingContextMethods<crate::DomTypeHolder> for ImageBitmapRen
             // bitmapContext as the context argument and no bitmap argument,
             // then return.
             self.set_bitmap(None);
+            self.mark_as_dirty();
 
             return Ok(());
         };
@@ -180,6 +239,7 @@ impl ImageBitmapRenderingContextMethods<crate::DomTypeHolder> for ImageBitmapRen
         // bitmapContext, and the bitmap argument referring to bitmap's
         // underlying bitmap data.
         self.set_bitmap(Some(image_bitmap));
+        self.mark_as_dirty();
 
         // Step 5. Set the value of bitmap's [[Detached]] internal slot
         // to true.

--- a/components/script/dom/html/htmlcanvaselement.rs
+++ b/components/script/dom/html/htmlcanvaselement.rs
@@ -203,7 +203,7 @@ impl HTMLCanvasElement {
         let image_key = match rendering_context {
             RenderingContext::Placeholder(..) => None,
             RenderingContext::Context2d(..) => get_image_key(),
-            RenderingContext::BitmapRenderer(_) => None,
+            RenderingContext::BitmapRenderer(..) => get_image_key(),
             RenderingContext::WebGL(..) => get_image_key(),
             RenderingContext::WebGL2(..) => get_image_key(),
             #[cfg(feature = "webgpu")]
@@ -408,16 +408,20 @@ impl HTMLCanvasElement {
     pub(crate) fn update_rendering(&self, epoch: Epoch) -> Option<ImageKey> {
         let context = self.context()?;
         let image_key = self.image_key.get()?;
-        match &*context {
+        let pending = match &*context {
             RenderingContext::Placeholder(..) => false,
             RenderingContext::Context2d(context) => context.update_rendering(epoch),
-            RenderingContext::BitmapRenderer(..) => false,
+            RenderingContext::BitmapRenderer(context) => context.update_rendering(epoch),
             RenderingContext::WebGL(context) => context.update_rendering(epoch),
             RenderingContext::WebGL2(context) => context.base_context().update_rendering(epoch),
             #[cfg(feature = "webgpu")]
             RenderingContext::WebGPU(context) => context.update_rendering(epoch),
+        };
+
+        if pending {
+            return Some(image_key);
         }
-        .then_some(image_key)
+        None
     }
 }
 

--- a/tests/wpt/meta/html/canvas/element/manual/imagebitmap/imageBitmapRendering-transferFromImageBitmap-flipped.html.ini
+++ b/tests/wpt/meta/html/canvas/element/manual/imagebitmap/imageBitmapRendering-transferFromImageBitmap-flipped.html.ini
@@ -1,2 +1,0 @@
-[imageBitmapRendering-transferFromImageBitmap-flipped.html]
-  expected: FAIL

--- a/tests/wpt/meta/html/canvas/element/manual/imagebitmap/imageBitmapRendering-transferFromImageBitmap.html.ini
+++ b/tests/wpt/meta/html/canvas/element/manual/imagebitmap/imageBitmapRendering-transferFromImageBitmap.html.ini
@@ -1,2 +1,0 @@
-[imageBitmapRendering-transferFromImageBitmap.html]
-  expected: FAIL

--- a/tests/wpt/meta/html/canvas/offscreen/text/canvas.2d.fontStretch.extra-expanded.html.ini
+++ b/tests/wpt/meta/html/canvas/offscreen/text/canvas.2d.fontStretch.extra-expanded.html.ini
@@ -1,2 +1,2 @@
 [canvas.2d.fontStretch.extra-expanded.html]
-  expected: FAIL
+  expected: [TIMEOUT, FAIL]


### PR DESCRIPTION
I noticed that the transferFromImageBitmap() was running without errors but the canvas stayed blank and this was becacuse of two issues:

The mark_as_dirty was empty meaning the canvas never knew it needed to repaint
The BitmapRenderer context had no rendering pipeline as such no ImageKey was allocated and update_rendering always returned false, so the way I fixed it is by

1. Implemented mark_as_dirty to call self.canvas.mark_as_dirty()
2. Allocated an ImageKey for BitmapRenderer contexts
3.Implemented set_image_key and update_rendering that sends the bitmap's pixel data to WebRender via the paint API
4, Calling mark_as_dirty after set_bitmap in TransferFromImageBitmap

Now the reason we are setting an ImageKey on the ImageBitmaRenderingContext is because it needs one to render to the screen and without it the canvas was always blank

Also I noticed that for some reasons I don't understand yet, the createImageBitmap hangs or is slow to render but after loading servo on an open tab, if I then go ahead and open another tab and paste the file link there, the previous tab which had the bitmap image now renders properly 

Fixes: #43565

<img width="383" height="238" alt="Screenshot from 2026-04-06 13-44-28" src="https://github.com/user-attachments/assets/4c5096ba-ee84-4e7a-a3c6-673cc12276c4" />
<img width="389" height="292" alt="Screenshot from 2026-04-06 15-38-55" src="https://github.com/user-attachments/assets/43b45e60-61d8-48de-b53e-6da5ab988768" />
