### PR TITLE
script: Accept names of `PerformanceTiming` members as marks in `Performance.measure`

### DIFF
--- a/components/script/dom/performance/performance.rs
+++ b/components/script/dom/performance/performance.rs
@@ -7,6 +7,8 @@ use std::cmp::Ordering;
 use std::collections::VecDeque;
 
 use dom_struct::dom_struct;
+use script_bindings::cformat;
+use script_bindings::codegen::GenericBindings::WindowBinding::WindowMethods;
 use script_bindings::codegen::GenericUnionTypes::StringOrPerformanceMeasureOptions;
 use servo_base::cross_process_instant::CrossProcessInstant;
 use time::Duration;
@@ -469,25 +471,88 @@ impl Performance {
     }
 
     /// <https://w3c.github.io/user-timing/#convert-a-mark-to-a-timestamp>
+    fn convert_a_name_to_a_timestamp(&self, name: &str) -> Fallible<CrossProcessInstant> {
+        // Step 1. If the global object is not a Window object, throw a TypeError.
+        let Some(window) = DomRoot::downcast::<Window>(self.global()) else {
+            return Err(Error::Type(cformat!(
+                "Cannot use {name} from non-window global"
+            )));
+        };
+
+        // Step 2. If name is navigationStart, return 0.
+        if name == "navigationStart" {
+            return Ok(self.time_origin);
+        }
+
+        // Step 3. Let startTime be the value of navigationStart in the PerformanceTiming interface.
+        // FIXME: We don't implement this value yet, so we assume it's zero (and then we don't need it at all)
+
+        // Step 4. Let endTime be the value of name in the PerformanceTiming interface.
+        // NOTE: We store all performance values on the document
+        let document = window.Document();
+        let end_time = match name {
+            "unloadEventStart" => document.get_unload_event_start(),
+            "unloadEventEnd" => document.get_unload_event_end(),
+            "domInteractive" => document.get_dom_interactive(),
+            "domContentLoadedEventStart" => document.get_dom_content_loaded_event_start(),
+            "domContentLoadedEventEnd" => document.get_dom_content_loaded_event_end(),
+            "domComplete" => document.get_dom_complete(),
+            "loadEventStart" => document.get_load_event_start(),
+            "loadEventEnd" => document.get_load_event_end(),
+            other => {
+                if cfg!(debug_assertions) {
+                    unreachable!("{other:?} is not the name of a timestamp");
+                }
+                return Err(Error::Operation(None));
+            },
+        };
+        // Step 5. If endTime is 0, throw an InvalidAccessError.
+        let Some(end_time) = end_time else {
+            return Err(Error::InvalidAccess(Some(format!(
+                "{name} hasn't happened yet"
+            ))));
+        };
+
+        // Step 6. Return result of subtracting startTime from endTime.
+        Ok(end_time)
+    }
+
+    /// <https://w3c.github.io/user-timing/#convert-a-mark-to-a-timestamp>
     fn convert_a_mark_to_a_timestamp(
         &self,
         mark: &StringOrDouble,
     ) -> Fallible<CrossProcessInstant> {
         match mark {
             StringOrDouble::String(name) => {
-                // TODO: Step 1. If mark is a DOMString and it has the same name as a read only attribute in the
+                // Step 1. If mark is a DOMString and it has the same name as a read only attribute in the
                 // PerformanceTiming interface, let end time be the value returned by running the convert
                 // a name to a timestamp algorithm with name set to the value of mark.
-
+                // TODO: These aren't all fields because servo doesn't support some of them yet
+                if matches!(
+                    &*name.str(),
+                    "navigationStart" |
+                        "unloadEventStart" |
+                        "unloadEventEnd" |
+                        "domInteractive" |
+                        "domContentLoadedEventStart" |
+                        "domContentLoadedEventEnd" |
+                        "domComplete" |
+                        "loadEventStart" |
+                        "loadEventEnd"
+                ) {
+                    self.convert_a_name_to_a_timestamp(&name.str())
+                }
                 // Step 2. Otherwise, if mark is a DOMString, let end time be the value of the startTime
                 // attribute from the most recent occurrence of a PerformanceMark object in the performance entry
                 // buffer whose name is mark. If no matching entry is found, throw a SyntaxError.
-                self.buffer
-                    .borrow()
-                    .get_last_entry_start_time_with_name_and_type(name.clone(), EntryType::Mark)
-                    .ok_or(Error::Syntax(Some(format!(
-                        "No PerformanceMark named {name} exists"
-                    ))))
+                else {
+                    self.buffer
+                        .borrow()
+                        .get_last_entry_start_time_with_name_and_type(name.clone(), EntryType::Mark)
+                        .ok_or(Error::Syntax(Some(format!(
+                            "No PerformanceMark named {name} exists"
+                        ))))
+                }
             },
             // Step 3. Otherwise, if mark is a DOMHighResTimeStamp:
             StringOrDouble::Double(timestamp) => {

--- a/components/script/dom/performance/performance.rs
+++ b/components/script/dom/performance/performance.rs
@@ -470,7 +470,7 @@ impl Performance {
         }
     }
 
-    /// <https://w3c.github.io/user-timing/#convert-a-mark-to-a-timestamp>
+    /// <https://w3c.github.io/user-timing/#convert-a-name-to-a-timestamp>
     fn convert_a_name_to_a_timestamp(&self, name: &str) -> Fallible<CrossProcessInstant> {
         // Step 1. If the global object is not a Window object, throw a TypeError.
         let Some(window) = DomRoot::downcast::<Window>(self.global()) else {

--- a/tests/wpt/include.ini
+++ b/tests/wpt/include.ini
@@ -308,6 +308,8 @@ skip: true
   skip: false
 [user-timing]
   skip: false
+  [measure_associated_with_navigation_timing.html]
+    skip: true
 [wasm]
   skip: false
 [webaudio]

--- a/tests/wpt/meta/user-timing/clearMeasures.html.ini
+++ b/tests/wpt/meta/user-timing/clearMeasures.html.ini
@@ -1,2 +1,0 @@
-[clearMeasures.html]
-  expected: ERROR

--- a/tests/wpt/meta/user-timing/measure-exceptions.html.ini
+++ b/tests/wpt/meta/user-timing/measure-exceptions.html.ini
@@ -1,10 +1,4 @@
 [measure-exceptions.html]
-  [Passing 'unloadEventStart' as a mark to measure API should cause error when the mark is empty.]
-    expected: FAIL
-
-  [Passing 'unloadEventEnd' as a mark to measure API should cause error when the mark is empty.]
-    expected: FAIL
-
   [Passing 'redirectStart' as a mark to measure API should cause error when the mark is empty.]
     expected: FAIL
 
@@ -12,22 +6,4 @@
     expected: FAIL
 
   [Passing 'secureConnectionStart' as a mark to measure API should cause error when the mark is empty.]
-    expected: FAIL
-
-  [Passing 'domInteractive' as a mark to measure API should cause error when the mark is empty.]
-    expected: FAIL
-
-  [Passing 'domContentLoadedEventStart' as a mark to measure API should cause error when the mark is empty.]
-    expected: FAIL
-
-  [Passing 'domContentLoadedEventEnd' as a mark to measure API should cause error when the mark is empty.]
-    expected: FAIL
-
-  [Passing 'domComplete' as a mark to measure API should cause error when the mark is empty.]
-    expected: FAIL
-
-  [Passing 'loadEventStart' as a mark to measure API should cause error when the mark is empty.]
-    expected: FAIL
-
-  [Passing 'loadEventEnd' as a mark to measure API should cause error when the mark is empty.]
     expected: FAIL

--- a/tests/wpt/meta/user-timing/measure_associated_with_navigation_timing.html.ini
+++ b/tests/wpt/meta/user-timing/measure_associated_with_navigation_timing.html.ini
@@ -1,4 +1,0 @@
-[measure_associated_with_navigation_timing.html]
-  expected: ERROR
-  [Measure of navigationStart to loadEventEnd should be positive value.]
-    expected: FAIL

--- a/tests/wpt/meta/user-timing/measure_exceptions_navigation_timing.html.ini
+++ b/tests/wpt/meta/user-timing/measure_exceptions_navigation_timing.html.ini
@@ -1,12 +1,3 @@
 [measure_exceptions_navigation_timing.html]
-  [window.performance.measure("measure", "loadEventEnd"), where "loadEventEnd" is a navigation timing attribute with a value of 0, throws a InvalidAccessError exception.]
-    expected: FAIL
-
   [window.performance.measure("measure", "loadEventEnd", "responseEnd"), where "loadEventEnd" is a navigation timing attribute with a value of 0, throws a InvalidAccessError exception.]
-    expected: FAIL
-
-  [window.performance.measure("measure", "navigationStart", "loadEventEnd"), where "loadEventEnd" is a navigation timing attribute with a value of 0, throws a InvalidAccessError exception.]
-    expected: FAIL
-
-  [window.performance.measure("measure", "loadEventEnd", "loadEventEnd"), where "loadEventEnd" is a navigation timing attribute with a value of 0, throws a InvalidAccessError exception.]
     expected: FAIL

--- a/tests/wpt/meta/user-timing/measures.html.ini
+++ b/tests/wpt/meta/user-timing/measures.html.ini
@@ -1,2 +1,0 @@
-[measures.html]
-  expected: ERROR

--- a/tests/wpt/meta/user-timing/performance-measure-invalid.worker.js.ini
+++ b/tests/wpt/meta/user-timing/performance-measure-invalid.worker.js.ini
@@ -1,6 +1,0 @@
-[performance-measure-invalid.worker.html]
-  [When converting 'navigationStart' to a timestamp, the global object has to be a Window object.]
-    expected: FAIL
-
-  [When converting 'navigationStart' to a timestamp and a mark named 'navigationStart' exists, the global object has to be a Window object.]
-    expected: FAIL


### PR DESCRIPTION
This change allows users to pass a mark like `"navigationStart"` to `Performance.measure` and that will resolve to the value of `navigationStart` on the `PerformanceTiming` interface.

Testing: New tests start to pass
Part of https://github.com/servo/servo/issues/43821 - we no longer throw an exception in the case above.
