### PR TITLE
allocator: Make jemalloc code optional

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -327,7 +327,7 @@ script_bindings = { package = "servo-script-bindings", version = "=0.5.0", path 
 script_webgpu = { package = "servo-script-webgpu", version = "=0.5.0", path = "components/script_webgpu" }
 script_traits = { package = "servo-script-traits", version = "=0.5.0", path = "components/shared/script" }
 servo = { version = "=0.5.0", path = "components/servo", default-features = false }
-servo-allocator = { version = "=0.5.0", path = "components/allocator", default-features = false }
+servo-allocator = { version = "=0.5.0", path = "components/allocator" }
 servo-background-hang-monitor = { version = "=0.5.0", path = "components/background_hang_monitor" }
 servo-background-hang-monitor-api = { version = "=0.5.0", path = "components/shared/background_hang_monitor" }
 servo-base = { version = "=0.5.0", path = "components/shared/base" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -327,7 +327,7 @@ script_bindings = { package = "servo-script-bindings", version = "=0.5.0", path 
 script_webgpu = { package = "servo-script-webgpu", version = "=0.5.0", path = "components/script_webgpu" }
 script_traits = { package = "servo-script-traits", version = "=0.5.0", path = "components/shared/script" }
 servo = { version = "=0.5.0", path = "components/servo", default-features = false }
-servo-allocator = { version = "=0.5.0", path = "components/allocator" }
+servo-allocator = { version = "=0.5.0", path = "components/allocator", default-features = false }
 servo-background-hang-monitor = { version = "=0.5.0", path = "components/background_hang_monitor" }
 servo-background-hang-monitor-api = { version = "=0.5.0", path = "components/shared/background_hang_monitor" }
 servo-base = { version = "=0.5.0", path = "components/shared/base" }

--- a/components/allocator/Cargo.toml
+++ b/components/allocator/Cargo.toml
@@ -14,7 +14,8 @@ path = "lib.rs"
 
 [features]
 allocation-tracking = ["backtrace", "dep:rustc-hash", "log"]
-use-system-allocator = ["libc"]
+use-system-allocator = []
+use-jemalloc = ["dep:tikv-jemalloc-sys", "dep:tikv-jemallocator"]
 
 [dependencies]
 backtrace = { workspace = true, optional = true }
@@ -22,9 +23,9 @@ log = { workspace = true, optional = true }
 rustc-hash = { workspace = true, optional = true }
 
 [target.'cfg(not(any(windows, target_env = "ohos")))'.dependencies]
-libc = { workspace = true, optional = true }
-tikv-jemalloc-sys = { workspace = true }
-tikv-jemallocator = { workspace = true }
+libc = { workspace = true }
+tikv-jemalloc-sys = { workspace = true, optional = true }
+tikv-jemallocator = { workspace = true, optional = true }
 
 [target.'cfg(windows)'.dependencies]
 windows-sys = { workspace = true, features = ["Win32_System_Memory"] }

--- a/components/allocator/Cargo.toml
+++ b/components/allocator/Cargo.toml
@@ -14,7 +14,6 @@ path = "lib.rs"
 
 [features]
 allocation-tracking = ["backtrace", "dep:rustc-hash", "log"]
-use-system-allocator = []
 use-jemalloc = ["dep:tikv-jemalloc-sys", "dep:tikv-jemallocator"]
 
 [dependencies]

--- a/components/allocator/Cargo.toml
+++ b/components/allocator/Cargo.toml
@@ -14,7 +14,7 @@ path = "lib.rs"
 
 [features]
 allocation-tracking = ["backtrace", "dep:rustc-hash", "log"]
-use-system-allocator = []
+use-system-allocator = ["libc"]
 use-jemalloc = ["dep:tikv-jemalloc-sys", "dep:tikv-jemallocator"]
 
 [dependencies]
@@ -23,7 +23,7 @@ log = { workspace = true, optional = true }
 rustc-hash = { workspace = true, optional = true }
 
 [target.'cfg(not(any(windows, target_env = "ohos")))'.dependencies]
-libc = { workspace = true }
+libc = { workspace = true, optional = true }
 tikv-jemalloc-sys = { workspace = true, optional = true }
 tikv-jemallocator = { workspace = true, optional = true }
 

--- a/components/allocator/Cargo.toml
+++ b/components/allocator/Cargo.toml
@@ -14,7 +14,7 @@ path = "lib.rs"
 
 [features]
 allocation-tracking = ["backtrace", "dep:rustc-hash", "log"]
-use-system-allocator = ["libc"]
+use-system-allocator = []
 use-jemalloc = ["dep:tikv-jemalloc-sys", "dep:tikv-jemallocator"]
 
 [dependencies]
@@ -23,7 +23,7 @@ log = { workspace = true, optional = true }
 rustc-hash = { workspace = true, optional = true }
 
 [target.'cfg(not(any(windows, target_env = "ohos")))'.dependencies]
-libc = { workspace = true, optional = true }
+libc = { workspace = true }
 tikv-jemalloc-sys = { workspace = true, optional = true }
 tikv-jemallocator = { workspace = true, optional = true }
 

--- a/components/allocator/lib.rs
+++ b/components/allocator/lib.rs
@@ -160,7 +160,11 @@ mod platform {
 
 #[cfg(all(
     not(windows),
-    any(feature = "use-system-allocator", target_env = "ohos", not(feature = "use-jemalloc"))
+    any(
+        feature = "use-system-allocator",
+        target_env = "ohos",
+        not(feature = "use-jemalloc")
+    )
 ))]
 mod platform {
     pub use std::alloc::System as Allocator;

--- a/components/allocator/lib.rs
+++ b/components/allocator/lib.rs
@@ -58,7 +58,18 @@ pub static enclosing_size: Option<EnclosingSizeFn> = Some(crate::enclosing_size_
 #[cfg(not(feature = "allocation-tracking"))]
 pub static enclosing_size: Option<EnclosingSizeFn> = None;
 
-#[cfg(not(any(windows, feature = "use-system-allocator", target_env = "ohos")))]
+#[cfg(all(
+    feature = "use-system-allocator",
+    feature = "use-jemalloc",
+    not(any(windows, target_env = "ohos"))
+))]
+compile_error!(
+    "The features `use-system-allocator` and `use-jemalloc` are mutually exclusive!\
+ If you want to use the system allocator, you must use `--no-default-features` in combination\
+ with `--features=use-system-allocator`."
+);
+
+#[cfg(all(feature = "use-jemalloc", not(any(windows, target_env = "ohos"))))]
 mod platform {
     use std::ffi::CStr;
     use std::mem::size_of_val;
@@ -149,7 +160,7 @@ mod platform {
 
 #[cfg(all(
     not(windows),
-    any(feature = "use-system-allocator", target_env = "ohos")
+    any(feature = "use-system-allocator", target_env = "ohos", not(feature = "use-jemalloc"))
 ))]
 mod platform {
     pub use std::alloc::System as Allocator;

--- a/components/allocator/lib.rs
+++ b/components/allocator/lib.rs
@@ -58,17 +58,6 @@ pub static enclosing_size: Option<EnclosingSizeFn> = Some(crate::enclosing_size_
 #[cfg(not(feature = "allocation-tracking"))]
 pub static enclosing_size: Option<EnclosingSizeFn> = None;
 
-#[cfg(all(
-    feature = "use-system-allocator",
-    feature = "use-jemalloc",
-    not(any(windows, target_env = "ohos"))
-))]
-compile_error!(
-    "The features `use-system-allocator` and `use-jemalloc` are mutually exclusive!\
- If you want to use the system allocator, you must use `--no-default-features` in combination\
- with `--features=use-system-allocator`."
-);
-
 #[cfg(all(feature = "use-jemalloc", not(any(windows, target_env = "ohos"))))]
 mod platform {
     use std::ffi::CStr;
@@ -158,14 +147,7 @@ mod platform {
     }
 }
 
