### PR TITLE
storage: fix incorrect data sharing by passing document origin to storage thread

### DIFF
--- a/components/script/dom/storage.rs
+++ b/components/script/dom/storage.rs
@@ -57,7 +57,7 @@ impl Storage {
     }
 
     fn get_immutable_origin(&self) -> ImmutableOrigin {
-        self.global().get_url().origin()
+        self.global().origin().immutable().clone()
     }
 
     fn send_storage_msg(&self, msg: WebStorageThreadMsg) -> SendResult {

--- a/components/script/dom/storage.rs
+++ b/components/script/dom/storage.rs
@@ -6,7 +6,7 @@ use profile_traits::generic_channel;
 use servo_base::generic_channel::{GenericSend, SendResult};
 use servo_base::id::WebViewId;
 use servo_constellation_traits::ScriptToConstellationMessage;
-use servo_url::ServoUrl;
+use servo_url::{ImmutableOrigin, ServoUrl};
 use storage_traits::webstorage_thread::{WebStorageThreadMsg, WebStorageType};
 
 use crate::dom::bindings::codegen::Bindings::StorageBinding::StorageMethods;
@@ -56,6 +56,10 @@ impl Storage {
         self.global().get_url()
     }
 
+    fn get_immutable_origin(&self) -> ImmutableOrigin {
+        self.global().get_url().origin()
+    }
+
     fn send_storage_msg(&self, msg: WebStorageThreadMsg) -> SendResult {
         GenericSend::send(self.global().storage_threads(), msg)
     }
@@ -71,7 +75,7 @@ impl StorageMethods<crate::DomTypeHolder> for Storage {
             sender,
             self.storage_type,
             self.webview_id(),
-            self.get_url(),
+            self.get_immutable_origin(),
         ))
         .unwrap();
         receiver.recv().unwrap() as u32
@@ -86,7 +90,7 @@ impl StorageMethods<crate::DomTypeHolder> for Storage {
             sender,
             self.storage_type,
             self.webview_id(),
-            self.get_url(),
+            self.get_immutable_origin(),
             index,
         ))
         .unwrap();
@@ -103,7 +107,7 @@ impl StorageMethods<crate::DomTypeHolder> for Storage {
             sender,
             self.storage_type,
             self.webview_id(),
-            self.get_url(),
+            self.get_immutable_origin(),
             name,
         );
         self.send_storage_msg(msg).unwrap();
@@ -121,7 +125,7 @@ impl StorageMethods<crate::DomTypeHolder> for Storage {
             sender,
             self.storage_type,
             self.webview_id(),
-            self.get_url(),
+            self.get_immutable_origin(),
             name.clone(),
             value.clone(),
         );
@@ -150,7 +154,7 @@ impl StorageMethods<crate::DomTypeHolder> for Storage {
             sender,
             self.storage_type,
             self.webview_id(),
-            self.get_url(),
+            self.get_immutable_origin(),
             name.clone(),
         );
         self.send_storage_msg(msg).unwrap();
@@ -168,7 +172,7 @@ impl StorageMethods<crate::DomTypeHolder> for Storage {
             sender,
             self.storage_type,
             self.webview_id(),
-            self.get_url(),
+            self.get_immutable_origin(),
         ))
         .unwrap();
         if receiver.recv().unwrap() {
@@ -185,7 +189,7 @@ impl StorageMethods<crate::DomTypeHolder> for Storage {
             sender,
             self.storage_type,
             self.webview_id(),
-            self.get_url(),
+            self.get_immutable_origin(),
         ))
         .unwrap();
         receiver

--- a/components/shared/storage/webstorage_thread.rs
+++ b/components/shared/storage/webstorage_thread.rs
@@ -7,7 +7,7 @@ use profile_traits::mem::ReportsChan;
 use serde::{Deserialize, Serialize};
 use servo_base::generic_channel::GenericSender;
 use servo_base::id::WebViewId;
