### PR TITLE
devtools: Replace new with register for PageStyleActor

### DIFF
--- a/components/devtools/actors/inspector.rs
+++ b/components/devtools/actors/inspector.rs
@@ -116,22 +116,19 @@ impl InspectorActor {
             browsing_context_name: browsing_context_name.clone(),
         };
 
-        let page_style_actor = PageStyleActor {
-            name: registry.new_name::<PageStyleActor>(),
-        };
+        let page_style_name = PageStyleActor::register(registry);
 
         let walker_name = WalkerActor::register(registry, browsing_context_name);
 
         let inspector_actor = Self {
             name: registry.new_name::<InspectorActor>(),
             highlighter_name: highlighter_actor.name(),
-            page_style_name: page_style_actor.name(),
+            page_style_name,
             walker_name,
         };
         let inspector_name = inspector_actor.name();
 
         registry.register(highlighter_actor);
-        registry.register(page_style_actor);
         registry.register(inspector_actor);
 
         inspector_name

--- a/components/devtools/actors/inspector/page_style.rs
+++ b/components/devtools/actors/inspector/page_style.rs
@@ -129,6 +129,13 @@ impl Actor for PageStyleActor {
 }
 
 impl PageStyleActor {
+    pub fn register(registry: &ActorRegistry) -> String {
+        let name = registry.new_name::<Self>();
+        let actor = Self { name: name.clone() };
+        registry.register::<Self>(actor);
+        name
+    }
+
     fn get_applied(
         &self,
         request: ClientRequest,


### PR DESCRIPTION
  Added a `register` method to `PageStyleActor` following the same pattern used by other actors in the devtools codebase. Updated `InspectorActor::register` to use it instead of  constructing `PageStyleActor` directly.
                                                                                                                                                                                        
  Testing: 
Ran `./mach try linux-unit-tests` and `./mach test-devtools`. No new failures introduced.       

                                                                             
  Fixes:part of  #43800
