### PR TITLE
devtools: Use `DebuggerValue` in console

### DIFF
--- a/components/devtools/actors/console.rs
+++ b/components/devtools/actors/console.rs
@@ -11,19 +11,19 @@ use std::sync::atomic::{AtomicBool, Ordering};
 
 use atomic_refcell::AtomicRefCell;
 use devtools_traits::{
-    ConsoleArgument, ConsoleMessage, ConsoleMessageFields, DevtoolScriptControlMsg, PageError,
-    StackFrame, get_time_stamp,
+    ConsoleMessage, ConsoleMessageFields, DevtoolScriptControlMsg, PageError, StackFrame,
+    get_time_stamp,
 };
 use malloc_size_of_derive::MallocSizeOf;
 use serde::Serialize;
-use serde_json::{self, Map, Number, Value};
+use serde_json::{self, Map, Value};
 use servo_base::generic_channel::{self, GenericSender};
 use servo_base::id::TEST_PIPELINE_ID;
 use uuid::Uuid;
 
 use crate::actor::{Actor, ActorError, ActorRegistry};
 use crate::actors::browsing_context::BrowsingContextActor;
-use crate::actors::object::{ObjectActor, ObjectPropertyDescriptor, debugger_value_to_json};
+use crate::actors::object::debugger_value_to_json;
 use crate::actors::worker::WorkerTargetActor;
 use crate::protocol::{ClientRequest, DevtoolsConnection, JsonPacketStream};
 use crate::resource::{ResourceArrayType, ResourceAvailable};
@@ -50,85 +50,10 @@ impl DevtoolsConsoleMessage {
             arguments: message
                 .arguments
                 .into_iter()
-                .map(|argument| console_argument_to_value(argument, registry))
+                .map(|argument| debugger_value_to_json(registry, argument))
                 .collect(),
             stacktrace: message.stacktrace,
         }
-    }
-}
-
-fn console_argument_to_value(argument: ConsoleArgument, registry: &ActorRegistry) -> Value {
-    match argument {
-        ConsoleArgument::String(value) => Value::String(value),
-        ConsoleArgument::Integer(value) => Value::Number(value.into()),
-        ConsoleArgument::Number(value) => {
-            Number::from_f64(value).map(Value::from).unwrap_or_default()
-        },
-        ConsoleArgument::Boolean(value) => Value::Bool(value),
-        ConsoleArgument::Object(object) => {
-            // Create a new actor for the object.
-            // These are currently never cleaned up, and we make no attempt at re-using the same actor
-            // if the same object is logged repeatedly.
-            let object_name = ObjectActor::register(registry, None, object.class.clone(), None);
-
-            // TODO: Replace these with ObjectActor::encode
-            #[derive(Serialize)]
-            #[serde(rename_all = "camelCase")]
-            struct DevtoolsConsoleObjectArgument {
-                r#type: String,
-                actor: String,
-                class: String,
-                own_property_length: usize,
-                extensible: bool,
-                frozen: bool,
-                sealed: bool,
-                is_error: bool,
-                preview: DevtoolsConsoleObjectArgumentPreview,
-            }
-
-            #[derive(Serialize)]
-            #[serde(rename_all = "camelCase")]
-            struct DevtoolsConsoleObjectArgumentPreview {
-                kind: String,
-                own_properties: HashMap<String, ObjectPropertyDescriptor>,
-                own_properties_length: usize,
-            }
-
-            let own_properties: HashMap<String, ObjectPropertyDescriptor> = object
-                .own_properties
-                .into_iter()
-                .map(|property| {
-                    let property_descriptor = ObjectPropertyDescriptor {
-                        configurable: property.configurable,
-                        enumerable: property.enumerable,
-                        writable: property.writable,
-                        value: console_argument_to_value(property.value, registry),
-                    };
-
-                    (property.key, property_descriptor)
-                })
-                .collect();
-
-            let argument = DevtoolsConsoleObjectArgument {
-                r#type: "object".to_owned(),
-                actor: object_name,
-                class: object.class,
-                own_property_length: own_properties.len(),
-                extensible: true,
-                frozen: false,
-                sealed: false,
-                is_error: false,
-                preview: DevtoolsConsoleObjectArgumentPreview {
-                    kind: "Object".to_string(),
-                    own_properties_length: own_properties.len(),
-                    own_properties,
-                },
-            };
-
-            // to_value can fail if the implementation of Serialize fails or there are non-string map keys.
-            // Neither should be possible here
-            serde_json::to_value(argument).unwrap()
-        },
     }
 }
 