-use servo_url::ServoUrl;
+use servo_url::{ImmutableOrigin};
 
 #[derive(Clone, Copy, Debug, Deserialize, PartialEq, MallocSizeOf, Serialize)]
 pub enum WebStorageType {
@@ -30,14 +30,14 @@ impl OriginDescriptor {
 #[derive(Debug, Deserialize, Serialize)]
 pub enum WebStorageThreadMsg {
     /// gets the number of key/value pairs present in the associated storage data
-    Length(GenericSender<usize>, WebStorageType, WebViewId, ServoUrl),
+    Length(GenericSender<usize>, WebStorageType, WebViewId, ImmutableOrigin),
 
     /// gets the name of the key at the specified index in the associated storage data
     Key(
         GenericSender<Option<String>>,
         WebStorageType,
         WebViewId,
-        ServoUrl,
+        ImmutableOrigin,
         u32,
     ),
 
@@ -46,7 +46,7 @@ pub enum WebStorageThreadMsg {
         GenericSender<Vec<String>>,
         WebStorageType,
         WebViewId,
-        ServoUrl,
+        ImmutableOrigin,
     ),
 
     /// gets the value associated with the given key in the associated storage data
@@ -54,7 +54,7 @@ pub enum WebStorageThreadMsg {
         GenericSender<Option<String>>,
         WebStorageType,
         WebViewId,
-        ServoUrl,
+        ImmutableOrigin,
         String,
     ),
 
@@ -63,7 +63,7 @@ pub enum WebStorageThreadMsg {
         GenericSender<Result<(bool, Option<String>), ()>>,
         WebStorageType,
         WebViewId,
-        ServoUrl,
+        ImmutableOrigin,
         String,
         String,
     ),
@@ -73,12 +73,12 @@ pub enum WebStorageThreadMsg {
         GenericSender<Option<String>>,
         WebStorageType,
         WebViewId,
-        ServoUrl,
+        ImmutableOrigin,
         String,
     ),
 
     /// clears the associated storage data by removing all the key/value pairs
-    Clear(GenericSender<bool>, WebStorageType, WebViewId, ServoUrl),
+    Clear(GenericSender<bool>, WebStorageType, WebViewId, ImmutableOrigin),
 
     /// clones all storage data of the given top-level browsing context for a new browsing context.
     /// should only be used for sessionStorage.

--- a/components/shared/storage/webstorage_thread.rs
+++ b/components/shared/storage/webstorage_thread.rs
@@ -7,7 +7,7 @@ use profile_traits::mem::ReportsChan;
 use serde::{Deserialize, Serialize};
 use servo_base::generic_channel::GenericSender;
 use servo_base::id::WebViewId;
-use servo_url::{ImmutableOrigin};
+use servo_url::ImmutableOrigin;
 
 #[derive(Clone, Copy, Debug, Deserialize, PartialEq, MallocSizeOf, Serialize)]
 pub enum WebStorageType {
@@ -30,7 +30,12 @@ impl OriginDescriptor {
 #[derive(Debug, Deserialize, Serialize)]
 pub enum WebStorageThreadMsg {
     /// gets the number of key/value pairs present in the associated storage data
-    Length(GenericSender<usize>, WebStorageType, WebViewId, ImmutableOrigin),
+    Length(
+        GenericSender<usize>,
+        WebStorageType,
+        WebViewId,
+        ImmutableOrigin,
+    ),
 
     /// gets the name of the key at the specified index in the associated storage data
     Key(
@@ -78,7 +83,12 @@ pub enum WebStorageThreadMsg {
     ),
 
     /// clears the associated storage data by removing all the key/value pairs
-    Clear(GenericSender<bool>, WebStorageType, WebViewId, ImmutableOrigin),
+    Clear(
+        GenericSender<bool>,
+        WebStorageType,
+        WebViewId,
+        ImmutableOrigin,
+    ),
 
     /// clones all storage data of the given top-level browsing context for a new browsing context.
     /// should only be used for sessionStorage.

--- a/components/storage/tests/webstorage.rs
+++ b/components/storage/tests/webstorage.rs
@@ -7,7 +7,7 @@ use servo_base::generic_channel as base_channel;
 use servo_base::generic_channel::GenericSend;
 use servo_base::id::TEST_WEBVIEW_ID;
 use servo_default_resources as _;
-use servo_url::ServoUrl;
+use servo_url::{ImmutableOrigin, ServoUrl};
 use storage_traits::StorageThreads;
 use storage_traits::webstorage_thread::{WebStorageThreadMsg, WebStorageType};
 use tempfile::TempDir;
@@ -56,7 +56,7 @@ impl WebStorageTest {
         self.threads.clone()
     }
 
-    pub(crate) fn length(&self, storage_type: WebStorageType, url: &ServoUrl) -> usize {
+    pub(crate) fn length(&self, storage_type: WebStorageType, url: &ImmutableOrigin) -> usize {
         let (sender, receiver) = base_channel::channel().unwrap();
         self.threads
             .send(WebStorageThreadMsg::Length(
@@ -72,7 +72,7 @@ impl WebStorageTest {
     pub(crate) fn key(
         &self,
         storage_type: WebStorageType,
-        url: &ServoUrl,
+        url: &ImmutableOrigin,
         index: u32,
     ) -> Option<String> {
         let (sender, receiver) = base_channel::channel().unwrap();
@@ -88,7 +88,7 @@ impl WebStorageTest {
         receiver.recv().unwrap()
     }
 
-    pub(crate) fn keys(&self, storage_type: WebStorageType, url: &ServoUrl) -> Vec<String> {
+    pub(crate) fn keys(&self, storage_type: WebStorageType, url: &ImmutableOrigin) -> Vec<String> {
         let (sender, receiver) = base_channel::channel().unwrap();
         self.threads
             .send(WebStorageThreadMsg::Keys(
@@ -104,7 +104,7 @@ impl WebStorageTest {
     pub(crate) fn get_item(
         &self,
         storage_type: WebStorageType,
-        url: &ServoUrl,
+        url: &ImmutableOrigin,
         key: &str,
     ) -> Option<String> {
         let (sender, receiver) = base_channel::channel().unwrap();
@@ -123,7 +123,7 @@ impl WebStorageTest {
     pub(crate) fn set_item(
         &self,
         storage_type: WebStorageType,
-        url: &ServoUrl,
+        url: &ImmutableOrigin,
         key: &str,
         value: &str,
     ) -> Result<(bool, Option<String>), ()> {
@@ -144,7 +144,7 @@ impl WebStorageTest {
     pub(crate) fn remove_item(
         &self,
         storage_type: WebStorageType,
-        url: &ServoUrl,
+        url: &ImmutableOrigin,
         key: &str,
     ) -> Option<String> {
         let (sender, receiver) = base_channel::channel().unwrap();
@@ -160,7 +160,7 @@ impl WebStorageTest {
         receiver.recv().unwrap()
     }
 
-    pub(crate) fn clear(&self, storage_type: WebStorageType, url: &ServoUrl) -> bool {
+    pub(crate) fn clear(&self, storage_type: WebStorageType, url: &ImmutableOrigin) -> bool {
         let (sender, receiver) = base_channel::channel().unwrap();
         self.threads
             .send(WebStorageThreadMsg::Clear(
@@ -196,11 +196,11 @@ fn set_and_get_item() {
     let url = ServoUrl::parse("https://example.com").unwrap();
 
     // Set a value.
-    let result = test.set_item(WebStorageType::Local, &url, "foo", "bar");
+    let result = test.set_item(WebStorageType::Local, &url.origin(), "foo", "bar");
     assert_eq!(result, Ok((true, None)));
 
     // Retrieve the value.
-    let result = test.get_item(WebStorageType::Local, &url, "foo");
+    let result = test.get_item(WebStorageType::Local, &url.origin(), "foo");
     assert_eq!(result, Some("bar".into()));
 }
 
@@ -210,11 +210,11 @@ fn set_and_get_item_in_memory() {
     let url = ServoUrl::parse("https://example.com").unwrap();
 
     // Set a value.
-    let result = test.set_item(WebStorageType::Local, &url, "foo", "bar");
+    let result = test.set_item(WebStorageType::Local, &url.origin(), "foo", "bar");
     assert_eq!(result, Ok((true, None)));
 
     // Retrieve the value.
-    let result = test.get_item(WebStorageType::Local, &url, "foo");
+    let result = test.get_item(WebStorageType::Local, &url.origin(), "foo");
     assert_eq!(result, Some("bar".into()));
 }
 
@@ -225,20 +225,20 @@ fn length_key_and_keys() {
 
     // Insert two items.
     for (k, v) in [("foo", "v1"), ("bar", "v2")] {
-        let _ = test.set_item(WebStorageType::Local, &url, k, v);
+        let _ = test.set_item(WebStorageType::Local, &url.origin(), k, v);
     }
 
     // Verify length.
-    let result = test.length(WebStorageType::Local, &url);
+    let result = test.length(WebStorageType::Local, &url.origin());
     assert_eq!(result, 2);
 
     // Verify key(0) returns one of the inserted keys.
-    let result = test.key(WebStorageType::Local, &url, 0);
+    let result = test.key(WebStorageType::Local, &url.origin(), 0);
     let key0 = result.unwrap();
     assert!(key0 == "foo" || key0 == "bar");
 
     // Verify keys vector contains both keys.
-    let result = test.keys(WebStorageType::Local, &url);
+    let result = test.keys(WebStorageType::Local, &url.origin());
     assert_eq!(result.len(), 2);
     assert!(result.contains(&"foo".to_string()));
     assert!(result.contains(&"bar".to_string()));
@@ -251,23 +251,23 @@ fn remove_item_and_clear() {
 
     // Insert items.
     for (k, v) in [("foo", "v1"), ("bar", "v2")] {
-        let _ = test.set_item(WebStorageType::Local, &url, k, v);
+        let _ = test.set_item(WebStorageType::Local, &url.origin(), k, v);
     }
 
     // Remove one item and verify old value is returned.
-    let result = test.remove_item(WebStorageType::Local, &url, "foo");
+    let result = test.remove_item(WebStorageType::Local, &url.origin(), "foo");
     assert_eq!(result, Some("v1".into()));
 
     // Removing again should return None.
-    let result = test.remove_item(WebStorageType::Local, &url, "foo");
+    let result = test.remove_item(WebStorageType::Local, &url.origin(), "foo");
     assert_eq!(result, None);
 
     // Clear storage and verify it reported change.
-    let result = test.clear(WebStorageType::Local, &url);
+    let result = test.clear(WebStorageType::Local, &url.origin());
     assert!(result);
 
     // Length should now be zero.
-    let result = test.length(WebStorageType::Local, &url);
+    let result = test.length(WebStorageType::Local, &url.origin());
     assert_eq!(result, 0);
 }
 
@@ -280,7 +280,7 @@ fn test_origin_descriptors(
     let url = ServoUrl::parse("https://example.com").unwrap();
 
     // Set a value.
-    let _ = test.set_item(storage_type, &url, "foo", "bar");
+    let _ = test.set_item(storage_type, &url.origin(), "foo", "bar");
 
     // Verify descriptors.
     let descriptors = threads.webstorage_origins(storage_type);
@@ -326,10 +326,10 @@ fn test_clear_data_for_sites(test: WebStorageTest, storage_type: WebStorageType)
     let url = ServoUrl::parse("https://example.com").unwrap();
 
     // Set a value.
-    let _ = test.set_item(storage_type, &url, "foo", "bar");
+    let _ = test.set_item(storage_type, &url.origin(), "foo", "bar");
 
     // Verify length.
-    let result = test.length(storage_type, &url);
+    let result = test.length(storage_type, &url.origin());
     assert_eq!(result, 1);
 
     // Verify descriptors.
@@ -340,7 +340,7 @@ fn test_clear_data_for_sites(test: WebStorageTest, storage_type: WebStorageType)
     threads.clear_webstorage_for_sites(storage_type, &["example.com"]);
 
     // Length should now be zero.
-    let result = test.length(storage_type, &url);
+    let result = test.length(storage_type, &url.origin());
     assert_eq!(result, 0);
 
     // There should now be no descriptors.
@@ -360,7 +360,7 @@ fn test_clear_data_for_sites(test: WebStorageTest, storage_type: WebStorageType)
     let threads = test.threads();
 
     // Length should still be zero.
-    let result = test.length(storage_type, &url);
+    let result = test.length(storage_type, &url.origin());
     assert_eq!(result, 0);
 
     // There should still be no descriptors.
@@ -376,10 +376,10 @@ fn test_clear_data_for_sites(test: WebStorageTest, storage_type: WebStorageType)
     }
 
     // Set a different value.
-    let _ = test.set_item(storage_type, &url, "foo2", "bar2");
+    let _ = test.set_item(storage_type, &url.origin(), "foo2", "bar2");
 
     // Verify the original value doesn't exist.
-    let result = test.get_item(storage_type, &url, "foo");
+    let result = test.get_item(storage_type, &url.origin(), "foo");
     assert_eq!(result, None);
 }
 
@@ -408,7 +408,7 @@ fn no_storage_type_conflict() {
     let url = ServoUrl::parse("https://example.com").unwrap();
     test.set_item(
         WebStorageType::Local,
-        &url,
+        &url.origin(),
         "key".into(),
         "local_value".into(),
     )
@@ -416,16 +416,16 @@ fn no_storage_type_conflict() {
     // Set session storage item.
     test.set_item(
         WebStorageType::Session,
-        &url,
+        &url.origin(),
         "key".into(),
         "session_value".into(),
     )
     .unwrap();
     // Shutdown threads to ensure data is cleared from session storage and local storage is loaded from disk
     test = test.restart();
-    let result = test.get_item(WebStorageType::Local, &url, "key".into());
+    let result = test.get_item(WebStorageType::Local, &url.origin(), "key".into());
     assert_eq!(result, Some("local_value".into()));
     // Get session storage item.
-    let result = test.get_item(WebStorageType::Session, &url, "key".into());
+    let result = test.get_item(WebStorageType::Session, &url.origin(), "key".into());
     assert_eq!(result, None);
 }

--- a/components/storage/tests/webstorage.rs
+++ b/components/storage/tests/webstorage.rs
@@ -56,14 +56,14 @@ impl WebStorageTest {
         self.threads.clone()
     }
 
-    pub(crate) fn length(&self, storage_type: WebStorageType, url: &ImmutableOrigin) -> usize {
+    pub(crate) fn length(&self, storage_type: WebStorageType, origin: &ImmutableOrigin) -> usize {
         let (sender, receiver) = base_channel::channel().unwrap();
         self.threads
             .send(WebStorageThreadMsg::Length(
                 sender,
                 storage_type,
                 TEST_WEBVIEW_ID,
-                url.clone(),
+                origin.clone(),
             ))
             .unwrap();
         receiver.recv().unwrap()
@@ -72,7 +72,7 @@ impl WebStorageTest {
     pub(crate) fn key(
         &self,
         storage_type: WebStorageType,
-        url: &ImmutableOrigin,
+        origin: &ImmutableOrigin,
         index: u32,
     ) -> Option<String> {
         let (sender, receiver) = base_channel::channel().unwrap();
@@ -81,21 +81,25 @@ impl WebStorageTest {
                 sender,
                 storage_type,
                 TEST_WEBVIEW_ID,
-                url.clone(),
+                origin.clone(),
                 index,
             ))
             .unwrap();
         receiver.recv().unwrap()
     }
 
-    pub(crate) fn keys(&self, storage_type: WebStorageType, url: &ImmutableOrigin) -> Vec<String> {
+    pub(crate) fn keys(
+        &self,
+        storage_type: WebStorageType,
+        origin: &ImmutableOrigin,
+    ) -> Vec<String> {
         let (sender, receiver) = base_channel::channel().unwrap();
         self.threads
             .send(WebStorageThreadMsg::Keys(
                 sender,
                 storage_type,
                 TEST_WEBVIEW_ID,
-                url.clone(),
+                origin.clone(),
             ))
             .unwrap();
         receiver.recv().unwrap()
@@ -104,7 +108,7 @@ impl WebStorageTest {
     pub(crate) fn get_item(
         &self,
         storage_type: WebStorageType,
-        url: &ImmutableOrigin,
+        origin: &ImmutableOrigin,
         key: &str,
     ) -> Option<String> {
         let (sender, receiver) = base_channel::channel().unwrap();
@@ -113,7 +117,7 @@ impl WebStorageTest {
                 sender,
                 storage_type,
                 TEST_WEBVIEW_ID,
-                url.clone(),
+                origin.clone(),
                 key.into(),
             ))
             .unwrap();
@@ -123,7 +127,7 @@ impl WebStorageTest {
     pub(crate) fn set_item(
         &self,
         storage_type: WebStorageType,
-        url: &ImmutableOrigin,
+        origin: &ImmutableOrigin,
         key: &str,
         value: &str,
     ) -> Result<(bool, Option<String>), ()> {
@@ -133,7 +137,7 @@ impl WebStorageTest {
                 sender,
                 storage_type,
                 TEST_WEBVIEW_ID,
-                url.clone(),
+                origin.clone(),
                 key.into(),
                 value.into(),
             ))
@@ -144,7 +148,7 @@ impl WebStorageTest {
     pub(crate) fn remove_item(
         &self,
         storage_type: WebStorageType,
-        url: &ImmutableOrigin,
+        origin: &ImmutableOrigin,
         key: &str,
     ) -> Option<String> {
         let (sender, receiver) = base_channel::channel().unwrap();
@@ -153,21 +157,21 @@ impl WebStorageTest {
                 sender,
                 storage_type,
                 TEST_WEBVIEW_ID,
-                url.clone(),
+                origin.clone(),
                 key.into(),
             ))
             .unwrap();
         receiver.recv().unwrap()
     }
 
-    pub(crate) fn clear(&self, storage_type: WebStorageType, url: &ImmutableOrigin) -> bool {
+    pub(crate) fn clear(&self, storage_type: WebStorageType, origin: &ImmutableOrigin) -> bool {
         let (sender, receiver) = base_channel::channel().unwrap();
         self.threads
             .send(WebStorageThreadMsg::Clear(
                 sender,
                 storage_type,
                 TEST_WEBVIEW_ID,
-                url.clone(),
+                origin.clone(),
             ))
             .unwrap();
         receiver.recv().unwrap()

--- a/components/storage/webstorage/mod.rs
+++ b/components/storage/webstorage/mod.rs
@@ -489,9 +489,9 @@ impl WebStorageManager {
         sender: GenericSender<usize>,
         storage_type: WebStorageType,
         webview_id: WebViewId,
-        url: ImmutableOrigin,
+        origin: ImmutableOrigin,
     ) {
-        let data = self.select_data(storage_type, webview_id, url);
+        let data = self.select_data(storage_type, webview_id, origin);
         sender
             .send(data.map_or(0, |entry| entry.inner().len()))
             .unwrap();
@@ -502,10 +502,10 @@ impl WebStorageManager {
         sender: GenericSender<Option<String>>,
         storage_type: WebStorageType,
         webview_id: WebViewId,
-        url: ImmutableOrigin,
+        origin: ImmutableOrigin,
         index: u32,
     ) {
-        let data = self.select_data(storage_type, webview_id, url);
+        let data = self.select_data(storage_type, webview_id, origin);
         let key = data
             .and_then(|entry| entry.inner().keys().nth(index as usize))
             .cloned();
@@ -517,9 +517,9 @@ impl WebStorageManager {
         sender: GenericSender<Vec<String>>,
         storage_type: WebStorageType,
         webview_id: WebViewId,
-        url: ImmutableOrigin,
+        origin: ImmutableOrigin,
     ) {
-        let data = self.select_data(storage_type, webview_id, url);
+        let data = self.select_data(storage_type, webview_id, origin);
         let keys = data.map_or(vec![], |entry| entry.inner().keys().cloned().collect());
 
         sender.send(keys).unwrap();
@@ -534,11 +534,11 @@ impl WebStorageManager {
         sender: GenericSender<Result<(bool, Option<String>), ()>>,
         storage_type: WebStorageType,
         webview_id: WebViewId,
-        url: ImmutableOrigin,
+        origin: ImmutableOrigin,
         name: String,
         value: String,
     ) {
-        let Some(entry) = self.ensure_data_mut(storage_type, webview_id, url.clone()) else {
+        let Some(entry) = self.ensure_data_mut(storage_type, webview_id, origin.clone()) else {
             sender.send(Err(())).unwrap();
             return;
         };
@@ -565,7 +565,7 @@ impl WebStorageManager {
                         }
                     });
             if storage_type == WebStorageType::Local {
-                if let Ok(env) = self.get_environment_mut(&url) {
+                if let Ok(env) = self.get_environment_mut(&origin) {
                     env.set(&name, &value);
                 }
             }
@@ -579,10 +579,10 @@ impl WebStorageManager {
         sender: GenericSender<Option<String>>,
         storage_type: WebStorageType,
         webview_id: WebViewId,
-        url: ImmutableOrigin,
+        origin: ImmutableOrigin,
         name: String,
     ) {
-        let data = self.select_data(storage_type, webview_id, url);
+        let data = self.select_data(storage_type, webview_id, origin);
         sender
             .send(data.and_then(|entry| entry.inner().get(&name)).cloned())
             .unwrap();
@@ -594,14 +594,14 @@ impl WebStorageManager {
         sender: GenericSender<Option<String>>,
         storage_type: WebStorageType,
         webview_id: WebViewId,
-        url: ImmutableOrigin,
+        origin: ImmutableOrigin,
         name: String,
     ) {
-        let data = self.select_data_mut(storage_type, webview_id, url.clone());
+        let data = self.select_data_mut(storage_type, webview_id, origin.clone());
         let old_value = data.and_then(|entry| entry.remove(&name));
         sender.send(old_value).unwrap();
         if storage_type == WebStorageType::Local {
-            if let Ok(env) = self.get_environment_mut(&url) {
+            if let Ok(env) = self.get_environment_mut(&origin) {
                 env.delete(&name);
             }
         }
@@ -612,9 +612,9 @@ impl WebStorageManager {
         sender: GenericSender<bool>,
         storage_type: WebStorageType,
         webview_id: WebViewId,
-        url: ImmutableOrigin,
+        origin: ImmutableOrigin,
     ) {
-        let data = self.select_data_mut(storage_type, webview_id, url.clone());
+        let data = self.select_data_mut(storage_type, webview_id, origin.clone());
         sender
             .send(data.is_some_and(|entry| {
                 if !entry.inner().is_empty() {
@@ -626,7 +626,7 @@ impl WebStorageManager {
             }))
             .unwrap();
         if storage_type == WebStorageType::Local {
-            if let Ok(env) = self.get_environment_mut(&url) {
+            if let Ok(env) = self.get_environment_mut(&origin) {
                 env.clear();
             }
         }

--- a/components/storage/webstorage/mod.rs
+++ b/components/storage/webstorage/mod.rs
@@ -489,9 +489,9 @@ impl WebStorageManager {
         sender: GenericSender<usize>,
         storage_type: WebStorageType,
         webview_id: WebViewId,
-        url: ServoUrl,
+        url: ImmutableOrigin,
     ) {
-        let data = self.select_data(storage_type, webview_id, url.origin());
+        let data = self.select_data(storage_type, webview_id, url);
         sender
             .send(data.map_or(0, |entry| entry.inner().len()))
             .unwrap();
@@ -502,10 +502,10 @@ impl WebStorageManager {
         sender: GenericSender<Option<String>>,
         storage_type: WebStorageType,
         webview_id: WebViewId,
-        url: ServoUrl,
+        url: ImmutableOrigin,
         index: u32,
     ) {
-        let data = self.select_data(storage_type, webview_id, url.origin());
+        let data = self.select_data(storage_type, webview_id, url);
         let key = data
             .and_then(|entry| entry.inner().keys().nth(index as usize))
             .cloned();
@@ -517,9 +517,9 @@ impl WebStorageManager {
         sender: GenericSender<Vec<String>>,
         storage_type: WebStorageType,
         webview_id: WebViewId,
-        url: ServoUrl,
+        url: ImmutableOrigin,
     ) {
-        let data = self.select_data(storage_type, webview_id, url.origin());
+        let data = self.select_data(storage_type, webview_id, url);
         let keys = data.map_or(vec![], |entry| entry.inner().keys().cloned().collect());
 
         sender.send(keys).unwrap();
@@ -534,11 +534,11 @@ impl WebStorageManager {
         sender: GenericSender<Result<(bool, Option<String>), ()>>,
         storage_type: WebStorageType,
         webview_id: WebViewId,
-        url: ServoUrl,
+        url: ImmutableOrigin,
         name: String,
         value: String,
     ) {
-        let Some(entry) = self.ensure_data_mut(storage_type, webview_id, url.origin()) else {
+        let Some(entry) = self.ensure_data_mut(storage_type, webview_id, url.clone()) else {
             sender.send(Err(())).unwrap();
             return;
         };
@@ -565,7 +565,7 @@ impl WebStorageManager {
                         }
                     });
             if storage_type == WebStorageType::Local {
-                if let Ok(env) = self.get_environment_mut(&url.origin()) {
+                if let Ok(env) = self.get_environment_mut(&url) {
                     env.set(&name, &value);
                 }
             }
@@ -579,10 +579,10 @@ impl WebStorageManager {
         sender: GenericSender<Option<String>>,
         storage_type: WebStorageType,
         webview_id: WebViewId,
-        url: ServoUrl,
+        url: ImmutableOrigin,
         name: String,
     ) {
-        let data = self.select_data(storage_type, webview_id, url.origin());
+        let data = self.select_data(storage_type, webview_id, url);
         sender
             .send(data.and_then(|entry| entry.inner().get(&name)).cloned())
             .unwrap();
@@ -594,14 +594,14 @@ impl WebStorageManager {
         sender: GenericSender<Option<String>>,
         storage_type: WebStorageType,
         webview_id: WebViewId,
-        url: ServoUrl,
+        url: ImmutableOrigin,
         name: String,
     ) {
-        let data = self.select_data_mut(storage_type, webview_id, url.origin());
+        let data = self.select_data_mut(storage_type, webview_id, url.clone());
         let old_value = data.and_then(|entry| entry.remove(&name));
         sender.send(old_value).unwrap();
         if storage_type == WebStorageType::Local {
-            if let Ok(env) = self.get_environment_mut(&url.origin()) {
+            if let Ok(env) = self.get_environment_mut(&url) {
                 env.delete(&name);
             }
         }
@@ -612,9 +612,9 @@ impl WebStorageManager {
         sender: GenericSender<bool>,
         storage_type: WebStorageType,
         webview_id: WebViewId,
-        url: ServoUrl,
+        url: ImmutableOrigin,
     ) {
-        let data = self.select_data_mut(storage_type, webview_id, url.origin());
+        let data = self.select_data_mut(storage_type, webview_id, url.clone());
         sender
             .send(data.is_some_and(|entry| {
                 if !entry.inner().is_empty() {
@@ -626,7 +626,7 @@ impl WebStorageManager {
             }))
             .unwrap();
         if storage_type == WebStorageType::Local {
-            if let Ok(env) = self.get_environment_mut(&url.origin()) {
+            if let Ok(env) = self.get_environment_mut(&url) {
                 env.clear();
             }
         }

--- a/tests/wpt/meta/webstorage/localstorage-share-data-unrelated-origins.html.ini
+++ b/tests/wpt/meta/webstorage/localstorage-share-data-unrelated-origins.html.ini
@@ -1,3 +1,0 @@
-[localstorage-share-data-unrelated-origins.html]
-  [Ensure two about:srcdoc origins cannot share localstorage]
-    expected: FAIL


### PR DESCRIPTION
Changes all the uses of `ServoUrl` to `ImmutableOrigin` in `WebStorageThreadMsg`

Testing: Adds a test case as described in the issue.

```html
<!DOCTYPE html>
<html lang="en">

<head>
  <meta charset="UTF-8">
  <meta name="viewport" content="width=device-width, initial-scale=1">
  <title></title>
</head>

<body>
  <main>
    <h1>Tab and Program crashes!</h1>
    <iframe srcdoc="
          <body>
            <p>Hello Web users! <br/> I am an iframe, <br /> I set a key and then retreive it. </p> 
            <script>
              for (let i = 0; i < 1000; i++) {
                window.localStorage.setItem('truth', 'Servo is awesome! 🌐')
                const example = window.localStorage.getItem('truth')
                
                console.log(example === 'Servo is awesome! 🌐')
              }
            </script>
          </body> 
          "></iframe>
  </main>
</body>

</html>

```

Fixes: #44001