-#[cfg(all(
-    not(windows),
-    any(
-        feature = "use-system-allocator",
-        target_env = "ohos",
-        not(feature = "use-jemalloc")
-    )
-))]
+#[cfg(all(not(windows), any(target_env = "ohos", not(feature = "use-jemalloc"))))]
 mod platform {
     pub use std::alloc::System as Allocator;
     use std::os::raw::c_void;

--- a/components/servo/Cargo.toml
+++ b/components/servo/Cargo.toml
@@ -23,7 +23,7 @@ default = ["bundled", "default_web_features", "js_jit"]
 #  configuration with `--no-default-features` build
 #
 # A convenience feature to enable all default web features servo has.
-default_web_features = ["gamepad", "clipboard", "webgpu", "webxr"]
+default_web_features = ["clipboard", "webgpu", "webxr"]
 # Bundle required resources in the binary.
 bundled = ["baked-in-resources", "bundled_freetype"]
 

--- a/components/servo/Cargo.toml
+++ b/components/servo/Cargo.toml
@@ -17,8 +17,17 @@ crate-type = ["rlib"]
 
 [features]
 # Note: Servoshell does not use the default features of servo, so you also
-# need to add features that should be default to ports/servoshell/Cargo.toml
-default = ["baked-in-resources", "bundled_freetype", "clipboard", "js_jit"]
+# need to add feature-groups that should be default to ports/servoshell/Cargo.toml
+default = ["bundled", "default_web_features", "js_jit"]
+## Convenience feature groups, to select multiple related features for a sensible
+#  configuration with `--no-default-features` build
+#
+# A convenience feature to enable all default web features servo has.
+default_web_features = ["gamepad", "clipboard", "webgpu", "webxr"]
+# Bundle required resources in the binary.
+bundled = ["baked-in-resources", "bundled_freetype"]
+
+# Individual features below this line.
 background_hang_monitor = ["servo-background-hang-monitor/sampler"]
 # This is slightly magical, but this will also work on ohos, where `servo-default-resource` is not added,
 # which makes `baked-in-resources a no-op (as intended) on ohos (and perhaps other platforms in the future).

--- a/components/servo/Cargo.toml
+++ b/components/servo/Cargo.toml
@@ -18,7 +18,7 @@ crate-type = ["rlib"]
 [features]
 # Note: Servoshell does not use the default features of servo, so you also
 # need to add feature-groups that should be default to ports/servoshell/Cargo.toml
-default = ["bundled", "default_web_features", "js_jit"]
+default = ["bundled", "js_jit"]
 ## Convenience feature groups, to select multiple related features for a sensible
 #  configuration with `--no-default-features` build
 #

--- a/components/servo/Cargo.toml
+++ b/components/servo/Cargo.toml
@@ -18,7 +18,7 @@ crate-type = ["rlib"]
 [features]
 # Note: Servoshell does not use the default features of servo, so you also
 # need to add feature-groups that should be default to ports/servoshell/Cargo.toml
-default = ["bundled", "js_jit"]
+default = ["bundled", "clipboard", "js_jit"]
 ## Convenience feature groups, to select multiple related features for a sensible
 #  configuration with `--no-default-features` build
 #

--- a/ports/servoshell/Cargo.toml
+++ b/ports/servoshell/Cargo.toml
@@ -41,7 +41,18 @@ OriginalFilename = "servoshell.exe"
 ProductName = "ServoShell"
 
 [features]
-default = ["baked-in-resources", "bundled_freetype", "gamepad", "servo/clipboard", "servo-allocator/use-jemalloc", "js_jit", "max_log_level", "webgpu", "webxr"]
+# Prefer using feature groups here to bundle related features.
+default = ["bundled", "default_web_features", "default_perf", "max_log_level"]
+# This should match `default` but using the system allocator instead of any custom allocator.
+default_asan = ["bundled", "default_web_features", "js_jit", "servo-allocator/use-system-allocator", "max_log_level"]
+# Feature groups:
+default_web_features = ["servo/default_web_features"]
+# A reasonable base performance.
+default_perf = ["js_jit", "servo-allocator/use-jemalloc"]
+# Bundle required resources in the binary.
+bundled = ["servo/bundled"]
+
+## Individual features below this line
 baked-in-resources = ["servo/baked-in-resources"]
 bundled_freetype = ["servo/bundled_freetype"]
 crown = ["servo/crown"]

--- a/ports/servoshell/Cargo.toml
+++ b/ports/servoshell/Cargo.toml
@@ -41,10 +41,10 @@ OriginalFilename = "servoshell.exe"
 ProductName = "ServoShell"
 
 [features]
-# Prefer using feature groups here to bundle related features.
-default = ["bundled", "default_web_features", "default_perf", "max_log_level"]
-# This should match `default` but use the system allocator instead of any custom allocator.
-default_with_system_allocator = ["bundled", "default_web_features", "js_jit", "servo-allocator/use-system-allocator", "max_log_level"]
+# Don't add new features to `default` directly. Add to `default_without_allocator` instead.
+default = ["default_without_allocator", "servo-allocator/use-jemalloc"]
+# default features, without a custom allocator.
+default_without_allocator = ["bundled", "default_web_features", "max_log_level"]
 # Feature groups:
 default_web_features = ["servo/default_web_features"]
 # A reasonable base performance.
@@ -135,7 +135,7 @@ gilrs = { workspace = true }
 glow = { workspace = true }
 headers = { workspace = true }
 serde_json = { workspace = true }
-# For optional feature servo-allocator/use-system-allocator and servo-allocator/allocation-tracking
+# For optional feature servo-allocator/use-jemalloc and servo-allocator/allocation-tracking
 servo-allocator = { workspace = true, default-features = false }
 surfman = { workspace = true, features = ["sm-raw-window-handle-06", "sm-x11"] }
 winit = { workspace = true }

--- a/ports/servoshell/Cargo.toml
+++ b/ports/servoshell/Cargo.toml
@@ -43,8 +43,8 @@ ProductName = "ServoShell"
 [features]
 # Prefer using feature groups here to bundle related features.
 default = ["bundled", "default_web_features", "default_perf", "max_log_level"]
-# This should match `default` but using the system allocator instead of any custom allocator.
-default_asan = ["bundled", "default_web_features", "js_jit", "servo-allocator/use-system-allocator", "max_log_level"]
+# This should match `default` but use the system allocator instead of any custom allocator.
+default_with_system_allocator = ["bundled", "default_web_features", "js_jit", "servo-allocator/use-system-allocator", "max_log_level"]
 # Feature groups:
 default_web_features = ["servo/default_web_features"]
 # A reasonable base performance.

--- a/ports/servoshell/Cargo.toml
+++ b/ports/servoshell/Cargo.toml
@@ -43,10 +43,12 @@ ProductName = "ServoShell"
 [features]
 # Don't add new features to `default` directly. Add to `default_without_allocator` instead.
 default = ["default_without_allocator", "servo-allocator/use-jemalloc"]
-# default features, without a custom allocator.
-default_without_allocator = ["bundled", "default_web_features", "max_log_level"]
 # Feature groups:
-default_web_features = ["servo/default_web_features"]
+# default features, without a custom allocator.
+default_without_allocator = ["bundled", "default_web_features", "max_log_level", "js_jit"]
+# Default web features should be kept in sync with the list in servo/Cargo.toml.
+# We also need to enable our own features, since we also have `cfg` gated code here.
+default_web_features = ["servo/default_web_features", "gamepad", "webgpu", "webxr"]
 # A reasonable base performance.
 default_perf = ["js_jit", "servo-allocator/use-jemalloc"]
 # Bundle required resources in the binary.

--- a/ports/servoshell/Cargo.toml
+++ b/ports/servoshell/Cargo.toml
@@ -138,7 +138,7 @@ glow = { workspace = true }
 headers = { workspace = true }
 serde_json = { workspace = true }
 # For optional feature servo-allocator/use-jemalloc and servo-allocator/allocation-tracking
-servo-allocator = { workspace = true, default-features = false }
+servo-allocator = { workspace = true }
 surfman = { workspace = true, features = ["sm-raw-window-handle-06", "sm-x11"] }
 winit = { workspace = true }
 

--- a/ports/servoshell/Cargo.toml
+++ b/ports/servoshell/Cargo.toml
@@ -41,7 +41,7 @@ OriginalFilename = "servoshell.exe"
 ProductName = "ServoShell"
 
 [features]
-default = ["baked-in-resources", "bundled_freetype", "gamepad", "servo/clipboard", "js_jit", "max_log_level", "webgpu", "webxr"]
+default = ["baked-in-resources", "bundled_freetype", "gamepad", "servo/clipboard", "servo-allocator/use-jemalloc", "js_jit", "max_log_level", "webgpu", "webxr"]
 baked-in-resources = ["servo/baked-in-resources"]
 bundled_freetype = ["servo/bundled_freetype"]
 crown = ["servo/crown"]
@@ -125,7 +125,7 @@ glow = { workspace = true }
 headers = { workspace = true }
 serde_json = { workspace = true }
 # For optional feature servo-allocator/use-system-allocator and servo-allocator/allocation-tracking
-servo-allocator = { workspace = true }
+servo-allocator = { workspace = true, default-features = false }
 surfman = { workspace = true, features = ["sm-raw-window-handle-06", "sm-x11"] }
 winit = { workspace = true }
 

--- a/ports/servoshell/Cargo.toml
+++ b/ports/servoshell/Cargo.toml
@@ -49,8 +49,6 @@ default_without_allocator = ["bundled", "default_web_features", "max_log_level",
 # Default web features should be kept in sync with the list in servo/Cargo.toml.
 # We also need to enable our own features, since we also have `cfg` gated code here.
 default_web_features = ["servo/default_web_features", "gamepad", "webgpu", "webxr"]
-# A reasonable base performance.
-default_perf = ["js_jit", "servo-allocator/use-jemalloc"]
 # Bundle required resources in the binary.
 bundled = ["servo/bundled"]
 

--- a/python/servo/build_commands.py
+++ b/python/servo/build_commands.py
@@ -53,6 +53,18 @@ SUPPORTED_TSAN_TARGETS = [
     "x86_64-unknown-linux-gnu",
 ]
 
+# Should be kept in sync with servoshell default features (best-effort).
+ASAN_SERVOSHELL_DEFAULT_FEATURES = [
+    "baked-in-resources",
+    "bundled_freetype",
+    "gamepad",
+    "servo/clipboard",
+    "js_jit",
+    "max_log_level",
+    "webgpu",
+    "webxr",
+]
+
 
 def get_rustc_llvm_version() -> Optional[list[int]]:
     """Determine the LLVM version of `rustc` and return it as a List[major, minor, patch, ...]
@@ -303,6 +315,9 @@ class MachCommands(CommandBase):
 
             # asan replaces system allocator with asan allocator
             # we need to make sure that we do not replace it with jemalloc
+            if "--no-default-features" not in opts:
+                opts += ["--no-default-features"]
+                self.features.extend(ASAN_SERVOSHELL_DEFAULT_FEATURES)
             self.features.append("servo-allocator/use-system-allocator")
         elif sanitizer.is_tsan():
             if target_triple not in SUPPORTED_TSAN_TARGETS:

--- a/python/servo/build_commands.py
+++ b/python/servo/build_commands.py
@@ -310,7 +310,7 @@ class MachCommands(CommandBase):
                 print(
                     "Info: Explicit `--no-default-features` passed in an ASAN build."
                     " Skipping `mach` override of default features. If you are not sure what"
-                    " you are doing, consider removing `--no-default-features from your invocation."
+                    " you are doing, consider removing `--no-default-features` from your invocation."
                 )
         elif sanitizer.is_tsan():
             if target_triple not in SUPPORTED_TSAN_TARGETS:

--- a/python/servo/build_commands.py
+++ b/python/servo/build_commands.py
@@ -308,9 +308,9 @@ class MachCommands(CommandBase):
                 self.features.append("default_without_allocator")
             else:
                 print(
-                    "Info: Explicit `--no-default-features` passed in an ASAN build. \
-                Skipping `mach` override of default features. If you are not sure what \
-                you are doing, consider removing `--no-default-features from your invocation."
+                    "Info: Explicit `--no-default-features` passed in an ASAN build."
+                    " Skipping `mach` override of default features. If you are not sure what"
+                    " you are doing, consider removing `--no-default-features from your invocation."
                 )
         elif sanitizer.is_tsan():
             if target_triple not in SUPPORTED_TSAN_TARGETS:

--- a/python/servo/build_commands.py
+++ b/python/servo/build_commands.py
@@ -301,9 +301,11 @@ class MachCommands(CommandBase):
             env["TARGET_CFLAGS"] += " -fsanitize=address"
             env["TARGET_CXXFLAGS"] += " -fsanitize=address"
 
+            # Servoshell enables a statically linked `jemalloc` by default, but we want to use libc malloc with ASAN,
+            # hence we use the default configuration without the custom allocator.
             if "--no-default-features" not in opts:
                 opts += ["--no-default-features"]
-                self.features.append("default_asan")
+                self.features.append("default_without_allocator")
             else:
                 print(
                     "Info: Explicit `--no-default-features` passed in an ASAN build. \

--- a/python/servo/build_commands.py
+++ b/python/servo/build_commands.py
@@ -53,18 +53,6 @@ SUPPORTED_TSAN_TARGETS = [
     "x86_64-unknown-linux-gnu",
 ]
 
-# Should be kept in sync with servoshell default features (best-effort).
-ASAN_SERVOSHELL_DEFAULT_FEATURES = [
-    "baked-in-resources",
-    "bundled_freetype",
-    "gamepad",
-    "servo/clipboard",
-    "js_jit",
-    "max_log_level",
-    "webgpu",
-    "webxr",
-]
-
 
 def get_rustc_llvm_version() -> Optional[list[int]]:
     """Determine the LLVM version of `rustc` and return it as a List[major, minor, patch, ...]
@@ -313,12 +301,15 @@ class MachCommands(CommandBase):
             env["TARGET_CFLAGS"] += " -fsanitize=address"
             env["TARGET_CXXFLAGS"] += " -fsanitize=address"
 
-            # asan replaces system allocator with asan allocator
-            # we need to make sure that we do not replace it with jemalloc
             if "--no-default-features" not in opts:
                 opts += ["--no-default-features"]
-                self.features.extend(ASAN_SERVOSHELL_DEFAULT_FEATURES)
-            self.features.append("servo-allocator/use-system-allocator")
+                self.features.append("default_asan")
+            else:
+                print(
+                    "Info: Explicit `--no-default-features` passed in an ASAN build. \
+                Skipping `mach` override of default features. If you are not sure what \
+                you are doing, consider removing `--no-default-features from your invocation."
+                )
         elif sanitizer.is_tsan():
             if target_triple not in SUPPORTED_TSAN_TARGETS:
                 print(


### PR DESCRIPTION
Add a feature, so we can avoid compiling the tikv-jemalloc crates, when they are not needed.
Reviewer feedback requested the jemalloc and and the system allocator backends to be mutually exclusive, meaning that `use-system-allocator` and the new `use-jemalloc` feature shouldn't be able to be used together.
That leads to the removal of the `use-system-allocator`  feature, since we can also detect the absense of custom allocator features instead, which means we remove on error path. 
For convenience purposes, this PR also adds feature groups, which bundle certain features: Our default web features, and bundled options. In servoshell we consolidate those into a `default_without_allocator` feature, so that in our ASAN build we can use the system allocator, while keeping other default dependencies.

These feature groups should also be more generally useful, e.g. if we start feature-gating more web-platform features.


Testing: Requires manual testing, to test the non-default allocator (system allocator) is still selected via `./mach build --no-default-features --features default_without_allocator`.