### PR TITLE
script: Further implement fontsize command

### DIFF
--- a/components/script/dom/execcommand/basecommand.rs
+++ b/components/script/dom/execcommand/basecommand.rs
@@ -2,24 +2,26 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-use servo_arc::Arc as ServoArc;
-use style::properties::declaration_block::PropertyDeclarationBlock;
+use script_bindings::inheritance::Castable;
+use style::properties::PropertyDeclarationId;
 use style::properties::generated::LonghandId;
-use style::properties::{ComputedValues, PropertyDeclarationId};
 use style_traits::ToCss;
 
 use crate::dom::bindings::codegen::Bindings::CSSStyleDeclarationBinding::CSSStyleDeclarationMethods;
 use crate::dom::bindings::codegen::Bindings::HTMLElementBinding::HTMLElementMethods;
+use crate::dom::bindings::codegen::Bindings::HTMLFontElementBinding::HTMLFontElementMethods;
 use crate::dom::bindings::str::DOMString;
 use crate::dom::document::Document;
 use crate::dom::element::Element;
 use crate::dom::execcommand::commands::defaultparagraphseparator::execute_default_paragraph_separator_command;
 use crate::dom::execcommand::commands::delete::execute_delete_command;
 use crate::dom::execcommand::commands::fontsize::{
-    execute_fontsize_command, value_for_fontsize_command,
+    execute_fontsize_command, font_size_loosely_equivalent, value_for_fontsize_command,
 };
 use crate::dom::execcommand::commands::stylewithcss::execute_style_with_css_command;
 use crate::dom::html::htmlelement::HTMLElement;
+use crate::dom::html::htmlfontelement::HTMLFontElement;
+use crate::dom::node::{Node, NodeTraits, ShadowIncluding};
 use crate::dom::selection::Selection;
 use crate::script_runtime::CanGc;
 
