### PR TITLE
servoshell: Ignore requests to focus unknown WebViews via keyboard shortcuts

### DIFF
--- a/ports/servoshell/running_app_state.rs
+++ b/ports/servoshell/running_app_state.rs
@@ -140,12 +140,12 @@ impl WebViewCollection {
     }
 
     pub(crate) fn activate_webview_by_index(&mut self, index: usize) {
-        self.activate_webview(
-            *self
-                .creation_order
-                .get(index)
-                .expect("Tried to activate an unknown WebView"),
-        );
+        let Some(webview_id) = self.creation_order.get(index) else {
+            // Just ignore requests to activate uknown WebViews. This can happen by pressing
+            // keyboard shortcuts in the interface.
+            return;
+        };
+        self.activate_webview(*webview_id);
     }
 }
 


### PR DESCRIPTION
Instead of panicking when pressing a keyboard shortcut for an uknown
WebView, just silently ignore the request. This code path is only
followed when using keyboard shortcuts, so this isn't going to hide any
unexpected behavior.

Testing: We do not have testing at this level of servoshell.
Fixes: #44056.
