### PR TITLE
script: Fix computation of "fontsize" command value

### DIFF
--- a/components/script/dom/execcommand/basecommand.rs
+++ b/components/script/dom/execcommand/basecommand.rs
@@ -84,7 +84,7 @@ impl CssPropertyName {
                             }
                         })
                         .or_else(|| {
-                            let pixels = style.clone_font().font_size.computed_size().px();
+                            let pixels = style.get_font().font_size.computed_size().px();
                             Some(format!("{}px", pixels).into())
                         });
                 },

--- a/components/script/dom/execcommand/basecommand.rs
+++ b/components/script/dom/execcommand/basecommand.rs
@@ -68,6 +68,11 @@ impl CssPropertyName {
                     // resolution would have done. This also allows us to later check for
                     // loose equivalence for font elements, since we would return the size as an
                     // integer, without a size indicator (e.g. `px`).
+                    //
+                    // However, if no such relevant declaration exists, then we should fallback
+                    // to pixels after all. For the effective command value, this essentially means
+                    // we will overwrite it. For the value of the "fontsize" command, we would then
+                    // need to convert it using [`legacy_font_size_for`].
                     return element
                         .upcast::<Node>()
                         .inclusive_ancestors(ShadowIncluding::No)
@@ -77,6 +82,10 @@ impl CssPropertyName {
                             } else {
                                 self.value_set_for_style(ancestor.downcast::<Element>()?)
                             }
+                        })
+                        .or_else(|| {
+                            let pixels = style.clone_font().font_size.computed_size().px();
+                            Some(format!("{}px", pixels).into())
                         });
                 },
                 CssPropertyName::FontWeight => style.clone_font_weight().to_css_string(),

--- a/components/script/dom/execcommand/commands/fontsize.rs
+++ b/components/script/dom/execcommand/commands/fontsize.rs
@@ -2,63 +2,48 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-use html5ever::local_name;
-use script_bindings::inheritance::Castable;
+use app_units::Au;
+use servo_config::pref;
 use style::attr::parse_integer;
+use style::values::computed::CSSPixelLength;
+use style::values::specified::FontSize;
 
-use crate::dom::ShadowIncluding;
-use crate::dom::bindings::codegen::Bindings::AttrBinding::AttrMethods;
 use crate::dom::bindings::codegen::Bindings::DocumentBinding::DocumentMethods;
-use crate::dom::bindings::root::DomRoot;
 use crate::dom::bindings::str::DOMString;
 use crate::dom::document::Document;
-use crate::dom::element::Element;
 use crate::dom::execcommand::basecommand::CommandName;
 use crate::dom::execcommand::contenteditable::{
     NodeExecCommandSupport, SelectionExecCommandSupport,
 };
-use crate::dom::html::htmlfontelement::HTMLFontElement;
-use crate::dom::node::Node;
 use crate::dom::selection::Selection;
 use crate::script_runtime::CanGc;
 
-impl HTMLFontElement {
-    fn font_size_if_size_matches(&self, should_match_size: i32) -> Option<i32> {
-        let attribute = self
-            .upcast::<Element>()
-            .get_attribute(&local_name!("size"))?;
-        let value = attribute.Value();
-        let size = value.parse::<i32>().ok()?;
-
-        Some(size).filter(|size| *size == should_match_size)
-    }
-}
-
 /// <https://w3c.github.io/editing/docs/execCommand/#legacy-font-size-for>