@@ -47,30 +49,63 @@ pub(crate) enum CssPropertyName {
     FontSize,
     FontWeight,
     FontStyle,
+    TextDecorationLine,
 }
 
 impl CssPropertyName {
-    fn resolved_value_for_node(&self, style: ServoArc<ComputedValues>) -> String {
-        match self {
-            CssPropertyName::BackgroundColor => style.clone_background_color().to_css_string(),
-            CssPropertyName::FontSize => style.clone_font_size().to_css_string(),
-            CssPropertyName::FontWeight => style.clone_font_weight().to_css_string(),
-            CssPropertyName::FontStyle => style.clone_font_style().to_css_string(),
-        }
+    fn resolved_value_for_node(&self, element: &Element) -> Option<DOMString> {
+        let style = element.style()?;
+
+        Some(
+            match self {
+                CssPropertyName::BackgroundColor => style.clone_background_color().to_css_string(),
+                CssPropertyName::FontSize => {
+                    // Font size is special, in that it can't use the resolved styles to compute
+                    // values. That's because it is influenced by other factors as well, and it
+                    // should also take into account size attributes of font elements.
+                    //
+                    // Therefore, we do a manual traversal up the chain to mimic what style
+                    // resolution would have done. This also allows us to later check for
+                    // loose equivalence for font elements, since we would return the size as an
+                    // integer, without a size indicator (e.g. `px`).
+                    return element
+                        .upcast::<Node>()
+                        .inclusive_ancestors(ShadowIncluding::No)
+                        .find_map(|ancestor| {
+                            if let Some(ancestor_font) = ancestor.downcast::<HTMLFontElement>() {
+                                Some(ancestor_font.Size())
+                            } else {
+                                self.value_set_for_style(ancestor.downcast::<Element>()?)
+                            }
+                        });
+                },
+                CssPropertyName::FontWeight => style.clone_font_weight().to_css_string(),
+                CssPropertyName::FontStyle => style.clone_font_style().to_css_string(),
+                CssPropertyName::TextDecorationLine => {
+                    style.clone_text_decoration_line().to_css_string()
+                },
+            }
+            .into(),
+        )
     }
 
     /// Retrieves a respective css longhand value from the style declarations of an
     /// element. Note that this is different than the computed values, since this is
     /// only relevant when the author specified rules on the specific element.
-    pub(crate) fn value_set_for_style(
-        &self,
-        style: &PropertyDeclarationBlock,
-    ) -> Option<DOMString> {
+    pub(crate) fn value_set_for_style(&self, element: &Element) -> Option<DOMString> {
+        let style_attribute = element.style_attribute().borrow();
+        let declarations = style_attribute.as_ref()?;
+        let document = element.owner_document();
+        let shared_lock = document.style_shared_lock();
+        let read_lock = shared_lock.read();
+        let style = declarations.read_with(&read_lock);
+
         let longhand_id = match self {
             CssPropertyName::BackgroundColor => LonghandId::BackgroundColor,
             CssPropertyName::FontSize => LonghandId::FontSize,
             CssPropertyName::FontWeight => LonghandId::FontWeight,
             CssPropertyName::FontStyle => LonghandId::FontStyle,
+            CssPropertyName::TextDecorationLine => LonghandId::TextDecorationLine,
         };
         style
             .get(PropertyDeclarationId::Longhand(longhand_id))
@@ -87,6 +122,7 @@ impl CssPropertyName {
             CssPropertyName::FontSize => "font-size",
             CssPropertyName::FontWeight => "font-weight",
             CssPropertyName::FontStyle => "font-style",
+            CssPropertyName::TextDecorationLine => "text-decoration-line",
         }
         .into()
     }
@@ -100,6 +136,26 @@ impl CssPropertyName {
         let style = element.Style(CanGc::from_cx(cx));
 
         let _ = style.SetProperty(cx, self.property_name(), new_value, "".into());
+    }
+
+    pub(crate) fn remove_from_element(
+        &self,
+        cx: &mut js::context::JSContext,
+        element: &HTMLElement,
+    ) {
+        let _ = element
+            .Style(CanGc::from_cx(cx))
+            .RemoveProperty(cx, self.property_name());
+    }
+
+    pub(crate) fn value_for_element(
+        &self,
+        cx: &mut js::context::JSContext,
+        element: &HTMLElement,
+    ) -> DOMString {
+        element
+            .Style(CanGc::from_cx(cx))
+            .GetPropertyValue(self.property_name())
     }
 }
 
@@ -221,12 +277,18 @@ impl CommandName {
         second: Option<&DOMString>,
     ) -> bool {
         // > Two quantities are loosely equivalent values for a command if either they are equivalent values for the command,
-        self.are_equivalent_values(first, second)
+        if self.are_equivalent_values(first, second) {
+            return true;
+        }
         // > or if the command is the fontSize command;
         // > one of the quantities is one of "x-small", "small", "medium", "large", "x-large", "xx-large", or "xxx-large";
         // > and the other quantity is the resolved value of "font-size" on a font element whose size attribute
         // > has the corresponding value set ("1" through "7" respectively).
-        // TODO
+        if let (CommandName::FontSize, Some(first), Some(second)) = (self, first, second) {
+            font_size_loosely_equivalent(first, second)
+        } else {
+            false
+        }
     }
 
     /// <https://w3c.github.io/editing/docs/execCommand/#relevant-css-property>
@@ -244,9 +306,7 @@ impl CommandName {
 
     pub(crate) fn resolved_value_for_node(&self, element: &Element) -> Option<DOMString> {
         let property = self.relevant_css_property()?;
-        element
-            .style()
-            .map(|style| property.resolved_value_for_node(style).into())
+        property.resolved_value_for_node(element)
     }
 
     pub(crate) fn is_enabled_in_plaintext_only_state(&self) -> bool {

--- a/components/script/dom/execcommand/commands/fontsize.rs
+++ b/components/script/dom/execcommand/commands/fontsize.rs
@@ -7,6 +7,7 @@ use script_bindings::inheritance::Castable;
 use style::attr::parse_integer;
 
 use crate::dom::ShadowIncluding;
+use crate::dom::bindings::codegen::Bindings::AttrBinding::AttrMethods;
 use crate::dom::bindings::codegen::Bindings::DocumentBinding::DocumentMethods;
 use crate::dom::bindings::root::DomRoot;
 use crate::dom::bindings::str::DOMString;
@@ -23,15 +24,13 @@ use crate::script_runtime::CanGc;
 
 impl HTMLFontElement {
     fn font_size_if_size_matches(&self, should_match_size: i32) -> Option<i32> {
-        if should_match_size !=
-            self.upcast::<Element>()
-                .get_int_attribute(&local_name!("size"), 0)
-        {
-            return None;
-        }
-        self.upcast::<Node>()
-            .style()
-            .map(|style| style.clone_font().font_size.computed_size().px() as i32)
+        let attribute = self
+            .upcast::<Element>()
+            .get_attribute(&local_name!("size"))?;
+        let value = attribute.Value();
+        let size = value.parse::<i32>().ok()?;
+
+        Some(size).filter(|size| *size == should_match_size)
     }
 }
 
@@ -165,4 +164,26 @@ pub(crate) fn value_for_fontsize_command(
     let pixel_size = command_value.parse::<i32>().ok()?;
     // Step 3. Return the legacy font size for pixel size.
     Some(legacy_font_size_for(pixel_size, document))
+}
+
+fn normalize_font_string(str_: &str) -> &str {
+    match str_ {
+        "1" => "x-small",
+        "2" => "small",
+        "3" => "medium",
+        "4" => "large",
+        "5" => "x-large",
+        "6" => "xx-large",
+        "7" => "xxx-large",
+        _ => str_,
+    }
+}
+
+/// Handles fontsize command part of
+/// <https://w3c.github.io/editing/docs/execCommand/#loosely-equivalent-values>
+pub(crate) fn font_size_loosely_equivalent(first: &DOMString, second: &DOMString) -> bool {
+    // > one of the quantities is one of "x-small", "small", "medium", "large", "x-large", "xx-large", or "xxx-large";
+    // > and the other quantity is the resolved value of "font-size" on a font element whose size attribute
+    // > has the corresponding value set ("1" through "7" respectively).
+    normalize_font_string(&first.str()) == second || first == normalize_font_string(&second.str())
 }

--- a/components/script/dom/execcommand/contenteditable.rs
+++ b/components/script/dom/execcommand/contenteditable.rs
@@ -32,6 +32,7 @@ use crate::dom::execcommand::basecommand::{CommandName, CssPropertyName};
 use crate::dom::html::htmlanchorelement::HTMLAnchorElement;
 use crate::dom::html::htmlbrelement::HTMLBRElement;
 use crate::dom::html::htmlelement::HTMLElement;
+use crate::dom::html::htmlfontelement::HTMLFontElement;
 use crate::dom::html::htmlimageelement::HTMLImageElement;
 use crate::dom::html::htmllielement::HTMLLIElement;
 use crate::dom::html::htmltablecellelement::HTMLTableCellElement;
@@ -219,43 +220,104 @@ impl HTMLElement {
     fn local_name(&self) -> &str {
         self.upcast::<Element>().local_name()
     }
-}
 
-impl Element {
     /// <https://w3c.github.io/editing/docs/execCommand/#clear-the-value>
-    fn clear_the_value(&self) {
+    fn clear_the_value(&self, cx: &mut js::context::JSContext, command: &CommandName) {
         // Step 1. Let command be the current command.
-        // TODO
+        //
+        // Passed in as argument
+
+        let node = self.upcast::<Node>();
+        let element = self.upcast::<Element>();
+
         // Step 2. If element is not editable, return the empty list.
-        // TODO
+        if !node.is_editable() {
+            return;
+        }
         // Step 3. If element's specified command value for command is null,
         // return the empty list.
-        // TODO
+        if element.specified_command_value(command).is_none() {
+            return;
+        }
         // Step 4. If element is a simple modifiable element:
-        // TODO
-        // Step 5. If command is "strikethrough", and element has a style attribute
-        // that sets "text-decoration" to some value containing "line-through",
-        // delete "line-through" from the value.
-        // TODO
-        // Step 6. If command is "underline", and element has a style attribute that
-        // sets "text-decoration" to some value containing "underline", delete "underline" from the value.
-        // TODO
+        if element.is_simple_modifiable_element() {
+            // Step 4.1. Let children be the children of element.
+            // Step 4.2. For each child in children, insert child into element's parent immediately before element, preserving ranges.
+            let element_parent = node.GetParentNode().expect("Must always have a parent");
+            for child in node.children() {
+                if element_parent.InsertBefore(cx, &child, Some(node)).is_err() {
+                    unreachable!("Must always be able to insert");
+                }
+            }
+            // Step 4.3. Remove element from its parent.
+            node.remove_self(cx);
+            // Step 4.4. Return children.
+            return;
+        }
+        match command {
+            // Step 5. If command is "strikethrough", and element has a style attribute
+            // that sets "text-decoration" to some value containing "line-through",
+            // delete "line-through" from the value.
+            CommandName::Strikethrough => {
+                let property = CssPropertyName::TextDecorationLine;
+                if property.value_for_element(cx, self) == "line-through" {
+                    // TODO: Only remove line-through
+                    property.remove_from_element(cx, self);
+                }
+            },
+            // Step 6. If command is "underline", and element has a style attribute that
+            // sets "text-decoration" to some value containing "underline", delete "underline" from the value.
+            CommandName::Underline => {
+                let property = CssPropertyName::TextDecorationLine;
+                if property.value_for_element(cx, self) == "underline" {
+                    // TODO: Only remove underline
+                    property.remove_from_element(cx, self);
+                }
+            },
+            _ => {},
+        }
         // Step 7. If the relevant CSS property for command is not null,
         // unset that property of element.
-        // TODO
+        if let Some(property) = command.relevant_css_property() {
+            property.remove_from_element(cx, self);
+        }
         // Step 8. If element is a font element:
-        // TODO
+        if self.is::<HTMLFontElement>() {
+            match command {
+                // Step 8.1. If command is "foreColor", unset element's color attribute, if set.
+                CommandName::ForeColor => {
+                    element.remove_attribute_by_name(&local_name!("color"), CanGc::from_cx(cx));
+                },
+                // Step 8.2. If command is "fontName", unset element's face attribute, if set.
+                CommandName::FontName => {
+                    element.remove_attribute_by_name(&local_name!("face"), CanGc::from_cx(cx));
+                },
+                // Step 8.3. If command is "fontSize", unset element's size attribute, if set.
+                CommandName::FontSize => {
+                    element.remove_attribute_by_name(&local_name!("size"), CanGc::from_cx(cx));
+                },
+                _ => {},
+            }
+        }
         // Step 9. If element is an a element and command is "createLink" or "unlink",
         // unset the href property of element.
-        // TODO
+        if self.is::<HTMLAnchorElement>() &&
+            matches!(command, CommandName::CreateLink | CommandName::Unlink)
+        {
+            element.remove_attribute_by_name(&local_name!("href"), CanGc::from_cx(cx));
+        }
         // Step 10. If element's specified command value for command is null,
         // return the empty list.
-        // TODO
+        if element.specified_command_value(command).is_none() {
+            // TODO
+        }
         // Step 11. Set the tag name of element to "span",
         // and return the one-node list consisting of the result.
         // TODO
     }
+}
 
+impl Element {
     /// <https://w3c.github.io/editing/docs/execCommand/#specified-command-value>
     pub(crate) fn specified_command_value(&self, command: &CommandName) -> Option<DOMString> {
         match command {
@@ -290,18 +352,7 @@ impl Element {
         let property = command.relevant_css_property()?;
         // Step 10. If element has a style attribute set, and that attribute has the effect of setting property,
         // return the value that it sets property to.
-        if let Some(value) = self
-            .style_attribute()
-            .borrow()
-            .as_ref()
-            .and_then(|declarations| {
-                let document = self.owner_document();
-                let shared_lock = document.style_shared_lock();
-                let read_lock = shared_lock.read();
-                let declarations = declarations.read_with(&read_lock);
-                property.value_set_for_style(declarations)
-            })
-        {
+        if let Some(value) = property.value_set_for_style(self) {
             return Some(value);
         }
         // Step 11. If element is a font element that has an attribute whose effect is to create a presentational hint for property,
@@ -325,6 +376,46 @@ impl Element {
             // Step 13. Return null.
             _ => None,
         }
+    }
+
+    /// <https://w3c.github.io/editing/docs/execCommand/#simple-modifiable-element>
+    fn is_simple_modifiable_element(&self) -> bool {
+        // > It is an a, b, em, font, i, s, span, strike, strong, sub, sup, or u element with no attributes.
+        // TODO
+
+        // > It is an a, b, em, font, i, s, span, strike, strong, sub, sup, or u element
+        // > with exactly one attribute, which is style,
+        // > which sets no CSS properties (including invalid or unrecognized properties).
+        // TODO
+
+        // > It is an a element with exactly one attribute, which is href.
+        // TODO
+
+        // > It is a font element with exactly one attribute, which is either color, face, or size.
+        // TODO
+
+        // > It is a b or strong element with exactly one attribute, which is style,
+        // > and the style attribute sets exactly one CSS property
+        // > (including invalid or unrecognized properties), which is "font-weight".
+        // TODO
+
+        // > It is an i or em element with exactly one attribute, which is style,
+        // > and the style attribute sets exactly one CSS property (including invalid or unrecognized properties),
+        // > which is "font-style".
+        // TODO
+
+        // > It is an a, font, or span element with exactly one attribute, which is style,
+        // > and the style attribute sets exactly one CSS property (including invalid or unrecognized properties),
+        // > and that property is not "text-decoration".
+        // TODO
+
+        // > It is an a, font, s, span, strike, or u element with exactly one attribute,
+        // > which is style, and the style attribute sets exactly one CSS property
+        // > (including invalid or unrecognized properties), which is "text-decoration",
+        // > which is set to "line-through" or "underline" or "overline" or "none".
+        // TODO
+
+        false
     }
 }
 
@@ -971,7 +1062,9 @@ impl Node {
             let children = current_ancestor_node.children();
             // Step 11.5. If the specified command value of current ancestor for command is not null, clear the value of current ancestor.
             if has_command_value {
-                current_ancestor.clear_the_value();
+                if let Some(html_element) = current_ancestor.downcast::<HTMLElement>() {
+                    html_element.clear_the_value(cx, command);
+                }
             }
             // Step 11.6. For every child in children:
             for child in children {
@@ -1011,17 +1104,17 @@ impl Node {
         // That's command
 
         // Step 2. If node's parent is null, abort this algorithm.
-        let Some(parent_node) = self.GetParentNode() else {
+        if self.GetParentNode().is_none() {
             return;
-        };
+        }
         // Step 3. If new value is null, abort this algorithm.
         let Some(new_value) = new_value else {
             return;
         };
         // Step 4. If node is an allowed child of "span":
         if is_allowed_child(
-            NodeOrString::String("span".to_owned()),
             NodeOrString::Node(DomRoot::from_ref(self)),
+            NodeOrString::String("span".to_owned()),
         ) {
             // Step 4.1. Reorder modifiable descendants of node's previousSibling.
             // TODO
@@ -1127,7 +1220,9 @@ impl Node {
         // Step 15. If new parent is null, let new parent be the result of calling createElement("span") on the ownerDocument of node.
         let new_parent = new_parent.unwrap_or_else(|| document.create_element(cx, "span"));
         // Step 16. Insert new parent in node's parent before node.
-        if parent_node
+        if self
+            .GetParentNode()
+            .expect("Must always have a parent")
             .InsertBefore(cx, new_parent.upcast(), Some(self))
             .is_err()
         {
@@ -3072,9 +3167,9 @@ impl SelectionExecCommandSupport for Selection {
         // Step 5. Let element list be all editable Elements effectively contained in the active range.
         // Step 6. For each element in element list, clear the value of element.
         active_range.for_each_effectively_contained_child(|child| {
-            if child.upcast::<Node>().is_editable() {
-                if let Some(element_child) = child.downcast::<Element>() {
-                    element_child.clear_the_value();
+            if child.is_editable() {
+                if let Some(element_child) = child.downcast::<HTMLElement>() {
+                    element_child.clear_the_value(cx, &command);
                 }
             }
         });
@@ -3086,8 +3181,8 @@ impl SelectionExecCommandSupport for Selection {
                 child.push_down_values(cx, &command, new_value.clone());
                 // Step 8.2. If node is an allowed child of "span", force the value of node.
                 if is_allowed_child(
-                    NodeOrString::String("span".to_owned()),
                     NodeOrString::Node(DomRoot::from_ref(child)),
+                    NodeOrString::String("span".to_owned()),
                 ) {
                     child.force_the_value(cx, &command, new_value.as_ref());
                 }

--- a/tests/wpt/meta/editing/run/fontsize.html.ini
+++ b/tests/wpt/meta/editing/run/fontsize.html.ini
@@ -5,9 +5,6 @@
   [[["fontsize","4"\]\] "foo[\]bar" queryCommandValue("fontsize") after]
     expected: FAIL
 
-  [[["stylewithcss","true"\],["fontsize","4"\]\] "<p>[foo</p> <p>bar\]</p>" compare innerHTML]
-    expected: FAIL
-
   [[["stylewithcss","true"\],["fontsize","4"\]\] "<p>[foo</p> <p>bar\]</p>" queryCommandValue("fontsize") before]
     expected: FAIL
 
@@ -59,9 +56,6 @@
   [[["stylewithcss","false"\],["fontsize","4"\]\] "<p>[foo</p><p> <span>bar</span> </p><p>baz\]</p>" queryCommandValue("fontsize") after]
     expected: FAIL
 
-  [[["stylewithcss","true"\],["fontsize","4"\]\] "<p>[foo<p><br><p>bar\]" compare innerHTML]
-    expected: FAIL
-
   [[["stylewithcss","true"\],["fontsize","4"\]\] "<p>[foo<p><br><p>bar\]" queryCommandValue("fontsize") before]
     expected: FAIL
 
@@ -107,9 +101,6 @@
   [[["fontsize","4"\]\] "<span>foo[</span><span>\]bar</span>" queryCommandValue("fontsize") after]
     expected: FAIL
 
-  [[["stylewithcss","true"\],["fontsize","4"\]\] "foo[bar\]baz" compare innerHTML]
-    expected: FAIL
-
   [[["stylewithcss","true"\],["fontsize","4"\]\] "foo[bar\]baz" queryCommandValue("fontsize") before]
     expected: FAIL
 
@@ -125,9 +116,6 @@
   [[["stylewithcss","false"\],["fontsize","4"\]\] "foo[bar\]baz" queryCommandValue("fontsize") after]
     expected: FAIL
 
-  [[["stylewithcss","true"\],["fontsize","4"\]\] "foo[bar<b>baz\]qoz</b>quz" compare innerHTML]
-    expected: FAIL
-
   [[["stylewithcss","true"\],["fontsize","4"\]\] "foo[bar<b>baz\]qoz</b>quz" queryCommandValue("fontsize") before]
     expected: FAIL
 
@@ -141,9 +129,6 @@
     expected: FAIL
 
   [[["stylewithcss","false"\],["fontsize","4"\]\] "foo[bar<b>baz\]qoz</b>quz" queryCommandValue("fontsize") after]
-    expected: FAIL
-
-  [[["stylewithcss","true"\],["fontsize","4"\]\] "foo[bar<i>baz\]qoz</i>quz" compare innerHTML]
     expected: FAIL
 
   [[["stylewithcss","true"\],["fontsize","4"\]\] "foo[bar<i>baz\]qoz</i>quz" queryCommandValue("fontsize") before]
@@ -176,9 +161,6 @@
   [[["stylewithcss","false"\],["fontsize","4"\]\] "{<p><p> <p>foo</p>}" queryCommandValue("fontsize") after]
     expected: FAIL
 
-  [[["stylewithcss","true"\],["fontsize","1"\]\] "foo[bar\]baz" compare innerHTML]
-    expected: FAIL
-
   [[["stylewithcss","true"\],["fontsize","1"\]\] "foo[bar\]baz" queryCommandValue("fontsize") before]
     expected: FAIL
 
@@ -192,9 +174,6 @@
     expected: FAIL
 
   [[["stylewithcss","false"\],["fontsize","1"\]\] "foo[bar\]baz" queryCommandValue("fontsize") after]
-    expected: FAIL
-
-  [[["stylewithcss","true"\],["fontsize","0"\]\] "foo[bar\]baz" compare innerHTML]
     expected: FAIL
 
   [[["stylewithcss","true"\],["fontsize","0"\]\] "foo[bar\]baz" queryCommandValue("fontsize") before]
@@ -212,9 +191,6 @@
   [[["stylewithcss","false"\],["fontsize","0"\]\] "foo[bar\]baz" queryCommandValue("fontsize") after]
     expected: FAIL
 
-  [[["stylewithcss","true"\],["fontsize","-5"\]\] "foo[bar\]baz" compare innerHTML]
-    expected: FAIL
-
   [[["stylewithcss","true"\],["fontsize","-5"\]\] "foo[bar\]baz" queryCommandValue("fontsize") before]
     expected: FAIL
 
@@ -228,9 +204,6 @@
     expected: FAIL
 
   [[["stylewithcss","false"\],["fontsize","-5"\]\] "foo[bar\]baz" queryCommandValue("fontsize") after]
-    expected: FAIL
-
-  [[["stylewithcss","true"\],["fontsize","6"\]\] "foo[bar\]baz" compare innerHTML]
     expected: FAIL
 
   [[["stylewithcss","true"\],["fontsize","6"\]\] "foo[bar\]baz" queryCommandValue("fontsize") before]
@@ -320,9 +293,6 @@
   [[["fontsize","xx-large"\]\] "foo[bar\]baz" queryCommandValue("fontsize") after]
     expected: FAIL
 
-  [[["stylewithcss","true"\],["fontsize"," 1 "\]\] "foo[bar\]baz" compare innerHTML]
-    expected: FAIL
-
   [[["stylewithcss","true"\],["fontsize"," 1 "\]\] "foo[bar\]baz" queryCommandValue("fontsize") before]
     expected: FAIL
 
@@ -344,9 +314,6 @@
   [[["fontsize","1."\]\] "foo[bar\]baz" queryCommandValue("fontsize") after]
     expected: FAIL
 
-  [[["stylewithcss","true"\],["fontsize","1.0"\]\] "foo[bar\]baz" compare innerHTML]
-    expected: FAIL
-
   [[["stylewithcss","true"\],["fontsize","1.0"\]\] "foo[bar\]baz" queryCommandValue("fontsize") before]
     expected: FAIL
 
@@ -360,9 +327,6 @@
     expected: FAIL
 
   [[["stylewithcss","false"\],["fontsize","1.0"\]\] "foo[bar\]baz" queryCommandValue("fontsize") after]
-    expected: FAIL
-
-  [[["stylewithcss","true"\],["fontsize","1.0e2"\]\] "foo[bar\]baz" compare innerHTML]
     expected: FAIL
 
   [[["stylewithcss","true"\],["fontsize","1.0e2"\]\] "foo[bar\]baz" queryCommandValue("fontsize") before]
@@ -380,9 +344,6 @@
   [[["stylewithcss","false"\],["fontsize","1.0e2"\]\] "foo[bar\]baz" queryCommandValue("fontsize") after]
     expected: FAIL
 
-  [[["stylewithcss","true"\],["fontsize","1.1"\]\] "foo[bar\]baz" compare innerHTML]
-    expected: FAIL
-
   [[["stylewithcss","true"\],["fontsize","1.1"\]\] "foo[bar\]baz" queryCommandValue("fontsize") before]
     expected: FAIL
 
@@ -396,9 +357,6 @@
     expected: FAIL
 
   [[["stylewithcss","false"\],["fontsize","1.1"\]\] "foo[bar\]baz" queryCommandValue("fontsize") after]
-    expected: FAIL
-
-  [[["stylewithcss","true"\],["fontsize","1.9"\]\] "foo[bar\]baz" compare innerHTML]
     expected: FAIL
 
   [[["stylewithcss","true"\],["fontsize","1.9"\]\] "foo[bar\]baz" queryCommandValue("fontsize") before]
@@ -479,9 +437,6 @@
   [[["fontsize","-0"\]\] "foo[bar\]baz" queryCommandValue("fontsize") after]
     expected: FAIL
 
-  [[["stylewithcss","true"\],["fontsize","-1"\]\] "foo[bar\]baz" compare innerHTML]
-    expected: FAIL
-
   [[["stylewithcss","true"\],["fontsize","-1"\]\] "foo[bar\]baz" queryCommandValue("fontsize") before]
     expected: FAIL
 
@@ -495,9 +450,6 @@
     expected: FAIL
 
   [[["stylewithcss","false"\],["fontsize","-1"\]\] "foo[bar\]baz" queryCommandValue("fontsize") after]
-    expected: FAIL
-
-  [[["stylewithcss","true"\],["fontsize","-9"\]\] "foo[bar\]baz" compare innerHTML]
     expected: FAIL
 
   [[["stylewithcss","true"\],["fontsize","-9"\]\] "foo[bar\]baz" queryCommandValue("fontsize") before]
@@ -519,9 +471,6 @@
     expected: FAIL
 
   [[["fontsize",""\]\] "foo[bar\]baz" queryCommandValue("fontsize") after]
-    expected: FAIL
-
-  [[["stylewithcss","true"\],["fontsize","4"\]\] "<table><tbody><tr><td>foo<td>b[a\]r<td>baz</table>" compare innerHTML]
     expected: FAIL
 
   [[["stylewithcss","true"\],["fontsize","4"\]\] "<table><tbody><tr><td>foo<td>b[a\]r<td>baz</table>" queryCommandValue("fontsize") before]
@@ -554,9 +503,6 @@
   [[["stylewithcss","false"\],["fontsize","4"\]\] "<table><tbody><tr data-start=1 data-end=2><td>foo<td>bar<td>baz</table>" queryCommandValue("fontsize") after]
     expected: FAIL
 
-  [[["stylewithcss","true"\],["fontsize","4"\]\] "<table><tbody><tr data-start=0 data-end=2><td>foo<td>bar<td>baz</table>" compare innerHTML]
-    expected: FAIL
-
   [[["stylewithcss","true"\],["fontsize","4"\]\] "<table><tbody><tr data-start=0 data-end=2><td>foo<td>bar<td>baz</table>" queryCommandValue("fontsize") before]
     expected: FAIL
 
@@ -572,9 +518,6 @@
   [[["stylewithcss","false"\],["fontsize","4"\]\] "<table><tbody><tr data-start=0 data-end=2><td>foo<td>bar<td>baz</table>" queryCommandValue("fontsize") after]
     expected: FAIL
 
-  [[["stylewithcss","true"\],["fontsize","4"\]\] "<table><tbody data-start=0 data-end=1><tr><td>foo<td>bar<td>baz</table>" compare innerHTML]
-    expected: FAIL
-
   [[["stylewithcss","true"\],["fontsize","4"\]\] "<table><tbody data-start=0 data-end=1><tr><td>foo<td>bar<td>baz</table>" queryCommandValue("fontsize") before]
     expected: FAIL
 
@@ -585,6 +528,9 @@
     expected: FAIL
 
   [[["stylewithcss","true"\],["fontsize","4"\]\] "<p>[foo</p> <p>bar\]</p>" queryCommandState("stylewithcss") before]
+    expected: FAIL
+
+  [[["fontsize","-0"\]\] "foo[bar\]baz" compare innerHTML]
     expected: FAIL
 
 
@@ -907,9 +853,6 @@
   [[["stylewithcss","false"\],["fontsize","4"\]\] "<span style=\\"font-size: 2em\\">foo[bar\]baz</span>" queryCommandValue("fontsize") after]
     expected: FAIL
 
-  [[["stylewithcss","true"\],["fontsize","4"\]\] "<p style=\\"font-size: xx-small\\">foo[bar\]baz</p>" compare innerHTML]
-    expected: FAIL
-
   [[["stylewithcss","true"\],["fontsize","4"\]\] "<p style=\\"font-size: xx-small\\">foo[bar\]baz</p>" queryCommandValue("fontsize") before]
     expected: FAIL
 
@@ -923,9 +866,6 @@
     expected: FAIL
 
   [[["stylewithcss","false"\],["fontsize","4"\]\] "<p style=\\"font-size: xx-small\\">foo[bar\]baz</p>" queryCommandValue("fontsize") after]
-    expected: FAIL
-
-  [[["stylewithcss","true"\],["fontsize","4"\]\] "<p style=\\"font-size: medium\\">foo[bar\]baz</p>" compare innerHTML]
     expected: FAIL
 
   [[["stylewithcss","true"\],["fontsize","4"\]\] "<p style=\\"font-size: medium\\">foo[bar\]baz</p>" queryCommandValue("fontsize") before]
@@ -947,9 +887,6 @@
     expected: FAIL
 
   [[["fontsize","4"\]\] "<p style=\\"font-size: large\\">foo[bar\]baz</p>" queryCommandValue("fontsize") after]
-    expected: FAIL
-
-  [[["stylewithcss","true"\],["fontsize","4"\]\] "<p style=\\"font-size: 2em\\">foo[bar\]baz</p>" compare innerHTML]
     expected: FAIL
 
   [[["stylewithcss","true"\],["fontsize","4"\]\] "<p style=\\"font-size: 2em\\">foo[bar\]baz</p>" queryCommandValue("fontsize") before]
@@ -1045,9 +982,6 @@
   [[["stylewithcss","false"\],["fontsize","3"\]\] "<font size=6>foo <span style=\\"font-size: 2em\\">b[a\]r</span> baz</font>" queryCommandValue("fontsize") after]
     expected: FAIL
 
-  [[["stylewithcss","true"\],["fontsize","3"\]\] "foo<big>[bar\]</big>baz" compare innerHTML]
-    expected: FAIL
-
   [[["stylewithcss","true"\],["fontsize","3"\]\] "foo<big>[bar\]</big>baz" queryCommandValue("fontsize") before]
     expected: FAIL
 
@@ -1061,9 +995,6 @@
     expected: FAIL
 
   [[["stylewithcss","false"\],["fontsize","3"\]\] "foo<big>[bar\]</big>baz" queryCommandValue("fontsize") after]
-    expected: FAIL
-
-  [[["stylewithcss","true"\],["fontsize","3"\]\] "foo<big>b[a\]r</big>baz" compare innerHTML]
     expected: FAIL
 
   [[["stylewithcss","true"\],["fontsize","3"\]\] "foo<big>b[a\]r</big>baz" queryCommandValue("fontsize") before]
@@ -1081,9 +1012,6 @@
   [[["stylewithcss","false"\],["fontsize","3"\]\] "foo<big>b[a\]r</big>baz" queryCommandValue("fontsize") after]
     expected: FAIL
 
-  [[["stylewithcss","true"\],["fontsize","3"\]\] "foo<small>[bar\]</small>baz" compare innerHTML]
-    expected: FAIL
-
   [[["stylewithcss","true"\],["fontsize","3"\]\] "foo<small>[bar\]</small>baz" queryCommandValue("fontsize") before]
     expected: FAIL
 
@@ -1097,9 +1025,6 @@
     expected: FAIL
 
   [[["stylewithcss","false"\],["fontsize","3"\]\] "foo<small>[bar\]</small>baz" queryCommandValue("fontsize") after]
-    expected: FAIL
-
-  [[["stylewithcss","true"\],["fontsize","3"\]\] "foo<small>b[a\]r</small>baz" compare innerHTML]
     expected: FAIL
 
   [[["stylewithcss","true"\],["fontsize","3"\]\] "foo<small>b[a\]r</small>baz" queryCommandValue("fontsize") before]
@@ -1157,6 +1082,9 @@
     expected: FAIL
 
   [[["stylewithcss","true"\],["fontsize","4"\]\] "<table data-start=0 data-end=1><tbody><tr><td>foo<td>bar<td>baz</table>" queryCommandState("stylewithcss") before]
+    expected: FAIL
+
+  [[["fontsize","4"\]\] "<font size=+1>foo[bar\]baz</font>" compare innerHTML]
     expected: FAIL
 
 

--- a/tests/wpt/meta/editing/run/multitest.html.ini
+++ b/tests/wpt/meta/editing/run/multitest.html.ini
@@ -6547,9 +6547,6 @@
   [[["stylewithcss","false"\],["fontsize","4"\],["insertText","a"\]\] "<font size=7>{}<br></font>" compare innerHTML]
     expected: FAIL
 
-  [[["stylewithcss","false"\],["fontsize","4"\],["insertText","a"\]\] "<font size=7>{}<br></font>" queryCommandValue("fontsize") before]
-    expected: FAIL
-
   [[["stylewithcss","false"\],["fontsize","4"\],["insertText","a"\]\] "<font size=7>{}<br></font>" queryCommandValue("fontsize") after]
     expected: FAIL
 


### PR DESCRIPTION
While debugging test failures, I discovered that I had reversed the `is_allowed_child` arguments. That made a bunch more tests pass, but then also started to fail tests as we weren't clearing the previous value and computing loose equivalence.

Therefore, this PR fixes the reversal and implements the relevant parts of some algorithms as to not regress too much. There are two new failures related to how integers should be parsed, but tackling that separately.

Part of #25005

Testing: WPT