### PR TITLE
mozjs: Rebuild from source if `jitspew` feature is enabled

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5078,7 +5078,8 @@ dependencies = [
 [[package]]
 name = "mozjs"
 version = "0.15.8"
-source = "git+https://github.com/simonwuelker/mozjs?branch=jitspew-from-source#712ca6c8dcd5aa56b2b4dc303294e91fc34ab86f"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4e51874bd557fcc5809a3e133714998d2b856ab29aa59fba79f3398f0537e48"
 dependencies = [
  "bindgen",
  "cc",
@@ -5092,7 +5093,8 @@ dependencies = [
 [[package]]
 name = "mozjs_sys"
 version = "0.140.8-3"
-source = "git+https://github.com/simonwuelker/mozjs?branch=jitspew-from-source#712ca6c8dcd5aa56b2b4dc303294e91fc34ab86f"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f70e26e45204d1cbd73d2508007ab5cbb3411bddb057c47977bae6844861a8fa"
 dependencies = [
  "bindgen",
  "cc",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5077,9 +5077,8 @@ dependencies = [
 
 [[package]]
 name = "mozjs"
-version = "0.15.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "226edc79aa3f990a61330d4011471910273f6ee6bbfd0dcb93b18f5a03505f6b"
+version = "0.15.8"
+source = "git+https://github.com/simonwuelker/mozjs?branch=jitspew-from-source#712ca6c8dcd5aa56b2b4dc303294e91fc34ab86f"
 dependencies = [
  "bindgen",
  "cc",
@@ -5092,9 +5091,8 @@ dependencies = [
 
 [[package]]
 name = "mozjs_sys"
-version = "0.140.8-2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b50224a02c96e1e703f7d055377431333dfc5cd3a09ccf03f8a2c8a156c7af8"
+version = "0.140.8-3"
+source = "git+https://github.com/simonwuelker/mozjs?branch=jitspew-from-source#712ca6c8dcd5aa56b2b4dc303294e91fc34ab86f"
 dependencies = [
  "bindgen",
  "cc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -370,8 +370,8 @@ codegen-units = 1
 #
 # Or for mozjs:
 #
-mozjs = { git="https://github.com/simonwuelker/mozjs", branch="jitspew-from-source" }
-mozjs_sys = { git="https://github.com/simonwuelker/mozjs", branch="jitspew-from-source" }
+# mozjs = { path = "../mozjs/mozjs" }
+# mozjs_sys = { path = "../mozjs/mozjs-sys" }
 #
 # Or for CSP crate:
 # content-security-policy = { path = "../rust-content-security-policy" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -109,7 +109,7 @@ indexmap = { version = "2.11.4", features = ["std"] }
 inventory = { version = "0.3.24" }
 ipc-channel = "0.21"
 itertools = "0.14"
-js = { package = "mozjs", version = "=0.15.7", default-features = false, features = ["libz-sys", "intl"] }
+js = { package = "mozjs", version = "=0.15.8", default-features = false, features = ["libz-sys", "intl"] }
 keyboard-types = { version = "0.8.3", features = ["serde", "webdriver"] }
 kurbo = { version = "0.12", features = ["euclid"] }
 libc = "0.2"
@@ -370,8 +370,8 @@ codegen-units = 1
 #
 # Or for mozjs:
 #
-# mozjs = { path = "../mozjs/mozjs" }
-# mozjs_sys = { path = "../mozjs/mozjs-sys" }
+mozjs = { git="https://github.com/simonwuelker/mozjs", branch="jitspew-from-source" }
+mozjs_sys = { git="https://github.com/simonwuelker/mozjs", branch="jitspew-from-source" }
 #
 # Or for CSP crate:
 # content-security-policy = { path = "../rust-content-security-policy" }


### PR DESCRIPTION
The `IONFLAGS` environment variable configure logging for the JIT, but it must be enabled in spidermonkey at compile time. The prebuilt mozjs binaries don't enable it, so we must build from source.

Companion PR for https://github.com/servo/mozjs/pull/728

Testing: We don't have tests for the build process
