### PR TITLE
Remove introduction_type_override field from HTMLScriptElement

### DIFF
--- a/components/script/dom/html/htmlscriptelement.rs
+++ b/components/script/dom/html/htmlscriptelement.rs
@@ -111,11 +111,6 @@ pub(crate) struct HTMLScriptElement {
     /// <https://html.spec.whatwg.org/multipage/#concept-script-external>
     from_an_external_file: Cell<bool>,
 
-    /// `introductionType` value to set in the `CompileOptionsWrapper`, overriding the usual
-    /// `srcScript` or `inlineScript` that this script would normally use.
-    #[no_trace]
-    introduction_type_override: Cell<Option<&'static CStr>>,
-
     /// <https://html.spec.whatwg.org/multipage/#dom-script-blocking>
     blocking: MutNullableDom<DOMTokenList>,
 
@@ -143,7 +138,6 @@ impl HTMLScriptElement {
             line_number: creator.return_line_number(),
             script_text: DomRefCell::new(DOMString::new()),
             from_an_external_file: Cell::new(false),
-            introduction_type_override: Cell::new(None),
             blocking: Default::default(),
             marked_as_render_blocking: Default::default(),
         }
@@ -692,8 +686,8 @@ impl HTMLScriptElement {
         cx: &mut JSContext,
         introduction_type_override: Option<&'static CStr>,
     ) {
-        self.introduction_type_override
-            .set(introduction_type_override);
+        let introduction_type =
+            introduction_type_override.or(Some(IntroductionType::INLINE_SCRIPT));
 
         // Step 1. If el's already started is true, then return.
         if self.already_started.get() {
@@ -968,7 +962,7 @@ impl HTMLScriptElement {
                         base_url,
                         options,
                         ErrorReporting::Unmuted,
-                        introduction_type_override.or(Some(IntroductionType::INLINE_SCRIPT)),
+                        introduction_type,
                         self.line_number as u32,
                         false,
                     );
@@ -1020,6 +1014,7 @@ impl HTMLScriptElement {
                         base_url,
                         options,
                         self.line_number as u32,
+                        introduction_type,
                     );
                     return;
                 },

--- a/components/script/script_module.rs
+++ b/components/script/script_module.rs
@@ -1360,6 +1360,7 @@ pub(crate) fn fetch_inline_module_script(
     url: ServoUrl,
     options: ScriptFetchOptions,
     line_number: u32,
+    introduction_type: Option<&'static CStr>,
 ) {
     // Step 1. Let script be the result of creating a JavaScript module script using sourceText, settingsObject, baseURL, and options.
     let module_tree = Rc::new(ModuleTree::create_a_javascript_module_script(
@@ -1369,7 +1370,7 @@ pub(crate) fn fetch_inline_module_script(
         options,
         false,
         line_number,
-        Some(IntroductionType::INLINE_SCRIPT),
+        introduction_type,
         CanGc::from_cx(cx),
     ));
     let fetch_client = ModuleFetchClient::from_global_scope(&owner.global());


### PR DESCRIPTION
Removed ```introduction_type_override``` field from ```HTMLScriptElement``` & passed the new variable to ```fetch_inline_module_script```

Testing: No testing required, compiles successfully.
Fixes: #43980