### PR TITLE
devtools: Replace new with register for HighlighterActor

### DIFF
--- a/components/devtools/actors/inspector.rs
+++ b/components/devtools/actors/inspector.rs
@@ -111,8 +111,7 @@ impl Actor for InspectorActor {
 
 impl InspectorActor {
     pub fn register(registry: &ActorRegistry, browsing_context_name: String) -> String {
-        let highlighter_name =
-            HighlighterActor::register(registry, browsing_context_name.clone());
+        let highlighter_name = HighlighterActor::register(registry, browsing_context_name.clone());
 
         let page_style_actor = PageStyleActor {
             name: registry.new_name::<PageStyleActor>(),

--- a/components/devtools/actors/inspector.rs
+++ b/components/devtools/actors/inspector.rs
@@ -111,10 +111,8 @@ impl Actor for InspectorActor {
 
 impl InspectorActor {
     pub fn register(registry: &ActorRegistry, browsing_context_name: String) -> String {
-        let highlighter_actor = HighlighterActor {
-            name: registry.new_name::<HighlighterActor>(),
-            browsing_context_name: browsing_context_name.clone(),
-        };
+        let highlighter_name =
+            HighlighterActor::register(registry, browsing_context_name.clone());
 
         let page_style_actor = PageStyleActor {
             name: registry.new_name::<PageStyleActor>(),
@@ -124,13 +122,12 @@ impl InspectorActor {
 
         let inspector_actor = Self {
             name: registry.new_name::<InspectorActor>(),
-            highlighter_name: highlighter_actor.name(),
+            highlighter_name,
             page_style_name: page_style_actor.name(),
             walker_name,
         };
         let inspector_name = inspector_actor.name();
 
-        registry.register(highlighter_actor);
         registry.register(page_style_actor);
         registry.register(inspector_actor);
 

--- a/components/devtools/actors/inspector/highlighter.rs
+++ b/components/devtools/actors/inspector/highlighter.rs
@@ -97,6 +97,16 @@ impl Actor for HighlighterActor {
 }
 
 impl HighlighterActor {
+    pub fn register(registry: &ActorRegistry, browsing_context_name: String) -> String {
+        let name = registry.new_name::<Self>();
+        let actor = Self {
+            name: name.clone(),
+            browsing_context_name,
+        };
+        registry.register::<Self>(actor);
+        name
+    }
+
     fn instruct_script_thread_to_highlight_node(
         &self,
         node_name: Option<String>,


### PR DESCRIPTION
  Added a `register` method to `HighlighterActor` following the same pattern used by other actors in the devtools codebase. Updated `InspectorActor::register` to use it instead of  onstructing `HighlighterActor` directly.
                                                                                                                                                                                        
  Testing: 
Ran `./mach try linux-unit-tests` and `./mach test-devtools`. No new failures introduced.       

                                                                             
  Fixes:part of  #43800

