### PR TITLE
layout: Resolve `word-spacing` percentages against computed `font-size`

### DIFF
--- a/components/layout/flow/inline/text_run.rs
+++ b/components/layout/flow/inline/text_run.rs
@@ -456,7 +456,7 @@ impl TextRun {
         let parent_style = self.inline_styles.style.borrow().clone();
         let inherited_text_style = parent_style.get_inherited_text().clone();
         let font_size = parent_style.get_font().font_size.computed_size().into();
-        let word_spacing = inherited_text_style.word_spacing.to_used_value(font_size);
+        let word_spacing = Some(inherited_text_style.word_spacing.to_used_value(font_size));
         let letter_spacing = inherited_text_style
             .letter_spacing
             .0
@@ -512,7 +512,6 @@ impl TextRun {
                 letter_spacing
             };
 
-            let word_spacing = Some(word_spacing);
             let info = FontAndScriptInfo {
                 font,
                 script,
@@ -544,7 +543,6 @@ impl TextRun {
         // of those cases, just use the first font.
         if current.is_none() {
             current = font_group.first(&layout_context.font_context).map(|font| {
-                let word_spacing = Some(word_spacing);
                 TextRunSegment::new(
                     Arc::new(FontAndScriptInfo {
                         font,

--- a/components/layout/flow/inline/text_run.rs
+++ b/components/layout/flow/inline/text_run.rs
@@ -473,8 +473,6 @@ impl TextRun {
         // The next bytes index of the charcter within the entire inline formatting context's text.
         let mut next_byte_index = self.text_range.start;
 
-        let resolve_word_spacing_for_font = |_font: &FontRef| word_spacing;
-
         for (character, next_character) in char_iterator {
             let current_character_index = next_character_index;
             next_character_index += 1;
@@ -514,7 +512,7 @@ impl TextRun {
                 letter_spacing
             };
 
-            let word_spacing = Some(resolve_word_spacing_for_font(&font));
+            let word_spacing = Some(word_spacing);
             let info = FontAndScriptInfo {
                 font,
                 script,
@@ -546,7 +544,7 @@ impl TextRun {
         // of those cases, just use the first font.
         if current.is_none() {
             current = font_group.first(&layout_context.font_context).map(|font| {
-                let word_spacing = Some(resolve_word_spacing_for_font(&font));
+                let word_spacing = Some(word_spacing);
                 TextRunSegment::new(
                     Arc::new(FontAndScriptInfo {
                         font,

--- a/components/layout/flow/inline/text_run.rs
+++ b/components/layout/flow/inline/text_run.rs
@@ -6,7 +6,6 @@ use std::mem;
 use std::ops::Range;
 use std::sync::Arc;
 
-use style::Zero;
 use app_units::Au;
 use fonts::{FontContext, FontRef, GlyphStore, ShapingFlags, ShapingOptions};
 use icu_locid::subtags::Language;
@@ -421,78 +420,15 @@ impl TextRun {
         bidi_info: &BidiInfo,
     ) {
         let parent_style = self.inline_styles.style.borrow().clone();
-        let inherited_text_style = parent_style.get_inherited_text().clone();
-        let font_size = parent_style.get_font().font_size.computed_size();
-        let word_spacing = inherited_text_style
-            .word_spacing
-            .to_used_value(font_size.into());
-        let letter_spacing = inherited_text_style
-            .letter_spacing
-            .0
-            .to_used_value(font_size.into());
-        let letter_spacing = if !letter_spacing.is_zero() {
-            Some(letter_spacing)
-        } else {
-            None
-        };
-        let language = parent_style
-            .get_font()
-            ._x_lang
-            .0
-            .parse()
-            .unwrap_or(Language::UND);
-
-        let mut flags = ShapingFlags::empty();
-        if inherited_text_style.text_rendering == TextRendering::Optimizespeed {
-            flags.insert(ShapingFlags::IGNORE_LIGATURES_SHAPING_FLAG);
-            flags.insert(ShapingFlags::DISABLE_KERNING_SHAPING_FLAG)
+        let mut segments = self.segment_text_by_font(
+            layout_context,
+            formatting_context_text,
+            bidi_info,
+            &parent_style,
+        );
+        for segment in segments.iter_mut() {
+            segment.shape_text(&parent_style, formatting_context_text, linebreaker);
         }
-
-        let segments = self
-            .segment_text_by_font(
-                layout_context,
-                formatting_context_text,
-                bidi_info,
-                &parent_style,
-            )
-            .into_iter()
-            .map(|mut segment| {
-                let mut flags = flags;
-                if segment.info.bidi_level.is_rtl() {
-                    flags.insert(ShapingFlags::RTL_FLAG);
-                }
-
-                // From https://www.w3.org/TR/css-text-3/#cursive-script:
-                // Cursive scripts do not admit gaps between their letters for either
-                // justification or letter-spacing.
-                let letter_spacing = if is_cursive_script(segment.info.script) {
-                    None
-                } else {
-                    letter_spacing
-                };
-                if letter_spacing.is_some() {
-                    flags.insert(ShapingFlags::IGNORE_LIGATURES_SHAPING_FLAG);
-                };
-
-                let shaping_options = ShapingOptions {
-                    letter_spacing,
-                    word_spacing: Some(word_spacing),
-                    script: segment.info.script,
-                    language,
-                    flags,
-                };
-
-                segment.shape_text(
-                    &parent_style,
-                    formatting_context_text,
-                    linebreaker,
-                    &shaping_options,
-                );
-
-                segment
-            })
-            .collect();
-
         let _ = std::mem::replace(&mut self.shaped_text, segments);
     }
 
@@ -516,15 +452,15 @@ impl TextRun {
         let language = x_lang.0.parse().unwrap_or(Language::UND);
         let text_run_text = &formatting_context_text[self.text_range.clone()];
         let char_iterator = TwoCharsAtATimeIterator::new(text_run_text.chars());
-        
+
         let parent_style = self.inline_styles.style.borrow().clone();
         let inherited_text_style = parent_style.get_inherited_text().clone();
-        let font_size = parent_style.get_font().font_size.computed_size();
-        let word_spacing = inherited_text_style.word_spacing.to_used_value(font_size.into());
+        let font_size = parent_style.get_font().font_size.computed_size().into();
+        let word_spacing = inherited_text_style.word_spacing.to_used_value(font_size);
         let letter_spacing = inherited_text_style
             .letter_spacing
             .0
-            .to_used_value(font_size.into());
+            .to_used_value(font_size);
         let letter_spacing = if !letter_spacing.is_zero() {
             Some(letter_spacing)
         } else {

--- a/components/layout/flow/inline/text_run.rs
+++ b/components/layout/flow/inline/text_run.rs
@@ -422,9 +422,7 @@ impl TextRun {
         let parent_style = self.inline_styles.style.borrow().clone();
         let inherited_text_style = parent_style.get_inherited_text().clone();
         let font_size = parent_style.get_font().font_size.computed_size();
-        let word_spacing = inherited_text_style
-            .word_spacing
-            .to_used_value(font_size.into());
+        let word_spacing = inherited_text_style.word_spacing.to_used_value(font_size.into());
         let letter_spacing = inherited_text_style.letter_spacing.0.resolve(font_size);
         let letter_spacing = if letter_spacing.px() != 0. {
             Some(app_units::Au::from(letter_spacing))

--- a/components/layout/flow/inline/text_run.rs
+++ b/components/layout/flow/inline/text_run.rs
@@ -14,6 +14,7 @@ use log::warn;
 use malloc_size_of_derive::MallocSizeOf;
 use servo_arc::Arc as ServoArc;
 use servo_base::text::is_bidi_control;
+use style::Zero;
 use style::computed_values::text_rendering::T as TextRendering;
 use style::computed_values::white_space_collapse::T as WhiteSpaceCollapse;
 use style::computed_values::word_break::T as WordBreak;
@@ -425,9 +426,12 @@ impl TextRun {
         let word_spacing = inherited_text_style
             .word_spacing
             .to_used_value(font_size.into());
-        let letter_spacing = inherited_text_style.letter_spacing.0.resolve(font_size);
-        let letter_spacing = if letter_spacing.px() != 0. {
-            Some(app_units::Au::from(letter_spacing))
+        let letter_spacing = inherited_text_style
+            .letter_spacing
+            .0
+            .to_used_value(font_size.into());
+        let letter_spacing = if !letter_spacing.is_zero() {
+            Some(letter_spacing)
         } else {
             None
         };

--- a/components/layout/flow/inline/text_run.rs
+++ b/components/layout/flow/inline/text_run.rs
@@ -420,15 +420,75 @@ impl TextRun {
         bidi_info: &BidiInfo,
     ) {
         let parent_style = self.inline_styles.style.borrow().clone();
-        let mut segments = self.segment_text_by_font(
-            layout_context,
-            formatting_context_text,
-            bidi_info,
-            &parent_style,
-        );
-        for segment in segments.iter_mut() {
-            segment.shape_text(&parent_style, formatting_context_text, linebreaker);
+        let inherited_text_style = parent_style.get_inherited_text().clone();
+        let font_size = parent_style.get_font().font_size.computed_size();
+        let word_spacing = inherited_text_style
+            .word_spacing
+            .to_used_value(font_size.into());
+        let letter_spacing = inherited_text_style.letter_spacing.0.resolve(font_size);
+        let letter_spacing = if letter_spacing.px() != 0. {
+            Some(app_units::Au::from(letter_spacing))
+        } else {
+            None
+        };
+        let language = parent_style
+            .get_font()
+            ._x_lang
+            .0
+            .parse()
+            .unwrap_or(Language::UND);
+
+        let mut flags = ShapingFlags::empty();
+        if inherited_text_style.text_rendering == TextRendering::Optimizespeed {
+            flags.insert(ShapingFlags::IGNORE_LIGATURES_SHAPING_FLAG);
+            flags.insert(ShapingFlags::DISABLE_KERNING_SHAPING_FLAG)
         }
+
+        let segments = self
+            .segment_text_by_font(
+                layout_context,
+                formatting_context_text,
+                bidi_info,
+                &parent_style,
+            )
+            .into_iter()
+            .map(|mut segment| {
+                let mut flags = flags;
+                if segment.info.bidi_level.is_rtl() {
+                    flags.insert(ShapingFlags::RTL_FLAG);
+                }
+
+                // From https://www.w3.org/TR/css-text-3/#cursive-script:
+                // Cursive scripts do not admit gaps between their letters for either
+                // justification or letter-spacing.
+                let letter_spacing = if is_cursive_script(segment.info.script) {
+                    None
+                } else {
+                    letter_spacing
+                };
+                if letter_spacing.is_some() {
+                    flags.insert(ShapingFlags::IGNORE_LIGATURES_SHAPING_FLAG);
+                };
+
+                let shaping_options = ShapingOptions {
+                    letter_spacing,
+                    word_spacing: Some(word_spacing),
+                    script: segment.info.script,
+                    language,
+                    flags,
+                };
+
+                segment.shape_text(
+                    &parent_style,
+                    formatting_context_text,
+                    linebreaker,
+                    &shaping_options,
+                );
+
+                segment
+            })
+            .collect();
+
         let _ = std::mem::replace(&mut self.shaped_text, segments);
     }
 

--- a/components/layout/flow/inline/text_run.rs
+++ b/components/layout/flow/inline/text_run.rs
@@ -6,6 +6,7 @@ use std::mem;
 use std::ops::Range;
 use std::sync::Arc;
 
+use style::Zero;
 use app_units::Au;
 use fonts::{FontContext, FontRef, GlyphStore, ShapingFlags, ShapingOptions};
 use icu_locid::subtags::Language;
@@ -459,7 +460,7 @@ impl TextRun {
         let letter_spacing = inherited_text_style
             .letter_spacing
             .0
-            .to_used_value(font_size);
+            .to_used_value(font_size.into());
         let letter_spacing = if !letter_spacing.is_zero() {
             Some(letter_spacing)
         } else {

--- a/components/layout/flow/inline/text_run.rs
+++ b/components/layout/flow/inline/text_run.rs
@@ -422,7 +422,9 @@ impl TextRun {
         let parent_style = self.inline_styles.style.borrow().clone();
         let inherited_text_style = parent_style.get_inherited_text().clone();
         let font_size = parent_style.get_font().font_size.computed_size();
-        let word_spacing = inherited_text_style.word_spacing.to_used_value(font_size.into());
+        let word_spacing = inherited_text_style
+            .word_spacing
+            .to_used_value(font_size.into());
         let letter_spacing = inherited_text_style.letter_spacing.0.resolve(font_size);
         let letter_spacing = if letter_spacing.px() != 0. {
             Some(app_units::Au::from(letter_spacing))

--- a/components/layout/flow/inline/text_run.rs
+++ b/components/layout/flow/inline/text_run.rs
@@ -7,9 +7,7 @@ use std::ops::Range;
 use std::sync::Arc;
 
 use app_units::Au;
-use fonts::{
-    FontContext, FontRef, GlyphStore, LAST_RESORT_GLYPH_ADVANCE, ShapingFlags, ShapingOptions,
-};
+use fonts::{FontContext, FontRef, GlyphStore, ShapingFlags, ShapingOptions};
 use icu_locid::subtags::Language;
 use log::warn;
 use malloc_size_of_derive::MallocSizeOf;
@@ -453,37 +451,28 @@ impl TextRun {
         let language = x_lang.0.parse().unwrap_or(Language::UND);
         let text_run_text = &formatting_context_text[self.text_range.clone()];
         let char_iterator = TwoCharsAtATimeIterator::new(text_run_text.chars());
-
+        
         let parent_style = self.inline_styles.style.borrow().clone();
         let inherited_text_style = parent_style.get_inherited_text().clone();
+        let font_size = parent_style.get_font().font_size.computed_size();
+        let word_spacing = inherited_text_style.word_spacing.to_used_value(font_size.into());
         let letter_spacing = inherited_text_style
             .letter_spacing
             .0
-            .resolve(parent_style.clone_font().font_size.computed_size());
-        let letter_spacing = if letter_spacing.px() != 0. {
-            Some(app_units::Au::from(letter_spacing))
+            .to_used_value(font_size);
+        let letter_spacing = if !letter_spacing.is_zero() {
+            Some(letter_spacing)
         } else {
             None
         };
         let text_rendering = inherited_text_style.text_rendering;
-        let word_spacing = inherited_text_style.word_spacing.to_length().map(Au::from);
 
         // The next current character index within the entire inline formatting context's text.
         let mut next_character_index = self.character_range.start;
         // The next bytes index of the charcter within the entire inline formatting context's text.
         let mut next_byte_index = self.text_range.start;
 
-        let resolve_word_spacing_for_font = |font: &FontRef| {
-            word_spacing.unwrap_or_else(|| {
-                let space_width = font
-                    .glyph_index(' ')
-                    .map(|glyph_id| font.glyph_h_advance(glyph_id))
-                    .unwrap_or(LAST_RESORT_GLYPH_ADVANCE);
-                inherited_text_style
-                    .word_spacing
-                    .to_used_value(Au::from_f64_px(space_width))
-            })
-        };
+        let resolve_word_spacing_for_font = |_font: &FontRef| word_spacing;
 
         for (character, next_character) in char_iterator {
             let current_character_index = next_character_index;

--- a/tests/wpt/meta/css/css-text/word-spacing/word-spacing-percent-001.html.ini
+++ b/tests/wpt/meta/css/css-text/word-spacing/word-spacing-percent-001.html.ini
@@ -1,2 +1,0 @@
-[word-spacing-percent-001.html]
-  expected: FAIL


### PR DESCRIPTION
Changes ```word-spacing``` to resolve percentages against the computed ```font-size```, instead of the size of a space.

Testing: ```tests/wpt/tests/css/css-text/word-spacing/word-spacing-percent-001.html``` is now passing

Fixes: #43997