### PR TITLE
script: Reduce `ShadowRoot::bind_to_tree` complexity from O(2^N) to O(N)

### DIFF
--- a/components/script/dom/element/element.rs
+++ b/components/script/dom/element/element.rs
@@ -699,7 +699,9 @@ impl Element {
         // non-shadow-tree children of `self` no longer have layout boxes as they are no
         // longer in the flat tree.
         let node = self.upcast::<Node>();
-        node.remove_layout_boxes_from_subtree();
+        if node.is_connected() {
+            node.remove_layout_boxes_from_subtree();
+        }
 
         // Step 6. Set shadow's delegates focus to delegatesFocus
         shadow_root.set_delegates_focus(delegates_focus);

--- a/components/script/dom/element/element.rs
+++ b/components/script/dom/element/element.rs
@@ -699,9 +699,7 @@ impl Element {
         // non-shadow-tree children of `self` no longer have layout boxes as they are no
         // longer in the flat tree.
         let node = self.upcast::<Node>();
-        if node.is_connected() {
-            node.remove_layout_boxes_from_subtree();
-        }
+        node.remove_layout_boxes_from_subtree();
 
         // Step 6. Set shadow's delegates focus to delegatesFocus
         shadow_root.set_delegates_focus(delegates_focus);

--- a/components/script/dom/shadowroot.rs
+++ b/components/script/dom/shadowroot.rs
@@ -614,15 +614,20 @@ impl VirtualMethods for ShadowRoot {
 
         shadow_root.set_flag(NodeFlags::IS_CONNECTED, context.tree_connected);
 
-        let context = BindContext::new(shadow_root, IsShadowTree::Yes);
+        let inner_context = BindContext::new(shadow_root, IsShadowTree::Yes);
 
-        // avoid iterate over the shadow root itself
-        for node in shadow_root.traverse_preorder(ShadowIncluding::Yes).skip(1) {
-            node.set_flag(NodeFlags::IS_CONNECTED, context.tree_connected);
+        // If we're already inside a shadow tree (i.e., we're a nested shadow root),
+        // skip iterating over descendants since they will be traversed by the outer
+        // traversal (which includes shadow trees).
+        if context.is_shadow_tree == IsShadowTree::No {
+            // avoid iterate over the shadow root itself
+            for node in shadow_root.traverse_preorder(ShadowIncluding::Yes).skip(1) {
+                node.set_flag(NodeFlags::IS_CONNECTED, inner_context.tree_connected);
 
-            // Out-of-document elements never have the descendants flag set
-            debug_assert!(!node.get_flag(NodeFlags::HAS_DIRTY_DESCENDANTS));
-            vtable_for(&node).bind_to_tree(cx, &context);
+                // Out-of-document elements never have the descendants flag set
+                debug_assert!(!node.get_flag(NodeFlags::HAS_DIRTY_DESCENDANTS));
+                vtable_for(&node).bind_to_tree(cx, &inner_context);
+            }
         }
     }
 

--- a/components/script/dom/shadowroot.rs
+++ b/components/script/dom/shadowroot.rs
@@ -616,18 +616,13 @@ impl VirtualMethods for ShadowRoot {
 
         let inner_context = BindContext::new(shadow_root, IsShadowTree::Yes);
 
-        // If we're already inside a shadow tree (i.e., we're a nested shadow root),
-        // skip iterating over descendants since they will be traversed by the outer
-        // traversal (which includes shadow trees).
-        if context.is_shadow_tree == IsShadowTree::No {
-            // avoid iterate over the shadow root itself
-            for node in shadow_root.traverse_preorder(ShadowIncluding::Yes).skip(1) {
-                node.set_flag(NodeFlags::IS_CONNECTED, inner_context.tree_connected);
+        // avoid iterate over the shadow root itself
+        for node in shadow_root.traverse_preorder(ShadowIncluding::No).skip(1) {
+            node.set_flag(NodeFlags::IS_CONNECTED, inner_context.tree_connected);
 
-                // Out-of-document elements never have the descendants flag set
-                debug_assert!(!node.get_flag(NodeFlags::HAS_DIRTY_DESCENDANTS));
-                vtable_for(&node).bind_to_tree(cx, &inner_context);
-            }
+            // Out-of-document elements never have the descendants flag set
+            debug_assert!(!node.get_flag(NodeFlags::HAS_DIRTY_DESCENDANTS));
+            vtable_for(&node).bind_to_tree(cx, &inner_context);
         }
     }
 

--- a/tests/wpt/tests/shadow-dom/build-deep-detached-shadow-then-append-text.html
+++ b/tests/wpt/tests/shadow-dom/build-deep-detached-shadow-then-append-text.html
@@ -1,0 +1,29 @@
+<!doctype html>
+<meta charset="utf-8">
+<title>Build detached deeply nested shadow tree, attach to document, then append text node</title>
+<link rel="author" title="Euclid Ye" href="mailto:yezhizhenjiakang@gmail.com">
+<link rel="help" href="https://github.com/servo/servo/issues/43998">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+
+<div id="X"></div>
+
+<script>
+test(() => {
+  const detachedRoot = document.createElement('div');
+  let currentContainer = detachedRoot;
+  const depth = 999;
+
+  for (let i = 0; i < depth; i++) {
+    const childHost = document.createElement('div');
+    const childShadow = childHost.attachShadow({ mode: 'open' });
+    currentContainer.appendChild(childHost);
+    currentContainer = childShadow;
+  }
+
+  document.getElementById('X').appendChild(detachedRoot);
+  currentContainer.appendChild(document.createTextNode('Hello!'));
+
+  assert_equals(currentContainer.textContent, 'Hello!');
+}, "Build detached deeply nested shadow tree, attaching to the document, then appending a text node should not hang or crash");
+</script>


### PR DESCRIPTION
During traversal, exclude shadow roots.

Analysis:
Each shadow root is processed twice:
- via host: Element::bind_to_tree()
-  Via iterator

In total, this would be
```math
\sum_{i=0}^{N-1} 2^i = 2^N - 1
```

Testing: Added a test.
Fixes: https://github.com/servo/servo/issues/43998