### PR TITLE
script: Use the global's origin when claiming blob tokens.

### DIFF
--- a/components/script/dom/request.rs
+++ b/components/script/dom/request.rs
@@ -12,7 +12,6 @@ use http::header::{HeaderName, HeaderValue};
 use http::method::InvalidMethod;
 use js::rust::HandleObject;
 use net_traits::ReferrerPolicy as MsgReferrerPolicy;
-use net_traits::blob_url_store::UrlWithBlobClaim;
 use net_traits::fetch::headers::is_forbidden_method;
 use net_traits::request::{
     CacheMode as NetTraitsRequestCache, CredentialsMode as NetTraitsRequestCredentials,
@@ -43,6 +42,7 @@ use crate::dom::promise::Promise;
 use crate::dom::stream::readablestream::ReadableStream;
 use crate::fetch::RequestWithGlobalScope;
 use crate::script_runtime::CanGc;
+use crate::url::ensure_blob_referenced_by_url_is_kept_alive;
 
 #[dom_struct]
 pub(crate) struct Request {
@@ -574,9 +574,10 @@ impl Request {
 }
 
 fn net_request_from_global(global: &GlobalScope, url: ServoUrl) -> NetTraitsRequest {
+    let url = ensure_blob_referenced_by_url_is_kept_alive(global, url);
     RequestBuilder::new(
         global.webview_id(),
-        UrlWithBlobClaim::from_url_without_having_claimed_blob(url),
+        url,
         global.get_referrer(),
     )
     .with_global_scope(global)

--- a/components/script/dom/request.rs
+++ b/components/script/dom/request.rs
@@ -575,13 +575,9 @@ impl Request {
 
 fn net_request_from_global(global: &GlobalScope, url: ServoUrl) -> NetTraitsRequest {
     let url = ensure_blob_referenced_by_url_is_kept_alive(global, url);
-    RequestBuilder::new(
-        global.webview_id(),
-        url,
-        global.get_referrer(),
-    )
-    .with_global_scope(global)
-    .build()
+    RequestBuilder::new(global.webview_id(), url, global.get_referrer())
+        .with_global_scope(global)
+        .build()
 }
 
 /// <https://fetch.spec.whatwg.org/#concept-method-normalize>

--- a/components/script/fetch.rs
+++ b/components/script/fetch.rs
@@ -146,7 +146,7 @@ pub(crate) struct FetchGroup {
 fn request_init_from_request(request: NetTraitsRequest, global: &GlobalScope) -> RequestBuilder {
     let mut builder = RequestBuilder::new(
         request.target_webview_id,
-        UrlWithBlobClaim::from_url_without_having_claimed_blob(request.url()),
+        request.url_with_blob_claim(),
         request.referrer,
     )
     .method(request.method)

--- a/components/script/url.rs
+++ b/components/script/url.rs
@@ -15,7 +15,7 @@ pub(crate) fn ensure_blob_referenced_by_url_is_kept_alive(
         Ok(lock) => lock,
         Err(url) => {
             let token = BlobResolver {
-                origin: global.api_base_url().origin(),
+                origin: global.origin().immutable().clone(),
                 resource_threads: global.resource_threads(),
             }
             .acquire_blob_token_for(&url);

--- a/components/shared/net/request.rs
+++ b/components/shared/net/request.rs
@@ -915,6 +915,10 @@ impl Request {
         self.url_list.first().unwrap().url()
     }
 
+    pub fn url_with_blob_claim(&self) -> UrlWithBlobClaim {
+        self.url_list.first().unwrap().clone()
+    }
+
     pub fn original_url(&self) -> ServoUrl {
         match self.mode {
             RequestMode::WebSocket {

--- a/tests/wpt/meta/FileAPI/url/sandboxed-iframe.html.ini
+++ b/tests/wpt/meta/FileAPI/url/sandboxed-iframe.html.ini
@@ -12,38 +12,11 @@
   [Blob URL fragment is implemented.]
     expected: TIMEOUT
 
-  [Blob URLs can be used in XHR]
-    expected: FAIL
-
-  [XHR with a fragment should succeed]
-    expected: FAIL
-
-  [Only exact matches should revoke URLs, using XHR]
-    expected: FAIL
-
-  [XHR should return Content-Type from Blob]
-    expected: FAIL
-
-  [Revoke blob URL after open(), will fetch]
-    expected: FAIL
-
-  [Blob URLs can be used in fetch]
-    expected: FAIL
-
-  [fetch with a fragment should succeed]
-    expected: FAIL
-
-  [Only exact matches should revoke URLs, using fetch]
-    expected: FAIL
-
-  [fetch should return Content-Type from Blob]
-    expected: FAIL
-
-  [Revoke blob URL after creating Request, will fetch]
-    expected: FAIL
-
   [Revoke blob URL after creating Request, then clone Request, will fetch]
     expected: FAIL
 
-  [Revoke blob URL after calling fetch, fetch should succeed]
+  [XHR of a revoked URL should fail]
+    expected: FAIL
+
+  [fetch of a revoked URL should fail]
     expected: FAIL

--- a/tests/wpt/meta/workers/opaque-origin.html.ini
+++ b/tests/wpt/meta/workers/opaque-origin.html.ini
@@ -1,4 +1,5 @@
 [opaque-origin.html]
   expected: TIMEOUT
-  [Worker has an opaque origin.]
-    expected: FAIL
+
+  [Worker can access BroadcastChannel]
+    expected: TIMEOUT


### PR DESCRIPTION
`global.api_base_url().origin()` returns a unique opaque origin when the base URL is an opaque origin. When we use the global's origin instead, requests for claimed blobs can now pass the same-origin check.

Testing: Newly passing tests.
Fixes: #43326
Fixes: #43973
