### PR TITLE
localstorage: test storage is not shared across iframes with opaque origins

### DIFF
--- a/tests/wpt/meta/webstorage/localstorage-share-data-unrelated-origins.html.ini
+++ b/tests/wpt/meta/webstorage/localstorage-share-data-unrelated-origins.html.ini
@@ -1,0 +1,3 @@
+[localstorage-share-data-unrelated-origins.html]
+  [Ensure two about:srcdoc origins cannot share localstorage]
+    expected: FAIL

--- a/tests/wpt/tests/webstorage/localstorage-share-data-unrelated-origins.html
+++ b/tests/wpt/tests/webstorage/localstorage-share-data-unrelated-origins.html
@@ -1,0 +1,38 @@
+<!doctype html>
+<meta charset=utf-8>
+<title>localStorage: origin sharing test</title>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src='/common/get-host-info.sub.js'></script>
+<iframe id="iframe" srcdoc="
+  <script>
+    window.localStorage.setItem('test', 'user')
+  </script>
+"></iframe>
+
+<body>
+  <div id="testDiv"></div>
+  <script>
+    // Here's the set-up for this test:
+    // Step 1. (iframe) has the URI about:srcdoc and sets a localstorage key.
+    // Step 2. (window) an onload handler for the iframe runs a JavaScript function that 
+    //          creates a new iframe with cross-origin URL to page two.
+    // Step 3. (page two iframe) has the URI about:src. 
+    //          It retrieves the value from localStorage set by the iframe in step 1.
+    //          And sends the value using postMessage to window.parent.parent
+    // Step 4. (window) Uses an `onmessage` handler to recieve the value from the dispatched event.
+    //          A test inside the handler uses assert_not_equals to verify that 
+    //          the two origins do not share the same localStorage
+    const iframe = document.getElementById("iframe")
+    const pageURL = get_host_info().HTTP_REMOTE_ORIGIN + "/webstorage/resources/localstorage_origin_page_two.html";
+
+    iframe.addEventListener("load", (event) => {
+      const iframe_page_two = document.createElement("iframe");
+      var t = async_test("Ensure two about:srcdoc origins cannot share localstorage")
+      iframe_page_two.src = pageURL;
+      testDiv.appendChild(iframe_page_two);
+      window.onmessage = t.step_func_done(function(e) {
+        assert_not_equals(e.data, 'user');
+      }) 
+    })
+  </script>

--- a/tests/wpt/tests/webstorage/localstorage-share-data-unrelated-origins.html
+++ b/tests/wpt/tests/webstorage/localstorage-share-data-unrelated-origins.html
@@ -23,16 +23,18 @@
     // Step 4. (window) Uses an `onmessage` handler to recieve the value from the dispatched event.
     //          A test inside the handler uses assert_not_equals to verify that 
     //          the two origins do not share the same localStorage
-    const iframe = document.getElementById("iframe")
-    const pageURL = get_host_info().HTTP_REMOTE_ORIGIN + "/webstorage/resources/localstorage_origin_page_two.html";
+    var t = async_test(t => {
+      const iframe = document.getElementById("iframe")
+      const pageURL = get_host_info().HTTP_REMOTE_ORIGIN + "/webstorage/resources/localstorage_origin_page_two.html";
 
-    iframe.addEventListener("load", (event) => {
-      const iframe_page_two = document.createElement("iframe");
-      var t = async_test("Ensure two about:srcdoc origins cannot share localstorage")
-      iframe_page_two.src = pageURL;
-      testDiv.appendChild(iframe_page_two);
-      window.onmessage = t.step_func_done(function(e) {
-        assert_not_equals(e.data, 'user');
-      }) 
-    })
+      iframe.addEventListener("load", t.step_func(() => {
+        const iframe_page_two = document.createElement("iframe");
+        iframe_page_two.src = pageURL;
+        testDiv.appendChild(iframe_page_two);
+        window.onmessage = t.step_func(function(e) {
+          assert_not_equals(e.data, 'user');
+          t.done()
+        }) 
+      }))
+    }, "Ensure two about:srcdoc origins cannot share localstorage")
   </script>