-pub(crate) fn legacy_font_size_for(pixel_size: i32, document: &Document) -> DOMString {
-    let font_elements: Vec<DomRoot<HTMLFontElement>> = document
-        .upcast::<Node>()
-        .traverse_preorder(ShadowIncluding::No)
-        .filter_map(DomRoot::downcast::<HTMLFontElement>)
-        .collect();
+pub(crate) fn legacy_font_size_for(pixel_size: f32, document: &Document) -> DOMString {
+    let quirks_mode = document.quirks_mode();
+    let base_size = CSSPixelLength::from(Au::from_f32_px(pref!(fonts_default_size) as f32));
     // Step 1. Let returned size be 1.
     let mut returned_size = 1;
     // Step 2. While returned size is less than 7:
     while returned_size < 7 {
         // Step 2.1. Let lower bound be the resolved value of "font-size" in pixels
         // of a font element whose size attribute is set to returned size.
-        let lower_bound = font_elements
-            .iter()
-            .find_map(|font_element| font_element.font_size_if_size_matches(returned_size))
-            .unwrap_or_default();
+        let FontSize::Keyword(lower_keyword) = FontSize::from_html_size(returned_size) else {
+            unreachable!("Always computed as keyword");
+        };
+        let lower_bound = lower_keyword
+            .kw
+            .to_length_without_context(quirks_mode, base_size);
         // Step 2.2. Let upper bound be the resolved value of "font-size" in pixels
         // of a font element whose size attribute is set to one plus returned size.
-        let upper_bound = font_elements
-            .iter()
-            .find_map(|font_element| font_element.font_size_if_size_matches(returned_size + 1))
-            .unwrap_or_default();
+        let FontSize::Keyword(upper_keyword) = FontSize::from_html_size(returned_size + 1) else {
+            unreachable!("Always computed as keyword");
+        };
+        let upper_bound = upper_keyword
+            .kw
+            .to_length_without_context(quirks_mode, base_size);
         // Step 2.3. Let average be the average of upper bound and lower bound.
-        let average = (lower_bound + upper_bound) / 2;
+        let average = (lower_bound.0.px() + upper_bound.0.px()) / 2.0;
         // Step 2.4. If pixel size is less than average,
         // return the one-code unit string consisting of the digit returned size.
         //
@@ -161,20 +146,31 @@ pub(crate) fn value_for_fontsize_command(
         .first_formattable_contained_node()
         .unwrap_or_else(|| active_range.start_container())
         .effective_command_value(&CommandName::FontSize)?;
-    let pixel_size = command_value.parse::<i32>().ok()?;
     // Step 3. Return the legacy font size for pixel size.
-    Some(legacy_font_size_for(pixel_size, document))
+    //
+    // Only in the case we have resolved to actual pixels, we need to
+    // do its conversion. In other cases, we already have the relevant
+    // font size or corresponding css value. This avoids expensive
+    // conversions of pixels to other values.
+    if command_value.ends_with_str("px") {
+        command_value.str()[0..command_value.len() - 2]
+            .parse::<f32>()
+            .ok()
+            .map(|value| legacy_font_size_for(value, document))
+    } else {
+        Some(normalize_font_string(&command_value.str()).into())
+    }
 }
 
 fn normalize_font_string(str_: &str) -> &str {
     match str_ {
-        "1" => "x-small",
-        "2" => "small",
-        "3" => "medium",
-        "4" => "large",
-        "5" => "x-large",
-        "6" => "xx-large",
-        "7" => "xxx-large",
+        "x-small" => "1",
+        "small" => "2",
+        "medium" => "3",
+        "large" => "4",
+        "x-large" => "5",
+        "xx-large" => "6",
+        "xxx-large" => "7",
         _ => str_,
     }
 }

--- a/components/script/dom/execcommand/execcommands.rs
+++ b/components/script/dom/execcommand/execcommands.rs
@@ -195,8 +195,8 @@ impl DocumentExecCommandSupport for Document {
                 // convert the value override to an integer number of pixels and return the legacy font size for the result.
                 if command == CommandName::FontSize {
                     value_override
-                        .parse()
-                        .map(|parsed| legacy_font_size_for(parsed, self))
+                        .parse::<i32>()
+                        .map(|parsed| legacy_font_size_for(parsed as f32, self))
                         .unwrap_or(value_override)
                 } else {
                     value_override

--- a/components/script_bindings/domstring.rs
+++ b/components/script_bindings/domstring.rs
@@ -542,6 +542,10 @@ impl DOMString {
         self.str().starts_with(needle)
     }
 
+    pub fn ends_with_str(&self, needle: &str) -> bool {
+        self.str().ends_with(needle)
+    }
+
     pub fn contains(&self, needle: &str) -> bool {
         self.str().contains(needle)
     }

--- a/tests/wpt/meta/editing/run/fontsize.html.ini
+++ b/tests/wpt/meta/editing/run/fontsize.html.ini
@@ -1,7 +1,4 @@
 [fontsize.html?1-1000]
-  [[["fontsize","4"\]\] "foo[\]bar" queryCommandValue("fontsize") before]
-    expected: FAIL
-
   [[["fontsize","4"\]\] "foo[\]bar" queryCommandValue("fontsize") after]
     expected: FAIL
 
@@ -535,46 +532,16 @@
 
 
 [fontsize.html?1001-2000]
-  [[["stylewithcss","false"\],["fontsize","4"\]\] "<table><tbody data-start=0 data-end=1><tr><td>foo<td>bar<td>baz</table>" queryCommandValue("fontsize") before]
-    expected: FAIL
-
   [[["stylewithcss","false"\],["fontsize","4"\]\] "<table><tbody data-start=0 data-end=1><tr><td>foo<td>bar<td>baz</table>" queryCommandValue("fontsize") after]
-    expected: FAIL
-
-  [[["stylewithcss","true"\],["fontsize","4"\]\] "<table data-start=0 data-end=1><tbody><tr><td>foo<td>bar<td>baz</table>" queryCommandValue("fontsize") before]
-    expected: FAIL
-
-  [[["stylewithcss","true"\],["fontsize","4"\]\] "<table data-start=0 data-end=1><tbody><tr><td>foo<td>bar<td>baz</table>" queryCommandValue("fontsize") after]
     expected: FAIL
 
   [[["stylewithcss","false"\],["fontsize","4"\]\] "<table data-start=0 data-end=1><tbody><tr><td>foo<td>bar<td>baz</table>" compare innerHTML]
     expected: FAIL
 
-  [[["stylewithcss","false"\],["fontsize","4"\]\] "<table data-start=0 data-end=1><tbody><tr><td>foo<td>bar<td>baz</table>" queryCommandValue("fontsize") before]
-    expected: FAIL
-
-  [[["stylewithcss","false"\],["fontsize","4"\]\] "<table data-start=0 data-end=1><tbody><tr><td>foo<td>bar<td>baz</table>" queryCommandValue("fontsize") after]
-    expected: FAIL
-
-  [[["stylewithcss","true"\],["fontsize","4"\]\] "{<table><tr><td>foo<td>bar<td>baz</table>}" queryCommandValue("fontsize") before]
-    expected: FAIL
-
-  [[["stylewithcss","true"\],["fontsize","4"\]\] "{<table><tr><td>foo<td>bar<td>baz</table>}" queryCommandValue("fontsize") after]
-    expected: FAIL
-
   [[["stylewithcss","false"\],["fontsize","4"\]\] "{<table><tr><td>foo<td>bar<td>baz</table>}" compare innerHTML]
     expected: FAIL
 
-  [[["stylewithcss","false"\],["fontsize","4"\]\] "{<table><tr><td>foo<td>bar<td>baz</table>}" queryCommandValue("fontsize") before]
-    expected: FAIL
-
-  [[["stylewithcss","false"\],["fontsize","4"\]\] "{<table><tr><td>foo<td>bar<td>baz</table>}" queryCommandValue("fontsize") after]
-    expected: FAIL
-
   [[["stylewithcss","true"\],["fontsize","4"\]\] "foo<font size=1>[bar\]</font>baz" compare innerHTML]
-    expected: FAIL
-
-  [[["stylewithcss","true"\],["fontsize","4"\]\] "foo<font size=1>[bar\]</font>baz" queryCommandValue("fontsize") before]
     expected: FAIL
 
   [[["stylewithcss","true"\],["fontsize","4"\]\] "foo<font size=1>[bar\]</font>baz" queryCommandValue("fontsize") after]
@@ -583,16 +550,10 @@
   [[["stylewithcss","false"\],["fontsize","4"\]\] "foo<font size=1>[bar\]</font>baz" compare innerHTML]
     expected: FAIL
 
-  [[["stylewithcss","false"\],["fontsize","4"\]\] "foo<font size=1>[bar\]</font>baz" queryCommandValue("fontsize") before]
-    expected: FAIL
-
   [[["stylewithcss","false"\],["fontsize","4"\]\] "foo<font size=1>[bar\]</font>baz" queryCommandValue("fontsize") after]
     expected: FAIL
 
   [[["stylewithcss","true"\],["fontsize","4"\]\] "<font size=1>foo[bar\]baz</font>" compare innerHTML]
-    expected: FAIL
-
-  [[["stylewithcss","true"\],["fontsize","4"\]\] "<font size=1>foo[bar\]baz</font>" queryCommandValue("fontsize") before]
     expected: FAIL
 
   [[["stylewithcss","true"\],["fontsize","4"\]\] "<font size=1>foo[bar\]baz</font>" queryCommandValue("fontsize") after]
@@ -601,16 +562,10 @@
   [[["stylewithcss","false"\],["fontsize","4"\]\] "<font size=1>foo[bar\]baz</font>" compare innerHTML]
     expected: FAIL
 
-  [[["stylewithcss","false"\],["fontsize","4"\]\] "<font size=1>foo[bar\]baz</font>" queryCommandValue("fontsize") before]
-    expected: FAIL
-
   [[["stylewithcss","false"\],["fontsize","4"\]\] "<font size=1>foo[bar\]baz</font>" queryCommandValue("fontsize") after]
     expected: FAIL
 
   [[["stylewithcss","true"\],["fontsize","4"\]\] "foo<font size=3>[bar\]</font>baz" compare innerHTML]
-    expected: FAIL
-
-  [[["stylewithcss","true"\],["fontsize","4"\]\] "foo<font size=3>[bar\]</font>baz" queryCommandValue("fontsize") before]
     expected: FAIL
 
   [[["stylewithcss","true"\],["fontsize","4"\]\] "foo<font size=3>[bar\]</font>baz" queryCommandValue("fontsize") after]
@@ -619,16 +574,10 @@
   [[["stylewithcss","false"\],["fontsize","4"\]\] "foo<font size=3>[bar\]</font>baz" compare innerHTML]
     expected: FAIL
 
-  [[["stylewithcss","false"\],["fontsize","4"\]\] "foo<font size=3>[bar\]</font>baz" queryCommandValue("fontsize") before]
-    expected: FAIL
-
   [[["stylewithcss","false"\],["fontsize","4"\]\] "foo<font size=3>[bar\]</font>baz" queryCommandValue("fontsize") after]
     expected: FAIL
 
   [[["stylewithcss","true"\],["fontsize","4"\]\] "<font size=3>foo[bar\]baz</font>" compare innerHTML]
-    expected: FAIL
-
-  [[["stylewithcss","true"\],["fontsize","4"\]\] "<font size=3>foo[bar\]baz</font>" queryCommandValue("fontsize") before]
     expected: FAIL
 
   [[["stylewithcss","true"\],["fontsize","4"\]\] "<font size=3>foo[bar\]baz</font>" queryCommandValue("fontsize") after]
@@ -637,31 +586,10 @@
   [[["stylewithcss","false"\],["fontsize","4"\]\] "<font size=3>foo[bar\]baz</font>" compare innerHTML]
     expected: FAIL
 
-  [[["stylewithcss","false"\],["fontsize","4"\]\] "<font size=3>foo[bar\]baz</font>" queryCommandValue("fontsize") before]
-    expected: FAIL
-
   [[["stylewithcss","false"\],["fontsize","4"\]\] "<font size=3>foo[bar\]baz</font>" queryCommandValue("fontsize") after]
     expected: FAIL
 
   [[["stylewithcss","true"\],["fontsize","4"\]\] "foo<font size=4>[bar\]</font>baz" compare innerHTML]
-    expected: FAIL
-
-  [[["stylewithcss","true"\],["fontsize","4"\]\] "foo<font size=4>[bar\]</font>baz" queryCommandValue("fontsize") before]
-    expected: FAIL
-
-  [[["stylewithcss","true"\],["fontsize","4"\]\] "foo<font size=4>[bar\]</font>baz" queryCommandValue("fontsize") after]
-    expected: FAIL
-
-  [[["stylewithcss","false"\],["fontsize","4"\]\] "foo<font size=4>[bar\]</font>baz" queryCommandValue("fontsize") before]
-    expected: FAIL
-
-  [[["stylewithcss","false"\],["fontsize","4"\]\] "foo<font size=4>[bar\]</font>baz" queryCommandValue("fontsize") after]
-    expected: FAIL
-
-  [[["fontsize","4"\]\] "<font size=4>foo[bar\]baz</font>" queryCommandValue("fontsize") before]
-    expected: FAIL
-
-  [[["fontsize","4"\]\] "<font size=4>foo[bar\]baz</font>" queryCommandValue("fontsize") after]
     expected: FAIL
 
   [[["stylewithcss","true"\],["fontsize","4"\]\] "foo<font size=+1>[bar\]</font>baz" compare innerHTML]
@@ -691,16 +619,10 @@
   [[["stylewithcss","true"\],["fontsize","4"\]\] "<font size=4>foo<font size=1>b[a\]r</font>baz</font>" compare innerHTML]
     expected: FAIL
 
-  [[["stylewithcss","true"\],["fontsize","4"\]\] "<font size=4>foo<font size=1>b[a\]r</font>baz</font>" queryCommandValue("fontsize") before]
-    expected: FAIL
-
   [[["stylewithcss","true"\],["fontsize","4"\]\] "<font size=4>foo<font size=1>b[a\]r</font>baz</font>" queryCommandValue("fontsize") after]
     expected: FAIL
 
   [[["stylewithcss","false"\],["fontsize","4"\]\] "<font size=4>foo<font size=1>b[a\]r</font>baz</font>" compare innerHTML]
-    expected: FAIL
-
-  [[["stylewithcss","false"\],["fontsize","4"\]\] "<font size=4>foo<font size=1>b[a\]r</font>baz</font>" queryCommandValue("fontsize") before]
     expected: FAIL
 
   [[["stylewithcss","false"\],["fontsize","4"\]\] "<font size=4>foo<font size=1>b[a\]r</font>baz</font>" queryCommandValue("fontsize") after]
@@ -745,16 +667,10 @@
   [[["stylewithcss","true"\],["fontsize","4"\]\] "foo<span style=\\"font-size: medium\\">[bar\]</span>baz" compare innerHTML]
     expected: FAIL
 
-  [[["stylewithcss","true"\],["fontsize","4"\]\] "foo<span style=\\"font-size: medium\\">[bar\]</span>baz" queryCommandValue("fontsize") before]
-    expected: FAIL
-
   [[["stylewithcss","true"\],["fontsize","4"\]\] "foo<span style=\\"font-size: medium\\">[bar\]</span>baz" queryCommandValue("fontsize") after]
     expected: FAIL
 
   [[["stylewithcss","false"\],["fontsize","4"\]\] "foo<span style=\\"font-size: medium\\">[bar\]</span>baz" compare innerHTML]
-    expected: FAIL
-
-  [[["stylewithcss","false"\],["fontsize","4"\]\] "foo<span style=\\"font-size: medium\\">[bar\]</span>baz" queryCommandValue("fontsize") before]
     expected: FAIL
 
   [[["stylewithcss","false"\],["fontsize","4"\]\] "foo<span style=\\"font-size: medium\\">[bar\]</span>baz" queryCommandValue("fontsize") after]
@@ -763,40 +679,16 @@
   [[["stylewithcss","true"\],["fontsize","4"\]\] "<span style=\\"font-size: medium\\">foo[bar\]baz</span>" compare innerHTML]
     expected: FAIL
 
-  [[["stylewithcss","true"\],["fontsize","4"\]\] "<span style=\\"font-size: medium\\">foo[bar\]baz</span>" queryCommandValue("fontsize") before]
-    expected: FAIL
-
   [[["stylewithcss","true"\],["fontsize","4"\]\] "<span style=\\"font-size: medium\\">foo[bar\]baz</span>" queryCommandValue("fontsize") after]
     expected: FAIL
 
   [[["stylewithcss","false"\],["fontsize","4"\]\] "<span style=\\"font-size: medium\\">foo[bar\]baz</span>" compare innerHTML]
     expected: FAIL
 
-  [[["stylewithcss","false"\],["fontsize","4"\]\] "<span style=\\"font-size: medium\\">foo[bar\]baz</span>" queryCommandValue("fontsize") before]
-    expected: FAIL
-
   [[["stylewithcss","false"\],["fontsize","4"\]\] "<span style=\\"font-size: medium\\">foo[bar\]baz</span>" queryCommandValue("fontsize") after]
     expected: FAIL
 
-  [[["stylewithcss","true"\],["fontsize","4"\]\] "foo<span style=\\"font-size: large\\">[bar\]</span>baz" queryCommandValue("fontsize") before]
-    expected: FAIL
-
-  [[["stylewithcss","true"\],["fontsize","4"\]\] "foo<span style=\\"font-size: large\\">[bar\]</span>baz" queryCommandValue("fontsize") after]
-    expected: FAIL
-
   [[["stylewithcss","false"\],["fontsize","4"\]\] "foo<span style=\\"font-size: large\\">[bar\]</span>baz" compare innerHTML]
-    expected: FAIL
-
-  [[["stylewithcss","false"\],["fontsize","4"\]\] "foo<span style=\\"font-size: large\\">[bar\]</span>baz" queryCommandValue("fontsize") before]
-    expected: FAIL
-
-  [[["stylewithcss","false"\],["fontsize","4"\]\] "foo<span style=\\"font-size: large\\">[bar\]</span>baz" queryCommandValue("fontsize") after]
-    expected: FAIL
-
-  [[["fontsize","4"\]\] "<span style=\\"font-size: large\\">foo[bar\]baz</span>" queryCommandValue("fontsize") before]
-    expected: FAIL
-
-  [[["fontsize","4"\]\] "<span style=\\"font-size: large\\">foo[bar\]baz</span>" queryCommandValue("fontsize") after]
     expected: FAIL
 
   [[["stylewithcss","true"\],["fontsize","4"\]\] "<span style=\\"font-size: large\\">foo<span style=\\"font-size: xx-small\\">b[a\]r</span>baz</span>" compare innerHTML]
@@ -805,16 +697,10 @@
   [[["stylewithcss","true"\],["fontsize","4"\]\] "<span style=\\"font-size: large\\">foo<span style=\\"font-size: xx-small\\">b[a\]r</span>baz</span>" queryCommandValue("fontsize") before]
     expected: FAIL
 
-  [[["stylewithcss","true"\],["fontsize","4"\]\] "<span style=\\"font-size: large\\">foo<span style=\\"font-size: xx-small\\">b[a\]r</span>baz</span>" queryCommandValue("fontsize") after]
-    expected: FAIL
-
   [[["stylewithcss","false"\],["fontsize","4"\]\] "<span style=\\"font-size: large\\">foo<span style=\\"font-size: xx-small\\">b[a\]r</span>baz</span>" compare innerHTML]
     expected: FAIL
 
   [[["stylewithcss","false"\],["fontsize","4"\]\] "<span style=\\"font-size: large\\">foo<span style=\\"font-size: xx-small\\">b[a\]r</span>baz</span>" queryCommandValue("fontsize") before]
-    expected: FAIL
-
-  [[["stylewithcss","false"\],["fontsize","4"\]\] "<span style=\\"font-size: large\\">foo<span style=\\"font-size: xx-small\\">b[a\]r</span>baz</span>" queryCommandValue("fontsize") after]
     expected: FAIL
 
   [[["stylewithcss","true"\],["fontsize","4"\]\] "foo<span style=\\"font-size: 2em\\">[bar\]</span>baz" compare innerHTML]
@@ -868,25 +754,13 @@
   [[["stylewithcss","false"\],["fontsize","4"\]\] "<p style=\\"font-size: xx-small\\">foo[bar\]baz</p>" queryCommandValue("fontsize") after]
     expected: FAIL
 
-  [[["stylewithcss","true"\],["fontsize","4"\]\] "<p style=\\"font-size: medium\\">foo[bar\]baz</p>" queryCommandValue("fontsize") before]
-    expected: FAIL
-
   [[["stylewithcss","true"\],["fontsize","4"\]\] "<p style=\\"font-size: medium\\">foo[bar\]baz</p>" queryCommandValue("fontsize") after]
     expected: FAIL
 
   [[["stylewithcss","false"\],["fontsize","4"\]\] "<p style=\\"font-size: medium\\">foo[bar\]baz</p>" compare innerHTML]
     expected: FAIL
 
-  [[["stylewithcss","false"\],["fontsize","4"\]\] "<p style=\\"font-size: medium\\">foo[bar\]baz</p>" queryCommandValue("fontsize") before]
-    expected: FAIL
-
   [[["stylewithcss","false"\],["fontsize","4"\]\] "<p style=\\"font-size: medium\\">foo[bar\]baz</p>" queryCommandValue("fontsize") after]
-    expected: FAIL
-
-  [[["fontsize","4"\]\] "<p style=\\"font-size: large\\">foo[bar\]baz</p>" queryCommandValue("fontsize") before]
-    expected: FAIL
-
-  [[["fontsize","4"\]\] "<p style=\\"font-size: large\\">foo[bar\]baz</p>" queryCommandValue("fontsize") after]
     expected: FAIL
 
   [[["stylewithcss","true"\],["fontsize","4"\]\] "<p style=\\"font-size: 2em\\">foo[bar\]baz</p>" queryCommandValue("fontsize") before]
@@ -922,25 +796,13 @@
   [[["stylewithcss","false"\],["fontsize","3"\]\] "<p style=\\"font-size: xx-small\\">foo[bar\]baz</p>" queryCommandValue("fontsize") after]
     expected: FAIL
 
-  [[["fontsize","3"\]\] "<p style=\\"font-size: medium\\">foo[bar\]baz</p>" queryCommandValue("fontsize") before]
-    expected: FAIL
-
-  [[["fontsize","3"\]\] "<p style=\\"font-size: medium\\">foo[bar\]baz</p>" queryCommandValue("fontsize") after]
-    expected: FAIL
-
   [[["stylewithcss","true"\],["fontsize","3"\]\] "<p style=\\"font-size: large\\">foo[bar\]baz</p>" compare innerHTML]
-    expected: FAIL
-
-  [[["stylewithcss","true"\],["fontsize","3"\]\] "<p style=\\"font-size: large\\">foo[bar\]baz</p>" queryCommandValue("fontsize") before]
     expected: FAIL
 
   [[["stylewithcss","true"\],["fontsize","3"\]\] "<p style=\\"font-size: large\\">foo[bar\]baz</p>" queryCommandValue("fontsize") after]
     expected: FAIL
 
   [[["stylewithcss","false"\],["fontsize","3"\]\] "<p style=\\"font-size: large\\">foo[bar\]baz</p>" compare innerHTML]
-    expected: FAIL
-
-  [[["stylewithcss","false"\],["fontsize","3"\]\] "<p style=\\"font-size: large\\">foo[bar\]baz</p>" queryCommandValue("fontsize") before]
     expected: FAIL
 
   [[["stylewithcss","false"\],["fontsize","3"\]\] "<p style=\\"font-size: large\\">foo[bar\]baz</p>" queryCommandValue("fontsize") after]
@@ -982,22 +844,13 @@
   [[["stylewithcss","false"\],["fontsize","3"\]\] "<font size=6>foo <span style=\\"font-size: 2em\\">b[a\]r</span> baz</font>" queryCommandValue("fontsize") after]
     expected: FAIL
 
-  [[["stylewithcss","true"\],["fontsize","3"\]\] "foo<big>[bar\]</big>baz" queryCommandValue("fontsize") before]
-    expected: FAIL
-
   [[["stylewithcss","true"\],["fontsize","3"\]\] "foo<big>[bar\]</big>baz" queryCommandValue("fontsize") after]
     expected: FAIL
 
   [[["stylewithcss","false"\],["fontsize","3"\]\] "foo<big>[bar\]</big>baz" compare innerHTML]
     expected: FAIL
 
-  [[["stylewithcss","false"\],["fontsize","3"\]\] "foo<big>[bar\]</big>baz" queryCommandValue("fontsize") before]
-    expected: FAIL
-
   [[["stylewithcss","false"\],["fontsize","3"\]\] "foo<big>[bar\]</big>baz" queryCommandValue("fontsize") after]
-    expected: FAIL
-
-  [[["stylewithcss","true"\],["fontsize","3"\]\] "foo<big>b[a\]r</big>baz" queryCommandValue("fontsize") before]
     expected: FAIL
 
   [[["stylewithcss","true"\],["fontsize","3"\]\] "foo<big>b[a\]r</big>baz" queryCommandValue("fontsize") after]
@@ -1006,13 +859,7 @@
   [[["stylewithcss","false"\],["fontsize","3"\]\] "foo<big>b[a\]r</big>baz" compare innerHTML]
     expected: FAIL
 
-  [[["stylewithcss","false"\],["fontsize","3"\]\] "foo<big>b[a\]r</big>baz" queryCommandValue("fontsize") before]
-    expected: FAIL
-
   [[["stylewithcss","false"\],["fontsize","3"\]\] "foo<big>b[a\]r</big>baz" queryCommandValue("fontsize") after]
-    expected: FAIL
-
-  [[["stylewithcss","true"\],["fontsize","3"\]\] "foo<small>[bar\]</small>baz" queryCommandValue("fontsize") before]
     expected: FAIL
 
   [[["stylewithcss","true"\],["fontsize","3"\]\] "foo<small>[bar\]</small>baz" queryCommandValue("fontsize") after]
@@ -1021,22 +868,13 @@
   [[["stylewithcss","false"\],["fontsize","3"\]\] "foo<small>[bar\]</small>baz" compare innerHTML]
     expected: FAIL
 
-  [[["stylewithcss","false"\],["fontsize","3"\]\] "foo<small>[bar\]</small>baz" queryCommandValue("fontsize") before]
-    expected: FAIL
-
   [[["stylewithcss","false"\],["fontsize","3"\]\] "foo<small>[bar\]</small>baz" queryCommandValue("fontsize") after]
-    expected: FAIL
-
-  [[["stylewithcss","true"\],["fontsize","3"\]\] "foo<small>b[a\]r</small>baz" queryCommandValue("fontsize") before]
     expected: FAIL
 
   [[["stylewithcss","true"\],["fontsize","3"\]\] "foo<small>b[a\]r</small>baz" queryCommandValue("fontsize") after]
     expected: FAIL
 
   [[["stylewithcss","false"\],["fontsize","3"\]\] "foo<small>b[a\]r</small>baz" compare innerHTML]
-    expected: FAIL
-
-  [[["stylewithcss","false"\],["fontsize","3"\]\] "foo<small>b[a\]r</small>baz" queryCommandValue("fontsize") before]
     expected: FAIL
 
   [[["stylewithcss","false"\],["fontsize","3"\]\] "foo<small>b[a\]r</small>baz" queryCommandValue("fontsize") after]
@@ -1048,34 +886,16 @@
   [[["stylewithcss","true"\],["fontsize","4"\]\] "fo[o<font size=2>b\]ar</font>baz" queryCommandIndeterm("fontsize") before]
     expected: FAIL
 
-  [[["stylewithcss","true"\],["fontsize","4"\]\] "fo[o<font size=2>b\]ar</font>baz" queryCommandValue("fontsize") before]
-    expected: FAIL
-
-  [[["stylewithcss","true"\],["fontsize","4"\]\] "fo[o<font size=2>b\]ar</font>baz" queryCommandValue("fontsize") after]
-    expected: FAIL
-
   [[["stylewithcss","false"\],["fontsize","4"\]\] "fo[o<font size=2>b\]ar</font>baz" compare innerHTML]
     expected: FAIL
 
   [[["stylewithcss","false"\],["fontsize","4"\]\] "fo[o<font size=2>b\]ar</font>baz" queryCommandIndeterm("fontsize") before]
     expected: FAIL
 
-  [[["stylewithcss","false"\],["fontsize","4"\]\] "fo[o<font size=2>b\]ar</font>baz" queryCommandValue("fontsize") before]
-    expected: FAIL
-
-  [[["stylewithcss","false"\],["fontsize","4"\]\] "fo[o<font size=2>b\]ar</font>baz" queryCommandValue("fontsize") after]
-    expected: FAIL
-
   [[["stylewithcss","true"\],["fontsize","4"\]\] "foo<font size=2>ba[r</font>b\]az" compare innerHTML]
     expected: FAIL
 
   [[["stylewithcss","true"\],["fontsize","4"\]\] "foo<font size=2>ba[r</font>b\]az" queryCommandIndeterm("fontsize") before]
-    expected: FAIL
-
-  [[["stylewithcss","true"\],["fontsize","4"\]\] "foo<font size=2>ba[r</font>b\]az" queryCommandValue("fontsize") before]
-    expected: FAIL
-
-  [[["stylewithcss","true"\],["fontsize","4"\]\] "foo<font size=2>ba[r</font>b\]az" queryCommandValue("fontsize") after]
     expected: FAIL
 
   [[["stylewithcss","false"\],["fontsize","4"\]\] "foo<font size=2>ba[r</font>b\]az" compare innerHTML]
@@ -1092,9 +912,6 @@
   [[["stylewithcss","false"\],["fontsize","4"\]\] "foo<font size=2>ba[r</font>b\]az" queryCommandIndeterm("fontsize") before]
     expected: FAIL
 
-  [[["stylewithcss","false"\],["fontsize","4"\]\] "foo<font size=2>ba[r</font>b\]az" queryCommandValue("fontsize") before]
-    expected: FAIL
-
   [[["stylewithcss","false"\],["fontsize","4"\]\] "foo<font size=2>ba[r</font>b\]az" queryCommandValue("fontsize") after]
     expected: FAIL
 
@@ -1102,9 +919,6 @@
     expected: FAIL
 
   [[["stylewithcss","true"\],["fontsize","4"\]\] "fo[o<font size=2>bar</font>b\]az" queryCommandIndeterm("fontsize") before]
-    expected: FAIL
-
-  [[["stylewithcss","true"\],["fontsize","4"\]\] "fo[o<font size=2>bar</font>b\]az" queryCommandValue("fontsize") before]
     expected: FAIL
 
   [[["stylewithcss","true"\],["fontsize","4"\]\] "fo[o<font size=2>bar</font>b\]az" queryCommandValue("fontsize") after]
@@ -1116,34 +930,16 @@
   [[["stylewithcss","false"\],["fontsize","4"\]\] "fo[o<font size=2>bar</font>b\]az" queryCommandIndeterm("fontsize") before]
     expected: FAIL
 
-  [[["stylewithcss","false"\],["fontsize","4"\]\] "fo[o<font size=2>bar</font>b\]az" queryCommandValue("fontsize") before]
-    expected: FAIL
-
   [[["stylewithcss","false"\],["fontsize","4"\]\] "fo[o<font size=2>bar</font>b\]az" queryCommandValue("fontsize") after]
     expected: FAIL
 
   [[["stylewithcss","true"\],["fontsize","4"\]\] "foo[<font size=2>b\]ar</font>baz" compare innerHTML]
     expected: FAIL
 
-  [[["stylewithcss","true"\],["fontsize","4"\]\] "foo[<font size=2>b\]ar</font>baz" queryCommandValue("fontsize") before]
-    expected: FAIL
-
-  [[["stylewithcss","true"\],["fontsize","4"\]\] "foo[<font size=2>b\]ar</font>baz" queryCommandValue("fontsize") after]
-    expected: FAIL
-
   [[["stylewithcss","false"\],["fontsize","4"\]\] "foo[<font size=2>b\]ar</font>baz" compare innerHTML]
     expected: FAIL
 
-  [[["stylewithcss","false"\],["fontsize","4"\]\] "foo[<font size=2>b\]ar</font>baz" queryCommandValue("fontsize") before]
-    expected: FAIL
-
-  [[["stylewithcss","false"\],["fontsize","4"\]\] "foo[<font size=2>b\]ar</font>baz" queryCommandValue("fontsize") after]
-    expected: FAIL
-
   [[["stylewithcss","true"\],["fontsize","4"\]\] "foo<font size=2>ba[r</font>\]baz" compare innerHTML]
-    expected: FAIL
-
-  [[["stylewithcss","true"\],["fontsize","4"\]\] "foo<font size=2>ba[r</font>\]baz" queryCommandValue("fontsize") before]
     expected: FAIL
 
   [[["stylewithcss","true"\],["fontsize","4"\]\] "foo<font size=2>ba[r</font>\]baz" queryCommandValue("fontsize") after]
@@ -1152,34 +948,16 @@
   [[["stylewithcss","false"\],["fontsize","4"\]\] "foo<font size=2>ba[r</font>\]baz" compare innerHTML]
     expected: FAIL
 
-  [[["stylewithcss","false"\],["fontsize","4"\]\] "foo<font size=2>ba[r</font>\]baz" queryCommandValue("fontsize") before]
-    expected: FAIL
-
   [[["stylewithcss","false"\],["fontsize","4"\]\] "foo<font size=2>ba[r</font>\]baz" queryCommandValue("fontsize") after]
     expected: FAIL
 
   [[["stylewithcss","true"\],["fontsize","4"\]\] "foo[<font size=2>bar</font>\]baz" compare innerHTML]
     expected: FAIL
 
-  [[["stylewithcss","true"\],["fontsize","4"\]\] "foo[<font size=2>bar</font>\]baz" queryCommandValue("fontsize") before]
-    expected: FAIL
-
-  [[["stylewithcss","true"\],["fontsize","4"\]\] "foo[<font size=2>bar</font>\]baz" queryCommandValue("fontsize") after]
-    expected: FAIL
-
   [[["stylewithcss","false"\],["fontsize","4"\]\] "foo[<font size=2>bar</font>\]baz" compare innerHTML]
     expected: FAIL
 
-  [[["stylewithcss","false"\],["fontsize","4"\]\] "foo[<font size=2>bar</font>\]baz" queryCommandValue("fontsize") before]
-    expected: FAIL
-
-  [[["stylewithcss","false"\],["fontsize","4"\]\] "foo[<font size=2>bar</font>\]baz" queryCommandValue("fontsize") after]
-    expected: FAIL
-
   [[["stylewithcss","true"\],["fontsize","4"\]\] "foo<font size=2>[bar\]</font>baz" compare innerHTML]
-    expected: FAIL
-
-  [[["stylewithcss","true"\],["fontsize","4"\]\] "foo<font size=2>[bar\]</font>baz" queryCommandValue("fontsize") before]
     expected: FAIL
 
   [[["stylewithcss","true"\],["fontsize","4"\]\] "foo<font size=2>[bar\]</font>baz" queryCommandValue("fontsize") after]
@@ -1188,28 +966,13 @@
   [[["stylewithcss","false"\],["fontsize","4"\]\] "foo<font size=2>[bar\]</font>baz" compare innerHTML]
     expected: FAIL
 
-  [[["stylewithcss","false"\],["fontsize","4"\]\] "foo<font size=2>[bar\]</font>baz" queryCommandValue("fontsize") before]
-    expected: FAIL
-
   [[["stylewithcss","false"\],["fontsize","4"\]\] "foo<font size=2>[bar\]</font>baz" queryCommandValue("fontsize") after]
     expected: FAIL
 
   [[["stylewithcss","true"\],["fontsize","4"\]\] "foo{<font size=2>bar</font>}baz" compare innerHTML]
     expected: FAIL
 
-  [[["stylewithcss","true"\],["fontsize","4"\]\] "foo{<font size=2>bar</font>}baz" queryCommandValue("fontsize") before]
-    expected: FAIL
-
-  [[["stylewithcss","true"\],["fontsize","4"\]\] "foo{<font size=2>bar</font>}baz" queryCommandValue("fontsize") after]
-    expected: FAIL
-
   [[["stylewithcss","false"\],["fontsize","4"\]\] "foo{<font size=2>bar</font>}baz" compare innerHTML]
-    expected: FAIL
-
-  [[["stylewithcss","false"\],["fontsize","4"\]\] "foo{<font size=2>bar</font>}baz" queryCommandValue("fontsize") before]
-    expected: FAIL
-
-  [[["stylewithcss","false"\],["fontsize","4"\]\] "foo{<font size=2>bar</font>}baz" queryCommandValue("fontsize") after]
     expected: FAIL
 
   [[["stylewithcss","true"\],["fontsize","4"\]\] "<font size=1>fo[o</font><span style=font-size:xx-small>b\]ar</span>" compare innerHTML]
@@ -1218,100 +981,34 @@
   [[["stylewithcss","true"\],["fontsize","4"\]\] "<font size=1>fo[o</font><span style=font-size:xx-small>b\]ar</span>" queryCommandIndeterm("fontsize") before]
     expected: FAIL
 
-  [[["stylewithcss","true"\],["fontsize","4"\]\] "<font size=1>fo[o</font><span style=font-size:xx-small>b\]ar</span>" queryCommandValue("fontsize") before]
-    expected: FAIL
-
-  [[["stylewithcss","true"\],["fontsize","4"\]\] "<font size=1>fo[o</font><span style=font-size:xx-small>b\]ar</span>" queryCommandValue("fontsize") after]
-    expected: FAIL
-
   [[["stylewithcss","false"\],["fontsize","4"\]\] "<font size=1>fo[o</font><span style=font-size:xx-small>b\]ar</span>" compare innerHTML]
     expected: FAIL
 
   [[["stylewithcss","false"\],["fontsize","4"\]\] "<font size=1>fo[o</font><span style=font-size:xx-small>b\]ar</span>" queryCommandIndeterm("fontsize") before]
     expected: FAIL
 
-  [[["stylewithcss","false"\],["fontsize","4"\]\] "<font size=1>fo[o</font><span style=font-size:xx-small>b\]ar</span>" queryCommandValue("fontsize") before]
-    expected: FAIL
-
-  [[["stylewithcss","false"\],["fontsize","4"\]\] "<font size=1>fo[o</font><span style=font-size:xx-small>b\]ar</span>" queryCommandValue("fontsize") after]
-    expected: FAIL
-
   [[["stylewithcss","true"\],["fontsize","4"\]\] "<font size=2>fo[o</font><span style=font-size:small>b\]ar</span>" compare innerHTML]
-    expected: FAIL
-
-  [[["stylewithcss","true"\],["fontsize","4"\]\] "<font size=2>fo[o</font><span style=font-size:small>b\]ar</span>" queryCommandValue("fontsize") before]
-    expected: FAIL
-
-  [[["stylewithcss","true"\],["fontsize","4"\]\] "<font size=2>fo[o</font><span style=font-size:small>b\]ar</span>" queryCommandValue("fontsize") after]
     expected: FAIL
 
   [[["stylewithcss","false"\],["fontsize","4"\]\] "<font size=2>fo[o</font><span style=font-size:small>b\]ar</span>" compare innerHTML]
     expected: FAIL
 
-  [[["stylewithcss","false"\],["fontsize","4"\]\] "<font size=2>fo[o</font><span style=font-size:small>b\]ar</span>" queryCommandValue("fontsize") before]
-    expected: FAIL
-
-  [[["stylewithcss","false"\],["fontsize","4"\]\] "<font size=2>fo[o</font><span style=font-size:small>b\]ar</span>" queryCommandValue("fontsize") after]
-    expected: FAIL
-
   [[["stylewithcss","true"\],["fontsize","4"\]\] "<font size=3>fo[o</font><span style=font-size:medium>b\]ar</span>" compare innerHTML]
-    expected: FAIL
-
-  [[["stylewithcss","true"\],["fontsize","4"\]\] "<font size=3>fo[o</font><span style=font-size:medium>b\]ar</span>" queryCommandValue("fontsize") before]
-    expected: FAIL
-
-  [[["stylewithcss","true"\],["fontsize","4"\]\] "<font size=3>fo[o</font><span style=font-size:medium>b\]ar</span>" queryCommandValue("fontsize") after]
     expected: FAIL
 
   [[["stylewithcss","false"\],["fontsize","4"\]\] "<font size=3>fo[o</font><span style=font-size:medium>b\]ar</span>" compare innerHTML]
     expected: FAIL
 
-  [[["stylewithcss","false"\],["fontsize","4"\]\] "<font size=3>fo[o</font><span style=font-size:medium>b\]ar</span>" queryCommandValue("fontsize") before]
-    expected: FAIL
-
-  [[["stylewithcss","false"\],["fontsize","4"\]\] "<font size=3>fo[o</font><span style=font-size:medium>b\]ar</span>" queryCommandValue("fontsize") after]
-    expected: FAIL
-
-  [[["fontsize","4"\]\] "<font size=4>fo[o</font><span style=font-size:large>b\]ar</span>" queryCommandValue("fontsize") before]
-    expected: FAIL
-
-  [[["fontsize","4"\]\] "<font size=4>fo[o</font><span style=font-size:large>b\]ar</span>" queryCommandValue("fontsize") after]
-    expected: FAIL
-
   [[["stylewithcss","true"\],["fontsize","4"\]\] "<font size=5>fo[o</font><span style=font-size:x-large>b\]ar</span>" compare innerHTML]
-    expected: FAIL
-
-  [[["stylewithcss","true"\],["fontsize","4"\]\] "<font size=5>fo[o</font><span style=font-size:x-large>b\]ar</span>" queryCommandValue("fontsize") before]
-    expected: FAIL
-
-  [[["stylewithcss","true"\],["fontsize","4"\]\] "<font size=5>fo[o</font><span style=font-size:x-large>b\]ar</span>" queryCommandValue("fontsize") after]
     expected: FAIL
 
   [[["stylewithcss","false"\],["fontsize","4"\]\] "<font size=5>fo[o</font><span style=font-size:x-large>b\]ar</span>" compare innerHTML]
     expected: FAIL
 
-  [[["stylewithcss","false"\],["fontsize","4"\]\] "<font size=5>fo[o</font><span style=font-size:x-large>b\]ar</span>" queryCommandValue("fontsize") before]
-    expected: FAIL
-
-  [[["stylewithcss","false"\],["fontsize","4"\]\] "<font size=5>fo[o</font><span style=font-size:x-large>b\]ar</span>" queryCommandValue("fontsize") after]
-    expected: FAIL
-
   [[["stylewithcss","true"\],["fontsize","4"\]\] "<font size=6>fo[o</font><span style=font-size:xx-large>b\]ar</span>" compare innerHTML]
     expected: FAIL
 
-  [[["stylewithcss","true"\],["fontsize","4"\]\] "<font size=6>fo[o</font><span style=font-size:xx-large>b\]ar</span>" queryCommandValue("fontsize") before]
-    expected: FAIL
-
-  [[["stylewithcss","true"\],["fontsize","4"\]\] "<font size=6>fo[o</font><span style=font-size:xx-large>b\]ar</span>" queryCommandValue("fontsize") after]
-    expected: FAIL
-
   [[["stylewithcss","false"\],["fontsize","4"\]\] "<font size=6>fo[o</font><span style=font-size:xx-large>b\]ar</span>" compare innerHTML]
-    expected: FAIL
-
-  [[["stylewithcss","false"\],["fontsize","4"\]\] "<font size=6>fo[o</font><span style=font-size:xx-large>b\]ar</span>" queryCommandValue("fontsize") before]
-    expected: FAIL
-
-  [[["stylewithcss","false"\],["fontsize","4"\]\] "<font size=6>fo[o</font><span style=font-size:xx-large>b\]ar</span>" queryCommandValue("fontsize") after]
     expected: FAIL
 
   [[["styleWithCSS","false"\],["fontSize","7"\]\] "<font color=#ff0000>[abc\]</font>" compare innerHTML]

--- a/tests/wpt/meta/editing/run/forwarddelete.html.ini
+++ b/tests/wpt/meta/editing/run/forwarddelete.html.ini
@@ -897,34 +897,16 @@
   [[["styleWithCSS","false"\],["defaultparagraphseparator","p"\],["forwarddelete",""\]\] "<p><font size=3>foo[\]</font><p><font size=5>bar</font>" compare innerHTML]
     expected: FAIL
 
-  [[["styleWithCSS","false"\],["defaultparagraphseparator","p"\],["forwarddelete",""\]\] "<p><font size=3>foo[\]</font><p><font size=5>bar</font>" queryCommandValue("fontSize") before]
-    expected: FAIL
-
-  [[["styleWithCSS","false"\],["defaultparagraphseparator","p"\],["forwarddelete",""\]\] "<p><font size=3>foo[\]</font><p><font size=5>bar</font>" queryCommandValue("fontSize") after]
-    expected: FAIL
-
   [[["styleWithCSS","false"\],["defaultparagraphseparator","div"\],["forwarddelete",""\]\] "<p><font size=4>foo[\]</font><p><font size=5>bar</font>": execCommand("forwarddelete", false, "") return value]
     expected: FAIL
 
   [[["styleWithCSS","false"\],["defaultparagraphseparator","div"\],["forwarddelete",""\]\] "<p><font size=4>foo[\]</font><p><font size=5>bar</font>" compare innerHTML]
     expected: FAIL
 
-  [[["styleWithCSS","false"\],["defaultparagraphseparator","div"\],["forwarddelete",""\]\] "<p><font size=4>foo[\]</font><p><font size=5>bar</font>" queryCommandValue("fontSize") before]
-    expected: FAIL
-
-  [[["styleWithCSS","false"\],["defaultparagraphseparator","div"\],["forwarddelete",""\]\] "<p><font size=4>foo[\]</font><p><font size=5>bar</font>" queryCommandValue("fontSize") after]
-    expected: FAIL
-
   [[["styleWithCSS","false"\],["defaultparagraphseparator","p"\],["forwarddelete",""\]\] "<p><font size=4>foo[\]</font><p><font size=5>bar</font>": execCommand("forwarddelete", false, "") return value]
     expected: FAIL
 
   [[["styleWithCSS","false"\],["defaultparagraphseparator","p"\],["forwarddelete",""\]\] "<p><font size=4>foo[\]</font><p><font size=5>bar</font>" compare innerHTML]
-    expected: FAIL
-
-  [[["styleWithCSS","false"\],["defaultparagraphseparator","p"\],["forwarddelete",""\]\] "<p><font size=4>foo[\]</font><p><font size=5>bar</font>" queryCommandValue("fontSize") before]
-    expected: FAIL
-
-  [[["styleWithCSS","false"\],["defaultparagraphseparator","p"\],["forwarddelete",""\]\] "<p><font size=4>foo[\]</font><p><font size=5>bar</font>" queryCommandValue("fontSize") after]
     expected: FAIL
 
   [[["styleWithCSS","false"\],["defaultparagraphseparator","div"\],["forwarddelete",""\]\] "<p><font color=blue>foo[\]</font><p><font size=5>bar</font>": execCommand("forwarddelete", false, "") return value]
@@ -969,12 +951,6 @@
   [[["styleWithCSS","false"\],["defaultparagraphseparator","div"\],["forwarddelete",""\]\] "<p><font size=5>foo[\]</font><p><font color=blue>bar</font>" compare innerHTML]
     expected: FAIL
 
-  [[["styleWithCSS","false"\],["defaultparagraphseparator","div"\],["forwarddelete",""\]\] "<p><font size=5>foo[\]</font><p><font color=blue>bar</font>" queryCommandValue("fontSize") before]
-    expected: FAIL
-
-  [[["styleWithCSS","false"\],["defaultparagraphseparator","div"\],["forwarddelete",""\]\] "<p><font size=5>foo[\]</font><p><font color=blue>bar</font>" queryCommandValue("fontSize") after]
-    expected: FAIL
-
   [[["styleWithCSS","false"\],["defaultparagraphseparator","div"\],["forwarddelete",""\]\] "<p><font size=5>foo[\]</font><p><font color=blue>bar</font>" queryCommandValue("foreColor") before]
     expected: FAIL
 
@@ -985,12 +961,6 @@
     expected: FAIL
 
   [[["styleWithCSS","false"\],["defaultparagraphseparator","p"\],["forwarddelete",""\]\] "<p><font size=5>foo[\]</font><p><font color=blue>bar</font>" compare innerHTML]
-    expected: FAIL
-
-  [[["styleWithCSS","false"\],["defaultparagraphseparator","p"\],["forwarddelete",""\]\] "<p><font size=5>foo[\]</font><p><font color=blue>bar</font>" queryCommandValue("fontSize") before]
-    expected: FAIL
-
-  [[["styleWithCSS","false"\],["defaultparagraphseparator","p"\],["forwarddelete",""\]\] "<p><font size=5>foo[\]</font><p><font color=blue>bar</font>" queryCommandValue("fontSize") after]
     expected: FAIL
 
   [[["styleWithCSS","false"\],["defaultparagraphseparator","p"\],["forwarddelete",""\]\] "<p><font size=5>foo[\]</font><p><font color=blue>bar</font>" queryCommandValue("foreColor") before]
@@ -3549,12 +3519,6 @@
     expected: FAIL
 
   [[["styleWithCSS","false"\],["defaultparagraphseparator","div"\],["forwarddelete",""\]\] "<p><font size=3>foo[\]</font><p><font size=5>bar</font>" compare innerHTML]
-    expected: FAIL
-
-  [[["styleWithCSS","false"\],["defaultparagraphseparator","div"\],["forwarddelete",""\]\] "<p><font size=3>foo[\]</font><p><font size=5>bar</font>" queryCommandValue("fontSize") before]
-    expected: FAIL
-
-  [[["styleWithCSS","false"\],["defaultparagraphseparator","div"\],["forwarddelete",""\]\] "<p><font size=3>foo[\]</font><p><font size=5>bar</font>" queryCommandValue("fontSize") after]
     expected: FAIL
 
 

--- a/tests/wpt/meta/editing/run/multitest.html.ini
+++ b/tests/wpt/meta/editing/run/multitest.html.ini
@@ -2501,9 +2501,6 @@
   [[["fontsize","4"\],["insertimage","/img/lion.svg"\]\] "foo[\]bar" compare innerHTML]
     expected: FAIL
 
-  [[["fontsize","4"\],["insertimage","/img/lion.svg"\]\] "foo[\]bar" queryCommandValue("fontsize") before]
-    expected: FAIL
-
   [[["fontsize","4"\],["insertimage","/img/lion.svg"\]\] "foo[\]bar" queryCommandValue("fontsize") after]
     expected: FAIL
 
@@ -5048,9 +5045,6 @@
   [[["subscript",""\],["fontsize","2"\],["inserttext","a"\]\] "foo[\]bar" queryCommandState("subscript") after]
     expected: FAIL
 
-  [[["subscript",""\],["fontsize","2"\],["inserttext","a"\]\] "foo[\]bar" queryCommandValue("fontsize") before]
-    expected: FAIL
-
   [[["subscript",""\],["fontsize","2"\],["inserttext","a"\]\] "foo[\]bar" queryCommandValue("fontsize") after]
     expected: FAIL
 
@@ -7199,6 +7193,9 @@
     expected: FAIL
 
   [[["delete",""\],["inserttext","d"\],["inserttext","e"\],["inserttext","f"\]\] "<div>abc<b><i>[def</i></b>\]ghi</div>" compare innerHTML]
+    expected: FAIL
+
+  [[["stylewithcss","false"\],["fontsize","4"\],["insertText","a"\]\] "<font size=7>{}<br></font>" queryCommandValue("fontsize") before]
     expected: FAIL
 
 


### PR DESCRIPTION
The initial interpretation of "convert the font size to the value in pixels" was completely off. I thought it meant the existing font elements in the DOM, but instead it implied that you would have to convert these into pixels according to the HTML size table.

Therefore, use the implementation in Stylo to convert the html size to a keyword and then compute the value for the keyword.

To make that work, we need to compute the pixel size as fallback when resolving the CSS value on the node. We check if it were pixels and then go through the conversion. If they aren't pixels, we can skip all that logic and directly convert, saving a few cycles.

Part of #25005

Testing: WPT