--- a/components/devtools/lib.rs
+++ b/components/devtools/lib.rs
@@ -22,9 +22,9 @@ use std::thread;
 use crossbeam_channel::{Receiver, Sender, unbounded};
 use devtools_traits::{
     ChromeToDevtoolsControlMsg, ConsoleLogLevel, ConsoleMessage, ConsoleMessageFields,
-    DevtoolScriptControlMsg, DevtoolsControlMsg, DevtoolsPageInfo, DomMutation, EnvironmentInfo,
-    FrameInfo, FrameOffset, NavigationState, NetworkEvent, PauseReason, ScriptToDevtoolsControlMsg,
-    SourceInfo, WorkerId, get_time_stamp,
+    DebuggerValue, DevtoolScriptControlMsg, DevtoolsControlMsg, DevtoolsPageInfo, DomMutation,
+    EnvironmentInfo, FrameInfo, FrameOffset, NavigationState, NetworkEvent, PauseReason,
+    ScriptToDevtoolsControlMsg, SourceInfo, WorkerId, get_time_stamp,
 };
 use embedder_traits::{AllowOrDeny, EmbedderMsg, EmbedderProxy};
 use log::{trace, warn};
@@ -345,7 +345,7 @@ impl DevtoolsInstance {
                             column_number: css_error.column,
                             time_stamp: get_time_stamp(),
                         },
-                        arguments: vec![css_error.msg.into()],
+                        arguments: vec![DebuggerValue::StringValue(css_error.msg)],
                         stacktrace: None,
                     };
                     let console_message =

--- a/components/script/dom/console.rs
+++ b/components/script/dom/console.rs
@@ -7,8 +7,9 @@ use std::ptr::{self, NonNull};
 use std::slice;
 
 use devtools_traits::{
-    ConsoleArgument, ConsoleArgumentObject, ConsoleArgumentPropertyValue, ConsoleLogLevel,
-    ConsoleMessage, ConsoleMessageFields, ScriptToDevtoolsControlMsg, StackFrame, get_time_stamp,
+    ConsoleLogLevel, ConsoleMessage, ConsoleMessageFields, DebuggerValue, ObjectPreview,
+    PropertyDescriptor as DevtoolsPropertyDescriptor, ScriptToDevtoolsControlMsg, StackFrame,
+    get_time_stamp,
 };
 use embedder_traits::EmbedderMsg;
 use js::conversions::jsstr_to_string;
