### PR TITLE
devtools: Replace new with register for NodeActor

### DIFF
--- a/components/devtools/actors/inspector/node.rs
+++ b/components/devtools/actors/inspector/node.rs
@@ -261,11 +261,15 @@ impl Actor for NodeActor {
 impl NodeActor {
     pub fn register(
         registry: &ActorRegistry,
+        script_id: String,
         script_chan: GenericSender<DevtoolScriptControlMsg>,
         pipeline: PipelineId,
         walker: String,
     ) -> String {
         let name = registry.new_name::<Self>();
+
+        registry.register_script_actor(script_id, name.clone());
+
         let actor = Self {
             name: name.clone(),
             script_chan,
@@ -298,10 +302,13 @@ impl NodeInfoToProtocol for NodeInfo {
     ) -> NodeActorMsg {
         let get_or_register_node_actor = |id: &str| {
             if !registry.script_actor_registered(id.to_string()) {
-                let node_name =
-                    NodeActor::register(registry, script_chan.clone(), pipeline, walker.clone());
-                registry.register_script_actor(id.to_string(), node_name.clone());
-                node_name
+                NodeActor::register(
+                    registry,
+                    id.to_string(),
+                    script_chan.clone(),
+                    pipeline,
+                    walker.clone(),
+                )
             } else {
                 registry.script_to_actor(id.to_string())
             }

--- a/components/devtools/actors/inspector/node.rs
+++ b/components/devtools/actors/inspector/node.rs
@@ -258,6 +258,26 @@ impl Actor for NodeActor {
     }
 }
 
+impl NodeActor {
+    pub fn register(
+        registry: &ActorRegistry,
+        script_chan: GenericSender<DevtoolScriptControlMsg>,
+        pipeline: PipelineId,
+        walker: String,
+    ) -> String {
+        let name = registry.new_name::<Self>();
+        let actor = Self {
+            name: name.clone(),
+            script_chan,
+            pipeline,
+            walker,
+            style_rules: AtomicRefCell::new(HashMap::new()),
+        };
+
+        registry.register(actor);
+        name
+    }
+}
 pub trait NodeInfoToProtocol {
     fn encode(
         self,
@@ -278,17 +298,9 @@ impl NodeInfoToProtocol for NodeInfo {
     ) -> NodeActorMsg {
         let get_or_register_node_actor = |id: &str| {
             if !registry.script_actor_registered(id.to_string()) {
-                let node_name = registry.new_name::<NodeActor>();
+                let node_name =
+                    NodeActor::register(registry, script_chan.clone(), pipeline, walker.clone());
                 registry.register_script_actor(id.to_string(), node_name.clone());
-
-                let node_actor = NodeActor {
-                    name: node_name.clone(),
-                    script_chan: script_chan.clone(),
-                    pipeline,
-                    walker: walker.clone(),
-                    style_rules: AtomicRefCell::new(HashMap::new()),
-                };
-                registry.register(node_actor);
                 node_name
             } else {
                 registry.script_to_actor(id.to_string())


### PR DESCRIPTION
Added a `register` method to `NodeActor` following the same pattern used by other actors in the devtools codebase. Updated `NodeInfoToProtocol::get_or_register_node_actor` to use it instead of  constructing `NodeActor` directly.
                                                                                                                                                                                        
Testing: 
Ran `./mach try linux-unit-tests` and `./mach test-devtools`. No new failures introduced.       

Fixes:part of  #43800
