### PR TITLE
script: Avoid forwarding body event handlers without a browsing context

### DIFF
--- a/components/script/dom/html/htmlbodyelement.rs
+++ b/components/script/dom/html/htmlbodyelement.rs
@@ -154,7 +154,7 @@ impl VirtualMethods for HTMLBodyElement {
     ) {
         let do_super_mutate = match (attr.local_name(), mutation) {
             (name, AttributeMutation::Set(..)) if name.starts_with("on") => {
-                let window = self.owner_window();
+                let document = self.owner_document();
                 // https://html.spec.whatwg.org/multipage/
                 // #event-handlers-on-elements,-document-objects,-and-window-objects:event-handlers-6
                 match name {
@@ -181,15 +181,22 @@ impl VirtualMethods for HTMLBodyElement {
                     &local_name!("onstorage") |
                     &local_name!("onunhandledrejection") |
                     &local_name!("onunload") => {
-                        let source = &**attr.value();
-                        let evtarget = window.upcast::<EventTarget>(); // forwarded event
-                        let source_line = 1; // TODO(#9604) obtain current JS execution line
-                        evtarget.set_event_handler_uncompiled(
-                            window.get_url(),
-                            source_line,
-                            &name[2..],
-                            source,
-                        );
+                        if document.has_browsing_context() {
+                            // https://html.spec.whatwg.org/multipage/webappapis.html
+                            // #event-handler-attributes%3Aevent-handler-content-attributes-3
+                            // This matches the `has_browsing_context()` check done by the
+                            // `window_event_handlers!(ForwardToWindow)` macro for WebIDL attributes.
+                            let window = document.window();
+                            let source = &**attr.value();
+                            let evtarget = window.upcast::<EventTarget>(); // forwarded event
+                            let source_line = 1; // TODO(#9604) obtain current JS execution line
+                            evtarget.set_event_handler_uncompiled(
+                                window.get_url(),
+                                source_line,
+                                &name[2..],
+                                source,
+                            );
+                        }
                         false
                     },
                     _ => true, // HTMLElement::attribute_mutated will take care of this.

--- a/tests/wpt/meta/dom/ranges/Range-cloneContents.html.ini
+++ b/tests/wpt/meta/dom/ranges/Range-cloneContents.html.ini
@@ -1,3 +1,0 @@
-[Range-cloneContents.html]
-  bug: https://github.com/servo/servo/issues/36561
-  expected: ERROR

--- a/tests/wpt/meta/dom/ranges/Range-deleteContents.html.ini
+++ b/tests/wpt/meta/dom/ranges/Range-deleteContents.html.ini
@@ -1,3 +1,0 @@
-[Range-deleteContents.html]
-  bug: https://github.com/servo/servo/issues/36561
-  expected: ERROR

--- a/tests/wpt/meta/dom/ranges/Range-extractContents.html.ini
+++ b/tests/wpt/meta/dom/ranges/Range-extractContents.html.ini
@@ -1,3 +1,0 @@
-[Range-extractContents.html]
-  bug: https://github.com/servo/servo/issues/36561
-  expected: ERROR

--- a/tests/wpt/meta/dom/ranges/Range-insertNode.html.ini
+++ b/tests/wpt/meta/dom/ranges/Range-insertNode.html.ini
@@ -1,3 +1,0 @@
-[Range-insertNode.html]
-  bug: https://github.com/servo/servo/issues/36561
-  expected: ERROR

--- a/tests/wpt/meta/dom/ranges/Range-surroundContents.html.ini
+++ b/tests/wpt/meta/dom/ranges/Range-surroundContents.html.ini
@@ -1,3 +1,0 @@
-[Range-surroundContents.html]
-  bug: https://github.com/servo/servo/issues/36561
-  expected: ERROR

--- a/tests/wpt/meta/html/webappapis/scripting/events/onerroreventhandler.html.ini
+++ b/tests/wpt/meta/html/webappapis/scripting/events/onerroreventhandler.html.ini
@@ -1,0 +1,9 @@
+
+[onerroreventhandler.html]
+  bug: https://github.com/servo/servo/issues/44157
+  expected: TIMEOUT
+  [onerror + ErrorEvent + Window]
+    expected: TIMEOUT
+
+  [onerror + !ErrorEvent + Window]
+    expected: TIMEOUT


### PR DESCRIPTION

 When mutating window-reflecting event handler attributes on <body>, HTMLBodyElement::attribute_mutated forwarded handlers to owner_window() even for documents without a browsing context.
    
This caused handlers such as onload to be attached to the wrong window in cases involving createHTMLDocument() and node cloning.
    
Only forward these handlers when the owner document has a browsing context. This matches the has_browsing_context() check used by window_event_handlers!(ForwardToWindow) and the spec algorithm.
    
The Range WPT expectations added for this issue are removed, as those tests now pass. The onerroreventhandler.html test is marked as TIMEOUT as its failure is a separate issue tracked in #44157 .



Testing: 
- ./mach fmt
- ./mach test-tidy
- ./mach test-wpt -r dom/ranges
- ./mach test-wpt -r html/webappapis/scripting/events/onerroreventhandler.html
-  ./mach try linux-wpt ( Try run [#24328414549](https://github.com/arabson99/servo/actions/runs/24328414549))

Reproduced locally with the parent.html/child.html testcase from #36561.
Before this change, Servo logged "foo is not defined".
After this change, the error no longer appears.

Fixes: #36561