@@ -46,7 +47,7 @@ impl Console {
     #[expect(unsafe_code)]
     fn build_message(
         level: ConsoleLogLevel,
-        arguments: Vec<ConsoleArgument>,
+        arguments: Vec<DebuggerValue>,
         stacktrace: Option<Vec<StackFrame>>,
     ) -> ConsoleMessage {
         let cx = GlobalScope::get_cx();
@@ -72,7 +73,8 @@ impl Console {
 
         Self::send_to_embedder(global, level.clone(), formatted_message);
 
-        let console_message = Self::build_message(level, vec![message.into()], None);
+        let console_message =
+            Self::build_message(level, vec![DebuggerValue::StringValue(message)], None);
 
         Self::send_to_devtools(global, console_message);
     }
@@ -92,8 +94,8 @@ impl Console {
             let (formatted, consumed) = apply_sprintf_substitutions(cx, &messages);
             let remaining = &messages[consumed..];
 
-            let mut arguments: Vec<ConsoleArgument> =
-                vec![ConsoleArgument::String(formatted.clone())];
+            let mut arguments: Vec<DebuggerValue> =
+                vec![DebuggerValue::StringValue(formatted.clone())];
             for msg in remaining {
                 arguments.push(console_argument_from_handle_value(
                     cx,
@@ -170,39 +172,34 @@ fn console_argument_from_handle_value(
     cx: JSContext,
     handle_value: HandleValue,
     seen: &mut Vec<u64>,
-) -> ConsoleArgument {
+) -> DebuggerValue {
     #[expect(unsafe_code)]
     fn inner(
         cx: JSContext,
         handle_value: HandleValue,
         seen: &mut Vec<u64>,
-    ) -> Result<ConsoleArgument, ()> {
+    ) -> Result<DebuggerValue, ()> {
         if handle_value.is_string() {
             let js_string = ptr::NonNull::new(handle_value.to_string()).unwrap();
             let dom_string = unsafe { jsstr_to_string(*cx, js_string) };
-            return Ok(ConsoleArgument::String(dom_string));
-        }
-
-        if handle_value.is_int32() {
-            let integer = handle_value.to_int32();
-            return Ok(ConsoleArgument::Integer(integer));
+            return Ok(DebuggerValue::StringValue(dom_string));
         }
 
         if handle_value.is_number() {
             let number = handle_value.to_number();
-            return Ok(ConsoleArgument::Number(number));
+            return Ok(DebuggerValue::NumberValue(number));
         }
 
         if handle_value.is_boolean() {
             let boolean = handle_value.to_boolean();
-            return Ok(ConsoleArgument::Boolean(boolean));
+            return Ok(DebuggerValue::BooleanValue(boolean));
         }
 
         if handle_value.is_object() {
             // JS objects can create circular reference, and we want to avoid recursing infinitely
             if seen.contains(&handle_value.asBits_) {
                 // FIXME: Handle this properly
-                return Ok(ConsoleArgument::String("[circular]".into()));
+                return Ok(DebuggerValue::StringValue("[circular]".into()));
             }
 
             seen.push(handle_value.asBits_);
@@ -211,7 +208,11 @@ fn console_argument_from_handle_value(
             debug_assert_eq!(js_value, Some(handle_value.asBits_));
 
             if let Some(console_argument_object) = maybe_argument_object {
-                return Ok(ConsoleArgument::Object(console_argument_object));
+                return Ok(DebuggerValue::ObjectValue {
+                    uuid: "".to_string(),
+                    class: "Object".to_owned(),
+                    preview: Some(console_argument_object),
+                });
             }
 
             return Err(());
@@ -220,7 +221,7 @@ fn console_argument_from_handle_value(
         // FIXME: Handle more complex argument types here
         let stringified_value = stringify_handle_value(handle_value);
 
-        Ok(ConsoleArgument::String(stringified_value.into()))
+        Ok(DebuggerValue::StringValue(stringified_value.into()))
     }
 
     match inner(cx, handle_value, seen) {
@@ -228,7 +229,7 @@ fn console_argument_from_handle_value(
         Err(()) => {
             let in_realm_proof = AlreadyInRealm::assert_for_cx(cx);
             report_pending_exception(cx, InRealm::Already(&in_realm_proof), CanGc::note());
-            ConsoleArgument::String("<error>".into())
+            DebuggerValue::StringValue("<error>".into())
         },
     }
 }
@@ -238,7 +239,7 @@ fn console_object_from_handle_value(
     cx: JSContext,
     handle_value: HandleValue,
     seen: &mut Vec<u64>,
-) -> Option<ConsoleArgumentObject> {
+) -> Option<ObjectPreview> {
     rooted!(in(*cx) let object = handle_value.to_object());
     let mut object_class = ESClass::Other;
     if !unsafe { GetBuiltinClass(*cx, object.handle(), &mut object_class as *mut _) } {
@@ -299,18 +300,22 @@ fn console_object_from_handle_value(
             continue;
         };
 
-        own_properties.push(ConsoleArgumentPropertyValue {
-            key,
+        own_properties.push(DevtoolsPropertyDescriptor {
+            name: key,
+            value: console_argument_from_handle_value(cx, property.handle(), seen),
             configurable: descriptor.hasConfigurable_() && descriptor.configurable_(),
             enumerable: descriptor.hasEnumerable_() && descriptor.enumerable_(),
             writable: descriptor.hasWritable_() && descriptor.writable_(),
-            value: console_argument_from_handle_value(cx, property.handle(), seen),
+            is_accessor: false,
         });
     }
 
-    Some(ConsoleArgumentObject {
-        class: "Object".to_owned(),
-        own_properties,
+    Some(ObjectPreview {
+        kind: "Object".to_owned(),
+        own_properties_length: Some(own_properties.len() as u32),
+        own_properties: Some(own_properties),
+        function: None,
+        array_length: None,
     })
 }
 

--- a/components/shared/devtools/lib.rs
+++ b/components/shared/devtools/lib.rs
@@ -456,40 +456,9 @@ pub struct ConsoleMessageFields {
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
-pub enum ConsoleArgument {
-    String(String),
-    Integer(i32),
-    Number(f64),
-    Boolean(bool),
-    Object(ConsoleArgumentObject),
-}
-
-#[derive(Clone, Debug, Deserialize, Serialize)]
-pub struct ConsoleArgumentObject {
-    pub class: String,
-    pub own_properties: Vec<ConsoleArgumentPropertyValue>,
-}
-
-/// A property on a JS object passed as a console argument.
-#[derive(Clone, Debug, Deserialize, Serialize)]
-pub struct ConsoleArgumentPropertyValue {
-    pub key: String,
-    pub configurable: bool,
-    pub enumerable: bool,
-    pub writable: bool,
-    pub value: ConsoleArgument,
-}
-
-impl From<String> for ConsoleArgument {
-    fn from(value: String) -> Self {
-        Self::String(value)
-    }
-}
-
-#[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct ConsoleMessage {
     pub fields: ConsoleMessageFields,
-    pub arguments: Vec<ConsoleArgument>,
+    pub arguments: Vec<DebuggerValue>,
     pub stacktrace: Option<Vec<StackFrame>>,
 }
 

--- a/python/servo/devtools_tests.py
+++ b/python/servo/devtools_tests.py
@@ -978,6 +978,16 @@ class DevtoolsTests(unittest.IsolatedAsyncioTestCase):
         result = self.evaluate_and_capture_console_log_output("log_booleans();")
         self.assertEquals(result["arguments"], [True, False, True, False])
 
+    def test_console_log_numbers(self):
+        script_tag = "<script>let log_numbers = () => console.log(1/0, -1/0, 0/0, -0, 1);</script>"
+        self.run_servoshell(url=f"data:text/html,{script_tag}")
+
+        result = self.evaluate_and_capture_console_log_output("log_numbers();")
+
+        self.assertEquals(
+            result["arguments"], [{"type": "Infinity"}, {"type": "-Infinity"}, {"type": "NaN"}, {"type": "-0"}, 1.0]
+        )
+
     def test_console_log_sprintf_substitutions(self):
         script_tag = (
             "<script>let log_sprintf = () => "


### PR DESCRIPTION
Use same `DebuggerValue` in console actor as well. This helps us have single source of truth!

Testing: Added a new test
Fixes: part of https://github.com/servo/servo/issues/39858
