### PR TITLE
script: Skip clearing subtree layout boxes of detached element when attaching shadow to it

### DIFF
--- a/components/script/dom/element/element.rs
+++ b/components/script/dom/element/element.rs
@@ -699,8 +699,9 @@ impl Element {
         // non-shadow-tree children of `self` no longer have layout boxes as they are no
         // longer in the flat tree.
         let node = self.upcast::<Node>();
-        node.remove_layout_boxes_from_subtree();
-
+        if node.is_connected() {
+            node.remove_layout_boxes_from_subtree();
+        }
         // Step 6. Set shadow's delegates focus to delegatesFocus
         shadow_root.set_delegates_focus(delegates_focus);
 

--- a/components/script/dom/node/node.rs
+++ b/components/script/dom/node/node.rs
@@ -6,6 +6,7 @@
 
 use std::borrow::Cow;
 use std::cell::{Cell, LazyCell, UnsafeCell};
+use std::cell::RefCell;
 use std::default::Default;
 use std::f64::consts::PI;
 use std::marker::PhantomData;
@@ -268,6 +269,11 @@ pub(crate) enum ForceSlottableNodeReconciliation {
     Skip,
 }
 
+thread_local! {
+    static LOCAL_COUNTER: RefCell<u32> = RefCell::new(0);
+}
+
+
 impl Node {
     /// Adds a new child to the end of this node's list of children.
     ///
@@ -365,9 +371,13 @@ impl Node {
     }
 
     /// Clear this [`Node`]'s layout data and also clear the layout data of all children.
-    /// Note that clears layout data from all non-flat tree descendants and flat tree
+    /// Note that this clears layout data from all non-flat tree descendants and flat tree
     /// descendants.
     pub(crate) fn remove_layout_boxes_from_subtree(&self) {
+        LOCAL_COUNTER.with(|counter| {
+            *counter.borrow_mut() += 1;
+            println!("{}", *counter.borrow());
+        });
         for node in self.traverse_preorder(ShadowIncluding::Yes) {
             node.layout_data.borrow_mut().take();
         }

--- a/components/script/dom/node/node.rs
+++ b/components/script/dom/node/node.rs
@@ -6,7 +6,6 @@
 
 use std::borrow::Cow;
 use std::cell::{Cell, LazyCell, UnsafeCell};
-use std::cell::RefCell;
 use std::default::Default;
 use std::f64::consts::PI;
 use std::marker::PhantomData;
@@ -269,11 +268,6 @@ pub(crate) enum ForceSlottableNodeReconciliation {
     Skip,
 }
 
-thread_local! {
-    static LOCAL_COUNTER: RefCell<u32> = RefCell::new(0);
-}
-
-
 impl Node {
     /// Adds a new child to the end of this node's list of children.
     ///
@@ -374,10 +368,6 @@ impl Node {
     /// Note that this clears layout data from all non-flat tree descendants and flat tree
     /// descendants.
     pub(crate) fn remove_layout_boxes_from_subtree(&self) {
-        LOCAL_COUNTER.with(|counter| {
-            *counter.borrow_mut() += 1;
-            println!("{}", *counter.borrow());
-        });
         for node in self.traverse_preorder(ShadowIncluding::Yes) {
             node.layout_data.borrow_mut().take();
         }


### PR DESCRIPTION
There is no layout boxes to clear in this case. For the example in #43998,
this skips the traversal many times.

Testing: Should not change visible behaviour. [Try](https://github.com/servo/servo/actions/runs/24131782865).