--- a/tests/wpt/tests/webstorage/localstorage-share-data-unrelated-origins.html
+++ b/tests/wpt/tests/webstorage/localstorage-share-data-unrelated-origins.html
@@ -15,13 +15,13 @@
   <script>
     // Here's the set-up for this test:
     // Step 1. (iframe) has the URI about:srcdoc and sets a localstorage key.
-    // Step 2. (window) an onload handler for the iframe runs a JavaScript function that 
+    // Step 2. (window) an onload handler for the iframe runs a JavaScript function that
     //          creates a new iframe with cross-origin URL to page two.
-    // Step 3. (page two iframe) has the URI about:src. 
+    // Step 3. (page two iframe) has the URI about:src.
     //          It retrieves the value from localStorage set by the iframe in step 1.
     //          And sends the value using postMessage to window.parent.parent
     // Step 4. (window) Uses an `onmessage` handler to recieve the value from the dispatched event.
-    //          A test inside the handler uses assert_not_equals to verify that 
+    //          A test inside the handler uses assert_not_equals to verify that
     //          the two origins do not share the same localStorage
     var t = async_test(t => {
       const iframe = document.getElementById("iframe")
@@ -34,7 +34,7 @@
         window.onmessage = t.step_func(function(e) {
           assert_not_equals(e.data, 'user');
           t.done()
-        }) 
+        })
       }))
     }, "Ensure two about:srcdoc origins cannot share localstorage")
   </script>

--- a/tests/wpt/tests/webstorage/resources/localstorage_origin_page_two.html
+++ b/tests/wpt/tests/webstorage/resources/localstorage_origin_page_two.html
@@ -5,7 +5,7 @@
   <script src='/common/get-host-info.sub.js'></script>
   <script>
     const value = window.localStorage.getItem('test');
-    const pageURL = get_host_info().HTTP_REMOTE_ORIGIN + '/webstorage/localstorage-share-data-unrelated-origins.html';
+    const pageURL = get_host_info().HTTP_ORIGIN;
     window.parent.parent.postMessage(value, pageURL);
   </script>
 "></iframe>

--- a/tests/wpt/tests/webstorage/resources/localstorage_origin_page_two.html
+++ b/tests/wpt/tests/webstorage/resources/localstorage_origin_page_two.html
@@ -1,0 +1,15 @@
+<!doctype html>
+<meta charset=utf-8>
+<title>localStorage: origin test page two</title>
+<iframe id="iframe" srcdoc="
+  <script src='/common/get-host-info.sub.js'></script>
+  <script>
+    const value = window.localStorage.getItem('test');
+    const pageURL = get_host_info().HTTP_REMOTE_ORIGIN + '/webstorage/localstorage-share-data-unrelated-origins.html';
+    window.parent.parent.postMessage(value, pageURL);
+  </script>
+"></iframe>
+<body>
+</body>
+<script>
+</script>

--- a/tests/wpt/webgl/meta/MANIFEST.json
+++ b/tests/wpt/webgl/meta/MANIFEST.json
@@ -135,6 +135,10 @@
    }
   },
   "support": {
+   ".DS_Store": [
+    "92f464fbb2219e158e353a4695341364591d1017",
+    []
+   ],
    "00_test_list.txt": [
     "3fde5ef8de5a500e5b2d9e100c132a5732c2aa8d",
     []

--- a/tests/wpt/webgl/meta/MANIFEST.json
+++ b/tests/wpt/webgl/meta/MANIFEST.json
@@ -135,10 +135,6 @@
    }
   },
   "support": {
-   ".DS_Store": [
-    "92f464fbb2219e158e353a4695341364591d1017",
-    []
-   ],
    "00_test_list.txt": [
     "3fde5ef8de5a500e5b2d9e100c132a5732c2aa8d",
     []


### PR DESCRIPTION
Adds a WPT test to make sure we do not share the storage thread between any document that has an opaque URL.
The test is required for #43988

Testing: Adds a WPT test.
Fixes: #44001 
