### PR TITLE
allocator: Add feature to enable jemalloc stats

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -255,7 +255,7 @@ script = { package = "servo-script", version = "0.1.0", path = "components/scrip
 script_bindings = { package = "servo-script-bindings", version = "0.1.0", path = "components/script_bindings" }
 script_traits = { package = "servo-script-traits", version = "0.1.0", path = "components/shared/script" }
 servo = { version = "0.1.0", path = "components/servo", default-features = false }
-servo-allocator = { version = "0.1.0", path = "components/allocator" }
+servo-allocator = { version = "0.1.0", path = "components/allocator", default-features = false }
 servo-background-hang-monitor = { version = "0.1.0", path = "components/background_hang_monitor" }
 servo-background-hang-monitor-api = { version = "0.1.0", path = "components/shared/background_hang_monitor" }
 servo-base = { version = "0.1.0", path = "components/shared/base" }

--- a/components/allocator/Cargo.toml
+++ b/components/allocator/Cargo.toml
@@ -13,8 +13,10 @@ description.workspace = true
 path = "lib.rs"
 
 [features]
+default = ["use-jemalloc"]
 allocation-tracking = ["backtrace", "dep:rustc-hash", "log"]
-use-system-allocator = ["libc"]
+use-system-allocator = []
+use-jemalloc = ["dep:tikv-jemalloc-sys", "dep:tikv-jemallocator"]
 
 [dependencies]
 backtrace = { workspace = true, optional = true }
@@ -22,9 +24,9 @@ log = { workspace = true, optional = true }
 rustc-hash = { workspace = true, optional = true }
 
 [target.'cfg(not(any(windows, target_env = "ohos")))'.dependencies]
-libc = { workspace = true, optional = true }
-tikv-jemalloc-sys = { workspace = true }
-tikv-jemallocator = { workspace = true }
+libc = { workspace = true }
+tikv-jemalloc-sys = { workspace = true, optional = true }
+tikv-jemallocator = { workspace = true, optional = true }
 
 [target.'cfg(windows)'.dependencies]
 windows-sys = { workspace = true, features = ["Win32_System_Memory"] }

--- a/components/allocator/Cargo.toml
+++ b/components/allocator/Cargo.toml
@@ -17,6 +17,7 @@ default = ["use-jemalloc"]
 allocation-tracking = ["backtrace", "dep:rustc-hash", "log"]
 use-system-allocator = []
 use-jemalloc = ["dep:tikv-jemalloc-sys", "dep:tikv-jemallocator"]
+jemalloc-stats = ["tikv-jemalloc-sys?/stats"]
 
 [dependencies]
 backtrace = { workspace = true, optional = true }

--- a/components/allocator/lib.rs
+++ b/components/allocator/lib.rs
@@ -53,7 +53,14 @@ pub static enclosing_size: Option<EnclosingSizeFn> = Some(crate::enclosing_size_
 #[cfg(not(feature = "allocation-tracking"))]
 pub static enclosing_size: Option<EnclosingSizeFn> = None;
 
-#[cfg(not(any(windows, feature = "use-system-allocator", target_env = "ohos")))]
+// If both `use-jemalloc` and `use-system-allocator` are selected, use the system allocator.
+// `use-jemalloc` is selected by default in servoshell, and we mainly have the feature to be able
+// to remove the compile time dependency on jemalloc.
+#[cfg(all(
+    feature = "use-jemalloc",
+    not(feature = "use-system-allocator"),
+    not(any(windows, target_env = "ohos"))
+))]
 mod platform {
     use std::os::raw::c_void;
 
@@ -77,9 +84,14 @@ mod platform {
     }
 }
 
+// If no allocator feature is selected, use the system allocator.
 #[cfg(all(
     not(windows),
-    any(feature = "use-system-allocator", target_env = "ohos")
+    any(
+        feature = "use-system-allocator",
+        target_env = "ohos",
+        not(feature = "use-jemalloc")
+    ),
 ))]
 mod platform {
     pub use std::alloc::System as Allocator;

--- a/ports/servoshell/Cargo.toml
+++ b/ports/servoshell/Cargo.toml
@@ -41,7 +41,7 @@ OriginalFilename = "servoshell.exe"
 ProductName = "ServoShell"
 
 [features]
-default = ["baked-in-resources", "gamepad", "servo/clipboard", "servo-allocator/use-jemalloc", "js_jit", "max_log_level", "webgpu", "webxr"]
+default = ["baked-in-resources", "gamepad", "servo/clipboard", "servo-allocator/use-jemalloc", "servo-allocator/jemalloc-stats", "js_jit", "max_log_level", "webgpu", "webxr"]
 baked-in-resources = ["servo/baked-in-resources"]
 crown = ["servo/crown"]
 debugmozjs = ["servo/debugmozjs"]

--- a/ports/servoshell/Cargo.toml
+++ b/ports/servoshell/Cargo.toml
@@ -41,7 +41,7 @@ OriginalFilename = "servoshell.exe"
 ProductName = "ServoShell"
 
 [features]
-default = ["baked-in-resources", "gamepad", "servo/clipboard", "js_jit", "max_log_level", "webgpu", "webxr"]
+default = ["baked-in-resources", "gamepad", "servo/clipboard", "servo-allocator/use-jemalloc", "js_jit", "max_log_level", "webgpu", "webxr"]
 baked-in-resources = ["servo/baked-in-resources"]
 crown = ["servo/crown"]
 debugmozjs = ["servo/debugmozjs"]


### PR DESCRIPTION
Depends on #44032. 

We need to enable this feature to get the jemalloc related statistics in `about:memory`, otherwise they will not appear.
We enable this by default in servoshell, but don't add it to the default features of servo, since this is a debugging helper.

Testing: Manually tested by opening `about:memory` and observing the new jemalloc related entries.

