### PR TITLE
script: Move `StyleData` to `Element` from `Node`

### DIFF
--- a/components/layout/query.rs
+++ b/components/layout/query.rs
@@ -968,8 +968,8 @@ fn rendered_text_collection_steps(
 
     match node.type_id() {
         LayoutNodeType::Text => {
-            if let Some(element) = node.parent_node() {
-                match element.type_id() {
+            if let Some(parent_node) = node.parent_node() {
+                match parent_node.type_id() {
                     // Any text contained in these elements must be ignored.
                     LayoutNodeType::Element(LayoutElementType::HTMLCanvasElement) |
                     LayoutNodeType::Element(LayoutElementType::HTMLImageElement) |
@@ -984,7 +984,7 @@ fn rendered_text_collection_steps(
                     // Basically: a Select can only contain Options or OptGroups, while
                     // OptGroups may also contain Options. Everything else gets ignored.
                     LayoutNodeType::Element(LayoutElementType::HTMLOptGroupElement) => {
-                        if let Some(element) = element.parent_node() {
+                        if let Some(element) = parent_node.parent_node() {
                             if !matches!(
                                 element.type_id(),
                                 LayoutNodeType::Element(LayoutElementType::HTMLSelectElement)
@@ -1006,7 +1006,10 @@ fn rendered_text_collection_steps(
                     return items;
                 }
 
-                let Some(style_data) = element.style_data() else {
+                let Some(parent_element) = parent_node.to_threadsafe().as_element() else {
+                    return items;
+                };
+                let Some(style_data) = parent_element.style_data() else {
                     return items;
                 };
 
@@ -1029,11 +1032,13 @@ fn rendered_text_collection_steps(
                 // property is not 'none':
                 let display = style.get_box().display;
                 if display == Display::None {
-                    match element.type_id() {
+                    match parent_element.type_id() {
                         // Even if set to Display::None, Option/OptGroup elements need to
                         // be rendered.
-                        LayoutNodeType::Element(LayoutElementType::HTMLOptGroupElement) |
-                        LayoutNodeType::Element(LayoutElementType::HTMLOptionElement) => {},
+                        Some(
+                            LayoutNodeType::Element(LayoutElementType::HTMLOptGroupElement) |
+                            LayoutNodeType::Element(LayoutElementType::HTMLOptionElement),
+                        ) => {},
                         _ => {
                             return items;
                         },
@@ -1131,7 +1136,10 @@ fn rendered_text_collection_steps(
         _ => {
             // First we need to gather some infos to setup the various flags
             // before rendering the child nodes
-            let Some(style_data) = node.style_data() else {
+            let Some(element) = node.to_threadsafe().as_element() else {
+                return items;
+            };
+            let Some(style_data) = element.style_data() else {
                 return items;
             };
 

--- a/components/layout/traversal.rs
+++ b/components/layout/traversal.rs
@@ -7,7 +7,9 @@ use std::sync::Arc;
 
 use bitflags::Flags;
 use layout_api::LayoutDamage;
-use layout_api::wrapper_traits::{LayoutNode, ThreadSafeLayoutNode};
+use layout_api::wrapper_traits::{
+    LayoutElement, LayoutNode, ThreadSafeLayoutElement, ThreadSafeLayoutNode,
+};
 use script::layout_dom::{ServoLayoutNode, ServoThreadSafeLayoutNode};
 use style::context::{SharedStyleContext, StyleContext};
 use style::data::ElementData;
@@ -36,7 +38,7 @@ impl<'a> RecalcStyle<'a> {
 #[expect(unsafe_code)]
 impl<'dom, E> DomTraversal<E> for RecalcStyle<'_>
 where
-    E: TElement,
+    E: LayoutElement<'dom> + TElement,
     E::ConcreteNode: 'dom + LayoutNode<'dom>,
 {
     fn process_preorder<F>(
@@ -52,14 +54,14 @@ where
             return;
         }
 
-        let had_style_data = node.style_data().is_some();
+        let element = node.as_element().unwrap();
+        let had_style_data = element.style_data().is_some();
+
         unsafe {
-            node.initialize_style_and_layout_data::<DOMLayoutData>();
+            element.initialize_style_and_layout_data::<DOMLayoutData>();
         }
 
-        let element = node.as_element().unwrap();
         let mut element_data = element.mutate_data().unwrap();
-
         if !had_style_data {
             element_data.damage = RestyleDamage::reconstruct();
         }
@@ -179,12 +181,14 @@ pub(crate) fn compute_damage_and_rebuild_box_tree_inner(
     node: ServoThreadSafeLayoutNode<'_>,
     damage_from_parent: RestyleDamage,
 ) -> RestyleDamage {
-    let element_data = &node
-        .style_data()
-        .expect("Should not run `compute_damage` before styling.")
-        .element_data;
+    // Don't do any kind of damage propagation or box tree constuction for non-Element nodes,
+    // such as text and comments.
+    let Some(element) = node.as_element() else {
+        return damage_from_parent;
+    };
+
     let (element_damage, is_display_none) = {
-        let mut element_data = element_data.borrow_mut();
+        let mut element_data = element.element_data_mut();
         (
             std::mem::take(&mut element_data.damage),
             element_data.styles.is_display_none(),

--- a/components/script/devtools.rs
+++ b/components/script/devtools.rs
@@ -517,17 +517,17 @@ pub(crate) fn handle_get_layout(
         None => return reply.send(None).unwrap(),
         Some(found_node) => found_node,
     };
-    let auto_margins = determine_auto_margins(&node);
 
-    let elem = node
+    let element = node
         .downcast::<Element>()
         .expect("should be getting layout of element");
-    let rect = elem.GetBoundingClientRect(CanGc::from_cx(cx));
+
+    let rect = element.GetBoundingClientRect(CanGc::from_cx(cx));
     let width = rect.Width() as f32;
     let height = rect.Height() as f32;
 
     let window = node.owner_window();
-    let computed_style = window.GetComputedStyle(elem, None);
+    let computed_style = window.GetComputedStyle(element, None);
     let computed_layout = ComputedNodeLayout {
         display: computed_style.Display().into(),
         position: computed_style.Position().into(),
@@ -549,6 +549,7 @@ pub(crate) fn handle_get_layout(
         height,
     };
 
+    let auto_margins = element.determine_auto_margins();
     reply.send(Some((computed_layout, auto_margins))).unwrap();
 }
 
@@ -709,15 +710,17 @@ pub(crate) fn handle_highlight_dom_node(
     }
 }
 
-fn determine_auto_margins(node: &Node) -> AutoMargins {
-    let Some(style) = node.style() else {
-        return AutoMargins::default();
-    };
-    let margin = style.get_margin();
-    AutoMargins {
-        top: margin.margin_top.is_auto(),
-        right: margin.margin_right.is_auto(),
-        bottom: margin.margin_bottom.is_auto(),
-        left: margin.margin_left.is_auto(),
+impl Element {
+    fn determine_auto_margins(&self) -> AutoMargins {
+        let Some(style) = self.style() else {
+            return AutoMargins::default();
+        };
+        let margin = style.get_margin();
+        AutoMargins {
+            top: margin.margin_top.is_auto(),
+            right: margin.margin_right.is_auto(),
+            bottom: margin.margin_bottom.is_auto(),
+            left: margin.margin_left.is_auto(),
+        }
     }
 }

--- a/components/script/dom/document/document.rs
+++ b/components/script/dom/document/document.rs
@@ -715,12 +715,11 @@ impl Document {
             },
         };
 
-        if parent.is::<Element>() {
-            if !parent.is_styled() {
+        if let Some(parent_element) = parent.downcast::<Element>() {
+            if !parent_element.is_styled() {
                 return;
             }
-
-            if parent.is_display_none() {
+            if parent_element.is_display_none() {
                 return;
             }
         }

--- a/components/script/dom/element/element.rs
+++ b/components/script/dom/element/element.rs
@@ -25,7 +25,7 @@ use js::context::JSContext;
 use js::jsapi::{Heap, JSAutoRealm};
 use js::jsval::JSVal;
 use js::rust::HandleObject;
-use layout_api::{LayoutDamage, ScrollContainerQueryFlags};
+use layout_api::{LayoutDamage, QueryMsg, ScrollContainerQueryFlags, StyleData};
 use net_traits::ReferrerPolicy;
 use net_traits::request::{CorsSettings, CredentialsMode};
 use selectors::Element as SelectorsElement;
@@ -33,7 +33,7 @@ use selectors::attr::{AttrSelectorOperation, CaseSensitivity, NamespaceConstrain
 use selectors::bloom::{BLOOM_HASH_MASK, BloomFilter};
 use selectors::matching::{ElementSelectorFlags, MatchingContext};
 use selectors::sink::Push;
-use servo_arc::Arc;
+use servo_arc::Arc as ServoArc;
 use style::applicable_declarations::ApplicableDeclarationBlock;
 use style::attr::{AttrValue, LengthOrPercentageOrAuto};
 use style::context::QuirksMode;
@@ -192,7 +192,7 @@ pub struct Element {
     is: DomRefCell<Option<LocalName>>,
     #[conditional_malloc_size_of]
     #[no_trace]
-    style_attribute: DomRefCell<Option<Arc<Locked<PropertyDeclarationBlock>>>>,
+    style_attribute: DomRefCell<Option<ServoArc<Locked<PropertyDeclarationBlock>>>>,
     attr_list: MutNullableDom<NamedNodeMap>,
     class_list: MutNullableDom<DOMTokenList>,
     #[no_trace]
@@ -201,6 +201,11 @@ pub struct Element {
     /// operations may require restyling this element or its descendants.
     selector_flags: AtomicUsize,
     rare_data: DomRefCell<Option<Box<ElementRareData>>>,
+
+    /// Style data for this node. This is accessed and mutated by style
+    /// passes and is used to lay out this node and populate layout data.
+    #[no_trace]
+    style_data: DomRefCell<Option<Box<StyleData>>>,
 }
 
 impl fmt::Debug for Element {
@@ -313,6 +318,7 @@ impl Element {
             state: Cell::new(state),
             selector_flags: Default::default(),
             rare_data: Default::default(),
+            style_data: Default::default(),
         }
     }
 
@@ -352,6 +358,10 @@ impl Element {
             *rare_data = Some(Default::default());
         }
         RefMut::map(rare_data, |rare_data| rare_data.as_mut().unwrap())
+    }
+
+    pub(crate) fn clean_up_style_data(&self) {
+        self.style_data.borrow_mut().take();
     }
 
     pub(crate) fn restyle(&self, damage: NodeDamage) {
@@ -477,12 +487,6 @@ impl Element {
 
             reactions.clear();
         }
-    }
-
-    /// style will be `None` for elements in a `display: none` subtree. otherwise, the element has a
-    /// layout box iff it doesn't have `display: none`.
-    pub(crate) fn style(&self) -> Option<Arc<ComputedValues>> {
-        self.upcast::<Node>().style()
     }
 
     // https://drafts.csswg.org/cssom-view/#css-layout-box
@@ -977,6 +981,30 @@ impl Element {
         // Steps 3 and 4 are shared with other scroll targets.
         document.finish_handle_scroll_event(self.upcast());
     }
+
+    pub(crate) fn style(&self) -> Option<ServoArc<ComputedValues>> {
+        self.owner_window().layout_reflow(QueryMsg::StyleQuery);
+        self.style_data
+            .borrow()
+            .as_ref()
+            .map(|data| data.element_data.borrow().styles.primary().clone())
+    }
+
+    pub(crate) fn is_styled(&self) -> bool {
+        self.style_data.borrow().is_some()
+    }
+
+    pub(crate) fn is_display_none(&self) -> bool {
+        self.style_data.borrow().as_ref().is_none_or(|data| {
+            data.element_data
+                .borrow()
+                .styles
+                .primary()
+                .get_box()
+                .display
+                .is_none()
+        })
+    }
 }
 
 /// <https://dom.spec.whatwg.org/#valid-shadow-host-name>
@@ -1053,6 +1081,28 @@ impl<'dom> LayoutDom<'dom, Element> {
 
     pub(crate) fn get_parts_for_layout(self) -> Option<&'dom [Atom]> {
         get_attr_for_layout(self, &ns!(), &local_name!("part")).map(|attr| attr.as_tokens())
+    }
+
+    #[inline]
+    #[expect(unsafe_code)]
+    pub(crate) fn style_data(self) -> Option<&'dom StyleData> {
+        unsafe { self.unsafe_get().style_data.borrow_for_layout().as_deref() }
+    }
+
+    #[inline]
+    #[expect(unsafe_code)]
+    pub(crate) unsafe fn initialize_style_data(self) {
+        let data = unsafe { self.unsafe_get().style_data.borrow_mut_for_layout() };
+        debug_assert!(data.is_none());
+        *data = Some(Box::default());
+    }
+
+    #[inline]
+    #[expect(unsafe_code)]
+    pub(crate) unsafe fn clear_style_data(self) {
+        unsafe {
+            self.unsafe_get().style_data.borrow_mut_for_layout().take();
+        }
     }
 
     pub(crate) fn synthesize_presentational_hints_for_legacy_attributes<V>(self, hints: &mut V)
@@ -1398,7 +1448,7 @@ impl<'dom> LayoutDom<'dom, Element> {
 
         let shared_lock = document.style_shared_lock();
         hints.push(ApplicableDeclarationBlock::from_declarations(
-            Arc::new(shared_lock.wrap(property_declaration_block)),
+            ServoArc::new(shared_lock.wrap(property_declaration_block)),
             CascadeLevel::new(CascadeOrigin::PresHints),
             LayerOrder::root(),
         ));
@@ -1433,7 +1483,9 @@ impl<'dom> LayoutDom<'dom, Element> {
     }
 
     #[expect(unsafe_code)]
-    pub(crate) fn style_attribute(self) -> *const Option<Arc<Locked<PropertyDeclarationBlock>>> {
+    pub(crate) fn style_attribute(
+        self,
+    ) -> *const Option<ServoArc<Locked<PropertyDeclarationBlock>>> {
         unsafe { (self.unsafe_get()).style_attribute.borrow_for_layout() }
     }
 
@@ -1671,7 +1723,7 @@ impl Element {
 
     pub(crate) fn style_attribute(
         &self,
-    ) -> &DomRefCell<Option<Arc<Locked<PropertyDeclarationBlock>>>> {
+    ) -> &DomRefCell<Option<ServoArc<Locked<PropertyDeclarationBlock>>>> {
         &self.style_attribute
     }
 
@@ -2246,7 +2298,7 @@ impl Element {
                     {
                         return;
                     }
-                    Arc::new(doc.style_shared_lock().wrap(parse_style_attribute(
+                    ServoArc::new(doc.style_shared_lock().wrap(parse_style_attribute(
                         source,
                         &UrlExtraData(doc.base_url().get_arc()),
                         Some(win.css_error_reporter()),

--- a/components/script/dom/execcommand/contenteditable.rs
+++ b/components/script/dom/execcommand/contenteditable.rs
@@ -111,7 +111,10 @@ impl Text {
         let mut resolved_ancestor = ancestor.clone();
         for parent in ancestor.ancestors() {
             // Step 5. If the "display" property of some ancestor of node has resolved value "none", return true.
-            if parent.is_display_none() {
+            if parent
+                .downcast::<Element>()
+                .is_some_and(Element::is_display_none)
+            {
                 return true;
             }
             // Step 6. While ancestor is not a block node and its parent is not null, set ancestor to its parent.
@@ -174,7 +177,7 @@ impl Text {
         let has_preserve_space = self
             .upcast::<Node>()
             .GetParentNode()
-            .and_then(|parent| parent.style())
+            .and_then(|parent_node| parent_node.downcast::<Element>().and_then(Element::style))
             .is_some_and(|style| {
                 // Note that for "pre" and "pre-wrap", the longhand "white-space-collapse: preserve" applies
                 // https://www.w3.org/TR/css-text-4/#white-space-property
@@ -324,6 +327,10 @@ impl HTMLElement {
 }
 
 impl Element {
+    fn resolved_display_value(&self) -> Option<DisplayOutside> {
+        self.style().map(|style| style.get_box().display.outside())
+    }
+
     /// <https://w3c.github.io/editing/docs/execCommand/#specified-command-value>
     pub(crate) fn specified_command_value(&self, command: &CommandName) -> Option<DOMString> {
         match command {
@@ -1220,10 +1227,6 @@ where
 }
 
 impl Node {
-    fn resolved_display_value(&self) -> Option<DisplayOutside> {
-        self.style().map(|style| style.get_box().display.outside())
-    }
-
     /// <https://w3c.github.io/editing/docs/execCommand/#push-down-values>
     fn push_down_values(
         &self,
@@ -1612,8 +1615,10 @@ impl NodeExecCommandSupport for Node {
     /// <https://w3c.github.io/editing/docs/execCommand/#block-node>
     fn is_block_node(&self) -> bool {
         // > A block node is either an Element whose "display" property does not have resolved value "inline" or "inline-block" or "inline-table" or "none",
-        if self.is::<Element>() &&
-            self.resolved_display_value().is_some_and(|display| {
+        if self
+            .downcast::<Element>()
+            .and_then(Element::resolved_display_value)
+            .is_some_and(|display| {
                 display != DisplayOutside::Inline && display != DisplayOutside::None
             })
         {
@@ -1651,10 +1656,10 @@ impl NodeExecCommandSupport for Node {
     fn is_visible(&self) -> bool {
         for parent in self.inclusive_ancestors(ShadowIncluding::No) {
             // > excluding any node with an inclusive ancestor Element whose "display" property has resolved value "none".
-            if parent.is::<Element>() &&
-                parent
-                    .resolved_display_value()
-                    .is_some_and(|display| display == DisplayOutside::None)
+            if parent
+                .downcast::<Element>()
+                .and_then(Element::resolved_display_value)
+                .is_some_and(|display| display == DisplayOutside::None)
             {
                 return false;
             }

--- a/components/script/dom/node/node.rs
+++ b/components/script/dom/node/node.rs
@@ -29,8 +29,8 @@ use keyboard_types::Modifiers;
 use layout_api::wrapper_traits::SharedSelection;
 use layout_api::{
     AxesOverflow, BoxAreaType, CSSPixelRectIterator, GenericLayoutData, HTMLCanvasData,
-    HTMLMediaData, LayoutElementType, LayoutNodeType, PhysicalSides, QueryMsg, SVGElementData,
-    StyleData, TrustedNodeAddress, with_layout_state,
+    HTMLMediaData, LayoutElementType, LayoutNodeType, PhysicalSides, SVGElementData,
+    TrustedNodeAddress, with_layout_state,
 };
 use libc::{self, c_void, uintptr_t};
 use malloc_size_of::{MallocSizeOf, MallocSizeOfOps};
@@ -49,7 +49,6 @@ use style::attr::AttrValue;
 use style::context::QuirksMode;
 use style::dom::OpaqueNode;
 use style::dom_apis::{QueryAll, QueryFirst};
-use style::properties::ComputedValues;
 use style::selector_parser::PseudoElement;
 use style::stylesheets::Stylesheet;
 use style_traits::CSSPixel;
@@ -175,11 +174,6 @@ pub struct Node {
 
     /// The maximum version of any inclusive descendant of this node.
     inclusive_descendants_version: Cell<u64>,
-
-    /// Style data for this node. This is accessed and mutated by style
-    /// passes and is used to lay out this node and populate layout data.
-    #[no_trace]
-    style_data: DomRefCell<Option<Box<StyleData>>>,
 
     /// Layout data for this node. This is populated during layout and can
     /// be used for incremental relayout and script queries.
@@ -371,9 +365,11 @@ impl Node {
         }
     }
 
-    pub(crate) fn clean_up_style_and_layout_data(&self) {
-        self.style_data.borrow_mut().take();
+    fn clean_up_style_and_layout_data(&self) {
         self.layout_data.borrow_mut().take();
+        if let Some(element) = self.downcast::<Element>() {
+            element.clean_up_style_data();
+        }
     }
 
     /// Clean up flags and runs steps 11-14 of remove a node.
@@ -465,15 +461,9 @@ impl Node {
             .union(NodeFlags::HAS_SNAPSHOT)
             .union(NodeFlags::HANDLED_SNAPSHOT);
 
-        // Since both the initial traversal in light dom and the inner traversal
-        // in shadow DOM share the same code, we define a closure to prevent omissions.
-        let cleanup_node = |node: &Node| {
-            node.clean_up_style_and_layout_data();
-        };
-
         for node in root.traverse_preorder(ShadowIncluding::No) {
             node.set_flag(RESET_FLAGS | NodeFlags::IS_IN_SHADOW_TREE, false);
-            cleanup_node(&node);
+            node.clean_up_style_and_layout_data();
 
             // Make sure that we don't accidentally initialize the rare data for this node
             // by setting it to None
@@ -492,7 +482,7 @@ impl Node {
                     .traverse_preorder(ShadowIncluding::Yes)
                 {
                     node.set_flag(RESET_FLAGS, false);
-                    cleanup_node(&node);
+                    node.clean_up_style_and_layout_data();
                 }
             }
         }
@@ -1745,10 +1735,19 @@ impl Node {
         };
 
         let window = self.owner_window();
-        let display = self
-            .downcast::<Element>()
+        let element = self.downcast::<Element>();
+        let display = element
             .map(|elem| window.GetComputedStyle(elem, None))
             .map(|style| style.Display().into());
+
+        // It is not entirely clear when this should be set to false.
+        // Firefox considers nodes with "display: contents" to be displayed.
+        // The doctype node is displayed despite being `display: none`.
+        //
+        // TODO: Should this be false if the node is in a `display: none` subtree?
+        let is_displayed =
+            element.is_none_or(|element| !element.is_display_none()) || self.is::<DocumentType>();
+        let attrs = element.map(Element::summarize).unwrap_or_default();
 
         NodeInfo {
             unique_id: self.unique_id(pipeline),
@@ -1762,14 +1761,11 @@ impl Node {
             node_name: String::from(self.NodeName()),
             node_value: self.GetNodeValue().map(|v| v.into()),
             num_children,
-            attrs: self.downcast().map(Element::summarize).unwrap_or(vec![]),
+            attrs,
             is_shadow_host,
             shadow_root_mode,
             display,
-            // It is not entirely clear when this should be set to false.
-            // Firefox considers nodes with "display: contents" to be displayed.
-            // The doctype node is displayed despite being `display: none`.
-            is_displayed: !self.is_display_none() || self.is::<DocumentType>(),
+            is_displayed,
             doctype_name: self
                 .downcast::<DocumentType>()
                 .map(DocumentType::name)
@@ -1885,30 +1881,6 @@ impl Node {
         } else {
             None
         }
-    }
-
-    pub(crate) fn is_styled(&self) -> bool {
-        self.style_data.borrow().is_some()
-    }
-
-    pub(crate) fn is_display_none(&self) -> bool {
-        self.style_data.borrow().as_ref().is_none_or(|data| {
-            data.element_data
-                .borrow()
-                .styles
-                .primary()
-                .get_box()
-                .display
-                .is_none()
-        })
-    }
-
-    pub(crate) fn style(&self) -> Option<ServoArc<ComputedValues>> {
-        self.owner_window().layout_reflow(QueryMsg::StyleQuery);
-        self.style_data
-            .borrow()
-            .as_ref()
-            .map(|data| data.element_data.borrow().styles.primary().clone())
     }
 
     /// <https://html.spec.whatwg.org/multipage/#language>
@@ -2224,14 +2196,6 @@ impl<'dom> LayoutDom<'dom, Node> {
         (this).flags.set(flags);
     }
 
-    // FIXME(nox): How we handle style and layout data needs to be completely
-    // revisited so we can do that more cleanly and safely in layout 2020.
-    #[inline]
-    #[expect(unsafe_code)]
-    pub(crate) fn style_data(self) -> Option<&'dom StyleData> {
-        unsafe { self.unsafe_get().style_data.borrow_for_layout().as_deref() }
-    }
-
     #[inline]
     #[expect(unsafe_code)]
     pub(crate) fn layout_data(self) -> Option<&'dom GenericLayoutData> {
@@ -2239,21 +2203,6 @@ impl<'dom> LayoutDom<'dom, Node> {
     }
 
     /// Initialize the style data of this node.
-    ///
-    /// # Safety
-    ///
-    /// This method is unsafe because it modifies the given node during
-    /// layout. Callers should ensure that no other layout thread is
-    /// attempting to read or modify the opaque layout data of this node.
-    #[inline]
-    #[expect(unsafe_code)]
-    pub(crate) unsafe fn initialize_style_data(self) {
-        let data = unsafe { self.unsafe_get().style_data.borrow_mut_for_layout() };
-        debug_assert!(data.is_none());
-        *data = Some(Box::default());
-    }
-
-    /// Initialize the opaque layout data of this node.
     ///
     /// # Safety
     ///
@@ -2277,9 +2226,8 @@ impl<'dom> LayoutDom<'dom, Node> {
     /// attempting to read or modify the opaque layout data of this node.
     #[inline]
     #[expect(unsafe_code)]
-    pub(crate) unsafe fn clear_style_and_layout_data(self) {
+    pub(crate) unsafe fn clear_layout_data(self) {
         unsafe {
-            self.unsafe_get().style_data.borrow_mut_for_layout().take();
             self.unsafe_get().layout_data.borrow_mut_for_layout().take();
         }
     }
@@ -2813,7 +2761,6 @@ impl Node {
     fn new_(flags: NodeFlags, doc: Option<&Document>) -> Node {
         Node {
             eventtarget: EventTarget::new_inherited(),
-
             parent_node: Default::default(),
             first_child: Default::default(),
             last_child: Default::default(),
@@ -2824,7 +2771,6 @@ impl Node {
             children_count: Cell::new(0u32),
             flags: Cell::new(flags),
             inclusive_descendants_version: Cell::new(0),
-            style_data: Default::default(),
             layout_data: Default::default(),
         }
     }

--- a/components/script/layout_dom/element.rs
+++ b/components/script/layout_dom/element.rs
@@ -10,7 +10,8 @@ use embedder_traits::UntrustedNodeAddress;
 use html5ever::{LocalName, Namespace, local_name, ns};
 use js::jsapi::JSObject;
 use layout_api::wrapper_traits::{
-    LayoutNode, PseudoElementChain, ThreadSafeLayoutElement, ThreadSafeLayoutNode,
+    LayoutDataTrait, LayoutElement, LayoutNode, PseudoElementChain, ThreadSafeLayoutElement,
+    ThreadSafeLayoutNode,
 };
 use layout_api::{LayoutDamage, LayoutNodeType, StyleData};
 use selectors::Element as _;
@@ -60,6 +61,15 @@ pub struct ServoLayoutElement<'dom> {
     element: LayoutDom<'dom, Element>,
 }
 
+/// Those are supposed to be sound, but they aren't because the entire system
+/// between script and layout so far has been designed to work around their
+/// absence. Switching the entire thing to the inert crate infra will help.
+///
+/// FIXME(mrobinson): These are required because Layout 2020 sends non-threadsafe
+/// nodes to different threads. This should be adressed in a comprehensive way.
+unsafe impl Send for ServoLayoutElement<'_> {}
+unsafe impl Sync for ServoLayoutElement<'_> {}
+
 impl fmt::Debug for ServoLayoutElement<'_> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "<{}", self.element.local_name())?;
@@ -67,6 +77,24 @@ impl fmt::Debug for ServoLayoutElement<'_> {
             write!(f, " id={}", id)?;
         }
         write!(f, "> ({:#x})", self.as_node().opaque().0)
+    }
+}
+
+impl<'dom> LayoutElement<'dom> for ServoLayoutElement<'dom> {
+    unsafe fn initialize_style_and_layout_data<RequestedLayoutDataType: LayoutDataTrait>(&self) {
+        let inner = self.to_layout_dom();
+        if inner.style_data().is_none() {
+            unsafe { inner.initialize_style_data() };
+        }
+
+        let node = self.element.upcast::<Node>();
+        if node.layout_data().is_none() {
+            unsafe { node.initialize_layout_data(Box::<RequestedLayoutDataType>::default()) };
+        }
+    }
+
+    fn style_data(self) -> Option<&'dom StyleData> {
+        self.to_layout_dom().style_data()
     }
 }
 
@@ -95,10 +123,6 @@ impl<'dom> ServoLayoutElement<'dom> {
     #[inline]
     fn get_attr(&self, namespace: &Namespace, name: &LocalName) -> Option<&str> {
         self.element.get_attr_val_for_layout(namespace, name)
-    }
-
-    fn get_style_data(&self) -> Option<&StyleData> {
-        self.as_node().style_data()
     }
 
     /// Unset the snapshot flags on the underlying DOM object for this element.
@@ -409,14 +433,14 @@ impl<'dom> style::dom::TElement for ServoLayoutElement<'dom> {
     }
 
     fn store_children_to_process(&self, n: isize) {
-        let data = self.get_style_data().unwrap();
+        let data = self.style_data().unwrap();
         data.parallel
             .children_to_process
             .store(n, Ordering::Relaxed);
     }
 
     fn did_process_child(&self) -> isize {
-        let data = self.get_style_data().unwrap();
+        let data = self.style_data().unwrap();
         let old_value = data
             .parallel
             .children_to_process
@@ -426,30 +450,28 @@ impl<'dom> style::dom::TElement for ServoLayoutElement<'dom> {
     }
 
     unsafe fn clear_data(&self) {
-        unsafe { self.as_node().to_layout_dom().clear_style_and_layout_data() }
+        unsafe { self.element.clear_style_data() };
+        unsafe { self.as_node().to_layout_dom().clear_layout_data() }
     }
 
     unsafe fn ensure_data(&self) -> ElementDataMut<'_> {
-        unsafe {
-            self.as_node().to_layout_dom().initialize_style_data();
-        };
+        unsafe { self.element.initialize_style_data() };
         self.mutate_data().unwrap()
     }
 
     /// Whether there is an ElementData container.
     fn has_data(&self) -> bool {
-        self.get_style_data().is_some()
+        self.style_data().is_some()
     }
 
     /// Immutably borrows the ElementData.
     fn borrow_data(&self) -> Option<ElementDataRef<'_>> {
-        self.get_style_data().map(|data| data.element_data.borrow())
+        self.style_data().map(|data| data.element_data.borrow())
     }
 
     /// Mutably borrows the ElementData.
     fn mutate_data(&self) -> Option<ElementDataMut<'_>> {
-        self.get_style_data()
-            .map(|data| data.element_data.borrow_mut())
+        self.style_data().map(|data| data.element_data.borrow_mut())
     }
 
     fn skip_item_display_fixup(&self) -> bool {
@@ -1063,7 +1085,7 @@ impl<'dom> ThreadSafeLayoutElement<'dom> for ServoThreadSafeLayoutElement<'dom> 
 
     fn with_pseudo(&self, pseudo_element: PseudoElement) -> Option<Self> {
         if pseudo_element.is_eager() &&
-            self.style_data()
+            self.element_data()
                 .styles
                 .pseudos
                 .get(&pseudo_element)
@@ -1112,8 +1134,8 @@ impl<'dom> ThreadSafeLayoutElement<'dom> for ServoThreadSafeLayoutElement<'dom> 
         self.element.get_attr(namespace, name)
     }
 
-    fn style_data(&self) -> ElementDataRef<'_> {
-        self.element.borrow_data().expect("Unstyled layout node?")
+    fn style_data(&self) -> Option<&'dom StyleData> {
+        self.element.style_data()
     }
 
     fn is_shadow_host(&self) -> bool {

--- a/components/script/layout_dom/node.rs
+++ b/components/script/layout_dom/node.rs
@@ -14,7 +14,7 @@ use layout_api::wrapper_traits::{
 };
 use layout_api::{
     GenericLayoutData, HTMLCanvasData, HTMLMediaData, LayoutElementType, LayoutNodeType,
-    SVGElementData, StyleData, TrustedNodeAddress,
+    SVGElementData, TrustedNodeAddress,
 };
 use net_traits::image_cache::Image;
 use pixels::ImageMetadata;
@@ -64,8 +64,8 @@ unsafe impl Sync for ServoLayoutNode<'_> {}
 
 impl fmt::Debug for ServoLayoutNode<'_> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        if let Some(el) = self.as_element() {
-            el.fmt(f)
+        if let Some(element) = self.as_element() {
+            element.fmt(f)
         } else if self.is_text_node() {
             write!(f, "<text node> ({:#x})", self.opaque().0)
         } else {
@@ -224,6 +224,7 @@ impl<'dom> style::dom::TNode for ServoLayoutNode<'dom> {
 
 impl<'dom> LayoutNode<'dom> for ServoLayoutNode<'dom> {
     type ConcreteThreadSafeLayoutNode = ServoThreadSafeLayoutNode<'dom>;
+    type ConcreteLayoutElement = ServoLayoutElement<'dom>;
 
     fn to_threadsafe(&self) -> Self::ConcreteThreadSafeLayoutNode {
         ServoThreadSafeLayoutNode::new(*self)
@@ -233,22 +234,8 @@ impl<'dom> LayoutNode<'dom> for ServoLayoutNode<'dom> {
         NodeTypeIdWrapper(self.script_type_id()).into()
     }
 
-    unsafe fn initialize_style_and_layout_data<RequestedLayoutDataType: LayoutDataTrait>(&self) {
-        let inner = self.to_layout_dom();
-        if inner.style_data().is_none() {
-            unsafe { inner.initialize_style_data() };
-        }
-        if inner.layout_data().is_none() {
-            unsafe { inner.initialize_layout_data(Box::<RequestedLayoutDataType>::default()) };
-        }
-    }
-
     fn is_connected(&self) -> bool {
         unsafe { self.node.get_flag(NodeFlags::IS_CONNECTED) }
-    }
-
-    fn style_data(&self) -> Option<&'dom StyleData> {
-        self.to_layout_dom().style_data()
     }
 
     fn layout_data(&self) -> Option<&'dom GenericLayoutData> {
@@ -323,7 +310,7 @@ impl<'dom> ServoThreadSafeLayoutNode<'dom> {
             return self.parent_style(context);
         };
 
-        let style_data = &element.style_data().styles;
+        let style_data = &element.element_data().styles;
         let get_selected_style = || {
             // This is a workaround for handling the `::selection` pseudos where it would not
             // propagate to the children and Shadow DOM elements. For this case, UA widget
@@ -405,9 +392,10 @@ impl<'dom> ThreadSafeLayoutNode<'dom> for ServoThreadSafeLayoutNode<'dom> {
 
     fn as_element(&self) -> Option<ServoThreadSafeLayoutElement<'dom>> {
         self.node
-            .as_element()
-            .map(|el| ServoThreadSafeLayoutElement {
-                element: el,
+            .node
+            .downcast()
+            .map(|element| ServoThreadSafeLayoutElement {
+                element: ServoLayoutElement::from_layout_dom(element),
                 pseudo_element_chain: self.pseudo_element_chain,
             })
     }
@@ -415,10 +403,6 @@ impl<'dom> ThreadSafeLayoutNode<'dom> for ServoThreadSafeLayoutNode<'dom> {
     fn as_html_element(&self) -> Option<ServoThreadSafeLayoutElement<'dom>> {
         self.as_element()
             .filter(|element| element.element.is_html_element())
-    }
-
-    fn style_data(&self) -> Option<&'dom StyleData> {
-        self.node.style_data()
     }
 
     fn layout_data(&self) -> Option<&'dom GenericLayoutData> {

--- a/components/shared/layout/wrapper_traits.rs
+++ b/components/shared/layout/wrapper_traits.rs
@@ -19,7 +19,7 @@ use servo_base::id::{BrowsingContextId, PipelineId};
 use servo_url::ServoUrl;
 use style::attr::AttrValue;
 use style::context::SharedStyleContext;
-use style::data::ElementDataRef;
+use style::data::{ElementDataMut, ElementDataRef};
 use style::dom::{LayoutIterator, NodeInfo, OpaqueNode, TElement, TNode};
 use style::properties::ComputedValues;
 use style::selector_parser::{PseudoElement, PseudoElementCascadeType, SelectorImpl};
@@ -39,22 +39,12 @@ pub trait LayoutDataTrait: GenericLayoutDataTrait + Default + Send + Sync + 'sta
 /// or some other mechanism to ensure thread safety.
 pub trait LayoutNode<'dom>: Copy + Debug + TNode + Send + Sync {
     type ConcreteThreadSafeLayoutNode: ThreadSafeLayoutNode<'dom>;
+    type ConcreteLayoutElement: LayoutElement<'dom>;
+
     fn to_threadsafe(&self) -> Self::ConcreteThreadSafeLayoutNode;
 
     /// Returns the type ID of this node.
     fn type_id(&self) -> LayoutNodeType;
-
-    /// Initialize this node with empty style and opaque layout data.
-    ///
-    /// # Safety
-    ///
-    /// This method is unsafe because it modifies the given node during
-    /// layout. Callers should ensure that no other layout thread is
-    /// attempting to read or modify the opaque layout data of this node.
-    unsafe fn initialize_style_and_layout_data<RequestedLayoutDataType: LayoutDataTrait>(&self);
-
-    /// Get the [`StyleData`] for this node. Returns None if the node is unstyled.
-    fn style_data(&self) -> Option<&'dom StyleData>;
 
     /// Get the layout data of this node, attempting to downcast it to the desired type.
     /// Returns None if there is no layout data or it isn't of the desired type.
@@ -122,6 +112,20 @@ where
     }
 }
 
+pub trait LayoutElement<'dom>: Copy + Debug + Send + Sync {
+    /// Initialize this node with empty style and opaque layout data.
+    ///
+    /// # Safety
+    ///
+    /// This method is unsafe because it modifies the given node during
+    /// layout. Callers should ensure that no other layout thread is
+    /// attempting to read or modify the opaque layout data of this node.
+    unsafe fn initialize_style_and_layout_data<RequestedLayoutDataType: LayoutDataTrait>(&self);
+
+    /// Get the [`StyleData`] for this [`LayoutElement`].
+    fn style_data(self) -> Option<&'dom StyleData>;
+}
+
 /// A thread-safe version of `LayoutNode`, used during flow construction. This type of layout
 /// node does not allow any parents or siblings of nodes to be accessed, to avoid races.
 pub trait ThreadSafeLayoutNode<'dom>: Clone + Copy + Debug + NodeInfo + PartialEq + Sized {
@@ -168,9 +172,6 @@ pub trait ThreadSafeLayoutNode<'dom>: Clone + Copy + Debug + NodeInfo + PartialE
 
     /// Returns a ThreadSafeLayoutElement if this is an element in an HTML namespace, None otherwise.
     fn as_html_element(&self) -> Option<Self::ConcreteThreadSafeLayoutElement>;
-
-    /// Get the [`StyleData`] for this node. Returns None if the node is unstyled.
-    fn style_data(&self) -> Option<&'dom StyleData>;
 
     /// Get the layout data of this node, attempting to downcast it to the desired type.
     /// Returns None if there is no layout data or it isn't of the desired type.
@@ -306,7 +307,26 @@ pub trait ThreadSafeLayoutElement<'dom>:
 
     fn get_attr_enum(&self, namespace: &Namespace, name: &LocalName) -> Option<&AttrValue>;
 
-    fn style_data(&self) -> ElementDataRef<'_>;
+    /// Get the [`StyleData`] for this node. Returns None if the node is unstyled.
+    fn style_data(&self) -> Option<&'dom StyleData>;
+
+    /// Get a reference to the inner [`ElementDataRef`] for this element's [`StyleData`]. This will
+    /// panic if the element is unstyled.
+    fn element_data(&self) -> ElementDataRef<'dom> {
+        self.style_data()
+            .expect("Unstyled layout node?")
+            .element_data
+            .borrow()
+    }
+
+    /// Get a mutable reference to the inner [`ElementDataRef`] for this element's [`StyleData`].
+    /// This will panic if the element is unstyled.
+    fn element_data_mut(&self) -> ElementDataMut<'dom> {
+        self.style_data()
+            .expect("Unstyled layout node?")
+            .element_data
+            .borrow_mut()
+    }
 
     fn pseudo_element_chain(&self) -> PseudoElementChain;
 
@@ -317,18 +337,16 @@ pub trait ThreadSafeLayoutElement<'dom>:
     #[inline]
     fn style(&self, context: &SharedStyleContext) -> Arc<ComputedValues> {
         let get_style_for_pseudo_element =
-            |base_style: &Arc<ComputedValues>, pseudo_element: PseudoElement| {
+            |data: &ElementDataRef<'_>,
+             base_style: &Arc<ComputedValues>,
+             pseudo_element: PseudoElement| {
                 // Precompute non-eagerly-cascaded pseudo-element styles if not
                 // cached before.
                 match pseudo_element.cascade_type() {
                     // Already computed during the cascade.
-                    PseudoElementCascadeType::Eager => self
-                        .style_data()
-                        .styles
-                        .pseudos
-                        .get(&pseudo_element)
-                        .unwrap()
-                        .clone(),
+                    PseudoElementCascadeType::Eager => {
+                        data.styles.pseudos.get(&pseudo_element).unwrap().clone()
+                    },
                     PseudoElementCascadeType::Precomputed => context
                         .stylist
                         .precomputed_values_for_pseudo::<Self::ConcreteElement>(
@@ -353,17 +371,19 @@ pub trait ThreadSafeLayoutElement<'dom>:
                 }
             };
 
-        let data = self.style_data();
+        let data = self.element_data();
         let element_style = data.styles.primary();
         let pseudo_element_chain = self.pseudo_element_chain();
 
         let primary_pseudo_style = match pseudo_element_chain.primary {
-            Some(pseudo_element) => get_style_for_pseudo_element(element_style, pseudo_element),
+            Some(pseudo_element) => {
+                get_style_for_pseudo_element(&data, element_style, pseudo_element)
+            },
             None => return element_style.clone(),
         };
         match pseudo_element_chain.secondary {
             Some(pseudo_element) => {
-                get_style_for_pseudo_element(&primary_pseudo_style, pseudo_element)
+                get_style_for_pseudo_element(&data, &primary_pseudo_style, pseudo_element)
             },
             None => primary_pseudo_style,
         }

--- a/tests/unit/script/size_of.rs
+++ b/tests/unit/script/size_of.rs
@@ -30,10 +30,10 @@ macro_rules! sizeof_checker (
 
 // Update the sizes here
 sizeof_checker!(size_event_target, EventTarget, 48);
-sizeof_checker!(size_node, Node, 168);
+sizeof_checker!(size_node, Node, 152);
 sizeof_checker!(size_element, Element, 344);
 sizeof_checker!(size_htmlelement, HTMLElement, 360);
 sizeof_checker!(size_div, HTMLDivElement, 360);
 sizeof_checker!(size_span, HTMLSpanElement, 360);
-sizeof_checker!(size_text, Text, 200);
-sizeof_checker!(size_characterdata, CharacterData, 200);
+sizeof_checker!(size_text, Text, 184);
+sizeof_checker!(size_characterdata, CharacterData, 184);


### PR DESCRIPTION
Many things are nodes, such as `CharacterData` and attributes. They
don't need style data at all. This saves 16 bytes on every attribute and
text node.

Testing: This should not change testable behavior (only save some memory),
so it should be covered by existing tests.
