### PR TITLE
devtools: Pass `steppingType` to `onPop` hook

### DIFF
--- a/components/default-resources/resources/debugger.js
+++ b/components/default-resources/resources/debugger.js
@@ -410,7 +410,9 @@ function makeSteppingHooks(steppingType, startFrame) {
             this.reportedPop = true;
             suspendedFrame = startFrame;
             if (steppingType !== "finish") {
-                return handlePauseAndRespond(startFrame, completion);
+                // TODO: completion contains the return value, we have to send it back
+                // <https://searchfox.org/firefox-main/source/devtools/server/actors/thread.js#1026>
+                return handlePauseAndRespond(startFrame, { type_: steppingType });
             }
             attachSteppingHooks("next", startFrame);
         },


### PR DESCRIPTION
Fixes crashes when stepping in certain situations.

Testing: Ran `mach test-devtools` and manual testing
Part of: #36027
