### PR TITLE
backport: release: Fix result check for cancelled workflows (#44017)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -68,7 +68,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Publish as latest (success)
-        if: ${{ !contains(needs.*.result, 'failure') && !contains(needs.*.result, 'cancelled') }}
+        if: ${{ !contains(needs.*.result, 'failure') && (!contains(needs.*.result, 'cancelled') && !cancelled()) }}
         run: |
           gh api \
             --method PATCH \
@@ -77,7 +77,7 @@ jobs:
             /repos/${RELEASE_REPO}/releases/${RELEASE_ID} \
             -F draft=false
       - name: Publish as latest (failure)
-        if: ${{ contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled') }}
+        if: ${{ contains(needs.*.result, 'failure') || (contains(needs.*.result, 'cancelled') || cancelled()) }}
         run: |
           gh api \
             --method PATCH \


### PR DESCRIPTION
This applies the changes from #44017 to the release/v0.1 branch, to improve the action reliability before the upcoming release.

-------

If the entire workflow was cancelled we also need to check for `cancelled()`. Simply checking needs.*.result is not sufficient - it was observed that the success branch was still entered when only checking needs.

Testing: Tested manually, by cancelling [this
workflow](https://github.com/servo/servo/actions/runs/24119740924/job/70371050119) which resulted in a draft release publish (failure branch)
