### PR TITLE
script/net: Make URL List closer to spec

### DIFF
--- a/components/net/http_loader.rs
+++ b/components/net/http_loader.rs
@@ -2481,7 +2481,13 @@ async fn cors_preflight_fetch(
         },
         RequestPolicyContainer::PolicyContainer(policy_container) => policy_container.clone(),
     })
-    .url_list(request.url_list.clone())
+    .url_list(
+        request
+            .url_list
+            .iter()
+            .map(|claimed_url| claimed_url.url())
+            .collect(),
+    )
     .build();
 
     // Step 2. Append (`Accept`, `*/*`) to preflight’s header list.

--- a/components/net/http_loader.rs
+++ b/components/net/http_loader.rs
@@ -2481,6 +2481,7 @@ async fn cors_preflight_fetch(
         },
         RequestPolicyContainer::PolicyContainer(policy_container) => policy_container.clone(),
     })
+    .url_list(request.url_list.clone())
     .build();
 
     // Step 2. Append (`Accept`, `*/*`) to preflight’s header list.

--- a/components/script/dom/response.rs
+++ b/components/script/dom/response.rs
@@ -54,6 +54,7 @@ pub(crate) struct Response {
     fetch_body_stream: MutNullableDom<ReadableStream>,
     #[ignore_malloc_size_of = "StreamConsumer"]
     stream_consumer: DomRefCell<Option<StreamConsumer>>,
+    /// FIXME: This should be removed.
     redirected: Cell<bool>,
     is_body_empty: Cell<bool>,
 }
@@ -289,6 +290,11 @@ impl ResponseMethods<crate::DomTypeHolder> for Response {
     }
 
     /// <https://fetch.spec.whatwg.org/#dom-response-redirected>
+    /// TODO: The redirected getter steps are to return true if
+    /// this’s response’s URL list’s size is greater than 1; otherwise false.
+    ///
+    /// But if we do like spec says, test fails, probably because
+    /// we not fully set URL list in spec steps.
     fn Redirected(&self) -> bool {
         self.redirected.get()
     }

--- a/components/script/navigation.rs
+++ b/components/script/navigation.rs
@@ -254,8 +254,8 @@ impl InProgressLoad {
         .body(self.load_data.data.clone())
         .redirect_mode(RedirectMode::Manual)
         .crash(self.load_data.crash.clone())
-        .client(request_client);
-        request_builder.url_list = self.url_list.clone();
+        .client(request_client)
+        .url_list(self.url_list.clone());
 
         if !request_builder.headers.contains_key(header::ACCEPT) {
             request_builder

--- a/components/shared/net/request.rs
+++ b/components/shared/net/request.rs
@@ -491,7 +491,7 @@ pub struct RequestBuilder {
     /// <https://fetch.spec.whatwg.org/#concept-request-nonce-metadata>
     pub cryptographic_nonce_metadata: String,
 
-    // to keep track of redirects
+    /// <https://fetch.spec.whatwg.org/#concept-request-url-list>
     pub url_list: Vec<ServoUrl>,
 
     /// <https://fetch.spec.whatwg.org/#concept-request-parser-metadata>
@@ -632,6 +632,12 @@ impl RequestBuilder {
     /// <https://fetch.spec.whatwg.org/#concept-request-referrer-policy>
     pub fn referrer_policy(mut self, referrer_policy: ReferrerPolicy) -> RequestBuilder {
         self.referrer_policy = referrer_policy;
+        self
+    }
+
+    /// <https://fetch.spec.whatwg.org/#concept-request-url-list>
+    pub fn url_list(mut self, url_list: Vec<ServoUrl>) -> RequestBuilder {
+        self.url_list = url_list;
         self
     }
 
@@ -836,8 +842,6 @@ pub struct Request {
     pub integrity_metadata: String,
     /// <https://fetch.spec.whatwg.org/#concept-request-nonce-metadata>
     pub cryptographic_nonce_metadata: String,
-    // Use the last method on url_list to act as spec current url field, and
-    // first method to act as spec url field
     /// <https://fetch.spec.whatwg.org/#concept-request-url-list>
     pub url_list: Vec<UrlWithBlobClaim>,
     /// <https://fetch.spec.whatwg.org/#concept-request-redirect-count>


### PR DESCRIPTION
[Redirected](https://fetch.spec.whatwg.org/#dom-response-redirected) should be decided by the URL List.
Currently it does not. We add some TODO, fill URL in more places according to spec.

Testing: This should not change behaviour, as URL list is mostly used by [Redirected](https://fetch.spec.whatwg.org/#dom-response-redirected). If we do it now, we get test failures as URL list is not fully set in all spec steps.