### PR TITLE
Add tracing spans into generated code for getters, setters and methods

### DIFF
--- a/components/script_bindings/codegen/codegen.py
+++ b/components/script_bindings/codegen/codegen.py
@@ -4540,11 +4540,18 @@ class CGSpecializedMethod(CGAbstractExternMethod):
                                                         self.method)
         return CGWrapper(CGMethodCall([], nativeName, self.method.isStatic(),
                                       self.descriptor, self.method),
-                         pre="let mut cx = JSContext::from_ptr(ptr::NonNull::new(cx).unwrap());\n"
-                             "let cx = &mut cx;\n"
-                             f"let this = &*(this as *const {self.descriptor.concreteType});\n"
-                             "let args = &*args;\n"
-                             "let argc = args.argc_;\n")
+                         pre=f"""\
+                         let _span = profile_traits::trace_span!(
+                             "sv_jsapi.method.{self.descriptor.interface.identifier.name}.{nativeName}"
+                         )
+                         .entered();
+
+                         let mut cx = JSContext::from_ptr(ptr::NonNull::new(cx).unwrap());
+                         let cx = &mut cx;
+                         let this = &*(this as *const {self.descriptor.concreteType});
+                         let args = &*args;
+                         let argc = args.argc_;
+                         """)
 
     @staticmethod
     def makeNativeName(descriptor: Descriptor, method: IDLMethod) -> str:
@@ -4709,9 +4716,16 @@ class CGSpecializedGetter(CGAbstractExternMethod):
 
         return CGWrapper(CGGetterCall([], self.attr.type, nativeName,
                                       self.descriptor, self.attr),
-                         pre="let mut cx = JSContext::from_ptr(ptr::NonNull::new(cx).unwrap());\n"
-                             "let cx = &mut cx;\n"
-                             f"let this = &*(this as *const {self.descriptor.concreteType});\n")
+                         pre=f"""\
+                         let _span = profile_traits::trace_span!(
+                             "sv_jsapi.method.{self.descriptor.interface.identifier.name}.{nativeName}"
+                         )
+                         .entered();
+
+                         let mut cx = JSContext::from_ptr(ptr::NonNull::new(cx).unwrap());
+                         let cx = &mut cx;
+                         let this = &*(this as *const {self.descriptor.concreteType});
+                         """)
 
     @staticmethod
     def makeNativeName(descriptor: Descriptor, attr: IDLAttribute) -> str:
@@ -4766,9 +4780,16 @@ class CGSpecializedSetter(CGAbstractExternMethod):
                                                         self.attr)
         return CGWrapper(
             CGSetterCall([], self.attr.type, nativeName, self.descriptor, self.attr),
-            pre=("let mut cx = JSContext::from_ptr(ptr::NonNull::new(cx).unwrap());\n"
-                 "let cx = &mut cx;\n"
-                 f"let this = &*(this as *const {self.descriptor.concreteType});\n")
+            pre=f"""\
+            let _span = profile_traits::trace_span!(
+             "sv_jsapi.method.{self.descriptor.interface.identifier.name}.{nativeName}"
+            )
+            .entered();
+
+            let mut cx = JSContext::from_ptr(ptr::NonNull::new(cx).unwrap());
+            let cx = &mut cx;
+            let this = &*(this as *const {self.descriptor.concreteType});
+            """
         )
 
     @staticmethod


### PR DESCRIPTION
Add tracing spans into generated code for getters, setters and methods.

This allows for better performance testing of various DOM APIs

Testing: No observable code changes
