### PR TITLE
script/constellation: Rename and consolidate cross-`Document` focus messaging

### DIFF
--- a/components/constellation/constellation.rs
+++ b/components/constellation/constellation.rs
@@ -1908,15 +1908,20 @@ where
                     data,
                 );
             },
-            ScriptToConstellationMessage::Focus(focused_child_browsing_context_id, sequence) => {
-                self.handle_focus_msg(
+            ScriptToConstellationMessage::FocusAncestorBrowsingContextsForFocusingSteps(
+                focused_child_browsing_context_id,
+                sequence,
+            ) => {
+                self.handle_focus_ancestor_browsing_contexts_for_focusing_steps(
                     source_pipeline_id,
                     focused_child_browsing_context_id,
                     sequence,
                 );
             },
-            ScriptToConstellationMessage::FocusRemoteDocument(focused_browsing_context_id) => {
-                self.handle_focus_remote_document_msg(focused_browsing_context_id);
+            ScriptToConstellationMessage::FocusRemoteBrowsingContext(
+                focused_browsing_context_id,
+            ) => {
+                self.handle_focus_remote_browsing_context(focused_browsing_context_id);
             },
             ScriptToConstellationMessage::SetThrottledComplete(throttled) => {
                 self.handle_set_throttled_complete(source_pipeline_id, throttled);
@@ -4453,7 +4458,7 @@ where
     }
 
     #[servo_tracing::instrument(skip_all)]
-    fn handle_focus_msg(
+    fn handle_focus_ancestor_browsing_contexts_for_focusing_steps(
         &mut self,
         pipeline_id: PipelineId,
         focused_child_browsing_context_id: Option<BrowsingContextId>,
@@ -4493,23 +4498,20 @@ where
         self.focus_browsing_context(Some(pipeline_id), focused_browsing_context_id);
     }
 
-    fn handle_focus_remote_document_msg(&mut self, focused_browsing_context_id: BrowsingContextId) {
-        let pipeline_id = match self.browsing_contexts.get(&focused_browsing_context_id) {
-            Some(browsing_context) => browsing_context.pipeline_id,
-            None => return warn!("Browsing context {} not found", focused_browsing_context_id),
+    fn handle_focus_remote_browsing_context(&mut self, target: BrowsingContextId) {
+        let Some(browsing_context) = self.browsing_contexts.get(&target) else {
+            return warn!("{target:?} not found for focus message");
         };
-
-        // Ignore if its active document isn't fully active.
-        if self.get_activity(pipeline_id) != DocumentActivity::FullyActive {
-            debug!(
-                "Ignoring the remote focus request because pipeline {} of \
-                browsing context {} is not fully active",
-                pipeline_id, focused_browsing_context_id,
-            );
-            return;
+        let pipeline_id = browsing_context.pipeline_id;
+        let Some(pipeline) = self.pipelines.get(&pipeline_id) else {
+            return warn!("{pipeline_id:?} not found for focus message");
+        };
+        if let Err(error) = pipeline
+            .event_loop
+            .send(ScriptThreadMessage::FocusDocument(pipeline_id))
+        {
+            self.handle_send_error(pipeline_id, error);
         }
-
-        self.focus_browsing_context(None, focused_browsing_context_id);
     }
 
     /// Perform [the focusing steps][1] for the active document of
@@ -4610,7 +4612,10 @@ where
         // > substeps: [...]
         for &pipeline in old_focus_chain_pipelines.iter() {
             if Some(pipeline.id) != initiator_pipeline_id {
-                let msg = ScriptThreadMessage::Unfocus(pipeline.id, pipeline.focus_sequence);
+                let msg = ScriptThreadMessage::UnfocusDocumentAsPartOfFocusingSteps(
+                    pipeline.id,
+                    pipeline.focus_sequence,
+                );
                 trace!("Sending {:?} to {}", msg, pipeline.id);
                 if let Err(e) = pipeline.event_loop.send(msg) {
                     send_errors.push((pipeline.id, e));
@@ -4630,49 +4635,35 @@ where
             // Don't send a message to the browsing context that initiated this
             // focus operation. It already knows that it has gotten focus.
             if Some(pipeline.id) != initiator_pipeline_id {
-                let msg = if let Some(child_browsing_context_id) = child_browsing_context_id {
-                    // Focus the container element of `child_browsing_context_id`.
-                    ScriptThreadMessage::FocusIFrame(
+                if let Err(error) = pipeline.event_loop.send(
+                    ScriptThreadMessage::FocusDocumentAsPartOfFocusingSteps(
                         pipeline.id,
-                        child_browsing_context_id,
                         pipeline.focus_sequence,
-                    )
-                } else {
-                    // Focus the document.
-                    ScriptThreadMessage::FocusDocument(pipeline.id, pipeline.focus_sequence)
-                };
-                trace!("Sending {:?} to {}", msg, pipeline.id);
-                if let Err(e) = pipeline.event_loop.send(msg) {
-                    send_errors.push((pipeline.id, e));
+                        child_browsing_context_id,
+                    ),
+                ) {
+                    send_errors.push((pipeline.id, error));
                 }
-            } else {
-                trace!(
-                    "Not notifying {} - it's the initiator of this focus operation",
-                    pipeline.id
-                );
             }
             child_browsing_context_id = Some(pipeline.browsing_context_id);
         }
 
-        if let (Some(pipeline), Some(child_browsing_context_id)) =
-            (first_common_pipeline_in_chain, child_browsing_context_id)
-        {
+        if let Some(pipeline) = first_common_pipeline_in_chain {
             if Some(pipeline.id) != initiator_pipeline_id {
-                // Focus the container element of `child_browsing_context_id`.
-                let msg = ScriptThreadMessage::FocusIFrame(
-                    pipeline.id,
-                    child_browsing_context_id,
-                    pipeline.focus_sequence,
-                );
-                trace!("Sending {:?} to {}", msg, pipeline.id);
-                if let Err(e) = pipeline.event_loop.send(msg) {
-                    send_errors.push((pipeline.id, e));
+                if let Err(error) = pipeline.event_loop.send(
+                    ScriptThreadMessage::FocusDocumentAsPartOfFocusingSteps(
+                        pipeline.id,
+                        pipeline.focus_sequence,
+                        child_browsing_context_id,
+                    ),
+                ) {
+                    send_errors.push((pipeline.id, error));
                 }
             }
         }
 
-        for (pipeline_id, e) in send_errors {
-            self.handle_send_error(pipeline_id, e);
+        for (pipeline_id, error) in send_errors {
+            self.handle_send_error(pipeline_id, error);
         }
     }
 
@@ -4753,7 +4744,7 @@ where
                 let _ = response_sender.send(is_open);
             },
             WebDriverCommandMsg::FocusBrowsingContext(browsing_context_id) => {
-                self.handle_focus_remote_document_msg(browsing_context_id);
+                self.handle_focus_remote_browsing_context(browsing_context_id);
             },
             // TODO: This should use the ScriptThreadMessage::EvaluateJavaScript command
             WebDriverCommandMsg::ScriptCommand(browsing_context_id, cmd) => {
@@ -5094,9 +5085,16 @@ where
 
         // If the browsing context is focused, focus the document
         let msg = if is_focused {
-            ScriptThreadMessage::FocusDocument(pipeline_id, pipeline.focus_sequence)
+            ScriptThreadMessage::FocusDocumentAsPartOfFocusingSteps(
+                pipeline_id,
+                pipeline.focus_sequence,
+                None,
+            )
         } else {
-            ScriptThreadMessage::Unfocus(pipeline_id, pipeline.focus_sequence)
+            ScriptThreadMessage::UnfocusDocumentAsPartOfFocusingSteps(
+                pipeline_id,
+                pipeline.focus_sequence,
+            )
         };
         if let Err(e) = pipeline.event_loop.send(msg) {
             self.handle_send_error(pipeline_id, e);

--- a/components/constellation/tracing.rs
+++ b/components/constellation/tracing.rs
@@ -144,8 +144,10 @@ mod from_script {
                 Self::BroadcastStorageEvent(..) => target!("BroadcastStorageEvent"),
                 Self::ChangeRunningAnimationsState(..) => target!("ChangeRunningAnimationsState"),
                 Self::CreateCanvasPaintThread(..) => target!("CreateCanvasPaintThread"),
-                Self::Focus(..) => target!("Focus"),
-                Self::FocusRemoteDocument(..) => target!("FocusRemoteDocument"),
+                Self::FocusAncestorBrowsingContextsForFocusingSteps(..) => {
+                    target!("FocusAncestorBrowsingContextsForFocusingSteps")
+                },
+                Self::FocusRemoteBrowsingContext(..) => target!("FocusRemoteBrowsingContext"),
                 Self::GetTopForBrowsingContext(..) => target!("GetTopForBrowsingContext"),
                 Self::GetBrowsingContextInfo(..) => target!("GetBrowsingContextInfo"),
                 Self::GetDocumentOrigin(..) => target!("GetDocumentOrigin"),

--- a/components/script/dom/dissimilaroriginwindow.rs
+++ b/components/script/dom/dissimilaroriginwindow.rs
@@ -189,7 +189,14 @@ impl DissimilarOriginWindowMethods<crate::DomTypeHolder> for DissimilarOriginWin
 
     /// <https://html.spec.whatwg.org/multipage/#dom-window-focus>
     fn Focus(&self) {
-        self.window_proxy().focus();
+        let browsing_context_id = self.window_proxy.browsing_context_id();
+        debug!("Initiating a focus operation for {browsing_context_id:?}");
+        self.globalscope
+            .script_to_constellation_chan()
+            .send(ScriptToConstellationMessage::FocusRemoteBrowsingContext(
+                browsing_context_id,
+            ))
+            .unwrap();
     }
 
     /// <https://html.spec.whatwg.org/multipage/#dom-location>

--- a/components/script/dom/document/focus.rs
+++ b/components/script/dom/document/focus.rs
@@ -171,17 +171,6 @@ impl DocumentFocusHandler {
         self.focus_sequence.get()
     }
 
-    /// Update the local focus state accordingly after being notified that the
-    /// document's container is removed from the top-level browsing context's
-    /// focus chain (not considering system focus).
-    pub(crate) fn handle_container_unfocus(&self, can_gc: CanGc) {
-        if self.window.parent_info().is_none() {
-            warn!("Top-level document cannot be unfocused");
-            return;
-        }
-        self.focus(FocusOperation::Unfocus, FocusInitiator::Remote, can_gc);
-    }
-
     /// Reassign the focus context to the element that last requested focus during this
     /// transaction, or the document if no elements requested it.
     pub(crate) fn focus(
@@ -336,11 +325,12 @@ impl DocumentFocusHandler {
                         .unwrap_or(&"(none)"),
                 );
 
-                self.window
-                    .send_to_constellation(ScriptToConstellationMessage::Focus(
+                self.window.send_to_constellation(
+                    ScriptToConstellationMessage::FocusAncestorBrowsingContextsForFocusingSteps(
                         child_browsing_context_id,
                         sequence,
-                    ));
+                    ),
+                );
             },
             (false, false) => {
                 // Our `Document` doesn't have focus, and we intend to keep it

--- a/components/script/dom/window.rs
+++ b/components/script/dom/window.rs
@@ -145,6 +145,7 @@ use crate::dom::css::cssstyledeclaration::{
     CSSModificationAccess, CSSStyleDeclaration, CSSStyleOwner,
 };
 use crate::dom::customelementregistry::CustomElementRegistry;
+use crate::dom::document::focus::{FocusInitiator, FocusOperation, FocusableArea};
 use crate::dom::document::{
     AnimationFrameCallback, Document, SameOriginDescendantNavigablesIterator,
 };
@@ -1274,23 +1275,34 @@ impl WindowMethods<crate::DomTypeHolder> for Window {
     }
 
     /// <https://html.spec.whatwg.org/multipage/#dom-window-focus>
-    fn Focus(&self) {
-        // > 1. Let `current` be this `Window` object's browsing context.
-        // >
-        // > 2. If `current` is null, then return.
-        let current = match self.undiscarded_window_proxy() {
-            Some(proxy) => proxy,
-            None => return,
-        };
+    fn Focus(&self, cx: &mut js::context::JSContext) {
+        // Step 1. Let current be this's navigable.
+        // Note: We don't necessarily have access to the navigable, because it might
+        // be in another process.
 
-        // > 3. Run the focusing steps with `current`.
-        current.focus();
-
-        // > 4. If current is a top-level browsing context, user agents are
-        // >    encouraged to trigger some sort of notification to indicate to
-        // >    the user that the page is attempting to gain focus.
+        // Step 2. If current is null, then return.
         //
-        // TODO: Step 4
+        // Note: This is equivalent to there being an active `Document` and the WindowProxy
+        // not being discarded due to the parent <iframe> being removed from its `Document`.
+        let document = self.Document();
+        if !document.is_active() || self.undiscarded_window_proxy().is_none() {
+            return;
+        }
+
+        // Step 3. If the allow focus steps given current's active document return false, then return.
+        // TODO: Implement this.
+
+        // Step 4. Run the focusing steps with current.
+        document.focus_handler().focus(
+            FocusOperation::Focus(FocusableArea::Viewport),
+            FocusInitiator::Local,
+            CanGc::from_cx(cx),
+        );
+
+        // Step 5. If current is a top-level traversable, user agents are encouraged to trigger some
+        // sort of notification to indicate to the user that the page is attempting to gain focus.
+        //
+        // Note: We currently don't do this. Most browsers don't.
     }
 
     /// <https://html.spec.whatwg.org/multipage/#dom-window-blur>

--- a/components/script/dom/windowproxy.rs
+++ b/components/script/dom/windowproxy.rs
@@ -696,23 +696,6 @@ impl WindowProxy {
         result
     }
 
-    /// Run [the focusing steps] with this browsing context.
-    ///
-    /// [the focusing steps]: https://html.spec.whatwg.org/multipage/#focusing-steps
-    pub fn focus(&self) {
-        debug!(
-            "Requesting the constellation to initiate a focus operation for \
-            browsing context {}",
-            self.browsing_context_id()
-        );
-        self.global()
-            .script_to_constellation_chan()
-            .send(ScriptToConstellationMessage::FocusRemoteDocument(
-                self.browsing_context_id(),
-            ))
-            .unwrap();
-    }
-
     pub fn document_origin(&self) -> Option<String> {
         let pipeline_id = self.currently_active()?;
         let (result_sender, result_receiver) = generic_channel::channel().unwrap();

--- a/components/script/messaging.rs
+++ b/components/script/messaging.rs
@@ -76,9 +76,10 @@ impl MixedMessage {
                 ScriptThreadMessage::UpdatePipelineId(_, _, _, id, _) => Some(*id),
                 ScriptThreadMessage::UpdateHistoryState(id, ..) => Some(*id),
                 ScriptThreadMessage::RemoveHistoryStates(id, ..) => Some(*id),
-                ScriptThreadMessage::FocusIFrame(id, ..) => Some(*id),
-                ScriptThreadMessage::FocusDocument(id, ..) => Some(*id),
-                ScriptThreadMessage::Unfocus(id, ..) => Some(*id),
+
+                ScriptThreadMessage::FocusDocumentAsPartOfFocusingSteps(id, ..) => Some(*id),
+                ScriptThreadMessage::UnfocusDocumentAsPartOfFocusingSteps(id, ..) => Some(*id),
+                ScriptThreadMessage::FocusDocument(id) => Some(*id),
                 ScriptThreadMessage::WebDriverScriptCommand(id, ..) => Some(*id),
                 ScriptThreadMessage::TickAllAnimations(..) => None,
                 ScriptThreadMessage::WebFontLoaded(id) => Some(*id),

--- a/components/script/script_thread.rs
+++ b/components/script/script_thread.rs
@@ -1825,18 +1825,21 @@ impl ScriptThread {
             ScriptThreadMessage::RemoveHistoryStates(pipeline_id, history_states) => {
                 self.handle_remove_history_states(pipeline_id, history_states)
             },
-            ScriptThreadMessage::FocusIFrame(parent_pipeline_id, frame_id, sequence) => self
-                .handle_focus_iframe_msg(
-                    parent_pipeline_id,
-                    frame_id,
-                    sequence,
-                    CanGc::from_cx(cx),
-                ),
-            ScriptThreadMessage::FocusDocument(pipeline_id, sequence) => {
-                self.handle_focus_document_msg(pipeline_id, sequence, CanGc::from_cx(cx))
+            ScriptThreadMessage::FocusDocumentAsPartOfFocusingSteps(
+                pipeline_id,
+                sequence,
+                iframe_browsing_context_id,
+            ) => self.handle_focus_document_as_part_of_focusing_steps(
+                cx,
+                pipeline_id,
+                sequence,
+                iframe_browsing_context_id,
+            ),
+            ScriptThreadMessage::UnfocusDocumentAsPartOfFocusingSteps(pipeline_id, sequence) => {
+                self.handle_unfocus_document_as_part_of_focusing_steps(cx, pipeline_id, sequence);
             },
-            ScriptThreadMessage::Unfocus(pipeline_id, sequence) => {
-                self.handle_unfocus_msg(pipeline_id, sequence, CanGc::from_cx(cx))
+            ScriptThreadMessage::FocusDocument(pipeline_id) => {
+                self.handle_focus_document(cx, pipeline_id);
             },
             ScriptThreadMessage::WebDriverScriptCommand(pipeline_id, msg) => {
                 self.handle_webdriver_msg(pipeline_id, msg, cx)
@@ -2845,101 +2848,87 @@ impl ScriptThread {
         warn!("change of activity sent to nonexistent pipeline");
     }
 
-    fn handle_focus_iframe_msg(
+    fn handle_focus_document_as_part_of_focusing_steps(
         &self,
-        parent_pipeline_id: PipelineId,
-        browsing_context_id: BrowsingContextId,
+        cx: &mut js::context::JSContext,
+        pipeline_id: PipelineId,
         sequence: FocusSequenceNumber,
-        can_gc: CanGc,
+        browsing_context_id: Option<BrowsingContextId>,
     ) {
-        let document = self
-            .documents
-            .borrow()
-            .find_document(parent_pipeline_id)
-            .unwrap();
-
-        let Some(iframe_element) = ({
-            // Enclose `iframes()` call and create a new root to avoid retaining
-            // borrow.
-            let iframes = document.iframes();
-            iframes
-                .get(browsing_context_id)
-                .map(|iframe| DomRoot::from_ref(iframe.element.upcast::<Node>()))
-        }) else {
+        let Some(document) = self.documents.borrow().find_document(pipeline_id) else {
+            warn!("Unknown {pipeline_id:?} for FocusDocumentAsPartOfFocusingSteps message.");
             return;
         };
 
-        if document.focus_handler().focus_sequence() > sequence {
+        let focus_handler = document.focus_handler();
+        if focus_handler.focus_sequence() > sequence {
             debug!(
-                "Disregarding the FocusIFrame message because the contained sequence number is \
-                too old ({:?} < {:?})",
-                sequence,
-                document.focus_handler().focus_sequence()
+                "Disregarding the FocusDocumentAsPartOfFocusingSteps message because \
+                the contained sequence number is too old ({sequence:?} < {:?})",
+                focus_handler.focus_sequence()
             );
             return;
         }
 
-        if let Some(focusable_area) = iframe_element.get_the_focusable_area() {
-            iframe_element.owner_document().focus_handler().focus(
-                FocusOperation::Focus(focusable_area),
-                FocusInitiator::Remote,
-                can_gc,
-            );
-        }
+        let focusable_area = browsing_context_id
+            .and_then(|browsing_context_id| {
+                document
+                    .iframes()
+                    .get(browsing_context_id)
+                    .map(|iframe| FocusableArea::Node {
+                        node: DomRoot::from_ref(iframe.element.upcast()),
+                        kind: Default::default(),
+                    })
+            })
+            .unwrap_or(FocusableArea::Viewport);
+
+        focus_handler.focus(
+            FocusOperation::Focus(focusable_area),
+            FocusInitiator::Remote,
+            CanGc::from_cx(cx),
+        );
     }
 
-    fn handle_focus_document_msg(
-        &self,
-        pipeline_id: PipelineId,
-        sequence: FocusSequenceNumber,
-        can_gc: CanGc,
-    ) {
-        if let Some(document) = self.documents.borrow().find_document(pipeline_id) {
-            let focus_handler = document.focus_handler();
-            if focus_handler.focus_sequence() > sequence {
-                debug!(
-                    "Disregarding the FocusDocument message because the contained sequence number is \
-                    too old ({:?} < {:?})",
-                    sequence,
-                    focus_handler.focus_sequence()
-                );
-                return;
-            }
-            focus_handler.focus(
-                FocusOperation::Focus(FocusableArea::Viewport),
-                FocusInitiator::Remote,
-                can_gc,
-            );
-        } else {
-            warn!(
-                "Couldn't find document by pipleline_id:{pipeline_id:?} when handle_focus_document_msg."
-            );
-        }
+    fn handle_focus_document(&self, cx: &mut js::context::JSContext, pipeline_id: PipelineId) {
+        let Some(document) = self.documents.borrow().find_document(pipeline_id) else {
+            warn!("Unknown {pipeline_id:?} for FocusDocument message.");
+            return;
+        };
+        document.window().Focus(cx);
     }
 
-    fn handle_unfocus_msg(
+    fn handle_unfocus_document_as_part_of_focusing_steps(
         &self,
+        cx: &mut js::context::JSContext,
         pipeline_id: PipelineId,
         sequence: FocusSequenceNumber,
-        can_gc: CanGc,
     ) {
-        if let Some(document) = self.documents.borrow().find_document(pipeline_id) {
-            let focus_handler = document.focus_handler();
-            if focus_handler.focus_sequence() > sequence {
-                debug!(
-                    "Disregarding the Unfocus message because the contained sequence number is \
-                    too old ({:?} < {:?})",
-                    sequence,
-                    focus_handler.focus_sequence()
-                );
-                return;
-            }
-            focus_handler.handle_container_unfocus(can_gc);
-        } else {
-            warn!(
-                "Couldn't find document by pipleline_id:{pipeline_id:?} when handle_unfocus_msg."
-            );
+        let Some(document) = self.documents.borrow().find_document(pipeline_id) else {
+            warn!("Unknown {pipeline_id:?} for UnfocusDocumentAsPartOfFocusingSteps");
+            return;
+        };
+
+        // We ignore unfocus requests for top-level `Document`s as they *always* have focus.
+        // Note that this does not take into account system focus.
+        if document.window().is_top_level() {
+            return;
         }
+
+        let focus_handler = document.focus_handler();
+        if focus_handler.focus_sequence() > sequence {
+            debug!(
+                "Disregarding the Unfocus message because the contained sequence number is \
+                too old ({:?} < {:?})",
+                sequence,
+                focus_handler.focus_sequence()
+            );
+            return;
+        }
+        focus_handler.focus(
+            FocusOperation::Unfocus,
+            FocusInitiator::Remote,
+            CanGc::from_cx(cx),
+        );
     }
 
     #[expect(clippy::too_many_arguments)]

--- a/components/script_bindings/codegen/Bindings.conf
+++ b/components/script_bindings/codegen/Bindings.conf
@@ -870,7 +870,20 @@ DOMInterfaces = {
     'canGc': ['CookieStore', 'FetchLater', 'GetVisualViewport', 'ReportError', 'Screen', 'StructuredClone'],
     'additionalTraits': ['crate::interfaces::WindowHelpers'],
     'realm': ['CreateImageBitmap', 'CreateImageBitmap_', 'WebdriverCallback', 'GetOpener', 'Fetch'],
-    'cx': ['GetLocalStorage', 'GetSessionStorage', 'Location', 'Open', 'PostMessage', 'PostMessage_', 'SetInterval', 'SetTimeout', 'Stop', 'TrustedTypes', 'WebdriverException']
+    'cx': [
+        'Focus',
+        'GetLocalStorage',
+        'GetSessionStorage', 
+        'Location',
+        'Open',
+        'PostMessage',
+        'PostMessage_',
+        'SetInterval',
+        'SetTimeout',
+        'Stop',
+        'TrustedTypes',
+        'WebdriverException'
+    ]
 },
 
 'WindowProxy' : {

--- a/components/shared/constellation/from_script_message.rs
+++ b/components/shared/constellation/from_script_message.rs
@@ -614,9 +614,10 @@ pub enum ScriptToConstellationMessage {
     ///
     /// The second field is a sequence number that the constellation should use
     /// when sending a focus-related message to the sender pipeline next time.
-    Focus(Option<BrowsingContextId>, FocusSequenceNumber),
-    /// Requests the constellation to focus the specified browsing context.
-    FocusRemoteDocument(BrowsingContextId),
+    FocusAncestorBrowsingContextsForFocusingSteps(Option<BrowsingContextId>, FocusSequenceNumber),
+    /// Have the Constellation trigger a remote call to `Focus` on the `Window` of the given
+    /// [`BrowsingContextId`].
+    FocusRemoteBrowsingContext(BrowsingContextId),
     /// Get the top-level browsing context info for a given browsing context.
     GetTopForBrowsingContext(BrowsingContextId, GenericSender<Option<WebViewId>>),
     /// Get the browsing context id of the browsing context in which pipeline is

--- a/components/shared/script/lib.rs
+++ b/components/shared/script/lib.rs
@@ -226,17 +226,19 @@ pub enum ScriptThreadMessage {
     UpdateHistoryState(PipelineId, Option<HistoryStateId>, ServoUrl),
     /// Removes inaccesible history states.
     RemoveHistoryStates(PipelineId, Vec<HistoryStateId>),
-    /// Set an iframe to be focused. Used when an element in an iframe gains focus.
-    /// PipelineId is for the parent, BrowsingContextId is for the nested browsing context
-    FocusIFrame(PipelineId, BrowsingContextId, FocusSequenceNumber),
-    /// Focus the document. Used when the container gains focus.
-    FocusDocument(PipelineId, FocusSequenceNumber),
-    /// Notifies that the document's container (e.g., an iframe) is not included
-    /// in the top-level browsing context's focus chain (not considering system
-    /// focus) anymore.
-    ///
-    /// Obviously, this message is invalid for a top-level document.
-    Unfocus(PipelineId, FocusSequenceNumber),
+    /// Focus a `Document` as part of the focusing steps which focuses all parent `Document`s of a
+    /// newly focused `<iframe>`. Note that this is not used for the `Document` and `Element` that
+    /// is gaining focus as that is handled locally in the originating `ScriptThread`.
+    FocusDocumentAsPartOfFocusingSteps(PipelineId, FocusSequenceNumber, Option<BrowsingContextId>),
+    /// Unfocus a `Document` as part of the focusing steps which unfocuses all parent `Document`s of an
+    /// `<iframe>` losing focus. This does not do anything for a top-level `Document`, which can never
+    /// lose focus (apart from losing system focus, which is a separate concept).
+    UnfocusDocumentAsPartOfFocusingSteps(PipelineId, FocusSequenceNumber),
+    /// Focus a `Document` and run the focusing steps. This is used when calling the DOM `focus()`
+    /// API on a remote `Window` as well as from WebDriver. The difference between this and
+    /// `FocusDocumentAsPartOfFocusingSteps` is that this version actually does run the focusing
+    /// steps and may result in blur and focus events firing up the frame tree.
+    FocusDocument(PipelineId),
     /// Passes a webdriver command to the script thread for execution
     WebDriverScriptCommand(PipelineId, WebDriverScriptCommand),
     /// Notifies script thread that all animations are done


### PR DESCRIPTION
There are two times that Servo needs to ask other `Document`s to either
focus or blur.

- During processing of the "focusing steps". When a new element gains
  focus this may cause focus to be lost or gained in parent `<iframe>`s.
- When calling `focus()` on a DOM Window from another origin.

In both of these cases we need to request that a `Document` gain or lose
focus via the Constellation, but in the second case we may have a
`BrowsingContextId` of the `<iframe>` gaining focus and a
`FocusSequence`. This change splits those cases into two kinds of
messages.

Finally, run the entire focusing steps when calling `window.focus()`
instead of going to the constellation immediately. This will be
important in a followup changes where messaging order is made more
consistent.

Testing: This should not change behavior so is covered by existing tests.
